### PR TITLE
10780-Spotter-crashes-in-Pharo-9

### DIFF
--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -433,6 +433,13 @@ Collection >> collect: collectBlock thenSelect: selectBlock [
 	^ (self collect: collectBlock) select: selectBlock
 ]
 
+{ #category : #hotfix }
+Collection >> collectionSizeThreshold [ 
+	"This method should be in newtools, as a workaround it is added here. This is solved
+	correctly in Pharo10"
+	^ 3000
+]
+
 { #category : #testing }
 Collection >> contains: aBlock [
 	"For compatibility, please use #anySatisfy: instead!"


### PR DESCRIPTION
add the missing method to Collection (#collectionSizeThreshold).

I add it to the image, not the Newtools package as a workaround, this is correctly fixed in Pharo10 already.

fixes #10780

