### PR TITLE
Faulty code snippet: test evaluation

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -1791,11 +1791,18 @@ RBCodeSnippet >> group: aString [
 RBCodeSnippet >> hasAllNotices: someNotices [
 
 	(self notices ifNil: [0] ifNotNil: [self notices size]) = someNotices size ifFalse: [ ^ false ].
-	^ someNotices allSatisfy: [ :each |
-		  self notices anySatisfy: [ :each2 |
-			  each node start = each2 first & (each node stop = each2 second)
-			  & (each position = each2 third)
-			  & (each messageText = each2 fourth) ] ]
+	^ someNotices allSatisfy: [ :each | self hasNotice: each ]
+]
+
+{ #category : #testing }
+RBCodeSnippet >> hasNotice: aNotice [
+
+	self notices ifNil: [ ^ false ].
+	^ self notices anySatisfy: [ :each |
+		aNotice node start = each first
+		& (aNotice node stop = each second)
+		& (aNotice position = each third)
+		& (aNotice messageText = each fourth) ]
 ]
 
 { #category : #testing }

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -1814,6 +1814,13 @@ RBCodeSnippet >> hasNotice: aString at: anInteger [
 		  each third = anInteger and: [ each fourth = aString ] ]
 ]
 
+{ #category : #testing }
+RBCodeSnippet >> hasUndeclared [
+
+	self notices ifNil: [ ^ false ].
+	^ self notices anySatisfy: [ :n | n fourth = 'Undeclared variable' ]
+]
+
 { #category : #accessing }
 RBCodeSnippet >> hasValue [
 

--- a/src/AST-Core-Tests/RBCodeSnippetScriptingTest.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippetScriptingTest.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : #RBCodeSnippetScriptingTest,
+	#superclass : #RBCodeSnippetTest,
+	#category : #'AST-Core-Tests-Snippets'
+}
+
+{ #category : #tests }
+RBCodeSnippetScriptingTest class >> testParameters [
+
+	^ ParametrizedTestMatrix new
+		  forSelector: #snippet addOptions: (RBCodeSnippet allSnippets select: [:each | each isMethod not ]);
+		  yourself
+]

--- a/src/AST-Core-Tests/RBCodeSnippetTest.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippetTest.class.st
@@ -49,7 +49,7 @@ RBCodeSnippetTest >> snippet: anObject [
 { #category : #tests }
 RBCodeSnippetTest >> testCodeImporter [
 
-	| string importer class runBlock value |
+	| string importer class runBlock |
 	"Code importer meed a plain expression or use a custom format"
 	snippet source isAllSeparators ifTrue: [ ^ self skip ].
 	string := snippet isMethod
@@ -74,6 +74,7 @@ RBCodeSnippetTest >> testCodeImporter [
 
 	"When not faulty, it's more complicated..."
 	runBlock := [
+	            | value |
 	            value := importer evaluate.
 
 	            snippet isMethod ifTrue: [
@@ -85,20 +86,9 @@ RBCodeSnippetTest >> testCodeImporter [
 		            phonyArgs := (1 to: method numArgs) asArray.
 		            value := nil withArgs: phonyArgs executeMethod: method ].
 
-	            "Need to execute the block (see testExecute for rationale)"
-	            value isBlock ifTrue: [
-		            | phonyBlockArgs |
-		            phonyBlockArgs := (1 to: value numArgs) asArray.
-		            value := value valueWithArguments: phonyBlockArgs ] ].
+	            value ].
 
-	snippet messageNotUnderstood ifNotNil: [ :mnu |
-		runBlock onDNU: mnu do: [ ^ self ].
-		^ self signalFailure: 'Should have raised MNU ' , mnu ].
-
-	snippet raise ifNotNil: [ :r | ^ self should: runBlock raise: r ].
-
-	self shouldnt: runBlock raise: CodeError.
-	self assert: value equals: snippet value
+	self testExecuteBlock: runBlock
 ]
 
 { #category : #tests }

--- a/src/OpalCompiler-Tests/RBCodeSnippetScriptingTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetScriptingTest.extension.st
@@ -1,0 +1,46 @@
+Extension { #name : #RBCodeSnippetScriptingTest }
+
+{ #category : #'*OpalCompiler-Tests' }
+RBCodeSnippetScriptingTest >> testEvaluateFaulty [
+
+	| runBlock |
+	self skipIf: #exec.
+
+	runBlock := [
+		OpalCompiler new
+			permitFaulty: true;
+			evaluate: snippet source ].
+
+	self testExecuteBlock: runBlock
+]
+
+{ #category : #'*OpalCompiler-Tests' }
+RBCodeSnippetScriptingTest >> testEvaluateOnError [
+
+	| runBlock value |
+	self skipIf: #exec.
+
+	value := #tag.
+	runBlock := [ value := OpalCompiler new evaluate: snippet source ].
+
+	snippet isFaulty
+		ifTrue: [
+			self should: runBlock raise: CodeError.
+			self assert: value equals: #tag ]
+		ifFalse: [ self testExecuteBlock: runBlock ]
+]
+
+{ #category : #'*OpalCompiler-Tests' }
+RBCodeSnippetScriptingTest >> testEvaluateOnErrorResume [
+
+	| runBlock value |
+	self skipIf: #exec.
+
+	value := #tag.
+	runBlock := [
+	            [ OpalCompiler new evaluate: snippet source ]
+		            on: CodeError
+		            do: [ :e | e resume ] ].
+
+	self testExecuteBlock: runBlock
+]

--- a/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : #RBCodeSnippetTest }
 
 { #category : #'*OpalCompiler-Tests' }
-RBCodeSnippetTest >> testCompile [
+RBCodeSnippetTest >> testCompileFaulty [
 
 	| method |
 

--- a/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
@@ -144,21 +144,31 @@ RBCodeSnippetTest >> testExecute: method [
 	self assert: method isCompiledMethod.
 
 	phonyArgs := (1 to: method numArgs) asArray.
+	runBlock := [ nil withArgs: phonyArgs executeMethod: method ].
 
-	"Executing a lone block will just return a block, we have to call value to have something more interesting"
-	snippet parse isBlock
-		ifTrue: [
-			| block phonyBlockArgs |
-			block := nil withArgs: phonyArgs executeMethod: method.
-			phonyBlockArgs := (1 to: block numArgs) asArray.
-			runBlock := [ block valueWithArguments: phonyBlockArgs ] ]
-		ifFalse: [ runBlock := [ nil withArgs: phonyArgs executeMethod: method ] ].
+	self testExecuteBlock: runBlock
+]
 
+{ #category : #'*OpalCompiler-Tests' }
+RBCodeSnippetTest >> testExecuteBlock: aRunBlock [
+
+	| runBlock |
+	"a block that apply value on aRunBlock until it's no more a block"
+	runBlock := [
+	            | value block phonyBlockArgs |
+	            block := aRunBlock.
+	            [  phonyBlockArgs := (1 to: block numArgs) asArray.
+	               value := block valueWithArguments: phonyBlockArgs.
+	               value isBlock ] whileTrue: [ block := value ].
+	            value ].
+
+	"Now we can evaluate and check the various possible expectations"
 	snippet messageNotUnderstood ifNotNil: [ :mnu |
 		runBlock onDNU: mnu do: [ ^ self ].
 		self signalFailure: 'Should have raised MNU ' , mnu ].
 
-	snippet raise ifNotNil: [ :class | ^ self should: runBlock raise: class ].
+	snippet raise ifNotNil: [ :class |
+		^ self should: runBlock raise: class ].
 
 	snippet hasValue
 		ifFalse: [ self should: runBlock raise: RuntimeSyntaxError ]


### PR DESCRIPTION
Evaluation of random strings (the evil eval) can be performed with `OpalCompiler evaluate: aString`.
CodeSnippet did not have tests to check it, it is now done.

Because only scripts can be evaluated (not method definitions), a subclass `RBCodeSnippetScriptingTest` is created that matrix tests only on scripts.

Some cleanup is performed on RBCodeSnippet. Especially, a new method `testExecuteBlock:` to factorize the execution and check of a snippet byproduct.