### PR TITLE
fix ShiftClassInstaller that fails to migrate some objects

### DIFF
--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -77,7 +77,7 @@ ShiftClassInstaller >> copyObject: oldObject to: newClass [
 	| newObject hiddenSlots |
 	
 	newObject := (newClass isVariable and: [oldClass isVariable])
-		ifTrue: [ newClass basicNew: oldObject size ]
+		ifTrue: [ newClass basicNew: oldObject basicSize ]
 		ifFalse: [ newClass basicNew ].
 
 	"first initialize all hidden slots"


### PR DESCRIPTION
The following expression fails because the ShiftClassInstaller>>copyObject:to: measures the indexed variable size by `size` which should be `basicSize`.
```
ShiftClassInstaller new 
    oldClass: MethodDictionary;  
    copyObject: (MethodDictionary new: 3) to: MethodDictionary
```