### PR TITLE
Unified isLiteral categories

### DIFF
--- a/src/Kernel/Boolean.class.st
+++ b/src/Kernel/Boolean.class.st
@@ -149,7 +149,7 @@ Boolean >> ifTrue: trueAlternativeBlock ifFalse: falseAlternativeBlock [
 	self subclassResponsibility
 ]
 
-{ #category : #printing }
+{ #category : #testing }
 Boolean >> isLiteral [ 
 	^ true
 ]

--- a/src/Kernel/Character.class.st
+++ b/src/Kernel/Character.class.st
@@ -655,7 +655,7 @@ Character >> isLineSeparator [
 	^ self characterSet isLineSeparator: self
 ]
 
-{ #category : #'testing - kind' }
+{ #category : #testing }
 Character >> isLiteral [
 
 	^ true

--- a/src/Kernel/Integer.class.st
+++ b/src/Kernel/Integer.class.st
@@ -1077,7 +1077,7 @@ Integer >> isInteger [
 	^ true
 ]
 
-{ #category : #printing }
+{ #category : #testing }
 Integer >> isLiteral [
 
 	^true


### PR DESCRIPTION
Fixes #11238

Unified the categories of the implementation of `isLiteral`