### PR TITLE
Improve: Symbol class>>#internSelector: can just record the symbol

### DIFF
--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -68,7 +68,7 @@ Symbol class >> cleanUp [
 	self resetSelectorTable
 ]
 
-{ #category : #accessing }
+{ #category : #cleanup }
 Symbol class >> compactSymbolTable [
 	"Reduce the size of the symbol table so that it holds all existing symbols + 25% (changed from 1000 since sets like to have 25% free and the extra space would grow back in a hurry)"
 
@@ -87,7 +87,7 @@ Symbol class >> findInterned: aString [
 
 ]
 
-{ #category : #'instance creation' }
+{ #category : #'selector table' }
 Symbol class >> findInternedSelector: aString [
 	"return a selector if the argument is used as a selector, nil if not"
 
@@ -120,13 +120,6 @@ Symbol class >> intern: aStringOrSymbol [
 
 	^ (self lookup: aStringOrSymbol) ifNil: [ 
 		  NewSymbols add: aStringOrSymbol createSymbol ]
-]
-
-{ #category : #'instance creation' }
-Symbol class >> internSelector: aStringOrSymbol [
-
-	^ (self selectorTable like: aStringOrSymbol) ifNil: [ 
-		  self selectorTable add: aStringOrSymbol asSymbol ]
 ]
 
 { #category : #'instance creation' }
@@ -196,12 +189,17 @@ Symbol class >> readFrom: strm [
     	^ strm contents parseLiterals first.
 ]
 
-{ #category : #cleanup }
+{ #category : #'selector table' }
 Symbol class >> rebuildSelectorTable [
 
 	^ SystemNavigation new allMethods
 		  collect: [ :method | method selector ]
 		  as: WeakIdentitySet
+]
+
+{ #category : #'selector table' }
+Symbol class >> recordSelector: aSymbol [
+	self selectorTable add: aSymbol
 ]
 
 { #category : #private }
@@ -214,17 +212,17 @@ Symbol class >> rehash [
 	self resetSelectorTable.
 ]
 
-{ #category : #private }
+{ #category : #cleanup }
 Symbol class >> resetSelectorTable [
 	^ SelectorTable := nil
 ]
 
-{ #category : #private }
+{ #category : #'selector table' }
 Symbol class >> selectorTable [
 	^SelectorTable ifNil: [SelectorTable := self rebuildSelectorTable]
 ]
 
-{ #category : #accessing }
+{ #category : #'selector table' }
 Symbol class >> selectorThatStartsCaseSensitive: leadingCharacters skipping: skipSym [
 	"Same as thatStartsCaseSensitive:skipping: but on the SelectorTable only"
 	| size firstMatch key |

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -100,7 +100,7 @@ Behavior >> addSelectorSilently: selector withMethod: compiledMethod [
 	compiledMethod methodClass: self.
 	compiledMethod selector: selector.
 	"We record all selectors that are used as method names"
-	Symbol internSelector: selector
+	Symbol recordSelector: selector
 ]
 
 { #category : #'adding-removing methods' }


### PR DESCRIPTION
#internSelector: was following #intern: and used #like to return the selector found in the selector table.

But: 
- the only client does not use the return value
- symbols are unique, so this makes no sense, in general, to look them up

The PR renames #internSelector: to #recordSelector: without deprecation, as this is not a public API