### PR TITLE
Faulty code: cleanup CodeError

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -1482,8 +1482,8 @@ RBCodeSnippet class >> styleAllWithError [
 		each compileOnError: [ :exception |
 				"In case of error, insert error message (like an old-school smalltalk compiler)"
 				text
-					replaceFrom: exception location
-					to: exception location - 1
+					replaceFrom: exception position
+					to: exception position - 1
 					with: (exception messageText asText addAttribute:
 							 (TextBackgroundColor color: Color lightBlue)).
 				bigtext append: String cr.

--- a/src/AST-Core/CodeError.class.st
+++ b/src/AST-Core/CodeError.class.st
@@ -55,6 +55,12 @@ CodeError >> location: anInteger [
 ]
 
 { #category : #accessing }
+CodeError >> messageText [
+
+	^ self notice messageText
+]
+
+{ #category : #accessing }
 CodeError >> methodClass [
 	^ self methodNode methodClass
 ]

--- a/src/AST-Core/CodeError.class.st
+++ b/src/AST-Core/CodeError.class.st
@@ -7,10 +7,7 @@ Class {
 	#name : #CodeError,
 	#superclass : #Error,
 	#instVars : [
-		'notice',
-		'node',
-		'location',
-		'sourceCode'
+		'notice'
 	],
 	#category : #'AST-Core-Exception'
 }
@@ -49,12 +46,6 @@ CodeError >> location [
 ]
 
 { #category : #accessing }
-CodeError >> location: anInteger [
-
-	location := anInteger
-]
-
-{ #category : #accessing }
 CodeError >> messageText [
 
 	^ self notice messageText
@@ -73,11 +64,6 @@ CodeError >> methodNode [
 { #category : #accessing }
 CodeError >> node [
 	^ self notice node
-]
-
-{ #category : #accessing }
-CodeError >> node: aNode [
-	node := aNode
 ]
 
 { #category : #accessing }
@@ -102,10 +88,4 @@ CodeError >> position [
 CodeError >> sourceCode [
 
 	^ self methodNode sourceCode
-]
-
-{ #category : #accessing }
-CodeError >> sourceCode: aString [
-
-	sourceCode := aString
 ]

--- a/src/AST-Core/CodeError.class.st
+++ b/src/AST-Core/CodeError.class.st
@@ -7,6 +7,7 @@ Class {
 	#name : #CodeError,
 	#superclass : #Error,
 	#instVars : [
+		'notice',
 		'node',
 		'location',
 		'sourceCode'
@@ -73,6 +74,18 @@ CodeError >> node [
 { #category : #accessing }
 CodeError >> node: aNode [
 	node := aNode
+]
+
+{ #category : #accessing }
+CodeError >> notice [
+
+	^ notice
+]
+
+{ #category : #accessing }
+CodeError >> notice: anObject [
+
+	notice := anObject
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/CodeError.class.st
+++ b/src/AST-Core/CodeError.class.st
@@ -45,9 +45,7 @@ CodeError >> isResumable [
 { #category : #accessing }
 CodeError >> location [
 
-	location ifNotNil: [ ^ location  ].
-	node ifNotNil: [ ^ node start ].
-	^ nil
+	^ self position
 ]
 
 { #category : #accessing }
@@ -58,17 +56,17 @@ CodeError >> location: anInteger [
 
 { #category : #accessing }
 CodeError >> methodClass [
-	^self methodNode methodClass
+	^ self methodNode methodClass
 ]
 
 { #category : #accessing }
 CodeError >> methodNode [
-	^node methodNode
+	^ self node methodNode
 ]
 
 { #category : #accessing }
 CodeError >> node [
-	^ node
+	^ self notice node
 ]
 
 { #category : #accessing }
@@ -89,11 +87,15 @@ CodeError >> notice: anObject [
 ]
 
 { #category : #accessing }
+CodeError >> position [
+
+	^ self notice position
+]
+
+{ #category : #accessing }
 CodeError >> sourceCode [
 
-	sourceCode ifNotNil: [  ^ sourceCode ].
-	node ifNotNil: [  ^ node sourceCode ].
-	^ nil
+	^ self methodNode sourceCode
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -315,9 +315,6 @@ RBProgramNode >> checkFaulty: aBlock [
 
 	SyntaxErrorNotification new
 		notice: errorNotice;
-		sourceCode: self methodNode sourceCode;
-		messageText: errorNotice messageText;
-		location: errorNotice position;
 		signal.
 
 	"If resumed, just return"

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -70,10 +70,13 @@ RBProgramNode class >> resetFormatter [
 
 { #category : #notice }
 RBProgramNode >> addError: anErrorMessage [
-
 	"Add an error information to the node. Node with error information are considered faulty.
 	Semantic passes that check the validity of AST are the targetted clients of this method."
-	self addNotice: (RBErrorNotice new messageText: anErrorMessage)
+
+	| notice |
+	notice := RBErrorNotice new messageText: anErrorMessage.
+	self addNotice: notice.
+	^ notice
 ]
 
 { #category : #adding }
@@ -311,6 +314,7 @@ RBProgramNode >> checkFaulty: aBlock [
 	aBlock ifNotNil: [ aBlock cull: errorNotice messageText cull: errorNotice position cull: self ].
 
 	SyntaxErrorNotification new
+		notice: errorNotice;
 		sourceCode: self methodNode sourceCode;
 		messageText: errorNotice messageText;
 		location: errorNotice position;

--- a/src/CodeImport/MethodChunk.class.st
+++ b/src/CodeImport/MethodChunk.class.st
@@ -68,7 +68,7 @@ MethodChunk >> importFor: requestor logSource: logSource [
 		compile: contents
 		classified: categoryName
 		withStamp: stamp
-		notifying: (self methodCompileRequestorFor: requestor)
+		notifying: nil
 		logSource: logSource
 ]
 

--- a/src/CodeImportCommandLineHandlers/STCommandLineHandler.class.st
+++ b/src/CodeImportCommandLineHandlers/STCommandLineHandler.class.st
@@ -49,7 +49,7 @@ STCommandLineHandler class >> printCompilerWarning: aSyntaxErrorNotification [
 	| stderr position contents errorLine errorMessage maxLineNumberSize lineNumber |
 
 	"format the error"
-	position := aSyntaxErrorNotification location.
+	position := aSyntaxErrorNotification position.
 	contents := aSyntaxErrorNotification sourceCode.
 	errorLine := contents lineNumberCorrespondingToIndex: position.
 	stderr := VTermOutputDriver stderr.

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -93,9 +93,6 @@ OCASTSemanticAnalyzer >> error: aMessage forNode: aNode [
 
 	OCSemanticError new
 		notice: notice;
-		node: aNode;
-		messageText: aMessage;
-		location: aNode startWithoutParentheses;
 		signal
 ]
 
@@ -130,8 +127,6 @@ OCASTSemanticAnalyzer >> storeIntoReadOnlyVariable: variableNode [
 
 	^ OCStoreIntoReadOnlyVariableError new
 		  notice: notice;
-		  node: variableNode;
-		  messageText: 'Assignment to read-only variable';
 		  signal
 ]
 
@@ -144,8 +139,6 @@ OCASTSemanticAnalyzer >> storeIntoReservedVariable: variableNode [
 
 	^ OCStoreIntoReservedVariableError new
 		  notice: notice;
-		  node: variableNode;
-		  messageText: 'Assigment to reserved variable';
 		  signal
 ]
 

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -86,10 +86,13 @@ OCASTSemanticAnalyzer >> declareVariableNode: aVariableNode as: anOCTempVariable
 
 { #category : #errors }
 OCASTSemanticAnalyzer >> error: aMessage forNode: aNode [
-	aNode addError: aMessage.
+
+	| notice |
+	notice := aNode addError: aMessage.
 	compilationContext permitFaulty ifTrue: [ ^ self ].
 
 	OCSemanticError new
+		notice: notice;
 		node: aNode;
 		messageText: aMessage;
 		location: aNode startWithoutParentheses;
@@ -120,24 +123,30 @@ OCASTSemanticAnalyzer >> shadowing: var withVariable: aNode [
 
 { #category : #'error handling' }
 OCASTSemanticAnalyzer >> storeIntoReadOnlyVariable: variableNode [
-	variableNode addError: 'Assignment to read-only variable'.
+
+	| notice |
+	notice := variableNode addError: 'Assignment to read-only variable'.
 	compilationContext permitFaulty ifTrue: [ ^ self ].
 
 	^ OCStoreIntoReadOnlyVariableError new
-		node: variableNode;
-		messageText: 'Assignment to read-only variable';
-		signal
+		  notice: notice;
+		  node: variableNode;
+		  messageText: 'Assignment to read-only variable';
+		  signal
 ]
 
 { #category : #'error handling' }
 OCASTSemanticAnalyzer >> storeIntoReservedVariable: variableNode [
-	variableNode addError: 'Assigment to reserved variable'.
+
+	| notice |
+	notice := variableNode addError: 'Assigment to reserved variable'.
 	compilationContext permitFaulty ifTrue: [ ^ self ].
 
 	^ OCStoreIntoReservedVariableError new
-		node: variableNode;
-		messageText: 'Assigment to reserved variable';
-		signal
+		  notice: notice;
+		  node: variableNode;
+		  messageText: 'Assigment to reserved variable';
+		  signal
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -441,8 +441,6 @@ OpalCompiler >> parseForRequestor [
 		self compilationContext noPattern ifTrue: [
 			CodeError new
 				notice: notification node notices first; "Ugly temporary hack"
-				node: notification node;
-				messageText: notification messageText;
 				signal.
 			].
 		"I do not like the API that much.

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -440,6 +440,7 @@ OpalCompiler >> parseForRequestor [
 		"The menu is in fact broken on 'noPattern' mode (expression/script/doit) because some reparation assume it's a method body, so just signal as an error (on: block bellow)"
 		self compilationContext noPattern ifTrue: [
 			CodeError new
+				notice: notification node notices first; "Ugly temporary hack"
 				node: notification node;
 				messageText: notification messageText;
 				signal.

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -458,10 +458,9 @@ OpalCompiler >> parseForRequestor [
 	on: CodeError
 	do: [ :exception |
 		ast := nil. "Invalidate the AST to avoid compilation if failBlock do return"
-		exception sourceCode: source contents.
 		requestor
 			notify: exception messageText , ' ->'
-			at: exception location
+			at: exception position
 			in: exception sourceCode.
 		self compilationContext failBlock value ]
 ]

--- a/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
@@ -31,7 +31,7 @@ RBCodeSnippetTest >> testCompileOnError [
 	error := nil.
 	method := snippet compileOnError: [ :e |
 		          self assert:
-			          (snippet hasNotice: e messageText at: e location).
+			          (snippet hasNotice: e messageText at: e position).
 		          self assert: error isNil. "single invocation"
 		          error := e ].
 	snippet isFaulty
@@ -49,7 +49,7 @@ RBCodeSnippetTest >> testCompileOnErrorResume [
 	error := nil.
 	method := snippet compileOnError: [ :e |
 		          self assert:
-			          (snippet hasNotice: e messageText at: e location).
+			          (snippet hasNotice: e messageText at: e position).
 		          error := e.
 		          e resume ].
 	self assert: snippet isFaulty equals: error isNotNil.


### PR DESCRIPTION
CodeError is a superclass of syntactic and semantic errors (exceptions).
It exists to unify things and factorize some code but was introduced before the existence of RBNotice that reify error and warning messages on AST nodes.

This PR tries to bring consistency by simply making CodeError points to a RBNotice instead of a RBNode and duplicate information.
All domain information "error and warning messages on a AST node" is now managed to a single class (RBNotice), and the job of `CodeError` is to be an Error (exception).

Most code is straight forward. The only weirdness is the nullification of an argument "requestor" in CodeImport, but this is to avoid complex PR dependency with #13162