### PR TITLE
Added new text selection for pharo

### DIFF
--- a/src/Rubric-Tests/RubTextSegmentMorphTest.class.st
+++ b/src/Rubric-Tests/RubTextSegmentMorphTest.class.st
@@ -1,0 +1,73 @@
+Class {
+	#name : #RubTextSegmentMorphTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'editor',
+		'textArea'
+	],
+	#category : #'Rubric-Tests-Editing-Core'
+}
+
+{ #category : #running }
+RubTextSegmentMorphTest >> setUp [
+	super setUp.
+	textArea := RubEditingArea new.
+	editor := RubTextEditor forTextArea: textArea.
+	"Add text with a paragraph"
+	editor addString: 'Lorem ipsum dolor sit amet'.
+]
+
+{ #category : #running }
+RubTextSegmentMorphTest >> testBasic [
+	| textSegmentMorph |
+	textSegmentMorph := textArea newPrimarySelection.
+	self assert: textSegmentMorph textArea equals: textArea.
+	self assert: textSegmentMorph firstIndex equals: textArea markIndex.
+	self assert: textSegmentMorph lastIndex equals: textArea pointIndex.
+]
+
+{ #category : #running }
+RubTextSegmentMorphTest >> testComputeVerticesMultipleLines [
+	"
+'foo
+	fooBarZork
+brain'"
+	| textSegmentMorph vertices |
+	editor addString: 'foo
+	BarZork
+brain'.
+	editor selectInterval: (2 to: 15).
+	textSegmentMorph := textArea newPrimarySelection.
+	self assert: textSegmentMorph firstIndex equals: 2.
+	self assert: textSegmentMorph lastIndex equals: 16.
+	self assert: editor selection equals: 'oo
+	BarZork
+br'.
+	vertices := textSegmentMorph getVertices asArray. 
+	self assert: vertices equals: 
+		{(8.796005249023438@25).
+		(8.796005249023438@6).
+		(24.888015747070313@6).
+		(24.888015747070313@25).
+		(74.70603942871094@25).
+		(74.70603942871094@44).
+		(18.70001220703125@44).
+		(18.70001220703125@63).
+		(5@63).
+		(5@25)}.
+	
+]
+
+{ #category : #running }
+RubTextSegmentMorphTest >> testComputeVerticesSingleLine [
+	| textSegmentMorph vertices |
+	"'Lorem ipsum dolor sit amet'"
+	editor selectInterval: (1 to: 5)."Lorem"
+	textSegmentMorph := textArea newPrimarySelection.
+	self assert: textSegmentMorph firstIndex equals: 1.
+	self assert: textSegmentMorph lastIndex equals: 6.
+	self assert: editor selection equals: 'Lorem'.
+	vertices := textSegmentMorph getVertices. 
+	self assert: vertices size equals: 5.
+	
+]

--- a/src/Rubric/RubTextSegmentMorph.class.st
+++ b/src/Rubric/RubTextSegmentMorph.class.st
@@ -115,35 +115,44 @@ RubTextSegmentMorph >> computeSmoothVertices [
 
 { #category : #private }
 RubTextSegmentMorph >> computeStraightVertices [
-	| firstCB lastCB firstLineIndex lastLineIndex firstLine lastLine verts secondLine thirdLine |
+	| firstCB lastCB firstLineIndex lastLineIndex firstLine lastLine 
+	verts lines textarea margins segmentGap textAreaLeft |
 	firstCB := self characterBlockForIndex: firstIndex.
 	lastCB := self characterBlockForIndex: lastIndex.
+	lines := self lines.
+	textarea := self textArea.
+	margins := self margins.
 	firstLineIndex := self lineIndexOfCharacterIndex: firstIndex.
 	lastLineIndex := self lineIndexOfCharacterIndex: lastIndex.
-	firstLine := self lines at: firstLineIndex.
-	lastLine := self lines at: lastLineIndex.
+	firstLine := lines at: firstLineIndex.
+	lastLine := lines at: lastLineIndex.
 	verts := OrderedCollection new.
-	firstLine = lastLine
-		ifTrue: [
-			verts add: firstCB bottomLeft.
-			verts add: firstCB topLeft.
-			firstIndex ~= lastIndex
-				ifTrue: [
-					verts add: lastCB topLeft.
-					verts add: lastCB bottomLeft.
-					verts add: firstCB bottomLeft ] ]
-		ifFalse: [
-			secondLine := self lines at: firstLineIndex + 1.
-			thirdLine := self lines at: lastLineIndex - 1.
-			verts add: firstCB bottomLeft - (1 @ 0).
-			verts add: firstCB topLeft - (1 @ 0).
-			verts add: (self textArea right - self margins right) @ firstLine top.
-			verts add: (self textArea right - self margins right) @ thirdLine bottom.
+	segmentGap := 1@0.
+	firstLine = lastLine ifTrue: [
+		verts add: firstCB bottomLeft.
+		verts add: firstCB topLeft.
+		firstIndex ~= lastIndex ifTrue: [
 			verts add: lastCB topLeft.
 			verts add: lastCB bottomLeft.
-			verts add: lastLine bottomLeft - (1 @ 0).
-			verts add: secondLine topLeft - (1 @ 0).
-			verts add: firstCB bottomLeft - (1 @ 0) ].
+			verts add: firstCB bottomLeft ] ]
+	ifFalse: [ 
+		textAreaLeft := textArea left + margins left.
+		verts 
+			add: firstCB bottomLeft - segmentGap;
+			add: firstCB topLeft - segmentGap.
+		firstLineIndex to: lastLineIndex - 1 do: [ :index | | line |
+			line := lines at: index.
+			verts 
+				add: line actualWidth + margins left @ line top + segmentGap;
+				add: line actualWidth + margins left @ line bottom + segmentGap.
+		].
+		
+		verts
+			add: lastCB topLeft + segmentGap;
+			add: lastCB bottomLeft + segmentGap;
+			add: textAreaLeft @ lastLine bottom - segmentGap;
+			add: textAreaLeft @ firstLine bottom - segmentGap.
+	].
 	self setVertices: verts
 ]
 


### PR DESCRIPTION
This pull request address the following issue
- https://github.com/pharo-project/pharo/issues/13126
- https://github.com/pharo-project/pharo/issues/9832

Here some screen captures

Before:
<img width="786" alt="image" src="https://user-images.githubusercontent.com/10532890/229169784-840c498f-2e4e-4005-b7ec-bfda2e6dc3bb.png">

With this change
<img width="674" alt="image" src="https://user-images.githubusercontent.com/10532890/229169931-ff3a75dd-f58a-4991-aad9-6e617bd3ddde.png">

The selection uses each line actual width to compute the rectangle.
It works for all rubric text editors.