### PR TITLE
This PR introduced a basic use of the new string primitive imlpemente…

### DIFF
--- a/src/Collections-Strings/ByteString.class.st
+++ b/src/Collections-Strings/ByteString.class.st
@@ -184,6 +184,37 @@ ByteString >> byteSize [
 	^self size
 ]
 
+{ #category : #comparing }
+ByteString >> compareWith: anotherString [
+
+	"Return a negative Smi, 0 or a positive Smi if self is anotherString, with the collating order of characters given optionnally by the order array."
+
+	<primitive: 158>
+	^ self compareWith: anotherString collated: AsciiOrder
+]
+
+{ #category : #comparing }
+ByteString >> compareWith: anotherString collated: order [
+
+	"Return a negative Smi, 0 or a positive Smi if self is anotherString, with the collating order of characters given optionnally by the order array."
+
+	<primitive: 158>
+	| len1 len2 c1 c2 |
+	len1 := self size.
+	len2 := anotherString size.
+	1 to: (len1 min: len2) do: [ :i | 
+		c1 := order at: (self basicAt: i) + 1.
+		c2 := order at: (anotherString basicAt: i) + 1.
+		c1 = c2 ifFalse: [ 
+			^ c1 < c2
+				  ifTrue: [ -1 ]
+				  ifFalse: [ 1 ] ] ].
+	len1 = len2 ifTrue: [ ^ 0 ].
+	^ len1 < len2
+		  ifTrue: [ -1 ]
+		  ifFalse: [ 1 ]
+]
+
 { #category : #converting }
 ByteString >> createSymbol [
 

--- a/src/Collections-Strings/ByteSymbol.class.st
+++ b/src/Collections-Strings/ByteSymbol.class.st
@@ -70,6 +70,37 @@ ByteSymbol >> byteSize [
 ]
 
 { #category : #comparing }
+ByteSymbol >> compareWith: anotherString [
+
+	"Return a negative Smi, 0 or a positive Smi if self is anotherString, with the collating order of characters given optionnally by the order array."
+
+	<primitive: 158>
+	^ self compareWith: anotherString collated: AsciiOrder
+]
+
+{ #category : #comparing }
+ByteSymbol >> compareWith: anotherString collated: order [
+
+	"Return a negative Smi, 0 or a positive Smi if self is anotherString, with the collating order of characters given optionnally by the order array."
+
+	<primitive: 158>
+	| len1 len2 c1 c2 |
+	len1 := self size.
+	len2 := anotherString size.
+	1 to: (len1 min: len2) do: [ :i | 
+		c1 := order at: (self basicAt: i) + 1.
+		c2 := order at: (anotherString basicAt: i) + 1.
+		c1 = c2 ifFalse: [ 
+			^ c1 < c2
+				  ifTrue: [ -1 ]
+				  ifFalse: [ 1 ] ] ].
+	len1 = len2 ifTrue: [ ^ 0 ].
+	^ len1 < len2
+		  ifTrue: [ -1 ]
+		  ifFalse: [ 1 ]
+]
+
+{ #category : #comparing }
 ByteSymbol >> findSubstring: key in: body startingAt: start matchTable: matchTable [
 	"Answer the index in the string body at which the substring key first occurs, at or beyond start.  The match is determined using matchTable, which can be used to effect, eg, case-insensitive matches.  If no match is found, zero will be returned."
 	<primitive: 'primitiveFindSubstring' module: 'MiscPrimitivePlugin'>

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -966,9 +966,9 @@ String >> compare: string1 with: string2 collated: order [
 	"((ByteArray with: 97 with: 0 with: 0 with: 0) asString sameAs: 'Abcd' asWideString) >>> false"
 	"('a000' asWideString sameAs: (ByteArray with: 97 with: 0 with: 0 with: 0) asString) >>> false"
 	
-	(string1 isByteString and: [string2 isByteString]) ifTrue: [
-		^ ByteString compare: string1 with: string2 collated: order].
-     "Primitive does not fail properly right now"
+	(string1 isByteString and: [string2 isByteString]) ifTrue: [ ^ (string1 compareWith: string2 collated: order) sign + 2 ].
+    
+	"Primitive does not fail properly right now"
 	^ String compare: string1 with: string2 collated: order
 ]
 


### PR DESCRIPTION
…d by Sophie.

Fix [#https://github.com/pharo-project/pharo/issues/3156](https://github.com/pharo-project/pharo/issues/3156)

There are two more steps to improve further the perfs:
- Remove passing the ASCII order when possible because the new primitive works faster if we do no pass this optional parameter
- Update the users of #String>>#compare:with:collated: to compare with positive/0/negative instead of 0/1/2 and avoid to send "sign +2" 

Benches: 

[ 'This is a test' = 'This is a test' ] bench.

"After: '18266371.200 per second'"
"Before: '10208252.099 per second'"

[ 'This is a test' = 'This isn''t a test' ] bench. "After: '42902022.000 per second'"
"Before: '42747076.139 per second'"

[ 'This' = 'This' ] bench.
"After: '18408173.296 per second'"
"Before: '10456056.377 per second'"

[ 'This' = 'That' ] bench.
"After: '20356481.311 per second'"
"Before: '10439757.545 per second'"