### PR TITLE
Fauty code: RBParser parse only faulty code

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippetTest.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippetTest.class.st
@@ -146,7 +146,7 @@ RBCodeSnippetTest >> testMonticello [
 	self assert: MCMockClassE methods size equals: 0.
 
 	snippet isFaulty ifTrue: [
-			self should: [ definition load ] raise: CodeError.
+			self should: [ 	[ definition load ] on: Warning do: [ :e | e resume ]. "Ignore Selector missmatches" ] raise: CodeError.
 			self assert: MCMockClassE methods size equals: 0.
 			^ self ].
 

--- a/src/AST-Core-Tests/RBErrorNodeParserTest.class.st
+++ b/src/AST-Core-Tests/RBErrorNodeParserTest.class.st
@@ -437,7 +437,7 @@ RBErrorNodeParserTest >> testFaultyMessageSendWithSymbolsArgumentShouldHaveTheCo
 RBErrorNodeParserTest >> testFaultyMethodConsumesEntireStream [
 
 	| parser |
-	parser := self parserClass newFaulty.
+	parser := self parserClass new.
 	parser initializeParserWith: 'ret ^ 1 ^ 2'.
 	parser parseMethod.
 

--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -1439,13 +1439,9 @@ RBParserTest >> testParserErrorsWithErrorBlock [
 
 	#(#('self foo. + 3' 1) #('self 0' 1) #('self asdf;;asfd' 1))
 		do: [:each | |ast errorCount|
-				errorCount := 0.
 			    ast := self parserClass new
-					beFaulty;
-					errorBlock: [ errorCount := errorCount + 1 ];
 					initializeParserWith: each first;
 					parseExpression.
-				self assert: errorCount equals: each last.
 
 				errorCount := 0.
 				RBParseErrorNodeVisitor visit: ast do: [ :n | errorCount := errorCount + 1 ].

--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -606,7 +606,7 @@ RBParserTest >> testGarbageTemporaryVariable [
 	| tree |
 	tree := self parseFaultyExpression: '| temp'.
 	self assert: tree isFaulty.
-	self assert: tree errorMessage equals: '''|'' expected'
+	self assert: tree errorMessage equals: '''|'' or variable expected'
 ]
 
 { #category : #'garbage tests' }
@@ -614,7 +614,7 @@ RBParserTest >> testGarbageTemporaryVariableHasMissingClosure [
 	| tree |
 	tree := self parseFaultyExpression: '| temp'.
 	self assert: tree isFaulty.
-	self assert: tree errorMessage equals: '''|'' expected'
+	self assert: tree errorMessage equals: '''|'' or variable expected'
 ]
 
 { #category : #'garbage tests' }
@@ -627,7 +627,7 @@ RBParserTest >> testGarbageTemporaryVariableIsWrong [
 
 	errorNode := tree statements first.
 	self assert: errorNode isParseError.
-	self assert: errorNode errorMessage equals: '''|'' expected'
+	self assert: errorNode errorMessage equals: '''|'' or variable expected'
 ]
 
 { #category : #'tests - Interval' }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -23,8 +23,7 @@ Class {
 		'errorBlock',
 		'source',
 		'comments',
-		'pragmas',
-		'isFaulty'
+		'pragmas'
 	],
 	#category : #'AST-Core-Parser'
 }
@@ -156,11 +155,6 @@ RBParser >> basicParsePragma [
 				ifFalse: [ self parseBinaryPragma ] ]
 ]
 
-{ #category : #initialization }
-RBParser >> beFaulty [
-	isFaulty := true
-]
-
 { #category : #'private - classes' }
 RBParser >> blockNodeClass [
 	^ RBBlockNode
@@ -232,18 +226,6 @@ RBParser >> initialize [
 RBParser >> initializeParserWith: aString [
 	source := aString.
 	self scanner: (self scannerClass on: (ReadStream on: aString))
-]
-
-{ #category : #accessing }
-RBParser >> isFaulty [
-
-	^ isFaulty
-]
-
-{ #category : #accessing }
-RBParser >> isFaulty: anObject [
-
-	isFaulty := anObject
 ]
 
 { #category : #'private - classes' }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -29,20 +29,6 @@ Class {
 	#category : #'AST-Core-Parser'
 }
 
-{ #category : #'instance creation' }
-RBParser class >> newFaulty [
-
-	^ self new beFaulty
-]
-
-{ #category : #'instance creation' }
-RBParser class >> newWithErrorBlock: aBlock [
-
-	^ self new
-		errorBlock: aBlock;
-		yourself
-]
-
 { #category : #parsing }
 RBParser class >> parseExpression: aString [
 	^self parseExpression: aString onError: nil

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -43,7 +43,6 @@ RBParser class >> parseExpression: aString onError: aBlock [
 RBParser class >> parseFaultyExpression: aString [
 	"parse aString even if syntactically incorrect. Instead of raising an error, we create an AST with RB RBParseErrorNode"
 	^ self new
-		beFaulty;
 		initializeParserWith: aString;
 		parseExpression
 ]
@@ -52,7 +51,6 @@ RBParser class >> parseFaultyExpression: aString [
 RBParser class >> parseFaultyMethod: aString [
 	"parse aString even if syntactically incorrect. Instead of raising an error, we create an AST with RB RBParseErrorNode"
 	^ self new
-		beFaulty;
 		initializeParserWith: aString;
 		parseMethod
 ]
@@ -77,7 +75,6 @@ RBParser class >> parseMethod: aString onError: aBlock [
 { #category : #parsing }
 RBParser class >> parseMethodPattern: aString [
 	^ (self new
-		   errorBlock: [ :error :position | ^ nil ];
 		   initializeParserWith: aString;
 		   parseMessagePattern) selector
 ]
@@ -228,8 +225,7 @@ RBParser >> getErrorFromClosuresWithMissingOpenings: aCollection [
 
 { #category : #initialization }
 RBParser >> initialize [
-	comments := OrderedCollection new.
-	isFaulty := false
+	comments := OrderedCollection new
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -36,11 +36,7 @@ RBParser class >> parseExpression: aString [
 
 { #category : #parsing }
 RBParser class >> parseExpression: aString onError: aBlock [
-
-	^self new
-        errorBlock: aBlock;
-        initializeParserWith: aString;
-        parseExpression
+	^ (self parseFaultyExpression: aString) checkFaulty: aBlock
 ]
 
 { #category : #parsing }
@@ -75,11 +71,7 @@ RBParser class >> parseMethod: aString [
 
 { #category : #parsing }
 RBParser class >> parseMethod: aString onError: aBlock [
-	| parser |
-	parser := self new
-		errorBlock: aBlock;
-		initializeParserWith: aString.
-	^ parser parseMethod
+	^ (self parseFaultyMethod: aString) checkFaulty: aBlock
 ]
 
 { #category : #parsing }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -20,7 +20,6 @@ Class {
 		'scanner',
 		'currentToken',
 		'nextToken',
-		'errorBlock',
 		'source',
 		'comments',
 		'pragmas'
@@ -182,12 +181,14 @@ RBParser >> englobingErrorNodeClass [
 
 { #category : #'error handling' }
 RBParser >> errorBlock [
-	^errorBlock
+
+	self deprecated: 'see errorBlock:'
 ]
 
 { #category : #accessing }
 RBParser >> errorBlock: aBlock [
-	errorBlock := aBlock
+
+	self deprecated: 'RBParser instances offer no more errorBlock facility. Use helpers methods on the class side, or `checkFaulty: aBlock` on a parsed AST'
 ]
 
 { #category : #'error handling' }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -119,7 +119,7 @@ RBParser >> addCommentsTo: aNode [
 { #category : #'private - parsing' }
 RBParser >> addParserError: errorMessage to: aNode [
 	| errorNode |
-	errorNode := self parserError: errorMessage.
+	errorNode := self parseErrorNode: errorMessage.
 	aNode addFaultyNode: errorNode.
 	^ aNode
 ]
@@ -223,7 +223,7 @@ RBParser >> getErrorFromClosuresWithMissingOpenings: aCollection [
 					ifTrue: [  aCollection isEmpty
 							ifFalse: [| errorNode | errorNode := self parseEnglobingError: (OrderedCollection with: aCollection last) with: currentToken errorMessage: ''')'' expected'.  aCollection removeLast. errorNode]
 							ifTrue: [ self parseEnglobingError: aCollection copy with: currentToken errorMessage: ''')'' expected'] ] ]
-				ifFalse: [ self parserError: 'Unknown input at end' ])
+				ifFalse: [ self parseErrorNode: 'Unknown input at end' ])
 ]
 
 { #category : #initialization }
@@ -303,7 +303,7 @@ RBParser >> parseAssignment [
 
 	| node position err |
 	currentToken isAssignment ifTrue: [
-		err := self parserError: 'variable expected in assigment'.
+		err := self parseErrorNode: 'variable expected in assigment'.
 		self step. "Consume the :="
 		node := self parseAssignment. "parse the right side".
 		node := RBAssignmentErrorNode from: err contents: { node }.
@@ -356,7 +356,7 @@ RBParser >> parseBinaryPattern [
 		^ self methodNodeClass
 			selector: #''
 			arguments: #()
-			body: (self sequenceNodeClass statements: (OrderedCollection with: (self parserError: 'Message pattern expected')))].
+			body: (self sequenceNodeClass statements: (OrderedCollection with: (self parseErrorNode: 'Message pattern expected')))].
 
 	binaryToken := currentToken.
 	self step.
@@ -374,7 +374,7 @@ RBParser >> parseBinaryPattern [
 RBParser >> parseBinaryPragma [
 	| binaryToken |
 	currentToken isBinary
-		ifFalse: [ ^ self parserError: 'Message pattern expected' ].
+		ifFalse: [ ^ self parseErrorNode: 'Message pattern expected' ].
 	binaryToken := currentToken.
 	self step.
 	^ self pragmaNodeClass
@@ -431,7 +431,7 @@ RBParser >> parseBlockArgsInto: node [
 					self stepBar]
 				ifFalse:
 					[(currentToken isSpecial: $])
-						ifFalse: [ args add:(self parserError: '''|'' or parameter expected')]]].
+						ifFalse: [ args add:(self parseErrorNode: '''|'' or parameter expected')]]].
 	node
 		arguments: args;
 		colons: colons.
@@ -463,7 +463,7 @@ RBParser >> parseCascadeMessage [
 		"Cut parsing with an error.
 		If in faulty mode, continue the execution and generate a faulty cascade node.
 		Note that this bad cascade node will be added to the list of messages."
-		err := self parserError: 'Message expected'.
+		err := self parseErrorNode: 'Message expected'.
 		node := RBInvalidCascadeErrorNode from: err contents: { node }
 	].
 	receiver := node receiver.
@@ -506,7 +506,7 @@ RBParser >> parseCascadeMessageWithReceiver: receiver [
 
 	For now, do not touch the unexpected token and let it be propagated to the caller.
 	Maybe someing up the callchain will gladly use it or know how to recover (eg unfinished statement)"
-	errorNode := self parserError: 'Cascade message expected'.
+	errorNode := self parseErrorNode: 'Cascade message expected'.
 	^ errorNode
 ]
 
@@ -523,7 +523,7 @@ RBParser >> parseDoIt [
 { #category : #'private - classes' }
 RBParser >> parseEnglobingError: aCollection with: aToken errorMessage: anErrorMessage [
 	| firstParse |
-	firstParse := self parserError: anErrorMessage.
+	firstParse := self parseErrorNode: anErrorMessage.
 	^firstParse isParseError
 		ifTrue: [
 			(self englobingErrorNodeClass error: aToken withNodes: aCollection)
@@ -686,7 +686,7 @@ RBParser >> parseLiteralArrayObject [
 			[^currentToken isForByteArray
 				ifTrue: [self parseLiteralByteArray]
 				ifFalse: [self parseLiteralArray]].
-	currentToken isError ifTrue:[ |errorNode| errorNode :=  self parserError: currentToken cause.
+	currentToken isError ifTrue:[ |errorNode| errorNode :=  self parseErrorNode: currentToken cause.
 		 ^ errorNode].
 	currentToken isLiteralToken ifFalse: [self patchLiteralArrayToken].
 	^self parsePrimitiveLiteral
@@ -731,7 +731,7 @@ RBParser >> parseLiteralByteArrayObject [
 			[currentToken value isInteger and: [currentToken value between: 0 and: 255]])
 		ifFalse: [
 			| errorNode lost |
-			errorNode := self parserError: '8-bit integer expected'.
+			errorNode := self parseErrorNode: '8-bit integer expected'.
 			"Error recovery: consume the token as classic literal array object"
 			lost := self parseLiteralArrayObject.
 			errorNode value: lost value asString.
@@ -746,7 +746,7 @@ RBParser >> parseLiterals: aString [
 	stream := (Array new: 5) writeStream.
 	[self atEnd or: [currentToken isSpecial: $)]]
 		whileFalse: [stream nextPut: self parseLiteralArrayObject].
-	self atEnd ifFalse: [ ^ self parserError: 'Unknown input at end'].
+	self atEnd ifFalse: [ ^ self parseErrorNode: 'Unknown input at end'].
 	^stream contents collect: [ :each | each value ]
 ]
 
@@ -830,7 +830,7 @@ RBParser >> parsePragmaLiteral [
 			[^currentToken isForByteArray
 				ifTrue: [self parseLiteralByteArray]
 				ifFalse: [self parseLiteralArray]].
-	currentToken isLiteralToken ifFalse: [^self parserError:'Literal constant expected'].
+	currentToken isLiteralToken ifFalse: [^self parseErrorNode:'Literal constant expected'].
 	"Return a literal value node."
 	^self parsePrimitiveLiteral
 ]
@@ -906,7 +906,7 @@ RBParser >> parsePrimitiveObject [
 	": is only acceptable at the begin of a block. So just consume them as bad expression"
 	(currentToken isSpecial: $:) ifTrue: [ ^self parseVariableNode ].
 
-	errorNode := self parserError: 'Variable or expression expected'.
+	errorNode := self parseErrorNode: 'Variable or expression expected'.
 	^errorNode
 ]
 
@@ -949,7 +949,7 @@ RBParser >> parseStatementInto: statementList periodList: periods withAcceptedSt
 	[(')]}' includes: currentToken value)
 		and: [ (aCollectionOfClosers includes: currentToken value) not ]]
 			whileTrue: [
-				err := self parserError: 'Missing opener for closer: ', currentToken value asString.
+				err := self parseErrorNode: 'Missing opener for closer: ', currentToken value asString.
 				node := (RBUnfinishedStatementErrorNode from: err contents: { node })
 					valueAfter: currentToken value asString;
 					stop: currentToken stop.
@@ -969,7 +969,7 @@ RBParser >> parseStatementInto: statementList periodList: periods withAcceptedSt
 		 then parserError will unfortunately consume and lose it.
 		 A better design is needed."
 		node isParseError ifFalse: [ 
-			err := self parserError: 'End of statement expected'.
+			err := self parseErrorNode: 'End of statement expected'.
 			node := RBUnfinishedStatementErrorNode from: err contents: { node } ]
 	].
 
@@ -1129,7 +1129,7 @@ RBParser >> parseVariableNode [
 	| errorNode |
 	currentToken isIdentifier ifTrue: [ ^ self parsePrimitiveIdentifier ].
 
-	errorNode := self parserError: 'Variable name expected'.
+	errorNode := self parseErrorNode: 'Variable name expected'.
 
 	"Consume : and optional identifier that follows as an error"
 	(currentToken isSpecial: $:) ifTrue: [
@@ -1142,24 +1142,6 @@ RBParser >> parseVariableNode [
 			errorNode value: errorNode value , currentToken source.
 			self step ] ].
 
-	^ errorNode
-]
-
-{ #category : #'error handling' }
-RBParser >> parserError: aString [
-
-	| errorNode |
-	errorNode := self parseErrorNode: aString.
-	errorBlock ifNotNil: [ errorBlock cull: errorNode errorMessage cull: errorNode errorPosition cull: self ].
-	isFaulty ifTrue: [ ^ errorNode ].
-
-	SyntaxErrorNotification new
-		sourceCode: source;
-		messageText: errorNode errorMessage;
-		location: errorNode errorPosition;
-		signal.
-
-	"If resumed, return with the error node"
 	^ errorNode
 ]
 
@@ -1205,7 +1187,7 @@ RBParser >> patchLiteralArrayToken [
 			^self].
 	(currentToken isIdentifier
 		or: [currentToken isBinary or: [currentToken isKeyword]])
-			ifFalse: [^self parserError: 'Invalid token'].
+			ifFalse: [^self parseErrorNode: 'Invalid token'].
 	currentToken := RBLiteralToken
 				value: currentToken value asSymbol
 				start: currentToken start

--- a/src/AST-Core/RBPatternParser.class.st
+++ b/src/AST-Core/RBPatternParser.class.st
@@ -115,7 +115,7 @@ RBPatternParser >> parseUnaryMessage [
 	currentToken isIdentifier]
 			whileTrue: [
 				currentToken isKeywordPattern
-					ifTrue: [ self parserError: ' incomplete keyword pattern ' ].
+					ifTrue: [ self parseErrorNode: ' incomplete keyword pattern ' ].
 				node := self parseUnaryMessageWith: node].
 	self addCommentsTo: node.
 	^node

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -144,8 +144,7 @@ RBProgramNode >> allNotices [
 
 	| result |
 	result := OrderedCollection new.
-	result addAll: self notices.
-	self nodesDo: [ :node | result addAll: node notices ].
+	self nodesPostorderDo: [ :node | result addAll: node notices ].
 	^ result
 ]
 

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -139,6 +139,16 @@ RBProgramNode >> allDefinedVariables [
 ]
 
 { #category : #notice }
+RBProgramNode >> allErrorNotices [
+	"Include also error notices of all children"
+
+	| result |
+	result := OrderedCollection new.
+	self nodesPostorderDo: [ :node | result addAll: node errorNotices ].
+	^ result
+]
+
+{ #category : #notice }
 RBProgramNode >> allNotices [
 	"Include also notices of all children"
 

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -297,6 +297,28 @@ RBProgramNode >> cascadeListCharacter [
 	^$;
 ]
 
+{ #category : #notice }
+RBProgramNode >> checkFaulty: aBlock [
+	"Helper method to evaluate errorBlock and/or signal SyntaxErrorNotification in case of a faulty AST"
+
+	| errorNotice |
+	"Fast noop case"
+	self isFaulty ifFalse: [ ^ self ].
+
+	"Search for the first error, to signal"
+	errorNotice := self allErrorNotices first.
+
+	aBlock ifNotNil: [ aBlock cull: errorNotice messageText cull: errorNotice node errorPosition cull: self ].
+
+	SyntaxErrorNotification new
+		sourceCode: self methodNode sourceCode;
+		messageText: errorNotice messageText;
+		location: errorNotice node errorPosition;
+		signal.
+
+	"If resumed, just return"
+]
+
 { #category : #accessing }
 RBProgramNode >> children [
 	^#()

--- a/src/AST-Core/RBTemporariesErrorNode.class.st
+++ b/src/AST-Core/RBTemporariesErrorNode.class.st
@@ -17,8 +17,8 @@ RBTemporariesErrorNode class >> error: aToken withNodes: aCollection [
 	 Since the closure is a |, the default assumption is that it's a binary selector."
 	"If the collection is empty, there is only the token in the error."
 	^aCollection isEmpty
-		ifTrue: [ self new contents: aCollection; start: aToken start; stop: aToken stop; errorMessage: '''|'' expected' ]
-		ifFalse: [ self new contents: aCollection; start: aToken start; stop: aCollection last stop; errorMessage: '''|'' expected' ]
+		ifTrue: [ self new contents: aCollection; start: aToken start; stop: aToken stop; errorMessage: '''|'' or variable expected' ]
+		ifFalse: [ self new contents: aCollection; start: aToken start; stop: aCollection last stop; errorMessage: '''|'' or variable expected' ]
 ]
 
 { #category : #testing }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -301,17 +301,6 @@ OpalCompiler >> context: aContext [
 	self semanticScope: (self semanticScope asDoItScopeForContext: aContext)
 ]
 
-{ #category : #private }
-OpalCompiler >> createParser [
-
-	| parser |
-	parser := self parserClass new.
-	(self compilationContext optionParseErrors or: [ self allowParseErrorsNonInteractive ])
-		ifTrue: [ parser beFaulty ].
-	parser	 initializeParserWith: source contents.
-	^parser
-]
-
 { #category : #'public access' }
 OpalCompiler >> decompileMethod: aCompiledMethod [
 	^ Smalltalk globals
@@ -410,9 +399,12 @@ OpalCompiler >> options: anOptionsArray [
 { #category : #'public access' }
 OpalCompiler >> parse [
 
-	| parser |
-	parser := self createParser.
+	| parser permitFaulty |
+	parser := self parserClass new.
+	parser initializeParserWith: source contents.
 	ast := self semanticScope parseASTBy: parser.
+	permitFaulty := (self compilationContext optionParseErrors or: [ self allowParseErrorsNonInteractive ]).
+	permitFaulty ifFalse: [ ast checkFaulty: nil ].
 
 	ast methodNode compilationContext: self compilationContext.
 	self callParsePlugins.

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -451,6 +451,7 @@ OpalCompiler >> parseForRequestor [
 		notification retry ] ]
 	on: CodeError
 	do: [ :exception |
+		ast := nil. "Invalidate the AST to avoid compilation if failBlock do return"
 		exception sourceCode: source contents.
 		requestor
 			notify: exception messageText , ' ->'

--- a/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
@@ -155,7 +155,6 @@ RBExtractMethodRefactoring >> extractMethod [
 	extractCode := self getExtractedSource.
 	extractedParseTree := self parserClass new
 		errorBlock: [ :string :pos :parser | errorMessage := string. ];
-		beFaulty;
 		source: extractCode;
 		parseExpression.
 	extractedParseTree

--- a/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
@@ -151,7 +151,7 @@ RBExtractMethodRefactoring >> extract: anInterval from: aSelector in: aClass [
 
 { #category : #transforming }
 RBExtractMethodRefactoring >> extractMethod [
-	| parseTree isSequence extractCode subtree newCode errorMessage |
+	| parseTree isSequence extractCode subtree newCode |
 	extractCode := self getExtractedSource.
 	extractedParseTree := self parserClass new
 		source: extractCode;

--- a/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
@@ -154,14 +154,13 @@ RBExtractMethodRefactoring >> extractMethod [
 	| parseTree isSequence extractCode subtree newCode errorMessage |
 	extractCode := self getExtractedSource.
 	extractedParseTree := self parserClass new
-		errorBlock: [ :string :pos :parser | errorMessage := string. ];
 		source: extractCode;
 		parseExpression.
 	extractedParseTree
 		ifNil: [ self refactoringFailure: 'Invalid source to extract' ].
 	extractedParseTree isFaulty
 		ifTrue: [ self
-				refactoringFailure: 'Invalid source to extract - ' , errorMessage ].
+				refactoringFailure: 'Invalid source to extract - ' , extractedParseTree allErrorNotices first messageText ].
 	(extractedParseTree isSequence
 		and: [ extractedParseTree statements isEmpty ])
 		ifTrue: [ self refactoringError: 'Select some code to extract' ].


### PR DESCRIPTION
RBParser is able (and tested) to produce AST with error nodes and precise error and warning information (notices)

The handling of error with error blocks or syntax error notifications is inferior because they are activated too early, without so much context: there is no AST yet, so such errors are only identified with a message string and a single position.
Moreover, they add complexity to the Parser code.

This PR tries to do what  #12912 could not: remove errorBlock from RBParser.
What changed since then is a lot a cleanup and the RBNotice API, so I hope this will work now.

Features

* no more beFaulty, errorBlock or even SyntaxErrorNotification: the parser only goal is to generate AST, not to care about your feeling or water down bad news. You ask an AST, you get an AST, no questions asked, not many flavors to choose.
* new method `RBProgramNode>>checkFaulty:` that simulates the old parser handling of error.
   Therefore, clients that rely on beFaulty, errorBlock and/or SyntaxErrorNotification: can just use this method on the resulting AST and should get the same behavior.
  Note that the receiver is an AST node, not a parser, this is neat.
* Method on the class side of RBParser `parse(Faulty)?(Expression|Method):(onError:)?` are still here, and use `checkFaulty:` to achieve the same results but in a smoother way.