### PR TITLE
DrTest see extension classes

### DIFF
--- a/src/DrTests-CommentsToTests/DTCommentTestConfiguration.class.st
+++ b/src/DrTests-CommentsToTests/DTCommentTestConfiguration.class.st
@@ -14,6 +14,8 @@ DTCommentTestConfiguration >> asTestSuite [
 	suite := TestSuite named: 'Test Generated From Comments'.
 	classes := self items addAll: (self items collect: [ :each | each class ]); yourself.
 	methods := classes flatCollect: [ :each | each methods ].
+	"keep only methods defined in a selected package or methods whose classes are defined in a selected package."
+	methods := methods select: [ :m | (packagesSelected includes: m package) or: [ packagesSelected includes: m origin package ] ].
 	methods do: [ :method | 
 		method pharoDocCommentNodes do: [ :docComment | 
 			suite addTest: (CommentTestCase for: docComment) ] ].

--- a/src/DrTests-CommentsToTests/DTCommentToTestPlugin.class.st
+++ b/src/DrTests-CommentsToTests/DTCommentToTestPlugin.class.st
@@ -38,8 +38,11 @@ DTCommentToTestPlugin >> firstListLabel [
 { #category : #api }
 DTCommentToTestPlugin >> itemsToBeAnalysedFor: packagesSelected [
 
-	^ packagesSelected flatCollect: [ :package | 
-		  package definedClasses select: [ :class | class hasDocComment ] ]
+	"note `asSet` is used to avoid duplication if a class is defined/extended in more than one package"
+
+	^ packagesSelected asSet flatCollect: [ :package | 
+		  package definedOrExtendedClasses select: [ :class | 
+			  class hasDocComment ] ]
 ]
 
 { #category : #api }

--- a/src/DrTests/DTDefaultPluginPresenter.class.st
+++ b/src/DrTests/DTDefaultPluginPresenter.class.st
@@ -147,6 +147,7 @@ DTDefaultPluginPresenter >> initializeItemsListAndLabel [
 
 	itemsList := self newFilterableListPresenter.
 	itemsList
+		displayIcon: [ :aClass | self iconNamed: aClass systemIconName  ];
 		help: 'Select the classes to analyze. Cmd+A or Ctrl+A to select all classes.';
 		sortingBlock: #name ascending;
 		displayBlock: [ :item | item name ];

--- a/src/DrTests/DTDefaultPluginPresenter.class.st
+++ b/src/DrTests/DTDefaultPluginPresenter.class.st
@@ -148,6 +148,9 @@ DTDefaultPluginPresenter >> initializeItemsListAndLabel [
 	itemsList := self newFilterableListPresenter.
 	itemsList
 		displayIcon: [ :aClass | self iconNamed: aClass systemIconName  ];
+		displayColor: [ :aClass | (self packagesSelected includes: aClass package)
+				ifTrue: [ self theme textColor ]
+				ifFalse: [ self theme classExtensionColor ] ];
 		help: 'Select the classes to analyze. Cmd+A or Ctrl+A to select all classes.';
 		sortingBlock: #name ascending;
 		displayBlock: [ :item | item name ];

--- a/src/DrTests/DTFilterableListPresenter.class.st
+++ b/src/DrTests/DTFilterableListPresenter.class.st
@@ -61,6 +61,12 @@ DTFilterableListPresenter >> displayBlock: aBlock [
 	^ self listPresenter display: aBlock
 ]
 
+{ #category : #accessing }
+DTFilterableListPresenter >> displayIcon: aFullBlockClosure [ 
+
+	self listPresenter displayIcon: aFullBlockClosure 
+]
+
 { #category : #private }
 DTFilterableListPresenter >> filterList [
 	"Filters the list according to the filterTextInput."

--- a/src/DrTests/DTFilterableListPresenter.class.st
+++ b/src/DrTests/DTFilterableListPresenter.class.st
@@ -61,6 +61,12 @@ DTFilterableListPresenter >> displayBlock: aBlock [
 	^ self listPresenter display: aBlock
 ]
 
+{ #category : #api }
+DTFilterableListPresenter >> displayColor: aBlock [
+
+	self listPresenter displayColor: aBlock.
+]
+
 { #category : #accessing }
 DTFilterableListPresenter >> displayIcon: aFullBlockClosure [ 
 

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -553,6 +553,11 @@ RPackage >> definedMethodsShouldBecomeExtensionWhenRemovingClass: aClassName [
 ]
 
 { #category : #accessing }
+RPackage >> definedOrExtendedClasses [
+	^ self definedClasses | self extendedClasses
+]
+
+{ #category : #accessing }
 RPackage >> definedSelectorsForClass: aClass [
 
 	^ aClass isMeta


### PR DESCRIPTION
With the executable comment plugin of DrTest, selecting a package now gives access to classes extended in that package.

For classes extended in a package, only extended methods are tested (not the whole class).
For classes defined in a package, all methods are tested, including those extended in other package. This is the old behavior and  is compatible with the system browser view (and better be safe than sorry).

The behavior is compatible when multiple packages are selected and a same class is defined/extended more than once.

In the list view, extended classes are displayed with the right color (gray by default) to help the user to visualize that they selected only a subset of the methods (the subset related to the selected packages).