### PR TITLE
Do a small wait after SDL window is created

### DIFF
--- a/src/OSWindow-SDL2/OSSDL2Driver.class.st
+++ b/src/OSWindow-SDL2/OSSDL2Driver.class.st
@@ -132,6 +132,10 @@ OSSDL2Driver >> createWindowWithAttributes: attributes osWindow: osWindow [
 		"The OSWindow handle has to be set inside of this critical section to avoid losing some events such as expose."
 		osWindow setJustCreatedHandle: aBackendWindow.
 	].
+
+	"Workaround to https://github.com/pharo-project/pharo/issues/10981"
+	20 milliSeconds wait.
+
 	^ aBackendWindow
 ]
 


### PR DESCRIPTION
Fixes issue #10981 
This change seems to fix the problem but I still don't have a good explanation. In any case, waiting 20ms on session start is not much.
