### PR TITLE
Fix leaking subscriptions in SpRubFindReplaceService

### DIFF
--- a/src/Rubric-SpecFindReplaceDialog/SpRubFindReplaceService.class.st
+++ b/src/Rubric-SpecFindReplaceDialog/SpRubFindReplaceService.class.st
@@ -9,7 +9,8 @@ Class {
 	#instVars : [
 		'dialog',
 		'dialogWindow',
-		'textAreaHolder'
+		'textAreaHolder',
+		'findReplaceRequiredSubscription'
 	],
 	#category : #'Rubric-SpecFindReplaceDialog'
 }
@@ -140,9 +141,21 @@ SpRubFindReplaceService >> textArea [
 
 { #category : #services }
 SpRubFindReplaceService >> textArea: aTextArea [
+	| oldTextArea |
+	oldTextArea := textAreaHolder at: 1 ifAbsent: nil.
 	textAreaHolder at: 1 put: aTextArea.
-	aTextArea announcer 
+	oldTextArea == aTextArea ifTrue: [ ^ self ].
+	self unsubscribeFindReplaceWindowRequired.
+	findReplaceRequiredSubscription := aTextArea announcer
 		when: RubFindReplaceWindowRequired send: #whenFindReplaceWindowRequired: to: self.
+]
+
+{ #category : #private }
+SpRubFindReplaceService >> unsubscribeFindReplaceWindowRequired [
+
+	findReplaceRequiredSubscription ifNil: [ ^ self ].
+	findReplaceRequiredSubscription announcer removeSubscription: findReplaceRequiredSubscription.
+	findReplaceRequiredSubscription := nil
 ]
 
 { #category : #updating }

--- a/src/Rubric-SpecFindReplaceDialog/SpRubFindReplaceService.class.st
+++ b/src/Rubric-SpecFindReplaceDialog/SpRubFindReplaceService.class.st
@@ -141,9 +141,10 @@ SpRubFindReplaceService >> textArea [
 { #category : #services }
 SpRubFindReplaceService >> textArea: aTextArea [
 	| oldTextArea |
-	oldTextArea := textAreaHolder at: 1 ifAbsent: nil.
-	textAreaHolder at: 1 put: aTextArea.
+	oldTextArea := textAreaHolder at: 1 ifAbsent: nil. 
 	oldTextArea == aTextArea ifTrue: [ ^ self ].
+	oldTextArea ifNotNil: [ oldTextArea announcer unsubscribe: self ].
+	textAreaHolder at: 1 put: aTextArea.
 	aTextArea announcer
 		when: RubFindReplaceWindowRequired send: #whenFindReplaceWindowRequired: to: self.
 ]

--- a/src/Rubric-SpecFindReplaceDialog/SpRubFindReplaceService.class.st
+++ b/src/Rubric-SpecFindReplaceDialog/SpRubFindReplaceService.class.st
@@ -9,8 +9,7 @@ Class {
 	#instVars : [
 		'dialog',
 		'dialogWindow',
-		'textAreaHolder',
-		'findReplaceRequiredSubscription'
+		'textAreaHolder'
 	],
 	#category : #'Rubric-SpecFindReplaceDialog'
 }
@@ -145,17 +144,8 @@ SpRubFindReplaceService >> textArea: aTextArea [
 	oldTextArea := textAreaHolder at: 1 ifAbsent: nil.
 	textAreaHolder at: 1 put: aTextArea.
 	oldTextArea == aTextArea ifTrue: [ ^ self ].
-	self unsubscribeFindReplaceWindowRequired.
-	findReplaceRequiredSubscription := aTextArea announcer
+	aTextArea announcer
 		when: RubFindReplaceWindowRequired send: #whenFindReplaceWindowRequired: to: self.
-]
-
-{ #category : #private }
-SpRubFindReplaceService >> unsubscribeFindReplaceWindowRequired [
-
-	findReplaceRequiredSubscription ifNil: [ ^ self ].
-	findReplaceRequiredSubscription announcer removeSubscription: findReplaceRequiredSubscription.
-	findReplaceRequiredSubscription := nil
 ]
 
 { #category : #updating }


### PR DESCRIPTION
Fixes #11603 

This fixes the subscription leak that causes #11603 by making `SpRubFindReplaceService>>#textArea:` idempotent.
We also make sure to unsubscribe from the announcer if the target text area is changed for some reason.