### PR TITLE
Clean blocks simpler checks

### DIFF
--- a/src/Coverage/CoverageCollectorTest.class.st
+++ b/src/Coverage/CoverageCollectorTest.class.st
@@ -76,7 +76,7 @@ CoverageCollectorTest >> testBasicCoverage [
 	self assert: res uncoveredMethods asArray equals: { Rectangle>>#intersect: }
 ]
 
-{ #category : #test }
+{ #category : #tests }
 CoverageCollectorTest >> testCallgraph [
 
 	| cov graph |
@@ -160,7 +160,7 @@ CoverageCollectorTest >> testNodeCoverage2 [
 	self assert: res uncoveredNodes size equals: 6.
 ]
 
-{ #category : #test }
+{ #category : #tests }
 CoverageCollectorTest >> testNodeDistancesFrom [
 
 	| cov graph target distances |
@@ -173,7 +173,7 @@ CoverageCollectorTest >> testNodeDistancesFrom [
 	self assert: (distances values sorted) equals: { 0. 1. 1. 1. 1. 1. 2. 2. 2. 2. 2. 2. 2}.
 ]
 
-{ #category : #test }
+{ #category : #tests }
 CoverageCollectorTest >> testNodeDistancesTo [
 
 	| cov graph target distances |

--- a/src/Kernel/CleanBlockClosure.class.st
+++ b/src/Kernel/CleanBlockClosure.class.st
@@ -85,17 +85,20 @@ CleanBlockClosure >> outerCode: aCompiledCode [
 ]
 
 { #category : #scanning }
-CleanBlockClosure >> readsField: varIndex [ 
-	^self compiledBlock readsField: varIndex
+CleanBlockClosure >> readsField: varIndex [
+	"Clean blocks by definition do not read fields"
+	^false
 ]
 
 { #category : #scanning }
 CleanBlockClosure >> readsSelf [
-	^self compiledBlock readsSelf
+	"Clean blocks by definition do not access self"
+	^false
 ]
 
 { #category : #scanning }
 CleanBlockClosure >> readsThisContext [
+	"Clean blocks can access thisContext, we have to forward to the compiled block to check"
 	^self compiledBlock readsThisContext
 ]
 
@@ -122,10 +125,12 @@ CleanBlockClosure >> sendsAnySelectorOf: aCollection [
 
 { #category : #scanning }
 CleanBlockClosure >> sendsToSuper [
-	^self compiledBlock sendsToSuper
+	"Clean blocks by definition do not access super"
+	^false
 ]
 
 { #category : #scanning }
-CleanBlockClosure >> writesField: varIndex [ 
-	^self compiledBlock writesField: varIndex
+CleanBlockClosure >> writesField: varIndex [
+	"Clean blocks by definition do not read fields"
+	^false
 ]

--- a/src/Refactoring2-Transformations-Tests/RBMoveMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveMethodParametrizedTest.class.st
@@ -17,7 +17,7 @@ RBMoveMethodParametrizedTest >> constructor [
 	^ #selector:class:variable:
 ]
 
-{ #category : #test }
+{ #category : #tests }
 RBMoveMethodParametrizedTest >> testMoveMethodIntoArgument [
 	| refactoring class |
 	self proceedThroughWarning: 
@@ -53,7 +53,7 @@ RBMoveMethodParametrizedTest >> testMoveMethodIntoArgument [
 	self assert: (class parseTreeFor: #rewriteRule:) equals: (self parseMethod: 'rewriteRule: anObject rewriteRule := anObject')
 ]
 
-{ #category : #test }
+{ #category : #tests }
 RBMoveMethodParametrizedTest >> testMoveMethodIntoClass [
 	| refactoring class |
 	(model classFor: Object) compile: 'aTestMethodName ^ OrderedCollection new addAll: (1 to: 100); yourself' classified: #test.
@@ -76,7 +76,7 @@ RBMoveMethodParametrizedTest >> testMoveMethodIntoClass [
 		equals: (self parseMethod: 'oneToOneHundred ^ self new addAll: (1 to: 100); yourself')
 ]
 
-{ #category : #test }
+{ #category : #tests }
 RBMoveMethodParametrizedTest >> testMoveMethodIntoClassVariable [
 	| refactoring class |
 	self proceedThroughWarning: 
@@ -111,7 +111,7 @@ RBMoveMethodParametrizedTest >> testMoveMethodIntoClassVariable [
 	self assert: (class parseTreeFor: #rewriteRule:) equals: (self parseMethod: 'rewriteRule: anObject rewriteRule := anObject')
 ]
 
-{ #category : #test }
+{ #category : #tests }
 RBMoveMethodParametrizedTest >> testMoveMethodIntoInstanceVariable [
 	| refactoring class |
 	self proceedThroughWarning: 
@@ -146,7 +146,7 @@ RBMoveMethodParametrizedTest >> testMoveMethodIntoInstanceVariable [
 	self assert: (class parseTreeFor: #builder:) equals: (self parseMethod: 'builder: anObject builder := anObject')
 ]
 
-{ #category : #test }
+{ #category : #tests }
 RBMoveMethodParametrizedTest >> testMoveMethodThatReferencesPoolDictionary [
 	| refactoring class |
 	self proceedThroughWarning: 


### PR DESCRIPTION
simplify the checks on CleanBlockClosure about accessing self, super and ivars: by definition, a clean block does not access those