### PR TITLE
12948-Broken-ast-method-on-compiled-block

### DIFF
--- a/src/Kernel-Tests-Extended/BlockClosureTest.extension.st
+++ b/src/Kernel-Tests-Extended/BlockClosureTest.extension.st
@@ -53,8 +53,8 @@ BlockClosureTest >> testTallyInstructions [
 	| expected |
 	expected := Smalltalk compiler compilationContext
 		            optionCleanBlockClosure
-		            ifTrue: [ 26 ]
-		            ifFalse: [ 27 ].
+		            ifTrue: [ 27 ]
+		            ifFalse: [ 28 ].
 	self
 		assert: (Context tallyInstructions: aBlockContext) size
 		equals: expected

--- a/src/Kernel-Tests/CompiledCodeTest.class.st
+++ b/src/Kernel-Tests/CompiledCodeTest.class.st
@@ -228,10 +228,10 @@ CompiledCodeTest >> testLiteralsDoNotConsiderTheInnerBlockLiterals [
 	self assertCollection: method literals equals: {
 			2.
 			(UndeclaredVariable key: #test value: nil).
+			(GlobalVariable key: #Class value: Class).
 			block.
 			#doIt:.
-			#( #array ).
-			(GlobalVariable key: #Class value: Class) }
+			#( #array )}
 ]
 
 { #category : #'tests - literals' }
@@ -270,14 +270,14 @@ CompiledCodeTest >> testLiteralsEvenTheOnesInTheInnerBlocks [
 		equals: {
 				2.
 				(UndeclaredVariable key: #test value: nil).
+				(GlobalVariable key: #Class value: Class).
 				2.
 				(UndeclaredVariable key: #test value: nil).
 				#( #arrayInBlock ).
-				#name.
 				(GlobalVariable key: #Object value: Object).
+				#name.
 				#doIt:.
-				#( #array ).
-				(GlobalVariable key: #Class value: Class) }
+				#( #array ). }
 ]
 
 { #category : #'tests - literals' }

--- a/src/OpalCompiler-Core/OCASTTranslatorForEffect.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslatorForEffect.class.st
@@ -110,9 +110,6 @@ OCASTTranslatorForEffect >> visitSequenceNode: aSequenceNode [
 
 { #category : #'visitor - double dispatching' }
 OCASTTranslatorForEffect >> visitVariableNode: aVariableNode [
-	"when visiting a variable for effect, we could push it and then pop it, but we do nothing"
-	| variable |
-	variable := aVariableNode variable.
-	(variable isLiteralVariable or: [ variable isUndeclaredVariable ])
-		ifTrue: [ methodBuilder addLiteral: variable ]
+	super visitVariableNode: aVariableNode.
+	methodBuilder popTop
 ]

--- a/src/OpalCompiler-Tests/MethodMapTest.class.st
+++ b/src/OpalCompiler-Tests/MethodMapTest.class.st
@@ -72,6 +72,17 @@ MethodMapTest >> testBlockWithTempsSourceNode [
 	self assert: sourceNode equals: (self parseExpression: '[ | t1 t2 | ]')
 ]
 
+{ #category : #'tests - ast mapping' }
+MethodMapTest >> testCompiledBlockSourceNode [
+
+	| method block |
+	"if we compile a method, but to not install it, make sure that we can map the block to the AST"
+
+	method := OpalCompiler new compile: 'foo Object. [ self ]. ^ #bar'.
+	block := method literals detect: #isCompiledBlock.
+	self assert: block sourceNode equals: (self parseExpression: '[ self ]')
+]
+
 { #category : #'tests - temp access' }
 MethodMapTest >> testCopiedVarFromDeadContext [
 	self assert:  (self compileAndRunExample:  #exampleCopiedVarFromDeadContext) equals: 2

--- a/src/Reflectivity/RFASTTranslatorForEffect.class.st
+++ b/src/Reflectivity/RFASTTranslatorForEffect.class.st
@@ -122,18 +122,13 @@ RFASTTranslatorForEffect >> visitSequenceNode: aSequenceNode [
 { #category : #'visitor - double dispatching' }
 RFASTTranslatorForEffect >> visitVariableNode: aVariableNode [
 
-	| binding |
-
 	self emitPreamble: aVariableNode.
 	self emitMetaLinkBefore: aVariableNode.
 
 	aVariableNode hasMetalinkInstead
 		ifTrue: [ self emitMetaLinkInstead: aVariableNode ].
 
-	"when visiting a variable for effect, we could push it and then pop it, but we do nothing"
-	binding := aVariableNode binding.
-	(binding isLiteralVariable or: [ binding isUndeclaredVariable ])
-		ifTrue: [ methodBuilder addLiteral: binding ].
+	aVariableNode variable emitValue: methodBuilder.
 
 	self emitMetaLinkAfterNoEnsure: aVariableNode
 ]


### PR DESCRIPTION
remove the optimization to not emit code for

```
aVariable.
```

We now push and pop the variable, this makes sure that decompiled code will not loose the variable access.

Optimizations should be done on anothe level.

fixes #12948