### PR TITLE
Debugger selection messed up when using breakpoints in a block #11733 

### DIFF
--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -471,6 +471,7 @@ OCASTTranslator >> translateFullBlock: aBlockNode [
 	methodBuilder mapToNode: aBlockNode body.
 	methodBuilder addBlockReturnTopIfRequired.
 	aBlockNode ir: self ir.
+	aBlockNode resetBcToASTCache.
 	^ aBlockNode ir compiledBlock: aBlockNode scope
 ]
 

--- a/src/OpalCompiler-Core/RBBlockNode.extension.st
+++ b/src/OpalCompiler-Core/RBBlockNode.extension.st
@@ -79,6 +79,12 @@ RBBlockNode >> pcsForNode: aNode [
 ]
 
 { #category : #'*OpalCompiler-Core' }
+RBBlockNode >> resetBcToASTCache [
+
+	bcToASTCache := nil
+]
+
+{ #category : #'*OpalCompiler-Core' }
 RBBlockNode >> sourceNodeForPC: anInteger [
 	^ self bcToASTCache nodeForPC: anInteger
 ]

--- a/src/Reflectivity-Tests/ReflectiveMethodTest.class.st
+++ b/src/Reflectivity-Tests/ReflectiveMethodTest.class.st
@@ -14,6 +14,20 @@ ReflectiveMethodTest >> tearDown [
 	super tearDown
 ]
 
+{ #category : #tests }
+ReflectiveMethodTest >> testASTCacheIsCleanedAfterMetaLinkRemoval [
+	| method bcToASTCache |
+	selector := #exampleBlock.
+	method := ReflectivityExamples >> selector. 
+	method createTwin.
+	bcToASTCache :=  method ast blockNodes first bcToASTCache.
+	
+	(ReflectivityExamples >> selector) invalidate.
+	ReflectivityExamples new perform: selector.
+	
+	self deny: method ast blockNodes first bcToASTCache identicalTo: bcToASTCache.
+]
+
 { #category : #'tests - creation' }
 ReflectiveMethodTest >> testCreateReflectiveMethod [
 	| compiledMethod reflectiveMethod |


### PR DESCRIPTION
Trying to debug some code where there is a real block and a breakpoint was set in the block at some point messed up the code selection in the debugger. Indeed, the bytecode to AST cache of the block still contains bytecodes generated by the breakpoint metalink. The debugger the uses this wrong information and code selection is wrong, making it hard to debug.

Fixes #11733