### PR TITLE
ProtocolOrganizer cleanings

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
@@ -227,15 +227,15 @@ ClyMethodEditorToolMorph >> tagAndPackageEditingMethod: aMethod [
 
 { #category : #operations }
 ClyMethodEditorToolMorph >> tagEditingMethod: aMethod [
+
 	| existingTags removedTags newTags |
 	self applyChangesBy: [
-		existingTags := aMethod tags reject: [:each | each beginsWith: '*'].
+		existingTags := aMethod tags reject: [ :each | each beginsWith: '*' ].
 		removedTags := existingTags reject: [ :each | methodTags includes: each ].
 		newTags := methodTags reject: [ :each | existingTags includes: each ].
 
-		newTags do: [ :each | aMethod tagWith: each asSymbol].
-		removedTags do: [ :each | aMethod untagFrom: each asSymbol]
-	]
+		newTags do: [ :each | aMethod protocol: each asSymbol ].
+		removedTags do: [ :each | aMethod untagFrom: each asSymbol ] ]
 ]
 
 { #category : #accessing }

--- a/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
@@ -227,15 +227,15 @@ ClyMethodEditorToolMorph >> tagAndPackageEditingMethod: aMethod [
 
 { #category : #operations }
 ClyMethodEditorToolMorph >> tagEditingMethod: aMethod [
-
 	| existingTags removedTags newTags |
 	self applyChangesBy: [
-		existingTags := aMethod tags reject: [ :each | each beginsWith: '*' ].
+		existingTags := aMethod tags reject: [:each | each beginsWith: '*'].
 		removedTags := existingTags reject: [ :each | methodTags includes: each ].
 		newTags := methodTags reject: [ :each | existingTags includes: each ].
 
-		newTags do: [ :each | aMethod protocol: each asSymbol ].
-		removedTags do: [ :each | aMethod untagFrom: each asSymbol ] ]
+		newTags do: [ :each | aMethod tagWith: each asSymbol].
+		removedTags do: [ :each | aMethod untagFrom: each asSymbol]
+	]
 ]
 
 { #category : #accessing }

--- a/src/CodeImport/ProtocolOrganizer.extension.st
+++ b/src/CodeImport/ProtocolOrganizer.extension.st
@@ -1,0 +1,19 @@
+Extension { #name : #ProtocolOrganizer }
+
+{ #category : #'*CodeImport' }
+ProtocolOrganizer >> fromSpec: aSpec [
+	aSpec
+		do: [ :spec |
+			| name methods |
+			name := spec first asSymbol.
+			methods := spec allButFirst asSet.
+			self addProtocol: (Protocol name: name methodSelectors: methods) ]
+]
+
+{ #category : #'*CodeImport' }
+ProtocolOrganizer class >> fromSpec: aSpec [
+
+	^ self new
+		fromSpec: aSpec;
+		yourself
+]

--- a/src/EpiceaBrowsers-Tests/EpApplyTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpApplyTest.class.st
@@ -285,9 +285,9 @@ EpApplyTest >> testProtocolAddition [
 	aClass removeProtocol: 'protocol'.
 
 	self assert: inputEntry content class equals: EpProtocolAddition.
-	self deny: (aClass organization protocolOrganizer hasProtocolNamed: 'protocol').
+	self deny: (aClass organization hasProtocolNamed: 'protocol').
 	self applyInputEntry.
-	self assert: (aClass organization protocolOrganizer hasProtocolNamed: 'protocol')
+	self assert: (aClass organization hasProtocolNamed: 'protocol')
 ]
 
 { #category : #tests }
@@ -301,9 +301,9 @@ EpApplyTest >> testProtocolRemoval [
 	aClass organization addProtocolNamed: 'protocol'.
 
 	self assert: inputEntry content class equals: EpProtocolRemoval.
-	self assert: (aClass organization protocolOrganizer hasProtocolNamed: 'protocol').
+	self assert: (aClass organization hasProtocolNamed: 'protocol').
 	self applyInputEntry.
-	self deny: (aClass organization protocolOrganizer hasProtocolNamed: 'protocol')
+	self deny: (aClass organization hasProtocolNamed: 'protocol')
 ]
 
 { #category : #tests }

--- a/src/EpiceaBrowsers-Tests/EpRevertTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpRevertTest.class.st
@@ -298,9 +298,9 @@ EpRevertTest >> testProtocolAddition [
 	self setHeadAsInputEntry.
 
 	self assert: inputEntry content class equals: EpProtocolAddition.
-	self assert: (aClass organization protocolOrganizer hasProtocolNamed: 'protocol').
+	self assert: (aClass organization hasProtocolNamed: 'protocol').
 	self revertInputEntry.
-	self deny: (aClass organization protocolOrganizer hasProtocolNamed: 'protocol')
+	self deny: (aClass organization hasProtocolNamed: 'protocol')
 ]
 
 { #category : #tests }
@@ -313,9 +313,9 @@ EpRevertTest >> testProtocolRemoval [
 	self setHeadAsInputEntry.
 
 	self assert: inputEntry content class equals: EpProtocolRemoval.
-	self deny: (aClass organization protocolOrganizer hasProtocolNamed: 'protocol').
+	self deny: (aClass organization hasProtocolNamed: 'protocol').
 	self revertInputEntry.
-	self assert: (aClass organization protocolOrganizer hasProtocolNamed: 'protocol')
+	self assert: (aClass organization hasProtocolNamed: 'protocol')
 ]
 
 { #category : #tests }

--- a/src/EpiceaBrowsers/EpApplyPreviewer.class.st
+++ b/src/EpiceaBrowsers/EpApplyPreviewer.class.st
@@ -202,27 +202,23 @@ EpApplyPreviewer >> visitMethodRemoval: aChange [
 { #category : #visitor }
 EpApplyPreviewer >> visitProtocolAddition: aChange [
 
-	self
-		behaviorNamed: aChange behaviorAffectedName
-		ifPresent: [ :behavior |
-			^(behavior organization protocolOrganizer hasProtocolNamed: aChange protocol)
-				ifTrue: [ #() ]
-				ifFalse: [ { EpProtocolAddition behavior: behavior protocol: aChange protocol } ] ].
+	self behaviorNamed: aChange behaviorAffectedName ifPresent: [ :behavior |
+		^ (behavior organization hasProtocolNamed: aChange protocol)
+			  ifTrue: [ #(  ) ]
+			  ifFalse: [ { (EpProtocolAddition behavior: behavior protocol: aChange protocol) } ] ].
 
-	^ #()
+	^ #(  )
 ]
 
 { #category : #visitor }
 EpApplyPreviewer >> visitProtocolRemoval: aChange [
 
-	self
-		behaviorNamed: aChange behaviorAffectedName
-		ifPresent: [ :behavior |
-			^(behavior organization protocolOrganizer hasProtocolNamed: aChange protocol)
-				ifTrue: [ { EpProtocolRemoval behavior: behavior protocol: aChange protocol } ]
-				ifFalse: [ #() ] ].
+	self behaviorNamed: aChange behaviorAffectedName ifPresent: [ :behavior |
+		^ (behavior organization hasProtocolNamed: aChange protocol)
+			  ifTrue: [ { (EpProtocolRemoval behavior: behavior protocol: aChange protocol) } ]
+			  ifFalse: [ #(  ) ] ].
 
-	^ #()
+	^ #(  )
 ]
 
 { #category : #visitor }

--- a/src/EpiceaBrowsers/EpHasImpactVisitor.class.st
+++ b/src/EpiceaBrowsers/EpHasImpactVisitor.class.st
@@ -153,8 +153,7 @@ EpHasImpactVisitor >> visitProtocolAddition: aProtocolAddition [
 
 	self
 		behaviorNamed: aProtocolAddition behaviorAffectedName
-		ifPresent: [ :behavior |
-			^ (behavior organization protocolOrganizer hasProtocolNamed: aProtocolAddition protocol) not ].
+		ifPresent: [ :behavior | ^ (behavior organization hasProtocolNamed: aProtocolAddition protocol) not ].
 
 	^ true
 ]

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -23,7 +23,7 @@ ClassOrganization class >> forClass: aClass [
 ClassOrganization >> addProtocolNamed: protocolName [
 
 	| oldProtocols |
-	(self protocolOrganizer hasProtocolNamed: protocolName) ifTrue: [ ^ self ].
+	(self hasProtocolNamed: protocolName) ifTrue: [ ^ self ].
 
 	oldProtocols := self protocolNames copy.
 	self protocolOrganizer addProtocolNamed: protocolName.
@@ -45,7 +45,7 @@ ClassOrganization >> allProtocols [
 { #category : #accessing }
 ClassOrganization >> allProtocolsNames [
 
-	^ self protocolOrganizer allProtocolsNames
+	^ self allProtocols collect: [ :each | each name ]
 ]
 
 { #category : #'backward compatibility' }
@@ -132,6 +132,12 @@ ClassOrganization >> hasComment [
 ClassOrganization >> hasOrganizedClass [
 
 	^ organizedClass isNotNil
+]
+
+{ #category : #testing }
+ClassOrganization >> hasProtocolNamed: aString [
+
+	^ self allProtocols anySatisfy: [ :each | each name = aString ]
 ]
 
 { #category : #initialization }
@@ -221,7 +227,8 @@ ClassOrganization >> protocolNamed: aString [
 
 { #category : #accessing }
 ClassOrganization >> protocolNames [
-	^ self protocolOrganizer protocolNames
+
+	^ self protocols collect: #name
 ]
 
 { #category : #private }
@@ -248,22 +255,22 @@ ClassOrganization >> removeElement: aSymbol [
 ClassOrganization >> removeEmptyProtocols [
 
 	| oldProtocolNames removedProtocols |
-	oldProtocolNames := self protocolOrganizer allProtocolsNames copy.
+	oldProtocolNames := self allProtocolsNames copy.
 
 	removedProtocols := self protocolOrganizer removeEmptyProtocols.
 	removedProtocols do: [ :each | self notifyOfRemovedProtocolNamed: each name ].
 
-	self notifyOfChangedProtocolNamesFrom: oldProtocolNames to: self protocolOrganizer allProtocolsNames
+	self notifyOfChangedProtocolNamesFrom: oldProtocolNames to: self allProtocolsNames
 ]
 
 { #category : #accessing }
 ClassOrganization >> removeProtocol: aProtocol [
 
 	| oldProtocolNames |
-	oldProtocolNames := self protocolOrganizer allProtocolsNames copy.
+	oldProtocolNames := self allProtocolsNames copy.
 	self protocolOrganizer removeProtocol: aProtocol.
 	self notifyOfRemovedProtocolNamed: aProtocol name.
-	self notifyOfChangedProtocolNamesFrom: oldProtocolNames to: self protocolOrganizer allProtocolsNames
+	self notifyOfChangedProtocolNamesFrom: oldProtocolNames to: self allProtocolsNames
 ]
 
 { #category : #accessing }
@@ -279,7 +286,7 @@ ClassOrganization >> removeProtocolIfEmpty: protocolName [
 { #category : #accessing }
 ClassOrganization >> removeProtocolNamed: protocolName [
 
-	(self protocolOrganizer hasProtocolNamed: protocolName) ifFalse: [ ^ self ].
+	(self hasProtocolNamed: protocolName) ifFalse: [ ^ self ].
 
 	self removeProtocol: (self protocolNamed: protocolName)
 ]

--- a/src/Kernel/ProtocolOrganizer.class.st
+++ b/src/Kernel/ProtocolOrganizer.class.st
@@ -13,14 +13,6 @@ Class {
 	#category : #'Kernel-Protocols'
 }
 
-{ #category : #import }
-ProtocolOrganizer class >> fromSpec: aSpec [
-
-	^ self new
-		fromSpec: aSpec;
-		yourself
-]
-
 { #category : #'protocol - adding' }
 ProtocolOrganizer >> addProtocol: aProtocol [
 
@@ -29,11 +21,13 @@ ProtocolOrganizer >> addProtocol: aProtocol [
 
 { #category : #'protocol - adding' }
 ProtocolOrganizer >> addProtocolNamed: aName [
-	^ protocols add: (Protocol name: aName)
+
+	^ self addProtocol: (Protocol name: aName)
 ]
 
 { #category : #accessing }
 ProtocolOrganizer >> allMethodSelectors [
+
 	^ self protocols flatCollect: [ :p | p methodSelectors ]
 ]
 
@@ -47,12 +41,6 @@ ProtocolOrganizer >> allProtocol [
 ProtocolOrganizer >> allProtocols [
 
 	^ { allProtocol }, protocols asArray
-]
-
-{ #category : #accessing }
-ProtocolOrganizer >> allProtocolsNames [
-
-	^ self allProtocols collect: [:each | each name]
 ]
 
 { #category : #'protocol - adding' }
@@ -79,26 +67,10 @@ ProtocolOrganizer >> extensionProtocols [
 	^ self protocols select: #isExtensionProtocol
 ]
 
-{ #category : #importing }
-ProtocolOrganizer >> fromSpec: aSpec [
-	aSpec
-		do: [ :spec |
-			| name methods |
-			name := spec first asSymbol.
-			methods := spec allButFirst asSet.
-			self addProtocol: (Protocol name: name methodSelectors: methods) ]
-]
-
 { #category : #protocol }
 ProtocolOrganizer >> getProtocolNamed: aByteString ifNone: aBlockClosure [
 
 	^ protocols detect: [:e | e name = aByteString ] ifNone: aBlockClosure
-]
-
-{ #category : #testing }
-ProtocolOrganizer >> hasProtocolNamed: aString [
-
-	^ self allProtocols anySatisfy: [ :each | each name = aString ]
 ]
 
 { #category : #testing }
@@ -145,14 +117,6 @@ ProtocolOrganizer >> protocolNamed: aString ifAbsent: aBlock [
 	^  self allProtocols
 		detect: [ :e | e name = aString ]
 		ifNone: aBlock
-]
-
-{ #category : #accessing }
-ProtocolOrganizer >> protocolNames [
-
-	^ protocols
-		collect: #name
-		as: Array
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This does two things:
- Put code import specific methods in CodeImport package
- Inline some behavior of ProtocolOrganizer in ClassOrganization

This is madness:

```st
aClass organization protocolOrganizer hasProtocolNamed: aString	
```

I'm trying to make Demeter a little happier even if there are still work to do about that.