### PR TITLE
Move #asNumber from AST-Core to Kernel (where it is also already tested)

### DIFF
--- a/src/AST-Core/String.extension.st
+++ b/src/AST-Core/String.extension.st
@@ -1,13 +1,5 @@
 Extension { #name : #String }
 
-{ #category : #'*AST-Core-Parser' }
-String >> asNumber [
-	"Answer the Number created by interpreting the receiver as the string
-	representation of a number."
-
-	^Number readFromString: self
-]
-
 { #category : #'*AST-Core' }
 String >> isValidSelector [
 	"check I could be a valid selector (name of method).

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -699,6 +699,13 @@ String >> asLowercase [
 ]
 
 { #category : #converting }
+String >> asNumber [
+	"Answer the Number created by interpreting the receiver as the string representation of a number."
+
+	^ Number readFromString: self
+]
+
+{ #category : #converting }
 String >> asOctetString [
 	"Convert the receiver into an octet string, if possible"
 	"(IE, I am a WideString containing only character with codePoints < 255, so all of them fit in a latin1-string)."


### PR DESCRIPTION
String>>asNumber is a core method and shouldn't be in AST-Core as reported by https://github.com/pharo-project/pharo/issues/12188
