### PR TITLE
9828-Inspector-columns-cannot-be-resized 

### DIFF
--- a/src/Morphic-Widgets-FastTable/FTColumnResizerMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTColumnResizerMorph.class.st
@@ -178,7 +178,7 @@ FTColumnResizerMorph >> updateFromEvent: anEvent [
 	(delta < 0 and: [ delta negated > (leftColumn width - (self width) - 5) ])
 		ifTrue: [ delta := (leftColumn width - (self width) - 5) negated ].
 
-	leftColumn column width: (leftColumn column width ifNil: [ leftColumn width ]) + delta.
-	rightColumn column width: (rightColumn column width ifNil: [ rightColumn width ]) - delta.	
+	leftColumn column model width: (leftColumn column width ifNil: [ leftColumn width ]) + delta.
+	rightColumn column model width: (rightColumn column width ifNil: [ rightColumn width ]) - delta.	
 	container changed
 ]

--- a/src/Zinc-Character-Encoding-Core/ZnBufferedReadStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnBufferedReadStream.class.st
@@ -380,26 +380,23 @@ ZnBufferedReadStream >> upToEnd [
 	"Read elements until the stream is atEnd and return them as a collection."
 
 	| streamSize result remaining |
-
 	"If the stream knows its size we can reduce overhead by allocating a buffer of the correct size.
 	If the size is an over-estimate, #next: will copy the results in to a buffer of the correct size."
-	streamSize := [ self size ]
-		on: Error
-		do: [ 0 ].
-	streamSize > 0 ifTrue:
-		[ result := self next: (streamSize - self position) ].
+	streamSize := [ self size ] on: Error do: [ 0 ].
+	result := streamSize > 0 
+		ifTrue: [ self next: (streamSize - self position) ]
+		ifFalse: [ self collectionSpecies new ].
 	"If the size is an under-estimate we're not at the end, get the rest and append to the result"
-	self atEnd ifFalse:
-		[ remaining := self collectionSpecies streamContents: [ :out | 
-			[ self atEnd ] whileFalse: [ 
-				position > limit
-					ifTrue: [ self nextBuffer ].	
-				out next: limit - position + 1 putAll: buffer startingAt: position.
-				position := limit + 1 ] ].
-		result := result
-						ifNil: [ remaining ]
-						ifNotNil: [ result, remaining ] ].
-	^result
+	^ self atEnd
+		ifTrue: [ result ]
+		ifFalse: [ 
+			remaining := self collectionSpecies streamContents: [ :out | 
+				[ self atEnd ] whileFalse: [ 
+					position > limit
+						ifTrue: [ self nextBuffer ].	
+					out next: limit - position + 1 putAll: buffer startingAt: position.
+					position := limit + 1 ] ].
+			result := result , remaining ]
 ]
 
 { #category : #accessing }

--- a/src/Zinc-Character-Encoding-Tests/ZnBufferedReadStreamTest.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnBufferedReadStreamTest.class.st
@@ -77,7 +77,10 @@ ZnBufferedReadStreamTest >> testReadUpToEnd [
 	stream sizeBuffer: 4.
 	stream next: 2.
 	self assert: stream upToEnd equals: '23456789'.
-	self assert: stream atEnd
+	self assert: stream atEnd.
+	stream := ZnBufferedReadStream on: #[] readStream.
+	self assert: stream upToEnd equals: #[].
+	self assert: stream atEnd.
 ]
 
 { #category : #tests }

--- a/src/Zinc-HTTP-Examples/ZnStaticFileServerDelegate.class.st
+++ b/src/Zinc-HTTP-Examples/ZnStaticFileServerDelegate.class.st
@@ -48,7 +48,7 @@ ZnStaticFileServerDelegate >> actualFilenameFor: uri [
 	| subElements subDir entry |
 	(uri isEmpty and: [ self prefix isEmpty ]) ifTrue: [ ^ self indexFileIn: self directory ].
 	(self prefix isEmpty or: [ uri isEmpty not and: [ uri pathSegments beginsWith: self prefix ] ]) ifFalse: [ ^ nil ].
-	subElements := (uri pathSegments allButFirst: self prefix size) reject: [ :each | each = #/ ].
+	subElements := (uri pathSegments allButFirst: self prefix size) reject: [ :each | each = $/ ].
 	subDir := subElements allButLast inject: self directory into: [ :parent :sub | | file |
 		(file := parent / sub) exists
 			ifTrue: [ file ]
@@ -81,7 +81,7 @@ ZnStaticFileServerDelegate >> directory: fileDirectory [
 { #category : #private }
 ZnStaticFileServerDelegate >> directoryRedirectFor: uri [
 	| directoryUri |
-	directoryUri := uri copy addPathSegment: #/.  
+	directoryUri := uri copy addPathSegment: $/.  
 	^ ZnResponse redirect: directoryUri 
 ]
 

--- a/src/Zinc-HTTP-Examples/ZnStaticFileServerDelegateTest.class.st
+++ b/src/Zinc-HTTP-Examples/ZnStaticFileServerDelegateTest.class.st
@@ -8,6 +8,15 @@ Class {
 }
 
 { #category : #private }
+ZnStaticFileServerDelegateTest >> indexHtml [
+	^ '<html>
+<head><title>Index</title></head>
+<body><h1>Hi, i''m the index page</h1></body>
+</html>
+'
+]
+
+{ #category : #private }
 ZnStaticFileServerDelegateTest >> largeHtml [
 	^ String streamContents: [ :out |
 		out << '<html><body>'.
@@ -31,6 +40,10 @@ ZnStaticFileServerDelegateTest >> setUp [
 		writeStreamFor: 'wide.html' 
 		do: [ :stream |
 			stream nextPutAll: self wideHtml ].
+	ZnFileSystemUtils
+		writeStreamFor: 'index.html' 
+		do: [ :stream |
+			stream nextPutAll: self indexHtml ].
 ]
 
 { #category : #private }
@@ -47,7 +60,8 @@ ZnStaticFileServerDelegateTest >> tearDown [
 	ZnFileSystemUtils 
 		deleteIfExists: 'small.html'; 
 		deleteIfExists: 'large.html'; 
-		deleteIfExists: 'wide.html'.
+		deleteIfExists: 'wide.html';
+		deleteIfExists: 'index.html'.
 	super tearDown	
 	
 ]
@@ -149,6 +163,24 @@ ZnStaticFileServerDelegateTest >> testIfModifiedSinceNotModified [
 			get.
 		self assert: client response isNotModified.
 		self deny: client response hasEntity ]
+]
+
+{ #category : #tests }
+ZnStaticFileServerDelegateTest >> testRedirect [
+	self
+		withServerDo: [ :server | 
+			| client |
+			(client := ZnClient new)
+				beOneShot;
+				url: server localUrl;
+				addPath: #('local-files');
+				get.
+			self assert: client isSuccess.
+			self assert: client response contentType equals: ZnMimeType textHtml.
+			self assert: client contents equals: self indexHtml.
+			self assert: (ZnUtils parseHttpDate: (client response headers at: 'Modification-Date')) equals: (ZnFileSystemUtils modificationTimeFor: 'index.html') asUTC.
+			self assert: (ZnUtils parseHttpDate: (client response headers at: 'Expires')) > (DateAndTime now + 10 days).
+			self assert: (client response headers at: 'Cache-Control') equals: (server delegate maxAgeFor: ZnMimeType textHtml) ]
 ]
 
 { #category : #private }

--- a/src/Zinc-HTTP/ZnClient.class.st
+++ b/src/Zinc-HTTP/ZnClient.class.st
@@ -156,9 +156,11 @@ ZnClient >> certificate: anObject [
 { #category : #private }
 ZnClient >> cleanupConnection [
 	(self isOneShot 
-		or: [ 
-			(request notNil and: [ request wantsConnectionClose ])
-				or: [ response notNil and: [ response wantsConnectionClose ] ] ])
+		or: [
+			self streaming not
+				and: [
+					(request notNil and: [ request wantsConnectionClose ])
+						or: [ response notNil and: [ response wantsConnectionClose ] ] ] ])
 		ifTrue: [
 			self close ]
 ]
@@ -1445,6 +1447,7 @@ ZnClient >> setBearerAuthentication: token [
 	"Set the bearer token for authentication (e.g. OAuth 2.0) for the current request."
 	
 	self request setBearerAuthentication: token
+
 ]
 
 { #category : #'accessing - request' }

--- a/src/Zinc-Resource-Meta-Core/ZnUrl.class.st
+++ b/src/Zinc-Resource-Meta-Core/ZnUrl.class.st
@@ -652,6 +652,7 @@ ZnUrl >> path [
 				each = $/
 					ifFalse: [ stream nextPutAll: each ] ]
 			separatedBy: [ stream nextPut: $/ ] ]
+
 ]
 
 { #category : #printing }
@@ -828,6 +829,7 @@ ZnUrl >> queryAt: key add: value [
 
 	query ifNil: [ query := ZnMultiValueDictionary new ].
 	query at: key asString add: (value ifNotNil: [ value asString ])
+
 ]
 
 { #category : #'accessing - query' }
@@ -856,6 +858,7 @@ ZnUrl >> queryAt: key put: value [
 
 	query ifNil: [ query := ZnMultiValueDictionary new ].
 	query at: key asString put: (value ifNotNil: [ value asString ])
+
 ]
 
 { #category : #'accessing - query' }

--- a/src/Zinc-Tests/ZnClientTest.class.st
+++ b/src/Zinc-Tests/ZnClientTest.class.st
@@ -348,6 +348,27 @@ ZnClientTest >> testGetSmallHTMLUrlConstruction [
 ]
 
 { #category : #testing }
+ZnClientTest >> testGetStreamingConnectionClose [
+	self withServerDo: [ :server | 
+		| client result contents |
+		server onRequestRespond: [ :request |
+			(ZnResponse ok: (ZnEntity textCRLF: 'OK'))
+				setConnectionClose;
+				yourself ].
+		result := (client := ZnClient new)
+			url: server localUrl;
+			streaming: true;
+			get.
+		self assert: client isSuccess.
+		self assert: client response contentType equals: ZnMimeType textPlain.
+		self assert: result isStream.
+		self assert: client entity stream equals: result.
+		contents := result upToEnd utf8Decoded.
+		self assert: (contents includesSubstring: 'OK').
+		client close ]
+]
+
+{ #category : #testing }
 ZnClientTest >> testGetWideStringHTML [
 	| client text |
 	text := '<html><h1>Czech is in Czech {1}e{2}tina.</h1></html>' format: { 269 asCharacter. 353 asCharacter}.


### PR DESCRIPTION
`FTColumnResizerMorph>>updateFromEvent` computes the updated column widths from the resizer event data; at the end of the method, it updates the wrong variables and nothing happens. This fix changes the receiver at the end as we need to update the `column model width`, not the `column width`.