### PR TITLE
This adds an example and a test for Fluid Slot definitions

### DIFF
--- a/src/Slot-Examples/ExampleSlotWithFluidAPI.class.st
+++ b/src/Slot-Examples/ExampleSlotWithFluidAPI.class.st
@@ -1,0 +1,49 @@
+"
+This is an example of a slot that has meta data which is set using a fluid api (cascade)
+"
+Class {
+	#name : #ExampleSlotWithFluidAPI,
+	#superclass : #InstanceVariableSlot,
+	#instVars : [
+		'value1',
+		'value2'
+	],
+	#category : #'Slot-Examples-Base'
+}
+
+{ #category : #printing }
+ExampleSlotWithFluidAPI >> printOn: aStream [
+	aStream 
+		store: self name;
+		nextPutAll: ' => ';
+		nextPutAll: self class name;
+		nextPutAll: ' value1: ';
+		store: value1;
+		nextPut: $;;
+		nextPutAll: ' value2: ';
+		store: value2
+]
+
+{ #category : #accessing }
+ExampleSlotWithFluidAPI >> value1 [
+
+	^ value1
+]
+
+{ #category : #accessing }
+ExampleSlotWithFluidAPI >> value1: anObject [
+
+	value1 := anObject
+]
+
+{ #category : #accessing }
+ExampleSlotWithFluidAPI >> value2 [
+
+	^ value2
+]
+
+{ #category : #accessing }
+ExampleSlotWithFluidAPI >> value2: anObject [
+
+	value2 := anObject
+]

--- a/src/Slot-Tests/ExampleSlotWithFluidAPITest.class.st
+++ b/src/Slot-Tests/ExampleSlotWithFluidAPITest.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : #ExampleSlotWithFluidAPITest,
+	#superclass : #SlotSilentTest,
+	#category : #'Slot-Tests-Examples'
+}
+
+{ #category : #tests }
+ExampleSlotWithFluidAPITest >> testExampleSlotWithFluidAPI [
+
+	"Shows that we can use cascade (fluid api) to set meta data on slots. As the #=> has precedense, the cascade
+	is sent to the slot instance"
+
+	| slot |
+	slot := #slot => ExampleSlotWithFluidAPI
+		        value1: #testvalue1;
+		        value2: #testvalue2.
+	aClass := self make: [ :builder | builder slots: { slot } ].
+	self assert: (aClass hasSlotNamed: #slot).
+
+	self assert: slot value1 equals: #testvalue1.
+	self assert: slot value2 equals: #testvalue2.
+	self
+		assert: slot printString
+		equals: '#slot => ExampleSlotWithFluidAPI value1: #testvalue1; value2: #testvalue2'
+]


### PR DESCRIPTION
 Like with classes, the idea that we have to add all possible combinations of  setters leads to a combinatorial explosion. We need to be able to do things like

```
#slot => ExampleSlotWithFluidAPI  
                 value1: #testvalue1;  
                 value2: #testvalue2
```

if we ever want to be able to use this for anything non-trivial.

This PR just adds an example  on the level of Slots and a test that uses the class builder directly.

We can define classes using this, but editing is broken due to the Fluid Class Parser enforcing "#name => ClassName oneSelector: #state", that is, the Fuid Class Parser enforces a non-fluid API for Slots, oddly. (see #6410 for an issue, see CDAbstractClassDefinitionParser>>#handleSlotNode: for where it breaks)