### PR TITLE
enable #optionInlineTimesRepeat and #optionInlineRepeat

### DIFF
--- a/src/Collections-Streams/Stream.class.st
+++ b/src/Collections-Streams/Stream.class.st
@@ -129,7 +129,6 @@ Stream >> next: anInteger [
 
 { #category : #accessing }
 Stream >> next: anInteger put: anObject [ 
-	<compilerOptions: #(+ optionInlineTimesRepeat)>
 	
 	"Make anObject be the next anInteger number of objects accessible by the 
 	receiver. Answer anObject."

--- a/src/Kernel-Tests/CompiledBlockTest.class.st
+++ b/src/Kernel-Tests/CompiledBlockTest.class.st
@@ -13,9 +13,9 @@ CompiledBlockTest >> testLiteralEqual [
 
 	| value |
 	value := 0.
-	10 timesRepeat: [self assert: value equals: 0].
+	(1 to: 10) do: [self assert: value equals: 0].
 	value := 1.
-	10 timesRepeat: [self assert: value equals: 0].'.
+	(1 to: 10) do: [self assert: value equals: 0].'.
 	
 	compiledBlocks := methodToTest literals select: [ :each | each isCompiledBlock ].
 	self assert: compiledBlocks size equals: 2.
@@ -30,9 +30,9 @@ CompiledBlockTest >> testPcInOuter [
 
 	| value |
 	value := 0.
-	10 timesRepeat: [self assert: value equals: 0].
+	(1 to: 10) do: [self assert: value equals: 0].
 	value := 1.
-	10 timesRepeat: [self assert: value equals: 0].'.
+	(1 to: 10) do: [self assert: value equals: 0].'.
 	
 	compiledBlocks := methodToTest literals select: [ :each | each isCompiledBlock ].
 	self assert: compiledBlocks size equals: 2.

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -284,8 +284,8 @@ CompilationContext class >> optionsDescription [
 	(+ optionInlineWhile 				'Inline whileTrue, whileTrue:, whileFalse:, whileFalse if specific conditions are met (See isInlineWhile)')
 	(+ optionInlineToDo 				'Inline to:do:, to:by:do: if specific conditions are met (See isInlineToDo)')
 	(+ optionInlineCase 				'Inline caseOf:, caseOf:otherwise: if specific conditions are met (See isInlineCase)')
-	(- optionInlineTimesRepeat 		'Inline timesRepeat: if specific conditions are met (See isInlineTimesRepeat)')
-	(- optionInlineRepeat 			'Inline repeat if specific conditions are met (See isInlineRepeat)')
+	(+ optionInlineTimesRepeat 		'Inline timesRepeat: if specific conditions are met (See isInlineTimesRepeat)')
+	(+ optionInlineRepeat 			'Inline repeat if specific conditions are met (See isInlineRepeat)')
 	(- optionInlineNone 				'To turn off all inlining options. Overrides the others')
 	
 	(- optionEmbeddSources         'Embedd sources into CompiledMethod instead of storing in .changes')


### PR DESCRIPTION
- I checked the decompiler: it tests already that these methods work decompiled (it decompiled to #timesRepeat decompiles to #to:do:, but that is not possble differently)
- Debugger works, too


Fixes #11169