### PR TITLE
Old class template should be in OldPharoClassPrinter

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -86,24 +86,6 @@ Class class >> superclassOrder: classes [
     ^all
 ]
 
-{ #category : #'instance creation' }
-Class class >> template: aSystemCategoryName [ 
-	"Answer an expression that can be edited and evaluated in order to define a new class."
-
-	^ self templateForSubclassOf: Object name category: aSystemCategoryName
-]
-
-{ #category : #'instance creation' }
-Class class >> templateForSubclassOf: priorClassName category: systemCategoryName [ 
-	"Answer an expression that can be edited and evaluated in order to define a new class, given that the class previously looked at was as given"
-
-	^priorClassName asString, ' subclass: #NameOfSubclass
-	instanceVariableNames: ''''
-	classVariableNames: ''''
-	poolDictionaries: ''''
-	package: ''' , systemCategoryName asString , ''''
-]
-
 { #category : #'class variables' }
 Class >> addClassVarNamed: aString [ 
 	"Add the argument, aString, as a class variable of the receiver.

--- a/src/Kernel/OldPharoClassDefinitionPrinter.class.st
+++ b/src/Kernel/OldPharoClassDefinitionPrinter.class.st
@@ -162,6 +162,24 @@ OldPharoClassDefinitionPrinter >> poolOn: stream [
 			store: poolString ]
 ]
 
+{ #category : #'instance creation' }
+OldPharoClassDefinitionPrinter >> template: aSystemCategoryName [ 
+	"Answer an expression that can be edited and evaluated in order to define a new class."
+
+	^ self templateForSubclassOf: Object name category: aSystemCategoryName
+]
+
+{ #category : #'instance creation' }
+OldPharoClassDefinitionPrinter >> templateForSubclassOf: priorClassName category: systemCategoryName [ 
+	"Answer an expression that can be edited and evaluated in order to define a new class, given that the class previously looked at was as given"
+
+	^priorClassName asString, ' subclass: #NameOfSubclass
+	instanceVariableNames: ''''
+	classVariableNames: ''''
+	poolDictionaries: ''''
+	package: ''' , systemCategoryName asString , ''''
+]
+
 { #category : #template }
 OldPharoClassDefinitionPrinter >> testClassDefinitionTemplateInPackage: aString [
 


### PR DESCRIPTION
Fix for "Old class template is still around and should be in the correct printer OldPharoClassPrinter and not Class". Issue #12171