### PR TITLE
#instVarNamed: does not need to send #asSymbol to the name

### DIFF
--- a/src/Kernel/AbstractLayoutScope.class.st
+++ b/src/Kernel/AbstractLayoutScope.class.st
@@ -130,7 +130,7 @@ AbstractLayoutScope >> resolveSlot: aName [
 { #category : #accessing }
 AbstractLayoutScope >> resolveSlot: aName ifFound: foundBlock ifNone: exceptionBlock [
 	self allSlotsDo: [ :slot | 
-		slot name == aName ifTrue: [ ^ foundBlock cull: slot ]].
+		slot name = aName ifTrue: [ ^ foundBlock cull: slot ]].
 	^ exceptionBlock value
 ]
 

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -1127,7 +1127,7 @@ ClassDescription >> slotNamed: aName ifFound: foundBlock [
 
 { #category : #slots }
 ClassDescription >> slotNamed: aName ifFound: foundBlock ifNone: exceptionBlock [
-	^self classLayout resolveSlot: aName asSymbol ifFound: foundBlock ifNone: exceptionBlock
+	^self classLayout resolveSlot: aName ifFound: foundBlock ifNone: exceptionBlock
 ]
 
 { #category : #slots }

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1082,14 +1082,14 @@ Object >> instVarAt: index put: anObject [
 ]
 
 { #category : #introspection }
-Object >> instVarNamed: aString [
+Object >> instVarNamed: aStringOrSymbol [
 	"Return the value of the instance variable in me with that name.  Slow, but very useful.
 	We support here all slots (even non indexed) but raise a backward compatible exception"
 
 	^ self class
-		slotNamed: aString
+		slotNamed: aStringOrSymbol
 		ifFound: [ :slot | slot read: self ]
-		ifNone: [ InstanceVariableNotFound signalFor: aString asString ]
+		ifNone: [ InstanceVariableNotFound signalFor: aStringOrSymbol asString ]
 ]
 
 { #category : #introspection }

--- a/src/Ring-Core/RGPointerLayout.class.st
+++ b/src/Ring-Core/RGPointerLayout.class.st
@@ -116,7 +116,7 @@ RGPointerLayout >> removeSlot: anRGSlot [
 RGPointerLayout >> resolveSlot: aName ifFound: foundBlock ifNone: noneBlock [
 
 	self allSlots do: [ :slot | 
-		slot name == aName ifTrue: [ ^ foundBlock cull: slot ] ].
+		slot name = aName ifTrue: [ ^ foundBlock cull: slot ] ].
 	^ noneBlock value
 ]
 


### PR DESCRIPTION
ClassDescription>>#slotNamed:ifFound:ifNone:  converts the String to a symbol.

This was needed as AbstractLayoutScope>>#resolveSlot:ifFound:ifNone: was checking for identity.  

If we use #= there, we do not need to convert the string to a symbol.