### PR TITLE
Fix case insensitive auto-completion setting

### DIFF
--- a/src/HeuristicCompletion-Model/CoCompletionContext.class.st
+++ b/src/HeuristicCompletion-Model/CoCompletionContext.class.st
@@ -155,7 +155,7 @@ CoCompletionContext >> isScripting [
 { #category : #narrowing }
 CoCompletionContext >> narrowWith: aString [ 
 
-	self completion replaceFilterWith: (CoCaseSensitiveBeginsWithFilter filterString: aString)
+	self completion replaceFilterWith: (CoBeginsWithFilter caseSensitive: NECPreferences caseSensitive filterString: aString)
 ]
 
 { #category : #accessing }

--- a/src/HeuristicCompletion-Model/CoGlobalVariableFetcher.class.st
+++ b/src/HeuristicCompletion-Model/CoGlobalVariableFetcher.class.st
@@ -27,6 +27,7 @@ CoGlobalVariableFetcher >> entriesDo: aBlock [
 	self systemNavigation
 		allClassNamesStartingWith: filter completionString 
 		do: [ :e | aBlock value: (NECGlobalEntry contents: e node: astNode) ]
+		caseSensitive: (NECPreferences caseSensitive)
 ]
 
 { #category : #accessing }

--- a/src/HeuristicCompletion-Tests/CoMockSystemNavigation.class.st
+++ b/src/HeuristicCompletion-Tests/CoMockSystemNavigation.class.st
@@ -19,6 +19,14 @@ CoMockSystemNavigation >> allClassNamesStartingWith: aString do: aBlock [
 			ifTrue: [ aBlock value: e ] ]
 ]
 
+{ #category : #query }
+CoMockSystemNavigation >> allClassNamesStartingWith: aString do: aBlock caseSensitive: cs [
+
+	globals do: [ :e |
+		(aString isEmpty or: [ e beginsWith: aString caseSensitive: cs ])
+			ifTrue: [ aBlock value: e ] ]
+]
+
 { #category : #accessing }
 CoMockSystemNavigation >> allSelectorsStartingWith: aString do: aBlock [
 

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -40,7 +40,7 @@ SystemNavigation >> allCallsOn: aSymbol [
 { #category : #query }
 SystemNavigation >> allClassNamesStartingWith: aString do: aBlock [
 
-	self allClassNamesStartingWith: aString do: aBlock caseSensitive: false
+	self allClassNamesStartingWith: aString do: aBlock caseSensitive: true
 ]
 
 { #category : #query }

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -46,6 +46,14 @@ SystemNavigation >> allClassNamesStartingWith: aString do: aBlock [
 ]
 
 { #category : #query }
+SystemNavigation >> allClassNamesStartingWith: aString do: aBlock caseSensitive: cs [
+
+	self allClassesDo: [ :e |
+		(e name beginsWith: aString caseSensitive: cs)
+			ifTrue: [ aBlock value: e name ] ]
+]
+
+{ #category : #query }
 SystemNavigation >> allClasses [
 	"Returns all the classes in the current environment."
 

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -40,9 +40,7 @@ SystemNavigation >> allCallsOn: aSymbol [
 { #category : #query }
 SystemNavigation >> allClassNamesStartingWith: aString do: aBlock [
 
-	self allClassesDo: [ :e |
-		(e name beginsWith: aString)
-			ifTrue: [ aBlock value: e name ] ]
+	self allClassNamesStartingWith: aString do: aBlock caseSensitive: false
 ]
 
 { #category : #query }


### PR DESCRIPTION
Attempts to fix #11445 

Replaces hardcoded calls to `CoCaseSensitiveBeginsWithFilter>>#filterString` with the factory method call where relevant, also adds an overload to `#allClassNamesStartingWith` allowing case-insensitive retrieval of class names by prefix