### PR TITLE
adding entries in the debug world menu to enable / disable all breakpoints in the image

### DIFF
--- a/src/Reflectivity/Breakpoint.class.st
+++ b/src/Reflectivity/Breakpoint.class.st
@@ -88,13 +88,25 @@ Breakpoint class >> cleanUp [
 
 { #category : #'world menu' }
 Breakpoint class >> debugWorldMenuOn: aBuilder [
+
 	<worldMenu>
-	
 	(aBuilder item: #'Remove all Breakpoints')
 		parent: #Breakpoints;
 		order: 2;
 		help: 'Remove all the breakpoints of the image.';
-		action: [ self removeAll ]
+		action: [ self removeAll ].
+
+	(aBuilder item: #'Enable all Breakpoints')
+		parent: #Breakpoints;
+		order: 2;
+		help: 'Enable all the breakpoints of the image.';
+		action: [ self all do: #enable ].
+
+	(aBuilder item: #'Disable all Breakpoints')
+		parent: #Breakpoints;
+		order: 2;
+		help: 'Disable all the breakpoints of the image.';
+		action: [ self all do: #disable ]
 ]
 
 { #category : #'system announcements' }


### PR DESCRIPTION
Fix #11599 

I added entries in the debug world menu so that we can disable and tenable all breakpoints in the image.

This is something that could be done programatically but a shortcut is not too much for that as this is something that not everybody knows we can do and, sometimes, we regularly want to remove/put again breakpoints. And people that don't know do that manually