### PR TITLE
Replacing baseColor method call from class to instance side

### DIFF
--- a/src/Reflectivity-Examples/ReflectivitySourceCodeAgroupation.class.st
+++ b/src/Reflectivity-Examples/ReflectivitySourceCodeAgroupation.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #'accessing - defaults' }
 ReflectivitySourceCodeAgroupation >> defaultColor [
 
-	^ Smalltalk ui theme baseColor
+	^ UITheme current baseColor
 ]
 
 { #category : #initialization }

--- a/src/Reflectivity-Examples/ReflectivitySourceCodeAgroupation.class.st
+++ b/src/Reflectivity-Examples/ReflectivitySourceCodeAgroupation.class.st
@@ -7,9 +7,10 @@ Class {
 	#category : #'Reflectivity-Examples'
 }
 
-{ #category : #initialize }
+{ #category : #'accessing - defaults' }
 ReflectivitySourceCodeAgroupation >> defaultColor [
-	^UITheme current class baseColor
+
+	^ Smalltalk ui theme baseColor
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
Instead of calling the method baseColor from the class side of UITheme, calling it from the instance.
This is a necessary step to after integrate the new color palette.