### PR TITLE
9932-RegistryThreshold-in-Socket-seems-to-be-unused

### DIFF
--- a/src/Network-Kernel/Socket.class.st
+++ b/src/Network-Kernel/Socket.class.st
@@ -18,7 +18,6 @@ Class {
 		'InvalidSocket',
 		'OtherEndClosed',
 		'Registry',
-		'RegistryThreshold',
 		'TCPSocketType',
 		'ThisEndClosed',
 		'UDPSocketType',
@@ -69,8 +68,6 @@ Socket class >> initialize [
 	Connected := 2.
 	OtherEndClosed := 3.
 	ThisEndClosed := 4.
-
-	RegistryThreshold := 100. "# of sockets"
 ]
 
 { #category : #'network initialization' }
@@ -306,18 +303,6 @@ Socket class >> register: anObject [
 { #category : #registry }
 Socket class >> registry [
 	^Registry ifNil: [Registry := WeakRegistry new]
-]
-
-{ #category : #registry }
-Socket class >> registryThreshold [
-	"Return the registry threshold above which socket creation may fail due to too many already open sockets. If the threshold is reached, a full GC will be issued if the creation of a socket fails."
-	^RegistryThreshold
-]
-
-{ #category : #registry }
-Socket class >> registryThreshold: aNumber [
-	"Return the registry threshold above which socket creation may fail due to too many already open sockets. If the threshold is reached, a full GC will be issued if the creation of a socket fails."
-	RegistryThreshold := aNumber
 ]
 
 { #category : #tests }


### PR DESCRIPTION
remove unused registryThreshold class var and accessors. fixes #9932