### PR TITLE
Fix formating of non methods

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyClassEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassEditorToolMorph.class.st
@@ -75,6 +75,13 @@ ClyClassEditorToolMorph >> editingClass: anObject [
 	editingClass := anObject
 ]
 
+{ #category : #formatting }
+ClyClassEditorToolMorph >> formatSourceCode [
+	"Do nothing. MAybe in the future we could format the fluid class definition but for now we don't want errors"
+
+	
+]
+
 { #category : #testing }
 ClyClassEditorToolMorph >> isSimilarTo: anotherBrowserTool [
 


### PR DESCRIPTION
Before this commit we were getting ar error if we tried to format a class comment or a class definition. Now it does nothing.  For the fluid class maybe we could suceed to format it since it's Pharo code, but that will be for later.

Fixes #12986