### PR TITLE
Remove extra statement separator (dot)

### DIFF
--- a/src/FileSystem-Disk/WindowsStore.class.st
+++ b/src/FileSystem-Disk/WindowsStore.class.st
@@ -22,7 +22,7 @@ WindowsStore class >> isCaseSensitive [
 
 { #category : #accessing }
 WindowsStore class >> maxFileNameLength [
-	self flag: #pharoTodo. "More tests needed here!".
+	self flag: #pharoTodo. "More tests needed here!"
 	^ 255
 ]
 


### PR DESCRIPTION
While the extra dot is allowed by the compiler it is unnecessary and makes porting code to other dialects more difficult.