### PR TITLE
11099-Pharo11-build-broken-Error-Could-not-determine-image-version-Using-fallback 

### DIFF
--- a/src/BaselineOfFuelPlatform/BaselineOfFuelPlatform.class.st
+++ b/src/BaselineOfFuelPlatform/BaselineOfFuelPlatform.class.st
@@ -102,6 +102,7 @@ BaselineOfFuelPlatform >> pharoPackagesAndGroups: spec [
 
 { #category : #adding }
 BaselineOfFuelPlatform >> platformAttributes [
+	(SystemVersion current version beginsWith: 'Pharo11') ifTrue: [ ^ #('pharo11.x') ].
 	(SystemVersion current version beginsWith: 'Pharo10') ifTrue: [ ^ #('pharo10.x') ].
 	(SystemVersion current version beginsWith: 'Pharo9') ifTrue: [ ^ #('pharo9.x') ].
 	(SystemVersion current version beginsWith: 'Pharo8') ifTrue: [ ^ #('pharo8.x') ].


### PR DESCRIPTION
add Pharo11 to #platformAttributes