### PR TITLE
Making completion support $_ in class and method names

### DIFF
--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -68,7 +68,7 @@ CompletionEngine >> completionTokenStart [
 
 { #category : #accessing }
 CompletionEngine >> context [
-	^context
+	^context ifNil: [ context := self createContext ]
 ]
 
 { #category : #private }

--- a/src/NECompletion/Character.extension.st
+++ b/src/NECompletion/Character.extension.st
@@ -3,5 +3,5 @@ Extension { #name : #Character }
 { #category : #'*NECompletion' }
 Character >> isCompletionCharacter [
 	"I defined the logic that completion can only happen with alphanumeric : characters."
-	^ self isAlphaNumeric or: [ self = $: ]
+	^ self isAlphaNumeric or: [ { $: . $_ } includes: self  ]
 ]

--- a/src/NECompletion/Character.extension.st
+++ b/src/NECompletion/Character.extension.st
@@ -3,5 +3,5 @@ Extension { #name : #Character }
 { #category : #'*NECompletion' }
 Character >> isCompletionCharacter [
 	"I defined the logic that completion can only happen with alphanumeric : characters."
-	^ self isAlphaNumeric or: [ { $: . $_ } includes: self  ]
+	^ self isAlphaNumeric or: [ #(:  _) includes: self  ]
 ]

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -819,9 +819,10 @@ RubSmalltalkEditor >> isWordCharacterAt: index in: aString [
 		"Check that it is a keyword selector.
 		 - followed by a colon
 		 - but not by an assignment "
-		character = $: and: [ 
-			aString size > index
-				and: [  (aString at: index + 1) ~= $= ] ] ]
+		(character = $_) or: [ 
+			(character = $:) and: [ 
+				aString size > index
+					and: [  (aString at: index + 1) ~= $= ] ] ] ]
 ]
 
 { #category : #'menu messages' }


### PR DESCRIPTION
Fix #10986 by preventing completion to break when classes and methods contain underscore