### PR TITLE
Faulty code: various undeclared cleanups

### DIFF
--- a/bootstrap/scripts/02-monticello-bootstrap/03-bootstrapMonticelloRemote.st
+++ b/bootstrap/scripts/02-monticello-bootstrap/03-bootstrapMonticelloRemote.st
@@ -11,7 +11,7 @@ mcPackages := #(
  ).
 
 (MonticelloBootstrap inDirectory: (CommandLineArguments new optionAt: 'BOOTSTRAP_PACKAGE_CACHE_DIR' ifAbsent: [ MCCacheRepository uniqueInstance directory ]) asFileReference)
-  loadPackagesNamed: mcPackages.
+  loadPackagesNamed: mcPackages!
 
 InternetConfiguration initialize.
 NetNameResolver initialize.

--- a/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
+++ b/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
@@ -31,7 +31,7 @@ mcPackages := #(
 MCMethodDefinition initializersEnabled: false.
 
 (MonticelloBootstrap inDirectory: (MCCacheRepository uniqueInstance directory))
-  loadPackagesNamed: mcPackages.
+  loadPackagesNamed: mcPackages!
 
 MCMethodDefinition initializersEnabled: true.
 

--- a/src/AST-Core/RBNotice.class.st
+++ b/src/AST-Core/RBNotice.class.st
@@ -28,7 +28,7 @@ RBNotice >> description [
 			  nextPutAll: ':';
 			  nextPutAll: self messageText;
 			  nextPutAll: '->';
-			  nextPutAll: node displaySourceCode ]
+			  nextPutAll: (node sourceCode asString withBlanksCondensed truncateWithElipsisTo: 60) ]
 ]
 
 { #category : #testing }

--- a/src/GeneralRules-Tests/ReGlobalVariablesUsageRuleTest.class.st
+++ b/src/GeneralRules-Tests/ReGlobalVariablesUsageRuleTest.class.st
@@ -26,7 +26,7 @@ ReGlobalVariablesUsageRuleTest >> setUp [
 		at: #MyGlobal
 		put: (self class >> #sampleMethod) sourceCode.
 
-	self class compile: 'sampleMethod
+	self class compiler permitFaulty: true; install: 'sampleMethod
 	sampleMethod
 		Smalltalk value.
 		MyGlobal value'

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -803,7 +803,7 @@ CompiledMethodTest >> testUndeclaredReparationWithClass [
 	Smalltalk globals removeKey: #TestUndeclaredVariable ifAbsent: [].
 	Undeclared removeKey: #TestUndeclaredVariable ifAbsent: []. "Because obsolete may remain"
 
-	method := self class compiler compile: 'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]'.
+	method := self class compiler permitFaulty: true; compile: 'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]'.
 	self assert: method usesUndeclareds.
 	self assert: (nil executeMethod: method) equals: nil.
 
@@ -834,7 +834,7 @@ CompiledMethodTest >> testUndeclaredReparationWithGlobal [
 
 	Smalltalk globals removeKey: #TestUndeclaredVariable ifAbsent: [].
 
-	method := self class compiler compile: 'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]'.
+	method := self class compiler permitFaulty: true; compile: 'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]'.
 	self assert: method usesUndeclareds.
 	self assert: (nil executeMethod: method) equals: nil.
 
@@ -868,7 +868,7 @@ CompiledMethodTest >> testUndeclaredReparationWithInstanceVariable [
 	receiver := class new.
 
 	"Note: unlike related tests, we need here a reveiver (see above) and to install the method in the class"
-	method := class >> (class compile: 'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]').
+	method := class compiler permitFaulty: true; install: 'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]'.
 	self assert: method usesUndeclareds.
 	self assert: (receiver executeMethod: method) equals: nil.
 
@@ -909,7 +909,7 @@ CompiledMethodTest >> testUndeclaredReparationWithShared [
 	class := Object subclass: #TestUndeclaredVariableClass instanceVariableNames: '' classVariableNames: '' category: ''.
 	self assert: (class bindingOf: #TestUndeclaredVariable) isNil.
 
-	method := class compiler compile: 'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]'.
+	method := class compiler permitFaulty: true; compile: 'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]'.
 	self assert: method usesUndeclareds.
 	self assert: (nil executeMethod: method) equals: nil.
 
@@ -944,9 +944,9 @@ CompiledMethodTest >> testUsesUndeclareds [
 	| method |
 	method := self class compiler compile: 'x ^x'.
 	self deny: method usesUndeclareds.
-	method := self class compiler compile: 'z ^z'.
+	method := self class compiler permitFaulty: true; compile: 'z ^z'.
 	self assert: method usesUndeclareds.
-	method := self class compiler compile: 'msg self in: [ :anObject | var1 := 1 ]'.
+	method := self class compiler permitFaulty: true; compile: 'msg self in: [ :anObject | var1 := 1 ]'.
 	self assert: method usesUndeclareds
 ]
 

--- a/src/Kernel-Tests/CompiledCodeTest.class.st
+++ b/src/Kernel-Tests/CompiledCodeTest.class.st
@@ -60,7 +60,7 @@ CompiledCodeTest >> testBlockReturnSpecial [
 CompiledCodeTest >> testHasLiteral [
 
 	| method |
-	method := self class compiler compile: 'method
+	method := self class compiler permitFaulty: true; compile: 'method
 		<pragma: #pragma>
 		test := 1+2.
 		self doIt: [
@@ -94,7 +94,7 @@ CompiledCodeTest >> testHasLiteral [
 CompiledCodeTest >> testHasLiteralSuchThat [
 
 	| method |
-	method := self class compiler compile: 'method
+	method := self class compiler permitFaulty: true; compile: 'method
 		<pragma: #pragma>
 		test := 1+2.
 		self doIt: [
@@ -126,7 +126,7 @@ CompiledCodeTest >> testHasLiteralSuchThat [
 CompiledCodeTest >> testHasSelector [
 
 	| method |
-	method := self class compiler compile: 'method
+	method := self class compiler permitFaulty: true; compile: 'method
 		<pragma: #pragma>
 		test := 1+2.
 		self doIt: [
@@ -158,7 +158,7 @@ CompiledCodeTest >> testHasSelector [
 CompiledCodeTest >> testHasSelectorSpecialSelectorIndex [
 
 	| method specialIndex |
-	method := self class compiler compile: 'method
+	method := self class compiler permitFaulty: true; compile: 'method
 		<pragma: #pragma>
 		test := 1+2.
 		self do: [
@@ -210,7 +210,7 @@ CompiledCodeTest >> testHasTemporaries [
 CompiledCodeTest >> testLiteralsDoNotConsiderTheInnerBlockLiterals [
 
 	| method block |
-	method := self class compiler compile: 'method
+	method := self class compiler permitFaulty: true; compile: 'method
 		<pragma: #pragma>
 		test := 1+2.
 		Class.
@@ -220,7 +220,7 @@ CompiledCodeTest >> testLiteralsDoNotConsiderTheInnerBlockLiterals [
 		Object.
 		self name ].
 		^#(#array) '.
-	block := (self class compiler evaluate: '[
+	block := (self class compiler permitFaulty: true; evaluate: '[
 		test := 1 - 2.
 		test := #(arrayInBlock).
 		Object.
@@ -254,7 +254,7 @@ CompiledCodeTest >> testLiteralsDoesNotContainMethodName [
 CompiledCodeTest >> testLiteralsEvenTheOnesInTheInnerBlocks [
 	"The behavior is different than literals"
 	| method |
-	method := self class compiler compile: 'method
+	method := self class compiler permitFaulty: true; compile: 'method
 		<pragma: #pragma>
 		test := 1+2.
 		Class.

--- a/src/OpalCompiler-Tests/OCCodeReparatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCCodeReparatorTest.class.st
@@ -146,7 +146,7 @@ OCCodeReparatorTest >> testUndeclaredVariable [
 		on: OCUndeclaredVariableWarning
 		do: [ :e |
 			flag := true.
-			e pass "do nothing" ].
+			e resume "continue" ].
 
 	self assert: flag.
 	self assert: method isCompiledMethod.

--- a/src/OpalCompiler-Tests/OCCompiledMethodIntegrityTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompiledMethodIntegrityTest.class.st
@@ -102,6 +102,7 @@ OCCompiledMethodIntegrityTest >> testUndeclaredVariable [
 			'methodWithUndeclaredVar
 											^ undeclaredTestVar';
 		class: OCMockCompilationClass;
+		permitFaulty: true;
 		compile.
 
 	undeclaredBinding := newCompiledMethod literals detect: [ :each | each name = #undeclaredTestVar ].
@@ -119,6 +120,7 @@ OCCompiledMethodIntegrityTest >> testUndeclaredVariableWhenItIsAlreadyRegistered
 			'methodWithUndeclaredVar
 											^ undeclaredTestVar';
 		class: OCMockCompilationClass;
+		permitFaulty: true;
 		compile.
 
 	undeclaredBinding := newCompiledMethod literals detect: [ :each | each name = #undeclaredTestVar ].
@@ -140,6 +142,7 @@ OCCompiledMethodIntegrityTest >> testUndeclaredVariableWhenItIsAlreadyRegistered
 			'methodWithUndeclaredVar
 											^ undeclaredTestVar';
 		class: OCMockCompilationClass;
+		permitFaulty: true;
 		compile.
 
 	undeclaredBinding := newCompiledMethod literals detect: [ :each | each name = #undeclaredTestVar ].

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -279,7 +279,7 @@ OCCompilerTest >> testUndefinedVariableFrontend [
 	self deny: (Undeclared includesKey: #undefinedName123).
 	self should: [ OpalCompiler new compile: 'foo ^undefinedName123 ¿ 2' ] raise: CodeError.
 	self deny: (Undeclared includesKey: #undefinedName123).
-	OpalCompiler new compile: 'foo ^undefinedName123'.
+	OpalCompiler new permitFaulty: true; compile: 'foo ^undefinedName123'.
 	self assert: (Undeclared includesKey: #undefinedName123).
 
 	"Cleanup"

--- a/src/OpalCompiler-Tests/OCDoitTest.class.st
+++ b/src/OpalCompiler-Tests/OCDoitTest.class.st
@@ -139,7 +139,7 @@ OCDoitTest >> testDoitContextCheckClass [
 
 	| ast method |
 	method := OpalCompiler new
-		source: 'tempForTesting';
+		source: 'true';
 		noPattern: true;
 		context: thisContext;
 		compile.

--- a/src/OpalCompiler-Tests/OCEnvironmentScopeTest.class.st
+++ b/src/OpalCompiler-Tests/OCEnvironmentScopeTest.class.st
@@ -26,6 +26,7 @@ OCEnvironmentScopeTest >> testCompileWithEnvironment [
 	method := OpalCompiler new
 					environment: environment;
 					class: (environment at: #MyClass);
+					permitFaulty: true;
 					compile: 'tt ^Object'.
 	return := method valueWithReceiver: nil arguments: #().
 	self assert: return equals: nil


### PR DESCRIPTION
Some cleanup extracted from #13244 that I think are good as is

Summary

* fix notice description in early boostrap (fewer features available)
* Remove undeclared variables in some boostrap script by splitting them into two chunks
* add some `permitFaulty` in tests that use undeclared variables