### PR TITLE
[Compiler] fix code generation when compiling syntax errors: EnglobingError

### DIFF
--- a/src/AST-Core/RBParseErrorNode.class.st
+++ b/src/AST-Core/RBParseErrorNode.class.st
@@ -51,16 +51,6 @@ RBParseErrorNode >> arguments [
 	^ #()
 ]
 
-{ #category : #converting }
-RBParseErrorNode >> asSyntaxErrorNotification [
-	^SyntaxErrorNotification new
-		setClass: self methodNode methodClass
-		code: self methodNode source
-		doitFlag: false
-		errorMessage: errorMessage
-		location: self start
-]
-
 { #category : #accessing }
 RBParseErrorNode >> binding: anOCTempVariable [ 
 	"only for compatibility"

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -567,6 +567,12 @@ OCASTTranslator >> visitConstantBlockNode: anBlockNode [
 ]
 
 { #category : #'visitor - double dispatching' }
+OCASTTranslator >> visitEnglobingErrorNode: anErrorNode [
+	"raise error at runtime"
+	self visitParseErrorNode: anErrorNode
+]
+
+{ #category : #'visitor - double dispatching' }
 OCASTTranslator >> visitInlinedBlockNode: anOptimizedBlockNode [
 
 	"We are visiting a scope that is not a block, but inlined in the outer context.

--- a/src/OpalCompiler-Tests/OCCompileWithFailureTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompileWithFailureTest.class.st
@@ -44,3 +44,18 @@ OCCompileWithFailureTest >> testEvalSimpleMethodWithError [
 	cm := ast compiledMethod.
 	self should: [cm valueWithReceiver: nil arguments: #()] raise: RuntimeSyntaxError
 ]
+
+{ #category : #tests }
+OCCompileWithFailureTest >> testParenthesis [
+	| result cm | 
+	result := UndefinedObject compiler
+    source: 'self assert: pragma( numArgs equals: 0.';
+    noPattern: true;
+    options:  #(+ optionParseErrors + optionSkipSemanticWarnings);
+    requestor: self;
+    parse. 
+	self assert: result isDoIt.
+	self assert: result isFaulty.
+	cm := result compiledMethod.
+	self should: [cm valueWithReceiver: nil arguments: #()] raise: RuntimeSyntaxError
+]


### PR DESCRIPTION
- add a test with an faulty expression that has a EnglobingError
- implement visitEnglobingErrorNode: in the compiler to generate a runtime error so we open a debugger if we execute code like that
- remove  unused #asSyntaxErrorNotification