### PR TITLE
IRBuilder: add support for outerContext flag for Closure creation 

### DIFF
--- a/src/OpalCompiler-Core/IRBuilder.class.st
+++ b/src/OpalCompiler-Core/IRBuilder.class.st
@@ -309,6 +309,12 @@ IRBuilder >> pushFullClosureCompiledBlock: compiledBlock copiedValues: copiedVal
 ]
 
 { #category : #instructions }
+IRBuilder >> pushFullClosureCompiledBlock: compiledBlock copiedValues: copiedValues outerContextNeeded: aBoolean [
+
+	^ self add: (IRInstruction pushFullClosureCompiledBlock: compiledBlock copiedValues: copiedValues outerContextNeeded: aBoolean)
+]
+
+{ #category : #instructions }
 IRBuilder >> pushInstVar: index [
 
 	self add: (IRInstruction pushInstVar: index).

--- a/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
+++ b/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
@@ -507,7 +507,7 @@ IRBytecodeGenerator >> pushFullBlockClosure: fullBlock [
 		genPushFullClosure: (self literalIndexOf: fullBlock compiledBlock) 
 		numCopied: fullBlock copiedValues size
 		receiverOnStack: false
-		outerContextNeeded: true
+		outerContextNeeded: fullBlock outerContextNeeded
 ]
 
 { #category : #instructions }

--- a/src/OpalCompiler-Core/IRInstruction.class.st
+++ b/src/OpalCompiler-Core/IRInstruction.class.st
@@ -70,6 +70,15 @@ IRInstruction class >> pushFullClosureCompiledBlock: compiledBlock copiedValues:
 ]
 
 { #category : #'instance creation' }
+IRInstruction class >> pushFullClosureCompiledBlock: compiledBlock copiedValues: copiedValues outerContextNeeded: aBoolean [
+	^IRPushFullClosure new
+			copiedValues: copiedValues;
+			compiledBlock: compiledBlock;
+			outerContextNeeded: aBoolean
+			yourself.
+]
+
+{ #category : #'instance creation' }
 IRInstruction class >> pushInstVar: index [
 
 	^ IRPushInstVar new 

--- a/src/OpalCompiler-Core/IRPushFullClosure.class.st
+++ b/src/OpalCompiler-Core/IRPushFullClosure.class.st
@@ -8,7 +8,8 @@ Class {
 	#superclass : #IRInstruction,
 	#instVars : [
 		'compiledBlock',
-		'copiedValues'
+		'copiedValues',
+		'outerContextNeeded'
 	],
 	#category : #'OpalCompiler-Core-IR-Nodes'
 }
@@ -41,6 +42,18 @@ IRPushFullClosure >> copiedValues: anObject [
 { #category : #debugging }
 IRPushFullClosure >> indexForVarNamed: aName [
 	^ sourceNode ir indexForVarNamed: aName
+]
+
+{ #category : #accessing }
+IRPushFullClosure >> outerContextNeeded [
+
+	^ outerContextNeeded ifNil: [ true ]
+]
+
+{ #category : #accessing }
+IRPushFullClosure >> outerContextNeeded: anObject [
+
+	outerContextNeeded := anObject
 ]
 
 { #category : #scoping }


### PR DESCRIPTION
The block creation bytecode supports to create blocks without an outer context.

This PR adds support to IRBuilder to create blocks like that. It is not active.

To enable it in the compiler, add the argument to the end of the block creation in OCASTTranslator>>#visitBlockNode:  "outerContextNeeded: aBlockNode hasNonLocalReturn"

Note: for sure this will need changes to work, I can recompile the image but Job>>#owner makes problems