### PR TITLE
Corrected spelling per Issue #11674

### DIFF
--- a/src/EpiceaBrowsers/EpSettings.class.st
+++ b/src/EpiceaBrowsers/EpSettings.class.st
@@ -36,7 +36,7 @@ EpSettings class >> lostEventsDetectorEnabledSettingOn: aBuilder [
 	(aBuilder setting: #lostEventsDetectorEnabled)
 		label: 'Detect lost events on start-up';
 		default: true;
-		description: 'Check if current Epicea log has events that were not applied in this image (useful for recovegin changes when the image crashed)';
+		description: 'Check if current Epicea log has events that were not applied in this image (useful for recovering changes when the image crashed)';
 		parent: #epicea;
 		target: self.
 ]


### PR DESCRIPTION
Changed 'recovegin' to 'recovering' .