### PR TITLE
Disable ReCompactSourceCodeRule for p11

### DIFF
--- a/src/Renraku/ReCompactSourceCodeRule.class.st
+++ b/src/Renraku/ReCompactSourceCodeRule.class.st
@@ -46,7 +46,8 @@ ReCompactSourceCodeRule class >> criticizeFinalDotInMethodBody: aBoolean [
 { #category : #'class initialization' }
 ReCompactSourceCodeRule class >> initialize [
 
-	CriticizeFinalDotInMethodBody := true
+	CriticizeFinalDotInMethodBody := true.
+	self enabled: false
 ]
 
 { #category : #running }


### PR DESCRIPTION
ReCompactSourceCodeRule has too many violations. In P12 we want to make the editor automatically remove those spaces so that the rule does not get triggered much.  But this is too late for p11 and the rule adds too much noise.