### PR TITLE
Context-use-homeMethod 

### DIFF
--- a/src/Debugger-Model-Tests/StepOverTest.class.st
+++ b/src/Debugger-Model-Tests/StepOverTest.class.st
@@ -226,7 +226,7 @@ StepOverTest >> testStepOverReturnInUnwindBlock [
 	self 
 		assert: session interruptedContext closure 
 		identicalTo: session interruptedContext sender unwindBlock.
-	[session interruptedContext home selector == #methodWithUnwindReturn] 
+	[session interruptedContext homeMethod selector == #methodWithUnwindReturn] 
 		whileTrue: [ session stepOver ].
 	self assert: session interruptedContext closure identicalTo: rootBlock
 ]

--- a/src/Hermes/HECompiledBlock.class.st
+++ b/src/Hermes/HECompiledBlock.class.st
@@ -87,6 +87,6 @@ HECompiledBlock >> value: aCompiledBlock [
 	1 to: bytecode size do: [ :i | bytecode at: i put: (aCompiledBlock at: i + literalSpace) ].
 
 	literals := aCompiledBlock allLiterals allButLast collect: [ :e | e asExportedLiteral ].
-	"The last literal is the home method or block of this compiledBlock"
+	"The last literal is the outer method or block of this compiledBlock"
 	literals := literals copyWith: nil asExportedLiteral.
 ]

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -375,7 +375,7 @@ Context >> basicSize [
 
 { #category : #testing }
 Context >> belongsToDoIt [
-	^self home method isDoIt
+	^self homeMethod isDoIt
 ]
 
 { #category : #'instruction decoding' }


### PR DESCRIPTION
- replace "home method" with the new #homeMethod which works for blocks without a home
- fix a comment in Hermes