### PR TITLE
Improve faulty parsing - simplify RBParser error API

### DIFF
--- a/src/AST-Core-Tests/RBFormatterTest.class.st
+++ b/src/AST-Core-Tests/RBFormatterTest.class.st
@@ -19,8 +19,7 @@ RBFormatterTest >> formatClass: aClass selector: aSymbol [
 	source := aClass sourceCodeAt: aSymbol.
 	tree1 := self parserClass parseMethod: source.
 	tree2 := self parserClass
-		parseMethod: (self formatterClass new format: tree1)
-		onError: [ :err :pos | self assert: false ].
+		parseFaultyMethod: (self formatterClass new format: tree1).
 	self assert: tree1 equals: tree2
 ]
 

--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -1441,13 +1441,11 @@ RBParserTest >> testParserErrorsWithErrorBlock [
 
 	#(#('self foo. + 3' 1) #('self 0' 1) #('self asdf;;asfd' 1))
 		do: [:each | |ast errorCount|
-			   [ ast := self parseError: each first onError:
-					[:msg :pos :parser | parser parseErrorNode: msg]]
-						on: ReparseAfterSourceEditing do: [].
+			ast := self parserClass parseFaultyExpression: each first.
 
-				errorCount := 0.
-				RBParseErrorNodeVisitor visit: ast do: [ :n | errorCount := errorCount + 1 ].
-				self assert: errorCount equals: each last ]
+			errorCount := 0.
+			RBParseErrorNodeVisitor visit: ast do: [ :n | errorCount := errorCount + 1 ].
+			self assert: errorCount equals: each last ]
 ]
 
 { #category : #'tests - Array' }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -50,16 +50,20 @@ RBParser class >> newWithErrorBlock: aBlock [
 
 { #category : #parsing }
 RBParser class >> parseExpression: aString [
-	^self parseExpression: aString onError: nil
+
+	^ self new
+		  initializeParserWith: aString;
+		  parseExpression
 ]
 
 { #category : #parsing }
 RBParser class >> parseExpression: aString onError: aBlock [
 
-	^self new
-        errorBlock: aBlock;
-        initializeParserWith: aString;
-        parseExpression
+	| parser |
+	^ [ parser := self new initializeParserWith: aString.
+		 parser parseExpression ]
+		on: SyntaxErrorNotification
+		do: [ :e | aBlock cull: e errorMessage cull: e location cull: parser ]
 ]
 
 { #category : #parsing }
@@ -91,16 +95,19 @@ RBParser class >> parseLiterals: aString [
 
 { #category : #parsing }
 RBParser class >> parseMethod: aString [
-	^self parseMethod: aString onError: nil
+	^ self new
+		initializeParserWith: aString;
+		parseMethod
 ]
 
 { #category : #parsing }
 RBParser class >> parseMethod: aString onError: aBlock [
+
 	| parser |
-	parser := self new
-		errorBlock: aBlock;
-		initializeParserWith: aString.
-	^ parser parseMethod
+	^ [ parser := self new initializeParserWith: aString.
+		 parser parseMethod ]
+		on: SyntaxErrorNotification
+		do: [ :e | aBlock cull: e errorMessage cull: e location cull: parser ]
 ]
 
 { #category : #parsing }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -113,7 +113,7 @@ RBParser class >> parseMethod: aString onError: aBlock [
 { #category : #parsing }
 RBParser class >> parseMethodPattern: aString [
 	^ (self new
-		   errorBlock: [ :error :position | ^ nil ];
+			beFaulty;
 		   initializeParserWith: aString;
 		   parseMessagePattern) selector
 ]

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -23,7 +23,8 @@ Class {
 		'errorBlock',
 		'source',
 		'comments',
-		'pragmas'
+		'pragmas',
+		'isFaulty'
 	],
 	#category : #'AST-Core-Parser'
 }
@@ -184,6 +185,7 @@ RBParser >> basicParsePragma [
 
 { #category : #initialization }
 RBParser >> beFaulty [
+	isFaulty := true.
 	errorBlock := self class errorNodeBlock
 ]
 
@@ -252,7 +254,8 @@ RBParser >> getErrorFromClosuresWithMissingOpenings: aCollection [
 
 { #category : #initialization }
 RBParser >> initialize [
-	comments := OrderedCollection new
+	comments := OrderedCollection new.
+	isFaulty := false. "Default is to raise ~~hell~~ syntax errors"
 ]
 
 { #category : #accessing }
@@ -1235,6 +1238,8 @@ RBParser >> parseVariableNode [
 RBParser >> parserError: aString [
 	"Let the errorBlock try to recover from the error. Answer a ParseNode (possibly an RBParseErrorNode) or signal there is new source"
 	| errorNode errorMessage errorPosition newSource |
+	isFaulty ifTrue: [ ^ self parseErrorNode: aString ].
+
 	errorNode := self errorBlock cull: aString cull: self errorPosition cull: self.
 	errorNode ifNotNil: [ ^ errorNode ].
 	currentToken isError

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -1372,7 +1372,7 @@ RBParser >> saveCommentsDuring: aBlock [
 RBParser >> scanner: aScanner [
 	scanner := aScanner.
 	pragmas := nil.
-	self initialize.
+	comments := OrderedCollection new.
 	self step
 ]
 

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -43,8 +43,10 @@ RBParser class >> newFaulty [
 { #category : #'instance creation' }
 RBParser class >> newWithErrorBlock: aBlock [
 
+	self deprecated: 'RBParser takes no more an error block'.
+
 	^ self new
-		errorBlock: aBlock;
+		beFaulty;
 		yourself
 ]
 
@@ -233,8 +235,8 @@ RBParser >> errorBlock [
 
 { #category : #accessing }
 RBParser >> errorBlock: aBlock [
-	errorBlock := aBlock.
-	scanner ifNotNil: [scanner errorBlock: aBlock]
+
+	self deprecated: 'RBParser accepts no more an error block. Either use the faulty mode or catch the SyntaxErrorNotification (various `onError:` methods can do that four you)'
 ]
 
 { #category : #'error handling' }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -20,7 +20,6 @@ Class {
 		'scanner',
 		'currentToken',
 		'nextToken',
-		'errorBlock',
 		'source',
 		'comments',
 		'pragmas',
@@ -28,11 +27,6 @@ Class {
 	],
 	#category : #'AST-Core-Parser'
 }
-
-{ #category : #accessing }
-RBParser class >> errorNodeBlock [
-	^ [ :aString :position :parser| parser parseErrorNode: aString ]
-]
 
 { #category : #'instance creation' }
 RBParser class >> newFaulty [
@@ -200,7 +194,6 @@ RBParser >> basicParsePragma [
 { #category : #initialization }
 RBParser >> beFaulty [
 	isFaulty := true.
-	errorBlock := self class errorNodeBlock
 ]
 
 { #category : #'private - classes' }
@@ -226,11 +219,6 @@ RBParser >> doItMethodNodeClass [
 { #category : #'private - classes' }
 RBParser >> englobingErrorNodeClass [
 	^RBEnglobingErrorNode
-]
-
-{ #category : #'error handling' }
-RBParser >> errorBlock [
-	^errorBlock ifNil: [[:message :position | ]] ifNotNil: [errorBlock]
 ]
 
 { #category : #accessing }
@@ -1251,11 +1239,9 @@ RBParser >> parseVariableNode [
 { #category : #'error handling' }
 RBParser >> parserError: aString [
 	"Let the errorBlock try to recover from the error. Answer a ParseNode (possibly an RBParseErrorNode) or signal there is new source"
-	| errorNode errorMessage errorPosition |
+	| errorMessage errorPosition |
 	isFaulty ifTrue: [ ^ self parseErrorNode: aString ].
 
-	errorNode := self errorBlock cull: aString cull: self errorPosition cull: self.
-	errorNode ifNotNil: [ ^ errorNode ].
 	currentToken isError
 		ifTrue: [ errorMessage := currentToken cause. errorPosition := currentToken location ]
 		ifFalse: [errorMessage := aString. errorPosition := currentToken start].

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -100,9 +100,7 @@ RBParser class >> parseMethod: aString onError: aBlock [
 	parser := self new
 		errorBlock: aBlock;
 		initializeParserWith: aString.
-	^ [ parser parseMethod ]
-		on: ReparseAfterSourceEditing
-		do: [ :exception | self parseMethod: exception newSource onError: aBlock ]
+	^ parser parseMethod
 ]
 
 { #category : #parsing }
@@ -1244,7 +1242,7 @@ RBParser >> parseVariableNode [
 { #category : #'error handling' }
 RBParser >> parserError: aString [
 	"Let the errorBlock try to recover from the error. Answer a ParseNode (possibly an RBParseErrorNode) or signal there is new source"
-	| errorNode errorMessage errorPosition newSource |
+	| errorNode errorMessage errorPosition |
 	isFaulty ifTrue: [ ^ self parseErrorNode: aString ].
 
 	errorNode := self errorBlock cull: aString cull: self errorPosition cull: self.
@@ -1253,15 +1251,12 @@ RBParser >> parserError: aString [
 		ifTrue: [ errorMessage := currentToken cause. errorPosition := currentToken location ]
 		ifFalse: [errorMessage := aString. errorPosition := currentToken start].
 
-	newSource := SyntaxErrorNotification
+	SyntaxErrorNotification
 						inClass: Object
 						withCode: source
 						doitFlag: false
 						errorMessage: errorMessage
 						location: errorPosition.
-
-	"If the syntax error notification is resumed, then the source was corrected and we have to announce that parsing can restart."
-	ReparseAfterSourceEditing signalWithNewSource: newSource
 ]
 
 { #category : #private }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -37,7 +37,7 @@ RBParser class >> errorNodeBlock [
 { #category : #'instance creation' }
 RBParser class >> newFaulty [
 
-	^ self newWithErrorBlock: self errorNodeBlock
+	^ self new beFaulty
 ]
 
 { #category : #'instance creation' }
@@ -65,14 +65,21 @@ RBParser class >> parseExpression: aString onError: aBlock [
 { #category : #parsing }
 RBParser class >> parseFaultyExpression: aString [
 	"parse aString even if syntactically incorrect. Instead of raising an error, we create an AST with RB RBParseErrorNode"
-	^self parseExpression: aString onError: self errorNodeBlock
+
+	^ self new
+		beFaulty;
+		initializeParserWith: aString;
+		parseExpression
 ]
 
 { #category : #parsing }
 RBParser class >> parseFaultyMethod: aString [
 	"parse aString even if syntactically incorrect. Instead of raising an error, we create an AST with RB RBParseErrorNode"
 
-	^ self parseMethod: aString onError: self errorNodeBlock
+	^ self new
+		beFaulty;
+		initializeParserWith: aString;
+		parseMethod
 ]
 
 { #category : #parsing }

--- a/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
@@ -155,9 +155,7 @@ RBExtractMethodRefactoring >> extractMethod [
 	extractCode := self getExtractedSource.
 	extractedParseTree := self parserClass
 		parseExpression: extractCode
-		onError: [ :string :pos :parser |
-			errorMessage := string.
-			parser parseErrorNode: string ].
+		onError: [ :string :pos :parser | errorMessage := string ].
 	extractedParseTree
 		ifNil: [ self refactoringFailure: 'Invalid source to extract' ].
 	extractedParseTree isFaulty


### PR DESCRIPTION
Error handling in the whole compilation infrastructure of Pharo is sometime really weird, possibly for a lot of reasons (going from stacked historical compatibility hacks; to insane design choices that could be used as counter example and case study in a graduated software engineering course).

This PR tries to clean up (a little) the current status. Now that `RBScanner` is a little better (cf #12900) it is the turn of `RBParser`.

It is important to remember that `RBParser` is a simple *utility* component in the whole compilation infrastructure. Its main client is `OpalCompiler` that is a far more complex beast (unfortunately). Therefore:

* Providing the possibility of interactive recovery on syntax error is overengineering (and seems not really used by any client). The simpler used solution is to inform the client of errors and let it run a new parser.
* `RBParser` is not the place to have complex UI/UX/event-programming design. `OpalCompiler` and its clients, like the Rubric code editor, are (maybe) a better place to do fancy things.
* Syntax errors are a normal thing to expect, and most of the time, manipulating faulty AST is what one really want.

The main thing of the PR is to kill `errorBlock` and stop using `ReparseAfterSourceEditing`.

The proposed API is now:

* low level: a class toggle `beFaulty` (and instance variable `isFaulty`) to activate fault-tolerant parsing that produce AST that contains `RBParseErrorNode`, and otherwise signals `SyntaxErrorNotification`.
* helpers methods `parseFaulty*` are preserved (and still do not signal SyntaxError).
* helpers `Xxxx:OnError:` are also preserved, the behavior change a little so that the given block is used to intercept the syntax error signal in a compatible way. The only change is that there is no recovery (no client never cared about that anyway). The value of the block will be the value of the whole `Xxx:OnError:` call.

Note that bugs in the PR might break the usability of images by limiting the possibility to compile new code. So good reviewing is needed :)