### PR TITLE
Fixing RBChildrenToSiblingsRefactoring to handle Classes that use Traits

### DIFF
--- a/src/Refactoring-Core/RBChildrenToSiblingsRefactoring.class.st
+++ b/src/Refactoring-Core/RBChildrenToSiblingsRefactoring.class.st
@@ -210,7 +210,7 @@ RBChildrenToSiblingsRefactoring >> reparentSubclasses [
 RBChildrenToSiblingsRefactoring >> selectorsToPushUpFrom: aClass [ 
 	| superSelectors |
 	superSelectors := self computeSubclassSupersOf: aClass.
-	^aClass selectors select: 
+	^aClass localSelectors select: 
 			[:each | 
 			(superSelectors includes: each) or: [self shouldPushUp: each from: aClass]]
 ]


### PR DESCRIPTION
Fix #9447 