### PR TITLE
11912-Compiler-add-option-for-constant-blocks

### DIFF
--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -131,6 +131,16 @@ CompilationContext class >> optionCleanBlockClosure: aBoolean [
 ]
 
 { #category : #'options - settings API' }
+CompilationContext class >> optionConstantBlockClosure [
+	^ self readDefaultOption: #optionConstantBlockClosure
+]
+
+{ #category : #'options - settings API' }
+CompilationContext class >> optionConstantBlockClosure: aBoolean [
+	^ self writeDefaultOption: #optionConstantBlockClosure value: aBoolean
+]
+
+{ #category : #'options - settings API' }
 CompilationContext class >> optionEmbeddSources [
 	^ self readDefaultOption: #optionEmbeddSources
 ]
@@ -299,7 +309,8 @@ CompilationContext class >> optionsDescription [
 	(- optionInlineNone 				'To turn off all inlining options. Overrides the others')
 	
 	(- optionEmbeddSources         'Embedd sources into CompiledMethod instead of storing in .changes')
-		(- optionBlockClosureOptionalOuter 			'Compiler compiles closure creation with outerContext only if it has a non-local return. Experimental')
+	(- optionBlockClosureOptionalOuter 			'Compiler compiles closure creation with outerContext only if it has a non-local return. Experimental')
+	(- optionConstantBlockClosure 			'Compiler compiles closure creation to use ConstantBlockClosure for constant with 0-3 arguments. Experimental')
 	(- optionCleanBlockClosure 			'Compiler compiles closure creation to use CleanBlockClosure instead of FullBlockClosure for clean blocks. Experimental')
 	(- optionLongIvarAccessBytecodes 	'Specific inst var accesses to Maybe context objects')
 	(+ optionOptimizeIR 					'Rewrite jumps in bytecode in a slightly more efficient way')
@@ -511,6 +522,11 @@ CompilationContext >> optionBlockClosureOptionalOuter [
 { #category : #options }
 CompilationContext >> optionCleanBlockClosure [
 	^ options includes: #optionCleanBlockClosure
+]
+
+{ #category : #options }
+CompilationContext >> optionConstantBlockClosure [
+	^ options includes: #optionConstantBlockClosure
 ]
 
 { #category : #options }

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -515,7 +515,7 @@ OCASTTranslator >> visitBlockNode: aBlockNode [
 	aBlockNode arguments size >15 ifTrue: [self backendError: 'Too many arguments' forNode: aBlockNode ].
 	
 	aBlockNode isInlined ifTrue: [^ self visitInlinedBlockNode: aBlockNode ].
-	(self compilationContext optionCleanBlockClosure and: [aBlockNode isConstant and: [ aBlockNode numArgs < 4  ]]) ifTrue: [ ^ self visitConstantBlockNode: aBlockNode].
+	(self compilationContext optionConstantBlockClosure and: [aBlockNode isConstant and: [ aBlockNode numArgs < 4  ]]) ifTrue: [ ^ self visitConstantBlockNode: aBlockNode].
 	(self compilationContext optionCleanBlockClosure and: [ aBlockNode isClean ]) ifTrue: [ ^ self visitCleanBlockNode: aBlockNode].
 	
 	compiledBlock := self compilationContext astTranslatorClass new translateFullBlock: aBlockNode.
@@ -539,8 +539,11 @@ OCASTTranslator >> visitCascadeNode: aCascadeNode [
 
 { #category : #'visitor - double dispatching' }
 OCASTTranslator >> visitCleanBlockNode: aBlockNode [
+	"create and push a clean blockclosure. As we create the clean block at compile time,
+	block creation at runtime is much faster than that of a full block"
 
 	| compiledBlock cleanBlock |
+	
 	compiledBlock := self compilationContext astTranslatorClass new 
 		                 translateFullBlock: aBlockNode.
 	cleanBlock := (CleanBlockClosure new: 0)
@@ -552,7 +555,8 @@ OCASTTranslator >> visitCleanBlockNode: aBlockNode [
 
 { #category : #'visitor - double dispatching' }
 OCASTTranslator >> visitConstantBlockNode: anBlockNode [
-
+	"create statically a constant blockclosure (we support 0-3 arguments). 
+	Constant blockclosures are specialized clean blocks: same creation speed, but faster execution"
 	| constantBlock compiledBlock |
 	constantBlock := ConstantBlockClosure 
 							  numArgs: anBlockNode numArgs


### PR DESCRIPTION
add an option to turn on constant block that is independend of the clean block option. fixes #11912