### PR TITLE
Package 'Coverage' as a higher level API for code coverage

### DIFF
--- a/src/BaselineOfCoverage/BaselineOfCoverage.class.st
+++ b/src/BaselineOfCoverage/BaselineOfCoverage.class.st
@@ -1,0 +1,15 @@
+Class {
+	#name : #BaselineOfCoverage,
+	#superclass : #BaselineOf,
+	#category : #BaselineOfCoverage
+}
+
+{ #category : #baselines }
+BaselineOfCoverage >> baseline: spec [
+	<baseline>
+	spec
+		for: #common
+		do: [ 
+			spec
+				package: 'Coverage' ]
+]

--- a/src/BaselineOfCoverage/package.st
+++ b/src/BaselineOfCoverage/package.st
@@ -1,0 +1,1 @@
+Package { #name : #BaselineOfCoverage }

--- a/src/BaselineOfDrTests/BaselineOfDrTests.class.st
+++ b/src/BaselineOfDrTests/BaselineOfDrTests.class.st
@@ -12,6 +12,7 @@ BaselineOfDrTests >> baseline: spec [
 		do: [ 
 			spec
 				package: 'DrTests';
+				package: 'Coverage';
 				package: 'DrTests-TestsRunner' with: [ spec requires: #('DrTests') ];
 				package: 'DrTests-TestCoverage' with: [ spec requires: #('DrTests' 'Coverage') ];
 				package: 'DrTests-TestsProfiling' with: [ spec requires: #('DrTests') ];

--- a/src/BaselineOfDrTests/BaselineOfDrTests.class.st
+++ b/src/BaselineOfDrTests/BaselineOfDrTests.class.st
@@ -13,7 +13,7 @@ BaselineOfDrTests >> baseline: spec [
 			spec
 				package: 'DrTests';
 				package: 'DrTests-TestsRunner' with: [ spec requires: #('DrTests') ];
-				package: 'DrTests-TestCoverage' with: [ spec requires: #('DrTests') ];
+				package: 'DrTests-TestCoverage' with: [ spec requires: #('DrTests' 'Coverage') ];
 				package: 'DrTests-TestsProfiling' with: [ spec requires: #('DrTests') ];
 				package: 'DrTests-Tests' with: [ spec requires: #('DrTests' 'DrTests-TestsRunner' 'DrTests-TestCoverage-Tests-Mocks') ];
 				package: 'DrTests-TestCoverage-Tests' with: [ spec requires: #('DrTests-TestCoverage' 'DrTests-TestCoverage-Tests-Mocks') ];

--- a/src/BaselineOfSUnit/BaselineOfSUnit.class.st
+++ b/src/BaselineOfSUnit/BaselineOfSUnit.class.st
@@ -40,7 +40,7 @@ BaselineOfSUnit >> baseline: spec [
 				package: 'SUnit-Visitor' with: [ spec requires: #('SUnit-Core') ];
 				package: 'SUnit-Visitor-Tests' with: [ spec requires: #('SUnit-Visitor') ];
 				package: 'SUnit-MockObjects' with: [ spec requires: #('SUnit-Core') ];
-				package: 'SUnit-UI';
+				package: 'SUnit-UI' with: [ spec requires: #('Coverage') ];
 				package: 'SUnit-Support-UITesting-Tests';
 				package: 'SUnit-Support-UITesting';
 				package: 'SUnit-Help';

--- a/src/BaselineOfSUnit/BaselineOfSUnit.class.st
+++ b/src/BaselineOfSUnit/BaselineOfSUnit.class.st
@@ -44,12 +44,13 @@ BaselineOfSUnit >> baseline: spec [
 				package: 'SUnit-Support-UITesting-Tests';
 				package: 'SUnit-Support-UITesting';
 				package: 'SUnit-Help';
+				package: 'Coverage';
 				package: 'JenkinsTools-Core';
 				package: 'JenkinsTools-ExtraReports'.
 			spec
 				group: 'Core' with: #('SUnit-Core' 'SUnit-Core-Traits' 'SUnit-Visitor');
 				group: 'MockObjects' with: #('SUnit-MockObjects');
-				group: 'UI' with: #('SUnit-UI' 'SUnit-Support-UITesting');
+				group: 'UI' with: #('SUnit-UI' 'SUnit-Support-UITesting' 'Coverage');
 				group: 'Tests' with: #('SUnit-Tests' 'SUnit-Support-UITesting-Tests' 'SUnit-Visitor-Tests');
 				group: 'Help' with: #('SUnit-Help');
 				group: 'JenkinsSupport' with: #('JenkinsTools-Core' 'JenkinsTools-ExtraReports');

--- a/src/Coverage/CoverageCollector.class.st
+++ b/src/Coverage/CoverageCollector.class.st
@@ -1,14 +1,20 @@
 "
 I represent a code coverage session.
 
-Here is a quick usage
+My instances can track the execution of methods and nodes and collects which are covered by execution and which are not.
+
+Currently, compiled methods and sequences of statements (bodies of methods and block) can be tracked.
+This is a compromise between efficency and precision that is good enough precition to track covered paths.
+
+Here is a quick usage:
 
 ```
-| coverage result |
-coverage := CoverageCollector new. ""Instantiate""
-coverage methods: collectionOfCompiledMethods. ""Configure with the methods to watch.""
-result := coverage runOn: [ some. code ]. ""Setup, execute and teardown.""
-result percentage. ""Inspect the results""
+| collector coverage |
+collector := CoverageCollector new. ""Instantiate""
+collector methods: Point methods, Rectangle methods.  ""Configure with the methods to watch.""
+coverage := collector runOn: [ (1@1 corner: 2@2) center ].  ""Setup, execute and teardown.""
+(coverage methods includes: Point>>#x) >>> true.  ""Inspect the results""
+(coverage nodes size > 10) >>> true. ""Covered paths are also available""
 ```
 
 The `CoverageCollector>>#runOn:` methods is a high level method.
@@ -24,8 +30,7 @@ It calls the following fine grained methods in order:
 Note: if `uninstall` is not called, some instrumentation may leaks.
 You can use the global `CoverageCollector class>>#uninstallAll` to remove all instrumentation if needed.
 
-
-
+Warning: because of the instrumentation, new instances of `CompiledMethod` can be created to replace existing one during the coverage computation. This means that the identity of method objects returned by expression like `Point>>#x` could be not reliable and that `=` and related methods may not behave as you expect if you use lower level methods.
 "
 Class {
 	#name : #CoverageCollector,
@@ -52,13 +57,13 @@ CoverageCollector class >> uninstalAll [
 { #category : #basic }
 CoverageCollector >> basicCollectResult [
 
-	"Collect the results nut does not reset the annotations."
+	"Collect the results but does not reset the annotations."
 
 	| res |
 	res := CoverageResult new.
 	res collector: self.
 	res methods: (methods select: [ :m | m ast hasBeenExecuted ]).
-	res nodes: Set new.
+	res nodes: IdentitySet new.
 	nodes do: [ :node | 
 			node hasBeenExecuted ifTrue: [ res nodes add: node ] ].
 
@@ -68,7 +73,7 @@ CoverageCollector >> basicCollectResult [
 { #category : #basic }
 CoverageCollector >> basicRun: aBlock [
 
-"just run the block. We consider that the correct setup is done and that a teardown will be performed."
+	"Just run the block. We consider that the correct setup is done and that a teardown will be performed."
 
 	^ aBlock value
 ]
@@ -76,9 +81,11 @@ CoverageCollector >> basicRun: aBlock [
 { #category : #basic }
 CoverageCollector >> collectResult [
 
-	"Collect the results. This also resets the annotations."
+	"Collect the results.
+	This also remaps the methods and resets the annotations."
 
 	| res |
+	self remapMethods.
 	res := self basicCollectResult.
 	self reset.
 	^ res
@@ -90,8 +97,9 @@ CoverageCollector >> initialize [
 	metalink := MetaLink new
 		            selector: #tagExecuted;
 		            metaObject: #node.
-	methods := Set new.
-	nodes := Set new.
+	methods := IdentitySet new.
+	"Need IdentitySet here because we want to distinguish equivalent nodes."
+	nodes := IdentitySet new.
 ]
 
 { #category : #basic }
@@ -101,13 +109,13 @@ CoverageCollector >> install [
 	
 	Sequence nodes are also prepared. This enable a basic path coverage."
 
-	[ 
 	methods do: [ :meth | 
-		meth ast link: metalink.
 		meth ast nodesDo: [ :node | 
 			node isSequence ifTrue: [ 
 				node link: metalink.
-				nodes add: node ] ] ] ] valueUnpreemptively
+				nodes add: node ] ].
+		meth ast link: metalink.
+	 ]
 ]
 
 { #category : #running }
@@ -139,6 +147,7 @@ CoverageCollector >> methods: anObject [
 
 { #category : #accessing }
 CoverageCollector >> nodes [
+
 	^ nodes
 ]
 
@@ -151,6 +160,13 @@ CoverageCollector >> printOn: aStream [
 		print: methods size;
 		nextPutAll: ' nodes: ';
 		print: nodes size
+]
+
+{ #category : #private }
+CoverageCollector >> remapMethods [
+
+	"Because of metalinks, CompiledMethods can by recompiled, so this method is called to updates the list of methods with the 'current' list of methods."
+	^ methods := methods collect: [ :m | m classBinding value >> m selector ]
 ]
 
 { #category : #initialization }
@@ -181,7 +197,7 @@ CoverageCollector >> uninstall [
 
 	"Remove the instrumentation.
 	
-	Use `runOn:` or `installOn:` that automatically call `uninstall`"
+	Use `runOn:` or `installOn:` that automatically ensures that `uninstall` is called."
 
 	metalink uninstall
 ]

--- a/src/Coverage/CoverageCollector.class.st
+++ b/src/Coverage/CoverageCollector.class.st
@@ -1,0 +1,187 @@
+"
+I represent a code coverage session.
+
+Here is a quick usage
+
+```
+| coverage result |
+coverage := CoverageCollector new. ""Instantiate""
+coverage methods: collectionOfCompiledMethods. ""Configure with the methods to watch.""
+result := coverage runOn: [ some. code ]. ""Setup, execute and teardown.""
+result percentage. ""Inspect the results""
+```
+
+The `CoverageCollector>>#runOn:` methods is a high level method.
+It calls the following fine grained methods in order:
+
+* `CoverageCollector>>#install` to instrument the preselected methods
+* `CoverageCollector>>#installOn:` to instrument the preselected methods ensuring `uninstall` is performed.
+* `CoverageCollector>>#basicRun:` to watch the execution of a block.
+* `CoverageCollector>>#uninstall` to remove the instrumentation on methods.
+* `CoverageCollector>>#collectResult` to build and return a `CoverageResult` instance.
+* `CoverageCollector>>#reset` to clear the annotation on executed methods.
+
+Note: if `uninstall` is not called, some instrumentation may leaks.
+You can use the global `CoverageCollector class>>#uninstallAll` to remove all instrumentation if needed.
+
+
+
+"
+Class {
+	#name : #CoverageCollector,
+	#superclass : #Object,
+	#instVars : [
+		'metalink',
+		'methods',
+		'nodes'
+	],
+	#category : #'Coverage-Base'
+}
+
+{ #category : #installation }
+CoverageCollector class >> uninstalAll [
+
+	"If for some reason metalinks are not removed, force a full image cleaning"
+
+	<script>
+	MetaLink allInstancesDo: [ :each | 
+		(each selector == #tagExecuted and: [ each metaObject == #node ]) 
+			ifTrue: [ each uninstall ] ]
+]
+
+{ #category : #basic }
+CoverageCollector >> basicCollectResult [
+
+	"Collect the results nut does not reset the annotations."
+
+	| res |
+	res := CoverageResult new.
+	res collector: self.
+	res methods: (methods select: [ :m | m ast hasBeenExecuted ]).
+	res nodes: Set new.
+	nodes do: [ :node | 
+			node hasBeenExecuted ifTrue: [ res nodes add: node ] ].
+
+	^ res
+]
+
+{ #category : #basic }
+CoverageCollector >> basicRun: aBlock [
+
+"just run the block. We consider that the correct setup is done and that a teardown will be performed."
+
+	^ aBlock value
+]
+
+{ #category : #basic }
+CoverageCollector >> collectResult [
+
+	"Collect the results. This also resets the annotations."
+
+	| res |
+	res := self basicCollectResult.
+	self reset.
+	^ res
+]
+
+{ #category : #initialization }
+CoverageCollector >> initialize [
+
+	metalink := MetaLink new
+		            selector: #tagExecuted;
+		            metaObject: #node.
+	methods := Set new.
+	nodes := Set new.
+]
+
+{ #category : #basic }
+CoverageCollector >> install [
+
+	"Prepare the metalink. This can be slow.
+	
+	Sequence nodes are also prepared. This enable a basic path coverage."
+
+	[ 
+	methods do: [ :meth | 
+		meth ast link: metalink.
+		meth ast nodesDo: [ :node | 
+			node isSequence ifTrue: [ 
+				node link: metalink.
+				nodes add: node ] ] ] ] valueUnpreemptively
+]
+
+{ #category : #running }
+CoverageCollector >> installOn: aBlock [
+
+	"just run a block, with installation and uninstallation."
+
+	self install.
+	aBlock ensure: [ self uninstall ].
+]
+
+{ #category : #accessing }
+CoverageCollector >> metalink [
+
+	^ metalink
+]
+
+{ #category : #accessing }
+CoverageCollector >> methods [
+
+	^ methods
+]
+
+{ #category : #accessing }
+CoverageCollector >> methods: anObject [
+
+	methods := anObject
+]
+
+{ #category : #accessing }
+CoverageCollector >> nodes [
+	^ nodes
+]
+
+{ #category : #printing }
+CoverageCollector >> printOn: aStream [
+
+	super printOn: aStream.
+	aStream
+		nextPutAll: ' methods: ';
+		print: methods size;
+		nextPutAll: ' nodes: ';
+		print: nodes size
+]
+
+{ #category : #initialization }
+CoverageCollector >> reset [
+
+	"Cleanup the annotations, metalinks remain installed.
+	You should call if before you measure something."
+
+	methods do: [ :meth | meth ast removeProperty: #tagExecuted ifAbsent: [ ] ].
+	nodes do: [ :each | each removeProperty: #tagExecuted ifAbsent: [ ] ].
+]
+
+{ #category : #running }
+CoverageCollector >> runOn: aBlock [
+
+	"Fully run self, with installation, execution and uninstallation.
+	
+	Returns a CoverageResult."
+
+	self installOn: [
+		self reset.
+		self basicRun: aBlock ].
+	^ self collectResult
+]
+
+{ #category : #basic }
+CoverageCollector >> uninstall [
+
+	"Remove the instrumentation.
+	
+	Use `runOn:` or `installOn:` that automatically call `uninstall`"
+
+	metalink uninstall
+]

--- a/src/Coverage/CoverageCollectorTest.class.st
+++ b/src/Coverage/CoverageCollectorTest.class.st
@@ -5,6 +5,51 @@ Class {
 }
 
 { #category : #example }
+CoverageCollectorTest >> methodCallMethods [
+
+	self methodEmpty.
+	self methodOnlyReturn.
+	self methodTwoPaths: true.
+	self methodManyBlocks
+]
+
+{ #category : #example }
+CoverageCollectorTest >> methodEmpty [
+]
+
+{ #category : #example }
+CoverageCollectorTest >> methodManyBlocks [
+
+	| i |
+	i := 5.
+	[ 1. i > 0 ] whileTrue: [ 2. i := i - 1 ].
+	[ 3. i > 0 ] whileTrue: [ "not called" 4. i := i - 1 ].
+	{ 0. 1 } collect: [ :j |
+		| block |
+		{ 0. 1 } do: [ :x | 6. x ].
+		{ } do: [ :x | "not called" 7. x ].
+		block := [ 8. ].
+		block value.
+		block := [ ].
+		block value.
+		block := [ "not called" 9. ].
+		block := [ ] "not called".
+		j ]
+]
+
+{ #category : #example }
+CoverageCollectorTest >> methodNotCalled [
+	
+	^ 'Not expected to be called'
+]
+
+{ #category : #example }
+CoverageCollectorTest >> methodOnlyReturn [
+
+	^1
+]
+
+{ #category : #example }
 CoverageCollectorTest >> methodTwoPaths: aBoolean [
 
 	aBoolean ifTrue: [ 1 ].
@@ -17,13 +62,22 @@ CoverageCollectorTest >> testBasicCoverage [
 
 	| cov res |
 	cov := CoverageCollector new.
-	cov methods add: Rectangle>>#width.
-	cov methods add: Rectangle>>#area.
-	cov methods add: Rectangle>>#intersect:.
+	cov methods: { Rectangle>>#width. Rectangle>>#area. Rectangle>>#intersect: }.
 	res := cov runOn: [ (1@1 corner: 2@2) area ].
 	self assert: cov metalink hasNodes not. "metaliks where removed"
-	self assert: res methods size equals: 2.
-	self assert: res uncoveredMethods size equals: 1.
+	self assert: res methods asSet equals: {Rectangle>>#width. Rectangle>>#area} asSet.
+	self assert: res uncoveredMethods asArray equals: { Rectangle>>#intersect: }
+]
+
+{ #category : #tests }
+CoverageCollectorTest >> testExaple [
+
+	| collector coverage |
+	collector := CoverageCollector new. "Instantiate"
+	collector methods: Point methods, Rectangle methods.  "Configure with the methods to watch."	
+	coverage := collector runOn: [ (1@1 corner: 2@2) center ].  "Setup, execute and teardown."
+	self assert: (coverage methods includes: Point>>#x).  "Inspect the results"
+	self assert: (coverage nodes size > 10). "Covered paths are also available"
 ]
 
 { #category : #tests }
@@ -69,6 +123,24 @@ CoverageCollectorTest >> testNodeCoverage [
 	self assert: res percentage asInteger equals: 100.
 	self assert: res uncoveredNodes size equals: 0.
 
+]
+
+{ #category : #tests }
+CoverageCollectorTest >> testNodeCoverage2 [
+
+	| cov res |
+	cov := CoverageCollector new.
+	cov methods: (self class methods select: [ :m | 'method*' match: m selector ]).
+
+	res := cov runOn: [ self methodCallMethods ].
+	self assert: cov metalink hasNodes not. "metaliks where removed"
+	self assert: cov methods size equals: 6.
+	self assert: cov nodes size equals: 20.
+
+	self assert: res methods size equals: 5.
+	self assert: res nodes size equals: 14.
+	self assert: (cov nodes includesAll: res nodes).
+	self assert: res uncoveredNodes size equals: 6.
 ]
 
 { #category : #tests }

--- a/src/Coverage/CoverageCollectorTest.class.st
+++ b/src/Coverage/CoverageCollectorTest.class.st
@@ -1,0 +1,82 @@
+Class {
+	#name : #CoverageCollectorTest,
+	#superclass : #TestCase,
+	#category : #'Coverage-Tests'
+}
+
+{ #category : #example }
+CoverageCollectorTest >> methodTwoPaths: aBoolean [
+
+	aBoolean ifTrue: [ 1 ].
+	aBoolean ifTrue: [ ^2 ] ifFalse: [ 3 ].
+	^4.
+]
+
+{ #category : #tests }
+CoverageCollectorTest >> testBasicCoverage [
+
+	| cov res |
+	cov := CoverageCollector new.
+	cov methods add: Rectangle>>#width.
+	cov methods add: Rectangle>>#area.
+	cov methods add: Rectangle>>#intersect:.
+	res := cov runOn: [ (1@1 corner: 2@2) area ].
+	self assert: cov metalink hasNodes not. "metaliks where removed"
+	self assert: res methods size equals: 2.
+	self assert: res uncoveredMethods size equals: 1.
+]
+
+{ #category : #tests }
+CoverageCollectorTest >> testNoCoverage [
+
+	| cov res |
+	cov := CoverageCollector new.
+	cov methods add: Rectangle>>#closeTo:.
+	res := cov runOn: [ (1@1 corner: 2@2) area ].
+	self assert: res methods size equals: 0.
+	self assert: res percentage equals: 0.
+]
+
+{ #category : #tests }
+CoverageCollectorTest >> testNodeCoverage [
+
+	| cov res |
+	cov := CoverageCollector new.
+	cov methods add: self class>>#methodTwoPaths:.
+
+	res := cov runOn: [ self methodTwoPaths: false. self methodTwoPaths: false. ].
+	self assert: cov metalink hasNodes not. "metaliks where removed"
+	self assert: cov methods size equals: 1.
+	self assert: cov nodes size equals: 4.
+
+	self assert: res methods size equals: 1.
+	self assert: res nodes size equals: 2.
+	self assert: (cov nodes includesAll: res nodes).
+	self assert: res percentage asInteger equals: 50.
+	self assert: res uncoveredNodes size equals: 2.
+	
+	res := cov runOn: [ self methodTwoPaths: true. self methodTwoPaths: true. ].
+	self assert: (cov nodes includesAll: res nodes).
+	self assert: res methods size equals: 1.
+	self assert: res nodes size equals: 3.
+	self assert: res percentage asInteger equals: 75.
+	self assert: res uncoveredNodes size equals: 1.
+
+	res := cov runOn: [ self methodTwoPaths: true. self methodTwoPaths: false. ].
+	self assert: (cov nodes includesAll: res nodes).
+	self assert: res methods size equals: 1.
+	self assert: res nodes size equals: 4.
+	self assert: res percentage asInteger equals: 100.
+	self assert: res uncoveredNodes size equals: 0.
+
+]
+
+{ #category : #tests }
+CoverageCollectorTest >> testNothingToCover [
+
+	| cov res |
+	cov := CoverageCollector new.
+	res := cov runOn: [ (1@1 corner: 2@2) area ].
+	self assert: res methods size equals: 0.
+	self assert: res percentage isNaN.
+]

--- a/src/Coverage/CoverageResult.class.st
+++ b/src/Coverage/CoverageResult.class.st
@@ -29,6 +29,39 @@ CoverageResult >> collector: anObject [
 	collector := anObject
 ]
 
+{ #category : #computation }
+CoverageResult >> crown [
+
+	| uncoveredMethods uncoveredSelectors crown |
+	uncoveredMethods := collector methods difference: methods.
+	self assert:
+		uncoveredMethods size + methods size = collector methods size.
+
+	uncoveredSelectors := uncoveredMethods
+		                      collect: [ :each | each selector ]
+		                      as: Set.
+
+	crown := Dictionary new.
+
+	methods do: [ :m | 
+		m sendNodes do: [ :n | 
+			| selector |
+			selector := n selector.
+			(uncoveredSelectors includes: selector) ifTrue: [ 
+				| c |
+				c := crown at: selector ifAbsentPut: [ 
+					     | nc |
+					     nc := Crown new.
+					     nc selector: selector.
+					     uncoveredMethods
+						     select: [ :x | x selector = selector ]
+						     thenDo: [ :x | nc callees add: x ].
+					     nc ].
+				c callers add: n ] ] ].
+
+	^ crown
+]
+
 { #category : #accessing }
 CoverageResult >> methods [
 

--- a/src/Coverage/CoverageResult.class.st
+++ b/src/Coverage/CoverageResult.class.st
@@ -96,8 +96,6 @@ CoverageResult >> percentage [
 { #category : #printing }
 CoverageResult >> printOn: aStream [
 
-	"Append a sequence of characters to aStream that identify the receiver."
-
 	super printOn: aStream.
 	aStream
 		nextPutAll: ' methods: ';

--- a/src/Coverage/CoverageResult.class.st
+++ b/src/Coverage/CoverageResult.class.st
@@ -1,0 +1,92 @@
+"
+I represents the result of a code coverage measure.
+
+My instances are produced by `CoverageCollector>>#collectResult`.
+They contains the set of covered methods and sequence nodes.
+
+The original CoverageCollector is known so that usfull information (like `CoverageResult>>#percentage`) can be computed.
+"
+Class {
+	#name : #CoverageResult,
+	#superclass : #Object,
+	#instVars : [
+		'collector',
+		'methods',
+		'nodes'
+	],
+	#category : #'Coverage-Base'
+}
+
+{ #category : #accessing }
+CoverageResult >> collector [
+
+	^ collector
+]
+
+{ #category : #accessing }
+CoverageResult >> collector: anObject [
+
+	collector := anObject
+]
+
+{ #category : #accessing }
+CoverageResult >> methods [
+
+	^ methods
+]
+
+{ #category : #accessing }
+CoverageResult >> methods: anObject [
+
+	methods := anObject
+]
+
+{ #category : #accessing }
+CoverageResult >> nodes [
+
+	^ nodes
+]
+
+{ #category : #accessing }
+CoverageResult >> nodes: anObject [
+
+	nodes := anObject
+]
+
+{ #category : #computation }
+CoverageResult >> percentage [
+
+	collector nodes isEmpty ifTrue: [ ^ Float nan ].
+	^ 100.0 * nodes size / collector nodes size
+]
+
+{ #category : #printing }
+CoverageResult >> printOn: aStream [
+
+	"Append a sequence of characters to aStream that identify the receiver."
+
+	super printOn: aStream.
+	aStream
+		nextPutAll: ' methods: ';
+		print: methods size;
+		nextPutAll: ' (';
+		print: ((100.0 * methods size / collector methods size) rounded) ;
+		nextPutAll: '%) nodes: ';
+		print: nodes size;
+		nextPutAll: ' (';
+		print: ((100.0 * nodes size / collector nodes size) rounded) ;
+		nextPutAll: '%)'
+
+]
+
+{ #category : #computation }
+CoverageResult >> uncoveredMethods [
+
+	^ collector methods \ methods
+]
+
+{ #category : #computation }
+CoverageResult >> uncoveredNodes [
+
+	^ collector nodes \ nodes
+]

--- a/src/Coverage/Crown.class.st
+++ b/src/Coverage/Crown.class.st
@@ -36,8 +36,6 @@ Crown >> initialize [
 { #category : #printing }
 Crown >> printOn: aStream [
 
-	"Append a sequence of characters to aStream that identify the receiver."
-
 	super printOn: aStream.
 	aStream print: selector.
 	aStream

--- a/src/Coverage/Crown.class.st
+++ b/src/Coverage/Crown.class.st
@@ -1,0 +1,62 @@
+"
+I represent an not fully visided selector in a core result.
+
+For a given `selector`, I associate callers that are call sites (`RBSendNode`) in covered methods to callees that are uncovered methods (`CompiledMethod`).
+"
+Class {
+	#name : #Crown,
+	#superclass : #Object,
+	#instVars : [
+		'selector',
+		'callees',
+		'callers'
+	],
+	#category : #'Coverage-Base'
+}
+
+{ #category : #accessing }
+Crown >> callees [
+
+	^ callees
+]
+
+{ #category : #accessing }
+Crown >> callers [
+
+	^ callers
+]
+
+{ #category : #initialization }
+Crown >> initialize [
+
+	callees := OrderedCollection new.
+	callers := OrderedCollection new
+]
+
+{ #category : #printing }
+Crown >> printOn: aStream [
+
+	"Append a sequence of characters to aStream that identify the receiver."
+
+	super printOn: aStream.
+	aStream print: selector.
+	aStream
+		nextPutAll: ' callers: ';
+		print: callers size.
+	aStream
+		nextPutAll: ' callees: ';
+		print: callees size.
+
+]
+
+{ #category : #accessing }
+Crown >> selector [
+
+	^ selector
+]
+
+{ #category : #accessing }
+Crown >> selector: anObject [
+
+	selector := anObject
+]

--- a/src/Coverage/ManifestCoverage.class.st
+++ b/src/Coverage/ManifestCoverage.class.st
@@ -1,0 +1,10 @@
+"
+High level API to manage code coverage in Pharo.
+
+See class `CoverageCollector` for details.
+"
+Class {
+	#name : #ManifestCoverage,
+	#superclass : #PackageManifest,
+	#category : #'Coverage-Manifest'
+}

--- a/src/Coverage/package.st
+++ b/src/Coverage/package.st
@@ -1,0 +1,1 @@
+Package { #name : #Coverage }

--- a/src/DrTests-TestCoverage/DTTestCoveragePlugin.class.st
+++ b/src/DrTests-TestCoverage/DTTestCoveragePlugin.class.st
@@ -7,8 +7,7 @@ Class {
 	#superclass : #DrTestsPlugin,
 	#instVars : [
 		'methods',
-		'testClasses',
-		'link'
+		'testClasses'
 	],
 	#category : #'DrTests-TestCoverage'
 }
@@ -47,9 +46,6 @@ DTTestCoveragePlugin >> defineData: aDTpluginConfiguration [
 	methods := methods reject: [ :meth | meth isSubclassResponsibility ].
 	testClasses := aDTpluginConfiguration packagesSelected flatCollect: [ 
 		               :p | p classes ].
-	link := MetaLink new
-		        selector: #tagExecuted;
-		        metaObject: #node
 ]
 
 { #category : #accessing }
@@ -75,21 +71,19 @@ DTTestCoveragePlugin >> resultButtonHelp [
 
 { #category : #api }
 DTTestCoveragePlugin >> runForConfiguration: aDTpluginConfiguration [
-	| suite notExecuted result |
+	| suite collector coverage notExecuted result |
 	result := self pluginResultClass new.
 	self defineData: aDTpluginConfiguration.
 	suite := self suiteFor: testClasses.
-	[ methods do: [ :meth | meth ast link: link ].
-	[ self runTestSuites: {suite} ]
-		ensure: [ link uninstall ] ] valueUnpreemptively.
-	notExecuted := methods reject: [ :each | each ast hasBeenExecuted ].
+	collector := CoverageCollector new.
+	collector methods: methods.
+	coverage := collector runOn: [ self runTestSuites: {suite} ].
+	notExecuted := coverage uncoveredMethods.
 	notExecuted isEmpty
 		ifTrue: [ result percent: 1s2 ]
 		ifFalse: [ result
 				percent: 1s2 - (notExecuted size / methods size asScaledDecimal: 2);
-				methodList: notExecuted ].	"cleanup the annotations"
-	methods
-		do: [ :each | each ast removeProperty: #tagExecuted ifAbsent: [  ] ].
+				methodList: notExecuted ].
 	^ result
 ]
 

--- a/src/SUnit-UI/TestRunner.class.st
+++ b/src/SUnit-UI/TestRunner.class.st
@@ -387,29 +387,23 @@ TestRunner >> classesSearchFrame [
 
 { #category : #actions }
 TestRunner >> collectCoverageFor: methods [
-	| suite link notExecuted |
+	| suite coverage collector notExecuted |
 	suite := self
 		resetResult;
 		suiteForAllSelected.
 	
-	link := MetaLink new
-		selector: #tagExecuted;
-		metaObject: #node.
-	
-	[ methods do: [ :meth | meth ast link: link].
-	[ self runSuite: suite ] ensure: [ link uninstall ] ] valueUnpreemptively.
+	collector := CoverageCollector new.
+	collector methods: methods.
+	coverage := collector runOn: [ self runSuite: suite ].
 
-	notExecuted := methods reject: [:each | each ast hasBeenExecuted].
+	notExecuted := coverage uncoveredMethods.
 	notExecuted isEmpty 
 		ifTrue:  [ UIManager default inform: 'Congratulations. Your tests cover all code under analysis.' ]
 		ifFalse: [ 
 			Smalltalk tools messageList 
 				browse: notExecuted
 				title: 'Not Covered Code (' , (100 - (100 * notExecuted size // methods size)) printString , '% Code Coverage)'].
-	
-	"cleanup the annotations"
-	methods do: [ :each | each ast removeProperty: #tagExecuted ifAbsent: [ ] ].
-	
+		
 	self saveResultInHistory
 ]
 


### PR DESCRIPTION
I propose an independent package that offers a simple API to compute code coverage and to deal with low-level stuff.
While it uses metalink internally, the user is not directly exposed to it.

Currently, compiled methods and sequences of statements (bodies of methods and block) can be tracked.
This is a compromise between efficiency and precision that is good enough precision to track covered paths.

Here is a quick usage:

```st
| collector coverage |
collector := CoverageCollector new. "Instantiate"
collector methods: Point methods, Rectangle methods.  "Configure with the methods to watch."
coverage := collector runOn: [ (1@1 corner: 2@2) center ].  "Setup, execute and teardown."
(coverage methods includes: Point>>#x) >>> true.  "Inspect the results"
(coverage nodes size > 10) >>> true. "Covered paths are also available"
```

Existing usage of metalinks in SUnit and DrTest are also updated to use this new package instead.
