### PR TITLE
Ensure #setUp is classified in running

### DIFF
--- a/src/Tool-Base/MethodClassifier.class.st
+++ b/src/Tool-Base/MethodClassifier.class.st
@@ -13,10 +13,20 @@ Class {
 	#classInstVars : [
 		'prefixMapping',
 		'keywordSuffixMapping',
-		'pragmaMapping'
+		'pragmaMapping',
+		'exactMapping'
 	],
 	#category : #'Tool-Base-Utilities'
 }
+
+{ #category : #private }
+MethodClassifier class >> buildExactMapping [
+
+	exactMapping := Dictionary new
+		                at: 'setUp' put: 'running';
+		                at: 'tearDown' put: 'running';
+		                yourself
+]
 
 { #category : #private }
 MethodClassifier class >> buildKeywordSuffixMapping [
@@ -49,53 +59,54 @@ MethodClassifier class >> buildPragmaMapping [
 
 { #category : #private }
 MethodClassifier class >> buildPrefixMapping [
+
 	prefixMapping := Dictionary new
-		at: 'accept' put: 'visiting';
-		at: 'accepts' put: 'testing';
-		at: 'add' put: 'adding';
-		at: 'as' put: 'converting';
-		at: 'assert' put: 'asserting';
-		at: 'at' put: 'accessing';
-		at: 'baseline' put: 'baselines';
-		at: 'bench' put: 'benchmarking';
-		at: 'benchmark' put: 'benchmarking';
-		at: 'can' put: 'testing';
-		at: 'compile' put: 'compiling';
-		at: 'copy' put: 'copying';
-		at: 'deny' put: 'asserting';
-		at: 'first' put: 'accessing';
-		at: 'format' put: 'formatting';
-		at: 'from' put: 'instance creation';
-		at: 'has' put: 'testing';
-		at: 'includes' put: 'testing';
-		at: 'index' put: 'accessing';
-		at: 'initialize' put: 'initialization';
-		at: 'is' put: 'testing';
-		at: 'last' put: 'accessing';
-		at: 'matches' put: 'testing';
-		at: 'max' put: 'accessing';
-		at: 'maximum' put: 'accessing';
-		at: 'min' put: 'accessing';
-		at: 'minimum' put: 'accessing';
-		at: 'needs' put: 'testing';
-		at: 'new' put: 'instance creation';
-		at: 'parse' put: 'parsing';
-		at: 'print' put: 'printing';
-		at: 'remove' put: 'removing';
-		at: 'render' put: 'rendering';
-		at: 'requires' put: 'testing';
-		at: 'reset' put: 'initialization';
-		at: 'set' put: 'initialization';
-		at: 'should' put: 'asserting';
-		at: 'shouldnt' put: 'asserting';
-		at: 'signal' put: 'signalling';
-		at: 'sort' put: 'sorting';
-		at: 'test' put: 'tests';
-		at: 'total' put: 'accessing';
-		at: 'version' put: 'versions';
-		at: 'visit' put: 'visiting';
-		at: 'write' put: 'writing';
-		yourself
+		                 at: 'accept' put: 'visiting';
+		                 at: 'accepts' put: 'testing';
+		                 at: 'add' put: 'adding';
+		                 at: 'as' put: 'converting';
+		                 at: 'assert' put: 'asserting';
+		                 at: 'at' put: 'accessing';
+		                 at: 'baseline' put: 'baselines';
+		                 at: 'bench' put: 'benchmarking';
+		                 at: 'benchmark' put: 'benchmarking';
+		                 at: 'can' put: 'testing';
+		                 at: 'compile' put: 'compiling';
+		                 at: 'copy' put: 'copying';
+		                 at: 'deny' put: 'asserting';
+		                 at: 'first' put: 'accessing';
+		                 at: 'format' put: 'formatting';
+		                 at: 'from' put: 'instance creation';
+		                 at: 'has' put: 'testing';
+		                 at: 'includes' put: 'testing';
+		                 at: 'index' put: 'accessing';
+		                 at: 'initialize' put: 'initialization';
+		                 at: 'is' put: 'testing';
+		                 at: 'last' put: 'accessing';
+		                 at: 'matches' put: 'testing';
+		                 at: 'max' put: 'accessing';
+		                 at: 'maximum' put: 'accessing';
+		                 at: 'min' put: 'accessing';
+		                 at: 'minimum' put: 'accessing';
+		                 at: 'needs' put: 'testing';
+		                 at: 'new' put: 'instance creation';
+		                 at: 'parse' put: 'parsing';
+		                 at: 'print' put: 'printing';
+		                 at: 'remove' put: 'removing';
+		                 at: 'render' put: 'rendering';
+		                 at: 'requires' put: 'testing';
+		                 at: 'reset' put: 'initialization';
+		                 at: 'set' put: 'initialization';
+		                 at: 'should' put: 'asserting';
+		                 at: 'shouldnt' put: 'asserting';
+		                 at: 'signal' put: 'signalling';
+		                 at: 'sort' put: 'sorting';
+		                 at: 'test' put: 'tests';
+		                 at: 'total' put: 'accessing';
+		                 at: 'version' put: 'versions';
+		                 at: 'visit' put: 'visiting';
+		                 at: 'write' put: 'writing';
+		                 yourself
 ]
 
 { #category : #classification }
@@ -115,11 +126,18 @@ MethodClassifier class >> classifyAll: aCollectionOfMethods [
 
 { #category : #private }
 MethodClassifier class >> clearMappings [
-	"self clearMappings"
 
-	prefixMapping := nil.
-	keywordSuffixMapping := nil.
-	pragmaMapping := nil
+	<script>
+	prefixMapping := keywordSuffixMapping := pragmaMapping := exactMapping := nil
+]
+
+{ #category : #accessing }
+MethodClassifier class >> exactMapping [
+	"use a class inst var so subclasses can define custom mappings"
+
+	^ exactMapping ifNil: [
+		  self buildExactMapping.
+		  exactMapping ]
 ]
 
 { #category : #accessing }
@@ -133,9 +151,10 @@ MethodClassifier class >> keywordSuffixMapping [
 { #category : #accessing }
 MethodClassifier class >> pragmaMapping [
 	"use a class inst var so subclasses can define custom mappings"
+
 	^ pragmaMapping ifNil: [
-		self buildPragmaMapping.
-		pragmaMapping]
+		  self buildPragmaMapping.
+		  pragmaMapping ]
 ]
 
 { #category : #accessing }
@@ -178,9 +197,9 @@ MethodClassifier >> classifyAll: aCollectionOfMethods [
 
 { #category : #accessing }
 MethodClassifier >> listToFindProtocols [
-	^ #(#protocolAccessorFor: #protocolByKnownKeywordSuffix:
-	#protocolByKnownPragma: #protocolByKnownPrefix:
-	#protocolByOtherImplementors: #protocolInSuperclassProtocol:)
+
+	^ #( #protocolByKnownMapping: #protocolAccessorFor: #protocolByKnownKeywordSuffix: #protocolByKnownPragma: #protocolByKnownPrefix: #protocolByOtherImplementors:
+	     #protocolInSuperclassProtocol: )
 ]
 
 { #category : #'classification-rules' }
@@ -204,6 +223,12 @@ MethodClassifier >> protocolAccessorFor: aMethod [
 MethodClassifier >> protocolByKnownKeywordSuffix: aMethod [
 	(self protocolForKnownKeywordSuffixOfSelector: aMethod selector)
 		ifNotNil: [ :p | protocol := p ]
+]
+
+{ #category : #'classification-rules' }
+MethodClassifier >> protocolByKnownMapping: aMethod [
+
+	self class exactMapping keysAndValuesDo: [ :selector :p | aMethod selector = selector ifTrue: [ protocol := p ] ]
 ]
 
 { #category : #'classification-rules' }

--- a/src/Tools-Tests/MethodClassifierTest.class.st
+++ b/src/Tools-Tests/MethodClassifierTest.class.st
@@ -45,3 +45,15 @@ MethodClassifierTest >> testProtocolForKnownPrefixOfSelector [
 			"it shouldn't mis-classify 'island' as 'testing' just because it starts with 'is'"
 			self deny: (classifier protocolForKnownPrefixOfSelector: (prefix , 'more') asSymbol) equals: protocol ]
 ]
+
+{ #category : #tests }
+MethodClassifierTest >> testProtocolForSetUp [
+
+	self assert: (MethodClassifier new suggestProtocolFor: ClassTest >> #setUp) equals: #running
+]
+
+{ #category : #tests }
+MethodClassifierTest >> testProtocolForTearDown [
+
+	self assert: (MethodClassifier suggestProtocolFor: ClassTest >> #tearDown) equals: #running
+]


### PR DESCRIPTION
We currently have a release test that #setUp should be classified in #running but the current MethodClassifier put it in initialization. This update the behavior by adding a list of methods we want to see in specific protocols + add a test