### PR TITLE
Variables: Fix Prrinting and Fluid Class definition that uses ClassVariable 

### DIFF
--- a/src/Kernel/ClassVariable.class.st
+++ b/src/Kernel/ClassVariable.class.st
@@ -35,11 +35,17 @@ ClassVariable >> definingClass: anObject [
 ]
 
 { #category : #printing }
-ClassVariable >> definitionString [
+ClassVariable >> definitionOn: aStream [
 	"non special globals are defined by the symbol"
-	^ self needsFullDefinition
-		ifTrue: [ super definitionString ]
-		ifFalse: [ self name printString ]
+	^self needsFullDefinition
+		ifTrue: [ super definitionOn: aStream ]
+		ifFalse: [ self name printOn: aStream ]
+]
+
+{ #category : #printing }
+ClassVariable >> definitionString [
+	"Every subclass that adds state must redefine either this method or #printOn:"
+	^ String streamContents: [:s | self definitionOn: s]
 ]
 
 { #category : #'code generation' }
@@ -106,6 +112,15 @@ ClassVariable >> possiblyUsingClasses [
 	"we can access from both the class and the metaclass"
 	classes addAll: (classes collect: [ :class | class class ]).
 	^ classes
+]
+
+{ #category : #printing }
+ClassVariable >> printOn: aStream [
+	"Every subclass that adds state must redefine either this method or #definitionString"
+	aStream
+		store: self name;
+		nextPutAll: ' => ';
+		nextPutAll: self class name
 ]
 
 { #category : #queries }

--- a/src/Kernel/Slot.class.st
+++ b/src/Kernel/Slot.class.st
@@ -102,12 +102,6 @@ Slot >> definingClass: aClass [
 ]
 
 { #category : #printing }
-Slot >> definitionOn: aStream [
-	"Every subclass that adds state must redefine either this method or #printOn:"
-	^ self printOn: aStream
-]
-
-{ #category : #printing }
 Slot >> definitionString [
 	"Every subclass that adds state must redefine either this method or #printOn:"
 	^ String streamContents: [:s | self definitionOn: s]

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -91,6 +91,12 @@ Variable >> definingNode [
 	^ nil
 ]
 
+{ #category : #printing }
+Variable >> definitionOn: aStream [
+	"Every subclass that adds state must redefine either this method or #printOn:"
+	^ self printOn: aStream
+]
+
 { #category : #'code generation' }
 Variable >> emitStore: methodBuilder [
 

--- a/src/Slot-Tests/ClassVariableTest.class.st
+++ b/src/Slot-Tests/ClassVariableTest.class.st
@@ -89,6 +89,15 @@ ClassVariableTest >> testPossiblyUsingClasses [
 	self assert: (variable possiblyUsingClasses includes: CompositionScanner class)
 ]
 
+{ #category : #tests }
+ClassVariableTest >> testPrintOn [
+	| variable |
+	variable := SmalltalkImage classVariableNamed: #CompilerClass.
+	self assert: variable definitionString equals: '#CompilerClass'.
+	"but we print as a self-evaluation varibale defition"
+	self assert: variable printString equals: '#CompilerClass => ClassVariable'
+]
+
 { #category : #'tests - properties' }
 ClassVariableTest >> testPropertyAtPut [
 


### PR DESCRIPTION
When using Fluid Class definitons, we can define Classs Variables (aka Shared Variables) that are implemented by subclasses of ClassVariable.

(and an example, look at WeakClassVariable)

This PR makes sure that
- the printString is the definition, that is,   #MyVar => ClassVariable
- The class definitons shows #MyVar => ClassVariable, but the short form if the variable is just a ClassVariable

This will make it possible to use self-defined Class Variable kinds and we can start to experiment, e.g. we can 
- have a class var with the value in the definition, see InitializedClassVariable and LazyClassVariable
- we can experiment with more intelligent class vars that work as a Cache and manage the memory they allocate in a more clever way