### PR TITLE
Rules-add-missing-group

### DIFF
--- a/src/GeneralRules/ReClassVariableNeitherReadNorWrittenRule.class.st
+++ b/src/GeneralRules/ReClassVariableNeitherReadNorWrittenRule.class.st
@@ -20,6 +20,11 @@ ReClassVariableNeitherReadNorWrittenRule >> check: aClass forCritiquesDo: aCriti
 ]
 
 { #category : #accessing }
+ReClassVariableNeitherReadNorWrittenRule >> group [
+	^ 'Clean Code'
+]
+
+{ #category : #accessing }
 ReClassVariableNeitherReadNorWrittenRule >> name [
 
 	^ 'Class variable not read or not written'

--- a/src/GeneralRules/ReIvarNeitherReadNorWrittenRule.class.st
+++ b/src/GeneralRules/ReIvarNeitherReadNorWrittenRule.class.st
@@ -20,6 +20,11 @@ ReIvarNeitherReadNorWrittenRule >> check: aClass forCritiquesDo: aCriticBlock [
 ]
 
 { #category : #accessing }
+ReIvarNeitherReadNorWrittenRule >> group [
+	^ 'Clean Code'
+]
+
+{ #category : #accessing }
 ReIvarNeitherReadNorWrittenRule >> name [
 
 	^ 'Instance variable not read or not written'

--- a/src/GeneralRules/ReTestCaseShouldNotUseInitializeRule.class.st
+++ b/src/GeneralRules/ReTestCaseShouldNotUseInitializeRule.class.st
@@ -37,6 +37,11 @@ ReTestCaseShouldNotUseInitializeRule >> basicCheck: aClass [
 ]
 
 { #category : #accessing }
+ReTestCaseShouldNotUseInitializeRule >> group [
+	^ 'Clean Code'
+]
+
+{ #category : #accessing }
 ReTestCaseShouldNotUseInitializeRule >> name [
 	
 	^ 'Tests should not use initialize'

--- a/src/Renraku-Tests/RenrakuBaseTestCase.class.st
+++ b/src/Renraku-Tests/RenrakuBaseTestCase.class.st
@@ -22,7 +22,7 @@ RenrakuBaseTestCase class >> isAbstract [
 { #category : #running }
 RenrakuBaseTestCase >> setUp [
 	super setUp.
-	testPackage := (RPackage named: #'Renraku-Nuclear-Site') register.
+	testPackage := (RPackage named: #'RenrakuCreatedForTests') register.
 	self setupScreamerRule.
 ]
 

--- a/src/Renraku/ReClassSideResetMethodProtocolRule.class.st
+++ b/src/Renraku/ReClassSideResetMethodProtocolRule.class.st
@@ -34,6 +34,11 @@ ReClassSideResetMethodProtocolRule >> critiqueFor: aMethod [
 ]
 
 { #category : #accessing }
+ReClassSideResetMethodProtocolRule >> group [
+	^ 'Clean Code'
+]
+
+{ #category : #accessing }
 ReClassSideResetMethodProtocolRule >> name [
 
 	^ 'Class side methods called #reset should be in the ''class initialization'' protocol'


### PR DESCRIPTION
When you use the Code Critique Browser, some roles are shown as having no group. This PR puts them in the 'Clean Code' group