### PR TITLE
12008-Blocks-check-senders-of-compiledCode-can-we-use-homeMethod 

### DIFF
--- a/src/Debugger-Model/DebugContext.class.st
+++ b/src/Debugger-Model/DebugContext.class.st
@@ -125,7 +125,7 @@ DebugContext >> locateClosureHomeWithContent: aText [
 	context isBlockContext ifTrue: [
 		closureHome := context activeHome.
 		closureHome ifNil: [
-			self blockNotFoundDialog: context compiledCode method with: aText.
+			self blockNotFoundDialog: context homeMethod with: aText.
 		 	^ nil ].
 		 (self confirm: 'I will have to revert to the method from\which this block originated.  Is that OK?' withCRs) 
 			ifFalse: [ ^ nil ].

--- a/src/Kernel/Deprecation.class.st
+++ b/src/Kernel/Deprecation.class.st
@@ -139,7 +139,7 @@ Deprecation >> defaultAction [
 
 { #category : #private }
 Deprecation >> deprecatedMethodName [
-	^self contextOfDeprecatedMethod compiledCode method printString
+	^self contextOfDeprecatedMethod homeMethod printString
 ]
 
 { #category : #accessing }
@@ -201,7 +201,7 @@ Deprecation >> rule: aRule [
 
 { #category : #private }
 Deprecation >> sendingMethodName [
-	^self contextOfSender compiledCode method printString
+	^self contextOfSender homeMethod printString
 ]
 
 { #category : #handling }
@@ -218,10 +218,11 @@ Deprecation >> showWarning [
 
 { #category : #handling }
 Deprecation >> signal [
-	| pragma |
-	(context compiledCode method hasPragmaNamed: #transform:to:) ifFalse: [ ^super signal ].
+	| pragma homeMethod |
+	homeMethod := context homeMethod.
+	(homeMethod hasPragmaNamed: #transform:to:) ifFalse: [ ^super signal ].
 
-	pragma := context compiledCode method pragmaAt: #transform:to:.
+	pragma := homeMethod pragmaAt: #transform:to:.
 	self rule: pragma arguments first -> pragma arguments second.
 	self transform
 ]
@@ -231,7 +232,7 @@ Deprecation >> transform [
 	| node rewriteRule aMethod |
 	self shouldTransform ifFalse: [ ^ self signal].
 	self rewriterClass ifNil:[ ^ self signal ].
-	aMethod := self contextOfSender compiledCode method.
+	aMethod := self contextOfSender homeMethod.
 	aMethod isDoIt ifTrue:[ ^ self signal ]. "no need to transform doits"
 	node := self contextOfSender sourceNodeExecuted.
 	RecursionStopper during: [

--- a/src/Kernel/LocalRecursionStopper.class.st
+++ b/src/Kernel/LocalRecursionStopper.class.st
@@ -21,7 +21,7 @@ LocalRecursionStopper class >> activeMethods [
 { #category : #api }
 LocalRecursionStopper class >> during: aBlock [
 	<debuggerCompleteToSender>
-	self stopMethod: thisContext sender compiledCode method during: aBlock
+	self stopMethod: thisContext sender homeMethod during: aBlock
 ]
 
 { #category : #private }

--- a/src/Kernel/RecursionStopper.class.st
+++ b/src/Kernel/RecursionStopper.class.st
@@ -29,7 +29,7 @@ RecursionStopper class >> default [
 RecursionStopper class >> during: aBlock [
 	<debuggerCompleteToSender>
 	self default 
-		stopMethod: thisContext sender compiledCode method
+		stopMethod: thisContext sender homeMethod
 		during: aBlock
 ]
 

--- a/src/Kernel/Semaphore.class.st
+++ b/src/Kernel/Semaphore.class.st
@@ -145,7 +145,7 @@ Semaphore >> criticalReleasingOnError: mutuallyExcludedBlock [
 { #category : #'process termination handling' }
 Semaphore >> handleProcessTerminationOfWaitingContext: suspendedContext [
 
-	^suspendedContext compiledCode method == (Semaphore compiledMethodAt: #critical:) 
+	^suspendedContext homeMethod == (Semaphore compiledMethodAt: #critical:) 
 		ifTrue: [ suspendedContext home]
 		ifFalse: [ suspendedContext]
 ]

--- a/src/ThreadedFFI/TFCallbackSameProcessRunStrategy.class.st
+++ b/src/ThreadedFFI/TFCallbackSameProcessRunStrategy.class.st
@@ -50,7 +50,7 @@ TFCallbackSameProcessRunStrategy >> executeCallback: aCallbackInvocation on: aTF
 	process := self callbackProcess.
 		
 	"I will reuse the same process if it is not used already. Reentrant callbacks should fork a new process"
-	(process isSuspended and: [ process suspendedContext compiledCode method = (self class >> #waitForever) ])
+	(process isSuspended and: [ process suspendedContext homeMethod = (self class >> #waitForever) ])
 		ifFalse: [ ^ super executeCallback: aCallbackInvocation on: aTFRunner ].	
 
 	methodToUse := self class >> #doExecuteCallback:on:.

--- a/src/UnifiedFFI-Tests/FFICalloutMethodBuilderTestContext.class.st
+++ b/src/UnifiedFFI-Tests/FFICalloutMethodBuilderTestContext.class.st
@@ -40,6 +40,11 @@ FFICalloutMethodBuilderTestContext >> ffiLibrary [
 ]
 
 { #category : #accessing }
+FFICalloutMethodBuilderTestContext >> homeMethod [
+	^ self
+]
+
+{ #category : #accessing }
 FFICalloutMethodBuilderTestContext >> method [
 	^ self
 ]

--- a/src/UnifiedFFI/FFICallout.class.st
+++ b/src/UnifiedFFI/FFICallout.class.st
@@ -391,9 +391,9 @@ FFICallout >> resolveUntypedArgument: anArgument [
 { #category : #accessing }
 FFICallout >> sender: aSenderContext [
 	| nArgs |
-	self requestor: aSenderContext compiledCode method methodClass.
-	nArgs := aSenderContext compiledCode method numArgs.
-	methodArgs := aSenderContext compiledCode method argumentNames.
+	self requestor: aSenderContext homeMethod methodClass.
+	nArgs := aSenderContext homeMethod numArgs.
+	methodArgs := aSenderContext homeMethod argumentNames.
 	self receiver: aSenderContext receiver.
 	self assert: (methodArgs size = nArgs).
 

--- a/src/UnifiedFFI/FFICalloutAPI.class.st
+++ b/src/UnifiedFFI/FFICalloutAPI.class.st
@@ -92,8 +92,8 @@ FFICalloutAPI >> findUffiEnterContext [
 	pragmaName := #ffiCalloutTranslator.
 	
 	uffiEnterContext := (uFFIEntryPointContext ifNil: [ thisContext ]) findContextSuchThat: [ :ctx |
-		(ctx compiledCode method hasPragmaNamed: pragmaName)
-			and: [ (ctx sender compiledCode method hasPragmaNamed: pragmaName) not] ].
+		(ctx homeMethod hasPragmaNamed: pragmaName)
+			and: [ (ctx sender homeMethod hasPragmaNamed: pragmaName) not] ].
 	^ uffiEnterContext
 ]
 
@@ -206,5 +206,5 @@ FFICalloutAPI >> uFFIEnterMethodSelector [
 	That is, the selector that was called by client code to invoke uffi.
 	If we got here from a context not controlled by uffi, return nil, as we have found no method"
 	
-	^ self findUffiEnterContext ifNotNil: [ :ctx | ctx compiledCode method selector ]
+	^ self findUffiEnterContext ifNotNil: [ :ctx | ctx homeMethod selector ]
 ]

--- a/src/UnifiedFFI/FFICalloutMethodBuilder.class.st
+++ b/src/UnifiedFFI/FFICalloutMethodBuilder.class.st
@@ -187,7 +187,7 @@ FFICalloutMethodBuilder >> libraryName [
 
 { #category : #accessing }
 FFICalloutMethodBuilder >> method [
-	^ self sender compiledCode method
+	^ self sender homeMethod
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
use #homeMethod instead of "compiledCode method", this is much clearer what it is. fixes #12008