### PR TITLE
SDL2 on MacOS required to postpone focus

### DIFF
--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -129,14 +129,14 @@ OSWorldRenderer >> doActivate [
 	driver afterSetWindowTitle: Smalltalk image imageFile fullName onWindow: osWindow.
 	driver startUp: true.
 
-	"SDL2 on MacOS required to postpone focus.
-	See: https://github.com/pharo-project/pharo/issues/10981"
-	[ osWindow focus ] fork.
-
 	world worldState doFullRepaint.
 	world displayWorld.
 
-	OSWindowClipboard new beDefault
+	OSWindowClipboard new beDefault.
+
+	"SDL2 on MacOS presented a bug if this message send is done earlier on this method.
+	See: https://github.com/pharo-project/pharo/issues/10981"
+	osWindow focus
 ]
 
 { #category : #operations }

--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -129,7 +129,9 @@ OSWorldRenderer >> doActivate [
 	driver afterSetWindowTitle: Smalltalk image imageFile fullName onWindow: osWindow.
 	driver startUp: true.
 
-	osWindow focus.
+	"SDL2 on MacOS required to postpone focus.
+	See: https://github.com/pharo-project/pharo/issues/10981"
+	[ osWindow focus ] fork.
 
 	world worldState doFullRepaint.
 	world displayWorld.

--- a/src/OSWindow-SDL2/OSSDL2Driver.class.st
+++ b/src/OSWindow-SDL2/OSSDL2Driver.class.st
@@ -133,9 +133,6 @@ OSSDL2Driver >> createWindowWithAttributes: attributes osWindow: osWindow [
 		osWindow setJustCreatedHandle: aBackendWindow.
 	].
 
-	"Workaround to https://github.com/pharo-project/pharo/issues/10981"
-	20 milliSeconds wait.
-
 	^ aBackendWindow
 ]
 


### PR DESCRIPTION
- Fix #10981
- Revert previous unsuccessful fix: https://github.com/pharo-project/pharo/pull/11082
