### PR TITLE
Fixed issue 11210: Do not skip NativeArrayTest>>#testDoubleArraysHaveCorrectLayout

### DIFF
--- a/src/Collections-Tests/NativeArrayTest.class.st
+++ b/src/Collections-Tests/NativeArrayTest.class.st
@@ -93,8 +93,6 @@ NativeArrayTest >> testAtPutExactSizeNumber [
 
 { #category : #tests }
 NativeArrayTest >> testDoubleArraysHaveCorrectLayout [
-	self skip.
-	"this is broken, work in progress see https://github.com/pharo-project/pharo/issues/5956"
 	self assert: DoubleWordArray classLayout class equals: DoubleWordLayout.
 	self assert: DoubleByteArray classLayout class equals: DoubleByteLayout
 ]


### PR DESCRIPTION
Removed the skipped message and the comment section