### PR TITLE
better fix for #12858: check isTempVariable

### DIFF
--- a/src/OpalCompiler-Core/CopiedLocalVariable.class.st
+++ b/src/OpalCompiler-Core/CopiedLocalVariable.class.st
@@ -3,7 +3,7 @@ A copied variable is an arg or temp var that is copied into a block that later r
 "
 Class {
 	#name : #CopiedLocalVariable,
-	#superclass : #TemporaryVariable,
+	#superclass : #LocalVariable,
 	#instVars : [
 		'originalVar'
 	],
@@ -34,6 +34,11 @@ CopiedLocalVariable >> isArgumentVariable [
 { #category : #testing }
 CopiedLocalVariable >> isCopying [
 	^true
+]
+
+{ #category : #testing }
+CopiedLocalVariable >> isTempVariable [
+	^ originalVar isTempVariable
 ]
 
 { #category : #'read/write usage' }

--- a/src/Shout/CopiedLocalVariable.extension.st
+++ b/src/Shout/CopiedLocalVariable.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #CopiedLocalVariable }
+
+{ #category : #'*Shout' }
+CopiedLocalVariable >> styleNameIn: aRBVariableNode [
+
+	^ originalVar styleNameIn: aRBVariableNode
+]


### PR DESCRIPTION

better fix for #12858: check isTempVariable:
- CopiedLocalVariable is a decorator, it should not be a subclass of TemporaryVariable because it can wrap an argument var, too
- implement isTempVariable to delegate to the original var
- add a method for Shout