### PR TITLE
[POC] Faulty Code: make undeclared variable a semantic error

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -328,12 +328,14 @@ RBCodeSnippet class >> badExpressions [
 		        (self new
 			         source: '| | a';
 			         formattedCode: 'a';
-			         isFaulty: false;
+			         isParseFaulty: false;
+			         value: nil;
 			         notices: #( #( 5 5 5 'Undeclared variable' ) )). "This one is legal, it is an empty list of temporaries, the | are dismissed"
 		        (self new
 			         source: '|| a';
 			         formattedCode: 'a';
-			         isFaulty: false;
+			         isParseFaulty: false;
+			         value: nil;
 			         notices: #( #( 4 4 4 'Undeclared variable' ) )). "Same, but are messing with the Scanner"
 		        (self new
 			         source: ' ||| a';
@@ -517,7 +519,8 @@ RBCodeSnippet class >> badExpressions [
 		        (self new
 			         source: '[:a| | |b]';
 			         formattedCode: '[ :a | b ]';
-			         isFaulty: false;
+			         isParseFaulty: false;
+			         value: nil;
 			         notices: #( #( 9 9 9 'Undeclared variable' ) )). "Explicit empty list of temporaries"
 		        (self new
 			         source: '[:a| ||a]';
@@ -954,7 +957,8 @@ RBCodeSnippet class >> badExpressions [
 		        "$ə isLetter >>> true" "$ə asInteger >>> 16r0259" "Latin Small Letter Schwa"
 		        (self new
 			         source: 'Δə';
-			         isFaulty: false;
+			         isParseFaulty: false;
+			         value: nil;
 			         notices: #( #( 1 2 1 'Undeclared variable' ) )). "valid identifier"
 		        (self new
 			         source: '| Δə | Δə := 1. Δə + 1';
@@ -1213,6 +1217,7 @@ RBCodeSnippet class >> badSemantic [
 	list := {
 		        (self new
 			         source: 'a := 10. ^ a';
+			         isFaulty: true;
 			         value: 10;
 			         notices:
 				         #( #( 1 1 1 'Undeclared variable' )
@@ -1220,6 +1225,8 @@ RBCodeSnippet class >> badSemantic [
 			         skip: #exec). "a is bound to an undefined variable, and according to some compilation options it could be registerer or not registered. This is very bad as regitred ones act like globals thus polute other tests. So disable the execution for now."
 		        (self new
 			         source: '^ a';
+			         isFaulty: true;
+			         value: nil;
 			         notices: #( #( 3 3 3 'Undeclared variable' ) )).
 
 		        "Uninitialized variable"

--- a/src/AST-Core-Tests/RBCodeSnippetTest.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippetTest.class.st
@@ -67,10 +67,10 @@ RBCodeSnippetTest >> testCodeImporter [
 	self skipIf: #exec.
 
 	"Importer should fail when faulty"
-	snippet isFaulty ifTrue: [
+"	snippet isFaulty ifTrue: [
 		self should: [ importer evaluate ] raise: CodeError.
 		snippet isMethod ifTrue: [ class removeFromSystem ].
-		^ self ].
+		^ self ]."
 
 	"When not faulty, it's more complicated..."
 	runBlock := [
@@ -89,7 +89,8 @@ RBCodeSnippetTest >> testCodeImporter [
 	            value isBlock ifTrue: [
 		            | phonyBlockArgs |
 		            phonyBlockArgs := (1 to: value numArgs) asArray.
-		            value := value valueWithArguments: phonyBlockArgs ] ].
+		            value := value valueWithArguments: phonyBlockArgs ].
+					value ].
 
 	snippet messageNotUnderstood ifNotNil: [ :mnu |
 		runBlock onDNU: mnu do: [ ^ self ].
@@ -97,8 +98,9 @@ RBCodeSnippetTest >> testCodeImporter [
 
 	snippet raise ifNotNil: [ :r | ^ self should: runBlock raise: r ].
 
-	self shouldnt: runBlock raise: CodeError.
-	self assert: value equals: snippet value
+	snippet hasValue
+		ifFalse: [ self should: runBlock raise: RuntimeSyntaxError ]
+		ifTrue: [ self assert: runBlock value equals: snippet value ]
 ]
 
 { #category : #tests }

--- a/src/AST-Core/CodeError.class.st
+++ b/src/AST-Core/CodeError.class.st
@@ -13,6 +13,12 @@ Class {
 }
 
 { #category : #accessing }
+CodeError >> description [
+
+	^ self class name , ':' , self notice description
+]
+
+{ #category : #accessing }
 CodeError >> errorCode [
 
 	self

--- a/src/AST-Core/RBNotice.class.st
+++ b/src/AST-Core/RBNotice.class.st
@@ -11,6 +11,26 @@ Class {
 	#category : #'AST-Core-Notice'
 }
 
+{ #category : #accessing }
+RBNotice >> description [
+
+	^ String streamContents: [ :stream |
+		  stream
+			  nextPutAll: self class name;
+			  nextPutAll: ' ';
+			  nextPutAll: (node methodNode methodClass
+					   ifNotNil: [ :class | class name ]
+					   ifNil: [ '???' ]);
+			  nextPutAll: '>>#';
+			  nextPutAll: node methodNode selector;
+			  nextPutAll: ' ';
+			  print: self position;
+			  nextPutAll: ':';
+			  nextPutAll: self messageText;
+			  nextPutAll: '->';
+			  nextPutAll: node displaySourceCode ]
+]
+
 { #category : #testing }
 RBNotice >> isError [
 

--- a/src/AST-Core/RBNotice.class.st
+++ b/src/AST-Core/RBNotice.class.st
@@ -52,3 +52,15 @@ RBNotice >> position [
 
 	^ node start
 ]
+
+{ #category : #printing }
+RBNotice >> printOn: aStream [
+
+	aStream
+		nextPutAll: self class name;
+		nextPutAll: '(';
+		print: self position;
+		nextPutAll: ':';
+		nextPutAll: self messageText;
+		nextPutAll: ')'
+]

--- a/src/CodeImport/DoItChunk.class.st
+++ b/src/CodeImport/DoItChunk.class.st
@@ -37,6 +37,7 @@ DoItChunk >> importFor: requestor logSource: logSource [
 		source: contents;
 		requestor: requestor;
 		logged: logSource;
+		permitFaulty: true;
 		evaluate
 ]
 

--- a/src/CodeImport/MethodChunk.class.st
+++ b/src/CodeImport/MethodChunk.class.st
@@ -64,12 +64,13 @@ MethodChunk >> handleMissingBehavior [
 MethodChunk >> importFor: requestor logSource: logSource [
 	self existsBehavior
 		ifFalse: [ self handleMissingBehavior ].
-	^ self targetClass
-		compile: contents
-		classified: categoryName
-		withStamp: stamp
-		notifying: nil
-		logSource: logSource
+	^ self targetClass compiler
+		source: contents;
+		protocolName: categoryName;
+		changeStamp: stamp;
+		logSource: logSource;
+		permitFaulty: true;
+		install
 ]
 
 { #category : #testing }

--- a/src/CodeImport/MethodChunk.class.st
+++ b/src/CodeImport/MethodChunk.class.st
@@ -62,15 +62,20 @@ MethodChunk >> handleMissingBehavior [
 
 { #category : #importing }
 MethodChunk >> importFor: requestor logSource: logSource [
+
+	| method |
 	self existsBehavior
 		ifFalse: [ self handleMissingBehavior ].
-	^ self targetClass compiler
+
+	method := self targetClass compiler
 		source: contents;
 		protocolName: categoryName;
 		changeStamp: stamp;
 		logged: logSource;
 		permitFaulty: true;
-		install
+		install.
+
+	^ method selector
 ]
 
 { #category : #testing }

--- a/src/CodeImport/MethodChunk.class.st
+++ b/src/CodeImport/MethodChunk.class.st
@@ -68,7 +68,7 @@ MethodChunk >> importFor: requestor logSource: logSource [
 		source: contents;
 		protocolName: categoryName;
 		changeStamp: stamp;
-		logSource: logSource;
+		logged: logSource;
 		permitFaulty: true;
 		install
 ]

--- a/src/CodeImportCommandLineHandlers/STCommandLineHandler.class.st
+++ b/src/CodeImportCommandLineHandlers/STCommandLineHandler.class.st
@@ -128,6 +128,10 @@ STCommandLineHandler >> handleError: error reference: aReference [
 	(error isKindOf: OCSemanticWarning)
 		ifTrue: [ ^ error pass ].
 
+	"Display CodeError nicely"
+	(error isKindOf: CodeError)
+		ifTrue: [ self class printCodeError: error ].
+
 	"spit out a warning if in headless mode, otherwise a debugger will popup"
 	Smalltalk isHeadless
 		ifTrue: [ self inform: 'Errors in script loaded from ', aReference name ].

--- a/src/CodeImportCommandLineHandlers/STCommandLineHandler.class.st
+++ b/src/CodeImportCommandLineHandlers/STCommandLineHandler.class.st
@@ -112,11 +112,12 @@ STCommandLineHandler >> end [
 
 { #category : #private }
 STCommandLineHandler >> handleError: error [
+	"for syntax errors we print more detailed error informations"
 
-	"for syntax errors we can used the default action"	"otherwise resignal it"
-	(error isKindOf: CodeError)
-		ifTrue: [ error defaultAction ]
-		ifFalse: [ error pass ]
+	(error isKindOf: CodeError) ifTrue: [
+		self class printCodeError: error ].
+
+	error pass
 ]
 
 { #category : #private }

--- a/src/CodeImportCommandLineHandlers/STCommandLineHandler.class.st
+++ b/src/CodeImportCommandLineHandlers/STCommandLineHandler.class.st
@@ -45,12 +45,12 @@ STCommandLineHandler class >> isResponsibleFor: aCommandLine [
 ]
 
 { #category : #printing }
-STCommandLineHandler class >> printCompilerWarning: aSyntaxErrorNotification [
+STCommandLineHandler class >> printCodeError: aCodeError [
 	| stderr position contents errorLine errorMessage maxLineNumberSize lineNumber |
 
 	"format the error"
-	position := aSyntaxErrorNotification position.
-	contents := aSyntaxErrorNotification sourceCode.
+	position := aCodeError position.
+	contents := aCodeError sourceCode.
 	errorLine := contents lineNumberCorrespondingToIndex: position.
 	stderr := VTermOutputDriver stderr.
 
@@ -58,7 +58,7 @@ STCommandLineHandler class >> printCompilerWarning: aSyntaxErrorNotification [
 	errorMessage := String streamContents: [ :s|
 		s nextPutAll: 'Syntax Error on line ';
 			print: errorLine; nextPutAll: ': ';
-			print: aSyntaxErrorNotification messageText].
+			print: aCodeError messageText].
 
 	 stderr red;
 		nextPutAll: errorMessage; lf;

--- a/src/Flashback-Decompiler-Tests/FBDDecompilerTest.class.st
+++ b/src/Flashback-Decompiler-Tests/FBDDecompilerTest.class.st
@@ -57,7 +57,7 @@ FBDDecompilerTest >> decompileThenRecompile: originalMethod [
 	| methodNode |
 	methodNode := FBDDecompiler new decompile: originalMethod.
 	methodNode ifNil: [ ^ nil ].
-	^ self exampleClass compiler compile: methodNode formattedCode
+	^ self exampleClass compiler permitFaulty: true; compile: methodNode formattedCode
 ]
 
 { #category : #accessing }

--- a/src/Flashback-Decompiler/FBDDecompiler.class.st
+++ b/src/Flashback-Decompiler/FBDDecompiler.class.st
@@ -584,8 +584,9 @@ FBDDecompiler >> recompile: selector from: oldClass [
 		source: (self decompile: oldClass >> selector) formattedCode;
 		class: oldClass;
 		failBlock: [ ^ self ];
+		permitFaulty: true; "Do not signal existing problems"		
 		compiledMethodTrailer: CompiledMethodTrailer empty;
-		compile.	"Assume OK after proceed from SyntaxError"
+		compile.
 	selector == newMethod selector
 		ifFalse: [ self error: 'selector changed!' ].
 	oldClass 	addSelector: selector withRecompiledMethod: newMethod

--- a/src/GeneralRules-Tests/ReGlobalVariablesUsageRuleTest.class.st
+++ b/src/GeneralRules-Tests/ReGlobalVariablesUsageRuleTest.class.st
@@ -26,7 +26,7 @@ ReGlobalVariablesUsageRuleTest >> setUp [
 		at: #MyGlobal
 		put: (self class >> #sampleMethod) sourceCode.
 
-	self class compile: 'sampleMethod
+	self class compiler permitFaulty: true; install: 'sampleMethod
 	sampleMethod
 		Smalltalk value.
 		MyGlobal value'

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -803,7 +803,7 @@ CompiledMethodTest >> testUndeclaredReparationWithClass [
 	Smalltalk globals removeKey: #TestUndeclaredVariable ifAbsent: [].
 	Undeclared removeKey: #TestUndeclaredVariable ifAbsent: []. "Because obsolete may remain"
 
-	method := self class compiler compile: 'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]'.
+	method := self class compiler permitFaulty: true; compile: 'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]'.
 	self assert: method usesUndeclareds.
 	self assert: (nil executeMethod: method) equals: nil.
 
@@ -834,7 +834,7 @@ CompiledMethodTest >> testUndeclaredReparationWithGlobal [
 
 	Smalltalk globals removeKey: #TestUndeclaredVariable ifAbsent: [].
 
-	method := self class compiler compile: 'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]'.
+	method := self class compiler permitFaulty: true; compile: 'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]'.
 	self assert: method usesUndeclareds.
 	self assert: (nil executeMethod: method) equals: nil.
 
@@ -868,7 +868,7 @@ CompiledMethodTest >> testUndeclaredReparationWithInstanceVariable [
 	receiver := class new.
 
 	"Note: unlike related tests, we need here a reveiver (see above) and to install the method in the class"
-	method := class >> (class compile: 'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]').
+	method := class compiler permitFaulty: true; install: 'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]'.
 	self assert: method usesUndeclareds.
 	self assert: (receiver executeMethod: method) equals: nil.
 
@@ -909,7 +909,7 @@ CompiledMethodTest >> testUndeclaredReparationWithShared [
 	class := Object subclass: #TestUndeclaredVariableClass instanceVariableNames: '' classVariableNames: '' category: ''.
 	self assert: (class bindingOf: #TestUndeclaredVariable) isNil.
 
-	method := class compiler compile: 'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]'.
+	method := class compiler permitFaulty: true; compile: 'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]'.
 	self assert: method usesUndeclareds.
 	self assert: (nil executeMethod: method) equals: nil.
 
@@ -944,9 +944,9 @@ CompiledMethodTest >> testUsesUndeclareds [
 	| method |
 	method := self class compiler compile: 'x ^x'.
 	self deny: method usesUndeclareds.
-	method := self class compiler compile: 'z ^z'.
+	method := self class compiler permitFaulty: true; compile: 'z ^z'.
 	self assert: method usesUndeclareds.
-	method := self class compiler compile: 'msg self in: [ :anObject | var1 := 1 ]'.
+	method := self class compiler permitFaulty: true; compile: 'msg self in: [ :anObject | var1 := 1 ]'.
 	self assert: method usesUndeclareds
 ]
 

--- a/src/Kernel-Tests/CompiledCodeTest.class.st
+++ b/src/Kernel-Tests/CompiledCodeTest.class.st
@@ -62,6 +62,7 @@ CompiledCodeTest >> testHasLiteral [
 	| method |
 	method := self class compiler compile: 'method
 		<pragma: #pragma>
+		|test|
 		test := 1+2.
 		self doIt: [
 		test := 1 - 2.
@@ -96,6 +97,7 @@ CompiledCodeTest >> testHasLiteralSuchThat [
 	| method |
 	method := self class compiler compile: 'method
 		<pragma: #pragma>
+		|test|
 		test := 1+2.
 		self doIt: [
 		test := 1 - 2.
@@ -128,6 +130,7 @@ CompiledCodeTest >> testHasSelector [
 	| method |
 	method := self class compiler compile: 'method
 		<pragma: #pragma>
+		|test|
 		test := 1+2.
 		self doIt: [
 		test := 1 - 2.
@@ -160,6 +163,7 @@ CompiledCodeTest >> testHasSelectorSpecialSelectorIndex [
 	| method specialIndex |
 	method := self class compiler compile: 'method
 		<pragma: #pragma>
+		|test|
 		test := 1+2.
 		self do: [
 		test := 1 - 2.
@@ -210,7 +214,7 @@ CompiledCodeTest >> testHasTemporaries [
 CompiledCodeTest >> testLiteralsDoNotConsiderTheInnerBlockLiterals [
 
 	| method block |
-	method := self class compiler compile: 'method
+	method := self class compiler permitFaulty: true; compile: 'method
 		<pragma: #pragma>
 		test := 1+2.
 		Class.
@@ -220,7 +224,7 @@ CompiledCodeTest >> testLiteralsDoNotConsiderTheInnerBlockLiterals [
 		Object.
 		self name ].
 		^#(#array) '.
-	block := (self class compiler evaluate: '[
+	block := (self class compiler permitFaulty: true; evaluate: '[
 		test := 1 - 2.
 		test := #(arrayInBlock).
 		Object.
@@ -253,7 +257,7 @@ CompiledCodeTest >> testLiteralsDoesNotContainMethodName [
 CompiledCodeTest >> testLiteralsEvenTheOnesInTheInnerBlocks [
 	"The behavior is different than literals"
 	| method |
-	method := self class compiler compile: 'method
+	method := self class compiler permitFaulty: true; compile: 'method
 		<pragma: #pragma>
 		test := 1+2.
 		Class.

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -393,18 +393,10 @@ ClassDescription >> compile: sourceCode classified: protocolName withStamp: chan
 		source: sourceCode;
 		requestor: requestor;
 		failBlock:  [ ^ nil ];
-		compile.
-
-	logSource ifTrue: [
-		self
-			logMethodSource: (requestor ifNotNil: [ :r | r text ] ifNil: [ sourceCode ]) "the requestor text might have been changed by the compiler and may be different thant text argument"
-			forMethod: method
-			inCategory: protocolName
-			withStamp: changeStamp ].
-
-	self addAndClassifySelector: method selector withMethod: method inProtocol: protocolName.
-
-	self instanceSide noteCompilationOf: method meta: self isClassSide.
+		protocolName: protocolName;
+		changeStamp: changeStamp;
+		logged: logSource;
+		install.
 
 	^ method selector
 ]

--- a/src/Monticello/MethodAddition.class.st
+++ b/src/Monticello/MethodAddition.class.st
@@ -48,6 +48,7 @@ MethodAddition >> createCompiledMethod [
 		                  source: text asString;
 		                  requestor: requestor;
 		                  failBlock: [ ^ nil ];
+								permitFaulty: true;
 		                  compile.
 	selector := compiledMethod selector.
 	self writeSourceToLog.

--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -115,9 +115,9 @@ Behavior >> recompile: selector from: oldClass [
 				source: (oldClass sourceCodeAt: selector);
 				class: self;
 				failBlock: [^ self];
-				permitFaulty: true;
+				permitFaulty: true; "Do not signal existing problems"
 				compiledMethodTrailer: method trailer;
-				compile.   "Assume OK after proceed from SyntaxError"
+				compile.
 	selector == newMethod selector ifFalse: [self error: 'selector changed!'].
 	self addSelector: selector withRecompiledMethod: newMethod
 ]

--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -115,6 +115,7 @@ Behavior >> recompile: selector from: oldClass [
 				source: (oldClass sourceCodeAt: selector);
 				class: self;
 				failBlock: [^ self];
+				permitFaulty: true;
 				compiledMethodTrailer: method trailer;
 				compile.   "Assume OK after proceed from SyntaxError"
 	selector == newMethod selector ifFalse: [self error: 'selector changed!'].

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -156,7 +156,8 @@ OCASTSemanticAnalyzer >> undeclaredVariable: variableNode [
 	"If a invalid variable exists, we use it witout warning"
 	self invalidVariables at: varName ifPresent: [ :v | ^ v ].
 
-	variableNode addWarning: 'Undeclared variable'.
+	self error: 'Undeclared variable' forNode: variableNode.
+
 	"If a registered undeclared variable exists, use it. Otherwise create an unregistered one."
 	"It will be registered only at backend when a CompiledMethod is produced.
 	Or never if compilation is aborted or if only frontend is requested."
@@ -164,13 +165,6 @@ OCASTSemanticAnalyzer >> undeclaredVariable: variableNode [
 		       at: varName
 		       ifAbsentPut: [
 		       UndeclaredVariable possiblyRegisteredWithName: varName ].
-	compilationContext permitFaulty ifTrue: [ ^ var ].
-
-	OCUndeclaredVariableWarning new
-		node: variableNode;
-		compilationContext: compilationContext;
-		messageText: 'Undeclared variable';
-		signal.
 
 	^ var
 ]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -404,6 +404,13 @@ OpalCompiler >> install [
 	^ method
 ]
 
+{ #category : #actions }
+OpalCompiler >> install: aSource [
+
+	self source: aSource.
+	^ self install
+]
+
 { #category : #testing }
 OpalCompiler >> isInteractive [
 	^ compilationContext interactive

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -32,7 +32,9 @@ Class {
 		'ast',
 		'source',
 		'compilationContext',
-		'compilationContextClass'
+		'compilationContextClass',
+		'protocolName',
+		'changeStamp'
 	],
 	#classInstVars : [
 		'overlayEnvironment'
@@ -224,6 +226,11 @@ OpalCompiler >> callPlugins [
 ]
 
 { #category : #accessing }
+OpalCompiler >> changeStamp: aString [ 
+	changeStamp := aString
+]
+
+{ #category : #accessing }
 OpalCompiler >> class: aClass [
 	self compilationContext class: aClass
 ]
@@ -365,6 +372,38 @@ OpalCompiler >> format: textOrString [
 		format
 ]
 
+{ #category : #actions }
+OpalCompiler >> install [
+	"Compile and install a method in a class"
+
+	| class method logSource |
+	class := self semanticScope targetClass.
+	self assert: class isNotNil.
+
+	method := self compile.
+	method ifNil: [ ^ method ].
+
+	protocolName ifNil: [ protocolName := Protocol unclassified ].
+	changeStamp ifNil: [ changeStamp := Author changeStamp ].
+	logSource := compilationContext logged ifNil: [ class acceptsLoggingOfCompilation ].
+
+	logSource ifTrue: [
+		class
+			logMethodSource: source contents
+			forMethod: method
+			inCategory: protocolName
+			withStamp: changeStamp ].
+
+	class
+		addAndClassifySelector: method selector
+		withMethod: method
+		inProtocol: protocolName.
+
+	class instanceSide noteCompilationOf: method meta: class isClassSide.
+
+	^ method
+]
+
 { #category : #testing }
 OpalCompiler >> isInteractive [
 	^ compilationContext interactive
@@ -499,6 +538,11 @@ OpalCompiler >> permitFaulty: aBoolean [
 { #category : #accessing }
 OpalCompiler >> productionEnvironment: anObject [
 	compilationContext productionEnvironment: anObject
+]
+
+{ #category : #accessing }
+OpalCompiler >> protocolName: aString [ 
+	protocolName := aString
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Tests/OCCompiledMethodIntegrityTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompiledMethodIntegrityTest.class.st
@@ -102,6 +102,7 @@ OCCompiledMethodIntegrityTest >> testUndeclaredVariable [
 			'methodWithUndeclaredVar
 											^ undeclaredTestVar';
 		class: OCMockCompilationClass;
+		permitFaulty: true;
 		compile.
 
 	undeclaredBinding := newCompiledMethod literals detect: [ :each | each name = #undeclaredTestVar ].
@@ -119,6 +120,7 @@ OCCompiledMethodIntegrityTest >> testUndeclaredVariableWhenItIsAlreadyRegistered
 			'methodWithUndeclaredVar
 											^ undeclaredTestVar';
 		class: OCMockCompilationClass;
+		permitFaulty: true;
 		compile.
 
 	undeclaredBinding := newCompiledMethod literals detect: [ :each | each name = #undeclaredTestVar ].
@@ -140,6 +142,7 @@ OCCompiledMethodIntegrityTest >> testUndeclaredVariableWhenItIsAlreadyRegistered
 			'methodWithUndeclaredVar
 											^ undeclaredTestVar';
 		class: OCMockCompilationClass;
+		permitFaulty: true;
 		compile.
 
 	undeclaredBinding := newCompiledMethod literals detect: [ :each | each name = #undeclaredTestVar ].

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -247,9 +247,9 @@ OCCompilerTest >> testUndefinedVariable [
 	Undeclared removeKey: #undefinedName123 ifAbsent: [ ].
 	self
 		assert: {
-			OpalCompiler new evaluate: 'undefinedName123'.
-			OpalCompiler new evaluate: 'undefinedName123 := 1. undefinedName123'.
-			OpalCompiler new evaluate: 'undefinedName123'.
+			OpalCompiler new permitFaulty: true; evaluate: 'undefinedName123'.
+			OpalCompiler new permitFaulty: true; evaluate: 'undefinedName123 := 1. undefinedName123'.
+			OpalCompiler new permitFaulty: true; evaluate: 'undefinedName123'.
 			}
 		equals: { nil. 1. 1. }.
 
@@ -280,7 +280,7 @@ OCCompilerTest >> testUndefinedVariableFrontend [
 	self deny: (Undeclared includesKey: #undefinedName123).
 	self should: [ OpalCompiler new compile: 'foo ^undefinedName123 ¿ 2' ] raise: CodeError.
 	self deny: (Undeclared includesKey: #undefinedName123).
-	OpalCompiler new compile: 'foo ^undefinedName123'.
+	OpalCompiler new permitFaulty: true; compile: 'foo ^undefinedName123'.
 	self assert: (Undeclared includesKey: #undefinedName123).
 
 	"Cleanup"

--- a/src/OpalCompiler-Tests/OCDoitTest.class.st
+++ b/src/OpalCompiler-Tests/OCDoitTest.class.st
@@ -139,7 +139,7 @@ OCDoitTest >> testDoitContextCheckClass [
 
 	| ast method |
 	method := OpalCompiler new
-		source: 'tempForTesting';
+		source: '|temp| temp';
 		noPattern: true;
 		context: thisContext;
 		compile.

--- a/src/OpalCompiler-Tests/OCEnvironmentScopeTest.class.st
+++ b/src/OpalCompiler-Tests/OCEnvironmentScopeTest.class.st
@@ -26,6 +26,7 @@ OCEnvironmentScopeTest >> testCompileWithEnvironment [
 	method := OpalCompiler new
 					environment: environment;
 					class: (environment at: #MyClass);
+					permitFaulty: true;
 					compile: 'tt ^Object'.
 	return := method valueWithReceiver: nil arguments: #().
 	self assert: return equals: nil

--- a/src/OpalCompiler-Tests/OpalCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTest.class.st
@@ -147,3 +147,71 @@ OpalCompilerTest >> testEvaluateWithBindingsWithUppercaseName [
 		evaluate: '1+MyVar'.
 	self assert: result equals: 4
 ]
+
+{ #category : #tests }
+OpalCompilerTest >> testInstall [
+
+	| method |
+	"Cleanup"
+	(MockForCompilation includesSelector: #foo) ifTrue: [
+		MockForCompilation removeSelector: #foo ].
+	"Precond"
+	self deny: (MockForCompilation includesSelector: #foo).
+
+	method := MockForCompilation compiler
+		          source: 'foo ^42';
+		          changeStamp: 'JP 4/01/2023 01:23';
+		          protocolName: 'hitching';
+		          install.
+
+	self assert: method equals: MockForCompilation >> #foo.
+	self assert: MockForCompilation new foo equals: 42.
+
+	"Cleanup"
+	method removeFromSystem.
+	self deny: (MockForCompilation includesSelector: #foo)
+]
+
+{ #category : #tests }
+OpalCompilerTest >> testInstallException [
+
+	| method message |
+	"Precond"
+	self deny: (MockForCompilation includesSelector: #foo).
+
+	[
+	method := MockForCompilation compiler
+		          source: 'foo ^¿';
+		          install ]
+		on: CodeError
+		do: [ :error | message := error messageText , ' :(' ].
+
+	self deny: (MockForCompilation includesSelector: #foo).
+	self assert: method isNil.
+	self assert: message equals: 'Unknown character :('
+]
+
+{ #category : #tests }
+OpalCompilerTest >> testInstallRequestor [
+
+	| method requestor |
+	"precond"
+	self deny: (MockForCompilation includesSelector: #foo).
+
+	requestor := OCMockRequestor new.
+
+	[
+	method := MockForCompilation compiler
+		          source: 'foo ^¿';
+		          requestor: requestor;
+		          failBlock: [  ];
+		          changeStamp: 'JP 3/24/2023 18:39';
+		          protocolName: 'hitching';
+		          install ]
+		on: CodeError
+		do: [  ].
+
+	self deny: (MockForCompilation includesSelector: #foo).
+	self assert: method isNil.
+	self assert: requestor notifyList first first equals: 'Unknown character ->'
+]

--- a/src/OpalCompiler-Tests/OpalCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTest.class.st
@@ -179,10 +179,7 @@ OpalCompilerTest >> testInstallException [
 	"Precond"
 	self deny: (MockForCompilation includesSelector: #foo).
 
-	[
-	method := MockForCompilation compiler
-		          source: 'foo ^¿';
-		          install ]
+	[ method := MockForCompilation compiler install: 'foo ^¿' ]
 		on: CodeError
 		do: [ :error | message := error messageText , ' :(' ].
 

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -86,7 +86,7 @@ RPackageTest >> testAllUnsentMessages [
 	class2
 		compile: 'nonexistingMethodName1 42';
 		compile: 'nonexistingMethodName3 42';
-		compile: 'nonexistingMethodName4 class1 new nonexistingMethodName2'.
+		compile: 'nonexistingMethodName4 TestClass new nonexistingMethodName2'.
 
 	self assert: package allUnsentMessages size equals: 3.
 

--- a/src/TraitsV2/TaAbstractComposition.class.st
+++ b/src/TraitsV2/TaAbstractComposition.class.st
@@ -149,6 +149,7 @@ TaAbstractComposition >> compile: selector into: aClass [
 				source: sourceCode;
 				class: aClass ;
 				failBlock: [^ false];
+				permitFaulty: true;
 				compiledMethodTrailer: trailer;
 				compile.   "Assume OK after proceed from SyntaxError"
 

--- a/src/TraitsV2/TraitedClass.class.st
+++ b/src/TraitsV2/TraitedClass.class.st
@@ -285,8 +285,9 @@ TraitedClass >> recompile: selector from: oldClass [
 				source: (oldClass sourceCodeAt: selector);
 				class: self;
 				failBlock: [^ self];
+				permitFaulty: true; "Do not signal existing problems"
 				compiledMethodTrailer: method trailer;
-				compile.   "Assume OK after proceed from SyntaxError"
+				compile.
 	selector == newMethod selector ifFalse: [self error: 'selector changed!'].
 
 	method properties

--- a/src/TraitsV2/TraitedMetaclass.class.st
+++ b/src/TraitsV2/TraitedMetaclass.class.st
@@ -302,8 +302,9 @@ TraitedMetaclass >> recompile: selector from: oldClass [
 				source: (oldClass sourceCodeAt: selector);
 				class: self;
 				failBlock: [^ self];
+				permitFaulty: true; "Do not signal existing problems"
 				compiledMethodTrailer: method trailer;
-				compile.   "Assume OK after proceed from SyntaxError"
+				compile.
 	selector == newMethod selector ifFalse: [self error: 'selector changed!'].
 
 	method properties


### PR DESCRIPTION
Do not merge, this is just a concept PR to see how far we are currently in the CI.
Code is ugly, do lot look at it.

So, a little explanation.
Undeclared variable (#13006) is a warning in non-interactive mode, but an error in interactive mode.
The first step of what I tried is to make it always an error.

Obviously, all the non-interactive clients of the compiler that deal (for good or bad reasons) with undeclared variables are failing on this new kind of error.
So the second step is to pass each failing clients in faulty mode (`permitFaulty`). Code will be executed and/or installed even if they contain undeclared variable. (note #13152 is needed for that).

In order to be able to bootstrap, 3 clients need to be updated:
* CodeImport for initial .st files, why are there undeclared variable here? I don't know.
* Monticello for import of package, there are undeclared variables because it's the way Monticello works, I'm not sure if we can change that easily.
* TraitsV2 because traits are used I assume, but it's nor clear why there are undeclared variables in traits

The bootstrap is working, but now many tests are failing. The 3rd step is to check them all. 111 is not that much.

I'm still not sure what to do with undeclared variables, but I hope this experiments will help up to decide.