### PR TITLE
Ensuring that Calypso catches any NotFound errors that could appear when a breakpoint on a test under debug doesn' exist anymore

### DIFF
--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyDebugTestCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyDebugTestCommand.class.st
@@ -35,7 +35,11 @@ ClyDebugTestCommand >> runTest: testSelector of: testClass [
 
 	| breakpoint |
 	breakpoint := Breakpoint new
-		node: (testClass lookupSelector: testSelector) ast;
-		install.
-	[super runTest: testSelector of: testClass] ensure: [ breakpoint remove ]
+		              node: (testClass lookupSelector: testSelector) ast;
+		              install.
+	[ super runTest: testSelector of: testClass ] ensure: [
+		[ breakpoint remove ]
+			on: NotFound
+			do: [ "If the test under debug has been recompiled, the breakpoint doesn't exist anymore"
+				self inform: 'The breakpoint already doesn''t exist anymore' ] ]
 ]


### PR DESCRIPTION
Fixes #13020 

When you run a test from Calypso, it will put a breakpoint on the AST method node of the test in order to stop at the beginning of the method to debug.

Then it uses ensure: to remove the breakpoint when the test is finished.

Then, by modifying the method under debug and by recompiling the method in the debugger (or in Calypso itself) , it also changes the AST. Notably, the metalink doesn't exist anymore. So it is wrong from Calypso to systematically remove the breakpoint. It should remove it only if the breakpoint still exists