### PR TITLE
Revert "9828-Inspector-columns-cannot-be-resized "

### DIFF
--- a/src/Morphic-Widgets-FastTable/FTColumnResizerMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTColumnResizerMorph.class.st
@@ -178,7 +178,7 @@ FTColumnResizerMorph >> updateFromEvent: anEvent [
 	(delta < 0 and: [ delta negated > (leftColumn width - (self width) - 5) ])
 		ifTrue: [ delta := (leftColumn width - (self width) - 5) negated ].
 
-	leftColumn column model width: (leftColumn column width ifNil: [ leftColumn width ]) + delta.
-	rightColumn column model width: (rightColumn column width ifNil: [ rightColumn width ]) - delta.	
+	leftColumn column width: (leftColumn column width ifNil: [ leftColumn width ]) + delta.
+	rightColumn column width: (rightColumn column width ifNil: [ rightColumn width ]) - delta.	
 	container changed
 ]


### PR DESCRIPTION
Reverts pharo-project/pharo#11262

as I explained there, this change is not good because 
a) not all FTTableMorph columns have a model, and 
b) not all columns are resizable

this change will introduce a problem on users of the morph without using spec.