### PR TITLE
Compiler get isFaulty

### DIFF
--- a/src/AST-Core/CompiledMethod.extension.st
+++ b/src/AST-Core/CompiledMethod.extension.st
@@ -27,7 +27,7 @@ CompiledMethod >> parseTree [
 	ast := self methodClass compiler
 		source: self sourceCode;
 		failBlock: [^ self decompile ];
-		options: #( + #optionParseErrors #optionSkipSemanticWarnings ) ;
+		isFaulty: true;
 		class: self methodClass;
 		parse.
 	ast compilationContext compiledMethod: self.

--- a/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
@@ -91,7 +91,7 @@ ClyMethodEditorToolMorph >> currentEditedAST [
 
 	^ self methodClass compiler
 		  source: self pendingText;
-		  options: #( + optionParseErrors + optionSkipSemanticWarnings );
+		 isFaulty: true;
 		  parse
 ]
 

--- a/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
@@ -72,7 +72,7 @@ CoASTResultSetBuilder >> parseNode [
 		(completionContext completionClass compiler
 			source: completionContext source;
 			noPattern: completionContext isScripting;
-			options: #(+ optionParseErrors + optionSkipSemanticWarnings);
+			isFaulty: true;
 			parse) nodeForOffset: completionContext position ]
 ]
 

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -476,7 +476,7 @@ CompiledMethodTest >> testIsFaulty [
 	|  cm |
 	cm := OpalCompiler new
 				source: 'method 3+';
-				options: #(+ optionParseErrors +optionEmbeddSources);
+				isFaulty: true;
 				compile.
 	self assert: cm isFaulty.
 	self deny: (OCASTTranslator>>#visitParseErrorNode:) isFaulty

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -607,7 +607,7 @@ CompiledMethod >> isFaulty [
 	"we have to parse the ast here as #ast does not know that this needs optionParseErrors"
 	ast := self methodClass compiler
 				source: self sourceCode;
-				options: #(+ optionParseErrors);
+				isFaulty: true;
 				parse.
 	^ ast isFaulty
 ]

--- a/src/NECompletion/CompletionContext.class.st
+++ b/src/NECompletion/CompletionContext.class.st
@@ -125,7 +125,7 @@ CompletionContext >> parseSource [
 	ast := class compiler
 		source: source;
 		noPattern: self isScripting;
-		options: #(+ optionParseErrors + optionSkipSemanticWarnings);
+		isFaulty: true;
 		parse.
 	TypingVisitor new visitNode: ast
 ]

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -34,7 +34,8 @@ Class {
 		'requestorScopeClass',
 		'bindings',
 		'compiledMethodClass',
-		'semanticScope'
+		'semanticScope',
+		'isFaulty'
 	],
 	#classVars : [
 		'DefaultOptions',
@@ -499,7 +500,8 @@ CompilationContext >> initialize [
 	options := Set new.
 	astTransformPlugins := OrderedCollection withAll: self class defaultTransformationPlugins.
 	astParseTransformPlugins := OrderedCollection withAll: self class defaultParseTransformationPlugins.
-	semanticScope := OCMethodSemanticScope targetingClass: nil class
+	semanticScope := OCMethodSemanticScope targetingClass: nil class.
+	isFaulty := false
 ]
 
 { #category : #accessing }
@@ -511,6 +513,18 @@ CompilationContext >> interactive [
 	^ (requestor respondsTo: #interactive)
 		  ifTrue: [ requestor interactive ]
 		  ifFalse: [ true ]
+]
+
+{ #category : #accessing }
+CompilationContext >> isFaulty [
+
+	^ isFaulty
+]
+
+{ #category : #accessing }
+CompilationContext >> isFaulty: anObject [
+
+	isFaulty := anObject
 ]
 
 { #category : #accessing }
@@ -639,6 +653,10 @@ CompilationContext >> optionSkipSemanticWarnings [
 
 { #category : #options }
 CompilationContext >> parseOptions: optionsArray [
+
+	(optionsArray includesAny: #( #optionParseErrorsNonInteractiveOnly
+		    #optionParseErrors #optionSkipSemanticWarnings )) ifTrue: [ isFaulty := true ].
+
 	options parseOptions: optionsArray
 ]
 

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -84,7 +84,7 @@ OCASTSemanticAnalyzer >> declareVariableNode: aVariableNode as: anOCTempVariable
 { #category : #errors }
 OCASTSemanticAnalyzer >> error: aMessage forNode: aNode [
 	aNode addError: aMessage.
-	compilationContext optionSkipSemanticWarnings ifTrue: [ ^ self ].
+	compilationContext isFaulty ifTrue: [ ^ self ].
 
 	OCSemanticError new
 		node: aNode;
@@ -110,7 +110,8 @@ OCASTSemanticAnalyzer >> scope: aSemScope [
 { #category : #'error handling' }
 OCASTSemanticAnalyzer >> shadowingVariable: aNode [
 	aNode addWarning: 'Name already defined'.
-	compilationContext optionSkipSemanticWarnings ifTrue: [ ^aNode ].
+	compilationContext isFaulty ifTrue: [ ^aNode ].
+
 	^ OCShadowVariableWarning new
 		node: aNode;
 		compilationContext: compilationContext;
@@ -120,7 +121,7 @@ OCASTSemanticAnalyzer >> shadowingVariable: aNode [
 { #category : #'error handling' }
 OCASTSemanticAnalyzer >> storeIntoReadOnlyVariable: variableNode [
 	variableNode addError: 'Assignment to read-only variable'.
-	compilationContext optionSkipSemanticWarnings ifTrue: [ ^ self ].
+	compilationContext isFaulty ifTrue: [ ^ self ].
 
 	^ OCStoreIntoReadOnlyVariableError new
 		node: variableNode;
@@ -131,7 +132,8 @@ OCASTSemanticAnalyzer >> storeIntoReadOnlyVariable: variableNode [
 { #category : #'error handling' }
 OCASTSemanticAnalyzer >> storeIntoReservedVariable: variableNode [
 	variableNode addError: 'Assigment to reserved variable'.
-	compilationContext optionSkipSemanticWarnings ifTrue: [ ^ self ].
+	compilationContext isFaulty ifTrue: [ ^ self ].
+
 	^ OCStoreIntoReservedVariableError new
 		node: variableNode;
 		messageText: 'Assigment to reserved variable';
@@ -154,7 +156,7 @@ OCASTSemanticAnalyzer >> undeclaredVariable: variableNode [
 	Or never if compilation is aborted or if only frontend is requested."
 	varName := variableNode name asSymbol.
 	var := self undeclared at: varName ifAbsentPut: [ UndeclaredVariable possiblyRegisteredWithName: varName ].
-	compilationContext optionSkipSemanticWarnings ifTrue: [ ^ var ].
+	compilationContext isFaulty ifTrue: [ ^ var ].
 
 	^ OCUndeclaredVariableWarning new
 		node: variableNode;

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -48,7 +48,8 @@ OCRequestorScope >> lookupVar: name declare: aBoolean [
 	"We do not want to auto define bindings for unknown Globals"
 	name first isUppercase ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean].
 	"do not 'create bindings' in requestor scope if we just want to style a possible unknown variable"
-	((compilationContext optionSkipSemanticWarnings or: [aBoolean not])
+	self flag: 'This one is bad. the faulty mode should not impact if/how variables are created.'.
+	((compilationContext isFaulty or: [aBoolean not])
 		and: [ (requestor hasBindingOf: name) not ])
 		ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean ].
 

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -314,8 +314,7 @@ OpalCompiler >> createParser [
 
 	| parser |
 	parser := self parserClass new.
-	(self compilationContext optionParseErrors or: [ self allowParseErrorsNonInteractive ])
-		ifTrue: [ parser beFaulty ].
+	parser isFaulty: self compilationContext isFaulty.
 	parser	 initializeParserWith: source contents.
 	^parser
 ]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -403,6 +403,12 @@ OpalCompiler >> getSourceFromRequestorSelection [
 ]
 
 { #category : #testing }
+OpalCompiler >> isFaulty: aBoolean [
+
+	self compilationContext isFaulty: aBoolean
+]
+
+{ #category : #testing }
 OpalCompiler >> isInteractive [
 	^ compilationContext interactive
 ]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -194,11 +194,6 @@ OpalCompiler >> addPlugin: aClass [
 	compilationContext addASTTransformationPlugin: aClass
 ]
 
-{ #category : #private }
-OpalCompiler >> allowParseErrorsNonInteractive [
-	^self compilationContext optionParseErrorsNonInteractiveOnly and: [ self isInteractive not ]
-]
-
 { #category : #accessing }
 OpalCompiler >> bindings: aDictionary [
 	"allows to define additional binding, note: Globals are not shadowed"

--- a/src/OpalCompiler-Tests/OCCompileWithFailureTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompileWithFailureTest.class.st
@@ -35,7 +35,7 @@ OCCompileWithFailureTest >> testEvalSimpleMethodWithError [
 	| ast cm |
 	ast := OpalCompiler new
 				source: 'method 3+';
-				options: #(+ optionParseErrors);
+				isFaulty: true;
 				parse.
 
 	self assert: ast isMethod.

--- a/src/OpalCompiler-Tests/OCCompileWithFailureTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompileWithFailureTest.class.st
@@ -23,7 +23,7 @@ OCCompileWithFailureTest >> testEmptyBlockArg [
 	result := UndefinedObject compiler
     source: '^[ :]';
     noPattern: true;
-    options:  #(+ optionParseErrors + optionSkipSemanticWarnings);
+    isFaulty: true;
     requestor: self;
     parse.
 	self assert: result isDoIt.
@@ -51,7 +51,7 @@ OCCompileWithFailureTest >> testParenthesis [
 	result := UndefinedObject compiler
     source: 'self assert: pragma( numArgs equals: 0.';
     noPattern: true;
-    options:  #(+ optionParseErrors + optionSkipSemanticWarnings);
+    isFaulty: true;
     requestor: self;
     parse.
 	self assert: result isDoIt.

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -465,13 +465,13 @@ OCCompilerTest >> testUndefinedVariable [
 	self
 		assert: {
 			OpalCompiler new
-				options: #( + optionSkipSemanticWarnings );
+				isFaulty: true;
 				evaluate: 'undefinedName123'.
 			OpalCompiler new
-				options: #( + optionSkipSemanticWarnings );
+				isFaulty: true;
 				evaluate: 'undefinedName123 := 2. undefinedName123'.
 			OpalCompiler new
-				options: #( + optionSkipSemanticWarnings );
+				isFaulty: true;
 				evaluate: 'undefinedName123' }
 		equals: { nil. 2. 2. }.
 

--- a/src/OpalCompiler-Tests/RBCodeSnippet.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippet.extension.st
@@ -4,7 +4,7 @@ Extension { #name : #RBCodeSnippet }
 RBCodeSnippet >> compile [
 
 	^ [ OpalCompiler new
-		  options: #( #optionParseErrors #optionSkipSemanticWarnings );
+		  isFaulty: true;
 		  noPattern: isMethod not;
 		  compile: self source ]
 	on: CodeError do: [ :e |
@@ -34,7 +34,7 @@ RBCodeSnippet >> doSemanticAnalysis [
 	So just ask the compiler."
 
 	^ OpalCompiler new
-		  options: #( #optionParseErrors #optionSkipSemanticWarnings );
+		  isFaulty: true;
 		  noPattern: isMethod not;
 		  parse: self source "Note: `parse:` also does the semantic analysis and return the AST"
 ]

--- a/src/PharoDocComment/PharoDocCommentExpression.class.st
+++ b/src/PharoDocComment/PharoDocCommentExpression.class.st
@@ -44,7 +44,7 @@ PharoDocCommentExpression >> expressionNodeReal [
 		  source: self source;
 		  noPattern: true;
 		  receiver: self methodClass;
-		  options: #( + optionParseErrors );
+		  isFaulty: true;
 		  parse
 ]
 

--- a/src/Shout-Tests/SHRBStyleAttributionTest.class.st
+++ b/src/Shout-Tests/SHRBStyleAttributionTest.class.st
@@ -46,7 +46,7 @@ SHRBStyleAttributionTest >> style: aText [
 		       source: aText asString;
 		       noPattern: false;
 		       class: self class;
-		       options: #( + optionParseErrors + optionSkipSemanticWarnings );
+		       isFaulty: true;
 		       parse.
 	styler style: aText ast: ast.
 

--- a/src/Shout-Tests/SHRBTextStylerTest.class.st
+++ b/src/Shout-Tests/SHRBTextStylerTest.class.st
@@ -23,8 +23,8 @@ SHRBTextStylerTest >> style: aText [
 
 	ast := self class compiler
 		source: aText asString;
-		noPattern: false ;
-		options:  #(+ optionParseErrors + optionSkipSemanticWarnings);
+		noPattern: false;
+		isFaulty: true;
 		parse.
 	styler style: aText ast: ast.
 

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -796,7 +796,7 @@ SHRBTextStyler >> privateStyle: aText [
 	compiler := classOrMetaClass compiler
 		source: aText asString;
 		noPattern: self isForWorkspace ;
-		options:  #(+ optionParseErrors + optionSkipSemanticWarnings);
+		isFaulty: true;
 		requestor: workspace.
 
 	self plugins do: [ :each | compiler addParsePlugin: each ].


### PR DESCRIPTION
Parsing and compiling in a "faulty" way is not really a preference toggle, it's mainly the responsibility of client to state what they want and what kind of results they are ready to deal with.

So this PR deprecate the options `#optionParseErrorsNonInteractiveOnly` `#optionParseErrors` `#optionSkipSemanticWarnings` and propose a single compilation flag.
This simplifies the code of clients and the internal logic of the compiler.

Also, I did not like the `options:` way because the syntax is cumbersome, long names are easy to misspell, and spelling errors are silently ignored.

I use a flag named `isFaulty`, that I also exposed in the parser #13042. But now I have a second thought. *faulty* means *containing a fault or defect; imperfect or defective*, that make sense for an AST or a method, but not really for the parser or the compiler. Here are some alternative names. I will change the name to the one you prefer.

* `acceptFaulty`
* `tolerateFaulty`
* `supportFaulty`
* `permitFaulty`
* something else?