### PR TITLE
Fixes #11925, ExternalBrowser does not show class definition from ST files Bug

### DIFF
--- a/src/Ring-OldChunkImporter/RingChunkImporter.class.st
+++ b/src/Ring-OldChunkImporter/RingChunkImporter.class.st
@@ -215,7 +215,7 @@ RingChunkImporter >> visitDoItChunk: aChunk [
 
 	| contents |
 	contents := aChunk contents.
-	('*ubclass:*instanceVariableNames:*classVariableNames:*poolDictionaries:*category:*'
+	('*ubclass:*instanceVariableNames:*'
 		match: contents) ifTrue:[^self classDefinition: contents with: aChunk].
 	('* class*instanceVariableNames:*'
 		match: contents) ifTrue:[^self metaClassDefinition: contents with: aChunk].		


### PR DESCRIPTION
Fixes issue: #11925.
This patch makes sure `visitDoItChunk:` delegates to `classDefinition:with:` for a wider range of class definitions. It is `classDefinition:with` which does the actual work. 