### PR TITLE
12885-Objectassert-fails-with-non-booleans-contradicting-its-own-comment 

### DIFF
--- a/src/Kernel-Tests/ObjectTest.class.st
+++ b/src/Kernel-Tests/ObjectTest.class.st
@@ -27,6 +27,15 @@ ObjectTest >> testAs [
 	self assert: coll1 identicalTo: coll2
 ]
 
+{ #category : #tests }
+ObjectTest >> testAssert [
+
+	self shouldnt: [Object new assert: true] raise: AssertionFailure.
+	self shouldnt: [
+		"make sure that we non-boolean arguments just fails"
+		self should: [Object new assert: 1] raise: AssertionFailure ] raise: [NonBooleanReceiver]. 
+]
+
 { #category : #'tests - accessing' }
 ObjectTest >> testBasicSize [
 	"Numbers are not indexable"

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -380,7 +380,7 @@ Object >> assert: aBlock description: aStringOrBlock [
 	"Throw an assertion error if aBlock does not evaluates to true."
 
 	<debuggerCompleteToSender>
-	aBlock value ifFalse: [
+	aBlock value == true ifFalse: [
 		AssertionFailure signal: aStringOrBlock value ]
 ]
 

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -380,6 +380,7 @@ Object >> assert: aBlock description: aStringOrBlock [
 	"Throw an assertion error if aBlock does not evaluates to true."
 
 	<debuggerCompleteToSender>
+	"we do the == true check to avoid NonBooleanReceiver error for nonBoolean aBlock values"
 	aBlock value == true ifFalse: [
 		AssertionFailure signal: aStringOrBlock value ]
 ]


### PR DESCRIPTION
make #assert: allow to be more stable for non-booleans
fixes #12885