### PR TITLE
Add missing keyDown: message in FTSearchFunction

### DIFF
--- a/src/Morphic-Widgets-FastTable/FTSearchFunction.class.st
+++ b/src/Morphic-Widgets-FastTable/FTSearchFunction.class.st
@@ -23,6 +23,11 @@ FTSearchFunction >> ghostText [
 ]
 
 { #category : #'event handling' }
+FTSearchFunction >> keyDown: anEvent [
+	^ self keyStroke: anEvent
+]
+
+{ #category : #'event handling' }
 FTSearchFunction >> keyStroke: anEvent [
 	(anEvent keyCharacter isAlphaNumeric not)
 		ifTrue: [ ^ false ].


### PR DESCRIPTION
Fixes #11724

From what I see, this was also missing in Pharo 10 as well, but I'm not quite sure why it works there.