### PR TITLE
11558-leadingChar-is-provided-but-unused 

### DIFF
--- a/src/Multilingual-Encodings/EncodedCharSet.class.st
+++ b/src/Multilingual-Encodings/EncodedCharSet.class.st
@@ -127,12 +127,6 @@ EncodedCharSet class >> isUppercase: char [
 ]
 
 { #category : #'class methods' }
-EncodedCharSet class >> leadingChar [
-
-	self subclassResponsibility.
-]
-
-{ #category : #'class methods' }
 EncodedCharSet class >> nextPutValue: ascii toStream: aStream withShiftSequenceIfNeededForTextConverterState: state [
 
 	self subclassResponsibility.

--- a/src/Multilingual-Encodings/Unicode.class.st
+++ b/src/Multilingual-Encodings/Unicode.class.st
@@ -730,6 +730,7 @@ Unicode class >> isUppercase: char [
 
 { #category : #'class methods' }
 Unicode class >> leadingChar [
+	self deprecated: 'not supported anymore' on: '6 September 2022' in: 'Pharo11'.
 	^ 0
 ]
 


### PR DESCRIPTION
- remove EncodedCharSet class>>leadingChar
- deprecate Unicode class>>#leadingChar

fixes #11558