### PR TITLE
Fix selection of multiword

### DIFF
--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -309,12 +309,12 @@ CompletionEngine >> replaceTokenInEditorWith: aString [
 	| wordEnd old positionAfterFirstKeyword offset firstKeyword wordStart |
 	"Try to correctly replace the current token in the word.
 	The code editor should be able to do it by himself"
-	wordEnd := self editor nextWord: self editor caret.
+	wordEnd := (self editor nextWord: self editor caret - 1).
 	"If the returned index is the size of the text that means that the caret is at the end of the text and there is no more word after, so add 1 to the index to be out of range to select the entierely word because of the selectInvisiblyFrom:to: remove 1 just after to be at the end of then final word"
-	wordEnd = self editor text size ifTrue:[ wordEnd := wordEnd + 1 ].
-	
+	wordEnd > self editor text size ifTrue:[ wordEnd := wordEnd + 1 ].
+
 	wordStart := self editor previousWord: (self editor caret - 1).
-		
+
 	self editor
 		selectInvisiblyFrom: wordStart
 		to: wordEnd - 1.

--- a/src/NECompletion-Tests/CompletionEngineTest.class.st
+++ b/src/NECompletion-Tests/CompletionEngineTest.class.st
@@ -283,6 +283,25 @@ CompletionEngineTest >> testReplaceTokenAfterMovingCaretToMiddleOfWordWithFollow
 	self assert: editor text equals: 'self toto something that follows'
 ]
 
+{ #category : #tests }
+CompletionEngineTest >> testReplaceTokenWithCaretBeforeEndOfTextWithSpecialCharacterReplacesEntireWord [
+
+	"If the caret is at the end of a word, replace the entire word"
+
+	| text |
+	text := '(self mEthOdThatDoesNotExist)'.
+	self
+		setEditorText: text;
+		selectAt: text size "just before the closing parenthesis".
+
+	editor textArea openInWorld.
+	controller openMenu.
+
+	controller context replaceTokenInEditorWith: 'toto'.
+
+	self assert: editor text equals: '(self toto)'
+]
+
 { #category : #'tests - interaction' }
 CompletionEngineTest >> testReplaceTokenWithCaretInTheMiddleOfWordReplacesEntireWord [
 

--- a/src/NECompletion-Tests/CompletionEngineTest.class.st
+++ b/src/NECompletion-Tests/CompletionEngineTest.class.st
@@ -229,18 +229,18 @@ CompletionEngineTest >> testReplaceKeywordTokenWithCaretInTheEndOfWordWithFollow
 	"If the caret is at the end of a word, replace the entire word"
 
 	| text |
-	text := 'mEthOdThatDoesNotExist:'.
+	text := 'self mEthOdThatDoesNotExist: something that follows'.
 
 	self
 		setEditorText: text;
-		selectAt: text size + 1.
+		selectAt: 'self mEthOdThatDoesNotExist' size + 1.
 
 	editor textArea openInWorld.
 	controller openMenu.
 
-	controller context replaceTokenInEditorWith: 'toto'.
+	controller context replaceTokenInEditorWith: 'mEthOdThatDoesNotExist:'.
 
-	self assert: editor text asString equals: 'toto'
+	self assert: editor text asString equals: 'self mEthOdThatDoesNotExist: something that follows'
 ]
 
 { #category : #'tests - interaction' }

--- a/src/NECompletion-Tests/CompletionEngineTest.class.st
+++ b/src/NECompletion-Tests/CompletionEngineTest.class.st
@@ -229,18 +229,18 @@ CompletionEngineTest >> testReplaceKeywordTokenWithCaretInTheEndOfWordWithFollow
 	"If the caret is at the end of a word, replace the entire word"
 
 	| text |
-	text := 'self mEthOdThatDoesNotExist: something that follows'.
+	text := 'mEthOdThatDoesNotExist:'.
 
 	self
 		setEditorText: text;
-		selectAt: 'self mEthOdThatDoesNotExist' size + 1.
+		selectAt: text size + 1.
 
 	editor textArea openInWorld.
 	controller openMenu.
 
-	controller context replaceTokenInEditorWith: 'mEthOdThatDoesNotExist:'.
+	controller context replaceTokenInEditorWith: 'toto'.
 
-	self assert: editor text asString equals: 'self mEthOdThatDoesNotExist: something that follows'
+	self assert: editor text asString equals: 'toto'
 ]
 
 { #category : #'tests - interaction' }

--- a/src/Rubric-Tests/RubTextEditorTest.class.st
+++ b/src/Rubric-Tests/RubTextEditorTest.class.st
@@ -5,7 +5,8 @@ Class {
 	#name : #RubTextEditorTest,
 	#superclass : #TestCase,
 	#instVars : [
-		'editor'
+		'editor',
+		'string'
 	],
 	#category : #'Rubric-Tests-Editing-Core'
 }
@@ -16,26 +17,38 @@ RubTextEditorTest >> setUp [
 	super setUp.
 	editor := RubTextEditor forTextArea: RubTextFieldArea new.
 	"Add text with a paragraph"
-	editor addString: 'Lorem ipsum dolor sit amet'.
+	string := 'Lorem ipsum '.
+	editor addString: string
 ]
 
 { #category : #tests }
 RubTextEditorTest >> testNextWord [
 
 	| textSize |
-	textSize := 'Lorem ipsum dolor sit amet' size.
+	textSize := string size.
 	self assert: (editor nextWord: -999) equals: 1. "Out of range"
 	self assert: (editor nextWord: 0) equals: 1. "Out of range"
-	self assert: (editor nextWord: 1) equals: 1. "L|orem ipsum >> L|orem ipsum"
-	self assert: (editor nextWord: 2) equals: 6. "Lo|rem ipsum >> Lorem |ipsum"
-	self assert: (editor nextWord: 4) equals: 6. "Lore|m ipsum >> Lorem |ipsum"
-	self assert: (editor nextWord: 11) equals: 12. "Lorem ipsum| dolor >> Lorem ipsum |dolor"
-	self assert: (editor nextWord: 18) equals: 18. "Lorem ipsum dolor |sit amet >> Lorem ipsum dolor |sit amet"
-	self assert: (editor nextWord: (textSize - 2)) equals: textSize. "Lorem ipsum dolor sit am|et >> Lorem ipsum dolor sit amet|"
-	self assert: (editor nextWord: (textSize - 1)) equals: textSize. "Lorem ipsum dolor sit ame|t >> Lorem ipsum dolor sit amet|"
-	self assert: (editor nextWord: (textSize)) equals: textSize. "Lorem ipsum dolor sit amet| >> Lorem ipsum dolor sit amet|"
-	self assert: (editor nextWord: (textSize + 1)) equals: textSize. "Out of range"
-	self assert: (editor nextWord: 999) equals: textSize. "Out of range"
+
+	1 to: 5 do: [ :i |
+		"From:   |Lorem ipsum
+		 To:     Lore|m ipsum
+		 Should be: Lorem| ipsum"
+		self assert: (editor nextWord: i) equals: 6 ].
+
+	"Lorem| ipsum >> Lorem |ipsum"
+	self assert: (editor nextWord: 6) equals: 7.
+
+	7 to: 11 do: [ :i |
+		"From:   Lorem |ipsum
+		 To:     Lorem ipsu|m
+		 Should be: Lorem ipsum|"
+		self assert: (editor nextWord: i) equals: 12 ].
+
+	"There is a space after ipsum:"
+	"Lorem ipsum| >> Lorem ipsum |"
+	self assert: (editor nextWord: 12) equals: 13.
+
+	self assert: (editor nextWord: 999) equals: textSize + 1. "Out of range"
 ]
 
 { #category : #tests }

--- a/src/Rubric-Tests/RubTextEditorTest.class.st
+++ b/src/Rubric-Tests/RubTextEditorTest.class.st
@@ -26,8 +26,8 @@ RubTextEditorTest >> testNextWord [
 
 	| textSize |
 	textSize := string size.
-	self assert: (editor nextWord: -999) equals: 1. "Out of range"
-	self assert: (editor nextWord: 0) equals: 1. "Out of range"
+	self assert: (editor nextWord: -999) equals: 6. "Out of range means start of text"
+	self assert: (editor nextWord: 0) equals: 6. "Out of range means start of text"
 
 	1 to: 5 do: [ :i |
 		"From:   |Lorem ipsum
@@ -55,53 +55,66 @@ RubTextEditorTest >> testNextWord [
 RubTextEditorTest >> testPreviousWord [
 
 	| textSize |
-	textSize := 'Lorem ipsum dolor sit amet' size.
+	textSize := 'Lorem ipsum ' size.
+	self assert: (editor previousWord: -999) equals: 1. "Out of range"
 	self assert: (editor previousWord: 0) equals: 1. "Out of range"
-	self assert: (editor previousWord: 1) equals: 1. "L|orem ipsum >> L|orem ipsum"
-	self assert: (editor previousWord: 4) equals: 1. "Lore|m ipsum >> L|orem ipsum"
-	self assert: (editor previousWord: 11) equals: 7. "Lorem ipsum| >> Lorem i|psum"
-	self assert: (editor previousWord: 18) equals: 18. "Lorem ipsum dolor |sit amet >> Lorem ipsum dolor |sit amet"
-	self assert: (editor previousWord: (textSize - 1)) equals: (textSize - 3). "Lorem ipsum dolor sit ame|t >> Lorem ipsum dolor sit a|met"
-	self assert: (editor previousWord: (textSize)) equals: (textSize - 3). "Lorem ipsum dolor sit amet| >> Lorem ipsum dolor sit a|met"
-	self assert: (editor previousWord: (textSize + 1)) equals: (textSize). "Out of range"
-	self assert: (editor previousWord: 999) equals: (textSize). "Out of range"
+
+	1 to: 7 do: [ :i |
+		"From:   |Lorem ipsum
+		 To:     Lore|m ipsum
+		 Should be: Lorem| ipsum"
+		self assert: (editor previousWord: i) equals: 1 ].
+
+	8 to: 13 do: [ :i |
+		"From:   Lorem |ipsum
+		 To:     Lorem ipsu|m
+		 Should be: Lorem ipsum|"
+		self assert: (editor previousWord: i) equals: 7 ].
+
+	self assert: (editor previousWord: 999) equals: 7. "Out of range"
 ]
 
 { #category : #tests }
 RubTextEditorTest >> testSelectWordMarkPoint [
 
 	| textSize |
+	string := 'Lorem ipsum dolor sit amet'.
+	editor addString: string.
 	textSize := editor string size.
-	
+
 	editor selectWordMark: 0 point: 0. "Lorem ipsum dolor sit amet >> [L]orem ipsum dolor sit amet "
 	self assert: editor markIndex equals: 1.
-	self assert: editor pointIndex equals: 2.	
-	
+	self assert: editor pointIndex equals: 6.
+
 	editor selectWordMark: 2 point: 4. "Lorem ipsum dolor sit amet >> [Lorem ]ipsum dolor sit amet "
 	self assert: editor markIndex equals: 1.
-	self assert: editor pointIndex equals: 7.	
-	
+	self assert: editor pointIndex equals: 6.
+
+	editor selectWordMark: 9 point: 11. "Lorem ipsum dolor sit amet >> Lorem [ipsum] dolor sit amet "
+	self assert: editor markIndex equals: 7.
+	self assert: editor pointIndex equals: 12.
+
 	editor selectWordMark: 9 point: 12. "Lorem ipsum dolor sit amet >> Lorem [ipsum ]dolor sit amet "
 	self assert: editor markIndex equals: 7.
-	self assert: editor pointIndex equals: 13.	
-	
+	self assert: editor pointIndex equals: 13.
+
 	editor selectWordMark: 3 point: 24. "Lorem ipsum dolor sit amet >> [Lorem ipsum dolor sit amet ]"
 	self assert: editor markIndex equals: 1.
-	self assert: editor pointIndex equals: 26 + 1.	
-	
+	self assert: editor pointIndex equals: 26 + 1.
+
 	editor selectWordMark: 1 point: 26. "Lorem ipsum dolor sit amet >> [Lorem ipsum dolor sit amet ]"
 	self assert: editor markIndex equals: 1.
-	self assert: editor pointIndex equals: 26 + 1.	
-	
-	editor selectWordMark: 1 point: 1. "Lorem ipsum dolor sit amet >> [L]orem ipsum dolor sit amet"
+	self assert: editor pointIndex equals: 26 + 1.
+
+	editor selectWordMark: 1 point: 1. "Lorem ipsum dolor sit amet >> [Lorem] ipsum dolor sit amet"
 	self assert: editor markIndex equals: 1.
-	self assert: editor pointIndex equals: 2.	
-	
+	self assert: editor pointIndex equals: 6.
+
 	editor selectWordMark: 26 point: 26. "Lorem ipsum dolor sit amet >> Lorem ipsum dolor sit [amet ]"
 	self assert: editor markIndex equals: 23.
-	self assert: editor pointIndex equals: 26 + 1.	
-	
-	editor selectWordMark: 999 point: 999. "Lorem ipsum dolor sit amet >> Lorem ipsum dolor sit amet[]"
-	self assert: editor markIndex equals: 26.
 	self assert: editor pointIndex equals: 26 + 1.
+
+	editor selectWordMark: 999 point: 999. "Lorem ipsum dolor sit amet >> Lorem ipsum dolor sit [amet]"
+	self assert: editor markIndex equals: 23.
+	self assert: editor pointIndex equals: 26 + 1
 ]

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -1175,7 +1175,7 @@ RubTextEditor >> forwardDelete: aKeyboardEvent [
 			| idx1 idx2 |
 			idx1 := self startIndex min: self stopIndex.
 			idx2 := self stopIndex max: self startIndex.
-			aKeyboardEvent controlKeyPressed
+			aKeyboardEvent controlKeyPressed | aKeyboardEvent commandKeyPressed
 				ifTrue: [ idx2 := self nextWord: idx1 + 1 ]
 				ifFalse: [ idx2 := idx2 + 1 ].
 			self selectInvisiblyFrom: idx1 to: idx2 - 1 ].
@@ -1593,19 +1593,22 @@ RubTextEditor >> nextCharacterIfAbsent: aBlock [
 
 { #category : #private }
 RubTextEditor >> nextWord: position [
-	| string index initialIsAlphaNumeric size |
 
-	position <= 1 ifTrue:[ ^ 1 ].	
+	| string index initialIsAlphaNumeric size |
+	"Positions go from 1 to size + 1
+	Position N + 1 is after the Nth character"
+	position < 1 ifTrue: [ ^ 1 ].
 	string := self string.
-	size := string size.
+	size := string size + 1.
 	position >= size ifTrue: [ ^ size ].
 
 	index := position.
-	initialIsAlphaNumeric := self isWordCharacterAt: (index - 1) in: string.
+	initialIsAlphaNumeric := self isWordCharacterAt: index in: string.
 
-	[(index < size) 
-		and: [ (self isWordCharacterAt: index in: string) = initialIsAlphaNumeric]]
-			whileTrue: [index := index + 1].
+	[
+	index < size and: [
+		(self isWordCharacterAt: index in: string) = initialIsAlphaNumeric ] ]
+		whileTrue: [ index := index + 1 ].
 
 	^ index
 ]

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -1597,12 +1597,12 @@ RubTextEditor >> nextWord: position [
 	| string index initialIsAlphaNumeric size |
 	"Positions go from 1 to size + 1
 	Position N + 1 is after the Nth character"
-	position < 1 ifTrue: [ ^ 1 ].
+	index := 1 max: position.
+
 	string := self string.
 	size := string size + 1.
 	position >= size ifTrue: [ ^ size ].
 
-	index := position.
 	initialIsAlphaNumeric := self isWordCharacterAt: index in: string.
 
 	[
@@ -1748,19 +1748,38 @@ RubTextEditor >> previousCharacterIfAbsent: aBlock [
 
 { #category : #private }
 RubTextEditor >> previousWord: position [
-	| string index initialIsAlphaNumeric size |
-	position <= 1 ifTrue: [ ^ 1 ].	
+
+	| string index size beforeCaretIsAlpha afterCaretIsAlpha |
+	"The main strategy behind this is to move the caret backwards until there is a alpha/nonalpha or nonalpha/alpha pair.
+	To avoid staying in the same place, we need always move the character at least once before checking the condition"
+
+	position <= 2 ifTrue: [ ^ 1 ].
 	string := self string.
 	size := string size.
-	position > size ifTrue: [ ^ size ].
-	
-	index := position.
-	initialIsAlphaNumeric := self isWordCharacterAt: index in: string.
 
-	[index := index - 1] doWhileTrue:
-		[(index > 0) and: [ (self isWordCharacterAt: index in: string) = initialIsAlphaNumeric]].
+	"If we ask for the word starting after the string, start at the end of the string.
+	Remember that there are N+1 caret positions for a N-sized string."
+	index := (size + 1) min: position.
 
-	^ index + 1
+	"Go backwards once and check if character before the caret is alphanumeric.
+	If not alphanumeric, we go backwards once more.
+	This handles the case when the caret is after the first character of a word, in which case we should just go once backwards.
+	All other cases should go backwards more than once."
+	index := index - 1.
+	beforeCaretIsAlpha := index = 1 or: [
+		                      self isWordCharacterAt: index in: string ].
+	beforeCaretIsAlpha ifFalse: [
+		index := index - 1 ].
+
+	"Finally, iterate backwards until the alphanumericness before and after the caret changes"
+	[
+	afterCaretIsAlpha := beforeCaretIsAlpha := index = 1 or: [
+		                      self isWordCharacterAt: index in: string ].
+	beforeCaretIsAlpha := index = 1 or: [
+		                      self isWordCharacterAt: index - 1 in: string ].
+	beforeCaretIsAlpha = afterCaretIsAlpha and: [ index > 1 ] ]
+		whileTrue: [ index := index - 1 ].
+	^ index
 ]
 
 { #category : #'nonediting/nontyping keys' }
@@ -2132,17 +2151,19 @@ RubTextEditor >> selectWord: aKeyboardEvent [
 
 { #category : #'new selection' }
 RubTextEditor >> selectWordMark: marker point: selectionPoint [
+
 	| marker2 selectionPoint2 |
 	"This method is used my mouse drag.
 	It selects the correct words between the original point and the selection cursor point"
-	marker <= selectionPoint ifTrue: [
-		marker2 := self previousWord: marker.
-		selectionPoint2 := self nextWord: selectionPoint.
-	] ifFalse: [
-		"Mark calculations makes that its value sometimes is 0, and the next call fails without checking the border case."
-		marker2 := self nextWord: (marker > 0 ifTrue:[ marker ] ifFalse:[ 1 ]).
-		selectionPoint2 := (self previousWord: selectionPoint) - 1.
-	].
+	marker <= selectionPoint
+		ifTrue: [
+			marker2 := self previousWord: marker.
+			selectionPoint2 := (self nextWord: selectionPoint) - 1 ]
+		ifFalse: [ "Mark calculations makes that its value sometimes is 0, and the next call fails without checking the border case."
+			marker2 := self nextWord: (marker > 0
+					            ifTrue: [ marker ]
+					            ifFalse: [ 1 ]).
+			selectionPoint2 := (self previousWord: selectionPoint) - 1 ].
 
 	self selectMark: marker2 point: selectionPoint2
 ]


### PR DESCRIPTION
A string of N characters have N+1 caret positions. `#nextWord:` should take that into account.

Fix forwardDelete: also for mac machines