### PR TITLE
Simpler (and slightly faster) Symbol>>#intern: 

### DIFF
--- a/src/Collections-Strings/ByteString.class.st
+++ b/src/Collections-Strings/ByteString.class.st
@@ -184,6 +184,12 @@ ByteString >> byteSize [
 	^self size
 ]
 
+{ #category : #converting }
+ByteString >> createSymbol [
+
+	^(ByteSymbol basicNew: self size) string: self
+]
+
 { #category : #comparing }
 ByteString >> findSubstring: key in: body startingAt: start matchTable: matchTable [
 	

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -118,19 +118,10 @@ Symbol class >> initialize [
 ]
 
 { #category : #'instance creation' }
-Symbol class >> intern: aStringOrSymbol [ 
+Symbol class >> intern: aStringOrSymbol [
 
-	^(self lookup: aStringOrSymbol) ifNil:[
-		| aClass aSymbol |
-		aStringOrSymbol isSymbol ifTrue:[
-			aSymbol := aStringOrSymbol.
-		] ifFalse:[
-			aClass := aStringOrSymbol isOctetString ifTrue:[ByteSymbol] ifFalse:[WideSymbol].
-			aSymbol := aClass basicNew: aStringOrSymbol size.
-			aSymbol string: aStringOrSymbol.
-		].
-		NewSymbols add: aSymbol.
-		aSymbol].
+	^ (self lookup: aStringOrSymbol) ifNil: [ 
+		  NewSymbols add: aStringOrSymbol createSymbol ]
 ]
 
 { #category : #'instance creation' }
@@ -408,6 +399,12 @@ Symbol >> capitalized [
 { #category : #copying }
 Symbol >> copy [
 	"Answer with the receiver, because Symbols are unique."
+]
+
+{ #category : #converting }
+Symbol >> createSymbol [
+
+	^ self
 ]
 
 { #category : #evaluating }

--- a/src/Collections-Strings/WideString.class.st
+++ b/src/Collections-Strings/WideString.class.st
@@ -160,6 +160,15 @@ WideString >> byteSize [
 	^ self size * 4.
 ]
 
+{ #category : #converting }
+WideString >> ceateSymbol [
+	"We have to check if the string can be represented by a Bytesymbol to avoid two symbols
+	that represent the same string"
+	^ ((self isOctetString
+		    ifTrue: [ ByteSymbol ]
+		    ifFalse: [ WideSymbol ]) basicNew: self size) string: self
+]
+
 { #category : #copying }
 WideString >> copyFrom: start to: stop [
 

--- a/src/Collections-Strings/WideString.class.st
+++ b/src/Collections-Strings/WideString.class.st
@@ -160,15 +160,6 @@ WideString >> byteSize [
 	^ self size * 4.
 ]
 
-{ #category : #converting }
-WideString >> ceateSymbol [
-	"We have to check if the string can be represented by a Bytesymbol to avoid two symbols
-	that represent the same string"
-	^ ((self isOctetString
-		    ifTrue: [ ByteSymbol ]
-		    ifFalse: [ WideSymbol ]) basicNew: self size) string: self
-]
-
 { #category : #copying }
 WideString >> copyFrom: start to: stop [
 
@@ -176,6 +167,15 @@ WideString >> copyFrom: start to: stop [
 	n := super copyFrom: start to: stop.
 	n isOctetString ifTrue: [^ n asOctetString].
 	^ n.
+]
+
+{ #category : #converting }
+WideString >> createSymbol [
+	"We have to check if the string can be represented by a Bytesymbol to avoid two symbols
+	that represent the same string"
+	^ ((self isOctetString
+		    ifTrue: [ ByteSymbol ]
+		    ifFalse: [ WideSymbol ]) basicNew: self size) string: self
 ]
 
 { #category : #comparing }


### PR DESCRIPTION
This PR simplifies Symbol class >> #intern:

Dispatch the creation of the symbol to Symbol (do nothing), BytString (simple case) and WideString (needs to check #isOctedString in addition).

This means 
- we do one message send instead of sending #isSymbol and #isOctetString,
- we do not check #isOctetString for ByteString (the most common case)

We should benchmark this... it might be not faster