### PR TITLE
12858-CopiedLocalVariable-answers-false-to-isTemporaryVariable-even-when-it-is 

### DIFF
--- a/src/OpalCompiler-Core/CopiedLocalVariable.class.st
+++ b/src/OpalCompiler-Core/CopiedLocalVariable.class.st
@@ -3,7 +3,7 @@ A copied variable is an arg or temp var that is copied into a block that later r
 "
 Class {
 	#name : #CopiedLocalVariable,
-	#superclass : #LocalVariable,
+	#superclass : #TemporaryVariable,
 	#instVars : [
 		'originalVar'
 	],

--- a/src/OpalCompiler-Tests/OCASTClosureAnalyzerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTClosureAnalyzerTest.class.st
@@ -282,7 +282,8 @@ OCASTClosureAnalyzerTest >> testOptimizedBlockReadInBlock [
 
 	self assert: ast scope tempVars size equals: 1.
 	self assert: ast scope tempVector size equals: 0.
-	self deny: (ast scope lookupVar: 't1') isRemote
+	self deny: (ast scope lookupVar: 't1') isRemote.
+	self assert: (ast scope lookupVar: 't1') isTempVariable
 ]
 
 { #category : #'tests - special cases' }


### PR DESCRIPTION
- change superclass of CopiedLocalVariable to TemporaryVariable 
- add a test by enhancing testOptimizedBlockReadInBlock

(did not rename it to CopiedTempVariable, we could think about that)

fixes #12858