### PR TITLE
[backport] CompiledCode: add #bytecodes 

### DIFF
--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -159,6 +159,11 @@ CompiledCode >> bytecode [
 ]
 
 { #category : #accessing }
+CompiledCode >> bytecodes [
+	^self bytecode
+]
+
+{ #category : #accessing }
 CompiledCode >> clearFlag [
 	"Clear the user-level flag bit"
 


### PR DESCRIPTION


This PR adds back the method to Pharo10 so that we can write tests for Pharo10 and Pharo11 without checking the Version number