### PR TITLE
Object remove bindingOf: and hasBindingOf:

### DIFF
--- a/src/CodeImport/FileCompilerRequestor.class.st
+++ b/src/CodeImport/FileCompilerRequestor.class.st
@@ -13,6 +13,12 @@ Class {
 	#category : #'CodeImport-Utilities'
 }
 
+{ #category : #binding }
+FileCompilerRequestor >> bindingOf: aString [
+
+	^ nil
+]
+
 { #category : #accessing }
 FileCompilerRequestor >> contents [
 	^ contents
@@ -36,6 +42,12 @@ FileCompilerRequestor >> fileReference [
 { #category : #accessing }
 FileCompilerRequestor >> fileReference: anObject [
 	fileReference := anObject
+]
+
+{ #category : #binding }
+FileCompilerRequestor >> hasBindingOf: aString [
+
+	^ false
 ]
 
 { #category : #initialization }

--- a/src/CodeImport/MethodChunkCompilerRequestor.class.st
+++ b/src/CodeImport/MethodChunkCompilerRequestor.class.st
@@ -12,6 +12,12 @@ Class {
 	#category : #'CodeImport-Utilities'
 }
 
+{ #category : #binding }
+MethodChunkCompilerRequestor >> bindingOf: aString [
+
+	^ nil
+]
+
 { #category : #accessing }
 MethodChunkCompilerRequestor >> fileCompileRequestor [
 	^ fileCompileRequestor
@@ -20,6 +26,12 @@ MethodChunkCompilerRequestor >> fileCompileRequestor [
 { #category : #accessing }
 MethodChunkCompilerRequestor >> fileCompileRequestor: anObject [
 	fileCompileRequestor := anObject
+]
+
+{ #category : #binding }
+MethodChunkCompilerRequestor >> hasBindingOf: aString [
+
+	^ false
 ]
 
 { #category : #accessing }

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -518,12 +518,6 @@ Object >> beWritableObject [
 	^ self setIsReadOnlyObject: false
 ]
 
-{ #category : #binding }
-Object >> bindingOf: aString [
-
-	^ nil
-]
-
 { #category : #dependencies }
 Object >> breakDependents [
 	"Remove all of the receiver's dependents."
@@ -1010,12 +1004,6 @@ Object >> handleProcessTerminationOfWaitingContext: suspendedContext [
 { #category : #'error handling' }
 Object >> handles: exception [
 	"This method exists in case a non exception class is the first arg in an on:do: (for instance using a exception class that is not loaded). We prefer this to raising an error during error handling itself. Also, semantically it makes sense that the exception handler is not active if its exception class is not loaded"
-
-	^ false
-]
-
-{ #category : #binding }
-Object >> hasBindingOf: aString [
 
 	^ false
 ]

--- a/src/OpalCompiler-Tests/OCCompileWithFailureTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompileWithFailureTest.class.st
@@ -11,6 +11,18 @@ Class {
 	#category : #'OpalCompiler-Tests-Source'
 }
 
+{ #category : #binding }
+OCCompileWithFailureTest >> bindingOf: aString [
+
+	^ nil
+]
+
+{ #category : #binding }
+OCCompileWithFailureTest >> hasBindingOf: aString [
+
+	^ false
+]
+
 { #category : #'interactive error protocol' }
 OCCompileWithFailureTest >> notify: aMessage at: positon in: object [
 	"ingnore, for testEmptyBlockArg"

--- a/src/Rubric/RubScrolledTextMorph.class.st
+++ b/src/Rubric/RubScrolledTextMorph.class.st
@@ -220,6 +220,12 @@ RubScrolledTextMorph >> beWrapped [
 	self scrollPane beWrapped
 ]
 
+{ #category : #binding }
+RubScrolledTextMorph >> bindingOf: aString [
+
+	^ nil
+]
+
 { #category : #accessing }
 RubScrolledTextMorph >> borderStyleToUse [
 	"Answer the borderStyle that should be used for the receiver."
@@ -618,6 +624,12 @@ RubScrolledTextMorph >> handlesTextInputEvent: anEvent [
 	^ self scrollPane
 		  ifNotNil: [ :pane | pane handlesTextInputEvent: anEvent ]
 		  ifNil: [ super handlesTextInputEvent: anEvent ]
+]
+
+{ #category : #binding }
+RubScrolledTextMorph >> hasBindingOf: aString [
+
+	^ false
 ]
 
 { #category : #'model protocol' }


### PR DESCRIPTION
Because I just do not like them.
And, whatever they might be useful to should be put in a more specific class.
And, they do not even have any documentation.
And, I had a bad day so I'm grumpy.

More seriously, I'm not really sure if they are only related to some specific code path by requestors of OpalCompiler or if they are used for other concerns, so let's have the CI show us what will break.