### PR TITLE
11911-Compiler-add-compiler-option-for-outerContextNeeded 

### DIFF
--- a/src/Collections-Unordered/Dictionary.class.st
+++ b/src/Collections-Unordered/Dictionary.class.st
@@ -334,7 +334,7 @@ Dictionary >> associationsSelect: aBlock [
 { #category : #accessing }
 Dictionary >> at: key [ 
 	"Answer the value associated with the key."
-
+	<compilerOptions: #(+ optionBlockClosureOptionalOuter)>
 	^ self at: key ifAbsent: [self errorKeyNotFound: key]
 ]
 

--- a/src/Collections-Unordered/Dictionary.class.st
+++ b/src/Collections-Unordered/Dictionary.class.st
@@ -334,7 +334,6 @@ Dictionary >> associationsSelect: aBlock [
 { #category : #accessing }
 Dictionary >> at: key [ 
 	"Answer the value associated with the key."
-	<compilerOptions: #(+ optionBlockClosureOptionalOuter)>
 	^ self at: key ifAbsent: [self errorKeyNotFound: key]
 ]
 

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -111,6 +111,16 @@ CompilationContext class >> initialize [
 ]
 
 { #category : #'options - settings API' }
+CompilationContext class >> optionBlockClosureOptionalOuter [
+	^ self readDefaultOption: #optionBlockClosureOptionalOuter
+]
+
+{ #category : #'options - settings API' }
+CompilationContext class >> optionBlockClosureOptionalOuter: aBoolean [
+	^ self writeDefaultOption: #optionBlockClosureOptionalOuter value: aBoolean
+]
+
+{ #category : #'options - settings API' }
 CompilationContext class >> optionCleanBlockClosure [
 	^ self readDefaultOption: #optionCleanBlockClosure
 ]
@@ -289,6 +299,7 @@ CompilationContext class >> optionsDescription [
 	(- optionInlineNone 				'To turn off all inlining options. Overrides the others')
 	
 	(- optionEmbeddSources         'Embedd sources into CompiledMethod instead of storing in .changes')
+		(- optionBlockClosureOptionalOuter 			'Compiler compiles closure creation with outerContext only if it has a non-local return. Experimental')
 	(- optionCleanBlockClosure 			'Compiler compiles closure creation to use CleanBlockClosure instead of FullBlockClosure for clean blocks. Experimental')
 	(- optionLongIvarAccessBytecodes 	'Specific inst var accesses to Maybe context objects')
 	(+ optionOptimizeIR 					'Rewrite jumps in bytecode in a slightly more efficient way')
@@ -490,6 +501,11 @@ CompilationContext >> noPattern: anObject [
 		"when we compile an expression, embedd sources, as the resulting method will never be installed"
 		self parseOptions: #(+ #optionEmbeddSources).
 	 ]
+]
+
+{ #category : #options }
+CompilationContext >> optionBlockClosureOptionalOuter [
+	^ options includes: #optionBlockClosureOptionalOuter
 ]
 
 { #category : #options }

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -513,13 +513,17 @@ OCASTTranslator >> visitAssignmentNode: anAssignmentNode [
 OCASTTranslator >> visitBlockNode: aBlockNode [
 	| compiledBlock |
 	aBlockNode arguments size >15 ifTrue: [self backendError: 'Too many arguments' forNode: aBlockNode ].
+	
 	aBlockNode isInlined ifTrue: [^ self visitInlinedBlockNode: aBlockNode ].
 	(self compilationContext optionCleanBlockClosure and: [aBlockNode isConstant]) ifTrue: [ ^ self visitConstantBlockNode: aBlockNode].
+	(self compilationContext optionCleanBlockClosure and: [ aBlockNode isClean ]) ifTrue: [ ^ self visitCleanBlockNode: aBlockNode].
 	
 	compiledBlock := self compilationContext astTranslatorClass new translateFullBlock: aBlockNode.
-	(self compilationContext optionCleanBlockClosure and: [ aBlockNode isClean ])
-		ifTrue: [ methodBuilder pushLiteral: ((CleanBlockClosure new: 0) numArgs: compiledBlock numArgs; compiledBlock: compiledBlock)]
-		ifFalse: [methodBuilder pushFullClosureCompiledBlock: compiledBlock copiedValues: aBlockNode scope inComingCopiedVarNames  ]
+	
+	self compilationContext optionBlockClosureOptionalOuter 
+		ifTrue: [ methodBuilder pushFullClosureCompiledBlock: compiledBlock copiedValues: aBlockNode scope inComingCopiedVarNames outerContextNeeded: aBlockNode hasNonLocalReturn  ]
+		ifFalse: [ methodBuilder pushFullClosureCompiledBlock: compiledBlock copiedValues: aBlockNode scope inComingCopiedVarNames ]
+	
 ]
 
 { #category : #'visitor - double dispatching' }
@@ -531,6 +535,19 @@ OCASTTranslator >> visitCascadeNode: aCascadeNode [
 		effectTranslator visitNode: node.
 	].
 	self visitNode: aCascadeNode messages last.
+]
+
+{ #category : #'visitor - double dispatching' }
+OCASTTranslator >> visitCleanBlockNode: aBlockNode [
+
+	| compiledBlock cleanBlock |
+	compiledBlock := self compilationContext astTranslatorClass new 
+		                 translateFullBlock: aBlockNode.
+	cleanBlock := (CleanBlockClosure new: 0)
+			 numArgs: compiledBlock numArgs;
+			 compiledBlock: compiledBlock.
+
+	methodBuilder pushLiteral: cleanBlock
 ]
 
 { #category : #'visitor - double dispatching' }


### PR DESCRIPTION
Add compiler option for outerContextNeeded, it is disabled by default