### PR TITLE
Disable setting formatIncompleteIdentifiers by default

### DIFF
--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -340,7 +340,7 @@ SHRBTextStyler class >> defaultStyleTable [
 { #category : #styles }
 SHRBTextStyler class >> formatIncompleteIdentifiers [
 
-	^ formatIncompleteIdentifiers ifNil: [ formatIncompleteIdentifiers := true ]
+	^ formatIncompleteIdentifiers ifNil: [ formatIncompleteIdentifiers := false ]
 ]
 
 { #category : #styles }
@@ -399,7 +399,7 @@ SHRBTextStyler class >> settingsOn: aBuilder [
 	
 	(aBuilder setting: #formatIncompleteIdentifiers) 
 		target: self;
-		default: true;
+		default: false;
 		order: 1;
 		label: 'Format Incomplete Identifiers';
 		parentName: #'Syntax Highlighting';


### PR DESCRIPTION
Syntax highlighting is very slow when coloring garbage source code (e.g. a bad coy-paste in an editor window).

```st
[ StPlayground openContents: (String loremIpsum: 10000) ] timeToRun "14 seconds"
```

The culprit is `SHRBTextStyler>>#formatIncompleteSelector:` that calls `Symbol class>>#selectorThatStartsCaseSensitive:skipping:` that is insanely inefficient.

This method is used to distinguish bad selector that are prefix of existing selectors from just bad selectors.
Personally, I'm not sure to understand why that matters in the first place, especially since the default theme just color both of them red, so the default user could not see any difference anyway.

Luckily, this formatting is protected by a setting (introduced by 46360f7b7f5f031701a68d1eda2474a6983007d1). This PR just made the default to false. (My first idea was to nuke the whole thing).

Now, the default user can highlight garbage 4275% more efficiently!

```st
[ StPlayground openContents: (String loremIpsum: 10000) ] timeToRun "0.32 seconds"
```