### PR TITLE
12034-Context-we-have-both-home-and-methodReturnContext 

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -72,7 +72,7 @@ Context >> methodReturnConstant: value [
 	"Simulate the action of a 'return constant' bytecode whose value is the
 	 argument, value. This corresponds to a source expression like '^0'."
 
-	^self return: value from: self methodReturnContext
+	^self return: value from: self home
 ]
 
 { #category : #'*Debugging-Core' }

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -233,11 +233,12 @@ Context class >> tryNamedPrimitiveTemplateMethod [
 ]
 
 { #category : #private }
-Context >> aboutToReturn: result through: firstUnwindContext [ 
+Context >> aboutToReturn: result through: firstUnwindContext [
+
 	"Called from VM when an unwindBlock is found between self and its home.
 	 Return to home's sender, executing unwind blocks on the way."
 
-	self methodReturnContext return: result through: firstUnwindContext
+	self home return: result through: firstUnwindContext
 ]
 
 { #category : #controlling }
@@ -1091,7 +1092,9 @@ Context >> methodNode [
 
 { #category : #accessing }
 Context >> methodReturnContext [
-
+	self 
+		deprecated: 'Use #home instead' 
+		transformWith: '`@receiver methodReturnContext' -> '`@receiver home'.
 	^ self home.
 ]
 
@@ -1100,15 +1103,16 @@ Context >> methodReturnReceiver [
 	"Simulate the action of a 'return receiver' bytecode. This corresponds to
 	 the source expression '^self'."
 
-	^self return: self receiver from: self methodReturnContext
+	^self return: self receiver from: self home
 ]
 
 { #category : #'instruction decoding' }
 Context >> methodReturnTop [
+
 	"Simulate the action of a 'return top of stack' bytecode. This corresponds
 	 to source expressions like '^something'."
 
-	^self return: self pop from: self methodReturnContext
+	^ self return: self pop from: self home
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
- make sure to use #home everywhere
- deprecate #methodReturnContext