### PR TITLE
Fix DoIt highlighting and debugIt in ProcessBrowser

### DIFF
--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -570,7 +570,7 @@ CompiledMethod >> isDisabled: marker [
 
 { #category : #testing }
 CompiledMethod >> isDoIt [
-	^self selector isDoIt.
+	^self selector isDoIt
 ]
 
 { #category : #testing }

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -377,6 +377,11 @@ Context >> basicSize [
 	^self primitiveFail
 ]
 
+{ #category : #testing }
+Context >> belongsToDoIt [
+	^self home method isDoIt
+]
+
 { #category : #'instruction decoding' }
 Context >> blockReturnConstant: value [ 
 	"Simulate the interpreter's action when a ReturnConstantToCaller

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -450,13 +450,14 @@ RubSmalltalkEditor >> debug: aCompiledMethod receiver: anObject in: evalContext 
 
 	| process suspendedContext |
 	process := [ 
-	           aCompiledMethod
-		           valueWithReceiver: anObject
-		           arguments:
-		           (evalContext
-			            ifNil: [ #(  ) ]
-			            ifNotNil: [ { evalContext } ]) ] newProcess.
+		aCompiledMethod
+			valueWithReceiver: anObject
+			arguments: (aCompiledMethod numArgs = 0 
+				ifTrue: [ #() ] 
+				ifFalse: [ { evalContext } ] ) ]
+			newProcess.
 	suspendedContext := process suspendedContext.
+
 	(OupsDebugRequest newForContext: suspendedContext)
 		process: process;
 		compiledMethod: aCompiledMethod;

--- a/src/Tool-ProcessBrowser/ProcessBrowser.class.st
+++ b/src/Tool-ProcessBrowser/ProcessBrowser.class.st
@@ -407,7 +407,7 @@ ProcessBrowser >> build [
 		
 	textModel setText: self methodText.
 	textModel clearUserEdits.
-	scrolledText := textModel newScrolledText beForSmalltalkCode; yourself.
+	scrolledText := textModel newScrolledText beForSmalltalkScripting; yourself.
 	window
 		addMorph:  scrolledText
 		frame: (0 @ 0.5 corner: 1 @ 1).
@@ -578,6 +578,11 @@ ProcessBrowser >> isAutoUpdating [
 { #category : #updating }
 ProcessBrowser >> isAutoUpdatingPaused [
 	^autoUpdateProcess notNil and: [ autoUpdateProcess isSuspended ]
+]
+
+{ #category : #testing }
+ProcessBrowser >> isScripting [ 
+	^self doItContext belongsToDoIt
 ]
 
 { #category : #'process list' }


### PR DESCRIPTION
ProcessBrowser was missing fix for code highlighting of DoIt contexts and debugIt command was broken. Here it is fixed.
Run the following code for testing:
```Smalltalk
| tempA tempB |
tempA := 10.
tempB := 20.
work := 400. 
tempA @ tempB corner: tempB @ tempA.
tempA := tempA + tempB.
tempA * 100.
p := [
	Semaphore new wait
] forkNamed: 'TEST'.
self halt.
```
Once debugger is opened don't close it and open ProcessBrowser. Then found the TEST process and select the DoIt method. 
It should be highlighted correctly and DoIt/PrintIt/DebugIt commands should work properly with the variables from the code:

<img width="1002" alt="Screen Shot 2022-07-21 at 19 49 44" src="https://user-images.githubusercontent.com/8149664/180293389-42b27295-0584-4a79-bbec-8386effd9ee8.png">

