### PR TITLE
RBCodeSnippets test decompilation

### DIFF
--- a/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
@@ -9,6 +9,26 @@ RBCodeSnippetTest >> testCompile [
 ]
 
 { #category : #'*OpalCompiler-Tests' }
+RBCodeSnippetTest >> testDecompile [
+
+	| method ast |
+	method := snippet compile.
+	ast := method decompile.
+	self assert: ast isMethod.
+	"Decompilation lose many information. Not sure how to test more"
+]
+
+{ #category : #'*OpalCompiler-Tests' }
+RBCodeSnippetTest >> testDecompileIR [
+
+	| method ir |
+	method := snippet compile.
+	ir := method decompileIR.
+	self assert: ir class equals: IRMethod.
+	"Decompilation lose information. Not sure how to test more"
+]
+
+{ #category : #'*OpalCompiler-Tests' }
 RBCodeSnippetTest >> testExecute [
 
 	| method runBlock phonyArgs |


### PR DESCRIPTION
Run decompilation on all RBCodeSnippets.

Currently, It only tests that nothing fails internally. Testing the validity of result is hard since compilation->decompilation lose information (temp names, unused temps) or produce slightly different (but equivalent) code.