### PR TITLE
unskip #testPerformChangeClass 

### DIFF
--- a/src/Refactoring-Tests-Changes/RBRefactoringChangeTest.class.st
+++ b/src/Refactoring-Tests-Changes/RBRefactoringChangeTest.class.st
@@ -401,9 +401,7 @@ RBRefactoringChangeTest >> testPerformAddRemoveMethodInteractively [
 
 { #category : #'tests - perform' }
 RBRefactoringChangeTest >> testPerformChangeClass [
-	<skip>
 	| change |
-	self skip.
 	change := changes
 		defineClass:
 			self class name , ' << #' , self changeMock name


### PR DESCRIPTION
testPerformChangeClass is green now, we can un-skip it

(fixed by https://github.com/pharo-project/pharo/pull/12977)