### PR TITLE
HotFix. Restore `RBScanner>>#parseErrorNode:`

### DIFF
--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -302,6 +302,18 @@ RBScanner >> on: aStream [
 	comments := OrderedCollection new
 ]
 
+{ #category : #parsing }
+RBScanner >> parseErrorNode: aMessageString [
+	"This method might be called indirectly by errorBlocks.
+	especially by `RBParser class>>#errorNodeBlock` since the parser share its
+	error blocks with the scanner."
+
+	| sourceString |
+	sourceString := stream contents copyFrom: self errorPosition to: stream contents size.
+	^ RBParseErrorNode
+		errorMessage: aMessageString value: sourceString at: self errorPosition
+]
+
 { #category : #private }
 RBScanner >> previousStepPosition [
 	^characterType = #eof


### PR DESCRIPTION
#12861 removed code without client... except there was some unexpected clients

MNU was thus raised if, for instance, you mistakenly have unclosed strings or comments in a text editor, even for a short time while editing. It is not a big deal, but annoying.

This PR is a hot fix that restore the removed method (with an additional comment for good measure).
A followup PR might come later with regression tests to catch such a breakage in the future.