### PR TITLE
Fixes issue #11143: MiniDrTests raise error

### DIFF
--- a/src/DrTests/MiniDrTests.class.st
+++ b/src/DrTests/MiniDrTests.class.st
@@ -92,10 +92,7 @@ MiniDrTests >> updateUI [
 
 	super updateUI.
 	startButton color: self evaluateBackgroundColor.
-	startButton label: pluginResult summarizeInfo.
-	"The next line doesn't work because Spec2 does not handle button label's styles.
-	Should be changed at some point"
-	startButton label makeAllColor: pluginResult textColor.
+	startButton label: pluginResult summarizeInfo
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
Fix #11143

Deleted the line that was updateing the color of the label of the button presenter. Now, in Spec2, we have to use spec styles for the colors and so on.

Pair programming with @RemiDufloer for the Pharo Sprint.