### PR TITLE
11810-FT2Handle-classstartUp-compiled-code-on-image-startup

### DIFF
--- a/src/FreeType/FT2Handle.class.st
+++ b/src/FreeType/FT2Handle.class.st
@@ -10,21 +10,6 @@ Class {
 	#category : #'FreeType-Base'
 }
 
-{ #category : #'system startup' }
-FT2Handle class >> startUp: isImageStarting [
-	isImageStarting ifFalse: [ ^self ].
-
-	"Force the correct order of initialization of FTBindings"	
-	FTBitmap compileFields.
-	FTBitmapSize compileFields.
-	FTGeneric compileFields.
-	FTBBox compileFields.
-	
-	FTCharMapRec compileFields.
-	FTGlyphSlotRec compileFields.
-	FTFaceRec compileFields.
-]
-
 { #category : #initialization }
 FT2Handle >> beNull [
 	

--- a/src/FreeType/FT2Handle.class.st
+++ b/src/FreeType/FT2Handle.class.st
@@ -10,6 +10,20 @@ Class {
 	#category : #'FreeType-Base'
 }
 
+{ #category : #compiling }
+FT2Handle class >> compileAllFieldsInOrder [
+	"Force the correct order of generation of FFI Bindings"	
+	"This used to be done in #startUp:, we keep it in case FTBindings are changed and have to be regenerated"
+ 	FTBitmap compileFields.
+ 	FTBitmapSize compileFields.
+ 	FTGeneric compileFields.
+ 	FTBBox compileFields.
+
+ 	FTCharMapRec compileFields.
+ 	FTGlyphSlotRec compileFields.
+ 	FTFaceRec compileFields.
+]
+
 { #category : #initialization }
 FT2Handle >> beNull [
 	

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -419,7 +419,7 @@ ReleaseTest >> testShouldWorldMorphBeAfterFontClassesInStartupList [
 	"The Startup of he WorldMorph is now done in the UIManagerHandler"
 	| startupList |
 	startupList := (SessionManager default startupList collect: [:each | each handledId]).
-	#(StrikeFont LogicalFont FreeTypeSettings FreeTypeCache FT2Handle) 
+	#(StrikeFont LogicalFont FreeTypeSettings FreeTypeCache) 
 		do: [ :fontClass |
 			self should: [ (startupList indexOf: #UIManagerSessionHandler) > (startupList indexOf: #SystemSettingsPersistence) ] ]
 ]

--- a/src/System-SessionManager/SessionManager.class.st
+++ b/src/System-SessionManager/SessionManager.class.st
@@ -167,7 +167,6 @@ SessionManager class >> initializedSessionManager [
 		registerGuiClassNamed: #Color; "GUI"
 		registerGuiClassNamed: #FreeTypeCache; "GUI"
 		registerGuiClassNamed: #LogicalFont; "GUI"
-		registerGuiClassNamed: #FT2Handle; "GUI"
 		registerGuiClassNamed: #FreeTypeSettings; "GUI"
 		registerGuiClassNamed: #WorldMorph atPriority: 110; "GUI"
 		"It Should run at the end of everything to correctly handle the errors"


### PR DESCRIPTION
Try to fix #11810, check if we really have to create the methods on startup