### PR TITLE
Coverage: add static callgraphes

### DIFF
--- a/src/Coverage/CoverageCollector.class.st
+++ b/src/Coverage/CoverageCollector.class.st
@@ -38,7 +38,8 @@ Class {
 	#instVars : [
 		'metalink',
 		'methods',
-		'nodes'
+		'nodes',
+		'edges'
 	],
 	#category : #'Coverage-Base'
 }
@@ -98,8 +99,20 @@ CoverageCollector >> initialize [
 		            selector: #tagExecuted;
 		            metaObject: #node.
 	methods := IdentitySet new.
-	"Need IdentitySet here because we want to distinguish equivalent nodes."
+
+]
+
+{ #category : #initialization }
+CoverageCollector >> initializeNodes [
+
+	"Visit methods and collect their sequence nodes"
+
 	nodes := IdentitySet new.
+	methods do: [ :meth | 
+		meth ast nodesDo: [ :node | 
+			node isSequence ifTrue: [ 
+				nodes add: node ] ] ].
+	^ nodes.
 ]
 
 { #category : #basic }
@@ -110,12 +123,14 @@ CoverageCollector >> install [
 	Sequence nodes are also prepared. This enable a basic path coverage."
 
 	methods do: [ :meth | 
-		meth ast nodesDo: [ :node | 
-			node isSequence ifTrue: [ 
-				node link: metalink.
-				nodes add: node ] ].
 		meth ast link: metalink.
-	 ]
+	].
+
+	nodes ifNil: [ self initializeNodes ].
+	nodes do: [ :node | 
+		self assert: node isSequence.
+		node link: metalink.
+	].
 ]
 
 { #category : #running }

--- a/src/Coverage/CoverageCollector.class.st
+++ b/src/Coverage/CoverageCollector.class.st
@@ -79,6 +79,31 @@ CoverageCollector >> basicRun: aBlock [
 	^ aBlock value
 ]
 
+{ #category : #callgraph }
+CoverageCollector >> callgraph [
+
+	"Compute and return directed `edges` that connect nodes together.
+	
+	 The vertices of this static call graph are the sequence nodes (the main sequence of each methods + nested syntactic blocks) and the edges are direct block nesting and message sends:
+	 * a sequence is connected to each of its (directly) nested sequences;
+	 * a sequence with a message send is connected to the main sequence of all methods with the same selector.
+
+	 Note that only the `nodes` from the `methods`	are considered, so the resulting graph may not be connected.
+
+	 The result is a collection of pairs (arrays of 2 elements). The first element is the *source* node, the second element is the *destination* node.
+	 This representation is therefore usable with algorithms of `AI-Algorithms-Graph` for instance."
+
+	| visitor |
+	visitor := SequenceGraphVisitor new.
+	visitor collector: self.
+	
+	nodes ifNil: [ self initializeNodes ].
+
+	nodes do: [ :node | node acceptVisitor: visitor ].
+
+	^ edges := visitor edges.
+]
+
 { #category : #basic }
 CoverageCollector >> collectResult [
 
@@ -90,6 +115,11 @@ CoverageCollector >> collectResult [
 	res := self basicCollectResult.
 	self reset.
 	^ res
+]
+
+{ #category : #accessing }
+CoverageCollector >> edges [
+	^ edges
 ]
 
 { #category : #initialization }

--- a/src/Coverage/CoverageCollector.class.st
+++ b/src/Coverage/CoverageCollector.class.st
@@ -190,6 +190,73 @@ CoverageCollector >> methods: anObject [
 	methods := anObject
 ]
 
+{ #category : #callgraph }
+CoverageCollector >> nodeDistances: aNodeOrMethod isBackward: isBackward [
+
+	"Simple BFS to discover the distance of reachble nodes from a staring node.
+	 Edges can be followed forward or backward."
+
+	| aNode todo result todoLater depth |
+	
+	aNode := (aNodeOrMethod isCompiledMethod or: [aNodeOrMethod class = ReflectiveMethod])
+		ifTrue: [ aNodeOrMethod ast body ]
+		ifFalse: [ aNodeOrMethod ].
+	
+	self assert: (nodes includes: aNode).
+	result := IdentityDictionary new.
+	todo := OrderedCollection new.
+	todoLater := OrderedCollection new.
+	todo add: aNode.
+	result at: aNode put: 0.
+	depth := 1.
+	[ todo isNotEmpty ] whileTrue: [
+		| tmp |
+		todo do: [ :n |
+			edges do:  [ :e |
+				| n1 n2 |
+				isBackward
+					ifTrue: [
+						n1 := e second.
+						n2 := e first. ]
+					ifFalse: [ 
+						n1 := e first.
+						n2 := e second. ].
+					
+				((n1 ~~ n) or: [result includesKey: n2]) ifFalse: [ 
+					todoLater add: n2.
+					result at: n2 put: depth.
+				 ]
+			 ]
+		 ].
+		depth := depth + 1.
+		tmp := todo.
+		todo := todoLater.
+		todoLater := tmp.
+		todoLater removeAll.
+	].
+	^ result.
+]
+
+{ #category : #callgraph }
+CoverageCollector >> nodeDistancesFrom: aNodeOrMethod [
+
+	"Compute the distance of each node that is reached by `aNodeOrMethod` (according to `callgraph`).
+	 Returns a dictionary Node->integer.
+	 Only nodes with a finite distance from `aNodeOrMethod` are present in the dictionary (including `aNode` itself with a distance of 0)."
+
+	^ self nodeDistances: aNodeOrMethod isBackward: false
+]
+
+{ #category : #callgraph }
+CoverageCollector >> nodeDistancesTo: aNodeOrMethod [
+
+	"Compute the distance of each node that can reach `aNodeOrMethod` (according to `callgraph`).
+	 Returns a dictionary Node->integer.
+	 Only nodes with a finite distance to `aNodeOrMethod` are present in the dictionary (including `aNode` itself with a distance of 0)."
+
+	^ self nodeDistances: aNodeOrMethod isBackward: true
+]
+
 { #category : #accessing }
 CoverageCollector >> nodes [
 

--- a/src/Coverage/CoverageCollectorTest.class.st
+++ b/src/Coverage/CoverageCollectorTest.class.st
@@ -70,7 +70,7 @@ CoverageCollectorTest >> testBasicCoverage [
 ]
 
 { #category : #tests }
-CoverageCollectorTest >> testExaple [
+CoverageCollectorTest >> testExample [
 
 	| collector coverage |
 	collector := CoverageCollector new. "Instantiate"

--- a/src/Coverage/CoverageCollectorTest.class.st
+++ b/src/Coverage/CoverageCollectorTest.class.st
@@ -14,6 +14,10 @@ CoverageCollectorTest >> methodCallMethods [
 ]
 
 { #category : #example }
+CoverageCollectorTest >> methodCallee [
+]
+
+{ #category : #example }
 CoverageCollectorTest >> methodEmpty [
 ]
 
@@ -28,19 +32,22 @@ CoverageCollectorTest >> methodManyBlocks [
 		| block |
 		{ 0. 1 } do: [ :x | 6. x ].
 		{ } do: [ :x | "not called" 7. x ].
-		block := [ 8. ].
+		block := [ 8. self methodCallee ].
 		block value.
 		block := [ ].
 		block value.
 		block := [ "not called" 9. ].
 		block := [ ] "not called".
+		self methodCallee.
 		j ]
 ]
 
 { #category : #example }
 CoverageCollectorTest >> methodNotCalled [
-	
-	^ 'Not expected to be called'
+
+	"Not expected to be called"
+
+	self methodCallee.
 ]
 
 { #category : #example }
@@ -67,6 +74,16 @@ CoverageCollectorTest >> testBasicCoverage [
 	self assert: cov metalink hasNodes not. "metaliks where removed"
 	self assert: res methods asSet equals: {Rectangle>>#width. Rectangle>>#area} asSet.
 	self assert: res uncoveredMethods asArray equals: { Rectangle>>#intersect: }
+]
+
+{ #category : #test }
+CoverageCollectorTest >> testCallgraph [
+
+	| cov graph |
+	cov := CoverageCollector new.
+	cov methods: (self class methods select: [ :m | 'method*' match: m selector ]).
+	graph := cov callgraph.
+	self assert: graph size equals: 21
 ]
 
 { #category : #tests }
@@ -134,13 +151,39 @@ CoverageCollectorTest >> testNodeCoverage2 [
 
 	res := cov runOn: [ self methodCallMethods ].
 	self assert: cov metalink hasNodes not. "metaliks where removed"
-	self assert: cov methods size equals: 6.
-	self assert: cov nodes size equals: 20.
+	self assert: cov methods size equals: 7.
+	self assert: cov nodes size equals: 21.
 
-	self assert: res methods size equals: 5.
-	self assert: res nodes size equals: 14.
+	self assert: res methods size equals: 6.
+	self assert: res nodes size equals: 15.
 	self assert: (cov nodes includesAll: res nodes).
 	self assert: res uncoveredNodes size equals: 6.
+]
+
+{ #category : #test }
+CoverageCollectorTest >> testNodeDistancesFrom [
+
+	| cov graph target distances |
+	cov := CoverageCollector new.
+	cov methods: (self class methods select: [ :m | 'method*' match: m selector ]).
+	graph := cov callgraph.
+		
+	target := (self class >> #methodManyBlocks) ast body.
+	distances := cov nodeDistancesFrom: target.
+	self assert: (distances values sorted) equals: { 0. 1. 1. 1. 1. 1. 2. 2. 2. 2. 2. 2. 2}.
+]
+
+{ #category : #test }
+CoverageCollectorTest >> testNodeDistancesTo [
+
+	| cov graph target distances |
+	cov := CoverageCollector new.
+	cov methods: (self class methods select: [ :m | 'method*' match: m selector ]).
+	graph := cov callgraph.
+		
+	target := (self class >> #methodCallee) ast body.
+	distances := cov nodeDistancesTo: target.
+	self assert: (distances values sorted) equals: { 0. 1. 1. 1. 2. 3}.
 ]
 
 { #category : #tests }

--- a/src/Coverage/SequenceGraphVisitor.class.st
+++ b/src/Coverage/SequenceGraphVisitor.class.st
@@ -1,0 +1,77 @@
+"
+A Pharo AST visitor used internally to compute the callgraph of nodes.
+
+See `CoverageCollector>>#callgraph` for details.
+"
+Class {
+	#name : #SequenceGraphVisitor,
+	#superclass : #RBProgramNodeVisitor,
+	#instVars : [
+		'edges',
+		'currentNode',
+		'collector'
+	],
+	#category : #'Coverage-Base'
+}
+
+{ #category : #accessing }
+SequenceGraphVisitor >> collector [
+
+	^ collector
+]
+
+{ #category : #accessing }
+SequenceGraphVisitor >> collector: anObject [
+
+	collector := anObject
+]
+
+{ #category : #accessing }
+SequenceGraphVisitor >> edges [
+
+	^ edges
+]
+
+{ #category : #accessing }
+SequenceGraphVisitor >> edges: anObject [
+
+	edges := anObject
+]
+
+{ #category : #initialization }
+SequenceGraphVisitor >> initialize [
+
+	edges := OrderedCollection new.
+]
+
+{ #category : #visiting }
+SequenceGraphVisitor >> visitMessageNode: aMessageNode [
+
+	"Visit recusively"
+	super visitMessageNode: aMessageNode.
+
+	"And add an adge to all "
+	collector methods
+		select: [ :m | m selector = aMessageNode selector ]
+		thenDo: [ :m |
+			| target |
+			target := m ast body.
+			self assert: target isSequence.
+			edges add: { currentNode. target }. ].
+
+]
+
+{ #category : #visiting }
+SequenceGraphVisitor >> visitSequenceNode: aSequenceNode [
+
+	"Dot not visit sub-sequences, just mark an edge"
+	currentNode ifNotNil: [
+		edges add: { currentNode. aSequenceNode }.
+		^ self ].
+	
+	currentNode := aSequenceNode.
+	super visitSequenceNode: aSequenceNode.
+	currentNode := nil.
+
+
+]


### PR DESCRIPTION
This extends the Coverage package with static call graphs related to nodes to cover.

It was mainly implemented for directed graybox fuzzing, but can be used and extended for other means.