### PR TITLE
Improve announcements printing

### DIFF
--- a/src/Announcements-Core/AnnouncementSubscription.class.st
+++ b/src/Announcements-Core/AnnouncementSubscription.class.st
@@ -86,6 +86,19 @@ AnnouncementSubscription >> makeWeak [
 			announcementClass: announcementClass)
 ]
 
+{ #category : #printing }
+AnnouncementSubscription >> printOn: aStream [
+
+	super printOn: aStream.
+
+	aStream
+		nextPutAll: ' (';
+		print: self subscriber;
+		nextPutAll: ' subscribes to ';
+		print: self announcementClass;
+		nextPut: $)
+]
+
 { #category : #accessing }
 AnnouncementSubscription >> subscriber [
 	^ subscriber

--- a/src/Announcements-Core/WeakAnnouncementSubscription.class.st
+++ b/src/Announcements-Core/WeakAnnouncementSubscription.class.st
@@ -142,13 +142,15 @@ WeakAnnouncementSubscription >> next [
 ]
 
 { #category : #printing }
-WeakAnnouncementSubscription >> printOn: stream [
+WeakAnnouncementSubscription >> printOn: aStream [
 
-	super printOn: stream.
+	super printOn: aStream.
 
-	stream
-		nextPut: $(;
-		print: action;
+	aStream
+		nextPutAll: ' (';
+		print: self subscriber;
+		nextPutAll: ' subscribes to ';
+		print: self announcementClass;
 		nextPut: $)
 ]
 


### PR DESCRIPTION
With this PR the printing of announcement subscriptions will print the subscribing object and the announcement class. This is useful when an error related to announcements happens in the CI