### PR TITLE
OSSDL2FormRenderer: Release texture manually to avoid spike in memory usage

### DIFF
--- a/src/OSWindow-SDL2/OSSDL2FormRenderer.class.st
+++ b/src/OSWindow-SDL2/OSSDL2FormRenderer.class.st
@@ -37,7 +37,7 @@ OSSDL2FormRenderer >> createRenderer [
 { #category : #private }
 OSSDL2FormRenderer >> createTexture [
 	"Existing texture released explicitly to avoid memory leak on resize (issue#11183)"
-	texture ifNotNil: [ texture destroy. texture := nil ].
+	texture destroy.
 	texture := renderer createTextureFormat: SDL_PIXELFORMAT_XRGB8888
 						access: SDL_TEXTUREACCESS_STREAMING width: form width height: form height.
 	extent := form extent

--- a/src/OSWindow-SDL2/OSSDL2FormRenderer.class.st
+++ b/src/OSWindow-SDL2/OSSDL2FormRenderer.class.st
@@ -36,6 +36,8 @@ OSSDL2FormRenderer >> createRenderer [
 
 { #category : #private }
 OSSDL2FormRenderer >> createTexture [
+	"Existing texture released explicitly to avoid memory leak on resize (issue#11183)"
+	texture ifNotNil: [ texture destroy. texture := nil ].
 	texture := renderer createTextureFormat: SDL_PIXELFORMAT_XRGB8888
 						access: SDL_TEXTUREACCESS_STREAMING width: form width height: form height.
 	extent := form extent


### PR DESCRIPTION
Fixes #11183

This avoids spikes in memory usage causing issues like #11183