### PR TITLE
DoIts without method header and reformatting

### DIFF
--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -1597,14 +1597,18 @@ RBParserTest >> testPragmaImplicitLiteralArrayIsInvalid [
 	self shouldnt: [self parserClass parseMethod: pragmaWithStringAsArgument] raise: SyntaxErrorNotification.
 ]
 
-{ #category : #'error testing' }
-RBParserTest >> testPragmaInExpressionRaiseError [
+{ #category : #tests }
+RBParserTest >> testPragmaInExpression [
 	"Test if a working pragma in a method is faulty in an expression."
-	self should: [(self parserClass parseExpression: '| token | <some: #tag> true')] 
-		  raise: SyntaxErrorNotification.
-		
-	self shouldnt: [(self parserClass parseExpression: '| token | true')] 
-		  raise: SyntaxErrorNotification.
+	| node |
+	node := self parserClass parseExpression: '| token | <some: #tag> true'.
+	self assert: (node methodNode hasPragmaNamed: #some:).
+	
+	node := self parserClass parseExpression: '<some: #tag> true'.
+	self assert: (node methodNode hasPragmaNamed: #some:).
+	
+	self should: [(self parserClass parseExpression: '| token | 1+2. <some: #tag> true')] 
+		  raise: SyntaxErrorNotification
 ]
 
 { #category : #'error testing' }

--- a/src/AST-Core-Tests/RBProgramNodeTest.class.st
+++ b/src/AST-Core-Tests/RBProgramNodeTest.class.st
@@ -151,14 +151,19 @@ RBProgramNodeTest >> testAddNodesFirst [
 
 { #category : #'tests - adding' }
 RBProgramNodeTest >> testAddReturn [
-	| tree return |
+	| tree return existingReturn lastStatement |
 	tree := self parseExpression: '1. 2'.
+	lastStatement := tree statements last.
 	return := tree addReturn.
+	self assert: return start equals: lastStatement start.
+	self assert: return value equals: lastStatement.
 	self assert: tree statements last equals: return.
 	self assert: (self parseExpression: '1. ^ 2') equals: tree.
 	
 	tree := self parseExpression: '3. ^ 4'.
+	existingReturn := tree statements last.
 	return := tree addReturn.
+	self assert: return identicalTo: existingReturn.
 	self assert: tree statements last equals: return.
 	self assert: (self parseExpression: '3. ^ 4') equals: tree
 ]

--- a/src/AST-Core/ASTCacheMissStrategy.class.st
+++ b/src/AST-Core/ASTCacheMissStrategy.class.st
@@ -16,5 +16,5 @@ Class {
 
 { #category : #accessing }
 ASTCacheMissStrategy >> getASTFor: aCompiledMethod [
-	^ aCompiledMethod parseTree doSemanticAnalysisIn: aCompiledMethod methodClass
+	^ aCompiledMethod parseTree
 ]

--- a/src/AST-Core/CompiledMethod.extension.st
+++ b/src/AST-Core/CompiledMethod.extension.st
@@ -27,6 +27,7 @@ CompiledMethod >> parseTree [
 	ast := self methodClass compiler 
 		source: self sourceCode;
 		failBlock: [^ self decompile ];
+		class: self methodClass;
 		parse.
 	ast compilationContext compiledMethod: self.
 	^ast

--- a/src/AST-Core/RBDoItMethodNode.class.st
+++ b/src/AST-Core/RBDoItMethodNode.class.st
@@ -1,0 +1,17 @@
+Class {
+	#name : #RBDoItMethodNode,
+	#superclass : #RBMethodNode,
+	#category : #'AST-Core-Nodes'
+}
+
+{ #category : #initialization }
+RBDoItMethodNode >> initialize [ 	
+	super initialize.
+	
+	selector := #DoIt
+]
+
+{ #category : #testing }
+RBDoItMethodNode >> isDoIt [ 
+	^true
+]

--- a/src/AST-Core/RBDoItMethodNode.class.st
+++ b/src/AST-Core/RBDoItMethodNode.class.st
@@ -1,3 +1,10 @@
+"
+RBDoItMethodNode is the node that represents AST of DoIt expressions.
+It allows to distinguish between ASTs of real methods and DoIts. 
+
+- aMethodNode isDoIt
+
+"
 Class {
 	#name : #RBDoItMethodNode,
 	#superclass : #RBMethodNode,

--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -37,6 +37,11 @@ Class {
 }
 
 { #category : #'instance creation' }
+RBMethodNode class >> selector: aSymbol [
+	^self selector: aSymbol arguments: #()
+]
+
+{ #category : #'instance creation' }
 RBMethodNode class >> selector: aSymbol arguments: valueNodes [
 	^(self new)
 		selector: aSymbol;
@@ -372,12 +377,18 @@ RBMethodNode >> hash [
 
 { #category : #initialization }
 RBMethodNode >> initialize [
+	arguments := #().
 	pragmas := #().
 	replacements := SortedCollection sortBlock: 
 					[:a :b | 
 					a startPosition < b startPosition 
 						or: [a startPosition = b startPosition and: [a stopPosition < b stopPosition]]].
 	nodeReplacements := IdentityDictionary new
+]
+
+{ #category : #testing }
+RBMethodNode >> isDoIt [ 
+	^false
 ]
 
 { #category : #testing }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -187,7 +187,7 @@ RBParser >> beFaulty [
 	errorBlock := self class errorNodeBlock
 ]
 
-{ #category : #'private-classes' }
+{ #category : #'private - classes' }
 RBParser >> blockNodeClass [
 	^ RBBlockNode
 ]
@@ -200,6 +200,11 @@ RBParser >> cascadeNodeClass [
 { #category : #accessing }
 RBParser >> currentToken [
 	^currentToken
+]
+
+{ #category : #'private - classes' }
+RBParser >> doItMethodNodeClass [
+	^ RBDoItMethodNode
 ]
 
 { #category : #'private - classes' }
@@ -525,6 +530,16 @@ RBParser >> parseCascadeMessageWithReceiver: receiver [
 	^ errorNode
 ]
 
+{ #category : #parsing }
+RBParser >> parseDoIt [
+	"Parse and return an DoIt corresponding to the expression passed as a #source"
+	| methodNode |
+	methodNode := self doItMethodNodeClass new.
+	self parseMethodBodyInto: methodNode.
+	methodNode addReturn.
+	^methodNode
+]
+
 { #category : #'private - classes' }
 RBParser >> parseEnglobingError: aCollection with: aToken errorMessage: anErrorMessage [
 	| firstParse |
@@ -549,16 +564,13 @@ RBParser >> parseErrorNode: aMessageString [
 
 { #category : #parsing }
 RBParser >> parseExpression [
-	"Parse and return an AST corresponding to the expression passed as a #source"
-	| node |
-	node := self parseStatements: false.
-	(self methodNodeClass selector: #noMethod body: node) source: source.	"Make the sequence node have a method node as its parent"
-	self atEnd ifFalse: [ ^ self parseIncompleteExpression: node ].
-	(node statements isEmpty and: [currentToken comments notNil]) 
-			ifTrue: [self extractCommentsFrom: currentToken. self addCommentsTo: node.].
-	^(node statements size == 1 and: [ node temporaries isEmpty ])
-		  ifTrue: [ node statements first ]
-		  ifFalse: [ node ]
+	"Parse and return an AST node corresponding to the expression passed as a #source"
+	| methodNode |
+	methodNode := self doItMethodNodeClass new.
+	self parseMethodBodyInto: methodNode.	
+	^(methodNode statements size == 1 and: [ methodNode temporaries isEmpty ])
+		  ifTrue: [ methodNode statements first ]
+		  ifFalse: [ methodNode body ]
 ]
 
 { #category : #'private - parsing' }
@@ -742,22 +754,26 @@ RBParser >> parseMessagePattern [
 
 { #category : #parsing }
 RBParser >> parseMethod [
-	| methodNode sequenceNode | 
+	| methodNode | 
 	methodNode := self parseMessagePattern.
 	self parsePragmas.
 	self addCommentsTo: methodNode.
-	
-	methodNode body ifNil: [
-		sequenceNode := self sequenceNodeClass new.
-		methodNode body: sequenceNode ].
-	
-	self parseStatements: true into: methodNode body untilAnyCloserOf: #().
+	self parseMethodBodyInto: methodNode.
+	^methodNode
+]
+
+{ #category : #'private - parsing' }
+RBParser >> parseMethodBodyInto: aMethodNode [ 
+	aMethodNode source: source.
+	aMethodNode body ifNil: [ aMethodNode body: self sequenceNodeClass new ].	
+			
+	self parseStatements: true into: aMethodNode body untilAnyCloserOf: #().
 		
-	pragmas ifNotNil: [ methodNode pragmas: pragmas ].
-	methodNode source: source.
-	self atEnd ifFalse: [ ^ self parseIncompleteExpression: methodNode body ]. 
-	methodNode source: source.
-	^ methodNode
+	pragmas ifNotNil: [ aMethodNode pragmas: pragmas ].	
+	self atEnd ifFalse: [ self parseIncompleteExpression: aMethodNode body ].
+	(aMethodNode body statements isEmpty and: [currentToken comments notNil]) ifTrue: [
+		self extractCommentsFrom: currentToken. 
+		self addCommentsTo: aMethodNode body ].
 ]
 
 { #category : #'private - parsing' }
@@ -910,7 +926,7 @@ RBParser >> parseStatementInto: statementList periodList: periods [
 			returnPosition := currentToken start.
 			self step.
 			node := self returnNodeClass
-				        return: returnPosition
+				        start: returnPosition
 				        value: self parseAssignment ]
 		ifFalse: [ node := self parseAssignment ].
 
@@ -982,7 +998,7 @@ RBParser >> parseStatementInto: statementList periodList: periods withAcceptedSt
 			returnPosition := currentToken start.
 			self step.
 			node := self returnNodeClass
-				        return: returnPosition
+				        start: returnPosition
 				        value: self parseAssignment ]
 		ifFalse: [ node := self parseAssignment ].
 		
@@ -1110,14 +1126,6 @@ RBParser >> parseStatementList: pragmaBoolean into: sequenceNode untilAnyCloserO
 		statements: statements;
 		periods: periods.
 	^ sequenceNode
-]
-
-{ #category : #'private - parsing' }
-RBParser >> parseStatements: pragmaBoolean [
-	^ self
-		parseStatements: pragmaBoolean
-		into: self sequenceNodeClass new
-		untilAnyCloserOf: #()
 ]
 
 { #category : #'private - parsing' }

--- a/src/AST-Core/RBReturnNode.class.st
+++ b/src/AST-Core/RBReturnNode.class.st
@@ -11,20 +11,23 @@ Class {
 	#name : #RBReturnNode,
 	#superclass : #RBProgramNode,
 	#instVars : [
-		'return',
-		'value'
+		'value',
+		'start'
 	],
 	#category : #'AST-Core-Nodes'
 }
 
 { #category : #'instance creation' }
-RBReturnNode class >> return: returnInteger value: aValueNode [ 
-	^self new return: returnInteger value: aValueNode
+RBReturnNode class >> start: returnInteger value: aValueNode [ 
+	^self new 
+		start: returnInteger;
+		value: aValueNode
 ]
 
 { #category : #'instance creation' }
 RBReturnNode class >> value: aNode [
-	^self return: 0 value: aNode
+	^self new 
+		value: aNode
 ]
 
 { #category : #comparing }
@@ -73,7 +76,7 @@ RBReturnNode >> hash [
 RBReturnNode >> initialize [
 	super initialize.
 
-	return := 0
+	start := 0
 ]
 
 { #category : #testing }
@@ -109,25 +112,14 @@ RBReturnNode >> replaceNode: aNode withNode: anotherNode [
 	value == aNode ifTrue: [ self value: anotherNode ]
 ]
 
-{ #category : #'accessing - token' }
-RBReturnNode >> return [
-	^ return
-]
-
-{ #category : #'accessing - token' }
-RBReturnNode >> return: anInteger [
-	return := anInteger
-]
-
-{ #category : #initialization }
-RBReturnNode >> return: returnInteger value: anExpression [ 
-	return := returnInteger.
-	self value: anExpression
-]
-
 { #category : #accessing }
 RBReturnNode >> start [
-	^ return
+	^ start
+]
+
+{ #category : #'accessing - token' }
+RBReturnNode >> start: anInteger [
+	start := anInteger
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBSequenceNode.class.st
+++ b/src/AST-Core/RBSequenceNode.class.st
@@ -165,7 +165,7 @@ RBSequenceNode >> addReturn [
 		ifTrue: [ ^ nil ].
 	statements last isReturn
 		ifTrue: [ ^ statements last ].
-	node := RBReturnNode value: statements last.
+	node := RBReturnNode start: statements last start value: statements last.
 	statements at: statements size put: node.
 	node parent: self.
 	^ node

--- a/src/Calypso-Browser/ClyTextEditingMode.class.st
+++ b/src/Calypso-Browser/ClyTextEditingMode.class.st
@@ -51,11 +51,6 @@ ClyTextEditingMode >> initialize [
 	isForScripting := false
 ]
 
-{ #category : #accessing }
-ClyTextEditingMode >> isForScripting: anObject [
-	isForScripting := anObject
-]
-
 { #category : #testing }
 ClyTextEditingMode >> isScripting [
 	^ isForScripting

--- a/src/DrTests-CommentsToTests-Tests/CommentsToTestsTest.class.st
+++ b/src/DrTests-CommentsToTests-Tests/CommentsToTestsTest.class.st
@@ -28,7 +28,7 @@ CommentsToTestsTest >> testCommentWithSyntaxError [
 	docComment := thisContext method ast pharoDocCommentNodes first.
 	commentTestCase := CommentTestCase for: docComment.
 	
-	self should: [commentTestCase testIt] raise: SyntaxErrorNotification
+	self should: [commentTestCase testIt] raise: RuntimeSyntaxError
 ]
 
 { #category : #tests }

--- a/src/Kernel-ExtraUtils/ClassHierarchyPrinterTest.class.st
+++ b/src/Kernel-ExtraUtils/ClassHierarchyPrinterTest.class.st
@@ -44,6 +44,7 @@ ClassHierarchyPrinterTest >> testOnlyRBASTNodes [
 	RBProgramNode
 		RBComment
 		RBMethodNode
+			RBDoItMethodNode
 		RBPragmaNode
 		RBReturnNode
 		RBSequenceNode

--- a/src/Kernel-Tests-Extended/CompiledMethodTrailerTest.extension.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTrailerTest.extension.st
@@ -63,7 +63,8 @@ CompiledMethodTrailerTest >> testEmbeddingSourceCode [
 	"Test a big string"
 	self testEmbeddingSourceCode: (String loremIpsum: 30000).
 	
-	""
+	"Test an empty DoIt"
+	self testEmbeddingSourceCode: ''
 ]
 
 { #category : #'*Kernel-Tests-Extended' }

--- a/src/Kernel/CompiledMethodTrailer.class.st
+++ b/src/Kernel/CompiledMethodTrailer.class.st
@@ -472,7 +472,8 @@ CompiledMethodTrailer >> encodeEmbeddedSourceWide [
 { #category : #private }
 CompiledMethodTrailer >> encodeLengthField: integer [
 	| bytes value |
-	[integer > 0] assert.
+	[integer >= 0] assert.
+	integer = 0 ifTrue: [ ^#[0] ].
 	value := integer.
 	bytes := ByteArray streamContents: [:str |
 		[ value > 0 ] whileTrue: [

--- a/src/OpalCompiler-Core/OCContextualDoItSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCContextualDoItSemanticScope.class.st
@@ -110,8 +110,3 @@ OCContextualDoItSemanticScope >> targetContext: aContext [
 
 	targetContext := aContext
 ]
-
-{ #category : #'code compilation' }
-OCContextualDoItSemanticScope >> transformDoItExpressionToMethodAST: expressionAST [
-	^expressionAST asDoItForContext: targetContext
-]

--- a/src/OpalCompiler-Core/OCDoItSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCDoItSemanticScope.class.st
@@ -43,15 +43,11 @@ OCDoItSemanticScope >> isDoItScope [
 
 { #category : #parsing }
 OCDoItSemanticScope >> parseASTBy: aParser [
-	^aParser parseExpression
+
+	^aParser parseDoIt
 ]
 
 { #category : #accessing }
 OCDoItSemanticScope >> receiver [
 	^ self subclassResponsibility
-]
-
-{ #category : #'code compilation' }
-OCDoItSemanticScope >> transformDoItExpressionToMethodAST: expressionAST [
-	self subclassResponsibility 
 ]

--- a/src/OpalCompiler-Core/OCReceiverDoItSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCReceiverDoItSemanticScope.class.st
@@ -60,8 +60,3 @@ OCReceiverDoItSemanticScope >> targetReceiver: anObject [
 
 	targetReceiver := anObject
 ]
-
-{ #category : #'code compilation' }
-OCReceiverDoItSemanticScope >> transformDoItExpressionToMethodAST: expressionAST [
-	^expressionAST asDoit
-]

--- a/src/OpalCompiler-Core/OCSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCSemanticScope.class.st
@@ -95,6 +95,11 @@ OCSemanticScope >> parseASTBy: aParser [
 	self subclassResponsibility 
 ]
 
+{ #category : #printing }
+OCSemanticScope >> scopeLevel [ 
+	^0
+]
+
 { #category : #accessing }
 OCSemanticScope >> targetClass [ 
 	self subclassResponsibility  

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -259,17 +259,7 @@ OpalCompiler >> compile: textOrString [
 { #category : #private }
 OpalCompiler >> compileDoItFromAST [ 
 	| method |
-	ast := self semanticScope transformDoItExpressionToMethodAST: ast.
-	ast compilationContext: self compilationContext.
-	self doSemanticAnalysis.
 	method := self compileMethodFromAST.
-	"The method source at this point is pure expression without DoIt method header (pattern)
-	Thefore We need to re-parse so that the AST and its source is in sync with the 
-	bytecode to be able to debug the doIt. Recompile not needed"
-	ast := RBParser parseMethod: ast formattedCode.
-	ast compilationContext: self compilationContext.
-	self doSemanticAnalysis.
-	"we store the ast in the DoIt method so that the debugger can read variables from the requestor"
 	method propertyAt: #ast put: ast.
 	^method
 ]

--- a/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
@@ -165,7 +165,7 @@ OCASTTranslatorTest >> testExamplePrimitiveErrorCode [
 	| ast ir newMethod |
 	method := OCOpalExamples >> #examplePrimitiveErrorCode.
 	ast := method parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
+	ir := ast ir.
 
 	newMethod := ir compiledMethod.
 	self assert: method primitive equals: newMethod primitive
@@ -176,7 +176,7 @@ OCASTTranslatorTest >> testExamplePrimitiveErrorCodeModule [
 	| ast ir newMethod |
 	method := OCOpalExamples >> #examplePrimitiveErrorCodeModule.
 	ast := method parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
+	ir := ast ir.
 
 	newMethod := ir compiledMethod.
 
@@ -192,7 +192,7 @@ OCASTTranslatorTest >> testExamplePrimitiveErrorModule [
 	| ast ir |
 	method := OCOpalExamples >> #examplePrimitiveErrorModule.
 	ast := method parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
+	ir := ast ir.
 	self assert: ir tempKeys equals: #(#errorCode)
 ]
 
@@ -204,7 +204,7 @@ OCASTTranslatorTest >> testExamplePrimitiveModuleError [
 	| ast ir |
 	method := OCOpalExamples >> #examplePrimitiveModuleError.
 	ast := method parseTree.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
+	ir := ast ir.
 	self assert: ir tempKeys equals: #(#errorCode)
 ]
 

--- a/src/OpalCompiler-Tests/OCCompileWithFailureTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompileWithFailureTest.class.st
@@ -26,7 +26,8 @@ OCCompileWithFailureTest >> testEmptyBlockArg [
     options:  #(+ optionParseErrors + optionSkipSemanticWarnings);
     requestor: self;
     parse. 
-	self assert: result isReturn
+	self assert: result isDoIt.
+	self assert: result statements first isReturn
 ]
 
 { #category : #tests }

--- a/src/Reflectivity/RFReflectivityASTCacheStrategy.class.st
+++ b/src/Reflectivity/RFReflectivityASTCacheStrategy.class.st
@@ -17,7 +17,6 @@ Class {
 { #category : #accessing }
 RFReflectivityASTCacheStrategy >> getASTFor: aCompiledMethod [
 	^ aCompiledMethod reflectiveMethod
-		ifNil: [ aCompiledMethod parseTree
-				doSemanticAnalysisIn: aCompiledMethod methodClass ]
+		ifNil: [ aCompiledMethod parseTree ]
 		ifNotNil: [ :rfMethod | rfMethod ast ]
 ]

--- a/src/Rubric/RubScrolledTextModel.class.st
+++ b/src/Rubric/RubScrolledTextModel.class.st
@@ -137,6 +137,11 @@ RubScrolledTextModel >> interactionModel: anObject [
 	interactionModel := anObject
 ]
 
+{ #category : #testing }
+RubScrolledTextModel >> isScripting [
+	^interactionModel isScripting
+]
+
 { #category : #menu }
 RubScrolledTextModel >> menu [
 	^ nil

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -948,9 +948,18 @@ SHRBTextStyler >> formatIncompleteSelector: aMessageNode [
 			ifFalse: [ #undefinedKeyword ]
 ]
 
+{ #category : #initialization }
+SHRBTextStyler >> initialize [ 
+	super initialize.
+	
+	isForWorkspace := false
+]
+
 { #category : #accessing }
-SHRBTextStyler >> isForWorkspace [
-	^ isForWorkspace ifNil: [ workspace notNil ]
+SHRBTextStyler >> isForWorkspace [  
+	^workspace 
+		ifNil: [ isForWorkspace ]
+		ifNotNil: [ workspace isScripting ]
 ]
 
 { #category : #accessing }
@@ -1349,6 +1358,5 @@ SHRBTextStyler >> visitVariableNode: aVariableNode [
 
 { #category : #accessing }
 SHRBTextStyler >> workspace: aWorkspace [ 
-	workspace := aWorkspace.
-	isForWorkspace ifNil: [ isForWorkspace := true ]
+	workspace := aWorkspace
 ]

--- a/src/Tools-CodeNavigation-Tests/CNSelectorExtractionOnPositionTest.class.st
+++ b/src/Tools-CodeNavigation-Tests/CNSelectorExtractionOnPositionTest.class.st
@@ -109,7 +109,7 @@ CNSelectorExtractionOnPositionTest >> testCaretAfterABlock [
 	sourceCode := selector.
 	ast := (RBParser parseFaultyExpression: selector).
 	self caretAfter: ast.
-	self assert: self selectedSelector equals: #noMethod
+	self assert: self selectedSelector equals: ast methodNode selector
 ]
 
 { #category : #'tests - no selection - withOutMessage' }
@@ -119,7 +119,7 @@ CNSelectorExtractionOnPositionTest >> testCaretAfterABlockWithArgument [
 	sourceCode := selector.
 	ast := (RBParser parseFaultyExpression: selector).
 	self caretAfter: ast.
-	self assert: self selectedSelector equals: #noMethod
+	self assert: self selectedSelector equals: ast methodNode selector
 ]
 
 { #category : #'tests - no selection - withOutMessage' }
@@ -129,7 +129,7 @@ CNSelectorExtractionOnPositionTest >> testCaretAfterADynamicArray [
 	sourceCode := selector.
 	ast := (RBParser parseFaultyExpression: selector).
 	self caretAfter: ast.
-	self assert: self selectedSelector equals: #noMethod
+	self assert: self selectedSelector equals: ast methodNode selector
 ]
 
 { #category : #'tests - no selection - withOutMessage' }
@@ -139,7 +139,7 @@ CNSelectorExtractionOnPositionTest >> testCaretAfterADynamicArrayWithAnElement [
 	sourceCode := selector.
 	ast := (RBParser parseFaultyExpression: selector).
 	self caretAfter: ast.
-	self assert: self selectedSelector equals: #noMethod
+	self assert: self selectedSelector equals: ast methodNode selector
 ]
 
 { #category : #'tests - no selection - withOutMessage' }
@@ -149,7 +149,7 @@ CNSelectorExtractionOnPositionTest >> testCaretAfterALiteralArray [
 	sourceCode := selector.
 	ast := (RBParser parseFaultyExpression: selector).
 	self caretAfter: ast.
-	self assert: self selectedSelector equals: #noMethod
+	self assert: self selectedSelector equals: ast methodNode selector
 ]
 
 { #category : #'tests - no selection - withOutMessage' }
@@ -159,7 +159,7 @@ CNSelectorExtractionOnPositionTest >> testCaretAfterALiteralArrayWithAnElement [
 	sourceCode := selector.
 	ast := (RBParser parseFaultyExpression: selector).
 	self caretAfter: ast.
-	self assert: self selectedSelector equals: #noMethod
+	self assert: self selectedSelector equals: ast methodNode selector
 ]
 
 { #category : #'tests - no selection - blocks' }
@@ -460,7 +460,7 @@ CNSelectorExtractionOnPositionTest >> testCaretOnNonValidCode [
 	sourceCode := 'anObjectdo : 2'.
 	ast := (RBParser parseFaultyExpression: sourceCode).
 	self caretAfter: ast.
-	self assert: self selectedSelector equals: #noMethod.
+	self assert: self selectedSelector equals: ast methodNode selector.
 ]
 
 { #category : #'tests - no selection - withOutMessage' }

--- a/src/Tools-CodeNavigation/CNSelectorExtractor.class.st
+++ b/src/Tools-CodeNavigation/CNSelectorExtractor.class.st
@@ -82,9 +82,9 @@ CNSelectorExtractor >> extractSelectorFromNode: aNode [
 			node := node parent messages first ] ].
 	
 	"In the case of doIt methods"
-	(node selector = #noMethod and: [ aNode isVariable ])
+	(node isMethod and: [ node isDoIt and: [ aNode isVariable ]])
 		ifTrue: [  ^ aNode name ].		
-	(node selector = #noMethod and: [ aNode isParseError ])
+	(node isMethod and: [ node isDoIt and: [ aNode isParseError ]])
 		ifTrue: [ ^ aNode value asSymbol ifEmpty: [ nil ] ].
 
 	^ node selector


### PR DESCRIPTION
DoIts without method header and reformatting:
![simpleDoIt](https://user-images.githubusercontent.com/8149664/180092149-d8c28226-78a8-4ea9-b474-90bccc94be8a.png)

- RBParser is refactored to simplify method and doIts parsing/compilation
 - common parts are extracted to parseMethodBodyInto:
    - pragmas are supported in doIts (see #testPragmaInExpression):
      - it was some strange constraint

      - compilation flags can be now enabled in workspace
  - RBReturnNode is improved with better var name for position: #start instead of #return 
  - RBDoItMethodNode is introduced to represent method nodes in doIt ASTs
 - SHRBTextStyler>>isWorkspace uses isScripting which respects semantic scope to correctly highlight DoIts without headers

PR does not fix highlighting in the debugger and inspector for no-header DoIts. These fixes are in their repos:
- https://github.com/pharo-spec/NewTools/pull/400
- https://github.com/pharo-spec/Spec/pull/1296