### PR TITLE
Refactor make class abstract

### DIFF
--- a/src/Refactoring-Core/RBCreateAccessorsForVariableTransformation.class.st
+++ b/src/Refactoring-Core/RBCreateAccessorsForVariableTransformation.class.st
@@ -41,6 +41,12 @@ Class {
 	#category : #'Refactoring-Core-Transformation'
 }
 
+{ #category : #displaying }
+RBCreateAccessorsForVariableTransformation class >> basicMenuItemString [
+
+	^ 'Generate accessors'
+]
+
 { #category : #'instance creation' }
 RBCreateAccessorsForVariableTransformation class >> classVariable: aVarName class: aClass [
 	^ self variable: aVarName class: aClass classVariable: true

--- a/src/Refactoring-Core/RBCreateAccessorsForVariableTransformation.class.st
+++ b/src/Refactoring-Core/RBCreateAccessorsForVariableTransformation.class.st
@@ -52,8 +52,9 @@ RBCreateAccessorsForVariableTransformation class >> instanceVariable: aVarName c
 ]
 
 { #category : #accessing }
-RBCreateAccessorsForVariableTransformation class >> kind [
-	^ 'Transformation'
+RBCreateAccessorsForVariableTransformation class >> isTransformation [ 
+
+	^ true
 ]
 
 { #category : #'instance creation' }

--- a/src/Refactoring-Core/RBCreateLazyAccessorsForVariableTransformation.class.st
+++ b/src/Refactoring-Core/RBCreateLazyAccessorsForVariableTransformation.class.st
@@ -33,6 +33,12 @@ Class {
 	#category : #'Refactoring-Core-Transformation'
 }
 
+{ #category : #displaying }
+RBCreateLazyAccessorsForVariableTransformation class >> basicMenuItemString [ 
+
+	^ 'Generate lazy accessors'
+]
+
 { #category : #'instance creation' }
 RBCreateLazyAccessorsForVariableTransformation class >> model: aRBSmalltalk variable: aVarName class: aClass classVariable: aBoolean defaultValue: aString [
 	^(self 

--- a/src/Refactoring-Core/RBGenerateEqualHashTransformation.class.st
+++ b/src/Refactoring-Core/RBGenerateEqualHashTransformation.class.st
@@ -47,6 +47,12 @@ Class {
 	#category : #'Refactoring-Core-Transformation'
 }
 
+{ #category : #displaying }
+RBGenerateEqualHashTransformation class >> basicMenuItemString [
+
+	^ 'Generate equal and hash'
+]
+
 { #category : #'instance creation' }
 RBGenerateEqualHashTransformation class >> className: aClass variables: anArray [
 	^ (self className: aClass) variables: anArray

--- a/src/Refactoring-Core/RBGenerateEqualHashTransformation.class.st
+++ b/src/Refactoring-Core/RBGenerateEqualHashTransformation.class.st
@@ -52,9 +52,10 @@ RBGenerateEqualHashTransformation class >> className: aClass variables: anArray 
 	^ (self className: aClass) variables: anArray
 ]
 
-{ #category : #accessing }
-RBGenerateEqualHashTransformation class >> kind [ 
-	^ 'Transformation'
+{ #category : #testing }
+RBGenerateEqualHashTransformation class >> isTransformation [ 
+
+	^ true
 ]
 
 { #category : #'instance creation' }

--- a/src/Refactoring-Core/RBGeneratePrintOnTransformation.class.st
+++ b/src/Refactoring-Core/RBGeneratePrintOnTransformation.class.st
@@ -35,6 +35,12 @@ Class {
 	#category : #'Refactoring-Core-Transformation'
 }
 
+{ #category : #displaying }
+RBGeneratePrintOnTransformation class >> basicMenuItemString [
+
+	^ 'Generate printOn:'
+]
+
 { #category : #'instance creation' }
 RBGeneratePrintOnTransformation class >> className: aClass variables: anArray [
 	^ (self className: aClass) variables: anArray

--- a/src/Refactoring-Core/RBGeneratePrintOnTransformation.class.st
+++ b/src/Refactoring-Core/RBGeneratePrintOnTransformation.class.st
@@ -40,9 +40,10 @@ RBGeneratePrintOnTransformation class >> className: aClass variables: anArray [
 	^ (self className: aClass) variables: anArray
 ]
 
-{ #category : #accessing }
-RBGeneratePrintOnTransformation class >> kind [ 
-	^ 'Transformation'
+{ #category : #testing }
+RBGeneratePrintOnTransformation class >> isTransformation [ 
+
+	^ true
 ]
 
 { #category : #'instance creation' }

--- a/src/Refactoring-Core/RBMakeClassAbstractTransformation.class.st
+++ b/src/Refactoring-Core/RBMakeClassAbstractTransformation.class.st
@@ -7,6 +7,12 @@ Class {
 	#category : #'Refactoring-Core-Transformation'
 }
 
+{ #category : #displaying }
+RBMakeClassAbstractTransformation class >> basicMenuItemString [
+
+	^ 'Make abstract'
+]
+
 { #category : #'instance creation' }
 RBMakeClassAbstractTransformation class >> class: targetClass [
 

--- a/src/Refactoring-Core/RBMakeClassAbstractTransformation.class.st
+++ b/src/Refactoring-Core/RBMakeClassAbstractTransformation.class.st
@@ -1,0 +1,42 @@
+Class {
+	#name : #RBMakeClassAbstractTransformation,
+	#superclass : #RBClassRefactoring,
+	#instVars : [
+		'targetClass'
+	],
+	#category : #'Refactoring-Core-Transformation'
+}
+
+{ #category : #'instance creation' }
+RBMakeClassAbstractTransformation class >> class: targetClass [
+
+	^ self new class: targetClass 
+]
+
+{ #category : #accessing }
+RBMakeClassAbstractTransformation class >> kind [
+
+	^ 'Transformation'
+]
+
+{ #category : #'instance creation' }
+RBMakeClassAbstractTransformation >> class: class [
+
+	targetClass := class
+]
+
+{ #category : #preconditions }
+RBMakeClassAbstractTransformation >> preconditions [
+	
+	^ (RBCondition isAbstractClass: targetClass) not
+]
+
+{ #category : #transforming }
+RBMakeClassAbstractTransformation >> transform [
+	(RBAddMethodTransformation
+		                   sourceCode: 'isAbstract
+		
+	^ self == ' , targetClass asString
+		                   in: targetClass classSide
+		                   withProtocols: #( #testing )) execute
+]

--- a/src/Refactoring-Core/RBMakeClassAbstractTransformation.class.st
+++ b/src/Refactoring-Core/RBMakeClassAbstractTransformation.class.st
@@ -13,10 +13,10 @@ RBMakeClassAbstractTransformation class >> class: targetClass [
 	^ self new class: targetClass 
 ]
 
-{ #category : #accessing }
-RBMakeClassAbstractTransformation class >> kind [
+{ #category : #testing }
+RBMakeClassAbstractTransformation class >> isTransformation [ 
 
-	^ 'Transformation'
+	^ true
 ]
 
 { #category : #'instance creation' }

--- a/src/Refactoring-Core/RBRefactoring.class.st
+++ b/src/Refactoring-Core/RBRefactoring.class.st
@@ -95,6 +95,13 @@ RBRefactoring class >> isAbstract [
 ]
 
 { #category : #accessing }
+RBRefactoring class >> isTransformation [
+	"Tells if this refactoring is a refactoring or a transformation."
+
+	^ false
+]
+
+{ #category : #accessing }
 RBRefactoring class >> kind [
 	"Tells if this refactoring is a refactoring or a transformation.
 	Returns either 'Refactoring' or 'Transformation'"

--- a/src/Refactoring-Core/RBRefactoring.class.st
+++ b/src/Refactoring-Core/RBRefactoring.class.st
@@ -39,6 +39,12 @@ Class {
 	#category : #'Refactoring-Core-Refactorings'
 }
 
+{ #category : #displaying }
+RBRefactoring class >> basicMenuItemString [
+
+	^ self subclassResponsibility
+]
+
 { #category : #cleaning }
 RBRefactoring class >> cleanUp [
 	"RefactoringOptions holds on to blocks, we should make sure to recreate them so the block references the current method"
@@ -101,12 +107,12 @@ RBRefactoring class >> isTransformation [
 	^ false
 ]
 
-{ #category : #accessing }
-RBRefactoring class >> kind [
-	"Tells if this refactoring is a refactoring or a transformation.
-	Returns either 'Refactoring' or 'Transformation'"
+{ #category : #displaying }
+RBRefactoring class >> menuItemString [
 
-	^ 'Refactoring'
+	^ (self isTransformation
+		   ifTrue: [ '(T) ' ]
+		   ifFalse: [ '' ]) , self basicMenuItemString
 ]
 
 { #category : #'accessing signal' }

--- a/src/Refactoring-Core/RBReplaceMessageSendTransformation.class.st
+++ b/src/Refactoring-Core/RBReplaceMessageSendTransformation.class.st
@@ -29,6 +29,12 @@ Class {
 	#category : #'Refactoring-Core-Refactorings'
 }
 
+{ #category : #displaying }
+RBReplaceMessageSendTransformation class >> basicMenuItemString [
+
+	^ 'Replace senders'
+]
+
 { #category : #accessing }
 RBReplaceMessageSendTransformation class >> kind [
 

--- a/src/Refactoring-Tests-Core/RBBasicLintRuleTestData.class.st
+++ b/src/Refactoring-Tests-Core/RBBasicLintRuleTestData.class.st
@@ -56,6 +56,12 @@ RBBasicLintRuleTestData class >> createParseTreeRule: codeStrings name: aName [
 		name: aName
 ]
 
+{ #category : #testing }
+RBBasicLintRuleTestData class >> isAbstract [
+		
+	^ self == RBBasicLintRuleTestData
+]
+
 { #category : #'unnecessary code' }
 RBBasicLintRuleTestData class >> justSendsSuper [
 	| detector matcher |

--- a/src/Refactoring2-Transformations-Tests/RBMakeClassAbstractParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMakeClassAbstractParametrizedTest.class.st
@@ -1,0 +1,42 @@
+Class {
+	#name : #RBMakeClassAbstractParametrizedTest,
+	#superclass : #RBWithDifferentConstructorsParametrizedTest,
+	#instVars : [
+		'testClass'
+	],
+	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+}
+
+{ #category : #tests }
+RBMakeClassAbstractParametrizedTest class >> testParameters [
+	^ ParametrizedTestMatrix new
+		addCase: { #rbClass -> RBMakeClassAbstractTransformation };
+		yourself
+]
+
+{ #category : #running }
+RBMakeClassAbstractParametrizedTest >> setUp [
+	super setUp.
+	model := self abstractVariableTestData.
+	
+	testClass := RBBasicLintRuleTestData.
+	testClass class removeSelector: #isAbstract.
+]
+
+{ #category : #running }
+RBMakeClassAbstractParametrizedTest >> tearDown [ 
+
+	testClass class removeSelector: #isAbstract.
+	super tearDown 
+]
+
+{ #category : #tests }
+RBMakeClassAbstractParametrizedTest >> testMakeClassAbstractAddsIsAbstractMethodToClassSide [
+	| refactoring |
+	refactoring := rbClass class: testClass.
+	
+	self executeRefactoring: refactoring.
+	self assert: ((refactoring model classNamed: testClass name) classSide 
+			parseTreeFor: #isAbstract) 
+		equals: (self parseMethod: 'isAbstract ^self == ', testClass name)
+]

--- a/src/SystemCommands-ClassCommands/SycCMakeAbstractCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycCMakeAbstractCommand.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #executing }
 SycCMakeAbstractCommand >> executeRefactoring [
 
-	(RBMakeClassAbstractTransformation class: targetClass) execute
+	(self refactoringClass class: targetClass) execute
 ]
 
 { #category : #accessing }
@@ -27,10 +27,16 @@ SycCMakeAbstractCommand >> isApplicable [
 
 { #category : #testing }
 SycCMakeAbstractCommand >> name [
-	^ '(T) Make Abstract'
+	^ self refactoringClass menuItemString
 ]
 
 { #category : #testing }
 SycCMakeAbstractCommand >> order [
 	^ 40
+]
+
+{ #category : #'factory method' }
+SycCMakeAbstractCommand >> refactoringClass [
+
+	^ RBMakeClassAbstractTransformation 
 ]

--- a/src/SystemCommands-ClassCommands/SycCMakeAbstractCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycCMakeAbstractCommand.class.st
@@ -10,13 +10,7 @@ Class {
 { #category : #executing }
 SycCMakeAbstractCommand >> executeRefactoring [
 
-	| transformation |
-	transformation := (RBAddMethodTransformation
-		                   sourceCode: 'isAbstract
-		
-	^ self == ' , targetClass asString
-		                   in: targetClass classSide
-		                   withProtocols: #( #testing )) execute
+	(RBMakeClassAbstractTransformation class: targetClass) execute
 ]
 
 { #category : #accessing }
@@ -33,7 +27,7 @@ SycCMakeAbstractCommand >> isApplicable [
 
 { #category : #testing }
 SycCMakeAbstractCommand >> name [
-	^ 'Make Abstract'
+	^ '(T) Make Abstract'
 ]
 
 { #category : #testing }

--- a/src/SystemCommands-ClassCommands/SycGenerateEqualAndHashCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycGenerateEqualAndHashCommand.class.st
@@ -11,7 +11,7 @@ Class {
 SycGenerateEqualAndHashCommand >> asRefactorings [
 
 	^{
-		RBGenerateEqualHashTransformation 
+		self refactoringClass 
 			className: targetClass name
 			variables: (variables collect: [:each | each name])
 	}
@@ -21,7 +21,7 @@ SycGenerateEqualAndHashCommand >> asRefactorings [
 SycGenerateEqualAndHashCommand >> defaultMenuItemName [
 	"Make sure that the user knows that this is a transformation by adding (T) in front of the menu item name."
 	
-	^'(T) Generate equal and hash'
+	^ self refactoringClass menuItemString
 ]
 
 { #category : #execution }
@@ -36,4 +36,10 @@ SycGenerateEqualAndHashCommand >> prepareFullExecutionInContext: aToolContext [
 	variables := aToolContext 
 		requestMultipleVariables: 'Choose variables for equality' 
 		from: {targetClass}
+]
+
+{ #category : #'factory method' }
+SycGenerateEqualAndHashCommand >> refactoringClass [ 
+
+	^ RBGenerateEqualHashTransformation
 ]

--- a/src/SystemCommands-ClassCommands/SycGeneratePrintOnCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycGeneratePrintOnCommand.class.st
@@ -11,7 +11,7 @@ Class {
 SycGeneratePrintOnCommand >> asRefactorings [
 
 	^{
-		RBGeneratePrintOnTransformation 
+		self refactoringClass  
 			className: targetClass name
 			variables: (variables collect: [:each | each name])
 	}
@@ -20,7 +20,7 @@ SycGeneratePrintOnCommand >> asRefactorings [
 { #category : #accessing }
 SycGeneratePrintOnCommand >> defaultMenuItemName [
 	"Make sure that the user knows that this is a transformation by adding (T) in front of the menu item name."
-	^'(T) Generate printOn:'
+	^ self refactoringClass menuItemString 
 ]
 
 { #category : #execution }
@@ -35,4 +35,10 @@ SycGeneratePrintOnCommand >> prepareFullExecutionInContext: aToolContext [
 	variables := aToolContext 
 		requestMultipleVariables: 'Choose variables for print string' 
 		from: {targetClass}
+]
+
+{ #category : #'factory method' }
+SycGeneratePrintOnCommand >> refactoringClass [ 
+
+	^ RBGeneratePrintOnTransformation
 ]

--- a/src/SystemCommands-MessageCommands/SycReplaceMessageCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycReplaceMessageCommand.class.st
@@ -17,7 +17,7 @@ SycReplaceMessageCommand >> createRefactoring [
 	
 	^ newSelector newArgs
 		ifNotEmpty:[ 
-		(RBReplaceMessageSendTransformation
+		(self refactoringClass 
 		model: model
 		replaceMethod: originalMessage selector 
 		in: selectedClass
@@ -26,7 +26,7 @@ SycReplaceMessageCommand >> createRefactoring [
 		inAllClasses: self replaceInAllClasses)
 		initializers: newSelector newArgs values ]
 	ifEmpty:[ 
-	 (RBReplaceMessageSendTransformation
+	 (self refactoringClass 
 		model: model
 		replaceMethod: originalMessage selector 
 		in: selectedClass 
@@ -45,7 +45,7 @@ SycReplaceMessageCommand >> defaultMenuIconName [
 SycReplaceMessageCommand >> defaultMenuItemName [
 	"Make sure that the user knows that this is a transformation by adding (T) in front of the menu item name."
 	
-	^ '(T) Replace senders'
+	^ self refactoringClass menuItemString
 ]
 
 { #category : #execution }
@@ -70,6 +70,12 @@ SycReplaceMessageCommand >> prepareFullExecutionInContext: aToolContext [
 	originalMessage selector = methodName selector ifTrue: [ 
 		CmdCommandAborted signal ].
 	newSelector := methodName
+]
+
+{ #category : #'factory method' }
+SycReplaceMessageCommand >> refactoringClass [ 
+
+	^ RBReplaceMessageSendTransformation
 ]
 
 { #category : #execution }

--- a/src/SystemCommands-VariableCommands/SycGenerateVariableAccessorCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycGenerateVariableAccessorCommand.class.st
@@ -11,7 +11,7 @@ Class {
 SycGenerateVariableAccessorCommand >> asRefactorings [
 
 	^self
-		createRefactorings: RBCreateAccessorsForVariableTransformation 
+		createRefactorings: self refactoringClass  
 		using: [ :refactoring :var |
 			refactoring classVariable: var isClassVariable ]
 ]
@@ -25,5 +25,11 @@ SycGenerateVariableAccessorCommand >> defaultMenuIconName [
 SycGenerateVariableAccessorCommand >> defaultMenuItemName [
 	"Make sure that the user knows that this is a transformation by adding (T) in front of the menu item name."
 
-	^'(T) Generate accessors'
+	^ self refactoringClass menuItemString
+]
+
+{ #category : #'factory method' }
+SycGenerateVariableAccessorCommand >> refactoringClass [ 
+
+	^ RBCreateAccessorsForVariableTransformation
 ]

--- a/src/SystemCommands-VariableCommands/SycGenerateVariableAccessorsWithLazyInitializationCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycGenerateVariableAccessorsWithLazyInitializationCommand.class.st
@@ -26,7 +26,7 @@ SycGenerateVariableAccessorsWithLazyInitializationCommand class >> fullBrowserMe
 { #category : #converting }
 SycGenerateVariableAccessorsWithLazyInitializationCommand >> asRefactorings [
 
-	^ { (RBCreateLazyAccessorsForVariableTransformation 
+	^ { (self refactoringClass  
 		variable: variable name
 		class: variable definingClass 
 		classVariable: variable isClassVariable
@@ -42,7 +42,7 @@ SycGenerateVariableAccessorsWithLazyInitializationCommand >> defaultMenuIconName
 SycGenerateVariableAccessorsWithLazyInitializationCommand >> defaultMenuItemName [
 	"Make sure that the user knows that this is a transformation by adding (T) in front of the menu item name."
 
-	^'(T) Generate accessors (lazy)'
+	^ self refactoringClass menuItemString
 ]
 
 { #category : #testing }
@@ -60,4 +60,10 @@ SycGenerateVariableAccessorsWithLazyInitializationCommand >> prepareFullExecutio
 		           initialAnswer: 'nil'
 		           title: 'Default variable''s value'.
 	value isEmptyOrNil ifTrue: [ CmdCommandAborted signal ]
+]
+
+{ #category : #'factory method' }
+SycGenerateVariableAccessorsWithLazyInitializationCommand >> refactoringClass [ 
+
+	^ RBCreateLazyAccessorsForVariableTransformation
 ]


### PR DESCRIPTION
This PR introduces a few smaller changes:
* Move logic from MakeClassAbstract command to a new Transformation class
* Change `kind` method to return true/false and rename it to `isTransformation`
* Dynamically add "(T) " as prefix for menu items that are transformation