### PR TITLE
11634-Unimplemented-message-send-in-FT2FaceemboldenOutline

### DIFF
--- a/src/FreeType/FT2Face.class.st
+++ b/src/FreeType/FT2Face.class.st
@@ -799,3 +799,8 @@ FT2Face >> underlineThickness [
 FT2Face >> unitsPerEm [
 	^unitsPerEm
 ]
+
+{ #category : #validation }
+FT2Face >> validate [
+	"Do nothing, overridden in subclass FreeTypeFace>>#validate"
+]


### PR DESCRIPTION
add back the emty #validate method as there are senders *and* it is overriden in a subclass