### PR TITLE
rubric: doit actions on empty selection selects the current expression

### DIFF
--- a/src/Rubric-Tests/RubSmalltalkEditorTest.class.st
+++ b/src/Rubric-Tests/RubSmalltalkEditorTest.class.st
@@ -99,6 +99,15 @@ RubSmalltalkEditorTest >> assertNodeError [
 ]
 
 { #category : #assertions }
+RubSmalltalkEditorTest >> assertNodeReturn [
+	| node |
+
+	node := self executeBestNodeFor: '^'.
+
+	self assert: node isReturn
+]
+
+{ #category : #assertions }
 RubSmalltalkEditorTest >> assertNodeSelector: aSelector [
 	| node |
 
@@ -464,7 +473,7 @@ RubSmalltalkEditorTest >> testBestNodeWithValidPostionOnMethodPeriodEnd [
 
 	self
 		positionAfter: '9.';
-		assertNodeValue: 9
+		assertNodeReturn
 ]
 
 { #category : #'tests - bestNodeIn' }
@@ -487,7 +496,7 @@ RubSmalltalkEditorTest >> testBestNodeWithValidPostionOnStatementPeriodEnd [
 
 	self
 		positionAfter: '3.';
-		assertNodeValue: 3
+		assertNodeSelector: #/
 ]
 
 { #category : #'tests - bestNodeIn' }

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -158,7 +158,7 @@ RubSmalltalkEditor >> bestNodeInString: source at: selectionInterval editingMode
 		(selectionInterval isEmpty and: [ isFavouringExpressions and: [
 			(source at: (stop + 1 min: source size)) isAlphaNumeric not ]]) ifTrue: [
 				"If there is white space or statement terminator, try to backup to find a better node"
-				[stop > 0 and: [('.;' includes: (source at: stop)) or: [(source at: stop) isSeparator ]]]
+				[stop > 0 and: [(source at: stop) isSeparator ]]
 					whileTrue: [ start := stop := stop - 1 ].
 				start := stop].
 		node := ast bestNodeFor: (start to: stop).

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -158,7 +158,7 @@ RubSmalltalkEditor >> bestNodeInString: source at: selectionInterval editingMode
 		(selectionInterval isEmpty and: [ isFavouringExpressions and: [
 			(source at: (stop + 1 min: source size)) isAlphaNumeric not ]]) ifTrue: [
 				"If there is white space or statement terminator, try to backup to find a better node"
-				[stop > 0 and: [(source at: stop) isSeparator ]]
+				[stop > 0 and: [((source at: stop) = $;) or: [(source at: stop) isSeparator ]]]
 					whileTrue: [ start := stop := stop - 1 ].
 				start := stop].
 		node := ast bestNodeFor: (start to: stop).

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -487,7 +487,7 @@ RubSmalltalkEditor >> debugIt: aKeyboardEvent [
 RubSmalltalkEditor >> debugSelection [
 	"Treat the current selection as an expression; evaluate and debugg it in a new debugger."
 
-	self lineSelectAndEmptyCheck: [^self].
+	self expressionSelectAndEmptyCheck: [^self].
 	self debug: self selection
 ]
 
@@ -542,7 +542,7 @@ RubSmalltalkEditor >> evaluateSelectionAndDo: aBlock [
 	"Treat the current selection as an expression; evaluate it and invoke aBlock with the result.
 	If no selection is present select the current line."
 
-	self lineSelectAndEmptyCheck: [^ ''].
+	self expressionSelectAndEmptyCheck: [^ ''].
 	^ self
 		evaluate: self selection
 		andDo: aBlock
@@ -559,6 +559,16 @@ RubSmalltalkEditor >> exploreIt: aKeyboardEvent [
 
 	self exploreIt.
 	^ true
+]
+
+{ #category : #'menu messages' }
+RubSmalltalkEditor >> expressionSelectAndEmptyCheck: returnBlock [
+	"If the current selection is an insertion point, expand it to be the entire current expression; if after that's done the selection is still empty, then evaluate the returnBlock, which will typically consist of '[^ self]' in the caller -- check senders of this method to understand this."
+	"Based on lineSelectAndEmptyCheck:"
+
+	self hasSelection ifTrue: [ ^ self ].
+	self widenSelectionOfIt.  "if current selection is an insertion point, then first select the entire expression in which occurs before proceeding"
+	self hasSelection ifFalse: [textArea flash.  ^ returnBlock value]
 ]
 
 { #category : #'source navigation' }
@@ -1176,7 +1186,7 @@ RubSmalltalkEditor >> tallyIt [
 RubSmalltalkEditor >> tallySelection [
 	"Treat the current selection as an expression; evaluate and tally it."
 
-	self lineSelectAndEmptyCheck: [ ^ self ].
+	self expressionSelectAndEmptyCheck: [ ^ self ].
 	self tally: self selection
 ]
 


### PR DESCRIPTION
doit actions (and related ones like inspect or debug) are a nice feature.

However, a thing that I do not like is how it is not aware of the AST and force us to select things.
Especially because if no selection, it defaults on the whole line.
The issue is that the line is often a poor approximation of code meaningful elements (like expressions or statements).

This PR changes the default selection to be the current expression instead of the line.
It changes only rubric (and calypso) and does not touch newtools (debugger or workspace).

Examples. Write the following in a new method panel in Calypso:

```st
foo

1 + 
  100000 timesRepeat: [ (Integer primesUpTo: 100) last factorial ].
```

* Put your cursor on 100, ctrl-I and you get an inspector on 100
* Put your cursor on 100, ctrl-B and you get a browser on the SmallInteger class
* Put your cursor on Integer, ctrl-B and you get a browser on the Integer class
* Put your cursor on factorial, ctrl-shift-D and you can debug the factorial code (and prove yourself that 96192759682482119853328425949563698712343813919172976158104477319333745612481875498805879175589072651261284189679678167647067832320000000000000000000000 make sense)
* Put your cursor just after `[` or `]`, ctrl-I and you can inspect a block
* Put your cursor on `timesRepeat:`, right click, *Profile it*, and you get a profile report
* Put your cursor at the end of the line (after the dot), ctrl-P and `100001` is printed

You can try exactly the same in workspace (or a rubric without this PR) and suffer how bad working with line boundaries by default is.

Note: if you like lines a lot, you can still double-click at their beginning or end to select them, I suppose.