### PR TITLE
11248-Check-CanSelectorTable-use-WeakIndentitySet

### DIFF
--- a/src/Collections-Strings-Tests/SymbolTest.class.st
+++ b/src/Collections-Strings-Tests/SymbolTest.class.st
@@ -372,6 +372,12 @@ SymbolTest >> testIsLiteralSymbol [
 		description: 'valid ascii selector symbols can be printed without string quotes'.
 ]
 
+{ #category : #'tests - selectors' }
+SymbolTest >> testIsSelectorSymbol [
+	self deny: #'no selector exist with spaces' isSelectorSymbol.
+	self assert: #assert:equals: isSelectorSymbol
+]
+
 { #category : #requirements }
 SymbolTest >> testNew [
 	

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -475,7 +475,7 @@ Symbol >> isOrientedFill [
 
 { #category : #testing }
 Symbol >> isSelectorSymbol [
-	^ (self class selectorTable like: self) notNil
+	^ self class selectorTable includes: self
 ]
 
 { #category : #testing }

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -210,7 +210,7 @@ Symbol class >> rebuildSelectorTable [
 
 	^ SystemNavigation new allMethods
 		  collect: [ :method | method selector ]
-		  as: WeakSet
+		  as: WeakIdentitySet
 ]
 
 { #category : #private }


### PR DESCRIPTION
We can use a WeakIdentitySet as we make sure to only add symbols (which are unique). Fixes #11248