### PR TITLE
11243-Symbol-classrebuildSelectorTable-hould-not-use-allInstancesDo

### DIFF
--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -210,14 +210,10 @@ Symbol class >> readFrom: strm [
 
 { #category : #cleanup }
 Symbol class >> rebuildSelectorTable [
-	| selectorTable |
-	selectorTable := WeakSet new.
-	CompiledMethod
-		allInstancesDo: [ :method | 
-			| selector |
-			selector := method selector.
-			selector ifNotNil: [ selectorTable add: selector ] ].
-	^selectorTable.
+
+	^ SystemNavigation new allMethods
+		  collect: [ :method | method selector ]
+		  as: WeakSet
 ]
 
 { #category : #private }

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -213,7 +213,7 @@ Symbol class >> rebuildSelectorTable [
 
 	^ SystemNavigation new allMethods
 		  collect: [ :method | method selector ]
-		  as: WeakIdentitySet
+		  as: WeakSet
 ]
 
 { #category : #private }

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -213,7 +213,7 @@ Symbol class >> rebuildSelectorTable [
 
 	^ SystemNavigation new allMethods
 		  collect: [ :method | method selector ]
-		  as: WeakSet
+		  as: WeakIdentitySet
 ]
 
 { #category : #private }


### PR DESCRIPTION
do not use allInstancesDo: and simplify, fixes #11243