### PR TITLE
Escape '|' and '.' characters to prevent regex interpretation

### DIFF
--- a/src/Text-Edition/FindReplaceService.class.st
+++ b/src/Text-Edition/FindReplaceService.class.st
@@ -38,7 +38,7 @@ FindReplaceService >> caseSensitive: aBoolean [
 { #category : #accessing }
 FindReplaceService >> convertedFindString [
 	| specials |
-	specials := '^$:\+*[]()?'.
+	specials := '|^$:\+*[]()?.'.
 	^String
 		streamContents: [:s | self findString
 			do: [:c | (specials includes: c) ifTrue: [s nextPut:$\].

--- a/src/Text-Edition/FindReplaceService.class.st
+++ b/src/Text-Edition/FindReplaceService.class.st
@@ -38,7 +38,7 @@ FindReplaceService >> caseSensitive: aBoolean [
 { #category : #accessing }
 FindReplaceService >> convertedFindString [
 	| specials |
-	specials := '|^$:\+*[]()?.'.
+	specials := '|^$:\+*[](){}?.'.
 	^String
 		streamContents: [:s | self findString
 			do: [:c | (specials includes: c) ifTrue: [s nextPut:$\].


### PR DESCRIPTION
fixes #13001