### PR TITLE
11230-ClassParser-Improve-Hierarchy-CDSharedVariableNodeCDSlotNode

### DIFF
--- a/src/ClassParser/CDSharedVariableNode.class.st
+++ b/src/ClassParser/CDSharedVariableNode.class.st
@@ -1,6 +1,9 @@
+"
+This class models definiton of Class Variables
+"
 Class {
 	#name : #CDSharedVariableNode,
-	#superclass : #CDSlotNode,
+	#superclass : #CDVariableNode,
 	#category : #'ClassParser-Model'
 }
 
@@ -15,6 +18,8 @@ CDSharedVariableNode class >> slot: aSlot node: aNode [
 
 { #category : #transforming }
 CDSharedVariableNode >> asClassVariable [
+	"for not this only supports ClassVariables. 
+	We need to create a ClassVariable here using the Variable Definition"
 	^ ClassVariable named: self name.
 ]
 

--- a/src/ClassParser/CDSlotNode.class.st
+++ b/src/ClassParser/CDSlotNode.class.st
@@ -1,41 +1,11 @@
+"
+This class models definiton of instance Variables (Slots)
+"
 Class {
 	#name : #CDSlotNode,
-	#superclass : #CDNode,
-	#instVars : [
-		'node',
-		'start',
-		'stop',
-		'name',
-		'initializationMessage',
-		'slotClassName'
-	],
+	#superclass : #CDVariableNode,
 	#category : #'ClassParser-Model'
 }
-
-{ #category : #'instance creation' }
-CDSlotNode class >> node: aNode name: aName slotClassName: aSymbol initializationMessage: aMessageNode start: start stop: stop [
-	
-	^ self new
-		node: aNode;
-		name: aName;
-		slotClassName: aSymbol;
-		initializationMessage: aMessageNode;
-		start: start;
-		stop: stop;
-		yourself
-]
-
-{ #category : #'instance creation' }
-CDSlotNode class >> node: aNode name: aName slotClassName: aSymbol start: start stop: stop [
-	
-	^ self new
-		node: aNode;
-		name: aName;
-		slotClassName: aSymbol;
-		start: start;
-		stop: stop;
-		yourself
-]
 
 { #category : #transforming }
 CDSlotNode >> asSlot [
@@ -44,33 +14,8 @@ CDSlotNode >> asSlot [
 	^InstanceVariableSlot named: name
 ]
 
-{ #category : #accessing }
-CDSlotNode >> binding [
-	"To be polymorphic to RB method nodes"
-	^self
-]
-
-{ #category : #accessing }
-CDSlotNode >> initializationMessage [
-	"Return the message node representing the initialization part of a slot."
-	
-	^ initializationMessage
-]
-
-{ #category : #accessing }
-CDSlotNode >> initializationMessage: aMessageNode [ 
-	
-	initializationMessage := aMessageNode
-]
-
 { #category : #testing }
 CDSlotNode >> isClassVariable [
-	"To be polymorphic to RB method nodes"
-	^false
-]
-
-{ #category : #testing }
-CDSlotNode >> isGlobalVariable [
 	"To be polymorphic to RB method nodes"
 	^false
 ]
@@ -85,106 +30,4 @@ CDSlotNode >> isInstanceVariable [
 CDSlotNode >> isLiteralVariable [
 	"To be polymorphic to RB method nodes"
 	^false
-]
-
-{ #category : #testing }
-CDSlotNode >> isTempVariable [
-	"To be polymorphic to RB method nodes"
-	^false
-]
-
-{ #category : #testing }
-CDSlotNode >> isUndeclaredVariable [
-	"To be polymorphic to RB method nodes"
-	^false
-]
-
-{ #category : #testing }
-CDSlotNode >> isVariable [
-	"To be polymorphic to RB method nodes"
-	| existingClass |
-	existingClass := self classDefinitionNode existingClassIfAbsent: [   
-		"Until class will be created the variables does not exist yet" 
-		^false ].
-	^existingClass 
-		slotNamed: name asSymbol 
-		ifFound: [true] 
-		ifNone: [
-			"Until class will be compiled with new slot the new slot does not exist yet"
-			false]
-]
-
-{ #category : #testing }
-CDSlotNode >> isWorkspaceVariable [
-	^ false
-]
-
-{ #category : #accessing }
-CDSlotNode >> name [
-
-	^ name
-]
-
-{ #category : #accessing }
-CDSlotNode >> name: aString [
-
-	name := aString
-]
-
-{ #category : #accessing }
-CDSlotNode >> node: aNode [ 
-	node := aNode
-]
-
-{ #category : #printing }
-CDSlotNode >> printOn: aStream [
-
-	aStream
-		nextPutAll: self class name;
-		nextPutAll: '(';
-		print: name ;
-		nextPutAll: ' => ';
-		print: slotClassName;
-		nextPutAll: ')'
-]
-
-{ #category : #accessing }
-CDSlotNode >> slotClassName [
-	"Return a symbol representing the class of the slot: i.e., 'x' => InstanceVariableSlot slotClassName returns 
-	#InstanceVariableSlot"
-	
-	^ slotClassName
-]
-
-{ #category : #accessing }
-CDSlotNode >> slotClassName: aSymbol [ 
-	
-	slotClassName := aSymbol
-]
-
-{ #category : #accessing }
-CDSlotNode >> sourceInterval [
-	^start to: stop
-]
-
-{ #category : #selection }
-CDSlotNode >> start [
-
-	^ start
-]
-
-{ #category : #accessing }
-CDSlotNode >> start: anInteger [ 
-	start := anInteger
-]
-
-{ #category : #selection }
-CDSlotNode >> stop [
-	^ stop
-]
-
-{ #category : #accessing }
-CDSlotNode >> stop: anInteger [ 
-	
-	stop := anInteger
 ]

--- a/src/ClassParser/CDVariableNode.class.st
+++ b/src/ClassParser/CDVariableNode.class.st
@@ -1,0 +1,189 @@
+"
+Abstract superclass for Variable definitions: Slots (instance and class side) and ClassVariables (aka SharedVariables)
+"
+Class {
+	#name : #CDVariableNode,
+	#superclass : #CDNode,
+	#instVars : [
+		'node',
+		'start',
+		'stop',
+		'name',
+		'initializationMessage',
+		'variableClassName'
+	],
+	#category : #'ClassParser-Model'
+}
+
+{ #category : #testing }
+CDVariableNode class >> isAbstract [
+		
+	^ self == CDVariableNode
+]
+
+{ #category : #'instance creation' }
+CDVariableNode class >> node: aNode name: aName slotClassName: aSymbol initializationMessage: aMessageNode start: start stop: stop [
+	
+	^ self new
+		node: aNode;
+		name: aName;
+		variableClassName: aSymbol;
+		initializationMessage: aMessageNode;
+		start: start;
+		stop: stop;
+		yourself
+]
+
+{ #category : #'instance creation' }
+CDVariableNode class >> node: aNode name: aName slotClassName: aSymbol start: start stop: stop [
+	
+	^ self new
+		node: aNode;
+		name: aName;
+		variableClassName: aSymbol;
+		start: start;
+		stop: stop;
+		yourself
+]
+
+{ #category : #accessing }
+CDVariableNode >> binding [
+	"To be polymorphic to RB method nodes"
+	^self
+]
+
+{ #category : #accessing }
+CDVariableNode >> initializationMessage [
+	"Return the message node representing the initialization part of a slot."
+	
+	^ initializationMessage
+]
+
+{ #category : #accessing }
+CDVariableNode >> initializationMessage: aMessageNode [ 
+	
+	initializationMessage := aMessageNode
+]
+
+{ #category : #testing }
+CDVariableNode >> isClassVariable [
+	^ self subclassResponsibility
+]
+
+{ #category : #testing }
+CDVariableNode >> isGlobalVariable [
+	"To be polymorphic to RB method nodes"
+	^false
+]
+
+{ #category : #testing }
+CDVariableNode >> isInstanceVariable [
+	^ self subclassResponsibility
+]
+
+{ #category : #testing }
+CDVariableNode >> isLiteralVariable [
+	^ self subclassResponsibility
+]
+
+{ #category : #testing }
+CDVariableNode >> isTempVariable [
+	"To be polymorphic to RB method nodes"
+	^false
+]
+
+{ #category : #testing }
+CDVariableNode >> isUndeclaredVariable [
+	"To be polymorphic to RB method nodes"
+	^false
+]
+
+{ #category : #testing }
+CDVariableNode >> isVariable [
+	"To be polymorphic to RB method nodes"
+	| existingClass |
+	existingClass := self classDefinitionNode existingClassIfAbsent: [   
+		"Until class will be created the variables does not exist yet" 
+		^false ].
+	^existingClass 
+		slotNamed: name asSymbol 
+		ifFound: [true] 
+		ifNone: [
+			"Until class will be compiled with new slot the new slot does not exist yet"
+			false]
+]
+
+{ #category : #testing }
+CDVariableNode >> isWorkspaceVariable [
+	^ false
+]
+
+{ #category : #accessing }
+CDVariableNode >> name [
+
+	^ name
+]
+
+{ #category : #accessing }
+CDVariableNode >> name: aString [
+
+	name := aString
+]
+
+{ #category : #accessing }
+CDVariableNode >> node: aNode [ 
+	node := aNode
+]
+
+{ #category : #printing }
+CDVariableNode >> printOn: aStream [
+
+	aStream
+		nextPutAll: self class name;
+		nextPutAll: '(';
+		print: name ;
+		nextPutAll: ' => ';
+		print: variableClassName;
+		nextPutAll: ')'
+]
+
+{ #category : #accessing }
+CDVariableNode >> sourceInterval [
+	^start to: stop
+]
+
+{ #category : #selection }
+CDVariableNode >> start [
+
+	^ start
+]
+
+{ #category : #accessing }
+CDVariableNode >> start: anInteger [ 
+	start := anInteger
+]
+
+{ #category : #selection }
+CDVariableNode >> stop [
+	^ stop
+]
+
+{ #category : #accessing }
+CDVariableNode >> stop: anInteger [ 
+	
+	stop := anInteger
+]
+
+{ #category : #accessing }
+CDVariableNode >> variableClassName [
+	"Return a symbol representing the class of the variable i.e., 'x' => InstanceVariableSlot slotClassName returns 
+	#InstanceVariableSlot"
+	
+	^ variableClassName
+]
+
+{ #category : #accessing }
+CDVariableNode >> variableClassName: aSymbol [ 
+	
+	variableClassName := aSymbol
+]

--- a/src/ClassParser/ShiftClassBuilder.extension.st
+++ b/src/ClassParser/ShiftClassBuilder.extension.st
@@ -17,7 +17,7 @@ ShiftClassBuilder >> buildFromAST: aCDClassDefinitionNode [
 		
 	self layoutClass: aCDClassDefinitionNode layoutClass.
 		
-	self slots: (aCDClassDefinitionNode slots collect: [ :e | e asSlot ]).
+	self slots: (aCDClassDefinitionNode slots collect: [ :e | e asSlot]).
 	
 	self sharedVariables: (aCDClassDefinitionNode sharedSlots collect: [ :e | e ]).
 	


### PR DESCRIPTION
CDSharedVariableNode is a subclass of CDSlotNode. This is not really good, as SharedVariables (ClassVariables) are not Slots.

The hierarchy should have an abstract CDVariableNode with the two classes being subclasses of that.


fixes #11230