### PR TITLE
Faulty code - signal mainly CodeError

### DIFF
--- a/src/AST-Core-Tests/RBFormatterTest.class.st
+++ b/src/AST-Core-Tests/RBFormatterTest.class.st
@@ -47,19 +47,19 @@ RBFormatterTest >> testFormatPragmaWithLastIsSymbolArgument [
 	inputSource := 'foo  <selector: #= > ^ self'.
 	tree := self parseMethod: inputSource.
 	outputSource := self formatterClass new format: tree.
-	self shouldnt: [self parseMethod: outputSource] raise: SyntaxErrorNotification.
+	self shouldnt: [self parseMethod: outputSource] raise: CodeError.
 
 	"already worked and still should for non-symbol arguments"
 	inputSource := 'foo  <selector: 0 > ^ self'.
 	tree := self parseMethod: inputSource.
 	outputSource := self formatterClass new format: tree.
-	self shouldnt: [self parseMethod: outputSource] raise: SyntaxErrorNotification.
+	self shouldnt: [self parseMethod: outputSource] raise: CodeError.
 
 	"already worked and should still work for pragmas without arguments"
 	inputSource := 'foo  <selector> ^ self'.
 	tree := self parseMethod: inputSource.
 	outputSource := self formatterClass new format: tree.
-	self shouldnt: [self parseMethod: outputSource] raise: SyntaxErrorNotification
+	self shouldnt: [self parseMethod: outputSource] raise: CodeError
 ]
 
 { #category : #tests }

--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -104,19 +104,19 @@ RBParserTest >> testArrayNodesContainRightAmountOfStatementsAndPeriods [
 { #category : #'garbage tests' }
 RBParserTest >> testAssignToMessageRaisesSyntaxError [
 	"Raising a syntax exception when trying to do an assignement on a message."
-	self should: [self parserClass parseExpression: 'receiver selector := 1 + 2'] raise: SyntaxErrorNotification
+	self should: [self parserClass parseExpression: 'receiver selector := 1 + 2'] raise: CodeError
 ]
 
 { #category : #'garbage tests' }
 RBParserTest >> testAssignementRightValueWithUnfortunatePontuationRaisesSyntaxError [
 	"The idea is for the parser to realise the first dot isn't supposed to be here and select it. Also add a side note to give suggestion     on the provenance of the error."
-	self should: [self parserClass parseExpression: 'temp := .1 + 2.'] raise: SyntaxErrorNotification.
-	self should: [self parserClass parseExpression: 'temp := 1. + 2.'] raise: SyntaxErrorNotification.
-	self should: [self parserClass parseExpression: 'temp := 1 +. 2.'] raise: SyntaxErrorNotification.
+	self should: [self parserClass parseExpression: 'temp := .1 + 2.'] raise: CodeError.
+	self should: [self parserClass parseExpression: 'temp := 1. + 2.'] raise: CodeError.
+	self should: [self parserClass parseExpression: 'temp := 1 +. 2.'] raise: CodeError.
 
 	"The same could be made for other special characters."
-	self should: [self parserClass parseExpression: 'temp := ;1 + 2.'] raise: SyntaxErrorNotification.
-	self should: [self parserClass parseExpression: 'temp := ,1 + 2.'] raise: SyntaxErrorNotification
+	self should: [self parserClass parseExpression: 'temp := ;1 + 2.'] raise: CodeError.
+	self should: [self parserClass parseExpression: 'temp := ,1 + 2.'] raise: CodeError
 ]
 
 { #category : #'error testing' }
@@ -124,16 +124,16 @@ RBParserTest >> testBadlyPlacedPragmaRaiseError [
 	"The placement in the string will have an impact on the parsing methods involved.
 	 Pragmas are supposed to be written in the beginning of a method."
 	self shouldnt: [(self parserClass parseMethod: 'foo | token | <some: #tag> ^true')]
-		  raise: SyntaxErrorNotification.
+		  raise: CodeError.
 
 	self should: [(self parserClass parseMethod: 'foo | token | ^true <some: #tag>')]
-		  raise: 	SyntaxErrorNotification.
+		  raise: 	CodeError.
 
 	self should: [(self parserClass parseMethod: 'foo | token | token:= 5 <some: #tag> ^token')]
-		  raise: 	SyntaxErrorNotification.
+		  raise: 	CodeError.
 
 	self should: [(self parserClass parseMethod: 'foo | token |  token messaged <some: #tag> ^token')]
-		  raise: 	SyntaxErrorNotification
+		  raise: 	CodeError
 ]
 
 { #category : #'tests - Interval' }
@@ -224,9 +224,9 @@ RBParserTest >> testBlockReturnNode [
 RBParserTest >> testCascade [
 	self assert: (self parserClass parseExpression: ' self msg; yourself') isCascade.
 	self assert: (self parserClass parseExpression: ' self msg:(arg msg:arg); yourself') isCascade.
-	self should: [ self parserClass parseExpression: ' (self msg); yourself' ] raise: SyntaxErrorNotification.
-	self should: [ self parserClass parseExpression: ' self ; yourself' ] raise: SyntaxErrorNotification.
-	self should: [ self parserClass parseExpression: ' (self) ; yourself' ] raise: SyntaxErrorNotification
+	self should: [ self parserClass parseExpression: ' (self msg); yourself' ] raise: CodeError.
+	self should: [ self parserClass parseExpression: ' self ; yourself' ] raise: CodeError.
+	self should: [ self parserClass parseExpression: ' (self) ; yourself' ] raise: CodeError
 ]
 
 { #category : #'tests - Cascade' }
@@ -328,10 +328,10 @@ RBParserTest >> testCascadeWithMissingSelectorRaisesError [
 
 { #category : #'error testing' }
 RBParserTest >> testCascadeWithNoMessageRaiseError [
-	self should: [ self parserClass parseExpression: ' (self msg); yourself' ] raise: SyntaxErrorNotification.
-	self should: [ self parserClass parseExpression: ' self ; yourself' ] raise: SyntaxErrorNotification.
-	self should: [ self parserClass parseExpression: ' (self) ; yourself' ] raise: SyntaxErrorNotification.
-	self should: [ self parserClass parseExpression: ' self msg ;  ; yourself' ] raise: SyntaxErrorNotification
+	self should: [ self parserClass parseExpression: ' (self msg); yourself' ] raise: CodeError.
+	self should: [ self parserClass parseExpression: ' self ; yourself' ] raise: CodeError.
+	self should: [ self parserClass parseExpression: ' (self) ; yourself' ] raise: CodeError.
+	self should: [ self parserClass parseExpression: ' self msg ;  ; yourself' ] raise: CodeError
 ]
 
 { #category : #'tests - comparing' }
@@ -561,7 +561,7 @@ RBParserTest >> testErrorNodeForBadParenthesesStopAtEnd [
 RBParserTest >> testFaultyLiteralRaiseSyntaxError [
 	#('#"bar"foo' '# foo' '#1' '#12' '#12.3' '# 1' '##1' '#"bar"1')
 		do: [ :expr |
-		self should: [self parserClass parseExpression: expr] raise: SyntaxErrorNotification ]
+		self should: [self parserClass parseExpression: expr] raise: CodeError ]
 ]
 
 { #category : #tests }
@@ -598,7 +598,7 @@ RBParserTest >> testGarbageForgottenReceiver [
 	"Test made in sight of implementing the search of previous litterals when encountering an unknown
 	 variable in case it is, in fact, a selector. This works for cascade (forgotten ;) or missing
 	 receiver like self ..."
-	self should: [self parserClass parseExpression: '|temp | temp := 1 + 2. + 3'] raise: SyntaxErrorNotification
+	self should: [self parserClass parseExpression: '|temp | temp := 1 + 2. + 3'] raise: CodeError
 ]
 
 { #category : #'garbage tests' }
@@ -880,13 +880,13 @@ RBParserTest >> testInvalidPragmaPosition [
 	'foo [:x | <foo: $a> ] value'
 	'foo ^ <foo: $a>'
 	)
-	do: [ :each | self should: [ self parserClass parseMethod: each ] raise: SyntaxErrorNotification ]
+	do: [ :each | self should: [ self parserClass parseMethod: each ] raise: CodeError ]
 ]
 
 { #category : #'garbage tests' }
 RBParserTest >> testInvalidSelectorRaisesSyntaxError [
 	"Could propose multiple reparations like assignement, period, array..."
-	self should: [self parserClass parseExpression: 'temp 1 + 3'] raise: SyntaxErrorNotification
+	self should: [self parserClass parseExpression: 'temp 1 + 3'] raise: CodeError
 ]
 
 { #category : #tests }
@@ -1067,7 +1067,7 @@ RBParserTest >> testModifying [
 
 { #category : #'error testing' }
 RBParserTest >> testNegativeNumberError [
-	self should: [ self parserClass parseExpression: '- 2' ] raise: SyntaxErrorNotification
+	self should: [ self parserClass parseExpression: '- 2' ] raise: CodeError
 ]
 
 { #category : #'error testing' }
@@ -1580,9 +1580,9 @@ RBParserTest >> testPragmaConstantLiteralArgument [
 	validPragma := 'foo <return: #Point> ^ 0@0'.
 	"Point as argument is not allowed"
 	invalidPragma := 'foo <return: Point> ^ 0@0'.
-	self shouldnt:[self parserClass parseMethod: primitiveDeclartion] raise: SyntaxErrorNotification.
-	self shouldnt:[self parserClass 	parseMethod: validPragma] raise: SyntaxErrorNotification.
-	self should:[self parserClass parseMethod: invalidPragma] raise: SyntaxErrorNotification
+	self shouldnt:[self parserClass parseMethod: primitiveDeclartion] raise: CodeError.
+	self shouldnt:[self parserClass 	parseMethod: validPragma] raise: CodeError.
+	self should:[self parserClass parseMethod: invalidPragma] raise: CodeError
 ]
 
 { #category : #'error testing' }
@@ -1594,21 +1594,21 @@ RBParserTest >> testPragmaImplicitLiteralArrayIsInvalid [
 	pragmaWithExpressionAsArgument := 'foo
 	<func: (3+4) res: 7>
 	^ self'.
-	self should:[self parserClass parseMethod: pragmaWithExpressionAsArgument] raise: SyntaxErrorNotification.
+	self should:[self parserClass parseMethod: pragmaWithExpressionAsArgument] raise: CodeError.
 
 	"an explicit literal array is allowed"
 	pragmaWithLiteralArrayAsArgument := 'foo
 	<func: #(3+4) res: 7>
 	^ self'.
 	"Should work"
-	self shouldnt: [self parserClass parseMethod: pragmaWithLiteralArrayAsArgument] raise: SyntaxErrorNotification.
+	self shouldnt: [self parserClass parseMethod: pragmaWithLiteralArrayAsArgument] raise: CodeError.
 
 	"and of course a string literal"
 	pragmaWithStringAsArgument := 'foo
 	<func: ''(3+4)'' res: 7>
 	^ self'.
 	"should work"
-	self shouldnt: [self parserClass parseMethod: pragmaWithStringAsArgument] raise: SyntaxErrorNotification
+	self shouldnt: [self parserClass parseMethod: pragmaWithStringAsArgument] raise: CodeError
 ]
 
 { #category : #tests }
@@ -1622,7 +1622,7 @@ RBParserTest >> testPragmaInExpression [
 	self assert: (node methodNode hasPragmaNamed: #some:).
 
 	self should: [(self parserClass parseExpression: '| token | 1+2. <some: #tag> true')]
-		  raise: SyntaxErrorNotification
+		  raise: CodeError
 ]
 
 { #category : #'error testing' }
@@ -1684,7 +1684,7 @@ RBParserTest >> testPragmas [
 		"comment2"
 		<a>
 		<.
-		^1'] raise: SyntaxErrorNotification
+		^1'] raise: CodeError
 ]
 
 { #category : #'tests - parsing' }
@@ -1875,7 +1875,7 @@ RBParserTest >> testSymbolLiteral [
 	('# 1' 1)
 	('##1' 1)
 	('#"bar"1' 1)) do: [ :pair |
-		self should: [self parserClass parseExpression: pair first] raise: SyntaxErrorNotification ]
+		self should: [self parserClass parseExpression: pair first] raise: CodeError ]
 ]
 
 { #category : #'tests - Literal' }
@@ -1927,7 +1927,7 @@ RBParserTest >> testUnclosedParenthesesErrorNodeContainsRightValue [
 { #category : #'garbage tests' }
 RBParserTest >> testUnclosedParenthesesRaiseSyntaxError [
 	"Should propose a closing parenthese before the end of the statement. Should also offer possibility to quickly erase it."
-	self should: [self parserClass parseExpression: '(temp := 1 + 3 .'] raise: SyntaxErrorNotification
+	self should: [self parserClass parseExpression: '(temp := 1 + 3 .'] raise: CodeError
 ]
 
 { #category : #'error testing' }
@@ -1942,21 +1942,21 @@ RBParserTest >> testUnclosedTemporariesErrorNodeContainsRightValue [
 RBParserTest >> testUnfinishedStatementWithLeadingBracesRaisesError [
 
 	self should: [(self parserClass parseExpression: '[]}')]
-		  raise: SyntaxErrorNotification
+		  raise: CodeError
 ]
 
 { #category : #'error testing' }
 RBParserTest >> testUnfinishedStatementWithLeadingBracketRaisesError [
 
 	self should: [(self parserClass parseExpression: '[]]')]
-		  raise: SyntaxErrorNotification
+		  raise: CodeError
 ]
 
 { #category : #'error testing' }
 RBParserTest >> testUnfinishedStatementWithLeadingParenthesisRaisesError [
 
 	self should: [(self parserClass parseExpression: '[])')]
-		  raise: SyntaxErrorNotification
+		  raise: CodeError
 ]
 
 { #category : #private }

--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -576,7 +576,7 @@ RBParserTest >> testFormatter [
 { #category : #'garbage tests' }
 RBParserTest >> testGarbageForgottenDotAfterAssignement [
 	| tree child error |
-	self shouldnt: [self parserClass parseExpression: '|temp | temp := 1 + 2 temp + 3'] raise: SyntaxErrorNotification.
+	self shouldnt: [self parserClass parseExpression: '|temp | temp := 1 + 2 temp + 3'] raise: CodeError.
 
 	tree := self parserClass parseExpression: '|temp | temp := 1 + 2 temp + 3'.
 	self assert: tree isSequence.

--- a/src/AST-Core-Tests/RBScannerTest.class.st
+++ b/src/AST-Core-Tests/RBScannerTest.class.st
@@ -1582,7 +1582,7 @@ RBScannerTest >> testNextWithTwoDoubleQuotesInComment [
 	source := '"only the"" opening"'.
 	self
 		shouldnt: [ token := (self buildScannerForText: source) next ]
-		raise: SyntaxErrorNotification.
+		raise: CodeError.
 	self assert: token comments first value equals: 'only the" opening'
 ]
 

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -310,7 +310,7 @@ RBProgramNode >> checkFaulty: aBlock [
 
 	aBlock ifNotNil: [ aBlock cull: errorNotice messageText cull: errorNotice position cull: self ].
 
-	SyntaxErrorNotification new
+	CodeError new
 		sourceCode: self methodNode sourceCode;
 		messageText: errorNotice messageText;
 		location: errorNotice position;

--- a/src/CodeImportCommandLineHandlers/STCommandLineHandler.class.st
+++ b/src/CodeImportCommandLineHandlers/STCommandLineHandler.class.st
@@ -114,7 +114,7 @@ STCommandLineHandler >> end [
 STCommandLineHandler >> handleError: error [
 
 	"for syntax errors we can used the default action"	"otherwise resignal it"
-	(error isKindOf: SyntaxErrorNotification)
+	(error isKindOf: CodeError)
 		ifTrue: [ error defaultAction ]
 		ifFalse: [ error pass ]
 ]
@@ -131,16 +131,6 @@ STCommandLineHandler >> handleError: error reference: aReference [
 	Smalltalk isHeadless
 		ifTrue: [ self inform: 'Errors in script loaded from ', aReference name ].
 
-	"for syntax errors we can use the default action"
-	(error isKindOf: SyntaxErrorNotification)
-		ifTrue: [ ^ error defaultAction ].
-
-	(error isKindOf: OCSemanticError)
-		ifTrue: [
-			self class printCompilerWarning: error.
-			^ error resume: error defaultAction ].
-
-	"otherwise resignal it"
 	error pass
 ]
 

--- a/src/DrTests-CommentsToTests-Tests/CommentsToTestsTest.class.st
+++ b/src/DrTests-CommentsToTests-Tests/CommentsToTestsTest.class.st
@@ -28,7 +28,7 @@ CommentsToTestsTest >> testCommentWithSyntaxError [
 	docComment := thisContext method ast pharoDocCommentNodes first.
 	commentTestCase := CommentTestCase for: docComment.
 
-	self should: [commentTestCase testIt] raise: SyntaxErrorNotification
+	self should: [commentTestCase testIt] raise: CodeError
 ]
 
 { #category : #tests }

--- a/src/OpalCompiler-Tests/OCASTBasicTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTBasicTranslatorTest.class.st
@@ -21,5 +21,5 @@ OCASTBasicTranslatorTest >> testSyntaxError [
 
 	self
 		should: [ self compileSource: 'foo (']
-		raise: SyntaxErrorNotification
+		raise: CodeError
 ]

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -278,7 +278,7 @@ OCCompilerTest >> testUndefinedVariableFrontend [
 	Undeclared removeKey: #undefinedName123 ifAbsent: [ ].
 	OpalCompiler new parse: 'foo ^undefinedName123'.
 	self deny: (Undeclared includesKey: #undefinedName123).
-	self should: [ OpalCompiler new compile: 'foo ^undefinedName123 ¿ 2' ] raise: SyntaxErrorNotification.
+	self should: [ OpalCompiler new compile: 'foo ^undefinedName123 ¿ 2' ] raise: CodeError.
 	self deny: (Undeclared includesKey: #undefinedName123).
 	OpalCompiler new compile: 'foo ^undefinedName123'.
 	self assert: (Undeclared includesKey: #undefinedName123).

--- a/src/PharoDocComment-Tests/PharoDocCommentTest.class.st
+++ b/src/PharoDocComment-Tests/PharoDocCommentTest.class.st
@@ -86,8 +86,8 @@ PharoDocCommentTest >> testExpressionSyntaxError [
 	self assert: node expression isFaulty.
 	"but the structure of the >>> looks ok"
 	self assert: node expression isWellFormed.
-	self should: [ node expression evaluate ] raise: SyntaxErrorNotification.
-	self should: [ (CommentTestCase for: node) testIt ] raise: SyntaxErrorNotification
+	self should: [ node expression evaluate ] raise: CodeError.
+	self should: [ (CommentTestCase for: node) testIt ] raise: CodeError
 ]
 
 { #category : #tests }

--- a/src/Tool-Finder/Finder.class.st
+++ b/src/Tool-Finder/Finder.class.st
@@ -85,9 +85,9 @@ Finder >> computeWithMethodFinder: aString [
 	data := aString trimRight: [ :char | char isSeparator or: [ char = $. ] ].
 
 	[ dataObjects := Smalltalk compiler evaluate: '{' , data , '}' ]
-		on: SyntaxErrorNotification, RuntimeSyntaxError
+		on: CodeError, RuntimeSyntaxError
 		do: [ :e |
-			self inform: 'Syntax Error: ' , e messageText.
+			self inform: 'Error: ' , e messageText.
 			^ #() ].	"#( data1 data2 result )"
 
 	dataObjects size < 2


### PR DESCRIPTION
This PR change the code to use `CodeError` instead of `SyntaxErrorNotification`.

Because it is no more necessarily a syntax error, and it's no more a notification.