### PR TITLE
Reset SelectorTable on #cleanUp

### DIFF
--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -149,6 +149,8 @@ Symbol class >> internCharacter: aCharacter [
 Symbol class >> internSelector: aStringOrSymbol [
 	| selector |
 	aStringOrSymbol isDoIt ifTrue: [ ^self ].
+	(aStringOrSymbol == #UndefinedMethod) ifTrue: [ ^self ].
+	Smalltalk globals at: #Transcript ifPresent: [:tr | tr ifNotNil: [tr show: 'InterningSelector: ', aStringOrSymbol asString;cr]].
 	selector := (self selectorTable like: aStringOrSymbol)
 		ifNil: [ self selectorTable add: aStringOrSymbol asSymbol ].
 	^ selector

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -149,7 +149,6 @@ Symbol class >> internCharacter: aCharacter [
 Symbol class >> internSelector: aStringOrSymbol [
 	| selector |
 	aStringOrSymbol isDoIt ifTrue: [ ^self ].
-	(aStringOrSymbol == #UndefinedMethod) ifTrue: [ ^self ].
 	Smalltalk globals at: #Transcript ifPresent: [:tr | tr ifNotNil: [tr show: 'InterningSelector: ', aStringOrSymbol asString;cr]].
 	selector := (self selectorTable like: aStringOrSymbol)
 		ifNil: [ self selectorTable add: aStringOrSymbol asSymbol ].

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -224,7 +224,7 @@ Symbol class >> readFrom: strm [
 { #category : #cleanup }
 Symbol class >> rebuildSelectorTable [
 	| selectorTable |
-	Transcript show: '#rebuildSelectorTable';cr.
+	Smalltalk globals at: #Transcript ifPresent: [:tr | tr show: '#rebuildSelectorTable';cr].
 	selectorTable := WeakSet new.
 	CompiledMethod
 		allInstancesDo: [ :method | 
@@ -246,7 +246,7 @@ Symbol class >> rehash [
 
 { #category : #private }
 Symbol class >> resetSelectorTable [
-	Transcript show: '#resetSelectorTable';cr.
+	Smalltalk globals at: #Transcript ifPresent: [:tr | tr show: '#rebuildSelectorTable';cr].
 	^ SelectorTable := nil
 ]
 

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -148,6 +148,7 @@ Symbol class >> internCharacter: aCharacter [
 { #category : #'instance creation' }
 Symbol class >> internSelector: aStringOrSymbol [
 	| selector |
+	aStringOrSymbol isDoIt ifTrue: [ ^self ].
 	selector := (self selectorTable like: aStringOrSymbol)
 		ifNil: [ self selectorTable add: aStringOrSymbol asSymbol ].
 	^ selector

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -147,12 +147,9 @@ Symbol class >> internCharacter: aCharacter [
 
 { #category : #'instance creation' }
 Symbol class >> internSelector: aStringOrSymbol [
-	| selector |
-	aStringOrSymbol isDoIt ifTrue: [ ^self ].
-	Smalltalk globals at: #Transcript ifPresent: [:tr | tr ifNotNil: [tr show: 'InterningSelector: ', aStringOrSymbol asString;cr]].
-	selector := (self selectorTable like: aStringOrSymbol)
-		ifNil: [ self selectorTable add: aStringOrSymbol asSymbol ].
-	^ selector
+
+	^ (self selectorTable like: aStringOrSymbol) ifNil: [ 
+		  self selectorTable add: aStringOrSymbol asSymbol ]
 ]
 
 { #category : #'instance creation' }
@@ -225,7 +222,6 @@ Symbol class >> readFrom: strm [
 { #category : #cleanup }
 Symbol class >> rebuildSelectorTable [
 	| selectorTable |
-	Smalltalk globals at: #Transcript ifPresent: [:tr | tr ifNotNil: [tr show: '#rebuildSelectorTable';cr]].
 	selectorTable := WeakSet new.
 	CompiledMethod
 		allInstancesDo: [ :method | 
@@ -247,7 +243,6 @@ Symbol class >> rehash [
 
 { #category : #private }
 Symbol class >> resetSelectorTable [
-		Smalltalk globals at: #Transcript ifPresent: [:tr | tr ifNotNil: [tr show: '#resetSelectorTable';cr]].
 	^ SelectorTable := nil
 ]
 

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -224,7 +224,7 @@ Symbol class >> readFrom: strm [
 { #category : #cleanup }
 Symbol class >> rebuildSelectorTable [
 	| selectorTable |
-	Smalltalk globals at: #Transcript ifPresent: [:tr | tr show: '#rebuildSelectorTable';cr].
+	Smalltalk globals at: #Transcript ifPresent: [:tr | tr ifNotNil: [tr show: '#rebuildSelectorTable';cr]].
 	selectorTable := WeakSet new.
 	CompiledMethod
 		allInstancesDo: [ :method | 

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -224,6 +224,7 @@ Symbol class >> readFrom: strm [
 { #category : #cleanup }
 Symbol class >> rebuildSelectorTable [
 	| selectorTable |
+	Transcript show: '#rebuildSelectorTable';cr.
 	selectorTable := WeakSet new.
 	CompiledMethod
 		allInstancesDo: [ :method | 
@@ -245,6 +246,7 @@ Symbol class >> rehash [
 
 { #category : #private }
 Symbol class >> resetSelectorTable [
+	Transcript show: '#resetSelectorTable';cr.
 	^ SelectorTable := nil
 ]
 

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -67,7 +67,7 @@ Symbol class >> cleanUp [
 	"Flush caches"
 
 	self compactSymbolTable.
-	self rebuildSelectorTable
+	self resetSelectorTable
 ]
 
 { #category : #accessing }
@@ -110,11 +110,6 @@ Symbol class >> hasInterned: aString ifTrue: symBlock [
 		ifNotNil: [ :symbol | 
 			symBlock value: symbol.
 			true ]
-]
-
-{ #category : #private }
-Symbol class >> initSelectorTable [
-	^ SelectorTable := WeakSet new
 ]
 
 { #category : #'class initialization' }
@@ -227,12 +222,14 @@ Symbol class >> readFrom: strm [
 
 { #category : #cleanup }
 Symbol class >> rebuildSelectorTable [
-	self initSelectorTable.
+	| selectorTable |
+	selectorTable := WeakSet new.
 	CompiledMethod
 		allInstancesDo: [ :method | 
 			| selector |
 			selector := method selector.
-			selector ifNotNil: [ SelectorTable add: selector ] ]
+			selector ifNotNil: [ selectorTable add: selector ] ].
+	^selectorTable.
 ]
 
 { #category : #private }
@@ -242,12 +239,17 @@ Symbol class >> rehash [
 
 	SymbolTable := WeakSet withAll: self allSubInstances.
 	NewSymbols := WeakSet new.
-	self rebuildSelectorTable.
+	self resetSelectorTable.
+]
+
+{ #category : #private }
+Symbol class >> resetSelectorTable [
+	^ SelectorTable := nil
 ]
 
 { #category : #private }
 Symbol class >> selectorTable [
-	^SelectorTable ifNil: [self initSelectorTable]
+	^SelectorTable ifNil: [SelectorTable := self rebuildSelectorTable]
 ]
 
 { #category : #accessing }

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -246,7 +246,7 @@ Symbol class >> rehash [
 
 { #category : #private }
 Symbol class >> resetSelectorTable [
-	Smalltalk globals at: #Transcript ifPresent: [:tr | tr show: '#rebuildSelectorTable';cr].
+		Smalltalk globals at: #Transcript ifPresent: [:tr | tr ifNotNil: [tr show: '#resetSelectorTable';cr]].
 	^ SelectorTable := nil
 ]
 

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -98,7 +98,9 @@ Behavior >> addSelectorSilently: selector withMethod: compiledMethod [
 
 	self methodDict at: selector put: compiledMethod.
 	compiledMethod methodClass: self.
-	compiledMethod selector: selector
+	compiledMethod selector: selector.
+	"We record all selectors that are used as method names"
+	Symbol internSelector: selector
 ]
 
 { #category : #'adding-removing methods' }

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -1019,7 +1019,6 @@ CompiledMethod >> selector: aSelector [
 	 or, if the method has any properties or pragmas, the selector of
 	 the MethodProperties stored in the penultimate literal."
 	| penultimateLiteral nl | 
-	Symbol internSelector:  aSelector.
 	(penultimateLiteral := self penultimateLiteral) isMethodProperties
 		ifTrue: [penultimateLiteral selector: aSelector]
 		ifFalse: [(nl := self numLiterals) < 2 ifTrue:


### PR DESCRIPTION
This PR makes sure to nil out the SelectorTable on #cleanUp and #rehash.

This means that the download image will be a bit smaller (WeakSet of size 140K entries).