### PR TITLE
Faulty code: improve error on unexpected block parameter

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -66,7 +66,7 @@ RBCodeSnippet class >> badExpressions [
 			         notices: #( #( 1 1 2 'Character expected' ) )).
 		        (self new
 			         source: ':';
-			         notices: #( #( 1 1 1 'Variable name expected' ) )).
+			         notices: #( #( 1 1 1 'Unexpected token' ) )).
 		        (self new
 			         source: '';
 			         isFaulty: false). "emptyness is ok"
@@ -359,33 +359,43 @@ RBCodeSnippet class >> badExpressions [
 		        "Nevertheless, the parser will try to catch unexpected :a together"
 		        (self new
 			         source: ':a';
-			         notices: #( #( 1 2 1 'Variable name expected' ) )).
+			         notices: #( #( 1 2 1 'Unexpected block parameter' ) )).
 		        (self new
 			         source: '::a';
-			         notices: #( #( 1 3 1 'Variable name expected' ) )).
+			         formattedCode: ':. :a';
+			         notices:
+				         #( #( 1 1 1 'Unexpected token' )
+				            #( 2 3 2 'Unexpected block parameter' ) )).
 		        (self new
 			         source: ':::a';
-			         notices: #( #( 1 4 1 'Variable name expected' ) )).
+			         formattedCode: ':. :. :a';
+			         notices:
+				         #( #( 1 1 1 'Unexpected token' )
+				            #( 2 2 2 'Unexpected token' )
+				            #( 3 4 3 'Unexpected block parameter' ) )).
 		        (self new
 			         source: '::';
-			         notices: #( #( 1 2 1 'Variable name expected' ) )).
+			         formattedCode: ':. :';
+			         notices:
+				         #( #( 1 1 1 'Unexpected token' )
+				            #( 2 2 2 'Unexpected token' ) )).
 		        (self new
 			         source: ':a foo';
-			         notices: #( #( 1 2 1 'Variable name expected' ) )).
+			         notices: #( #( 1 2 1 'Unexpected block parameter' ) )).
 		        (self new
 			         source: 'a :foo';
 			         formattedCode: 'a. :foo';
 			         notices:
 				         #( #( 1 1 1 'Undeclared variable' )
 				            #( 1 2 3 'End of statement expected' )
-				            #( 3 6 3 'Variable name expected' ) )).
+				            #( 3 6 3 'Unexpected block parameter' ) )).
 		        (self new
 			         source: 'a : foo';
 			         formattedCode: 'a. :foo';
 			         notices:
 				         #( #( 1 1 1 'Undeclared variable' )
 				            #( 1 2 3 'End of statement expected' )
-				            #( 3 7 3 'Variable name expected' ) )).
+				            #( 3 7 3 'Unexpected block parameter' ) )).
 		        (self new
 			         source: 'a:';
 			         formattedCode: ' a: ';
@@ -393,7 +403,7 @@ RBCodeSnippet class >> badExpressions [
 				            #( 3 2 3 'Variable or expression expected' ) )). "keyword message with a missing receiver and argument"
 		        (self new
 			         source: 'a::';
-			         notices: #( #( 1 3 1 'unexpected token' ) )). "just a bad token"
+			         notices: #( #( 1 3 1 'Unexpected token' ) )). "just a bad token"
 		        (self new
 			         source: 'a:foo';
 			         formattedCode: ' a: foo';
@@ -403,29 +413,32 @@ RBCodeSnippet class >> badExpressions [
 			         source: 'a::foo';
 			         formattedCode: 'a::. foo';
 			         notices:
-				         #( #( 1 3 1 'unexpected token' )
+				         #( #( 1 3 1 'Unexpected token' )
 				            #( 4 6 4 'Undeclared variable' ) )).
 		        (self new
 			         source: ':a:foo';
-			         formattedCode: ': a: foo';
-			         notices: #( #( 1 3 1 'Variable name expected' )
+			         formattedCode: ':. a: foo';
+			         notices:
+				         #( #( 1 1 1 'Unexpected token' )
+				            #( 2 1 2 'Variable or expression expected' )
 				            #( 4 6 4 'Undeclared variable' ) )).
 		        (self new
 			         source: '|:a|';
 			         formattedCode: '| . :a | ';
 			         notices: #( #( 1 1 2 '''|'' or variable expected' )
-				            #( 2 3 2 'Variable name expected' )
+				            #( 2 3 2 'Unexpected block parameter' )
 				            #( 5 4 5 'Variable or expression expected' ) )).
 		        (self new
 			         source: '|:a';
 			         formattedCode: '| . :a';
 			         notices: #( #( 1 1 2 '''|'' or variable expected' )
-				            #( 2 3 2 'Variable name expected' ) )).
+				            #( 2 3 2 'Unexpected block parameter' ) )).
 		        (self new
 			         source: '|::a';
-			         formattedCode: '| . ::a';
+			         formattedCode: '| . :. :a';
 			         notices: #( #( 1 1 2 '''|'' or variable expected' )
-				            #( 2 4 2 'Variable name expected' ) )).
+				            #( 2 2 2 'Unexpected token' )
+				            #( 3 4 3 'Unexpected block parameter' ) )).
 		        (self new
 			         source: '|a:|';
 			         formattedCode: '| . a: | ';
@@ -1030,7 +1043,7 @@ RBCodeSnippet class >> badMethods [
 			         source: ':';
 			         formattedCode: ' . :';
 			         notices: #( #( 1 0 1 'Message pattern expected' )
-				            #( 1 1 1 'Variable name expected' ) )).
+				            #( 1 1 1 'Unexpected token' ) )).
 		        (self new
 			         source: '#(foo bar)';
 			         formattedCode: ' . #( foo bar )';
@@ -1088,7 +1101,7 @@ RBCodeSnippet class >> badMethods [
 			         source: 'foo:bar:';
 			         formattedCode: ' . foo:bar:';
 			         notices: #( #( 1 0 1 'Message pattern expected' )
-				            #( 1 8 1 'unexpected token' ) )). "`foo:bar:` is a single token, and is unexpected"
+				            #( 1 8 1 'Unexpected token' ) )). "`foo:bar:` is a single token, and is unexpected"
 
 		        "Bad pragma message"
 		        (self new

--- a/src/AST-Core/RBEnglobingErrorNode.class.st
+++ b/src/AST-Core/RBEnglobingErrorNode.class.st
@@ -55,7 +55,7 @@ RBEnglobingErrorNode class >> from: aParseErrorNode contents: anArrayOfNodes [
 
 	^ self new
 		start: (aParseErrorNode start min: (anArrayOfNodes min: #start));
-		stop: (aParseErrorNode stop max: (anArrayOfNodes min: #stop));
+		stop: (aParseErrorNode stop max: (anArrayOfNodes max: #stop));
 		errorPosition: aParseErrorNode errorPosition;
 		errorMessage: aParseErrorNode errorMessage;
 		valueAfter: aParseErrorNode value;

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -891,8 +891,20 @@ RBParser >> parsePrimitiveObject [
 			currentToken value = $( ifTrue: [^self parseParenthesizedExpression].
 			currentToken value = ${ ifTrue: [^self parseArray]].
 
-	": is only acceptable at the begin of a block. So just consume them as bad expression"
-	(currentToken isSpecial: $:) ifTrue: [ ^self parseVariableNode ].
+	":id is only acceptable at the begin of a block. So just consume them as unexpected"
+	((currentToken isSpecial: $:) and: [ self nextToken isIdentifier ])
+		ifTrue: [
+			| start |
+			start := currentToken start.
+			self step. ":"
+			errorNode := RBParseErrorNode new
+				             errorMessage: 'Unexpected block parameter';
+				             start: start;
+				             errorPosition: start;
+				             stop: currentToken stop;
+				             value: ':' , currentToken value.
+			self step. "identifier"
+			^ errorNode ].
 
 	errorNode := self parseErrorNode: 'Variable or expression expected'.
 	^errorNode

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -952,7 +952,7 @@ RBParser >> parseStatementInto: statementList periodList: periods withAcceptedSt
 		"We did not progress, its mean that 1. we have a error node and 2. we are missing something (or found something unexpected, its the same thing)."
 		"Solution to recover. Consume the token to create the statement."
 		node := RBParseErrorNode new
-			errorMessage: 'unexpected token';
+			errorMessage: 'Unexpected token';
 			value: currentToken value asString;
 			start: currentToken start;
 			stop: currentToken stop;


### PR DESCRIPTION
Previous error messages on unexpected `:foo` was weird, this PR tries to fix that