### PR TITLE
Faulty code: position fixes on some ast nodes (and various cleanup)

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -513,16 +513,14 @@ RBCodeSnippet class >> styleAllWithError [
 				].
 
 		"Then the fun part. Add line for each node with error or warning"
-		ast := each doSemanticAnalysis. 
+		ast := each doSemanticAnalysis.
 		ast nodesPostorderDo: [ :node |
 			node notices do: [ :notice |
-				text := each textWithNode: node message: notice messageText.
+				text := each textWithNode: node message: notice messageText at: notice position.
 				bigtext append: String cr.
 				bigtext append: String tab.
 				bigtext append: text.
-				bigtext append: '   '.
-				bigtext append: (node class name asText makeAllColor: Color gray).
-				bigtext append: (' (semanticWarning)' asText makeAllColor: Color gray).
+				bigtext append: (('   {1} ({2})' format: {node class name. notice class name}) asText makeAllColor: Color gray)
 			] ] ].
 	bigtext inspect
 ]
@@ -690,25 +688,18 @@ RBCodeSnippet >> source: anObject [
 ]
 
 { #category : #inspecting }
-RBCodeSnippet >> textWithNode: aNode message: aString [
+RBCodeSnippet >> textWithNode: aNode message: aString at: aPosition [
 
-	| text stop |
+	| text |
 	text := self styledText.
-	stop := aNode stop min: text size.
 	"Highlight the error node background"
 	text
 		addAttribute: (TextBackgroundColor color: Color cyan)
 		from: aNode start
-		to: stop.
-	"Insert the message after the stop so that:
-	 1. we can see where are zero-width errors
-	 2. we have the same output than the compiler error (above)"
-	stop := aNode isParseError
-		ifTrue: [ aNode errorPosition ifNil: [ aNode stop + 1 ] ]
-		ifFalse: [ aNode stop + 1 "after" ].
+		to: aNode stop.
 	text
-		replaceFrom: stop
-		to: stop - 1
+		replaceFrom: aPosition
+		to: aPosition - 1
 		with: (aString asText addAttribute:
 				 (TextBackgroundColor color: Color lightBlue)).
 	^ text

--- a/src/AST-Core-Tests/RBCodeSnippetTest.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippetTest.class.st
@@ -163,7 +163,32 @@ RBCodeSnippetTest >> testMonticello [
 { #category : #tests }
 RBCodeSnippetTest >> testParse [
 
-	self assert: snippet parse isFaulty equals: (snippet isParseFaulty ifNil: [snippet isFaulty])
+	| ast |
+	ast := snippet parse.
+
+	self
+		assert: ast isFaulty
+		equals: (snippet isParseFaulty ifNil: [ snippet isFaulty ]).
+
+	"Smoke test on the method node"
+	self assert: ast methodNode reformatSource isString.
+
+	"Smoke test on each AST node (in alphabetic order of selectors)"
+	ast nodesDo: [ :node |
+		self assert: ((node allParents includes: ast) or: [node = ast]).
+		node start to: node stop do: [ :i | self assert: ((node bestNodeFor: (i to: i)) isKindOf: RBProgramNode) ].
+		node start+1 to: node stop do: [ :i | self assert: ((node bestNodeForPosition: i) isKindOf: RBProgramNode) ].
+		self assert: node displaySourceCode isString.
+		self assert: node dump equals: node dump.
+		node hasMultipleReturns.
+		node hasNonLocalReturn.
+		self assert: node sourceCode isString.
+		node start to: node stop do: [ :i | self assert: ((node nodeForOffset: i) isKindOf: RBProgramNode) ].
+		self assert: node printString isString.
+		self assert: node selfMessages isCollection.
+		self assert: node methodNode = ast equals: snippet isMethod.
+		self assert: (node methodOrBlockNode isKindOf: RBProgramNode).
+	]
 ]
 
 { #category : #tests }

--- a/src/AST-Core-Tests/RBErrorNodeParserTest.class.st
+++ b/src/AST-Core-Tests/RBErrorNodeParserTest.class.st
@@ -478,7 +478,8 @@ RBErrorNodeParserTest >> testFaultyNumericLiteral [
 	self assert: node isFaulty.
 	self assert: node isMessage.
 	self assert: node receiver isParseError.
-	self assert: node receiver sourceInterval equals: (1 to: 4).
+	self assert: node receiver sourceInterval equals: (1 to: 3).
+	self assert: node receiver errorPosition equals: 4.
 	self assert: node receiver errorMessage equals: 'an integer greater than 1 as valid radix expected'.
 	self assert: node selector equals: #r.
 	self assert: node receiver formattedCode equals: '000'.
@@ -494,7 +495,8 @@ RBErrorNodeParserTest >> testFaultyNumericLiteral2 [
 	self assert: node isFaulty.
 	self assert: node isMessage.
 	self assert: node receiver isParseError.
-	self assert: node receiver sourceInterval equals: (1 to: 3).
+	self assert: node receiver sourceInterval equals: (1 to: 2).
+	self assert: node receiver errorPosition equals: 3.
 	self assert: node receiver errorMessage equals: 'a digit between 0 and 1 expected'.
 	self assert: node selector equals: #x.
 	self assert: node receiver formattedCode equals: '2r'.
@@ -512,9 +514,10 @@ RBErrorNodeParserTest >> testFaultyStringLiteral [
 	self assert: node selector equals: #','.
 	self assert: node arguments first isParseError.
 	self assert: node arguments first errorMessage equals: 'Unmatched '' in string literal.'.
-	self assert: node arguments first sourceInterval equals: (7 to: 11).
+	self assert: node arguments first sourceInterval equals: (7 to: 10).
+	self assert: node arguments first errorPosition equals: 11.
 	self assert: node arguments first formattedCode equals: '''bar'.
-	self assert: node formattedCode equals: '''foo'' , ''bar'.
+	self assert: node formattedCode equals: '''foo'' , ''bar'
 ]
 
 { #category : #tests }
@@ -528,7 +531,8 @@ RBErrorNodeParserTest >> testFaultyStringLiteral2 [
 	self assert: node selector equals: #','.
 	self assert: node arguments first isParseError.
 	self assert: node arguments first errorMessage equals: 'Unmatched '' in string literal.'.
-	self assert: node arguments first sourceInterval equals: (7 to: 8).
+	self assert: node arguments first sourceInterval equals: (7 to: 7).
+	self assert: node arguments first errorPosition equals: 8.
 	self assert: node arguments first formattedCode equals: ''''.
 	self assert: node formattedCode equals: '''foo'' , '''.
 ]

--- a/src/AST-Core/RBDumpVisitor.class.st
+++ b/src/AST-Core/RBDumpVisitor.class.st
@@ -194,12 +194,16 @@ RBDumpVisitor >> visitMethodNode: aMethodNode [
 RBDumpVisitor >> visitParseErrorNode: aParseErrorNode [
 	stream
 		nextPutAll: aParseErrorNode class name;
-		nextPutAll: ' errorMessage: '.
-	aParseErrorNode errorMessage printOn: stream.
-	stream nextPutAll: ' value: '.
-	aParseErrorNode value printOn: stream.
-	stream nextPutAll: ' at: '.
-	aParseErrorNode start printOn: stream
+		nextPutAll: ' new errorMessage: ';
+		print: aParseErrorNode errorMessage;
+		nextPutAll: '; value: ';
+		print: aParseErrorNode value;
+		nextPutAll: '; start: ';
+		print: aParseErrorNode start;
+		nextPutAll: '; stop: ';
+		print: aParseErrorNode stop;
+		nextPutAll: '; errorPosition: ';
+		print: aParseErrorNode errorPosition
 ]
 
 { #category : #visiting }

--- a/src/AST-Core/RBErrorNodeNotice.class.st
+++ b/src/AST-Core/RBErrorNodeNotice.class.st
@@ -7,14 +7,14 @@ Class {
 	#category : #'AST-Core-Notice'
 }
 
-{ #category : #'error handling' }
-RBErrorNodeNotice >> errorPosition [
-
-	^ node errorPosition
-]
-
 { #category : #accessing }
 RBErrorNodeNotice >> messageText [
 
 	^ node errorMessage
+]
+
+{ #category : #'error handling' }
+RBErrorNodeNotice >> position [
+
+	^ node errorPosition
 ]

--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -242,11 +242,6 @@ RBMethodNode >> compilationContext: aCompilationContext [
 	compilationContext := aCompilationContext
 ]
 
-{ #category : #completion }
-RBMethodNode >> completionToken [
-	^ self selector
-]
-
 { #category : #'accessing - conceptual' }
 RBMethodNode >> conceptualArgumentSize [
 	"Return the cumulted length of the parameters (yes parameters are called arguments in Pharo - not good!). It does not count spaces and the selectors.

--- a/src/AST-Core/RBNotice.class.st
+++ b/src/AST-Core/RBNotice.class.st
@@ -11,12 +11,6 @@ Class {
 	#category : #'AST-Core-Notice'
 }
 
-{ #category : #'error handling' }
-RBNotice >> errorPosition [
-
-	^ node start
-]
-
 { #category : #testing }
 RBNotice >> isError [
 
@@ -51,4 +45,10 @@ RBNotice >> node [
 RBNotice >> node: anObject [
 
 	node := anObject
+]
+
+{ #category : #'error handling' }
+RBNotice >> position [
+
+	^ node start
 ]

--- a/src/AST-Core/RBParseErrorNode.class.st
+++ b/src/AST-Core/RBParseErrorNode.class.st
@@ -23,16 +23,6 @@ Class {
 	#category : #'AST-Core-Nodes - ErrorNodes'
 }
 
-{ #category : #'instance creation' }
-RBParseErrorNode class >> errorMessage: aString value: aValue at: aPosition [
-
-	^ self new
-		errorMessage: aString;
-		value: aValue;
-		start: aPosition;
-		yourself
-]
-
 { #category : #comparing }
 RBParseErrorNode >> = anObject [
 	self == anObject ifTrue: [^true].

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -517,17 +517,22 @@ RBParser >> parseErrorNode: aMessageString [
 	currentToken isError
 		ifTrue: [
 			"The current token is an error, consume it and use its content for the error node."
-			errorNode := RBParseErrorNode errorMessage: currentToken cause value: currentToken value at: self errorPosition.
-			errorNode stop: currentToken location-1.
-			errorNode errorPosition: currentToken location.
+			errorNode := RBParseErrorNode new
+				errorMessage: currentToken cause;
+				value: currentToken value;
+				start: self errorPosition;
+				stop: currentToken location-1;
+				errorPosition: currentToken location.
 			self step.
 			^ errorNode].
 	"The current token is not an error but is unexpected. Maybe something is missing?
 	Anyway, the error node is an empty string and the current token will be used to continue the parsing."
-	errorNode := RBParseErrorNode errorMessage: aMessageString value: '' asString at: self errorPosition.
-	errorNode stop: self errorPosition - 1.
-	errorNode errorPosition: self errorPosition.
-	^errorNode
+	^ RBParseErrorNode new
+		errorMessage: aMessageString;
+		value: '' asString;
+		start: self errorPosition;
+		stop: self errorPosition - 1;
+		errorPosition: self errorPosition
 ]
 
 { #category : #parsing }
@@ -924,7 +929,13 @@ RBParser >> parseStatementInto: statementList periodList: periods withAcceptedSt
 	startOfStatementToken = currentToken ifTrue: [
 		"We did not progress, its mean that 1. we have a error node and 2. we are missing something (or found something unexpected, its the same thing)."
 		"Solution to recover. Consume the token to create the statement."
-		node := RBParseErrorNode errorMessage: 'unexpected token' value: currentToken value asString at: currentToken start.
+		node := RBParseErrorNode new
+			errorMessage: 'unexpected token';
+			value: currentToken value asString;
+			start: currentToken start;
+			stop: currentToken stop;
+			errorPosition: currentToken start.
+
 		self step ].
 
 	"At this point we have parsed a full statement."
@@ -951,7 +962,7 @@ RBParser >> parseStatementInto: statementList periodList: periods withAcceptedSt
 		"I do not like the following guard. If currentToken is an unrelated error,
 		 then parserError will unfortunately consume and lose it.
 		 A better design is needed."
-		node isParseError ifFalse: [ 
+		node isParseError ifFalse: [
 			err := self parseErrorNode: 'End of statement expected'.
 			node := RBUnfinishedStatementErrorNode from: err contents: { node } ]
 	].

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -784,20 +784,24 @@ RBParser >> parsePragma [
 
 	| startToken pragma |
 	startToken := currentToken.
-	self step.
+	self step. "<"
 	pragma := self basicParsePragma.
 	(currentToken isBinary and: [ currentToken value == #> ]) ifFalse: [
+		pragma isPragma ifTrue: [
+			pragma
+				left: startToken start;
+				right: currentToken start-1 ].
 		pragma := self
 			          parseEnglobingError: (OrderedCollection with: pragma)
 			          with: startToken
 			          errorMessage: '''>'' expected'.
-		pragma stop: currentToken stop.
 		^ self addPragma: pragma ].
 
 	pragma
 		left: startToken start;
-		right: currentToken start.
-	self step.
+		right: currentToken stop.
+
+	self step. ">"
 	self addPragma: pragma
 ]
 

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -518,7 +518,7 @@ RBParser >> parseErrorNode: aMessageString [
 		ifTrue: [
 			"The current token is an error, consume it and use its content for the error node."
 			errorNode := RBParseErrorNode errorMessage: currentToken cause value: currentToken value at: self errorPosition.
-			errorNode stop: currentToken location.
+			errorNode stop: currentToken location-1.
 			errorNode errorPosition: currentToken location.
 			self step.
 			^ errorNode].

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -308,12 +308,12 @@ RBProgramNode >> checkFaulty: aBlock [
 	"Search for the first error, to signal"
 	errorNotice := self allErrorNotices first.
 
-	aBlock ifNotNil: [ aBlock cull: errorNotice messageText cull: errorNotice errorPosition cull: self ].
+	aBlock ifNotNil: [ aBlock cull: errorNotice messageText cull: errorNotice position cull: self ].
 
 	SyntaxErrorNotification new
 		sourceCode: self methodNode sourceCode;
 		messageText: errorNotice messageText;
-		location: errorNotice errorPosition;
+		location: errorNotice position;
 		signal.
 
 	"If resumed, just return"


### PR DESCRIPTION
Added extensive smoke tests on AST nodes, then corrections and cleanup.

Nothing so fancy, but some source code positions were not set or were off-by-one. Thus, causing issues with inconsistent intervals and source code extraction.