### PR TITLE
[cleanup] remove empty test classes

### DIFF
--- a/src/AST-Core-Tests/RASTTest.class.st
+++ b/src/AST-Core-Tests/RASTTest.class.st
@@ -1,5 +1,0 @@
-Class {
-	#name : #RASTTest,
-	#superclass : #RBParserTest,
-	#category : #'AST-Core-Tests-Parser'
-}

--- a/src/Calypso-NavigationModel-Tests/ClyQueryResultTest.class.st
+++ b/src/Calypso-NavigationModel-Tests/ClyQueryResultTest.class.st
@@ -1,5 +1,0 @@
-Class {
-	#name : #ClyQueryResultTest,
-	#superclass : #TestCase,
-	#category : #'Calypso-NavigationModel-Tests-Result'
-}

--- a/src/Calypso-SystemPlugins-SUnit-Queries-Tests/ClyAbstractlyNamedTest.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Queries-Tests/ClyAbstractlyNamedTest.class.st
@@ -1,5 +1,0 @@
-Class {
-	#name : #ClyAbstractlyNamedTest,
-	#superclass : #TestCase,
-	#category : #'Calypso-SystemPlugins-SUnit-Queries-Tests'
-}

--- a/src/Calypso-SystemPlugins-SUnit-Queries-Tests/ClyAbstractlyNamedTest.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Queries-Tests/ClyAbstractlyNamedTest.class.st
@@ -1,0 +1,9 @@
+"
+This class is used by test cases to test the coverage.
+See class references.
+"
+Class {
+	#name : #ClyAbstractlyNamedTest,
+	#superclass : #TestCase,
+	#category : #'Calypso-SystemPlugins-SUnit-Queries-Tests'
+}

--- a/src/Calypso-SystemPlugins-SUnit-Queries-Tests/ClyTestedClass2MockTest.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Queries-Tests/ClyTestedClass2MockTest.class.st
@@ -1,5 +1,0 @@
-Class {
-	#name : #ClyTestedClass2MockTest,
-	#superclass : #TestCase,
-	#category : #'Calypso-SystemPlugins-SUnit-Queries-Tests'
-}

--- a/src/Calypso-SystemPlugins-SUnit-Queries-Tests/ClyTestedClass2MockTest.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Queries-Tests/ClyTestedClass2MockTest.class.st
@@ -1,0 +1,9 @@
+"
+This class is used by test cases to test the coverage.
+See class references.
+"
+Class {
+	#name : #ClyTestedClass2MockTest,
+	#superclass : #ClyAbstractNavigationEnvironmentTest,
+	#category : #'Calypso-SystemPlugins-SUnit-Queries-Tests'
+}

--- a/src/Clap-Tests/ClapTestRunnerTest.class.st
+++ b/src/Clap-Tests/ClapTestRunnerTest.class.st
@@ -1,5 +1,0 @@
-Class {
-	#name : #ClapTestRunnerTest,
-	#superclass : #ClapPharoCommandsTest,
-	#category : #'Clap-Tests-Commands'
-}

--- a/src/FreeType/FT2Face.class.st
+++ b/src/FreeType/FT2Face.class.st
@@ -488,19 +488,25 @@ FT2Face >> maxAdvanceWidth [
 
 { #category : #initialization }
 FT2Face >> newFaceFromExternalMemory: aFreeTypeExternalMemory index: anInteger [
-	| memSize holder returnCode |
 
+	| memSize holder returnCode |
 	aFreeTypeExternalMemory validate.
 	memSize := aFreeTypeExternalMemory bytes size.
 	holder := PointerHolder new.
-	
+
 	FT2Library current checkLibrary.
-	returnCode := FT2Library current ffiNewFace: holder fromMemory: aFreeTypeExternalMemory handle size: memSize  index: anInteger.
-	returnCode ~= 0
-		ifTrue: [ FT2Error errorCode: returnCode signal: 'Error reading new face from memory'].
-		
+	returnCode := FT2Library current
+		              ffiNewFace: holder
+		              fromMemory: aFreeTypeExternalMemory getHandle
+		              size: memSize
+		              index: anInteger.
+	returnCode ~= 0 ifTrue: [ 
+		FT2Error
+			errorCode: returnCode
+			signal: 'Error reading new face from memory' ].
+
 	handle := holder value.
-	self autoRelease.
+	self autoRelease
 ]
 
 { #category : #initialization }

--- a/src/Network-Tests/HTTPEncodingTest.class.st
+++ b/src/Network-Tests/HTTPEncodingTest.class.st
@@ -1,8 +1,0 @@
-"
-SUnit tests for HTTPEncoding
-"
-Class {
-	#name : #HTTPEncodingTest,
-	#superclass : #TestCase,
-	#category : #'Network-Tests-Protocols'
-}

--- a/src/Ombu-Tests/OmSequentialSuffixStrategyTest.class.st
+++ b/src/Ombu-Tests/OmSequentialSuffixStrategyTest.class.st
@@ -1,8 +1,0 @@
-"
-An OmSecuentialSuffixStrategyTest is a test class for testing the behavior of OmSecuentialSuffixStrategy
-"
-Class {
-	#name : #OmSequentialSuffixStrategyTest,
-	#superclass : #OmSessionStoreNameStrategyTest,
-	#category : #'Ombu-Tests'
-}

--- a/src/Ombu-Tests/OmTimeStampSuffixStrategyTest.class.st
+++ b/src/Ombu-Tests/OmTimeStampSuffixStrategyTest.class.st
@@ -1,8 +1,0 @@
-"
-An OmTimeStampSuffixStrategyTest is a test class for testing the behavior of OmTimeStampSuffixStrategy
-"
-Class {
-	#name : #OmTimeStampSuffixStrategyTest,
-	#superclass : #OmSessionStoreNameStrategyTest,
-	#category : #'Ombu-Tests'
-}

--- a/src/Ring-Tests-Core/RGMergeErrorTest.class.st
+++ b/src/Ring-Tests-Core/RGMergeErrorTest.class.st
@@ -1,5 +1,0 @@
-Class {
-	#name : #RGMergeErrorTest,
-	#superclass : #RGTest,
-	#category : #'Ring-Tests-Core'
-}

--- a/src/Rubric-Tests/RubAbstractTextAreaTest.class.st
+++ b/src/Rubric-Tests/RubAbstractTextAreaTest.class.st
@@ -1,8 +1,0 @@
-"
-A RubAbstractTextAreaTest is a test class for testing the behavior of RubAbstractTextArea
-"
-Class {
-	#name : #RubAbstractTextAreaTest,
-	#superclass : #TestCase,
-	#category : #'Rubric-Tests-Base'
-}

--- a/src/Rubric-Tests/RubEditingAreaTest.class.st
+++ b/src/Rubric-Tests/RubEditingAreaTest.class.st
@@ -3,7 +3,7 @@ A RubEditingAreaTest is a test class for testing the behavior of RubEditingArea
 "
 Class {
 	#name : #RubEditingAreaTest,
-	#superclass : #RubAbstractTextAreaTest,
+	#superclass : #TestCase,
 	#instVars : [
 		'area',
 		'position',

--- a/src/Text-Tests/MultiFontTest.class.st
+++ b/src/Text-Tests/MultiFontTest.class.st
@@ -1,8 +1,0 @@
-"
-Test for internationalized fonts
-"
-Class {
-	#name : #MultiFontTest,
-	#superclass : #TestCase,
-	#category : #'Text-Tests-Fonts'
-}


### PR DESCRIPTION
Multiple test classes are currently empty in a new image.
This PR removes them.
There was also an empty test superclass.

Let me know if something may be an issue.