### PR TITLE
ConstantBlockClosure: active when compiling with clean blocks enabled

### DIFF
--- a/src/Debugging-Core/CompiledBlock.extension.st
+++ b/src/Debugging-Core/CompiledBlock.extension.st
@@ -18,7 +18,7 @@ CompiledBlock >> pcInOuter [
 			literalOffset ifNotNil: [
 				| literal |
 				literal := (self outerCode literalAt: literalOffset + 1).
-				((literal isKindOf: CleanBlockClosure) and: [literal compiledBlock = self  ])ifTrue: [ ^ instructionStream pc ].  ].
+				((literal isKindOf: CleanBlockClosure) and: [literal compiledBlock == self  ])ifTrue: [ ^ instructionStream pc ].  ].
 			instructionStream pc: (instructionStream nextPc: (outer at: instructionStream pc))].	
 		
 	self error: 'block not installed in outer code'.

--- a/src/Debugging-Core/CompiledBlock.extension.st
+++ b/src/Debugging-Core/CompiledBlock.extension.st
@@ -18,7 +18,7 @@ CompiledBlock >> pcInOuter [
 			literalOffset ifNotNil: [
 				| literal |
 				literal := (self outerCode literalAt: literalOffset + 1).
-				(literal class == CleanBlockClosure and: [literal compiledBlock = self  ])ifTrue: [ ^ instructionStream pc ].  ].
+				((literal isKindOf: CleanBlockClosure) and: [literal compiledBlock = self  ])ifTrue: [ ^ instructionStream pc ].  ].
 			instructionStream pc: (instructionStream nextPc: (outer at: instructionStream pc))].	
 		
 	self error: 'block not installed in outer code'.

--- a/src/Fuel-Tests-Core/FLBlockClosureSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLBlockClosureSerializationTest.class.st
@@ -106,6 +106,8 @@ FLBlockClosureSerializationTest >> testBlockClosureRemovedClean [
 	"Raise no error when materializing a clean closure whose method was removed."
 
 	| aClass aClosure |
+	"to be removed when we compile constant closure by default"
+	[  ] class == ConstantBlockClosure ifFalse: [ self skip ].
 	aClass := self classFactory silentlyNewClass.
 	self classFactory
 		silentlyCompile:  'methodWithClosure  ^ [ 42 ]'

--- a/src/Fuel-Tests-Core/FLBlockClosureSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLBlockClosureSerializationTest.class.st
@@ -24,12 +24,12 @@ FLBlockClosureSerializationTest class >> blockClosureWithTempVariableRead [
 
 { #category : #'tests-change' }
 FLBlockClosureSerializationTest >> testBlockClosureChangeDifferentBytecodes [
-	"Raise an error when materializing a closure whose method has changed bytecodes."
+	"Raise an error when materializing a non-clean closure whose method has changed bytecodes."
 
 	| aClass aClosure |
 	aClass := self classFactory silentlyNewClass.
 	self classFactory
-		silentlyCompile: 'methodWithClosure  ^ [ 42 ]'
+		silentlyCompile: 'methodWithClosure  ^ [ 42 yourself ]'
 		in: aClass.
 	aClosure := aClass new perform: #methodWithClosure.
 	self serialize: aClosure.
@@ -44,17 +44,17 @@ FLBlockClosureSerializationTest >> testBlockClosureChangeDifferentBytecodes [
 
 { #category : #'tests-change' }
 FLBlockClosureSerializationTest >> testBlockClosureChangeSameBytecodes [
-	"Tolerate materializing a closure whose method has changed but not the bytecodes."
+	"Tolerate materializing a non-clean closure whose method has changed but not the bytecodes."
 
 	| aClass aClosure materializedClosure |
 	aClass := self classFactory silentlyNewClass.
 	self classFactory
-		silentlyCompile: 'methodWithClosure  ^ [ 41 ]'
+		silentlyCompile: 'methodWithClosure  ^ [ 41 yourself ]'
 		in: aClass.
 	aClosure := aClass new perform: #methodWithClosure.
 	self serialize: aClosure.
 	self classFactory
-		silentlyCompile:  'methodWithClosure  ^ [ 42 ]'
+		silentlyCompile:  'methodWithClosure  ^ [ 42 yourself]'
 		in: aClass.
 	self deny: aClosure method isInstalled.
 	materializedClosure := self materialized.
@@ -93,12 +93,27 @@ FLBlockClosureSerializationTest >> testBlockClosureRemoved [
 	| aClass aClosure |
 	aClass := self classFactory silentlyNewClass.
 	self classFactory
-		silentlyCompile:  'methodWithClosure  ^ [ 42 ]'
+		silentlyCompile:  'methodWithClosure  ^ [ 42 yourself ]'
 		in: aClass.
 	aClosure := aClass new perform: #methodWithClosure.
 	self serialize: aClosure.
 	aClass removeSelectorSilently: #methodWithClosure.
 	self should: [ self materialized ] raise: FLMethodNotFound
+]
+
+{ #category : #'tests-change' }
+FLBlockClosureSerializationTest >> testBlockClosureRemovedClean [
+	"Raise no error when materializing a clean closure whose method was removed."
+
+	| aClass aClosure |
+	aClass := self classFactory silentlyNewClass.
+	self classFactory
+		silentlyCompile:  'methodWithClosure  ^ [ 42 ]'
+		in: aClass.
+	aClosure := aClass new perform: #methodWithClosure.
+	self serialize: aClosure.
+	aClass removeSelectorSilently: #methodWithClosure.
+	self shouldnt: [ self materialized ] raise: FLMethodNotFound
 ]
 
 { #category : #'tests-clean' }

--- a/src/Fuel-Tests-Core/FLFullBlockClosureSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLFullBlockClosureSerializationTest.class.st
@@ -11,7 +11,7 @@ FLFullBlockClosureSerializationTest >> testBlockClosureChangeDifferentBytecodes 
 	| aClass aClosure |
 	aClass := self classFactory silentlyNewClass.
 	self classFactory
-		silentlyCompile: 'methodWithClosure  ^ [ 42 ]'
+		silentlyCompile: 'methodWithClosure  ^ [ 42 yourself ]'
 		in: aClass.
 	aClosure := aClass new perform: #methodWithClosure.
 	self serializer fullySerializeMethod: aClosure compiledBlock method.
@@ -20,6 +20,28 @@ FLFullBlockClosureSerializationTest >> testBlockClosureChangeDifferentBytecodes 
 		silentlyCompile: 'methodWithClosure  ^ 42'
 		in: aClass.
 	self should: [ self materialized ] raise: FLMethodChanged.
+	
+	self materializer disableMethodChangedWarning.
+	self materialized
+]
+
+{ #category : #tests }
+FLFullBlockClosureSerializationTest >> testBlockClosureChangeDifferentBytecodesClean [
+	"Raise an error when materializing a closure whose method has changed bytecodes."
+
+	| aClass aClosure |
+	aClass := self classFactory silentlyNewClass.
+	self classFactory
+		silentlyCompile: 'methodWithClosure  ^ [ 42 ]'
+		in: aClass.
+	aClosure := aClass new perform: #methodWithClosure.
+	self serializer fullySerializeMethod: aClosure compiledBlock method.
+	self serialize: aClosure.
+	self classFactory
+		silentlyCompile: 'methodWithClosure  ^ 42'
+		in: aClass.
+	"clean blocks are independent"
+	self shouldnt: [ self materialized ] raise: FLMethodChanged.
 	
 	self materializer disableMethodChangedWarning.
 	self materialized

--- a/src/Fuel-Tests-Core/FLFullBlockClosureSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLFullBlockClosureSerializationTest.class.st
@@ -30,6 +30,8 @@ FLFullBlockClosureSerializationTest >> testBlockClosureChangeDifferentBytecodesC
 	"Raise an error when materializing a closure whose method has changed bytecodes."
 
 	| aClass aClosure |
+	"to be removed when we compile constant closure by default"
+	[  ] class == ConstantBlockClosure ifFalse: [ self skip ].
 	aClass := self classFactory silentlyNewClass.
 	self classFactory
 		silentlyCompile: 'methodWithClosure  ^ [ 42 ]'

--- a/src/Fuel-Tests-Core/FLGlobalEnvironmentTest.class.st
+++ b/src/Fuel-Tests-Core/FLGlobalEnvironmentTest.class.st
@@ -83,6 +83,8 @@ FLGlobalEnvironmentTest >> testCompiledMethodChangedClean [
 	"A compiled methods should be serialized as global by default. On materialization, it must be found in the global environment, and the bytecodes hash must be the same. Else, raise a proper error."
 	
 	| classA classB |
+	"to be removed when we compile constant closure by default"
+	[  ] class == ConstantBlockClosure ifFalse: [ self skip ].
 	classA := self classFactory silentlyNewClass.
 	self classFactory
 		silentlyCompile:  'm  ^ 42'

--- a/src/Fuel-Tests-Core/FLGlobalEnvironmentTest.class.st
+++ b/src/Fuel-Tests-Core/FLGlobalEnvironmentTest.class.st
@@ -64,7 +64,7 @@ FLGlobalEnvironmentTest >> testCompiledMethodChanged [
 		in: classA.
 	classB := self classFactory silentlyNewClass.
 	self classFactory
-		silentlyCompile: 'm  ^ [ 42 ]'
+		silentlyCompile: 'm  ^ [ 42 yourself ]'
 		in: classB.
 
 	self materializer environment: (Dictionary new
@@ -74,6 +74,31 @@ FLGlobalEnvironmentTest >> testCompiledMethodChanged [
 	self serialize: classA >> #m.
 
 	self should: [ self materialized ]
+		raise: FLMethodChanged 
+		description: 'Serialized and materialized methods should have the same bytecodes.'
+]
+
+{ #category : #tests }
+FLGlobalEnvironmentTest >> testCompiledMethodChangedClean [
+	"A compiled methods should be serialized as global by default. On materialization, it must be found in the global environment, and the bytecodes hash must be the same. Else, raise a proper error."
+	
+	| classA classB |
+	classA := self classFactory silentlyNewClass.
+	self classFactory
+		silentlyCompile:  'm  ^ 42'
+		in: classA.
+	classB := self classFactory silentlyNewClass.
+	self classFactory
+		silentlyCompile: 'm  ^ [ 42 ]'
+		in: classB.
+
+	self materializer environment: (Dictionary new
+		at: classA name put: classB;
+		yourself).
+
+	self serialize: classA >> #m.
+
+	self shouldnt: [ self materialized ]
 		raise: FLMethodChanged 
 		description: 'Serialized and materialized methods should have the same bytecodes.'
 ]

--- a/src/Kernel-Tests-Extended/ProcessTest.class.st
+++ b/src/Kernel-Tests-Extended/ProcessTest.class.st
@@ -313,13 +313,14 @@ ProcessTest >> testIsNotTerminatedWhenItIsInsideLastTerminationMethod [
 ProcessTest >> testIsNotTerminatedWhenItIsJustStartedByEnteringMainBlock [
 	
 	| process processBody |
-	processBody := [ #test ].
+	"this test works only on fullblocks with home context (due to isBottomContext)"
+	processBody := [ #test yourself].
 	process := processBody newProcess.
 	
 	[process step.
 	self deny: process isTerminated] 
 		doWhileTrue: [ process suspendedContext isBottomContext ].
-		
+
 	self assert: process suspendedContext closure identicalTo: processBody.
 	self deny: process isTerminated
 ]

--- a/src/Kernel/CleanBlockClosure.class.st
+++ b/src/Kernel/CleanBlockClosure.class.st
@@ -28,6 +28,11 @@ Class {
 	#category : #'Kernel-Methods'
 }
 
+{ #category : #fuel }
+CleanBlockClosure >> cleanCopy [
+	"nothing to do"
+]
+
 { #category : #printing }
 CleanBlockClosure >> doPrintOn: aStream [
 

--- a/src/Kernel/CleanBlockClosure.class.st
+++ b/src/Kernel/CleanBlockClosure.class.st
@@ -23,18 +23,10 @@ Class {
 	#superclass : #BlockClosure,
 	#type : #variable,
 	#instVars : [
-		'ivarNeededByVMToBeChecked'
+		'literal'
 	],
 	#category : #'Kernel-Methods'
 }
-
-{ #category : #accessing }
-CleanBlockClosure >> IvarNeededByVMToBeChecked [
-	"Clean blocks do not store a receiver, but it seems that the VM expects closures to have 4 ivars
-	We should check if we can fix that.
-	To see the problem: remove the var from CleanBlockClosure, enable the clean block option and recompile. Vm will crash"
-	^ivarNeededByVMToBeChecked
-]
 
 { #category : #printing }
 CleanBlockClosure >> doPrintOn: aStream [
@@ -70,6 +62,14 @@ CleanBlockClosure >> isClean [
 { #category : #testing }
 CleanBlockClosure >> isEmbeddedBlock [
 	^ true
+]
+
+{ #category : #accessing }
+CleanBlockClosure >> literal [
+	"The variable and accessor should be in the subclass ConstantBlockClosure.
+	It seems that the VM expects closures to have 4 ivars
+	We should check if we can fix that."
+	^literal
 ]
 
 { #category : #accessing }

--- a/src/Kernel/ConstantBlockClosure.class.st
+++ b/src/Kernel/ConstantBlockClosure.class.st
@@ -21,16 +21,8 @@ Class {
 	#category : #'Kernel-Methods'
 }
 
-{ #category : #compilation }
-ConstantBlockClosure >> blockIR [
-	^IRBuilder new 
-			pushLiteral: literal; 
-			blockReturnTop; 
-			ir
-]
-
 { #category : #accessing }
-ConstantBlockClosure >> returnValue: anObject [
+ConstantBlockClosure >> literal: anObject [
 	 literal := anObject
 ]
 

--- a/src/Kernel/ConstantBlockClosure.class.st
+++ b/src/Kernel/ConstantBlockClosure.class.st
@@ -7,7 +7,12 @@ Some blocks just return a literal, without sending messages or accessing the arg
 
 it is clear that these blocks are clean. But they are even more interesting: we can implement a special kind of Clean Block that can be evaluated faster. 
 
+We create a dummy compiledBlock which and use it to find the pcInOuter / do pc-ast mapping.
+
 the RBBlockNode has two methods: #isConstant returns true, #constantValue returns the literal for constant blocks.
+
+
+	
 "
 Class {
 	#name : #ConstantBlockClosure,
@@ -16,15 +21,17 @@ Class {
 	#category : #'Kernel-Methods'
 }
 
+{ #category : #compilation }
+ConstantBlockClosure >> blockIR [
+	^IRBuilder new 
+			pushLiteral: literal; 
+			blockReturnTop; 
+			ir
+]
+
 { #category : #accessing }
 ConstantBlockClosure >> returnValue: anObject [
-	 literal := anObject.
-	"dummy compiledBlock, we use it to find the pcInOuter 
-	and for queries that are done in the bytecode level."
-	compiledBlock := 
-		(IRBuilder new 
-			pushLiteral: literal; 
-			blockReturnTop; ir) compiledBlock
+	 literal := anObject
 ]
 
 { #category : #evaluating }

--- a/src/Kernel/ConstantBlockClosure.class.st
+++ b/src/Kernel/ConstantBlockClosure.class.st
@@ -1,0 +1,58 @@
+"
+Some blocks just return a literal, without sending messages or accessing the arguments
+
+	[] -> returns nil
+	[1]
+	[: arg | 'a string']
+
+it is clear that these blocks are clean. But they are even more interesting: we can implement a special kind of Clean Block that can be evaluated faster. 
+
+the RBBlockNode has two methods: #isConstant returns true, #constantValue returns the literal for constant blocks.
+"
+Class {
+	#name : #ConstantBlockClosure,
+	#superclass : #CleanBlockClosure,
+	#type : #variable,
+	#category : #'Kernel-Methods'
+}
+
+{ #category : #accessing }
+ConstantBlockClosure >> returnValue: anObject [
+	 literal := anObject.
+	"dummy compiledBlock, we use it to find the pcInOuter 
+	and for queries that are done in the bytecode level."
+	compiledBlock := 
+		(IRBuilder new 
+			pushLiteral: literal; 
+			blockReturnTop; ir) compiledBlock
+]
+
+{ #category : #evaluating }
+ConstantBlockClosure >> value [
+	^literal
+]
+
+{ #category : #evaluating }
+ConstantBlockClosure >> value: anObject [
+	^literal
+]
+
+{ #category : #evaluating }
+ConstantBlockClosure >> value: firstArg value: secondArg [
+	^literal
+]
+
+{ #category : #evaluating }
+ConstantBlockClosure >> value: firstArg value: secondArg value: thirdArg [
+	^literal
+]
+
+{ #category : #evaluating }
+ConstantBlockClosure >> value: firstArg value: secondArg value: thirdArg value: fourthArg [
+	^literal
+]
+
+{ #category : #evaluating }
+ConstantBlockClosure >> valueWithArguments: anArray [
+	^literal
+]

--- a/src/OpalCompiler-Core/IRMethod.class.st
+++ b/src/OpalCompiler-Core/IRMethod.class.st
@@ -115,6 +115,14 @@ IRMethod >> compilationContext: aCompilationContext [
 ]
 
 { #category : #translating }
+IRMethod >> compiledBlock [
+
+	^compiledMethod 
+		ifNil: [self generateBlock: CompiledMethodTrailer empty withScope: nil ]
+		ifNotNil: [compiledMethod]
+]
+
+{ #category : #translating }
 IRMethod >> compiledBlock: scope [
 
 	^compiledMethod 
@@ -178,8 +186,9 @@ IRMethod >> generate: trailer [
 IRMethod >> generateBlock: trailer withScope: scope [
 	| irTranslator |
       irTranslator := IRTranslator context: compilationContext trailer: trailer.
+	scope ifNotNil: [
+		irTranslator pushOuterVectors: scope].
 	irTranslator 
-		pushOuterVectors: scope;
 		visitNode: self;
 		pragmas: pragmas.
 	compiledMethod := irTranslator compiledBlock.

--- a/src/OpalCompiler-Core/IRMethod.class.st
+++ b/src/OpalCompiler-Core/IRMethod.class.st
@@ -178,9 +178,8 @@ IRMethod >> generate: trailer [
 IRMethod >> generateBlock: trailer withScope: scope [
 	| irTranslator |
       irTranslator := IRTranslator context: compilationContext trailer: trailer.
-	scope ifNotNil: [
-		irTranslator pushOuterVectors: scope].
 	irTranslator 
+		pushOuterVectors: scope;
 		visitNode: self;
 		pragmas: pragmas.
 	compiledMethod := irTranslator compiledBlock.

--- a/src/OpalCompiler-Core/IRMethod.class.st
+++ b/src/OpalCompiler-Core/IRMethod.class.st
@@ -115,14 +115,6 @@ IRMethod >> compilationContext: aCompilationContext [
 ]
 
 { #category : #translating }
-IRMethod >> compiledBlock [
-
-	^compiledMethod 
-		ifNil: [self generateBlock: CompiledMethodTrailer empty withScope: nil ]
-		ifNotNil: [compiledMethod]
-]
-
-{ #category : #translating }
 IRMethod >> compiledBlock: scope [
 
 	^compiledMethod 

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -499,11 +499,7 @@ OCASTTranslator >> visitBlockNode: aBlockNode [
 	| compiledBlock |
 	aBlockNode arguments size >15 ifTrue: [self backendError: 'Too many arguments' forNode: aBlockNode ].
 	aBlockNode isInlined ifTrue: [^ self visitInlinedBlockNode: aBlockNode ].
-	aBlockNode isConstant ifTrue: [ 
-			methodBuilder pushLiteral:	(ConstantBlockClosure new 
-					returnValue: aBlockNode constantValue;
-					numArgs: aBlockNode arguments size ).
-			 ^	self].
+	aBlockNode isConstant ifTrue: [ ^ self visitConstantBlockNode: aBlockNode].
 	compiledBlock := self compilationContext astTranslatorClass new translateFullBlock: aBlockNode.
 	(self compilationContext optionCleanBlockClosure and: [ aBlockNode isClean ])
 		ifTrue: [ methodBuilder pushLiteral: ((CleanBlockClosure new: 0) numArgs: compiledBlock numArgs; compiledBlock: compiledBlock)]
@@ -519,6 +515,20 @@ OCASTTranslator >> visitCascadeNode: aCascadeNode [
 		effectTranslator visitNode: node.
 	].
 	self visitNode: aCascadeNode messages last.
+]
+
+{ #category : #'visitor - double dispatching' }
+OCASTTranslator >> visitConstantBlockNode: anBlockNode [
+
+	| constantBlock ir |
+	constantBlock := ConstantBlockClosure new
+		                 returnValue: anBlockNode constantValue;
+		                 numArgs: anBlockNode arguments size.
+	ir := constantBlock blockIR.
+	constantBlock compiledBlock: ir compiledBlock. 
+	"we have to set the IR on the RBBlockNode for pc->AST mapping"
+	anBlockNode ir: ir.
+	methodBuilder pushLiteral: constantBlock
 ]
 
 { #category : #'visitor - double dispatching' }

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -514,7 +514,8 @@ OCASTTranslator >> visitBlockNode: aBlockNode [
 	| compiledBlock |
 	aBlockNode arguments size >15 ifTrue: [self backendError: 'Too many arguments' forNode: aBlockNode ].
 	aBlockNode isInlined ifTrue: [^ self visitInlinedBlockNode: aBlockNode ].
-	aBlockNode isConstant ifTrue: [ ^ self visitConstantBlockNode: aBlockNode].
+	(self compilationContext optionCleanBlockClosure and: [aBlockNode isConstant]) ifTrue: [ ^ self visitConstantBlockNode: aBlockNode].
+	
 	compiledBlock := self compilationContext astTranslatorClass new translateFullBlock: aBlockNode.
 	(self compilationContext optionCleanBlockClosure and: [ aBlockNode isClean ])
 		ifTrue: [ methodBuilder pushLiteral: ((CleanBlockClosure new: 0) numArgs: compiledBlock numArgs; compiledBlock: compiledBlock)]

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -537,7 +537,7 @@ OCASTTranslator >> visitConstantBlockNode: anBlockNode [
 
 	| constantBlock compiledBlock |
 	constantBlock := ConstantBlockClosure new
-		                 returnValue: anBlockNode constantValue;
+		                 literal: anBlockNode constantValue;
 		                 numArgs: anBlockNode arguments size.
 	compiledBlock := self translateConstantBlock: anBlockNode.
 	constantBlock compiledBlock: compiledBlock.

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -451,6 +451,21 @@ OCASTTranslator >> shouldBeSentToValueOrEffectTranslator [
 ]
 
 { #category : #'visitor - double dispatching' }
+OCASTTranslator >> translateConstantBlock: aBlockNode [
+	| ir |
+
+	ir := IRBuilder new 
+				mapToNode: aBlockNode;
+				numArgs: aBlockNode arguments size;
+				pushLiteral: aBlockNode constantValue; 
+				blockReturnTop; 
+				ir.
+	aBlockNode ir: ir.
+	aBlockNode resetBcToASTCache.
+	^ ir compiledBlock: aBlockNode scope
+]
+
+{ #category : #'visitor - double dispatching' }
 OCASTTranslator >> translateFullBlock: aBlockNode [
 
 	methodBuilder mapToNode: aBlockNode.
@@ -520,14 +535,12 @@ OCASTTranslator >> visitCascadeNode: aCascadeNode [
 { #category : #'visitor - double dispatching' }
 OCASTTranslator >> visitConstantBlockNode: anBlockNode [
 
-	| constantBlock ir |
+	| constantBlock compiledBlock |
 	constantBlock := ConstantBlockClosure new
 		                 returnValue: anBlockNode constantValue;
 		                 numArgs: anBlockNode arguments size.
-	ir := constantBlock blockIR.
-	constantBlock compiledBlock: ir compiledBlock. 
-	"we have to set the IR on the RBBlockNode for pc->AST mapping"
-	anBlockNode ir: ir.
+	compiledBlock := self translateConstantBlock: anBlockNode.
+	constantBlock compiledBlock: compiledBlock.
 	methodBuilder pushLiteral: constantBlock
 ]
 

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -499,7 +499,11 @@ OCASTTranslator >> visitBlockNode: aBlockNode [
 	| compiledBlock |
 	aBlockNode arguments size >15 ifTrue: [self backendError: 'Too many arguments' forNode: aBlockNode ].
 	aBlockNode isInlined ifTrue: [^ self visitInlinedBlockNode: aBlockNode ].
-	
+	aBlockNode isConstant ifTrue: [ 
+			methodBuilder pushLiteral:	(ConstantBlockClosure new 
+					returnValue: aBlockNode constantValue;
+					numArgs: aBlockNode arguments size ).
+			 ^	self].
 	compiledBlock := self compilationContext astTranslatorClass new translateFullBlock: aBlockNode.
 	(self compilationContext optionCleanBlockClosure and: [ aBlockNode isClean ])
 		ifTrue: [ methodBuilder pushLiteral: ((CleanBlockClosure new: 0) numArgs: compiledBlock numArgs; compiledBlock: compiledBlock)]


### PR DESCRIPTION
Experiment to see what will fail

- add a special kind of clean block: constant clean blocks. 
- change the compiler to instantiate those for all #isConstant bocks