### PR TITLE
Cleanup: align #isTransparent and other #isXXX methods

### DIFF
--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -472,7 +472,7 @@ Symbol >> isKeyword [
 	^ self precedence = 3
 ]
 
-{ #category : #printing }
+{ #category : #testing }
 Symbol >> isOrientedFill [
 	"Needs to be implemented here because symbols can occupy 'color' slots of morphs."
 

--- a/src/Colors/Color.class.st
+++ b/src/Colors/Color.class.st
@@ -1588,42 +1588,47 @@ Color >> initializeRed: r green: g blue: b range: range [
 	self setAlpha: 1.0.
 ]
 
-{ #category : #queries }
+{ #category : #testing }
 Color >> isBitmapFill [
-	^false
+
+	^ false
 ]
 
-{ #category : #queries }
+{ #category : #testing }
 Color >> isBlack [
 	"Return true if the receiver represents black"
-	^rgb = 0
+	
+	^ rgb = 0
 ]
 
-{ #category : #queries }
+{ #category : #testing }
 Color >> isColor [
 
 	^ true
 ]
 
-{ #category : #queries }
+{ #category : #testing }
 Color >> isGradientFill [
-	^false
+
+	^ false
 ]
 
-{ #category : #queries }
+{ #category : #testing }
 Color >> isGray [
 	"Return true if the receiver represents a shade of gray"
+	
 	^(self privateRed = self privateGreen) and: [self privateRed = self privateBlue]
 ]
 
-{ #category : #queries }
+{ #category : #testing }
 Color >> isOpaque [
 	^ alpha = 255
 ]
 
-{ #category : #queries }
+{ #category : #testing }
 Color >> isOrientedFill [
 	"Return true if the receiver keeps an orientation (e.g., origin, direction, and normal)"
+	
 	^false
 ]
 
@@ -1632,25 +1637,25 @@ Color >> isSelfEvaluating [
 	^ true
 ]
 
-{ #category : #queries }
+{ #category : #testing }
 Color >> isSolidFill [
 	^true
 ]
 
-{ #category : #queries }
+{ #category : #testing }
 Color >> isTranslucent [
 
 	^ alpha < 255
 ]
 
-{ #category : #queries }
+{ #category : #testing }
 Color >> isTranslucentButNotTransparent [
 	"Answer true if this any of this morph is translucent but not transparent."
 	
 	^ self isTranslucent and: [ self isTransparent not ]
 ]
 
-{ #category : #queries }
+{ #category : #testing }
 Color >> isTransparent [
 
 	^ alpha = 0

--- a/src/Graphics-Canvas/BitmapFillStyle.class.st
+++ b/src/Graphics-Canvas/BitmapFillStyle.class.st
@@ -65,7 +65,8 @@ BitmapFillStyle >> form: aForm [
 
 { #category : #testing }
 BitmapFillStyle >> isBitmapFill [
-	^true
+
+	^ true
 ]
 
 { #category : #testing }

--- a/src/Graphics-Canvas/CompositeFillStyle.class.st
+++ b/src/Graphics-Canvas/CompositeFillStyle.class.st
@@ -99,9 +99,9 @@ CompositeFillStyle >> isCompositeFill [
 CompositeFillStyle >> isGradientFill [
 	"Answer whether any of the composited fill styles are gradients."
 
-	self fillStyles reverseDo: [:fs |
-		fs isGradientFill ifTrue: [^true]].
-	^false
+	self fillStyles reverseDo: [ :fs | 
+		fs isGradientFill ifTrue: [ ^ true ] ].
+	^ false
 ]
 
 { #category : #testing }
@@ -117,14 +117,14 @@ CompositeFillStyle >> isOrientedFill [
 CompositeFillStyle >> isTranslucent [
 	"Answer whether all of the composited fill styles are transparent."
 
-	^self fillStyles allSatisfy: [:fs | fs isTranslucent]
+	^ self fillStyles allSatisfy: [ :fs | fs isTranslucent ]
 ]
 
 { #category : #testing }
 CompositeFillStyle >> isTransparent [
 	"Answer whether all of the composited fill styles are transparent."
 
-	^self fillStyles allSatisfy: [:fs | fs isTransparent]
+	^ self fillStyles allSatisfy: [ :fs | fs isTransparent ]
 ]
 
 { #category : #accessing }

--- a/src/Graphics-Canvas/FillStyle.class.st
+++ b/src/Graphics-Canvas/FillStyle.class.st
@@ -21,7 +21,8 @@ FillStyle >> fillRectangle: aRectangle on: aCanvas [
 
 { #category : #testing }
 FillStyle >> isBitmapFill [
-	^false
+
+	^ false
 ]
 
 { #category : #testing }
@@ -34,12 +35,14 @@ FillStyle >> isCompositeFill [
 
 { #category : #testing }
 FillStyle >> isGradientFill [
-	^false
+
+	^ false
 ]
 
 { #category : #testing }
 FillStyle >> isOrientedFill [
 	"Return true if the receiver keeps an orientation (e.g., origin, direction, and normal)"
+	
 	^false
 ]
 
@@ -50,11 +53,13 @@ FillStyle >> isSolidFill [
 
 { #category : #testing }
 FillStyle >> isTranslucent [
-	^true "Since we don't know better"
+
+	^ true "Since we don't know better"
 ]
 
 { #category : #testing }
 FillStyle >> isTransparent [
+
 	^false
 ]
 

--- a/src/Graphics-Canvas/GradientFillStyle.class.st
+++ b/src/Graphics-Canvas/GradientFillStyle.class.st
@@ -158,7 +158,8 @@ GradientFillStyle >> hash [
 
 { #category : #testing }
 GradientFillStyle >> isGradientFill [
-	^true
+
+	^ true
 ]
 
 { #category : #testing }
@@ -168,7 +169,8 @@ GradientFillStyle >> isRadialFill [
 
 { #category : #testing }
 GradientFillStyle >> isTranslucent [
-	^isTranslucent ifNil:[isTranslucent := self checkTranslucency]
+
+	^ isTranslucent ifNil: [ isTranslucent := self checkTranslucency ]
 ]
 
 { #category : #converting }

--- a/src/Graphics-Canvas/OrientedFillStyle.class.st
+++ b/src/Graphics-Canvas/OrientedFillStyle.class.st
@@ -50,7 +50,8 @@ OrientedFillStyle >> hash [
 { #category : #testing }
 OrientedFillStyle >> isOrientedFill [
 	"Return true if the receiver keeps an orientation (e.g., origin, direction, and normal)"
-	^true
+	
+	^ true
 ]
 
 { #category : #accessing }

--- a/src/Graphics-Canvas/SolidFillStyle.class.st
+++ b/src/Graphics-Canvas/SolidFillStyle.class.st
@@ -51,12 +51,14 @@ SolidFillStyle >> isSolidFill [
 
 { #category : #testing }
 SolidFillStyle >> isTranslucent [
-	^color isTranslucent
+
+	^ color isTranslucent
 ]
 
 { #category : #testing }
 SolidFillStyle >> isTransparent [
-	^color isTransparent
+
+	^ color isTransparent
 ]
 
 { #category : #printing }

--- a/src/Graphics-Display Objects/ColorForm.class.st
+++ b/src/Graphics-Display Objects/ColorForm.class.st
@@ -284,7 +284,8 @@ ColorForm >> isColorForm [
 { #category : #testing }
 ColorForm >> isTranslucent [
 	"Answer whether this form may be translucent"
-	^true
+	
+	^ true
 ]
 
 { #category : #'pixel accessing' }

--- a/src/Graphics-Display Objects/DisplayObject.class.st
+++ b/src/Graphics-Display Objects/DisplayObject.class.st
@@ -198,8 +198,9 @@ DisplayObject >> initialExtent [
 	^ self extent + (4@4)
 ]
 
-{ #category : #'displaying - display' }
+{ #category : #testing }
 DisplayObject >> isTransparent [
+
 	^ false
 ]
 

--- a/src/Graphics-Display Objects/InfiniteForm.class.st
+++ b/src/Graphics-Display Objects/InfiniteForm.class.st
@@ -157,36 +157,42 @@ InfiniteForm >> form: aForm [
 	patternForm := aForm
 ]
 
-{ #category : #'fillstyle protocol' }
+{ #category : #testing }
 InfiniteForm >> isBitmapFill [
-	^true
+
+	^ true
 ]
 
-{ #category : #'fillstyle protocol' }
+{ #category : #testing }
 InfiniteForm >> isGradientFill [
-	^false
+
+	^ false
 ]
 
-{ #category : #'fillstyle protocol' }
+{ #category : #testing }
 InfiniteForm >> isOrientedFill [
-	^true
+
+	^ true
 ]
 
-{ #category : #'fillstyle protocol' }
+{ #category : #testing }
 InfiniteForm >> isSolidFill [
-	^false
+
+	^ false
 ]
 
-{ #category : #'fillstyle protocol' }
+{ #category : #testing }
 InfiniteForm >> isTiled [
 	"Return true if the receiver should be drawn as a tiled pattern"
-	^true
+	
+	^ true
 ]
 
-{ #category : #'fillstyle protocol' }
+{ #category : #testing }
 InfiniteForm >> isTranslucent [
 	"Return true since the bitmap may be translucent and we don't really want to check"
-	^true
+	
+	^ true
 ]
 
 { #category : #testing }

--- a/src/Morphic-Base/StringMorph.class.st
+++ b/src/Morphic-Base/StringMorph.class.st
@@ -418,9 +418,10 @@ StringMorph >> isEditable: evt [
 	^(self isEditable and: [evt shiftPressed])
 ]
 
-{ #category : #accessing }
+{ #category : #testing }
 StringMorph >> isTranslucentButNotTransparent [
 	"Answer true if this any of this morph is translucent but not transparent."
+	
 	^ true
 ]
 

--- a/src/Morphic-Base/TextMorph.class.st
+++ b/src/Morphic-Base/TextMorph.class.st
@@ -989,9 +989,10 @@ TextMorph >> installEditorToReplace: priorEditor [
 	^ editor
 ]
 
-{ #category : #accessing }
+{ #category : #testing }
 TextMorph >> isAutoFit [
-	^ self valueOfProperty: #autoFitContents ifAbsent: [true]
+
+	^ self valueOfProperty: #autoFitContents ifAbsent: [ true ]
 ]
 
 { #category : #'linked frames' }
@@ -1006,22 +1007,22 @@ TextMorph >> isTextMorph [
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : #testing }
 TextMorph >> isTranslucentButNotTransparent [
 	"Overridden from BorderedMorph to test backgroundColor instead of (text) color."
 
 	backgroundColor ifNil: [ ^ true ].
-	(backgroundColor isColor and: [ backgroundColor isTranslucentButNotTransparent ])
-		ifTrue: [ ^ true ].
-	(borderColor isColor and: [ borderColor isTranslucentButNotTransparent ])
-		ifTrue: [ ^ true ].
+	(backgroundColor isColor and: [ 
+		 backgroundColor isTranslucentButNotTransparent ]) ifTrue: [ ^ true ].
+	(borderColor isColor and: [ 
+		 borderColor isTranslucentButNotTransparent ]) ifTrue: [ ^ true ].
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : #testing }
 TextMorph >> isWrapped [
 	
-	^wrapFlag
+	^ wrapFlag
 ]
 
 { #category : #'editing helpers' }

--- a/src/Morphic-Core/BorderedMorph.class.st
+++ b/src/Morphic-Core/BorderedMorph.class.st
@@ -211,8 +211,10 @@ BorderedMorph >> initializeBorder [
 BorderedMorph >> isTranslucentButNotTransparent [
 	"Answer true if this any of this morph is translucent but not transparent."
 
-	(color isColor and: [color isTranslucentButNotTransparent]) ifTrue: [^ true].
-	(borderColor isColor and: [borderColor isTranslucentButNotTransparent]) ifTrue: [^ true].
+	(color isColor and: [ color isTranslucentButNotTransparent ]) 
+		ifTrue: [ ^ true ].
+	(borderColor isColor and: [ 
+		 borderColor isTranslucentButNotTransparent ]) ifTrue: [ ^ true ].
 	^ false
 ]
 

--- a/src/Morphic-Widgets-Scrolling/ScrollPane.class.st
+++ b/src/Morphic-Widgets-Scrolling/ScrollPane.class.st
@@ -543,7 +543,8 @@ ScrollPane >> innerBounds [
 
 { #category : #testing }
 ScrollPane >> isAutoFit [
-	^false
+
+	^ false
 ]
 
 { #category : #'geometry testing' }


### PR DESCRIPTION
Fix #11279