### PR TITLE
[Quick review] fix #11265: Underscore in class name breaks text completion

### DIFF
--- a/src/NECompletion-Tests/CompletionEngineTest.class.st
+++ b/src/NECompletion-Tests/CompletionEngineTest.class.st
@@ -48,7 +48,10 @@ CompletionEngineTest >> keyboardEventFor: char useCommand: command [
 		charCode: char asciiValue
 		hand: nil 
 		stamp: Time now.
-	event key: (KeyboardKey fromCharacter: char).
+	event key: (KeyboardKey fromCharacter: char 
+		ifNone: [ char = $_ 
+			ifTrue: [ KeyboardKey named: #UNDERSCORE ] 
+			ifFalse:[ Error signal: 'unsuported' ] ]).
 	^event
 ]
 
@@ -117,6 +120,25 @@ CompletionEngineTest >> tearDown [
 	controller closeMenu.
 	editor textArea delete.
 	super tearDown
+]
+
+{ #category : #'tests - keyboard' }
+CompletionEngineTest >> testCompletionOpenOnUnderscore [
+
+	"If the caret is at the end of a word, replace the entire word"
+	
+	| text |
+	text := 'self underscore_'.
+	
+	self
+		setEditorText: text;
+		selectAt: 'self underscore_' size + 1.
+	
+	editor textArea openInWorld.
+	controller openMenu.
+	editor keyDown: (self keyboardEventFor: $_).
+
+	self assert: controller isMenuOpen
 ]
 
 { #category : #'tests - interaction' }

--- a/src/NECompletion/Character.extension.st
+++ b/src/NECompletion/Character.extension.st
@@ -2,6 +2,6 @@ Extension { #name : #Character }
 
 { #category : #'*NECompletion' }
 Character >> isCompletionCharacter [
-	"I defined the logic that completion can only happen with alphanumeric : characters."
-	^ self isAlphaNumeric or: [ #(:  _) includes: self  ]
+	"Method stays for readability of user"
+	^ self tokenish
 ]


### PR DESCRIPTION
fix #11265 + a small test.
We tried to add a test to check that there were results, however, it seems untested currently, and we didn't add required accesses.
We preferred to keep the fix small, and test that the behavior was as expected.