### PR TITLE
Fix print on recursive array

### DIFF
--- a/src/Collections-Sequenceable-Tests/ArrayTest.class.st
+++ b/src/Collections-Sequenceable-Tests/ArrayTest.class.st
@@ -711,6 +711,8 @@ ArrayTest >> testIsLiteral [
 	aLiteralArray at: 1 put: self class.
 	self deny: aLiteralArray isLiteral.
 	self deny: (literalArray as: WeakArray) isLiteral description: 'instances of Array subclasses are not literal'.
+	self deny: recursiveArray isLiteral.
+
 ]
 
 { #category : #tests }

--- a/src/Collections-Sequenceable-Tests/ArrayTest.class.st
+++ b/src/Collections-Sequenceable-Tests/ArrayTest.class.st
@@ -47,7 +47,8 @@ Class {
 		'collectionOfCollectionsOfInts',
 		'simpleCollection',
 		'stringCollectionWithSameBeginingAnEnd',
-		'collectionOfFloat'
+		'collectionOfFloat',
+		'recursiveArray'
 	],
 	#category : #'Collections-Sequenceable-Tests-Base'
 }
@@ -486,6 +487,9 @@ ArrayTest >> setUp [
 	collectionOfFloatWithEqualElements:={1.5. 5.5. 6.5. 1.5}.
 	stringCollectionWithSameBeginingAnEnd := {'c'. 's'. 'c' copy}.
 	collection5Elements := { 1. 2. 5. 3. 4.}.
+
+	recursiveArray := example1 copy.
+	recursiveArray at: 5 put: recursiveArray.
 ]
 
 { #category : #requirements }
@@ -625,17 +629,6 @@ ArrayTest >> testCombinationsTaken [
 		hasSameElements: #( #( 1 2 3 ) #( 1 2 4 ) #( 1 3 4 ) #( 2 3 4 ) )
 ]
 
-{ #category : #tests }
-ArrayTest >> testComplexIsSelfEvaluating [
-	| complexArray restoredArray |
-	complexArray := {1 . true . false . nil . #a . 'a' . $a . Float pi . Float halfPi . (4 / 5) . Float infinity negated . (1 @ 2) . (0 @ 0 extent: 1 @ 1).
-	('hola' -> 0) . Object . Object class}.
-	complexArray := complexArray copyWith: complexArray.
-	self assert: complexArray isSelfEvaluating.
-	restoredArray := self class evaluate: complexArray printString.
-	self assert: restoredArray equals: complexArray
-]
-
 { #category : #'tests - copy' }
 ArrayTest >> testCopyNonEmptyWithoutAllNotIncluded [
 ]
@@ -723,10 +716,12 @@ ArrayTest >> testIsLiteral [
 { #category : #tests }
 ArrayTest >> testIsSelfEvaluating [
 
-	self assert: example1 isSelfEvaluating.
-	example1 at: 1 put: Bag new.
-	self deny: example1 isSelfEvaluating.
-	example1 at: 1 put: 1.
+	self assert: selfEvaluatingArray isSelfEvaluating.
+
+	selfEvaluatingArray at: 1 put: Bag new.
+	self deny: selfEvaluatingArray isSelfEvaluating.
+
+	self deny: recursiveArray isSelfEvaluating
 ]
 
 { #category : #tests }
@@ -774,11 +769,60 @@ ArrayTest >> testPremultiply [
 
 { #category : #tests }
 ArrayTest >> testPrinting [
+
 	self assert: literalArray printString equals: '#(1 true 3 #four)'.
+	self assert: collectionOfCollectionsOfInts printString equals: '#(1 #(2 3) #(4 #(5 6)))'.
+	self assert: nonSEarray2 printString equals: '{#Array->Array}'.
+	self assert: nonSEArray1 printString equals: 'an Array(1 a Set(1))'
+]
+
+{ #category : #tests }
+ArrayTest >> testPrintingRecursive [
+
+	| printStringLimit |
+	printStringLimit := 50000. "Max limit"
+
+	self assert: recursiveArray printString size equals: printStringLimit.
+
+	"Indirect recursion"
+	recursiveArray at: 1 put: example2.
+	example2 at: 1 put: recursiveArray.
+	self assert: recursiveArray printString size equals: printStringLimit
+]
+
+{ #category : #tests }
+ArrayTest >> testSelfEvaluating [
+
+	self assert: selfEvaluatingArray isSelfEvaluating.
 	self assert: literalArray equals: (self class compiler evaluate: literalArray printString).
 	self assert: selfEvaluatingArray equals: (self class compiler evaluate: selfEvaluatingArray printString).
-	self assert: nonSEArray1 printString equals: 'an Array(1 a Set(1))'.
-	self assert: nonSEarray2 printString equals: '{#Array->Array}'
+
+	self deny: recursiveArray isSelfEvaluating.
+	self deny: nonSEArray1 isSelfEvaluating.
+
+
+]
+
+{ #category : #tests }
+ArrayTest >> testSelfEvaluatingComplexCase [
+	| complexArray restoredArray |
+	complexArray := {1 . true . false . nil . #a . 'a' . $a . Float pi . Float halfPi . (4 / 5) . Float infinity negated . (1 @ 2) . (0 @ 0 extent: 1 @ 1).
+	('hola' -> 0) . Object . Object class}.
+	complexArray := complexArray copyWith: complexArray.
+	self assert: complexArray isSelfEvaluating.
+
+	restoredArray := self class evaluate: complexArray printString.
+	self assert: restoredArray equals: complexArray
+]
+
+{ #category : #tests }
+ArrayTest >> testShouldBePrintedAsLiteral [
+
+	self assert: empty shouldBePrintedAsLiteral.
+	self assert: literalArray shouldBePrintedAsLiteral.
+	
+	self deny: (literalArray copyWith: 3/4) shouldBePrintedAsLiteral.
+	self deny: recursiveArray shouldBePrintedAsLiteral.
 ]
 
 { #category : #'tests - shuffling' }

--- a/src/Collections-Sequenceable/Array.class.st
+++ b/src/Collections-Sequenceable/Array.class.st
@@ -301,7 +301,19 @@ Array >> isArray [
 
 { #category : #testing }
 Array >> isLiteral [
-	^self class == Array and: [self allSatisfy: [:each | each isLiteral]]
+
+	^ self class == Array and: [ self isLiteral: {  } ]
+]
+
+{ #category : #testing }
+Array >> isLiteral: alreadyVisited [
+
+	"Do not call super! This logic ends with an infinite recursion"
+
+	(alreadyVisited identityIncludes: self) ifTrue: [ "Recursive structure cannot be literals" 
+		^ false ].
+
+	^ self allSatisfy: [ :each | each isLiteral: alreadyVisited , { self } ]
 ]
 
 { #category : #'self evaluating' }

--- a/src/Collections-Sequenceable/Array.class.st
+++ b/src/Collections-Sequenceable/Array.class.st
@@ -306,7 +306,17 @@ Array >> isLiteral [
 
 { #category : #'self evaluating' }
 Array >> isSelfEvaluating [
-	^ (self allSatisfy: [:each | each isSelfEvaluating]) and: [self class == Array]
+
+	^ self class == Array and: [ self allSatisfy: [ :each | each isSelfEvaluating: { self } ] ]
+]
+
+{ #category : #'self evaluating' }
+Array >> isSelfEvaluating: alreadyVisited [
+
+	(super isSelfEvaluating: alreadyVisited) ifTrue: [ 
+		^ self isSelfEvaluating: alreadyVisited , { self } ].
+
+	^ false
 ]
 
 { #category : #comparing }
@@ -367,7 +377,16 @@ Array >> replaceFrom: start to: stop with: replacement startingAt: repStart [
 { #category : #'literal testing' }
 Array >> shouldBePrintedAsLiteral [
 
-	^self class == Array and: [ self allSatisfy: [ :each | each shouldBePrintedAsLiteral ] ]
+	^ self class == Array and: [ self allSatisfy: [ :each | each shouldBePrintedAsLiteral: { self } ] ]
+]
+
+{ #category : #'literal testing' }
+Array >> shouldBePrintedAsLiteral: alreadyVisited [
+
+	(super shouldBePrintedAsLiteral: alreadyVisited) ifTrue: [ 
+		^ self shouldBePrintedAsLiteral: alreadyVisited , { self } ].
+
+	^ false
 ]
 
 { #category : #printing }

--- a/src/Collections-Sequenceable/Array.class.st
+++ b/src/Collections-Sequenceable/Array.class.st
@@ -313,10 +313,12 @@ Array >> isSelfEvaluating [
 { #category : #'self evaluating' }
 Array >> isSelfEvaluating: alreadyVisited [
 
-	(super isSelfEvaluating: alreadyVisited) ifTrue: [ 
-		^ self allSatisfy: [ :each | each isSelfEvaluating: alreadyVisited , { self } ] ].
+	"Do not call super! This logic ends with an infinite recursion"
 
-	^ false
+	(alreadyVisited identityIncludes: self) ifTrue: [ "Recursive structure cannot be a self evaluated" 
+		^ false ].
+
+	^ self allSatisfy: [ :each | each isSelfEvaluating: alreadyVisited , { self } ]
 ]
 
 { #category : #comparing }
@@ -383,10 +385,12 @@ Array >> shouldBePrintedAsLiteral [
 { #category : #'literal testing' }
 Array >> shouldBePrintedAsLiteral: alreadyVisited [
 
-	(super shouldBePrintedAsLiteral: alreadyVisited) ifTrue: [ 
-		^ self allSatisfy: [ :each | each shouldBePrintedAsLiteral: alreadyVisited , { self } ] ].
+	"Do not call super! This logic ends with an infinite recursion"
 
-	^ false
+	(alreadyVisited identityIncludes: self) ifTrue: [ "Recursive structure cannot be a literal" 
+		^ false ].
+
+	^ self allSatisfy: [ :each | each shouldBePrintedAsLiteral: alreadyVisited , { self } ]
 ]
 
 { #category : #printing }

--- a/src/Collections-Sequenceable/Array.class.st
+++ b/src/Collections-Sequenceable/Array.class.st
@@ -307,14 +307,14 @@ Array >> isLiteral [
 { #category : #'self evaluating' }
 Array >> isSelfEvaluating [
 
-	^ self class == Array and: [ self allSatisfy: [ :each | each isSelfEvaluating: { self } ] ]
+	^ self class == Array and: [ self isSelfEvaluating: { } ]
 ]
 
 { #category : #'self evaluating' }
 Array >> isSelfEvaluating: alreadyVisited [
 
 	(super isSelfEvaluating: alreadyVisited) ifTrue: [ 
-		^ self isSelfEvaluating: alreadyVisited , { self } ].
+		^ self allSatisfy: [ :each | each isSelfEvaluating: alreadyVisited , { self } ] ].
 
 	^ false
 ]
@@ -377,14 +377,14 @@ Array >> replaceFrom: start to: stop with: replacement startingAt: repStart [
 { #category : #'literal testing' }
 Array >> shouldBePrintedAsLiteral [
 
-	^ self class == Array and: [ self allSatisfy: [ :each | each shouldBePrintedAsLiteral: { self } ] ]
+	^ self class == Array and: [ self shouldBePrintedAsLiteral: {  } ]
 ]
 
 { #category : #'literal testing' }
 Array >> shouldBePrintedAsLiteral: alreadyVisited [
 
 	(super shouldBePrintedAsLiteral: alreadyVisited) ifTrue: [ 
-		^ self shouldBePrintedAsLiteral: alreadyVisited , { self } ].
+		^ self allSatisfy: [ :each | each shouldBePrintedAsLiteral: alreadyVisited , { self } ] ].
 
 	^ false
 ]

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1353,6 +1353,14 @@ Object >> isSelfEvaluating [
 	^ self isLiteral
 ]
 
+{ #category : #'self evaluating' }
+Object >> isSelfEvaluating: alreadyVisited [
+
+	(alreadyVisited identityIncludes: self) ifTrue: [ "Recursive structure cannot be a literal" 
+		^ false ].
+	^ self class == Array or: [ self isLiteral ]
+]
+
 { #category : #testing }
 Object >> isStream [
 	"Return true if the receiver responds to the stream protocol"
@@ -1903,6 +1911,14 @@ Object >> shouldBeImplemented [
 Object >> shouldBePrintedAsLiteral [
 
 	^self isLiteral
+]
+
+{ #category : #'literal testing' }
+Object >> shouldBePrintedAsLiteral: alreadyVisited [
+
+	(alreadyVisited identityIncludes: self) ifTrue: [ "Recursive structure cannot be a literal" 
+		^ false ].
+	^ self class == Array or: [ self isLiteral ]
 ]
 
 { #category : #'error handling' }

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1262,6 +1262,12 @@ Object >> isLiteral [
 	^ false
 ]
 
+{ #category : #testing }
+Object >> isLiteral: alreadyVisited [
+
+	^ self isLiteral
+]
+
 { #category : #'class membership' }
 Object >> isMemberOf: aClass [
 	"Answer whether the receiver is an instance of the class, aClass."

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1253,8 +1253,11 @@ Object >> isKindOf: aClass [
 
 { #category : #testing }
 Object >> isLiteral [
-	"Answer whether the receiver has a literal text form recognized by the 
-	compiler."
+
+	"Answer whether the receiver has a literal text form recognized by the compiler.
+	For ex:
+	#(1 true #three #(4) )
+	"
 
 	^ false
 ]
@@ -1349,6 +1352,8 @@ Object >> isRectangle [
 
 { #category : #'self evaluating' }
 Object >> isSelfEvaluating [
+
+	"A self evaluating object means that the string representation can be evaluated and give an identical object"
 
 	^ self isLiteral
 ]
@@ -1908,7 +1913,9 @@ Object >> shouldBeImplemented [
 { #category : #'literal testing' }
 Object >> shouldBePrintedAsLiteral [
 
-	^self isLiteral
+	"Only literals should be printed as literals"
+
+	^ self isLiteral
 ]
 
 { #category : #'literal testing' }

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1356,9 +1356,7 @@ Object >> isSelfEvaluating [
 { #category : #'self evaluating' }
 Object >> isSelfEvaluating: alreadyVisited [
 
-	(alreadyVisited identityIncludes: self) ifTrue: [ "Recursive structure cannot be a literal" 
-		^ false ].
-	^ self class == Array or: [ self isSelfEvaluating ]
+	^ self isSelfEvaluating
 ]
 
 { #category : #testing }
@@ -1916,9 +1914,7 @@ Object >> shouldBePrintedAsLiteral [
 { #category : #'literal testing' }
 Object >> shouldBePrintedAsLiteral: alreadyVisited [
 
-	(alreadyVisited identityIncludes: self) ifTrue: [ "Recursive structure cannot be a literal" 
-		^ false ].
-	^ self class == Array or: [ self shouldBePrintedAsLiteral ]
+	^ self shouldBePrintedAsLiteral
 ]
 
 { #category : #'error handling' }

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1358,7 +1358,7 @@ Object >> isSelfEvaluating: alreadyVisited [
 
 	(alreadyVisited identityIncludes: self) ifTrue: [ "Recursive structure cannot be a literal" 
 		^ false ].
-	^ self class == Array or: [ self isLiteral ]
+	^ self class == Array or: [ self isSelfEvaluating ]
 ]
 
 { #category : #testing }
@@ -1918,7 +1918,7 @@ Object >> shouldBePrintedAsLiteral: alreadyVisited [
 
 	(alreadyVisited identityIncludes: self) ifTrue: [ "Recursive structure cannot be a literal" 
 		^ false ].
-	^ self class == Array or: [ self isLiteral ]
+	^ self class == Array or: [ self shouldBePrintedAsLiteral ]
 ]
 
 { #category : #'error handling' }


### PR DESCRIPTION
Fix https://github.com/pharo-project/pharo/issues/11479

with @jordanmontt @sbragagnolo and @privat 
in the Pharo Sprint on 28/10

----------

Maybe we can add another issue to show a "good" string. 
Now the printed string is not very useful, it doesn't show the elements after recursion:
```
l1 := {1 . 2 . 3 . 4 . 5}.
l1 at: 3 put: l1.
l1 "an Array(1 2 an Array(1 2 an Array(1 2 an Array(1 2 an Array( ..."
```

It's the same for any collection, not only arrays.