### PR TITLE
Improve ClySystemEnvironment>>defineNewClassFrom

### DIFF
--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -200,8 +200,7 @@ ClySystemEnvironment >> defineNewClassFrom: newClassDefinitionString notifying: 
 	(newClass isKindOf: FluidClassBuilder) ifTrue: [ newClass := newClass install ]
 	]
 		on: OCUndeclaredVariableWarning
-		do: [ :ex | "we are only interested in class definitions"
-			ex compilationContext noPattern ifFalse: [ ex pass ].
+		do: [ :ex |
 			"Undeclared Vars should not lead to the standard dialog to define them but instead should not accept"
 			self inform: 'Undeclared Variable in Class Definition'.
 			^ nil ].

--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -216,10 +216,13 @@ ClySystemEnvironment >> defineNewFluidClassOrTraitFrom: newClassDefinitionString
 	| newClass |
 	[
 	newClass := (self classCompilerFor: oldClass)
-		            source: '(' , newClassDefinitionString , ') install';
+		            source: newClassDefinitionString;
 		            requestor: aController;
 		            logged: true;
-		            "for now a super ugly patch"evaluate ]
+		            evaluate.
+	"mild ugly hack"
+	(newClass isKindOf: FluidClassBuilder) ifTrue: [ newClass := newClass install ]
+		 ]
 		on: OCUndeclaredVariableWarning
 		do: [ :ex | "we are only interested in class definitions"
 			ex compilationContext noPattern ifFalse: [ ex pass ].

--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -202,7 +202,11 @@ ClySystemEnvironment >> defineNewClassFrom: newClassDefinitionString notifying: 
 		on: OCUndeclaredVariableWarning
 		do: [ :ex |
 			"Undeclared Vars should not lead to the standard dialog to define them but instead should not accept"
-			self inform: 'Undeclared Variable in Class Definition'.
+			"Note: this currently prevents legitimate(?) reparations on the superclass name"
+
+			"Note: I hate inserted `->` error messages, but the presentation of errors is the responsibility of `aController`.
+			 and because consistency is a virtue, we should not hack an ad hoc error reporting here"
+			aController notify: ex errorMessage , '->' at: ex location in: newClassDefinitionString.
 			^ nil ].
 
 	^ newClass isBehavior

--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -139,7 +139,7 @@ ClySystemEnvironment >> compileANewClassFrom: newClassDefinitionString notifying
 		ifTrue: [
 			ClassDefinitionPrinter showFluidClassDefinition: true.
 			^ self
-				  defineNewFluidClassOrTraitFrom: newClassDefinitionString
+				  defineNewClassFrom: newClassDefinitionString
 				  notifying: aController
 				  startingFrom: oldClass ]
 		ifFalse: [
@@ -186,7 +186,7 @@ ClySystemEnvironment >> defaultClassCompiler [
 { #category : #compiling }
 ClySystemEnvironment >> defineNewClassFrom: newClassDefinitionString notifying: aController startingFrom: oldClass [
 
-	"Precondition: newClassDefinitionString is not a fluid class"
+	"Note: newClassDefinitionString can be a fluid class of a standars one"
 
 	| newClass |
 	[
@@ -195,34 +195,10 @@ ClySystemEnvironment >> defineNewClassFrom: newClassDefinitionString notifying: 
 		            requestor: aController;
 		            failBlock: [ ^ nil ];
 		            logged: true;
-		            evaluate ]
-		on: OCUndeclaredVariableWarning
-		do: [ :ex | "we are only interested in class definitions"
-			ex compilationContext noPattern ifFalse: [ ex pass ].
-			"Undeclared Vars should not lead to the standard dialog to define them but instead should not accept"
-			self inform: 'Undeclared Variable in Class Definition'.
-			^ nil ].
-
-	^ newClass isBehavior
-		  ifTrue: [ newClass ]
-		  ifFalse: [ nil ]
-]
-
-{ #category : #compiling }
-ClySystemEnvironment >> defineNewFluidClassOrTraitFrom: newClassDefinitionString notifying: aController startingFrom: oldClass [
-
-	"Precondition: newClassDefinitionString is a fluid class or trait"
-
-	| newClass |
-	[
-	newClass := (self classCompilerFor: oldClass)
-		            source: newClassDefinitionString;
-		            requestor: aController;
-		            logged: true;
 		            evaluate.
-	"mild ugly hack"
+	"mild ugly hack for fluid classes (and traits)"
 	(newClass isKindOf: FluidClassBuilder) ifTrue: [ newClass := newClass install ]
-		 ]
+	]
 		on: OCUndeclaredVariableWarning
 		do: [ :ex | "we are only interested in class definitions"
 			ex compilationContext noPattern ifFalse: [ ex pass ].

--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -84,7 +84,7 @@ SystemDependenciesTest >> knownIDEDependencies [
 
 	"ideally this list should be empty"
 
-	^ #('Spec2-CommonWidgets' #'Calypso-SystemPlugins-Traits-Queries-Tests-PWithTraits' #'AI-Algorithms-Graph')
+	^ #('Spec2-CommonWidgets' #'Calypso-SystemPlugins-Traits-Queries-Tests-PWithTraits' #'AI-Algorithms-Graph' #'FluidClassBuilder')
 ]
 
 { #category : #'known dependencies' }


### PR DESCRIPTION
Low-hanging fruit. A small cleanup of ClyClassDefinitionEditorToolMorph that reduces the hackish level a little

* merge fuild and non-fluid
* reduce hackish level (a little) or error diagnosis

Note: review commit by commit because the global diff is trash