### PR TITLE
Some smaller fixes/cleanups related to Blocks

### DIFF
--- a/src/AST-Core-Tests/RBBlockNodeTest.class.st
+++ b/src/AST-Core-Tests/RBBlockNodeTest.class.st
@@ -19,6 +19,7 @@ RBBlockNodeTest >> testHasNonLocalReturn [
 	self deny: [ [  ] ] sourceNode hasNonLocalReturn.
 	self assert: [ ^ 1 ] sourceNode hasNonLocalReturn.
 	self assert: [ [ ^ 1 ] ] sourceNode hasNonLocalReturn.
+	self assert: [ { 1 . ^2 }  ] sourceNode hasNonLocalReturn.
 	self assert: (self class>>#testHasNonLocalReturn) ast hasNonLocalReturn.
 	"return on the level of the method is a local return"
 	self deny: (Object>>#yourself) ast hasNonLocalReturn.
@@ -31,6 +32,7 @@ RBBlockNodeTest >> testIsClean [
 	escpRead := escpWrite := 1.
 	self deny: [ self yourself ] sourceNode isClean.
 	self deny: [ ^ 1 ] sourceNode isClean.
+	self deny: [ { 1 . ^2 }  ] sourceNode isClean.
 	self deny: [ testSelector foo ] sourceNode isClean.
 	self deny: [ escpRead foo ] sourceNode isClean.
 	self deny: [ escpWrite := 2 ] sourceNode isClean.
@@ -46,6 +48,7 @@ RBBlockNodeTest >> testIsClean [
 	self assert: [ :a | a + 2 ] sourceNode isClean.
 	self assert: [ :a :b | a + b + 3 ] sourceNode isClean.
 	self assert: [ | a | a := 1. a + 3 ] sourceNode isClean.
+		
 	self assert: [ true ifTrue: [  ] ]  sourceNode isClean.
 	"optimized blocks"
 	self assert: [ 

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -93,6 +93,14 @@ CompiledCode >> accessesSlot: aSlot [
 ]
 
 { #category : #accessing }
+CompiledCode >> allBlocks [
+	| all |
+	all := IdentitySet new.
+	self allBlocksDo: [ :each | all add: each ].
+	^all
+]
+
+{ #category : #accessing }
 CompiledCode >> allBlocksDo: aBlock [
 
 	self literals 

--- a/src/OpalCompiler-Core/CompiledCode.extension.st
+++ b/src/OpalCompiler-Core/CompiledCode.extension.st
@@ -16,3 +16,9 @@ CompiledCode >> compilerClass [
 		ifNil: [Smalltalk compilerClass] 
 		ifNotNil: [:class | class compilerClass].
 ]
+
+{ #category : #'*OpalCompiler-Core' }
+CompiledCode >> ir [
+	"We as the AST for the IR... for decompiling ir from bytecode, look at IRBytecodeDecompiler"
+	^ self ast ir
+]

--- a/src/OpalCompiler-Core/CompiledMethod.extension.st
+++ b/src/OpalCompiler-Core/CompiledMethod.extension.st
@@ -16,12 +16,6 @@ CompiledMethod >> decompileIR [
 ]
 
 { #category : #'*OpalCompiler-Core' }
-CompiledMethod >> ir [
-	"We as the AST for the IR... for decompiling ir from bytecode, look at IRBytecodeDecompiler"
-	^ self ast ir
-]
-
-{ #category : #'*OpalCompiler-Core' }
 CompiledMethod >> irPrimitive [
 
 	| primNode n |


### PR DESCRIPTION
- #isClean and #hasNonLocalReturn tests should test for { 1 . ^2 }
- add CompileCode #allBlocks, as we have withAllBlocks already
- Move #ir from CompiledMethod to CompiledCode to allow easy access of the block IR