### PR TITLE
11937-Cycling-of-Halos-does-not-work-anymore

### DIFF
--- a/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
+++ b/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
@@ -67,6 +67,7 @@ BaselineOfMorphicCore >> postload: loader package: packageSpec [
 
 	Cursor initTarget.
 	EventManager initialize.
+	UserInputEvent initialize.
 
 	world := WorldMorph new.
 	world instVarNamed: #worldState put: WorldState new.

--- a/src/Morphic-Base/HaloMorph.class.st
+++ b/src/Morphic-Base/HaloMorph.class.st
@@ -694,7 +694,7 @@ HaloMorph >> containsPoint: aPoint event: anEvent [
 	"Blue buttons are handled by the halo"
 
 	(anEvent isMouse and: [ 
-		 anEvent isMouseDown and: [ anEvent blueButtonPressed ] ]) ifFalse: [ 
+		 anEvent isMouseDown and: [ anEvent isSpecialGesture ] ]) ifFalse: [ 
 		^ super containsPoint: aPoint event: anEvent ].
 	^ bounds containsPoint: anEvent position
 ]
@@ -977,6 +977,8 @@ HaloMorph >> handleSize [
 HaloMorph >> handleSpecialGesture: event [
 	"Transfer the halo to the next likely recipient"
 
+	#haloHandleSpecialGesture traceCr. 
+
 	target ifNil: [ ^ self delete ].
 	event hand obtainHalo: self.
 	positionOffset := event position
@@ -990,9 +992,8 @@ HaloMorph >> handleSpecialGesture: event [
 ]
 
 { #category : #'meta-actions' }
-HaloMorph >> handlerForBlueButtonDown: anEvent [
-	"Blue button was clicked within the receiver"
-
+HaloMorph >> handlerForSpecialGestureDown:  anEvent [
+	"The special gesture for halo has been done"
 	^ self
 ]
 

--- a/src/Morphic-Base/HaloMorph.class.st
+++ b/src/Morphic-Base/HaloMorph.class.st
@@ -977,8 +977,6 @@ HaloMorph >> handleSize [
 HaloMorph >> handleSpecialGesture: event [
 	"Transfer the halo to the next likely recipient"
 
-	#haloHandleSpecialGesture traceCr. 
-
 	target ifNil: [ ^ self delete ].
 	event hand obtainHalo: self.
 	positionOffset := event position

--- a/src/Morphic-Base/Object.extension.st
+++ b/src/Morphic-Base/Object.extension.st
@@ -117,18 +117,18 @@ Object class >> taskbarIcon [
 ]
 
 { #category : #'*Morphic-Base' }
+Object class >> taskbarIconName [
+	"Answer the icon for an instance of the receiver in a task bar"
+
+	^#smallWindow
+]
+
+{ #category : #'*Morphic-Base' }
 Object >> taskbarIconName [
 	"Answer the icon for the receiver in a task bar
 	or nil for the default."
 
 	^self class taskbarIconName
-]
-
-{ #category : #'*Morphic-Base' }
-Object class >> taskbarIconName [
-	"Answer the icon for an instance of the receiver in a task bar"
-
-	^#smallWindow
 ]
 
 { #category : #'*Morphic-Base' }

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -2872,9 +2872,9 @@ Morph >> handleMouseDown: anEvent [
 	anEvent hand newMouseFocus: self event: anEvent.
 	
 	"Check to open halo"
-	(anEvent blueButtonChanged or: [ "HACK"
-		 anEvent redButtonChanged & anEvent altKeyPressed
-		 & anEvent shiftPressed ]) ifTrue: [ ^ self handleSpecialGesture: anEvent ].
+	anEvent isSpecialGesture  
+		ifTrue: [ 
+			^ self handleSpecialGesture: anEvent ].
 
 	self mouseDown: anEvent.
 
@@ -3060,18 +3060,10 @@ Morph >> handleWindowEvent: anEvent [
 
 { #category : #'meta-actions' }
 Morph >> handlerForBlueButtonDown: anEvent [
-	"Return the (prospective) handler for a mouse down event. The handler is temporarily installed and can be used for morphs further down the hierarchy to negotiate whether the inner or the outer morph should finally handle the event.
-	Note: Halos handle blue button events themselves so we will only be asked if there is currently no halo on top of us.
-	Check whtehr halods are enabled (for deployment)."
+	"Return the (prospective) handler for a mouse down event.
+	In this case all blue buttons are disabled unless the subclass whant to handle it"
 
-	self wantsHaloFromClick ifFalse: [ ^ nil ].
-
-	self class cycleHalosBothDirections
-		ifTrue: [ anEvent handler ifNil: [ ^ self ].
-			(anEvent handler isKindOf: PasteUpMorph) ifTrue: [ ^ self ] ].
-	^ anEvent shiftPressed
-		ifFalse: [ "let outer guy have it" nil ]
-		ifTrue: [ "let me have it" self ]
+	^ nil
 ]
 
 { #category : #'event handling' }
@@ -3079,6 +3071,9 @@ Morph >> handlerForMouseDown: anEvent [
 	"Return the (prospective) handler for a mouse down event. The handler is temporarily 
 	installed and can be used for morphs further down the hierarchy to negotiate whether 
 	the inner or the outer morph should finally handle the event."
+
+	anEvent isSpecialGesture 
+		ifTrue: [ ^ self handlerForSpecialGestureDown: anEvent ].
 
 	anEvent blueButtonPressed
 		ifTrue: [^ self handlerForBlueButtonDown: anEvent].
@@ -3094,6 +3089,20 @@ Morph >> handlerForMouseDown: anEvent [
 	^self mouseDownPriority >= anEvent handler mouseDownPriority
 		ifTrue: [ self]
 		ifFalse: [ nil]
+]
+
+{ #category : #'meta-actions' }
+Morph >> handlerForSpecialGestureDown: anEvent [
+	"Return the (prospective) handler for a special gesture event (Halos). 
+	The handler is temporarily installed and can be used for morphs further down the hierarchy to negotiate whether the inner or the outer morph should finally handle the event."
+
+	self wantsHaloFromClick ifFalse: [ ^ nil ].
+
+	self class cycleHalosBothDirections
+		ifTrue: [ anEvent handler ifNil: [ ^ self ].
+			(anEvent handler isKindOf: PasteUpMorph) ifTrue: [ ^ self ] ].
+		
+	^ self
 ]
 
 { #category : #'event handling' }

--- a/src/Morphic-Core/MouseButtonEvent.class.st
+++ b/src/Morphic-Core/MouseButtonEvent.class.st
@@ -20,7 +20,7 @@ MouseButtonEvent >> blueButtonChanged [
 { #category : #accessing }
 MouseButtonEvent >> isSpecialGesture [
 	"This is the gesture to open the Halos"
-	^ self redButtonPressed & self altKeyPressed & self shiftPressed
+	^ self blueButtonPressed or: [self redButtonPressed & self altKeyPressed & self shiftPressed]
 ]
 
 { #category : #accessing }

--- a/src/Morphic-Core/MouseButtonEvent.class.st
+++ b/src/Morphic-Core/MouseButtonEvent.class.st
@@ -18,6 +18,12 @@ MouseButtonEvent >> blueButtonChanged [
 ]
 
 { #category : #accessing }
+MouseButtonEvent >> isSpecialGesture [
+	"This is the gesture to open the Halos"
+	^ self redButtonPressed & self altKeyPressed & self shiftPressed
+]
+
+{ #category : #accessing }
 MouseButtonEvent >> redButtonChanged [
 	"Answer true if the red mouse button has changed. This is the first mouse button."
 

--- a/src/Morphic-Core/UserInputEvent.class.st
+++ b/src/Morphic-Core/UserInputEvent.class.st
@@ -11,8 +11,48 @@ Class {
 		'handler',
 		'wasHandled'
 	],
+	#classVars : [
+		'ALT_KEY_MASK',
+		'CMD_KEY_MASK',
+		'CTRL_KEY_MASK',
+		'SHIFT_KEY_MASK'
+	],
 	#category : #'Morphic-Core-Events'
 }
+
+{ #category : #initialization }
+UserInputEvent class >> altKeyMask [
+
+	^ ALT_KEY_MASK
+]
+
+{ #category : #initialization }
+UserInputEvent class >> cmdKeyMask [
+
+	^ 	CMD_KEY_MASK
+]
+
+{ #category : #initialization }
+UserInputEvent class >> ctrlKeyMask [
+
+	^ CTRL_KEY_MASK
+]
+
+{ #category : #initialization }
+UserInputEvent class >> initialize [
+
+	SHIFT_KEY_MASK := 8.
+	CMD_KEY_MASK := 2r01000000.
+	CTRL_KEY_MASK := 2r00010000.
+	ALT_KEY_MASK := 2r00100000.
+]
+
+{ #category : #initialization }
+UserInputEvent class >> shiftKeyMask [
+
+	^ SHIFT_KEY_MASK 
+
+]
 
 { #category : #'modifier state' }
 UserInputEvent >> altKeyPressed [
@@ -26,7 +66,7 @@ UserInputEvent >> altKeyPressed [
 UserInputEvent >> anyModifierKeyPressed [
 	"ignore, however, the shift keys 'cause that's not REALLY a command key "
 
-	^ self buttons anyMask: 2r01110000	"cmd | opt | ctrl"
+	^ self buttons anyMask: CMD_KEY_MASK | ALT_KEY_MASK | CTRL_KEY_MASK
 ]
 
 { #category : #printing }
@@ -52,7 +92,7 @@ UserInputEvent >> commandKeyPressed [
 	"Answer true if the command key on the keyboard was being held down when this event occurred."
 
 	"The mask for command bit pressed"
-	^ buttons anyMask: 2r01000000
+	^ buttons anyMask: CMD_KEY_MASK
 ]
 
 { #category : #'modifier state' }
@@ -60,7 +100,7 @@ UserInputEvent >> controlKeyPressed [
 	"Answer true if the control key on the keyboard was being held down when this event occurred."
 
 	"The mask for control bit pressed"
-	^ buttons anyMask: 2r00010000
+	^ buttons anyMask: CTRL_KEY_MASK
 ]
 
 { #category : #initialize }
@@ -96,7 +136,7 @@ UserInputEvent >> optionKeyPressed [
 	"Answer true if the alt/option key on the keyboard was being held down when this event occurred."
 
 	"00100000 is the bit that marks that option/alt has been pressed"
-	^ buttons anyMask: 2r00100000
+	^ buttons anyMask: ALT_KEY_MASK
 ]
 
 { #category : #accessing }
@@ -120,7 +160,7 @@ UserInputEvent >> setPosition: aPoint [
 UserInputEvent >> shiftPressed [
 	"Answer true if the shift key on the keyboard was being held down when this event occurred."
 
-	^ buttons anyMask: 8
+	^ buttons anyMask: SHIFT_KEY_MASK
 ]
 
 { #category : #transforming }

--- a/src/Morphic-Tests/HaloMorphTest.class.st
+++ b/src/Morphic-Tests/HaloMorphTest.class.st
@@ -57,9 +57,11 @@ HaloMorphTest >> simulateSpecialGesture: aPoint [
 
 { #category : #running }
 HaloMorphTest >> tearDown [ 
-	
-	self currentWorld hands first halo ifNotNil: [:halo | halo delete].
-	outerMorph ifNotNil: [ outerMorph delete ].
+
+	innerMorph ifNotNil: [ innerMorph removeHalo; delete ].	
+	outerMorph ifNotNil: [ outerMorph removeHalo; delete ].
+
+	self currentHand initForEvents.
 	
 	super tearDown.
 

--- a/src/Morphic-Tests/HaloMorphTest.class.st
+++ b/src/Morphic-Tests/HaloMorphTest.class.st
@@ -1,0 +1,96 @@
+Class {
+	#name : #HaloMorphTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'outerMorph',
+		'innerMorph'
+	],
+	#category : #'Morphic-Tests-Widgets'
+}
+
+{ #category : #initialization }
+HaloMorphTest >> setUp [ 
+
+	super setUp.
+	outerMorph := Morph new 
+		color: Color red;
+		extent: 100@100;
+		yourself.
+	
+	innerMorph := Morph new
+		color: Color green;
+		extent: 50@50;
+		yourself.
+	
+	outerMorph addMorph: innerMorph.
+	innerMorph position: 10@10.
+	
+]
+
+{ #category : #tests }
+HaloMorphTest >> simulateSpecialGesture: aPoint [
+
+	| buttons hand evt |
+	buttons := MouseEvent redButton | UserInputEvent altKeyMask | UserInputEvent shiftKeyMask.
+	hand := self currentWorld hands first.
+
+	evt := (MouseButtonEvent new 
+		setType: #mouseDown
+		position: aPoint
+		which:  buttons
+		buttons: buttons
+		hand: hand
+		stamp: Time millisecondClockValue).
+		
+	hand handleEvent: evt.
+	
+	evt := (MouseButtonEvent new 
+		setType: #mouseUp
+		position: aPoint
+		which:  buttons
+		buttons: buttons
+		hand: hand
+		stamp: Time millisecondClockValue).
+		
+	hand handleEvent: evt.
+]
+
+{ #category : #initialization }
+HaloMorphTest >> tearDown [ 
+	
+	super tearDown.
+	
+	self currentWorld hands first halo ifNotNil: [:halo | halo delete].
+	outerMorph ifNotNil: [ outerMorph delete ].
+]
+
+{ #category : #tests }
+HaloMorphTest >> testSpecialGestureOnInnerMorphPutsHaloInInnerMorph [
+
+	outerMorph openInWorld.
+	self simulateSpecialGesture: innerMorph center.
+	
+	self assert: self currentWorld hands first halo target equals: innerMorph
+]
+
+{ #category : #tests }
+HaloMorphTest >> testSpecialGestureOnInnerMorphTwiceGoesToOuterMorph [
+
+	outerMorph openInWorld.
+
+	self simulateSpecialGesture: innerMorph center.
+	"I have to wait to avoid being detected as double-click"
+	HandMorph doubleClickTime milliSeconds wait. 
+	self simulateSpecialGesture: innerMorph center.
+	
+	self assert: self currentWorld hands first halo target equals: outerMorph
+]
+
+{ #category : #tests }
+HaloMorphTest >> testSpecialGestureOnOuterMorphPutsHaloInOuterMorph [
+
+	outerMorph openInWorld.
+	self simulateSpecialGesture: outerMorph position + (1@1).
+	
+	self assert: self currentWorld hands first halo target equals: outerMorph
+]

--- a/src/Morphic-Tests/HaloMorphTest.class.st
+++ b/src/Morphic-Tests/HaloMorphTest.class.st
@@ -8,7 +8,7 @@ Class {
 	#category : #'Morphic-Tests-Widgets'
 }
 
-{ #category : #initialization }
+{ #category : #running }
 HaloMorphTest >> setUp [ 
 
 	super setUp.
@@ -55,13 +55,14 @@ HaloMorphTest >> simulateSpecialGesture: aPoint [
 	hand handleEvent: evt.
 ]
 
-{ #category : #initialization }
+{ #category : #running }
 HaloMorphTest >> tearDown [ 
-	
-	super tearDown.
 	
 	self currentWorld hands first halo ifNotNil: [:halo | halo delete].
 	outerMorph ifNotNil: [ outerMorph delete ].
+	
+	super tearDown.
+
 ]
 
 { #category : #tests }

--- a/src/Morphic-Tests/MorphicEventHandlerTest.class.st
+++ b/src/Morphic-Tests/MorphicEventHandlerTest.class.st
@@ -107,7 +107,7 @@ MorphicEventHandlerTest >> testMiddleButtonOpenHalos [
 		setType: #mouseDown
 		position: 0@0
 		which: MouseButtonEvent blueButton
-		buttons: 0
+		buttons: MouseButtonEvent blueButton
 		hand: morph world activeHand
 		stamp: Time millisecondClockValue).
 	

--- a/src/OSWindow-Core/OSWindowMorphicEventHandler.class.st
+++ b/src/OSWindow-Core/OSWindowMorphicEventHandler.class.st
@@ -109,10 +109,10 @@ OSWindowMorphicEventHandler >> convertModifiers: modifiers [
 	| buttons |
 	buttons := 0.
 	
-	modifiers alt ifTrue: [ buttons := buttons | 2r00100000 ]. "Alt key"
-	modifiers ctrl ifTrue: [ buttons := buttons | 2r00010000 ]. "Control key"
-	modifiers shift ifTrue: [ buttons := buttons | 8 ]. "Shift key"
-	modifiers cmd ifTrue: [ buttons := buttons | 2r01000000 ]. "Cmd key"
+	modifiers alt ifTrue: [ buttons := buttons | UserInputEvent altKeyMask ].
+	modifiers ctrl ifTrue: [ buttons := buttons | UserInputEvent ctrlKeyMask ].
+	modifiers shift ifTrue: [ buttons := buttons | UserInputEvent shiftKeyMask ].
+	modifiers cmd ifTrue: [ buttons := buttons | UserInputEvent cmdKeyMask ].
 	
 	modifiers buttons button1 ifTrue:  [ buttons := buttons | MouseButtonEvent redButton ].
 	modifiers buttons button2 ifTrue:  [ buttons := buttons | MouseButtonEvent blueButton ].


### PR DESCRIPTION
- Adding special test method for special gesture (the halo one)
- Spliting the handle of special gesture and middle mouse button.
- Adding test
- Extracting constants in UserInputEvent class
- Fixing existing test that checks the middle button with the halos.

Fix https://github.com/pharo-project/pharo/issues/11937