### PR TITLE
Closes #11817. The class creation text suggestion in Calypso now uses the current cl…

### DIFF
--- a/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
@@ -94,7 +94,7 @@ OCUndeclaredVariableWarning >> defineClass: className [
 	classSymbol := className asSymbol.
 	systemCategory := self methodClass category
 		ifNil: [ 'Unknown' ].
-	classDefinition := ClassDefinitionPrinter new classDefinitionTemplateInPackage: '' forClass: classSymbol.
+	classDefinition := ClassDefinitionPrinter new classDefinitionTemplateInPackage: systemCategory forClass: classSymbol.
 	classDefinition := UIManager default 
 		multiLineRequest: 'Edit class definition:'
 		initialAnswer: classDefinition


### PR DESCRIPTION
...class package instead of an empy String. Closes #11817
Now the new class suggestion text template suggests as package the current class package instead as an empty String.