### PR TITLE
Improve faulty parsing by testing unreachable code

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -225,6 +225,16 @@ RBCodeSnippet class >> badExpressions [
 		self new source: '#(^1)'; formattedCode: '#( #''^'' 1 )'; isFaulty: false; value: #(^1). "Obviously..."
 		self new source: '#[ ^ 1]'.
 
+		"Unreachable code"
+		"Unreachable analysis is very simple and targets statement that dirrecty follows a return statement."
+		"Note that faulty code can still be executed without a RuntimeSyntaxError"
+		self new source: '^ 1. 2. ^ 3'; value: 1.
+		self new source: '[ ^ 1. 2. ^ 3 ]'; raise: BlockCannotReturn. "like [^1]"
+		self new source: '{ ^ 1. 2. ^ 3 }'; value: 1.
+		self new source: '[ ^ 1 ]. 2. ^ 3'; isFaulty: false; value: 3.
+		self new source: '{ ^ 1 }. 2. ^ 3'; isFaulty: false; value: 1. "This one could have been..."
+		self new source: 'true ifTrue: [ ^ 1 ] ifFalse: [ ^ 2 ]. ^ 3'; isFaulty: false; value: 1. "Not *syntactic* enough"
+
 		"Bad string literal"
 		"Note: the only cases are the missing closing quotes since everything inside is captured as is and there is no escape sequences or interpolation (yet?)"
 		self new source: '''hello'.

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -220,6 +220,7 @@ RBCodeSnippet class >> badExpressions [
 		self new source: '1 foo: ^2'; formattedCode: ' 1 foo: .<r>^ 2'.
 		self new source: '(^1)'; formattedCode: ' ( .<r> ^ 1)'. "^ can only appear a the begin of a statement, so a random ^ cause an unfinished statement error"
 		self new source: '^^1'; formattedCode: ' ^ .<r>^ 1' "Same spirit".
+		self new source: '[ ^ 1 ]'; isFaulty: false; raise: BlockCannotReturn. "when the block is evaluated, the method is already gone."
 		self new source: '{ ^ 1 }'; isFaulty: false; value: 1. "I did not expect this one to be legal"
 		self new source: '#(^1)'; formattedCode: '#( #''^'' 1 )'; isFaulty: false; value: #(^1). "Obviously..."
 		self new source: '#[ ^ 1]'.

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -10,6 +10,7 @@ See `RBCodeSnippet allSnippets` for a various collection of instances.
 * value <Object> the expected value when executed
 * hasValue <Boolean> is the compiled method produce a value
 * messageNotUnderstood <Symbol> the expected MNU error when executed
+* numberOfCritique <Integer> how many critiques are expected
 * skippedTests <Collection> list of test to not execute (that should be fixed)
 
 Tests are executed by the parametrized matrix class `RBCodeSnippetTest`
@@ -27,7 +28,8 @@ Class {
 		'hasValue',
 		'formattedCode',
 		'skippedTests',
-		'messageNotUnderstood'
+		'messageNotUnderstood',
+		'numberOfCritiques'
 	],
 	#category : #'AST-Core-Tests-Snippets'
 }
@@ -477,6 +479,18 @@ RBCodeSnippet >> messageNotUnderstood [
 RBCodeSnippet >> messageNotUnderstood: anObject [
 
 	messageNotUnderstood := anObject
+]
+
+{ #category : #accessing }
+RBCodeSnippet >> numberOfCritiques [
+
+	^ numberOfCritiques
+]
+
+{ #category : #accessing }
+RBCodeSnippet >> numberOfCritiques: anObject [
+
+	numberOfCritiques := anObject
 ]
 
 { #category : #parsing }

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -9,6 +9,7 @@ See `RBCodeSnippet allSnippets` for a various collection of instances.
 * isFaulty <Boolean> is the parser expected to produce a faulty AST 
 * value <Object> the expected value when executed
 * hasValue <Boolean> is the compiled method produce a value
+* raise <Exception class> the exception that should be raised at runtime
 * messageNotUnderstood <Symbol> the expected MNU error when executed
 * numberOfCritique <Integer> how many critiques are expected
 * skippedTests <Collection> list of test to not execute (that should be fixed)
@@ -28,6 +29,7 @@ Class {
 		'hasValue',
 		'formattedCode',
 		'skippedTests',
+		'raise',
 		'messageNotUnderstood',
 		'numberOfCritiques'
 	],
@@ -508,6 +510,18 @@ RBCodeSnippet >> printOn: aStream [
 		nextPut: $(;
 		nextPutAll: source;
 		nextPut: $)
+]
+
+{ #category : #accessing }
+RBCodeSnippet >> raise [
+
+	^ raise
+]
+
+{ #category : #accessing }
+RBCodeSnippet >> raise: anObject [
+
+	raise := anObject
 ]
 
 { #category : #accessing }

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -575,5 +575,6 @@ RBCodeSnippet >> value [
 { #category : #accessing }
 RBCodeSnippet >> value: anObject [
 
-	value := anObject
+	value := anObject.
+	hasValue := true
 ]

--- a/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
@@ -31,6 +31,8 @@ RBCodeSnippetTest >> testExecute [
 		runBlock onDNU: mnu do: [ ^ self ].
 		self signalFailure: 'Should have raised MNU ' , mnu ].
 
+	snippet raise ifNotNil: [ :class | ^ self should: runBlock raise: class ].
+
 	snippet hasValue
 		ifFalse: [ self should: runBlock raise: RuntimeSyntaxError ]
 		ifTrue: [ self assert: runBlock value equals: snippet value ]

--- a/src/Renraku-Tests/RBCodeSnippetTest.extension.st
+++ b/src/Renraku-Tests/RBCodeSnippetTest.extension.st
@@ -7,6 +7,10 @@ RBCodeSnippetTest >> testCritiques [
 	ast := snippet parse.
 	critiques := ast critiques.
 
+	snippet numberOfCritiques ifNotNil: [ :n |
+		self assert: critiques size equals: n.
+		^ self ].
+
 	"Alone blocks will have ReDeadBlockRule. Currently no other critiques are fired."
 	"When we get some critiques, we will add a instance vaviable in the snippet to validate them"
 	ast isBlock


### PR DESCRIPTION
This PR just add more tests and improve RBCodeSnippet.

It also tests unreachable statement errors, but nothing was changed in the parser since everything went fine enough.