### PR TITLE
Improve faulty compilation - semantic error

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -442,8 +442,8 @@ RBCodeSnippet class >> badSemantic [
 		"Backend errors"
 		"FIXME: syntax error are thrown by the compiler even in *faulty* mode.
 		 FIXME: semantic analysis does not catch the error (backend issue)"
-		self new source: 'foo ^ [ :a1 :a2 :a3 :a4 :a5 :a6 :a7 :a8 :a9 :a10 :a11 :a12 :a13 :a14 :a15 :a16 | a1 ]'; isMethod: true; isFaulty: true; skip: #compile; skip: #testDoSemanticAnalysisOnError. "Too many arguments"
-		self new source: 'a1: a1 a2: a2 a3: a3 a4: a4 a5: a5 a6: a6 a7: a7 a8: a8 a9: a9 a10: a10 a11: a11 a12: a12 a13: a13 a14: a14 a15: a15 a16: a16 ^ a1'; isMethod: true; isFaulty: true; skip: #compile; skip: #testDoSemanticAnalysisOnError. "Too many arguments"
+		self new source: 'foo ^ [ :a1 :a2 :a3 :a4 :a5 :a6 :a7 :a8 :a9 :a10 :a11 :a12 :a13 :a14 :a15 :a16 | a1 ]'; isMethod: true; isFaulty: true. "Too many arguments"
+		self new source: 'a1: a1 a2: a2 a3: a3 a4: a4 a5: a5 a6: a6 a7: a7 a8: a8 a9: a9 a10: a10 a11: a11 a12: a12 a13: a13 a14: a14 a15: a15 a16: a16 ^ a1'; isMethod: true; isFaulty: true. "Too many arguments"
 		}.
 	"Setup default values"
 	list do: [ :each |

--- a/src/AST-Core-Tests/RBProgramNodeTest.class.st
+++ b/src/AST-Core-Tests/RBProgramNodeTest.class.st
@@ -660,6 +660,13 @@ RBProgramNodeTest >> testPropertyAtIfAbsentPut [
 	self assert: (self node propertyAt: #foo ifAbsentPut: [ false ])
 ]
 
+{ #category : #tests }
+RBProgramNodeTest >> testPropertyAtIfPresent [
+	self assert: (self node propertyAt: #foo ifPresent:[ :p | #bad ]) equals: nil.
+	self node propertyAt: #foo put: true.
+	self assert: (self node propertyAt: #foo ifPresent:[ :p | p ]).
+]
+
 { #category : #'tests - properties' }
 RBProgramNodeTest >> testPropertyAtIfPresentIfAbsent [
 	self assert: (self node propertyAt: #foo ifPresent:[ false ] ifAbsent: [ true ]) equals: true.

--- a/src/AST-Core/RBArrayNode.class.st
+++ b/src/AST-Core/RBArrayNode.class.st
@@ -157,8 +157,9 @@ RBArrayNode >> isEmpty [
 	^ statements isEmpty
 ]
 
-{ #category : #testing }
+{ #category : #errors }
 RBArrayNode >> isFaulty [
+	self isError ifTrue: [ ^ true ].
 	^self statements anySatisfy: [:each | each isFaulty]
 ]
 

--- a/src/AST-Core/RBAssignmentNode.class.st
+++ b/src/AST-Core/RBAssignmentNode.class.st
@@ -108,8 +108,9 @@ RBAssignmentNode >> isAssignment [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : #errors }
 RBAssignmentNode >> isFaulty [
+	self isError ifTrue: [ ^ true ].
 	^self variable isFaulty or: [ self value isFaulty ]
 ]
 

--- a/src/AST-Core/RBBlockNode.class.st
+++ b/src/AST-Core/RBBlockNode.class.st
@@ -269,8 +269,9 @@ RBBlockNode >> isConstant [
 		ifNotEmpty: [:statements | statements first isLiteralNode ]
 ]
 
-{ #category : #testing }
+{ #category : #errors }
 RBBlockNode >> isFaulty [
+	self isError ifTrue: [ ^ true ].
 	^(self arguments anySatisfy: [:each | each isFaulty] ) or: [ self body isFaulty]
 ]
 

--- a/src/AST-Core/RBCascadeNode.class.st
+++ b/src/AST-Core/RBCascadeNode.class.st
@@ -96,9 +96,10 @@ RBCascadeNode >> isCascade [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : #errors }
 RBCascadeNode >> isFaulty [
-	^self messages anySatisfy: [:each | each isFaulty]
+	self isError ifTrue: [ ^ true ].
+	^self messages anySatisfy: [:each | each isFaulty ]
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBLiteralArrayNode.class.st
+++ b/src/AST-Core/RBLiteralArrayNode.class.st
@@ -88,8 +88,9 @@ RBLiteralArrayNode >> equalTo: anObject withMapping: aDictionary [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : #errors }
 RBLiteralArrayNode >> isFaulty [
+	self isError ifTrue: [ ^ true ].
 	^self contents anySatisfy: [:each | each isFaulty]
 ]
 

--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -166,8 +166,9 @@ RBMessageNode >> isContainmentReplacement: aNode [
 		or: [self arguments anySatisfy: [:each | (self mappingFor: each) = aNode]]
 ]
 
-{ #category : #testing }
+{ #category : #errors }
 RBMessageNode >> isFaulty [
+	self isError ifTrue: [ ^ true ].
 	^self receiver isFaulty or: [self arguments anySatisfy: [:each | each isFaulty]]
 ]
 

--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -391,8 +391,9 @@ RBMethodNode >> isDoIt [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : #errors }
 RBMethodNode >> isFaulty [
+	self isError ifTrue: [ ^ true ].
 	(self arguments anySatisfy: [:each | each isFaulty]) ifTrue:[ ^true].
 	(self pragmas anySatisfy: [:each | each isFaulty]) ifTrue:[ ^true].
 	^self body isFaulty

--- a/src/AST-Core/RBParseErrorNode.class.st
+++ b/src/AST-Core/RBParseErrorNode.class.st
@@ -76,6 +76,11 @@ RBParseErrorNode >> hash [
 	^ (self value hash bitXor: self errorMessage hash)
 ]
 
+{ #category : #errors }
+RBParseErrorNode >> isError [
+	^true
+]
+
 { #category : #testing }
 RBParseErrorNode >> isFaulty [
 	^true

--- a/src/AST-Core/RBParseErrorNode.class.st
+++ b/src/AST-Core/RBParseErrorNode.class.st
@@ -81,7 +81,7 @@ RBParseErrorNode >> isError [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : #errors }
 RBParseErrorNode >> isFaulty [
 	^true
 ]

--- a/src/AST-Core/RBPragmaNode.class.st
+++ b/src/AST-Core/RBPragmaNode.class.st
@@ -125,8 +125,9 @@ RBPragmaNode >> isBinary [
 	^ (self isUnary or: [self isKeyword]) not
 ]
 
-{ #category : #testing }
+{ #category : #errors }
 RBPragmaNode >> isFaulty [
+	self isError ifTrue: [ ^ true ].
 	^self arguments anySatisfy: [:each | each isFaulty]
 ]
 

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -908,6 +908,13 @@ RBProgramNode >> propertyAt: aKey ifAbsentPut: aBlock [
 	^ self propertyAt: aKey ifAbsent: [ self propertyAt: aKey put: aBlock value ]
 ]
 
+{ #category : #accessing }
+RBProgramNode >> propertyAt: aKey ifPresent: aPresentBlock [
+	"Evaluate aPresentBlock with the the property value associated with aKey. Return nil if aKey is not found."
+
+	^ properties ifNotNil: [ properties at: aKey ifPresent: aPresentBlock ifAbsent: [ nil ] ]
+]
+
 { #category : #properties }
 RBProgramNode >> propertyAt: aKey ifPresent: aPresentBlock ifAbsent: anAbsentBlock [
 	"Answer the property value associated with aKey or, if aKey is found, answer the result of evaluating aPresentBlock, else evaluates anAbsentBlock."

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -68,6 +68,14 @@ RBProgramNode class >> resetFormatter [
 	self formatterClass: nil
 ]
 
+{ #category : #errors }
+RBProgramNode >> addError: anErrorMessage [
+
+	"Add an error information to the node. Node with error information are considered faulty.
+	Semantic passes that check the validity of AST are the targetted clients of this method."
+	self propertyAt: #error put: anErrorMessage
+]
+
 { #category : #replacing }
 RBProgramNode >> addReplacement: aStringReplacement [
 	parent ifNil: [^self].
@@ -543,6 +551,14 @@ RBProgramNode >> isDynamicArray [
 { #category : #testing }
 RBProgramNode >> isEnglobingError [
 	^false
+]
+
+{ #category : #errors }
+RBProgramNode >> isError [
+	"An error node is either a RBParseErrorNode (for syntactic errors) or has error information (for semantic errors).
+	see `addError:`"
+
+	^ self propertyAt: #error ifPresent: [ true ] ifAbsent: [ false ]
 ]
 
 { #category : #testing }

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -568,10 +568,11 @@ RBProgramNode >> isEvaluatedFirst [
 	^parent isNil or: [parent isSequence or: [parent evaluatedFirst: self]]
 ]
 
-{ #category : #testing }
+{ #category : #errors }
 RBProgramNode >> isFaulty [
-	"return true if the AST contains a RBParseErrorNode"
-	^false
+
+	"return true if the AST is or contains a isError node."
+	^ self isError
 ]
 
 { #category : #testing }

--- a/src/AST-Core/RBReturnNode.class.st
+++ b/src/AST-Core/RBReturnNode.class.st
@@ -79,8 +79,9 @@ RBReturnNode >> initialize [
 	start := 0
 ]
 
-{ #category : #testing }
+{ #category : #errors }
 RBReturnNode >> isFaulty [
+	self isError ifTrue: [ ^ true ].
 	^self value isFaulty
 ]
 

--- a/src/AST-Core/RBSequenceNode.class.st
+++ b/src/AST-Core/RBSequenceNode.class.st
@@ -327,8 +327,9 @@ RBSequenceNode >> initialize [
 	temporaries := OrderedCollection new
 ]
 
-{ #category : #testing }
+{ #category : #errors }
 RBSequenceNode >> isFaulty [
+	self isError ifTrue: [ ^ true ].
 	^self statements anySatisfy: [:each | each isFaulty]
 ]
 

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -105,6 +105,7 @@ OCASTSemanticAnalyzer >> shadowingVariable: aNode [
 
 { #category : #'error handling' }
 OCASTSemanticAnalyzer >> storeIntoReadOnlyVariable: variableNode [
+	variableNode addError: 'Cannot store into'.
 	compilationContext optionSkipSemanticWarnings ifTrue: [ ^ self ].
 
 	^ OCStoreIntoReadOnlyVariableError new
@@ -116,6 +117,7 @@ OCASTSemanticAnalyzer >> storeIntoReadOnlyVariable: variableNode [
 
 { #category : #'error handling' }
 OCASTSemanticAnalyzer >> storeIntoReservedVariable: variableNode [
+	variableNode addError: 'Cannot store into'.
 	compilationContext optionSkipSemanticWarnings ifTrue: [ ^ self ].
 	^ OCStoreIntoReservedVariableError new
 		node: variableNode;

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -42,6 +42,19 @@ OCASTSemanticAnalyzer >> analyzeLocalVariableWrite: aLocalVariable [
 					ifFalse: [ aLocalVariable markWrite ]
 ]
 
+{ #category : #errors }
+OCASTSemanticAnalyzer >> backendError: aMessage forNode: aNode [
+	aNode addError: aMessage.
+	compilationContext optionSkipSemanticWarnings ifTrue: [ ^ self ].
+
+	SyntaxErrorNotification
+		inClass: Object
+		withCode: aNode methodNode source
+		doitFlag: false
+		errorMessage: aMessage
+		location: aNode startWithoutParentheses
+]
+
 { #category : #accessing }
 OCASTSemanticAnalyzer >> blockCounter [
 	^blockCounter ifNil: [0]
@@ -158,6 +171,8 @@ OCASTSemanticAnalyzer >> visitAssignmentNode: anAssignmentNode [
 
 { #category : #visiting }
 OCASTSemanticAnalyzer >> visitBlockNode: aBlockNode [
+	aBlockNode arguments size >15 ifTrue: [self backendError: 'Too many arguments' forNode: aBlockNode ].
+
 	blockCounter := self blockCounter + 1.
 
 	aBlockNode isInlined ifTrue: [^ self visitInlinedBlockNode: aBlockNode ].
@@ -182,6 +197,8 @@ OCASTSemanticAnalyzer >> visitInlinedBlockNode: aBlockNode [
 
 { #category : #visiting }
 OCASTSemanticAnalyzer >> visitMethodNode: aMethodNode [
+
+	aMethodNode arguments size > 15 ifTrue: [ self backendError: 'Too many arguments' forNode: aMethodNode ].
 
 	scope := OCMethodScope new outerScope: compilationContext scope.
 	aMethodNode scope: scope.  scope node: aMethodNode.

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -54,17 +54,6 @@ OCASTTranslator class >> initialize [
 		                     (#whileTrue -> #emitWhileTrue:) } asDictionary
 ]
 
-{ #category : #errors }
-OCASTTranslator >> backendError: aMessage forNode: aNode [
-
-	SyntaxErrorNotification
-		inClass: Object
-		withCode: aNode methodNode source
-		doitFlag: false
-		errorMessage: aMessage
-		location: aNode startWithoutParentheses
-]
-
 { #category : #initialization }
 OCASTTranslator >> classForEffect [
 	^OCASTTranslatorForEffect
@@ -524,7 +513,7 @@ OCASTTranslator >> visitAssignmentNode: anAssignmentNode [
 { #category : #'visitor - double dispatching' }
 OCASTTranslator >> visitBlockNode: aBlockNode [
 	| compiledBlock |
-	aBlockNode arguments size >15 ifTrue: [self backendError: 'Too many arguments' forNode: aBlockNode ].
+	aBlockNode isError ifTrue: [ ^ self emitRuntimeError: aBlockNode ].
 
 	aBlockNode isInlined ifTrue: [^ self visitInlinedBlockNode: aBlockNode ].
 	(self compilationContext optionConstantBlockClosure and: [aBlockNode isConstant and: [ aBlockNode numArgs < 4  ]]) ifTrue: [ ^ self visitConstantBlockNode: aBlockNode].
@@ -650,7 +639,7 @@ OCASTTranslator >> visitMessageNode: aMessageNode [
 { #category : #'visitor - double dispatching' }
 OCASTTranslator >> visitMethodNode: aMethodNode [
 
-	aMethodNode arguments size > 15 ifTrue: [self backendError: 'Too many arguments' forNode: aMethodNode ].
+	aMethodNode isError ifTrue: [self emitRuntimeError: aMethodNode ].
 
 	methodBuilder compilationContext: aMethodNode compilationContext.
 	methodBuilder addTemps: aMethodNode scope tempVarNames.

--- a/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
@@ -52,7 +52,7 @@ RBCodeSnippetTest >> testDoSemanticAnalysis [
 	| ast |
 	ast := snippet doSemanticAnalysis.
 	self assert: ast isMethod.
-	"self assert: ast isFaulty equals: snippet isFaulty" self flag: #FIXME
+	self assert: ast isFaulty equals: snippet isFaulty
 ]
 
 { #category : #'*OpalCompiler-Tests' }

--- a/src/Reflectivity/RFASTTranslator.class.st
+++ b/src/Reflectivity/RFASTTranslator.class.st
@@ -114,7 +114,7 @@ RFASTTranslator >> visitAssignmentNode: anAssignmentNode [
 { #category : #'visitor - double dispatching' }
 RFASTTranslator >> visitBlockNode: aBlockNode [
 	| compiledBlock |
-	aBlockNode arguments size >15 ifTrue: [self backendError: 'Too many arguments' forNode: aBlockNode ].
+	aBlockNode isError ifTrue: [self emitRuntimeError: aBlockNode ].
 	aBlockNode isInlined ifTrue: [^ self visitInlinedBlockNode: aBlockNode ].
 
 	self emitPreamble: aBlockNode.
@@ -222,7 +222,7 @@ RFASTTranslator >> visitMessageNode: aMessageNode [
 RFASTTranslator >> visitMethodNode: aMethodNode [
 	"I ignore all links when I am primitive as ReflectiveMethod compiles a wrapper"
 
-	aMethodNode arguments size > 15 ifTrue: [self backendError: 'Too many arguments' forNode: aMethodNode ].
+	aMethodNode isError ifTrue: [self emitRuntimeError: aMethodNode ].
 
 	methodBuilder compilationContext: aMethodNode compilationContext.
 	methodBuilder addTemps: aMethodNode scope tempVarNames.


### PR DESCRIPTION
This PR extends AST API with basic methods for semantic error

* `addError:` to let compiler add semantic error information on Node
* `isError` to let AST user knows if the node is erroneous
* `isFaulty` is extended to encompass both syntax error (`RBParseErrorNode`) and other kind of errors (`isError`)

The internal implementation is to use a node property `#error`.

Currently, (I'm not aware of a plan to add more semantic error, so this is not the better term) there seems to be only 2 semantic errors: unwritable variable (for some reason read-only and reserved are distinguished) and too much argument (for block and methods), the latter was moved from backend to the semantic analysis (because the whole point of semantic analysis is to get these errors before compilation).
The status of undeclared variable as error is unclear and seems to depend on UI related stuff (and possibly the humidity level).

The code is deliberately written as simple as possible, first attempts were too much complex for a limited gain.

A possible future improvement could be to unify and reify errors and warnings (strings are poor).
Maybe look at how critiques does the deal.

UI related concerns (like nice icons in the icon bar) will be added in a future PR.

Another question is how much people like (or rely) on the current semantic error/warnings exception hierarchy (`OCSemanticError`, `OCStoreIntoReadOnlyVariableError`, `OCStoreIntoReservedVariableError`, `OCSemanticWarning`, `OCShadowVariableWarning`, `OCUndeclaredVariableWarning`)