### PR TITLE
11107-Small-speedup-for-Dictionaryat 

### DIFF
--- a/src/Collections-Unordered/Dictionary.class.st
+++ b/src/Collections-Unordered/Dictionary.class.st
@@ -339,10 +339,13 @@ Dictionary >> associationsSelect: aBlock [
 ]
 
 { #category : #accessing }
-Dictionary >> at: key [ 
-	"Answer the value associated with the key."
+Dictionary >> at: key [
+	"Answer the value associated with the key. 
+	To avoid block creation, we do not re-use #at:ifAbsent:"
 
-	^ self at: key ifAbsent: [self errorKeyNotFound: key]
+	^ (array at: (self findElementOrNil: key))
+		  ifNil: [ self errorKeyNotFound: key ]
+		  ifNotNil: [ :assoc | assoc value ]
 ]
 
 { #category : #'nested dictionaries' }

--- a/src/Collections-Unordered/SmallDictionary.class.st
+++ b/src/Collections-Unordered/SmallDictionary.class.st
@@ -218,13 +218,14 @@ SmallDictionary >> associationsSelect: aBlock [
 
 { #category : #accessing }
 SmallDictionary >> at: key [
-		"Answer the value associated with the key.
-		To avoid block creation, we do not re-use #at:ifAbsent:"
+	"Answer the value associated with the key.
+	To avoid block creation, we do not re-use #at:ifAbsent:"
 
-		| index |
-		index := self findIndexForKey: key.
-		index = 0 ifTrue: [ ^ self errorKeyNotFound: key ].
-		^ values at: index
+	| index |
+	index := self findIndexForKey: key.
+	^ index = 0
+		  ifTrue: [ self errorKeyNotFound: key ]
+		  ifFalse: [ values at: index ]
 ]
 
 { #category : #'nested dictionaries' }

--- a/src/Collections-Unordered/SmallDictionary.class.st
+++ b/src/Collections-Unordered/SmallDictionary.class.st
@@ -217,10 +217,14 @@ SmallDictionary >> associationsSelect: aBlock [
 ]
 
 { #category : #accessing }
-SmallDictionary >> at: key [ 
-	"Answer the value associated with the key."
+SmallDictionary >> at: key [
+		"Answer the value associated with the key.
+		To avoid block creation, we do not re-use #at:ifAbsent:"
 
-	^ self at: key ifAbsent: [self errorKeyNotFound: key]
+		| index |
+		index := self findIndexForKey: key.
+		index = 0 ifTrue: [ ^ self errorKeyNotFound: key ].
+		^ values at: index
 ]
 
 { #category : #'nested dictionaries' }

--- a/src/Collections-Weak/WeakValueDictionary.class.st
+++ b/src/Collections-Weak/WeakValueDictionary.class.st
@@ -38,6 +38,16 @@ WeakValueDictionary >> associationsDo: aBlock [
 	array do: [ :each | each value ifNotNil: [ :value | aBlock value: each key -> value enclosedElement ] ]
 ]
 
+{ #category : #accessing }
+WeakValueDictionary >> at: key [
+	"Answer the value associated with the key. 
+	To avoid block creation, we do not re-use #at:ifAbsent:"
+
+	^ (array at: (self findElementOrNil: key)) value
+			ifNil: [ self errorKeyNotFound: key ]
+			ifNotNil: [ :value | value enclosedElement ]
+]
+
 { #category : #adding }
 WeakValueDictionary >> at: key ifAbsent: aBlock [
 	"Answer the value associated with the key or, if key isn't found,

--- a/src/Kernel/MethodDictionary.class.st
+++ b/src/Kernel/MethodDictionary.class.st
@@ -102,6 +102,18 @@ MethodDictionary >> associationsDo: aBlock [
 ]
 
 { #category : #accessing }
+MethodDictionary >> at: key [
+	"Answer the value associated with the key. 
+	To avoid block creation, we do not re-use #at:ifAbsent:"
+	
+	| index |
+	index := self findElementOrNil: key.
+	^(self basicAt: index) 
+		ifNil: [ self errorKeyNotFound: key ]
+		ifNotNil: [ array at: index ]
+]
+
+{ #category : #accessing }
 MethodDictionary >> at: key ifAbsent: aBlock [
 
 	| index |


### PR DESCRIPTION
manual inlining in Dictionary>>#at: to avoid having to create the block for every call. Speeds up micro benchmark ~20%

closes #11107