### PR TITLE
Compiler: enable optionInlineTimesRepeat and optionInlineRepeat by default

### DIFF
--- a/src/Kernel-Tests/CompiledBlockTest.class.st
+++ b/src/Kernel-Tests/CompiledBlockTest.class.st
@@ -13,9 +13,9 @@ CompiledBlockTest >> testLiteralEqual [
 
 	| value |
 	value := 0.
-	10 timesRepeat: [self assert: value equals: 0].
+	(1 to: 10) do: [self assert: value equals: 0].
 	value := 1.
-	10 timesRepeat: [self assert: value equals: 0].'.
+	(1 to: 10) do: [self assert: value equals: 0].'.
 
 	compiledBlocks := methodToTest literals select: [ :each | each isCompiledBlock ].
 	self assert: compiledBlocks size equals: 2.
@@ -30,9 +30,9 @@ CompiledBlockTest >> testPcInOuter [
 
 	| value |
 	value := 0.
-	10 timesRepeat: [self assert: value equals: 0].
+	(1 to: 10) do: [self assert: value equals: 0].
 	value := 1.
-	10 timesRepeat: [self assert: value equals: 0].'.
+	(1 to: 10) do: [self assert: value equals: 0].'.
 
 	compiledBlocks := methodToTest literals select: [ :each | each isCompiledBlock ].
 	self assert: compiledBlocks size equals: 2.

--- a/src/Kernel-Tests/CompiledBlockTest.class.st
+++ b/src/Kernel-Tests/CompiledBlockTest.class.st
@@ -13,6 +13,7 @@ CompiledBlockTest >> testLiteralEqual [
 
 	| value |
 	value := 0.
+	"Do not use #to:do: because it is optimized and will prevent us of testing the behavior we want."
 	(1 to: 10) do: [self assert: value equals: 0].
 	value := 1.
 	(1 to: 10) do: [self assert: value equals: 0].'.

--- a/src/Kernel-Tests/CompiledBlockTest.class.st
+++ b/src/Kernel-Tests/CompiledBlockTest.class.st
@@ -31,6 +31,7 @@ CompiledBlockTest >> testPcInOuter [
 
 	| value |
 	value := 0.
+	"Do not use #to:do: because it is optimized and will prevent us of testing the behavior we want."
 	(1 to: 10) do: [self assert: value equals: 0].
 	value := 1.
 	(1 to: 10) do: [self assert: value equals: 0].'.

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -304,8 +304,8 @@ CompilationContext class >> optionsDescription [
 	(+ optionInlineWhile 				'Inline whileTrue, whileTrue:, whileFalse:, whileFalse if specific conditions are met (See isInlineWhile)')
 	(+ optionInlineToDo 				'Inline to:do:, to:by:do: if specific conditions are met (See isInlineToDo)')
 	(+ optionInlineCase 				'Inline caseOf:, caseOf:otherwise: if specific conditions are met (See isInlineCase)')
-	(- optionInlineTimesRepeat 		'Inline timesRepeat: if specific conditions are met (See isInlineTimesRepeat)')
-	(- optionInlineRepeat 			'Inline repeat if specific conditions are met (See isInlineRepeat)')
+	(+ optionInlineTimesRepeat 		'Inline timesRepeat: if specific conditions are met (See isInlineTimesRepeat)')
+	(+ optionInlineRepeat 			'Inline repeat if specific conditions are met (See isInlineRepeat)')
 	(- optionInlineNone 				'To turn off all inlining options. Overrides the others')
 
 	(- optionEmbeddSources         'Embedd sources into CompiledMethod instead of storing in .changes')


### PR DESCRIPTION
enable the following by default:

	(+ optionInlineTimesRepeat 		'Inline timesRepeat: if specific conditions are met (See isInlineTimesRepeat)')
	(+ optionInlineRepeat 			'Inline repeat if specific conditions are met (See isInlineRepeat)')
				
fixes #11169