### PR TITLE
Improve OCUndeclaredVariableWarning>>openMenuIn

### DIFF
--- a/src/OpalCompiler-Core/OCSemanticWarning.class.st
+++ b/src/OpalCompiler-Core/OCSemanticWarning.class.st
@@ -21,15 +21,6 @@ OCSemanticWarning >> compilationContext: anObject [
 	compilationContext := anObject
 ]
 
-{ #category : #correcting }
-OCSemanticWarning >> defaultAction [
-
-	compilationContext interactive ifFalse: [ ^nil ].
-	^self openMenuIn:
-		[:labels :lines :caption |
-		UIManager default chooseFrom: labels lines: lines title: caption]
-]
-
 { #category : #'accessing - compatibility' }
 OCSemanticWarning >> errorCode [
 	self requestor ifNil: [
@@ -65,11 +56,6 @@ OCSemanticWarning >> node [
 { #category : #accessing }
 OCSemanticWarning >> node: anObject [
 	node := anObject
-]
-
-{ #category : #correcting }
-OCSemanticWarning >> openMenuIn: aBlock [
-	self subclassResponsibility
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OCShadowVariableWarning.class.st
+++ b/src/OpalCompiler-Core/OCShadowVariableWarning.class.st
@@ -23,11 +23,6 @@ OCShadowVariableWarning >> node: aVariableNode [
 ]
 
 { #category : #correcting }
-OCShadowVariableWarning >> openMenuIn: aBlock [
-	self error: 'should not be called'
-]
-
-{ #category : #correcting }
 OCShadowVariableWarning >> raiseSemanticError [
 
 	^OCSemanticError new

--- a/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
@@ -150,14 +150,7 @@ OCUndeclaredVariableWarning >> node: aVariableNode [
 
 { #category : #'menu morph' }
 OCUndeclaredVariableWarning >> openMenu [
-	| alternatives labels actions lines caption choice name interval requestor |
-
-	"Turn off suggestions when in RubSmalltalkCommentMode
- 	This is a workaround, the plan is to not do this as part of the exception"
- 	requestor := compilationContext requestor.
- 	((requestor class name = #RubEditingArea) and: [
- 		requestor editingMode class name = #RubSmalltalkCommentMode])
- 					ifTrue: [ ^UndeclaredVariable named: node name ].
+	| alternatives labels actions lines caption choice name interval |
 
 	interval := node sourceInterval.
 	name := node name.

--- a/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
@@ -83,7 +83,8 @@ OCUndeclaredVariableWarning >> defaultAction [
 		ifNotNil: [className, '>>', selector]
 			ifNil: ['<unknown>']).
 
-	^super defaultAction ifNil: [ self declareUndefined ]
+	compilationContext interactive ifFalse: [ ^ self declareUndefined ].
+	^self openMenu
 ]
 
 { #category : #correcting }
@@ -147,8 +148,8 @@ OCUndeclaredVariableWarning >> node: aVariableNode [
 	messageText := 'Undeclared temp: ', aVariableNode name
 ]
 
-{ #category : #correcting }
-OCUndeclaredVariableWarning >> openMenuIn: aBlock [
+{ #category : #'menu morph' }
+OCUndeclaredVariableWarning >> openMenu [
 	| alternatives labels actions lines caption choice name interval requestor |
 
 	"Turn off suggestions when in RubSmalltalkCommentMode
@@ -179,7 +180,7 @@ OCUndeclaredVariableWarning >> openMenuIn: aBlock [
 				add: [
 					[ self defineClass: name ]
 						on: Abort
-						do: [ self openMenuIn: aBlock ] ].
+						do: [ self openMenu ] ].
 			labels add: 'Declare new global'.
 			actions add: [ self declareGlobal ].
 			compilationContext requestor isScripting ifFalse:
@@ -190,7 +191,7 @@ OCUndeclaredVariableWarning >> openMenuIn: aBlock [
 				add: [
 					[ self defineTrait: name ]
 						on: Abort
-						do: [ self openMenuIn: aBlock ] ] ].
+						do: [ self openMenu ] ] ].
 	lines add: labels size.
 	alternatives
 		do: [ :each |
@@ -201,7 +202,7 @@ OCUndeclaredVariableWarning >> openMenuIn: aBlock [
 	lines add: labels size.
 	labels add: 'Cancel'.
 	caption := 'Unknown variable: ' , name , ' please correct, or cancel:'.
-	choice := aBlock value: labels value: lines value: caption.
+	choice := UIManager default chooseFrom: labels lines: lines title: caption.
 	^choice ifNotNil: [ self resume: (actions at: choice ifAbsent: [ compilationContext failBlock value ]) value ]
 ]
 


### PR DESCRIPTION
Low-hanging fruit. A small cleanup of openMenuIn that reduces the hackish level a little

* Remove overkill parameter
* Move the menu to the only class that cares
* Drop ugly dead hack (possibly related to some code removed a long time ago)