### PR TITLE
Fix class editor not refreshing when switching between class/instance sides

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyClassEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassEditorToolMorph.class.st
@@ -86,7 +86,10 @@ ClyClassEditorToolMorph >> isSimilarTo: anotherBrowserTool [
 ClyClassEditorToolMorph >> isValidInContext: aClyFullBrowserContext [
 	self context class = aClyFullBrowserContext class 
 		ifFalse: [ ^ false ].
-		
+
+	self context metaLevelScope = aClyFullBrowserContext metaLevelScope
+		ifFalse: [ ^ false ].
+
 	^ editingClass = aClyFullBrowserContext lastSelectedClass
 		or: [  editingClass = aClyFullBrowserContext lastSelectedClass instanceSide ]
 ]


### PR DESCRIPTION
Fixes #12088 

This checks whether the metalevel also matches within the validity computation. If the metalevel does not match, the tool validity is signalled as false. 