### PR TITLE
Finder: Ignoring combinations selector for collections

### DIFF
--- a/src/Tool-Finder/Collection.extension.st
+++ b/src/Tool-Finder/Collection.extension.st
@@ -5,3 +5,9 @@ Collection class >> approvedSelectorsForMethodFinder [
 
 	 ^ self selectors
 ]
+
+{ #category : #'*Tool-Finder' }
+Collection class >> forbiddenSelectorsForMethodFinder [
+
+	^ #( #combinations )
+]

--- a/src/Tool-Finder/Symbol.extension.st
+++ b/src/Tool-Finder/Symbol.extension.st
@@ -3,5 +3,5 @@ Extension { #name : #Symbol }
 { #category : #'*Tool-Finder' }
 Symbol class >> forbiddenSelectorsForMethodFinder [
 
-	^ #(string: privateAt:put:)
+	^ super forbiddenSelectorsForMethodFinder , #( string: #privateAt:put: )
 ]


### PR DESCRIPTION
Pair programming with @ValentinBourcier

Fix issue https://github.com/pharo-project/pharo/issues/13153 ignoring the method combinations. This needs to be discussed. Maybe another better way of doing this is to, as @privat  said in the issue, to put a timeout for each method and to ignore the methods that timed out.

We hear opinions :)