### PR TITLE
Environment: comment #allMethods, add #methods

### DIFF
--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -85,7 +85,7 @@ SystemDictionary >> allClassesDo: aBlock [
 
 { #category : #'accessing - classes and traits' }
 SystemDictionary >> allMethods [
-
+	"all methods, including copies from Traits"
 	^ self allBehaviors flatCollect: [ :behavior | behavior methods ]
 ]
 
@@ -290,6 +290,12 @@ SystemDictionary >> maxIdentityHash [
 	<primitive: 176>
 	
 	^self primitiveFailed
+]
+
+{ #category : #'accessing - classes and traits' }
+SystemDictionary >> methods [
+	"all methods, but without those installed by Traits"
+	^ self allBehaviors flatCollect: [ :behavior | behavior localMethods ]
 ]
 
 { #category : #'accessing - class and trait names' }

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -113,6 +113,7 @@ SystemNavigation >> allImplementorsOf: aSelector [
 
 { #category : #query }
 SystemNavigation >> allMethods [
+	"all methods, including copies from Traits"
 	^ self environment allMethods
 ]
 
@@ -311,6 +312,12 @@ SystemNavigation >> instanceSideMethodsWithNilKeyInLastLiteral [
 SystemNavigation >> isUnsentMessage: selector [
 	^ self allBehaviors
 		noneSatisfy: [ :behavior | behavior thoroughHasSelectorReferringTo: selector ]
+]
+
+{ #category : #query }
+SystemNavigation >> methods [
+	"all methods, but without those installed by Traits"
+	^ self environment methods
 ]
 
 { #category : #'identifying obsoletes' }


### PR DESCRIPTION
- comment #allMethods to explain that it returns trait methods, too
- add #methods that uses #localMethods

We do not use #methods anywhere, as #localMethods is from Traits and not avalaible in the bootstrap before Traits are installed. This is no good, as just iterating over the methods that are local speeds clients that now use #allMethods.

issue #11928 stays open, but having #methods is important to be able to write scripts that analyse the system without having to explain traits implementation details.