### PR TITLE
Symbol a little more as block

### DIFF
--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -408,6 +408,11 @@ Symbol >> createSymbol [
 
 { #category : #evaluating }
 Symbol >> cull: anObject [ 
+
+	"A Symbol can be mostly used as a BlockClosure. See value: for details"
+	
+	"#asUppercase cull: 'hello' >>> 'HELLO'"
+
 	^anObject perform: self.
 ]
 
@@ -596,8 +601,26 @@ Symbol >> uncapitalized [
 ]
 
 { #category : #evaluating }
-Symbol >> value: anObject [ 
-	^anObject perform: self.
+Symbol >> value: anObject [
+
+	"A Symbol can be mostly used as a BlockClosure.
+	The behavior is to send self a a message on anObject. See perform."
+
+	"#asUppercase value: 'hello' >>> 'HELLO'"
+
+	"For instance, this feature can be usefull on many methods of Collections."
+
+	"
+	(#(0 10 20 -30) collect: #negated) >>> #(0 -10 -20 30)
+	('Hello, World!' select: #isLetter) >>> 'HelloWorld'
+	behave the same as
+	(#(0 10 20 -30) collect: [ :each | each negated ]) >>> #(0 -10 -20 30)
+	('Hello, World!' select: [ :each | each isLetter ]) >>> 'HelloWorld'
+	"
+
+	"Keep advised that Symbols are not real Blocks and only a subset of operations are simulated."
+
+	^ anObject perform: self
 ]
 
 { #category : #copying }

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -416,6 +416,16 @@ Symbol >> cull: anObject [
 	^anObject perform: self.
 ]
 
+{ #category : #evaluating }
+Symbol >> cull: anObject cull: anObject2 [
+
+	"A Symbol can be mostly used as a BlockClosure. See value: for details"
+
+	"(#at: cull: 'hello' cull: 2) >>> $e"
+
+	^ anObject perform: self with: anObject2
+]
+
 { #category : #private }
 Symbol >> errorNoModification [
 
@@ -621,6 +631,25 @@ Symbol >> value: anObject [
 	"Keep advised that Symbols are not real Blocks and only a subset of operations are simulated."
 
 	^ anObject perform: self
+]
+
+{ #category : #evaluating }
+Symbol >> value: anObject value: anObject2 [
+
+	"A Symbol can be mostly used as a BlockClosure. See value: for details"
+
+	"(#+ value: 2 value: 3) >>> 5"
+	"(#at: value: #(10 20 30) value: 2) >>> 20"
+
+	"This method can be useful with some methods of Collection.
+	(#(1 9 0 6 6) sorted: #>=) >>> #(9 6 6 1 0)
+	(#(2r101 2r011 2r100) inject: 0 into: #bitXor:) >>> 2r010 
+	behave the same as
+	(#(1 9 0 6 6) sorted: [:a : b| a >= b]) >>> #(9 6 6 1 0)
+	(#(2r101 2r011 2r100) inject: 0 into: [:a :b| a bitXor: b]) >>> 2r010
+	"
+
+	^ anObject perform: self with: anObject2
 ]
 
 { #category : #copying }


### PR DESCRIPTION
Implements Symbol>>value:value: so symbol can be used in more methods of collection (and other classes)

You can now write the following

```
(#(1 9 0 6 6) sorted: #>=) >>> #(9 6 6 1 0)
(#(2r101 2r011 2r100) inject: 0 into: #bitXor:) >>> 2r010 
```

Maybe we can simulate the whole API of blocks on symbols, but I'm not sure: 1. that this is a good idea nor 2. what is best way to do it without too much boilerplate code, duplication and technical dept. Maybe with traits?