### PR TITLE
[Test] Remove download of V6 sources

### DIFF
--- a/bootstrap/scripts/2-download.sh
+++ b/bootstrap/scripts/2-download.sh
@@ -35,11 +35,6 @@ if [ ! -e "${BOOTSTRAP_DOWNLOADS}/bootstrapImage.zip" ]; then
 	download_to https://github.com/guillep/PharoBootstrap/releases/download/v1.7.8/bootstrapImage.zip ${BOOTSTRAP_DOWNLOADS}/bootstrapImage.zip
 fi 
 
-# checking for PharoV60.sources
-if [ ! -e "${BOOTSTRAP_DOWNLOADS}/PharoV60.sources.zip" ]; then
-	download_to http://files.pharo.org/sources/PharoV60.sources.zip ${BOOTSTRAP_DOWNLOADS}/PharoV60.sources.zip
-fi
-
 # checking for icons
 # update the commit hash as soon as you need a new version of the icons to be loaded
 if [ ! -e "${BOOTSTRAP_DOWNLOADS}/idea11.zip" ]; then
@@ -53,11 +48,6 @@ fi
 # bootstrap image
 if [ ! -e "./Pharo.image" ]; then
 	unzip -u ${BOOTSTRAP_DOWNLOADS}/bootstrapImage.zip -d .
-fi
-
-# PharoV6 sources
-if [ ! -e "${BOOTSTRAP_CACHE}/PharoV60.sources" ]; then
-	unzip -u ${BOOTSTRAP_DOWNLOADS}/PharoV60.sources.zip -d ${BOOTSTRAP_CACHE}
 fi
 
 # Icons


### PR DESCRIPTION
Bootstrap should not need V6 sources anymore?