### PR TITLE
AST: add a recursive #hasNonLocalReturn and #isConstant

### DIFF
--- a/src/AST-Core-Tests/RBBlockNodeTest.class.st
+++ b/src/AST-Core-Tests/RBBlockNodeTest.class.st
@@ -5,10 +5,12 @@ Class {
 }
 
 { #category : #tests }
-RBBlockNodeTest >> testHasBlockReturnRecursive [
+RBBlockNodeTest >> testHasReturn [
 
 	self deny: [  ] sourceNode hasReturn.
 	self deny: [ [  ] ] sourceNode hasReturn.
 	self assert: [ ^ 1 ] sourceNode hasReturn.
-	self assert: [ [ ^ 1 ] ] sourceNode hasReturn
+	self assert: [ [ ^ 1 ] ] sourceNode hasReturn.
+	self assert: (self class>>#testHasReturn) ast hasReturn.
+	self deny: (Object>>#halt) ast hasReturn
 ]

--- a/src/AST-Core-Tests/RBBlockNodeTest.class.st
+++ b/src/AST-Core-Tests/RBBlockNodeTest.class.st
@@ -5,6 +5,14 @@ Class {
 }
 
 { #category : #tests }
+RBBlockNodeTest >> testConstantValue [
+
+	self assert: [  ] sourceNode constantValue equals: nil.
+	self assert: [ 1 ] sourceNode constantValue equals: 1.
+	self should: [[ ^1 ] sourceNode constantValue] raise: TestResult error
+]
+
+{ #category : #tests }
 RBBlockNodeTest >> testHasNonLocalReturn [
 
 	self deny: [  ] sourceNode hasNonLocalReturn.
@@ -15,4 +23,13 @@ RBBlockNodeTest >> testHasNonLocalReturn [
 	"return on the level of the method is a local return"
 	self deny: (Object>>#yourself) ast hasNonLocalReturn.
 	self deny: (Object>>#halt) ast hasNonLocalReturn
+]
+
+{ #category : #tests }
+RBBlockNodeTest >> testIsConstant [
+
+	self assert: [  ] sourceNode isConstant.
+	self assert: [ 1 ] sourceNode isConstant.
+	self deny: [ ^1 ] sourceNode isConstant.
+	self deny: [ 1 sin. 1 ] sourceNode isConstant
 ]

--- a/src/AST-Core-Tests/RBBlockNodeTest.class.st
+++ b/src/AST-Core-Tests/RBBlockNodeTest.class.st
@@ -1,0 +1,14 @@
+Class {
+	#name : #RBBlockNodeTest,
+	#superclass : #RBParseTreeTest,
+	#category : #'AST-Core-Tests-Nodes'
+}
+
+{ #category : #tests }
+RBBlockNodeTest >> testHasBlockReturnRecursive [
+
+	self deny: [  ] sourceNode hasReturn.
+	self deny: [ [  ] ] sourceNode hasReturn.
+	self assert: [ ^ 1 ] sourceNode hasReturn.
+	self assert: [ [ ^ 1 ] ] sourceNode hasReturn
+]

--- a/src/AST-Core-Tests/RBBlockNodeTest.class.st
+++ b/src/AST-Core-Tests/RBBlockNodeTest.class.st
@@ -5,12 +5,14 @@ Class {
 }
 
 { #category : #tests }
-RBBlockNodeTest >> testHasReturn [
+RBBlockNodeTest >> testHasNonLocalReturn [
 
-	self deny: [  ] sourceNode hasReturn.
-	self deny: [ [  ] ] sourceNode hasReturn.
-	self assert: [ ^ 1 ] sourceNode hasReturn.
-	self assert: [ [ ^ 1 ] ] sourceNode hasReturn.
-	self assert: (self class>>#testHasReturn) ast hasReturn.
-	self deny: (Object>>#halt) ast hasReturn
+	self deny: [  ] sourceNode hasNonLocalReturn.
+	self deny: [ [  ] ] sourceNode hasNonLocalReturn.
+	self assert: [ ^ 1 ] sourceNode hasNonLocalReturn.
+	self assert: [ [ ^ 1 ] ] sourceNode hasNonLocalReturn.
+	self assert: (self class>>#testHasNonLocalReturn) ast hasNonLocalReturn.
+	"return on the level of the method is a local return"
+	self deny: (Object>>#yourself) ast hasNonLocalReturn.
+	self deny: (Object>>#halt) ast hasNonLocalReturn
 ]

--- a/src/AST-Core/RBBlockNode.class.st
+++ b/src/AST-Core/RBBlockNode.class.st
@@ -140,6 +140,14 @@ RBBlockNode >> colons: anArray [
 	colons := anArray
 ]
 
+{ #category : #accessing }
+RBBlockNode >> constantValue [
+	self isConstant ifFalse: [ self error: 'block is not constant' ].
+	^ body statements 
+		ifEmpty: [ nil ] 
+		ifNotEmpty: [:statements | statements first value ]
+]
+
 { #category : #matching }
 RBBlockNode >> copyInContext: aDictionary [ 
 	^ self class new
@@ -224,6 +232,14 @@ RBBlockNode >> initialize [
 RBBlockNode >> isBlock [
 
 	^ true
+]
+
+{ #category : #testing }
+RBBlockNode >> isConstant [
+	"is the block just returning a literal?"	
+	^ body statements 
+		ifEmpty: [ true "empty block returns nil" ] 
+		ifNotEmpty: [:statements | statements first isLiteralNode ]
 ]
 
 { #category : #testing }

--- a/src/AST-Core/RBBlockNode.class.st
+++ b/src/AST-Core/RBBlockNode.class.st
@@ -188,12 +188,6 @@ RBBlockNode >> hasBlockReturn [
 ]
 
 { #category : #testing }
-RBBlockNode >> hasReturn [
-	self hasBlockReturn ifTrue: [ ^ true ].
-	^ super hasReturn
-]
-
-{ #category : #testing }
 RBBlockNode >> hasTemporaries [
 
 	^ self temporaries isNotEmpty

--- a/src/AST-Core/RBBlockNode.class.st
+++ b/src/AST-Core/RBBlockNode.class.st
@@ -188,6 +188,12 @@ RBBlockNode >> hasBlockReturn [
 ]
 
 { #category : #testing }
+RBBlockNode >> hasReturn [
+	self hasBlockReturn ifTrue: [ ^ true ].
+	^ super hasReturn
+]
+
+{ #category : #testing }
 RBBlockNode >> hasTemporaries [
 
 	^ self temporaries isNotEmpty

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -455,6 +455,12 @@ RBProgramNode >> hasProperty: aKey [
 	^ properties notNil and: [ properties includesKey: aKey ]
 ]
 
+{ #category : #testing }
+RBProgramNode >> hasReturn [
+	"check if there is a return anywhere"
+	^ self children anySatisfy: [ :child | child hasReturn ]
+]
+
 { #category : #comparing }
 RBProgramNode >> hashForCollection: aCollection [
 	^ aCollection isEmpty ifTrue: [ 0 ] ifFalse: [ aCollection first hash ]

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -448,17 +448,18 @@ RBProgramNode >> hasMultipleReturns [
 	^count > 1
 ]
 
+{ #category : #testing }
+RBProgramNode >> hasNonLocalReturn [
+	"check if there is a non-local return anywhere
+	Note: returns in a method itself are local returns"
+	^ self children anySatisfy: [ :child | child hasNonLocalReturn ]
+]
+
 { #category : #properties }
 RBProgramNode >> hasProperty: aKey [
 	"Test if the property aKey is present."
 	
 	^ properties notNil and: [ properties includesKey: aKey ]
-]
-
-{ #category : #testing }
-RBProgramNode >> hasReturn [
-	"check if there is a return anywhere"
-	^ self children anySatisfy: [ :child | child hasReturn ]
 ]
 
 { #category : #comparing }

--- a/src/AST-Core/RBSequenceNode.class.st
+++ b/src/AST-Core/RBSequenceNode.class.st
@@ -285,11 +285,12 @@ RBSequenceNode >> equalTo: anObject withMapping: aDictionary [
 ]
 
 { #category : #testing }
-RBSequenceNode >> hasReturn [
-
+RBSequenceNode >> hasNonLocalReturn [
+	"check if there is a non-local return anywhere
+	Note: returns in a method itself are local returns"
 	^ self lastIsReturn
-		  ifTrue: [ true ]
-		  ifFalse: [ super hasReturn ]
+		  ifTrue: [ parent isMethod not ]
+		  ifFalse: [ super hasNonLocalReturn ]
 ]
 
 { #category : #testing }

--- a/src/AST-Core/RBSequenceNode.class.st
+++ b/src/AST-Core/RBSequenceNode.class.st
@@ -285,6 +285,14 @@ RBSequenceNode >> equalTo: anObject withMapping: aDictionary [
 ]
 
 { #category : #testing }
+RBSequenceNode >> hasReturn [
+
+	^ self lastIsReturn
+		  ifTrue: [ true ]
+		  ifFalse: [ super hasReturn ]
+]
+
+{ #category : #testing }
 RBSequenceNode >> hasTemporaries [
 
 	^ temporaries isNotEmpty

--- a/src/OpalCompiler-Core/RBProgramNode.extension.st
+++ b/src/OpalCompiler-Core/RBProgramNode.extension.st
@@ -38,6 +38,11 @@ RBProgramNode >> doSemanticAnalysisIn: aClass [
 ]
 
 { #category : #'*OpalCompiler-Core' }
+RBProgramNode >> hasReturn [
+	^ self children anySatisfy: [ :child | child hasReturn ]
+]
+
+{ #category : #'*OpalCompiler-Core' }
 RBProgramNode >> irInstruction [
 	^ self methodOrBlockNode ir firstInstructionMatching: [:instr | instr sourceNode == self ]
 ]

--- a/src/OpalCompiler-Core/RBProgramNode.extension.st
+++ b/src/OpalCompiler-Core/RBProgramNode.extension.st
@@ -38,11 +38,6 @@ RBProgramNode >> doSemanticAnalysisIn: aClass [
 ]
 
 { #category : #'*OpalCompiler-Core' }
-RBProgramNode >> hasReturn [
-	^ self children anySatisfy: [ :child | child hasReturn ]
-]
-
-{ #category : #'*OpalCompiler-Core' }
 RBProgramNode >> irInstruction [
 	^ self methodOrBlockNode ir firstInstructionMatching: [:instr | instr sourceNode == self ]
 ]


### PR DESCRIPTION
This PR 

- adds a #hasNonLocalReturn method.It return true of there is a non-local return in the AST subtree This is mostly interesting to be called on a Block level: "does this block need a context to return or not?"
- add a #isConstant check for RBBlockNode. Blocks that just return a constant value can be optimized not only to be pre-compiled (as they are a special kind of clean), but we can even speed up execution (that is, implement a kind of block with a fast #value that returns the constant without the need to evaluate another method)
