### PR TITLE
11671-MetaLinks-on-methods-with-no-return-statement-implicit-self-are-called-twice 

### DIFF
--- a/src/Reflectivity-Tests/ReflectivityReificationTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityReificationTest.class.st
@@ -1136,6 +1136,24 @@ ReflectivityReificationTest >> testReifyMethodValue [
 	self assert: tag equals: 5
 ]
 
+{ #category : #'tests - method' }
+ReflectivityReificationTest >> testReifyMethodValueNoReturn [
+	| methodNode instance |
+	methodNode := (ReflectivityExamples >> #exampleMethod2) ast.
+	link := MetaLink new
+		metaObject: self;
+		selector: #tagExec:;
+		control: #after;
+		arguments: #(value).
+	methodNode link: link.
+	self assert: methodNode hasMetalink.
+	self assert: (ReflectivityExamples >> #exampleMethod2) class equals: ReflectiveMethod.
+	self assert: tag isNil.
+	instance := ReflectivityExamples new.
+	self assert: instance exampleMethod2 equals: instance.
+	self assert: tag equals: instance
+]
+
 { #category : #'tests - assignment' }
 ReflectivityReificationTest >> testReifyNewValueAssignmentAfter [
 	| varNode instance |

--- a/src/Reflectivity/RFASTTranslator.class.st
+++ b/src/Reflectivity/RFASTTranslator.class.st
@@ -244,9 +244,14 @@ RFASTTranslator >> visitMethodNode: aMethodNode [
 			withVars: aMethodNode scope tempVectorVarNames.
 	].
 	effectTranslator visitNode: aMethodNode body.
-	aMethodNode isPrimitive ifFalse: [self emitMetaLinkAfterNoEnsure: aMethodNode].
-	(aMethodNode hasProperty: #wrappedPrimitive) ifTrue: [methodBuilder pushTemp: #RFReifyValueVar; returnTop].
-	aMethodNode body lastIsReturn ifFalse:  [methodBuilder pushReceiver; returnTop].
+	(aMethodNode hasProperty: #wrapperMethod)
+	 ifTrue: [
+		"after links are only active in the wrapper method" 
+		self emitMetaLinkAfterNoEnsure: aMethodNode.
+		"the wrapper has to return the value of the wrapped method"
+		methodBuilder pushTemp: #RFReifyValueVar; returnTop]
+	ifFalse: [
+		aMethodNode body lastIsReturn ifFalse:  [methodBuilder pushReceiver; returnTop]].
 ]
 
 { #category : #'visitor - double dispatching' }

--- a/src/Reflectivity/RFSemanticAnalyzer.class.st
+++ b/src/Reflectivity/RFSemanticAnalyzer.class.st
@@ -68,7 +68,7 @@ RFSemanticAnalyzer >> visitMethodNode: aMethodNode [
 	aMethodNode scope: scope.  scope node: aMethodNode.
 	aMethodNode arguments do: [:node | self declareArgumentNode: node ].
 	aMethodNode pragmas do: [:each | self visitNode: each].
-	(aMethodNode hasProperty: #wrappedPrimitive) 
+	(aMethodNode hasProperty: #wrapperMethod) 
 		ifTrue: [self declareTemporaryNode: (RBVariableNode named: #RFReifyValueVar)].
 	self analyseForLinksForNodes: aMethodNode.
 	self visitNode: aMethodNode body.

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -61,7 +61,7 @@ ReflectiveMethod >> decreaseLinkCount [
 
 { #category : #invalidate }
 ReflectiveMethod >> destroyTwin [
-	(ast hasProperty: #wrappedPrimitive) ifTrue: [  ast :=  compiledMethod parseTree].
+	(ast hasProperty: #wrapperMethod) ifTrue: [  ast :=  compiledMethod parseTree].
 	self recompileAST.
 	self installCompiledMethod.
 	compiledMethod reflectiveMethod: nil.
@@ -104,7 +104,7 @@ ReflectiveMethod >> generatePrimitiveWrapper [
 		body: assignmentNode asSequenceNode.
 		
 	wrapperMethod methodClass: ast methodClass.
-	wrapperMethod propertyAt: #wrappedPrimitive put: true.
+	wrapperMethod propertyAt: #wrapperMethod put: true.
 	ast hasMetalink ifTrue: [wrapperMethod propertyAt: #links put: (ast propertyAt: #links)].
 	ast := wrapperMethod.
 ]


### PR DESCRIPTION
- add test for #after on methods with no return
- fix emit for method to only emit the code for the wrapper method
- rename #wrappedPrimitive to #wrapperMethod as we use it not only for primitives

Fixes #11671


