### PR TITLE
Add an "exit condition" to the UI loop to allow a former UI process t…

### DIFF
--- a/src/Debugger-Oups/OupsDebuggerSystem.class.st
+++ b/src/Debugger-Oups/OupsDebuggerSystem.class.st
@@ -137,11 +137,9 @@ OupsDebuggerSystem >> spawnNewUIProcess [
 { #category : 'helpers' }
 OupsDebuggerSystem >> spawnNewUIProcessIfNecessary: aDebugRequest [
 
-	"If aDebugRequest is about debugging the UI process, we must create a new UI process to take its place. Because the debugged process will be suspended at some point, and suspending the UI process means freezing the UI of the image; similarly if the UI is currently blocked, create a new UI and let the blocked UI finish its last cycle only."
+	"If aDebugRequest is about debugging the UI process, we must create a new UI process to take its place. Because the debugged process will be suspended at some point, and suspending the UI process means freezing the UI of the image; for simplicity, in case of any debug request create a new UI and let the currently active UI finish its last cycle only."
 
-	(aDebugRequest debugSession isAboutUIProcess or: [
-		self defaultUIManager uiProcess isBlocked]) ifTrue: [ 
-			self spawnNewUIProcess ]
+	self spawnNewUIProcess
 ]
 
 { #category : 'helpers' }

--- a/src/Debugger-Oups/OupsDebuggerSystem.class.st
+++ b/src/Debugger-Oups/OupsDebuggerSystem.class.st
@@ -137,10 +137,11 @@ OupsDebuggerSystem >> spawnNewUIProcess [
 { #category : 'helpers' }
 OupsDebuggerSystem >> spawnNewUIProcessIfNecessary: aDebugRequest [
 
-	"If aDebugRequest is about debugging the UI process, we must create a new UI process to take its place. Because the debugged process will be suspended at some point, and suspending the UI process means freezing the UI of the image"
+	"If aDebugRequest is about debugging the UI process, we must create a new UI process to take its place. Because the debugged process will be suspended at some point, and suspending the UI process means freezing the UI of the image; similarly if the UI is currently blocked, create a new UI and let the blocked UI finish its last cycle only."
 
-	aDebugRequest debugSession isAboutUIProcess ifTrue: [
-		self spawnNewUIProcess ]
+	(aDebugRequest debugSession isAboutUIProcess or: [
+		self defaultUIManager uiProcess isBlocked]) ifTrue: [ 
+			self spawnNewUIProcess ]
 ]
 
 { #category : 'helpers' }

--- a/src/Kernel-Extended-Tests/ProcessTest.class.st
+++ b/src/Kernel-Extended-Tests/ProcessTest.class.st
@@ -40,6 +40,35 @@ ProcessTest >> testActiveProcessFromProcesorShouldUseInstalledEffectiveProcess [
 ]
 
 { #category : 'tests' }
+ProcessTest >> testBlockedProcessState [
+
+	| semaphore mutex p |
+	semaphore := Semaphore new.
+	self deny: Processor activeProcess isBlocked.
+	self deny: ([Processor activeProcess suspend] forkAt: Processor activePriority + 1) isBlocked.
+	self deny: ([Processor activeProcess terminate] forkAt: Processor activePriority + 1) isBlocked.
+	self deny: ([semaphore wait] forkAt: Processor activePriority) isBlocked.
+	self deny: (([semaphore wait] forkAt: Processor activePriority) suspend; yourself) isBlocked.
+	self deny: (([semaphore wait] forkAt: Processor activePriority) suspend; resume) isBlocked.
+	self deny: ([semaphore wait] forkAt: Processor activePriority) terminate isBlocked.
+	self assert: ([semaphore wait] forkAt: Processor activePriority + 1) isBlocked.
+	self assert: ([semaphore wait] forkAt: Processor activePriority + 1) suspendingList == semaphore.
+	self deny: (([semaphore wait] forkAt: Processor activePriority + 1) suspend; yourself) isBlocked.
+	self deny: (([semaphore wait] forkAt: Processor activePriority + 1) suspend; resume) isBlocked.
+	self deny: ([semaphore wait] forkAt: Processor activePriority + 1) terminate isBlocked.
+
+	mutex := Mutex new.
+	[mutex critical: [semaphore wait]] forkAt: Processor activePriority + 1.
+	p := [mutex critical: []] forkAt: Processor activePriority + 1.
+	self assert: p isBlocked.
+	self assert: p suspendingList == (mutex instVarNamed: #semaphore).
+	
+	"tear down"
+	[semaphore isEmpty] whileFalse: [semaphore signal]
+
+]
+
+{ #category : 'tests' }
 ProcessTest >> testChangingOtherPriorityAffectsScheduling [
 
 	| val sem proc1 proc2 |

--- a/src/Kernel/Process.class.st
+++ b/src/Kernel/Process.class.st
@@ -366,7 +366,7 @@ Process >> isBlocked [
 	^false
 ]
 
-{ #category : 'testing'. }
+{ #category : 'testing' }
 Process >> isSuspended [
 	"A #suspended process will not run until sent #resume. New processes
 	start in this state (though the #fork family sends #resume internally),

--- a/src/Kernel/Process.class.st
+++ b/src/Kernel/Process.class.st
@@ -359,10 +359,11 @@ Process >> isReady [
 
 { #category : 'testing' }
 Process >> isBlocked [
-	"Answer true if blocked on a semaphore."
-	self isActiveProcess ifTrue: [ ^false ].
-	self isTerminated ifTrue: [ ^false ].
-	^myList class == Semaphore
+	"Answer true if blocked on a condition variable.
+	A process is blocked if it is waiting on some list
+	(e.g. a Semaphore), other than the runnable process lists."
+	myList ifNotNil: [ :list | ^list class ~~ ProcessList ].
+	^false
 ]
 
 { #category : 'testing'. }

--- a/src/Kernel/Process.class.st
+++ b/src/Kernel/Process.class.st
@@ -358,6 +358,14 @@ Process >> isReady [
 ]
 
 { #category : 'testing' }
+Process >> isBlocked [
+	"Answer true if blocked on a semaphore."
+	self isActiveProcess ifTrue: [ ^false ].
+	self isTerminated ifTrue: [ ^false ].
+	^myList class == Semaphore
+]
+
+{ #category : 'testing'. }
 Process >> isSuspended [
 	"A #suspended process will not run until sent #resume. New processes
 	start in this state (though the #fork family sends #resume internally),

--- a/src/Polymorph-Widgets/MorphicUIManager.class.st
+++ b/src/Polymorph-Widgets/MorphicUIManager.class.st
@@ -600,7 +600,7 @@ MorphicUIManager >> showWaitCursorWhile: aBlock [
 MorphicUIManager >> spawnNewProcess [
 
 	UIProcess := [
-		MorphicRenderLoop new doOneCycleWhile: [ self uiProcess isActiveProcess ]
+		MorphicRenderLoop new doOneCycleWhile: [ self uiProcess isActive ]
 	] newProcess priority: Processor userSchedulingPriority.
 	UIProcess name: 'Morphic UI Process'.
 	UIProcess resume

--- a/src/Polymorph-Widgets/MorphicUIManager.class.st
+++ b/src/Polymorph-Widgets/MorphicUIManager.class.st
@@ -599,11 +599,13 @@ MorphicUIManager >> showWaitCursorWhile: aBlock [
 { #category : 'ui process' }
 MorphicUIManager >> spawnNewProcess [
 
-	UIProcess := [
-		MorphicRenderLoop new doOneCycleWhile: [ self uiProcess isActive ]
+	| newUIProcess |
+	newUIProcess := [
+		MorphicRenderLoop new doOneCycleWhile: [ newUIProcess isActive ]
 	] newProcess priority: Processor userSchedulingPriority.
-	UIProcess name: 'Morphic UI Process'.
-	UIProcess resume
+	newUIProcess name: 'Morphic UI Process'.
+	UIProcess := newUIProcess.
+	newUIProcess resume
 ]
 
 { #category : 'ui process' }

--- a/src/Polymorph-Widgets/MorphicUIManager.class.st
+++ b/src/Polymorph-Widgets/MorphicUIManager.class.st
@@ -600,7 +600,7 @@ MorphicUIManager >> showWaitCursorWhile: aBlock [
 MorphicUIManager >> spawnNewProcess [
 
 	UIProcess := [
-		MorphicRenderLoop new doOneCycleWhile: [ UIManager default uiProcess isActiveProcess ]
+		MorphicRenderLoop new doOneCycleWhile: [ self uiProcess isActiveProcess ]
 	] newProcess priority: Processor userSchedulingPriority.
 	UIProcess name: 'Morphic UI Process'.
 	UIProcess resume

--- a/src/Polymorph-Widgets/MorphicUIManager.class.st
+++ b/src/Polymorph-Widgets/MorphicUIManager.class.st
@@ -599,11 +599,11 @@ MorphicUIManager >> showWaitCursorWhile: aBlock [
 { #category : 'ui process' }
 MorphicUIManager >> spawnNewProcess [
 
-	UIProcess := [ MorphicRenderLoop new doOneCycleWhile: [ true ] ] newProcess priority:
-		             Processor userSchedulingPriority.
-	UIProcess
-		name: 'Morphic UI Process';
-		resume
+	UIProcess := [
+		MorphicRenderLoop new doOneCycleWhile: [ UIManager default uiProcess isActiveProcess ]
+	] newProcess priority: Processor userSchedulingPriority.
+	UIProcess name: 'Morphic UI Process'.
+	UIProcess resume
 ]
 
 { #category : 'ui process' }


### PR DESCRIPTION
…o finish its last cycle and terminate automatically when replaced by a new UI. This change could allow UI processes blocked on custom semaphores to continue waiting for a signal and finish their previous job before terminating automatically. Useful for keeping the UI responsive during evaluation of examples like this:

s := Semaphore new.
[1/0. s signal] fork.
s wait

This is a first approxiamation of the solution and may require some polishing :)