### PR TITLE
Simplify and deprecate ClassDescription>>allProtocolsUpTo:

### DIFF
--- a/src/Deprecated12/ClassDescription.extension.st
+++ b/src/Deprecated12/ClassDescription.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #ClassDescription }
+
+{ #category : #'*Deprecated12' }
+ClassDescription >> allProtocolsUpTo: mostGenericClass [
+	"Answer a list of all the method protocols of the receiver and all its superclasses, up through mostGenericClass"
+
+	| protocols |
+	self deprecated: 'This methods will be removed in the next version of Pharo. If you use it, you can inline it.'.
+	protocols := (self allSuperclassesIncluding: mostGenericClass) flatCollectAsSet: [ :aClass | aClass organization protocolNames ].
+	protocols remove: Protocol nullProtocolName ifAbsent: [  ].
+	^ protocols
+]

--- a/src/Deprecated12/ClassDescriptionTest.extension.st
+++ b/src/Deprecated12/ClassDescriptionTest.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #ClassDescriptionTest }
+
+{ #category : #'*Deprecated12' }
+ClassDescriptionTest >> testAllProtocolsUpTo [
+	"If this test fails, it may be because method protocols are sorted in #allMethodCategoriesIntegratedThrough. Take care that if the protocols of the class under test are already sorted, you won't see any problem."
+	self assert: ((CompiledMethod selectorsInProtocol: 'testing') includes: #isAbstract).
+	CompiledMethod allProtocolsUpTo: Object.
+	self assert: ((CompiledMethod selectorsInProtocol: 'testing') includes: #isAbstract)
+]

--- a/src/Kernel-Tests/ClassDescriptionTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionTest.class.st
@@ -16,14 +16,6 @@ ClassDescriptionTest >> classToBeTested [
 	^ ClassDescription
 ]
 
-{ #category : #tests }
-ClassDescriptionTest >> testAllMethodCategoriesIntegratedThrough [
-	"If this test fails, it may be because method protocols are sorted in #allMethodCategoriesIntegratedThrough. Take care that if the protocols of the class under test are already sorted, you won't see any problem."
-	self assert: ((CompiledMethod selectorsInProtocol: 'testing') includes: #isAbstract).
-	CompiledMethod allProtocolsUpTo: Object.
-	self assert: ((CompiledMethod selectorsInProtocol: 'testing') includes: #isAbstract)
-]
-
 { #category : #'tests - slots' }
 ClassDescriptionTest >> testAllSlots [
 	self assert: Context allSlots size equals: 6

--- a/src/Kernel/AbstractProtocol.class.st
+++ b/src/Kernel/AbstractProtocol.class.st
@@ -31,12 +31,6 @@ AbstractProtocol class >> nullProtocolName [
 ]
 
 { #category : #accessing }
-AbstractProtocol class >> nullProtocolName [
-
-	^ #'no messages'
-]
-
-{ #category : #accessing }
 AbstractProtocol class >> unclassified [
 	^ #'as yet unclassified'
 ]

--- a/src/Kernel/AbstractProtocol.class.st
+++ b/src/Kernel/AbstractProtocol.class.st
@@ -31,6 +31,12 @@ AbstractProtocol class >> nullCategory [
 ]
 
 { #category : #accessing }
+AbstractProtocol class >> nullProtocolName [
+
+	^ #'no messages'
+]
+
+{ #category : #accessing }
 AbstractProtocol class >> unclassified [
 	^ #'as yet unclassified'
 ]

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -117,24 +117,6 @@ ClassDescription >> allLocalCallsOn: aSymbol [
 ]
 
 { #category : #'accessing - method dictionary' }
-ClassDescription >> allProtocolsUpTo: mostGenericClass [
-	"Answer a list of all the method protocols of the receiver and all its superclasses, up through mostGenericClass"
-
-	| otherClassCategories thisClassCategories lowercaseSortBlock  |
-
-	otherClassCategories := OrderedCollection new.
-	lowercaseSortBlock  := [ :a :b | a asLowercase <= b asLowercase ].
-
-	(self allSuperclassesIncluding: mostGenericClass) do: [ :aClass |
-		 otherClassCategories addAll: aClass organization protocolNames ].
-	otherClassCategories remove: 'no messages' ifAbsent: [  ].
-	thisClassCategories := self organization protocolNames sorted: lowercaseSortBlock.
-
-	^ thisClassCategories , ((otherClassCategories asSet removeAllSuchThat: [ :each |
-								thisClassCategories includes: each ]) sorted: lowercaseSortBlock)
-]
-
-{ #category : #'accessing - method dictionary' }
 ClassDescription >> allSelectorsInProtocol: aName [
 	"Answer a list of all the methods of the receiver and all its
 	superclasses that are in the protocol named aName"


### PR DESCRIPTION
allProtocolsUpTo: is not used in the image so I propose to deprecate it.  In case an external tool is using it, I updated the method to be simpler so it can probably just be inlined. 