### PR TITLE
Speed up #assertCollection:hasSameElements: in case they are equals.

### DIFF
--- a/src/SUnit-Core-Traits/TAssertable.trait.st
+++ b/src/SUnit-Core-Traits/TAssertable.trait.st
@@ -61,7 +61,9 @@ TAssertable >> assertCollection: actual equals: expected [
 
 { #category : #asserting }
 TAssertable >> assertCollection: actual hasSameElements: expected [
-	"Assert that a collection contains the same elements as the given collection. Order is not checked, only the presence/absence of elements."
+	"Assert that a collection contains the same elements as the given collection. Order is not checked, only the presence/absence of elements.
+
+	For performance reasons we check first that they are not equals because difference computation takes long on collections that are not really small."
 
 	[ self assert: actual equals: expected ]
 		on: AssertionFailure

--- a/src/SUnit-Core-Traits/TAssertable.trait.st
+++ b/src/SUnit-Core-Traits/TAssertable.trait.st
@@ -61,28 +61,29 @@ TAssertable >> assertCollection: actual equals: expected [
 
 { #category : #asserting }
 TAssertable >> assertCollection: actual hasSameElements: expected [
-	"Assert that a collection contains the same elements as the given collection. Order is not checked, only the presence/absence of elements.
+	"Assert that a collection contains the same elements as the given collection. Order is not checked, only the presence/absence of elements. Occurences of elements mater."
 
-	For performance reasons we check first that they are not equals because difference computation takes long on collections that are not really small."
+	| missingElements additionalElements |
+	"For performance reasons we check first that they are not equals because difference computation takes long on collections that are not really small."
+	actual = expected ifTrue: [ ^ self ].
 
-	[ self assert: actual equals: expected ]
-		on: AssertionFailure
-		do: [
-			| missingElements additionalElements |
-			additionalElements := actual difference: expected.
-			missingElements := expected difference: (actual intersection: expected).
-			self assert: (additionalElements isEmpty and: [ missingElements isEmpty ]) description: (String streamContents: [ :stream |
-					 stream
-						 nextPutAll: 'Given Collections do not match!';
-						 lf;
-						 tab;
-						 nextPutAll: 'additions : ';
-						 print: additionalElements asArray;
-						 lf;
-						 tab;
-						 nextPutAll: 'missing: ';
-						 print: missingElements asArray;
-						 lf ]) ]
+	"The fast way to know if they have the same elements is to make them a bag. In case they don't have the same elements, then we compute the differences to print a nice little log to the user so that he knows the added and removed elements :)"
+	actual asBag = expected asBag ifTrue: [ ^ self ].
+
+	additionalElements := actual difference: expected.
+	missingElements := expected difference: (actual intersection: expected).
+	self assert: (additionalElements isEmpty and: [ missingElements isEmpty ]) description: (String streamContents: [ :stream |
+			 stream
+				 nextPutAll: 'Given Collections do not match!';
+				 lf;
+				 tab;
+				 nextPutAll: 'additions : ';
+				 print: additionalElements asArray;
+				 lf;
+				 tab;
+				 nextPutAll: 'missing: ';
+				 print: missingElements asArray;
+				 lf ])
 ]
 
 { #category : #asserting }

--- a/src/SUnit-Core-Traits/TAssertable.trait.st
+++ b/src/SUnit-Core-Traits/TAssertable.trait.st
@@ -62,18 +62,25 @@ TAssertable >> assertCollection: actual equals: expected [
 { #category : #asserting }
 TAssertable >> assertCollection: actual hasSameElements: expected [
 	"Assert that a collection contains the same elements as the given collection. Order is not checked, only the presence/absence of elements."
-	| missingElements additionalElements |
 
-	additionalElements := actual difference: expected.
-	missingElements := expected difference: (actual intersection: expected).
-	self
-		assert: (additionalElements isEmpty and: [ missingElements isEmpty ])
-		description: (String streamContents:
-			[:stream |
-			stream
-				nextPutAll: 'Given Collections do not match!'; lf;
-				tab; nextPutAll: 'additions : '; print: additionalElements asArray; lf;
-				tab; nextPutAll: 'missing: '; print: missingElements asArray; lf ])
+	[ self assert: actual equals: expected ]
+		on: AssertionFailure
+		do: [
+			| missingElements additionalElements |
+			additionalElements := actual difference: expected.
+			missingElements := expected difference: (actual intersection: expected).
+			self assert: (additionalElements isEmpty and: [ missingElements isEmpty ]) description: (String streamContents: [ :stream |
+					 stream
+						 nextPutAll: 'Given Collections do not match!';
+						 lf;
+						 tab;
+						 nextPutAll: 'additions : ';
+						 print: additionalElements asArray;
+						 lf;
+						 tab;
+						 nextPutAll: 'missing: ';
+						 print: missingElements asArray;
+						 lf ]) ]
 ]
 
 { #category : #asserting }

--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -164,28 +164,29 @@ TestAsserter >> assertCollection: actualCollection equals: expectedCollection [
 
 { #category : #asserting }
 TestAsserter >> assertCollection: actual hasSameElements: expected [
-	"Assert that a collection contains the same elements as the given collection. Order is not checked, only the presence/absence of elements.
+	"Assert that a collection contains the same elements as the given collection. Order is not checked, only the presence/absence of elements. Occurences of elements mater."
 
-	For performance reasons we check first that they are not equals because difference computation takes long on collections that are not really small."
+	| missingElements additionalElements |
+	"For performance reasons we check first that they are not equals because difference computation takes long on collections that are not really small."
+	actual = expected ifTrue: [ ^ self ].
 
-	[ self assert: actual equals: expected ]
-		on: AssertionFailure
-		do: [
-			| missingElements additionalElements |
-			additionalElements := actual difference: expected.
-			missingElements := expected difference: (actual intersection: expected).
-			self assert: (additionalElements isEmpty and: [ missingElements isEmpty ]) description: (String streamContents: [ :stream |
-					 stream
-						 nextPutAll: 'Given Collections do not match!';
-						 lf;
-						 tab;
-						 nextPutAll: 'additions : ';
-						 print: additionalElements asArray;
-						 lf;
-						 tab;
-						 nextPutAll: 'missing: ';
-						 print: missingElements asArray;
-						 lf ]) ]
+	"The fast way to know if they have the same elements is to make them a bag. In case they don't have the same elements, then we compute the differences to print a nice little log to the user so that he knows the added and removed elements :)"
+	actual asBag = expected asBag ifTrue: [ ^ self ].
+
+	additionalElements := actual difference: expected.
+	missingElements := expected difference: (actual intersection: expected).
+	self assert: (additionalElements isEmpty and: [ missingElements isEmpty ]) description: (String streamContents: [ :stream |
+			 stream
+				 nextPutAll: 'Given Collections do not match!';
+				 lf;
+				 tab;
+				 nextPutAll: 'additions : ';
+				 print: additionalElements asArray;
+				 lf;
+				 tab;
+				 nextPutAll: 'missing: ';
+				 print: missingElements asArray;
+				 lf ])
 ]
 
 { #category : #asserting }

--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -164,7 +164,9 @@ TestAsserter >> assertCollection: actualCollection equals: expectedCollection [
 
 { #category : #asserting }
 TestAsserter >> assertCollection: actual hasSameElements: expected [
-	"Assert that a collection contains the same elements as the given collection. Order is not checked, only the presence/absence of elements."
+	"Assert that a collection contains the same elements as the given collection. Order is not checked, only the presence/absence of elements.
+
+	For performance reasons we check first that they are not equals because difference computation takes long on collections that are not really small."
 
 	[ self assert: actual equals: expected ]
 		on: AssertionFailure

--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -163,28 +163,27 @@ TestAsserter >> assertCollection: actualCollection equals: expectedCollection [
 ]
 
 { #category : #asserting }
-TestAsserter >> assertCollection: actualCollection hasSameElements: expected [
+TestAsserter >> assertCollection: actual hasSameElements: expected [
 	"Assert that a collection contains the same elements as the given collection. Order is not checked, only the presence/absence of elements."
 
-	| missingElements additionalElements |
-	additionalElements := actualCollection difference: expected.
-	missingElements := expected difference: (actualCollection intersection: expected).
-	self
-		assert: (additionalElements isEmpty and: [ missingElements isEmpty ])
-		description:
-			(String
-				streamContents: [ :stream |
-					stream
-						nextPutAll: 'Given Collections do not match!';
-						lf;
-						tab;
-						nextPutAll: 'additions : ';
-						print: additionalElements asArray;
-						lf;
-						tab;
-						nextPutAll: 'missing: ';
-						print: missingElements asArray;
-						lf ])
+	[ self assert: actual equals: expected ]
+		on: AssertionFailure
+		do: [
+			| missingElements additionalElements |
+			additionalElements := actual difference: expected.
+			missingElements := expected difference: (actual intersection: expected).
+			self assert: (additionalElements isEmpty and: [ missingElements isEmpty ]) description: (String streamContents: [ :stream |
+					 stream
+						 nextPutAll: 'Given Collections do not match!';
+						 lf;
+						 tab;
+						 nextPutAll: 'additions : ';
+						 print: additionalElements asArray;
+						 lf;
+						 tab;
+						 nextPutAll: 'missing: ';
+						 print: missingElements asArray;
+						 lf ]) ]
 ]
 
 { #category : #asserting }


### PR DESCRIPTION
Better fix for https://github.com/pharo-project/pharo/pull/13143

Fixes #13142