### PR TITLE
Faulty code: CodeError are resumable

### DIFF
--- a/src/AST-Core/CodeError.class.st
+++ b/src/AST-Core/CodeError.class.st
@@ -34,6 +34,13 @@ CodeError >> errorMessage [
 	^ messageText
 ]
 
+{ #category : #'private - testing' }
+CodeError >> isResumable [
+
+	"When resumed, faulty AST are produced"
+	^true
+]
+
 { #category : #accessing }
 CodeError >> location [
 

--- a/src/AST-Core/CompiledMethod.extension.st
+++ b/src/AST-Core/CompiledMethod.extension.st
@@ -27,6 +27,7 @@ CompiledMethod >> parseTree [
 	ast := self methodClass compiler
 		source: self sourceCode;
 		failBlock: [^ self decompile ];
+		options: #( + #optionParseErrors #optionSkipSemanticWarnings ) ;
 		class: self methodClass;
 		parse.
 	ast compilationContext compiledMethod: self.

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -1243,7 +1243,10 @@ RBParser >> parserError: aString [
 						sourceCode: source;
 						messageText: errorMessage;
 						location: errorPosition;
-						signal
+						signal.
+
+	"If resumed, produce an error node"
+	^ self parseErrorNode: errorMessage
 ]
 
 { #category : #private }

--- a/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
@@ -68,6 +68,8 @@ RBCodeSnippetTest >> testDecompile [
 	method ifNil: [ ^ self skip ]. "Another test responsibility"
 	ast := method decompile.
 	self assert: ast isMethod.
+	ast := method parseTree.
+	self assert: ast isMethod.
 	"Decompilation lose many information. Not sure how to test more"
 ]
 

--- a/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
@@ -26,6 +26,17 @@ RBCodeSnippetTest >> testCompileOnError [
 ]
 
 { #category : #'*OpalCompiler-Tests' }
+RBCodeSnippetTest >> testCompileOnErrorResume [
+
+	| method error |
+	error := nil.
+	method := snippet compileOnError: [ :e | error := e messageText. e resume ].
+	self assert: snippet isFaulty equals: error isNotNil.
+	self assert: method isCompiledMethod.
+	self testExecute: method
+]
+
+{ #category : #'*OpalCompiler-Tests' }
 RBCodeSnippetTest >> testCompileWithRequestor [
 
 	| requestor method |


### PR DESCRIPTION
This PR feels like nothing, but is an achievement based on numerous previous PR on cleaning, improvements and bugfixes.

It shows that error management in compilation starts to become consistent.

It also means that when a debugger windows pop up in syntax or semantic error, user can "resume" and a faulty method might be produced.

e.g. try the following in the playground

```st
Smalltalk compiler evaluate: '1+'
```

You will get a syntax error. Then click on "▶️ proceed", and the code will be executed anyway (you proceeded, it's your fault) and thus you will a runtime error (whatever as hard you try, a thing is missing, and no decent value can be produced).

Note: I expect that some things might break, although faulty AST and faulty CompiledMethods are tested a lot, but I likely missed some code paths or usage (especially in GUI)