### PR TITLE
11316-ClassFactoryForTestCasedeleteClasses-should-call-deleteClass

### DIFF
--- a/src/SUnit-Core/ClassFactoryForTestCase.class.st
+++ b/src/SUnit-Core/ClassFactoryForTestCase.class.st
@@ -122,7 +122,7 @@ ClassFactoryForTestCase >> deleteClass: aClass [
 { #category : #cleaning }
 ClassFactoryForTestCase >> deleteClasses [
 
-	self createdClasses do: [ :class | self delete: class ]
+	self createdClasses do: [ :class | self deleteClass: class ]
 ]
 
 { #category : #cleaning }


### PR DESCRIPTION
The PR #11133 exposes a bug in ClassFactoryForTestCase

ClassFactoryForTestCase>>#deleteClasses should call #deleteClass:

#deleteClasses now calls #delete:, but that does not remove the class from createdClasses

fixes #11316