### PR TITLE
use Context>>#homeMethod

### DIFF
--- a/src/Kernel-BytecodeEncoders/BytecodeEncoder.class.st
+++ b/src/Kernel-BytecodeEncoders/BytecodeEncoder.class.st
@@ -118,7 +118,7 @@ BytecodeEncoder >> nextPut: aByte [
 { #category : #'bytecode generation' }
 BytecodeEncoder >> outOfRangeError: string index: index range: rangeStart to: rangeEnd [
 	"For now..."
-	^self error: thisContext sender compiledCode method selector, ' ', string
+	^self error: thisContext sender homeMethod selector, ' ', string
 				, ' index ', index printString
 				, ' is out of range ', rangeStart printString, ' to ', rangeEnd printString
 ]

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -1075,7 +1075,7 @@ Context >> methodClass [
 
 { #category : #accessing }
 Context >> methodNode [
-	^ self compiledCode methodNode.
+	^ self homeMethod methodNode
 ]
 
 { #category : #accessing }
@@ -1102,7 +1102,7 @@ Context >> methodReturnTop [
 
 { #category : #accessing }
 Context >> methodSelector [
-	^ self compiledCode selector
+	^ self homeMethod selector
 ]
 
 { #category : #'private - exceptions' }
@@ -1400,7 +1400,7 @@ Context >> printDetails: stream [
 Context >> printOn: aStream [
 	(closureOrNil isNotNil and: [closureOrNil isKindOf: CleanBlockClosure]) ifTrue: 
 		[ | selector |
-			selector := self selector ifNil: [ self compiledCode defaultSelector ].
+			selector := self selector.
 			aStream 
 			 print: closureOrNil;
 			 nextPutAll: ' in ';
@@ -1416,7 +1416,7 @@ Context >> printOn: aStream [
 				ifNil: [ ^ super printOn: aStream ].
 			class := self receiver class.
 			mclass := self methodClass.
-			selector := self selector ifNil: [ self compiledCode defaultSelector ].
+			selector := self selector.
 			aStream nextPutAll: class name.
 			mclass == class
 				ifFalse:

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -894,9 +894,9 @@ Object >> explicitRequirement [
 	| originalMethod originalArguments errorBlock originalReceiver callingContext originalSelector |
 	errorBlock := [ ^ self error: 'Explicitly required method' ].
 	callingContext := thisContext sender.
-	originalMethod := callingContext compiledCode method.
+	originalMethod := callingContext homeMethod.
 	originalMethod isFromTrait
-		ifFalse: errorBlock.
+		ifFalse: [ errorBlock value].
 	originalReceiver := callingContext receiver.
 	originalSelector := originalMethod selector.
 	originalArguments := callingContext arguments.


### PR DESCRIPTION
- use #homeMethod in Context #methodNode and #methodSelector
- simplify printOn: #selector already does the nil check and fallback to default
- use homeMethod in explicitRequirement and BytecodeEncoder