### PR TITLE
Fixed resolving desktop file location

### DIFF
--- a/src/FileSystem-Core/PlatformResolver.class.st
+++ b/src/FileSystem-Core/PlatformResolver.class.st
@@ -41,6 +41,8 @@ PlatformResolver >> cantFindOriginError [
 
 { #category : #origins }
 PlatformResolver >> desktop [
+
+	<origin>
 	^ self home / 'Desktop'
 ]
 


### PR DESCRIPTION
Fixes #9682 
PlatformResolver had missing `<origin>` pragma for desktop, therefore `FileLocator desktop asFileReference children` resulted in error.