### PR TITLE
12006-Performance-Regression-in-Fuel-Serialization-of-Blocks--CompiledMethods 

### DIFF
--- a/src/Fuel-Core/BlockClosure.extension.st
+++ b/src/Fuel-Core/BlockClosure.extension.st
@@ -11,9 +11,9 @@ BlockClosure >> cleanCopy [
 
 { #category : #'*Fuel-Core' }
 BlockClosure >> cleanOuterContext [
-	"Clean my outerContext preserving just the receiver and method, which are the only needed by a clean block closure."
-
-	outerContext := outerContext cleanCopy
+	"Clean my outerContext preserving just the receiver and method, which are the only needed by a clean block closure. outerContext can already be nil if the block was compiled without context"
+	
+	outerContext ifNotNil: [ outerContext := outerContext cleanCopy ]
 ]
 
 { #category : #'*Fuel-Core' }

--- a/src/Fuel-Tests-Core/FLContextSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLContextSerializationTest.class.st
@@ -186,7 +186,7 @@ FLContextSerializationTest >> testDoIt [
 	Note: we run the evaluation in a separate process to minimize the number of
 			contexts that will be serialized (potentially pulling in a large number
 			of additional objects)"
-
+	<compilerOptions: #(+ optionBlockClosureOptionalOuter)>
 	[ [ Smalltalk compiler evaluate: 'self error' ]
 		on: Error
 		do: [ :error |


### PR DESCRIPTION
Fixes #12006 by compiling the closure without outer context