### PR TITLE
Expand class comment for Set

### DIFF
--- a/src/Collections-Unordered/IdentitySet.class.st
+++ b/src/Collections-Unordered/IdentitySet.class.st
@@ -1,33 +1,35 @@
 "
-The same as a Set, except that items are compared using #== instead of #=.
+The same as a Set, except that items are compared using `#==` instead of `#=`.
 
-Almost any class named IdentityFoo is the same as Foo except for the way items are compared.  In Foo, #= is used, while in IdentityFoo, #== is used.  That is, identity collections will treat items as the same only if they have the same identity.
+Almost any class named IdentityFoo is the same as Foo except for the way items are compared.  
+In Foo, `#=` is used, while in IdentityFoo, `#==` is used.  That is, identity collections will 
+treat items as the same only if they have the same identity.
 
 For example, note that copies of a string are equal:
-
+```
 	('abc' copy) = ('abc' copy)
-
+```
 but they are not identitcal:
-
+```
 	('abc' copy) == ('abc' copy)
-
+```
 A regular Set will only include equal objects once:
-
+```
 	| aSet |
 	aSet := Set new.
 	aSet add: 'abc' copy.
 	aSet add: 'abc' copy.
 	aSet
-
+```
 
 An IdentitySet will include multiple equal objects if they are not identical:
-
+```
 	| aSet |
 	aSet := IdentitySet new.
 	aSet add: 'abc' copy.
 	aSet add: 'abc' copy.
 	aSet
-
+```
 "
 Class {
 	#name : #IdentitySet,

--- a/src/Collections-Unordered/PluggableSet.class.st
+++ b/src/Collections-Unordered/PluggableSet.class.st
@@ -1,14 +1,18 @@
 "
-PluggableSets allow the redefinition of hashing and equality by clients. This is in particular useful if the clients know about specific properties of the objects stored in the set which in turn can heavily improve the performance of sets and dictionaries.
+PluggableSets allow the redefinition of hashing and equality by clients. 
+This is in particular useful if the clients know about specific properties of 
+the objects stored in the set which in turn can heavily improve the performance 
+of sets and dictionaries.
 
-Note: As of Pharo 1.1#11284, using normal Dictionary is actually faster as the bench below shows... ;-)
+Note: As of Pharo 1.1#11284, using normal `Dictionary` is actually faster as the bench below shows... ;-)
 
 Instance variables:
 	hashBlock	<BlockContext>	A one argument block used for hashing the elements.
 	equalBlock	<BlockContext>	A two argument block used for comparing the elements.
 
-Example: Adding 1000 integer points in the range (0@0) to: (100@100) to a set.
-
+### Example
+Adding 1000 integer points in the range (0@0) to: (100@100) to a set.
+```
 	| rnd set max pt |
 	set := Set new: 1000.
 	rnd := Random new.
@@ -19,9 +23,10 @@ Example: Adding 1000 integer points in the range (0@0) to: (100@100) to a set.
 			set add: pt.
 		].
 	].
-
-The above is way slow since the default hashing function of points leads to an awful lot of collisions in the set. And now the same, with a somewhat different hash function:
-
+```
+The above is way slow since the default hashing function of points leads 
+to an awful lot of collisions in the set. And now the same, with a somewhat different hash function:
+```
 	| rnd set max pt |
 	set := PluggableSet new: 1000.
 	set hashBlock:[:item| (item x bitShift: 16) + item y].
@@ -33,7 +38,7 @@ The above is way slow since the default hashing function of points leads to an a
 			set add: pt.
 		].
 	].
-
+```
 "
 Class {
 	#name : #PluggableSet,

--- a/src/Collections-Unordered/Set.class.st
+++ b/src/Collections-Unordered/Set.class.st
@@ -3,10 +3,69 @@ I represent a set of objects without duplicates.  I can hold anything that respo
 `#hash` and `#=`, except for nil.  My instances will automatically grow, if necessary,
 Note that I rely on `#=`, not `#==`.  If you want a set using `#==`, use `IdentitySet`.
 
+## Public API and Key Messages
 
-The core operation is `HashedCollection>>#findElementOrNil:`, which either finds the position where an
-object is stored in array, if it is present, or finds a suitable position holding nil, if
-its argument is not present in array.
+### Initializing and Adding
+
+A `Set` can be created with values using the `Set class>>#newFrom:` class selector which will add the 
+values of a collection as the values of the `Set`, with any duplicates removed. See `Bag` for a collection
+that will retain the count of duplicate elements.
+
+```
+s := Set newFrom: #(1 2 3 4 5).  ""a Set(2 4 3 5 1)""
+
+s2 := Set newFrom: #(1 1 1 2 2 ).  ""a Set(1 2)""
+```
+
+Alternatively, an empty set can be created and elements added to it progressively using `Set>>#add:`
+
+```
+s := Set new.
+s add: 13.
+s add: 1.
+```
+
+### Testing
+
+Check if a value is present in a `Set` using the `Set>>#includes:` selector.
+
+```
+""Look if 12 is the value of any key in the Set""
+s := Set newFrom: #(1 2 3 4 5).
+s includes: 12.  ""false""
+```
+		
+### Removing
+
+Use the `Collection>>#remove:` selector to remove a value from the `Set`, which will cause
+an error if the value is not found. Use the `Set>>#remove:ifAbsent:` selector to control this behavior.
+
+```
+s := Set newFrom: #(1 2 3 4 5).
+s remove: 5.  ""a Set(1 3 2 4)""
+s remove: 1200.  ""Error""
+s remove: 1200 ifAbsent: [ ""do something"" ].
+```
+
+### Set operations
+The usual set theoretic operations are also available.
+```
+s1 := Set newFrom: #(1 2 3).
+s2 := Set newFrom: #(2 3 4).
+```
+#### Union
+```
+s3 := s1 union: s2. ""a Set(1 2 3 4)""
+```
+#### Difference
+```
+s1 difference: s2. ""a Set(1)""
+s2 difference: s1. ""a Set(4)""
+```
+#### Intersection
+```
+s1 intersection: s2. ""a Set(2 3)""
+```
 
 ### Instance structure:
 
@@ -16,6 +75,9 @@ its argument is not present in array.
 
 -  tally	The number of elements in the set.  The array size is always greater than this.
 
+- The core operation is `HashedCollection>>#findElementOrNil:`, which either finds the position where an
+  object is stored in array, if it is present, or finds a suitable position holding nil, if
+  its argument is not present in array.
 
 "
 Class {

--- a/src/Collections-Unordered/Set.class.st
+++ b/src/Collections-Unordered/Set.class.st
@@ -4,7 +4,7 @@ I represent a set of objects without duplicates.  I can hold anything that respo
 Note that I rely on `#=`, not `#==`.  If you want a set using `#==`, use `IdentitySet`.
 
 
-The core operation is #find`ElementOrNil:`, which either finds the position where an
+The core operation is `HashedCollection>>#findElementOrNil:`, which either finds the position where an
 object is stored in array, if it is present, or finds a suitable position holding nil, if
 its argument is not present in array.
 


### PR DESCRIPTION
- Add examples and key messages to `Set` class comment
- Convert `IdentitySet` and `PluggableSet` class comments to microdown style
