### PR TITLE
Turn off ReLongMethodsRule for test methods

### DIFF
--- a/src/GeneralRules/ReLongMethodsRule.class.st
+++ b/src/GeneralRules/ReLongMethodsRule.class.st
@@ -30,6 +30,8 @@ ReLongMethodsRule class >> uniqueIdentifierName [
 { #category : #running }
 ReLongMethodsRule >> basicCheck: aMethod [
 	| numberOfStatements |
+	"long methods are no problem for tests"
+	aMethod isTestMethod ifTrue: [ ^false ].
 	numberOfStatements := 0.
 
 	aMethod ast


### PR DESCRIPTION
ReLongMethodsRule checks for long methods as in normal code, it is better to break them up.

But for tests, this is not a problem to have long test methods.

This pr makes sure to not warn for long methods in tests