### PR TITLE
11142-TestRunner--classNamesNotUnderTest-is-sent-but-not-implemented 

### DIFF
--- a/src/SUnit-UI/TestRunner.class.st
+++ b/src/SUnit-UI/TestRunner.class.st
@@ -469,16 +469,18 @@ TestRunner >> errorTestSuites [
 
 { #category : #actions }
 TestRunner >> excludeClassesNotUnderTestFrom: methods [
+	"this is used by the code coverage tool to allow to exclude classes"
+	<ignoreNotImplementedSelectors: #(classNamesNotUnderTest)>
 	classesSelected
-		do: [ :class | 
+		do: [ :class |
 			(class class includesSelector: #classNamesNotUnderTest)
-				ifTrue: [ 
+				ifTrue: [
 					class classNamesNotUnderTest
-						do: [ :className | 
+						do: [ :className |
 							| theClass |
 							theClass := Smalltalk globals classNamed: className.
 							theClass
-								ifNotNil: [ 
+								ifNotNil: [
 									theClass methods do: [ :each | methods remove: each  ifAbsent: [  ] ].
 									theClass class methods do: [ :each | methods remove: each  ifAbsent: [  ] ] ] ] ] ]
 ]


### PR DESCRIPTION
tag excludeClassesNotUnderTestFrom: to make it explicit that we know that the unsent selector is not a problem