### PR TITLE
Remove RBInstanceVariableNode crufts

### DIFF
--- a/src/Refactoring2-Transformations/RBParseTreeSearcher.extension.st
+++ b/src/Refactoring2-Transformations/RBParseTreeSearcher.extension.st
@@ -58,10 +58,7 @@ RBParseTreeSearcher class >> whichMethodIn: aCollection matches: subtree [
 
 	| isGetterBlock searchTree |
 	isGetterBlock := self new
-		matchesAnyMethodOf: #(
-			'`method ^ `@aValue`{ :aNode |
-				(aNode isKindOf: RBInstanceVariableNode)
-				or: [ aNode isKindOf: RBLiteralValueNode ] }' )
+		matchesAnyMethodOf: #( '`method ^ `@aValue`{ :aNode | aNode isKindOf: RBLiteralValueNode }' )
 		do: [ :node :answer | true ].
 	searchTree := self matchingTreeForSubtree: subtree.
 

--- a/src/Reflectivity/RFReification.class.st
+++ b/src/Reflectivity/RFReification.class.st
@@ -107,11 +107,6 @@ RFReification >> genForRBGlobalNode [
 ]
 
 { #category : #generate }
-RFReification >> genForRBInstanceVariableNode [
-	^self genForRBVariableNode
-]
-
-{ #category : #generate }
 RFReification >> genForRBLiteralArrayNode [
 	^self genForRBProgramNode
 ]


### PR DESCRIPTION
#13189 shows that some leftover from a presumably removed class RBInstanceVariableNode remains, and was not detected because used in an evaluated string — eval is evil :)

Some method `visitInstanceVariableNode:` did still exist with a parameter named `aRBInstanceVariableNode` but I think they are still used via `Slot>>#acceptVisitor:node:`. I'm not sure, so I do not touch