### PR TITLE
Deleted FinderUI class>>#searchedTextListMaxSize:

### DIFF
--- a/src/Tool-Finder/FinderUI.class.st
+++ b/src/Tool-Finder/FinderUI.class.st
@@ -120,13 +120,6 @@ FinderUI class >> on: aFinder [
 	^instance
 ]
 
-{ #category : #accessing }
-FinderUI class >> searchedTextListMaxSize: anInteger [
-
-	self allInstancesDo: [:each | each searchedTextListMaxSize: anInteger].
-	searchedTextListMaxSize := anInteger
-]
-
 { #category : #'event subscriptions' }
 FinderUI class >> subscribesDisableUseRegExOn: aFinder to: anInstance [
 


### PR DESCRIPTION
Deleted `FinderUI class>>#searchedTextListMaxSize:`

Fixes #11245 