### PR TITLE
fix the default loadLibrary: for linux

### DIFF
--- a/src/UnifiedFFI/UnixDynamicLoader.class.st
+++ b/src/UnifiedFFI/UnixDynamicLoader.class.st
@@ -4,8 +4,20 @@ I'm a unix platform (works in mac too) dynamic library loader.
 Class {
 	#name : #UnixDynamicLoader,
 	#superclass : #DynamicLoader,
+	#classVars : [
+		'RTLD_LAZY',
+		'RTLD_NOW'
+	],
 	#category : #'UnifiedFFI-Libraries'
 }
+
+{ #category : #'class initialization' }
+UnixDynamicLoader class >> initialize [
+
+	"flags for dlopen"
+	RTLD_LAZY := 1.
+	RTLD_NOW := 2
+]
 
 { #category : #testing }
 UnixDynamicLoader class >> isAvailable [
@@ -20,11 +32,18 @@ UnixDynamicLoader >> lastError [
 
 { #category : #misc }
 UnixDynamicLoader >> loadLibrary: path [
-	^ self loadLibrary: path flag: 0
+
+	^ self loadLibrary: path flag: RTLD_LAZY
 ]
 
 { #category : #misc }
 UnixDynamicLoader >> loadLibrary: filename flag: flag [
+	"
+	Flags can be:
+	RTLD_LAZY = 1
+	RTLD_NOW = 2
+	"
+
 	^ self ffiCall: #(void *dlopen(const char *filename, int flag))
 ]
 


### PR DESCRIPTION
which was receiving a wrong argument (zero) and it was causing the load to fail.
obviously, the fact nobody reported it talks about how much this is used, but well... :)