### PR TITLE
Use internal FuelPlatform

### DIFF
--- a/src/BaselineOfFuel/BaselineOfFuel.class.st
+++ b/src/BaselineOfFuel/BaselineOfFuel.class.st
@@ -19,86 +19,20 @@ BaselineOfFuel >> addPostloadHacks [
 
 { #category : #baselines }
 BaselineOfFuel >> baseline: spec [
-  <baseline>
-  spec
-	for: #common
-	do: [
+
+	<baseline>
+	| repository |
+	repository := self packageRepositoryURL.
+	spec for: #common do: [
 		spec postLoadDoIt: #addPostloadHacks.
 
-		self   
-			fuelPlatform: spec;
-			smark: spec.
+		spec baseline: 'FuelPlatform' with: [ spec repository: repository ].
 
 		spec
 			package: 'Fuel-Core' with: [ spec requires: 'FuelPlatform' ];
-			package: 'Fuel-Debug' with: [ spec requires: 'Core' ];
-			package: 'Fuel-Benchmarks' with: [ spec requires: #('Core' 'SMark-Jenkins') ];
-			
-			package: 'Fuel-Tests-Core' with: [ spec requires: 'Core' ];
-			package: 'Fuel-Tests-Debug' with: [ spec requires: #('Fuel-Debug' 'Tests') ];
-			package: 'Fuel-Tests-Benchmarks' with: [ spec requires: #('Fuel-Benchmarks' 'Tests') ].
-					
+			package: 'Fuel-Tests-Core' with: [ spec requires: 'Core' ].
+
 		spec
-			group: 'default' with: #('Core');
-			group: 'Core' with: #('Fuel-Core');
-			group: 'Tests' with: #('Core' 'Fuel-Tests-Core');
-			group: 'Debug' with: #('Core' 'Fuel-Debug') ].
-
-	self
-		groupsForPharoCommon: spec;
-		groupsForSqueakCommon: spec
-]
-
-{ #category : #'baselines-helpers' }
-BaselineOfFuel >> fuelPlatform: spec [		
-	spec 
-		baseline: 'FuelPlatform' 
-		with: [
-			| branch |
-			branch := Smalltalk globals
-				at: #SmalltalkCI
-				ifPresent: [ :class |
-					(class
-						perform: #getEnv:
-						withArguments: #(FL_USE_PLATFORM_MASTER))
-							ifNotNil: [ 'master' ]
-							ifNil: [ 'v5' ] ]
-				ifAbsent: [ 'v5' ].
-			spec
-				repository: 'github://theseion/FuelPlatform:', branch, '/repository';
-  				loads: 'default' ]
-]
-
-{ #category : #'baselines-helpers' }
-BaselineOfFuel >> groupsForPharoCommon: spec [
-	spec for: #pharo do: [
-		spec
-			group: 'DevelopmentGroup' with: #('Debug' 'Tests' 'Fuel-Tests-Debug');
-			group: 'Benchmarks' with: #('Core' 'Fuel-Benchmarks' 'Fuel-Tests-Benchmarks') ]
-]
-
-{ #category : #'baselines-helpers' }
-BaselineOfFuel >> groupsForSqueakCommon: spec [
-	spec for: #squeak do: [
-		spec
-			group: 'Benchmarks'
-			with: #('Core' 'Fuel-Benchmarks') ]
-]
-
-{ #category : #'baselines-helpers' }
-BaselineOfFuel >> smark: spec [		
-	spec
-		project: 'SMark' with: [
-			spec
-				className: 'ConfigurationOfSMark';
-				versionString: #development;
-				file: 'ConfigurationOfSMark';
-				repository: 'http://smalltalkhub.com/mc/StefanMarr/SMark/main' ].
-
-	spec
-		package: 'SMark-Jenkins' with: [ 
-			spec 
-				repository: 'http://smalltalkhub.com/mc/ClementBera/classic-bench/main';
-				requires: 'SMark' ]
-
+			group: 'Core' with: #( 'Fuel-Core' );
+			group: 'Tests' with: #( 'Core' 'Fuel-Tests-Core' ) ]
 ]

--- a/src/BaselineOfFuelPlatform/BaselineOfFuelPlatform.class.st
+++ b/src/BaselineOfFuelPlatform/BaselineOfFuelPlatform.class.st
@@ -4,9 +4,6 @@ We use a separate baseline to make it simpler to manage the platform classes. Us
 Class {
 	#name : #BaselineOfFuelPlatform,
 	#superclass : #BaselineOf,
-	#instVars : [
-		'customProjectAttributes'
-	],
 	#category : #BaselineOfFuelPlatform
 }
 

--- a/src/BaselineOfFuelPlatform/BaselineOfFuelPlatform.class.st
+++ b/src/BaselineOfFuelPlatform/BaselineOfFuelPlatform.class.st
@@ -10,11 +10,6 @@ Class {
 	#category : #BaselineOfFuelPlatform
 }
 
-{ #category : #accessing }
-BaselineOfFuelPlatform >> addCustomProjectAttribute: aSymbol [
-	customProjectAttributes := self customProjectAttributes copyWith: aSymbol
-]
-
 { #category : #adding }
 BaselineOfFuelPlatform >> addPostloadHacks [
 	| platformClass |
@@ -32,122 +27,16 @@ BaselineOfFuelPlatform >> addPostloadHacks [
 
 { #category : #baselines }
 BaselineOfFuelPlatform >> baseline: spec [
-  <baseline>
-  spec
-	for: #common
-	do: [		
+
+	<baseline>
+	spec for: #common do: [
+		spec postLoadDoIt: #addPostloadHacks.
+
 		spec
-			postLoadDoIt: #addPostloadHacks;
-			package: 'Fuel-Platform-Core'.
-			
-		spec
-			group: 'default'
-			with: #('Fuel-Platform-Core' 'FuelPlatformCurrentGroup') ].
-	
-	self 
-		pharoPackagesAndGroups: spec;
-		squeakPackagesAndGroups: spec
-]
+			package: 'Fuel-Platform-Core';
+			package: 'Fuel-Platform-Pharo-Core' with: [ spec requires: 'Fuel-Platform-Core' ] ].
 
-{ #category : #accessing }
-BaselineOfFuelPlatform >> customProjectAttributes [
-	^ customProjectAttributes ifNil: [ customProjectAttributes := self platformAttributes ]
-]
-
-{ #category : #accessing }
-BaselineOfFuelPlatform >> loadAll [
-	#(pharo 'pharo1.x' 'pharo2.x' 'pharo3.x' 'pharo4.x' 'pharo5.x' 'pharo6.x' 'pharo7.x'
-		squeak 'squeak4.x' 'squeak5.x' 'squeak6.x') do: [ :attribute |
-			self addCustomProjectAttribute: attribute ]
-]
-
-{ #category : #helpers }
-BaselineOfFuelPlatform >> pharoPackagesAndGroups: spec [
-	spec for: #pharo do: [
-		spec package: 'Fuel-Platform-Pharo-Core' with: [ spec requires: 'Fuel-Platform-Core' ] ].
-	spec for: #'pharo1.x' do: [
-		spec package: 'Fuel-Platform-Pharo-01x' with: [ spec requires: 'Fuel-Platform-Pharo-Core' ].
-		spec group: 'FuelPlatformCurrentGroup' with: 'Fuel-Platform-Pharo-01x' ].
-	spec for: #'pharo2.x' do: [
-		spec package: 'Fuel-Platform-Pharo-02' with: [ spec requires: 'Fuel-Platform-Pharo-Core' ].
-		spec group: 'FuelPlatformCurrentGroup' with: 'Fuel-Platform-Pharo-02' ].
-	spec for: #'pharo3.x' do: [
-		spec package: 'Fuel-Platform-Pharo-03' with: [ spec requires: 'Fuel-Platform-Pharo-Core' ].
-		spec group: 'FuelPlatformCurrentGroup' with: 'Fuel-Platform-Pharo-03' ].
-	spec for: #'pharo4.x' do: [
-		spec package: 'Fuel-Platform-Pharo-04' with: [ spec requires: 'Fuel-Platform-Pharo-Core' ].
-		spec group: 'FuelPlatformCurrentGroup' with: 'Fuel-Platform-Pharo-04' ].
-	spec for: #'pharo5.x' do: [
-		spec package: 'Fuel-Platform-Pharo-05' with: [ spec requires: 'Fuel-Platform-Pharo-Core' ].
-		spec group: 'FuelPlatformCurrentGroup' with: 'Fuel-Platform-Pharo-05' ].
-	spec for: #'pharo6.x' do: [
-		spec package: 'Fuel-Platform-Pharo-06' with: [ spec requires: 'Fuel-Platform-Pharo-Core' ].
-		spec group: 'FuelPlatformCurrentGroup' with: 'Fuel-Platform-Pharo-06' ].
-	spec for: #'pharo7.x' do: [
-		spec package: 'Fuel-Platform-Pharo-07' with: [ spec requires: 'Fuel-Platform-Pharo-Core' ].
-		spec group: 'FuelPlatformCurrentGroup' with: 'Fuel-Platform-Pharo-07' ].
-	spec for: #'pharo8.x' do: [
-		spec package: 'Fuel-Platform-Pharo-08' with: [ spec requires: 'Fuel-Platform-Pharo-Core' ].
-		spec group: 'FuelPlatformCurrentGroup' with: #('Fuel-Platform-Pharo-08') ].
-	spec for: #'pharo9.x' do: [
-		spec package: 'Fuel-Platform-Pharo-09' with: [ spec requires: 'Fuel-Platform-Pharo-Core' ].
-		spec group: 'FuelPlatformCurrentGroup' with: #('Fuel-Platform-Pharo-09') ].
-	spec for: #'pharo10.x' do: [
-		spec package: 'Fuel-Platform-Pharo-10' with: [ spec requires: 'Fuel-Platform-Pharo-Core' ].
-		spec group: 'FuelPlatformCurrentGroup' with: #('Fuel-Platform-Pharo-10') ].
 	spec for: #'pharo11.x' do: [
 		spec package: 'Fuel-Platform-Pharo-11' with: [ spec requires: 'Fuel-Platform-Pharo-Core' ].
-		spec group: 'FuelPlatformCurrentGroup' with: #('Fuel-Platform-Pharo-11') ].
-	spec for: #'fuel-fallback' do: [
-		spec package: 'Fuel-Platform-Pharo-11' with: [ spec requires: 'Fuel-Platform-Pharo-Core' ].
-		spec group: 'FuelPlatformCurrentGroup' with: #('Fuel-Platform-Pharo-11') ]
-]
-
-{ #category : #adding }
-BaselineOfFuelPlatform >> platformAttributes [
-	(SystemVersion current version beginsWith: 'Pharo11') ifTrue: [ ^ #('pharo11.x') ].
-	(SystemVersion current version beginsWith: 'Pharo10') ifTrue: [ ^ #('pharo10.x') ].
-	(SystemVersion current version beginsWith: 'Pharo9') ifTrue: [ ^ #('pharo9.x') ].
-	(SystemVersion current version beginsWith: 'Pharo8') ifTrue: [ ^ #('pharo8.x') ].
-	(SystemVersion current version beginsWith: 'Pharo7') ifTrue: [ ^ #('pharo7.x') ].
-	(SystemVersion current version beginsWith: 'Pharo6') ifTrue: [ ^ #('pharo6.x') ].
-	(SystemVersion current version beginsWith: 'Pharo5') ifTrue: [ ^ #('pharo5.x') ].
-	(SystemVersion current version beginsWith: 'Pharo4') ifTrue: [ ^ #('pharo4.x') ].
-	(SystemVersion current version beginsWith: 'Pharo3') ifTrue: [ ^ #('pharo3.x') ].
-	(SystemVersion current version beginsWith: 'Pharo2') ifTrue: [ ^ #('pharo2.x') ].
-	(SystemVersion current version beginsWith: 'Pharo6') ifTrue: [ ^ #('pharo6.x') ].
-	(SystemVersion current version beginsWith: 'Pharo1.') ifTrue: [ ^ #('pharo1.x') ].
-	(#('Pharo1.1' 'Pharo-1.1') anySatisfy: [ :version |
-			SystemVersion current version beginsWith: version ]) ifTrue: [ ^ #('pharo1.x') ].
-	
-	(SystemVersion current version beginsWith: 'Squeak6') ifTrue: [ ^ #('squeak6.x') ].
-	(SystemVersion current version beginsWith: 'Squeak5') ifTrue: [ ^ #('squeak5.x') ].
-	((SystemVersion current version beginsWith: 'Squeak4.6') or: [
-			"See #fixSystemVersion"
-			[ (Smalltalk imageName includesSubString: '4.6') ]
-				on: MessageNotUnderstood
-				do: [ false ] ]) ifTrue: [ ^ #('squeak4.x') ].
-	(SystemVersion current version beginsWith: 'Squeak4.') ifTrue: [ ^ #('squeak4.x') ].
-	
-	
-	Warning signal: 'Could not determine image version. Using fallback'.
-	^ #('fuel-fallback')
-]
-
-{ #category : #helpers }
-BaselineOfFuelPlatform >> squeakPackagesAndGroups: spec [
-	spec for: #squeak do: [
-		spec package: 'Fuel-Platform-Squeak-Core' with: [ spec requires: 'Fuel-Platform-Core' ] ].
-	spec for: #'squeak4.x' do: [
-		spec package: 'Fuel-Platform-Squeak-04x' with: [ spec requires: 'Fuel-Platform-Squeak-Core' ].
-		spec group: 'FuelPlatformCurrentGroup' with: 'Fuel-Platform-Squeak-04x' ].
-	spec for: #'squeak5.x' do: [
-		spec package: 'Fuel-Platform-Squeak-05' with: [ spec requires: 'Fuel-Platform-Squeak-Core' ].
-		spec group: 'FuelPlatformCurrentGroup' with: 'Fuel-Platform-Squeak-05' ].
-	spec for: #'squeak6.x' do: [
-		spec package: 'Fuel-Platform-Squeak-06' with: [ spec requires: 'Fuel-Platform-Squeak-Core' ].
-		spec group: 'FuelPlatformCurrentGroup' with: 'Fuel-Platform-Squeak-06' ].
-	spec for: #'fuel-fallback' do: [
-		spec package: 'Fuel-Platform-Squeak-06' with: [ spec requires: 'Fuel-Platform-Squeak-Core' ].
-		spec group: 'FuelPlatformCurrentGroup' with: 'Fuel-Platform-Squeak-06' ]
+		spec group: 'FuelPlatformCurrentGroup' with: #( 'Fuel-Platform-Pharo-11' ) ]
 ]

--- a/src/Fuel-Core/FLWordObjectCluster.class.st
+++ b/src/Fuel-Core/FLWordObjectCluster.class.st
@@ -26,13 +26,13 @@ FLWordObjectCluster >> materializeInstanceWith: aDecoder [
 
 	| inst wideSize |
 	wideSize := aDecoder nextEncodedUint32.
-	inst := theClass basicNew: wideSize.	
+	inst := theClass basicNew: wideSize.
 
-	aDecoder nextEncodedWordsInto: inst. 
+	aDecoder nextEncodedWordsInto: inst.
 
-	(aDecoder isBigEndian = FLPlatform current isBigEndian asBit)
-		ifTrue: [^ inst ]
-		ifFalse: [ ^ self swapBytesOf: inst ]
+	^ aDecoder isBigEndian = FLPlatform current isBigEndian asBit
+		  ifTrue: [ inst ]
+		  ifFalse: [ self swapBytesOf: inst ]
 ]
 
 { #category : #'serialize/materialize' }

--- a/src/UnifiedFFI/FFIExternalResourceManager.class.st
+++ b/src/UnifiedFFI/FFIExternalResourceManager.class.st
@@ -103,16 +103,13 @@ FFIExternalResourceManager >> addResource: anObject [
 
 { #category : #'external resource management' }
 FFIExternalResourceManager >> addResource: anObject data: resourceData [
-	registry
-		add: anObject
-		executor: (FFIExternalResourceExecutor new
-			resourceClass: anObject class
-			data: resourceData)
+  registry add: anObject finalizer: (FFIExternalResourceExecutor new resourceClass: anObject class data: resourceData)
 ]
 
 { #category : #'external resource management' }
 FFIExternalResourceManager >> addResource: anObject executor: anExecutor [
-	registry add: anObject executor: anExecutor
+
+	registry add: anObject finalizer: anExecutor
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
This commit does:
- Use the internal pharo FuelPlatform instead of the external one
- Simplify the baseline to keep only what is managed by Pharo current version
- Sync with Fuel (There was only a return extraction)
- Replace deprecated calls in UFFI (it happened automatically and I'm too lazy to do a PR just for that)

In FuelPlatform we still explicitly reference Pharo11 tag because IIRC we need to update FuelPlatform for each version of Pharo so it should break in Pharo 12.  This does not fix Pharo 12 but at least it will make Pharo 11 more reproduceable.