### PR TITLE
Add Generator class>>onDo:

### DIFF
--- a/src/Collections-Streams-Tests/GeneratorTest.class.st
+++ b/src/Collections-Streams-Tests/GeneratorTest.class.st
@@ -131,6 +131,17 @@ GeneratorTest >> testNext [
 ]
 
 { #category : #tests }
+GeneratorTest >> testOnDo [
+
+	| generator |
+	generator := Generator onDo: [ :doBody | Integer primesUpTo: 10000000 do: doBody ].
+	
+	self assert: generator next equals: 2.
+	self assert: generator next equals: 3.
+	self assert: generator next equals: 5.
+]
+
+{ #category : #tests }
 GeneratorTest >> testPeek [
 	| generator |
 	generator := self numbersBetween: 1 and: 3.

--- a/src/Collections-Streams/Generator.class.st
+++ b/src/Collections-Streams/Generator.class.st
@@ -85,6 +85,18 @@ Generator class >> on: aBlock [
 	^ self basicNew initializeOn: aBlock
 ]
 
+{ #category : #enumerating }
+Generator class >> onDo: aBlock [
+
+	"Helper to tranform any `do:`-like method into a generator."
+	
+	"|generator|
+	generator := Generator onDo: [ :doBody | Integer primesUpTo: 10000000 do: doBody ].
+	(generator next: 5) asArray >>> #(2 3 5 7 11)"
+		
+	^ self on: [ :generator | aBlock value: [ :arg | generator yield: arg ] ]
+]
+
 { #category : #examples }
 Generator class >> somePrimes [
 	"self somePrimes" 


### PR DESCRIPTION
Generators in Pharo are nice, and very powerful.
But transforming a callback-based `do:`-like method into a generator is not as straightforward as it could be.

This PR proposes the class sside `onDo:` method to ease this transformation.

E.g. you have a callback based do-like method that values a block on each element.

```st
Integer primesUpTo: 10000000 do: [ :each| each traceCr ]
```

Now, processing the elements as a stream of elements is as easy as:

```st
|generator|
generator := Generator onDo: [ :block | Integer primesUpTo: 10000000 do: block ].
(generator next: 5) asArray >>> #(2 3 5 7 11)
```

For comparison, the classic `on:` approach is:

```st
|generator|
generator := Generator on: [ :gen | Integer primesUpTo: 10000000 do: [ :prime| gen yield: prime]].
(generator next: 5) asArray >>> #(2 3 5 7 11)
```