### PR TITLE
Clean version of PR 11498: DrTests: Rerunning test

### DIFF
--- a/src/DrTests-TestsRunner/DTRerunCommand.class.st
+++ b/src/DrTests-TestsRunner/DTRerunCommand.class.st
@@ -7,9 +7,9 @@ Class {
 	#category : #'DrTests-TestsRunner-Commands'
 }
 
-{ #category : #hooks }
+{ #category : #executing }
 DTRerunCommand >> execute [
-	self context runPluginFor: (self plugin buildReRunConfigurationFrom: self context)
+	self context drTests runPluginFor: (self plugin buildReRunConfigurationFrom: self context drTests)
 ]
 
 { #category : #hooks }

--- a/src/DrTests-TestsRunner/DrTestsPlugin.extension.st
+++ b/src/DrTests-TestsRunner/DrTestsPlugin.extension.st
@@ -7,6 +7,6 @@ DrTestsPlugin >> buildReRunConfigurationFrom: aDrTests [
 	^ DTReRunConfiguration new
 		originalConfiguration: aDrTests testsConfiguration;
 		previousResult: aDrTests pluginResult;
-		configurationToRun: (DTTestsRunnerConfiguration items: aDrTests resultSelected contentForReRun);
+		configurationToRun: (DTTestsRunnerConfiguration items: aDrTests contentForReRun);
 		yourself
 ]

--- a/src/DrTests/DTDefaultPluginPresenter.class.st
+++ b/src/DrTests/DTDefaultPluginPresenter.class.st
@@ -137,6 +137,11 @@ DTDefaultPluginPresenter >> connectPresenters [
 						roots: (resultTreeViewOrNil resultTreeFor: drTests pluginResult) subResults ] ].
 ]
 
+{ #category : #accessing }
+DTDefaultPluginPresenter >> drTests [
+	^ drTests
+]
+
 { #category : #'private - initialization' }
 DTDefaultPluginPresenter >> initializeItemsListAndLabel [
 

--- a/src/DrTests/DrTests.class.st
+++ b/src/DrTests/DrTests.class.st
@@ -103,6 +103,12 @@ DrTests >> connectPresenters [
 	self currentPlugin: self pluginsDropList selectedItem new
 ]
 
+{ #category : #'accessing - subwidgets' }
+DrTests >> contentForReRun [
+
+	^ self pluginPresenter resultSelected contentForReRun
+]
+
 { #category : #accessing }
 DrTests >> currentPlugin: aPlugin [
 


### PR DESCRIPTION
Rerunning test in DrTets raised error. Now fixed.
For more details, see PR #11498 (closed).
The first attempt was closed because the branch mixed two pending PR. 