### PR TITLE
LongMessageDialogWindow wraps the text

### DIFF
--- a/src/Polymorph-Widgets/LongMessageDialogWindow.class.st
+++ b/src/Polymorph-Widgets/LongMessageDialogWindow.class.st
@@ -58,6 +58,7 @@ LongMessageDialogWindow >> newTextMorph [
 			beForPlainText;
 			minWidth: Display width // 4;
 			minHeight: Display height // 4;
+			wrapped: true;
 			beReadOnly.
 	^tm
 ]


### PR DESCRIPTION
When reading information on a critique, you get:

![long1](https://user-images.githubusercontent.com/135828/227064829-ffa1cb4d-f287-4a97-b3ee-19aff2e8c23d.png)

That's bad.

Now you get:

![long2](https://user-images.githubusercontent.com/135828/227064837-cad37b4f-9801-4bb5-bc34-5edc41f7860b.png)

That's better