### PR TITLE
Update matchesTypes to fix DNU in matchesTypes

### DIFF
--- a/src/Morphic-Core/ExternalDropHandler.class.st
+++ b/src/Morphic-Core/ExternalDropHandler.class.st
@@ -135,7 +135,7 @@ ExternalDropHandler >> matchesExtension: aExtension [
 ExternalDropHandler >> matchesTypes: types [
 	(self type isNil or: [types isNil])
 		ifTrue: [^false].
-	^types anySatisfy: [:mimeType | mimeType beginsWith: self type]
+	^types anySatisfy: [:mimeType | mimeType main beginsWith: self type]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Fixes: #12610 

ZnMimeType has accessors which are not used in the `matchesTypes:` method. This fixes it, but it is untested if it has repercussions.