### PR TITLE
Categorize RBShortAssignmentToken>>#length like superclass

### DIFF
--- a/src/AST-Core/RBShortAssignmentToken.class.st
+++ b/src/AST-Core/RBShortAssignmentToken.class.st
@@ -8,7 +8,8 @@ Class {
 	#category : #'AST-Core-Tokens'
 }
 
-{ #category : #private }
+{ #category : #accessing }
 RBShortAssignmentToken >> length [
+
 	^ 1
 ]


### PR DESCRIPTION
Fix #11568