### PR TITLE
InitializedSlot-check-default 

### DIFF
--- a/src/VariablesLibrary-Tests/InitializedSlotTest.class.st
+++ b/src/VariablesLibrary-Tests/InitializedSlotTest.class.st
@@ -5,6 +5,33 @@ Class {
 }
 
 { #category : #tests }
+InitializedSlotTest >> testBlockWithNonSharedDefault [
+ 	"If we use a block the resulting default value should not be shared among instances"
+
+ 	| slot objectA objectB defaultA defaultB |
+ 	slot := #slot1 => InitializedSlot default: [ OrderedCollection new ].
+ 	aClass := self make: [ :builder | builder slots: { slot } ].
+ 	self assert: (aClass hasSlotNamed: #slot1).
+
+ 	objectA := aClass new.
+ 	objectB := aClass new.
+
+ 	defaultA := slot read: objectA.
+ 	defaultB := slot read: objectB.
+
+ 	self assert: defaultA isEmpty.
+ 	self assert: defaultB isEmpty.
+
+ 	"Each instance has its own collection"
+ 	self deny: defaultA identicalTo: defaultB.
+
+ 	defaultA add: 'HelloWorld'.
+
+ 	self assert: (slot read: objectA) size equals: 1.
+ 	self assert: (slot read: objectB) size equals: 0
+]
+
+{ #category : #tests }
 InitializedSlotTest >> testLazyClassVariableReflectiveBlockParameter [
 	| classVar |
 	classVar := #ClassVar => LazyClassVariable default: [:class | class].
@@ -13,7 +40,26 @@ InitializedSlotTest >> testLazyClassVariableReflectiveBlockParameter [
 	self assert: classVar read equals: aClass
 ]
 
-{ #category : #tests }
+{ #category : #'tests - printing' }
+InitializedSlotTest >> testPrintOn [
+
+ 	| slot |
+ 	slot := #slot1 => InitializedSlot default: [ OrderedCollection new ].
+	self
+		assert: slot definitionString
+		equals: '#slot1 => InitializedSlot default: [ OrderedCollection new ]'.
+
+	slot := #slot1 => InitializedSlot default: #literal.
+	self
+		assert: slot definitionString
+		equals: '#slot1 => InitializedSlot default: #literal'.
+
+	"On eval, we raise an error, the ClassParser can show a nicer error in the class definition"
+	self should: [#slot1 => InitializedSlot default: 5@2] raise: Error.
+	self should: [#slot1 => InitializedSlot default: OrderedCollection new] raise: Error
+]
+
+{ #category : #'tests - read/write' }
 InitializedSlotTest >> testReadWriteCompiled [
 	| slot object|
 	slot := #slot1 => InitializedSlot default: 5.
@@ -28,7 +74,7 @@ InitializedSlotTest >> testReadWriteCompiled [
 	self assert: (object slot1) equals: 10
 ]
 
-{ #category : #tests }
+{ #category : #'tests - read/write' }
 InitializedSlotTest >> testReflectiveReadWrite [
 	| slot object|
 	slot := #slot1 => InitializedSlot default: 5.
@@ -42,7 +88,7 @@ InitializedSlotTest >> testReflectiveReadWrite [
 	self assert: (slot read: object) equals: 10
 ]
 
-{ #category : #tests }
+{ #category : #'tests - read/write' }
 InitializedSlotTest >> testReflectiveReadWriteBlock [
 	| slot object|
 	slot := #slot1 => InitializedSlot default: [4+1].

--- a/src/VariablesLibrary/AbstractInitializedSlot.class.st
+++ b/src/VariablesLibrary/AbstractInitializedSlot.class.st
@@ -32,6 +32,9 @@ AbstractInitializedSlot >> default [
 
 { #category : #accessing }
 AbstractInitializedSlot >> default: anObject [
+	"this needs to be a literal or clean block"
+	(anObject isLiteral or: [ anObject isBlock and: [anObject isClean]])
+		ifFalse: [ self error: 'default value has to be a literal or clean block' ].
 	default := anObject
 ]
 


### PR DESCRIPTION
fixes #12819

When using InitializedSlot, it is tempting to use "OrderedCollection new" as the default. But that is not a good idea, as this instance would be created at slot definition time.

A solution is to restrict the the default value to be a literal (read only) or a clean block (evaluated each time the class is instantiated).

When creating slots via evaluation, we can just raise an error. The class parser then can show a nice user level error message when parsing the class definition. 

```
testPrintOn

 	| slot |
 	slot := #slot1 => InitializedSlot default: [ OrderedCollection new ].
	self
		assert: slot definitionString
		equals: '#slot1 => InitializedSlot default: [ OrderedCollection new ]'.

	slot := #slot1 => InitializedSlot default: #literal.
	self
		assert: slot definitionString
		equals: '#slot1 => InitializedSlot default: #literal'.

	"On eval, we raise an error, the ClassParser can show a nicer error in the class definition"
	self should: [#slot1 => InitializedSlot default: 5@2] raise: Error.
	self should: [#slot1 => InitializedSlot default: OrderedCollection new] raise: Error
```