### PR TITLE
Fix halo gesture - workaround

### DIFF
--- a/src/Morphic-Base/HaloMorph.class.st
+++ b/src/Morphic-Base/HaloMorph.class.st
@@ -659,22 +659,6 @@ HaloMorph >> basicBoxForSimpleHalos [
 		  ifNone: [ self error: 'should not happen' ]
 ]
 
-{ #category : #'meta-actions' }
-HaloMorph >> blueButtonDown: event [
-	"Transfer the halo to the next likely recipient"
-
-	target ifNil: [ ^ self delete ].
-	event hand obtainHalo: self.
-	positionOffset := event position
-	                  - (target point: target position in: owner).
-	"wait for drags or transfer"
-	event hand
-		waitForClicksOrDrag: self
-		event: event
-		selectors: { #transferHalo:. nil. nil. #dragTarget: }
-		threshold: 5
-]
-
 { #category : #accessing }
 HaloMorph >> borderStyle [
 	"Answer the border style to use for the receiver.
@@ -988,6 +972,22 @@ HaloMorph >> handleListenEvent: anEvent [
 HaloMorph >> handleSize [
 
 	^ 30
+]
+
+{ #category : #'meta-actions' }
+HaloMorph >> handleSpecialGesture: event [
+	"Transfer the halo to the next likely recipient"
+
+	target ifNil: [ ^ self delete ].
+	event hand obtainHalo: self.
+	positionOffset := event position
+	                  - (target point: target position in: owner).
+	"wait for drags or transfer"
+	event hand
+		waitForClicksOrDrag: self
+		event: event
+		selectors: { #transferHalo:. nil. nil. #dragTarget: }
+		threshold: 5
 ]
 
 { #category : #'meta-actions' }

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -1231,34 +1231,6 @@ Morph >> beginsWith: aString fromList: aMorph [
 ]
 
 { #category : #'meta-actions' }
-Morph >> blueButtonDown: anEvent [
-	"Special gestures (cmd-mouse on the Macintosh; Alt-mouse on Windows and Unix) allow a mouse-sensitive morph to be moved or bring up a halo for the morph."
-	| h tfm doNotDrag |
-	h := anEvent hand halo.
-	"Prevent wrap around halo transfers originating from throwing the event back in"
-	doNotDrag := false.
-	h ifNotNil:[
-		(h innerTarget == self) ifTrue:[doNotDrag := true].
-		(h innerTarget hasOwner: self) ifTrue:[doNotDrag := true].
-		(self hasOwner: h target) ifTrue:[doNotDrag := true]].
-
-	tfm := (self transformedFrom: nil) inverseTransformation.
-
-	"cmd-drag on flexed morphs works better this way"
-	h := self addHalo: (anEvent transformedBy: tfm).
-	h ifNil: [^ self].
-	doNotDrag ifTrue:[^self].
-	"Initiate drag transition if requested"
-	anEvent hand 
-		waitForClicksOrDrag: h
-		event: (anEvent transformedBy: tfm)
-		selectors: { nil. nil. nil. #dragTarget:. }
-		threshold: 5.
-	"Pass focus explicitly here"
-	anEvent hand newMouseFocus: h.
-]
-
-{ #category : #'meta-actions' }
 Morph >> blueButtonUp: anEvent [
 	"Ignored. Theoretically we should never get here since control is transferred to the halo on #blueButtonDown: but subclasses may implement this differently."
 ]
@@ -2876,31 +2848,39 @@ Morph >> handleListenEvent: anEvent [
 
 { #category : #'events - processing' }
 Morph >> handleMouseDown: anEvent [
+
 	"System level event handling."
-	anEvent wasHandled ifTrue:[^self]. "not interested"
+
+	anEvent wasHandled ifTrue: [ ^ self ]. "not interested"
 	anEvent hand removePendingBalloonFor: self.
 	anEvent wasHandled: true.
-	
-	(anEvent controlKeyPressed
-			and: [self cmdGesturesEnabled and: [ anEvent shiftPressed]])
-		ifTrue: [
-			self invokeMetaMenu: anEvent.
-			^ self eventHandler ifNotNil: [:handler | handler mouseDown: anEvent fromMorph: self ] ].
+
+	(anEvent controlKeyPressed and: [ 
+		 self cmdGesturesEnabled and: [ anEvent shiftPressed ] ]) ifTrue: [ 
+		self invokeMetaMenu: anEvent.
+		^ self eventHandler ifNotNil: [ :handler | 
+			  handler mouseDown: anEvent fromMorph: self ] ].
 
 	"Make me modal during mouse transitions"
 	anEvent hand newMouseFocus: self event: anEvent.
-	anEvent blueButtonChanged ifTrue:[^self blueButtonDown: anEvent].
 	
+	"Check to open halo"
+	(anEvent blueButtonChanged or: [ "HACK"
+		 anEvent redButtonChanged & anEvent altKeyPressed
+		 & anEvent shiftPressed ]) ifTrue: [ ^ self handleSpecialGesture: anEvent ].
+
 	self mouseDown: anEvent.
-	
+
 	anEvent hand removeHaloFromClick: anEvent on: self.
-	(self handlesMouseStillDown: anEvent) ifTrue:[
-		self startStepping: #handleMouseStillDown: 
+	(self handlesMouseStillDown: anEvent) ifTrue: [ 
+		self
+			startStepping: #handleMouseStillDown:
 			at: Time millisecondClockValue + self mouseStillDownThreshold
-			arguments: {anEvent copy resetHandlerFields}
+			arguments: { anEvent copy resetHandlerFields }
 			stepTime: self mouseStillDownStepRate ].
-		
-	^ self eventHandler ifNotNil: [:handler | handler mouseDown: anEvent fromMorph: self ]
+
+	^ self eventHandler ifNotNil: [ :handler | 
+		  handler mouseDown: anEvent fromMorph: self ]
 ]
 
 { #category : #'events - processing' }
@@ -2999,6 +2979,34 @@ Morph >> handleMouseWheel: anEvent [
 	(self handlesMouseWheel: anEvent) ifTrue:[
 		anEvent wasHandled: true.
 		self mouseWheel: anEvent]
+]
+
+{ #category : #'meta-actions' }
+Morph >> handleSpecialGesture: mouseDownEvent [
+	"Special gestures (cmd-mouse on the Macintosh; Alt-mouse on Windows and Unix) allow a mouse-sensitive morph to be moved or bring up a halo for the morph."
+	| h tfm doNotDrag |
+	h := mouseDownEvent hand halo.
+	"Prevent wrap around halo transfers originating from throwing the event back in"
+	doNotDrag := false.
+	h ifNotNil:[
+		(h innerTarget == self) ifTrue:[doNotDrag := true].
+		(h innerTarget hasOwner: self) ifTrue:[doNotDrag := true].
+		(self hasOwner: h target) ifTrue:[doNotDrag := true]].
+
+	tfm := (self transformedFrom: nil) inverseTransformation.
+
+	"cmd-drag on flexed morphs works better this way"
+	h := self addHalo: (mouseDownEvent transformedBy: tfm).
+	h ifNil: [^ self].
+	doNotDrag ifTrue:[^self].
+	"Initiate drag transition if requested"
+	mouseDownEvent hand 
+		waitForClicksOrDrag: h
+		event: (mouseDownEvent transformedBy: tfm)
+		selectors: { nil. nil. nil. #dragTarget:. }
+		threshold: 5.
+	"Pass focus explicitly here"
+	mouseDownEvent hand newMouseFocus: h.
 ]
 
 { #category : #'events - processing' }

--- a/src/SUnit-Support-UITesting/MorphHandlingMiddleButton.class.st
+++ b/src/SUnit-Support-UITesting/MorphHandlingMiddleButton.class.st
@@ -12,15 +12,15 @@ Class {
 }
 
 { #category : #'meta-actions' }
-MorphHandlingMiddleButton >> blueButtonDown: anEvent [
-
-	receivedBlueButtonDown := true.
-]
-
-{ #category : #'meta-actions' }
 MorphHandlingMiddleButton >> blueButtonUp: anEvent [
 
 	receivedBlueButtonUp := true.
+]
+
+{ #category : #'meta-actions' }
+MorphHandlingMiddleButton >> handleSpecialGesture: anEvent [
+
+	receivedBlueButtonDown := true.
 ]
 
 { #category : #'meta-actions' }


### PR DESCRIPTION
Fix https://github.com/pharo-project/pharo/issues/11051

A workaround with flavour to a hack is implemented fixing `Shift + Option + (primary) Click` shortcut to open halo.

It was tested manually and checked expected behaviour in Roassal.

TODO:
- Maybe we need a better way to manage this shortcuts / special gestures, now the code is a little bit hard to understand and modify
- **Tests are missing** (I was looking the examples but time was over)

_Made during 25/03 sprint_