### PR TITLE
Fix #12408, remove containerTabs from the notebook and not from the owner submorphs

### DIFF
--- a/src/Calypso-Browser/ClyBrowserToolMorph.class.st
+++ b/src/Calypso-Browser/ClyBrowserToolMorph.class.st
@@ -511,7 +511,7 @@ ClyBrowserToolMorph >> rebuildStatusBar [
 { #category : #controlling }
 ClyBrowserToolMorph >> removeFromBrowser [
 
-	containerTab delete
+	containerTab owner removePage: containerTab
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
**Analysis**

To remove the class/inst method creation tab, the method "ClyBrowserToolMorph >> removeFromBrowser" is called.
This method was trying to delete the tab by sending the message "delete" to the instance var "containerTab".

The "delete" method is implemented by the superclass "Morph". It tries to delete the "Morph" object (the "containerTab" in our case) from its parent's list of "submorphs".

**First observation**

Our "containerTab" is never part of this "submorphs" list.
This is the reason why the tab is never closed on a new method save.

**Second observation**

The parent of the "containerTab" is a "ClyNotebookMorph" and allows to add widgets as pages in a Calypso notebook.
It is a subtype of "SpNotebookMorph" which provides methods to add/remove pages.


**Fix**

- I don't know why the "containerTab" is not in the "submorphs" list. 
  We could try to fix this, but it could have a big impact on other parts of the system.

- I chose to use the "removePage" method from  "SpNotebookMorph" instead.
  The only reason why this could fail is if the owner of the tab is not a "ClyNotebookMorph".
  But this not supposed to happen as tabs are added via "ClyBrowserToolMorph >> addNotebookPageOn: aNotebook".


