### PR TITLE
Add commentSourcePointer to ClassDescription

### DIFF
--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -12,7 +12,8 @@ Class {
 	#name : #ClassDescription,
 	#superclass : #Behavior,
 	#instVars : [
-		'organization'
+		'organization',
+		'commentSourcePointer'
 	],
 	#category : #'Kernel-Classes'
 }


### PR DESCRIPTION
commentSourcePointer is now defined in ClassOrganization, which wastes space.

To be able to move it, we first have to add the ivar using a manual PR.

Fist step for https://github.com/pharo-project/pharo/issues/10958