### PR TITLE
CopyClassRefactoring copies class comment as well

### DIFF
--- a/src/Refactoring-Core/RBCopyClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBCopyClassRefactoring.class.st
@@ -68,7 +68,8 @@ RBCopyClassRefactoring >> copyClass [
 		addClass: className
 		superclass: aClass superclass
 		subclasses: #()
-		category: self category).
+		category: self category
+		comment: aClass comment).
 ]
 
 { #category : #copying }

--- a/src/Refactoring-Core/RBInsertClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBInsertClassRefactoring.class.st
@@ -14,7 +14,8 @@ Class {
 	#instVars : [
 		'category',
 		'superclass',
-		'subclasses'
+		'subclasses',
+		'comment'
 	],
 	#category : #'Refactoring-Core-Refactorings'
 }
@@ -39,12 +40,33 @@ RBInsertClassRefactoring class >> model: aRBSmalltalk addClass: aName superclass
 		yourself
 ]
 
+{ #category : #'instance creation' }
+RBInsertClassRefactoring class >> model: aRBSmalltalk addClass: aName superclass: aClass subclasses: aCollection category: aSymbol comment: aCommentString [
+	^ self new
+		model: aRBSmalltalk;
+		addClass: aName
+			superclass: aClass
+			subclasses: aCollection
+			category: aSymbol
+			comment: aCommentString;
+		yourself
+]
+
 { #category : #initialization }
 RBInsertClassRefactoring >> addClass: aName superclass: aClass subclasses: aCollection category: aSymbol [ 
 	self className: aName.
 	superclass := self classObjectFor: aClass.
 	subclasses := aCollection collect: [:each | self classObjectFor: each].
 	category := aSymbol
+]
+
+{ #category : #initialization }
+RBInsertClassRefactoring >> addClass: aName superclass: aClass subclasses: aCollection category: aSymbol comment: aCommentString [
+	self className: aName.
+	superclass := self classObjectFor: aClass.
+	subclasses := aCollection collect: [:each | self classObjectFor: each].
+	category := aSymbol.
+	comment := aCommentString 
 ]
 
 { #category : #preconditions }
@@ -84,10 +106,13 @@ RBInsertClassRefactoring >> storeOn: aStream [
 
 { #category : #transforming }
 RBInsertClassRefactoring >> transform [
+
+	| classDefinitionString |
+	classDefinitionString := '<1p> subclass: #<2s> instanceVariableNames: '''' classVariableNames: '''' poolDictionaries: '''' category: <3p>'
+		                         expandMacrosWith: superclass
+		                         with: className
+		                         with: category asString.
 	self model
-		defineClass: ('<1p> subclass: #<2s> instanceVariableNames: '''' classVariableNames: '''' poolDictionaries: '''' category: <3p>' 
-					expandMacrosWith: superclass
-					with: className
-					with: category asString);
+		defineClass: classDefinitionString withComment: comment;
 		reparentClasses: subclasses to: (self model classNamed: className asSymbol)
 ]

--- a/src/Refactoring-Core/RBNamespace.class.st
+++ b/src/Refactoring-Core/RBNamespace.class.st
@@ -370,6 +370,16 @@ RBNamespace >> defineClass: aString [
 	^ change
 ]
 
+{ #category : #changes }
+RBNamespace >> defineClass: aString withComment: aCommentString [
+
+	| change newClass |
+	change := self defineClass: aString.
+	newClass := self classNamed: change changeClassName.
+	newClass comment: aCommentString.
+	^ change
+]
+
 { #category : #accessing }
 RBNamespace >> description [
 	^ self changes name


### PR DESCRIPTION
CopyClassRefactoring is a composite refactoring that uses InsertClassRefactoring.
Extend InsertClassRefactoring with the option to specify class comment for the inserted class.

Fixes: #11520 

Note: this will also copy the demo template. Problem with this is that pharo won't warn you about your class not having a comment. I tried to fix this one as well, but couldn't figure it out completely. If anyone has any suggestions, let me know.