### PR TITLE
Slots: For experiments, add Setting for unrestricted definitions

### DIFF
--- a/src/ClassParser-Tests/CDFluidClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDFluidClassParserTest.class.st
@@ -378,6 +378,27 @@ CDFluidClassParserTest >> testTraitSequence [
 	self assert: def traitDefinition sequence first name equals: #MyTrait.
 ]
 
+{ #category : #'tests - (r) slots' }
+CDFluidClassParserTest >> testUnrestrictedSlots [
+
+	| parser defString def slot |
+	parser := self classDefinitionParserClass new.
+	
+	"check that we can experiment with if we enable the setting"
+	self classDefinitionParserClass  unrestrictedVariableDefinitions: true.
+	
+	defString := 'Object << #MyObject
+		slots: { Slot named: #slotName  };
+		package: #MyPackage'.
+	def := parser parse: defString.
+	slot := def slots first.
+	self assert: slot name equals: #slotName. 
+	self assert: slot variableClassName equals: #Slot.
+	self classDefinitionParserClass  unrestrictedVariableDefinitions: false.
+	"if it is the default false, we do no allow it"
+	self should: [ 	def := parser parse: defString ] raise: Error
+]
+
 { #category : #'tests - (r) kinds' }
 CDFluidClassParserTest >> testVariableByteSubclass [
 

--- a/src/ClassParser/CDFluidClassDefinitionParser.class.st
+++ b/src/ClassParser/CDFluidClassDefinitionParser.class.st
@@ -39,8 +39,37 @@ Class {
 		'classNameNode',
 		'superclassNode'
 	],
+	#classInstVars : [
+		'unrestrictedVariableDefinitions'
+	],
 	#category : #'ClassParser-Parser'
 }
+
+{ #category : #settings }
+CDFluidClassDefinitionParser class >> settingsOn: aBuilder [
+	
+	<systemsettings>
+	(aBuilder setting: #unrestrictedVariableDefinitions)
+		parent: #codeBrowsing;
+		default: false;
+		label: 'Unrestricted Slots/Class Variable Definitions';
+		description: 'EXPERIMENTAL: If true, the system will allow any expression as 
+a Variable Definition (for Slots and Classvariables) that evaluates to a valid instance. 
+		
+WARNING1: you have to load all the Variable implementation classes *before* any users. 
+WARNING2: the definition will be loaded by *unchecked* evaluation';
+		target: self.
+]
+
+{ #category : #settings }
+CDFluidClassDefinitionParser class >> unrestrictedVariableDefinitions [
+	^ unrestrictedVariableDefinitions ifNil: [ false ]
+]
+
+{ #category : #settings }
+CDFluidClassDefinitionParser class >> unrestrictedVariableDefinitions: aBoolean [
+	unrestrictedVariableDefinitions := aBoolean
+]
 
 { #category : #parsing }
 CDFluidClassDefinitionParser >> handleClassAndSuperclassOf: aNode [
@@ -171,6 +200,11 @@ CDFluidClassDefinitionParser >> handleSharedVariableNodesFromArrayNode: aRBArray
 { #category : #'parsing - variables' }
 CDFluidClassDefinitionParser >> handleSlotNode: slotDefNode [
 	 | slot |
+	
+	"Setting, default off, to allow experiments"
+	self class unrestrictedVariableDefinitions ifTrue: [ 
+		^ classDefinition addSlot: (self handleUnrestrictedSlotDefinition: slotDefNode) ].
+	
 	"when a slot is just #inst"
 	slotDefNode isLiteralNode ifTrue: [ slot := self handleSlotNodeSimple: slotDefNode].
 	"#inst => InstanceVariableSlot default: 5; default2: 4"
@@ -262,6 +296,26 @@ CDFluidClassDefinitionParser >> handleSuperclassNode: aSuperclassNode [
 CDFluidClassDefinitionParser >> handleTag: aNode [
 
 	classDefinition tag: (CDClassTagNode new name: aNode value)
+]
+
+{ #category : #'parsing - variables' }
+CDFluidClassDefinitionParser >> handleUnrestrictedSlotDefinition: slotDefNode [
+
+	"If the preference is enabled, allow unrestricted slot definitions. 
+	TAKE CARE: There is no way to know the name nor the class witout executing the code of the defintion.
+	This means that a) code will be evaluated which could have side effects and b) you need to load the Slot Class
+	before any users, as an UndefinedSlot can not be created, as we do not know the name"
+
+	| slotInstance |
+	"create the instance of the slot for real, we use this to fill out the name and variableClassName"
+	slotInstance := slotDefNode evaluate.
+
+	^ CDSlotNode new
+		  node: slotDefNode;
+		  name: slotInstance name;
+		  variableClassName: slotInstance class name;
+		  start: slotDefNode start;
+		  stop: slotDefNode stop
 ]
 
 { #category : #parsing }


### PR DESCRIPTION
This PR adds a setting #unrestrictedVariableDefinitions (default is off). Fixes #4629

The idea is that this allows easy experimentation, anything used in Pharo itself can not enable this option, but instead we would enhance the ClassParser to parse the kind of defintions we want to support out of the box.

Here is the description text of the Setting:

EXPERIMENTAL: If true, the system will allow any expression as  a Variable Definition (for Slots and Classvariables) that evaluates to a valid instance. 
		
WARNING1: you have to load all the Variable implementation classes *before* any users. 
WARNING2: the definition will be loaded by *unchecked* evaluation