### PR TITLE
CleanBlock cleanup code: there should be no receiver ivar

### DIFF
--- a/src/Kernel/CleanBlockClosure.class.st
+++ b/src/Kernel/CleanBlockClosure.class.st
@@ -23,10 +23,18 @@ Class {
 	#superclass : #BlockClosure,
 	#type : #variable,
 	#instVars : [
-		'receiver'
+		'ivarNeededByVMToBeChecked'
 	],
 	#category : #'Kernel-Methods'
 }
+
+{ #category : #accessing }
+CleanBlockClosure >> IvarNeededByVMToBeChecked [
+	"Clean blocks do not store a receiver, but it seems that the VM expects closures to have 4 ivars
+	We should check if we can fix that.
+	To see the problem: remove the var from CleanBlockClosure, enable the clean block option and recompile. Vm will crash"
+	^ivarNeededByVMToBeChecked
+]
 
 { #category : #printing }
 CleanBlockClosure >> doPrintOn: aStream [
@@ -101,7 +109,8 @@ CleanBlockClosure >> readsThisContext [
 
 { #category : #accessing }
 CleanBlockClosure >> receiver [
-	^ receiver
+	"Clean blocks do not know the receiver"
+	^ nil
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Clean blocks do not store a receiver, but it seems that the VM expects closures to have 4 ivars

We should check if we can fix that.
To see the problem: remove the var from CleanBlockCloure, enable the clean block option and recompile. Vm will crash