### PR TITLE
Rename "category" variables to "protocol"

### DIFF
--- a/src/CodeExport-Traits/TraitedClass.extension.st
+++ b/src/CodeExport-Traits/TraitedClass.extension.st
@@ -1,15 +1,14 @@
 Extension { #name : #TraitedClass }
 
 { #category : #'*CodeExport-Traits' }
-TraitedClass >> fileOutLocalMethodsInCategory: aSymbol on: aFileStream [
+TraitedClass >> fileOutLocalMethodsInCategory: aProtocol on: aFileStream [
+
 	| selectors |
-
 	aFileStream cr.
-	selectors := self selectorsToFileOutCategory: aSymbol.
+	selectors := self selectorsToFileOutCategory: aProtocol.
 
-	selectors do: [:sel |
-		((self isLocalSelector: sel) or: [ (self traitComposition selectors includes: sel) not]) ifTrue: [
-		self printMethodChunk: sel on: aFileStream ]].
+	selectors do: [ :selector |
+		((self isLocalSelector: selector) or: [ (self traitComposition selectors includes: selector) not ]) ifTrue: [ self printMethodChunk: selector on: aFileStream ] ].
 
 	^ self
 ]

--- a/src/CodeExport-Traits/TraitedMetaclass.extension.st
+++ b/src/CodeExport-Traits/TraitedMetaclass.extension.st
@@ -1,15 +1,13 @@
 Extension { #name : #TraitedMetaclass }
 
 { #category : #'*CodeExport-Traits' }
-TraitedMetaclass >> fileOutLocalMethodsInCategory: aSymbol on: aFileStream [
+TraitedMetaclass >> fileOutLocalMethodsInCategory: aProtocol on: aFileStream [
+
 	| selectors |
-	
 	aFileStream cr.
-	selectors := self selectorsToFileOutCategory: aSymbol.
-	
-	selectors do: [:sel | 
-		(self isLocalSelector: sel) ifTrue: [ 
-		self printMethodChunk: sel on: aFileStream ]].
-	
+	selectors := self selectorsToFileOutCategory: aProtocol.
+
+	selectors do: [ :sel | (self isLocalSelector: sel) ifTrue: [ self printMethodChunk: sel on: aFileStream ] ].
+
 	^ self
 ]

--- a/src/CodeExport/ClassDescription.extension.st
+++ b/src/CodeExport/ClassDescription.extension.st
@@ -1,9 +1,9 @@
 Extension { #name : #ClassDescription }
 
 { #category : #'*CodeExport' }
-ClassDescription >> fileOutCategory: catName [
+ClassDescription >> fileOutCategory: aProtocol [
 
-	self organization fileOutCategory: catName
+	self organization fileOutCategory: aProtocol
 ]
 
 { #category : #'*CodeExport' }
@@ -88,22 +88,29 @@ ClassDescription >> fileOutOrganizationOn: aFileStream [
 ]
 
 { #category : #'*CodeExport' }
-ClassDescription >> printCategoryChunk: category on: aFileStream withStamp: changeStamp priorMethod: priorMethod [
-	"Print a method category preamble.  This must have a category name.
+ClassDescription >> printCategoryChunk: aProtocol on: aFileStream withStamp: changeStamp priorMethod: priorMethod [
+	"Print a method category preamble.  This must have a protocol name.
 	It may have an author/date stamp, and it may have a prior source link.
 	If it has a prior source link, it MUST have a stamp, even if it is empty."
 
-"The current design is that changeStamps and prior source links are preserved in the changes file.  All fileOuts include changeStamps.  Condensing sources, however, eliminates all stamps (and links, natch)."
+	"The current design is that changeStamps and prior source links are preserved in the changes file.  All fileOuts include changeStamps.  Condensing sources, however, eliminates all stamps (and links, natch)."
 
-	aFileStream cr; nextPut: $!.
-	aFileStream nextChunkPut: (String streamContents:
-		[:strm |
-		strm nextPutAll: self name; nextPutAll: ' methodsFor: '; print: category asString.
-		(changeStamp ~~ nil and:
-			[changeStamp size > 0 or: [priorMethod ~~ nil]]) ifTrue:
-			[strm nextPutAll: ' stamp: '; print: changeStamp].
-		priorMethod ~~ nil ifTrue:
-			[strm nextPutAll: ' prior: '; print: priorMethod sourcePointer]])
+	aFileStream
+		cr;
+		nextPut: $!.
+	aFileStream nextChunkPut: (String streamContents: [ :strm |
+			 strm
+				 nextPutAll: self name;
+				 nextPutAll: ' methodsFor: ';
+				 print: aProtocol asString.
+			 (changeStamp ~~ nil and: [ changeStamp size > 0 or: [ priorMethod ~~ nil ] ]) ifTrue: [
+				 strm
+					 nextPutAll: ' stamp: ';
+					 print: changeStamp ].
+			 priorMethod ~~ nil ifTrue: [
+				 strm
+					 nextPutAll: ' prior: ';
+					 print: priorMethod sourcePointer ] ])
 ]
 
 { #category : #'*CodeExport' }

--- a/src/CodeExport/ClassDescription.extension.st
+++ b/src/CodeExport/ClassDescription.extension.st
@@ -152,6 +152,6 @@ ClassDescription >> printMethodChunk: selector on: outStream [
 ]
 
 { #category : #'*CodeExport' }
-ClassDescription >> selectorsToFileOutCategory: aSymbol [
-	^ self organization listAtCategoryNamed: aSymbol
+ClassDescription >> selectorsToFileOutCategory: aProtocol [
+	^ self organization listAtCategoryNamed: aProtocol
 ]

--- a/src/CodeImport/Categorizer.extension.st
+++ b/src/CodeImport/Categorizer.extension.st
@@ -4,11 +4,11 @@ Extension { #name : #Categorizer }
 Categorizer >> changeFromString: aString [
 	"Parse the argument, aString, and make this be the receiver's structure."
 
-	| categorySpecs |
-	categorySpecs := aString parseLiterals.
+	| protocolSpecs |
+	protocolSpecs := aString parseLiterals.
 	"If nothing was scanned and I had no elements before, then default me"
-	(categorySpecs isEmpty and: [elementArray isEmpty])
+	(protocolSpecs isEmpty and: [elementArray isEmpty])
 		ifTrue: [^ self setDefaultList: Array new].
 
-	^ self changeFromCategorySpecs: categorySpecs
+	^ self changeFromCategorySpecs: protocolSpecs
 ]

--- a/src/Epicea/CompiledMethod.extension.st
+++ b/src/Epicea/CompiledMethod.extension.st
@@ -4,11 +4,11 @@ Extension { #name : #CompiledMethod }
 CompiledMethod >> asEpiceaRingDefinition [
 
 	^ (RGMethodDefinition named: self selector)
-		parentName: self methodClass name;
-		isMetaSide: self methodClass isMeta;
-		protocol: self category;
-		sourceCode: self sourceCode;
-		stamp: self timeStamp;
-		package: (self package ifNotNil: [:package | package name]);
-		yourself
+		  parentName: self methodClass name;
+		  isMetaSide: self methodClass isMeta;
+		  protocol: self protocol;
+		  sourceCode: self sourceCode;
+		  stamp: self timeStamp;
+		  package: (self package ifNotNil: [ :package | package name ]);
+		  yourself
 ]

--- a/src/Kernel/Categorizer.class.st
+++ b/src/Kernel/Categorizer.class.st
@@ -45,9 +45,9 @@ Class {
 
 { #category : #'class initialization' }
 Categorizer class >> allCategory [
-	"Return a symbol that represents the virtual all methods category."
+	"Return a symbol that represents the virtual all methods protocol."
 
-	^#'-- all --'
+	^ #'-- all --'
 ]
 
 { #category : #'class initialization' }
@@ -97,36 +97,25 @@ Categorizer class >> sortAllCategories [
 ]
 
 { #category : #operations }
-Categorizer >> addCategory: newCategory [
-	^ self addCategory: newCategory before: nil
+Categorizer >> addCategory: aProtocol [
+	^ self addCategory: aProtocol before: nil
 ]
 
 { #category : #operations }
-Categorizer >> addCategory: catString before: nextCategory [
-	"Add a new category named heading.
-	If default category exists and is empty, remove it.
-	If nextCategory is nil, then add the new one at the end,
-	otherwise, insert it before nextCategory."
-	| index newCategory |
-	newCategory := catString asSymbol.
-	(categoryArray indexOf: newCategory) > 0
-		ifTrue: [^self].	"heading already exists, so done"
-	index := categoryArray indexOf: nextCategory
-		ifAbsent: [categoryArray size + 1].
-	categoryArray := categoryArray
-		copyReplaceFrom: index
-		to: index-1
-		with: (Array with: newCategory).
-	categoryStops := categoryStops
-		copyReplaceFrom: index
-		to: index-1
-		with: (Array with: (index = 1
-				ifTrue: [0]
-				ifFalse: [categoryStops at: index-1])).
+Categorizer >> addCategory: aProtocol before: nextProtocol [
+	"Add a new protocol named heading. If default protocol exists and is empty, remove it.
+	If nextProtocol is nil, then add the new one at the end, otherwise, insert it before nextProtocol."
+
+	| index newProtocol |
+	newProtocol := aProtocol asSymbol.
+	(categoryArray indexOf: newProtocol) > 0 ifTrue: [ ^ self ]. "heading already exists, so done"
+	index := categoryArray indexOf: nextProtocol ifAbsent: [ categoryArray size + 1 ].
+	categoryArray := categoryArray copyReplaceFrom: index to: index - 1 with: (Array with: newProtocol).
+	categoryStops := categoryStops copyReplaceFrom: index to: index - 1 with: (Array with: (index = 1
+				                   ifTrue: [ 0 ]
+				                   ifFalse: [ categoryStops at: index - 1 ])).
 	"remove empty default category"
-	(newCategory ~= Default
-			and: [(self listAtCategoryNamed: Default) isEmpty])
-		ifTrue: [self removeCategory: Default]
+	(newProtocol ~= Default and: [ (self listAtCategoryNamed: Default) isEmpty ]) ifTrue: [ self removeCategory: Default ]
 ]
 
 { #category : #accessing }
@@ -143,100 +132,92 @@ Categorizer >> assertInvariant [
 
 { #category : #private }
 Categorizer >> basicRemoveElement: element [
-	"Remove the selector, element, from all categories."
-	| categoryIndex elementIndex nextStop newElements |
-	categoryIndex := 1.
+	"Remove the selector, element, from all protocols."
+
+	| protocolIndex elementIndex nextStop newElements |
+	protocolIndex := 1.
 	elementIndex := 0.
 	nextStop := 0.
 	"nextStop keeps track of the stops in the new element array"
 	newElements := (Array new: elementArray size) writeStream.
-	[(elementIndex := elementIndex + 1) <= elementArray size]
-		whileTrue:
-			[[elementIndex > (categoryStops at: categoryIndex)]
-				whileTrue:
-					[categoryStops at: categoryIndex put: nextStop.
-					categoryIndex := categoryIndex + 1].
-			(elementArray at: elementIndex) = element
-				ifFalse:
-					[nextStop := nextStop + 1.
-					newElements nextPut: (elementArray at: elementIndex)]].
-	[categoryIndex <= categoryStops size]
-		whileTrue:
-			[categoryStops at: categoryIndex put: nextStop.
-			categoryIndex := categoryIndex + 1].
+	[ (elementIndex := elementIndex + 1) <= elementArray size ] whileTrue: [
+		[ elementIndex > (categoryStops at: protocolIndex) ] whileTrue: [
+			categoryStops at: protocolIndex put: nextStop.
+			protocolIndex := protocolIndex + 1 ].
+		(elementArray at: elementIndex) = element ifFalse: [
+			nextStop := nextStop + 1.
+			newElements nextPut: (elementArray at: elementIndex) ] ].
+	[ protocolIndex <= categoryStops size ] whileTrue: [
+		categoryStops at: protocolIndex put: nextStop.
+		protocolIndex := protocolIndex + 1 ].
 	elementArray := newElements contents.
 	self assertInvariant
 ]
 
 { #category : #accessing }
 Categorizer >> categories [
-	"Answer an Array of categories (names)."
-	categoryArray ifNil: [^ nil].
-	(categoryArray size = 1
-		and: [categoryArray first = Default & (elementArray isEmpty)])
-		ifTrue: [^Array with: NullCategory].
-	^categoryArray
+	"Answer an Array of protocols (names)."
+
+	categoryArray ifNil: [ ^ nil ].
+	(categoryArray size = 1 and: [ categoryArray first = Default & elementArray isEmpty ]) ifTrue: [ ^ Array with: NullCategory ].
+	^ categoryArray
 ]
 
 { #category : #accessing }
 Categorizer >> categories: anArray [
-	"Reorder my categories to be in order of the argument, anArray. If the
+	"Reorder my protocols to be in order of the argument, anArray. If the
 	resulting organization does not include all elements, then give an error."
 
-	| newCategories newStops newElements newElementsSet catName list runningTotal |
-
+	| newProtocols newStops newElements newElementsSet protocol list runningTotal |
 	anArray size < 2 ifTrue: [ ^ self ].
 
-	newCategories := Array new: anArray size.
+	newProtocols := Array new: anArray size.
 	newStops := Array new: anArray size.
 	newElements := OrderedCollection new: anArray size.
 	runningTotal := 0.
-	1 to: anArray size do:
-		[:i |
-		catName := (anArray at: i) asSymbol.
-		list := self listAtCategoryNamed: catName.
+	1 to: anArray size do: [ :index |
+		protocol := (anArray at: index) asSymbol.
+		list := self listAtCategoryNamed: protocol.
 		newElements addAllLast: list.
-		newCategories at: i put: catName.
-		newStops at: i put: (runningTotal := runningTotal + list size)].
+		newProtocols at: index put: protocol.
+		newStops at: index put: (runningTotal := runningTotal + list size) ].
 	newElements := newElements asArray.
 	"create a temporary set for super-fast includes check"
 	newElementsSet := newElements asSet.
-	elementArray do:
-		[:element | "check to be sure all elements are included"
-		(newElementsSet includes: element)
-			ifFalse: [^self error: 'New categories must match old ones']].
+	elementArray do: [ :element | "check to be sure all elements are included"
+		(newElementsSet includes: element) ifFalse: [ ^ self error: 'New categories must match old ones' ] ].
 	"Everything is good, now update my three arrays."
-	categoryArray := newCategories.
+	categoryArray := newProtocols.
 	categoryStops := newStops.
 	elementArray := newElements
 ]
 
 { #category : #queries }
 Categorizer >> categoryOfElement: element [
-	"Answer the category associated with the argument, element."
+	"Answer the protocol associated with the argument, element."
 
 	| index |
 	index := self numberOfCategoryOfElement: element.
 	^ index = 0
-		ifTrue: [ nil]
-		ifFalse: [ categoryArray at: index ]
+		  ifTrue: [ nil ]
+		  ifFalse: [ categoryArray at: index ]
 ]
 
 { #category : #operations }
-Categorizer >> changeFromCategorySpecs: categorySpecs [
+Categorizer >> changeFromCategorySpecs: protocolSpecs [
 	"Tokens is an array of categorySpecs as scanned from a browser 'reorganize' pane, or built up by some other process, such as a scan of an environment."
 
-	| newCategories newStops temp cc currentStop oldElements newElements |
+	| newProtocol newStops temp cc currentStop oldElements newElements |
 	oldElements := elementArray asSet.
-	newCategories := Array new: categorySpecs size.
-	newStops := Array new: categorySpecs size.
+	newProtocol := Array new: protocolSpecs size.
+	newStops := Array new: protocolSpecs size.
 	currentStop := 0.
 	newElements := (Array new: 16) writeStream.
-	1 to: categorySpecs size do: [ :i |
-		| selectors catSpec |
-		catSpec := categorySpecs at: i.
-		newCategories at: i put: catSpec first asSymbol.
-		selectors := catSpec allButFirst
+	1 to: protocolSpecs size do: [ :i |
+		| selectors protocolSpec |
+		protocolSpec := protocolSpecs at: i.
+		newProtocol at: i put: protocolSpec first asSymbol.
+		selectors := protocolSpec allButFirst
 			collect: [ :each |
 				each isSymbol
 					ifTrue: [ each ]
@@ -250,7 +231,7 @@ Categorizer >> changeFromCategorySpecs: categorySpecs [
 		newStops at: i put: currentStop ].	"Ignore extra elements but don't lose any existing elements!"
 	oldElements := oldElements collect: [ :elem | Array with: (self categoryOfElement: elem) with: elem ].
 	newElements := newElements contents.
-	categoryArray := newCategories.
+	categoryArray := newProtocol.
 	(cc := categoryArray asSet) size = categoryArray size
 		ifFalse: [
 			"has duplicate element"

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -969,10 +969,10 @@ ClassDescription >> removeProtocol: aString [
 	"Remove each of the messages categorized under aString in the method
 	dictionary of the receiver. Then remove the protocol aString."
 
-	| categoryName |
-	categoryName := aString asSymbol.
-	(self organization listAtCategoryNamed: categoryName) do: [ :sel | self removeSelector: sel ].
-	self organization removeCategory: categoryName
+	| protocol |
+	protocol := aString asSymbol.
+	(self organization listAtCategoryNamed: protocol) do: [ :sel | self removeSelector: sel ].
+	self organization removeCategory: protocol
 ]
 
 { #category : #'accessing - method dictionary' }
@@ -1005,21 +1005,16 @@ ClassDescription >> reorganize [
 ]
 
 { #category : #'accessing - method dictionary' }
-ClassDescription >> selectorsInCategory: aName [
-	"Answer a list of the selectors of the receiver that are in category named aName"
+ClassDescription >> selectorsInCategory: aProtocol [
 
-	| aColl |
-	aColl := Set withAll: (self organization listAtCategoryNamed: aName).
-	^ aColl asArray sort
+	^ self selectorsInProtocol: aProtocol
 ]
 
 { #category : #'accessing - method dictionary' }
-ClassDescription >> selectorsInProtocol: aName [
-	"Answer a list of the selectors of the receiver that are in category named aName"
+ClassDescription >> selectorsInProtocol: aProtocol [
+	"Answer a list of the selectors of the receiver that are in aProtocol"
 
-	| aColl |
-	aColl := Set withAll: (self organization listAtCategoryNamed: aName).
-	^ aColl asArray sort
+	^ (Set withAll: (self organization listAtCategoryNamed: aProtocol)) asArray sort
 ]
 
 { #category : #'pool variable' }
@@ -1248,10 +1243,10 @@ ClassDescription >> wantsChangeSetLogging [
 
 { #category : #organization }
 ClassDescription >> whichCategoryIncludesSelector: aSelector [
-	"Answer the category of the argument, aSelector, in the organization of
+	"Answer the protcol of the argument, aSelector, in the organization of
 	the receiver, or answer nil if the receiver does not inlcude this selector."
 
-	^self organization categoryOfElement: aSelector
+	^ self organization categoryOfElement: aSelector
 ]
 
 { #category : #queries }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -27,41 +27,33 @@ ClassDescription >> acceptsLoggingOfCompilation [
 ]
 
 { #category : #'accessing - method dictionary' }
-ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod inProtocol: category [
-	| priorMethodOrNil priorOriginOrNil oldProtocol newProtocol |
+ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod inProtocol: aProtocol [
 
-	priorMethodOrNil := self
-		compiledMethodAt: selector
-		ifAbsent: [ nil ].
+	| priorMethodOrNil priorOriginOrNil oldProtocol newProtocol |
+	priorMethodOrNil := self compiledMethodAt: selector ifAbsent: [ nil ].
 	priorMethodOrNil ifNotNil: [ priorOriginOrNil := priorMethodOrNil origin ].
 
 	self addSelectorSilently: selector withMethod: compiledMethod.
 
 	oldProtocol := self organization categoryOfElement: selector.
 	SystemAnnouncer uniqueInstance suspendAllWhile: [
-		self organization
-			classify: selector
-			under: (category = Protocol unclassified
-				ifTrue: [ oldProtocol ]
-				ifFalse: [ category ]) ].
+		self organization classify: selector under: (aProtocol = Protocol unclassified
+				 ifTrue: [ oldProtocol ]
+				 ifFalse: [ aProtocol ]) ].
 	newProtocol := self organization categoryOfElement: selector.
 
 	self isAnonymous ifTrue: [ ^ self ].
 
 	(priorMethodOrNil isNil or: [ priorOriginOrNil ~= compiledMethod origin ])
 		ifTrue: [ SystemAnnouncer uniqueInstance methodAdded: compiledMethod ]
-		ifFalse: [
-			"If protocol changed and someone is from different package, I need to throw a method recategorized"
+		ifFalse: [ "If protocol changed and someone is from different package, I need to throw a method recategorized"
 			self
 				notifyRepackage: selector
 				method: compiledMethod
 				oldProtocol: oldProtocol
 				newProtocol: newProtocol.
 
-			SystemAnnouncer uniqueInstance
-				methodChangedFrom: priorMethodOrNil
-				to: compiledMethod
-				oldProtocol: oldProtocol ]
+			SystemAnnouncer uniqueInstance methodChangedFrom: priorMethodOrNil to: compiledMethod oldProtocol: oldProtocol ]
 ]
 
 { #category : #organization }
@@ -381,62 +373,57 @@ ClassDescription >> compile: code classified: heading [
 	object that converts to a string or a PositionableStream on an object that
 	converts to a string."
 
-	^self
-		compile: code
-		classified: heading
-		notifying: nil
+	^ self compile: code classified: heading notifying: nil
 ]
 
 { #category : #compiling }
-ClassDescription >> compile: text classified: category notifying: requestor [
+ClassDescription >> compile: text classified: aProtocol notifying: requestor [
+
 	| stamp |
 	stamp := self acceptsLoggingOfCompilation
-		ifTrue: [ Author changeStamp ]
-		ifFalse: [ nil ].
+		         ifTrue: [ Author changeStamp ]
+		         ifFalse: [ nil ].
 	^ self
-		compile: text
-		classified: category
-		withStamp: stamp
-		notifying: requestor
+		  compile: text
+		  classified: aProtocol
+		  withStamp: stamp
+		  notifying: requestor
 ]
 
 { #category : #compiling }
-ClassDescription >> compile: text classified: category withStamp: changeStamp notifying: requestor [
+ClassDescription >> compile: text classified: aProtocol withStamp: changeStamp notifying: requestor [
+
 	^ self
-		compile: text
-		classified: category
-		withStamp: changeStamp
-		notifying: requestor
-		logSource: self acceptsLoggingOfCompilation
+		  compile: text
+		  classified: aProtocol
+		  withStamp: changeStamp
+		  notifying: requestor
+		  logSource: self acceptsLoggingOfCompilation
 ]
 
 { #category : #compiling }
-ClassDescription >> compile: text classified: category withStamp: changeStamp notifying: requestor logSource: logSource [
+ClassDescription >> compile: text classified: aProtocol withStamp: changeStamp notifying: requestor logSource: logSource [
 
 	| method selector |
-
 	method := self compiler
-		source: text;
-		requestor: requestor;
-		failBlock:  [ ^nil ];
-		compile.
+		          source: text;
+		          requestor: requestor;
+		          failBlock: [ ^ nil ];
+		          compile.
 
 	selector := method selector.
 	logSource ifTrue: [
 		self
-			logMethodSource: (requestor ifNotNil: [ :r | r text ] ifNil: [ text ]) "the requestor text might have been changed by the compiler and may be different thant text argument"
+			logMethodSource: (requestor
+					 ifNotNil: [ :r | r text ]
+					 ifNil: [ text ])
 			forMethod: method
-			inCategory: category
-			withStamp: changeStamp].
+			inCategory: aProtocol
+			withStamp: changeStamp "the requestor text might have been changed by the compiler and may be different thant text argument" ].
 
-	self
-		addAndClassifySelector: selector
-		withMethod: method
-		inProtocol: category.
+	self addAndClassifySelector: selector withMethod: method inProtocol: aProtocol.
 
-	self instanceSide
-		noteCompilationOfMethod: method
-		meta: self isClassSide.
+	self instanceSide noteCompilationOfMethod: method meta: self isClassSide.
 
 	^ selector
 ]
@@ -445,24 +432,21 @@ ClassDescription >> compile: text classified: category withStamp: changeStamp no
 ClassDescription >> compile: code notifying: requestor [
 	"Refer to the comment in Behavior|compile:notifying:."
 
-	^self compile: code
-		 classified: Protocol unclassified
-		 notifying: requestor
+	^ self compile: code classified: Protocol unclassified notifying: requestor
 ]
 
 { #category : #compiling }
-ClassDescription >> compileSilently: code classified: category [
-	"Compile the code and classify the resulting method in the given category, leaving no trail in the system log, nor in any change set, nor in the 'recent submissions' list. This should only be used when you know for sure that the compilation will succeed."
+ClassDescription >> compileSilently: code classified: aProtocol [
+	"Compile the code and classify the resulting method in the given protocol, leaving no trail in the system log, nor in any change set, nor in the 'recent submissions' list. This should only be used when you know for sure that the compilation will succeed."
 
-	^ self compileSilently: code classified: category notifying: nil
+	^ self compileSilently: code classified: aProtocol notifying: nil
 ]
 
 { #category : #compiling }
-ClassDescription >> compileSilently: code classified: category notifying: requestor [
-	"Compile the code and classify the resulting method in the given category, leaving no trail in the system log, nor in any change set, nor in the 'recent submissions' list. This should only be used when you know for sure that the compilation will succeed."
+ClassDescription >> compileSilently: code classified: aProtocol notifying: requestor [
+	"Compile the code and classify the resulting method in the given protocol, leaving no trail in the system log, nor in any change set, nor in the 'recent submissions' list. This should only be used when you know for sure that the compilation will succeed."
 
-	^ SystemAnnouncer uniqueInstance
-		suspendAllWhile: [self compile: code classified: category notifying: requestor]
+	^ SystemAnnouncer uniqueInstance suspendAllWhile: [ self compile: code classified: aProtocol notifying: requestor ]
 ]
 
 { #category : #copying }
@@ -478,50 +462,38 @@ ClassDescription >> copy: sel from: class [
 ]
 
 { #category : #copying }
-ClassDescription >> copy: sel from: class classified: cat [
-	"Install the method associated with the first arugment, sel, a message
+ClassDescription >> copy: aSelector from: class classified: aProtocol [
+	"Install the method associated with the first arugment, aSelector, a message
 	selector, found in the method dictionary of the second argument, class,
 	as one of the receiver's methods. Classify the message under the third
-	argument, cat."
+	argument, aProtocol."
 
-	| code category |
+	| code protocol |
 	"Useful when modifying an existing class"
-	code := class sourceCodeAt: sel.
-	code ifNotNil:
-			[cat
-				ifNil: [category := class organization categoryOfElement: sel]
-				ifNotNil: [category := cat].
-			(self includesLocalSelector: sel)
-				ifTrue: [code asString = (self sourceCodeAt: sel) asString
-							ifFalse: [self error: self name
-										, ' '
-										, sel
-										, ' will be redefined if you proceed.']].
-			self compile: code classified: category]
+	code := class sourceCodeAt: aSelector.
+	code ifNotNil: [
+		protocol := aProtocol ifNil: [ class organization categoryOfElement: aSelector ].
+		(self includesLocalSelector: aSelector) ifTrue: [
+			code asString = (self sourceCodeAt: aSelector) asString ifFalse: [ self error: self name , ' ' , aSelector , ' will be redefined if you proceed.' ] ].
+		self compile: code classified: protocol ]
 ]
 
 { #category : #copying }
-ClassDescription >> copyAll: selArray from: class [
+ClassDescription >> copyAll: arrayOfSelectors from: class [
 	"Install all the methods found in the method dictionary of the second
 	argument, class, as the receiver's methods. Classify the messages under
 	-As yet not classified-."
 
-	self copyAll: selArray
-		from: class
-		classified: nil
+	self copyAll: arrayOfSelectors from: class classified: nil
 ]
 
 { #category : #copying }
-ClassDescription >> copyAll: selArray from: class classified: cat [
+ClassDescription >> copyAll: arrayOfSelectors from: class classified: aProtocol [
 	"Install all the methods found in the method dictionary of the second
 	argument, class, as the receiver's methods. Classify the messages under
-	the third argument, cat."
+	the third argument, aProtocol."
 
-	selArray do: [:s |
-		(class includesLocalSelector: s) ifTrue: [
-			self copy: s
-				from: class
-				classified: cat ] ]
+	arrayOfSelectors do: [ :selector | (class includesLocalSelector: selector) ifTrue: [ self copy: selector from: class classified: aProtocol ] ]
 ]
 
 { #category : #copying }
@@ -531,28 +503,24 @@ ClassDescription >> copyAllCategoriesFrom: aClass [
 	these categories into the method dictionary of the receiver, classified
 	under the appropriate categories."
 
-	aClass organization categories do: [:cat | self copyCategory: cat from: aClass]
+	aClass organization categories do: [ :protocol | self copyCategory: protocol from: aClass ]
 ]
 
 { #category : #copying }
-ClassDescription >> copyCategory: cat from: class [
-	"Specify that one of the categories of messages for the receiver is cat, as
+ClassDescription >> copyCategory: aProtocol from: class [
+	"Specify that one of the categories of messages for the receiver is aProtocol, as
 	found in the class, class. Copy each message found in this category."
 
-	self copyCategory: cat
-		from: class
-		classified: cat
+	self copyCategory: aProtocol from: class classified: aProtocol
 ]
 
 { #category : #copying }
-ClassDescription >> copyCategory: cat from: aClass classified: newCat [
+ClassDescription >> copyCategory: aProtocol from: aClass classified: newProtocol [
 	"Specify that one of the categories of messages for the receiver is the
-	third argument, newCat. Copy each message found in the category cat in
-	class aClass into this new category."
+	third argument, newProtocol. Copy each message found in the protocol cat in
+	class aClass into this new protocol."
 
-	self copyAll: (aClass organization listAtCategoryNamed: cat)
-		from: aClass
-		classified: newCat
+	self copyAll: (aClass organization listAtCategoryNamed: aProtocol) from: aClass classified: newProtocol
 ]
 
 { #category : #slots }
@@ -883,14 +851,11 @@ ClassDescription >> noteCompilationOfMethod: aCompiledMethod meta: isMeta [
 ]
 
 { #category : #'organization updating' }
-ClassDescription >> notifyOfRecategorizedSelector: selector from: oldCategory to: newCategory [
+ClassDescription >> notifyOfRecategorizedSelector: selector from: oldProtocol to: newProtocol [
 	"If compiled method is not there, it meens it has been removed, not recategorized... so I skip
 	 the method recategorized announce"
-	(self compiledMethodAt: selector ifAbsent: [ nil ])
-		ifNotNil: [ :method |
-			SystemAnnouncer uniqueInstance
-				methodRecategorized: method
-				oldProtocol: oldCategory ]
+
+	(self compiledMethodAt: selector ifAbsent: [ nil ]) ifNotNil: [ :method | SystemAnnouncer uniqueInstance methodRecategorized: method oldProtocol: oldProtocol ]
 ]
 
 { #category : #private }
@@ -1002,11 +967,11 @@ ClassDescription >> removeMethodTag: aSymbol [
 { #category : #'accessing - method dictionary' }
 ClassDescription >> removeProtocol: aString [
 	"Remove each of the messages categorized under aString in the method
-	dictionary of the receiver. Then remove the category aString."
+	dictionary of the receiver. Then remove the protocol aString."
+
 	| categoryName |
 	categoryName := aString asSymbol.
-	(self organization listAtCategoryNamed: categoryName) do:
-		[:sel | self removeSelector: sel].
+	(self organization listAtCategoryNamed: categoryName) do: [ :sel | self removeSelector: sel ].
 	self organization removeCategory: categoryName
 ]
 
@@ -1068,8 +1033,7 @@ ClassDescription >> sharedPoolOfVarNamed: aString [
 ClassDescription >> sharedPoolString [
 	"Answer a string of my shared pools separated by spaces."
 
-	^String streamContents: [ :stream |
-		self sharedPoolStringOn: stream ]
+	^ String streamContents: [ :stream | self sharedPoolStringOn: stream ]
 ]
 
 { #category : #printing }

--- a/src/Monticello-Tests/MCMethodDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCMethodDefinitionTest.class.st
@@ -94,15 +94,15 @@ MCMethodDefinitionTest >> testLoadAndUnload [
 MCMethodDefinitionTest >> testMethodDefinitionWithEmptyProtocolIsClassifiedAsAsYetUnclassified [
 
 	| methodDef |
-	methodDef := (MCMethodDefinition
-			className: #Object
-			classIsMeta: false
-			selector: #name
-			category: '' 
-			timeStamp: nil
-			source: 'name
-	^ self printString').
-	self assert: methodDef category equals: #'as yet unclassified'.
+	methodDef := MCMethodDefinition
+		             className: #Object
+		             classIsMeta: false
+		             selector: #name
+		             category: ''
+		             timeStamp: nil
+		             source: 'name
+	^ self printString'.
+	self assert: methodDef protocol equals: #'as yet unclassified'
 ]
 
 { #category : #testing }

--- a/src/Monticello/MCMethodDefinition.class.st
+++ b/src/Monticello/MCMethodDefinition.class.st
@@ -18,11 +18,11 @@ Class {
 	#instVars : [
 		'classIsMeta',
 		'source',
-		'category',
 		'selector',
 		'className',
 		'timeStamp',
-		'sortKey'
+		'sortKey',
+		'protocol'
 	],
 	#classVars : [
 		'Definitions',
@@ -101,9 +101,8 @@ MCMethodDefinition class >> shutDown [
 
 { #category : #comparing }
 MCMethodDefinition >> = aDefinition [
-	^ super = aDefinition
-		and: [ aDefinition category = self category
-		and: [ aDefinition source withInternalLineEndings = self source withInternalLineEndings ] ]
+
+	^ super = aDefinition and: [ aDefinition protocol = self protocol and: [ aDefinition source withInternalLineEndings = self source withInternalLineEndings ] ]
 ]
 
 { #category : #visiting }
@@ -123,24 +122,24 @@ MCMethodDefinition >> actualClass [
 
 { #category : #installing }
 MCMethodDefinition >> addMethodAdditionTo: aCollection [
+
 	| methodAddition |
 	methodAddition := MethodAddition new
-		compile: source
-		classified: category
-		withStamp: timeStamp
-		notifying: nil
-		logSource: true
-		inClass: self actualClass.
+		                  compile: source
+		                  classified: protocol
+		                  withStamp: timeStamp
+		                  notifying: nil
+		                  logSource: true
+		                  inClass: self actualClass.
 	"This might raise an exception and never return"
 	methodAddition createCompiledMethod.
-	aCollection add: methodAddition.
-
+	aCollection add: methodAddition
 ]
 
 { #category : #'accessing - backward' }
 MCMethodDefinition >> category [
 	"Please favor protocol instead of category. We want to have method protocol and class package and tag = a category"
-	^ category
+	^ protocol
 ]
 
 { #category : #accessing }
@@ -150,21 +149,21 @@ MCMethodDefinition >> classIsMeta [
 
 { #category : #accessing }
 MCMethodDefinition >> className [
-	^className
+
+	^ className
 ]
 
 { #category : #printing }
 MCMethodDefinition >> description [
-	^ Array	
-		with: className
-		with: selector
-		with: classIsMeta
+
+	^ Array with: className with: selector with: classIsMeta
 ]
 
 { #category : #accessing }
 MCMethodDefinition >> diffSource [
-	^'"protocol: ', self protocol,'"
-', self source.
+
+	^ '"protocol: ' , self protocol , '"
+' , self source
 ]
 
 { #category : #printing }
@@ -189,23 +188,19 @@ MCMethodDefinition >> hash [
 	| hash |
 	hash := String stringHash: classIsMeta asString initialHash: 0.
 	hash := String stringHash: source initialHash: hash.
-	hash := String stringHash: category initialHash: hash.
+	hash := String stringHash: protocol initialHash: hash.
 	hash := String stringHash: className initialHash: hash.
 	^ hash
 ]
 
 { #category : #serializing }
-MCMethodDefinition >> initializeWithClassName: classString
-classIsMeta: metaBoolean
-selector: selectorString
-category: catString
-timeStamp: timeString
-source: sourceString [
+MCMethodDefinition >> initializeWithClassName: classString classIsMeta: metaBoolean selector: selectorString category: aProtocol timeStamp: timeString source: sourceString [
+
 	className := classString asSymbol.
 	selector := selectorString asSymbol.
-	category := catString
-		ifNil: [ #'as yet unclassified']
-		ifNotNil: [ (catString asSymbol) ifEmpty: [#'as yet unclassified']].
+	protocol := aProtocol
+		            ifNil: [ #'as yet unclassified' ]
+		            ifNotNil: [ aProtocol asSymbol ifEmpty: [ #'as yet unclassified' ] ].
 	timeStamp := timeString.
 	classIsMeta := metaBoolean.
 	source := sourceString withInternalLineEndings
@@ -218,7 +213,7 @@ MCMethodDefinition >> isCodeDefinition [
 
 { #category : #installing }
 MCMethodDefinition >> isExtensionMethod [
-	^ category beginsWith: '*'
+	^ protocol beginsWith: '*'
 ]
 
 { #category : #installing }
@@ -253,14 +248,14 @@ MCMethodDefinition >> isMethodDefinition [
 { #category : #installing }
 MCMethodDefinition >> isOverrideMethod [
 	"this oughta check the package"
-	^ self isExtensionMethod and: [category endsWith: '-override']
+	^ self isExtensionMethod and: [protocol endsWith: '-override']
 ]
 
 { #category : #accessing }
 MCMethodDefinition >> load [
 	self actualClass
 		compile: source
-		classified: category
+		classified: protocol
 		withStamp: timeStamp
 		notifying: nil
 ]
@@ -272,15 +267,11 @@ MCMethodDefinition >> overridenMethodOrNil [
 	Preconditions: 
 	  - self actualClass is installed in the System Dictionary.
 	  - self isOverrideMethod is true."
-	
+
 	| realMethod |
-	realMethod := self actualClass
-		compiledMethodAt: self selector
-		ifAbsent: [ ^ nil ].
-		
-	^ SourceFiles
-		changeRecordsFor: realMethod asRingDefinition
-		detect: [ :protocol | protocol ~= category ]
+	realMethod := self actualClass compiledMethodAt: self selector ifAbsent: [ ^ nil ].
+
+	^ SourceFiles changeRecordsFor: realMethod asRingDefinition detect: [ :p | p ~= protocol ]
 ]
 
 { #category : #installing }
@@ -299,49 +290,49 @@ MCMethodDefinition >> postloadOver: aDefinition [
 { #category : #annotations }
 MCMethodDefinition >> printAnnotations: requests on: aStream [
 	"Add a string for an annotation pane, trying to fulfill the browser annotationRequests."
-	
-	requests do: [ :aRequest |
-		aRequest == #timeStamp ifTrue: [ aStream nextPutAll: self timeStamp ].
-		aRequest == #messageCategory ifTrue: [ aStream nextPutAll: self category ].
-		aRequest == #requirements ifTrue: [
-			self requirements do: [ :req |
-				aStream nextPutAll: req ] separatedBy: [ aStream space ]].
-	] separatedBy: [ aStream space ].
+
+	requests
+		do: [ :aRequest |
+			aRequest == #timeStamp ifTrue: [ aStream nextPutAll: self timeStamp ].
+			aRequest == #messageCategory ifTrue: [ aStream nextPutAll: self protocol ].
+			aRequest == #requirements ifTrue: [ self requirements do: [ :req | aStream nextPutAll: req ] separatedBy: [ aStream space ] ] ]
+		separatedBy: [ aStream space ]
 ]
 
 { #category : #accessing }
 MCMethodDefinition >> protocol [
 	"Return in which protocol (conceptual groups of methods) the receiver is grouped into."
-	^ category
+	^ protocol
 ]
 
 { #category : #installing }
 MCMethodDefinition >> removeSelector: aSelector fromClass: aClass [
 	"Safely remove the given selector from the target class.
 	Be careful not to remove the selector when it has wandered
-	to another package, but remove the category if it is empty."
+	to another package, but remove the protocol if it is empty."
 
 	| newProtocol |
 	newProtocol := aClass organization categoryOfElement: aSelector.
 	newProtocol
 		ifNotNil: [ 
 			"If moved to and fro extension, ignore removal"
-			(category beginsWith: '*') = (newProtocol beginsWith: '*')
+			(protocol beginsWith: '*') = (newProtocol beginsWith: '*')
 				ifFalse: [ ^ self ].	"Check if moved between different extension categories"
-			((category beginsWith: '*') and: [ category ~= newProtocol ])
+			((protocol beginsWith: '*') and: [ protocol ~= newProtocol ])
 				ifTrue: [ ^ self ] ].
 	aClass removeSelector: aSelector.
-	aClass organization removeProtocolIfEmpty: category
+	aClass organization removeProtocolIfEmpty: protocol
 ]
 
-{ #category : #comparing }
+{ #category : #accessing }
 MCMethodDefinition >> requirements [
 	^ Array with: className
 ]
 
 { #category : #accessing }
 MCMethodDefinition >> selector [
-	^selector
+
+	^ selector
 ]
 
 { #category : #printing }

--- a/src/OpalCompiler-Core/CompiledMethod.extension.st
+++ b/src/OpalCompiler-Core/CompiledMethod.extension.st
@@ -28,7 +28,8 @@ CompiledMethod >> recompile [
 
 { #category : #'*OpalCompiler-Core' }
 CompiledMethod >> reformat [
-	self methodClass compile: self ast formattedCode classified:  self category
+
+	self methodClass compile: self ast formattedCode classified: self protocol
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/RPackage-Core/ClassDescription.extension.st
+++ b/src/RPackage-Core/ClassDescription.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #ClassDescription }
 
 { #category : #'*RPackage-Core' }
 ClassDescription >> compileSilently: code [
-	"Compile the code and classify the resulting method in the given category, leaving no trail in the system log, nor in any change set, nor in the 'recent submissions' list. This should only be used when you know for sure that the compilation will succeed."
+	"Compile the code and classify the resulting method in the given protocol, leaving no trail in the system log, nor in any change set, nor in the 'recent submissions' list. This should only be used when you know for sure that the compilation will succeed."
 
 	^ self compileSilently: code classified: 'not defined category' notifying: nil
 ]

--- a/src/Ring-Definitions-Core/CompiledMethod.extension.st
+++ b/src/Ring-Definitions-Core/CompiledMethod.extension.st
@@ -27,21 +27,21 @@ CompiledMethod >> asFullRingDefinition [
 
 { #category : #'*Ring-Definitions-Core' }
 CompiledMethod >> asHistoricalRingDefinition [
-
 	"Retrieves a historical RGMethodDefinition object based on the data of the receiver.
 	Source, protocol and stamp are retrieved from the source file method"
+
 	| ring |
 	ring := (RGMethodDefinition named: self selector)
-				parentName: self methodClass name;
-				isMetaSide: self methodClass isMeta.
+		        parentName: self methodClass name;
+		        isMetaSide: self methodClass isMeta.
 
 	self sourcePointer isZero
 		ifTrue: [ "this should not happen but sometimes the system looks corrupted"
-			ring protocol: self category;
+			ring
+				protocol: self protocol;
 				sourceCode: self sourceCode;
 				stamp: self timeStamp ]
-		ifFalse: [
-			ring sourcePointer: self sourcePointer ].
+		ifFalse: [ ring sourcePointer: self sourcePointer ].
 	ring asHistorical.
 
 	^ ring
@@ -52,14 +52,14 @@ CompiledMethod >> asPassiveRingDefinition [
 	"Retrieves a passive RGMethodDefinition object based on the data of the receiver.
 	Source, protocol and stamp are retrieved from value assigned in creation"
 
-	^RGMethodDefinition new
-		 	name: self selector;
-			parentName: self methodClass name;
-			isMetaSide: self methodClass isMeta;
-			protocol: self category;
-			sourceCode: self sourceCode;
-			stamp: self timeStamp;
-			asPassive
+	^ RGMethodDefinition new
+		  name: self selector;
+		  parentName: self methodClass name;
+		  isMetaSide: self methodClass isMeta;
+		  protocol: self protocol;
+		  sourceCode: self sourceCode;
+		  stamp: self timeStamp;
+		  asPassive
 ]
 
 { #category : #'*Ring-Definitions-Core' }

--- a/src/Ring-Definitions-Monticello/MCMethodDefinition.extension.st
+++ b/src/Ring-Definitions-Monticello/MCMethodDefinition.extension.st
@@ -3,11 +3,11 @@ Extension { #name : #MCMethodDefinition }
 { #category : #'*Ring-Definitions-Monticello' }
 MCMethodDefinition >> asRingDefinition [
 
-	^RGMethodDefinition new
-		name: self selector;
-		parentName: self className;
-		isMetaSide: self classIsMeta;
-		protocol: self protocol;
-		sourceCode: self source;
-		stamp: self timeStamp
+	^ RGMethodDefinition new
+		  name: self selector;
+		  parentName: self className;
+		  isMetaSide: self classIsMeta;
+		  protocol: self protocol;
+		  sourceCode: self source;
+		  stamp: self timeStamp
 ]

--- a/src/Ring-Monticello/MCMethodDefinition.extension.st
+++ b/src/Ring-Monticello/MCMethodDefinition.extension.st
@@ -17,7 +17,7 @@ MCMethodDefinition >> asRGDefinition [
 MCMethodDefinition >> ensureRingDefinitionIn: anRGEnvironment [
 
 	^ anRGEnvironment backend definitionFor: self ifAbsentRegister: [
-		| def classDef metaclassDef parent protocol |
+		| def classDef metaclassDef parent aProtocol |
 		classDef := anRGEnvironment ensureClassNamed: self className asSymbol.
 
 		classDef isTrait
@@ -41,9 +41,9 @@ MCMethodDefinition >> ensureRingDefinitionIn: anRGEnvironment [
 		def author: (self authorForStamp: self timeStamp).
 		def time: (self timeForStamp: self timeStamp).
 
-		protocol := parent ensureProtocolNamed: self category asSymbol.
-		parent addProtocol: protocol.
-		def protocol: protocol.
+		aProtocol := parent ensureProtocolNamed: self category asSymbol.
+		parent addProtocol: aProtocol.
+		def protocol: aProtocol.
 		def
 	]
 ]

--- a/src/System-Sources/ClassDescription.extension.st
+++ b/src/System-Sources/ClassDescription.extension.st
@@ -1,13 +1,12 @@
 Extension { #name : #ClassDescription }
 
 { #category : #'*System-Sources' }
-ClassDescription >> logMethodSource: aText forMethod: aCompiledMethod inCategory: category withStamp: changeStamp [
+ClassDescription >> logMethodSource: aText forMethod: aCompiledMethod inCategory: aProtocol withStamp: changeStamp [
+
 	aCompiledMethod
 		putSource: aText
 		class: self
-		category: category
+		category: aProtocol
 		withStamp: changeStamp
-		priorMethod: (self
-					compiledMethodAt: aCompiledMethod selector
-					ifAbsent: [])
+		priorMethod: (self compiledMethodAt: aCompiledMethod selector ifAbsent: [  ])
 ]

--- a/src/Tests/ClassTraitTest.class.st
+++ b/src/Tests/ClassTraitTest.class.st
@@ -12,26 +12,26 @@ ClassTraitTest >> testChanges [
 	| classTrait |
 	classTrait := self t1 classTrait.
 	self deny: (self t5 classSide includesSelector: #m1ClassSide).
-	classTrait compile: 'm1ClassSide ^17' classified: 'mycategory'.	"local selectors"
+	classTrait compile: 'm1ClassSide ^17' classified: 'myprotocol'.	"local selectors"
 	self assert: (classTrait includesLocalSelector: #m1ClassSide).
 	self deny: (classTrait includesLocalSelector: #otherSelector).	"propagation"
 	self assert: (self t5 classSide methodDict includesKey: #m1ClassSide).
 	self assert: (self c2 class methodDict includesKey: #m1ClassSide).
 	self c2 m1ClassSide.
 	self assert: self c2 m1ClassSide equals: 17.	"category"
-	self assert: (self c2 class organization categoryOfElement: #m1ClassSide) equals: 'mycategory'.	"conflicts"
-	self t2 classSide compile: 'm1ClassSide' classified: 'mycategory'.
+	self assert: (self c2 class organization categoryOfElement: #m1ClassSide) equals: 'myprotocol'.	"conflicts"
+	self t2 classSide compile: 'm1ClassSide' classified: 'myprotocol'.
 	self assert: (self c2 class methodDict includesKey: #m1ClassSide).
 	self deny: (self c2 class includesLocalSelector: #m1ClassSide).
 	self should: [ self c2 m1ClassSide ] raise: Error.	"conflict category"
-	self assert: (self c2 class organization categoryOfElement: #m1ClassSide) equals: #mycategory
+	self assert: (self c2 class organization categoryOfElement: #m1ClassSide) equals: #myprotocol
 ]
 
 { #category : #tests }
 ClassTraitTest >> testConflictsAliasesAndExclusions [
 	"conflict"
 
-	self t1 classTrait compile: 'm2ClassSide: x ^99' classified: 'mycategory'.
+	self t1 classTrait compile: 'm2ClassSide: x ^99' classified: 'myprotocol'.
 	self assert: (self t1 classTrait includesLocalSelector: #m2ClassSide:).
 	self assert: (self t5 classTrait >> #m2ClassSide:) isConflict.
 	self assert: (self c2 class >> #m2ClassSide:) isConflict.

--- a/src/TraitsV2-Compatibility/TraitMethodDescription.class.st
+++ b/src/TraitsV2-Compatibility/TraitMethodDescription.class.st
@@ -56,21 +56,23 @@ TraitMethodDescription >> effectiveMethodCategory [
 ]
 
 { #category : #accessing }
-TraitMethodDescription >> effectiveMethodCategoryCurrent: currentCategoryOrNil new: newCategoryOrNil [
+TraitMethodDescription >> effectiveMethodCategoryCurrent: currentProtocolOrNil new: newProtocolOrNil [
+
 	| result size isCurrent isConflict |
 	size := self size.
-	size = 0 ifTrue: [^ nil].
+	size = 0 ifTrue: [ ^ nil ].
 	result := self locatedMethods anyOne category.
-	size = 1 ifTrue: [^ result].
+	size = 1 ifTrue: [ ^ result ].
 
-	isCurrent := currentCategoryOrNil isNil.
+	isCurrent := currentProtocolOrNil isNil.
 	isConflict := false.
-	self locatedMethods do: [:each | | cat |
+	self locatedMethods do: [ :each |
+		| cat |
 		cat := each category.
-		isCurrent := isCurrent or: [cat == currentCategoryOrNil].
-		isConflict := isConflict or: [cat ~~ result]].
-	isConflict ifFalse: [^ result].
-	(isCurrent not and: [newCategoryOrNil notNil]) ifTrue: [^ newCategoryOrNil].
+		isCurrent := isCurrent or: [ cat == currentProtocolOrNil ].
+		isConflict := isConflict or: [ cat ~~ result ] ].
+	isConflict ifFalse: [ ^ result ].
+	(isCurrent not and: [ newProtocolOrNil notNil ]) ifTrue: [ ^ newProtocolOrNil ].
 
 	^ Protocol ambiguous
 ]

--- a/src/TraitsV2/MetaclassForTraits.class.st
+++ b/src/TraitsV2/MetaclassForTraits.class.st
@@ -96,10 +96,11 @@ MetaclassForTraits >> name [
 ]
 
 { #category : #'organization updating' }
-MetaclassForTraits >> notifyOfRecategorizedSelector: selector from: oldCategory to: newCategory [
+MetaclassForTraits >> notifyOfRecategorizedSelector: selector from: oldProtocol to: newProtocol [
 	"When there is a recategorization of a selector, I propagate the changes to my users"
-	super notifyOfRecategorizedSelector: selector from: oldCategory to: newCategory.
-	self traitUsers do: [ :e | e recategorizeSelector: selector from: oldCategory to: newCategory ]
+
+	super notifyOfRecategorizedSelector: selector from: oldProtocol to: newProtocol.
+	self traitUsers do: [ :e | e recategorizeSelector: selector from: oldProtocol to: newProtocol ]
 ]
 
 { #category : #printing }

--- a/src/TraitsV2/TraitedClass.class.st
+++ b/src/TraitsV2/TraitedClass.class.st
@@ -20,12 +20,9 @@ Class {
 }
 
 { #category : #'accessing - method dictionary' }
-TraitedClass class >> addAndClassifySelector: selector withMethod: compiledMethod inProtocol: aCategory [
+TraitedClass class >> addAndClassifySelector: selector withMethod: compiledMethod inProtocol: aProtocol [
 
-	super
-		addAndClassifySelector: selector
-		withMethod: compiledMethod
-		inProtocol: aCategory.
+	super addAndClassifySelector: selector withMethod: compiledMethod inProtocol: aProtocol.
 
 	self propagateChangeOf: selector
 ]
@@ -80,17 +77,14 @@ TraitedClass class >> traitUsers [
 ]
 
 { #category : #'accessing - method dictionary' }
-TraitedClass >> addAndClassifySelector: selector withMethod: compiledMethod inProtocol: aCategory [
-
+TraitedClass >> addAndClassifySelector: selector withMethod: compiledMethod inProtocol: aProtocol [
 	"When a new methods is added, I add it to the localMethodDict and also propagate the changes to my users"
+
 	self localMethodDict at: selector put: compiledMethod.
 
-	super
-		addAndClassifySelector: selector
-		withMethod: compiledMethod
-		inProtocol: aCategory.
+	super addAndClassifySelector: selector withMethod: compiledMethod inProtocol: aProtocol.
 
-	TraitChange addSelector: selector on: self.
+	TraitChange addSelector: selector on: self
 ]
 
 { #category : #'accessing - method dictionary' }
@@ -257,22 +251,20 @@ TraitedClass >> rebuildMethodDictionary [
 ]
 
 { #category : #categories }
-TraitedClass >> recategorizeSelector: selector from: oldCategory to: newCategory [
+TraitedClass >> recategorizeSelector: selector from: oldProtocol to: newProtocol [
+
 	| original |
-
 	"When a method is recategorized I have to classify the method, but also recategorize the aliases pointing to it"
-
 	original := self organization categoryOfElement: selector ifAbsent: [ ^ self ].
 
 	"If it is nil is because it is a removal. It will removed when the method is removed."
-	newCategory ifNil: [ ^ self ].
+	newProtocol ifNil: [ ^ self ].
 
-	original = oldCategory
-		ifTrue: [ self organization classify: selector under: newCategory suppressIfDefault: true ].
+	original = oldProtocol ifTrue: [ self organization classify: selector under: newProtocol suppressIfDefault: true ].
 
 	(self traitComposition reverseAlias: selector) do: [ :e |
-		self recategorizeSelector: e from: oldCategory to: newCategory.
-		self notifyOfRecategorizedSelector: e from: oldCategory to: newCategory ].
+		self recategorizeSelector: e from: oldProtocol to: newProtocol.
+		self notifyOfRecategorizedSelector: e from: oldProtocol to: newProtocol ].
 
 	self organization removeEmptyCategories
 ]

--- a/src/TraitsV2/TraitedMetaclass.class.st
+++ b/src/TraitsV2/TraitedMetaclass.class.st
@@ -25,14 +25,11 @@ TraitedMetaclass class >> traitedClassTrait [
 ]
 
 { #category : #'accessing - method dictionary' }
-TraitedMetaclass >> addAndClassifySelector: selector withMethod: compiledMethod inProtocol: aCategory [
+TraitedMetaclass >> addAndClassifySelector: selector withMethod: compiledMethod inProtocol: aProtocol [
 
 	self localMethodDict at: selector put: compiledMethod.
 
-	super
-		addAndClassifySelector: selector
-		withMethod: compiledMethod
-		inProtocol: aCategory.
+	super addAndClassifySelector: selector withMethod: compiledMethod inProtocol: aProtocol.
 
 	TraitChange addSelector: selector on: self
 ]
@@ -274,22 +271,20 @@ TraitedMetaclass >> rebuildMethodDictionary [
 ]
 
 { #category : #categories }
-TraitedMetaclass >> recategorizeSelector: selector from: oldCategory to: newCategory [
+TraitedMetaclass >> recategorizeSelector: selector from: oldProtocol to: newProtocol [
+
 	| original |
-
 	"When a method is recategorized I have to classify the method, but also recategorize the aliases pointing to it"
-
 	original := self organization categoryOfElement: selector ifAbsent: [ ^ self ].
 
 	"If it is nil is because it is a removal. It will removed when the method is removed."
-	newCategory ifNil: [ ^ self ].
+	newProtocol ifNil: [ ^ self ].
 
-	original = oldCategory
-		ifTrue: [ self organization classify: selector under: newCategory suppressIfDefault: true ].
+	original = oldProtocol ifTrue: [ self organization classify: selector under: newProtocol suppressIfDefault: true ].
 
 	(self traitComposition reverseAlias: selector) do: [ :e |
-		self recategorizeSelector: e from: oldCategory to: newCategory.
-		self notifyOfRecategorizedSelector: e from: oldCategory to: newCategory ].
+		self recategorizeSelector: e from: oldProtocol to: newProtocol.
+		self notifyOfRecategorizedSelector: e from: oldProtocol to: newProtocol ].
 
 	self organization removeEmptyCategories
 ]


### PR DESCRIPTION
We have 3 way to call protocols in the image and this is crazy to understand the code.

This is a tiny step toward unification: Renaming some variables "category" to use "protocol" 