### PR TITLE
Remove zinc file system from bootstrap

### DIFF
--- a/bootstrap/scripts/02-monticello-bootstrap/03-bootstrapMonticelloRemote.st
+++ b/bootstrap/scripts/02-monticello-bootstrap/03-bootstrapMonticelloRemote.st
@@ -6,7 +6,6 @@ mcPackages := #(
  'MonticelloRemoteRepositories'
 
  'Zinc-HTTP'
- 'Zinc-FileSystem'
  'Zodiac-Core'
  ).
 

--- a/bootstrap/src/Pharo30Bootstrap/PBBootstrap.class.st
+++ b/bootstrap/src/Pharo30Bootstrap/PBBootstrap.class.st
@@ -340,7 +340,6 @@ PBBootstrap >> monticelloNetworkPackageNames [
 		 'MonticelloRemoteRepositories'
 
 		 'Zinc-HTTP'
-		 'Zinc-FileSystem'
 		 'Zodiac-Core')
 ]
 

--- a/src/Zinc-FileSystem/package.st
+++ b/src/Zinc-FileSystem/package.st
@@ -1,1 +1,0 @@
-Package { #name : #'Zinc-FileSystem' }


### PR DESCRIPTION
Try to remove Zinc-FileSystem by removing the reference from the bootstrap. 

I need to see if the CI will work now