### PR TITLE
Improving the speed of the compiler when compiling methods with a lot of literals

### DIFF
--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -499,7 +499,7 @@ Symbol >> isUnary [
 { #category : #comparing }
 Symbol >> literalEqual: other [
 
-	^ self class == other class and: [self == other]
+	^ self == other
 ]
 
 { #category : #'system primitives' }

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -496,6 +496,12 @@ Symbol >> isUnary [
 	^ self precedence = 1
 ]
 
+{ #category : #comparing }
+Symbol >> literalEqual: other [
+
+	^ self class == other class and: [self == other]
+]
+
 { #category : #'system primitives' }
 Symbol >> numArgs: n [
 	"Answer a string that can be used as a selector with n arguments.

--- a/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
+++ b/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
@@ -100,8 +100,8 @@ IRBytecodeGenerator >> addLastLiteral: object [
 
 { #category : #private }
 IRBytecodeGenerator >> addLiteral: object [
-	literals add: object.
-	^ literals identityIndexOf: object
+	^ literals addLiteral: object.
+
 ]
 
 { #category : #private }
@@ -348,7 +348,7 @@ IRBytecodeGenerator >> initialize [
 { #category : #initialization }
 IRBytecodeGenerator >> irPrimitive: anIrPrimitive [
 	literals isEmpty ifFalse: [self error: 'init prim before adding instructions'].
-	anIrPrimitive spec ifNotNil: [literals add: anIrPrimitive spec].
+	anIrPrimitive spec ifNotNil: [literals addLiteral: anIrPrimitive spec].
 	primNumber := anIrPrimitive num.
 	primNumber = 0 ifTrue: [ ^ self ].
 	self encoderClass callPrimitiveCode ifNil: [ ^ self ].
@@ -403,8 +403,7 @@ IRBytecodeGenerator >> literalIndexOf: object [
 
 	| index |
 	
-	(index := literals literalIndexOf: object ifAbsent: 0) > 0 ifFalse: [
-		index := self addLiteral: object].
+	index := literals literalIndexOf: object ifAbsent: [self addLiteral: object].
 	
 	"conversion from 1 based to 0 based"
 	^ index - 1

--- a/src/OpalCompiler-Core/OCLiteralDictionary.class.st
+++ b/src/OpalCompiler-Core/OCLiteralDictionary.class.st
@@ -22,7 +22,7 @@ OCLiteralDictionary >> scanFor: anObject [
 	"Scan the key array for the first slot containing either a nil (indicating an empty slot) or an element that matches anObject. Answer the index of that slot or zero if no slot is found. This method will be overridden in various subclasses that have different interpretations for matching elements."
 	| finish start element |
 	finish := array size.
-	start := (anObject identityHash \\ finish) + 1.
+	start := (anObject hash \\ finish) + 1.
 
 	"Search from (hash mod size) to the end."
 	start to: finish do:

--- a/src/OpalCompiler-Core/OCLiteralDictionary.class.st
+++ b/src/OpalCompiler-Core/OCLiteralDictionary.class.st
@@ -1,0 +1,38 @@
+"
+I am special version of a dictionary that compares the keys using the #literalEquals: message.
+"
+Class {
+	#name : #OCLiteralDictionary,
+	#superclass : #Dictionary,
+	#category : #'OpalCompiler-Core-Extras'
+}
+
+{ #category : #accessing }
+OCLiteralDictionary >> keyAtValue: value ifAbsent: exceptionBlock [
+	"Answer the key that is the external name for the argument, value. If 
+	there is none, answer the result of evaluating exceptionBlock."
+ 
+	self associationsDo: 
+		[:association | (value literalEqual: association value) ifTrue: [^ association key]].
+	^ exceptionBlock value
+]
+
+{ #category : #private }
+OCLiteralDictionary >> scanFor: anObject [
+	"Scan the key array for the first slot containing either a nil (indicating an empty slot) or an element that matches anObject. Answer the index of that slot or zero if no slot is found. This method will be overridden in various subclasses that have different interpretations for matching elements."
+	| finish start element |
+	finish := array size.
+	start := (anObject identityHash \\ finish) + 1.
+
+	"Search from (hash mod size) to the end."
+	start to: finish do:
+		[:index | ((element := array at: index) == nil or: [element key literalEqual: anObject])
+			ifTrue: [^ index ]].
+
+	"Search from 1 to where we started."
+	1 to: start-1 do:
+		[:index | ((element := array at: index) == nil or: [element key literalEqual: anObject])
+			ifTrue: [^ index ]].
+
+	^ 0  "No match AND no empty slot"
+]

--- a/src/OpalCompiler-Core/OCLiteralList.class.st
+++ b/src/OpalCompiler-Core/OCLiteralList.class.st
@@ -8,7 +8,6 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'literalsDict',
-		'lastIndex',
 		'first'
 	],
 	#category : #'OpalCompiler-Core-Extras'
@@ -18,10 +17,11 @@ Class {
 OCLiteralList >> addLiteral: anObject [
 
 	"I keep the first element, so it can be easily returned"
-	lastIndex = 0 
-		ifTrue: [ first := anObject ].
+	literalsDict ifEmpty: [ first := anObject ].
 	
-	^ literalsDict at: anObject ifAbsentPut: [ lastIndex := lastIndex + 1 ]
+	"The index of the last inserted element is the the size of the literalsDict,
+	as the elements are always added and never removed"
+	^ literalsDict at: anObject ifAbsentPut: [ literalsDict size + 1 ]
 ]
 
 { #category : #converting }
@@ -29,7 +29,7 @@ OCLiteralList >> asArray [
 
 	| result |
 	
-	result := Array new: lastIndex.
+	result := Array new: literalsDict size.
 	
 	literalsDict associationsDo: [ :anAssoc | result at: anAssoc value put: anAssoc key ].
 	
@@ -46,14 +46,13 @@ OCLiteralList >> first [
 OCLiteralList >> initialize [
 
 	super initialize.
-	lastIndex := 0.
 	literalsDict := OCLiteralDictionary new
 ]
 
 { #category : #testing }
 OCLiteralList >> isEmpty [
 
-	^ lastIndex = 0
+	^ literalsDict isEmpty
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OCLiteralList.class.st
+++ b/src/OpalCompiler-Core/OCLiteralList.class.st
@@ -1,46 +1,63 @@
 "
-Holds a unique ordered collection of literals
+Holds a unique ordered collection of literals.
+I uses an special dictionary inside that compares literals using #literalEquals message.
+I am optimised to guarantee that literals all unique and have an unique index.
 "
 Class {
 	#name : #OCLiteralList,
-	#superclass : #OrderedCollection,
+	#superclass : #Object,
 	#instVars : [
-		'equalitySet'
+		'literalsDict',
+		'lastIndex',
+		'first'
 	],
 	#category : #'OpalCompiler-Core-Extras'
 }
 
 { #category : #adding }
-OCLiteralList >> addLast: object [
-	"Only add if not already in list"
+OCLiteralList >> addLiteral: anObject [
 
-	(equalitySet includes: object) ifTrue: [^ object].
-	equalitySet add: object.
-	super addLast: object.
-	^ object
+	"I keep the first element, so it can be easily returned"
+	lastIndex = 0 
+		ifTrue: [ first := anObject ].
+	
+	^ literalsDict at: anObject ifAbsentPut: [ lastIndex := lastIndex + 1 ]
 ]
 
-{ #category : #accessing }
-OCLiteralList >> indexOf: anElement startingAt: start ifAbsent: exceptionBlock [
+{ #category : #converting }
+OCLiteralList >> asArray [
 
-	start to: self size do:
-		[:index | ((self at: index) literalEqual: anElement) ifTrue: [^ index]].
-	^ exceptionBlock value
+	| result |
+	
+	result := Array new: lastIndex.
+	
+	literalsDict associationsDo: [ :anAssoc | result at: anAssoc value put: anAssoc key ].
+	
+	^ result.
+]
+
+{ #category : #adding }
+OCLiteralList >> first [
+	
+	^ first 
+]
+
+{ #category : #initialization }
+OCLiteralList >> initialize [
+
+	super initialize.
+	lastIndex := 0.
+	literalsDict := OCLiteralDictionary new
+]
+
+{ #category : #testing }
+OCLiteralList >> isEmpty [
+
+	^ lastIndex = 0
 ]
 
 { #category : #accessing }
 OCLiteralList >> literalIndexOf: anElement ifAbsent: exceptionBlock [
-	"Answer the index of anElement within the receiver. If the receiver does 
-	not contain anElement, answer the result of evaluating the argument, 
-	exceptionBlock."
-	1 to: self size do:
-		[:i | ((self at: i) literalEqual: anElement) ifTrue: [^ i]].
-	^ exceptionBlock value
-]
 
-{ #category : #private }
-OCLiteralList >> setCollection: anArray [
-
-	super setCollection: anArray.
-	equalitySet := OCLiteralSet new: anArray size.
+	^ literalsDict at: anElement ifAbsent: exceptionBlock
 ]


### PR DESCRIPTION
I have tested that a method with 32k literals is compiled 50 times faster. 
For small & common methods there is not impact.
I have replaced the implementation using an array with linear scan to use a specialized Dictionary that uses #literalEquals:.
It has not impact in small methods because before it was using an array and a Set to guarantee uniqueness, so the impact is similar.

I would backport it to P10.