### PR TITLE
make ReparseAfterSourceEditing not resumable

### DIFF
--- a/src/OpalCompiler-Core/ReparseAfterSourceEditing.class.st
+++ b/src/OpalCompiler-Core/ReparseAfterSourceEditing.class.st
@@ -18,6 +18,19 @@ ReparseAfterSourceEditing class >> signalWithNewSource: aSourceCode [
 		signal
 ]
 
+{ #category : #handling }
+ReparseAfterSourceEditing >> defaultAction [
+	"Senders do not expect the exception to be resumed"
+
+	self unhandledErrorAction
+]
+
+{ #category : #testing }
+ReparseAfterSourceEditing >> isResumable [
+
+	^false
+]
+
 { #category : #accessing }
 ReparseAfterSourceEditing >> newSource [
 


### PR DESCRIPTION
Low-hanging fruit. A small improvement of ReparseAfterSourceEditing that reduces the hackish level a little.

ReparseAfterSourceEditing is a BAD Notification, as senders expect it to be always caught and never resumed.
Change code to catch error is one of these two expectations are not met.

Maybe change the superclass? But `Error` is not a better choice, since the semantic is not the right one.
What about a new subclass of Exception called `HackishLongJump` for hackish long jumps? :)