### PR TITLE
New fix code importer

### DIFF
--- a/src/CodeImport-Tests/ChunkImportTestCase.class.st
+++ b/src/CodeImport-Tests/ChunkImportTestCase.class.st
@@ -17,6 +17,14 @@ ChunkImportTestCase >> importAClass [
 			category: ''CodeImport-Tests-Garbage''!'
 ]
 
+{ #category : #auxiliar }
+ChunkImportTestCase >> importAFluidClass [
+
+	^CodeImporter evaluateString: 'Object << #CodeImportTestCaseTestClass
+			slots: {#var1 . #var2 . #var3};
+			package: ''CodeImport-Tests-Garbage''!'
+]
+
 { #category : #'importing-code' }
 ChunkImportTestCase >> testExportAMethodWithLangTag [
 	|  stream chunkWriteStream |
@@ -177,6 +185,20 @@ ChunkImportTestCase >> testImportAClassCommentWithExclamationMarks [
 		class := self importAClass.
 		CodeImporter evaluateString: ('!{1} commentStamp: ''<historical>'' prior: 0!{2}!' format: { class name asString . commentToWrite }).
 		self assert: comment equals: class comment.
+	] ensure: [ class ifNotNil: [ class removeFromSystem ] ] ]
+]
+
+{ #category : #tests }
+ChunkImportTestCase >> testImportAFluidClass [
+	| class |
+	SystemAnnouncer uniqueInstance suspendAllWhile: [ [
+		class := self importAFluidClass.
+		self assert: #CodeImportTestCaseTestClass equals: class name.
+		self assert: (class instVarNames includes: 'var1').
+		self assert: (class instVarNames includes: 'var2').
+		self assert: (class instVarNames includes: 'var3').
+		self assert: class packageName equals: 'CodeImport-Tests-Garbage'.
+
 	] ensure: [ class ifNotNil: [ class removeFromSystem ] ] ]
 ]
 

--- a/src/CodeImport/ChunkFileFormatParser.class.st
+++ b/src/CodeImport/ChunkFileFormatParser.class.st
@@ -98,6 +98,11 @@ ChunkFileFormatParser >> doItChunkClass [
 	^ DoItChunk
 ]
 
+{ #category : #'as yet unclassified' }
+ChunkFileFormatParser >> fluidClassChunkClass [
+	^ FluidClassChunk
+]
+
 { #category : #initialization }
 ChunkFileFormatParser >> initialize [
 	super initialize.
@@ -236,7 +241,12 @@ ChunkFileFormatParser >> parseNextDeclaration [
 	isMetadata := readStream isNextChunkMetaData.
 	nextChunk := readStream next.
 	isMetadata
-		ifFalse: [ self addDeclaration: (self doItChunkClass contents: nextChunk) ]
+		ifFalse: [
+			| isFluid |
+				isFluid := (nextChunk splitOn: Character space) second = '<<'.
+				isFluid 
+					ifFalse: [ self addDeclaration: (self doItChunkClass contents: nextChunk) ]
+					ifTrue: [ self addDeclaration: (self fluidClassChunkClass contents: nextChunk) ] ]
 		ifTrue:
 			[
 			| substrings |

--- a/src/CodeImport/FluidClassChunk.class.st
+++ b/src/CodeImport/FluidClassChunk.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #FluidClassChunk,
+	#superclass : #CodeChunk,
+	#category : #'CodeImport-Chunks'
+}

--- a/src/CodeImport/FluidClassChunk.class.st
+++ b/src/CodeImport/FluidClassChunk.class.st
@@ -3,3 +3,35 @@ Class {
 	#superclass : #CodeChunk,
 	#category : #'CodeImport-Chunks'
 }
+
+{ #category : #visiting }
+FluidClassChunk >> accept: aVisitor [
+	self halt. 
+	self flag: #todo. 
+	"we should check the logic of the visitCodeChunk and adapt it to the fluid class."
+	^ aVisitor visitFluidClassChunk: self
+]
+
+{ #category : #accessing }
+FluidClassChunk >> description [
+	^ contents
+]
+
+{ #category : #importing }
+FluidClassChunk >> importFor: requestor logSource: logSource [ 
+
+
+	SystemAnnouncer uniqueInstance announce: (DoItChunkImported new
+		contents: contents;
+		requestor: requestor;
+		logSource: logSource;
+		yourself).
+	"We raise the same event because apparently there is only one."
+	
+	"we get a build so we ask it to install itself"
+	^ (Smalltalk compiler class new
+		source: contents;
+		requestor: requestor;
+		logged: logSource;
+		evaluate) install
+]

--- a/src/CodeImport/FluidClassChunk.class.st
+++ b/src/CodeImport/FluidClassChunk.class.st
@@ -6,9 +6,7 @@ Class {
 
 { #category : #visiting }
 FluidClassChunk >> accept: aVisitor [
-	self halt. 
-	self flag: #todo. 
-	"we should check the logic of the visitCodeChunk and adapt it to the fluid class."
+
 	^ aVisitor visitFluidClassChunk: self
 ]
 

--- a/src/Ring-ChunkImporter/RGChunkImporter.class.st
+++ b/src/Ring-ChunkImporter/RGChunkImporter.class.st
@@ -495,6 +495,123 @@ RGChunkImporter >> visitDoItChunk: aChunk [
 	doIts add: aChunk
 ]
 
+{ #category : #visiting }
+RGChunkImporter >> visitFluidClassChunk: aChunk [
+
+	| contents ast layoutClass selectorParts superclassName subclassName instanceVariableNames classVariableNames categoryName packageName poolDictionariesNames layoutDefinition slotsDefinition traitsDefinition isTrait hasNilSuperclass |
+
+	self halt.
+
+	contents := aChunk contents trimBoth.
+	(contents endsWith: '!') ifTrue: [ contents := contents allButLast ].
+
+	ast := RBParser parseExpression: contents onError: [
+		doIts add: aChunk.
+		^ self ].
+
+	layoutClass := selectorParts := superclassName := subclassName := instanceVariableNames :=
+		classVariableNames := categoryName := packageName := poolDictionariesNames := layoutDefinition :=
+		slotsDefinition := traitsDefinition := nil.
+
+	isTrait := false.
+
+	hasNilSuperclass := self isNilSuperclassDefinition: ast.
+	hasNilSuperclass
+		ifTrue: [ ast := ast statements first ].
+
+	(ast isMessage and: [self allowedSelectors includes: ast selector]) ifTrue: [
+		superclassName := ast receiver formattedCode.
+		self assert: ast arguments isNotEmpty.
+		selectorParts := ast selector findBetweenSubstrings: {$:}.
+
+		(superclassName endsWith: ' classTrait')
+			ifTrue: [isTrait := true]. "for usage of #uses:"
+
+		"TODO: handle removeSelector:, comment:"
+
+		self if: selectorParts in: ast includes: #subclass do: [:argument |
+			subclassName := argument value.
+			layoutClass := RGFixedLayout. ].
+
+		self if: selectorParts in: ast includes: #named do: [:argument |
+			subclassName := argument value.
+			isTrait := true.
+			layoutClass := RGFixedLayout. ].
+
+		self if: selectorParts in: ast includes: #immediateSubclass do: [:argument |
+			subclassName := argument value.
+			layoutClass := RGImmediateLayout ].
+
+		self if: selectorParts in: ast includes: #variableSubclass do: [:argument |
+			subclassName := argument value.
+			layoutClass := RGVariableLayout ].
+
+		self if: selectorParts in: ast includes: #variableByteSubclass do: [:argument |
+			subclassName := argument value.
+			layoutClass := RGByteLayout ].
+
+		self if: selectorParts in: ast includes: #variableWordSubclass do: [:argument |
+			subclassName := argument value.
+			layoutClass := RGWordLayout ].
+
+		self if: selectorParts in: ast includes: #weakSubclass do: [:argument |
+			subclassName := argument value.
+			layoutClass := RGWeakLayout ].
+
+		self if: selectorParts in: ast includes: #ephemeronSubclass do: [:argument |
+			subclassName := argument value.
+			layoutClass := RGEphemeronLayout ].
+
+		self if: selectorParts in: ast includes: #instanceVariableNames do: [:argument |
+			instanceVariableNames := argument value. ].
+
+		self if: selectorParts in: ast includes: #classVariableNames do: [:argument |
+			classVariableNames := argument value. ].
+
+		self if: selectorParts in: ast includes: #category do: [:argument |
+			categoryName := argument value. ].
+
+		self if: selectorParts in: ast includes: #package do: [:argument |
+			packageName := argument value. ].
+
+		self if: selectorParts in: ast includes: #poolDictionaries do: [:argument |
+			poolDictionariesNames := argument value. ].
+
+		self if: selectorParts in: ast includes: #layout do: [:argument |
+			layoutDefinition := argument formattedCode. ].
+
+		self if: selectorParts in: ast includes: #slots do: [:argument |
+			slotsDefinition := argument "use AST directly". ].
+
+		self if: selectorParts in: ast includes: #uses do: [:argument |
+			traitsDefinition := argument formattedCode. ].
+
+		hasNilSuperclass ifTrue: [superclassName := nil].
+
+		(#(#instanceVariableNames: uses: uses:instanceVariableNames:) includes: ast selector) ifTrue: [ 			subclassName := ast receiver formattedCode asSymbol.
+			superclassName := nil ].
+
+		(#(CompiledBlock CompiledCode CompiledMethod) includes: subclassName) ifTrue: [
+			layoutClass := RGCompiledMethodLayout ].
+
+		^ self createBehavior: subclassName
+			superclassName: superclassName
+			instanceVariableNames: instanceVariableNames
+			classVariableNames: classVariableNames
+			categoryName: categoryName
+			packageName: packageName
+			poolDictionariesNames: poolDictionariesNames
+			layoutClass: layoutClass
+			layoutDefinition: layoutDefinition
+			slotsDefinition: slotsDefinition
+			traits: traitsDefinition
+			isTrait: isTrait
+			hasNilSuperclass: hasNilSuperclass.
+	].
+
+	doIts add: aChunk
+]
+
 { #category : #visitor }
 RGChunkImporter >> visitMethodChunk: aChunk [
 

--- a/src/Ring-ChunkImporter/RGChunkImporter.class.st
+++ b/src/Ring-ChunkImporter/RGChunkImporter.class.st
@@ -498,118 +498,23 @@ RGChunkImporter >> visitDoItChunk: aChunk [
 { #category : #visiting }
 RGChunkImporter >> visitFluidClassChunk: aChunk [
 
-	| contents ast layoutClass selectorParts superclassName subclassName instanceVariableNames classVariableNames categoryName packageName poolDictionariesNames layoutDefinition slotsDefinition traitsDefinition isTrait hasNilSuperclass |
-
-	self halt.
+	| klass contents |
+	self flag: #ToCheck.
+	"I could not check this method because I have not idea how to test it. But the logic is there
+	I'm pretty sure that the result should be added to a RingEnvironment but it requires more investigation
+	and Ring Chunk importer imports more than just a class definition since it can be followed by 
+	other messsages."
 
 	contents := aChunk contents trimBoth.
 	(contents endsWith: '!') ifTrue: [ contents := contents allButLast ].
 
-	ast := RBParser parseExpression: contents onError: [
-		doIts add: aChunk.
-		^ self ].
-
-	layoutClass := selectorParts := superclassName := subclassName := instanceVariableNames :=
-		classVariableNames := categoryName := packageName := poolDictionariesNames := layoutDefinition :=
-		slotsDefinition := traitsDefinition := nil.
-
-	isTrait := false.
-
-	hasNilSuperclass := self isNilSuperclassDefinition: ast.
-	hasNilSuperclass
-		ifTrue: [ ast := ast statements first ].
-
-	(ast isMessage and: [self allowedSelectors includes: ast selector]) ifTrue: [
-		superclassName := ast receiver formattedCode.
-		self assert: ast arguments isNotEmpty.
-		selectorParts := ast selector findBetweenSubstrings: {$:}.
-
-		(superclassName endsWith: ' classTrait')
-			ifTrue: [isTrait := true]. "for usage of #uses:"
-
-		"TODO: handle removeSelector:, comment:"
-
-		self if: selectorParts in: ast includes: #subclass do: [:argument |
-			subclassName := argument value.
-			layoutClass := RGFixedLayout. ].
-
-		self if: selectorParts in: ast includes: #named do: [:argument |
-			subclassName := argument value.
-			isTrait := true.
-			layoutClass := RGFixedLayout. ].
-
-		self if: selectorParts in: ast includes: #immediateSubclass do: [:argument |
-			subclassName := argument value.
-			layoutClass := RGImmediateLayout ].
-
-		self if: selectorParts in: ast includes: #variableSubclass do: [:argument |
-			subclassName := argument value.
-			layoutClass := RGVariableLayout ].
-
-		self if: selectorParts in: ast includes: #variableByteSubclass do: [:argument |
-			subclassName := argument value.
-			layoutClass := RGByteLayout ].
-
-		self if: selectorParts in: ast includes: #variableWordSubclass do: [:argument |
-			subclassName := argument value.
-			layoutClass := RGWordLayout ].
-
-		self if: selectorParts in: ast includes: #weakSubclass do: [:argument |
-			subclassName := argument value.
-			layoutClass := RGWeakLayout ].
-
-		self if: selectorParts in: ast includes: #ephemeronSubclass do: [:argument |
-			subclassName := argument value.
-			layoutClass := RGEphemeronLayout ].
-
-		self if: selectorParts in: ast includes: #instanceVariableNames do: [:argument |
-			instanceVariableNames := argument value. ].
-
-		self if: selectorParts in: ast includes: #classVariableNames do: [:argument |
-			classVariableNames := argument value. ].
-
-		self if: selectorParts in: ast includes: #category do: [:argument |
-			categoryName := argument value. ].
-
-		self if: selectorParts in: ast includes: #package do: [:argument |
-			packageName := argument value. ].
-
-		self if: selectorParts in: ast includes: #poolDictionaries do: [:argument |
-			poolDictionariesNames := argument value. ].
-
-		self if: selectorParts in: ast includes: #layout do: [:argument |
-			layoutDefinition := argument formattedCode. ].
-
-		self if: selectorParts in: ast includes: #slots do: [:argument |
-			slotsDefinition := argument "use AST directly". ].
-
-		self if: selectorParts in: ast includes: #uses do: [:argument |
-			traitsDefinition := argument formattedCode. ].
-
-		hasNilSuperclass ifTrue: [superclassName := nil].
-
-		(#(#instanceVariableNames: uses: uses:instanceVariableNames:) includes: ast selector) ifTrue: [ 			subclassName := ast receiver formattedCode asSymbol.
-			superclassName := nil ].
-
-		(#(CompiledBlock CompiledCode CompiledMethod) includes: subclassName) ifTrue: [
-			layoutClass := RGCompiledMethodLayout ].
-
-		^ self createBehavior: subclassName
-			superclassName: superclassName
-			instanceVariableNames: instanceVariableNames
-			classVariableNames: classVariableNames
-			categoryName: categoryName
-			packageName: packageName
-			poolDictionariesNames: poolDictionariesNames
-			layoutClass: layoutClass
-			layoutDefinition: layoutDefinition
-			slotsDefinition: slotsDefinition
-			traits: traitsDefinition
-			isTrait: isTrait
-			hasNilSuperclass: hasNilSuperclass.
-	].
-
-	doIts add: aChunk
+	klass := ShiftClassBuilder new
+		buildEnvironment: self class environment;
+		"this is not really correct since the environment may be something else than the current environment."
+		
+		buildFromAST: (CDFluidClassDefinitionParser parse: contents);
+		build.	
+	^  klass asRingDefinition
 ]
 
 { #category : #visitor }

--- a/src/Ring-OldChunkImporter/RingChunkImporter.class.st
+++ b/src/Ring-OldChunkImporter/RingChunkImporter.class.st
@@ -105,6 +105,19 @@ RingChunkImporter >> fileInFrom: aStream [
 	changes do: [ :change | change accept: self ]
 ]
 
+{ #category : #private }
+RingChunkImporter >> fluidClassDefinition: aString with: chgRec [
+	| klass |
+	klass := ShiftClassBuilder new
+		buildEnvironment: self class environment;
+		"this is not really correct since the environment may be something else than the current environment."
+		
+		buildFromAST: (CDFluidClassDefinitionParser parse: aString);
+		build.
+	"klass is not a ring class but a not installed class. So it may break."	
+	package addClass: klass asRingDefinition
+]
+
 { #category : #reading }
 RingChunkImporter >> fromFileNamed: aName [
 
@@ -230,6 +243,15 @@ RingChunkImporter >> visitDoItChunk: aChunk [
 	('* initialize'
 		match: contents) ifTrue:[^self]. "Initialization is done based on class>>initialize"
 	doIts add: aChunk
+]
+
+{ #category : #visiting }
+RingChunkImporter >> visitFluidClassChunk: aFluidClassChunk [ 
+	
+	| contents |
+	contents := aFluidClassChunk contents.
+	('*<<*package:*'
+		match: contents) ifTrue:[^self fluidClassDefinition: contents with: aFluidClassChunk].
 ]
 
 { #category : #visitor }


### PR DESCRIPTION
Now you can drop a file out that uses fluidclass without breaking anything else.
All the three menu items that you can use from dropping the file are working. 
I added some tests. 

What this PR is not doing is fixing the Ring code importer since it is a lot more complex but this is not used in the filein.
