### PR TITLE
Make title bar layout dependent on new settings option and OS

### DIFF
--- a/src/Polymorph-Widgets/ThemeSettings.class.st
+++ b/src/Polymorph-Widgets/ThemeSettings.class.st
@@ -35,7 +35,8 @@ Class {
 		'menuSelectionTextColor',
 		'selectionTextColor',
 		'secondarySelectionTextColor',
-		'findReplaceSelectionTextColor'
+		'findReplaceSelectionTextColor',
+		'labelAreaLayout'
 	],
 	#category : #'Polymorph-Widgets-Themes'
 }
@@ -53,6 +54,15 @@ ThemeSettings >> applySettingsFrom: aThemeSettings [
 		windowColor: aThemeSettings windowColor;
 		selectionColor: aThemeSettings selectionColor;
 		autoSelectionColor: aThemeSettings autoSelectionColor
+]
+
+{ #category : #updating }
+ThemeSettings >> applyToDisplayedWindows [
+			
+	(SystemWindow withAllSubclasses
+		flatCollect: [ :sysWinClass | sysWinClass allInstances ])
+			select: [ :sysWin | sysWin isDisplayed ]
+				thenDo: [ :dispSysWin | dispSysWin themeChanged ]
 ]
 
 { #category : #menu }
@@ -450,7 +460,8 @@ ThemeSettings >> preferRoundCorner [
 ThemeSettings >> preferRoundCorner: aBoolean [
 	"Set the value of preferRoundCorner"
 
-	preferRoundCorner := aBoolean
+	preferRoundCorner := aBoolean.
+	self applyToDisplayedWindows
 ]
 
 { #category : #accessing }

--- a/src/Polymorph-Widgets/ThemeSettings.class.st
+++ b/src/Polymorph-Widgets/ThemeSettings.class.st
@@ -312,6 +312,21 @@ ThemeSettings >> initialize [
 ]
 
 { #category : #accessing }
+ThemeSettings >> labelAreaLayout [
+	"Answer the value of labelAreaLayout"
+
+	^labelAreaLayout  ifNil: [labelAreaLayout  := #platformDependent]
+]
+
+{ #category : #accessing }
+ThemeSettings >> labelAreaLayout: aSelector [
+	"Set the value of labelAreaLayout"
+
+	labelAreaLayout  := aSelector.
+	self applyToDisplayedWindows
+]
+
+{ #category : #accessing }
 ThemeSettings >> manualSelectionColor [
 	"Answer the inverse of autoSelectionColor."
 

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -1288,14 +1288,24 @@ UITheme >> configureWindowDropShadowFor: aWindow [
 UITheme >> configureWindowLabelAreaFor: aWindow [
 	"Configure the label area for the given window."
 
-	|padding|
+	| macOSLayout addCloseBox addCollapseExpandBoxes addMenuBox padding paddingStep |
+	macOSLayout := self labelAreaLayout = #macOS
+		or: [ self labelAreaLayout = #platformDependent and: Smalltalk os isMacOS ].
+	addCloseBox := [ aWindow hasCloseBox ifTrue: [aWindow addCloseBox ] ].
+	addCollapseExpandBoxes := [
+		aWindow hasCollapseBox ifTrue: [aWindow addCollapseBox ].
+		aWindow hasExpandBox ifTrue: [aWindow addExpandBox ] ].
+	addMenuBox := [ aWindow hasMenuBox ifTrue: [aWindow addMenuControl ] ].
 	padding := 0.
 	aWindow labelArea
 		addMorphBack: (Morph new extent: aWindow class borderWidth @ 0).
-	aWindow hasCloseBox ifTrue: [aWindow addCloseBox. padding := padding + 1].
-	aWindow hasCollapseBox ifTrue: [aWindow addCollapseBox. padding := padding + 1].
-	aWindow hasExpandBox ifTrue: [aWindow addExpandBox. padding := padding + 1].
-	aWindow hasMenuBox ifTrue: [padding := padding - 1].
+	macOSLayout
+		ifTrue: [ addCloseBox value. addCollapseExpandBoxes value. paddingStep := 1 ]
+		ifFalse: [ addMenuBox value. paddingStep := -1 ].
+	aWindow hasCloseBox ifTrue: [padding := padding + paddingStep].
+	aWindow hasCollapseBox ifTrue: [padding := padding + paddingStep].
+	aWindow hasExpandBox ifTrue: [padding := padding + paddingStep].
+	aWindow hasMenuBox ifTrue: [padding := padding - paddingStep].
 	aWindow labelArea
 		addMorphBack: (Morph new extent: aWindow class borderWidth @ 0; hResizing: #spaceFill).
 	aWindow basicLabel ifNotNil: [:label | 
@@ -1308,7 +1318,9 @@ UITheme >> configureWindowLabelAreaFor: aWindow [
 	padding > 0 ifTrue: [
 		aWindow labelArea
 			addMorphBack: (Morph new extent: (aWindow boxExtent x * padding) @ 0)].
-	aWindow hasMenuBox ifTrue: [aWindow addMenuControl].
+	macOSLayout
+		ifTrue: [ addMenuBox value ]
+		ifFalse: [ addCollapseExpandBoxes value. addCloseBox value ].
 	aWindow labelArea
 		addMorphBack: (Morph new extent: aWindow class borderWidth @ 0)
 ]
@@ -2367,6 +2379,11 @@ UITheme >> initializeForms [
 		at: #windowMaximizePassive put: self newWindowInactiveControlForm;
 		at: #windowMenuPassive put: self newWindowMenuPassiveForm;
 		at: #windowMenuOver put: self newWindowMenuOverForm
+]
+
+{ #category : #accessing }
+UITheme >> labelAreaLayout [
+	^ self settings labelAreaLayout
 ]
 
 { #category : #'label-styles' }

--- a/src/Settings-Polymorph/PolymorphSystemSettings.class.st
+++ b/src/Settings-Polymorph/PolymorphSystemSettings.class.st
@@ -244,6 +244,24 @@ PolymorphSystemSettings class >> desktopSettingsOn: aBuilder [
 				]]
 ]
 
+{ #category : #morphic }
+PolymorphSystemSettings class >> labelAreaLayoutSettingsOn: aBuilder [
+	<systemsettings>
+	(aBuilder pickOne: #labelAreaLayout)
+		label: 'Label area layout' translated;
+		parent: #windows;
+		target: UITheme;
+		targetSelector: #currentSettings;
+		default: #platformDependent;
+		domainValues: {
+			'Platform Dependent' translated -> #platformDependent.
+			'macOS' -> #macOS.
+			'Windows/Linux' -> #WindowsOrLinux };
+		description: 'If Platform Dependent, label area elements are placed as they are in the windows of the current OS.
+If macOS, close/collapse/expand boxes are placed on the left, and menu control on the right.
+If Windows/Linux, elements are placed in order: menu control, label, collapse/expand/close boxes.'.
+]
+
 { #category : #settings }
 PolymorphSystemSettings class >> morphicHaloSettingsOn: aBuilder [ 
 	(aBuilder group: #halo)


### PR DESCRIPTION
Fixes #11718

- Adds a new instance variable `labelAreaLayout` to the ThemeSettings class and adds access methods for it
- Makes the window label area configuring dependent on the value of this variable
- Adds a “Label area layout” option to the “Windows” section of the Settings Browser
- Bonus: adds a method `ThemeSettings >> #applyToDisplayedWindows` for applying settings to the all displayed SystemWindow instances