### PR TITLE
11307-ZipArchive-extract-functionality-does-not-have-support-for-filenames-containing-utf8-characters

### DIFF
--- a/src/Compression/ZipFileMember.class.st
+++ b/src/Compression/ZipFileMember.class.st
@@ -90,7 +90,7 @@ ZipFileMember >> readCentralDirectoryFileHeaderFrom: aStream [
 	localHeaderRelativeOffset := endianStream nextLittleEndianNumber: 4.
 
 	fileName := (aStream next: fileNameLength) asString.
-	cdExtraField := (aStream next: extraFieldLength) asByteArray asString.
+	cdExtraField := (aStream next: extraFieldLength) asByteArray utf8Decoded.
 	fileComment := (aStream next: fileCommentLength) asByteArray utf8Decoded.
 
 	self desiredCompressionMethod: compressionMethod
@@ -133,7 +133,7 @@ ZipFileMember >> readLocalDirectoryFileHeaderFrom: aStream [
 	fileNameLength := endianStream nextLittleEndianNumber: 2.
 	extraFieldLength := endianStream nextLittleEndianNumber: 2.
 
-	fileName := (aStream next: fileNameLength) asString.
+	fileName := (aStream next: fileNameLength) utf8Decoded.
 	localExtraField := (aStream next: extraFieldLength) asByteArray.
 
 	dataOffset := aStream position.


### PR DESCRIPTION
This PR does the fix as described in the issue tracker entry.

fixes #11307