### PR TITLE
10774-FTP-clientgetDataInto-lost-returned-information

### DIFF
--- a/src/Network-Protocols/FTPClient.class.st
+++ b/src/Network-Protocols/FTPClient.class.st
@@ -165,7 +165,6 @@ FTPClient >> getDataInto: dataStream [
 			self checkForPendingError.
 			bytesRead := self dataSocket receiveDataWithTimeoutInto: buf.
 			1 to: bytesRead do: [:ii | dataStream nextPut: (buf at: ii)]].
-	dataStream reset.	"position: 0."
 	^ dataStream
 ]
 


### PR DESCRIPTION
This PR fixes FTPClient as described in the issue tracker entry

fixes #10774