### PR TITLE
fix 8661: enables IM support in SDL2

### DIFF
--- a/src/Morphic-Core/AbstractWorldRenderer.class.st
+++ b/src/Morphic-Core/AbstractWorldRenderer.class.st
@@ -299,6 +299,12 @@ AbstractWorldRenderer >> logRenderingTimeMeasurements: measurements [
 	self class logRenderingTimeMeasurements: measurements
 ]
 
+{ #category : #events }
+AbstractWorldRenderer >> requestTextEditingAt: aRectangle [ 
+	
+	self subclassResponsibility
+]
+
 { #category : #operations }
 AbstractWorldRenderer >> restoreMorphicDisplay [ 
 

--- a/src/Morphic-Core/AbstractWorldRenderer.class.st
+++ b/src/Morphic-Core/AbstractWorldRenderer.class.st
@@ -300,6 +300,11 @@ AbstractWorldRenderer >> logRenderingTimeMeasurements: measurements [
 ]
 
 { #category : #events }
+AbstractWorldRenderer >> requestStopTextEditing [
+	^ self subclassResponsibility 
+]
+
+{ #category : #events }
 AbstractWorldRenderer >> requestTextEditingAt: aRectangle [ 
 	
 	self subclassResponsibility

--- a/src/Morphic-Core/HandMorph.class.st
+++ b/src/Morphic-Core/HandMorph.class.st
@@ -526,6 +526,9 @@ HandMorph >> handleEvent: anEvent [
 	"Notify listeners"
 	self sendListenEvent: evt to: self eventListeners.
 
+	(evt isTextEditionEvent or: [evt isTextInputEvent]) ifTrue: [
+		^ self sendEvent: evt focus: keyboardFocus  ].
+
 	evt isWindowEvent ifTrue: [
 		^ self sendEvent: evt focus: nil ].
 	
@@ -577,6 +580,7 @@ HandMorph >> handleEvent: anEvent [
 	].
 	self showMouseFocusEvent: evt.
 	self mouseOverHandler processMouseOver: lastMouseEvent.
+
 ]
 
 { #category : #drawing }

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -3016,6 +3016,26 @@ Morph >> handleSpecialGesture: mouseDownEvent [
 	mouseDownEvent hand newMouseFocus: h.
 ]
 
+{ #category : #'event handling' }
+Morph >> handleTextEditionEvent: anEvent [
+	"System level event handling."
+
+	anEvent wasHandled ifTrue: [ ^ self ].
+	(self handlesTextEditionEvent: anEvent) ifTrue: [ 
+		anEvent wasHandled: true.
+		self textEdition: anEvent ]
+]
+
+{ #category : #'event handling' }
+Morph >> handleTextInputEvent: anEvent [
+	"System level event handling."
+	
+	anEvent wasHandled ifTrue:[^self].
+	(self handlesTextInputEvent: anEvent) ifTrue:[
+		anEvent wasHandled: true.
+		self textInput: anEvent]
+]
+
 { #category : #'events - processing' }
 Morph >> handleUnknownEvent: anEvent [
 	"An event of an unknown type was sent to the receiver. What shall we do?!"
@@ -3179,6 +3199,20 @@ Morph >> handlesMouseStillDown: evt [
 { #category : #'events - processing' }
 Morph >> handlesMouseWheel: evt [
 	"Do I want to receive mouseWheel events?." 
+
+	^false
+]
+
+{ #category : #'event handling' }
+Morph >> handlesTextEditionEvent: evt [
+	"Do I want to receive text edition events?" 
+
+	^false
+]
+
+{ #category : #'event handling' }
+Morph >> handlesTextInputEvent: evt [
+	"Do I want to receive text edition events?" 
 
 	^false
 ]
@@ -5217,6 +5251,36 @@ Morph >> replaceSubmorph: oldMorph by: newMorph [
 	(w := newMorph world) ifNotNil: [ newMorph startSteppingSubmorphs ]
 ]
 
+{ #category : #'event handling' }
+Morph >> requestStopTextEditing [
+
+	"Used by a morph to request stop text edition capabilities.
+	The rendering backend can use this, for example, close the IME (input-method-editor).
+	Use it in pair with requestTextEditingAt:
+	
+	By default, propagate the request to the owner.
+	If this morph has no owner, do nothing.
+	Particular morphs (e.g., the root of the composition hierarchy should override)"
+	self owner ifNil: [ ^ self ].
+	self owner requestStopTextEditing
+]
+
+{ #category : #'event handling' }
+Morph >> requestTextEditingAt: aRectangle [
+
+	"Used by a morph to request text edition capabilities.
+	The rendering backend can use this information to, for example, open the IME (input-method-editor).
+	The rectangle indicates the position where the IME menu could be shown.
+	
+	Use it in pair with requestStopTextEditing
+	
+	By default, propagate the request to the owner.
+	If this morph has no owner, do nothing.
+	Particular morphs (e.g., the root of the composition hierarchy should override)"
+	self owner ifNil: [ ^ self ].
+	self owner requestTextEditingAt: aRectangle
+]
+
 { #category : #'accessing - extension' }
 Morph >> resetExtension [
 	"reset the extension slot if it is not needed"
@@ -6104,6 +6168,14 @@ Morph >> textAnchorType: aSymbol [
 	^ aSymbol == #document
 		ifTrue: [ self removeProperty: #textAnchorType ]
 		ifFalse: [ self setProperty: #textAnchorType toValue: aSymbol ]
+]
+
+{ #category : #'event handling' }
+Morph >> textEdition: aTextEditionEvent [
+]
+
+{ #category : #'event handling' }
+Morph >> textInput: aTextInputEvent [
 ]
 
 { #category : #theme }

--- a/src/Morphic-Core/MorphicEvent.class.st
+++ b/src/Morphic-Core/MorphicEvent.class.st
@@ -85,6 +85,17 @@ MorphicEvent >> isMove [
 ]
 
 { #category : #testing }
+MorphicEvent >> isTextEditionEvent [
+	^false
+]
+
+{ #category : #testing }
+MorphicEvent >> isTextInputEvent [
+
+	^ false
+]
+
+{ #category : #testing }
 MorphicEvent >> isWindowEvent [
 	^false
 ]

--- a/src/Morphic-Core/MorphicEventDispatcher.class.st
+++ b/src/Morphic-Core/MorphicEventDispatcher.class.st
@@ -200,6 +200,16 @@ MorphicEventDispatcher >> handleStep: anEvent [
 ]
 
 { #category : #'dispatching - callback' }
+MorphicEventDispatcher >> handleTextEditionEvent: aTextEditionEvent [
+	^ self dispatchDefault: aTextEditionEvent with: morph
+]
+
+{ #category : #'dispatching - callback' }
+MorphicEventDispatcher >> handleTextInputEvent: aTextInputEvent [ 
+	^ self dispatchDefault: aTextInputEvent with: morph
+]
+
+{ #category : #'dispatching - callback' }
 MorphicEventDispatcher >> handleUnknownEvent: anEvent [ 
 	^ self dispatchDefault: anEvent with: morph
 ]

--- a/src/Morphic-Core/NullWorldRenderer.class.st
+++ b/src/Morphic-Core/NullWorldRenderer.class.st
@@ -64,6 +64,16 @@ NullWorldRenderer >> icon: aForm [
 	"Do nothing, a null world rendered has no window, so no icon either"
 ]
 
+{ #category : #events }
+NullWorldRenderer >> requestStopTextEditing [
+]
+
+{ #category : #events }
+NullWorldRenderer >> requestTextEditingAt: aRectangle [
+
+	
+]
+
 { #category : #rendering }
 NullWorldRenderer >> updateDamage: rectangles [
 

--- a/src/Morphic-Core/TextEditionEvent.class.st
+++ b/src/Morphic-Core/TextEditionEvent.class.st
@@ -1,0 +1,58 @@
+Class {
+	#name : #TextEditionEvent,
+	#superclass : #UserInputEvent,
+	#instVars : [
+		'text',
+		'start',
+		'length'
+	],
+	#category : #'Morphic-Core-Events'
+}
+
+{ #category : #accessing }
+TextEditionEvent >> isTextEditionEvent [
+
+	^true
+]
+
+{ #category : #accessing }
+TextEditionEvent >> length [
+
+	^ length
+]
+
+{ #category : #accessing }
+TextEditionEvent >> length: anInteger [
+
+	length := anInteger
+]
+
+{ #category : #dispatching }
+TextEditionEvent >> sentTo: anObject [
+
+	^anObject handleTextEditionEvent: self
+]
+
+{ #category : #accessing }
+TextEditionEvent >> start [
+
+	^ start
+]
+
+{ #category : #accessing }
+TextEditionEvent >> start: anInteger [
+
+	start := anInteger
+]
+
+{ #category : #accessing }
+TextEditionEvent >> text [
+
+	^ text
+]
+
+{ #category : #accessing }
+TextEditionEvent >> text: aString [
+
+	text := aString
+]

--- a/src/Morphic-Core/TextInputEvent.class.st
+++ b/src/Morphic-Core/TextInputEvent.class.st
@@ -1,0 +1,31 @@
+Class {
+	#name : #TextInputEvent,
+	#superclass : #UserInputEvent,
+	#instVars : [
+		'text'
+	],
+	#category : #'Morphic-Core-Events'
+}
+
+{ #category : #testing }
+TextInputEvent >> isTextInputEvent [
+
+	^true
+]
+
+{ #category : #dispatching }
+TextInputEvent >> sentTo: anObject [
+
+	^anObject handleTextInputEvent: self
+]
+
+{ #category : #accessing }
+TextInputEvent >> text [
+	^ text
+]
+
+{ #category : #accessing }
+TextInputEvent >> text: aString [
+
+	text := aString
+]

--- a/src/Morphic-Core/WorldMorph.class.st
+++ b/src/Morphic-Core/WorldMorph.class.st
@@ -470,6 +470,18 @@ WorldMorph >> removeHand: aHandMorph [
 	worldState removeHand: aHandMorph
 ]
 
+{ #category : #'event handling' }
+WorldMorph >> requestStopTextEditing [
+
+	self worldState worldRenderer requestStopTextEditing
+]
+
+{ #category : #'event handling' }
+WorldMorph >> requestTextEditingAt: aRectangle [
+
+	self worldState worldRenderer requestTextEditingAt: aRectangle
+]
+
 { #category : #'world state' }
 WorldMorph >> restoreMorphicDisplay [
 

--- a/src/Morphic-Widgets-Scrolling/GeneralScrollPaneMorph.class.st
+++ b/src/Morphic-Widgets-Scrolling/GeneralScrollPaneMorph.class.st
@@ -253,6 +253,18 @@ GeneralScrollPaneMorph >> handlesMouseWheel: evt [
 	^true
 ]
 
+{ #category : #'event handling' }
+GeneralScrollPaneMorph >> handlesTextEditionEvent: anEvent [
+
+	^ self scrollTarget handlesTextEditionEvent: anEvent
+]
+
+{ #category : #'event handling' }
+GeneralScrollPaneMorph >> handlesTextInputEvent: anEvent [
+
+	^ self scrollTarget handlesTextInputEvent: anEvent
+]
+
 { #category : #initialization }
 GeneralScrollPaneMorph >> initialize [
 	"Initialize the receiver."
@@ -442,6 +454,18 @@ GeneralScrollPaneMorph >> setScrollDeltas [
 	self
 		hSetScrollDelta;
 		vSetScrollDelta
+]
+
+{ #category : #'event handling' }
+GeneralScrollPaneMorph >> textEdition: aTextEditionEvent [
+
+	self scrollTarget textEdition: aTextEditionEvent
+]
+
+{ #category : #'event handling' }
+GeneralScrollPaneMorph >> textInput: aTextInputEvent [
+
+	self scrollTarget textInput: aTextInputEvent
 ]
 
 { #category : #updating }

--- a/src/OSWindow-Core/OSBackendWindow.class.st
+++ b/src/OSWindow-Core/OSBackendWindow.class.st
@@ -194,6 +194,11 @@ OSBackendWindow >> startTextInput [
 ]
 
 { #category : #'text input' }
+OSBackendWindow >> startTextInputAtRectangle: anObject [
+	self subclassResponsibility
+]
+
+{ #category : #'text input' }
 OSBackendWindow >> stopTextInput [
 	self subclassResponsibility
 ]

--- a/src/OSWindow-Core/OSNullBackendWindow.class.st
+++ b/src/OSWindow-Core/OSNullBackendWindow.class.st
@@ -114,6 +114,11 @@ OSNullBackendWindow >> startTextInput [
 ]
 
 { #category : #'text input' }
+OSNullBackendWindow >> startTextInputAtRectangle: anObject [
+	isTextInputActive := true
+]
+
+{ #category : #'text input' }
 OSNullBackendWindow >> stopTextInput [
 	isTextInputActive := false
 ]

--- a/src/OSWindow-Core/OSTextEditingEvent.class.st
+++ b/src/OSWindow-Core/OSTextEditingEvent.class.st
@@ -1,0 +1,42 @@
+"
+I am an event that happens when editing text that is not yet committed.
+Often happens when the user invoces an input method editor (IME) to type in languages like japanese or chinese, or when one holds a key and accents are proposed.
+"
+Class {
+	#name : #OSTextEditingEvent,
+	#superclass : #OSTextInputEvent,
+	#instVars : [
+		'start',
+		'length'
+	],
+	#category : #'OSWindow-Core-Events'
+}
+
+{ #category : #visitor }
+OSTextEditingEvent >> accept: aVisitor [
+	^ aVisitor visitTextEditingEvent: self
+]
+
+{ #category : #accessing }
+OSTextEditingEvent >> length [
+
+	^ length
+]
+
+{ #category : #accessing }
+OSTextEditingEvent >> length: anObject [
+
+	length := anObject
+]
+
+{ #category : #accessing }
+OSTextEditingEvent >> start [
+
+	^ start
+]
+
+{ #category : #accessing }
+OSTextEditingEvent >> start: anObject [
+
+	start := anObject
+]

--- a/src/OSWindow-Core/OSWindow.class.st
+++ b/src/OSWindow-Core/OSWindow.class.st
@@ -414,6 +414,17 @@ OSWindow >> startTextInput [
 ]
 
 { #category : #'text input' }
+OSWindow >> startTextInputAtRectangle: aRectangle [
+
+	"Start accepting Unicode text input events.
+	I will start accepting Unicode text input events in the focused window, and start emitting text input and text editing events.
+	Please use me in pair with stopTextInput.
+	On some platforms I may activate the screen keyboard."
+
+	self validHandle startTextInputAtRectangle: aRectangle
+]
+
+{ #category : #'text input' }
 OSWindow >> stopTextInput [
 	"Stop receiving any text input events"
 

--- a/src/OSWindow-Core/OSWindowEventVisitor.class.st
+++ b/src/OSWindow-Core/OSWindowEventVisitor.class.st
@@ -65,6 +65,10 @@ OSWindowEventVisitor >> visitMouseWheelEvent: anEvent [
 ]
 
 { #category : #visiting }
+OSWindowEventVisitor >> visitTextEditingEvent: anEvent [
+]
+
+{ #category : #visiting }
 OSWindowEventVisitor >> visitTextInputEvent: anEvent [
 ]
 

--- a/src/OSWindow-Core/OSWindowMorphicEventHandler.class.st
+++ b/src/OSWindow-Core/OSWindowMorphicEventHandler.class.st
@@ -265,26 +265,45 @@ OSWindowMorphicEventHandler >> visitMouseWheelEvent: anEvent [
 ]
 
 { #category : #visiting }
-OSWindowMorphicEventHandler >> visitTextInputEvent: anEvent [
-	| keyEvent char mods |
-	anEvent text ifNil: [ ^ nil ].
-	char := anEvent text first.
-	char ifNil: [ ^ nil ].
-	mods := anEvent modifiers.
-	"If a modifier key is pressed the keystroke event is handled by #visitMouseDownEvent:"
-	(mods alt or: [ mods ctrl or: [ mods cmd ] ])
-		ifTrue: [ ^ nil ].
-		
-	keyEvent := KeyboardEvent new
-		setType: #keystroke
-		buttons: (self convertModifiers: anEvent modifiers)
-		position: (self convertPosition: anEvent position)
-		keyValue: char charCode
-		charCode: char charCode
-		hand: self activeHand
-		stamp: Time millisecondClockValue.
+OSWindowMorphicEventHandler >> visitTextEditingEvent: anEvent [
 	
+	| keyEvent |
+	keyEvent := TextEditionEvent new
+		setHand: self activeHand;
+		setPosition: (self convertPosition: anEvent position);
+		text: anEvent text;
+		start: anEvent start;
+		length: anEvent length;
+		wasHandled: false.
 	^ keyEvent
+]
+
+{ #category : #visiting }
+OSWindowMorphicEventHandler >> visitTextInputEvent: anEvent [
+	anEvent text ifNil: [ ^ nil ].
+	(anEvent text size = 1 and: [ anEvent text first codePoint < 128 ])
+		ifTrue: [ 
+			| char mods |
+			char := anEvent text first.
+			char ifNil: [ ^ nil ].
+			mods := anEvent modifiers.
+			"If a modifier key is pressed the keystroke event is handled by #visitMouseDownEvent:"
+			(mods alt or: [ mods ctrl or: [ mods cmd ] ]) ifTrue: [ ^ nil ].
+
+			^ KeyboardEvent new
+				  setType: #keystroke
+				  buttons: (self convertModifiers: anEvent modifiers)
+				  position: (self convertPosition: anEvent position)
+				  keyValue: char charCode
+				  charCode: char charCode
+				  hand: self activeHand
+				  stamp: Time millisecondClockValue ]
+		ifFalse: [ 
+			^ TextInputEvent new
+				  setHand: self activeHand;
+				  setPosition: (self convertPosition: anEvent position);
+				  text: anEvent text;
+				  wasHandled: false ]
 ]
 
 { #category : #visiting }

--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -214,6 +214,18 @@ OSWorldRenderer >> pickMostSuitableWindowDriver [
 	^ driver
 ]
 
+{ #category : #events }
+OSWorldRenderer >> requestStopTextEditing [
+	
+	osWindow stopTextInput
+]
+
+{ #category : #events }
+OSWorldRenderer >> requestTextEditingAt: aRectangle [ 
+	
+	osWindow startTextInputAtRectangle: aRectangle
+]
+
 { #category : #accessing }
 OSWorldRenderer >> screenScaleFactor [
 

--- a/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
+++ b/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
@@ -535,6 +535,16 @@ OSSDL2BackendWindow >> startTextInput [
 ]
 
 { #category : #'text input' }
+OSSDL2BackendWindow >> startTextInputAtRectangle: aRectangle [
+
+	"See https://wiki.libsdl.org/SDL_StartTextInput"
+
+	sdl2Window
+		startTextInput;
+		setTextInputRectangle: aRectangle asSDLRect
+]
+
+{ #category : #'text input' }
 OSSDL2BackendWindow >> stopTextInput [
 	"See https://wiki.libsdl.org/SDL_StopTextInput"
 
@@ -668,6 +678,19 @@ OSSDL2BackendWindow >> visitSystemWindowEvent: systemWindowEvent [
 		diagonalDPI: diagonalDPI;
 		screenScaleFactor: screenScaleFactor;
 		deliver
+]
+
+{ #category : #'event handling' }
+OSSDL2BackendWindow >> visitTextEditingEvent: event [
+	| osEvent |
+	"Nothing for now"
+	osEvent := OSTextEditingEvent for: osWindow.
+	osEvent
+		text: (ZnUTF8Encoder new decodeBytes: event text);
+		position: self mousePosition;
+		start: event start;
+		length: event length.
+	^ osEvent deliver
 ]
 
 { #category : #'event handling' }

--- a/src/OSWindow-SDL2/SDL_TextEditingEvent.class.st
+++ b/src/OSWindow-SDL2/SDL_TextEditingEvent.class.st
@@ -1,0 +1,580 @@
+"
+# An Editing event
+
+https://wiki.libsdl.org/SDL_TextEditingEvent
+
+A structure that contains keyboard text editing event information.
+Text editing events inform about text that was not _yet_ accepted by the user.
+"
+Class {
+	#name : #'SDL_TextEditingEvent',
+	#superclass : #SDL2MappedEvent,
+	#classVars : [
+		'OFFSET_LENGTH',
+		'OFFSET_START',
+		'OFFSET_TEXT0',
+		'OFFSET_TEXT1',
+		'OFFSET_TEXT10',
+		'OFFSET_TEXT11',
+		'OFFSET_TEXT12',
+		'OFFSET_TEXT13',
+		'OFFSET_TEXT14',
+		'OFFSET_TEXT15',
+		'OFFSET_TEXT16',
+		'OFFSET_TEXT17',
+		'OFFSET_TEXT18',
+		'OFFSET_TEXT19',
+		'OFFSET_TEXT2',
+		'OFFSET_TEXT20',
+		'OFFSET_TEXT21',
+		'OFFSET_TEXT22',
+		'OFFSET_TEXT23',
+		'OFFSET_TEXT24',
+		'OFFSET_TEXT25',
+		'OFFSET_TEXT26',
+		'OFFSET_TEXT27',
+		'OFFSET_TEXT28',
+		'OFFSET_TEXT29',
+		'OFFSET_TEXT3',
+		'OFFSET_TEXT30',
+		'OFFSET_TEXT31',
+		'OFFSET_TEXT4',
+		'OFFSET_TEXT5',
+		'OFFSET_TEXT6',
+		'OFFSET_TEXT7',
+		'OFFSET_TEXT8',
+		'OFFSET_TEXT9',
+		'OFFSET_TIMESTAMP',
+		'OFFSET_TYPE',
+		'OFFSET_WINDOWID'
+	],
+	#category : #'OSWindow-SDL2-Bindings'
+}
+
+{ #category : #'event type' }
+SDL_TextEditingEvent class >> eventType [
+	^ SDL_TEXTEDITING
+]
+
+{ #category : #'fields description' }
+SDL_TextEditingEvent class >> fieldsDesc [
+	"
+	self initializeAccessors
+	"
+	^ #(
+    Uint32 type;
+    Uint32 timestamp;
+    Uint32 windowID;
+
+	"HACK: for char text[32];"
+      char text0;
+	char text1;
+	char text2;
+	char text3;
+	char text4;
+	char text5;
+	char text6;
+	char text7;
+	char text8;
+	char text9;
+	char text10;
+	char text11;
+	char text12;
+	char text13;
+	char text14;
+	char text15;
+	char text16;
+	char text17;
+	char text18;
+	char text19;
+	char text20;
+	char text21;
+	char text22;
+	char text23;
+	char text24;
+	char text25;
+	char text26;
+	char text27;
+	char text28;
+	char text29;
+	char text30;
+	char text31;
+	
+	Sint32 start; "the location to begin editing from"
+	Sint32 length "the number of characters to edit from the start point
+
+"
+ 	)
+]
+
+{ #category : #visitor }
+SDL_TextEditingEvent >> accept: aVisitor [
+	^ aVisitor visitTextEditingEvent: self
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> length [
+	"This method was automatically generated"
+	^handle signedLongAt: OFFSET_LENGTH
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> length: anObject [
+	"This method was automatically generated"
+	handle signedLongAt: OFFSET_LENGTH put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> start [
+	"This method was automatically generated"
+	^handle signedLongAt: OFFSET_START
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> start: anObject [
+	"This method was automatically generated"
+	handle signedLongAt: OFFSET_START put: anObject
+]
+
+{ #category : #accesing }
+SDL_TextEditingEvent >> strlen [
+	| len |
+	len := 0.
+	12 to: 12 + 32 - 1 do:
+		[ :i | 
+		(self getHandle nbUInt8AtOffset: i) = 0
+			ifTrue: [ ^ len ].
+		len := len + 1 ].
+	^ len
+]
+
+{ #category : #accesing }
+SDL_TextEditingEvent >> text [
+	| len text |
+	len := self strlen.
+	text := ByteArray new: len.
+	1 to: len do: [ :i |
+		text at: i put: (self getHandle nbUInt8AtOffset: 12 + i - 1)
+	].
+	^ text
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text0 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT0
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text0: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT0 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text1 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT1
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text10 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT10
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text10: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT10 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text11 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT11
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text11: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT11 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text12 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT12
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text12: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT12 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text13 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT13
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text13: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT13 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text14 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT14
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text14: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT14 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text15 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT15
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text15: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT15 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text16 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT16
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text16: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT16 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text17 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT17
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text17: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT17 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text18 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT18
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text18: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT18 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text19 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT19
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text19: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT19 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text1: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT1 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text2 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT2
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text20 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT20
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text20: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT20 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text21 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT21
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text21: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT21 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text22 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT22
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text22: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT22 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text23 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT23
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text23: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT23 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text24 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT24
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text24: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT24 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text25 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT25
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text25: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT25 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text26 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT26
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text26: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT26 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text27 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT27
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text27: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT27 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text28 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT28
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text28: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT28 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text29 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT29
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text29: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT29 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text2: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT2 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text3 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT3
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text30 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT30
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text30: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT30 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text31 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT31
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text31: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT31 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text3: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT3 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text4 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT4
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text4: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT4 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text5 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT5
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text5: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT5 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text6 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT6
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text6: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT6 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text7 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT7
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text7: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT7 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text8 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT8
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text8: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT8 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text9 [
+	"This method was automatically generated"
+	^handle unsignedCharAt: OFFSET_TEXT9
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> text9: anObject [
+	"This method was automatically generated"
+	handle unsignedCharAt: OFFSET_TEXT9 put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> timestamp [
+	"This method was automatically generated"
+	^handle unsignedLongAt: OFFSET_TIMESTAMP
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> timestamp: anObject [
+	"This method was automatically generated"
+	handle unsignedLongAt: OFFSET_TIMESTAMP put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> type [
+	"This method was automatically generated"
+	^handle unsignedLongAt: OFFSET_TYPE
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> type: anObject [
+	"This method was automatically generated"
+	handle unsignedLongAt: OFFSET_TYPE put: anObject
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> windowID [
+	"This method was automatically generated"
+	^handle unsignedLongAt: OFFSET_WINDOWID
+]
+
+{ #category : #'accessing structure variables' }
+SDL_TextEditingEvent >> windowID: anObject [
+	"This method was automatically generated"
+	handle unsignedLongAt: OFFSET_WINDOWID put: anObject
+]

--- a/src/OSWindow-SDL2/SDL_TextEditingEvent.class.st
+++ b/src/OSWindow-SDL2/SDL_TextEditingEvent.class.st
@@ -136,7 +136,7 @@ SDL_TextEditingEvent >> start: anObject [
 	handle signedLongAt: OFFSET_START put: anObject
 ]
 
-{ #category : #accesing }
+{ #category : #accessing }
 SDL_TextEditingEvent >> strlen [
 	| len |
 	len := 0.
@@ -148,7 +148,7 @@ SDL_TextEditingEvent >> strlen [
 	^ len
 ]
 
-{ #category : #accesing }
+{ #category : #accessing }
 SDL_TextEditingEvent >> text [
 	| len text |
 	len := self strlen.

--- a/src/OSWindow-SDL2/SDL_Window.class.st
+++ b/src/OSWindow-SDL2/SDL_Window.class.st
@@ -158,6 +158,12 @@ SDL_Window >> setSizeW: w h: h [
 	^ self ffiCall: #( void SDL_SetWindowSize ( self , int w , int h ) )
 ]
 
+{ #category : #'text input' }
+SDL_Window >> setTextInputRectangle: aSDL2Rectangle [
+
+	^ self ffiCall: #(void SDL_SetTextInputRect(SDL_Rect* aSDL2Rectangle))
+]
+
 { #category : #'window management' }
 SDL_Window >> show [
 	^ self ffiCall: #( void SDL_ShowWindow( self ) )

--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -1203,7 +1203,6 @@ RubAbstractTextArea >> keyboardFocusChange: aBoolean [
 		ifTrue: [ 
 			self hasFocus: true.
 			editing := false.
-			self editor unselect.
 			self requestTextEditingAt:
 				((self cursor positionInWorld corner: self cursor positionInWorld) 
 					 translateBy: 0 @ (self font height + 4)) truncated.
@@ -1211,12 +1210,9 @@ RubAbstractTextArea >> keyboardFocusChange: aBoolean [
 		ifFalse: [ 
 			self hasFocus: false.
 			self requestStopTextEditing.
-			editing = true ifTrue: [ 
-				self editor unselect.
-				editing := false ].
+			editing = true ifTrue: [ editing := false ].
 			self hideOverEditableTextCursor ].
-	super keyboardFocusChange: aBoolean.
-	self focusChanged
+	super keyboardFocusChange: aBoolean
 ]
 
 { #category : #accessing }

--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -96,7 +96,8 @@ Class {
 		'mouseDownPoint',
 		'completionEngine',
 		'maxLength',
-		'findReplaceService'
+		'findReplaceService',
+		'editing'
 	],
 	#classVars : [
 		'BackgroundColor',
@@ -780,6 +781,12 @@ RubAbstractTextArea >> editPrimarySelectionSeparately [
 	(view embeddedInMorphicWindowLabeled: 'Selection editing') openInHand.
 ]
 
+{ #category : #'accessing - im text input' }
+RubAbstractTextArea >> editing [
+
+	^ editing = true
+]
+
 { #category : #'accessing - editing mode' }
 RubAbstractTextArea >> editingMode [
 	^ editingMode
@@ -988,6 +995,13 @@ RubAbstractTextArea >> handleEdit: editBlock [
 ]
 
 { #category : #'event handling' }
+RubAbstractTextArea >> handleKeyDown: anEvent [
+
+	editing = true ifTrue: [ ^ self ].
+	^ super handleKeyDown: anEvent
+]
+
+{ #category : #'event handling' }
 RubAbstractTextArea >> handleKeystroke: anEvent [ 
 	"System level event handling."
 
@@ -1064,6 +1078,18 @@ RubAbstractTextArea >> handlesMouseOver: evt [
 	^ self enabled
 ]
 
+{ #category : #'event handling' }
+RubAbstractTextArea >> handlesTextEditionEvent: anEvent [
+
+	^ true
+]
+
+{ #category : #'event handling' }
+RubAbstractTextArea >> handlesTextInputEvent: anEvent [
+
+	^ true
+]
+
 { #category : #completion }
 RubAbstractTextArea >> hasCompletionEngine [
 	
@@ -1116,7 +1142,8 @@ RubAbstractTextArea >> initialize [
 	self compose.
 	self addCursor.
 	self plugFindReplace.
-	DefaultTextColor := self theme textColor
+	DefaultTextColor := self theme textColor.
+	editing := false
 ]
 
 { #category : #keymapping }
@@ -1156,24 +1183,40 @@ RubAbstractTextArea >> keyDown: anEvent [
 
 { #category : #'event handling' }
 RubAbstractTextArea >> keyStroke: anEvent [
+
 	"Handle a keystroke event."
-	anEvent hand anyButtonPressed
-		ifTrue: [ ^ self ].
-	self handleEdit: [ self editor keystroke: anEvent ].
+
+	anEvent hand anyButtonPressed ifTrue: [ ^ self ].
+	self handleEdit: [ 
+		editing = true
+			ifTrue: [ 
+				editing := false.
+				self editor unselect ]
+			ifFalse: [ self editor keystroke: anEvent ] ].
 	self scrollSelectionIntoView: nil
 ]
 
 { #category : #'event handling' }
 RubAbstractTextArea >> keyboardFocusChange: aBoolean [
+
 	aBoolean
-		ifTrue: [
+		ifTrue: [ 
 			self hasFocus: true.
+			editing := false.
+			self editor unselect.
+			self requestTextEditingAt:
+				((self cursor positionInWorld corner: self cursor positionInWorld) 
+					 translateBy: 0 @ (self font height + 4)) truncated.
 			self showOverEditableTextCursor ]
 		ifFalse: [ 
 			self hasFocus: false.
+			self requestStopTextEditing.
+			editing = true ifTrue: [ 
+				self editor unselect.
+				editing := false ].
 			self hideOverEditableTextCursor ].
 	super keyboardFocusChange: aBoolean.
-	self focusChanged.
+	self focusChanged
 ]
 
 { #category : #accessing }
@@ -1906,12 +1949,32 @@ RubAbstractTextArea >> textColor: newColor [
 	self changed.
 ]
 
+{ #category : #'event handling' }
+RubAbstractTextArea >> textEdition: aTextEditionEvent [
+
+	aTextEditionEvent text
+		ifNotEmpty: [ :editText | 
+			self editor zapSelectionWith: editText.
+			editing := true ]
+		ifEmpty: [ 
+			editing = true ifTrue: [ 
+				self editor zapSelectionWith: ''.
+				editing := false ] ]
+]
+
 { #category : #'accessing - text' }
 RubAbstractTextArea >> textFont: aFont [
 	self addAttribute: (TextFontReference toFont: aFont).
 	self paragraph compose.
 	self recomputeSelection.
 	self  announce: (RubTextStyleChanged morph: self).
+]
+
+{ #category : #'event handling' }
+RubAbstractTextArea >> textInput: aTextInputEvent [
+	self editor zapSelectionWith: aTextInputEvent text.
+	self editor unselect.
+	editing := false
 ]
 
 { #category : #'accessing - text' }

--- a/src/Rubric/RubScrolledTextMorph.class.st
+++ b/src/Rubric/RubScrolledTextMorph.class.st
@@ -603,6 +603,22 @@ RubScrolledTextMorph >> handlesMouseWheel: evt [
 	^ true
 ]
 
+{ #category : #'event handling' }
+RubScrolledTextMorph >> handlesTextEditionEvent: anEvent [
+
+	^ self scrollPane
+		  ifNotNil: [ :pane | pane handlesTextEditionEvent: anEvent ]
+		  ifNil: [ super handlesTextEditionEvent: anEvent ]
+]
+
+{ #category : #'event handling' }
+RubScrolledTextMorph >> handlesTextInputEvent: anEvent [
+
+	^ self scrollPane
+		  ifNotNil: [ :pane | pane handlesTextInputEvent: anEvent ]
+		  ifNil: [ super handlesTextInputEvent: anEvent ]
+]
+
 { #category : #'model protocol' }
 RubScrolledTextMorph >> hasEditingConflicts [
 	^ hasEditingConflicts
@@ -1075,6 +1091,13 @@ RubScrolledTextMorph >> textColor: aColor [
 	self textArea textColor: aColor
 ]
 
+{ #category : #'event handling' }
+RubScrolledTextMorph >> textEdition: aTextEditionEvent [
+
+	self scrollPane ifNotNil: [ :scrollpane | 
+		scrollpane textEdition: aTextEditionEvent ]
+]
+
 { #category : #accessing }
 RubScrolledTextMorph >> textFont [
 	"We should clean"
@@ -1085,6 +1108,13 @@ RubScrolledTextMorph >> textFont [
 { #category : #accessing }
 RubScrolledTextMorph >> textFont: aFont [
 	self textArea font: aFont
+]
+
+{ #category : #'event handling' }
+RubScrolledTextMorph >> textInput: aTextInputEvent [
+
+	self scrollPane ifNotNil: [ :scrollpane | 
+		scrollpane textInput: aTextInputEvent ]
 ]
 
 { #category : #accessing }

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -654,6 +654,7 @@ RubTextEditor >> cursorLeft: aKeyboardEvent [
 	selecting or extending current selection. Don't allow cursor past 
 	beginning of text"
 
+	textArea editing ifTrue: [ ^ false ].
 	self closeTypeIn.
 	self
 		moveCursor:[:position | position - 1 max: 1]
@@ -702,6 +703,7 @@ RubTextEditor >> cursorRight: aKeyboardEvent [
 	start selecting characters or extending already selected characters. 
 	Don't allow cursor past end of text"
 
+	textArea editing ifTrue: [ ^ false ].
 	self closeTypeIn.
 	self
 		moveCursor: [:position | position + 1]
@@ -1547,7 +1549,11 @@ RubTextEditor >> moveCursor: directionBlock forward: forward specialBlock: speci
 	shift
 		ifTrue: [self selectMark: (indices at: #fixed) point: newPosition - 1]
 		ifFalse: [self selectAt: newPosition].
-	self setEmphasisHereFromTextForward: forward
+	self setEmphasisHereFromTextForward: forward.
+
+	textArea
+		requestTextEditingAt: (textArea cursor positionInWorld
+			corner: textArea cursor positionInWorld).
 ]
 
 { #category : #nesting }


### PR DESCRIPTION
This PR provides support for IM-related support for SDL2 library, and solves https://github.com/pharo-project/pharo/issues/8661 .

Some natural languages needs a support agent so-called IM to input letters/symbols including emojis.
IMs are most often provided by OSs and Desktop environments, including macOS, Linux desktops and Windows platforms.
IM accepts keyboard inputs and offers candidate letters/symbols/strings so that the user can choose what should be poured into a text widget.

SDL2 provides a generic API to support IMs.
An SDL2 application should respond to two events: TextEditing and TextInput.
TextEditing is triggered when the user is choosing from candidate strings, and TextInput is triggered when the choice is done.

This PR is to define the events at different layers of frameworks (SDL and morphic) and implements handlers for them.