### PR TITLE
Change extract method shortcut to `cmd e, cmd m`

### DIFF
--- a/src/SystemCommands-SourceCodeCommands/SycExtractMethodCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycExtractMethodCommand.class.st
@@ -23,7 +23,7 @@ SycExtractMethodCommand class >> canBeExecutedInContext: aSourceCodeContext [
 SycExtractMethodCommand class >> methodEditorShortcutActivation [
 	<classAnnotation>
 	
-	^CmdShortcutActivation by: $g meta shift for: ClySourceCodeContext
+	^CmdShortcutActivation by: $e meta, $m meta for: ClySourceCodeContext
 ]
 
 { #category : #converting }


### PR DESCRIPTION
Closes: #11836 