### PR TITLE
Faulty code: inspect notice

### DIFF
--- a/src/AST-Core/RBNotice.class.st
+++ b/src/AST-Core/RBNotice.class.st
@@ -31,6 +31,13 @@ RBNotice >> description [
 			  nextPutAll: node displaySourceCode ]
 ]
 
+{ #category : #inspecting }
+RBNotice >> inspectionSource [
+
+	<inspectorPresentationOrder: 30 title: 'Source'>
+	^ node inspectionSource
+]
+
 { #category : #testing }
 RBNotice >> isError [
 

--- a/src/AST-Core/RBNotice.class.st
+++ b/src/AST-Core/RBNotice.class.st
@@ -94,6 +94,15 @@ RBNotice >> printOn: aStream [
 
 { #category : #signalling }
 RBNotice >> signalError [
+	"If a debugger is opened here, it means that a code error (syntax error or semantic error)
+	was uncaught while compiling some code.
+	Inspect `self` to get a view of the problematic source code.
+
+	Resuming the error (proceed) will continue the compilation anyway, but might produce an
+	executable code that will signal runtime errors at runtime.
+	However, it allows you to repair and recompile the code at your own time.
+
+	If you close the debugger, then we will all forgot this ever happen."
 
 	CodeError new
 		notice: self;

--- a/src/AST-Core/RBParseErrorNode.class.st
+++ b/src/AST-Core/RBParseErrorNode.class.st
@@ -90,7 +90,7 @@ RBParseErrorNode >> initialize [
 
 	super initialize.
 	"Add its own notice"
-	self addNotice: (RBErrorNodeNotice new)
+	self addNotice: (RBSyntaxErrorNotice new)
 ]
 
 { #category : #errors }

--- a/src/AST-Core/RBSyntaxErrorNotice.class.st
+++ b/src/AST-Core/RBSyntaxErrorNotice.class.st
@@ -2,19 +2,19 @@
 I am the implicit notice of a RBParseErrorNode
 "
 Class {
-	#name : #RBErrorNodeNotice,
+	#name : #RBSyntaxErrorNotice,
 	#superclass : #RBErrorNotice,
 	#category : #'AST-Core-Notice'
 }
 
 { #category : #accessing }
-RBErrorNodeNotice >> messageText [
+RBSyntaxErrorNotice >> messageText [
 
 	^ node errorMessage
 ]
 
 { #category : #'error handling' }
-RBErrorNodeNotice >> position [
+RBSyntaxErrorNotice >> position [
 
 	^ node errorPosition
 ]


### PR DESCRIPTION
Small improvement on RBNotice

* rename RBErrorNodeNotice as RBSyntaxErrorNotice, because it is what it is
* add a comment on the CodeError signal (shown by debuggers)
* add inspection on notice