### PR TITLE
Update behaviour of #protocolNamed:

### DIFF
--- a/src/EpiceaBrowsers/EpHasImpactVisitor.class.st
+++ b/src/EpiceaBrowsers/EpHasImpactVisitor.class.st
@@ -164,15 +164,10 @@ EpHasImpactVisitor >> visitProtocolRemoval: aProtocolRemoved [
 	- the protocl exists, and
 	- there are methods in the protocol that are not trait methods"
 
-	self
-		behaviorNamed: aProtocolRemoved behaviorAffectedName
-		ifPresent: [ :behavior | | selectors |
-			selectors := (behavior organization protocolOrganizer
-				getProtocolNamed: aProtocolRemoved protocol
-				ifNone: [ ^ false ]) methodSelectors.
-			(selectors allSatisfy: [ :each |
-					(behavior compiledMethodAt: each) isFromTrait ]) ifTrue:
-						[ ^ false ] ].
+	self behaviorNamed: aProtocolRemoved behaviorAffectedName ifPresent: [ :behavior |
+		| selectors |
+		selectors := (behavior organization protocolNamed: aProtocolRemoved protocol ifAbsent: [ ^ false ]) methodSelectors.
+		(selectors allSatisfy: [ :each | (behavior compiledMethodAt: each) isFromTrait ]) ifTrue: [ ^ false ] ].
 
 	^ true
 ]

--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -65,6 +65,13 @@ ClassOrganizationTest >> testMethodsInProtocolNamed [
 ]
 
 { #category : #tests }
+ClassOrganizationTest >> testProtocolNamed [
+
+	self assert: (self organization protocolNamed: 'empty') name equals: 'empty'.
+	self should: [ self organization protocolNamed: 'non existing' ] raise: NotFound
+]
+
+{ #category : #tests }
 ClassOrganizationTest >> testProtocolNames [
 
 	self assertCollection: self organization protocolNames hasSameElements: #( #empty #one )

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -222,7 +222,7 @@ ClassOrganization >> protocolNameOfElement: aSelector ifAbsent: aBlock [
 { #category : #accessing }
 ClassOrganization >> protocolNamed: aString [
 
-	^ self protocolOrganizer protocolNamed: aString ifAbsent: [ nil ]
+	^ self protocolOrganizer protocolNamed: aString ifAbsent: [ NotFound signalFor: aString ]
 ]
 
 { #category : #accessing }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -226,6 +226,12 @@ ClassOrganization >> protocolNamed: aString [
 ]
 
 { #category : #accessing }
+ClassOrganization >> protocolNamed: aString ifAbsent: aBlock [
+
+	self protocolOrganizer protocolNamed: aString ifAbsent: aBlock
+]
+
+{ #category : #accessing }
 ClassOrganization >> protocolNames [
 
 	^ self protocols collect: #name
@@ -277,18 +283,15 @@ ClassOrganization >> removeProtocol: aProtocol [
 ClassOrganization >> removeProtocolIfEmpty: protocolName [
 	"The protocol may already have been removed, be non empty or a special protocol which can't be removed, such as 'all'."
 
-	(self protocolNamed: protocolName)
-		ifNotNil: [ :protocol |
-			(protocol isEmpty and: [ protocol canBeRemoved ])
-				ifTrue: [ self removeProtocol: protocol ] ]
+	| protocol |
+	protocol := self protocolNamed: protocolName ifAbsent: [ ^ self ].
+	(protocol isEmpty and: [ protocol canBeRemoved ]) ifTrue: [ self removeProtocol: protocol ]
 ]
 
 { #category : #accessing }
 ClassOrganization >> removeProtocolNamed: protocolName [
 
-	(self hasProtocolNamed: protocolName) ifFalse: [ ^ self ].
-
-	self removeProtocol: (self protocolNamed: protocolName)
+	self removeProtocol: (self protocolNamed: protocolName ifAbsent: [ ^ self ])
 ]
 
 { #category : #removing }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -222,7 +222,7 @@ ClassOrganization >> protocolNameOfElement: aSelector ifAbsent: aBlock [
 { #category : #accessing }
 ClassOrganization >> protocolNamed: aString [
 
-	^ self protocolOrganizer protocolNamed: aString ifAbsent: [ NotFound signalFor: aString ]
+	^ self protocolOrganizer protocolNamed: aString
 ]
 
 { #category : #accessing }
@@ -297,11 +297,13 @@ ClassOrganization >> removeProtocolNamed: protocolName [
 { #category : #removing }
 ClassOrganization >> renameProtocolNamed: oldName toBe: newName [
 
+	(self hasProtocolNamed: oldName) ifFalse: [ ^ self ].
+
 	self silentlyRenameProtocolNamed: oldName toBe: newName.
 
 	self notifyOfChangedProtocolNameFrom: oldName to: newName.
 	"I need to notify also the selector changes, otherwise RPackage will not notice"
-	(self protocolOrganizer protocolNamed: newName) methodSelectors do: [ :each | self notifyOfChangedSelector: each from: oldName to: newName ]
+	(self protocolNamed: newName) methodSelectors do: [ :each | self notifyOfChangedSelector: each from: oldName to: newName ]
 ]
 
 { #category : #'backward compatibility' }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -228,7 +228,7 @@ ClassOrganization >> protocolNamed: aString [
 { #category : #accessing }
 ClassOrganization >> protocolNamed: aString ifAbsent: aBlock [
 
-	self protocolOrganizer protocolNamed: aString ifAbsent: aBlock
+	^ self protocolOrganizer protocolNamed: aString ifAbsent: aBlock
 ]
 
 { #category : #accessing }

--- a/src/Kernel/Protocol.class.st
+++ b/src/Kernel/Protocol.class.st
@@ -13,11 +13,6 @@ Class {
 }
 
 { #category : #'instance creation' }
-Protocol class >> empty [
-	 ^ self name: #''
-]
-
-{ #category : #'instance creation' }
 Protocol class >> name: nm [
 
 	^ self new

--- a/src/Kernel/ProtocolOrganizer.class.st
+++ b/src/Kernel/ProtocolOrganizer.class.st
@@ -51,7 +51,7 @@ ProtocolOrganizer >> classify: aSymbol inProtocolNamed: aProtocolName [
 
 	"maybe here we should check if this method already belong to another protocol"
 	(self protocolsOfSelector: aSymbol) do: [ :p | p removeMethodSelector: aSymbol ].
-	protocol := self getProtocolNamed: name ifNone: [ self addProtocolNamed: name ].
+	protocol := self protocolNamed: name ifAbsent: [ self addProtocolNamed: name ].
 
 	protocol addMethodSelector: aSymbol
 ]
@@ -65,12 +65,6 @@ ProtocolOrganizer >> existsProtocolNamed: aProtocolName [
 { #category : #accessing }
 ProtocolOrganizer >> extensionProtocols [
 	^ self protocols select: #isExtensionProtocol
-]
-
-{ #category : #protocol }
-ProtocolOrganizer >> getProtocolNamed: aByteString ifNone: aBlockClosure [
-
-	^ protocols detect: [:e | e name = aByteString ] ifNone: aBlockClosure
 ]
 
 { #category : #testing }

--- a/src/Kernel/ProtocolOrganizer.class.st
+++ b/src/Kernel/ProtocolOrganizer.class.st
@@ -74,6 +74,12 @@ ProtocolOrganizer >> getProtocolNamed: aByteString ifNone: aBlockClosure [
 ]
 
 { #category : #testing }
+ProtocolOrganizer >> hasProtocolNamed: aString [
+
+	^ self allProtocols anySatisfy: [ :each | each name = aString ]
+]
+
+{ #category : #testing }
 ProtocolOrganizer >> includesSelector: selector [
 	^ protocols anySatisfy: [ :each | each includesSelector: selector ]
 ]
@@ -86,15 +92,16 @@ ProtocolOrganizer >> initialize [
 
 { #category : #'backward compatibility' }
 ProtocolOrganizer >> methodsInProtocolNamed: aName [
+
 	aName = AllProtocol defaultName ifTrue: [ ^ self allMethodSelectors ].
 
-	^ (self protocolNamed: aName) methodSelectors
+	^ (self protocolNamed: aName ifAbsent: [ ^ #(  ) ]) methodSelectors
 ]
 
 { #category : #private }
 ProtocolOrganizer >> moveMethodsFrom: fromProtocolNamed to: toProtocolNamed [
-	| fromProtocol toProtocol |
 
+	| fromProtocol toProtocol |
 	fromProtocol := self protocolNamed: fromProtocolNamed.
 	toProtocol := self protocolNamed: toProtocolNamed.
 
@@ -107,9 +114,7 @@ ProtocolOrganizer >> moveMethodsFrom: fromProtocolNamed to: toProtocolNamed [
 { #category : #accessing }
 ProtocolOrganizer >> protocolNamed: aName [
 
-	^ self
-		protocolNamed: aName
-		ifAbsent: [ Protocol empty ]
+	^ self protocolNamed: aName ifAbsent: [ NotFound signalFor: aName ]
 ]
 
 { #category : #accessing }
@@ -162,22 +167,23 @@ ProtocolOrganizer >> removeProtocol: aProtocol [
 
 { #category : #'protocol - removing' }
 ProtocolOrganizer >> removeProtocolNamed: aName [
-	| protocolToRemove |
 
-	protocolToRemove := self protocolNamed: aName.
-	^ self removeProtocol: protocolToRemove
+	^ self removeProtocol: (self protocolNamed: aName ifAbsent: [ ^ self ])
 ]
 
 { #category : #accessing }
 ProtocolOrganizer >> renameProtocol: oldName into: newName [
+
+	(self hasProtocolNamed: oldName) ifFalse: [ ^ self ].
+
 	(self existsProtocolNamed: newName)
 		ifTrue: [
 			self moveMethodsFrom: oldName to: newName.
 			self removeProtocolNamed: oldName ]
 		ifFalse: [
 			^ (self protocolNamed: oldName)
-				name: newName;
-				yourself ]
+				  name: newName;
+				  yourself ]
 ]
 
 { #category : #initialization }

--- a/src/Monticello-Tests/MCPackageTest.class.st
+++ b/src/Monticello-Tests/MCPackageTest.class.st
@@ -21,13 +21,16 @@ MCPackageTest >> tearDown [
 
 { #category : #tests }
 MCPackageTest >> testUnload [
+
 	| mock |
 	self mockPackage unload.
 	self deny: (testingEnvironment hasClassNamed: #MCMockClassA).
 	self deny: (MCSnapshotTest includesSelector: #mockClassExtension).
-	self deny: (MCSnapshotTest  organization protocolNamed: self mockExtensionMethodCategory) notNil.
+	MCSnapshotTest organization protocolNamed: self mockExtensionMethodCategory ifAbsent: [ self fail: 'Protocol should not be missing' ].
 	mock := testingEnvironment at: #MCMock.
-	self assert: (mock subclasses detect: [ :c | c name = #MCMockClassA ] ifNone: [  ]) isNil
+	self assert: (mock subclasses
+			 detect: [ :c | c name = #MCMockClassA ]
+			 ifNone: [  ]) isNil
 ]
 
 { #category : #tests }
@@ -36,14 +39,15 @@ MCPackageTest >> testUnloadWithAdditionalTracking [
 
 	| mock |
 	SystemAnnouncer uniqueInstance when: MethodRemoved send: #aMethodRemoved: to: self.
-	self assert: (SystemAnnouncer uniqueInstance hasSubscriber: self ).
+	self assert: (SystemAnnouncer uniqueInstance hasSubscriber: self).
 	self mockPackage unload.
 	self deny: (testingEnvironment hasClassNamed: #MCMockClassA).
 	self deny: (MCSnapshotTest includesSelector: #mockClassExtension).
-	self deny: (MCSnapshotTest  organization protocolNamed: self mockExtensionMethodCategory) notNil.
+	MCSnapshotTest organization protocolNamed: self mockExtensionMethodCategory ifAbsent: [ self fail: 'Protocol should not be missing' ].
 	mock := testingEnvironment at: #MCMock.
-	self assert: (mock subclasses detect: [ :c | c name = #MCMockClassA ] ifNone: [  ]) isNil.
+	self assert: (mock subclasses
+			 detect: [ :c | c name = #MCMockClassA ]
+			 ifNone: [  ]) isNil.
 	SystemAnnouncer uniqueInstance unsubscribe: self.
-	self deny: (SystemAnnouncer uniqueInstance hasSubscriber: self ).
-
+	self deny: (SystemAnnouncer uniqueInstance hasSubscriber: self)
 ]

--- a/src/Monticello-Tests/MCPackageTest.class.st
+++ b/src/Monticello-Tests/MCPackageTest.class.st
@@ -26,7 +26,7 @@ MCPackageTest >> testUnload [
 	self mockPackage unload.
 	self deny: (testingEnvironment hasClassNamed: #MCMockClassA).
 	self deny: (MCSnapshotTest includesSelector: #mockClassExtension).
-	MCSnapshotTest organization protocolNamed: self mockExtensionMethodCategory ifAbsent: [ self fail: 'Protocol should not be missing' ].
+	self deny: (MCSnapshotTest organization hasProtocolNamed: self mockExtensionMethodCategory).
 	mock := testingEnvironment at: #MCMock.
 	self assert: (mock subclasses
 			 detect: [ :c | c name = #MCMockClassA ]
@@ -43,7 +43,7 @@ MCPackageTest >> testUnloadWithAdditionalTracking [
 	self mockPackage unload.
 	self deny: (testingEnvironment hasClassNamed: #MCMockClassA).
 	self deny: (MCSnapshotTest includesSelector: #mockClassExtension).
-	MCSnapshotTest organization protocolNamed: self mockExtensionMethodCategory ifAbsent: [ self fail: 'Protocol should not be missing' ].
+	self deny: (MCSnapshotTest organization hasProtocolNamed: self mockExtensionMethodCategory).
 	mock := testingEnvironment at: #MCMock.
 	self assert: (mock subclasses
 			 detect: [ :c | c name = #MCMockClassA ]

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -1342,13 +1342,11 @@ RPackage >> removeSelector: aSelector ofMetaclassName: aClassName [
 
 { #category : #private }
 RPackage >> renameExtensionsPrefixedWith: oldName to: newName [
+
 	| protocols |
+	protocols := self extensionMethods collect: [ :each | each origin organization protocolNamed: each protocol ] as: Set.
 
-	protocols := self extensionMethods
-		collect: [ :each | each origin organization protocolNamed:  each protocol ]
-		as: Set.
-
-	protocols do: [ :each | each rename: '*', newName, (each name allButFirst: oldName size + 1) ]
+	protocols do: [ :each | each rename: '*' , newName , (each name allButFirst: oldName size + 1) ]
 ]
 
 { #category : #private }

--- a/src/Refactoring-Environment/RBNotEnvironment.class.st
+++ b/src/Refactoring-Environment/RBNotEnvironment.class.st
@@ -39,10 +39,8 @@ RBNotEnvironment >> includesPackage: aRPackage [
 
 { #category : #testing }
 RBNotEnvironment >> includesProtocol: aProtocol in: aClass [
-	^ (aClass organization protocolOrganizer
-		getProtocolNamed: aProtocol
-		ifNone: [ ^ false ]) methodSelectors
-		anySatisfy: [ :selector | self includesSelector: selector in: aClass ]
+
+	^ (aClass organization protocolNamed: aProtocol ifAbsent: [ ^ false ]) methodSelectors anySatisfy: [ :selector | self includesSelector: selector in: aClass ]
 ]
 
 { #category : #testing }

--- a/src/Refactoring2-Transformations-Tests/RBMethodProtocolTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMethodProtocolTransformationTest.class.st
@@ -26,46 +26,33 @@ RBMethodProtocolTransformationTest >> testMethodDoesNotExist [
 
 { #category : #tests }
 RBMethodProtocolTransformationTest >> testRefactoring [
+
 	| refactoring |
-	self assert: (RBDummyEmptyClass organization protocolOrganizer protocolNamed: 'empty protocol 2') isEmpty.
+	self deny: (RBDummyEmptyClass organization hasProtocolNamed: 'empty protocol 2').
 
 	refactoring := (RBMethodProtocolTransformation protocol: 'empty protocol 2' inMethod: #someMethod inClass: #RBDummyEmptyClass) asRefactoring transform.
 	RBRefactoryChangeManager instance performChange: refactoring changes.
 
-	self deny: (RBDummyEmptyClass organization protocolOrganizer protocolNamed: 'empty protocol 2') isEmpty.
+	self deny: (RBDummyEmptyClass organization protocolNamed: 'empty protocol 2') isEmpty.
 
 	refactoring := (RBMethodProtocolTransformation protocol: 'empty protocol 1' inMethod: #someMethod inClass: #RBDummyEmptyClass) asRefactoring transform.
 	RBRefactoryChangeManager instance performChange: refactoring changes.
 
-	self assert: (RBDummyEmptyClass organization protocolOrganizer protocolNamed: 'empty protocol 2') isEmpty
+	self deny: (RBDummyEmptyClass organization hasProtocolNamed: 'empty protocol 2')
 ]
 
 { #category : #tests }
 RBMethodProtocolTransformationTest >> testTransform [
 
 	| transformation |
-	self assert: ( RBDummyEmptyClass
-		organization protocolOrganizer
-		protocolNamed: 'empty protocol 2' ) isEmpty.
+	self deny: (RBDummyEmptyClass organization hasProtocolNamed: 'empty protocol 2').
 
-	transformation := (RBMethodProtocolTransformation new
-		protocol: 'empty protocol 2'
-		inMethod: #someMethod
-		inClass: #RBDummyEmptyClass)
-		transform.
+	transformation := (RBMethodProtocolTransformation new protocol: 'empty protocol 2' inMethod: #someMethod inClass: #RBDummyEmptyClass) transform.
 	RBRefactoryChangeManager instance performChange: transformation changes.
 
-	self assert: ( RBDummyEmptyClass
-		organization protocolOrganizer
-		protocolNamed: 'empty protocol 2' ) isEmpty not.
+	self deny: (RBDummyEmptyClass organization protocolNamed: 'empty protocol 2') isEmpty.
 
-	transformation := (RBMethodProtocolTransformation new
-		protocol: 'empty protocol 1'
-		inMethod: #someMethod
-		inClass: #RBDummyEmptyClass)
-		transform.
+	transformation := (RBMethodProtocolTransformation new protocol: 'empty protocol 1' inMethod: #someMethod inClass: #RBDummyEmptyClass) transform.
 	RBRefactoryChangeManager instance performChange: transformation changes.
-	self assert: ( RBDummyEmptyClass
-		organization protocolOrganizer
-		protocolNamed: 'empty protocol 2' ) isEmpty
+	self deny: (RBDummyEmptyClass organization hasProtocolNamed: 'empty protocol 2')
 ]

--- a/src/ReleaseTests/ProperMethodCategorizationTest.class.st
+++ b/src/ReleaseTests/ProperMethodCategorizationTest.class.st
@@ -151,7 +151,7 @@ ProperMethodCategorizationTest >> testNoEmptyProtocols [
 	violating := Dictionary new.
 	ProtoObject withAllSubclasses
 		do: [ :cls |
-			protocolsWithoutMethods := cls organization protocolOrganizer protocols select: [ :e | e isEmpty and: [ e canBeRemoved ] ].
+			protocolsWithoutMethods := cls organization protocols select: [ :e | e isEmpty and: [ e canBeRemoved ] ].
 			protocolsWithoutMethods notEmpty ifTrue: [ violating at: cls put: protocolsWithoutMethods ] ].
 
 	self assertEmpty: violating

--- a/src/UnifiedFFI/FFIStructure.class.st
+++ b/src/UnifiedFFI/FFIStructure.class.st
@@ -313,11 +313,9 @@ FFIStructure class >> rebuildFieldAccessors [
 
 { #category : #private }
 FFIStructure class >> removeAllMethodsInProtocol: protocolName [
+
 	| protocol |
-
-	protocol := self organization protocolNamed: protocolName.
-	protocol ifNil: [ ^ self ].
-
+	protocol := self organization protocolNamed: protocolName ifAbsent: [ ^ self ].
 	protocol methods do: [ :each | self removeSelector: each ]
 ]
 


### PR DESCRIPTION
We have an incoherence between ClassOrganization and ProtocolOrganizer about #protocolNamed:

ClassOrganization is returning nil if the protocol is missing.
ProtocolOrganizer is returning a nameless protocol.

I was trying to think about which I prefer, but I don't like either!

Here is what I propose:
- Add ClassOrganization>>#protocolNamed:ifAbsent: to deal with the possibility of a missing protocol
- Make #protocolNamed: throw a NotFound error in case the protocol does not exist.

This PR also fix other Demeter's law violations and reduces the exposition of protocolOrganizer in the system. (Slowly but surely we will kill it!)