### PR TITLE
OSSDL2FormRenderer: Fix DNU on start

### DIFF
--- a/src/OSWindow-SDL2/OSSDL2FormRenderer.class.st
+++ b/src/OSWindow-SDL2/OSSDL2FormRenderer.class.st
@@ -37,7 +37,7 @@ OSSDL2FormRenderer >> createRenderer [
 { #category : #private }
 OSSDL2FormRenderer >> createTexture [
 	"Existing texture released explicitly to avoid memory leak on resize (issue#11183)"
-	texture destroy.
+	texture ifNotNil: [ texture destroy ].
 	texture := renderer createTextureFormat: SDL_PIXELFORMAT_XRGB8888
 						access: SDL_TEXTUREACCESS_STREAMING width: form width height: form height.
 	extent := form extent


### PR DESCRIPTION
Fixes #11616

texture is `nil' on initialization, so a nil-guard is needed here