### PR TITLE
Fix for multiple Epicea issues

### DIFF
--- a/src/Epicea/EpCategoryRegistration.class.st
+++ b/src/Epicea/EpCategoryRegistration.class.st
@@ -1,0 +1,14 @@
+"
+I represent the registration of a package.
+"
+Class {
+	#name : #EpCategoryRegistration,
+	#superclass : #EpCategoryChange,
+	#category : #'Epicea-Model'
+}
+
+{ #category : #visitor }
+EpCategoryRegistration >> accept: aVisitor [
+
+	^ aVisitor visitCategoryRegistration: self
+]

--- a/src/Epicea/EpMonitor.class.st
+++ b/src/Epicea/EpMonitor.class.st
@@ -255,7 +255,7 @@ EpMonitor >> categoryAdded: aCategoryAdded [
 EpMonitor >> categoryRegistered: aCategoryAdded [
 
 	self handleAnyErrorDuring: [
-			self addEvent: (EpCategoryAddition named: aCategoryAdded package name) ]
+			self addEvent: (EpCategoryRegistration named: aCategoryAdded package name) ]
 ]
 
 { #category : #'announcement handling' }

--- a/src/Epicea/EpMonitor.class.st
+++ b/src/Epicea/EpMonitor.class.st
@@ -252,6 +252,13 @@ EpMonitor >> categoryAdded: aCategoryAdded [
 ]
 
 { #category : #'announcement handling' }
+EpMonitor >> categoryRegistered: aCategoryAdded [
+
+	self handleAnyErrorDuring: [
+			self addEvent: (EpCategoryAddition named: aCategoryAdded package name) ]
+]
+
+{ #category : #'announcement handling' }
 EpMonitor >> categoryRemoved: aPackageCategoryRemoved [
 
 	self handleAnyErrorDuring:[
@@ -514,6 +521,15 @@ EpMonitor >> methodRemoved: aMethodRemovedAnnouncement [
 ]
 
 { #category : #'announcement handling' }
+EpMonitor >> packageRenamed: aCategoryRenamed [
+
+	self handleAnyErrorDuring: [
+		self addEvent: (EpCategoryRename
+			oldName: aCategoryRenamed oldName
+			newName: aCategoryRenamed newName) ]
+]
+
+{ #category : #'announcement handling' }
 EpMonitor >> protocolAdded: aProtocolAdded [
 
 	self handleAnyErrorDuring: [
@@ -575,6 +591,8 @@ EpMonitor >> subscribeToSystemAnnouncer [
 	{	CategoryAdded -> #categoryAdded:.
 		CategoryRemoved -> #categoryRemoved:.
 		CategoryRenamed -> #categoryRenamed:.
+		RPackageRegistered -> #categoryRegistered:.
+		RPackageRenamed -> #packageRenamed:.
 		ClassAdded-> #behaviorAdded:.
 		ClassRemoved->#behaviorRemoved:.
 		MethodAdded -> #methodAdded:.

--- a/src/Epicea/EpTCodeChangeVisitor.trait.st
+++ b/src/Epicea/EpTCodeChangeVisitor.trait.st
@@ -37,6 +37,12 @@ EpTCodeChangeVisitor >> visitCategoryChange: aChange [
 ]
 
 { #category : #visitor }
+EpTCodeChangeVisitor >> visitCategoryRegistration: aChange [
+
+	^ self visitCategoryChange: aChange
+]
+
+{ #category : #visitor }
 EpTCodeChangeVisitor >> visitCategoryRemoval: aChange [
 	^ self visitCategoryChange: aChange
 ]

--- a/src/EpiceaBrowsers-Tests/EpLostChangesDetectorTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpLostChangesDetectorTest.class.st
@@ -27,7 +27,9 @@ EpLostChangesDetectorTest >> testDetectNoChange [
 	self deny: detector hasLostChanges.
 	self assertEmpty: detector lostChanges.
 
-	self assert: monitor log entriesCount equals: 2	"Just to be sure of the assumed precondition: category and only one class created"
+	"Category addition and registration are two separate events"
+	"Just to be sure of the assumed precondition: category and only one class created"	
+	self assert: monitor log entriesCount equals: 3
 ]
 
 { #category : #tests }
@@ -71,7 +73,7 @@ EpLostChangesDetectorTest >> testDetectOneChangeDetectedAndOneIgnored [
 { #category : #tests }
 EpLostChangesDetectorTest >> testDetectThreeChanges [
 
-	| logWithLostChanges numberOfLostChanges expectedLostClassNames detectedLostChanges |
+	| logWithLostChanges numberOfLostChanges expectedLostClassNames detectedLostChanges detectedLostClassChanges |
 
 	"Build a log with several lost changes (class additions)"
 	numberOfLostChanges := 3.
@@ -83,10 +85,14 @@ EpLostChangesDetectorTest >> testDetectThreeChanges [
 	detector := EpLostChangesDetector newWithLog: logWithLostChanges.
 
 	detectedLostChanges := detector lostChanges.
-	detectedLostChanges do: [ :each | self assert: each content isEpClassChange ].
-
-	self assert: detectedLostChanges size equals: numberOfLostChanges.
 	self
-		assert: (detectedLostChanges collect: [ :each | each content behaviorAffectedName ]) asArray
+		assert: (detectedLostChanges anySatisfy: [ : omEntry | omEntry content isEpCategoryChange ])
+		description: 'It test that the class additions include a category registration'.
+	detectedLostClassChanges := detectedLostChanges reject: [ : omEntry | omEntry content isEpCategoryChange ].
+	detectedLostClassChanges do: [ :each | self assert: each content isEpClassChange ].
+
+	self assert: detectedLostClassChanges size equals: numberOfLostChanges.
+	self
+		assert: (detectedLostClassChanges collect: [ :each | each content behaviorAffectedName ]) asArray
 		equals: expectedLostClassNames
 ]

--- a/src/EpiceaBrowsers/EpApplyPreviewer.class.st
+++ b/src/EpiceaBrowsers/EpApplyPreviewer.class.st
@@ -99,6 +99,14 @@ EpApplyPreviewer >> visitCategoryAddition: aChange [
 ]
 
 { #category : #visitor }
+EpApplyPreviewer >> visitCategoryRegistration: aChange [
+
+	^ (self includesCategory: aChange categoryName)
+			ifTrue: [ #() ]
+			ifFalse: [ { aChange } ]
+]
+
+{ #category : #visitor }
 EpApplyPreviewer >> visitCategoryRemoval: aChange [
 
 	^ (self includesCategory: aChange categoryName)

--- a/src/EpiceaBrowsers/EpApplyVisitor.class.st
+++ b/src/EpiceaBrowsers/EpApplyVisitor.class.st
@@ -40,6 +40,13 @@ EpApplyVisitor >> visitCategoryAddition: aPackageCreated [
 ]
 
 { #category : #visitor }
+EpApplyVisitor >> visitCategoryRegistration: aPackageCreated [
+
+	self halt.
+	environment organization addCategory: aPackageCreated categoryName
+]
+
+{ #category : #visitor }
 EpApplyVisitor >> visitCategoryRemoval: aPackageRemoved [
 	environment organization removeCategory: aPackageRemoved categoryName
 ]

--- a/src/EpiceaBrowsers/EpApplyVisitor.class.st
+++ b/src/EpiceaBrowsers/EpApplyVisitor.class.st
@@ -42,8 +42,6 @@ EpApplyVisitor >> visitCategoryAddition: aPackageCreated [
 { #category : #visitor }
 EpApplyVisitor >> visitCategoryRegistration: aPackageCreated [
 
-	self halt.
-	environment organization addCategory: aPackageCreated categoryName
 ]
 
 { #category : #visitor }

--- a/src/EpiceaBrowsers/EpHasImpactVisitor.class.st
+++ b/src/EpiceaBrowsers/EpHasImpactVisitor.class.st
@@ -84,6 +84,12 @@ EpHasImpactVisitor >> visitCategoryAddition: aChange [
 ]
 
 { #category : #visitor }
+EpHasImpactVisitor >> visitCategoryRegistration: aChange [
+
+	^ (environment organization includesCategory: aChange categoryName) not
+]
+
+{ #category : #visitor }
 EpHasImpactVisitor >> visitCategoryRemoval: aChange [
 
 	^ environment organization includesCategory: aChange categoryName

--- a/src/EpiceaBrowsers/EpIconVisitor.class.st
+++ b/src/EpiceaBrowsers/EpIconVisitor.class.st
@@ -53,6 +53,12 @@ EpIconVisitor >> visitCategoryAddition: aCategoryChange [
 ]
 
 { #category : #visitor }
+EpIconVisitor >> visitCategoryRegistration: aCategoryChange [
+
+	^ self additionIcon
+]
+
+{ #category : #visitor }
 EpIconVisitor >> visitCategoryRemoval: aCategoryChange [
 	^ self removalIcon
 ]

--- a/src/EpiceaBrowsers/EpInverseVisitor.class.st
+++ b/src/EpiceaBrowsers/EpInverseVisitor.class.st
@@ -47,6 +47,14 @@ EpInverseVisitor >> visitCategoryAddition: aChange [
 ]
 
 { #category : #visitor }
+EpInverseVisitor >> visitCategoryRegistration: aChange [
+
+	^ EpCategoryRegistration
+			named: aChange categoryName
+			packageName: aChange affectedPackageName
+]
+
+{ #category : #visitor }
 EpInverseVisitor >> visitCategoryRemoval: aChange [
 
 	^ EpCategoryAddition

--- a/src/EpiceaBrowsers/EpMorphVisitor.class.st
+++ b/src/EpiceaBrowsers/EpMorphVisitor.class.st
@@ -110,6 +110,12 @@ EpMorphVisitor >> visitCategoryAddition: aCategoryChange [
 ]
 
 { #category : #visitor }
+EpMorphVisitor >> visitCategoryRegistration: aCategoryChange [
+
+	^ self displayCategory: aCategoryChange categoryName
+]
+
+{ #category : #visitor }
 EpMorphVisitor >> visitCategoryRemoval: aCategoryChange [
 
 	^ self displayCategory: aCategoryChange categoryName

--- a/src/EpiceaBrowsers/EpNewStateVisitor.class.st
+++ b/src/EpiceaBrowsers/EpNewStateVisitor.class.st
@@ -32,6 +32,12 @@ EpNewStateVisitor >> visitCategoryAddition: aClassCategoryCreatedChange [
 ]
 
 { #category : #visitor }
+EpNewStateVisitor >> visitCategoryRegistration: aClassCategoryCreatedChange [
+
+	^ aClassCategoryCreatedChange categoryName
+]
+
+{ #category : #visitor }
 EpNewStateVisitor >> visitCategoryRename: aClassCategoryRenamedChange [
 
 	^ aClassCategoryRenamedChange newCategoryName


### PR DESCRIPTION
This PR includes fixes for reported problems with Epicea not registering Category additions or renames, for example:

https://github.com/pharo-project/pharo/issues/12147
https://github.com/pharo-project/pharo/issues/12149
https://github.com/feenkcom/gtoolkit/issues/2952
https://github.com/pharo-project/pharo/issues/4014

This was due to Epicea wasn't aware of RPackage announcements when creating a package in the class hierarchy browser, or when renaming a package. Proposed changes includes a new Epicea class to receive and manage such notifications.
