### PR TITLE
revert changes from FTTableMorph

### DIFF
--- a/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
@@ -659,6 +659,20 @@ FTTableMorph >> isYellowButtonReallyPressed: anEvent [
 ]
 
 { #category : #'event handling' }
+FTTableMorph >> keyDown: event [
+	self flag: #pharoTodo. "If the function is explicit this should be redirect to the function widget."
+	((super keyDown: event) or: [ self navigationKey: event ])
+		ifTrue: [ ^ true ].
+
+	^ self keyDownSearch: event
+]
+
+{ #category : #'event handling' }
+FTTableMorph >> keyDownSearch: event [
+	^ function keyDown: event
+]
+
+{ #category : #'event handling' }
 FTTableMorph >> keyStroke: event [
 	self flag: #pharoTodo. "If the function is explicit this should be redirect to the function widget."
 	((super keyStroke: event) or: [ self navigationKey: event ])
@@ -704,14 +718,6 @@ FTTableMorph >> keyStrokeArrowUp: event [
 { #category : #'event handling' }
 FTTableMorph >> keyStrokeSearch: event [
 	^ function keyStroke: event
-]
-
-{ #category : #'event handling' }
-FTTableMorph >> keyUp: event [
-	self flag: #pharoTodo. "If the function is explicit this should be redirect to the function widget."
-	((super keyUp: event) or: [ self navigationKey: event ])
-		ifTrue: [ ^ true ].
-	^ self keyUpSearch: event
 ]
 
 { #category : #'event handling' }


### PR DESCRIPTION
This pull request will revert changes of:
By removing `keyUp:` and reintroducing `keyDown:`
- https://github.com/pharo-project/pharo/pull/12439

You have to reopen this issue:
- https://github.com/pharo-project/pharo/issues/12434