### PR TITLE
Improve FileReference>>=

### DIFF
--- a/src/FileSystem-Core/FileReference.class.st
+++ b/src/FileSystem-Core/FileReference.class.st
@@ -61,7 +61,7 @@ FileReference >> = other [
 	"Perform the path comparison last as conversion to absolute paths is relatively expensive"
 	^ self species = other species
 		and: [self fileSystem = other fileSystem
-			and: [self absolutePath = other absolutePath]]
+			and: [self absolutePath canonicalize = other absolutePath canonicalize]]
 ]
 
 { #category : #accessing }

--- a/src/FileSystem-Tests-Core/FileReferenceTest.class.st
+++ b/src/FileSystem-Tests-Core/FileReferenceTest.class.st
@@ -489,6 +489,15 @@ FileReferenceTest >> testEqual [
 	self assert: a equals: b
 ]
 
+{ #category : #running }
+FileReferenceTest >> testEqualAbsoluteRelativePath [
+	| a b |
+	
+	a := filesystem / 'a/b/c'.
+	b := filesystem / 'a/b/c/../c'.
+	self assert: a  equals: b.
+]
+
 { #category : #tests }
 FileReferenceTest >> testEqualityRelativeVsAbsolute [
 


### PR DESCRIPTION
Two FileReferences are considered equal if they refer to the same file / directory. 
So, we must remove . and .. in their paths.