### PR TITLE
11965-Implement-ContextactiveHome-without-using-home

### DIFF
--- a/src/Kernel-Tests/ContextTest.class.st
+++ b/src/Kernel-Tests/ContextTest.class.st
@@ -140,13 +140,20 @@ ContextTest >> testActivateReturnValue [
 ContextTest >> testActiveHome [
 	| block |
 	"Active BlockContext Home And ActiveHome"
-	block := [ thisContext home == thisContext activeHome].
+	block := [ self. "to make it non-clean" thisContext home == thisContext activeHome].
+	self assert: block class equals: FullBlockClosure.
 	self assert: block value.
 	
 	"for Method Context"
 	self
 		assert: aMethodContext activeHome identicalTo: aMethodContext;
-		assert: aMethodContext activeHome identicalTo: aMethodContext home
+		assert: aMethodContext activeHome identicalTo: aMethodContext home.
+	
+	"non-active block context"
+	nonActiveBlockContext := self class returnNonActiveContextOfBlock.
+	self assert: (nonActiveBlockContext activeHome) isNil.
+		
+	
 ]
 
 { #category : #private }
@@ -251,12 +258,6 @@ ContextTest >> testNoStepIntoQuickMethod [
 	has not been set."
 	newContext := aMethodContext step.
 	self assert: newContext identicalTo: aMethodContext
-]
-
-{ #category : #tests }
-ContextTest >> testNonActiveBlockContextActiveHome [
-	nonActiveBlockContext := self class returnNonActiveContextOfBlock.
-	self assert: (nonActiveBlockContext activeHome) isNil.
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/ContextTest.class.st
+++ b/src/Kernel-Tests/ContextTest.class.st
@@ -137,15 +137,30 @@ ContextTest >> testActivateReturnValue [
 ]
 
 { #category : #tests }
-ContextTest >> testActiveBlockContextHomeAndActiveHome [
-	[ self assert: thisContext home identicalTo:  thisContext activeHome.] value
-]
-
-{ #category : #private }
-ContextTest >> testActiveHomeMethodContext [
+ContextTest >> testActiveHome [
+	| block |
+	"Active BlockContext Home And ActiveHome"
+	block := [ thisContext home == thisContext activeHome].
+	self assert: block value.
+	
+	"for Method Context"
 	self
 		assert: aMethodContext activeHome identicalTo: aMethodContext;
 		assert: aMethodContext activeHome identicalTo: aMethodContext home
+]
+
+{ #category : #private }
+ContextTest >> testActiveHomeClean [
+	<compilerOptions: #(+ optionCleanBlockClosure)>
+	| block |
+	block := [thisContext activeHome method].
+	self assert: block class equals: CleanBlockClosure.
+	
+	self assert: block value equals: block homeMethod.
+	
+	block := [thisContext activeHome].
+	self assert: block class equals: CleanBlockClosure.
+	self assert: block value equals: thisContext
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/ContextTest.class.st
+++ b/src/Kernel-Tests/ContextTest.class.st
@@ -156,20 +156,6 @@ ContextTest >> testActiveHome [
 	
 ]
 
-{ #category : #private }
-ContextTest >> testActiveHomeClean [
-	<compilerOptions: #(+ optionCleanBlockClosure)>
-	| block |
-	block := [thisContext activeHome method].
-	self assert: block class equals: CleanBlockClosure.
-	
-	self assert: block value equals: block homeMethod.
-	
-	block := [thisContext activeHome].
-	self assert: block class equals: CleanBlockClosure.
-	self assert: block value equals: thisContext
-]
-
 { #category : #tests }
 ContextTest >> testAstScope [
 

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -266,13 +266,14 @@ Context >> activateReturn: aContext value: value [
 Context >> activeHome [
 	"If executing closure, search senders for the activation of the original
 	 (outermost) method that (indirectly) created my closure (the closureHome).
-	 If the closureHome is not found on the sender chain answer nil."
+	 If the closureHome is not found on the sender chain answer nil.
+	This method does not use #home and thus works for any block without and outerContext"
 
-	| methodReturnContext |
+	| homeMethod |
 	self isBlockContext ifFalse: [^self].
 	self sender ifNil: [^nil].
-	methodReturnContext := self methodReturnContext.
-	^self sender findContextSuchThat: [:ctxt | ctxt = methodReturnContext]
+	homeMethod := self homeMethod.
+	^self sender findMethodContextSuchThat: [:ctxt | ctxt method == homeMethod]
 ]
 
 { #category : #accessing }

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -271,9 +271,8 @@ Context >> activeHome [
 
 	| homeMethod |
 	self isBlockContext ifFalse: [^self].
-	self sender ifNil: [^nil].
 	homeMethod := self homeMethod.
-	^self sender findMethodContextSuchThat: [:ctxt | ctxt method == homeMethod]
+	^self findMethodContextSuchThat: [:ctxt | ctxt method == homeMethod]
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Tests/OCClosureTest.class.st
+++ b/src/OpalCompiler-Tests/OCClosureTest.class.st
@@ -28,6 +28,20 @@ OCClosureTest >> setUp [
 	collection := OrderedCollection new
 ]
 
+{ #category : #'test - clean' }
+OCClosureTest >> testActiveHomeClean [
+	<compilerOptions: #(+ optionCleanBlockClosure)>
+	| block |
+	block := [thisContext activeHome method].
+	self assert: block class equals: CleanBlockClosure.
+	
+	self assert: block value equals: block homeMethod.
+	
+	block := [thisContext activeHome].
+	self assert: block class equals: CleanBlockClosure.
+	self assert: block value equals: thisContext
+]
+
 { #category : #tests }
 OCClosureTest >> testBlockArgument [
 	| block block1 block2 |


### PR DESCRIPTION
- implement #activeHome to not need outerContext
- add test
- refactor existing test

fixes #11965

#activeHome returns the #home if it is currently on the stack, the debugger uses that to check if a “save and proceed”
is possible when editing code in a Block. It is implemented to search up the sender chain until it finds the #home:

```Smalltalk
activeHome
	| methodReturnContext |
	self isBlockContext ifFalse: [^self].
	self sender ifNil: [^nil].
	methodReturnContext := self methodReturnContext.
	^self sender findContextSuchThat: [:ctxt | ctxt = methodReturnContext]
```

But it can be rewritten to do the same, but checking for the #homeMethod:

```Smalltalk
activeHome
	| homeMethod |
	self isBlockContext ifFalse: [^self].
	homeMethod := self homeMethod.
	^self findMethodContextSuchThat: [:ctxt | ctxt method == homeMethod]
```

With #homeMethod being implemented to delegate to the bock:

```Smalltalk
Context>>homeMethod
	"Answer the method in which the receiver was defined, i.e. the context from which an ^-return ] should return from. Note: implemented to not need #home"

	^ closureOrNil ifNil: [ self method ] ifNotNil: [ :closure | closure homeMethod ]
```

Where, if no #outerContext is available, it asks the CompiledBlock:

```Smalltalk
BlockClosure>>homeMethod
	"return the home method. If no #home is available due to no outerContext, use the compiledBlock"
	^ (self home
		   ifNotNil: [ :homeContext | homeContext ]
		   ifNil: [ self compiledBlock ]) method
```

Which uses the static  #outerCode chain (CompiledBlocks encode have a back-pointer to the enclosing block or method),
with #method following #outerCode until it reaches a CompiledMethod:

```Smalltalk
CompiledBlock>>method
	"answer the compiled method that I am installed in, or nil if none.”
	^self outerCode method
```
