### PR TITLE
12191-RBAddMethodChange-moves-all-uncategorized-to-accessing 

### DIFF
--- a/src/Refactoring-Changes/RBAddMethodChange.class.st
+++ b/src/Refactoring-Changes/RBAddMethodChange.class.st
@@ -215,10 +215,7 @@ RBAddMethodChange >> protocols [
 RBAddMethodChange >> protocols: aCollectionOrString [
 
 	protocols := aCollectionOrString isString
-		             ifTrue: [ 
-			             aCollectionOrString = Protocol unclassified
-				             ifTrue: [ protocols := #( accessing ) ]
-				             ifFalse: [ Array with: aCollectionOrString ] ]
+		             ifTrue: [ { aCollectionOrString } ]
 		             ifFalse: [ aCollectionOrString ]
 ]
 

--- a/src/Refactoring-Tests-Changes/RBRefactoringChangeTest.class.st
+++ b/src/Refactoring-Tests-Changes/RBRefactoringChangeTest.class.st
@@ -302,7 +302,7 @@ RBRefactoringChangeTest >> testCompileInMetaclass [
 	self assert: change isMeta.
 	self assert: change selector equals: #new.
 	self assert: change source equals: 'new'.
-	self assert: change protocol equals: #accessing.
+	self assert: change protocol equals: Protocol unclassified.
 	self universalTestFor: change
 ]
 


### PR DESCRIPTION
fixes #12191:

- do not move unclassified method to 'accessing'
- fix test