### PR TITLE
fix OSWIndowDriver shutdown while saving

### DIFF
--- a/src/Morphic-Core/AbstractWorldRenderer.class.st
+++ b/src/Morphic-Core/AbstractWorldRenderer.class.st
@@ -140,10 +140,11 @@ AbstractWorldRenderer class >> priority [
 { #category : #'system startup' }
 AbstractWorldRenderer class >> shutDown: quitting [
 
+	MainWorldRenderer ifNotNil: [ :aRenderer | 
+		aRenderer shutDown: quitting ]. 
+	
 	quitting ifFalse: [ ^ self ].
-
-	[ MainWorldRenderer ifNotNil: [ :e | e deactivate ] ] ensure: [ 
-		MainWorldRenderer := nil ]
+	MainWorldRenderer := nil
 ]
 
 { #category : #profiling }
@@ -156,7 +157,9 @@ AbstractWorldRenderer class >> startProfilingRenderingTime [
 { #category : #'system startup' }
 AbstractWorldRenderer class >> startUp: isANewSession [
 
-	isANewSession ifTrue: [ MainWorldRenderer := nil ]
+	isANewSession ifTrue: [ MainWorldRenderer := nil ].
+	MainWorldRenderer ifNotNil: [ 
+		MainWorldRenderer startUp: isANewSession ]
 ]
 
 { #category : #profiling }
@@ -324,6 +327,17 @@ AbstractWorldRenderer >> restoreMorphicDisplay [
 	world defer: [Cursor normal show].
 		
 	world layoutChanged.
+]
+
+{ #category : #'system startup' }
+AbstractWorldRenderer >> shutDown: quitting [
+
+	quitting ifTrue: [ self deactivate ]
+]
+
+{ #category : #'system startup' }
+AbstractWorldRenderer >> startUp: resuming [ 
+
 ]
 
 { #category : #rendering }

--- a/src/OSWindow-Core/OSWindowDriver.class.st
+++ b/src/OSWindow-Core/OSWindowDriver.class.st
@@ -92,11 +92,13 @@ You will need to restart the image to make this changes take effect.';
 
 { #category : #'system startup' }
 OSWindowDriver class >> shutDown: quitting [
+
 	quitting ifFalse: [ ^ self ].
+
 	Current ifNil: [ ^ self ].
 
 	"Clean driver"
-	Current shutDown.
+	Current shutDown: quitting.
 	Current := nil.
 	
 	"clean OSWindow worlds"
@@ -127,6 +129,10 @@ OSWindowDriver >> isNullDriver [
 ]
 
 { #category : #'system startup' }
-OSWindowDriver >> shutDown [
-	"A hook to perform cleanups when shuting down a driver"
+OSWindowDriver >> shutDown: quitting [
+]
+
+{ #category : #'system startup' }
+OSWindowDriver >> startUp: resuming [
+
 ]

--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -93,7 +93,6 @@ OSWorldRenderer >> deferUpdatesDuring: aBlock [
 
 { #category : #private }
 OSWorldRenderer >> doActivate [
-
 	| attributes initialExtent |
 	
 	initialExtent := world worldState realWindowExtent ifNil: [976@665].
@@ -113,7 +112,8 @@ OSWorldRenderer >> doActivate [
 	osWindow := OSWindow createWithAttributes: attributes eventHandler: (OSWindowMorphicEventHandler for: world).
 	
 	driver afterMainPharoWindowCreated: osWindow.
-	driver afterSetWindowTitle: Smalltalk image imageFile fullName onWindow: osWindow.
+	driver afterSetWindowTitle: Smalltalk image imageFile fullName onWindow: osWindow.	
+	driver startUp: true.
 		
 	osWindow focus. 
 	
@@ -230,6 +230,23 @@ OSWorldRenderer >> requestTextEditingAt: aRectangle [
 OSWorldRenderer >> screenScaleFactor [
 
 	^ world scaleFactor * self windowScaleFactor
+]
+
+{ #category : #'system startup' }
+OSWorldRenderer >> shutDown: quitting [
+
+	super shutDown: quitting.
+	driver ifNotNil: [ 
+		driver shutDown: quitting ]	
+	
+]
+
+{ #category : #'system startup' }
+OSWorldRenderer >> startUp: resuming [
+
+	super startUp: resuming.
+	driver ifNotNil: [ 
+		driver startUp: resuming ]
 ]
 
 { #category : #operations }

--- a/src/OSWindow-SDL2/OSSDL2Driver.class.st
+++ b/src/OSWindow-SDL2/OSSDL2Driver.class.st
@@ -231,8 +231,7 @@ OSSDL2Driver >> initialize [
 "		initVideo;
 		initJoystick;
 		initGameController;
-"		initEverything.
-	self setupEventLoop.
+"		initEverything
 ]
 
 { #category : #'window creation and deletion' }
@@ -361,19 +360,24 @@ OSSDL2Driver >> setGLAttributes: glAttributes [
 
 { #category : #'events-processing' }
 OSSDL2Driver >> setupEventLoop [
+
 	EventLoopProcess ifNotNil: [ 
-		EventLoopProcess isTerminating ifFalse: [EventLoopProcess terminate. EventLoopProcess := nil] ].
-	EventLoopProcess := self class isVMDisplayUsingSDL2 ifTrue: [ 
-		[ self eventLoopProcessWithVMWindow ] 
-		forkAt: Processor lowIOPriority
-	] ifFalse: [ 
-		self class hasPlugin ifTrue: [ 
-			[ self eventLoopProcessWithPlugin ] 
-			forkAt: Processor lowIOPriority ]
+		EventLoopProcess isTerminating ifFalse: [ 
+			EventLoopProcess terminate. 
+			EventLoopProcess := nil ] ].
+	
+	EventLoopProcess := self class isVMDisplayUsingSDL2 
+		ifTrue: [ 
+			[ self eventLoopProcessWithVMWindow ] 
+			forkAt: Processor lowIOPriority ] 
 		ifFalse: [ 
-			[ self eventLoopProcessWithoutPlugin ] 
-			forkAt: Processor lowIOPriority ].
-	].
+			self class hasPlugin 
+				ifTrue: [ 
+					[ self eventLoopProcessWithPlugin ] 
+					forkAt: Processor lowIOPriority ]
+				ifFalse: [ 
+					[ self eventLoopProcessWithoutPlugin ] 
+					forkAt: Processor lowIOPriority ] ].
 
 	EventLoopProcess
 		name: 'SDL2 Event loop';
@@ -381,13 +385,29 @@ OSSDL2Driver >> setupEventLoop [
 ]
 
 { #category : #'system startup' }
-OSSDL2Driver >> shutDown [
+OSSDL2Driver >> shutDown: quitting [
 	"Reset WindowMap and JoystickMap when shuting down (otherwise there will be handlers 
 	 remaining on restart)"
 
-	WindowMap := nil.
-	JoystickMap := nil.
-	EventLoopProcess ifNotNil: [ EventLoopProcess terminate ].
+	quitting ifTrue: [ 
+		WindowMap := nil.
+		JoystickMap := nil ].
+
+	self shutdownEventLoop
+]
+
+{ #category : #'events-processing' }
+OSSDL2Driver >> shutdownEventLoop [
+
+	EventLoopProcess ifNil: [ ^ self ].
+	EventLoopProcess terminate.
+	EventLoopProcess := nil
+]
+
+{ #category : #'system startup' }
+OSSDL2Driver >> startUp: resuming [
+
+	self setupEventLoop
 ]
 
 { #category : #'global events' }


### PR DESCRIPTION
the event loop needs to be stopped while saving the image, otherwise reopening the image after save (and not quit) will keep the event loop running, even when in non-interactive mode.