### PR TITLE
RubTextEditor: Bind the MENU key to open the context menu

### DIFF
--- a/src/OSWindow-Core/OSKeySymbols.class.st
+++ b/src/OSWindow-Core/OSKeySymbols.class.st
@@ -278,7 +278,7 @@ OSKeySymbols class >> data [
 		(16r40000061 OSK_KP_9 kp_9)
 		(16r40000062 OSK_KP_0 kp_0)
 		(16r40000063 OSK_KP_PERIOD KP_Decimal)
-		(16r40000065 OSK_MENU menu) "win32 menu key / pharo issue#11659"
+		(16r40000065 OSK_APPLICATION menu) "win32 menu key / pharo issue#11659"
 		"(16r40000066 OSK_POWER power)"
 		(16r40000067 OSK_KP_EQUALS kp_equal)
 		(16r40000068 OSK_F13 f13)

--- a/src/OSWindow-Core/OSKeySymbols.class.st
+++ b/src/OSWindow-Core/OSKeySymbols.class.st
@@ -278,8 +278,8 @@ OSKeySymbols class >> data [
 		(16r40000061 OSK_KP_9 kp_9)
 		(16r40000062 OSK_KP_0 kp_0)
 		(16r40000063 OSK_KP_PERIOD KP_Decimal)
-		"(16r40000065 OSK_APPLICATION application)
-		(16r40000066 OSK_POWER power)"
+		(16r40000065 OSK_MENU menu) "win32 menu key / pharo issue#11659"
+		"(16r40000066 OSK_POWER power)"
 		(16r40000067 OSK_KP_EQUALS kp_equal)
 		(16r40000068 OSK_F13 f13)
 		(16r40000069 OSK_F14 f14)

--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -1524,13 +1524,21 @@ RubAbstractTextArea >> openFindDialog [
 { #category : #menu }
 RubAbstractTextArea >> openMenu [
 	"Opens the menu at the cursor position"
-	(self getMenu: false)
+	self openMenu: false and: [ :menu |
+		menu invokeAt: self cursor positionInWorld in: self currentWorld
+	]
+]
+
+{ #category : #menu }
+RubAbstractTextArea >> openMenu: shiftKeyState and: aBlock [
+	"Opens the menu at the cursor position, executing the given block afterwards"
+	(self getMenu: shiftKeyState)
 		ifNotNil: [ :menu |
 			menu privateOwner: self.
 			menu setInvokingView: self editor.
-			menu invokeAt: self cursor positionInWorld in: self currentWorld.
-			self changed.
-		].
+			aBlock value: menu.
+			self changed
+		]
 ]
 
 { #category : #'accessing - editor' }
@@ -2240,13 +2248,6 @@ RubAbstractTextArea >> yellowButtonActivity: shiftKeyState [
 	Check if required first!"
 	self wantsYellowButtonMenu
 		ifFalse: [ ^ false ].	
-	(self getMenu: shiftKeyState)
-		ifNotNil: [ :menu|
-			menu privateOwner: self.
-			menu setInvokingView: self editor.
-			menu invokeModal. 
-			self changed.
-			^ true].
-		
+	self openMenu: shiftKeyState and: #invokeModal.
 	^ true
 ]

--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -1521,6 +1521,18 @@ RubAbstractTextArea >> openFindDialog [
 		ifFalse: [self flash]
 ]
 
+{ #category : #menu }
+RubAbstractTextArea >> openMenu [
+	"Opens the menu at the cursor position"
+	(self getMenu: false)
+		ifNotNil: [ :menu |
+			menu privateOwner: self.
+			menu setInvokingView: self editor.
+			menu invokeAt: self cursor positionInWorld in: self currentWorld.
+			self changed.
+		].
+]
+
 { #category : #'accessing - editor' }
 RubAbstractTextArea >> openingDelimiters [
 	^ self editor openingDelimiters

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -778,7 +778,8 @@ RubTextEditor >> defaultCommandKeymapping [
 	(KeyboardKey keypadDown -> #cursorDown:).
 	(KeyboardKey keypadEnter -> #crWithIndent:).
 	(KeyboardKey tab -> #tab:).
-	(KeyboardKey delete -> #forwardDelete:) } do: [ :assoc | 
+	(KeyboardKey delete -> #forwardDelete:).
+	(KeyboardKey menu -> #menu:)} do: [ :assoc | 
 		cmdMap at: assoc key  put: assoc value ].
 	^ cmdMap
 ]
@@ -1522,6 +1523,13 @@ RubTextEditor >> markIndex [
 { #category : #'accessing - selection' }
 RubTextEditor >> markIndex: markIndex pointIndex: pointIndex [
 	textArea markIndex: markIndex pointIndex: pointIndex
+]
+
+{ #category : #'menu messages' }
+RubTextEditor >> menu: aKeyboardEvent [
+	"Displays the menu"
+	self textArea yellowButtonActivity: false.
+	^ false
 ]
 
 { #category : #accessing }

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -1528,7 +1528,7 @@ RubTextEditor >> markIndex: markIndex pointIndex: pointIndex [
 { #category : #'menu messages' }
 RubTextEditor >> menu: aKeyboardEvent [
 	"Displays the menu"
-	self textArea yellowButtonActivity: false.
+	self textArea openMenu.
 	^ false
 ]
 

--- a/src/System-Platforms/KeyboardKey.class.st
+++ b/src/System-Platforms/KeyboardKey.class.st
@@ -1097,6 +1097,12 @@ KeyboardKey class >> metaRight [
 	^ self named: #META_R
 ]
 
+{ #category : #'accessing - keys - special' }
+KeyboardKey class >> menu [
+
+	^ self named: 'MENU'
+]
+
 { #category : #'accessing - keys - symbols' }
 KeyboardKey class >> minus [
 	^ self named: #MINUS

--- a/src/System-Platforms/KeyboardKey.class.st
+++ b/src/System-Platforms/KeyboardKey.class.st
@@ -1100,7 +1100,7 @@ KeyboardKey class >> metaRight [
 { #category : #'accessing - keys - special' }
 KeyboardKey class >> menu [
 
-	^ self named: 'MENU'
+	^ self named: #MENU
 ]
 
 { #category : #'accessing - keys - symbols' }


### PR DESCRIPTION
Fixes #11658 

* Adds an additional key binding to RubTextEditor, binding the menu key (≣) to the context menu
* `KeyboardKey class >> menu` is also added to facilitate further bindings elsewhere in Pharo later