### PR TITLE
add RBCodeSnippetTest>>testCompileWithRequestor

### DIFF
--- a/src/OpalCompiler-Tests/OCMockRequestor.class.st
+++ b/src/OpalCompiler-Tests/OCMockRequestor.class.st
@@ -1,0 +1,84 @@
+"
+I'm a test utility class that tries to mock a requestor API and just log callbacks
+"
+Class {
+	#name : #OCMockRequestor,
+	#superclass : #Object,
+	#instVars : [
+		'notifyList',
+		'interactive',
+		'isScripting'
+	],
+	#category : #'OpalCompiler-Tests-Misc'
+}
+
+{ #category : #binding }
+OCMockRequestor >> bindingOf: aSymbol [
+
+	^ nil
+]
+
+{ #category : #'interactive error protocol' }
+OCMockRequestor >> correctFrom: anInteger to: anInteger2 with: aString [
+
+	self error: 'I do not want to mock this one'
+]
+
+{ #category : #binding }
+OCMockRequestor >> hasBindingOf: aSymbol [
+
+	^ false
+]
+
+{ #category : #initialization }
+OCMockRequestor >> initialize [
+
+	notifyList := OrderedCollection new.
+	interactive := false
+]
+
+{ #category : #accessing }
+OCMockRequestor >> interactive [
+	^ interactive
+]
+
+{ #category : #accessing }
+OCMockRequestor >> interactive: anObject [
+
+	interactive := anObject
+]
+
+{ #category : #accessing }
+OCMockRequestor >> isScripting [
+	^ isScripting
+]
+
+{ #category : #testing }
+OCMockRequestor >> isScripting: aBoolean [
+
+	isScripting := aBoolean
+]
+
+{ #category : #'interactive error protocol' }
+OCMockRequestor >> notify: aString at: anInteger in: aString3 [
+
+	notifyList add: { aString. anInteger. aString3 }
+]
+
+{ #category : #accessing }
+OCMockRequestor >> notifyList [
+
+	^ notifyList
+]
+
+{ #category : #accessing }
+OCMockRequestor >> text [
+
+	^ 'I do not really care'
+]
+
+{ #category : #accessing }
+OCMockRequestor >> textMorph [
+
+	self error: 'Seriously, a Morph?'
+]

--- a/src/OpalCompiler-Tests/RBCodeSnippet.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippet.extension.st
@@ -21,7 +21,7 @@ RBCodeSnippet >> compileOnError: aBlock [
 
 	^ [ OpalCompiler new
 		  noPattern: isMethod not;
-		  compile: self source ] on: SyntaxErrorNotification do: [ :e | aBlock value: e ]
+		  compile: self source ] on: SyntaxErrorNotification do: [ :e | aBlock cull: e ]
 ]
 
 { #category : #'*OpalCompiler-Tests' }

--- a/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
@@ -24,6 +24,27 @@ RBCodeSnippetTest >> testCompileOnError [
 ]
 
 { #category : #'*OpalCompiler-Tests' }
+RBCodeSnippetTest >> testCompileWithRequestor [
+
+	| requestor method |
+	requestor := OCMockRequestor new.
+	requestor interactive: false.
+	requestor isScripting: snippet isMethod not. "Not sure how this lead to different information than `noPattern:` or it is just a redundant redundancy"
+	method := OpalCompiler new
+		          noPattern: snippet isMethod not;
+		          requestor: requestor;
+		          failBlock: [ "When a requestion is set, a failBlock MUST also be set or compilation might crash internally"
+			          self assert: snippet isFaulty.
+			          self assert: requestor notifyList isNotEmpty.
+			          ^ self ];
+		          compile: snippet source.
+
+	"Still alive? (failBlock never called)"
+	self deny: snippet isFaulty.
+	self assert: requestor notifyList isEmpty
+]
+
+{ #category : #'*OpalCompiler-Tests' }
 RBCodeSnippetTest >> testDecompile [
 
 	| method ast |


### PR DESCRIPTION
This adds a new test set for OpalCompiler when a (non-interactive) requestor is given (currently with more than 256 faulty or weird snippets to systematically test various corner cases).

Internal API of the OpalCompiler<->requestor relationship is quite hairy and most mocked method were found by reverse engineering (static and dynamic approaches).
Some code paths might have not been discovered yet :)

Future PR will try to also mock and test interactive requestors, but this is harder since real windows are open and human user interactions are expected without any clear control from the compiler nor the requestor (e.g. the common "unknown variable foo, please correct or cancel" menu).
Moreover, the semantic of the Pharo language change in interactive mode, so it might be another kind of testing challenge.