### PR TITLE
Do not resolve absolute paths to open a file

### DIFF
--- a/src/FileSystem-Core/FileSystem.class.st
+++ b/src/FileSystem-Core/FileSystem.class.st
@@ -668,10 +668,10 @@ FileSystem >> open: aResolvable writable: aBoolean [
 	that path using the specified access mode."
 
 	| path |
-	path := self resolve: aResolvable.
-	^ store handleClass
-		open: (FileReference fileSystem: self path: path)
-		writable: aBoolean
+	path := aResolvable isAbsolute
+		        ifTrue: [ aResolvable ]
+		        ifFalse: [ self resolve: aResolvable ].
+	^ store handleClass open: (FileReference fileSystem: self path: path) writable: aBoolean
 ]
 
 { #category : #private }


### PR DESCRIPTION
Currently to open a file we always resolve the path relatively to the… working directory

This commit changes that to resolve only in case the path is not absolute. In case of absolute path we can just use the path as it is. This could help use resolve https://github.com/pharo-project/pharo-launcher/issues/590