### PR TITLE
Symbol-intern-blankIconOfWidth

### DIFF
--- a/src/Polymorph-Widgets/ThemeIcons.class.st
+++ b/src/Polymorph-Widgets/ThemeIcons.class.st
@@ -229,6 +229,17 @@ ThemeIcons >> blankIcon [
 
 { #category : #utilities }
 ThemeIcons >> blankIconOfWidth: aNumber [ 
+
+	"We hard-code the most used cases to avoid symbol creation"
+
+	aNumber == 16 ifTrue: [ ^ self icons
+		at: #blank16
+		ifAbsentPut: [Form extent: 16 @ 1 depth: 8] ].
+	
+	aNumber == 10 ifTrue: [ ^ self icons
+		at: #blank10
+		ifAbsentPut: [Form extent: 10 @ 1 depth: 8] ].
+
 	^ self icons
 		at: ('blank-' , aNumber asString) asSymbol
 		ifAbsentPut: [Form extent: aNumber @ 1 depth: 8]


### PR DESCRIPTION
when logging #asSymbol on String, we see calls from #blankIconOfWidth:  when using the menues.

This PR hard-codes the cases used in practice, avoiding Symbol interning