### PR TITLE
Fix "undo" operation erroneously removing the dirty flag when undo operation performed after saving

### DIFF
--- a/src/Calypso-Browser/ClyTextEditor.class.st
+++ b/src/Calypso-Browser/ClyTextEditor.class.st
@@ -51,3 +51,12 @@ ClyTextEditor >> printIt [
 				do: [ '<error in printString: try ''Inspect it'' to debug>' ].
 			self afterSelectionInsertAndSelect: printString ]
 ]
+
+{ #category : #operations }
+ClyTextEditor >> undo [
+
+	super undo.
+
+	self editingState undoManager hasPrevious ifFalse: [ 
+		self browserTool changesCancelled]
+]

--- a/src/Calypso-Browser/ClyTextEditor.class.st
+++ b/src/Calypso-Browser/ClyTextEditor.class.st
@@ -51,12 +51,3 @@ ClyTextEditor >> printIt [
 				do: [ '<error in printString: try ''Inspect it'' to debug>' ].
 			self afterSelectionInsertAndSelect: printString ]
 ]
-
-{ #category : #operations }
-ClyTextEditor >> undo [
-
-	super undo.
-
-	self editingState undoManager hasPrevious ifFalse: [ 
-		self browserTool changesCancelled]
-]

--- a/src/Calypso-Browser/ClyTextEditorToolMorph.class.st
+++ b/src/Calypso-Browser/ClyTextEditorToolMorph.class.st
@@ -151,6 +151,7 @@ ClyTextEditorToolMorph >> changesCancelRequested: aRubCancelEditRequested [
 { #category : #'events handling' }
 ClyTextEditorToolMorph >> changesCancelled [
 
+	self pendingText = self editingText ifFalse: [ ^self ].
 	textMorph hasUnacceptedEdits: false.
 	self textUpdated
 ]

--- a/src/Calypso-Browser/ClyTextEditorToolMorph.class.st
+++ b/src/Calypso-Browser/ClyTextEditorToolMorph.class.st
@@ -151,6 +151,7 @@ ClyTextEditorToolMorph >> changesCancelRequested: aRubCancelEditRequested [
 { #category : #'events handling' }
 ClyTextEditorToolMorph >> changesCancelled [
 
+	"Avoid clearing the dirty flag if the pending text differs from the current text (issue#11649)"
 	self pendingText = self editingText ifFalse: [ ^self ].
 	textMorph hasUnacceptedEdits: false.
 	self textUpdated


### PR DESCRIPTION
Fixes #11649

This makes sure that the editor is always marked "changed" after an undo operation.