### PR TITLE
Cleanup-asCollectionElement-ChunkFileFormatParser

### DIFF
--- a/src/CodeImport/ChunkFileFormatParser.class.st
+++ b/src/CodeImport/ChunkFileFormatParser.class.st
@@ -165,7 +165,6 @@ ChunkFileFormatParser >> parseCommentDeclaration: commentPreamble [
 	"
 
 	| behaviorName isMeta stamp |
-	self asCollectionElement.
 	behaviorName := commentPreamble first asSymbol.
 	isMeta := commentPreamble second ~= self commentStampSelector.
 	stamp := isMeta


### PR DESCRIPTION
ChunkFileFormatParser>>#parseCommentDeclaration: had a

```
	self asCollectionElement.
```	

Which is just returning self. remove