### PR TITLE
SpRubFindReplaceDialog: Clear selection on close

### DIFF
--- a/src/Rubric-SpecFindReplaceDialog/SpRubFindReplaceDialog.class.st
+++ b/src/Rubric-SpecFindReplaceDialog/SpRubFindReplaceDialog.class.st
@@ -119,7 +119,7 @@ SpRubFindReplaceDialog >> initializeDialogWindow: aDialogWindowPresenter [
 		title: self title;
 		initialExtent: 430 @ 220.
 		
-	aDialogWindowPresenter whenClosedDo: [ service discardDialog. service findText: '' ]
+	aDialogWindowPresenter whenClosedDo: [ service findText: ''. service discardDialog ]
 ]
 
 { #category : #initialization }

--- a/src/Rubric-SpecFindReplaceDialog/SpRubFindReplaceDialog.class.st
+++ b/src/Rubric-SpecFindReplaceDialog/SpRubFindReplaceDialog.class.st
@@ -119,7 +119,7 @@ SpRubFindReplaceDialog >> initializeDialogWindow: aDialogWindowPresenter [
 		title: self title;
 		initialExtent: 430 @ 220.
 		
-	aDialogWindowPresenter whenClosedDo: [ service discardDialog ]
+	aDialogWindowPresenter whenClosedDo: [ service discardDialog. service findText: '' ]
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
Fix #11601

This clears the highlighted text when the "Find & Replace" dialog is closed. This makes the dialog behave in a similar way to Gedit, Kate, and other GUI editors on common desktop environments.