### PR TITLE
speedup-testNoShadowedVariablesInMethods 

### DIFF
--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -334,7 +334,7 @@ ReleaseTest >> testNoSentNotImplementedSelectors [
 ReleaseTest >> testNoShadowedVariablesInMethods [
 	"Fail if there are methods who define shadowed temps or args"
 	| found validExceptions remaining |
-	found := SystemNavigation default allMethodsSelect: [ :m |
+	found := SystemNavigation default methods select: [ :m |
 		m ast variableDefinitionNodes anySatisfy: [ :node | node variable isShadowing ] ].
 	"Make sure to not waste memory with all the ASTs"
 	ASTCache reset.


### PR DESCRIPTION
Speedup test no shadowed variables in methods by using #methods which does not run it for all the copies that traits install