### PR TITLE
Rename AddClass refactoring/transformation to InsertClass and cleanup

### DIFF
--- a/src/Refactoring-Core/RBAddClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBAddClassRefactoring.class.st
@@ -84,7 +84,7 @@ RBAddClassRefactoring >> storeOn: aStream [
 
 { #category : #transforming }
 RBAddClassRefactoring >> transform [
-	(self model)
+	self model
 		defineClass: ('<1p> subclass: #<2s> instanceVariableNames: '''' classVariableNames: '''' poolDictionaries: '''' category: <3p>' 
 					expandMacrosWith: superclass
 					with: className

--- a/src/Refactoring-Core/RBChildrenToSiblingsRefactoring.class.st
+++ b/src/Refactoring-Core/RBChildrenToSiblingsRefactoring.class.st
@@ -56,7 +56,7 @@ RBChildrenToSiblingsRefactoring >> abstractSuperclass [
 
 { #category : #transforming }
 RBChildrenToSiblingsRefactoring >> addSuperclass [
-	self performCompositeRefactoring: (RBAddClassRefactoring 
+	self performCompositeRefactoring: (RBInsertClassRefactoring 
 				model: self model
 				addClass: className
 				superclass: parent superclass

--- a/src/Refactoring-Core/RBCopyClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBCopyClassRefactoring.class.st
@@ -63,7 +63,7 @@ RBCopyClassRefactoring >> category: aSymbol [
 
 { #category : #transforming }
 RBCopyClassRefactoring >> copyClass [
-	self performCompositeRefactoring: (RBAddClassRefactoring
+	self performCompositeRefactoring: (RBInsertClassRefactoring
 		model: self model
 		addClass: className
 		superclass: aClass superclass

--- a/src/Refactoring-Core/RBInsertClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBInsertClassRefactoring.class.st
@@ -9,7 +9,7 @@ My preconditions verify that I use a valid class name, that does not yet exists 
 and the subclasses (if any) were direct subclasses of the superclass.
 "
 Class {
-	#name : #RBAddClassRefactoring,
+	#name : #RBInsertClassRefactoring,
 	#superclass : #RBClassRefactoring,
 	#instVars : [
 		'category',
@@ -20,7 +20,7 @@ Class {
 }
 
 { #category : #'instance creation' }
-RBAddClassRefactoring class >> addClass: aName superclass: aClass subclasses: aCollection category: aSymbol [
+RBInsertClassRefactoring class >> addClass: aName superclass: aClass subclasses: aCollection category: aSymbol [
 	^ self new
 		addClass: aName
 		superclass: aClass
@@ -29,7 +29,7 @@ RBAddClassRefactoring class >> addClass: aName superclass: aClass subclasses: aC
 ]
 
 { #category : #'instance creation' }
-RBAddClassRefactoring class >> model: aRBSmalltalk addClass: aName superclass: aClass subclasses: aCollection category: aSymbol [ 
+RBInsertClassRefactoring class >> model: aRBSmalltalk addClass: aName superclass: aClass subclasses: aCollection category: aSymbol [ 
 	^ self new
 		model: aRBSmalltalk;
 		addClass: aName
@@ -40,7 +40,7 @@ RBAddClassRefactoring class >> model: aRBSmalltalk addClass: aName superclass: a
 ]
 
 { #category : #initialization }
-RBAddClassRefactoring >> addClass: aName superclass: aClass subclasses: aCollection category: aSymbol [ 
+RBInsertClassRefactoring >> addClass: aName superclass: aClass subclasses: aCollection category: aSymbol [ 
 	self className: aName.
 	superclass := self classObjectFor: aClass.
 	subclasses := aCollection collect: [:each | self classObjectFor: each].
@@ -48,7 +48,7 @@ RBAddClassRefactoring >> addClass: aName superclass: aClass subclasses: aCollect
 ]
 
 { #category : #preconditions }
-RBAddClassRefactoring >> preconditions [
+RBInsertClassRefactoring >> preconditions [
 	| cond |
 	cond := ((RBCondition isMetaclass: superclass) 
 				errorMacro: 'Superclass must not be a metaclass') not.
@@ -67,7 +67,7 @@ RBAddClassRefactoring >> preconditions [
 ]
 
 { #category : #printing }
-RBAddClassRefactoring >> storeOn: aStream [ 
+RBInsertClassRefactoring >> storeOn: aStream [ 
 	aStream nextPut: $(.
 	self class storeOn: aStream.
 	aStream
@@ -83,7 +83,7 @@ RBAddClassRefactoring >> storeOn: aStream [
 ]
 
 { #category : #transforming }
-RBAddClassRefactoring >> transform [
+RBInsertClassRefactoring >> transform [
 	self model
 		defineClass: ('<1p> subclass: #<2s> instanceVariableNames: '''' classVariableNames: '''' poolDictionaries: '''' category: <3p>' 
 					expandMacrosWith: superclass

--- a/src/Refactoring-Core/RBSplitClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBSplitClassRefactoring.class.st
@@ -94,7 +94,7 @@ RBSplitClassRefactoring >> abstractVariableReferences [
 
 { #category : #'private - transforming' }
 RBSplitClassRefactoring >> addClass [
-	self performCompositeRefactoring: (RBAddClassRefactoring 
+	self performCompositeRefactoring: (RBInsertClassRefactoring 
 				model: self model
 				addClass: newClassName
 				superclass: Object

--- a/src/Refactoring2-Transformations-Tests/RBAddClassParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddClassParametrizedTest.class.st
@@ -24,28 +24,6 @@ RBAddClassParametrizedTest >> setUp [
 	model := self abstractVariableTestData.
 ]
 
-{ #category : #tests }
-RBAddClassParametrizedTest >> testAddClass [
-	| refactoring newClass superClass classTest |
-	
-	refactoring := self createRefactoringWithArguments: 
-		{ #FooTest . #RBAbstractRefactoringTest . (Array with: self class) . #'Refactory-Testing' }.
-		
-	self executeRefactoring: refactoring.
-	
-	newClass := refactoring model classNamed: #FooTest.
-	superClass := refactoring model classNamed: #RBAbstractRefactoringTest.
-	classTest := refactoring model classNamed: self class name.
-	self assert: newClass superclass equals: superClass.
-	self assert: (superClass subclasses includes: newClass).
-	self assert: newClass classSide superclass equals: superClass classSide.
-	self assert: (superClass classSide subclasses includes: newClass classSide).
-	self assert: classTest superclass equals: newClass.
-	self assert: (newClass subclasses includes: classTest).
-	self assert: classTest classSide superclass equals: newClass classSide.
-	self assert: (newClass classSide subclasses includes: classTest classSide)
-]
-
 { #category : #'failure tests' }
 RBAddClassParametrizedTest >> testEmptyCategory [
 	self shouldFail: (self createRefactoringWithArguments:
@@ -59,24 +37,58 @@ RBAddClassParametrizedTest >> testExistingClassName [
 ]
 
 { #category : #tests }
+RBAddClassParametrizedTest >> testInsertClassWithinExistingHiearchy [
+	| refactoring insertedClass parentOfInsertedClass childOfInsertedClass |
+	
+	refactoring := self createRefactoringWithArguments: 
+		{ #InsertedClass . #RBAbstractRefactoringTest . (Array with: self class) . #'Refactory-Testing' }.
+		"addClass: superclass: subclasses: category:"
+	self executeRefactoring: refactoring.
+	
+	insertedClass := refactoring model classNamed: #InsertedClass.
+	parentOfInsertedClass := refactoring model classNamed: #RBAbstractRefactoringTest.
+	childOfInsertedClass := refactoring model classNamed: self class name.
+	
+	"The inserted class is correctly inserted between the currrent class and its superclass.
+	The checks only check the inserted-superclass link."
+	self assert: insertedClass superclass equals: parentOfInsertedClass.
+	self assert: (parentOfInsertedClass subclasses includes: insertedClass).
+	
+	"Metaclasses are correctly linked"
+	self assert: insertedClass classSide superclass equals: parentOfInsertedClass classSide.
+	self assert: (parentOfInsertedClass classSide subclasses includes: insertedClass classSide).
+	
+	"The inserted class is correctly inserted between the currrent class and its superclass.
+	The checks only check the insertedclass and its subclasses."
+	self assert: childOfInsertedClass superclass equals: insertedClass.
+	self assert: (insertedClass subclasses includes: childOfInsertedClass).
+	self assert: childOfInsertedClass classSide superclass equals: insertedClass classSide.
+	self assert: (insertedClass classSide subclasses includes: childOfInsertedClass classSide)
+]
+
+{ #category : #tests }
 RBAddClassParametrizedTest >> testModelAddClass [
-	| refactoring newClass superClass subclass |
-	subclass := model classNamed: #Bar.
-	superClass := model classNamed: #Foo.
+	| refactoring insertedClass superClass subclass |
+	superClass := model classNamed: #NewSuperClass.
+	subclass := model classNamed: #NewSubclass.
+
 	refactoring := self createRefactoringWithModel: model andArguments:
-		{ #FooTest . superClass name . (Array with: subclass) . #'Refactory-Testing' }.
+		{ #InsertedClass . superClass name . (Array with: subclass) . #'Refactory-Testing' }.
+		"addClass: superclass: subclasses: category:"
 		
 	self executeRefactoring: refactoring.
 	
-	newClass := model classNamed: #FooTest.
-	self assert: newClass superclass equals: superClass.
-	self assert: (superClass subclasses includes: newClass).
-	self assert: newClass classSide superclass equals: superClass classSide.
-	self assert: (superClass classSide subclasses includes: newClass classSide).
-	self assert: subclass superclass equals: newClass.
-	self assert: (newClass subclasses includes: subclass).
-	self assert: subclass classSide superclass equals: newClass classSide.
-	self assert: (newClass classSide subclasses includes: subclass classSide)
+	insertedClass := model classNamed: #InsertedClass.
+	self assert: insertedClass superclass equals: superClass.
+	self assert: (superClass subclasses includes: insertedClass).
+	
+	self assert: insertedClass classSide superclass equals: superClass classSide.
+	self assert: (superClass classSide subclasses includes: insertedClass classSide).
+	
+	self assert: subclass superclass equals: insertedClass.
+	self assert: (insertedClass subclasses includes: subclass).
+	self assert: subclass classSide superclass equals: insertedClass classSide.
+	self assert: (insertedClass classSide subclasses includes: subclass classSide)
 ]
 
 { #category : #'failure tests' }

--- a/src/Refactoring2-Transformations-Tests/RBInsertClassParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBInsertClassParametrizedTest.class.st
@@ -76,8 +76,8 @@ RBInsertClassParametrizedTest >> testModelExistingClassName [
 { #category : #tests }
 RBInsertClassParametrizedTest >> testModelInsertClass [
 	| refactoring insertedClass superClass subclass |
-	superClass := model classNamed: #NewSuperClass.
-	subclass := model classNamed: #NewSubclass.
+	superClass := model classNamed: #Foo.
+	subclass := model classNamed: #Bar.
 
 	refactoring := self createRefactoringWithModel: model andArguments:
 		{ #InsertedClass . superClass name . (Array with: subclass) . #'Refactory-Testing' }.

--- a/src/Refactoring2-Transformations-Tests/RBInsertClassParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBInsertClassParametrizedTest.class.st
@@ -1,43 +1,43 @@
 Class {
-	#name : #RBAddClassParametrizedTest,
+	#name : #RBInsertClassParametrizedTest,
 	#superclass : #RBAbstractRefactoringTest,
 	#category : #'Refactoring2-Transformations-Tests-Parametrized'
 }
 
 { #category : #tests }
-RBAddClassParametrizedTest class >> testParameters [
+RBInsertClassParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
-		addCase: { #rbClass -> RBAddClassRefactoring };
-		addCase: { #rbClass -> RBAddClassTransformation };
+		addCase: { #rbClass -> RBInsertClassRefactoring };
+		addCase: { #rbClass -> RBInsertClassTransformation };
 		yourself
 ]
 
 { #category : #accessing }
-RBAddClassParametrizedTest >> constructor [ 
+RBInsertClassParametrizedTest >> constructor [ 
 	^ #addClass:superclass:subclasses:category:
 ]
 
 { #category : #running }
-RBAddClassParametrizedTest >> setUp [
+RBInsertClassParametrizedTest >> setUp [
 
 	super setUp.
 	model := self abstractVariableTestData.
 ]
 
 { #category : #'failure tests' }
-RBAddClassParametrizedTest >> testEmptyCategory [
+RBInsertClassParametrizedTest >> testEmptyCategory [
 	self shouldFail: (self createRefactoringWithArguments:
 		{ #FooTest . #RBAbstractRefactoringTest . (Array with: self class) . #'' })
 ]
 
 { #category : #'failure tests' }
-RBAddClassParametrizedTest >> testExistingClassName [
+RBInsertClassParametrizedTest >> testExistingClassName [
 	self shouldFail: (self createRefactoringWithArguments:
 		{ #Object . self class name asSymbol . #() .  #'Refactory-Testing' } )
 ]
 
 { #category : #tests }
-RBAddClassParametrizedTest >> testInsertClassWithinExistingHiearchy [
+RBInsertClassParametrizedTest >> testInsertClassWithinExistingHiearchy [
 	| refactoring insertedClass parentOfInsertedClass childOfInsertedClass |
 	
 	refactoring := self createRefactoringWithArguments: 
@@ -66,8 +66,15 @@ RBAddClassParametrizedTest >> testInsertClassWithinExistingHiearchy [
 	self assert: (insertedClass classSide subclasses includes: childOfInsertedClass classSide)
 ]
 
+{ #category : #'failure tests' }
+RBInsertClassParametrizedTest >> testModelExistingClassName [
+
+	self shouldFail: (self createRefactoringWithModel: model andArguments: 
+		{ #Foo . #Object . #() . #'Refactory-Testing' })
+]
+
 { #category : #tests }
-RBAddClassParametrizedTest >> testModelAddClass [
+RBInsertClassParametrizedTest >> testModelInsertClass [
 	| refactoring insertedClass superClass subclass |
 	superClass := model classNamed: #NewSuperClass.
 	subclass := model classNamed: #NewSubclass.
@@ -92,21 +99,14 @@ RBAddClassParametrizedTest >> testModelAddClass [
 ]
 
 { #category : #'failure tests' }
-RBAddClassParametrizedTest >> testModelExistingClassName [
-
-	self shouldFail: (self createRefactoringWithModel: model andArguments: 
-		{ #Foo . #Object . #() . #'Refactory-Testing' })
-]
-
-{ #category : #'failure tests' }
-RBAddClassParametrizedTest >> testModelInvalidSubclass [
+RBInsertClassParametrizedTest >> testModelInvalidSubclass [
 
 	self shouldFail: (self createRefactoringWithModel: model andArguments: 
 		{ #Foo2 . #Object . (Array with: (model classNamed: #Bar)) . #'Refactory-Tesing' } )
 ]
 
 { #category : #'failure tests' }
-RBAddClassParametrizedTest >> testModelNonImmediateSubclassOfSuperclass [
+RBInsertClassParametrizedTest >> testModelNonImmediateSubclassOfSuperclass [
 	| refactoring |
 	refactoring := self createRefactoringWithModel: model andArguments:  
 		{ #Foo2 . #Object .(Array with: (model classNamed: #Bar)) . #'Refactory-Tesing'}.
@@ -115,19 +115,19 @@ RBAddClassParametrizedTest >> testModelNonImmediateSubclassOfSuperclass [
 ]
 
 { #category : #'failure tests' }
-RBAddClassParametrizedTest >> testNonImmediateSubclassOfSuperclass [
+RBInsertClassParametrizedTest >> testNonImmediateSubclassOfSuperclass [
 	self shouldFail: (self createRefactoringWithArguments: 
 		{ #Foo . #RBCompositeLintRuleTestData . (Array with: RBBasicLintRuleTestData) . #'Refactory-Tesing'})
 ]
 
 { #category : #'failure tests' }
-RBAddClassParametrizedTest >> testSubclassIsMetaslass [
+RBInsertClassParametrizedTest >> testSubclassIsMetaslass [
 	self shouldFail: (self createRefactoringWithArguments: 
 		{ #Foo . #RBLintRuleTestData . (Array with: RBCompositeLintRuleTestData class) . #'Refactory-Tesing'})
 ]
 
 { #category : #'failure tests' }
-RBAddClassParametrizedTest >> testSuperclassIsMetaclass [
+RBInsertClassParametrizedTest >> testSuperclassIsMetaclass [
 	self shouldFail: (self createRefactoringWithArguments:  
 		{ #Foo . self class class name asSymbol . #() . #'Refactory-Testing'})
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRenameClassParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameClassParametrizedTest.class.st
@@ -146,7 +146,7 @@ rename class B to A
 	classA := ('RBClass' , 'ToRename') asSymbol.
 	classB := 'TestUnmarkClassRenameSource' asSymbol.
 	classC := 'TestUnmarkClassRenameTarget' asSymbol.
-	addClass := RBAddClassTransformation
+	addClass := RBInsertClassTransformation
 		model: model
 		addClass: classB
 		superclass: #Object

--- a/src/Refactoring2-Transformations-Tests/RBTransformationsTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBTransformationsTest.class.st
@@ -125,7 +125,7 @@ RBTransformationsTest >> testCompositeTransform [
 	newClassName := (self changeMock name, 'Temporary') asSymbol.
 	transformation := RBCompositeTransformation new
 		transformations: (OrderedCollection new
-			add: (RBAddClassTransformation
+			add: (RBInsertClassTransformation
 					addClass: newClassName
 					superclass: #Object
 					subclasses: #() 

--- a/src/Refactoring2-Transformations/RBInsertClassTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBInsertClassTransformation.class.st
@@ -3,10 +3,10 @@ Adds a class in the image, optionally inside an hierarchy (with superclass or su
 
 Usage:
 | transformation |
-transformation := (RBAddClassTransformation
-	addClass: #FooTest
+transformation := (RBInsertClassTransformation
+	addClass: #InsertedClass
 	superclass: #RBTransformationTest
-	subclasses: (Array with: RBAddClassTransformationTest)
+	subclasses: (Array with: RBInsertClassTransformationTest)
 	category: #'Refactoring2-Transformations-Tests')
 	transform.
 (ChangesBrowser changes: transformation model changes changes) open

--- a/src/Refactoring2-Transformations/RBInsertClassTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBInsertClassTransformation.class.st
@@ -18,7 +18,7 @@ Preconditions:
 - name of the category must be a valid one
 "
 Class {
-	#name : #RBAddClassTransformation,
+	#name : #RBInsertClassTransformation,
 	#superclass : #RBClassTransformation,
 	#instVars : [
 		'superclass',
@@ -29,7 +29,7 @@ Class {
 }
 
 { #category : #'instance creation' }
-RBAddClassTransformation class >> addClass: aName superclass: aClass subclasses: aCollection category: aSymbol [
+RBInsertClassTransformation class >> addClass: aName superclass: aClass subclasses: aCollection category: aSymbol [
 
 	^ self new
 		addClass: aName
@@ -40,7 +40,7 @@ RBAddClassTransformation class >> addClass: aName superclass: aClass subclasses:
 ]
 
 { #category : #'instance creation' }
-RBAddClassTransformation class >> model: aRBSmalltalk addClass: aName superclass: aClass subclasses: aCollection category: aSymbol [
+RBInsertClassTransformation class >> model: aRBSmalltalk addClass: aName superclass: aClass subclasses: aCollection category: aSymbol [
 
 	^ self new
 		model: aRBSmalltalk;
@@ -52,7 +52,7 @@ RBAddClassTransformation class >> model: aRBSmalltalk addClass: aName superclass
 ]
 
 { #category : #api }
-RBAddClassTransformation >> addClass: aName superclass: aClass category: aSymbol [
+RBInsertClassTransformation >> addClass: aName superclass: aClass category: aSymbol [
 
 	self
 		addClass: aName
@@ -62,7 +62,7 @@ RBAddClassTransformation >> addClass: aName superclass: aClass category: aSymbol
 ]
 
 { #category : #api }
-RBAddClassTransformation >> addClass: aName superclass: superclassName subclasses: aCollection category: aSymbol [
+RBInsertClassTransformation >> addClass: aName superclass: superclassName subclasses: aCollection category: aSymbol [
 
 	self className: aName.
 	superclass := superclassName asSymbol.
@@ -71,7 +71,7 @@ RBAddClassTransformation >> addClass: aName superclass: superclassName subclasse
 ]
 
 { #category : #preconditions }
-RBAddClassTransformation >> preconditions [
+RBInsertClassTransformation >> preconditions [
 
 	| cond |
 	cond := ((RBCondition isMetaclass: (self model classObjectFor: superclass)) 
@@ -90,7 +90,7 @@ RBAddClassTransformation >> preconditions [
 ]
 
 { #category : #executing }
-RBAddClassTransformation >> privateTransform [
+RBInsertClassTransformation >> privateTransform [
 
 	self model
 		defineClass: ('<1p> subclass: #<2s> instanceVariableNames: '''' classVariableNames: '''' poolDictionaries: '''' category: <3p>' 
@@ -102,7 +102,7 @@ RBAddClassTransformation >> privateTransform [
 ]
 
 { #category : #printing }
-RBAddClassTransformation >> storeOn: aStream [ 
+RBInsertClassTransformation >> storeOn: aStream [ 
 
 	aStream nextPut: $(.
 	self class storeOn: aStream.

--- a/src/Refactoring2-Transformations/RBRenameAndDeprecateClassTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBRenameAndDeprecateClassTransformation.class.st
@@ -49,7 +49,7 @@ RBRenameAndDeprecateClassTransformation >> buildTransformations [
 
 	^ transformations ifNil: [ 
 		transformations := OrderedCollection
-			with: (RBAddClassTransformation
+			with: (RBInsertClassTransformation
 						addClass: self tmpName
 						superclass: className asSymbol
 						subclasses: #()

--- a/src/Refactoring2-Transformations/RBSplitClassTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBSplitClassTransformation.class.st
@@ -82,7 +82,7 @@ RBSplitClassTransformation >> abstractVariableReferences [
 RBSplitClassTransformation >> addClass [
 
 	transformations add: 
-		(RBAddClassTransformation 
+		(RBInsertClassTransformation 
 			model: self model 
 			addClass: newClassName 
 			superclass: #Object

--- a/src/SystemCommands-ClassCommands/SycCmAddSubclassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycCmAddSubclassCommand.class.st
@@ -11,7 +11,7 @@ Class {
 SycCmAddSubclassCommand >> executeRefactoring [
 	
 	| refactoring |
-	refactoring := RBAddClassTransformation
+	refactoring := RBInsertClassTransformation
 		addClass: newClassName 
 		superclass: targetClass asString
 		subclasses:  #()

--- a/src/SystemCommands-ClassCommands/SycCmInsertSubclassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycCmInsertSubclassCommand.class.st
@@ -12,7 +12,7 @@ Class {
 SycCmInsertSubclassCommand >> executeRefactoring [
 	
 	| refactoring |
-	refactoring := RBAddClassTransformation
+	refactoring := RBInsertClassTransformation
 		addClass: newClassName
 		superclass: targetClass asString
 		subclasses: targetClass subclasses

--- a/src/SystemCommands-ClassCommands/SycCmInsertSuperclassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycCmInsertSuperclassCommand.class.st
@@ -12,7 +12,7 @@ Class {
 SycCmInsertSuperclassCommand >> executeRefactoring [
 	
 	| refactoring |
-	refactoring := RBAddClassTransformation 
+	refactoring := RBInsertClassTransformation 
 		addClass: newClassName
 		superclass: targetClass superclass asString
 		subclasses: {targetClass}

--- a/src/SystemCommands-ClassCommands/SycRenameClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycRenameClassCommand.class.st
@@ -47,10 +47,14 @@ SycRenameClassCommand >> newName: anObject [
 
 { #category : #execution }
 SycRenameClassCommand >> prepareFullExecutionInContext: aToolContext [
+
 	super prepareFullExecutionInContext: aToolContext.
-	
-	newName := UIManager default 
-		request: 'New name of the class' initialAnswer: targetClass name title: 'Rename a class'.
-		
-	newName isEmptyOrNil | (newName = targetClass name) ifTrue: [ CmdCommandAborted signal]
+
+	newName := UIManager default
+		           request: 'New name of the class'
+		           initialAnswer: targetClass name
+		           title: 'Rename a class'.
+
+	newName isEmptyOrNil | (newName = targetClass name) ifTrue: [ 
+		CmdCommandAborted signal ]
 ]

--- a/src/SystemCommands-MessageCommands/SycChangeMessageSignatureCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycChangeMessageSignatureCommand.class.st
@@ -102,19 +102,25 @@ SycChangeMessageSignatureCommand >> prepareFullExecutionInContext: aToolContext 
 
 { #category : #requesting }
 SycChangeMessageSignatureCommand >> requestNewMessageIn: aToolContext [
+
 	| methodName dialog invalidArgNames |
 	invalidArgNames := self computeInvalidArgNamesForSelector: originalMessage selector.
-	methodName := RBMethodName selector: originalMessage selector arguments: originalMessage argumentNames.
-	dialog := SycMethodNameEditorPresenter openOn: methodName withInvalidArgs: invalidArgNames
-		canRenameArgs: self canRenameArgs
-		canRemoveArgs: self canRemoveArgs
-		canAddArgs: self canAddArgs
-		canEditName: self canEditName .
-	dialog cancelled ifTrue: [  CmdCommandAborted signal ].
-	
-	originalMessage selector = methodName selector & (originalMessage argumentNames = methodName arguments)
-		ifTrue: [ CmdCommandAborted signal].	
-	^methodName
+	methodName := RBMethodName
+		              selector: originalMessage selector
+		              arguments: originalMessage argumentNames.
+	dialog := SycMethodNameEditorPresenter
+		          openOn: methodName
+		          withInvalidArgs: invalidArgNames
+		          canRenameArgs: self canRenameArgs
+		          canRemoveArgs: self canRemoveArgs
+		          canAddArgs: self canAddArgs
+		          canEditName: self canEditName.
+	dialog cancelled ifTrue: [ CmdCommandAborted signal ].
+
+	originalMessage selector = methodName selector
+	& (originalMessage argumentNames = methodName arguments) ifTrue: [ 
+		CmdCommandAborted signal ].
+	^ methodName
 ]
 
 { #category : #execution }

--- a/src/SystemCommands-MessageCommands/SycRenameMessageCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycRenameMessageCommand.class.st
@@ -35,7 +35,7 @@ SycRenameMessageCommand >> createRefactoring [
 		in: (SycMessageOriginHack of: originalMessage) "look at SycMessageOriginHack comment"
 		to: newSignature selector 
 		permutation: newSignature permutation)
-		renameMap: newSignature renameMap
+			renameMap: newSignature renameMap
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Renamed AddClass refactoring/transformation to InsertClass to have a more revealing name.
Updated some variable names in tests to improve readability.