### PR TITLE
RubTextEditor/TextEditor: Make ctrl+backspace delete the previous word

### DIFF
--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -255,7 +255,7 @@ RubTextEditor >> backWord: aKeyboardEvent [
 RubTextEditor >> backspace: aKeyboardEvent [
 	| result startIndex |
 	self closeTypeIn.
-	result := aKeyboardEvent shiftPressed
+	result := aKeyboardEvent controlKeyPressed
 		ifTrue: [ self backWord: aKeyboardEvent keyCharacter ]
 		ifFalse: [ 
 			self hasSelection

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -1175,8 +1175,8 @@ RubTextEditor >> forwardDelete: aKeyboardEvent [
 			| idx1 idx2 |
 			idx1 := self startIndex min: self stopIndex.
 			idx2 := self stopIndex max: self startIndex.
-			aKeyboardEvent shiftPressed
-				ifTrue: [ idx2 := self nextWord: idx1 ]
+			aKeyboardEvent controlKeyPressed
+				ifTrue: [ idx2 := self nextWord: idx1 + 1 ]
 				ifFalse: [ idx2 := idx2 + 1 ].
 			self selectInvisiblyFrom: idx1 to: idx2 - 1 ].
 	self addDeleteSelectionUndoRecord.

--- a/src/Text-Edition/TextEditor.class.st
+++ b/src/Text-Edition/TextEditor.class.st
@@ -1763,7 +1763,7 @@ TextEditor >> forwardDelete: aKeyboardEvent [
 		ifFalse: [	| idx1 idx2 |
 				idx1 := self startIndex min: self stopIndex.
 				idx2 := self stopIndex max: self startIndex.
-				aKeyboardEvent shiftPressed
+				aKeyboardEvent controlKeyPressed
 					ifTrue: [idx2 := (self nextWord: idx1)]
 					ifFalse: [idx2 := idx2 + 1].
 				self selectInvisiblyFrom: idx1 to: idx2 - 1].

--- a/src/Text-Edition/TextEditor.class.st
+++ b/src/Text-Edition/TextEditor.class.st
@@ -713,7 +713,7 @@ TextEditor >> backspace: aKeyboardEvent [
 	"Backspace over the last character."
 	| result startIndex |
 	self closeTypeIn.
-	result := aKeyboardEvent shiftPressed 
+	result := aKeyboardEvent controlKeyPressed 
 		ifTrue: [self backWord: aKeyboardEvent keyCharacter]
 		ifFalse: [self hasSelection
 			ifTrue: [self replaceSelectionWith: self nullText]

--- a/src/Tool-Base/PharoShortcuts.class.st
+++ b/src/Tool-Base/PharoShortcuts.class.st
@@ -174,7 +174,7 @@ PharoShortcuts >> delShortcut [
 { #category : #'keymaps - editor edit' }
 PharoShortcuts >> delWordShortcut [
 
-	^ OSPlatform current isMacOS
+	^ (OSPlatform current isMacOS)
 		ifTrue: [ Character $d ctrl asShortcut ]
 		ifFalse: [ Character delete ctrl asShortcut ]
 ]

--- a/src/Tool-Base/PharoShortcuts.class.st
+++ b/src/Tool-Base/PharoShortcuts.class.st
@@ -175,7 +175,7 @@ PharoShortcuts >> delShortcut [
 PharoShortcuts >> delWordShortcut [
 
 	^ (OSPlatform current isMacOS)
-		ifTrue: [ Character $d ctrl asShortcut ]
+		ifTrue: [ $d ctrl asShortcut ]
 		ifFalse: [ Character delete ctrl asShortcut ]
 ]
 

--- a/src/Tool-Base/PharoShortcuts.class.st
+++ b/src/Tool-Base/PharoShortcuts.class.st
@@ -249,7 +249,8 @@ PharoShortcuts >> forwardLineShortcut [
 
 { #category : #'keymaps - editor navigation' }
 PharoShortcuts >> forwardWordShortcut [
-	^ Character arrowRight ctrl
+	"Equivalent to: ctrl+right on Windows/Linux, option/alt+right on OSX"
+	^ Character arrowRight meta
 ]
 
 { #category : #'keymaps - editor style' }

--- a/src/Tool-Base/PharoShortcuts.class.st
+++ b/src/Tool-Base/PharoShortcuts.class.st
@@ -60,6 +60,7 @@ PharoShortcuts >> backwardWordDeleteShortcut [
 
 { #category : #'keymaps - editor navigation' }
 PharoShortcuts >> backwardWordShortcut [
+	"Equivalent to: ctrl+left on Windows/Linux, option/alt+left on OSX"
 	^ Character arrowLeft meta
 ]
 

--- a/src/Tool-Base/PharoShortcuts.class.st
+++ b/src/Tool-Base/PharoShortcuts.class.st
@@ -174,7 +174,9 @@ PharoShortcuts >> delShortcut [
 { #category : #'keymaps - editor edit' }
 PharoShortcuts >> delWordShortcut [
 
-	^ Character delete ctrl asShortcut
+	^ OSPlatform current isMacOS
+		ifTrue: [ Character $d ctrl asShortcut ]
+		ifFalse: [ Character delete ctrl asShortcut ]
 ]
 
 { #category : #'keymaps - code' }

--- a/src/Tool-Base/PharoShortcuts.class.st
+++ b/src/Tool-Base/PharoShortcuts.class.st
@@ -55,7 +55,7 @@ PharoShortcuts >> backwardLineShortcut [
 { #category : #'keymaps - editor edit' }
 PharoShortcuts >> backwardWordDeleteShortcut [
 
-	^ Character backspace shift
+	^ Character backspace ctrl
 ]
 
 { #category : #'keymaps - editor navigation' }
@@ -174,7 +174,7 @@ PharoShortcuts >> delShortcut [
 { #category : #'keymaps - editor edit' }
 PharoShortcuts >> delWordShortcut [
 
-	^ Character delete shift asShortcut
+	^ Character delete ctrl asShortcut
 ]
 
 { #category : #'keymaps - code' }
@@ -249,7 +249,7 @@ PharoShortcuts >> forwardLineShortcut [
 
 { #category : #'keymaps - editor navigation' }
 PharoShortcuts >> forwardWordShortcut [
-	^ Character arrowRight meta
+	^ Character arrowRight ctrl
 ]
 
 { #category : #'keymaps - editor style' }
@@ -462,7 +462,7 @@ PharoShortcuts >> selectBackwardLineShortcut [
 
 { #category : #'keymaps - editor selection' }
 PharoShortcuts >> selectBackwardWordShortcut [
-	^ Character arrowLeft meta shift
+	^ Character arrowLeft shift ctrl
 ]
 
 { #category : #'keymaps - editor selection' }
@@ -479,7 +479,7 @@ PharoShortcuts >> selectForwardLineShortcut [
 
 { #category : #'keymaps - editor selection' }
 PharoShortcuts >> selectForwardWordShortcut [
-	^ Character arrowRight shift meta
+	^ Character arrowRight shift ctrl
 ]
 
 { #category : #'keymaps - editor selection' }

--- a/src/Tool-Base/PharoShortcuts.class.st
+++ b/src/Tool-Base/PharoShortcuts.class.st
@@ -481,7 +481,8 @@ PharoShortcuts >> selectForwardLineShortcut [
 
 { #category : #'keymaps - editor selection' }
 PharoShortcuts >> selectForwardWordShortcut [
-	^ Character arrowRight shift ctrl
+	"Equivalent to: ctrl+shift+right on Windows/Linux, option/alt+shift+right on OSX"
+	^ Character arrowRight shift meta
 ]
 
 { #category : #'keymaps - editor selection' }

--- a/src/Tool-Base/PharoShortcuts.class.st
+++ b/src/Tool-Base/PharoShortcuts.class.st
@@ -54,8 +54,8 @@ PharoShortcuts >> backwardLineShortcut [
 
 { #category : #'keymaps - editor edit' }
 PharoShortcuts >> backwardWordDeleteShortcut [
-
-	^ Character backspace ctrl
+	"Equivalent to: ctrl+backspace on Windows/Linux, option/alt+backspace on OSX"
+	^ Character backspace meta
 ]
 
 { #category : #'keymaps - editor navigation' }

--- a/src/Tool-Base/PharoShortcuts.class.st
+++ b/src/Tool-Base/PharoShortcuts.class.st
@@ -463,7 +463,8 @@ PharoShortcuts >> selectBackwardLineShortcut [
 
 { #category : #'keymaps - editor selection' }
 PharoShortcuts >> selectBackwardWordShortcut [
-	^ Character arrowLeft shift ctrl
+	"Equivalent to: ctrl+shift+left on Windows/Linux, option/alt+shift+left on OSX"
+	^ Character arrowLeft shift meta
 ]
 
 { #category : #'keymaps - editor selection' }


### PR DESCRIPTION
Fixes #2914 

* Ctrl+Backspace now deletes the previous word
* Ctrl+Delete now deletes the next word (note that this never worked, even with the previous key-binding shift+delete due to an off-by-one error)
* Updates PharoShortcuts accordingly (I am aware that they are currently unused - this is noted by #11191, but it is important to keep these updated as we may want to use them at some point)