### PR TITLE
Fix #11794: Enhance CI to use the right VM version

### DIFF
--- a/bootstrap/scripts/envversion.sh
+++ b/bootstrap/scripts/envversion.sh
@@ -97,7 +97,7 @@ function set_version_variables() {
 		set_version_pull_request_variables
 	fi
 	
-	PHARO_VM_VERSION="90"
+	PHARO_VM_VERSION=${PHARO_SHORT_VERSION}
 	
 	# Prefix the commit hash with a g, to be compatible with git-describe commit hashes
 	# https://git-scm.com/docs/git-describe

--- a/bootstrap/scripts/runKernelTests.sh
+++ b/bootstrap/scripts/runKernelTests.sh
@@ -13,7 +13,6 @@ CACHE="${BOOTSTRAP_CACHE:-bootstrap-cache}"
 
 SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 . ${SCRIPTS}/envvars.sh
-set_version_variables
 
 
 find ${CACHE}
@@ -24,10 +23,19 @@ find ${CACHE}
 # WARNING: If you change this, you will need to change "runTests.sh" too
 #
 TEST_NAME_PREFIX=$(find ${CACHE} -name "Pharo*.zip" | head -n 1 | cut -d'/' -f 2 | cut -d'-' -f 1-2)
-TEST_VM_VERSION=${PHARO_VM_VERSION}
+
+# Extract the VM version from the image file version, avoiding going to git to extract the tags
+# This is handy in later stages of the build process when no repository is available, e.g., to run the tests
+# Input: Pharo11.0-PR-64bit-7264e14.zip
+# Output: 110
+# Works by 
+#  - taking the entire name,
+#  - removing the suffix after the first dot
+#  - removing the prefix "Pharo"
+TEST_VM_VERSION=`echo ${TEST_NAME_PREFIX} | cut -d'.' -f 1 | cut -c6-`0
 
 #Odd PR builds use the the latest VM, else use the stable VM
-if [[ $(is_development_build) == "1" && $((${BUILD_NUMBER} % 2)) -eq 1 ]]
+if [[ $(is_development_build) == "0" && $((${BUILD_NUMBER} % 2)) -eq 1 ]]
 then
  TEST_VM_KIND="vmLatest"
 else

--- a/bootstrap/scripts/runKernelTests.sh
+++ b/bootstrap/scripts/runKernelTests.sh
@@ -13,6 +13,7 @@ CACHE="${BOOTSTRAP_CACHE:-bootstrap-cache}"
 
 SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 . ${SCRIPTS}/envvars.sh
+set_version_variables
 
 
 find ${CACHE}
@@ -23,8 +24,7 @@ find ${CACHE}
 # WARNING: If you change this, you will need to change "runTests.sh" too
 #
 TEST_NAME_PREFIX=$(find ${CACHE} -name "Pharo*.zip" | head -n 1 | cut -d'/' -f 2 | cut -d'-' -f 1-2)
-#TEST_VM_VERSION=$(echo "${TEST_NAME_PREFIX}" | cut -d'-' -f 1| cut -c 6- | cut -d'.' -f 1-2 | sed 's/\.//')
-TEST_VM_VERSION="90"
+TEST_VM_VERSION=${PHARO_VM_VERSION}
 
 #Odd PR builds use the the latest VM, else use the stable VM
 if [[ $(is_development_build) == "1" && $((${BUILD_NUMBER} % 2)) -eq 1 ]]

--- a/bootstrap/scripts/runTests.sh
+++ b/bootstrap/scripts/runTests.sh
@@ -13,7 +13,6 @@ CACHE="${BOOTSTRAP_CACHE:-bootstrap-cache}"
 
 SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 . ${SCRIPTS}/envvars.sh
-set_version_variables
 
 find ${CACHE}
 
@@ -23,7 +22,16 @@ find ${CACHE}
 # WARNING: If you change this, you will need to change "runKernelTests.sh" too
 #
 TEST_NAME_PREFIX=$(find ${CACHE} -name "Pharo*.zip" | head -n 1 | cut -d'/' -f 2 | cut -d'-' -f 1-2)
-TEST_VM_VERSION=${PHARO_VM_VERSION}
+
+# Extract the VM version from the image file version, avoiding going to git to extract the tags
+# This is handy in later stages of the build process when no repository is available, e.g., to run the tests
+# Input: Pharo11.0-PR-64bit-7264e14.zip
+# Output: 110
+# Works by 
+#  - taking the entire name,
+#  - removing the suffix after the first dot
+#  - removing the prefix "Pharo"
+TEST_VM_VERSION=`echo ${TEST_NAME_PREFIX} | cut -d'.' -f 1 | cut -c6-`0
 
 #Odd PR builds use the the latest VM, else use the stable VM
 if [[ $(is_development_build) == "1" && $((${BUILD_NUMBER} % 2)) -eq 1 ]]

--- a/bootstrap/scripts/runTests.sh
+++ b/bootstrap/scripts/runTests.sh
@@ -13,6 +13,7 @@ CACHE="${BOOTSTRAP_CACHE:-bootstrap-cache}"
 
 SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 . ${SCRIPTS}/envvars.sh
+set_version_variables
 
 find ${CACHE}
 
@@ -22,8 +23,7 @@ find ${CACHE}
 # WARNING: If you change this, you will need to change "runKernelTests.sh" too
 #
 TEST_NAME_PREFIX=$(find ${CACHE} -name "Pharo*.zip" | head -n 1 | cut -d'/' -f 2 | cut -d'-' -f 1-2)
-#TEST_VM_VERSION=$(echo "${TEST_NAME_PREFIX}" | cut -d'-' -f 1| cut -c 6- | cut -d'.' -f 1-2 | sed 's/\.//')
-TEST_VM_VERSION="90"
+TEST_VM_VERSION=${PHARO_VM_VERSION}
 
 #Odd PR builds use the the latest VM, else use the stable VM
 if [[ $(is_development_build) == "1" && $((${BUILD_NUMBER} % 2)) -eq 1 ]]

--- a/bootstrap/scripts/runTests.sh
+++ b/bootstrap/scripts/runTests.sh
@@ -34,7 +34,7 @@ TEST_NAME_PREFIX=$(find ${CACHE} -name "Pharo*.zip" | head -n 1 | cut -d'/' -f 2
 TEST_VM_VERSION=`echo ${TEST_NAME_PREFIX} | cut -d'.' -f 1 | cut -c6-`0
 
 #Odd PR builds use the the latest VM, else use the stable VM
-if [[ $(is_development_build) == "1" && $((${BUILD_NUMBER} % 2)) -eq 1 ]]
+if [[ $(is_development_build) == "0" && $((${BUILD_NUMBER} % 2)) -eq 1 ]]
 then
  TEST_VM_KIND="vmLatest"
 else


### PR DESCRIPTION
Make PHARO_VM_VERSION match the Pharo version
Make test scripts use PHARO_VM_VERSION