### PR TITLE
12289-Refactoring-Tests-are-failling-when-using-Fluid-syntax

### DIFF
--- a/src/Refactoring-Changes/SystemDictionary.extension.st
+++ b/src/Refactoring-Changes/SystemDictionary.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #SystemDictionary }
+
+{ #category : #'*Refactoring-Changes' }
+SystemDictionary >> defineClass: aDefinition withController: aController [
+
+	^ (self class compiler
+		source: aDefinition;
+		requestor: aController;
+		logged: true;
+		evaluate) fluidInstall
+]

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -169,16 +169,6 @@ SystemDictionary >> classOrTraitNamed: aString [
 				  ifTrue: [ global classSide ] ] ]
 ]
 
-{ #category : #removing }
-SystemDictionary >> defineClass: aDefinition withController: aController [
-
-	^ self class compiler
-		source: aDefinition;
-		requestor: aController;
-		logged: true;
-		evaluate
-]
-
 { #category : #accessing }
 SystemDictionary >> environment [
 	"For conversion from SmalltalkImage to SystemDictionary"


### PR DESCRIPTION
- Adding support to correctly install the class when using Fluid Syntax
- Moving method as an extension of refactorings as it is the only user.