### PR TITLE
11312-users-of--findInternedSelector-can-use-isSelectorSymbol

### DIFF
--- a/src/Reflectivity-Tools/SemanticMessageIconStyler.class.st
+++ b/src/Reflectivity-Tools/SemanticMessageIconStyler.class.st
@@ -32,5 +32,5 @@ SemanticMessageIconStyler >> segmentMorphClass [
 
 { #category : #testing }
 SemanticMessageIconStyler >> shouldStyleNode: aNode [
-	^ aNode isMessage and: [ (Symbol findInternedSelector: aNode selector value asString) isNil ]
+	^ aNode isMessage and: [ aNode selector value isSelectorSymbol not ]
 ]

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -1216,10 +1216,10 @@ SHRBTextStyler >> visitLiteralValueNode: aLiteralValueNode [
 { #category : #visiting }
 SHRBTextStyler >> visitMessageNode: aMessageNode [
 	| style link |
-	style := #keyword.
 	
-	aMessageNode selector isSelectorSymbol 
-		ifFalse: [ style := self formatIncompleteSelector: aMessageNode ].
+	style := aMessageNode selector isSelectorSymbol 
+		ifTrue: [ #keyword ]
+		ifFalse: [ self formatIncompleteSelector: aMessageNode ].
 		
 	link := TextMethodLink sourceNode: aMessageNode.
 	self styleOpenParenthese: aMessageNode.

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -1218,7 +1218,7 @@ SHRBTextStyler >> visitMessageNode: aMessageNode [
 	| style link |
 	style := #keyword.
 	
-	aMessageNode selector isSelectorsSymbol 
+	aMessageNode selector isSelectorSymbol 
 		ifFalse: [ style := self formatIncompleteSelector: aMessageNode ].
 		
 	link := TextMethodLink sourceNode: aMessageNode.

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -1218,8 +1218,8 @@ SHRBTextStyler >> visitMessageNode: aMessageNode [
 	| style link |
 	style := #keyword.
 	
-	(Symbol findInternedSelector: aMessageNode selector asString)
-		ifNil:[ style := self formatIncompleteSelector: aMessageNode ].
+	aMessageNode selector isSelectorsSymbol 
+		ifFalse: [ style := self formatIncompleteSelector: aMessageNode ].
 		
 	link := TextMethodLink sourceNode: aMessageNode.
 	self styleOpenParenthese: aMessageNode.


### PR DESCRIPTION
use #isSelectorSymbol, this avoids a lookup in the SymbolTable and thus speeds things up a little

fixes #11312