### PR TITLE
10963-Memory-AllProtocol-uses-a-lot-of-memory

### DIFF
--- a/src/Kernel/AbstractProtocol.class.st
+++ b/src/Kernel/AbstractProtocol.class.st
@@ -78,7 +78,7 @@ AbstractProtocol >> name [
 ]
 
 { #category : #accessing }
-AbstractProtocol >> name: arg1 [ 
+AbstractProtocol >> name: aString [ 
 	^ self subclassResponsibility
 ]
 

--- a/src/Kernel/AbstractProtocol.class.st
+++ b/src/Kernel/AbstractProtocol.class.st
@@ -1,0 +1,94 @@
+"
+Abstract superclass for Protocol, AllProtocol should not inherit from Protocol to avoid wasting memory
+"
+Class {
+	#name : #AbstractProtocol,
+	#superclass : #Object,
+	#category : #'Kernel-Protocols'
+}
+
+{ #category : #'instance creation' }
+AbstractProtocol class >> ambiguous [
+	^ #ambiguous
+]
+
+{ #category : #accessing }
+AbstractProtocol class >> defaultName [
+
+	^  self unclassified
+]
+
+{ #category : #testing }
+AbstractProtocol class >> isAbstract [
+		
+	^ self == AbstractProtocol
+]
+
+{ #category : #accessing }
+AbstractProtocol class >> nullCategory [
+
+	^ #'no messages'
+]
+
+{ #category : #accessing }
+AbstractProtocol class >> unclassified [
+	^ #'as yet unclassified'
+]
+
+{ #category : #private }
+AbstractProtocol >> canBeRemoved [
+	^ self isEmpty
+]
+
+{ #category : #testing }
+AbstractProtocol >> canBeRenamed [
+	^ true
+]
+
+{ #category : #testing }
+AbstractProtocol >> includesSelector: selector [
+
+	^ self methodSelectors includes: selector
+]
+
+{ #category : #testing }
+AbstractProtocol >> isEmpty [
+	^ self methodSelectors isEmpty
+]
+
+{ #category : #testing }
+AbstractProtocol >> isExtensionProtocol [ 
+	^ self name first = $*.
+]
+
+{ #category : #testing }
+AbstractProtocol >> isVirtualProtocol [
+	"A virtual protocol is a calculated one (it does not have any methods by it self)"
+	^ false
+]
+
+{ #category : #accessing }
+AbstractProtocol >> methodSelectors [
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+AbstractProtocol >> name [
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+AbstractProtocol >> name: arg1 [ 
+	^ self subclassResponsibility
+]
+
+{ #category : #printing }
+AbstractProtocol >> printOn: aStream [
+	aStream
+		nextPutAll: self class name;
+		nextPutAll: ' (';
+		nextPutAll: self name;
+		nextPutAll: ') - ';
+		print: self methodSelectors size;
+		nextPutAll: ' selector(s)'
+]

--- a/src/Kernel/AllProtocol.class.st
+++ b/src/Kernel/AllProtocol.class.st
@@ -3,7 +3,7 @@ An AllProtocol is a special protocol to hanlde the ""all"" case
 "
 Class {
 	#name : #AllProtocol,
-	#superclass : #Protocol,
+	#superclass : #AbstractProtocol,
 	#instVars : [
 		'protocolOrganizer'
 	],
@@ -24,7 +24,7 @@ AllProtocol class >> protocolOrganizer: protocolOrganizer [
 		yourself
 ]
 
-{ #category : #testing }
+{ #category : #private }
 AllProtocol >> canBeRemoved [
 	^ false
 ]
@@ -32,12 +32,6 @@ AllProtocol >> canBeRemoved [
 { #category : #testing }
 AllProtocol >> canBeRenamed [
 	^ false
-]
-
-{ #category : #initialization }
-AllProtocol >> initialize [
-	"overridden to not itialize unsused methodSelectors, more cleanup needed"
-	name := self class defaultName.
 ]
 
 { #category : #testing }
@@ -54,7 +48,7 @@ AllProtocol >> methodSelectors [
 AllProtocol >> name [
 	^ (self isEmpty and: [ protocolOrganizer protocols isEmpty ])
 		ifTrue: [ self class nullCategory ]
-		ifFalse: [ name ]
+		ifFalse: [  self class defaultName ]
 ]
 
 { #category : #accessing }

--- a/src/Kernel/Protocol.class.st
+++ b/src/Kernel/Protocol.class.st
@@ -4,24 +4,13 @@ It's composed of a name and a set of method selectors
 "
 Class {
 	#name : #Protocol,
-	#superclass : #Object,
+	#superclass : #AbstractProtocol,
 	#instVars : [
 		'name',
 		'methodSelectors'
 	],
 	#category : #'Kernel-Protocols'
 }
-
-{ #category : #'instance creation' }
-Protocol class >> ambiguous [
-	^ #ambiguous
-]
-
-{ #category : #accessing }
-Protocol class >> defaultName [
-
-	^  self unclassified
-]
 
 { #category : #'instance creation' }
 Protocol class >> empty [ 
@@ -44,41 +33,14 @@ Protocol class >> name: nm methodSelectors: methods [
 		yourself
 ]
 
-{ #category : #accessing }
-Protocol class >> nullCategory [
-
-	^ #'no messages'
-]
-
-{ #category : #accessing }
-Protocol class >> unclassified [
-	^ #'as yet unclassified'
-]
-
-{ #category : #accessing }
+{ #category : #'adding-removing' }
 Protocol >> addAllMethodsFrom: aProtocol [
 	aProtocol methodSelectors do: [ :each | self addMethodSelector: each ]
 ]
 
-{ #category : #accessing }
+{ #category : #'adding-removing' }
 Protocol >> addMethodSelector: aSymbol [
 	^ methodSelectors add: aSymbol
-]
-
-{ #category : #private }
-Protocol >> canBeRemoved [
-	^ self isEmpty
-]
-
-{ #category : #testing }
-Protocol >> canBeRenamed [
-	^ true
-]
-
-{ #category : #testing }
-Protocol >> includesSelector: selector [
-
-	^ methodSelectors includes: selector
 ]
 
 { #category : #initialization }
@@ -88,22 +50,6 @@ Protocol >> initialize [
 
 	methodSelectors := IdentitySet new.
 	name := self class defaultName.
-]
-
-{ #category : #testing }
-Protocol >> isEmpty [
-	^ self methodSelectors isEmpty
-]
-
-{ #category : #testing }
-Protocol >> isExtensionProtocol [ 
-	^ self name first = $*.
-]
-
-{ #category : #testing }
-Protocol >> isVirtualProtocol [
-	"A virtual protocol is a calculated one (it does not have any methods by it self)"
-	^ false
 ]
 
 { #category : #accessing }
@@ -127,23 +73,12 @@ Protocol >> name: anObject [
 	name := anObject asSymbol
 ]
 
-{ #category : #printing }
-Protocol >> printOn: aStream [
-	aStream
-		nextPutAll: self class name;
-		nextPutAll: ' (';
-		nextPutAll: self name;
-		nextPutAll: ') - ';
-		print: self methodSelectors size;
-		nextPutAll: ' selector(s)'
-]
-
-{ #category : #accessing }
+{ #category : #'adding-removing' }
 Protocol >> removeAllMethodSelectors [
 	^ methodSelectors removeAll
 ]
 
-{ #category : #accessing }
+{ #category : #'adding-removing' }
 Protocol >> removeMethodSelector: aSymbol [
 	^ methodSelectors remove: aSymbol
 ]

--- a/src/Ring-Core/AbstractProtocol.extension.st
+++ b/src/Ring-Core/AbstractProtocol.extension.st
@@ -1,7 +1,7 @@
-Extension { #name : #Protocol }
+Extension { #name : #AbstractProtocol }
 
 { #category : #'*Ring-Core' }
-Protocol >> asRingMinimalDefinitionIn: anRGEnvironment [
+AbstractProtocol >> asRingMinimalDefinitionIn: anRGEnvironment [
 
 	self error: 'For Protocol you need to use #asRingMinimalDefinitionIn:parent: because parent class cannot be resolved automatically'
 ]

--- a/src/SystemCommands-RefactoringSupport/RBAbstractSelectionPresenter.class.st
+++ b/src/SystemCommands-RefactoringSupport/RBAbstractSelectionPresenter.class.st
@@ -49,10 +49,11 @@ RBAbstractSelectionPresenter >> components [
 
 { #category : #initialization }
 RBAbstractSelectionPresenter >> initializeDropList [
+
 	dropList := self newDropList.
 	dropList
 		display: [ :scope | scope name ];
-		iconBlock: [ :e | e systemIcon ]
+		displayIcon: [ :e | e systemIcon ]
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
This PR Refactors the Protocol hierarchy. By not inheriting from Protocol, AllProtocol does not need to allocate space for the two ivars that it never uses (name and methodSelectors).

(there are numberOfClasses*2 instances of AllProtocol)

fixes #10963