### PR TITLE
Finder: Ignoring combinations selector for collections

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -128,6 +128,7 @@ RBCodeSnippet class >> badExpressions [
 		"Note: bad temporaries will be stored as error statements"
 		self new source: '| '.
 		self new source: '| a b'.
+		self new source: '|-'; formattedCode: '| . - '. "Here |- is scanned as a single operator token, so parser must work more"
 		self new source: '| 1'; formattedCode: '| . 1'.
 		"Note that the | character is also a binary operator, so a missing opening | become a binary call with a missing argument (see bellow)"
 		self new source: 'a | '.

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -1403,6 +1403,9 @@ RBParser >> stepBar [
 	value := currentToken value.
 	(value size < 2 or: [ value first ~= $| ]) ifTrue: [ ^ self step ].
 
+	"Because the current token might escape, we need to update the old curent token and create a new current token"
+	currentToken value: '|'.
+	currentToken := currentToken clone.
 	currentToken value: value allButFirst.
 	currentToken start: currentToken start + 1
 ]

--- a/src/Debugger-Model/DebugContext.class.st
+++ b/src/Debugger-Model/DebugContext.class.st
@@ -33,8 +33,7 @@ Class {
 	#name : #DebugContext,
 	#superclass : #Object,
 	#instVars : [
-		'context',
-		'topContext'
+		'context'
 	],
 	#category : #'Debugger-Model-Core'
 }
@@ -110,8 +109,7 @@ DebugContext >> evaluate: expression [
 
 { #category : #initialization }
 DebugContext >> forContext: aContext [
-	context := aContext.
-	topContext := aContext
+	context := aContext
 ]
 
 { #category : #accessing }
@@ -191,9 +189,4 @@ DebugContext >> selectedMessageName [
 DebugContext >> source [
 	"Answer the source code of the currently selected context."
 	^ context sourceCode
-]
-
-{ #category : #initialization }
-DebugContext >> topContext: aContext [
-	topContext := aContext
 ]

--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -98,7 +98,7 @@ DebugSession >> contextChanged [
 { #category : #accessing }
 DebugSession >> createModelForContext: aContext [
 
-	^ (self class contextModelClass forContext: aContext) topContext: interruptedContext
+	^ (self class contextModelClass forContext: aContext)
 ]
 
 { #category : #initialization }

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -2039,13 +2039,16 @@ Object >> subclassResponsibility [
 Object >> toFinalizeSend: aSelector to: aFinalizer with: aResourceHandle [
 	"When I am finalized (e.g., garbage collected) close the associated resource handle by sending aSelector to the appropriate finalizer (the guy who knows how to get rid of the resource).
 	WARNING: Neither the finalizer nor the resource handle are allowed to reference me. If they do, then I will NEVER be garbage collected. Since this cannot be validated here, it is up to the client to make sure this invariant is not broken."
-	self == aFinalizer ifTrue:[self error: 'I cannot finalize myself'].
-	self == aResourceHandle ifTrue:[self error: 'I cannot finalize myself'].
-	^self finalizationRegistry add: self executor:
-		(ObjectFinalizer new
-			receiver: aFinalizer
-			selector: aSelector
-			argument: aResourceHandle)
+
+	self == aFinalizer ifTrue: [ self error: 'I cannot finalize myself' ].
+	self == aResourceHandle ifTrue: [
+		self error: 'I cannot finalize myself' ].
+	^ self finalizationRegistry
+		  add: self
+		  finalizer: (ObjectFinalizer new
+				   receiver: aFinalizer
+				   selector: aSelector
+				   argument: aResourceHandle)
 ]
 
 { #category : #'error handling' }

--- a/src/MonticelloGUI/MCCodeTool.class.st
+++ b/src/MonticelloGUI/MCCodeTool.class.st
@@ -167,12 +167,6 @@ MCCodeTool >> selectedClass [
 ]
 
 { #category : #subclassresponsibility }
-MCCodeTool >> selectedClassOrMetaClass [
-	"Answer the class that is selected, or nil"
-	self subclassResponsibility
-]
-
-{ #category : #subclassresponsibility }
 MCCodeTool >> selectedMessageCategoryName [
 	"Answer the method category of the method that is selected, or nil"
 	self subclassResponsibility

--- a/src/MonticelloGUI/MCTool.class.st
+++ b/src/MonticelloGUI/MCTool.class.st
@@ -299,6 +299,11 @@ MCTool >> preferredColor [
 	^ (Color r: 0.627 g: 0.69 b: 0.976)
 ]
 
+{ #category : #accessing }
+MCTool >> selectedClassOrMetaClass [
+	^nil
+]
+
 { #category : #'morphic ui' }
 MCTool >> setDefaultFocus [
 	"set the default focus on the morph elements.

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -20,7 +20,9 @@ Class {
 	#instVars : [
 		'methodBuilder',
 		'effectTranslator',
-		'valueTranslator'
+		'valueTranslator',
+		'nextUniqueInlineID',
+		'parentTranslator'
 	],
 	#classVars : [
 		'OptimizedMessages'
@@ -281,40 +283,47 @@ OCASTTranslator >> emitRuntimeError: aNode [
 
 { #category : #'inline messages' }
 OCASTTranslator >> emitTimesRepeat: aMessageNode [
-	| limit block limitEmit |
 
+	| limit block limitEmit limitVariableName iteratorVariableName uniqueInlineID startLabelName doneLabelName |
 	limit := aMessageNode receiver.
 	block := aMessageNode arguments last.
+	uniqueInlineID := self nextUniqueInlineID.
+	limitVariableName := uniqueInlineID , #limit.
+	iteratorVariableName := uniqueInlineID , #iterator.
+	startLabelName := uniqueInlineID , #start.
+	doneLabelName := uniqueInlineID , #done.
 
-	limitEmit := [valueTranslator visitNode: limit].
+	limitEmit := [ valueTranslator visitNode: limit ].
 	"if the limit is not just a literal or a non-writable variable, make a temp store it there"
-	(limit isLiteralNode or: [limit isVariable and: [limit variable isWritable not]]) ifFalse: [
-		valueTranslator visitNode: limit.
-		methodBuilder addTemp: #'0limit'.
-		methodBuilder storeTemp: #'0limit'.
-		methodBuilder popTop.
-		limitEmit := [methodBuilder pushTemp: #'0limit']].
+	(limit isLiteralNode or: [
+		 limit isVariable and: [ limit variable isWritable not ] ])
+		ifFalse: [
+			valueTranslator visitNode: limit.
+			methodBuilder addTemp: limitVariableName.
+			methodBuilder storeTemp: limitVariableName.
+			methodBuilder popTop.
+			limitEmit := [ methodBuilder pushTemp: limitVariableName ] ].
 
 	"push start. allocate and initialize iterator"
 	self isValueTranslator ifTrue: [ limitEmit value ].
 	methodBuilder pushLiteral: 1.
-	methodBuilder addTemp: #'0iterator'.
-	methodBuilder storeTemp: #'0iterator'.
+	methodBuilder addTemp: iteratorVariableName.
+	methodBuilder storeTemp: iteratorVariableName.
 	methodBuilder popTop.
-	methodBuilder jumpBackTarget: #start.
-	methodBuilder pushTemp: #'0iterator'.
+	methodBuilder jumpBackTarget: startLabelName.
+	methodBuilder pushTemp: iteratorVariableName.
 	limitEmit value.
-	methodBuilder send: #<=.
-	methodBuilder jumpAheadTo: #done if: false.
+	methodBuilder send: #'<='.
+	methodBuilder jumpAheadTo: doneLabelName if: false.
 
 	effectTranslator visitInlinedBlockNode: block.
-	methodBuilder pushTemp: #'0iterator'.
+	methodBuilder pushTemp: iteratorVariableName.
 	methodBuilder pushLiteral: 1.
 	methodBuilder send: #+.
-	methodBuilder storeTemp: #'0iterator'.
+	methodBuilder storeTemp: iteratorVariableName.
 	methodBuilder popTop.
-	methodBuilder jumpBackTo: #start.
-	methodBuilder jumpAheadTarget: #done
+	methodBuilder jumpBackTo: startLabelName.
+	methodBuilder jumpAheadTarget: doneLabelName
 ]
 
 { #category : #'inline messages' }
@@ -399,11 +408,14 @@ OCASTTranslator >> emitWhileTrue: aMessageNode [
 { #category : #initialization }
 OCASTTranslator >> initialize [
 
+	super initialize.
+	
 	methodBuilder := IRBuilder new.
 	effectTranslator := self classForEffect basicNew.
 	valueTranslator := self classForValue basicNew.
 	effectTranslator setFromSimilar: self.
-	valueTranslator setFromSimilar: self
+	valueTranslator setFromSimilar: self.
+	nextUniqueInlineID := 0
 ]
 
 { #category : #accessing }
@@ -422,6 +434,17 @@ OCASTTranslator >> isValueTranslator [
 	^self == valueTranslator
 ]
 
+{ #category : #'inline messages' }
+OCASTTranslator >> nextUniqueInlineID [
+
+	"The UniqueID has to be shared between the hierarchy of OCASTTranslators.
+	The OCASTTranslator has inside one for Effect and one for value. They should share ID values."
+	parentTranslator ifNotNil: [ ^ parentTranslator nextUniqueInlineID ].
+
+	nextUniqueInlineID := nextUniqueInlineID + 1.
+	^ nextUniqueInlineID asString asSymbol
+]
+
 { #category : #private }
 OCASTTranslator >> privateEffectTranslator [
 	^ effectTranslator
@@ -438,10 +461,11 @@ OCASTTranslator >> privateValueTranslator [
 ]
 
 { #category : #initialization }
-OCASTTranslator >> setFromSimilar: aSimilarTranslator [
-	methodBuilder := aSimilarTranslator privateMethodBuilder.
-	effectTranslator := aSimilarTranslator privateEffectTranslator.
-	valueTranslator := aSimilarTranslator privateValueTranslator
+OCASTTranslator >> setFromSimilar: aParentTranslator [
+	methodBuilder := aParentTranslator privateMethodBuilder.
+	effectTranslator := aParentTranslator privateEffectTranslator.
+	valueTranslator := aParentTranslator privateValueTranslator.
+	parentTranslator := aParentTranslator.
 ]
 
 { #category : #errors }

--- a/src/OpalCompiler-Tests/OCASTTimesRepeatTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTTimesRepeatTranslatorTest.class.st
@@ -11,6 +11,42 @@ OCASTTimesRepeatTranslatorTest class >> testParameters [
 			forSelector: #optimization addOptions: { #optionInlineTimesRepeat . #optionInlineNone })
 ]
 
+{ #category : #tests }
+OCASTTimesRepeatTranslatorTest >> testNestedTimesRepeat [
+
+	| result |
+
+	result := self testSource: 'example
+		| s |
+		s := OrderedCollection new.
+		
+			3 timesRepeat: [ 
+			  s add: #outer.
+			4 timesRepeat: [ 
+		     s add: #inner ] ].
+		^ s'.
+		
+	self assert: result equals: #(#outer #inner #inner #inner #inner #outer #inner #inner #inner #inner #outer #inner #inner #inner #inner) asOrderedCollection.
+]
+
+{ #category : #tests }
+OCASTTimesRepeatTranslatorTest >> testSequencedTimesRepeat [
+
+	| result |
+
+	result := self testSource: 'example
+		| s |
+		s := OrderedCollection new.
+		
+			3 timesRepeat: [ 
+			  s add: #first ].
+			4 timesRepeat: [ 
+		     s add: #second ].
+		^ s'.
+		
+	self assert: result equals: #(#first #first #first #second #second #second #second) asOrderedCollection.
+]
+
 { #category : #'tests - blocks - optimized' }
 OCASTTimesRepeatTranslatorTest >> testTimesRepeatExecutesBlock [
 

--- a/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
@@ -26,7 +26,9 @@ OCASTTranslatorTest >> compilationContext [
 	context := CompilationContext new
 		encoderClass: self encoder;
 		bindings: globals;
-		yourself.
+		parseOptions: { #'+' . optimization };
+		yourself.	
+	
 	^ context
 ]
 

--- a/src/Tool-Finder/Collection.extension.st
+++ b/src/Tool-Finder/Collection.extension.st
@@ -5,3 +5,9 @@ Collection class >> approvedSelectorsForMethodFinder [
 
 	 ^ self selectors
 ]
+
+{ #category : #'*Tool-Finder' }
+Collection class >> forbiddenSelectorsForMethodFinder [
+
+	^ #( #combinations )
+]

--- a/src/Tool-Finder/Symbol.extension.st
+++ b/src/Tool-Finder/Symbol.extension.st
@@ -3,5 +3,5 @@ Extension { #name : #Symbol }
 { #category : #'*Tool-Finder' }
 Symbol class >> forbiddenSelectorsForMethodFinder [
 
-	^ #(string: privateAt:put:)
+	^ super forbiddenSelectorsForMethodFinder , #( string: #privateAt:put: )
 ]

--- a/src/UnifiedFFI/OSPlatform.extension.st
+++ b/src/UnifiedFFI/OSPlatform.extension.st
@@ -42,7 +42,7 @@ OSPlatform >> processorArchitecture [
 		x86_64  64-bit intel
 		arm64   64-bit arm"
 
-	^ LibC resultOfCommand: 'uname -m'
+	^ (LibC resultOfCommand: 'uname -m') trimBoth
 ]
 
 { #category : #'*UnifiedFFI' }

--- a/src/UnifiedFFI/WinPlatform.extension.st
+++ b/src/UnifiedFFI/WinPlatform.extension.st
@@ -41,9 +41,9 @@ WinPlatform >> processorArchitecture [
     X86 - 32 bit
 	"
 	| architecture |
-	architecture := self environment at: 'PROCESSOR_ARCHITECTURE'.
+	architecture := (self environment at: 'PROCESSOR_ARCHITECTURE') trimBoth.
 
 	^ (architecture asLowercase = 'x86' and: [ self isTranslated ])
-		ifTrue: [ self environment at: 'PROCESSOR_ARCHITEW6432' ]
-		ifFalse: [ architecture ]
+		ifTrue: [ (self environment at: 'PROCESSOR_ARCHITEW6432') trimBoth ]
+		ifFalse: [ architecture trimBoth ]
 ]

--- a/src/UnifiedFFI/WinPlatform.extension.st
+++ b/src/UnifiedFFI/WinPlatform.extension.st
@@ -45,5 +45,5 @@ WinPlatform >> processorArchitecture [
 
 	^ (architecture asLowercase = 'x86' and: [ self isTranslated ])
 		ifTrue: [ (self environment at: 'PROCESSOR_ARCHITEW6432') trimBoth ]
-		ifFalse: [ architecture trimBoth ]
+		ifFalse: [ architecture ]
 ]


### PR DESCRIPTION
Pair programming with @ValentinBourcier 

Fix issue #13153 ignoring the method `combinations`. This needs to be discussed. Maybe another better way of doing this is to, as @privat said in the issue, to put a timeout for *each* method and to ignore the methods that timed out.

We hear opinions :)