### PR TITLE
Pharo11-UFT8-Monticello

### DIFF
--- a/src/Monticello/MCVersionInfoWriter.class.st
+++ b/src/Monticello/MCVersionInfoWriter.class.st
@@ -25,7 +25,7 @@ MCVersionInfoWriter >> writeVersionInfo: aVersionInfo [
 	#(name message id date time author) do: [:sel | 
 		stream 
 			nextPutAll: sel; space;
-			print: (((aVersionInfo perform: sel) ifNil: ['']) asString encodeWith: 'latin-1' ) asString; space ].
+			print: (((aVersionInfo perform: sel) ifNil: ['']) asString encodeWith: #utf8  ) asString; space ].
 	stream nextPutAll: 'ancestors ('.
 	aVersionInfo ancestors do: [:ea | self writeVersionInfo: ea].
 	stream nextPutAll: ') stepChildren ('.


### PR DESCRIPTION
This commit changes the encoding as described in the Issue  #11226

The MC reader and installer already assume utf8 and fall back to latin1 on error... we could do the same if needed
(see MCMczReader>>#contentStreamForMember: )