### PR TITLE
11928-SystemDictionaryallMethods-rerturns-Traits-methods

### DIFF
--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -199,7 +199,7 @@ Symbol class >> readFrom: strm [
 { #category : #'selector table' }
 Symbol class >> rebuildSelectorTable [
 
-	^ SystemNavigation new allMethods
+	^ SystemNavigation new methods
 		  collect: [ :method | method selector ]
 		  as: WeakIdentitySet
 ]

--- a/src/Kernel/ReservedVariable.class.st
+++ b/src/Kernel/ReservedVariable.class.st
@@ -88,7 +88,7 @@ ReservedVariable >> scope [
 { #category : #queries }
 ReservedVariable >> usingMethods [
 	"first call is very slow as it creates all ASTs"
-	^environment allMethods select: [ : method |
+	^environment methods select: [ : method |
 		method ast variableNodes anySatisfy: [ :varNode | varNode variable == self]]
 ]
 

--- a/src/Kernel/SelfVariable.class.st
+++ b/src/Kernel/SelfVariable.class.st
@@ -39,7 +39,7 @@ SelfVariable >> usingMethods [
 	"Super sends are doing a pushSelf, too, we need to still check the AST level sometimes.
 	FFI methods after a first call do not have a self send in the bytecode, but one in the code"
 
-	^ environment allMethods select: [ :method | 
+	^ environment methods select: [ :method | 
 		method isFFIMethod or: [  
 		  method readsSelf and: [ 
 			  method sendsToSuper not or: [ 

--- a/src/Kernel/SuperVariable.class.st
+++ b/src/Kernel/SuperVariable.class.st
@@ -37,6 +37,6 @@ SuperVariable >> readInContext: aContext [
 SuperVariable >> usingMethods [
 	"as super is just a push Self, this detects real super sends, not accesses to super which 
 	should never happen"
-	^ environment allMethods select: [ :method | 
+	^ environment methods select: [ :method | 
 		  method sendsToSuper ]
 ]

--- a/src/Kernel/ThisContextVariable.class.st
+++ b/src/Kernel/ThisContextVariable.class.st
@@ -35,6 +35,6 @@ ThisContextVariable >> readInContext: aContext [
 
 { #category : #queries }
 ThisContextVariable >> usingMethods [
-	^ environment allMethods select: [ :method | 
+	^ environment methods select: [ :method | 
 		  method readsThisContext ]
 ]

--- a/src/PharoDocComment-Tests/DocCommentsReleaseTest.class.st
+++ b/src/PharoDocComment-Tests/DocCommentsReleaseTest.class.st
@@ -15,7 +15,7 @@ DocCommentsReleaseTest class >> buildSuite [
 	suite := TestSuite named: 'Test Generated From Comments'.
 	"we do not run examples in tests (as they are used just for testing and might be broken by
 	design"
-	methods := self environment allMethods reject: [ :method | method methodClass isTestCase ].
+	methods := self environment methods reject: [ :method | method methodClass isTestCase ].
 	"for now skip all class side methods to be in sync with DrTests"
 	methods do: [ :method | 
 		method pharoDocCommentNodes do: [ :docComment | 

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -214,7 +214,7 @@ ReleaseTest >> testManifestNamesAccordingToPackageNames [
 ReleaseTest >> testMethodsContainNoHalt [
 
 	| methods |
-	methods := SystemNavigation new allMethods select: [ :method | method containsHalt ].
+	methods := SystemNavigation new methods select: [ :method | method containsHalt ].
 	"these methods are using halt for testing something"
 	methods := methods reject: [ :method | 
 		           method hasPragmaNamed: #haltOrBreakpointForTesting ].
@@ -260,10 +260,7 @@ ReleaseTest >> testNoEmptyPackages [
 ReleaseTest >> testNoEquivalentSuperclassMethods [
 
 	| methods |
-	"we do not care about methods that are installed from traits"
-	methods := SystemNavigation new allMethods reject: [:method | method isFromTrait].
-	
-	methods := methods select: [:method |
+	methods := SystemNavigation new methods select: [:method |
 	method methodClass superclass
 		ifNotNil: [ :superclass | (superclass lookupSelector: method selector)
 			ifNotNil: [ :overridenMethod | method equivalentTo: overridenMethod ]
@@ -285,7 +282,7 @@ ReleaseTest >> testNoEquivalentSuperclassMethods [
 ReleaseTest >> testNoLiteralIsPinnedInMemory [
 	| methodsWithPinnedLiterals |
 	
-	methodsWithPinnedLiterals := SystemNavigation default allMethods flatCollect: [ :each | 
+	methodsWithPinnedLiterals := SystemNavigation default methods flatCollect: [ :each | 
 	(each allLiterals select: [ :eachLiteral | eachLiteral isPinnedInMemory ])
 		ifNotEmpty: [ { each } ]
 		ifEmpty: [ #() ] ].
@@ -305,14 +302,14 @@ ReleaseTest >> testNoNullCharacter [
 	"Check that we do not have NULL in sources - see https://github.com/pharo-project/pharo/issues/9631"
 	
 	| violations |
-	violations := SystemNavigation default allMethods select: [ :m | m sourceCode includes: Character null ].
+	violations := SystemNavigation default methods select: [ :m | m sourceCode includes: Character null ].
 	self assert: violations isEmpty description: 'Source corrupted: Methods with Null character found'
 ]
 
 { #category : #'tests - source' }
 ReleaseTest >> testNoPeriodInMethodSignature [
 	| methods |
-	methods := SystemNavigation new allMethods select: [ :method | 
+	methods := SystemNavigation new methods select: [ :method | 
  		method sourceCode lines first trimRight last == $..].
 	
 	self assert: methods isEmpty description: [ 

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -292,6 +292,12 @@ SystemDictionary >> maxIdentityHash [
 	^self primitiveFailed
 ]
 
+{ #category : #'accessing - classes and traits' }
+SystemDictionary >> methods [
+	"Return all methods, not including methods installed from Traits"
+	^ self allBehaviors flatCollect: [ :behavior | behavior localMethods ]
+]
+
 { #category : #'accessing - class and trait names' }
 SystemDictionary >> nonClassNames [
 	"Answer a sorted collection of all non-class names. Use the return value of #fillCaches to avoid concurrency issues."

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -157,7 +157,7 @@ SystemNavigation >> allObjectsOrNil [
 SystemNavigation >> allPrimitiveMethods [
 	"Answer all the methods that are implemented by primitives."
 
-	^self allMethods
+	^self methods
 		select: [ :method | method isPrimitive ]
 		thenCollect: [ :method | method methodClass name , ' ' , 
 			     method selector , ' ', method primitive printString ]
@@ -239,7 +239,7 @@ SystemNavigation >> allUnimplementedCalls [
 
 	"Answer all methods where a message is sent but the selector is not implemented anywhere in the system."
 
-	^ self allMethods select: [ :meth | 
+	^ self methods select: [ :meth | 
 		  | ignored |
 		  ignored := (meth pragmaAt: #ignoreUnimplementedCalls:)
 			             ifNotNil: [ :pragma | pragma argumentAt: 1 ]
@@ -311,6 +311,12 @@ SystemNavigation >> instanceSideMethodsWithNilKeyInLastLiteral [
 SystemNavigation >> isUnsentMessage: selector [
 	^ self allBehaviors
 		noneSatisfy: [ :behavior | behavior thoroughHasSelectorReferringTo: selector ]
+]
+
+{ #category : #query }
+SystemNavigation >> methods [
+	"Return all methods, not including methods installed from Traits"
+	^ self environment methods
 ]
 
 { #category : #'identifying obsoletes' }

--- a/src/TraitsV2/Behavior.extension.st
+++ b/src/TraitsV2/Behavior.extension.st
@@ -48,7 +48,7 @@ Behavior >> localMethodNamed: selector ifAbsent: aBlock [
 Behavior >> localMethods [
 	"returns the methods of classes excluding the ones of the traits that the class uses" 
 	 
-	^ self methods
+	^ self methodDict values
 ]
 
 { #category : #'*TraitsV2' }


### PR DESCRIPTION
Instead of fixing #allMethods, this adds #methods, this way we can get all the methods with traits installed copies with #allMethods. 

- add #methods to SystemNavigation and Smalltalk globals: #allMethods returns with trait installes, methods without
- inline Behavior>>#localMethods
- fix all senders of allMethods to use #methods

fixes #11928