### PR TITLE
FIx #wantsSteps deprecated calls

### DIFF
--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -1956,7 +1956,13 @@ SystemWindow >> wantsHalo [
 SystemWindow >> wantsSteps [
 	"Return true if the model wants its view to be stepped.  For an open system window, we give the model to offer an opinion"
 
-	^ isCollapsed not and: [ model isNotNil and: [ model wantsSteps ] ]
+	isCollapsed ifTrue: [ ^ false ].
+
+	model ifNil: [ ^ false ].
+
+	model isCollection ifTrue: [ ^ false ].
+
+	^ model wantsSteps
 ]
 
 { #category : #stepping }


### PR DESCRIPTION
The deprecated calls seems to happen when the model of a window is a collection and not an actual model

Fixes #12595