### PR TITLE
ClassComments-Via-Class 

### DIFF
--- a/src/Calypso-SystemQueries-Tests/ClyClassCommentsQueryTest.class.st
+++ b/src/Calypso-SystemQueries-Tests/ClyClassCommentsQueryTest.class.st
@@ -52,20 +52,6 @@ ClyClassCommentsQueryTest >> testFromClassScope [
 ]
 
 { #category : #tests }
-ClyClassCommentsQueryTest >> testFromClassWithoutCommentWhenPatternSatisfiesCommentTemplate [
-
-	| noCommentClass substring |
-	noCommentClass := Object newAnonymousSubclass.
-	self deny: noCommentClass hasComment.
-	substring := noCommentClass comment copyFrom: 4 to: 30.
-
-	query pattern: (ClySubstringPattern with: substring).
-	self queryFromScope: ClyClassScope of: noCommentClass.
-
-	self assert: resultItems isEmpty
-]
-
-{ #category : #tests }
 ClyClassCommentsQueryTest >> testThisClassShouldIncludeExpectedComment [
 
 	self assert: (self class comment

--- a/src/Epicea/Class.extension.st
+++ b/src/Epicea/Class.extension.st
@@ -12,8 +12,8 @@ Class >> asEpiceaRingDefinition [
 		        addInstanceVariables: self instVarNames;
 		        addClassVariables: self classVarNames;
 		        addSharedPools: self sharedPoolNames;
-		        comment: self organization classComment;
-		        stamp: self organization commentStamp;
+		        comment: self comment;
+		        stamp: self commentStamp;
 		        definitionSource: self definitionString;
 		        package: (EpPlatform current packageNameFor: self);
 		        withMetaclass.

--- a/src/EpiceaBrowsers-Tests/EpHasImpactFilterTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpHasImpactFilterTest.class.st
@@ -78,8 +78,8 @@ EpHasImpactFilterTest >> testCommentWithImpact [
 		newWithBehavior: aClass asEpiceaRingDefinition
 		oldComment: 'a'
 		newComment: 'b'
-		oldStamp: aClass organization commentStamp
-		newStamp: aClass organization commentStamp).
+		oldStamp: aClass commentStamp
+		newStamp: aClass commentStamp).
 	aClass comment: 'c'.
 	self assert: (impactFilter accepts: anEvent)
 ]
@@ -93,8 +93,8 @@ EpHasImpactFilterTest >> testCommentWithoutImpact [
 		newWithBehavior: aClass asEpiceaRingDefinition
 		oldComment: 'a'
 		newComment: 'b'
-		oldStamp: aClass organization commentStamp
-		newStamp: aClass organization commentStamp).
+		oldStamp: aClass commentStamp
+		newStamp: aClass commentStamp).
 	aClass comment: 'c'.
 	aClass comment: 'b'.
 	self deny: (impactFilter accepts: anEvent)

--- a/src/EpiceaBrowsers-Tests/EpRevertTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpRevertTest.class.st
@@ -41,7 +41,7 @@ EpRevertTest >> testBehaviorCommentChange [
 
 	self revertInputEntry.
 
-	self assert: aClass organization classComment equals: 'before'
+	self assert: aClass comment equals: 'before'
 ]
 
 { #category : #tests }

--- a/src/EpiceaBrowsers/EpApplyPreviewer.class.st
+++ b/src/EpiceaBrowsers/EpApplyPreviewer.class.st
@@ -63,13 +63,13 @@ EpApplyPreviewer >> visitBehaviorCommentChange: aChange [
 	self
 		behaviorNamed: aChange behaviorAffectedName
 		ifPresent: [ :aBehavior |
-			(aBehavior organization classComment = aChange newComment) ifFalse: [
+			(aBehavior comment = aChange newComment) ifFalse: [
 				^ {
 					EpBehaviorCommentChange
 						newWithBehavior: aBehavior
-						oldComment: aBehavior organization classComment
+						oldComment: aBehavior comment
 						newComment: aChange newComment
-						oldStamp: aBehavior organization commentStamp
+						oldStamp: aBehavior commentStamp
 						newStamp: aChange newStamp
 				} ] ].
 

--- a/src/EpiceaBrowsers/EpHasImpactVisitor.class.st
+++ b/src/EpiceaBrowsers/EpHasImpactVisitor.class.st
@@ -62,7 +62,7 @@ EpHasImpactVisitor >> visitBehaviorCommentChange: aChange [
 		behaviorNamed: aChange behaviorAffectedName
 		ifPresent: [ :aClass |
 			^ aClass comment ~= aChange newComment or: [
-			aClass organization commentStamp ~= aChange newStamp ] ].
+			aClass commentStamp ~= aChange newStamp ] ].
 
 	^ true
 ]

--- a/src/Fuel-Tests-Core/FLTCreateClassOrTraitSerializationTest.trait.st
+++ b/src/Fuel-Tests-Core/FLTCreateClassOrTraitSerializationTest.trait.st
@@ -146,7 +146,7 @@ FLTCreateClassOrTraitSerializationTest >> testCreateWithComment [
 	materializedClassOrTrait := self resultOfSerializeRemoveAndMaterialize: aClassOrTrait.
 
 	self assert: 'test comment' = materializedClassOrTrait comment asString.
-	self assert: 'test stamp' = materializedClassOrTrait organization commentStamp.
+	self assert: 'test stamp' = materializedClassOrTrait commentStamp.
 ]
 
 { #category : #tests }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -197,12 +197,12 @@ ClassDescription >> classComment: aString stamp: aStamp [
 	"Store the comment, aString or Text or RemoteString, associated with the class we are organizing.  Empty string gets stored only if had a non-empty one before."
 
 	| pointer header oldComment oldStamp preamble |
-	oldComment := self organization classComment.
-	oldStamp := self organization commentStamp.
+	oldComment := self comment.
+	oldStamp := self commentStamp.
 
 	aString string = oldComment string ifTrue: [ ^ self ].
 
-	pointer := self organization commentSourcePointer ifNil: [0].
+	pointer := self commentSourcePointer ifNil: [0].
 
 
 	preamble := String streamContents: [ :file |
@@ -219,8 +219,7 @@ ClassDescription >> classComment: aString stamp: aStamp [
 		writeSource: aString
 		preamble: preamble
 		onSuccess: [ :newSourcePointer |
-			self organization
-				commentSourcePointer: newSourcePointer]
+			self commentSourcePointer: newSourcePointer]
 		onFail: [ "ignore" ].
 
 	SystemAnnouncer uniqueInstance
@@ -334,8 +333,7 @@ ClassDescription >> classesThatImplementAllOf: selectorSet [
 
 { #category : #'accessing - comment' }
 ClassDescription >> comment [
-    "Answer the receiver's comment. (If missing, supply a template) "
-    ^self instanceSide organization classComment ifEmpty: [ self classCommentBlank ]
+    ^self instanceSide organization classComment
 ]
 
 { #category : #'accessing - comment' }
@@ -352,10 +350,29 @@ ClassDescription >> comment: aStringOrText stamp: aStamp [
 	self instanceSide classComment: aStringOrText stamp: aStamp
 ]
 
+{ #category : #'accessing - comment' }
+ClassDescription >> commentSourcePointer [
+	"for now get it from the organization"
+	^self instanceSide organization commentSourcePointer
+]
+
+{ #category : #'accessing - comment' }
+ClassDescription >> commentSourcePointer: anObject [
+	self instanceSide organization commentSourcePointer: anObject
+]
+
+{ #category : #'accessing - comment' }
+ClassDescription >> commentStamp [
+
+	^ commentSourcePointer
+		  ifNil: [ self instanceSide organization commentStamp ]
+		  ifNotNil: [ SourceFiles commentTimeStampAt: commentSourcePointer]
+]
+
 { #category : #'file in/out' }
 ClassDescription >> commentStamp: changeStamp [
 	"update the changeStamp"
-	self comment: self organization comment stamp: changeStamp
+	self comment: self instanceSide organization comment stamp: changeStamp
 ]
 
 { #category : #compiling }

--- a/src/Monticello-Tests/MCClassDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCClassDefinitionTest.class.st
@@ -81,7 +81,7 @@ MCClassDefinitionTest >> testCreation [
 	self assert: d classInstVarNames asArray equals: #().
 	self assert: d comment isString.
 	self assert: d comment equals: self classAComment.
-	self assert: d commentStamp equals: self mockClassA organization commentStamp
+	self assert: d commentStamp equals: self mockClassA commentStamp
 ]
 
 { #category : #tests }
@@ -141,8 +141,8 @@ MCClassDefinitionTest >> testLoadAndUnload [
 	self assertEmpty: c classVarNames.
 	self assertEmpty: c sharedPools.
 	self assert: c category equals: self mockCategoryName.
-	self assert: c organization classComment equals: (self commentForClass: 'MCMockClassC').
-	self assert: c organization commentStamp equals: (self commentStampForClass: 'MCMockClassC').
+	self assert: c comment equals: (self commentForClass: 'MCMockClassC').
+	self assert: c commentStamp equals: (self commentStampForClass: 'MCMockClassC').
 	d unload.
 	self deny: (testingEnvironment hasClassNamed: 'MCMockClassC')
 ]

--- a/src/Monticello/Class.extension.st
+++ b/src/Monticello/Class.extension.st
@@ -21,8 +21,8 @@ Class >> asClassDefinition [
 						poolDictionaryNames: self sharedPoolNames
 						classInstVarNames: (self class localSlots collect: [:each | each definitionString])
 						type: self mcType
-						comment: self organization classComment	asString
-						commentStamp: self organization commentStamp ]
+						comment: self comment
+						commentStamp: self commentStamp ]
 	
 		ifFalse: [  
 				 MCClassDefinition
@@ -36,8 +36,8 @@ Class >> asClassDefinition [
 						poolDictionaryNames: self sharedPoolNames
 						classInstVarNames: (self class localSlots collect: [ :each | each name ])
 						type: self mcType
-						comment: self organization classComment	asString
-						commentStamp: self organization commentStamp ]
+						comment: self comment
+						commentStamp: self commentStamp ]
 	
 
 

--- a/src/Monticello/Trait.extension.st
+++ b/src/Monticello/Trait.extension.st
@@ -20,8 +20,8 @@ Trait >> asClassDefinition [
 				instVarNames: (self localSlots collect: [:each |each definitionString])
 				classInstVarNames: (self classSide localSlots collect: [:each |each definitionString])
 				classTraitComposition: classTraitCompositionToUse
-				comment: self organization classComment asString
-				commentStamp: self organization commentStamp ]
+				comment: self comment
+				commentStamp: self commentStamp ]
 		 ifFalse: [  
 			MCTraitDefinition
 				name: self name
@@ -30,8 +30,8 @@ Trait >> asClassDefinition [
 				instVarNames: (self localSlots collect: [ :each | each name ])
 				classInstVarNames: (self class localSlots collect: [ :each | each name ])
 				classTraitComposition: classTraitCompositionToUse
-				comment: self organization classComment asString
-				commentStamp: self organization commentStamp
+				comment: self comment
+				commentStamp: self commentStamp
 				]
 		
 	

--- a/src/MonticelloGUI-Tests/MCSnapshotBrowserTest.class.st
+++ b/src/MonticelloGUI-Tests/MCSnapshotBrowserTest.class.st
@@ -88,7 +88,7 @@ MCSnapshotBrowserTest >> classAClassProtocols [
 
 { #category : #private }
 MCSnapshotBrowserTest >> classAComment [
-	^ self mockClassA organization classComment.
+	^ self mockClassA comment.
 ]
 
 { #category : #private }

--- a/src/Morphic-Widgets-FastTable/FTExampleClassInfoTableDataSource.class.st
+++ b/src/Morphic-Widgets-FastTable/FTExampleClassInfoTableDataSource.class.st
@@ -39,8 +39,8 @@ FTExampleClassInfoTableDataSource >> iconFor: index [
 			class hasErrorTest
 				ifTrue: [ ^ self iconNamed: #testRed ].
 			^ self iconNamed: #testNotRun ].
-	class organization classComment
-		ifEmpty: [ ^ self iconNamed: #uncommentedClass].
+	class hasComment 
+		ifFalse: [ ^ self iconNamed: #uncommentedClass].
 	((class
 		includesBehavior: (Smalltalk globals at: #TestCase ifAbsent: [ false ]))
 		and: [ class isAbstract not ])
@@ -51,8 +51,6 @@ FTExampleClassInfoTableDataSource >> iconFor: index [
 			class hasErrorTest
 				ifTrue: [ ^ self iconNamed: #testRed ].
 			^ self iconNamed: #testNotRun ].
-	class organization classComment
-		ifEmpty: [ ^ self iconNamed: #uncommentedClass ].
 	^ self iconNamed: class systemIconName
 ]
 

--- a/src/Morphic-Widgets-FastTable/FTExampleDataSource.class.st
+++ b/src/Morphic-Widgets-FastTable/FTExampleDataSource.class.st
@@ -40,8 +40,8 @@ FTExampleDataSource >> iconFor: index [
 			class hasErrorTest
 				ifTrue: [ ^ self iconNamed: #testRed ].
 			^ self iconNamed: #testNotRun ].
-	class organization classComment
-		ifEmpty: [ ^ self iconNamed: #uncommentedClass ].
+	class hasComment 
+		ifFalse: [ ^ self iconNamed: #uncommentedClass].
 	((class
 		includesBehavior: (Smalltalk globals at: #TestCase ifAbsent: [ false ]))
 		and: [ class isAbstract not ])
@@ -52,7 +52,5 @@ FTExampleDataSource >> iconFor: index [
 			class hasErrorTest
 				ifTrue: [ ^ self iconNamed: #testRed ].
 			^ self iconNamed: #testNotRun ].
-	class organization classComment
-		ifEmpty: [ ^ self iconNamed: #uncommentedClass ].
 	^ self iconNamed: class systemIconName
 ]

--- a/src/Polymorph-Widgets/SystemWindow.extension.st
+++ b/src/Polymorph-Widgets/SystemWindow.extension.st
@@ -6,7 +6,7 @@ SystemWindow >> aboutText [
 
 	^self model
 		ifNil: ['This is a system window without a model' translated]
-		ifNotNil: [self model class instanceSide organization classComment
+		ifNotNil: [self model class instanceSide comment
 					ifEmpty: ['The model of this window has no class comment']
 					ifNotEmpty: [:comment | comment]]
 ]

--- a/src/Refactoring-Changes/RBCommentChange.class.st
+++ b/src/Refactoring-Changes/RBCommentChange.class.st
@@ -25,7 +25,7 @@ RBCommentChange class >> comment: aString in: aClass [
 RBCommentChange >> asUndoOperation [
 
 	^ self copy
-		  comment: self changeClass organization classComment;
+		  comment: self changeClass comment;
 		  yourself
 ]
 

--- a/src/Refactoring-Tests-Changes/RBRefactoringChangeTest.class.st
+++ b/src/Refactoring-Tests-Changes/RBRefactoringChangeTest.class.st
@@ -423,9 +423,9 @@ RBRefactoringChangeTest >> testPerformChangeClass [
 RBRefactoringChangeTest >> testPerformChangeComment [
 	| change comment |
 	change := changes comment: 'Some Comment' in: self changeMock.
-	comment := change changeClass organization classComment.
+	comment := change changeClass comment.
 	self perform: change do: [ self assert: change changeClass comment equals: 'Some Comment' ].
-	self assert: change changeClass organization classComment equals: comment
+	self assert: change changeClass comment equals: comment
 ]
 
 { #category : #'tests - perform' }

--- a/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
@@ -39,7 +39,7 @@ NoUnusedVariablesLeftTest >> testNoUnusedInstanceVariablesLeft [
 
 	classes := variables collect: [ :each | each definingClass ] as: Set.
 
-	validExceptions := { RBFooLintRuleTestData . RBLintRuleTestData .RBFooDummyLintRuleTest . RBDummyLintRuleTest. MockWithComplexSlot .ClassDescription }.
+	validExceptions := { RBFooLintRuleTestData . RBLintRuleTestData .RBFooDummyLintRuleTest . RBDummyLintRuleTest. MockWithComplexSlot }.
 
 	remaining := classes asOrderedCollection removeAll: validExceptions; yourself.
 	self assert: remaining isEmpty description: ('the following classes have unused instance variables and should be cleaned: ', remaining asString)

--- a/src/Ring-Core/RGReadOnlyImageBackend.class.st
+++ b/src/Ring-Core/RGReadOnlyImageBackend.class.st
@@ -40,19 +40,19 @@ RGReadOnlyImageBackend >> categoryFor: anRGBehavior [
 { #category : #'class comment' }
 RGReadOnlyImageBackend >> classCommentAuthorFor: anRGComment [
 
-	^ RGStampParser authorForStamp: (self realBehaviorFor: anRGComment parent) organization commentStamp
+	^ RGStampParser authorForStamp: (self realBehaviorFor: anRGComment parent) commentStamp
 ]
 
 { #category : #'class comment' }
 RGReadOnlyImageBackend >> classCommentContentFor: anRGComment [
 
-	^ (self realBehaviorFor: anRGComment parent) organization classComment
+	^ (self realBehaviorFor: anRGComment parent) comment
 ]
 
 { #category : #'class comment' }
 RGReadOnlyImageBackend >> classCommentTimeFor: anRGComment [
 
-	^ RGStampParser timeForStamp: (self realBehaviorFor: anRGComment parent) organization commentStamp
+	^ RGStampParser timeForStamp: (self realBehaviorFor: anRGComment parent) commentStamp
 ]
 
 { #category : #trait }

--- a/src/Ring-Definitions-Core/Class.extension.st
+++ b/src/Ring-Definitions-Core/Class.extension.st
@@ -52,8 +52,8 @@ Class >> asRingDefinition [
 		addInstanceVariables: self instVarNames;
 		addClassVariables: self classVarNames;
 		addSharedPools: self sharedPoolNames;
-		comment: self organization classComment;
-		stamp: self organization commentStamp;
+		comment: self comment;
+		stamp: self commentStamp;
 		definitionSource: self definitionString;
 		package: self package asRingDefinition;
 		withMetaclass.

--- a/src/Ring-Definitions-Core/RGCommentDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGCommentDefinition.class.st
@@ -41,7 +41,7 @@ RGCommentDefinition >> asHistorical [
 	self annotationNamed: self class statusKey put: #historical.
 	self sourcePointer ifNil: [
 		self realClass ifNotNil: [ :realClass |
-			self sourcePointer: realClass organization commentSourcePointer ] ]
+			self sourcePointer: realClass commentSourcePointer ] ]
 ]
 
 { #category : #'type of comments' }
@@ -80,9 +80,9 @@ RGCommentDefinition >> commentDataPointers [
 RGCommentDefinition >> content [
 
 	self isActive
-		ifTrue: [ ^ self realClass organization classComment ].
+		ifTrue: [ ^ self realClass comment ].
 	self isHistorical
-		ifTrue: [ ^ self contentAtPointer ifNil:[ self realClass ifNil:[ content ] ifNotNil:[ :rc| rc organization classComment ] ] ].
+		ifTrue: [ ^ self contentAtPointer ifNil:[ self realClass ifNil:[ content ] ifNotNil:[ :rc| rc comment ] ] ].
 	^ content
 ]
 
@@ -114,13 +114,11 @@ RGCommentDefinition >> fromActiveToPassive [
 	"If the receiver was generated as an active comment, it can be converted to a passive one by reading the data of the real class organization"
 
 	| realClass |
-	self isActive
-		ifFalse: [ ^ self ].
+	self isActive ifFalse: [ ^ self ].
 	realClass := self realClass.
-	realClass notNil
-		ifTrue: [
-			self content: realClass organization classComment.
-			self stamp: realClass organization commentStamp ].
+	realClass ifNotNil: [
+		self content: realClass comment.
+		self stamp: realClass commentStamp ].
 	self asPassive
 ]
 
@@ -253,9 +251,9 @@ RGCommentDefinition >> stamp [
 	"Retrieves the user-alias + timestamp associated to the receiver (if exists)"
 
 	self isActive
-		ifTrue: [ ^ self realClass organization commentStamp ].
+		ifTrue: [ ^ self realClass commentStamp ].
 	self isHistorical
-		ifTrue: [ ^ self stampAtPointer ifNil:[ self realClass ifNil:[ stamp ] ifNotNil:[ :rc| rc organization commentStamp ] ] ].
+		ifTrue: [ ^ self stampAtPointer ifNil:[ self realClass ifNil:[ stamp ] ifNotNil:[ :rc| rc commentStamp ] ] ].
 	^ stamp
 ]
 

--- a/src/Ring-Definitions-Core/Trait.extension.st
+++ b/src/Ring-Definitions-Core/Trait.extension.st
@@ -11,8 +11,8 @@ Trait >> asRingDefinition [
 		        category: self category;
 		        superclassName: #Trait;
 		        traitCompositionSource: self traitCompositionString;
-		        comment: self organization classComment;
-		        stamp: self organization commentStamp;
+		        comment: self comment;
+		        stamp: self commentStamp;
 		        definitionSource: self definitionString;
 		        withMetaclass.
 

--- a/src/Ring-Tests-Core/RGReadOnlyImageBackendTest.class.st
+++ b/src/Ring-Tests-Core/RGReadOnlyImageBackendTest.class.st
@@ -92,7 +92,7 @@ RGReadOnlyImageBackendTest >> testClassTrait [
 	self assert: classTrait baseTrait name equals: 'RGTestTrait'.
 	self assert: classTrait category equals: 'Ring-Tests-Core'.
 	self assert: classTrait superclass name equals: #Trait.
-	self assert: classTrait comment content equals: RGTestTrait organization comment.
+	self assert: classTrait comment content equals: RGTestTrait comment.
 	self assert: classTrait localMethods size equals: RGTestTrait classTrait localMethods size.
 	self assert: classTrait protocols asSortedCollection equals: RGTestTrait classTrait protocols asSortedCollection.
 	self assert: classTrait metaclass name equals: #MetaclassForTraits.
@@ -271,7 +271,7 @@ RGReadOnlyImageBackendTest >> testTrait [
 	self assert: trait classTrait name equals: 'RGTestTrait classTrait'.
 	self assert: trait category equals: 'Ring-Tests-Core'.
 	self assert: trait superclass identicalTo: trait.	"cycle, nil in reality"
-	self assert: trait comment content equals: RGTestTrait organization comment.
+	self assert: trait comment content equals: RGTestTrait comment.
 	self assert: trait localMethods size equals: RGTestTrait localMethods size.
 	self assert: trait protocols asSortedCollection equals: RGTestTrait protocols asSortedCollection.
 	self assert: trait metaclass name equals: 'RGTestTrait classTrait'.

--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -166,7 +166,7 @@ ShClassInstallerTest >> testClassWithComment [
 				commentStamp: 'anStamp' ].
 
 	self assert: newClass comment equals: 'I have a comment'.
-	self assert: newClass organization commentStamp equals: 'anStamp'
+	self assert: newClass commentStamp equals: 'anStamp'
 ]
 
 { #category : #tests }

--- a/src/Slot-Tests/SlotBasicTest.class.st
+++ b/src/Slot-Tests/SlotBasicTest.class.st
@@ -77,7 +77,7 @@ SlotBasicTest >> testClassWithCommentAndStamp [
 
 	self assert: aClass name equals: self aClassName.
 	self assert: aClass comment equals: 'A class Comment'.
-	self assert: aClass organization commentStamp equals: (Object>>#halt) stamp
+	self assert: aClass commentStamp equals: (Object>>#halt) stamp
 ]
 
 { #category : #'tests - basic' }

--- a/src/System-SourcesCondenser/PharoChangesCondenser.class.st
+++ b/src/System-SourcesCondenser/PharoChangesCondenser.class.st
@@ -141,7 +141,7 @@ PharoChangesCondenser >> swapClassComment: classOrTrait [
 	remoteStringMap
 		at: classOrTrait
 		ifPresent: [ :remoteString |
-			classOrTrait organization commentSourcePointer:  remoteString sourcePointer]
+			classOrTrait commentSourcePointer: remoteString sourcePointer]
 ]
 
 { #category : #'private - 2 swapping' }
@@ -187,10 +187,9 @@ PharoChangesCondenser >> updateQuitPosition [
 
 { #category : #'private - 1 writing' }
 PharoChangesCondenser >> writeClassComment: aClass [
-	| organizer commentRemoteString stamp |
+	| commentRemoteString stamp |
 
-	organizer := aClass organization.
-	commentRemoteString := self commentRemoteStringFor: organizer.
+	commentRemoteString := self commentRemoteStringFor: aClass.
 
 	(commentRemoteString isNil or: [ commentRemoteString sourceFileNumber = 1 ])
 		ifTrue: [ ^ self ].
@@ -199,12 +198,12 @@ PharoChangesCondenser >> writeClassComment: aClass [
 		strm
 			nextPutAll: aClass name;
 			nextPutAll: ' commentStamp: '.
-		stamp := organizer commentStamp
+		stamp := aClass commentStamp
 			ifNil: ['<historical>'].
 		stamp storeOn: strm ].
 
 	self
-		writeRemoteString: organizer classComment
+		writeRemoteString: aClass comment
 		for: aClass
 ]
 

--- a/src/System-SourcesCondenser/PharoSourcesCondenser.class.st
+++ b/src/System-SourcesCondenser/PharoSourcesCondenser.class.st
@@ -89,10 +89,9 @@ PharoSourcesCondenser >> updateQuitPosition [
 { #category : #writing }
 PharoSourcesCondenser >> writeClassComment: aClass [
 
-	| organizer commentRemoteString stamp |
+	| commentRemoteString stamp |
 
-	organizer := aClass organization.
-	commentRemoteString := self commentRemoteStringFor: organizer.
+	commentRemoteString := self commentRemoteStringFor: aClass.
 
 	commentRemoteString ifNil: [ ^ self ].
 
@@ -101,9 +100,9 @@ PharoSourcesCondenser >> writeClassComment: aClass [
 			strm
 				nextPutAll: aClass name;
 				nextPutAll: ' commentStamp: '.
-			stamp := organizer commentStamp ifNil: [ '<historical>' ].
+			stamp := aClass commentStamp ifNil: [ '<historical>' ].
 			stamp storeOn: strm
 			].
 
-	self writeRemoteString: organizer classComment for: aClass
+	self writeRemoteString: aClass comment for: aClass
 ]

--- a/src/Tool-Base/SystemNavigation.extension.st
+++ b/src/Tool-Base/SystemNavigation.extension.st
@@ -12,7 +12,7 @@ SystemNavigation >> allMethodsWithSourceString: aString matchCase: caseSensitive
 		each selectorsDo: [:sel |
 			((each sourceCodeAt: sel) includesSubstring: aString caseSensitive: caseSensitive)
 					ifTrue: [ addMethod value: each value: sel ]].
-			(each organization classComment asString includesSubstring: aString caseSensitive: caseSensitive) ifTrue: [ addComment value: each]	].
+			(each comment includesSubstring: aString caseSensitive: caseSensitive) ifTrue: [ addComment value: each]	].
 	^ list
 ]
 
@@ -149,7 +149,7 @@ SystemNavigation >> browseClassCommentsWithString: aString matchCase: caseSensit
 	list := Set new.
 	Cursor wait showWhile: [
 		self environment allClassesDo: [:class |
-			(class organization classComment asString
+			(class comment
 							includesSubstring: aString caseSensitive: caseSensitive) ifTrue: [
 								list add: (RGCommentDefinition realClass: class)
 							]


### PR DESCRIPTION
This PR changes all cliens to as the class directly for comments, not the #organizer

This prepares to move the classCommentSourcePointer to ClassDescription

This turns for now off the automatic class template, this should be done in the UI, not in the model