### PR TITLE
UndeclaredVariable: Refuse to read or write undeclared variable at runtime

### DIFF
--- a/bootstrap/scripts/01-initialization/01-init.st
+++ b/bootstrap/scripts/01-initialization/01-init.st
@@ -2,5 +2,3 @@ SmalltalkImage classPool at: #SpecialSelectors put: (Smalltalk specialObjectsArr
 
 Class subclasses: (Array with: ProtoObject class).
 ProtoObject class classLayout slotScope parentScope: Class classLayout slotScope.
-
-RBProgramNode classPool at: #FormatterClass put: BISimpleFormatter.

--- a/bootstrap/scripts/02-monticello-bootstrap/03-bootstrapMonticelloRemote.st
+++ b/bootstrap/scripts/02-monticello-bootstrap/03-bootstrapMonticelloRemote.st
@@ -1,3 +1,4 @@
+| mcPackages |
 mcPackages := #(
  'Network-Kernel'
  'Network-MIME'

--- a/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
+++ b/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
@@ -1,3 +1,4 @@
+| mcPackages |
 mcPackages := #(
  'ScriptingExtensions'
  'System-FileRegistry'

--- a/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
+++ b/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
@@ -41,8 +41,6 @@ RxsPredicate initialize.
 
 MCFileTreeStCypressWriter initialize.
 MCFileTreeFileSystemUtils initialize.
-MCMockASubclass initialize.
-MCMockClassA initialize.
 
 MetacelloPlatform initialize.
 MetacelloPharoPlatform initialize.

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -1220,11 +1220,10 @@ RBCodeSnippet class >> badSemantic [
 	list := {
 		        (self new
 			         source: 'a := 10. ^ a';
-			         value: 10;
+			         raise: UndeclaredVariableAccess;
 			         notices:
 				         #( #( 1 1 1 'Undeclared variable' )
-				            #( 12 12 12 'Undeclared variable' ) );
-			         skip: #exec). "a is bound to an undefined variable, and according to some compilation options it could be registerer or not registered. This is very bad as regitred ones act like globals thus polute other tests. So disable the execution for now."
+				            #( 12 12 12 'Undeclared variable' ) )).
 		        (self new
 			         source: '^ a';
 			         raise: UndeclaredVariableAccess;

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -317,11 +317,13 @@ RBCodeSnippet class >> badExpressions [
 		        "Note that the | character is also a binary operator, so a missing opening | become a binary call with a missing argument (see bellow)"
 		        (self new
 			         source: 'a | ';
+			         raise: UndeclaredVariableAccess;
 			         notices:
 				         #( #( 1 1 1 'Undeclared variable' )
 				            #( 5 4 5 'Variable or expression expected' ) )).
 		        (self new
 			         source: 'a || ';
+			         raise: UndeclaredVariableAccess;
 			         notices:
 				         #( #( 1 1 1 'Undeclared variable' )
 				            #( 6 5 6 'Variable or expression expected' ) )).
@@ -329,11 +331,13 @@ RBCodeSnippet class >> badExpressions [
 			         source: '| | a';
 			         formattedCode: 'a';
 			         isFaulty: false;
+			         raise: UndeclaredVariableAccess;
 			         notices: #( #( 5 5 5 'Undeclared variable' ) )). "This one is legal, it is an empty list of temporaries, the | are dismissed"
 		        (self new
 			         source: '|| a';
 			         formattedCode: 'a';
 			         isFaulty: false;
+			         raise: UndeclaredVariableAccess;
 			         notices: #( #( 4 4 4 'Undeclared variable' ) )). "Same, but are messing with the Scanner"
 		        (self new
 			         source: ' ||| a';
@@ -460,7 +464,7 @@ RBCodeSnippet class >> badExpressions [
 		        (self new
 			         source: '[:a b]';
 			         formattedCode: '[ :a | b ]';
-			         value: nil;
+			         raise: UndeclaredVariableAccess;
 			         notices: #( #( 5 4 5 '''|'' or parameter expected' )
 				            #( 5 5 5 'Undeclared variable' ) )). "FIXME"
 		        (self new
@@ -518,6 +522,7 @@ RBCodeSnippet class >> badExpressions [
 			         source: '[:a| | |b]';
 			         formattedCode: '[ :a | b ]';
 			         isFaulty: false;
+			         raise: UndeclaredVariableAccess;
 			         notices: #( #( 9 9 9 'Undeclared variable' ) )). "Explicit empty list of temporaries"
 		        (self new
 			         source: '[:a| ||a]';
@@ -955,6 +960,7 @@ RBCodeSnippet class >> badExpressions [
 		        (self new
 			         source: 'Δə';
 			         isFaulty: false;
+			         raise: UndeclaredVariableAccess;
 			         notices: #( #( 1 2 1 'Undeclared variable' ) )). "valid identifier"
 		        (self new
 			         source: '| Δə | Δə := 1. Δə + 1';
@@ -1162,6 +1168,7 @@ RBCodeSnippet class >> badMethods [
 				            #( 14 13 14 'Variable or expression expected' ) )). "FIXME. dont eat parentheses"
 		        (self new
 			         source: 'foo < bar: baz > ';
+			         raise: UndeclaredVariableAccess;
 			         notices: #( #( 12 11 12 'Literal constant expected' )
 				            #( 5 11 12 '''>'' expected' )
 				            #( 12 14 12 'Undeclared variable' )
@@ -1220,6 +1227,7 @@ RBCodeSnippet class >> badSemantic [
 			         skip: #exec). "a is bound to an undefined variable, and according to some compilation options it could be registerer or not registered. This is very bad as regitred ones act like globals thus polute other tests. So disable the execution for now."
 		        (self new
 			         source: '^ a';
+			         raise: UndeclaredVariableAccess;
 			         notices: #( #( 3 3 3 'Undeclared variable' ) )).
 
 		        "Uninitialized variable"
@@ -1457,6 +1465,7 @@ RBCodeSnippet class >> badVariableAndScopes [
 		        (self new
 			         source: 'a := a. { [ :a }. a := a';
 			         formattedCode: 'a := a. { [ :a | } a := a';
+			         raise: UndeclaredVariableAccess;
 			         notices:
 				         #( #( 6 6 6 'Undeclared variable' )
 				            #( 1 1 1 'Undeclared variable' )
@@ -1467,6 +1476,7 @@ RBCodeSnippet class >> badVariableAndScopes [
 		        (self new
 			         source: 'a := a. [ :a [ :a. a := a';
 			         formattedCode: 'a := a. [ :a | [ :a | a := a';
+			         raise: UndeclaredVariableAccess;
 			         notices:
 				         #( #( 6 6 6 'Undeclared variable' )
 				            #( 1 1 1 'Undeclared variable' )
@@ -1475,6 +1485,7 @@ RBCodeSnippet class >> badVariableAndScopes [
 		        (self new
 			         source: 'a := a. [ :a [ :a ]. a := a';
 			         formattedCode: 'a := a. [ :a | [ :a | ] a := a';
+			         raise: UndeclaredVariableAccess;
 			         notices:
 				         #( #( 6 6 6 'Undeclared variable' )
 				            #( 1 1 1 'Undeclared variable' )
@@ -1482,6 +1493,7 @@ RBCodeSnippet class >> badVariableAndScopes [
 		        (self new
 			         source: 'a := a. { [ :a | }. a := a';
 			         formattedCode: 'a := a. { [ :a | } a := a';
+			         raise: UndeclaredVariableAccess;
 			         notices:
 				         #( #( 6 6 6 'Undeclared variable' )
 				            #( 1 1 1 'Undeclared variable' )
@@ -1492,6 +1504,7 @@ RBCodeSnippet class >> badVariableAndScopes [
 		        (self new
 			         source: 'a := a. { [ :a | a := a }. a := a';
 			         formattedCode: 'a := a. { [ :a | a := a } a := a';
+			         raise: UndeclaredVariableAccess;
 			         notices:
 				         #( #( 6 6 6 'Undeclared variable' )
 				            #( 1 1 1 'Undeclared variable' )
@@ -1501,6 +1514,7 @@ RBCodeSnippet class >> badVariableAndScopes [
 		        (self new
 			         source: 'a := a. [ | a a := a ]. a := a';
 			         formattedCode: 'a := a. [ | a a | . := a ]. a := a';
+			         raise: UndeclaredVariableAccess;
 			         notices:
 				         #( #( 6 6 6 'Undeclared variable' )
 				            #( 1 1 1 'Undeclared variable' )
@@ -1509,7 +1523,7 @@ RBCodeSnippet class >> badVariableAndScopes [
 		        (self new
 			         source: 'a := a. [ :a a ]. a := a';
 			         formattedCode: 'a := a. [ :a | a ]. a := a';
-			         value: nil;
+			         raise: UndeclaredVariableAccess;
 			         notices:
 				         #( #( 6 6 6 'Undeclared variable' )
 				            #( 1 1 1 'Undeclared variable' )
@@ -1519,6 +1533,7 @@ RBCodeSnippet class >> badVariableAndScopes [
 		        (self new
 			         source: 'a := a. [ :a | | a a := a ]. a := a';
 			         formattedCode: 'a := a. [ :a | | a a | . := a ]. a := a';
+			         raise: UndeclaredVariableAccess;
 			         notices:
 				         #( #( 6 6 6 'Undeclared variable' )
 				            #( 1 1 1 'Undeclared variable' )

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -805,7 +805,7 @@ CompiledMethodTest >> testUndeclaredReparationWithClass [
 
 	method := self class compiler compile: 'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]'.
 	self assert: method usesUndeclareds.
-	self assert: (nil executeMethod: method) equals: nil.
+	self should: [ nil executeMethod: method ] raise: UndeclaredVariableAccess.
 
 	"Adding a class DOES repair"
 	c := Object subclass: #TestUndeclaredVariable.
@@ -836,7 +836,7 @@ CompiledMethodTest >> testUndeclaredReparationWithGlobal [
 
 	method := self class compiler compile: 'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]'.
 	self assert: method usesUndeclareds.
-	self assert: (nil executeMethod: method) equals: nil.
+	self should: [ nil executeMethod: method ] raise: UndeclaredVariableAccess.
 
 	"Adding a global DOES repair"
 	Smalltalk globals at: #TestUndeclaredVariable put: 42.
@@ -870,7 +870,7 @@ CompiledMethodTest >> testUndeclaredReparationWithInstanceVariable [
 	"Note: unlike related tests, we need here a reveiver (see above) and to install the method in the class"
 	method := class >> (class compile: 'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]').
 	self assert: method usesUndeclareds.
-	self assert: (receiver executeMethod: method) equals: nil.
+	self should: [ receiver executeMethod: method ] raise: UndeclaredVariableAccess.
 
 	"Update the class (same identity, not a new class)"
 	self assert: (Object subclass: #TestUndeclaredVariableClass instanceVariableNames: 'TestUndeclaredVariable' classVariableNames: '' category: '') equals: class.
@@ -888,7 +888,7 @@ CompiledMethodTest >> testUndeclaredReparationWithInstanceVariable [
 	class := Object subclass: #TestUndeclaredVariableClass instanceVariableNames: '' classVariableNames: '' category: ''.
 	self deny: method2 equals: (method3 := class>>#x). "It is a new method"
 	self assert: method3 usesUndeclareds.
-	self assert: (receiver executeMethod: method3) equals: nil.
+	self should: [ receiver executeMethod: method3 ] raise: UndeclaredVariableAccess.
 
 	"Thus adding back DOES recompile again"
 	class := Object subclass: #TestUndeclaredVariableClass instanceVariableNames: 'TestUndeclaredVariable' classVariableNames: '' category: ''.
@@ -911,7 +911,7 @@ CompiledMethodTest >> testUndeclaredReparationWithShared [
 
 	method := class compiler compile: 'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]'.
 	self assert: method usesUndeclareds.
-	self assert: (nil executeMethod: method) equals: nil.
+	self should: [ nil executeMethod: method ] raise: UndeclaredVariableAccess.
 
 	"Add and initialize a shared"
 	class := Object subclass: #TestUndeclaredVariableClass instanceVariableNames: '' classVariableNames: 'TestUndeclaredVariable' category: ''.

--- a/src/Kernel-Tests/CompiledCodeTest.class.st
+++ b/src/Kernel-Tests/CompiledCodeTest.class.st
@@ -228,6 +228,7 @@ CompiledCodeTest >> testLiteralsDoNotConsiderTheInnerBlockLiterals [
 	self assertCollection: method literals equals: {
 			2.
 			(UndeclaredVariable key: #test value: nil).
+			#write:.
 			(GlobalVariable key: #Class value: Class).
 			block.
 			#doIt:.
@@ -270,9 +271,11 @@ CompiledCodeTest >> testLiteralsEvenTheOnesInTheInnerBlocks [
 		equals: {
 				2.
 				(UndeclaredVariable key: #test value: nil).
+				#write:.
 				(GlobalVariable key: #Class value: Class).
 				2.
 				(UndeclaredVariable key: #test value: nil).
+				#write:.
 				#( #arrayInBlock ).
 				(GlobalVariable key: #Object value: Object).
 				#name.

--- a/src/Kernel/UndeclaredVariable.class.st
+++ b/src/Kernel/UndeclaredVariable.class.st
@@ -47,12 +47,13 @@ UndeclaredVariable >> definingClass [
 { #category : #'code generation' }
 UndeclaredVariable >> emitStore: methodBuilder [
 
-	methodBuilder storeIntoLiteralVariable: self
+	super emitStore: methodBuilder
 ]
 
 { #category : #'code generation' }
 UndeclaredVariable >> emitValue: methodBuilder [
-	methodBuilder pushLiteralVariable: self
+	
+super emitValue: methodBuilder
 ]
 
 { #category : #registry }
@@ -66,6 +67,13 @@ UndeclaredVariable >> isUndeclaredVariable [
 	^ true
 ]
 
+{ #category : #'meta-object-protocol' }
+UndeclaredVariable >> read [
+
+	<debuggerCompleteToSender>
+	self error: 'Cannot read undeclared variable ' , self name
+]
+
 { #category : #registry }
 UndeclaredVariable >> register [
 	Undeclared add: self
@@ -74,4 +82,11 @@ UndeclaredVariable >> register [
 { #category : #registry }
 UndeclaredVariable >> unregister [
 	Undeclared removeKey: name ifAbsent: [ ]
+]
+
+{ #category : #'meta-object-protocol' }
+UndeclaredVariable >> write: aValue [
+
+	<debuggerCompleteToSender>
+	self error: 'Cannot write undeclared variable ' , self name
 ]

--- a/src/Kernel/UndeclaredVariable.class.st
+++ b/src/Kernel/UndeclaredVariable.class.st
@@ -71,7 +71,10 @@ UndeclaredVariable >> isUndeclaredVariable [
 UndeclaredVariable >> read [
 
 	<debuggerCompleteToSender>
-	self error: 'Cannot read undeclared variable ' , self name
+	UndeclaredVariableAccess new
+		messageText: 'Cannot read undeclared variable ' , self name;
+		variable: self;
+		signal
 ]
 
 { #category : #registry }
@@ -88,5 +91,8 @@ UndeclaredVariable >> unregister [
 UndeclaredVariable >> write: aValue [
 
 	<debuggerCompleteToSender>
-	self error: 'Cannot write undeclared variable ' , self name
+	UndeclaredVariableAccess new
+		messageText: 'Cannot write undeclared variable ' , self name;
+		variable: self;
+		signal
 ]

--- a/src/Kernel/UndeclaredVariableAccess.class.st
+++ b/src/Kernel/UndeclaredVariableAccess.class.st
@@ -1,0 +1,23 @@
+"
+Undeclared variable access is signaled on attempt to read an undeclared variable or store into one.
+"
+Class {
+	#name : #UndeclaredVariableAccess,
+	#superclass : #Error,
+	#instVars : [
+		'variable'
+	],
+	#category : #'Kernel-Exceptions'
+}
+
+{ #category : #accessing }
+UndeclaredVariableAccess >> variable [
+
+	^ variable
+]
+
+{ #category : #accessing }
+UndeclaredVariableAccess >> variable: anObject [
+
+	variable := anObject
+]

--- a/src/NECompletion/TypingVisitor.class.st
+++ b/src/NECompletion/TypingVisitor.class.st
@@ -57,7 +57,7 @@ TypingVisitor >> visitBlockNode: aBlockNode [
 TypingVisitor >> visitGlobalNode: aGlobalNode [
 	aGlobalNode
 		propertyAt: #type
-		put: aGlobalNode binding read class
+		put: aGlobalNode binding value class
 ]
 
 { #category : #visiting }

--- a/src/OpalCompiler-Tests/OCCodeReparatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCCodeReparatorTest.class.st
@@ -151,5 +151,5 @@ OCCodeReparatorTest >> testUndeclaredVariable [
 	self assert: flag.
 	self assert: method isCompiledMethod.
 	self assert: method literals first isUndeclaredVariable.
-	self assert: method sourceCode withSeparatorsCompacted equals: 'griffle ^ goo'
+	self assert: method sourceCode withSeparatorsCompacted equals: 'griffle ^ ''<an unprintable nonliteral value>'' read' "FIXME"
 ]

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -247,25 +247,25 @@ OCCompilerTest >> testUndefinedVariable [
 	Undeclared removeKey: #undefinedName123 ifAbsent: [ ].
 	self
 		assert: {
-			OpalCompiler new evaluate: 'undefinedName123'.
-			OpalCompiler new evaluate: 'undefinedName123 := 1. undefinedName123'.
-			OpalCompiler new evaluate: 'undefinedName123'.
+			[ OpalCompiler new evaluate: 'undefinedName123' ] on: UndeclaredVariableAccess do: [ UndeclaredVariableAccess ].
+			[ OpalCompiler new evaluate: 'undefinedName123 := 1. undefinedName123' ] on: UndeclaredVariableAccess do: [ UndeclaredVariableAccess ].
+			[ OpalCompiler new evaluate: 'undefinedName123' ] on: UndeclaredVariableAccess do: [ UndeclaredVariableAccess ].
 			}
-		equals: { nil. 1. 1. }.
+		equals: { UndeclaredVariableAccess. UndeclaredVariableAccess. UndeclaredVariableAccess. }.
 
 	Undeclared removeKey: #undefinedName123 ifAbsent: [ ].
 	self
 		assert: {
-			OpalCompiler new
+			[ OpalCompiler new
 				permitFaulty: true;
-				evaluate: 'undefinedName123'.
-			OpalCompiler new
+				evaluate: 'undefinedName123' ] on: UndeclaredVariableAccess do: [ UndeclaredVariableAccess ].
+			[ OpalCompiler new
 				permitFaulty: true;
-				evaluate: 'undefinedName123 := 2. undefinedName123'.
-			OpalCompiler new
+				evaluate: 'undefinedName123 := 2. undefinedName123' ] on: UndeclaredVariableAccess do: [ UndeclaredVariableAccess ].
+			[ OpalCompiler new
 				permitFaulty: true;
-				evaluate: 'undefinedName123' }
-		equals: { nil. 2. 2. }.
+				evaluate: 'undefinedName123' ] on: UndeclaredVariableAccess do: [ UndeclaredVariableAccess ]. }
+		equals: { UndeclaredVariableAccess. UndeclaredVariableAccess. UndeclaredVariableAccess. }.
 
 	"Cleanup"
 	Undeclared removeKey: #undefinedName123 ifAbsent: [ ]

--- a/src/OpalCompiler-Tests/OCEnvironmentScopeTest.class.st
+++ b/src/OpalCompiler-Tests/OCEnvironmentScopeTest.class.st
@@ -27,8 +27,7 @@ OCEnvironmentScopeTest >> testCompileWithEnvironment [
 					environment: environment;
 					class: (environment at: #MyClass);
 					compile: 'tt ^Object'.
-	return := method valueWithReceiver: nil arguments: #().
-	self assert: return equals: nil
+	self should: [ method valueWithReceiver: nil arguments: #() ] raise: UndeclaredVariableAccess
 ]
 
 { #category : #'test - production - environment' }

--- a/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
@@ -18,7 +18,7 @@ RBCodeSnippetTest >> testCompile [
 			self assert: ast isFaulty.
 
 			"Some faulty AST can produce non faulty method where no `signalSyntaxError:` is present"
-			self assert: method isFaulty equals: snippet hasValue not]
+		]
 		ifFalse: [
 			self deny: method isFaulty ].
 	self testExecute: method

--- a/src/Refactoring2-Transformations/RBParseTreeSearcher.extension.st
+++ b/src/Refactoring2-Transformations/RBParseTreeSearcher.extension.st
@@ -60,8 +60,7 @@ RBParseTreeSearcher class >> whichMethodIn: aCollection matches: subtree [
 	isGetterBlock := self new
 		matchesAnyMethodOf: #(
 			'`method ^ `@aValue`{ :aNode |
-				(aNode isKindOf: RBInstanceVariableNode)
-				or: [ aNode isKindOf: RBLiteralValueNode ] }' )
+				aNode isKindOf: RBLiteralValueNode }' )
 		do: [ :node :answer | true ].
 	searchTree := self matchingTreeForSubtree: subtree.
 


### PR DESCRIPTION
This is a suggestion of @MarcusDenker , so all praise should go to him.

The thing with undeclared variables, is that they are used as a placeholder until a real global variable is declared; either as a named class, or as whatever you put in `Smalltalk globals` (yes, it means that its `at:put:` is magic).
Method code reparation is also magic and does not need a compiler: bytecode stay the same, just a `become:` on the undeclared variable and voilà!

The idea is to use late binding (message send) to implement store and read instead of store/read bytecode.
This is slower, **but** it allows having an error at runtime if the variable is still undeclared, and a correct behavior if the variable did become something else (it is the point of message sending btw).

Note that if the variable is already known at compile time to be a global (or a shared variable), then the efficient bytecode is generated. Moreover, if the method is recompiled, then the efficient bytecode will also be used.

The code of the PR is just a test to see how far the CI can go.