### PR TITLE
Do not stack RBUnfinishedStatementErrorNode

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -62,12 +62,15 @@ RBCodeSnippet class >> badExpressions [
 		self new source: '#['.
 		self new source: '{'.
 
+		self new source: '{ [ ( '.
+		self new source: '  )]}'.
+
 		"Compounds with an unexped thing inside"
-		self new source: '(1]2)'; formattedCode: '  ( 1].<r> 2)'.
-		self new source: '(1}2)'; formattedCode: '  ( 1}.<r> 2)'.
+		self new source: '(1]2)'; formattedCode: ' ( 1].<r> 2)'.
+		self new source: '(1}2)'; formattedCode: ' ( 1}.<r> 2)'.
 		self new source: '(1. 2)'; formattedCode: '( 1.<r> 2)'.
-		self new source: '[1)2]'; formattedCode: '[<r>  1).<r>2 ]'.
-		self new source: '[1}2]'; formattedCode: '[<r>  1}.<r>2 ]'.
+		self new source: '[1)2]'; formattedCode: '[<r> 1).<r>2 ]'.
+		self new source: '[1}2]'; formattedCode: '[<r> 1}.<r>2 ]'.
 		self new source: '#(1]2}3)'; formattedCode:'#( 1 #'']'' 2 #''}'' 3 )'; isFaulty: false; value: #(1]2}3). "`#(` can eat almost anything"
 		self new source: '#[ 1 ) 2]'.
 		self new source: '#[ 1 } 2]'.
@@ -75,8 +78,8 @@ RBCodeSnippet class >> badExpressions [
 		self new source: '#[ 1 -1 2]'.
 		self new source: '#[ 1 1.0 2]'.
 		self new source: '#[ 1 256 2]'.
-		self new source: '{1)2}'; formattedCode: '{<r><t>  1).<r><t>2 }'.
-		self new source: '{1]2}'; formattedCode: '{<r><t>  1].<r><t>2 }'.
+		self new source: '{1)2}'; formattedCode: '{<r><t> 1).<r><t>2 }'.
+		self new source: '{1]2}'; formattedCode: '{<r><t> 1].<r><t>2 }'.
 
 		"...or without expected thing"
 		"Note: all compounds `[]` `#()` `#[]` `{}` are legal empty, except one"

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -1019,11 +1019,13 @@ RBParser >> parseStatementInto: statementList periodList: periods withAcceptedSt
 	"Next we should have the end of the statement
 	  - a dot or
 	  - an accepted scope closer e.g., )]} or
-	  - or the end of the stream.
-	If it is neither, we should mark our statement as unfinished statement."
+	  - the end of the stream.
+	If it is neither, we should mark our statement as unfinished statement.
+	And we do not stack unfinished statements."
 	(currentToken value ~= $.
 		and: [ (aCollectionOfClosers includes: currentToken value) not
-			and: [ currentToken isEOF not ] ] ) ifTrue: [
+			and: [ currentToken isEOF not
+				and: [ node isUnfinishedStatement not ] ] ] ) ifTrue: [
 		self parserError: 'End of statement expected'.
 		node := RBUnfinishedStatementErrorNode
 			contents: { node }


### PR DESCRIPTION
Add a guard to avoid stacking RBUnfinishedStatementErrorNode objects.

It could happen is a previous error is a compound without a closing, for instance.