### PR TITLE
Prevent BlockClosure>>benchFor: to loop infinitely

### DIFF
--- a/src/Kernel-Chronology-Extras/BlockClosure.extension.st
+++ b/src/Kernel-Chronology-Extras/BlockClosure.extension.st
@@ -15,20 +15,28 @@ BlockClosure >> bench [
 
 { #category : #'*Kernel-Chronology-Extras' }
 BlockClosure >> benchFor: duration [
+
 	"Run me for duration and return a BenchmarkResult"
-	
+
 	"[ 100 factorial ] benchFor: 2 seconds"
-	
-	| count run started |
+
+	| count run exception started |
 	count := 0.
 	run := true.
-	[ duration wait. run := false ] forkAt: Processor timingPriority - 1.
+	exception := nil. "Used to catch possible exception in the wakeup thread"
+	[ [ duration wait. ]
+			on: Exception
+			do: [ :e | exception := e ].
+		run := false ] forkAt: Processor timingPriority - 1.
 	started := Time millisecondClockValue.
-	[ run ] whileTrue: [ self value. count := count + 1 ].
-	^ BenchmarkResult new 
-		iterations: count; 
-		elapsedTime: (Time millisecondsSince: started) milliSeconds; 
-		yourself
+	[ run ] whileTrue: [ 
+		self value.
+		count := count + 1 ].
+	exception ifNotNil: [ exception signal ].
+	^ BenchmarkResult new
+		  iterations: count;
+		  elapsedTime: (Time millisecondsSince: started) milliSeconds;
+		  yourself
 ]
 
 { #category : #'*Kernel-Chronology-Extras' }

--- a/src/Kernel-Tests-Extended/BlockClosureTest.extension.st
+++ b/src/Kernel-Tests-Extended/BlockClosureTest.extension.st
@@ -14,6 +14,14 @@ BlockClosureTest >> testBenchFor [
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
+BlockClosureTest >> testBenchForException [
+
+	"benchFor: expects a duration. Check that the bencher does not go in an infinite loop if the wakeup thread fails."
+
+	self should: [ [ 100 factorial ] benchFor: 1 ] raise: Error
+]
+
+{ #category : #'*Kernel-Tests-Extended' }
 BlockClosureTest >> testCannotReturn [
 
 	| block p |


### PR DESCRIPTION
`[ 100 factorial ] benchFor: 5` hangs since `5 wait` silently fails (5 is not a duration) thus `run` never became `false`.

The PR adds the catch of exceptions, ensure run is set to false, and reraises the exception on the main thread (so the user can see and debug it).

Questions for reviewers: It is OK to just `exeption signal` to reraise the exception in the correct thread?