### PR TITLE
Lint rule warning for Calypso to warn unconditional recursion

### DIFF
--- a/src/GeneralRules/ReUnconditionalRecursionRule.class.st
+++ b/src/GeneralRules/ReUnconditionalRecursionRule.class.st
@@ -7,6 +7,12 @@ Class {
 	#category : #'GeneralRules-Migrated'
 }
 
+{ #category : #testing }
+ReUnconditionalRecursionRule class >> checksMethod [
+
+	^ true
+]
+
 { #category : #accessing }
 ReUnconditionalRecursionRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"


### PR DESCRIPTION
Add a lint rule warning to Calypso that shows unconditional recursion when detected.
