### PR TITLE
Fix #11540: Selecting a string and pressing Implementors breaks in Calypso New Class pane

### DIFF
--- a/src/Calypso-SystemTools-QueryBrowser/ClyTextEditor.extension.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyTextEditor.extension.st
@@ -27,7 +27,7 @@ ClyTextEditor >> implementorsOf: selectedSelector [
 
 	self browser
 		browseImplementorsOf: selectedSelector
-		inNameResolver: self browserTool editingMethod methodClass
+		inNameResolver: self browserTool selectedClassOrMetaClass
 ]
 
 { #category : #'*Calypso-SystemTools-QueryBrowser' }
@@ -79,7 +79,7 @@ ClyTextEditor >> sendersOf: selectedSelector [
 
 	self browser
 		browseReferencesTo: selectedSelector
-		inNameResolver: self browserTool editingMethod methodClass
+		inNameResolver: self browserTool selectedClassOrMetaClass
 ]
 
 { #category : #'*Calypso-SystemTools-QueryBrowser' }


### PR DESCRIPTION
Use #selectedClassOrMetaClass instead of asking for the #editingMethod. Each tool will extract the correct class on demand