### PR TITLE
RubAbstractTextArea: Avoid a superfluous isNotNil in handleEdit:

### DIFF
--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -974,6 +974,20 @@ RubAbstractTextArea >> grabbedAllowed [
 	^ scrollPane isNil
 ]
 
+{ #category : #accessing }
+RubAbstractTextArea >> grow [
+	"Answer whether the area should grow horizontally."
+
+	^ grow
+]
+
+{ #category : #accessing }
+RubAbstractTextArea >> grow: aBool [
+	"Set whether the area should grow horizontally."
+
+	grow := aBool
+]
+
 { #category : #geometry }
 RubAbstractTextArea >> handleBoundsChange: aBlock [
 	| oldBounds |
@@ -993,7 +1007,7 @@ RubAbstractTextArea >> handleEdit: editBlock [
 
 	editBlock value.
 	"Fit to width on edit"
-	(self grow isNotNil & self grow) ifTrue: [
+	grow ifTrue: [
 		self width: (1 max: self maxLineWidth + self margins left + self margins right)
 	].
 	self selectionChanged	"Note new selection"
@@ -1144,6 +1158,7 @@ RubAbstractTextArea >> highlightMessageSend [
 { #category : #initialization }
 RubAbstractTextArea >> initialize [
 	super initialize.
+	grow := false.
 	self compose.
 	self addCursor.
 	self plugFindReplace.
@@ -1305,20 +1320,6 @@ RubAbstractTextArea >> maxLength: anInteger [
 	"Set the maximum number of characters that may be typed."
 
 	maxLength := anInteger max: 0
-]
-
-{ #category : #accessing }
-RubAbstractTextArea >> grow [
-	"Answer whether the area should grow horizontally."
-
-	^ grow
-]
-
-{ #category : #accessing }
-RubAbstractTextArea >> grow: aBool [
-	"Set whether the area should grow horizontally."
-
-	grow := aBool
 ]
 
 { #category : #measuring }


### PR DESCRIPTION
Follow-up to #11583

Initialize the grow variable instead and avoid an isNotNil message