### PR TITLE
ProtocolOrganizer: Inline in ClassOrganization most behavior not dealing with instance variables directly

### DIFF
--- a/src/CodeImport/ClassOrganization.extension.st
+++ b/src/CodeImport/ClassOrganization.extension.st
@@ -24,5 +24,5 @@ ClassOrganization >> internalChangeFromString: protocolSpecs [
 		| name methods |
 		name := spec first asSymbol.
 		methods := spec allButFirst asSet.
-		self protocolOrganizer addProtocol: (Protocol name: name methodSelectors: methods) ]
+		self addProtocol: (Protocol name: name methodSelectors: methods) ]
 ]

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -21,20 +21,21 @@ ClassOrganization class >> forClass: aClass [
 { #category : #accessing }
 ClassOrganization >> addProtocol: aProtocol [
 
-	^ self addProtocol: aProtocol
+	^ self protocolOrganizer addProtocol: aProtocol
 ]
 
 { #category : #accessing }
 ClassOrganization >> addProtocolNamed: protocolName [
 
-	| oldProtocols |
+	| oldProtocols protocol |
 	(self hasProtocolNamed: protocolName) ifTrue: [ ^ self ].
 
 	oldProtocols := self protocolNames copy.
 
-	self addProtocol: (Protocol name: protocolName).
+	protocol := self addProtocol: (Protocol name: protocolName).
 	self notifyOfAddedProtocol: protocolName.
-	self notifyOfChangedProtocolNamesFrom: oldProtocols to: self protocolNames
+	self notifyOfChangedProtocolNamesFrom: oldProtocols to: self protocolNames.
+	^ protocol
 ]
 
 { #category : #'backward compatibility' }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -19,6 +19,12 @@ ClassOrganization class >> forClass: aClass [
 ]
 
 { #category : #accessing }
+ClassOrganization >> addProtocol: aProtocol [
+
+	^ self addProtocol: aProtocol
+]
+
+{ #category : #accessing }
 ClassOrganization >> addProtocolNamed: protocolName [
 
 	| oldProtocols |
@@ -26,7 +32,7 @@ ClassOrganization >> addProtocolNamed: protocolName [
 
 	oldProtocols := self protocolNames copy.
 
-	self protocolOrganizer addProtocol: (Protocol name: protocolName).
+	self addProtocol: (Protocol name: protocolName).
 	self notifyOfAddedProtocol: protocolName.
 	self notifyOfChangedProtocolNamesFrom: oldProtocols to: self protocolNames
 ]

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -45,9 +45,15 @@ ClassOrganization >> allMethodSelectors [
 ]
 
 { #category : #accessing }
+ClassOrganization >> allProtocol [
+
+	^ self protocolOrganizer allProtocol
+]
+
+{ #category : #accessing }
 ClassOrganization >> allProtocols [
 
-	^ self protocolOrganizer allProtocols
+	^ { self allProtocol } , self protocols
 ]
 
 { #category : #accessing }
@@ -68,6 +74,22 @@ ClassOrganization >> classComment: aString [
 	self comment: aString
 ]
 
+{ #category : #'protocol - adding' }
+ClassOrganization >> classify: aSymbol inProtocolNamed: aProtocolName [
+
+	| name protocol |
+	name := aProtocolName.
+	name = self allProtocol name ifTrue: [ name := Protocol unclassified ].
+
+	"maybe here we should check if this method already belong to another protocol"
+	self protocols
+		select: [ :p | p includesSelector: aSymbol ]
+		thenDo: [ :p | p removeMethodSelector: aSymbol ].
+	protocol := self protocolNamed: name ifAbsent: [ self addProtocolNamed: name ].
+
+	protocol addMethodSelector: aSymbol
+]
+
 { #category : #'backward compatibility' }
 ClassOrganization >> classify: selector under: aProtocolName [
 
@@ -76,7 +98,7 @@ ClassOrganization >> classify: selector under: aProtocolName [
 	oldProtocolName := self protocolNameOfElement: selector.
 	(forceNotify or: [ oldProtocolName ~= aProtocolName or: [ aProtocolName ~= Protocol unclassified ] ]) ifFalse: [ ^ self ].
 	oldProtocols := self protocolsOfSelector: selector.
-	self protocolOrganizer classify: selector inProtocolNamed: aProtocolName.
+	self classify: selector inProtocolNamed: aProtocolName.
 	(oldProtocols select: #canBeRemoved) do: [ :e | self removeProtocol: e ].
 	oldProtocolName ifNotNil: [ self notifyOfChangedSelector: selector from: oldProtocolName to: aProtocolName ]
 ]
@@ -118,7 +140,7 @@ ClassOrganization >> commentStamp [
 { #category : #copying }
 ClassOrganization >> copyFrom: otherOrganization [
 
-	otherOrganization protocols do: [ :protocol | protocol methodSelectors do: [ :m | protocolOrganizer classify: m inProtocolNamed: protocol name ] ]
+	otherOrganization protocols do: [ :protocol | protocol methodSelectors do: [ :m | self classify: m inProtocolNamed: protocol name ] ]
 ]
 
 { #category : #accessing }

--- a/src/Kernel/ProtocolOrganizer.class.st
+++ b/src/Kernel/ProtocolOrganizer.class.st
@@ -43,22 +43,6 @@ ProtocolOrganizer >> allProtocols [
 	^ { self allProtocol } , self protocols
 ]
 
-{ #category : #'protocol - adding' }
-ProtocolOrganizer >> classify: aSymbol inProtocolNamed: aProtocolName [
-
-	| name protocol |
-	name := aProtocolName.
-	name = allProtocol name ifTrue: [ name := Protocol unclassified ].
-
-	"maybe here we should check if this method already belong to another protocol"
-	self protocols
-		select: [ :p | p includesSelector: aSymbol ]
-		thenDo: [ :p | p removeMethodSelector: aSymbol ].
-	protocol := self protocolNamed: name ifAbsent: [ self addProtocolNamed: name ].
-
-	protocol addMethodSelector: aSymbol
-]
-
 { #category : #testing }
 ProtocolOrganizer >> hasProtocolNamed: aString [
 

--- a/src/TraitsV2/TaAbstractComposition.class.st
+++ b/src/TraitsV2/TaAbstractComposition.class.st
@@ -138,7 +138,6 @@ TaAbstractComposition >> compile: selector into: aClass [
 	This version classify the method in the class passed as parameter"
 
 	| method newMethod sourceCode trailer traitDefining |
-
 	traitDefining := self traitDefining: selector.
 
 	method := self compiledMethodAt: selector.
@@ -146,23 +145,21 @@ TaAbstractComposition >> compile: selector into: aClass [
 	trailer := method trailer.
 
 	newMethod := aClass compiler
-				source: sourceCode;
-				class: aClass ;
-				failBlock: [^ false];
-				compiledMethodTrailer: trailer;
-				compile.   "Assume OK after proceed from SyntaxError"
+		             source: sourceCode;
+		             class: aClass;
+		             failBlock: [ ^ false ];
+		             compiledMethodTrailer: trailer;
+		             compile. "Assume OK after proceed from SyntaxError"
 
-	selector == newMethod selector ifFalse: [self error: 'selector changed!'].
+	selector == newMethod selector ifFalse: [ self error: 'selector changed!' ].
 
-	(selector ~= method selector or: [self changesSourceCode: selector])
+	(selector ~= method selector or: [ self changesSourceCode: selector ])
 		ifTrue: [ self saveSourceCode: sourceCode ofMethod: newMethod ]
 		ifFalse: [ newMethod setSourcePointer: method sourcePointer ].
 
 	aClass addSelectorSilently: selector withMethod: newMethod.
 
-	aClass organization protocolOrganizer
-		classify: selector
-		inProtocolNamed: (self categoryOfMethod: method withSelector: method selector).
+	aClass organization classify: selector inProtocolNamed: (self categoryOfMethod: method withSelector: method selector).
 
 	aClass >> selector propertyAt: #traitSource put: traitDefining.
 	^ true
@@ -187,7 +184,6 @@ TaAbstractComposition >> compiledMethodAt: aSelector ifAbsent: aValuable [
 
 { #category : #operations }
 TaAbstractComposition >> copyMethod: aSelector into: aClass replacing: replacing [
-
 	"When the included method does not need to be source rewritten or recompiled,
 	it is query by using #changesSourceCode:, the method is inserted in aClass' method dictionary.
 	The compiled method is just copied and the source is stored in the change file
@@ -197,7 +193,6 @@ TaAbstractComposition >> copyMethod: aSelector into: aClass replacing: replacing
 	"
 
 	| aCompiledMethod source newMethod traitDefining sourceHasChanged |
-
 	traitDefining := self traitDefining: aSelector.
 	aCompiledMethod := self compiledMethodAt: aSelector.
 	source := self getSourceCodeOf: aCompiledMethod usingSelector: aSelector.
@@ -210,8 +205,9 @@ TaAbstractComposition >> copyMethod: aSelector into: aClass replacing: replacing
 	 - The trait defining the method is not the same.
 	 - If both methods have source code and if the source codes are not the same.
 	"
-	aClass methodDict at: aSelector ifPresent:[ :originalMethod |
-		((replacing not and: [(originalMethod traitSource = traitDefining) and: [originalMethod hasSourceCode]]) and: [ source isNotNil and: [ source = originalMethod sourceCode ] ]) ifTrue: [ ^ false ]].
+	aClass methodDict at: aSelector ifPresent: [ :originalMethod |
+		((replacing not and: [ originalMethod traitSource = traitDefining and: [ originalMethod hasSourceCode ] ]) and: [
+			 source isNotNil and: [ source = originalMethod sourceCode ] ]) ifTrue: [ ^ false ] ].
 
 	newMethod := aCompiledMethod copy.
 	newMethod selector: aSelector.
@@ -221,9 +217,7 @@ TaAbstractComposition >> copyMethod: aSelector into: aClass replacing: replacing
 
 	aClass addSelectorSilently: aSelector withMethod: newMethod.
 
-	aClass organization protocolOrganizer
-		classify: aSelector
-		inProtocolNamed: aCompiledMethod category asSymbol.
+	aClass organization classify: aSelector inProtocolNamed: aCompiledMethod category asSymbol.
 
 	aClass organization removeEmptyProtocols.
 


### PR DESCRIPTION
This PR inline more of the protocol organizer behavior into ClassOrganization. It mostly inline the behavior that does not deal with instance variables of ProtocolOrganizer.

List of changes:
- ClassOrganization now understand #addProtocol: 
- ClassOrganization>>#addProtocolNamed: now return the protocol
- ClassOrganization know how to return the #allProtocol 
- Add #classify:inProtocolNamed: in ClassOrganization. THIS INCLUDES A CHANGE IN BEHAVIOR! If the protocol does not exist yet, we announce its creation. In the past it was created silently and I think this is a bug.