### PR TITLE
Clean some parsing code

### DIFF
--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -792,21 +792,6 @@ RBParser >> parseMethodBodyInto: aMethodNode [
 ]
 
 { #category : #'private - parsing' }
-RBParser >> parseNumberLiteral [
-	"Creates a literal value node from a number literal token."
-	| token |
-	"self deprecated: 'Unnecessary method because it is the same as parsePrimitiveValueLiteral, both called only by parsePrimitiveLiteral' transformWith: self parsePrimitiveLiteral."
-	token := currentToken.
-	self step.
-
-	^self literalValueNodeClass
-		value: token value
-		start: token start
-		stop: token stop
-		source: token source
-]
-
-{ #category : #'private - parsing' }
 RBParser >> parseParenthesizedExpression [
 	| node startToken |
 	startToken := currentToken.
@@ -884,9 +869,17 @@ RBParser >> parsePrimitiveKeywordPragma [
 
 { #category : #'private - parsing' }
 RBParser >> parsePrimitiveLiteral [
-	^ currentToken isNumberLiteralToken
-		ifTrue: [ self parseNumberLiteral ]
-		ifFalse: [ self parsePrimitiveValueLiteral ]
+	"Creates a literal value node from a literal token."
+	| token |
+
+	token := currentToken.
+	self step.
+
+	^self literalValueNodeClass
+		value: token value
+		start: token start
+		stop: token stop
+		source: token source
 ]
 
 { #category : #'private - parsing' }
@@ -907,21 +900,6 @@ RBParser >> parsePrimitiveObject [
 			currentToken value = ${ ifTrue: [^self parseArray]].
 	errorNode := self parserError: 'Variable or expression expected'.
 	^errorNode
-]
-
-{ #category : #'private - parsing' }
-RBParser >> parsePrimitiveValueLiteral [
-	"Creates a literal value node from a literal token."
-	| token |
-	"self deprecated: 'Unnecessary method because it is the same as parseNumberLiteral, both called only by parsePrimitiveLiteral' transformWith: self parsePrimitiveLiteral."
-	token := currentToken.
-	self step.
-
-	^self literalValueNodeClass
-		value: token value
-		start: token start
-		stop: token stop
-		source: token source
 ]
 
 { #category : #'private - parsing' }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -590,7 +590,7 @@ RBParser >> parseIncompleteExpression: priorStatementsNode [
 	self step.
 	priorStatementsNode statements: statements.
 	^self atEnd ifTrue: [ priorStatementsNode ]
-				  ifFalse: [ self parseStatementList: false into: priorStatementsNode until: [ false "No extra condition, just until the end of the stream" ].
+				  ifFalse: [ self parseStatementList: false into: priorStatementsNode untilAnyCloserOf: '' "No extra condition, just until the end of the stream".
 								self atEnd ifFalse: [ self parseIncompleteExpression: priorStatementsNode ]
 											  ifTrue: [ priorStatementsNode ] ]
 ]
@@ -1058,37 +1058,6 @@ RBParser >> parseStatementInto: statementList periodList: periods withAcceptedSt
 ]
 
 { #category : #'private - parsing' }
-RBParser >> parseStatementList: pragmaBoolean into: sequenceNode until: aBlock [
-
-	"Parse a list of statements and set those statetements to a sequence node.
-	Stop parsing when we finish the current scope.
-	Different scopes such as blocks or methods can decide different stop conditions."
-
-	| statements return periods |
-	return := false.
-	statements := sequenceNode statements.
-	periods := OrderedCollection new.
-
-	self addCommentsTo: sequenceNode.
-
-	pragmaBoolean ifTrue: [ self parsePragmas ].
-
-	[ currentToken isSpecial: $. ]
-		whileTrue: [
-			periods add: currentToken start.
-			self step ].
-
-	[  self atEnd or: [ aBlock value ] ] whileFalse: [
-		self parseStatementInto: statements periodList: periods ].
-
-	statements notEmpty ifTrue: [ self addCommentsTo: statements last ].
-	sequenceNode
-		statements: statements;
-		periods: periods.
-	^ sequenceNode
-]
-
-{ #category : #'private - parsing' }
 RBParser >> parseStatementList: pragmaBoolean into: sequenceNode untilAnyCloserOf: aCollectionOfClosers [
 
 	"Parse a list of statements and set those statetements to a sequence node.
@@ -1124,17 +1093,6 @@ RBParser >> parseStatementList: pragmaBoolean into: sequenceNode untilAnyCloserO
 		statements: statements;
 		periods: periods.
 	^ sequenceNode
-]
-
-{ #category : #'private - parsing' }
-RBParser >> parseStatements: pragmaBoolean into: aSequenceNode until: aBlock [
-
-	self parseTemporariesInto: aSequenceNode.
-
-	^self
-		parseStatementList: pragmaBoolean
-		into: aSequenceNode
-		until: aBlock
 ]
 
 { #category : #'private - parsing' }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -292,15 +292,6 @@ RBParser >> nextToken [
 ]
 
 { #category : #'private - parsing' }
-RBParser >> parseArgs [
-	"Return a collection of variable node."
-	| args |
-	args := OrderedCollection new.
-	[currentToken isIdentifier] whileTrue: [args add: self parseVariableNode].
-	^args
-]
-
-{ #category : #'private - parsing' }
 RBParser >> parseArray [
 	"Although an array node represents an array, it is not an Array-like object."
 	| startToken node |

--- a/src/AST-Core/RBPatternParser.class.st
+++ b/src/AST-Core/RBPatternParser.class.st
@@ -50,7 +50,7 @@ RBPatternParser >> parsePatternBlock: aClass [
 	self
 		parseStatements: false
 		into: node body
-		until: [ currentToken isSpecial: $} ].
+		untilAnyCloserOf: '}'.
 
 	(currentToken isSpecial: $})
 		ifFalse: [ self addParserError: '''}'' expected' to: node body.

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -302,14 +302,6 @@ RBScanner >> on: aStream [
 	comments := OrderedCollection new
 ]
 
-{ #category : #'error handling' }
-RBScanner >> parseErrorNode: aMessageString [
-	| sourceString |
-	sourceString := stream contents copyFrom: self errorPosition to: stream contents size.
-	^ RBParseErrorNode
-		errorMessage: aMessageString value: sourceString at: self errorPosition
-]
-
 { #category : #private }
 RBScanner >> previousStepPosition [
 	^characterType = #eof

--- a/src/OpalCompiler-Tests/OCTargetCompilerParser.class.st
+++ b/src/OpalCompiler-Tests/OCTargetCompilerParser.class.st
@@ -3,7 +3,7 @@ I am a ridiculous alternate parser, that replaces any literal symbol #dontReturn
 
 It's the simplest change to the compiler that I could imagine that doesn't interfere with the fact that the class-side `compilerClass` method can't be interfered with.
 
-Note that  I only override a single method, and that method is somewhat deprecated, so changes in the superclass must be reflected here.
+Note that  I only override a single private method, so changes in the superclass must be reflected here.
 "
 Class {
 	#name : #OCTargetCompilerParser,
@@ -11,8 +11,8 @@ Class {
 	#category : #'OpalCompiler-Tests-Semantic'
 }
 
-{ #category : #parsing }
-OCTargetCompilerParser >> parsePrimitiveValueLiteral [
+{ #category : #'private - parsing' }
+OCTargetCompilerParser >> parsePrimitiveLiteral [
 	"Creates a literal value node from a literal token."
 	| token value |
 	token := currentToken.


### PR DESCRIPTION
Remove two unused methods, factorize two deprecated methods, and merge two set of clonish methods

* `RBScanner>>#parseErrorNode` no clients
* `RBParser>>#parseArgs` no clients (`RBParser>>#parseBlockArgsInto:` is used instead)
* deprecated methods `RBParser>>#parseNumberLiteral` and its clone `RBParser>>#parsePrimitiveValueLiteral` removed and code moved to `RBParser>>#parsePrimitiveLiteral`
* `RBParser>>#parseStatements:into:until:` and `RBParser>>#parseStatementList:into:until:` removed in profit of their simpler siblings `RBParser>>#parseStatements:into:untilAnyCloserOf:` and `RBParser>>#parseStatementList:into:untilAnyCloserOf:` (clients are adapted)