### PR TITLE
FTTableMorph: Allow expansion/collapse of nodes using arrow keys

### DIFF
--- a/src/Calypso-Browser/ClyCollapsedDataSource.class.st
+++ b/src/Calypso-Browser/ClyCollapsedDataSource.class.st
@@ -229,7 +229,7 @@ ClyCollapsedDataSource >> retrieveChildrenOf: aDataSourceItem [
 	| childQuery childDataSource |
 	childQuery := queryView 
 		queryToExpand: aDataSourceItem 
-		ifAbsent: [self error: 'cant retrieve children from ', aDataSourceItem printString].
+		ifAbsent: [ClyNoChildren signalFor: aDataSourceItem].
 	
 	childDataSource := ClyCollapsedDataSource on: childQuery.
 	childDataSource openOn: queryView.

--- a/src/Calypso-Browser/ClyCollapsedDataSource.class.st
+++ b/src/Calypso-Browser/ClyCollapsedDataSource.class.st
@@ -229,7 +229,7 @@ ClyCollapsedDataSource >> retrieveChildrenOf: aDataSourceItem [
 	| childQuery childDataSource |
 	childQuery := queryView 
 		queryToExpand: aDataSourceItem 
-		ifAbsent: [ClyNoChildren signalFor: aDataSourceItem].
+		ifAbsent: [ClyNoChildrenError signalFor: aDataSourceItem].
 	
 	childDataSource := ClyCollapsedDataSource on: childQuery.
 	childDataSource openOn: queryView.

--- a/src/Calypso-Browser/ClyNoChildren.class.st
+++ b/src/Calypso-Browser/ClyNoChildren.class.st
@@ -1,0 +1,32 @@
+"
+I am ClyNoChildren, an exception indicating that an operation on a parent in a parent-child structure failed due to the absence of child elements. 
+"
+Class {
+	#name : #ClyNoChildren,
+	#superclass : #Error,
+	#instVars : [
+		'parent'
+	],
+	#category : #'Calypso-Browser-Exceptions'
+}
+
+{ #category : #signalling }
+ClyNoChildren class >> signalFor: aParentObject [
+	"Create and signal a ClyNotFound exception for aParentObject in the default receiver."
+			
+	^ self new
+		parent: aParentObject;
+		signal
+]
+
+{ #category : #accessing }
+ClyNoChildren >> parent [
+
+	^ parent
+]
+
+{ #category : #accessing }
+ClyNoChildren >> parent: anObject [
+
+	parent := anObject
+]

--- a/src/Calypso-Browser/ClyNoChildrenError.class.st
+++ b/src/Calypso-Browser/ClyNoChildrenError.class.st
@@ -2,7 +2,7 @@
 I am ClyNoChildren, an exception indicating that an operation on a parent in a parent-child structure failed due to the absence of child elements. 
 "
 Class {
-	#name : #ClyNoChildren,
+	#name : #ClyNoChildrenError,
 	#superclass : #Error,
 	#instVars : [
 		'parent'
@@ -11,7 +11,7 @@ Class {
 }
 
 { #category : #signalling }
-ClyNoChildren class >> signalFor: aParentObject [
+ClyNoChildrenError class >> signalFor: aParentObject [
 	"Create and signal a ClyNotFound exception for aParentObject in the default receiver."
 			
 	^ self new
@@ -20,13 +20,13 @@ ClyNoChildren class >> signalFor: aParentObject [
 ]
 
 { #category : #accessing }
-ClyNoChildren >> parent [
+ClyNoChildrenError >> parent [
 
 	^ parent
 ]
 
 { #category : #accessing }
-ClyNoChildren >> parent: anObject [
+ClyNoChildrenError >> parent: anObject [
 
 	parent := anObject
 ]

--- a/src/Calypso-Browser/ClyNoChildrenError.class.st
+++ b/src/Calypso-Browser/ClyNoChildrenError.class.st
@@ -1,5 +1,5 @@
 "
-I am ClyNoChildren, an exception indicating that an operation on a parent in a parent-child structure failed due to the absence of child elements. 
+I am ClyNoChildrenError, an exception indicating that an operation on a parent in a parent-child structure failed due to the absence of child elements. 
 "
 Class {
 	#name : #ClyNoChildrenError,
@@ -12,7 +12,7 @@ Class {
 
 { #category : #signalling }
 ClyNoChildrenError class >> signalFor: aParentObject [
-	"Create and signal a ClyNotFound exception for aParentObject in the default receiver."
+	"Create and signal a ClyNotFoundError exception for aParentObject in the default receiver."
 			
 	^ self new
 		parent: aParentObject;

--- a/src/Calypso-Browser/ClyQueryViewMorph.class.st
+++ b/src/Calypso-Browser/ClyQueryViewMorph.class.st
@@ -741,11 +741,7 @@ ClyQueryViewMorph >> selectionRejected: announcement [
 		^ self
 	].
 	announcement direction = #right ifTrue: [
-		self selection items do: [ :item |
-			item isExpanded ifFalse: [
-				(item isRoot or: item hasChildren) ifTrue: [ item expand ]
-			] 
-		]
+		self selection items do: [ :item | [ item expand ] on: ClyNoChildren do: ["ignored"] ]
 	]
 ]
 

--- a/src/Calypso-Browser/ClyQueryViewMorph.class.st
+++ b/src/Calypso-Browser/ClyQueryViewMorph.class.st
@@ -522,6 +522,7 @@ ClyQueryViewMorph >> initializeTable [
 	table dragEnabled: true.
 	table dropEnabled: true.
 	table onAnnouncement: FTSelectionChanged send: #selectionChanged to: self.
+	table onAnnouncement: FTSelectionRejected send: #selectionRejected: to: self.
 	table addColumn: ClyMainTableColumn default.
 	table vResizing: #spaceFill.
 	table hResizing: #spaceFill.
@@ -729,6 +730,23 @@ ClyQueryViewMorph >> selectionChanged [
 				withEnoughArguments: {self selection}].
 	].
 	self triggerClickCommands
+]
+
+{ #category : #'event handling' }
+ClyQueryViewMorph >> selectionRejected: announcement [
+	"Called when a selection is performed outside the table bounds"
+	announcement direction = #left ifTrue: [
+		self selection items do: [ :item | item isExpanded ifTrue: [ item collapse ] ].
+		self update.
+		^ self
+	].
+	announcement direction = #right ifTrue: [
+		self selection items do: [ :item |
+			item isExpanded ifFalse: [
+				(item isRoot or: item hasChildren) ifTrue: [ item expand ]
+			] 
+		]
+	]
 ]
 
 { #category : #initialization }

--- a/src/Calypso-Browser/ClyQueryViewMorph.class.st
+++ b/src/Calypso-Browser/ClyQueryViewMorph.class.st
@@ -741,7 +741,7 @@ ClyQueryViewMorph >> selectionRejected: announcement [
 		^ self
 	].
 	announcement direction = #right ifTrue: [
-		self selection items do: [ :item | [ item expand ] on: ClyNoChildren do: ["ignored"] ]
+		self selection items do: [ :item | [ item expand ] on: ClyNoChildrenError do: ["ignored"] ]
 	]
 ]
 

--- a/src/Morphic-Widgets-FastTable/FTSelectionRejected.class.st
+++ b/src/Morphic-Widgets-FastTable/FTSelectionRejected.class.st
@@ -1,0 +1,40 @@
+"
+I announce a rejected selection change (e.g. an attempt to a row/column or cell outside the bounds of the table)
+
+Description
+-------------------
+
+I store the direction of the change.
+
+Public API and Key Messages
+-------------------
+
+•	#withDirection: is the sole constructor 
+
+
+Internal Representation and Key Implementation Points.
+------------------
+
+Instance Variables
+direction:	Direction of the attempted selection
+"
+Class {
+	#name : #FTSelectionRejected,
+	#superclass : #FTAnnouncement,
+	#instVars : [
+		'direction'
+	],
+	#category : #'Morphic-Widgets-FastTable-Announcement'
+}
+
+{ #category : #accessing }
+FTSelectionRejected >> direction [
+
+	^ direction
+]
+
+{ #category : #accessing }
+FTSelectionRejected >> direction: anObject [
+
+	direction := anObject
+]

--- a/src/Morphic-Widgets-FastTable/FTSelectionRejected.class.st
+++ b/src/Morphic-Widgets-FastTable/FTSelectionRejected.class.st
@@ -27,6 +27,13 @@ Class {
 	#category : #'Morphic-Widgets-FastTable-Announcement'
 }
 
+{ #category : #'instance creation' }
+FTSelectionRejected class >> withDirection: aDirection [
+	^ self new
+		direction: aDirection;
+		yourself
+]
+
 { #category : #accessing }
 FTSelectionRejected >> direction [
 

--- a/src/Morphic-Widgets-FastTable/FTSelectionRejected.class.st
+++ b/src/Morphic-Widgets-FastTable/FTSelectionRejected.class.st
@@ -1,5 +1,5 @@
 "
-I announce a rejected selection change (e.g. an attempt to a row/column or cell outside the bounds of the table)
+I announce a rejected selection change (e.g. an attempt to select a row/column or cell outside the bounds of the table)
 
 Description
 -------------------

--- a/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
@@ -674,14 +674,20 @@ FTTableMorph >> keyStrokeArrowDown: event [
 
 { #category : #'event handling' }
 FTTableMorph >> keyStrokeArrowLeft: event [
-	(self selectionModeStrategy is: self selectedIndex afterColumn: 1) ifFalse: [ ^ self ].
+	(self selectionModeStrategy is: self selectedIndex afterColumn: 1) ifFalse: [ 
+		self announcer announce: (FTSelectionRejected withDirection: #left).
+		^ self 
+	].
 	self resetFunction.
 	self selectIndex: (self selectionModeStrategy selectableIndexBefore: self selectedIndex) event: event
 ]
 
 { #category : #'event handling' }
 FTTableMorph >> keyStrokeArrowRight: event [
-	(self selectionModeStrategy is: self selectedIndex beforeColumn: self numberOfColumns) ifFalse: [ ^ self ].
+	(self selectionModeStrategy is: self selectedIndex beforeColumn: self numberOfColumns) ifFalse: [ 
+		self announcer announce: (FTSelectionRejected withDirection: #right).
+		^ self 
+	].
 	self resetFunction.
 	self selectIndex: (self selectionModeStrategy selectableIndexAfter: self selectedIndex) event: event
 ]


### PR DESCRIPTION
Fixes  #11643

Implementation strategy:

* Adds an additional announcement class `FTSelectionRejected` that is used to signal attempted out-of-bounds selections in a FTTreeMorph
* FTTreeMorph announces `FTSelectionRejected` whenever an out-of-bounds selection is attempted
* ClyQueryViewMorph registers a handler for this announcement
* The handler checks the direction vector, if it is to the right, expand the node. Otherwise collapse it.