### PR TITLE
Fix for "Browse this version in Calypso" Error after clicking an unloaded package

### DIFF
--- a/src/Tool-DependencyAnalyser-Tests/DAMessageSendAnalyzerTest.class.st
+++ b/src/Tool-DependencyAnalyser-Tests/DAMessageSendAnalyzerTest.class.st
@@ -14,6 +14,16 @@ DAMessageSendAnalyzerTest >> setUp [
 ]
 
 { #category : #tests }
+DAMessageSendAnalyzerTest >> testRPackage [
+
+	self assert: (analyzer rPackage isKindOf: RPackage).
+	analyzer := DAMessageSendAnalyzer on: 'Unloaded-Dummy-Package'.
+	self
+		assert: (analyzer rPackage isKindOf: RPackage)
+		description: 'It test that rPackage still answer a RPackage even when the analyzer was instantiated with an unexisting or unloaded package'
+]
+
+{ #category : #tests }
 DAMessageSendAnalyzerTest >> testShouldFindDependencyWhenUnimplementedCalls [
 	self 
 		assert: analyzer missingMethods size 

--- a/src/Tool-DependencyAnalyser/DAMessageSendAnalyzer.class.st
+++ b/src/Tool-DependencyAnalyser/DAMessageSendAnalyzer.class.st
@@ -130,7 +130,11 @@ DAMessageSendAnalyzer >> possibleDeadCode [
 
 { #category : #accessing }
 DAMessageSendAnalyzer >> rPackage [
-	^ packageAnalysis rPackageSet packages detect: [ :each | each packageName = self packageName ]
+	"Answer a <RPackage> matching the receiver's package name. If we are browsing an unloaded package, then answer a virtual RPackage so the message send analyzer could preserve its behavior with loaded packages in #manuallyResolvedDependencies"
+
+	^ packageAnalysis rPackageSet packages
+		ifNotEmpty: [ : rPackages | rPackages detect: [ :each | each packageName = self packageName ] ]
+		ifEmpty: [ RPackage named: 'Virtual' , self packageName ]
 ]
 
 { #category : #computing }


### PR DESCRIPTION
A NotFound exception is raised from the DAMessageSendAnalyzer after clicking a package in the Calypso browser on an unloaded package. This was found when trying to reproduce #9684.

See https://github.com/pharo-project/pharo/issues/12412 for video to reproduce. This commit preserves #rPackage behavior by answering a virtual RPackage so Calypso does not break trying to analyze dependencies of an unloaded package.