### PR TITLE
Adding an API in OCBytecodeToASTCache, RBMethodNode and RBBlockNode to map AST nodes to a pc range.

### DIFF
--- a/src/OpalCompiler-Core/OCBytecodeToASTCache.class.st
+++ b/src/OpalCompiler-Core/OCBytecodeToASTCache.class.st
@@ -62,6 +62,12 @@ OCBytecodeToASTCache >> firstBcOffset [
 	^ firstBcOffset
 ]
 
+{ #category : #astAndAstMapping }
+OCBytecodeToASTCache >> firstBcOffsetForNode: aNode [
+
+	^ (self pcsForNode: aNode) at: 1 ifAbsent: nil
+]
+
 { #category : #initialization }
 OCBytecodeToASTCache >> generateForNode: aNode [
 	| methodOrBlockIr currentBcOffset |
@@ -92,6 +98,14 @@ OCBytecodeToASTCache >> lastBcOffset [
 	^ lastBcOffset
 ]
 
+{ #category : #astAndAstMapping }
+OCBytecodeToASTCache >> lastBcOffsetForNode: aNode [
+
+	| pcsForNode |
+	pcsForNode := self pcsForNode: aNode.
+	^ pcsForNode at: pcsForNode size ifAbsent: nil
+]
+
 { #category : #accessing }
 OCBytecodeToASTCache >> methodNode [
 	^ methodOrBlockNode
@@ -107,4 +121,10 @@ OCBytecodeToASTCache >> nodeForPC: pc [
 	pc < firstBcOffset ifTrue: [ ^ methodOrBlockNode ].
 	pc > lastBcOffset ifTrue: [ ^ bcToASTMap at: lastBcOffset ].
 	^ bcToASTMap at: pc
+]
+
+{ #category : #astAndAstMapping }
+OCBytecodeToASTCache >> pcsForNode: aNode [
+
+	^ (bcToASTMap keys select: [ :key | (bcToASTMap at: key) == aNode ]) asOrderedCollection
 ]

--- a/src/OpalCompiler-Core/RBBlockNode.extension.st
+++ b/src/OpalCompiler-Core/RBBlockNode.extension.st
@@ -6,6 +6,12 @@ RBBlockNode >> bcToASTCache [
 ]
 
 { #category : #'*OpalCompiler-Core' }
+RBBlockNode >> firstPcForNode: aNode [
+
+	^ self bcToASTCache firstBcOffsetForNode: aNode
+]
+
+{ #category : #'*OpalCompiler-Core' }
 RBBlockNode >> ir [
 	"if the ir is not yet set, generate the IR for the whole method, it fills the property here"
 	self propertyAt: #ir ifAbsent: [ self methodNode generateIR  ].
@@ -55,9 +61,21 @@ RBBlockNode >> isInlinedLoop [
 ]
 
 { #category : #'*OpalCompiler-Core' }
+RBBlockNode >> lastPcForNode: aNode [
+
+	^ self bcToASTCache lastBcOffsetForNode: aNode
+]
+
+{ #category : #'*OpalCompiler-Core' }
 RBBlockNode >> owningScope [
 
 	^ self scope ifNil: ["inlined" ^ parent owningScope]
+]
+
+{ #category : #'*OpalCompiler-Core' }
+RBBlockNode >> pcsForNode: aNode [
+
+	^ self bcToASTCache pcsForNode: aNode
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -48,6 +48,12 @@ RBMethodNode class >> errorMethodNode: selector errorMessage: messageText [
 ]
 
 { #category : #'*OpalCompiler-Core' }
+RBMethodNode >> firstPcForNode: aNode [
+
+	^ self bcToASTCache firstBcOffsetForNode: aNode
+]
+
+{ #category : #'*OpalCompiler-Core' }
 RBMethodNode >> generate [
 	"The receiver is the root of a parse tree. Answer a CompiledMethod. The
 	argument, trailer, is the references to the source code that is stored with 
@@ -116,6 +122,12 @@ RBMethodNode >> irInstruction [
 ]
 
 { #category : #'*OpalCompiler-Core' }
+RBMethodNode >> lastPcForNode: aNode [
+
+	^ self bcToASTCache lastBcOffsetForNode: aNode
+]
+
+{ #category : #'*OpalCompiler-Core' }
 RBMethodNode >> methodProperties [
 	^self propertyAt: #methodProperties ifAbsent: nil
 ]
@@ -151,6 +163,12 @@ RBMethodNode >> methodPropertyAt: aKey put: anObject [
 { #category : #'*OpalCompiler-Core' }
 RBMethodNode >> owningScope [
 	^ self scope
+]
+
+{ #category : #'*OpalCompiler-Core' }
+RBMethodNode >> pcsForNode: aNode [
+
+	^ self bcToASTCache pcsForNode: aNode
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
@@ -52,6 +52,34 @@ OCBytecodeToASTCacheTest >> testFirstBCOffsetWithQuickReturn [
 ]
 
 { #category : #tests }
+OCBytecodeToASTCacheTest >> testFirstBcOffsetForNodeWhenMappedPcsAreEmpty [
+
+	| aimedNode pcsForAimedNode |
+	compiledMethod := MethodMapExamples >> #helperMethod13.
+	cache := OCBytecodeToASTCache generateForNode: compiledMethod ast.
+	aimedNode := compiledMethod ast statements second receiver.
+	pcsForAimedNode := cache pcsForNode: aimedNode.
+
+	self assertEmpty: pcsForAimedNode.
+	self assert: (cache firstBcOffsetForNode: aimedNode) equals: nil
+]
+
+{ #category : #tests }
+OCBytecodeToASTCacheTest >> testFirstBcOffsetForNodeWhenMappedPcsAreNotEmpty [
+
+	| aimedNode pcsForAimedNode |
+	compiledMethod := MethodMapExamples >> #helperMethod13.
+	cache := OCBytecodeToASTCache generateForNode: compiledMethod ast.
+	aimedNode := compiledMethod ast statements second.
+	pcsForAimedNode := cache pcsForNode: aimedNode.
+
+	self deny: pcsForAimedNode isEmpty.
+	self
+		assert: (cache firstBcOffsetForNode: aimedNode)
+		equals: pcsForAimedNode first
+]
+
+{ #category : #tests }
 OCBytecodeToASTCacheTest >> testHigherThanLastBCOffsetAccessTest [
 	| pc |
 	pc := cache lastBcOffset + 5.
@@ -68,6 +96,34 @@ OCBytecodeToASTCacheTest >> testLastBCOffsetTest [
 		equals:
 			compiledMethod ast ir startSequence withAllSuccessors last last
 				bytecodeOffset
+]
+
+{ #category : #tests }
+OCBytecodeToASTCacheTest >> testLastBcOffsetForNodeWhenMappedPcsAreEmpty [
+
+	| aimedNode pcsForAimedNode |
+	compiledMethod := MethodMapExamples >> #helperMethod13.
+	cache := OCBytecodeToASTCache generateForNode: compiledMethod ast.
+	aimedNode := compiledMethod ast statements second receiver.
+	pcsForAimedNode := cache pcsForNode: aimedNode.
+
+	self assertEmpty: pcsForAimedNode.
+	self assert: (cache lastBcOffsetForNode: aimedNode) equals: nil
+]
+
+{ #category : #tests }
+OCBytecodeToASTCacheTest >> testLastBcOffsetForNodeWhenMappedPcsAreNotEmpty [
+
+	| aimedNode pcsForAimedNode |
+	compiledMethod := MethodMapExamples >> #helperMethod13.
+	cache := OCBytecodeToASTCache generateForNode: compiledMethod ast.
+	aimedNode := compiledMethod ast statements second.
+	pcsForAimedNode := cache pcsForNode: aimedNode.
+
+	self deny: pcsForAimedNode isEmpty.
+	self
+		assert: (cache lastBcOffsetForNode: aimedNode)
+		equals: pcsForAimedNode last
 ]
 
 { #category : #tests }
@@ -106,4 +162,21 @@ OCBytecodeToASTCacheTest >> testNodeForBCOffsetTestFull [
 	self assert: mappedNode sourceCode equals: expectedNode sourceCode.	
 	self assert: mappedNode start equals: expectedNode start.
 	self assert: mappedNode stop equals: expectedNode stop
+]
+
+{ #category : #tests }
+OCBytecodeToASTCacheTest >> testPcsForNode [
+
+	| aimedNode pcsForAimedNode |
+	compiledMethod := MethodMapExamples >> #helperMethod13.
+	cache := OCBytecodeToASTCache generateForNode: compiledMethod ast.
+	aimedNode := compiledMethod ast statements second.
+	pcsForAimedNode := cache pcsForNode: aimedNode.
+
+	pcsForAimedNode do: [ :pc | 
+		self assert: (cache nodeForPC: pc) identicalTo: aimedNode ].
+
+	(cache bcToASTMap keys reject: [ :value | 
+		 pcsForAimedNode includes: value ]) do: [ :pc | 
+		self deny: (cache nodeForPC: pc) identicalTo: aimedNode ]
 ]


### PR DESCRIPTION
`OCBytecodeToASTCache` only provides a way to easily map bytecode offsets to AST nodes but it doesn't allow to do it the other way around.

I implemented an API in this class to do so:

- `OCBytecodeToASTCache>>#pcsForNode:`that returns a collection of pcs of bytecodes that are mapped to the argument node.
-  `OCBytecodeToASTCache>>#firstBcForNode:` that returns the first bytecode offset in the pc range mapped to the argument node, and nil if the argument node isn't mapped to any bytecode offset.
- `OCBytecodeToASTCache>>#lastBcForNode:` that returns the last bytecode offset in the pc range mapped to the argument node, and nil if the argument node isn't mapped to any bytecode offset.

This API is also in `RBBlockNode`and `RBMethodNode`to have an easier AST -> pc mapping, just like it already is for the pc -> AST mapping