### PR TITLE
Fix #13107 cannot remove used slot

### DIFF
--- a/src/Calypso-Browser/ClyTextEditor.class.st
+++ b/src/Calypso-Browser/ClyTextEditor.class.st
@@ -44,7 +44,7 @@ ClyTextEditor >> notify: aString at: anInteger in: aStream [
 	"Note: error reporting can still be improved, but this need more work"
 
 	| pos message |
-	message := (aString endsWith: '->')
+	message := (aString endsWith: ' ->')
 		ifTrue: [ aString allButLast: 3 ]
 		ifFalse: [ aString ].
 

--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -189,7 +189,11 @@ ClySystemEnvironment >> defineNewClassFrom: newClassDefinitionString notifying: 
 	"Note: newClassDefinitionString can be a fluid class of a standars one"
 
 	| newClass |
-	[
+	"On parser & semantic errors (including undeclared because we are in the legacy scripting interactive mode),
+	there is UI notification.
+	On execution, some methods might be recompiled and cause issues:
+	* Warnings (undeclared/shadowed) are sillently passed, but should be fixed by the user later.
+	* Errors are unlikely (method should be already broken), but cause (resumable) syntax error for now."
 	newClass := (self classCompilerFor: oldClass)
 		            source: newClassDefinitionString;
 		            requestor: aController;
@@ -197,17 +201,7 @@ ClySystemEnvironment >> defineNewClassFrom: newClassDefinitionString notifying: 
 		            logged: true;
 		            evaluate.
 	"mild ugly hack for fluid classes (and traits)"
-	(newClass isKindOf: FluidClassBuilder) ifTrue: [ newClass := newClass install ]
-	]
-		on: OCUndeclaredVariableWarning
-		do: [ :ex |
-			"Undeclared Vars should not lead to the standard dialog to define them but instead should not accept"
-			"Note: this currently prevents legitimate(?) reparations on the superclass name"
-
-			"Note: I hate inserted `->` error messages, but the presentation of errors is the responsibility of `aController`.
-			 and because consistency is a virtue, we should not hack an ad hoc error reporting here"
-			aController notify: ex messageText , '->' at: ex location in: newClassDefinitionString.
-			^ nil ].
+	(newClass isKindOf: FluidClassBuilder) ifTrue: [ newClass := newClass install ].
 
 	^ newClass isBehavior
 		  ifTrue: [ newClass ]

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -163,6 +163,7 @@ OCASTSemanticAnalyzer >> undeclaredVariable: variableNode [
 	OCUndeclaredVariableWarning new
 		node: variableNode;
 		compilationContext: compilationContext;
+		messageText: 'Undeclared variable';
 		signal.
 
 	^ var

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -437,6 +437,13 @@ OpalCompiler >> parseForRequestor [
 	do: [ :notification |
 		| res |
 		self isInteractive ifFalse: [ notification pass ].
+		"The menu is in fact broken on 'noPattern' mode (expression/script/doit) because some reparation assume it's a method body, so just signal as an error (on: block bellow)"
+		self compilationContext noPattern ifTrue: [
+			CodeError new
+				node: notification node;
+				messageText: notification messageText;
+				signal.
+			].
 		"I do not like the API that much.
 		 reparator can have 3 outcomes:
 		  * reparation done, reparse. true


### PR DESCRIPTION
* first commit fixes the unexpected empty string
* second commit fixes the off-by-one error
* third commit improves the poor API in the compiler a little
* fourth commit fixes bad scope of exceptions

See bug description.
Fix #13107