### PR TITLE
Get the variable names of objects

### DIFF
--- a/src/Kernel-Tests/ContextTest.class.st
+++ b/src/Kernel-Tests/ContextTest.class.st
@@ -48,7 +48,7 @@ ContextTest class >> returnNonActiveContextOfBlock [
 	^ Block value
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #utils }
 ContextTest >> DoIt [
 
 	"Mock DoIt method that does not do things"
@@ -231,7 +231,7 @@ ContextTest >> testReturn [
 ]
 
 { #category : #tests }
-ContextTest >> testSearchPlayground [
+ContextTest >> testSearchDoIt [
 
 	|doit|
 	
@@ -247,11 +247,11 @@ ContextTest >> testSearchPlayground [
 		method: aCompiledMethod
 		arguments: #().
 		
-	self assert: (aMethodContext searchPlayground) equals: doit
+	self assert: (aMethodContext searchDoIt) equals: doit
 ]
 
 { #category : #tests }
-ContextTest >> testSearchPlaygroundNil [
+ContextTest >> testSearchDoItNil [
 
 	aMethodContext := Context
 		sender: thisContext
@@ -259,7 +259,7 @@ ContextTest >> testSearchPlaygroundNil [
 		method: aCompiledMethod
 		arguments: #().
 		
-	self assert: (aMethodContext searchPlayground) equals: nil
+	self assert: (aMethodContext searchDoIt) equals: nil
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/ContextTest.class.st
+++ b/src/Kernel-Tests/ContextTest.class.st
@@ -405,6 +405,37 @@ ContextTest >> testSteppingReturnSelfMethod [
 	self assert: newContext identicalTo: aMethodContext
 ]
 
+{ #category : #'as yet unclassified' }
+ContextTest >> testvariableNamesOf [
+
+	| a b c |
+	a := 'hello'.
+	b := 'hel' , 'lo'.
+
+	self assert: (thisContext variableNamesOf: a) equals: #( #a ).
+
+	c := a.
+
+	self assert: (thisContext variableNamesOf: a) equals: #( #a #c ).
+]
+
+{ #category : #'as yet unclassified' }
+ContextTest >> testvariableNamesOf: x and: y [
+
+	| a b c |
+	a := x.
+	b := y.
+	c := a.
+
+	self assert: (thisContext variableNamesOf: a) equals: #( #x #a #c )
+]
+
+{ #category : #'as yet unclassified' }
+ContextTest >> testvariableNamesOfWithArgs [
+
+	self testvariableNamesOf: 'hello' and: 'world'
+]
+
 { #category : #tests }
 ContextTest >> verifyJumpWithSelector: selector [
 	| guineaPig normalStackp readOnlyStackp |

--- a/src/Kernel-Tests/ContextTest.class.st
+++ b/src/Kernel-Tests/ContextTest.class.st
@@ -48,6 +48,12 @@ ContextTest class >> returnNonActiveContextOfBlock [
 	^ Block value
 ]
 
+{ #category : #'as yet unclassified' }
+ContextTest >> DoIt [
+
+	"Mock DoIt method that does not do things"
+]
+
 { #category : #private }
 ContextTest >> privRestartArgBlockTest [
 	"This tests may loop endlessly if incorrect, so call it from another method testing it does not time out"
@@ -222,6 +228,38 @@ ContextTest >> testReturn [
 		method: aCompiledMethod
 		arguments: #().
 	self assert: (aMethodContext return: 5) equals: 5
+]
+
+{ #category : #tests }
+ContextTest >> testSearchPlayground [
+
+	|doit|
+	
+	doit := Context
+		sender: thisContext
+		receiver: nil
+		method: self class >> #DoIt
+		arguments: #().
+
+	aMethodContext := Context
+		sender: doit
+		receiver: aReceiver
+		method: aCompiledMethod
+		arguments: #().
+		
+	self assert: (aMethodContext searchPlayground) equals: doit
+]
+
+{ #category : #tests }
+ContextTest >> testSearchPlaygroundNil [
+
+	aMethodContext := Context
+		sender: thisContext
+		receiver: aReceiver
+		method: aCompiledMethod
+		arguments: #().
+		
+	self assert: (aMethodContext searchPlayground) equals: nil
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/ContextTest.class.st
+++ b/src/Kernel-Tests/ContextTest.class.st
@@ -48,7 +48,7 @@ ContextTest class >> returnNonActiveContextOfBlock [
 	^ Block value
 ]
 
-{ #category : #utils }
+{ #category : #utilities }
 ContextTest >> DoIt [
 
 	"Mock DoIt method that does not do things"

--- a/src/Kernel-Tests/ContextTest.class.st
+++ b/src/Kernel-Tests/ContextTest.class.st
@@ -405,10 +405,10 @@ ContextTest >> testSteppingReturnSelfMethod [
 	self assert: newContext identicalTo: aMethodContext
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 ContextTest >> testvariableNamesOf [
 
-	| a b c |
+	| a b c d |
 	a := 'hello'.
 	b := 'hel' , 'lo'.
 
@@ -416,21 +416,44 @@ ContextTest >> testvariableNamesOf [
 
 	c := a.
 
-	self assert: (thisContext variableNamesOf: a) equals: #( #a #c ).
+	self assert: (thisContext variableNamesOf: a) sorted 	equals: #( #a #c ).
+
+	d := a.
+
+	{ a } do: [ :z | 
+		| t |
+		self assert: (thisContext variableNamesOf: a) sorted equals: #( #a #c #d #z ).
+		t := z.
+		c := nil.
+		self assert: (thisContext variableNamesOf: a) sorted equals: #( #a #d #t #z ) ].
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 ContextTest >> testvariableNamesOf: x and: y [
 
-	| a b c |
+	| a b c d e |
+		
 	a := x.
 	b := y.
 	c := a.
 
-	self assert: (thisContext variableNamesOf: a) equals: #( #x #a #c )
+	self assert: (thisContext variableNamesOf: a) sorted equals: #( #a #c #x ).
+
+	d := a.
+
+	{ a } do: [ :z | 
+		| t |
+		self assert: (thisContext variableNamesOf: a) sorted equals: #( #a #c #d #x #z ).
+		t := a.
+		c := nil.
+		e := a.
+		self assert: (thisContext variableNamesOf: a) sorted equals: #( #a #d #e #t #x #z ).
+		].
+	
+	a := nil
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 ContextTest >> testvariableNamesOfWithArgs [
 
 	self testvariableNamesOf: 'hello' and: 'world'

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -2267,9 +2267,9 @@ Context >> variableNamesOf: anObject [
 
 	"Retrieve the names of the arguments and temporary variables, if any, that refer to the given object."
 
-	^ (1 to: self size)
-		  select: [ :i | (self at: i) == anObject ]
-		  thenCollect: [ :i | self home method tempNames at: i ]
+	^self astScope allTemps
+		select: [ :v | (v readInContext: self) == anObject ]
+		thenCollect: [ :v | v name ]
 ]
 
 { #category : #private }

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -1779,14 +1779,14 @@ Context >> runUntilErrorOrReturnFrom: aSender [
 ]
 
 { #category : #'debugger access' }
-Context >> searchPlayground [
+Context >> searchDoIt [
 
-	"Search down into the call stack and look for the playgroud context (UndefinedObject>>DoIt).
+	"Search down into the call stack and look for a DoIt context.
 	Return `nil` if not found."
 	
 	self belongsToDoIt ifTrue: [ ^ self home ].
 	sender ifNil: [ ^nil ].
-	^ sender searchPlayground.
+	^ sender searchDoIt.
 ]
 
 { #category : #'debugger access' }

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -1779,6 +1779,17 @@ Context >> runUntilErrorOrReturnFrom: aSender [
 ]
 
 { #category : #'debugger access' }
+Context >> searchPlayground [
+
+	"Search down into the call stack and look for the playgroud context (UndefinedObject>>DoIt).
+	Return `nil` if not found."
+	
+	self receiver ifNil: [self selector == #DoIt ifTrue: [ ^self ] ].
+	sender ifNil: [ ^nil ].
+	^ sender searchPlayground.
+]
+
+{ #category : #'debugger access' }
 Context >> selector [
 	"Answer the selector of the method that created the receiver."
 

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -1784,7 +1784,7 @@ Context >> searchPlayground [
 	"Search down into the call stack and look for the playgroud context (UndefinedObject>>DoIt).
 	Return `nil` if not found."
 	
-	self receiver ifNil: [self selector == #DoIt ifTrue: [ ^self ] ].
+	self belongsToDoIt ifTrue: [ ^ self home ].
 	sender ifNil: [ ^nil ].
 	^ sender searchPlayground.
 ]
@@ -2260,6 +2260,16 @@ Context >> unwindTo: aContext [
 			context unwindComplete: true.
 			unwindBlock := context unwindBlock.
 			unwindBlock value ]].
+]
+
+{ #category : #'debugger access' }
+Context >> variableNamesOf: anObject [
+
+	"Retrieve the names of the arguments and temporary variables, if any, that refer to the given object."
+
+	^ (1 to: self size)
+		  select: [ :i | (self at: i) == anObject ]
+		  thenCollect: [ :i | self home method tempNames at: i ]
 ]
 
 { #category : #private }


### PR DESCRIPTION
This comes from a question on the Discord. I thought it was a nice exercise for me :)

The context, if I'm correct, is that you are playing on the playground and call complex methods that call complex methods, etc.
At some point, you want to know the name of temporary variable that hold some objects.

The proposed method Context>>variableNamesOf: just do that

```
|a b|
a := 'hello'.
b := 'world'.
(thisContext variableNamesOf: a) >>> #(#a).
b := a.
(thisContext variableNamesOf: a) >>> #(#a #b).
```