### PR TITLE
12418-MCMethodDefinition-asSymbol-error-when-catString-isNil-loading-BaselineOf 

### DIFF
--- a/src/Monticello/MCMethodDefinition.class.st
+++ b/src/Monticello/MCMethodDefinition.class.st
@@ -203,11 +203,12 @@ timeStamp: timeString
 source: sourceString [
 	className := classString asSymbol.
 	selector := selectorString asSymbol.
-	category := (catString asSymbol) ifEmpty: [#'as yet unclassified'].
+	category := catString
+		ifNil: [ #'as yet unclassified']
+		ifNotNil: [ (catString asSymbol) ifEmpty: [#'as yet unclassified']].
 	timeStamp := timeString.
 	classIsMeta := metaBoolean.
-	source := sourceString withInternalLineEndings.
-
+	source := sourceString withInternalLineEndings
 ]
 
 { #category : #testing }


### PR DESCRIPTION
guard category for nil, fixes #12418