### PR TITLE
Cleanup instance variables even when tear down fails

### DIFF
--- a/src/SUnit-Core/TestCase.class.st
+++ b/src/SUnit-Core/TestCase.class.st
@@ -844,11 +844,13 @@ TestCase >> run: aResult [
 
 { #category : #running }
 TestCase >> runCase [
-	self resources do: [:each | each availableFor: self].
-	[self setUp.
-	self performTest] ensure: [
-		self tearDown.
-		self cleanUpInstanceVariables]
+
+	self resources do: [ :each | each availableFor: self ].
+	[ [
+		self setUp.
+		self performTest ]
+			ensure: [ self tearDown ] ]
+			ensure: [ self cleanUpInstanceVariables ]
 ]
 
 { #category : #running }

--- a/src/SUnit-Tests/FailingTearDownTest.class.st
+++ b/src/SUnit-Tests/FailingTearDownTest.class.st
@@ -1,0 +1,68 @@
+"
+This class mixes two concerns (for conciseness).
+It tests that a test case failing in the tear down does indeed clean up its instance variables.
+It does so by making an instance of itself and testing it.
+
+The test can be executed with shouldFailTearDown true or false, with default false.
+If true, it will fail during tearDown.
+If false, it will not fail.
+"
+Class {
+	#name : #FailingTearDownTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'instanceVariable',
+		'shouldFailTearDown',
+		'assignedVariableToTestCleanup'
+	],
+	#category : #'SUnit-Tests-Core'
+}
+
+{ #category : #running }
+FailingTearDownTest >> failTearDown [
+
+	shouldFailTearDown := true
+]
+
+{ #category : #initialization }
+FailingTearDownTest >> initialize [
+
+	super initialize.
+	shouldFailTearDown := false
+]
+
+{ #category : #running }
+FailingTearDownTest >> isClean [
+
+	^ assignedVariableToTestCleanup isNil
+]
+
+{ #category : #running }
+FailingTearDownTest >> tearDown [
+
+	shouldFailTearDown ifTrue: [ self error: 'Failing to test the tearDown' ].
+	super tearDown
+]
+
+{ #category : #running }
+FailingTearDownTest >> testAssignToTestCleanup [
+
+	"
+	This test is not meant to assert something but to be used by #testFailingTearDown.
+	It will just assign a variable to the current test instance so we can test the further cleanup.
+	See the class comment for more details
+	"
+	assignedVariableToTestCleanup := 'some value'
+]
+
+{ #category : #running }
+FailingTearDownTest >> testFailingTearDown [
+
+	| testCase |
+	testCase := self class selector: #testAssignToTestCleanup.
+	testCase failTearDown.
+
+	testCase run.
+
+	self assert: testCase isClean
+]


### PR DESCRIPTION
Test case instance variables should be cleaned up even if the tear down fails.
