### PR TITLE
Improve faulty AST fromatting by RBSimpleFormatter

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippetTest.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippetTest.class.st
@@ -91,3 +91,13 @@ RBCodeSnippetTest >> testParseOnError [
 		ifTrue: [ self deny: error equals: nil ]
 		ifFalse: [ self assert: error equals: nil ]
 ]
+
+{ #category : #tests }
+RBCodeSnippetTest >> testSimpleFormattedCode [
+
+	| ast fast east |
+	ast := snippet parse.
+	fast := (RBSimpleFormatter format: ast) reject: #isSeparator.
+	east := snippet formattedCode reject: #isSeparator.
+	self assert: fast  equals: east
+]

--- a/src/AST-Core/RBSimpleFormatter.class.st
+++ b/src/AST-Core/RBSimpleFormatter.class.st
@@ -118,7 +118,7 @@ RBSimpleFormatter >> formatBlockArgumentsFor: aBlockNode [
 		ifTrue: [ ^ self ].
 	aBlockNode arguments
 		do: [ :each |
-			   codeStream nextPut: $:.
+				each isParseError ifFalse: [ codeStream nextPut: $: ].
 			   self
 					visitNode: each;
 			   		formatCommentsFor: each;
@@ -304,7 +304,7 @@ RBSimpleFormatter >> needsParenthesisFor: aNode [
 	aNode isValue
 		ifFalse: [ ^ false ].
 	aNode isParseError
-		ifTrue: [ ^false ].
+		ifTrue: [ ^ aNode hasParentheses ].
 	parent := aNode parent ifNil: [ ^ false ].
 	aNode precedence < parent precedence
 		ifTrue: [ ^ false ].
@@ -422,6 +422,17 @@ RBSimpleFormatter >> visitCascadeNode: aCascadeNode [
 ]
 
 { #category : #visiting }
+RBSimpleFormatter >> visitEnglobingErrorNode: aNode [
+
+	self writeString: aNode value.
+	self formatBlockArgumentsFor: aNode.
+	aNode contents do: [ :each | self visitNode: each ] separatedBy: [
+		codeStream nextPutAll: ' '.
+		self newLine ].
+	self writeString: aNode valueAfter
+]
+
+{ #category : #visiting }
 RBSimpleFormatter >> visitLiteralArrayNode: aRBArrayLiteralNode [
 	| brackets |
 	codeStream nextPut: $#.
@@ -494,7 +505,12 @@ RBSimpleFormatter >> visitPatternWrapperBlockNode: aRBPatternWrapperBlockNode [
 
 { #category : #visiting }
 RBSimpleFormatter >> visitPragmaNode: aPragmaNode [
-	codeStream nextPut: $<.
+
+	| hackNoBrackets |
+	"If the parent is an error, the '<' and '>' are already taken care of."
+	hackNoBrackets := aPragmaNode parent isNotNil and: [ aPragmaNode parent isEnglobingError ].
+
+	hackNoBrackets ifFalse: [ codeStream nextPut: $< ].
 	self
 		formatSelectorAndArguments: aPragmaNode
 		firstSeparator: [
@@ -502,7 +518,7 @@ RBSimpleFormatter >> visitPragmaNode: aPragmaNode [
 				ifTrue: [ self space ] ]
 		restSeparator: [ self space ].
 	self addSpaceIfNeededForLastArgument: aPragmaNode.
-	codeStream nextPut: $>
+	hackNoBrackets ifFalse: [ codeStream nextPut: $> ]
 ]
 
 { #category : #visiting }


### PR DESCRIPTION
This PR teaches RBSimpleFormatter (from AST-Code) to format error nodes.

RBCodeSnippetTest is also extended to test that.

Note: EFFormatter is the default formatter, I do not know if maintaining RBSimpleFormatter worth something.