### PR TITLE
ReleaseTest-Symbol-unused-classvar

### DIFF
--- a/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
@@ -22,7 +22,7 @@ NoUnusedVariablesLeftTest >> testNoUnusedClassVariablesLeft [
 	
 	classes := variables collect: [ :each | each definingClass ] as: Set.
 	
-	validExceptions := #(OSKeySymbols FooSharedPool SDL2Constants AthensCairoDefinitions BalloonEngineConstants ShTestSharedPool RBLintRuleTestData RBDummyLintRuleTest MCMockClassF Unicode Character Symbol STONAlternativeRepresentationTestObject).	
+	validExceptions := #(OSKeySymbols FooSharedPool SDL2Constants AthensCairoDefinitions BalloonEngineConstants ShTestSharedPool RBLintRuleTestData RBDummyLintRuleTest MCMockClassF Unicode Character STONAlternativeRepresentationTestObject).	
 	
 	remaining := classes asOrderedCollection reject: [ :each  | validExceptions includes: each name].
 	self assert: remaining isEmpty description: ('the following classes have unused class variables and should be cleaned: ', remaining asString)

--- a/src/ReleaseTests/ProperMethodCategorizationTest.class.st
+++ b/src/ReleaseTests/ProperMethodCategorizationTest.class.st
@@ -146,7 +146,7 @@ ProperMethodCategorizationTest >> testNoUncategorizedMethods [
 	remaining := violating asOrderedCollection reject: [ :each  | validExceptions includes: each name].
 
 	"we lock in the number of problematic classes, this way it can only improve"
-	self assert: remaining size <= 3
+	self assert: remaining size <= 2
 ]
 
 { #category : #tests }


### PR DESCRIPTION
- remove Symbol from testNoUnusedClassVariablesLeft
- testNoUncategorizedMethods can check for 2 (it could be 1 if not a new one woul have been added in the meantime)