### PR TITLE
Compiler source code is String

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
@@ -36,7 +36,7 @@ ClyMethodCodeEditorToolMorph class >> shouldBeActivatedInContext: aBrowserContex
 ClyMethodCodeEditorToolMorph >> applyChanges [
 	| selector methodClass currentMethod |
 	methodClass := self chooseClassForNewMethodIfNone: [^false].
-	selector := methodClass compile: self pendingText classified: editingMethod protocol notifying: textMorph.
+	selector := methodClass compile: self pendingText asString classified: editingMethod protocol notifying: textMorph.
 	selector ifNil: [^false ].
 	currentMethod := methodClass >> selector.
 	self setMethodProtocol: currentMethod.

--- a/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
@@ -90,7 +90,7 @@ ClyMethodEditorToolMorph >> chooseClassForNewMethodIfNone: aBlock [
 ClyMethodEditorToolMorph >> currentEditedAST [
 
 	^ self methodClass compiler
-		  source: self pendingText;
+		  source: self pendingText asString;
 		  parse
 ]
 

--- a/src/Monticello-Tests/MCStWriterTest.class.st
+++ b/src/Monticello-Tests/MCStWriterTest.class.st
@@ -17,7 +17,7 @@ MCStWriterTest >> assertAllChunksAreWellFormed [
 { #category : #asserting }
 MCStWriterTest >> assertChunkIsWellFormed: chunk [
 	self class compiler
-		source:  chunk readStream ;
+		source: chunk;
 		class: UndefinedObject;
 		noPattern: true;
 		failBlock:  [self assert: false];
@@ -35,7 +35,7 @@ MCStWriterTest >> assertContentsOf: strm match: expected [
 { #category : #asserting }
 MCStWriterTest >> assertMethodChunkIsWellFormed: chunk [
 	self class compiler
-		source: chunk readStream;
+		source: chunk;
 		class: UndefinedObject;
 		failBlock: [self assert: false];
 		compile.

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -581,7 +581,6 @@ OpalCompiler >> semanticScope: anObject [
 { #category : #accessing }
 OpalCompiler >> source: aString [
 
-	self flag: 'source should be a string, but call contents for old clients that send streams'.
-	aString isString ifFalse: [ self error: 'Need string!' ]. "To remove"
+	"source should be a string, but call contents for old clients that send streams"
 	source := aString contents
 ]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -389,7 +389,7 @@ OpalCompiler >> install [
 
 	logSource ifTrue: [
 		class
-			logMethodSource: source contents
+			logMethodSource: source
 			forMethod: method
 			inCategory: protocolName
 			withStamp: changeStamp ].
@@ -418,7 +418,7 @@ OpalCompiler >> isInteractive [
 
 { #category : #private }
 OpalCompiler >> logDoIt [
-	self compilationContext logDoItEvaluation: source contents
+	self compilationContext logDoItEvaluation: source
 ]
 
 { #category : #accessing }
@@ -444,7 +444,7 @@ OpalCompiler >> parse [
 	self permitFaulty ifNil: [ self permitFaulty: true ].
 
 	parser := self parserClass new.
-	parser initializeParserWith: source contents.
+	parser initializeParserWith: source.
 	ast := self semanticScope parseASTBy: parser.
 
 	self permitFaulty ifFalse: [ ast checkFaulty: nil ].
@@ -580,5 +580,7 @@ OpalCompiler >> semanticScope: anObject [
 
 { #category : #accessing }
 OpalCompiler >> source: aString [
-	source := aString readStream
+
+	self flag: 'source should be a string, but call contents for old clients that send streams'.
+	source := aString contents
 ]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -582,5 +582,6 @@ OpalCompiler >> semanticScope: anObject [
 OpalCompiler >> source: aString [
 
 	self flag: 'source should be a string, but call contents for old clients that send streams'.
+	aString isString ifFalse: [ self error: 'Need string!' ]. "To remove"
 	source := aString contents
 ]

--- a/src/OpalCompiler-Tests/OCCompilerSyntaxErrorNotifyingTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerSyntaxErrorNotifyingTest.class.st
@@ -48,7 +48,7 @@ OCCompilerSyntaxErrorNotifyingTest >> enumerateAllSelections [
 { #category : #private }
 OCCompilerSyntaxErrorNotifyingTest >> evaluateSelection [
 	^ OpalCompiler new
-		source: morph editor selection readStream;
+		source: morph editor selection;
 		"Note subtle difference versus  (morph editor selectionAsStream).
 		The later does not answer the same contents and would raise a SyntaxErrorNotification with wrong sub-selection"
 		failBlock: [^failure];

--- a/src/System-Changes/ChangeRecord.class.st
+++ b/src/System-Changes/ChangeRecord.class.st
@@ -77,7 +77,7 @@ ChangeRecord >> fileIn [
 				ifTrue:
 					[
 					methodClass
-						compile: self text
+						compile: self string
 						classified: category
 						withStamp: stamp
 						notifying: nil ].
@@ -88,7 +88,7 @@ ChangeRecord >> fileIn [
 						ifFalse: [ self class compiler evaluate: s ] ].
 			type == #classComment
 				ifTrue:
-					[ (Smalltalk globals at: class asSymbol) comment: self text stamp: stamp ] ]
+					[ (Smalltalk globals at: class asSymbol) comment: self string stamp: stamp ] ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Ancient code artifacts and scriptures suggests that at some point in time, the compiler could have required the source code to be a stream.
It is not possible since some time (the parser takes a string before I even start to hack it) but some old clients still uselessly wrap the source code on a stream reader. Moreover, OpalCompiler host its source ivar as a stream, and internally only use its `contents`.

So this PR is mainly a cleanup

* OpalCompiler: use a String for its `source`
* many OpalCompiler clients: give String instead of a Stream.
* few clients: give String instead of a Text.

Commit 9865d55b9a5341d52837daf20d24413c15481565 will be removed in the final version of the PR.
I added it to force CT to catch possible missing clients.