### PR TITLE
CompiledBlocks: compile quick returns

### DIFF
--- a/src/Kernel/CompiledBlock.class.st
+++ b/src/Kernel/CompiledBlock.class.st
@@ -135,11 +135,6 @@ CompiledBlock >> pragmas [
 	^ #()
 ]
 
-{ #category : #accessing }
-CompiledBlock >> primitive [
-	^ 0
-]
-
 { #category : #printing }
 CompiledBlock >> printOn: anStream [
 	

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -655,7 +655,12 @@ CompiledCode >> pragmas [
 
 { #category : #accessing }
 CompiledCode >> primitive [
-	^ self subclassResponsibility
+	"Answer the primitive index associated with the receiver.
+	 Zero indicates that this is not a primitive method."
+	| initialPC |
+	^(self header anyMask: 65536) "Is the hasPrimitive? flag set?"
+		ifTrue: [(self at: (initialPC := self initialPC) + 1) + ((self at: initialPC + 2) bitShift: 8)]
+		ifFalse: [0]
 ]
 
 { #category : #printing }

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -809,16 +809,6 @@ CompiledMethod >> prepareForSimulationWith: numArgs [
 	self encoderClass prepareMethod: self forSimulationWith: numArgs
 ]
 
-{ #category : #accessing }
-CompiledMethod >> primitive [
-	"Answer the primitive index associated with the receiver.
-	 Zero indicates that this is not a primitive method."
-	| initialPC |
-	^(self header anyMask: 65536) "Is the hasPrimitive? flag set?"
-		ifTrue: [(self at: (initialPC := self initialPC) + 1) + ((self at: initialPC + 2) bitShift: 8)]
-		ifFalse: [0]
-]
-
 { #category : #printing }
 CompiledMethod >> printOn: aStream [ 
 	"Overrides method inherited from the byte arrayed collection."

--- a/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
+++ b/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
@@ -157,8 +157,16 @@ IRBytecodeGenerator >> compilationContext: aCompilationContext [
 
 { #category : #results }
 IRBytecodeGenerator >> compiledBlockWith: trailer [
-	| lits header cb |
+	| lits quickPrimitive header cb |
 	lits := self literals allButLast "1 free only for compiledBlock".
+	quickPrimitive := self quickMethodPrim.
+	(primNumber = 0 and: [quickPrimitive > 0]) ifTrue: [
+		"if we are a quick method we need to add a bytecode at the beginning. #bytecodes
+		takes primitiveBytes into account" 
+		primitiveBytes := (ByteArray new: 4) writeStream.
+		encoder stream: primitiveBytes.
+		encoder genCallPrimitive: quickPrimitive.
+	].
 	header := self spurVMHeader: lits size.
 	cb := CompiledBlock newMethod: self bytecodes size header: header.
 	(WriteStream with: cb)


### PR DESCRIPTION
This PR makes sure to compile Quick returns if a block has just a non-local return, just as we do for methods.