### PR TITLE
Remove ClassOrganization>>allProtocolNames

### DIFF
--- a/src/Deprecated12/ClassOrganization.extension.st
+++ b/src/Deprecated12/ClassOrganization.extension.st
@@ -10,8 +10,8 @@ ClassOrganization >> addCategory: aString [
 { #category : #'*Deprecated12' }
 ClassOrganization >> allCategories [
 
-	self deprecated: 'Use #protocolsNames instead.' transformWith: '`@rcv allCategories' -> '`@rcv protocolsNames'.
-	^ self protocolsNames
+	self deprecated: 'Use #protocolNames instead.' transformWith: '`@rcv allCategories' -> '`@rcv protocolNames'.
+	^ self protocolNames
 ]
 
 { #category : #'*Deprecated12' }

--- a/src/Deprecated12/ClassOrganization.extension.st
+++ b/src/Deprecated12/ClassOrganization.extension.st
@@ -10,8 +10,8 @@ ClassOrganization >> addCategory: aString [
 { #category : #'*Deprecated12' }
 ClassOrganization >> allCategories [
 
-	self deprecated: 'Use #allProtocolsNames instead.' transformWith: '`@rcv allCategories' -> '`@rcv allProtocolsNames'.
-	^ self allProtocolsNames
+	self deprecated: 'Use #protocolsNames instead.' transformWith: '`@rcv allCategories' -> '`@rcv protocolsNames'.
+	^ self protocolsNames
 ]
 
 { #category : #'*Deprecated12' }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -284,19 +284,13 @@ ClassOrganization >> protocolNamed: aString ifAbsent: aBlock [
 { #category : #accessing }
 ClassOrganization >> protocolNames [
 
-	^ self protocols collect: #name
+	^ self protocols collect: [ :protocol | protocol name ]
 ]
 
 { #category : #accessing }
 ClassOrganization >> protocols [
 
 	^ protocols asArray
-]
-
-{ #category : #accessing }
-ClassOrganization >> protocolsNames [
-
-	^ self allProtocols collect: [ :each | each name ]
 ]
 
 { #category : #protocol }
@@ -320,7 +314,7 @@ ClassOrganization >> removeElement: aSymbol [
 ClassOrganization >> removeEmptyProtocols [
 
 	| oldProtocolNames removedProtocols |
-	oldProtocolNames := self protocolsNames copy.
+	oldProtocolNames := self protocolNames copy.
 
 	removedProtocols := protocols
 		                    select: [ :protocol | protocol canBeRemoved ]
@@ -328,7 +322,7 @@ ClassOrganization >> removeEmptyProtocols [
 			                    self removeProtocol: protocol.
 			                    self notifyOfRemovedProtocolNamed: protocol name ].
 
-	self notifyOfChangedProtocolNamesFrom: oldProtocolNames to: self protocolsNames
+	self notifyOfChangedProtocolNamesFrom: oldProtocolNames to: self protocolNames
 ]
 
 { #category : #accessing }
@@ -337,10 +331,10 @@ ClassOrganization >> removeProtocol: aProtocol [
 	| oldProtocolNames |
 	aProtocol canBeRemoved ifFalse: [ ^ self ].
 
-	oldProtocolNames := self protocolsNames copy.
+	oldProtocolNames := self protocolNames copy.
 	protocols remove: aProtocol ifAbsent: [  ].
 	self notifyOfRemovedProtocolNamed: aProtocol name.
-	self notifyOfChangedProtocolNamesFrom: oldProtocolNames to: self protocolsNames
+	self notifyOfChangedProtocolNamesFrom: oldProtocolNames to: self protocolNames
 ]
 
 { #category : #accessing }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -63,12 +63,6 @@ ClassOrganization >> allProtocols [
 	^ { self allProtocol } , self protocols
 ]
 
-{ #category : #accessing }
-ClassOrganization >> allProtocolsNames [
-
-	^ self allProtocols collect: [ :each | each name ]
-]
-
 { #category : #'backward compatibility' }
 ClassOrganization >> classComment [
 

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -299,6 +299,12 @@ ClassOrganization >> protocols [
 	^ protocols asArray
 ]
 
+{ #category : #accessing }
+ClassOrganization >> protocolsNames [
+
+	^ self allProtocols collect: [ :each | each name ]
+]
+
 { #category : #protocol }
 ClassOrganization >> protocolsOfSelector: aSelector [
 
@@ -320,8 +326,7 @@ ClassOrganization >> removeElement: aSymbol [
 ClassOrganization >> removeEmptyProtocols [
 
 	| oldProtocolNames removedProtocols |
-	oldProtocolNames := self allProtocolsNames copy.
-
+	oldProtocolNames := self protocolsNames copy.
 
 	removedProtocols := protocols
 		                    select: [ :protocol | protocol canBeRemoved ]
@@ -329,7 +334,7 @@ ClassOrganization >> removeEmptyProtocols [
 			                    self removeProtocol: protocol.
 			                    self notifyOfRemovedProtocolNamed: protocol name ].
 
-	self notifyOfChangedProtocolNamesFrom: oldProtocolNames to: self allProtocolsNames
+	self notifyOfChangedProtocolNamesFrom: oldProtocolNames to: self protocolsNames
 ]
 
 { #category : #accessing }
@@ -338,10 +343,10 @@ ClassOrganization >> removeProtocol: aProtocol [
 	| oldProtocolNames |
 	aProtocol canBeRemoved ifFalse: [ ^ self ].
 
-	oldProtocolNames := self allProtocolsNames copy.
+	oldProtocolNames := self protocolsNames copy.
 	protocols remove: aProtocol ifAbsent: [  ].
 	self notifyOfRemovedProtocolNamed: aProtocol name.
-	self notifyOfChangedProtocolNamesFrom: oldProtocolNames to: self allProtocolsNames
+	self notifyOfChangedProtocolNamesFrom: oldProtocolNames to: self protocolsNames
 ]
 
 { #category : #accessing }

--- a/src/MonticelloGUI-Tests/MCSnapshotBrowserTest.class.st
+++ b/src/MonticelloGUI-Tests/MCSnapshotBrowserTest.class.st
@@ -41,14 +41,12 @@ MCSnapshotBrowserTest >> assertAListIncludes: anArrayOfStrings [
 
 { #category : #asserting }
 MCSnapshotBrowserTest >> assertAListMatches: strings [
+
 	| lists |
-	lists := self listMorphs collect: [:each | each getList].
+	lists := self listMorphs collect: [ :each | each getList ].
 	lists
-		detect: [ :list|
-			(list size = strings size) and: [list includesAll: strings]]
-		ifNone: [ 
-			self fail: 'Could not find all "', strings asArray asString, '" ', 
-						'in any of "', (lists collect: #asArray) asArray asString, '"'  ].
+		detect: [ :list | list size = strings size and: [ list includesAll: strings ] ]
+		ifNone: [ self fail: 'Could not find all "' , strings asArray asString , '" ' , 'in any of "' , (lists collect: #asArray) asArray asString , '"' ]
 ]
 
 { #category : #asserting }
@@ -83,7 +81,8 @@ MCSnapshotBrowserTest >> classABooleanMethods [
 
 { #category : #private }
 MCSnapshotBrowserTest >> classAClassProtocols [
-	^ self protocolsForClass: self mockClassA class.
+
+	^ self protocolsForClass: self mockClassA class
 ]
 
 { #category : #private }
@@ -185,7 +184,7 @@ MCSnapshotBrowserTest >> morphsOfClass: aMorphClass [
 { #category : #private }
 MCSnapshotBrowserTest >> protocolsForClass: aClass [
 
-	^ aClass organization protocolsNames
+	^ aClass organization protocolNames
 ]
 
 { #category : #selecting }
@@ -277,7 +276,7 @@ MCSnapshotBrowserTest >> testMethodIsCleared [
 	self clickOnListItem: 'MCMockClassA'.
 	self clickOnListItem: 'boolean'.
 	self clickOnListItem: 'falsehood'.
-	self clickOnListItem: AllProtocol defaultName.
+	self clickOnListItem: 'numeric'.
 	
 	self denyAListHasSelection: 'falsehood'.
 ]

--- a/src/MonticelloGUI-Tests/MCSnapshotBrowserTest.class.st
+++ b/src/MonticelloGUI-Tests/MCSnapshotBrowserTest.class.st
@@ -185,7 +185,7 @@ MCSnapshotBrowserTest >> morphsOfClass: aMorphClass [
 { #category : #private }
 MCSnapshotBrowserTest >> protocolsForClass: aClass [
 
-	^ aClass organization allProtocolsNames
+	^ aClass organization protocolsNames
 ]
 
 { #category : #selecting }

--- a/src/MonticelloGUI/MCSnapshotBrowser.class.st
+++ b/src/MonticelloGUI/MCSnapshotBrowser.class.st
@@ -428,12 +428,11 @@ MCSnapshotBrowser >> visibleMethods [
 
 { #category : #listing }
 MCSnapshotBrowser >> visibleProtocols [
-	| methods protocols |
-	self switchIsComment ifTrue: [^ Array new].
+
+	| methods |
+	self switchIsComment ifTrue: [ ^ Array new ].
 	methods := self methodsForSelectedClass.
-	protocols := (methods collect: [:ea | ea category]) asSet asSortedCollection.
-	protocols add: AllProtocol defaultName.
-	^ protocols 
+	^ (methods collect: [ :ea | ea category ]) asSet asSortedCollection
 ]
 
 { #category : #'morphic ui' }

--- a/src/ReleaseTests/ProperMethodCategorizationTest.class.st
+++ b/src/ReleaseTests/ProperMethodCategorizationTest.class.st
@@ -165,7 +165,7 @@ ProperMethodCategorizationTest >> testNoLeadingOrTrailingSpacesInCategoryNames [
 	violations := OrderedCollection new.
 
 	Object allSubclasses do: [ :each |
-		each organization protocolsNames do: [ :cat | ((cat endsWith: ' ') or: [ cat endsWith: ' ' ]) ifTrue: [ violations add: each -> cat ] ] ].
+		each organization protocolNames do: [ :cat | ((cat endsWith: ' ') or: [ cat endsWith: ' ' ]) ifTrue: [ violations add: each -> cat ] ] ].
 
 	self assert: violations isEmpty description: 'Found protocol names with leading or trailing spaces: ' , violations asString
 ]

--- a/src/ReleaseTests/ProperMethodCategorizationTest.class.st
+++ b/src/ReleaseTests/ProperMethodCategorizationTest.class.st
@@ -165,7 +165,7 @@ ProperMethodCategorizationTest >> testNoLeadingOrTrailingSpacesInCategoryNames [
 	violations := OrderedCollection new.
 
 	Object allSubclasses do: [ :each |
-		each organization allProtocolsNames do: [ :cat | ((cat endsWith: ' ') or: [ cat endsWith: ' ' ]) ifTrue: [ violations add: each -> cat ] ] ].
+		each organization protocolsNames do: [ :cat | ((cat endsWith: ' ') or: [ cat endsWith: ' ' ]) ifTrue: [ violations add: each -> cat ] ] ].
 
 	self assert: violations isEmpty description: 'Found protocol names with leading or trailing spaces: ' , violations asString
 ]

--- a/src/Tool-Base/AbstractTool.class.st
+++ b/src/Tool-Base/AbstractTool.class.st
@@ -11,10 +11,9 @@ Class {
 AbstractTool class >> protocolSuggestionsFor: aClass [
 
 	| classProtocols reject allExistingProtocols interestingProtocols |
-	classProtocols := aClass organization allProtocolsNames.
+	classProtocols := aClass organization protocolsNames.
 	reject := Set new.
 	reject
-		add: AllProtocol defaultName;
 		add: Protocol nullProtocolName;
 		add: Protocol unclassified.
 	allExistingProtocols := (SystemNavigation default

--- a/src/Tool-Base/AbstractTool.class.st
+++ b/src/Tool-Base/AbstractTool.class.st
@@ -11,7 +11,7 @@ Class {
 AbstractTool class >> protocolSuggestionsFor: aClass [
 
 	| classProtocols reject allExistingProtocols interestingProtocols |
-	classProtocols := aClass organization protocolsNames.
+	classProtocols := aClass organization protocolNames.
 	reject := Set new.
 	reject
 		add: Protocol nullProtocolName;


### PR DESCRIPTION
#allProtocolNames return the name of the protocols + #'--all--', but this #'--all--' is never used. 

This removes #allProtocolNames and adds #protocolNames instead that does not deal with the instance of AllProtocol. 

The end goal is to remove AllProtocol from that system because this is not really used and makes the MM too complicated for what it does.