### PR TITLE
Refactor TextConstants to separate font and non-font constants (Issue : #13015)

### DIFF
--- a/src/Text-Core/TextConstants.class.st
+++ b/src/Text-Core/TextConstants.class.st
@@ -87,11 +87,10 @@ Class {
 		'RightMarginTab',
 		'Space',
 		'Tab',
-		'TextSharedInformation'
 	],
 	#category : #'Text-Core-Base'
 }
-
+"TextSharedInformation"
 { #category : #accessing }
 TextConstants class >> BS [
 	^BS
@@ -502,10 +501,10 @@ TextConstants class >> Tab [
 	^Tab
 ]
 
-{ #category : #accessing }
+"{ #category : #accessing }
 TextConstants class >> TextSharedInformation [
 	^TextSharedInformation
-]
+]"
 
 { #category : #'backward compatibility' }
 TextConstants class >> at: aSymbol [
@@ -516,7 +515,7 @@ TextConstants class >> at: aSymbol [
 { #category : #'class initialization' }
 TextConstants class >> initialize [
 
-	TextSharedInformation ifNil: [ TextSharedInformation := Dictionary new].
+	"TextSharedInformation ifNil: [ TextSharedInformation := Dictionary new]."
 	Ctrll := Character value: 153.
 	Ctrld := Character value: 132.
 	ESC := Character value: 160.
@@ -600,3 +599,4 @@ TextConstants class >> initialize [
 	Ctrlp := Character value: 138.
 	DefaultBaseline := 12
 ]
+"Assuming that fonts do indeed refer to the styles of text such as bold and italic, Having a separate SharedPool to hold the fonts looks more appropriate for upcoming changes."

--- a/src/Text-Core/TextConstants.class.st
+++ b/src/Text-Core/TextConstants.class.st
@@ -507,10 +507,10 @@ TextConstants class >> TextSharedInformation [
 ]"
 
 { #category : #'backward compatibility' }
-TextConstants class >> at: aSymbol [
+"TextConstants class >> at: aSymbol [
 
 	^ self classPool at: aSymbol ifAbsent: [self TextSharedInformation at: aSymbol]
-]
+]"
 
 { #category : #'class initialization' }
 TextConstants class >> initialize [


### PR DESCRIPTION
This pull request addresses issue #13015 by refactoring the TextConstants class to separate font and constants. Currently, TextConstants contains both constant and fonts which can cause confusion in the code. By separating them, the code becomes more organized and easier to maintain.