### PR TITLE
Factorize recompile:from:

### DIFF
--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -109,6 +109,16 @@ Behavior >> recompile: selector [
 Behavior >> recompile: selector from: oldClass [
 	"Compile the method associated with selector in the receiver's method dictionary."
 
+	| newMethod |
+	newMethod := self recompileBasic: selector from: oldClass.
+	self addSelector: selector withRecompiledMethod: newMethod
+]
+
+{ #category : #'*OpalCompiler-Core' }
+Behavior >> recompileBasic: selector from: oldClass [
+	"Compile the method associated with selector in the receiver's context.
+	The resulting compiled method is not installed."
+
 	| method newMethod |
 	method := oldClass compiledMethodAt: selector.
 	newMethod := oldClass compiler
@@ -118,7 +128,7 @@ Behavior >> recompile: selector from: oldClass [
 				compiledMethodTrailer: method trailer;
 				compile.   "Assume OK after proceed from SyntaxError"
 	selector == newMethod selector ifFalse: [self error: 'selector changed!'].
-	self addSelector: selector withRecompiledMethod: newMethod
+	^ newMethod
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -117,14 +117,15 @@ Behavior >> recompile: selector from: oldClass [
 { #category : #'*OpalCompiler-Core' }
 Behavior >> recompileBasic: selector from: oldClass [
 	"Compile the method associated with selector in the receiver's context.
-	The resulting compiled method is not installed."
+	The resulting compiled method is not installed.
+	If the original method is faulty, the result will be also faulty (silently)."
 
 	| method newMethod |
 	method := oldClass compiledMethodAt: selector.
 	newMethod := oldClass compiler
 				source: (oldClass sourceCodeAt: selector);
 				class: self;
-				failBlock: [^ self];
+				permitFaulty: true;
 				compiledMethodTrailer: method trailer;
 				compile.   "Assume OK after proceed from SyntaxError"
 	selector == newMethod selector ifFalse: [self error: 'selector changed!'].

--- a/src/TraitsV2/TraitedClass.class.st
+++ b/src/TraitsV2/TraitedClass.class.st
@@ -281,13 +281,7 @@ TraitedClass >> recompile: selector from: oldClass [
 
 	| method newMethod |
 	method := oldClass compiledMethodAt: selector.
-	newMethod := self compiler
-				source: (oldClass sourceCodeAt: selector);
-				class: self;
-				failBlock: [^ self];
-				compiledMethodTrailer: method trailer;
-				compile.   "Assume OK after proceed from SyntaxError"
-	selector == newMethod selector ifFalse: [self error: 'selector changed!'].
+	newMethod := self recompileBasic: selector from: oldClass.
 
 	method properties
 		at: #traitSource

--- a/src/TraitsV2/TraitedMetaclass.class.st
+++ b/src/TraitsV2/TraitedMetaclass.class.st
@@ -298,13 +298,7 @@ TraitedMetaclass >> recompile: selector from: oldClass [
 
 	| method newMethod |
 	method := oldClass compiledMethodAt: selector.
-	newMethod := self compiler
-				source: (oldClass sourceCodeAt: selector);
-				class: self;
-				failBlock: [^ self];
-				compiledMethodTrailer: method trailer;
-				compile.   "Assume OK after proceed from SyntaxError"
-	selector == newMethod selector ifFalse: [self error: 'selector changed!'].
+	newMethod := self recompileBasic: selector from: oldClass.
 
 	method properties
 		at: #traitSource


### PR DESCRIPTION
There are 4 implementation of recompile:from: one for Behavior, two for traits and the last one for FBDDecompiler. The first three can be factorized.

Moreover, the PR made recompile faulty aware by ignoring existing code errors (it's not its responsibility).