### PR TITLE
implement #selectedClassOrMetaClass in MCTool to return nil

### DIFF
--- a/src/MonticelloGUI/MCCodeTool.class.st
+++ b/src/MonticelloGUI/MCCodeTool.class.st
@@ -167,12 +167,6 @@ MCCodeTool >> selectedClass [
 ]
 
 { #category : #subclassresponsibility }
-MCCodeTool >> selectedClassOrMetaClass [
-	"Answer the class that is selected, or nil"
-	self subclassResponsibility
-]
-
-{ #category : #subclassresponsibility }
 MCCodeTool >> selectedMessageCategoryName [
 	"Answer the method category of the method that is selected, or nil"
 	self subclassResponsibility

--- a/src/MonticelloGUI/MCTool.class.st
+++ b/src/MonticelloGUI/MCTool.class.st
@@ -299,6 +299,11 @@ MCTool >> preferredColor [
 	^ (Color r: 0.627 g: 0.69 b: 0.976)
 ]
 
+{ #category : #accessing }
+MCTool >> selectedClassOrMetaClass [
+	^nil
+]
+
 { #category : #'morphic ui' }
 MCTool >> setDefaultFocus [
 	"set the default focus on the morph elements.


### PR DESCRIPTION
fixes #13149

I did not really test MC tools, I am sure there will be more problems as they are not used often these days 
(we should think about removing them)