### PR TITLE
FindAndReplaceRefactoring is a transformation

### DIFF
--- a/src/Refactoring-Core/RBExtractMethodAndOccurrences.class.st
+++ b/src/Refactoring-Core/RBExtractMethodAndOccurrences.class.st
@@ -70,7 +70,7 @@ RBExtractMethodAndOccurrences >> findImplementorOf: aSelector [
 { #category : #transforming }
 RBExtractMethodAndOccurrences >> findOccurrencesClass [
 
-	^ RBFindAndReplaceRefactoring
+	^ RBFindAndReplaceTransformation
 ]
 
 { #category : #transforming }

--- a/src/Refactoring-Core/RBExtractSetUpMethodAndOccurrences.class.st
+++ b/src/Refactoring-Core/RBExtractSetUpMethodAndOccurrences.class.st
@@ -66,7 +66,7 @@ RBExtractSetUpMethodAndOccurrences >> extractMethodClass [
 
 { #category : #transforming }
 RBExtractSetUpMethodAndOccurrences >> findOccurrencesClass [
-	^ RBFindAndReplaceSetUpRefactoring
+	^ RBFindAndReplaceSetUpTransformation
 ]
 
 { #category : #transforming }

--- a/src/Refactoring-Core/RBFindAndReplaceSetUpTransformation.class.st
+++ b/src/Refactoring-Core/RBFindAndReplaceSetUpTransformation.class.st
@@ -54,13 +54,13 @@ RBTest >> testExample4
 ```
 "
 Class {
-	#name : #RBFindAndReplaceSetUpRefactoring,
-	#superclass : #RBFindAndReplaceRefactoring,
-	#category : #'Refactoring-Core-Refactorings'
+	#name : #RBFindAndReplaceSetUpTransformation,
+	#superclass : #RBFindAndReplaceTransformation,
+	#category : #'Refactoring-Core-Transformation-Simple'
 }
 
 { #category : #'instance creation' }
-RBFindAndReplaceSetUpRefactoring class >> model: aModel of: aClass inWholeHierarchy: aBoolean [
+RBFindAndReplaceSetUpTransformation class >> model: aModel of: aClass inWholeHierarchy: aBoolean [
 	^ self new
 		model: aModel;
 		of: aClass
@@ -69,7 +69,7 @@ RBFindAndReplaceSetUpRefactoring class >> model: aModel of: aClass inWholeHierar
 ]
 
 { #category : #'instance creation' }
-RBFindAndReplaceSetUpRefactoring class >> of: aClass inWholeHierarchy: aBoolean [
+RBFindAndReplaceSetUpTransformation class >> of: aClass inWholeHierarchy: aBoolean [
 	^ self new
 		of: aClass
 		inWholeHierarchy: aBoolean;
@@ -77,19 +77,19 @@ RBFindAndReplaceSetUpRefactoring class >> of: aClass inWholeHierarchy: aBoolean 
 ]
 
 { #category : #accessing }
-RBFindAndReplaceSetUpRefactoring >> extractMethodRefactoring [
+RBFindAndReplaceSetUpTransformation >> extractMethodRefactoring [
 	^ RBExtractSetUpMethodRefactoring new
-			setOption: #useExistingMethod 
-			toUse:  [ :ref :aSelector | 
+			setOption: #useExistingMethod
+			toUse:  [ :ref :aSelector |
 				true];
-			setOption: #extractAssignment 
-			toUse:  [ :ref :aSelector | 
+			setOption: #extractAssignment
+			toUse:  [ :ref :aSelector |
 				true];
 			yourself
 ]
 
 { #category : #accessing }
-RBFindAndReplaceSetUpRefactoring >> methodNode [ 
+RBFindAndReplaceSetUpTransformation >> methodNode [
 	| node |
 	node := super methodNode.
 	node body removeNode: (RBParser parseExpression: 'super setUp.').
@@ -97,9 +97,9 @@ RBFindAndReplaceSetUpRefactoring >> methodNode [
 ]
 
 { #category : #accessing }
-RBFindAndReplaceSetUpRefactoring >> nodesOf: methodNode [
+RBFindAndReplaceSetUpTransformation >> nodesOf: methodNode [
 	| combinations limit |
-	
+
 	combinations := super nodesOf: methodNode.
 	^ combinations ifEmpty: [ combinations ]
 		ifNotEmpty: [ limit :=  methodNode body statements first start.
@@ -107,18 +107,18 @@ RBFindAndReplaceSetUpRefactoring >> nodesOf: methodNode [
 ]
 
 { #category : #'instance creation' }
-RBFindAndReplaceSetUpRefactoring >> of: aClass inWholeHierarchy: aBoolean [
+RBFindAndReplaceSetUpTransformation >> of: aClass inWholeHierarchy: aBoolean [
 	class := self classObjectFor: aClass.
 	selector := #setUp.
-	replacesAllHierarchy := aBoolean.
+	replacesAllHierarchy := aBoolean
 ]
 
 { #category : #preconditions }
-RBFindAndReplaceSetUpRefactoring >> selectorsFor: cls [
+RBFindAndReplaceSetUpTransformation >> selectorsFor: cls [
 	^ (cls selectors select: [:e | e isTestSelector]) copyWithout: selector
 ]
 
 { #category : #accessing }
-RBFindAndReplaceSetUpRefactoring >> startLimitOf: sourceCode [
+RBFindAndReplaceSetUpTransformation >> startLimitOf: sourceCode [
 	^ ((self parserClass parseMethod: sourceCode) body statements first start)
 ]

--- a/src/Refactoring-Core/RBFindAndReplaceTransformation.class.st
+++ b/src/Refactoring-Core/RBFindAndReplaceTransformation.class.st
@@ -42,7 +42,7 @@ MyClassB >> dummyMethod
 ```
 "
 Class {
-	#name : #RBFindAndReplaceRefactoring,
+	#name : #RBFindAndReplaceTransformation,
 	#superclass : #RBMethodRefactoring,
 	#instVars : [
 		'method',
@@ -51,118 +51,113 @@ Class {
 		'matchNodes',
 		'occurrences'
 	],
-	#category : #'Refactoring-Core-Refactorings'
+	#category : #'Refactoring-Core-Transformation-Simple'
 }
 
 { #category : #'instance creation' }
-RBFindAndReplaceRefactoring class >> find: aMethod of: aClass inWholeHierarchy: aBoolean [
-	^ self new 
-		find: aMethod 
+RBFindAndReplaceTransformation class >> find: aMethod of: aClass inWholeHierarchy: aBoolean [
+	^ self new
+		find: aMethod
 		of: aClass
 		inWholeHierarchy: aBoolean;
 		yourself
 ]
 
 { #category : #'instance creation' }
-RBFindAndReplaceRefactoring class >> model: aModel find: aMethod of: aClass inWholeHierarchy: aBoolean [
+RBFindAndReplaceTransformation class >> model: aModel find: aMethod of: aClass inWholeHierarchy: aBoolean [
 	^ self new
-		model: aModel; 
-		find: aMethod 
+		model: aModel;
+		find: aMethod
 		of: aClass
 		inWholeHierarchy: aBoolean;
 		yourself
 ]
 
 { #category : #accessing }
-RBFindAndReplaceRefactoring >> argumentsOf: aDictionary [
+RBFindAndReplaceTransformation >> argumentsOf: aDictionary [
 	"Return the arguments values of a method ocurrence"
-	
+
 	|args limit|
 	limit := self method ast arguments size - 1.
 	args := OrderedCollection new.
 	0 to: limit do: [ :each |
-		args add: 
-			(aDictionary at: (aDictionary keys detect: 
+		args add:
+			(aDictionary at: (aDictionary keys detect:
 				[ :e | (e name asString) =  ('`@argMatch', each asString)])) sourceCode
 	 ].
 	^ args
 ]
 
 { #category : #accessing }
-RBFindAndReplaceRefactoring >> extract: occurrence of: rbMethod [
+RBFindAndReplaceTransformation >> extract: occurrence of: rbMethod [
 	[|refactoring |
-	refactoring := self extractMethodRefactoring. 
+	refactoring := self extractMethodRefactoring.
 	refactoring model: self model.
 	refactoring 	extract: occurrence key from: rbMethod selector in: rbMethod modelClass.
-	refactoring setOption: #existingSelector toUse:  [ :ref | 
+	refactoring setOption: #existingSelector toUse:  [ :ref |
 			ref parameters: (self argumentsOf: occurrence value).
 			selector].
 	self performCompositeRefactoring: refactoring ] on: Exception do: [ :e | e ]
 ]
 
 { #category : #accessing }
-RBFindAndReplaceRefactoring >> extractMethodRefactoring [
+RBFindAndReplaceTransformation >> extractMethodRefactoring [
 	^ RBExtractMethodRefactoring new
-			setOption: #useExistingMethod 
-			toUse:  [ :ref :aSelector | 
+			setOption: #useExistingMethod
+			toUse:  [ :ref :aSelector |
 				true];
 			yourself
 ]
 
 { #category : #initialization }
-RBFindAndReplaceRefactoring >> find: aSelector of: aClass inWholeHierarchy: aBoolean [
+RBFindAndReplaceTransformation >> find: aSelector of: aClass inWholeHierarchy: aBoolean [
 	class := self classObjectFor: aClass.
 	selector := aSelector.
-	replacesAllHierarchy := aBoolean.
+	replacesAllHierarchy := aBoolean
 ]
 
 { #category : #accessing }
-RBFindAndReplaceRefactoring >> findAndReplaceOccurrencesIn: rbMethod [ 
-	self findOccurrencesIn: rbMethod
-]
-
-{ #category : #accessing }
-RBFindAndReplaceRefactoring >> findOccurrencesIn: rbMethod [
+RBFindAndReplaceTransformation >> findOccurrencesIn: rbMethod [
 	|methodNode sourceCode flag |
 	flag := false.
 	methodNode := rbMethod ast.
 	sourceCode := methodNode sourceCode.
 	(self nodesOf: methodNode) do: [ :each |
             each first < each last
-                ifTrue: [ 
+                ifTrue: [
 	self matchNodes do: [ :matchNode | matchNode
                       match: (self patternParserClass parseExpression: (sourceCode copyFrom: each first to: each last ))
                       onSuccess: [ :map |
-	self extract: ((each first to: each last) -> map) 
+	self extract: ((each first to: each last) -> map)
 	of: rbMethod.
 	occurrences := occurrences + 1.
 	flag := true. ]
                       onFailure: [  ] .
 						flag ifTrue: [ self findOccurrencesIn: (rbMethod modelClass methodFor: rbMethod selector).
-							^ self]]]]. 
+							^ self]]]].
 	methodNode body nodesDo: [ :node |
 		self matchNodes do: [ :matchNode | matchNode
                       match: node
                       onSuccess: [ :map |
-	self extract: ((node start to: node stop) -> map) 
+	self extract: ((node start to: node stop) -> map)
 	of: rbMethod.
 	occurrences := occurrences + 1.
 	flag := true.]
                       onFailure: [  ] .
 						flag ifTrue: [ self findOccurrencesIn: (rbMethod modelClass methodFor: rbMethod selector).
-							^ self]]].
+							^ self]]]
 ]
 
 { #category : #initialization }
-RBFindAndReplaceRefactoring >> initialize [ 
+RBFindAndReplaceTransformation >> initialize [
 	super initialize.
-	occurrences := 0.
+	occurrences := 0
 ]
 
 { #category : #accessing }
-RBFindAndReplaceRefactoring >> matchNodes [
+RBFindAndReplaceTransformation >> matchNodes [
 
-	^ matchNodes ifNil: [ 
+	^ matchNodes ifNil: [
 		  | visitor node sourceCode |
 		  visitor := RBMatchVisitor new.
 		  node := self methodNode.
@@ -174,8 +169,8 @@ RBFindAndReplaceRefactoring >> matchNodes [
 		  matchNodes := OrderedCollection new.
 		  matchNodes add:
 			  (self patternParserClass parseExpression: sourceCode).
-		  node lastIsReturn ifTrue: [ 
-			  node hasMultipleReturns ifFalse: [ 
+		  node lastIsReturn ifTrue: [
+			  node hasMultipleReturns ifFalse: [
 				  sourceCode := sourceCode copyReplaceAll: '^' with: ''.
 				  matchNodes add:
 					  (self patternParserClass parseExpression: sourceCode) ] ].
@@ -183,18 +178,18 @@ RBFindAndReplaceRefactoring >> matchNodes [
 ]
 
 { #category : #accessing }
-RBFindAndReplaceRefactoring >> method [
+RBFindAndReplaceTransformation >> method [
 	^ method ifNil: [ method := class methodFor: selector ]
 ]
 
 { #category : #accessing }
-RBFindAndReplaceRefactoring >> methodNode [
+RBFindAndReplaceTransformation >> methodNode [
 
 	^ self method ast copy
 ]
 
 { #category : #accessing }
-RBFindAndReplaceRefactoring >> nodesOf: methodNode [
+RBFindAndReplaceTransformation >> nodesOf: methodNode [
 	|visitor node|
 	visitor := RBCombinatorVisitor new.
 	node := methodNode copy.
@@ -203,12 +198,12 @@ RBFindAndReplaceRefactoring >> nodesOf: methodNode [
 ]
 
 { #category : #accessing }
-RBFindAndReplaceRefactoring >> patternParserClass [
+RBFindAndReplaceTransformation >> patternParserClass [
 	^ RBPatternParser
 ]
 
 { #category : #preconditions }
-RBFindAndReplaceRefactoring >> preconditions [
+RBFindAndReplaceTransformation >> preconditions [
 
 	| condition rbMethod |
 
@@ -216,10 +211,10 @@ RBFindAndReplaceRefactoring >> preconditions [
 	condition := (RBCondition definesSelector: selector in: class)
 	             & (replacesAllHierarchy
 			              ifFalse: [ self emptyCondition ]
-			              ifTrue: [ 
+			              ifTrue: [
 				              class allSubclasses
 					              inject: self emptyCondition
-					              into: [ :cond :aClass | 
+					              into: [ :cond :aClass |
 						              cond
 						              &
 						              (RBCondition definesSelector: selector in: aClass orIsSimilarTo: rbMethod)
@@ -228,7 +223,7 @@ RBFindAndReplaceRefactoring >> preconditions [
 ]
 
 { #category : #accessing }
-RBFindAndReplaceRefactoring >> replaceArgumentsByPattern: sourceCode [ 
+RBFindAndReplaceTransformation >> replaceArgumentsByPattern: sourceCode [
 	|newSource|
 	newSource := sourceCode copyWithRegex: 'tempMatch*' matchesReplacedWith: '`@tempMatch' .
 	newSource := newSource copyWithRegex: 'argMatch*' matchesReplacedWith: '`@argMatch'.
@@ -236,17 +231,17 @@ RBFindAndReplaceRefactoring >> replaceArgumentsByPattern: sourceCode [
 ]
 
 { #category : #preconditions }
-RBFindAndReplaceRefactoring >> selectorsFor: cls [
+RBFindAndReplaceTransformation >> selectorsFor: cls [
 	^ cls selectors copyWithout: selector
 ]
 
 { #category : #accessing }
-RBFindAndReplaceRefactoring >> startLimitOf: sourceCode [
+RBFindAndReplaceTransformation >> startLimitOf: sourceCode [
 	^ self method ast body statements first start
 ]
 
 { #category : #printing }
-RBFindAndReplaceRefactoring >> storeOn: aStream [
+RBFindAndReplaceTransformation >> storeOn: aStream [
 	aStream nextPut: $(.
 	self class storeOn: aStream.
 	aStream nextPutAll: ' find: #';
@@ -255,15 +250,15 @@ RBFindAndReplaceRefactoring >> storeOn: aStream [
 		nextPutAll: class name;
 		nextPutAll: ' inAllHierarchy: '.
 	replacesAllHierarchy storeOn: aStream.
-	aStream nextPut: $).
+	aStream nextPut: $)
 ]
 
-{ #category : #preconditions }
-RBFindAndReplaceRefactoring >> transform [
+{ #category : #transforming }
+RBFindAndReplaceTransformation >> transform [
 	|classes|
 	classes :=replacesAllHierarchy ifFalse: [ { class } ] ifTrue: [ class withAllSubclasses ].
 	classes do: [ :cls | (self selectorsFor: cls) do: [ :sel | |rbMethod|
 		rbMethod := cls methodFor: sel.
-		self findAndReplaceOccurrencesIn: rbMethod] ].
+		self findOccurrencesIn: rbMethod] ].
 	self inform: occurrences asString, ' occurrences were found and changed.'
 ]

--- a/src/Refactoring2-Transformations-Tests/RBFindAndReplaceParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBFindAndReplaceParametrizedTest.class.st
@@ -4,10 +4,10 @@ Class {
 	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
 }
 
-{ #category : #tests }
+{ #category : #'building suites' }
 RBFindAndReplaceParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
-		addCase: { #rbClass -> RBFindAndReplaceRefactoring };
+		addCase: { #rbClass -> RBFindAndReplaceTransformation };
 		yourself
 ]
 

--- a/src/Refactoring2-Transformations-Tests/RBFindAndReplaceSetUpParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBFindAndReplaceSetUpParametrizedTest.class.st
@@ -4,10 +4,10 @@ Class {
 	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
 }
 
-{ #category : #tests }
+{ #category : #'building suites' }
 RBFindAndReplaceSetUpParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
-		addCase: { #rbClass -> RBFindAndReplaceSetUpRefactoring };
+		addCase: { #rbClass -> RBFindAndReplaceSetUpTransformation };
 		yourself
 ]
 

--- a/src/SystemCommands-MessageCommands/SycFindAndReplaceMethodCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycFindAndReplaceMethodCommand.class.st
@@ -21,10 +21,10 @@ SycFindAndReplaceMethodCommand class >> defaultMenuIconName [
 SycFindAndReplaceMethodCommand >> applyResultInContext: aToolContext [
 ]
 
-{ #category : #testing }
+{ #category : #execution }
 SycFindAndReplaceMethodCommand >> createRefactoring [
 
-	^ RBFindAndReplaceRefactoring
+	^ RBFindAndReplaceTransformation
 		model: model
 		find: originalMessage selector
 		of: originalMessage contextUser origin

--- a/src/SystemCommands-MethodCommands/SycFindAndReplaceSetUpCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycFindAndReplaceSetUpCommand.class.st
@@ -13,7 +13,7 @@ Class {
 { #category : #executing }
 SycFindAndReplaceSetUpCommand >> executeRefactoring [
 	| refactoring |
-	refactoring := RBFindAndReplaceSetUpRefactoring 
+	refactoring := RBFindAndReplaceSetUpTransformation
 		model: model
 		of: method origin
 		inWholeHierarchy: self searchInTheWholeHierarchy.

--- a/src/SystemCommands-SourceCodeCommands/SycInlineMethodCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycInlineMethodCommand.class.st
@@ -22,8 +22,8 @@ SycInlineMethodCommand >> asRefactorings [
 		    inline: sourceNode sourceInterval
 		    inMethod: method selector
 		    forClass: method origin)
-		   setOption: #inlineExpression toUse: [ :ref :aString | 
-			   (self confirm: 
+		   setOption: #inlineExpression toUse: [ :ref :aString |
+			   (self confirm:
 					('Do you want to extract the expression ''<1s>'' into a variable in the current method?'
 					 	expandMacrosWith: aString)) not ];
 		   yourself) }


### PR DESCRIPTION
- Rename `RBFindAndReplaceRefactoring` to be Transformation
- tag it with Transformation-Simple (simple transformations that can be reused in complex refactorings)
- removes unnecessary method: ` RBFindAndReplaceRefactoring >> findAndReplaceOccurrencesIn:`