### PR TITLE
Filter on substrings in DrTest

### DIFF
--- a/src/DrTests-Tests/DTFilterableListPresenterTest.class.st
+++ b/src/DrTests-Tests/DTFilterableListPresenterTest.class.st
@@ -21,17 +21,18 @@ DTFilterableListPresenterTest >> setUp [
 
 { #category : #tests }
 DTFilterableListPresenterTest >> testFilterStrings [
+
 	filterableList filterTextInput text: 'foo|bar'.
 
-	self assertCollection: filterableList filterStrings hasSameElements: #('foo*' 'bar*').
+	self assertCollection: filterableList filterStrings hasSameElements: #( '*foo*' '*bar*' ).
 
 	filterableList filterTextInput text: '|bar'.
 
-	self assertCollection: filterableList filterStrings hasSameElements: #('bar*').
+	self assertCollection: filterableList filterStrings hasSameElements: #( '*bar*' ).
 
 	filterableList filterTextInput text: 'foo|'.
 
-	self assertCollection: filterableList filterStrings hasSameElements: #('foo*')
+	self assertCollection: filterableList filterStrings hasSameElements: #( '*foo*' )
 ]
 
 { #category : #tests }
@@ -42,7 +43,7 @@ DTFilterableListPresenterTest >> testFilterWorks [
 	filterableList filterTextInput text: '2'.
 
 	self assertCollection: filterableList allItems equals: (1 to: 20).
-	self assertCollection: filterableList visibleItems equals: #(2 20).
+	self assertCollection: filterableList visibleItems equals: #(2 12 20).
 
 	filterableList filterTextInput text: ''.
 

--- a/src/DrTests/DTFilterableListPresenter.class.st
+++ b/src/DrTests/DTFilterableListPresenter.class.st
@@ -96,8 +96,8 @@ DTFilterableListPresenter >> filterList [
 DTFilterableListPresenter >> filterStrings [
 
 	^ (self filterTextInput text splitOn: $|)
-		reject: #isEmpty
-		thenCollect: [ :pattern | pattern , '*' ]
+		  reject: #isEmpty
+		  thenCollect: [ :pattern | '*' , pattern , '*' ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Currently it was filtereng elements only if they begun by the pattern. Now, they filter if the item includes the pattern

Fixes #12788