### PR TITLE
11334-DAPackageRelationGraphDiffTest-raises-PotentialOutDatedDependencyWarning 

### DIFF
--- a/src/Collections-Strings/ManifestCollectionsStrings.class.st
+++ b/src/Collections-Strings/ManifestCollectionsStrings.class.st
@@ -12,11 +12,6 @@ ManifestCollectionsStrings class >> dependencies [
 	^ #(#'Collections-Streams' #'Collections-Weak' #'Collections-Native' #'Collections-Support' #Kernel #'Collections-Sequenceable' #'Multilingual-Encodings' #'Collections-Abstract')
 ]
 
-{ #category : #'meta-data - dependency analyser' }
-ManifestCollectionsStrings class >> manuallyResolvedDependencies [
-	^ #(#'System-Support' )
-]
-
 { #category : #'meta-data' }
 ManifestCollectionsStrings class >> packageName [
 	^ #'Collections-Strings'


### PR DESCRIPTION
The CI log showed lots of messages " Collections-Strings: System-Support dependency declared in the package Manifest as manuallyResolvedDependencies not detected as a dependency"

Fixes 11334