### PR TITLE
RBMakeClassAbstractTransformation-no-whitespace

### DIFF
--- a/src/Refactoring-Core/RBMakeClassAbstractTransformation.class.st
+++ b/src/Refactoring-Core/RBMakeClassAbstractTransformation.class.st
@@ -41,7 +41,7 @@ RBMakeClassAbstractTransformation >> preconditions [
 RBMakeClassAbstractTransformation >> transform [
 	(RBAddMethodTransformation
 		                   sourceCode: 'isAbstract
-		
+
 	^ self == ' , targetClass asString
 		                   in: targetClass classSide
 		                   withProtocols: #( #testing )) execute


### PR DESCRIPTION
make sure that the RBMakeClassAbstractTransformation does not add whitespaces that are not needed