### PR TITLE
Faulty parser - better error position and messages

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -713,9 +713,12 @@ RBCodeSnippet >> textWithNode: aNode message: aString [
 	"Insert the message after the stop so that:
 	 1. we can see where are zero-width errors
 	 2. we have the same output than the compiler error (above)"
+	stop := aNode isParseError
+		ifTrue: [ aNode errorPosition ]
+		ifFalse: [ aNode stop + 1 "after" ].
 	text
-		replaceFrom: stop + 1
-		to: stop
+		replaceFrom: stop
+		to: stop - 1
 		with: (aString asText addAttribute:
 				 (TextBackgroundColor color: Color lightBlue)).
 	^ text

--- a/src/AST-Core-Tests/RBErrorNodeParserTest.class.st
+++ b/src/AST-Core-Tests/RBErrorNodeParserTest.class.st
@@ -15,7 +15,7 @@ RBErrorNodeParserTest >> testFaultyAssigment [
 	self   deny: node contents first isFaulty.
 	self assert: node contents first value equals: 1.
 	self assert: node sourceInterval equals: (1 to: 3).
-	self assert: node errorMessage equals: 'identifier expected in assigment'.
+	self assert: node errorMessage equals: 'variable expected in assigment'.
 	self assert: node formattedCode equals: ':= 1'
 ]
 
@@ -261,7 +261,7 @@ RBErrorNodeParserTest >> testFaultyCascadeMessageExpected [
 	self assert: node isCascade.
 
 	self assert: node messages first isCascadeError.
-	self assert: node messages first sourceInterval equals: (1 to: 1).
+	self assert: node messages first sourceInterval equals: (1 to: 0).
 	self
 		assert: node messages first errorMessage
 		equals: 'Message expected'.
@@ -286,7 +286,7 @@ RBErrorNodeParserTest >> testFaultyCascadeMessageExpected2 [
 	self assert: node isCascade.
 
 	self assert: node messages first isCascadeError.
-	self assert: node messages first sourceInterval equals: (1 to: 1).
+	self assert: node messages first sourceInterval equals: (1 to: 0).
 	self
 		assert: node messages first errorMessage
 		equals: 'Message expected'.
@@ -318,7 +318,7 @@ RBErrorNodeParserTest >> testFaultyCascadeMessageExpected3 [
 	self assert: node isCascade.
 
 	self assert: node messages first isCascadeError.
-	self assert: node messages first sourceInterval equals: (1 to: 8).
+	self assert: node messages first sourceInterval equals: (1 to: 7).
 	self
 		assert: node messages first errorMessage
 		equals: 'Message expected'.
@@ -347,7 +347,7 @@ RBErrorNodeParserTest >> testFaultyCascadeMessageExpected4 [
 	self assert: node isCascade.
 
 	self assert: node messages first isCascadeError.
-	self assert: node messages first sourceInterval equals: (1 to: 2).
+	self assert: node messages first sourceInterval equals: (1 to: 1).
 	self
 		assert: node messages first errorMessage
 		equals: 'Message expected'.

--- a/src/AST-Core/RBDumpVisitor.class.st
+++ b/src/AST-Core/RBDumpVisitor.class.st
@@ -88,27 +88,28 @@ RBDumpVisitor >> visitCascadeNode:aCascadeNode [
 
 { #category : #visiting }
 RBDumpVisitor >> visitEnglobingErrorNode: anEnglobingErrorNode [
+
 	stream
 		nextPutAll: '(';
 		nextPutAll: anEnglobingErrorNode class name;
-		nextPutAll: ' contents: {'.
-	anEnglobingErrorNode contents
-		do: [ :each |
-			each acceptVisitor: self.
-			stream nextPutAll: '. ' ].
-	stream nextPut: $}.
-	stream nextPutAll: ' start: '.
-	anEnglobingErrorNode start printOn: stream.
-	stream nextPutAll: ' stop: '.
-	anEnglobingErrorNode stop printOn: stream.
-	stream nextPutAll: ' errorMessage: '.
-	anEnglobingErrorNode errorMessage printOn: stream.
+		nextPutAll: ' new contents: {'.
+	anEnglobingErrorNode contents do: [ :each |
+		each acceptVisitor: self.
+		stream nextPutAll: '. ' ].
 	stream
-		nextPutAll: ') value: ';
-		nextPutAll: anEnglobingErrorNode value printString;
+		nextPutAll: '}; start: ';
+		print: anEnglobingErrorNode start;
+		nextPutAll: '; stop: ';
+		print: anEnglobingErrorNode stop;
+		nextPutAll: '; errorPosition ';
+		print: anEnglobingErrorNode errorPosition;
+		nextPutAll: '; errorMessage: ';
+		print: anEnglobingErrorNode errorMessage;
+		nextPutAll: '; value: ';
+		print: anEnglobingErrorNode value;
 		nextPutAll: '; valueAfter: ';
-		nextPutAll: anEnglobingErrorNode valueAfter printString;
-		nextPutAll: '; yourself'
+		print: anEnglobingErrorNode valueAfter;
+		nextPutAll: '; yourself)'
 ]
 
 { #category : #visiting }

--- a/src/AST-Core/RBDumpVisitor.class.st
+++ b/src/AST-Core/RBDumpVisitor.class.st
@@ -101,7 +101,7 @@ RBDumpVisitor >> visitEnglobingErrorNode: anEnglobingErrorNode [
 		print: anEnglobingErrorNode start;
 		nextPutAll: '; stop: ';
 		print: anEnglobingErrorNode stop;
-		nextPutAll: '; errorPosition ';
+		nextPutAll: '; errorPosition: ';
 		print: anEnglobingErrorNode errorPosition;
 		nextPutAll: '; errorMessage: ';
 		print: anEnglobingErrorNode errorMessage;

--- a/src/AST-Core/RBEnglobingErrorNode.class.st
+++ b/src/AST-Core/RBEnglobingErrorNode.class.st
@@ -23,15 +23,6 @@ Class {
 	#category : #'AST-Core-Nodes - ErrorNodes'
 }
 
-{ #category : #'instance creation' }
-RBEnglobingErrorNode class >> contents: aCollection start: aStart stop: aStop errorMessage: message [
-	^self new
-		contents: aCollection;
-		start: aStart;
-		stop: aStop;
-		errorMessage: message
-]
-
 { #category : #construction }
 RBEnglobingErrorNode class >> error: aToken withNodes: aCollection [
 

--- a/src/AST-Core/RBEnglobingErrorNode.class.st
+++ b/src/AST-Core/RBEnglobingErrorNode.class.st
@@ -34,6 +34,7 @@ RBEnglobingErrorNode class >> contents: aCollection start: aStart stop: aStop er
 
 { #category : #construction }
 RBEnglobingErrorNode class >> error: aToken withNodes: aCollection [
+
 	"Realise a selection between the different englobing error node classes possible according to the
 	 received token. If the value of the token is not recognised, we create an undetermined one."
 	('()' includes: aToken value)
@@ -50,7 +51,11 @@ RBEnglobingErrorNode class >> error: aToken withNodes: aCollection [
 		ifTrue: [ ^RBTemporariesErrorNode error: aToken withNodes: aCollection ].
 	('<' = aToken value asString)
 		ifTrue: [ ^RBPragmaErrorNode error: aToken withNodes: aCollection ].
-	^self new contents: aCollection; start: aCollection first start; stop: aToken stop; errorMessage: 'complementary of''',aToken value,''' expected'
+	^self new
+		contents: aCollection;
+		start: aCollection first start;
+		stop: aToken stop;
+		errorMessage: 'complementary of''',aToken value,''' expected'
 ]
 
 { #category : #'instance creation' }

--- a/src/AST-Core/RBEnglobingErrorNode.class.st
+++ b/src/AST-Core/RBEnglobingErrorNode.class.st
@@ -53,6 +53,19 @@ RBEnglobingErrorNode class >> error: aToken withNodes: aCollection [
 	^self new contents: aCollection; start: aCollection first start; stop: aToken stop; errorMessage: 'complementary of''',aToken value,''' expected'
 ]
 
+{ #category : #'instance creation' }
+RBEnglobingErrorNode class >> from: aParseErrorNode contents: anArrayOfNodes [
+	"Transform a simple error node into a englobing one while preserving most information"
+
+	^ self new
+		start: (aParseErrorNode start min: (anArrayOfNodes min: #start));
+		stop: (aParseErrorNode stop max: (anArrayOfNodes min: #stop));
+		errorPosition: aParseErrorNode errorPosition;
+		errorMessage: aParseErrorNode errorMessage;
+		valueAfter: aParseErrorNode value;
+		contents: anArrayOfNodes
+]
+
 { #category : #visiting }
 RBEnglobingErrorNode >> acceptVisitor: aVisitor [
 

--- a/src/AST-Core/RBParseErrorNode.class.st
+++ b/src/AST-Core/RBParseErrorNode.class.st
@@ -75,7 +75,7 @@ RBParseErrorNode >> errorMessage: anObject [
 { #category : #accessing }
 RBParseErrorNode >> errorPosition [
 
-	^ errorPosition ifNil: [ self stop ]
+	^ errorPosition
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBParseErrorNode.class.st
+++ b/src/AST-Core/RBParseErrorNode.class.st
@@ -17,7 +17,8 @@ Class {
 		'errorMessage',
 		'value',
 		'start',
-		'stop'
+		'stop',
+		'errorPosition'
 	],
 	#category : #'AST-Core-Nodes - ErrorNodes'
 }
@@ -69,6 +70,18 @@ RBParseErrorNode >> errorMessage [
 { #category : #accessing }
 RBParseErrorNode >> errorMessage: anObject [
 	errorMessage := anObject
+]
+
+{ #category : #accessing }
+RBParseErrorNode >> errorPosition [
+
+	^ errorPosition ifNil: [ self stop ]
+]
+
+{ #category : #accessing }
+RBParseErrorNode >> errorPosition: anObject [
+
+	errorPosition := anObject
 ]
 
 { #category : #comparing }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -750,10 +750,12 @@ RBParser >> parseLiteralByteArrayObject [
 	(currentToken isLiteralToken and:
 			[currentToken value isInteger and: [currentToken value between: 0 and: 255]])
 		ifFalse: [
-			| errorNode |
+			| errorNode lost |
 			errorNode := self parserError: '8-bit integer expected'.
 			"Error recovery: consume the token as classic literal array object"
-			errorNode value: self parseLiteralArrayObject value asString.
+			lost := self parseLiteralArrayObject.
+			errorNode value: lost value asString.
+			errorNode stop: lost stop.
 			^ errorNode ].
 	^self parsePrimitiveLiteral
 ]

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -323,13 +323,12 @@ RBParser >> parseAssignment [
 	"Need one token lookahead to see if we have a ':='. This method could
 	make it possible to assign the literals true, false and nil."
 
-	| node position |
+	| node position err |
 	currentToken isAssignment ifTrue: [
-		self parserError: 'Variable expected'.
-		position := currentToken start.
+		err := self parserError: 'variable expected in assigment'.
 		self step. "Consume the :="
 		node := self parseAssignment. "parse the right side".
-		node := RBAssignmentErrorNode contents: { node } start: position stop: node stop errorMessage: 'identifier expected in assigment'.
+		node := RBAssignmentErrorNode from: err contents: { node }.
 		node value: ':='.
 		^ node
 	].
@@ -463,7 +462,7 @@ RBParser >> parseBlockArgsInto: node [
 
 { #category : #'private - parsing' }
 RBParser >> parseCascadeMessage [
-	| node receiver messages semicolons |
+	| node receiver messages semicolons err |
 	"Parse of the first message. It can be either unary, binary or keyword."
 	node := self parseKeywordMessage.
 
@@ -486,12 +485,8 @@ RBParser >> parseCascadeMessage [
 		"Cut parsing with an error.
 		If in faulty mode, continue the execution and generate a faulty cascade node.
 		Note that this bad cascade node will be added to the list of messages."
-		self parserError: 'Message expected'.
-		node := RBInvalidCascadeErrorNode
-			contents: { node }
-			start: node start
-			stop: currentToken stop
-			errorMessage: 'Message expected'.
+		err := self parserError: 'Message expected'.
+		node := RBInvalidCascadeErrorNode from: err contents: { node }
 	].
 	receiver := node receiver.
  	messages add: node.
@@ -552,7 +547,10 @@ RBParser >> parseEnglobingError: aCollection with: aToken errorMessage: anErrorM
 	| firstParse |
 	firstParse := self parserError: anErrorMessage.
 	^firstParse isParseError
-		ifTrue: [ (self englobingErrorNodeClass error: aToken withNodes: aCollection) value: aToken value asString ]
+		ifTrue: [
+			(self englobingErrorNodeClass error: aToken withNodes: aCollection)
+				value: aToken value asString;
+				errorPosition: firstParse errorPosition ]
 		ifFalse: [ firstParse ]
 ]
 
@@ -939,7 +937,7 @@ RBParser >> parseStatementInto: statementList periodList: periods withAcceptedSt
 
 	Put any period found at the end of this statement int the periods collection.
 	"
-	| returnPosition node startOfStatementToken |
+	| returnPosition node startOfStatementToken err |
 
 	"Record the token found at the beginning of the statement.
 	If at the end we did not consume it, consume it and mark it as a bad statement for now"
@@ -969,13 +967,10 @@ RBParser >> parseStatementInto: statementList periodList: periods withAcceptedSt
 	[(')]}' includes: currentToken value)
 		and: [ (aCollectionOfClosers includes: currentToken value) not ]]
 			whileTrue: [
-				self parserError: 'Missing opener for closer: ', currentToken value asString.
-				node := RBUnfinishedStatementErrorNode
-					contents: { node }
-					start: node start
-					stop: currentToken stop
-					errorMessage: 'Missing opener for closer: ', currentToken value asString.
-				node valueAfter: currentToken value asString.
+				err := self parserError: 'Missing opener for closer: ', currentToken value asString.
+				node := (RBUnfinishedStatementErrorNode from: err contents: { node })
+					valueAfter: currentToken value asString;
+					stop: currentToken stop.
 				self step ].
 
 	"Next we should have the end of the statement
@@ -991,12 +986,9 @@ RBParser >> parseStatementInto: statementList periodList: periods withAcceptedSt
 		"I do not like the following guard. If currentToken is an unrelated error,
 		 then parserError will unfortunately consume and lose it.
 		 A better design is needed."
-		node isParseError ifFalse: [ self parserError: 'End of statement expected' ].
-		node := RBUnfinishedStatementErrorNode
-			contents: { node }
-			start: node start
-			stop: node stop
-			errorMessage: 'End of statement expected'
+		node isParseError ifFalse: [ 
+			err := self parserError: 'End of statement expected'.
+			node := RBUnfinishedStatementErrorNode from: err contents: { node } ]
 	].
 
 	"Then consume all dots and comments coming after this well formed statement, if there was any"
@@ -1013,12 +1005,8 @@ RBParser >> parseStatementInto: statementList periodList: periods withAcceptedSt
 	"If the previous node in the statement list is a return node, mark this node as unreachable"
 
 	(statementList notEmpty and: [ statementList last isReturn ]) ifTrue: [
-		self parserError: 'Unreachable code'.
-		node := RBUnreachableStatementErrorNode
-			contents: { node }
-			start: node start
-			stop: node stop
-			errorMessage: 'Unreachable code' ].
+		err := self parserError: 'Unreachable code'.
+		node := RBUnreachableStatementErrorNode from: err contents: { node } ].
 
 	"Commit the statement to the statements list"
 	statementList add: node

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -556,19 +556,21 @@ RBParser >> parseEnglobingError: aCollection with: aToken errorMessage: anErrorM
 
 { #category : #'private - parsing' }
 RBParser >> parseErrorNode: aMessageString [
-	| errorPosition|
+	| errorNode |
 	currentToken isError
-		ifTrue: [ | errorNode|
-					 "The current token is an error, consume it and use its content for the error node."
-				    errorNode := RBParseErrorNode errorMessage: currentToken cause value: currentToken value at: currentToken start.
-					 errorNode stop: currentToken location.
-					 self step.
-					 ^errorNode].
+		ifTrue: [
+			"The current token is an error, consume it and use its content for the error node."
+			errorNode := RBParseErrorNode errorMessage: currentToken cause value: currentToken value at: self errorPosition.
+			errorNode stop: currentToken location.
+			errorNode errorPosition: currentToken location.
+			self step.
+			^ errorNode].
 	"The current token is not an error but is unexpected. Maybe something is missing?
 	Anyway, the error node is an empty string and the current token will be used to continue the parsing."
-	errorPosition := self errorPosition.
-	(errorPosition = 0) ifTrue: [ errorPosition := self errorPosition].
-	^ RBParseErrorNode errorMessage: aMessageString value: '' asString at: errorPosition
+	errorNode := RBParseErrorNode errorMessage: aMessageString value: '' asString at: self errorPosition.
+	errorNode stop: self errorPosition - 1.
+	errorNode errorPosition: self errorPosition.
+	^errorNode
 ]
 
 { #category : #parsing }
@@ -1169,19 +1171,15 @@ RBParser >> parseVariableNode [
 { #category : #'error handling' }
 RBParser >> parserError: aString [
 
-	| errorNode errorMessage errorPosition |
-	currentToken isError
-		ifTrue: [ errorMessage := currentToken cause. errorPosition := currentToken location ]
-		ifFalse: [ errorMessage := aString. errorPosition := currentToken start ].
-
+	| errorNode |
 	errorNode := self parseErrorNode: aString.
-	errorBlock ifNotNil: [ errorBlock cull: errorMessage cull: errorPosition cull: self ].
+	errorBlock ifNotNil: [ errorBlock cull: errorNode errorMessage cull: errorNode errorPosition cull: self ].
 	isFaulty ifTrue: [ ^ errorNode ].
 
 	SyntaxErrorNotification new
 		sourceCode: source;
-		messageText: errorMessage;
-		location: errorPosition;
+		messageText: errorNode errorMessage;
+		location: errorNode errorPosition;
 		signal.
 
 	"If resumed, return with the error node"

--- a/src/OpalCompiler-Tests/OCCompilerNotifyingTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerNotifyingTest.class.st
@@ -45,7 +45,7 @@ OCCompilerNotifyingTest >> enumerateAllSelections [
 	1 to: self numberOfSelections do: [ :n |
 		self assert: (self evaluateSelectionNumber: n) identicalTo: failure.
 		self assert: morph editor selection asString equals: (expectedErrors at: n).
-		self assert: (expectedErrorPositions at: n) equals: morph editor startIndex.
+		self assert: morph editor startIndex equals: (expectedErrorPositions at: n).
 		morph editor cut ]
 ]
 


### PR DESCRIPTION
In the parser, the management of faulty parsing with `RBParseErrorNode` and especially with `RBEnglobingErrorNode` was hacked in parallel of the existing Exception and errorBlock error handling, including redundancy (and inconsistency) on error messages and error positions.

This PR tries to simplify the mess a little, especially:

* new `errorPostion` in `RBParseErrorNode` (and `RBEnglobingErrorNode`) to pinpoint the exact location, you should put the cursor or popup message (or insert `->` messages in source code if it's your kink).
* new `RBEnglobingErrorNode class>>#from:contents:` to transform a `RBParseErrorNode` into a `RBEnglobingErrorNode` (or a subclass) reusing the information and adapting the span of the error (that could also be adapted further if needed).