### PR TITLE
Declare global variables Display, World and ActiveWorld

### DIFF
--- a/src/BaselineOfDisplay/BaselineOfDisplay.class.st
+++ b/src/BaselineOfDisplay/BaselineOfDisplay.class.st
@@ -83,6 +83,9 @@ BaselineOfDisplay >> preload: loader package: packageSpec [
 	"Ignore pre and post loads if already executed"
 	Initialized = true ifTrue: [ ^ self ].
 
+	"Declare global variable"
+	Smalltalk globals at: #Display put: nil.
+
 	initializersEnabled := MCMethodDefinition initializersEnabled.
 	MCMethodDefinition initializersEnabled: false.
 ]

--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -363,6 +363,10 @@ BaselineOfMorphic >> preload: loader package: packageSpec [
 	Initialized = true ifTrue: [ ^ self ].
 
 	SystemNotification signal: 'Starting preload action'.
+
+	"Declare global variables"
+	Smalltalk globals at: #World put: nil.
+	Smalltalk globals at: #ActiveWorld put: nil.
 	
 	initializersEnabled := MCMethodDefinition initializersEnabled.
 	MCMethodDefinition initializersEnabled: false.


### PR DESCRIPTION
Image produced with #13201 included show that there are only 7 users of `runtimeUndeclaredWrite:`

* `UndeclaredVariable>>#emitStore:` (as a symbol, and obviously)
* 2 tests, as symbol (not message send)
* `ClyClassWithUndeclares>>#method2WithUndeclares` that is a test method with an explicit undeclared variable
* `DisplayScreen>>#fullscreen` that access undeclared `Display` (was declared after its compilation)
* `DisplayScreen>>#replacedBy:do:` same
* `WorldState>>#runLocalStepMethodsIn:` that access undeclared `ActiveWorld`

So, only 3 methods with static write to undeclared global variables, so using the slow path bytecode (not that bad, there is a grand total of 136 827 methods on the image used)

The easy solution to improve these methods is to declare the globals before they are compiled.

If we search where these two globals are initialized, it's in two `postload:package:` methods of BaselineOfMorphic and BaselineOfDisplay.

I know nothing about baselines, but I suppose that the method `preload:package:` is called before the classes and methods are installed, so just propose to declare the globals there.

Note: I also declare `World` for consistency, since it is initialized along `ActiveWorld` in the postload