### PR TITLE
Cleanup-deadcode-workingCopySearchAdd

### DIFF
--- a/src/MonticelloGUI/MCWorkingCopyBrowser.class.st
+++ b/src/MonticelloGUI/MCWorkingCopyBrowser.class.st
@@ -934,17 +934,6 @@ MCWorkingCopyBrowser >> workingCopySearchAccept: string [
 ]
 
 { #category : #'morphic ui' }
-MCWorkingCopyBrowser >> workingCopySearchAdd: aString [ 
-	self workingCopySearchList: (self workingCopySearchList
-			remove: aString
-			ifAbsent: [];
-			 yourself).
-	self workingCopySearchList size = self workingCopySearchMaxSize
-		ifTrue: [self workingCopySearchList removeLast].
-	self workingCopySearchList addFirst: aString 
-]
-
-{ #category : #'morphic ui' }
 MCWorkingCopyBrowser >> workingCopySearchField [
 	^ SearchMorph new
 		model: self;

--- a/src/Morphic-Core/HandMorph.class.st
+++ b/src/Morphic-Core/HandMorph.class.st
@@ -868,21 +868,16 @@ HandMorph >> processEvents [
 	"Process user input events from the local input devices."
 
 	| evt |
-
 	[ (evt := self pendingEventQueue nextOrNil) notNil ] whileTrue: [ 
 		evt == #invalid ifTrue: [ ^ self ].
 		evt ifNotNil: [ "Finally, handle it"
 			self handleEvent: evt.
 			"For better user feedback, return immediately after a mouse event has been processed."
-			( evt isMouse and: [ evt isMouseWheel not ] )
-				ifTrue: [ ^ self ]
-		]
-	].
-	
+			(evt isMouse and: [ evt isMouseWheel not ]) ifTrue: [ ^ self ] ] ].
+
 	"note: if we come here we didn't have any mouse events"
-	mouseClickState notNil ifTrue: [ 
-		"No mouse events during this cycle. Make sure click states time out accordingly"
-		mouseClickState handleEvent: lastMouseEvent asMouseMove from: self ].
+	mouseClickState ifNotNil: [ "No mouse events during this cycle. Make sure click states time out accordingly" 
+		mouseClickState handleEvent: lastMouseEvent asMouseMove from: self ]
 ]
 
 { #category : #'private - events' }

--- a/src/System-Changes/ChangeSet.class.st
+++ b/src/System-Changes/ChangeSet.class.st
@@ -635,7 +635,7 @@ ChangeSet >> changeRecorderFor: class [
 	cname := class isString
 		ifTrue: [ class ]
 		ifFalse: [ class isBehavior ifTrue: [class name] ifFalse: [ nil printString] ].
-	^ changeRecords at: cname ifAbsent: [ ^ changeRecords at: cname put: (ClassChangeRecord new initFor: cname) ]
+	^ changeRecords at: cname ifAbsentPut: [ ClassChangeRecord new initFor: cname ]
 ]
 
 { #category : #'class changes' }

--- a/src/System-Object Events/Object.extension.st
+++ b/src/System-Object Events/Object.extension.st
@@ -4,12 +4,7 @@ Extension { #name : #Object }
 Object >> actionForEvent: anEventSelector [
     "Answer the action to be evaluated when <anEventSelector> has been triggered."
 
-	| actions |
-	actions := self actionMap
-		at: anEventSelector asSymbol
-		ifAbsent: [^nil].
- 
-	^ actions asMinimalRepresentation
+	^ self actionForEvent: anEventSelector ifAbsent: [nil]
 ]
 
 { #category : #'*System-Object Events' }
@@ -21,8 +16,9 @@ ifAbsent: anExceptionBlock [
 	actions := self actionMap
 		at: anEventSelector asSymbol
 		ifAbsent: [nil].
-	actions ifNil: [^anExceptionBlock value].
-	^ actions asMinimalRepresentation
+	^actions 
+		ifNil: [anExceptionBlock value]
+		ifNotNil: [:act | act asMinimalRepresentation ]
 ]
 
 { #category : #'*System-Object Events' }


### PR DESCRIPTION
Some trivial cleanups:

- workingCopySearchAdd: is dead code (no senders, sends a non-existing selector)
- ifNotNil: transfrom in #processEvents
- use #ifAbsentPut: in changeRecorderFor:
- simplify #actionForEvent: