### PR TITLE
12300-Compiler-is-slow-with-string-literals-containing-exclamation-marks

### DIFF
--- a/src/System-Sources/ChunkWriteStream.class.st
+++ b/src/System-Sources/ChunkWriteStream.class.st
@@ -12,6 +12,12 @@ Class {
 }
 
 { #category : #writing }
+ChunkWriteStream >> afterNexPut [
+
+	decoratedStream flush
+]
+
+{ #category : #writing }
 ChunkWriteStream >> bang [
 	
 	decoratedStream nextPut: self terminatorMark
@@ -25,6 +31,35 @@ ChunkWriteStream >> doesNotUnderstand: aMessage [
 ]
 
 { #category : #accessing }
+ChunkWriteStream >> duplicateTerminatorMarkOn: aString [
+	"Append the argument, aString, to the receiver, doubling embedded ! terminators and adding a extra one"
+
+	| string start bangIndex newStringStream |
+	string := aString asString.
+	newStringStream := WriteStream on: (string species new: string size * 2).
+	start := 1.
+
+	[ (bangIndex := string indexOf: self terminatorMark startingAt: start) = 0 ]
+		whileFalse: [
+			newStringStream
+				next: bangIndex - start + 1
+				putAll: string
+				startingAt: start.
+
+			newStringStream nextPut: self terminatorMark. "double it"
+			start := bangIndex + 1 ].
+
+	newStringStream
+		next: string size - start + 1
+		putAll: string
+		startingAt: start.
+
+	newStringStream nextPut: self terminatorMark. "one extra"
+
+	^ newStringStream contents
+]
+
+{ #category : #accessing }
 ChunkWriteStream >> nextChunkPut: aString [
 
 	^ self nextPut: aString
@@ -34,17 +69,15 @@ ChunkWriteStream >> nextChunkPut: aString [
 ChunkWriteStream >> nextPut: aString [
 	"Append the argument, aString, to the receiver, doubling embedded ! terminators and adding a extra one"
 
-	| string start bangIndex |
-	string := aString asString.
-	start := 1.
-	[ (bangIndex := string indexOf: self terminatorMark startingAt: start) = 0 ]
-		whileFalse: [
-			decoratedStream next: bangIndex - start + 1 putAll: string startingAt: start.
-			self bang. "double it"
-			start := bangIndex + 1 ].
-	decoratedStream next: string size - start + 1 putAll: string startingAt: start.
-	self bang. "one extra"
-	decoratedStream flush
+	| string |
+	string := self duplicateTerminatorMarkOn: aString asString.
+
+	decoratedStream
+		next: string size
+		putAll: string
+		startingAt: 1.
+
+	self afterNexPut
 ]
 
 { #category : #accessing }

--- a/src/System-Sources/SourceChunkWriteStream.class.st
+++ b/src/System-Sources/SourceChunkWriteStream.class.st
@@ -8,26 +8,8 @@ Class {
 	#category : #'System-Sources-Utilities'
 }
 
-{ #category : #accessing }
-SourceChunkWriteStream >> nextPut: aString [
-	"Append the argument, aString, to the receiver, doubling embedded ! terminators and adding a extra one"
+{ #category : #writing }
+SourceChunkWriteStream >> afterNexPut [
 
-	| string start bangIndex |
-	string := aString asString.
-	start := 1.
-	[ 
-	(bangIndex := string indexOf: self terminatorMark startingAt: start)
-	= 0 ] whileFalse: [ 
-		decoratedStream
-			next: bangIndex - start + 1
-			putAll: string
-			startingAt: start.
-		self bang. "double it"
-		start := bangIndex + 1 ].
-	decoratedStream
-		next: string size - start + 1
-		putAll: string
-		startingAt: start.
-	self bang. "one extra"
 	decoratedStream setToEnd
 ]


### PR DESCRIPTION
Fix #12300

Duplicating the terminator mark should be done in a Stream in memory.  The ZnEncoderStream works faster when it can encode a longer string. Calling it multiple times with smaller strings affects its performance.

To test the performance: 

```Smalltalk
stream := String new writeStream.
stream nextPutAll: 'exclamationSlow';
cr; tab; nextPutAll: '^'''.
100000 timesRepeat:[stream nextPutAll: 'slow!'].
stream nextPutAll: ''''.
x := Time millisecondsToRun:[Object compile:stream contents].

stream2 := String new writeStream.
stream2 nextPutAll: 'exclamationFast';
cr; tab; nextPutAll: '^'''.
100000 timesRepeat:[stream2 nextPutAll: 'fast.'].
stream2 nextPutAll: ''''.
[RBParser parseMethod: stream2 contents] timeToRun.
y:= Time millisecondsToRun:[Object compile:stream2 contents].

{ #withExclamationMarks -> x. #withoutExclamationMarks -> y }
```

Old Implementation: "{#withExclamationMarks->9967. #withoutExclamationMarks->50}"

New Implementation: "{#withExclamationMarks->94. #withoutExclamationMarks->95}"