### PR TITLE
Rubric/Calypso improve menu entries (especially browse)

### DIFF
--- a/src/Rubric/RubEditingMode.class.st
+++ b/src/Rubric/RubEditingMode.class.st
@@ -23,9 +23,6 @@ RubEditingMode class >> extendedSearchMenuOn: aBuilder [
 		label: 'Code search...' translated;
 		withSeparatorAfter;
 		with: [
-					(aBuilder item: #'Browse full class' translated)
-						keyText: 'b';
-						selector: #browseFullClass.
 					(aBuilder item: #'Senders of it' translated)
 						keyText: 'n';
 						selector: #sendersOfIt.

--- a/src/Rubric/RubEditingMode.class.st
+++ b/src/Rubric/RubEditingMode.class.st
@@ -40,7 +40,6 @@ RubEditingMode class >> extendedSearchMenuOn: aBuilder [
 						keyText: 'E';
 						selector: #methodStringsContainingit.
 					(aBuilder item: #'Case sensitive method literal strings with it' translated)
-						keyText: 'E';
 						selector: #methodCaseSensitiveStringsContainingit.
 					(aBuilder item: #'Method source with it' translated)
 						selector: #methodSourceContainingIt;

--- a/src/Rubric/RubSmalltalkCodeMode.class.st
+++ b/src/Rubric/RubSmalltalkCodeMode.class.st
@@ -56,7 +56,7 @@ RubSmalltalkCodeMode class >> menuOn: aBuilder [
 		keyText: 'b';
 		selector: #browseFullClass;
 		help: nil;
-		iconName: #nautilus.
+		iconName: #smallSystemBrowser.
 	(aBuilder item: #'Do & basic inspect it' translated)
 		keyText: 'I';
 		selector: #basicInspectIt;
@@ -69,7 +69,7 @@ RubSmalltalkCodeMode class >> menuOn: aBuilder [
 		iconName: #smallDebug.
 	(aBuilder item: #'Profile it' translated)
 		selector: #tallyIt;
-		iconName: #smallDebug;
+		iconName: #smallProfile;
 		withSeparatorAfter.
 	(aBuilder item: #'Find...' translated)
 		keyText: 'f';

--- a/src/Rubric/RubSmalltalkCodeMode.class.st
+++ b/src/Rubric/RubSmalltalkCodeMode.class.st
@@ -52,6 +52,11 @@ RubSmalltalkCodeMode class >> menuOn: aBuilder [
 		selector: #inspectIt;
 		help: nil;
 		iconName: #smallInspectIt.
+	(aBuilder item: #'Do & browse its class' translated)
+		keyText: 'b';
+		selector: #browseFullClass;
+		help: nil;
+		iconName: #nautilus.
 	(aBuilder item: #'Do & basic inspect it' translated)
 		keyText: 'I';
 		selector: #basicInspectIt;

--- a/src/Rubric/RubSmalltalkCodeMode.class.st
+++ b/src/Rubric/RubSmalltalkCodeMode.class.st
@@ -116,8 +116,7 @@ RubSmalltalkCodeMode class >> menuOn: aBuilder [
 		keyText: '2';
 		selector: #widenSelectionOfIt;
 		help: nil;
-		iconName: #smallFullscreen;
-		withSeparatorAfter.
+		iconName: #smallFullscreen.
 	(aBuilder item: #'Compare selection to clipboard' translated)
 		keyText: 'C';
 		selector: #compareToClipboard;

--- a/src/Rubric/RubSmalltalkCodeMode.class.st
+++ b/src/Rubric/RubSmalltalkCodeMode.class.st
@@ -111,7 +111,18 @@ RubSmalltalkCodeMode class >> menuOn: aBuilder [
 	(aBuilder item: #'Paste Recent' translated)
 		selector: #pasteRecent;
 		help: nil;
-		iconName: #smallCopy;
+		iconName: #smallCopy.
+	(aBuilder item: #'Widen selection' translated)
+		keyText: '2';
+		selector: #widenSelectionOfIt;
+		help: nil;
+		iconName: #smallFullscreen;
+		withSeparatorAfter.
+	(aBuilder item: #'Compare selection to clipboard' translated)
+		keyText: 'C';
+		selector: #compareToClipboard;
+		help: nil;
+		iconName: #diff;
 		withSeparatorAfter.
 	aBuilder model
 		ifNotNil: [ :mod |

--- a/src/Rubric/RubSmalltalkCodeMode.class.st
+++ b/src/Rubric/RubSmalltalkCodeMode.class.st
@@ -42,17 +42,17 @@ RubSmalltalkCodeMode class >> menuOn: aBuilder [
 		selector: #doIt;
 		help: nil;
 		iconName: #smallDoIt.
-	(aBuilder item: #'Print it' translated)
+	(aBuilder item: #'Do & print it' translated)
 		keyText: 'p';
 		selector: #printIt;
 		help: nil;
 		iconName: #smallPrintIt.
-	(aBuilder item: #'Inspect it' translated)
+	(aBuilder item: #'Do & inspect it' translated)
 		keyText: 'i';
 		selector: #inspectIt;
 		help: nil;
 		iconName: #smallInspectIt.
-	(aBuilder item: #'Basic Inspect it' translated)
+	(aBuilder item: #'Do & basic inspect it' translated)
 		keyText: 'I';
 		selector: #basicInspectIt;
 		help: nil;

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -28,7 +28,7 @@ RubSmalltalkEditor class >> buildShortcutsOn: aBuilder [
 		category: RubSmalltalkEditor name
 		default: $b meta
 		do: [ :target | target editor browseFullClass ]
-		description: 'Browse'.
+		description: 'Do & browse its class'.
 
 	(aBuilder shortcut: #doIt)
 		category: RubSmalltalkEditor name

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -40,13 +40,13 @@ RubSmalltalkEditor class >> buildShortcutsOn: aBuilder [
 		category: RubSmalltalkEditor name
 		default: $i meta
 		do: [ :target | target editor inspectIt: nil ]
-		description: 'Inspect it'.
+		description: 'Do & inspect it'.
 
 	(aBuilder shortcut: #basicInspectIt)
 		category: RubSmalltalkEditor name
 		default: $i meta shift
 		do: [ :target | target editor basicInspectIt ]
-		description: 'Basic Inspect it'.
+		description: 'Do & basic inspect it'.
 
 	(aBuilder shortcut: #implementorsOfIt)
 		category: RubSmalltalkEditor name
@@ -64,7 +64,7 @@ RubSmalltalkEditor class >> buildShortcutsOn: aBuilder [
 		category: RubSmalltalkEditor name
 		default: $p meta
 		do: [ :target | target editor printIt ]
-		description: 'Print it'.
+		description: 'Do & print it'.
 
 	(aBuilder shortcut: #debugIt)
 		category: RubSmalltalkEditor name


### PR DESCRIPTION
I just discovered why *Browse class* did behave so badly: it is a "do it" action that evaluates then browse the class, and not a navigation that statically resolves class names.

I'm very fine with this new acquired knowledge, but I blame the rubric menu to be so bad:

* "browse" in is the same submenu "code search..." with entries like "senders" and "source code with strings", instead of with other related doit actions (like "inspect it" for instance).
* The label is "Browse full class" that do not hint any kind of evaluation or doit action.

Because hacking compilers requires high quality hacking tools, this PR does the following:

* Move "browse it" with other "doit" action menu (I use the browser icon).
* Precise "Do &" in front of "doit" actions. This helps discoverability of tools.
* Add some menu entry for actions that have keybinding but no menu entries: diff & widen.
* Small fixes because they were easy to do.