### PR TITLE
Resolves #11184: printStringLimitedTo:Using: will fail to actually respect limit

### DIFF
--- a/src/Kernel-Tests/ObjectTest.class.st
+++ b/src/Kernel-Tests/ObjectTest.class.st
@@ -207,8 +207,8 @@ ObjectTest >> testDisplayString [
 ObjectTest >> testDisplayStringLimitedString [
 
 	| actual |
-	actual := Object new displayStringLimitedTo: 4.
-	self assert: actual equals: 'an O...etc...'
+	actual := Object new displayStringLimitedTo: 8.
+	self assert: actual equals: 'an O[..]'
 ]
 
 { #category : #tests }
@@ -243,8 +243,8 @@ ObjectTest >> testInstVarNamedPut [
 ObjectTest >> testPrintLimitedString [
 
 	| actual |
-	actual := Object new printStringLimitedTo: 4.
-	self assert: actual equals: 'an O...etc...'
+	actual := Object new printStringLimitedTo: 8.
+	self assert: actual equals: 'an O[..]'
 ]
 
 { #category : #'tests - printing' }

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1649,11 +1649,12 @@ Object >> printStringLimitedTo: limit [
 { #category : #printing }
 Object >> printStringLimitedTo: limit using: printBlock [
 	"Answer a String whose characters are a description of the receiver
-	produced by given printBlock. It ensures the result will be not bigger than given limit"
+	produced by given printBlock. It ensures the result will be not bigger than given limit.
+	Given that the '...etc...' is itself nine characters long, limit should be at least 10."
 	| limitedString |
-	limitedString := String streamContents: printBlock limitedTo: limit.
-	limitedString size < limit ifTrue: [^ limitedString].
-	^ limitedString , '...etc...'
+	limitedString := String streamContents: printBlock limitedTo: limit + 1.
+	limitedString size <= limit ifTrue: [^ limitedString].
+	^ (limitedString truncateTo: limit - 9), '...etc...'
 ]
 
 { #category : #streaming }

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1650,11 +1650,11 @@ Object >> printStringLimitedTo: limit [
 Object >> printStringLimitedTo: limit using: printBlock [
 	"Answer a String whose characters are a description of the receiver
 	produced by given printBlock. It ensures the result will be not bigger than given limit.
-	Given that the '...etc...' is itself nine characters long, limit should be at least 10."
+	Given that the '[..]' is itself four characters long, limit should be at least 5."
 	| limitedString |
 	limitedString := String streamContents: printBlock limitedTo: limit + 1.
 	limitedString size <= limit ifTrue: [^ limitedString].
-	^ (limitedString truncateTo: limit - 9), '...etc...'
+	^ (limitedString truncateTo: limit - 4), '[..]'
 ]
 
 { #category : #streaming }


### PR DESCRIPTION
Changes Object >> printStringLimitedTo:Using so that it actually properly respects the limit, and that it doesn't add '...etc...' when exactly at the limit and thus not needed.