### PR TITLE
Fail doc comment release test if a comment test has a syntax error.

### DIFF
--- a/src/PharoDocComment/CommentTestCase.class.st
+++ b/src/PharoDocComment/CommentTestCase.class.st
@@ -62,7 +62,9 @@ CommentTestCase >> printString [
 CommentTestCase >> testIt [
 
 	| value |
-	value := self evaluate.
+	value := [ self evaluate ]
+		         on: RuntimeSyntaxError
+		         do: [ self fail: 'Invalid documentation comment test.' ].
 	self assert: value isAssociation.
 	self assert: value key equals: value value
 ]


### PR DESCRIPTION
Currently the CIâ¯will juste break if that happens and the feedback is really really poor