### PR TITLE
Reduce false positives of some general rules

### DIFF
--- a/src/GeneralRules/ReCollectionMessagesToExternalObjectRule.class.st
+++ b/src/GeneralRules/ReCollectionMessagesToExternalObjectRule.class.st
@@ -16,8 +16,11 @@ ReCollectionMessagesToExternalObjectRule class >> uniqueIdentifierName [
 
 { #category : #hooks }
 ReCollectionMessagesToExternalObjectRule >> afterCheck: aNode mappings: mappingDict [
-	| collectionOwner |
-	((mappingDict at: '`@collectionGetter:') beginsWith: 'as') ifTrue: [ ^ false ].
+	| collectionGetter collectionOwner |
+	collectionGetter := mappingDict at: '`@collectionGetter:'.
+	"Check selectors that assumes unowned result"
+	collectionGetter = 'copy' ifTrue: [ ^ false ].
+	(collectionGetter beginsWith: 'as') ifTrue: [ ^ false ].
 	collectionOwner := mappingDict at: (RBPatternVariableNode named: '`@collectionOwner').
 	 collectionOwner isVariable ifFalse: [ ^ true ].
 	^ self isNotSpecialVariable: collectionOwner.

--- a/src/GeneralRules/ReUtilityMethodsRule.class.st
+++ b/src/GeneralRules/ReUtilityMethodsRule.class.st
@@ -21,13 +21,15 @@ ReUtilityMethodsRule class >> uniqueIdentifierName [
 
 { #category : #running }
 ReUtilityMethodsRule >> basicCheck: aMethod [
-	aMethod methodClass isMeta ifTrue: [ ^false ].
-	aMethod selector isUnary ifTrue: [ ^false ].
-	(self utilityProtocols includes: aMethod protocol) ifTrue: [ ^false ].
+
+	aMethod methodClass isMeta ifTrue: [ ^ false ].
+	aMethod selector isUnary ifTrue: [ ^ false ].
+	(self utilityProtocols includes: aMethod protocol) ifTrue: [ ^ false ].
 	aMethod isOverridden ifTrue: [ ^ false ].
-   aMethod sendsToSuper ifTrue: [ ^ false ].
+	aMethod sendsToSuper ifTrue: [ ^ false ].
 	aMethod selfMessages isEmpty ifFalse: [ ^ false ].
-	^aMethod methodClass definedVariables noneSatisfy: [ :variable | variable isAccessedIn: aMethod ]
+	^ aMethod methodClass definedVariables noneSatisfy: [ :variable |
+		  variable isAccessedIn: aMethod ]
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/ReUtilityMethodsRule.class.st
+++ b/src/GeneralRules/ReUtilityMethodsRule.class.st
@@ -26,6 +26,7 @@ ReUtilityMethodsRule >> basicCheck: aMethod [
 	aMethod selector isUnary ifTrue: [ ^ false ].
 	(self utilityProtocols includes: aMethod protocol) ifTrue: [ ^ false ].
 	aMethod isOverridden ifTrue: [ ^ false ].
+	aMethod isOverriding ifTrue: [ ^ false ].
 	aMethod sendsToSuper ifTrue: [ ^ false ].
 	aMethod selfMessages isEmpty ifFalse: [ ^ false ].
 	^ aMethod methodClass definedVariables noneSatisfy: [ :variable |


### PR DESCRIPTION
Make the rules ReCollectionMessagesToExternalObjectRule and  ReUtilityMethodsRule more lenient to reduce false positives and noise.