### PR TITLE
Calypso: self in <script:> is the selected class

### DIFF
--- a/src/Calypso-SystemPlugins-ClassScripts-Queries/ClyClassScript.class.st
+++ b/src/Calypso-SystemPlugins-ClassScripts-Queries/ClyClassScript.class.st
@@ -94,7 +94,7 @@ ClyClassScript >> iconName [
 
 { #category : #accessing }
 ClyClassScript >> implementorClass [
-	^ implementorMethod origin
+	^ implementorMethod methodClass
 ]
 
 { #category : #accessing }
@@ -103,8 +103,8 @@ ClyClassScript >> implementorMethod [
 ]
 
 { #category : #accessing }
-ClyClassScript >> implementorMethod: anObject [
-	implementorMethod := anObject
+ClyClassScript >> implementorMethod: aCompiledMethod [
+	implementorMethod := aCompiledMethod
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
To fix #12107

Also renamed an argument anObject->aCompiledMethod, that's unrelated but so handy to do it...