### PR TITLE
Unnecessary characters rule should be an information and not a warning

### DIFF
--- a/src/Renraku/ReCompactSourceCodeRule.class.st
+++ b/src/Renraku/ReCompactSourceCodeRule.class.st
@@ -83,3 +83,9 @@ ReCompactSourceCodeRule >> providesChange [
 
 	^ true
 ]
+
+{ #category : #accessing }
+ReCompactSourceCodeRule >> severity [
+
+	^ #information
+]


### PR DESCRIPTION
Fix #12614