### PR TITLE
remove ByteLayout from FFIBackend and children

### DIFF
--- a/src/FFI-Kernel/FFIBackend.class.st
+++ b/src/FFI-Kernel/FFIBackend.class.st
@@ -4,7 +4,6 @@ I am an strategy to implement different backends for FFI.
 Class {
 	#name : #FFIBackend,
 	#superclass : #Object,
-	#type : #bytes,
 	#classVars : [
 		'Current'
 	],

--- a/src/FFI-Kernel/NullFFIBackend.class.st
+++ b/src/FFI-Kernel/NullFFIBackend.class.st
@@ -4,7 +4,6 @@ I am a null implementation of a FFIBackend
 Class {
 	#name : #NullFFIBackend,
 	#superclass : #FFIBackend,
-	#type : #bytes,
 	#category : #'FFI-Kernel'
 }
 

--- a/src/ThreadedFFI/TFFIBackend.class.st
+++ b/src/ThreadedFFI/TFFIBackend.class.st
@@ -4,7 +4,6 @@ I am the FFI backend implemented by using TFFI
 Class {
 	#name : #TFFIBackend,
 	#superclass : #FFIBackend,
-	#type : #bytes,
 	#category : #'ThreadedFFI-Base'
 }
 


### PR DESCRIPTION
there is no need to have this classes as ByteLayout classes, and it poses some problems when serializing them with fuel.