### PR TITLE
11842-Context-menu-on-class-variables-opens-debug-menu

### DIFF
--- a/src/ClassParser/CDSharedVariableNode.class.st
+++ b/src/ClassParser/CDSharedVariableNode.class.st
@@ -30,6 +30,14 @@ CDSharedVariableNode >> isClassVariable [
 ]
 
 { #category : #testing }
+CDSharedVariableNode >> isGlobalClassNameBinding [
+	"To be polymorphic to RB method nodes. This is a bit odd as this is just called due to 
+	#binding returning self, normally this should be called on LiteralVariable"
+	
+	^false
+]
+
+{ #category : #testing }
 CDSharedVariableNode >> isInstanceVariable [
 	"To be polymorphic to RB method nodes"
 	^false


### PR DESCRIPTION
add back the method, add a comment why it is implemented here

fixes #11842