### PR TITLE
Implement #asSlot to return a correct Slot instances for complex slots

### DIFF
--- a/src/ClassParser/CDSlotNode.class.st
+++ b/src/ClassParser/CDSlotNode.class.st
@@ -9,9 +9,14 @@ Class {
 
 { #category : #transforming }
 CDSlotNode >> asSlot [
-	"for not this only supports instance variable slots. 
-	We need to create a slot here using the slot class and initialization message"
-	^InstanceVariableSlot named: name
+
+	"when parsing old style definitions, the node is just the string of all ivars"
+	node isLiteralNode ifTrue: [ ^InstanceVariableSlot named: name ]
+	
+	"As we controll the creation of the AST, it is safe to evaluate it. The
+	only thing that can go wrong is that the class of the slot is not yet loaded,
+	we crate an UndefinedSlot for that case".
+	^ [ node evaluate ] on: Error do: [ UndefinedSlot named: self name ast: node ]
 ]
 
 { #category : #testing }

--- a/src/ClassParser/ShiftClassBuilder.extension.st
+++ b/src/ClassParser/ShiftClassBuilder.extension.st
@@ -19,7 +19,7 @@ ShiftClassBuilder >> buildFromAST: aCDClassDefinitionNode [
 		
 	self slots: (aCDClassDefinitionNode slots collect: [ :e | e asSlot]).
 	
-	self sharedVariables: (aCDClassDefinitionNode sharedVariables collect: [ :e | e ]).
+	self sharedVariables: (aCDClassDefinitionNode sharedVariables collect: [ :e | e asClassVariable]).
 	
 	aCDClassDefinitionNode packageName
 		ifNotNil: [ :cat | package := cat ]


### PR DESCRIPTION
This PR implements #asSlot to work with Slots that are not InstanceVariableSlots. It falls back to create a UndefinedSlot if a problem happens