### PR TITLE
Move SearchFacade to MonticelloGUI

### DIFF
--- a/src/MonticelloGUI/MCSearchFacade.class.st
+++ b/src/MonticelloGUI/MCSearchFacade.class.st
@@ -2,25 +2,25 @@
 SearchFacade is a facade for creating searching dialog window
 "
 Class {
-	#name : #SearchFacade,
+	#name : #MCSearchFacade,
 	#superclass : #Object,
-	#category : #'Tool-Base-Utilities'
+	#category : #'MonticelloGUI-Tools'
 }
 
 { #category : #'message search' }
-SearchFacade class >> allMessageSearchFor: aClass [
+MCSearchFacade class >> allMessageSearchFor: aClass [
 
 	^ self messageSearchIn: aClass allMethods
 ]
 
 { #category : #'class search' }
-SearchFacade class >> classSearch [
+MCSearchFacade class >> classSearch [
 
 	^ self classSearchInEnvironment: self environment
 ]
 
 { #category : #'class search' }
-SearchFacade class >> classSearchIn: classes [
+MCSearchFacade class >> classSearchIn: classes [
 	^ ListDialogWindow new
 		getList: [ :r | classes select: [ :e | r search: e name ] ];
 		displayBlock: [ :e | e name ];
@@ -29,31 +29,31 @@ SearchFacade class >> classSearchIn: classes [
 ]
 
 { #category : #'class search' }
-SearchFacade class >> classSearchInEnvironment: anEnvironment [
+MCSearchFacade class >> classSearchInEnvironment: anEnvironment [
 	| classes |
 	classes :=  anEnvironment classesAndTraits sorted: [ :a :b| a name <= b name ].
 	^ self classSearchIn: classes.
 ]
 
 { #category : #'class search' }
-SearchFacade class >> hierarchySearchFor: aClass [
+MCSearchFacade class >> hierarchySearchFor: aClass [
 	| classes |
 	classes := aClass allSuperclasses reverse, (aClass allSubclasses sorted: [ :a :b| a name <= b name ]).
 	^ self classSearchIn: classes
 ]
 
 { #category : #'package search' }
-SearchFacade class >> mcPackageSearch [
+MCSearchFacade class >> mcPackageSearch [
 	^ self mcPackageSearchRejectAll: [ :aPackage | false ] withInitialFilter: nil
 ]
 
 { #category : #'package search' }
-SearchFacade class >> mcPackageSearchRejectAll: aRejectBlock [
+MCSearchFacade class >> mcPackageSearchRejectAll: aRejectBlock [
 	^ self mcPackageSearchRejectAll: aRejectBlock withInitialFilter: nil
 ]
 
 { #category : #'package search' }
-SearchFacade class >> mcPackageSearchRejectAll: aRejectBlock withInitialFilter: filter [
+MCSearchFacade class >> mcPackageSearchRejectAll: aRejectBlock withInitialFilter: filter [
 	| workingCopies |
 	
 	workingCopies := MCWorkingCopy allManagers asSortedCollection: [ :a :b | a packageName <= b packageName].
@@ -69,13 +69,13 @@ SearchFacade class >> mcPackageSearchRejectAll: aRejectBlock withInitialFilter: 
 ]
 
 { #category : #'message search' }
-SearchFacade class >> messageSearchFor: aClass [
+MCSearchFacade class >> messageSearchFor: aClass [
 
 	^ self messageSearchIn: aClass methods
 ]
 
 { #category : #'message search' }
-SearchFacade class >> messageSearchIn: aCollection [
+MCSearchFacade class >> messageSearchIn: aCollection [
 	| rawList |
 	rawList := aCollection sorted: [ :a :b | a selector <= b selector ].
 	^ ListDialogWindow new
@@ -86,13 +86,13 @@ SearchFacade class >> messageSearchIn: aCollection [
 ]
 
 { #category : #'package search' }
-SearchFacade class >> packageSearch [
+MCSearchFacade class >> packageSearch [
 				
 	^ self packageSearchIn: self environment
 ]
 
 { #category : #'package search' }
-SearchFacade class >> packageSearchIn: anEnvironment [
+MCSearchFacade class >> packageSearchIn: anEnvironment [
 	| rawList |
 	rawList := anEnvironment organization categories sort.
 	^ ListDialogWindow new
@@ -103,7 +103,7 @@ SearchFacade class >> packageSearchIn: anEnvironment [
 ]
 
 { #category : #'protocol search' }
-SearchFacade class >> protocolSearchIn: aCollection [
+MCSearchFacade class >> protocolSearchIn: aCollection [
 	^ ListDialogWindow new
 		getList: [ :r | aCollection sorted select: [ :e | r search: e ] ];
 		displayBlock: [ :e | e ];
@@ -112,13 +112,13 @@ SearchFacade class >> protocolSearchIn: aCollection [
 ]
 
 { #category : #'rpackage search' }
-SearchFacade class >> rPackageSearch [
+MCSearchFacade class >> rPackageSearch [
 				
 	^ self rPackageSearchIn: RPackageOrganizer default
 ]
 
 { #category : #'rpackage search' }
-SearchFacade class >> rPackageSearchIn: anOrganizer [
+MCSearchFacade class >> rPackageSearchIn: anOrganizer [
 	| rawList |
 	rawList := anOrganizer packages sorted: [ :a :b | a name <= b name ].
 	^ ListDialogWindow new
@@ -130,14 +130,14 @@ SearchFacade class >> rPackageSearchIn: anOrganizer [
 ]
 
 { #category : #'class search' }
-SearchFacade class >> subclassSearchFor: aClass [
+MCSearchFacade class >> subclassSearchFor: aClass [
 	| classes |
 	classes := aClass allSubclasses sorted: [ :a :b| a name <= b name ].
 	^ self classSearchIn: classes
 ]
 
 { #category : #'class search' }
-SearchFacade class >> superclassSearchFor: aClass [
+MCSearchFacade class >> superclassSearchFor: aClass [
 
 	^ self classSearchIn: aClass allSuperclasses reverse
 ]

--- a/src/MonticelloGUI/MCWorkingCopyBrowser.class.st
+++ b/src/MonticelloGUI/MCWorkingCopyBrowser.class.st
@@ -157,7 +157,7 @@ MCWorkingCopyBrowser >> addRepositoryToPackage [
 
 	self repository
 		ifNotNil: [ :repos | 
-			((SearchFacade mcPackageSearchRejectAll: [ :aPackage | aPackage repositoryGroup includes: repos ] withInitialFilter: nil)
+			((MCSearchFacade mcPackageSearchRejectAll: [ :aPackage | aPackage repositoryGroup includes: repos ] withInitialFilter: nil)
 				chooseFromOwner: self window)
 				ifNotNil: [ :wc | 
 					workingCopy := wc.
@@ -201,7 +201,7 @@ MCWorkingCopyBrowser >> addRequiredPackage [
 	| chosen |
 	workingCopy
 		ifNotNil: [ :wc | 
-			chosen := (SearchFacade mcPackageSearchRejectAll: [ :ea | ea = wc or: [ wc requiredPackages includes: ea package ] ])
+			chosen := (MCSearchFacade mcPackageSearchRejectAll: [ :ea | ea = wc or: [ wc requiredPackages includes: ea package ] ])
 				chooseFromOwner: self window.
 			chosen
 				ifNotNil: [ 


### PR DESCRIPTION
Move SearchFacade to MonticelloGUI and rename it to MCSearchFacade to keep package naming consistent.
#12084

