### PR TITLE
Fix issue #11496: Executable comments checker of DrTests #11496

### DIFF
--- a/src/DrTests-CommentsToTests/DTCommentTestConfiguration.class.st
+++ b/src/DrTests-CommentsToTests/DTCommentTestConfiguration.class.st
@@ -12,7 +12,7 @@ DTCommentTestConfiguration >> asTestSuite [
 
 	| suite classes methods |
 	suite := TestSuite named: 'Test Generated From Comments'.
-	classes := self items addAll: (self items collect: [ :each | each class ]).
+	classes := self items addAll: (self items collect: [ :each | each class ]); yourself.
 	methods := classes flatCollect: [ :each | each methods ].
 	methods do: [ :method | 
 		method pharoDocCommentNodes do: [ :docComment | 


### PR DESCRIPTION
Some classes was lost while collecting (#11496)
Before:
![beforeChange](https://user-images.githubusercontent.com/68972499/182346551-3065fc92-9fdc-4d10-ae50-4ea001173e9a.png)

Now
![afterChange](https://user-images.githubusercontent.com/68972499/182346605-5b36969a-3aad-488e-b2f1-51bad67ddad7.png)
:
