### PR TITLE
Rewrite some error messages to follow the style `Foo expected`

### DIFF
--- a/src/AST-Core-Tests/RBErrorNodeParserTest.class.st
+++ b/src/AST-Core-Tests/RBErrorNodeParserTest.class.st
@@ -381,7 +381,7 @@ RBErrorNodeParserTest >> testFaultyLiterabByteArray [
 	self assert: node contents second isFaulty.
 	self assert: node contents second value equals: 'hello'.
 	self assert: node contents second sourceInterval equals: (6 to: 10).
-	self assert: node contents second errorMessage equals: 'Expecting 8-bit integer'.
+	self assert: node contents second errorMessage equals: '8-bit integer expected'.
 	self assert: node contents second formattedCode equals: 'hello'.
 
 	self deny: node contents third isFaulty.

--- a/src/AST-Core-Tests/RBScannerTest.class.st
+++ b/src/AST-Core-Tests/RBScannerTest.class.st
@@ -358,7 +358,7 @@ RBScannerTest >> testNextDollarSignExpectedACharacter [
 	| scanner token |
 	scanner := self buildScannerForText: '$'.
 	token := scanner next.
-	self assert: token cause equals: 'A Character was expected'
+	self assert: token cause equals: 'Character expected'
 ]
 
 { #category : #'tests - Error' }
@@ -802,7 +802,7 @@ RBScannerTest >> testNextLiteralBeginningWithDigitThrowsError [
 	token := scanner next.
 	self assert: token isError.
 	self assert: token value equals: '#'.
-	self assert: token cause equals: 'Expecting a literal type'
+	self assert: token cause equals: 'Literal expected'
 ]
 
 { #category : #'tests - Error' }
@@ -812,7 +812,7 @@ RBScannerTest >> testNextLiteralBeginningWithSpecialThrowsError [
 	token := scanner next.
 	self assert: token isError.
 	self assert: token value equals: '#'.
-	self assert: token cause equals: 'Expecting a literal type'
+	self assert: token cause equals: 'Literal expected'
 ]
 
 { #category : #'tests - Error' }
@@ -822,7 +822,7 @@ RBScannerTest >> testNextLiteralBeginningWithUnknownThrowsError [
 	token := scanner next.
 	self assert: token isError.
 	self assert: token value equals: '#'.
-	self assert: token cause equals: 'Expecting a literal type'
+	self assert: token cause equals: 'Literal expected'
 ]
 
 { #category : #'tests - Literal' }
@@ -955,7 +955,7 @@ RBScannerTest >> testNextLiteralCharacterWithAMissingCharacter [
 	source := '$'.
 	scanner := self buildScannerForText: source.
 	scannedToken := scanner next.
-	self verifyErrorToken: scannedToken message: 'A Character was expected' translated valueExpected: '$'
+	self verifyErrorToken: scannedToken message: 'Character expected' translated valueExpected: '$'
 ]
 
 { #category : #'tests - Start' }

--- a/src/AST-Core-Tests/RBScannerTest.class.st
+++ b/src/AST-Core-Tests/RBScannerTest.class.st
@@ -1526,7 +1526,7 @@ RBScannerTest >> testNextWithAWrongSymbolGetError [
 	source := '#^'.
 	scanner := self buildScannerForText: source.
 	scannedToken := scanner next.
-	self verifyErrorToken: scannedToken message: 'Expecting a literal type' translated valueExpected: '#'
+	self verifyErrorToken: scannedToken message: 'Literal expected' translated valueExpected: '#'
 ]
 
 { #category : #tests }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -301,7 +301,7 @@ RBParser >> parseArray [
 	node left: startToken start.
 	self parseStatementList: false  into: node untilAnyCloserOf: '}'.
 	(currentToken isSpecial: $})
-		ifFalse: [ ^ self parseEnglobingError: node statements with: startToken errorMessage: 'expected }'].
+		ifFalse: [ ^ self parseEnglobingError: node statements with: startToken errorMessage: '''}'' expected'].
 	node right: currentToken start.
 	self step.
 	^ node
@@ -314,7 +314,7 @@ RBParser >> parseAssignment [
 
 	| node position |
 	currentToken isAssignment ifTrue: [
-		self parserError: 'identifier expected in assigment'.
+		self parserError: 'Variable expected'.
 		position := currentToken start.
 		self step. "Consume the :="
 		node := self parseAssignment. "parse the right side".
@@ -445,10 +445,10 @@ RBParser >> parseBlockArgsInto: node [
 									currentToken
 										value: #|;
 										start: currentToken start + 1]
-								ifFalse: [ args add:(self parserError: '''|'' expected')]]]
+								ifFalse: [ args add:(self parserError: '''|'' or parameter expected')]]]
 				ifFalse:
 					[(currentToken isSpecial: $])
-						ifFalse: [ args add:(self parserError: '''|'' expected')]]].
+						ifFalse: [ args add:(self parserError: '''|'' or parameter expected')]]].
 	node
 		arguments: args;
 		colons: colons.
@@ -480,7 +480,7 @@ RBParser >> parseCascadeMessage [
 		"Cut parsing with an error.
 		If in faulty mode, continue the execution and generate a faulty cascade node.
 		Note that this bad cascade node will be added to the list of messages."
-		self parserError: 'cascaded message not allowed'.
+		self parserError: 'Message expected'.
 		node := RBInvalidCascadeErrorNode
 			contents: { node }
 			start: node start
@@ -739,7 +739,7 @@ RBParser >> parseLiteralByteArrayObject [
 			[currentToken value isInteger and: [currentToken value between: 0 and: 255]])
 		ifFalse: [
 			| errorNode |
-			errorNode := self parserError: 'Expecting 8-bit integer'.
+			errorNode := self parserError: '8-bit integer expected'.
 			"Error recovery: consume the token as classic literal array object"
 			errorNode value: self parseLiteralArrayObject value asString.
 			^ errorNode ].
@@ -1120,7 +1120,7 @@ RBParser >> parseTemporariesInto: aSequenceNode [
 					self step.
 					temps := self parseTemps.
 					(currentToken isBinary and: [currentToken value = #|])
-						ifFalse: [ errorNode :=  self parseEnglobingError: temps with: startToken errorMessage: '''|'' expected'.
+						ifFalse: [ errorNode :=  self parseEnglobingError: temps with: startToken errorMessage: '''|'' or variable expected'.
 									 aSequenceNode addFaultyNode: errorNode.
 									 temps := OrderedCollection new.
 									 leftBar := nil.

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -467,7 +467,7 @@ RBScanner >> scanLiteral [
 	"Accept multiple #."
 	currentCharacter = $#
 		ifTrue: [ ^ self scanLiteral ].
-	^ (self scanError: 'Expecting a literal type') value: '#'
+	^ (self scanError: 'Literal expected') value: '#'
 ]
 
 { #category : #'private - scanning' }
@@ -494,7 +494,7 @@ RBScanner >> scanLiteralCharacter [
 	"'$$' is a correct string to be scanned and the second $ mustn't trigger a new scan."
 	| token |
 	self step.	"$"
-	currentCharacter ifNil:[ ^ (self scanError:'A Character was expected') value: '$'].
+	currentCharacter ifNil:[ ^ (self scanError:'Character expected') value: '$'].
 	token := RBLiteralToken
 				value: currentCharacter
 				start: tokenStart

--- a/src/OpalCompiler-Tests/OCCompilerNotifyingTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerNotifyingTest.class.st
@@ -157,7 +157,7 @@ OCCompilerNotifyingTest >> testInvalidExternalFunctionDeclaration [
 
 { #category : #tests }
 OCCompilerNotifyingTest >> testInvalidLiteralCharacter [
-	self setUpForErrorsIn: '^ #yourself , #` Expecting a literal type ->`) , #end'.
+	self setUpForErrorsIn: '^ #yourself , #` Literal expected ->`) , #end'.
 	self enumerateAllSelections
 ]
 
@@ -239,14 +239,14 @@ OCCompilerNotifyingTest >> testMissingPeriodSeparatorBetweenStatements [
 { #category : #tests }
 OCCompilerNotifyingTest >> testMissingSeparatorBetweenBlockArgumentAndStatements [
 
-	self setUpForErrorsIn: '[ :x ` ''|'' expected ->`x + 1 ]'.
+	self setUpForErrorsIn: '[ :x ` ''|'' or parameter expected ->`x + 1 ]'.
 	self enumerateAllSelections
 ]
 
 { #category : #tests }
 OCCompilerNotifyingTest >> testTooLargeAnIntegerInALiteralByteArray [
 
-	self setUpForErrorsIn: '#[ 1 2 ` Expecting 8-bit integer ->`256 4 5]'.
+	self setUpForErrorsIn: '#[ 1 2 ` 8-bit integer expected ->`256 4 5]'.
 	self enumerateAllSelections
 ]
 
@@ -273,9 +273,9 @@ OCCompilerNotifyingTest >> testUnmatchedBlockBracket [
 
 { #category : #tests }
 OCCompilerNotifyingTest >> testUnmatchedBraceArray [
-	self setUpForErrorsIn: '{ 1. 2` expected } ->`'.
+	self setUpForErrorsIn: '{ 1. 2` ''}'' expected ->`'.
 	self enumerateAllSelections.
-	self setUpForErrorsIn: '{ 1. 2 ` expected } ->`'.
+	self setUpForErrorsIn: '{ 1. 2 ` ''}'' expected ->`'.
 	self enumerateAllSelections
 ]
 
@@ -312,14 +312,14 @@ OCCompilerNotifyingTest >> testUnmatchedLiteralParenthesis [
 { #category : #tests }
 OCCompilerNotifyingTest >> testUnmatchedLocalTempDeclaration [
 
-	self setUpForErrorsIn: '| x y ` ''|'' expected ->`'.
+	self setUpForErrorsIn: '| x y ` ''|'' or variable expected ->`'.
 	self enumerateAllSelections
 ]
 
 { #category : #tests }
 OCCompilerNotifyingTest >> testUnmatchedLocalTempDeclarationInABlock [
 
-	self setUpForErrorsIn: '[:z | | x y ` ''|'' expected ->`]'.
+	self setUpForErrorsIn: '[:z | | x y ` ''|'' or variable expected ->`]'.
 	self enumerateAllSelections
 ]
 


### PR DESCRIPTION
The format `Foo expected` (with an uppercase, no article and no verb) is used on almost all error messages. This PR changes some noncompliant ones.

Also, on `| expected`, `varable` or `parameter` are added, because they are also expected, and because it helps to understand the context.

Note: this PR might conflict with #12868, so merge the other before.
You might consider reviewing this one in the meantime.