### PR TITLE
add includes: to FinalizationRegistry.

### DIFF
--- a/src/System-Finalization/FinalizationRegistry.class.st
+++ b/src/System-Finalization/FinalizationRegistry.class.st
@@ -116,6 +116,12 @@ FinalizationRegistry >> handleErrorsDuring: aBlock [
 	aBlock	 on: Error fork: [ :e | e pass ]
 ]
 
+{ #category : #testing }
+FinalizationRegistry >> includes: anObject [
+
+    ^ ephemeronCollection anySatisfy: [ :entry | entry key == anObject ]
+]
+
 { #category : #initialization }
 FinalizationRegistry >> initialize [
 


### PR DESCRIPTION
add includes: to FinalizationRegistry.

The original WeakRegistry was a Collection so it understood this message. It is used in some projects like gtk-bindings.