### PR TITLE
Faulty compiler: new CodeError class

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -642,7 +642,7 @@ RBCodeSnippet >> parseOnError: aBlock [
 	^ [ isMethod
 			  ifTrue: [ RBParser parseMethod: self source ]
 			  ifFalse: [ RBParser parseExpression: self source ] ]
-		  on: SyntaxErrorNotification
+		  on: CodeError
 		  do: [ :e | aBlock value: e ]
 ]
 

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -503,7 +503,7 @@ RBCodeSnippet class >> styleAllWithError [
 				text
 					replaceFrom: exception location
 					to: exception location - 1
-					with: (exception errorMessage asText addAttribute:
+					with: (exception messageText asText addAttribute:
 							 (TextBackgroundColor color: Color lightBlue)).
 				bigtext append: String cr.
 				bigtext append: String tab.

--- a/src/AST-Core-Tests/RBCodeSnippetTest.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippetTest.class.st
@@ -133,7 +133,7 @@ RBCodeSnippetTest >> testParseOnError [
 	| ast error |
 	error := nil.
 
-	ast := snippet parseOnError: [ :e | error := e errorMessage ].
+	ast := snippet parseOnError: [ :e | error := e messageText ].
 
 	(snippet isParseFaulty ifNil: [ snippet isFaulty ])
 		ifTrue: [ self assert: error isNotNil ]

--- a/src/AST-Core-Tests/RBCodeSnippetTest.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippetTest.class.st
@@ -68,7 +68,7 @@ RBCodeSnippetTest >> testCodeImporter [
 
 	"Importer should fail when faulty"
 	snippet isFaulty ifTrue: [
-		self should: [ importer evaluate ] raise: SyntaxErrorNotification.
+		self should: [ importer evaluate ] raise: CodeError.
 		snippet isMethod ifTrue: [ class removeFromSystem ].
 		^ self ].
 

--- a/src/AST-Core-Tests/RBCodeSnippetTest.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippetTest.class.st
@@ -97,7 +97,7 @@ RBCodeSnippetTest >> testCodeImporter [
 
 	snippet raise ifNotNil: [ :r | ^ self should: runBlock raise: r ].
 
-	self shouldnt: runBlock raise: SyntaxErrorNotification.
+	self shouldnt: runBlock raise: CodeError.
 	self assert: value equals: snippet value
 ]
 

--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -1441,9 +1441,8 @@ RBParserTest >> testParserErrorsWithErrorBlock [
 
 	#(#('self foo. + 3' 1) #('self 0' 1) #('self asdf;;asfd' 1))
 		do: [:each | |ast errorCount|
-			   [ ast := self parseError: each first onError:
-					[:msg :pos :parser | parser parseErrorNode: msg]]
-						on: ReparseAfterSourceEditing do: [].
+			    ast := self parseError: each first onError:
+					[:msg :pos :parser | parser parseErrorNode: msg].
 
 				errorCount := 0.
 				RBParseErrorNodeVisitor visit: ast do: [ :n | errorCount := errorCount + 1 ].

--- a/src/AST-Core/CodeError.class.st
+++ b/src/AST-Core/CodeError.class.st
@@ -1,0 +1,79 @@
+"
+I represent a syntax or a semantic error in some pharo code.
+
+My instances are signaled by the parser or the compiler.
+"
+Class {
+	#name : #CodeError,
+	#superclass : #Error,
+	#instVars : [
+		'node',
+		'location',
+		'sourceCode'
+	],
+	#category : #'AST-Core-Exception'
+}
+
+{ #category : #accessing }
+CodeError >> errorCode [
+
+	self deprecated: 'use errorCode'.
+
+	^ self sourceCode
+]
+
+{ #category : #accessing }
+CodeError >> errorMessage [
+
+	self deprecated: 'use messageText'.
+
+	^ messageText
+]
+
+{ #category : #accessing }
+CodeError >> location [
+
+	location ifNotNil: [ ^ location  ].
+	node ifNotNil: [ ^ node start ].
+	^ nil
+]
+
+{ #category : #accessing }
+CodeError >> location: anInteger [
+
+	location := anInteger
+]
+
+{ #category : #accessing }
+CodeError >> methodClass [
+	^self methodNode methodClass
+]
+
+{ #category : #accessing }
+CodeError >> methodNode [
+	^node methodNode
+]
+
+{ #category : #accessing }
+CodeError >> node [
+	^ node
+]
+
+{ #category : #accessing }
+CodeError >> node: aNode [
+	node := aNode
+]
+
+{ #category : #accessing }
+CodeError >> sourceCode [
+
+	sourceCode ifNotNil: [  ^ sourceCode ].
+	node ifNotNil: [  ^ node sourceCode ].
+	^ nil
+]
+
+{ #category : #accessing }
+CodeError >> sourceCode: aString [
+
+	sourceCode := aString
+]

--- a/src/AST-Core/CodeError.class.st
+++ b/src/AST-Core/CodeError.class.st
@@ -17,7 +17,9 @@ Class {
 { #category : #accessing }
 CodeError >> errorCode [
 
-	self deprecated: 'use errorCode'.
+	self
+		deprecated: 'errorCode is so misleading'
+		transformWith: '`@receiver errorCode' -> '`@receiver sourceCode'.
 
 	^ self sourceCode
 ]
@@ -25,7 +27,9 @@ CodeError >> errorCode [
 { #category : #accessing }
 CodeError >> errorMessage [
 
-	self deprecated: 'use messageText'.
+	self
+		deprecated: 'As with exceptions, prefer messageText'
+		transformWith: '`@receiver errorMessage' -> '`@receiver messageText'.
 
 	^ messageText
 ]

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -1241,15 +1241,11 @@ RBParser >> parserError: aString [
 		ifTrue: [ errorMessage := currentToken cause. errorPosition := currentToken location ]
 		ifFalse: [errorMessage := aString. errorPosition := currentToken start].
 
-	newSource := SyntaxErrorNotification
-						inClass: Object
-						withCode: source
-						doitFlag: false
-						errorMessage: errorMessage
-						location: errorPosition.
-
-	"If the syntax error notification is resumed, then the source was corrected and we have to announce that parsing can restart."
-	ReparseAfterSourceEditing signalWithNewSource: newSource
+	newSource := SyntaxErrorNotification new
+						sourceCode: source;
+						messageText: errorMessage;
+						location: errorPosition;
+						signal
 ]
 
 { #category : #private }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -92,9 +92,7 @@ RBParser class >> parseMethod: aString onError: aBlock [
 	parser := self new
 		errorBlock: aBlock;
 		initializeParserWith: aString.
-	^ [ parser parseMethod ]
-		on: ReparseAfterSourceEditing
-		do: [ :exception | self parseMethod: exception newSource onError: aBlock ]
+	^ parser parseMethod
 ]
 
 { #category : #parsing }

--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -206,7 +206,7 @@ ClySystemEnvironment >> defineNewClassFrom: newClassDefinitionString notifying: 
 
 			"Note: I hate inserted `->` error messages, but the presentation of errors is the responsibility of `aController`.
 			 and because consistency is a virtue, we should not hack an ad hoc error reporting here"
-			aController notify: ex errorMessage , '->' at: ex location in: newClassDefinitionString.
+			aController notify: ex messageText , '->' at: ex location in: newClassDefinitionString.
 			^ nil ].
 
 	^ newClass isBehavior

--- a/src/CodeImportCommandLineHandlers/STCommandLineHandler.class.st
+++ b/src/CodeImportCommandLineHandlers/STCommandLineHandler.class.st
@@ -50,7 +50,7 @@ STCommandLineHandler class >> printCompilerWarning: aSyntaxErrorNotification [
 
 	"format the error"
 	position := aSyntaxErrorNotification location.
-	contents := aSyntaxErrorNotification errorCode.
+	contents := aSyntaxErrorNotification sourceCode.
 	errorLine := contents lineNumberCorrespondingToIndex: position.
 	stderr := VTermOutputDriver stderr.
 
@@ -58,7 +58,7 @@ STCommandLineHandler class >> printCompilerWarning: aSyntaxErrorNotification [
 	errorMessage := String streamContents: [ :s|
 		s nextPutAll: 'Syntax Error on line ';
 			print: errorLine; nextPutAll: ': ';
-			print: aSyntaxErrorNotification errorMessage].
+			print: aSyntaxErrorNotification messageText].
 
 	 stderr red;
 		nextPutAll: errorMessage; lf;

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -124,7 +124,6 @@ OCASTSemanticAnalyzer >> storeIntoReadOnlyVariable: variableNode [
 
 	^ OCStoreIntoReadOnlyVariableError new
 		node: variableNode;
-		compilationContext: compilationContext;
 		messageText: 'Assignment to read-only variable';
 		signal
 ]
@@ -135,7 +134,6 @@ OCASTSemanticAnalyzer >> storeIntoReservedVariable: variableNode [
 	compilationContext optionSkipSemanticWarnings ifTrue: [ ^ self ].
 	^ OCStoreIntoReservedVariableError new
 		node: variableNode;
-		compilationContext: compilationContext;
 		messageText: 'Assigment to reserved variable';
 		signal
 ]

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -85,12 +85,11 @@ OCASTSemanticAnalyzer >> error: aMessage forNode: aNode [
 	aNode addError: aMessage.
 	compilationContext optionSkipSemanticWarnings ifTrue: [ ^ self ].
 
-	SyntaxErrorNotification
-		inClass: Object
-		withCode: aNode methodNode source
-		doitFlag: false
-		errorMessage: aMessage
-		location: aNode startWithoutParentheses
+	OCSemanticError new
+		node: aNode;
+		messageText: aMessage;
+		location: aNode startWithoutParentheses;
+		signal
 ]
 
 { #category : #variables }

--- a/src/OpalCompiler-Core/OCSemanticError.class.st
+++ b/src/OpalCompiler-Core/OCSemanticError.class.st
@@ -3,65 +3,6 @@ Raises a semantic error during semantic analysis
 "
 Class {
 	#name : #OCSemanticError,
-	#superclass : #Error,
-	#instVars : [
-		'compilationContext',
-		'node'
-	],
+	#superclass : #CodeError,
 	#category : #'OpalCompiler-Core-Exception'
 }
-
-{ #category : #accessing }
-OCSemanticError >> compilationContext [
-	^ compilationContext
-]
-
-{ #category : #accessing }
-OCSemanticError >> compilationContext: anObject [
-	compilationContext := anObject
-]
-
-{ #category : #exceptiondescription }
-OCSemanticError >> defaultAction [
-	^self notify: messageText at: node start
-]
-
-{ #category : #accessing }
-OCSemanticError >> methodClass [
-	^self methodNode methodClass
-]
-
-{ #category : #accessing }
-OCSemanticError >> methodNode [
-	^node methodNode
-]
-
-{ #category : #accessing }
-OCSemanticError >> node [
-	^ node
-]
-
-{ #category : #accessing }
-OCSemanticError >> node: aNode [
-	node := aNode
-]
-
-{ #category : #'error handling' }
-OCSemanticError >> notify: aString at: location [
-	^self requestor
-		ifNil: [SyntaxErrorNotification
-					inClass: self methodClass
-					withCode: self methodNode source
-					doitFlag: false
-					errorMessage: aString
-					location: location]
-		ifNotNil: [self requestor
-					notify: aString , ' ->'
-					at: location
-					in: self requestor text]
-]
-
-{ #category : #accessing }
-OCSemanticError >> requestor [
-	^ compilationContext requestor
-]

--- a/src/OpalCompiler-Core/OCShadowVariableWarning.class.st
+++ b/src/OpalCompiler-Core/OCShadowVariableWarning.class.st
@@ -27,7 +27,6 @@ OCShadowVariableWarning >> raiseSemanticError [
 
 	^OCSemanticError new
 		node: node;
-		compilationContext: compilationContext;
 		messageText: self stringMessage;
 		signal
 ]

--- a/src/OpalCompiler-Core/OCStoreIntoReadOnlyVariableError.class.st
+++ b/src/OpalCompiler-Core/OCStoreIntoReadOnlyVariableError.class.st
@@ -7,16 +7,3 @@ Class {
 	#superclass : #OCSemanticError,
 	#category : #'OpalCompiler-Core-Exception'
 }
-
-{ #category : #accessing }
-OCStoreIntoReadOnlyVariableError >> description [
-	"Return a textual description of the exception."
-
-	^ String
-		streamContents: [ :stream |
-			stream << super description asString.
-			stream cr.
-			stream << self methodClass asString.
-			stream cr.
-			stream << self methodNode asString ]
-]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -258,9 +258,9 @@ OpalCompiler >> compile [
 			self compilationContext requestor
                 ifNotNil: [
 						self compilationContext requestor
-							notify: exception errorMessage , ' ->'
+							notify: exception messageText , ' ->'
 							at: exception location
-							in: exception errorCode.
+							in: exception sourceCode.
                     ^ self compilationContext failBlock value ]
                 ifNil: [ exception pass ]]
 ]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -253,7 +253,8 @@ OpalCompiler >> compile [
 	^[
 		self parse.
 		self semanticScope compileMethodFromASTBy: self
-	] on: SyntaxErrorNotification do: [ :exception |
+	] on: CodeError do: [ :exception |
+			exception sourceCode: source contents.
 			self compilationContext requestor
                 ifNotNil: [
 						self compilationContext requestor
@@ -331,9 +332,7 @@ OpalCompiler >> decompileMethod: aCompiledMethod [
 
 { #category : #private }
 OpalCompiler >> doSemanticAnalysis [
-	^[ast doSemanticAnalysis]
-		on: OCSemanticError
-		do: [ :ex | ex defaultAction. ^ self compilationContext failBlock value ]
+	^ ast doSemanticAnalysis
 ]
 
 { #category : #plugins }

--- a/src/OpalCompiler-Core/SyntaxErrorNotification.class.st
+++ b/src/OpalCompiler-Core/SyntaxErrorNotification.class.st
@@ -7,13 +7,7 @@ TODO: unify with the OCSemanticWarning hierarchy
 "
 Class {
 	#name : #SyntaxErrorNotification,
-	#superclass : #Notification,
-	#instVars : [
-		'inClass',
-		'code',
-		'doitFlag',
-		'location'
-	],
+	#superclass : #CodeError,
 	#category : #'OpalCompiler-Core-Exception'
 }
 
@@ -25,52 +19,4 @@ SyntaxErrorNotification class >> inClass: aClass withCode: codeString doitFlag: 
 		doitFlag: doitFlag
 		errorMessage: errorString
 		location: location) signal
-]
-
-{ #category : #exceptiondescription }
-SyntaxErrorNotification >> defaultAction [
-
-	"Notification are silently ignored by default.
-	Because SyntaxErrors are special (and not really resumable) it's better to force an error"
-	^ self unhandledErrorAction
-]
-
-{ #category : #accessing }
-SyntaxErrorNotification >> doitFlag [
-	^doitFlag
-]
-
-{ #category : #accessing }
-SyntaxErrorNotification >> errorClass [
-	^inClass
-]
-
-{ #category : #accessing }
-SyntaxErrorNotification >> errorCode [
-	^code
-]
-
-{ #category : #accessing }
-SyntaxErrorNotification >> errorMessage [
-	^messageText
-]
-
-{ #category : #accessing }
-SyntaxErrorNotification >> location [
-	^location
-]
-
-{ #category : #accessing }
-SyntaxErrorNotification >> messageText [
-	^ super messageText
-		ifNil: [messageText := code]
-]
-
-{ #category : #accessing }
-SyntaxErrorNotification >> setClass: aClass code: codeString doitFlag: aBoolean errorMessage: errorString location: anInteger [
-	inClass := aClass.
-	code := codeString.
-	doitFlag := aBoolean.
-	messageText := errorString.
-	location := anInteger
 ]

--- a/src/OpalCompiler-Core/SyntaxErrorNotification.class.st
+++ b/src/OpalCompiler-Core/SyntaxErrorNotification.class.st
@@ -13,10 +13,9 @@ Class {
 
 { #category : #exceptionInstantiator }
 SyntaxErrorNotification class >> inClass: aClass withCode: codeString doitFlag: doitFlag errorMessage: errorString location: location [
-	^ (self new
-		setClass: aClass
-		code: codeString
-		doitFlag: doitFlag
-		errorMessage: errorString
-		location: location) signal
+	self new
+		sourceCode: codeString;
+		messageText: errorString;
+		location: location;
+		signal
 ]

--- a/src/OpalCompiler-Tests/OCCompilerSyntaxErrorNotifyingTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerSyntaxErrorNotifyingTest.class.st
@@ -24,7 +24,7 @@ OCCompilerSyntaxErrorNotifyingTest >> enumerateAllSelections [
 	This can be compared to expected error notification."
 	1 to: self numberOfSelections do: [:n |
 		| result |
-		result := [self evaluateSelectionNumber: n] on: SyntaxErrorNotification do: [:exc |
+		result := [self evaluateSelectionNumber: n] on: CodeError do: [:exc |
 			| expectedNotification expectedNotificationLocation |
 			expectedNotification := (expectedErrors at: n) allButFirst allButLast: 3.
 			expectedNotificationLocation := (expectedErrorPositions at: n) - (morph editor startIndex - 1).

--- a/src/OpalCompiler-Tests/OCCompilerSyntaxErrorNotifyingTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerSyntaxErrorNotifyingTest.class.st
@@ -22,15 +22,27 @@ OCCompilerSyntaxErrorNotifyingTest >> enumerateAllSelections [
 	"This method intercepts the SyntaxErrorNotification and prevent the SyntaxError morph to open.
 	The notification errorCode hold the source of evaluated sub-selection with inserted error message.
 	This can be compared to expected error notification."
-	1 to: self numberOfSelections do: [:n |
+
+	1 to: self numberOfSelections do: [ :n |
 		| result |
-		result := [self evaluateSelectionNumber: n] on: CodeError do: [:exc |
-			| expectedNotification expectedNotificationLocation |
-			expectedNotification := (expectedErrors at: n) allButFirst allButLast: 3.
-			expectedNotificationLocation := (expectedErrorPositions at: n) - (morph editor startIndex - 1).
-			self assert: exc location equals: expectedNotificationLocation.
-			self assert: exc errorMessage asString equals: expectedNotification.
-			exc return: nil]]
+		result := [ self evaluateSelectionNumber: n ]
+			          on: CodeError
+			          do: [ :exc |
+				          | expectedNotification expectedNotificationLocation |
+				          expectedNotification := (expectedErrors at: n)
+					                                  allButFirst allButLast: 3.
+				          expectedNotificationLocation := (expectedErrorPositions
+					                                           at: n)
+				                                          -
+				                                          (morph editor startIndex
+				                                           - 1).
+				          self
+					          assert: exc location
+					          equals: expectedNotificationLocation.
+				          self
+					          assert: exc messageText asString
+					          equals: expectedNotification.
+				          exc return: nil ] ]
 ]
 
 { #category : #private }

--- a/src/OpalCompiler-Tests/RBCodeSnippet.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippet.extension.st
@@ -21,7 +21,7 @@ RBCodeSnippet >> compileOnError: aBlock [
 
 	^ [ OpalCompiler new
 		  noPattern: isMethod not;
-		  compile: self source ] on: SyntaxErrorNotification do: [ :e | aBlock cull: e ]
+		  compile: self source ] on: CodeError do: [ :e | aBlock cull: e ]
 ]
 
 { #category : #'*OpalCompiler-Tests' }
@@ -45,5 +45,5 @@ RBCodeSnippet >> doSemanticAnalysisOnError: aBlock [
 
 	^ [ OpalCompiler new
 		  noPattern: isMethod not;
-		  parse: self source ] on: SyntaxErrorNotification do: [ :e | aBlock value: e ]
+		  parse: self source ] on: CodeError do: [ :e | aBlock value: e ]
 ]

--- a/src/OpalCompiler-Tests/RBCodeSnippet.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippet.extension.st
@@ -7,7 +7,7 @@ RBCodeSnippet >> compile [
 		  options: #( #optionParseErrors #optionSkipSemanticWarnings );
 		  noPattern: isMethod not;
 		  compile: self source ]
-	on: SyntaxErrorNotification do: [ :e |
+	on: CodeError do: [ :e |
 		"Compilation should success, because its the *faulty* mode".
 		"If this is expected, then just return nil"
 		self ifSkip: #compile then: [^ nil ].

--- a/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
@@ -16,7 +16,7 @@ RBCodeSnippetTest >> testCompileOnError [
 
 	| method error |
 	error := nil.
-	method := snippet compileOnError: [ :e | error := e errorMessage ].
+	method := snippet compileOnError: [ :e | error := e messageText ].
 	snippet isFaulty
 		ifTrue: [ self assert: error isNotNil ]
 		ifFalse: [
@@ -88,7 +88,7 @@ RBCodeSnippetTest >> testDoSemanticAnalysisOnError [
 	| ast error |
 	error := nil.
 
-	ast := snippet doSemanticAnalysisOnError: [ :e | error := e errorMessage ].
+	ast := snippet doSemanticAnalysisOnError: [ :e | error := e messageText ].
 
 	snippet isFaulty
 		ifTrue: [ self assert: error isNotNil ]

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -194,7 +194,7 @@ RubSmalltalkEditor >> bestNodeInTextArea [
 	"We build the AST (which can be faulty when we are scripting) then ask the best node for the interval."
 	^ (self isScripting
 		   ifTrue: [ RBParser parseFaultyExpression: self textArea string ]
-		   ifFalse: [ RBParser parseMethod: self textArea string ]) bestNodeFor: (self textArea startIndex to: self textArea stopIndex)
+		   ifFalse: [ RBParser parseFaultyMethod: self textArea string ]) bestNodeFor: (self textArea startIndex to: self textArea stopIndex)
 ]
 
 { #category : #'source navigation' }

--- a/src/Tool-Finder/Finder.class.st
+++ b/src/Tool-Finder/Finder.class.st
@@ -87,7 +87,7 @@ Finder >> computeWithMethodFinder: aString [
 	[ dataObjects := Smalltalk compiler evaluate: '{' , data , '}' ]
 		on: SyntaxErrorNotification, RuntimeSyntaxError
 		do: [ :e |
-			self inform: 'Syntax Error: ' , e errorMessage.
+			self inform: 'Syntax Error: ' , e messageText.
 			^ #() ].	"#( data1 data2 result )"
 
 	dataObjects size < 2


### PR DESCRIPTION
This PR adds a new error super class for syntactic and semantic errors: `CodeError`.

The changes are rather brutal since:

* SyntaxErrorNotification become an Error (instead of a notification). The name stays unchanged for now.
* OCSemanticError is stripped of its responsibility to report error on the UI (yes, it was this bad).

Note: `OCSemanticWarning`, especially `OCUndeclaredVariableWarning` are let untouched (yet!)

Let's see if CI thinks this to too much change to handle...