### PR TITLE
reduce-asSymbol-in-tools 

### DIFF
--- a/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserMorph.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserMorph.class.st
@@ -188,7 +188,7 @@ ClyFullBrowserMorph >> buildTitleFromSelections [
 		ifTrue: [ self classSelection lastSelectedItem ]
 		ifFalse: [ self methodSelection lastSelectedItem].
 
-	newTitle := mainItem systemDefinition printDefiningClass.
+	newTitle := mainItem systemDefinition printDefiningClass asString.
 	mainItem systemDefinition isInstanceSide & (metaLevelScope = ClyClassSideScope)
 		ifTrue: [ newTitle := newTitle , ' class' ].
 	self methodSelection isEmpty ifFalse: [ 

--- a/src/Morphic-Base/ShortcutReminder.class.st
+++ b/src/Morphic-Base/ShortcutReminder.class.st
@@ -278,7 +278,14 @@ ShortcutReminder >> positionShortcut: aMorph [
 	fullBounds. 
 	"the layout has to be computed before changing the position."
 	
-	aMorph perform: (position , ':') asSymbol with: (position value: area).
+	"#position: setter makes sure that just these are possible, no need for #perform:"
+	position == #topLeft ifTrue: [^aMorph topLeft: (position value: area) ].
+	position == #topRight  ifTrue: [ ^aMorph topRight: (position value: area) ].
+	position == #center  ifTrue: [ ^aMorph center: (position value: area) ].
+	position == #bottomLeft  ifTrue: [ ^aMorph bottomLeft: (position value: area) ].
+	position == #bottomRight ifTrue: [ ^aMorph bottomRight: (position value: area) ].
+	
+	
 ]
 
 { #category : #private }

--- a/src/Renraku/ReProperMethodProtocolNameForAccessingRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolNameForAccessingRule.class.st
@@ -10,5 +10,5 @@ Class {
 { #category : #idioms }
 ReProperMethodProtocolNameForAccessingRule class >> protocolIdiom [ 
 
-	^self use: 'accessing' insteadOf: #('accessor' 'accessors' 'acessing' 'acccessing' 'accesing' 'acesing')
+	^self use: #accessing insteadOf: #(#'accessor' #'accessors' #'acessing' #'acccessing' #'accesing' #'acesing')
 ]

--- a/src/Renraku/ReProperMethodProtocolNameForAddingRemovingRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolNameForAddingRemovingRule.class.st
@@ -10,5 +10,5 @@ Class {
 { #category : #idioms }
 ReProperMethodProtocolNameForAddingRemovingRule class >> protocolIdiom [
 
-	^self use: 'adding-removing' insteadOf: #('adding/removing')
+	^self use: #'adding-removing' insteadOf: #(#'adding/removing')
 ]

--- a/src/Renraku/ReProperMethodProtocolNameForConvertingRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolNameForConvertingRule.class.st
@@ -10,5 +10,5 @@ Class {
 { #category : #idioms }
 ReProperMethodProtocolNameForConvertingRule class >> protocolIdiom [ 
 
-	^self use: 'converting' insteadOf: #('conversion' 'conversions')
+	^self use: #'converting' insteadOf: #(#'conversion' #'conversions')
 ]

--- a/src/Renraku/ReProperMethodProtocolNameForFileInOutRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolNameForFileInOutRule.class.st
@@ -7,5 +7,5 @@ Class {
 { #category : #idioms }
 ReProperMethodProtocolNameForFileInOutRule class >> protocolIdiom [ 
 
-	^self use: 'file in/out' insteadOf: #('filein/out' 'fileIn/Out' 'fileIn/out' 'filein/Out' 'file-in/out')
+	^self use: #'file in/out' insteadOf: #(#'filein/out' #'fileIn/Out' #'fileIn/out' #'filein/Out' #'file-in/out')
 ]

--- a/src/Renraku/ReProperMethodProtocolNameForInstanceCreationRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolNameForInstanceCreationRule.class.st
@@ -10,5 +10,5 @@ Class {
 { #category : #idioms }
 ReProperMethodProtocolNameForInstanceCreationRule class >> protocolIdiom [ 
 
-	^self use: 'instance creation' insteadOf: #('instance-creation' 'instances-creation' 'instances creation')
+	^self use: #'instance creation' insteadOf: #(#'instance-creation' #'instances-creation' #'instances creation')
 ]

--- a/src/Renraku/ReProperMethodProtocolNameForRemovalRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolNameForRemovalRule.class.st
@@ -7,5 +7,5 @@ Class {
 { #category : #idioms }
 ReProperMethodProtocolNameForRemovalRule class >> protocolIdiom [ 
 
-	^self use: 'removing' insteadOf: #('remove' 'removal')
+	^self use: #'removing' insteadOf: #(#'remove' #'removal')
 ]

--- a/src/Renraku/ReProperMethodProtocolNameForUtilitiesRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolNameForUtilitiesRule.class.st
@@ -10,5 +10,5 @@ Class {
 { #category : #idioms }
 ReProperMethodProtocolNameForUtilitiesRule class >> protocolIdiom [ 
 
-	^self use: 'utilities' insteadOf: #('utils' 'utility')
+	^self use: #'utilities' insteadOf: #(#'utils' #'utility')
 ]

--- a/src/Renraku/ReProperMethodProtocolNameRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolNameRule.class.st
@@ -16,7 +16,7 @@ Class {
 { #category : #'private - accessing' }
 ReProperMethodProtocolNameRule class >> badMethodProtocolNames [
 
-	^self protocolIdiom value collect: [:each | each asSymbol ]
+	^self protocolIdiom value
 ]
 
 { #category : #'testing - interest' }


### PR DESCRIPTION
another trivial change to reduce the need to intern symbols, this time when using the code browser

- convert to string early in buildTitleFromSelections
- ReProperMethodProtocolNameForFileInOutRule should use symbols directly, not convert every time the rule is run