### PR TITLE
Cleanup-asRingMinimalDefinitionIn-Parent 

### DIFF
--- a/src/Ring-Core/AbstractProtocol.extension.st
+++ b/src/Ring-Core/AbstractProtocol.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #AbstractProtocol }
-
-{ #category : #'*Ring-Core' }
-AbstractProtocol >> asRingMinimalDefinitionIn: anRGEnvironment [
-
-	self error: 'For Protocol you need to use #asRingMinimalDefinitionIn:parent: because parent class cannot be resolved automatically'
-]

--- a/src/Ring-Core/Slot.extension.st
+++ b/src/Ring-Core/Slot.extension.st
@@ -2,15 +2,6 @@ Extension { #name : #Slot }
 
 { #category : #'*Ring-Core' }
 Slot >> asRingMinimalDefinitionIn: anRGEnvironment [
-
-	^ self asRingMinimalDefinitionIn: anRGEnvironment parent: (self definingClass classLayout asRingMinimalDefinitionIn: anRGEnvironment)
-]
-
-{ #category : #'*Ring-Core' }
-Slot >> asRingMinimalDefinitionIn: anRGEnvironment parent: anRGLayout [
-
 	^ anRGEnvironment backend definitionFor: self ifAbsentRegister: [
-		| def |
-		def := RGUnknownSlot named: self name asSymbol parent: anRGLayout.
-		def ].
+		RGUnknownSlot named: self name asSymbol parent: (self definingClass classLayout asRingMinimalDefinitionIn: anRGEnvironment)]
 ]

--- a/src/Ring-TraitsV2Support/TaAliasMethod.extension.st
+++ b/src/Ring-TraitsV2Support/TaAliasMethod.extension.st
@@ -7,9 +7,9 @@ TaAliasMethod >> asRingMinimalDefinitionIn: anRGEnvironment [
 		ifAbsentRegister: [ | definingClass def |
 			definingClass := Smalltalk environment allBehaviors detect: [ :b | b traitComposition transformations includes: self ].
 
-			definingClass traitComposition == self
-				ifTrue: [ def := RGTraitAlias parent: (definingClass asRingMinimalDefinitionIn: anRGEnvironment) ]
-				ifFalse: [ def := RGTraitAlias parent: (definingClass traitComposition asRingMinimalDefinitionIn: anRGEnvironment) ].
+			def := definingClass traitComposition == self
+				ifTrue: [RGTraitAlias parent: (definingClass asRingMinimalDefinitionIn: anRGEnvironment) ]
+				ifFalse: [RGTraitAlias parent: (definingClass traitComposition asRingMinimalDefinitionIn: anRGEnvironment) ].
 
 
 			"we need to set real object because we cannot simply identify the real object from the model data"


### PR DESCRIPTION
Small cleanup:

- remove last method asRingMinimalDefinitionIn:parent:
- remove AbstractProtocol>>#asRingMinimalDefinitionIn: which raises an error (and says to use # asRingMinimalDefinitionIn:parent: which does not exist)