### PR TITLE
12066-CI-test-failing-on-CI-SystemDependenciesTesttestExternalBasicToolsDependencies

### DIFF
--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -54,10 +54,13 @@ SystemDependenciesTest >> externalDependendiesOf: packagesCollection [
 
 { #category : #'known dependencies' }
 SystemDependenciesTest >> knownBasicToolsDependencies [
- 
-	"ideally this list should be empty"	
-	^ #('AST-Core-Tests' 'Athens-Cairo' 'Athens-Core' 
-	#'Athens-Morphic' #'Refactoring-Critics' #'Reflectivity' #'Reflectivity-Tools' #Shout 'ParametrizedTests' 'HeuristicCompletion-Model' #VariablesLibrary #'Spec2-CommonWidgets')
+
+	"ideally this list should be empty"
+
+	^ #( 'AST-Core-Tests' 'Athens-Cairo' 'Athens-Core' #'Athens-Morphic'
+	     #'Refactoring-Critics' #'Refactoring2-Transformations'
+	     #Reflectivity #'Reflectivity-Tools' #Shout 'ParametrizedTests'
+	     'HeuristicCompletion-Model' #VariablesLibrary #'Spec2-CommonWidgets' )
 ]
 
 { #category : #'known dependencies' }


### PR DESCRIPTION
fixes #12066