### PR TITLE
Deprecated method Character class >> #allCharacters and replaced its references

### DIFF
--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -74,7 +74,7 @@ RBScanner class >> initializeClassificationTable [
 	CascadePatternCharacter := $;.
 	classificationTable := Array new: 255.
 	self 
-		initializeChars: (Character allCharacters
+		initializeChars: (Character allByteCharacters
 			select: [ :each | each isLetter ])
 		to: #alphabetic.
 	self initializeUnderscore.
@@ -82,7 +82,7 @@ RBScanner class >> initializeClassificationTable [
 	self initializeChars: Character specialCharacters to: #binary.
 	self initializeChars: '().:;[]{}^' to: #special.
 	self
-		initializeChars: (Character allCharacters
+		initializeChars: (Character allByteCharacters
 			select: [ :each | each isSeparator ])
 		to: #separator
 ]

--- a/src/Collections-Strings-Tests/CharacterTest.class.st
+++ b/src/Collections-Strings-Tests/CharacterTest.class.st
@@ -118,8 +118,9 @@ CharacterTest >> testPrintString [
 
 { #category : #tests }
 CharacterTest >> testPrintStringAll [
-	Character allCharacters
-		do: [ :each | self assert: (self class compiler evaluate: each printString) equals: each ]
+
+	Character allByteCharacters do: [ :each | 
+		self assert: (self class compiler evaluate: each printString) equals: each ]
 ]
 
 { #category : #tests }
@@ -144,6 +145,7 @@ CharacterTest >> testStoreString [
 
 { #category : #tests }
 CharacterTest >> testStoreStringAll [
-	Character allCharacters
-		do: [ :each | self assert: (self class compiler evaluate: each storeString) equals: each ]
+
+	Character allByteCharacters do: [ :each | 
+		self assert: (self class compiler evaluate: each storeString) equals: each ]
 ]

--- a/src/Fuel-Tests-Core/FLBasicSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLBasicSerializationTest.class.st
@@ -113,7 +113,7 @@ FLBasicSerializationTest >> testCharacter [
 		ifFalse: [
 			self assertSerializationEqualityOf: (Character value: 12345). "Japanese Hiragana 'A' " ].
 		
-	self assertSerializationEqualityOf: Character allCharacters.
+	self assertSerializationEqualityOf: Character allByteCharacters.
 	self assertSerializationEqualityOf: (Array with: $a with: (Character value: 12345)).
 ]
 

--- a/src/Kernel/Character.class.st
+++ b/src/Kernel/Character.class.st
@@ -28,9 +28,15 @@ Character class >> allByteCharacters [
 
 { #category : #'instance creation' }
 Character class >> allCharacters [
+
 	"This name is obsolete since only the characters that will fit in a byte can be queried"
-	
-	^self allByteCharacters
+
+	self
+		deprecated:
+			'This name is obsolete since only the characters that will fit in a byte can be queried'
+		transformWith: '`@rec allCharacters' -> '`@rec allByteCharacters'.
+
+	^ self allByteCharacters
 ]
 
 { #category : #constants }


### PR DESCRIPTION
Solves issue #11576

Deprecated method `Character class >> #allCharacters` and replaced its references to the method to `Character class > #allByteCharacters`