### PR TITLE
Removed duplicated line form RubSmalltalkEditor>>tallySelection

### DIFF
--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -1183,7 +1183,6 @@ RubSmalltalkEditor >> tallySelection [
 	"Treat the current selection as an expression; evaluate and tally it."
 
 	self lineSelectAndEmptyCheck: [ ^ self ].
-	self lineSelectAndEmptyCheck: [ ^ self ].
 	self tally: self selectionAsStream
 ]
 


### PR DESCRIPTION
This PR just removes the dupicated line from the method.