### PR TITLE
fix-tests-commentSourcePointer

### DIFF
--- a/src/Kernel-Tests/BehaviorTest.class.st
+++ b/src/Kernel-Tests/BehaviorTest.class.st
@@ -148,7 +148,7 @@ BehaviorTest >> testIncludesMethod [
 BehaviorTest >> testInstSize [
 	self assert: Object instSize equals: 0.
 	self assert: Point instSize equals: 2.
-	self assert: Metaclass instSize equals: 6
+	self assert: Metaclass instSize equals: 7
 ]
 
 { #category : #tests }

--- a/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
@@ -37,7 +37,7 @@ NoUnusedVariablesLeftTest >> testNoUnusedInstanceVariablesLeft [
 	
 	classes := variables collect: [ :each | each definingClass ] as: Set.
 	
-	validExceptions := { RBFooLintRuleTestData . RBLintRuleTestData .RBFooDummyLintRuleTest . RBDummyLintRuleTest. MockWithComplexSlot}.	
+	validExceptions := { RBFooLintRuleTestData . RBLintRuleTestData .RBFooDummyLintRuleTest . RBDummyLintRuleTest. MockWithComplexSlot .ClassDescription }.	
 	
 	remaining := classes asOrderedCollection removeAll: validExceptions; yourself.
 	self assert: remaining isEmpty description: ('the following classes have unused instance variables and should be cleaned: ', remaining asString)


### PR DESCRIPTION
fix two failing tests after add class comment pointer to ass description.

After we use it, we will remove the validExcpetion from testNoUnusedInstanceVariablesLeft