### PR TITLE
12049-CI-failure-in-build-testSetUpMethodInSUnitTestsNeedsToBeInRunningProtocol 

### DIFF
--- a/src/Collections-Tests/ByteArrayTest.class.st
+++ b/src/Collections-Tests/ByteArrayTest.class.st
@@ -18,7 +18,7 @@ ByteArrayTest >> collectionWith5Elements [
 	^ collectionWith5Elements
 ]
 
-{ #category : #requirements }
+{ #category : #running }
 ByteArrayTest >> setUp [ 
 
 	super setUp.

--- a/src/Text-Tests/RunArrayTest.class.st
+++ b/src/Text-Tests/RunArrayTest.class.st
@@ -18,7 +18,7 @@ RunArrayTest >> collectionWith5Elements [
 	^ collectionWith5Elements
 ]
 
-{ #category : #initialization }
+{ #category : #running }
 RunArrayTest >> setUp [ 
 
 	super setUp.


### PR DESCRIPTION
fixes #12049