### PR TITLE
Improve faulty parsing on variables

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -99,69 +99,69 @@ RBCodeSnippet class >> badExpressions [
 		"Note: bad temporaries will be stored as error statements"
 		self new source: '|'.
 		self new source: '| a b'.
-		self new source: '| 1'; formattedCode: '|'. "FIXME"
+		self new source: '| 1'; formattedCode: '|.<r>1'.
 		"Note that the | character is also a binary operator, so a missing opening | become a binary call with a missing argument (see bellow)"
 		self new source: 'a | '.
 		self new source: 'a || '.
 		self new source: '| | a'; formattedCode: 'a'; isFaulty: false. "This one is legal, it is an empty list of temporaries, the | are dismissed"
 		self new source: '|| a'; formattedCode: 'a'; isFaulty: false. "Same, but are messing with the Scanner"
-		self new source: ' ||| a'; formattedCode: ' ||| a'. "FIXME. this one is a empty temps and a binary operator | with a mising receiver"
-		self new source: ' |||| a'; formattedCode: ' |||| a'. "FIXME. this one is a empty temps and a binary operator || with a mising receiver"
+		self new source: ' ||| a'; formattedCode: ' | a'. "this one is a empty temps and a binary operator | with a mising receiver"
+		self new source: ' |||| a'; formattedCode: ' || a'. "this one is a empty temps and a binary operator || with a mising receiver"
 		self new source: '| a | | b'; formattedCode: '| a |<r> | b'. "A valid temporary followed by a binary operator with a missing receiver"
-		self new source: '| a ||b'; formattedCode: '| a.<r>b'. "FIXME"
+		self new source: '| a ||b'; formattedCode: '| a |<r> | b'. "same"
 
 		"Unexpected parameters (or columns)"
 		"Note that `:a` is not a token but a special `:` followed by an identifier, whereas `a:` is a single token."
 		"Nevertheless, the parser will try to catch unexpected :a together"
-		self new source: ':a'; formattedCode: ' :.<r>a'.
-		self new source: '::a'; formattedCode: ' :.<r> :.<r>a'.
-		self new source: ':::a'; formattedCode: ' :.<r> :.<r> :.<r>a'.
-		self new source: '::'; formattedCode: ' :.<r>:'.
-		self new source: ':a foo'; formattedCode: ' :.<r>a foo'.
-		self new source: 'a :foo'; formattedCode: ' a.<r> :.<r>foo'.
-		self new source: 'a : foo'; formattedCode: ' a.<r> :.<r>foo'.
+		self new source: ':a'.
+		self new source: '::a'.
+		self new source: ':::a'.
+		self new source: '::'.
+		self new source: ':a foo'.
+		self new source: 'a :foo'; formattedCode: ' a.<r>:foo'.
+		self new source: 'a : foo'; formattedCode: ' a.<r>:foo'.
 		self new source: 'a:'; formattedCode: ' a: '. "keyword message with a missing receiver and argument"
 		self new source: 'a::'. "just a bad token"
 		self new source: 'a:foo'; formattedCode: ' a: foo'. "keyword message with a missing receiver"
 		self new source: 'a::foo'; formattedCode: ' a::.<r>foo'.
-		self new source: ':a:foo'; formattedCode: ' :.<r> a: foo'. "FIXME"
-		self new source: '|:a|'; formattedCode: '|.<r>a | '.
-		self new source: '|:a'; formattedCode: '|.<r>a'.
-		self new source: '|::a'; formattedCode: '|.<r> :.<r>a'.
-		self new source: '|a:|'; formattedCode: '|.<r> | '. "FIXME"
-		self new source: '|a:'; formattedCode: '|'. "FIXME"
+		self new source: ':a:foo'; formattedCode: ': a: foo'.
+		self new source: '|:a|'; formattedCode: '|.<r>:a | '.
+		self new source: '|:a'; formattedCode: '|.<r>:a'.
+		self new source: '|::a'; formattedCode: '|.<r>::a'.
+		self new source: '|a:|'; formattedCode: '|.<r> a:  | '.
+		self new source: '|a:'; formattedCode: '|.<r> a: '.
 
 		"Bad block parameters"
 		"A bad parameter cause a error object to be added as the last element of the block parameter.
 		On formating, a double space can be seen."
-		self new source: '[:a b]'; formattedCode: '[ :a : | b ]'; skip: #testExecute.
-		self new source: '[:a 1]'; formattedCode: '[ :a : | 1 ]'; skip: #testExecute.
+		self new source: '[:a b]'; formattedCode: '[ :a  | b ]'; skip: #testExecute.
+		self new source: '[:a 1]'; formattedCode: '[ :a  | 1 ]'; skip: #testExecute.
 		self new source: '[:a :]'; formattedCode: '[ :a : |  ]'; skip: #testExecute.
-		self new source: '[:a ::b]'; formattedCode: '[ :a : :b |  ]'; skip: #testExecute.
+		self new source: '[:a ::b]'; formattedCode: '[ :a ::b |  ]'; skip: #testExecute.
 		self new source: '[:a :b]'; formattedCode: '[ :a :b |  ]'; isFaulty: false. "no pipe (and no body) is legal"
 		self new source: '[: a : b]'; formattedCode: '[ :a :b |  ]'; isFaulty: false. "spaces are also legal"
-		self new source: '[:a:b]'; formattedCode: '[ : : |  a: b ]'. "FIXME"
+		self new source: '[:a:b]'; formattedCode: '[ :  |  a: b ]'. "FIXME?"
 		self new source: '[  a:  ]'. "no parameters, a keyword message send witout receiver nor arguments"
-		self new source: '[ | ]'; formattedCode: '[ |'. "FIXME"
-		self new source: '[ | b ]'; formattedCode: '[ | b'. "FIXME"
-		self new source: '[ :a | | b ]'; formattedCode: '[ | b'. "FIXME"
-		self new source: '[ :a || b ]'; formattedCode: '[ | b'. "FIXME"
+		self new source: '[ | ]'.
+		self new source: '[ | b ]'.
+		self new source: '[ :a | | b ]'.
+		self new source: '[ :a || b ]'; formattedCode: '[ :a | | b ]'.
 		self new source: '[:a| | |b]'; formattedCode: '[ :a | b ]'; isFaulty: false. "Explicit empty list of temporaries"
 		self new source: '[:a| ||b]'; formattedCode: '[ :a | b ]'; isFaulty: false. "Same but mess with the Scanner"
 		self new source: '[:a|| |b]'; formattedCode: '[ :a | b ]'; isFaulty: false. "Same"
-		self new source: '[:a|||b]'; formattedCode: '[ :a : |  ||| b ]'. "FIXME"
-		self new source: '[:a||||b]'; formattedCode: '[ :a : |  |||| b ]'. "FIXME"
+		self new source: '[:a|||b]'; formattedCode: '[ :a | b ]'; isFaulty: false. "Same"
+		self new source: '[:a||||b]'; formattedCode: '[ :a |  | b ]'. "same + binary | without receiver"
 
 		"Unclosed blocks"
-		self new source: '[: | '; formattedCode: '['. "FIXME"
-		self new source: '[:'; formattedCode: '['. "FIXME"
-		self new source: '[:a :b | '; formattedCode: '['. "FIXME"
-		self new source: '[:a :b'; formattedCode: '['. "FIXME"
-		self new source: '[:a b'; formattedCode: '[ b'. "FIXME"
-		self new source: '[:a | '; formattedCode: '['. "FIXME"
-		self new source: '[:a |  b'; formattedCode: '[ b'. "FIXME"
+		self new source: '[: | '.
+		self new source: '[:'; formattedCode: '[:  | '.
+		self new source: '[:a :b | '.
+		self new source: '[:a :b'; formattedCode: '[:a :b  | '.
+		self new source: '[:a b'; formattedCode: '[:a  |  b'.
+		self new source: '[:a | '.
+		self new source: '[:a |  b'.
 		self new source: '[ |'.
-		self new source: '[ | 1'; formattedCode: '[ |'. "FIXME"
+		self new source: '[ | 1'.
 		self new source: '[ | a'.
 
 		"Missing receiver or argument in message sends.
@@ -198,7 +198,7 @@ RBCodeSnippet class >> badExpressions [
 		self new source: '1 foo:;bar'; formattedCode: '1<r><t>foo: ;<r><t>bar'. "The cascade is correct here. It's a simple error of a missing argument"
 		self new source: '1 foo;2'; formattedCode: ' 1<r><t>foo;<r><t>.<r>2'.
 		self new source: '(1 sign: 2);bar'; formattedCode: '(1 sign: 2)<r><t>;<r><t>bar'.
-		self new source: '(1 sign);bar'; formattedCode: '1 sign<r><t>;<r><t>bar'. "BUT the parentheses are lost, but is changes the meaning"
+		self new source: '(1 sign);bar'; formattedCode: '1 sign<r><t>;<r><t>bar'. "FIXME the parentheses are lost, and this changes the meaning"
 		"Longer cascade"
 		self new source: ';;'; formattedCode: '<r><t>;<r><t>;<r><t>'.
 		self new source: '1 sign;;bar'; formattedCode: '1<r><t>sign;<r><t>;<r><t>bar'.
@@ -207,11 +207,11 @@ RBCodeSnippet class >> badExpressions [
 		self new source: '^ '.
 		self new source: '1+^2'; formattedCode: ' 1 + .<r>^ 2'.
 		self new source: '1 foo: ^2'; formattedCode: ' 1 foo: .<r>^ 2'.
-		self new source: '(^1)'; formattedCode: ' ( .<r> ^ 1)'. "FIXME WTF"
-		self new source: '^^1'; formattedCode: ' ^ .<r>^ 1' "FIXME, same spirit".
+		self new source: '(^1)'; formattedCode: ' ( .<r> ^ 1)'. "^ can only appear a the begin of a statement, so a random ^ cause an unfinished statement error"
+		self new source: '^^1'; formattedCode: ' ^ .<r>^ 1' "Same spirit".
 		self new source: '{ ^ 1 }'; isFaulty: false; value: 1. "I did not expect this one to be legal"
 		self new source: '#(^1)'; formattedCode: '#( #''^'' 1 )'; isFaulty: false; value: #(^1). "Obviously..."
-		self new source: '#[ ^ 1]'; skip: #testDump.
+		self new source: '#[ ^ 1]'.
 
 		"Bad string literal"
 		"Note: the only cases are the missing closing quotes since everything inside is captured as is and there is no escape sequences or interpolation (yet?)"

--- a/src/AST-Core/RBBlockErrorNode.class.st
+++ b/src/AST-Core/RBBlockErrorNode.class.st
@@ -9,6 +9,9 @@ or the closure : [ block node .
 Class {
 	#name : #RBBlockErrorNode,
 	#superclass : #RBEnglobingErrorNode,
+	#instVars : [
+		'arguments'
+	],
 	#category : #'AST-Core-Nodes - ErrorNodes'
 }
 
@@ -25,6 +28,17 @@ RBBlockErrorNode class >> error: aToken withNodes: aCollection [
 	^message = ''']'' expected'
 		ifTrue: [ self new content: aCollection; start: aToken start; stop: aCollection last stop; errorMessage: message ]
 		ifFalse: [ self new content: aCollection; start: aCollection first start; stop: aToken stop; errorMessage: message ]
+]
+
+{ #category : #accessing }
+RBBlockErrorNode >> arguments [
+	^arguments
+]
+
+{ #category : #accessing }
+RBBlockErrorNode >> arguments: anObject [
+
+	arguments := anObject
 ]
 
 { #category : #testing }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -437,21 +437,10 @@ RBParser >> parseBlockArgsInto: node [
 			arg isParseError ifTrue: [ arg value: ':' ]].
 	verticalBar
 		ifTrue:
-			[currentToken isBinary
+			[(currentToken isBinary and: [currentToken value first = $|])
 				ifTrue:
 					[node bar: currentToken start.
-					currentToken value = #|
-						ifTrue: [self step]
-						ifFalse:
-							[currentToken value = #'||'
-								ifTrue:
-									["Hack the current token to be the start
-									of temps bar"
-
-									currentToken
-										value: #|;
-										start: currentToken start + 1]
-								ifFalse: [ args add:(self parserError: '''|'' expected')]]]
+					self stepBar]
 				ifFalse:
 					[(currentToken isSpecial: $])
 						ifFalse: [ args add:(self parserError: '''|'' expected')]]].
@@ -1123,13 +1112,13 @@ RBParser >> parseTemporariesInto: aSequenceNode [
 	leftBar := rightBar := nil.
 	currentToken isBinary
 		ifTrue:
-			[currentToken value = #|
+			[currentToken value first = $|
 				ifTrue:
 					[ startToken := currentToken.
 					leftBar := currentToken start.
-					self step.
+					self stepBar. "Consume one | only"
 					temps := self parseTemps.
-					(currentToken isBinary and: [currentToken value = #|])
+					(currentToken isBinary and: [currentToken value first = $|])
 						ifFalse: [ errorNode :=  self parseEnglobingError: temps with: startToken errorMessage: '''|'' expected'.
 									 aSequenceNode addFaultyNode: errorNode.
 									 temps := OrderedCollection new.
@@ -1137,12 +1126,7 @@ RBParser >> parseTemporariesInto: aSequenceNode [
 								    ]
 						ifTrue: [
 							rightBar := currentToken start.
-							self step ]]
-				ifFalse:
-					[currentToken value = #'||'
-						ifTrue:
-							[rightBar := (leftBar := currentToken start) + 1.
-							self step]]].
+							self stepBar "Consume one | only" ]]].
 
 	aSequenceNode leftBar: leftBar temporaries: temps rightBar: rightBar
 ]
@@ -1383,6 +1367,20 @@ RBParser >> step [
 			[currentToken := nextToken.
 			nextToken := nil]
 		ifNil: [currentToken := self scannerNext]
+]
+
+{ #category : #private }
+RBParser >> stepBar [
+	"When possible, only consume the first bar (`|`) of the current binary token"
+
+	"All of this because | can be a separator (block args), a type of brackets (temps) and a valid first character of binary operators."
+
+	| value |
+	value := currentToken value.
+	(value size < 2 or: [ value first ~= $| ]) ifTrue: [ ^ self step ].
+
+	currentToken value: value allButFirst.
+	currentToken start: currentToken start + 1
 ]
 
 { #category : #'private - classes' }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -412,7 +412,11 @@ RBParser >> parseBlock [
 		untilAnyCloserOf: ']'.
 
 	(currentToken isSpecial: $])
-		ifFalse: [ ^ self parseEnglobingError: node body statements with: startToken errorMessage: ''']'' expected'].
+		ifFalse: [
+			^ (self parseEnglobingError: node body statements with: startToken errorMessage: ''']'' expected')
+				arguments: node arguments;
+				yourself
+		].
 	node right: currentToken start.
 	self step.
 	^node

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -904,6 +904,10 @@ RBParser >> parsePrimitiveObject [
 			[currentToken value = $[ ifTrue: [^self saveCommentsDuring:[self parseBlock]].
 			currentToken value = $( ifTrue: [^self parseParenthesizedExpression].
 			currentToken value = ${ ifTrue: [^self parseArray]].
+
+	": is only acceptable at the begin of a block. So just consume them as bad expression"
+	(currentToken isSpecial: $:) ifTrue: [ ^self parseVariableNode ].
+
 	errorNode := self parserError: 'Variable or expression expected'.
 	^errorNode
 ]

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -1200,9 +1200,22 @@ RBParser >> parseUnaryPragma [
 RBParser >> parseVariableNode [
 	"If called without having an Identifier Token : sends an error.
 	 Return a variable node with current token value, start position and comments."
-	currentToken isIdentifier
-		ifFalse: [ ^ self parserError: 'Variable name expected' ].
-	^self parsePrimitiveIdentifier
+
+	| errorNode |
+	currentToken isIdentifier ifTrue: [ ^ self parsePrimitiveIdentifier ].
+
+	errorNode := self parserError: 'Variable name expected'.
+
+	"Consume : and optional identifier that follows as an error"
+	(currentToken isSpecial: $:) ifTrue: [
+		self step. "consume : if present"
+		errorNode value: ':'.
+		currentToken isIdentifier ifTrue: [ "Also consume the identifier"
+			errorNode stop: currentToken stop.
+			errorNode value: ':' , currentToken source.
+			self step ] ].
+
+	^ errorNode
 ]
 
 { #category : #'error handling' }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -1125,8 +1125,9 @@ RBParser >> parseTemporariesInto: aSequenceNode [
 									 temps := OrderedCollection new.
 									 leftBar := nil.
 								    ]
-						ifTrue: [ rightBar := currentToken start ].
-					self step]
+						ifTrue: [
+							rightBar := currentToken start.
+							self step ]]
 				ifFalse:
 					[currentToken value = #'||'
 						ifTrue:

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -424,7 +424,7 @@ RBParser >> parseBlock [
 
 { #category : #'private - parsing' }
 RBParser >> parseBlockArgsInto: node [
-	| verticalBar args colons |
+	| verticalBar args arg colons |
 	args := OrderedCollection new: 2.
 	colons := OrderedCollection new: 2.
 	verticalBar := false.
@@ -432,7 +432,9 @@ RBParser >> parseBlockArgsInto: node [
 			[colons add: currentToken start.
 			self step.	":"
 			verticalBar := true.
-			args add: self parseVariableNode].
+			args add: (arg := self parseVariableNode).
+			"In case of error, preserve the lone : to ditinguish from error witout even a :"
+			arg isParseError ifTrue: [ arg value: ':' ]].
 	verticalBar
 		ifTrue:
 			[currentToken isBinary

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -434,7 +434,7 @@ RBParser >> parseBlockArgsInto: node [
 			verticalBar := true.
 			args add: (arg := self parseVariableNode).
 			"In case of error, preserve the lone : to ditinguish from error witout even a :"
-			arg isParseError ifTrue: [ arg value: ':' ]].
+			arg isParseError ifTrue: [ arg value: ':', arg value ]].
 	verticalBar
 		ifTrue:
 			[(currentToken isBinary and: [currentToken value first = $|])
@@ -1196,11 +1196,13 @@ RBParser >> parseVariableNode [
 
 	"Consume : and optional identifier that follows as an error"
 	(currentToken isSpecial: $:) ifTrue: [
-		self step. "consume : if present"
-		errorNode value: ':'.
+		[ currentToken isSpecial: $: ] whileTrue: [
+			self step. "consume : while present"
+			errorNode stop: currentToken stop.
+			errorNode value: errorNode value , ':' ].
 		currentToken isIdentifier ifTrue: [ "Also consume the identifier"
 			errorNode stop: currentToken stop.
-			errorNode value: ':' , currentToken source.
+			errorNode value: errorNode value , currentToken source.
 			self step ] ].
 
 	^ errorNode

--- a/src/EnlumineurFormatter/EFFormatter.class.st
+++ b/src/EnlumineurFormatter/EFFormatter.class.st
@@ -2134,12 +2134,13 @@ EFFormatter >> visitCascadeNode: aCascadeNode [
 
 { #category : #visiting }
 EFFormatter >> visitEnglobingErrorNode: aNode [
+
 	self writeString: aNode value.
+	self formatBlockArgumentsFor: aNode.
 	aNode children do: [ :e |
 		codeStream space.
 		self visitNode: e ].
-	self writeString: aNode valueAfter.
-
+	self writeString: aNode valueAfter
 ]
 
 { #category : #visiting }

--- a/src/EnlumineurFormatter/EFFormatter.class.st
+++ b/src/EnlumineurFormatter/EFFormatter.class.st
@@ -1187,8 +1187,8 @@ EFFormatter >> formatBlockArgumentsFor: aBlockNode [
 	onAnotherLine := self areArgumentsTooLong: args.
 	args do: [ :each |
 		onAnotherLine ifTrue: [ self newLine ].
-		codeStream nextPut: $:.
-		self visitVariableNode: each.
+		each isParseError ifFalse: [ codeStream nextPut: $: ].
+		each acceptVisitor: self.
 		self formatCommentCloseToStatements ifTrue: [
 			self spaceAndFormatComments: each ].
 		self space ].


### PR DESCRIPTION
Some work on the parsing of variable (temps and block arguments).

Most work is aimed at removing FIXME in `RBCodeSnippet class >> #badExpressions`

Main changes are:
* Bad temps and blocks args are preserved in the faulty ast and in formatted code
* `BRParser>>#nextBar` to simplify the code (and make it less random) when dealing with `|` as separator
* unexpected block parameters declaration `:foo` are treated like a bad variable.

See individual commits for details.