### PR TITLE
Make explicit hostname and port work with bitbucket

### DIFF
--- a/src/Metacello-Bitbucket/MCBitbucketRepository.class.st
+++ b/src/Metacello-Bitbucket/MCBitbucketRepository.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #MCBitbucketRepository,
-	#superclass : #MCGitBasedNetworkRepository,
+	#superclass : #MCPrivateHostableRepository,
 	#category : #'Metacello-Bitbucket'
 }
 
@@ -21,15 +21,14 @@ MCBitbucketRepository class >> createRepositoryFromSpec: aRepositorySpec on: aPl
 	^ aPlatform createBitbucketRepository: aRepositorySpec
 ]
 
-{ #category : #testing }
-MCBitbucketRepository class >> isAvailableFor: type [
-	^ type = 'bitbucket'
+{ #category : #private }
+MCBitbucketRepository class >> defaultHostname [
+	^ 'bitbucket.org'
 ]
 
 { #category : #testing }
-MCBitbucketRepository class >> isEnabled [
-
-	^true
+MCBitbucketRepository class >> isAvailableFor: type [
+	^ type = 'bitbucket'
 ]
 
 { #category : #private }

--- a/src/Metacello-GitBasedRepository/MCGitBasedNetworkRepository.class.st
+++ b/src/Metacello-GitBasedRepository/MCGitBasedNetworkRepository.class.st
@@ -112,7 +112,7 @@ MCGitBasedNetworkRepository class >> initialize [
 MCGitBasedNetworkRepository class >> isAbstract [
     "abstract as far as creating new repositories interactively? yes"
 
-    ^ true
+    ^ self == MCGitBasedNetworkRepository
 ]
 
 { #category : #testing }

--- a/src/Metacello-GitBasedRepository/MCPrivateHostableRepository.class.st
+++ b/src/Metacello-GitBasedRepository/MCPrivateHostableRepository.class.st
@@ -1,0 +1,96 @@
+"
+I am a repository that can be hosted privately using for example, a private instance of bitbucket or gitlab.
+I can parse different kind of URIs, containing the host, in the following format:
+
+hosting://[host:]owner/project[:version]/code/path'
+"
+Class {
+	#name : #MCPrivateHostableRepository,
+	#superclass : #MCGitBasedNetworkRepository,
+	#instVars : [
+		'hostname',
+		'sshPort'
+	],
+	#category : #'Metacello-GitBasedRepository'
+}
+
+{ #category : #testing }
+MCPrivateHostableRepository class >> isAbstract [
+    "abstract as far as creating new repositories interactively? yes"
+
+    ^ self == MCPrivateHostableRepository
+]
+
+{ #category : #testing }
+MCPrivateHostableRepository class >> isEnabled [
+
+	^ true
+]
+
+{ #category : #private }
+MCPrivateHostableRepository class >> parseLocation: locationUrl version: versionString [
+	"Gitlab can be self hosted, so we need some way to tell in the location the service url and not use gitlab.com in 
+	a hardcoded way.
+	This parsing extensions supports adding the hostname before the project owner name:
+	Eg. gitlab://selfhostedgitlab.com:owner/project
+	If no hostname is specified default to the old behavior (using gitlab.com)
+	"
+
+	| location hostAndOwner |
+	"Remove gitlab:// prefix"
+	location := locationUrl copyFrom: self description size + 1 to: locationUrl size.
+	"Take the next chunk up to the first / and split it to get the hostname and owner"
+	hostAndOwner := (location copyFrom: 1 to: (location indexOf: $/)) splitOn: $:.
+	^ hostAndOwner size = 1
+		ifTrue: [ "No hostname specified, so use the default one"
+			(super parseLocation: locationUrl version: versionString)
+				hostname: self defaultHostname;
+				yourself ]
+		ifFalse: [ | newLocationUrl hostname sshPort numberOfCharactersToRemoveFromLocation |
+			hostname := hostAndOwner first.
+			numberOfCharactersToRemoveFromLocation := hostname size + 2.
+			"If the hostAndOwner array has 3 parts, we have a ssh port"
+			hostAndOwner size > 2
+				ifTrue: [ sshPort := hostAndOwner second.
+					numberOfCharactersToRemoveFromLocation := numberOfCharactersToRemoveFromLocation + sshPort size + 1 ].	
+			newLocationUrl := self description , (location copyFrom: numberOfCharactersToRemoveFromLocation to: location size).
+			"Reuse the parsing omitting the hostname"
+			(super parseLocation: newLocationUrl version: versionString)
+				hostname: hostname;
+				sshPort: sshPort;
+				yourself ]
+]
+
+{ #category : #accessing }
+MCPrivateHostableRepository >> hostname [
+	^ hostname
+]
+
+{ #category : #initialization }
+MCPrivateHostableRepository >> hostname: aString [ 
+	hostname := aString
+]
+
+{ #category : #accessing }
+MCPrivateHostableRepository >> httpsUrl [
+	^ 'https://<1s>/<2s>.git' expandMacrosWith: self hostname with: projectPath
+]
+
+{ #category : #accessing }
+MCPrivateHostableRepository >> scpUrl [
+	"If the sshPort is not nil it means that we have a non default ssh port. Thus we need to add `ssh://` and th port number to the scheme"
+
+	^ self sshPort
+		ifNil: [ 'git@<1s>:<2s>.git' expandMacrosWith: self hostname with: projectPath ]
+		ifNotNil: [ :port | 'ssh://git@<1s>:<2s>/<3s>.git' expandMacrosWith: self hostname with: port with: projectPath ]
+]
+
+{ #category : #accessing }
+MCPrivateHostableRepository >> sshPort [
+	^ sshPort
+]
+
+{ #category : #accessing }
+MCPrivateHostableRepository >> sshPort: anObject [
+	sshPort := anObject
+]

--- a/src/Metacello-Gitlab/MCGitlabRepository.class.st
+++ b/src/Metacello-Gitlab/MCGitlabRepository.class.st
@@ -28,11 +28,7 @@ Internal Representation and Key Implementation Points.
 "
 Class {
 	#name : #MCGitlabRepository,
-	#superclass : #MCGitBasedNetworkRepository,
-	#instVars : [
-		'hostname',
-		'sshPort'
-	],
+	#superclass : #MCPrivateHostableRepository,
 	#category : #'Metacello-Gitlab'
 }
 
@@ -53,67 +49,7 @@ MCGitlabRepository class >> defaultHostname [
 	^ 'gitlab.com'
 ]
 
-{ #category : #testing }
-MCGitlabRepository class >> isEnabled [
-
-	^ true
-]
-
-{ #category : #private }
-MCGitlabRepository class >> parseLocation: locationUrl version: versionString [
-	"Gitlab can be self hosted, so we need some way to tell in the location the service url and not use gitlab.com in 
-	a hardcoded way.
-	This parsing extensions supports adding the hostname before the project owner name:
-	Eg. gitlab://selfhostedgitlab.com:owner/project
-	If no hostname is specified default to the old behavior (using gitlab.com)
-	"
-
-	| location hostAndOwner |
-	"Remove gitlab:// prefix"
-	location := locationUrl copyFrom: self description size + 1 to: locationUrl size.
-	"Take the next chunk up to the first / and split it to get the hostname and owner"
-	hostAndOwner := (location copyFrom: 1 to: (location indexOf: $/)) splitOn: $:.
-	^ hostAndOwner size = 1
-		ifTrue: [ "No hostname specified, so use the default one"
-			(super parseLocation: locationUrl version: versionString)
-				hostname: self defaultHostname;
-				yourself ]
-		ifFalse: [ | newLocationUrl hostname sshPort numberOfCharactersToRemoveFromLocation |
-			hostname := hostAndOwner first.
-			numberOfCharactersToRemoveFromLocation := hostname size + 2.
-			"If the hostAndOwner array has 3 parts, we have a ssh port"
-			hostAndOwner size > 2
-				ifTrue: [ sshPort := hostAndOwner second.
-					numberOfCharactersToRemoveFromLocation := numberOfCharactersToRemoveFromLocation + sshPort size + 1 ].	
-			newLocationUrl := self description , (location copyFrom: numberOfCharactersToRemoveFromLocation to: location size).
-			"Reuse the parsing omitting the hostname"
-			(super parseLocation: newLocationUrl version: versionString)
-				hostname: hostname;
-				sshPort: sshPort;
-				yourself ]
-]
-
-{ #category : #accessing }
-MCGitlabRepository >> hostname [
-	^ hostname
-]
-
-{ #category : #initialization }
-MCGitlabRepository >> hostname: aString [ 
-	hostname := aString
-]
-
 { #category : #private }
 MCGitlabRepository >> projectTagsUrlFor: aProjectPath [
 	^ 'https://<1s>/api/v4/projects/<2s>/repository/tags' expandMacrosWith: self hostname with: aProjectPath
-]
-
-{ #category : #accessing }
-MCGitlabRepository >> sshPort [
-	^ sshPort
-]
-
-{ #category : #accessing }
-MCGitlabRepository >> sshPort: anObject [
-	sshPort := anObject
 ]

--- a/src/Monticello-Tests/MCRepositoryTest.class.st
+++ b/src/Monticello-Tests/MCRepositoryTest.class.st
@@ -85,6 +85,44 @@ MCRepositoryTest >> testAddAndLoad [
 ]
 
 { #category : #tests }
+MCRepositoryTest >> testCanCreateBitBucketRepositoryFromUrl [
+
+	repository := MCBitbucketRepository location: 'bitbucket://dalehenrich/MetacelloRepository:master/monticello/repos/itory/path'.
+	
+	self assert: repository projectPath equals: 'dalehenrich/MetacelloRepository'.
+	self assert: repository projectVersion equals: 'master'.
+	self assert: repository repoPath equals: 'monticello/repos/itory/path'.
+	
+	self assert: repository hostname equals: 'bitbucket.org'.
+]
+
+{ #category : #tests }
+MCRepositoryTest >> testCanCreateBitBucketRepositoryFromUrlWithExplicitHost [
+
+	repository := MCBitbucketRepository location: 'bitbucket://one.other.host:dalehenrich/MetacelloRepository:master/monticello/repos/itory/path'.
+
+	self assert: repository projectPath equals: 'dalehenrich/MetacelloRepository'.
+	self assert: repository projectVersion equals: 'master'.
+	self assert: repository repoPath equals: 'monticello/repos/itory/path'.
+	
+	self assert: repository hostname equals: 'one.other.host'.
+	self assert: repository sshPort equals: nil.
+]
+
+{ #category : #tests }
+MCRepositoryTest >> testCanCreateBitBucketRepositoryFromUrlWithExplicitHostAndPort [
+
+	repository := MCBitbucketRepository location: 'bitbucket://one.other.host:220:dalehenrich/MetacelloRepository:master/monticello/repos/itory/path'.
+
+	self assert: repository projectPath equals: 'dalehenrich/MetacelloRepository'.
+	self assert: repository projectVersion equals: 'master'.
+	self assert: repository repoPath equals: 'monticello/repos/itory/path'.
+	
+	self assert: repository hostname equals: 'one.other.host'.
+	self assert: repository sshPort equals: '220'.
+]
+
+{ #category : #tests }
 MCRepositoryTest >> testCanCreateFileRepositoryFromUrl [
 	repository := MCRepository fromUrl: 'file:///tmp'.
 	self assert: (repository isKindOf: MCFileBasedRepository) 


### PR DESCRIPTION
Make explicit hostname and port available to bitbucket in addition to gitlab.

- Refactor gitlab support to abstract it and make it work for bitbucket
- Add some tests
- [TODO] I moved some methods from iceberg extensions to these MC repos, we will need to remove the iceberg extensions for this to work