### PR TITLE
Removing unused instance variable `topContext` in DebugContext

### DIFF
--- a/src/Debugger-Model/DebugContext.class.st
+++ b/src/Debugger-Model/DebugContext.class.st
@@ -33,8 +33,7 @@ Class {
 	#name : #DebugContext,
 	#superclass : #Object,
 	#instVars : [
-		'context',
-		'topContext'
+		'context'
 	],
 	#category : #'Debugger-Model-Core'
 }
@@ -110,8 +109,7 @@ DebugContext >> evaluate: expression [
 
 { #category : #initialization }
 DebugContext >> forContext: aContext [
-	context := aContext.
-	topContext := aContext
+	context := aContext
 ]
 
 { #category : #accessing }
@@ -191,9 +189,4 @@ DebugContext >> selectedMessageName [
 DebugContext >> source [
 	"Answer the source code of the currently selected context."
 	^ context sourceCode
-]
-
-{ #category : #initialization }
-DebugContext >> topContext: aContext [
-	topContext := aContext
 ]

--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -98,7 +98,7 @@ DebugSession >> contextChanged [
 { #category : #accessing }
 DebugSession >> createModelForContext: aContext [
 
-	^ (self class contextModelClass forContext: aContext) topContext: interruptedContext
+	^ (self class contextModelClass forContext: aContext)
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
Fixes #13111 

The instance varaible `topContext` of the class `DebugContext`:

- is not used inside the class `DebugContext`
- has no getter (so is not used by any other class)
- has a setter that is used once in `DebugSession>>#createModelForContext:` but, well, it is useless to call a setter if the set variable isn't used anywhere

That's why I removed this instance variable