### PR TITLE
11063-ExternalChangesBrowserbuildMenu-should-use-selectedItemsSorted 

### DIFF
--- a/src/Tool-ExternalBrowser/ExternalChangesBrowser.class.st
+++ b/src/Tool-ExternalBrowser/ExternalChangesBrowser.class.st
@@ -142,7 +142,7 @@ ExternalChangesBrowser >> buildMenu [
 	aMenu 	addItem: [ :item | 
 			item
 				name: 'File in all selected';
-				action: [ self fileIn: changes selectedItems ] ].
+				action: [ self fileIn: changes selectedItemsSorted ] ].
 
 	aMenu 	addItem: [ :item | 
 			item


### PR DESCRIPTION
Fix ExternalChangesBrowser as described in the issue tracker entry: use #selectedItemsSorted

fixes 11063