### PR TITLE
Bootstrap scripts: do not use undeclared variables

### DIFF
--- a/bootstrap/scripts/01-initialization/01-init.st
+++ b/bootstrap/scripts/01-initialization/01-init.st
@@ -2,5 +2,3 @@ SmalltalkImage classPool at: #SpecialSelectors put: (Smalltalk specialObjectsArr
 
 Class subclasses: (Array with: ProtoObject class).
 ProtoObject class classLayout slotScope parentScope: Class classLayout slotScope.
-
-RBProgramNode classPool at: #FormatterClass put: BISimpleFormatter.

--- a/bootstrap/scripts/02-monticello-bootstrap/03-bootstrapMonticelloRemote.st
+++ b/bootstrap/scripts/02-monticello-bootstrap/03-bootstrapMonticelloRemote.st
@@ -1,3 +1,4 @@
+| mcPackages |
 mcPackages := #(
  'Network-Kernel'
  'Network-MIME'

--- a/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
+++ b/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
@@ -1,3 +1,4 @@
+| mcPackages |
 mcPackages := #(
  'ScriptingExtensions'
  'System-FileRegistry'

--- a/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
+++ b/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
@@ -41,8 +41,6 @@ RxsPredicate initialize.
 
 MCFileTreeStCypressWriter initialize.
 MCFileTreeFileSystemUtils initialize.
-MCMockASubclass initialize.
-MCMockClassA initialize.
 
 MetacelloPlatform initialize.
 MetacelloPharoPlatform initialize.


### PR DESCRIPTION
#13189 showed that early bootstrap used undeclared variables in some `.st` files, either as temporary variables (bad!) or as dead classes. Their removal (or displacement in other packages unrequired by the bootstrap) did not cause direct visible bugs in the bootstrap, so CI went fine, and cruft were left over.