### PR TITLE
Improve faulty parsing of cascades

### DIFF
--- a/src/AST-Core-Tests/RBErrorNodeParserTest.class.st
+++ b/src/AST-Core-Tests/RBErrorNodeParserTest.class.st
@@ -141,6 +141,202 @@ RBErrorNodeParserTest >> testFaultyCascade [
 ]
 
 { #category : #tests }
+RBErrorNodeParserTest >> testFaultyCascadeCascadeMessageExpected [
+
+	| node |
+	node := self parserClass parseFaultyExpression: '1 foo;'.
+
+	self assert: node isFaulty.
+	self assert: node isCascade.
+
+	self deny: node messages first isFaulty.
+	self assert: node messages first selector equals: #foo.
+
+	self assert: node messages second isParseError.
+	self assert: node messages second sourceInterval equals: (7 to: 6).
+	self
+		assert: node messages second errorMessage
+		equals: 'Cascade message expected'.
+	self assert: node messages second formattedCode equals: ''.
+
+	self
+		assert: node formattedCode
+		equals: '1<r><t>foo;<r><t>' expandMacros
+]
+
+{ #category : #tests }
+RBErrorNodeParserTest >> testFaultyCascadeCascadeMessageExpected2 [
+
+	| node |
+	node := self parserClass parseFaultyExpression: '1 foo;;bar'.
+
+	self assert: node isFaulty.
+	self assert: node isCascade.
+
+	self deny: node messages first isFaulty.
+	self assert: node messages first selector equals: #foo.
+
+	self assert: node messages second isParseError.
+	self assert: node messages second sourceInterval equals: (7 to: 6).
+	self
+		assert: node messages second errorMessage
+		equals: 'Cascade message expected'.
+	self assert: node messages second formattedCode equals: ''.
+
+	self deny: node messages third isFaulty.
+	self assert: node messages third selector equals: #bar.
+
+	self
+		assert: node formattedCode
+		equals: '1<r><t>foo;<r><t>;<r><t>bar' expandMacros
+]
+
+{ #category : #tests }
+RBErrorNodeParserTest >> testFaultyCascadeCascadeMessageExpected3 [
+
+	| node |
+	node := self parserClass parseFaultyExpression: '1 foo;;'.
+
+	self assert: node isFaulty.
+	self assert: node isCascade.
+
+	self deny: node messages first isFaulty.
+	self assert: node messages first selector equals: #foo.
+
+	self assert: node messages second isParseError.
+	self assert: node messages second sourceInterval equals: (7 to: 6).
+	self
+		assert: node messages second errorMessage
+		equals: 'Cascade message expected'.
+	self assert: node messages second formattedCode equals: ''.
+
+	self assert: node messages third isParseError.
+	self assert: node messages third sourceInterval equals: (8 to: 7).
+	self
+		assert: node messages third errorMessage
+		equals: 'Cascade message expected'.
+	self assert: node messages third formattedCode equals: ''.
+
+	self
+		assert: node formattedCode
+		equals: '1<r><t>foo;<r><t>;<r><t>' expandMacros
+]
+
+{ #category : #tests }
+RBErrorNodeParserTest >> testFaultyCascadeMessageExpected [
+
+	| node |
+	node := self parserClass parseFaultyExpression: ';foo'.
+
+	self assert: node isFaulty.
+	self assert: node isCascade.
+
+	self assert: node messages first isCascadeError.
+	self assert: node messages first sourceInterval equals: (1 to: 1).
+	self
+		assert: node messages first errorMessage
+		equals: 'Message expected'.
+	self assert: node messages first formattedCode equals: ' '.
+
+	self assert: node messages second isFaulty. "Faulty because there is no receiver!"
+	self assert: node messages second selector equals: #foo.
+	self assert: node messages second receiver isParseError.
+
+	self
+		assert: node formattedCode
+		equals: '<r><t>;<r><t>foo' expandMacros
+]
+
+{ #category : #tests }
+RBErrorNodeParserTest >> testFaultyCascadeMessageExpected2 [
+
+	| node |
+	node := self parserClass parseFaultyExpression: ';;foo'.
+
+	self assert: node isFaulty.
+	self assert: node isCascade.
+
+	self assert: node messages first isCascadeError.
+	self assert: node messages first sourceInterval equals: (1 to: 1).
+	self
+		assert: node messages first errorMessage
+		equals: 'Message expected'.
+	self assert: node messages first formattedCode equals: ' '.
+
+	self assert: node messages second isParseError.
+	self assert: node messages second sourceInterval equals: (2 to: 1).
+	self
+		assert: node messages second errorMessage
+		equals: 'Cascade message expected'.
+	self assert: node messages second formattedCode equals: ''.
+
+	self assert: node messages third isFaulty. "Faulty because there is no receiver!"
+	self assert: node messages third selector equals: #foo.
+	self assert: node messages third receiver isParseError.
+
+	self
+		assert: node formattedCode
+		equals: '<r><t>;<r><t>;<r><t>foo' expandMacros
+]
+
+{ #category : #tests }
+RBErrorNodeParserTest >> testFaultyCascadeMessageExpected3 [
+
+	| node |
+	node := self parserClass parseFaultyExpression: '(1 foo); bar'.
+
+	self assert: node isFaulty.
+	self assert: node isCascade.
+
+	self assert: node messages first isCascadeError.
+	self assert: node messages first sourceInterval equals: (1 to: 8).
+	self
+		assert: node messages first errorMessage
+		equals: 'Message expected'.
+	self assert: node messages first formattedCode equals: ' 1 foo'.
+
+	self deny: node messages first receiver isFaulty.
+	self assert: node messages first receiver isMessage.
+	self assert: node messages first receiver selector equals: #foo.
+
+	self deny: node messages second isFaulty.
+	self assert: node messages second isMessage.
+	self assert: node messages second selector equals: #bar.
+
+	self
+		assert: node formattedCode
+		equals: '1 foo<r><t>;<r><t>bar' expandMacros
+]
+
+{ #category : #tests }
+RBErrorNodeParserTest >> testFaultyCascadeMessageExpected4 [
+
+	| node |
+	node := self parserClass parseFaultyExpression: '1; bar'.
+
+	self assert: node isFaulty.
+	self assert: node isCascade.
+
+	self assert: node messages first isCascadeError.
+	self assert: node messages first sourceInterval equals: (1 to: 2).
+	self
+		assert: node messages first errorMessage
+		equals: 'Message expected'.
+	self assert: node messages first formattedCode equals: ' 1'.
+
+	self deny: node messages first receiver isFaulty.
+	self assert: node messages first receiver value equals: 1.
+
+	self deny: node messages second isFaulty.
+	self assert: node messages second isMessage.
+	self assert: node messages second selector equals: #bar.
+
+	self
+		assert: node formattedCode
+		equals: '1<r><t>;<r><t>bar' expandMacros
+]
+
+{ #category : #tests }
 RBErrorNodeParserTest >> testFaultyMessageSendShouldHaveTheCorrectMessage [
 
 	| node |

--- a/src/AST-Core-Tests/RBFormatterTest.class.st
+++ b/src/AST-Core-Tests/RBFormatterTest.class.st
@@ -148,12 +148,17 @@ RBFormatterTest >> testParseError [
 		'1:=2' -> ' 1.<r> :=.<r>2'.
 
 		"Bad cascades"
-		"FIXME: the formater is currently broken on some cases (message send to nil)"
-		"';'"
-		"'1;'."
+		';' -> '<r><t>;<r><t>'.
+		'1;foo' -> '1<r><t>;<r><t>foo'.
+		'1;' -> '1<r><t>;<r><t>'.
 		'1 foo;' -> '1<r><t>foo;<r><t>'.
-		'1 foo;2' -> '1<r><t>foo;<r><t>'. "FIXME"
-		"';;'."
+		'1 foo:;bar' -> '1<r><t>foo: ;<r><t>bar'. "The cascade is correct here. It's a simple error of a missing argument"
+		'1 foo;2' -> '1<r><t>foo;<r><t>'. "FIXME. 2 is eaten"
+		'(1 foo: 2);bar' -> '(1 foo: 2)<r><t>;<r><t>bar'.
+		'(1 foo);bar' -> '1 foo<r><t>;<r><t>bar'. "BUT the parentheses are lost, but is changes the meaning"
+		"Longer cascade"
+		';;' -> '<r><t>;<r><t>;<r><t>'.
+		'1 foo;;bar' -> '1<r><t>foo;<r><t>;<r><t>bar'.
 
 		"Bad returns"
 		'^ '.

--- a/src/AST-Core-Tests/RBFormatterTest.class.st
+++ b/src/AST-Core-Tests/RBFormatterTest.class.st
@@ -153,7 +153,7 @@ RBFormatterTest >> testParseError [
 		'1;' -> '1<r><t>;<r><t>'.
 		'1 foo;' -> '1<r><t>foo;<r><t>'.
 		'1 foo:;bar' -> '1<r><t>foo: ;<r><t>bar'. "The cascade is correct here. It's a simple error of a missing argument"
-		'1 foo;2' -> '1<r><t>foo;<r><t>'. "FIXME. 2 is eaten"
+		'1 foo;2' -> ' 1<r><t>foo;<r><t>.<r>2'.
 		'(1 foo: 2);bar' -> '(1 foo: 2)<r><t>;<r><t>bar'.
 		'(1 foo);bar' -> '1 foo<r><t>;<r><t>bar'. "BUT the parentheses are lost, but is changes the meaning"
 		"Longer cascade"

--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -263,12 +263,19 @@ RBParserTest >> testCascadeReplacementCanLeadToOddErrors [
 
 { #category : #'error testing' }
 RBParserTest >> testCascadeWithInvalidSelectorRaisesError [
-	| tree |
-	tree := self parseFaultyExpression: 'faulty cascade; repared ; 1; node'.
-	self assert: tree isCascade.
-	self assert: tree messages size equals: 4.
+	| tree0 tree |
+	tree0 := self parseFaultyExpression: 'faulty cascade; repared ; 1; node'.
+	self assert: tree0 isSequence.
 
-	"The presence of an error in a cascade (when parsingFaulty) parses the cascade until the end and stores the error node inside 	 the cascade."
+	tree := tree0 statements first.
+	self assert: tree isUnfinishedStatement.
+
+	tree := tree statement.
+	self assert: tree isCascade.
+	self assert: tree messages size equals: 3.
+
+	"The presence of an error in a cascade (when parsingFaulty) aborts the cascade and start a new statement.
+	The error node is stored inside the cascade."
 	self assert: tree messages first isMessage.
 	self assert: tree messages first receiver name equals: #faulty.
 	self assert: tree messages first selectorNode equals: (RBSelectorNode value: #cascade).
@@ -277,11 +284,21 @@ RBParserTest >> testCascadeWithInvalidSelectorRaisesError [
 	self assert: tree messages second receiver name equals: #faulty.
 	self assert: tree messages second selectorNode equals: (RBSelectorNode value: #repared).
 
-	self assert: tree messages third isFaulty.
+	self assert: tree messages third isParseError.
 	self assert: tree messages third errorMessage equals: 'Cascade message expected'.
 
+	"Its possible that what follows the cascade is also a cascade, but with a faulty first message.
+	The error is also stored inside the cascade."
+
+	tree := tree0 statements second.
+	self assert: tree isCascade.
+	self assert: tree messages size equals: 2.
+
+	self assert: tree messages first isParseError.
+	self assert: tree messages first errorMessage equals: 'Message expected'.
+
 	self assert: tree messages last isMessage.
-	self assert: tree messages last receiver name equals: #faulty.
+	self assert: tree messages last receiver value equals: 1.
 	self assert: tree messages last selectorNode equals: (RBSelectorNode value: #node)
 ]
 

--- a/src/AST-Core/RBInvalidCascadeErrorNode.class.st
+++ b/src/AST-Core/RBInvalidCascadeErrorNode.class.st
@@ -1,11 +1,26 @@
+"
+This is the particular englobing node when the first message of a cascade node is faulty.
+
+E.g. `5;foo` or `(5 foo);bar` where there is a value node (a possible receiver) but no message.
+The only content of the error node is this possible receiver.
+
+It is also used if the first message is empty: not even a receiver, e.g. `;foo`.
+In this case the content (the receiver) is an error node (expected value).
+
+Beware that instances of this class can be the first element of ""messages"" on a faulty RBCascadeNode object.
+"
 Class {
 	#name : #RBInvalidCascadeErrorNode,
 	#superclass : #RBEnglobingErrorNode,
 	#category : #'AST-Core-Nodes - ErrorNodes'
 }
 
-{ #category : #accessing }
-RBInvalidCascadeErrorNode >> cascade [
+{ #category : #testing }
+RBInvalidCascadeErrorNode >> isCascadeError [
+	^true
+]
 
+{ #category : #accessing }
+RBInvalidCascadeErrorNode >> receiver [
 	^ content first
 ]

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -476,17 +476,17 @@ RBParser >> parseCascadeMessage [
 	"
 	(node isMessage not or: [ node hasParentheses ]) ifTrue: [
 		"Cut parsing with an error.
-		If in faulty mode, continue the execution and generate a faulty cascade node."
+		If in faulty mode, continue the execution and generate a faulty cascade node.
+		Note that this bad cascade node will be added to the list of messages."
 		self parserError: 'cascaded message not allowed'.
-		receiver := node := RBInvalidCascadeErrorNode
+		node := RBInvalidCascadeErrorNode
 			content: { node }
 			start: node start
 			stop: currentToken stop
-			errorMessage: 'End of statement expected'.
-	] ifFalse: [
-		receiver := node receiver.
-	 	messages add: node.
+			errorMessage: 'Message expected'.
 	].
+	receiver := node receiver.
+ 	messages add: node.
 
 	"Extract the messages following the cascade marker $;"
 	[currentToken isSpecial and: [currentToken value = $;]] whileTrue: [
@@ -497,6 +497,8 @@ RBParser >> parseCascadeMessage [
 		self saveCommentsDuring: [
 			newMessage := self parseCascadeMessageWithReceiver: receiver ].
 		self addCommentsTo: newMessage.
+		"Note that newMessage can be a message node or a error node.
+		In all cases, it will be added to the list of messages."
 		messages add: newMessage ].
 
 	^self cascadeNodeClass messages: messages semicolons: semicolons

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -522,13 +522,10 @@ RBParser >> parseCascadeMessageWithReceiver: receiver [
 
 	"At this point we know this is an invalid cascade.
 	Many things can happen next: it could be a closer parenthesis or bracket, the end of the stream, a non-identifier or an empty cascade.
-	For now, if it is a closer return an empty error node.
-	If it is not a closer, consume it"
+
+	For now, do not touch the unexpected token and let it be propagated to the caller.
+	Maybe someing up the callchain will gladly use it or know how to recover (eg unfinished statement)"
 	errorNode := self parserError: 'Cascade message expected'.
-	(currentToken value ~= $.
-		and: [ ('])};' includes: currentToken value) not
-			and: [ currentToken isEOF not ] ] )
-				ifTrue: [ self step ].
 	^ errorNode
 ]
 

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -514,6 +514,11 @@ RBProgramNode >> isCascade [
 ]
 
 { #category : #testing }
+RBProgramNode >> isCascadeError [
+	^false
+]
+
+{ #category : #testing }
 RBProgramNode >> isClassVariable [
 	^ false
 ]


### PR DESCRIPTION
Improve the current parsing of faulty cascades and enrich RBInvalidCascadeErrorNode, change the logic and add documentation and tests (lots of tests).

The PR ensures that tokens in a faulty cascade are not lost when consumed during the error recovery.

Note that currently (and previously, the PR does not introduce that, it just generalizes it) a faulty cascade node is a legal `RBCascadeNode` instance but contains errors nodes in its `messages` instance variable.
The class `RBInvalidCascadeErrorNode` is still only used for the first item of a cascade node if there is an error on it.
Also, the class name is bad (and redundant), maybe `RBMessageError` could a better name. But the PR does not change that. I could if some comments ask for it :p
Anyway, client of faulty AST should still be careful when manipulating them.

A first logic change is that when an unexpected token is found after a `;`, then the whole cascade is aborted and the unexpected token is not consumed (the previous behavior was to drop the token and continue the cascade). It means that `a foo; 5 bar` will be parsed as two statements: an unfinished cascade `a foo ;` then a non-faulty message send `5 bar`.
It is more consistent with how other unexpected tokens are handled. (e.g. `a foo 5 bar` is parsed as two statements: a unfinished statement `a foo` and a non a faulty message send `5  bar`). This behavior also makes sense in the context of method edition with live feedback and highlighting where a new statement is added (thus initially unfinished) in the middle of existing code.

A second logic change is that if the first element is not a message send, then it is considered the receiver of the following messages. e.g. `a;foo;bar` will have 3 elements, a first faulty one as `a` alone is not a full message send, then two correct message sends `a foo` and `a bar`. This change reduces the number of faulty things in the AST.

