### PR TITLE
add #numArgs to RBBlockNode

### DIFF
--- a/src/AST-Core-Tests/RBBlockNodeTest.class.st
+++ b/src/AST-Core-Tests/RBBlockNodeTest.class.st
@@ -61,3 +61,10 @@ RBBlockNodeTest >> testIsConstant [
 	self deny: [ ^1 ] sourceNode isConstant.
 	self deny: [ 1 sin. 1 ] sourceNode isConstant
 ]
+
+{ #category : #tests }
+RBBlockNodeTest >> testNumArgs [
+	self assert: [  ] sourceNode numArgs equals: 0.
+	self assert: [:a  |  ] sourceNode numArgs equals: 1.
+	self assert: [:a :b  |  ] sourceNode numArgs equals:  [:a :b  |  ] numArgs.
+]

--- a/src/AST-Core/RBBlockNode.class.st
+++ b/src/AST-Core/RBBlockNode.class.st
@@ -292,6 +292,11 @@ RBBlockNode >> needsParenthesis [
 	^false
 ]
 
+{ #category : #accessing }
+RBBlockNode >> numArgs [
+	^ self arguments size
+]
+
 { #category : #copying }
 RBBlockNode >> postCopy [
 	super postCopy.


### PR DESCRIPTION
While getting the numbers for https://github.com/pharo-project/pharo/issues/11901, I was missing #numArgs.

We have #numArgs on RBMethodNode and RBMessageNode, and on BlockClosure. add it to RBBlockBode, too