### PR TITLE
Improve faulty scanning on comments

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -49,6 +49,18 @@ RBCodeSnippet class >> badExpressions [
 		self new source: '#'.
 		self new source: '$'.
 		self new source: ':'.
+		self new source: ''; isFaulty: false. "emptyness is ok"
+		
+		"Comments"
+		"EFFormater is not the best here :("
+		self new source: '"" '; isFaulty: false.
+		self new source: '"nothing" '; isFaulty: false.
+		self new source: '"com"1"ment"'; formattedCode: '1'; isFaulty: false; value: 1. "The comments are in the AST, the formatter just do not know to show them because we format only the node and not the whole method body"
+		self new source: '"a" 1 "b". "c" 2 "d"'; formattedCode: '1. "a" "b" "c" 2 "d"'; isFaulty: false; value: 2. "a and b moved around. Formatter issue. FIXME?"
+		self new source: '"unfinished'.
+		self new source: '"also unfinished""'.
+		self new source: '"'.
+		self new source: '"""'.
 
 		"Bad compound"
 		self new source: '( 1 + 2'.

--- a/src/AST-Core-Tests/RBScannerTest.class.st
+++ b/src/AST-Core-Tests/RBScannerTest.class.st
@@ -1541,16 +1541,22 @@ RBScannerTest >> testNextWithAnIdentifierTokenGetTheIdentifierToken [
 
 { #category : #tests }
 RBScannerTest >> testNextWithAnOpeningCommentAtEndGetError [
-	| source |
+	| source token |
 	source := 'self "'.
-	self should: [(self buildScannerForText: source) next] raise: SyntaxErrorNotification
+	token := (self buildScannerForText: source) next; next.
+	self assert: token isError.
+	self assert: token cause equals: 'Unmatched " in comment.'.
+	self assert: token value equals: '"'
 ]
 
 { #category : #tests }
 RBScannerTest >> testNextWithAnOpeningCommentGetError [
-	| source |
+	| source token |
 	source := '"only the opening'.
-	self should: [(self buildScannerForText: source) next] raise: SyntaxErrorNotification
+	token := (self buildScannerForText: source) next.
+	self assert: token isError.
+	self assert: token cause equals: 'Unmatched " in comment.'.
+	self assert: token value equals: source
 ]
 
 { #category : #tests }
@@ -1582,18 +1588,23 @@ RBScannerTest >> testNextWithTwoDoubleQuotesInComment [
 
 { #category : #tests }
 RBScannerTest >> testNextWithTwoDoubleQuotesInCommentGetError [
-	| source |
+	| source token |
 	source := '"only the"" opening'.
-	self
-		should: [ (self buildScannerForText: source) next ]
-		raise: SyntaxErrorNotification
+	token := (self buildScannerForText: source) next.
+	self assert: token isError.
+	self assert: token cause equals: 'Unmatched " in comment.'.
+	self assert: token value equals: source
 ]
 
 { #category : #'tests - Error' }
 RBScannerTest >> testNextWithUnFinishedCommentGivesAnError [
-	| scanner |
-	scanner := self buildScannerForText: 'firstToken "unfinished comment secondToken'.
-	self should: [scanner next] raise: SyntaxErrorNotification
+
+	| source token |
+	source := 'firstToken "unfinished comment secondToken'.
+	token := (self buildScannerForText: source) next; next.
+	self assert: token isError.
+	self assert: token cause equals: 'Unmatched " in comment.'.
+	self assert: token value equals: '"unfinished comment secondToken'
 ]
 
 { #category : #'tests - Creation api' }

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -399,6 +399,24 @@ RBScanner >> scanError: theCause [
 ]
 
 { #category : #'private - scanning' }
+RBScanner >> scanError: theCause from: aPosition [
+	"An error token accepts every character given, recognised or not."
+	"The value of the error token is the verbatim text from aPosition to the current position (both included)."
+	| location |
+	"error location is the next not parseable character. Or current stream position + 1 if
+	an expected character is missing."
+	location := stream position.
+	currentCharacter
+		ifNotNil: [ :char | buffer nextPut: char ]
+		ifNil: [ location := stream position + 1 ].
+	^ RBErrorToken
+		value: (self scanBackFrom: aPosition)
+		start: aPosition
+		cause: theCause
+		location: location
+]
+
+{ #category : #'private - scanning' }
 RBScanner >> scanIdentifierOrKeyword [
 	"!! Attention !! There are 3 case of Literal Tokens : true, false and nil."
 	"This scan accepts keywords only containing a colon."

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -368,16 +368,16 @@ RBScanner >> scanComment [
 	buffer reset.
 	self step.
 	self atEnd
-		ifTrue: [ ^ self scannerError: 'Unmatched " in comment.' ].
+		ifTrue: [ ^ self scanError: 'Unmatched " in comment.' from: start ].
 	[ currentCharacter = $" and: [ self step ~= $" ] ]
 		whileFalse: [ characterType = #eof
-				ifTrue: [ ^ self scannerError: 'Unmatched " in comment.' ].
+				ifTrue: [ ^ self scanError: 'Unmatched " in comment.' from: start ].
 			buffer nextPut: currentCharacter.
 			self step ].
 	stop := self atEnd
 		ifTrue: [ stream position ]
 		ifFalse: [ stream position - 1 ].
-	comments add: (RBCommentToken value: buffer contents start: start stop: stop)
+	^ RBCommentToken value: buffer contents start: start stop: stop
 ]
 
 { #category : #'private - scanning' }
@@ -658,6 +658,7 @@ RBScanner >> scanToken [
 	currentCharacter = $' ifTrue: [^self scanLiteralString].
 	currentCharacter = $# ifTrue: [^self scanLiteral].
 	currentCharacter = $$ ifTrue: [^self scanLiteralCharacter].
+	currentCharacter = $" ifTrue: [^self scanComment]. "Assume a bad comment (as they are usually stripped)"
 	^self scanUnknownCharacter
 ]
 
@@ -696,7 +697,14 @@ RBScanner >> step [
 { #category : #'private - scanning' }
 RBScanner >> stripSeparators [
 
-	[[characterType = #separator] whileTrue: [self step].
-	currentCharacter = $"]
-			whileTrue: [self scanComment]
+	[[ characterType = #separator ] whileTrue: [ self step ].
+	currentCharacter = $" ] whileTrue: [
+		| comment |
+		comment := self scanComment.
+		comment isError ifTrue: [
+			"Reset the position and stop here. The token will be consumed later by scanToken"
+			stream position: comment start - 1.
+			self step.
+			^ self ].
+		comments add: comment ]
 ]

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -6,6 +6,7 @@ Instance Variables:
 	characterType	<ByteSymbol>	The type of the next character. (e.g. #alphabetic, etc.)
 	classificationTable	<Array of: Symbol>	Mapping from Character values to their characterType.
 	comments	<Collection of: Interval>	Source intervals of scanned comments that must be attached to the next token.
+	nextToken <RBToken>	The ""free"" `next` token, used to store bad comment so no backtracking is needed
 	currentCharacter	<Character>	The character currently being processed.
 	errorBlock	<BlockClosure>	The block to execute on lexical errors.
 	extendedLiterals	<Boolean>	True if IBM-type literals are allowed. In VW, this is false.
@@ -32,7 +33,8 @@ Class {
 		'characterType',
 		'classificationTable',
 		'comments',
-		'errorBlock'
+		'errorBlock',
+		'nextToken'
 	],
 	#classVars : [
 		'CascadePatternCharacter',
@@ -163,7 +165,7 @@ RBScanner class >> scanTokenObjects: aStringOrStream [
 
 { #category : #testing }
 RBScanner >> atEnd [
-	^characterType = #eof
+	^characterType = #eof and: [ nextToken isNil ]
 ]
 
 { #category : #private }
@@ -275,6 +277,11 @@ Binary --> [*] : eof
 { #category : #accessing }
 RBScanner >> next [
 	| token |
+	"Consume the one remembered (likely a bad comment)"
+	nextToken ifNotNil: [ :t |
+		nextToken := nil.
+		^t ].
+
 	buffer reset.
 	tokenStart := stream position.
 	token := characterType = #eof
@@ -702,9 +709,8 @@ RBScanner >> stripSeparators [
 		| comment |
 		comment := self scanComment.
 		comment isError ifTrue: [
-			"Reset the position and stop here. The token will be consumed later by scanToken"
-			stream position: comment start - 1.
-			self step.
+			"Remember to use the error as the next token"
+			nextToken := comment.
 			^ self ].
 		comments add: comment ]
 ]


### PR DESCRIPTION
Comment was the only (remaining) scanned token to possibly signal a syntax error notification (and possibly launch a recovery editor in the UI) instead of producing an error token. This PR change that.

The issue was that comments are stripped from the scanner flow, but AFTER the next token is scanned (so that we can attach the comments on the token returned by `next`).
~~The proposal is if one of the comment is a bad comment (the only current case is an unterminated comment), we have to rewind the stream position (and the scanned state) just before the faulty token so that the next `next` will scan and return this faulty token.~~
The proposal is if one of the comment is a bad comment (the only current case is an unterminated comment), we just remember it, so it will be the next token (returned by `next`).

Note that EFFormatter have some issues with comments, so tests are let as it but will catch on future improvements.