### PR TITLE
Improve faulty parsing of assigments

### DIFF
--- a/src/AST-Core-Tests/RBErrorNodeParserTest.class.st
+++ b/src/AST-Core-Tests/RBErrorNodeParserTest.class.st
@@ -5,6 +5,35 @@ Class {
 }
 
 { #category : #tests }
+RBErrorNodeParserTest >> testFaultyAssigment [
+
+	| node |
+	node := self parserClass parseFaultyExpression: ':=1'.
+
+	self assert: node isFaulty.
+	self assert: node isParseError.
+	self   deny: node content first isFaulty.
+	self assert: node content first value equals: 1.
+	self assert: node sourceInterval equals: (1 to: 3).
+	self assert: node errorMessage equals: 'identifier expected in assigment'.
+	self assert: node formattedCode equals: ':= 1'
+]
+
+{ #category : #tests }
+RBErrorNodeParserTest >> testFaultyAssigment2 [
+
+	| node |
+	node := self parserClass parseFaultyExpression: 'a:='.
+
+	self assert: node isFaulty.
+	self assert: node value isParseError.
+	self assert: node value sourceInterval equals: (4 to: 3).
+	self assert: node value errorMessage equals: 'Variable or expression expected'.
+	self assert: node value formattedCode equals: ''.
+	self assert: node formattedCode equals: 'a := '
+]
+
+{ #category : #tests }
 RBErrorNodeParserTest >> testFaultyBinaryMessageSendArgument [
 
 	| node |

--- a/src/AST-Core-Tests/RBFormatterTest.class.st
+++ b/src/AST-Core-Tests/RBFormatterTest.class.st
@@ -143,9 +143,9 @@ RBFormatterTest >> testParseError [
 		"Bad assignments"
 		"FIXME, `:=` without variable is badly parsed."
 		'a := '.
-		':='.
-		':=2' -> ' :=.<r>2'.
-		'1:=2' -> ' 1.<r> :=.<r>2'.
+		':= '.
+		':= 2'.
+		'1:=2' -> ' 1.<r>:= 2'.
 
 		"Bad cascades"
 		"FIXME: the formater is currently broken on some cases (message send to nil)"

--- a/src/AST-Core-Tests/RBFormatterTest.class.st
+++ b/src/AST-Core-Tests/RBFormatterTest.class.st
@@ -141,11 +141,12 @@ RBFormatterTest >> testParseError [
 		' goodby: 2 my: 3'.
 
 		"Bad assignments"
-		"FIXME, `:=` without variable is badly parsed."
 		'a := '.
 		':= '.
 		':= 2'.
 		'1:=2' -> ' 1.<r>:= 2'.
+		'1 foo := 2' -> ' 1 foo.<r>:= 2'.
+		'(1:=2)' -> ' ( 1.<r> := 2)'.
 
 		"Bad cascades"
 		"FIXME: the formater is currently broken on some cases (message send to nil)"

--- a/src/AST-Core/RBAssignmentErrorNode.class.st
+++ b/src/AST-Core/RBAssignmentErrorNode.class.st
@@ -1,0 +1,12 @@
+"
+This is a particular englobing node that is an assigment.
+Exemple : `indentifier := expression`
+Can be created by forgetting the identifier `:= expression`.
+
+If the identifier is present but the expression is missing, a valid RBAssignmentNode is created but with a error node for its value.
+"
+Class {
+	#name : #RBAssignmentErrorNode,
+	#superclass : #RBEnglobingErrorNode,
+	#category : #'AST-Core-Nodes - ErrorNodes'
+}

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -322,8 +322,19 @@ RBParser >> parseAssignment [
 	make it possible to assign the literals true, false and nil."
 
 	| node position |
+	currentToken isAssignment ifTrue: [
+		self parserError: 'identifier expected in assigment'.
+		position := currentToken start.
+		self step. "Consume the :="
+		node := self parseAssignment. "parse the right side".
+		node := RBAssignmentErrorNode content: { node } start: position stop: node stop errorMessage: 'identifier expected in assigment'.
+		node value: ':='.
+		^ node
+	].
+
 	(currentToken isIdentifier and: [self nextToken isAssignment])
 		ifFalse: [^self parseCascadeMessage].
+
 	node := self parseVariableNode.
 	position := currentToken start.
 	self step.

--- a/src/EnlumineurFormatter-Tests/EFParseErrorExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFParseErrorExpressionTest.class.st
@@ -33,5 +33,5 @@ EFParseErrorExpressionTest >> testParseError2 [
 	configurationSelector := #basicConfiguration.
 	source := self formatter format: expr.
 	self assert: source equals:
-' 1. :='
+' 1. := '
 ]

--- a/src/Kernel-ExtraUtils/ClassHierarchyPrinterTest.class.st
+++ b/src/Kernel-ExtraUtils/ClassHierarchyPrinterTest.class.st
@@ -60,6 +60,7 @@ ClassHierarchyPrinterTest >> testOnlyRBASTNodes [
 			RBParseErrorNode
 				RBEnglobingErrorNode
 					RBArrayErrorNode
+					RBAssignmentErrorNode
 					RBBlockErrorNode
 					RBInvalidCascadeErrorNode
 					RBLiteralArrayErrorNode


### PR DESCRIPTION
Add a specific handling on the parser when a lone `:=` is found. It produces instances of a new specific class RBAssignmentErrorNode.

Bad left values, like in `a foo := 5` are likely to be consumed as unfinished statements (like `a foo.`), then the `:=` that follows (and the right value) consumed as distinct statements of assignment errors (like `:= 5`). Thus, producing an acceptable faulty AST.

A possible alternative faulty AST could be to include the unfinished left value as a child of the RBAssignmentErrorNode.
But this requires to hack the parser more (for not that much additional value)