### PR TITLE
skip the test testNewProcessTaskRunnerRunsInNewProcessEveryTime on the CI

### DIFF
--- a/src/TaskIt-Tests/TKTNewProcessTaskRunnerTest.class.st
+++ b/src/TaskIt-Tests/TKTNewProcessTaskRunnerTest.class.st
@@ -21,8 +21,11 @@ TKTNewProcessTaskRunnerTest >> testNewProcessTaskRunnerExceptionIsHandledByExcep
 
 { #category : #tests }
 TKTNewProcessTaskRunnerTest >> testNewProcessTaskRunnerRunsInNewProcessEveryTime [
-
+	
 	| runner hashes futures hashesSet |
+	self skipOnPharoCITestingEnvironment.
+	"this fails randomly on the CI"
+	
 	runner := TKTNewProcessTaskRunner new.
 	hashes := AtomicSharedQueue new.
 	


### PR DESCRIPTION
skip the test skipOnPharoCITestingEnvironment on the CI, it fails radomly.