### PR TITLE
Log the package been tested on CI.

### DIFF
--- a/src/JenkinsTools-Core/HDReport.class.st
+++ b/src/JenkinsTools-Core/HDReport.class.st
@@ -29,7 +29,10 @@ HDReport class >> runPackage: aString [
 
 { #category : #running }
 HDReport class >> runPackages: aCollectionOfStrings [
-	^ aCollectionOfStrings collect: [ :each | self runPackage: each ]
+
+	^ aCollectionOfStrings collect: [ :packageName |
+		  Stdio stdout << 'Running tests of ' << packageName << OSPlatform current lineEnding.
+		  self runPackage: packageName ]
 ]
 
 { #category : #private }


### PR DESCRIPTION
The CI test runner is not always robust and it happens that we have crashes while running the tests.  To make it a little easier to locate the problems, I propose here to write on wich package we are launching tests. Like this, if a crash happens, we can know which test package is responsible.