### PR TITLE
11533-Ring-RGMethodDefinitionisDoIt-missing

### DIFF
--- a/src/Ring-Definitions-Core/RGMethodDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGMethodDefinition.class.st
@@ -325,6 +325,11 @@ RGMethodDefinition >> isDefined [
 	^rClass notNil and: [ rClass includesSelector: self selector ]
 ]
 
+{ #category : #testing }
+RGMethodDefinition >> isDoIt [
+	^self selector isDoIt
+]
+
 { #category : #'testing - SUnit-support' }
 RGMethodDefinition >> isErrorTest [
 	"Is the receiver a test method that raised an error?"


### PR DESCRIPTION
add #isDoIt so that RB methods can be used where compiledmethods are used.

fixes #11533