### PR TITLE
Compiler small cleanups after DoItIn: cleanup

### DIFF
--- a/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
+++ b/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
@@ -345,7 +345,7 @@ IRBytecodeGenerator >> initialize [
 	self label: self newDummySeqId
 ]
 
-{ #category : #initialize }
+{ #category : #initialization }
 IRBytecodeGenerator >> irPrimitive: anIrPrimitive [
 	literals isEmpty ifFalse: [self error: 'init prim before adding instructions'].
 	anIrPrimitive spec ifNotNil: [literals add: anIrPrimitive spec].

--- a/src/OpalCompiler-Core/IRTranslator.class.st
+++ b/src/OpalCompiler-Core/IRTranslator.class.st
@@ -148,7 +148,7 @@ IRTranslator >> visitMethod: anIr [
 	gen forceLongForm: anIr forceLongForm.
 	self visitSequences: anIr allSequences.
 	"Literals for sends and pushLiteral: are added later, here we
-	add all the additionalLiterals from e.g. optimized contructs like #ifTrue:.
+	add all the additionalLiterals from e.g. optimized constructs like #ifTrue:.
 	that have been added with #addLiteral:.
 	With the new bytecode set we have no constraints and can just add all of them."
 	anIr additionalLiterals do: [ :each | gen addLiteral: each ]

--- a/src/OpalCompiler-Core/IRTranslator.class.st
+++ b/src/OpalCompiler-Core/IRTranslator.class.st
@@ -104,7 +104,7 @@ IRTranslator >> pushScope: anIRBlockOrMethod [
 	currentScope push: anIRBlockOrMethod
 ]
 
-{ #category : #initialize }
+{ #category : #accessing }
 IRTranslator >> trailer: aTrailer [
 
 	trailer := aTrailer
@@ -147,7 +147,10 @@ IRTranslator >> visitMethod: anIr [
 	gen numTemps: (anIr tempMap size).
 	gen forceLongForm: anIr forceLongForm.
 	self visitSequences: anIr allSequences.
-	"we can just add the additional literals as normal literls with the new bytecode set"
+	"Literals for sends and pushLiteral: are added later, here we
+	add all the additionalLiterals from e.g. optimized contructs like #ifTrue:.
+	that have been added with #addLiteral:.
+	With the new bytecode set we have no constraints and can just add all of them."
 	anIr additionalLiterals do: [ :each | gen addLiteral: each ]
 ]
 

--- a/src/OpalCompiler-Core/OCContextualDoItSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCContextualDoItSemanticScope.class.st
@@ -45,12 +45,6 @@ OCContextualDoItSemanticScope >> asDoItScopeForReceiver: anObject [
 	^self
 ]
 
-{ #category : #'code evaluation' }
-OCContextualDoItSemanticScope >> evaluateDoIt: doItMethod [
-
-	^targetContext receiver withArgs: #() executeMethod: doItMethod
-]
-
 { #category : #testing }
 OCContextualDoItSemanticScope >> hasBindingThatBeginsWith: aString [
 	
@@ -93,6 +87,11 @@ OCContextualDoItSemanticScope >> lookupVar: name declare: aBoolean [
 	(targetContext lookupVar: name declare: aBoolean) ifNotNil: [ :v | ^self importVariable: v].
 
 	^super lookupVar: name declare: aBoolean
+]
+
+{ #category : #accessing }
+OCContextualDoItSemanticScope >> receiver [
+	^targetContext receiver
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OCDoItSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCDoItSemanticScope.class.st
@@ -32,7 +32,8 @@ OCDoItSemanticScope >> compileMethodFromASTBy: aCompiler [
 
 { #category : #'code evaluation' }
 OCDoItSemanticScope >> evaluateDoIt: doItMethod [
-	self subclassResponsibility 
+
+	^self receiver withArgs: #() executeMethod: doItMethod
 ]
 
 { #category : #testing }
@@ -43,6 +44,11 @@ OCDoItSemanticScope >> isDoItScope [
 { #category : #parsing }
 OCDoItSemanticScope >> parseASTBy: aParser [
 	^aParser parseExpression
+]
+
+{ #category : #accessing }
+OCDoItSemanticScope >> receiver [
+	^ self subclassResponsibility
 ]
 
 { #category : #'code compilation' }

--- a/src/OpalCompiler-Core/OCReceiverDoItSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCReceiverDoItSemanticScope.class.st
@@ -32,12 +32,6 @@ OCReceiverDoItSemanticScope class >> targetingReceiver: anObject [
 		targetReceiver: anObject
 ]
 
-{ #category : #'code evaluation' }
-OCReceiverDoItSemanticScope >> evaluateDoIt: doItMethod [
-
-	^targetReceiver withArgs: #() executeMethod: doItMethod
-]
-
 { #category : #accessing }
 OCReceiverDoItSemanticScope >> receiver [
 

--- a/src/OpalCompiler-Core/RBProgramNode.extension.st
+++ b/src/OpalCompiler-Core/RBProgramNode.extension.st
@@ -3,10 +3,9 @@ Extension { #name : #RBProgramNode }
 { #category : #'*OpalCompiler-Core' }
 RBProgramNode >> asDoItForContext: aContext [
 	"The VM can only evaluate methods. wrap this ast in a doitIn MethodNode to evaluate in a context"
-	|methodNode|
-	methodNode := self asDoit.	
-	methodNode semanticScope: (OCContextualDoItSemanticScope targetingContext: aContext).
-	^methodNode
+
+	^ self asDoit semanticScope:
+		  (OCContextualDoItSemanticScope targetingContext: aContext)
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Core/SyntaxErrorNotification.class.st
+++ b/src/OpalCompiler-Core/SyntaxErrorNotification.class.st
@@ -12,14 +12,12 @@ Class {
 
 { #category : #exceptionInstantiator }
 SyntaxErrorNotification class >> inClass: aClass withCode: codeString doitFlag: doitFlag errorMessage: errorString location: location [
-	| sourceCode |
-	sourceCode := (self new
+	^ (self new
 		setClass: aClass
 		code: codeString
 		doitFlag: doitFlag
 		errorMessage: errorString
-		location: location) signal.
-	^sourceCode ifNil: [ self error: 'source nil, should not happen' ].
+		location: location) signal
 ]
 
 { #category : #exceptiondescription }

--- a/src/Shout-Tests/SHRBTextStylerTest.class.st
+++ b/src/Shout-Tests/SHRBTextStylerTest.class.st
@@ -25,7 +25,6 @@ SHRBTextStylerTest >> style: aText [
 		source: aText asString;
 		noPattern: false ;
 		options:  #(+ optionParseErrors + optionSkipSemanticWarnings);
-		requestor: nil;
 		parse.				
 	styler style: aText ast: ast.
 	
@@ -41,7 +40,6 @@ SHRBTextStylerTest >> styleExpression: aText [
 		source: aText asString;
 		noPattern: true ;
 		options:  #(+ optionParseErrors + optionSkipSemanticWarnings);
-		requestor: nil;
 		parse.				
 	styler style: aText ast: ast.
 	


### PR DESCRIPTION
- IRTranslater: document additional literals better
- we can just have one #evaluateDoIt: method now
- simplify asDoItForContext:
- remove some #requestor: nil; (as it is nil by default)