### PR TITLE
Backport visitWindowExposeEvent to redraw when windows are re-exposed

### DIFF
--- a/src/OSWindow-Core/OSWindowMorphicEventHandler.class.st
+++ b/src/OSWindow-Core/OSWindowMorphicEventHandler.class.st
@@ -317,6 +317,12 @@ OSWindowMorphicEventHandler >> visitWindowDropEvent: anEvent [
 ]
 
 { #category : #visiting }
+OSWindowMorphicEventHandler >> visitWindowExposeEvent: anEvent [
+
+	morphicWorld worldState doFullRepaint
+]
+
+{ #category : #visiting }
 OSWindowMorphicEventHandler >> visitWindowResizeEvent: anEvent [
 
 	"window resized"


### PR DESCRIPTION
This fixes window exposures in different platforms