### PR TITLE
extract return statement from ifTrue:ifFalse: expression. fix: #12155

### DIFF
--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -246,9 +246,9 @@ CompiledCode >> frameSize [
 	"Answer the size of temporary frame needed to run the receiver."
 	"NOTE:  Versions 2.7 and later use two sizes of contexts."
 
-	(self header noMask: 16r20000)
-		ifTrue: [^ SmallFrame]
-		ifFalse: [^ LargeFrame]
+	^ (self header noMask: 16r20000)
+		ifTrue: [SmallFrame]
+		ifFalse: [LargeFrame]
 ]
 
 { #category : #literals }


### PR DESCRIPTION
extract return statement from ifTrue:ifFalse: expression in CompiledCode>>#frameSize. fix: #12155