### PR TITLE
Deprecate-theMetaClass-theNonMetaClass

### DIFF
--- a/src/Refactoring-Core/RBAbstractClass.class.st
+++ b/src/Refactoring-Core/RBAbstractClass.class.st
@@ -749,12 +749,16 @@ RBAbstractClass >> superclassRedefines: aSelector [
 
 { #category : #'accessing - deprecated' }
 RBAbstractClass >> theMetaClass [
-	^ model metaclassNamed: self name
+	self deprecated:  'Please use #classSide instead' transformWith:  '`@receiver theMetaClass' 
+						-> '`@receiver classSide'.
+	^ self classSide
 ]
 
 { #category : #'accessing - deprecated' }
 RBAbstractClass >> theNonMetaClass [
-	^ model classNamed: self name
+	self deprecated:  'Please use #instanceSide instead' transformWith:  '`@receiver theNonMetaClass' 
+						-> '`@receiver instanceSide'.
+	^ self instanceSide
 ]
 
 { #category : #'variable accessing' }

--- a/src/Refactoring-Core/RBClass.class.st
+++ b/src/Refactoring-Core/RBClass.class.st
@@ -304,8 +304,3 @@ RBClass >> sharedPoolNames [
 RBClass >> sharedPools [
 	^ self allPoolDictionaryNames collect: [ :each | Smalltalk globals at: each asSymbol ifAbsent: [ Dictionary new ] ]
 ]
-
-{ #category : #'accessing - deprecated' }
-RBClass >> theNonMetaClass [
-	^ self
-]

--- a/src/Refactoring-Core/RBMetaclass.class.st
+++ b/src/Refactoring-Core/RBMetaclass.class.st
@@ -81,8 +81,3 @@ RBMetaclass >> storeOn: aStream [
 	super storeOn: aStream.
 	aStream nextPutAll: ' class'
 ]
-
-{ #category : #'accessing - deprecated' }
-RBMetaclass >> theMetaClass [
-	^ self
-]


### PR DESCRIPTION
This PR finally deprecates the last theMetaClass and theNonMetaClass after all senders where fixed