### PR TITLE
Fix senders/implementors of class variables and shared pools

### DIFF
--- a/src/Calypso-SystemTools-OldToolCompatibillity/ClyOldMessageBrowserAdapter.class.st
+++ b/src/Calypso-SystemTools-OldToolCompatibillity/ClyOldMessageBrowserAdapter.class.st
@@ -68,8 +68,11 @@ ClyOldMessageBrowserAdapter class >> browseClasses: classes [
 ]
 
 { #category : #opening }
-ClyOldMessageBrowserAdapter class >> browseImplementorsOf: aSymbol [ 
-	^ClyQueryBrowserMorph browseImplementorsOf: aSymbol
+ClyOldMessageBrowserAdapter class >> browseImplementorsOf: aSymbol inNameResolver: methodContext [
+
+	^ ClyQueryBrowserMorph
+		  browseImplementorsOf: aSymbol
+		  inNameResolver: methodContext
 ]
 
 { #category : #opening }

--- a/src/Calypso-SystemTools-QueryBrowser/ClyBrowserMorph.extension.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyBrowserMorph.extension.st
@@ -1,12 +1,12 @@
 Extension { #name : #ClyBrowserMorph }
 
 { #category : #'*Calypso-SystemTools-QueryBrowser' }
-ClyBrowserMorph >> browseImplementorsOf: aSymbol [
+ClyBrowserMorph >> browseImplementorsOf: aSymbol inNameResolver: aNameResolver [
 	| classBinding classToBrowse |
 	aSymbol first isUppercase ifTrue: [ 
-		classBinding := self system bindingOf: aSymbol.
+		classBinding := aNameResolver bindingOf: aSymbol.
 		classBinding ifNotNil: [ 
-			classToBrowse := classBinding value.
+			classToBrowse := classBinding definingClass ifNil: [ classBinding value ].
 			classToBrowse isClassOrTrait ifFalse: [ classToBrowse := classToBrowse class ].
 			^self spawnBrowser: ClyFullBrowserMorph withState: [ :browser | 
 				browser selectClass: classToBrowse]]].
@@ -17,11 +17,11 @@ ClyBrowserMorph >> browseImplementorsOf: aSymbol [
 { #category : #'*Calypso-SystemTools-QueryBrowser' }
 ClyBrowserMorph >> browseReferencesTo: aSymbol [
 	
-	self browseReferencesTo: aSymbol from: self system
+	self browseReferencesTo: aSymbol inNameResolver: self system
 ]
 
 { #category : #'*Calypso-SystemTools-QueryBrowser' }
-ClyBrowserMorph >> browseReferencesTo: aSymbol from: anEnvironment [
+ClyBrowserMorph >> browseReferencesTo: aSymbol inNameResolver: anEnvironment [
 	
 	| classBinding |
 	aSymbol isSymbol and: [ aSymbol first isUppercase ifTrue: [ 

--- a/src/Calypso-SystemTools-QueryBrowser/ClyQueryBrowserMorph.class.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyQueryBrowserMorph.class.st
@@ -52,7 +52,7 @@ ClyQueryBrowserMorph class >> browseClasses: classes [
 ]
 
 { #category : #opening }
-ClyQueryBrowserMorph class >> browseImplementorsOf: aSymbol [
+ClyQueryBrowserMorph class >> browseImplementorsOf: aSymbol inNameResolver: methodContext [
 	^self openOn: (ClyMessageImplementorsQuery of: aSymbol)
 ]
 

--- a/src/Calypso-SystemTools-QueryBrowser/ClyTextEditor.extension.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyTextEditor.extension.st
@@ -24,8 +24,10 @@ ClyTextEditor >> classNamesContainingIt [
 
 { #category : #'*Calypso-SystemTools-QueryBrowser' }
 ClyTextEditor >> implementorsOf: selectedSelector [
-	
-	self browser browseImplementorsOf: selectedSelector
+
+	self browser
+		browseImplementorsOf: selectedSelector
+		inNameResolver: self browserTool editingMethod methodClass
 ]
 
 { #category : #'*Calypso-SystemTools-QueryBrowser' }
@@ -34,7 +36,7 @@ ClyTextEditor >> implementorsOfIt [
 	| selector |
 	(selector := self selectedSelector) ifNil: [ ^ textArea flash ].
 	selector isCharacter ifTrue: [ ^ textArea flash ].
-	self browser browseImplementorsOf: selector
+	self implementorsOf: selector
 ]
 
 { #category : #'*Calypso-SystemTools-QueryBrowser' }
@@ -60,7 +62,7 @@ ClyTextEditor >> referencesTo: aVariableName [
 			var := ClyInstanceVariable on: slot visibleFrom: class.
 			^self browser spawnQueryBrowserOn: (ClyVariableReferencesQuery of: var)]].
 	
-	self browser browseReferencesTo: aVariableName asSymbol from: class
+	self browser browseReferencesTo: aVariableName asSymbol inNameResolver: class
 ]
 
 { #category : #'*Calypso-SystemTools-QueryBrowser' }
@@ -75,7 +77,9 @@ ClyTextEditor >> referencesToIt [
 { #category : #'*Calypso-SystemTools-QueryBrowser' }
 ClyTextEditor >> sendersOf: selectedSelector [
 
-	self browser browseReferencesTo: selectedSelector
+	self browser
+		browseReferencesTo: selectedSelector
+		inNameResolver: self browserTool editingMethod methodClass
 ]
 
 { #category : #'*Calypso-SystemTools-QueryBrowser' }


### PR DESCRIPTION
Lookup the classes defining class variables and shared pools by giving a name resolver to calypso.
Take the name resolver from the currently selected method in the tool where the shortcut is activated.