### PR TITLE
Enable Fluid Class Definitions

### DIFF
--- a/src/Kernel/ClassDefinitionPrinter.class.st
+++ b/src/Kernel/ClassDefinitionPrinter.class.st
@@ -131,7 +131,7 @@ ClassDefinitionPrinter class >> settingsOn: aBuilder [
 	<systemsettings>
 	(aBuilder setting: #showFluidClassDefinition)
 		parent: #codeBrowsing;
-		default: false;
+		default: true;
 		label: 'Use fluid class definition';
 		description: 'If true, the system will display the class definition using a fluid interface e.g., 
 
@@ -161,7 +161,7 @@ Object << #Faked
 { #category : #configure }
 ClassDefinitionPrinter class >> showFluidClassDefinition [
 
-	^ ShowFluidClassDefinition ifNil: [ ShowFluidClassDefinition := false ]
+	^ ShowFluidClassDefinition ifNil: [ ShowFluidClassDefinition := true ]
 ]
 
 { #category : #configure }


### PR DESCRIPTION
Enable Fluid by default.

The goal is to check of there are stll problems with tests