### PR TITLE
12416-Fixing-Classes-Reported-by-NoUnusedVariablesLeftTest

### DIFF
--- a/src/SUnit-Tests/FailingTearDownTest.class.st
+++ b/src/SUnit-Tests/FailingTearDownTest.class.st
@@ -11,7 +11,6 @@ Class {
 	#name : #FailingTearDownTest,
 	#superclass : #TestCase,
 	#instVars : [
-		'instanceVariable',
 		'shouldFailTearDown',
 		'assignedVariableToTestCleanup'
 	],


### PR DESCRIPTION
Removing unused instance variable.
Fix #12416 