### PR TITLE
fixing OCBcToASTCache so that `pcsForNode:` gives the bytecode offsets associated to a node, in the ascending order

### DIFF
--- a/src/OpalCompiler-Core/OCBytecodeToASTCache.class.st
+++ b/src/OpalCompiler-Core/OCBytecodeToASTCache.class.st
@@ -126,5 +126,5 @@ OCBytecodeToASTCache >> nodeForPC: pc [
 { #category : #astAndAstMapping }
 OCBytecodeToASTCache >> pcsForNode: aNode [
 
-	^ (bcToASTMap keys select: [ :key | (bcToASTMap at: key) == aNode ]) asOrderedCollection
+	^ (bcToASTMap keys select: [ :key | (bcToASTMap at: key) == aNode ]) asOrderedCollection sorted
 ]

--- a/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
@@ -175,6 +175,8 @@ OCBytecodeToASTCacheTest >> testPcsForNode [
 
 	pcsForAimedNode do: [ :pc | 
 		self assert: (cache nodeForPC: pc) identicalTo: aimedNode ].
+	
+	self assert: pcsForAimedNode isSorted.
 
 	(cache bcToASTMap keys reject: [ :value | 
 		 pcsForAimedNode includes: value ]) do: [ :pc | 


### PR DESCRIPTION
Fixes #11845 .

When using `OCBcToASTCache>>#firstBcOffsetForNode:`, it did not return the first bytecode offset associated to a node, because `OCBcToASTCache>>#pcsForNode:` did not return the associated pcs in the ascending order.

I simply fixed it so that `pcsForNode:` returns the associated pcs to a node in the ascending order