### PR TITLE
Move tasks in taskbar

### DIFF
--- a/src/Kernel-Tests/NumberTest.class.st
+++ b/src/Kernel-Tests/NumberTest.class.st
@@ -20,6 +20,30 @@ NumberTest >> testAsInteger [
 	self assert: (1/2) asInteger equals: 0
 ]
 
+{ #category : #test }
+NumberTest >> testClampReturnsMaxIfNumberIsOverMax [
+
+	self assert: (80 clampBetween: 10 and: 20) equals: 20. 
+
+	
+]
+
+{ #category : #test }
+NumberTest >> testClampReturnsMinIfNumberIsBelowMin [
+
+	self assert: (8 clampBetween: 10 and: 20) equals: 10. 
+
+	
+]
+
+{ #category : #test }
+NumberTest >> testClampReturnsSameNumberIfBetweenMinAndMax [
+
+	self assert: (17 clampBetween: 10 and: 20) equals: 17. 
+
+	
+]
+
 { #category : #tests }
 NumberTest >> testFractionPart [
 	self

--- a/src/Kernel-Tests/NumberTest.class.st
+++ b/src/Kernel-Tests/NumberTest.class.st
@@ -20,7 +20,7 @@ NumberTest >> testAsInteger [
 	self assert: (1/2) asInteger equals: 0
 ]
 
-{ #category : #test }
+{ #category : #tests }
 NumberTest >> testClampReturnsMaxIfNumberIsOverMax [
 
 	self assert: (80 clampBetween: 10 and: 20) equals: 20. 
@@ -28,7 +28,7 @@ NumberTest >> testClampReturnsMaxIfNumberIsOverMax [
 	
 ]
 
-{ #category : #test }
+{ #category : #tests }
 NumberTest >> testClampReturnsMinIfNumberIsBelowMin [
 
 	self assert: (8 clampBetween: 10 and: 20) equals: 10. 
@@ -36,7 +36,7 @@ NumberTest >> testClampReturnsMinIfNumberIsBelowMin [
 	
 ]
 
-{ #category : #test }
+{ #category : #tests }
 NumberTest >> testClampReturnsSameNumberIfBetweenMinAndMax [
 
 	self assert: (17 clampBetween: 10 and: 20) equals: 17. 

--- a/src/Kernel/Number.class.st
+++ b/src/Kernel/Number.class.st
@@ -254,6 +254,15 @@ Number >> ceiling [
                ifFalse: [ truncation + 1 ]
 ]
 
+{ #category : #calculating }
+Number >> clampBetween: min and: max [ 
+	
+	 (self between: min and: max ) ifTrue: [ ^ self  ]
+	ifFalse: [( self < min )  ifTrue: [ ^ min]].
+	^ max
+	
+]
+
 { #category : #converting }
 Number >> copySignTo: aNumber [
 	"Return a number with same magnitude as aNumber and same sign as self."

--- a/src/Morphic-Widgets-Taskbar-Tests/TaskbarMorphTest.class.st
+++ b/src/Morphic-Widgets-Taskbar-Tests/TaskbarMorphTest.class.st
@@ -176,7 +176,7 @@ TaskbarMorphTest >> testMoveTaskbarTaskLeftDoesNothingOnFirstTask [
 
 { #category : #tests }
 TaskbarMorphTest >> testMoveTaskbarTaskLeftMovesItOnePositionToTheLeft [
-	| firstTask secondTask systemWindow taskbarMorph |
+	| firstTask secondTask taskbarMorph |
 	taskbar := self.
 	world := self.
 	taskbar updateTasks.

--- a/src/Morphic-Widgets-Taskbar-Tests/TaskbarMorphTest.class.st
+++ b/src/Morphic-Widgets-Taskbar-Tests/TaskbarMorphTest.class.st
@@ -82,6 +82,71 @@ TaskbarMorphTest >> tasks [
 ]
 
 { #category : #tests }
+TaskbarMorphTest >> testCanBeMoveLeftIfItsNotTheFirstTask [
+	| firstTask secondTask taskbarMorph |
+	taskbar := self.
+	world := self.
+	taskbar updateTasks.
+	taskbarMorph := TaskbarMorph new.
+	firstTask := self addTaskWithWindow.
+	secondTask := self addTaskWithWindow.
+	taskbarMorph orderedTasks: { firstTask. secondTask } asOrderedCollection.
+	
+	
+	self assert: (taskbarMorph canMoveLeft: (secondTask  morph) ).
+]
+
+{ #category : #tests }
+TaskbarMorphTest >> testCanBeMoveRightIfItsNotTheLastTask [
+	| firstTask secondTask taskbarMorph |
+	taskbar := self.
+	world := self.
+	taskbar updateTasks.
+	taskbarMorph := TaskbarMorph new.
+	firstTask := self addTaskWithWindow.
+	secondTask := self addTaskWithWindow.
+	taskbarMorph orderedTasks: { firstTask. secondTask } asOrderedCollection.
+	
+	
+	self assert: (taskbarMorph canMoveRight: (firstTask morph) ).
+]
+
+{ #category : #tests }
+TaskbarMorphTest >> testCantBeMoveLeftIfItsTheFirstTask [
+	| firstTask secondTask taskbarMorph |
+	taskbar := self.
+	world := self.
+	taskbar updateTasks.
+	taskbarMorph := TaskbarMorph new.
+	firstTask := self addTaskWithWindow.
+	secondTask := self addTaskWithWindow.
+	taskbarMorph orderedTasks: { firstTask. secondTask } asOrderedCollection.
+	
+	
+	self assert: (taskbarMorph canMoveLeft: (firstTask   morph) ) equals: false.
+]
+
+{ #category : #tests }
+TaskbarMorphTest >> testCantBeMoveRightIfItsTheLastTask [
+
+	| firstTask secondTask taskbarMorph |
+	taskbar := self.
+	world := self.
+	taskbar updateTasks.
+	taskbarMorph := TaskbarMorph new.
+	firstTask := self addTaskWithWindow.
+	secondTask := self addTaskWithWindow.
+	taskbarMorph orderedTasks: { 
+			firstTask.
+			secondTask } asOrderedCollection.
+
+
+	self
+		assert: (taskbarMorph canMoveRight: secondTask morph)
+		equals: false
+]
+
+{ #category : #tests }
 TaskbarMorphTest >> testEmptyTaskBarList [
 	taskbar := self.
 	world := self.

--- a/src/Morphic-Widgets-Taskbar-Tests/TaskbarMorphTest.class.st
+++ b/src/Morphic-Widgets-Taskbar-Tests/TaskbarMorphTest.class.st
@@ -18,8 +18,6 @@ TaskbarMorphTest >> addTaskWithWindow [
 
 	| newTask morph |
 	morph := SystemWindow new.
-	"morph privateOwner: self.
-	morph world: world."
 	newTask := taskbar newTaskFor: morph.
 	self orderedTasks add: newTask.
 	^ newTask
@@ -82,7 +80,8 @@ TaskbarMorphTest >> tasks [
 ]
 
 { #category : #tests }
-TaskbarMorphTest >> testCanBeMoveLeftIfItsNotTheFirstTask [
+TaskbarMorphTest >> testCanBeMovedLeftIfItsNotTheFirstTask [
+
 	| firstTask secondTask taskbarMorph |
 	taskbar := self.
 	world := self.
@@ -90,14 +89,16 @@ TaskbarMorphTest >> testCanBeMoveLeftIfItsNotTheFirstTask [
 	taskbarMorph := TaskbarMorph new.
 	firstTask := self addTaskWithWindow.
 	secondTask := self addTaskWithWindow.
-	taskbarMorph orderedTasks: { firstTask. secondTask } asOrderedCollection.
-	
-	
-	self assert: (taskbarMorph canMoveLeft: (secondTask  morph) ).
+	taskbarMorph orderedTasks: { 
+			firstTask.
+			secondTask } asOrderedCollection.
+
+	self assert: (taskbarMorph canMoveLeft: secondTask morph)
 ]
 
 { #category : #tests }
-TaskbarMorphTest >> testCanBeMoveRightIfItsNotTheLastTask [
+TaskbarMorphTest >> testCanBeMovedRightIfItsNotTheLastTask [
+
 	| firstTask secondTask taskbarMorph |
 	taskbar := self.
 	world := self.
@@ -105,14 +106,16 @@ TaskbarMorphTest >> testCanBeMoveRightIfItsNotTheLastTask [
 	taskbarMorph := TaskbarMorph new.
 	firstTask := self addTaskWithWindow.
 	secondTask := self addTaskWithWindow.
-	taskbarMorph orderedTasks: { firstTask. secondTask } asOrderedCollection.
-	
-	
-	self assert: (taskbarMorph canMoveRight: (firstTask morph) ).
+	taskbarMorph orderedTasks: { 
+			firstTask.
+			secondTask } asOrderedCollection.
+
+	self assert: (taskbarMorph canMoveRight: firstTask morph)
 ]
 
 { #category : #tests }
-TaskbarMorphTest >> testCantBeMoveLeftIfItsTheFirstTask [
+TaskbarMorphTest >> testCantBeMovedLeftIfItsTheFirstTask [
+
 	| firstTask secondTask taskbarMorph |
 	taskbar := self.
 	world := self.
@@ -120,14 +123,15 @@ TaskbarMorphTest >> testCantBeMoveLeftIfItsTheFirstTask [
 	taskbarMorph := TaskbarMorph new.
 	firstTask := self addTaskWithWindow.
 	secondTask := self addTaskWithWindow.
-	taskbarMorph orderedTasks: { firstTask. secondTask } asOrderedCollection.
-	
-	
-	self assert: (taskbarMorph canMoveLeft: (firstTask   morph) ) equals: false.
+	taskbarMorph orderedTasks: { 
+			firstTask.
+			secondTask } asOrderedCollection.
+
+	self deny: (taskbarMorph canMoveLeft: firstTask morph)
 ]
 
 { #category : #tests }
-TaskbarMorphTest >> testCantBeMoveRightIfItsTheLastTask [
+TaskbarMorphTest >> testCantBeMovedRightIfItsTheLastTask [
 
 	| firstTask secondTask taskbarMorph |
 	taskbar := self.
@@ -142,8 +146,7 @@ TaskbarMorphTest >> testCantBeMoveRightIfItsTheLastTask [
 
 
 	self
-		assert: (taskbarMorph canMoveRight: secondTask morph)
-		equals: false
+		deny: (taskbarMorph canMoveRight: secondTask morph)
 ]
 
 { #category : #tests }

--- a/src/Morphic-Widgets-Taskbar-Tests/TaskbarMorphTest.class.st
+++ b/src/Morphic-Widgets-Taskbar-Tests/TaskbarMorphTest.class.st
@@ -13,6 +13,18 @@ Class {
 	#category : #'Morphic-Widgets-Taskbar-Tests'
 }
 
+{ #category : #'mocking taskbar' }
+TaskbarMorphTest >> addTaskWithWindow [
+
+	| newTask morph |
+	morph := SystemWindow new.
+	"morph privateOwner: self.
+	morph world: world."
+	newTask := taskbar newTaskFor: morph.
+	self orderedTasks add: newTask.
+	^ newTask
+]
+
 { #category : #'mocking world' }
 TaskbarMorphTest >> addWindow [
 	^world addWindowToWorld
@@ -81,6 +93,21 @@ TaskbarMorphTest >> testEmptyTaskBarList [
 TaskbarMorphTest >> testIfTheTestedMethodIstheSameThatTheOneUsedInProd [
 
 	self assert: self theMethodInProdThatShouldBeTested bytecode equals: (self class >> #updateOrderedTasksFrom:) bytecode
+]
+
+{ #category : #tests }
+TaskbarMorphTest >> testMoveTaskbarTaskLeftMovesItOnePositionToTheLeft [
+	| firstTask secondTask systemWindow taskbarMorph |
+	taskbar := self.
+	world := self.
+	taskbar updateTasks.
+	taskbarMorph := TaskbarMorph new.
+	firstTask := self addTaskWithWindow.
+	secondTask := self addTaskWithWindow.
+	taskbarMorph orderedTasks: { firstTask. secondTask } asOrderedCollection.
+	taskbarMorph move: secondTask withOffset: -1.
+	
+	self assert: secondTask equals: taskbarMorph orderedTasks first.
 ]
 
 { #category : #tests }

--- a/src/Morphic-Widgets-Taskbar-Tests/TaskbarMorphTest.class.st
+++ b/src/Morphic-Widgets-Taskbar-Tests/TaskbarMorphTest.class.st
@@ -96,6 +96,20 @@ TaskbarMorphTest >> testIfTheTestedMethodIstheSameThatTheOneUsedInProd [
 ]
 
 { #category : #tests }
+TaskbarMorphTest >> testMoveTaskbarTaskLeftDoesNothingOnFirstTask [
+	| firstTask taskbarMorph |
+	taskbar := self.
+	world := self.
+	taskbar updateTasks.
+	taskbarMorph := TaskbarMorph new.
+	firstTask := self addTaskWithWindow.
+	taskbarMorph orderedTasks: { firstTask } asOrderedCollection.
+	taskbarMorph move: firstTask withOffset: -1.
+	
+	self assert: firstTask equals: taskbarMorph orderedTasks first.
+]
+
+{ #category : #tests }
 TaskbarMorphTest >> testMoveTaskbarTaskLeftMovesItOnePositionToTheLeft [
 	| firstTask secondTask systemWindow taskbarMorph |
 	taskbar := self.
@@ -108,6 +122,35 @@ TaskbarMorphTest >> testMoveTaskbarTaskLeftMovesItOnePositionToTheLeft [
 	taskbarMorph move: secondTask withOffset: -1.
 	
 	self assert: secondTask equals: taskbarMorph orderedTasks first.
+]
+
+{ #category : #tests }
+TaskbarMorphTest >> testMoveTaskbarTaskRightDoesNothingOnLastTask [
+	| firstTask taskbarMorph |
+	taskbar := self.
+	world := self.
+	taskbar updateTasks.
+	taskbarMorph := TaskbarMorph new.
+	firstTask := self addTaskWithWindow.
+	taskbarMorph orderedTasks: { firstTask } asOrderedCollection.
+	taskbarMorph move: firstTask withOffset: 1.
+	
+	self assert: firstTask equals: taskbarMorph orderedTasks first.
+]
+
+{ #category : #tests }
+TaskbarMorphTest >> testMoveTaskbarTaskRightMovesItOnePositionToTheRight [
+	| firstTask secondTask taskbarMorph |
+	taskbar := self.
+	world := self.
+	taskbar updateTasks.
+	taskbarMorph := TaskbarMorph new.
+	firstTask := self addTaskWithWindow.
+	secondTask := self addTaskWithWindow.
+	taskbarMorph orderedTasks: { firstTask. secondTask } asOrderedCollection.
+	taskbarMorph move: firstTask withOffset: 1.
+	
+	self assert: firstTask equals: taskbarMorph orderedTasks last.
 ]
 
 { #category : #tests }

--- a/src/Morphic-Widgets-Taskbar/SystemWindow.extension.st
+++ b/src/Morphic-Widgets-Taskbar/SystemWindow.extension.st
@@ -8,6 +8,21 @@ SystemWindow >> basicTaskThumbnailOfSize: thumbExtent [
 ]
 
 { #category : #'*Morphic-Widgets-Taskbar' }
+SystemWindow >> canBeMovedToLeft [
+	
+	
+	self worldTaskbar ifNil: [ ^ false ].
+	^ ((self worldTaskbar orderedTasks first morph) ~= self).
+]
+
+{ #category : #'*Morphic-Widgets-Taskbar' }
+SystemWindow >> canBeMovedToRight [
+
+	self worldTaskbar ifNil: [ ^ false ].
+	^ ((self worldTaskbar orderedTasks last morph) ~= self).
+]
+
+{ #category : #'*Morphic-Widgets-Taskbar' }
 SystemWindow >> isTaskbarPresent [
 	"Answer whether there is a taskbar in the world."
 
@@ -156,13 +171,13 @@ SystemWindow >> taskbarButtonMenu: aMenu [
 		target: self
 		selector: #taskbarMoveLeft
 		getStateSelector: nil
-		enablementSelector: true.
+		enablementSelector: #canBeMovedToLeft.
 	moveSubmenu
 		addToggle: 'Move right' translated
 		target: self
 		selector: #taskbarMoveRight
 		getStateSelector: nil
-		enablementSelector: true.
+		enablementSelector: #canBeMovedToRight.
 	menu addLine.
 	
 	submenu := theme newMenuIn: self for: self.

--- a/src/Morphic-Widgets-Taskbar/SystemWindow.extension.st
+++ b/src/Morphic-Widgets-Taskbar/SystemWindow.extension.st
@@ -70,7 +70,7 @@ SystemWindow >> taskThumbnailOfSize: thumbExtent [
 ]
 
 { #category : #'*Morphic-Widgets-Taskbar' }
-SystemWindow >> taskbarButtonClicked [ "TODO add protocol"
+SystemWindow >> taskbarButtonClicked [
 	"The taskbar button for the receiver has been clicked.
 	If minimised then restore.
 	If active then minimize.

--- a/src/Morphic-Widgets-Taskbar/SystemWindow.extension.st
+++ b/src/Morphic-Widgets-Taskbar/SystemWindow.extension.st
@@ -164,7 +164,7 @@ SystemWindow >> taskbarButtonMenu: aMenu [
 	moveSubmenu := theme newMenuIn: self for: self.
 	menu
 		add: 'Move'
-		icon: self theme windowCloseForm "TODO add icon"
+		icon: (self iconNamed: #blank)
 		subMenu: moveSubmenu.
 	moveSubmenu
 		addToggle: 'Move left' translated

--- a/src/Morphic-Widgets-Taskbar/SystemWindow.extension.st
+++ b/src/Morphic-Widgets-Taskbar/SystemWindow.extension.st
@@ -12,14 +12,14 @@ SystemWindow >> canBeMovedToLeft [
 	
 	
 	self worldTaskbar ifNil: [ ^ false ].
-	^ ((self worldTaskbar orderedTasks first morph) ~= self).
+	^ self worldTaskbar canMoveLeft: self.
 ]
 
 { #category : #'*Morphic-Widgets-Taskbar' }
 SystemWindow >> canBeMovedToRight [
 
 	self worldTaskbar ifNil: [ ^ false ].
-	^ ((self worldTaskbar orderedTasks last morph) ~= self).
+	^ self worldTaskbar canMoveRight: self.
 ]
 
 { #category : #'*Morphic-Widgets-Taskbar' }

--- a/src/Morphic-Widgets-Taskbar/SystemWindow.extension.st
+++ b/src/Morphic-Widgets-Taskbar/SystemWindow.extension.st
@@ -157,7 +157,12 @@ SystemWindow >> taskbarButtonMenu: aMenu [
 		selector: #taskbarMoveLeft
 		getStateSelector: nil
 		enablementSelector: true.
-
+	moveSubmenu
+		addToggle: 'Move right' translated
+		target: self
+		selector: #taskbarMoveRight
+		getStateSelector: nil
+		enablementSelector: true.
 	menu addLine.
 	
 	submenu := theme newMenuIn: self for: self.

--- a/src/Morphic-Widgets-Taskbar/SystemWindow.extension.st
+++ b/src/Morphic-Widgets-Taskbar/SystemWindow.extension.st
@@ -261,15 +261,16 @@ SystemWindow >> taskbarState [
 
 { #category : #'*Morphic-Widgets-Taskbar' }
 SystemWindow >> taskbarTask [
-	"Answer a new taskbar task for the receiver.
+	"Answer a taskbar task for the receiver.
 	Answer nil if not required."
 
 	(self valueOfProperty: #noTaskbarTask ifAbsent: [false]) ifTrue: [^nil].
-	^TaskbarTask
+	taskbarTask := TaskbarTask
 		morph: self
 		state: self taskbarState
 		icon: self taskbarIcon
-		label: self taskbarLabel
+		label: self taskbarLabel.
+	^taskbarTask.
 ]
 
 { #category : #'*Morphic-Widgets-Taskbar' }

--- a/src/Morphic-Widgets-Taskbar/SystemWindow.extension.st
+++ b/src/Morphic-Widgets-Taskbar/SystemWindow.extension.st
@@ -55,7 +55,7 @@ SystemWindow >> taskThumbnailOfSize: thumbExtent [
 ]
 
 { #category : #'*Morphic-Widgets-Taskbar' }
-SystemWindow >> taskbarButtonClicked [
+SystemWindow >> taskbarButtonClicked [ "TODO add protocol"
 	"The taskbar button for the receiver has been clicked.
 	If minimised then restore.
 	If active then minimize.
@@ -110,7 +110,7 @@ SystemWindow >> taskbarButtonLeft: aButton event: evt in: aMorph [
 SystemWindow >> taskbarButtonMenu: aMenu [
 	"Answer the menu for the task bar button."
 
-	| menu theme submenu  |
+	| menu theme submenu  moveSubmenu |
 	theme :=  self theme.	
 	menu := theme newMenuIn: self for: self.
 	
@@ -146,6 +146,20 @@ SystemWindow >> taskbarButtonMenu: aMenu [
 		
 	menu addLine.
 
+	moveSubmenu := theme newMenuIn: self for: self.
+	menu
+		add: 'Move'
+		icon: self theme windowCloseForm "TODO add icon"
+		subMenu: moveSubmenu.
+	moveSubmenu
+		addToggle: 'Move left' translated
+		target: self
+		selector: #taskbarMoveLeft
+		getStateSelector: nil
+		enablementSelector: true.
+
+	menu addLine.
+	
 	submenu := theme newMenuIn: self for: self.
 	menu
 		add: 'Close all'

--- a/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
+++ b/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
@@ -249,6 +249,21 @@ TaskbarMorph >> morphicLayerNumber [
 	^11
 ]
 
+{ #category : #initialization }
+TaskbarMorph >> move: task withOffset: offset [
+
+	| selectedTask currentTaskIndex newOrderedTasks newTaskIndex currentOrderedTasks |
+	currentOrderedTasks := self orderedTasks.
+	selectedTask := task.
+	currentTaskIndex := currentOrderedTasks indexOf: selectedTask.
+	newOrderedTasks := currentOrderedTasks copy.
+	newOrderedTasks removeAt: currentTaskIndex.
+	newTaskIndex := currentTaskIndex + offset.
+	newOrderedTasks add: selectedTask beforeIndex: newTaskIndex.
+	self orderedTasks: newOrderedTasks.
+	^ self updateTaskButtons "TODO is this the right way to update the toolbar?"
+]
+
 { #category : #accessing }
 TaskbarMorph >> orderedTasks [
 	"Answer the value of orderedTasks"

--- a/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
+++ b/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
@@ -265,7 +265,7 @@ TaskbarMorph >> morphicLayerNumber [
 TaskbarMorph >> move: task withOffset: offset [
 
 	| currentTaskIndex newOrderedTasks newTaskIndex currentOrderedTasks |
-	self updateTasks . " update tasks because if a new window is not added actually on the task bar the shortcut won't work"
+	"self updateTasks . update tasks because if a new window is not added actually on the task bar the shortcut won't work"
 	currentOrderedTasks := self orderedTasks.
 	currentTaskIndex := currentOrderedTasks indexOf: task .
 	(currentTaskIndex = 0 ) ifTrue: [ ^ nil ].

--- a/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
+++ b/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
@@ -261,11 +261,10 @@ TaskbarMorph >> morphicLayerNumber [
 	^11
 ]
 
-{ #category : #initialization }
+{ #category : #taskbar }
 TaskbarMorph >> move: task withOffset: offset [
 
 	| currentTaskIndex newOrderedTasks newTaskIndex currentOrderedTasks |
-	"self updateTasks . update tasks because if a new window is not added actually on the task bar the shortcut won't work"
 	currentOrderedTasks := self orderedTasks.
 	currentTaskIndex := currentOrderedTasks indexOf: task .
 	(currentTaskIndex = 0 ) ifTrue: [ ^ nil ].
@@ -274,7 +273,7 @@ TaskbarMorph >> move: task withOffset: offset [
 	newTaskIndex := ((currentTaskIndex + offset) clampBetween: 1 and: (self orderedTasks size)) .
 	newOrderedTasks add: task beforeIndex: newTaskIndex.
 	self orderedTasks: newOrderedTasks.
-	^ self updateTaskButtons "TODO is this the right way to update the toolbar?"
+	^ self updateTaskButtons
 ]
 
 { #category : #accessing }

--- a/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
+++ b/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
@@ -258,7 +258,7 @@ TaskbarMorph >> move: task withOffset: offset [
 	currentTaskIndex := currentOrderedTasks indexOf: selectedTask.
 	newOrderedTasks := currentOrderedTasks copy.
 	newOrderedTasks removeAt: currentTaskIndex.
-	newTaskIndex := currentTaskIndex + offset.
+	newTaskIndex := ((currentTaskIndex + offset) clampBetween: 1 and: (self orderedTasks size)) .
 	newOrderedTasks add: selectedTask beforeIndex: newTaskIndex.
 	self orderedTasks: newOrderedTasks.
 	^ self updateTaskButtons "TODO is this the right way to update the toolbar?"

--- a/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
+++ b/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
@@ -112,6 +112,18 @@ TaskbarMorph >> buttonForMorph: aMorph [
 	^index = 0 ifTrue: [nil] ifFalse: [self submorphs at: index ifAbsent: []]
 ]
 
+{ #category : #taskbar }
+TaskbarMorph >> canMoveLeft: task [
+
+ ^ ((self orderedTasks first morph) ~= task).
+]
+
+{ #category : #taskbar }
+TaskbarMorph >> canMoveRight: task [
+
+ ^ ((self orderedTasks last morph) ~= task).
+]
+
 { #category : #drawing }
 TaskbarMorph >> clipSubmorphs [ 
 

--- a/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
+++ b/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
@@ -264,14 +264,15 @@ TaskbarMorph >> morphicLayerNumber [
 { #category : #initialization }
 TaskbarMorph >> move: task withOffset: offset [
 
-	| selectedTask currentTaskIndex newOrderedTasks newTaskIndex currentOrderedTasks |
+	| currentTaskIndex newOrderedTasks newTaskIndex currentOrderedTasks |
+	self updateTasks . " update tasks because if a new window is not added actually on the task bar the shortcut won't work"
 	currentOrderedTasks := self orderedTasks.
-	selectedTask := task.
-	currentTaskIndex := currentOrderedTasks indexOf: selectedTask.
+	currentTaskIndex := currentOrderedTasks indexOf: task .
+	(currentTaskIndex = 0 ) ifTrue: [ ^ nil ].
 	newOrderedTasks := currentOrderedTasks copy.
 	newOrderedTasks removeAt: currentTaskIndex.
 	newTaskIndex := ((currentTaskIndex + offset) clampBetween: 1 and: (self orderedTasks size)) .
-	newOrderedTasks add: selectedTask beforeIndex: newTaskIndex.
+	newOrderedTasks add: task beforeIndex: newTaskIndex.
 	self orderedTasks: newOrderedTasks.
 	^ self updateTaskButtons "TODO is this the right way to update the toolbar?"
 ]

--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -1870,9 +1870,14 @@ SystemWindow >> taskbarIcon [
 { #category : #move }
 SystemWindow >> taskbarMoveLeft [
 
-	| offset |
-	offset := -1.
-	self moveTaskbarTaskToOffset: offset "TODO handle first element?"
+	self moveTaskbarTaskToOffset: -1 
+]
+
+{ #category : #move }
+SystemWindow >> taskbarMoveRight [
+	
+
+	self moveTaskbarTaskToOffset: 1.
 ]
 
 { #category : #'open/close' }

--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -1860,6 +1860,16 @@ SystemWindow >> taskbarIcon [
 	^super taskbarIcon
 ]
 
+{ #category : #'as yet unclassified' }
+SystemWindow >> taskbarMoveLeft [ "TODO add to protocol"
+	| selectedTask |
+	self worldTaskbar ifNotNil: [ :worldTaskbar |
+		selectedTask := (worldTaskbar orderedTasks select: [:task | task morph = self]) first.
+		1halt.
+		worldTaskbar orderedTasks: (worldTaskbar orderedTasks indexOf: selectedTask)
+	].
+]
+
 { #category : #'open/close' }
 SystemWindow >> toggleClosable [
 	"Reinstate the close box. Go via theme to maintain box order."

--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -1173,7 +1173,9 @@ SystemWindow >> initialize [
 	
 	self extent: (300 @ 200) scaledByDisplayScaleFactor.
 	mustNotClose := false.
-	updatablePanes := Array new
+	updatablePanes := Array new.
+	self bindKeyCombination: (Character arrowLeft meta shift alt ) toAction: [self taskbarMoveLeft ].
+	self bindKeyCombination: (Character arrowRight meta shift alt) toAction: [self taskbarMoveRight ].
 ]
 
 { #category : #keymapping }

--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -1453,7 +1453,7 @@ SystemWindow >> mouseUp: evt [
 { #category : #move }
 SystemWindow >> moveTaskbarTaskToOffset: offset [
 
-	self worldTaskbar ifNotNil: [ :worldTaskbar | worldTaskbar move: self taskbarTask withOffset: offset ]
+	self worldTaskbar ifNotNil: [ :worldTaskbar | worldTaskbar updateTasks; move: self taskbarTask withOffset: offset ]
 ]
 
 { #category : #'open/close' }

--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -1861,13 +1861,23 @@ SystemWindow >> taskbarIcon [
 ]
 
 { #category : #'as yet unclassified' }
-SystemWindow >> taskbarMoveLeft [ "TODO add to protocol"
-	| selectedTask |
-	self worldTaskbar ifNotNil: [ :worldTaskbar |
-		selectedTask := (worldTaskbar orderedTasks select: [:task | task morph = self]) first.
-		1halt.
-		worldTaskbar orderedTasks: (worldTaskbar orderedTasks indexOf: selectedTask)
-	].
+SystemWindow >> taskbarMoveLeft [
+
+	"TODO add to protocol"
+
+	| selectedTask taskIndex newOrderedTasks |
+	self worldTaskbar ifNotNil: [ :worldTaskbar | 
+		| currentOrderedTasks |
+		currentOrderedTasks := worldTaskbar orderedTasks.
+		selectedTask := currentOrderedTasks detect: [ :task | 
+			                 task morph = self ].
+		taskIndex := currentOrderedTasks indexOf: selectedTask.
+		newOrderedTasks := currentOrderedTasks copy.
+		newOrderedTasks removeAt: taskIndex.
+		newOrderedTasks add: selectedTask beforeIndex: taskIndex - 1. "TODO handle first element?"
+		worldTaskbar orderedTasks: newOrderedTasks.
+		worldTaskbar updateTaskButtons."TODO is this the right way to update the toolbar?"
+		 ]
 ]
 
 { #category : #'open/close' }

--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -23,7 +23,8 @@ Class {
 		'labelArea',
 		'expandBox',
 		'embeddable',
-		'isResizeable'
+		'isResizeable',
+		'taskbarTask'
 	],
 	#classVars : [
 		'CloseBoxImage',
@@ -1447,6 +1448,12 @@ SystemWindow >> mouseUp: evt [
 	submorphs do: [:m | (m containsPoint: cp) ifTrue: [m mouseUp: evt]]
 ]
 
+{ #category : #move }
+SystemWindow >> moveTaskbarTaskToOffset: offset [
+
+	self worldTaskbar ifNotNil: [ :worldTaskbar | worldTaskbar move: self taskbarTask withOffset: offset ]
+]
+
 { #category : #'open/close' }
 SystemWindow >> mustNotClose [
 	^ mustNotClose == true
@@ -1860,24 +1867,12 @@ SystemWindow >> taskbarIcon [
 	^super taskbarIcon
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #move }
 SystemWindow >> taskbarMoveLeft [
 
-	"TODO add to protocol"
-
-	| selectedTask taskIndex newOrderedTasks |
-	self worldTaskbar ifNotNil: [ :worldTaskbar | 
-		| currentOrderedTasks |
-		currentOrderedTasks := worldTaskbar orderedTasks.
-		selectedTask := currentOrderedTasks detect: [ :task | 
-			                 task morph = self ].
-		taskIndex := currentOrderedTasks indexOf: selectedTask.
-		newOrderedTasks := currentOrderedTasks copy.
-		newOrderedTasks removeAt: taskIndex.
-		newOrderedTasks add: selectedTask beforeIndex: taskIndex - 1. "TODO handle first element?"
-		worldTaskbar orderedTasks: newOrderedTasks.
-		worldTaskbar updateTaskButtons."TODO is this the right way to update the toolbar?"
-		 ]
+	| offset |
+	offset := -1.
+	self moveTaskbarTaskToOffset: offset "TODO handle first element?"
 ]
 
 { #category : #'open/close' }


### PR DESCRIPTION
# add the possibility to move the tasks in the taskbar

With @nrainhart implement the possibility to move a task on the task bar, we add a shortcut : ` CTRL + SHIFT + ALT + ArrowLef | ArrowRight  ` 

![image](https://user-images.githubusercontent.com/92677219/169767986-c79c25d7-fb62-4bb2-a27e-7d784d39fd19.png)


![image](https://user-images.githubusercontent.com/92677219/169768233-a23b33e0-2b4c-419e-ac81-8f4c4e7b0ffa.png)


