### PR TITLE
KeyboardKey class>>#initializeKeyFromCharacterCompatibilityTable maps 3 characters incorrectly

### DIFF
--- a/src/System-Platforms/KeyboardKey.class.st
+++ b/src/System-Platforms/KeyboardKey.class.st
@@ -416,12 +416,12 @@ KeyboardKey class >> initializeKeyFromCharacterCompatibilityTable [
 		Character end 			. #End "XK_End".
 		Character space 		. #Space "XK_Space".
 		$/ 							. #SLASH.
-		$] 							. #BRACKETLEFT.
-		$[ 							. #BRACKETRIGHT.
+		$] 							. #BRACKETRIGHT.
+		$[ 							. #BRACKETLEFT.
 		$( 							. #parenleft.
 		$) 							. #parenright.
 		$< 							. #less.
-		$< 							. #greater.
+		$> 							. #greater.
 		$| 							. #bar.
 		$- 							. #minus}
 			pairsDo: [ :character :keyname |


### PR DESCRIPTION
Fixes #13150
KeyboardKey class>>#initializeKeyFromCharacterCompatibilityTable maps 3 characters incorrectly