### PR TITLE
Cleanup some compiler clients

### DIFF
--- a/src/AST-Core/CompiledMethod.extension.st
+++ b/src/AST-Core/CompiledMethod.extension.st
@@ -26,7 +26,6 @@ CompiledMethod >> parseTree [
 	| ast |
 	ast := self methodClass compiler
 		source: self sourceCode;
-		failBlock: [^ self decompile ];
 		class: self methodClass;
 		parse.
 	ast compilationContext compiledMethod: self.

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -392,7 +392,7 @@ ClassDescription >> compile: sourceCode classified: protocolName withStamp: chan
 	method := self compiler
 		source: sourceCode;
 		requestor: requestor;
-		failBlock:  [ ^ nil ];
+		failBlock: (requestor ifNil: nil ifNotNil: [ [ ^ nil ] ]); "no failblock if no requestor"
 		protocolName: protocolName;
 		changeStamp: changeStamp;
 		logged: logSource;

--- a/src/Monticello-Tests/MCStWriterTest.class.st
+++ b/src/Monticello-Tests/MCStWriterTest.class.st
@@ -20,7 +20,6 @@ MCStWriterTest >> assertChunkIsWellFormed: chunk [
 		source: chunk;
 		class: UndefinedObject;
 		noPattern: true;
-		failBlock:  [self assert: false];
 		compile
 ]
 
@@ -37,7 +36,6 @@ MCStWriterTest >> assertMethodChunkIsWellFormed: chunk [
 	self class compiler
 		source: chunk;
 		class: UndefinedObject;
-		failBlock: [self assert: false];
 		compile.
 	
 ]

--- a/src/Monticello/MCMethodDefinition.class.st
+++ b/src/Monticello/MCMethodDefinition.class.st
@@ -128,7 +128,6 @@ MCMethodDefinition >> addMethodAdditionTo: aCollection [
 		compile: source
 		classified: category
 		withStamp: timeStamp
-		notifying: nil
 		logSource: true
 		inClass: self actualClass.
 	"This might raise an exception and never return"

--- a/src/Monticello/MethodAddition.class.st
+++ b/src/Monticello/MethodAddition.class.st
@@ -1,5 +1,5 @@
 "
-I represent the addition of a method to a class.  I can produce the CompiledMethod, install it, and then notify the system that the method has been added.  This allows Monticello to implement atomic addition.  A loader can compile all classes and methods first and then install all methods only after they have been all compiled, and in a way that executes little code.ß
+I represent the addition of a method to a class.  I can produce the CompiledMethod, install it, and then notify the system that the method has been added.  This allows Monticello to implement atomic addition.  A loader can compile all classes and methods first and then install all methods only after they have been all compiled, and in a way that executes little code.
 "
 Class {
 	#name : #MethodAddition,
@@ -8,7 +8,6 @@ Class {
 		'text',
 		'category',
 		'changeStamp',
-		'requestor',
 		'logSource',
 		'myClass',
 		'selector',
@@ -31,12 +30,11 @@ MethodAddition >> compile [
 ]
 
 { #category : #compilation }
-MethodAddition >> compile: aString classified: aString1 withStamp: aString2 notifying: aRequestor logSource: aBoolean inClass: aClass [
+MethodAddition >> compile: aString classified: aString1 withStamp: aString2 logSource: aBoolean inClass: aClass [
 
 	text := aString.
 	category := aString1.
 	changeStamp := aString2.
-	requestor := aRequestor.
 	logSource := aBoolean.
 	myClass := aClass
 ]
@@ -44,11 +42,7 @@ MethodAddition >> compile: aString classified: aString1 withStamp: aString2 noti
 { #category : #operations }
 MethodAddition >> createCompiledMethod [
 
-	compiledMethod := myClass compiler
-		                  source: text asString;
-		                  requestor: requestor;
-		                  failBlock: [ ^ nil ];
-		                  compile.
+	compiledMethod := myClass compiler compile: text asString.
 	selector := compiledMethod selector.
 	self writeSourceToLog.
 	priorMethodOrNil := myClass compiledMethodAt: selector ifAbsent: [ nil ].

--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -27,7 +27,7 @@ Behavior >> compile: code notifying: requestor [
 	method  := self compiler
 		source: code;
 		requestor: requestor;
-		failBlock: [ ^nil ];
+		failBlock: (requestor ifNil: nil ifNotNil: [ [ ^ nil ] ]); "no failblock if no requestor"
 		compile.
 
 	method putSource: code

--- a/src/OpalCompiler-Tests/OCCompilerSyntaxErrorNotifyingTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerSyntaxErrorNotifyingTest.class.st
@@ -47,10 +47,5 @@ OCCompilerSyntaxErrorNotifyingTest >> enumerateAllSelections [
 
 { #category : #private }
 OCCompilerSyntaxErrorNotifyingTest >> evaluateSelection [
-	^ OpalCompiler new
-		source: morph editor selection;
-		"Note subtle difference versus  (morph editor selectionAsStream).
-		The later does not answer the same contents and would raise a SyntaxErrorNotification with wrong sub-selection"
-		failBlock: [^failure];
-		evaluate
+	^ OpalCompiler new evaluate: morph editor selection
 ]

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -236,7 +236,6 @@ OCCompilerTest >> testSiblingBlocksTempShadowing [
 	OpalCompiler new
 		source: 'temp [:temp | ]. [:temp | ]';
 		class: MockForCompilation;
-		failBlock: [self fail. ^ nil ];
 		compile
 ]
 

--- a/src/TraitsV2/TaAbstractComposition.class.st
+++ b/src/TraitsV2/TaAbstractComposition.class.st
@@ -148,7 +148,6 @@ TaAbstractComposition >> compile: selector into: aClass [
 	newMethod := aClass compiler
 				source: sourceCode;
 				class: aClass ;
-				failBlock: [^ false];
 				compiledMethodTrailer: trailer;
 				compile.   "Assume OK after proceed from SyntaxError"
 


### PR DESCRIPTION
Pharo11 and (current) Pharo12 and probably older versions of Pharo offers a failBlock on OpalCompiler.
But it is required if there is a requestor, and ignored otherwise.
So a failBlock without a requestor (or in faulty mode) is just dead code that can be removed.

This PR do some cleanup to remove unused failBlock (possible cruft).

It also removes the requestor of Monticello MethodAddition that is always nil