### PR TITLE
Fix hasSelector:specialSelectorIndex: on FFI methods that are compiled

### DIFF
--- a/src/UnifiedFFI-Tests/FFICompilerPluginTest.class.st
+++ b/src/UnifiedFFI-Tests/FFICompilerPluginTest.class.st
@@ -54,6 +54,18 @@ FFICompilerPluginTest >> testExecutionOfWrongFFIMethodShouldRaiseAnError [
 ]
 
 { #category : #tests }
+FFICompilerPluginTest >> testFFIMethodDelegatesWhenLookingForHasSelector [
+
+	| buffer ffiMethod |
+	buffer := ByteArray new: 12.
+	self ffiCopyString: 'Hello World!' to: buffer.
+
+	ffiMethod := (FFICompilerPluginTest >> #ffiCopyString:to:).
+	
+	self assert: (ffiMethod hasSelector: #ffiCall: specialSelectorIndex: nil).
+]
+
+{ #category : #tests }
 FFICompilerPluginTest >> testMethodCall [
 	| buffer |
 	buffer := ByteArray new: 12.

--- a/src/UnifiedFFI-Tests/FFICompilerPluginTest.class.st
+++ b/src/UnifiedFFI-Tests/FFICompilerPluginTest.class.st
@@ -57,10 +57,11 @@ FFICompilerPluginTest >> testExecutionOfWrongFFIMethodShouldRaiseAnError [
 FFICompilerPluginTest >> testFFIMethodDelegatesWhenLookingForHasSelector [
 
 	| buffer ffiMethod |
+	"Execute the method to ensure it is compiled as FFI method"
 	buffer := ByteArray new: 12.
 	self ffiCopyString: 'Hello World!' to: buffer.
 
-	ffiMethod := (FFICompilerPluginTest >> #ffiCopyString:to:).
+	ffiMethod := FFICompilerPluginTest >> #ffiCopyString:to:.
 	
 	self assert: (ffiMethod hasSelector: #ffiCall: specialSelectorIndex: nil).
 ]

--- a/src/UnifiedFFI/CompiledMethod.extension.st
+++ b/src/UnifiedFFI/CompiledMethod.extension.st
@@ -13,6 +13,9 @@ CompiledMethod >> ffiArgumentNames [
 
 { #category : #'*UnifiedFFI' }
 CompiledMethod >> hasSelector: selector specialSelectorIndex: specialOrNil [
+	"Answer whether this method refers to a selector. FFI methods require special
+	consideration since a substitution of the original method is installed in the
+	method dictionary."
 
 	| ffiNonCompiledMethod |
 	ffiNonCompiledMethod := self

--- a/src/UnifiedFFI/CompiledMethod.extension.st
+++ b/src/UnifiedFFI/CompiledMethod.extension.st
@@ -12,6 +12,23 @@ CompiledMethod >> ffiArgumentNames [
 ]
 
 { #category : #'*UnifiedFFI' }
+CompiledMethod >> hasSelector: selector specialSelectorIndex: specialOrNil [
+
+	| ffiNonCompiledMethod |
+	ffiNonCompiledMethod := self
+		propertyAt: #ffiNonCompiledMethod
+		ifAbsent: [
+			^ super
+				hasSelector: selector
+				specialSelectorIndex: specialOrNil ].
+
+	^ ffiNonCompiledMethod
+		hasSelector: selector
+		specialSelectorIndex: specialOrNil
+
+]
+
+{ #category : #'*UnifiedFFI' }
 CompiledMethod >> isFFIMethod [
 	
 	^ self hasProperty: #isFFIMethod


### PR DESCRIPTION
FFI methods must delegate to the original non-compiled method to respond.

Fix #12304