### PR TITLE
Multiline Executable Comments

### DIFF
--- a/src/Calypso-SystemQueries/ClyLocalClassScope.class.st
+++ b/src/Calypso-SystemQueries/ClyLocalClassScope.class.st
@@ -43,11 +43,11 @@ ClyLocalClassScope class >> metaLevelForHierarchyOf: aClass [
 	"Subclasses should decide what meta level of given class
 	should be used to retrieve/build hierarchy.
 	For example superclass hierarchy of ProtoObject class 
-	can stop at it according to instance side hierarchy 
-		ProtoObject superclass >>> nil
-	Or it can follow full superclass chain which will ends at Object and ProtoObject
-		ProtoObject class superclass >>> Class
-	This method adds such decision to concrete kind of local scope
+	can stop at it according to instance side hierarchy" 
+		"ProtoObject superclass >>> nil"
+	"Or it can follow full superclass chain which will ends at Object and ProtoObject"
+		"ProtoObject class superclass >>> Class"
+	"This method adds such decision to concrete kind of local scope
 	which allows to use scopes to restrict visibility of class hierarchy"
 	self subclassResponsibility
 ]

--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -34,13 +34,13 @@ Collection class >> newFromArray: anArray [
 	Important: Subclasses of Collection that redefine withAll: or newFrom: should also redefine this method
 	either by having a proper implementation (specific to Arrays) or by calling the redefined versions of withAll:/newFrom:."
 
-	"{ 1. 2. 3 } asSet >>> Set new add: 1; add:2; add:3; yourself"
-	"{ 1. 2. 3 } asOrderedCollection >>> OrderedCollection new add: 1; add:2; add:3; yourself"
-	"{ 1->2. 3->4 } asDictionary >>> Dictionary new at: 1 put: 2; at: 3 put:4; yourself"
+	"{ 1. 2. 3 } asSet >>> (Set new add: 1; add:2; add:3; yourself)"
+	"{ 1. 2. 3 } asOrderedCollection >>> (OrderedCollection new add: 1; add:2; add:3; yourself)"
+	"{ 1->2. 3->4 } asDictionary >>> (Dictionary new at: 1 put: 2; at: 3 put:4; yourself)"
 
-	"{ 1. 2. 3 } as: Set >>> Set new add: 1; add:2; add:3; yourself"
-	"{ 1. 2. 3 } as: OrderedCollection >>> OrderedCollection new add: 1; add:2; add:3; yourself"
-	"{ 1->2. 3->4 } as: Dictionary >>> Dictionary new at: 1 put: 2; at: 3 put:4; yourself"
+	"({ 1. 2. 3 } as: Set) >>> (Set new add: 1; add:2; add:3; yourself)"
+	"({ 1. 2. 3 } as: OrderedCollection) >>> (OrderedCollection new add: 1; add:2; add:3; yourself)"
+	"({ 1->2. 3->4 } as: Dictionary) >>> (Dictionary new at: 1 put: 2; at: 3 put:4; yourself)"
 
 	| newCollection size |
 	size := anArray size.
@@ -169,7 +169,7 @@ Collection >> adaptToCollection: rcvr andSend: selector [
 
 	Is used to implement Collection>>+, Collection>>-, etc."
 
-	"#(10 20 30) adaptToCollection: #(0 1 2) andSend: #@ >>> {(0@10). (1@20). (2@30)}"
+	"(#(10 20 30) adaptToCollection: #(0 1 2) andSend: #@) >>> {(0@10). (1@20). (2@30)}"
 
 	(rcvr isSequenceable and: [ self isSequenceable ]) ifFalse:
 		[self error: 'Only sequenceable collections may be combined arithmetically'].
@@ -267,16 +267,16 @@ Collection >> allSatisfy: aBlock [
 	If aBlock returns false for any element return false.
 	Otherwise return true."
 
-	"#(1 2) allSatisfy: [ :each | each even ] >>> false"
-	"#(2 4) allSatisfy: [ :each | each even ] >>> true"
+	"(#(1 2) allSatisfy: [ :each | each even ]) >>> false"
+	"(#(2 4) allSatisfy: [ :each | each even ]) >>> true"
 
-	"'hello' allSatisfy: #isLetter >>> true"
-	"'hello!' allSatisfy: #isLetter >>> false"
+	"('hello' allSatisfy: #isLetter) >>> true"
+	"('hello!' allSatisfy: #isLetter) >>> false"
 
-	"(3 to: 8 by: 2) allSatisfy: #isPrime >>> true"
-	"(3 to: 9 by: 2) allSatisfy: #isPrime >>> false"
+	"((3 to: 8 by: 2) allSatisfy: #isPrime) >>> true"
+	"((3 to: 9 by: 2) allSatisfy: #isPrime) >>> false"
 
-	"#() allSatisfy: [false] >>> true"
+	"(#() allSatisfy: [false]) >>> true"
 
 	self do: [ :each | (aBlock value: each) ifFalse: [ ^ false ] ].
 	^ true
@@ -306,16 +306,16 @@ Collection >> anySatisfy: aBlock [
 	If aBlock returns true for any element return true.
 	Otherwise return false."
 
-	"#(1 3) anySatisfy: [ :each | each even ] >>> false"
-	"#(1 2) anySatisfy: [ :each | each even ] >>> true"
+	"(#(1 3) anySatisfy: [ :each | each even ]) >>> false"
+	"(#(1 2) anySatisfy: [ :each | each even ]) >>> true"
 
-	"'hello world!' anySatisfy: [ :each | each isLetter ] >>> true"
-	"'hello world!' anySatisfy: [ :each | each isDigit ] >>> false"
+	"('hello world!' anySatisfy: [ :each | each isLetter ]) >>> true"
+	"('hello world!' anySatisfy: [ :each | each isDigit ]) >>> false"
 
-	"(4 to: 9) anySatisfy: #isPrime >>> true"
-	"(4 to: 50 by: 2) anySatisfy: #isPrime >>> false"
+	"((4 to: 9) anySatisfy: #isPrime) >>> true"
+	"((4 to: 50 by: 2) anySatisfy: #isPrime) >>> false"
 
-	"#() anySatisfy: [ true ] >>> false"
+	"(#() anySatisfy: [ true ]) >>> false"
 
 	self do: [ :each | (aBlock value: each) ifTrue: [ ^ true ] ].
 	^ false
@@ -519,7 +519,9 @@ Collection >> asStringOn: aStream delimiter: delimString [
 	with a delimiter String like: 'a, b, c'
 	Uses #asString instead of #print:."
 
-	"String streamContents: [:s| 'abcd' asStringOn: s delimiter: '->'] >>> 'a->b->c->d'"
+	"(String streamContents: [:s|
+		'abcd' asStringOn: s delimiter: '->'])
+	>>> 'a->b->c->d'"
 
 	self
 		do: [ :elem | aStream nextPutAll: elem asString ]
@@ -536,7 +538,9 @@ Collection >> asStringOn: aStream delimiter: delimString last: lastDelimString [
 
 	Note: Feel free to improve the code to detect the last element."
 
-	"String streamContents: [:s| 'abcd' asStringOn: s delimiter: ', ' last: ' and '] >>> 'a, b, c and d'"
+	"(String streamContents: [:s|
+		'abcd' asStringOn: s delimiter: ', ' last: ' and '])
+	>>> 'a, b, c and d'"
 
 	| n sz |
 	n := 1.
@@ -558,9 +562,15 @@ Collection >> associationsDo: aBlock [
 	The point of this method it to do the *right thing* on Dictionaries and related classes.
 	"
 
-	"String streamContents: [:s| {'one'->1. 'two'->2} associationsDo: [:a| s << a key << ':' << a value asString << ';']] >>> 'one:1;two:2;'"
+	"(String streamContents: [:s|
+		{'one'->1. 'two'->2} associationsDo: [:a|
+			s << a key << ':' << a value asString << ';']])
+	>>> 'one:1;two:2;'"
 
-	"String streamContents: [:s| {'one'->1. 'two'->2} asOrderedDictionary associationsDo: [:a| s << a key << ':' << a value asString << ';']] >>> 'one:1;two:2;'"
+	"(String streamContents: [:s|
+		{'one'->1. 'two'->2} asOrderedDictionary associationsDo: [:a|
+			s << a key << ':' << a value asString << ';']])
+	>>> 'one:1;two:2;'"
 
 	self do: aBlock
 ]
@@ -584,7 +594,7 @@ Collection >> collect: aBlock [
 	"(#(10 20 30) collect: [:e | e+1]) >>> #(11 21 31)"
 	"({10@20. 30@0} collect: [:e | e x]) >>> #(10 30)"
 	"('Hello, world!' collect: [:e | e isLetter ifTrue: e ifFalse: $-]) >>> 'Hello--world-'"
-	"(1 to: 10) collect: [:i| i gcd: 6] >>> #(1 2 3 2 1 6 1 2 3 2)"
+	"((1 to: 10) collect: [:i| i gcd: 6]) >>> #(1 2 3 2 1 6 1 2 3 2)"
 	"(#() collect: [:x | x+1]) >>> #()"
 
 	| newCollection |
@@ -743,8 +753,8 @@ Collection >> detect: aBlock [
 	Answer the first element for which aBlock evaluates to true."
 
 	"({1@3. 2@1. 3@6. 4@8} detect: [ :each | each x even ]) >>> (2@1)"
-	"(104 to: 120) detect: #isPrime >>> 107"
-	"'Hello!' detect: #isLowercase) >>> $e"
+	"((104 to: 120) detect: #isPrime) >>> 107"
+	"('Hello!' detect: #isLowercase) >>> $e"
 
 	^ self detect: aBlock ifNone: [ self errorNotFound: aBlock ]
 ]
@@ -810,7 +820,7 @@ Collection >> detectMax: aBlock [
 	"({ 2@6 . -4@3 . 10@ -3 } detectMax: [ :p | p x ]) >>> (10@ -3)"
 	"({ 2@6 . -4@3 . 10@ -3 } detectMax: [ :p | p y ]) >>> (2@6)"
 	"((10 to: 20) detectMax: [ :p | p gcd: 6 ]) >>> 12"
-	"'Hello' detectMax: #asciiValue >>> $o"
+	"('Hello' detectMax: #asciiValue) >>> $o"
 
 	| maxElement maxValue |
 	self do: [:each | | val |
@@ -835,7 +845,7 @@ Collection >> detectMin: aBlock [
 
 	"({ 2@6 . -4@3 . 10@ -3 } detectMin: [ :p | p x ]) >>> (-4@3)"
 	"({ 2@6 . -4@3 . 10@ -3 } detectMin: [ :p | p y ]) >>> (10@ -3)"
-	"'Hello!' detectMin: #asciiValue >>> $!"
+	"('Hello!' detectMin: #asciiValue) >>> $!"
 
 	| minElement minValue |
 	self do: [:each | | val |
@@ -889,16 +899,20 @@ Collection >> do: aBlock [
 
 	This is the general foreach method, but for most standard needs there is often a more specific and simpler method."
 
-	"
-	|s| s:=0. #(10 20 30) do: [:each | s := s + each]. s >>> 60
-	but use sum or inject:into: instead
-	(#(10 20 30) inject: 0 into: [:s :each| s + each ]) >>> 60
-	#(10 20 30) sum >>> 60
-	"
+	"|s|
+	s:=0.
+	#(10 20 30) do: [:each | s := s + each].
+	s >>> 60"
+	
+	"but use sum or inject:into: instead"
+	
+	"(#(10 20 30) inject: 0 into: [:s :each| s + each ]) >>> 60"
+	"#(10 20 30) sum >>> 60"
 
 	"
-	(String streamContents: [:s | #('hello' 'the' 'world') do: [:each | s << each]]) >>> 'hellotheworld'
-	"
+	(String streamContents: [:s |
+		#('hello' 'the' 'world') do: [:each | s << each]])
+	>>> 'hellotheworld'"
 
 	self subclassResponsibility
 ]
@@ -946,7 +960,7 @@ Collection >> emptyCheck [
 	"Signal CollectionIsEmpty if the collection is empty"
 
 	"#(10 20) emptyCheck >>> #(10 20)"
-	"[#() emptyCheck] on: CollectionIsEmpty do: [ 'oops' ] >>> 'oops'"
+	"([#() emptyCheck] on: CollectionIsEmpty do: [ 'oops' ]) >>> 'oops'"
 
 	self isEmpty ifTrue: [self errorEmptyCollection]
 ]
@@ -1188,8 +1202,8 @@ Collection >> ifNotEmpty: notEmptyBlock ifEmpty: emptyBlock [
 Collection >> includes: anObject [ 
 	"Answer whether anObject is one of the receiver's elements."
 
-	"#(10 20 30) includes: 20) >>> true"
-	"#(10 20 30) includes: 21) >>> false"
+	"(#(10 20 30) includes: 20) >>> true"
+	"(#(10 20 30) includes: 21) >>> false"
 
 	"((1 to:9 by:2) includes: 3) >>> true"
 	"((1 to:9 by:2) includes: 4) >>> false"
@@ -1242,7 +1256,8 @@ Collection >> includesAnyOf: aCollection [
 Collection >> includesSubstringAnywhere: testString [
 	"Answer whether the receiver includes, anywhere in its nested structure, a string that has testString as a substring"
 
-	"#(first (second third) ((allSentMessages ('Elvis' includes:)))) includesSubstringAnywhere:  'lvi' >>> true"
+	"(#(first (second third) ((allSentMessages ('Elvis' includes:))))
+		includesSubstringAnywhere:  'lvi') >>> true"
 
 	self do:
 		[:element |
@@ -1318,7 +1333,7 @@ Collection >> isEmptyOrNil [
 
 	"#() isEmptyOrNil >>> true"
 	"nil isEmptyOrNil >>> true"
-	"[0 isEmptyOrNil] on: MessageNotUnderstood do: ['oops'] >>> 'oops'"
+	"([0 isEmptyOrNil] on: MessageNotUnderstood do: ['oops']) >>> 'oops'"
 
 	^ self isEmpty
 ]
@@ -1362,11 +1377,11 @@ Collection >> median [
 Collection >> noneSatisfy: aBlock [
 	"Evaluate aBlock with the elements of the receiver. If aBlock returns false for all elements return true. Otherwise return false"
 
-	"#(2 4 6) noneSatisfy: [:x|x odd] >>> true"
-	"#(1 2 3) noneSatisfy: [:x|x odd] >>> false"
-	"'hello!' noneSatisfy: #isUppercase >>> true"
-	"'hello!' noneSatisfy: #isLetter >>> false"
-	"#() noneSatisfy: ['oops'] >>> true"
+	"(#(2 4 6) noneSatisfy: [:x|x odd]) >>> true"
+	"(#(1 2 3) noneSatisfy: [:x|x odd]) >>> false"
+	"('hello!' noneSatisfy: #isUppercase) >>> true"
+	"('hello!' noneSatisfy: #isLetter) >>> false"
+	"(#() noneSatisfy: ['oops']) >>> true"
 
 	self do: [:item | (aBlock value: item) ifTrue: [^ false]].
 	^ true
@@ -1466,8 +1481,9 @@ Collection >> printOn: aStream delimiter: delimString last: lastDelimString [
 { #category : #enumerating }
 Collection >> reduce: aBlock [
 	"Fold the result of the receiver into aBlock. The argument aBlock must take two or more arguments. It applies the argument, binaryBlock cumulatively to the elements of the receiver. For sequenceable collections the elements will be used in order, for unordered collections the order is unspecified."
-	"( #(1 2 3) asSet reduce: [ :a :b | a + b ] ) >>> 1 + 2 + 3"
-	"( #(1 2 3 4 5) asSet reduce: [ :a :b :c | a + b + c ] ) >>> 1 + 2 + 3 + 4 + 5"
+	
+	"( #(1 2 3) asSet reduce: [ :a :b | a + b ] ) >>> (1 + 2 + 3)"
+	"( #(1 2 3 4 5) asSet reduce: [ :a :b :c | a + b + c ] ) >>> (1 + 2 + 3 + 4 + 5)"
 
 	"Maybe look at the related method Collection>>inject:into:"
 
@@ -1585,11 +1601,11 @@ Collection >> select: aBlock [
 
 	"({1@2. 6@3. 2@ -1.} select: [:e| e x > e y]) >>> {(6@3). (2@ -1)}"
 
-	"'heLlo wOrLd' select: #isUppercase >>> 'LOL'"
+	"('heLlo wOrLd' select: #isUppercase) >>> 'LOL'"
 
 	"((1 to: 10) select: #isPrime) >>> #(2 3 5 7)"
 
-	"#() select: [true] >>> #()"
+	"(#() select: [true]) >>> #()"
 
 	| newCollection |
 	newCollection := self copyEmpty.
@@ -1663,7 +1679,7 @@ comparison."
 
 	"(#(3 1 4 2) sorted: [:a :b| a>=b]) >>> #(4 3 2 1)"
 	"('hello' sorted: [:a :b| a>=b]) >>> 'ollhe'"
-	"(1 to: 10 by: 2) sorted: [:a :b| a>=b] >>> #(9 7 5 3 1)"
+	"((1 to: 10 by: 2) sorted: [:a :b| a>=b]) >>> #(9 7 5 3 1)"
 
 	^self asArray sort: aSortBlockOrNil
 ]
@@ -1698,7 +1714,7 @@ Collection >> sum: aBlock [
 
 	"(#(1 -4 -10 1) sum: #abs) >>> 16"
 
-	"({1@ -4. -10@1} sum: #abs) >>> 11@5"
+	"({1@ -4. -10@1} sum: #abs) >>> (11@5)"
 
 	"(#() sum: #abs) >>> 0"
 
@@ -1751,9 +1767,9 @@ Collection >> sumNumbers: aBlock [
 	more general, sumNumbers: is meant to support the most often encountered use case of
 	dealing with numbers."
 
-	"#(1 -2 4) sumNumbers: #abs >>> 7"
+	"(#(1 -2 4) sumNumbers: #abs) >>> 7"
 
-	"#() sumNumbers: #abs >>> 0"
+	"(#() sumNumbers: #abs) >>> 0"
 
 	^ self
 		inject: 0

--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -32,17 +32,15 @@ Collection class >> newFromArray: anArray [
 	So other collections can be easily and efficiently initialized with `{1. 2. 3} asFoo` syntax.
 	
 	Important: Subclasses of Collection that redefine withAll: or newFrom: should also redefine this method
-	either by having a proper implementation (specific to Arrays) or by calling the redefined versions of withAll:/newFrom:.
+	either by having a proper implementation (specific to Arrays) or by calling the redefined versions of withAll:/newFrom:."
 
-	Examples:
-	{ 1. 2. 3 } asSet >>> Set new add: 1; add:2; add:3; yourself
-	{ 1. 2. 3 } asOrderedCollection >>> OrderedCollection new add: 1; add:2; add:3; yourself
-	{ 1->2. 3->4 } asDictionary >>> Dictionary new at: 1 put: 2; at: 3 put:4; yourself
+	"{ 1. 2. 3 } asSet >>> Set new add: 1; add:2; add:3; yourself"
+	"{ 1. 2. 3 } asOrderedCollection >>> OrderedCollection new add: 1; add:2; add:3; yourself"
+	"{ 1->2. 3->4 } asDictionary >>> Dictionary new at: 1 put: 2; at: 3 put:4; yourself"
 
-	{ 1. 2. 3 } as: Set >>> Set new add: 1; add:2; add:3; yourself
-	{ 1. 2. 3 } as: OrderedCollection >>> OrderedCollection new add: 1; add:2; add:3; yourself
-	{ 1->2. 3->4 } as: Dictionary >>> Dictionary new at: 1 put: 2; at: 3 put:4; yourself
-	"
+	"{ 1. 2. 3 } as: Set >>> Set new add: 1; add:2; add:3; yourself"
+	"{ 1. 2. 3 } as: OrderedCollection >>> OrderedCollection new add: 1; add:2; add:3; yourself"
+	"{ 1->2. 3->4 } as: Dictionary >>> Dictionary new at: 1 put: 2; at: 3 put:4; yourself"
 
 	| newCollection size |
 	size := anArray size.
@@ -807,13 +805,12 @@ Collection >> detect: aBlock ifNone: exceptionBlock [
 Collection >> detectMax: aBlock [
 	"Evaluate aBlock with each of the receiver's elements as the argument.
 	Answer the element for which aBlock evaluates to the highest magnitude.
-	If collection empty, return nil.  This method might also be called elect:.
+	If collection empty, return nil.  This method might also be called elect:."
 
-	({ 2@6 . -4@3 . 10@ -3 } detectMax: [ :p | p x ]) >>> (10@ -3)
-	({ 2@6 . -4@3 . 10@ -3 } detectMax: [ :p | p y ]) >>> (2@6)
-	((10 to: 20) detectMax: [ :p | p gcd: 6 ]) >>> 12
-	'Hello' detectMax: #asciiValue >>> $o
-	"
+	"({ 2@6 . -4@3 . 10@ -3 } detectMax: [ :p | p x ]) >>> (10@ -3)"
+	"({ 2@6 . -4@3 . 10@ -3 } detectMax: [ :p | p y ]) >>> (2@6)"
+	"((10 to: 20) detectMax: [ :p | p gcd: 6 ]) >>> 12"
+	"'Hello' detectMax: #asciiValue >>> $o"
 
 	| maxElement maxValue |
 	self do: [:each | | val |
@@ -834,13 +831,11 @@ Collection >> detectMax: aBlock [
 Collection >> detectMin: aBlock [
 	"Evaluate aBlock with each of the receiver's elements as the argument.
 	Answer the element for which aBlock evaluates to the lowest number.
-	If collection empty, return nil.
+	If collection empty, return nil."
 
-	Example of use:
-	({ 2@6 . -4@3 . 10@ -3 } detectMin: [ :p | p x ]) >>> (-4@3)
-	({ 2@6 . -4@3 . 10@ -3 } detectMin: [ :p | p y ]) >>> (10@ -3)
-	'Hello!' detectMin: #asciiValue >>> $!
-	"
+	"({ 2@6 . -4@3 . 10@ -3 } detectMin: [ :p | p x ]) >>> (-4@3)"
+	"({ 2@6 . -4@3 . 10@ -3 } detectMin: [ :p | p y ]) >>> (10@ -3)"
+	"'Hello!' detectMin: #asciiValue >>> $!"
 
 	| minElement minValue |
 	self do: [:each | | val |
@@ -996,12 +991,11 @@ Collection >> findFirstInByteString: aByteString startingAt: start [
 	Default is to use a naive algorithm.
 	Subclasses might want to implement a more efficient scheme.
 
-	Return 0 if not found.
+	Return 0 if not found."
 
-	('aeiou' findFirstInByteString: 'hello world' startingAt: 1) >>> 2.
-	('aeiou' findFirstInByteString: 'hello world' startingAt: 3) >>> 5.
-	('aeiou' findFirstInByteString: 'hello world' startingAt: 9) >>> 0.
-	"
+	"('aeiou' findFirstInByteString: 'hello world' startingAt: 1) >>> 2."
+	"('aeiou' findFirstInByteString: 'hello world' startingAt: 3) >>> 5."
+	"('aeiou' findFirstInByteString: 'hello world' startingAt: 9) >>> 0."
 
 	start to: aByteString size do:
 		[:index |
@@ -1085,13 +1079,10 @@ Collection >> gather: aBlock [
 
 { #category : #enumerating }
 Collection >> groupedBy: aBlock [
-	"Answer a dictionary whose keys are the result of evaluating aBlock for all my elements, and the value for each key is the selection of my elements that evaluated to that key. Uses species.
+	"Answer a dictionary whose keys are the result of evaluating aBlock for all my elements, and the value for each key is the selection of my elements that evaluated to that key. Uses species."
 
-	Example of use:
-	(#(1 2 3 4 5) groupedBy: [ :v | v odd ]) asString >>> 'an OrderedDictionary(true->#(1 3 5) false->#(2 4))'
-	"
-
-
+	"(#(1 2 3 4 5) groupedBy: [ :v | v odd ]) asString
+		>>> 'an OrderedDictionary(true->#(1 3 5) false->#(2 4))'"
 
 	| groups |
 	groups := OrderedDictionary new.
@@ -1109,8 +1100,12 @@ Collection >> groupedBy: aBlock having: aSelectionBlock [
 	elements for which keyBlock returns the same results, and return those
 	collections allowed by selectBlock."
 
-	"In the following example, the group `3->#(34)` is filtered out because there is not 2 elements.
-	(#(1 5 21 28 34) groupedBy: [:x| x // 10] having: [:v| v size = 2]) >>> {0->#(1 5). 2->#(21 28)} asOrderedDictionary"
+	"In the following example, the group `3->#(34)` is filtered out because there is not 2 elements."
+	
+	"(#(1 5 21 28 34)
+		groupedBy: [:x| x // 10]
+		having: [:v| v size = 2])
+	>>> {0->#(1 5). 2->#(21 28)} asOrderedDictionary"
 
 	^ (self groupedBy: aBlock) select: aSelectionBlock
 ]
@@ -1267,15 +1262,14 @@ Collection >> inject: thisValue into: binaryBlock [
 
 	"(#(2r101 2r11 2r1000) inject: 0 into: [ :acc :each | acc bitXor: each ]) >>> 2r1110"
 
-	"(#(10 20 30) inject: 0 into: [ :sum :each | sum + each ]) >>> 60
-	But use sum or sum: instead!
-	#(10 20 30) sum >>> 60
-	"
+	"(#(10 20 30) inject: 0 into: [ :sum :each | sum + each ]) >>> 60"
+	"But use sum or sum: instead!"
+	"#(10 20 30) sum >>> 60"
 
-	"(#(10 20 30) inject: OrderedCollection new into: [ :a :e | a add: (e + 1). a ]) >>> #(11 21 31) asOrderedCollection
-	But use collect: or collect:as: instead!
-	(#(10 20 30) collect: [:e| e+1]) >>> #(11 21 31)
-	"
+	"(#(10 20 30) inject: OrderedCollection new into: [ :a :e | a add: (e + 1). a ])
+		>>> #(11 21 31) asOrderedCollection"
+	"But use collect: or collect:as: instead!"
+	"(#(10 20 30) collect: [:e| e+1]) >>> #(11 21 31)"
 
 	| nextValue |
 	nextValue := thisValue.
@@ -1331,15 +1325,12 @@ Collection >> isEmptyOrNil [
 
 { #category : #testing }
 Collection >> isNotEmpty [
-	"Answer whether the receiver contains any elements.
+	"Answer whether the receiver contains any elements."
 
-	Example of use:
-
-	#() isNotEmpty >>> false
-	#(()) isNotEmpty >>> true
-	'' isNotEmpty >>> false
-	' ' isNotEmpty >>> true
-	"
+	"#() isNotEmpty >>> false"
+	"#(()) isNotEmpty >>> true"
+	"'' isNotEmpty >>> false"
+	"' ' isNotEmpty >>> true"
 
 	^ self isEmpty not
 ]
@@ -1355,15 +1346,13 @@ Collection >> isSequenceable [
 { #category : #'math functions' }
 Collection >> median [
 	"Return the middle element, or as close as we can get.
-	The collection must not be empty.
+	The collection must not be empty."
 
-	Example of use:
-	{1 . 2 . 3 . 4 . 5} median >>> 3
-	{1 . 2 . 4 . 5} median >>> 3
-	{1 . 2 . 5 . 5} median >>> (7/2)
-	{3} median >>> 3
-	([{} median] on: CollectionIsEmpty do: [ 'oops' ]) >>> 'oops'
-	"
+	"{1 . 2 . 3 . 4 . 5} median >>> 3"
+	"{1 . 2 . 4 . 5} median >>> 3"
+	"{1 . 2 . 5 . 5} median >>> (7/2)"
+	"{3} median >>> 3"
+	"([{} median] on: CollectionIsEmpty do: [ 'oops' ]) >>> 'oops'"
 
 	self emptyCheck.
 	^ self asSortedCollection median
@@ -1408,12 +1397,16 @@ Collection >> occurrencesOf: anObject [
 { #category : #printing }
 Collection >> printElementsOn: aStream [
 	"List elements betwen () and separated by spaces.
-	Is used by printOn: and other related printing methods.
+	Is used by printOn: and other related printing methods."
 
-	String streamContents: [:s| {10. 'hello'} printElementsOn: s] >>> '(10 ''hello'')'
-	String streamContents: [:s| #() printElementsOn: s] >>> '()'
+	"(String streamContents: [:s|
+		{10. 'hello'} printElementsOn: s])
+		>>> '(10 ''hello'')'"
+	"(String streamContents: [:s|
+		#() printElementsOn: s])
+		>>> '()'"
 
-	Note: The original code used #skip:, but some streams do not support that,
+	"Note: The original code used #skip:, but some streams do not support that,
 	 and we don't really need it."
 
 	aStream nextPut: $(.
@@ -1437,10 +1430,11 @@ Collection >> printOn: aStream [
 { #category : #printing }
 Collection >> printOn: aStream delimiter: delimString [
 	"Print elements on a stream separated
-	with a delimiter String like: 'a, b, c'
+	with a delimiter String like: 'a, b, c'"
 
-	String streamContents: [:s| { 10. 'hello'. $x } printOn: s delimiter: ', '] >>> '10, ''hello'', $x'
-	"
+	"(String streamContents: [:s|
+		{ 10. 'hello'. $x } printOn: s delimiter: ', '])
+		>>> '10, ''hello'', $x'"
 
 	self do: [:elem | aStream print: elem] separatedBy: [aStream nextPutAll: delimString]
 ]
@@ -1449,11 +1443,13 @@ Collection >> printOn: aStream delimiter: delimString [
 Collection >> printOn: aStream delimiter: delimString last: lastDelimString [
 	"Print elements on a stream separated
 	with a delimiter between all the elements and with
-	a special one before the last like: 'a, b and c'
+	a special one before the last like: 'a, b and c'"
 
-	(String streamContents: [:s| { 10. 'hello'. $x } printOn: s delimiter: ', ' last: ' & ']) >>> '10, ''hello'' & $x'
+	"(String streamContents: [:s|
+		{ 10. 'hello'. $x } printOn: s delimiter: ', ' last: ' & '])
+		>>> '10, ''hello'' & $x'"
 
-	Note: Feel free to improve the code to detect the last element."
+	"Note: Feel free to improve the code to detect the last element."
 
 	| n sz |
 	n := 1.

--- a/src/Collections-Abstract/SequenceableCollection.class.st
+++ b/src/Collections-Abstract/SequenceableCollection.class.st
@@ -453,10 +453,10 @@ SequenceableCollection >> before: target ifAbsent: exceptionBlock [
 SequenceableCollection >> beginsWith: aSequenceableCollection [
 	"Answer true if the receiver starts with the argument collection"
 	
-	"#(1 2 3 4 5) beginsWith: #() >>> true"
-	"#(1 2 3) beginsWith: #(1 2 3 4 5) >>> false"
-	"#(1 2 3 4 5) beginsWith: #(0 1 2) >>> false"
-	"#(1 2 3 4 5) beginsWith: #(1 2 3) >>> true"
+	"(#(1 2 3 4 5) beginsWith: #()) >>> true"
+	"(#(1 2 3) beginsWith: #(1 2 3 4 5)) >>> false"
+	"(#(1 2 3 4 5) beginsWith: #(0 1 2)) >>> false"
+	"(#(1 2 3 4 5) beginsWith: #(1 2 3)) >>> true"
 	
 	aSequenceableCollection ifEmpty: [ ^true ].
 	self size < aSequenceableCollection size ifTrue: [^false].
@@ -487,7 +487,7 @@ SequenceableCollection >> collect: aBlock [
 	Collect the resulting values into a collection like the receiver. Answer  
 	the new collection."
 	
-	"#(1 2 3) collect: [:each | each  + 10] >>> #(11 12 13) "
+	"(#(1 2 3) collect: [:each | each  + 10]) >>> #(11 12 13) "
 
 	| newCollection |
 	newCollection := self species new: self size.
@@ -1793,7 +1793,7 @@ SequenceableCollection >> readStream [
 SequenceableCollection >> readStreamDo: aBlock [
 	"Evaluates the argument with the read stream of the collection. Answers the result."
 	
-	"#(3 4 5) readStreamDo: [ :stream | stream contents ] >>> #(3 4 5)"
+	"(#(3 4 5) readStreamDo: [ :stream | stream contents ]) >>> #(3 4 5)"
 
 	^ aBlock value: self readStream
 ]
@@ -1859,7 +1859,7 @@ SequenceableCollection >> reduceRight: aBlock [
 SequenceableCollection >> reject: rejectBlock [ 
 	"Optimized version of Collection>>#reject:"
 	
-	"#(1 2 3 4) reject: [:each | each = 3 ] >>> #(1 2 4)"
+	"(#(1 2 3 4) reject: [:each | each = 3 ]) >>> #(1 2 4)"
 	
 	| each |
 	
@@ -2085,7 +2085,7 @@ SequenceableCollection >> shuffle [
 { #category : #shuffling }
 SequenceableCollection >> shuffleBy: aRandom [
 	"Durstenfeld's version of the Fisher-Yates shuffle"
-	"{1. 2. 3. 4. 5} shuffleBy: (Random seed: 42) >>> #(2 5 4 3 1)"
+	"({1. 2. 3. 4. 5} shuffleBy: (Random seed: 42)) >>> #(2 5 4 3 1)"
 
 	self size to: 2 by: -1 do: [ :i | 
 		self swap: i with: (aRandom nextInteger: i) ]

--- a/src/Collections-Arithmetic/Collection.extension.st
+++ b/src/Collections-Arithmetic/Collection.extension.st
@@ -108,10 +108,10 @@ Collection >> averageIfEmpty: aBlock [
 	"This method return the average of the collection if it is not empty. In the other case,
 	it return the value of the block. It means the user the user of this method decide of the return value."
 
-	"#(10) averageIfEmpty: [ 0 ] >>> 10"
-	"#() averageIfEmpty: [ 0 ] >>> 0"
-	"{3@5. 7@ -4} averageIfEmpty: [0@0] >>> (5@(1/2))"
-	"{} averageIfEmpty: [0@0] >>> (0@0)"
+	"(#(10) averageIfEmpty: [ 0 ]) >>> 10"
+	"(#() averageIfEmpty: [ 0 ]) >>> 0"
+	"({3@5. 7@ -4} averageIfEmpty: [0@0]) >>> (5@(1/2))"
+	"({} averageIfEmpty: [0@0]) >>> (0@0)"
 
 	self ifEmpty: [ ^ aBlock value ].
 	^ self average
@@ -163,7 +163,7 @@ Collection >> max [
 	"Return the maximum value of the collection"
 
 	"#(1 5 10 -4) max >>> 10"
-	"{1@5. 10@ -4} max >>> 10@5"
+	"{1@5. 10@ -4} max >>> (10@5)"
 
 	^ self inject: self anyOne into: [ :max :each | max max: each ]
 ]
@@ -173,7 +173,7 @@ Collection >> min [
 	"Return the minimum value of the collection"
 
 	"#(1 5 10 -4) min >>> -4"
-	"{1@5. 10@ -4} min >>> 1@ -4"
+	"{1@5. 10@ -4} min >>> (1@ -4)"
 
 	^ self inject: self anyOne into: [:min :each | min min: each]
 ]
@@ -201,7 +201,7 @@ Collection >> range [
 	"returns the difference between the max and min element, their positions notwithstanding"
 
 	"#( 1 51 10 ) range >>> 50"
-	"{1@50. 10@ -10. 5@5} range >>> 9@60"
+	"{1@50. 10@ -10. 5@5} range >>> (9@60)"
 
 	^ self max - self min
 ]
@@ -281,7 +281,7 @@ Collection >> sum [
 
 	"sum works with objects that understands + and - messages, like Points"
 
-	"{1@5. 2@3. 4@7} sum >>> 7@15"
+	"{1@5. 2@3. 4@7} sum >>> (7@15)"
 
 	"or even Collections"
 

--- a/src/Collections-Arithmetic/Collection.extension.st
+++ b/src/Collections-Arithmetic/Collection.extension.st
@@ -277,13 +277,15 @@ Collection >> sum [
 
 	"#(1 2 4) sum >>> 7"
 
-	"[#() sum] on: CollectionIsEmpty do: ['oops'] >>> 'oops'"
+	"([#() sum] on: CollectionIsEmpty do: ['oops']) >>> 'oops'"
 
-	"sum works with objects that understands + and - messages, like Points
-	{1@5. 2@3. 4@7} sum >>> 7@15
+	"sum works with objects that understands + and - messages, like Points"
 
-	or even Collections
-	#((1 5 1) (2 3 3) (4 7 2)) sum >>> #(7 15 6)"
+	"{1@5. 2@3. 4@7} sum >>> 7@15"
+
+	"or even Collections"
+
+	"#((1 5 1) (2 3 3) (4 7 2)) sum >>> #(7 15 6)"
 
 	| sum sample |
 	self emptyCheck.

--- a/src/Collections-Unordered/Dictionary.class.st
+++ b/src/Collections-Unordered/Dictionary.class.st
@@ -162,7 +162,7 @@ Dictionary class >> newFrom: aDictionaryOrCollectionOfAssociations [
 	"Answer an instance of me containing the same associations as the argument.
 	If the same key appears twice, the last one enumerated will win"
 		
-	"Dictionary newFrom: {1->#a. 2->#b. 3->#c} >>> {1->#a. 2->#b. 3->#c} asDictionary"
+	"(Dictionary newFrom: {1->#a. 2->#b. 3->#c}) >>> ({1->#a. 2->#b. 3->#c} asDictionary)"
 	
 	| newDictionary |
 	newDictionary := self new: aDictionaryOrCollectionOfAssociations size.

--- a/src/Colors/Color.class.st
+++ b/src/Colors/Color.class.st
@@ -107,8 +107,8 @@ Color class >> brown [
 { #category : #'instance creation' }
 Color class >> colorFrom: parm [
 	"Return an instantiated color from parm.  If parm is already a color, return it, else return the result of my performing it if it's a symbol or, if it is a list, it can either be an array of three numbers, which will be interpreted as RGB values, or a list of symbols, the first of which is sent to me and then the others of which are in turn sent to the prior result, thus allowing entries of the form #(blue darker).  Else just return the thing"
-	"Color colorFrom: #(blue darker) >>>  (Color r: 0.0 g: 0.0 b: 0.9198435972629521 alpha: 1.0) "
-	"(Color colorFrom: Color blue darker)>>>( (Color r: 0.0 g: 0.0 b: 0.9198435972629521 alpha: 1.0))"
+	"(Color colorFrom: #(blue darker)) >>> (Color r: 0.0 g: 0.0 b: 0.9198435972629521 alpha: 1.0) "
+	"(Color colorFrom: Color blue darker)>>> ((Color r: 0.0 g: 0.0 b: 0.9198435972629521 alpha: 1.0))"
 	"(Color colorFrom: #blue)>>> (Color blue)"
 	"(Color colorFrom: #(0.0 0.0 1.0)) >>> (Color blue)"
 
@@ -400,7 +400,7 @@ Color class >> hex: aFloat [
 	"Return an hexadecimal two-digits string between 00 and FF
 	for a float between 0.0 and 1.0"
 
-	" Color hex: 0.2 >>> '33' "
+	"(Color hex: 0.2) >>> '33'"
 
 	| str |
 	str := (aFloat * 255) asInteger printStringHex asLowercase.

--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -338,14 +338,12 @@ Context >> stepToSendOrReturn [
 
 { #category : #'*Debugging-Core' }
 Context class >> tallyInstructions: aBlock [
-	"
-	Count the occurrences of each bytecode during the execution of aBlock.
+	"Count the occurrences of each bytecode during the execution of aBlock.
 	Return a Array of associations using the byte as key and the occurrences as values sorted by the instruction opcode numeric values.
 	
-	This method uses the in-image bytecode interpreter to evaluate and count the instructions.
+	This method uses the in-image bytecode interpreter to evaluate and count the instructions."
 	
-	(Context tallyInstructions: [3.14159 printString]) size >>> 122
-	"
+	"(Context tallyInstructions: [3.14159 printString]) size >>> 122"
 	
 	| tallies |
 	tallies := Bag new.

--- a/src/DrTests-CommentsToTests-Tests/CommentsToTestsTest.class.st
+++ b/src/DrTests-CommentsToTests-Tests/CommentsToTestsTest.class.st
@@ -47,12 +47,13 @@ CommentsToTestsTest >> testErrorComment [
 CommentsToTestsTest >> testSimpleComment [
 	"(1+3)>>>4"
 	
-	| docComment commentTestCase |
+	| docComment commentTestCase value |
 
 	docComment := thisContext method ast pharoDocCommentNodes first.
 	commentTestCase := CommentTestCase for: docComment.
+	value := commentTestCase evaluate.
 		
 	self
-		assert: commentTestCase currentValue
-		equals: commentTestCase expectedValue
+		assert: value key
+		equals: value value
 ]

--- a/src/DrTests-CommentsToTests/DTCommentToTestPlugin.class.st
+++ b/src/DrTests-CommentsToTests/DTCommentToTestPlugin.class.st
@@ -42,7 +42,7 @@ DTCommentToTestPlugin >> itemsToBeAnalysedFor: packagesSelected [
 
 	^ packagesSelected asSet flatCollect: [ :package | 
 		  package definedOrExtendedClasses select: [ :class | 
-			  class hasDocComment ] ]
+			  class hasDocComment or: [ class class hasDocComment ] ] ]
 ]
 
 { #category : #api }

--- a/src/Kernel/Point.class.st
+++ b/src/Kernel/Point.class.st
@@ -475,8 +475,8 @@ Point >> min [
 { #category : #comparing }
 Point >> min: aPoint [ 
 	"Answer the upper left corner of the rectangle uniquely defined by the receiver and the argument, aPoint."
-	"(100@200) min: (330@400) >>> (100@200)"
-	"(100@200) min: (30@400) >>> (30@200)"
+	"((100@200) min: (330@400)) >>> (100@200)"
+	"((100@200) min: (30@400)) >>> (30@200)"
 	
 	^ (x min: aPoint x) @ (y min: aPoint y)
 ]

--- a/src/Math-Operations-Extensions/Integer.extension.st
+++ b/src/Math-Operations-Extensions/Integer.extension.st
@@ -429,7 +429,7 @@ Integer >> numberOfCombinationsTaken: k [
 	It is calculated as C(n,k) = n! / (k! (n-k)!) 
 	For 6 numberOfCombinationsTaken: 3, this is 6*5*4 / (1*2*3)"
 	
-	"6 numberOfCombinationsTaken: 3 >>> 20"
+	"(6 numberOfCombinationsTaken: 3) >>> 20"
 
 	| numerator denominator |
 	k < 0 ifTrue: [^ 0].

--- a/src/PharoDocComment-Tests/PharoDocCommentTest.class.st
+++ b/src/PharoDocComment-Tests/PharoDocCommentTest.class.st
@@ -59,8 +59,6 @@ PharoDocCommentTest >> testMultipleDocCommentsInOneComment [
 	| espression |
 	espression := thisContext method ast pharoDocCommentNodes first expression.
 	self assert: espression evaluate equals: 7.
-	espression := thisContext method ast pharoDocCommentNodes second expression.
-	self assert: espression evaluate equals: 3.
 ]
 
 { #category : #tests }

--- a/src/PharoDocComment-Tests/PharoDocCommentTest.class.st
+++ b/src/PharoDocComment-Tests/PharoDocCommentTest.class.st
@@ -30,7 +30,7 @@ PharoDocCommentTest >> testExpressionReferencingSelf [
 	"self >>> PharoDocCommentTest"
 	| espression |
 	espression := thisContext method ast pharoDocCommentNodes first expression.
-	self assert: espression evaluate equals: self class.
+	self assert: espression evaluate equals: self class -> self class.
 ]
 
 { #category : #tests }
@@ -38,7 +38,7 @@ PharoDocCommentTest >> testExpressionResult [
 	"3 + 4 >>> 7"
 	| expression |
 	expression := thisContext method ast pharoDocCommentNodes first expression.
-	self assert: expression evaluate equals: 7
+	self assert: expression evaluate equals: 7->7
 ]
 
 { #category : #tests }
@@ -47,9 +47,9 @@ PharoDocCommentTest >> testMultipleDocComments [
 	"1 + 2 >>> 3."
 	| espression |
 	espression := thisContext method ast pharoDocCommentNodes first expression.
-	self assert: espression evaluate equals: 7.
+	self assert: espression evaluate equals: 7->7.
 	espression := thisContext method ast pharoDocCommentNodes second expression.
-	self assert: espression evaluate equals: 3.
+	self assert: espression evaluate equals: 3->3.
 ]
 
 { #category : #tests }
@@ -58,7 +58,7 @@ PharoDocCommentTest >> testMultipleDocCommentsInOneComment [
 	1 + 2 >>> 3."
 	| espression |
 	espression := thisContext method ast pharoDocCommentNodes first expression.
-	self assert: espression evaluate equals: 7.
+	self assert: espression evaluate equals: 3->3.
 ]
 
 { #category : #tests }
@@ -68,5 +68,5 @@ PharoDocCommentTest >> testNodeResultSource [
 	
 	| node |
 	node := thisContext method ast pharoDocCommentNodes first.
-	self assert: node result source equals: '3 + 4 >>> 7'
+	self assert: node expression source equals: '3 + 4 >>> 7'
 ]

--- a/src/PharoDocComment/CommentTestCase.class.st
+++ b/src/PharoDocComment/CommentTestCase.class.st
@@ -25,11 +25,6 @@ CommentTestCase class >> testSelectors [
 ]
 
 { #category : #accessing }
-CommentTestCase >> currentValue [
-	^ docCommentNode expression evaluate
-]
-
-{ #category : #accessing }
 CommentTestCase >> docCommentNode: aDocComment [
 
 	docCommentNode := aDocComment.
@@ -41,9 +36,10 @@ CommentTestCase >> drTestsBrowse [
  	docCommentNode browse
 ]
 
-{ #category : #accessing }
-CommentTestCase >> expectedValue [
-	^ docCommentNode result evaluate
+{ #category : #'public access' }
+CommentTestCase >> evaluate [
+
+	^ docCommentNode expression evaluate.
 ]
 
 { #category : #accessing }
@@ -64,5 +60,8 @@ CommentTestCase >> printString [
 
 { #category : #tests }
 CommentTestCase >> testIt [
-	self assert: self expectedValue equals: self currentValue
+
+	| value |
+	value := self evaluate.
+	self assert: value key equals: value value
 ]

--- a/src/PharoDocComment/DocCommentIconStyler.class.st
+++ b/src/PharoDocComment/DocCommentIconStyler.class.st
@@ -56,7 +56,7 @@ DocCommentIconStyler >> runExampleBlock: aNode [
 		examples := aNode pharoDocCommentNodes.
 		(examples
 			collect: [ :example | 
-			{ example expression expressionCode formattedCode . example expression evaluate . example result expressionCode formattedCode}]) inspect]
+			{ example expression expressionCode formattedCode . example expression evaluate}]) inspect]
 ]
 
 { #category : #testing }

--- a/src/PharoDocComment/Object.extension.st
+++ b/src/PharoDocComment/Object.extension.st
@@ -2,13 +2,25 @@ Extension { #name : #Object }
 
 { #category : #'*PharoDocComment' }
 Object >> >>> anObject [
+
 	"Return a pair. It is handy to support the tweaking of pharo doc expression. A pharo doc expression is a comment as the following one:"
 
 	"4 + 3 >>> 7"
-	
-	"Pay attention when you write an executable comment for keyword-based method : surround with parentheses your expression because, otherwise the executable comment won't work as the message is binary."
-	
+
+	"Pay attention when you write an executable comment for keyword-based method: surround with parentheses your expression because, otherwise the executable comment won't work as the message is binary."
+
 	"(1 max: 1000) >>> 1000"
+
+	"An executable comment must be in its own comment block (enclosed in double quotes) and can be multi-line for better readability.
+	Code editor hint: you can double click on the inner side of a double quote to select the whole comment block, then Cmd+I to evaluate and inspect the whole executable comment."
+	
+	"| rectangles |
+	rectangles := OrderedCollection new
+		add: (Rectangle left: 5 right: 10 top: 0 bottom: 15);
+		add: (Rectangle left: 0 right: 15 top: 5 bottom: 10);
+		yourself.
+	(Rectangle merging: rectangles)
+		>>> (Rectangle left: 0 right: 15 top: 0 bottom: 15)"
 
 	^ self -> anObject
 ]

--- a/src/PharoDocComment/PharoDocCommentExpression.class.st
+++ b/src/PharoDocComment/PharoDocCommentExpression.class.st
@@ -5,7 +5,6 @@ Class {
 	#name : #PharoDocCommentExpression,
 	#superclass : #Object,
 	#instVars : [
-		'expressionInterval',
 		'source',
 		'node'
 	],
@@ -25,7 +24,7 @@ PharoDocCommentExpression >> evaluate [
 
 { #category : #accessing }
 PharoDocCommentExpression >> expression [
-	^ self source copyFrom: expressionInterval first to: expressionInterval last
+	^ self source.
 ]
 
 { #category : #accessing }
@@ -36,16 +35,6 @@ PharoDocCommentExpression >> expressionCode [
 		  noPattern: true;
 		  options: #( + optionParseErrors );
 		  parse
-]
-
-{ #category : #accessing }
-PharoDocCommentExpression >> expressionInterval [
-	^ expressionInterval
-]
-
-{ #category : #accessing }
-PharoDocCommentExpression >> expressionInterval: anObject [
-	expressionInterval := anObject
 ]
 
 { #category : #operation }

--- a/src/PharoDocComment/PharoDocCommentNode.class.st
+++ b/src/PharoDocComment/PharoDocCommentNode.class.st
@@ -36,7 +36,7 @@ PharoDocCommentNode class >> docCommentEnabled: aBoolean [
 
 { #category : #parsing }
 PharoDocCommentNode class >> docCommentRangesIn: aText [
-	^ '(([^[:cntrl:]]*)>>>\3?([^[:cntrl:]]*))' asRegex matchingRangesIn: aText
+	^ '((.*)>>>(.*))' asRegex matchingRangesIn: aText
 ]
 
 { #category : #'instance creation' }

--- a/src/PharoDocComment/PharoDocCommentNode.class.st
+++ b/src/PharoDocComment/PharoDocCommentNode.class.st
@@ -79,15 +79,6 @@ PharoDocCommentNode class >> settingsOn: aBuilder [
 		parent: #codeBrowsing
 ]
 
-{ #category : #converting }
-PharoDocCommentNode >> asTriplet [
-	"Return the expression, its returned value and its expected result."
-	
-	^ { self expression expressionCode formattedCode. 
-		 self expression evaluate. 
-		 self result expressionCode formattedCode }
-]
-
 { #category : #private }
 PharoDocCommentNode >> browse [
 	| methodNode |

--- a/src/PharoDocComment/PharoDocCommentNode.class.st
+++ b/src/PharoDocComment/PharoDocCommentNode.class.st
@@ -15,8 +15,7 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'sourceNode',
-		'expression',
-		'result'
+		'expression'
 	],
 	#classVars : [
 		'DocCommentEnabled'
@@ -34,35 +33,20 @@ PharoDocCommentNode class >> docCommentEnabled: aBoolean [
 	DocCommentEnabled := aBoolean
 ]
 
-{ #category : #parsing }
-PharoDocCommentNode class >> docCommentRangesIn: aText [
-	^ '((.*)>>>(.*))' asRegex matchingRangesIn: aText
-]
-
 { #category : #'instance creation' }
-PharoDocCommentNode class >> expression: aDocExpression result: anotherDocExpression inComment: aRBComment [
+PharoDocCommentNode class >> expression: aDocExpression inComment: aRBComment [
 	^ self new
 		expression: aDocExpression;
-		result: anotherDocExpression;
 		sourceNode: aRBComment
 		yourself
 ]
 
 { #category : #parsing }
 PharoDocCommentNode class >> parseDocComments: aRBCommentNode [
-	| ranges |
-	ranges := self docCommentRangesIn: aRBCommentNode contents.
-	^ ranges
-		collect: [ :range | 
-			| expression result exps |
-			exps := '>>>' split: (aRBCommentNode contents copyFrom: range first to: range last).
-			expression := PharoDocCommentExpression new
-				expressionInterval: (range first to: range first + exps first size - 1);
-				source: aRBCommentNode contents.
-			result := PharoDocCommentExpression new
-				expressionInterval: (1 + range last - exps last size to: range last);
-				source: aRBCommentNode contents.
-			self expression: expression result: result inComment: aRBCommentNode ]
+
+	| expression |
+	expression := PharoDocCommentExpression new source: aRBCommentNode contents.
+	^ { (self expression: expression inComment: aRBCommentNode) }
 ]
 
 { #category : #settings }
@@ -105,17 +89,6 @@ PharoDocCommentNode >> printOn: aStream [
 		nextPutAll: '(';
 		nextPutAll: self expression source;
 		nextPutAll: ')'
-]
-
-{ #category : #accessing }
-PharoDocCommentNode >> result [
-	^ result
-]
-
-{ #category : #accessing }
-PharoDocCommentNode >> result: anObject [
-	result := anObject.
-	anObject node: self
 ]
 
 { #category : #accessing }

--- a/src/PharoDocComment/SHRBTextStyler.extension.st
+++ b/src/PharoDocComment/SHRBTextStyler.extension.st
@@ -4,26 +4,20 @@ Extension { #name : #SHRBTextStyler }
 SHRBTextStyler >> styleDocComment: aRBComment [
 	aRBComment pharoDocCommentNodes
 		do: [ :pharoDocComment | 
-			self styleDocExpression: pharoDocComment expression in: aRBComment.
-			self
-				addStyle: #binary
-				from: aRBComment start + pharoDocComment expression expressionInterval last
-				to: aRBComment start + pharoDocComment result expressionInterval first.
-			self styleDocExpression: pharoDocComment result in: aRBComment ]
+			self styleDocExpression: pharoDocComment expression in: aRBComment. ]
 ]
 
 { #category : #'*PharoDocComment' }
 SHRBTextStyler >> styleDocExpression: aPharoDocExpression in: aRBComment [
-	| expressionText expressionNode expressionInterval |
+	| expressionText expressionNode |
 	expressionNode := aPharoDocExpression expressionCode.
 	expressionText := expressionNode source asText.
-	expressionInterval := aPharoDocExpression expressionInterval.
 	self class new style: expressionText ast: expressionNode.
 	expressionText
 		withIndexDo: [ :char :ij | 
 			| index |
-			index := ij - 1 + aRBComment start.
-			charAttr from: expressionInterval first + index to: expressionInterval first + index put: (expressionText attributesAt: ij) ]
+			index := ij + aRBComment start.
+			charAttr at: index put: (expressionText attributesAt: ij) ]
 ]
 
 { #category : #'*PharoDocComment' }

--- a/src/System-Platforms/KeyboardKey.class.st
+++ b/src/System-Platforms/KeyboardKey.class.st
@@ -350,10 +350,9 @@ KeyboardKey class >> four [
 KeyboardKey class >> fromCharacter: aCharacter [
 	"For backwards compatibility mainly.
 	Return the key that should correspond to some character.
-	Handle normal ascii characters and special control keys only (enter, tab space...)
+	Handle normal ascii characters and special control keys only (enter, tab space...)"
 	
-	 (KeyboardKey fromCharacter: $a) >>> KeyboardKey A
-	"
+	"(KeyboardKey fromCharacter: $a) >>> KeyboardKey A"
 	
 	^ self keyFromCharacterTable at: aCharacter ifAbsent: [ self named: aCharacter asString asUppercase ]
 ]
@@ -362,10 +361,9 @@ KeyboardKey class >> fromCharacter: aCharacter [
 KeyboardKey class >> fromCharacter: aCharacter ifNone: aBlock [
 	"For backwards compatibility mainly.
 	Return the key that should correspond to some character.
-	Handle normal ascii characters and special control keys only (enter, tab space...)
+	Handle normal ascii characters and special control keys only (enter, tab space...)"
 	
-	 (KeyboardKey fromCharacter: $a) >>> KeyboardKey A
-	"
+	"(KeyboardKey fromCharacter: $a) >>> KeyboardKey A"
 	
 	^ self keyFromCharacterTable
 		at: aCharacter 
@@ -1104,20 +1102,18 @@ KeyboardKey class >> minus [
 
 { #category : #'instance creation' }
 KeyboardKey class >> named: aString [
-	"Returns the instance of myself having aString as name.
+	"Returns the instance of myself having aString as name."
 	
-	 (KeyboardKey named: 'SHIFT_L') >>> (KeyboardKey value: 65505)
-	"
+	"(KeyboardKey named: 'SHIFT_L') >>> (KeyboardKey value: 65505)"
 	
 	^ KeyNameTable at: aString
 ]
 
 { #category : #'instance creation' }
 KeyboardKey class >> named: aString ifNone: aBlock [
-	"Returns the instance of myself having aString as name.
+	"Returns the instance of myself having aString as name."
 	
-	 (KeyboardKey named: 'SHIFT_L') >>> (KeyboardKey value: 65505)
-	"
+	"(KeyboardKey named: 'SHIFT_L') >>> (KeyboardKey value: 65505)"
 	
 	^ KeyNameTable at: aString ifAbsent: aBlock
 ]


### PR DESCRIPTION
This set of commits extends and simplifies executable comments.

First, it extends executable comments to the whole comment block, allowing multi-line comments.
This is the original intended behavior, since single-line expression is a strong limitation on readability, whereas readability is a required quality of examples.
Moreover, a double click on the inner part of the double quote selects the whole comment block, making DoIt inspections easy.

Obviously, this breaks existing executable comments with multiple expressions or which include text.
But surprisingly, there were not a lot of them (~15) and were easy to fix. Just add a couple of `"` to separate expressions and text.

Second, it handles the executable expressions as a whole, making `>>>` a standard binary operator.
Previously, the `>>>` was explicitly and manually separated. Making both left, and right parts parsed, highlighted and evaluated independently.
This previous behavior has three issues:
* it made `>>>` a syntactic construct with a lower precedence, lower than keyword message send. Whereas `>>>` in a full expression has a standard binary infix operator precedence. Thus making *DoIt* and automatic testing behaving differently.
* It prevented the left and right parts to share context, especially temporary variables needed by the example.
* It was bloated code, because handling both parts separately was superfluous, and because the parser already knows how to separate the operands of a binary infix operator.

The change of precedence shows that ~80 tests were in fact broken, but accepted by DrTest and CI testing nevertheless because of the weird precedence of `>>>` that was used.