### PR TITLE
FTTableMorph: Pass some keyboard events to the filter field if it is focused

### DIFF
--- a/src/Calypso-Browser/FTTableMorph.extension.st
+++ b/src/Calypso-Browser/FTTableMorph.extension.st
@@ -22,6 +22,13 @@ FTTableMorph >> filterField [
 ]
 
 { #category : #'*Calypso-Browser' }
+FTTableMorph >> filterFieldHasKeyboardFocus [
+	| field |
+	field := self filterField.
+	^ field isNotNil and: [ field hasKeyboardFocus ]
+]
+
+{ #category : #'*Calypso-Browser' }
 FTTableMorph >> filterString [
 	(function isKindOf: FTFilterFunction) ifFalse: [ ^'' ]. 
 	^function pattern ifNil: [ '' ]

--- a/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
@@ -525,16 +525,32 @@ FTTableMorph >> initializeKeyBindings [
 		toAction: [ :target :morph :event | self keyStrokeArrowDown: event ].
 	self 
 		bindKeyCombination: Character arrowLeft shift | Character arrowLeft asKeyCombination
-		toAction: [ :target :morph :event | self keyStrokeArrowLeft: event ].
+		toAction: [ :target :morph :event |
+			self filterFieldHasKeyboardFocus
+				ifTrue: [ self filterField moveCursorBy: -1 ]
+				ifFalse: [ self keyStrokeArrowLeft: event ]
+		].
 	self 
 		bindKeyCombination: Character arrowRight shift | Character arrowRight asKeyCombination
-		toAction: [ :target :morph :event | self keyStrokeArrowRight: event ].
+		toAction: [ :target :morph :event |
+			self filterFieldHasKeyboardFocus
+				ifTrue: [ self filterField moveCursorBy: 1 ]
+				ifFalse: [ self keyStrokeArrowRight: event ]
+		].
 	self 
 		bindKeyCombination: Character home asKeyCombination
-		toAction: [ self selectFirst ].
+		toAction: [
+			self filterFieldHasKeyboardFocus
+				ifTrue: [ self filterField moveCursorToIndex: 0 ]
+				ifFalse: [ self selectFirst ]
+			].
 	self 
 		bindKeyCombination: Character end asKeyCombination
-		toAction: [ self selectLast ].
+		toAction: [
+			self filterFieldHasKeyboardFocus
+				ifTrue: [ self filterField moveCursorToIndex: #last ]
+				ifFalse: [ self selectLast ]
+		].
 	self 
 		bindKeyCombination: self shortcutProvider selectAllShortcut
 		toAction: [ self selectAll ]

--- a/src/Rubric/RubScrolledTextMorph.class.st
+++ b/src/Rubric/RubScrolledTextMorph.class.st
@@ -816,8 +816,21 @@ RubScrolledTextMorph >> mouseWheel: event [
 ]
 
 { #category : #'accessing - selection' }
-RubScrolledTextMorph >> moveCursorToIndex: anIndex [ 
-	self selectFrom: anIndex to: anIndex - 1
+RubScrolledTextMorph >> moveCursorBy: amount [
+	"Moves the cursor by the given amount. Amount may be negative"
+	| index |
+	index := self selectionInterval first.
+	index := index + amount.
+	index := 0 max: index.
+	index := (self text size + 1) min: index.
+	self moveCursorToIndex: index
+]
+
+{ #category : #'accessing - selection' }
+RubScrolledTextMorph >> moveCursorToIndex: anIndex [
+	| index |
+	index := #last = anIndex ifTrue: [ self text size + 1 ] ifFalse: [ anIndex ].
+	self selectFrom: index to: index - 1
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
Fixes #11646

This triggers actions on `FTTableMorph` or on its `RubTextFieldMorph` child depending on whether the filter input has keyboard focus or not.