### PR TITLE
Improve faulty parsing of methods

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -139,10 +139,10 @@ RBCodeSnippet class >> badExpressions [
 		"Bad block parameters"
 		"A bad parameter cause a error object to be added as the last element of the block parameter.
 		On formating, a double space can be seen."
-		self new source: '[:a b]'; formattedCode: '[ :a : | b ]'; skip: #testExecute.
-		self new source: '[:a 1]'; formattedCode: '[ :a : | 1 ]'; skip: #testExecute.
-		self new source: '[:a :]'; formattedCode: '[ :a : |  ]'; skip: #testExecute.
-		self new source: '[:a ::b]'; formattedCode: '[ :a : :b |  ]'; skip: #testExecute.
+		self new source: '[:a b]'; formattedCode: '[ :a : | b ]'; hasValue: true. "FIXME"
+		self new source: '[:a 1]'; formattedCode: '[ :a : | 1 ]'; hasValue: true; value: 1. "FIXME"
+		self new source: '[:a :]'; formattedCode: '[ :a : |  ]'; hasValue: true. "FIXME"
+		self new source: '[:a ::b]'; formattedCode: '[ :a : :b |  ]'; hasValue: true. "FIXME"
 		self new source: '[:a :b]'; formattedCode: '[ :a :b |  ]'; isFaulty: false. "no pipe (and no body) is legal"
 		self new source: '[: a : b]'; formattedCode: '[ :a :b |  ]'; isFaulty: false. "spaces are also legal"
 		self new source: '[:a:b]'; formattedCode: '[ : : |  a: b ]'. "FIXME"

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -35,7 +35,7 @@ Class {
 { #category : #accessing }
 RBCodeSnippet class >> allSnippets [
 
-	^ self badExpressions
+	^ self badExpressions, self badMethods
 ]
 
 { #category : #accessing }
@@ -270,6 +270,68 @@ RBCodeSnippet class >> badExpressions [
 		each formattedCode
 			ifNil: [ each formattedCode: each source ]
 			ifNotNil: [ each formattedCode: each formattedCode expandMacros ].
+	].
+	^ list
+]
+
+{ #category : #accessing }
+RBCodeSnippet class >> badMethods [
+
+	| list |
+	list := {
+		"Emptyness"
+		self new source: ' '.
+
+		"Wrong token for pattern"
+		"An empty pattern will be set, and the first statement will be a error node."
+		self new source: '5'; formattedCode: ' . 5'.
+		self new source: '''hello'''; formattedCode: ' . ''hello'''.
+		self new source: '#hello'; formattedCode: ' . #hello'.
+		self new source: ':'; formattedCode: ' . :'.
+		self new source: '#(foo bar)'; formattedCode: ' . #( foo bar )'.
+
+		"Random bad token"
+		"Tought: is complainng about the bad token really better than complaining about the bad pattern?"
+		self new source: ' $'.
+		self new source: ' ''hello'.
+		self new source: ' 2r3'; formattedCode: ' 2r. 3'.
+
+		"Bad aruments"
+		"The missing argument will be an error, the remainer starts the body"
+		self new source: '+ '; hasValue: true.
+		self new source: '+ 1'; hasValue: true.
+		self new source: '+ foo: '.
+		self new source: 'foo: '; hasValue: true.
+		self new source: 'foo: 1'; hasValue: true.
+		self new source: 'foo: + '.
+		self new source: 'foo: bar: '; hasValue: true.
+		self new source: 'foo:bar:'; formattedCode: ' . foo:bar:'. "`foo:bar:` is a single token, and is unexpected"
+
+		"Bad pragma message"
+		self new source: 'foo < '; hasValue: true.
+		self new source: 'foo <> '.
+		self new source: 'foo < 4'; hasValue: true.
+		self new source: 'foo < bar '; hasValue: true.
+		self new source: 'foo < bar: '; hasValue: true.
+		self new source: 'foo < bar: 1 1 > '.
+		self new source: 'foo < bar ; baz > '; formattedCode: 'foo < bar ; baz. > '.
+
+		"Bad pragma value"
+		self new source: 'foo <bar: > '; hasValue: true.
+		self new source: 'foo <bar:(1)>'; formattedCode: 'foo < bar: 1 > '. "FIXME. dont eat parentheses"
+		self new source: 'foo < bar: baz > '.
+		self new source: 'foo < bar: 1 + 1 > '.
+		self new source: 'foo < bar: [ 1 ] > '.
+		self new source: 'foo < bar: { 1 } > '.
+		self new source: 'foo <bar: #[ -1]> '; hasValue: true. "Literal bytes arrays are acceptable, but this one is faulty"
+		self new source: 'foo < + 1> '; isFaulty: false. "Binary message is legal pragma"
+		self new source: 'foo < + > '; hasValue: true.
+		}.
+	"Setup default values"
+	list do: [ :each |
+		each isMethod: true.
+		each isFaulty ifNil: [ each isFaulty: true ].
+		each formattedCode ifNil: [ each formattedCode: each source ].
 	].
 	^ list
 ]

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -7,6 +7,7 @@ See `RBCodeSnippet allSnippets` for a various collection of instances.
 * formatedCode <String> the expected reformated code
 * isFaulty <Boolean> is the parser expected to produce a faulty AST 
 * value <Object> the expected value when executed
+* hasValue <Boolean> is the compiled method produce a value
 * messageNotUnderstood <Symbol> the expected MNU error when executed
 * skippedTests <Collection> list of test to not execute (that should be fixed)
 
@@ -21,6 +22,7 @@ Class {
 		'source',
 		'isFaulty',
 		'value',
+		'hasValue',
 		'formattedCode',
 		'skippedTests',
 		'messageNotUnderstood'
@@ -354,6 +356,18 @@ RBCodeSnippet >> formattedCode [
 RBCodeSnippet >> formattedCode: anObject [
 
 	formattedCode := anObject
+]
+
+{ #category : #accessing }
+RBCodeSnippet >> hasValue [
+
+	^ hasValue ifNil: [ value isNotNil | isFaulty not ]
+]
+
+{ #category : #accessing }
+RBCodeSnippet >> hasValue: anObject [
+
+	hasValue := anObject
 ]
 
 { #category : #asserting }

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -4,6 +4,7 @@ Small pieces of source code used used to test various AST based tools.
 See `RBCodeSnippet allSnippets` for a various collection of instances.
 
 * source <String> the source code of the snippet
+* isMethod <Boolean> the source is for a full method (with pattern and maybe pragmas)
 * formatedCode <String> the expected reformated code
 * isFaulty <Boolean> is the parser expected to produce a faulty AST 
 * value <Object> the expected value when executed
@@ -20,6 +21,7 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'source',
+		'isMethod',
 		'isFaulty',
 		'value',
 		'hasValue',
@@ -263,6 +265,7 @@ RBCodeSnippet class >> badExpressions [
 		}.
 	"Setup default values"
 	list do: [ :each |
+		each isMethod: false.
 		each isFaulty ifNil: [ each isFaulty: true ].
 		each formattedCode
 			ifNil: [ each formattedCode: each source ]
@@ -391,6 +394,18 @@ RBCodeSnippet >> isFaulty: anObject [
 ]
 
 { #category : #accessing }
+RBCodeSnippet >> isMethod [
+
+	^ isMethod
+]
+
+{ #category : #accessing }
+RBCodeSnippet >> isMethod: anObject [
+
+	isMethod := anObject
+]
+
+{ #category : #accessing }
 RBCodeSnippet >> messageNotUnderstood [
 
 	^ messageNotUnderstood
@@ -404,7 +419,9 @@ RBCodeSnippet >> messageNotUnderstood: anObject [
 
 { #category : #parsing }
 RBCodeSnippet >> parse [
-	^ RBParser parseFaultyExpression: self source
+	^ isMethod
+		ifTrue: [ RBParser parseFaultyMethod: self source ]
+		ifFalse: [ RBParser parseFaultyExpression: self source ]
 ]
 
 { #category : #printing }

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -369,7 +369,7 @@ RBCodeSnippet class >> styleAllWithError [
 		"Try to compile it"
 		[
 		OpalCompiler new
-			noPattern: true;
+			noPattern: each isMethod not;
 			compile: each source ]
 			on: SyntaxErrorNotification
 			do: [ :exception |

--- a/src/AST-Core-Tests/RBCodeSnippetTest.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippetTest.class.st
@@ -78,14 +78,16 @@ RBCodeSnippetTest >> testParse [
 { #category : #tests }
 RBCodeSnippetTest >> testParseOnError [
 
+	| error |
+	error := nil.
+
+	[snippet isMethod
+			ifTrue: [ RBParser parseMethod: snippet source ]
+			ifFalse: [ RBParser parseExpression: snippet source ] ]
+		on: SyntaxErrorNotification
+		do: [ :e | error := e errorMessage ].
+
 	snippet isFaulty
-		ifTrue: [
-			RBParser
-				parseExpression: snippet source
-				onError: [ :message :parser :position | ^ self ].
-			self signalFailure: 'An error is expected' ]
-		ifFalse: [
-			RBParser
-				parseExpression: snippet source
-				onError: [ :message | ^ self signalFailure: 'Error unexpected: ', message ] ]
+		ifTrue: [ self deny: error equals: nil ]
+		ifFalse: [ self assert: error equals: nil ]
 ]

--- a/src/AST-Core-Tests/RBCodeSnippetTest.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippetTest.class.st
@@ -64,7 +64,9 @@ RBCodeSnippetTest >> testDump [
 { #category : #tests }
 RBCodeSnippetTest >> testFormattedCode [
 
-	self assert: snippet parse formattedCode equals: snippet formattedCode
+	| ast |
+	ast := snippet parse.
+	self assert: ast formattedCode withSeparatorsCompacted equals: snippet formattedCode withSeparatorsCompacted
 ]
 
 { #category : #tests }

--- a/src/AST-Core-Tests/RBErrorNodeParserTest.class.st
+++ b/src/AST-Core-Tests/RBErrorNodeParserTest.class.st
@@ -461,7 +461,7 @@ RBErrorNodeParserTest >> testFaultyMethodWithoutSignatureHasAnErrorNodeAndContin
 	node := self parserClass parseFaultyMethod: '1 between: 2 and: 3'.
 
 	self assert: node isMethod.
-	self assert: node selector equals: #faulty.
+	self assert: node selector equals: #''.
 
 	self assert: node body statements first isParseError.
 

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -808,13 +808,23 @@ RBParser >> parseParenthesizedExpression [
 { #category : #'private - parsing' }
 RBParser >> parsePragma [
 	"Method called by parsePragmas which already verified that current token is the special character <"
+
 	| startToken pragma |
 	startToken := currentToken.
 	self step.
 	pragma := self basicParsePragma.
-	(currentToken isBinary and: [ currentToken value == #> ])
-		ifFalse: [  ^self addPragma: ( self parseEnglobingError: (OrderedCollection with: pragma) with: startToken errorMessage: '''>'' expected')].
-	pragma left: startToken start; right: currentToken start.
+	(currentToken isBinary and: [ currentToken value == #> ]) ifFalse: [
+		pragma := self
+			          parseEnglobingError: (OrderedCollection with: pragma)
+			          with: startToken
+			          errorMessage: '''>'' expected'.
+		pragma stop: currentToken stop.
+		^ self addPragma: pragma ].
+
+	pragma
+		left: startToken start;
+		right: currentToken start.
+	self step.
 	self addPragma: pragma
 ]
 
@@ -833,9 +843,9 @@ RBParser >> parsePragmaLiteral [
 
 { #category : #'private - parsing' }
 RBParser >> parsePragmas [
-	[ currentToken isBinary and: [ currentToken value = #< ] ] whileTrue: [
-		self parsePragma.
-		self step ]
+
+	[ currentToken isBinary and: [ currentToken value = #< ] ]
+		whileTrue: [ self parsePragma ]
 ]
 
 { #category : #'private - parsing' }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -366,7 +366,7 @@ RBParser >> parseBinaryPattern [
 	currentToken isBinary
 		ifFalse: [
 		^ self methodNodeClass
-			selector: #faulty
+			selector: #''
 			arguments: #()
 			body: (self sequenceNodeClass statements: (OrderedCollection with: (self parserError: 'Message pattern expected')))].
 

--- a/src/AST-Core/RBPragmaErrorNode.class.st
+++ b/src/AST-Core/RBPragmaErrorNode.class.st
@@ -25,3 +25,8 @@ RBPragmaErrorNode class >> error: aToken withNodes: aCollection [
 RBPragmaErrorNode >> isPragmaError [
 	^true
 ]
+
+{ #category : #testing }
+RBPragmaErrorNode >> isPrimitive [
+	^false
+]

--- a/src/EnlumineurFormatter/EFFormatter.class.st
+++ b/src/EnlumineurFormatter/EFFormatter.class.st
@@ -2229,15 +2229,20 @@ EFFormatter >> visitPatternWrapperBlockNode: aRBPatternWrapperBlockNode [
 
 { #category : #visiting }
 EFFormatter >> visitPragmaNode: aPragmaNode [
-	codeStream nextPut: $<.
-	self 
-		formatSelectorAndArguments: aPragmaNode 
-		firstSeparator: [ 
+
+	| hackNoBrackets |
+	"If the parent is an error, the '<' and '>' are already taken care of."
+	hackNoBrackets := aPragmaNode parent isNotNil and: [ aPragmaNode parent isEnglobingError ].
+
+	hackNoBrackets ifFalse: [ codeStream nextPut: $< ].
+	self
+		formatSelectorAndArguments: aPragmaNode
+		firstSeparator: [
 			aPragmaNode selector isInfix
 				ifTrue: [ self space ] ]
 		restSeparator: [ self space ].
 	self addSpaceIfNeededForLastArgument: aPragmaNode.
-	codeStream nextPut: $>
+	hackNoBrackets ifFalse: [ codeStream nextPut: $> ]
 ]
 
 { #category : #visiting }

--- a/src/EnlumineurFormatter/EFFormatter.class.st
+++ b/src/EnlumineurFormatter/EFFormatter.class.st
@@ -1258,8 +1258,10 @@ EFFormatter >> formatMethodPatternFor: aMethodNode [
 
 { #category : #'private - formatting' }
 EFFormatter >> formatPragmasFor: aMethodNode [
-	
-	aMethodNode pragmas do: [ :each | self visitPragmaNode: each; newLine ]
+
+	aMethodNode pragmas do: [ :each |
+		each acceptVisitor: self.
+		self newLine ]
 ]
 
 { #category : #'private - formatting' }

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -676,6 +676,7 @@ OCASTTranslator >> visitParseErrorNode: anErrorNode [
 OCASTTranslator >> visitPragmaNode: aPragmaNode [
 
 	| var |
+	aPragmaNode isParseError ifTrue: [ ^self ].
 	methodBuilder addPragma: aPragmaNode asPragma.
 
 	"if the pragma is a primitive that defines an error variable, we need to store error value

--- a/src/OpalCompiler-Tests/RBCodeSnippet.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippet.extension.st
@@ -5,6 +5,6 @@ RBCodeSnippet >> compile [
 
 	^ OpalCompiler new
 		  options: #( #optionParseErrors );
-		  noPattern: true;
+		  noPattern: isMethod not;
 		  compile: self source
 ]

--- a/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
@@ -11,24 +11,27 @@ RBCodeSnippetTest >> testCompile [
 { #category : #'*OpalCompiler-Tests' }
 RBCodeSnippetTest >> testExecute [
 
-	| method runBlock |
+	| method runBlock phonyArgs |
 	self skipIf: #testExecute.
 	method := snippet compile.
 	self assert: method isCompiledMethod.
 
+	phonyArgs := (1 to: method numArgs) asArray.
+
 	"Executing a lone block will just return a block, we have to call value to have something more interesting"
 	snippet parse isBlock
 		ifTrue: [
-			| block |
-			block := nil executeMethod: method.
-			runBlock := [ block cull: 1 cull: 2 ] ]
-		ifFalse: [ runBlock := [ nil executeMethod: method ] ].
+			| block phonyBlockArgs |
+			block := nil withArgs: phonyArgs executeMethod: method.
+			phonyBlockArgs := (1 to: block numArgs) asArray.
+			runBlock := [ block valueWithArguments: phonyBlockArgs ] ]
+		ifFalse: [ runBlock := [ nil withArgs: phonyArgs executeMethod: method ] ].
 
 	snippet messageNotUnderstood ifNotNil: [ :mnu |
 		runBlock onDNU: mnu do: [ ^ self ].
 		self signalFailure: 'Should have raised MNU ' , mnu ].
 
-	snippet isFaulty
-		ifTrue: [ self should: runBlock raise: RuntimeSyntaxError ]
-		ifFalse: [ self assert: runBlock value equals: snippet value ]
+	snippet hasValue
+		ifFalse: [ self should: runBlock raise: RuntimeSyntaxError ]
+		ifTrue: [ self assert: runBlock value equals: snippet value ]
 ]


### PR DESCRIPTION
This PR is a little larger than the previous one but it's mainly small commits.

* Extends RBCodeSnipped with full methods (including broken pattern, arguments and pragmas).
* Fix various clients of faulty pragma nodes (not that numerous in fact).

Note: I do not change the compiler behavior when dealing with faulty AST. Especially, no RuntimeSyntaxicError is signaled is the method contains buggy pragmas or parameters. But maybe it's not the job of the compiler to do such policy decision about what faulty code is acceptable to execute or not?