### PR TITLE
Fix #11065: Ordered dictionaries should not ignore order when compared.

### DIFF
--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -292,6 +292,12 @@ Collection >> asDictionary [
 ]
 
 { #category : #converting }
+Collection >> asIdentityDictionary [
+
+	^ self as: IdentityDictionary
+]
+
+{ #category : #converting }
 Collection >> asIdentitySet [
 	^(IdentitySet new: self size) addAll: self; yourself
 ]

--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -292,12 +292,6 @@ Collection >> asDictionary [
 ]
 
 { #category : #converting }
-Collection >> asIdentityDictionary [
-
-	^ self as: IdentityDictionary
-]
-
-{ #category : #converting }
 Collection >> asIdentitySet [
 	^(IdentitySet new: self size) addAll: self; yourself
 ]

--- a/src/Collections-Sequenceable-Tests/OrderedDictionaryTest.class.st
+++ b/src/Collections-Sequenceable-Tests/OrderedDictionaryTest.class.st
@@ -802,8 +802,8 @@ OrderedDictionaryTest >> testEquals [
 				equals: dictionaryTwo asDictionary ]
 		ifTrue: [ 
 			self
-				assertDictionary: dictionaryOne asIdentityDictionary
-				equals: dictionaryTwo asIdentityDictionary ]
+				assertDictionary: (dictionaryOne as: IdentityDictionary)
+				equals: (dictionaryTwo as: IdentityDictionary) ]
 ]
 
 { #category : #tests }

--- a/src/Collections-Sequenceable-Tests/OrderedDictionaryTest.class.st
+++ b/src/Collections-Sequenceable-Tests/OrderedDictionaryTest.class.st
@@ -767,20 +767,23 @@ OrderedDictionaryTest >> testDo [
 
 { #category : #tests }
 OrderedDictionaryTest >> testEquals [
-	| dictionaryOne dictionaryTwo |
+	| dictionaryOne dictionaryTwo dictionaryThree |
 
 	dictionaryOne := self emptyDictionary.
 	dictionaryTwo := self emptyDictionary.
+	dictionaryThree := self emptyDictionary.
+
 	self
 		assertDictionary: dictionaryOne
 		equals: dictionaryTwo.
 
-	"For equality, order will not matter"
+	"Order now matters for equality of Ordered dictionaries"
 	self orderedAssociations
 		with: self orderedAssociations reversed
 		do: [:firstAssociation :secondAssociation |
 			dictionaryOne add: firstAssociation.
 			dictionaryTwo add: secondAssociation.
+			dictionaryThree add: firstAssociation.
 			self
 				assertDictionary: dictionaryOne
 				doesNotEqual: self emptyDictionary.
@@ -795,7 +798,18 @@ OrderedDictionaryTest >> testEquals [
 
 	self
 		assertDictionary: dictionaryOne
-		equals: dictionaryTwo.
+		doesNotEqual: dictionaryTwo.
+
+	self
+		assertDictionary: dictionaryOne
+		equals: dictionaryThree.
+	
+	"New way to test for equality regardless of ordering"	
+	self
+		assertDictionary: dictionaryOne asDictionary
+		equals: dictionaryTwo asDictionary	
+	
+	
 ]
 
 { #category : #tests }

--- a/src/Collections-Sequenceable-Tests/OrderedDictionaryTest.class.st
+++ b/src/Collections-Sequenceable-Tests/OrderedDictionaryTest.class.st
@@ -767,20 +767,18 @@ OrderedDictionaryTest >> testDo [
 
 { #category : #tests }
 OrderedDictionaryTest >> testEquals [
-	| dictionaryOne dictionaryTwo dictionaryThree |
 
+	| dictionaryOne dictionaryTwo dictionaryThree |
 	dictionaryOne := self emptyDictionary.
 	dictionaryTwo := self emptyDictionary.
 	dictionaryThree := self emptyDictionary.
 
-	self
-		assertDictionary: dictionaryOne
-		equals: dictionaryTwo.
+	self assertDictionary: dictionaryOne equals: dictionaryTwo.
 
 	"Order now matters for equality of Ordered dictionaries"
 	self orderedAssociations
 		with: self orderedAssociations reversed
-		do: [:firstAssociation :secondAssociation |
+		do: [ :firstAssociation :secondAssociation | 
 			dictionaryOne add: firstAssociation.
 			dictionaryTwo add: secondAssociation.
 			dictionaryThree add: firstAssociation.
@@ -790,26 +788,22 @@ OrderedDictionaryTest >> testEquals [
 			self
 				assertDictionary: dictionaryTwo
 				doesNotEqual: self emptyDictionary.
-			dictionaryOne size < self orderedAssociations size
-				ifTrue: [
-					self
-						assertDictionary: dictionaryOne
-						doesNotEqual: dictionaryTwo]].
+			dictionaryOne size < self orderedAssociations size ifTrue: [ 
+				self assertDictionary: dictionaryOne doesNotEqual: dictionaryTwo ] ].
 
-	self
-		assertDictionary: dictionaryOne
-		doesNotEqual: dictionaryTwo.
+	self assertDictionary: dictionaryOne doesNotEqual: dictionaryTwo.
+	self assertDictionary: dictionaryOne equals: dictionaryThree.
 
-	self
-		assertDictionary: dictionaryOne
-		equals: dictionaryThree.
-	
-	"New way to test for equality regardless of ordering"	
-	self
-		assertDictionary: dictionaryOne asDictionary
-		equals: dictionaryTwo asDictionary	
-	
-	
+	"New way to test for equality regardless of ordering"
+	self isTestingIdentityDictionary
+		ifFalse: [ 
+			self
+				assertDictionary: dictionaryOne asDictionary
+				equals: dictionaryTwo asDictionary ]
+		ifTrue: [ 
+			self
+				assertDictionary: dictionaryOne asIdentityDictionary
+				equals: dictionaryTwo asIdentityDictionary ]
 ]
 
 { #category : #tests }

--- a/src/Collections-Sequenceable/OrderedDictionary.class.st
+++ b/src/Collections-Sequenceable/OrderedDictionary.class.st
@@ -1,5 +1,9 @@
 "
-I am a collection that act as a Dictionary except that I use key insertion order when enumerating, printing, or returing collections of keys/values/associations, but not when testing for equality (but it does not matters in this case).
+I am a collection that act as a Dictionary except that I use key insertion order when comparing, enumerating, printing, or returning collections of keys/values/associations.
+
+NB: Prior implementation ignored order in testing for equality: to ignore order now, simply compare 'orderedDict1 asDictionary = orderedDict2 asDictionary' in 
+a similar manner to using #asSet when comparing OrderedCollections for equality of content regardless of ordering.
+
 I will assume that you know the Dictionary class in this comment.
 
 I work mainly as a Dictionary except that I also store the keys in an Array that keeps the order of elements. 
@@ -93,10 +97,7 @@ OrderedDictionary >> = anObject [
 		and: [self size = anObject size])
 		ifFalse: [^ false].
 
-	dictionary associationsDo: [:each |
-		(anObject at: each key ifAbsent: [^ false]) = each value
-			ifFalse: [^ false]].
-	^ true.
+	^self associations = anObject associations.
 ]
 
 { #category : #adding }


### PR DESCRIPTION
If you want to ignore ordering when comparing OrderedDictionaries, just send them the message asDictionary first, just like you might send asSet to OrderedCollections to compare them in an order indifferent manner.

Note that this is a bit of a 'mare of a class.  Far too many methods and its purpose seems fundamentally unclear.  However these changes are simple and just fix `=`, the relevant test and a comment.