### PR TITLE
Fix #3067: Float>>#closeTo: does not use Float>>epsilon as default precision

### DIFF
--- a/src/Kernel-Tests-Extended/FloatTest.extension.st
+++ b/src/Kernel-Tests-Extended/FloatTest.extension.st
@@ -123,56 +123,173 @@ FloatTest >> testBinaryLiteralString [
 
 	self assert: 0.0 binaryLiteralString equals: '0.0'.
 	self assert: 0.0 negated binaryLiteralString equals: '-0.0'.
-	self assert: Float infinity binaryLiteralString equals: 'Float infinity'.
-	self assert: Float infinity negated binaryLiteralString equals: 'Float infinity negated'.
+	self
+		assert: Float infinity binaryLiteralString
+		equals: 'Float infinity'.
+	self
+		assert: Float infinity negated binaryLiteralString
+		equals: 'Float infinity negated'.
 	self assert: Float nan binaryLiteralString equals: 'Float nan'.
 
-	self assert: Float fminDenormalized binaryLiteralString equals: '2r0.0000000000000000000000000000000000000000000000000001e-1022'.
-	self assert: Float fminNormalized binaryLiteralString equals: '2r1.0000000000000000000000000000000000000000000000000000e-1022'.
-	self assert: (Float fminNormalized - Float fminDenormalized) binaryLiteralString equals: '2r0.1111111111111111111111111111111111111111111111111111e-1022'.
-	self assert: Float epsilon binaryLiteralString equals: '2r1.0000000000000000000000000000000000000000000000000000e-52'.
-	self assert: Float fmax binaryLiteralString equals: '2r1.1111111111111111111111111111111111111111111111111111e1023'.
+	self
+		assert: Float fminDenormalized binaryLiteralString
+		equals:
+		'2r0.0000000000000000000000000000000000000000000000000001e-1022'.
+	self
+		assert: Float fminNormalized binaryLiteralString
+		equals:
+		'2r1.0000000000000000000000000000000000000000000000000000e-1022'.
+	self
+		assert:
+		(Float fminNormalized - Float fminDenormalized) binaryLiteralString
+		equals:
+		'2r0.1111111111111111111111111111111111111111111111111111e-1022'.
+	self
+		assert: Float machineEpsilon binaryLiteralString
+		equals:
+		'2r1.0000000000000000000000000000000000000000000000000000e-52'.
+	self
+		assert: Float fmax binaryLiteralString
+		equals:
+		'2r1.1111111111111111111111111111111111111111111111111111e1023'.
 
-	self assert: Float fminDenormalized negated binaryLiteralString equals: '-2r0.0000000000000000000000000000000000000000000000000001e-1022'.
-	self assert: Float fminNormalized negated binaryLiteralString equals: '-2r1.0000000000000000000000000000000000000000000000000000e-1022'.
+	self
+		assert: Float fminDenormalized negated binaryLiteralString
+		equals:
+		'-2r0.0000000000000000000000000000000000000000000000000001e-1022'.
+	self
+		assert: Float fminNormalized negated binaryLiteralString
+		equals:
+		'-2r1.0000000000000000000000000000000000000000000000000000e-1022'.
 
-	self assert: 1.0 binaryLiteralString equals: '2r1.0000000000000000000000000000000000000000000000000000e0'.
-	self assert: (1.0 + Float epsilon) binaryLiteralString equals: '2r1.0000000000000000000000000000000000000000000000000001e0'.
-	self assert: (1.0 - (Float epsilon / 2)) binaryLiteralString equals: '2r1.1111111111111111111111111111111111111111111111111111e-1'.
-	self assert: 2.0 binaryLiteralString equals: '2r1.0000000000000000000000000000000000000000000000000000e1'.
+	self
+		assert: 1.0 binaryLiteralString
+		equals: '2r1.0000000000000000000000000000000000000000000000000000e0'.
+	self
+		assert: (1.0 + Float machineEpsilon) binaryLiteralString
+		equals: '2r1.0000000000000000000000000000000000000000000000000001e0'.
+	self
+		assert: (1.0 - (Float machineEpsilon / 2)) binaryLiteralString
+		equals:
+		'2r1.1111111111111111111111111111111111111111111111111111e-1'.
+	self
+		assert: 2.0 binaryLiteralString
+		equals: '2r1.0000000000000000000000000000000000000000000000000000e1'.
 
-	self assert: 0.1 binaryLiteralString equals: '2r1.1001100110011001100110011001100110011001100110011010e-4'.
-	self assert: 0.2 binaryLiteralString equals: '2r1.1001100110011001100110011001100110011001100110011010e-3'.
-	self assert: 0.3 binaryLiteralString equals: '2r1.0011001100110011001100110011001100110011001100110011e-2'.
-	self assert: (0.1 + 0.2) binaryLiteralString equals: '2r1.0011001100110011001100110011001100110011001100110100e-2'.
-	self assert: 0.5 binaryLiteralString equals: '2r1.0000000000000000000000000000000000000000000000000000e-1'.
+	self
+		assert: 0.1 binaryLiteralString
+		equals:
+		'2r1.1001100110011001100110011001100110011001100110011010e-4'.
+	self
+		assert: 0.2 binaryLiteralString
+		equals:
+		'2r1.1001100110011001100110011001100110011001100110011010e-3'.
+	self
+		assert: 0.3 binaryLiteralString
+		equals:
+		'2r1.0011001100110011001100110011001100110011001100110011e-2'.
+	self
+		assert: (0.1 + 0.2) binaryLiteralString
+		equals:
+		'2r1.0011001100110011001100110011001100110011001100110100e-2'.
+	self
+		assert: 0.5 binaryLiteralString
+		equals:
+		'2r1.0000000000000000000000000000000000000000000000000000e-1'.
 
-	self assert: 2r0.0000000000000000000000000000000000000000000000000001e-1022 binaryLiteralString equals: '2r0.0000000000000000000000000000000000000000000000000001e-1022'.
-	self assert: 2r0.0101010101010101010101010101010101010101010101010101e-1022 binaryLiteralString equals: '2r0.0101010101010101010101010101010101010101010101010101e-1022'.
-	self assert: 2r0.1010101010101010101010101010101010101010101010101010e-1022 binaryLiteralString equals: '2r0.1010101010101010101010101010101010101010101010101010e-1022'.
-	self assert: 2r0.1111111111111111111111111111111111111111111111111111e-1022 binaryLiteralString equals: '2r0.1111111111111111111111111111111111111111111111111111e-1022'.
-	self assert: 2r1.0101010101010101010101010101010101010101010101010101e-3 binaryLiteralString equals: '2r1.0101010101010101010101010101010101010101010101010101e-3'.
-	self assert: 2r1.1010101010101010101010101010101010101010101010101010e3 binaryLiteralString equals: '2r1.1010101010101010101010101010101010101010101010101010e3'.
-	self assert: 2r1.1111111111111111111111111111111111111111111111111111e1023 binaryLiteralString equals: '2r1.1111111111111111111111111111111111111111111111111111e1023'.
+	self
+		assert:
+			2r0.0000000000000000000000000000000000000000000000000001e-1022
+				binaryLiteralString
+		equals:
+		'2r0.0000000000000000000000000000000000000000000000000001e-1022'.
+	self
+		assert:
+			2r0.0101010101010101010101010101010101010101010101010101e-1022
+				binaryLiteralString
+		equals:
+		'2r0.0101010101010101010101010101010101010101010101010101e-1022'.
+	self
+		assert:
+			2r0.1010101010101010101010101010101010101010101010101010e-1022
+				binaryLiteralString
+		equals:
+		'2r0.1010101010101010101010101010101010101010101010101010e-1022'.
+	self
+		assert:
+			2r0.1111111111111111111111111111111111111111111111111111e-1022
+				binaryLiteralString
+		equals:
+		'2r0.1111111111111111111111111111111111111111111111111111e-1022'.
+	self
+		assert: 2r1.0101010101010101010101010101010101010101010101010101e-3
+				binaryLiteralString
+		equals:
+		'2r1.0101010101010101010101010101010101010101010101010101e-3'.
+	self
+		assert: 2r1.1010101010101010101010101010101010101010101010101010e3
+				binaryLiteralString
+		equals: '2r1.1010101010101010101010101010101010101010101010101010e3'.
+	self
+		assert:
+			2r1.1111111111111111111111111111111111111111111111111111e1023
+				binaryLiteralString
+		equals:
+		'2r1.1111111111111111111111111111111111111111111111111111e1023'.
 
-	self assert: -2r0.0000000000000000000000000000000000000000000000000001e-1022 binaryLiteralString equals: '-2r0.0000000000000000000000000000000000000000000000000001e-1022'.
-	self assert: -2r1.0000000000000000000000000000000000000000000000000000e-1022 binaryLiteralString equals: '-2r1.0000000000000000000000000000000000000000000000000000e-1022'.
-	self assert: -2r1.1111111111111111111111111111111111111111111111111111e1023 binaryLiteralString equals: '-2r1.1111111111111111111111111111111111111111111111111111e1023'.
+	self
+		assert:
+			-2r0.0000000000000000000000000000000000000000000000000001e-1022
+				binaryLiteralString
+		equals:
+		'-2r0.0000000000000000000000000000000000000000000000000001e-1022'.
+	self
+		assert:
+			-2r1.0000000000000000000000000000000000000000000000000000e-1022
+				binaryLiteralString
+		equals:
+		'-2r1.0000000000000000000000000000000000000000000000000000e-1022'.
+	self
+		assert:
+			-2r1.1111111111111111111111111111111111111111111111111111e1023
+				binaryLiteralString
+		equals:
+		'-2r1.1111111111111111111111111111111111111111111111111111e1023'.
 
-	self assert: (Float fromIEEE64Bit: 2r0111111111110000000000000000000000000000000000000000000000000001) binaryLiteralString equals: 'Float nan'.
-	self assert: (Float fromIEEE64Bit: 2r0111111111111111111111111111111111111111111111111111111111111111) binaryLiteralString equals: 'Float nan'.
-	self assert: (Float fromIEEE64Bit: 2r1111111111110000000000000000000000000000000000000000000000000001) binaryLiteralString equals: 'Float nan'.
-	self assert: (Float fromIEEE64Bit: 2r1111111111111111111111111111111111111111111111111111111111111111) binaryLiteralString equals: 'Float nan'
+	self
+		assert: (Float fromIEEE64Bit:
+				 2r0111111111110000000000000000000000000000000000000000000000000001)
+				binaryLiteralString
+		equals: 'Float nan'.
+	self
+		assert: (Float fromIEEE64Bit:
+				 2r0111111111111111111111111111111111111111111111111111111111111111)
+				binaryLiteralString
+		equals: 'Float nan'.
+	self
+		assert: (Float fromIEEE64Bit:
+				 2r1111111111110000000000000000000000000000000000000000000000000001)
+				binaryLiteralString
+		equals: 'Float nan'.
+	self
+		assert: (Float fromIEEE64Bit:
+				 2r1111111111111111111111111111111111111111111111111111111111111111)
+				binaryLiteralString
+		equals: 'Float nan'
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
 FloatTest >> testCharacterization [
-
 	"Test the largest finite representable floating point value"
+
 	self assert: Float fmax successor equals: Float infinity.
 	self assert: Float infinity predecessor equals: Float fmax.
-	self assert: Float fmax negated predecessor equals: Float infinity negated.
-	self assert: Float infinity negated successor equals: Float fmax negated.
+	self
+		assert: Float fmax negated predecessor
+		equals: Float infinity negated.
+	self
+		assert: Float infinity negated successor
+		equals: Float fmax negated.
 
 	"Test the smallest positive representable floating point value"
 	self assert: Float fmin predecessor equals: 0.0.
@@ -181,27 +298,44 @@ FloatTest >> testCharacterization [
 	self assert: 0.0 predecessor equals: Float fmin negated.
 
 	"Test the relative precision"
-	self assert: Float one + Float epsilon > Float one.
-	self assert: Float one + Float epsilon equals: Float one successor.
-	self assert: Float one + (Float epsilon / Float radix) equals: Float one.
+	self assert: Float one + Float machineEpsilon > Float one.
+	self
+		assert: Float one + Float machineEpsilon
+		equals: Float one successor.
+	self
+		assert: Float one + (Float machineEpsilon / Float radix)
+		equals: Float one.
 
 	"Test maximum and minimum exponent"
 	self assert: Float fmax exponent equals: Float emax.
 	self assert: Float fminNormalized exponent equals: Float emin.
-	Float denormalized ifTrue: [
-		self assert: Float fminDenormalized exponent equals: (Float emin + 1 - Float precision)].
+	Float denormalized ifTrue: [ 
+		self
+			assert: Float fminDenormalized exponent
+			equals: Float emin + 1 - Float precision ].
 
 	"Alternative tests for maximum and minimum"
-	self assert: (Float radix - Float epsilon) * (Float radix raisedTo: Float emax) equals: Float fmax.
-	self assert: Float epsilon * (Float radix raisedTo: Float emin) equals: Float fmin.
+	self
+		assert: Float radix - Float machineEpsilon
+			* (Float radix raisedTo: Float emax)
+		equals: Float fmax.
+	self
+		assert: Float machineEpsilon * (Float radix raisedTo: Float emin)
+		equals: Float fmin.
 
 	"Test sucessors and predecessors"
 	self assert: Float one predecessor successor equals: Float one.
 	self assert: Float one successor predecessor equals: Float one.
-	self assert: Float one negated predecessor successor equals: Float one negated.
-	self assert: Float one negated successor predecessor equals: Float one negated.
+	self
+		assert: Float one negated predecessor successor
+		equals: Float one negated.
+	self
+		assert: Float one negated successor predecessor
+		equals: Float one negated.
 	self assert: Float infinity successor equals: Float infinity.
-	self assert: Float infinity negated predecessor equals: Float infinity negated.
+	self
+		assert: Float infinity negated predecessor
+		equals: Float infinity negated.
 	self assert: Float nan predecessor isNaN.
 	self assert: Float nan successor isNaN.
 
@@ -286,12 +420,14 @@ FloatTest >> testComparison [
 { #category : #'*Kernel-Tests-Extended' }
 FloatTest >> testDegreeCos [
 
-	45.0 degreeCos.	"Following tests use approximate equality, because cosine are generally evaluated using inexact Floating point arithmetic"
-	self assert: (45.0 degreeCos squared - 0.5) abs <= Float epsilon.
-	self assert: (60.0 degreeCos - 0.5) abs <= Float epsilon.
-	self assert: (120.0 degreeCos + 0.5) abs <= Float epsilon.
-	-360.0 to: 360.0 do: [ :i | self assert: (i degreeCos closeTo: i degreesToRadians cos) ].	"Following tests use strict equality which is a requested property of degreeCos"
-	-10.0 to: 10.0 do: [ :k |
+	45.0 degreeCos. "Following tests use approximate equality, because cosine are generally evaluated using inexact Floating point arithmetic"
+	self assert:
+		(45.0 degreeCos squared - 0.5) abs <= Float machineEpsilon.
+	self assert: (60.0 degreeCos - 0.5) abs <= Float machineEpsilon.
+	self assert: (120.0 degreeCos + 0.5) abs <= Float machineEpsilon.
+	-360.0 to: 360.0 do: [ :i | 
+	self assert: (i degreeCos closeTo: i degreesToRadians cos) ]. "Following tests use strict equality which is a requested property of degreeCos"
+	-10.0 to: 10.0 do: [ :k | 
 		self assert: (k * 360 + 90) degreeCos equals: 0.
 		self assert: (k * 360 - 90) degreeCos equals: 0.
 		self assert: (k * 360 + 180) degreeCos + 1 equals: 0.
@@ -309,12 +445,14 @@ FloatTest >> testDegreeCosForExceptionalValues [
 { #category : #'*Kernel-Tests-Extended' }
 FloatTest >> testDegreeSin [
 
-	45.0 degreeSin.	"Following tests use approximate equality, because sine are generally evaluated using inexact Floating point arithmetic"
-	self assert: (45.0 degreeSin squared - 0.5) abs <= Float epsilon.
-	self assert: (30.0 degreeSin - 0.5) abs <= Float epsilon.
-	self assert: (-30.0 degreeSin + 0.5) abs <= Float epsilon.
-	-360.0 to: 360.0 do: [ :i | self assert: (i degreeSin closeTo: i degreesToRadians sin) ].	"Following tests use strict equality which is a requested property of degreeSin"
-	-10.0 to: 10.0 do: [ :k |
+	45.0 degreeSin. "Following tests use approximate equality, because sine are generally evaluated using inexact Floating point arithmetic"
+	self assert:
+		(45.0 degreeSin squared - 0.5) abs <= Float machineEpsilon.
+	self assert: (30.0 degreeSin - 0.5) abs <= Float machineEpsilon.
+	self assert: (-30.0 degreeSin + 0.5) abs <= Float machineEpsilon.
+	-360.0 to: 360.0 do: [ :i | 
+	self assert: (i degreeSin closeTo: i degreesToRadians sin) ]. "Following tests use strict equality which is a requested property of degreeSin"
+	-10.0 to: 10.0 do: [ :k | 
 		self assert: (k * 360 + 90) degreeSin - 1 equals: 0.
 		self assert: (k * 360 - 90) degreeSin + 1 equals: 0.
 		self assert: (k * 360 + 180) degreeSin equals: 0.
@@ -372,14 +510,16 @@ FloatTest >> testFloorLog2 [
 	"Float internal representation of Float being in base 2, we expect (aFloat floorLog: 2) to be exact."
 
 	| aBitLess aBitMore |
-	aBitMore := 1 + Float epsilon.
-	aBitLess := 1 - Float epsilon.
-	Float emin + 1 to: Float emax - 1 do: [:exp |
+	aBitMore := 1 + Float machineEpsilon.
+	aBitLess := 1 - Float machineEpsilon.
+	Float emin + 1 to: Float emax - 1 do: [ :exp | 
 		| exactPowerOfTwo |
 		exactPowerOfTwo := 1.0 timesTwoPower: exp.
 		self assert: (exactPowerOfTwo floorLog: 2) equals: exp.
 		self assert: (exactPowerOfTwo * aBitMore floorLog: 2) equals: exp.
-		self assert: (exactPowerOfTwo * aBitLess floorLog: 2) equals: exp - 1]
+		self
+			assert: (exactPowerOfTwo * aBitLess floorLog: 2)
+			equals: exp - 1 ]
 ]
 
 { #category : #'*Kernel-Tests-Extended' }

--- a/src/Kernel-Tests-Extended/IntegerTest.extension.st
+++ b/src/Kernel-Tests-Extended/IntegerTest.extension.st
@@ -56,12 +56,14 @@ IntegerTest >> testBitOr [
 { #category : #'*Kernel-Tests-Extended' }
 IntegerTest >> testDegreeCos [
 
-	45 degreeCos.	"Following tests use approximate equality, because cosine are generally evaluated using inexact Floating point arithmetic"
-	self assert: (45 degreeCos squared - (1 / 2)) abs <= Float epsilon.
-	self assert: (60 degreeCos - (1 / 2)) abs <= Float epsilon.
-	self assert: (120 degreeCos + (1 / 2)) abs <= Float epsilon.
-	-360 to: 360 do: [ :i | self assert: (i degreeCos closeTo: i degreesToRadians cos) ].	"Following tests use strict equality which is a requested property of degreeCos"
-	-10 to: 10 do: [ :k |
+	45 degreeCos. "Following tests use approximate equality, because cosine are generally evaluated using inexact Floating point arithmetic"
+	self assert:
+		(45 degreeCos squared - (1 / 2)) abs <= Float machineEpsilon.
+	self assert: (60 degreeCos - (1 / 2)) abs <= Float machineEpsilon.
+	self assert: (120 degreeCos + (1 / 2)) abs <= Float machineEpsilon.
+	-360 to: 360 do: [ :i | 
+	self assert: (i degreeCos closeTo: i degreesToRadians cos) ]. "Following tests use strict equality which is a requested property of degreeCos"
+	-10 to: 10 do: [ :k | 
 		self assert: (k * 360 + 90) degreeCos equals: 0.
 		self assert: (k * 360 - 90) degreeCos equals: 0.
 		self assert: (k * 360 + 180) degreeCos + 1 equals: 0.
@@ -71,12 +73,14 @@ IntegerTest >> testDegreeCos [
 { #category : #'*Kernel-Tests-Extended' }
 IntegerTest >> testDegreeSin [
 
-	45 degreeSin.	"Following tests use approximate equality, because sine are generally evaluated using inexact Floating point arithmetic"
-	self assert: (45 degreeSin squared - (1 / 2)) abs <= Float epsilon.
-	self assert: (30 degreeSin - (1 / 2)) abs <= Float epsilon.
-	self assert: (-30 degreeSin + (1 / 2)) abs <= Float epsilon.
-	-360 to: 360 do: [ :i | self assert: (i degreeSin closeTo: i degreesToRadians sin) ].	"Following tests use strict equality which is a requested property of degreeSin"
-	-10 to: 10 do: [ :k |
+	45 degreeSin. "Following tests use approximate equality, because sine are generally evaluated using inexact Floating point arithmetic"
+	self assert:
+		(45 degreeSin squared - (1 / 2)) abs <= Float machineEpsilon.
+	self assert: (30 degreeSin - (1 / 2)) abs <= Float machineEpsilon.
+	self assert: (-30 degreeSin + (1 / 2)) abs <= Float machineEpsilon.
+	-360 to: 360 do: [ :i | 
+	self assert: (i degreeSin closeTo: i degreesToRadians sin) ]. "Following tests use strict equality which is a requested property of degreeSin"
+	-10 to: 10 do: [ :k | 
 		self assert: (k * 360 + 90) degreeSin - 1 equals: 0.
 		self assert: (k * 360 - 90) degreeSin + 1 equals: 0.
 		self assert: (k * 360 + 180) degreeSin equals: 0.

--- a/src/Kernel-Tests/NumberTest.class.st
+++ b/src/Kernel-Tests/NumberTest.class.st
@@ -194,6 +194,6 @@ NumberTest >> testRounded [
 
 	self assert: 0 rounded equals: 0.
 	self assert: 1 rounded equals: 1.
-	self assert: (1/2) rounded equals: 1.
-	self assert: ((1/2) - Float epsilon) rounded equals: 0
+	self assert: (1 / 2) rounded equals: 1.
+	self assert: (1 / 2 - Float machineEpsilon) rounded equals: 0
 ]

--- a/src/Kernel/BoxedFloat64.class.st
+++ b/src/Kernel/BoxedFloat64.class.st
@@ -155,7 +155,7 @@ BoxedFloat64 >> exp [
 	correction := 1.0 + fract.
 	delta := fract * fract / 2.0.
 	div := 2.0.
-	[delta > Epsilon] whileTrue: [
+	[delta > MathApproximationEpsilon] whileTrue: [
 		correction := correction + delta.
 		div := div + 1.0.
 		delta := delta * fract / div].
@@ -216,7 +216,7 @@ BoxedFloat64 >> ln [
 	div := 1.0.
 	pow := delta := sum := x.
 	x := x negated.  "x <= 0"
-	eps := Epsilon * (n abs + 1.0).
+	eps := MathApproximationEpsilon * (n abs + 1.0).
 	[delta > eps] whileTrue: [
 		"pass one: delta is positive"
 		div := div + 1.0.

--- a/src/Kernel/Float.class.st
+++ b/src/Kernel/Float.class.st
@@ -34,12 +34,13 @@ Class {
 	#name : #Float,
 	#superclass : #Number,
 	#classVars : [
+		'DefaultComparisonPrecision',
 		'E',
-		'Epsilon',
 		'Halfpi',
 		'Infinity',
 		'Ln10',
 		'Ln2',
+		'MathApproximationEpsilon',
 		'MaxVal',
 		'MaxValLn',
 		'MinValLogBase2',
@@ -63,6 +64,12 @@ Float class >> basicNew [
 { #category : #'instance creation' }
 Float class >> basicNew: anInteger [
 	^BoxedFloat64 basicNew: 2
+]
+
+{ #category : #constants }
+Float class >> defaultComparisonPrecision [
+
+	^ DefaultComparisonPrecision
 ]
 
 { #category : #constants }
@@ -189,7 +196,12 @@ Float class >> initialize [
 	Sqrt2 := 1.41421356237309504880168872420969808.
 	E := 2.718281828459045235360287471353.
 
-	Epsilon := 0.000000000001.  "Defines precision of mathematical functions"
+	"Defines precision of approximated mathematical functions such as trigonometric functions.
+	Use a small enough epsilon value to make approximations as good as possible."
+	MathApproximationEpsilon := 0.000000000001.
+	
+	"Default precision used for comparing two float numbers"
+	DefaultComparisonPrecision := 0.0001.
 
 	MaxVal := 1.7976931348623157e308.
 	MaxValLn := 709.782712893384.

--- a/src/Kernel/SmallFloat64.class.st
+++ b/src/Kernel/SmallFloat64.class.st
@@ -174,7 +174,7 @@ SmallFloat64 >> exp [
 	correction := 1.0 + fract.
 	delta := fract * fract / 2.0.
 	div := 2.0.
-	[delta > Epsilon] whileTrue: [
+	[delta > MathApproximationEpsilon] whileTrue: [
 		correction := correction + delta.
 		div := div + 1.0.
 		delta := delta * fract / div].
@@ -255,7 +255,7 @@ SmallFloat64 >> ln [
 	div := 1.0.
 	pow := delta := sum := x.
 	x := x negated.  "x <= 0"
-	eps := Epsilon * (n abs + 1.0).
+	eps := MathApproximationEpsilon * (n abs + 1.0).
 	[delta > eps] whileTrue: [
 		"pass one: delta is positive"
 		div := div + 1.0.

--- a/src/Math-Operations-Extensions/BoxedFloat64.extension.st
+++ b/src/Math-Operations-Extensions/BoxedFloat64.extension.st
@@ -15,7 +15,7 @@ BoxedFloat64 >> arcTan [
 	theta := (self * Halfpi) / (self + 1.0).
 
 	"iterate"
-	eps := Halfpi * Epsilon.
+	eps := Halfpi * MathApproximationEpsilon.
 	step := theta.
 	[(step * step) > eps] whileTrue: [
 		sinTheta := theta sin.
@@ -44,7 +44,7 @@ BoxedFloat64 >> sin [
 	sum := delta := self.
 	self2 := 0.0 - (self * self).
 	i := 2.0.
-	[delta > Epsilon] whileTrue: [
+	[delta > MathApproximationEpsilon] whileTrue: [
 		"once"
 		delta := (delta * self2) / (i * (i + 1.0)).
 		i := i + 2.0.
@@ -72,7 +72,7 @@ BoxedFloat64 >> sqrt [
 	exp := self exponent // 2.
 	guess := self timesTwoPower: 0 - exp.
 	"get eps value"
-	eps := guess * Epsilon.
+	eps := guess * MathApproximationEpsilon.
 	eps := eps * eps.
 	delta := (self - (guess * guess)) / (guess * 2.0).
 	[ delta * delta > eps ]

--- a/src/Math-Operations-Extensions/Float.extension.st
+++ b/src/Math-Operations-Extensions/Float.extension.st
@@ -118,7 +118,7 @@ Float >> asIEEE64BitWord [
 Float >> closeTo: num [
  	"Tell whether the receiver and arguments are close from each."
 	
-	^ self closeTo: num precision: 0.0001
+	^ self closeTo: num precision: DefaultComparisonPrecision
 ]
 
 { #category : #'*Math-Operations-Extensions' }

--- a/src/Math-Operations-Extensions/Float.extension.st
+++ b/src/Math-Operations-Extensions/Float.extension.st
@@ -164,9 +164,11 @@ Float >> degreesToRadians [
 
 { #category : #'*Math-Operations-Extensions' }
 Float class >> epsilon [
-	"Answer difference between 1.0 and previous representable value"
-	
-	^1.0 timesTwoPower: 1 - self precision
+
+	self
+		deprecated: 'Use machineEpsilon instead'
+		transformWith: '`@receiver epsilon' -> '`@receiver machineEpsilon'.
+	^ self machineEpsilon
 ]
 
 { #category : #'*Math-Operations-Extensions' }
@@ -211,6 +213,18 @@ Float >> log [
 	"Answer the base 10 logarithm of the receiver."
 
 	^ self ln / Ln10
+]
+
+{ #category : #'*Math-Operations-Extensions' }
+Float class >> machineEpsilon [
+	"Answer the machine epsilon or macheps, defined by wikipedia asCalypsoItemContext 
+	https://en.wikipedia.org/wiki/Machine_epsilon
+	
+	*an upper bound on the relative approximation error due to rounding in floating point arithmetic*
+	
+	Compute it as the difference between 1.0 and previous representable value"
+	
+	^1.0 timesTwoPower: 1 - self precision
 ]
 
 { #category : #'*Math-Operations-Extensions' }
@@ -327,5 +341,5 @@ Float >> ulp [
 	exponent := self exponent.
 	^exponent < self class emin
 		ifTrue: [Float fminDenormalized]
- 		ifFalse: [Float epsilon timesTwoPower: exponent]
+ 		ifFalse: [Float machineEpsilon timesTwoPower: exponent]
 ]

--- a/src/Math-Operations-Extensions/SmallFloat64.extension.st
+++ b/src/Math-Operations-Extensions/SmallFloat64.extension.st
@@ -15,7 +15,7 @@ SmallFloat64 >> arcTan [
 	theta := (self * Halfpi) / (self + 1.0).
 
 	"iterate"
-	eps := Halfpi * Epsilon.
+	eps := Halfpi * MathApproximationEpsilon.
 	step := theta.
 	[(step * step) > eps] whileTrue: [
 		sinTheta := theta sin.
@@ -44,7 +44,7 @@ SmallFloat64 >> sin [
 	sum := delta := self.
 	self2 := 0.0 - (self * self).
 	i := 2.0.
-	[delta > Epsilon] whileTrue: [
+	[delta > MathApproximationEpsilon] whileTrue: [
 		"once"
 		delta := (delta * self2) / (i * (i + 1.0)).
 		i := i + 2.0.
@@ -72,7 +72,7 @@ SmallFloat64 >> sqrt [
 	exp := self exponent // 2.
 	guess := self timesTwoPower: 0 - exp.
 	"get eps value"
-	eps := guess * Epsilon.
+	eps := guess * MathApproximationEpsilon.
 	eps := eps * eps.
 	delta := (self - (guess * guess)) / (guess * 2.0).
 	[ delta * delta > eps ]

--- a/src/NumberParser-Tests/NumberParserTest.class.st
+++ b/src/NumberParser-Tests/NumberParserTest.class.st
@@ -395,7 +395,7 @@ NumberParserTest >> testSqueezingOutNumbers [
 	self assert: '123blabla' squeezeOutNumber equals: 123.
 	self assert: 'blabla123' squeezeOutNumber equals: 123.
 	self assert: 'blabla12blabla' squeezeOutNumber equals: 12.
-	self assert: ('12.3bla' squeezeOutNumber -12.3 ) abs < 0.0001.
+	self assert: ('12.3bla' squeezeOutNumber -12.3 ) abs < Float defaultComparisonPrecision.
 	self assert: '.1' squeezeOutNumber > 0.
 	
 	self assert: 'blabla1230' squeezeOutNumber equals: 1230.

--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -51,12 +51,6 @@ TestAsserter class >> classForTestSuite [
 	^ TestSuite
 ]
 
-{ #category : #accessing }
-TestAsserter class >> defaultPrecisionsForCloseToComparison [
-	"This number comes from the one used in Float>>#closeTo: implementation."
-	^ 0.0001
-]
-
 { #category : #logging }
 TestAsserter class >> failureLog [
 	^Transcript
@@ -89,13 +83,12 @@ TestAsserter class >> suiteClass [
 { #category : #asserting }
 TestAsserter >> assert: actualNumber closeTo: expectedNumber [
 	"Tell whether the actualNumber and expectedNumber ARE close to each others with a margin of
-	 the default precision (see class-side method #defaultPrecisionsForCloseToComparison).
-	"
+	 the default precision"
 
 	self
 		assert: actualNumber
 		closeTo: expectedNumber
-		precision: self class defaultPrecisionsForCloseToComparison
+		precision: Float defaultComparisonPrecision
 ]
 
 { #category : #asserting }
@@ -338,9 +331,12 @@ TestAsserter >> deny: aBooleanOrBlock [
 { #category : #asserting }
 TestAsserter >> deny: actualNumber closeTo: expectedNumber [
 	"Tell whether the actualNumber and expectedNumber are NOT close to each others with a margin of
-	 the default precision (see class-side method #defaultPrecisionsForCloseToComparison).
-	"
-	self deny: actualNumber closeTo: expectedNumber precision: self class defaultPrecisionsForCloseToComparison
+	 the default precision"
+
+	self
+		deny: actualNumber
+		closeTo: expectedNumber
+		precision: Float defaultComparisonPrecision
 ]
 
 { #category : #asserting }


### PR DESCRIPTION
Fix #3067

Better constant naming for float epsilons
Rename epsilon as machine epsilon for clarity (+deprecation)