### PR TITLE
Add BaselineOf:>>#pharoVersionsFrom:

### DIFF
--- a/src/Metacello-Base/BaselineOf.class.st
+++ b/src/Metacello-Base/BaselineOf.class.st
@@ -106,6 +106,12 @@ BaselineOf >> baseline: spec [
 	"
 ]
 
+{ #category : #baselines }
+BaselineOf >> pharoVersionsFrom: aVersion [
+
+	^ (aVersion to: SystemVersion current major) collect: [ :v | ('pharo' , v asString , '.x') asSymbol ]
+]
+
 { #category : #accessing }
 BaselineOf >> projectClass [
     ^ MetacelloMCBaselineProject


### PR DESCRIPTION
Add an helper when we want to sepcify in a configuration that we want a package to be loaded in Pharo X and later versions.