### PR TITLE
11968-Clean-Blocks-Jobowner-assumes-valid-outerContext

### DIFF
--- a/src/Jobs/BlockClosure.extension.st
+++ b/src/Jobs/BlockClosure.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #BlockClosure }
 { #category : #'*Jobs' }
 BlockClosure >> asJob [
 	"the owner is the object where the job was started, not where the block was created"
-	^ Job block: self owner: thisContext sender receiver
+	^ self asJobWithOwner: thisContext sender receiver
 ]
 
 { #category : #'*Jobs' }

--- a/src/Jobs/BlockClosure.extension.st
+++ b/src/Jobs/BlockClosure.extension.st
@@ -2,6 +2,12 @@ Extension { #name : #BlockClosure }
 
 { #category : #'*Jobs' }
 BlockClosure >> asJob [
+	"the owner is the object where the job was started, not where the block was created"
+	^ Job block: self owner: thisContext sender receiver
+]
 
-	^ Job block: self
+{ #category : #'*Jobs' }
+BlockClosure >> asJobWithOwner: anObject [
+
+	^ Job block: self owner: anObject
 ]

--- a/src/Jobs/Job.class.st
+++ b/src/Jobs/Job.class.st
@@ -21,7 +21,8 @@ Class {
 		'children',
 		'isRunning',
 		'parent',
-		'process'
+		'process',
+		'owner'
 	],
 	#classInstVars : [
 		'jobAnnouncer'
@@ -34,6 +35,15 @@ Job class >> block: aBlock [
 
 	^(self new)
 		block: aBlock;
+		yourself
+]
+
+{ #category : #'instance creation' }
+Job class >> block: aBlock owner: anObject [
+
+	^(self new)
+		block: aBlock;
+		owner: anObject;
 		yourself
 ]
 
@@ -272,8 +282,12 @@ Job >> min: aNumber [
 
 { #category : #accessing }
 Job >> owner [
+	^ owner
+]
 
-	^ block outerContext receiver
+{ #category : #accessing }
+Job >> owner: anObject [ 
+	owner := anObject
 ]
 
 { #category : #private }


### PR DESCRIPTION
Change Job to not rely on the homeContext receiver for the owner, but instead use the object that created the Job with #asJob.

In addion, add  #asJobWithOwner: to set it explicitly