### PR TITLE
11635-Compiler-eval-an-expression-with-halt-and-bindings-opens-Emergency-Evaluator

### DIFF
--- a/src/OpalCompiler-Core/OCExtraBindingScope.class.st
+++ b/src/OpalCompiler-Core/OCExtraBindingScope.class.st
@@ -24,6 +24,11 @@ Class {
 	#category : #'OpalCompiler-Core-Semantics'
 }
 
+{ #category : #'temp vars' }
+OCExtraBindingScope >> allTemps [
+	^#()
+]
+
 { #category : #accessing }
 OCExtraBindingScope >> bindings [
 	^ bindings

--- a/src/OpalCompiler-Tests/OCDoitTest.class.st
+++ b/src/OpalCompiler-Tests/OCDoitTest.class.st
@@ -69,6 +69,33 @@ OCDoitTest >> testDoItContextReadTemp [
 ]
 
 { #category : #tests }
+OCDoitTest >> testDoItExtraBindings [
+	"We can use extra bindings in a DoIt"
+	
+	| result |
+	result := OpalCompiler new
+		bindings: {  #binding -> 1};
+		evaluate: 'binding'.
+	self assert: result equals: 1
+]
+
+{ #category : #tests }
+OCDoitTest >> testDoItHalt [
+	
+	self should: [OpalCompiler new 
+			evaluate: 'self halt'] raise: Halt
+]
+
+{ #category : #tests }
+OCDoitTest >> testDoItHaltBinding [
+	"We can evaluate with a halt and extra bindings"
+	
+	self should: [OpalCompiler new 
+			bindings: {#binding -> 1 };
+			evaluate: 'self halt'] raise: Halt
+]
+
+{ #category : #tests }
 OCDoitTest >> testDoItRequestorEvalError [
 	| value |
 	value  := OpalCompiler new 


### PR DESCRIPTION
fixes #11635, adds some testst for the cases