### PR TITLE
[Refactoring] push down method in some classes driver

### DIFF
--- a/src/Refactoring-UI/RBPushDownMethodDriver.class.st
+++ b/src/Refactoring-UI/RBPushDownMethodDriver.class.st
@@ -32,10 +32,10 @@ RBPushDownMethodDriver class >> model: aRBNamespace scopes: refactoringScopes pu
 RBPushDownMethodDriver >> execute [
 
 	| changes refactoring |
-	refactoring := self refactoring.
 	methods := self selectMethods.
 	methods ifNil: [ ^ self ].
 
+	refactoring := self refactoring.
 	changes := [
 	           [ refactoring generateChanges ]
 		           on: RBApplicabilityChecksFailedError
@@ -80,5 +80,6 @@ RBPushDownMethodDriver >> selectMethods [
 			          (class methods sort: [ :a :b | a asString < b asString ])
 				          asOrderedCollection
 		          selecting: methods asOrderedCollection.
+	dialog cancelled ifTrue: [ ^ nil ].
 	^ dialog presenter selectedItems
 ]

--- a/src/Refactoring-UI/RBPushDownMethodInSomeClassesDriver.class.st
+++ b/src/Refactoring-UI/RBPushDownMethodInSomeClassesDriver.class.st
@@ -37,3 +37,31 @@ RBPushDownMethodInSomeClassesDriver >> model: aRBNamespace scopes: refactoringSc
 	methods := methodsList.
 	class := methods first origin
 ]
+
+{ #category : #execution }
+RBPushDownMethodInSomeClassesDriver >> selectClasses [
+
+	| dialog |
+	dialog := StVariablesSelectionPresenter
+		          label: 'Push down in classes: '
+		          withItems:
+			          (class subclasses sort: [ :a :b | a name < b name ])
+				          asOrderedCollection
+		          selecting: class subclasses.
+	dialog cancelled ifTrue: [ ^ nil ].
+	^ dialog presenter selectedItems collect: [ :each | each name ]
+]
+
+{ #category : #execution }
+RBPushDownMethodInSomeClassesDriver >> selectMethods [
+
+	| dialog |
+	dialog := StMethodsSelectionPresenter
+		          label: 'Push down methods from ' , class name
+		          withItems:
+			          (class methods sort: [ :a :b | a asString < b asString ])
+				          asOrderedCollection
+		          selecting: methods asOrderedCollection.
+	dialog cancelled ifTrue: [ ^ nil ].
+	^ dialog presenter selectedItems
+]

--- a/src/Refactoring-UI/RBPushDownMethodInSomeClassesDriver.class.st
+++ b/src/Refactoring-UI/RBPushDownMethodInSomeClassesDriver.class.st
@@ -29,6 +29,32 @@ RBPushDownMethodInSomeClassesDriver class >> model: aRBNamespace scopes: refacto
 	^ self new model: aRBNamespace scopes: refactoringScopes pushDown: methods
 ]
 
+{ #category : #execution }
+RBPushDownMethodInSomeClassesDriver >> execute [
+
+	| changes refactoring |
+	methods := self selectMethods.
+	methods ifNil: [ ^ self ].
+	classes := self selectClasses.
+	classes ifNil: [ ^ self ].
+	
+	refactoring := self refactoring.
+	changes := [
+	           [ refactoring generateChanges ]
+		           on: RBApplicabilityChecksFailedError
+		           do: [ :err |
+		           ^ RBRefactoringFailure signal: err messageText ] ]
+		           on: RBBreakingChangeChecksFailedWarning
+		           do: [ :err |
+			           RBRefactoringWarning signal: err messageText.
+			           "If user answers no, error is being propagated."
+			           err resume ].
+	(StRefactoringPreviewPresenter
+		 changes: changes
+		 inEnvironment: model
+		 scopes: scopes) open
+]
+
 { #category : #initialization }
 RBPushDownMethodInSomeClassesDriver >> model: aRBNamespace scopes: refactoringScopes pushDown: methodsList [
 
@@ -36,6 +62,16 @@ RBPushDownMethodInSomeClassesDriver >> model: aRBNamespace scopes: refactoringSc
 	scopes := refactoringScopes.
 	methods := methodsList.
 	class := methods first origin
+]
+
+{ #category : #resources }
+RBPushDownMethodInSomeClassesDriver >> refactoring [
+
+	^ RBPushDownMethodRefactoring
+		model: model
+		pushDown: (methods collect: [ :each | each selector ])
+		from: class
+		in: classes.
 ]
 
 { #category : #execution }

--- a/src/Refactoring-UI/RBPushDownMethodInSomeClassesDriver.class.st
+++ b/src/Refactoring-UI/RBPushDownMethodInSomeClassesDriver.class.st
@@ -13,11 +13,8 @@ You can create my instance and execute the refactoring by running:
 "
 Class {
 	#name : #RBPushDownMethodInSomeClassesDriver,
-	#superclass : #RBDriver,
+	#superclass : #RBPushDownMethodDriver,
 	#instVars : [
-		'methods',
-		'scopes',
-		'class',
 		'classes'
 	],
 	#category : #'Refactoring-UI'
@@ -55,15 +52,6 @@ RBPushDownMethodInSomeClassesDriver >> execute [
 		 scopes: scopes) open
 ]
 
-{ #category : #initialization }
-RBPushDownMethodInSomeClassesDriver >> model: aRBNamespace scopes: refactoringScopes pushDown: methodsList [
-
-	model := aRBNamespace.
-	scopes := refactoringScopes.
-	methods := methodsList.
-	class := methods first origin
-]
-
 { #category : #resources }
 RBPushDownMethodInSomeClassesDriver >> refactoring [
 
@@ -86,18 +74,4 @@ RBPushDownMethodInSomeClassesDriver >> selectClasses [
 		          selecting: class subclasses.
 	dialog cancelled ifTrue: [ ^ nil ].
 	^ dialog presenter selectedItems collect: [ :each | each name ]
-]
-
-{ #category : #execution }
-RBPushDownMethodInSomeClassesDriver >> selectMethods [
-
-	| dialog |
-	dialog := StMethodsSelectionPresenter
-		          label: 'Push down methods from ' , class name
-		          withItems:
-			          (class methods sort: [ :a :b | a asString < b asString ])
-				          asOrderedCollection
-		          selecting: methods asOrderedCollection.
-	dialog cancelled ifTrue: [ ^ nil ].
-	^ dialog presenter selectedItems
 ]

--- a/src/Refactoring-UI/RBPushDownMethodInSomeClassesDriver.class.st
+++ b/src/Refactoring-UI/RBPushDownMethodInSomeClassesDriver.class.st
@@ -1,0 +1,39 @@
+"
+I represent a driver that invokes `PushDownMethod` refactoring.
+
+I am responsible for asking user which methods to push down and to which classes to push to.
+
+When I gather all needed information I am calling and executing push down method refactoring.
+
+You can create my instance and execute the refactoring by running:
+
+```
+(RBPushDownMethodDriver model: aRBNamespace scopes: refactoringScopes pushDown: methods) execute
+```
+"
+Class {
+	#name : #RBPushDownMethodInSomeClassesDriver,
+	#superclass : #RBDriver,
+	#instVars : [
+		'methods',
+		'scopes',
+		'class',
+		'classes'
+	],
+	#category : #'Refactoring-UI'
+}
+
+{ #category : #initialization }
+RBPushDownMethodInSomeClassesDriver class >> model: aRBNamespace scopes: refactoringScopes pushDown: methods [
+
+	^ self new model: aRBNamespace scopes: refactoringScopes pushDown: methods
+]
+
+{ #category : #initialization }
+RBPushDownMethodInSomeClassesDriver >> model: aRBNamespace scopes: refactoringScopes pushDown: methodsList [
+
+	model := aRBNamespace.
+	scopes := refactoringScopes.
+	methods := methodsList.
+	class := methods first origin
+]

--- a/src/SystemCommands-MethodCommands/SycPushDownMethodInSomeClassesCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycPushDownMethodInSomeClassesCommand.class.st
@@ -14,19 +14,8 @@ Class {
 
 { #category : #converting }
 SycPushDownMethodInSomeClassesCommand >> asRefactorings [
-	"Return push down method refactoring using method"
-	| refactoring |
-	refactoring := RBPushDownMethodRefactoring
-		model: model
-		pushDown: (methods collect: [ :each | each selector ])
-		from: methods first origin
-		in: self classes.
-	^ OrderedCollection with: refactoring
-]
 
-{ #category : #converting }
-SycPushDownMethodInSomeClassesCommand >> classes [
-	^ classes ifNil: [ classes := #() ]
+	self shouldNotImplement
 ]
 
 { #category : #accessing }
@@ -40,7 +29,23 @@ SycPushDownMethodInSomeClassesCommand >> defaultMenuItemName [
 ]
 
 { #category : #execution }
+SycPushDownMethodInSomeClassesCommand >> executeRefactorings [
+
+	(RBPushDownMethodInSomeClassesDriver
+		model: model
+		scopes: refactoringScopes
+		pushDown: methods) execute
+]
+
+{ #category : #testing }
+SycPushDownMethodInSomeClassesCommand >> isComplexRefactoring [ 
+
+	^ false
+]
+
+{ #category : #execution }
 SycPushDownMethodInSomeClassesCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
-	self selectMethodsAndClasses
+	refactoringScopes := aToolContext refactoringScopes
+
 ]

--- a/src/SystemCommands-MethodCommands/SycPushDownMethodInSomeClassesCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycPushDownMethodInSomeClassesCommand.class.st
@@ -1,8 +1,13 @@
+"
+I am a command that pushes down methods in some classes.
+
+I am responsible for delegating execution to `RBPushDownMethodInSomeClassesDriver`.
+"
 Class {
 	#name : #SycPushDownMethodInSomeClassesCommand,
 	#superclass : #SysRefactoringMethodCommand,
 	#instVars : [
-		'classes'
+		'refactoringScopes'
 	],
 	#category : #'SystemCommands-MethodCommands'
 }
@@ -38,22 +43,4 @@ SycPushDownMethodInSomeClassesCommand >> defaultMenuItemName [
 SycPushDownMethodInSomeClassesCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
 	self selectMethodsAndClasses
-]
-
-{ #category : #execution }
-SycPushDownMethodInSomeClassesCommand >> selectMethodsAndClasses [
-	| dialog class|
-	class := methods first origin.
-	dialog := StMethodsSelectionPresenter
-		   label: 'Push down methods from ', class name
-			withItems: (class methods sort: [ :a :b | a asString < b asString ]) asOrderedCollection
-			selecting: methods asOrderedCollection.
-	dialog cancelled ifTrue: [ CmdCommandAborted signal ].
-	methods := dialog presenter selectedItems.
-	dialog := StVariablesSelectionPresenter
-		   label: 'Push down in classes: '
-			withItems: (class subclasses sort: [ :a :b | a name < b name ]) asOrderedCollection
-			selecting: class subclasses.
-	dialog cancelled ifTrue: [ CmdCommandAborted signal ].
-	classes := (dialog presenter selectedItems) collect: [ :each | each name ]
 ]


### PR DESCRIPTION
* fixed a bug in `RBPushDownMethodDriver` where methods were selected after refactoring was created thus making no difference in the outcome
* introduced driver for `SycPushDownMethodsInSomeClassesCommand`