### PR TITLE
FFI: Add +optAutoReleaseReturnedValue option

### DIFF
--- a/src/UnifiedFFI-Tests/FFIAutoReleaseOptionCalloutTest.class.st
+++ b/src/UnifiedFFI-Tests/FFIAutoReleaseOptionCalloutTest.class.st
@@ -1,0 +1,91 @@
+Class {
+	#name : #FFIAutoReleaseOptionCalloutTest,
+	#superclass : #TestCase,
+	#category : #'UnifiedFFI-Tests-Tests'
+}
+
+{ #category : #'instance creation' }
+FFIAutoReleaseOptionCalloutTest >> newFFIMethodWithSignature: signature doing: aBlock options: options [
+
+	| calloutAPI methodBuilder |
+	calloutAPI := FFICalloutAPI inUFFIContext: nil.
+	methodBuilder := FFIMockCalloutMethodBuilder calloutAPI: calloutAPI.
+	methodBuilder doing: aBlock.
+	methodBuilder requestor: (FFICallout new
+		methodArgs: aBlock argumentNames;
+		requestor: methodBuilder;
+		options: options;
+		yourself).
+
+	^ methodBuilder build: [ :builder |
+			builder
+				signature: signature;
+				sender: methodBuilder ]
+]
+
+{ #category : #tests }
+FFIAutoReleaseOptionCalloutTest >> testExternalObject [
+
+	self
+		testOnFFIMethodWithSignature: #( FFITestObject f #(  ) )
+		doing: [ ExternalAddress new ]
+		checkWith: [ :return |
+			FFIExternalResourceManager uniqueInstance includes: return ]
+]
+
+{ #category : #tests }
+FFIAutoReleaseOptionCalloutTest >> testExternalStructure [
+
+	self
+		testOnFFIMethodWithSignature: #( FFITestStructure * f ( ) )
+		doing: [ FFITestStructure externalNew ]
+		checkWith: [ :return |
+			ExternalAddress finalizationRegistry includes: return getHandle ]
+]
+
+{ #category : #tests }
+FFIAutoReleaseOptionCalloutTest >> testNotYetImplementedOnString [
+
+	self
+		should: [
+			self
+				newFFIMethodWithSignature: #( char* f ( ) )
+				doing: [ ExternalAddress null ]
+				options: #( + optAutoReleaseReturnedValue ) ]
+		raise: Error
+		whoseDescriptionIncludes: 'cannot yet use +optAutoReleaseReturnedValue'
+		description: 'Not yet implemented'
+]
+
+{ #category : #tests }
+FFIAutoReleaseOptionCalloutTest >> testOnFFIMethodWithSignature: anArray doing: mockedFunctionReturn checkWith: aBlockToTestIfAutoReleaseWasDone [
+
+	| return method |
+	method := self
+		newFFIMethodWithSignature: anArray
+		doing: mockedFunctionReturn
+		options: #().
+	return := method valueWithReceiver: nil arguments: #().
+	self
+		deny: (aBlockToTestIfAutoReleaseWasDone value: return)
+		description: 'By default, autoRelease was not performed on the returned object'.
+
+	method := self
+		newFFIMethodWithSignature: anArray
+		doing: mockedFunctionReturn
+		options: #( + optAutoReleaseReturnedValue ).
+	return := method valueWithReceiver: nil arguments: #().
+	self
+		assert: (aBlockToTestIfAutoReleaseWasDone value: return)
+		description: 'With the option, autoRelease was performed'
+]
+
+{ #category : #tests }
+FFIAutoReleaseOptionCalloutTest >> testVoidPointer [
+
+	self
+		testOnFFIMethodWithSignature: #( void* f ( ) )
+		doing: [ ExternalAddress null ]
+		checkWith: [ :return |
+			ExternalAddress finalizationRegistry includes: return ]
+]

--- a/src/UnifiedFFI/ExternalObject.extension.st
+++ b/src/UnifiedFFI/ExternalObject.extension.st
@@ -2,8 +2,9 @@ Extension { #name : #ExternalObject }
 
 { #category : #'*UnifiedFFI' }
 ExternalObject >> autoRelease [
-	self isExternalAddress ifFalse: [ ^ self ].
-	^ self getHandle autoRelease
+	self getHandle isExternalAddress ifFalse: [ ^ self ].
+	self getHandle autoRelease.
+	^ self
 ]
 
 { #category : #'*UnifiedFFI' }

--- a/src/UnifiedFFI/FFICallbackType.class.st
+++ b/src/UnifiedFFI/FFICallbackType.class.st
@@ -21,7 +21,10 @@ FFICallbackType >> basicEmitArgument: aBuilder context: aContext inCallout: aCal
 ]
 
 { #category : #'emitting code' }
-FFICallbackType >> emitReturn: aBuilder resultTempVar: resultVar context: aContext [
+FFICallbackType >> emitReturn: aBuilder resultTempVar: resultVar context: aContext inCallout: aCallout [
+
+	aCallout shouldAutoReleaseReturnedValue ifTrue: [
+		self error: 'Functions returning a callback type cannot use +optAutoReleaseReturnedValue' ].
 
 	^ aBuilder
 		addTemp: #tmpResult;

--- a/src/UnifiedFFI/FFICallout.class.st
+++ b/src/UnifiedFFI/FFICallout.class.st
@@ -394,6 +394,12 @@ FFICallout >> sender: aSenderContext [
 	self assert: (methodArgs size = nArgs)
 ]
 
+{ #category : #asserting }
+FFICallout >> shouldAutoReleaseReturnedValue [
+
+	^ self optionAt: #optAutoReleaseReturnedValue
+]
+
 { #category : #configuration }
 FFICallout >> stringEncodingStrategy [
 

--- a/src/UnifiedFFI/FFICharacterType.class.st
+++ b/src/UnifiedFFI/FFICharacterType.class.st
@@ -55,6 +55,9 @@ FFICharacterType >> defaultReturnOnError [
 FFICharacterType >> emitReturn: aBuilder resultTempVar: resultVar context: aContext inCallout: aCallout [
 
 	| isString |
+	aCallout shouldAutoReleaseReturnedValue ifTrue: [
+		self error: 'Functions returning char* type cannot yet use +optAutoReleaseReturnedValue.' ].
+
 	isString := self pointerArity = 1.
 	^ isString
 		ifTrue: [

--- a/src/UnifiedFFI/FFIExternalReferenceType.class.st
+++ b/src/UnifiedFFI/FFIExternalReferenceType.class.st
@@ -70,6 +70,38 @@ FFIExternalReferenceType >> defaultReturnOnError [
 ]
 
 { #category : #'emitting code' }
+FFIExternalReferenceType >> emitReturn: aBuilder resultTempVar: resultVar context: aContext inCallout: aCallout [
+	aBuilder
+		addTemp: #tmpResult;
+		"keep invoke result into the tmpResult var"
+		storeTemp: resultVar;
+		popTop;
+		"return := self objectClass basicNew"
+		pushLiteralVariable: self objectClass binding;
+		send: #basicNew;
+		storeTemp: #tmpResult;
+		popTop;
+		"return instVarAt: (index of argName) put: result"
+		pushTemp: #tmpResult;
+		pushLiteral: (self objectClass
+			instVarIndexFor: self instanceVariableName
+			ifAbsent: [ self error: 'No handle instVar' ]);
+		pushTemp: resultVar;
+		send: #instVarAt:put:;
+		popTop.
+
+	aCallout shouldAutoReleaseReturnedValue ifTrue: [
+		aBuilder
+			pushTemp: #tmpResult;
+			send: #autoRelease;
+			popTop ].
+
+	^ aBuilder
+		pushTemp: #tmpResult;
+		returnTop
+]
+
+{ #category : #'emitting code' }
 FFIExternalReferenceType >> emitReturnArgument: builder context: aContext [
 	self loader
 		emitPointerArityUnpack: builder

--- a/src/UnifiedFFI/FFIExternalReferenceType.class.st
+++ b/src/UnifiedFFI/FFIExternalReferenceType.class.st
@@ -70,30 +70,6 @@ FFIExternalReferenceType >> defaultReturnOnError [
 ]
 
 { #category : #'emitting code' }
-FFIExternalReferenceType >> emitReturn: aBuilder resultTempVar: resultVar context: aContext [
-	^ aBuilder
-		addTemp: #tmpResult;
-		"keep invoke result into the tmpResult var"
-		storeTemp: resultVar;
-		popTop;
-		"return := self objectClass basicNew"
-		pushLiteralVariable: self objectClass binding;
-		send: #basicNew;
-		storeTemp: #tmpResult;
-		popTop;
-		"return instVarAt: (index of argName) put: result"
-		pushTemp: #tmpResult;
-		pushLiteral: (self objectClass
-			instVarIndexFor: self instanceVariableName
-			ifAbsent: [ self error: 'No handle instVar' ]);
-		pushTemp: resultVar;
-		send: #instVarAt:put:;
-		popTop;
-		pushTemp: #tmpResult;
-		returnTop
-]
-
-{ #category : #'emitting code' }
 FFIExternalReferenceType >> emitReturnArgument: builder context: aContext [
 	self loader
 		emitPointerArityUnpack: builder

--- a/src/UnifiedFFI/FFIExternalResourceManager.class.st
+++ b/src/UnifiedFFI/FFIExternalResourceManager.class.st
@@ -115,6 +115,12 @@ FFIExternalResourceManager >> addResource: anObject executor: anExecutor [
 	registry add: anObject executor: anExecutor
 ]
 
+{ #category : #testing }
+FFIExternalResourceManager >> includes: anObject [
+
+	^ registry includes: anObject
+]
+
 { #category : #initialization }
 FFIExternalResourceManager >> initialize [
 	registry := WeakRegistry new

--- a/src/UnifiedFFI/FFIExternalStructureType.class.st
+++ b/src/UnifiedFFI/FFIExternalStructureType.class.st
@@ -53,6 +53,17 @@ FFIExternalStructureType >> emitFlatStructureLayoutFieldInto: flatStructureLayou
 	objectClass emitFlatStructureLayoutFieldInto: flatStructureLayout
 ]
 
+{ #category : #'emitting code' }
+FFIExternalStructureType >> emitReturn: aBuilder resultTempVar: resultVar context: aContext inCallout: aCallout [
+
+	aCallout shouldAutoReleaseReturnedValue ifTrue: [
+		aBuilder
+			pushDup;
+			send: #autoRelease;
+			popTop ].
+	^ aBuilder returnTop
+]
+
 { #category : #accessing }
 FFIExternalStructureType >> externalType [
 	^ ExternalType structTypeNamed: self objectClass name

--- a/src/UnifiedFFI/FFIVoid.class.st
+++ b/src/UnifiedFFI/FFIVoid.class.st
@@ -60,9 +60,14 @@ FFIVoid >> emitPointerReturn: aBuilder resultTempVar: resultVar context: aContex
 ]
 
 { #category : #'emitting code' }
-FFIVoid >> emitReturn: aBuilder resultTempVar: resultVar context: aContext [
-	self isPointer
-		ifTrue: [ ^ super emitReturn: aBuilder resultTempVar: resultVar context: aContext ].
+FFIVoid >> emitReturn: aBuilder resultTempVar: resultVar context: aContext inCallout: aCallout [
+	self isPointer ifTrue: [
+		aCallout shouldAutoReleaseReturnedValue ifTrue: [
+			aBuilder
+				pushDup;
+				send: #autoRelease;
+				popTop ].
+		^ aBuilder returnTop ].
 	^ self emitSelfReturn: aBuilder
 ]
 


### PR DESCRIPTION
Add +optAutoReleaseReturnedValue option.

This simplifies a common case where the C function returns an object what must be freed/released/destroyed by the caller.

Example of bindings to [a Cairo function](https://www.cairographics.org/manual/cairo-Paths.html#cairo-copy-path) as it's currently done in [Alexandrie](https://github.com/pharo-graphics/Alexandrie):

```
AeCairoContext>>
currentPath
	"Return a copy of the current path."

	^ self unownedCurrentPath
		  autoRelease;
		  yourself
```
and:
```
AeCairoContext>>
unownedCurrentPath
	"Return a copy of the current path.
	Warning: Sender is responsible of freeing (or sending autoRelease) the returned object."

	^ self ffiCall: #( AeCairoPath cairo_copy_path #( self ) )
```

With this new option, both methods can be rewritten as a single method:
```
AeCairoContext>>
currentPath
	"Return a copy of the current path."

	^ self
		  ffiCall: #( AeCairoPath cairo_copy_path #( self ) )
		  options: #( + optAutoReleaseReturnedValue )
```