### PR TITLE
RBCodeSnippet format, tidify and better default mechanism

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -1094,10 +1094,11 @@ RBCodeSnippet >> parseOnError: aBlock [
 RBCodeSnippet >> printOn: aStream [
 
 	super printOn: aStream.
-	aStream
-		nextPut: $(;
-		nextPutAll: source;
-		nextPut: $)
+	source ifNotNil: [
+		aStream
+			nextPut: $(;
+			nextPutAll: source;
+			nextPut: $) ]
 ]
 
 { #category : #accessing }

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -49,285 +49,564 @@ RBCodeSnippet class >> allSnippets [
 
 { #category : #accessing }
 RBCodeSnippet class >> badExpressions [
-
 	"This list contains various (and possibly systematic) variations of faulty inputs (and some correct ones for good measure)."
+
 	"Unless specifically testing token handling (e.g. in the scanner) try to use the formater format `formattedCode` as the source to simplify this file"
+
 	| list |
 	list := {
-		"Random alone special character (lone opening or closing characters are managed in others sections)"
-		self new source: '#'.
-		self new source: '$'.
-		self new source: ':'.
-		self new source: ''; isFaulty: false. "emptyness is ok"
-		
-		"Comments"
-		"EFFormater is not the best here :("
-		self new source: '"" '; isFaulty: false.
-		self new source: '"nothing" '; isFaulty: false.
-		self new source: '"com"1"ment"'; formattedCode: '1'; isFaulty: false; value: 1. "The comments are in the AST, the formatter just do not know to show them because we format only the node and not the whole method body"
-		self new source: '"a" 1 "b". "c" 2 "d"'; formattedCode: '1. "a" "b" "c" 2 "d"'; isFaulty: false; value: 2. "a and b moved around. Formatter issue. FIXME?"
-		self new source: '"unfinished'.
-		self new source: '"also unfinished""'.
-		self new source: '"'.
-		self new source: '"""'.
+		        (self new source: '#').
+		        (self new source: '$').
+		        (self new source: ':').
+		        (self new
+			         source: '';
+			         isFaulty: false). "emptyness is ok"
 
-		"Bad compound"
-		self new source: '( 1 + 2'.
-		self new source: '#( 1 + 2'.
-		self new source: '[ 1 + 2'.
-		self new source: '#[ 1 2'.
-		self new source: '{ 1 + 2'.
-		self new source: '1 + 2 )'.
-		self new source: '1 + 2 ]'.
-		self new source: '1 + 2 }'.
+		        "Comments"
+		        "EFFormater is not the best here :("
+		        (self new
+			         source: '"" ';
+			         isFaulty: false).
+		        (self new
+			         source: '"nothing" ';
+			         isFaulty: false).
+		        (self new
+			         source: '"com"1"ment"';
+			         formattedCode: '1';
+			         isFaulty: false;
+			         value: 1). "The comments are in the AST, the formatter just do not know to show them because we format only the node and not the whole method body"
+		        (self new
+			         source: '"a" 1 "b". "c" 2 "d"';
+			         formattedCode: '1. "a" "b" "c" 2 "d"';
+			         isFaulty: false;
+			         value: 2). "a and b moved around. Formatter issue. FIXME?"
+		        (self new source: '"unfinished').
+		        (self new source: '"also unfinished""').
+		        (self new source: '"').
+		        (self new source: '"""').
 
-		self new source: '( '.
-		self new source: '#( '.
-		self new source: '[ '.
-		self new source: '#[ '.
-		self new source: '{ '.
+		        "Bad compound"
+		        (self new source: '( 1 + 2').
+		        (self new source: '#( 1 + 2').
+		        (self new source: '[ 1 + 2').
+		        (self new source: '#[ 1 2').
+		        (self new source: '{ 1 + 2').
+		        (self new source: '1 + 2 )').
+		        (self new source: '1 + 2 ]').
+		        (self new source: '1 + 2 }').
 
-		self new source: '{ [ ( '.
-		self new source: ') ] }'.
+		        (self new source: '( ').
+		        (self new source: '#( ').
+		        (self new source: '[ ').
+		        (self new source: '#[ ').
+		        (self new source: '{ ').
 
-		"Compounds with an unexped thing inside"
-		self new source: '(1]2)'; formattedCode: '( 1 ]. 2 )'.
-		self new source: '(1}2)'; formattedCode: '( 1 }. 2 )'.
-		self new source: '(1. 2)'; formattedCode: '( 1. 2 )'.
-		self new source: '[1)2]'; formattedCode: '[ 1 ). 2 ]'.
-		self new source: '[1}2]'; formattedCode: '[ 1 }. 2 ]'.
-		self new source: '#(1]2}3)'; formattedCode:'#( 1 #'']'' 2 #''}'' 3 )'; isFaulty: false; value: #(1]2}3). "`#(` can eat almost anything"
-		self new source: '#( 0 1r2 4 )'; formattedCode: '#( 0 1 r2 4 )'. "Almost anything..."
-		self new source: '#[ 1 ) 2 ]'.
-		self new source: '#[ 1 } 2 ]'.
-		self new source: '#[ 1 a 2 ]'.
-		self new source: '#[ 1 -1 2 ]'.
-		self new source: '#[ 1 1.0 2 ]'.
-		self new source: '#[ 1 256 2 ]'.
-		self new source: '{1)2}'; formattedCode: '{ 1 ). 2 }'.
-		self new source: '{1]2}'; formattedCode: '{ 1 ]. 2 }'.
+		        (self new source: '{ [ ( ').
+		        (self new source: ') ] }').
 
-		"...or without expected thing"
-		"Note: all compounds `[]` `#()` `#[]` `{}` are legal empty, except one"
-		self new source: '()'.
+		        "Compounds with an unexped thing inside"
+		        (self new
+			         source: '(1]2)';
+			         formattedCode: '( 1 ]. 2 )').
+		        (self new
+			         source: '(1}2)';
+			         formattedCode: '( 1 }. 2 )').
+		        (self new
+			         source: '(1. 2)';
+			         formattedCode: '( 1. 2 )').
+		        (self new
+			         source: '[1)2]';
+			         formattedCode: '[ 1 ). 2 ]').
+		        (self new
+			         source: '[1}2]';
+			         formattedCode: '[ 1 }. 2 ]').
+		        (self new
+			         source: '#(1]2}3)';
+			         formattedCode: '#( 1 #'']'' 2 #''}'' 3 )';
+			         isFaulty: false;
+			         value: #( 1 #']' 2 #'}' 3 )). "`#(` can eat almost anything"
+		        (self new
+			         source: '#( 0 1r2 4 )';
+			         formattedCode: '#( 0 1 r2 4 )'). "Almost anything..."
+		        (self new source: '#[ 1 ) 2 ]').
+		        (self new source: '#[ 1 } 2 ]').
+		        (self new source: '#[ 1 a 2 ]').
+		        (self new source: '#[ 1 -1 2 ]').
+		        (self new source: '#[ 1 1.0 2 ]').
+		        (self new source: '#[ 1 256 2 ]').
+		        (self new
+			         source: '{1)2}';
+			         formattedCode: '{ 1 ). 2 }').
+		        (self new
+			         source: '{1]2}';
+			         formattedCode: '{ 1 ]. 2 }').
 
-		"Bad sequence. The first expression is considered unfinished."
-		self new source: '1 2'; formattedCode: '1. 2'.
-		self new source: '1 foo 2'; formattedCode: '1 foo. 2'.
-		self new source: '(1)2'; formattedCode: '1. 2'.
-		self new source: '1(2)'; formattedCode: '1. 2'.
-		self new source: '(1)(2)'; formattedCode: '1. 2'.
-		self new source: '#hello#world'; formattedCode: '#hello. #world'.
-		self new source: '$h$w'; formattedCode: '$h. $w'.
-		self new source: '[1][2]'; formattedCode: '[ 1 ]. [ 2 ]'.
-		self new source: '{1}{2}'; formattedCode: '{ 1 }. { 2 }'.
-		self new source: '#(1)#(2)'; formattedCode: '#( 1 ). #( 2 )'.
-		self new source: '#[1]#[2]'; formattedCode: '#[ 1 ]. #[ 2 ]'.
+		        "...or without expected thing"
+		        "Note: all compounds `[]` `#()` `#[]` `{}` are legal empty, except one"
+		        (self new source: '()').
 
-		"Bad temporary variable declarations"
-		"Note: bad temporaries will be stored as error statements"
-		self new source: '| '.
-		self new source: '| a b'.
-		self new source: '| 1'; formattedCode: '| . 1'.
-		"Note that the | character is also a binary operator, so a missing opening | become a binary call with a missing argument (see bellow)"
-		self new source: 'a | '.
-		self new source: 'a || '.
-		self new source: '| | a'; formattedCode: 'a'; isFaulty: false. "This one is legal, it is an empty list of temporaries, the | are dismissed"
-		self new source: '|| a'; formattedCode: 'a'; isFaulty: false. "Same, but are messing with the Scanner"
-		self new source: ' ||| a'; formattedCode: ' | a'. "this one is a empty temps and a binary operator | with a mising receiver"
-		self new source: ' |||| a'; formattedCode: ' || a'. "this one is a empty temps and a binary operator || with a mising receiver"
-		self new source: '| a | | b'. "A valid temporary followed by a binary operator with a missing receiver"
-		self new source: '| a ||b'; formattedCode: '| a | | b'. "same"
+		        "Bad sequence. The first expression is considered unfinished."
+		        (self new
+			         source: '1 2';
+			         formattedCode: '1. 2').
+		        (self new
+			         source: '1 foo 2';
+			         formattedCode: '1 foo. 2').
+		        (self new
+			         source: '(1)2';
+			         formattedCode: '1. 2').
+		        (self new
+			         source: '1(2)';
+			         formattedCode: '1. 2').
+		        (self new
+			         source: '(1)(2)';
+			         formattedCode: '1. 2').
+		        (self new
+			         source: '#hello#world';
+			         formattedCode: '#hello. #world').
+		        (self new
+			         source: '$h$w';
+			         formattedCode: '$h. $w').
+		        (self new
+			         source: '[1][2]';
+			         formattedCode: '[ 1 ]. [ 2 ]').
+		        (self new
+			         source: '{1}{2}';
+			         formattedCode: '{ 1 }. { 2 }').
+		        (self new
+			         source: '#(1)#(2)';
+			         formattedCode: '#( 1 ). #( 2 )').
+		        (self new
+			         source: '#[1]#[2]';
+			         formattedCode: '#[ 1 ]. #[ 2 ]').
 
-		"Unexpected parameters (or columns)"
-		"Note that `:a` is not a token but a special `:` followed by an identifier, whereas `a:` is a single token."
-		"Nevertheless, the parser will try to catch unexpected :a together"
-		self new source: ':a'.
-		self new source: '::a'.
-		self new source: ':::a'.
-		self new source: '::'.
-		self new source: ':a foo'.
-		self new source: 'a :foo'; formattedCode: 'a. :foo'.
-		self new source: 'a : foo'; formattedCode: 'a. :foo'.
-		self new source: 'a:'; formattedCode: ' a: '. "keyword message with a missing receiver and argument"
-		self new source: 'a::'. "just a bad token"
-		self new source: 'a:foo'; formattedCode: ' a: foo'. "keyword message with a missing receiver"
-		self new source: 'a::foo'; formattedCode: 'a::. foo'.
-		self new source: ':a:foo'; formattedCode: ': a: foo'.
-		self new source: '|:a|'; formattedCode: '| . :a | '.
-		self new source: '|:a'; formattedCode: '| . :a'.
-		self new source: '|::a'; formattedCode: '| . ::a'.
-		self new source: '|a:|'; formattedCode: '| . a: | '.
-		self new source: '|a:'; formattedCode: '| . a: '.
+		        "Bad temporary variable declarations"
+		        "Note: bad temporaries will be stored as error statements"
+		        (self new source: '| ').
+		        (self new source: '| a b').
+		        (self new
+			         source: '| 1';
+			         formattedCode: '| . 1').
+		        "Note that the | character is also a binary operator, so a missing opening | become a binary call with a missing argument (see bellow)"
+		        (self new source: 'a | ').
+		        (self new source: 'a || ').
+		        (self new
+			         source: '| | a';
+			         formattedCode: 'a';
+			         isFaulty: false). "This one is legal, it is an empty list of temporaries, the | are dismissed"
+		        (self new
+			         source: '|| a';
+			         formattedCode: 'a';
+			         isFaulty: false). "Same, but are messing with the Scanner"
+		        (self new
+			         source: ' ||| a';
+			         formattedCode: ' | a'). "this one is a empty temps and a binary operator | with a mising receiver"
+		        (self new
+			         source: ' |||| a';
+			         formattedCode: ' || a'). "this one is a empty temps and a binary operator || with a mising receiver"
+		        (self new source: '| a | | b'). "A valid temporary followed by a binary operator with a missing receiver"
+		        (self new
+			         source: '| a ||b';
+			         formattedCode: '| a | | b'). "same"
 
-		"Bad block parameters"
-		"A bad parameter cause a error object to be added as the last element of the block parameter.
+		        "Unexpected parameters (or columns)"
+		        "Note that `:a` is not a token but a special `:` followed by an identifier, whereas `a:` is a single token."
+		        "Nevertheless, the parser will try to catch unexpected :a together"
+		        (self new source: ':a').
+		        (self new source: '::a').
+		        (self new source: ':::a').
+		        (self new source: '::').
+		        (self new source: ':a foo').
+		        (self new
+			         source: 'a :foo';
+			         formattedCode: 'a. :foo').
+		        (self new
+			         source: 'a : foo';
+			         formattedCode: 'a. :foo').
+		        (self new
+			         source: 'a:';
+			         formattedCode: ' a: '). "keyword message with a missing receiver and argument"
+		        (self new source: 'a::'). "just a bad token"
+		        (self new
+			         source: 'a:foo';
+			         formattedCode: ' a: foo'). "keyword message with a missing receiver"
+		        (self new
+			         source: 'a::foo';
+			         formattedCode: 'a::. foo').
+		        (self new
+			         source: ':a:foo';
+			         formattedCode: ': a: foo').
+		        (self new
+			         source: '|:a|';
+			         formattedCode: '| . :a | ').
+		        (self new
+			         source: '|:a';
+			         formattedCode: '| . :a').
+		        (self new
+			         source: '|::a';
+			         formattedCode: '| . ::a').
+		        (self new
+			         source: '|a:|';
+			         formattedCode: '| . a: | ').
+		        (self new
+			         source: '|a:';
+			         formattedCode: '| . a: ').
+
+		        "Bad block parameters"
+		        "A bad parameter cause a error object to be added as the last element of the block parameter.
 		On formating, a double space can be seen."
-		self new source: '[:a b]'; formattedCode: '[ :a | b ]'; hasValue: true. "FIXME"
-		self new source: '[:a 1]'; formattedCode: '[ :a | 1 ]'; hasValue: true; value: 1. "FIXME"
-		self new source: '[:a :]'; formattedCode: '[ :a : | ]'; hasValue: true. "FIXME"
-		self new source: '[:a ::b]'; formattedCode: '[ :a ::b | ]'; hasValue: true. "FIXME"
-		self new source: '[:a :b]'; formattedCode: '[ :a :b | ]'; isFaulty: false. "no pipe (and no body) is legal"
-		self new source: '[: a : b]'; formattedCode: '[ :a :b | ]'; isFaulty: false. "spaces are also legal"
-		self new source: '[:a:b]'; formattedCode: '[ : | a: b ]'. "FIXME?"
-		self new source: '[ a: ]'. "no parameters, a keyword message send witout receiver nor arguments"
-		self new source: '[ | ]'.
-		self new source: '[ | b ]'.
-		self new source: '[ :a | | b ]'.
-		self new source: '[ :a || b ]'; formattedCode: '[ :a | | b ]'.
-		self new source: '[:a| | |b]'; formattedCode: '[ :a | b ]'; isFaulty: false. "Explicit empty list of temporaries"
-		self new source: '[:a| ||b]'; formattedCode: '[ :a | b ]'; isFaulty: false. "Same but mess with the Scanner"
-		self new source: '[:a|| |b]'; formattedCode: '[ :a | b ]'; isFaulty: false. "Same"
-		self new source: '[:a|||b]'; formattedCode: '[ :a | b ]'; isFaulty: false. "Same"
-		self new source: '[:a||||b]'; formattedCode: '[ :a | | b ]'. "same + binary | without receiver"
+		        (self new
+			         source: '[:a b]';
+			         formattedCode: '[ :a | b ]';
+			         hasValue: true). "FIXME"
+		        (self new
+			         source: '[:a 1]';
+			         formattedCode: '[ :a | 1 ]';
+			         hasValue: true;
+			         value: 1). "FIXME"
+		        (self new
+			         source: '[:a :]';
+			         formattedCode: '[ :a : | ]';
+			         hasValue: true). "FIXME"
+		        (self new
+			         source: '[:a ::b]';
+			         formattedCode: '[ :a ::b | ]';
+			         hasValue: true). "FIXME"
+		        (self new
+			         source: '[:a :b]';
+			         formattedCode: '[ :a :b | ]';
+			         isFaulty: false). "no pipe (and no body) is legal"
+		        (self new
+			         source: '[: a : b]';
+			         formattedCode: '[ :a :b | ]';
+			         isFaulty: false). "spaces are also legal"
+		        (self new
+			         source: '[:a:b]';
+			         formattedCode: '[ : | a: b ]'). "FIXME?"
+		        (self new source: '[ a: ]'). "no parameters, a keyword message send witout receiver nor arguments"
+		        (self new source: '[ | ]').
+		        (self new source: '[ | b ]').
+		        (self new source: '[ :a | | b ]').
+		        (self new
+			         source: '[ :a || b ]';
+			         formattedCode: '[ :a | | b ]').
+		        (self new
+			         source: '[:a| | |b]';
+			         formattedCode: '[ :a | b ]';
+			         isFaulty: false). "Explicit empty list of temporaries"
+		        (self new
+			         source: '[:a| ||b]';
+			         formattedCode: '[ :a | b ]';
+			         isFaulty: false). "Same but mess with the Scanner"
+		        (self new
+			         source: '[:a|| |b]';
+			         formattedCode: '[ :a | b ]';
+			         isFaulty: false). "Same"
+		        (self new
+			         source: '[:a|||b]';
+			         formattedCode: '[ :a | b ]';
+			         isFaulty: false). "Same"
+		        (self new
+			         source: '[:a||||b]';
+			         formattedCode: '[ :a | | b ]'). "same + binary | without receiver"
 
-		"Unclosed blocks"
-		self new source: '[ : | '.
-		self new source: '[:'; formattedCode: '[ : | '.
-		self new source: '[ :a :b | '.
-		self new source: '[ :a :b'; formattedCode: '[ :a :b | '.
-		self new source: '[ :a b'; formattedCode: '[ :a | b'.
-		self new source: '[ :a | '.
-		self new source: '[ :a | b'.
-		self new source: '[ | '.
-		self new source: '[ | 1'.
-		self new source: '[ | a'.
+		        "Unclosed blocks"
+		        (self new source: '[ : | ').
+		        (self new
+			         source: '[:';
+			         formattedCode: '[ : | ').
+		        (self new source: '[ :a :b | ').
+		        (self new
+			         source: '[ :a :b';
+			         formattedCode: '[ :a :b | ').
+		        (self new
+			         source: '[ :a b';
+			         formattedCode: '[ :a | b').
+		        (self new source: '[ :a | ').
+		        (self new source: '[ :a | b').
+		        (self new source: '[ | ').
+		        (self new source: '[ | 1').
+		        (self new source: '[ | a').
 
-		"Missing receiver or argument in message sends.
+		        "Missing receiver or argument in message sends.
 		Note: a unary message send without a receiver will be 'correctly' mistaken as a variable, so not a parsing error"
-		"binary"
-		self new source: ' + '.
-		self new source: '1 + '.
-		self new source: ' + 2'.
-		"keywords"
-		self new source: ' hello: '.
-		self new source: '1 hello: '.
-		self new source: ' hello: 2'.
-		self new source: ' goodby: my: '.
-		self new source: '1 goodby: my: '.
-		self new source: '1 goodby: 2 my: '.
-		self new source: ' goodby: 2 my: '.
-		self new source: ' goodby: my: 3'.
-		self new source: '1 goodby: my: 3'.
-		self new source: ' goodby: 2 my: 3'.
-		"Combinaisons"
-		self new source: ' + foo: - '.
+		        "binary"
+		        (self new source: ' + ').
+		        (self new source: '1 + ').
+		        (self new source: ' + 2').
+		        "keywords"
+		        (self new source: ' hello: ').
+		        (self new source: '1 hello: ').
+		        (self new source: ' hello: 2').
+		        (self new source: ' goodby: my: ').
+		        (self new source: '1 goodby: my: ').
+		        (self new source: '1 goodby: 2 my: ').
+		        (self new source: ' goodby: 2 my: ').
+		        (self new source: ' goodby: my: 3').
+		        (self new source: '1 goodby: my: 3').
+		        (self new source: ' goodby: 2 my: 3').
+		        "Combinaisons"
+		        (self new source: ' + foo: - ').
 
-		"Bad assignments"
-		self new source: 'a := '.
-		self new source: ':= '.
-		self new source: ':= 2'.
-		self new source: '1:=2'; formattedCode: '1. := 2'.
+		        "Bad assignments"
+		        (self new source: 'a := ').
+		        (self new source: ':= ').
+		        (self new source: ':= 2').
+		        (self new
+			         source: '1:=2';
+			         formattedCode: '1. := 2').
 
-		"Bad cascades"
-		self new source: ';'; formattedCode: ' ; '.
-		self new source: '1;foo'; formattedCode: '1 ; foo'.
-		self new source: '1;'; formattedCode: '1 ; '.
-		self new source: '1 sign;'; formattedCode: '1 sign; '.
-		self new source: '1 foo:;bar'; formattedCode: '1 foo: ; bar'. "The cascade is correct here. It's a simple error of a missing argument"
-		self new source: '1 foo;2'; formattedCode: '1 foo; . 2'.
-		self new source: '(1 sign: 2);bar'; formattedCode: '(1 sign: 2) ; bar'.
-		self new source: '(1 sign);bar'; formattedCode: '1 sign ; bar'. "FIXME the parentheses are lost, and this changes the meaning"
-		"Longer cascade"
-		self new source: ';;'; formattedCode: ' ; ; '.
-		self new source: '1 sign;;bar'; formattedCode: '1 sign; ; bar'.
+		        "Bad cascades"
+		        (self new
+			         source: ';';
+			         formattedCode: ' ; ').
+		        (self new
+			         source: '1;foo';
+			         formattedCode: '1 ; foo').
+		        (self new
+			         source: '1;';
+			         formattedCode: '1 ; ').
+		        (self new
+			         source: '1 sign;';
+			         formattedCode: '1 sign; ').
+		        (self new
+			         source: '1 foo:;bar';
+			         formattedCode: '1 foo: ; bar'). "The cascade is correct here. It's a simple error of a missing argument"
+		        (self new
+			         source: '1 foo;2';
+			         formattedCode: '1 foo; . 2').
+		        (self new
+			         source: '(1 sign: 2);bar';
+			         formattedCode: '(1 sign: 2) ; bar').
+		        (self new
+			         source: '(1 sign);bar';
+			         formattedCode: '1 sign ; bar'). "FIXME the parentheses are lost, and this changes the meaning"
+		        "Longer cascade"
+		        (self new
+			         source: ';;';
+			         formattedCode: ' ; ; ').
+		        (self new
+			         source: '1 sign;;bar';
+			         formattedCode: '1 sign; ; bar').
 
-		"Bad returns"
-		self new source: '^ '.
-		self new source: '1+^2'; formattedCode: '1 + . ^ 2'.
-		self new source: '1 foo: ^2'; formattedCode: '1 foo: . ^ 2'.
-		self new source: '(^1)'; formattedCode: '( . ^ 1 )'. "^ can only appear a the begin of a statement, so a random ^ cause an unfinished statement error"
-		self new source: '^^1'; formattedCode: '^ . ^ 1' "Same spirit".
-		self new source: '[ ^ 1 ]'; isFaulty: false; raise: BlockCannotReturn. "when the block is evaluated, the method is already gone."
-		self new source: '{ ^ 1 }'; isFaulty: false; value: 1. "I did not expect this one to be legal"
-		self new source: '#(^1)'; formattedCode: '#( #''^'' 1 )'; isFaulty: false; value: #(^1). "Obviously..."
-		self new source: '#[ ^ 1 ]'.
+		        "Bad returns"
+		        (self new source: '^ ').
+		        (self new
+			         source: '1+^2';
+			         formattedCode: '1 + . ^ 2').
+		        (self new
+			         source: '1 foo: ^2';
+			         formattedCode: '1 foo: . ^ 2').
+		        (self new
+			         source: '(^1)';
+			         formattedCode: '( . ^ 1 )'). "^ can only appear a the begin of a statement, so a random ^ cause an unfinished statement error"
+		        (self new
+			         source: '^^1';
+			         formattedCode: '^ . ^ 1'). "Same spirit"
+		        (self new
+			         source: '[ ^ 1 ]';
+			         isFaulty: false;
+			         raise: BlockCannotReturn). "when the block is evaluated, the method is already gone."
+		        (self new
+			         source: '{ ^ 1 }';
+			         isFaulty: false;
+			         value: 1). "I did not expect this one to be legal"
+		        (self new
+			         source: '#(^1)';
+			         formattedCode: '#( #''^'' 1 )';
+			         isFaulty: false;
+			         value: #( #'^' 1 )). "Obviously..."
+		        (self new source: '#[ ^ 1 ]').
 
-		"Unreachable code (warnings)"
-		"Unreachable analysis is very simple and targets statement that directly follows a return statement."
-		"Note that faulty code can still be executed without a RuntimeSyntaxError"
-		self new source: '^ 1. 2. ^ 3'; isFaulty: false; value: 1.
-		self new source: '[ ^ 1. 2. ^ 3 ]'; isFaulty: false; raise: BlockCannotReturn. "like [^1]"
-		self new source: '{ ^ 1. 2. ^ 3 }'; isFaulty: false; value: 1.
-		self new source: '[ ^ 1 ]. 2. ^ 3'; isFaulty: false; value: 3.
-		self new source: '{ ^ 1 }. 2. ^ 3'; isFaulty: false; value: 1. "This one could have been..."
-		self new source: 'true ifTrue: [ ^ 1 ] ifFalse: [ ^ 2 ]. ^ 3'; isFaulty: false; value: 1. "Not *syntactic* enough"
+		        "Unreachable code (warnings)"
+		        "Unreachable analysis is very simple and targets statement that directly follows a return statement."
+		        "Note that faulty code can still be executed without a RuntimeSyntaxError"
+		        (self new
+			         source: '^ 1. 2. ^ 3';
+			         isFaulty: false;
+			         value: 1).
+		        (self new
+			         source: '[ ^ 1. 2. ^ 3 ]';
+			         isFaulty: false;
+			         raise: BlockCannotReturn). "like [^1]"
+		        (self new
+			         source: '{ ^ 1. 2. ^ 3 }';
+			         isFaulty: false;
+			         value: 1).
+		        (self new
+			         source: '[ ^ 1 ]. 2. ^ 3';
+			         isFaulty: false;
+			         value: 3).
+		        (self new
+			         source: '{ ^ 1 }. 2. ^ 3';
+			         isFaulty: false;
+			         value: 1). "This one could have been..."
+		        (self new
+			         source: 'true ifTrue: [ ^ 1 ] ifFalse: [ ^ 2 ]. ^ 3';
+			         isFaulty: false;
+			         value: 1). "Not *syntactic* enough"
 
-		"Bad string literal"
-		"Note: the only cases are the missing closing quotes since everything inside is captured as is and there is no escape sequences or interpolation (yet?)"
-		self new source: '''hello'.
-		self new source: '''hello''''world'.
-		self new source: ''''.
-		self new source: '''hello'''''. "unclosed string that ends with an escaped quote"
+		        "Bad string literal"
+		        "Note: the only cases are the missing closing quotes since everything inside is captured as is and there is no escape sequences or interpolation (yet?)"
+		        (self new source: '''hello').
+		        (self new source: '''hello''''world').
+		        (self new source: '''').
+		        (self new source: '''hello'''''). "unclosed string that ends with an escaped quote"
 
-		"Bad symbol literal"
-		self new source: '#1'; formattedCode: '#. 1'. "Become a bad sequence"
-		self new source: '#1r0'; formattedCode: '#. 1 r0'. "Two bad sequences"
-		self new source: '##'; formattedCode: '#'. "errr. ok?"
-		"Note: if quotes, same thing than strings"
-		self new source: '#''hello'.
-		self new source: '#''hello''''world'.
-		self new source: '#'''.
-		self new source: '#''hello'''''.
-		self new source: '###''hello'.
-		self new source: '###''hello''''world'.
-		self new source: '###'''.
-		self new source: '###''hello'''''.
+		        "Bad symbol literal"
+		        (self new
+			         source: '#1';
+			         formattedCode: '#. 1'). "Become a bad sequence"
+		        (self new
+			         source: '#1r0';
+			         formattedCode: '#. 1 r0'). "Two bad sequences"
+		        (self new
+			         source: '##';
+			         formattedCode: '#'). "errr. ok?"
+		        "Note: if quotes, same thing than strings"
+		        (self new source: '#''hello').
+		        (self new source: '#''hello''''world').
+		        (self new source: '#''').
+		        (self new source: '#''hello''''').
+		        (self new source: '###''hello').
+		        (self new source: '###''hello''''world').
+		        (self new source: '###''').
+		        (self new source: '###''hello''''').
 
-		"Bad numeric literal"
-		"Note: currently there is only 2 cases or bad numeric literal, both related to bad radix"
-		self new source: '2r'.
-		self new source: '2rx'; formattedCode: '2r x'. "a bad number followed by a unary message send"
-		self new source: '2r3'; formattedCode: '2r. 3'. "a bad number followed by a number, causing a case of unfinished sequence"
-		self new source: '0r'; formattedCode: '0 r'.
-		self new source: '000rx'; formattedCode: '000 rx'.
-		self new source: '000r1'; formattedCode: '000 r1'.
-		self new source: '3r12345'; formattedCode: '3r12. 345'.
+		        "Bad numeric literal"
+		        "Note: currently there is only 2 cases or bad numeric literal, both related to bad radix"
+		        (self new source: '2r').
+		        (self new
+			         source: '2rx';
+			         formattedCode: '2r x'). "a bad number followed by a unary message send"
+		        (self new
+			         source: '2r3';
+			         formattedCode: '2r. 3'). "a bad number followed by a number, causing a case of unfinished sequence"
+		        (self new
+			         source: '0r';
+			         formattedCode: '0 r').
+		        (self new
+			         source: '000rx';
+			         formattedCode: '000 rx').
+		        (self new
+			         source: '000r1';
+			         formattedCode: '000 r1').
+		        (self new
+			         source: '3r12345';
+			         formattedCode: '3r12. 345').
 
-		"These ones are correct, the number parser is very prermisive (except for radix, see above)"
-		self new source: '1.'; formattedCode: '1'; isFaulty: false; value:1.
-		self new source: '1.1.1'; formattedCode: '1.1. 1'; isFaulty: false; value:1.
-		self new source: '1a'; formattedCode: '1 a'; isFaulty: false; messageNotUnderstood: #a.
-		self new source: '1a1a1'; formattedCode: '1 a1a1'; isFaulty: false; messageNotUnderstood: #a1a1.
-		self new source: '1e'; formattedCode: '1 e'; isFaulty: false; messageNotUnderstood: #e.
-		self new source: '1e1e1'; formattedCode: '1e1 e1'; isFaulty: false; messageNotUnderstood: #e1.
-		self new source: '1s'; isFaulty: false; value: 1s0. "ScaledDecimal is a thing (!) that have literals (!!) inconsistent with '1e' (!!!)"
-		self new source: '1s1s1'; formattedCode: '1s1 s1'; isFaulty: false; messageNotUnderstood: #s1.
-		self new source: '10r89abcd'; formattedCode: '10r89 abcd'; isFaulty: false; messageNotUnderstood: #abcd.
-		self new source: '12r89abcd'; formattedCode: '12r89ab cd'; isFaulty: false; messageNotUnderstood: #cd.
-		self new source: '36r1halt'; isFaulty: false; value: 2486513. "ahah"
+		        "These ones are correct, the number parser is very prermisive (except for radix, see above)"
+		        (self new
+			         source: '1.';
+			         formattedCode: '1';
+			         isFaulty: false;
+			         value: 1).
+		        (self new
+			         source: '1.1.1';
+			         formattedCode: '1.1. 1';
+			         isFaulty: false;
+			         value: 1).
+		        (self new
+			         source: '1a';
+			         formattedCode: '1 a';
+			         isFaulty: false;
+			         messageNotUnderstood: #a).
+		        (self new
+			         source: '1a1a1';
+			         formattedCode: '1 a1a1';
+			         isFaulty: false;
+			         messageNotUnderstood: #a1a1).
+		        (self new
+			         source: '1e';
+			         formattedCode: '1 e';
+			         isFaulty: false;
+			         messageNotUnderstood: #e).
+		        (self new
+			         source: '1e1e1';
+			         formattedCode: '1e1 e1';
+			         isFaulty: false;
+			         messageNotUnderstood: #e1).
+		        (self new
+			         source: '1s';
+			         isFaulty: false;
+			         value: 1s0). "ScaledDecimal is a thing (!) that have literals (!!) inconsistent with '1e' (!!!)"
+		        (self new
+			         source: '1s1s1';
+			         formattedCode: '1s1 s1';
+			         isFaulty: false;
+			         messageNotUnderstood: #s1).
+		        (self new
+			         source: '10r89abcd';
+			         formattedCode: '10r89 abcd';
+			         isFaulty: false;
+			         messageNotUnderstood: #abcd).
+		        (self new
+			         source: '12r89abcd';
+			         formattedCode: '12r89ab cd';
+			         isFaulty: false;
+			         messageNotUnderstood: #cd).
+		        (self new
+			         source: '36r1halt';
+			         isFaulty: false;
+			         value: 2486513). "ahah"
 
-		"Bad characters"
-		"Pharo is Unicode aware."
-		"$Δ isLetter >>> true" "$Δ asInteger >>> 16r0394" "Greek Capital Letter Delta"
-		"$ə isLetter >>> true" "$ə asInteger >>> 16r0259" "Latin Small Letter Schwa"
-		self new source: 'Δə'; isFaulty: false. "valid identifier"
-		self new source: '| Δə | Δə := 1. Δə + 1'; isFaulty: false; value: 2.
+		        "Bad characters"
+		        "Pharo is Unicode aware."
+		        "$Δ isLetter >>> true" "$Δ asInteger >>> 16r0394" "Greek Capital Letter Delta"
+		        "$ə isLetter >>> true" "$ə asInteger >>> 16r0259" "Latin Small Letter Schwa"
+		        (self new
+			         source: 'Δə';
+			         isFaulty: false). "valid identifier"
+		        (self new
+			         source: '| Δə | Δə := 1. Δə + 1';
+			         isFaulty: false;
+			         value: 2).
 
-		"$± isSpecial >>> true" "$± asInteger >>> 16r00B1" "Plus Minus Sign" "Only a few unicode characters are isSpecial in Pharo"
-		self new source: '1 ± 1'; isFaulty: false; messageNotUnderstood: #'±'. "Valid binary operator, but not implemented"
-		"$→ isSpecial >>> false" "$→ asInteger hex >>> 16r2192" "Rightwards Arrow"
-		self new source: '→'. "Unknown character. Not isSpecial"
-		"$٠ isDigit >>> true" "$٠ asInteger >>> 16r0660" "Arabic-indic Digit Zero"
-		self new source: '٠'. "Unknown character. Not a valid number (basic ASCII only for numbers!)"
-		"Currently in Pharo, there is no 'isSeparator' character outside the ASCII range"
-		"Character nbsp isSeparator >>> false" "Even the standard nbsp"
-		self new source: Character nbsp asString. "Unknown character. Not isSeparator"
+		        "$± isSpecial >>> true" "$± asInteger >>> 16r00B1" "Plus Minus Sign" "Only a few unicode characters are isSpecial in Pharo"
+		        (self new
+			         source: '1 ± 1';
+			         isFaulty: false;
+			         messageNotUnderstood: #±). "Valid binary operator, but not implemented"
+		        "$→ isSpecial >>> false" "$→ asInteger hex >>> 16r2192" "Rightwards Arrow"
+		        (self new source: '→'). "Unknown character. Not isSpecial"
+		        "$٠ isDigit >>> true" "$٠ asInteger >>> 16r0660" "Arabic-indic Digit Zero"
+		        (self new source: '٠'). "Unknown character. Not a valid number (basic ASCII only for numbers!)"
+		        "Currently in Pharo, there is no 'isSeparator' character outside the ASCII range"
+		        "Character nbsp isSeparator >>> false" "Even the standard nbsp"
+		        (self new source: Character nbsp asString). "Unknown character. Not isSeparator"
 
-		self new source: '$→'; isFaulty: false; value: $→.
-		self new source: '''Δ→ə'''; isFaulty: false; value: 'Δ→ə'.
-		self new source: '"Δ→ə" '; isFaulty: false.
-		self new source: '#''Δ→ə'''; isFaulty: false; value: #'Δ→ə'.
-		self new source: '#Δə'; formattedCode: '#''Δə''' ; isFaulty: false; value: #'Δə'.
-		self new source: '#(Δ→ə)'; formattedCode: '#( Δ → ə )'. "This one is faulty because → is a parse error"
-		self new source: '#→'; formattedCode: '#. →'. "Two independent errors"
-		}.
+		        (self new
+			         source: '$→';
+			         isFaulty: false;
+			         value: $→).
+		        (self new
+			         source: '''Δ→ə''';
+			         isFaulty: false;
+			         value: 'Δ→ə').
+		        (self new
+			         source: '"Δ→ə" ';
+			         isFaulty: false).
+		        (self new
+			         source: '#''Δ→ə''';
+			         isFaulty: false;
+			         value: #'Δ→ə').
+		        (self new
+			         source: '#Δə';
+			         formattedCode: '#''Δə''';
+			         isFaulty: false;
+			         value: #'Δə').
+		        (self new
+			         source: '#(Δ→ə)';
+			         formattedCode: '#( Δ → ə )'). "This one is faulty because → is a parse error"
+		        (self new
+			         source: '#→';
+			         formattedCode: '#. →') "Two independent errors" }.
+	"Random alone special character (lone opening or closing characters are managed in others sections)"
 	"Setup default values"
 	list do: [ :each |
 		each isMethod: false.
 		each isFaulty ifNil: [ each isFaulty: true ].
-		each formattedCode ifNil: [ each formattedCode: each source ].
-	].
+		each formattedCode ifNil: [ each formattedCode: each source ] ].
 	^ list
 ]
 
@@ -336,134 +615,289 @@ RBCodeSnippet class >> badMethods [
 
 	| list |
 	list := {
-		"Emptyness"
-		self new source: ' '.
+		        (self new source: ' ').
 
-		"Wrong token for pattern"
-		"An empty pattern will be set, and the first statement will be a error node."
-		self new source: '5'; formattedCode: ' . 5'.
-		self new source: '''hello'''; formattedCode: ' . ''hello'''.
-		self new source: '#hello'; formattedCode: ' . #hello'.
-		self new source: ':'; formattedCode: ' . :'.
-		self new source: '#(foo bar)'; formattedCode: ' . #( foo bar )'.
+		        "Wrong token for pattern"
+		        "An empty pattern will be set, and the first statement will be a error node."
+		        (self new
+			         source: '5';
+			         formattedCode: ' . 5').
+		        (self new
+			         source: '''hello''';
+			         formattedCode: ' . ''hello''').
+		        (self new
+			         source: '#hello';
+			         formattedCode: ' . #hello').
+		        (self new
+			         source: ':';
+			         formattedCode: ' . :').
+		        (self new
+			         source: '#(foo bar)';
+			         formattedCode: ' . #( foo bar )').
 
-		"Random bad token"
-		"Tought: is complainng about the bad token really better than complaining about the bad pattern?"
-		self new source: ' $'.
-		self new source: ' ''hello'.
-		self new source: ' 2r3'; formattedCode: ' 2r. 3'.
+		        "Random bad token"
+		        "Tought: is complainng about the bad token really better than complaining about the bad pattern?"
+		        (self new source: ' $').
+		        (self new source: ' ''hello').
+		        (self new
+			         source: ' 2r3';
+			         formattedCode: ' 2r. 3').
 
-		"Bad aruments"
-		"The missing argument will be an error, the remainer starts the body"
-		self new source: '+ '; hasValue: true.
-		self new source: '+ 1'; hasValue: true.
-		self new source: '+ foo: '.
-		self new source: 'foo: '; hasValue: true.
-		self new source: 'foo: 1'; hasValue: true.
-		self new source: 'foo: + '.
-		self new source: 'foo: bar: '; hasValue: true.
-		self new source: 'foo:bar:'; formattedCode: ' . foo:bar:'. "`foo:bar:` is a single token, and is unexpected"
+		        "Bad aruments"
+		        "The missing argument will be an error, the remainer starts the body"
+		        (self new
+			         source: '+ ';
+			         hasValue: true).
+		        (self new
+			         source: '+ 1';
+			         hasValue: true).
+		        (self new source: '+ foo: ').
+		        (self new
+			         source: 'foo: ';
+			         hasValue: true).
+		        (self new
+			         source: 'foo: 1';
+			         hasValue: true).
+		        (self new source: 'foo: + ').
+		        (self new
+			         source: 'foo: bar: ';
+			         hasValue: true).
+		        (self new
+			         source: 'foo:bar:';
+			         formattedCode: ' . foo:bar:'). "`foo:bar:` is a single token, and is unexpected"
 
-		"Bad pragma message"
-		self new source: 'foo < '; hasValue: true.
-		self new source: 'foo <> '.
-		self new source: 'foo < 4'; hasValue: true.
-		self new source: 'foo < bar '; hasValue: true.
-		self new source: 'foo < bar: '; hasValue: true.
-		self new source: 'foo < bar: 1 1 > '.
-		self new source: 'foo < bar ; baz > '; formattedCode: 'foo < bar ; baz. > '.
+		        "Bad pragma message"
+		        (self new
+			         source: 'foo < ';
+			         hasValue: true).
+		        (self new source: 'foo <> ').
+		        (self new
+			         source: 'foo < 4';
+			         hasValue: true).
+		        (self new
+			         source: 'foo < bar ';
+			         hasValue: true).
+		        (self new
+			         source: 'foo < bar: ';
+			         hasValue: true).
+		        (self new source: 'foo < bar: 1 1 > ').
+		        (self new
+			         source: 'foo < bar ; baz > ';
+			         formattedCode: 'foo < bar ; baz. > ').
 
-		"Bad pragma value"
-		self new source: 'foo <bar: > '; hasValue: true.
-		self new source: 'foo <bar:(1)>'; formattedCode: 'foo < bar: 1 > '. "FIXME. dont eat parentheses"
-		self new source: 'foo < bar: baz > '.
-		self new source: 'foo < bar: 1 + 1 > '.
-		self new source: 'foo < bar: [ 1 ] > '.
-		self new source: 'foo < bar: { 1 } > '.
-		self new source: 'foo <bar: #[ -1 ]> '; hasValue: true. "Literal bytes arrays are acceptable, but this one is faulty"
-		self new source: 'foo < + 1> '; isFaulty: false. "Binary message is legal pragma"
-		self new source: 'foo < + > '; hasValue: true.
-		}.
+		        "Bad pragma value"
+		        (self new
+			         source: 'foo <bar: > ';
+			         hasValue: true).
+		        (self new
+			         source: 'foo <bar:(1)>';
+			         formattedCode: 'foo < bar: 1 > '). "FIXME. dont eat parentheses"
+		        (self new source: 'foo < bar: baz > ').
+		        (self new source: 'foo < bar: 1 + 1 > ').
+		        (self new source: 'foo < bar: [ 1 ] > ').
+		        (self new source: 'foo < bar: { 1 } > ').
+		        (self new
+			         source: 'foo <bar: #[ -1 ]> ';
+			         hasValue: true). "Literal bytes arrays are acceptable, but this one is faulty"
+		        (self new
+			         source: 'foo < + 1> ';
+			         isFaulty: false). "Binary message is legal pragma"
+		        (self new
+			         source: 'foo < + > ';
+			         hasValue: true) }.
+	"Emptyness"
 	"Setup default values"
 	list do: [ :each |
 		each isMethod: true.
 		each isFaulty ifNil: [ each isFaulty: true ].
-		each formattedCode ifNil: [ each formattedCode: each source ].
-	].
+		each formattedCode ifNil: [ each formattedCode: each source ] ].
 	^ list
 ]
 
 { #category : #accessing }
 RBCodeSnippet class >> badSemantic [
-
 	"List of varions semantic and backend errors."
+
 	| list |
 	list := {
-		"Undefined variable"
-		"For some reason, this is just a warning in non-faulty mode, not an error."
-		self new source: 'a := 10. ^ a'; isFaulty: false; value: nil; skip: #exec. "a is bound to an undefined variable, and according to some compilation options it could be registerer or not registered. This is very bad as regitred ones act like globals thus polute other tests. So disable the execution for now."
-		self new source: '^ a'; isFaulty: false; value: nil.
+		        (self new
+			         source: 'a := 10. ^ a';
+			         isFaulty: false;
+			         value: nil;
+			         skip: #exec). "a is bound to an undefined variable, and according to some compilation options it could be registerer or not registered. This is very bad as regitred ones act like globals thus polute other tests. So disable the execution for now."
+		        (self new
+			         source: '^ a';
+			         isFaulty: false;
+			         value: nil).
 
-		"Uninitialized variable"
-		self new source: '| a | ^ a'; value: nil.
-		self new source: '| a | [ a := 10 ]. ^ a'; value: nil.
-		self new source: '| a | [ ^ a ]. a := 10'; value: 10.
+		        "Uninitialized variable"
+		        (self new
+			         source: '| a | ^ a';
+			         value: nil).
+		        (self new
+			         source: '| a | [ a := 10 ]. ^ a';
+			         value: nil).
+		        (self new
+			         source: '| a | [ ^ a ]. a := 10';
+			         value: 10).
 
-		"Duplicated variable definition (same scope)"
-		self new source: 'foo: a bar: a ^ a'; value: 1; isMethod: true.
-		self new source: '| a a | a := 10. ^ a'; value: 10.
-		self new source: '[ | a a | a := 10. a ]'; value: 10.
-		self new source: '[ :a :a | a ]'; value: 1.
+		        "Duplicated variable definition (same scope)"
+		        (self new
+			         source: 'foo: a bar: a ^ a';
+			         value: 1;
+			         isMethod: true).
+		        (self new
+			         source: '| a a | a := 10. ^ a';
+			         value: 10).
+		        (self new
+			         source: '[ | a a | a := 10. a ]';
+			         value: 10).
+		        (self new
+			         source: '[ :a :a | a ]';
+			         value: 1).
 
-		"Shadowed variables"
-		self new source: 'foo: a ^ [ | a | a := 10. a ] value + a'; isMethod: true; value: 11.
-		self new source: 'foo | a | a := 1. ^ [ | a | a := 10. a ] value + a'; isMethod: true; value: 11.
-		self new source: 'foo ^ [ | a | a := 1. [ | a | a := 10. a ] value + a ] value'; isMethod: true; value: 11.
-		self new source: 'foo ^ [ :a | [ | a | a := 10. a ] value + a ] value: 1'; isMethod: true; value: 11.
-		self new source: 'foo: a ^ [ :a | a ] value: 10 + a'; isMethod: true; value: 11.
-		self new source: 'foo | a | a := 1. ^ [ :a | a ] value: 10 + a'; isMethod: true; value: 11.
-		self new source: 'foo ^ [ | a | a := 1. [ :a | a ] value: 10 + a ] value'; isMethod: true; value: 11.
-		self new source: 'foo ^ [ :a | [ :a | a ] value: 10 + a ] value: 1'; isMethod: true; value: 11. "phonyArgs"
+		        "Shadowed variables"
+		        (self new
+			         source: 'foo: a ^ [ | a | a := 10. a ] value + a';
+			         isMethod: true;
+			         value: 11).
+		        (self new
+			         source:
+				         'foo | a | a := 1. ^ [ | a | a := 10. a ] value + a';
+			         isMethod: true;
+			         value: 11).
+		        (self new
+			         source:
+				         'foo ^ [ | a | a := 1. [ | a | a := 10. a ] value + a ] value';
+			         isMethod: true;
+			         value: 11).
+		        (self new
+			         source:
+				         'foo ^ [ :a | [ | a | a := 10. a ] value + a ] value: 1';
+			         isMethod: true;
+			         value: 11).
+		        (self new
+			         source: 'foo: a ^ [ :a | a ] value: 10 + a';
+			         isMethod: true;
+			         value: 11).
+		        (self new
+			         source: 'foo | a | a := 1. ^ [ :a | a ] value: 10 + a';
+			         isMethod: true;
+			         value: 11).
+		        (self new
+			         source:
+				         'foo ^ [ | a | a := 1. [ :a | a ] value: 10 + a ] value';
+			         isMethod: true;
+			         value: 11).
+		        (self new
+			         source: 'foo ^ [ :a | [ :a | a ] value: 10 + a ] value: 1';
+			         isMethod: true;
+			         value: 11). "phonyArgs"
 
-		"Write on readonly or reserved"
-		self new source: 'foo: a a := 10. ^ a'; isMethod: true; isFaulty: true.
-		self new source: '[ :a | a := 10. a ]'; isFaulty: true.
-		"The following assignment are explicitely no-op, to minimize the impact if, for some broken reasons, they are really executed"
-		self new source: 'nil := nil'; isFaulty: true; isParseFaulty: true; formattedCode: 'nil. := nil'. "it is a literal, not an identifier"
-		self new source: 'true := true'; isFaulty: true; isParseFaulty: true; formattedCode: 'true. := true'. "it is a literal, not an identifier"
-		self new source: 'false := false'; isFaulty: true; isParseFaulty: true; formattedCode: 'false. := false'. "it is a literal, not an identifier"
-		self new source: 'self := self'; isFaulty: true; numberOfCritiques: 1.
-		self new source: 'super := super'; isFaulty: true; numberOfCritiques: 1.
-		self new source: 'thisContext := thisContext'; isFaulty: true; numberOfCritiques: 1.
-		self new source: 'Object := Object'; isFaulty: true; numberOfCritiques: 1.
+		        "Write on readonly or reserved"
+		        (self new
+			         source: 'foo: a a := 10. ^ a';
+			         isMethod: true;
+			         isFaulty: true).
+		        (self new
+			         source: '[ :a | a := 10. a ]';
+			         isFaulty: true).
+		        "The following assignment are explicitely no-op, to minimize the impact if, for some broken reasons, they are really executed"
+		        (self new
+			         source: 'nil := nil';
+			         isFaulty: true;
+			         isParseFaulty: true;
+			         formattedCode: 'nil. := nil'). "it is a literal, not an identifier"
+		        (self new
+			         source: 'true := true';
+			         isFaulty: true;
+			         isParseFaulty: true;
+			         formattedCode: 'true. := true'). "it is a literal, not an identifier"
+		        (self new
+			         source: 'false := false';
+			         isFaulty: true;
+			         isParseFaulty: true;
+			         formattedCode: 'false. := false'). "it is a literal, not an identifier"
+		        (self new
+			         source: 'self := self';
+			         isFaulty: true;
+			         numberOfCritiques: 1).
+		        (self new
+			         source: 'super := super';
+			         isFaulty: true;
+			         numberOfCritiques: 1).
+		        (self new
+			         source: 'thisContext := thisContext';
+			         isFaulty: true;
+			         numberOfCritiques: 1).
+		        (self new
+			         source: 'Object := Object';
+			         isFaulty: true;
+			         numberOfCritiques: 1).
 
-		"Shadowed reserved or global"
-		self new source: '| self | self := 1. ^ self'; value: 1.
-		self new source: '| super | super := 1. ^ super'; value: 1.
-		self new source: '| thisContext | thisContext := 1. ^ thisContext'; value: 1.
-		self new source: '| Object | Object := 1. ^ Object'; value: 1.
-		self new source: 'foo: self ^ self + 1'; isMethod: true; value: 2.
-		self new source: 'foo: super ^ super + 1'; isMethod: true; value: 2.
-		self new source: 'foo: thisContext ^ thisContext + 1'; isMethod: true; value: 2.
-		self new source: 'foo: Object ^ Object + 1'; isMethod: true; value: 2.
-		self new source: '[ :self | self + 1 ]'; value: 2.
-		self new source: '[ :super | super + 1 ]'; value: 2.
-		self new source: '[ :thisContext | thisContext + 1 ]'; value: 2.
-		self new source: '[ :Object | Object + 1 ]'; value: 2.
+		        "Shadowed reserved or global"
+		        (self new
+			         source: '| self | self := 1. ^ self';
+			         value: 1).
+		        (self new
+			         source: '| super | super := 1. ^ super';
+			         value: 1).
+		        (self new
+			         source: '| thisContext | thisContext := 1. ^ thisContext';
+			         value: 1).
+		        (self new
+			         source: '| Object | Object := 1. ^ Object';
+			         value: 1).
+		        (self new
+			         source: 'foo: self ^ self + 1';
+			         isMethod: true;
+			         value: 2).
+		        (self new
+			         source: 'foo: super ^ super + 1';
+			         isMethod: true;
+			         value: 2).
+		        (self new
+			         source: 'foo: thisContext ^ thisContext + 1';
+			         isMethod: true;
+			         value: 2).
+		        (self new
+			         source: 'foo: Object ^ Object + 1';
+			         isMethod: true;
+			         value: 2).
+		        (self new
+			         source: '[ :self | self + 1 ]';
+			         value: 2).
+		        (self new
+			         source: '[ :super | super + 1 ]';
+			         value: 2).
+		        (self new
+			         source: '[ :thisContext | thisContext + 1 ]';
+			         value: 2).
+		        (self new
+			         source: '[ :Object | Object + 1 ]';
+			         value: 2).
 
-		"Backend errors"
-		"FIXME: syntax error are thrown by the compiler even in *faulty* mode.
+		        "Backend errors"
+		        "FIXME: syntax error are thrown by the compiler even in *faulty* mode.
 		 FIXME: semantic analysis does not catch the error (backend issue)"
-		self new source: 'foo ^ [ :a1 :a2 :a3 :a4 :a5 :a6 :a7 :a8 :a9 :a10 :a11 :a12 :a13 :a14 :a15 :a16 | a1 ]'; isMethod: true; isFaulty: true. "Too many arguments"
-		self new source: 'a1: a1 a2: a2 a3: a3 a4: a4 a5: a5 a6: a6 a7: a7 a8: a8 a9: a9 a10: a10 a11: a11 a12: a12 a13: a13 a14: a14 a15: a15 a16: a16 ^ a1'; isMethod: true; isFaulty: true. "Too many arguments"
-		}.
+		        (self new
+			         source:
+				         'foo ^ [ :a1 :a2 :a3 :a4 :a5 :a6 :a7 :a8 :a9 :a10 :a11 :a12 :a13 :a14 :a15 :a16 | a1 ]';
+			         isMethod: true;
+			         isFaulty: true). "Too many arguments"
+		        (self new
+			         source:
+				         'a1: a1 a2: a2 a3: a3 a4: a4 a5: a5 a6: a6 a7: a7 a8: a8 a9: a9 a10: a10 a11: a11 a12: a12 a13: a13 a14: a14 a15: a15 a16: a16 ^ a1';
+			         isMethod: true;
+			         isFaulty: true) "Too many arguments" }.
+	"Undefined variable"
+	"For some reason, this is just a warning in non-faulty mode, not an error."
 	"Setup default values"
 	list do: [ :each |
 		each isMethod ifNil: [ each isMethod: false ].
 		each isFaulty ifNil: [ each isFaulty: false ].
 		each isParseFaulty ifNil: [ each isParseFaulty: false ].
-		each formattedCode ifNil: [ each formattedCode: each source ]
-	].
+		each formattedCode ifNil: [ each formattedCode: each source ] ].
 	^ list
 ]
 

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -260,20 +260,19 @@ RBCodeSnippet class >> badExpressions [
 		        (self new
 			         source: '[:a b]';
 			         formattedCode: '[ :a | b ]';
-			         hasValue: true). "FIXME"
+			         value: nil). "FIXME"
 		        (self new
 			         source: '[:a 1]';
 			         formattedCode: '[ :a | 1 ]';
-			         hasValue: true;
 			         value: 1). "FIXME"
 		        (self new
 			         source: '[:a :]';
 			         formattedCode: '[ :a : | ]';
-			         hasValue: true). "FIXME"
+			         value: nil). "FIXME"
 		        (self new
 			         source: '[:a ::b]';
 			         formattedCode: '[ :a ::b | ]';
-			         hasValue: true). "FIXME"
+			         value: nil). "FIXME"
 		        (self new
 			         source: '[:a :b]';
 			         formattedCode: '[ :a :b | ]';
@@ -649,21 +648,21 @@ RBCodeSnippet class >> badMethods [
 		        "The missing argument will be an error, the remainer starts the body"
 		        (self new
 			         source: '+ ';
-			         hasValue: true).
+			         value: nil).
 		        (self new
 			         source: '+ 1';
-			         hasValue: true).
+			         value: nil).
 		        (self new source: '+ foo: ').
 		        (self new
 			         source: 'foo: ';
-			         hasValue: true).
+			         value: nil).
 		        (self new
 			         source: 'foo: 1';
-			         hasValue: true).
+			         value: nil).
 		        (self new source: 'foo: + ').
 		        (self new
 			         source: 'foo: bar: ';
-			         hasValue: true).
+			         value: nil).
 		        (self new
 			         source: 'foo:bar:';
 			         formattedCode: ' . foo:bar:'). "`foo:bar:` is a single token, and is unexpected"
@@ -671,17 +670,17 @@ RBCodeSnippet class >> badMethods [
 		        "Bad pragma message"
 		        (self new
 			         source: 'foo < ';
-			         hasValue: true).
+			         value: nil).
 		        (self new source: 'foo <> ').
 		        (self new
 			         source: 'foo < 4';
-			         hasValue: true).
+			         value: nil).
 		        (self new
 			         source: 'foo < bar ';
-			         hasValue: true).
+			         value: nil).
 		        (self new
 			         source: 'foo < bar: ';
-			         hasValue: true).
+			         value: nil).
 		        (self new source: 'foo < bar: 1 1 > ').
 		        (self new
 			         source: 'foo < bar ; baz > ';
@@ -690,7 +689,7 @@ RBCodeSnippet class >> badMethods [
 		        "Bad pragma value"
 		        (self new
 			         source: 'foo <bar: > ';
-			         hasValue: true).
+			         value: nil).
 		        (self new
 			         source: 'foo <bar:(1)>';
 			         formattedCode: 'foo < bar: 1 > '). "FIXME. dont eat parentheses"
@@ -700,13 +699,13 @@ RBCodeSnippet class >> badMethods [
 		        (self new source: 'foo < bar: { 1 } > ').
 		        (self new
 			         source: 'foo <bar: #[ -1 ]> ';
-			         hasValue: true). "Literal bytes arrays are acceptable, but this one is faulty"
+			         value: nil). "Literal bytes arrays are acceptable, but this one is faulty"
 		        (self new
 			         source: 'foo < + 1> ';
 			         isFaulty: false). "Binary message is legal pragma"
 		        (self new
 			         source: 'foo < + > ';
-			         hasValue: true) }.
+			         value: nil) }.
 	"Setup default values"
 	self new
 		group: #badMethods;
@@ -726,21 +725,13 @@ RBCodeSnippet class >> badSemantic [
 	list := {
 		        (self new
 			         source: 'a := 10. ^ a';
-			         isFaulty: false;
-			         value: nil;
+			         value: 10;
 			         skip: #exec). "a is bound to an undefined variable, and according to some compilation options it could be registerer or not registered. This is very bad as regitred ones act like globals thus polute other tests. So disable the execution for now."
-		        (self new
-			         source: '^ a';
-			         isFaulty: false;
-			         value: nil).
+		        (self new source: '^ a').
 
 		        "Uninitialized variable"
-		        (self new
-			         source: '| a | ^ a';
-			         value: nil).
-		        (self new
-			         source: '| a | [ a := 10 ]. ^ a';
-			         value: nil).
+		        (self new source: '| a | ^ a').
+		        (self new source: '| a | [ a := 10 ]. ^ a').
 		        (self new
 			         source: '| a | [ ^ a ]. a := 10';
 			         value: 10).
@@ -748,8 +739,8 @@ RBCodeSnippet class >> badSemantic [
 		        "Duplicated variable definition (same scope)"
 		        (self new
 			         source: 'foo: a bar: a ^ a';
-			         value: 1;
-			         isMethod: true).
+			         isMethod: true;
+			         value: 1).
 		        (self new
 			         source: '| a a | a := 10. ^ a';
 			         value: 10).
@@ -809,19 +800,19 @@ RBCodeSnippet class >> badSemantic [
 		        "The following assignment are explicitely no-op, to minimize the impact if, for some broken reasons, they are really executed"
 		        (self new
 			         source: 'nil := nil';
+			         formattedCode: 'nil. := nil';
 			         isFaulty: true;
-			         isParseFaulty: true;
-			         formattedCode: 'nil. := nil'). "it is a literal, not an identifier"
+			         isParseFaulty: true). "it is a literal, not an identifier"
 		        (self new
 			         source: 'true := true';
+			         formattedCode: 'true. := true';
 			         isFaulty: true;
-			         isParseFaulty: true;
-			         formattedCode: 'true. := true'). "it is a literal, not an identifier"
+			         isParseFaulty: true). "it is a literal, not an identifier"
 		        (self new
 			         source: 'false := false';
+			         formattedCode: 'false. := false';
 			         isFaulty: true;
-			         isParseFaulty: true;
-			         formattedCode: 'false. := false'). "it is a literal, not an identifier"
+			         isParseFaulty: true). "it is a literal, not an identifier"
 		        (self new
 			         source: 'self := self';
 			         isFaulty: true;

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -33,7 +33,9 @@ Class {
 		'skippedTests',
 		'raise',
 		'messageNotUnderstood',
-		'numberOfCritiques'
+		'numberOfCritiques',
+		'group',
+		'default'
 	],
 	#category : #'AST-Core-Tests-Snippets'
 }
@@ -601,12 +603,12 @@ RBCodeSnippet class >> badExpressions [
 		        (self new
 			         source: '#→';
 			         formattedCode: '#. →') "Two independent errors" }.
-	"Random alone special character (lone opening or closing characters are managed in others sections)"
 	"Setup default values"
-	list do: [ :each |
-		each isMethod: false.
-		each isFaulty ifNil: [ each isFaulty: true ].
-		each formattedCode ifNil: [ each formattedCode: each source ] ].
+	self new
+		group: #badExpressions;
+		isMethod: false;
+		isFaulty: true;
+		applyDefaultTo: list.
 	^ list
 ]
 
@@ -705,12 +707,12 @@ RBCodeSnippet class >> badMethods [
 		        (self new
 			         source: 'foo < + > ';
 			         hasValue: true) }.
-	"Emptyness"
 	"Setup default values"
-	list do: [ :each |
-		each isMethod: true.
-		each isFaulty ifNil: [ each isFaulty: true ].
-		each formattedCode ifNil: [ each formattedCode: each source ] ].
+	self new
+		group: #badMethods;
+		isMethod: true;
+		isFaulty: true;
+		applyDefaultTo: list.
 	^ list
 ]
 
@@ -719,6 +721,8 @@ RBCodeSnippet class >> badSemantic [
 	"List of varions semantic and backend errors."
 
 	| list |
+	"Undefined variable
+	For some reason, this is just a warning in non-faulty mode, not an error."
 	list := {
 		        (self new
 			         source: 'a := 10. ^ a';
@@ -890,14 +894,13 @@ RBCodeSnippet class >> badSemantic [
 				         'a1: a1 a2: a2 a3: a3 a4: a4 a5: a5 a6: a6 a7: a7 a8: a8 a9: a9 a10: a10 a11: a11 a12: a12 a13: a13 a14: a14 a15: a15 a16: a16 ^ a1';
 			         isMethod: true;
 			         isFaulty: true) "Too many arguments" }.
-	"Undefined variable"
-	"For some reason, this is just a warning in non-faulty mode, not an error."
 	"Setup default values"
-	list do: [ :each |
-		each isMethod ifNil: [ each isMethod: false ].
-		each isFaulty ifNil: [ each isFaulty: false ].
-		each isParseFaulty ifNil: [ each isParseFaulty: false ].
-		each formattedCode ifNil: [ each formattedCode: each source ] ].
+	self new
+		group: #badSemantic;
+		isMethod: false;
+		isFaulty: false;
+		isParseFaulty: false;
+		applyDefaultTo: list.
 	^ list
 ]
 
@@ -960,6 +963,24 @@ RBCodeSnippet class >> styleAllWithError [
 ]
 
 { #category : #accessing }
+RBCodeSnippet >> applyDefaultTo: aCollection [
+
+	aCollection do: [ :each |
+		each default: self.
+		each isMethod ifNil: [ each isMethod: self isMethod ].
+		each isParseFaulty ifNil: [ each isParseFaulty: self isParseFaulty ].
+		each isFaulty ifNil: [ each isFaulty: self isFaulty ].
+		each formattedCode ifNil: [ each formattedCode: each source ].
+	]
+]
+
+{ #category : #accessing }
+RBCodeSnippet >> default: aRBCodeSnippet [
+
+	default := aRBCodeSnippet
+]
+
+{ #category : #accessing }
 RBCodeSnippet >> formattedCode [
 
 	^ formattedCode
@@ -969,6 +990,16 @@ RBCodeSnippet >> formattedCode [
 RBCodeSnippet >> formattedCode: anObject [
 
 	formattedCode := anObject
+]
+
+{ #category : #accessing }
+RBCodeSnippet >> group [
+	^ group
+]
+
+{ #category : #accessing }
+RBCodeSnippet >> group: aString [
+	group := aString
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This is a simple (but important) cleanup of the code snippet definitions.

RBCodeSnippet was introduced to help to test a lot of piece of codes on a lot of code processing and tools (thanks to matrix testing). There are more than 4700 (green) tests right now; something that could not scale if wrote by hand.
Especially, it helped me to prevent numerous breakages when dealing with compiler work.

Currently, expected results on snippets are quite limited: is there a syntax error? what is the value if I execute it? etc.
Therefore, if RBCodeSnippet become larger with more snippets and more kind of tests (thus more expected results to fill), it will also start to have scaling issues: how to add new expected results on numerous existing snippets, and how to add new snippets and declare the expected results of numerous tests. It's the problem of matrix testing, you have somehow to have a way to declare (or to compute) the value of each individual cells.

So this PR does 3 things:

* Reformat the source of methods listing the snippet.
  While I do not appreciate the format style that much, it will be less difficult to maintain in the long term.
* Provide "inheritance" of snippets. That allows a default snippet to mass-define the characteristics of other snippets.
  In fact, it was already done by hand, but not it's simpler, cleaner, and more powerful.
* Prepare future PR that will add new kind of tests.

The full diff is huge because of reformatting, but it is isolated in the first commit, so other commits are shorter and simpler.