### PR TITLE
Add #closeTo: on sequenceable collection

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -140,7 +140,8 @@ BaselineOfIDE >> baseline: spec [
 				repository: repository;
 				loads: #( 'tests' ) ].
 				
-				
+
+		spec package: 'Math-Operations-Extensions-Tests'.
 		spec package: 'Network-Tests'.
 		spec package: 'Network-Mail-Tests'.
 		spec package: 'Gofer-Tests'.

--- a/src/Math-Operations-Extensions-Tests/MathOperationsExtensionsTest.class.st
+++ b/src/Math-Operations-Extensions-Tests/MathOperationsExtensionsTest.class.st
@@ -1,0 +1,24 @@
+Class {
+	#name : #MathOperationsExtensionsTest,
+	#superclass : #TestCase,
+	#category : #'Math-Operations-Extensions-Tests'
+}
+
+{ #category : #tests }
+MathOperationsExtensionsTest >> testCloseToPrecisionSequenceableCollections [
+
+	self assert: (#( 1.9283 2.3029 ) closeTo: #( 1.9284 2.3028 ) precision: 0.001).
+
+
+	self deny: (#( 1.9283 2.3029 ) closeTo: #( 1.9284 2.3028 ) precision: 0.00001)
+]
+
+{ #category : #tests }
+MathOperationsExtensionsTest >> testCloseToSequenceableCollections [
+
+	self assert: (#( 1.9283901234902349 2.302949083493849 ) closeTo: #( 1.9283901234902348 2.302949083493899 )).
+
+	self deny: (#( 1.9283901234902349 2.302949083493849 3 ) closeTo: #( 1.9283901234902348 3 2.302949083493899 )).
+
+	self deny: (#( 1.9283901234902349 2.302949083493849 ) closeTo: #( 1.8283901234902348 2.302949083493899 ))
+]

--- a/src/Math-Operations-Extensions-Tests/package.st
+++ b/src/Math-Operations-Extensions-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Math-Operations-Extensions-Tests' }

--- a/src/Math-Operations-Extensions/SequenceableCollection.extension.st
+++ b/src/Math-Operations-Extensions/SequenceableCollection.extension.st
@@ -1,0 +1,21 @@
+Extension { #name : #SequenceableCollection }
+
+{ #category : #'*Math-Operations-Extensions' }
+SequenceableCollection >> closeTo: aSequenceableCollection [
+	"Return true if all my elements are close to the elements of same index of the parameter"
+
+	"#(1.9283901234902349 2.302949083493849) closeTo: #(1.9283901234902348 2.302949083493899) >>> true"
+
+	self with: aSequenceableCollection do: [ :a :b | (a closeTo: b) ifFalse: [ ^ false ] ].
+	^ true
+]
+
+{ #category : #'*Math-Operations-Extensions' }
+SequenceableCollection >> closeTo: aSequenceableCollection precision: aPrecision [
+	"Return true if all my elements are close to the elements of same index of the parameter with a certain precision"
+
+	"#(1.9283 2.3029) closeTo: #(1.9284 2.3028) precision: 0.001 >>> true"
+
+	self with: aSequenceableCollection do: [ :a :b | (a closeTo: b) ifFalse: [ ^ false ] ].
+	^ true
+]

--- a/src/Math-Operations-Extensions/SequenceableCollection.extension.st
+++ b/src/Math-Operations-Extensions/SequenceableCollection.extension.st
@@ -16,6 +16,6 @@ SequenceableCollection >> closeTo: aSequenceableCollection precision: aPrecision
 
 	"#(1.9283 2.3029) closeTo: #(1.9284 2.3028) precision: 0.001 >>> true"
 
-	self with: aSequenceableCollection do: [ :a :b | (a closeTo: b) ifFalse: [ ^ false ] ].
+	self with: aSequenceableCollection do: [ :a :b | (a closeTo: b precision: aPrecision) ifFalse: [ ^ false ] ].
 	^ true
 ]

--- a/src/Math-Operations-Extensions/SequenceableCollection.extension.st
+++ b/src/Math-Operations-Extensions/SequenceableCollection.extension.st
@@ -4,7 +4,7 @@ Extension { #name : #SequenceableCollection }
 SequenceableCollection >> closeTo: aSequenceableCollection [
 	"Return true if all my elements are close to the elements of same index of the parameter"
 
-	"#(1.9283901234902349 2.302949083493849) closeTo: #(1.9283901234902348 2.302949083493899) >>> true"
+	"(#(1.9283901234902349 2.302949083493849) closeTo: #(1.9283901234902348 2.302949083493899)) >>> true"
 
 	^ self closeTo: aSequenceableCollection precision: Float defaultComparisonPrecision
 ]
@@ -13,7 +13,7 @@ SequenceableCollection >> closeTo: aSequenceableCollection [
 SequenceableCollection >> closeTo: aSequenceableCollection precision: aPrecision [
 	"Return true if all my elements are close to the elements of same index of the parameter with a certain precision"
 
-	"#(1.9283 2.3029) closeTo: #(1.9284 2.3028) precision: 0.001 >>> true"
+	"(#(1.9283 2.3029) closeTo: #(1.9284 2.3028) precision: 0.001) >>> true"
 
 	self with: aSequenceableCollection do: [ :a :b | (a closeTo: b precision: aPrecision) ifFalse: [ ^ false ] ].
 	^ true

--- a/src/Math-Operations-Extensions/SequenceableCollection.extension.st
+++ b/src/Math-Operations-Extensions/SequenceableCollection.extension.st
@@ -6,8 +6,7 @@ SequenceableCollection >> closeTo: aSequenceableCollection [
 
 	"#(1.9283901234902349 2.302949083493849) closeTo: #(1.9283901234902348 2.302949083493899) >>> true"
 
-	self with: aSequenceableCollection do: [ :a :b | (a closeTo: b) ifFalse: [ ^ false ] ].
-	^ true
+	^ self closeTo: aSequenceableCollection precision: Float defaultComparisonPrecision
 ]
 
 { #category : #'*Math-Operations-Extensions' }


### PR DESCRIPTION
This is originally part of PolyMath in Core package but we are trying to remove this package and the closest package this methods could go to is Math-Operations-Extensions. Thus we are proposing this to Pharo.