### PR TITLE
Improve SystemOrganizer namings

### DIFF
--- a/src/CodeExport/ClassDescription.extension.st
+++ b/src/CodeExport/ClassDescription.extension.st
@@ -144,6 +144,7 @@ ClassDescription >> printMethodChunk: selector on: outStream [
 ]
 
 { #category : #'*CodeExport' }
-ClassDescription >> selectorsToFileOutCategory: aSymbol [
-	^ self organization listAtCategoryNamed: aSymbol
+ClassDescription >> selectorsToFileOutCategory: protocolName [
+
+	^ self organization methodsInProtocolNamed: protocolName
 ]

--- a/src/CodeExport/RPackage.extension.st
+++ b/src/CodeExport/RPackage.extension.st
@@ -2,22 +2,21 @@ Extension { #name : #RPackage }
 
 { #category : #'*CodeExport' }
 RPackage >> fileOut [
-	| internalStream |
 
+	| internalStream |
 	internalStream := (String new: 1000) writeStream.
 
-	self classTags do: [ :each |
-		SystemOrganization
-			fileOutCategory: each categoryName
-			on: internalStream ].
+	self classTags do: [ :each | SystemOrganization fileOutPackageNamed: each categoryName on: internalStream ].
 
 	classExtensionSelectors keysAndValuesDo: [ :className :selectors |
-		selectors do: [ :selector | | extendedClass |
+		selectors do: [ :selector |
+			| extendedClass |
 			extendedClass := self class environment classNamed: className.
 			extendedClass fileOutMethod: selector on: internalStream ] ].
 
 	metaclassExtensionSelectors keysAndValuesDo: [ :className :selectors |
-		selectors do: [ :selector | | extendedClass |
+		selectors do: [ :selector |
+			| extendedClass |
 			extendedClass := self class environment classNamed: className.
 			extendedClass classSide fileOutMethod: selector on: internalStream ] ].
 

--- a/src/CodeExport/RPackageTag.extension.st
+++ b/src/CodeExport/RPackageTag.extension.st
@@ -2,13 +2,11 @@ Extension { #name : #RPackageTag }
 
 { #category : #'*CodeExport' }
 RPackageTag >> fileOut [
-	| internalStream |
 
+	| internalStream |
 	internalStream := (String new: 1000) writeStream.
 
-	SystemOrganization
-		fileOutCategory: self categoryName
-		on: internalStream.
+	SystemOrganization fileOutPackageNamed: self categoryName on: internalStream.
 
 	^ CodeExporter writeSourceCodeFrom: internalStream baseName: self name isSt: true
 ]

--- a/src/CodeExport/SystemOrganizer.extension.st
+++ b/src/CodeExport/SystemOrganizer.extension.st
@@ -1,60 +1,34 @@
 Extension { #name : #SystemOrganizer }
 
 { #category : #'*CodeExport' }
-SystemOrganizer >> fileOut [
-	"SystemOrganization fileOut"
-
-	| internalStream |
-	internalStream := (String new: 30000) writeStream.
-	internalStream nextPutAll: 'SystemOrganization changeFromCategorySpecs: #('; cr;
-		print: SystemOrganization;  "ends with a cr"
-		nextPutAll: ')!'; cr.
-
-	CodeExporter
-		writeSourceCodeFrom: internalStream
-		baseName: 'SystemOrganization.st' asFileReference nextVersion basenameWithoutExtension
-		isSt: true
-]
-
-{ #category : #'*CodeExport' }
-SystemOrganizer >> fileOutCategory: packageName [
+SystemOrganizer >> fileOutPackageNamed: packageName [
 	"Store on the file named category (a string) concatenated with '.st' all the
 	classes associated with the category."
 
 	| internalStream |
 	internalStream := (String new: 1000) writeStream.
-	self fileOutCategory: packageName on: internalStream.
+	self fileOutPackageNamed: packageName on: internalStream.
 	^ CodeExporter writeSourceCodeFrom: internalStream baseName: packageName isSt: true
 ]
 
 { #category : #'*CodeExport' }
-SystemOrganizer >> fileOutCategory: packageName on: aFileStream [
-	"Store on the file associated with aFileStream, all the classes associated
-	with the category and any requested shared pools."
-	^self fileOutCategory: packageName on: aFileStream initializing: true
-]
-
-{ #category : #'*CodeExport' }
-SystemOrganizer >> fileOutCategory: packageName on: aFileStream initializing: aBool [
+SystemOrganizer >> fileOutPackageNamed: packageName on: aFileStream [
 	"Store on the file associated with aFileStream, all the traits and classes associated
-	with the category and any requested shared pools in the right order."
+	with the package and any requested shared pools in the right order."
 
-	| poolSet tempClass classes traits |
+	| tempClass classes traits |
 	traits := self orderedTraitsIn: packageName.
 	classes := self superclassOrder: packageName.
-	poolSet := Set new.
-	classes do:  [:class | class sharedPools do: [:eachPool | poolSet add: eachPool]].
-	poolSet notEmpty ifTrue: [
+	(classes flatCollectAsSet: [ :class | class sharedPools ]) ifNotEmpty: [ :poolSet |
 		tempClass := Class new.
 		tempClass shouldFileOutPools ifTrue: [
-			poolSet := poolSet select: [:aPool |
-				tempClass shouldFileOutPool: (self environment keyAtIdentityValue: aPool)].
-			poolSet do: [:aPool | tempClass fileOutPool: aPool onFileStream: aFileStream]]].
-	traits, classes
-		do: [:each |
-			each
-				fileOutOn: aFileStream
-				initializing: false ]
-		separatedBy: [ aFileStream cr; nextPut: Character newPage; cr ].
-	aBool ifTrue: [classes do: [:cls | cls fileOutInitializerOn: aFileStream]]
+			poolSet
+				select: [ :aPool | tempClass shouldFileOutPool: (self environment keyAtIdentityValue: aPool) ]
+				thenDo: [ :aPool | tempClass fileOutPool: aPool onFileStream: aFileStream ] ] ].
+	traits , classes do: [ :each | each fileOutOn: aFileStream initializing: false ] separatedBy: [
+		aFileStream
+			cr;
+			nextPut: Character newPage;
+			cr ].
+	classes do: [ :cls | cls fileOutInitializerOn: aFileStream ]
 ]

--- a/src/CodeExport/SystemOrganizer.extension.st
+++ b/src/CodeExport/SystemOrganizer.extension.st
@@ -2,8 +2,8 @@ Extension { #name : #SystemOrganizer }
 
 { #category : #'*CodeExport' }
 SystemOrganizer >> fileOutPackageNamed: packageName [
-	"Store on the file named category (a string) concatenated with '.st' all the
-	classes associated with the category."
+	"Store on the file named packageName (a string) concatenated with '.st' all the
+	classes associated with the package name."
 
 	| internalStream |
 	internalStream := (String new: 1000) writeStream.

--- a/src/CodeExport/SystemOrganizer.extension.st
+++ b/src/CodeExport/SystemOrganizer.extension.st
@@ -17,31 +17,31 @@ SystemOrganizer >> fileOut [
 ]
 
 { #category : #'*CodeExport' }
-SystemOrganizer >> fileOutCategory: category [
+SystemOrganizer >> fileOutCategory: packageName [
 	"Store on the file named category (a string) concatenated with '.st' all the
 	classes associated with the category."
 
 	| internalStream |
 	internalStream := (String new: 1000) writeStream.
-	self fileOutCategory: category on: internalStream.
-	^ CodeExporter writeSourceCodeFrom: internalStream baseName: category isSt: true
+	self fileOutCategory: packageName on: internalStream.
+	^ CodeExporter writeSourceCodeFrom: internalStream baseName: packageName isSt: true
 ]
 
 { #category : #'*CodeExport' }
-SystemOrganizer >> fileOutCategory: category on: aFileStream [
+SystemOrganizer >> fileOutCategory: packageName on: aFileStream [
 	"Store on the file associated with aFileStream, all the classes associated
 	with the category and any requested shared pools."
-	^self fileOutCategory: category on: aFileStream initializing: true
+	^self fileOutCategory: packageName on: aFileStream initializing: true
 ]
 
 { #category : #'*CodeExport' }
-SystemOrganizer >> fileOutCategory: category on: aFileStream initializing: aBool [
+SystemOrganizer >> fileOutCategory: packageName on: aFileStream initializing: aBool [
 	"Store on the file associated with aFileStream, all the traits and classes associated
 	with the category and any requested shared pools in the right order."
 
 	| poolSet tempClass classes traits |
-	traits := self orderedTraitsIn: category.
-	classes := self superclassOrder: category.
+	traits := self orderedTraitsIn: packageName.
+	classes := self superclassOrder: packageName.
 	poolSet := Set new.
 	classes do:  [:class | class sharedPools do: [:eachPool | poolSet add: eachPool]].
 	poolSet notEmpty ifTrue: [

--- a/src/Deprecated12/ClassOrganization.extension.st
+++ b/src/Deprecated12/ClassOrganization.extension.st
@@ -1,13 +1,6 @@
 Extension { #name : #ClassOrganization }
 
 { #category : #'*Deprecated12' }
-ClassOrganization >> addCategory: aString [
-
-	self deprecated: 'Use #addProtocolNamed: instead.' transformWith: '`@rcv addCategory: `@arg' -> '`@rcv addProtocolNamed: `@arg'.
-	self addProtocolNamed: aString
-]
-
-{ #category : #'*Deprecated12' }
 ClassOrganization >> allCategories [
 
 	self deprecated: 'Use #allProtocolsNames instead.' transformWith: '`@rcv allCategories' -> '`@rcv allProtocolsNames'.

--- a/src/Deprecated12/ClassOrganization.extension.st
+++ b/src/Deprecated12/ClassOrganization.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : #ClassOrganization }
 
 { #category : #'*Deprecated12' }
+ClassOrganization >> addCategory: aString [
+
+	self deprecated: 'Use #addProtocolNamed: instead.' transformWith: '`@rcv addCategory: `@arg' -> '`@rcv addProtocolNamed: `@arg'.
+	self addProtocolNamed: aString
+]
+
+{ #category : #'*Deprecated12' }
 ClassOrganization >> allCategories [
 
 	self deprecated: 'Use #allProtocolsNames instead.' transformWith: '`@rcv allCategories' -> '`@rcv allProtocolsNames'.

--- a/src/Deprecated12/SystemOrganizer.extension.st
+++ b/src/Deprecated12/SystemOrganizer.extension.st
@@ -20,3 +20,10 @@ SystemOrganizer >> categoriesMatching: matchString [
 	self deprecated: 'Use #packageNamesMatching: instead' transformWith: '`@rcv categoriesMatching: `@arg' -> '`@rcv packageNamesMatching: `@arg'.
 	^ self packageNamesMatching: matchString
 ]
+
+{ #category : #'*Deprecated12' }
+SystemOrganizer >> categoryOfElement: element [
+
+	self deprecated: 'Use #packageNameOfElement: instead' transformWith: '`@rcv categoryOfElement: `@arg' -> '`@rcv packageNameOfElement: `@arg'.
+	^ self packageNameOfElement: element
+]

--- a/src/Deprecated12/SystemOrganizer.extension.st
+++ b/src/Deprecated12/SystemOrganizer.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : #SystemOrganizer }
 
 { #category : #'*Deprecated12' }
+SystemOrganizer >> addCategory: packageName [
+
+	self deprecated: 'Use #addPackageNamed: instead' transformWith: '`@rcv addCategory: `@arg' -> '`@rcv addPackageNamed: `@arg'.
+	^ self addPackageNamed: packageName
+]
+
+{ #category : #'*Deprecated12' }
 SystemOrganizer >> categories [
 
 	self deprecated: 'Use #packageNames instead' transformWith: '`@rcv categories' -> '`@rcv packageNames'.

--- a/src/Deprecated12/SystemOrganizer.extension.st
+++ b/src/Deprecated12/SystemOrganizer.extension.st
@@ -36,6 +36,13 @@ SystemOrganizer >> classesInCategory: packageName [
 ]
 
 { #category : #'*Deprecated12' }
+SystemOrganizer >> includesCategory: packageName [
+
+	self deprecated: 'Use #includesPackageNamed: instead' transformWith: '`@rcv includesCategory: `@arg' -> '`@rcv includesPackageNamed: `@arg'.
+	^ self includesPackageNamed: packageName
+]
+
+{ #category : #'*Deprecated12' }
 SystemOrganizer >> removeCategoriesMatching: matchString [
 
 	self deprecated: 'Use #removePackageNamesMatching: instead' transformWith: '`@rcv removeCategoriesMatching: `@arg' -> '`@rcv removePackageNamesMatching: `@arg'.

--- a/src/Deprecated12/SystemOrganizer.extension.st
+++ b/src/Deprecated12/SystemOrganizer.extension.st
@@ -36,6 +36,13 @@ SystemOrganizer >> classesInCategory: packageName [
 ]
 
 { #category : #'*Deprecated12' }
+SystemOrganizer >> removeCategory: packageName [
+
+	self deprecated: 'Use #removePackageNamed: instead' transformWith: '`@rcv removeCategory: `@arg' -> '`@rcv removePackageNamed: `@arg'.
+	^ self removePackageNamed: packageName
+]
+
+{ #category : #'*Deprecated12' }
 SystemOrganizer >> renameCategory: oldPackageName toBe: newPackageName [
 
 	self

--- a/src/Deprecated12/SystemOrganizer.extension.st
+++ b/src/Deprecated12/SystemOrganizer.extension.st
@@ -6,3 +6,10 @@ SystemOrganizer >> addCategory: packageName [
 	self deprecated: 'Use #addPackageNamed: instead' transformWith: '`@rcv addCategory: `@arg' -> '`@rcv addPackageNamed: `@arg'.
 	^ self addPackageNamed: packageName
 ]
+
+{ #category : #'*Deprecated12' }
+SystemOrganizer >> categories [
+
+	self deprecated: 'Use #packageNames instead' transformWith: '`@rcv categories' -> '`@rcv packageNames'.
+	^ self packageNames
+]

--- a/src/Deprecated12/SystemOrganizer.extension.st
+++ b/src/Deprecated12/SystemOrganizer.extension.st
@@ -27,3 +27,10 @@ SystemOrganizer >> categoryOfElement: element [
 	self deprecated: 'Use #packageNameOfElement: instead' transformWith: '`@rcv categoryOfElement: `@arg' -> '`@rcv packageNameOfElement: `@arg'.
 	^ self packageNameOfElement: element
 ]
+
+{ #category : #'*Deprecated12' }
+SystemOrganizer >> classesInCategory: packageName [
+
+	self deprecated: 'Use #classesInPackageNamed: instead' transformWith: '`@rcv classesInCategory: `@arg' -> '`@rcv classesInPackageNamed: `@arg'.
+	^ self classesInPackageNamed: packageName
+]

--- a/src/Deprecated12/SystemOrganizer.extension.st
+++ b/src/Deprecated12/SystemOrganizer.extension.st
@@ -34,3 +34,12 @@ SystemOrganizer >> classesInCategory: packageName [
 	self deprecated: 'Use #classesInPackageNamed: instead' transformWith: '`@rcv classesInCategory: `@arg' -> '`@rcv classesInPackageNamed: `@arg'.
 	^ self classesInPackageNamed: packageName
 ]
+
+{ #category : #'*Deprecated12' }
+SystemOrganizer >> renameCategory: oldPackageName toBe: newPackageName [
+
+	self
+		deprecated: 'Use #renamePackageNamed:to: instead'
+		transformWith: '`@rcv renameCategory: `@arg toBe: `@arg2' -> '`@rcv renamePackageNamed: `@arg to: `@arg2'.
+	^ self renamePackageNamed: oldPackageName to: newPackageName
+]

--- a/src/Deprecated12/SystemOrganizer.extension.st
+++ b/src/Deprecated12/SystemOrganizer.extension.st
@@ -57,6 +57,13 @@ SystemOrganizer >> removeCategory: packageName [
 ]
 
 { #category : #'*Deprecated12' }
+SystemOrganizer >> removeSystemCategory: packageName [
+
+	self deprecated: 'Use #removeFromSystemPackageName: instead' transformWith: '`@rcv removeSystemCategory: `@arg' -> '`@rcv removeFromSystemPackageName: `@arg'.
+	^ self removeFromSystemPackageName: packageName
+]
+
+{ #category : #'*Deprecated12' }
 SystemOrganizer >> renameCategory: oldPackageName toBe: newPackageName [
 
 	self

--- a/src/Deprecated12/SystemOrganizer.extension.st
+++ b/src/Deprecated12/SystemOrganizer.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #SystemOrganizer }
+
+{ #category : #'*Deprecated12' }
+SystemOrganizer >> addCategory: packageName [
+
+	self deprecated: 'Use #addPackageNamed: instead' transformWith: '`@rcv addCategory: `@arg' -> '`@rcv addPackageNamed: `@arg'.
+	^ self addPackageNamed: packageName
+]

--- a/src/Deprecated12/SystemOrganizer.extension.st
+++ b/src/Deprecated12/SystemOrganizer.extension.st
@@ -36,6 +36,13 @@ SystemOrganizer >> classesInCategory: packageName [
 ]
 
 { #category : #'*Deprecated12' }
+SystemOrganizer >> removeCategoriesMatching: matchString [
+
+	self deprecated: 'Use #removePackageNamesMatching: instead' transformWith: '`@rcv removeCategoriesMatching: `@arg' -> '`@rcv removePackageNamesMatching: `@arg'.
+	^ self removePackageNamesMatching: matchString
+]
+
+{ #category : #'*Deprecated12' }
 SystemOrganizer >> removeCategory: packageName [
 
 	self deprecated: 'Use #removePackageNamed: instead' transformWith: '`@rcv removeCategory: `@arg' -> '`@rcv removePackageNamed: `@arg'.

--- a/src/Deprecated12/SystemOrganizer.extension.st
+++ b/src/Deprecated12/SystemOrganizer.extension.st
@@ -13,3 +13,10 @@ SystemOrganizer >> categories [
 	self deprecated: 'Use #packageNames instead' transformWith: '`@rcv categories' -> '`@rcv packageNames'.
 	^ self packageNames
 ]
+
+{ #category : #'*Deprecated12' }
+SystemOrganizer >> categoriesMatching: matchString [
+
+	self deprecated: 'Use #packageNamesMatching: instead' transformWith: '`@rcv categoriesMatching: `@arg' -> '`@rcv packageNamesMatching: `@arg'.
+	^ self packageNamesMatching: matchString
+]

--- a/src/Deprecated12/SystemOrganizer.extension.st
+++ b/src/Deprecated12/SystemOrganizer.extension.st
@@ -43,6 +43,13 @@ SystemOrganizer >> includesCategory: packageName [
 ]
 
 { #category : #'*Deprecated12' }
+SystemOrganizer >> listAtCategoryNamed: packageName [
+
+	self deprecated: 'Use #classNamesInPackageNamed: instead' transformWith: '`@rcv listAtCategoryNamed: `@arg' -> '`@rcv classNamesInPackageNamed: `@arg'.
+	^ self classNamesInPackageNamed: packageName
+]
+
+{ #category : #'*Deprecated12' }
 SystemOrganizer >> removeCategoriesMatching: matchString [
 
 	self deprecated: 'Use #removePackageNamesMatching: instead' transformWith: '`@rcv removeCategoriesMatching: `@arg' -> '`@rcv removePackageNamesMatching: `@arg'.

--- a/src/Deprecated12/SystemOrganizer.extension.st
+++ b/src/Deprecated12/SystemOrganizer.extension.st
@@ -1,13 +1,6 @@
 Extension { #name : #SystemOrganizer }
 
 { #category : #'*Deprecated12' }
-SystemOrganizer >> addCategory: packageName [
-
-	self deprecated: 'Use #addPackageNamed: instead' transformWith: '`@rcv addCategory: `@arg' -> '`@rcv addPackageNamed: `@arg'.
-	^ self addPackageNamed: packageName
-]
-
-{ #category : #'*Deprecated12' }
 SystemOrganizer >> categories [
 
 	self deprecated: 'Use #packageNames instead' transformWith: '`@rcv categories' -> '`@rcv packageNames'.

--- a/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
+++ b/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
@@ -16,7 +16,7 @@ EpCodeChangeIntegrationTest >> categoryNameForTesting [
 { #category : #running }
 EpCodeChangeIntegrationTest >> tearDown [
 
-	self class environment organization removeCategory: self categoryNameForTesting.
+	self class environment organization removePackageNamed: self categoryNameForTesting.
 	super tearDown
 ]
 
@@ -47,7 +47,7 @@ EpCodeChangeIntegrationTest >> testCategoryRemoval [
 	self class environment organization addPackageNamed: self categoryNameForTesting.
 	self assert: (self countLogEventsWith: EpCategoryRemoval) equals: 0.
 
-	self class environment organization removeCategory: self categoryNameForTesting.
+	self class environment organization removePackageNamed: self categoryNameForTesting.
 	self assert: (self countLogEventsWith: EpCategoryRemoval) equals: 1.
 	self assert: (self allLogEventsWith: EpCategoryRemoval) first affectedPackageName equals: self categoryNameForTesting
 ]

--- a/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
+++ b/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
@@ -35,25 +35,21 @@ EpCodeChangeIntegrationTest >> testCategoryAddition [
 
 	self assert: (self countLogEventsWith: EpCategoryAddition) equals: 0.
 
-	self class environment organization addCategory: self categoryNameForTesting.
+	self class environment organization addPackageNamed: self categoryNameForTesting.
 
 	self assert: (self countLogEventsWith: EpCategoryAddition) equals: 1.
-	self
-		assert: (self allLogEventsWith: EpCategoryAddition) first affectedPackageName
-		equals: self categoryNameForTesting
+	self assert: (self allLogEventsWith: EpCategoryAddition) first affectedPackageName equals: self categoryNameForTesting
 ]
 
 { #category : #tests }
 EpCodeChangeIntegrationTest >> testCategoryRemoval [
 
-	self class environment organization addCategory: self categoryNameForTesting.
+	self class environment organization addPackageNamed: self categoryNameForTesting.
 	self assert: (self countLogEventsWith: EpCategoryRemoval) equals: 0.
 
 	self class environment organization removeCategory: self categoryNameForTesting.
 	self assert: (self countLogEventsWith: EpCategoryRemoval) equals: 1.
-	self
-		assert: (self allLogEventsWith: EpCategoryRemoval) first affectedPackageName
-		equals: self categoryNameForTesting
+	self assert: (self allLogEventsWith: EpCategoryRemoval) first affectedPackageName equals: self categoryNameForTesting
 ]
 
 { #category : #tests }

--- a/src/EpiceaBrowsers-Tests/EpApplyPreviewerTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpApplyPreviewerTest.class.st
@@ -143,9 +143,9 @@ EpApplyPreviewerTest >> testCategoryRenameWithPreviousRollback [
 	aCategory := classFactory defaultCategory.
 	anotherCategory := aCategory , '2'.
 	organization addPackageNamed: aCategory.
-	organization renameCategory: aCategory toBe: anotherCategory.
+	organization renamePackageNamed: aCategory to: anotherCategory.
 	self setHeadAsInputEntry.
-	organization renameCategory: anotherCategory toBe: aCategory. "Rollback"
+	organization renamePackageNamed: anotherCategory to: aCategory. "Rollback"
 
 	self assertOutputsAnEventWith: [ :output |
 		self assert: output class equals: EpCategoryRename.
@@ -467,7 +467,7 @@ EpApplyPreviewerTest >> testRedundantCategoryRenameWithAbsentCategory [
 	aCategory := classFactory defaultCategory.
 	anotherCategory := aCategory , '2'.
 	organization addPackageNamed: aCategory.
-	organization renameCategory: aCategory toBe: anotherCategory.
+	organization renamePackageNamed: aCategory to: anotherCategory.
 	self setHeadAsInputEntry.
 
 	self assertEmptyPreviewLog

--- a/src/EpiceaBrowsers-Tests/EpApplyPreviewerTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpApplyPreviewerTest.class.st
@@ -112,29 +112,27 @@ EpApplyPreviewerTest >> testBehaviorNameChange [
 { #category : #tests }
 EpApplyPreviewerTest >> testCategoryAdditionWithCategoryRemoved [
 
-	self class environment organization addCategory: classFactory defaultCategory.
+	self class environment organization addPackageNamed: classFactory defaultCategory.
 	self setHeadAsInputEntry.
 	self class environment organization removeCategory: classFactory defaultCategory.
 
-	self assertOutputsAnEventWith: [:output |
+	self assertOutputsAnEventWith: [ :output |
 		self assert: output class equals: EpCategoryAddition.
-		self assert: output categoryName equals: classFactory defaultCategory.
-		]
+		self assert: output categoryName equals: classFactory defaultCategory ]
 ]
 
 { #category : #tests }
 EpApplyPreviewerTest >> testCategoryRemovalWithCategoryAdded [
 
-	self class environment organization addCategory: classFactory defaultCategory.
+	self class environment organization addPackageNamed: classFactory defaultCategory.
 	self class environment organization removeCategory: classFactory defaultCategory.
 	self setHeadAsInputEntry.
 
-	self class environment organization addCategory: classFactory defaultCategory.
+	self class environment organization addPackageNamed: classFactory defaultCategory.
 
-	self assertOutputsAnEventWith: [:output |
+	self assertOutputsAnEventWith: [ :output |
 		self assert: output class equals: EpCategoryRemoval.
-		self assert: output categoryName equals: classFactory defaultCategory.
-		]
+		self assert: output categoryName equals: classFactory defaultCategory ]
 ]
 
 { #category : #tests }
@@ -143,17 +141,16 @@ EpApplyPreviewerTest >> testCategoryRenameWithPreviousRollback [
 	| organization aCategory anotherCategory |
 	organization := self class environment organization.
 	aCategory := classFactory defaultCategory.
-	anotherCategory := aCategory, '2'.
-	organization addCategory: aCategory.
+	anotherCategory := aCategory , '2'.
+	organization addPackageNamed: aCategory.
 	organization renameCategory: aCategory toBe: anotherCategory.
 	self setHeadAsInputEntry.
 	organization renameCategory: anotherCategory toBe: aCategory. "Rollback"
 
-	self assertOutputsAnEventWith: [:output |
+	self assertOutputsAnEventWith: [ :output |
 		self assert: output class equals: EpCategoryRename.
 		self assert: output oldCategoryName equals: aCategory.
-		self assert: output newCategoryName equals: anotherCategory.
-		]
+		self assert: output newCategoryName equals: anotherCategory ]
 ]
 
 { #category : #tests }
@@ -446,7 +443,7 @@ EpApplyPreviewerTest >> testRedundantBehaviorCommentChangeWithAbsentBehavior [
 { #category : #tests }
 EpApplyPreviewerTest >> testRedundantCategoryAddition [
 
-	self class environment organization addCategory: classFactory defaultCategory.
+	self class environment organization addPackageNamed: classFactory defaultCategory.
 	self setHeadAsInputEntry.
 
 	self assertEmptyPreviewLog
@@ -455,7 +452,7 @@ EpApplyPreviewerTest >> testRedundantCategoryAddition [
 { #category : #tests }
 EpApplyPreviewerTest >> testRedundantCategoryRemoval [
 
-	self class environment organization addCategory: classFactory defaultCategory.
+	self class environment organization addPackageNamed: classFactory defaultCategory.
 	self class environment organization removeCategory: classFactory defaultCategory.
 	self setHeadAsInputEntry.
 
@@ -468,8 +465,8 @@ EpApplyPreviewerTest >> testRedundantCategoryRenameWithAbsentCategory [
 	| organization aCategory anotherCategory |
 	organization := self class environment organization.
 	aCategory := classFactory defaultCategory.
-	anotherCategory := aCategory, '2'.
-	organization addCategory: aCategory.
+	anotherCategory := aCategory , '2'.
+	organization addPackageNamed: aCategory.
 	organization renameCategory: aCategory toBe: anotherCategory.
 	self setHeadAsInputEntry.
 

--- a/src/EpiceaBrowsers-Tests/EpApplyPreviewerTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpApplyPreviewerTest.class.st
@@ -114,7 +114,7 @@ EpApplyPreviewerTest >> testCategoryAdditionWithCategoryRemoved [
 
 	self class environment organization addPackageNamed: classFactory defaultCategory.
 	self setHeadAsInputEntry.
-	self class environment organization removeCategory: classFactory defaultCategory.
+	self class environment organization removePackageNamed: classFactory defaultCategory.
 
 	self assertOutputsAnEventWith: [ :output |
 		self assert: output class equals: EpCategoryAddition.
@@ -125,7 +125,7 @@ EpApplyPreviewerTest >> testCategoryAdditionWithCategoryRemoved [
 EpApplyPreviewerTest >> testCategoryRemovalWithCategoryAdded [
 
 	self class environment organization addPackageNamed: classFactory defaultCategory.
-	self class environment organization removeCategory: classFactory defaultCategory.
+	self class environment organization removePackageNamed: classFactory defaultCategory.
 	self setHeadAsInputEntry.
 
 	self class environment organization addPackageNamed: classFactory defaultCategory.
@@ -453,7 +453,7 @@ EpApplyPreviewerTest >> testRedundantCategoryAddition [
 EpApplyPreviewerTest >> testRedundantCategoryRemoval [
 
 	self class environment organization addPackageNamed: classFactory defaultCategory.
-	self class environment organization removeCategory: classFactory defaultCategory.
+	self class environment organization removePackageNamed: classFactory defaultCategory.
 	self setHeadAsInputEntry.
 
 	self assertEmptyPreviewLog

--- a/src/EpiceaBrowsers-Tests/EpApplyTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpApplyTest.class.st
@@ -42,9 +42,9 @@ EpApplyTest >> testCategoryAdditionWithCategoryRemoved [
 	organization removePackageNamed: aCategory.
 
 	self assert: inputEntry content class equals: EpCategoryAddition.
-	self deny: (organization includesCategory: aCategory).
+	self deny: (organization includesPackageNamed: aCategory).
 	self applyInputEntry.
-	self assert: (organization includesCategory: aCategory)
+	self assert: (organization includesPackageNamed: aCategory)
 ]
 
 { #category : #tests }
@@ -59,9 +59,9 @@ EpApplyTest >> testCategoryRemovalWithCategoryAdded [
 	organization addPackageNamed: aCategory.
 
 	self assert: inputEntry content class equals: EpCategoryRemoval.
-	self assert: (organization includesCategory: aCategory).
+	self assert: (organization includesPackageNamed: aCategory).
 	self applyInputEntry.
-	self deny: (organization includesCategory: aCategory)
+	self deny: (organization includesPackageNamed: aCategory)
 ]
 
 { #category : #tests }
@@ -77,11 +77,11 @@ EpApplyTest >> testCategoryRename [
 	organization renamePackageNamed: anotherCategory to: aCategory. "Rollback"
 
 	self assert: inputEntry content class equals: EpCategoryRename.
-	self assert: (organization includesCategory: aCategory).
-	self deny: (organization includesCategory: anotherCategory).
+	self assert: (organization includesPackageNamed: aCategory).
+	self deny: (organization includesPackageNamed: anotherCategory).
 	self applyInputEntry.
-	self deny: (organization includesCategory: aCategory).
-	self assert: (organization includesCategory: anotherCategory)
+	self deny: (organization includesPackageNamed: aCategory).
+	self assert: (organization includesPackageNamed: anotherCategory)
 ]
 
 { #category : #tests }

--- a/src/EpiceaBrowsers-Tests/EpApplyTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpApplyTest.class.st
@@ -39,7 +39,7 @@ EpApplyTest >> testCategoryAdditionWithCategoryRemoved [
 	aCategory := classFactory defaultCategory.
 	organization addPackageNamed: aCategory.
 	self setHeadAsInputEntry.
-	organization removeCategory: aCategory.
+	organization removePackageNamed: aCategory.
 
 	self assert: inputEntry content class equals: EpCategoryAddition.
 	self deny: (organization includesCategory: aCategory).
@@ -54,7 +54,7 @@ EpApplyTest >> testCategoryRemovalWithCategoryAdded [
 	organization := self class environment organization.
 	aCategory := classFactory defaultCategory.
 	organization addPackageNamed: aCategory.
-	organization removeCategory: aCategory.
+	organization removePackageNamed: aCategory.
 	self setHeadAsInputEntry.
 	organization addPackageNamed: aCategory.
 

--- a/src/EpiceaBrowsers-Tests/EpApplyTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpApplyTest.class.st
@@ -72,9 +72,9 @@ EpApplyTest >> testCategoryRename [
 	aCategory := classFactory defaultCategory.
 	anotherCategory := aCategory , '2'.
 	organization addPackageNamed: aCategory.
-	organization renameCategory: aCategory toBe: anotherCategory.
+	organization renamePackageNamed: aCategory to: anotherCategory.
 	self setHeadAsInputEntry.
-	organization renameCategory: anotherCategory toBe: aCategory. "Rollback"
+	organization renamePackageNamed: anotherCategory to: aCategory. "Rollback"
 
 	self assert: inputEntry content class equals: EpCategoryRename.
 	self assert: (organization includesCategory: aCategory).

--- a/src/EpiceaBrowsers-Tests/EpApplyTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpApplyTest.class.st
@@ -37,7 +37,7 @@ EpApplyTest >> testCategoryAdditionWithCategoryRemoved [
 	| organization aCategory |
 	organization := self class environment organization.
 	aCategory := classFactory defaultCategory.
-	organization addCategory: aCategory.
+	organization addPackageNamed: aCategory.
 	self setHeadAsInputEntry.
 	organization removeCategory: aCategory.
 
@@ -53,10 +53,10 @@ EpApplyTest >> testCategoryRemovalWithCategoryAdded [
 	| organization aCategory |
 	organization := self class environment organization.
 	aCategory := classFactory defaultCategory.
-	organization addCategory: aCategory.
+	organization addPackageNamed: aCategory.
 	organization removeCategory: aCategory.
 	self setHeadAsInputEntry.
-	organization addCategory: aCategory.
+	organization addPackageNamed: aCategory.
 
 	self assert: inputEntry content class equals: EpCategoryRemoval.
 	self assert: (organization includesCategory: aCategory).
@@ -70,8 +70,8 @@ EpApplyTest >> testCategoryRename [
 	| organization aCategory anotherCategory |
 	organization := self class environment organization.
 	aCategory := classFactory defaultCategory.
-	anotherCategory := aCategory, '2'.
-	organization addCategory: aCategory.
+	anotherCategory := aCategory , '2'.
+	organization addPackageNamed: aCategory.
 	organization renameCategory: aCategory toBe: anotherCategory.
 	self setHeadAsInputEntry.
 	organization renameCategory: anotherCategory toBe: aCategory. "Rollback"

--- a/src/EpiceaBrowsers-Tests/EpRevertTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpRevertTest.class.st
@@ -67,9 +67,9 @@ EpRevertTest >> testCategoryAdditionWithCategoryRemoved [
 	organization addPackageNamed: aCategory.
 	self setHeadAsInputEntry.
 
-	self assert: (organization includesCategory: aCategory).
+	self assert: (organization includesPackageNamed: aCategory).
 	self revertInputEntry.
-	self deny: (organization includesCategory: aCategory)
+	self deny: (organization includesPackageNamed: aCategory)
 ]
 
 { #category : #tests }
@@ -82,9 +82,9 @@ EpRevertTest >> testCategoryRemovalWithCategoryAdded [
 	organization removePackageNamed: aCategory.
 	self setHeadAsInputEntry.
 
-	self deny: (organization includesCategory: aCategory).
+	self deny: (organization includesPackageNamed: aCategory).
 	self revertInputEntry.
-	self assert: (organization includesCategory: aCategory)
+	self assert: (organization includesPackageNamed: aCategory)
 ]
 
 { #category : #tests }
@@ -99,11 +99,11 @@ EpRevertTest >> testCategoryRename [
 	self setHeadAsInputEntry.
 
 	self assert: inputEntry content class equals: EpCategoryRename.
-	self deny: (organization includesCategory: aCategory).
-	self assert: (organization includesCategory: anotherCategory).
+	self deny: (organization includesPackageNamed: aCategory).
+	self assert: (organization includesPackageNamed: anotherCategory).
 	self revertInputEntry.
-	self assert: (organization includesCategory: aCategory).
-	self deny: (organization includesCategory: anotherCategory)
+	self assert: (organization includesPackageNamed: aCategory).
+	self deny: (organization includesPackageNamed: anotherCategory)
 ]
 
 { #category : #tests }

--- a/src/EpiceaBrowsers-Tests/EpRevertTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpRevertTest.class.st
@@ -79,7 +79,7 @@ EpRevertTest >> testCategoryRemovalWithCategoryAdded [
 	organization := self class environment organization.
 	aCategory := classFactory defaultCategory.
 	organization addPackageNamed: aCategory.
-	organization removeCategory: aCategory.
+	organization removePackageNamed: aCategory.
 	self setHeadAsInputEntry.
 
 	self deny: (organization includesCategory: aCategory).

--- a/src/EpiceaBrowsers-Tests/EpRevertTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpRevertTest.class.st
@@ -64,7 +64,7 @@ EpRevertTest >> testCategoryAdditionWithCategoryRemoved [
 	| organization aCategory |
 	organization := self class environment organization.
 	aCategory := classFactory defaultCategory.
-	organization addCategory: aCategory.
+	organization addPackageNamed: aCategory.
 	self setHeadAsInputEntry.
 
 	self assert: (organization includesCategory: aCategory).
@@ -78,7 +78,7 @@ EpRevertTest >> testCategoryRemovalWithCategoryAdded [
 	| organization aCategory |
 	organization := self class environment organization.
 	aCategory := classFactory defaultCategory.
-	organization addCategory: aCategory.
+	organization addPackageNamed: aCategory.
 	organization removeCategory: aCategory.
 	self setHeadAsInputEntry.
 
@@ -93,8 +93,8 @@ EpRevertTest >> testCategoryRename [
 	| organization aCategory anotherCategory |
 	organization := self class environment organization.
 	aCategory := classFactory defaultCategory.
-	anotherCategory := aCategory, '2'.
-	organization addCategory: aCategory.
+	anotherCategory := aCategory , '2'.
+	organization addPackageNamed: aCategory.
 	organization renameCategory: aCategory toBe: anotherCategory.
 	self setHeadAsInputEntry.
 

--- a/src/EpiceaBrowsers-Tests/EpRevertTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpRevertTest.class.st
@@ -95,7 +95,7 @@ EpRevertTest >> testCategoryRename [
 	aCategory := classFactory defaultCategory.
 	anotherCategory := aCategory , '2'.
 	organization addPackageNamed: aCategory.
-	organization renameCategory: aCategory toBe: anotherCategory.
+	organization renamePackageNamed: aCategory to: anotherCategory.
 	self setHeadAsInputEntry.
 
 	self assert: inputEntry content class equals: EpCategoryRename.

--- a/src/EpiceaBrowsers/EpApplyPreviewer.class.st
+++ b/src/EpiceaBrowsers/EpApplyPreviewer.class.st
@@ -34,7 +34,7 @@ EpApplyPreviewer >> environment: anObject [
 { #category : #private }
 EpApplyPreviewer >> includesCategory: aString [
 
-	^ self environment organization includesCategory: aString
+	^ self environment organization includesPackageNamed: aString
 ]
 
 { #category : #visitor }

--- a/src/EpiceaBrowsers/EpApplyVisitor.class.st
+++ b/src/EpiceaBrowsers/EpApplyVisitor.class.st
@@ -47,7 +47,8 @@ EpApplyVisitor >> visitCategoryRegistration: aPackageCreated [
 
 { #category : #visitor }
 EpApplyVisitor >> visitCategoryRemoval: aPackageRemoved [
-	environment organization removeCategory: aPackageRemoved categoryName
+
+	environment organization removePackageNamed: aPackageRemoved categoryName
 ]
 
 { #category : #visitor }

--- a/src/EpiceaBrowsers/EpApplyVisitor.class.st
+++ b/src/EpiceaBrowsers/EpApplyVisitor.class.st
@@ -53,9 +53,7 @@ EpApplyVisitor >> visitCategoryRemoval: aPackageRemoved [
 { #category : #visitor }
 EpApplyVisitor >> visitCategoryRename: aChange [
 
-	environment organization
-		renameCategory: aChange oldCategoryName
-		toBe: aChange newCategoryName
+	environment organization renamePackageNamed: aChange oldCategoryName to: aChange newCategoryName
 ]
 
 { #category : #visitor }

--- a/src/EpiceaBrowsers/EpApplyVisitor.class.st
+++ b/src/EpiceaBrowsers/EpApplyVisitor.class.st
@@ -36,7 +36,8 @@ EpApplyVisitor >> visitBehaviorNameChange: aClassRenameChange [
 
 { #category : #visitor }
 EpApplyVisitor >> visitCategoryAddition: aPackageCreated [
-	environment organization addCategory: aPackageCreated categoryName
+
+	environment organization addPackageNamed: aPackageCreated categoryName
 ]
 
 { #category : #visitor }

--- a/src/Fuel-Platform-Core/FLPlatform.class.st
+++ b/src/Fuel-Platform-Core/FLPlatform.class.st
@@ -107,13 +107,13 @@ FLPlatform class >> isResponsibleForCurrentPlatform [
 
 { #category : #'private-convenience' }
 FLPlatform class >> removeModifications [
-	((Smalltalk globals at: #(Smalltalk globals at: #PackageInfo)) named: self extensionProtocolName) extensionMethods do: [ :methodReference |
+
+	((Smalltalk globals at: #( Smalltalk globals at: #PackageInfo )) named: self extensionProtocolName) extensionMethods do: [ :methodReference |
 		methodReference actualClass removeSelector: methodReference selector ].
-	((Smalltalk globals at: #(Smalltalk globals at: #PackageInfo)) named: self hacksCategoryName) in: [ :hacks |
-		hacks classes do: [ :classOrTrait |
-			classOrTrait removeFromSystem ].
-		(Smalltalk globals at: #PackageOrganizer) default  unregisterPackage: hacks ].
-	SystemOrganizer default removeCategory: self hacksCategoryName
+	((Smalltalk globals at: #( Smalltalk globals at: #PackageInfo )) named: self hacksCategoryName) in: [ :hacks |
+		hacks classes do: [ :classOrTrait | classOrTrait removeFromSystem ].
+		(Smalltalk globals at: #PackageOrganizer) default unregisterPackage: hacks ].
+	SystemOrganizer default removePackageNamed: self hacksCategoryName
 ]
 
 { #category : #'class initialization' }

--- a/src/Fuel-Tests-Core/FLClassFactoryForTestCase.class.st
+++ b/src/Fuel-Tests-Core/FLClassFactoryForTestCase.class.st
@@ -70,12 +70,11 @@ FLClassFactoryForTestCase >> cleanUpSystemOrganization [
 	"This method is necessary because we create classes in a non-default environment. The
 	SystemOrganization is global and ClassFactoryForTestCase interacts with it to clean out
 	categories."
+
 	| categoriesMatchString categories |
-	categoriesMatchString := self defaultPackageName, '-*'.
-	categories := SystemOrganization categoriesMatching: categoriesMatchString.
-	categories do: [ :category |
-		(SystemOrganization listAtCategoryNamed: category) do: [ :behavior |
-			SystemOrganization removeElement: behavior ] ]
+	categoriesMatchString := self defaultPackageName , '-*'.
+	categories := SystemOrganization packageNamesMatching: categoriesMatchString.
+	categories do: [ :category | (SystemOrganization listAtCategoryNamed: category) do: [ :behavior | SystemOrganization removeElement: behavior ] ]
 ]
 
 { #category : #accessing }

--- a/src/Fuel-Tests-Core/FLClassFactoryForTestCase.class.st
+++ b/src/Fuel-Tests-Core/FLClassFactoryForTestCase.class.st
@@ -153,9 +153,8 @@ FLClassFactoryForTestCase >> deleteClasses [
 
 { #category : #'private-cleaning' }
 FLClassFactoryForTestCase >> deletePackage [
-	| categoriesMatchString |
-	categoriesMatchString := self defaultPackageName, '-*'.
-	SystemOrganization removeCategoriesMatching: categoriesMatchString
+
+	SystemOrganization removePackageNamesMatching: self defaultPackageName , '-*'
 ]
 
 { #category : #'private-cleaning' }

--- a/src/Fuel-Tests-Core/FLClassFactoryForTestCase.class.st
+++ b/src/Fuel-Tests-Core/FLClassFactoryForTestCase.class.st
@@ -67,9 +67,8 @@ FLClassFactoryForTestCase >> cleanUpChangeSetForClassNames: classeNames [
 
 { #category : #'private-cleaning' }
 FLClassFactoryForTestCase >> cleanUpSystemOrganization [
-	"This method is necessary because we create classes in a non-default environment. The
-	SystemOrganization is global and ClassFactoryForTestCase interacts with it to clean out
-	categories."
+	"This method is necessary because we create classes in a non-default environment.
+	The SystemOrganization is global and ClassFactoryForTestCase interacts with it to clean out the packages."
 
 	(SystemOrganization packageNamesMatching: self defaultPackageName , '-*') do: [ :packageName |
 		(SystemOrganization classNamesInPackageNamed: packageName) do: [ :behavior | SystemOrganization removeElement: behavior ] ]

--- a/src/Fuel-Tests-Core/FLClassFactoryForTestCase.class.st
+++ b/src/Fuel-Tests-Core/FLClassFactoryForTestCase.class.st
@@ -71,10 +71,8 @@ FLClassFactoryForTestCase >> cleanUpSystemOrganization [
 	SystemOrganization is global and ClassFactoryForTestCase interacts with it to clean out
 	categories."
 
-	| categoriesMatchString categories |
-	categoriesMatchString := self defaultPackageName , '-*'.
-	categories := SystemOrganization packageNamesMatching: categoriesMatchString.
-	categories do: [ :category | (SystemOrganization listAtCategoryNamed: category) do: [ :behavior | SystemOrganization removeElement: behavior ] ]
+	(SystemOrganization packageNamesMatching: self defaultPackageName , '-*') do: [ :packageName |
+		(SystemOrganization classNamesInPackageNamed: packageName) do: [ :behavior | SystemOrganization removeElement: behavior ] ]
 ]
 
 { #category : #accessing }

--- a/src/Fuel-Tests-Core/FLFullBasicSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLFullBasicSerializationTest.class.st
@@ -101,9 +101,8 @@ FLFullBasicSerializationTest >> testCreateClassWithChangedSuperclassFormat [
 FLFullBasicSerializationTest >> testMethodDictionaries [
 	"Tests correct serialization of all the method dictionaries in the System package."
 
-	(SystemOrganization categoriesMatching: 'System*') do: [ :category |
-		(SystemOrganization classesInCategory: category) do: [ :class |
-			self resultOfSerializeAndMaterializeMethodDictionary: class methodDictionary ] ]
+	(SystemOrganization packageNamesMatching: 'System*') do: [ :category |
+		(SystemOrganization classesInCategory: category) do: [ :class | self resultOfSerializeAndMaterializeMethodDictionary: class methodDictionary ] ]
 ]
 
 { #category : #tests }

--- a/src/Fuel-Tests-Core/FLFullBasicSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLFullBasicSerializationTest.class.st
@@ -102,7 +102,7 @@ FLFullBasicSerializationTest >> testMethodDictionaries [
 	"Tests correct serialization of all the method dictionaries in the System package."
 
 	(SystemOrganization packageNamesMatching: 'System*') do: [ :category |
-		(SystemOrganization classesInCategory: category) do: [ :class | self resultOfSerializeAndMaterializeMethodDictionary: class methodDictionary ] ]
+		(SystemOrganization classesInPackageNamed: category) do: [ :class | self resultOfSerializeAndMaterializeMethodDictionary: class methodDictionary ] ]
 ]
 
 { #category : #tests }

--- a/src/Gofer-Core/GoferCleanup.class.st
+++ b/src/Gofer-Core/GoferCleanup.class.st
@@ -18,9 +18,8 @@ GoferCleanup >> cleanup: aWorkingCopy [
 { #category : #cleaning }
 GoferCleanup >> cleanupCategories: aWorkingCopy [
 
-	aWorkingCopy packageSet systemCategories do: [ :category |
-		(Smalltalk organization classesInCategory: category) isEmpty
-			ifTrue: [ Smalltalk organization removeSystemCategory: category ] ]
+	aWorkingCopy packageSet systemCategories do: [ :packageName |
+		(Smalltalk organization classesInPackageNamed: packageName) isEmpty ifTrue: [ Smalltalk organization removeSystemCategory: packageName ] ]
 ]
 
 { #category : #cleaning }

--- a/src/Gofer-Core/GoferCleanup.class.st
+++ b/src/Gofer-Core/GoferCleanup.class.st
@@ -32,7 +32,7 @@ GoferCleanup >> cleanupProtocols: aWorkingCopy [
 
 	aWorkingCopy packageSet classesAndMetaClasses do: [ :class |
 		(aWorkingCopy packageSet coreCategoriesForClass: class) do: [ :category |
-			(class organization listAtCategoryNamed: category) isEmpty ifTrue: [ class organization removeProtocolNamed: category ] ] ]
+			(class organization methodsInProtocolNamed: category) isEmpty ifTrue: [ class organization removeProtocolNamed: category ] ] ]
 ]
 
 { #category : #running }

--- a/src/Gofer-Core/GoferCleanup.class.st
+++ b/src/Gofer-Core/GoferCleanup.class.st
@@ -19,7 +19,7 @@ GoferCleanup >> cleanup: aWorkingCopy [
 GoferCleanup >> cleanupCategories: aWorkingCopy [
 
 	aWorkingCopy packageSet systemCategories do: [ :packageName |
-		(Smalltalk organization classesInPackageNamed: packageName) isEmpty ifTrue: [ Smalltalk organization removeSystemCategory: packageName ] ]
+		(Smalltalk organization classesInPackageNamed: packageName) ifEmpty: [ Smalltalk organization removeFromSystemPackageName: packageName ] ]
 ]
 
 { #category : #cleaning }

--- a/src/Gofer-Tests/GoferOperationTest.class.st
+++ b/src/Gofer-Tests/GoferOperationTest.class.st
@@ -89,7 +89,7 @@ GoferOperationTest >> testCleanup [
 	class organization addProtocolNamed: #empty.
 	class class organization addProtocolNamed: #empty.
 	gofer cleanup.
-	self deny: (Smalltalk organization categories includes: #'GoferFoo-Empty').
+	self deny: (Smalltalk organization packageNames includes: #'GoferFoo-Empty').
 	self deny: (class organization protocolNames includes: #'GoferFoo-Empty').
 	self deny: (class class organization protocolNames includes: #'GoferFoo-Empty')
 ]

--- a/src/Gofer-Tests/GoferOperationTest.class.st
+++ b/src/Gofer-Tests/GoferOperationTest.class.st
@@ -85,7 +85,7 @@ GoferOperationTest >> testCleanup [
 		package: 'GoferFoo';
 		load.
 	class := environment classNamed: #GoferFoo.
-	environment organization addCategory: #'GoferFoo-Empty'.
+	environment organization addPackageNamed: #'GoferFoo-Empty'.
 	class organization addProtocolNamed: #empty.
 	class class organization addProtocolNamed: #empty.
 	gofer cleanup.

--- a/src/JenkinsTools-Core/HDReport.class.st
+++ b/src/JenkinsTools-Core/HDReport.class.st
@@ -13,8 +13,9 @@ HDReport class >> runCategories: aCollectionOfStrings [
 ]
 
 { #category : #running }
-HDReport class >> runCategory: aString [
-	^ self runClasses: (Smalltalk organization classesInCategory: aString) named: aString
+HDReport class >> runCategory: packageName [
+
+	^ self runClasses: (Smalltalk organization classesInPackageNamed: packageName) named: packageName
 ]
 
 { #category : #running }

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -281,12 +281,10 @@ Class >> category [
 	(latter is much more expensive)"
 
 	| result |
-	self basicCategory ifNotNil: [ :symbol |
-		((self environment organization listAtCategoryNamed: symbol) includes: self name)
-			ifTrue: [ ^symbol ] ].
-	result := (self environment organization categoryOfElement: self name)
-		ifNil: [ #Unclassified ]
-		ifNotNil: [:value | value].
+	self basicCategory ifNotNil: [ :symbol | ((self environment organization classNamesInPackageNamed: symbol) includes: self name) ifTrue: [ ^ symbol ] ].
+	result := (self environment organization packageNameOfElement: self name)
+		          ifNil: [ #Unclassified ]
+		          ifNotNil: [ :value | value ].
 	self basicCategory: result.
 
 	^ result

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -19,13 +19,6 @@ ClassOrganization class >> forClass: aClass [
 		yourself
 ]
 
-{ #category : #deprecated }
-ClassOrganization >> addCategory: aString [
-
-	self deprecated: 'Use #addProtocolNamed: instead.' transformWith: '`@rcv addCategory: `@arg' -> '`@rcv addProtocolNamed: `@arg'.
-	self addProtocolNamed: aString
-]
-
 { #category : #accessing }
 ClassOrganization >> addProtocolNamed: protocolName [
 

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -19,6 +19,13 @@ ClassOrganization class >> forClass: aClass [
 		yourself
 ]
 
+{ #category : #deprecated }
+ClassOrganization >> addCategory: aString [
+
+	self deprecated: 'Use #addProtocolNamed: instead.' transformWith: '`@rcv addCategory: `@arg' -> '`@rcv addProtocolNamed: `@arg'.
+	self addProtocolNamed: aString
+]
+
 { #category : #accessing }
 ClassOrganization >> addProtocolNamed: protocolName [
 

--- a/src/Metacello-PharoCommonPlatform/MetacelloPharoCommonPlatform.class.st
+++ b/src/Metacello-PharoCommonPlatform/MetacelloPharoCommonPlatform.class.st
@@ -48,7 +48,7 @@ MetacelloPharoCommonPlatform >> copyClass: oldClass as: newName inCategory: newC
 		ifTrue: [ ^ self error: copysName , ' already exists' ].
 	newDefinition := oldClass definition copyReplaceAll: '#' , oldClass name asString with: '#' , copysName asString printString.
 	newDefinition := newDefinition
-		copyReplaceAll: 'category: ' , (SystemOrganization categoryOfElement: oldClass name) asString printString
+		copyReplaceAll: 'category: ' , (SystemOrganization packageNameOfElement: oldClass name) asString printString
 		with: 'category: ' , newCategoryName printString.
 	class := self compiler logged: true; evaluate: newDefinition.
 	class class instanceVariableNames: oldClass class instanceVariablesString.

--- a/src/Monticello-Tests/MCOrganizationTest.class.st
+++ b/src/Monticello-Tests/MCOrganizationTest.class.st
@@ -6,9 +6,10 @@ Class {
 
 { #category : #tests }
 MCOrganizationTest >> testLoadAndUnload [
+
 	| category |
 	category := 'TestPackageToUnload'.
-	SystemOrganization addCategory: category.
+	SystemOrganization addPackageNamed: category.
 	(MCOrganizationDefinition categories: { category }) unload.
 	self deny: (SystemOrganization includesCategory: category)
 ]

--- a/src/Monticello-Tests/MCOrganizationTest.class.st
+++ b/src/Monticello-Tests/MCOrganizationTest.class.st
@@ -11,7 +11,7 @@ MCOrganizationTest >> testLoadAndUnload [
 	category := 'TestPackageToUnload'.
 	SystemOrganization addPackageNamed: category.
 	(MCOrganizationDefinition categories: { category }) unload.
-	self deny: (SystemOrganization includesCategory: category)
+	self deny: (SystemOrganization includesPackageNamed: category)
 ]
 
 { #category : #tests }

--- a/src/Monticello-Tests/MCStWriterTest.class.st
+++ b/src/Monticello-Tests/MCStWriterTest.class.st
@@ -124,7 +124,7 @@ MCMethodDeclaration className: #MCMockClassD selector: #one category: #''''as ye
 
 { #category : #data }
 MCStWriterTest >> expectedOrganizationDefinition [
-	^ 'SystemOrganization addCategory: #MonticelloMocks!
+	^ 'SystemOrganization addPackageNamed: #MonticelloMocks!
 '
 ]
 

--- a/src/Monticello-Tests/RPackageCategorySynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageCategorySynchronisationTest.class.st
@@ -49,7 +49,7 @@ RPackageCategorySynchronisationTest >> testRenameCategoryAlsoRenameAllExtensionP
 	self createMethodNamed: 'longNameExtensionFromXInClassInY' inClass: classInY inCategory: '*XXXXX-subcategory'.
 	self createMethodNamed: 'extensionFromXInClassInZ' inClass: classInZ inCategory: '*XXXXX'.
 
-	Smalltalk organization renameCategory: 'XXXXX' toBe: 'NewCategoryName'.
+	Smalltalk organization renamePackageNamed: 'XXXXX' to: 'NewCategoryName'.
 
 	self assert: XPackage name equals: 'NewCategoryName'.
 	self assert: (classInY >> #extensionFromXInClassInY) category equals: '*NewCategoryName'.
@@ -65,7 +65,7 @@ RPackageCategorySynchronisationTest >> testRenameCategoryChangeTheNameOfThePacka
 	self addXCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
 
-	Smalltalk organization renameCategory: 'XXXXX' toBe: 'YYYYY'.
+	Smalltalk organization renamePackageNamed: 'XXXXX' to: 'YYYYY'.
 	self assert: XPackage name equals: 'YYYYY'
 ]
 
@@ -77,7 +77,7 @@ RPackageCategorySynchronisationTest >> testRenameCategoryUpdateTheOrganizer [
 	self addXCategory.
 
 	XPackage := self organizer packageNamed: #XXXXX.
-	Smalltalk organization renameCategory: 'XXXXX' toBe: 'YYYYY'.
+	Smalltalk organization renamePackageNamed: 'XXXXX' to: 'YYYYY'.
 	self assert: (self organizer packageNamed: 'YYYYY' asSymbol) equals: XPackage.
 	self deny: (self organizer includesPackageNamed: #XXXXX)
 ]
@@ -85,11 +85,9 @@ RPackageCategorySynchronisationTest >> testRenameCategoryUpdateTheOrganizer [
 { #category : #'tests - operations on categories' }
 RPackageCategorySynchronisationTest >> testRenameUnknownCategoryCreatesNewRPackage [
 	"test that when we rename a category that is not registered in RPackage , it does not raise errors and simply create a new package. We need this behaviour as for now, create a new category with the class browser does not emit the corrects events, and therefore RPackage can not be directly updated"
-	
-	SystemAnnouncer uniqueInstance suspendAllWhile: [
-		self addXCategory.
-		].
+
+	SystemAnnouncer uniqueInstance suspendAllWhile: [ self addXCategory ].
 	self deny: (self organizer includesPackageNamed: #XXXXX).
-	Smalltalk organization renameCategory: 'XXXXX' toBe: 'YYYYY'.
-	self assert: (self organizer includesPackageNamed: #YYYYY).
+	Smalltalk organization renamePackageNamed: 'XXXXX' to: 'YYYYY'.
+	self assert: (self organizer includesPackageNamed: #YYYYY)
 ]

--- a/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
@@ -494,36 +494,37 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRemovingExtensionCate
 ]
 
 { #category : #'tests - operations on protocols' }
-RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingClassicCategoryToExtensionCategoryMoveAllMethodsFromParentPackageToExtendingPackage [	 
+RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingClassicCategoryToExtensionCategoryMoveAllMethodsFromParentPackageToExtendingPackage [
 	"test that when we reoganized a class by renaming a  classic category (a category not beginning with '*') to an extension category, all the methods are moved from the  parent package of the class to the extending package"
-	|XPackage YPackage class| 
+
+	| XPackage YPackage class |
 	self addXYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
-	YPackage  := self organizer packageNamed: #YYYYY.
+	YPackage := self organizer packageNamed: #YYYYY.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	
-	self createMethodNamed: 'stubMethod' inClass: class  inCategory: 'classic category'.
-	self createMethodNamed: 'stubMethod2' inClass: class  inCategory: 'classic category'.
-	
-	class organization renameCategory: 'classic category' toBe: '*yyyyy'.
-	
+
+	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
+	self createMethodNamed: 'stubMethod2' inClass: class inCategory: 'classic category'.
+
+	class organization renameProtocolNamed: 'classic category' toBe: '*yyyyy'.
+
 	self assert: (YPackage includesExtensionSelector: #stubMethod ofClass: class).
 	self assert: (YPackage includesExtensionSelector: #stubMethod2 ofClass: class).
 	self deny: (XPackage includesDefinedSelector: #stubMethod ofClass: class).
-	self deny: (XPackage includesDefinedSelector: #stubMethod2 ofClass: class).
+	self deny: (XPackage includesDefinedSelector: #stubMethod2 ofClass: class)
 ]
 
 { #category : #'tests - operations on protocols' }
 RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingClassicCategoryToExtensionCategoryMoveMethodsFromParentPackageToExtendingPackage [
 	"test that when we reoganized a class by renaming a  classic category (a category not beginning with '*') to an extension category, all the methods are moved from the  parent package of the class to the extending package"
 
-	|XPackage YPackage class| 
+	| XPackage YPackage class |
 	self addXYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
-	YPackage  := self organizer packageNamed: #YYYYY.
+	YPackage := self organizer packageNamed: #YYYYY.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	self createMethodNamed: 'stubMethod' inClass: class  inCategory: 'classic category'.
-	class organization renameCategory: 'classic category' toBe: '*yyyyy'.
+	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
+	class organization renameProtocolNamed: 'classic category' toBe: '*yyyyy'.
 	self assert: (YPackage includesExtensionSelector: #stubMethod ofClass: class).
 	self deny: (XPackage includesDefinedSelector: #stubMethod ofClass: class)
 ]
@@ -531,15 +532,15 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingClassicCatego
 { #category : #'tests - operations on protocols' }
 RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingExtensionCategoryToAnotherExtensionCategoryAddMethodsToTheNewPackage [
 	"test that when we reoganized a class by renaming an extension category (a category beginning with '*') to another extension category, all the methods are moved to the new extendingPackage"
-	
-	|XPackage YPackage ZPackage class| 
+
+	| XPackage YPackage ZPackage class |
 	self addXYZCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
-	YPackage  := self organizer packageNamed: #YYYYY.
-	ZPackage  := self organizer packageNamed: #ZZZZZ.
+	YPackage := self organizer packageNamed: #YYYYY.
+	ZPackage := self organizer packageNamed: #ZZZZZ.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	self createMethodNamed: 'stubMethod' inClass: class  inCategory: '*yyyyy'.
-	class organization renameCategory: '*yyyyy' toBe: '*zzzzz'.
+	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
+	class organization renameProtocolNamed: '*yyyyy' toBe: '*zzzzz'.
 	self assert: (ZPackage includesExtensionSelector: #stubMethod ofClass: class).
 	self deny: (YPackage includesExtensionSelector: #stubMethod ofClass: class).
 	self deny: (XPackage includesDefinedSelector: #stubMethod ofClass: class)
@@ -548,35 +549,35 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingExtensionCate
 { #category : #'tests - operations on protocols' }
 RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingExtensionCategoryToClassicCategoryMoveAllMethodsFromExtendingPackageToParentPackage [
 	"test that when we reoganized a class by renaming an extension category (a category beginning with '*') to a classic category, all the methods are moved from the  extendingPackage to the parent package of the class"
-	
-	|XPackage YPackage class| 
+
+	| XPackage YPackage class |
 	self addXYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
-	YPackage  := self organizer packageNamed: #YYYYY.
+	YPackage := self organizer packageNamed: #YYYYY.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	
-	self createMethodNamed: 'stubMethod' inClass: class  inCategory: '*yyyyy'.
-	self createMethodNamed: 'stubMethod2' inClass: class  inCategory: '*yyyyy'.
-	
-	class organization renameCategory: '*yyyyy' toBe: 'classic category'.
-	
+
+	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
+	self createMethodNamed: 'stubMethod2' inClass: class inCategory: '*yyyyy'.
+
+	class organization renameProtocolNamed: '*yyyyy' toBe: 'classic category'.
+
 	self deny: (YPackage includesExtensionSelector: #stubMethod ofClass: class).
 	self deny: (YPackage includesExtensionSelector: #stubMethod2 ofClass: class).
 	self assert: (XPackage includesDefinedSelector: #stubMethod ofClass: class).
-	self assert: (XPackage includesDefinedSelector: #stubMethod2 ofClass: class).
+	self assert: (XPackage includesDefinedSelector: #stubMethod2 ofClass: class)
 ]
 
 { #category : #'tests - operations on protocols' }
 RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingExtensionCategoryToClassicCategoryMoveMethodsFromExtendingPackageToParentPackage [
 	"test that when we reoganized a class by renaming an extension category (a category beginning with '*') to a classic category, all the methods are moved from the  extendingPackage to the parent package of the class"
-	
-	|XPackage YPackage class| 
+
+	| XPackage YPackage class |
 	self addXYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
-	YPackage  := self organizer packageNamed: #YYYYY.
+	YPackage := self organizer packageNamed: #YYYYY.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	self createMethodNamed: 'stubMethod' inClass: class  inCategory: '*yyyyy'.
-	class organization renameCategory: '*yyyyy' toBe: 'classic category'.
+	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
+	class organization renameProtocolNamed: '*yyyyy' toBe: 'classic category'.
 	self deny: (YPackage includesExtensionSelector: #stubMethod ofClass: class).
 	self assert: (XPackage includesDefinedSelector: #stubMethod ofClass: class)
 ]

--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -19,12 +19,14 @@ Class {
 
 { #category : #utilities }
 RPackageMCSynchronisationTest >> addXCategory [
-	testingEnvironment organization addCategory: 'XXXXX'.
+
+	testingEnvironment organization addPackageNamed: 'XXXXX'
 ]
 
 { #category : #utilities }
 RPackageMCSynchronisationTest >> addXMatchCategory [
-	testingEnvironment organization addCategory: 'XXXXX-YYYY'.
+
+	testingEnvironment organization addPackageNamed: 'XXXXX-YYYY'
 ]
 
 { #category : #utilities }
@@ -47,15 +49,13 @@ RPackageMCSynchronisationTest >> addXYZCategory [
 { #category : #utilities }
 RPackageMCSynchronisationTest >> addYCategory [
 
-	testingEnvironment organization addCategory: 'YYYYY'.
-			
+	testingEnvironment organization addPackageNamed: 'YYYYY'
 ]
 
 { #category : #utilities }
 RPackageMCSynchronisationTest >> addZCategory [
 
-	testingEnvironment organization addCategory: 'ZZZZZ'.
-			
+	testingEnvironment organization addPackageNamed: 'ZZZZZ'
 ]
 
 { #category : #setup }

--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -61,56 +61,83 @@ RPackageMCSynchronisationTest >> addZCategory [
 { #category : #setup }
 RPackageMCSynchronisationTest >> cleanClassesPackagesAndCategories [
 
-		|mCPackage|
-		Smalltalk removeClassNamed: 'NewClass'.
-		Smalltalk removeClassNamed: 'RPackageNewStubClass'.
-		Smalltalk removeClassNamed: 'RPackageOldStubClass'.
-		Smalltalk removeClassNamed: 'Foo'.
-		Smalltalk removeClassNamed: 'FooOther'.
-		Smalltalk removeClassNamed: 'NewTrait'.
-		Smalltalk removeClassNamed: 'ClassInYPackage'.
-		Smalltalk removeClassNamed: 'ClassInZPackage'.
-		Smalltalk organization removeCategory: 'Zork'.
-		Smalltalk organization removeCategory: 'XXXXX'.
-		Smalltalk organization removeCategory: 'XXXXX-YYYY'.
-		Smalltalk organization removeCategory: 'XXXX'.
-		Smalltalk organization removeCategory: 'YYYYY'.
-		Smalltalk organization removeCategory: 'ZZZZZ'.
-		Smalltalk organization removeCategory: 'FooPackage-Core'.
-		Smalltalk organization removeCategory: 'FooPackage-Other'.
-		Smalltalk organization removeCategory: 'FooPackage'.
-		Smalltalk organization removeCategory: 'OriginalCategory'.
-		Smalltalk organization removeCategory: 'NewCategoryName'.
-		Smalltalk organization removeCategory: 'Y'.
-		mCPackage := (self allManagers detect: [:each | each packageName = 'OriginalCategory'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].
-		mCPackage := (self allManagers detect: [:each | each packageName = 'XXXXX'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].
-		mCPackage := (self allManagers detect: [:each | each packageName = 'XXXX'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].
-		mCPackage := (self allManagers detect: [:each | each packageName = 'YYYYY'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].
-		mCPackage := (self allManagers detect: [:each | each packageName = 'YYYY'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].
-		mCPackage := (self allManagers detect: [:each | each packageName = 'Yyyyy'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].	
-		mCPackage := (self allManagers detect: [:each | each packageName = 'YyYyY'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].
-		mCPackage := (self allManagers detect: [:each | each packageName = 'Y'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].
-		mCPackage := (self allManagers detect: [:each | each packageName = 'ZZZZZ'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].	
-		mCPackage := (self allManagers detect: [:each | each packageName = 'Zzzzz'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].
-		mCPackage := (self allManagers detect: [:each | each packageName = 'FooPackage-Core'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].
-		mCPackage := (self allManagers detect: [:each | each packageName = 'FooPackage-Other'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].
-		mCPackage := (self allManagers detect: [:each | each packageName = 'FooPackage'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].
-		mCPackage := (self allManagers detect: [:each | each packageName = 'Zork'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].
-			
+	| mCPackage |
+	Smalltalk removeClassNamed: 'NewClass'.
+	Smalltalk removeClassNamed: 'RPackageNewStubClass'.
+	Smalltalk removeClassNamed: 'RPackageOldStubClass'.
+	Smalltalk removeClassNamed: 'Foo'.
+	Smalltalk removeClassNamed: 'FooOther'.
+	Smalltalk removeClassNamed: 'NewTrait'.
+	Smalltalk removeClassNamed: 'ClassInYPackage'.
+	Smalltalk removeClassNamed: 'ClassInZPackage'.
+	Smalltalk organization removePackageNamed: 'Zork'.
+	Smalltalk organization removePackageNamed: 'XXXXX'.
+	Smalltalk organization removePackageNamed: 'XXXXX-YYYY'.
+	Smalltalk organization removePackageNamed: 'XXXX'.
+	Smalltalk organization removePackageNamed: 'YYYYY'.
+	Smalltalk organization removePackageNamed: 'ZZZZZ'.
+	Smalltalk organization removePackageNamed: 'FooPackage-Core'.
+	Smalltalk organization removePackageNamed: 'FooPackage-Other'.
+	Smalltalk organization removePackageNamed: 'FooPackage'.
+	Smalltalk organization removePackageNamed: 'OriginalCategory'.
+	Smalltalk organization removePackageNamed: 'NewCategoryName'.
+	Smalltalk organization removePackageNamed: 'Y'.
+	mCPackage := self allManagers
+		             detect: [ :each | each packageName = 'OriginalCategory' ]
+		             ifNone: [ nil ].
+	mCPackage ifNotNil: [ mCPackage unregister ].
+	mCPackage := self allManagers
+		             detect: [ :each | each packageName = 'XXXXX' ]
+		             ifNone: [ nil ].
+	mCPackage ifNotNil: [ mCPackage unregister ].
+	mCPackage := self allManagers
+		             detect: [ :each | each packageName = 'XXXX' ]
+		             ifNone: [ nil ].
+	mCPackage ifNotNil: [ mCPackage unregister ].
+	mCPackage := self allManagers
+		             detect: [ :each | each packageName = 'YYYYY' ]
+		             ifNone: [ nil ].
+	mCPackage ifNotNil: [ mCPackage unregister ].
+	mCPackage := self allManagers
+		             detect: [ :each | each packageName = 'YYYY' ]
+		             ifNone: [ nil ].
+	mCPackage ifNotNil: [ mCPackage unregister ].
+	mCPackage := self allManagers
+		             detect: [ :each | each packageName = 'Yyyyy' ]
+		             ifNone: [ nil ].
+	mCPackage ifNotNil: [ mCPackage unregister ].
+	mCPackage := self allManagers
+		             detect: [ :each | each packageName = 'YyYyY' ]
+		             ifNone: [ nil ].
+	mCPackage ifNotNil: [ mCPackage unregister ].
+	mCPackage := self allManagers
+		             detect: [ :each | each packageName = 'Y' ]
+		             ifNone: [ nil ].
+	mCPackage ifNotNil: [ mCPackage unregister ].
+	mCPackage := self allManagers
+		             detect: [ :each | each packageName = 'ZZZZZ' ]
+		             ifNone: [ nil ].
+	mCPackage ifNotNil: [ mCPackage unregister ].
+	mCPackage := self allManagers
+		             detect: [ :each | each packageName = 'Zzzzz' ]
+		             ifNone: [ nil ].
+	mCPackage ifNotNil: [ mCPackage unregister ].
+	mCPackage := self allManagers
+		             detect: [ :each | each packageName = 'FooPackage-Core' ]
+		             ifNone: [ nil ].
+	mCPackage ifNotNil: [ mCPackage unregister ].
+	mCPackage := self allManagers
+		             detect: [ :each | each packageName = 'FooPackage-Other' ]
+		             ifNone: [ nil ].
+	mCPackage ifNotNil: [ mCPackage unregister ].
+	mCPackage := self allManagers
+		             detect: [ :each | each packageName = 'FooPackage' ]
+		             ifNone: [ nil ].
+	mCPackage ifNotNil: [ mCPackage unregister ].
+	mCPackage := self allManagers
+		             detect: [ :each | each packageName = 'Zork' ]
+		             ifNone: [ nil ].
+	mCPackage ifNotNil: [ mCPackage unregister ]
 ]
 
 { #category : #private }

--- a/src/Monticello-Tests/RPackageMonticelloSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMonticelloSynchronisationTest.class.st
@@ -20,15 +20,12 @@ RPackageMonticelloSynchronisationTest >> testAddMCPackageCreatesAPackage [
 { #category : #'tests - operations on MCPackages' }
 RPackageMonticelloSynchronisationTest >> testAddMCPackageForCategoryAlreadyExistingDoesNotCreateAPackage [
 	"test that when we create a MCPackage and that a category of this name already exists, no package is created"
- 
-	|tmpPackage|
-	testingEnvironment organization addCategory: 'Zork'.
+
+	| tmpPackage |
+	testingEnvironment organization addPackageNamed: 'Zork'.
 	tmpPackage := self organizer packageNamed: #Zork.
 	MCWorkingCopy forPackage: (MCPackage new name: #Zork).
-	self assert: tmpPackage equals: (self organizer packageNamed: #Zork).
-		
-		
-					  
+	self assert: tmpPackage equals: (self organizer packageNamed: #Zork)
 ]
 
 { #category : #'tests - operations on MCPackages' }

--- a/src/Monticello/MCOrganizationDefinition.class.st
+++ b/src/Monticello/MCOrganizationDefinition.class.st
@@ -147,5 +147,5 @@ MCOrganizationDefinition >> summary [
 { #category : #unloading }
 MCOrganizationDefinition >> unload [
 
-	categories do: [ :pacakgeName | (SystemOrganization listAtCategoryNamed: pacakgeName) ifEmpty: [ SystemOrganization removePackageNamed: pacakgeName ] ]
+	categories do: [ :pacakgeName | (SystemOrganization classNamesInPackageNamed: pacakgeName) ifEmpty: [ SystemOrganization removePackageNamed: pacakgeName ] ]
 ]

--- a/src/Monticello/MCOrganizationDefinition.class.st
+++ b/src/Monticello/MCOrganizationDefinition.class.st
@@ -147,5 +147,5 @@ MCOrganizationDefinition >> summary [
 { #category : #unloading }
 MCOrganizationDefinition >> unload [
 
-	categories do: [ :pacakgeName | (SystemOrganization isEmptyCategoryNamed: pacakgeName) ifTrue: [ SystemOrganization removePackageNamed: pacakgeName ] ]
+	categories do: [ :pacakgeName | (SystemOrganization listAtCategoryNamed: pacakgeName) ifEmpty: [ SystemOrganization removePackageNamed: pacakgeName ] ]
 ]

--- a/src/Monticello/MCOrganizationDefinition.class.st
+++ b/src/Monticello/MCOrganizationDefinition.class.st
@@ -147,5 +147,5 @@ MCOrganizationDefinition >> summary [
 { #category : #unloading }
 MCOrganizationDefinition >> unload [
 
-	categories do: [ :pacakgeName | (SystemOrganization classNamesInPackageNamed: pacakgeName) ifEmpty: [ SystemOrganization removePackageNamed: pacakgeName ] ]
+	categories do: [ :packageName | (SystemOrganization classNamesInPackageNamed: packageName) ifEmpty: [ SystemOrganization removePackageNamed: packageName ] ]
 ]

--- a/src/Monticello/MCOrganizationDefinition.class.st
+++ b/src/Monticello/MCOrganizationDefinition.class.st
@@ -146,8 +146,6 @@ MCOrganizationDefinition >> summary [
 
 { #category : #unloading }
 MCOrganizationDefinition >> unload [
-	categories
-		do: [ :category | 
-			(SystemOrganization isEmptyCategoryNamed: category)
-				ifTrue: [ SystemOrganization removeCategory: category ] ]
+
+	categories do: [ :pacakgeName | (SystemOrganization isEmptyCategoryNamed: pacakgeName) ifTrue: [ SystemOrganization removePackageNamed: pacakgeName ] ]
 ]

--- a/src/Monticello/MCStReader.class.st
+++ b/src/Monticello/MCStReader.class.st
@@ -126,11 +126,10 @@ MCStReader >> readStream [
 
 { #category : #reading }
 MCStReader >> systemOrganizationFromRecords: changeRecords [
-	| categories |
-	categories := changeRecords
-					select: [:ea | 'SystemOrganization*' match: ea string]
-					thenCollect: [:ea | (self categoryFromDoIt: ea string)].
-	^ categories isEmpty ifFalse: [MCOrganizationDefinition categories: categories asArray]
+
+	^ (changeRecords
+		   select: [ :ea | 'SystemOrganization*' match: ea string ]
+		   thenCollect: [ :ea | self categoryFromDoIt: ea string ]) ifNotEmpty: [ :packageNames | MCOrganizationDefinition categories: packageNames asArray ]
 ]
 
 { #category : #reading }

--- a/src/Monticello/MCStWriter.class.st
+++ b/src/Monticello/MCStWriter.class.st
@@ -95,9 +95,10 @@ MCStWriter >> visitTraitDefinition: definition [
 ]
 
 { #category : #writing }
-MCStWriter >> writeCategory: categoryName [
+MCStWriter >> writeCategory: packageName [
+
 	stream
-		nextChunkPut: 'SystemOrganization addCategory: ', categoryName printString;
+		nextChunkPut: 'SystemOrganization addPackageNamed: ' , packageName printString;
 		cr
 ]
 

--- a/src/Morphic-Base/Object.extension.st
+++ b/src/Morphic-Base/Object.extension.st
@@ -117,18 +117,18 @@ Object class >> taskbarIcon [
 ]
 
 { #category : #'*Morphic-Base' }
+Object class >> taskbarIconName [
+	"Answer the icon for an instance of the receiver in a task bar"
+
+	^#smallWindow
+]
+
+{ #category : #'*Morphic-Base' }
 Object >> taskbarIconName [
 	"Answer the icon for the receiver in a task bar
 	or nil for the default."
 
 	^self class taskbarIconName
-]
-
-{ #category : #'*Morphic-Base' }
-Object class >> taskbarIconName [
-	"Answer the icon for an instance of the receiver in a task bar"
-
-	^#smallWindow
 ]
 
 { #category : #'*Morphic-Base' }

--- a/src/Morphic-Base/StringMorph.class.st
+++ b/src/Morphic-Base/StringMorph.class.st
@@ -85,14 +85,14 @@ StringMorph class >> exampleFullEmphaisedString [
 { #category : #examples }
 StringMorph class >> exampleManyStringMorphs [
 	"Return a morph with lots of strings for testing display speed."
-	<sampleInstance>
 
+	<sampleInstance>
 	| c |
 	c := AlignmentMorph newColumn.
-	self class environment organization categories do:
-		[:cat | c addMorph: (StringMorph new contents: cat)].
-	^ c position: 100@50;
-			openInWorld
+	self class environment organization packageNames do: [ :packageName | c addMorph: (StringMorph new contents: packageName) ].
+	^ c
+		  position: 100 @ 50;
+		  openInWorld
 ]
 
 { #category : #editing }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -1442,7 +1442,7 @@ RPackage >> selectorsForClass: aClass [
 { #category : #'system compatibility' }
 RPackage >> systemCategories [
 
-	^ self systemOrganization categories select: [:cat | self includesSystemCategory: cat]
+	^ self systemOrganization packageNames select: [ :cat | self includesSystemCategory: cat ]
 ]
 
 { #category : #'system compatibility' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -1377,30 +1377,25 @@ RPackage >> renameTagsPrefixedWith: oldName to: newName [
 RPackage >> renameTo: aSymbol [
 	"Rename a package with a different name, provided as a symbol"
 
-	| oldName newName oldCategoryNames repositoryGroup |
+	| oldName newName oldPackageNames repositoryGroup |
 	oldName := self name.
 	newName := aSymbol asSymbol.
 	repositoryGroup := self mcPackage workingCopy repositoryGroup.
 	self organizer validatePackageDoesNotExist: aSymbol.
-	oldCategoryNames := (self classTags collect: [:each | each categoryName] as: Set)
-		add: self name;
-		difference: {newName}.
+	oldPackageNames := (self classTags collect: [ :each | each categoryName ] as: Set)
+		                   add: self name;
+		                   difference: { newName }.
 	self name: aSymbol.
-	SystemAnnouncer uniqueInstance
-		suspendAllWhile: [ self definedClasses
-				do:
-					[ :each | each category: newName , (each category allButFirst: oldName size) ].
-			oldCategoryNames
-				do: [ :each | SystemOrganizer default removeCategory: each ] ].
+	SystemAnnouncer uniqueInstance suspendAllWhile: [
+		self definedClasses do: [ :each | each category: newName , (each category allButFirst: oldName size) ].
+		oldPackageNames do: [ :packageName | SystemOrganizer default removePackageNamed: packageName ] ].
 	self renameTagsPrefixedWith: oldName to: newName.
 	self renameExtensionsPrefixedWith: oldName to: newName.
 	self organizer
 		basicUnregisterPackageNamed: oldName;
 		basicRegisterPackage: self.
 	self mcPackage workingCopy repositoryGroup: repositoryGroup.
-	SystemAnnouncer uniqueInstance
-		announce:
-			(RPackageRenamed to: self oldName: oldName newName: newName)
+	SystemAnnouncer uniqueInstance announce: (RPackageRenamed to: self oldName: oldName newName: newName)
 ]
 
 { #category : #private }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -143,13 +143,11 @@ RPackageOrganizer class >> isPackageDefinedForClass: aClass [
 RPackageOrganizer class >> methodAdded: anEvent [
 	"precondition: package exist, class exist"
 
-	| methodCategory |
-	methodCategory := anEvent protocol.
-	(methodCategory isEmptyOrNil or:[ methodCategory first ~= $* ])
-		ifFalse: [
-			(self isPackageDefinedForClass: anEvent methodClass)
-					ifFalse: [self packageClass new named: (Smalltalk organization categoryOfElement: anEvent methodClass instanceSide asSymbol) ].
-		]
+	| methodProtocol |
+	methodProtocol := anEvent protocol.
+	(methodProtocol isEmptyOrNil or: [ methodProtocol first ~= $* ]) ifFalse: [
+		(self isPackageDefinedForClass: anEvent methodClass) ifFalse: [
+			self packageClass new named: (Smalltalk organization packageNameOfElement: anEvent methodClass instanceSide asSymbol) ] ]
 ]
 
 { #category : #private }

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -209,6 +209,7 @@ RPackageTag >> removeFromPackage [
 
 { #category : #accessing }
 RPackageTag >> renameTo: newTagName [
+
 	| oldName categoryName tagName |
 	tagName := self name.
 	oldName := self toCategoryName: tagName.
@@ -219,28 +220,21 @@ RPackageTag >> renameTo: newTagName [
 	self basicRenameTo: newTagName.
 	SystemAnnouncer uniqueInstance suspendAllWhile: [
 		self classes do: [ :each | each category: categoryName ].
-		self class environment organization
-			renameCategory: oldName
-			toBe: categoryName].
-	SystemAnnouncer uniqueInstance
-		classTagRenamed: tagName
-		inPackage: self package
-		to: newTagName
+		self class environment organization renamePackageNamed: oldName to: categoryName ].
+	SystemAnnouncer uniqueInstance classTagRenamed: tagName inPackage: self package to: newTagName
 ]
 
 { #category : #accessing }
 RPackageTag >> renameTo: aString category: categoryName [
-	| oldName |
 
+	| oldName |
 	oldName := self toCategoryName: self name.
 	oldName = categoryName ifTrue: [ ^ self ].
 
 	self basicRenameTo: aString.
 	SystemAnnouncer uniqueInstance suspendAllWhile: [
 		self classes do: [ :each | each category: categoryName ].
-		self class environment organization
-			renameCategory: oldName
-			toBe: categoryName. ]
+		self class environment organization renamePackageNamed: oldName to: categoryName ]
 ]
 
 { #category : #private }

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -74,7 +74,8 @@ RPackageTag >> classes [
 
 { #category : #accessing }
 RPackageTag >> ensureSystemCategory [
-	SystemOrganization addCategory: self categoryName
+
+	SystemOrganization addPackageNamed: self categoryName
 ]
 
 { #category : #accessing }

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -52,31 +52,25 @@ RPackageIncrementalTest >> setUp [
 RPackageIncrementalTest >> tearDown [
 
 	| logging |
-	createdPackages  do: [:each | self removePackage: each name].
+	createdPackages do: [ :each | self removePackage: each name ].
 	"just remove package from package organizer dictionary"
 
-	createdPackages  do: [:each |
-		|mCPackage|
+	createdPackages do: [ :each |
+		| mCPackage |
 		mCPackage := self allManagers
-							detect: [:mcPackage | mcPackage packageName = each packageName asString]
-							ifNone: [nil].
-		mCPackage ifNotNil: [mCPackage unregister].
-		each extendedClasses do: [ :extendedClass|
-			self packageClass organizer
-		 		unregisterExtendingPackage: each forClass: extendedClass.]].
+			             detect: [ :mcPackage | mcPackage packageName = each packageName asString ]
+			             ifNone: [ nil ].
+		mCPackage ifNotNil: [ mCPackage unregister ].
+		each extendedClasses do: [ :extendedClass | self packageClass organizer unregisterExtendingPackage: each forClass: extendedClass ] ].
 	"all ***extending*** classes the packages are also unregistered from PackageOrganizer"
-	(createdClasses reject: [:c| c isObsolete]) do: [:cls|
-		"(RPackage organizer includesPackageBackPointerForClass: cls)
+	(createdClasses reject: [ :c | c isObsolete ]) do: [ :cls | "(RPackage organizer includesPackageBackPointerForClass: cls)
 			ifTrue: [cls package unregisterClass: cls.].
 		when RPackageOrganizer was not looking at system event we had to do the commented actions"
 		logging := false.
-		cls removeFromSystem: logging.
+		cls removeFromSystem: logging
 		"not logging so no event are raised"
-		"but this also means that the consistency cannot be ensured by internal system announcer too."
-		].
-	createdCategories do: [:each |
-		SystemOrganization removeCategory: each.
-		 ].
+		"but this also means that the consistency cannot be ensured by internal system announcer too." ].
+	createdCategories do: [ :packageName | SystemOrganization removePackageNamed: packageName ].
 	super tearDown
 ]
 

--- a/src/Refactoring-Environment/RBBrowserEnvironment.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironment.class.st
@@ -193,7 +193,8 @@ RBBrowserEnvironment >> cachedResultOf: aQuery [
 
 { #category : #accessing }
 RBBrowserEnvironment >> categories [
-	^ self systemDictionary organization categories select: [ :each | self includesCategory: each ]
+
+	^ self systemDictionary organization packageNames select: [ :each | self includesCategory: each ]
 ]
 
 { #category : #'accessing - classes' }

--- a/src/Refactoring-Environment/RBBrowserEnvironment.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironment.class.st
@@ -873,7 +873,8 @@ RBBrowserEnvironment >> updateUsing: newUpdateStrategy by: updateBlock [
 
 { #category : #accessing }
 RBBrowserEnvironment >> whichCategoryIncludes: aClassName [
-	^ self systemDictionary organization categoryOfElement: aClassName
+
+	^ self systemDictionary organization packageNameOfElement: aClassName
 ]
 
 { #category : #accessing }

--- a/src/Refactoring-Environment/RBBrowserEnvironment.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironment.class.st
@@ -206,13 +206,12 @@ RBBrowserEnvironment >> classNames [
 ]
 
 { #category : #accessing }
-RBBrowserEnvironment >> classNamesFor: aCategoryName [
-	^ (self systemDictionary organization listAtCategoryNamed: aCategoryName) select: [ :each |
-		| class |
-		class := self systemDictionary at: each ifAbsent: [ nil ].
-		class notNil
-			and: [ (self includesClass: class)
-			or: [ self includesClass: class class ] ] ]
+RBBrowserEnvironment >> classNamesFor: packageName [
+
+	^ (self systemDictionary organization classNamesInPackageNamed: packageName) select: [ :className |
+		  | class |
+		  class := self systemDictionary at: className ifAbsent: [ nil ].
+		  class isNotNil and: [ (self includesClass: class) or: [ self includesClass: class class ] ] ]
 ]
 
 { #category : #environments }

--- a/src/Ring-OldChunkImporter/RingChunkImporter.class.st
+++ b/src/Ring-OldChunkImporter/RingChunkImporter.class.st
@@ -17,13 +17,11 @@ Class {
 
 { #category : #examples }
 RingChunkImporter class >> example [
+
 	| internalStream |
 	internalStream := (String new: 1000) writeStream.
-	SystemOrganization
-		fileOutCategory: 'Ring-Deprecated-ChunkImporter-Base'
-		on: internalStream.
-	(RingChunkImporter fromStream: internalStream contents readStream)
-		inspect
+	SystemOrganization fileOutPackageNamed: 'Ring-Deprecated-ChunkImporter-Base' on: internalStream.
+	(RingChunkImporter fromStream: internalStream contents readStream) inspect
 ]
 
 { #category : #'instance creation' }

--- a/src/SUnit-Core/ClassFactoryForTestCase.class.st
+++ b/src/SUnit-Core/ClassFactoryForTestCase.class.st
@@ -128,9 +128,7 @@ ClassFactoryForTestCase >> deleteClasses [
 { #category : #cleaning }
 ClassFactoryForTestCase >> deletePackage [
 
-	| categoriesMatchString |
-	categoriesMatchString := self packageName , '-*'.
-	SystemOrganization removeCategoriesMatching: categoriesMatchString
+	SystemOrganization removePackageNamesMatching: self packageName , '-*'
 ]
 
 { #category : #cleaning }

--- a/src/SUnit-Core/ClassFactoryWithOrganization.class.st
+++ b/src/SUnit-Core/ClassFactoryWithOrganization.class.st
@@ -22,10 +22,8 @@ ClassFactoryWithOrganization class >> newWithOrganization: aSystemOrganizer [
 { #category : #cleaning }
 ClassFactoryWithOrganization >> deletePackage [
 
-	| categoriesMatchString |
-	categoriesMatchString := self packageName , '-*'.
 	self organization
-		removeCategoriesMatching: categoriesMatchString;
+		removePackageNamesMatching: self packageName , '-*';
 		removeEmptyPackages
 ]
 

--- a/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
@@ -56,27 +56,26 @@ ClassFactoryForTestCaseTest >> testClassFastCreationInDifferentCategories [
 
 { #category : #testing }
 ClassFactoryForTestCaseTest >> testDefaultCategoryCleanUp [
-	| createdClassNames allClasses allTraits |
 
+	| createdClassNames allClasses allTraits |
 	3 timesRepeat: [
 		factory newClass.
-		factory newTrait].
+		factory newTrait ].
 
 	createdClassNames := factory createdClassNames.
 
 	factory cleanUp.
 
-	self assert: (factory createdClasses allSatisfy: [:class| class isObsolete]).
-	self assert: (factory createdTraits allSatisfy: [:trait| trait isObsolete]).
+	self assert: (factory createdClasses allSatisfy: [ :class | class isObsolete ]).
+	self assert: (factory createdTraits allSatisfy: [ :trait | trait isObsolete ]).
 
 	allClasses := SystemNavigation new allClasses.
 	allTraits := testingEnvironment allTraits.
 
-	self assert: (factory createdClasses noneSatisfy: [:class| allClasses includes: class]).
-	self assert: (factory createdTraits noneSatisfy: [:trait| allTraits includes: trait]).
-	self deny: (SystemOrganization categories includes: factory defaultCategory).
-	self class environment at: #ChangeSet ifPresent: [:changeSet |
-		self deny: (changeSet current changedClassNames includesAnyOf: createdClassNames) ]
+	self assert: (factory createdClasses noneSatisfy: [ :class | allClasses includes: class ]).
+	self assert: (factory createdTraits noneSatisfy: [ :trait | allTraits includes: trait ]).
+	self deny: (SystemOrganization packageNames includes: factory defaultCategory).
+	self class environment at: #ChangeSet ifPresent: [ :changeSet | self deny: (changeSet current changedClassNames includesAnyOf: createdClassNames) ]
 ]
 
 { #category : #testing }

--- a/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
@@ -101,6 +101,7 @@ ClassFactoryForTestCaseTest >> testMultipleClassCreation [
 
 { #category : #testing }
 ClassFactoryForTestCaseTest >> testPackageCleanUp [
+
 	| createdClassNames allClasses |
 	3 timesRepeat: [ factory newClassInCategory: #One ].
 	2 timesRepeat: [ factory newClassInCategory: #Two ].
@@ -109,7 +110,7 @@ ClassFactoryForTestCaseTest >> testPackageCleanUp [
 	self assert: (factory createdClasses allSatisfy: [ :class | class isObsolete ]).
 	allClasses := SystemNavigation new allClasses.
 	self assert: (factory createdClasses noneSatisfy: [ :class | allClasses includes: class ]).
-	self assertEmpty: (SystemOrganization categoriesMatching: factory packageName , '*').
+	self assertEmpty: (SystemOrganization packageNamesMatching: factory packageName , '*').
 	self class environment at: #ChangeSet ifPresent: [ :changeSet | self deny: (changeSet current changedClassNames includesAnyOf: createdClassNames) ]
 ]
 

--- a/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
@@ -93,10 +93,11 @@ ClassFactoryForTestCaseTest >> testDuplicateClassWithNewName [
 
 { #category : #testing }
 ClassFactoryForTestCaseTest >> testMultipleClassCreation [
+
 	5 timesRepeat: [ factory newClass ].
 	self assert: (SystemNavigation new allClasses includesAll: factory createdClasses).
 	self assert: factory createdClassNames asSet size equals: 5.
-	self assert: (SystemOrganization listAtCategoryNamed: factory defaultCategory) asSet equals: factory createdClassNames asSet
+	self assert: (SystemOrganization classNamesInPackageNamed: factory defaultCategory) asSet equals: factory createdClassNames asSet
 ]
 
 { #category : #testing }
@@ -116,22 +117,24 @@ ClassFactoryForTestCaseTest >> testPackageCleanUp [
 
 { #category : #testing }
 ClassFactoryForTestCaseTest >> testSingleClassCreation [
+
 	| class elementsInCategoryForTest |
 	class := factory newSubclassOf: Object instanceVariableNames: 'a b c' classVariableNames: 'X Y'.
 	self assert: (SystemNavigation new allClasses includes: class).
-	elementsInCategoryForTest := SystemOrganization listAtCategoryNamed: factory defaultCategory.
-	self assert: elementsInCategoryForTest equals: {class name}.
-	self assert: class instVarNames equals: #(a b c).
-	self assert: class classPool keys asSet equals: #(X Y) asSet
+	elementsInCategoryForTest := SystemOrganization classNamesInPackageNamed: factory defaultCategory.
+	self assert: elementsInCategoryForTest equals: { class name }.
+	self assert: class instVarNames equals: #( a b c ).
+	self assert: class classPool keys asSet equals: #( X Y ) asSet
 ]
 
 { #category : #testing }
 ClassFactoryForTestCaseTest >> testSingleClassFastCreation [
+
 	| class elementsInCategoryForTest |
 	class := factory newClass.
 	self assert: (SystemNavigation new allClasses includes: class).
-	elementsInCategoryForTest := SystemOrganization listAtCategoryNamed: factory defaultCategory.
-	self assert: elementsInCategoryForTest equals: {class name}.
+	elementsInCategoryForTest := SystemOrganization classNamesInPackageNamed: factory defaultCategory.
+	self assert: elementsInCategoryForTest equals: { class name }.
 	self assertEmpty: class instVarNames.
 	self assertEmpty: class classPool
 ]

--- a/src/SUnit-Tests/ClassFactoryWithOrganizationTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryWithOrganizationTest.class.st
@@ -55,17 +55,16 @@ ClassFactoryWithOrganizationTest >> testClassFastCreationInDifferentCategories [
 
 { #category : #testing }
 ClassFactoryWithOrganizationTest >> testDefaultCategoryCleanUp [
+
 	| createdClassNames allClasses |
-	3 timesRepeat: [
-		factory newClass].
+	3 timesRepeat: [ factory newClass ].
 	createdClassNames := factory createdClassNames.
 	factory cleanUp.
-	self assert: (factory createdClasses allSatisfy: [:class| class isObsolete]).
+	self assert: (factory createdClasses allSatisfy: [ :class | class isObsolete ]).
 	allClasses := self testedEnvironment allClasses.
-	self assert: (factory createdClasses noneSatisfy: [:class| allClasses includes: class]).
-	self deny: (self testedOrganization categories includes: factory defaultCategory).
-	self class environment at: #ChangeSet ifPresent: [:changeSet |
-		self deny: (changeSet current changedClassNames includesAnyOf: createdClassNames) ]
+	self assert: (factory createdClasses noneSatisfy: [ :class | allClasses includes: class ]).
+	self deny: (self testedOrganization packageNames includes: factory defaultCategory).
+	self class environment at: #ChangeSet ifPresent: [ :changeSet | self deny: (changeSet current changedClassNames includesAnyOf: createdClassNames) ]
 ]
 
 { #category : #testing }

--- a/src/SUnit-Tests/ClassFactoryWithOrganizationTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryWithOrganizationTest.class.st
@@ -69,10 +69,11 @@ ClassFactoryWithOrganizationTest >> testDefaultCategoryCleanUp [
 
 { #category : #testing }
 ClassFactoryWithOrganizationTest >> testMultipleClassCreation [
+
 	5 timesRepeat: [ factory newClass ].
 	self assert: (self testedEnvironment allClasses includesAll: factory createdClasses).
 	self assert: factory createdClassNames asSet size equals: 5.
-	self assert: (self testedOrganization listAtCategoryNamed: factory defaultCategory) asSet equals: factory createdClassNames asSet.
+	self assert: (self testedOrganization classNamesInPackageNamed: factory defaultCategory) asSet equals: factory createdClassNames asSet.
 	factory createdClasses do: [ :aClass | self assertEnvironmentOf: aClass ]
 ]
 
@@ -93,24 +94,26 @@ ClassFactoryWithOrganizationTest >> testPackageCleanUp [
 
 { #category : #testing }
 ClassFactoryWithOrganizationTest >> testSingleClassCreation [
+
 	| class elementsInCategoryForTest |
 	class := factory newSubclassOf: Object instanceVariableNames: 'a b c' classVariableNames: 'X Y'.
 	self assert: (self testedEnvironment allClasses includes: class).
 	factory createdClasses do: [ :aClass | self assertEnvironmentOf: aClass ].
-	elementsInCategoryForTest := self testedOrganization listAtCategoryNamed: factory defaultCategory.
-	self assert: elementsInCategoryForTest equals: {class name}.
-	self assert: class instVarNames equals: #(a b c).
-	self assert: class classPool keys asSet equals: #(X Y) asSet
+	elementsInCategoryForTest := self testedOrganization classNamesInPackageNamed: factory defaultCategory.
+	self assert: elementsInCategoryForTest equals: { class name }.
+	self assert: class instVarNames equals: #( a b c ).
+	self assert: class classPool keys asSet equals: #( X Y ) asSet
 ]
 
 { #category : #testing }
 ClassFactoryWithOrganizationTest >> testSingleClassFastCreation [
+
 	| class elementsInCategoryForTest |
 	class := factory newClass.
 	self assert: (self testedEnvironment allClasses includes: class).
-	elementsInCategoryForTest := self testedOrganization listAtCategoryNamed: factory defaultCategory.
+	elementsInCategoryForTest := self testedOrganization classNamesInPackageNamed: factory defaultCategory.
 	factory createdClasses do: [ :aClass | self assertEnvironmentOf: aClass ].
-	self assert: elementsInCategoryForTest equals: {class name}.
+	self assert: elementsInCategoryForTest equals: { class name }.
 	self assertEmpty: class instVarNames.
 	self assertEmpty: class classPool
 ]

--- a/src/SUnit-Tests/ClassFactoryWithOrganizationTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryWithOrganizationTest.class.st
@@ -78,6 +78,7 @@ ClassFactoryWithOrganizationTest >> testMultipleClassCreation [
 
 { #category : #testing }
 ClassFactoryWithOrganizationTest >> testPackageCleanUp [
+
 	| createdClassNames allClasses |
 	3 timesRepeat: [ factory newClassInCategory: #One ].
 	2 timesRepeat: [ factory newClassInCategory: #Two ].
@@ -86,7 +87,7 @@ ClassFactoryWithOrganizationTest >> testPackageCleanUp [
 	self assert: (factory createdClasses allSatisfy: [ :class | class isObsolete ]).
 	allClasses := self testedEnvironment allClasses.
 	self assert: (factory createdClasses noneSatisfy: [ :class | allClasses includes: class ]).
-	self assertEmpty: (self testedOrganization categoriesMatching: factory packageName , '*').
+	self assertEmpty: (self testedOrganization packageNamesMatching: factory packageName , '*').
 	self class environment at: #ChangeSet ifPresent: [ :changeSet | self deny: (changeSet current changedClassNames includesAnyOf: createdClassNames) ]
 ]
 

--- a/src/SUnit-UI/TestRunner.class.st
+++ b/src/SUnit-UI/TestRunner.class.st
@@ -594,15 +594,12 @@ TestRunner >> filterPackages [
 
 { #category : #utilities }
 TestRunner >> findClassesForPackages: aCollection [
-	| items |
-	aCollection isEmpty
-		ifTrue: [ ^ self baseClass withAllSubclasses asSet ].
-	items := aCollection
-		flatCollect: [ :category |
-			((Smalltalk organization listAtCategoryNamed: category)
-				collect: [ :each | Smalltalk globals at: each ])
-				select: [ :each | each includesBehavior: self baseClass ] ].
-	^ items asSet
+
+	aCollection ifEmpty: [ ^ self baseClass withAllSubclasses asSet ].
+
+	^ aCollection flatCollectAsSet: [ :packageName |
+		  ((Smalltalk organization classNamesInPackageNamed: packageName) collect: [ :each | Smalltalk globals at: each ]) select: [ :each |
+			  each includesBehavior: self baseClass ] ]
 ]
 
 { #category : #utilities }

--- a/src/SUnit-UI/TestRunner.class.st
+++ b/src/SUnit-UI/TestRunner.class.st
@@ -607,16 +607,13 @@ TestRunner >> findClassesForPackages: aCollection [
 
 { #category : #utilities }
 TestRunner >> findPackages [
+
 	| visible |
 	visible := Set new.
-	self baseClass withAllSubclassesDo: [ :each |
-		each category ifNotNil: [ :category |
-			visible add: category ] ].
+	self baseClass withAllSubclassesDo: [ :each | each category ifNotNil: [ :category | visible add: category ] ].
 	^ Array streamContents: [ :stream |
-		Smalltalk organization categories do: [ :each |
-			((visible includes: each)
-					and: [ packagePattern isNil or: [ (packagePattern matchesIn: each) isNotEmpty]])
-				ifTrue: [ stream nextPut: each ] ] ]
+		  Smalltalk organization packageNames do: [ :packageName |
+			  ((visible includes: packageName) and: [ packagePattern isNil or: [ (packagePattern matchesIn: packageName) isNotEmpty ] ]) ifTrue: [ stream nextPut: packageName ] ] ]
 ]
 
 { #category : #actions }

--- a/src/Slot-Tests/SlotAnnouncementsTest.class.st
+++ b/src/Slot-Tests/SlotAnnouncementsTest.class.st
@@ -171,11 +171,11 @@ SlotAnnouncementsTest >> testClassAddedToNewCategoryShouldAnnounceCategoryAdded 
 
 	self subscribeOn: CategoryAdded.
 
-	self deny: (self class environment organization includesCategory: self aCategory).
+	self deny: (self class environment organization includesPackageNamed: self aCategory).
 
 	self createClass.
 
-	self assert: (self class environment organization includesCategory: self aCategory).
+	self assert: (self class environment organization includesPackageNamed: self aCategory).
 
 	self assert: self collectedAnnouncements size equals: 1
 ]

--- a/src/Slot-Tests/SlotClassBuilderTest.class.st
+++ b/src/Slot-Tests/SlotClassBuilderTest.class.st
@@ -93,10 +93,11 @@ SlotClassBuilderTest >> tearDown [
 	"We remove the classes that could have been created during test run"
 
 	SystemAnnouncer uniqueInstance suspendAllWhile: [
-		{ self aClassName. self anotherClassName. self yetAnotherClassName. self yetYetAnotherClassName } do: [ :each |
-			testingEnvironment
-				at: each
-				ifPresent: [ :class | class removeFromSystem ]]].
+		{
+			self aClassName.
+			self anotherClassName.
+			self yetAnotherClassName.
+			self yetYetAnotherClassName } do: [ :each | testingEnvironment at: each ifPresent: [ :class | class removeFromSystem ] ] ].
 
 	SystemAnnouncer uniqueInstance unsubscribe: self.
 
@@ -104,11 +105,8 @@ SlotClassBuilderTest >> tearDown [
 		cleanUpTrait: TOne;
 		cleanUpTrait: TTwo.
 
-	Smalltalk organization removeCategory: self aCategory.
-	(RPackageOrganizer default
-		packageNamed: self aCategory
-		ifAbsent: [ ^ self ])
-		unregister.
+	Smalltalk organization removePackageNamed: self aCategory.
+	(RPackageOrganizer default packageNamed: self aCategory ifAbsent: [ ^ self ]) unregister.
 
 	super tearDown
 ]

--- a/src/System-Changes/ChangeSet.class.st
+++ b/src/System-Changes/ChangeSet.class.st
@@ -1140,7 +1140,7 @@ ChangeSet >> methodsWithoutClassifications [
 		[:aClass |
 		(self methodChangesAtClass: aClass name) associationsDo:
 				[:mAssoc | | aSelector | (aClass includesSelector:  (aSelector := mAssoc key)) ifTrue:
-						[(notClassified includes: (aClass organization categoryOfElement: aSelector))
+						[(notClassified includes: (aClass organization protocolNameOfElement: aSelector))
 								ifTrue: [slips add: aClass name , ' ' , aSelector]]]].
 	^ slips
 ]

--- a/src/System-Support-Tests/SystemOrganizerTest.class.st
+++ b/src/System-Support-Tests/SystemOrganizerTest.class.st
@@ -22,10 +22,9 @@ SystemOrganizerTest >> testDefaultEnvironment [
 
 { #category : #tests }
 SystemOrganizerTest >> testThatExistingPackagenamesDoesNotContainIllegalCharacters [
-	| illegalCharacters |
 
+	| illegalCharacters |
 	illegalCharacters := #( $\ $/ $: $* $? $" $< $> $| ).
 
-	self class environment organization categories do: [ :aPackageName |
-		self deny: (aPackageName includesAnyOf: illegalCharacters) ]
+	self class environment organization packageNames do: [ :aPackageName | self deny: (aPackageName includesAnyOf: illegalCharacters) ]
 ]

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -390,7 +390,7 @@ SystemDictionary >> renameClass: aClass from: oldName to: newName [
 	"Rename the class, aClass, to have the title newName."
 
 	| oldref category |
-	category := self organization categoryOfElement: oldName.
+	category := self organization packageNameOfElement: oldName.
 	self organization classify: newName under: category.
 	self organization removeElement: oldName.
 	oldref := self associationAt: oldName.

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -57,8 +57,8 @@ SystemOrganizer >> classify: element under: packageName [
 		at: packageName
 		ifPresent: [ :classes | (classes includes: element) ifTrue: [ ^ self ] ]
 		ifAbsent: [ self addPackageNamed: packageName ].
-	(self packageNameOfElement: element) ifNotNil: [ :oldCategory |
-		oldCategory = packageName ifTrue: [ ^ self ].
+	(self packageNameOfElement: element) ifNotNil: [ :oldPackageName |
+		oldPackageName = packageName ifTrue: [ ^ self ].
 		self removeElement: element ].
 
 	(packagesMap at: packageName) add: element
@@ -96,9 +96,8 @@ SystemOrganizer >> initialize [
 
 { #category : #queries }
 SystemOrganizer >> orderedTraitsIn: packageName [
-	"Answer an OrderedCollection containing references to the traits in the
-	category whose name is the argument, category (a string). The traits
-	are ordered so they can be filed in."
+	"Answer an OrderedCollection containing references to the traits in the package.
+	The traits are ordered so they can be filed in."
 
 	| behaviors traits |
 	behaviors := (self classNamesInPackageNamed: packageName) collect: [ :title | self environment at: title ].
@@ -109,7 +108,7 @@ SystemOrganizer >> orderedTraitsIn: packageName [
 
 { #category : #queries }
 SystemOrganizer >> packageNameOfElement: element [
-	"Answer the category associated with the argument, element."
+	"Answer the package name associated with the argument, element."
 
 	packagesMap keysAndValuesDo: [ :packageName :classes | (classes includes: element) ifTrue: [ ^ packageName ] ].
 
@@ -133,7 +132,7 @@ SystemOrganizer >> packageNamesMatching: matchString [
 SystemOrganizer >> removeElement: element [
 	"Remove the element from all packages."
 
-	packagesMap keysAndValuesDo: [ :category :classes | (classes includes: element) ifTrue: [ classes remove: element ] ]
+	packagesMap keysAndValuesDo: [ :packageName :classes | (classes includes: element) ifTrue: [ classes remove: element ] ]
 ]
 
 { #category : #removing }
@@ -160,7 +159,7 @@ SystemOrganizer >> removePackageNamed: packageName [
 
 	packagesMap
 		at: packageName
-		ifPresent: [ :classes | classes ifNotEmpty: [ ^ self error: 'cannot remove non-empty category ' , packageName ] ]
+		ifPresent: [ :classes | classes ifNotEmpty: [ ^ self error: 'Cannot remove non-empty package named: ' , packageName ] ]
 		ifAbsent: [ ^ self ].
 
 	packagesMap removeKey: packageName.
@@ -177,7 +176,7 @@ SystemOrganizer >> removePackageNamesMatching: matchString [
 
 { #category : #accessing }
 SystemOrganizer >> renamePackageNamed: oldPackageName to: newPackageName [
-	"Rename a category. No action if new name already exists, or if old name does not exist."
+	"No action if new name already exists, or if old name does not exist."
 
 	packagesMap at: newPackageName ifPresent: [ "new name exists, so no action" ^ self ].
 
@@ -193,9 +192,8 @@ SystemOrganizer >> renamePackageNamed: oldPackageName to: newPackageName [
 
 { #category : #queries }
 SystemOrganizer >> superclassOrder: packageName [
-	"Answer an OrderedCollection containing references to the classes in the
-	category whose name is the argument, category (a string). The classes
-	are ordered with superclasses first so they can be filed in."
+	"Answer an OrderedCollection containing references to the classes in the package.
+	The classes are ordered with superclasses first so they can be filed in."
 
 	| behaviors classes |
 	behaviors := (self classNamesInPackageNamed: packageName) collect: [ :title | self environment at: title ].

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -145,20 +145,6 @@ SystemOrganizer >> removeCategoriesMatching: matchString [
 	(self packageNamesMatching: matchString) do: [ :c | self removeSystemCategory: c ]
 ]
 
-{ #category : #accessing }
-SystemOrganizer >> removeCategory: packageName [
-	"Remove packageName. Create an error notificiation if the package has any elements in it."
-
-	packagesMap
-		at: packageName
-		ifPresent: [ :classes | classes ifNotEmpty: [ ^ self error: 'cannot remove non-empty category ' , packageName ] ]
-		ifAbsent: [ ^ self ].
-
-	packagesMap removeKey: packageName.
-
-	SystemAnnouncer uniqueInstance classCategoryRemoved: packageName
-]
-
 { #category : #operations }
 SystemOrganizer >> removeElement: element [
 	"Remove the element from all packages."
@@ -175,13 +161,27 @@ SystemOrganizer >> removeEmptyPackages [
 			emptyPackages do: [ :emptyPackage | packagesMap removeKey: emptyPackage ] ]
 ]
 
+{ #category : #accessing }
+SystemOrganizer >> removePackageNamed: packageName [
+	"Create an error notificiation if the package has any elements in it."
+
+	packagesMap
+		at: packageName
+		ifPresent: [ :classes | classes ifNotEmpty: [ ^ self error: 'cannot remove non-empty category ' , packageName ] ]
+		ifAbsent: [ ^ self ].
+
+	packagesMap removeKey: packageName.
+
+	SystemAnnouncer uniqueInstance classCategoryRemoved: packageName
+]
+
 { #category : #removing }
 SystemOrganizer >> removeSystemCategory: packageName [
 	"remove all the classes and traits associated with the packageName"
 
 	(self orderedTraitsIn: packageName) , (self superclassOrder: packageName) reverseDo: [ :each | each removeFromSystem ].
 
-	self removeCategory: packageName
+	self removePackageNamed: packageName
 ]
 
 { #category : #accessing }

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -28,7 +28,7 @@ SystemOrganizer class >> default [
 ]
 
 { #category : #accessing }
-SystemOrganizer >> addCategory: packageName [
+SystemOrganizer >> addPackageNamed: packageName [
 
 	packagesMap at: packageName asSymbol ifPresent: [ ^ self ] ifAbsentPut: [ OrderedCollection new ].
 
@@ -72,7 +72,7 @@ SystemOrganizer >> classify: element under: packageName [
 	packagesMap
 		at: packageName
 		ifPresent: [ :classes | (classes includes: element) ifTrue: [ ^ self ] ]
-		ifAbsent: [ self addCategory: packageName ].
+		ifAbsent: [ self addPackageNamed: packageName ].
 
 	(self categoryOfElement: element) ifNotNil: [ :oldCategory |
 		oldCategory = packageName ifTrue: [ ^ self ].

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -36,15 +36,6 @@ SystemOrganizer >> addPackageNamed: packageName [
 ]
 
 { #category : #queries }
-SystemOrganizer >> categoryOfElement: element [
-	"Answer the category associated with the argument, element."
-
-	packagesMap keysAndValuesDo: [ :packageName :classes | (classes includes: element) ifTrue: [ ^ packageName ] ].
-
-	^ nil
-]
-
-{ #category : #queries }
 SystemOrganizer >> classesInCategory: packageName [
 
 	^ (self listAtCategoryNamed: packageName) collect: [ :className | self environment at: className ]
@@ -59,8 +50,7 @@ SystemOrganizer >> classify: element under: packageName [
 		at: packageName
 		ifPresent: [ :classes | (classes includes: element) ifTrue: [ ^ self ] ]
 		ifAbsent: [ self addPackageNamed: packageName ].
-
-	(self categoryOfElement: element) ifNotNil: [ :oldCategory |
+	(self packageNameOfElement: element) ifNotNil: [ :oldCategory |
 		oldCategory = packageName ifTrue: [ ^ self ].
 		self removeElement: element ].
 
@@ -124,6 +114,15 @@ SystemOrganizer >> orderedTraitsIn: packageName [
 	traits := behaviors select: [ :each | each isTrait ].
 	traits := traits asSortedCollection: [ :t1 :t2 | (t2 traitComposition allTraits includes: t1) or: [ (t1 traitComposition allTraits includes: t2) not ] ].
 	^ traits asArray
+]
+
+{ #category : #queries }
+SystemOrganizer >> packageNameOfElement: element [
+	"Answer the category associated with the argument, element."
+
+	packagesMap keysAndValuesDo: [ :packageName :classes | (classes includes: element) ifTrue: [ ^ packageName ] ].
+
+	^ nil
 ]
 
 { #category : #accessing }

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -35,13 +35,6 @@ SystemOrganizer >> addCategory: packageName [
 	SystemAnnouncer uniqueInstance classCategoryAdded: packageName
 ]
 
-{ #category : #private }
-SystemOrganizer >> basicRemoveElement: element [
-	"Remove the element from all packages."
-
-	categoryMap keysAndValuesDo: [ :category :classes | (classes includes: element) ifTrue: [ classes remove: element ] ]
-]
-
 { #category : #accessing }
 SystemOrganizer >> categories [
 
@@ -83,7 +76,7 @@ SystemOrganizer >> classify: element under: packageName [
 
 	(self categoryOfElement: element) ifNotNil: [ :oldCategory |
 		oldCategory = packageName ifTrue: [ ^ self ].
-		self basicRemoveElement: element ].
+		self removeElement: element ].
 
 	(categoryMap at: packageName) add: element
 ]
@@ -170,7 +163,9 @@ SystemOrganizer >> removeCategory: packageName [
 
 { #category : #operations }
 SystemOrganizer >> removeElement: element [
-	^ self basicRemoveElement: element
+	"Remove the element from all packages."
+
+	categoryMap keysAndValuesDo: [ :category :classes | (classes includes: element) ifTrue: [ classes remove: element ] ]
 ]
 
 { #category : #removing }

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -35,18 +35,12 @@ SystemOrganizer >> addPackageNamed: packageName [
 	SystemAnnouncer uniqueInstance classCategoryAdded: packageName
 ]
 
-{ #category : #accessing }
-SystemOrganizer >> categories [
-
-	^ packagesMap keys
-]
-
 { #category : #queries }
 SystemOrganizer >> categoriesMatching: matchString [
 	"Return all matching categories"
 
-	self categories ifNil: [ ^ #(  ) ].
-	^ self categories select: [ :packageName | matchString match: packageName ]
+	self packageNames ifNil: [ ^ #(  ) ].
+	^ self packageNames select: [ :packageName | matchString match: packageName ]
 ]
 
 { #category : #queries }
@@ -101,7 +95,7 @@ SystemOrganizer >> environment: aSystemDictionary [
 { #category : #testing }
 SystemOrganizer >> includesCategory: packageName [
 
-	^ self categories includes: packageName
+	^ self packageNames includes: packageName
 ]
 
 { #category : #initialization }
@@ -138,6 +132,12 @@ SystemOrganizer >> orderedTraitsIn: packageName [
 	traits := behaviors select: [ :each | each isTrait ].
 	traits := traits asSortedCollection: [ :t1 :t2 | (t2 traitComposition allTraits includes: t1) or: [ (t1 traitComposition allTraits includes: t2) not ] ].
 	^ traits asArray
+]
+
+{ #category : #accessing }
+SystemOrganizer >> packageNames [
+
+	^ packagesMap keys
 ]
 
 { #category : #removing }

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -15,7 +15,7 @@ Class {
 
 { #category : #cleanup }
 SystemOrganizer class >> cleanUp: agressive [
-	"Remove empty categories when cleaning aggressively"
+	"Remove empty packages when cleaning aggressively"
 
 	agressive ifTrue: [ SystemOrganization removeEmptyPackages ]
 ]
@@ -75,7 +75,7 @@ SystemOrganizer >> environment: aSystemDictionary [
 ]
 
 { #category : #testing }
-SystemOrganizer >> includesCategory: packageName [
+SystemOrganizer >> includesPackageNamed: packageName [
 
 	^ self packageNames includes: packageName
 ]

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -145,6 +145,15 @@ SystemOrganizer >> removeEmptyPackages [
 			emptyPackages do: [ :emptyPackage | packagesMap removeKey: emptyPackage ] ]
 ]
 
+{ #category : #removing }
+SystemOrganizer >> removeFromSystemPackageName: packageName [
+	"remove all the classes and traits associated with the packageName"
+
+	(self orderedTraitsIn: packageName) , (self superclassOrder: packageName) reverseDo: [ :each | each removeFromSystem ].
+
+	self removePackageNamed: packageName
+]
+
 { #category : #accessing }
 SystemOrganizer >> removePackageNamed: packageName [
 	"Create an error notificiation if the package has any elements in it."
@@ -163,16 +172,7 @@ SystemOrganizer >> removePackageNamed: packageName [
 SystemOrganizer >> removePackageNamesMatching: matchString [
 	"Remove all matching package names with their classes"
 
-	(self packageNamesMatching: matchString) do: [ :c | self removeSystemCategory: c ]
-]
-
-{ #category : #removing }
-SystemOrganizer >> removeSystemCategory: packageName [
-	"remove all the classes and traits associated with the packageName"
-
-	(self orderedTraitsIn: packageName) , (self superclassOrder: packageName) reverseDo: [ :each | each removeFromSystem ].
-
-	self removePackageNamed: packageName
+	(self packageNamesMatching: matchString) do: [ :packageName | self removeFromSystemPackageName: packageName ]
 ]
 
 { #category : #accessing }

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -36,6 +36,13 @@ SystemOrganizer >> addPackageNamed: packageName [
 ]
 
 { #category : #queries }
+SystemOrganizer >> classNamesInPackageNamed: packageName [
+	"Answer classes names into packageName."
+
+	^ (packagesMap at: packageName ifAbsent: [ Array new ]) asArray
+]
+
+{ #category : #queries }
 SystemOrganizer >> classesInPackageNamed: packageName [
 
 	^ (self listAtCategoryNamed: packageName) collect: [ :className | self environment at: className ]
@@ -88,20 +95,13 @@ SystemOrganizer >> initialize [
 ]
 
 { #category : #queries }
-SystemOrganizer >> listAtCategoryNamed: packageName [
-	"Answer classes names into packageName."
-
-	^ (packagesMap at: packageName ifAbsent: [ Array new ]) asArray
-]
-
-{ #category : #queries }
 SystemOrganizer >> orderedTraitsIn: packageName [
 	"Answer an OrderedCollection containing references to the traits in the
 	category whose name is the argument, category (a string). The traits
 	are ordered so they can be filed in."
 
 	| behaviors traits |
-	behaviors := (self listAtCategoryNamed: packageName) collect: [ :title | self environment at: title ].
+	behaviors := (self classNamesInPackageNamed: packageName) collect: [ :title | self environment at: title ].
 	traits := behaviors select: [ :each | each isTrait ].
 	traits := traits asSortedCollection: [ :t1 :t2 | (t2 traitComposition allTraits includes: t1) or: [ (t1 traitComposition allTraits includes: t2) not ] ].
 	^ traits asArray
@@ -198,7 +198,7 @@ SystemOrganizer >> superclassOrder: packageName [
 	are ordered with superclasses first so they can be filed in."
 
 	| behaviors classes |
-	behaviors := (self listAtCategoryNamed: packageName) collect: [ :title | self environment at: title ].
+	behaviors := (self classNamesInPackageNamed: packageName) collect: [ :title | self environment at: title ].
 	classes := behaviors select: [ :each | each isBehavior ].
 	^ Class superclassOrder: classes
 ]

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -138,13 +138,6 @@ SystemOrganizer >> packageNamesMatching: matchString [
 	^ self packageNames select: [ :packageName | matchString match: packageName ]
 ]
 
-{ #category : #removing }
-SystemOrganizer >> removeCategoriesMatching: matchString [
-	"Remove all matching package names with their classes"
-
-	(self packageNamesMatching: matchString) do: [ :c | self removeSystemCategory: c ]
-]
-
 { #category : #operations }
 SystemOrganizer >> removeElement: element [
 	"Remove the element from all packages."
@@ -173,6 +166,13 @@ SystemOrganizer >> removePackageNamed: packageName [
 	packagesMap removeKey: packageName.
 
 	SystemAnnouncer uniqueInstance classCategoryRemoved: packageName
+]
+
+{ #category : #removing }
+SystemOrganizer >> removePackageNamesMatching: matchString [
+	"Remove all matching package names with their classes"
+
+	(self packageNamesMatching: matchString) do: [ :c | self removeSystemCategory: c ]
 ]
 
 { #category : #removing }

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -8,7 +8,7 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'environment',
-		'categoryMap'
+		'packagesMap'
 	],
 	#category : #'System-Support-Image'
 }
@@ -30,7 +30,7 @@ SystemOrganizer class >> default [
 { #category : #accessing }
 SystemOrganizer >> addCategory: packageName [
 
-	categoryMap at: packageName asSymbol ifPresent: [ ^ self ] ifAbsentPut: [ OrderedCollection new ].
+	packagesMap at: packageName asSymbol ifPresent: [ ^ self ] ifAbsentPut: [ OrderedCollection new ].
 
 	SystemAnnouncer uniqueInstance classCategoryAdded: packageName
 ]
@@ -38,7 +38,7 @@ SystemOrganizer >> addCategory: packageName [
 { #category : #accessing }
 SystemOrganizer >> categories [
 
-	^ categoryMap keys
+	^ packagesMap keys
 ]
 
 { #category : #queries }
@@ -53,7 +53,7 @@ SystemOrganizer >> categoriesMatching: matchString [
 SystemOrganizer >> categoryOfElement: element [
 	"Answer the category associated with the argument, element."
 
-	categoryMap keysAndValuesDo: [ :packageName :classes | (classes includes: element) ifTrue: [ ^ packageName ] ].
+	packagesMap keysAndValuesDo: [ :packageName :classes | (classes includes: element) ifTrue: [ ^ packageName ] ].
 
 	^ nil
 ]
@@ -69,7 +69,7 @@ SystemOrganizer >> classify: element under: packageName [
 
 	packageName ifNil: [ self error: 'Category cannot be nil.' ].
 
-	categoryMap
+	packagesMap
 		at: packageName
 		ifPresent: [ :classes | (classes includes: element) ifTrue: [ ^ self ] ]
 		ifAbsent: [ self addCategory: packageName ].
@@ -78,7 +78,7 @@ SystemOrganizer >> classify: element under: packageName [
 		oldCategory = packageName ifTrue: [ ^ self ].
 		self removeElement: element ].
 
-	(categoryMap at: packageName) add: element
+	(packagesMap at: packageName) add: element
 ]
 
 { #category : #operations }
@@ -108,13 +108,13 @@ SystemOrganizer >> includesCategory: packageName [
 SystemOrganizer >> initialize [
 
 	super initialize.
-	categoryMap := Dictionary new
+	packagesMap := Dictionary new
 ]
 
 { #category : #testing }
 SystemOrganizer >> isEmptyCategoryNamed: packageName [
 
-	^ categoryMap
+	^ packagesMap
 		  at: packageName
 		  ifPresent: [ :classes | classes isEmpty ]
 		  ifAbsent: [ false ]
@@ -124,7 +124,7 @@ SystemOrganizer >> isEmptyCategoryNamed: packageName [
 SystemOrganizer >> listAtCategoryNamed: packageName [
 	"Answer classes names into packageName."
 
-	^ (categoryMap at: packageName ifAbsent: [ Array new ]) asArray
+	^ (packagesMap at: packageName ifAbsent: [ Array new ]) asArray
 ]
 
 { #category : #queries }
@@ -151,12 +151,12 @@ SystemOrganizer >> removeCategoriesMatching: matchString [
 SystemOrganizer >> removeCategory: packageName [
 	"Remove packageName. Create an error notificiation if the package has any elements in it."
 
-	categoryMap
+	packagesMap
 		at: packageName
 		ifPresent: [ :classes | classes ifNotEmpty: [ ^ self error: 'cannot remove non-empty category ' , packageName ] ]
 		ifAbsent: [ ^ self ].
 
-	categoryMap removeKey: packageName.
+	packagesMap removeKey: packageName.
 
 	SystemAnnouncer uniqueInstance classCategoryRemoved: packageName
 ]
@@ -165,16 +165,16 @@ SystemOrganizer >> removeCategory: packageName [
 SystemOrganizer >> removeElement: element [
 	"Remove the element from all packages."
 
-	categoryMap keysAndValuesDo: [ :category :classes | (classes includes: element) ifTrue: [ classes remove: element ] ]
+	packagesMap keysAndValuesDo: [ :category :classes | (classes includes: element) ifTrue: [ classes remove: element ] ]
 ]
 
 { #category : #removing }
 SystemOrganizer >> removeEmptyPackages [
 	"Remove empty packages."
 
-	(categoryMap select: [ :classes | classes isEmpty ]) keys
+	(packagesMap select: [ :classes | classes isEmpty ]) keys
 		ifNotEmpty: [ :emptyPackages |
-			emptyPackages do: [ :emptyPackage | categoryMap removeKey: emptyPackage ] ]
+			emptyPackages do: [ :emptyPackage | packagesMap removeKey: emptyPackage ] ]
 ]
 
 { #category : #removing }
@@ -190,13 +190,13 @@ SystemOrganizer >> removeSystemCategory: packageName [
 SystemOrganizer >> renameCategory: oldPackageName toBe: newPackageName [
 	"Rename a category. No action if new name already exists, or if old name does not exist."
 
-	categoryMap at: newPackageName ifPresent: [ "new name exists, so no action" ^ self ].
+	packagesMap at: newPackageName ifPresent: [ "new name exists, so no action" ^ self ].
 
-	categoryMap
+	packagesMap
 		at: oldPackageName
 		ifPresent: [ :classes |
-			categoryMap at: newPackageName put: classes.
-			categoryMap removeKey: oldPackageName ]
+			packagesMap at: newPackageName put: classes.
+			packagesMap removeKey: oldPackageName ]
 		ifAbsent: [ "old name not found, so no action" ^ self ].
 
 	SystemAnnouncer uniqueInstance classCategoryRenamedFrom: oldPackageName to: newPackageName

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -36,14 +36,6 @@ SystemOrganizer >> addPackageNamed: packageName [
 ]
 
 { #category : #queries }
-SystemOrganizer >> categoriesMatching: matchString [
-	"Return all matching categories"
-
-	self packageNames ifNil: [ ^ #(  ) ].
-	^ self packageNames select: [ :packageName | matchString match: packageName ]
-]
-
-{ #category : #queries }
 SystemOrganizer >> categoryOfElement: element [
 	"Answer the category associated with the argument, element."
 
@@ -140,11 +132,18 @@ SystemOrganizer >> packageNames [
 	^ packagesMap keys
 ]
 
+{ #category : #queries }
+SystemOrganizer >> packageNamesMatching: matchString [
+	"Return all matching package names"
+
+	^ self packageNames select: [ :packageName | matchString match: packageName ]
+]
+
 { #category : #removing }
 SystemOrganizer >> removeCategoriesMatching: matchString [
 	"Remove all matching package names with their classes"
 
-	(self categoriesMatching: matchString) do: [ :c | self removeSystemCategory: c ]
+	(self packageNamesMatching: matchString) do: [ :c | self removeSystemCategory: c ]
 ]
 
 { #category : #accessing }

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -27,6 +27,13 @@ SystemOrganizer class >> default [
 	^ self environment organization
 ]
 
+{ #category : #deprecated }
+SystemOrganizer >> addCategory: packageName [
+
+	self deprecated: 'Use #addPackageNamed: instead' transformWith: '`@rcv addCategory: `@arg' -> '`@rcv addPackageNamed: `@arg'.
+	^ self addPackageNamed: packageName
+]
+
 { #category : #accessing }
 SystemOrganizer >> addPackageNamed: packageName [
 

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -28,17 +28,16 @@ SystemOrganizer class >> default [
 ]
 
 { #category : #accessing }
-SystemOrganizer >> addCategory: catString [
-	"Add a new category named catString"
+SystemOrganizer >> addCategory: packageName [
 
-	categoryMap at: catString asSymbol ifPresent: [ ^ self ] ifAbsentPut: [ OrderedCollection new ].
+	categoryMap at: packageName asSymbol ifPresent: [ ^ self ] ifAbsentPut: [ OrderedCollection new ].
 
-	SystemAnnouncer uniqueInstance classCategoryAdded: catString
+	SystemAnnouncer uniqueInstance classCategoryAdded: packageName
 ]
 
 { #category : #private }
 SystemOrganizer >> basicRemoveElement: element [
-	"Remove the element from all categories."
+	"Remove the element from all packages."
 
 	categoryMap keysAndValuesDo: [ :category :classes | (classes includes: element) ifTrue: [ classes remove: element ] ]
 ]
@@ -54,51 +53,51 @@ SystemOrganizer >> categoriesMatching: matchString [
 	"Return all matching categories"
 
 	self categories ifNil: [ ^ #(  ) ].
-	^ self categories select: [ :c | matchString match: c ]
+	^ self categories select: [ :packageName | matchString match: packageName ]
 ]
 
 { #category : #queries }
 SystemOrganizer >> categoryOfElement: element [
 	"Answer the category associated with the argument, element."
 
-	categoryMap keysAndValuesDo: [ :category :classes | (classes includes: element) ifTrue: [ ^ category ] ].
+	categoryMap keysAndValuesDo: [ :packageName :classes | (classes includes: element) ifTrue: [ ^ packageName ] ].
 
 	^ nil
 ]
 
 { #category : #queries }
-SystemOrganizer >> classesInCategory: category [
+SystemOrganizer >> classesInCategory: packageName [
 
-	^ (self listAtCategoryNamed: category) collect: [ :className | self environment at: className ]
+	^ (self listAtCategoryNamed: packageName) collect: [ :className | self environment at: className ]
 ]
 
 { #category : #operations }
-SystemOrganizer >> classify: element under: categoryName [
-	"Store the argument, element, in the category named heading."
+SystemOrganizer >> classify: element under: packageName [
 
-	categoryName ifNil: [ self error: 'Category cannot be nil.' ].
+	packageName ifNil: [ self error: 'Category cannot be nil.' ].
 
 	categoryMap
-		at: categoryName
+		at: packageName
 		ifPresent: [ :classes | (classes includes: element) ifTrue: [ ^ self ] ]
-		ifAbsent: [ self addCategory: categoryName ].
+		ifAbsent: [ self addCategory: packageName ].
 
 	(self categoryOfElement: element) ifNotNil: [ :oldCategory |
-		oldCategory = categoryName ifTrue: [ ^ self ].
+		oldCategory = packageName ifTrue: [ ^ self ].
 		self basicRemoveElement: element ].
 
-	(categoryMap at: categoryName) add: element
+	(categoryMap at: packageName) add: element
 ]
 
 { #category : #operations }
-SystemOrganizer >> classifyAll: aCollection under: categoryName [
+SystemOrganizer >> classifyAll: aCollection under: packageName [
 
-	aCollection do: [ :element | self classify: element under: categoryName ]
+	aCollection do: [ :element | self classify: element under: packageName ]
 ]
 
 { #category : #accessing }
 SystemOrganizer >> environment [
-	 ^ environment ifNil: [ environment := Smalltalk globals]
+
+	^ environment ifNil: [ environment := Smalltalk globals ]
 ]
 
 { #category : #accessing }
@@ -107,12 +106,9 @@ SystemOrganizer >> environment: aSystemDictionary [
 ]
 
 { #category : #testing }
-SystemOrganizer >> includesCategory: aString [
-	"Tests if a category is already included."
+SystemOrganizer >> includesCategory: packageName [
 
-	^ self categories
-		  ifNil: [ false ]
-		  ifNotNil: [ :categories | categories includes: aString ]
+	^ self categories includes: packageName
 ]
 
 { #category : #initialization }
@@ -123,29 +119,29 @@ SystemOrganizer >> initialize [
 ]
 
 { #category : #testing }
-SystemOrganizer >> isEmptyCategoryNamed: categoryName [
+SystemOrganizer >> isEmptyCategoryNamed: packageName [
 
 	^ categoryMap
-		  at: categoryName
+		  at: packageName
 		  ifPresent: [ :classes | classes isEmpty ]
 		  ifAbsent: [ false ]
 ]
 
 { #category : #queries }
-SystemOrganizer >> listAtCategoryNamed: categoryName [
-	"Answer the array of elements associated with the name, categoryName."
+SystemOrganizer >> listAtCategoryNamed: packageName [
+	"Answer classes names into packageName."
 
-	^ (categoryMap at: categoryName ifAbsent: [ Array new ]) asArray
+	^ (categoryMap at: packageName ifAbsent: [ Array new ]) asArray
 ]
 
 { #category : #queries }
-SystemOrganizer >> orderedTraitsIn: category [
+SystemOrganizer >> orderedTraitsIn: packageName [
 	"Answer an OrderedCollection containing references to the traits in the
 	category whose name is the argument, category (a string). The traits
 	are ordered so they can be filed in."
 
 	| behaviors traits |
-	behaviors := (self listAtCategoryNamed: category) collect: [ :title | self environment at: title ].
+	behaviors := (self listAtCategoryNamed: packageName) collect: [ :title | self environment at: title ].
 	traits := behaviors select: [ :each | each isTrait ].
 	traits := traits asSortedCollection: [ :t1 :t2 | (t2 traitComposition allTraits includes: t1) or: [ (t1 traitComposition allTraits includes: t2) not ] ].
 	^ traits asArray
@@ -153,24 +149,23 @@ SystemOrganizer >> orderedTraitsIn: category [
 
 { #category : #removing }
 SystemOrganizer >> removeCategoriesMatching: matchString [
-	"Remove all matching categories with their classes"
+	"Remove all matching package names with their classes"
 
 	(self categoriesMatching: matchString) do: [ :c | self removeSystemCategory: c ]
 ]
 
 { #category : #accessing }
-SystemOrganizer >> removeCategory: category [
-	"Remove the category named, cat. Create an error notificiation if the
-	category has any elements in it."
+SystemOrganizer >> removeCategory: packageName [
+	"Remove packageName. Create an error notificiation if the package has any elements in it."
 
 	categoryMap
-		at: category
-		ifPresent: [ :classes | classes ifNotEmpty: [ ^ self error: 'cannot remove non-empty category ' , category ] ]
+		at: packageName
+		ifPresent: [ :classes | classes ifNotEmpty: [ ^ self error: 'cannot remove non-empty category ' , packageName ] ]
 		ifAbsent: [ ^ self ].
 
-	categoryMap removeKey: category.
+	categoryMap removeKey: packageName.
 
-	SystemAnnouncer uniqueInstance classCategoryRemoved: category
+	SystemAnnouncer uniqueInstance classCategoryRemoved: packageName
 ]
 
 { #category : #operations }
@@ -188,38 +183,38 @@ SystemOrganizer >> removeEmptyPackages [
 ]
 
 { #category : #removing }
-SystemOrganizer >> removeSystemCategory: category [
-	"remove all the classes and traits associated with the category"
+SystemOrganizer >> removeSystemCategory: packageName [
+	"remove all the classes and traits associated with the packageName"
 
-	(self orderedTraitsIn: category) , (self superclassOrder: category) reverseDo: [ :each | each removeFromSystem ].
+	(self orderedTraitsIn: packageName) , (self superclassOrder: packageName) reverseDo: [ :each | each removeFromSystem ].
 
-	self removeCategory: category
+	self removeCategory: packageName
 ]
 
 { #category : #accessing }
-SystemOrganizer >> renameCategory: oldCatString toBe: newCatString [
+SystemOrganizer >> renameCategory: oldPackageName toBe: newPackageName [
 	"Rename a category. No action if new name already exists, or if old name does not exist."
 
-	categoryMap at: newCatString ifPresent: [ "new name exists, so no action" ^ self ].
+	categoryMap at: newPackageName ifPresent: [ "new name exists, so no action" ^ self ].
 
 	categoryMap
-		at: oldCatString
+		at: oldPackageName
 		ifPresent: [ :classes |
-			categoryMap at: newCatString put: classes.
-			categoryMap removeKey: oldCatString ]
+			categoryMap at: newPackageName put: classes.
+			categoryMap removeKey: oldPackageName ]
 		ifAbsent: [ "old name not found, so no action" ^ self ].
 
-	SystemAnnouncer uniqueInstance classCategoryRenamedFrom: oldCatString to: newCatString
+	SystemAnnouncer uniqueInstance classCategoryRenamedFrom: oldPackageName to: newPackageName
 ]
 
 { #category : #queries }
-SystemOrganizer >> superclassOrder: category [
+SystemOrganizer >> superclassOrder: packageName [
 	"Answer an OrderedCollection containing references to the classes in the
 	category whose name is the argument, category (a string). The classes
 	are ordered with superclasses first so they can be filed in."
 
 	| behaviors classes |
-	behaviors := (self listAtCategoryNamed: category) collect: [ :title | self environment at: title ].
+	behaviors := (self listAtCategoryNamed: packageName) collect: [ :title | self environment at: title ].
 	classes := behaviors select: [ :each | each isBehavior ].
 	^ Class superclassOrder: classes
 ]

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -27,13 +27,6 @@ SystemOrganizer class >> default [
 	^ self environment organization
 ]
 
-{ #category : #deprecated }
-SystemOrganizer >> addCategory: packageName [
-
-	self deprecated: 'Use #addPackageNamed: instead' transformWith: '`@rcv addCategory: `@arg' -> '`@rcv addPackageNamed: `@arg'.
-	^ self addPackageNamed: packageName
-]
-
 { #category : #accessing }
 SystemOrganizer >> addPackageNamed: packageName [
 

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -36,7 +36,7 @@ SystemOrganizer >> addPackageNamed: packageName [
 ]
 
 { #category : #queries }
-SystemOrganizer >> classesInCategory: packageName [
+SystemOrganizer >> classesInPackageNamed: packageName [
 
 	^ (self listAtCategoryNamed: packageName) collect: [ :className | self environment at: className ]
 ]

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -45,7 +45,7 @@ SystemOrganizer >> classNamesInPackageNamed: packageName [
 { #category : #queries }
 SystemOrganizer >> classesInPackageNamed: packageName [
 
-	^ (self listAtCategoryNamed: packageName) collect: [ :className | self environment at: className ]
+	^ (self classNamesInPackageNamed: packageName) collect: [ :className | self environment at: className ]
 ]
 
 { #category : #operations }

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -87,15 +87,6 @@ SystemOrganizer >> initialize [
 	packagesMap := Dictionary new
 ]
 
-{ #category : #testing }
-SystemOrganizer >> isEmptyCategoryNamed: packageName [
-
-	^ packagesMap
-		  at: packageName
-		  ifPresent: [ :classes | classes isEmpty ]
-		  ifAbsent: [ false ]
-]
-
 { #category : #queries }
 SystemOrganizer >> listAtCategoryNamed: packageName [
 	"Answer classes names into packageName."

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -185,7 +185,7 @@ SystemOrganizer >> removeSystemCategory: packageName [
 ]
 
 { #category : #accessing }
-SystemOrganizer >> renameCategory: oldPackageName toBe: newPackageName [
+SystemOrganizer >> renamePackageNamed: oldPackageName to: newPackageName [
 	"Rename a category. No action if new name already exists, or if old name does not exist."
 
 	packagesMap at: newPackageName ifPresent: [ "new name exists, so no action" ^ self ].

--- a/src/Tests/ClassRenameFixTest.class.st
+++ b/src/Tests/ClassRenameFixTest.class.st
@@ -39,18 +39,20 @@ ClassRenameFixTest >> removeEverythingInSetFromSystem: aChangeSet [
 
 { #category : #tests }
 ClassRenameFixTest >> renameClassUsing: aBlock [
+
 	| createdClass foundClasses |
 	originalName := self newUniqueClassName.
 
 	createdClass := self class classInstaller make: [ :aBuilder |
-		aBuilder name: originalName;
-		package: 'ClassRenameFix-GeneradClass' ].
+		                aBuilder
+			                name: originalName;
+			                package: 'ClassRenameFix-GeneradClass' ].
 
 	newClassName := self newUniqueClassName.
 	aBlock value: createdClass value: newClassName.
 	self assert: (testingEnvironment classNamed: originalName) isNil.
 	self assert: (testingEnvironment classNamed: newClassName) notNil.
-	foundClasses := testingEnvironment organization listAtCategoryNamed: 'ClassRenameFix-GeneradClass'.
+	foundClasses := testingEnvironment organization classNamesInPackageNamed: 'ClassRenameFix-GeneradClass'.
 	self assert: foundClasses notEmpty.
 	self assert: (foundClasses includes: newClassName).
 	self assert: createdClass name equals: newClassName

--- a/src/Tests/SystemAnnouncerTest.class.st
+++ b/src/Tests/SystemAnnouncerTest.class.st
@@ -28,18 +28,17 @@ SystemAnnouncerTest >> tearDown [
 
 { #category : #tests }
 SystemAnnouncerTest >> testProtocolAdded [
-	| pass class classReorganized protocolAdded |
 
+	| pass class classReorganized protocolAdded |
 	pass := false.
 
-	SystemAnnouncer uniqueInstance
-		when: ProtocolAdded do: [ :ann |
-			pass := true.
-			classReorganized := ann classReorganized.
-			protocolAdded := ann protocol ].
+	SystemAnnouncer uniqueInstance when: ProtocolAdded do: [ :ann |
+		pass := true.
+		classReorganized := ann classReorganized.
+		protocolAdded := ann protocol ].
 
 	class := factory newClass.
-	class organization addCategory: 'shiny-new-category'.
+	class organization addProtocolNamed: 'shiny-new-category'.
 
 	self assert: pass.
 	self assert: classReorganized equals: class.
@@ -48,20 +47,19 @@ SystemAnnouncerTest >> testProtocolAdded [
 
 { #category : #tests }
 SystemAnnouncerTest >> testProtocolRemoved [
-	| pass class classRemoved protocolRemoved |
 
+	| pass class classRemoved protocolRemoved |
 	pass := false.
 
-	SystemAnnouncer uniqueInstance
-		when: ProtocolRemoved do: [ :ann |
-			pass := true.
-			classRemoved := ann classReorganized.
-			protocolRemoved := ann protocol ].
+	SystemAnnouncer uniqueInstance when: ProtocolRemoved do: [ :ann |
+		pass := true.
+		classRemoved := ann classReorganized.
+		protocolRemoved := ann protocol ].
 
 	class := factory newClass.
-	class organization addCategory: 'shiny-new-category'.
+	class organization addProtocolNamed: 'shiny-new-category'.
 
-	class organization removeCategory: 'shiny-new-category'.
+	class organization removeProtocolNamed: 'shiny-new-category'.
 
 	self assert: pass.
 	self assert: classRemoved equals: class.

--- a/src/Tests/TraitFileOutTest.class.st
+++ b/src/Tests/TraitFileOutTest.class.st
@@ -65,7 +65,7 @@ TraitFileOutTest >> testFileOutCategory [
 	file them in again."
 
 	self timeLimit: 30 seconds.
-	self class environment organization fileOutCategory: self categoryName.
+	self class environment organization fileOutPackageNamed: self categoryName.
 	self class environment organization removeSystemCategory: self categoryName.
 	self deny: (testingEnvironment keys asSet includesAnyOf: #(#CA #CB #TA #TB #TC #TD)).
 

--- a/src/Tests/TraitFileOutTest.class.st
+++ b/src/Tests/TraitFileOutTest.class.st
@@ -25,19 +25,20 @@ TraitFileOutTest >> categoryName [
 
 { #category : #running }
 TraitFileOutTest >> setUp [
-	super setUp.
-	self class environment organization addCategory: self categoryName.
 
-	td := self createTraitNamed: #TD uses: {}.
+	super setUp.
+	self class environment organization addPackageNamed: self categoryName.
+
+	td := self createTraitNamed: #TD uses: {  }.
 	td compile: 'd' classified: #cat1.
 	tc := self createTraitNamed: #TC uses: td.
 	tc compile: 'c' classified: #cat1.
 	tb := self createTraitNamed: #TB uses: td.
 	tb compile: 'b' classified: #cat1.
-	ta := self createTraitNamed: #TA uses: tb + tc @ {#cc->#c} - {#c}.
+	ta := self createTraitNamed: #TA uses: tb + tc @ { (#cc -> #c) } - { #c }.
 	ta compile: 'a' classified: #cat1.
 
-	ca := self createClassNamed: #CA superclass: Object uses: {}.
+	ca := self createClassNamed: #CA superclass: Object uses: {  }.
 	ca compile: 'ca' classified: #cat1.
 	cb := self createClassNamed: #CB superclass: ca uses: ta.
 	cb compile: 'cb' classified: #cat1.

--- a/src/Tests/TraitFileOutTest.class.st
+++ b/src/Tests/TraitFileOutTest.class.st
@@ -48,12 +48,12 @@ TraitFileOutTest >> setUp [
 
 { #category : #running }
 TraitFileOutTest >> tearDown [
+
 	| dir |
 	dir := FileSystem workingDirectory.
-	self createdClassesAndTraits, self resourceClassesAndTraits  do: [:each |
-		(dir / each asString,'st') ensureDelete ] .
-	(dir / self categoryName,'st') ensureDelete.
-	self class environment organization removeSystemCategory: self categoryName.
+	self createdClassesAndTraits , self resourceClassesAndTraits do: [ :each | (dir / each asString , 'st') ensureDelete ].
+	(dir / self categoryName , 'st') ensureDelete.
+	self class environment organization removeFromSystemPackageName: self categoryName.
 	"Ensure cleaning of obsoletes refs"
 	ca := cb := ta := tb := tc := td := nil.
 	super tearDown
@@ -66,19 +66,19 @@ TraitFileOutTest >> testFileOutCategory [
 
 	self timeLimit: 30 seconds.
 	self class environment organization fileOutPackageNamed: self categoryName.
-	self class environment organization removeSystemCategory: self categoryName.
-	self deny: (testingEnvironment keys asSet includesAnyOf: #(#CA #CB #TA #TB #TC #TD)).
+	self class environment organization removeFromSystemPackageName: self categoryName.
+	self deny: (testingEnvironment keys asSet includesAnyOf: #( #CA #CB #TA #TB #TC #TD )).
 
-	CodeImporter evaluateFileNamed: (self categoryName , '.st').
-	self assertCollection: testingEnvironment keys asSet includesAll: #(#CA #CB #TA #TB #TC #TD).
+	CodeImporter evaluateFileNamed: self categoryName , '.st'.
+	self assertCollection: testingEnvironment keys asSet includesAll: #( #CA #CB #TA #TB #TC #TD ).
 	ta := testingEnvironment at: #TA.
-	self assert: ta traitComposition asString equals:  '((TB + TC) @ {#cc->#c}) - {#c}'.
-	self assertCollection: ta selectors asSet includesAll: #(#a #b #cc).
+	self assert: ta traitComposition asString equals: '((TB + TC) @ {#cc->#c}) - {#c}'.
+	self assertCollection: ta selectors asSet includesAll: #( #a #b #cc ).
 	cb := testingEnvironment at: #CB.
 	self assert: cb traitComposition asString equals: 'TA'.
-	self assertCollection: cb selectors asSet includesAll: #(#cb #a #b #cc).	"test classSide traitComposition of CB"
+	self assertCollection: cb selectors asSet includesAll: #( #cb #a #b #cc ). "test classSide traitComposition of CB"
 	self assert: cb classSide traitComposition asString equals: 'TA classTrait + TC'.
-	self assertCollection: cb classSide selectors asSet includesAll: #(#d #c)
+	self assertCollection: cb classSide selectors asSet includesAll: #( #d #c )
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Instead of using the vocabulary around "categroy", make it around "packageName" which is way more understandable.