### PR TITLE
Experiment to not use #compactSymbolTable (see #11319)

### DIFF
--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -148,10 +148,9 @@ BaselineOfMorphic >> cleanUpAfterMorphicInitialization [
 	Smalltalk globals flushClassNameCache.
 	ScrollBarMorph initializeImagesCache.
 
-	3 timesRepeat: [ 
-		Smalltalk garbageCollect.
-	 	Symbol compactSymbolTable ].
-	 	HashedCollection rehashAll.
+	Smalltalk garbageCollect.
+	HashedCollection rehashAll.
+	Symbol rehash.
 	  
 	  "Remove empty categories, which are not in MC packages, because MC does
 	  not do this (this script does not make packages dirty)"

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -64,8 +64,7 @@ Symbol class >> allSymbols [
 Symbol class >> cleanUp [
 	"Flush caches"
 
-	self compactSymbolTable.
-	self resetSelectorTable
+	self rehash
 ]
 
 { #category : #cleanup }


### PR DESCRIPTION
- in #cleanup call #rehash 
- in #cleanUpAfterMorphicInitialization call Symbol rehash

(see #11319 for more infos)