### PR TITLE
Refactor: insert new class refactoring

### DIFF
--- a/src/Refactoring-Core/RBChildrenToSiblingsRefactoring.class.st
+++ b/src/Refactoring-Core/RBChildrenToSiblingsRefactoring.class.st
@@ -56,7 +56,7 @@ RBChildrenToSiblingsRefactoring >> abstractSuperclass [
 
 { #category : #transforming }
 RBChildrenToSiblingsRefactoring >> addSuperclass [
-	self performCompositeRefactoring: (RBInsertClassRefactoring
+	self performCompositeRefactoring: (RBInsertNewClassRefactoring
 				model: self model
 				addClass: className
 				superclass: parent superclass

--- a/src/Refactoring-Core/RBCopyClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBCopyClassRefactoring.class.st
@@ -63,7 +63,7 @@ RBCopyClassRefactoring >> category: aSymbol [
 
 { #category : #transforming }
 RBCopyClassRefactoring >> copyClass [
-	self performCompositeRefactoring: (RBInsertClassRefactoring
+	self performCompositeRefactoring: (RBInsertNewClassRefactoring
 		model: self model
 		addClass: className
 		superclass: aClass superclass

--- a/src/Refactoring-Core/RBInsertClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBInsertClassRefactoring.class.st
@@ -54,10 +54,8 @@ RBInsertClassRefactoring class >> model: aRBSmalltalk addClass: aName superclass
 
 { #category : #initialization }
 RBInsertClassRefactoring >> addClass: aName superclass: aClass subclasses: aCollection category: aSymbol [
-	self className: aName.
-	superclass := self classObjectFor: aClass.
-	subclasses := aCollection collect: [:each | self classObjectFor: each].
-	category := aSymbol
+	self addClass: aName superclass: aClass subclasses: aCollection category: aSymbol comment: ''
+	
 ]
 
 { #category : #initialization }

--- a/src/Refactoring-Core/RBInsertNewClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBInsertNewClassRefactoring.class.st
@@ -9,7 +9,7 @@ My preconditions verify that I use a valid class name, that does not yet exists 
 and the subclasses (if any) were direct subclasses of the superclass.
 "
 Class {
-	#name : #RBInsertClassRefactoring,
+	#name : #RBInsertNewClassRefactoring,
 	#superclass : #RBClassRefactoring,
 	#instVars : [
 		'category',
@@ -21,7 +21,7 @@ Class {
 }
 
 { #category : #'instance creation' }
-RBInsertClassRefactoring class >> addClass: aName superclass: aClass subclasses: aCollection category: aSymbol [
+RBInsertNewClassRefactoring class >> addClass: aName superclass: aClass subclasses: aCollection category: aSymbol [
 	^ self new
 		addClass: aName
 		superclass: aClass
@@ -30,7 +30,7 @@ RBInsertClassRefactoring class >> addClass: aName superclass: aClass subclasses:
 ]
 
 { #category : #'instance creation' }
-RBInsertClassRefactoring class >> model: aRBSmalltalk addClass: aName superclass: aClass subclasses: aCollection category: aSymbol [
+RBInsertNewClassRefactoring class >> model: aRBSmalltalk addClass: aName superclass: aClass subclasses: aCollection category: aSymbol [
 	^ self new
 		model: aRBSmalltalk;
 		addClass: aName
@@ -41,7 +41,7 @@ RBInsertClassRefactoring class >> model: aRBSmalltalk addClass: aName superclass
 ]
 
 { #category : #'instance creation' }
-RBInsertClassRefactoring class >> model: aRBSmalltalk addClass: aName superclass: aClass subclasses: aCollection category: aSymbol comment: aCommentString [
+RBInsertNewClassRefactoring class >> model: aRBSmalltalk addClass: aName superclass: aClass subclasses: aCollection category: aSymbol comment: aCommentString [
 	^ self new
 		model: aRBSmalltalk;
 		addClass: aName
@@ -53,13 +53,13 @@ RBInsertClassRefactoring class >> model: aRBSmalltalk addClass: aName superclass
 ]
 
 { #category : #initialization }
-RBInsertClassRefactoring >> addClass: aName superclass: aClass subclasses: aCollection category: aSymbol [
+RBInsertNewClassRefactoring >> addClass: aName superclass: aClass subclasses: aCollection category: aSymbol [
 	self addClass: aName superclass: aClass subclasses: aCollection category: aSymbol comment: ''
 	
 ]
 
 { #category : #initialization }
-RBInsertClassRefactoring >> addClass: aName superclass: aClass subclasses: aCollection category: aSymbol comment: aCommentString [
+RBInsertNewClassRefactoring >> addClass: aName superclass: aClass subclasses: aCollection category: aSymbol comment: aCommentString [
 	self className: aName.
 	superclass := self classObjectFor: aClass.
 	subclasses := aCollection collect: [:each | self classObjectFor: each].
@@ -68,7 +68,7 @@ RBInsertClassRefactoring >> addClass: aName superclass: aClass subclasses: aColl
 ]
 
 { #category : #preconditions }
-RBInsertClassRefactoring >> preconditions [
+RBInsertNewClassRefactoring >> preconditions [
 	| cond |
 	cond := ((RBCondition isMetaclass: superclass)
 				errorMacro: 'Superclass must not be a metaclass') not.
@@ -87,7 +87,7 @@ RBInsertClassRefactoring >> preconditions [
 ]
 
 { #category : #printing }
-RBInsertClassRefactoring >> storeOn: aStream [
+RBInsertNewClassRefactoring >> storeOn: aStream [
 	aStream nextPut: $(.
 	self class storeOn: aStream.
 	aStream
@@ -103,7 +103,7 @@ RBInsertClassRefactoring >> storeOn: aStream [
 ]
 
 { #category : #transforming }
-RBInsertClassRefactoring >> transform [
+RBInsertNewClassRefactoring >> transform [
 
 	| classDefinitionString |
 	classDefinitionString := '<1p> %<%< #<2s> package: <3p>'

--- a/src/Refactoring-Core/RBSplitClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBSplitClassRefactoring.class.st
@@ -95,7 +95,7 @@ RBSplitClassRefactoring >> abstractVariableReferences [
 
 { #category : #'private - transforming' }
 RBSplitClassRefactoring >> addClass [
-	self performCompositeRefactoring: (RBInsertClassRefactoring
+	self performCompositeRefactoring: (RBInsertNewClassRefactoring
 				model: self model
 				addClass: newClassName
 				superclass: Object

--- a/src/Refactoring2-Transformations-Tests/RBCopyPackageParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBCopyPackageParametrizedTest.class.st
@@ -39,7 +39,7 @@ RBCopyPackageParametrizedTest >> createPackageNamed: packageName withClasses: aC
 
 	aCollection do: [ : className |
 		| refactoring |
-		refactoring := RBInsertClassTransformation
+		refactoring := RBInsertNewClassTransformation
 						addClass: className
 						superclass: #Object
 						subclasses: #()

--- a/src/Refactoring2-Transformations-Tests/RBInsertClassParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBInsertClassParametrizedTest.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #tests }
 RBInsertClassParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
-		addCase: { #rbClass -> RBInsertClassRefactoring };
+		addCase: { #rbClass -> RBInsertNewClassRefactoring };
 		addCase: { #rbClass -> RBInsertClassTransformation };
 		yourself
 ]

--- a/src/Refactoring2-Transformations-Tests/RBInsertClassParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBInsertClassParametrizedTest.class.st
@@ -8,7 +8,7 @@ Class {
 RBInsertClassParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBInsertNewClassRefactoring };
-		addCase: { #rbClass -> RBInsertClassTransformation };
+		addCase: { #rbClass -> RBInsertNewClassTransformation };
 		yourself
 ]
 

--- a/src/Refactoring2-Transformations-Tests/RBRenameClassParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameClassParametrizedTest.class.st
@@ -143,7 +143,7 @@ rename class B to A
 	classA := ('RBClass' , 'ToRename') asSymbol.
 	classB := 'TestUnmarkClassRenameSource' asSymbol.
 	classC := 'TestUnmarkClassRenameTarget' asSymbol.
-	addClass := RBInsertClassTransformation
+	addClass := RBInsertNewClassTransformation
 		model: model
 		addClass: classB
 		superclass: #Object

--- a/src/Refactoring2-Transformations-Tests/RBTransformationsTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBTransformationsTest.class.st
@@ -125,7 +125,7 @@ RBTransformationsTest >> testCompositeTransform [
 	newClassName := (self changeMock name, 'Temporary') asSymbol.
 	transformation := RBCompositeTransformation new
 		transformations: (OrderedCollection new
-			add: (RBInsertClassTransformation
+			add: (RBInsertNewClassTransformation
 					addClass: newClassName
 					superclass: #Object
 					subclasses: #()

--- a/src/Refactoring2-Transformations/RBInsertNewClassTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBInsertNewClassTransformation.class.st
@@ -1,35 +1,16 @@
-"
-Adds a class in the image, optionally inside an hierarchy (with superclass or subclasses).
-
-Usage:
-| transformation |
-transformation := (RBInsertClassTransformation
-	addClass: #InsertedClass
-	superclass: #RBTransformationTest
-	subclasses: (Array with: RBInsertClassTransformationTest)
-	category: #'Refactoring2-Transformations-Tests')
-	transform.
-(ChangesBrowser changes: transformation model changes changes) open
-
-Preconditions:
-- superclass must be an existing class
-- each subclass also must be an existing class
-- name of the class to be added must be non-existent in the system
-- name of the category must be a valid one
-"
 Class {
-	#name : #RBInsertClassTransformation,
+	#name : #RBInsertNewClassTransformation,
 	#superclass : #RBClassTransformation,
 	#instVars : [
 		'superclass',
 		'subclasses',
 		'category'
 	],
-	#category : #'Refactoring2-Transformations-Model'
+	#category : #'Refactoring2-Transformations-Model-Unused'
 }
 
 { #category : #'instance creation' }
-RBInsertClassTransformation class >> addClass: aName superclass: aClass subclasses: aCollection category: aSymbol [
+RBInsertNewClassTransformation class >> addClass: aName superclass: aClass subclasses: aCollection category: aSymbol [
 
 	^ self new
 		addClass: aName
@@ -40,7 +21,7 @@ RBInsertClassTransformation class >> addClass: aName superclass: aClass subclass
 ]
 
 { #category : #'instance creation' }
-RBInsertClassTransformation class >> model: aRBSmalltalk addClass: aName superclass: aClass subclasses: aCollection category: aSymbol [
+RBInsertNewClassTransformation class >> model: aRBSmalltalk addClass: aName superclass: aClass subclasses: aCollection category: aSymbol [
 
 	^ self new
 		model: aRBSmalltalk;
@@ -52,7 +33,7 @@ RBInsertClassTransformation class >> model: aRBSmalltalk addClass: aName supercl
 ]
 
 { #category : #api }
-RBInsertClassTransformation >> addClass: aName superclass: aClass category: aSymbol [
+RBInsertNewClassTransformation >> addClass: aName superclass: aClass category: aSymbol [
 
 	self
 		addClass: aName
@@ -62,7 +43,7 @@ RBInsertClassTransformation >> addClass: aName superclass: aClass category: aSym
 ]
 
 { #category : #api }
-RBInsertClassTransformation >> addClass: aName superclass: superclassName subclasses: aCollection category: aSymbol [
+RBInsertNewClassTransformation >> addClass: aName superclass: superclassName subclasses: aCollection category: aSymbol [
 
 	self className: aName.
 	superclass := superclassName asSymbol.
@@ -71,7 +52,7 @@ RBInsertClassTransformation >> addClass: aName superclass: superclassName subcla
 ]
 
 { #category : #preconditions }
-RBInsertClassTransformation >> preconditions [
+RBInsertNewClassTransformation >> preconditions [
 	"Superclass and subclasses shouldn't be metaclasses.
 	Each subclass should be immediate subclass of superclass."
 
@@ -96,7 +77,7 @@ RBInsertClassTransformation >> preconditions [
 ]
 
 { #category : #executing }
-RBInsertClassTransformation >> privateTransform [
+RBInsertNewClassTransformation >> privateTransform [
 
 	self model
 		defineClass: ('<1p> %<%< #<2s> package: <3p>'
@@ -108,7 +89,7 @@ RBInsertClassTransformation >> privateTransform [
 ]
 
 { #category : #printing }
-RBInsertClassTransformation >> storeOn: aStream [
+RBInsertNewClassTransformation >> storeOn: aStream [
 
 	aStream nextPut: $(.
 	self class storeOn: aStream.

--- a/src/Refactoring2-Transformations/RBInsertNewClassTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBInsertNewClassTransformation.class.st
@@ -1,3 +1,24 @@
+"
+Adds a class in the image, optionally inside an hierarchy (with superclass or subclasses).
+
+Usage:
+```
+| transformation |
+transformation := (RBInsertClassTransformation
+	addClass: #InsertedClass
+	superclass: #RBTransformationTest
+	subclasses: (Array with: RBInsertClassTransformationTest)
+	category: #'Refactoring2-Transformations-Tests')
+	transform.
+(ChangesBrowser changes: transformation model changes changes) open
+```
+
+Preconditions:
+- superclass must be an existing class
+- each subclass also must be an existing class
+- name of the class to be added must be non-existent in the system
+- name of the category must be a valid one
+"
 Class {
 	#name : #RBInsertNewClassTransformation,
 	#superclass : #RBClassTransformation,

--- a/src/Refactoring2-Transformations/RBRenameAndDeprecateClassTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBRenameAndDeprecateClassTransformation.class.st
@@ -49,7 +49,7 @@ RBRenameAndDeprecateClassTransformation >> buildTransformations [
 
 	^ transformations ifNil: [
 		transformations := OrderedCollection
-			with: (RBInsertClassTransformation
+			with: (RBInsertNewClassTransformation
 						addClass: self tmpName
 						superclass: className asSymbol
 						subclasses: #()

--- a/src/Refactoring2-Transformations/RBSplitClassTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBSplitClassTransformation.class.st
@@ -82,7 +82,7 @@ RBSplitClassTransformation >> abstractVariableReferences [
 RBSplitClassTransformation >> addClass [
 
 	transformations add:
-		(RBInsertClassTransformation
+		(RBInsertNewClassTransformation
 			model: self model
 			addClass: newClassName
 			superclass: #Object

--- a/src/SystemCommands-ClassCommands/SycCmAddSubclassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycCmAddSubclassCommand.class.st
@@ -11,7 +11,7 @@ Class {
 SycCmAddSubclassCommand >> executeRefactoring [
 
 	| refactoring |
-	refactoring := RBInsertClassRefactoring
+	refactoring := RBInsertNewClassRefactoring
 		addClass: newClassName
 		superclass: targetClass asString
 		subclasses:  #()

--- a/src/SystemCommands-ClassCommands/SycCmAddSubclassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycCmAddSubclassCommand.class.st
@@ -11,7 +11,7 @@ Class {
 SycCmAddSubclassCommand >> executeRefactoring [
 
 	| refactoring |
-	refactoring := RBInsertClassTransformation
+	refactoring := RBInsertClassRefactoring
 		addClass: newClassName
 		superclass: targetClass asString
 		subclasses:  #()

--- a/src/SystemCommands-ClassCommands/SycCmInsertSubclassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycCmInsertSubclassCommand.class.st
@@ -12,7 +12,7 @@ Class {
 SycCmInsertSubclassCommand >> executeRefactoring [
 
 	| refactoring |
-	refactoring := RBInsertClassTransformation
+	refactoring := RBInsertClassRefactoring
 		addClass: newClassName
 		superclass: targetClass asString
 		subclasses: targetClass subclasses

--- a/src/SystemCommands-ClassCommands/SycCmInsertSubclassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycCmInsertSubclassCommand.class.st
@@ -12,7 +12,7 @@ Class {
 SycCmInsertSubclassCommand >> executeRefactoring [
 
 	| refactoring |
-	refactoring := RBInsertClassRefactoring
+	refactoring := RBInsertNewClassRefactoring
 		addClass: newClassName
 		superclass: targetClass asString
 		subclasses: targetClass subclasses

--- a/src/SystemCommands-ClassCommands/SycCmInsertSuperclassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycCmInsertSuperclassCommand.class.st
@@ -12,7 +12,7 @@ Class {
 SycCmInsertSuperclassCommand >> executeRefactoring [
 
 	| refactoring |
-	refactoring := RBInsertClassRefactoring
+	refactoring := RBInsertNewClassRefactoring
 		addClass: newClassName
 		superclass: targetClass superclass asString
 		subclasses: {targetClass}

--- a/src/SystemCommands-ClassCommands/SycCmInsertSuperclassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycCmInsertSuperclassCommand.class.st
@@ -12,7 +12,7 @@ Class {
 SycCmInsertSuperclassCommand >> executeRefactoring [
 
 	| refactoring |
-	refactoring := RBInsertClassTransformation
+	refactoring := RBInsertClassRefactoring
 		addClass: newClassName
 		superclass: targetClass superclass asString
 		subclasses: {targetClass}


### PR DESCRIPTION
`RBInserClassTransformation` and `RBInsertClassRefactoring` have the same duplicate logic. This PR addresses this issue by:
* migrating usages of `RBInserClassTransformation` to refactoring
* tagging transformation as unused
* renaming the refactoring so it's more clear that it will produce a new class