### PR TITLE
ConstantBlocks-fix-testIsNotTerminatedWhenItIsInsideLastTerminationMethod 

### DIFF
--- a/src/Kernel-Tests-Extended/ProcessTest.class.st
+++ b/src/Kernel-Tests-Extended/ProcessTest.class.st
@@ -290,7 +290,8 @@ ProcessTest >> testIsNotSuspendedWhenItIsTerminated [
 ProcessTest >> testIsNotTerminatedWhenItIsInsideLastTerminationMethod [
 	
 	| process processBody |
-	processBody := [ #test ].
+	"We do not use a constant block, it has no context when executing"
+	processBody := [ #test yourself].
 	process := processBody newProcess.
 	
 	[process step.


### PR DESCRIPTION
testIsNotTerminatedWhenItIsInsideLastTerminationMethod was using a constant block, but as constant blocks have no context when executing, they are not a good "sample block" for this test. The fix is to use a non-constant clean block, so we will see later if clean blocks are problematic here (I think they are not, as this is about execution, not creation)