### PR TITLE
Skipping test in windows as it is hanging

### DIFF
--- a/src/Zinc-Tests/ZnServerTest.class.st
+++ b/src/Zinc-Tests/ZnServerTest.class.st
@@ -543,6 +543,10 @@ ZnServerTest >> testSmall [
 
 { #category : #testing }
 ZnServerTest >> testTooManyConcurrentConnections [
+
+	"This test fails in windows, waiting for a fix"
+	Smalltalk os isWindows ifTrue: [ ^ self skip ].
+
 	self usingClassicSocketStreamsOnWindowsDo: [
 		self withServerDo: [ :server | | client clients |
 			self deny: server debugMode.


### PR DESCRIPTION
The test is hanging in windows, we don't know why... but should be skipped 😮 