### PR TITLE
Add regression test to Shout

### DIFF
--- a/src/Shout-Tests/SHRBStyleAttributionTest.class.st
+++ b/src/Shout-Tests/SHRBStyleAttributionTest.class.st
@@ -90,6 +90,20 @@ SHRBStyleAttributionTest >> testAssignmentStyle [
 ]
 
 { #category : #tests }
+SHRBStyleAttributionTest >> testAttributeInBlockHasRightStyle [
+
+	| aText |
+	aText := 'm: arg self do: [ :each | arg ]' asText.
+	self style: aText.
+
+	self
+		assertStyleOf: aText
+		between: 27
+		and: 29
+		shouldBe: #argument
+]
+
+{ #category : #tests }
 SHRBStyleAttributionTest >> testBinaryStyle [
 
 	| aText |


### PR DESCRIPTION
A bug in shout allowed to detect a problem fixed in https://github.com/pharo-project/pharo/pull/12971
This adds a regression test