### PR TITLE
Improve scanning: escape comments

### DIFF
--- a/src/AST-Core-Tests/RBErrorNodeParserTest.class.st
+++ b/src/AST-Core-Tests/RBErrorNodeParserTest.class.st
@@ -170,32 +170,6 @@ RBErrorNodeParserTest >> testFaultyCascade [
 ]
 
 { #category : #tests }
-RBErrorNodeParserTest >> testFaultyLiterabByteArray [
-
-	| source node |
-	source := '#[ 1 hello 3]'.
-	node := self parserClass parseFaultyExpression: source.
-
-	self assert: node isFaulty.
-	self assert: node isLiteralByteArrayError.
-
-	self deny: node content first isFaulty.
-	self assert: node content first value equals: 1.
-
-	self assert: node content second isFaulty.
-	self assert: node content second value equals: 'hello'.
-	self assert: node content second sourceInterval equals: (6 to: 10).
-	self assert: node content second errorMessage equals: 'Expecting 8-bit integer'.
-	self assert: node content second formattedCode equals: 'hello'.
-
-	self deny: node content third isFaulty.
-	self assert: node content third value equals: 3.
-
-	self assert: node sourceInterval equals: (1 to: 13).
-	self assert: node formattedCode equals: source
-]
-
-{ #category : #tests }
 RBErrorNodeParserTest >> testFaultyCascadeCascadeMessageExpected [
 
 	| node |
@@ -389,6 +363,32 @@ RBErrorNodeParserTest >> testFaultyCascadeMessageExpected4 [
 	self
 		assert: node formattedCode
 		equals: '1<r><t>;<r><t>bar' expandMacros
+]
+
+{ #category : #tests }
+RBErrorNodeParserTest >> testFaultyLiterabByteArray [
+
+	| source node |
+	source := '#[ 1 hello 3]'.
+	node := self parserClass parseFaultyExpression: source.
+
+	self assert: node isFaulty.
+	self assert: node isLiteralByteArrayError.
+
+	self deny: node content first isFaulty.
+	self assert: node content first value equals: 1.
+
+	self assert: node content second isFaulty.
+	self assert: node content second value equals: 'hello'.
+	self assert: node content second sourceInterval equals: (6 to: 10).
+	self assert: node content second errorMessage equals: 'Expecting 8-bit integer'.
+	self assert: node content second formattedCode equals: 'hello'.
+
+	self deny: node content third isFaulty.
+	self assert: node content third value equals: 3.
+
+	self assert: node sourceInterval equals: (1 to: 13).
+	self assert: node formattedCode equals: source
 ]
 
 { #category : #tests }

--- a/src/AST-Core-Tests/RBScannerTest.class.st
+++ b/src/AST-Core-Tests/RBScannerTest.class.st
@@ -26,11 +26,11 @@ RBScannerTest >> testCommentTokenHasTheRightValue [
 
 	scanner := self buildScannerForText: String tab, ' """nested at beggining"" comment" firstToken'.
 	token := scanner next comments first.
-	self assert: token value equals: '""nested at beggining"" comment'.
+	self assert: token value equals: '"nested at beggining" comment'.
 
 	scanner := self buildScannerForText: String tab, ' "comment ""nested at end""" firstToken'.
 	token := scanner next comments first.
-	self assert: token value equals: 'comment ""nested at end""'
+	self assert: token value equals: 'comment "nested at end"'
 ]
 
 { #category : #'tests - Comment' }
@@ -1577,7 +1577,7 @@ RBScannerTest >> testNextWithTwoDoubleQuotesInComment [
 	self
 		shouldnt: [ token := (self buildScannerForText: source) next ]
 		raise: SyntaxErrorNotification.
-	self assert: token comments first value equals: 'only the"" opening'
+	self assert: token comments first value equals: 'only the" opening'
 ]
 
 { #category : #tests }

--- a/src/AST-Core/RBComment.class.st
+++ b/src/AST-Core/RBComment.class.st
@@ -18,8 +18,14 @@ self firstStatement.
 The ""method comment"" is assigned to the method node, the ""comment about the return"" is assigned
 to the ""self firstStatement"" node!
 
+Note that comments can be escaped by doubling the quotation (like in a string).
+Therefore `""This is """"a single"""" comment""` is a single comment.
+Whereas `""This is "" ""three"" "" comments""` is three comments.
+
 instance variables
-	contents 	<String> the comment text
+	contents 	<String> the comment text without the quotes.
+		Note double quotes are unescaped, so you get single quotes here.
+		You can use `sourceCode` to get the original text with all verbatim quotes. 
 	start	<Number> (start-) position within the method source
 
 "

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -365,7 +365,7 @@ RBScanner >> scanComment [
 	self step.
 	self atEnd
 		ifTrue: [ ^ self scannerError: 'Unmatched " in comment.' ].
-	[ currentCharacter = $" and: [ "buffer nextPut: currentCharacter." self step ~= $" ] ]
+	[ currentCharacter = $" and: [ self step ~= $" ] ]
 		whileFalse: [ characterType = #eof
 				ifTrue: [ ^ self scannerError: 'Unmatched " in comment.' ].
 			buffer nextPut: currentCharacter.

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -365,7 +365,7 @@ RBScanner >> scanComment [
 	self step.
 	self atEnd
 		ifTrue: [ ^ self scannerError: 'Unmatched " in comment.' ].
-	[ currentCharacter = $" and: [ buffer nextPut: currentCharacter. self step ~= $" ] ]
+	[ currentCharacter = $" and: [ "buffer nextPut: currentCharacter." self step ~= $" ] ]
 		whileFalse: [ characterType = #eof
 				ifTrue: [ ^ self scannerError: 'Unmatched " in comment.' ].
 			buffer nextPut: currentCharacter.
@@ -373,7 +373,7 @@ RBScanner >> scanComment [
 	stop := self atEnd
 		ifTrue: [ stream position ]
 		ifFalse: [ stream position - 1 ].
-	comments add: (RBCommentToken value: (buffer contents copyFrom: 1 to: buffer contents size -1) start: start stop: stop)
+	comments add: (RBCommentToken value: buffer contents start: start stop: stop)
 ]
 
 { #category : #'private - scanning' }

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -1213,6 +1213,30 @@ String >> endsWithDigit [
 	^ self notEmpty and: [self last isDigit]
 ]
 
+{ #category : #converting }
+String >> escapeCharacter: aCharacter [
+	"Returns a new string with contents equals to self surrounded by aCharacter.
+	Escapes all occurrences of aCharacter within aString by doubling them."
+
+	"('abc' escapeCharacter: $X) >>> 'abc'"
+
+	"('aXb' escapeCharacter: $X) >>> 'aXXb'"
+
+	"('XaX' escapeCharacter: $X) >>> 'XXaXX'"
+
+	"('XXaXbXXcXXXdXX' escapeCharacter: $X) >>> 'XXXXaXXbXXXXcXXXXXXdXXXX'"
+
+	| result stream |
+	result := WriteStream with: ''.
+	stream := ReadStream on: self.
+	[ stream atEnd ] whileFalse: [
+		result nextPutAll: (stream upTo: aCharacter).
+		stream peekBack = aCharacter ifTrue: [
+			result nextPut: aCharacter.
+			result nextPut: aCharacter ] ].
+	^ result contents
+]
+
 { #category : #formatting }
 String >> expandMacros [
 	"'<t>' expandMacros >>> String tab"

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -1215,8 +1215,8 @@ String >> endsWithDigit [
 
 { #category : #converting }
 String >> escapeCharacter: aCharacter [
-	"Returns a new string with contents equals to self surrounded by aCharacter.
-	Escapes all occurrences of aCharacter within aString by doubling them."
+	"Returns a copy of the string doubling all occurence of aCharacter."
+	"See `unescapeCharacter:` for the opposite"
 
 	"('abc' escapeCharacter: $X) >>> 'abc'"
 
@@ -2720,6 +2720,7 @@ String >> uncapitalized [
 String >> unescapeCharacter: aCharacter [
 	"Unescape an escaped string. Assume the string has all occurrences of aCharacter are escaped. That is, they are in pairs.
 	This method returns a copy of the string replacing all pairs of aCharacter by a single appearance of it."
+	"See `escapeCharacter:` for the opposite"
 
 	"('''''' unescapeCharacter: $') >>> ''''"
 	"('''' unescapeCharacter: $') >>> ''"

--- a/src/EnlumineurFormatter/EFFormatter.class.st
+++ b/src/EnlumineurFormatter/EFFormatter.class.st
@@ -1009,7 +1009,7 @@ EFFormatter >> areArgumentsTooLong: anArray [
 EFFormatter >> basicFormatCommentFor: aComment [
 	codeStream
 		nextPut: $";
-		nextPutAll: aComment contents;
+		nextPutAll: (aComment contents escapeCharacter: $");
 		nextPut: $"
 ]
 
@@ -1958,17 +1958,18 @@ EFFormatter >> privateFormatMethodPatternMultiLineFor: aMethodNode [
 
 { #category : #utilities }
 EFFormatter >> resizeComment: aComment withFirstLineShorterOf: anIndex [
-	| cutComment firstLine currentCharPos |
+	| cutComment firstLine currentCharPos contents |
 	currentCharPos := 1.
-	firstLine := (aComment contents
+	contents := aComment contents escapeCharacter: $".
+	firstLine := (contents
 		withNoLineLongerThan: self maxLineLength - anIndex) lineNumber: 1.
 	[ currentCharPos > firstLine size ]
 		whileFalse: [ codeStream nextPut: (firstLine at: currentCharPos).
 			currentCharPos := currentCharPos + 1 ].
-	currentCharPos > aComment contents size
+	currentCharPos > contents size
 		ifTrue: [ ^ self ].
 	self newLine.
-	cutComment := aComment contents allButFirst: currentCharPos.
+	cutComment := contents allButFirst: currentCharPos.
 	self resizeStringDependingOnWindowSizeFor: cutComment
 ]
 
@@ -1977,7 +1978,7 @@ EFFormatter >> resizeCommentFor: aComment startingAt: anIndex [
 	codeStream nextPut: $".
 	"Hack to keep the right comment in pop up like cmd n, cmd m..."
 	self maxLineLength < 50
-		ifTrue: [ codeStream nextPutAll: aComment contents ]
+		ifTrue: [ codeStream nextPutAll: (aComment contents escapeCharacter: $") ]
 		ifFalse:
 			[ 
 			aComment contents
@@ -1992,7 +1993,7 @@ EFFormatter >> resizeCommentFor: aComment startingAt: anIndex [
 { #category : #utilities }
 EFFormatter >> resizeStringDependingOnWindowSizeFor: aComment [
 	| resizedComment |
-	resizedComment := aComment contents withNoLineLongerThan: self maxLineLength.
+	resizedComment := (aComment contents escapeCharacter: $") withNoLineLongerThan: self maxLineLength.
 	resizedComment do: [ :each | 
 		codeStream nextPut: each.
 		each = Character cr

--- a/src/PharoDocComment-Tests/PharoDocCommentTest.class.st
+++ b/src/PharoDocComment-Tests/PharoDocCommentTest.class.st
@@ -144,7 +144,7 @@ PharoDocCommentTest >> testNestedInsanity [
 	node expression evaluate >>> (7->7)
 	""This is the end of the executable comment"""
 
-	"Now it's the real test... or it is?"
+	"Now it's the real test... or is it?"
 	| node |
 	node := thisContext method ast pharoDocCommentNodes first.
 	self assert: node expression source equals: '"Seriously, you should not do what follows"

--- a/src/PharoDocComment-Tests/PharoDocCommentTest.class.st
+++ b/src/PharoDocComment-Tests/PharoDocCommentTest.class.st
@@ -121,3 +121,41 @@ PharoDocCommentTest >> testMultipleDocCommentsInOneComment [
 	self should: [ node expression evaluate ] raise: RuntimeSyntaxError.
 	self should: [ (CommentTestCase for: node) testIt ] raise: RuntimeSyntaxError
 ]
+
+{ #category : #tests }
+PharoDocCommentTest >> testNestedComments [
+	"3 + 4 ""the sum"" >>> ""is seven"" 7 "
+	| node |
+	node := thisContext method ast pharoDocCommentNodes first.
+	self assert: node expression source equals: '3 + 4 "the sum" >>> "is seven" 7 '.
+	self assert: node expression isFaulty not.
+	self assert: node expression evaluate equals: 7->7.
+	(CommentTestCase for: node) testIt
+]
+
+{ #category : #tests }
+PharoDocCommentTest >> testNestedInsanity [
+	"""Seriously, you should not do what follows""
+		""3 + 4 """"a nested executable comment with a nested nested comment
+		because it's how we roll baby"""" >>> 7""
+	""that is not the test, it's still the executable comment""
+	| node |
+	node := thisContext method ast allComments second pharoDocCommentNodes first.
+	node expression evaluate >>> (7->7)
+	""This is the end of the executable comment"""
+
+	"Now it's the real test... or it is?"
+	| node |
+	node := thisContext method ast pharoDocCommentNodes first.
+	self assert: node expression source equals: '"Seriously, you should not do what follows"
+		"3 + 4 ""a nested executable comment with a nested nested comment
+		because it''s how we roll baby"" >>> 7"
+	"that is not the test, it''s still the executable comment"
+	| node |
+	node := thisContext method ast allComments second pharoDocCommentNodes first.
+	node expression evaluate >>> (7->7)
+	"This is the end of the executable comment"'.
+	self assert: node expression isFaulty not.
+	self assert: node expression evaluate equals: ((7->7)->(7->7)).
+	(CommentTestCase for: node) testIt
+]

--- a/src/PharoDocComment/SHRBTextStyler.extension.st
+++ b/src/PharoDocComment/SHRBTextStyler.extension.st
@@ -24,7 +24,7 @@ SHRBTextStyler >> styleDocExpression: aPharoDocExpression in: aRBComment [
 		(expressionText at: ij) = $" ifTrue: [
 			"Because doublequote are escaped in the original source code,
 			just highlight both character the same and increase the original source offset"
-			charAttr at: index put: attr.
+			charAttr at: index + 1 put: attr.
 			off := off + 1 ] ]
 ]
 

--- a/src/PharoDocComment/SHRBTextStyler.extension.st
+++ b/src/PharoDocComment/SHRBTextStyler.extension.st
@@ -9,15 +9,23 @@ SHRBTextStyler >> styleDocComment: aRBComment [
 
 { #category : #'*PharoDocComment' }
 SHRBTextStyler >> styleDocExpression: aPharoDocExpression in: aRBComment [
-	| expressionText expressionNode |
+
+	| expressionText expressionNode off |
 	expressionNode := aPharoDocExpression expressionNode.
 	expressionText := expressionNode source asText.
 	self class new style: expressionText ast: expressionNode.
-	expressionText
-		withIndexDo: [ :char :ij |
-			| index |
-			index := ij + aRBComment start.
-			charAttr at: index put: (expressionText attributesAt: ij) ]
+
+	off := aRBComment start.
+	expressionText withIndexDo: [ :char :ij |
+		| index attr |
+		index := ij + off.
+		attr := expressionText attributesAt: ij.
+		charAttr at: index put: attr.
+		(expressionText at: ij) = $" ifTrue: [
+			"Because doublequote are escaped in the original source code,
+			just highlight both character the same and increase the original source offset"
+			charAttr at: index put: attr.
+			off := off + 1 ] ]
 ]
 
 { #category : #'*PharoDocComment' }


### PR DESCRIPTION
Few people know (I even did not know that last week) but in pharo you can escape double-quotes in comments by doubling the double-quote. (there are only a few uses of this syntactic feature in the pharo base code)

```st
"A comment with a "" inside"
```

For some reason (?), the pharo scanner did not unescape the double double-quote and let clients deal with possibly unexpected content with superfluous `"` (because when people comment `"a""b"` what they really mean is `a"b`).
One of these client was the executable comments (see #12807) where nested comment break the whole thing, so the PR tries to fix the root cause.

* Teach the scanner to unescape the comment contents when creating the comment token.
* Fix the highlighting in executable comments with nested comments.
* Teach EFFormatter to put back double `"` when formatting comments.

fix #12844
related to #12807 (half fix, the CI issue is still problematic)
replace #12830