### PR TITLE
Add <ignoreForCoverage> to methods generated by the manifest builder

### DIFF
--- a/src/Manifest-Core/TheManifestBuilder.class.st
+++ b/src/Manifest-Core/TheManifestBuilder.class.st
@@ -281,17 +281,20 @@ TheManifestBuilder >> compileSelector: selector returnValue: aLiteral [
 
 { #category : #private }
 TheManifestBuilder >> compileSelector: selector returnValue: aLiteral classified: aProtocolName [
+
 	| source |
 	source := String streamContents: [ :stream |
-		stream
-			nextPutAll: selector asString;
-			nextPut: Character cr;
-			nextPut: Character tab;
-			nextPutAll: '^ ';
-			nextPutAll: aLiteral ].
-	manifestClass class
-		compile: source
-		classified: aProtocolName
+		          stream
+			          nextPut: Character cr;
+			          nextPut: Character cr;
+			          nextPut: Character tab;
+			          nextPutAll: '<ignoreForCoverage>';
+			          nextPutAll: selector asString;
+			          nextPut: Character cr;
+			          nextPut: Character tab;
+			          nextPutAll: '^ ';
+			          nextPutAll: aLiteral ].
+	manifestClass class compile: source classified: aProtocolName
 ]
 
 { #category : #manifest }

--- a/src/Manifest-Core/TheManifestBuilder.class.st
+++ b/src/Manifest-Core/TheManifestBuilder.class.st
@@ -285,11 +285,11 @@ TheManifestBuilder >> compileSelector: selector returnValue: aLiteral classified
 	| source |
 	source := String streamContents: [ :stream |
 		          stream
+			          nextPutAll: selector asString;
 			          nextPut: Character cr;
 			          nextPut: Character cr;
 			          nextPut: Character tab;
 			          nextPutAll: '<ignoreForCoverage>';
-			          nextPutAll: selector asString;
 			          nextPut: Character cr;
 			          nextPut: Character tab;
 			          nextPutAll: '^ ';


### PR DESCRIPTION
The generated methods are meta data and most project will ignore them. Iâ¯propose to simply generate them with the pragma by default