### PR TITLE
fix DNU in VTermTestRunner

### DIFF
--- a/src/JenkinsTools-Core/HDTestReport.class.st
+++ b/src/JenkinsTools-Core/HDTestReport.class.st
@@ -15,8 +15,7 @@ Class {
 		'stageName',
 		'progressFileName',
 		'progressStream',
-		'shouldSerializeError',
-		'fileName'
+		'shouldSerializeError'
 	],
 	#classVars : [
 		'CurrentStageName'
@@ -288,7 +287,7 @@ HDTestReport >> serializeError: error of: aTestCase [
 					                         ctx methodSelector == #performTest ] ].
 			context := context copyTo: testCaseMethodContext.
 
-			fuelFileName := fileName copyReplaceAll: '.xml' with: ('-' , aTestCase class name asString , '-',  aTestCase selector asString , '.fuel').
+			fuelFileName := self suiteFileNameWithoutExtension , ('-' , aTestCase class name asString , '-',  aTestCase selector asString , '.fuel').
 
 			[ fuelOutStackDebugAction 
 					serializeStackFromContext: context sender 
@@ -305,9 +304,7 @@ HDTestReport >> setUp [
 	progressStream nextPutAll: 'running suite: ';
 		nextPutAll: suite name ; crlf; flush.
 
-	fileName := stageName isEmpty ifTrue: [ '' ] ifFalse: [ stageName , '-' ].
-	fileName := fileName , suite name , '-Test.xml'.
-	aFile := File named: fileName .
+	aFile := File named: self suiteFileNameWithoutExtension , '.xml' .
 	aFile delete.
 	stream := ZnCharacterWriteStream
 			on: (aFile writeStream setToEnd; yourself)
@@ -365,6 +362,16 @@ HDTestReport >> suiteErrors [
 { #category : #accessing }
 HDTestReport >> suiteFailures [
 	^ suiteFailures
+]
+
+{ #category : #accessing }
+HDTestReport >> suiteFileNameWithoutExtension [
+
+	| fileName |
+	fileName := stageName isEmpty
+		            ifTrue: [ '' ]
+		            ifFalse: [ stageName , '-' ].
+	^ fileName , suite name , '-Test'
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
When running tests with VTermTestRunner, i.e. in headless mode and no Junit output, the test runner throws a DNU while trying to serialize the stack with Fuel.