### PR TITLE
OpalCompiler-Simplify-interactive

### DIFF
--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -20,7 +20,6 @@ Class {
 		'noPattern',
 		'class',
 		'logged',
-		'interactive',
 		'compiledMethod',
 		'options',
 		'environment',
@@ -449,12 +448,13 @@ CompilationContext >> initialize [
 
 { #category : #accessing }
 CompilationContext >> interactive [
-	^ interactive ifNil: [ false ]
-]
 
-{ #category : #accessing }
-CompilationContext >> interactive: anObject [
-	interactive := anObject
+	requestor ifNil: [ ^ false ].
+	"we asume requestors are interactive, but they can override.
+	this should be simplified "
+	^ (requestor respondsTo: #interactive)
+		  ifTrue: [ requestor interactive ]
+		  ifFalse: [ true ]
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OCStoreIntoReadOnlyVariableError.class.st
+++ b/src/OpalCompiler-Core/OCStoreIntoReadOnlyVariableError.class.st
@@ -20,10 +20,3 @@ OCStoreIntoReadOnlyVariableError >> description [
 			stream cr.
 			stream << self methodNode asString ]
 ]
-
-{ #category : #signaling }
-OCStoreIntoReadOnlyVariableError >> signal [
-	compilationContext interactive
-		ifFalse: [ ^ SystemNotification signal: self asString ].
-	^ super signal
-]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -400,17 +400,7 @@ OpalCompiler >> getSourceFromRequestorSelection [
 
 { #category : #testing }
 OpalCompiler >> isInteractive [
-	^self isInteractiveFor: compilationContext requestor
-]
-
-{ #category : #private }
-OpalCompiler >> isInteractiveFor: aRequestor [
-	"the requester can override if the compiler is interactive or not"
-	aRequestor ifNil: [^ false ].
-	
-	^ (aRequestor respondsTo: #interactive)
-		ifTrue: [ aRequestor interactive ]
-		ifFalse: [ true ]
+	^ compilationContext interactive
 ]
 
 { #category : #private }
@@ -513,8 +503,7 @@ OpalCompiler >> receiver: anObject [
 
 { #category : #accessing }
 OpalCompiler >> requestor: aRequestor [
-	self compilationContext requestor: aRequestor.
-	self compilationContext interactive: (self isInteractiveFor: aRequestor).
+	self compilationContext requestor: aRequestor
 ]
 
 { #category : #plugins }

--- a/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
@@ -26,7 +26,6 @@ OCASTTranslatorTest >> compilationContext [
 	context := CompilationContext new
 		encoderClass: self encoder;
 		bindings: globals;
-		interactive: true;
 		yourself.
 	^ context
 ]


### PR DESCRIPTION
The compiler has a lot of odd features as we wanted to be 100% backward compatible.

This PR simplifies the idea of #isInteractive:  if there is no requestor, we are not interactive.

This means we do not need the flag "interactive" on CompilationContext and can simplify.

For now we keep the odd feature that requestors can implmement #interative and return false, but don no thave to.
(I think we should simpliy that, too)