### PR TITLE
Use MethodClassifier protocol for new methods instead of the selected protocol

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
@@ -39,6 +39,7 @@ ClyMethodCodeEditorToolMorph >> applyChanges [
 	selector := methodClass compile: self pendingText classified: editingMethod protocol notifying: textMorph.
 	selector ifNil: [^false ].
 	currentMethod := methodClass >> selector.
+	self setMethodProtocol: currentMethod.
 	self tagAndPackageEditingMethod: currentMethod.
 	self switchToMethod: currentMethod.
 	"update the AST to the just compiled method. This clears breakpoints. To be improved"
@@ -312,6 +313,18 @@ ClyMethodCodeEditorToolMorph >> selectedSourceNode [
 		ifFalse: [ ast bestNodeFor: selectedInterval ].
 
 	^ selectedNode ifNil: [ ast ]
+]
+
+{ #category : #operations }
+ClyMethodCodeEditorToolMorph >> setMethodProtocol: currentMethod [
+	"Only change the protocol if we created a new method, not if we edit an existing one"
+
+	(editingMethod selector = currentMethod selector and: [
+		 editingMethod methodClass = currentMethod methodClass ]) ifTrue: [ ^ self ].
+
+	MethodClassifier
+		classify: currentMethod
+		fallbackProtocol: editingMethod protocol
 ]
 
 { #category : #initialization }

--- a/src/Calypso-SystemTools-Core/ClyMethodCreationToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodCreationToolMorph.class.st
@@ -50,9 +50,8 @@ ClyMethodCreationToolMorph >> applyChanges [
 	selector ifNil: [ ^false ].
 
 	newMethod := selectedClass >> selector.
-	methodTags ifEmpty: [
-		MethodClassifier classify: newMethod.
-		methodTags := newMethod tags ].
+	MethodClassifier classify: newMethod fallbackProtocol: (methodTags ifEmpty: [ nil ] ifNotEmpty: [ :tags | tags anyOne]).
+	methodTags := newMethod tags.
 	self tagAndPackageEditingMethod: newMethod.
 
 	self removeFromBrowser.

--- a/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
@@ -231,8 +231,8 @@ ClyMethodEditorToolMorph >> tagEditingMethod: aMethod [
 	| existingTags removedTags newTags |
 	self applyChangesBy: [
 		existingTags := aMethod tags reject: [:each | each beginsWith: '*'].
-		removedTags := existingTags reject: [ :each | methodTags includes: each ].
-		newTags := methodTags reject: [ :each | existingTags includes: each ].
+		newTags := existingTags reject: [ :each | methodTags includes: each ].
+		removedTags := methodTags reject: [ :each | existingTags includes: each ].
 
 		newTags do: [ :each | aMethod tagWith: each asSymbol].
 		removedTags do: [ :each | aMethod untagFrom: each asSymbol]

--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -125,6 +125,25 @@ DebugSession >> implement: aMessage classified: aSymbol inClass: aClass forConte
 	self contextChanged
 ]
 
+{ #category : #'debug - session' }
+DebugSession >> implement: aMessage inClass: aClass forContext: aContext [
+	| method |
+	aClass compile: (DynamicMessageImplementor for: aMessage in: aClass) value.
+	method := aClass lookupSelector: aMessage selector.
+
+	MethodClassifier classify: method.
+
+	aContext privRefreshWith: method.
+	aContext method numArgs > 0 ifTrue:
+		[aMessage arguments withIndexDo:
+			[:arg :index|
+				aContext tempAt: index put: arg]].
+
+	self updateContextTo: aContext.
+	self contextChanged.
+	^ method
+]
+
 { #category : #private }
 DebugSession >> installAlarm: aSelector [
 

--- a/src/Tool-Base/MethodClassifier.class.st
+++ b/src/Tool-Base/MethodClassifier.class.st
@@ -43,8 +43,6 @@ MethodClassifier class >> buildKeywordSuffixMapping [
 MethodClassifier class >> buildPragmaMapping [
 	pragmaMapping := Dictionary new
 		at: 'example' put: 'examples';
-		at: 'spec' put: 'specs';
-		at: 'spec:' put: 'specs';
 		at: 'symbolicVersion:' put: 'symbolic versions';
 		yourself
 ]

--- a/src/Tool-Base/MethodClassifier.class.st
+++ b/src/Tool-Base/MethodClassifier.class.st
@@ -106,6 +106,11 @@ MethodClassifier class >> classify: aMethod [
 ]
 
 { #category : #classification }
+MethodClassifier class >> classify: aMethod fallbackProtocol: fallbackProtocol [
+	^ self new classify: aMethod fallbackProtocol: fallbackProtocol
+]
+
+{ #category : #classification }
 MethodClassifier class >> classifyAll: aCollectionOfMethods [
 	^ self new classifyAll: aCollectionOfMethods
 ]
@@ -151,8 +156,18 @@ MethodClassifier class >> suggestProtocolFor: aMethod [
 { #category : #classification }
 MethodClassifier >> classify: aMethod [
 
+	self classify: aMethod fallbackProtocol: nil
+]
+
+{ #category : #classification }
+MethodClassifier >> classify: aMethod fallbackProtocol: fallbackProtocol [
+	"fallback protocol is the protocol that was selected at method creation.
+	It will only be used if standard rules do not find a protocol for this method.
+	It allows to have consistency for well known method names / prefixes."
+
 	self suggestProtocolFor: aMethod.
-	protocol ifNotNil: [ aMethod protocol: protocol ]
+	protocol ifNotNil: [ ^ aMethod protocol: protocol ].
+	fallbackProtocol ifNotNil: [ aMethod protocol: fallbackProtocol ]
 ]
 
 { #category : #classification }


### PR DESCRIPTION
It will avoid critics and broken release tests.
If there is no protocol found by MethodClassifier, then the selected protocol is used as fallback