### PR TITLE
This commit simplifies some conditionals using `isEmpty` followed by an #ifTrue:[ifFalse:]

### DIFF
--- a/src/Kernel-Chronology-Extras/Stopwatch.class.st
+++ b/src/Kernel-Chronology-Extras/Stopwatch.class.st
@@ -25,14 +25,14 @@ Stopwatch >> duration [
 
 	| ts last |
 	self isSuspended
-		ifTrue:
-			[ (ts := self timespans) isEmpty ifTrue:
-				[ ts := { Timespan starting: DateAndTime now duration: Duration zero } ] ]
-		ifFalse:
-			[ last := self timespans last.
+		ifTrue: [ (ts := self timespans) ifEmpty: [ ts := { (Timespan starting: DateAndTime now duration: Duration zero) } ] ]
+		ifFalse: [
+			last := self timespans last.
 			ts := self timespans allButLast
-				add: (last duration: (DateAndTime now - last start); yourself);
-				yourself ].
+				      add: (last
+						       duration: DateAndTime now - last start;
+						       yourself);
+				      yourself ].
 
 	^ (ts collect: [ :t | t duration ]) sum
 ]

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -838,21 +838,18 @@ Class >> removeClassVarNamed: aString interactive: interactive [
 
 	| aSymbol varUserClass |
 	aSymbol := aString asSymbol.
-	(self classPool includesKey: aSymbol)
-		ifFalse: [ ^ self error: aString , ' is not a class variable' ].
+	(self classPool includesKey: aSymbol) ifFalse: [ ^ self error: aString , ' is not a class variable' ].
 	varUserClass := self anyUserOfClassVarNamed: aSymbol.
 	varUserClass notNil & interactive ifTrue: [
-		(self	confirm: (aString , ' is still used in code of class ' , varUserClass name , '.\Is it okay to move it to Undeclared?') withCRs)
-			ifFalse: [ ^ self ] ].
+		(self confirm: (aString , ' is still used in code of class ' , varUserClass name , '.\Is it okay to move it to Undeclared?') withCRs) ifFalse: [ ^ self ] ].
 
 	varUserClass
 		ifNotNil: [
 			NewUndeclaredWarning signal: aString in: self name.
-			Undeclared declare: aSymbol from: self classPool]
-		ifNil: [ self classPool removeKey: aSymbol].
+			Undeclared declare: aSymbol from: self classPool ]
+		ifNil: [ self classPool removeKey: aSymbol ].
 
-	self classPool isEmpty
-		ifTrue: [ self classPool: nil ].
+	self classPool ifEmpty: [ self classPool: nil ].
 
 	SystemAnnouncer uniqueInstance classModificationAppliedTo: self
 ]
@@ -906,49 +903,42 @@ Class >> removeSharedPool: aDictionary [
 	: Note that it removes the wrong one if there are two empty Dictionaries in the list."
 
 	| satisfiedSet workingSet aSubclass |
-	(self sharedPools includes: aDictionary)
-		ifFalse: [^self error: 'the dictionary is not in my pool'].
+	(self sharedPools includes: aDictionary) ifFalse: [ ^ self error: 'the dictionary is not in my pool' ].
 
 	"first see if it is declared in a superclass in which case we can remove it."
-	(self selectSuperclasses: [:class | class sharedPools includes: aDictionary]) isEmpty
-		ifFalse: [self sharedPools remove: aDictionary.
-				self sharedPools isEmpty ifTrue: [self sharedPools: nil].
-				^self].
+	(self selectSuperclasses: [ :class | class sharedPools includes: aDictionary ]) ifNotEmpty: [
+		self sharedPools remove: aDictionary.
+		self sharedPools isEmpty ifTrue: [ self sharedPools: nil ].
+		^ self ].
 
 	"second get all the subclasses that reference aDictionary through me rather than a
 	superclass that is one of my subclasses."
 
 	workingSet := self subclasses asOrderedCollection.
 	satisfiedSet := Set new.
-	[workingSet isEmpty] whileFalse:
-		[aSubclass := workingSet removeFirst.
-		(aSubclass sharedPools includes: aDictionary)
-			ifFalse:
-				[satisfiedSet add: aSubclass.
-				workingSet addAll: aSubclass subclasses]].
+	[ workingSet isEmpty ] whileFalse: [
+		aSubclass := workingSet removeFirst.
+		(aSubclass sharedPools includes: aDictionary) ifFalse: [
+			satisfiedSet add: aSubclass.
+			workingSet addAll: aSubclass subclasses ] ].
 
 	"for each of these, see if they refer to any of the variables in aDictionary because
 	if they do, we can not remove the dictionary."
 	satisfiedSet add: self.
-	satisfiedSet do:
-		[:sub |
-		aDictionary associationsDo:
-			[:aGlobal |
-			(sub whichSelectorsReferTo: aGlobal) isEmpty
-				ifFalse: [^self error: aGlobal key
-								, ' is still used in code of class '
-								, sub name]]].
+	satisfiedSet do: [ :sub |
+		aDictionary associationsDo: [ :aGlobal |
+			(sub whichSelectorsReferTo: aGlobal) ifNotEmpty: [ ^ self error: aGlobal key , ' is still used in code of class ' , sub name ] ] ].
 	self sharedPools remove: aDictionary.
-	self sharedPools isEmpty ifTrue: [self sharedPools: nil]
+	self sharedPools ifEmpty: [ self sharedPools: nil ]
 ]
 
 { #category : #'accessing - class hierarchy' }
 Class >> removeSubclass: aSubclass [
 	"If the argument, aSubclass, is one of the receiver's subclasses, remove it."
 
-	self subclasses == nil ifFalse:
-		[self subclasses:  (self subclasses copyWithout: aSubclass).
-		self subclasses isEmpty ifTrue: [self subclasses: nil]]
+	self subclasses == nil ifFalse: [
+		self subclasses: (self subclasses copyWithout: aSubclass).
+		self subclasses ifEmpty: [ self subclasses: nil ] ]
 ]
 
 { #category : #'class name' }
@@ -1015,24 +1005,25 @@ Class >> sharedPoolsDo: aBlockClosure [
 { #category : #initialization }
 Class >> sharing: poolString [
 	"Set up sharedPools. Answer whether recompilation is advisable."
+
 	| oldPools |
 	oldPools := self sharedPools.
 	self sharedPools: OrderedCollection new.
-	(poolString substrings: ' ') do:
-		[:poolName |
-		self sharedPools add: (self environment at: poolName asSymbol ifAbsent:[
-			(self confirm: 'The pool dictionary ', poolName,' does not exist.',
-						'\Do you want it automatically created?' withCRs)
-				ifTrue: [ self classInstaller make: [ :builder |
-							builder superclass: SharedPool;
-							name: poolName;
-							category: self category ]]
-				ifFalse:[^self inform: poolName,' does not exist']])].
-	self sharedPools isEmpty ifTrue: [self sharedPools: nil].
-	oldPools do: [:pool |
-				| found |
-				found := self sharedPools anySatisfy: [:p | p == pool].
-				found ifFalse: [^ true "A pool got deleted"]].
+	(poolString substrings: ' ') do: [ :poolName |
+		self sharedPools add: (self environment at: poolName asSymbol ifAbsent: [
+				 (self confirm: 'The pool dictionary ' , poolName , ' does not exist.' , '\Do you want it automatically created?' withCRs)
+					 ifTrue: [
+						 self classInstaller make: [ :builder |
+							 builder
+								 superclass: SharedPool;
+								 name: poolName;
+								 category: self category ] ]
+					 ifFalse: [ ^ self inform: poolName , ' does not exist' ] ]) ].
+	self sharedPools ifEmpty: [ self sharedPools: nil ].
+	oldPools do: [ :pool |
+		| found |
+		found := self sharedPools anySatisfy: [ :p | p == pool ].
+		found ifFalse: [ ^ true "A pool got deleted" ] ].
 	^ false
 ]
 

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -215,6 +215,7 @@ ClassDescription >> classComment: aString stamp: aStamp [
 { #category : #'accessing - comment' }
 ClassDescription >> classCommentBlank [
 	"Classes can override this method to show another template."
+
 	"There are two use cases: a class hierarchy can give information about what kind of comment is
 	useful (see 'PackageManifest class'). If in addition, '#hasComment ^true' can be implemented in
 	cases where the class does not need a dedicated comment. See 'TestCase class'for an example"
@@ -238,19 +239,27 @@ Public API and Key Messages
    One simple example is simply gorgeous.
 
 Internal Representation and Key Implementation Points.'.
-
-	(self instanceVariables isNotEmpty)
-		 ifTrue: [stream cr; cr; nextPutAll: '    Instance Variables'.  ].
-
-	self instVarNames sorted do: [:each |
+	self instanceVariables ifNotEmpty: [
 		stream
-			cr; tab; nextPutAll: each;
+			cr;
+			cr;
+			nextPutAll: '    Instance Variables' ].
+
+	self instVarNames sorted do: [ :each |
+		stream
+			cr;
+			tab;
+			nextPutAll: each;
 			nextPut: $:;
-			tab; tab;
-			nextPutAll: '<Object>'].
+			tab;
+			tab;
+			nextPutAll: '<Object>' ].
 	stream cr.
-	stream cr; cr; nextPutAll: '    Implementation Points'.
-	^stream contents
+	stream
+		cr;
+		cr;
+		nextPutAll: '    Implementation Points'.
+	^ stream contents
 ]
 
 { #category : #'accessing - parallel hierarchy' }
@@ -300,17 +309,11 @@ ClassDescription >> classesThatImplementAllOf: selectorSet [
 
 	| found remaining |
 	found := OrderedCollection new.
-	selectorSet do:
-		[:sel | (self includesSelector: sel) ifTrue: [found add: sel]].
-	found isEmpty
-		ifTrue: [^ self subclasses inject: Array new
-						into: [:subsThatDo :sub |
-							subsThatDo , (sub classesThatImplementAllOf: selectorSet)]]
-		ifFalse: [remaining := selectorSet copyWithoutAll: found.
-				remaining isEmpty ifTrue: [^ Array with: self].
-				^ self subclasses inject: Array new
-						into: [:subsThatDo :sub |
-							subsThatDo , (sub classesThatImplementAllOf: remaining)]]
+	selectorSet do: [ :sel | (self includesSelector: sel) ifTrue: [ found add: sel ] ].
+	found ifEmpty: [ ^ self subclasses inject: Array new into: [ :subsThatDo :sub | subsThatDo , (sub classesThatImplementAllOf: selectorSet) ] ] ifNotEmpty: [
+		remaining := selectorSet copyWithoutAll: found.
+		remaining isEmpty ifTrue: [ ^ Array with: self ].
+		^ self subclasses inject: Array new into: [ :subsThatDo :sub | subsThatDo , (sub classesThatImplementAllOf: remaining) ] ]
 ]
 
 { #category : #'accessing - comment' }

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -866,12 +866,16 @@ CompiledMethod >> properties [
 { #category : #accessing }
 CompiledMethod >> properties: aMethodProperties [
 	"Set the method-properties of the receiver to aMethodProperties."
-	self literalAt: self numLiterals - 1
-		put: (aMethodProperties isEmpty
-				ifTrue: [aMethodProperties selector]
-				ifFalse: [aMethodProperties
-							setMethod: self;
-							yourself])
+
+	self
+		literalAt: self numLiterals - 1
+		put:
+			(aMethodProperties
+				ifEmpty: [ aMethodProperties selector ]
+				ifNotEmpty: [
+			 		aMethodProperties
+				 		setMethod: self;
+				 		yourself ])
 ]
 
 { #category : #'accessing - pragmas & properties' }

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -1385,7 +1385,6 @@ Context >> printDebugStackOn: aStream [
 
 { #category : #printing }
 Context >> printDetails: stream [
-
 	"Put my class>>selector and instance variables and arguments and temporaries on the stream.  Protect against errors during printing."
 
 	| errorMessage string |
@@ -1395,18 +1394,18 @@ Context >> printDetails: stream [
 		tab;
 		nextPutAll: 'Receiver: '.
 	errorMessage := '<<error during printing>>'.
-	stream nextPutAll:
-		([ receiver printStringLimitedTo: 90 ] on: Exception do: [ errorMessage ]).
+	stream nextPutAll: ([ receiver printStringLimitedTo: 90 ]
+			 on: Exception
+			 do: [ errorMessage ]).
 
 	stream
 		cr;
 		tab;
 		nextPutAll: 'Arguments and temporary variables: ';
 		cr.
-	string := [
-	          (self tempsAndValuesLimitedTo: 80 indent: 2)
-		          padRightTo: 1
-		          with: $x ] on: Exception do:  [ errorMessage ].
+	string := [ (self tempsAndValuesLimitedTo: 80 indent: 2) padRightTo: 1 with: $x ]
+		          on: Exception
+		          do: [ errorMessage ].
 	stream nextPutAll: string.
 
 	stream
@@ -1414,13 +1413,15 @@ Context >> printDetails: stream [
 		tab;
 		nextPutAll: 'Receiver''s instance variables: ';
 		cr.
-	receiver class allInstVarNames isEmpty
-		ifTrue: [
-			stream nextPutAll:
-				([ receiver printStringLimitedTo: 90 ] on: Exception do:  [ errorMessage ]) ]
-		ifFalse: [
+	receiver class allInstVarNames
+		ifEmpty: [
+			stream nextPutAll: ([ receiver printStringLimitedTo: 90 ]
+					 on: Exception
+					 do: [ errorMessage ]) ]
+		ifNotEmpty: [
 			[ receiver longPrintOn: stream limitedTo: 80 indent: 2 ]
-				on: Exception do:  [ stream nextPutAll: errorMessage ] ].
+				on: Exception
+				do: [ stream nextPutAll: errorMessage ] ].
 	stream cr
 ]
 

--- a/src/Kernel/Message.class.st
+++ b/src/Kernel/Message.class.st
@@ -99,13 +99,12 @@ Message >> numArgs [
 { #category : #printing }
 Message >> printOn: stream [
 
-	args isEmpty ifTrue: [^ stream nextPutAll: selector].
-	args with: selector keywords do: [:arg :word |
+	args ifEmpty: [ ^ stream nextPutAll: selector ].
+	args with: selector keywords do: [ :arg :word |
 		stream nextPutAll: word.
 		stream space.
 		arg printOn: stream.
-		stream space.
-	].
+		stream space ].
 	stream skip: -1
 ]
 

--- a/src/Kernel/MessageSend.class.st
+++ b/src/Kernel/MessageSend.class.st
@@ -78,18 +78,16 @@ MessageSend >> asWeakMessageSend [
 MessageSend >> collectArguments: anArgArray [
 	"Private"
 
-    | staticArgs |
-    staticArgs := self arguments.
-    ^(anArgArray size = staticArgs size)
-        ifTrue: [anArgArray]
-        ifFalse:
-            [(staticArgs isEmpty
-                ifTrue: [ staticArgs := Array new: selector numArgs]
-                ifFalse: [staticArgs copy] )
-                    replaceFrom: 1
-                    to: (anArgArray size min: staticArgs size)
-                    with: anArgArray
-                    startingAt: 1]
+	| staticArgs |
+	staticArgs := self arguments.
+	^ anArgArray size = staticArgs size
+		  ifTrue: [ anArgArray ]
+		  ifFalse: [
+			  (staticArgs ifEmpty: [ staticArgs := Array new: selector numArgs ] ifNotEmpty: [ staticArgs copy ])
+				  replaceFrom: 1
+				  to: (anArgArray size min: staticArgs size)
+				  with: anArgArray
+				  startingAt: 1 ]
 ]
 
 { #category : #evaluating }

--- a/src/Kernel/Monitor.class.st
+++ b/src/Kernel/Monitor.class.st
@@ -169,14 +169,12 @@ Monitor >> isOwnerProcess [
 
 { #category : #private }
 Monitor >> privateCleanup [
+
 	queuesMutex critical: [
-		defaultQueue isEmpty ifTrue: [defaultQueue := nil].
+		defaultQueue ifEmpty: [ defaultQueue := nil ].
 		queueDict ifNotNil: [
-			queueDict copy keysAndValuesDo: [:id :queue |
-				queue isEmpty ifTrue: [queueDict removeKey: id]].
-			queueDict isEmpty ifTrue: [queueDict := nil].
-		].
-	]
+			queueDict copy keysAndValuesDo: [ :id :queue | queue ifEmpty: [ queueDict removeKey: id ] ].
+			queueDict ifEmpty: [ queueDict := nil ] ] ]
 ]
 
 { #category : #private }
@@ -205,7 +203,7 @@ Monitor >> signal: aSymbolOrNil [
 	| queue |
 	self checkOwnerProcess.
 	queue := self queueFor: aSymbolOrNil.
-	queue isEmpty ifTrue: [queue := self defaultQueue].
+	queue ifEmpty: [ queue := self defaultQueue ].
 	self signalQueue: queue
 ]
 
@@ -245,9 +243,8 @@ Monitor >> signalLock: aSemaphore inQueue: anOrderedCollection [
 
 { #category : #private }
 Monitor >> signalQueue: anOrderedCollection [
-	queuesMutex critical: [
-	 anOrderedCollection isEmpty ifFalse: [
-			anOrderedCollection removeFirst signal ] ]
+
+	queuesMutex critical: [ anOrderedCollection ifNotEmpty: [ anOrderedCollection removeFirst signal ] ]
 ]
 
 { #category : #'signaling-specific' }

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1474,9 +1474,10 @@ Object >> longPrintString [
 	"Answer a String whose characters are a description of the receiver."
 
 	| str |
-	str := String streamContents: [:aStream | self longPrintOn: aStream].
+	str := String streamContents: [ :aStream | self longPrintOn: aStream ].
+
 	"Objects without inst vars should return something"
-	^ str isEmpty ifTrue: [self printString, String cr] ifFalse: [str]
+	^ str ifEmpty: [ self printString , String cr ]
 ]
 
 { #category : #printing }
@@ -1484,9 +1485,10 @@ Object >> longPrintStringLimitedTo: aLimitValue [
 	"Answer a String whose characters are a description of the receiver."
 
 	| str |
-	str := String streamContents: [:aStream | self longPrintOn: aStream limitedTo: aLimitValue indent: 0].
+	str := String streamContents: [ :aStream | self longPrintOn: aStream limitedTo: aLimitValue indent: 0 ].
+
 	"Objects without inst vars should return something"
-	^ str isEmpty ifTrue: [self printString, String cr] ifFalse: [str]
+	^ str ifEmpty: [ self printString , String cr ]
 ]
 
 { #category : #dependencies }
@@ -1804,8 +1806,8 @@ Object >> removeDependent: anObject [
 	"Remove the given object as one of the receiver's dependents."
 
 	| dependents |
-	dependents := self dependents reject: [:each | each == anObject].
-	self myDependents: (dependents isEmpty ifFalse: [dependents]).
+	dependents := self dependents reject: [ :each | each == anObject ].
+	self myDependents: dependents.
 	^ anObject
 ]
 

--- a/src/Kernel/ProcessList.class.st
+++ b/src/Kernel/ProcessList.class.st
@@ -103,24 +103,26 @@ ProcessList >> add: aLinkOrObject beforeLink: otherLink [
 { #category : #adding }
 ProcessList >> addFirst: aLinkOrObject [
 	"Add aLink to the beginning of the receiver's list. Answer aLink."
-	|aLink|
+
+	| aLink |
 	aLink := aLinkOrObject asLink.
-	self isEmpty ifTrue: [lastLink := aLink].
+	self ifEmpty: [ lastLink := aLink ].
 	aLink nextLink: firstLink.
 	firstLink := aLink.
-	^aLink
+	^ aLink
 ]
 
 { #category : #adding }
 ProcessList >> addLast: aLinkOrObject [
 	"Add aLink to the end of the receiver's list. Answer aLink."
-	|aLink|
+
+	| aLink |
 	aLink := aLinkOrObject asLink.
-	self isEmpty
-		ifTrue: [firstLink := aLink]
-		ifFalse: [lastLink nextLink: aLink].
+	self 
+		ifEmpty: [ firstLink := aLink ]
+		ifNotEmpty: [ lastLink nextLink: aLink ].
 	lastLink := aLink.
-	^aLink
+	^ aLink
 ]
 
 { #category : #accessing }

--- a/src/Kernel/ProcessorScheduler.class.st
+++ b/src/Kernel/ProcessorScheduler.class.st
@@ -215,22 +215,24 @@ ProcessorScheduler >> lowestPriority [
 
 { #category : #'CPU usage tally' }
 ProcessorScheduler >> nextReadyProcess [
+
 	quiescentProcessLists reverseDo: [ :list |
-		list isEmpty ifFalse: [ | proc |
+		list ifNotEmpty: [
+			| proc |
 			proc := list first.
-			proc suspendedContext ifNotNil: [ ^proc ]]].
-	^nil
+			proc suspendedContext ifNotNil: [ ^ proc ] ] ].
+	^ nil
 ]
 
 { #category : #accessing }
 ProcessorScheduler >> preemptedProcess [
 	"Return the process that the currently active process just preempted."
+
 	| list |
-	activeProcess priority to: 1 by: -1 do:[:priority|
+	activeProcess priority to: 1 by: -1 do: [ :priority |
 		list := quiescentProcessLists at: priority.
-		list isEmpty ifFalse:[^list last].
-	].
-	^nil
+		list ifNotEmpty: [ ^ list last ] ].
+	^ nil
 
 	"Processor preemptedProcess"
 ]
@@ -288,11 +290,9 @@ ProcessorScheduler >> suspendFirstAt: aPriority ifNone: noneBlock [
 	"Suspend the first Process that is waiting to run with priority aPriority. If
 	no Process is waiting, evaluate the argument, noneBlock."
 
-	| aList |
-	aList := quiescentProcessLists at: aPriority.
-	^ aList isEmpty
-		  ifTrue: [ noneBlock value ]
-		  ifFalse: [ aList first suspend ]
+	^ (quiescentProcessLists at: aPriority)
+			ifEmpty: [ noneBlock value ]
+			ifNotEmpty: [ :aList | aList first suspend ]
 ]
 
 { #category : #'priority names' }

--- a/src/Kernel/Semaphore.class.st
+++ b/src/Kernel/Semaphore.class.st
@@ -196,7 +196,7 @@ Semaphore >> signal [
 Semaphore >> terminateProcess [
 	"Terminate the process waiting on this semaphore, if any."
 
-	self isEmpty ifFalse: [ self removeFirst terminate ]
+	self ifNotEmpty: [ self removeFirst terminate ]
 ]
 
 { #category : #communication }

--- a/src/Kernel/WeakMessageSend.class.st
+++ b/src/Kernel/WeakMessageSend.class.st
@@ -82,18 +82,17 @@ WeakMessageSend >> asMinimalRepresentation [
 { #category : #private }
 WeakMessageSend >> collectArguments: anArgArray [
 	"Private"
-    | staticArgs |
-    staticArgs := self arguments.
-    ^(anArgArray size = staticArgs size)
-        ifTrue: [ Array withAll: anArgArray ]
-        ifFalse:
-            [(staticArgs isEmpty
-                ifTrue: [ staticArgs := Array new: selector numArgs]
-                ifFalse: [ Array withAll: staticArgs ] )
-                    replaceFrom: 1
-                    to: (anArgArray size min: staticArgs size)
-                    with: anArgArray
-                    startingAt: 1]
+
+	| staticArgs |
+	staticArgs := self arguments.
+	^ anArgArray size = staticArgs size
+		  ifTrue: [ Array withAll: anArgArray ]
+		  ifFalse: [
+			  (staticArgs ifEmpty: [ staticArgs := Array new: selector numArgs ] ifNotEmpty: [ Array withAll: staticArgs ])
+				  replaceFrom: 1
+				  to: (anArgArray size min: staticArgs size)
+				  with: anArgArray
+				  startingAt: 1 ]
 ]
 
 { #category : #evaluating }

--- a/src/Math-Operations-Extensions/Integer.extension.st
+++ b/src/Math-Operations-Extensions/Integer.extension.st
@@ -3,29 +3,27 @@ Extension { #name : #Integer }
 { #category : #'*Math-Operations-Extensions' }
 Integer >> asWords [
 	"SmallInteger maxVal asWords"
+
 	| mils minus three num answer milCount |
-	self = 0 ifTrue: [^'zero'].
-	mils := #('' ' thousand' ' million' ' billion' ' trillion' ' quadrillion' ' quintillion' ' sextillion' ' septillion' ' octillion' ' nonillion' ' decillion' ' undecillion' ' duodecillion' ' tredecillion' ' quattuordecillion' ' quindecillion' ' sexdecillion' ' septendecillion' ' octodecillion' ' novemdecillion' ' vigintillion').
+	self = 0 ifTrue: [ ^ 'zero' ].
+	mils := #( '' ' thousand' ' million' ' billion' ' trillion' ' quadrillion' ' quintillion' ' sextillion' ' septillion' ' octillion' ' nonillion' ' decillion'
+	           ' undecillion' ' duodecillion' ' tredecillion' ' quattuordecillion' ' quindecillion' ' sexdecillion' ' septendecillion' ' octodecillion'
+	           ' novemdecillion' ' vigintillion' ).
 	num := self.
 	minus := ''.
 	self < 0 ifTrue: [
 		minus := 'negative '.
-		num := num negated.
-	].
+		num := num negated ].
 	answer := String new.
 	milCount := 1.
-	[num > 0] whileTrue: [
+	[ num > 0 ] whileTrue: [
 		three := (num \\ 1000) threeDigitName.
 		num := num // 1000.
-		three isEmpty ifFalse: [
-			answer isEmpty ifFalse: [
-				answer := ', ',answer
-			].
-			answer := three,(mils at: milCount),answer.
-		].
-		milCount := milCount + 1.
-	].
-	^minus,answer
+		three ifNotEmpty: [
+			answer isEmpty ifFalse: [ answer := ', ' , answer ].
+			answer := three , (mils at: milCount) , answer ].
+		milCount := milCount + 1 ].
+	^ minus , answer
 ]
 
 { #category : #'*Math-Operations-Extensions' }

--- a/src/System-Object Events/Object.extension.st
+++ b/src/System-Object Events/Object.extension.st
@@ -87,11 +87,10 @@ forEvent: anEventSelector [
 { #category : #'*System-Object Events' }
 Object >> removeActionsForEvent: anEventSelector [
 
-    | map |
-    map := self actionMap.
-    map removeKey: anEventSelector asSymbol ifAbsent: [].
-    map isEmpty
-        ifTrue: [self releaseActionMap]
+	| map |
+	map := self actionMap.
+	map removeKey: anEventSelector asSymbol ifAbsent: [  ].
+	map ifEmpty: [ self releaseActionMap ]
 ]
 
 { #category : #'*System-Object Events' }


### PR DESCRIPTION
This applies on the Kernel packages.

It is more readable to read `a ifEmpty:` than to read `a isEmpty ifTrue:` Also, with #ifNotEmpty: we can use directly the collection as a parameter of the block making the code even simpler.

Sorry for the change in formatting but this was done through a script followed by a manual review