### PR TITLE
Fix #11995: Handle attempted creation of existing package gracefully

### DIFF
--- a/src/SystemCommands-PackageCommands-Tests/SycAddNewPackageCommandTest.class.st
+++ b/src/SystemCommands-PackageCommands-Tests/SycAddNewPackageCommandTest.class.st
@@ -1,0 +1,51 @@
+"
+A SycAddNewPackageCommandTest is a test class for testing the behavior of SycAddNewPackageCommand
+"
+Class {
+	#name : #SycAddNewPackageCommandTest,
+	#superclass : #TestCase,
+	#category : #'SystemCommands-PackageCommands-Tests'
+}
+
+{ #category : #tests }
+SycAddNewPackageCommandTest >> testExecute [
+
+	| systemEnvironment command |
+	systemEnvironment := MockObject new
+		                     on: #createPackageNamed:
+		                     with: 'Test-Package'.
+
+	command := SycAddNewPackageCommand new
+		           systemEnvironment: systemEnvironment;
+		           packageName: 'Test-Package';
+		           execute.
+
+	self assert: command resultPackage equals: systemEnvironment.
+	self verify: systemEnvironment
+
+]
+
+{ #category : #tests }
+SycAddNewPackageCommandTest >> testExecuteAlreadyExists [
+
+	| systemEnvironment command |
+	systemEnvironment := MockObject new.
+	systemEnvironment
+		on: #createPackageNamed:
+		with: 'Test-Package'
+		verify: [ 
+			RPackageConflictError signal:
+				'A package named Test-Package already exists' ].
+	systemEnvironment
+		on: #packageNamed:
+		with: 'Test-Package'
+		respond: #sentinel.
+
+	command := SycAddNewPackageCommand new
+		           systemEnvironment: systemEnvironment;
+		           packageName: 'Test-Package';
+		           execute.
+
+	self assert: command resultPackage equals: #sentinel.
+	self verify: systemEnvironment
+]

--- a/src/SystemCommands-PackageCommands-Tests/package.st
+++ b/src/SystemCommands-PackageCommands-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'SystemCommands-PackageCommands-Tests' }

--- a/src/SystemCommands-PackageCommands/SycAddNewPackageCommand.class.st
+++ b/src/SystemCommands-PackageCommands/SycAddNewPackageCommand.class.st
@@ -44,7 +44,9 @@ SycAddNewPackageCommand >> defaultMenuItemName [
 { #category : #execution }
 SycAddNewPackageCommand >> execute [
 
-	resultPackage := systemEnvironment createPackageNamed: packageName
+	resultPackage := [ systemEnvironment createPackageNamed: packageName ]
+		                 on: RPackageConflictError
+		                 do: [ systemEnvironment packageNamed: packageName ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Fixes #11995

* Answers with existing package instance if a package with the same name already exists
* Adds some test coverage for `SycAddNewPackageCommand`