### PR TITLE
Odd PR builds use the the latest VM, else use the stable VM

### DIFF
--- a/bootstrap/scripts/runKernelTests.sh
+++ b/bootstrap/scripts/runKernelTests.sh
@@ -22,11 +22,12 @@ TEST_NAME_PREFIX=$(find ${CACHE} -name "Pharo*.zip" | head -n 1 | cut -d'/' -f 2
 #TEST_VM_VERSION=$(echo "${TEST_NAME_PREFIX}" | cut -d'-' -f 1| cut -c 6- | cut -d'.' -f 1-2 | sed 's/\.//')
 TEST_VM_VERSION="90"
 
-if [ "${1}" -eq "32" ]
+#Odd PR builds use the the latest VM, else use the stable VM
+if [ $(is_development_build) == 1 && $((BUILD_NUMBER % 2)) -eq 1 ]]
 then
- TEST_VM_KIND="vm"
+ TEST_VM_KIND="vmLatest"
 else
- TEST_VM_KIND="vmLatest"	
+ TEST_VM_KIND="vm"	
 fi
 
 ${BOOTSTRAP_REPOSITORY:-.}/bootstrap/scripts/getPharoVM.sh ${TEST_VM_VERSION} ${TEST_VM_KIND} ${1}

--- a/bootstrap/scripts/runKernelTests.sh
+++ b/bootstrap/scripts/runKernelTests.sh
@@ -23,7 +23,7 @@ TEST_NAME_PREFIX=$(find ${CACHE} -name "Pharo*.zip" | head -n 1 | cut -d'/' -f 2
 TEST_VM_VERSION="90"
 
 #Odd PR builds use the the latest VM, else use the stable VM
-if [ $(is_development_build) == 1 && $((BUILD_NUMBER % 2)) -eq 1 ]]
+if [ ${is_development_build} == 1 && $(${BUILD_NUMBER} % 2) -eq 1 ]]
 then
  TEST_VM_KIND="vmLatest"
 else

--- a/bootstrap/scripts/runKernelTests.sh
+++ b/bootstrap/scripts/runKernelTests.sh
@@ -23,7 +23,7 @@ TEST_NAME_PREFIX=$(find ${CACHE} -name "Pharo*.zip" | head -n 1 | cut -d'/' -f 2
 TEST_VM_VERSION="90"
 
 #Odd PR builds use the the latest VM, else use the stable VM
-if [ ${is_development_build} == 1 && $(${BUILD_NUMBER} % 2) -eq 1 ]]
+if [[ $(is_development_build) == "1" && $((${BUILD_NUMBER} % 2)) -eq 1 ]]
 then
  TEST_VM_KIND="vmLatest"
 else

--- a/bootstrap/scripts/runTests.sh
+++ b/bootstrap/scripts/runTests.sh
@@ -22,11 +22,12 @@ TEST_NAME_PREFIX=$(find ${CACHE} -name "Pharo*.zip" | head -n 1 | cut -d'/' -f 2
 #TEST_VM_VERSION=$(echo "${TEST_NAME_PREFIX}" | cut -d'-' -f 1| cut -c 6- | cut -d'.' -f 1-2 | sed 's/\.//')
 TEST_VM_VERSION="90"
 
-if [ "${1}" -eq "32" ]
+#Odd PR builds use the the latest VM, else use the stable VM
+if [ $(is_development_build) == 1 && $((BUILD_NUMBER % 2)) -eq 1 ]]
 then
- TEST_VM_KIND="vm"
+ TEST_VM_KIND="vmLatest"
 else
- TEST_VM_KIND="vmLatest"	
+ TEST_VM_KIND="vm"	
 fi
 
 ${BOOTSTRAP_REPOSITORY:-.}/bootstrap/scripts/getPharoVM.sh ${TEST_VM_VERSION} ${TEST_VM_KIND} ${1}

--- a/bootstrap/scripts/runTests.sh
+++ b/bootstrap/scripts/runTests.sh
@@ -23,7 +23,7 @@ TEST_NAME_PREFIX=$(find ${CACHE} -name "Pharo*.zip" | head -n 1 | cut -d'/' -f 2
 TEST_VM_VERSION="90"
 
 #Odd PR builds use the the latest VM, else use the stable VM
-if [ $(is_development_build) == 1 && $((BUILD_NUMBER % 2)) -eq 1 ]]
+if [ ${is_development_build} == 1 && $(${BUILD_NUMBER} % 2) -eq 1 ]]
 then
  TEST_VM_KIND="vmLatest"
 else

--- a/bootstrap/scripts/runTests.sh
+++ b/bootstrap/scripts/runTests.sh
@@ -23,7 +23,7 @@ TEST_NAME_PREFIX=$(find ${CACHE} -name "Pharo*.zip" | head -n 1 | cut -d'/' -f 2
 TEST_VM_VERSION="90"
 
 #Odd PR builds use the the latest VM, else use the stable VM
-if [ $(is_development_build) == 1 && $((BUILD_NUMBER % 2)) -eq 1 ]]
+if [[ $(is_development_build) == "1" && $((${BUILD_NUMBER} % 2)) -eq 1 ]]
 then
  TEST_VM_KIND="vmLatest"
 else


### PR DESCRIPTION
We need to slowly start pushing the latest VM version, right now hosted in the `pharoX` branch of the VM repository.
This branch so far has all our latest work on the VM for at least one year:
 - interpreter variable auto-localization (https://github.com/pharo-project/pharo-vm/pull/371)
 - slang cleanups and improvements (https://github.com/pharo-project/pharo-vm/pull/413, https://github.com/pharo-project/pharo-vm/pull/265, https://github.com/pharo-project/pharo-vm/pull/230, https://github.com/pharo-project/pharo-vm/pull/413, https://github.com/pharo-project/pharo-vm/pull/311, https://github.com/pharo-project/pharo-vm/pull/307, https://github.com/pharo-project/pharo-vm/pull/291)
 - SIMD support in the JIT (https://github.com/pharo-project/pharo-vm/pull/421, https://github.com/pharo-project/pharo-vm/pull/444)
 - the initial work on the perm space (https://github.com/pharo-project/pharo-vm/pull/377, https://github.com/pharo-project/pharo-vm/pull/388, https://github.com/pharo-project/pharo-vm/pull/372, https://github.com/pharo-project/pharo-vm/pull/416, https://github.com/pharo-project/pharo-vm/pull/418)
 - many many bugfixes
 - …

To not disrupt everybody’s work, I propose to make some kind of AB testing on the CI, **only impacting PRs**.
- odd builds (1,3,5,…) use the latest VM 
- even builds (2,4,6,…) use the stable VM

This will make sure that:
 - the latest VM will be tested in a complex scenario (load code, run tests…)
 - people that have a problem can re-run their builds to get a stable run