### PR TITLE
[improvement] add microsecond to API

### DIFF
--- a/src/Kernel-Tests/DurationTest.class.st
+++ b/src/Kernel-Tests/DurationTest.class.st
@@ -280,6 +280,17 @@ DurationTest >> testLessThan [
 ]
 
 { #category : #tests }
+DurationTest >> testMicroSeconds [
+	#(#(5 0 5000) #(1000005 1 5000) #(-5 0 -5000) #(-1000005 -1 -5000) #(1234000567 1234 567000) #(-1234000567 -1234 -567000))
+		do: [ :each | 
+			| duration | 
+			duration := Duration microSeconds: each first.
+			self assert: duration asSeconds equals: each second.
+			self assert: duration nanoSeconds equals: each third ]
+	"argument (milliseconds)        seconds nanoseconds"
+]
+
+{ #category : #tests }
 DurationTest >> testMilliSeconds [
 	#(#(5 0 5000000) #(1005 1 5000000) #(-5 0 -5000000) #(-1005 -1 -5000000) #(1234567 1234 567000000) #(-1234567 -1234 -567000000))
 		do: [ :each | 

--- a/src/Kernel-Tests/FluidClassDefinitionPrinterTest.class.st
+++ b/src/Kernel-Tests/FluidClassDefinitionPrinterTest.class.st
@@ -58,7 +58,7 @@ FluidClassDefinitionPrinterTest >> testChronologyConstants [
 	self
 		assert: (self forClass: ChronologyConstants)
 		equals: 'SharedPool << #ChronologyConstants
-	sharedVariables: { #NanosInSecond . #MonthNames . #SecondsInHour . #SecondsInDay . #DayNames . #DaysInMonth . #HoursInDay . #NanosInMillisecond . #SecondsInMinute . #SqueakEpoch . #MinutesInHour . #MicrosecondsInDay };
+	sharedVariables: { #SqueakEpoch . #SecondsInDay . #DayNames . #MonthNames . #MicrosecondsInDay . #SecondsInHour . #NanosInSecond . #SecondsInMinute . #NanosInMillisecond . #DaysInMonth . #NanosInMicroSecond . #HoursInDay . #MinutesInHour };
 	tag: ''Chronology'';
 	package: ''Kernel'''
 ]

--- a/src/Kernel-Tests/FluidClassDefinitionPrinterTest.class.st
+++ b/src/Kernel-Tests/FluidClassDefinitionPrinterTest.class.st
@@ -58,7 +58,7 @@ FluidClassDefinitionPrinterTest >> testChronologyConstants [
 	self
 		assert: (self forClass: ChronologyConstants)
 		equals: 'SharedPool << #ChronologyConstants
-	sharedVariables: { #SqueakEpoch . #SecondsInDay . #DayNames . #MonthNames . #MicrosecondsInDay . #SecondsInHour . #NanosInSecond . #SecondsInMinute . #NanosInMillisecond . #DaysInMonth . #NanosInMicroSecond . #HoursInDay . #MinutesInHour };
+	sharedVariables: { #SqueakEpoch . #SecondsInDay . #DayNames . #MonthNames . #SecondsInHour . #MicrosecondsInDay . #NanosInSecond . #SecondsInMinute . #NanosInMillisecond . #DaysInMonth . #NanosInMicroSecond . #HoursInDay . #MinutesInHour };
 	tag: ''Chronology'';
 	package: ''Kernel'''
 ]

--- a/src/Kernel-Tests/LegacyClassDefinitionPrinterTest.class.st
+++ b/src/Kernel-Tests/LegacyClassDefinitionPrinterTest.class.st
@@ -51,7 +51,7 @@ LegacyClassDefinitionPrinterTest >> testChronologyConstants [
 		assert: (self forClass: ChronologyConstants)
 		equals: 'SharedPool subclass: #ChronologyConstants
 	instanceVariableNames: ''''
-	classVariableNames: ''DayNames DaysInMonth HoursInDay MicrosecondsInDay MinutesInHour MonthNames NanosInMillisecond NanosInSecond SecondsInDay SecondsInHour SecondsInMinute SqueakEpoch''
+	classVariableNames: ''DayNames DaysInMonth HoursInDay MicrosecondsInDay MinutesInHour MonthNames NanosInMicroSecond NanosInMillisecond NanosInSecond SecondsInDay SecondsInHour SecondsInMinute SqueakEpoch''
 	poolDictionaries: ''''
 	category: ''Kernel-Chronology'''
 ]

--- a/src/Kernel-Tests/OldClassDefinitionPrinterTest.class.st
+++ b/src/Kernel-Tests/OldClassDefinitionPrinterTest.class.st
@@ -62,7 +62,7 @@ OldClassDefinitionPrinterTest >> testChronologyConstants [
 		assert: (self forClass: ChronologyConstants)
 		equals: 'SharedPool subclass: #ChronologyConstants
 	instanceVariableNames: ''''
-	classVariableNames: ''DayNames DaysInMonth HoursInDay MicrosecondsInDay MinutesInHour MonthNames NanosInMillisecond NanosInSecond SecondsInDay SecondsInHour SecondsInMinute SqueakEpoch''
+	classVariableNames: ''DayNames DaysInMonth HoursInDay MicrosecondsInDay MinutesInHour MonthNames NanosInMicroSecond NanosInMillisecond NanosInSecond SecondsInDay SecondsInHour SecondsInMinute SqueakEpoch''
 	package: ''Kernel-Chronology'''
 ]
 

--- a/src/Kernel/ChronologyConstants.class.st
+++ b/src/Kernel/ChronologyConstants.class.st
@@ -11,6 +11,7 @@ Class {
 		'MicrosecondsInDay',
 		'MinutesInHour',
 		'MonthNames',
+		'NanosInMicroSecond',
 		'NanosInMillisecond',
 		'NanosInSecond',
 		'SecondsInDay',
@@ -33,6 +34,7 @@ ChronologyConstants class >> initialize [
 	HoursInDay := 24.
 	NanosInSecond := 10 raisedTo: 9.
 	NanosInMillisecond := 10 raisedTo: 6.
+	NanosInMicroSecond := 10 raisedTo: 3.
 	DayNames := #(Sunday Monday Tuesday Wednesday Thursday Friday Saturday).
 		
 	MonthNames := #(January February March April May June July

--- a/src/Kernel/Duration.class.st
+++ b/src/Kernel/Duration.class.st
@@ -55,6 +55,13 @@ Duration class >> hours: aNumber [
 ]
 
 { #category : #'instance creation simple' }
+Duration class >> microSeconds: microCount [
+	^ self
+		seconds: (microCount quo: 1000000)
+		nanoSeconds: (microCount rem: 1000000) * NanosInMicroSecond 
+]
+
+{ #category : #'instance creation simple' }
 Duration class >> milliSeconds: milliCount [
      
 	^ self


### PR DESCRIPTION
Useful for people using microsecondsToRun:
The naming microSecond or microsecond is inconsistent to, I took one randomly.

This seems to be an oversight that is just missing from the API.