### PR TITLE
Cleanup: OneCharacterSymbols: Symbol allSymbols contains one-character symbols twice 

### DIFF
--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -740,8 +740,7 @@ String >> asString [
 
 { #category : #converting }
 String >> asSymbol [
-	"Answer the unique Symbol whose characters are the characters of the 
-	string."
+	"Answer the unique Symbol whose characters are the characters of the string."
 	^Symbol intern: self
 ]
 

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -140,11 +140,6 @@ Symbol class >> intern: aStringOrSymbol [
 ]
 
 { #category : #'instance creation' }
-Symbol class >> internCharacter: aCharacter [
-	^self intern: aCharacter asString
-]
-
-{ #category : #'instance creation' }
 Symbol class >> internSelector: aStringOrSymbol [
 	| selector |
 	selector := (self selectorTable like: aStringOrSymbol)

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -57,9 +57,8 @@ Symbol class >> allSymbols [
 	"Answer all interned symbols"
 	^Array streamContents:[:s|
 		s nextPutAll: NewSymbols.
-		s nextPutAll: OneCharacterSymbols.
 		s nextPutAll: SymbolTable.
-	].
+	]
 ]
 
 { #category : #cleanup }
@@ -120,9 +119,6 @@ Symbol class >> initSelectorTable [
 { #category : #'class initialization' }
 Symbol class >> initialize [
 	self rehash.
-	OneCharacterSymbols := nil.
-	OneCharacterSymbols := (1 to: 256) collect: [ :i | (i - 1) asCharacter asSymbol].
-
 	SessionManager default
 		registerSystemClassNamed: #Symbol
 ]
@@ -145,9 +141,7 @@ Symbol class >> intern: aStringOrSymbol [
 
 { #category : #'instance creation' }
 Symbol class >> internCharacter: aCharacter [
-	aCharacter asciiValue > 256 ifTrue:[^self intern: aCharacter asString].
-	OneCharacterSymbols ifNil: [^self intern: aCharacter asString].
-	^OneCharacterSymbols at: aCharacter asciiValue + 1
+	^self intern: aCharacter asString
 ]
 
 { #category : #'instance creation' }
@@ -270,43 +264,6 @@ Symbol class >> selectorThatStartsCaseSensitive: leadingCharacters skipping: ski
 		] after: skipSym.
 
 	^nil
-]
-
-{ #category : #accessing }
-Symbol class >> selectorsContaining: aString [
-	"Answer a list of selectors that contain aString within them. Case-insensitive.  Does return symbols that begin with a capital letter."
-
-	| size selectorList ascii |
-
-	selectorList := OrderedCollection new.
-	(size := aString size) = 0 ifTrue: [^selectorList].
-
-	aString size = 1 ifTrue:
-		[
-			ascii := aString first asciiValue.
-			ascii < 128 ifTrue: [selectorList add: (OneCharacterSymbols at: ascii+1)]
-		].
-
-	(aString first isAlphaNumeric) ifFalse:
-		[
-			aString size = 2 ifTrue: 
-				[Symbol hasInterned: aString ifTrue:
-					[:s | selectorList add: s]].
-			^selectorList
-		].
-
-	selectorList := selectorList copyFrom: 2 to: selectorList size.
-
-	self allSymbolTablesDo: [:each |
-		each size >= size ifTrue:
-			[(each findSubstring: aString in: each startingAt: 1 
-				matchTable: CaseInsensitiveOrder) > 0
-						ifTrue: [selectorList add: each]]].
-
-	^selectorList reject: [:each | "reject non-selectors, but keep ones that begin with an uppercase"
-		each numArgs < 0 and: [each asString uncapitalized numArgs < 0]].
-
-"Symbol selectorsContaining: 'scon'"
 ]
 
 { #category : #'system startup' }

--- a/src/Kernel/Character.class.st
+++ b/src/Kernel/Character.class.st
@@ -357,8 +357,7 @@ Character >> asString [
 { #category : #converting }
 Character >> asSymbol [ 
 	"Answer a Symbol consisting of the receiver as the only element."
-
-	^Symbol internCharacter: self
+	^ self asString asSymbol
 ]
 
 { #category : #converting }

--- a/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
@@ -22,7 +22,7 @@ NoUnusedVariablesLeftTest >> testNoUnusedClassVariablesLeft [
 	
 	classes := variables collect: [ :each | each definingClass ] as: Set.
 	
-	validExceptions := #(OSKeySymbols FooSharedPool SDL2Constants AthensCairoDefinitions BalloonEngineConstants ShTestSharedPool RBLintRuleTestData RBDummyLintRuleTest MCMockClassF Unicode Character STONAlternativeRepresentationTestObject).	
+	validExceptions := #(OSKeySymbols FooSharedPool SDL2Constants AthensCairoDefinitions BalloonEngineConstants ShTestSharedPool RBLintRuleTestData RBDummyLintRuleTest MCMockClassF Unicode Character Symbol STONAlternativeRepresentationTestObject).	
 	
 	remaining := classes asOrderedCollection reject: [ :each  | validExceptions includes: each name].
 	self assert: remaining isEmpty description: ('the following classes have unused class variables and should be cleaned: ', remaining asString)


### PR DESCRIPTION
This PR removes the initialize and use of OneCharacterSymbols.

- OneCharacterSymbols is not used by #intern:, just allSymbols
- Why add a symbol for all characters anyway? We will intern them as needed.
- The current scheme we could them twice... as they are interned via #intern: and inside the OneCharacterSymbols.

The class variable is not yet removed.

This removed the unused method #selectorsContaining:, too