### PR TITLE
Transition deprecate method refactoring to use driver

### DIFF
--- a/src/Refactoring-Core/RBApplicabilityChecksFailedError.class.st
+++ b/src/Refactoring-Core/RBApplicabilityChecksFailedError.class.st
@@ -1,0 +1,8 @@
+"
+I represent an Error that is signaled when applicability checks are not met.
+"
+Class {
+	#name : #RBApplicabilityChecksFailedError,
+	#superclass : #Error,
+	#category : #'Refactoring-Core-Support'
+}

--- a/src/Refactoring-Core/RBBreakingChangeChecksFailedWarning.class.st
+++ b/src/Refactoring-Core/RBBreakingChangeChecksFailedWarning.class.st
@@ -1,0 +1,8 @@
+"
+I represent a Warning that is signaled when breaking change checks are not met.
+"
+Class {
+	#name : #RBBreakingChangeChecksFailedWarning,
+	#superclass : #Notification,
+	#category : #'Refactoring-Core-Support'
+}

--- a/src/Refactoring-Core/RBDeprecateMethodDriver.class.st
+++ b/src/Refactoring-Core/RBDeprecateMethodDriver.class.st
@@ -55,10 +55,6 @@ RBDeprecateMethodDriver >> getMethodThatWillReplaceDeprecatedMethod [
 		               title: 'New selector'.
 	newSelector isEmptyOrNil | (newSelector = methodToDeprecate) ifTrue: [ 
 		CmdCommandAborted signal ].
-	(methodToDeprecate numArgs = newSelector numArgs or: [ 
-		 newSelector numArgs = 0 ]) ifFalse: [ 
-		RBRefactoringFailure signal:
-			'The new selectors should have the same number of arguments as the old one, or not have them at all' ].
 	^ newSelector
 ]
 

--- a/src/Refactoring-Core/RBDeprecateMethodDriver.class.st
+++ b/src/Refactoring-Core/RBDeprecateMethodDriver.class.st
@@ -54,7 +54,7 @@ RBDeprecateMethodDriver >> getMethodThatWillReplaceDeprecatedMethod [
 		               initialAnswer: methodToDeprecate
 		               title: 'New selector'.
 	newSelector isEmptyOrNil | (newSelector = methodToDeprecate) ifTrue: [ 
-		CmdCommandAborted signal ].
+		RBRefactoringFailure signal: 'New selector should not be empty OR same as current selector.' ].
 	^ newSelector
 ]
 

--- a/src/Refactoring-Core/RBDeprecateMethodDriver.class.st
+++ b/src/Refactoring-Core/RBDeprecateMethodDriver.class.st
@@ -1,0 +1,58 @@
+"
+I represent a driver that invokes `DeprecateMethod` refactoring.
+
+I am responsible for asking user which selector will replace deprecated method and validating if selected selector can be used.
+When I gather all needed information I am calling and executing deprecate method refactoring.
+
+You can create my instance and execute the refactoring by running:
+
+```
+(RBDeprecateMethodDriver model: aRBNamespace deprecateMethod: aSelector in: aClass) execute
+```
+"
+Class {
+	#name : #RBDeprecateMethodDriver,
+	#superclass : #RBDriver,
+	#instVars : [
+		'methodToDeprecate',
+		'methodToReplaceDeprecatedMethod',
+		'refactoring'
+	],
+	#category : #'Refactoring-Core-UI'
+}
+
+{ #category : #'instance creation' }
+RBDeprecateMethodDriver class >> model: aRBNamespace deprecateMethod: aString in: aClass [
+
+	^ self new model: aRBNamespace deprecateMethod: aString in: aClass
+]
+
+{ #category : #accessing }
+RBDeprecateMethodDriver >> getMethodThatWillReplaceDeprecatedMethod [
+
+	| newSelector |
+	newSelector := UIManager default
+		               request: 'Method to replace ' , methodToDeprecate
+		               initialAnswer: methodToDeprecate
+		               title: 'New selector'.
+	newSelector isEmptyOrNil | (newSelector = methodToDeprecate) ifTrue: [ 
+		CmdCommandAborted signal ].
+	(methodToDeprecate numArgs = newSelector numArgs or: [ 
+		 newSelector numArgs = 0 ]) ifFalse: [ 
+		RBRefactoringFailure signal:
+			'The new selectors should have the same number of arguments as the old one, or not have them at all' ].
+	^ newSelector
+]
+
+{ #category : #initialization }
+RBDeprecateMethodDriver >> model: aRBNamespace deprecateMethod: aSelector in: aClass [
+
+	methodToDeprecate := aSelector.
+	methodToReplaceDeprecatedMethod := self getMethodThatWillReplaceDeprecatedMethod.
+
+	refactoring := RBDeprecateMethodRefactoring
+		               model: aRBNamespace
+		               deprecateMethod: aSelector
+		               in: aClass
+		               using: methodToReplaceDeprecatedMethod
+]

--- a/src/Refactoring-Core/RBDeprecateMethodDriver.class.st
+++ b/src/Refactoring-Core/RBDeprecateMethodDriver.class.st
@@ -27,7 +27,7 @@ RBDeprecateMethodDriver class >> model: aRBNamespace deprecateMethod: aString in
 	^ self new model: aRBNamespace deprecateMethod: aString in: aClass
 ]
 
-{ #category : #accessing }
+{ #category : #'ui - requests' }
 RBDeprecateMethodDriver >> getMethodThatWillReplaceDeprecatedMethod [
 
 	| newSelector |

--- a/src/Refactoring-Core/RBDeprecateMethodDriver.class.st
+++ b/src/Refactoring-Core/RBDeprecateMethodDriver.class.st
@@ -27,6 +27,24 @@ RBDeprecateMethodDriver class >> model: aRBNamespace deprecateMethod: aString in
 	^ self new model: aRBNamespace deprecateMethod: aString in: aClass
 ]
 
+{ #category : #execution }
+RBDeprecateMethodDriver >> execute [
+
+	| changes |
+	changes := [ 
+	           [ refactoring generateChanges ]
+		           on: RBApplicabilityChecksFailedError
+		           do: [ :err | 
+		           ^ RBRefactoringFailure signal: err messageText ] ]
+		           on: RBBreakingChangeChecksFailedWarning
+		           do: [ :err | 
+			           RBRefactoringWarning signal: err messageText.
+			           "If user answers no, error is being propagated."
+			           err resume ].
+	self flag: #TODO. "preview changes and confirm before executing"
+	refactoring performChanges
+]
+
 { #category : #'ui - requests' }
 RBDeprecateMethodDriver >> getMethodThatWillReplaceDeprecatedMethod [
 

--- a/src/Refactoring-Core/RBDeprecateMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBDeprecateMethodRefactoring.class.st
@@ -67,6 +67,18 @@ RBDeprecateMethodRefactoring class >> model: aRBSmalltalk deprecateMethod: aSele
 		yourself
 ]
 
+{ #category : #preconditions }
+RBDeprecateMethodRefactoring >> applicabilityConditions [
+
+	^ RBCondition definesSelector: oldSelector in: class
+]
+
+{ #category : #preconditions }
+RBDeprecateMethodRefactoring >> breakingChangeConditions [
+
+	^ RBCondition canUnderstand: newSelector in: class
+]
+
 { #category : #transforming }
 RBDeprecateMethodRefactoring >> callDeprecationMethod [
 
@@ -76,7 +88,7 @@ RBDeprecateMethodRefactoring >> callDeprecationMethod [
 		in: ''' , SystemVersion current imageVersionString , ''''
 ]
 
-{ #category : #preconditions }
+{ #category : #initialization }
 RBDeprecateMethodRefactoring >> deprecateMethod: aSelector in: aClass using: newSel [
 	oldSelector := aSelector asSymbol.
 	newSelector := newSel asSymbol.
@@ -86,11 +98,7 @@ RBDeprecateMethodRefactoring >> deprecateMethod: aSelector in: aClass using: new
 { #category : #preconditions }
 RBDeprecateMethodRefactoring >> preconditions [
 
-	^ (RBCondition definesSelector: oldSelector in: class) 
-		& (RBCondition canUnderstand: newSelector in: class)
-		& (RBCondition 
-							withBlock: [oldSelector numArgs = newSelector numArgs or: [ newSelector numArgs = 0 ]]
-							errorString: 'The new selectors should have the same number of arguments as the old one, or not have them at all').
+	^ self applicabilityConditions & self breakingChangeConditions
 ]
 
 { #category : #printing }

--- a/src/Refactoring-Core/RBDeprecateMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBDeprecateMethodRefactoring.class.st
@@ -95,6 +95,20 @@ RBDeprecateMethodRefactoring >> deprecateMethod: aSelector in: aClass using: new
 	class := self classObjectFor: aClass.
 ]
 
+{ #category : #execution }
+RBDeprecateMethodRefactoring >> generateChanges [
+
+	self applicabilityConditions check ifFalse: [ 
+		^ RBApplicabilityChecksFailedError signal:
+			  self applicabilityConditions errorString ].
+	self breakingChangeConditions check ifFalse: [ 
+		RBBreakingChangeChecksFailedWarning signal:
+			self breakingChangeConditions errorString ].
+
+	self transform.
+	^ self changes
+]
+
 { #category : #preconditions }
 RBDeprecateMethodRefactoring >> preconditions [
 

--- a/src/Refactoring-Core/RBDeprecateMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBDeprecateMethodRefactoring.class.st
@@ -76,7 +76,12 @@ RBDeprecateMethodRefactoring >> applicabilityConditions [
 { #category : #preconditions }
 RBDeprecateMethodRefactoring >> breakingChangeConditions [
 
-	^ RBCondition canUnderstand: newSelector in: class
+	^ (RBCondition canUnderstand: newSelector in: class) & (RBCondition
+		   withBlock: [ 
+			   oldSelector numArgs = newSelector numArgs or: [ 
+				   newSelector numArgs = 0 ] ]
+		   errorString:
+		   'The new selectors should have the same number of arguments as the old one, or not have them at all')
 ]
 
 { #category : #transforming }

--- a/src/Refactoring-Core/RBDriver.class.st
+++ b/src/Refactoring-Core/RBDriver.class.st
@@ -28,42 +28,8 @@ RBDriver class >> isAbstract [
 	^ self == RBDriver
 ]
 
-{ #category : #preconditions }
-RBDriver >> checkApplicability [
-
-	^ self subclassResponsibility
-]
-
-{ #category : #preconditions }
-RBDriver >> checkBreakingChanges [
-
-	^ self subclassResponsibility
-]
-
-{ #category : #preconditions }
-RBDriver >> confirmBreakingChanges [
-
-	self subclassResponsibility
-]
-
 { #category : #execution }
 RBDriver >> execute [
-
-	self checkApplicability ifFalse: [ 
-		^ self refactoringError ].
-	self checkBreakingChanges ifFalse: [
-		"Open warning dialog. It throws an error if user answers No."
-		self confirmBreakingChanges ].
-	self executeRefactoring
-]
-
-{ #category : #execution }
-RBDriver >> executeRefactoring [
-	self subclassResponsibility
-]
-
-{ #category : #error }
-RBDriver >> refactoringError [
-
-	self subclassResponsibility
+	
+	self subclassResponsibility 
 ]

--- a/src/Refactoring-Core/RBMoveMethodToClassSideRefactoring.class.st
+++ b/src/Refactoring-Core/RBMoveMethodToClassSideRefactoring.class.st
@@ -58,7 +58,7 @@ RBMoveMethodToClassSideRefactoring >> addMethod: rbMethod to: aClass toProtocol:
 ]
 
 { #category : #preconditions }
-RBMoveMethodToClassSideRefactoring >> applicabilityPreconditions [
+RBMoveMethodToClassSideRefactoring >> applicabilityConditions [
 
 	^ (RBCondition isMetaclass: class) not
 ]
@@ -133,7 +133,7 @@ RBMoveMethodToClassSideRefactoring >> parseTree [
 { #category : #preconditions }
 RBMoveMethodToClassSideRefactoring >> preconditions [
 
-	^ self applicabilityPreconditions & self breakingChangeConditions 
+	^ self applicabilityConditions & self breakingChangeConditions 
 ]
 
 { #category : #transforming }

--- a/src/Refactoring-Core/RBMoveMethodsToClassSideDriver.class.st
+++ b/src/Refactoring-Core/RBMoveMethodsToClassSideDriver.class.st
@@ -35,7 +35,7 @@ RBMoveMethodsToClassSideDriver >> checkApplicability [
 
 	| checks |
 	checks := self refactorings collect: [ :each | 
-		          each applicabilityPreconditions check ].
+		          each applicabilityConditions check ].
 	^ checks reduce: [ :a :b | a & b ]
 ]
 
@@ -96,9 +96,9 @@ RBMoveMethodsToClassSideDriver >> refactoringError [
 
 	| errorStrings |
 	errorStrings := self refactorings
-		                reject: [ :each | each applicabilityPreconditions check ]
+		                reject: [ :each | each applicabilityConditions check ]
 		                thenCollect: [ :each | 
-		                each applicabilityPreconditions errorString ].
+		                each applicabilityConditions errorString ].
 	errorStrings := String streamContents: [ :stream | 
 		                errorStrings
 			                do: [ :str | stream << str ]

--- a/src/Refactoring-Core/RBMoveMethodsToClassSideDriver.class.st
+++ b/src/Refactoring-Core/RBMoveMethodsToClassSideDriver.class.st
@@ -2,15 +2,14 @@
 I represent a driver that invokes `MoveToClassSide` refactoring.
 
 I implement methods from parent class and define some helper methods that are needed to execute `MoveToClassSide` refactoring:
-- `prepareFullExecution` - retrieve all selected methods from context
-- `generateRefactorings` - creating `MoveToClassSide` refactorings for each of the methods
+- `generateRefactorings` - creating `MoveToClassSide` refactorings for each of the selected methods
 - checking preconditions and breaking changes
 - executing the refactoring
 
 You can create my instance and execute the refactoring by running:
 
 ```
-(RBMoveMethodsToClassSideDriver withContext: context) execute
+(RBMoveMethodsToClassSideDriver model: aRBNamespace methods: aCollectionOfMethods) execute
 ```
 "
 Class {
@@ -67,7 +66,16 @@ RBMoveMethodsToClassSideDriver >> confirmBreakingChanges [
 ]
 
 { #category : #execution }
-RBMoveMethodsToClassSideDriver >> executeRefactoring [
+RBMoveMethodsToClassSideDriver >> execute [
+
+	self checkApplicability ifFalse: [ self refactoringError ].
+	self checkBreakingChanges ifFalse: [ "Open warning dialog. It throws an error if user answers No." 
+		self confirmBreakingChanges ].
+	self executeRefactorings
+]
+
+{ #category : #execution }
+RBMoveMethodsToClassSideDriver >> executeRefactorings [
 
 	refactorings do: [ :each | 
 		each transform.

--- a/src/SystemCommands-MessageCommands/SycDeprecateMessageCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycDeprecateMessageCommand.class.st
@@ -9,9 +9,6 @@ Internal Representation and Key Implementation Points.
 Class {
 	#name : #SycDeprecateMessageCommand,
 	#superclass : #SycChangeMessageSignatureCommand,
-	#instVars : [
-		'newSelector'
-	],
 	#category : #'SystemCommands-MessageCommands'
 }
 
@@ -26,29 +23,29 @@ SycDeprecateMessageCommand class >> canBeExecutedInContext: aToolContext [
 ]
 
 { #category : #execution }
-SycDeprecateMessageCommand >> createRefactoring [
-
-	^ RBDeprecateMethodRefactoring
-		model: model 
-		deprecateMethod: originalMessage selector  
-		in: originalMessage contextUser origin
-		using: newSelector
+SycDeprecateMessageCommand >> applyResultInContext: aContext [
+	
 ]
 
 { #category : #accessing }
 SycDeprecateMessageCommand >> defaultMenuItemName [
-	^'Deprecate'
+
+	^ 'Deprecate'
 ]
 
 { #category : #execution }
-SycDeprecateMessageCommand >> prepareFullExecutionInContext: aToolContext [
-	| oldSelector |
-	super prepareFullExecutionInContext: aToolContext.
-	
-	oldSelector := originalMessage selector.
-	newSelector := UIManager default 
-		request: 'Method to replace ', oldSelector  
-		initialAnswer: oldSelector
-		title: 'New selector'.
-	newSelector isEmptyOrNil | (newSelector = oldSelector) ifTrue: [ CmdCommandAborted signal ]
+SycDeprecateMessageCommand >> execute [
+
+	(RBDeprecateMethodDriver
+		 model: model
+		 deprecateMethod: originalMessage selector
+		 in: originalMessage contextUser origin) execute
+]
+
+{ #category : #testing }
+SycDeprecateMessageCommand >> isComplexRefactoring [ 
+	"We need to override this to prevent `RBRefactoringPreviewPresenter` from opening (See `CmdCommand >> execute` for details.) 
+	We want this command to call the appropriate Driver that will execute refactoring."
+
+	^ false
 ]


### PR DESCRIPTION
This PR transitions _deprecate method_ refactoring to use driver object.
Some UI code was successfully moved from refactoring and from command to the driver.
The _deprecate method_ refactoring also introduces new API for retrieving changes and performing them.

TODO:
* show a preview of refactoring changes before performing them
* transition _move to class side_ refactoring to the new API