### PR TITLE
12807-Executable-comment-syntax-error-leads-to-CI-crash 

### DIFF
--- a/src/DrTests-CommentsToTests-Tests/CommentsToTestsTest.class.st
+++ b/src/DrTests-CommentsToTests-Tests/CommentsToTestsTest.class.st
@@ -28,7 +28,7 @@ CommentsToTestsTest >> testCommentWithSyntaxError [
 	docComment := thisContext method ast pharoDocCommentNodes first.
 	commentTestCase := CommentTestCase for: docComment.
 
-	self should: [commentTestCase testIt] raise: RuntimeSyntaxError
+	self should: [commentTestCase testIt] raise: SyntaxErrorNotification
 ]
 
 { #category : #tests }

--- a/src/PharoDocComment-Tests/PharoDocCommentTest.class.st
+++ b/src/PharoDocComment-Tests/PharoDocCommentTest.class.st
@@ -36,9 +36,9 @@ PharoDocCommentTest >> testExpressionNoAssociation [
 	"(3 + 4 >>> 7) value"
 	| node |
 	node := thisContext method ast pharoDocCommentNodes first.
-	self assert: node expression isFaulty.
-	self should: [ node expression evaluate ] raise: RuntimeSyntaxError.
-	self should: [ (CommentTestCase for: node) testIt ] raise: RuntimeSyntaxError
+	self deny: node expression isWellFormed.
+	self should: [ node expression evaluate ] raise: Error.
+	self should: [ (CommentTestCase for: node) testIt ] raise: Error
 ]
 
 { #category : #tests }
@@ -82,9 +82,12 @@ PharoDocCommentTest >> testExpressionSyntaxError [
 	"3 + 4) >>> 7"
 	| node |
 	node := thisContext method ast pharoDocCommentNodes first.
+	"We get a syntax error"
 	self assert: node expression isFaulty.
-	self should: [ node expression evaluate ] raise: RuntimeSyntaxError.
-	self should: [ (CommentTestCase for: node) testIt ] raise: RuntimeSyntaxError
+	"but the structure of the >>> looks ok"
+	self assert: node expression isWellFormed.
+	self should: [ node expression evaluate ] raise: SyntaxErrorNotification.
+	self should: [ (CommentTestCase for: node) testIt ] raise: SyntaxErrorNotification
 ]
 
 { #category : #tests }
@@ -96,8 +99,8 @@ PharoDocCommentTest >> testExpressionZero [
 	| node |
 	node := thisContext method ast pharoDocCommentNodes first.
 	self assert: node expression isFaulty.
-	self should: [ node expression evaluate ] raise: RuntimeSyntaxError.
-	self should: [ (CommentTestCase for: node) testIt ] raise: RuntimeSyntaxError
+	self should: [ node expression evaluate ] raise: Error.
+	self should: [ (CommentTestCase for: node) testIt ] raise: Error
 ]
 
 { #category : #tests }
@@ -118,8 +121,8 @@ PharoDocCommentTest >> testMultipleDocCommentsInOneComment [
 	| node |
 	node := thisContext method ast pharoDocCommentNodes first.
 	self assert: node expression isFaulty.
-	self should: [ node expression evaluate ] raise: RuntimeSyntaxError.
-	self should: [ (CommentTestCase for: node) testIt ] raise: RuntimeSyntaxError
+	self should: [ node expression evaluate ] raise: Error.
+	self should: [ (CommentTestCase for: node) testIt ] raise: Error
 ]
 
 { #category : #tests }

--- a/src/PharoDocComment/PharoDocCommentExpression.class.st
+++ b/src/PharoDocComment/PharoDocCommentExpression.class.st
@@ -16,14 +16,13 @@ Class {
 PharoDocCommentExpression >> evaluate [
 
 	"Note: it seems there is no easy way here to reuse in Opal the parsed AST and just compile&evaluate it."
-
-	self isFaulty ifTrue: [ RuntimeSyntaxError signal ].
+	self isWellFormed ifFalse: [ self error: 'Doc comment is not well formed' ].
+	"we do not check for isFaulty here, as in the case of syntax errors, we want the evaluate to give us better error messages"
 
 	^ self methodClass compiler
 		  source: self source;
 		  noPattern: true;
 		  receiver: self methodClass;
-		  options: #( + optionParseErrors );
 		  evaluate
 ]
 
@@ -54,8 +53,15 @@ PharoDocCommentExpression >> isFaulty [
 
 	"Check is the ast is OK and follows the 2 specific doccomments rules"
 
+	^ self isNotWellFormed or: [ self expressionNode isFaulty ]
+]
+
+{ #category : #testing }
+PharoDocCommentExpression >> isNotWellFormed [
+
+	"Check is the ast follows the 2 specific doccomments rules"
+
 	| cpt |
-	self expressionNode isFaulty ifTrue: [ ^ true ].
 
 	"There should be exactly only one triple > message send"
 	cpt := 0.
@@ -67,6 +73,12 @@ PharoDocCommentExpression >> isFaulty [
 	self expressionNode body statements last value selector ~= #>>> ifTrue: [ ^ true ].
 
 	^false
+]
+
+{ #category : #testing }
+PharoDocCommentExpression >> isWellFormed [
+
+	^self isNotWellFormed not
 ]
 
 { #category : #operation }


### PR DESCRIPTION
This is a fix for better error messages for Doc comments.

- add a way to test for not well formed doc comments independ if there is a syntax error (#isWellFormed)
- in #evaluate we check that and raise and error, the we recompile and let the compiler give us good error messages for the expression that we compile

An improvement that could be made as a next step if to add a specific exception for the doc commen error and describe how the expression is not well formed.

fixes #12807