### PR TITLE
Moving Deferred messages to instance side

### DIFF
--- a/src/Morphic-Core/MorphicRenderLoop.class.st
+++ b/src/Morphic-Core/MorphicRenderLoop.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #'deferred message' }
 MorphicRenderLoop >> defer: aValuable [
 
-	WorldState addDeferredUIMessage: aValuable
+	self currentWorld defer: aValuable
 ]
 
 { #category : #'initialize-release' }

--- a/src/Morphic-Core/WorldMorph.class.st
+++ b/src/Morphic-Core/WorldMorph.class.st
@@ -216,7 +216,8 @@ WorldMorph >> becomeActiveDuring: aBlock [
 		on: Error
 		do: [ :ex | 
 			ActiveWorld := priorWorld.
-			ex pass ]
+			ex pass ].
+	ActiveWorld := priorWorld.
 ]
 
 { #category : #'meta-actions' }

--- a/src/Morphic-Core/WorldState.class.st
+++ b/src/Morphic-Core/WorldState.class.st
@@ -18,12 +18,12 @@ Class {
 		'activeHand',
 		'currentCursor',
 		'worldRenderer',
-		'realWindowExtent'
+		'realWindowExtent',
+		'deferredUIMessages'
 	],
 	#classVars : [
 		'CanSurrenderToOS',
 		'DebugShowDamage',
-		'DeferredUIMessages',
 		'DesktopMenuPragmaKeyword',
 		'DesktopMenuTitle',
 		'EasySelectingWorld',
@@ -41,12 +41,6 @@ WorldState class >> MinCycleLapse: milliseconds [
 	MinCycleLapse := milliseconds ifNotNil: [ milliseconds rounded ].
 ]
 
-{ #category : #'deferred message' }
-WorldState class >> addDeferredUIMessage: aValuable [
-	"aValuable will be executed in the next UI rendering cycle"
-	self deferredUIMessages nextPut: aValuable
-]
-
 { #category : #'testing os' }
 WorldState class >> canSurrenderToOS: aBoolean [
 
@@ -61,18 +55,6 @@ WorldState class >> debugShowDamage [
 { #category : #accessing }
 WorldState class >> debugShowDamage: aBoolean [
 	DebugShowDamage := aBoolean
-]
-
-{ #category : #'deferred message' }
-WorldState class >> defer: aValuable [
-	"aValuable will be executed in the next UI rendering cycle"
-	self addDeferredUIMessage: aValuable.
-]
-
-{ #category : #'deferred message' }
-WorldState class >> deferredUIMessages [
-
-	^DeferredUIMessages ifNil: [DeferredUIMessages := WaitfreeQueue  new].
 ]
 
 { #category : #settings }
@@ -162,7 +144,7 @@ WorldState class >> initialize [
 	"WorldState initialize"
 
 	MinCycleLapse := 16.		"allows 60 frames per second..."
-	DeferredUIMessages := nil.
+
 ]
 
 { #category : #'drawing cycle' }
@@ -457,8 +439,16 @@ WorldState >> damageRecorder [
 
 { #category : #'deferred message' }
 WorldState >> defer: aValuable [
+	
 	"aValuable will be executed in the next UI rendering cycle"
-	self class defer: aValuable
+	self deferredUIMessages nextPut: aValuable
+]
+
+{ #category : #'private - accessing' }
+WorldState >> deferredUIMessages [
+
+	deferredUIMessages ifNil: [ deferredUIMessages := WaitfreeQueue new ].
+	^ deferredUIMessages
 ]
 
 { #category : #'worldmenu building' }
@@ -780,7 +770,7 @@ WorldState >> runStepMethodsIn: aWorld [
 	
 	| queue nextInQueue|
 	"If available dispatch some deferred UI Message"
-	queue := self class deferredUIMessages.
+	queue := self deferredUIMessages.
 	[(nextInQueue := queue nextOrNil) isNil]
 		whileFalse: [ nextInQueue value].
 	self runLocalStepMethodsIn: aWorld.

--- a/src/Polymorph-Widgets/MorphicUIManager.class.st
+++ b/src/Polymorph-Widgets/MorphicUIManager.class.st
@@ -301,7 +301,7 @@ MorphicUIManager >> debugProcess: process context: context label: title fullView
 { #category : #'ui process' }
 MorphicUIManager >> defer: aValuable [
 	"aValuable will be executed in the next UI rendering cycle"
-	WorldState defer: aValuable
+	self currentWorld defer: aValuable
 ]
 
 { #category : #'ui requests' }

--- a/src/TaskIt/TKTUIProcessTaskRunner.class.st
+++ b/src/TaskIt/TKTUIProcessTaskRunner.class.st
@@ -11,5 +11,5 @@ TKTUIProcessTaskRunner >> isUIRunner [
 
 { #category : #scheduling }
 TKTUIProcessTaskRunner >> scheduleTaskExecution: aTaskExecution [
-	WorldState addDeferredUIMessage: [ self executeTask: aTaskExecution ]
+	self currentWorld defer: [ self executeTask: aTaskExecution ]
 ]

--- a/src/Tool-ProcessBrowser/ProcessBrowser.class.st
+++ b/src/Tool-ProcessBrowser/ProcessBrowser.class.st
@@ -383,7 +383,7 @@ ProcessBrowser >> browsedEnvironment [
 ProcessBrowser >> build [
 	| window  scrolledText |
 	window := (SystemWindow labelled: 'later') model: self.
-	self deferredMessageRecipient: WorldState.
+	self deferredMessageRecipient: window currentWorld.
 	window
 		addMorph: ((PluggableListMorph
 				on: self


### PR DESCRIPTION
 - Using the currentWorld message instead of the class.
 - Moving the list of deferred messages to the instance side.