### PR TITLE
CI: when getting pharo version/prefix on PR, do not use --first-parent

### DIFF
--- a/bootstrap/scripts/envversion.sh
+++ b/bootstrap/scripts/envversion.sh
@@ -70,10 +70,11 @@ function set_version_snapshot_variables() {
 function set_version_pull_request_variables() {
 	# I'm not development build, I should be a PR
 	# HACK: Since this is a PR branch, I do not have all information I need. I assume I will have a tag indicating Pharo version.
+	# Note: do not use `--first-parent` here, since Jenkins is crazy and use the PR as the first parent wheras useful version information in the targeted branch.
 	# This will answer "Pharo7.0-PR"
-	PHARO_NAME_PREFIX="Pharo$(git describe --long --tags --first-parent | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 1-2)-PR"
+	PHARO_NAME_PREFIX="Pharo$(git describe --long --tags | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 1-2)-PR"
 	# This will answer "70"
-	PHARO_SHORT_VERSION="$(git describe --long --tags --first-parent | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 1-2 | sed 's/\.//')"
+	PHARO_SHORT_VERSION="$(git describe --long --tags | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 1-2 | sed 's/\.//')"
 }
 
 # sets all variables:


### PR DESCRIPTION
Current CI bash scripts use `git describe --first-parent` to extract version information from the git repository. It is used cosmetically to feed values to versions numbers, but is also used to enable/disable some tests according to the version number.

Instead of using the merge commits automatically done by github for each PR, Jenkins is doing its own merge commit with the PR head and the target branch. Unfortunately, Jenkins does it in the wrong order, where the PR is the first parent and the target branch is the second one.

While the order of parents on merge commits have a very little influence on git (and this is good!), there is an actual (opt-in) tradition of the first parent being the main branch and other parents being feature branches. This tradition gives, for instance, the option `--first-parent` of the `git describe` command.

All this made that old commits merged on newer branches will use the version information of these older commits instead of the correct more recent one, thus making some tests failing. Eg #11770 and #11771

Note: Since this is a CI related PR, and that there is no meta-CI infrastructure, there is no easy way to see if this really solve the issue of the aforementioned PR. So, in order to test the effects, this PR is artificially based on a quite old pharo commit.