### PR TITLE
Fixing issue #9545: DrTests should show 'expected failures' and 'passed unexpectedly'

### DIFF
--- a/src/DrTests-TestsRunner/DTExpectedFailureResultType.class.st
+++ b/src/DrTests-TestsRunner/DTExpectedFailureResultType.class.st
@@ -1,0 +1,23 @@
+"
+I model the fact that a tests expected to fail failed
+"
+Class {
+	#name : #DTExpectedFailureResultType,
+	#superclass : #DTTestResultType,
+	#category : #'DrTests-TestsRunner-Results'
+}
+
+{ #category : #factory }
+DTExpectedFailureResultType class >> backgroundColor [
+	^ TestResult defaultColorBackGroundForExpectedFailureTest
+]
+
+{ #category : #accessing }
+DTExpectedFailureResultType >> isExpectedFailure [
+	^ true
+]
+
+{ #category : #accessing }
+DTExpectedFailureResultType >> name [
+	^ 'ExpectedFailure'
+]

--- a/src/DrTests-TestsRunner/DTTestResultType.class.st
+++ b/src/DrTests-TestsRunner/DTTestResultType.class.st
@@ -18,6 +18,11 @@ DTTestResultType class >> error [
 ]
 
 { #category : #factory }
+DTTestResultType class >> expectedFailure [
+	^ DTExpectedFailureResultType new
+]
+
+{ #category : #factory }
 DTTestResultType class >> fail [
 	^ DTFailResultType new
 ]
@@ -35,6 +40,11 @@ DTTestResultType class >> skipped [
 { #category : #factory }
 DTTestResultType class >> textColor [
 	^ TestResult defaultColorText
+]
+
+{ #category : #factory }
+DTTestResultType class >> unexpectedPass [
+	^ DTUnexpectedPassResultType new
 ]
 
 { #category : #testing }

--- a/src/DrTests-TestsRunner/DTTestResultType.class.st
+++ b/src/DrTests-TestsRunner/DTTestResultType.class.st
@@ -42,6 +42,11 @@ DTTestResultType >> isError [
 	^ false
 ]
 
+{ #category : #accessing }
+DTTestResultType >> isExpectedFailure [
+	^ false
+]
+
 { #category : #testing }
 DTTestResultType >> isFail [
 	^ false
@@ -54,6 +59,11 @@ DTTestResultType >> isPass [
 
 { #category : #testing }
 DTTestResultType >> isSkipped [
+	^ false
+]
+
+{ #category : #accessing }
+DTTestResultType >> isUnexpectedPass [
 	^ false
 ]
 

--- a/src/DrTests-TestsRunner/DTTestsRunnerPlugin.class.st
+++ b/src/DrTests-TestsRunner/DTTestsRunnerPlugin.class.st
@@ -122,15 +122,14 @@ DTTestsRunnerPlugin >> runForConfiguration: aDTpluginConfiguration [
 
 { #category : #private }
 DTTestsRunnerPlugin >> runSuite: aTestSuite withResult: aResult [
-	aTestSuite
-		when: TestAnnouncement
-		do: [ :testAnnouncement | 
-			self flag: #TODO. "Dirty"
-			testAnnouncement test class = TestSuite
-				ifTrue: [ 
-					self announceStatusChanged: ('Running test {1}.' format: {testAnnouncement test name}) ] ].
-	[ aTestSuite run: aResult ]
-		ensure: [ aTestSuite unsubscribe: TestAnnouncement ]
+
+	aTestSuite when: TestAnnouncement do: [ :testAnnouncement | 
+		self flag: #TODO. "Dirty"
+		testAnnouncement test class = TestSuite ifTrue: [ 
+			self announceStatusChanged:
+				('Running test {1}.' format: { testAnnouncement test name }) ] ].
+	[ aResult mergeWith: (aTestSuite run) ] ensure: [ 
+		aTestSuite unsubscribe: TestAnnouncement ]
 ]
 
 { #category : #private }

--- a/src/DrTests-TestsRunner/DTTestsRunnerResult.class.st
+++ b/src/DrTests-TestsRunner/DTTestsRunnerResult.class.st
@@ -62,17 +62,23 @@ DTTestsRunnerResult >> buildTreeForUI [
 		subResults:
 			{DTTreeNode new
 				name: DTTestResultType error pluralName;
-				subResults: (self buildLeavesFrom: self testResults errors asOrderedCollection type: DTTestResultType error);
+				subResults: (self buildLeavesFrom: self errors type: DTTestResultType error);
 				yourself.
 			DTTreeNode new
 				name: DTTestResultType fail pluralName;
-				subResults: (self buildLeavesFrom: self testResults failures asOrderedCollection type: DTTestResultType fail).
+				subResults: (self buildLeavesFrom: self failures type: DTTestResultType fail).
 			DTTreeNode new
 				name: DTTestResultType skipped pluralName;
-				subResults: (self buildLeavesFrom: self testResults skipped asOrderedCollection type: DTTestResultType skipped).
+				subResults: (self buildLeavesFrom: self skipped type: DTTestResultType skipped).
 			DTTreeNode new
 				name: DTTestResultType pass pluralName;
-				subResults: (self buildLeavesFrom: self testResults passed asOrderedCollection type: DTTestResultType pass)
+				subResults: (self buildLeavesFrom: self passed type: DTTestResultType pass).
+			DTTreeNode new
+				name: DTTestResultType expectedFailure pluralName;
+				subResults: (self buildLeavesFrom: self expectedFailures type: DTTestResultType expectedFailure).
+			DTTreeNode new
+				name: DTTestResultType unexpectedPass pluralName;
+				subResults: (self buildLeavesFrom: self unexpectedPassed type: DTTestResultType unexpectedPass).
 		};
 		yourself
 ]

--- a/src/DrTests-TestsRunner/DTTestsRunnerResult.class.st
+++ b/src/DrTests-TestsRunner/DTTestsRunnerResult.class.st
@@ -114,6 +114,34 @@ DTTestsRunnerResult >> buildTreeForUIByClassesAndProtocol [
 ]
 
 { #category : #accessing }
+DTTestsRunnerResult >> errors [
+
+	^ self testResults errors asOrderedCollection
+]
+
+{ #category : #accessing }
+DTTestsRunnerResult >> expectedFailures [
+	^ self testResults expectedDefects
+]
+
+{ #category : #accessing }
+DTTestsRunnerResult >> failures [
+	^ self testResults failures asOrderedCollection 
+	   select: [ :t | t shouldPass ]
+]
+
+{ #category : #accessing }
+DTTestsRunnerResult >> passed [
+	^ self testResults passed asOrderedCollection 
+		select: [ :t | t shouldPass]
+]
+
+{ #category : #accessing }
+DTTestsRunnerResult >> skipped [
+	^ self testResults skipped
+]
+
+{ #category : #accessing }
 DTTestsRunnerResult >> summarizeInfo [
 	"Text showed in miniDrTests with info of the result "
 
@@ -148,4 +176,9 @@ DTTestsRunnerResult >> textColor [
 	testsResult errors ifNotEmpty: [ ^ DTErrorResultType textColor ].
 	testsResult failures ifNotEmpty: [ ^ DTFailResultType textColor  ].
 	^ DTPassResultType textColor
+]
+
+{ #category : #accessing }
+DTTestsRunnerResult >> unexpectedPassed [
+	^ self testResults unexpectedPasses asOrderedCollection
 ]

--- a/src/DrTests-TestsRunner/DTUnexpectedPassResultType.class.st
+++ b/src/DrTests-TestsRunner/DTUnexpectedPassResultType.class.st
@@ -1,0 +1,24 @@
+"
+I model the fact that a test expected to fail passed
+"
+Class {
+	#name : #DTUnexpectedPassResultType,
+	#superclass : #DTTestResultType,
+	#category : #'DrTests-TestsRunner-Results'
+}
+
+{ #category : #factory }
+DTUnexpectedPassResultType class >> backgroundColor [
+	^ TestResult defaultColorBackGroundForUnexpectedPassTest
+]
+
+{ #category : #accessing }
+DTUnexpectedPassResultType >> isUnexpectedPass [
+
+	^ true
+]
+
+{ #category : #accessing }
+DTUnexpectedPassResultType >> name [
+	^ 'Unexpected passed test'
+]


### PR DESCRIPTION
#DrTest and expectedFailures
Many issues has been created about how DrTests deels with expectedFailures. In the following example, many packages has been executed and some of them contains expectedFailures. Here is the result
![Old](https://user-images.githubusercontent.com/68972499/182168762-8a3e8339-7b14-4bd4-8c21-d264aea82e7d.png)

We would like to have categories for such tests (expectedFailure) when they fail or pass. This PR allows that. We can see the result by running the same package:
![New](https://user-images.githubusercontent.com/68972499/182169481-3cfc0c1f-79e7-476c-9aff-9964b8d3530f.png)
![exemple_expected_failure](https://user-images.githubusercontent.com/68972499/182169531-e9c3fe7c-f2a9-4fbe-876d-3cc6098c9304.png)

