### PR TITLE
POC BlockClosure>>valueAtCompileTime

### DIFF
--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -212,6 +212,12 @@ RBMessageNode >> isUnary [
 	^arguments isEmpty
 ]
 
+{ #category : #testing }
+RBMessageNode >> isValueAtCompileTime [
+
+	^ self selector = #valueAtCompileTime and: [ receiver isBlock ]
+]
+
 { #category : #accessing }
 RBMessageNode >> keywords [
 	^ self selector keywords.

--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -215,7 +215,7 @@ RBMessageNode >> isUnary [
 { #category : #testing }
 RBMessageNode >> isValueAtCompileTime [
 
-	^ self selector = #valueAtCompileTime and: [ receiver isBlock ]
+	^ self selector = #valueAtCompileTime and: [ receiver isBlock and: [ receiver hasArguments not ]]
 ]
 
 { #category : #accessing }

--- a/src/Kernel-Tests/ValueAtCompileTimeTest.class.st
+++ b/src/Kernel-Tests/ValueAtCompileTimeTest.class.st
@@ -40,16 +40,12 @@ ValueAtCompileTimeTest >> testValueAtCompileTimeNoLiteralBlock [
 
 { #category : #tests }
 ValueAtCompileTimeTest >> testValueAtCompileTimeNoParameters [
-
-	|v|
 	
 	"Parameters are not accepted"
 	
-	self flag: 'FIXME: add compiler errors or warnings'.
-	
-	v := [ :x | {x} ] valueAtCompileTime.
-	
-	self assert: v equals: { nil }
+	self flag: 'FIXME: add compiler errors or warnings instead of raising runtime error'.
+		
+	self should: [ [ :x | {x} ] valueAtCompileTime ] raise: Error
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/ValueAtCompileTimeTest.class.st
+++ b/src/Kernel-Tests/ValueAtCompileTimeTest.class.st
@@ -1,0 +1,101 @@
+Class {
+	#name : #ValueAtCompileTimeTest,
+	#superclass : #TestCase,
+	#category : #'Kernel-Tests-Methods'
+}
+
+{ #category : #tests }
+ValueAtCompileTimeTest >> testValueAtCompileTime [
+
+	|v|
+	
+	v := [ 1+2 ] valueAtCompileTime.
+	
+	self assert: v equals: 3
+]
+
+{ #category : #tests }
+ValueAtCompileTimeTest >> testValueAtCompileTimeLocalTempsAreOK [
+
+	|v|
+	
+	v := [ |x| x:= 1. { x. x+1 } ] valueAtCompileTime.
+	
+	self assert: v equals: { 1. 2 }
+]
+
+{ #category : #tests }
+ValueAtCompileTimeTest >> testValueAtCompileTimeNoLiteralBlock [
+
+	|b|
+	
+	"Only a literal block is accepted"
+	
+	self flag: 'FIXME: add compiler errors or warnings'.
+
+	b := [ {1+2} ].
+	
+	self should: [ b valueAtCompileTime ] raise: Error
+]
+
+{ #category : #tests }
+ValueAtCompileTimeTest >> testValueAtCompileTimeNoParameters [
+
+	|v|
+	
+	"Parameters are not accepted"
+	
+	self flag: 'FIXME: add compiler errors or warnings'.
+	
+	v := [ :x | {x} ] valueAtCompileTime.
+	
+	self assert: v equals: { nil }
+]
+
+{ #category : #tests }
+ValueAtCompileTimeTest >> testValueAtCompileTimeReuse [
+
+	"The object evaluated at compile time is reused and mutable.
+	User discretion is advised."
+
+	| res |
+
+	1 to: 5 do: [ :i | "The same ordered collection will be reused."
+		res := [ { 0 } asOrderedCollection ] valueAtCompileTime.
+
+		"Force a reset at the first loop to avoid polution from unrelated executions."
+		i = 1 ifTrue: [ res removeAll ].
+
+		res add: i ].
+
+	"For information, if `value` was user instead of `valueAtCompileTime`, res will be {0.5}"
+	self assert: res asArray equals: { 1. 2. 3. 4. 5 }
+]
+
+{ #category : #tests }
+ValueAtCompileTimeTest >> testValueAtCompileTimeSpeedup [
+
+	|b1 b2|
+
+	b1 := [ [ 100 factorial ] value ] benchFor: 0.01second.
+	b2 := [ [ 100 factorial ] valueAtCompileTime ] benchFor: 0.01second.
+	
+	"x100 is very conservative. But if for some reason the evaluation is not done a compile time, this should detect it."
+	self assert: (100 * b1 executionsPerSecond) < (b2 executionsPerSecond)
+]
+
+{ #category : #tests }
+ValueAtCompileTimeTest >> testValueAtCompileTimeUnbinded [
+
+	|v x|
+	
+	x := 4.
+	
+	"Values are not bound inside the block."
+	
+	self flag: 'FIXME: add compiler errors or warnings'.
+	
+	v := [ {x. self} ] valueAtCompileTime.
+	
+	self assert: v equals: { nil. nil }
+]

--- a/src/Kernel/BlockClosure.class.st
+++ b/src/Kernel/BlockClosure.class.st
@@ -730,6 +730,29 @@ BlockClosure >> valueAfterWaiting: aDelay [
 					print: self ] )
 ]
 
+{ #category : #'evaluating-special' }
+BlockClosure >> valueAtCompileTime [
+
+	"This is a *magic* method that forces the evaluation of a block at compile time by the Opal compiler.
+	The constraints are the following:
+
+	* self should be a literal block (not a variable or the result of a computation).
+	* self should not have any parameter.
+	* sejlf should not capture a context (variable decared outside the block). Temporary variable declared in the block are OK.
+	
+	The value (any object) of such an early evaluation will be used *as is* at runtime in lieu of
+	this method evaluation.
+
+	The object will be not mutable, so any alteration of its state will be preserved.
+	(Note: as a analogy, this can be compared to a `static` variable in C).
+	Object>>#clone or related method can be called on the result to reduce unexpected mutation.
+
+	If, for some, this method is called at runtime it will raise an error.
+	"
+	
+	Error new signal: 'Bad usage of valueAtCompileTime'
+]
+
 { #category : #evaluating }
 BlockClosure >> valueNoContextSwitch [
 	"An exact copy of BlockClosure>>value except that this version will not preempt

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -388,7 +388,7 @@ OCASTTranslator >> emitValueAtCompileTime: aMessageNode [
 
 	"Create the associated fullblock"
 	fullBlock := (FullBlockClosure new: 0)
-		             numArgs: 0;
+		             numArgs: compiledBlock numArgs; "Should be 0, but inconsistency here may cause runtime issues, so better save than sorry"
 		             compiledBlock: compiledBlock;
 		             yourself.
 

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -373,6 +373,29 @@ OCASTTranslator >> emitToDo: aMessageNode step: step [
 	methodBuilder jumpAheadTarget: #done.
 ]
 
+{ #category : #'special magic' }
+OCASTTranslator >> emitValueAtCompileTime: aMessageNode [
+
+	| blockNode compiledBlock fullBlock |
+	methodBuilder addLiteral: aMessageNode selector. "so searching for senders will work"
+
+	"Create the associated compiled node.
+		We wont keed it, it is just for an immediate execution at compile time.
+	Note: the compiledBlock is incomplete as there is no associated method. But it seems to be good enough."
+	blockNode := aMessageNode receiver.
+	compiledBlock := self compilationContext astTranslatorClass new 
+		                 translateFullBlock: blockNode.
+
+	"Create the associated fullblock"
+	fullBlock := (FullBlockClosure new: 0)
+		             numArgs: 0;
+		             compiledBlock: compiledBlock;
+		             yourself.
+
+	"Execute the block *as is* then push the value stored in a literal"
+	methodBuilder pushLiteral: fullBlock value
+]
+
 { #category : #'inline messages factored' }
 OCASTTranslator >> emitWhile: aMessageNode boolean: aBoolean [
 
@@ -579,6 +602,9 @@ OCASTTranslator >> visitMessageNode: aMessageNode [
 		^self 
 			perform: (OptimizedMessages at: aMessageNode selector)
 			with: aMessageNode].
+	aMessageNode isValueAtCompileTime ifTrue: [
+		^ self emitValueAtCompileTime: aMessageNode 
+	 ].
 	^ self emitMessageNode: aMessageNode
 ]
 


### PR DESCRIPTION
This is a proof of concept.

@MarcusDenker talked about a need to have heavy or complex objects (initialized collections for instances) evaluated at compile time instead of at runtime.

This PR offers a generalized way to evaluate any expression at compile time, with obviously the support of the Opal compiler.
Instead of a syntax extension, the magic is hidden behind a special method `BlockClosure>>valueAtCompileTime`.

Why blocks?
Blocks are a very powerful and standard Pharo element that encloses a semi-autonomous expression whose evaluation could be skipped, repeated, deferred, etc.

Since the time of the evaluation of a block is flexible, the idea is to also permit the evaluation of a block **before** the evaluation of the method that contains it (ahead of time) with the special message (the obnoxious selector is a *mise en guarde*).

While classic time travel schemes cause known time continuum issues, the trick here is that the compiler (opal) statically detects such a message send and then evaluate the block itself and store the value as a literal of the Compiled Method (that is not a real literal, but a simple a shared object stored in the method).

