### PR TITLE
do not rebuild all Calypso tools at each selection change

### DIFF
--- a/src/Calypso-Browser-Tests/ClyBrowserContextAbstractTest.class.st
+++ b/src/Calypso-Browser-Tests/ClyBrowserContextAbstractTest.class.st
@@ -1,0 +1,146 @@
+Class {
+	#name : #ClyBrowserContextAbstractTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'browser'
+	],
+	#category : #'Calypso-Browser-Tests'
+}
+
+{ #category : #helpers }
+ClyBrowserContextAbstractTest >> allClyContextBut: contexts [
+
+	^ {  ClyFullBrowserPackageContext.
+		  ClyFullBrowserClassGroupContext.
+		  ClyFullBrowserMethodContext.
+		  ClyFullBrowserMethodGroupContext.
+		  ClyFullBrowserVariableContext } 
+		reject: [ :ctx | contexts includes: ctx ]
+]
+
+{ #category : #helpers }
+ClyBrowserContextAbstractTest >> classContext [
+
+	^ ClyFullBrowserClassContext new
+		tool: browser;
+		selectedItems: browser classSelection items;
+		yourself.
+]
+
+{ #category : #helpers }
+ClyBrowserContextAbstractTest >> classGroupContext [
+
+	^ ClyFullBrowserClassGroupContext new
+		tool: browser;
+		selectedItems: browser classGroupSelection items;
+		yourself.
+]
+
+{ #category : #helpers }
+ClyBrowserContextAbstractTest >> datasourceItemsWith: anObject named: aName [
+
+	^ { ClyDataSourceItem of: nil value: (ClyBrowserItem named: aName with: anObject) }
+]
+
+{ #category : #helpers }
+ClyBrowserContextAbstractTest >> deleteBrowser [
+
+	browser ifNotNil: [ 
+		browser window ifNotNil: [ :window | 
+			window delete ] ]
+]
+
+{ #category : #helpers }
+ClyBrowserContextAbstractTest >> differentClassGroupContext [
+	| items |
+	
+	self deleteBrowser.
+	browser := ClyFullBrowserMorph open.
+	browser selectPackage: (RPackageOrganizer default packageNamed: #Kernel) atClassTag: 'Chronology'.
+	items := browser classGroupSelection items.
+
+	^ ClyFullBrowserClassGroupContext new
+		tool: browser;
+		selectedItems: items;
+		yourself.
+]
+
+{ #category : #helpers }
+ClyBrowserContextAbstractTest >> differentMethodContext [
+
+	^ self methodContext
+		selectedItems: (self datasourceItemsWith: Object>>#= named: #new );
+		yourself
+]
+
+{ #category : #helpers }
+ClyBrowserContextAbstractTest >> differentPackageContext [
+
+	^ self packageContext
+		selectedItems: (self datasourceItemsWith: Object package named: #Kernel );
+		yourself
+]
+
+{ #category : #helpers }
+ClyBrowserContextAbstractTest >> findBrowserTool: aClyToolMorphClass [
+	
+	^ browser tabManager tools 
+		detect: [ :aTool | aTool class = aClyToolMorphClass ]
+]
+
+{ #category : #helpers }
+ClyBrowserContextAbstractTest >> methodContext [
+
+	^ ClyFullBrowserMethodContext new
+		selectedItems: browser methodSelection items;
+		yourself.
+]
+
+{ #category : #helpers }
+ClyBrowserContextAbstractTest >> methodGroupContext [
+
+	^ ClyFullBrowserMethodGroupContext new
+		selectedItems: browser methodGroupSelection items;
+		yourself.
+]
+
+{ #category : #helpers }
+ClyBrowserContextAbstractTest >> openBrowserWithPackageAndClassGroupOnlySelected [
+
+	self deleteBrowser.
+	browser := ClyFullBrowserMorph open.
+	browser selectPackage: (RPackageOrganizer default packageNamed: #Kernel) atClassTag: 'BasicObjects'.
+]
+
+{ #category : #helpers }
+ClyBrowserContextAbstractTest >> openBrowserWithPackageOnlySelected [
+
+	self deleteBrowser.
+	browser := ClyFullBrowserMorph open.
+	browser selectPackage: self class package.
+]
+
+{ #category : #helpers }
+ClyBrowserContextAbstractTest >> packageContext [
+
+	^ ClyFullBrowserPackageContext new
+		tool: browser;
+		selectedItems: browser packageSelection items;
+		yourself.
+]
+
+{ #category : #running }
+ClyBrowserContextAbstractTest >> setUp [
+	super setUp.
+	
+	browser := ClyFullBrowserMorph 
+		openOnClass: self class 
+		selector: self class selectors anyOne.
+]
+
+{ #category : #running }
+ClyBrowserContextAbstractTest >> tearDown [ 
+
+	self deleteBrowser.
+	super tearDown.
+]

--- a/src/Calypso-Browser-Tests/ClyBrowserToolValidityTest.class.st
+++ b/src/Calypso-Browser-Tests/ClyBrowserToolValidityTest.class.st
@@ -1,0 +1,349 @@
+Class {
+	#name : #ClyBrowserToolValidityTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'browser',
+		'tool',
+		'context'
+	],
+	#category : #'Calypso-Browser-Tests'
+}
+
+{ #category : #helpers }
+ClyBrowserToolValidityTest >> allClyContextBut: contexts [
+
+	^ {  ClyFullBrowserPackageContext.
+		  ClyFullBrowserClassGroupContext.
+		  ClyFullBrowserMethodContext.
+		  ClyFullBrowserMethodGroupContext.
+		  ClyFullBrowserVariableContext } 
+		reject: [ :ctx | contexts includes: ctx ]
+]
+
+{ #category : #helpers }
+ClyBrowserToolValidityTest >> classContext [
+
+	^ ClyFullBrowserClassContext new
+		tool: browser;
+		selectedItems: browser classSelection items;
+		yourself.
+]
+
+{ #category : #helpers }
+ClyBrowserToolValidityTest >> classGroupContext [
+
+	^ ClyFullBrowserClassGroupContext new
+		tool: browser;
+		selectedItems: browser classGroupSelection items;
+		yourself.
+]
+
+{ #category : #helpers }
+ClyBrowserToolValidityTest >> datasourceItemsWith: anObject named: aName [
+
+	^ { ClyDataSourceItem of: nil value: (ClyBrowserItem named: aName with: anObject) }
+]
+
+{ #category : #helpers }
+ClyBrowserToolValidityTest >> deleteBrowser [
+
+	browser ifNotNil: [ 
+		browser window ifNotNil: [ :window | 
+			window delete ] ]
+]
+
+{ #category : #helpers }
+ClyBrowserToolValidityTest >> differentClassGroupContext [
+	| items |
+	
+	self deleteBrowser.
+	browser := ClyFullBrowserMorph open.
+	browser selectPackage: (RPackageOrganizer default packageNamed: #Kernel) atClassTag: 'Chronology'.
+	items := browser classGroupSelection items.
+
+	^ ClyFullBrowserClassGroupContext new
+		tool: browser;
+		selectedItems: items;
+		yourself.
+]
+
+{ #category : #helpers }
+ClyBrowserToolValidityTest >> differentMethodContext [
+
+	^ self methodContext
+		selectedItems: (self datasourceItemsWith: Object>>#= named: #new );
+		yourself
+]
+
+{ #category : #helpers }
+ClyBrowserToolValidityTest >> differentPackageContext [
+
+	^ self packageContext
+		selectedItems: (self datasourceItemsWith: Object package named: #Kernel );
+		yourself
+]
+
+{ #category : #helpers }
+ClyBrowserToolValidityTest >> findBrowserTool: aClyToolMorphClass [
+	
+	^ browser tabManager tools 
+		detect: [ :aTool | aTool class = aClyToolMorphClass ]
+]
+
+{ #category : #testing }
+ClyBrowserToolValidityTest >> isValidInContextOtherThan: someContexts [
+
+	^ (self allClyContextBut: someContexts) 
+		anySatisfy: [ :ctx | tool isValidInContext: ctx ]
+]
+
+{ #category : #helpers }
+ClyBrowserToolValidityTest >> methodContext [
+
+	^ ClyFullBrowserMethodContext new
+		selectedItems: browser methodSelection items;
+		yourself.
+]
+
+{ #category : #helpers }
+ClyBrowserToolValidityTest >> methodGroupContext [
+
+	^ ClyFullBrowserMethodGroupContext new
+		selectedItems: browser methodGroupSelection items;
+		yourself.
+]
+
+{ #category : #helpers }
+ClyBrowserToolValidityTest >> openBrowserWithPackageAndClassGroupOnlySelected [
+
+	self deleteBrowser.
+	browser := ClyFullBrowserMorph open.
+	browser selectPackage: (RPackageOrganizer default packageNamed: #Kernel) atClassTag: 'BasicObjects'.
+]
+
+{ #category : #helpers }
+ClyBrowserToolValidityTest >> openBrowserWithPackageOnlySelected [
+
+	self deleteBrowser.
+	browser := ClyFullBrowserMorph open.
+	browser selectPackage: self class package.
+]
+
+{ #category : #helpers }
+ClyBrowserToolValidityTest >> packageContext [
+
+	^ ClyFullBrowserPackageContext new
+		tool: browser;
+		selectedItems: browser packageSelection items;
+		yourself.
+]
+
+{ #category : #running }
+ClyBrowserToolValidityTest >> setUp [
+	super setUp.
+	
+	browser := ClyFullBrowserMorph 
+		openOnClass: self class 
+		selector: self class selectors anyOne.
+]
+
+{ #category : #running }
+ClyBrowserToolValidityTest >> tearDown [ 
+
+	self deleteBrowser
+]
+
+{ #category : #tests }
+ClyBrowserToolValidityTest >> testClassCommentToolIsNotValidWhenNotAClassContext [
+
+	tool := self findBrowserTool: ClyRichTextClassCommentEditorToolMorph.
+	
+	self deny: (self isValidInContextOtherThan: { ClyFullBrowserClassContext }).
+]
+
+{ #category : #tests }
+ClyBrowserToolValidityTest >> testClassCommentToolIsNotValidWhenReferencingDifferentClass [
+
+	tool := self findBrowserTool: ClyRichTextClassCommentEditorToolMorph.
+	context := self classContext
+		selectedItems: (self datasourceItemsWith: Object named: #Object );
+		yourself.
+	
+	self deny: (tool isValidInContext: context).
+]
+
+{ #category : #tests }
+ClyBrowserToolValidityTest >> testClassCommentToolIsValidWhenReferencingSameClass [
+
+	tool := self findBrowserTool: ClyRichTextClassCommentEditorToolMorph.
+	
+	self assert: (tool isValidInContext: self classContext).
+]
+
+{ #category : #tests }
+ClyBrowserToolValidityTest >> testClassCreationToolIsNotValidWhenNotAPackageOrClassGroupContext [
+	
+	self openBrowserWithPackageOnlySelected.
+	tool := self findBrowserTool: ClyClassCreationToolMorph.
+	
+	self deny: (self isValidInContextOtherThan: { ClyFullBrowserPackageContext . ClyFullBrowserClassGroupContext }).
+]
+
+{ #category : #tests }
+ClyBrowserToolValidityTest >> testClassCreationToolIsNotValidWhenReferencingDifferentClassGroup [
+
+	self openBrowserWithPackageAndClassGroupOnlySelected.
+	tool := self findBrowserTool: ClyClassCreationToolMorph.
+	
+	self deny: (tool isValidInContext: self differentClassGroupContext).
+]
+
+{ #category : #tests }
+ClyBrowserToolValidityTest >> testClassCreationToolIsNotValidWhenReferencingDifferentPackage [
+
+	self openBrowserWithPackageOnlySelected.
+	tool := self findBrowserTool: ClyClassCreationToolMorph.
+	
+	self deny: (tool isValidInContext: self differentPackageContext).
+]
+
+{ #category : #tests }
+ClyBrowserToolValidityTest >> testClassCreationToolIsValidWhenClassGroupContext [
+
+	self openBrowserWithPackageAndClassGroupOnlySelected.
+	tool := self findBrowserTool: ClyClassCreationToolMorph.
+	
+	self assert: (tool isValidInContext: self classGroupContext).
+]
+
+{ #category : #tests }
+ClyBrowserToolValidityTest >> testClassCreationToolIsValidWhenPackageContext [
+
+	self openBrowserWithPackageOnlySelected.
+	tool := self findBrowserTool: ClyClassCreationToolMorph.
+	
+	self assert: (tool isValidInContext: self packageContext).
+]
+
+{ #category : #tests }
+ClyBrowserToolValidityTest >> testClassDefinitionToolIsNotValidWhenNotAClassContext [
+
+	tool := self findBrowserTool: ClyClassDefinitionEditorToolMorph.
+	
+	self deny: (self isValidInContextOtherThan: { ClyFullBrowserClassContext }).
+]
+
+{ #category : #tests }
+ClyBrowserToolValidityTest >> testClassDefinitionToolIsNotValidWhenReferencingDifferentClass [
+
+	tool := self findBrowserTool: ClyClassDefinitionEditorToolMorph.
+	context := self classContext
+		selectedItems: (self datasourceItemsWith: Object named: #Object );
+		yourself.
+	
+	self deny: (tool isValidInContext: context).
+]
+
+{ #category : #tests }
+ClyBrowserToolValidityTest >> testClassDefinitionToolIsValidWhenClassContext [
+
+	tool := self findBrowserTool: ClyClassDefinitionEditorToolMorph.
+	
+	self assert: (tool isValidInContext: self classContext).
+]
+
+{ #category : #tests }
+ClyBrowserToolValidityTest >> testMethodEditorToolIsNotValidWhenNotAMethodContext [
+
+	tool := self findBrowserTool: ClyMethodCodeEditorToolMorph.
+	
+	self deny: (self isValidInContextOtherThan: { ClyFullBrowserMethodContext }).
+]
+
+{ #category : #tests }
+ClyBrowserToolValidityTest >> testMethodEditorToolIsNotValidWhenReferencingDifferentMethod [
+
+	tool := self findBrowserTool: ClyMethodCodeEditorToolMorph.
+	
+	self deny: (tool isValidInContext: self differentMethodContext).
+]
+
+{ #category : #tests }
+ClyBrowserToolValidityTest >> testMethodEditorToolIsValidWhenReferencingSameMethod [
+
+	tool := self findBrowserTool: ClyMethodCodeEditorToolMorph.
+	
+	self assert: (tool isValidInContext: self methodContext).
+]
+
+{ #category : #tests }
+ClyBrowserToolValidityTest >> testPackageCommentToolIsNotValidWhenNotAPackageOrClassGroupContext [
+
+	self openBrowserWithPackageOnlySelected.
+	tool := self findBrowserTool: ClyPackageRichTextCommentEditorToolMorph.
+	
+	self deny: (self isValidInContextOtherThan: { ClyFullBrowserPackageContext . ClyFullBrowserClassGroupContext }).
+]
+
+{ #category : #tests }
+ClyBrowserToolValidityTest >> testPackageCommentToolIsNotValidWhenReferencingDifferentPackage [
+
+	self openBrowserWithPackageOnlySelected.
+	tool := self findBrowserTool: ClyPackageRichTextCommentEditorToolMorph.
+	
+	self deny: (tool isValidInContext: self differentPackageContext).
+]
+
+{ #category : #tests }
+ClyBrowserToolValidityTest >> testPackageCommentToolIsValidWhenClassGroupContext [
+
+	self openBrowserWithPackageAndClassGroupOnlySelected.
+	tool := self findBrowserTool: ClyPackageRichTextCommentEditorToolMorph.
+	
+	self assert: (tool isValidInContext: self classGroupContext).
+]
+
+{ #category : #tests }
+ClyBrowserToolValidityTest >> testPackageCommentToolIsValidWhenReferencingDifferentClassGroup [
+
+	self openBrowserWithPackageAndClassGroupOnlySelected.
+	tool := self findBrowserTool: ClyPackageRichTextCommentEditorToolMorph.
+	
+	self assert: (tool isValidInContext: self differentClassGroupContext).
+]
+
+{ #category : #tests }
+ClyBrowserToolValidityTest >> testPackageCommmentToolIsValidWhenPackageContext [
+
+	self openBrowserWithPackageOnlySelected.
+	tool := self findBrowserTool: ClyPackageRichTextCommentEditorToolMorph.
+		
+	self assert: (tool isValidInContext: self packageContext).
+]
+
+{ #category : #tests }
+ClyBrowserToolValidityTest >> testSetUpToolIsNotValidWhenNotAClassContext [
+
+	tool := self findBrowserTool: ClyTestSetUpEditorToolMorph.
+	
+	self deny: (self isValidInContextOtherThan: { ClyFullBrowserClassContext }).
+]
+
+{ #category : #tests }
+ClyBrowserToolValidityTest >> testSetUpToolIsNotValidWhenReferencingDifferentClass [
+
+	tool := self findBrowserTool: ClyTestSetUpEditorToolMorph.
+	context := self classContext
+		selectedItems: (self datasourceItemsWith: Object named: #Object );
+		yourself.
+	
+	self deny: (tool isValidInContext: context).
+]
+
+{ #category : #tests }
+ClyBrowserToolValidityTest >> testSetUpToolIsValidWhenReferencingSameClass [
+
+	tool := self findBrowserTool: ClyTestSetUpEditorToolMorph.
+	
+	self assert: (tool isValidInContext: self classContext).
+]

--- a/src/Calypso-Browser-Tests/ClyBrowserToolValidityTest.class.st
+++ b/src/Calypso-Browser-Tests/ClyBrowserToolValidityTest.class.st
@@ -1,156 +1,18 @@
 Class {
 	#name : #ClyBrowserToolValidityTest,
-	#superclass : #TestCase,
+	#superclass : #ClyBrowserContextAbstractTest,
 	#instVars : [
-		'browser',
 		'tool',
 		'context'
 	],
 	#category : #'Calypso-Browser-Tests'
 }
 
-{ #category : #helpers }
-ClyBrowserToolValidityTest >> allClyContextBut: contexts [
-
-	^ {  ClyFullBrowserPackageContext.
-		  ClyFullBrowserClassGroupContext.
-		  ClyFullBrowserMethodContext.
-		  ClyFullBrowserMethodGroupContext.
-		  ClyFullBrowserVariableContext } 
-		reject: [ :ctx | contexts includes: ctx ]
-]
-
-{ #category : #helpers }
-ClyBrowserToolValidityTest >> classContext [
-
-	^ ClyFullBrowserClassContext new
-		tool: browser;
-		selectedItems: browser classSelection items;
-		yourself.
-]
-
-{ #category : #helpers }
-ClyBrowserToolValidityTest >> classGroupContext [
-
-	^ ClyFullBrowserClassGroupContext new
-		tool: browser;
-		selectedItems: browser classGroupSelection items;
-		yourself.
-]
-
-{ #category : #helpers }
-ClyBrowserToolValidityTest >> datasourceItemsWith: anObject named: aName [
-
-	^ { ClyDataSourceItem of: nil value: (ClyBrowserItem named: aName with: anObject) }
-]
-
-{ #category : #helpers }
-ClyBrowserToolValidityTest >> deleteBrowser [
-
-	browser ifNotNil: [ 
-		browser window ifNotNil: [ :window | 
-			window delete ] ]
-]
-
-{ #category : #helpers }
-ClyBrowserToolValidityTest >> differentClassGroupContext [
-	| items |
-	
-	self deleteBrowser.
-	browser := ClyFullBrowserMorph open.
-	browser selectPackage: (RPackageOrganizer default packageNamed: #Kernel) atClassTag: 'Chronology'.
-	items := browser classGroupSelection items.
-
-	^ ClyFullBrowserClassGroupContext new
-		tool: browser;
-		selectedItems: items;
-		yourself.
-]
-
-{ #category : #helpers }
-ClyBrowserToolValidityTest >> differentMethodContext [
-
-	^ self methodContext
-		selectedItems: (self datasourceItemsWith: Object>>#= named: #new );
-		yourself
-]
-
-{ #category : #helpers }
-ClyBrowserToolValidityTest >> differentPackageContext [
-
-	^ self packageContext
-		selectedItems: (self datasourceItemsWith: Object package named: #Kernel );
-		yourself
-]
-
-{ #category : #helpers }
-ClyBrowserToolValidityTest >> findBrowserTool: aClyToolMorphClass [
-	
-	^ browser tabManager tools 
-		detect: [ :aTool | aTool class = aClyToolMorphClass ]
-]
-
 { #category : #testing }
 ClyBrowserToolValidityTest >> isValidInContextOtherThan: someContexts [
 
 	^ (self allClyContextBut: someContexts) 
 		anySatisfy: [ :ctx | tool isValidInContext: ctx ]
-]
-
-{ #category : #helpers }
-ClyBrowserToolValidityTest >> methodContext [
-
-	^ ClyFullBrowserMethodContext new
-		selectedItems: browser methodSelection items;
-		yourself.
-]
-
-{ #category : #helpers }
-ClyBrowserToolValidityTest >> methodGroupContext [
-
-	^ ClyFullBrowserMethodGroupContext new
-		selectedItems: browser methodGroupSelection items;
-		yourself.
-]
-
-{ #category : #helpers }
-ClyBrowserToolValidityTest >> openBrowserWithPackageAndClassGroupOnlySelected [
-
-	self deleteBrowser.
-	browser := ClyFullBrowserMorph open.
-	browser selectPackage: (RPackageOrganizer default packageNamed: #Kernel) atClassTag: 'BasicObjects'.
-]
-
-{ #category : #helpers }
-ClyBrowserToolValidityTest >> openBrowserWithPackageOnlySelected [
-
-	self deleteBrowser.
-	browser := ClyFullBrowserMorph open.
-	browser selectPackage: self class package.
-]
-
-{ #category : #helpers }
-ClyBrowserToolValidityTest >> packageContext [
-
-	^ ClyFullBrowserPackageContext new
-		tool: browser;
-		selectedItems: browser packageSelection items;
-		yourself.
-]
-
-{ #category : #running }
-ClyBrowserToolValidityTest >> setUp [
-	super setUp.
-	
-	browser := ClyFullBrowserMorph 
-		openOnClass: self class 
-		selector: self class selectors anyOne.
-]
-
-{ #category : #running }
-ClyBrowserToolValidityTest >> tearDown [ 
-
-	self deleteBrowser
 ]
 
 { #category : #tests }

--- a/src/Calypso-Browser-Tests/ClyNotebookPageRecyclerTest.class.st
+++ b/src/Calypso-Browser-Tests/ClyNotebookPageRecyclerTest.class.st
@@ -1,0 +1,105 @@
+Class {
+	#name : #ClyNotebookPageRecyclerTest,
+	#superclass : #ClyBrowserContextAbstractTest,
+	#category : #'Calypso-Browser-Tests'
+}
+
+{ #category : #tests }
+ClyNotebookPageRecyclerTest >> testDoesNotRecycleToolWhenNotValidInContext [
+
+	| recycler tools |
+	tools := browser tabManager tools select: [ :tool | tool class = ClyRichTextClassCommentEditorToolMorph ].
+	recycler := ClyNotebookPageRecycler on: tools contexts: { self methodContext }.
+	
+	self assert: recycler toolsToKeep isEmpty.
+]
+
+{ #category : #tests }
+ClyNotebookPageRecyclerTest >> testRecycleToolWhenValidInContext [
+	
+	| recycler tools |
+	tools := browser tabManager tools select: [ :tool | tool class = ClyRichTextClassCommentEditorToolMorph ].
+	
+	recycler := ClyNotebookPageRecycler on: tools contexts: { self classContext }.
+	
+	self assert: recycler toolsToKeep size equals: 1.		
+	self assert: recycler toolsToKeep anyOne class equals: ClyRichTextClassCommentEditorToolMorph.
+]
+
+{ #category : #tests }
+ClyNotebookPageRecyclerTest >> testTargetedToolsWhenManyContext [
+
+	| recycler tools |
+	recycler := ClyNotebookPageRecycler on: nil.
+	
+	recycler setTargetedToolsForContexts: { self methodContext . self classContext }.
+	
+	self assert: recycler targetedTools size equals: 4.
+	tools := recycler targetedTools collect: [ :targetTool | targetTool activation toolClass ].
+	self assertCollection: tools hasSameElements: { ClyMethodCodeEditorToolMorph . ClyClassDefinitionEditorToolMorph . ClyRichTextClassCommentEditorToolMorph . ClyTestSetUpEditorToolMorph }.
+
+]
+
+{ #category : #tests }
+ClyNotebookPageRecyclerTest >> testTargetedToolsWhenOneContext [
+
+	| recycler |
+	recycler := ClyNotebookPageRecycler on: nil.
+	
+	recycler setTargetedToolsForContexts: { self methodContext }.
+	
+	self assert: recycler targetedTools size equals: 1.
+	self assert: recycler targetedTools anyOne activation toolClass equals: ClyMethodCodeEditorToolMorph.
+
+]
+
+{ #category : #tests }
+ClyNotebookPageRecyclerTest >> testToolsToInstall [
+
+	| recycler |
+	recycler := ClyNotebookPageRecycler 
+		on: #()
+		contexts: { self methodContext }.
+	
+	self assert: recycler toolsToInstall size equals: 1.
+	self assert: recycler toolsToInstall anyOne equals: ClyMethodCodeEditorToolMorph.
+]
+
+{ #category : #tests }
+ClyNotebookPageRecyclerTest >> testToolsToKeepWhenManyContext [
+
+	| recycler tools |
+	recycler := ClyNotebookPageRecycler 
+		on: browser tabManager tools 
+		contexts: { self methodContext . self classContext }.
+	
+	self assert: recycler toolsToKeep size equals: 4.
+	tools := recycler toolsToKeep collect: [ :tool | tool class ].
+	self assertCollection: tools hasSameElements: { ClyMethodCodeEditorToolMorph . ClyClassDefinitionEditorToolMorph . ClyRichTextClassCommentEditorToolMorph . ClyTestSetUpEditorToolMorph }.
+
+]
+
+{ #category : #tests }
+ClyNotebookPageRecyclerTest >> testToolsToKeepWhenOneContext [
+
+	| recycler |
+	recycler := ClyNotebookPageRecycler 
+		on: browser tabManager tools
+		contexts: { self methodContext }.
+	
+	self assert: recycler toolsToKeep size equals: 1.
+	self assert: recycler toolsToKeep anyOne class equals: ClyMethodCodeEditorToolMorph.
+
+]
+
+{ #category : #tests }
+ClyNotebookPageRecyclerTest >> testToolsToRemoveWhenManyToolsToRemove [
+
+	| recycler |
+	recycler := ClyNotebookPageRecycler 
+		on: browser tabManager tools
+		contexts: { self methodContext }.
+	
+	self assert: recycler toolsToRemove size equals: 5.
+	self assert: recycler toolsToKeep size equals: 1.
+]

--- a/src/Calypso-Browser-Tests/package.st
+++ b/src/Calypso-Browser-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Calypso-Browser-Tests' }

--- a/src/Calypso-Browser/ClyBrowserMorph.class.st
+++ b/src/Calypso-Browser/ClyBrowserMorph.class.st
@@ -443,6 +443,12 @@ ClyBrowserMorph >> navigateForward [
 ]
 
 { #category : #accessing }
+ClyBrowserMorph >> navigationContexts [
+
+	^ navigationViews collect: [ :each | each createSelectionContext ]
+]
+
+{ #category : #accessing }
 ClyBrowserMorph >> navigationContextsDo: aBlock [
 
 	navigationViews do: [ :each | aBlock value: each createSelectionContext ]

--- a/src/Calypso-Browser/ClyBrowserToolMorph.class.st
+++ b/src/Calypso-Browser/ClyBrowserToolMorph.class.st
@@ -479,6 +479,15 @@ ClyBrowserToolMorph >> isTabSelected [
 	^ selectedTab = containerTab
 ]
 
+{ #category : #testing }
+ClyBrowserToolMorph >> isValidInContext: aClyFullBrowserContext [
+	" Tell if the current tool is still valid for the given context. If so, the tool will be reused instead of being rebuilt or discarded.
+	Every subclass should redefine this method to tell when the tool is still valid or not.
+	This method is there to replace #isSimilarTo: that needs tool instantiation to do the comparison."
+	
+	^ false
+]
+
 { #category : #controlling }
 ClyBrowserToolMorph >> okToClose [
 	self hasUnacceptedEdits ifFalse: [ ^true ].

--- a/src/Calypso-Browser/ClyNotebookManager.class.st
+++ b/src/Calypso-Browser/ClyNotebookManager.class.st
@@ -93,14 +93,13 @@ ClyNotebookManager >> addTool: aBrowserTool [
 
 { #category : #updating }
 ClyNotebookManager >> basicUpdateTools [
-		| newTools needsNewSelection selectedTools currentTools |
-		newTools := OrderedCollection new.	
-		browser navigationContextsDo: [ :each | self buildToolsOn: newTools for: each].
+		| needsNewSelection selectedTools currentTools |
+
 		needsNewSelection := self requiresNewDesiredSelection.
 		selectedTools := self selectedTools.
 		currentTools := tools copy.
 
-		self updateTabsWith: newTools.
+		self updateTabs.
 		(needsNewSelection or: [ tools ~= currentTools ]) 
 			ifTrue: [ self restoreSelectedTools: selectedTools].
 ]
@@ -391,22 +390,21 @@ ClyNotebookManager >> tools: anObject [
 ]
 
 { #category : #updating }
-ClyNotebookManager >> updateTabsWith: newTools [
-	| toRemove toInstall |
+ClyNotebookManager >> updateTabs [
+	| toRemove toInstall recycler |
 
-	toRemove := OrderedCollection withAll: tools.
-	toInstall := OrderedCollection new.
-	newTools do: [ :new | 
-		tools 
-			detect: [ :existing | existing isSimilarTo: new ]
-			ifFound: [ :existing | toRemove remove: existing ]
-			ifNone: [ toInstall add: new ] ].
-
+	recycler := ClyNotebookPageRecycler on: tools contexts: browser navigationContexts.
+	toInstall := recycler toolsToInstall.
+	toRemove := recycler toolsToRemove.
+		
 	"We need to install the new tabs before removing the old ones.
 	Because removing the old ones force to generate the content of the existing ones.
 	Even the ones we are going to remove"
-	toInstall do: [ :each | self addTool: each ].
-	toRemove 
+	toInstall do: [ :targetTool | | tool |
+		tool := targetTool createToolFor: browser.
+		browser decorateTool: tool.
+		self addTool: tool ].
+	toRemove
 		reject: [ :each | each wantsStayInDifferentContext ]
 		thenDo: [ :each | self removeTool: each ].
 	tools do: [ :each | each browserContextWasChanged ].

--- a/src/Calypso-Browser/ClyNotebookPageRecycler.class.st
+++ b/src/Calypso-Browser/ClyNotebookPageRecycler.class.st
@@ -1,0 +1,108 @@
+"
+I allow to recycle existing tools in a SystemBrowser (instances of `ClyBrowserToolMorph`) when the context changes.
+It avoids to rebuild all tools when they are still valid in the new context.
+
+I need a list of current tools and the list of new contexts to compute the list of tools to keep, to remove and the new one to install. For this purpose, I build a list of targeted tools and I try to find a tool matching the target tool in the existing tools.
+I use `ClyTargetTool` to do the matching.
+"
+Class {
+	#name : #ClyNotebookPageRecycler,
+	#superclass : #Object,
+	#instVars : [
+		'tools',
+		'targetedTools',
+		'isMatched'
+	],
+	#category : #'Calypso-Browser-Tabs'
+}
+
+{ #category : #'instance creation' }
+ClyNotebookPageRecycler class >> on: toolList [ 
+	
+	^ self new
+		tools: toolList;
+		yourself
+]
+
+{ #category : #'instance creation' }
+ClyNotebookPageRecycler class >> on: toolList contexts: aListOfClyBrowserContext [
+	
+	^ (self on: toolList)
+		setTargetedToolsForContexts: aListOfClyBrowserContext;
+		yourself
+
+]
+
+{ #category : #private }
+ClyNotebookPageRecycler >> activationStrategiesFor: aClyBrowserContext [
+	
+	^ ClyTabActivationStrategyAnnotation activeInstancesInContext: aClyBrowserContext
+]
+
+{ #category : #private }
+ClyNotebookPageRecycler >> ensureMatched [
+
+	isMatched ifTrue: [ ^ self ].
+	self matchTools.
+	isMatched := true.
+
+]
+
+{ #category : #private }
+ClyNotebookPageRecycler >> matchTools [
+	
+	self targetedTools do: [ :targetTool | targetTool match: tools ]
+]
+
+{ #category : #initialization }
+ClyNotebookPageRecycler >> setTargetedToolsForContexts: aListOfClyBrowserContext [
+	
+	targetedTools := aListOfClyBrowserContext flatCollect: [ :aClyBrowserContext | 
+			self targetedToolsFor: aClyBrowserContext ].
+	isMatched := false.
+
+]
+
+{ #category : #accessing }
+ClyNotebookPageRecycler >> targetedTools [
+	
+	^ targetedTools
+]
+
+{ #category : #private }
+ClyNotebookPageRecycler >> targetedToolsFor: aClyBrowserContext [
+	
+	^ (self activationStrategiesFor: aClyBrowserContext)
+		collect: [ :strategy | ClyTargetTool forActivation: strategy context: aClyBrowserContext]
+]
+
+{ #category : #accessing }
+ClyNotebookPageRecycler >> tools: toolList [ 
+	
+	tools := toolList.
+]
+
+{ #category : #querying }
+ClyNotebookPageRecycler >> toolsToInstall [
+	
+	self ensureMatched.
+
+	^ self targetedTools 
+		reject: [ :tool | tool isMatched ]
+]
+
+{ #category : #accessing }
+ClyNotebookPageRecycler >> toolsToKeep [
+	
+	self ensureMatched.
+
+	^ self targetedTools 
+		select: [ :tool | tool isMatched ]
+		thenCollect: [ :tool | tool matchedTool ]
+]
+
+{ #category : #querying }
+ClyNotebookPageRecycler >> toolsToRemove [
+	
+	^ tools difference: self toolsToKeep
+]

--- a/src/Calypso-Browser/ClyTargetTool.class.st
+++ b/src/Calypso-Browser/ClyTargetTool.class.st
@@ -1,0 +1,68 @@
+"
+I represent a Browser tool that is wanted by the browser according to its context.
+I will be compared to existing tools to know if I need to be instantiated or if there is a tool that matches.
+"
+Class {
+	#name : #ClyTargetTool,
+	#superclass : #Object,
+	#instVars : [
+		'context',
+		'activation',
+		'matchedTool'
+	],
+	#category : #'Calypso-Browser-Tabs'
+}
+
+{ #category : #initialization }
+ClyTargetTool class >> forActivation: aClyTabActivationStrategyAnnotation context: aClyBrowserContext [
+
+	^ self new
+		forActivation: aClyTabActivationStrategyAnnotation context: aClyBrowserContext;
+		yourself
+]
+
+{ #category : #accessing }
+ClyTargetTool >> activation [
+
+	^ activation
+]
+
+{ #category : #accessing }
+ClyTargetTool >> context [
+	^ context
+]
+
+{ #category : #matching }
+ClyTargetTool >> createToolFor: browser [
+
+	^ activation createToolFor: browser inContext: context
+]
+
+{ #category : #initialization }
+ClyTargetTool >> forActivation: aClyTabActivationStrategyAnnotation context: aClyBrowserContext [
+	
+	activation := aClyTabActivationStrategyAnnotation.
+	context := aClyBrowserContext 
+]
+
+{ #category : #testing }
+ClyTargetTool >> isMatched [
+	
+	^ matchedTool isNotNil
+]
+
+{ #category : #matching }
+ClyTargetTool >> match: aListOfClyTool [ 
+	
+	aListOfClyTool 
+		detect: [ :tool | activation toolClass = tool class
+			and: [ tool isValidInContext: self context ] ]
+		ifFound: [ :tool | matchedTool := tool ]
+		ifNone: [ "ignore" ]
+]
+
+{ #category : #accessing }
+ClyTargetTool >> matchedTool [
+
+	^ matchedTool
+]

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyTestSetUpEditorToolMorph.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyTestSetUpEditorToolMorph.class.st
@@ -79,6 +79,14 @@ ClyTestSetUpEditorToolMorph >> isSimilarTo: anotherBrowserTool [
 		and: [ testClass == anotherBrowserTool testClass ]
 ]
 
+{ #category : #testing }
+ClyTestSetUpEditorToolMorph >> isValidInContext: aClyFullBrowserContext [
+	self context class = aClyFullBrowserContext class 
+		ifFalse: [ ^ false ].
+		
+	^ aClyFullBrowserContext selectedClasses includes: self testClass
+]
+
 { #category : #initialization }
 ClyTestSetUpEditorToolMorph >> setUpDefaultTemplate [
 

--- a/src/Calypso-SystemTools-Core/ClyClassCreationToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassCreationToolMorph.class.st
@@ -101,6 +101,22 @@ ClyClassCreationToolMorph >> isSimilarTo: anotherBrowserTool [
 		and: [ classTag = anotherBrowserTool classTag ]
 ]
 
+{ #category : #testing }
+ClyClassCreationToolMorph >> isValidInContext: aClyFullBrowserContext [
+	| isValid |
+	
+	self context class = aClyFullBrowserContext class 
+		ifFalse: [ ^ false ].
+		
+	isValid := true.
+	aClyFullBrowserContext isPackageSelected
+		ifTrue: [ isValid := package = aClyFullBrowserContext lastSelectedPackage ].
+
+	^ isValid and: [ aClyFullBrowserContext isClassTagSelected
+		ifTrue: [ classTag = aClyFullBrowserContext lastSelectedClassTag ]
+		ifFalse: [ classTag isNil ] ]
+]
+
 { #category : #accessing }
 ClyClassCreationToolMorph >> package [
 	^ package

--- a/src/Calypso-SystemTools-Core/ClyClassEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassEditorToolMorph.class.st
@@ -82,6 +82,15 @@ ClyClassEditorToolMorph >> isSimilarTo: anotherBrowserTool [
 	^editingClass = anotherBrowserTool editingClass
 ]
 
+{ #category : #testing }
+ClyClassEditorToolMorph >> isValidInContext: aClyFullBrowserContext [
+	self context class = aClyFullBrowserContext class 
+		ifFalse: [ ^ false ].
+		
+	^ editingClass = aClyFullBrowserContext lastSelectedClass
+		or: [  editingClass = aClyFullBrowserContext lastSelectedClass instanceSide ]
+]
+
 { #category : #printing }
 ClyClassEditorToolMorph >> printContext [
 	^editingClass printSystemPath

--- a/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
@@ -234,6 +234,16 @@ ClyMethodCodeEditorToolMorph >> isSimilarTo: anotherBrowserTool [
 			and: [ editingMethod origin == anotherBrowserTool editingMethod origin ] ]
 ]
 
+{ #category : #testing }
+ClyMethodCodeEditorToolMorph >> isValidInContext: aClyFullBrowserContext [
+	self context class = aClyFullBrowserContext class 
+		ifFalse: [ ^ false ].
+		
+	^ editingMethod = aClyFullBrowserContext lastSelectedMethod or: 
+		[ editingMethod selector == aClyFullBrowserContext lastSelectedMethod selector
+			and: [ editingMethod origin == aClyFullBrowserContext lastSelectedMethod origin ] ]
+]
+
 { #category : #accessing }
 ClyMethodCodeEditorToolMorph >> methodClass [
 

--- a/src/Tool-DependencyAnalyser-UI-Tab/DABrowserToolMorph.class.st
+++ b/src/Tool-DependencyAnalyser-UI-Tab/DABrowserToolMorph.class.st
@@ -63,6 +63,14 @@ DABrowserToolMorph >> isSimilarTo: anotherBrowserTool [
 	^ self analyzedPackage = anotherBrowserTool analyzedPackage
 ]
 
+{ #category : #testing }
+DABrowserToolMorph >> isValidInContext: aClyFullBrowserContext [
+	self context class = aClyFullBrowserContext class 
+		ifFalse: [ ^ false ].
+		
+	^ self analyzedPackage rPackageSet packageName = aClyFullBrowserContext lastSelectedClassGroup name
+]
+
 { #category : #initialization }
 DABrowserToolMorph >> setUpModelFromContext [
 


### PR DESCRIPTION
tools are now compared with the context with a method #isValidInContext: defined on the ClyToolMorph. This method has to be implemented on each tool to avoid rebuild.