### PR TITLE
Upgrade iceberg to 2.0.7 -- backport to Pharo 9

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -13,7 +13,7 @@ BaselineOfPharo class >> icebergRepository [
 { #category : #versions }
 BaselineOfPharo class >> icebergVersion [
 
-	^ 'v2.0.5'
+	^ 'v2.0.7'
 ]
 
 { #category : #versions }


### PR DESCRIPTION
Including bug fixes and libgit1.4.4