### PR TITLE
Calypso editor: stop inserting `->`

### DIFF
--- a/src/Calypso-Browser/ClyTextEditor.class.st
+++ b/src/Calypso-Browser/ClyTextEditor.class.st
@@ -37,6 +37,25 @@ ClyTextEditor >> cancel [
 	self browserTool cancelChanges
 ]
 
+{ #category : #'new selection' }
+ClyTextEditor >> notify: aString at: anInteger in: aStream [
+	"Because in calypso there is error icons and UI feedback absent in others RubEditor,
+	there no need to insert -> message in the text area"
+	"Note: error reporting can still be improved, but this need more work"
+
+	| pos message |
+	message := (aString endsWith: '->')
+		ifTrue: [ aString allButLast: 3 ]
+		ifFalse: [ aString ].
+
+	self inform: message.
+	pos := self selectionInterval notEmpty
+		ifTrue: [ self startIndex + anInteger - 1 ]
+		ifFalse: [ anInteger ].
+	self selectFrom: pos to: pos - 1. "move cursor in front of the location"
+	textArea flashColor: self theme dangerBackgroundColor
+]
+
 { #category : #operations }
 ClyTextEditor >> printIt [
 	"Treat the current text selection as an expression; evaluate it. Insert the

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -2560,14 +2560,8 @@ Morph >> fitInWorld [
 
 { #category : #macpal }
 Morph >> flash [
-	| originalFill flashFill |
 
-	flashFill := self flashFillStyle.
-	originalFill := self fillStyle.
-
-	self fillStyle: flashFill.
-
-	self addAlarm: #flashFinished:original: withArguments: { flashFill . originalFill } after: 50
+	self flashColor: self flashFillStyle
 ]
 
 { #category : #drawing }
@@ -2576,6 +2570,17 @@ Morph >> flashBounds [
 
 	5 timesRepeat:
 		[Display flash: self boundsInWorld  andWait: 120]
+]
+
+{ #category : #macpal }
+Morph >> flashColor: aColor [
+	| originalFill |
+
+	originalFill := self fillStyle.
+
+	self fillStyle: aColor.
+
+	self addAlarm: #flashFinished:original: withArguments: { aColor . originalFill } after: 50
 ]
 
 { #category : #macpal }


### PR DESCRIPTION
This is a rewrite of  #12499.

The main differences are:
* only targets code editor in calypso (and not all rubric editors)
* error reporting in calypso during code edition is better and complete, so flashing should not be a surprise.
* flashing is red (or whatever is dangerBackgroundColor in the tool theme), so a different flashing color than acceptance (that is hard-coded black).
* Mandatory (no configuration, so deal with it!)
* it's the beginning of the Pharo12 cycle, so there is time to improve if people complain (improve code and/or improve people)