### PR TITLE
RubSmalltalkEditor-remove-reference-RBParser 

### DIFF
--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -393,11 +393,6 @@ RubSmalltalkEditor >> computeSelectionIntervalForCurrentLine [
 ]
 
 { #category : #private }
-RubSmalltalkEditor >> computeSelectionIntervalFromCodeIn: aString at: anInterval [
-	^ (RBParser parseExpression: (aString copyFrom: anInterval first to: anInterval last)) sourceInterval
-]
-
-{ #category : #private }
 RubSmalltalkEditor >> computeSelectionIntervalFromCommentIn: aString at: anInterval [
 	| comment commentInterval |
 	comment := (RBScanner on: (aString copyFrom: anInterval first to: anInterval last) readStream) getComments.


### PR DESCRIPTION
trivial: remove dead code from RubSmalltalkEditor that references RBParser