### PR TITLE
Fix RefactoringChangeTests on fluid

### DIFF
--- a/src/Refactoring-Tests-Changes/RBRefactoringChangeTest.class.st
+++ b/src/Refactoring-Tests-Changes/RBRefactoringChangeTest.class.st
@@ -208,7 +208,7 @@ RBRefactoringChangeTest >> testAddMetaclassPattern [
 	self exampleClasses do: [ :class |
 		(class isObsolete or: [ class superclass notNil and: [ class superclass isObsolete ] ]) ifFalse: [  
  		| change |
-		change := changes defineClass: class class definitionString.
+		change := changes defineClass: class class oldDefinition.
 		self assert: (change isKindOf: RBAddMetaclassChange).
 		self assert: change changeClassName equals: class name.
 		self assert: change classInstanceVariableNames equals: class class instVarNames.
@@ -232,7 +232,7 @@ RBRefactoringChangeTest >> testAddTraitPattern [
 	
 	self exampleTraits do: [ :trait |
 		| change |
-		change := changes defineClass: trait definitionString.
+		change := changes defineClass: trait oldDefinition.
 		self assert: (change isKindOf: RBAddTraitChange).
 		self assert: change changeClassName equals: trait name.
 		self assert: change category equals: trait category.


### PR DESCRIPTION
Fix https://github.com/pharo-project/pharo/issues/11680

We keep the same strategies that the other tests: use `oldDefinition` message to avoid new fluid syntax.

We opened this issue to support it: https://github.com/pharo-project/pharo/issues/11740 