### PR TITLE
Symbol-simpler-findInternedSelector 

### DIFF
--- a/src/Collections-Strings-Tests/SymbolTest.class.st
+++ b/src/Collections-Strings-Tests/SymbolTest.class.st
@@ -355,6 +355,13 @@ SymbolTest >> testEndsWithAColon [
 	self deny: #fred endsWithAColon.
 ]
 
+{ #category : #'tests - selectors' }
+SymbolTest >> testFindInternedSelector [
+	self assert:( Symbol findInternedSelector: 'no selector exist with spaces') equals: nil.
+	self assert:( Symbol findInternedSelector: 'assert:equals:') equals: #assert:equals:.
+	self assert:( Symbol findInternedSelector: 'do:') equals: #do:
+]
+
 { #category : #tests }
 SymbolTest >> testIsLiteralSymbol [
 

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -92,8 +92,8 @@ Symbol class >> findInternedSelector: aString [
 	"return a selector if the argument is used as a selector, nil if not"
 
 	^ (self lookup: aString) ifNotNil: [ :symbol | 
-		 ( self selectorTable like: symbol)
-			  ifNotNil: [ :selectorSymbol | selectorSymbol | selectorSymbol ] ]
+		  (self selectorTable like: symbol) ifNotNil: [ :selectorSymbol | 
+			  selectorSymbol ] ]
 ]
 
 { #category : #private }

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -83,19 +83,17 @@ Symbol class >> compactSymbolTable [
 { #category : #'instance creation' }
 Symbol class >> findInterned: aString [
 
-	self hasInterned:aString ifTrue:[:symbol| ^symbol].
-	^nil.
+	^ self lookup: aString
+
 ]
 
 { #category : #'instance creation' }
 Symbol class >> findInternedSelector: aString [
-	| symbol |
-	symbol := self findInterned: aString.
-	"if it isn't found or not a SelectorSymbol - return nil"
-	(symbol isNil or: [ symbol isSelectorSymbol not ])
-		ifTrue: [ ^ nil ].
-	"otherwise, return this symbol"
-	^ symbol
+	"return a selector if the argument is used as a selector, nil if not"
+
+	^ (self lookup: aString) ifNotNil: [ :symbol | 
+		 ( self selectorTable like: symbol)
+			  ifNotNil: [ :selectorSymbol | selectorSymbol | selectorSymbol ] ]
 ]
 
 { #category : #private }


### PR DESCRIPTION
- findInterned: does the same as #lookup:, so it can just call it (this has not many users)
- findInternedSelector: can use #lookup: and query the Selectortable directly (and use #ifNotNil:)

This speeds up findInternedSelector: by ~3.5, which is used by the syntax highlighter

(but the main reason for the change is simplicity)