### PR TITLE
Profiler: simplify world menu

### DIFF
--- a/src/ProfilerUI/ProfilerPresenter.class.st
+++ b/src/ProfilerUI/ProfilerPresenter.class.st
@@ -22,10 +22,10 @@ ProfilerPresenter class >> defaultLayout [
 ]
 
 { #category : #examples }
-ProfilerPresenter class >> menuCommandOn: aBuilder [ 
+ProfilerPresenter class >> menuCommandOn: aBuilder [
 	<worldMenu>
-	(aBuilder item: #'Andreas & Time Profiler')
-		parent: #Profiling;  
+	(aBuilder item: #'Profiler')
+		parent: #Profiling;
 		order: 1;
 		icon: (self iconNamed: #smallProfile);
 		help: 'Profile the execution of a piece of code using different profilers, and navigate into the result.';

--- a/src/Tool-Profilers/TimeProfiler.class.st
+++ b/src/Tool-Profilers/TimeProfiler.class.st
@@ -72,17 +72,6 @@ TimeProfiler class >> fullReportMenuOn: aBuilder [
 ]
 
 { #category : #'world menu' }
-TimeProfiler class >> menuCommandOn: aBuilder [ 
-	<worldMenu>
-	(aBuilder item: #'Time Profiler')
-		parent: #Profiling;  
-		order: 1;
-		icon: (aBuilder iconNamed: self taskbarIconName);
-		help: 'Profile the execution of a piece of code and navigate into the result.';
-		action: [TimeProfiler new open]
-]
-
-{ #category : #'world menu' }
 TimeProfiler class >> menuProfilingOn: aBuilder [
 	<worldMenu>
 


### PR DESCRIPTION
This PR removes the old Time Profiler from the world menu.

With just one entry, we can change the name of the Profiler now to be just "Profiler"