### PR TITLE
Add #normalizeCamelCase and test

### DIFF
--- a/src/Collections-Strings-Tests/StringTest.class.st
+++ b/src/Collections-Strings-Tests/StringTest.class.st
@@ -1655,6 +1655,17 @@ StringTest >> testMatch [
 ]
 
 { #category : #tests }
+StringTest >> testNormalizeCamelCase [
+
+	self assert: '' normalizeCamelCase equals: String empty.
+	self assert: 'CamelCase' normalizeCamelCase equals: 'Camel Case'.
+	self assert: 'CamelCase123' normalizeCamelCase equals:'Camel Case123'.
+	self assert: 'ABC' normalizeCamelCase equals: 'ABC'.
+	self assert: 'TresTristesTigres' normalizeCamelCase equals: 'Tres Tristes Tigres'.
+	self assert: 'TresTristesTigresABC' normalizeCamelCase equals: 'Tres Tristes Tigres ABC'
+]
+
+{ #category : #tests }
 StringTest >> testNumArgs [
 	"This is about http://code.google.com/p/pharo/issues/detail?id=237"
 	

--- a/src/Collections-Strings-Tests/StringTest.class.st
+++ b/src/Collections-Strings-Tests/StringTest.class.st
@@ -1662,7 +1662,8 @@ StringTest >> testNormalizeCamelCase [
 	self assert: 'CamelCase123' normalizeCamelCase equals:'Camel Case123'.
 	self assert: 'ABC' normalizeCamelCase equals: 'ABC'.
 	self assert: 'TresTristesTigres' normalizeCamelCase equals: 'Tres Tristes Tigres'.
-	self assert: 'TresTristesTigresABC' normalizeCamelCase equals: 'Tres Tristes Tigres ABC'
+	self assert: 'TresTristesTigresABC' normalizeCamelCase equals: 'Tres Tristes Tigres ABC'.
+	self assert: 'CamelCase HelloWorld' normalizeCamelCase equals: 'Camel Case Hello World'.
 ]
 
 { #category : #tests }

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -2183,12 +2183,13 @@ String >> normalizeCamelCase [
 	"
 	'TheRollingStones' normalizeCamelCase >>> 'The Rolling Stones'
 	"
-	^ self class streamContents: [ :out |
-		self do: [ :e |
-			| isNewWord |
-			isNewWord := e isUppercase and: [ out position > 0 and: [ out peekLast isUppercase not ] ].
-			isNewWord ifTrue: [ out nextPut: Character space ].
-			out nextPut: e ] ]
+	^ self class streamContents: [ : stream |
+		self do: [ : char |
+			(char isUppercase and: [
+				(stream position > 0 and: [ stream peekLast isUppercase not ])
+					and: [ stream peekLast isSpaceSeparator not  ] ])
+						ifTrue: [ stream nextPut: Character space ].
+			stream nextPut: char ] ]
 ]
 
 { #category : #'system primitives' }

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -2178,6 +2178,19 @@ String >> match: text [
 	^ self startingAt: 1 match: text startingAt: 1
 ]
 
+{ #category : #converting }
+String >> normalizeCamelCase [
+	"
+	'TheRollingStones' normalizeCamelCase >>> 'The Rolling Stones'
+	"
+	^ self class streamContents: [ :out |
+		self do: [ :e |
+			| isNewWord |
+			isNewWord := e isUppercase and: [ out position > 0 and: [ out peekLast isUppercase not ] ].
+			isNewWord ifTrue: [ out nextPut: Character space ].
+			out nextPut: e ] ]
+]
+
 { #category : #'system primitives' }
 String >> numArgs [
 	"Answer either the number of arguments that the receiver would take if considered a selector.  Answer -1 if it couldn't be a selector. It is intended mostly for the assistance of spelling correction."


### PR DESCRIPTION
Add method to split a camel cased String into its "normalized" string version, separated by spaces.

```smalltalk
'PinkFloyd' normalizeCamelCase >>> 'Pink Floyd'
```