### PR TITLE
11198-Pharo10-Reflectivity-do-not-add-temp-for-value-if-not-generating-the-primtive-Wrapper

### DIFF
--- a/src/Reflectivity/RFSemanticAnalyzer.class.st
+++ b/src/Reflectivity/RFSemanticAnalyzer.class.st
@@ -68,7 +68,8 @@ RFSemanticAnalyzer >> visitMethodNode: aMethodNode [
 	aMethodNode scope: scope.  scope node: aMethodNode.
 	aMethodNode arguments do: [:node | self declareArgumentNode: node ].
 	aMethodNode pragmas do: [:each | self visitNode: each].
-	self declareTemporaryNode: (RBVariableNode named: #RFReifyValueVar).
+	(aMethodNode hasProperty: #wrappedPrimitive) 
+		ifTrue: [self declareTemporaryNode: (RBVariableNode named: #RFReifyValueVar)].
 	self analyseForLinksForNodes: aMethodNode.
 	self visitNode: aMethodNode body.
 ]


### PR DESCRIPTION
fixes #11198 for Pharo10