### PR TITLE
no more RBScanner errorBlock

### DIFF
--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -258,7 +258,7 @@ RBParser >> initialize [
 { #category : #accessing }
 RBParser >> initializeParserWith: aString [
 	source := aString.
-	self scanner: (self scannerClass on: (ReadStream on: aString) errorBlock: self errorBlock)
+	self scanner: (self scannerClass on: (ReadStream on: aString))
 ]
 
 { #category : #'private - classes' }
@@ -1358,7 +1358,6 @@ RBParser >> saveCommentsDuring: aBlock [
 RBParser >> scanner: aScanner [
 	scanner := aScanner.
 	pragmas := nil.
-	aScanner errorBlock: self errorBlock.
 	self initialize.
 	self step
 ]

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -8,7 +8,6 @@ Instance Variables:
 	comments	<Collection of: Interval>	Source intervals of scanned comments that must be attached to the next token.
 	nextToken <RBToken>	The ""free"" `next` token, used to store bad comment so no backtracking is needed
 	currentCharacter	<Character>	The character currently being processed.
-	errorBlock	<BlockClosure>	The block to execute on lexical errors.
 	extendedLiterals	<Boolean>	True if IBM-type literals are allowed. In VW, this is false.
 	nameSpaceCharacter	<Character>	The character used to separate namespaces.
 	numberType	<ByteSymbol>	The method to perform: to scan a number. 
@@ -33,7 +32,6 @@ Class {
 		'characterType',
 		'classificationTable',
 		'comments',
-		'errorBlock',
 		'nextToken'
 	],
 	#classVars : [
@@ -138,17 +136,6 @@ RBScanner class >> on: aStream [
 	^scanner
 ]
 
-{ #category : #'instance creation' }
-RBScanner class >> on: aStream errorBlock: aBlock [
-	| str |
-	str := self new on: aStream.
-	str
-		errorBlock: aBlock;
-		step;
-		stripSeparators.
-	^str
-]
-
 { #category : #accessing }
 RBScanner class >> patternVariableCharacter [
 	^ PatternVariableCharacter
@@ -195,21 +182,6 @@ RBScanner >> contents [
 	[ self atEnd ]
 		whileFalse: [ contentsStream nextPut: self next ].
 	^ contentsStream contents
-]
-
-{ #category : #'error handling' }
-RBScanner >> errorBlock [
-	^errorBlock ifNil: [[:message :position | ]] ifNotNil: [errorBlock]
-]
-
-{ #category : #accessing }
-RBScanner >> errorBlock: aBlock [
-	errorBlock := aBlock
-]
-
-{ #category : #'error handling' }
-RBScanner >> errorPosition [
-	^stream position
 ]
 
 { #category : #accessing }
@@ -307,18 +279,6 @@ RBScanner >> on: aStream [
 	stream := aStream.
 	classificationTable := self class classificationTable.
 	comments := OrderedCollection new
-]
-
-{ #category : #parsing }
-RBScanner >> parseErrorNode: aMessageString [
-	"This method might be called indirectly by errorBlocks.
-	especially by `RBParser class>>#errorNodeBlock` since the parser share its
-	error blocks with the scanner."
-
-	| sourceString |
-	sourceString := stream contents copyFrom: self errorPosition to: stream contents size.
-	^ RBParseErrorNode
-		errorMessage: aMessageString value: sourceString at: self errorPosition
 ]
 
 { #category : #private }
@@ -676,18 +636,6 @@ RBScanner >> scanUnknownCharacter [
 	"advance"
 	self step.
 	^ errorToken
-]
-
-{ #category : #'error handling' }
-RBScanner >> scannerError: aString [
-	(self errorBlock cull: aString cull: self errorPosition cull: self) ifNil: [
-		^ SyntaxErrorNotification
-					inClass: Object
-					withCode: stream contents
-					doitFlag: false
-					errorMessage: aString
-					location: stream position + 1
-	]
 ]
 
 { #category : #private }

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -141,7 +141,7 @@ RBScanner class >> on: aStream errorBlock: aBlock [
 
 	self
 		deprecated: 'The scanner no more signals errors or execute error blocks, it just silently produces error tokens'
-		transformWith: '`@receiver on: `@arg` errorBlock: `@arg2' -> '`@receiver on: `@arg1'.
+		transformWith: '`@receiver on: `@arg1 errorBlock: `@arg2' -> '`@receiver on: `@arg1'.
 	^ self on: aStream
 ]
 
@@ -195,8 +195,7 @@ RBScanner >> contents [
 
 { #category : #accessing }
 RBScanner >> errorBlock: aBlock [
-	"No-op as errorBlock is removed. But kept here for old clients"
-	"TODO remove once clients are migrated"
+	self deprecated: 'No-op as errorBlock is removed'
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -194,6 +194,12 @@ RBScanner >> contents [
 ]
 
 { #category : #accessing }
+RBScanner >> errorBlock: aBlock [
+	"No-op as errorBlock is removed. But kept here for old clients"
+	"TODO remove once clients are migrated"
+]
+
+{ #category : #accessing }
 RBScanner >> getComments [
 	| oldComments |
 	comments isEmpty ifTrue: [^nil].

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -136,6 +136,15 @@ RBScanner class >> on: aStream [
 	^scanner
 ]
 
+{ #category : #'instance creation' }
+RBScanner class >> on: aStream errorBlock: aBlock [
+
+	self
+		deprecated: 'The scanner no more signals errors or execute error blocks, it just silently produces error tokens'
+		transformWith: '`@receiver on: `@arg` errorBlock: `@arg2' -> '`@receiver on: `@arg1'.
+	^ self on: aStream
+]
+
 { #category : #accessing }
 RBScanner class >> patternVariableCharacter [
 	^ PatternVariableCharacter

--- a/src/Deprecated11/RBScanner.extension.st
+++ b/src/Deprecated11/RBScanner.extension.st
@@ -1,15 +1,6 @@
 Extension { #name : #RBScanner }
 
 { #category : #'*Deprecated11' }
-RBScanner class >> on: aStream errorBlock: aBlock [
-
-	self
-		deprecated: 'The scanner no more signals errors or execute error blocks, it just silently produces error tokens'
-		transformWith: '`@receiver on: `@arg` errorBlock: `@arg2' -> '`@receiver on: `@arg1'.
-	^ self on: aStream
-]
-
-{ #category : #'*Deprecated11' }
 RBScanner class >> scanTokens: aStringOrStream [
 	"Return the tokens (and not the scanner token objects)."
 	self deprecated: 'Unused in standard image Pharo 11, therefore deprecated without replacement'.

--- a/src/Deprecated11/RBScanner.extension.st
+++ b/src/Deprecated11/RBScanner.extension.st
@@ -1,6 +1,15 @@
 Extension { #name : #RBScanner }
 
 { #category : #'*Deprecated11' }
+RBScanner class >> on: aStream errorBlock: aBlock [
+
+	self
+		deprecated: 'The scanner no more signals errors or execute error blocks, it just silently produces error tokens'
+		transformWith: '`@receiver on: `@arg` errorBlock: `@arg2' -> '`@receiver on: `@arg1'.
+	^ self on: aStream
+]
+
+{ #category : #'*Deprecated11' }
 RBScanner class >> scanTokens: aStringOrStream [
 	"Return the tokens (and not the scanner token objects)."
 	self deprecated: 'Unused in standard image Pharo 11, therefore deprecated without replacement'.

--- a/src/Refactoring-Changes/RBRefactoryDefinitionChange.class.st
+++ b/src/Refactoring-Changes/RBRefactoryDefinitionChange.class.st
@@ -126,9 +126,7 @@ RBRefactoryDefinitionChange >> namesIn: aString [
 
 	| names scanner token |
 	names := OrderedCollection new.
-	scanner := RBScanner
-		           on: (ReadStream on: aString)
-		           errorBlock: [ :msg :pos | ^ names ].
+	scanner := RBScanner on: (ReadStream on: aString).
 	[ scanner atEnd ] whileFalse: [
 		token := scanner next.
 		token isIdentifier ifTrue: [ names add: token value ] ].


### PR DESCRIPTION
PR #12892 removed the last usage of errorBlock in RBScanner.

This PR does the **almost** final cleanup of now unused code.
Because existing images still refer to some undead method of RBScanner (`on:errorBlock:` and `errorBlock:`) they are kept as empty shells.
Note: for some reason, moving these two methods as extension methods in Deprecated11 also break Iceberg. Possible the "move" is not atomic so the removal of the method in AST-Core is done before it is added in Deprecated11 letting the low level code experiences MNU errors.