### PR TITLE
Fix DrTest UI when plugin selection change

### DIFF
--- a/src/DrTests/DrTests.class.st
+++ b/src/DrTests/DrTests.class.st
@@ -88,15 +88,14 @@ DrTests >> currentPlugin: aPlugin [
 
 	super currentPlugin: aPlugin.
 
-	aPlugin pluginPresenterClass = pluginPresenter class
-		ifFalse: [
-			newPluginPresenter := self
-				instantiate: aPlugin pluginPresenterClass
-				on: { aPlugin. self }.
-			self layout
-				replace: pluginPresenter
-				with: newPluginPresenter.
-			pluginPresenter := newPluginPresenter ].
+	"Always instantiate and update the plugin, as the plugin presenter class is not sufficient to tell them appart"
+	newPluginPresenter := self
+		instantiate: aPlugin pluginPresenterClass
+		on: { aPlugin. self }.
+	self layout
+		replace: pluginPresenter
+		with: newPluginPresenter.
+	pluginPresenter := newPluginPresenter.
 
 	self updateStatus: aPlugin pluginName , ' plugin is ready to work!' translated
 ]


### PR DESCRIPTION
A recent optimization (66dfc5bd4e967f09492d4cf1ce413aac11f287f5) disabled the update of plugin-related presentation (eg the package list) when a plugin is selected in the dropbox.

This made "executable comments" untestable with DrTest :(