### PR TITLE
OpalCompiler gain install

### DIFF
--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -393,18 +393,10 @@ ClassDescription >> compile: sourceCode classified: protocolName withStamp: chan
 		source: sourceCode;
 		requestor: requestor;
 		failBlock:  [ ^ nil ];
-		compile.
-
-	logSource ifTrue: [
-		self
-			logMethodSource: (requestor ifNotNil: [ :r | r text ] ifNil: [ sourceCode ]) "the requestor text might have been changed by the compiler and may be different thant text argument"
-			forMethod: method
-			inCategory: protocolName
-			withStamp: changeStamp ].
-
-	self addAndClassifySelector: method selector withMethod: method inProtocol: protocolName.
-
-	self instanceSide noteCompilationOf: method meta: self isClassSide.
+		protocolName: protocolName;
+		changeStamp: changeStamp;
+		logged: logSource;
+		install.
 
 	^ method selector
 ]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -404,6 +404,13 @@ OpalCompiler >> install [
 	^ method
 ]
 
+{ #category : #actions }
+OpalCompiler >> install: aSource [
+
+	self source: aSource.
+	^ self install
+]
+
 { #category : #testing }
 OpalCompiler >> isInteractive [
 	^ compilationContext interactive

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -32,7 +32,9 @@ Class {
 		'ast',
 		'source',
 		'compilationContext',
-		'compilationContextClass'
+		'compilationContextClass',
+		'protocolName',
+		'changeStamp'
 	],
 	#classInstVars : [
 		'overlayEnvironment'
@@ -224,6 +226,11 @@ OpalCompiler >> callPlugins [
 ]
 
 { #category : #accessing }
+OpalCompiler >> changeStamp: aString [ 
+	changeStamp := aString
+]
+
+{ #category : #accessing }
 OpalCompiler >> class: aClass [
 	self compilationContext class: aClass
 ]
@@ -365,6 +372,38 @@ OpalCompiler >> format: textOrString [
 		format
 ]
 
+{ #category : #actions }
+OpalCompiler >> install [
+	"Compile and install a method in a class"
+
+	| class method logSource |
+	class := self semanticScope targetClass.
+	self assert: class isNotNil.
+
+	method := self compile.
+	method ifNil: [ ^ method ].
+
+	protocolName ifNil: [ protocolName := Protocol unclassified ].
+	changeStamp ifNil: [ changeStamp := Author changeStamp ].
+	logSource := compilationContext logged ifNil: [ class acceptsLoggingOfCompilation ].
+
+	logSource ifTrue: [
+		class
+			logMethodSource: source contents
+			forMethod: method
+			inCategory: protocolName
+			withStamp: changeStamp ].
+
+	class
+		addAndClassifySelector: method selector
+		withMethod: method
+		inProtocol: protocolName.
+
+	class instanceSide noteCompilationOf: method meta: class isClassSide.
+
+	^ method
+]
+
 { #category : #testing }
 OpalCompiler >> isInteractive [
 	^ compilationContext interactive
@@ -499,6 +538,11 @@ OpalCompiler >> permitFaulty: aBoolean [
 { #category : #accessing }
 OpalCompiler >> productionEnvironment: anObject [
 	compilationContext productionEnvironment: anObject
+]
+
+{ #category : #accessing }
+OpalCompiler >> protocolName: aString [ 
+	protocolName := aString
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Tests/OpalCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTest.class.st
@@ -147,3 +147,71 @@ OpalCompilerTest >> testEvaluateWithBindingsWithUppercaseName [
 		evaluate: '1+MyVar'.
 	self assert: result equals: 4
 ]
+
+{ #category : #tests }
+OpalCompilerTest >> testInstall [
+
+	| method |
+	"Cleanup"
+	(MockForCompilation includesSelector: #foo) ifTrue: [
+		MockForCompilation removeSelector: #foo ].
+	"Precond"
+	self deny: (MockForCompilation includesSelector: #foo).
+
+	method := MockForCompilation compiler
+		          source: 'foo ^42';
+		          changeStamp: 'JP 4/01/2023 01:23';
+		          protocolName: 'hitching';
+		          install.
+
+	self assert: method equals: MockForCompilation >> #foo.
+	self assert: MockForCompilation new foo equals: 42.
+
+	"Cleanup"
+	method removeFromSystem.
+	self deny: (MockForCompilation includesSelector: #foo)
+]
+
+{ #category : #tests }
+OpalCompilerTest >> testInstallException [
+
+	| method message |
+	"Precond"
+	self deny: (MockForCompilation includesSelector: #foo).
+
+	[
+	method := MockForCompilation compiler
+		          source: 'foo ^¿';
+		          install ]
+		on: CodeError
+		do: [ :error | message := error messageText , ' :(' ].
+
+	self deny: (MockForCompilation includesSelector: #foo).
+	self assert: method isNil.
+	self assert: message equals: 'Unknown character :('
+]
+
+{ #category : #tests }
+OpalCompilerTest >> testInstallRequestor [
+
+	| method requestor |
+	"precond"
+	self deny: (MockForCompilation includesSelector: #foo).
+
+	requestor := OCMockRequestor new.
+
+	[
+	method := MockForCompilation compiler
+		          source: 'foo ^¿';
+		          requestor: requestor;
+		          failBlock: [  ];
+		          changeStamp: 'JP 3/24/2023 18:39';
+		          protocolName: 'hitching';
+		          install ]
+		on: CodeError
+		do: [  ].
+
+	self deny: (MockForCompilation includesSelector: #foo).
+	self assert: method isNil.
+	self assert: requestor notifyList first first equals: 'Unknown character ->'
+]

--- a/src/OpalCompiler-Tests/OpalCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTest.class.st
@@ -179,10 +179,7 @@ OpalCompilerTest >> testInstallException [
 	"Precond"
 	self deny: (MockForCompilation includesSelector: #foo).
 
-	[
-	method := MockForCompilation compiler
-		          source: 'foo ^¿';
-		          install ]
+	[ method := MockForCompilation compiler install: 'foo ^¿' ]
 		on: CodeError
 		do: [ :error | message := error messageText , ' :(' ].
 


### PR DESCRIPTION
The API `compile*` of ClassDescription has some defaults

* cannot specify some parameters like optimization options or faulty mode;
* returns a symbol instead of a compiled method (cf #12880);
* relies on the requestor (and I want to reduce its bad influence).

The proper solution is to move the responsibility to finish the job to the compiler, since it already has almost all information. In the long run, I want to provide a better API (I'm writing something), but I need this little step first, and I also need to run CI on it to see what it breaks.