### PR TITLE
Compiler gets permitFaulty

### DIFF
--- a/src/AST-Core/CompiledMethod.extension.st
+++ b/src/AST-Core/CompiledMethod.extension.st
@@ -27,7 +27,6 @@ CompiledMethod >> parseTree [
 	ast := self methodClass compiler
 		source: self sourceCode;
 		failBlock: [^ self decompile ];
-		options: #( + #optionParseErrors #optionSkipSemanticWarnings ) ;
 		class: self methodClass;
 		parse.
 	ast compilationContext compiledMethod: self.

--- a/src/AST-Core/RBErrorNodeNotice.class.st
+++ b/src/AST-Core/RBErrorNodeNotice.class.st
@@ -7,6 +7,12 @@ Class {
 	#category : #'AST-Core-Notice'
 }
 
+{ #category : #'error handling' }
+RBErrorNodeNotice >> errorPosition [
+
+	^ node errorPosition
+]
+
 { #category : #accessing }
 RBErrorNodeNotice >> messageText [
 

--- a/src/AST-Core/RBNotice.class.st
+++ b/src/AST-Core/RBNotice.class.st
@@ -11,6 +11,12 @@ Class {
 	#category : #'AST-Core-Notice'
 }
 
+{ #category : #'error handling' }
+RBNotice >> errorPosition [
+
+	^ node start
+]
+
 { #category : #testing }
 RBNotice >> isError [
 

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -308,12 +308,12 @@ RBProgramNode >> checkFaulty: aBlock [
 	"Search for the first error, to signal"
 	errorNotice := self allErrorNotices first.
 
-	aBlock ifNotNil: [ aBlock cull: errorNotice messageText cull: errorNotice node errorPosition cull: self ].
+	aBlock ifNotNil: [ aBlock cull: errorNotice messageText cull: errorNotice errorPosition cull: self ].
 
 	SyntaxErrorNotification new
 		sourceCode: self methodNode sourceCode;
 		messageText: errorNotice messageText;
-		location: errorNotice node errorPosition;
+		location: errorNotice errorPosition;
 		signal.
 
 	"If resumed, just return"

--- a/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
@@ -91,7 +91,6 @@ ClyMethodEditorToolMorph >> currentEditedAST [
 
 	^ self methodClass compiler
 		  source: self pendingText;
-		  options: #( + optionParseErrors + optionSkipSemanticWarnings );
 		  parse
 ]
 

--- a/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
@@ -72,7 +72,6 @@ CoASTResultSetBuilder >> parseNode [
 		(completionContext completionClass compiler
 			source: completionContext source;
 			noPattern: completionContext isScripting;
-			options: #(+ optionParseErrors + optionSkipSemanticWarnings);
 			parse) nodeForOffset: completionContext position ]
 ]
 

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -477,6 +477,7 @@ CompiledMethodTest >> testIsFaulty [
 	cm := OpalCompiler new
 				source: 'method 3+';
 				permitFaulty: true;
+				options: #(+ #optionEmbeddSources );
 				compile.
 	self assert: cm isFaulty.
 	self deny: (OCASTTranslator>>#visitParseErrorNode:) isFaulty

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -476,7 +476,7 @@ CompiledMethodTest >> testIsFaulty [
 	|  cm |
 	cm := OpalCompiler new
 				source: 'method 3+';
-				options: #(+ optionParseErrors +optionEmbeddSources);
+				permitFaulty: true;
 				compile.
 	self assert: cm isFaulty.
 	self deny: (OCASTTranslator>>#visitParseErrorNode:) isFaulty

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -607,7 +607,6 @@ CompiledMethod >> isFaulty [
 	"we have to parse the ast here as #ast does not know that this needs optionParseErrors"
 	ast := self methodClass compiler
 				source: self sourceCode;
-				options: #(+ optionParseErrors);
 				parse.
 	^ ast isFaulty
 ]

--- a/src/NECompletion/CompletionContext.class.st
+++ b/src/NECompletion/CompletionContext.class.st
@@ -125,7 +125,6 @@ CompletionContext >> parseSource [
 	ast := class compiler
 		source: source;
 		noPattern: self isScripting;
-		options: #(+ optionParseErrors + optionSkipSemanticWarnings);
 		parse.
 	TypingVisitor new visitNode: ast
 ]

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -641,7 +641,7 @@ CompilationContext >> optionSkipSemanticWarnings [
 { #category : #options }
 CompilationContext >> parseOptions: optionsArray [
 
-	(optionsArray includesAny: #( #optionParseErrors #allowParseErrorsNonInteractive #optionSkipSemanticWarnings )) ifTrue: [ permitFaulty := true ].
+	(optionsArray includesAny: #( #optionParseErrors #optionParseErrorsNonInteractiveOnly #optionSkipSemanticWarnings )) ifTrue: [ permitFaulty := true ].
 
 	options parseOptions: optionsArray
 ]

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -34,7 +34,8 @@ Class {
 		'requestorScopeClass',
 		'bindings',
 		'compiledMethodClass',
-		'semanticScope'
+		'semanticScope',
+		'permitFaulty'
 	],
 	#classVars : [
 		'DefaultOptions',
@@ -639,6 +640,9 @@ CompilationContext >> optionSkipSemanticWarnings [
 
 { #category : #options }
 CompilationContext >> parseOptions: optionsArray [
+
+	(optionsArray includesAny: #( #optionParseErrors #allowParseErrorsNonInteractive #optionSkipSemanticWarnings )) ifTrue: [ permitFaulty := true ].
+
 	options parseOptions: optionsArray
 ]
 
@@ -650,6 +654,18 @@ CompilationContext >> parserClass [
 { #category : #accessing }
 CompilationContext >> parserClass: anObject [
 	parserClass := anObject
+]
+
+{ #category : #accessing }
+CompilationContext >> permitFaulty [
+
+	^ permitFaulty
+]
+
+{ #category : #accessing }
+CompilationContext >> permitFaulty: anObject [
+
+	permitFaulty := anObject
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -16,6 +16,9 @@ Class {
 
 { #category : #api }
 OCASTSemanticAnalyzer >> analyze: aNode [
+
+	"Policy: simple semantic analysis is faulty by default"
+	compilationContext permitFaulty ifNil: [ compilationContext permitFaulty: true ].
 	self visitNode: aNode.
 	OCASTClosureAnalyzer new visitNode: aNode.
 	OCASTMethodMetadataAnalyser new visitNode: aNode
@@ -84,7 +87,7 @@ OCASTSemanticAnalyzer >> declareVariableNode: aVariableNode as: anOCTempVariable
 { #category : #errors }
 OCASTSemanticAnalyzer >> error: aMessage forNode: aNode [
 	aNode addError: aMessage.
-	compilationContext optionSkipSemanticWarnings ifTrue: [ ^ self ].
+	compilationContext permitFaulty ifTrue: [ ^ self ].
 
 	OCSemanticError new
 		node: aNode;
@@ -110,7 +113,7 @@ OCASTSemanticAnalyzer >> scope: aSemScope [
 { #category : #'error handling' }
 OCASTSemanticAnalyzer >> shadowingVariable: aNode [
 	aNode addWarning: 'Name already defined'.
-	compilationContext optionSkipSemanticWarnings ifTrue: [ ^aNode ].
+	compilationContext permitFaulty ifTrue: [ ^aNode ].
 	^ OCShadowVariableWarning new
 		node: aNode;
 		compilationContext: compilationContext;
@@ -120,7 +123,7 @@ OCASTSemanticAnalyzer >> shadowingVariable: aNode [
 { #category : #'error handling' }
 OCASTSemanticAnalyzer >> storeIntoReadOnlyVariable: variableNode [
 	variableNode addError: 'Assignment to read-only variable'.
-	compilationContext optionSkipSemanticWarnings ifTrue: [ ^ self ].
+	compilationContext permitFaulty ifTrue: [ ^ self ].
 
 	^ OCStoreIntoReadOnlyVariableError new
 		node: variableNode;
@@ -131,7 +134,8 @@ OCASTSemanticAnalyzer >> storeIntoReadOnlyVariable: variableNode [
 { #category : #'error handling' }
 OCASTSemanticAnalyzer >> storeIntoReservedVariable: variableNode [
 	variableNode addError: 'Assigment to reserved variable'.
-	compilationContext optionSkipSemanticWarnings ifTrue: [ ^ self ].
+	compilationContext permitFaulty ifTrue: [ ^ self ].
+
 	^ OCStoreIntoReservedVariableError new
 		node: variableNode;
 		messageText: 'Assigment to reserved variable';
@@ -154,13 +158,13 @@ OCASTSemanticAnalyzer >> undeclaredVariable: variableNode [
 	Or never if compilation is aborted or if only frontend is requested."
 	varName := variableNode name asSymbol.
 	var := self undeclared at: varName ifAbsentPut: [ UndeclaredVariable possiblyRegisteredWithName: varName ].
-	compilationContext optionSkipSemanticWarnings ifTrue: [ ^ var ].
+	compilationContext permitFaulty ifTrue: [ ^ var ].
 
 	OCUndeclaredVariableWarning new
 		node: variableNode;
 		compilationContext: compilationContext;
 		signal.
-	
+
 	^ var
 ]
 

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -48,7 +48,8 @@ OCRequestorScope >> lookupVar: name declare: aBoolean [
 	"We do not want to auto define bindings for unknown Globals"
 	name first isUppercase ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean].
 	"do not 'create bindings' in requestor scope if we just want to style a possible unknown variable"
-	((compilationContext optionSkipSemanticWarnings or: [aBoolean not])
+	self flag: 'The faulty mode should not impact how variable are bound'.
+	((compilationContext permitFaulty or: [aBoolean not])
 		and: [ (requestor hasBindingOf: name) not ])
 		ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean ].
 

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -477,6 +477,18 @@ OpalCompiler >> parserClass [
 	^self compilationContext parserClass
 ]
 
+{ #category : #'public access' }
+OpalCompiler >> permitFaulty [
+
+	^ self compilationContext permitFaulty
+]
+
+{ #category : #'public access' }
+OpalCompiler >> permitFaulty: aBoolean [
+
+	self compilationContext permitFaulty: aBoolean
+]
+
 { #category : #accessing }
 OpalCompiler >> productionEnvironment: anObject [
 	compilationContext productionEnvironment: anObject

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -399,12 +399,15 @@ OpalCompiler >> options: anOptionsArray [
 { #category : #'public access' }
 OpalCompiler >> parse [
 
-	| parser permitFaulty |
+	| parser |
+	"Policy: simple parsing is faulty by default"
+	self permitFaulty ifNil: [ self permitFaulty: true ].
+
 	parser := self parserClass new.
 	parser initializeParserWith: source contents.
 	ast := self semanticScope parseASTBy: parser.
-	permitFaulty := (self compilationContext optionParseErrors or: [ self allowParseErrorsNonInteractive ]).
-	permitFaulty ifFalse: [ ast checkFaulty: nil ].
+
+	self permitFaulty ifFalse: [ ast checkFaulty: nil ].
 
 	ast methodNode compilationContext: self compilationContext.
 	self callParsePlugins.
@@ -429,10 +432,13 @@ OpalCompiler >> parseForRequestor [
 	| requestor |
 	requestor := self compilationContext requestor.
 
+	"Policy: compiling and requestor is non-faulty by default"
+	self permitFaulty ifNil: [ self permitFaulty: false ].
+
 	"No requestor, easy path"
 	requestor ifNil: [ ^ self parse ].
 
-	^ [ [ self parse ]
+	^ [ [ 	self parse ]
 	on: OCUndeclaredVariableWarning
 	do: [ :notification |
 		| res |

--- a/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
@@ -41,6 +41,7 @@ OCASTTranslatorTest >> compileSource: source [
 	| ir ast |
 	ast := RBParser parseMethod: source.
 	ast compilationContext: self compilationContext.
+	ast compilationContext permitFaulty: false.
 	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
 	^ 	method := ir compiledMethod
 ]

--- a/src/OpalCompiler-Tests/OCCompileWithFailureTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompileWithFailureTest.class.st
@@ -23,7 +23,6 @@ OCCompileWithFailureTest >> testEmptyBlockArg [
 	result := UndefinedObject compiler
     source: '^[ :]';
     noPattern: true;
-    options:  #(+ optionParseErrors + optionSkipSemanticWarnings);
     requestor: self;
     parse.
 	self assert: result isDoIt.
@@ -35,7 +34,6 @@ OCCompileWithFailureTest >> testEvalSimpleMethodWithError [
 	| ast cm |
 	ast := OpalCompiler new
 				source: 'method 3+';
-				options: #(+ optionParseErrors);
 				parse.
 
 	self assert: ast isMethod.
@@ -51,7 +49,6 @@ OCCompileWithFailureTest >> testParenthesis [
 	result := UndefinedObject compiler
     source: 'self assert: pragma( numArgs equals: 0.';
     noPattern: true;
-    options:  #(+ optionParseErrors + optionSkipSemanticWarnings);
     requestor: self;
     parse.
 	self assert: result isDoIt.

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -465,13 +465,13 @@ OCCompilerTest >> testUndefinedVariable [
 	self
 		assert: {
 			OpalCompiler new
-				options: #( + optionSkipSemanticWarnings );
+				permitFaulty: true;
 				evaluate: 'undefinedName123'.
 			OpalCompiler new
-				options: #( + optionSkipSemanticWarnings );
+				permitFaulty: true;
 				evaluate: 'undefinedName123 := 2. undefinedName123'.
 			OpalCompiler new
-				options: #( + optionSkipSemanticWarnings );
+				permitFaulty: true;
 				evaluate: 'undefinedName123' }
 		equals: { nil. 2. 2. }.
 

--- a/src/OpalCompiler-Tests/RBCodeSnippet.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippet.extension.st
@@ -44,5 +44,6 @@ RBCodeSnippet >> doSemanticAnalysisOnError: aBlock [
 
 	^ [ OpalCompiler new
 		  noPattern: isMethod not;
+		  permitFaulty: false;
 		  parse: self source ] on: CodeError do: [ :e | aBlock value: e ]
 ]

--- a/src/OpalCompiler-Tests/RBCodeSnippet.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippet.extension.st
@@ -4,7 +4,7 @@ Extension { #name : #RBCodeSnippet }
 RBCodeSnippet >> compile [
 
 	^ [ OpalCompiler new
-		  options: #( #optionParseErrors #optionSkipSemanticWarnings );
+		  permitFaulty: true;
 		  noPattern: isMethod not;
 		  compile: self source ]
 	on: CodeError do: [ :e |

--- a/src/OpalCompiler-Tests/RBCodeSnippet.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippet.extension.st
@@ -34,7 +34,6 @@ RBCodeSnippet >> doSemanticAnalysis [
 	So just ask the compiler."
 
 	^ OpalCompiler new
-		  options: #( #optionParseErrors #optionSkipSemanticWarnings );
 		  noPattern: isMethod not;
 		  parse: self source "Note: `parse:` also does the semantic analysis and return the AST"
 ]

--- a/src/PharoDocComment/PharoDocCommentExpression.class.st
+++ b/src/PharoDocComment/PharoDocCommentExpression.class.st
@@ -44,7 +44,6 @@ PharoDocCommentExpression >> expressionNodeReal [
 		  source: self source;
 		  noPattern: true;
 		  receiver: self methodClass;
-		  options: #( + optionParseErrors );
 		  parse
 ]
 

--- a/src/Shout-Tests/SHRBStyleAttributionTest.class.st
+++ b/src/Shout-Tests/SHRBStyleAttributionTest.class.st
@@ -46,7 +46,6 @@ SHRBStyleAttributionTest >> style: aText [
 		       source: aText asString;
 		       noPattern: false;
 		       class: self class;
-		       options: #( + optionParseErrors + optionSkipSemanticWarnings );
 		       parse.
 	styler style: aText ast: ast.
 

--- a/src/Shout-Tests/SHRBTextStylerTest.class.st
+++ b/src/Shout-Tests/SHRBTextStylerTest.class.st
@@ -24,7 +24,6 @@ SHRBTextStylerTest >> style: aText [
 	ast := self class compiler
 		source: aText asString;
 		noPattern: false ;
-		options:  #(+ optionParseErrors + optionSkipSemanticWarnings);
 		parse.
 	styler style: aText ast: ast.
 

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -796,7 +796,6 @@ SHRBTextStyler >> privateStyle: aText [
 	compiler := classOrMetaClass compiler
 		source: aText asString;
 		noPattern: self isForWorkspace ;
-		options:  #(+ optionParseErrors + optionSkipSemanticWarnings);
 		requestor: workspace.
 
 	self plugins do: [ :each | compiler addParsePlugin: each ].


### PR DESCRIPTION
This is a rewrite of #13048 and includes code of #13080 that is not merged yet (so bigger commit list and diff)

Parsing and compiling in a "faulty" way is not really a preference toggle, it's mainly the responsibility of client to state what they want and what kind of results they are ready to deal with.

So this PR stop relying on the options #optionParseErrorsNonInteractiveOnly #optionParseErrors #optionSkipSemanticWarnings and propose a single compilation flag `permitFaulty`.
This simplifies the code of clients and the internal logic of the compiler.

Also, I did not like the options: way because the syntax is cumbersome, long names are easy to misspell, and spelling errors are silently ignored.
Note that the 3 options are now unused. I did not remove or deprecate them because doing so break the image at startup. Maybe something related to the system settings, but I'm not sure. (see https://ci.inria.fr/pharo-ci-jenkins2/blue/organizations/jenkins/Test%20pending%20pull%20request%20and%20branch%20Pipeline/detail/PR-13048/1/pipeline if you can help me with that)

The flag `permitFaulty` is stored in the compilerContext but accessible from the Compiler (I'm not a fan or having two classes is not the concern of the PR).

The main difference with #13048 is that there is a new default policy:

* for parsing and semantic analysis, permitFaulty is true by default.
* for compiling and evaluating the flag is false by default.

This simple policy is consistent with the new parser default policy (cf #13080) but also consistent with the usage, since I removed a lot of `options:` in clients that wanted only an AST in silence. A looked at every sender of parse, and I did not find a single client, except some tests, that required a non-faulty parsing and semantic analysis.