### PR TITLE
Remove some unecessary not from the kernel

### DIFF
--- a/src/Kernel-Tests-WithCompiler/SelfEvaluatingObjectTest.class.st
+++ b/src/Kernel-Tests-WithCompiler/SelfEvaluatingObjectTest.class.st
@@ -31,17 +31,20 @@ SelfEvaluatingObjectTest >> testObjects [
 	self assert: 10 isSelfEvaluating.
 	self assert: $a isSelfEvaluating.
 	self assert: 3.14157 isSelfEvaluating.
-	self assert: #(1 2 3) isSelfEvaluating.
+	self assert: #( 1 2 3 ) isSelfEvaluating.
 	self assert: #abc isSelfEvaluating.
 	self assert: 'abc' isSelfEvaluating.
 
 	self assert: Object isSelfEvaluating.
-	self assert: Object new isSelfEvaluating not.
+	self deny: Object new isSelfEvaluating.
 
-	self assert: {Float infinity . Float nan. Float infinity negated} isSelfEvaluating.
+	self assert: {
+			Float infinity.
+			Float nan.
+			Float infinity negated } isSelfEvaluating.
 
 	self assert: (Array with: 10) isSelfEvaluating.
-	self assert: (Array with: Object new) isSelfEvaluating not.
+	self deny: (Array with: Object new) isSelfEvaluating.
 
 	self assert: true isSelfEvaluating.
 	self assert: false isSelfEvaluating.
@@ -49,6 +52,6 @@ SelfEvaluatingObjectTest >> testObjects [
 	self assert: nil isSelfEvaluating.
 
 	self assert: (1 to: 10) isSelfEvaluating.
-	self assert: (1->2) isSelfEvaluating.
+	self assert: (1 -> 2) isSelfEvaluating.
 	self assert: Color red isSelfEvaluating
 ]

--- a/src/Kernel-Tests/ClassDefinitionPrinterConfigurationTest.class.st
+++ b/src/Kernel-Tests/ClassDefinitionPrinterConfigurationTest.class.st
@@ -50,5 +50,5 @@ ClassDefinitionPrinterConfigurationTest >> testToggleIsWorking [
 	| value |
 	value := ClassDefinitionPrinter showFluidClassDefinition.
 	ClassDefinitionPrinter toggleShowFluidClassDefinition.
-	self assert: ClassDefinitionPrinter showFluidClassDefinition equals: value not
+	self deny: ClassDefinitionPrinter showFluidClassDefinition equals: value
 ]

--- a/src/Kernel-Tests/ClassHierarchyTest.class.st
+++ b/src/Kernel-Tests/ClassHierarchyTest.class.st
@@ -35,15 +35,14 @@ ClassHierarchyTest >> testObjectFormatInstSize [
 
 { #category : #tests }
 ClassHierarchyTest >> testSubclassInstVar [
+
 	| subclasses |
-	SystemNavigation new
-		allClassesDo: [ :cls |
-			subclasses := cls subclasses.
-			self assert: subclasses isNil not.
-			subclasses
-				do: [ :subclass |
-					self assert: (subclasses occurrencesOf: subclass) equals: 1.
-					self assert: subclass superclass identicalTo: cls ] ]
+	SystemNavigation new allClassesDo: [ :cls |
+		subclasses := cls subclasses.
+		self deny: subclasses isNil.
+		subclasses do: [ :subclass |
+			self assert: (subclasses occurrencesOf: subclass) equals: 1.
+			self assert: subclass superclass identicalTo: cls ] ]
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/DateTest.class.st
+++ b/src/Kernel-Tests/DateTest.class.st
@@ -220,7 +220,6 @@ DateTest >> testEqual [
 DateTest >> testEquals [
 
 	| tzm8 tzp10 |
-
 	tzm8 := january23rd2004 translateTo: -8 hours.
 	tzp10 := january23rd2004 translateTo: 10 hours.
 
@@ -228,7 +227,7 @@ DateTest >> testEquals [
 		assert: (january23rd2004 equals: tzm8);
 		assert: (january23rd2004 equals: tzp10);
 		assert: (tzm8 equals: tzp10);
-		assert: (january23rd2004 equals: june2nd1973) not
+		deny: (january23rd2004 equals: june2nd1973)
 ]
 
 { #category : #tests }
@@ -304,28 +303,24 @@ DateTest >> testInquiries [
 DateTest >> testIsAfter [
 
 	| tzm8 tzp10 |
-
 	tzm8 := january23rd2004 translateTo: -8 hours.
 	tzp10 := january23rd2004 translateTo: 10 hours.
-
 	self
-		assert: (tzp10 isAfter: tzm8) not;
+		deny: (tzp10 isAfter: tzm8);
 		assert: (january23rd2004 isAfter: june2nd1973);
-		assert: (june2nd1973 isAfter: june2nd1973) not
+		deny: (june2nd1973 isAfter: june2nd1973)
 ]
 
 { #category : #tests }
 DateTest >> testIsBefore [
 
 	| tzm8 tzp10 |
-
 	tzm8 := january23rd2004 translateTo: -8 hours.
 	tzp10 := january23rd2004 translateTo: 10 hours.
-
 	self
-		assert: (tzm8 isBefore: tzp10) not;
+		deny: (tzm8 isBefore: tzp10);
 		assert: (june2nd1973 isBefore: january23rd2004);
-		assert: (june2nd1973 isBefore: june2nd1973) not
+		deny: (june2nd1973 isBefore: june2nd1973)
 ]
 
 { #category : #tests }
@@ -342,13 +337,12 @@ DateTest >> testIsLeapYear [
 DateTest >> testIsOnOrAfter [
 
 	| tzm8 tzp10 |
-
 	tzm8 := january23rd2004 translateTo: -8 hours.
 	tzp10 := january23rd2004 translateTo: 10 hours.
 
 	self
 		assert: (tzp10 isOnOrAfter: tzm8);
-		assert: (june2nd1973 isOnOrAfter: january23rd2004) not;
+		deny: (june2nd1973 isOnOrAfter: january23rd2004);
 		assert: (june2nd1973 isOnOrAfter: june2nd1973);
 		assert: (january23rd2004 isOnOrAfter: june2nd1973)
 ]
@@ -357,7 +351,6 @@ DateTest >> testIsOnOrAfter [
 DateTest >> testIsOnOrBefore [
 
 	| tzm8 tzp10 |
-
 	tzm8 := january23rd2004 translateTo: -8.
 	tzp10 := january23rd2004 translateTo: 10.
 
@@ -365,7 +358,7 @@ DateTest >> testIsOnOrBefore [
 		assert: (tzm8 isOnOrBefore: tzp10);
 		assert: (june2nd1973 isOnOrBefore: january23rd2004);
 		assert: (june2nd1973 isOnOrBefore: june2nd1973);
-		assert: (january23rd2004 isOnOrBefore: june2nd1973) not
+		deny: (january23rd2004 isOnOrBefore: june2nd1973)
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/MagnitudeTest.class.st
+++ b/src/Kernel-Tests/MagnitudeTest.class.st
@@ -27,9 +27,10 @@ MagnitudeTest >> testBeBetweenAnd [
 
 { #category : #tests }
 MagnitudeTest >> testBetweenAnd [
+
 	self assert: (3 between: 0 and: 5).
 	self assert: (5.0 between: 5.0 and: 5.0).
-	self assert: (Date today between: Date today +1 and: Date today +3) not
+	self deny: (Date today between: Date today + 1 and: Date today + 3)
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/ProcessTerminateBugTest.class.st
+++ b/src/Kernel-Tests/ProcessTerminateBugTest.class.st
@@ -9,21 +9,22 @@ Class {
 
 { #category : #tests }
 ProcessTerminateBugTest >> testSchedulerTermination [
+
 	| process sema gotHere sema2 |
 	gotHere := false.
 	sema := Semaphore new.
 	sema2 := Semaphore new.
 	process := [
-		sema signal.
-		sema2 wait.
-		"will be suspended here"
-		gotHere := true. "e.g., we must *never* get here" ] forkAt: Processor activeProcess priority.
+	           sema signal.
+	           sema2 wait.
+	           "will be suspended here"
+	           gotHere := true "e.g., we must *never* get here" ] forkAt: Processor activeProcess priority.
 	sema wait. "until process gets scheduled"
- 	process terminate.
+	process terminate.
 	sema2 signal.
 	Processor yield. "will give process a chance to continue and
 horribly screw up"
-	self assert: gotHere not
+	self deny: gotHere
 ]
 
 { #category : #tests }

--- a/src/Kernel/Float.class.st
+++ b/src/Kernel/Float.class.st
@@ -730,8 +730,8 @@ Float >> asMinimalDecimalFraction [
 	shead := s bitShift: slowbit.
 	[d := (r bitShift: slowbit) // shead.
 	r := r - (d * s).
-	(tc1 := (r > mMinus) not and: [roundingIncludesLimits or: [r < mMinus]]) |
-	(tc2 := (r + mPlus < s) not and: [roundingIncludesLimits or: [r + mPlus > s]])] whileFalse:
+	(tc1 := r <= mMinus and: [roundingIncludesLimits or: [r < mMinus]]) |
+	(tc2 := r + mPlus >= s and: [roundingIncludesLimits or: [r + mPlus > s]])] whileFalse:
 		[numerator := 10 * numerator + d.
 		denominator := 10 * denominator.
 		r := r * 10.

--- a/src/Kernel/PackageManifest.class.st
+++ b/src/Kernel/PackageManifest.class.st
@@ -30,7 +30,8 @@ PackageManifest class >> isDeprecated [
 
 { #category : #testing }
 PackageManifest class >> isManifest [
-	^ (self = PackageManifest) not
+
+	^ self ~= PackageManifest
 ]
 
 { #category : #'System-Support' }


### PR DESCRIPTION
Sometimes we use not when a more readable way exist.

For example instead of having `(a > b) not` it is easier to read `a <= b` since it required only one step in our thoughts. Or also, `self assert: a not` can just be `self deny: a`

This commit reduces the number of unecessary not in the kernel to help with readability. Sorry if it reformat things but I did that with a script