### PR TITLE
11725-Startup-Slow-in-OSX-previous-to-Monterrey

### DIFF
--- a/src/EpiceaBrowsers/EpSettings.class.st
+++ b/src/EpiceaBrowsers/EpSettings.class.st
@@ -86,7 +86,7 @@ EpSettings class >> storeNameStrategySettingsOn: aBuilder [
 		description: 'Choose how will be the Epicea logs named.';
 		parent: #epicea;
 		target: self;
-		default: OmRandomSuffixStrategy;
+		default: OmTimeStampSuffixStrategy;
 		domainValues: OmSessionStoreNamingStrategy availableStrategies.
 ]
 

--- a/src/Ombu/OmSessionStore.class.st
+++ b/src/Ombu/OmSessionStore.class.st
@@ -72,7 +72,7 @@ OmSessionStore class >> startUp [
 OmSessionStore class >> storeNameStrategy [
 
 	^ storeNameStrategy ifNil: [ 
-		storeNameStrategy := OmRandomSuffixStrategy new ]
+		storeNameStrategy := OmTimeStampSuffixStrategy new ]
 ]
 
 { #category : #accessing }

--- a/src/System-Identification-Tests/GlobalIdentifierPersistenceTest.class.st
+++ b/src/System-Identification-Tests/GlobalIdentifierPersistenceTest.class.st
@@ -91,11 +91,16 @@ GlobalIdentifierPersistenceTest >> testIsEnabled2 [
 { #category : #tests }
 GlobalIdentifierPersistenceTest >> testLoad [
 	"Load when nothing is stored."
-	| values |
-	values := Dictionary new.
+	| values identifier |
+
+	identifier := GlobalIdentifier basicNew initialize.
+	values := identifier persistedInformation.
 	values at: #a put: 42.
-	persistence load: values.
-	self assert: values size equals: 1.
+	
+	persistence load: identifier.
+	
+	"It has the saved value, the computerUUID and the secretUUID"
+	self assert: values size equals: 3.
 	self assert: (values at: #a) equals: 42.
 	self assert: preferences exists.
 ]
@@ -103,13 +108,18 @@ GlobalIdentifierPersistenceTest >> testLoad [
 { #category : #tests }
 GlobalIdentifierPersistenceTest >> testLoad2 [
 	"Load stored values."
-	| values loaded |
-	values := Dictionary new.
-	values at: #a put: 42.
-	persistence save: values.
-	loaded := Dictionary new.
-	persistence load: loaded.
-	self assert: loaded equals: values.
+	| identifier otherIdentifier |
+	identifier := GlobalIdentifier basicNew initialize.
+	otherIdentifier := GlobalIdentifier basicNew initialize.
+	
+	identifier persistedInformation at: #a put: 42.
+	persistence save: identifier persistedInformation.
+	
+	persistence load: otherIdentifier.
+	self assert: (otherIdentifier persistedInformation at: #a) equals: 42.
+	self assert: (otherIdentifier persistedInformation includesKey: #computerUUID).
+	self assert: (otherIdentifier persistedInformation includesKey: #secretUUID).
+
 ]
 
 { #category : #tests }

--- a/src/System-Identification-Tests/GlobalIdentifierTest.class.st
+++ b/src/System-Identification-Tests/GlobalIdentifierTest.class.st
@@ -136,7 +136,7 @@ GlobalIdentifierTest >> testBackwardCompatibility4 [
 	We use STON. The STON preference file is broken, we cannot read it.
 	Let's check that we keep FUEL file untouched and creates STON file."
 
-	| fuelPersistence fuelPrefereces data dictionary |
+	| fuelPersistence fuelPrefereces data dictionary newIdentifier |
 	fuelPersistence := GlobalIdentifierPersistence fuel.
 	fuelPersistence
 		checker:
@@ -161,9 +161,10 @@ GlobalIdentifierTest >> testBackwardCompatibility4 [
 	self assert: fuelPrefereces contents equals: data.
 	self assert: identifier persistenceStrategy preferences exists.
 	self deny: identifier persistenceStrategy preferencesContents equals: data.
-	dictionary := Dictionary new.
-	identifier persistenceStrategy load: dictionary.
-	self assert: dictionary equals: identifier persistedInformation
+
+	newIdentifier := GlobalIdentifier basicNew initialize.
+	identifier persistenceStrategy load: newIdentifier.
+	self assert: newIdentifier persistedInformation equals: identifier persistedInformation
 ]
 
 { #category : #tests }

--- a/src/System-Identification-Tests/GlobalIdentifierTest.class.st
+++ b/src/System-Identification-Tests/GlobalIdentifierTest.class.st
@@ -136,7 +136,7 @@ GlobalIdentifierTest >> testBackwardCompatibility4 [
 	We use STON. The STON preference file is broken, we cannot read it.
 	Let's check that we keep FUEL file untouched and creates STON file."
 
-	| fuelPersistence fuelPrefereces data dictionary newIdentifier |
+	| fuelPersistence fuelPrefereces data newIdentifier |
 	fuelPersistence := GlobalIdentifierPersistence fuel.
 	fuelPersistence
 		checker:

--- a/src/System-Identification/GlobalIdentifier.class.st
+++ b/src/System-Identification/GlobalIdentifier.class.st
@@ -89,12 +89,15 @@ GlobalIdentifier class >> uniqueInstance [
 GlobalIdentifier >> computerUUID [
 	"This value identifies a user logged into the computer.
 	Before calling #computerUUID method, you should call #ensure."
-	^ persistedInformation at: #computerUUID
+	
+	^ persistedInformation at: #computerUUID ifAbsentPut: [UUID new asString].
 ]
 
 { #category : #'load and saving' }
 GlobalIdentifier >> ensure [
-	self persistenceStrategy ensure: self persistedInformation
+	self persistenceStrategy ensure: self persistedInformation.
+
+
 ]
 
 { #category : #initialization }
@@ -102,8 +105,6 @@ GlobalIdentifier >> initialize [
 	super initialize.
 	"Dictionary contains all the values that we want to persist on disk."
 	persistedInformation := Dictionary new.
-	persistedInformation at: #computerUUID put: UUID new asString.
-	persistedInformation at: #secretUUID put: UUID new asString.
 	persistenceStrategy := GlobalIdentifierPersistence ston.
 	persistenceStrategy previous: GlobalIdentifierPersistence fuel.
 ]
@@ -135,5 +136,6 @@ GlobalIdentifier >> secretUUID [
 	"This value can be used for obfuscating an information before sending it.
 	See #obfuscate: method.
 	Before calling #secretUUID method, you should call #ensure."
-	^ persistedInformation at: #secretUUID
+	^ persistedInformation at: #secretUUID ifAbsentPut: [UUID new asString].
+
 ]

--- a/src/System-Identification/GlobalIdentifier.class.st
+++ b/src/System-Identification/GlobalIdentifier.class.st
@@ -95,9 +95,18 @@ GlobalIdentifier >> computerUUID [
 
 { #category : #'load and saving' }
 GlobalIdentifier >> ensure [
-	self persistenceStrategy ensure: self persistedInformation.
+	self persistenceStrategy ensure: self.
 
 
+]
+
+{ #category : #'load and saving' }
+GlobalIdentifier >> ensureComputerAndSecretValues [
+
+	"To be used before saving the dictionary with new values. So, we can ensure it is properly generated. Accessing the values force its generation"
+	
+	self computerUUID.
+	self secretUUID.
 ]
 
 { #category : #initialization }

--- a/src/System-Identification/GlobalIdentifierMerger.class.st
+++ b/src/System-Identification/GlobalIdentifierMerger.class.st
@@ -37,11 +37,11 @@ Class {
 
 { #category : #actions }
 GlobalIdentifierMerger >> convertValues [
-	existing 
+	existing
 		at: #computerUUID 
 		ifPresent: [ :aValue | existing at: #computerUUID put: aValue asString ]
 		ifAbsent: [ "ignore" ].
-	existing 
+	existing
 		at: #secretUUID
 		ifPresent: [ :aValue | existing at: #secretUUID put: aValue asString ]
 		ifAbsent: [ "ignore" ].

--- a/src/System-Identification/GlobalIdentifierPersistence.class.st
+++ b/src/System-Identification/GlobalIdentifierPersistence.class.st
@@ -70,11 +70,11 @@ GlobalIdentifierPersistence >> delete [
 ]
 
 { #category : #'load and saving' }
-GlobalIdentifierPersistence >> ensure: existingDictionary [
+GlobalIdentifierPersistence >> ensure: globalIdentifier [
 	"It proceeds all backward compatibility work."
 	self shouldCallPreviousPersistence ifTrue: [ 
-		previousPersistence ensure: existingDictionary ].
-	self load: existingDictionary
+		previousPersistence ensure: globalIdentifier ].
+	self load: globalIdentifier
 ]
 
 { #category : #operations }
@@ -107,19 +107,22 @@ GlobalIdentifierPersistence >> load [
 ]
 
 { #category : #'load and saving' }
-GlobalIdentifierPersistence >> load: existingDictionary [
+GlobalIdentifierPersistence >> load: globalIdentifier [
 	"It loads stored information into existingDictionary."
 	self isEnabled ifFalse: [ ^ self ].
 	self preferences ifAbsent: [
 		"This is a new computer, so we define new computer UUID.
 		User still has to agree about sending data if it is not has been done yet."
-		^ self save: existingDictionary ].
-	[ (self mergeExisting: existingDictionary stored: self load)
-			ifTrue: [ self save: existingDictionary ].
+		globalIdentifier ensureComputerAndSecretValues.
+		^ self save: globalIdentifier persistedInformation ].
+	[ (self mergeExisting: globalIdentifier stored: self load)
+			ifTrue: [ 
+				self save: globalIdentifier persistedInformation ].
 	] on: Error do: [ 
 		"Preferences likely contains a different settings version, so we store the actual one.
 		We should keep the preferences as stable as possible."
-		self mayOverwrite: existingDictionary ]
+		globalIdentifier ensureComputerAndSecretValues.
+		self mayOverwrite: globalIdentifier persistedInformation ]
 ]
 
 { #category : #'load and saving' }
@@ -130,9 +133,15 @@ GlobalIdentifierPersistence >> mayOverwrite: aDictionary [
 ]
 
 { #category : #merging }
-GlobalIdentifierPersistence >> mergeExisting: existingDictionary stored: storedDictionary [
+GlobalIdentifierPersistence >> mergeExisting: globalIdentifier stored: storedDictionary [
+	
+	"If the stored version does not have a computerUUID, we have to ensure the new one 
+	has it"
+	(storedDictionary includesKey: #computerUUID)
+		ifFalse: [ globalIdentifier ensureComputerAndSecretValues ].
+
 	^ GlobalIdentifierMerger new
-			existing: existingDictionary;
+			existing: globalIdentifier persistedInformation;
 			stored: storedDictionary;
 			merge
 ]


### PR DESCRIPTION
- Delaying the generation of the UUID for the computer when it is not loaded
- Using the OmTimeStamp strategy instead of the UUID (it is not random)