### PR TITLE
Improve ClyClassDefinitionEditorToolMorph>>applyChanges

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyClassDefinitionEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassDefinitionEditorToolMorph.class.st
@@ -10,18 +10,8 @@ Class {
 	#category : #'Calypso-SystemTools-Core-Editors-Classes'
 }
 
-{ #category : #building }
+{ #category : #operations }
 ClyClassDefinitionEditorToolMorph >> applyChanges [
-
-	| text |
-	text := self pendingText copy.
-	^ self applyChangesAsClassDefinition or: [
-		  self pendingText: text.
-		  self applyChangesAsMethodDefinition ]
-]
-
-{ #category : #building }
-ClyClassDefinitionEditorToolMorph >> applyChangesAsClassDefinition [
 
 	| newClass oldText |
 	oldText := self pendingText copy.
@@ -37,26 +27,6 @@ ClyClassDefinitionEditorToolMorph >> applyChangesAsClassDefinition [
 
 	editingClass == newClass ifFalse: [ self removeFromBrowser ].
 	browser selectClass: newClass.
-	^ true
-]
-
-{ #category : #building }
-ClyClassDefinitionEditorToolMorph >> applyChangesAsMethodDefinition [
-
-	| newMethod selector selectedClass |
-	selectedClass := self editingClass.
-
-	selector := selectedClass
-		            compile: self pendingText asString
-		            notifying: textMorph.
-
-	selector ifNil: [ ^ false ].
-	newMethod := selectedClass >> selector.
-	MethodClassifier classify: newMethod.
-
-	self removeFromBrowser.
-	browser tabManager desiredSelection: { ClyMethodCodeEditorToolMorph }.
-	browser selectMethod: newMethod.
 	^ true
 ]
 

--- a/src/Calypso-SystemTools-Core/ClyClassDefinitionEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassDefinitionEditorToolMorph.class.st
@@ -13,15 +13,11 @@ Class {
 { #category : #operations }
 ClyClassDefinitionEditorToolMorph >> applyChanges [
 
-	| newClass oldText |
-	oldText := self pendingText copy.
+	| newClass |
 	newClass := browser
 		            compileANewClassFrom: self pendingText asString
 		            notifying: textMorph
 		            startingFrom: editingClass.
-
-	"This was indeed a class, however, there is a syntax error somewhere"
-	textMorph text = oldText ifFalse: [ ^ true ].
 
 	newClass ifNil: [ ^ false ].
 


### PR DESCRIPTION
Low-hanging fruit. A small cleanup of ClyClassDefinitionEditorToolMorph that reduces the hackish level a little

* Do not reparse the class definition as a method definition in case of failure
* Do not assume a syntax error is related to a source code change