### PR TITLE
Rename SystemOrganizer "elements" into "Behavior"

### DIFF
--- a/src/Deprecated12/SystemOrganizer.extension.st
+++ b/src/Deprecated12/SystemOrganizer.extension.st
@@ -6,3 +6,10 @@ SystemOrganizer >> categoryOfElement: behaviorName [
 	self deprecated: 'Use #categoryOfBehavior: instead' transformWith: '`@rcv categoryOfElement: `@arg' -> '`@rcv categoryOfBehavior: `@arg'.
 	^ self categoryOfBehavior: behaviorName
 ]
+
+{ #category : #'*Deprecated12' }
+SystemOrganizer >> removeElement: behaviorName [
+
+	self deprecated: 'Use #removeBehavior: instead' transformWith: '`@rcv removeElement: `@arg' -> '`@rcv removeBehavior: `@arg'.
+	^ self removeBehavior: behaviorName
+]

--- a/src/Deprecated12/SystemOrganizer.extension.st
+++ b/src/Deprecated12/SystemOrganizer.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #SystemOrganizer }
+
+{ #category : #'*Deprecated12' }
+SystemOrganizer >> categoryOfElement: behaviorName [
+
+	self deprecated: 'Use #categoryOfBehavior: instead' transformWith: '`@rcv categoryOfElement: `@arg' -> '`@rcv categoryOfBehavior: `@arg'.
+	^ self categoryOfBehavior: behaviorName
+]

--- a/src/Fuel-Tests-Core/FLClassFactoryForTestCase.class.st
+++ b/src/Fuel-Tests-Core/FLClassFactoryForTestCase.class.st
@@ -74,8 +74,8 @@ FLClassFactoryForTestCase >> cleanUpSystemOrganization [
 	categoriesMatchString := self defaultPackageName, '-*'.
 	categories := SystemOrganization categoriesMatching: categoriesMatchString.
 	categories do: [ :category |
-		(SystemOrganization listAtCategoryNamed: category) do: [ :behavior |
-			SystemOrganization removeElement: behavior ] ]
+		(SystemOrganization listAtCategoryNamed: category) do: [ :behaviorName |
+			SystemOrganization removeBehavior: behaviorName ] ]
 ]
 
 { #category : #accessing }

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -281,12 +281,10 @@ Class >> category [
 	(latter is much more expensive)"
 
 	| result |
-	self basicCategory ifNotNil: [ :symbol |
-		((self environment organization listAtCategoryNamed: symbol) includes: self name)
-			ifTrue: [ ^symbol ] ].
-	result := (self environment organization categoryOfElement: self name)
-		ifNil: [ #Unclassified ]
-		ifNotNil: [:value | value].
+	self basicCategory ifNotNil: [ :symbol | ((self environment organization listAtCategoryNamed: symbol) includes: self name) ifTrue: [ ^ symbol ] ].
+	result := (self environment organization categoryOfBehavior: self)
+		          ifNil: [ #Unclassified ]
+		          ifNotNil: [ :value | value ].
 	self basicCategory: result.
 
 	^ result

--- a/src/Metacello-PharoCommonPlatform/MetacelloPharoCommonPlatform.class.st
+++ b/src/Metacello-PharoCommonPlatform/MetacelloPharoCommonPlatform.class.st
@@ -40,17 +40,18 @@ MetacelloPharoCommonPlatform >> compiler [
 
 { #category : #reflection }
 MetacelloPharoCommonPlatform >> copyClass: oldClass as: newName inCategory: newCategoryName [
+
 	| copysName class newDefinition |
 	copysName := newName asSymbol.
-	copysName = oldClass name
-		ifTrue: [ ^ oldClass ].
-	(Smalltalk globals includesKey: copysName)
-		ifTrue: [ ^ self error: copysName , ' already exists' ].
+	copysName = oldClass name ifTrue: [ ^ oldClass ].
+	(Smalltalk globals includesKey: copysName) ifTrue: [ ^ self error: copysName , ' already exists' ].
 	newDefinition := oldClass definition copyReplaceAll: '#' , oldClass name asString with: '#' , copysName asString printString.
 	newDefinition := newDefinition
-		copyReplaceAll: 'category: ' , (SystemOrganization categoryOfElement: oldClass name) asString printString
-		with: 'category: ' , newCategoryName printString.
-	class := self compiler logged: true; evaluate: newDefinition.
+		                 copyReplaceAll: 'category: ' , (SystemOrganization categoryOfBehavior: oldClass) asString printString
+		                 with: 'category: ' , newCategoryName printString.
+	class := self compiler
+		         logged: true;
+		         evaluate: newDefinition.
 	class class instanceVariableNames: oldClass class instanceVariablesString.
 	class copyAllMethodsFrom: oldClass.
 	class class copyAllMethodsFrom: oldClass class.

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -148,7 +148,7 @@ RPackageOrganizer class >> methodAdded: anEvent [
 	(methodCategory isEmptyOrNil or:[ methodCategory first ~= $* ])
 		ifFalse: [
 			(self isPackageDefinedForClass: anEvent methodClass)
-					ifFalse: [self packageClass new named: (Smalltalk organization categoryOfElement: anEvent methodClass instanceSide asSymbol) ].
+					ifFalse: [self packageClass new named: (Smalltalk organization categoryOfBehavior: anEvent methodClass instanceSide) ].
 		]
 ]
 

--- a/src/Refactoring-Environment/RBBrowserEnvironment.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironment.class.st
@@ -872,7 +872,7 @@ RBBrowserEnvironment >> updateUsing: newUpdateStrategy by: updateBlock [
 
 { #category : #accessing }
 RBBrowserEnvironment >> whichCategoryIncludes: aClassName [
-	^ self systemDictionary organization categoryOfElement: aClassName
+	^ self systemDictionary organization categoryOfBehavior: aClassName
 ]
 
 { #category : #accessing }

--- a/src/System-Changes/ChangeSet.class.st
+++ b/src/System-Changes/ChangeSet.class.st
@@ -1126,7 +1126,7 @@ ChangeSet >> methodsWithoutClassifications [
 		[:aClass |
 		(self methodChangesAtClass: aClass name) associationsDo:
 				[:mAssoc | | aSelector | (aClass includesSelector:  (aSelector := mAssoc key)) ifTrue:
-						[(notClassified includes: (aClass organization categoryOfElement: aSelector))
+						[(notClassified includes: (aClass organization protocolNameOfElement: aSelector))
 								ifTrue: [slips add: aClass name , ' ' , aSelector]]]].
 	^ slips
 ]

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -390,7 +390,7 @@ SystemDictionary >> renameClass: aClass from: oldName to: newName [
 	"Rename the class, aClass, to have the title newName."
 
 	| oldref category |
-	category := self organization categoryOfElement: oldName.
+	category := self organization categoryOfBehavior: oldName.
 	self organization classify: newName under: category.
 	self organization removeElement: oldName.
 	oldref := self associationAt: oldName.

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -217,7 +217,7 @@ SystemDictionary >> forgetClass: aClass logged: aBool [
 	"Delete the class, aClass, from the system.
 	Note that this doesn't do everything required to dispose of a class - to do that use Class>>removeFromSystem."
 
-	self organization removeElement: aClass name.
+	self organization removeBehavior: aClass.
 	SessionManager default unregisterClassNamed: aClass name.
 	self removeKey: aClass name ifAbsent: [  ]
 ]
@@ -392,7 +392,7 @@ SystemDictionary >> renameClass: aClass from: oldName to: newName [
 	| oldref category |
 	category := self organization categoryOfBehavior: oldName.
 	self organization classify: newName under: category.
-	self organization removeElement: oldName.
+	self organization removeBehavior: oldName.
 	oldref := self associationAt: oldName.
 	self removeKey: oldName.
 	oldref key: newName.

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -36,13 +36,6 @@ SystemOrganizer >> addCategory: catString [
 	SystemAnnouncer uniqueInstance classCategoryAdded: catString
 ]
 
-{ #category : #private }
-SystemOrganizer >> basicRemoveElement: element [
-	"Remove the element from all categories."
-
-	categoryMap keysAndValuesDo: [ :category :classes | (classes includes: element) ifTrue: [ classes remove: element ] ]
-]
-
 { #category : #accessing }
 SystemOrganizer >> categories [
 
@@ -85,7 +78,7 @@ SystemOrganizer >> classify: element under: categoryName [
 
 	(self categoryOfElement: element) ifNotNil: [ :oldCategory |
 		oldCategory = categoryName ifTrue: [ ^ self ].
-		self basicRemoveElement: element ].
+		self removeElement: element ].
 
 	(categoryMap at: categoryName) add: element
 ]
@@ -175,7 +168,9 @@ SystemOrganizer >> removeCategory: category [
 
 { #category : #operations }
 SystemOrganizer >> removeElement: element [
-	^ self basicRemoveElement: element
+	"Remove the element from all categories."
+
+	categoryMap keysAndValuesDo: [ :category :classes | (classes includes: element) ifTrue: [ classes remove: element ] ]
 ]
 
 { #category : #removing }

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -51,10 +51,10 @@ SystemOrganizer >> categoriesMatching: matchString [
 ]
 
 { #category : #queries }
-SystemOrganizer >> categoryOfElement: element [
+SystemOrganizer >> categoryOfElement: behaviorName [
 	"Answer the category associated with the argument, element."
 
-	categoryMap keysAndValuesDo: [ :category :classes | (classes includes: element) ifTrue: [ ^ category ] ].
+	categoryMap keysAndValuesDo: [ :category :classes | (classes includes: behaviorName) ifTrue: [ ^ category ] ].
 
 	^ nil
 ]
@@ -66,21 +66,21 @@ SystemOrganizer >> classesInCategory: category [
 ]
 
 { #category : #operations }
-SystemOrganizer >> classify: element under: categoryName [
+SystemOrganizer >> classify: behaviorName under: categoryName [
 	"Store the argument, element, in the category named heading."
 
 	categoryName ifNil: [ self error: 'Category cannot be nil.' ].
 
 	categoryMap
 		at: categoryName
-		ifPresent: [ :classes | (classes includes: element) ifTrue: [ ^ self ] ]
+		ifPresent: [ :classes | (classes includes: behaviorName) ifTrue: [ ^ self ] ]
 		ifAbsent: [ self addCategory: categoryName ].
 
-	(self categoryOfElement: element) ifNotNil: [ :oldCategory |
+	(self categoryOfElement: behaviorName) ifNotNil: [ :oldCategory |
 		oldCategory = categoryName ifTrue: [ ^ self ].
-		self removeElement: element ].
+		self removeElement: behaviorName ].
 
-	(categoryMap at: categoryName) add: element
+	(categoryMap at: categoryName) add: behaviorName
 ]
 
 { #category : #operations }
@@ -167,10 +167,10 @@ SystemOrganizer >> removeCategory: category [
 ]
 
 { #category : #operations }
-SystemOrganizer >> removeElement: element [
+SystemOrganizer >> removeElement: behaviorName [
 	"Remove the element from all categories."
 
-	categoryMap keysAndValuesDo: [ :category :classes | (classes includes: element) ifTrue: [ classes remove: element ] ]
+	categoryMap keysAndValuesDo: [ :category :classes | (classes includes: behaviorName) ifTrue: [ classes remove: behaviorName ] ]
 ]
 
 { #category : #removing }

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -149,6 +149,18 @@ SystemOrganizer >> orderedTraitsIn: category [
 	^ traits asArray
 ]
 
+{ #category : #operations }
+SystemOrganizer >> removeBehavior: behavior [
+	"Remove the behavior from all categories. I can take a Behavior or a Behavior name as argument."
+
+	| behaviorName |
+	behaviorName := behavior isBehavior
+		                ifTrue: [ behavior name ]
+		                ifFalse: [ behavior ].
+
+	categoryMap keysAndValuesDo: [ :category :classes | (classes includes: behaviorName) ifTrue: [ classes remove: behaviorName ] ]
+]
+
 { #category : #removing }
 SystemOrganizer >> removeCategoriesMatching: matchString [
 	"Remove all matching categories with their classes"
@@ -169,13 +181,6 @@ SystemOrganizer >> removeCategory: category [
 	categoryMap removeKey: category.
 
 	SystemAnnouncer uniqueInstance classCategoryRemoved: category
-]
-
-{ #category : #operations }
-SystemOrganizer >> removeElement: behaviorName [
-	"Remove the element from all categories."
-
-	categoryMap keysAndValuesDo: [ :category :classes | (classes includes: behaviorName) ifTrue: [ classes remove: behaviorName ] ]
 ]
 
 { #category : #removing }

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -51,8 +51,13 @@ SystemOrganizer >> categoriesMatching: matchString [
 ]
 
 { #category : #queries }
-SystemOrganizer >> categoryOfElement: behaviorName [
-	"Answer the category associated with the argument, element."
+SystemOrganizer >> categoryOfBehavior: behavior [
+	"Answer the category associated with the argument. This method can take a Behavior or a Behavior name as parameter."
+
+	| behaviorName |
+	behaviorName := behavior isBehavior
+		                ifTrue: [ behavior name ]
+		                ifFalse: [ behavior ].
 
 	categoryMap keysAndValuesDo: [ :category :classes | (classes includes: behaviorName) ifTrue: [ ^ category ] ].
 
@@ -76,7 +81,7 @@ SystemOrganizer >> classify: behaviorName under: categoryName [
 		ifPresent: [ :classes | (classes includes: behaviorName) ifTrue: [ ^ self ] ]
 		ifAbsent: [ self addCategory: categoryName ].
 
-	(self categoryOfElement: behaviorName) ifNotNil: [ :oldCategory |
+	(self categoryOfBehavior: behaviorName) ifNotNil: [ :oldCategory |
 		oldCategory = categoryName ifTrue: [ ^ self ].
 		self removeElement: behaviorName ].
 

--- a/src/Tests/ClassTraitTest.class.st
+++ b/src/Tests/ClassTraitTest.class.st
@@ -12,19 +12,19 @@ ClassTraitTest >> testChanges [
 	| classTrait |
 	classTrait := self t1 classTrait.
 	self deny: (self t5 classSide includesSelector: #m1ClassSide).
-	classTrait compile: 'm1ClassSide ^17' classified: 'mycategory'.	"local selectors"
+	classTrait compile: 'm1ClassSide ^17' classified: 'mycategory'. "local selectors"
 	self assert: (classTrait includesLocalSelector: #m1ClassSide).
-	self deny: (classTrait includesLocalSelector: #otherSelector).	"propagation"
+	self deny: (classTrait includesLocalSelector: #otherSelector). "propagation"
 	self assert: (self t5 classSide methodDict includesKey: #m1ClassSide).
 	self assert: (self c2 class methodDict includesKey: #m1ClassSide).
 	self c2 m1ClassSide.
-	self assert: self c2 m1ClassSide equals: 17.	"category"
-	self assert: (self c2 class organization categoryOfElement: #m1ClassSide) equals: 'mycategory'.	"conflicts"
+	self assert: self c2 m1ClassSide equals: 17. "category"
+	self assert: (self c2 class organization protocolNameOfElement: #m1ClassSide) equals: 'mycategory'. "conflicts"
 	self t2 classSide compile: 'm1ClassSide' classified: 'mycategory'.
 	self assert: (self c2 class methodDict includesKey: #m1ClassSide).
 	self deny: (self c2 class includesLocalSelector: #m1ClassSide).
-	self should: [ self c2 m1ClassSide ] raise: Error.	"conflict category"
-	self assert: (self c2 class organization categoryOfElement: #m1ClassSide) equals: #mycategory
+	self should: [ self c2 m1ClassSide ] raise: Error. "conflict category"
+	self assert: (self c2 class organization protocolNameOfElement: #m1ClassSide) equals: #mycategory
 ]
 
 { #category : #tests }

--- a/src/Tests/TraitMethodDescriptionTest.class.st
+++ b/src/Tests/TraitMethodDescriptionTest.class.st
@@ -18,24 +18,25 @@ TraitMethodDescriptionTest >> testArgumentNames [
 
 { #category : #tests }
 TraitMethodDescriptionTest >> testCategories [
-	self assert: (self t4 organization categoryOfElement: #m21) equals: #cat1.
-	self assert: (self t4 organization categoryOfElement: #m22) equals: #cat2.
-	self assert: (self t4 organization categoryOfElement: #m11) equals: #catX.
-	self assert: (self t4 organization categoryOfElement: #m12) equals: #cat2.
-	self assert: (self t4 organization categoryOfElement: #m13) equals: #cat3.
-	self assert: (self t6 organization categoryOfElement: #m22Alias) equals: #cat2.
+
+	self assert: (self t4 organization protocolNameOfElement: #m21) equals: #cat1.
+	self assert: (self t4 organization protocolNameOfElement: #m22) equals: #cat2.
+	self assert: (self t4 organization protocolNameOfElement: #m11) equals: #catX.
+	self assert: (self t4 organization protocolNameOfElement: #m12) equals: #cat2.
+	self assert: (self t4 organization protocolNameOfElement: #m13) equals: #cat3.
+	self assert: (self t6 organization protocolNameOfElement: #m22Alias) equals: #cat2.
 	self t2 organization classify: #m22 under: #catX.
-	self assert: (self t4 organization categoryOfElement: #m22) equals: #catX.
-	self assert: (self t6 organization categoryOfElement: #m22Alias) equals: #catX.
+	self assert: (self t4 organization protocolNameOfElement: #m22) equals: #catX.
+	self assert: (self t6 organization protocolNameOfElement: #m22Alias) equals: #catX.
 	self t6 organization classify: #m22 under: #catY.
 	self t6 organization classify: #m22Alias under: #catY.
 	self t2 organization classify: #m22 under: #catZ.
-	self assert: (self t6 organization categoryOfElement: #m22) equals: #catY.
-	self assert: (self t6 organization categoryOfElement: #m22Alias) equals: #catY.
+	self assert: (self t6 organization protocolNameOfElement: #m22) equals: #catY.
+	self assert: (self t6 organization protocolNameOfElement: #m22Alias) equals: #catY.
 	self t1 compile: 'mA' classified: #catA.
-	self assert: (self t4 organization categoryOfElement: #mA) equals: #catA.
+	self assert: (self t4 organization protocolNameOfElement: #mA) equals: #catA.
 	self t1 organization classify: #mA under: #cat1.
-	self assert: (self t4 organization categories includes: #catA) not
+	self assert: (self t4 organization protocolNames includes: #catA) not
 ]
 
 { #category : #tests }
@@ -78,23 +79,23 @@ TraitMethodDescriptionTest >> testConflictMethodCreation [
 
 { #category : #tests }
 TraitMethodDescriptionTest >> testConflictingCategories [
+
 	| t7 t8 |
 	self t2 compile: 'm11' classified: #catY.
-	self assert: (self t4 organization categoryOfElement: #m11) equals: #catX.
-	self assert: (self t5 organization categoryOfElement: #m11) equals: Protocol ambiguous.
+	self assert: (self t4 organization protocolNameOfElement: #m11) equals: #catX.
+	self assert: (self t5 organization protocolNameOfElement: #m11) equals: Protocol ambiguous.
 	t7 := self createTraitNamed: #T7 uses: self t1 + self t2.
-	self assert: (t7 organization categoryOfElement: #m11)
-				equals: Protocol ambiguous.
+	self assert: (t7 organization protocolNameOfElement: #m11) equals: Protocol ambiguous.
 	self t1 removeSelector: #m11.
-	self assert: (self t4 organization categoryOfElement: #m11) equals: #catX.
-	self assert: (self t5 organization categoryOfElement: #m11) equals: #catY.
-	self assert: (t7 organization categoryOfElement: #m11) equals: #catY.
-	self assert: (t7 organization categories includes: Protocol ambiguous) not.
+	self assert: (self t4 organization protocolNameOfElement: #m11) equals: #catX.
+	self assert: (self t5 organization protocolNameOfElement: #m11) equals: #catY.
+	self assert: (t7 organization protocolNameOfElement: #m11) equals: #catY.
+	self assert: (t7 organization protocolNames includes: Protocol ambiguous) not.
 	self t1 compile: 'm11' classified: #cat1.
 	t8 := self createTraitNamed: #T8 uses: self t1 + self t2.
 	t8 organization classify: #m11 under: #cat1.
 	self t1 organization classify: #m11 under: #catZ.
-	self assert: (self t4 organization categoryOfElement: #m11) equals: #catX.
-	self assert: (self t5 organization categoryOfElement: #m11) equals: Protocol ambiguous.
-	self assert: (t8 organization categoryOfElement: #m11) equals: #catZ
+	self assert: (self t4 organization protocolNameOfElement: #m11) equals: #catX.
+	self assert: (self t5 organization protocolNameOfElement: #m11) equals: Protocol ambiguous.
+	self assert: (t8 organization protocolNameOfElement: #m11) equals: #catZ
 ]

--- a/src/Tests/TraitPureBehaviorTest.class.st
+++ b/src/Tests/TraitPureBehaviorTest.class.st
@@ -143,11 +143,11 @@ TraitPureBehaviorTest >> testLocalSelectors [
 TraitPureBehaviorTest >> testMethodCategoryReorganization [
 
 	self t1 compile: 'm1' classified: 'category1'.
-	self assert: (self t5 organization categoryOfElement: #m1) equals: #category1.
-	self assert: (self c2 organization categoryOfElement: #m1) equals: #category1.
+	self assert: (self t5 organization protocolNameOfElement: #m1) equals: #category1.
+	self assert: (self c2 organization protocolNameOfElement: #m1) equals: #category1.
 	self t1 organization classify: #m1 under: #category2.
-	self assert: (self t5 organization categoryOfElement: #m1) equals: #category2.
-	self assert: (self c2 organization categoryOfElement: #m1) equals: #category2
+	self assert: (self t5 organization protocolNameOfElement: #m1) equals: #category2.
+	self assert: (self c2 organization protocolNameOfElement: #m1) equals: #category2
 ]
 
 { #category : #'tests - applying trait composition' }


### PR DESCRIPTION
In the system we have ClassOrganization and SystemOrganizer that use "element" as a way to describe their content, but why use this generic work when we know what they manipulate?

ClassOrganization is manipulating protocols and SystemOrganizer is manipulating behaviors!

Here I'm doing the renaming in SystemOrganizer. 
- #categoryOfElement: becomes #categoryOfBehavior (and in the futur I also want to kill this "category" vocabulary)
- #removeElement: becomes #removeBehavior

In addition, now both those methods support getting a Behavior and not a Behavior name as parameter. 
This is because the current SystemOrganizer is a glue between the class meta model and packages. It holds only symbols. But we want to remove the need of this glue and manipulate objects directly! So I'm allowing to give objects here and not just dead symbols.

I also got a bunch of deprecation rewrite that I shipped. I have the impression that sometimes those rewrites are not taken into account in Iceberg and I had to force the computation of dirty packages.

And one last thing (yes, really the last now). I removed a method that only had 1 sender and this sender was only calling this one method (#basicRemoveElement:)