### PR TITLE
11613-Review-RBLiteralNode-classvalue 

### DIFF
--- a/src/AST-Core/RBLiteralNode.class.st
+++ b/src/AST-Core/RBLiteralNode.class.st
@@ -22,7 +22,9 @@ RBLiteralNode class >> isAbstract [
 ]
 
 { #category : #'instance creation' }
-RBLiteralNode class >> value: aValue [ 
+RBLiteralNode class >> value: aValue [
+	"we check here for Array and ByteArray explicitly, as subclasses should use RBLiteralNode.
+	using #isByteArray would be inherited by subclasses"
 	^((aValue class == Array or: [aValue class == ByteArray]) 
 		ifTrue: [RBLiteralArrayNode]
 		ifFalse: [RBLiteralValueNode]) value: aValue


### PR DESCRIPTION
add a comment explaining why we do not use #isByteArray here, fixes #11613

(I do not like the method, maybe the check should be done by the user...