### PR TITLE
Faulty code: forbid write to undeclared variables

### DIFF
--- a/bootstrap/scripts/01-initialization/01-init.st
+++ b/bootstrap/scripts/01-initialization/01-init.st
@@ -2,5 +2,3 @@ SmalltalkImage classPool at: #SpecialSelectors put: (Smalltalk specialObjectsArr
 
 Class subclasses: (Array with: ProtoObject class).
 ProtoObject class classLayout slotScope parentScope: Class classLayout slotScope.
-
-RBProgramNode classPool at: #FormatterClass put: BISimpleFormatter.

--- a/bootstrap/scripts/02-monticello-bootstrap/03-bootstrapMonticelloRemote.st
+++ b/bootstrap/scripts/02-monticello-bootstrap/03-bootstrapMonticelloRemote.st
@@ -1,3 +1,4 @@
+| mcPackages |
 mcPackages := #(
  'Network-Kernel'
  'Network-MIME'

--- a/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
+++ b/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
@@ -1,3 +1,4 @@
+| mcPackages |
 mcPackages := #(
  'ScriptingExtensions'
  'System-FileRegistry'

--- a/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
+++ b/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
@@ -41,8 +41,6 @@ RxsPredicate initialize.
 
 MCFileTreeStCypressWriter initialize.
 MCFileTreeFileSystemUtils initialize.
-MCMockASubclass initialize.
-MCMockClassA initialize.
 
 MetacelloPlatform initialize.
 MetacelloPharoPlatform initialize.

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -1214,10 +1214,10 @@ RBCodeSnippet class >> badSemantic [
 		        (self new
 			         source: 'a := 10. ^ a';
 			         value: 10;
+			         raise: UndeclaredVariableWrite;
 			         notices:
 				         #( #( 1 1 1 'Undeclared variable' )
-				            #( 12 12 12 'Undeclared variable' ) );
-			         skip: #exec). "a is bound to an undefined variable, and according to some compilation options it could be registerer or not registered. This is very bad as regitred ones act like globals thus polute other tests. So disable the execution for now."
+				            #( 12 12 12 'Undeclared variable' ) )).
 		        (self new
 			         source: '^ a';
 			         notices: #( #( 3 3 3 'Undeclared variable' ) )).
@@ -1457,6 +1457,7 @@ RBCodeSnippet class >> badVariableAndScopes [
 		        (self new
 			         source: 'a := a. { [ :a }. a := a';
 			         formattedCode: 'a := a. { [ :a | } a := a';
+						raise: UndeclaredVariableWrite;
 			         notices:
 				         #( #( 6 6 6 'Undeclared variable' )
 				            #( 1 1 1 'Undeclared variable' )
@@ -1467,6 +1468,7 @@ RBCodeSnippet class >> badVariableAndScopes [
 		        (self new
 			         source: 'a := a. [ :a [ :a. a := a';
 			         formattedCode: 'a := a. [ :a | [ :a | a := a';
+						raise: UndeclaredVariableWrite;
 			         notices:
 				         #( #( 6 6 6 'Undeclared variable' )
 				            #( 1 1 1 'Undeclared variable' )
@@ -1475,6 +1477,7 @@ RBCodeSnippet class >> badVariableAndScopes [
 		        (self new
 			         source: 'a := a. [ :a [ :a ]. a := a';
 			         formattedCode: 'a := a. [ :a | [ :a | ] a := a';
+						raise: UndeclaredVariableWrite;
 			         notices:
 				         #( #( 6 6 6 'Undeclared variable' )
 				            #( 1 1 1 'Undeclared variable' )
@@ -1482,6 +1485,7 @@ RBCodeSnippet class >> badVariableAndScopes [
 		        (self new
 			         source: 'a := a. { [ :a | }. a := a';
 			         formattedCode: 'a := a. { [ :a | } a := a';
+						raise: UndeclaredVariableWrite;
 			         notices:
 				         #( #( 6 6 6 'Undeclared variable' )
 				            #( 1 1 1 'Undeclared variable' )
@@ -1492,6 +1496,7 @@ RBCodeSnippet class >> badVariableAndScopes [
 		        (self new
 			         source: 'a := a. { [ :a | a := a }. a := a';
 			         formattedCode: 'a := a. { [ :a | a := a } a := a';
+						raise: UndeclaredVariableWrite;
 			         notices:
 				         #( #( 6 6 6 'Undeclared variable' )
 				            #( 1 1 1 'Undeclared variable' )
@@ -1501,6 +1506,7 @@ RBCodeSnippet class >> badVariableAndScopes [
 		        (self new
 			         source: 'a := a. [ | a a := a ]. a := a';
 			         formattedCode: 'a := a. [ | a a | . := a ]. a := a';
+						raise: UndeclaredVariableWrite;
 			         notices:
 				         #( #( 6 6 6 'Undeclared variable' )
 				            #( 1 1 1 'Undeclared variable' )
@@ -1509,7 +1515,7 @@ RBCodeSnippet class >> badVariableAndScopes [
 		        (self new
 			         source: 'a := a. [ :a a ]. a := a';
 			         formattedCode: 'a := a. [ :a | a ]. a := a';
-			         value: nil;
+						raise: UndeclaredVariableWrite;
 			         notices:
 				         #( #( 6 6 6 'Undeclared variable' )
 				            #( 1 1 1 'Undeclared variable' )
@@ -1519,6 +1525,7 @@ RBCodeSnippet class >> badVariableAndScopes [
 		        (self new
 			         source: 'a := a. [ :a | | a a := a ]. a := a';
 			         formattedCode: 'a := a. [ :a | | a a | . := a ]. a := a';
+						raise: UndeclaredVariableWrite;
 			         notices:
 				         #( #( 6 6 6 'Undeclared variable' )
 				            #( 1 1 1 'Undeclared variable' )

--- a/src/Flashback-Decompiler-Tests/FBDDecompilerTest.class.st
+++ b/src/Flashback-Decompiler-Tests/FBDDecompilerTest.class.st
@@ -1002,6 +1002,8 @@ FBDDecompilerTest >> testWhileTrue2 [
 
 { #category : #tests }
 FBDDecompilerTest >> testWhileTrue3 [
+	<expectedFailure>
+	"See https://github.com/pharo-project/pharo/issues/13196"
 
 	self checkCorrectDecompilation: #exampleWhileTrue3
 ]

--- a/src/Kernel-Tests/CompiledCodeTest.class.st
+++ b/src/Kernel-Tests/CompiledCodeTest.class.st
@@ -228,6 +228,7 @@ CompiledCodeTest >> testLiteralsDoNotConsiderTheInnerBlockLiterals [
 	self assertCollection: method literals equals: {
 			2.
 			(UndeclaredVariable key: #test value: nil).
+			#runtimeUndeclaredWrite:.
 			(GlobalVariable key: #Class value: Class).
 			block.
 			#doIt:.
@@ -270,9 +271,11 @@ CompiledCodeTest >> testLiteralsEvenTheOnesInTheInnerBlocks [
 		equals: {
 				2.
 				(UndeclaredVariable key: #test value: nil).
+				#runtimeUndeclaredWrite:.
 				(GlobalVariable key: #Class value: Class).
 				2.
 				(UndeclaredVariable key: #test value: nil).
+				#runtimeUndeclaredWrite:.
 				#( #arrayInBlock ).
 				(GlobalVariable key: #Object value: Object).
 				#name.

--- a/src/Kernel/LiteralVariable.class.st
+++ b/src/Kernel/LiteralVariable.class.st
@@ -204,6 +204,14 @@ LiteralVariable >> readInContext: aContext [
 	^self value
 ]
 
+{ #category : #'code generation' }
+LiteralVariable >> runtimeUndeclaredWrite: anObject [
+	"This method is used internally to compile polymorphic write on undeclared variables.
+	Do not call it youself to not polute senders."
+
+	^ self write: anObject
+]
+
 { #category : #accessing }
 LiteralVariable >> scope [
 	^self definingClass

--- a/src/Kernel/UndeclaredVariable.class.st
+++ b/src/Kernel/UndeclaredVariable.class.st
@@ -45,9 +45,17 @@ UndeclaredVariable >> definingClass [
 ]
 
 { #category : #'code generation' }
-UndeclaredVariable >> emitStore: methodBuilder [
-
-	methodBuilder storeIntoLiteralVariable: self
+UndeclaredVariable >> emitStore: aMethodBuilder [
+	| tempName |
+	"Swap implementation comes from the superclass"
+	tempName := '0TempForStackManipulation'.
+	aMethodBuilder
+		addTemp: tempName;
+		storeTemp: tempName;
+		popTop;
+		pushLiteral: self;
+		pushTemp: tempName;
+		send: #runtimeUndeclaredWrite:
 ]
 
 { #category : #'code generation' }
@@ -69,6 +77,16 @@ UndeclaredVariable >> isUndeclaredVariable [
 { #category : #registry }
 UndeclaredVariable >> register [
 	Undeclared add: self
+]
+
+{ #category : #'code generation' }
+UndeclaredVariable >> runtimeUndeclaredWrite: anObject [
+
+	<debuggerCompleteToSender>
+	UndeclaredVariableWrite new
+		messageText: 'Attempt to write to undeclared variable ' , self name;
+		variable: self;
+		signal
 ]
 
 { #category : #registry }

--- a/src/Kernel/UndeclaredVariableWrite.class.st
+++ b/src/Kernel/UndeclaredVariableWrite.class.st
@@ -1,0 +1,23 @@
+"
+This error is signaled on write attempt to undeclared variables
+"
+Class {
+	#name : #UndeclaredVariableWrite,
+	#superclass : #Error,
+	#instVars : [
+		'variable'
+	],
+	#category : #'Kernel-Exceptions'
+}
+
+{ #category : #accessing }
+UndeclaredVariableWrite >> variable [
+
+	^ variable
+]
+
+{ #category : #accessing }
+UndeclaredVariableWrite >> variable: anObject [
+
+	variable := anObject
+]

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -248,10 +248,10 @@ OCCompilerTest >> testUndefinedVariable [
 	self
 		assert: {
 			OpalCompiler new evaluate: 'undefinedName123'.
-			OpalCompiler new evaluate: 'undefinedName123 := 1. undefinedName123'.
+			[ OpalCompiler new evaluate: 'undefinedName123 := 1. undefinedName123' ] on: UndeclaredVariableWrite do: [ UndeclaredVariableWrite ].
 			OpalCompiler new evaluate: 'undefinedName123'.
 			}
-		equals: { nil. 1. 1. }.
+		equals: { nil. UndeclaredVariableWrite. nil. }.
 
 	Undeclared removeKey: #undefinedName123 ifAbsent: [ ].
 	self
@@ -259,13 +259,13 @@ OCCompilerTest >> testUndefinedVariable [
 			OpalCompiler new
 				permitFaulty: true;
 				evaluate: 'undefinedName123'.
-			OpalCompiler new
+			[ OpalCompiler new
 				permitFaulty: true;
-				evaluate: 'undefinedName123 := 2. undefinedName123'.
+				evaluate: 'undefinedName123 := 2. undefinedName123' ] on: UndeclaredVariableWrite do: [ UndeclaredVariableWrite ].
 			OpalCompiler new
 				permitFaulty: true;
 				evaluate: 'undefinedName123' }
-		equals: { nil. 2. 2. }.
+		equals: { nil. UndeclaredVariableWrite. nil. }.
 
 	"Cleanup"
 	Undeclared removeKey: #undefinedName123 ifAbsent: [ ]

--- a/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
@@ -18,7 +18,7 @@ RBCodeSnippetTest >> testCompile [
 			self assert: ast isFaulty.
 
 			"Some faulty AST can produce non faulty method where no `signalSyntaxError:` is present"
-			self assert: method isFaulty equals: snippet hasValue not]
+			]
 		ifFalse: [
 			self deny: method isFaulty ].
 	self testExecute: method


### PR DESCRIPTION
This is a cleaned up version of #13189 that should de production ready.
This PR depends on #13195 (3 first commits)

The main change is that only write to undeclared variables at runtime is forbidden.
Read still transparently return nil (or at least the value of the undeclared).

Because static writes to undeclared variables are very rare, and dynamic ones almost nonexistent and always bugs, this should be unnoticeable in production.
But this will bring a little more sanity in the runtime semantic of the language; prevent most bad behaviors (and sneaky and tricky bugs) related to undeclared variables; and reduce user incomprehension during dev and learning.

Another change is names:
* The runtime error class is named `UndeclaredVariableWrite`
* The runtime message is named `runtimeUndeclaredWrite:`. A specific selector is used, so it is easier to track methods that use the late-binding implementation (I will look at them in the bootstrapped image if the gods of CI and rate limits favor us)

Note: MOP-based writes to the undeclared variable are still allowed because `Dictionary>>#add:` is used when registering an undeclared to the global `Undeclared`. But the `add:` method executes `element value: anAssociation value`, and `element` is here an undeclared variable, so signaling an error on `value:` fails at compile-time.
Since touching `Dictionary` seems too much for this PR, I did not change anything here.