### PR TITLE
add #optionBlockQuickReturn, fixes #12039

### DIFF
--- a/src/Kernel/CompiledBlock.class.st
+++ b/src/Kernel/CompiledBlock.class.st
@@ -164,6 +164,14 @@ CompiledBlock >> pragmas [
 	^ #()
 ]
 
+{ #category : #accessing }
+CompiledBlock >> primitive [
+	"see IRBytecodeGenerator>>#compiledBlockWith:"
+	^self class compiler compilationContext optionBlockQuickReturn 
+		ifTrue: [ super primitive ]
+		ifFalse: [ 0 ]
+]
+
 { #category : #printing }
 CompiledBlock >> printOn: anStream [
 	

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -121,6 +121,16 @@ CompilationContext class >> optionBlockClosureOptionalOuter: aBoolean [
 ]
 
 { #category : #'options - settings API' }
+CompilationContext class >> optionBlockQuickReturn [
+	^ self readDefaultOption: #optionBlockQuickReturn
+]
+
+{ #category : #'options - settings API' }
+CompilationContext class >> optionBlockQuickReturn: aBoolean [
+	^ self writeDefaultOption: #optionBlockQuickReturn value: aBoolean
+]
+
+{ #category : #'options - settings API' }
 CompilationContext class >> optionCleanBlockClosure [
 	^ self readDefaultOption: #optionCleanBlockClosure
 ]
@@ -309,6 +319,7 @@ CompilationContext class >> optionsDescription [
 	(- optionInlineNone 				'To turn off all inlining options. Overrides the others')
 	
 	(- optionEmbeddSources         'Embedd sources into CompiledMethod instead of storing in .changes')
+	(- optionBlockQuickReturn 			'Compiler compiles closure with Quick Return if possible,  Experimental')
 	(- optionBlockClosureOptionalOuter 			'Compiler compiles closure creation with outerContext only if it has a non-local return. Experimental')
 	(- optionConstantBlockClosure 			'Compiler compiles closure creation to use ConstantBlockClosure for constant with 0-3 arguments. Experimental')
 	(- optionCleanBlockClosure 			'Compiler compiles closure creation to use CleanBlockClosure instead of FullBlockClosure for clean blocks. Experimental')
@@ -517,6 +528,11 @@ CompilationContext >> noPattern: anObject [
 { #category : #options }
 CompilationContext >> optionBlockClosureOptionalOuter [
 	^ options includes: #optionBlockClosureOptionalOuter
+]
+
+{ #category : #options }
+CompilationContext >> optionBlockQuickReturn [
+	^ options includes: #optionBlockQuickReturn
 ]
 
 { #category : #options }

--- a/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
+++ b/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
@@ -159,6 +159,9 @@ IRBytecodeGenerator >> compilationContext: aCompilationContext [
 IRBytecodeGenerator >> compiledBlockWith: trailer [
 	| lits quickPrimitive header cb |
 	lits := self literals allButLast "1 free only for compiledBlock".
+compilationContext optionBlockQuickReturn ifTrue: [ 
+	"Experimental: generate quick method return just as we do for compiledMethod
+	TODO: fix Context step simulator to do the right thing with this"		
 	quickPrimitive := self quickMethodPrim.
 	(primNumber = 0 and: [quickPrimitive > 0]) ifTrue: [
 		"if we are a quick method we need to add a bytecode at the beginning. #bytecodes
@@ -166,7 +169,7 @@ IRBytecodeGenerator >> compiledBlockWith: trailer [
 		primitiveBytes := (ByteArray new: 4) writeStream.
 		encoder stream: primitiveBytes.
 		encoder genCallPrimitive: quickPrimitive.
-	].
+	]].
 	header := self spurVMHeader: lits size.
 	cb := CompiledBlock newMethod: self bytecodes size header: header.
 	(WriteStream with: cb)


### PR DESCRIPTION
turn off code generation for quick blocks for now, as the debugger (the context step simulator) gets confused