### PR TITLE
Fix for issue 11070: Interval>>= and Interval>>hash do not match

### DIFF
--- a/src/Collections-Sequenceable-Tests/IntervalTest.class.st
+++ b/src/Collections-Sequenceable-Tests/IntervalTest.class.st
@@ -446,6 +446,16 @@ IntervalTest >> testEquals4 [
 ]
 
 { #category : #tests }
+IntervalTest >> testEquals5 [
+	"Interval>>= and Interval>>hash do not match #11070"
+	self assert: (2 to: 10 by: 3) equals: (2 to: 9 by: 3). 
+	self assert: (2 to: 10 by: 3) hash equals: (2 to: 9 by: 3) hash. 
+
+	self deny: (2 to: 10 by: 3) equals: (2 to: 10 by: 4). 
+	self deny: (2 to: 10 by: 3) hash equals: (2 to: 10 by: 4) hash	
+]
+
+{ #category : #tests }
 IntervalTest >> testExtent [
 	self assert: (1 to: 10) extent equals: 9.
 	self assert: (1 to: 10 by: 2) extent equals: 9.

--- a/src/Collections-Sequenceable/Interval.class.st
+++ b/src/Collections-Sequenceable/Interval.class.st
@@ -249,7 +249,7 @@ Interval >> hash [
 	"Hash is reimplemented because = is implemented."
 
 	^(((start hash bitShift: 2)
-		bitOr: stop hash)
+		bitOr: self last hash)
 		bitShift: 1)
 		bitOr: self size
 ]


### PR DESCRIPTION
Intervals that are equal (`#=`) to each other --- e.g. `(2 to: 10 by: 3)` and `(2 to: 9 by: 3)` should have equal `hash`es.  Intervals that share a start, stop and size --- e.g. `(2 to: 10 by: 3)` and `(2 to: 10 by: 4)` --- and are not equal (`#~=`) to each other should not (excepting collisions) have equal `hash`es: indeed the different `step` size means they differ in all but the first element.