### PR TITLE
Faster Array>>asX and Array>>as:

### DIFF
--- a/src/Collections-Abstract/ArrayedCollection.class.st
+++ b/src/Collections-Abstract/ArrayedCollection.class.st
@@ -45,6 +45,16 @@ ArrayedCollection class >> newFrom: aCollection [
 ]
 
 { #category : #'instance creation' }
+ArrayedCollection class >> newFromArray: anArray [
+
+	| newCollection size |
+	size := anArray size.
+	newCollection := self new: size.
+	1 to: size do: [ :i | newCollection at: i put: (anArray at: i) ].
+	^ newCollection
+]
+
+{ #category : #'instance creation' }
 ArrayedCollection class >> with: anObject [ 
 	"Answer a new instance of me, containing only anObject."
 

--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -28,7 +28,7 @@ Collection class >> newFromArray: anArray [
 	"Fast initialization with the items of a given array.
 	This initializes elements faster that the generic withAll: or newFrom: methods.
 
-	The main selling point is that dyamic arrays like {1. 2. 3} are really fast in Pharo.
+	The main selling point is that dynamic arrays, like {1. 2. 3}, are really fast in Pharo.
 	So other collections can be easily and efficiently initialized with `{1. 2. 3} asFoo` syntax.
 
 	Examples:

--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -333,7 +333,7 @@ Collection >> asIdentitySet [
 { #category : #converting }
 Collection >> asNewArray [
 
-	"Like asArray: but return a copy is self is already an Array.
+	"Like asArray: but return a copy if self is already an Array.
 	This ensures that the result is always a new Array"
 
 	"'foo' asNewArray >>> 'foo' asArray"

--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -30,6 +30,9 @@ Collection class >> newFromArray: anArray [
 
 	The main selling point is that dynamic arrays, like {1. 2. 3}, are really fast in Pharo.
 	So other collections can be easily and efficiently initialized with `{1. 2. 3} asFoo` syntax.
+	
+	Important: Subclasses of Collection that redefine withAll: or newFrom: should also redefine this method
+	either by having a proper implementation (specific to Arrays) or by calling the redefined versions of withAll:/newFrom:.
 
 	Examples:
 	{ 1. 2. 3 } asSet >>> Set new add: 1; add:2; add:3; yourself

--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -23,6 +23,37 @@ Collection class >> isAbstract [
 ]
 
 { #category : #'instance creation' }
+Collection class >> newFromArray: anArray [
+
+	"Fast initialization with the items of a given array.
+	This initializes elements faster that the generic withAll: or newFrom: methods.
+
+	The main selling point is that dyamic arrays like {1. 2. 3} are really fast in Pharo.
+	So other collections can be easily and efficiently initialized with `{1. 2. 3} asFoo` syntax.
+
+	Examples:
+	{ 1. 2. 3 } asSet >>> Set new add: 1; add:2; add:3; yourself
+	{ 1. 2. 3 } asOrderedCollection >>> OrderedCollection new add: 1; add:2; add:3; yourself
+	{ 1->2. 3->4 } asDictionary >>> Dictionary new at: 1 put: 2; at: 3 put:4; yourself
+
+	{ 1. 2. 3 } as: Set >>> Set new add: 1; add:2; add:3; yourself
+	{ 1. 2. 3 } as: OrderedCollection >>> OrderedCollection new add: 1; add:2; add:3; yourself
+	{ 1->2. 3->4 } as: Dictionary >>> Dictionary new at: 1 put: 2; at: 3 put:4; yourself
+	"
+
+	| newCollection size |
+	size := anArray size.
+	newCollection := self new: size.
+	" This should be fast:
+	1. Integer>>to:do: is inlined in the bytecode (no block).
+	2. The Array>>at: callsite should be monomorph to a primitive method.
+	"
+
+	1 to: size do: [ :i | newCollection add: (anArray at: i) ].
+	^ newCollection
+]
+
+{ #category : #'instance creation' }
 Collection class >> with: anObject [ 
 	"Answer an instance of me containing anObject."
 

--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -328,6 +328,18 @@ Collection >> asIdentitySet [
 ]
 
 { #category : #converting }
+Collection >> asNewArray [
+
+	"Like asArray: but return a copy is self is already an Array.
+	This ensures that the result is always a new Array"
+
+	"'foo' asNewArray >>> 'foo' asArray"
+	"|a| a := #(1 2 3). a asNewArray == a >>> false"
+
+	^ self asArray
+]
+
+{ #category : #converting }
 Collection >> asOrderedCollection [
 	"Answer an OrderedCollection whose elements are the elements of the
 	receiver. The order in which elements are added depends on the order

--- a/src/Collections-Sequenceable/Array.class.st
+++ b/src/Collections-Sequenceable/Array.class.st
@@ -137,13 +137,14 @@ Array class >> new: sizeRequested [
 ]
 
 { #category : #converting }
-Array >> as: otherClass [
+Array >> as: aSimilarClass [
 
 	"Specific classes can redefine newFromArray: by a faster implementation if they want.
 
 	Note: see Collection class>>newFromArray: for the rationale."
 
-	^ otherClass newFromArray: self
+	aSimilarClass == self class ifTrue: [ ^ self ].
+	^ aSimilarClass newFromArray: self
 ]
 
 { #category : #converting }

--- a/src/Collections-Sequenceable/Array.class.st
+++ b/src/Collections-Sequenceable/Array.class.st
@@ -155,12 +155,6 @@ Array >> asArray [
 ]
 
 { #category : #converting }
-Array >> asDictionary [
-
-	^ Dictionary newFromArray: self
-]
-
-{ #category : #converting }
 Array >> asNewArray [
 
 	^ self clone.

--- a/src/Collections-Sequenceable/Array.class.st
+++ b/src/Collections-Sequenceable/Array.class.st
@@ -143,6 +143,12 @@ Array >> asArray [
 	^ self
 ]
 
+{ #category : #converting }
+Array >> asNewArray [
+
+	^ self clone.
+]
+
 { #category : #accessing }
 Array >> atWrap: index [ 
 

--- a/src/Collections-Sequenceable/Array.class.st
+++ b/src/Collections-Sequenceable/Array.class.st
@@ -137,6 +137,16 @@ Array class >> new: sizeRequested [
 ]
 
 { #category : #converting }
+Array >> as: otherClass [
+
+	"Specific classes can redefine newFromArray: by a faster implementation if they want.
+
+	Note: see Collection class>>newFromArray: for the rationale."
+
+	^ otherClass newFromArray: self
+]
+
+{ #category : #converting }
 Array >> asArray [
 	"Answer with the receiver itself."
 
@@ -144,9 +154,27 @@ Array >> asArray [
 ]
 
 { #category : #converting }
+Array >> asDictionary [
+
+	^ Dictionary newFromArray: self
+]
+
+{ #category : #converting }
 Array >> asNewArray [
 
 	^ self clone.
+]
+
+{ #category : #converting }
+Array >> asOrderedCollection [
+
+	^ OrderedCollection newFromArray: self
+]
+
+{ #category : #converting }
+Array >> asSet [
+
+	^ Set newFromArray: self
 ]
 
 { #category : #accessing }

--- a/src/Collections-Sequenceable/Interval.class.st
+++ b/src/Collections-Sequenceable/Interval.class.st
@@ -129,6 +129,15 @@ Interval class >> newFrom: aCollection [
 "
 ]
 
+{ #category : #'instance creation' }
+Interval class >> newFromArray: anArray [
+
+	"Interval does not store the elements.
+	There is no `new:`, no `add:`, etc. So fallback to the default behavior."
+
+	^ self newFrom: anArray
+]
+
 { #category : #accessing }
 Interval class >> streamSpecies [
 	^ Array

--- a/src/Collections-Sequenceable/OrderedCollection.class.st
+++ b/src/Collections-Sequenceable/OrderedCollection.class.st
@@ -134,6 +134,15 @@ OrderedCollection class >> newFrom: aCollection [
 ]
 
 { #category : #'instance creation' }
+OrderedCollection class >> newFromArray: anArray [
+
+	"Fast implementation. Just use a copy of the argument as a storage.
+	No need to copy the elements one by one."
+
+	^ self basicNew setContents: anArray asNewArray
+]
+
+{ #category : #'instance creation' }
 OrderedCollection class >> ofSize: n [
 	"Create a new collection of size n with nil as its elements.
 	This method exists because OrderedCollection new: n creates an

--- a/src/Collections-Sequenceable/SortedCollection.class.st
+++ b/src/Collections-Sequenceable/SortedCollection.class.st
@@ -71,6 +71,12 @@ Class {
 }
 
 { #category : #'instance creation' }
+SortedCollection class >> newFromArray: anArray [
+
+	^ (super newFromArray: anArray) reSort; yourself
+]
+
+{ #category : #'instance creation' }
 SortedCollection class >> sortBlock: aBlock [ 
 	"Answer an instance of me such that its elements are sorted according to the criterion specified in aBlock."
 

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -140,6 +140,17 @@ Object class >> newFrom: aSimilarObject [
 		ifFalse: [self basicNew]) copySameFrom: aSimilarObject
 ]
 
+{ #category : #'instance creation' }
+Object class >> newFromArray: anArray [
+
+	"Fast initialization from an Array.
+	This is mainly used by collections but have to be defined on Object class because it is a double dispatch call from Array>>as: and must be functionnal with non Collection arguments.
+
+	See Collection class>>newFromArray: for the rationale."
+
+	^ self newFrom: anArray
+]
+
 { #category : #'class initialization' }
 Object class >> reInitializeDependentsFields [
 	<script>

--- a/src/Text-Core/RunArray.class.st
+++ b/src/Text-Core/RunArray.class.st
@@ -49,7 +49,7 @@ RunArray class >> newFrom: aCollection [
 
 	"Answer an instance of me containing the same elements as aCollection."
 
-	"(RunArray newFrom: {1. 2. 2. 3}) >>> ({1. $a. $a. 3} as: RunArray)"
+	"(RunArray newFrom: {1. $a. $a. 3}) >>> ({1. $a. $a. 3} as: RunArray)"
 	"({1. $a. $a. 3} as: RunArray) values >>> #(1 $a 3)"
 	"({1. $a. $a. 3} as: RunArray) runs >>> #(1 2 1)"
 

--- a/src/Text-Core/RunArray.class.st
+++ b/src/Text-Core/RunArray.class.st
@@ -45,34 +45,40 @@ RunArray class >> new: size withAll: value [
 ]
 
 { #category : #'instance creation' }
-RunArray class >> newFrom: aCollection [ 
+RunArray class >> newFrom: aCollection [
+
 	"Answer an instance of me containing the same elements as aCollection."
+
+	"(RunArray newFrom: {1. 2. 2. 3}) >>> ({1. $a. $a. 3} as: RunArray)"
+	"({1. $a. $a. 3} as: RunArray) values >>> #(1 $a 3)"
+	"({1. $a. $a. 3} as: RunArray) runs >>> #(1 2 1)"
 
 	| runs values lastRun lastValue |
 	runs := (Array new: aCollection size // 2) writeStream.
 	values := (Array new: aCollection size // 2) writeStream.
 	lastRun := 0.
 	lastValue := Object new.
-	aCollection do: [:x | 
+	aCollection do: [ :x | 
 		lastValue = x
-			ifTrue: [lastRun := lastRun + 1]
-			ifFalse:
-				[lastRun > 0
-					ifTrue:
-						[runs nextPut: lastRun.
-						values nextPut: lastValue].
+			ifTrue: [ lastRun := lastRun + 1 ]
+			ifFalse: [ 
+				lastRun > 0 ifTrue: [ 
+					runs nextPut: lastRun.
+					values nextPut: lastValue ].
 				lastRun := 1.
-				lastValue := x]].
-	lastRun > 0
-		ifTrue:
-			[runs nextPut: lastRun.
-			values nextPut: lastValue].
-	^self basicNew setRuns: runs contents setValues: values contents
+				lastValue := x ] ].
+	lastRun > 0 ifTrue: [ 
+		runs nextPut: lastRun.
+		values nextPut: lastValue ].
+	^ self basicNew setRuns: runs contents setValues: values contents
+]
 
-"	RunArray newFrom: {1. 2. 2. 3}
-	{1. $a. $a. 3} as: RunArray
-	({1. $a. $a. 3} as: RunArray) values
-"
+{ #category : #'instance creation' }
+RunArray class >> newFromArray: anArray [
+
+	"Call specific newFrom:"
+
+	^ self newFrom: anArray
 ]
 
 { #category : #'instance creation' }


### PR DESCRIPTION
Important low-level change where conversion from Array are made faster. (up to x3 (at least) for `asOrderedCollection`)

This is useful as `{1. 2. 3} asFoo` (or `{1. 2. 3} as: Foo`) is the current de facto syntax to have initialized collections of various types with user defined content.

Note that subclasses of Collection that redefine `newFrom:` should also redefine `newFromArray:` or bad things could happen.
This is because the default (inherited) implementations of `newFromArray:` uses `new:` and `add:` (or `at:put:` for ArrayedCollection).