### PR TITLE
Re-introduce list morph shortcuts using keydown

### DIFF
--- a/src/Morphic-Widgets-List/SimpleHierarchicalListMorph.class.st
+++ b/src/Morphic-Widgets-List/SimpleHierarchicalListMorph.class.st
@@ -19,7 +19,8 @@ Class {
 		'lastSelection',
 		'lastKeystrokeTime',
 		'lastKeystrokes',
-		'searchedElement'
+		'searchedElement',
+		'keystrokeActionSelector'
 	],
 	#category : #'Morphic-Widgets-List'
 }
@@ -582,18 +583,28 @@ SimpleHierarchicalListMorph >> insertNewMorphs: morphList [
 ]
 
 { #category : #'event handling' }
+SimpleHierarchicalListMorph >> keyDown: event [
+
+	| aCharacter args |
+	event anyModifierKeyPressed ifFalse: [ ^ false ].
+	keystrokeActionSelector ifNil: [ ^ false ].
+	aCharacter := event keyCharacter.
+	(args := keystrokeActionSelector numArgs) = 1 ifTrue: [ 
+		^ model perform: keystrokeActionSelector with: aCharacter ].
+	args = 2 ifTrue: [ 
+		^ model perform: keystrokeActionSelector with: aCharacter with: self ].
+]
+
+{ #category : #'event handling' }
 SimpleHierarchicalListMorph >> keyStroke: event [
-
 	"Process potential command keys that are not handled by keymappings yet"
-	| aCharacter |
 
+	| aCharacter args |
 	aCharacter := event keyValue asCharacter.
-	event anyModifierKeyPressed
-		ifFalse: [ self basicKeyPressed: aCharacter.
-			^ false
-			].
-	( self scrollByKeyboard: event )
-		ifTrue: [ ^ true ].
+	event anyModifierKeyPressed ifFalse: [ 
+		self basicKeyPressed: aCharacter.
+		^ false ].
+	(self scrollByKeyboard: event) ifTrue: [ ^ true ].
 	^ false
 ]
 
@@ -603,6 +614,11 @@ SimpleHierarchicalListMorph >> keyboardFocusChange: aBoolean [
 	Update for focus feedback."
 	super keyboardFocusChange: aBoolean.
 	self focusChanged
+]
+
+{ #category : #accessing }
+SimpleHierarchicalListMorph >> keystrokeActionSelector: aString [ 
+	keystrokeActionSelector := aString
 ]
 
 { #category : #accessing }
@@ -822,6 +838,7 @@ SimpleHierarchicalListMorph >> on: anObject list: getListSel selected: getSelect
 	setSelectionSelector := setSelectionSel.
 	getMenuSelector := getMenuSel.
 	autoDeselect := true.
+	keystrokeActionSelector := keyActionSel.
 	self borderWidth: 1.
 	self list: self getList.
 ]

--- a/src/Morphic-Widgets-List/SimpleHierarchicalListMorph.class.st
+++ b/src/Morphic-Widgets-List/SimpleHierarchicalListMorph.class.st
@@ -599,7 +599,7 @@ SimpleHierarchicalListMorph >> keyDown: event [
 SimpleHierarchicalListMorph >> keyStroke: event [
 	"Process potential command keys that are not handled by keymappings yet"
 
-	| aCharacter args |
+	| aCharacter |
 	aCharacter := event keyValue asCharacter.
 	event anyModifierKeyPressed ifFalse: [ 
 		self basicKeyPressed: aCharacter.

--- a/src/Tool-Diff/PSMCPatchMorph.class.st
+++ b/src/Tool-Diff/PSMCPatchMorph.class.st
@@ -277,7 +277,8 @@ PSMCPatchMorph >> newChangeTreeMorph [
 		list: #changes
 		selected: #selectedChangeWrapper
 		changeSelected: #selectedChangeWrapper:)
-		getMenuSelector: #changesMenu:
+		getMenuSelector: #changesMenu:;
+		keystrokeActionSelector: #changeTreeKey:
 ]
 
 { #category : #private }


### PR DESCRIPTION
Previous refactorings lost the shortcuts in some old list morphs due to the impossibility to use keypress for them.
This PR adds them back as keydown events