### PR TITLE
Protocols: Allow to compile a method with an instance of Protocol

### DIFF
--- a/src/Calypso-SystemQueries/ClassDescription.extension.st
+++ b/src/Calypso-SystemQueries/ClassDescription.extension.st
@@ -5,7 +5,7 @@ ClassDescription >> tagsForAllMethods [
 	"I act as #tagsForMethods but I also takes into account methods comming from traits"
 
 	| allProtocols |
-	allProtocols := self organization protocols reject: [ :each | each name = Protocol unclassified | each isExtensionProtocol ].
+	allProtocols := self organization protocols reject: [ :protocol | protocol isUnclassified | protocol isExtensionProtocol ].
 
 	^ allProtocols
 		select: [ :protocol | protocol methodSelectors ifEmpty: [ true ] ifNotEmpty: [ :methods | methods anySatisfy: [ :method | self selectors includes: method ] ] ]

--- a/src/Calypso-SystemQueries/TraitedMetaclass.extension.st
+++ b/src/Calypso-SystemQueries/TraitedMetaclass.extension.st
@@ -7,7 +7,7 @@ TraitedMetaclass >> tagsForAllMethods [
 	| allProtocols selectors |
 
 	allProtocols := self organization protocols
-		reject: [ :each | each name = Protocol unclassified | each isExtensionProtocol ].
+		reject: [ :protocol | protocol isUnclassified | protocol isExtensionProtocol ].
 
 	selectors := self visibleMethods collect: [ :each | each selector ].
 

--- a/src/CodeExport/ClassDescription.extension.st
+++ b/src/CodeExport/ClassDescription.extension.st
@@ -106,8 +106,8 @@ ClassDescription >> printMethodChunk: selector on: outStream [
 ]
 
 { #category : #'*CodeExport' }
-ClassDescription >> printProtocolChunk: protocolName on: aFileStream withStamp: changeStamp priorMethod: priorMethod [
-	"Print a method preamble.  This must have a protocol name.
+ClassDescription >> printProtocolChunk: protocol on: aFileStream withStamp: changeStamp priorMethod: priorMethod [
+	"Print a method preamble.  This must have a protocol.
 	It may have an author/date stamp, and it may have a prior source link.
 	If it has a prior source link, it MUST have a stamp, even if it is empty."
 
@@ -120,7 +120,7 @@ ClassDescription >> printProtocolChunk: protocolName on: aFileStream withStamp: 
 			 strm
 				 nextPutAll: self name;
 				 nextPutAll: ' methodsFor: ';
-				 print: protocolName asString.
+				 print: protocol asSymbol.
 			 (changeStamp isNotNil and: [ changeStamp size > 0 or: [ priorMethod isNotNil ] ]) ifTrue: [
 				 strm
 					 nextPutAll: ' stamp: ';

--- a/src/Epicea/EpMonitor.class.st
+++ b/src/Epicea/EpMonitor.class.st
@@ -548,7 +548,7 @@ EpMonitor >> protocolAdded: aProtocolAdded [
 EpMonitor >> protocolRemoved: aProtocolRemoved [
 
 	"Skip an irrelevant case"
-	aProtocolRemoved protocol = Protocol unclassified ifTrue: [ ^self ].
+	aProtocolRemoved protocol isUnclassified ifTrue: [ ^self ].
 
 	self handleAnyErrorDuring: [
 		self addEvent:

--- a/src/GeneralRules/ReUnclassifiedMethodsRule.class.st
+++ b/src/GeneralRules/ReUnclassifiedMethodsRule.class.st
@@ -21,7 +21,7 @@ ReUnclassifiedMethodsRule class >> uniqueIdentifierName [
 
 { #category : #running }
 ReUnclassifiedMethodsRule >> basicCheck: aMethod [
-	^ aMethod protocol = Protocol unclassified
+	^ aMethod protocol isUnclassified
 ]
 
 { #category : #accessing }

--- a/src/Kernel/AbstractProtocol.class.st
+++ b/src/Kernel/AbstractProtocol.class.st
@@ -62,6 +62,11 @@ AbstractProtocol >> isExtensionProtocol [
 ]
 
 { #category : #testing }
+AbstractProtocol >> isUnclassified [
+	^ false
+]
+
+{ #category : #testing }
 AbstractProtocol >> isVirtualProtocol [
 	"A virtual protocol is a calculated one (it does not have any methods by it self)"
 	^ false

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -362,33 +362,33 @@ ClassDescription >> commentStamp: changeStamp [
 ]
 
 { #category : #compiling }
-ClassDescription >> compile: sourceCode classified: protocolName [
-	"Compile the argument, code, as source code in the context of the receiver and install the result in the receiver's method dictionary under the protocol, protocolName.
+ClassDescription >> compile: sourceCode classified: protocol [
+	"Compile the argument, code, as source code in the context of the receiver and install the result in the receiver's method dictionary under the protocol as parameter.
 	nil is to be notified if an error occurs.
 	The argument code is either a string or an object that converts to a string or a PositionableStream on an object that converts to a string."
 
-	^ self compile: sourceCode classified: protocolName notifying: nil
+	^ self compile: sourceCode classified: protocol notifying: nil
 ]
 
 { #category : #compiling }
-ClassDescription >> compile: sourceCode classified: protcolName notifying: requestor [
+ClassDescription >> compile: sourceCode classified: protcol notifying: requestor [
 
-	^ self compile: sourceCode classified: protcolName withStamp: Author changeStamp notifying: requestor
+	^ self compile: sourceCode classified: protcol withStamp: Author changeStamp notifying: requestor
 ]
 
 { #category : #compiling }
-ClassDescription >> compile: sourceCode classified: protocolName withStamp: changeStamp notifying: requestor [
+ClassDescription >> compile: sourceCode classified: protocol withStamp: changeStamp notifying: requestor [
 
 	^ self
 		  compile: sourceCode
-		  classified: protocolName
+		  classified: protocol
 		  withStamp: changeStamp
 		  notifying: requestor
 		  logSource: self acceptsLoggingOfCompilation
 ]
 
 { #category : #compiling }
-ClassDescription >> compile: sourceCode classified: protocolName withStamp: changeStamp notifying: requestor logSource: logSource [
+ClassDescription >> compile: sourceCode classified: protocol withStamp: changeStamp notifying: requestor logSource: logSource [
 
 	| method |
 
@@ -396,7 +396,7 @@ ClassDescription >> compile: sourceCode classified: protocolName withStamp: chan
 		source: sourceCode;
 		requestor: requestor;
 		failBlock:  [ ^ nil ];
-		protocolName: protocolName;
+		protocolName: protocol;
 		changeStamp: changeStamp;
 		logged: logSource;
 		install.
@@ -419,17 +419,17 @@ ClassDescription >> compileSilently: sourceCode [
 ]
 
 { #category : #compiling }
-ClassDescription >> compileSilently: sourceCode classified: protocolName [
+ClassDescription >> compileSilently: sourceCode classified: protocol [
 	"Compile the code and classify the resulting method in the given protocol, leaving no trail in the system log, nor in any change set, nor in the 'recent submissions' list. This should only be used when you know for sure that the compilation will succeed."
 
-	^ self compileSilently: sourceCode classified: protocolName notifying: nil
+	^ self compileSilently: sourceCode classified: protocol notifying: nil
 ]
 
 { #category : #compiling }
-ClassDescription >> compileSilently: sourceCode classified: protocolName notifying: requestor [
+ClassDescription >> compileSilently: sourceCode classified: protocol notifying: requestor [
 	"Compile the code and classify the resulting method in the given protocol, leaving no trail in the system log, nor in any change set, nor in the 'recent submissions' list."
 
-	^ SystemAnnouncer uniqueInstance suspendAllWhile: [ self compile: sourceCode classified: protocolName notifying: requestor ]
+	^ SystemAnnouncer uniqueInstance suspendAllWhile: [ self compile: sourceCode classified: protocol notifying: requestor ]
 ]
 
 { #category : #copying }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -396,7 +396,7 @@ ClassDescription >> compile: sourceCode classified: protocol withStamp: changeSt
 		source: sourceCode;
 		requestor: requestor;
 		failBlock:  [ ^ nil ];
-		protocolName: protocol;
+		protocol: protocol;
 		changeStamp: changeStamp;
 		logged: logSource;
 		install.

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -37,7 +37,7 @@ ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod 
 
 	oldProtocol := self organization protocolNameOfElement: selector.
 	SystemAnnouncer uniqueInstance suspendAllWhile: [
-		self organization classify: selector under: (protocol = Protocol unclassified
+		self organization classify: selector under: (protocol asSymbol = Protocol unclassified
 				 ifTrue: [ oldProtocol ]
 				 ifFalse: [ protocol ]) ].
 	newProtocol := self organization protocolNameOfElement: selector.

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -28,8 +28,8 @@ ClassDescription >> acceptsLoggingOfCompilation [
 
 { #category : #'accessing - method dictionary' }
 ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod inProtocol: protocol [
-	| priorMethodOrNil priorOriginOrNil oldProtocol newProtocol |
 
+	| priorMethodOrNil priorOriginOrNil oldProtocol newProtocol |
 	priorMethodOrNil := self compiledMethodAt: selector ifAbsent: [ nil ].
 	priorMethodOrNil ifNotNil: [ priorOriginOrNil := priorMethodOrNil origin ].
 
@@ -37,7 +37,7 @@ ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod 
 
 	oldProtocol := self organization protocolNameOfElement: selector.
 	SystemAnnouncer uniqueInstance suspendAllWhile: [
-		self organization classify: selector under: (protocol asSymbol = Protocol unclassified
+		self organization classify: selector under: (protocol isUnclassified
 				 ifTrue: [ oldProtocol ]
 				 ifFalse: [ protocol ]) ].
 	newProtocol := self organization protocolNameOfElement: selector.
@@ -1107,7 +1107,7 @@ ClassDescription >> tagsForMethods [
 	which is opposite to current Protocol implementation.
 	And extension protocol is not treated as tag"
 	| allProtocols |
-	allProtocols := self organization protocols reject: [ :each | each name = Protocol unclassified | each isExtensionProtocol ].
+	allProtocols := self organization protocols reject: [ :protocol | protocol isUnclassified | protocol isExtensionProtocol ].
 
 	^ allProtocols select: [ :each | self isLocalMethodsProtocol: each ] thenCollect: #name
 ]

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -75,16 +75,17 @@ ClassOrganization >> classComment: aString [
 ]
 
 { #category : #'backward compatibility' }
-ClassOrganization >> classify: selector under: aProtocolName [
+ClassOrganization >> classify: selector under: aProtocol [
 
-	| oldProtocolName forceNotify oldProtocols |
+	| oldProtocolName forceNotify oldProtocols newProtocolName |
+	newProtocolName := aProtocol asSymbol.
 	forceNotify := (self includesSelector: selector) not.
 	oldProtocolName := self protocolNameOfElement: selector.
-	(forceNotify or: [ oldProtocolName ~= aProtocolName or: [ aProtocolName ~= Protocol unclassified ] ]) ifFalse: [ ^ self ].
+	(forceNotify or: [ oldProtocolName ~= newProtocolName or: [ newProtocolName ~= Protocol unclassified ] ]) ifFalse: [ ^ self ].
 	oldProtocols := self protocolsOfSelector: selector.
-	self protocolOrganizer classify: selector inProtocolNamed: aProtocolName.
+	self protocolOrganizer classify: selector inProtocolNamed: newProtocolName.
 	(oldProtocols select: #canBeRemoved) do: [ :e | self removeProtocol: e ].
-	oldProtocolName ifNotNil: [ self notifyOfChangedSelector: selector from: oldProtocolName to: aProtocolName ]
+	oldProtocolName ifNotNil: [ self notifyOfChangedSelector: selector from: oldProtocolName to: newProtocolName ]
 ]
 
 { #category : #cleanup }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -81,7 +81,7 @@ ClassOrganization >> classify: selector under: aProtocol [
 	newProtocolName := aProtocol asSymbol.
 	forceNotify := (self includesSelector: selector) not.
 	oldProtocolName := self protocolNameOfElement: selector.
-	(forceNotify or: [ oldProtocolName ~= newProtocolName or: [ newProtocolName ~= Protocol unclassified ] ]) ifFalse: [ ^ self ].
+	(forceNotify or: [ oldProtocolName ~= newProtocolName or: [ aProtocol isUnclassified not ] ]) ifFalse: [ ^ self ].
 	oldProtocols := self protocolsOfSelector: selector.
 	self protocolOrganizer classify: selector inProtocolNamed: newProtocolName.
 	(oldProtocols select: #canBeRemoved) do: [ :e | self removeProtocol: e ].

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -1116,11 +1116,12 @@ CompiledMethod >> tags [
 	"Any method could be tagged with multiple symbols for user purpose.
 	For now we only define API to manage them implemented on top of method protocols.
 	Protocol unclassified means that method is not tagged by anything"
+
 	| protocol |
 	protocol := self protocol.
-	protocol ifNil: [ ^#() ].
-	protocol = Protocol unclassified ifTrue: [ ^#() ].
-	^{protocol}
+	protocol ifNil: [ ^ #(  ) ].
+	protocol isUnclassified ifTrue: [ ^ #(  ) ].
+	^ { protocol }
 ]
 
 { #category : #'source code management' }

--- a/src/Kernel/Protocol.class.st
+++ b/src/Kernel/Protocol.class.st
@@ -54,6 +54,12 @@ Protocol >> initialize [
 	name := self class defaultName
 ]
 
+{ #category : #testing }
+Protocol >> isUnclassified [
+
+	^ self name isUnclassified
+]
+
 { #category : #accessing }
 Protocol >> methodSelectors [
 	^ methodSelectors

--- a/src/Kernel/Protocol.class.st
+++ b/src/Kernel/Protocol.class.st
@@ -38,6 +38,13 @@ Protocol >> addMethodSelector: aSymbol [
 	^ methodSelectors add: aSymbol
 ]
 
+{ #category : #converting }
+Protocol >> asSymbol [
+	"This method is here to allow compiler To compile with a Protocol"
+
+	^ self name asSymbol
+]
+
 { #category : #initialization }
 Protocol >> initialize [
 

--- a/src/Kernel/String.extension.st
+++ b/src/Kernel/String.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #String }
 
 { #category : #'*Kernel' }
 String >> isUnclassified [
-	"Return true if I am the name of Uncliassified protocol"
+	"Return true if I am the name of unclassified protocol"
 
 	^ self = Protocol unclassified
 ]

--- a/src/Kernel/String.extension.st
+++ b/src/Kernel/String.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #String }
+
+{ #category : #'*Kernel' }
+String >> isUnclassified [
+	"Return true if I am the name of Uncliassified protocol"
+
+	^ self = Protocol unclassified
+]

--- a/src/Monticello/MethodAddition.class.st
+++ b/src/Monticello/MethodAddition.class.st
@@ -95,7 +95,7 @@ MethodAddition >> priorCategoryOrNil: anObject [
 MethodAddition >> writeSourceToLog [
 	logSource ifTrue: [
 		myClass logMethodSource: text forMethod: compiledMethod
-			inProtocolNamed: category withStamp: changeStamp
+			inProtocol: category withStamp: changeStamp
 	].
 
 ]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -530,7 +530,7 @@ OpalCompiler >> productionEnvironment: anObject [
 ]
 
 { #category : #accessing }
-OpalCompiler >> protocolName: aString [ 
+OpalCompiler >> protocol: aString [ 
 	protocol := aString
 ]
 

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -1,3 +1,30 @@
+"
+I provide the API of the whole Compiler Package for the case that the input is sourcecode.
+(if there is already and AST, call #generate (to compile) or #evaluate directly on the node)
+
+a pre-configures compiler instance can be requested with: 
+ - Smalltalk compiler
+ - a Class compiler 
+
+The compiler instance (actually: the compilation context) needs to be setup. See #class: #source: #noPattern: #requestor: for the most important accessors (more are in the accessing protocol). 
+
+See the class comment of CompilationContext for more information.
+
+The final step is one of three actions:
+
+-> parsing: parse source and return an AST.
+-> compile: parse and compile, return a CompiledMethod 
+-> evaluate: parse, compile, evaluate and return result
+
+Example:
+
+Smalltalk compiler
+	source: 'test 1+2';
+	class: Object;
+	compile.
+
+This returns a CompiledMethod.
+"
 Class {
 	#name : #OpalCompiler,
 	#superclass : #Object,

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -1,30 +1,3 @@
-"
-I provide the API of the whole Compiler Package for the case that the input is sourcecode.
-(if there is already and AST, call #generate (to compile) or #evaluate directly on the node)
-
-a pre-configures compiler instance can be requested with: 
- - Smalltalk compiler
- - a Class compiler 
-
-The compiler instance (actually: the compilation context) needs to be setup. See #class: #source: #noPattern: #requestor: for the most important accessors (more are in the accessing protocol). 
-
-See the class comment of CompilationContext for more information.
-
-The final step is one of three actions:
-
--> parsing: parse source and return an AST.
--> compile: parse and compile, return a CompiledMethod 
--> evaluate: parse, compile, evaluate and return result
-
-Example:
-
-Smalltalk compiler
-	source: 'test 1+2';
-	class: Object;
-	compile.
-
-This returns a CompiledMethod.
-"
 Class {
 	#name : #OpalCompiler,
 	#superclass : #Object,
@@ -33,8 +6,8 @@ Class {
 		'source',
 		'compilationContext',
 		'compilationContextClass',
-		'protocolName',
-		'changeStamp'
+		'changeStamp',
+		'protocol'
 	],
 	#classInstVars : [
 		'overlayEnvironment'
@@ -437,7 +410,7 @@ OpalCompiler >> install [
 	method := self compile.
 	method ifNil: [ ^ method ].
 
-	protocolName ifNil: [ protocolName := Protocol unclassified ].
+	protocol ifNil: [ protocol := Protocol unclassified ].
 	changeStamp ifNil: [ changeStamp := Author changeStamp ].
 	logSource := compilationContext logged ifNil: [ class acceptsLoggingOfCompilation ].
 
@@ -445,13 +418,13 @@ OpalCompiler >> install [
 		class
 			logMethodSource: source
 			forMethod: method
-			inProtocolNamed: protocolName
+			inProtocol: protocol
 			withStamp: changeStamp ].
 
 	class
 		addAndClassifySelector: method selector
 		withMethod: method
-		inProtocol: protocolName.
+		inProtocol: protocol.
 
 	class instanceSide noteCompilationOf: method meta: class isClassSide.
 
@@ -558,7 +531,7 @@ OpalCompiler >> productionEnvironment: anObject [
 
 { #category : #accessing }
 OpalCompiler >> protocolName: aString [ 
-	protocolName := aString
+	protocol := aString
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Tests/OCTargetCompiler.class.st
+++ b/src/OpalCompiler-Tests/OCTargetCompiler.class.st
@@ -1,9 +1,3 @@
-"
-I am a ridiculous alternate compiler, that replaces any literal symbol #dontReturnThis with the symbol #expectedReturn.
-
-It's the simplest change to the compiler that I could imagine that doesn't interfere with the fact that the class-side `compilerClass` method can't be interfered with.
-
-"
 Class {
 	#name : #OCTargetCompiler,
 	#superclass : #OpalCompiler,

--- a/src/OpalCompiler-Tests/OCTargetCompiler.class.st
+++ b/src/OpalCompiler-Tests/OCTargetCompiler.class.st
@@ -1,3 +1,9 @@
+"
+I am a ridiculous alternate compiler, that replaces any literal symbol #dontReturnThis with the symbol #expectedReturn.
+
+It's the simplest change to the compiler that I could imagine that doesn't interfere with the fact that the class-side `compilerClass` method can't be interfered with.
+
+"
 Class {
 	#name : #OCTargetCompiler,
 	#superclass : #OpalCompiler,

--- a/src/OpalCompiler-Tests/OpalCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTest.class.st
@@ -161,7 +161,7 @@ OpalCompilerTest >> testInstall [
 	method := MockForCompilation compiler
 		          source: 'foo ^42';
 		          changeStamp: 'JP 4/01/2023 01:23';
-		          protocolName: 'hitching';
+		          protocol: 'hitching';
 		          install.
 
 	self assert: method equals: MockForCompilation >> #foo.
@@ -203,7 +203,7 @@ OpalCompilerTest >> testInstallRequestor [
 		          requestor: requestor;
 		          failBlock: [  ];
 		          changeStamp: 'JP 3/24/2023 18:39';
-		          protocolName: 'hitching';
+		          protocol: 'hitching';
 		          install ]
 		on: CodeError
 		do: [  ].

--- a/src/Refactoring-Tests-Changes/RBRefactoringChangeTest.class.st
+++ b/src/Refactoring-Tests-Changes/RBRefactoringChangeTest.class.st
@@ -301,7 +301,7 @@ RBRefactoringChangeTest >> testCompileInMetaclass [
 	self assert: change isMeta.
 	self assert: change selector equals: #new.
 	self assert: change source equals: 'new'.
-	self assert: change protocol equals: Protocol unclassified.
+	self assert: change protocol isUnclassified.
 	self universalTestFor: change
 ]
 

--- a/src/System-Sources/ClassDescription.extension.st
+++ b/src/System-Sources/ClassDescription.extension.st
@@ -1,6 +1,17 @@
 Extension { #name : #ClassDescription }
 
 { #category : #'*System-Sources' }
+ClassDescription >> logMethodSource: aText forMethod: aCompiledMethod inProtocol: protocol withStamp: changeStamp [
+
+	aCompiledMethod
+		putSource: aText
+		class: self
+		protocol: protocol
+		withStamp: changeStamp
+		priorMethod: (self compiledMethodAt: aCompiledMethod selector ifAbsent: [  ])
+]
+
+{ #category : #'*System-Sources' }
 ClassDescription >> logMethodSource: aText forMethod: aCompiledMethod inProtocolNamed: protocolName withStamp: changeStamp [
 
 	aCompiledMethod

--- a/src/System-Sources/ClassDescription.extension.st
+++ b/src/System-Sources/ClassDescription.extension.st
@@ -10,14 +10,3 @@ ClassDescription >> logMethodSource: aText forMethod: aCompiledMethod inProtocol
 		withStamp: changeStamp
 		priorMethod: (self compiledMethodAt: aCompiledMethod selector ifAbsent: [  ])
 ]
-
-{ #category : #'*System-Sources' }
-ClassDescription >> logMethodSource: aText forMethod: aCompiledMethod inProtocolNamed: protocolName withStamp: changeStamp [
-
-	aCompiledMethod
-		putSource: aText
-		class: self
-		protocol: protocolName
-		withStamp: changeStamp
-		priorMethod: (self compiledMethodAt: aCompiledMethod selector ifAbsent: [  ])
-]

--- a/src/System-Sources/CompiledMethod.extension.st
+++ b/src/System-Sources/CompiledMethod.extension.st
@@ -1,11 +1,11 @@
 Extension { #name : #CompiledMethod }
 
 { #category : #'*System-Sources' }
-CompiledMethod >> putSource: sourceStr class: class protocol: protocolName withStamp: changeStamp priorMethod: priorMethod [
+CompiledMethod >> putSource: sourceStr class: class protocol: protocol withStamp: changeStamp priorMethod: priorMethod [
 
 	^ self putSource: sourceStr withPreamble: [ :file |
 		  class
-			  printProtocolChunk: protocolName
+			  printProtocolChunk: protocol
 			  on: file
 			  withStamp: changeStamp
 			  priorMethod: priorMethod.

--- a/src/Tool-Base/MethodClassifier.class.st
+++ b/src/Tool-Base/MethodClassifier.class.st
@@ -256,7 +256,7 @@ MethodClassifier >> protocolByOtherImplementors: aMethod [
 		ifNotEmpty: [ :methods |
 			methods
 				do: [ :method |
-					((method protocol beginsWith: '*') or: [ method protocol = Protocol unclassified ])
+					((method protocol beginsWith: '*') or: [ method protocol isUnclassified ])
 						ifFalse: [ protocolBag add: method protocol ]]
 				without: aMethod ].
 

--- a/src/TraitsV2/TraitedClass.class.st
+++ b/src/TraitsV2/TraitedClass.class.st
@@ -20,12 +20,9 @@ Class {
 }
 
 { #category : #'accessing - method dictionary' }
-TraitedClass class >> addAndClassifySelector: selector withMethod: compiledMethod inProtocol: aCategory [
+TraitedClass class >> addAndClassifySelector: selector withMethod: compiledMethod inProtocol: aProtocol [
 
-	super
-		addAndClassifySelector: selector
-		withMethod: compiledMethod
-		inProtocol: aCategory.
+	super addAndClassifySelector: selector withMethod: compiledMethod inProtocol: aProtocol.
 
 	self propagateChangeOf: selector
 ]
@@ -80,17 +77,14 @@ TraitedClass class >> traitUsers [
 ]
 
 { #category : #'accessing - method dictionary' }
-TraitedClass >> addAndClassifySelector: selector withMethod: compiledMethod inProtocol: aCategory [
-
+TraitedClass >> addAndClassifySelector: selector withMethod: compiledMethod inProtocol: aProtocol [
 	"When a new methods is added, I add it to the localMethodDict and also propagate the changes to my users"
+
 	self localMethodDict at: selector put: compiledMethod.
 
-	super
-		addAndClassifySelector: selector
-		withMethod: compiledMethod
-		inProtocol: aCategory.
+	super addAndClassifySelector: selector withMethod: compiledMethod inProtocol: aProtocol.
 
-	TraitChange addSelector: selector on: self.
+	TraitChange addSelector: selector on: self
 ]
 
 { #category : #'accessing - method dictionary' }

--- a/src/TraitsV2/TraitedMetaclass.class.st
+++ b/src/TraitsV2/TraitedMetaclass.class.st
@@ -25,14 +25,11 @@ TraitedMetaclass class >> traitedClassTrait [
 ]
 
 { #category : #'accessing - method dictionary' }
-TraitedMetaclass >> addAndClassifySelector: selector withMethod: compiledMethod inProtocol: aCategory [
+TraitedMetaclass >> addAndClassifySelector: selector withMethod: compiledMethod inProtocol: aProtocol [
 
 	self localMethodDict at: selector put: compiledMethod.
 
-	super
-		addAndClassifySelector: selector
-		withMethod: compiledMethod
-		inProtocol: aCategory.
+	super addAndClassifySelector: selector withMethod: compiledMethod inProtocol: aProtocol.
 
 	TraitChange addSelector: selector on: self
 ]


### PR DESCRIPTION
Here is a new step for going from symbol manipulation to usage of protocols. 

With this pr we get:
- We can now give an instance of Protocol to the compiler to compile a method instead of a symbol (but the symbol works too!)
- I renamed a bunch of methods to make that explicit
- I renamed the impacted variables
- In order to know if a protocol is unclassified, we now have #isUnclassified instead of comparing to `Protocol unclassified` (Btw, this method returns a string and not a protocol, so I'll change that later probably

This will help us when we will update CompileMethod>>protocol to return a protocol. We will have no problem with the compilation and to know if this protocol is unclassified