### PR TITLE
Allow creating Pharo methods using the Bytecode IR

### DIFF
--- a/src/AST-Core-Tests/RBMethodNodeTest.class.st
+++ b/src/AST-Core-Tests/RBMethodNodeTest.class.st
@@ -11,6 +11,30 @@ Class {
 RBMethodNodeTest >> methodWithArg: someArgName and: someAnotherArgName [
 ]
 
+{ #category : #helpers }
+RBMethodNodeTest >> sampleBytecodeMethod [
+
+	<opalBytecodeMethod>
+	^ IRBuilder buildIR: [ :builder |
+		builder
+				pushLiteral: 5;
+				returnTop
+		 ].
+]
+
+{ #category : #helpers }
+RBMethodNodeTest >> sampleBytecodeMethodWithArg: anArg [
+
+	<opalBytecodeMethod>
+	^ IRBuilder buildIR: [ :builder |
+		builder
+				numArgs: 1;
+				addTemps: { #arg };
+				pushTemp: #arg;
+				returnTop
+		 ].
+]
+
 { #category : #tests }
 RBMethodNodeTest >> testAddingMethodProperties [
 
@@ -85,6 +109,18 @@ RBMethodNodeTest >> testBlockHeadIsNotEmpty3 [
 		]'.
 
 	self deny: tree body statements first headIsNotEmpty
+]
+
+{ #category : #tests }
+RBMethodNodeTest >> testBytecodeMethodWithArguments [
+
+	self assert: (self sampleBytecodeMethodWithArg: 1) equals: 1
+]
+
+{ #category : #tests }
+RBMethodNodeTest >> testBytecodeMethodWithNoArguments [
+
+	self assert: self sampleBytecodeMethod equals: 5
 ]
 
 { #category : #tests }

--- a/src/AST-Core-Tests/RBParseTreeSearcherTest.class.st
+++ b/src/AST-Core-Tests/RBParseTreeSearcherTest.class.st
@@ -811,20 +811,6 @@ RBParseTreeSearcherTest >> testSearchingOptionKeywordsPartComposedSelector2 [
 	
 ]
 
-{ #category : #tests }
-RBParseTreeSearcherTest >> testWithoutAListDoesNotMatchComposedMessages [
-	"Using `arg, and not `@arg, we looking for multiple lists in one match pattern at the same time. 
-	Lists can be any receiver or args."
-
-	| contextDictionary |
-	searcher
-		matches: '`@receiver assert: `arg equals: true'
-		do: [ :aNode :answer | contextDictionary := searcher context ].
-	searcher executeTree: (self parseExpression:
-			 'self assert: reader storedSettings first realValue equals: true.').
-	self assert: contextDictionary isNil
-]
-
 { #category : #'tests - add search' }
 RBParseTreeSearcherTest >> testSimpleAddSearch [
 
@@ -841,4 +827,18 @@ RBParseTreeSearcherTest >> testSimpleAddSearches [
 	searcher addSearches: { '`@Super << `#ASymbol' -> [ :aNode :anAnswer | res := #class ]}.
 	searcher executeTree: (RBParser parseExpression: ' Object << #Point').
 	self assert: res equals: #class
+]
+
+{ #category : #tests }
+RBParseTreeSearcherTest >> testWithoutAListDoesNotMatchComposedMessages [
+	"Using `arg, and not `@arg, we looking for multiple lists in one match pattern at the same time. 
+	Lists can be any receiver or args."
+
+	| contextDictionary |
+	searcher
+		matches: '`@receiver assert: `arg equals: true'
+		do: [ :aNode :answer | contextDictionary := searcher context ].
+	searcher executeTree: (self parseExpression:
+			 'self assert: reader storedSettings first realValue equals: true.').
+	self assert: contextDictionary isNil
 ]

--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -603,6 +603,12 @@ RBMethodNode >> removePragma: aPragmaNode [
 ]
 
 { #category : #'adding-removing' }
+RBMethodNode >> removePragmaNamed: aPragmaName [
+
+	self pragmaNamed: aPragmaName ifPresent: [ :pragma | self removePragma: pragma ]
+]
+
+{ #category : #'adding-removing' }
 RBMethodNode >> removeSubtree: aTree [
 
 	^ aTree isReturn 

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -67,6 +67,19 @@ RBMethodNode >> generate: trailer [
 RBMethodNode >> generateIR [
 	| ir |
 	scope ifNil: [self doSemanticAnalysis].
+	
+	self pragmaNamed: #opalBytecodeMethod ifPresent: [ :pragma | | copy |
+		"We need to copy the AST node to avoid the recursive `generateIR` call from re-entering this condition"
+		copy := self copy;
+			arguments: #();
+			selector: #irDoIt;
+			yourself.
+		copy removePragmaNamed: pragma selector.
+		ir := copy generateIR compiledMethod valueWithReceiver: nil arguments: #().
+		ir sourceNode: self.
+		^ ir
+	].
+	
  	ir := (self compilationContext astTranslatorClass new
 			visitNode: self)
 			ir.

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -70,12 +70,9 @@ RBMethodNode >> generateIR [
 	
 	self pragmaNamed: #opalBytecodeMethod ifPresent: [ :pragma | | copy |
 		"We need to copy the AST node to avoid the recursive `generateIR` call from re-entering this condition"
-		copy := self copy;
-			arguments: #();
-			selector: #irDoIt;
-			yourself.
+		copy := self copy.
 		copy removePragmaNamed: pragma selector.
-		ir := copy generateIR compiledMethod valueWithReceiver: nil arguments: #().
+		ir := copy generateIR compiledMethod valueWithReceiver: nil arguments: (Array new: copy arguments size).
 		ir sourceNode: self.
 		^ ir
 	].


### PR DESCRIPTION
This PR extends the OpalCompiler to allow defining methods using the bytecode-like IR.