### PR TITLE
11218-CleanBlocks-Compiler-should-not-change-the-outerCode-for-all-blocks-in-the-literals 

### DIFF
--- a/src/Kernel/CleanBlockClosure.class.st
+++ b/src/Kernel/CleanBlockClosure.class.st
@@ -76,6 +76,11 @@ CleanBlockClosure >> messages [
 ]
 
 { #category : #accessing }
+CleanBlockClosure >> outerCode [
+	^self compiledBlock outerCode
+]
+
+{ #category : #accessing }
 CleanBlockClosure >> outerCode: aCompiledCode [
 	self compiledBlock outerCode: aCompiledCode
 ]

--- a/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
+++ b/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
@@ -172,7 +172,7 @@ IRBytecodeGenerator >> compiledBlockWith: trailer [
 		nextPutAll: self bytecodes.
 	lits withIndexDo: [:obj :i | cb literalAt: i put: obj].
 	cb needsFrameSize: self stackFrameSize.
-	self updateLiterals: cb.
+	self updateOuterCodeBlocks: cb.
 	^ cb
 ]
 
@@ -208,7 +208,7 @@ IRBytecodeGenerator >> compiledMethodWith: trailer header: header literals: lits
 		nextPutAll: self bytecodes.
 	lits withIndexDo: [:obj :i | cm literalAt: i put: obj].
 	cm needsFrameSize: self stackFrameSize.
-	self updateLiterals: cm.
+	self updateOuterCodeBlocks: cm.
 	self addProperties: cm.
 	^ cm
 ]
@@ -754,8 +754,12 @@ IRBytecodeGenerator >> updateJumpOffsets [
 ]
 
 { #category : #results }
-IRBytecodeGenerator >> updateLiterals: code [
-	"Add back pointer from compiled block to outer code"
-	code literals do: [ :each |
-		each isEmbeddedBlock ifTrue: [ each outerCode: code ] ]
+IRBytecodeGenerator >> updateOuterCodeBlocks: code [
+	"Add back pointer from compiled block to outer code for all blocks referenced from the literals"
+
+	| blocksToUpdate |
+	"Only do that for blocks the compiler created, where the outerCode is not yet set"
+	blocksToUpdate := code literals select: [ :each | 
+		                  each isEmbeddedBlock and: [ each outerCode isNil ] ].
+	blocksToUpdate do: [ :each | each outerCode: code ]
 ]


### PR DESCRIPTION
The Compiler adds a  back pointer from compiled block to the outer code.

Only do that for blocks the compiler created, where the outer code is not yet set.

fixes #11218