### PR TITLE
Attempt to fix scrolling behavior in RubAbstractTextArea & friends

### DIFF
--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -994,7 +994,7 @@ RubAbstractTextArea >> handleEdit: editBlock [
 	editBlock value.
 	"Fit to width on edit"
 	(self grow isNotNil & self grow) ifTrue: [
-		self width: (1 max: self maxLineWidth)
+		self width: (1 max: self maxLineWidth + self margins left + self margins right)
 	].
 	self selectionChanged	"Note new selection"
 ]
@@ -1328,7 +1328,7 @@ RubAbstractTextArea >> maxLineWidth [
 	w := 0.
 	self string linesDo: [ :line | w := w max: (self font widthOfString: line) ].
 	"check this later, not really sure about this calculation"
-	^ w * 6 // 5 + self margins left + self margins right
+	^ w * 6 // 5
 ]
 
 { #category : #accessing }

--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -96,6 +96,7 @@ Class {
 		'mouseDownPoint',
 		'completionEngine',
 		'maxLength',
+		'grow',
 		'findReplaceService',
 		'editing'
 	],
@@ -991,6 +992,10 @@ RubAbstractTextArea >> handleEdit: editBlock [
 	"Ensure that changed areas get suitably redrawn"
 
 	editBlock value.
+	"Fit to width on edit"
+	(self grow isNotNil & self grow) ifTrue: [
+		self width: (1 max: self maxLineWidth)
+	].
 	self selectionChanged	"Note new selection"
 ]
 
@@ -1300,6 +1305,30 @@ RubAbstractTextArea >> maxLength: anInteger [
 	"Set the maximum number of characters that may be typed."
 
 	maxLength := anInteger max: 0
+]
+
+{ #category : #accessing }
+RubAbstractTextArea >> grow [
+	"Answer whether the area should grow horizontally."
+
+	^ grow
+]
+
+{ #category : #accessing }
+RubAbstractTextArea >> grow: aBool [
+	"Set whether the area should grow horizontally."
+
+	grow := aBool
+]
+
+{ #category : #measuring }
+RubAbstractTextArea >> maxLineWidth [
+	"Answers with the maximum approximate pixel width across all lines"
+	| w |
+	w := 0.
+	self string linesDo: [ :line | w := w max: (self font widthOfString: line) ].
+	"check this later, not really sure about this calculation"
+	^ w * 6 // 5 + self margins left + self margins right
 ]
 
 { #category : #accessing }

--- a/src/Rubric/RubScrolledTextMorph.class.st
+++ b/src/Rubric/RubScrolledTextMorph.class.st
@@ -330,6 +330,7 @@ RubScrolledTextMorph >> defaultGhostTextMorph [
 RubScrolledTextMorph >> defaultScrollTarget [
 	| textArea |
 	textArea := self textAreaClass new.
+	textArea grow: true. "Ensure morph width tracks line width"
 	textArea backgroundColor: Color lightGray veryMuchLighter.
 	^ textArea
 ]


### PR DESCRIPTION
Attempts to fix #10666

Adds a flag that, if enabled, automatically resizes the text area horizontally so that its width equals the approximate point size of the longest text line in the editing pane. The flag is enabled by default for `RubScrolledTextMorph`'s textArea, thus alleviating issues with scrolling in Iceberg & Epicea's changeset viewers.