### PR TITLE
Compiler: remove getSourceFromRequestorSelection

### DIFF
--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -357,7 +357,6 @@ OpalCompiler >> evaluate [
 
 	| value doItMethod |
 	self noPattern: true.
-	self getSourceFromRequestorSelection.
 	doItMethod := self compile.
 	doItMethod ifNotNil: [
 			value := self semanticScope evaluateDoIt: doItMethod ].
@@ -389,17 +388,6 @@ OpalCompiler >> format: textOrString [
 	^self
 		source: textOrString;
 		format
-]
-
-{ #category : #private }
-OpalCompiler >> getSourceFromRequestorSelection [
-    | selection |
-    "if the requestor can provide a selection, we use that as the source"
-     (self compilationContext requestor respondsTo: #selection) ifFalse: [ ^self ].
-
-    selection := self compilationContext requestor selection .
-    selection isEmptyOrNil ifTrue: [ ^self ].
-    self source: selection asString
 ]
 
 { #category : #testing }

--- a/src/OpalCompiler-Tests/MockSourceEditor.class.st
+++ b/src/OpalCompiler-Tests/MockSourceEditor.class.st
@@ -75,13 +75,6 @@ MockSourceEditor >> selection [
 ]
 
 { #category : #selection }
-MockSourceEditor >> selectionAsStream [
-
-	^ ReadStream
-		on: (self text copyFrom: selectionStart to: selectionEnd)
-]
-
-{ #category : #selection }
 MockSourceEditor >> selectionInterval [
 
 	^ Interval from: selectionStart to: selectionEnd

--- a/src/OpalCompiler-Tests/OCCompilerNotifyingTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerNotifyingTest.class.st
@@ -52,7 +52,7 @@ OCCompilerNotifyingTest >> enumerateAllSelections [
 { #category : #private }
 OCCompilerNotifyingTest >> evaluateSelection [
 	^ OpalCompiler new
-		source: morph editor selectionAsStream;
+		source: morph editor selection;
 		requestor: morph editor;
 		failBlock: [^failure];
 		evaluate

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -322,7 +322,7 @@ RubSmalltalkEditor >> compile: aStream for: anObject in: evalContext [
 
 { #category : #'do-its' }
 RubSmalltalkEditor >> compileSelectionFor: anObject in: evalContext [
-	^ self compile: self selectionAsStream for: anObject in: evalContext
+	^ self compile: self selection for: anObject in: evalContext
 ]
 
 { #category : #'completion engine' }
@@ -488,7 +488,7 @@ RubSmalltalkEditor >> debugSelection [
 	"Treat the current selection as an expression; evaluate and debugg it in a new debugger."
 
 	self lineSelectAndEmptyCheck: [^self].
-	self debug: self selectionAsStream
+	self debug: self selection
 ]
 
 { #category : #'do-its' }
@@ -544,7 +544,7 @@ RubSmalltalkEditor >> evaluateSelectionAndDo: aBlock [
 
 	self lineSelectAndEmptyCheck: [^ ''].
 	^ self
-		evaluate: self selectionForDoitAsStream
+		evaluate: self selection
 		andDo: aBlock
 ]
 
@@ -1177,7 +1177,7 @@ RubSmalltalkEditor >> tallySelection [
 	"Treat the current selection as an expression; evaluate and tally it."
 
 	self lineSelectAndEmptyCheck: [ ^ self ].
-	self tally: self selectionAsStream
+	self tally: self selection
 ]
 
 { #category : #'completion engine' }

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -2151,15 +2151,6 @@ RubTextEditor >> selection [
 ]
 
 { #category : #'accessing - selection' }
-RubTextEditor >> selectionAsStream [
-	"Answer a ReadStream on the text in the paragraph that is currently
-	selected."
-
-	^ReadStream
-		on: (self string copyFrom: self startIndex to: self stopIndex - 1)
-]
-
-{ #category : #'accessing - selection' }
 RubTextEditor >> selectionInterval [
 	"Answer the interval that is currently selected."
 

--- a/src/Text-Edition/TextEditor.class.st
+++ b/src/Text-Edition/TextEditor.class.st
@@ -1493,7 +1493,7 @@ TextEditor >> evaluateSelectionAndDo: aBlock [
 				ctxt := model doItContext]
 		ifFalse: [rcvr := ctxt := nil].
 	result := rcvr class compiler
-			source: self selectionAsStream;
+			source: self selection;
 			context: ctxt;
 			receiver: rcvr;
 			requestor: self;
@@ -2755,15 +2755,6 @@ TextEditor >> selection [
 	"Answer the text in the paragraph that is currently selected."
 
 	^self text copyFrom: self startIndex to: self stopIndex - 1
-]
-
-{ #category : #'accessing - selection' }
-TextEditor >> selectionAsStream [
-	"Answer a ReadStream on the text in the paragraph that is currently
-	selected."
-
-	^ReadStream
-		on: (self string copyFrom: self startIndex to: self stopIndex - 1)
 ]
 
 { #category : #'accessing - selection' }


### PR DESCRIPTION
For some reason, the compiler did callback the UI editor to get the selection string to evaluate, misunderstanding that it should already have it. If editors give garbage to the compiler, it's not the responsibility of the compiler to repair. (I am not able rightly to apprehend the kind of confusion of ideas that could provoke such a design).

Moreover, kill selectionAsStream in editors as a string is OK for the compiler, no need of a stream.