### PR TITLE
Categorize refactorings and transformations

### DIFF
--- a/src/Refactoring-Core/RBAccessorClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBAccessorClassRefactoring.class.st
@@ -20,8 +20,13 @@ If the class already contains that accessor, I will create another one with a nu
 Class {
 	#name : #RBAccessorClassRefactoring,
 	#superclass : #RBClassRefactoring,
-	#category : #'Refactoring-Core-Refactorings'
+	#category : #'Refactoring-Core-Transformation'
 }
+
+{ #category : #accessing }
+RBAccessorClassRefactoring class >> kind [
+	^ 'Transformation'
+]
 
 { #category : #preconditions }
 RBAccessorClassRefactoring >> preconditions [

--- a/src/Refactoring-Core/RBCreateAccessorsForVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBCreateAccessorsForVariableRefactoring.class.st
@@ -28,6 +28,11 @@ RBCreateAccessorsForVariableRefactoring class >> instanceVariable: aVarName clas
 	^ self variable: aVarName class: aClass classVariable: false
 ]
 
+{ #category : #accessing }
+RBCreateAccessorsForVariableRefactoring class >> kind [
+	^ 'Transformation'
+]
+
 { #category : #'instance creation' }
 RBCreateAccessorsForVariableRefactoring class >> model: aRBSmalltalk classVariable: aVarName class: aClass [ 
 

--- a/src/Refactoring-Core/RBCreateAccessorsForVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBCreateAccessorsForVariableRefactoring.class.st
@@ -15,7 +15,7 @@ Class {
 		'needsReturn',
 		'selector'
 	],
-	#category : #'Refactoring-Core-Refactorings'
+	#category : #'Refactoring-Core-Transformation'
 }
 
 { #category : #'instance creation' }

--- a/src/Refactoring-Core/RBCreateAccessorsWithLazyInitializationForVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBCreateAccessorsWithLazyInitializationForVariableRefactoring.class.st
@@ -31,7 +31,7 @@ Class {
 	#instVars : [
 		'defaultValue'
 	],
-	#category : #'Refactoring-Core-Refactorings'
+	#category : #'Refactoring-Core-Transformation'
 }
 
 { #category : #'instance creation' }

--- a/src/Refactoring-Core/RBGenerateEqualHashRefactoring.class.st
+++ b/src/Refactoring-Core/RBGenerateEqualHashRefactoring.class.st
@@ -50,6 +50,11 @@ RBGenerateEqualHashRefactoring class >> className: aClass variables: anArray [
 	^ (self className: aClass) variables: anArray
 ]
 
+{ #category : #accessing }
+RBGenerateEqualHashRefactoring class >> kind [ 
+	^ 'Transformation'
+]
+
 { #category : #'instance creation' }
 RBGenerateEqualHashRefactoring class >> model: aNamespace className: aClass variables: anArray [
 	^ (self model: aNamespace className: aClass) variables: anArray

--- a/src/Refactoring-Core/RBGenerateEqualHashRefactoring.class.st
+++ b/src/Refactoring-Core/RBGenerateEqualHashRefactoring.class.st
@@ -42,7 +42,7 @@ Class {
 	#instVars : [
 		'variables'
 	],
-	#category : #'Refactoring-Core-Refactorings'
+	#category : #'Refactoring-Core-Transformation'
 }
 
 { #category : #'instance creation' }

--- a/src/Refactoring-Core/RBGeneratePrintStringRefactoring.class.st
+++ b/src/Refactoring-Core/RBGeneratePrintStringRefactoring.class.st
@@ -19,7 +19,7 @@ Class {
 	#instVars : [
 		'variables'
 	],
-	#category : #'Refactoring-Core-Refactorings'
+	#category : #'Refactoring-Core-Transformation'
 }
 
 { #category : #'instance creation' }

--- a/src/Refactoring-Core/RBGeneratePrintStringRefactoring.class.st
+++ b/src/Refactoring-Core/RBGeneratePrintStringRefactoring.class.st
@@ -27,6 +27,11 @@ RBGeneratePrintStringRefactoring class >> className: aClass variables: anArray [
 	^ (self className: aClass) variables: anArray
 ]
 
+{ #category : #accessing }
+RBGeneratePrintStringRefactoring class >> kind [ 
+	^ 'Transformation'
+]
+
 { #category : #'instance creation' }
 RBGeneratePrintStringRefactoring class >> model: aNamespace className: aClass variables: anArray [
 	^ (self model: aNamespace className: aClass) variables: anArray

--- a/src/Refactoring-Core/RBRefactoring.class.st
+++ b/src/Refactoring-Core/RBRefactoring.class.st
@@ -94,6 +94,14 @@ RBRefactoring class >> isAbstract [
 	^ self == RBRefactoring
 ]
 
+{ #category : #accessing }
+RBRefactoring class >> kind [
+	"Tells if this refactoring is a refactoring or a transformation.
+	Returns either 'Refactoring' or 'Transformation'"
+
+	^ 'Refactoring'
+]
+
 { #category : #'accessing signal' }
 RBRefactoring class >> preconditionSignal [
 	^ RBRefactoringError , RBRefactoringWarning


### PR DESCRIPTION
Some refactorings are not true refactorings but instead code generations or simply transformations. Added tag 'Transformation' to those refactorings.
Also, added a `kind` class method that tells whether an refactoring is a refactoring or transformation.