### PR TITLE
Faulty code improve scanner on error tokens

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -806,8 +806,7 @@ RBCodeSnippet class >> badExpressions [
 				            #( 2 2 3 'an integer greater than 1 as valid radix expected' ) )). "Two bad sequences"
 		        (self new
 			         source: '##';
-			         formattedCode: '#';
-			         notices: #( #( 1 2 3 'Literal expected' ) )). "errr. ok?"
+			         notices: #( #( 1 2 3 'Literal expected' ) )).
 		        "Note: if quotes, same thing than strings"
 		        (self new
 			         source: '#''hello';
@@ -951,16 +950,16 @@ RBCodeSnippet class >> badExpressions [
 		        "$→ isSpecial >>> false" "$→ asInteger hex >>> 16r2192" "Rightwards Arrow"
 		        (self new
 			         source: '→';
-			         notices: #( #( 1 0 1 'Unknown character' ) )). "Unknown character. Not isSpecial"
+			         notices: #( #( 1 1 1 'Unknown character' ) )). "Unknown character. Not isSpecial"
 		        "$٠ isDigit >>> true" "$٠ asInteger >>> 16r0660" "Arabic-indic Digit Zero"
 		        (self new
 			         source: '٠';
-			         notices: #( #( 1 0 1 'Unknown character' ) )). "Unknown character. Not a valid number (basic ASCII only for numbers!)"
+			         notices: #( #( 1 1 1 'Unknown character' ) )). "Unknown character. Not a valid number (basic ASCII only for numbers!)"
 		        "Currently in Pharo, there is no 'isSeparator' character outside the ASCII range"
 		        "Character nbsp isSeparator >>> false" "Even the standard nbsp"
 		        (self new
 			         source: Character nbsp asString;
-			         notices: #( #( 1 0 1 'Unknown character' ) )). "Unknown character. Not isSeparator"
+			         notices: #( #( 1 1 1 'Unknown character' ) )). "Unknown character. Not isSeparator"
 
 		        (self new
 			         source: '$→';
@@ -986,14 +985,14 @@ RBCodeSnippet class >> badExpressions [
 			         source: '#(Δ→ə)';
 			         formattedCode: '#( Δ → ə )';
 			         notices:
-				         #( #( 4 3 4 'Unknown character' )
+				         #( #( 4 4 4 'Unknown character' )
 				            #( 1 6 7 ''')'' expected' ) )). "This one is faulty because → is a parse error"
 		        (self new
 			         source: '#→';
 			         formattedCode: '#. →';
 			         notices:
 				         #( #( 1 1 2 'Literal expected' )
-				            #( 2 1 2 'Unknown character' ) )) "Two independent errors" }.
+				            #( 2 2 2 'Unknown character' ) )) "Two independent errors" }.
 	"Setup default values"
 	self new
 		group: #badExpressions;

--- a/src/AST-Core/RBErrorToken.class.st
+++ b/src/AST-Core/RBErrorToken.class.st
@@ -38,6 +38,11 @@ RBErrorToken >> location [
 ]
 
 { #category : #accessing }
+RBErrorToken >> location: anInteger [
+	location := anInteger
+]
+
+{ #category : #accessing }
 RBErrorToken >> value: theValue start: tokenStart cause: errorCause location: errorPosition [
 	self value: theValue start: tokenStart.
 	location := errorPosition.

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -521,7 +521,7 @@ RBParser >> parseErrorNode: aMessageString [
 				errorMessage: currentToken cause;
 				value: currentToken value;
 				start: self errorPosition;
-				stop: currentToken location-1;
+				stop: currentToken stop;
 				errorPosition: currentToken location.
 			self step.
 			^ errorNode].

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -475,7 +475,7 @@ RBScanner >> scanLiteral [
 	"Accept multiple #."
 	currentCharacter = $#
 		ifTrue: [ ^ self scanLiteral ].
-	^ (self scanError: 'Literal expected') value: '#'
+	^ self scanError: 'Literal expected' from: tokenStart
 ]
 
 { #category : #'private - scanning' }

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -302,15 +302,16 @@ RBScanner >> previousStepPosition [
 { #category : #'private - scanning' }
 RBScanner >> scanBackFrom: start [
 	"Return the verbatim content from the `start` position until the current position.
-	 The starting and current character are both included.
+	 The starting character is included, the current character is not included.
 	 The stream status (inclutiong its position) is preserved"
 
-	| len string stop |
-	stop := stream position.
+	| len string stop current |
+	current := stream position.
+	stop := currentCharacter ifNil: [ current ] ifNotNil: [ current - 1 ].
 	len := stop - start + 1.
 	stream position: start - 1.
 	string := stream next: len.
-	stream position: stop.
+	stream position: current.
 	^ string
 ]
 
@@ -379,10 +380,9 @@ RBScanner >> scanError: theCause [
 { #category : #'private - scanning' }
 RBScanner >> scanError: theCause from: aPosition [
 	"An error token accepts every character given, recognised or not."
-	"The value of the error token is the verbatim text from aPosition to the current position (both included)."
+	"The value of the error token is the verbatim text from aPosition (included) to the current position (not included)."
 	| location |
-	"error location is the next not parseable character. Or current stream position + 1 if
-	an expected character is missing."
+	"error location is current stream position. Or current stream position + 1 if eof."
 	location := stream position.
 	currentCharacter
 		ifNotNil: [ :char | buffer nextPut: char ]
@@ -521,8 +521,8 @@ RBScanner >> scanLiteralString [
 	(stream peekBack = $' and: [ stream position > start ]) ifFalse: [
 		"the peek logic here is because #upTo: does not tell if given char was found.
 		So if the stream did not move of if the last char is not a quote, then we have a problem."
-		string := self scanBackFrom: tokenStart. "the whole token, including ' (and #')"
 		self step. "to handle eof"
+		string := self scanBackFrom: tokenStart. "the whole token, including ' (and #')"
 		^ RBErrorToken
 			value: string
 			start: tokenStart
@@ -560,8 +560,8 @@ RBScanner >> scanNumber [
 	gotError := nil.
 	number := NumberParser parse: stream onError: [ :message | gotError := message ].
 	stop := stream position.
-	string := self scanBackFrom: start.
 	self step.
+	string := self scanBackFrom: start.
 	gotError ifNotNil: [
 	^ RBErrorToken
 		value: string

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -270,10 +270,7 @@ RBScanner >> next [
 
 	buffer reset.
 	tokenStart := stream position.
-	token := characterType = #eof
-				ifTrue:
-					[RBEOFToken start: tokenStart + 1	"The EOF token should occur after the end of input"]
-				ifFalse: [self scanToken].
+	token := self scanToken.
 	self stripSeparators.
 	token comments: self getComments.
 	^token
@@ -630,6 +627,7 @@ RBScanner >> scanToken [
 	"fast-n-ugly. Don't write stuff like this. Has been found to cause cancer in laboratory rats. Basically a
 	case statement. Didn't use Dictionary because lookup is pretty slow."
 
+	characterType = #eof ifTrue: [ ^ RBEOFToken start: tokenStart + 1 ]. "The EOF token should occur after the end of input"
 	characterType = #alphabetic ifTrue: [^self scanIdentifierOrKeyword].
 	(characterType = #digit
 		or: [currentCharacter = $- and: [(self classify: stream peek) = #digit]])

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -307,7 +307,7 @@ RBScanner >> scanBackFrom: start [
 
 	| len string stop current |
 	current := stream position.
-	stop := currentCharacter ifNil: [ current ] ifNotNil: [ current - 1 ].
+	stop := self previousStepPosition.
 	len := stop - start + 1.
 	stream position: start - 1.
 	string := stream next: len.
@@ -361,37 +361,21 @@ RBScanner >> scanComment [
 
 { #category : #'private - scanning' }
 RBScanner >> scanError: theCause [
-	"An error token accepts every character given, recognised or not."
-	"The value of an error token is one character maximum : the current character."
-	| location |
-	"error location is the next not parseable character. Or current stream position + 1 if
-	an expected character is missing."
-	location := stream position.
-	currentCharacter
-		ifNotNil: [ :char | buffer nextPut: char ]
-		ifNil: [ location := stream position + 1 ].
-	^ RBErrorToken
-		value: buffer contents asString
-		start: tokenStart
-		cause: theCause
-		location: location
+
+	^ self scanError: theCause from: tokenStart
 ]
 
 { #category : #'private - scanning' }
 RBScanner >> scanError: theCause from: aPosition [
-	"An error token accepts every character given, recognised or not."
 	"The value of the error token is the verbatim text from aPosition (included) to the current position (not included)."
-	| location |
-	"error location is current stream position. Or current stream position + 1 if eof."
-	location := stream position.
-	currentCharacter
-		ifNotNil: [ :char | buffer nextPut: char ]
-		ifNil: [ location := stream position + 1 ].
+
+	"The error location is current stream position. Or current stream position + 1 if eof."
+
 	^ RBErrorToken
-		value: (self scanBackFrom: aPosition)
-		start: aPosition
-		cause: theCause
-		location: location
+		  value: (self scanBackFrom: aPosition)
+		  start: aPosition
+		  cause: theCause
+		  location: self previousStepPosition + 1
 ]
 
 { #category : #'private - scanning' }
@@ -475,7 +459,7 @@ RBScanner >> scanLiteral [
 	"Accept multiple #."
 	currentCharacter = $#
 		ifTrue: [ ^ self scanLiteral ].
-	^ self scanError: 'Literal expected' from: tokenStart
+	^ self scanError: 'Literal expected'
 ]
 
 { #category : #'private - scanning' }
@@ -502,7 +486,7 @@ RBScanner >> scanLiteralCharacter [
 	"'$$' is a correct string to be scanned and the second $ mustn't trigger a new scan."
 	| token |
 	self step.	"$"
-	currentCharacter ifNil:[ ^ (self scanError:'Character expected') value: '$'].
+	currentCharacter ifNil:[ ^ self scanError: 'Character expected' ].
 	token := RBLiteralToken
 				value: currentCharacter
 				start: tokenStart
@@ -644,9 +628,10 @@ RBScanner >> scanToken [
 { #category : #'private - scanning' }
 RBScanner >> scanUnknownCharacter [
 	| errorToken |
-	errorToken := self scanError: 'Unknown character'.
-	"advance"
+	"consume unexpected character"
 	self step.
+	errorToken := self scanError: 'Unknown character'.
+	errorToken location: tokenStart. "Error location is before the character"
 	^ errorToken
 ]
 

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -294,14 +294,16 @@ RBScanner >> on: aStream [
 
 { #category : #private }
 RBScanner >> previousStepPosition [
+	"The index of the previous character (that was consumed)"
+
 	^characterType = #eof
-		ifTrue: [stream position]
-		ifFalse: [stream position - 1]
+		ifTrue: [stream position] "it's the index of the last character"
+		ifFalse: [stream position - 1] "-1 to cancel the lookahead"
 ]
 
 { #category : #'private - scanning' }
 RBScanner >> scanBackFrom: start [
-	"Return the verbatim content from the `start` position until the current position.
+	"Return the verbatim content from the `start` position until the current character.
 	 The starting character is included, the current character is not included.
 	 The stream status (inclutiong its position) is preserved"
 
@@ -367,9 +369,8 @@ RBScanner >> scanError: theCause [
 
 { #category : #'private - scanning' }
 RBScanner >> scanError: theCause from: aPosition [
-	"The value of the error token is the verbatim text from aPosition (included) to the current position (not included)."
-
-	"The error location is current stream position. Or current stream position + 1 if eof."
+	"The value of the error token is the verbatim text from aPosition (included) to the current position (not included).
+	The error location is index of the current (problematic) character. Or index of the last character + 1 if eof."
 
 	^ RBErrorToken
 		  value: (self scanBackFrom: aPosition)
@@ -631,7 +632,7 @@ RBScanner >> scanUnknownCharacter [
 	"consume unexpected character"
 	self step.
 	errorToken := self scanError: 'Unknown character'.
-	errorToken location: tokenStart. "Error location is before the character"
+	errorToken location: tokenStart. "Unlike other scanner errors, error location is here before the bad token"
 	^ errorToken
 ]
 


### PR DESCRIPTION
Error positions on unknown characters the content of bad `##` literal were off.
The culprit is RBScanner, so this PR tries to fix the handling of error content and position in the scanner.

Is issue is that `scanError:from:` and `scanError:` (and `scanBackFrom:`) included the current character in its string.
This is ok at the end of the stream, but problematic inside the stream, because the current token is often the problematic one that ends the previous token.
Therefore, clients used to call `scanError:` before consuming the last character, or just hard-coded the error token contents. But hardcoding were off for dry `#` if multiple `#` are present and the stop position was wrong for unknown character because the error was produced before consuming the bad character.

All the PR basically does, is to not include the current character in `scanError:` and cie. and update client to call it at the right time (after consuming the last character) or stopping hard-coding the text because it is now the correct one.


Related question, but unmodified by he PR: currently the error for a bad `#` literal (e.g. `#1` or `#` at the end of file) is `Literal expected` with the location (where to put the cursor in front of the problematic character) after the `#`. I'm not sure that it is the best message nor location.

Maybe `Invalid literal` (or something) could be used instead, with the cursor in front of `#`?

Also, `#1` does not consume the `1`, so you have `Literal expected` before the `1` (that can be misleading, because `1` is a kind of literal) and the 1 will be used for the next token. Perhaps `#1` should be scanned as a single invalid literal token instead?