### PR TITLE
backport-issue-12955: TFStringType is leaking when allocates the string for calling a function

### DIFF
--- a/src/ThreadedFFI-UFFI-Tests/TFUFFIDerivedTypeMarshallingTest.class.st
+++ b/src/ThreadedFFI-UFFI-Tests/TFUFFIDerivedTypeMarshallingTest.class.st
@@ -201,6 +201,20 @@ TFUFFIDerivedTypeMarshallingTest >> testMarshallingTrueReturnValue [
 ]
 
 { #category : #tests }
+TFUFFIDerivedTypeMarshallingTest >> testStringArgumentsAreReleasedIfNeeded [
+
+	| stringToMarshall cString initialSize |
+	[
+		initialSize := TFDerivedType string allocatedStrings size.
+
+		stringToMarshall := 'áèïô å∫'.
+		cString := self stringToPointer: stringToMarshall.
+
+		self assert: TFDerivedType string allocatedStrings size equals: initialSize
+	] ensure: [ cString free ]
+]
+
+{ #category : #tests }
 TFUFFIDerivedTypeMarshallingTest >> testSumSignedLongLong [
 
 	| return |

--- a/src/ThreadedFFI/TFStringType.class.st
+++ b/src/ThreadedFFI/TFStringType.class.st
@@ -66,16 +66,23 @@ TFStringType >> emitMarshallToPrimitive: anIRBuilder [
 
 ]
 
-{ #category : #writing }
+{ #category : #freeing }
 TFStringType >> freeValueIfNeeded: aCHeapValueHolder [
 	| pointer |
 
-	aCHeapValueHolder isNull ifTrue: [ ^ self ].
-	pointer := aCHeapValueHolder pointerAt: 1.
-	(self allocatedStrings includes: pointer) ifFalse: [ ^ self ].
+	aCHeapValueHolder isNull
+		ifTrue: [ ^ self ].
+
+	pointer := aCHeapValueHolder.
+
+	"If the pointer is a pointer to the string, and not the string directly"
+	(self allocatedStrings includes: pointer) ifFalse: [
+		pointer := aCHeapValueHolder pointerAt: 1.
+		(self allocatedStrings includes: pointer)
+			ifFalse: [ ^ self ]].
+
 	self allocatedStrings remove: pointer.
-	pointer isNull ifFalse: [ 
-		pointer free ]
+	pointer isNull ifFalse: [ pointer free ]
 ]
 
 { #category : #marshalling }


### PR DESCRIPTION
Fix #12955
Backporting fix of issue to Pharo 10.