### PR TITLE
Faulty code: improve code error descriptions

### DIFF
--- a/src/AST-Core/CodeError.class.st
+++ b/src/AST-Core/CodeError.class.st
@@ -13,6 +13,12 @@ Class {
 }
 
 { #category : #accessing }
+CodeError >> description [
+
+	^ self class name , ':' , self notice description
+]
+
+{ #category : #accessing }
 CodeError >> errorCode [
 
 	self

--- a/src/AST-Core/RBNotice.class.st
+++ b/src/AST-Core/RBNotice.class.st
@@ -11,6 +11,26 @@ Class {
 	#category : #'AST-Core-Notice'
 }
 
+{ #category : #accessing }
+RBNotice >> description [
+
+	^ String streamContents: [ :stream |
+		  stream
+			  nextPutAll: self class name;
+			  nextPutAll: ' ';
+			  nextPutAll: (node methodNode methodClass
+					   ifNotNil: [ :class | class name ]
+					   ifNil: [ '???' ]);
+			  nextPutAll: '>>#';
+			  nextPutAll: node methodNode selector;
+			  nextPutAll: ' ';
+			  print: self position;
+			  nextPutAll: ':';
+			  nextPutAll: self messageText;
+			  nextPutAll: '->';
+			  nextPutAll: node displaySourceCode ]
+]
+
 { #category : #testing }
 RBNotice >> isError [
 

--- a/src/AST-Core/RBNotice.class.st
+++ b/src/AST-Core/RBNotice.class.st
@@ -52,3 +52,15 @@ RBNotice >> position [
 
 	^ node start
 ]
+
+{ #category : #printing }
+RBNotice >> printOn: aStream [
+
+	aStream
+		nextPutAll: self class name;
+		nextPutAll: '(';
+		print: self position;
+		nextPutAll: ':';
+		nextPutAll: self messageText;
+		nextPutAll: ')'
+]

--- a/src/CodeImportCommandLineHandlers/STCommandLineHandler.class.st
+++ b/src/CodeImportCommandLineHandlers/STCommandLineHandler.class.st
@@ -112,11 +112,12 @@ STCommandLineHandler >> end [
 
 { #category : #private }
 STCommandLineHandler >> handleError: error [
+	"for syntax errors we print more detailed error informations"
 
-	"for syntax errors we can used the default action"	"otherwise resignal it"
-	(error isKindOf: CodeError)
-		ifTrue: [ error defaultAction ]
-		ifFalse: [ error pass ]
+	(error isKindOf: CodeError) ifTrue: [
+		self class printCodeError: error ].
+
+	error pass
 ]
 
 { #category : #private }
@@ -126,6 +127,10 @@ STCommandLineHandler >> handleError: error reference: aReference [
 	"We ignore warnings for now"
 	(error isKindOf: OCSemanticWarning)
 		ifTrue: [ ^ error pass ].
+
+	"Display CodeError nicely"
+	(error isKindOf: CodeError)
+		ifTrue: [ self class printCodeError: error ].
 
 	"spit out a warning if in headless mode, otherwise a debugger will popup"
 	Smalltalk isHeadless

--- a/src/CodeImportCommandLineHandlers/STCommandLineHandler.class.st
+++ b/src/CodeImportCommandLineHandlers/STCommandLineHandler.class.st
@@ -45,12 +45,12 @@ STCommandLineHandler class >> isResponsibleFor: aCommandLine [
 ]
 
 { #category : #printing }
-STCommandLineHandler class >> printCompilerWarning: aSyntaxErrorNotification [
+STCommandLineHandler class >> printCodeError: aCodeError [
 	| stderr position contents errorLine errorMessage maxLineNumberSize lineNumber |
 
 	"format the error"
-	position := aSyntaxErrorNotification position.
-	contents := aSyntaxErrorNotification sourceCode.
+	position := aCodeError position.
+	contents := aCodeError sourceCode.
 	errorLine := contents lineNumberCorrespondingToIndex: position.
 	stderr := VTermOutputDriver stderr.
 
@@ -58,7 +58,7 @@ STCommandLineHandler class >> printCompilerWarning: aSyntaxErrorNotification [
 	errorMessage := String streamContents: [ :s|
 		s nextPutAll: 'Syntax Error on line ';
 			print: errorLine; nextPutAll: ': ';
-			print: aSyntaxErrorNotification messageText].
+			print: aCodeError messageText].
 
 	 stderr red;
 		nextPutAll: errorMessage; lf;


### PR DESCRIPTION
This PR add some description features:

* printOn: on RBNotice
* long description in CodeError and RBNotice
* bring back nice syntax error message on command line mode, but for all code errors