### PR TITLE
Fix #3172: parseTreeFor: asymbol should be renamed parseTreeOfMethodNamed: aSymbol #3172

### DIFF
--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -325,8 +325,8 @@ RBParserTest >> testComparingTrees [
 	self exampleClasses do: [ :class |
 		class selectors do: [ :selector |
 			self
-				compare: (class parseTreeFor: selector)
-				to: (class parseTreeFor: selector) ] ]
+				compare: (class parseTreeForSelector: selector)
+				to: (class parseTreeForSelector: selector) ] ]
 ]
 
 { #category : #tests }
@@ -339,7 +339,7 @@ RBParserTest >> testCopy [
 
 	self exampleClasses do: [ :class |
 		class selectors do: [ :each |
-			tree := class parseTreeFor: each.
+			tree := class parseTreeForSelector: each.
 			self compare: tree to: tree copy ] ]
 ]
 
@@ -353,7 +353,7 @@ RBParserTest >> testCopyInContext [
 
 	self exampleClasses do: [ :class |
 		class selectors do: [ :each |
-			tree := class parseTreeFor: each.
+			tree := class parseTreeForSelector: each.
 			self compare: tree to: (tree copyInContext: Dictionary new) ] ]
 ]
 
@@ -475,7 +475,7 @@ RBParserTest >> testEqualToWithMapping [
 
 	self exampleClasses do: [ :class |
 		class selectors do: [ :each |
-			tree := class parseTreeFor: each.
+			tree := class parseTreeForSelector: each.
 			self assert: (tree equalTo: tree withMapping: Dictionary new) ] ]
 ]
 
@@ -552,8 +552,8 @@ RBParserTest >> testFormatter [
 	self exampleClasses do: [ :class |
 		class selectors do: [ :selector |
 		self
-			compare: (class parseTreeFor: selector)
-			to: (self parserClass parseMethod: (class parseTreeFor: selector) printString) ] ]
+			compare: (class parseTreeForSelector: selector)
+			to: (self parserClass parseMethod: (class parseTreeForSelector: selector) printString) ] ]
 ]
 
 { #category : #'garbage tests' }
@@ -966,7 +966,7 @@ RBParserTest >> testMatchInContext [
 
 	self exampleClasses do: [ :class |
 		class selectors do: [ :each |
-			tree := class parseTreeFor: each.
+			tree := class parseTreeForSelector: each.
 			self assert: (tree match: tree inContext: Dictionary new) ] ]
 ]
 
@@ -1675,7 +1675,7 @@ RBParserTest >> testPragmas [
 
 { #category : #'tests - parsing' }
 RBParserTest >> testPrimitives [
-	self assert: (Object parseTreeFor: #basicAt:) isPrimitive.
+	self assert: (Object parseTreeForSelector: #basicAt:) isPrimitive.
 	#(('foo ^true' false ) ('foo <some: #tag> ^true' false ) (' foo <some: #tag> <primitive: 123> ^true' true ) )
 			do: [:each | self assert: (self parserClass parseMethod: each first) isPrimitive equals: each last]
 ]

--- a/src/AST-Core-Tests/RBScannerTest.class.st
+++ b/src/AST-Core-Tests/RBScannerTest.class.st
@@ -1613,7 +1613,6 @@ package: ''UndefinedClasses-Experiment'.
 	self assert: ((self scannerClass scanTokenObjects: inp) collect: [ :each | each value ]) equals: exp
 ]
 
-
 { #category : #utilities }
 RBScannerTest >> verifyErrorToken: scannedToken message: message valueExpected: valueExpected [
 	self assert: scannedToken isError.

--- a/src/AST-Core/Behavior.extension.st
+++ b/src/AST-Core/Behavior.extension.st
@@ -2,5 +2,15 @@ Extension { #name : #Behavior }
 
 { #category : #'*AST-Core' }
 Behavior >> parseTreeFor: aSymbol [
+
+	self
+		deprecated: 'Use parseTreeForSelector: instead'
+		transformWith: '`@receiver parseTreeFor: `@argument'
+			-> '`@receiver parseTreeForSelector: `@argument'.
+	^ self parseTreeForSelector: aSymbol
+]
+
+{ #category : #'*AST-Core' }
+Behavior >> parseTreeForSelector: aSymbol [
 	^ (self compiledMethodAt: aSymbol) parseTree
 ]

--- a/src/NautilusRefactoring/NautilusRefactoring.class.st
+++ b/src/NautilusRefactoring/NautilusRefactoring.class.st
@@ -118,7 +118,7 @@ NautilusRefactoring >> selectVariableToMoveMethodTo: aSelector class: aClass [
 
 	| parseTree nameList |
 
-	parseTree := aClass parseTreeFor: aSelector.
+	parseTree := aClass parseTreeForSelector: aSelector.
 	parseTree
 		ifNil: [ parseTree := RBMethodNode selector: #value body: ( RBSequenceNode statements: #() ) ].
 	nameList := OrderedCollection new.

--- a/src/Refactoring-Core/RBAbstractClass.class.st
+++ b/src/Refactoring-Core/RBAbstractClass.class.st
@@ -185,7 +185,7 @@ RBAbstractClass >> canonicalArgumentName [
 RBAbstractClass >> checkSelector: aSelector using: aMatcher [ 
 
 	| parseTree |
-	parseTree := self parseTreeFor: aSelector.
+	parseTree := self parseTreeForSelector: aSelector.
 	parseTree ifNotNil: [aMatcher executeTree: parseTree].
 	^ aMatcher answer
 ]
@@ -250,7 +250,7 @@ RBAbstractClass >> convertMethod: selector using: searchReplacer [
 
 	| parseTree |
 
-	parseTree := self parseTreeFor: selector.
+	parseTree := self parseTreeForSelector: selector.
 	parseTree ifNil: [ ^ self ].
 	( searchReplacer executeTree: parseTree )
 		ifTrue: [ self compileTree: searchReplacer tree ]
@@ -538,7 +538,17 @@ RBAbstractClass >> newMethods [
 ]
 
 { #category : #'method accessing' }
-RBAbstractClass >> parseTreeFor: aSelector [
+RBAbstractClass >> parseTreeFor: aSymbol [
+
+	self
+		deprecated: 'Use parseTreeForSelector: instead'
+		transformWith: '`@receiver parseTreeFor: `@argument'
+			-> '`@receiver parseTreeForSelector: `@argument'.
+	^ self parseTreeForSelector: aSymbol
+]
+
+{ #category : #'method accessing' }
+RBAbstractClass >> parseTreeForSelector: aSelector [
 
 	| class method |
 

--- a/src/Refactoring-Core/RBChangeMethodNameRefactoring.class.st
+++ b/src/Refactoring-Core/RBChangeMethodNameRefactoring.class.st
@@ -121,7 +121,7 @@ RBChangeMethodNameRefactoring >> renameImplementors [
 		do: [ :each | 
 			| parseTree |
 
-			parseTree := each parseTreeFor: oldSelector.
+			parseTree := each parseTreeForSelector: oldSelector.
 			parseTree ifNil: [ self refactoringFailure: 'Could not parse source code.' ].
 			self implementorsCanBePrimitives
 				ifFalse: [ parseTree isPrimitive

--- a/src/Refactoring-Core/RBChildrenToSiblingsRefactoring.class.st
+++ b/src/Refactoring-Core/RBChildrenToSiblingsRefactoring.class.st
@@ -80,7 +80,7 @@ RBChildrenToSiblingsRefactoring >> computeSubclassSupersOf: aClass [
 	aClass subclasses do: 
 			[:each | 
 			each selectors 
-				do: [:sel | selectors addAll: (each parseTreeFor: sel) superMessages]].
+				do: [:sel | selectors addAll: (each parseTreeForSelector: sel) superMessages]].
 	^selectors
 ]
 

--- a/src/Refactoring-Core/RBCondition.class.st
+++ b/src/Refactoring-Core/RBCondition.class.st
@@ -128,7 +128,7 @@ RBCondition class >> definesSelector: aSelector in: aClass [
 RBCondition class >> definesSelector: aSelector in: aClass orIsSimilarTo: rbMethod [
 	^self new
 		block: [(aClass directlyDefinesMethod: aSelector)
-			ifTrue: [ (aClass parseTreeFor: aSelector) ~= rbMethod parseTree ]
+			ifTrue: [ (aClass parseTreeForSelector: aSelector) ~= rbMethod parseTree ]
 			ifFalse: [ false ]
 			]
 		errorString: aClass printString , ' <1?:does not >define<1?s:> ' , aSelector printString
@@ -382,7 +382,7 @@ RBCondition class >> methodDefiningTemporary: aString in: aClass ignore: aBlock 
 						ifFalse: 
 							[| parseTree |
 							method := class methodFor: each.
-							parseTree := class parseTreeFor: each.
+							parseTree := class parseTreeForSelector: each.
 							parseTree notNil ifTrue: [searcher executeTree: parseTree]]]].
 	^nil
 ]
@@ -412,7 +412,7 @@ RBCondition class >> subclassesOf: aClass referToSelector: aSelector [
 					   (each selectors
 						    detect: [ :sel | 
 							    | tree |
-							    tree := each parseTreeFor: sel.
+							    tree := each parseTreeForSelector: sel.
 							    tree notNil and: [ tree superMessages includes: aSelector ] ]
 						    ifNone: [ nil ]) notNil ]
 				   ifNone: [ nil ]) notNil ]

--- a/src/Refactoring-Core/RBCreateCascadeRefactoring.class.st
+++ b/src/Refactoring-Core/RBCreateCascadeRefactoring.class.st
@@ -117,7 +117,7 @@ RBCreateCascadeRefactoring >> findStatementNodes [
 RBCreateCascadeRefactoring >> parseTree [
 
 	parseTree
-		ifNil: [ parseTree := class parseTreeFor: selector.
+		ifNil: [ parseTree := class parseTreeForSelector: selector.
 			parseTree ifNil: [ self refactoringFailure: 'Could not parse sources' ]
 			].
 	^ parseTree

--- a/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
@@ -180,7 +180,7 @@ RBExtractMethodRefactoring >> extractMethod [
 	extractedParseTree body temporaries
 		ifNotEmpty: [ extractedParseTree body temporaries: #() ].
 	extractedParseTree source: extractCode.
-	parseTree := class parseTreeFor: selector.
+	parseTree := class parseTreeForSelector: selector.
 	parseTree
 		ifNil: [ self refactoringFailure: 'Could not parse ' , selector printString ].
 	subtree := isSequence
@@ -269,7 +269,7 @@ RBExtractMethodRefactoring >> isMethodEquivalentTo: aSelector [
 RBExtractMethodRefactoring >> isParseTreeEquivalentTo: aSelector [ 
 	| tree definingClass |
 	definingClass := class whoDefinesMethod: aSelector.
-	tree := definingClass parseTreeFor: aSelector.
+	tree := definingClass parseTreeForSelector: aSelector.
 	tree ifNil: [^false].
 	tree isPrimitive ifTrue: [^false].
 	needsReturn ifFalse: [ tree := self removeReturnsOf: tree ].
@@ -390,7 +390,7 @@ RBExtractMethodRefactoring >> renameParameterWith: oldName to: newName [
 { #category : #transforming }
 RBExtractMethodRefactoring >> reorderParametersToMatch: aSelector [ 
 	| tree dictionary |
-	tree := class parseTreeFor: aSelector.
+	tree := class parseTreeForSelector: aSelector.
 	needsReturn ifFalse: [ tree := self removeReturnsOf: tree ].
 	dictionary := Dictionary new.
 	tree body equalTo: extractedParseTree body withMapping: dictionary.

--- a/src/Refactoring-Core/RBExtractSetUpMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractSetUpMethodRefactoring.class.st
@@ -116,7 +116,7 @@ RBExtractSetUpMethodRefactoring >> shouldExtractAssignmentTo: name [
 { #category : #transforming }
 RBExtractSetUpMethodRefactoring >> startLimit: aNumber [
 	| node |
-	node := class parseTreeFor: selector.
+	node := class parseTreeForSelector: selector.
 	^ node statements ifEmpty: [ node body start ]
 		ifNotEmpty: [ node statements first start ]
 ]

--- a/src/Refactoring-Core/RBExtractToTemporaryRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractToTemporaryRefactoring.class.st
@@ -95,7 +95,7 @@ RBExtractToTemporaryRefactoring >> insertTemporary [
 RBExtractToTemporaryRefactoring >> parseTree [
 
 	parseTree
-		ifNil: [ parseTree := class parseTreeFor: selector.
+		ifNil: [ parseTree := class parseTreeForSelector: selector.
 			parseTree ifNil: [ self refactoringFailure: 'Could not parse method' ]
 			].
 	^ parseTree

--- a/src/Refactoring-Core/RBInlineAllSendersRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineAllSendersRefactoring.class.st
@@ -76,14 +76,14 @@ RBInlineAllSendersRefactoring >> initializePatternFor: aClass [
 RBInlineAllSendersRefactoring >> inlineMessagesInClass: aClass andSelector: aSelector [ 
 	| messagesToInline previousCountOfMessages rbMethod |
 	previousCountOfMessages := 4294967295.	"Some really large number > # of initial self sends."
-	rbMethod := aClass parseTreeFor: aSelector.
+	rbMethod := aClass parseTreeForSelector: aSelector.
 	rbMethod ifNil: [ ^ self ].
-	[ messagesToInline := self numberOfSelfSendsIn: (aClass parseTreeFor: aSelector).
+	[ messagesToInline := self numberOfSelfSendsIn: (aClass parseTreeForSelector: aSelector).
 	messagesToInline > 0 and: [previousCountOfMessages > messagesToInline]] 
 			whileTrue: 
 				[| node |
 				previousCountOfMessages := messagesToInline.
-				node := self selfSendIn: (aClass parseTreeFor: aSelector).
+				node := self selfSendIn: (aClass parseTreeForSelector: aSelector).
 				self onError: 
 						[self performCompositeRefactoring: ((RBInlineMethodRefactoring
 									model: self model

--- a/src/Refactoring-Core/RBInlineMethodFromComponentRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineMethodFromComponentRefactoring.class.st
@@ -81,7 +81,7 @@ RBInlineMethodFromComponentRefactoring >> classOfTheMethodToInline [
 { #category : #transforming }
 RBInlineMethodFromComponentRefactoring >> findSelectedMessage [
 
-	sourceParseTree := class parseTreeFor: sourceSelector.
+	sourceParseTree := class parseTreeForSelector: sourceSelector.
 	sourceParseTree ifNil: [ self refactoringFailure: 'Could not parse sources' ].
 	sourceMessage := sourceParseTree whichNodeIsContainedBy: sourceInterval.
 	sourceMessage

--- a/src/Refactoring-Core/RBInlineMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineMethodRefactoring.class.st
@@ -103,7 +103,7 @@ RBInlineMethodRefactoring >> compileMethod [
 { #category : #transforming }
 RBInlineMethodRefactoring >> findSelectedMessage [
 
-	sourceParseTree := class parseTreeFor: sourceSelector.
+	sourceParseTree := class parseTreeForSelector: sourceSelector.
 	sourceParseTree ifNil: [ self refactoringFailure: 'Could not parse sources' ].
 	sourceMessage := sourceParseTree whichNodeIsContainedBy: sourceInterval.
 	sourceMessage
@@ -267,7 +267,7 @@ RBInlineMethodRefactoring >> parseInlineMethod [
 						expandMacrosWith: class
 						with: self inlineSelector )
 			].
-	inlineParseTree := self classOfTheMethodToInline parseTreeFor: self inlineSelector.
+	inlineParseTree := self classOfTheMethodToInline parseTreeForSelector: self inlineSelector.
 	inlineParseTree ifNil: [ self refactoringFailure: 'Could not parse sources' ].
 	inlineParseTree lastIsReturn
 		ifFalse: [ inlineParseTree addSelfReturn ]

--- a/src/Refactoring-Core/RBInlineTemporaryRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineTemporaryRefactoring.class.st
@@ -107,7 +107,7 @@ RBInlineTemporaryRefactoring >> transform [
 { #category : #preconditions }
 RBInlineTemporaryRefactoring >> verifySelectedInterval [
 
-	sourceTree := class parseTreeFor: selector.
+	sourceTree := class parseTreeForSelector: selector.
 	sourceTree ifNil: [ self refactoringFailure: 'Could not parse source' ].
 	assignmentNode := sourceTree whichNodeIsContainedBy: sourceInterval.
 	assignmentNode isAssignment

--- a/src/Refactoring-Core/RBMoveMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBMoveMethodRefactoring.class.st
@@ -83,7 +83,7 @@ RBMoveMethodRefactoring >> addSelfReturn [
 { #category : #private }
 RBMoveMethodRefactoring >> buildParseTree [
 
-	parseTree := ( class parseTreeFor: selector ) copy.
+	parseTree := ( class parseTreeForSelector: selector ) copy.
 	parseTree ifNil: [ self refactoringFailure: 'Could not parse method' ]
 ]
 
@@ -149,7 +149,7 @@ RBMoveMethodRefactoring >> compileDelegatorMethod [
 					                  ifFalse: [ RBVariableNode named: each ] ]).
 	self hasOnlySelfReturns ifFalse: [ delegatorNode := RBReturnNode value: delegatorNode ].
 	statementNode := RBSequenceNode temporaries: #(  ) statements: (Array with: delegatorNode).
-	(tree := class parseTreeFor: selector) body: statementNode.
+	(tree := class parseTreeForSelector: selector) body: statementNode.
 	class compileTree: tree
 ]
 

--- a/src/Refactoring-Core/RBMoveMethodToClassSideRefactoring.class.st
+++ b/src/Refactoring-Core/RBMoveMethodToClassSideRefactoring.class.st
@@ -124,7 +124,7 @@ RBMoveMethodToClassSideRefactoring >> getTempName [
 RBMoveMethodToClassSideRefactoring >> parseTree [
 
 	parseTree
-		ifNil: [ parseTree := class parseTreeFor: method selector.
+		ifNil: [ parseTree := class parseTreeForSelector: method selector.
 			parseTree ifNil: [ self refactoringFailure: 'Could not parse method' ]
 			].
 	^ parseTree

--- a/src/Refactoring-Core/RBMoveVariableDefinitionRefactoring.class.st
+++ b/src/Refactoring-Core/RBMoveVariableDefinitionRefactoring.class.st
@@ -90,7 +90,7 @@ RBMoveVariableDefinitionRefactoring >> preconditions [
 						ifFalse: 
 							[self 
 								refactoringFailure: name , ' does not seem to be a valid variable name.'].
-					parseTree := class parseTreeFor: selector.
+					parseTree := class parseTreeForSelector: selector.
 					self checkParseTree.
 					true])
 ]

--- a/src/Refactoring-Core/RBPrettyPrintCodeRefactoring.class.st
+++ b/src/Refactoring-Core/RBPrettyPrintCodeRefactoring.class.st
@@ -25,7 +25,7 @@ RBPrettyPrintCodeRefactoring >> transform [
 					(self model environment includesSelector: selector in: class realClass)
 						ifTrue: [ source := class sourceCodeFor: selector.
 							source
-								ifNotNil: [ tree := class parseTreeFor: selector.
+								ifNotNil: [ tree := class parseTreeForSelector: selector.
 									tree
 										ifNotNil: [ formatted := tree formattedCode.
 											(source ~= formatted

--- a/src/Refactoring-Core/RBPullUpMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBPullUpMethodRefactoring.class.st
@@ -51,13 +51,13 @@ RBPullUpMethodRefactoring >> checkBackReferencesTo: aSelector [
 	| definingClass pushUpParseTree |
 	definingClass := targetSuperclass whoDefinesMethod: aSelector.
 	definingClass ifNil: [^self].
-	pushUpParseTree := class parseTreeFor: aSelector.
+	pushUpParseTree := class parseTreeForSelector: aSelector.
 	targetSuperclass allSubclasses do: 
 			[:each | 
 			each selectors do: 
 					[:sel | 
 					| parseTree |
-					parseTree := each parseTreeFor: sel.
+					parseTree := each parseTreeForSelector: sel.
 					(parseTree notNil and: 
 							[(parseTree superMessages includes: aSelector) 
 								and: [definingClass == (each whoDefinesMethod: aSelector)]]) 
@@ -112,7 +112,7 @@ RBPullUpMethodRefactoring >> checkSiblingSuperSendsFrom: aRBClass [
 	aRBClass selectors do: 
 			[:each | 
 			| tree |
-			tree := aRBClass parseTreeFor: each.
+			tree := aRBClass parseTreeForSelector: each.
 			tree ifNotNil: 
 					[tree superMessages do: 
 							[:aSelector | 
@@ -141,7 +141,7 @@ RBPullUpMethodRefactoring >> checkSuperSendsFromPushedUpMethods [
 	selectors do: 
 			[:each | 
 			| parseTree |
-			parseTree := class parseTreeFor: each.
+			parseTree := class parseTreeForSelector: each.
 			parseTree superMessages 
 				detect: [:sup | targetSuperclass directlyDefinesMethod: sup]
 				ifFound: 
@@ -165,8 +165,8 @@ RBPullUpMethodRefactoring >> checkSuperclass [
 	overrideSelectors := overrideSelectors
 		reject: [ :each | 
 			| myTree superTree |
-			myTree := class parseTreeFor: each.
-			superTree := targetSuperclass parseTreeFor: each.
+			myTree := class parseTreeForSelector: each.
+			superTree := targetSuperclass parseTreeForSelector: each.
 			superTree equalTo: myTree exceptForVariables: #() ].
 	overrideSelectors ifEmpty: [ ^ self ].
 	targetSuperclass isAbstract
@@ -192,7 +192,7 @@ RBPullUpMethodRefactoring >> copyDownMethod: aSelector [
 	subclasses := targetSuperclass subclasses 
 				reject: [:each | each directlyDefinesMethod: aSelector].
 	subclasses ifEmpty: [^ self ].
-	(superclassDefiner parseTreeFor: aSelector) superMessages 
+	(superclassDefiner parseTreeForSelector: aSelector) superMessages 
 		detect: [:each | superclassDefiner directlyDefinesMethod: each]
 		ifFound: 
 			[self 
@@ -204,7 +204,7 @@ RBPullUpMethodRefactoring >> copyDownMethod: aSelector [
 				, aSelector, '?'.
 	refactoring := RBExpandReferencedPoolsRefactoring 
 				model: self model
-				forMethod: (superclassDefiner parseTreeFor: aSelector)
+				forMethod: (superclassDefiner parseTreeForSelector: aSelector)
 				fromClass: superclassDefiner
 				toClasses: subclasses.
 	self performCompositeRefactoring: refactoring.
@@ -236,7 +236,7 @@ RBPullUpMethodRefactoring >> pullUp: aSelector [
 	source ifNil: [self refactoringFailure: 'Source for method not available'].
 	refactoring := RBExpandReferencedPoolsRefactoring 
 				model: self model
-				forMethod: (class parseTreeFor: aSelector)
+				forMethod: (class parseTreeForSelector: aSelector)
 				fromClass: class
 				toClasses: (Array with: targetSuperclass).
 	self performCompositeRefactoring: refactoring.
@@ -281,11 +281,11 @@ RBPullUpMethodRefactoring >> removeDuplicateMethods [
 { #category : #transforming }
 RBPullUpMethodRefactoring >> removeDuplicatesOf: aSelector [ 
 	| tree |
-	tree := targetSuperclass parseTreeFor: aSelector.
+	tree := targetSuperclass parseTreeForSelector: aSelector.
 	targetSuperclass allSubclasses do: 
 			[:each | 
 			((each directlyDefinesMethod: aSelector) and: 
-					[(tree equalTo: (each parseTreeFor: aSelector) exceptForVariables: #()) 
+					[(tree equalTo: (each parseTreeForSelector: aSelector) exceptForVariables: #()) 
 						and: [(each superclass whoDefinesMethod: aSelector) == targetSuperclass]]) 
 				ifTrue: 
 					[removeDuplicates 

--- a/src/Refactoring-Core/RBPushDownMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBPushDownMethodRefactoring.class.st
@@ -78,7 +78,7 @@ RBPushDownMethodRefactoring >> pushDown: aSelector [
 	protocols := class protocolsFor: aSelector.
 	refactoring := RBExpandReferencedPoolsRefactoring
 		               model: self model
-		               forMethod: (class parseTreeFor: aSelector)
+		               forMethod: (class parseTreeForSelector: aSelector)
 		               fromClass: class
 		               toClasses: self allClasses.
 	self performCompositeRefactoring: refactoring.

--- a/src/Refactoring-Core/RBRefactoring.class.st
+++ b/src/Refactoring-Core/RBRefactoring.class.st
@@ -158,7 +158,7 @@ RBRefactoring >> changes [
 { #category : #support }
 RBRefactoring >> checkClass: aRBClass selector: aSelector using: aMatcher [ 
 	| parseTree |
-	parseTree := aRBClass parseTreeFor: aSelector.
+	parseTree := aRBClass parseTreeForSelector: aSelector.
 	parseTree ifNotNil: [aMatcher executeTree: parseTree].
 	^aMatcher answer
 ]
@@ -239,7 +239,7 @@ RBRefactoring >> convertMethod: selector for: aClass using: searchReplacer [
 
 	| parseTree |
 
-	parseTree := aClass parseTreeFor: selector.
+	parseTree := aClass parseTreeForSelector: selector.
 	parseTree ifNil: [ ^ self ].
 	( searchReplacer executeTree: parseTree )
 		ifTrue: [ aClass compileTree: searchReplacer tree ]

--- a/src/Refactoring-Core/RBRefactoryTyper.class.st
+++ b/src/Refactoring-Core/RBRefactoryTyper.class.st
@@ -168,7 +168,7 @@ RBRefactoryTyper >> executeSearch: searcher [
 					[:sel | 
 					| parseTree |
 					methodName := sel.
-					parseTree := each parseTreeFor: sel.
+					parseTree := each parseTreeForSelector: sel.
 					parseTree doSemanticAnalysis.
 					parseTree notNil ifTrue: [searcher executeTree: parseTree]]]
 ]

--- a/src/Refactoring-Core/RBRemoveAllSendersRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveAllSendersRefactoring.class.st
@@ -83,7 +83,7 @@ RBRemoveAllSendersRefactoring >> removeSelfSenders [
 	flag := false.
 	(self model allReferencesTo: selector) do: [ :e | | node index |
 		index := 1.
-		[ node := self selfSendIn: (e methodClass parseTreeFor: e selector). node size < index ] 
+		[ node := self selfSendIn: (e methodClass parseTreeForSelector: e selector). node size < index ] 
 			whileFalse: [ 
 				self onError: [ self removeMethod: e of: (node at: index) ]
 					do: [ flag ifFalse: [ flag := true.

--- a/src/Refactoring-Core/RBRemoveMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveMethodRefactoring.class.st
@@ -100,7 +100,7 @@ RBRemoveMethodRefactoring >> checkSuperMethods [
 			[:each | 
 			(self superclassEquivalentlyDefines: each) 
 				ifTrue: 
-					[(class parseTreeFor: each) superMessages isEmpty 
+					[(class parseTreeForSelector: each) superMessages isEmpty 
 						ifFalse: [superMessages add: each]]
 				ifFalse: [nonSupers add: each]].
 	nonSupers isEmpty & superMessages isEmpty ifTrue: [^self].
@@ -114,7 +114,7 @@ RBRemoveMethodRefactoring >> justSendsSuper: aSelector [
 	| matcher parseTree superclass |
 
 	matcher := self parseTreeSearcherClass justSendsSuper.
-	parseTree := class parseTreeFor: aSelector.
+	parseTree := class parseTreeForSelector: aSelector.
 	( matcher executeTree: parseTree initialAnswer: false )
 		ifFalse: [ ^ false ].
 	parseTree lastIsReturn
@@ -122,7 +122,7 @@ RBRemoveMethodRefactoring >> justSendsSuper: aSelector [
 	superclass := class superclass whichClassIncludesSelector: aSelector.
 	superclass ifNil: [ ^ true ].	"Since there isn't a superclass that implements the message, we can 
 								 delete it since it would be an error anyway."
-	parseTree := superclass parseTreeFor: aSelector.
+	parseTree := superclass parseTreeForSelector: aSelector.
 	matcher := self parseTreeSearcher.
 	matcher
 		matches: '^``@object'
@@ -170,8 +170,8 @@ RBRemoveMethodRefactoring >> superclassEquivalentlyDefines: aSelector [
 	| superTree myTree |
 
 	class superclass ifNil: [ ^ false ].
-	superTree := class superclass parseTreeFor: aSelector.
-	myTree := class parseTreeFor: aSelector.
+	superTree := class superclass parseTreeForSelector: aSelector.
+	myTree := class parseTreeForSelector: aSelector.
 	( superTree isNil or: [ myTree isNil ] )
 		ifTrue: [ ^ false ].
 	^ superTree equalTo: myTree exceptForVariables: #()

--- a/src/Refactoring-Core/RBRemoveParameterRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveParameterRefactoring.class.st
@@ -40,7 +40,7 @@ RBRemoveParameterRefactoring >> applyValidations [
 	| tree |
 	(class directlyDefinesMethod: oldSelector) ifFalse: [ 
 		self refactoringFailure: 'Method doesn''t exist' ].
-	tree := class parseTreeFor: oldSelector.
+	tree := class parseTreeForSelector: oldSelector.
 	tree ifNil: [ self refactoringFailure: 'Cannot parse sources' ].
 	argument ifNil: [ 
 		self refactoringFailure: 'This method does not have an argument' ].
@@ -78,7 +78,7 @@ RBRemoveParameterRefactoring >> hasReferencesToTemporaryIn: each [
 
 	| tree |
 
-	tree := each parseTreeFor: oldSelector.
+	tree := each parseTreeForSelector: oldSelector.
 	tree ifNil: [ self refactoringFailure: 'Cannot parse sources.' ].
 	^ tree references: ( tree argumentNames at: parameterIndex )
 ]

--- a/src/Refactoring-Core/RBRenameArgumentOrTemporaryRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenameArgumentOrTemporaryRefactoring.class.st
@@ -90,7 +90,7 @@ RBRenameArgumentOrTemporaryRefactoring >> storeOn: aStream [
 { #category : #tranforming }
 RBRenameArgumentOrTemporaryRefactoring >> transform [
 	| definingNode variableNode |
-	parseTree := class parseTreeFor: selector.
+	parseTree := class parseTreeForSelector: selector.
 	variableNode := self whichVariableNode: parseTree inInterval: interval name: oldName.
 	(variableNode isNil or: [ variableNode isVariable not ])
 		ifTrue: [ self refactoringFailure: oldName asString , ' isn''t a valid variable' ].

--- a/src/Refactoring-Core/RBSplitCascadeRefactoring.class.st
+++ b/src/Refactoring-Core/RBSplitCascadeRefactoring.class.st
@@ -99,7 +99,7 @@ RBSplitCascadeRefactoring >> findMessageNodes [
 RBSplitCascadeRefactoring >> parseTree [
 
 	parseTree
-		ifNil: [ parseTree := class parseTreeFor: selector.
+		ifNil: [ parseTree := class parseTreeForSelector: selector.
 			parseTree ifNil: [ self refactoringFailure: 'Could not parse sources' ]
 			].
 	^ parseTree

--- a/src/Refactoring-Core/RBTemporaryToInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBTemporaryToInstanceVariableRefactoring.class.st
@@ -95,7 +95,7 @@ RBTemporaryToInstanceVariableRefactoring class >> model: aRBSmalltalk class: aCl
 { #category : #preconditions }
 RBTemporaryToInstanceVariableRefactoring >> checkForValidTemporaryVariable [
 	| parseTree |
-	parseTree := class parseTreeFor: selector.
+	parseTree := class parseTreeForSelector: selector.
 	(parseTree allTemporaryVariables includes: temporaryVariableName) 
 		ifFalse: 
 			[self refactoringFailure: temporaryVariableName 

--- a/src/Refactoring-Critics/RBSmalllintContext.class.st
+++ b/src/Refactoring-Critics/RBSmalllintContext.class.st
@@ -30,7 +30,7 @@ RBSmalllintContext >> buildParseTree [
 
 	| tree |
 
-	tree := self selectedClass parseTreeFor: self selector.
+	tree := self selectedClass parseTreeForSelector: self selector.
 	tree ifNil: [ ^ RBParser parseMethod: 'method' ].
 	^ tree
 ]

--- a/src/Refactoring-Tests-Core/RBSearchTest.class.st
+++ b/src/Refactoring-Tests-Core/RBSearchTest.class.st
@@ -184,6 +184,6 @@ RBSearchTest >> testAllSearches [
 			class selectors
 				do: [ :sel | 
 					currentSelector := sel.
-					searches do: [ :each | each executeTree: (class parseTreeFor: sel) initialAnswer: each answer ] ] ].
+					searches do: [ :each | each executeTree: (class parseTreeForSelector: sel) initialAnswer: each answer ] ] ].
 	classSearches do: [ :searches | searches do: [ :each | self assertEmpty: each answer ] ]
 ]

--- a/src/Refactoring2-Transformations-Tests/RBAbstractInstanceVariableParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAbstractInstanceVariableParametrizedTest.class.st
@@ -27,12 +27,12 @@ RBAbstractInstanceVariableParametrizedTest >> testAbstractInstanceVariable [
 		{ 'name' . #RBLintRuleTestData}.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBLintRuleTestData.
-	self assert: (class parseTreeFor: #name) equals: (self parseMethod: 'name ^name').
-	self assert: (class parseTreeFor: #name:) equals: (self parseMethod: 'name: aString
+	self assert: (class parseTreeForSelector: #name) equals: (self parseMethod: 'name ^name').
+	self assert: (class parseTreeForSelector: #name:) equals: (self parseMethod: 'name: aString
 	name := aString').
-	self assert: (class parseTreeFor: #initialize) equals: (self parseMethod: 'initialize
+	self assert: (class parseTreeForSelector: #initialize) equals: (self parseMethod: 'initialize
 	self name: ''''').
-	self assert: (class parseTreeFor: #printOn:) equals: (self parseMethod: 'printOn: aStream
+	self assert: (class parseTreeForSelector: #printOn:) equals: (self parseMethod: 'printOn: aStream
 	self name ifNil: [ super printOn: aStream ] ifNotNil: [ aStream nextPutAll: self name ]')
 ]
 

--- a/src/Refactoring2-Transformations-Tests/RBAddAccessorsForClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddAccessorsForClassTransformationTest.class.st
@@ -13,9 +13,9 @@ RBAddAccessorsForClassTransformationTest >> testRefactoring [
 	self assert: refactoring model changes changes size equals: 4.
 	
 	class := refactoring model classNamed: #RBVariableTransformation.
-	self assert: (class parseTreeFor: #variableName)
+	self assert: (class parseTreeForSelector: #variableName)
 		  equals: (self parseMethod: 'variableName ^variableName').
-	self assert: (class parseTreeFor: #variableName:)
+	self assert: (class parseTreeForSelector: #variableName:)
 		  equals: (self parseMethod: 'variableName: anObject variableName := anObject')
 ]
 
@@ -28,8 +28,8 @@ RBAddAccessorsForClassTransformationTest >> testTransform [
 	self assert: transformation model changes changes size equals: 2.
 	
 	class := transformation model classNamed: self changeMock name asSymbol.
-	self assert: (class parseTreeFor: #instVar)
+	self assert: (class parseTreeForSelector: #instVar)
 		  equals: (self parseMethod: 'instVar ^instVar').
-	self assert: (class parseTreeFor: #instVar:)
+	self assert: (class parseTreeForSelector: #instVar:)
 		  equals: (self parseMethod: 'instVar: anObject instVar := anObject')
 ]

--- a/src/Refactoring2-Transformations-Tests/RBAddAssignmentTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddAssignmentTransformationTest.class.st
@@ -56,8 +56,8 @@ RBAddAssignmentTransformationTest >> testRefactoring [
 	
 	class := refactoring model classNamed: #RBAddAssignmentTransformationTest.
 	self assert: (class directlyDefinesMethod: #methodBefore).
-	self assert: (class parseTreeFor: #methodBefore) body statements size equals: 2.
-	self assert: (class parseTreeFor: #methodBefore) body statements last value sourceCode equals: '1 asString'
+	self assert: (class parseTreeForSelector: #methodBefore) body statements size equals: 2.
+	self assert: (class parseTreeForSelector: #methodBefore) body statements last value sourceCode equals: '1 asString'
 ]
 
 { #category : #tests }
@@ -74,8 +74,8 @@ RBAddAssignmentTransformationTest >> testTransform [
 	self assert: transformation model changes changes size equals: 1.
 	
 	class := transformation model classNamed: self class name.
-	self assert: (class parseTreeFor: #methodBefore) body
-			equals: (class parseTreeFor: #methodAfter) body.
+	self assert: (class parseTreeForSelector: #methodBefore) body
+			equals: (class parseTreeForSelector: #methodAfter) body.
 ]
 
 { #category : #tests }

--- a/src/Refactoring2-Transformations-Tests/RBAddMessageSendTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddMessageSendTransformationTest.class.st
@@ -62,8 +62,8 @@ RBAddMessageSendTransformationTest >> testRefactoring [
 	self assert: refactoring model changes changes size equals: 1.
 	
 	class := refactoring model classNamed: #RBAddMessageSendTransformationTest.
-	self assert: (class parseTreeFor: #methodBefore) body
-			equals: (class parseTreeFor: #methodAfter) body.
+	self assert: (class parseTreeForSelector: #methodBefore) body
+			equals: (class parseTreeForSelector: #methodAfter) body.
 ]
 
 { #category : #tests }
@@ -79,6 +79,6 @@ RBAddMessageSendTransformationTest >> testTransform [
 	self assert: transformation model changes changes size equals: 1.
 	
 	class := transformation model classNamed: self class name.
-	self assert: (class parseTreeFor: #methodBefore) body
-			equals: (class parseTreeFor: #methodAfter) body.
+	self assert: (class parseTreeForSelector: #methodBefore) body
+			equals: (class parseTreeForSelector: #methodAfter) body.
 ]

--- a/src/Refactoring2-Transformations-Tests/RBAddMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddMethodParametrizedTest.class.st
@@ -30,7 +30,7 @@ RBAddMethodParametrizedTest >> testAddMethod [
 	
 	self executeRefactoring: refactoring.
 	self assert: ((refactoring model classNamed: #RBBasicLintRuleTestData) 
-			parseTreeFor: #printString1) 
+			parseTreeForSelector: #printString1) 
 		equals: (self parseMethod: 'printString1 ^super printString')
 ]
 
@@ -59,7 +59,7 @@ RBAddMethodParametrizedTest >> testModelAddMethod [
 				class . 
 				#(#accessing)}.
 	self executeRefactoring: refactoring.
-	self assert: (class parseTreeFor: #printString1) 
+	self assert: (class parseTreeForSelector: #printString1) 
 		  equals: (self parseMethod: 'printString1 ^super printString')
 ]
 

--- a/src/Refactoring2-Transformations-Tests/RBAddParameterParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddParameterParametrizedTest.class.st
@@ -39,12 +39,12 @@ RBAddParameterParametrizedTest >> testAddParameterAndRenameParameters [
 	refactoring renameMap: (Array with: ((RBArgumentName name: 'aBlock') newName: 'aBlock1')).
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBRefactoryTestDataApp.
-	self assert: (class parseTreeFor: newSelector) equals: (self parseMethod: 'called: anObject bar: anObject1 on: aBlock1
+	self assert: (class parseTreeForSelector: newSelector) equals: (self parseMethod: 'called: anObject bar: anObject1 on: aBlock1
 							Transcript
 								show: anObject printString;
 								cr.
 								aBlock1 value').
-	self assert: (class parseTreeFor: #caller) equals: (self parseMethod: 'caller
+	self assert: (class parseTreeForSelector: #caller) equals: (self parseMethod: 'caller
 							| anObject |
 							anObject := 5.
 							self 
@@ -63,12 +63,12 @@ RBAddParameterParametrizedTest >> testAddParameterForTwoArgumentMessage [
 		{oldSelector . RBRefactoryTestDataApp . newSelector . #(1 -1 2) . { newArg }}.
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBRefactoryTestDataApp.
-	self assert: (class parseTreeFor: newSelector) equals: (self parseMethod: 'called: anObject bar: anObject1 on: aBlock
+	self assert: (class parseTreeForSelector: newSelector) equals: (self parseMethod: 'called: anObject bar: anObject1 on: aBlock
 							Transcript
 								show: anObject printString;
 								cr.
 								aBlock value').
-	self assert: (class parseTreeFor: #caller) equals: (self parseMethod: 'caller
+	self assert: (class parseTreeForSelector: #caller) equals: (self parseMethod: 'caller
 							| anObject |
 							anObject := 5.
 							self 
@@ -89,11 +89,11 @@ RBAddParameterParametrizedTest >> testAddParameterThatReferencesGlobalAndLiteral
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBRefactoryTestDataApp.
 	self
-		assert: (class parseTreeFor: newSelector)
+		assert: (class parseTreeForSelector: newSelector)
 		equals: (self parseMethod: 'testFoo: anObject bar: anObject1
 								^self class + anObject').
 	self
-		assert: (class parseTreeFor: #callFoo)
+		assert: (class parseTreeForSelector: #callFoo)
 		equals: (self parseMethod:
 				 'callFoo ^self testFoo: 5 bar: (OrderedCollection new: 5)').
 	self deny: (class directlyDefinesMethod: oldSelector)
@@ -111,11 +111,11 @@ RBAddParameterParametrizedTest >> testAddParameterThatReferencesModelGlobal [
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBRefactoryTestDataApp.
 	self
-		assert: (class parseTreeFor: newSelector)
+		assert: (class parseTreeForSelector: newSelector)
 		equals: (self parseMethod: 'testFoo: anObject bar: anObject1
 								^self class + anObject').
 	self
-		assert: (class parseTreeFor: #callFoo)
+		assert: (class parseTreeForSelector: #callFoo)
 		equals:
 		(self parseMethod: 'callFoo ^self testFoo: 5 bar: (Bar new)').
 	self deny: (class directlyDefinesMethod: oldSelector)
@@ -133,11 +133,11 @@ RBAddParameterParametrizedTest >> testAddParameterThatReferencesSelf [
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBRefactoryTestDataApp.
 	self
-		assert: (class parseTreeFor: newSelector)
+		assert: (class parseTreeForSelector: newSelector)
 		equals: (self parseMethod: 'testFoo: anObject bar: aFoo
 								^self class + anObject').
 	self
-		assert: (class parseTreeFor: #callFoo)
+		assert: (class parseTreeForSelector: #callFoo)
 		equals:
 		(self parseMethod:
 			 'callFoo ^self testFoo: 5 bar: (self printString)').
@@ -157,11 +157,11 @@ RBAddParameterParametrizedTest >> testAddTwoParameters [
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBRefactoryTestDataApp.
 	self
-		assert: (class parseTreeFor: newSelector)
+		assert: (class parseTreeForSelector: newSelector)
 		equals: (self parseMethod: 'testColl: aColl foo: anObject string: aString
 								^self class + anObject').
 	self
-		assert: (class parseTreeFor: #callFoo)
+		assert: (class parseTreeForSelector: #callFoo)
 		equals: (self parseMethod:
 				 'callFoo ^self testColl: (OrderedCollection new: 5) foo: 5 string: ''string''').
 	self deny: (class directlyDefinesMethod: oldSelector)

--- a/src/Refactoring2-Transformations-Tests/RBAddPragmaTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddPragmaTransformationTest.class.st
@@ -62,8 +62,8 @@ RBAddPragmaTransformationTest >> testRefactoring [
 	self assert: refactoring model changes changes size equals: 1.
 	
 	class := refactoring model classNamed: #RBAddPragmaTransformationTest.
-	self assert: (class parseTreeFor: #methodBefore) body
-			equals: (class parseTreeFor: #methodAfter) body.
+	self assert: (class parseTreeForSelector: #methodBefore) body
+			equals: (class parseTreeForSelector: #methodAfter) body.
 ]
 
 { #category : #tests }
@@ -79,6 +79,6 @@ RBAddPragmaTransformationTest >> testTransform [
 	self assert: transformation model changes changes size equals: 1.
 	
 	class := transformation model classNamed: self class name.
-	self assert: (class parseTreeFor: #methodBefore) body
-			equals: (class parseTreeFor: #methodAfter) body.
+	self assert: (class parseTreeForSelector: #methodBefore) body
+			equals: (class parseTreeForSelector: #methodAfter) body.
 ]

--- a/src/Refactoring2-Transformations-Tests/RBAddReturnStatementTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddReturnStatementTransformationTest.class.st
@@ -72,8 +72,8 @@ RBAddReturnStatementTransformationTest >> testRefactoring [
 	self assert: refactoring model changes changes size equals: 1.
 	
 	class := refactoring model classNamed: #RBAddReturnStatementTransformationTest.
-	self assert: (class parseTreeFor: #methodBefore) body
-			equals: (class parseTreeFor: #methodAfter) body.
+	self assert: (class parseTreeForSelector: #methodBefore) body
+			equals: (class parseTreeForSelector: #methodAfter) body.
 ]
 
 { #category : #tests }
@@ -89,6 +89,6 @@ RBAddReturnStatementTransformationTest >> testTransform [
 	self assert: transformation model changes changes size equals: 1.
 	
 	class := transformation model classNamed: self class name.
-	self assert: (class parseTreeFor: #methodBefore) body
-			equals: (class parseTreeFor: #methodAfter) body.
+	self assert: (class parseTreeForSelector: #methodBefore) body
+			equals: (class parseTreeForSelector: #methodAfter) body.
 ]

--- a/src/Refactoring2-Transformations-Tests/RBAddSubtreeTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddSubtreeTransformationTest.class.st
@@ -61,5 +61,5 @@ RBAddSubtreeTransformationTest >> testTransform [
 	
 	class := transformation model classNamed: self changeMock name asSymbol.
 	self assert: (class directlyDefinesMethod: #one).
-	self assert: (class parseTreeFor: #one) body statements size equals: 2
+	self assert: (class parseTreeForSelector: #one) body statements size equals: 2
 ]

--- a/src/Refactoring2-Transformations-Tests/RBAddTemporaryVariableParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddTemporaryVariableParametrizedTest.class.st
@@ -28,7 +28,7 @@ RBAddTemporaryVariableParametrizedTest >> testAddTemporaryRefactoring [
 	
 	class := refactoring model classNamed: #RBAddReturnStatementTransformationTest.
 	self assert: (class directlyDefinesMethod: #methodBefore).
-	self assert: (class parseTreeFor: #methodBefore) temporaries size equals: 2
+	self assert: (class parseTreeForSelector: #methodBefore) temporaries size equals: 2
 ]
 
 { #category : #'failure tests' }

--- a/src/Refactoring2-Transformations-Tests/RBAddVariableAccessorsParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddVariableAccessorsParametrizedTest.class.st
@@ -53,8 +53,8 @@ RBAddVariableAccessorsParametrizedTest >> testNewClassVariableAccessors [
 	
 	class := refactoring model metaclassNamed: #RBLintRuleTestData.
 	self denyEmpty: refactoring changes changes.
-	self assert: (class parseTreeFor: #foo1) equals: (self parseMethod: 'foo1 ^Foo1').
-	self assert: (class parseTreeFor: #foo1:) equals: (self parseMethod: 'foo1: anObject Foo1 := anObject')
+	self assert: (class parseTreeForSelector: #foo1) equals: (self parseMethod: 'foo1 ^Foo1').
+	self assert: (class parseTreeForSelector: #foo1:) equals: (self parseMethod: 'foo1: anObject Foo1 := anObject')
 ]
 
 { #category : #tests }
@@ -68,8 +68,8 @@ RBAddVariableAccessorsParametrizedTest >> testNewInstanceVariableAccessors [
 	
 	class := refactoring model classNamed: #RBLintRuleTestData.
 	self denyEmpty: refactoring changes changes.
-	self assert: (class parseTreeFor: #foo1) equals: (self parseMethod: 'foo1 ^foo1').
-	self assert: (class parseTreeFor: #foo1:) equals: (self parseMethod: 'foo1: anObject foo1 := anObject')
+	self assert: (class parseTreeForSelector: #foo1) equals: (self parseMethod: 'foo1 ^foo1').
+	self assert: (class parseTreeForSelector: #foo1:) equals: (self parseMethod: 'foo1: anObject foo1 := anObject')
 ]
 
 { #category : #'failure tests' }

--- a/src/Refactoring2-Transformations-Tests/RBAddVariableAccessorsWithLazyInitializationParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddVariableAccessorsWithLazyInitializationParametrizedTest.class.st
@@ -42,10 +42,10 @@ RBAddVariableAccessorsWithLazyInitializationParametrizedTest >> testExistingClas
 	refactoring := self createRefactoringWithArguments:
 		{ 'Name1' . RBLintRuleTestData . true . nil }.
 	class := refactoring model classNamed: #RBLintRuleTestData.
-	self assert: (class classSide parseTreeFor: #name1) 
+	self assert: (class classSide parseTreeForSelector: #name1) 
 		equals: (self parseMethod: 'name1 ^Name1').
 	self executeRefactoring: refactoring.
-	self assert: (class classSide parseTreeFor: #name1) 
+	self assert: (class classSide parseTreeForSelector: #name1) 
 		equals: (self parseMethod: 'name1 ^Name1 ifNil: [Name1 := nil]').
 ]
 
@@ -55,10 +55,10 @@ RBAddVariableAccessorsWithLazyInitializationParametrizedTest >> testExistingInst
 	refactoring := self createRefactoringWithArguments: 
 		{ 'name' . RBLintRuleTestData . false . nil }.
 	class := refactoring model classNamed: #RBLintRuleTestData.
-	self assert: (class parseTreeFor: #name) 
+	self assert: (class parseTreeForSelector: #name) 
 		equals: (self parseMethod: 'name ^name').
 	self executeRefactoring: refactoring.
-	self assert: (class parseTreeFor: #name) 
+	self assert: (class parseTreeForSelector: #name) 
 		equals: (self parseMethod: 'name ^name ifNil: [name := nil]').
 ]
 
@@ -70,9 +70,9 @@ RBAddVariableAccessorsWithLazyInitializationParametrizedTest >> testNewClassVari
 	self executeRefactoring: ref.
 	class := ref model metaclassNamed: #RBLintRuleTestData.
 	self denyEmpty: ref changes changes.
-	self assert: (class parseTreeFor: #foo1) equals: (self parseMethod: 'foo1 ^Foo1 ifNil: [ Foo1 := ''someString'' ]').
-	self assert: (((class parseTreeFor: #foo1:) = (self parseMethod: 'foo1: anObject ^ Foo1 := anObject')) 
-		or: [ (class parseTreeFor: #foo1:) = (self parseMethod: 'foo1: anObject Foo1 := anObject') ])
+	self assert: (class parseTreeForSelector: #foo1) equals: (self parseMethod: 'foo1 ^Foo1 ifNil: [ Foo1 := ''someString'' ]').
+	self assert: (((class parseTreeForSelector: #foo1:) = (self parseMethod: 'foo1: anObject ^ Foo1 := anObject')) 
+		or: [ (class parseTreeForSelector: #foo1:) = (self parseMethod: 'foo1: anObject Foo1 := anObject') ])
 ]
 
 { #category : #tests }
@@ -83,8 +83,8 @@ RBAddVariableAccessorsWithLazyInitializationParametrizedTest >> testNewInstanceV
 	self executeRefactoring: ref.
 	class := ref model classNamed: #RBLintRuleTestData.
 	self denyEmpty: ref changes changes.
-	self assert: (class parseTreeFor: #foo1) equals: (self parseMethod: 'foo1 ^foo1 ifNil: [foo1 := 123]').
-	self assert: (class parseTreeFor: #foo1:) equals: (self parseMethod: 'foo1: anObject foo1 := anObject')
+	self assert: (class parseTreeForSelector: #foo1) equals: (self parseMethod: 'foo1 ^foo1 ifNil: [foo1 := 123]').
+	self assert: (class parseTreeForSelector: #foo1:) equals: (self parseMethod: 'foo1: anObject foo1 := anObject')
 ]
 
 { #category : #'failure tests' }

--- a/src/Refactoring2-Transformations-Tests/RBBasicDummyLintRuleTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBBasicDummyLintRuleTest.class.st
@@ -1130,7 +1130,7 @@ RBBasicDummyLintRuleTest class >> variableAssignedLiteral [
 								searcher := self parseTreeSearcher.
 								searcher addSearch: (each , ' := ``@object')
 											-> [:aNode :answer | answer isNil and: [aNode value isLiteralNode]].
-								tree := defClass parseTreeFor: selector.
+								tree := defClass parseTreeForSelector: selector.
 								tree notNil ifTrue: 
 										[(searcher executeTree: tree initialAnswer: nil) == true
 											ifTrue: [result addInstVar: each for: context selectedClass]]]]].
@@ -1163,7 +1163,7 @@ RBBasicDummyLintRuleTest class >> variableReferencedOnce [
 							== 1 
 							ifTrue: 
 								[| tree |
-								tree := defClass parseTreeFor: selector.
+								tree := defClass parseTreeForSelector: selector.
 								tree notNil 
 									ifTrue: 
 										[(RBReadBeforeWrittenTester readBeforeWritten: (Array with: each) in: tree) 

--- a/src/Refactoring2-Transformations-Tests/RBChildrenToSiblingsParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBChildrenToSiblingsParametrizedTest.class.st
@@ -72,10 +72,10 @@ RBChildrenToSiblingsParametrizedTest >> testModelChildrenToSibling [
 	self assert: class classSide superclass equals: superclass classSide.
 	self assert: subclass superclass equals: superclass.
 	self assert: subclass classSide superclass equals: superclass classSide.
-	self assert: (superclass parseTreeFor: #same) equals: (self parseMethod: 'same ^self initialize isKindOf: AbstractSuperclass').
-	self assert: (superclass parseTreeFor: #different) equals: (self parseMethod: 'different self subclassResponsibility').
+	self assert: (superclass parseTreeForSelector: #same) equals: (self parseMethod: 'same ^self initialize isKindOf: AbstractSuperclass').
+	self assert: (superclass parseTreeForSelector: #different) equals: (self parseMethod: 'different self subclassResponsibility').
 	self
-		assert: (superclass parseTreeFor: #initialize)
+		assert: (superclass parseTreeForSelector: #initialize)
 		equals:
 			(self
 				parseMethod:
@@ -87,21 +87,21 @@ RBChildrenToSiblingsParametrizedTest >> testModelChildrenToSibling [
 	self assert: (superclass directlyDefinesClassVariable: 'ClassVarName2').
 	self assert: (superclass classSide directlyDefinesInstanceVariable: 'classInstVarName1').
 	self
-		assert: (superclass classSide parseTreeFor: #foo)
+		assert: (superclass classSide parseTreeForSelector: #foo)
 		equals:
 			(self
 				parseMethod:
 					'foo
 							^classInstVarName1 + ClassVarName1 + ClassVarName2').
 	self
-		assert: (superclass classSide parseTreeFor: #new)
+		assert: (superclass classSide parseTreeForSelector: #new)
 		equals:
 			(self
 				parseMethod:
 					'new
 							^super new initialize').
 	self
-		assert: (superclass classSide parseTreeFor: #bar)
+		assert: (superclass classSide parseTreeForSelector: #bar)
 		equals:
 			(self
 				parseMethod:
@@ -116,14 +116,14 @@ RBChildrenToSiblingsParametrizedTest >> testModelChildrenToSibling [
 	self deny: (class directlyDefinesMethod: #initialize).
 	self deny: (class classSide directlyDefinesMethod: #new).
 	self
-		assert: (class parseTreeFor: #different)
+		assert: (class parseTreeForSelector: #different)
 		equals:
 			(self
 				parseMethod:
 					'different
 							^instVarName1 + instVarName2').
 	self
-		assert: (class classSide parseTreeFor: #bar)
+		assert: (class classSide parseTreeForSelector: #bar)
 		equals:
 			(self
 				parseMethod:

--- a/src/Refactoring2-Transformations-Tests/RBCopyPackageParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBCopyPackageParametrizedTest.class.st
@@ -94,7 +94,7 @@ RBCopyPackageParametrizedTest >> testCopyPackageAndChangesCopyReferences [
 		equals: #Object.
 
 	self
-		assert: ((aModel classNamed: #BarFTTest1) parseTreeFor: #foo)
+		assert: ((aModel classNamed: #BarFTTest1) parseTreeForSelector: #foo)
 		equals: (self parseMethod: 'foo
 			^ BarFTTest2')
 ]

--- a/src/Refactoring2-Transformations-Tests/RBDeprecateClassParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBDeprecateClassParametrizedTest.class.st
@@ -66,10 +66,10 @@ RBDeprecateClassParametrizedTest >> testModelRenameClass [
 	self assert: (model classNamed: #ClassDeprecatorTestingClassDeprecated) equals: deprecated.
 	self assert: (model classNamed: #ClassDeprecatorTestingClassDeprecatedUser) equals: user.
 
-	self assert: (user parseTreeFor: #foo)
+	self assert: (user parseTreeForSelector: #foo)
 		equals: (self parseMethod: 'foo ^ClassDeprecatorTestingClassReplacement').
 		
-	self assert: (user parseTreeFor: #objectName) 
+	self assert: (user parseTreeForSelector: #objectName) 
 		equals: (self parseMethod: 'objectName ^#(ClassDeprecatorTestingClassReplacement)').
 
 	self assert: user superclass name 

--- a/src/Refactoring2-Transformations-Tests/RBDeprecateMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBDeprecateMethodParametrizedTest.class.st
@@ -30,7 +30,7 @@ RBDeprecateMethodParametrizedTest >> testDeprecateMethodUsingMethodWithSameNumbe
 	self executeRefactoring: refactoring .
 	class := refactoring model classNamed: #RBRefactoryTestDataApp.
 	self
-		assert: ((class parseTreeFor: oldSelector ) statements anySatisfy: 
+		assert: ((class parseTreeForSelector: oldSelector ) statements anySatisfy: 
 			[ :e | e isMessage ifTrue: [ e selector = #deprecated:on:in: ] ]).
 ]
 
@@ -47,7 +47,7 @@ RBDeprecateMethodParametrizedTest >> testDeprecateMethodUsingMethodWithoutArgs [
 	self executeRefactoring: refactoring .
 	class := refactoring model classNamed: #RBRefactoryTestDataApp.
 	self
-		assert: ((class parseTreeFor: oldSelector ) statements anySatisfy: 
+		assert: ((class parseTreeForSelector: oldSelector ) statements anySatisfy: 
 			[ :e | e isMessage and: [ e selector = #deprecated:on:in: ] ]).
 ]
 

--- a/src/Refactoring2-Transformations-Tests/RBExtractMethodAndOccurrencesParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBExtractMethodAndOccurrencesParametrizedTest.class.st
@@ -39,14 +39,14 @@ RBExtractMethodAndOccurrencesParametrizedTest >> testExtractMethodWithTwoArgsAnd
 	self setupSearchInAllHierarchyFor: refactoring toReturn: true.
 	self setupMethodNameFor: refactoring toReturn: #stringArg:streamArg:.
 	self executeRefactoring: refactoring.
-	self assert: (class parseTreeFor: #stringArg:streamArg:) equals: (self parseMethod: 'stringArg: string streamArg: nameStream
+	self assert: (class parseTreeForSelector: #stringArg:streamArg:) equals: (self parseMethod: 'stringArg: string streamArg: nameStream
 
 	nameStream
 		nextPutAll: string;
 		nextPutAll: '' (''.
 	self problemCount printOn: nameStream.
 	nameStream nextPut: $)').
-	self assert: (class parseTreeFor: #displayName) equals: (self parseMethod: 'displayName
+	self assert: (class parseTreeForSelector: #displayName) equals: (self parseMethod: 'displayName
 
 	| nameStream string |
 	string := self name.
@@ -54,7 +54,7 @@ RBExtractMethodAndOccurrencesParametrizedTest >> testExtractMethodWithTwoArgsAnd
 	self stringArg: string streamArg: nameStream.
 	^ nameStream contents').
 	class := model classNamed: #MyClassB.
-	self assert: (class parseTreeFor: #anotherMethod) equals: (self parseMethod: 'anotherMethod
+	self assert: (class parseTreeForSelector: #anotherMethod) equals: (self parseMethod: 'anotherMethod
 
 	| aStream |
 	aStream := WriteStream on: (String new: 128).
@@ -70,9 +70,9 @@ RBExtractMethodAndOccurrencesParametrizedTest >> testExtractSimpleMethodAndOcurr
 	self setupSearchInAllHierarchyFor: refactoring toReturn: true.
 	self setupMethodNameFor: refactoring toReturn: #extractedMethod.
 	self executeRefactoring: refactoring.
-	self assert: (class parseTreeFor: #extractedMethod) equals: (self parseMethod: 'extractedMethod
+	self assert: (class parseTreeForSelector: #extractedMethod) equals: (self parseMethod: 'extractedMethod
 	^ currentChar isLetter.').
-	self assert: (class parseTreeFor: #myMethod) equals: (self parseMethod: 'myMethod
+	self assert: (class parseTreeForSelector: #myMethod) equals: (self parseMethod: 'myMethod
 
 	| token |
 	token := (String new: 100) writeStream.
@@ -87,11 +87,11 @@ RBExtractMethodAndOccurrencesParametrizedTest >> testExtractSimpleMethodAndOcurr
 	token := self extractedMethod example.
 	^ token contents').
 	class := model classNamed: #MyClassB.
-	self assert: (class parseTreeFor: #exampleMethod) equals: (self parseMethod: 'exampleMethod
+	self assert: (class parseTreeForSelector: #exampleMethod) equals: (self parseMethod: 'exampleMethod
 
 	^ self extractedMethod not').
 	class := model classNamed: #MyClassC.
-	self assert: (class parseTreeFor: #methodWithArg:) equals: (self parseMethod: 'methodWithArg: anArg
+	self assert: (class parseTreeForSelector: #methodWithArg:) equals: (self parseMethod: 'methodWithArg: anArg
 
 	(self extractedMethod and: [ anArg isDecimal ]) ifTrue: [ ^ self ].
 	^ nil')

--- a/src/Refactoring2-Transformations-Tests/RBExtractMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBExtractMethodParametrizedTest.class.st
@@ -42,11 +42,11 @@ RBExtractMethodParametrizedTest >> testExtractMethodAtEndOfMethodThatNeedsReturn
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBLintRuleTestData.
 
-	self assert: (class parseTreeFor: #openEditor) equals: (self parseMethod: 'openEditor
+	self assert: (class parseTreeForSelector: #openEditor) equals: (self parseMethod: 'openEditor
 	| rules |
 	rules := self failedRules.
 	^self foo: rules').
-	self assert: (class parseTreeFor: #foo:) equals: (self parseMethod: 'foo: rules
+	self assert: (class parseTreeForSelector: #foo:) equals: (self parseMethod: 'foo: rules
 	rules isEmpty ifTrue: [^self].
 	rules size == 1 ifTrue: [^rules first viewResults]')
 ]
@@ -59,11 +59,11 @@ RBExtractMethodParametrizedTest >> testExtractMethodThatMovesTemporaryVariable [
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
 
-	self assert: (class parseTreeFor: #superSends) equals: (self parseMethod: 'superSends
+	self assert: (class parseTreeForSelector: #superSends) equals: (self parseMethod: 'superSends
 	| rule |
 	rule := self foo1.
 	self rewriteUsing: rule').
-	self assert: (class parseTreeFor: #foo1) equals: (self parseMethod: 'foo1 | rule | 	rule := RBParseTreeRewriter new.
+	self assert: (class parseTreeForSelector: #foo1) equals: (self parseMethod: 'foo1 | rule | 	rule := RBParseTreeRewriter new.
 	rule addSearch: ''super `@message: ``@args''
 				-> (
 					[:aNode | 
@@ -82,11 +82,11 @@ RBExtractMethodParametrizedTest >> testExtractMethodThatNeedsArgument [
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
 
-	self assert: (class parseTreeFor: #checkMethod:) equals: (self parseMethod: 'checkMethod: aSmalllintContext 
+	self assert: (class parseTreeForSelector: #checkMethod:) equals: (self parseMethod: 'checkMethod: aSmalllintContext 
 	class := aSmalllintContext selectedClass.
 	(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: 
 			[self foo: aSmalllintContext]').
-	self assert: (class parseTreeFor: #foo:) equals: (self parseMethod: 'foo: aSmalllintContext (RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
+	self assert: (class parseTreeForSelector: #foo:) equals: (self parseMethod: 'foo: aSmalllintContext (RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
 				ifFalse: 
 					[builder compile: rewriteRule tree printString
 						in: class
@@ -101,13 +101,13 @@ RBExtractMethodParametrizedTest >> testExtractMethodThatNeedsTemporaryVariable [
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBLintRuleTestData.
 
-	self assert: (class parseTreeFor: #displayName) equals: (self parseMethod: 'displayName
+	self assert: (class parseTreeForSelector: #displayName) equals: (self parseMethod: 'displayName
 	| nameStream |
 	nameStream := WriteStream on: (String new: 64).
 	self foo: nameStream.
 	^nameStream contents').
 
-	self assert: (class parseTreeFor: #foo:) equals: (self parseMethod: 'foo: nameStream 	nameStream nextPutAll: self name;
+	self assert: (class parseTreeForSelector: #foo:) equals: (self parseMethod: 'foo: nameStream 	nameStream nextPutAll: self name;
 		nextPutAll: '' (''.
 	self problemCount printOn: nameStream.
 	nameStream nextPut: $).')
@@ -122,13 +122,13 @@ RBExtractMethodParametrizedTest >> testExtractMethodToSuperclass [
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
 
-	self assert: (class parseTreeFor: #checkMethod:) equals: (self parseMethod: 'checkMethod: aSmalllintContext 
+	self assert: (class parseTreeForSelector: #checkMethod:) equals: (self parseMethod: 'checkMethod: aSmalllintContext 
 	class := aSmalllintContext selectedClass.
 	(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: 
 			[self foo: aSmalllintContext]').
 	
 	class := refactoring model classNamed: #RBFooLintRuleTestData.
-	self assert: (class parseTreeFor: #foo:) equals: (self parseMethod: 'foo: aSmalllintContext (RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
+	self assert: (class parseTreeForSelector: #foo:) equals: (self parseMethod: 'foo: aSmalllintContext (RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
 				ifFalse: 
 					[builder compile: rewriteRule tree printString
 						in: class
@@ -147,7 +147,7 @@ RBExtractMethodParametrizedTest >> testExtractWithRenamingOfParameters [
 	class := refactoring model classNamed: #RBLintRuleTestData.
 
 	self
-		assert: (class parseTreeFor: #displayName)
+		assert: (class parseTreeForSelector: #displayName)
 		equals:
 			(self
 				parseMethod:
@@ -158,7 +158,7 @@ RBExtractMethodParametrizedTest >> testExtractWithRenamingOfParameters [
 	^nameStream contents').
 	"Extracted method with renamed parameters"
 	self
-		assert: (class parseTreeFor: #foo:)
+		assert: (class parseTreeForSelector: #foo:)
 		equals:
 			(self
 				parseMethod:
@@ -179,9 +179,9 @@ RBExtractMethodParametrizedTest >> testModelExtractMethodWithTemporariesSelected
 		andArguments: { (6 to: 36) . #foo . class }.
 	self setupMethodNameFor: refactoring toReturn: #foobar.
 	self executeRefactoring: refactoring.
-	self assert: (class parseTreeFor: #foo) 
+	self assert: (class parseTreeForSelector: #foo) 
 			equals: (self parseMethod: 'foo [self foobar] value').
-	self assert: (class parseTreeFor: #foobar) 
+	self assert: (class parseTreeForSelector: #foobar) 
 			equals: (self parseMethod: 'foobar |temp | temp := 5. ^temp * temp')
 ]
 
@@ -197,12 +197,12 @@ RBExtractMethodParametrizedTest >> testModelExtractMethodWithTemporaryAssigned [
 		andArguments: { (26 to: 102) . #foo . class }.
 	self setupMethodNameFor: refactoring toReturn: #foobar.
 	self executeRefactoring: refactoring.
-	self assert: (class parseTreeFor: #foo) 
+	self assert: (class parseTreeForSelector: #foo) 
 			equals: (self parseMethod: 'foo | temp | temp := self foobar. ^temp * temp').
 	self 
-		assert: ((class parseTreeFor: #foobar) = (self 
+		assert: ((class parseTreeForSelector: #foobar) = (self 
 						parseMethod: 'foobar | bar temp | bar := 5. temp := bar * bar. Transcript show: temp printString; cr. ^temp.')) |
-				((class parseTreeFor: #foobar) = (self 
+				((class parseTreeForSelector: #foobar) = (self 
 						parseMethod: 'foobar | temp bar | bar := 5. temp := bar * bar. Transcript show: temp printString; cr. ^temp.'))
 ]
 

--- a/src/Refactoring2-Transformations-Tests/RBExtractMethodToComponentParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBExtractMethodToComponentParametrizedTest.class.st
@@ -47,7 +47,7 @@ RBExtractMethodToComponentParametrizedTest >> testExtractMethodAtEndOfMethodThat
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 
 	self
-		assert: (class parseTreeFor: #openEditor)
+		assert: (class parseTreeForSelector: #openEditor)
 		equals:
 			(self
 				parseMethod:
@@ -56,7 +56,7 @@ RBExtractMethodToComponentParametrizedTest >> testExtractMethodAtEndOfMethodThat
 								rules := self failedRules.
 								^rules foo: self').
 	self
-		assert: ((refactoring model classNamed: #Collection) parseTreeFor: #foo:)
+		assert: ((refactoring model classNamed: #Collection) parseTreeForSelector: #foo:)
 		equals:
 			(self
 				parseMethod:
@@ -78,9 +78,9 @@ RBExtractMethodToComponentParametrizedTest >> testMoveWithoutSelfReference [
 	selectorsSize := class selectors size.
 	self executeRefactoring: refactoring.
 
-	self assert: (class parseTreeFor: #copyDictionary:) equals: (self parseMethod: 'copyDictionary: aDictionary ^aDictionary copyWithAssociations').
+	self assert: (class parseTreeForSelector: #copyDictionary:) equals: (self parseMethod: 'copyDictionary: aDictionary ^aDictionary copyWithAssociations').
 	self
-		assert: ((refactoring model classNamed: #Dictionary) parseTreeFor: #copyWithAssociations)
+		assert: ((refactoring model classNamed: #Dictionary) parseTreeForSelector: #copyWithAssociations)
 		equals:
 			(self
 				parseMethod:

--- a/src/Refactoring2-Transformations-Tests/RBExtractMethodTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBExtractMethodTransformationTest.class.st
@@ -67,7 +67,7 @@ RBExtractMethodTransformationTest >> testExtractUsingExistingMethodRefactoring [
 	self assert: transformation model changes changes size equals: 1.
 	
 	class := transformation model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeFor: #checkMethod:) 
+	self assert: (class parseTreeForSelector: #checkMethod:) 
 		  equals: (self parseMethod: 'checkMethod: aSmalllintContext
 	class := aSmalllintContext selectedClass.
 	(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: [ 
@@ -95,7 +95,7 @@ RBExtractMethodTransformationTest >> testExtractWithoutUseExistingMethodRefactor
 	self assert: transformation model changes changes size equals: 2.
 	
 	class := transformation model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeFor: #checkMethod:) 
+	self assert: (class parseTreeForSelector: #checkMethod:) 
 		  equals: (self parseMethod: 'checkMethod: aSmalllintContext
 	class := aSmalllintContext selectedClass.
 	(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: [ 
@@ -106,7 +106,7 @@ RBExtractMethodTransformationTest >> testExtractWithoutUseExistingMethodRefactor
 				compile: self bar
 				in: class
 				classified: aSmalllintContext protocols ] ]').	
-	self assert: (class parseTreeFor: #bar)
+	self assert: (class parseTreeForSelector: #bar)
 		equals: (self parseMethod: 'bar
 		rewriteRule tree printString').
 	self assert: (class directlyDefinesMethod: #bar)
@@ -137,12 +137,12 @@ RBExtractMethodTransformationTest >> testNeedsReturn [
 	self assert: refactoring model changes changes size equals: 2.
 	
 	class := refactoring model classNamed: #RBDummyLintRuleTest.
-	self assert: (class parseTreeFor: #openEditor)
+	self assert: (class parseTreeForSelector: #openEditor)
 		  equals: (self parseMethod: 'openEditor
 				| rules |
 				rules := self failedRules.
 				^self foo: rules').
-	self assert: (class parseTreeFor: #foo:)
+	self assert: (class parseTreeForSelector: #foo:)
 		  equals: (self parseMethod: 'foo: rules
 				rules isEmpty ifTrue: [^self].
 				rules size == 1 ifTrue: [^rules first viewResults]')
@@ -166,12 +166,12 @@ RBExtractMethodTransformationTest >> testRefactoring [
 	self assert: transformation model changes changes size equals: 2.
 	
 	class := transformation model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeFor: #checkMethod:) 
+	self assert: (class parseTreeForSelector: #checkMethod:) 
 		  equals: (self parseMethod: 'checkMethod: aSmalllintContext 
 			class := aSmalllintContext selectedClass.
 			(rewriteRule executeTree: aSmalllintContext parseTree)
 				ifTrue: [self foo: aSmalllintContext]').	
-	self assert: (class parseTreeFor: #foo:)
+	self assert: (class parseTreeForSelector: #foo:)
 		  equals: (self parseMethod: 'foo: aSmalllintContext 
 			(RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
 				ifFalse: [ builder
@@ -208,12 +208,12 @@ RBExtractMethodTransformationTest >> testTransform [
 	self assert: transformation model changes changes size equals: 4.			
 	
 	class := transformation model classNamed: self changeMock name.		
-	self assert: (class parseTreeFor: #foo) 
+	self assert: (class parseTreeForSelector: #foo) 
 		  equals: (self parseMethod: 'foo
 													| temp |
 													temp := self foobar.
 													^temp * temp').
-	self assert: (class parseTreeFor: #foobar)
+	self assert: (class parseTreeForSelector: #foobar)
 		  equals: (self parseMethod: 'foobar
 													| temp bar |
 													bar := 5.
@@ -237,12 +237,12 @@ RBExtractMethodTransformationTest >> testWithArgument [
 	self assert: refactoring model changes changes size equals: 2.
 		
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeFor: #checkMethod:) 
+	self assert: (class parseTreeForSelector: #checkMethod:) 
 		  equals: (self parseMethod: 'checkMethod: aSmalllintContext 
 					class := aSmalllintContext selectedClass.
 					(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: 
 						[self foo: aSmalllintContext]').
-	self assert: (class parseTreeFor: #foo:) 
+	self assert: (class parseTreeForSelector: #foo:) 
 		  equals: (self parseMethod: 'foo: aSmalllintContext
 					(RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
 						ifFalse: 
@@ -269,9 +269,9 @@ RBExtractMethodTransformationTest >> testWithTemporariesSelected [
 		asRefactoring transform. 
 	
 	self assert: refactoring model changes changes size equals: 4.
-	self assert: (class parseTreeFor: #foo) 
+	self assert: (class parseTreeForSelector: #foo) 
 		  equals: (self parseMethod: 'foo [self foobar] value').
-	self assert: (class parseTreeFor: #foobar) 
+	self assert: (class parseTreeForSelector: #foobar) 
 		  equals: (self parseMethod: 'foobar |temp | temp := 5. ^temp * temp')
 ]
 
@@ -298,9 +298,9 @@ RBExtractMethodTransformationTest >> testWithTemporaryAssigned [
 			asRefactoring transform.
 	
 	self assert: refactoring model changes changes size equals: 4.
-	self assert: (class parseTreeFor: #foo) 
+	self assert: (class parseTreeForSelector: #foo) 
 		  equals: (self parseMethod: 'foo | temp | temp := self foobar. ^temp * temp').
-	self assert: (class parseTreeFor: #foobar) 
+	self assert: (class parseTreeForSelector: #foobar) 
 		  equals: (self parseMethod: 'foobar | temp bar | bar := 5. temp := bar * bar. Transcript show: temp printString; cr. ^temp.')
 ]
 
@@ -319,12 +319,12 @@ RBExtractMethodTransformationTest >> testWithTemporaryVariable [
 	self assert: refactoring model changes changes size equals: 2.
 	
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeFor: #superSends)
+	self assert: (class parseTreeForSelector: #superSends)
 		  equals: (self parseMethod: 'superSends
 				| rule |
 				rule := self foo1.
 				self rewriteUsing: rule').
-	self assert: (class parseTreeFor: #foo1)
+	self assert: (class parseTreeForSelector: #foo1)
 		  equals: (self parseMethod: 'foo1 | rule |
 				rule := RBParseTreeRewriter new.
 				rule addSearch: ''super `@message: ``@args''
@@ -351,13 +351,13 @@ RBExtractMethodTransformationTest >> testWithTemporaryVariable2 [
 	self assert: refactoring model changes changes size equals: 2.
 
 	class := refactoring model classNamed: #RBDummyLintRuleTest.
-	self assert: (class parseTreeFor: #displayName)
+	self assert: (class parseTreeForSelector: #displayName)
 		  equals: (self parseMethod: 'displayName
 					| nameStream |
 					nameStream := WriteStream on: (String new: 64).
 					self foo: nameStream.
 					^nameStream contents').
-	self assert: (class parseTreeFor: #foo:)
+	self assert: (class parseTreeForSelector: #foo:)
 		  equals: (self parseMethod: 'foo: nameStream
 					nameStream nextPutAll: self name;
 								nextPutAll: '' (''.

--- a/src/Refactoring2-Transformations-Tests/RBExtractSetUpMethodAndOccurrencesParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBExtractSetUpMethodAndOccurrencesParametrizedTest.class.st
@@ -39,19 +39,19 @@ RBExtractSetUpMethodAndOccurrencesParametrizedTest >> testExtractSimpleMethodAnd
 	self setupSearchInAllHierarchyFor: refactoring toReturn: true.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBTest.
-	self assert: (class parseTreeFor: #setUp) 
+	self assert: (class parseTreeForSelector: #setUp) 
 		equals: (self parseMethod: 'setUp
 		super setUp. self someClasses. aString := ''Example''').
-	self assert: (class parseTreeFor: #testExample1) 
+	self assert: (class parseTreeForSelector: #testExample1) 
 		equals: (self parseMethod: 'testExample1 
 		self assert: 4 > 5 equals: false').
-	self assert: (class parseTreeFor: #testExample2) 
+	self assert: (class parseTreeForSelector: #testExample2) 
 		equals: (self parseMethod: 'testExample2
 		self assert: true').
-	self assert: (class parseTreeFor: #testExample3) 
+	self assert: (class parseTreeForSelector: #testExample3) 
 		equals: (self parseMethod: 'testExample3
 		self deny: false').
-	self assert: (class parseTreeFor: #testExample4) 
+	self assert: (class parseTreeForSelector: #testExample4) 
 		equals: (self parseMethod: 'testExample4
 		self assert: true.
 		self deny: false').

--- a/src/Refactoring2-Transformations-Tests/RBExtractSetUpMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBExtractSetUpMethodParametrizedTest.class.st
@@ -35,9 +35,9 @@ RBExtractSetUpMethodParametrizedTest >> testExtractSetUp [
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBDataTest.
 
-	self assert: (class parseTreeFor: #testExample) equals: (self parseMethod: 'testExample
+	self assert: (class parseTreeForSelector: #testExample) equals: (self parseMethod: 'testExample
 	self assert: true').
-	self assert: (class parseTreeFor: #setUp) equals: (self parseMethod: 'setUp
+	self assert: (class parseTreeForSelector: #setUp) equals: (self parseMethod: 'setUp
 	super setUp.
 	self someMethod')
 ]
@@ -49,19 +49,19 @@ RBExtractSetUpMethodParametrizedTest >> testExtractSetUpAndConvertTempsToInstVar
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBDataTest.
 	self assert: (class instanceVariableNames includes: #aString). 
-	self assert: (class parseTreeFor: #testExample1) equals: (self parseMethod: 'testExample1
+	self assert: (class parseTreeForSelector: #testExample1) equals: (self parseMethod: 'testExample1
 	| aNumber |
 	aNumber := 4.
 	self assert: aString isNotEmpty.
 	self deny: (aString , aNumber asString) isEmpty.
 	self assert: true').
-	self assert: (class parseTreeFor: #testExample2) equals: (self parseMethod: 'testExample2
+	self assert: (class parseTreeForSelector: #testExample2) equals: (self parseMethod: 'testExample2
 	| aNumber |
 	aString := ''sa''.
 	self someMethod.
 	aNumber := 4.
 	self assert: aString isNotEmpty.').
-	self assert: (class parseTreeFor: #setUp) equals: (self parseMethod: 'setUp
+	self assert: (class parseTreeForSelector: #setUp) equals: (self parseMethod: 'setUp
 	super setUp.
 	aString := ''Some string''.
 	self someMethod.')
@@ -75,16 +75,16 @@ RBExtractSetUpMethodParametrizedTest >> testExtractSetUpAndConvertTwoTempsToInst
 	class := refactoring model classNamed: #RBDataTest.
 	self assert: (class instanceVariableNames includes: #aString). 
 	self assert: (class instanceVariableNames includes: #aNumber). 
-	self assert: (class parseTreeFor: #testExample1) equals: (self parseMethod: 'testExample1
+	self assert: (class parseTreeForSelector: #testExample1) equals: (self parseMethod: 'testExample1
 	self assert: aString isNotEmpty.
 	self deny: (aString , aNumber asString) isEmpty.
 	self assert: true').
-	self assert: (class parseTreeFor: #testExample2) equals: (self parseMethod: 'testExample2
+	self assert: (class parseTreeForSelector: #testExample2) equals: (self parseMethod: 'testExample2
 	aString := ''sa''.
 	self someMethod.
 	aNumber := 4.
 	self assert: aString isNotEmpty.').
-	self assert: (class parseTreeFor: #setUp) equals: (self parseMethod: 'setUp
+	self assert: (class parseTreeForSelector: #setUp) equals: (self parseMethod: 'setUp
 	super setUp.
 	aString := ''Some string''.
 	self someMethod.

--- a/src/Refactoring2-Transformations-Tests/RBExtractToTemporaryParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBExtractToTemporaryParametrizedTest.class.st
@@ -45,7 +45,7 @@ RBExtractToTemporaryParametrizedTest >> testExtractToTemporaryForLastStatementIn
 		{ (52 to: 73) . 'temp' . methodName . RBRefactoryTestDataApp }.
 	self executeRefactoring: refactoring.
 
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: methodName) equals: (self parseMethod: 'caller2
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeForSelector: methodName) equals: (self parseMethod: 'caller2
 	^(1 to: 10) inject: 1 into: [:sum :each | | temp | temp := sum * (self foo: each). temp]')
 ]
 
@@ -56,7 +56,7 @@ RBExtractToTemporaryParametrizedTest >> testExtractToTemporaryInsideBlock [
 		{ (133 to: 141) . 'asdf' . #noMoveDefinition . RBRefactoryTestDataApp }.
 	self executeRefactoring: refactoring.
 
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #noMoveDefinition) equals: (self parseMethod: 'noMoveDefinition
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeForSelector: #noMoveDefinition) equals: (self parseMethod: 'noMoveDefinition
 	| temp |
 	^(self collect: 
 			[:each | 
@@ -71,7 +71,7 @@ RBExtractToTemporaryParametrizedTest >> testExtractToTemporaryWithDuplicates [
 	refactoring := self createRefactoringWithArguments: 
 		{ (73 to: 77) . 'temp' . #demoMethodWithDuplicates . RBRefactoryTestDataApp }.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #demoMethodWithDuplicates) equals: (self parseMethod: 'demoMethodWithDuplicates
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeForSelector: #demoMethodWithDuplicates) equals: (self parseMethod: 'demoMethodWithDuplicates
 	| a b result1 result2 answer temp |
 	a := 3.
 	temp := a + 5.

--- a/src/Refactoring2-Transformations-Tests/RBFindAndReplaceParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBFindAndReplaceParametrizedTest.class.st
@@ -58,7 +58,7 @@ RBFindAndReplaceParametrizedTest >> testFindOcurrencesInClass [
 	refactoring := self createRefactoringWithModel: model
 		andArguments: {#simpleMethod . class . false }.
 	self executeRefactoring: refactoring.
-	self assert: (class parseTreeFor: #myMethod) equals: (self parseMethod: 'myMethod
+	self assert: (class parseTreeForSelector: #myMethod) equals: (self parseMethod: 'myMethod
 
 	| token |
 	token := (String new: 100) writeStream.
@@ -73,11 +73,11 @@ RBFindAndReplaceParametrizedTest >> testFindOcurrencesInClass [
 	token := self simpleMethod example.
 	^ token contents').
 	class := model classNamed: #MyClassB.
-	self assert: (class parseTreeFor: #exampleMethod) equals: (self parseMethod: 'exampleMethod
+	self assert: (class parseTreeForSelector: #exampleMethod) equals: (self parseMethod: 'exampleMethod
 
 	^ currentChar isLetter not').
 	class := model classNamed: #MyClassC.
-	self assert: (class parseTreeFor: #methodWithArg:) equals: (self parseMethod: 'methodWithArg: anArg
+	self assert: (class parseTreeForSelector: #methodWithArg:) equals: (self parseMethod: 'methodWithArg: anArg
 
 	(currentChar isLetter and: [ anArg isDecimal ]) ifTrue: [ ^ self ].
 	^ nil')
@@ -94,7 +94,7 @@ RBFindAndReplaceParametrizedTest >> testFindOcurrencesInHierarchy [
 	refactoring := self createRefactoringWithModel: model
 		andArguments: { #simpleMethod . class . true }.
 	self executeRefactoring: refactoring.
-	self assert: (class parseTreeFor: #myMethod) equals: (self parseMethod: 'myMethod
+	self assert: (class parseTreeForSelector: #myMethod) equals: (self parseMethod: 'myMethod
 
 	| token |
 	token := (String new: 100) writeStream.
@@ -109,11 +109,11 @@ RBFindAndReplaceParametrizedTest >> testFindOcurrencesInHierarchy [
 	token := self simpleMethod example.
 	^ token contents').
 	class := model classNamed: #MyClassB.
-	self assert: (class parseTreeFor: #exampleMethod) equals: (self parseMethod: 'exampleMethod
+	self assert: (class parseTreeForSelector: #exampleMethod) equals: (self parseMethod: 'exampleMethod
 
 	^ self simpleMethod not').
 	class := model classNamed: #MyClassC.
-	self assert: (class parseTreeFor: #methodWithArg:) equals: (self parseMethod: 'methodWithArg: anArg
+	self assert: (class parseTreeForSelector: #methodWithArg:) equals: (self parseMethod: 'methodWithArg: anArg
 
 	(self simpleMethod and: [ anArg isDecimal ]) ifTrue: [ ^ self ].
 	^ nil')
@@ -131,6 +131,6 @@ RBFindAndReplaceParametrizedTest >> testFindOcurrencesWithArgInHierarchy [
 		andArguments: { #methodWithArg:andArg: . class . true }.
 	self executeRefactoring: refactoring.
 	class := model classNamed: #MyClassB.
-	self assert: (class parseTreeFor: #dummyMethod) equals: (self parseMethod: 
+	self assert: (class parseTreeForSelector: #dummyMethod) equals: (self parseMethod: 
 	'dummyMethod self methodWithArg: 3 andArg: self someMethod')
 ]

--- a/src/Refactoring2-Transformations-Tests/RBFindAndReplaceSetUpParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBFindAndReplaceSetUpParametrizedTest.class.st
@@ -31,16 +31,16 @@ RBFindAndReplaceSetUpParametrizedTest >> testReplaceSetUp [
 	class compile: 'setUp self someClasses. aString := ''Example''.'
 		classified: #(#accessing).
 	self executeRefactoring: refactoring.
-	self assert: (class parseTreeFor: #testExample1) 
+	self assert: (class parseTreeForSelector: #testExample1) 
 		equals: (self parseMethod: 'testExample1 
 		self assert: 4 > 5 equals: false').
-	self assert: (class parseTreeFor: #testExample2) 
+	self assert: (class parseTreeForSelector: #testExample2) 
 		equals: (self parseMethod: 'testExample2
 		self assert: true').
-	self assert: (class parseTreeFor: #testExample3) 
+	self assert: (class parseTreeForSelector: #testExample3) 
 		equals: (self parseMethod: 'testExample3
 		self deny: false').
-	self assert: (class parseTreeFor: #testExample4) 
+	self assert: (class parseTreeForSelector: #testExample4) 
 		equals: (self parseMethod: 'testExample4
 		self assert: true.
 		self deny: false').

--- a/src/Refactoring2-Transformations-Tests/RBInlineAllMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBInlineAllMethodParametrizedTest.class.st
@@ -26,7 +26,7 @@ RBInlineAllMethodParametrizedTest >> testInlineMethodCalledAsSuper [
 	class compile: 'foo: arg1 bar: arg2 ^ (super foo: arg1 bar: arg2) - arg1' classified: #(#accessing).
 	self executeRefactoring: (self createRefactoringWithModel: model
 		andArguments: { #foo:bar: . superclass }).
-	self assert: (class parseTreeFor: #foo:bar:) 
+	self assert: (class parseTreeForSelector: #foo:bar:) 
 			equals: (self parseMethod: 'foo: arg1 bar: arg2 ^ (arg1 + arg2) - arg1')
 ]
 
@@ -49,7 +49,7 @@ RBInlineAllMethodParametrizedTest >> testInlineMethodWithMultipleArgs [
 		classified: #(#accessing).
 	self executeRefactoring: (self createRefactoringWithModel: model
 		andArguments: { #foo:bar: . class }).
-	self assert: (class parseTreeFor: #exampleInline) 
+	self assert: (class parseTreeForSelector: #exampleInline) 
 			equals: (self parseMethod: 'exampleInline
 	| x |
 	x := 3 + (a + b).
@@ -63,9 +63,9 @@ RBInlineAllMethodParametrizedTest >> testInlineMethodWithMultipleSendersInMethod
 	refactoring := self createRefactoringWithArguments:  
 		{ methodName . RBRefactoryTestDataApp }.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineLast) equals: (self parseMethod: 'inlineLast
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeForSelector: #inlineLast) equals: (self parseMethod: 'inlineLast
 	5 = 3 ifTrue: [^self caller] ifFalse: [^(1 to: 10) inject: 1 into: [:sum :each | sum * (self foo: each)]] ').
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #multipleCalls) equals: (self parseMethod: 'multipleCalls
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeForSelector: #multipleCalls) equals: (self parseMethod: 'multipleCalls
 	(1 to: 10) inject: 1 into: [:sum :each | sum * (self foo: each)].
 	(1 to: 10) inject: 1 into: [:sum1 :each1 | sum1 * (self foo: each1)]')
 ]
@@ -80,8 +80,8 @@ RBInlineAllMethodParametrizedTest >> testRecursiveMethod [
 		compile: 'bar ^self foo' classified: #(#accessing).
 	self executeRefactoring: (self createRefactoringWithModel: model
 		andArguments: { #foo . class }).
-	self assert: (class parseTreeFor: #foo) 
+	self assert: (class parseTreeForSelector: #foo) 
 			equals: (self parseMethod: 'foo ^self foo').
-	self assert: (class parseTreeFor: #bar) 
+	self assert: (class parseTreeForSelector: #bar) 
 			equals: (self parseMethod: 'bar ^self foo')
 ]

--- a/src/Refactoring2-Transformations-Tests/RBInlineMethodFromComponentParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBInlineMethodFromComponentParametrizedTest.class.st
@@ -30,7 +30,7 @@ RBInlineMethodFromComponentParametrizedTest >> testInlineComponentIntoCascadedMe
 			toReturn: false.
 		self executeRefactoring: refactoring ].
 	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) 
-		parseTreeFor: #inlineComponent) 
+		parseTreeForSelector: #inlineComponent) 
 		equals: (self parseMethod: 'inlineComponent
 	| a aBehavior |
 	a := 5.
@@ -62,7 +62,7 @@ RBInlineMethodFromComponentParametrizedTest >> testInlineComponentMethodMax [
 			setupImplementorToInlineFor: refactoring
 			toReturn: class.
 		self executeRefactoring: refactoring ].
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineMax) equals: (self parseMethod: 'inlineMax
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeForSelector: #inlineMax) equals: (self parseMethod: 'inlineMax
 								| x y q |
 								x := 5.
 								y := 10.
@@ -88,7 +88,7 @@ RBInlineMethodFromComponentParametrizedTest >> testInlineEmptyComponentMethod [
 			toReturn: (refactoring model classNamed: #Object).
 		self executeRefactoring: refactoring ].
 	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) 
-		parseTreeFor: #inlineComponent) 
+		parseTreeForSelector: #inlineComponent) 
 		equals: (self parseMethod: 'inlineComponent
 	| a anObject |
 	a := 5.
@@ -118,7 +118,7 @@ RBInlineMethodFromComponentParametrizedTest >> testModelInlineMethodWithSameVari
 				{ (72 to: 84) . #foo . (model classNamed: #Object)}.
 			self setupInlineExpressionFor: refactoring toReturn: false.
 			self executeRefactoring: refactoring].
-	self assert: ((refactoring model classNamed: #Object) parseTreeFor: #foo) 
+	self assert: ((refactoring model classNamed: #Object) parseTreeForSelector: #foo) 
 			equals: (self 
 						parseMethod: 'foo | a b c | a := InlineMethodFromComponentTest new. b := 1. c := 2. ^a + b + c')
 ]
@@ -140,7 +140,7 @@ RBInlineMethodFromComponentParametrizedTest >> testModelInlineMethodWithSameVari
 			self setupInlineExpressionFor: refactoring toReturn: false.
 			self setupImplementorToInlineFor: refactoring toReturn: class.
 			self executeRefactoring: refactoring].
-	self assert: ((refactoring model classNamed: #Object) parseTreeFor: #foo) 
+	self assert: ((refactoring model classNamed: #Object) parseTreeForSelector: #foo) 
 			equals: (self 
 						parseMethod: 'foo | aRectangle temp | aRectangle := 0@0 corner: 1@1. temp := aRectangle. ^aRectangle origin extent: temp extent')
 ]
@@ -159,7 +159,7 @@ RBInlineMethodFromComponentParametrizedTest >> testModelInlineMethodWithSameVari
 				{ (72 to: 84) . #foo . (model classNamed: #Object) }.
 			self setupInlineExpressionFor: refactoring toReturn: false.
 			self executeRefactoring: refactoring].
-	self assert: ((refactoring model classNamed: #Object) parseTreeFor: #foo) 
+	self assert: ((refactoring model classNamed: #Object) parseTreeForSelector: #foo) 
 				equals: (self 
 						parseMethod: 'foo | a b c | a := InlineMethodFromComponentTest new. b := 1. c := 2. ^c + b + a')
 ]

--- a/src/Refactoring2-Transformations-Tests/RBInlineMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBInlineMethodParametrizedTest.class.st
@@ -37,7 +37,7 @@ RBInlineMethodParametrizedTest >> testInlineMethod [
 	
 	self executeRefactoring: refactoring.
 
-	self assert: ((refactoring model metaclassNamed: #RBBasicLintRuleTestData) parseTreeFor: #sentNotImplementedInApplication) equals: (self parseMethod: 'sentNotImplementedInApplication
+	self assert: ((refactoring model metaclassNamed: #RBBasicLintRuleTestData) parseTreeForSelector: #sentNotImplementedInApplication) equals: (self parseMethod: 'sentNotImplementedInApplication
 									| detector |
 									detector := self new.
 									detector name: ''Messages sent but not implemented in application''.
@@ -86,7 +86,7 @@ RBInlineMethodParametrizedTest >> testInlineMethod1 [
 	
 	self executeRefactoring: refactoring.
 
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #caller) equals: (self parseMethod: 'caller 
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeForSelector: #caller) equals: (self parseMethod: 'caller 
 									| anObject anObject1 | 
 									anObject := 5.
 									anObject1 := anObject + 1.
@@ -106,7 +106,7 @@ RBInlineMethodParametrizedTest >> testInlineMethod2 [
 	
 	self executeRefactoring: refactoring.
 
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: methodName) equals: (self parseMethod: 'caller1 
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeForSelector: methodName) equals: (self parseMethod: 'caller1 
 								| anObject each1 anObject1 | 
 								anObject := 5.
 								anObject1 := anObject + 1.
@@ -127,7 +127,7 @@ RBInlineMethodParametrizedTest >> testInlineMethod3 [
 	
 	self executeRefactoring: refactoring.
 
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: methodName) equals: (self parseMethod: 'caller2
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeForSelector: methodName) equals: (self parseMethod: 'caller2
 								^(1 to: 10) inject: 1 into: [:sum :each | sum * ((1 to: 10) inject: each into: [:sum1 :each1 | sum1 + each1])]	')
 ]
 
@@ -140,7 +140,7 @@ RBInlineMethodParametrizedTest >> testInlineMethod4 [
 	
 	self executeRefactoring: refactoring.
 
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineJunk) equals: (self parseMethod: 'inlineJunk
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeForSelector: #inlineJunk) equals: (self parseMethod: 'inlineJunk
 										| asdf bar1 baz1 asdf1 |
 										bar1 := 
 												[:each | 
@@ -165,7 +165,7 @@ RBInlineMethodParametrizedTest >> testInlineMethod5 [
 		{ (53 to: 64) . #inlineLast . RBRefactoryTestDataApp }.
 	self executeRefactoring: refactoring.
 
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineLast) equals: (self parseMethod: 'inlineLast
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeForSelector: #inlineLast) equals: (self parseMethod: 'inlineLast
 									5 = 3 ifTrue: [^self caller] ifFalse: [^	(1 to: 10) inject: 1 into: [:sum :each | sum * (self foo: each)]]')
 ]
 
@@ -181,7 +181,7 @@ RBInlineMethodParametrizedTest >> testInlineMethodForSuperSend [
 
 	self 
 		assert: ((model classNamed: #RBRenameInstanceVariableChange) 
-				parseTreeFor: #executeNotifying:) equals: (self 
+				parseTreeForSelector: #executeNotifying:) equals: (self 
 							parseMethod: 'executeNotifying: aBlock 
 									| undo undos undo1 |
 									self addNewVariable.
@@ -211,7 +211,7 @@ RBInlineMethodParametrizedTest >> testInlineRecursiveCascadedMethod [
 	
 	self executeRefactoring: refactoring.
 
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineMethod) equals: (self parseMethod: 'inlineMethod
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeForSelector: #inlineMethod) equals: (self parseMethod: 'inlineMethod
 									| temp temp1 |
 									self foo.
 									temp1 := self foo; inlineMethod; bar.
@@ -227,7 +227,7 @@ RBInlineMethodParametrizedTest >> testModelInlineRecursiveMethod [
 	refactoring := self createRefactoringWithModel: model andArguments: 
 		{ (15 to: 23) . #foo . class }.
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
-	self assert: (class parseTreeFor: #foo) 
+	self assert: (class parseTreeForSelector: #foo) 
 		equals: (self parseMethod: 'foo self bar. self bar. self foo. self bar. self bar')
 ]
 

--- a/src/Refactoring2-Transformations-Tests/RBInlineParameterParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBInlineParameterParametrizedTest.class.st
@@ -37,7 +37,7 @@ RBInlineParameterParametrizedTest >> testInlineLiteralArray [
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	
 	class := refactoring model classNamed: #RBRefactoryTestDataApp.
-	self assert: (class parseTreeFor: #inlineParameterMethod) equals: (self parseMethod: 'inlineParameterMethod | aSymbol | aSymbol := #(asdf). ^aSymbol isSymbol').
-	self assert: (class parseTreeFor: #sendInlineParameterMethod) equals: (self parseMethod: 'sendInlineParameterMethod ^self inlineParameterMethod').
+	self assert: (class parseTreeForSelector: #inlineParameterMethod) equals: (self parseMethod: 'inlineParameterMethod | aSymbol | aSymbol := #(asdf). ^aSymbol isSymbol').
+	self assert: (class parseTreeForSelector: #sendInlineParameterMethod) equals: (self parseMethod: 'sendInlineParameterMethod ^self inlineParameterMethod').
 	self deny: (class directlyDefinesMethod: ('inline' , 'ParameterMethod:') asSymbol)
 ]

--- a/src/Refactoring2-Transformations-Tests/RBInlineTemporaryParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBInlineTemporaryParametrizedTest.class.st
@@ -25,7 +25,7 @@ RBInlineTemporaryParametrizedTest >> testInlineTemporary [
 	
 	self executeRefactoring: refactoring.
 
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineMethod) equals: (self parseMethod: 'inlineMethod
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeForSelector: #inlineMethod) equals: (self parseMethod: 'inlineMethod
 										^self
 													foo;
 													inlineMethod;

--- a/src/Refactoring2-Transformations-Tests/RBMakeClassAbstractParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMakeClassAbstractParametrizedTest.class.st
@@ -37,6 +37,6 @@ RBMakeClassAbstractParametrizedTest >> testMakeClassAbstractAddsIsAbstractMethod
 	
 	self executeRefactoring: refactoring.
 	self assert: ((refactoring model classNamed: testClass name) classSide 
-			parseTreeFor: #isAbstract) 
+			parseTreeForSelector: #isAbstract) 
 		equals: (self parseMethod: 'isAbstract ^self == ', testClass name)
 ]

--- a/src/Refactoring2-Transformations-Tests/RBMoveMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveMethodParametrizedTest.class.st
@@ -34,8 +34,8 @@ RBMoveMethodParametrizedTest >> testMoveMethodIntoArgument [
 			toReturn: #foo:.
 		self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeFor: #checkMethod:) equals: (self parseMethod: 'checkMethod: aSmalllintContext aSmalllintContext foo: self').
-	self assert: ((refactoring model classNamed: #RBSmalllintContext) parseTreeFor: #foo:) equals: (self parseMethod: 'foo: transformationRule
+	self assert: (class parseTreeForSelector: #checkMethod:) equals: (self parseMethod: 'checkMethod: aSmalllintContext aSmalllintContext foo: self').
+	self assert: ((refactoring model classNamed: #RBSmalllintContext) parseTreeForSelector: #foo:) equals: (self parseMethod: 'foo: transformationRule
 	transformationRule class: self selectedClass.
 	(transformationRule rewriteRule executeTree: self parseTree) ifTrue: 
 			[(transformationRule class recursiveSelfRule executeTree: transformationRule rewriteRule tree initialAnswer: false)
@@ -43,14 +43,14 @@ RBMoveMethodParametrizedTest >> testMoveMethodIntoArgument [
 					[transformationRule builder compile: transformationRule rewriteRule tree printString
 						in: transformationRule class1
 						classified: self protocols]]').
-	self assert: (class parseTreeFor: #class1) equals: (self parseMethod: 'class1 ^class').
-	self assert: (class parseTreeFor: #class:) equals: (self parseMethod: 'class: anObject class := anObject').
-	self assert: (class classSide parseTreeFor: #recursiveSelfRule:) equals: (self parseMethod: 'recursiveSelfRule: anObject RecursiveSelfRule := anObject').
-	self assert: (class classSide parseTreeFor: #recursiveSelfRule) equals: (self parseMethod: 'recursiveSelfRule ^RecursiveSelfRule').
-	self assert: (class parseTreeFor: #builder) equals: (self parseMethod: 'builder ^builder').
-	self assert: (class parseTreeFor: #builder:) equals: (self parseMethod: 'builder: anObject builder := anObject').
-	self assert: (class parseTreeFor: #rewriteRule) equals: (self parseMethod: 'rewriteRule ^rewriteRule').
-	self assert: (class parseTreeFor: #rewriteRule:) equals: (self parseMethod: 'rewriteRule: anObject rewriteRule := anObject')
+	self assert: (class parseTreeForSelector: #class1) equals: (self parseMethod: 'class1 ^class').
+	self assert: (class parseTreeForSelector: #class:) equals: (self parseMethod: 'class: anObject class := anObject').
+	self assert: (class classSide parseTreeForSelector: #recursiveSelfRule:) equals: (self parseMethod: 'recursiveSelfRule: anObject RecursiveSelfRule := anObject').
+	self assert: (class classSide parseTreeForSelector: #recursiveSelfRule) equals: (self parseMethod: 'recursiveSelfRule ^RecursiveSelfRule').
+	self assert: (class parseTreeForSelector: #builder) equals: (self parseMethod: 'builder ^builder').
+	self assert: (class parseTreeForSelector: #builder:) equals: (self parseMethod: 'builder: anObject builder := anObject').
+	self assert: (class parseTreeForSelector: #rewriteRule) equals: (self parseMethod: 'rewriteRule ^rewriteRule').
+	self assert: (class parseTreeForSelector: #rewriteRule:) equals: (self parseMethod: 'rewriteRule: anObject rewriteRule := anObject')
 ]
 
 { #category : #tests }
@@ -69,10 +69,10 @@ RBMoveMethodParametrizedTest >> testMoveMethodIntoClass [
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #Object.
 	self
-		assert: ((model classFor: Object) parseTreeFor: #aTestMethodName)
+		assert: ((model classFor: Object) parseTreeForSelector: #aTestMethodName)
 		equals: (self parseMethod: 'aTestMethodName ^ OrderedCollection oneToOneHundred ').
 	self
-		assert: ((refactoring model classNamed: #OrderedCollection) classSide parseTreeFor: #oneToOneHundred)
+		assert: ((refactoring model classNamed: #OrderedCollection) classSide parseTreeForSelector: #oneToOneHundred)
 		equals: (self parseMethod: 'oneToOneHundred ^ self new addAll: (1 to: 100); yourself')
 ]
 
@@ -94,8 +94,8 @@ RBMoveMethodParametrizedTest >> testMoveMethodIntoClassVariable [
 			withArguments: #('transformationRule' 'aSmalllintContext' ).
 		self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeFor: #checkMethod:) equals: (self parseMethod: 'checkMethod: aSmalllintContext RecursiveSelfRule foo: self foo: aSmalllintContext').
-	self assert: ((refactoring model classNamed: #RBParseTreeSearcher) parseTreeFor: #foo:foo:) equals: (self parseMethod: 'foo: transformationRule foo: aSmalllintContext
+	self assert: (class parseTreeForSelector: #checkMethod:) equals: (self parseMethod: 'checkMethod: aSmalllintContext RecursiveSelfRule foo: self foo: aSmalllintContext').
+	self assert: ((refactoring model classNamed: #RBParseTreeSearcher) parseTreeForSelector: #foo:foo:) equals: (self parseMethod: 'foo: transformationRule foo: aSmalllintContext
 	transformationRule class: aSmalllintContext selectedClass.
 	(transformationRule rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: 
 			[(self executeTree: transformationRule rewriteRule tree initialAnswer: false)
@@ -103,12 +103,12 @@ RBMoveMethodParametrizedTest >> testMoveMethodIntoClassVariable [
 					[transformationRule builder compile: transformationRule rewriteRule tree printString
 						in: transformationRule class1
 						classified: aSmalllintContext protocols]]').
-	self assert: (class parseTreeFor: #class1) equals: (self parseMethod: 'class1 ^class').
-	self assert: (class parseTreeFor: #class:) equals: (self parseMethod: 'class: anObject class := anObject').
-	self assert: (class parseTreeFor: #builder) equals: (self parseMethod: 'builder ^builder').
-	self assert: (class parseTreeFor: #builder:) equals: (self parseMethod: 'builder: anObject builder := anObject').
-	self assert: (class parseTreeFor: #rewriteRule) equals: (self parseMethod: 'rewriteRule ^rewriteRule').
-	self assert: (class parseTreeFor: #rewriteRule:) equals: (self parseMethod: 'rewriteRule: anObject rewriteRule := anObject')
+	self assert: (class parseTreeForSelector: #class1) equals: (self parseMethod: 'class1 ^class').
+	self assert: (class parseTreeForSelector: #class:) equals: (self parseMethod: 'class: anObject class := anObject').
+	self assert: (class parseTreeForSelector: #builder) equals: (self parseMethod: 'builder ^builder').
+	self assert: (class parseTreeForSelector: #builder:) equals: (self parseMethod: 'builder: anObject builder := anObject').
+	self assert: (class parseTreeForSelector: #rewriteRule) equals: (self parseMethod: 'rewriteRule ^rewriteRule').
+	self assert: (class parseTreeForSelector: #rewriteRule:) equals: (self parseMethod: 'rewriteRule: anObject rewriteRule := anObject')
 ]
 
 { #category : #tests }
@@ -129,8 +129,8 @@ RBMoveMethodParametrizedTest >> testMoveMethodIntoInstanceVariable [
 			withArguments: #('transformationRule' 'aSmalllintContext' ).
 		self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeFor: #checkMethod:) equals: (self parseMethod: 'checkMethod: aSmalllintContext rewriteRule foo: self foo: aSmalllintContext').
-	self assert: ((refactoring model classNamed: #RBParseTreeRewriter) parseTreeFor: #foo:foo:) equals: (self parseMethod: 'foo: transformationRule foo: aSmalllintContext
+	self assert: (class parseTreeForSelector: #checkMethod:) equals: (self parseMethod: 'checkMethod: aSmalllintContext rewriteRule foo: self foo: aSmalllintContext').
+	self assert: ((refactoring model classNamed: #RBParseTreeRewriter) parseTreeForSelector: #foo:foo:) equals: (self parseMethod: 'foo: transformationRule foo: aSmalllintContext
 	transformationRule class: aSmalllintContext selectedClass.
 	(self executeTree: aSmalllintContext parseTree) ifTrue: 
 			[(transformationRule class recursiveSelfRule executeTree: self tree initialAnswer: false)
@@ -138,12 +138,12 @@ RBMoveMethodParametrizedTest >> testMoveMethodIntoInstanceVariable [
 					[transformationRule builder compile: self tree printString
 						in: transformationRule class1
 						classified: aSmalllintContext protocols]]').
-	self assert: (class parseTreeFor: #class1) equals: (self parseMethod: 'class1 ^class').
-	self assert: (class parseTreeFor: #class:) equals: (self parseMethod: 'class: anObject class := anObject').
-	self assert: (class classSide parseTreeFor: #recursiveSelfRule:) equals: (self parseMethod: 'recursiveSelfRule: anObject RecursiveSelfRule := anObject').
-	self assert: (class classSide parseTreeFor: #recursiveSelfRule) equals: (self parseMethod: 'recursiveSelfRule ^RecursiveSelfRule').
-	self assert: (class parseTreeFor: #builder) equals: (self parseMethod: 'builder ^builder').
-	self assert: (class parseTreeFor: #builder:) equals: (self parseMethod: 'builder: anObject builder := anObject')
+	self assert: (class parseTreeForSelector: #class1) equals: (self parseMethod: 'class1 ^class').
+	self assert: (class parseTreeForSelector: #class:) equals: (self parseMethod: 'class: anObject class := anObject').
+	self assert: (class classSide parseTreeForSelector: #recursiveSelfRule:) equals: (self parseMethod: 'recursiveSelfRule: anObject RecursiveSelfRule := anObject').
+	self assert: (class classSide parseTreeForSelector: #recursiveSelfRule) equals: (self parseMethod: 'recursiveSelfRule ^RecursiveSelfRule').
+	self assert: (class parseTreeForSelector: #builder) equals: (self parseMethod: 'builder ^builder').
+	self assert: (class parseTreeForSelector: #builder:) equals: (self parseMethod: 'builder: anObject builder := anObject')
 ]
 
 { #category : #tests }
@@ -163,8 +163,8 @@ RBMoveMethodParametrizedTest >> testMoveMethodThatReferencesPoolDictionary [
 			toReturn: #junk1.
 		self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBLintRuleTestData.
-	self assert: (class parseTreeFor: #junk) equals: (self parseMethod: 'junk ^RefactoryTestDataApp junk1').
-	self assert: ((refactoring model metaclassNamed: #RBRefactoryTestDataApp) parseTreeFor: #junk1) equals: (self parseMethod: 'junk1
+	self assert: (class parseTreeForSelector: #junk) equals: (self parseMethod: 'junk ^RefactoryTestDataApp junk1').
+	self assert: ((refactoring model metaclassNamed: #RBRefactoryTestDataApp) parseTreeForSelector: #junk1) equals: (self parseMethod: 'junk1
 	^RBRefactoryTestDataApp printString copyFrom: 1 to: CR').
 	self assert: (class directlyDefinesPoolDictionary: 'TextConstants' asSymbol)
 ]

--- a/src/Refactoring2-Transformations-Tests/RBMoveMethodToClassSideParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveMethodToClassSideParametrizedTest.class.st
@@ -49,9 +49,9 @@ RBMoveMethodToClassSideParametrizedTest >> testMoveMethodToClassSide [
 	self executeRefactoring: refactoring.
 	model := refactoring model.
 	someClass := model classNamed: className name.
-	self assert: (someClass parseTreeFor: ('threeElement', 'Point') asSymbol) equals: (self parseMethod: 'threeElementPoint ^ self class threeElementPoint').
+	self assert: (someClass parseTreeForSelector: ('threeElement', 'Point') asSymbol) equals: (self parseMethod: 'threeElementPoint ^ self class threeElementPoint').
 	someClass := model classNamed: className name, ' class'.
-	self assert: (someClass parseTreeFor: ('threeElement', 'Point') asSymbol) equals: (self parseMethod: 'threeElementPoint ^5 @ 5 + 6 @ 6').
+	self assert: (someClass parseTreeForSelector: ('threeElement', 'Point') asSymbol) equals: (self parseMethod: 'threeElementPoint ^5 @ 5 + 6 @ 6').
 ]
 
 { #category : #tests }
@@ -63,10 +63,10 @@ RBMoveMethodToClassSideParametrizedTest >> testMoveMethodToClassSideWithInsAndMe
 	self executeRefactoring: refactoring.
 	model := refactoring model.
 	someClass := model classNamed: className name.
-	self assert: (someClass parseTreeFor: ('rewrite', 'Using:') asSymbol) equals: (self parseMethod: 'rewriteUsing: searchReplacer
+	self assert: (someClass parseTreeForSelector: ('rewrite', 'Using:') asSymbol) equals: (self parseMethod: 'rewriteUsing: searchReplacer
 	^ self class rewriteUsing: searchReplacer').
 	someClass := model classNamed: className name, ' class'.
-	self assert: (someClass parseTreeFor: ('rewrite', 'Using:') asSymbol) equals: (self parseMethod: 'rewriteUsing: searchReplacer
+	self assert: (someClass parseTreeForSelector: ('rewrite', 'Using:') asSymbol) equals: (self parseMethod: 'rewriteUsing: searchReplacer
 
 	| aRBTransformationRuleTestData |
 	aRBTransformationRuleTestData := self new.

--- a/src/Refactoring2-Transformations-Tests/RBMoveTemporaryVariableDefinitionTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveTemporaryVariableDefinitionTransformationTest.class.st
@@ -24,7 +24,7 @@ RBMoveTemporaryVariableDefinitionTransformationTest >> testMoveDefinition [
 							transform.
 		
 	class := transformation model classNamed: #RBDummyRefactoryTestDataApp.
-	self assert: (class parseTreeFor: #moveDefinition)
+	self assert: (class parseTreeForSelector: #moveDefinition)
 		  equals: (self parseMethod: 'moveDefinition
 								^(self collect: 
 										[:each | 
@@ -49,7 +49,7 @@ RBMoveTemporaryVariableDefinitionTransformationTest >> testMoveDefinitionIntoBlo
 							asRefactoring transform.
 							
 	class := transformation model classNamed: #RBDummyRefactoryTestDataApp.
-	self assert: (class parseTreeFor: #referencesConditionFor:)
+	self assert: (class parseTreeForSelector: #referencesConditionFor:)
 		  equals: (self parseMethod: 'referencesConditionFor: aClass 
 						| environment  |
 						^(RBCondition withBlock: 

--- a/src/Refactoring2-Transformations-Tests/RBMoveVariableDefinitionParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveVariableDefinitionParametrizedTest.class.st
@@ -29,7 +29,7 @@ RBMoveVariableDefinitionParametrizedTest >> testMoveDefinition [
 		{ (19 to: 22) . RBRefactoryTestDataApp . #moveDefinition }.
 	self executeRefactoring: refactoring.
 
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #moveDefinition) equals: (self parseMethod: 'moveDefinition
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeForSelector: #moveDefinition) equals: (self parseMethod: 'moveDefinition
 								^(self collect: 
 										[:each | 
 										| temp |
@@ -48,7 +48,7 @@ RBMoveVariableDefinitionParametrizedTest >> testMoveDefinitionIntoBlockThatIsARe
 	refactoring := self createRefactoringWithArguments:
 		{ (48 to: 58) . RBRefactoryTestDataApp . #referencesConditionFor: }.
 	self executeRefactoring: refactoring.
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #referencesConditionFor:) equals: (self parseMethod: 'referencesConditionFor: aClass 
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeForSelector: #referencesConditionFor:) equals: (self parseMethod: 'referencesConditionFor: aClass 
 								| environment  |
 								^(RBCondition withBlock: 
 										[| association |association := Smalltalk globals associationAt: aClass name

--- a/src/Refactoring2-Transformations-Tests/RBProtectInstanceVariableParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBProtectInstanceVariableParametrizedTest.class.st
@@ -29,9 +29,9 @@ RBProtectInstanceVariableParametrizedTest >> testProtectInstanceVariable [
 		{('rewrite' , 'Rule1') . #RBSubclassOfClassToRename}.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBSubclassOfClassToRename.
-	self assert: (class parseTreeFor: #calls1) equals: (self parseMethod: 'calls1
+	self assert: (class parseTreeForSelector: #calls1) equals: (self parseMethod: 'calls1
 								^rewriteRule1 := (rewriteRule1 := self calls)').
-	self assert: (class parseTreeFor: #calls) equals: (self parseMethod: 'calls
+	self assert: (class parseTreeForSelector: #calls) equals: (self parseMethod: 'calls
 								^rewriteRule1 := rewriteRule1 , rewriteRule1').
 	self deny: (class directlyDefinesMethod: ('rewrite' , 'Rule1') asSymbol).
 	self deny: (class directlyDefinesMethod: ('rewrite' , 'Rule1:') asSymbol)

--- a/src/Refactoring2-Transformations-Tests/RBProtectVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBProtectVariableTransformationTest.class.st
@@ -22,17 +22,17 @@ RBProtectVariableTransformationTest >> testAccessorsAlreadyExist [
 		asRefactoring transform.
 	
 	class := model classNamed: #Foo.
-	self assert: (class parseTreeFor: #bar)
+	self assert: (class parseTreeForSelector: #bar)
 		equals: (self parseMethod: 'bar
 			"Add one to instVarName1"
 			self instVarName11: self instVarName11 + 1').
-	self assert: (class parseTreeFor: #instVarName11:) 
+	self assert: (class parseTreeForSelector: #instVarName11:) 
 		equals: (self parseMethod: 'instVarName11: anObject
 			instVarName1 := anObject').
-	self assert: (class parseTreeFor: #instVarName11) 
+	self assert: (class parseTreeForSelector: #instVarName11) 
 		equals: (self parseMethod: 'instVarName11 ^instVarName1').
 		
-	self assert: ((model classNamed: #Bar) parseTreeFor: #foo) 
+	self assert: ((model classNamed: #Bar) parseTreeForSelector: #foo) 
 		equals: (self parseMethod: 'foo
 			self instVarName11: self instVarName11 + instVarName2 + ClassVarName1')
 ]
@@ -47,20 +47,20 @@ RBProtectVariableTransformationTest >> testClassVariable [
 						asRefactoring transform.
 	
 	class := (refactoring model classNamed: #RBTransformationRuleTestData) classSide.
-	self assert: (class parseTreeFor: #recursiveSelfRule)
+	self assert: (class parseTreeForSelector: #recursiveSelfRule)
 			equals: (self parseMethod: 'recursiveSelfRule ^RecursiveSelfRule').
-	self assert: (class parseTreeFor: #recursiveSelfRule:) 
+	self assert: (class parseTreeForSelector: #recursiveSelfRule:) 
 			equals: (self parseMethod: 'recursiveSelfRule: anObject RecursiveSelfRule := anObject').
 	
-	self assert: (class parseTreeFor: #nuke) 
+	self assert: (class parseTreeForSelector: #nuke) 
 			equals: (self parseMethod: 'nuke self recursiveSelfRule: nil').
-	self assert: (class parseTreeFor: #initializeAfterLoad1) 
+	self assert: (class parseTreeForSelector: #initializeAfterLoad1) 
 			equals: (self parseMethod: 'initializeAfterLoad1
 				self recursiveSelfRule: self parseTreeSearcher.
 				self recursiveSelfRule
 					addMethodSearches: #(''`@methodName: `@args | `@temps | self `@methodName: `@args'' ''`@methodName: `@args | `@temps | ^self `@methodName: `@args'')
 					-> [:aNode :answer | true]').
-	self assert: ((refactoring model classNamed: #RBTransformationRuleTestData) parseTreeFor: #checkMethod:) 
+	self assert: ((refactoring model classNamed: #RBTransformationRuleTestData) parseTreeForSelector: #checkMethod:) 
 			equals: (self parseMethod: 'checkMethod: aSmalllintContext 
 				class := aSmalllintContext selectedClass.
 				(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: 
@@ -82,18 +82,18 @@ RBProtectVariableTransformationTest >> testClassVariableInModel [
 		asRefactoring transform.
 	
 	class := (model classNamed: #Foo) classSide.
-	self assert: (class parseTreeFor: #classVarName1) 
+	self assert: (class parseTreeForSelector: #classVarName1) 
 			equals: (self parseMethod: 'classVarName1 ^ClassVarName1').
-	self assert: (class parseTreeFor: #classVarName1:) 
+	self assert: (class parseTreeForSelector: #classVarName1:) 
 			equals: (self parseMethod: 'classVarName1: anObject ClassVarName1 := anObject').
 	
-	self assert: (class parseTreeFor: #foo)
+	self assert: (class parseTreeForSelector: #foo)
 			equals: (self parseMethod: 'foo
 				^self classVarName1: self classVarName1 * self classVarName1 * self classVarName1').
 					
-	self assert: (class instanceSide parseTreeFor: #classVarName1)
+	self assert: (class instanceSide parseTreeForSelector: #classVarName1)
 			equals: (self parseMethod: 'classVarName1 ^self class classVarName1').
-	self assert: (class instanceSide parseTreeFor: #classVarName1:) 
+	self assert: (class instanceSide parseTreeForSelector: #classVarName1:) 
 			equals: (self parseMethod: 'classVarName1: anObject
 				^self class classVarName1: anObject').
 				
@@ -122,12 +122,12 @@ RBProtectVariableTransformationTest >> testMetaclass [
 		class: class)
 		asRefactoring transform.
 				
-	self assert: (class parseTreeFor: #foo1) 
+	self assert: (class parseTreeForSelector: #foo1) 
 			equals: (self parseMethod: 'foo1 ^foo').
-	self assert: (class parseTreeFor: #foo:)
+	self assert: (class parseTreeForSelector: #foo:)
 			equals: (self parseMethod: 'foo: anObject foo := anObject').
 			
-	self assert: (class parseTreeFor: #zzz) 
+	self assert: (class parseTreeForSelector: #zzz) 
 			equals: (self parseMethod: 'zzz ^self foo: self foo1 + self foo1 * 2')
 ]
 
@@ -150,13 +150,13 @@ RBProtectVariableTransformationTest >> testRefactoring [
 						asRefactoring transform.
 	
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeFor: #builder) equals: (self parseMethod: 'builder ^builder').
-	self assert: (class parseTreeFor: #builder:) equals: (self parseMethod: 'builder: anObject
+	self assert: (class parseTreeForSelector: #builder) equals: (self parseMethod: 'builder ^builder').
+	self assert: (class parseTreeForSelector: #builder:) equals: (self parseMethod: 'builder: anObject
 	builder := anObject').
-	self assert: (class parseTreeFor: #viewResults) equals: (self parseMethod: 'viewResults
+	self assert: (class parseTreeForSelector: #viewResults) equals: (self parseMethod: 'viewResults
 		self builder inspect.
 		self resetResult').
-	self assert: (class parseTreeFor: #checkMethod:) equals: (self parseMethod: 'checkMethod: aSmalllintContext 
+	self assert: (class parseTreeForSelector: #checkMethod:) equals: (self parseMethod: 'checkMethod: aSmalllintContext 
 	class := aSmalllintContext selectedClass.
 	(rewriteRule executeTree: aSmalllintContext parseTree) 
 		ifTrue: 
@@ -181,7 +181,7 @@ RBProtectVariableTransformationTest >> testTransform [
 	self assert: (class directlyDefinesLocalMethod: #class1).
 	self assert: (class directlyDefinesLocalMethod: #class:).
 	
-	self assert: (class parseTreeFor: #superSends) equals: (self parseMethod: 
+	self assert: (class parseTreeForSelector: #superSends) equals: (self parseMethod: 
 	'superSends
 		| rule |
 		rule := RBParseTreeRewriter new.
@@ -194,7 +194,7 @@ RBProtectVariableTransformationTest >> testTransform [
 						-> ''self `@message: ``@args'').
 		self rewriteUsing: rule').
 	
-	self assert: (class parseTreeFor: #checkMethod:) equals: (self parseMethod:
+	self assert: (class parseTreeForSelector: #checkMethod:) equals: (self parseMethod:
 	'checkMethod: aSmalllintContext 
 		self class: aSmalllintContext selectedClass.
 		(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: 
@@ -267,14 +267,14 @@ RBProtectVariableTransformationTest >> testWithAssignment [
 						asRefactoring transform.
 	
 	class := model classNamed: #Foo.
-	self assert: (class parseTreeFor: #instVarName2:)
+	self assert: (class parseTreeForSelector: #instVarName2:)
 		equals: (self parseMethod: 'instVarName2: anObject instVarName2 := anObject').
-	self assert: (class parseTreeFor: #instVarName2) 
+	self assert: (class parseTreeForSelector: #instVarName2) 
 		equals: (self parseMethod: 'instVarName2 ^instVarName2').
 	
-	self assert: (class parseTreeFor: #foo)
+	self assert: (class parseTreeForSelector: #foo)
 		equals: (self parseMethod: 'foo ^self instVarName2: 3').
-	self assert: ((model classNamed: #Bar) parseTreeFor: #foo)
+	self assert: ((model classNamed: #Bar) parseTreeForSelector: #foo)
 		equals: (self parseMethod: 'foo
 			instVarName1 := instVarName1 + self instVarName2 + ClassVarName1')
 ]

--- a/src/Refactoring2-Transformations-Tests/RBPullUpMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBPullUpMethodParametrizedTest.class.st
@@ -67,13 +67,13 @@ RBPullUpMethodParametrizedTest >> testPullUpAndCopyDown [
 	self proceedThroughWarning: [ 
 		self executeRefactoring: (self createRefactoringWithModel: model 
 			andArguments: { #(#yourself) . class }) ].
-	self assert: (class superclass parseTreeFor: #yourself) 
+	self assert: (class superclass parseTreeForSelector: #yourself) 
 			equals: (self parseMethod: 'yourself ^1').
 	self deny: (class directlyDefinesMethod: #yourself).
 	class := model classNamed: #Foo2.
 	self assert: (class directlyDefinesMethod: #yourself).
-	self assert: (class parseTreeFor: #yourself) 
-			equals: ((model classNamed: #Object) parseTreeFor: #yourself)
+	self assert: (class parseTreeForSelector: #yourself) 
+			equals: ((model classNamed: #Object) parseTreeForSelector: #yourself)
 ]
 
 { #category : #'failure tests' }
@@ -102,13 +102,13 @@ RBPullUpMethodParametrizedTest >> testPullUpInAHighHierarchyClass [
 				pullUp: #(#example)
 				from: class 
 				to: superClass ).
-	self assert: (superClass parseTreeFor: #example) 
+	self assert: (superClass parseTreeForSelector: #example) 
 				equals: (self parseMethod: 'example ^1').
 	self deny: (class directlyDefinesMethod: #example).
 	class := model classNamed: #Subclass.
 	self assert: (class definesMethod: #example).
-	self assert: (class parseTreeFor: #example) 
-				equals: ((model classNamed: #SomeClass) parseTreeFor: #example)
+	self assert: (class parseTreeForSelector: #example) 
+				equals: ((model classNamed: #SomeClass) parseTreeForSelector: #example)
 ]
 
 { #category : #tests }
@@ -119,13 +119,13 @@ RBPullUpMethodParametrizedTest >> testPullUpMethodWithCopyOverriddenMethodsDown 
 			{ #(#isComposite ) . RBCompositeLintRuleTestData }.
 		self executeRefactoring: refactoring ].
 	self assert: ((refactoring model classNamed: #RBBasicLintRuleTestData) 
-			parseTreeFor: #isComposite) 
+			parseTreeForSelector: #isComposite) 
 		equals: (self parseMethod: 'isComposite ^false').
 	self assert: ((refactoring model classNamed: ('RBFoo' , 'LintRuleTestData') asSymbol) 
-			parseTreeFor: #isComposite) 
+			parseTreeForSelector: #isComposite) 
 		equals: (self parseMethod: 'isComposite ^false').
 	self assert: ((refactoring model classNamed: #RBLintRuleTestData) 
-			parseTreeFor: #isComposite) 
+			parseTreeForSelector: #isComposite) 
 		equals: (self parseMethod: 'isComposite ^true').
 	self deny: ((refactoring model classNamed: #RBCompositeLintRuleTestData) 
 		directlyDefinesMethod: #isComposite)
@@ -144,7 +144,7 @@ RBPullUpMethodParametrizedTest >> testPullUpMethodWithSharedPool [
 			pullUp: #(#poolReference)
 			from: class 
 			to: superClass) ].
-	self assert: (superClass parseTreeFor: #poolReference) 
+	self assert: (superClass parseTreeForSelector: #poolReference) 
 				equals: (self parseMethod: 'poolReference ^ SP').
 	self deny: (class directlyDefinesMethod: #poolReference).
 ]
@@ -157,7 +157,7 @@ RBPullUpMethodParametrizedTest >> testPullUpReferencesInstVar [
 		andArguments: { #(#foo ) . class }.
 	[ self executeRefactoring: refactoring ] valueSupplyingAnswer: true.
 	superClass := model classNamed: ('RBFooLint', 'RuleTestData1') asSymbol.
-	self assert: (superClass parseTreeFor: #foo) 
+	self assert: (superClass parseTreeForSelector: #foo) 
 				equals: (self parseMethod: 'foo ^ foo').
 	self assert: (superClass directlyDefinesInstanceVariable: #foo).
 	self deny: (class directlyDefinesMethod: #foo).

--- a/src/Refactoring2-Transformations-Tests/RBPushDownMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBPushDownMethodParametrizedTest.class.st
@@ -27,7 +27,7 @@ RBPushDownMethodParametrizedTest >> testPushDownMethod [
 	self deny: (class directlyDefinesMethod: #name:).
 	class subclasses do: 
 		[ :each | 
-		self assert: (each parseTreeFor: #name:)
+		self assert: (each parseTreeForSelector: #name:)
 			equals: (self parseMethod: 'name: aString name := aString') ]
 ]
 
@@ -58,7 +58,7 @@ RBPushDownMethodParametrizedTest >> testPushDownMethodSubclassesReferToSelector 
 { #category : #tests }
 RBPushDownMethodParametrizedTest >> testPushDownMethodThatReferencesPoolDictionary [
 	| refactoring class parseTree |
-	parseTree := RBLintRuleTestData parseTreeFor: #junk.
+	parseTree := RBLintRuleTestData parseTreeForSelector: #junk.
 	refactoring := self createRefactoringWithArguments: 
 		{ #(#junk ) . RBLintRuleTestData }.
 	self executeRefactoring: refactoring asRefactoring.
@@ -66,7 +66,7 @@ RBPushDownMethodParametrizedTest >> testPushDownMethodThatReferencesPoolDictiona
 	self deny: (class directlyDefinesMethod: #junk).
 	class subclasses do: 
 		[ :each | 
-		self assert: (each parseTreeFor: #junk) equals: parseTree.
+		self assert: (each parseTreeForSelector: #junk) equals: parseTree.
 		self assert: (each definesPoolDictionary: 'TextConstants' asSymbol) ]
 ]
 

--- a/src/Refactoring2-Transformations-Tests/RBRealizeClassParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRealizeClassParametrizedTest.class.st
@@ -43,13 +43,13 @@ RBRealizeClassParametrizedTest >> testRealizeAbstractClass [
 	self proceedThroughWarning: [ 
 		self executeRefactoring: 
 			(self createRefactoringWithArguments:  { model . #RBFooLintRuleTestData}) ].
-	self assert: (class parseTreeFor: #isEmpty) equals: 
+	self assert: (class parseTreeForSelector: #isEmpty) equals: 
 	(self parseMethod: 'isEmpty
 		self shouldBeImplemented').
-	self assert: (class parseTreeFor: #problemCount) equals: 
+	self assert: (class parseTreeForSelector: #problemCount) equals: 
 	(self parseMethod: 'problemCount
 		self shouldBeImplemented').
-	self assert: (class parseTreeFor: #viewResults) equals: 
+	self assert: (class parseTreeForSelector: #viewResults) equals: 
 	(self parseMethod: 'viewResults
 		self shouldBeImplemented')
 ]
@@ -60,13 +60,13 @@ RBRealizeClassParametrizedTest >> testRealizeClass [
 	class := model classNamed: #RBFooLintRuleTestData.
 	self executeRefactoring: 
 		(self createRefactoringWithArguments:  { model . #RBFooLintRuleTestData }).
-	self assert: (class parseTreeFor: #isEmpty) equals: 
+	self assert: (class parseTreeForSelector: #isEmpty) equals: 
 	(self parseMethod: 'isEmpty
 		self shouldBeImplemented').
-	self assert: (class parseTreeFor: #problemCount) equals: 
+	self assert: (class parseTreeForSelector: #problemCount) equals: 
 	(self parseMethod: 'problemCount
 		self shouldBeImplemented').
-	self assert: (class parseTreeFor: #viewResults) equals: 
+	self assert: (class parseTreeForSelector: #viewResults) equals: 
 	(self parseMethod: 'viewResults
 		self shouldBeImplemented')
 ]
@@ -80,13 +80,13 @@ RBRealizeClassParametrizedTest >> testRealizeWithAbstractSubclass [
 		self executeRefactoring: 
 			(self createRefactoringWithArguments: { model . #RBFooLintRuleTestData }) ].
 	class := model classNamed: #RBFooLintRuleTestData.
-	self assert: (class parseTreeFor: #isEmpty) equals: 
+	self assert: (class parseTreeForSelector: #isEmpty) equals: 
 	(self parseMethod: 'isEmpty
 		self shouldBeImplemented').
-	self assert: (class parseTreeFor: #problemCount) equals: 
+	self assert: (class parseTreeForSelector: #problemCount) equals: 
 	(self parseMethod: 'problemCount
 		self shouldBeImplemented').
-	self assert: (class parseTreeFor: #viewResults) equals: 
+	self assert: (class parseTreeForSelector: #viewResults) equals: 
 	(self parseMethod: 'viewResults
 		self shouldBeImplemented')
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveAllSendersParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveAllSendersParametrizedTest.class.st
@@ -24,8 +24,8 @@ RBRemoveAllSendersParametrizedTest >> testRemoveMessageInsideBlock [
 	self setupInlineExpressionFor: refactoring toReturn: false.
 	self proceedThroughWarning: [self executeRefactoring: refactoring ].
 	"remove 2 senders"
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #multipleCalls) equals: (self parseMethod: 'multipleCalls').
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeForSelector: #multipleCalls) equals: (self parseMethod: 'multipleCalls').
 	"it doesn't remove the sender, because its result is used"
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: #inlineLast) equals: (self parseMethod: 'inlineLast
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeForSelector: #inlineLast) equals: (self parseMethod: 'inlineLast
 	5 = 3 ifTrue: [^self caller] ifFalse: [^self caller2]').
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveAssignmentTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveAssignmentTransformationTest.class.st
@@ -74,8 +74,8 @@ RBRemoveAssignmentTransformationTest >> testRefactoring [
 	self assert: refactoring model changes changes size equals: 1.
 	
 	class := refactoring model classNamed: #RBRemoveAssignmentTransformationTest.
-	self assert: (class parseTreeFor: #methodBefore) body
-			equals: (class parseTreeFor: #methodAfter) body.
+	self assert: (class parseTreeForSelector: #methodBefore) body
+			equals: (class parseTreeForSelector: #methodAfter) body.
 ]
 
 { #category : #tests }
@@ -92,8 +92,8 @@ RBRemoveAssignmentTransformationTest >> testTransform [
 	self assert: transformation model changes changes size equals: 1.
 	
 	class := transformation model classNamed: self class name.
-	self assert: (class parseTreeFor: #methodBefore) body
-			equals: (class parseTreeFor: #methodAfter) body.
+	self assert: (class parseTreeForSelector: #methodBefore) body
+			equals: (class parseTreeForSelector: #methodAfter) body.
 ]
 
 { #category : #tests }

--- a/src/Refactoring2-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
@@ -23,9 +23,9 @@ RBRemoveDirectAccessToVariableTransformationTest >> testClassVariable [
 	self assert: refactoring model changes changes size equals: 2.
 	
 	class := (refactoring model classNamed: #RBRefactoryChangeManager) classSide.
-	self assert: (class parseTreeFor: #initialize) 
+	self assert: (class parseTreeForSelector: #initialize) 
 			equals: (self parseMethod: 'initialize self nuke. self undoSize: 20').
-	self assert: (class instanceSide parseTreeFor: #addUndo:) 
+	self assert: (class instanceSide parseTreeForSelector: #addUndo:) 
 			equals: (self parseMethod: 'addUndo: aRefactoringChange
 				undo push: aRefactoringChange.
 				undo size > self class undoSize
@@ -74,7 +74,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testInstanceVariable [
 		asRefactoring transform.
 	
 	class := model classNamed: #Foo.
-	self assert: (class parseTreeFor: #foo) 
+	self assert: (class parseTreeForSelector: #foo) 
 			equals: (self parseMethod: 'foo ^ self instVarName2: 3')
 ]
 
@@ -90,13 +90,13 @@ RBRemoveDirectAccessToVariableTransformationTest >> testRefactoring [
 	self assert: refactoring model changes changes size equals: 4.
 
 	class := refactoring model classNamed: #RBNamespace.
-	self assert: (class parseTreeFor: #includesGlobal:)
+	self assert: (class parseTreeForSelector: #includesGlobal:)
 		equals: (self parseMethod: 'includesGlobal: aSymbol 
 			(self hasRemoved: aSymbol) ifTrue: [^false].
 			(self includesClassNamed: aSymbol) ifTrue: [^true].
 			self environment at: aSymbol ifAbsent: [^false].
 			^ true').
-	self assert: (class parseTreeFor: #initialize) 
+	self assert: (class parseTreeForSelector: #initialize) 
 		equals: (self parseMethod: 'initialize
 	super initialize.
 	changes := changeFactory compositeRefactoryChange onSystemDictionary: self environment.
@@ -120,7 +120,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testTransform [
 							transform.
 	
 	class := transformation model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeFor: #superSends)
+	self assert: (class parseTreeForSelector: #superSends)
 		  equals: (self parseMethod: 
 	'superSends
 		| rule |
@@ -134,7 +134,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testTransform [
 						-> ''self `@message: ``@args'').
 		self rewriteUsing: rule').
 	
-	self assert: (class parseTreeFor: #checkMethod:)
+	self assert: (class parseTreeForSelector: #checkMethod:)
 		  equals: (self parseMethod:
 	'checkMethod: aSmalllintContext 
 		self class: aSmalllintContext selectedClass.

--- a/src/Refactoring2-Transformations-Tests/RBRemoveParameterParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveParameterParametrizedTest.class.st
@@ -54,9 +54,9 @@ RBRemoveParameterParametrizedTest >> testRemoveParameter [
 		{ 'anArg' . RBRefactoryTestDataApp . ('rename' , 'ThisMethod:') asSymbol }.
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBRefactoryTestDataApp.
-	self assert: (class parseTreeFor: #renameThisMethod) equals: (self parseMethod: 'renameThisMethod
+	self assert: (class parseTreeForSelector: #renameThisMethod) equals: (self parseMethod: 'renameThisMethod
 								^self').
-	self assert: (class parseTreeFor: #callMethod) equals: (self parseMethod: 'callMethod
+	self assert: (class parseTreeForSelector: #callMethod) equals: (self parseMethod: 'callMethod
 								^(self renameThisMethod)').
 	self deny: (class directlyDefinesMethod: ('rename' , 'ThisMethod:') asSymbol)
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRemovePragmaTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemovePragmaTransformationTest.class.st
@@ -64,8 +64,8 @@ RBRemovePragmaTransformationTest >> testRefactoring [
 	self assert: refactoring model changes changes size equals: 1.
 	
 	class := refactoring model classNamed: #RBRemovePragmaTransformationTest.
-	self assert: (class parseTreeFor: #methodBefore) body
-			equals: (class parseTreeFor: #methodAfter) body.
+	self assert: (class parseTreeForSelector: #methodBefore) body
+			equals: (class parseTreeForSelector: #methodAfter) body.
 ]
 
 { #category : #tests }
@@ -81,6 +81,6 @@ RBRemovePragmaTransformationTest >> testTransform [
 	self assert: transformation model changes changes size equals: 1.
 	
 	class := transformation model classNamed: self class name.
-	self assert: (class parseTreeFor: #methodBefore) body
-			equals: (class parseTreeFor: #methodAfter) body.
+	self assert: (class parseTreeForSelector: #methodBefore) body
+			equals: (class parseTreeForSelector: #methodAfter) body.
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveReturnStatementTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveReturnStatementTransformationTest.class.st
@@ -52,8 +52,8 @@ RBRemoveReturnStatementTransformationTest >> testRefactoring [
 	self assert: refactoring model changes changes size equals: 1.
 	
 	class := refactoring model classNamed: #RBRemoveReturnStatementTransformationTest.
-	self assert: (class parseTreeFor: #methodBefore) body
-			equals: (class parseTreeFor: #methodAfter) body.
+	self assert: (class parseTreeForSelector: #methodBefore) body
+			equals: (class parseTreeForSelector: #methodAfter) body.
 ]
 
 { #category : #tests }
@@ -79,6 +79,6 @@ RBRemoveReturnStatementTransformationTest >> testTransform [
 	self assert: transformation model changes changes size equals: 1.
 	
 	class := transformation model classNamed: self class name.
-	self assert: (class parseTreeFor: #methodBefore) body
-			equals: (class parseTreeFor: #methodAfter) body.
+	self assert: (class parseTreeForSelector: #methodBefore) body
+			equals: (class parseTreeForSelector: #methodAfter) body.
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveSenderMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveSenderMethodParametrizedTest.class.st
@@ -79,7 +79,7 @@ RBRemoveSenderMethodParametrizedTest >> testRemoveMessageInsideBlock [
 	self setupInlineExpressionFor: refactoring toReturn: false.
 	self executeRefactoring: refactoring .
 
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: methodName) equals: (self parseMethod: 'caller1
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeForSelector: methodName) equals: (self parseMethod: 'caller1
 	| anObject |
 	anObject := 5.
 	self called: anObject + 1
@@ -110,7 +110,7 @@ RBRemoveSenderMethodParametrizedTest >> testRemoveSenderIntoCascaded2Message [
 		self setupInlineExpressionFor: refactoring toReturn: false.
 		self executeRefactoring: refactoring ].
 	transformedMethod := ((refactoring model classNamed: #RBRefactoryTestDataApp) 
-	parseTreeFor: #inlineMethod).
+	parseTreeForSelector: #inlineMethod).
 	self assert: (transformedMethod = afterRefactoring1 or: [ transformedMethod = afterRefactoring2])
 ]
 
@@ -154,7 +154,7 @@ RBRemoveSenderMethodParametrizedTest >> testRemoveSenderIntoCascaded3Message [
 	self setupInlineExpressionFor: refactoring toReturn: false.
 	self executeRefactoring: refactoring ].
 	transformedMethod := ((refactoring model classNamed: #RBRefactoryTestDataApp) 
-	parseTreeFor: #referencesConditionFor:).
+	parseTreeForSelector: #referencesConditionFor:).
 	self assert: (transformedMethod = afterRefactoring1 or: [transformedMethod = afterRefactoring2])
 ]
 
@@ -170,7 +170,7 @@ RBRemoveSenderMethodParametrizedTest >> testRemoveSenderIntoCascadedMessage [
 	self setupInlineExpressionFor: refactoring toReturn: false.
 	
 	self executeRefactoring: refactoring ].
-	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: methodName) 
+	self assert: ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeForSelector: methodName) 
 		equals: (self parseMethod: 'called: anObject on: aBlock 
 			Transcript show: anObject printString.
 			aBlock value')
@@ -193,6 +193,6 @@ RBRemoveSenderMethodParametrizedTest >> testRemoveSimpleSenderOfMessage [
 			#RBRefactoryTestDataApp}.
 	self setupInlineExpressionFor: refactoring toReturn: false.
 	self executeRefactoring: refactoring .
-	transformedMethod := ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeFor: methodName) .
+	transformedMethod := ((refactoring model classNamed: #RBRefactoryTestDataApp) parseTreeForSelector: methodName) .
 	self assert: (transformedMethod = afterRefactoring1 or: [transformedMethod = afterRefactoring2 ])
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveSubtreeTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveSubtreeTransformationTest.class.st
@@ -45,7 +45,7 @@ RBRemoveSubtreeTransformationTest >> testRefactoring [
 	
 	class := transformation model classNamed: #RBRemoveMethodTransformation.
 	self assert: (class directlyDefinesMethod: #selector:from:).
-	self assert: (class parseTreeFor: #selector:from:) body statements size equals: 1
+	self assert: (class parseTreeForSelector: #selector:from:) body statements size equals: 1
 ]
 
 { #category : #tests }
@@ -57,7 +57,7 @@ RBRemoveSubtreeTransformationTest >> testTransform [
 
 	class := transformation model classNamed: self changeMock name asSymbol.
 	self assert: (class directlyDefinesMethod: #one).
-	self assertEmpty: (class parseTreeFor: #one) body statements
+	self assertEmpty: (class parseTreeForSelector: #one) body statements
 ]
 
 { #category : #tests }
@@ -74,5 +74,5 @@ RBRemoveSubtreeTransformationTest >> testTransformNotSequenceNode [
 
 	class := transformation model classNamed: self changeMock name asSymbol.
 	self assert: (class directlyDefinesMethod: #printString1).
-	self assertEmpty: (class parseTreeFor: #printString1) body statements
+	self assertEmpty: (class parseTreeForSelector: #printString1) body statements
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveTemporaryVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveTemporaryVariableTransformationTest.class.st
@@ -50,7 +50,7 @@ RBRemoveTemporaryVariableTransformationTest >> testRefactoring [
 	
 	class := refactoring model classNamed: #RBRemoveTemporaryVariableTransformationTest.
 	self assert: (class directlyDefinesMethod: #foo).		
-	self assert: (class parseTreeFor: #foo) temporaries size equals: 1
+	self assert: (class parseTreeForSelector: #foo) temporaries size equals: 1
 ]
 
 { #category : #tests }
@@ -79,7 +79,7 @@ RBRemoveTemporaryVariableTransformationTest >> testTransform [
 	
 	class := transformation model classNamed: self changeMock name.
 	self assert: (class directlyDefinesMethod: #one).		
-	self assert: (class parseTreeFor: #foo) temporaries size equals: 1
+	self assert: (class parseTreeForSelector: #foo) temporaries size equals: 1
 ]
 
 { #category : #tests }

--- a/src/Refactoring2-Transformations-Tests/RBRenameClassParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameClassParametrizedTest.class.st
@@ -55,9 +55,9 @@ RBRenameClassParametrizedTest >> testModelRenameSequenceClass [
 	self deny: (model includesClassNamed: #Foo1).
 	self deny: (model includesClassNamed: #Foo2).
 	self assert: (model includesClassNamed: #Foo3).
-	self assert: ((model classNamed: #Foo3) parseTreeFor: #foo) 
+	self assert: ((model classNamed: #Foo3) parseTreeForSelector: #foo) 
 		  equals: (self parseMethod: 'foo ^ Foo3').
-	self assert: ((model classNamed: #Foo3) parseTreeFor: #objectName) 
+	self assert: ((model classNamed: #Foo3) parseTreeForSelector: #objectName) 
 		  equals: (self parseMethod: 'objectName ^ #(Foo3)')
 ]
 
@@ -79,9 +79,9 @@ RBRenameClassParametrizedTest >> testRefactoring [
 	
 	self assert: (model includesClassNamed: #Thing).
 	self deny: (model includesClassNamed: #Object).
-	self assert: (class parseTreeFor: #foo) 
+	self assert: (class parseTreeForSelector: #foo) 
 		  equals: (self parseMethod: 'foo ^Thing').
-	self assert: (class parseTreeFor: #objectName) 
+	self assert: (class parseTreeForSelector: #objectName) 
 		  equals: (self parseMethod: 'objectName ^#(Thing)').
 	self assert: class superclass name equals: #Thing
 ]
@@ -98,16 +98,16 @@ RBRenameClassParametrizedTest >> testRenameClass [
 	self executeRefactoring: refactoring.
 	
 	aModel := refactoring model.
-	self assert: ((aModel classNamed: classB) parseTreeFor: #method1) 		
+	self assert: ((aModel classNamed: classB) parseTreeForSelector: #method1) 		
 		  		equals: (self parseMethod: 'method1
 	^self method2').
 	self deny: (aModel includesClassNamed: classA).
 	class := aModel classNamed: classC.
 	self assert: class superclass equals: (aModel classNamed: classB).
-	self assert: (class parseTreeFor: #symbolReference) 
+	self assert: (class parseTreeForSelector: #symbolReference) 
 				equals: (self parseMethod: 'symbolReference
 								^#RBNewClassName').
-	self assert: (class parseTreeFor: #reference) 
+	self assert: (class parseTreeForSelector: #reference) 
 				equals: (self parseMethod: 'reference
 								^RBNewClassName new')
 ]
@@ -125,7 +125,7 @@ RBRenameClassParametrizedTest >> testRenameClassFromTrait [
 	self assert: (aModel includesClassNamed: classB).
 	self deny: (aModel includesClassNamed: classA).
 	class := aModel classNamed: classC.
-	self assert: (class parseTreeFor: #methodFromTrait) 
+	self assert: (class parseTreeForSelector: #methodFromTrait) 
 				equals: (self parseMethod: 'methodFromTrait
 	RBNewClassName justForTest').
 	self assert: ((refactoring model classNamed: #RBClassUsingSharedPoolForTestData) methodFor: #methodFromTrait) modelClass name equals: #RBDummy

--- a/src/Refactoring2-Transformations-Tests/RBRenameClassVariableParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameClassVariableParametrizedTest.class.st
@@ -56,7 +56,7 @@ RBRenameClassVariableParametrizedTest >> testRenameClassVar [
 	self assert: (class directlyDefinesClassVariable: #RSR).
 	self deny: (class directlyDefinesClassVariable: #RecursiveSelfRule).
 	self
-		assert: (class classSide parseTreeFor: #initializeAfterLoad1)
+		assert: (class classSide parseTreeForSelector: #initializeAfterLoad1)
 		equals:
 			(self
 				parseMethod:
@@ -66,14 +66,14 @@ RBRenameClassVariableParametrizedTest >> testRenameClassVar [
 									addMethodSearches: #(''`@methodName: `@args | `@temps | self `@methodName: `@args'' ''`@methodName: `@args | `@temps | ^self `@methodName: `@args'')
 											-> [:aNode :answer | true]').
 	self
-		assert: (class classSide parseTreeFor: #nuke)
+		assert: (class classSide parseTreeForSelector: #nuke)
 		equals:
 			(self
 				parseMethod:
 					'nuke
 								RSR := nil').
 	self
-		assert: (class parseTreeFor: #checkMethod:)
+		assert: (class parseTreeForSelector: #checkMethod:)
 		equals:
 			(self
 				parseMethod:
@@ -101,8 +101,8 @@ RBRenameClassVariableParametrizedTest >> testRenameClassVarInSharedPool [
 	class := refactoring model classNamed: #RBSharedPoolForTestData.
 	userClass := refactoring model classNamed: #RBClassUsingSharedPoolForTestData.
 	
-	self assert: (class parseTreeFor: #msg1) equals: (self parseMethod: 'msg1 ^ VarOne').	
-	self assert: (class parseTreeFor: #msg2) equals: (self parseMethod: 'msg2 ^ VarOne').	
+	self assert: (class parseTreeForSelector: #msg1) equals: (self parseMethod: 'msg1 ^ VarOne').	
+	self assert: (class parseTreeForSelector: #msg2) equals: (self parseMethod: 'msg2 ^ VarOne').	
 		self flag: 'TODO : fix in tranform class'
 "	self assert: (userClass parseTreeFor: #msg3) equals: (self parseMethod: 'msg3 ^ VarOne').	"
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRenameInstanceVariableParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameInstanceVariableParametrizedTest.class.st
@@ -52,7 +52,7 @@ RBRenameInstanceVariableParametrizedTest >> testRenameInstVar [
 	self deny: (class directlyDefinesInstanceVariable: 'classBlock').
 	self
 		assert:
-			(class parseTreeFor: #checkClass:)
+			(class parseTreeForSelector: #checkClass:)
 				equals:
 					(self
 						parseMethod:
@@ -60,7 +60,7 @@ RBRenameInstanceVariableParametrizedTest >> testRenameInstVar [
 								^asdf value: aSmalllintContext value: result').
 	self
 		assert:
-			(class parseTreeFor: #initialize)
+			(class parseTreeForSelector: #initialize)
 				equals:
 					(self
 						parseMethod:
@@ -87,7 +87,7 @@ RBRenameInstanceVariableParametrizedTest >> testRenameInstVarFromTrait [
 	self assert: (class directlyDefinesInstanceVariable: 'var11').
 	self deny: (class directlyDefinesInstanceVariable: 'var1').
 	self
-		assert: (class parseTreeFor: #var1)
+		assert: (class parseTreeForSelector: #var1)
 		equals: (self parseMethod: 'var1 ^ var11').
 	class := refactoring model classNamed: #RBClassUsingSharedPoolForTestData.
 	self flag: 'TODO: for transformation'

--- a/src/Refactoring2-Transformations-Tests/RBRenameMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameMethodParametrizedTest.class.st
@@ -37,9 +37,9 @@ RBRenameMethodParametrizedTest >> testRenameMethodFromTrait [
 		{ ('just', 'ForTest') asSymbol . RBClassToRename classSide . #justForTest1 . (1 to: 0)}.
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #'RBClassToRename class'.
-	self assert: (class parseTreeFor: #justForTest1) 
+	self assert: (class parseTreeForSelector: #justForTest1) 
 		equals: (self parseMethod: 'justForTest1 ^ 42').
-	self assert: ((refactoring model classNamed: #RBDummy) parseTreeFor: #methodFromTrait) equals: (self parseMethod: 'methodFromTrait
+	self assert: ((refactoring model classNamed: #RBDummy) parseTreeForSelector: #methodFromTrait) equals: (self parseMethod: 'methodFromTrait
 	RBClassToRename justForTest1').
 	self deny: (class directlyDefinesMethod: ('just', 'ForTest') asSymbol).
 	self assert: ((refactoring model classNamed: #RBClassUsingSharedPoolForTestData) methodFor: #methodFromTrait) modelClass name equals: #RBDummy
@@ -53,7 +53,7 @@ RBRenameMethodParametrizedTest >> testRenameMethodOnlyInSomePackages [
 		{ ('check', 'Class:') asSymbol . RBBasicLintRuleTestData . #checkClass1: . (1 to: 1) }.
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBBasicLintRuleTestData.
-	self assert: (class parseTreeFor: #checkClass1:) 
+	self assert: (class parseTreeForSelector: #checkClass1:) 
 		equals: (self parseMethod: 'checkClass1: aSmalllintContext 
 	^classBlock value: aSmalllintContext value: result').
 ]
@@ -68,7 +68,7 @@ RBRenameMethodParametrizedTest >> testRenameMethodPermuteArgs [
 	class := refactoring model classNamed: #RBRefactoryTestDataApp.
 	self
 		assert:
-			(class parseTreeFor: ('demoRenameMethod:' , 'PermuteArgs:') asSymbol)
+			(class parseTreeForSelector: ('demoRenameMethod:' , 'PermuteArgs:') asSymbol)
 				equals:
 					(self
 						parseMethod:
@@ -77,7 +77,7 @@ RBRenameMethodParametrizedTest >> testRenameMethodPermuteArgs [
 	^ arg1 > arg2').
 	self
 		assert:
-			(class parseTreeFor: #demoExampleCall)
+			(class parseTreeForSelector: #demoExampleCall)
 				equals: (self parseMethod: 'demoExampleCall ^self demoRenameMethod: 2 PermuteArgs: 1')
 ]
 
@@ -89,9 +89,9 @@ RBRenameMethodParametrizedTest >> testRenamePermuteArgs [
 		('rename:' , 'two:') asSymbol . #(2 1 ) }.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBRefactoryTestDataApp.
-	self assert: (class parseTreeFor: ('rename:' , 'two:') asSymbol) 
+	self assert: (class parseTreeForSelector: ('rename:' , 'two:') asSymbol) 
 		equals: (self parseMethod: 'rename: argumentMethod two: this ^self printString, this, argumentMethod').
-	self assert: (class parseTreeFor: #exampleCall) 
+	self assert: (class parseTreeForSelector: #exampleCall) 
 		equals: (self parseMethod: 'exampleCall <sampleInstance> ^self rename: 2 two: 1')
 ]
 
@@ -120,11 +120,11 @@ RBRenameMethodParametrizedTest >> testRenameTestMethod [
 		{ ('rename' , 'ThisMethod:') asSymbol . RBRefactoryTestDataApp . #renameThisMethod2: . (1 to: 1) }.
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBRefactoryTestDataApp.
-	self assert: (class parseTreeFor: #renameThisMethod2:) equals: (self parseMethod: 'renameThisMethod2: anArg
+	self assert: (class parseTreeForSelector: #renameThisMethod2:) equals: (self parseMethod: 'renameThisMethod2: anArg
 	^self').
-	self assert: (class parseTreeFor: #callMethod) equals: (self parseMethod: 'callMethod
+	self assert: (class parseTreeForSelector: #callMethod) equals: (self parseMethod: 'callMethod
 	^(self renameThisMethod2: 5)').
-	self assert: (class parseTreeFor: #symbolReference) equals: (self parseMethod: 'symbolReference
+	self assert: (class parseTreeForSelector: #symbolReference) equals: (self parseMethod: 'symbolReference
 		^ #(#renameThisMethod2: #(4 #renameThisMethod2:))').
 	self deny: (class directlyDefinesMethod: ('rename' , 'ThisMethod:') asSymbol)
 ]
@@ -136,10 +136,10 @@ RBRenameMethodParametrizedTest >> testRenameTestMethod1 [
 		{ ('testMethod1') asSymbol . RBRefactoryTestDataApp . #testMethod2 . (1 to: 0) }.
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBRefactoryTestDataApp.
-	self assert: (class parseTreeFor: #testMethod2) 
+	self assert: (class parseTreeForSelector: #testMethod2) 
 		equals: (self parseMethod: 'testMethod2
 	^self testMethod2 , ([:each | each testMethod2] value: #(#(#testMethod2) 2 #testMethod2))').
-	self assert: ((refactoring model classNamed: #RBBasicLintRuleTestData) parseTreeFor: #classBlock:) 		equals: (self parseMethod: 'classBlock: aBlock
+	self assert: ((refactoring model classNamed: #RBBasicLintRuleTestData) parseTreeForSelector: #classBlock:) 		equals: (self parseMethod: 'classBlock: aBlock
 	classBlock := aBlock testMethod2').
 	self deny: (class directlyDefinesMethod: ('test' , 'Method1') asSymbol)
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRenameTemporaryParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameTemporaryParametrizedTest.class.st
@@ -102,7 +102,7 @@ RBRenameTemporaryParametrizedTest >> testRenameArg [
 		'asdf' . #RBLintRuleTestData . #name: }.
 	self executeRefactoring: refactoring.
 
-	self assert: ((refactoring model classNamed: #RBLintRuleTestData) parseTreeFor: #name:) equals: (self parseMethod: 'name: asdf 
+	self assert: ((refactoring model classNamed: #RBLintRuleTestData) parseTreeForSelector: #name:) equals: (self parseMethod: 'name: asdf 
 	name := asdf')
 ]
 
@@ -113,7 +113,7 @@ RBRenameTemporaryParametrizedTest >> testRenameTemporary [
 		'asdf' . #RBLintRuleTestData .#openEditor }.
 	self executeRefactoring: refactoring.
 
-	self assert: ((refactoring model classNamed: #RBLintRuleTestData) parseTreeFor: #openEditor) equals: (self parseMethod: 'openEditor
+	self assert: ((refactoring model classNamed: #RBLintRuleTestData) parseTreeForSelector: #openEditor) equals: (self parseMethod: 'openEditor
 								| asdf |
 								asdf := self failedRules.
 								asdf isEmpty ifTrue: [^self].

--- a/src/Refactoring2-Transformations-Tests/RBReplaceSubtreeTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBReplaceSubtreeTransformationTest.class.st
@@ -63,8 +63,8 @@ RBReplaceSubtreeTransformationTest >> testRefactoring [
 	
 	class := transformation model classNamed: #RBRemoveMethodTransformation.
 	self assert: (class directlyDefinesMethod: #selector:from:).
-	self assert: (class parseTreeFor: #selector:from:) body statements size equals: 2.
-	self assert: (class parseTreeFor: #selector:from:) body statements last isReturn.
+	self assert: (class parseTreeForSelector: #selector:from:) body statements size equals: 2.
+	self assert: (class parseTreeForSelector: #selector:from:) body statements last isReturn.
 ]
 
 { #category : #tests }
@@ -82,9 +82,9 @@ RBReplaceSubtreeTransformationTest >> testTransform [
 	
 	class := transformation model classNamed: self changeMock name asSymbol.
 	self assert: (class directlyDefinesMethod: #one).
-	self assert: (class parseTreeFor: #one) body statements size equals: 1.
-	self assert: (class parseTreeFor: #one) body statements first isReturn.
-	self assert: (class parseTreeFor: #one) body statements first value value equals: 123
+	self assert: (class parseTreeForSelector: #one) body statements size equals: 1.
+	self assert: (class parseTreeForSelector: #one) body statements first isReturn.
+	self assert: (class parseTreeForSelector: #one) body statements first value value equals: 123
 ]
 
 { #category : #tests }
@@ -102,7 +102,7 @@ RBReplaceSubtreeTransformationTest >> testTransformOneOfManyStatements [
 	
 	class := transformation model classNamed: #RBReplaceSubtreeTransformationTest.
 	self assert: (class directlyDefinesMethod: #testRefactoring).
-	self assert: (class parseTreeFor: #testRefactoring) body statements size equals: 6.
-	self assert: ((((class parseTreeFor: #testRefactoring) body statements at: 5) sourceCode withBlanksCondensed copyReplaceAll: String cr with: ' ')
+	self assert: (class parseTreeForSelector: #testRefactoring) body statements size equals: 6.
+	self assert: ((((class parseTreeForSelector: #testRefactoring) body statements at: 5) sourceCode withBlanksCondensed copyReplaceAll: String cr with: ' ')
 		includesSubstring: 'assert: (class parseTreeFor: #selector:from:) body statements size = 2').
 ]

--- a/src/Refactoring2-Transformations-Tests/RBSplitCascadeParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBSplitCascadeParametrizedTest.class.st
@@ -43,7 +43,7 @@ RBSplitCascadeParametrizedTest >> testSplitCascadeRefactoring [
 	
 	self executeRefactoring: refactoring.
 
-	self assert: ((refactoring model classNamed: #RBSplitCascadeParametrizedTest) parseTreeFor: #methodWithCascades) equals: (self parseMethod: 'methodWithCascades
+	self assert: ((refactoring model classNamed: #RBSplitCascadeParametrizedTest) parseTreeForSelector: #methodWithCascades) equals: (self parseMethod: 'methodWithCascades
 	| a receiver |
 	receiver := Object new.
 	receiver initialize.

--- a/src/Refactoring2-Transformations-Tests/RBSplitClassParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBSplitClassParametrizedTest.class.st
@@ -53,10 +53,10 @@ RBSplitClassParametrizedTest >> testSplitClass [
 	self assertCollection: (aModel classNamed: #BlockClass) instanceVariableNames 
 			hasSameElements: #(#methodBlock #classBlock).
 			
-	self assert: ((aModel classNamed: #RBBasicLintRuleTestData) parseTreeFor: #checkClass:) 
+	self assert: ((aModel classNamed: #RBBasicLintRuleTestData) parseTreeForSelector: #checkClass:) 
 				equals: (self parseMethod: 'checkClass: aSmalllintContext 
 	^blocks classBlock value: aSmalllintContext value: result').
-	self assert: ((aModel classNamed: #RBBasicLintRuleTestData) parseTreeFor: #checkMethod:) 
+	self assert: ((aModel classNamed: #RBBasicLintRuleTestData) parseTreeForSelector: #checkMethod:) 
 				equals: (self parseMethod: 'checkMethod: aSmalllintContext 
 	^blocks methodBlock value: aSmalllintContext value: result')
 ]

--- a/src/Refactoring2-Transformations-Tests/RBSplitClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBSplitClassTransformationTest.class.st
@@ -41,12 +41,12 @@ RBSplitClassTransformationTest >> testTransform [
 	self deny: (class instanceVariableNames includes: #receiver).
 	self assert: (class instanceVariableNames includes: #newReceiver).
 	
-	self assert: (class parseTreeFor: #receiver:)
+	self assert: (class parseTreeForSelector: #receiver:)
 		  equals: (self parseMethod:
 				'receiver: aString
 					newReceiver receiver: aString').
 					
-	self assert: (class parseTreeFor: #receiver)
+	self assert: (class parseTreeForSelector: #receiver)
 		  equals: (self parseMethod:
 				'receiver
 					^ newReceiver receiver 

--- a/src/Refactoring2-Transformations-Tests/RBTemporaryToInstanceVariableParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBTemporaryToInstanceVariableParametrizedTest.class.st
@@ -69,7 +69,7 @@ RBTemporaryToInstanceVariableParametrizedTest >> testTemporaryToInstanceVariable
 		{ RBLintRuleTestData . #displayName . 'nameStream'}.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBLintRuleTestData.
-	self assert: (class parseTreeFor: #displayName) equals: (self parseMethod: 'displayName
+	self assert: (class parseTreeForSelector: #displayName) equals: (self parseMethod: 'displayName
 								nameStream := WriteStream on: (String new: 64).
 								nameStream
 									nextPutAll: self name;
@@ -90,5 +90,5 @@ RBTemporaryToInstanceVariableParametrizedTest >> testWhenHierarchyDefinesVariabl
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	self assert: (class definesInstanceVariable: 'foo').
 	self deny: ((model classNamed: #Foo1) directlyDefinesInstanceVariable: 'foo').
-	self assert: (class parseTreeFor: #someMethod) equals: (self parseMethod: 'someMethod foo := 4. ^ foo').
+	self assert: (class parseTreeForSelector: #someMethod) equals: (self parseMethod: 'someMethod foo := 4. ^ foo').
 ]

--- a/src/Refactoring2-Transformations-Tests/RBTransformationsTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBTransformationsTest.class.st
@@ -53,7 +53,7 @@ RBTransformationsTest >> testAddMethodTransform [
 		transform.
 	
 	class := transformation model classNamed: self changeMock name.
-	self assert: (class parseTreeFor: #printString1)
+	self assert: (class parseTreeForSelector: #printString1)
 		  equals: (self parseMethod: 'printString1 ^super printString')
 ]
 
@@ -83,7 +83,7 @@ RBTransformationsTest >> testAddTemporaryVariableTransform [
 	
 	class := transformation model classNamed: self changeMock name asSymbol.
 	self assert: (class directlyDefinesMethod: #one).
-	self assert: (class parseTreeFor: #one) temporaries size equals: 1
+	self assert: (class parseTreeForSelector: #one) temporaries size equals: 1
 ]
 
 { #category : #tests }
@@ -97,9 +97,9 @@ RBTransformationsTest >> testAddVariableAccessorTransform [
 	self assert: transformation model changes changes size equals: 2.
 
 	class := transformation model classNamed: self changeMock name asSymbol.
-	self assert: (class parseTreeFor: #instVar) 
+	self assert: (class parseTreeForSelector: #instVar) 
 		equals: (self parseMethod: 'instVar ^instVar').
-	self assert: (class parseTreeFor: #instVar:) 
+	self assert: (class parseTreeForSelector: #instVar:) 
 		equals: (self parseMethod: 'instVar: anObject instVar := anObject')
 ]
 
@@ -144,7 +144,7 @@ RBTransformationsTest >> testCompositeTransform [
 	
 	class := transformation model classNamed: (self changeMock name, 'Temporary') asSymbol.
 	self assert: (class directlyDefinesInstanceVariable: 'asdf').
-	self assert: (class parseTreeFor: #printString1)
+	self assert: (class parseTreeForSelector: #printString1)
 		  equals: (self parseMethod: 'printString1 ^super printString')
 ]
 
@@ -189,13 +189,13 @@ RBTransformationsTest >> testDeprecateClassTransform [
 	
 	class := transformation model metaclassNamed: self changeMock name.
 	
-	self assert: (class parseTreeFor: #new)
+	self assert: (class parseTreeForSelector: #new)
 		equals: (self parseMethod: 'new
 				self deprecated: ''Use superclass '' on: ''4 May 2016''  in: #Pharo60.
 				^ super new').
-	self assert: (class parseTreeFor: #deprecated)
+	self assert: (class parseTreeForSelector: #deprecated)
 		equals: (self parseMethod: 'deprecated ^ true').
-	self assert: (class parseTreeFor: #systemIcon)
+	self assert: (class parseTreeForSelector: #systemIcon)
 		equals: (self parseMethod: 'systemIcon
 				^ Smalltalk ui icons iconNamed: #packageDelete').
 ]
@@ -290,7 +290,7 @@ RBTransformationsTest >> testRemoveMessageSendTransform [
 	self assert: transformation model changes changes size equals: 1.
 	
 	class := transformation model classNamed: #RBRefactoryTestDataApp.
-	self assert: (class parseTreeFor: methodName)
+	self assert: (class parseTreeForSelector: methodName)
 			equals:  (self parseMethod: 'called: anObject on: aBlock 
 	Transcript show: anObject printString.
 	aBlock value')
@@ -338,16 +338,16 @@ RBTransformationsTest >> testRenameClassTransform [
 	self assert: transformation model changes changes size equals: 1.
 	
 	class := transformation model classNamed: 'RBNewDummyClassName' asSymbol.
-	self assert: (class parseTreeFor: #method1)
+	self assert: (class parseTreeForSelector: #method1)
 		  equals: (self parseMethod: 'method1 ^ self method2').
 	self deny: (transformation model includesClassNamed: 'RBDummyClassToRename' asSymbol).
 				
 	class := transformation model classNamed: 'RBDummySubclassOfClassToRename' asSymbol.
 	self assert: class superclass 
 		  equals: (transformation model classNamed: 'RBNewDummyClassName' asSymbol).
-	self assert: (class parseTreeFor: #symbolReference) 
+	self assert: (class parseTreeForSelector: #symbolReference) 
 		  equals: (self parseMethod: 'symbolReference ^ #RBNewDummyClassName').
-	self assert: (class parseTreeFor: #reference) 
+	self assert: (class parseTreeForSelector: #reference) 
 		  equals: (self parseMethod: 'reference ^ RBNewDummyClassName new')
 ]
 
@@ -377,8 +377,8 @@ RBTransformationsTest >> testRenameTemporaryTransform [
 	
 	class := transformation model classNamed: self changeMock name.
 	self assert: (class directlyDefinesMethod: #foo).		
-	self assert: (class parseTreeFor: #foo) temporaries size equals: 2.
-	self assert: ((class parseTreeFor: #foo) temporaries anySatisfy: [ :e | e name = #temp2 ])
+	self assert: (class parseTreeForSelector: #foo) temporaries size equals: 2.
+	self assert: ((class parseTreeForSelector: #foo) temporaries anySatisfy: [ :e | e name = #temp2 ])
 ]
 
 { #category : #tests }
@@ -394,11 +394,11 @@ RBTransformationsTest >> testRenameVariableTransform [
 	class := transformation model classNamed: #RBBasicLintRuleTestData.
 	self assert: (class directlyDefinesInstanceVariable: 'asdf').
 	self deny: (class directlyDefinesInstanceVariable: 'classBlock').
-	self assert: (class parseTreeFor: #checkClass:)
+	self assert: (class parseTreeForSelector: #checkClass:)
 		  equals: (self parseMethod:
 				'checkClass: aSmalllintContext 
 					^asdf value: aSmalllintContext value: result').
-	self assert: (class parseTreeFor: #initialize)
+	self assert: (class parseTreeForSelector: #initialize)
 		  equals: (self parseMethod:
 				'initialize
 					super initialize.

--- a/src/Refactoring2-Transformations/RBAddSubtreeTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBAddSubtreeTransformation.class.st
@@ -86,7 +86,7 @@ RBAddSubtreeTransformation >> preconditions [
 { #category : #executing }
 RBAddSubtreeTransformation >> privateTransform [
 	| parseTree newNode |
-	parseTree := self definingClass parseTreeFor: selector.
+	parseTree := self definingClass parseTreeForSelector: selector.
 	parseTree ifNil: [ ^ self ].
 	newNode := self parserClass
 		parseExpression: sourceCode

--- a/src/Refactoring2-Transformations/RBChangeMethodNameTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBChangeMethodNameTransformation.class.st
@@ -132,7 +132,7 @@ RBChangeMethodNameTransformation >> renameImplementors [
 		do: [ :each | 
 			| parseTree |
 
-			parseTree := each parseTreeFor: oldSelector.
+			parseTree := each parseTreeForSelector: oldSelector.
 			parseTree ifNil: [ self refactoringFailure: 'Could not parse source code.' ].
 			self implementorsCanBePrimitives
 				ifFalse: [ parseTree isPrimitive

--- a/src/Refactoring2-Transformations/RBCompositeMethodTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBCompositeMethodTransformation.class.st
@@ -17,5 +17,5 @@ RBCompositeMethodTransformation >> definingClass [
 { #category : #accessing }
 RBCompositeMethodTransformation >> definingMethod [
 
-	^ self definingClass parseTreeFor: selector asSymbol
+	^ self definingClass parseTreeForSelector: selector asSymbol
 ]

--- a/src/Refactoring2-Transformations/RBExtractToTemporaryTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBExtractToTemporaryTransformation.class.st
@@ -105,7 +105,7 @@ RBExtractToTemporaryTransformation >> parseTree [
 
 	parseTree
 		ifNil: [ 
-			parseTree := class parseTreeFor: selector.
+			parseTree := class parseTreeForSelector: selector.
 			parseTree ifNil: [ self refactoringFailure: 'Could not parse method' ]
 		].
 	^ parseTree

--- a/src/Refactoring2-Transformations/RBInlineMethodTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBInlineMethodTransformation.class.st
@@ -88,7 +88,7 @@ RBInlineMethodTransformation >> compileMethod [
 { #category : #adding }
 RBInlineMethodTransformation >> findSelectedMessage [
 
-	sourceParseTree := class parseTreeFor: sourceSelector.
+	sourceParseTree := class parseTreeForSelector: sourceSelector.
 	sourceParseTree ifNil: [ self refactoringFailure: 'Could not parse sources' ].
 	sourceMessage := sourceParseTree whichNodeIsContainedBy: sourceInterval.
 	sourceMessage
@@ -255,7 +255,7 @@ RBInlineMethodTransformation >> parseInlineMethod [
 						expandMacrosWith: class
 						with: self inlineSelector )
 			].
-	inlineParseTree := self classOfTheMethodToInline parseTreeFor: self inlineSelector.
+	inlineParseTree := self classOfTheMethodToInline parseTreeForSelector: self inlineSelector.
 	inlineParseTree ifNil: [ self refactoringFailure: 'Could not parse sources' ].
 	inlineParseTree lastIsReturn
 		ifFalse: [ inlineParseTree addSelfReturn ]

--- a/src/Refactoring2-Transformations/RBInlineTemporaryTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBInlineTemporaryTransformation.class.st
@@ -97,7 +97,7 @@ RBInlineTemporaryTransformation >> storeOn: aStream [
 { #category : #preconditions }
 RBInlineTemporaryTransformation >> verifySelectedInterval [
 
-	sourceTree := class parseTreeFor: selector.
+	sourceTree := class parseTreeForSelector: selector.
 	sourceTree ifNil: [ self refactoringFailure: 'Could not parse source' ].
 	assignmentNode := sourceTree whichNodeIsContainedBy: sourceInterval.
 	assignmentNode isAssignment

--- a/src/Refactoring2-Transformations/RBMoveMethodToClassSideTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBMoveMethodToClassSideTransformation.class.st
@@ -79,7 +79,7 @@ RBMoveMethodToClassSideTransformation >> getNewSource [
 RBMoveMethodToClassSideTransformation >> parseTree [
 
 	parseTree
-		ifNil: [ parseTree := class parseTreeFor: method selector.
+		ifNil: [ parseTree := class parseTreeForSelector: method selector.
 			parseTree ifNil: [ self refactoringFailure: 'Could not parse method' ]
 			].
 	^ parseTree

--- a/src/Refactoring2-Transformations/RBMoveMethodTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBMoveMethodTransformation.class.st
@@ -90,7 +90,7 @@ RBMoveMethodTransformation >> addSelfReturn [
 { #category : #transforming }
 RBMoveMethodTransformation >> buildParseTree [
 
-	parseTree := ( class parseTreeFor: selector ) copy.
+	parseTree := ( class parseTreeForSelector: selector ) copy.
 	parseTree ifNil: [ self refactoringFailure: 'Could not parse method' ]
 ]
 
@@ -163,7 +163,7 @@ RBMoveMethodTransformation >> compileDelegatorMethod [
 					                  ifFalse: [ RBVariableNode named: each ] ]).
 	self hasOnlySelfReturns ifFalse: [ delegatorNode := RBReturnNode value: delegatorNode ].
 	statementNode := RBSequenceNode temporaries: #(  ) statements: (Array with: delegatorNode).
-	(tree := class parseTreeFor: selector) body: statementNode.
+	(tree := class parseTreeForSelector: selector) body: statementNode.
 	class compileTree: tree
 ]
 

--- a/src/Refactoring2-Transformations/RBPullUpMethodTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBPullUpMethodTransformation.class.st
@@ -59,13 +59,13 @@ RBPullUpMethodTransformation >> checkBackReferencesTo: aSelector [
 	| definingClass pushUpParseTree |
 	definingClass := targetSuperclass whoDefinesMethod: aSelector.
 	definingClass ifNil: [^self].
-	pushUpParseTree := class parseTreeFor: aSelector.
+	pushUpParseTree := class parseTreeForSelector: aSelector.
 	targetSuperclass allSubclasses do: 
 			[:each | 
 			each selectors do: 
 					[:sel | 
 					| parseTree |
-					parseTree := each parseTreeFor: sel.
+					parseTree := each parseTreeForSelector: sel.
 					(parseTree notNil and: 
 							[(parseTree superMessages includes: aSelector) 
 								and: [definingClass == (each whoDefinesMethod: aSelector)]]) 
@@ -121,7 +121,7 @@ RBPullUpMethodTransformation >> checkSiblingSuperSendsFrom: aRBClass [
 	aRBClass selectors do: 
 			[:each | 
 			| tree |
-			tree := aRBClass parseTreeFor: each.
+			tree := aRBClass parseTreeForSelector: each.
 			tree ifNotNil: 
 					[tree superMessages do: 
 							[:aSelector | 
@@ -150,7 +150,7 @@ RBPullUpMethodTransformation >> checkSuperSendsFromPushedUpMethods [
 	selectors do: 
 			[:each | 
 			| parseTree |
-			parseTree := class parseTreeFor: each.
+			parseTree := class parseTreeForSelector: each.
 			parseTree superMessages 
 				detect: [:sup | targetSuperclass directlyDefinesMethod: sup]
 				ifFound: 
@@ -174,8 +174,8 @@ RBPullUpMethodTransformation >> checkSuperclass [
 	overrideSelectors := overrideSelectors
 		reject: [ :each | 
 			| myTree superTree |
-			myTree := class parseTreeFor: each.
-			superTree := targetSuperclass parseTreeFor: each.
+			myTree := class parseTreeForSelector: each.
+			superTree := targetSuperclass parseTreeForSelector: each.
 			superTree equalTo: myTree exceptForVariables: #() ].
 	overrideSelectors ifEmpty: [ ^ self ].
 	targetSuperclass isAbstract
@@ -201,7 +201,7 @@ RBPullUpMethodTransformation >> copyDownMethod: aSelector [
 	subclasses := targetSuperclass subclasses 
 				reject: [:each | each directlyDefinesMethod: aSelector].
 	subclasses ifEmpty: [^ {  } ].
-	(superclassDefiner parseTreeFor: aSelector) superMessages 
+	(superclassDefiner parseTreeForSelector: aSelector) superMessages 
 		detect: [:each | superclassDefiner directlyDefinesMethod: each]
 		ifFound: 
 			[self 
@@ -213,7 +213,7 @@ RBPullUpMethodTransformation >> copyDownMethod: aSelector [
 				, aSelector, '?'.
 	refactoring := RBExpandReferencedPoolsTransformation
 				model: self model
-				forMethod: (superclassDefiner parseTreeFor: aSelector)
+				forMethod: (superclassDefiner parseTreeForSelector: aSelector)
 				fromClass: superclassDefiner
 				toClasses: subclasses.
 	^ Array with: refactoring
@@ -250,7 +250,7 @@ RBPullUpMethodTransformation >> pullUp: aSelector [
 	source ifNil: [self refactoringFailure: 'Source for method not available'].
 	refactoring := RBExpandReferencedPoolsTransformation
 				model: self model
-				forMethod: (class parseTreeFor: aSelector)
+				forMethod: (class parseTreeForSelector: aSelector)
 				fromClass: class
 				toClasses: (Array with: targetSuperclass).
 	^ Array 
@@ -300,11 +300,11 @@ RBPullUpMethodTransformation >> removeDuplicatesOf: aSelector [
 		model: self model 
 		with: [ :rbModel | 
 			| tree |
-			tree := targetSuperclass parseTreeFor: aSelector.
+			tree := targetSuperclass parseTreeForSelector: aSelector.
 			targetSuperclass allSubclasses collect: 
 			[:aClass | 
 			((aClass directlyDefinesMethod: aSelector) and: 
-					[(tree equalTo: (aClass parseTreeFor: aSelector) exceptForVariables: #()) 
+					[(tree equalTo: (aClass parseTreeForSelector: aSelector) exceptForVariables: #()) 
 						and: [(aClass superclass whoDefinesMethod: aSelector) == targetSuperclass]]) 
 				ifTrue: 
 					[removeDuplicates 

--- a/src/Refactoring2-Transformations/RBPushDownMethodTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBPushDownMethodTransformation.class.st
@@ -83,7 +83,7 @@ RBPushDownMethodTransformation >> pushDown: aSelector [
 	protocols := class protocolsFor: aSelector.
 	refactoring := RBExpandReferencedPoolsTransformation
 		               model: self model
-		               forMethod: (class parseTreeFor: aSelector)
+		               forMethod: (class parseTreeForSelector: aSelector)
 		               fromClass: class
 		               toClasses: self allClasses.
 	^ {refactoring}, (self allClasses select: [ :each | (each directlyDefinesMethod: aSelector) not ] 

--- a/src/Refactoring2-Transformations/RBRemoveMethodTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBRemoveMethodTransformation.class.st
@@ -113,7 +113,7 @@ RBRemoveMethodTransformation >> checkSuperMethods [
 
 	(self justSendsSuper: selector) ifTrue: [ ^ self ]
 		ifFalse: [ (self superclassEquivalentlyDefines: selector)
-			ifTrue: [ (self definingClass parseTreeFor: selector) superMessages
+			ifTrue: [ (self definingClass parseTreeForSelector: selector) superMessages
 				ifNotEmpty: [ self 
 						refactoringError: ('Although <1s> is equivalent to a superclass method,<n>
 							it contains a super send so it might modify behavior.'
@@ -125,7 +125,7 @@ RBRemoveMethodTransformation >> checkSuperMethods [
 RBRemoveMethodTransformation >> justSendsSuper: aSelector [
 	| matcher parseTree superclass |
 	matcher := self parseTreeSearcherClass justSendsSuper.
-	parseTree := self definingClass parseTreeFor: aSelector.
+	parseTree := self definingClass parseTreeForSelector: aSelector.
 	(matcher executeTree: parseTree initialAnswer: false)
 		ifFalse: [ ^ false ].
 	parseTree lastIsReturn
@@ -134,7 +134,7 @@ RBRemoveMethodTransformation >> justSendsSuper: aSelector [
 	superclass := self definingClass superclass
 		whichClassIncludesSelector: aSelector.
 	superclass ifNil: [ ^ true ].
-	parseTree := superclass parseTreeFor: aSelector.
+	parseTree := superclass parseTreeForSelector: aSelector.
 	matcher := self parseTreeSearcherClass new.
 	matcher
 		matches: '^``@object'
@@ -188,8 +188,8 @@ RBRemoveMethodTransformation >> superclassEquivalentlyDefines: aSelector [
 	| superTree myTree |
 
 	self definingClass superclass ifNil: [ ^ false ].
-	superTree := self definingClass superclass parseTreeFor: aSelector.
-	myTree := self definingClass parseTreeFor: aSelector.
+	superTree := self definingClass superclass parseTreeForSelector: aSelector.
+	myTree := self definingClass parseTreeForSelector: aSelector.
 	( superTree isNil or: [ myTree isNil ] )
 		ifTrue: [ ^ false ].
 	^ superTree equalTo: myTree exceptForVariables: #()

--- a/src/Refactoring2-Transformations/RBRemoveParameterTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBRemoveParameterTransformation.class.st
@@ -45,7 +45,7 @@ RBRemoveParameterTransformation >> getNewSelector [
 	| tree |
 	(class directlyDefinesMethod: oldSelector)
 		ifFalse: [ self refactoringFailure: 'Method doesn''t exist' ].
-	tree := class parseTreeFor: oldSelector.
+	tree := class parseTreeForSelector: oldSelector.
 	tree ifNil: [ self refactoringFailure: 'Cannot parse sources' ].
 	argument ifNil:[ self refactoringFailure: 'This method does not have an argument' ].
 	parameterIndex := tree argumentNames indexOf: argument ifAbsent: [ self refactoringFailure: 'Select a parameter!!' ].
@@ -58,7 +58,7 @@ RBRemoveParameterTransformation >> hasReferencesToTemporaryIn: each [
 
 	| tree |
 
-	tree := each parseTreeFor: oldSelector.
+	tree := each parseTreeForSelector: oldSelector.
 	tree ifNil: [ self refactoringFailure: 'Cannot parse sources.' ].
 	^ tree references: ( tree argumentNames at: parameterIndex )
 ]

--- a/src/Refactoring2-Transformations/RBRemoveSubtreeTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBRemoveSubtreeTransformation.class.st
@@ -66,7 +66,7 @@ RBRemoveSubtreeTransformation >> preconditions [
 						ifNil: [ self refactoringError: 'Invalid source to extract - ' , sourceCode ].
 					(tree isSequence and: [ tree statements isEmpty ])
 						ifTrue: [ self refactoringError: 'Selected code to extract is empty' ].
-					tree := ((self definingClass parseTreeFor: selector)
+					tree := ((self definingClass parseTreeForSelector: selector)
 						extractSubtreeWith: sourceCode)
 						ifNil: [ self
 								refactoringError: 'Could not extract code from method ' , selector ].
@@ -79,7 +79,7 @@ RBRemoveSubtreeTransformation >> privateTransform [
 	| parseTree |
 	"execute in terms of nodes and not in parserewriter"
 	"suggest remove similar code here"
-	parseTree := self definingClass parseTreeFor: selector.
+	parseTree := self definingClass parseTreeForSelector: selector.
 	parseTree ifNil: [ ^ self ].
 	
 	"Halt now."

--- a/src/Refactoring2-Transformations/RBReplaceSubtreeTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBReplaceSubtreeTransformation.class.st
@@ -59,7 +59,7 @@ RBReplaceSubtreeTransformation >> preconditions [
 								refactoringError: 'Invalid source to extract - ' , oldSourceCode ].
 					(tree isSequence and: [ tree statements isEmpty ])
 						ifTrue: [ self refactoringError: 'Selected code to extract is empty' ].
-					tree := ((self definingClass parseTreeFor: selector)
+					tree := ((self definingClass parseTreeForSelector: selector)
 						extractSubtreeWith: oldSourceCode)
 						ifNil: [ self
 								refactoringError: 'Could not extract code from method ' , selector ].
@@ -76,7 +76,7 @@ RBReplaceSubtreeTransformation >> preconditions [
 { #category : #executing }
 RBReplaceSubtreeTransformation >> privateTransform [
 	| tree oldTree newTree |
-	tree := self definingClass parseTreeFor: selector.
+	tree := self definingClass parseTreeForSelector: selector.
 	tree ifNil: [ ^ self ].
 	oldTree := tree extractSubtreeWith: oldSourceCode.
 	oldTree ifNil: [ ^ self ].

--- a/src/Refactoring2-Transformations/RBTemporaryToInstanceVariableTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBTemporaryToInstanceVariableTransformation.class.st
@@ -103,7 +103,7 @@ RBTemporaryToInstanceVariableTransformation class >> model: aRBSmalltalk class: 
 { #category : #preconditions }
 RBTemporaryToInstanceVariableTransformation >> checkForValidTemporaryVariable [
 	| parseTree |
-	parseTree := class parseTreeFor: selector.
+	parseTree := class parseTreeForSelector: selector.
 	(parseTree allTemporaryVariables includes: temporaryVariableName) 
 		ifFalse: 
 			[self refactoringFailure: temporaryVariableName 

--- a/src/Refactoring2-Transformations/RBTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBTransformation.class.st
@@ -142,7 +142,7 @@ RBTransformation >> convertMethod: selector for: aClass using: searchReplacer [
 	change is made then compile it into the changeBuilder."
 
 	| parseTree |
-	parseTree := aClass parseTreeFor: selector.
+	parseTree := aClass parseTreeForSelector: selector.
 	parseTree ifNil: [ ^ self ].
 	( searchReplacer executeTree: parseTree )
 		ifTrue: [ aClass compileTree: searchReplacer tree ]

--- a/src/SystemCommands-MessageCommands/SycMessageOriginHack.class.st
+++ b/src/SystemCommands-MessageCommands/SycMessageOriginHack.class.st
@@ -42,7 +42,17 @@ SycMessageOriginHack >> name [
 ]
 
 { #category : #'hacked methods' }
-SycMessageOriginHack >> parseTreeFor: aSelector [
+SycMessageOriginHack >> parseTreeFor: aSymbol [
+
+	self
+		deprecated: 'Use parseTreeForSelector: instead'
+		transformWith: '`@receiver parseTreeFor: `@argument'
+			-> '`@receiver parseTreeForSelector: `@argument'.
+	^ self parseTreeForSelector: aSymbol
+]
+
+{ #category : #'hacked methods' }
+SycMessageOriginHack >> parseTreeForSelector: aSelector [
 	^message
 ]
 


### PR DESCRIPTION
rename parseTreeFor: => parseTreeForSelector:

+ deprecation