### PR TITLE
remove  commentSourcePointer from ClassOrganization

### DIFF
--- a/src/Fuel-Tests-Core/FLTCreateClassOrTraitSerializationTest.trait.st
+++ b/src/Fuel-Tests-Core/FLTCreateClassOrTraitSerializationTest.trait.st
@@ -145,8 +145,10 @@ FLTCreateClassOrTraitSerializationTest >> testCreateWithComment [
 	
 	materializedClassOrTrait := self resultOfSerializeRemoveAndMaterialize: aClassOrTrait.
 
-	self assert: 'test comment' = materializedClassOrTrait comment asString.
-	self assert: 'test stamp' = materializedClassOrTrait commentStamp.
+	"we do not store the commentSourePointer, as is would be invalid in anther image.
+	see https://github.com/theseion/Fuel/issues/270"
+	self assert: '' = materializedClassOrTrait comment.
+	self assert: '' = materializedClassOrTrait commentStamp.
 ]
 
 { #category : #tests }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -186,13 +186,13 @@ ClassDescription >> basicOrganization: aClassOrg [
 	organization := aClassOrg
 ]
 
-{ #category : #'file in/out' }
+{ #category : #'accessing - comment' }
 ClassDescription >> classComment: aString [
 	"Store the comment, aString or Text or RemoteString, associated with the class we are orgainzing.  Empty string gets stored only if had a non-empty one before."
 	^ self classComment: aString stamp: '<historical>'
 ]
 
-{ #category : #'file in/out' }
+{ #category : #'accessing - comment' }
 ClassDescription >> classComment: aString stamp: aStamp [
 	"Store the comment, aString or Text or RemoteString, associated with the class we are organizing.  Empty string gets stored only if had a non-empty one before."
 
@@ -333,7 +333,9 @@ ClassDescription >> classesThatImplementAllOf: selectorSet [
 
 { #category : #'accessing - comment' }
 ClassDescription >> comment [
-    ^self instanceSide organization classComment
+    ^ commentSourcePointer
+		  ifNil: [ '' ]
+		  ifNotNil: [ :ptr | SourceFiles sourceCodeAt: ptr ]
 ]
 
 { #category : #'accessing - comment' }
@@ -352,23 +354,19 @@ ClassDescription >> comment: aStringOrText stamp: aStamp [
 
 { #category : #'accessing - comment' }
 ClassDescription >> commentSourcePointer [
-	"if not set, for now get it from the organization"
 	^ commentSourcePointer
-		  ifNil: [ self instanceSide organization commentSourcePointer ]
 ]
 
 { #category : #'accessing - comment' }
 ClassDescription >> commentSourcePointer: anObject [
-	"until it is removed, we set in on the organization, too"
-	self instanceSide organization commentSourcePointer: anObject.
-	commentSourcePointer := anObject.
+	commentSourcePointer := anObject
 ]
 
 { #category : #'accessing - comment' }
 ClassDescription >> commentStamp [
 
 	^ commentSourcePointer
-		  ifNil: [ self instanceSide organization commentStamp ]
+		  ifNil: [ '' ]
 		  ifNotNil: [ SourceFiles commentTimeStampAt: commentSourcePointer]
 ]
 

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -6,8 +6,7 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'protocolOrganizer',
-		'organizedClass',
-		'commentSourcePointer'
+		'organizedClass'
 	],
 	#category : #'Kernel-Protocols'
 }
@@ -83,9 +82,7 @@ ClassOrganization >> cleanUpProtocolsForClass: aClass [
 { #category : #accessing }
 ClassOrganization >> comment [
 
-	^ commentSourcePointer
-		  ifNil: [ '' ]
-		  ifNotNil: [ :ptr | SourceFiles sourceCodeAt: ptr ]
+	^ organizedClass comment
 ]
 
 { #category : #accessing }
@@ -95,26 +92,23 @@ ClassOrganization >> comment: aString [
 
 { #category : #accessing }
 ClassOrganization >> commentSourcePointer [
-	^ commentSourcePointer
+	^ organizedClass commentSourcePointer
 ]
 
 { #category : #accessing }
 ClassOrganization >> commentSourcePointer: anObject [
-	commentSourcePointer := anObject
+	organizedClass commentSourcePointer: anObject
 ]
 
 { #category : #accessing }
 ClassOrganization >> commentStamp [
 
-	^ commentSourcePointer
-		  ifNil: [ '' ]
-		  ifNotNil: [ SourceFiles commentTimeStampAt: commentSourcePointer]
+	^ organizedClass commentStamp
 ]
 
 { #category : #copying }
 ClassOrganization >> copyFrom: otherOrganization [
 
-	commentSourcePointer := otherOrganization commentSourcePointer.
 	otherOrganization protocols do: [ :protocol | protocol methodSelectors do: [ :m | protocolOrganizer classify: m inProtocolNamed: protocol name ] ]
 ]
 
@@ -125,7 +119,7 @@ ClassOrganization >> extensionProtocols [
 
 { #category : #testing }
 ClassOrganization >> hasComment [
-	^ commentSourcePointer isNotNil
+	^ organizedClass hasComment
 ]
 
 { #category : #testing }


### PR DESCRIPTION
this removes  commentSourcePointer from ClassOrganization, forwards for now the methods without deprecation