### PR TITLE
13051 improve the memory allocation of sequenceable collection runningof

### DIFF
--- a/src/Collections-Arithmetic/SequenceableCollection.extension.st
+++ b/src/Collections-Arithmetic/SequenceableCollection.extension.st
@@ -5,20 +5,16 @@ SequenceableCollection >> running: aBlock of: aSubsetSize [
 	"This is a generalization of a running average (a.k.a. moving average, rolling average) which allows you to apply any given block to the shifting subsets of a given size.
 
 	For example, given a collection #(1 2 3 4 5) and a window size 2, we collect subsets of this collection by starting with first 2 elements and shifting the window 1 element to the right: #((1 2)(2 3)(3 4)(4 5)), then we apply aBlock to each subset and collect the results. For example, if aBlock is [ :subset | subset average ], this will give us #(1.5 2.5 3.5 4.5)"
-	| result |
-
-	aSubsetSize > self size ifTrue: [
-		SubscriptOutOfBounds
-			signal: 'The subset size can not exceed the size of a collection' ].
-
-	aSubsetSize < 0 ifTrue: [
-		SubscriptOutOfBounds
-			signal: 'The subset size must be positive' ].
-
-	result := (1 to: self size - aSubsetSize + 1) collect: [ :i |
-		aBlock value: (self copyFrom: i to: i + aSubsetSize - 1) ].
-
-	^ self species withAll: result
+	| subset |
+	aSubsetSize > self size
+		ifTrue: [ SubscriptOutOfBounds signal: 'The subset size can not exceed collection size' ].
+	aSubsetSize < 0
+		ifTrue: [ SubscriptOutOfBounds signal: 'The subset size must be positive' ].
+	subset := self species new: aSubsetSize.
+	^ self species new: self size - aSubsetSize streamContents: [ :out |
+		(1 to: self size - aSubsetSize + 1) collect: [ :i |
+			subset replaceFrom: 1 to: aSubsetSize with: self startingAt: i.
+			out nextPut: (aBlock value: subset) ] ]
 ]
 
 { #category : #'*Collections-arithmetic' }

--- a/src/Graphics-Files/PNGReadWriter.class.st
+++ b/src/Graphics-Files/PNGReadWriter.class.st
@@ -751,7 +751,7 @@ PNGReadWriter >> nextImage [
 	transparentPixelValue := nil.
 	unknownChunks := Set new.
 	stream skip: 8.
-	[ stream atEnd or: [ self processNextChunk = #IEND ] ] whileFalse.
+	[ stream atEnd ] whileFalse: [ self processNextChunk ].
 	"Set up our form"
 	palette
 		ifNotNil: [ "Dump the palette if it's the same as our standard palette"
@@ -765,13 +765,15 @@ PNGReadWriter >> nextImage [
 	idatChunkStream
 		ifNil: [ self error: 'image data is missing' ]
 		ifNotNil: [ self processIDATChunk ].
+	unknownChunks isEmpty
+		ifFalse:
+			[ "Transcript show: ' ',unknownChunks asSortedCollection asArray printString." ].
 	self debugging
-		ifTrue: [
-			unknownChunks isEmpty ifFalse: [ self crTrace: 'unknownChunks = ' , unknownChunks sorted asArray printString ].
-			self crTrace: 'form = ' , form printString.
+		ifTrue: [ self crTrace: 'form = ' , form printString.
 			self crTrace: 'colorType = ' , colorType printString.
 			self crTrace: 'interlaceMethod = ' , interlaceMethod printString.
-			self crTrace: 'filters = ' , filtersSeen sortedCounts asArray printString ].
+			self
+				crTrace: 'filters = ' , filtersSeen sortedCounts asArray printString ].
 	^ form
 ]
 
@@ -994,13 +996,22 @@ PNGReadWriter >> processNextChunk [
  	(chunk isNil or: [ chunk size ~= length ])
  		ifTrue: [ chunk := self next: length ]
  		ifFalse: [ stream next: length into: chunk startingAt: 1 ].
-	chunkCrc := self nextLong bitXor: 16rFFFFFFFF.
-	crc := self updateCrc: 16rFFFFFFFF from: 1 to: 4 in: chunkType.
-	crc := self updateCrc: crc from: 1 to: length in: chunk.
+	chunkCrc := self nextLong bitXor: 4294967295.
+	crc := self
+		updateCrc: 4294967295
+		from: 1
+		to: 4
+		in: chunkType.
+	crc := self
+		updateCrc: crc
+		from: 1
+		to: length
+		in: chunk.
 	crc = chunkCrc ifFalse: [ self error: 'PNGReadWriter crc error in chunk ' , chunkType ].
-	chunkType = 'IEND' ifTrue: [ ^ #IEND "*should* be the last chunk" ].
-	chunkType = 'sBIT' ifTrue: [ ^ self processSBITChunk "could indicate unusual sample depth in original" ].
-	chunkType = 'gAMA' ifTrue: [ ^ self "indicates gamma correction value" ].
+	chunkType = 'IEND' ifTrue: [ ^ self	"*should* be the last chunk" ].
+	chunkType = 'sBIT' ifTrue:
+		[ ^ self processSBITChunk	"could indicate unusual sample depth in original" ].
+	chunkType = 'gAMA' ifTrue: [ ^ self	"indicates gamma correction value" ].
 	chunkType = 'bKGD' ifTrue: [ ^ self processBackgroundChunk ].
 	chunkType = 'pHYs' ifTrue: [ ^ self processPhysicalPixelChunk ].
 	chunkType = 'tRNS' ifTrue: [ ^ self processTransparencyChunk ].

--- a/src/Graphics-Files/PNGReadWriter.class.st
+++ b/src/Graphics-Files/PNGReadWriter.class.st
@@ -751,7 +751,7 @@ PNGReadWriter >> nextImage [
 	transparentPixelValue := nil.
 	unknownChunks := Set new.
 	stream skip: 8.
-	[ stream atEnd ] whileFalse: [ self processNextChunk ].
+	[ stream atEnd or: [ self processNextChunk = #IEND ] ] whileFalse.
 	"Set up our form"
 	palette
 		ifNotNil: [ "Dump the palette if it's the same as our standard palette"
@@ -765,15 +765,13 @@ PNGReadWriter >> nextImage [
 	idatChunkStream
 		ifNil: [ self error: 'image data is missing' ]
 		ifNotNil: [ self processIDATChunk ].
-	unknownChunks isEmpty
-		ifFalse:
-			[ "Transcript show: ' ',unknownChunks asSortedCollection asArray printString." ].
 	self debugging
-		ifTrue: [ self crTrace: 'form = ' , form printString.
+		ifTrue: [
+			unknownChunks isEmpty ifFalse: [ self crTrace: 'unknownChunks = ' , unknownChunks sorted asArray printString ].
+			self crTrace: 'form = ' , form printString.
 			self crTrace: 'colorType = ' , colorType printString.
 			self crTrace: 'interlaceMethod = ' , interlaceMethod printString.
-			self
-				crTrace: 'filters = ' , filtersSeen sortedCounts asArray printString ].
+			self crTrace: 'filters = ' , filtersSeen sortedCounts asArray printString ].
 	^ form
 ]
 
@@ -996,22 +994,13 @@ PNGReadWriter >> processNextChunk [
  	(chunk isNil or: [ chunk size ~= length ])
  		ifTrue: [ chunk := self next: length ]
  		ifFalse: [ stream next: length into: chunk startingAt: 1 ].
-	chunkCrc := self nextLong bitXor: 4294967295.
-	crc := self
-		updateCrc: 4294967295
-		from: 1
-		to: 4
-		in: chunkType.
-	crc := self
-		updateCrc: crc
-		from: 1
-		to: length
-		in: chunk.
+	chunkCrc := self nextLong bitXor: 16rFFFFFFFF.
+	crc := self updateCrc: 16rFFFFFFFF from: 1 to: 4 in: chunkType.
+	crc := self updateCrc: crc from: 1 to: length in: chunk.
 	crc = chunkCrc ifFalse: [ self error: 'PNGReadWriter crc error in chunk ' , chunkType ].
-	chunkType = 'IEND' ifTrue: [ ^ self	"*should* be the last chunk" ].
-	chunkType = 'sBIT' ifTrue:
-		[ ^ self processSBITChunk	"could indicate unusual sample depth in original" ].
-	chunkType = 'gAMA' ifTrue: [ ^ self	"indicates gamma correction value" ].
+	chunkType = 'IEND' ifTrue: [ ^ #IEND "*should* be the last chunk" ].
+	chunkType = 'sBIT' ifTrue: [ ^ self processSBITChunk "could indicate unusual sample depth in original" ].
+	chunkType = 'gAMA' ifTrue: [ ^ self "indicates gamma correction value" ].
 	chunkType = 'bKGD' ifTrue: [ ^ self processBackgroundChunk ].
 	chunkType = 'pHYs' ifTrue: [ ^ self processPhysicalPixelChunk ].
 	chunkType = 'tRNS' ifTrue: [ ^ self processTransparencyChunk ].


### PR DESCRIPTION
SequenceableCollection>>#running:of: is allocating too much data structures, we can make this more efficient.