### PR TITLE
ReNotOptimizedIfNilRule

### DIFF
--- a/src/GeneralRules/ReNotOptimizedIfNilRule.class.st
+++ b/src/GeneralRules/ReNotOptimizedIfNilRule.class.st
@@ -1,0 +1,32 @@
+"
+ifNil: ifNotNil: ifNil:ifNotNil: ifNotNil:ifNil: is used in a way that it can not be optimized.
+
+This can be fixed by making sure that all arguments are static blocks.
+
+See the method RBMessageNode>>#isInlineIfNil for the exact implementation of the check that the compiler uses
+
+
+"
+Class {
+	#name : #ReNotOptimizedIfNilRule,
+	#superclass : #ReNodeBasedRule,
+	#category : #'GeneralRules-Migrated'
+}
+
+{ #category : #running }
+ReNotOptimizedIfNilRule >> check: aNode forCritiquesDo: aBlock [
+	aNode isMessage ifFalse: [  ^ self ].
+	(#(ifNil: ifNotNil: ifNil:ifNotNil: ifNotNil:ifNil:) includes: aNode selector) ifFalse: [^ self].
+	aNode isInlineIfNil ifFalse: [
+		aBlock cull: (self critiqueFor: aNode) ]
+]
+
+{ #category : #accessing }
+ReNotOptimizedIfNilRule >> group [
+	^ 'Optimization'
+]
+
+{ #category : #accessing }
+ReNotOptimizedIfNilRule >> name [
+	^ 'ifNil: ifNotNil: ifNil:ifNotNil: ifNotNil:ifNil: is used in a way that it can not be optimized'
+]


### PR DESCRIPTION
This PR add ReNotOptimizedIfNilRule, it is ReNotOptimizedIfRule, but for ifNil: and friends.

```
ifNil: ifNotNil: ifNil:ifNotNil: ifNotNil:ifNil: is used in a way that it can not be optimized.

This can be fixed by making sure that all arguments are static blocks.

See the method RBMessageNode>>#isInlineIfNil for the exact implementation of the check that the compiler uses
```

It finds 113 cases in the current image