### PR TITLE
Fixes #11802, Inconsistent checks in class Time

### DIFF
--- a/src/Kernel-Chronology-Extras/Time.extension.st
+++ b/src/Kernel-Chronology-Extras/Time.extension.st
@@ -151,10 +151,6 @@ Time class >> hour: hour minute: minute second: second  nano: nano [
 Time class >> hour: hour minute: minute second: second  nanoSecond: nanoCount [
 	"Answer a Time - only second precision for now"
 	
-	hour >= HoursInDay ifTrue: [ Error new signal: ('An hour must be {1} or less' format: {HoursInDay})].
-	minute >= MinutesInHour ifTrue: [ Error new signal: ('A minute must be {1} or less' format: {MinutesInHour}) ].
-	second > SecondsInMinute ifTrue: [ Error new signal: ('A second must be {1} or less' format: {SecondsInMinute}) ].
-	
  	^ self 
 		seconds: (hour * SecondsInHour) + (minute * SecondsInMinute) + second 
 		nanoSeconds: nanoCount


### PR DESCRIPTION
Time class has this method:
```smalltalk
hour: hour minute: minute second: second  nanoSecond: nanoCount
	hour >= HoursInDay ifTrue: [ Error new signal: ('An hour must be {1} or less' format: {HoursInDay})].
	minute >= MinutesInHour ifTrue: [ Error new signal: ('A minute must be {1} or less' format: {MinutesInHour}) ].
	second > SecondsInMinute ifTrue: [ Error new signal: ('A second must be {1} or less' format: {SecondsInMinute}) ].
^ self 
	seconds: (hour * SecondsInHour) + (minute * SecondsInMinute) + second 
	nanoSeconds: nanoCount
```
It was added in #9098.
Issue 11802 correctly points out that:
- an hour of 24 is illegal, but reported that it must be 24 or less
- seconds should not be allowed value 60, but are
- negative values are not checked.

In addition, there is no check in `Time seconds: N`, where N can be both negative and N can be larger than a day.

This PR removed this test, allowing Time with any second value.