### PR TITLE
Fix conflict between formatter and rules: spaces before new lines

### DIFF
--- a/src/EnlumineurFormatter-Tests/EFAssignmentExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFAssignmentExpressionTest.class.st
@@ -117,7 +117,7 @@ EFAssignmentExpressionTest >> testExtraIndentationWhenMultiline2 [
 	self
 		assert: source
 		equals:
-'1 to: 4 do: [ 
+'1 to: 4 do: [
 	a := p2 - x - p0 - x * ( p3 - y - p0 - y )
 	     - ( p3 - x - p0 - x * ( p2 - y - p0 - y ) ) * b0
 	]'

--- a/src/EnlumineurFormatter-Tests/EFBlockExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFBlockExpressionTest.class.st
@@ -298,8 +298,7 @@ EFBlockExpressionTest >> numberOfSpaceChangedAfterIndentCharacterConfiguration [
 		newLineAfterCascade:true;
 		newLineBeforeFirstCascade: true;
 		numberOfSpacesInIndent: 1;
-		indentStyle: #space;
-		numberOfSpacesInIndent: 2;
+		indentStyle: #tabulation;
 		indentExtraSpaces:0
 ]
 
@@ -410,6 +409,7 @@ EFBlockExpressionTest >> tabIndentIsnotAffectedConfiguration [
 
 { #category : #tests }
 EFBlockExpressionTest >> testArgumentIsFormated [
+
 	self validate: ':i|i' isFormattedAs: ' :i | i '
 ]
 
@@ -498,7 +498,7 @@ i to: 10 do: [ :j |
 
 { #category : #tests }
 EFBlockExpressionTest >> testLongMultipleArguments [
-	self skip.
+
 	self 
 		validate: ' :superlong :longlong :long | Transcript show: longlong ; show: long'
 		isFormattedAs: 
@@ -511,12 +511,15 @@ Transcript
 
 { #category : #tests }
 EFBlockExpressionTest >> testLongSingleArgument [
-	self skip.
+
 	self 
 		validate: ' [:superlonglonglong | Transcript show:i; show: j]'
 		isFormattedAs: 
-'[ :superlonglonglong | 
-	Transcript show:i; show: j]'
+' 
+[ :superlonglonglong | 
+Transcript
+	show: i;
+	show: j ] '
 		with: #numberOfSpaceChangedAfterIndentCharacterConfiguration
 ]
 
@@ -615,7 +618,7 @@ EFBlockExpressionTest >> testNumberOfSpaces [
 EFBlockExpressionTest >> testOneSpaceIndent [
 	
 	self validate: ':i | i to: 10 do: [:j | Transcript show:i; show: j]'
-		isFormattedAs: ' :i | 
+	isFormattedAs: ' :i | 
 i to: 10 do: [ :j | 
  Transcript
   show: i;
@@ -667,7 +670,7 @@ tooLongStatement ' with: #tooLongStatementConfiguration
 ]
 
 { #category : #tests }
-EFBlockExpressionTest >> testnumberOfSpaceChangedAfterIndentCharacter [
+EFBlockExpressionTest >> testTwoSpaceIndent [
 
 	self validate: ':i | i to: 10 do: [:j | Transcript show:i; show: j]'
 	isFormattedAs: ' :i | 
@@ -675,7 +678,7 @@ i to: 10 do: [ :j |
   Transcript
     show: i;
     show: j ] '
-	with: #numberOfSpaceChangedAfterIndentCharacterConfiguration
+	with: #twoSpacesIndentConfiguration
 ]
 
 { #category : #configurations }
@@ -698,6 +701,12 @@ EFBlockExpressionTest >> tooLongStatementConfiguration [
 		formatCommentCloseToStatements:true;
 		maxLineLength:10;
 		indentExtraSpaces: 0
+]
+
+{ #category : #configurations }
+EFBlockExpressionTest >> twoSpacesIndentConfiguration [
+
+	^ self oneSpaceIndentConfiguration numberOfSpacesInIndent: 2
 ]
 
 { #category : #helpers }

--- a/src/EnlumineurFormatter-Tests/EFBlockExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFBlockExpressionTest.class.st
@@ -125,18 +125,6 @@ EFBlockExpressionTest >> dontFormatCommentWithStatementConfiguration [
 ]
 
 { #category : #configurations }
-EFBlockExpressionTest >> example: col [
-
-	| p2 x p0 p3 y b0 a |
-	col do: [
-		self doSomethingExceptional doSomethingElse doSomethingElseString ].
-
-	1 to: 4 do: [
-		a := p2 - x - p0 - x * (p3 - y - p0 - y)
-		     - (p3 - x - p0 - x * (p2 - y - p0 - y)) * b0 ]
-]
-
-{ #category : #configurations }
 EFBlockExpressionTest >> formatCommentWithStatementConfiguration [
 
 	^ self contextClass basicNew

--- a/src/EnlumineurFormatter-Tests/EFBlockExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFBlockExpressionTest.class.st
@@ -125,6 +125,18 @@ EFBlockExpressionTest >> dontFormatCommentWithStatementConfiguration [
 ]
 
 { #category : #configurations }
+EFBlockExpressionTest >> example: col [
+
+	| p2 x p0 p3 y b0 a |
+	col do: [
+		self doSomethingExceptional doSomethingElse doSomethingElseString ].
+
+	1 to: 4 do: [
+		a := p2 - x - p0 - x * (p3 - y - p0 - y)
+		     - (p3 - x - p0 - x * (p2 - y - p0 - y)) * b0 ]
+]
+
+{ #category : #configurations }
 EFBlockExpressionTest >> formatCommentWithStatementConfiguration [
 
 	^ self contextClass basicNew
@@ -434,9 +446,9 @@ EFBlockExpressionTest >> testArgumentsComments [
 EFBlockExpressionTest >> testDoNotKeepBlockInMessageConfiguration [
 	
 	self validate: ':i | i to: 10 do: [:j | Transcript show:i. Transcript show: j]'
-		isFormattedAs: ' :i | 
+		isFormattedAs: ' :i |
 i to: 10 do:
-	[ :j | 
+	[ :j |
 	Transcript show: i.
 	Transcript show: j ] '
 	with: #doNotKeepBlockInMessageConfiguration.
@@ -447,7 +459,7 @@ EFBlockExpressionTest >> testDontFormatCommentWithStatement [
 	self
 		validate: '1 factorial. "aComment" 2 factorial'
 		isFormattedAs:
-			' 
+'
 1 factorial "aComment".
 2 factorial '
 		with: #dontFormatCommentWithStatementConfiguration
@@ -467,7 +479,7 @@ EFBlockExpressionTest >> testFormatBody [
 	self
 		validate: ' [1]. [ a:=1] '
 		isFormattedAs:
-			' 
+'
 [ 1 ].
 [ a := 1 ] '
 ]
@@ -477,7 +489,7 @@ EFBlockExpressionTest >> testFormatCommentWithStatement [
 	self
 		validate: '1 factorial. "aComment" 2 factorial'
 		isFormattedAs:
-			' 
+'
 1 factorial. "aComment"
 2 factorial '
 		with: #formatCommentWithStatementConfiguration
@@ -488,8 +500,8 @@ EFBlockExpressionTest >> testFourSpaceIndent [
 	self
 		validate: ':i | i to: 10 do: [:j | Transcript show:i; show: j]'
 		isFormattedAs:
-' :i | 
-i to: 10 do: [ :j | 
+' :i |
+i to: 10 do: [ :j |
     Transcript
         show: i;
         show: j ] '
@@ -502,7 +514,7 @@ EFBlockExpressionTest >> testLongMultipleArguments [
 	self 
 		validate: ' :superlong :longlong :long | Transcript show: longlong ; show: long'
 		isFormattedAs: 
-' :superlong :longlong :long | 
+' :superlong :longlong :long |
 Transcript
 	show: longlong;
 	show: long '
@@ -515,8 +527,8 @@ EFBlockExpressionTest >> testLongSingleArgument [
 	self 
 		validate: ' [:superlonglonglong | Transcript show:i; show: j]'
 		isFormattedAs: 
-' 
-[ :superlonglonglong | 
+'
+[ :superlonglonglong |
 Transcript
 	show: i;
 	show: j ] '
@@ -529,7 +541,7 @@ EFBlockExpressionTest >> testMultiline [
 	self 
 		validate: '1+3. 6 factorial '
 		isFormattedAs: 
-' 
+'
 1 + 3.
 6 factorial '
 ]
@@ -540,7 +552,7 @@ EFBlockExpressionTest >> testNewLineAfterFirstBracketWhenMultilineWithArguments 
 	self 
 		validate: ':i | i+3. i factorial '
 		isFormattedAs: 
-' :i | 
+' :i |
 i + 3.
 i factorial '
 ]
@@ -551,7 +563,7 @@ EFBlockExpressionTest >> testNewLineAfterFirstBracketWhenMultilineWithTemporarie
 	self 
 		validate: '| tmp | 1+3. 6 factorial '
 		isFormattedAs: 
-' 
+'
 | tmp |
 1 + 3.
 6 factorial '
@@ -564,7 +576,7 @@ EFBlockExpressionTest >> testNewLineBeforeEndBrackets [
 	self 
 		validate:'3. 4'  
 		isFormattedAs:
-' 
+'
 3.
 4
 '  		with: #newLineBeforeEndBracketConfiguration.
@@ -598,7 +610,7 @@ EFBlockExpressionTest >> testNoNewLineBeforeEndBrackets [
 	self 
 		validate: '3. 4'  
 		isFormattedAs:
-' 
+'
 3.
 4 '  with: #noNewLineBeforeEndBracketConfiguration.
 ]
@@ -618,8 +630,8 @@ EFBlockExpressionTest >> testNumberOfSpaces [
 EFBlockExpressionTest >> testOneSpaceIndent [
 	
 	self validate: ':i | i to: 10 do: [:j | Transcript show:i; show: j]'
-	isFormattedAs: ' :i | 
-i to: 10 do: [ :j | 
+	isFormattedAs: ' :i |
+i to: 10 do: [ :j |
  Transcript
   show: i;
   show: j ] '
@@ -633,10 +645,30 @@ EFBlockExpressionTest >> testSpace [
 ]
 
 { #category : #tests }
+EFBlockExpressionTest >> testSpaceAtTheEndOfFirstLineWhenMultiline [
+
+	self
+		validate: 'self doSomethingExceptional doSomethingExceptional '
+		isFormattedAs: 
+'
+self doSomethingExceptional doSomethingExceptional '
+]
+
+{ #category : #tests }
+EFBlockExpressionTest >> testSpaceAtTheEndOfFirstLineWhenMultilineWithArguments [
+
+	self
+		validate: ':x | x doSomethingExceptional doSomethingExceptional '
+		isFormattedAs: 
+' :x |
+x doSomethingExceptional doSomethingExceptional '
+]
+
+{ #category : #tests }
 EFBlockExpressionTest >> testTabIndent [
 	self validate: ':i | i to: 10 do: [:j | Transcript show:i; show: j]'
-	isFormattedAs: ' :i | 
-i to: 10 do: [ :j | 
+	isFormattedAs: ' :i |
+i to: 10 do: [ :j |
 	Transcript
 		show: i;
 		show: j ] '
@@ -647,8 +679,8 @@ i to: 10 do: [ :j |
 EFBlockExpressionTest >> testTabIndentIsNotAffectedByNumberOfSpace [
 
 	self validate: ':i | i to: 10 do: [:j | Transcript show:i; show: j]'
-	 isFormattedAs: ' :i | 
-i to: 10 do: [ :j | 
+	 isFormattedAs: ' :i |
+i to: 10 do: [ :j |
 	Transcript
 		show: i;
 		show: j ] '
@@ -658,14 +690,14 @@ i to: 10 do: [ :j |
 { #category : #tests }
 EFBlockExpressionTest >> testTooLongBlockBody [
 	self validate: 'tooLongStatement' isFormattedAs:
-' 
+'
 tooLongStatement ' with: #tooLongStatementConfiguration
 ]
 
 { #category : #tests }
 EFBlockExpressionTest >> testTooLongBlockBodyWithArgument [
 	self validate: ':i | tooLongStatement' isFormattedAs:
-' :i | 
+' :i |
 tooLongStatement ' with: #tooLongStatementConfiguration
 ]
 
@@ -673,8 +705,8 @@ tooLongStatement ' with: #tooLongStatementConfiguration
 EFBlockExpressionTest >> testTwoSpaceIndent [
 
 	self validate: ':i | i to: 10 do: [:j | Transcript show:i; show: j]'
-	isFormattedAs: ' :i | 
-i to: 10 do: [ :j | 
+	isFormattedAs: ' :i |
+i to: 10 do: [ :j |
   Transcript
     show: i;
     show: j ] '

--- a/src/EnlumineurFormatter-Tests/EFCascadeExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFCascadeExpressionTest.class.st
@@ -230,7 +230,7 @@ EFCascadeExpressionTest >> testFormatMultilineMessage [
 		equals:
 '1
 	between: 2 and: 5;
-	to: 4 do: [ :each | 
+	to: 4 do: [ :each |
 		each factorial.
 		each + 1 ]'
 ]

--- a/src/EnlumineurFormatter-Tests/EFMessageExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFMessageExpressionTest.class.st
@@ -502,7 +502,7 @@ EFMessageExpressionTest >> testBlockParameterOnTheMethodLineWhenMultiline [
 	self
 		assert: source
 		equals:
-'1 to: 10 do: [ :i | 
+'1 to: 10 do: [ :i |
 	Transcript show: i.
 	Transcript cr.
 	Transcript cr ]'
@@ -516,7 +516,7 @@ EFMessageExpressionTest >> testBlockParameterWhenTheLineWillBeTooLong [
 	self
 		assert: source
 		equals: 
-'aMessage take: [ :i | 
+'aMessage take: [ :i |
 	i factorial ]'
 ]
 
@@ -528,8 +528,8 @@ EFMessageExpressionTest >> testBlockParameterWhenTheLineWillBeTooLong2 [
 	self
 		assert: source
 		equals:
-'aMessage take: [ 
-	:iiiiiiiiiiiiiii | 
+'aMessage take: [
+	:iiiiiiiiiiiiiii |
 	i factorial ]'
 ]
 
@@ -552,7 +552,7 @@ EFMessageExpressionTest >> testDontKeepBlockInMessage [
 		assert: source
 		equals:
 'aBoolean ifTrue:
-	[ :i | 
+	[ :i |
 	i := i factorial.
 	Transcript show: i ]'
 ]
@@ -591,7 +591,7 @@ EFMessageExpressionTest >> testExtraIndentInParentheses [
 	configurationSelector := #blockAndParenthesesInMessageConfiguration.
 	source := self formatExpression: '( [ :i | 	i factorial; +3 ] value: 15 )*3'.
 	self assert: source equals:
-'( [ :i | 
+'( [ :i |
   i
 	  factorial;
 	  + 3 ] value: 15 ) * 3'
@@ -603,7 +603,7 @@ EFMessageExpressionTest >> testExtraIndentInParenthesesWhenThreeSpacesInsidePare
 	configurationSelector := #extraIndentWithThreeSpacesInsideParenthesesConfiguration.
 	source := self formatExpression:'( [ :i | 	i factorial; +3 ] value: 15 )*3'.
 	self assert: source equals:
-'(   [ :i | 
+'(   [ :i |
     i
 	    factorial;
 	    + 3 ] value: 15   ) * 3'
@@ -647,7 +647,7 @@ EFMessageExpressionTest >> testKeepBlockInMessage [
 	self
 		assert: source
 		equals:
-'aBoolean ifTrue: [ :i | 
+'aBoolean ifTrue: [ :i |
 	i := i factorial.
 	Transcript show: i ]'
 ]
@@ -661,7 +661,7 @@ EFMessageExpressionTest >> testKeepBlockInMessageMutlilineNewLine [
 	self
 		assert: source
 		equals:
-'aBoolean ifTrue: [ 
+'aBoolean ifTrue: [
 	Transcript cr.
 	Transcript cr.
 	Transcript cr ]'
@@ -678,7 +678,7 @@ EFMessageExpressionTest >> testKeepBlockInMessageMutlilineSpace [
 	self
 		assert: source
 		equals:
-'aBoolean ifTrue: [ 
+'aBoolean ifTrue: [
 	12 factorial.
 	12 factorial.
 	3 factorial ]'
@@ -704,7 +704,7 @@ EFMessageExpressionTest >> testKeepBlockInMessageNotMutlilineNewLine [
 	self
 		assert: source
 		equals:
-			'aBoolean ifTrue: [ 
+			'aBoolean ifTrue: [
 	LongLongLongExpression ]'
 ]
 
@@ -796,7 +796,7 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine [
 	configurationSelector := #blockAndCascadeInMessageConfiguration.
 	source := self formatExpression: '1 to: 100 by: 2 do: [ :i | transcript show: i;cr; cr]'.
 	self assert: source equals:
-'1 to: 100 by: 2 do: [ :i | 
+'1 to: 100 by: 2 do: [ :i |
 	transcript
 		show: i;
 		cr;
@@ -815,7 +815,7 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine10 [
 	bar3: 5.'.
 	self assert: source equals:
 'foo
-	bar: [ 
+	bar: [
 		1 + 2.
 		2 + 2 ]
 	bar3: 5'
@@ -826,11 +826,11 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine11 [
 	| source |
 	configurationSelector := #blockAndCascadeInMessageConfiguration.
 	source := self formatExpression:
-'foo bar3: 5 bar2: [ 
+'foo bar3: 5 bar2: [
 	1 + 1.
 	2 + 2 ]'.
 	self assert: source equals:
-'foo bar3: 5 bar2: [ 
+'foo bar3: 5 bar2: [
 	1 + 1.
 	2 + 2 ]'
 ]
@@ -849,7 +849,7 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine12 [
 	self assert: source equals:
 'foo
 	bar3: 5
-	bar: [ 
+	bar: [
 		1 + 2.
 		2 + 2 ]
 	bar3: 5'
@@ -860,11 +860,11 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine13 [
 	| source |
 	configurationSelector := #blockAndCascadeInMessageConfiguration.
 	source := self formatExpression:
-'foo bar3: 5 bar3: 5 bar2: [ 
+'foo bar3: 5 bar3: 5 bar2: [
 	1 + 1.
 	2 + 2 ]'.
 	self assert: source equals:
-'foo bar3: 5 bar3: 5 bar2: [ 
+'foo bar3: 5 bar3: 5 bar2: [
 	1 + 1.
 	2 + 2 ]'
 ]
@@ -875,14 +875,14 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine14 [
 	configurationSelector := #blockAndCascadeInMessageConfiguration.
 	source := self formatExpression:
 'foo
-	bar: [ 
+	bar: [
 		1 + 2.
 		2 + 2 ]
 	bar3: 5 
 	bar3: 5'.
 	self assert: source equals:
 'foo
-	bar: [ 
+	bar: [
 		1 + 2.
 		2 + 2 ]
 	bar3: 5
@@ -900,10 +900,10 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine15 [
 		around: [ 1. 2 ]'.
 	self assert: source equals:
 'self
-	indent: (self do: [ 
+	indent: (self do: [
 			 1.
 			 2 ])
-	around: [ 
+	around: [
 		1.
 		2 ]'
 ]
@@ -916,7 +916,7 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine2 [
 	self assert: source equals:
 'aBoolean
 	ifTrue: [ ^1 ]
-	ifFalse: [ 
+	ifFalse: [
 		tmp := tmp + a.
 		^tmp ]'
 ]
@@ -928,7 +928,7 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine3 [
 	source := self formatExpression: 'aBoolean ifTrue:[ tmp := tmp + a. ^ tmp] ifFalse:[ ^ 0 ]'.
 	self assert: source equals:
 'aBoolean
-	ifTrue: [ 
+	ifTrue: [
 		tmp := tmp + a.
 		^ tmp ]
 	ifFalse: [ ^ 0 ]'
@@ -941,10 +941,10 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine4 [
 	source := self formatExpression: 'aBoolean ifTrue:[ tmp := tmp + a. ^ tmp] ifFalse:[ tmp := tmp + a. ^tmp]'.
 	self assert: source equals:
 'aBoolean
-	ifTrue: [ 
+	ifTrue: [
 		tmp := tmp + a.
 		^ tmp ]
-	ifFalse: [ 
+	ifFalse: [
 		tmp := tmp + a.
 		^ tmp ]'
 ]
@@ -955,7 +955,7 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine5 [
 	configurationSelector := #blockAndCascadeInMessageConfiguration.
 	source := self formatExpression: 'aBoolean ifTrue:[ ^ 1] ifFalse:[ tmp := tmp + a. ^tmp]'.
 	self assert: source equals:
-'aBoolean ifTrue: [ ^ 1 ] ifFalse: [ 
+'aBoolean ifTrue: [ ^ 1 ] ifFalse: [
 	tmp := tmp + a.
 	^ tmp ]'
 ]
@@ -975,10 +975,10 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine6 [
 	bar3: 5'.
 	self assert: source equals:
 'foo
-	bar: [ 
+	bar: [
 		1 + 2.
 		2 + 2 ]
-	bar2: [ 
+	bar2: [
 		1 + 1.
 		2 + 2 ]
 	bar3: 5'
@@ -1000,10 +1000,10 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine7 [
 	self assert: source equals:
 'foo
 	bar3: 5
-	bar: [ 
+	bar: [
 		1 + 2.
 		2 + 2 ]
-	bar2: [ 
+	bar2: [
 		1 + 1.
 		2 + 2 ]'
 ]
@@ -1023,11 +1023,11 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine8 [
 		2 + 2 ]'.
 	self assert: source equals:
 'foo
-	bar: [ 
+	bar: [
 		1 + 2.
 		2 + 2 ]
 	bar3: 5
-	bar2: [ 
+	bar2: [
 		1 + 1.
 		2 + 2 ]'.
 ]
@@ -1049,10 +1049,10 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine9 [
 	self assert: source equals:
 'foo
 	bar3: 5
-	bar: [ 
+	bar: [
 		1 + 2.
 		2 + 2 ]
-	bar2: [ 
+	bar2: [
 		1 + 1.
 		2 + 2 ]
 	bar3: 5'
@@ -1140,7 +1140,7 @@ EFMessageExpressionTest >> testNewLineBeforeStatementsWhenMultilineBlock [
 	self
 		assert: source
 		equals:
-'x = 0 ifFalse: [ 
+'x = 0 ifFalse: [
 	tan := y asFloat / x asFloat.
 	theta := tan arcCos ]'
 ]
@@ -1184,7 +1184,7 @@ EFMessageExpressionTest >> testNoNewLineBetweenVariableAndIfTrue [
 				  gammaTable: gammaTable
 				  ungammaTable: gammaInverseTable ]'.
 	self assert: source equals: 
-'x ifTrue: [ 
+'x ifTrue: [
 	aBitBlt
 		copyBitsColor: foreColorVal
 		alpha: foreColorAlpha

--- a/src/EnlumineurFormatter-Tests/EFMethodExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFMethodExpressionTest.class.st
@@ -335,7 +335,7 @@ EFMethodExpressionTest >> testBigMethod [
 	<pragma>
 	| tmp |
 	tmp := 1.
-	tmp to: 10 do: [:i | 
+	tmp to: 10 do: [:i |
 		Transcript
 			show: i;
 			cr;
@@ -407,7 +407,7 @@ EFMethodExpressionTest >> testMethodWithMessageArgument [
 	source := self formatter format: expr.
 	self assert: source equals:
 'aMethod
-	1 to: 10 do: [:i | 
+	1 to: 10 do: [:i |
 		Transcript
 			show: i;
 			cr;

--- a/src/EnlumineurFormatter-Tests/EFSequenceExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFSequenceExpressionTest.class.st
@@ -379,7 +379,7 @@ EFSequenceExpressionTest >> testNoNewLineBetweenVariableAndIfTrue [
 			gammaTable: gammaTable
 			ungammaTable: gammaInverseTable ]		
 "
-x ifTrue: [ 
+x ifTrue: [
 	aBitBlt
 		copyBitsColor: foreColorVal
 		alpha: foreColorAlpha

--- a/src/EnlumineurFormatter-Tests/EFTemporariesExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFTemporariesExpressionTest.class.st
@@ -130,7 +130,7 @@ EFTemporariesExpressionTest >> testCommentNotBasicFormat [
 	self
 		assert: source
 		equals:
-			'| d "comment     
+			'| d "comment
 " e |'
 ]
 

--- a/src/EnlumineurFormatter/EFFormatter.class.st
+++ b/src/EnlumineurFormatter/EFFormatter.class.st
@@ -1038,6 +1038,13 @@ EFFormatter >> characterSeparatorMethodSignatureFor: aMethodNode [
 			ifFalse: [ self space ]
 ]
 
+{ #category : #private }
+EFFormatter >> cleanSpacesAtTheEnd [
+
+	[ codeStream peekLast = Character space ] whileTrue: [
+		codeStream back ]
+]
+
 { #category : #accessing }
 EFFormatter >> codeStream [
 	^ codeStream
@@ -1151,23 +1158,23 @@ EFFormatter >> formatBlock2: aBlockNode [
 
 { #category : #'private - formatting' }
 EFFormatter >> formatBlock: aBlockNode [
- 	" see formatBlock2: for a possible alternate and faster definition."
-	
+	" see formatBlock2: for a possible alternate and faster definition."
+
 	| isMultiline |
 	isMultiline := self willBeMultiline: aBlockNode body.
-  
+
 	codeStream nextPutAll: self spacesInsideBlocksString.
-	
+
 	self formatBlockArgumentsFor: aBlockNode.
 	self formatBlockCommentFor: aBlockNode.
-	((isMultiline or: [ self isLineTooLongWithNode: aBlockNode body ]) 
-		and: [ self shouldPassNewLineAfterHeadOfBlock: aBlockNode ]) 
-			ifTrue: [ self newLine ].
-  
+	((isMultiline or: [ self isLineTooLongWithNode: aBlockNode body ])
+		 and: [ self shouldPassNewLineAfterHeadOfBlock: aBlockNode ])
+		ifTrue: [ self newLine ].
+
 	self visitSequenceNode: aBlockNode body.
-	
-	(self lineUpBlockBrackets and: [ isMultiline ]) 
-		ifTrue: [ self newLine ] 
+
+	(self lineUpBlockBrackets and: [ isMultiline ])
+		ifTrue: [ self newLine ]
 		ifFalse: [ codeStream nextPutAll: self spacesInsideBlocksString ]
 ]
 
@@ -1176,19 +1183,16 @@ EFFormatter >> formatBlockArgumentsFor: aBlockNode [
 
 	| onAnotherLine args |
 	args := aBlockNode arguments.
-	args isEmpty
-		ifTrue: [ ^ self ].
-	onAnotherLine := self areArgumentsTooLong: args. 
-	args
-		do: [ :each | 
-			onAnotherLine ifTrue: [self newLine ].
-			codeStream nextPut: $:.
-			self visitVariableNode: each.
-			self formatCommentCloseToStatements
-				ifTrue:
-					[ self spaceAndFormatComments: each ].
-			self space ].
-	codeStream nextPutAll: '| '.
+	args isEmpty ifTrue: [ ^ self ].
+	onAnotherLine := self areArgumentsTooLong: args.
+	args do: [ :each |
+		onAnotherLine ifTrue: [ self newLine ].
+		codeStream nextPut: $:.
+		self visitVariableNode: each.
+		self formatCommentCloseToStatements ifTrue: [
+			self spaceAndFormatComments: each ].
+		self space ].
+	codeStream nextPutAll: '| '
 ]
 
 { #category : #'private - formatting' }
@@ -1489,7 +1493,7 @@ EFFormatter >> initialize [
 { #category : #initialization }
 EFFormatter >> initializeCodeStream [
 
-  codeStream := WriteStream on: (String new: 256)
+  codeStream := ReadWriteStream on: (String new: 256)
 ]
 
 { #category : #initialization }
@@ -1753,9 +1757,8 @@ EFFormatter >> newLineBeforeFirstKeyword: aBoolean [
 { #category : #private }
 EFFormatter >> newLines: anInteger [
 	"Add a number of new lines and in addition store the position of the latest new lines in the stream so that latter we can compute the current line length."
-	
-	anInteger + self indentString size = 0
-		ifTrue: [ codeStream space ].
+
+	anInteger > 0 ifTrue: [ self cleanSpacesAtTheEnd ].
 	anInteger timesRepeat: [ codeStream cr ].
 	lineStart := codeStream position.
 	self indentTimesRepeat: self indent
@@ -1939,7 +1942,7 @@ EFFormatter >> privateFormatMethodPatternMultiLineFor: aMethodNode [
 	codeStream nextPutAll: selectors first.
 	self space.
 	self visitNode: arguments first.
-	codeStream nextPut: Character cr.
+	self newLine.
 	self
 		with: selectors allButFirst
 		and: arguments allButFirst

--- a/src/EnlumineurFormatter/EFFormatter.class.st
+++ b/src/EnlumineurFormatter/EFFormatter.class.st
@@ -1952,7 +1952,8 @@ EFFormatter >> privateFormatMethodPatternMultiLineFor: aMethodNode [
 			self space.
 			self visitNode: arg ]
 		separatedBy: [ self characterSeparatorMethodSignatureFor: aMethodNode].
-	self newLines: 1
+	self newLine
+
 ]
 
 { #category : #utilities }


### PR DESCRIPTION
After discussion in https://github.com/pharo-project/pharo/pull/12387 between @jordanmontt and @astares we change the formatter to not enter in collision with the rule.

Beyond the rules that any of us want in his code, I think that is important that the tools inside the environment won't conflict between them (ie. the formatter should not break other systems like linter, compiler, highlighter, etc ). 
Should be nice to maintain this equilibrium, if you change something in the system keep in mind that should be in harmony with the rest of the components.

> PR made in a Pharo Sprint with @hernanmd 
