### PR TITLE
Inline some protocol organizer behavior

### DIFF
--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -63,7 +63,7 @@ ClassOrganization >> classComment: aString [
 ClassOrganization >> classify: selector under: aProtocolName [
 
 	| oldProtocolName forceNotify oldProtocols |
-	forceNotify := (self protocolOrganizer includesSelector: selector) not.
+	forceNotify := (self includesSelector: selector) not.
 	oldProtocolName := self protocolNameOfElement: selector.
 	(forceNotify or: [ oldProtocolName ~= aProtocolName or: [ aProtocolName ~= Protocol unclassified ] ]) ifFalse: [ ^ self ].
 	oldProtocols := self protocolOrganizer protocolsOfSelector: selector.
@@ -132,6 +132,12 @@ ClassOrganization >> hasOrganizedClass [
 ClassOrganization >> hasProtocolNamed: aString [
 
 	^ self allProtocols anySatisfy: [ :each | each name = aString ]
+]
+
+{ #category : #testing }
+ClassOrganization >> includesSelector: selector [
+
+	^ self protocols anySatisfy: [ :each | each includesSelector: selector ]
 ]
 
 { #category : #initialization }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -291,7 +291,7 @@ ClassOrganization >> removeProtocolIfEmpty: protocolName [
 { #category : #accessing }
 ClassOrganization >> removeProtocolNamed: protocolName [
 
-	self removeProtocol: (self protocolNamed: protocolName ifAbsent: [ ^ self ])
+	^ self removeProtocol: (self protocolNamed: protocolName ifAbsent: [ ^ self ])
 ]
 
 { #category : #removing }
@@ -315,7 +315,16 @@ ClassOrganization >> setSubject: anObject [
 { #category : #private }
 ClassOrganization >> silentlyRenameProtocolNamed: oldName toBe: newName [
 
-	self protocolOrganizer renameProtocol: oldName into: newName
+	(self hasProtocolNamed: oldName) ifFalse: [ ^ self ].
+
+	(self hasProtocolNamed: newName)
+		ifTrue: [
+			self protocolOrganizer moveMethodsFrom: oldName to: newName.
+			self removeProtocolNamed: oldName ]
+		ifFalse: [
+			^ (self protocolNamed: oldName)
+				  name: newName;
+				  yourself ]
 ]
 
 { #category : #'backward compatibility' }

--- a/src/Kernel/ProtocolOrganizer.class.st
+++ b/src/Kernel/ProtocolOrganizer.class.st
@@ -73,11 +73,6 @@ ProtocolOrganizer >> hasProtocolNamed: aString [
 	^ self allProtocols anySatisfy: [ :each | each name = aString ]
 ]
 
-{ #category : #testing }
-ProtocolOrganizer >> includesSelector: selector [
-	^ protocols anySatisfy: [ :each | each includesSelector: selector ]
-]
-
 { #category : #initialization }
 ProtocolOrganizer >> initialize [
 	super initialize.

--- a/src/Kernel/ProtocolOrganizer.class.st
+++ b/src/Kernel/ProtocolOrganizer.class.st
@@ -45,12 +45,13 @@ ProtocolOrganizer >> allProtocols [
 
 { #category : #'protocol - adding' }
 ProtocolOrganizer >> classify: aSymbol inProtocolNamed: aProtocolName [
+
 	| name protocol |
 	name := aProtocolName.
 	name = allProtocol name ifTrue: [ name := Protocol unclassified ].
 
 	"maybe here we should check if this method already belong to another protocol"
-	(self protocolsOfSelector: aSymbol) do: [ :p | p removeMethodSelector: aSymbol ].
+	self removeMethod: aSymbol.
 	protocol := self protocolNamed: name ifAbsent: [ self addProtocolNamed: name ].
 
 	protocol addMethodSelector: aSymbol

--- a/src/Kernel/ProtocolOrganizer.class.st
+++ b/src/Kernel/ProtocolOrganizer.class.st
@@ -57,12 +57,6 @@ ProtocolOrganizer >> classify: aSymbol inProtocolNamed: aProtocolName [
 	protocol addMethodSelector: aSymbol
 ]
 
-{ #category : #private }
-ProtocolOrganizer >> existsProtocolNamed: aProtocolName [
-
-	^self allProtocols anySatisfy: [ :e | e name = aProtocolName ]
-]
-
 { #category : #accessing }
 ProtocolOrganizer >> extensionProtocols [
 	^ self protocols select: #isExtensionProtocol
@@ -126,12 +120,6 @@ ProtocolOrganizer >> protocolsOfSelector: aSelector [
 	^ (self protocols select: [:each | each includesSelector: aSelector ]) asArray
 ]
 
-{ #category : #protocol }
-ProtocolOrganizer >> protocolsSorted [
-	^ (self protocols collect: #name as: Array) sort
-		copyWithFirst: allProtocol name
-]
-
 { #category : #'protocol - removing' }
 ProtocolOrganizer >> removeEmptyProtocols [
 	| removedProtocols |
@@ -159,21 +147,6 @@ ProtocolOrganizer >> removeProtocol: aProtocol [
 ProtocolOrganizer >> removeProtocolNamed: aName [
 
 	^ self removeProtocol: (self protocolNamed: aName ifAbsent: [ ^ self ])
-]
-
-{ #category : #accessing }
-ProtocolOrganizer >> renameProtocol: oldName into: newName [
-
-	(self hasProtocolNamed: oldName) ifFalse: [ ^ self ].
-
-	(self existsProtocolNamed: newName)
-		ifTrue: [
-			self moveMethodsFrom: oldName to: newName.
-			self removeProtocolNamed: oldName ]
-		ifFalse: [
-			^ (self protocolNamed: oldName)
-				  name: newName;
-				  yourself ]
 ]
 
 { #category : #initialization }

--- a/src/Rubric/RubPluggableTextMorphExample.class.st
+++ b/src/Rubric/RubPluggableTextMorphExample.class.st
@@ -18,12 +18,12 @@ Class {
 
 { #category : #'source code area' }
 RubPluggableTextMorphExample >> accept: source notifying: aController [
+
 	| p result |
-	self selectedClass ifNil: [ ^self ].
-	p := self selectedClass organization protocolOrganizer protocolsOfSelector: self selector.
-	p := p ifEmpty: [ Protocol unclassified ] ifNotEmpty: [p anyOne name].
+	self selectedClass ifNil: [ ^ self ].
+	p := (self selectedClass >> self selector) protocol ifNil: [ Protocol unclassified ].
 	result := self selectedClass compile: source classified: p notifying: aController.
-	result ifNotNil: [self changed: #clearUserEdits ].
+	result ifNotNil: [ self changed: #clearUserEdits ].
 	^ result
 ]
 


### PR DESCRIPTION
Since https://github.com/pharo-project/pharo/pull/13187 is failing the CI build without explicit error, this is a sub set. 

It reduces the exposition of the protocol organizer and inline some of its behavior into class organization.
It also removes dead code