### PR TITLE
Syntactic check a single >>> on executable comments

### DIFF
--- a/src/Kernel/AsciiCharset.class.st
+++ b/src/Kernel/AsciiCharset.class.st
@@ -181,9 +181,9 @@ AsciiCharset class >> maxValue [
 
 { #category : #casing }
 AsciiCharset class >> toLowercase: aCharacter [
-	"(AsciiCharset toLowercase: $A) >>> $a.
-	 (AsciiCharset  toLowercase: $a) >>> $a.
-	 (AsciiCharset  toLowercase: $!) >>> $!"
+	"(AsciiCharset toLowercase: $A) >>> $a."
+	"(AsciiCharset  toLowercase: $a) >>> $a."
+	"(AsciiCharset  toLowercase: $!) >>> $!"
 
 	(aCharacter between: $A and: $Z)
 		ifFalse: [ ^ aCharacter ].
@@ -193,9 +193,9 @@ AsciiCharset class >> toLowercase: aCharacter [
 
 { #category : #casing }
 AsciiCharset class >> toUppercase: aCharacter [
-	"(AsciiCharset toUppercase: $a) >>> $A.
-	(AsciiCharset toUppercase: $A) >>> $A.
-	(AsciiCharset toUppercase: $!) >>> $!"
+	"(AsciiCharset toUppercase: $a) >>> $A."
+	"(AsciiCharset toUppercase: $A) >>> $A."
+	"(AsciiCharset toUppercase: $!) >>> $!"
 
 	(aCharacter between: $a and: $z)
 		ifFalse: [ ^ aCharacter ].

--- a/src/PharoDocComment-Tests/PharoDocCommentTest.class.st
+++ b/src/PharoDocComment-Tests/PharoDocCommentTest.class.st
@@ -20,35 +20,51 @@ PharoDocCommentTest >> testAssociation [
 { #category : #tests }
 PharoDocCommentTest >> testExpression [
 	"3 + 4 >>> 7"
-	| expression |
-	expression := thisContext method ast pharoDocCommentNodes first expression.
-	self assert: expression source equals: '3 + 4 >>> 7'
+	| node |
+	node := thisContext method ast pharoDocCommentNodes first.
+	self assert: node expression source equals: '3 + 4 >>> 7'.
+	self assert: node expression isFaulty not.
+	self assert: node expression evaluate equals: 7->7.
+	(CommentTestCase for: node) testIt.
 ]
 
 { #category : #tests }
 PharoDocCommentTest >> testExpressionNoAssociation [
+
+	"This one is not syntaxically valid since the last statement is not the triple >"
+
 	"(3 + 4 >>> 7) value"
 	| node |
 	node := thisContext method ast pharoDocCommentNodes first.
+	self assert: node expression isFaulty.
+	self should: [ node expression evaluate ] raise: RuntimeSyntaxError.
+	self should: [ (CommentTestCase for: node) testIt ] raise: RuntimeSyntaxError
+]
+
+{ #category : #tests }
+PharoDocCommentTest >> testExpressionNoAssociation2 [
+
+	"This one is syntaxically valid, but does not return an association at runtime."
+	
+	"true ifTrue: [^ 7]. 1 >>> 1"
+	| node |
+	node := thisContext method ast pharoDocCommentNodes first.
+	self assert: node expression isFaulty not.
 	self assert: node expression evaluate equals: 7.
 	self should: [ (CommentTestCase for: node) testIt ] raise: TestFailure
 ]
 
 { #category : #tests }
 PharoDocCommentTest >> testExpressionReferencingSelf [
+
+	"This one shows that self is correclty bound to the class"
+
 	"self >>> PharoDocCommentTest"
 	| node |
 	node := thisContext method ast pharoDocCommentNodes first.
+	self assert: node expression isFaulty not.
 	self assert: node expression evaluate equals: self class -> self class.
 	(CommentTestCase for: node) testIt.
-]
-
-{ #category : #tests }
-PharoDocCommentTest >> testExpressionResult [
-	"3 + 4 >>> 7"
-	| expression |
-	expression := thisContext method ast pharoDocCommentNodes first expression.
-	self assert: expression evaluate equals: 7->7
 ]
 
 { #category : #tests }
@@ -56,6 +72,7 @@ PharoDocCommentTest >> testExpressionRuntimeError [
 	"nil + nil >>> nil"
 	| node |
 	node := thisContext method ast pharoDocCommentNodes first.
+	self assert: node expression isFaulty not.
 	self should: [ node expression evaluate ] raise: Error.
 	self should: [ (CommentTestCase for: node) testIt ] raise: Error
 ]
@@ -65,6 +82,20 @@ PharoDocCommentTest >> testExpressionSyntaxError [
 	"3 + 4) >>> 7"
 	| node |
 	node := thisContext method ast pharoDocCommentNodes first.
+	self assert: node expression isFaulty.
+	self should: [ node expression evaluate ] raise: RuntimeSyntaxError.
+	self should: [ (CommentTestCase for: node) testIt ] raise: RuntimeSyntaxError
+]
+
+{ #category : #tests }
+PharoDocCommentTest >> testExpressionZero [
+
+	"This one feels like a doc comment but there is no real triple > message send in the AST."
+	
+	"#( 1 >>> 1 )"
+	| node |
+	node := thisContext method ast pharoDocCommentNodes first.
+	self assert: node expression isFaulty.
 	self should: [ node expression evaluate ] raise: RuntimeSyntaxError.
 	self should: [ (CommentTestCase for: node) testIt ] raise: RuntimeSyntaxError
 ]
@@ -84,17 +115,9 @@ PharoDocCommentTest >> testMultipleDocComments [
 PharoDocCommentTest >> testMultipleDocCommentsInOneComment [
 	"3 + 4 >>> 7.
 	1 + 2 >>> 3."
-	| espression |
-	espression := thisContext method ast pharoDocCommentNodes first expression.
-	self assert: espression evaluate equals: 3->3.
-]
-
-{ #category : #tests }
-PharoDocCommentTest >> testNodeResultSource [
-	"we use a doc comment here to test"
-	"3 + 4 >>> 7"
-	
 	| node |
 	node := thisContext method ast pharoDocCommentNodes first.
-	self assert: node expression source equals: '3 + 4 >>> 7'
+	self assert: node expression isFaulty.
+	self should: [ node expression evaluate ] raise: RuntimeSyntaxError.
+	self should: [ (CommentTestCase for: node) testIt ] raise: RuntimeSyntaxError
 ]

--- a/src/PharoDocComment-Tests/PharoDocCommentTest.class.st
+++ b/src/PharoDocComment-Tests/PharoDocCommentTest.class.st
@@ -26,11 +26,21 @@ PharoDocCommentTest >> testExpression [
 ]
 
 { #category : #tests }
+PharoDocCommentTest >> testExpressionNoAssociation [
+	"(3 + 4 >>> 7) value"
+	| node |
+	node := thisContext method ast pharoDocCommentNodes first.
+	self assert: node expression evaluate equals: 7.
+	self should: [ (CommentTestCase for: node) testIt ] raise: TestFailure
+]
+
+{ #category : #tests }
 PharoDocCommentTest >> testExpressionReferencingSelf [
 	"self >>> PharoDocCommentTest"
-	| espression |
-	espression := thisContext method ast pharoDocCommentNodes first expression.
-	self assert: espression evaluate equals: self class -> self class.
+	| node |
+	node := thisContext method ast pharoDocCommentNodes first.
+	self assert: node expression evaluate equals: self class -> self class.
+	(CommentTestCase for: node) testIt.
 ]
 
 { #category : #tests }
@@ -39,6 +49,24 @@ PharoDocCommentTest >> testExpressionResult [
 	| expression |
 	expression := thisContext method ast pharoDocCommentNodes first expression.
 	self assert: expression evaluate equals: 7->7
+]
+
+{ #category : #tests }
+PharoDocCommentTest >> testExpressionRuntimeError [
+	"nil + nil >>> nil"
+	| node |
+	node := thisContext method ast pharoDocCommentNodes first.
+	self should: [ node expression evaluate ] raise: Error.
+	self should: [ (CommentTestCase for: node) testIt ] raise: Error
+]
+
+{ #category : #tests }
+PharoDocCommentTest >> testExpressionSyntaxError [
+	"3 + 4) >>> 7"
+	| node |
+	node := thisContext method ast pharoDocCommentNodes first.
+	self should: [ node expression evaluate ] raise: RuntimeSyntaxError.
+	self should: [ (CommentTestCase for: node) testIt ] raise: RuntimeSyntaxError
 ]
 
 { #category : #tests }

--- a/src/PharoDocComment/CommentTestCase.class.st
+++ b/src/PharoDocComment/CommentTestCase.class.st
@@ -63,5 +63,6 @@ CommentTestCase >> testIt [
 
 	| value |
 	value := self evaluate.
+	self assert: value isAssociation.
 	self assert: value key equals: value value
 ]

--- a/src/PharoDocComment/DocCommentIconStyler.class.st
+++ b/src/PharoDocComment/DocCommentIconStyler.class.st
@@ -11,7 +11,7 @@ Class {
 DocCommentIconStyler >> exampleIsFaulty: aNode [
 	^ aNode comments
 		anySatisfy: [ :commentNode | commentNode pharoDocCommentNodes anySatisfy: [ :node |
-				node expression expressionNode isFaulty ]]
+				node expression isFaulty ]]
 ]
 
 { #category : #defaults }
@@ -46,8 +46,9 @@ DocCommentIconStyler >> notifySourceError: aNode [
 	
 	^ [ | examples faultyExample |
 		examples := aNode pharoDocCommentNodes.
-		faultyExample := examples detect: [ :example | example expression expressionNode isFaulty ].
-		RBParser parseExpression: faultyExample expression expression ]
+		faultyExample := examples detect: [ :example | example expression isFaulty ].
+		"FIXME: The parser do not show errors related to specific doccomments rules."
+		RBParser parseExpression: faultyExample expression source ]
 ]
 
 { #category : #private }

--- a/src/PharoDocComment/DocCommentIconStyler.class.st
+++ b/src/PharoDocComment/DocCommentIconStyler.class.st
@@ -11,7 +11,7 @@ Class {
 DocCommentIconStyler >> exampleIsFaulty: aNode [
 	^ aNode comments
 		anySatisfy: [ :commentNode | commentNode pharoDocCommentNodes anySatisfy: [ :node |
-				node expression expressionCode isFaulty ]]
+				node expression expressionNode isFaulty ]]
 ]
 
 { #category : #defaults }
@@ -46,7 +46,7 @@ DocCommentIconStyler >> notifySourceError: aNode [
 	
 	^ [ | examples faultyExample |
 		examples := aNode pharoDocCommentNodes.
-		faultyExample := examples detect: [ :example | example expression expressionCode isFaulty ].
+		faultyExample := examples detect: [ :example | example expression expressionNode isFaulty ].
 		RBParser parseExpression: faultyExample expression expression ]
 ]
 
@@ -56,7 +56,7 @@ DocCommentIconStyler >> runExampleBlock: aNode [
 		examples := aNode pharoDocCommentNodes.
 		(examples
 			collect: [ :example | 
-			{ example expression expressionCode formattedCode . example expression evaluate}]) inspect]
+			{ example expression expressionNode formattedCode . example expression evaluate}]) inspect]
 ]
 
 { #category : #testing }

--- a/src/PharoDocComment/Object.extension.st
+++ b/src/PharoDocComment/Object.extension.st
@@ -14,6 +14,8 @@ Object >> >>> anObject [
 	"An executable comment must be in its own comment block (enclosed in double quotes) and can be multi-line for better readability.
 	Code editor hint: you can double click on the inner side of a double quote to select the whole comment block, then Cmd+I to evaluate and inspect the whole executable comment."
 	
+	"Note: to be syntactically valid as an executable comment, there should be exactly one single triple > message send, and it should be the last statement."
+	
 	"| rectangles |
 	rectangles := OrderedCollection new
 		add: (Rectangle left: 5 right: 10 top: 0 bottom: 15);

--- a/src/PharoDocComment/PharoDocCommentExpression.class.st
+++ b/src/PharoDocComment/PharoDocCommentExpression.class.st
@@ -24,7 +24,7 @@ PharoDocCommentExpression >> evaluate [
 ]
 
 { #category : #accessing }
-PharoDocCommentExpression >> expressionCode [
+PharoDocCommentExpression >> expressionNode [
 
 	^ self methodClass compiler
 		  source: self source;

--- a/src/PharoDocComment/PharoDocCommentExpression.class.st
+++ b/src/PharoDocComment/PharoDocCommentExpression.class.st
@@ -6,7 +6,8 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'source',
-		'node'
+		'node',
+		'cachedExpressionNode'
 	],
 	#category : #'PharoDocComment-Base'
 }
@@ -15,7 +16,7 @@ Class {
 PharoDocCommentExpression >> evaluate [
 
 	^ self methodClass compiler
-		  source: self expression;
+		  source: self source;
 		  noPattern: true;
 		  receiver: self methodClass;
 		  options: #( + optionParseErrors );
@@ -23,15 +24,10 @@ PharoDocCommentExpression >> evaluate [
 ]
 
 { #category : #accessing }
-PharoDocCommentExpression >> expression [
-	^ self source.
-]
-
-{ #category : #accessing }
 PharoDocCommentExpression >> expressionCode [
 
 	^ self methodClass compiler
-		  source: self expression;
+		  source: self source;
 		  noPattern: true;
 		  options: #( + optionParseErrors );
 		  parse
@@ -56,7 +52,7 @@ PharoDocCommentExpression >> node: anObject [
 PharoDocCommentExpression >> printOn: aStream [
 	super printOn: aStream.
 	aStream nextPutAll: '('.
-	aStream nextPutAll: self expression. 
+	aStream nextPutAll: self source. 
 	aStream nextPutAll: ')'
 ]
 

--- a/src/PharoDocComment/PharoDocCommentExpression.class.st
+++ b/src/PharoDocComment/PharoDocCommentExpression.class.st
@@ -17,6 +17,8 @@ PharoDocCommentExpression >> evaluate [
 
 	"Note: it seems there is no easy way here to reuse in Opal the parsed AST and just compile&evaluate it."
 
+	self isFaulty ifTrue: [ RuntimeSyntaxError signal ].
+
 	^ self methodClass compiler
 		  source: self source;
 		  noPattern: true;
@@ -45,6 +47,26 @@ PharoDocCommentExpression >> expressionNodeReal [
 		  receiver: self methodClass;
 		  options: #( + optionParseErrors );
 		  parse.
+]
+
+{ #category : #testing }
+PharoDocCommentExpression >> isFaulty [
+
+	"Check is the ast is OK and follows the 2 specific doccomments rules"
+
+	| cpt |
+	self expressionNode isFaulty ifTrue: [ ^ true ].
+
+	"There should be exactly only one triple > message send"
+	cpt := 0.
+	self expressionNode nodesDo: [ :n |
+		(n isMessage and: [ n selector == #>>> ]) ifTrue: [ cpt := cpt + 1 ]].
+	cpt ~= 1 ifTrue: [ ^ true ].
+
+	"`self expressionNode` is a RBDoItMethodNode. The last statement should be a return of a binop of >>>"
+	self expressionNode body statements last value selector ~= #>>> ifTrue: [ ^ true ].
+
+	^false
 ]
 
 { #category : #operation }

--- a/src/PharoDocComment/PharoDocCommentExpression.class.st
+++ b/src/PharoDocComment/PharoDocCommentExpression.class.st
@@ -15,6 +15,8 @@ Class {
 { #category : #operation }
 PharoDocCommentExpression >> evaluate [
 
+	"Note: it seems there is no easy way here to reuse in Opal the parsed AST and just compile&evaluate it."
+
 	^ self methodClass compiler
 		  source: self source;
 		  noPattern: true;
@@ -26,11 +28,23 @@ PharoDocCommentExpression >> evaluate [
 { #category : #accessing }
 PharoDocCommentExpression >> expressionNode [
 
+	cachedExpressionNode ifNil: [
+		cachedExpressionNode := self expressionNodeReal
+	].
+	^ cachedExpressionNode.
+]
+
+{ #category : #accessing }
+PharoDocCommentExpression >> expressionNodeReal [
+
+	"Force the parsing of the expression node"
+
 	^ self methodClass compiler
 		  source: self source;
 		  noPattern: true;
+		  receiver: self methodClass;
 		  options: #( + optionParseErrors );
-		  parse
+		  parse.
 ]
 
 { #category : #operation }

--- a/src/PharoDocComment/SHRBTextStyler.extension.st
+++ b/src/PharoDocComment/SHRBTextStyler.extension.st
@@ -10,7 +10,7 @@ SHRBTextStyler >> styleDocComment: aRBComment [
 { #category : #'*PharoDocComment' }
 SHRBTextStyler >> styleDocExpression: aPharoDocExpression in: aRBComment [
 	| expressionText expressionNode |
-	expressionNode := aPharoDocExpression expressionCode.
+	expressionNode := aPharoDocExpression expressionNode.
 	expressionText := expressionNode source asText.
 	self class new style: expressionText ast: expressionNode.
 	expressionText


### PR DESCRIPTION
This PR is a follow-up of  #11774

Since executable comments are multiline, it could be easy to mistakenly put multiple `>>>` in a single comment block. Especially since the previous behavior was to process each line independently. e.g.

```
"1+2 >>> 3.
3+4 >>> 7"
```

The behavior proposed here is to reject such code and explicitly enforce the following rule:

> to be syntactically valid as an executable comment, there should be exactly one single triple > message send, and it should be the last statement.

In the existing code base (~2000 executable comments), there were only two errors; and some couples of `"` fixed both.

Note: there is no commit related to the UI yet, they may come in a future PR.