### PR TITLE
FastTable: context menu not activated on empty tables

### DIFF
--- a/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
@@ -734,6 +734,8 @@ FTTableMorph >> mouseDown: event [
 
 	needToggleAtMouseUp ifTrue: [ ^ self ].
 
+	event yellowButtonPressed ifTrue: [ ^ self click: event ].
+
 	(self selectionModeStrategy selectableIndexContainingPoint: event cursorPoint)
 		ifNotNil: [ :index | 
 			(self selectedIndexes includes: index)


### PR DESCRIPTION
Fix #11388