### PR TITLE
FilePathEncoder is not needed anymore / Pharo 11 requires a Deprecated11 package

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -1,3 +1,6 @@
+"
+Baseline for Pharo IDE
+"
 Class {
 	#name : #BaselineOfPharo,
 	#superclass : #BaselineOf,
@@ -88,7 +91,7 @@ BaselineOfPharo class >> specVersion [
 	^ 'Pharo10'
 ]
 
-{ #category : #baseline }
+{ #category : #baselines }
 BaselineOfPharo >> baseline: spec [
 	<baseline>
 	| repository |
@@ -103,13 +106,14 @@ BaselineOfPharo >> baseline: spec [
 			spec repository: repository; loads: #('IcebergSupport'). ].
 
 		spec package: 'Deprecated10'.
+		spec package: 'Deprecated11'.
 		
 		spec package: 'FluidClassBuilder'.
 		spec package: 'FluidClassBuilder-Tests' with: [ spec requires: 'FluidClassBuilder' ].
 	]
 ]
 
-{ #category : #baseline }
+{ #category : #actions }
 BaselineOfPharo >> postload: loader package: packageSpec [
 
 	WelcomeHelp openForRelease

--- a/src/Deprecated11/FilePathEncoder.class.st
+++ b/src/Deprecated11/FilePathEncoder.class.st
@@ -7,15 +7,33 @@ This class absorb the difference of internal and external representation of the 
 Class {
 	#name : #FilePathEncoder,
 	#superclass : #Object,
-	#category : #'Files-Directories'
+	#category : #Deprecated11
 }
 
 { #category : #encoding }
 FilePathEncoder class >> decode: aString [
+
+	self 
+		deprecated: 'Please use #utf8Decoded directly' 
+		transformWith:  '`@receiver decode: `@arg' 
+						-> '`@arg utf8Decoded'.
+						
 	^ aString utf8Decoded
 ]
 
 { #category : #encoding }
 FilePathEncoder class >> encode: pathString [
+
+	self 
+		deprecated: 'Please use #utf8Encoded directly' 
+		transformWith:  '`@receiver encode: `@arg' 
+						-> '`@arg utf8Encoded'.
+
 	^ pathString utf8Encoded
+]
+
+{ #category : #testing }
+FilePathEncoder class >> isDeprecated [ 
+
+	^true
 ]

--- a/src/Deprecated11/package.st
+++ b/src/Deprecated11/package.st
@@ -1,0 +1,1 @@
+Package { #name : #Deprecated11 }

--- a/src/Tool-FileList/String.extension.st
+++ b/src/Tool-FileList/String.extension.st
@@ -2,11 +2,8 @@ Extension { #name : #String }
 
 { #category : #'*Tool-FileList' }
 String >> asFileName [
-	"Answer a String made up from the receiver that is an acceptable file 
-	name."
+	"Answer a String made up from the receiver that is an acceptable file name."
 
-	| string checkedString |
-	string := FileSystem disk checkName: self fixErrors: true.
-	checkedString := FilePathEncoder encode: string.
-	^ FilePathEncoder decode: checkedString
+	^ FileSystem disk checkName: self fixErrors: true
+	 
 ]


### PR DESCRIPTION
- Fix #11129 and 
- Fix #11138