### PR TITLE
ProtocolOrganizer: Inline more behavior into ClassOrganization

### DIFF
--- a/src/CodeImport/ClassOrganization.extension.st
+++ b/src/CodeImport/ClassOrganization.extension.st
@@ -24,5 +24,5 @@ ClassOrganization >> internalChangeFromString: protocolSpecs [
 		| name methods |
 		name := spec first asSymbol.
 		methods := spec allButFirst asSet.
-		self protocolOrganizer addProtocol: (Protocol name: name methodSelectors: methods) ]
+		self addProtocol: (Protocol name: name methodSelectors: methods) ]
 ]

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -21,20 +21,21 @@ ClassOrganization class >> forClass: aClass [
 { #category : #accessing }
 ClassOrganization >> addProtocol: aProtocol [
 
-	^ self addProtocol: aProtocol
+	^ self protocolOrganizer addProtocol: aProtocol
 ]
 
 { #category : #accessing }
 ClassOrganization >> addProtocolNamed: protocolName [
 
-	| oldProtocols |
+	| oldProtocols protocol |
 	(self hasProtocolNamed: protocolName) ifTrue: [ ^ self ].
 
 	oldProtocols := self protocolNames copy.
 
-	self addProtocol: (Protocol name: protocolName).
+	protocol := self addProtocol: (Protocol name: protocolName).
 	self notifyOfAddedProtocol: protocolName.
-	self notifyOfChangedProtocolNamesFrom: oldProtocols to: self protocolNames
+	self notifyOfChangedProtocolNamesFrom: oldProtocols to: self protocolNames.
+	^ protocol
 ]
 
 { #category : #'backward compatibility' }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -45,9 +45,15 @@ ClassOrganization >> allMethodSelectors [
 ]
 
 { #category : #accessing }
+ClassOrganization >> allProtocol [
+
+	^ self protocolOrganizer allProtocol
+]
+
+{ #category : #accessing }
 ClassOrganization >> allProtocols [
 
-	^ self protocolOrganizer allProtocols
+	^ { self allProtocol } , self protocols
 ]
 
 { #category : #accessing }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -19,6 +19,12 @@ ClassOrganization class >> forClass: aClass [
 ]
 
 { #category : #accessing }
+ClassOrganization >> addProtocol: aProtocol [
+
+	^ self addProtocol: aProtocol
+]
+
+{ #category : #accessing }
 ClassOrganization >> addProtocolNamed: protocolName [
 
 	| oldProtocols |
@@ -26,7 +32,7 @@ ClassOrganization >> addProtocolNamed: protocolName [
 
 	oldProtocols := self protocolNames copy.
 
-	self protocolOrganizer addProtocol: (Protocol name: protocolName).
+	self addProtocol: (Protocol name: protocolName).
 	self notifyOfAddedProtocol: protocolName.
 	self notifyOfChangedProtocolNamesFrom: oldProtocols to: self protocolNames
 ]


### PR DESCRIPTION
This PR inline some of the protocol organizer behavior into ClassOrganization. It mostly inline the behavior that does not deal with instance variables of ProtocolOrganizer.

List of changes:
- ClassOrganization now understand #addProtocol:
- ClassOrganization>>#addProtocolNamed: now return the protocol
- ClassOrganization add #allProtocol 

