### PR TITLE
add missing utf8StringFromCString methods

### DIFF
--- a/src/UnifiedFFI/ByteArray.extension.st
+++ b/src/UnifiedFFI/ByteArray.extension.st
@@ -141,6 +141,11 @@ ByteArray >> readString [
 { #category : #'*UnifiedFFI' }
 ByteArray >> readStringUTF8 [
 
+	self 
+		deprecated: 'Please use #utf8StringFromCString instead' 
+		transformWith: '`@receiver readStringUTF8' 
+						-> '`@receiver utf8StringFromCString'.
+
 	^ (ExternalData fromHandle: self type: ExternalType string)
 		  utf8StringFromCString
 ]
@@ -171,6 +176,15 @@ ByteArray >> unpackHandleFromArity: arity [
 	arity > 1 ifTrue: [ ^ self error: 'Use ExternalAddress instead!' ].
 	^ self unsignedLongAt: 1
 
+]
+
+{ #category : #'*UnifiedFFI' }
+ByteArray >> utf8StringFromCString [
+
+	^ (ExternalData 
+			fromHandle: self 
+			type: ExternalType string)
+		utf8StringFromCString
 ]
 
 { #category : #'*UnifiedFFI' }


### PR DESCRIPTION
as is said... we deprecated readStringUTF8 in ExternalData but not its counterpart in ByteArray