### PR TITLE
RBCodeSnippet nice overview of error messages

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -274,7 +274,7 @@ RBCodeSnippet class >> styleAll [
 	<script>
 	| bigtext |
 	bigtext := Text new.
-	self badExpressions do: [ :each |
+	self allSnippets do: [ :each |
 		bigtext ifNotEmpty: [ bigtext append: String cr ].
 		bigtext append: each styledText ].
 	bigtext inspect

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -269,7 +269,7 @@ RBCodeSnippet class >> badExpressions [
 { #category : #script }
 RBCodeSnippet class >> styleAll [
 	"Display all snippets in a big styled text.
-	Each sniped is styled independently."
+	Each snipped is styled independently."
 
 	<script>
 	| bigtext |
@@ -277,6 +277,59 @@ RBCodeSnippet class >> styleAll [
 	self badExpressions do: [ :each |
 		bigtext ifNotEmpty: [ bigtext append: String cr ].
 		bigtext append: each styledText ].
+	bigtext inspect
+]
+
+{ #category : #script }
+RBCodeSnippet class >> styleAllWithError [
+	"Display all snippets in a big styled text with compilation error messages and error nodes.
+	Each compilation error message and each error node is displayed indenpendently."
+
+	<script>
+	| bigtext |
+	bigtext := Text new.
+	self badExpressions do: [ :each |
+		| text ast |
+		bigtext ifNotEmpty: [ bigtext append: String cr ].
+
+		"Get the original styled text"
+		text := each styledText.
+		bigtext append: text.
+
+		"Try to compile it"
+		[
+		OpalCompiler new
+			noPattern: true;
+			compile: each source ]
+			on: SyntaxErrorNotification
+			do: [ :exception |
+				"In case of error, insert error message (like an old-school smalltalk compiler)"
+				text
+					replaceFrom: exception location
+					to: exception location - 1
+					with: (exception errorMessage asText addAttribute:
+							 (TextBackgroundColor color: Color lightBlue)).
+				bigtext append: String cr.
+				bigtext append: String tab.
+				bigtext append: text. ].
+
+		"Then the fun part. Add line for each error node"
+		ast := each parse.
+		ast nodesDo: [ :node |
+			node isParseError ifTrue: [
+				text := each styledText.
+				text
+					addAttribute: (TextBackgroundColor color: Color cyan)
+					from: node start
+					to: (node stop min: text size).
+				text append: '    '.
+				text append: node errorMessage.
+				text append: '  ('.
+				text append: node class name.
+				text append: ')'.
+				bigtext append: String cr.
+				bigtext append: String tab.
+				bigtext append: text ] ] ].
 	bigtext inspect
 ]
 

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -288,8 +288,8 @@ RBCodeSnippet class >> styleAllWithError [
 	<script>
 	| bigtext |
 	bigtext := Text new.
-	self badExpressions do: [ :each |
-		| text ast |
+	self allSnippets do: [ :each |
+		| text ast stop |
 		bigtext ifNotEmpty: [ bigtext append: String cr ].
 
 		"Get the original styled text"
@@ -315,21 +315,29 @@ RBCodeSnippet class >> styleAllWithError [
 
 		"Then the fun part. Add line for each error node"
 		ast := each parse.
-		ast nodesDo: [ :node |
+		ast nodesPostorderDo: [ :node |
 			node isParseError ifTrue: [
 				text := each styledText.
+				stop := node stop min: text size.
+				"Highlight the error node background"
 				text
 					addAttribute: (TextBackgroundColor color: Color cyan)
 					from: node start
-					to: (node stop min: text size).
-				text append: '    '.
-				text append: node errorMessage.
-				text append: '  ('.
-				text append: node class name.
-				text append: ')'.
+					to: stop.
+				"Insert the message after the stop so that:
+				 1. we can see where are zero-width errors
+				 2. we have the same output than the compiler error (above)"
+				text
+					replaceFrom: stop + 1
+					to: stop
+					with: (node errorMessage asText addAttribute:
+							 (TextBackgroundColor color: Color lightBlue)).
 				bigtext append: String cr.
 				bigtext append: String tab.
-				bigtext append: text ] ] ].
+				bigtext append: text.
+				bigtext append: '   '.
+				bigtext append: (node class name asText makeAllColor: Color gray).
+		] ] ].
 	bigtext inspect
 ]
 

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -842,6 +842,14 @@ RBProgramNode >> nodesDo: aBlock [
 	self children do: [ :each | each nodesDo: aBlock ]
 ]
 
+{ #category : #iterating }
+RBProgramNode >> nodesPostorderDo: aBlock [
+	"Like RBProgramNode>>#nodesDo: but visit children first"
+
+	self children do: [ :each | each nodesPostorderDo: aBlock ].
+	aBlock value: self
+]
+
 { #category : #accessing }
 RBProgramNode >> parent [
 	^parent


### PR DESCRIPTION
Add a script to see at glance the current state of the work on faulty error parsing

![Capture d’écran du 2023-02-27 16-03-01](https://user-images.githubusercontent.com/135828/221685477-23ba06ba-5732-40b2-9cce-ede40449ba60.png)

Note: it should even be better once https://github.com/pharo-spec/NewTools/pull/468 is merged