### PR TITLE
new class SycInspectNodeCommand to simply inspect an AST node

### DIFF
--- a/src/SystemCommands-SourceCodeCommands/SycInspectNodeCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycInspectNodeCommand.class.st
@@ -1,0 +1,29 @@
+"
+I'm a simple command to inspect any AST node.
+"
+Class {
+	#name : #SycInspectNodeCommand,
+	#superclass : #SycSourceCodeCommand,
+	#category : #'SystemCommands-SourceCodeCommands'
+}
+
+{ #category : #execution }
+SycInspectNodeCommand >> asRefactorings [
+
+	self error: 'Not a refactoring'
+]
+
+{ #category : #execution }
+SycInspectNodeCommand >> defaultMenuIconName [
+	^ #smallInspectIt
+]
+
+{ #category : #execution }
+SycInspectNodeCommand >> defaultMenuItemName [
+	^'Inspect AST Node ' , sourceNode class name
+]
+
+{ #category : #execution }
+SycInspectNodeCommand >> execute [
+	sourceNode inspect
+]


### PR DESCRIPTION
When hacking on AST elements, it's nice to be able to inspect a given AST node of some code shown in an editor.

![Capture d’écran du 2023-03-06 08-36-41](https://user-images.githubusercontent.com/135828/223125490-d57467f5-296f-42af-be87-b649f8791e8e.png)
