### PR TITLE
Add new attributes to SDL_MouseWheelEvent

### DIFF
--- a/src/OSWindow-SDL2/SDL_MouseWheelDirection.class.st
+++ b/src/OSWindow-SDL2/SDL_MouseWheelDirection.class.st
@@ -1,0 +1,54 @@
+"
+I represent the scroll direction types for the Scroll event.
+
+I'm a binding to the following enum in SDL2 library:
+
+```
+typedef enum
+{
+    SDL_MOUSEWHEEL_NORMAL,    /**< The scroll direction is normal */
+    SDL_MOUSEWHEEL_FLIPPED    /**< The scroll direction is flipped / natural */
+} SDL_MouseWheelDirection;
+```
+
+
+"
+Class {
+	#name : #'SDL_MouseWheelDirection',
+	#superclass : #FFIEnumeration,
+	#classVars : [
+		'SDL_MOUSEWHEEL_FLIPPED',
+		'SDL_MOUSEWHEEL_NORMAL'
+	],
+	#category : #'OSWindow-SDL2-Bindings'
+}
+
+{ #category : #'accessing enum' }
+SDL_MouseWheelDirection class >> SDL_MOUSEWHEEL_FLIPPED [
+	"This method was automatically generated"
+	^ SDL_MOUSEWHEEL_FLIPPED
+]
+
+{ #category : #'accessing enum' }
+SDL_MouseWheelDirection class >> SDL_MOUSEWHEEL_NORMAL [
+	"This method was automatically generated"
+	^ SDL_MOUSEWHEEL_NORMAL
+]
+
+{ #category : #'enum declaration' }
+SDL_MouseWheelDirection class >> enumDecl [
+	"
+	self rebuildEnumAccessors
+	"
+
+	^ #(
+    SDL_MOUSEWHEEL_NORMAL  0    "The scroll direction is normal"
+    SDL_MOUSEWHEEL_FLIPPED 1    "The scroll direction is flipped"
+	)
+]
+
+{ #category : #'accessing enum' }
+SDL_MouseWheelDirection class >> initialize [
+
+	self initializeEnumeration.
+]

--- a/src/OSWindow-SDL2/SDL_MouseWheelDirection.class.st
+++ b/src/OSWindow-SDL2/SDL_MouseWheelDirection.class.st
@@ -47,7 +47,7 @@ SDL_MouseWheelDirection class >> enumDecl [
 	)
 ]
 
-{ #category : #'accessing enum' }
+{ #category : #'class initialization' }
 SDL_MouseWheelDirection class >> initialize [
 
 	self initializeEnumeration.

--- a/src/OSWindow-SDL2/SDL_MouseWheelEvent.class.st
+++ b/src/OSWindow-SDL2/SDL_MouseWheelEvent.class.st
@@ -5,6 +5,9 @@ Class {
 	#name : #'SDL_MouseWheelEvent',
 	#superclass : #SDL2MappedEvent,
 	#classVars : [
+		'OFFSET_DIRECTION',
+		'OFFSET_PRECISEX',
+		'OFFSET_PRECISEY',
 		'OFFSET_TIMESTAMP',
 		'OFFSET_TYPE',
 		'OFFSET_WHICH',
@@ -23,7 +26,7 @@ SDL_MouseWheelEvent class >> eventType [
 { #category : #'fields description' }
 SDL_MouseWheelEvent class >> fieldsDesc [
 	"
-	self initializeAccessors
+	self rebuildFieldAccessors
 	"
 	^ #(
     Uint32 type;
@@ -32,12 +35,51 @@ SDL_MouseWheelEvent class >> fieldsDesc [
     Uint32 which;
     Sint32 x;
     Sint32 y;
+    SDL_MouseWheelDirection direction;
+    float preciseX;
+    float preciseY;
  	)
 ]
 
 { #category : #visitor }
 SDL_MouseWheelEvent >> accept: aVisitor [
 	^ aVisitor visitMouseWheelEvent: self
+]
+
+{ #category : #'accessing - structure variables' }
+SDL_MouseWheelEvent >> direction [
+	"This method was automatically generated"
+	^SDL_MouseWheelDirection fromInteger: (handle unsignedLongAt: OFFSET_DIRECTION)
+]
+
+{ #category : #'accessing - structure variables' }
+SDL_MouseWheelEvent >> direction: anObject [
+	"This method was automatically generated"
+	handle unsignedLongAt: OFFSET_DIRECTION put: anObject value
+]
+
+{ #category : #'accessing - structure variables' }
+SDL_MouseWheelEvent >> preciseX [
+	"This method was automatically generated"
+	^handle floatAt: OFFSET_PRECISEX
+]
+
+{ #category : #'accessing - structure variables' }
+SDL_MouseWheelEvent >> preciseX: anObject [
+	"This method was automatically generated"
+	handle floatAt: OFFSET_PRECISEX put: anObject
+]
+
+{ #category : #'accessing - structure variables' }
+SDL_MouseWheelEvent >> preciseY [
+	"This method was automatically generated"
+	^handle floatAt: OFFSET_PRECISEY
+]
+
+{ #category : #'accessing - structure variables' }
+SDL_MouseWheelEvent >> preciseY: anObject [
+	"This method was automatically generated"
+	handle floatAt: OFFSET_PRECISEY put: anObject
 ]
 
 { #category : #'accessing - structure variables' }


### PR DESCRIPTION
Proposed to fix #12896.
In addition, also included binding to 'direction' attribute, added in SDL 2.0.4.


Post load action: `SDL_MouseWheelEvent rebuildFieldAccessors`


To test it:
1. Create a `printOn:` in `SDL_MouseWheelEvent` (see below)
2. In `OSSDL2Driver>>#processEvent:`, add the expression `mappedEvent traceCr.` right after `mappedEvent := sdlEvent mapped.`.
3. Open Transcript and scroll with the wheel or typical two-fingers in track pad.

Example of printOn: to see the new attributes:
```
printOn: stream 

	super printOn: stream.
	
	stream print: (self preciseX @ self preciseY).
	
	stream print: self direction.
```