### PR TITLE
Cleanup asSymbol ReservedVariable

### DIFF
--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -24,12 +24,12 @@ Class {
 { #category : #'instance creation' }
 RBVariableNode class >> identifierNamed: anIdentifierName at: aPosition [
 	
-	anIdentifierName = 'self'
-		ifTrue: [ ^ self selfNode named: anIdentifierName start: aPosition ].
-	anIdentifierName = 'thisContext'
-		ifTrue: [ ^ self thisContextNode named: anIdentifierName start: aPosition ].
-	anIdentifierName = 'super'
-		ifTrue: [ ^ self superNode named: anIdentifierName start: aPosition ].
+	anIdentifierName = #self
+		ifTrue: [ ^ self selfNode start: aPosition ].
+	anIdentifierName = #thisContext
+		ifTrue: [ ^ self thisContextNode start: aPosition ].
+	anIdentifierName = #super
+		ifTrue: [ ^ self superNode start: aPosition ].
 	^ self named: anIdentifierName start: aPosition.
 ]
 
@@ -47,17 +47,17 @@ RBVariableNode class >> named: aName start: aPosition [
 
 { #category : #'instance creation' }
 RBVariableNode class >> selfNode [
-	^ (self named: 'self') variable: SelfVariable instance
+	^ (self named: #self) variable: SelfVariable instance
 ]
 
 { #category : #'instance creation' }
 RBVariableNode class >> superNode [
-	^ (self named: 'super') variable: SuperVariable instance
+	^ (self named: #super) variable: SuperVariable instance
 ]
 
 { #category : #'instance creation' }
 RBVariableNode class >> thisContextNode [
-	^ (self named: 'thisContext') variable: ThisContextVariable instance
+	^ (self named: #thisContext) variable: ThisContextVariable instance
 ]
 
 { #category : #comparing }

--- a/src/Kernel/SelfVariable.class.st
+++ b/src/Kernel/SelfVariable.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #accessing }
 SelfVariable class >> variableName [
-	^'self'
+	^#self
 ]
 
 { #category : #visiting }

--- a/src/Kernel/SuperVariable.class.st
+++ b/src/Kernel/SuperVariable.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #accessing }
 SuperVariable class >> variableName [
-	^'super'
+	^#super
 ]
 
 { #category : #visiting }

--- a/src/Kernel/ThisContextVariable.class.st
+++ b/src/Kernel/ThisContextVariable.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #accessing }
 ThisContextVariable class >> variableName [
-	^'thisContext'
+	^#thisContext
 ]
 
 { #category : #visiting }


### PR DESCRIPTION
reduce the need to call #asSymbol on strings by using symbols when creating self/super/thisContext RBVariablesNodes.

(the code looks not that nice, there seem to be more possibilities for improvements later. This PR just reduces the need to create symbols from the strings)