### PR TITLE
Improve protocol suggestions when creating method from debugger

### DIFF
--- a/src/Tool-Base/AbstractTool.class.st
+++ b/src/Tool-Base/AbstractTool.class.st
@@ -10,17 +10,22 @@ Class {
 { #category : #private }
 AbstractTool class >> protocolSuggestionsFor: aClass [
 
-	| allExistingProtocols interestingProtocols reject |
+	| classProtocols reject allExistingProtocols interestingProtocols |
+	classProtocols := aClass organization allCategories.
 	reject := Set new.
 	reject
-		addAll: aClass organization allCategories;
 		add: AllProtocol defaultName;
 		add: Protocol nullCategory;
 		add: Protocol unclassified.
-	allExistingProtocols := SystemNavigation default allExistingProtocolsFor: aClass isMeta not.
-	
-	interestingProtocols := allExistingProtocols reject: [ :e | reject includes: e ].
-	^ interestingProtocols asOrderedCollection sort: [ :a :b | a asLowercase < b asLowercase ].
+	allExistingProtocols := (SystemNavigation default 
+		                         allExistingProtocolsFor: aClass isMeta not) 
+		                        reject: [ :p | classProtocols includes: p ].
+	interestingProtocols := classProtocols
+	                        ,
+		                        (allExistingProtocols asOrderedCollection 
+			                         sort: [ :a :b | 
+			                         a asLowercase < b asLowercase ]).
+	^ interestingProtocols reject: [ :e | reject includes: e ]
 ]
 
 { #category : #method }


### PR DESCRIPTION
When creating methods from the debugger, the protocol suggestions were not really useful. We were showing _all_ system protocols, except for the ones from the class being extended.

This PR modifies the suggestion list, to show the class' protocols at the top.

**Before:**

https://user-images.githubusercontent.com/21206379/181753750-456e27da-e771-4bae-96eb-e69d643d18df.mov

**After:**

https://user-images.githubusercontent.com/21206379/181753785-0c0dcbe2-392a-417a-9ac7-54c37ab6c352.mov
