### PR TITLE
New refactoring changes preview presenter

### DIFF
--- a/src/Refactoring-Core/RBDeprecateMethodDriver.class.st
+++ b/src/Refactoring-Core/RBDeprecateMethodDriver.class.st
@@ -16,10 +16,18 @@ Class {
 	#instVars : [
 		'methodToDeprecate',
 		'methodToReplaceDeprecatedMethod',
-		'refactoring'
+		'refactoring',
+		'scopes',
+		'model'
 	],
 	#category : #'Refactoring-Core-UI'
 }
+
+{ #category : #'instance creation' }
+RBDeprecateMethodDriver class >> deprecateMethod: aString in: aClass scopes: aCollection [
+
+	^ self new deprecateMethod: aString in: aClass  scopes: aCollection
+]
 
 { #category : #'instance creation' }
 RBDeprecateMethodDriver class >> model: aRBNamespace deprecateMethod: aString in: aClass [
@@ -27,11 +35,26 @@ RBDeprecateMethodDriver class >> model: aRBNamespace deprecateMethod: aString in
 	^ self new model: aRBNamespace deprecateMethod: aString in: aClass
 ]
 
+{ #category : #initialization }
+RBDeprecateMethodDriver >> deprecateMethod: aSelector in: aClass scopes: aCollection [
+
+	methodToDeprecate := aSelector.
+	methodToReplaceDeprecatedMethod := self getMethodThatWillReplaceDeprecatedMethod.
+	scopes := aCollection.
+	model := self refactoringScopeOn: scopes first.
+
+	refactoring := RBDeprecateMethodRefactoring
+		               model: model
+		               deprecateMethod: aSelector
+		               in: aClass
+		               using: methodToReplaceDeprecatedMethod
+]
+
 { #category : #execution }
 RBDeprecateMethodDriver >> execute [
 
-	| changes |
-	changes := [ 
+	| compositeChange |
+	compositeChange := [ 
 	           [ refactoring generateChanges ]
 		           on: RBApplicabilityChecksFailedError
 		           do: [ :err | 
@@ -41,8 +64,11 @@ RBDeprecateMethodDriver >> execute [
 			           RBRefactoringWarning signal: err messageText.
 			           "If user answers no, error is being propagated."
 			           err resume ].
-	self flag: #TODO. "preview changes and confirm before executing"
-	refactoring performChanges
+
+	(RBRefactoringPreviewPresenter
+		 changes: compositeChange
+		 inEnvironment: model
+		 scopes: scopes) open
 ]
 
 { #category : #'ui - requests' }
@@ -69,4 +95,10 @@ RBDeprecateMethodDriver >> model: aRBNamespace deprecateMethod: aSelector in: aC
 		               deprecateMethod: aSelector
 		               in: aClass
 		               using: methodToReplaceDeprecatedMethod
+]
+
+{ #category : #utilities }
+RBDeprecateMethodDriver >> refactoringScopeOn: aScope [
+
+	^ RBClassModelFactory rbNamespace onEnvironment: aScope asRBEnvironment 
 ]

--- a/src/Refactoring-Core/RBDeprecateMethodDriver.class.st
+++ b/src/Refactoring-Core/RBDeprecateMethodDriver.class.st
@@ -29,12 +29,6 @@ RBDeprecateMethodDriver class >> deprecateMethod: aString in: aClass scopes: aCo
 	^ self new deprecateMethod: aString in: aClass  scopes: aCollection
 ]
 
-{ #category : #'instance creation' }
-RBDeprecateMethodDriver class >> model: aRBNamespace deprecateMethod: aString in: aClass [
-
-	^ self new model: aRBNamespace deprecateMethod: aString in: aClass
-]
-
 { #category : #initialization }
 RBDeprecateMethodDriver >> deprecateMethod: aSelector in: aClass scopes: aCollection [
 
@@ -82,19 +76,6 @@ RBDeprecateMethodDriver >> getMethodThatWillReplaceDeprecatedMethod [
 	newSelector isEmptyOrNil | (newSelector = methodToDeprecate) ifTrue: [ 
 		RBRefactoringFailure signal: 'New selector should not be empty OR same as current selector.' ].
 	^ newSelector
-]
-
-{ #category : #initialization }
-RBDeprecateMethodDriver >> model: aRBNamespace deprecateMethod: aSelector in: aClass [
-
-	methodToDeprecate := aSelector.
-	methodToReplaceDeprecatedMethod := self getMethodThatWillReplaceDeprecatedMethod.
-
-	refactoring := RBDeprecateMethodRefactoring
-		               model: aRBNamespace
-		               deprecateMethod: aSelector
-		               in: aClass
-		               using: methodToReplaceDeprecatedMethod
 ]
 
 { #category : #utilities }

--- a/src/Refactoring-Core/RBRefactoringPreviewPresenter.class.st
+++ b/src/Refactoring-Core/RBRefactoringPreviewPresenter.class.st
@@ -36,7 +36,7 @@ RBRefactoringPreviewPresenter class >> title [
 	^ 'Refactoring changes'
 ]
 
-{ #category : #controlling }
+{ #category : #action }
 RBRefactoringPreviewPresenter >> accept [
 
 	(self okToChange not or: [ selectedChanges isEmptyOrNil ]) ifTrue: [ 
@@ -70,7 +70,7 @@ RBRefactoringPreviewPresenter >> changesFrom: aCompositeChange inEnvironment: an
 	self updateTablePresenter
 ]
 
-{ #category : #'initialize-release' }
+{ #category : #action }
 RBRefactoringPreviewPresenter >> closeWindow [
 
 	self window close

--- a/src/Refactoring-Core/RBRefactoringPreviewPresenter.class.st
+++ b/src/Refactoring-Core/RBRefactoringPreviewPresenter.class.st
@@ -9,9 +9,14 @@ Class {
 	#superclass : #SpPresenter,
 	#instVars : [
 		'changes',
+		'changesInScope',
+		'selectedChanges',
+		'scopes',
+		'activeScope',
 		'table',
 		'diffPresenter',
-		'selectedChanges',
+		'scopeLabel',
+		'scopeDropList',
 		'buttonOk',
 		'buttonCancel'
 	],
@@ -19,10 +24,10 @@ Class {
 }
 
 { #category : #'instance creation' }
-RBRefactoringPreviewPresenter class >> changes: aCompositeRefactoring scope: scope [
+RBRefactoringPreviewPresenter class >> changes: aCompositeRefactoring inEnvironment: aRBNamespace scopes: scopes [
 
 	^ self new
-		  changesFrom: aCompositeRefactoring forEnvironment: scope;
+		  changesFrom: aCompositeRefactoring inEnvironment: aRBNamespace scopes: scopes;
 		  yourself
 ]
 
@@ -55,12 +60,13 @@ RBRefactoringPreviewPresenter >> buildDiffFor: aChange [
 		  rightText: aChange textToDisplay
 ]
 
-{ #category : #utilities }
-RBRefactoringPreviewPresenter >> changesFrom: aCompositeChange forEnvironment: anEnvironment [
+{ #category : #initialization }
+RBRefactoringPreviewPresenter >> changesFrom: aCompositeChange inEnvironment: anEnvironment scopes: aCollection [
 
-	changes := (aCompositeChange whatToDisplayIn: self) select: [ :change | 
-		           anEnvironment includesClass: change changeClass ].
-	selectedChanges := OrderedCollection withAll: changes.
+	changes := aCompositeChange whatToDisplayIn: self.
+	scopes := aCollection.
+	self updateScopeList.
+	self updateChanges.
 	self updateTablePresenter
 ]
 
@@ -90,6 +96,8 @@ RBRefactoringPreviewPresenter >> connectPresenters [
 	table whenSelectionChangedDo: [ :selection | 
 		selection selectedItem ifNotNil: [ 
 			self buildDiffFor: selection selectedItem ] ].
+	
+	scopeDropList whenSelectedItemChangedDo: [ :scope | self updateActiveScope; updateChanges ].
 
 	buttonCancel action: [ self closeWindow ].
 	buttonOk action: [ self accept ]
@@ -98,16 +106,33 @@ RBRefactoringPreviewPresenter >> connectPresenters [
 { #category : #initialization }
 RBRefactoringPreviewPresenter >> initializeLayout [
 
+	| scopesLayout actionsLayout |
+	scopesLayout := SpBoxLayout newLeftToRight
+		                add: scopeLabel
+		                withConstraints:
+			                [ :constraints | constraints width: 60 ] yourself;
+		                add: scopeDropList;
+		                yourself.
+	actionsLayout := SpBoxLayout newLeftToRight
+		                 addLast: buttonOk
+		                 expand: false
+		                 fill: true
+		                 padding: 5;
+		                 addLast: buttonCancel
+		                 expand: false
+		                 fill: true
+		                 padding: 5;
+		                 yourself.
+
 	self layout: (SpBoxLayout newTopToBottom
 			 add: (SpBoxLayout newTopToBottom
+					  add: scopesLayout
+					  withConstraints:
+						  [ :constraints | constraints height: 30 ] yourself;
 					  add: table;
 					  add: diffPresenter;
 					  yourself);
-			 add: (SpBoxLayout newLeftToRight
-					  addLast: buttonOk expand: false fill: true padding: 5;
-					  addLast: buttonCancel expand: false fill: true padding: 5;
-					  yourself)
-			 expand: false;
+			 add: actionsLayout expand: false;
 			 yourself)
 ]
 
@@ -122,6 +147,9 @@ RBRefactoringPreviewPresenter >> initializePresenters [
 		columns: self columns;
 		hideColumnHeaders.
 
+	scopeLabel := self newLabel label: 'Scope '.
+	scopeDropList := self newDropList.
+	scopeDropList display: [ :scope | scope description capitalized ].
 
 	buttonOk := self newButton
 		            label: 'Ok';
@@ -145,8 +173,28 @@ RBRefactoringPreviewPresenter >> initializeWindow: aWindowPresenter [
 ]
 
 { #category : #update }
+RBRefactoringPreviewPresenter >> updateActiveScope [
+
+	activeScope := scopeDropList selectedItem asRBEnvironment
+]
+
+{ #category : #update }
+RBRefactoringPreviewPresenter >> updateChanges [
+
+	changesInScope := changes select: [ :change | 
+		                  activeScope includesClass: change changeClass ].
+	selectedChanges := OrderedCollection withAll: changesInScope
+]
+
+{ #category : #update }
+RBRefactoringPreviewPresenter >> updateScopeList [
+
+	scopeDropList items: scopes
+]
+
+{ #category : #update }
 RBRefactoringPreviewPresenter >> updateTablePresenter [
 
-	table items: changes.
+	table items: changesInScope.
 	table items ifNotEmpty: [ table selectIndex: 1 ]
 ]

--- a/src/Refactoring-Core/RBRefactoringPreviewPresenter.class.st
+++ b/src/Refactoring-Core/RBRefactoringPreviewPresenter.class.st
@@ -1,0 +1,152 @@
+"
+I am a tool that previews refactoring changes to the user. User can change the scope of the refactoring (default scopes are: class, hierarchy, package and image) and manually pick which changes to apply and which ones to skip. I am usually opened by `RBDriver` subclasses.
+
+I am responsible for keeping track of `selectedChanges` (which changes to apply). When user selects a change from the list of all changes, I display a diff between old and new version of that change. When user accepts changes he wants to execute, I am responsible for invoking `RBRefactoryChangeManager` to perform them.
+
+"
+Class {
+	#name : #RBRefactoringPreviewPresenter,
+	#superclass : #SpPresenter,
+	#instVars : [
+		'changes',
+		'table',
+		'diffPresenter',
+		'selectedChanges',
+		'buttonOk',
+		'buttonCancel'
+	],
+	#category : #'Refactoring-Core-UI'
+}
+
+{ #category : #'instance creation' }
+RBRefactoringPreviewPresenter class >> changes: aCompositeRefactoring scope: scope [
+
+	^ self new
+		  changesFrom: aCompositeRefactoring forEnvironment: scope;
+		  yourself
+]
+
+{ #category : #specs }
+RBRefactoringPreviewPresenter class >> title [
+	^ 'Refactoring changes'
+]
+
+{ #category : #controlling }
+RBRefactoringPreviewPresenter >> accept [
+
+	(self okToChange not or: [ selectedChanges isEmptyOrNil ]) ifTrue: [ 
+		UIManager default inform: 'No changes to apply.'.
+		self closeWindow ].
+	[ 
+	selectedChanges do: [ :change | 
+			RBRefactoryChangeManager instance
+				performChange: change;
+				addUndoPointer: RBRefactoryChangeManager nextCounter ] ] asJob
+		title: 'Refactoring';
+		run.
+	self closeWindow
+]
+
+{ #category : #private }
+RBRefactoringPreviewPresenter >> buildDiffFor: aChange [
+
+	^ diffPresenter
+		  leftText: aChange oldVersionTextToDisplay;
+		  rightText: aChange textToDisplay
+]
+
+{ #category : #utilities }
+RBRefactoringPreviewPresenter >> changesFrom: aCompositeChange forEnvironment: anEnvironment [
+
+	changes := (aCompositeChange whatToDisplayIn: self) select: [ :change | 
+		           anEnvironment includesClass: change changeClass ].
+	selectedChanges := OrderedCollection withAll: changes.
+	self updateTablePresenter
+]
+
+{ #category : #'initialize-release' }
+RBRefactoringPreviewPresenter >> closeWindow [
+
+	self window close
+]
+
+{ #category : #initialization }
+RBRefactoringPreviewPresenter >> columns [
+
+	^ { (SpCompositeTableColumn new
+		   addColumn:
+			   ((SpCheckBoxTableColumn evaluated: [ :change | selectedChanges includes: change ])
+				    onActivation: [ :change | selectedChanges add: change ];
+				    onDeactivation: [ :change | selectedChanges remove: change ];
+				    width: 20);
+		   addColumn: (SpStringTableColumn evaluated: #name);
+		   yourself) }
+]
+
+{ #category : #initialization }
+RBRefactoringPreviewPresenter >> connectPresenters [
+
+	super connectPresenters.
+	table whenSelectionChangedDo: [ :selection | 
+		selection selectedItem ifNotNil: [ 
+			self buildDiffFor: selection selectedItem ] ].
+
+	buttonCancel action: [ self closeWindow ].
+	buttonOk action: [ self accept ]
+]
+
+{ #category : #initialization }
+RBRefactoringPreviewPresenter >> initializeLayout [
+
+	self layout: (SpBoxLayout newTopToBottom
+			 add: (SpBoxLayout newTopToBottom
+					  add: table;
+					  add: diffPresenter;
+					  yourself);
+			 add: (SpBoxLayout newLeftToRight
+					  addLast: buttonOk expand: false fill: true padding: 5;
+					  addLast: buttonCancel expand: false fill: true padding: 5;
+					  yourself)
+			 expand: false;
+			 yourself)
+]
+
+{ #category : #initialization }
+RBRefactoringPreviewPresenter >> initializePresenters [
+
+	diffPresenter := self newDiff.
+	diffPresenter disable.
+
+	table := self newTable.
+	table
+		columns: self columns;
+		hideColumnHeaders.
+
+
+	buttonOk := self newButton
+		            label: 'Ok';
+		            icon: (self iconNamed: #smallOk).
+
+	buttonCancel := self newButton
+		                label: 'Cancel';
+		                icon: (self iconNamed: #smallCancel).
+	self focusOrder
+		add: buttonOk;
+		add: buttonCancel.
+	self initializeLayout
+]
+
+{ #category : #initialization }
+RBRefactoringPreviewPresenter >> initializeWindow: aWindowPresenter [
+
+	aWindowPresenter
+		title: self title;
+		initialExtent: 700 @ 500
+]
+
+{ #category : #update }
+RBRefactoringPreviewPresenter >> updateTablePresenter [
+
+	table items: changes.
+	table items ifNotEmpty: [ table selectIndex: 1 ]
+]

--- a/src/SystemCommands-MessageCommands/SycChangeMessageSignatureCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycChangeMessageSignatureCommand.class.st
@@ -20,7 +20,8 @@ Class {
 	#traits : 'TRefactoringCommandSupport',
 	#classTraits : 'TRefactoringCommandSupport classTrait',
 	#instVars : [
-		'originalMessage'
+		'originalMessage',
+		'refactoringScopes'
 	],
 	#category : #'SystemCommands-MessageCommands'
 }
@@ -97,6 +98,7 @@ SycChangeMessageSignatureCommand >> originalMessage: anObject [
 SycChangeMessageSignatureCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
 	self setUpModelFromContext: aToolContext.
+	refactoringScopes := aToolContext refactoringScopes.
 	originalMessage := aToolContext lastSelectedMessage
 ]
 

--- a/src/SystemCommands-MessageCommands/SycDeprecateMessageCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycDeprecateMessageCommand.class.st
@@ -37,9 +37,9 @@ SycDeprecateMessageCommand >> defaultMenuItemName [
 SycDeprecateMessageCommand >> execute [
 
 	(RBDeprecateMethodDriver
-		 model: model
 		 deprecateMethod: originalMessage selector
-		 in: originalMessage contextUser origin) execute
+		 in: originalMessage methodClass
+		 scopes: refactoringScopes) execute
 ]
 
 { #category : #testing }


### PR DESCRIPTION
A new implementation of `RBRefactoringPreviewPresenter`. This is a cleaned and smaller version of `SycRefactoringPreviewPresenter`. You can test it with DeprecateMethod refactoring (only refactoring that uses it for the moment). 

While developing I've noticed that similar logic is implemented in multiple places:
* ChangesBrowser
* RBReplaceBrowser
* RewriteRuleChangesBrowser
* SycRefactoringPreviewPresenter
* RBRefactoringPreviewPresenter (this PR)
Maybe there is a way to reduce duplication here and reuse some of the logic in multiple places?