### PR TITLE
testProperAccessingProtocolIsUsed can now check for 0

### DIFF
--- a/src/ReleaseTests/ProtocolConventionsTest.class.st
+++ b/src/ReleaseTests/ProtocolConventionsTest.class.st
@@ -72,7 +72,7 @@ ProtocolConventionsTest >> checkIdiomForRuleClass: aRuleClass notMoreViolationsT
 { #category : #tests }
 ProtocolConventionsTest >> testProperAccessingProtocolIsUsed [
 
-	self checkIdiomForRuleClass: ReProperMethodProtocolNameForAccessingRule notMoreViolationsThan: 1
+	self checkIdiomForRuleClass: ReProperMethodProtocolNameForAccessingRule
 ]
 
 { #category : #tests }


### PR DESCRIPTION
testProperAccessingProtocolIsUsed can now check for 0 as all are fixed