### PR TITLE
NumberParser accept and ignore underscore

### DIFF
--- a/src/NumberParser-Tests/NumberParserTest.class.st
+++ b/src/NumberParser-Tests/NumberParserTest.class.st
@@ -314,6 +314,20 @@ NumberParserTest >> testFloatmin [
 ]
 
 { #category : #'tests - Integer' }
+NumberParserTest >> testIntegerParseUnderscore [
+
+	self assert: (NumberParser parse: '1234') equals: 1234.
+	self assert: (NumberParser parse: '1_234') equals: 1234.
+	self assert: (NumberParser parse: '__1__2__3__4__') equals: 1234.
+	self should: [NumberParser parse: '__'] raise: Error.
+
+	self assert: (NumberParser parse: '16r1234_5678') equals: 16r12345678.
+
+	self assert: (NumberParser parse: '123_456_789.123_456_789') equals: 123456789.123456789.
+
+]
+
+{ #category : #'tests - Integer' }
 NumberParserTest >> testIntegerReadFrom [
 	"Ensure remaining characters in a stream are not lost when parsing an integer."
 	| rs i s |

--- a/src/NumberParser/NumberParser.class.st
+++ b/src/NumberParser/NumberParser.class.st
@@ -191,15 +191,16 @@ NumberParser >> nextElementaryLargeIntegerBase: aRadix [
 	nDigits := 0.
 	lastNonZero := 0.
 	[value isLarge or: [(char := sourceStream next) isNil
-		or: [digit := char digitValue.
+		or: [ char ~= $_ and: [digit := char digitValue.
 			(0 > digit or: [digit >= aRadix])
 				and: [sourceStream skip: -1.
-					true]]]]
+					true]]]]]
 		whileFalse: [
+			char ~= $_ ifTrue: [ 
 			nDigits := nDigits + 1.
 			0 = digit
 				ifFalse: [lastNonZero := nDigits].
-			value := value * aRadix + digit].
+			value := value * aRadix + digit]].
 	^value
 ]
 


### PR DESCRIPTION
The proposal is to extends number syntax to accept and ignore the underscore character `_` (ASCII 95).

Many languages (including Python https://peps.python.org/pep-0515/ , Java https://docs.oracle.com/javase/7/docs/technotes/guides/language/underscores-literals.html or Ruby) accept some forms of numeric literal that ignore `_`.

The idea is to permit long literals that are still readable, eg. `1_000_000_000` is easier for a human than `100000000` especially since in the previous literal a zero is missing (I'm a tricky deceitful fellow).

Usually, there is not a lot of constraint on the placement of `_` to accommodate various locales and usages or radix.

However, duplicate or training `_` are usually rejected as syntax error.
The PR just ignore any `_` without constrains. We might add them, or add them as rules for case that feel more being a syntax warning than a syntax error.