### PR TITLE
Compiler-Cleanup-OldDoItTransformations 

### DIFF
--- a/src/AST-Core/RBValueNode.class.st
+++ b/src/AST-Core/RBValueNode.class.st
@@ -50,7 +50,7 @@ RBValueNode >> evaluate [
 RBValueNode >> evaluateForContext: aContext [
 	"evaluate the AST taking variables from the context"
 	^(self asDoItForContext: aContext) 
-		generateWithSource valueWithReceiver: aContext receiver arguments: {aContext}.
+		generateWithSource valueWithReceiver: aContext receiver arguments: #().
 ]
 
 { #category : #evaluating }

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -451,7 +451,7 @@ Symbol >> isBinary [
 { #category : #testing }
 Symbol >> isDoIt [
 
-	^ (self == #DoIt) or: [self == #DoItIn:].
+	^ self == #DoIt
 ]
 
 { #category : #testing }

--- a/src/OpalCompiler-Core/OCContextualDoItSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCContextualDoItSemanticScope.class.st
@@ -48,7 +48,7 @@ OCContextualDoItSemanticScope >> asDoItScopeForReceiver: anObject [
 { #category : #'code evaluation' }
 OCContextualDoItSemanticScope >> evaluateDoIt: doItMethod [
 
-	^targetContext receiver withArgs: { targetContext } executeMethod: doItMethod
+	^targetContext receiver withArgs: #() executeMethod: doItMethod
 ]
 
 { #category : #testing }

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -139,13 +139,6 @@ RBMethodNode >> methodPropertyAt: aKey put: anObject [
 ]
 
 { #category : #'*OpalCompiler-Core' }
-RBMethodNode >> notShadowedTemporaryNamesFrom: aContext [
-	| ownVariableNames |
-	ownVariableNames := self allDefinedVariables collect: [ :var | var asString ].
-	^ aContext tempNames difference: ownVariableNames
-]
-
-{ #category : #'*OpalCompiler-Core' }
 RBMethodNode >> owningScope [
 	^ self scope
 ]
@@ -156,23 +149,6 @@ RBMethodNode >> primitiveFromPragma [
 		detect: [ :each | each isPrimitive ]
 		ifFound: [ :aPragmaPrimitive | aPragmaPrimitive asIRPrimitive ]
 		ifNone: [ IRPrimitive null ]
-]
-
-{ #category : #'*OpalCompiler-Core' }
-RBMethodNode >> rewriteTempsForContext: aContext [
-	| rewriter contextOnlyTemps |
-	rewriter := RBParseTreeRewriter new.
-	contextOnlyTemps := self notShadowedTemporaryNamesFrom: aContext.
-	aContext tempNames do:
-			[ :tempName | 
-			(contextOnlyTemps includes: tempName)
-				ifTrue:
-					[ rewriter
-						replace: tempName , ' := ``@object' with: 'ThisContext writeVariableNamed: ', tempName asString printString  , ' value: ``@object';
-						replace: tempName with: 'ThisContext readVariableNamed: ' , tempName asString printString ] ].
-	^ rewriter
-		executeTree: self;
-		tree
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Core/RBProgramNode.extension.st
+++ b/src/OpalCompiler-Core/RBProgramNode.extension.st
@@ -3,15 +3,9 @@ Extension { #name : #RBProgramNode }
 { #category : #'*OpalCompiler-Core' }
 RBProgramNode >> asDoItForContext: aContext [
 	"The VM can only evaluate methods. wrap this ast in a doitIn MethodNode to evaluate in a context"
-	| methodNode |
-	
-	methodNode := RBMethodNode 
-		selector: #DoItIn:
-		arguments: { RBVariableNode named: 'ThisContext' } 
-		body: self asSequenceNode transformLastToReturn.
-	
+	|methodNode|
+	methodNode := self asDoit.	
 	methodNode semanticScope: (OCContextualDoItSemanticScope targetingContext: aContext).
-	methodNode source: methodNode formattedCode.
 	^methodNode
 ]
 

--- a/src/OpalCompiler-Core/RBProgramNode.extension.st
+++ b/src/OpalCompiler-Core/RBProgramNode.extension.st
@@ -28,22 +28,6 @@ RBProgramNode >> asDoit [
 ]
 
 { #category : #'*OpalCompiler-Core' }
-RBProgramNode >> asReflectiveDoItForContext: aContext [
-	"The VM can only evaluate methods. wrap this ast in a doitIn MethodNode to evaluate in a context"
-	| methodNode |
-	
-	methodNode := RBMethodNode 
-		selector: #DoItIn:
-		arguments: { RBVariableNode named: 'ThisContext' } 
-		body: self asSequenceNode transformLastToReturn.
-	
-	methodNode methodClass: aContext receiver class.
-	methodNode rewriteTempsForContext: aContext.
-	methodNode source: methodNode formattedCode.
-	^methodNode
-]
-
-{ #category : #'*OpalCompiler-Core' }
 RBProgramNode >> asSequenceNode [
 	^RBSequenceNode statements: {self}
 ]

--- a/src/OpalCompiler-Tests/OCDoitTest.class.st
+++ b/src/OpalCompiler-Tests/OCDoitTest.class.st
@@ -50,7 +50,7 @@ OCDoitTest >> testDoItContextReadIvar [
 		          context: thisContext;
 		          compile.
 
-	value := method valueWithReceiver: self arguments: { thisContext }.
+	value := method valueWithReceiver: self arguments: #().
 	self assert: value equals: #someValue
 ]
 

--- a/src/Slot-Tests/DoItVariableTest.class.st
+++ b/src/Slot-Tests/DoItVariableTest.class.st
@@ -49,7 +49,7 @@ DoItVariableTest >> testDoItCompilation [
 		noPattern: true;
 		bindings: { var };
 		compile.
-	self assert: (doIt valueWithReceiver: self arguments: {thisContext}) equals: 102
+	self assert: (doIt valueWithReceiver: self arguments: #()) equals: 102
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Due to using DoItVariable, we do not need to transform temp read in #DoItIn: methods anymore to use the transformation of variable read and write  (#readVariableNamed: and write)

This PR just deletes the unused code