### PR TITLE
Implement dummy ClySystemBrowserContext>>#metaLevelScope

### DIFF
--- a/src/Calypso-SystemTools-Core/ClySystemBrowserContext.class.st
+++ b/src/Calypso-SystemTools-Core/ClySystemBrowserContext.class.st
@@ -157,6 +157,12 @@ ClySystemBrowserContext >> lastSelectedSourceNode [
 	^self lastSelectedMethod astForStylingInCalypso
 ]
 
+{ #category : #accessing }
+ClySystemBrowserContext >> metaLevelScope [
+
+	^ nil
+]
+
 { #category : #'refactoring support' }
 ClySystemBrowserContext >> refactoringScopes [
 	"It returns default browser scope as first one which makes it default for users"


### PR DESCRIPTION
Fixes #12108

This ensures all browsers have a default no-op implementation