### PR TITLE
EFFormatter use parenthesis on error nodes if some were present

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -80,7 +80,7 @@ RBCodeSnippet class >> badExpressions [
 
 		"...or without expected thing"
 		"Note: all compounds `[]` `#()` `#[]` `{}` are legal empty, except one"
-		self new source: '()'; formattedCode: ''. "Errr... I understand but I do not like it"
+		self new source: '()'.
 
 		"Bad sequence. The first expression is considered unfinished."
 		self new source: '1 2'; formattedCode: ' 1.<r>2'.

--- a/src/EnlumineurFormatter/EFFormatter.class.st
+++ b/src/EnlumineurFormatter/EFFormatter.class.st
@@ -1678,7 +1678,7 @@ EFFormatter >> needsParenthesisFor: aNode [
 	aNode isValue
 		ifFalse: [ ^ false ].
 	aNode isParseError
-		ifTrue: [ ^ false ].
+		ifTrue: [ ^ aNode hasParentheses ].
 	parent := aNode parent ifNil: [ ^ false ].
 	(aNode isMessage
 		and: [ parent isMessage


### PR DESCRIPTION
Since the precedence is unreliable on error nodes, better keep what the user used.