### PR TITLE
Redraw world on SDL_WINDOWEVENT_EXPOSED

### DIFF
--- a/src/OSWindow-Core/OSWindowMorphicEventHandler.class.st
+++ b/src/OSWindow-Core/OSWindowMorphicEventHandler.class.st
@@ -317,6 +317,12 @@ OSWindowMorphicEventHandler >> visitWindowDropEvent: anEvent [
 ]
 
 { #category : #visiting }
+OSWindowMorphicEventHandler >> visitWindowExposeEvent: anEvent [
+	"Completely redraw world when visible part of window changes to prevent some graphical glitches"
+    morphicWorld worldState doFullRepaint.
+]
+
+{ #category : #visiting }
 OSWindowMorphicEventHandler >> visitWindowResizeEvent: anEvent [
 
 	"window resized"


### PR DESCRIPTION
Related to #10999
Since Pharo 9 on Linux, OS window wouldn't redraw areas that were covered by anything outside it until other draw event inside it would be called. For example, dragging one window over Pharo window would leave traces of that window; they would stay until one would click on Pharo window to open a context menu or mouse over any morph with different on-hover appearance.
SDL sends SDL_WINDOWEVENT_EXPOSED event in such cases. I have seen no apparent way to find dirty rectangle that needs redrawing and simply redrawing entire window seems to be common approach elsewhere, so the solution is to simply redraw entire window when we receive the event. Everything but event handler were already made.
This patch has been tested by few Linux users and it doesn't seem to cause other issues so far.