### PR TITLE
EpHasImpactVisitor>>visitProtocolRemoval: handle protocols that only contain trait methods.

### DIFF
--- a/src/EpiceaBrowsers-Tests/EpHasImpactFilterTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpHasImpactFilterTest.class.st
@@ -118,3 +118,25 @@ EpHasImpactFilterTest >> testMethodWithoutImpact [
 	anEvent := OmEntry content: (EpMethodAddition method: aClass >> #a).
 	self deny: (impactFilter accepts: anEvent)
 ]
+
+{ #category : #tests }
+EpHasImpactFilterTest >> testProtocolRemovalOfTraitProtocol [
+	| anEntry aClass |
+
+	aClass := classFactory
+		newSubclassOf: classFactory defaultSuperclass 
+		uses: TAssertable
+		instanceVariableNames: '' 
+		classVariableNames: '' 
+		category: classFactory defaultTagPostfix.
+	anEntry := OmEntry content: (EpProtocolRemoval
+		behavior: aClass asRingDefinition 
+		protocol: #private).
+	self deny: (impactFilter accepts: anEntry).
+
+	aClass 
+		compile: 'a ^1'
+		classified: #private.
+
+	self assert: (impactFilter accepts: anEntry).
+]

--- a/src/EpiceaBrowsers/EpHasImpactVisitor.class.st
+++ b/src/EpiceaBrowsers/EpHasImpactVisitor.class.st
@@ -155,12 +155,20 @@ EpHasImpactVisitor >> visitProtocolAddition: aProtocolAddition [
 
 { #category : #visitor }
 EpHasImpactVisitor >> visitProtocolRemoval: aProtocolRemoved [
+	"Protocol removal has an impact if:
+	- the protocl exists, and
+	- there are methods in the protocol that are not trait methods"
 
 	self 
 		behaviorNamed: aProtocolRemoved behaviorAffectedName
-		ifPresent: [ :behavior | 
-			^ behavior organization protocolOrganizer hasProtocolNamed: aProtocolRemoved protocol ].
-		
+		ifPresent: [ :behavior | | selectors |
+			selectors := (behavior organization protocolOrganizer 
+				getProtocolNamed: aProtocolRemoved protocol
+				ifNone: [ ^ false ]) methodSelectors.
+			(selectors allSatisfy: [ :each |
+					(behavior compiledMethodAt: each) isFromTrait ]) ifTrue:
+						[ ^ false ] ].
+
 	^ true
 ]
 


### PR DESCRIPTION
See: https://github.com/pharo-project/pharo/issues/11941