### PR TITLE
11186-Clean-Blocks-fix-to-make-debugger-work

### DIFF
--- a/src/Debugger-Model-Tests/DebugSessionContexts2Test.class.st
+++ b/src/Debugger-Model-Tests/DebugSessionContexts2Test.class.st
@@ -36,6 +36,8 @@ DebugSessionContexts2Test >> testContextsAfterStepInto [
 
 	session stepInto.
 	expectedMethod := (self class >> #setUp) literalAt: 2.
+	"for cleanblocks, we have to get the compiledBlock"
+	expectedMethod isBlock ifTrue: [ expectedMethod := expectedMethod compiledBlock  ].
 
 	self
 		assert: session interruptedProcess suspendedContext method
@@ -53,6 +55,9 @@ DebugSessionContexts2Test >> testInterruptedContext [
 	"With fullblocks the method of the suspended context is a compiledBlock, not the method having it"
 	| expectedMethod |
 	expectedMethod := (self class >> #setUp) literalAt: 2.
+	"for cleanblocks, we have to get the compiledBlock"
+	expectedMethod isBlock ifTrue: [ expectedMethod := expectedMethod compiledBlock ].
+
 
 	self assert: (session interruptedContext method) equals: expectedMethod.
 ]

--- a/src/Debugger-Model-Tests/StepOverTest.class.st
+++ b/src/Debugger-Model-Tests/StepOverTest.class.st
@@ -6,7 +6,8 @@ Class {
 
 { #category : #helper }
 StepOverTest >> methodWithUnwindReturn [
-	[ #body ] ensure: [ ^#unwindReturn ]
+	| temp | "temp to make sure the block is not clean"
+	[ temp ] ensure: [ ^#unwindReturn ]
 ]
 
 { #category : #helper }
@@ -212,7 +213,8 @@ StepOverTest >> testStepOverNonErrorExceptionSignalWithHandlerDeeperInTheContext
 { #category : #tests }
 StepOverTest >> testStepOverReturnInUnwindBlock [
 	"methodWithUnwindReturn
-		[ #body ] ensure: [ ^#unwindReturn ]
+		| temp | ""temp to make sure the block is not clean""
+		[ temp ] ensure: [ ^#unwindReturn ]
 	"
 	| rootBlock |
 	rootBlock := [ self methodWithUnwindReturn ].

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -888,6 +888,7 @@ Context >> home [
 	"Answer the context in which the receiver was defined, i.e. the context from which an ^-return ] should return from."
 
 	closureOrNil ifNil: [ ^ self ].
+	"this happens for clean blocks. We should later check if it is not better to return nil"
 	closureOrNil outerContext ifNil: [ ^ self ].
 	^ closureOrNil outerContext home
 ]

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -884,12 +884,12 @@ Context >> hasTemporaryVariableNamed: aName [
 ]
 
 { #category : #accessing }
-Context >> home [ 
-	"Answer the context in which the receiver was defined, i.e. the context from which an ^-return should return from."
+Context >> home [
+	"Answer the context in which the receiver was defined, i.e. the context from which an ^-return ] should return from."
 
-	closureOrNil == nil ifTrue:
-		[^self].
-	^closureOrNil outerContext home
+	closureOrNil ifNil: [ ^ self ].
+	closureOrNil outerContext ifNil: [ ^ self ].
+	^ closureOrNil outerContext home
 ]
 
 { #category : #private }


### PR DESCRIPTION
- nil check in Context>>#home (this allows us to open the debugger from a clean block, we need to check next if it works correctly)

- fix two tests that need  a fix for clean blocks

fixes #11186