### PR TITLE
Formatter adds unnecessary empty line before (first) method comment

### DIFF
--- a/src/EnlumineurFormatter-Tests/EFMethodExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFMethodExpressionTest.class.st
@@ -12,12 +12,13 @@ EFMethodExpressionTest >> basicCommentFormatConfiguration [
 			BIPrettyPrinterContext new storeOn: s]"
 
 	^ self contextClass basicNew
-		indentStyle: #tabulation;
-		formatCommentCloseToStatements:false;
-		useBasicCommentFormat: true;
-		numberOfNewLinesAfterMethodSignature: 1;
-		numberOfNewLinesAfterMethodComment: 1;
-		indentExtraSpaces: 0
+		  indentStyle: #tabulation;
+		  formatCommentCloseToStatements: false;
+		  useBasicCommentFormat: true;
+		  numberOfNewLinesAfterMethodSignature: 1;
+		  numberOfNewLinesAfterMethodSignatureWithMethodComment: 1;
+		  numberOfNewLinesAfterMethodComment: 1;
+		  indentExtraSpaces: 0
 ]
 
 { #category : #configurations }
@@ -28,15 +29,16 @@ EFMethodExpressionTest >> basicConfiguration [
 			BIPrettyPrinterContext new storeOn: s]"
 
 	^ self contextClass basicNew
-		indentStyle: #tabulation;
-		formatCommentCloseToStatements:false;
-		useBasicCommentFormat: false;
-		maxLineLength: 50;
-		periodAtEndOfBlock: false;
-		periodAtEndOfMethod: false;
-		numberOfNewLinesAfterMethodSignature: 1;
-		numberOfNewLinesAfterMethodComment: 1;
-		indentExtraSpaces:0
+		  indentStyle: #tabulation;
+		  formatCommentCloseToStatements: false;
+		  useBasicCommentFormat: false;
+		  maxLineLength: 50;
+		  periodAtEndOfBlock: false;
+		  periodAtEndOfMethod: false;
+		  numberOfNewLinesAfterMethodSignature: 1;
+		  numberOfNewLinesAfterMethodSignatureWithMethodComment: 1;
+		  numberOfNewLinesAfterMethodComment: 1;
+		  indentExtraSpaces: 0
 ]
 
 { #category : #configurations }
@@ -47,29 +49,30 @@ EFMethodExpressionTest >> bigMethodeConfiguration [
 			BIPrettyPrinterContext new storeOn: s]"
 
 	^ self contextClass basicNew
-		indentStyle: #tabulation;
-		formatCommentCloseToStatements: false;
-		useBasicCommentFormat: false;
-		maxLineLength: 50;
-		periodAtEndOfBlock: false;
-		periodAtEndOfMethod: false;
-		multiLineMessages: Array new;
-		oneLineMessages: Array new;
-		indentsForKeywords: 1;
-		keepBlockInMessage: true;
-		retainBlankLinesBetweenStatements: false;
-		retainBlankLinesBetweenStatements: false;
-		minimumNewLinesBetweenStatements: 1;
-		newLineBeforeFirstCascade: true;
-		newLineAfterCascade: true;
-		numberOfArgumentsForMultiLine: 4;
-		numberOfNewLinesAfterTemporaries: 1;
-		numberOfSpacesInsideBlock: 0;
-		lineUpBlockBrackets: true;
-		numberOfNewLinesAfterMethodSignature: 1;
-		numberOfNewLinesAfterMethodComment: 1;
-		newLineBeforeFirstKeyword:true;
-		indentExtraSpaces:0
+		  indentStyle: #tabulation;
+		  formatCommentCloseToStatements: false;
+		  useBasicCommentFormat: false;
+		  maxLineLength: 50;
+		  periodAtEndOfBlock: false;
+		  periodAtEndOfMethod: false;
+		  multiLineMessages: Array new;
+		  oneLineMessages: Array new;
+		  indentsForKeywords: 1;
+		  keepBlockInMessage: true;
+		  retainBlankLinesBetweenStatements: false;
+		  retainBlankLinesBetweenStatements: false;
+		  minimumNewLinesBetweenStatements: 1;
+		  newLineBeforeFirstCascade: true;
+		  newLineAfterCascade: true;
+		  numberOfArgumentsForMultiLine: 4;
+		  numberOfNewLinesAfterTemporaries: 1;
+		  numberOfSpacesInsideBlock: 0;
+		  lineUpBlockBrackets: true;
+		  numberOfNewLinesAfterMethodSignature: 1;
+		  numberOfNewLinesAfterMethodSignatureWithMethodComment: 1;
+		  numberOfNewLinesAfterMethodComment: 1;
+		  newLineBeforeFirstKeyword: true;
+		  indentExtraSpaces: 0
 ]
 
 { #category : #configurations }
@@ -80,22 +83,23 @@ EFMethodExpressionTest >> cascadeConfiguration [
 			BIPrettyPrinterContext new storeOn: s]"
 
 	^ self contextClass basicNew
-		indentStyle: #tabulation;
-		formatCommentCloseToStatements:false;
-		useBasicCommentFormat: false;
-		maxLineLength: 50;
-		periodAtEndOfBlock: false;
-		periodAtEndOfMethod: false;
-		newLineBeforeFirstCascade:true;
-		newLineAfterCascade:true;
-		multiLineMessages: Array new;
-		oneLineMessages: Array new;
-		numberOfArgumentsForMultiLine:10;
-		keepBlockInMessage:true;
-		retainBlankLinesBetweenStatements:false;
-		numberOfNewLinesAfterMethodSignature:1;
-		minimumNewLinesBetweenStatements: 1;
-		indentExtraSpaces:0
+		  indentStyle: #tabulation;
+		  formatCommentCloseToStatements: false;
+		  useBasicCommentFormat: false;
+		  maxLineLength: 50;
+		  periodAtEndOfBlock: false;
+		  periodAtEndOfMethod: false;
+		  newLineBeforeFirstCascade: true;
+		  newLineAfterCascade: true;
+		  multiLineMessages: Array new;
+		  oneLineMessages: Array new;
+		  numberOfArgumentsForMultiLine: 10;
+		  keepBlockInMessage: true;
+		  retainBlankLinesBetweenStatements: false;
+		  numberOfNewLinesAfterMethodSignature: 1;
+		  numberOfNewLinesAfterMethodSignatureWithMethodComment: 1;
+		  minimumNewLinesBetweenStatements: 1;
+		  indentExtraSpaces: 0
 ]
 
 { #category : #configurations }
@@ -106,15 +110,16 @@ EFMethodExpressionTest >> newLineBetweenTopCommentsConfiguration [
 			BIPrettyPrinterContext new storeOn: s]"
 
 	^ self contextClass basicNew
-		indentStyle: #tabulation;
-		formatCommentCloseToStatements:false;
-		useBasicCommentFormat: false;
-		maxLineLength: 50;
-		periodAtEndOfBlock: false;
-		periodAtEndOfMethod: false;
-		numberOfNewLinesAfterMethodSignature: 1;
-		numberOfNewLinesAfterMethodComment: 1;
-		indentExtraSpaces:0
+		  indentStyle: #tabulation;
+		  formatCommentCloseToStatements: false;
+		  useBasicCommentFormat: false;
+		  maxLineLength: 50;
+		  periodAtEndOfBlock: false;
+		  periodAtEndOfMethod: false;
+		  numberOfNewLinesAfterMethodSignature: 1;
+		  numberOfNewLinesAfterMethodSignatureWithMethodComment: 1;
+		  numberOfNewLinesAfterMethodComment: 1;
+		  indentExtraSpaces: 0
 ]
 
 { #category : #configurations }
@@ -125,12 +130,13 @@ EFMethodExpressionTest >> noNewLineBetweenTopCommentsConfiguration [
 			BIPrettyPrinterContext new storeOn: s]"
 
 	^ self contextClass basicNew
-		indentStyle: #tabulation;
-		formatCommentCloseToStatements:false;
-		useBasicCommentFormat: true;
-		numberOfNewLinesAfterMethodSignature: 1;
-		numberOfNewLinesAfterMethodComment: 0;
-		indentExtraSpaces:0
+		  indentStyle: #tabulation;
+		  formatCommentCloseToStatements: false;
+		  useBasicCommentFormat: true;
+		  numberOfNewLinesAfterMethodSignature: 1;
+		  numberOfNewLinesAfterMethodSignatureWithMethodComment: 1;
+		  numberOfNewLinesAfterMethodComment: 0;
+		  indentExtraSpaces: 0
 ]
 
 { #category : #configurations }
@@ -141,12 +147,13 @@ EFMethodExpressionTest >> noNewLinesAfterCommentConfiguration [
 			BIPrettyPrinterContext new storeOn: s]"
 
 	^ self contextClass basicNew
-		indentStyle: #tabulation;
-		formatCommentCloseToStatements:false;
-		useBasicCommentFormat: true;
-		numberOfNewLinesAfterMethodSignature: 1;
-		numberOfNewLinesAfterMethodComment: 1;
-		indentExtraSpaces:0
+		  indentStyle: #tabulation;
+		  formatCommentCloseToStatements: false;
+		  useBasicCommentFormat: true;
+		  numberOfNewLinesAfterMethodSignature: 1;
+		  numberOfNewLinesAfterMethodSignatureWithMethodComment: 1;
+		  numberOfNewLinesAfterMethodComment: 1;
+		  indentExtraSpaces: 0
 ]
 
 { #category : #configurations }
@@ -157,13 +164,14 @@ EFMethodExpressionTest >> notBasicCommentFormatConfiguration [
 			BIPrettyPrinterContext new storeOn: s]"
 
 	^ self contextClass basicNew
-		indentStyle: #tabulation;
-		formatCommentCloseToStatements:false;
-		useBasicCommentFormat: false;
-		maxLineLength: 50;	
-		numberOfNewLinesAfterMethodSignature: 1;
-		numberOfNewLinesAfterMethodComment: 1;
-		indentExtraSpaces:0
+		  indentStyle: #tabulation;
+		  formatCommentCloseToStatements: false;
+		  useBasicCommentFormat: false;
+		  maxLineLength: 50;
+		  numberOfNewLinesAfterMethodSignature: 1;
+		  numberOfNewLinesAfterMethodSignatureWithMethodComment: 1;
+		  numberOfNewLinesAfterMethodComment: 1;
+		  indentExtraSpaces: 0
 ]
 
 { #category : #configurations }
@@ -174,13 +182,14 @@ EFMethodExpressionTest >> oneNewLineAfterCommentConfiguration [
 			BIPrettyPrinterContext new storeOn: s]"
 
 	^ self contextClass basicNew
-		indentStyle: #tabulation;
-		formatCommentCloseToStatements:false;
-		useBasicCommentFormat:false;
-		maxLineLength:50;
-		numberOfNewLinesAfterMethodSignature: 1;
-		numberOfNewLinesAfterMethodComment: 2;
-		indentExtraSpaces:0
+		  indentStyle: #tabulation;
+		  formatCommentCloseToStatements: false;
+		  useBasicCommentFormat: false;
+		  maxLineLength: 50;
+		  numberOfNewLinesAfterMethodSignature: 1;
+  		  numberOfNewLinesAfterMethodSignatureWithMethodComment: 1; 
+		  numberOfNewLinesAfterMethodComment: 2;
+		  indentExtraSpaces: 0
 ]
 
 { #category : #configurations }
@@ -203,10 +212,11 @@ EFMethodExpressionTest >> signatureConfiguration [
 			BIPrettyPrinterContext new storeOn: s]"
 
 	^ self contextClass basicNew
-		indentStyle: #tabulation;
-		formatCommentCloseToStatements:false;
-		numberOfNewLinesAfterMethodSignature: 1;
-		indentExtraSpaces:0
+		  indentStyle: #tabulation;
+		  formatCommentCloseToStatements: false;
+		  numberOfNewLinesAfterMethodSignature: 1;
+		  numberOfNewLinesAfterMethodSignatureWithMethodComment: 1;
+		  indentExtraSpaces: 0
 ]
 
 { #category : #configurations }
@@ -217,11 +227,12 @@ EFMethodExpressionTest >> signatureNotOnMultipleLinesConfiguration [
 			BIPrettyPrinterContext new storeOn: s]"
 
 	^ self contextClass basicNew
-		indentStyle: #tabulation;
-		formatCommentCloseToStatements:false;
-		methodSignatureOnMultipleLines: false;
-		numberOfNewLinesAfterMethodSignature: 1;
-		indentExtraSpaces:0
+		  indentStyle: #tabulation;
+		  formatCommentCloseToStatements: false;
+		  methodSignatureOnMultipleLines: false;
+		  numberOfNewLinesAfterMethodSignature: 1;
+		  numberOfNewLinesAfterMethodSignatureWithMethodComment: 1;
+		  indentExtraSpaces: 0
 ]
 
 { #category : #configurations }
@@ -232,12 +243,13 @@ EFMethodExpressionTest >> signatureOnMultipleLinesConfiguration [
 			BIPrettyPrinterContext new storeOn: s]"
 
 	^ self contextClass basicNew
-		indentStyle: #tabulation;
-		formatCommentCloseToStatements:false;
-		methodSignatureOnMultipleLines: true;
-		selectorAndArgumentCombinedMaxSize: 2;
-		numberOfNewLinesAfterMethodSignature: 0;
-		indentExtraSpaces:0
+		  indentStyle: #tabulation;
+		  formatCommentCloseToStatements: false;
+		  methodSignatureOnMultipleLines: true;
+		  selectorAndArgumentCombinedMaxSize: 2;
+		  numberOfNewLinesAfterMethodSignature: 0;
+		  numberOfNewLinesAfterMethodSignatureWithMethodComment: 0;
+		  indentExtraSpaces: 0
 ]
 
 { #category : #configurations }
@@ -248,16 +260,17 @@ EFMethodExpressionTest >> spaceIndentConfiguration [
 			BIPrettyPrinterContext new storeOn: s]"
 
 	^ self contextClass basicNew
-		numberOfSpacesInIndent: 10; "pay attention since there are dependency."
-		indentStyle: #space;
-		formatCommentCloseToStatements:false;
-		useBasicCommentFormat: false;
-		maxLineLength: 50;
-		periodAtEndOfBlock: false;
-		periodAtEndOfMethod: false;
-		numberOfNewLinesAfterMethodSignature: 1;
-		numberOfNewLinesAfterMethodComment: 1;
-		indentExtraSpaces:0
+		  numberOfSpacesInIndent: 10;
+		  "pay attention since there are dependency."indentStyle: #space;
+		  formatCommentCloseToStatements: false;
+		  useBasicCommentFormat: false;
+		  maxLineLength: 50;
+		  periodAtEndOfBlock: false;
+		  periodAtEndOfMethod: false;
+		  numberOfNewLinesAfterMethodSignature: 1;
+		  numberOfNewLinesAfterMethodSignatureWithMethodComment: 1;
+		  numberOfNewLinesAfterMethodComment: 1;
+		  indentExtraSpaces: 0
 ]
 
 { #category : #tests }
@@ -591,8 +604,9 @@ EFMethodExpressionTest >> twoNewLinesAfterSignatureConfiguration [
 			BIPrettyPrinterContext new storeOn: s]"
 
 	^ self contextClass basicNew
-		indentStyle: #tabulation;
-		formatCommentCloseToStatements:false;
-		numberOfNewLinesAfterMethodSignature: 3;
-		indentExtraSpaces:0
+		  indentStyle: #tabulation;
+		  formatCommentCloseToStatements: false;
+		  numberOfNewLinesAfterMethodSignature: 3;
+		  numberOfNewLinesAfterMethodSignatureWithMethodComment: 3;
+		  indentExtraSpaces: 0
 ]

--- a/src/EnlumineurFormatter/EFContext.class.st
+++ b/src/EnlumineurFormatter/EFContext.class.st
@@ -42,7 +42,8 @@ Class {
 		'numberOfNewLinesAfterMethodComment',
 		'newLinesAfterMethodSignature',
 		'periodAtEndOfMethod',
-		'periodAtEndOfBlock'
+		'periodAtEndOfBlock',
+		'newLinesAfterMethodSignatureWithMethodComment'
 	],
 	#category : #'EnlumineurFormatter-Core'
 }
@@ -285,6 +286,17 @@ EFContext >> numberOfNewLinesAfterMethodSignature [
 { #category : #accessing }
 EFContext >> numberOfNewLinesAfterMethodSignature: aBoolean [
 	newLinesAfterMethodSignature := aBoolean
+]
+
+{ #category : #accessing }
+EFContext >> numberOfNewLinesAfterMethodSignatureWithMethodComment [
+
+	^ newLinesAfterMethodSignatureWithMethodComment
+]
+
+{ #category : #accessing }
+EFContext >> numberOfNewLinesAfterMethodSignatureWithMethodComment: aBoolean [
+	newLinesAfterMethodSignatureWithMethodComment := aBoolean
 ]
 
 { #category : #accessing }

--- a/src/EnlumineurFormatter/EFContext.class.st
+++ b/src/EnlumineurFormatter/EFContext.class.st
@@ -234,8 +234,8 @@ EFContext >> newLineAfterCascade [
 ]
 
 { #category : #accessing }
-EFContext >> newLineAfterCascade: anInteger [
-	newLineAfterCascade := anInteger
+EFContext >> newLineAfterCascade: aBoolean [
+	newLineAfterCascade := aBoolean
 ]
 
 { #category : #accessing }
@@ -244,8 +244,8 @@ EFContext >> newLineBeforeFirstCascade [
 ]
 
 { #category : #accessing }
-EFContext >> newLineBeforeFirstCascade: anInteger [
-	newLineBeforeFirstCascade := anInteger
+EFContext >> newLineBeforeFirstCascade: aBoolean [
+	newLineBeforeFirstCascade := aBoolean
 ]
 
 { #category : #accessing }
@@ -274,8 +274,8 @@ EFContext >> numberOfNewLinesAfterMethodComment [
 ]
 
 { #category : #accessing }
-EFContext >> numberOfNewLinesAfterMethodComment: aBoolean [
-	numberOfNewLinesAfterMethodComment := aBoolean
+EFContext >> numberOfNewLinesAfterMethodComment: anInteger [
+	numberOfNewLinesAfterMethodComment := anInteger
 ]
 
 { #category : #accessing }
@@ -284,8 +284,8 @@ EFContext >> numberOfNewLinesAfterMethodSignature [
 ]
 
 { #category : #accessing }
-EFContext >> numberOfNewLinesAfterMethodSignature: aBoolean [
-	newLinesAfterMethodSignature := aBoolean
+EFContext >> numberOfNewLinesAfterMethodSignature: anInteger [
+	newLinesAfterMethodSignature := anInteger
 ]
 
 { #category : #accessing }
@@ -295,8 +295,8 @@ EFContext >> numberOfNewLinesAfterMethodSignatureWithMethodComment [
 ]
 
 { #category : #accessing }
-EFContext >> numberOfNewLinesAfterMethodSignatureWithMethodComment: aBoolean [
-	newLinesAfterMethodSignatureWithMethodComment := aBoolean
+EFContext >> numberOfNewLinesAfterMethodSignatureWithMethodComment: anInteger [
+	newLinesAfterMethodSignatureWithMethodComment := anInteger
 ]
 
 { #category : #accessing }
@@ -315,9 +315,9 @@ EFContext >> numberOfSpacesAfterCaretSymbolInReturn [
 ]
 
 { #category : #accessing }
-EFContext >> numberOfSpacesAfterCaretSymbolInReturn: aNumber [
-	spacesAfterCaretSymbolInReturn := self stringFromSpaceNumber: aNumber.
-	numberOfSpacesAfterCaretSymbolInReturn := aNumber
+EFContext >> numberOfSpacesAfterCaretSymbolInReturn: anInteger [
+	spacesAfterCaretSymbolInReturn := self stringFromSpaceNumber: anInteger.
+	numberOfSpacesAfterCaretSymbolInReturn := anInteger
 ]
 
 { #category : #accessing }
@@ -362,9 +362,9 @@ EFContext >> numberOfSpacesInsideBlock [
 ]
 
 { #category : #accessing }
-EFContext >> numberOfSpacesInsideBlock: aNumber [
-	spacesInsideBlocks := self stringFromSpaceNumber: aNumber.
-	numberOfSpacesInsideBlock := aNumber
+EFContext >> numberOfSpacesInsideBlock: anInteger [
+	spacesInsideBlocks := self stringFromSpaceNumber: anInteger.
+	numberOfSpacesInsideBlock := anInteger
 ]
 
 { #category : #accessing }
@@ -373,9 +373,9 @@ EFContext >> numberOfSpacesInsideParentheses [
 ]
 
 { #category : #accessing }
-EFContext >> numberOfSpacesInsideParentheses: aNumber [
-	spacesInsideParentheses := self stringFromSpaceNumber: aNumber.
-	numberOfSpacesInsideParentheses := aNumber
+EFContext >> numberOfSpacesInsideParentheses: anInteger [
+	spacesInsideParentheses := self stringFromSpaceNumber: anInteger.
+	numberOfSpacesInsideParentheses := anInteger
 ]
 
 { #category : #accessing }

--- a/src/EnlumineurFormatter/EFFormatter.class.st
+++ b/src/EnlumineurFormatter/EFFormatter.class.st
@@ -275,6 +275,17 @@ EFFormatter class >> numberOfNewLinesAfterMethodSignature: anInteger [
 ]
 
 { #category : #accessing }
+EFFormatter class >> numberOfNewLinesAfterMethodSignatureWithMethodComment [
+	^ DefaultPrettyPrintContext numberOfNewLinesAfterMethodSignatureWithMethodComment
+]
+
+{ #category : #accessing }
+EFFormatter class >> numberOfNewLinesAfterMethodSignatureWithMethodComment: anInteger [
+	DefaultPrettyPrintContext numberOfNewLinesAfterMethodSignatureWithMethodComment: anInteger.
+	self announceASettingChange
+]
+
+{ #category : #accessing }
 EFFormatter class >> numberOfNewLinesAfterTemporaries [
 	^ DefaultPrettyPrintContext numberOfNewLinesAfterTemporaries
 ]
@@ -653,13 +664,29 @@ myMethod
 EFFormatter class >> settingsNewLinesAfterMethodSignature: aBuilder [
 
 	(aBuilder setting: #numberOfNewLinesAfterMethodSignature)
-		label: 'New lines after method signature';
+		label: 'New lines after method signature for method without a method comment';
 		default: 2;
-		description: 'To set the number of new lines directly after the method signature.
+		description: 'To set the number of new lines directly after the method signature for a method without a method comment.
 When numberOfNewLinesAfterMethodSignature is set to 2 new lines
 
 myMethod: arg
 
+	^ true
+'
+]
+
+{ #category : #settings }
+EFFormatter class >> settingsNewLinesAfterMethodSignatureWithMethodComment: aBuilder [
+
+	(aBuilder setting: #numberOfNewLinesAfterMethodSignatureWithMethodComment)
+		label: 'New lines after method signature for method with a method comment';
+		default: 1;
+		description: 'To set the number of new lines directly after the method signature for a method with a method comment.
+When numberOfNewLinesAfterMethodSignature is set to 1 new lines
+
+myMethod: arg
+	"myComment"
+	
 	^ true
 '
 ]
@@ -721,34 +748,37 @@ EFFormatter class >> settingsOn: aBuilder [
 		parent: #codeFormatters;
 		label: 'Enlumineur Pretty Printer';
 		description: 'Settings related to automatic code formatting';
-		with: [ self settingsMaxLineLength: aBuilder.
-			self settingsCommentCloseToStatement: aBuilder.
-			self settingsIndentStyle: aBuilder.
-			self settingsNumberOfSpacesInIndent: aBuilder.
-			self settingsIndentsForKeywords: aBuilder.
-			self settingsKeepBlockInMessage: aBuilder.
-			self settingsAlignBlockBrackets: aBuilder.
-			self settingsMethodSignatureOnMultipleLines: aBuilder.
-			self settingsOneLineMessages: aBuilder.
-			self settingsMultiLineMessages: aBuilder.
-			self settingsMinimumNewLinesBetweenStatements: aBuilder.
-			self settingsNewLineAfterCascade: aBuilder.
-			self settingsNewLineBeforeFirstCascade: aBuilder.
-			self settingsNewLineBeforeFirstKeyword: aBuilder.
-			self settingsNewLinesAfterMethodComment: aBuilder.
-			self settingsNewLinesAfterMethodSignature: aBuilder.
-			self settingsNewLinesAfterTemporaries: aBuilder.
-			self settingsNumberOfArgumentsForMultiLine: aBuilder.
-			self settingsPeriodsAtEndOfBlock: aBuilder.
-			self settingsPeriodsAtEndOfMethod: aBuilder.
-			self settingsRetainBlankLinesBeforeComments: aBuilder.
-			self settingsRetainBlankLinesBetweenStatements: aBuilder.
-			self settingsSelectorAndArgumentCombinedMaxSize: aBuilder.
-			self settingsSpacesAfterCaretSymbolInReturn: aBuilder.
-			self settingsSpacesInsideBlocks: aBuilder.
-			self settingsSpacesInsideParentheses: aBuilder.
-			self settingsSpacesInsideArray: aBuilder.
-			self settingsUseBasicCommentFormat: aBuilder]
+		with: [ 
+			self 
+				settingsMaxLineLength: aBuilder;
+				settingsCommentCloseToStatement: aBuilder;
+				settingsIndentStyle: aBuilder;
+				settingsNumberOfSpacesInIndent: aBuilder;
+				settingsIndentsForKeywords: aBuilder;
+				settingsKeepBlockInMessage: aBuilder;
+				settingsAlignBlockBrackets: aBuilder;
+				settingsMethodSignatureOnMultipleLines: aBuilder;
+				settingsOneLineMessages: aBuilder;
+				settingsMultiLineMessages: aBuilder;
+				settingsMinimumNewLinesBetweenStatements: aBuilder;
+				settingsNewLineAfterCascade: aBuilder;
+				settingsNewLineBeforeFirstCascade: aBuilder;
+				settingsNewLineBeforeFirstKeyword: aBuilder;
+				settingsNewLinesAfterMethodComment: aBuilder;
+				settingsNewLinesAfterMethodSignature: aBuilder;
+				settingsNewLinesAfterMethodSignatureWithMethodComment: aBuilder;
+				settingsNewLinesAfterTemporaries: aBuilder;
+				settingsNumberOfArgumentsForMultiLine: aBuilder;
+				settingsPeriodsAtEndOfBlock: aBuilder;
+				settingsPeriodsAtEndOfMethod: aBuilder;
+				settingsRetainBlankLinesBeforeComments: aBuilder;
+				settingsRetainBlankLinesBetweenStatements: aBuilder;
+				settingsSelectorAndArgumentCombinedMaxSize: aBuilder;
+				settingsSpacesAfterCaretSymbolInReturn: aBuilder;
+				settingsSpacesInsideBlocks: aBuilder;
+				settingsSpacesInsideParentheses: aBuilder;
+				settingsSpacesInsideArray: aBuilder;
+				settingsUseBasicCommentFormat: aBuilder]
 ]
 
 { #category : #settings }
@@ -1189,7 +1219,9 @@ EFFormatter >> formatMethodBodyFor: aMethodNode [
 	self
 		indentAround:
 			[ 
-			self newLines: self numberOfNewLinesAfterMethodSignature.
+			self newLines: (aMethodNode comments 
+									ifEmpty: [ self numberOfNewLinesAfterMethodSignature ] 
+			 						ifNotEmpty: [ self numberOfNewLinesAfterMethodSignatureWithMethodComment ]).
 			self formatMethodCommentFor: aMethodNode.
 			self formatPragmasFor: aMethodNode.
 			self visitNode: aMethodNode body ]
@@ -1774,6 +1806,16 @@ EFFormatter >> numberOfNewLinesAfterMethodSignature [
 { #category : #accessing }
 EFFormatter >> numberOfNewLinesAfterMethodSignature: anInteger [
 	context numberOfNewLinesAfterMethodSignature: anInteger
+]
+
+{ #category : #accessing }
+EFFormatter >> numberOfNewLinesAfterMethodSignatureWithMethodComment [
+	^ context numberOfNewLinesAfterMethodSignatureWithMethodComment
+]
+
+{ #category : #accessing }
+EFFormatter >> numberOfNewLinesAfterMethodSignatureWithMethodComment: anInteger [
+	context numberOfNewLinesAfterMethodSignatureWithMethodComment: anInteger
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
 - introduce an additional setting #numberOfNewLinesAfterMethodSignatureWithMethodComment beside existing #numberOfNewLinesAfterMethodSignature

Fix #12175