### PR TITLE
Faulty code: keep AST and source information in faulty CompiledMethod

### DIFF
--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -604,11 +604,16 @@ CompiledMethod >> isFaulty [
 	| ast |
 	"fast pre-check: all methods with syntax errors reference this symbol"
   	(self refersToLiteral: #signalSyntaxError:) ifFalse: [ ^false].
-	"we have to parse the ast here as #ast does not know that this needs optionParseErrors"
-	ast := self methodClass compiler
+
+	"Check the ast in cache, if any"
+	ast := self propertyAt: #ast ifAbsent: [].
+
+	ast ifNil: [
+		"Warning, the following does not work for doit methods because this assumes `noPrefix:false` "
+		ast := self methodClass compiler
 				source: self sourceCode;
-				options: #(+ optionParseErrors);
-				parse.
+				options: #(+ optionParseErrors );
+				parse ].
 	^ ast isFaulty
 ]
 

--- a/src/OpalCompiler-Core/OCDoItSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCDoItSemanticScope.class.st
@@ -25,11 +25,6 @@ OCDoItSemanticScope >> asDoItScope [
 	^self
 ]
 
-{ #category : #'code compilation' }
-OCDoItSemanticScope >> compileMethodFromASTBy: aCompiler [
-	^aCompiler compileDoItFromAST
-]
-
 { #category : #'code evaluation' }
 OCDoItSemanticScope >> evaluateDoIt: doItMethod [
 

--- a/src/OpalCompiler-Core/OCMethodSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCMethodSemanticScope.class.st
@@ -28,11 +28,6 @@ OCMethodSemanticScope >> asDoItScope [
 ]
 
 { #category : #'code compilation' }
-OCMethodSemanticScope >> compileMethodFromASTBy: aCompiler [
-	^aCompiler compileMethodFromAST
-]
-
-{ #category : #'code compilation' }
 OCMethodSemanticScope >> parseASTBy: aParser [
 
 	^aParser parseMethod

--- a/src/OpalCompiler-Core/OCSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCSemanticScope.class.st
@@ -62,11 +62,6 @@ OCSemanticScope >> asDoItScopeForReceiver: anObject [
 	^OCReceiverDoItSemanticScope targetingReceiver: anObject
 ]
 
-{ #category : #'code compilation' }
-OCSemanticScope >> compileMethodFromASTBy: aCompiler [
-	self subclassResponsibility
-]
-
 { #category : #testing }
 OCSemanticScope >> hasBindingThatBeginsWith: aString [
 

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -251,10 +251,18 @@ OpalCompiler >> compilationContextClass: aClass [
 { #category : #'public access' }
 OpalCompiler >> compile [
 
-	| result |
+	| result keep method |
 	result := self parseForRequestor.
 	ast ifNil: [ ^ result ]. "some failBlock"
-	^ self semanticScope compileMethodFromASTBy: self
+
+	"We need to keep information (source and ast) on doit method and faulty code,
+	 because decompilation is not reliable and those will likely not be installed in a class."
+	keep := compilationContext noPattern or: [ ast isFaulty ].
+	keep ifTrue: [ compilationContext parseOptions: #( + #optionEmbeddSources ) ].
+	self callPlugins.
+	method := ast generateMethod.
+	keep ifTrue: [ method propertyAt: #ast put: ast ].
+	^ method
 ]
 
 { #category : #'public access' }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -273,20 +273,6 @@ OpalCompiler >> compile: textOrString [
 		compile
 ]
 
-{ #category : #private }
-OpalCompiler >> compileDoItFromAST [
-	| method |
-	method := self compileMethodFromAST.
-	method propertyAt: #ast put: ast.
-	^method
-]
-
-{ #category : #private }
-OpalCompiler >> compileMethodFromAST [
-	self callPlugins.
-	^ast generateMethod
-]
-
 { #category : #accessing }
 OpalCompiler >> compiledMethodClass: aClass [
 

--- a/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
@@ -8,6 +8,19 @@ RBCodeSnippetTest >> testCompile [
 	self skipIf: #compile.
 	method := snippet compile.
 	self assert: method isCompiledMethod.
+
+	snippet isFaulty
+		ifTrue: [
+			| ast |
+			self assert: method hasSourceCode.
+			self assert: method sourceCode equals: snippet source.
+			ast := method propertyAt: #ast.
+			self assert: ast isFaulty.
+
+			"Some faulty AST can produce non faulty method where no `signalSyntaxError:` is present"
+			self assert: method isFaulty equals: snippet hasValue not]
+		ifFalse: [
+			self deny: method isFaulty ].
 	self testExecute: method
 ]
 


### PR DESCRIPTION
https://github.com/pharo-project/pharo/pull/13084#issuecomment-1477133046 showed that `CompiledMethod>>#isFaulty` (and more generally decompilation) can be unreliable if source information is not preserved for faulty methods (and doit methods).

Therefore, this PR forces the compiler to preserve this information.
While the question of source&ast persistence and efficient storage is an important one, this PR is only focussed on the reliability of faulty compiled methods.