### PR TITLE
Improve faulty parsing on chars (and primitive arrays)

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -76,6 +76,7 @@ RBCodeSnippet class >> badExpressions [
 		self new source: '[1)2]'; formattedCode: '[<r> 1).<r>2 ]'.
 		self new source: '[1}2]'; formattedCode: '[<r> 1}.<r>2 ]'.
 		self new source: '#(1]2}3)'; formattedCode:'#( 1 #'']'' 2 #''}'' 3 )'; isFaulty: false; value: #(1]2}3). "`#(` can eat almost anything"
+		self new source: '#( 0 1r2 4 )'; formattedCode: '#( 0 1 r2 4)'. "Almost anything..."
 		self new source: '#[ 1 ) 2]'.
 		self new source: '#[ 1 } 2]'.
 		self new source: '#[ 1 a 2]'.

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -264,6 +264,31 @@ RBCodeSnippet class >> badExpressions [
 		self new source: '10r89abcd'; formattedCode: '10r89 abcd'; isFaulty: false; messageNotUnderstood: #abcd.
 		self new source: '12r89abcd'; formattedCode: '12r89ab cd'; isFaulty: false; messageNotUnderstood: #cd.
 		self new source: '36r1halt'; isFaulty: false; value: 2486513. "ahah"
+
+		"Bad characters"
+		"Pharo is Unicode aware."
+		"$Δ isLetter >>> true" "$Δ asInteger >>> 16r0394" "Greek Capital Letter Delta"
+		"$ə isLetter >>> true" "$ə asInteger >>> 16r0259" "Latin Small Letter Schwa"
+		self new source: 'Δə'; isFaulty: false. "valid identifier"
+		self new source: '| Δə | Δə := 1. Δə + 1'; isFaulty: false; value: 2.
+
+		"$± isSpecial >>> true" "$± asInteger >>> 16r00B1" "Plus Minus Sign" "Only a few unicode characters are isSpecial in Pharo"
+		self new source: '1 ± 1'; isFaulty: false; messageNotUnderstood: #'±'. "Valid binary operator, but not implemented"
+		"$→ isSpecial >>> false" "$→ asInteger hex >>> 16r2192" "Rightwards Arrow"
+		self new source: '→'. "Unknown character. Not isSpecial"
+		"$٠ isDigit >>> true" "$٠ asInteger >>> 16r0660" "Arabic-indic Digit Zero"
+		self new source: '٠'. "Unknown character. Not a valid number (basic ASCII only for numbers!)"
+		"Currently in Pharo, there is no 'isSeparator' character outside the ASCII range"
+		"Character nbsp isSeparator >>> false" "Even the standard nbsp"
+		self new source: Character nbsp asString. "Unknown character. Not isSeparator"
+
+		self new source: '$→'; isFaulty: false; value: $→.
+		self new source: '''Δ→ə'''; isFaulty: false; value: 'Δ→ə'.
+		self new source: '"Δ→ə" '; isFaulty: false.
+		self new source: '#''Δ→ə'''; isFaulty: false; value: #'Δ→ə'.
+		self new source: '#Δə'; formattedCode: '#''Δə''' ; isFaulty: false; value: #'Δə'.
+		self new source: '#(Δ→ə)'; formattedCode: '#( Δ → ə)'. "This one is faulty because → is a parse error"
+		self new source: '#→'; formattedCode: ' #. →'. "Two independent errors"
 		}.
 	"Setup default values"
 	list do: [ :each |

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -229,6 +229,7 @@ RBCodeSnippet class >> badExpressions [
 
 		"Bad symbol literal"
 		self new source: '#1'; formattedCode: ' #.<r>1'. "Become a bad sequence"
+		self new source: '#1r0'; formattedCode: ' #. 1 r0'. "Two bad sequences"
 		self new source: '##'; formattedCode: '#'. "errr. ok?"
 		"Note: if quotes, same thing than strings"
 		self new source: '#''hello'.

--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -1187,8 +1187,7 @@ RBParserTest >> testParseFaultyLiteral [
 	self assert: node isParseError.
 	self assert: node errorMessage equals: 'Unknown character'.
 	node := self parseFaultyExpression: faultyLiteralArray.
-	self assert: node isFaulty.
-	self assert: node isLiteralArray.
+	self assert: node isParseError.
 	self assert: node contents first errorMessage equals: 'Unknown character'
 ]
 

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -1035,7 +1035,10 @@ RBParser >> parseStatementInto: statementList periodList: periods withAcceptedSt
 		and: [ (aCollectionOfClosers includes: currentToken value) not
 			and: [ currentToken isEOF not
 				and: [ node isUnfinishedStatement not ] ] ] ) ifTrue: [
-		self parserError: 'End of statement expected'.
+		"I do not like the following guard. If currentToken is an unrelated error,
+		 then parserError will unfortunately consume and lose it.
+		 A better design is needed."
+		node isParseError ifFalse: [ self parserError: 'End of statement expected' ].
 		node := RBUnfinishedStatementErrorNode
 			contents: { node }
 			start: node start

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -661,16 +661,24 @@ RBParser >> parseKeywordPragma [
 
 { #category : #'private - parsing' }
 RBParser >> parseLiteralArray [
-	| literals startToken stop |
+	| literals startToken stop isFaulty value |
 	startToken := currentToken.
 	literals := (OrderedCollection new: 5).
+	isFaulty := false.
 	self step.
 	[self atEnd or: [currentToken isSpecial: $)]]
-		whileFalse: [literals add: self parseLiteralArrayObject].
+		whileFalse: [
+			literals add: (value := self parseLiteralArrayObject).
+			value isParseError ifTrue: [ isFaulty := true ] ].
 	stop := currentToken stop.
 	(currentToken isSpecial: $))
 		ifFalse: [ ^ self parseEnglobingError: literals with: startToken errorMessage: ''')'' expected'].
 	self step.
+	isFaulty ifTrue: [
+		^ (self parseEnglobingError: literals with: startToken errorMessage: nil)
+			valueAfter: ')';
+			stop: stop;
+			yourself ].
 	^self literalArrayNodeClass
 		startPosition: startToken start
 		contents: literals


### PR DESCRIPTION
Three things, but related (so a single PR to avoid conflicts).

1. Avoid losing errors nodes on consecutive errors.
2. Handle faulty literal arrays. e.g. `#(0 1r2 3)` where here `1r2` is a syntax error (bad number) so a faulty array is generated instead (otherwise clients of the AST will have a bad day). It's basically the same thing as faulty byte arrays. cf #12818.
3. The real thing: check that non ASCII characters behave correctly (or at least behave). The state of the current policy is out of scope of the PR. Random Unicode characters are mostly treated as syntax error (this is good). This explains the reason of the two previous points. Thanks to #12886 for the idea of testing code points above 127 :)