### PR TITLE
Clean copying methods of ClassDescription

### DIFF
--- a/src/Deprecated12/ClassDescription.extension.st
+++ b/src/Deprecated12/ClassDescription.extension.st
@@ -1,0 +1,74 @@
+Extension { #name : #ClassDescription }
+
+{ #category : #'*Deprecated12' }
+ClassDescription >> copy: selector from: originClass [
+	"Install a copy of originClass>>selector in myself as un unclassified method."
+
+	self deprecated: 'This method will be removed in the next version of Pharo.'.
+
+	self copy: selector from: originClass classified: nil
+]
+
+{ #category : #'*Deprecated12' }
+ClassDescription >> copy: selector from: originClass classified: protocolName [
+	"Install a copy of originClass>>selector in myself under the specified protocol."
+
+	| sourceCode protocol |
+	"Useful when modifying an existing class"
+	self deprecated: 'This method will be removed in the next version of Pharo.'.
+	sourceCode := originClass sourceCodeAt: selector.
+
+	sourceCode ifNil: [ ^ self ].
+
+	protocol := protocolName ifNil: [ originClass organization protocolNameOfElement: selector ].
+
+	(self includesLocalSelector: selector) ifTrue: [
+		sourceCode asString = (self sourceCodeAt: selector) asString ifFalse: [ self error: self name , ' ' , selector , ' will be redefined if you proceed.' ] ].
+
+	self compile: sourceCode classified: protocol
+]
+
+{ #category : #'*Deprecated12' }
+ClassDescription >> copyAll: selectors from: originClass [
+	"Install a copy of all selectors from originClass in myself as unclassified methods."
+
+	self deprecated: 'This method will be removed in the next version of Pharo.'.
+
+	self copyAll: selectors from: originClass classified: nil
+]
+
+{ #category : #'*Deprecated12' }
+ClassDescription >> copyAll: selectors from: originClass classified: protocolName [
+	"Install a copy of all selectors from originClass in myself under the specified protocol."
+
+	self deprecated: 'This will be removed in the next version of Pharo.'.
+
+	selectors do: [ :selector | (originClass includesLocalSelector: selector) ifTrue: [ self copy: selector from: originClass classified: protocolName ] ]
+]
+
+{ #category : #'*Deprecated12' }
+ClassDescription >> copyAllCategoriesFrom: originClass [
+	"Install a copy of each methods of originClass in myself under the same protocol."
+
+	self deprecated: 'Use #copyAllMethodsFrom: instead.' transformWith: '`@rcv copyAllCategoriesFrom: `@arg' -> '`@rcv copyAllMethodsFrom: `@arg'.
+
+	self copyAllMethodsFrom: originClass
+]
+
+{ #category : #'*Deprecated12' }
+ClassDescription >> copyCategory: protocolName from: originClass [
+	"Install all methods in the specified protocol of originClass in myself keeping the right protocol."
+
+	self deprecated: 'This method will be removed in the next version of Pharo.'.
+
+	self copyCategory: protocolName from: originClass classified: protocolName
+]
+
+{ #category : #'*Deprecated12' }
+ClassDescription >> copyCategory: protocolName from: aClass classified: newProtocolName [
+	"Move all methods in the protocol 'protocolName' of aClass into a protocol named 'newProtocolName'"
+
+	self deprecated: 'This method will be removed in the next version of Pharo.'.
+
+	self copyAll: (aClass organization methodsInProtocolNamed: protocolName) from: aClass classified: newProtocolName
+]

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -514,8 +514,8 @@ Class >> duplicateClassWithNewName: aSymbol [
 			builder
 				fillFor: self;
 				name: copysName ].
-	class copyAllCategoriesFrom: self.
-	class class copyAllCategoriesFrom: self class.
+	class copyAllMethodsFrom: self.
+	class class copyAllMethodsFrom: self class.
 	^ class
 ]
 

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -438,75 +438,17 @@ ClassDescription >> compileSilently: sourceCode classified: protocolName notifyi
 ]
 
 { #category : #copying }
-ClassDescription >> copy: selector from: class [
-	"Install the method associated with the first argument, selector, a message
-	selector, found in the method dictionary of the second argument, class,
-	as one of the receiver's methods. Classify the message under -As yet not
-	classified-."
+ClassDescription >> copyAllMethodsFrom: originClass [
+	"Install a copy of each methods of originClass in myself under the same protocol."
 
-	self copy: selector from: class classified: nil
-]
+	originClass methods do: [ :aMethod |
+		(self includesLocalSelector: aMethod selector) ifTrue: [
+			aMethod sourceCode asString = (self sourceCodeAt: aMethod selector) asString ifFalse: [
+				self error: ('{1}>>{2} will be redefined if you proceed.' format: {
+							 self name.
+							 aMethod selector }) ] ].
 
-{ #category : #copying }
-ClassDescription >> copy: selector from: class classified: protocolName [
-	"Install the method associated with the first arugment, selector, a message
-	selector, found in the method dictionary of the second argument, class,
-	as one of the receiver's methods. Classify the message under the third
-	argument, protocolName."
-
-	| sourceCode protocol |
-	"Useful when modifying an existing class"
-	sourceCode := class sourceCodeAt: selector.
-	sourceCode ifNotNil: [
-		protocol := protocolName
-			            ifNil: [ class organization protocolNameOfElement: selector ]
-			            ifNotNil: [ protocolName ].
-		(self includesLocalSelector: selector) ifTrue: [
-			sourceCode asString = (self sourceCodeAt: selector) asString ifFalse: [ self error: self name , ' ' , selector , ' will be redefined if you proceed.' ] ].
-		self compile: sourceCode classified: protocol ]
-]
-
-{ #category : #copying }
-ClassDescription >> copyAll: selectors from: class [
-	"Install all the methods found in the method dictionary of the second
-	argument, class, as the receiver's methods. Classify the messages under
-	-As yet not classified-."
-
-	self copyAll: selectors from: class classified: nil
-]
-
-{ #category : #copying }
-ClassDescription >> copyAll: selectors from: class classified: protocolName [
-	"Install all the methods found in the method dictionary of the second
-	argument, class, as the receiver's methods. Classify the messages under
-	the third argument, protocolName."
-
-	selectors do: [ :selector | (class includesLocalSelector: selector) ifTrue: [ self copy: selector from: class classified: protocolName ] ]
-]
-
-{ #category : #copying }
-ClassDescription >> copyAllCategoriesFrom: aClass [
-	"Specify that the protocole of messages for the receiver include all of
-	those found in the class, aClass. Install each of the messages found in
-	these protocols into the method dictionary of the receiver, classified
-	under the appropriate protocol."
-
-	aClass organization protocolNames do: [ :protocolName | self copyCategory: protocolName from: aClass ]
-]
-
-{ #category : #copying }
-ClassDescription >> copyCategory: protocolName from: class [
-	"Specify that one of the protocol of messages for the receiver is protocolName, as
-	found in the class, class. Copy each message found in this protocol."
-
-	self copyCategory: protocolName from: class classified: protocolName
-]
-
-{ #category : #copying }
-ClassDescription >> copyCategory: protocolName from: aClass classified: newProtocolName [
-	"Move all methods in the protocol 'protocolName' of aClass into a protocol named 'newProtocolName'"
-
-	self copyAll: (aClass organization methodsInProtocolNamed: protocolName) from: aClass classified: newProtocolName
+		self compile: aMethod sourceCode classified: aMethod protocol ]
 ]
 
 { #category : #slots }

--- a/src/Metacello-PharoCommonPlatform/MetacelloPharoCommonPlatform.class.st
+++ b/src/Metacello-PharoCommonPlatform/MetacelloPharoCommonPlatform.class.st
@@ -52,8 +52,8 @@ MetacelloPharoCommonPlatform >> copyClass: oldClass as: newName inCategory: newC
 		with: 'category: ' , newCategoryName printString.
 	class := self compiler logged: true; evaluate: newDefinition.
 	class class instanceVariableNames: oldClass class instanceVariablesString.
-	class copyAllCategoriesFrom: oldClass.
-	class class copyAllCategoriesFrom: oldClass class.
+	class copyAllMethodsFrom: oldClass.
+	class class copyAllMethodsFrom: oldClass class.
 	class category: newCategoryName.
 	^ class
 ]


### PR DESCRIPTION
Some of them were dead code. Some of them were really complicated for nothing. In the end, the only use of those methods is to copy the methods of a class in another class.  Before, what was done was to get all the procols of the origin class, get all the selectors in them, and try to copy the selectors doing various check since we didn't had a compiled method instance. 

Here I propose a much simpler version were we just iterate over the methods directly. This is simpler, requires less code and reduces the API of ClassDescription easily.