### PR TITLE
Faulty code: make OCASTSemanticAnalyzer (almost) faulty only

### DIFF
--- a/src/CodeImportCommandLineHandlers/STCommandLineHandler.class.st
+++ b/src/CodeImportCommandLineHandlers/STCommandLineHandler.class.st
@@ -137,7 +137,7 @@ STCommandLineHandler >> handleError: error reference: aReference [
 { #category : #installing }
 STCommandLineHandler >> handleErrorsDuring: aBlock reference: aReference [
 	aBlock
-		on: Error, OCSemanticWarning, OCSemanticError
+		on: Error, OCSemanticWarning
 		do: [ :e | self handleError: e reference: aReference ]
 ]
 

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -99,13 +99,7 @@ OCASTSemanticAnalyzer >> declareVariableNode: aVariableNode as: anOCTempVariable
 { #category : #errors }
 OCASTSemanticAnalyzer >> error: aMessage forNode: aNode [
 
-	| notice |
-	notice := aNode addError: aMessage.
-	compilationContext permitFaulty ifTrue: [ ^ self ].
-
-	OCSemanticError new
-		notice: notice;
-		signal
+	aNode addError: aMessage
 ]
 
 { #category : #accessing }
@@ -138,25 +132,13 @@ OCASTSemanticAnalyzer >> shadowing: var withVariable: aNode [
 { #category : #'error handling' }
 OCASTSemanticAnalyzer >> storeIntoReadOnlyVariable: variableNode [
 
-	| notice |
-	notice := variableNode addError: 'Assignment to read-only variable'.
-	compilationContext permitFaulty ifTrue: [ ^ self ].
-
-	^ OCStoreIntoReadOnlyVariableError new
-		  notice: notice;
-		  signal
+	variableNode addError: 'Assignment to read-only variable'
 ]
 
 { #category : #'error handling' }
 OCASTSemanticAnalyzer >> storeIntoReservedVariable: variableNode [
 
-	| notice |
-	notice := variableNode addError: 'Assigment to reserved variable'.
-	compilationContext permitFaulty ifTrue: [ ^ self ].
-
-	^ OCStoreIntoReservedVariableError new
-		  notice: notice;
-		  signal
+	variableNode addError: 'Assigment to reserved variable'
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OCSemanticError.class.st
+++ b/src/OpalCompiler-Core/OCSemanticError.class.st
@@ -1,8 +1,0 @@
-"
-Raises a semantic error during semantic analysis
-"
-Class {
-	#name : #OCSemanticError,
-	#superclass : #CodeError,
-	#category : #'OpalCompiler-Core-Exception'
-}

--- a/src/OpalCompiler-Core/OCStoreIntoReadOnlyVariableError.class.st
+++ b/src/OpalCompiler-Core/OCStoreIntoReadOnlyVariableError.class.st
@@ -1,9 +1,0 @@
-"
-Error when trying to assign to a non writeble Variable.
-(method arguments). For backward compatibility this error does not signal if the compilation context is not  interactive.
-"
-Class {
-	#name : #OCStoreIntoReadOnlyVariableError,
-	#superclass : #OCSemanticError,
-	#category : #'OpalCompiler-Core-Exception'
-}

--- a/src/OpalCompiler-Core/OCStoreIntoReservedVariableError.class.st
+++ b/src/OpalCompiler-Core/OCStoreIntoReservedVariableError.class.st
@@ -1,8 +1,0 @@
-"
-Error when trying to assign to self, super and thisContext
-"
-Class {
-	#name : #OCStoreIntoReservedVariableError,
-	#superclass : #OCSemanticError,
-	#category : #'OpalCompiler-Core-Exception'
-}

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -407,6 +407,8 @@ OpalCompiler >> parse [
 	self callParsePlugins.
 	self doSemanticAnalysis.
 
+	self permitFaulty ifFalse: [ ast checkFaulty: nil ].
+
 	^ ast
 ]
 

--- a/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
@@ -41,8 +41,9 @@ OCASTTranslatorTest >> compileSource: source [
 	| ir ast |
 	ast := RBParser parseMethod: source.
 	ast compilationContext: self compilationContext.
-	ast compilationContext permitFaulty: false.
-	ir := (ast doSemanticAnalysisIn: OCOpalExamples) ir.
+	ast doSemanticAnalysisIn: OCOpalExamples.
+	ast checkFaulty: nil.
+	ir := ast ir.
 	^ 	method := ir compiledMethod
 ]
 

--- a/src/OpalCompiler-Tests/OCASTVariableTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTVariableTranslatorTest.class.st
@@ -7,8 +7,7 @@ Class {
 { #category : #'tests - variables' }
 OCASTVariableTranslatorTest >> testAssignArgumentVariable [
 	self
-		should: [self compileSource: 'argument: anArgument
-	anArgument := 17'] raise: OCStoreIntoReadOnlyVariableError
+		should: [self compileSource: 'argument: anArgument  anArgument := 17'] raise: CodeError
 ]
 
 { #category : #'tests - variables' }
@@ -36,15 +35,13 @@ OCASTVariableTranslatorTest >> testAssignInstanceVariable [
 { #category : #'tests - variables' }
 OCASTVariableTranslatorTest >> testAssignSelfVariable [
 	self
-		should: [self compileSource: 'foo
-	self := 17'] raise: OCStoreIntoReservedVariableError
+		should: [self compileSource: 'foo self := 17'] raise: CodeError
 ]
 
 { #category : #'tests - variables' }
 OCASTVariableTranslatorTest >> testAssignSuperVariable [
 	self
-		should: [self compileSource: 'foo
-	super := 17'] raise: OCStoreIntoReservedVariableError
+		should: [self compileSource: 'foo super := 17'] raise: CodeError
 ]
 
 { #category : #'tests - variables' }
@@ -57,8 +54,7 @@ OCASTVariableTranslatorTest >> testAssignTemporaryVariable [
 { #category : #'tests - variables' }
 OCASTVariableTranslatorTest >> testAssignThisContextVariable [
 	self
-		should: [self compileSource: 'foo
-	thisContext := 17'] raise: OCStoreIntoReservedVariableError
+		should: [self compileSource: 'foo thisContext := 17'] raise: CodeError
 ]
 
 { #category : #'tests - variables' }


### PR DESCRIPTION
~~This PR need both #13163 and #13164.
For now, it is just here to test the CI and gather possible feedback (and joyful reactions of people).~~
needed PR are merged, and the code is rebased, It's now easy to review (and to rejoice!)

`OCASTSemanticAnalyzer` signals errors in non-faulty mode, and only annotates the AST in faulty mode.
This PR change that: now the analyzer does not care about the faulty mode (almost*), and it just annotates the AST. The signaling of errors is no more its responsibility.

It's the same change that was done to the parser a few PR ago (#13080).
You want to do semantic analysis on a bad AST full of semantic error? Then you get an AST marked up in red, and a silent stare from the semantic analyzer.
If you like exceptions, you can then run `checkFaulty` on the AST (it was introduced for faulty parsing).
It is what the compiler will do in non-faulty-mode, so you get your exceptions.

The benefits are that it simplifies the code of the semantic analyzer, and make its behavior consistent with the one of the parser. It also avoids AST to be only partially analyzed.

If you follow the PR series, you know that error information are now reified as `RBNotice` instances, and `CodeError` is a simple exception used as messenger. Therefore, `checkFaulty` only signals `CodeError` and there is no more need of a complex hierarchy of semantic errors (that only a few tests cared about, by the way).
So the PR also remove `OCSemanticError` and its subclasses.

(*) About the "almost" of the PR title. Only two places remains where the semantic analyzer gets a different behavior in faulty mode:
* For undeclared variables. It is a complex issue to address. cf #13006 . We need to do more cleanup, more improvements and grind more xp.
* For workspace variables, because workspace variables are created at semantic-time in compilation mode to avoid mass creation of random workspace variables each time you highlight the code. I do not like the current design of workspace variables, but's is another story and will be likely solved later — in DLC or something :).