### PR TITLE
Fast table should not manage keydown as keystroke

### DIFF
--- a/src/Morphic-Widgets-FastTable/FTSearchFunction.class.st
+++ b/src/Morphic-Widgets-FastTable/FTSearchFunction.class.st
@@ -23,11 +23,6 @@ FTSearchFunction >> ghostText [
 ]
 
 { #category : #'event handling' }
-FTSearchFunction >> keyDown: anEvent [
-	^ self keyStroke: anEvent
-]
-
-{ #category : #'event handling' }
 FTSearchFunction >> keyStroke: anEvent [
 
 	anEvent keyCharacter isAlphaNumeric ifFalse: [ ^ false ].


### PR DESCRIPTION
Do not manage a keydown as a keystroke. Otherwise a key event may be managed twice.

Fix https://github.com/pharo-project/pharo/issues/12434