### PR TITLE
fix the top and bottom of the rectangle of text input region so that …

### DIFF
--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -1198,9 +1198,9 @@ RubAbstractTextArea >> keyboardFocusChange: aBoolean [
 		ifTrue: [ 
 			self hasFocus: true.
 			editing := false.
-			self requestTextEditingAt:
-				((self cursor positionInWorld corner: self cursor positionInWorld) 
-					 translateBy: 0 @ (self font height + 4)) truncated.
+			self requestTextEditingAt: (self cursor positionInWorld corner:
+					 (self cursor positionInWorld translateBy:
+						  0 @ (self font height + 4))) truncated.
 			self showOverEditableTextCursor ]
 		ifFalse: [ 
 			self hasFocus: false.


### PR DESCRIPTION
…the candidate window can avoid the text line at the caret.