### PR TITLE
Improve faulty compilation: sanify undeclared variables

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -402,8 +402,13 @@ RBCodeSnippet class >> badSemantic [
 	| list |
 	list := {
 		"Undefined variable"
-		"For some reason, this is just a warning in non-faulty mode, not an error."
-		self new source: 'a := 10. ^ a'; isFaulty: false; value: nil. "Weird, I expected to be 10"
+		"In non-faulty mode, undeclared variables are shared at the method level like implicit temporaries.
+		 However, specific context/requestors can change the deal."
+		self new source: 'a := 10. ^ a'; isFaulty: false; value: 10.
+		self new source: '[ a := 10 ]. ^ a'; isFaulty: false; value: nil.
+		self new source: '[ a := 10 ] value. ^ a'; isFaulty: false; value: 10.
+		self new source: 'b := [ a ]. a := 10. ^ b value + 1'; isFaulty: false; value: 11.
+		self new source: 'b := [ ^ a ]. a := 10. ^ b value + 1'; isFaulty: false; value: 10.
 		self new source: '^ a'; isFaulty: false; value: nil.
 
 		"Uninitialized variable"

--- a/src/Calypso-SystemPlugins-Undeclared-Queries-Tests/ClyClassWithUndeclares.class.st
+++ b/src/Calypso-SystemPlugins-Undeclared-Queries-Tests/ClyClassWithUndeclares.class.st
@@ -14,10 +14,10 @@ ClyClassWithUndeclares class >> withFloatReturn [
 
 { #category : #'with undeclares' }
 ClyClassWithUndeclares >> method1WithUndeclares [
-	^undeclaredStubInstVar1 printString
+	^UndeclaredStubInstVar1 printString
 ]
 
 { #category : #'with undeclares' }
 ClyClassWithUndeclares >> method2WithUndeclares [
-	undeclaredStubInstVar2 := 100
+	UndeclaredStubInstVar2 := 100
 ]

--- a/src/Kernel-Tests/CompiledCodeTest.class.st
+++ b/src/Kernel-Tests/CompiledCodeTest.class.st
@@ -212,22 +212,22 @@ CompiledCodeTest >> testLiteralsDoNotConsiderTheInnerBlockLiterals [
 	| method block |
 	method := self class compiler compile: 'method
 		<pragma: #pragma>
-		test := 1+2.
+		Test := 1+2.
 		Class.
 		self doIt: [
-		test := 1 - 2.
-		test := #(arrayInBlock).
+		Test := 1 - 2.
+		Test := #(arrayInBlock).
 		Object.
 		self name ].
 		^#(#array) '.
 	block := (self class compiler evaluate: '[
-		test := 1 - 2.
-		test := #(arrayInBlock).
+		Test := 1 - 2.
+		Test := #(arrayInBlock).
 		Object.
 		self name ]') compiledBlock.
 	self assertCollection: method literals equals: {
 			2.
-			(UndeclaredVariable key: #test value: nil).
+			(UndeclaredVariable key: #Test value: nil).
 			block.
 			#doIt:.
 			#( #array ).

--- a/src/Kernel/UndeclaredVariable.class.st
+++ b/src/Kernel/UndeclaredVariable.class.st
@@ -12,6 +12,21 @@ Class {
 }
 
 { #category : #'instance creation' }
+UndeclaredVariable class >> getWithName: aString [
+	"Undeclared variable from faulty code use the following rule:
+
+	If the name starts with a uppercase, the undeclared variable is registered, and if one already exists it is reused.
+	It means that the undeclared variable is shared (implicit global) and that future global variable (like a class) with the same name will replace it.
+
+	If the name starts with a lowercase, a new unregistered undeclared variable is returned.
+	"
+
+	^ aString first isUppercase
+		  ifTrue: [ self registeredWithName: aString ]
+		  ifFalse: [ self named: aString ]
+]
+
+{ #category : #'instance creation' }
 UndeclaredVariable class >> registeredWithName: aString [
 	| varName |
 	varName := aString asSymbol.

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -137,6 +137,7 @@ OCASTSemanticAnalyzer >> undeclaredVariable: variableNode [
 	^ OCUndeclaredVariableWarning new
 		  node: variableNode;
 		  compilationContext: compilationContext;
+		  undefinedVariable: var;
 		  signal
 ]
 

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -8,7 +8,8 @@ Class {
 	#instVars : [
 		'scope',
 		'compilationContext',
-		'blockCounter'
+		'blockCounter',
+		'undeclaredVariables'
 	],
 	#category : #'OpalCompiler-Core-Semantics'
 }
@@ -126,12 +127,23 @@ OCASTSemanticAnalyzer >> storeIntoReservedVariable: variableNode [
 
 { #category : #'error handling' }
 OCASTSemanticAnalyzer >> undeclaredVariable: variableNode [
-	compilationContext optionSkipSemanticWarnings
-		ifTrue: [ ^UndeclaredVariable named: variableNode name asSymbol ].
+
+	| var |
+	var := self undeclaredVariables
+		       at: variableNode name asSymbol
+		       ifAbsentPut: [ UndeclaredVariable named: variableNode name asSymbol ].
+
+	compilationContext optionSkipSemanticWarnings ifTrue: [ ^ var ].
 	^ OCUndeclaredVariableWarning new
-		node: variableNode;
-		compilationContext: compilationContext;
-		signal
+		  node: variableNode;
+		  compilationContext: compilationContext;
+		  signal
+]
+
+{ #category : #accessing }
+OCASTSemanticAnalyzer >> undeclaredVariables [
+
+	^ undeclaredVariables ifNil: [ undeclaredVariables := Dictionary new ]
 ]
 
 { #category : #'error handling' }

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -128,10 +128,11 @@ OCASTSemanticAnalyzer >> storeIntoReservedVariable: variableNode [
 { #category : #'error handling' }
 OCASTSemanticAnalyzer >> undeclaredVariable: variableNode [
 
-	| var |
+	| var name |
+	name := variableNode name asSymbol.
 	var := self undeclaredVariables
-		       at: variableNode name asSymbol
-		       ifAbsentPut: [ UndeclaredVariable named: variableNode name asSymbol ].
+		       at: name
+		       ifAbsentPut: [ UndeclaredVariable getWithName: name ].
 
 	compilationContext optionSkipSemanticWarnings ifTrue: [ ^ var ].
 	^ OCUndeclaredVariableWarning new

--- a/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
@@ -4,6 +4,9 @@ I get signalled when a temporary variable is used that is not defined.  My defau
 Class {
 	#name : #OCUndeclaredVariableWarning,
 	#superclass : #OCSemanticWarning,
+	#instVars : [
+		'undefinedVariable'
+	],
 	#category : #'OpalCompiler-Core-Exception'
 }
 
@@ -70,7 +73,7 @@ OCUndeclaredVariableWarning >> declareTempAndPaste: name [
 { #category : #correcting }
 OCUndeclaredVariableWarning >> declareUndefined [
 
-	^UndeclaredVariable registeredWithName: node name
+	^ undefinedVariable
 ]
 
 { #category : #correcting }
@@ -240,4 +243,16 @@ OCUndeclaredVariableWarning >> substituteWord: correctWord wordInterval: spot of
 					with: correctWord.
 
 	^ o + correctWord size - spot size
+]
+
+{ #category : #accessing }
+OCUndeclaredVariableWarning >> undefinedVariable [
+
+	^ undefinedVariable
+]
+
+{ #category : #accessing }
+OCUndeclaredVariableWarning >> undefinedVariable: anObject [
+
+	undefinedVariable := anObject
 ]

--- a/src/OpalCompiler-Tests/OCCompiledMethodIntegrityTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompiledMethodIntegrityTest.class.st
@@ -100,28 +100,28 @@ OCCompiledMethodIntegrityTest >> testUndeclaredVariable [
 	newCompiledMethod := OpalCompiler new
 		source:
 			'methodWithUndeclaredVar
-											^ undeclaredTestVar';
+											^ UndeclaredTestVar';
 		class: OCMockCompilationClass;
 		compile.
 
-	undeclaredBinding := newCompiledMethod literals detect: [ :each | each name = #undeclaredTestVar ].
+	undeclaredBinding := newCompiledMethod literals detect: [ :each | each name = #UndeclaredTestVar ].
 	self assert: undeclaredBinding class equals: UndeclaredVariable.
-	self assert: undeclaredBinding identicalTo: (Undeclared associationAt: #undeclaredTestVar).
+	self assert: undeclaredBinding identicalTo: (Undeclared associationAt: #UndeclaredTestVar).
 	undeclaredBinding unregister
 ]
 
 { #category : #tests }
 OCCompiledMethodIntegrityTest >> testUndeclaredVariableWhenItIsAlreadyRegistered [
 	| newCompiledMethod undeclaredBinding var |
-	var := UndeclaredVariable registeredWithName: #undeclaredTestVar.
+	var := UndeclaredVariable registeredWithName: #UndeclaredTestVar.
 	newCompiledMethod := OpalCompiler new
 		source:
 			'methodWithUndeclaredVar
-											^ undeclaredTestVar';
+											^ UndeclaredTestVar';
 		class: OCMockCompilationClass;
 		compile.
 
-	undeclaredBinding := newCompiledMethod literals detect: [ :each | each name = #undeclaredTestVar ].
+	undeclaredBinding := newCompiledMethod literals detect: [ :each | each name = #UndeclaredTestVar ].
 	self assert: undeclaredBinding identicalTo: var.
 	undeclaredBinding unregister
 ]
@@ -134,16 +134,16 @@ OCCompiledMethodIntegrityTest >> testUndeclaredVariableWhenItIsAlreadyRegistered
 	The bootstrap will be updated at some point. But now this case needs to be supported:
 		- declaring undefined var should update registered variable when its type is not undeclared var"
 	| newCompiledMethod undeclaredBinding |
-	Undeclared add: #undeclaredTestVar -> nil.
+	Undeclared add: #UndeclaredTestVar -> nil.
 	newCompiledMethod := OpalCompiler new
 		source:
 			'methodWithUndeclaredVar
-											^ undeclaredTestVar';
+											^ UndeclaredTestVar';
 		class: OCMockCompilationClass;
 		compile.
 
-	undeclaredBinding := newCompiledMethod literals detect: [ :each | each name = #undeclaredTestVar ].
+	undeclaredBinding := newCompiledMethod literals detect: [ :each | each name = #UndeclaredTestVar ].
 	self assert: undeclaredBinding class equals: UndeclaredVariable.
-	self assert: undeclaredBinding identicalTo: (Undeclared associationAt: #undeclaredTestVar).
+	self assert: undeclaredBinding identicalTo: (Undeclared associationAt: #UndeclaredTestVar).
 	undeclaredBinding unregister
 ]

--- a/src/OpalCompiler-Tests/OpalCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTest.class.st
@@ -147,3 +147,39 @@ OpalCompilerTest >> testEvaluateWithBindingsWithUppercaseName [
 		evaluate: '1+MyVar'.
 	self assert: result equals: 4
 ]
+
+{ #category : #tests }
+OpalCompilerTest >> testUndefinedVariableLowercase [
+
+	self
+		assert: {
+				OpalCompiler new
+					evaluate: 'undefinedName123 := 1. undefinedName123'.
+				OpalCompiler new
+					evaluate: 'undefinedName123'.
+				OpalCompiler new
+					options: #( + optionSkipSemanticWarnings );
+					evaluate: 'undefinedName123 := 2. undefinedName123'.
+				OpalCompiler new
+					options: #( + optionSkipSemanticWarnings );
+					evaluate: 'undefinedName123' }
+		equals: { 1. nil. 2. nil }
+]
+
+{ #category : #tests }
+OpalCompilerTest >> testUndefinedVariableUppercase [
+
+	self
+		assert: {
+				OpalCompiler new
+					evaluate: 'UndefinedName123 := 1. UndefinedName123'.
+				OpalCompiler new
+					evaluate: 'UndefinedName123'.
+				OpalCompiler new
+					options: #( + optionSkipSemanticWarnings );
+					evaluate: 'UndefinedName123 := 2. UndefinedName123'.
+				OpalCompiler new
+					options: #( + optionSkipSemanticWarnings );
+					evaluate: 'UndefinedName123' }
+		equals: { 1. 1. 2. 2 }
+]


### PR DESCRIPTION
Previously, running

```st
{
OpalCompiler new evaluate: 'a := 1. a'.
OpalCompiler new evaluate: 'a'.
OpalCompiler new options: #(+optionSkipSemanticWarnings); evaluate: 'a := 2. a'.
OpalCompiler new options: #(+optionSkipSemanticWarnings); evaluate: 'a'.
}
```

gave `#{1 1 nil nil}` (and no exception or nothing).

That is so weird.

* unrelated `a` variables are bound together in the first 2 expressions.
* related `a` variables are not bound together in the third expression.
* `optionSkipSemanticWarnings` should just skip warnings, not change the whole semantic of the language.

The PR tries to address this mess:

* Undefined variables are grouped together in a same semantic analysis. Basically playing as implicit temps
* OCUndeclaredVariableWarning stop creating globally shared undefined variable by default, and just use the implicit temp.

Now the same code give `1 nil 2 nil` \o/