### PR TITLE
RPackageOrganizer should not call system organizer global but keep a reference 

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -1387,7 +1387,7 @@ RPackage >> renameTo: aSymbol [
 				do:
 					[ :each | each category: newName , (each category allButFirst: oldName size) ].
 			oldCategoryNames
-				do: [ :each | SystemOrganizer default removeCategory: each ] ].
+				do: [ :each | self systemOrganization removeCategory: each ] ].
 	self renameTagsPrefixedWith: oldName to: newName.
 	self renameExtensionsPrefixedWith: oldName to: newName.
 	self organizer
@@ -1449,7 +1449,7 @@ RPackage >> systemCategoryPrefix [
 { #category : #'system compatibility' }
 RPackage >> systemOrganization [
 
-	^ Smalltalk globals organization
+	^ self organizer systemOrganizer
 ]
 
 { #category : #queries }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -1,3 +1,105 @@
+"
+A RPackageOrganizer is responsible for providing all the package currently defined in the system.
+In addition it provides a back pointer from the class to its package.
+
+The classPackageMapping and the classExtendingPackageMapping should be moved in the future to the classes themselves. 
+
+
+For tests or actions that could destroy the package organizer,  do not access directly the singleton of RPackageOrganizer.
+Use instead 
+		RPackage withOrganizer: aNewOrganizer do: ablock
+			or via RPackage organizer
+		
+	
+RPackageOrganizer fillUp will fill up the system from the current PackageOrganizer
+	""self fillUp""
+	
+-----------------------------------------------------------------------------------------------------------------------------------------------	
+	
+	
+A rpackageOrganizer update itself when some changes are made in the system. It does that by registering to a systemAnnoucer, specifying an action when an annoucement is triggered.
+Here is what I (Cyrille Delaunay) propose to do for each annocuement triggered:
+
+SystemCategoryAddedAnnouncement 	
+	=> I would just register a new RPackage (if it does not already exist) in the RPackageOrganizer
+	
+SystemCategoryRemovedAnnouncement 
+     => I would just unregister the RPackage concerned from the organizer
+
+SystemCategoryRenamedAnnouncement
+     => I would update the RPackage concerned, by changing its name
+     => I would update the 'packages' dictionary of the organizer, putting the new name as key
+
+SystemClassAddedAnnouncement 
+    => Import the class in the RPackage concerned (RPackage >> importClass:)
+    => Register the class in the 'classPackageMapping' dictionary of the organizer (RPackageOrganizer >> registerPackage:forClass)
+    (=> maybe we should pay attention if both the class and the metaclass launch this kind of event ?)
+
+SystemClassRecategorizedAnnouncement
+    => I would update the old RPackage concerned:
+            => unregister the class
+            => unregister all defined methods of the class
+    => I would update the new RPackage:
+            => Import the class in the RPackage (importClass:)
+    => I would update the organizer:
+            => update the 'classPackageDictionary' to point on the new RPackage
+
+ 
+SystemClassRemovedAnnouncement
+    => I would update the RPackake concerned
+             => unregister the class
+             => unregister all defined methods of the class
+    => I would update the organizer:
+             => update the 'classPackageDictionary' to remove the class
+
+SystemClassRenamedAnnouncement
+    => I would update the RPackage in which the class is defined:
+             => update the 'classDefinedSelectors' dictionary (replace the old key by the new one)
+             => update the 'metaclassDefinedSelectors' dictionary (replace the old key by the new one)
+    => I would update all RPackages extending this class
+             => update the 'classExtensionsSelectors' dictionary (replace the old key by the new one)
+             => update the 'metaclassclassExtensionsSelectors' dictionary (replace the old key by the new one)
+    => I would update the organizer
+             => update the 'classPackageDictionary' to replace the key with the new class name
+             => update the 'classExtendingPackagesMapping' to replace the key with the new class name
+                          
+SystemClassReorganizedAnnouncement 
+    (=> I guess we should check if extensions have not been added or removed ? 
+      (to retrieve this information, the only thing I found is ClassDescription >> organization, and then check each category begining with '*' and compare with the organizer. seems to be painful, no?))
+	=> when an extension is removed, all methods inside are removed. Therefore, the MethodRemovedAnnounecement will do the job. Not sur this one still usefull
+
+SystemProtocolAddedAnnouncement
+    => I don’t see anything to do for this annoucement
+
+SystemProtocolRemovedAnnoucement
+    => If the category is an extension from a package, I would move all the methods concerned, from the extending RPackage to the class RPackage
+
+SystemMethodAddedAnnouncement
+       => I would check the category in which the method has been defined
+               => if it correspond to an extending package -> add the method to the extending RPackage
+               => if not, add the method to the class parentPackage
+
+SystemMethodModifiedAnnouncement
+       this annoucement can correspond to several kind of modifications:
+	       *  a method has been renamed
+                       => I would update the rPackage in which the method is defined to replace the old selector by the new one
+		* a method has been move to another category 
+			-maybe from a classic category to an extending package
+                             => we should move the method from the  method class parentPackage to extendingPackage package
+			-maybe from an extending package to another extending package
+                             => we should move the method from the  extendingPackage package to the other extendingPackage package
+			-maybe from an extending package to a classic category
+                             =>  we should move the method from the  extendingPackage to the method class parentPackage
+		        -maybe from a classic category to another classic category
+                             => we have nothing to do
+			
+
+SystemMethodRecategorizedAnnouncement
+          same thing than above
+
+SystemMethodRemovedAnnouncement
+       => I would simply remove the method from the RPackage in which it is register
+"
 Class {
 	#name : #RPackageOrganizer,
 	#superclass : #Object,

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -124,7 +124,7 @@ RPackageOrganizer class >> default [
 
 	^ default ifNil: [
 		  default := self new
-			             systemOrganizer: Smalltalk globals systemOrganizer;
+			             systemOrganizer: Smalltalk globals organization;
 			             yourself ]
 ]
 

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -1,105 +1,3 @@
-"
-A RPackageOrganizer is responsible for providing all the package currently defined in the system.
-In addition it provides a back pointer from the class to its package.
-
-The classPackageMapping and the classExtendingPackageMapping should be moved in the future to the classes themselves. 
-
-
-For tests or actions that could destroy the package organizer,  do not access directly the singleton of RPackageOrganizer.
-Use instead 
-		RPackage withOrganizer: aNewOrganizer do: ablock
-			or via RPackage organizer
-		
-	
-RPackageOrganizer fillUp will fill up the system from the current PackageOrganizer
-	""self fillUp""
-	
------------------------------------------------------------------------------------------------------------------------------------------------	
-	
-	
-A rpackageOrganizer update itself when some changes are made in the system. It does that by registering to a systemAnnoucer, specifying an action when an annoucement is triggered.
-Here is what I (Cyrille Delaunay) propose to do for each annocuement triggered:
-
-SystemCategoryAddedAnnouncement 	
-	=> I would just register a new RPackage (if it does not already exist) in the RPackageOrganizer
-	
-SystemCategoryRemovedAnnouncement 
-     => I would just unregister the RPackage concerned from the organizer
-
-SystemCategoryRenamedAnnouncement
-     => I would update the RPackage concerned, by changing its name
-     => I would update the 'packages' dictionary of the organizer, putting the new name as key
-
-SystemClassAddedAnnouncement 
-    => Import the class in the RPackage concerned (RPackage >> importClass:)
-    => Register the class in the 'classPackageMapping' dictionary of the organizer (RPackageOrganizer >> registerPackage:forClass)
-    (=> maybe we should pay attention if both the class and the metaclass launch this kind of event ?)
-
-SystemClassRecategorizedAnnouncement
-    => I would update the old RPackage concerned:
-            => unregister the class
-            => unregister all defined methods of the class
-    => I would update the new RPackage:
-            => Import the class in the RPackage (importClass:)
-    => I would update the organizer:
-            => update the 'classPackageDictionary' to point on the new RPackage
-
- 
-SystemClassRemovedAnnouncement
-    => I would update the RPackake concerned
-             => unregister the class
-             => unregister all defined methods of the class
-    => I would update the organizer:
-             => update the 'classPackageDictionary' to remove the class
-
-SystemClassRenamedAnnouncement
-    => I would update the RPackage in which the class is defined:
-             => update the 'classDefinedSelectors' dictionary (replace the old key by the new one)
-             => update the 'metaclassDefinedSelectors' dictionary (replace the old key by the new one)
-    => I would update all RPackages extending this class
-             => update the 'classExtensionsSelectors' dictionary (replace the old key by the new one)
-             => update the 'metaclassclassExtensionsSelectors' dictionary (replace the old key by the new one)
-    => I would update the organizer
-             => update the 'classPackageDictionary' to replace the key with the new class name
-             => update the 'classExtendingPackagesMapping' to replace the key with the new class name
-                          
-SystemClassReorganizedAnnouncement 
-    (=> I guess we should check if extensions have not been added or removed ? 
-      (to retrieve this information, the only thing I found is ClassDescription >> organization, and then check each category begining with '*' and compare with the organizer. seems to be painful, no?))
-	=> when an extension is removed, all methods inside are removed. Therefore, the MethodRemovedAnnounecement will do the job. Not sur this one still usefull
-
-SystemProtocolAddedAnnouncement
-    => I don't see anything to do for this annoucement
-
-SystemProtocolRemovedAnnoucement
-    => If the category is an extension from a package, I would move all the methods concerned, from the extending RPackage to the class RPackage
-
-SystemMethodAddedAnnouncement
-       => I would check the category in which the method has been defined
-               => if it correspond to an extending package -> add the method to the extending RPackage
-               => if not, add the method to the class parentPackage
-
-SystemMethodModifiedAnnouncement
-       this annoucement can correspond to several kind of modifications:
-	       *  a method has been renamed
-                       => I would update the rPackage in which the method is defined to replace the old selector by the new one
-		* a method has been move to another category 
-			-maybe from a classic category to an extending package
-                             => we should move the method from the  method class parentPackage to extendingPackage package
-			-maybe from an extending package to another extending package
-                             => we should move the method from the  extendingPackage package to the other extendingPackage package
-			-maybe from an extending package to a classic category
-                             =>  we should move the method from the  extendingPackage to the method class parentPackage
-		        -maybe from a classic category to another classic category
-                             => we have nothing to do
-			
-
-SystemMethodRecategorizedAnnouncement
-          same thing than above
-
-SystemMethodRemovedAnnouncement
-       => I would simply remove the method from the RPackage in which it is register
-"
 Class {
 	#name : #RPackageOrganizer,
 	#superclass : #Object,
@@ -108,7 +6,8 @@ Class {
 		'packages',
 		'classExtendingPackagesMapping',
 		'debuggingName',
-		'packageNames'
+		'packageNames',
+		'systemOrganizer'
 	],
 	#classInstVars : [
 		'default'
@@ -121,7 +20,10 @@ RPackageOrganizer class >> default [
 	"WARNING: Since this component can be changed (i.e. for testing) you should NOT use it directly.
 	  Use RPackage class>>#organizer instead"
 
-	^ default ifNil: [  default := self new ]
+	^ default ifNil: [
+		  default := self new
+			             systemOrganizer: Smalltalk globals systemOrganizer;
+			             yourself ]
 ]
 
 { #category : #'class initialization' }
@@ -482,6 +384,7 @@ RPackageOrganizer >> initialize [
 	classPackageMapping := IdentityDictionary new.
 	classExtendingPackagesMapping := IdentityDictionary new.
 	debuggingName := ''.
+	systemOrganizer := SystemOrganizer new.
 
 	self defineUnpackagedClassesPackage
 ]
@@ -1152,6 +1055,18 @@ RPackageOrganizer >> systemMethodRemovedActionFrom: ann [
 			methodPackage ifNotNil: [
 				methodPackage removeSelector: ann selector ofMetaclassName: ann methodClass instanceSide originalName].
 		]
+]
+
+{ #category : #accessing }
+RPackageOrganizer >> systemOrganizer [
+
+	^ systemOrganizer
+]
+
+{ #category : #accessing }
+RPackageOrganizer >> systemOrganizer: anObject [
+
+	systemOrganizer := anObject
 ]
 
 { #category : #'system integration' }


### PR DESCRIPTION
Instead of asking the "default system organizer" in a hard coded way, now each organization has its organizer.  The default organization knows the default system organizer. 

This reduces references to a global object so that each organization can be independant. This is also one of the first step to make RPackage part of the Pharo MM.

The end goal is to kill this new variable by in-lining its behavior in the meta model. But let's go step by step :) 