### PR TITLE
11245-Trivial-FinderUI-classsearchedTextListMaxSize-can-be-removed

### DIFF
--- a/src/Tool-Finder/FinderUI.class.st
+++ b/src/Tool-Finder/FinderUI.class.st
@@ -120,13 +120,6 @@ FinderUI class >> on: aFinder [
 	^instance
 ]
 
-{ #category : #accessing }
-FinderUI class >> searchedTextListMaxSize: anInteger [
-
-	self allInstancesDo: [:each | each searchedTextListMaxSize: anInteger].
-	searchedTextListMaxSize := anInteger
-]
-
 { #category : #'event subscriptions' }
 FinderUI class >> subscribesDisableUseRegExOn: aFinder to: anInstance [
 
@@ -872,12 +865,6 @@ FinderUI >> searchedTextList: aCollection [
 { #category : #accessing }
 FinderUI >> searchedTextListMaxSize [
 	^20
-]
-
-{ #category : #accessing }
-FinderUI >> searchedTextListMaxSize: anInteger [
-	[ self searchedTextList size > anInteger ] whileTrue: [ self searchedTextList removeLast ].
-	self changed: #searchedTextList
 ]
 
 { #category : #'text areas behavior' }

--- a/src/Tool-Finder/FinderUI.class.st
+++ b/src/Tool-Finder/FinderUI.class.st
@@ -15,9 +15,6 @@ Class {
 		'searchedTextList',
 		'sourceTextModel'
 	],
-	#classInstVars : [
-		'searchedTextListMaxSize'
-	],
 	#category : #'Tool-Finder-UI'
 }
 
@@ -35,11 +32,6 @@ FinderUI class >> doAllSubscriptionsOn: aFinder to: anInstance [
 { #category : #icons }
 FinderUI class >> icon [
 	^ self iconNamed: #smallFindIcon
-]
-
-{ #category : #'class initialization' }
-FinderUI class >> initialize [
-	searchedTextListMaxSize := 15
 ]
 
 { #category : #explanations }


### PR DESCRIPTION
cleanup. Fixes #11245