### PR TITLE
Rename #methodsInProtocolNamed: into #methodSelectorsInProtocol:

### DIFF
--- a/src/CodeExport/ClassDescription.extension.st
+++ b/src/CodeExport/ClassDescription.extension.st
@@ -7,7 +7,7 @@ ClassDescription >> fileOutChangedMessages: aSet on: aFileStream [
 
 	| org |
 	(org := self organization) protocolNames do: [ :protocolName |
-		(org methodSelectorsInProtocolNamed: protocolName)
+		(org methodSelectorsInProtocol: protocolName)
 			select: [ :selector | aSet includes: selector ]
 			thenDo: [ :selector | self printMethodChunk: selector on: aFileStream ] ]
 ]
@@ -134,5 +134,5 @@ ClassDescription >> printProtocolChunk: protocolName on: aFileStream withStamp: 
 { #category : #'*CodeExport' }
 ClassDescription >> selectorsInProtocolNamed: aSymbol [
 
-	^ self organization methodSelectorsInProtocolNamed: aSymbol
+	^ self organization methodSelectorsInProtocol: aSymbol
 ]

--- a/src/CodeExport/ClassDescription.extension.st
+++ b/src/CodeExport/ClassDescription.extension.st
@@ -7,7 +7,7 @@ ClassDescription >> fileOutChangedMessages: aSet on: aFileStream [
 
 	| org |
 	(org := self organization) protocolNames do: [ :protocolName |
-		(org methodsInProtocolNamed: protocolName)
+		(org methodSelectorsInProtocolNamed: protocolName)
 			select: [ :selector | aSet includes: selector ]
 			thenDo: [ :selector | self printMethodChunk: selector on: aFileStream ] ]
 ]
@@ -134,5 +134,5 @@ ClassDescription >> printProtocolChunk: protocolName on: aFileStream withStamp: 
 { #category : #'*CodeExport' }
 ClassDescription >> selectorsInProtocolNamed: aSymbol [
 
-	^ self organization methodsInProtocolNamed: aSymbol
+	^ self organization methodSelectorsInProtocolNamed: aSymbol
 ]

--- a/src/Deprecated12/ClassDescription.extension.st
+++ b/src/Deprecated12/ClassDescription.extension.st
@@ -80,5 +80,5 @@ ClassDescription >> copyCategory: protocolName from: aClass classified: newProto
 
 	self deprecated: 'This method will be removed in the next version of Pharo.'.
 
-	self copyAll: (aClass organization methodsInProtocolNamed: protocolName) from: aClass classified: newProtocolName
+	self copyAll: (aClass organization methodSelectorsInProtocolNamed: protocolName) from: aClass classified: newProtocolName
 ]

--- a/src/Deprecated12/ClassDescription.extension.st
+++ b/src/Deprecated12/ClassDescription.extension.st
@@ -80,5 +80,5 @@ ClassDescription >> copyCategory: protocolName from: aClass classified: newProto
 
 	self deprecated: 'This method will be removed in the next version of Pharo.'.
 
-	self copyAll: (aClass organization methodSelectorsInProtocolNamed: protocolName) from: aClass classified: newProtocolName
+	self copyAll: (aClass organization methodSelectorsInProtocol: protocolName) from: aClass classified: newProtocolName
 ]

--- a/src/Deprecated12/ClassOrganization.extension.st
+++ b/src/Deprecated12/ClassOrganization.extension.st
@@ -40,8 +40,8 @@ ClassOrganization >> categoryOfElement: aSelector ifAbsent: aBlock [
 { #category : #'*Deprecated12' }
 ClassOrganization >> listAtCategoryNamed: aName [
 
-	self deprecated: 'Use #methodsInProtocolNamed: instead.' transformWith: '`@rcv listAtCategoryNamed: `@arg' -> '`@rcv methodSelectorsInProtocolNamed: `@arg'.
-	^ self methodSelectorsInProtocolNamed: aName
+	self deprecated: 'Use #methodsInProtocolNamed: instead.' transformWith: '`@rcv listAtCategoryNamed: `@arg' -> '`@rcv methodSelectorsInProtocol: `@arg'.
+	^ self methodSelectorsInProtocol: aName
 ]
 
 { #category : #'*Deprecated12' }

--- a/src/Deprecated12/ClassOrganization.extension.st
+++ b/src/Deprecated12/ClassOrganization.extension.st
@@ -40,8 +40,8 @@ ClassOrganization >> categoryOfElement: aSelector ifAbsent: aBlock [
 { #category : #'*Deprecated12' }
 ClassOrganization >> listAtCategoryNamed: aName [
 
-	self deprecated: 'Use #methodsInProtocolNamed: instead.' transformWith: '`@rcv listAtCategoryNamed: `@arg' -> '`@rcv methodsInProtocolNamed: `@arg'.
-	^ self methodsInProtocolNamed: aName
+	self deprecated: 'Use #methodsInProtocolNamed: instead.' transformWith: '`@rcv listAtCategoryNamed: `@arg' -> '`@rcv methodSelectorsInProtocolNamed: `@arg'.
+	^ self methodSelectorsInProtocolNamed: aName
 ]
 
 { #category : #'*Deprecated12' }

--- a/src/Gofer-Core/GoferCleanup.class.st
+++ b/src/Gofer-Core/GoferCleanup.class.st
@@ -27,12 +27,11 @@ GoferCleanup >> cleanupCategories: aWorkingCopy [
 GoferCleanup >> cleanupProtocols: aWorkingCopy [
 
 	aWorkingCopy packageSet extendedClasses do: [ :class |
-		(aWorkingCopy packageSet extensionCategoriesForClass: class) do: [ :category |
-			(class organization methodsInProtocolNamed: category) isEmpty ifTrue: [ class organization removeProtocolNamed: category ] ] ].
+		(aWorkingCopy packageSet extensionCategoriesForClass: class) do: [ :protocolName | class organisation removeProtocolIfEmpty: protocolName ] ].
 
 	aWorkingCopy packageSet classesAndMetaClasses do: [ :class |
 		(aWorkingCopy packageSet coreCategoriesForClass: class) do: [ :category |
-			(class organization listAtCategoryNamed: category) isEmpty ifTrue: [ class organization removeProtocolNamed: category ] ] ]
+			(class organization listAtCategoryNamed: category) ifEmpty: [ class organization removeProtocolNamed: category ] ] ]
 ]
 
 { #category : #running }

--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -53,13 +53,13 @@ ClassOrganizationTest >> testAddProtocolNamed [
 ]
 
 { #category : #tests }
-ClassOrganizationTest >> testMethodSelectorsInProtocolNamed [
+ClassOrganizationTest >> testMethodSelectorsInProtocol [
 
 	| methods |
-	methods := self organization methodSelectorsInProtocolNamed: 'empty'.
+	methods := self organization methodSelectorsInProtocol: 'empty'.
 	self assertEmpty: methods.
 
-	methods := self organization methodSelectorsInProtocolNamed: 'one'.
+	methods := self organization methodSelectorsInProtocol: 'one'.
 	self assert: methods size equals: 1.
 	self assert: methods first equals: #one
 ]

--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -53,13 +53,13 @@ ClassOrganizationTest >> testAddProtocolNamed [
 ]
 
 { #category : #tests }
-ClassOrganizationTest >> testMethodsInProtocolNamed [
+ClassOrganizationTest >> testMethodSelectorsInProtocolNamed [
 
 	| methods |
-	methods := self organization methodsInProtocolNamed: 'empty'.
+	methods := self organization methodSelectorsInProtocolNamed: 'empty'.
 	self assertEmpty: methods.
 
-	methods := self organization methodsInProtocolNamed: 'one'.
+	methods := self organization methodSelectorsInProtocolNamed: 'one'.
 	self assert: methods size equals: 1.
 	self assert: methods first equals: #one
 ]

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -121,7 +121,7 @@ ClassDescription >> allSelectorsInProtocol: aName [
 	"Answer a list of all the methods of the receiver and all its
 	superclasses that are in the protocol named aName"
 
-	^ self withAllSuperclasses flatCollectAsSet: [ :class | class organization methodSelectorsInProtocolNamed: aName ]
+	^ self withAllSuperclasses flatCollectAsSet: [ :class | class organization methodSelectorsInProtocol: aName ]
 ]
 
 { #category : #'pool variable' }
@@ -695,7 +695,7 @@ ClassDescription >> localSlots [
 { #category : #organization }
 ClassDescription >> methodsInProtocol: aString [
 
-	^ (self organization methodSelectorsInProtocolNamed: aString) collect: [ :each | self compiledMethodAt: each ]
+	^ (self organization methodSelectorsInProtocol: aString) collect: [ :each | self compiledMethodAt: each ]
 ]
 
 { #category : #'accessing - tags' }
@@ -893,7 +893,7 @@ ClassDescription >> removeProtocol: protocolName [
 	"Remove each of the messages categorized under aString in the method
 	dictionary of the receiver. Then remove the category aString."
 
-	(self organization methodSelectorsInProtocolNamed: protocolName) do: [ :sel | self removeSelector: sel ].
+	(self organization methodSelectorsInProtocol: protocolName) do: [ :sel | self removeSelector: sel ].
 	self organization removeProtocolNamed: protocolName
 ]
 
@@ -930,14 +930,14 @@ ClassDescription >> reorganize [
 ClassDescription >> selectorsInCategory: aName [
 	"Answer a list of the selectors of the receiver that are in category named aName"
 
-	^ (self organization methodSelectorsInProtocolNamed: aName) asSet asArray sort
+	^ (self organization methodSelectorsInProtocol: aName) asSet asArray sort
 ]
 
 { #category : #'accessing - method dictionary' }
 ClassDescription >> selectorsInProtocol: aName [
 	"Answer a list of the selectors of the receiver that are in category named aName"
 
-	^ (self organization methodSelectorsInProtocolNamed: aName) asSet asArray sort
+	^ (self organization methodSelectorsInProtocol: aName) asSet asArray sort
 ]
 
 { #category : #'pool variable' }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -121,7 +121,7 @@ ClassDescription >> allSelectorsInProtocol: aName [
 	"Answer a list of all the methods of the receiver and all its
 	superclasses that are in the protocol named aName"
 
-	^ self withAllSuperclasses flatCollectAsSet: [ :class | class organization methodsInProtocolNamed: aName ]
+	^ self withAllSuperclasses flatCollectAsSet: [ :class | class organization methodSelectorsInProtocolNamed: aName ]
 ]
 
 { #category : #'pool variable' }
@@ -695,7 +695,7 @@ ClassDescription >> localSlots [
 { #category : #organization }
 ClassDescription >> methodsInProtocol: aString [
 
-	^ (self organization methodsInProtocolNamed: aString) collect: [ :each | self compiledMethodAt: each ]
+	^ (self organization methodSelectorsInProtocolNamed: aString) collect: [ :each | self compiledMethodAt: each ]
 ]
 
 { #category : #'accessing - tags' }
@@ -893,7 +893,7 @@ ClassDescription >> removeProtocol: protocolName [
 	"Remove each of the messages categorized under aString in the method
 	dictionary of the receiver. Then remove the category aString."
 
-	(self organization methodsInProtocolNamed: protocolName) do: [ :sel | self removeSelector: sel ].
+	(self organization methodSelectorsInProtocolNamed: protocolName) do: [ :sel | self removeSelector: sel ].
 	self organization removeProtocolNamed: protocolName
 ]
 
@@ -930,14 +930,14 @@ ClassDescription >> reorganize [
 ClassDescription >> selectorsInCategory: aName [
 	"Answer a list of the selectors of the receiver that are in category named aName"
 
-	^ (self organization methodsInProtocolNamed: aName) asSet asArray sort
+	^ (self organization methodSelectorsInProtocolNamed: aName) asSet asArray sort
 ]
 
 { #category : #'accessing - method dictionary' }
 ClassDescription >> selectorsInProtocol: aName [
 	"Answer a list of the selectors of the receiver that are in category named aName"
 
-	^ (self organization methodsInProtocolNamed: aName) asSet asArray sort
+	^ (self organization methodSelectorsInProtocolNamed: aName) asSet asArray sort
 ]
 
 { #category : #'pool variable' }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -194,7 +194,7 @@ ClassOrganization >> initializeClass: aClass [
 ]
 
 { #category : #accessing }
-ClassOrganization >> methodSelectorsInProtocolNamed: aName [
+ClassOrganization >> methodSelectorsInProtocol: aName [
 
 	aName = AllProtocol defaultName ifTrue: [ ^ self allMethodSelectors ].
 

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -194,7 +194,7 @@ ClassOrganization >> initializeClass: aClass [
 ]
 
 { #category : #accessing }
-ClassOrganization >> methodsInProtocolNamed: aName [
+ClassOrganization >> methodSelectorsInProtocolNamed: aName [
 
 	aName = AllProtocol defaultName ifTrue: [ ^ self allMethodSelectors ].
 

--- a/src/OpalCompiler-Tests/MethodPragmaTest.class.st
+++ b/src/OpalCompiler-Tests/MethodPragmaTest.class.st
@@ -49,7 +49,7 @@ MethodPragmaTest >> pragma: aSymbol selector: aSelector times: anInteger [
 { #category : #running }
 MethodPragmaTest >> tearDown [
 
-	(self class organization methodsInProtocolNamed: self methodCategory) do: [ :each | self class removeSelectorSilently: each ].
+	(self class organization methodSelectorsInProtocolNamed: self methodCategory) do: [ :each | self class removeSelectorSilently: each ].
 	self class organization removeProtocolNamed: self methodCategory.
 	super tearDown
 ]

--- a/src/OpalCompiler-Tests/MethodPragmaTest.class.st
+++ b/src/OpalCompiler-Tests/MethodPragmaTest.class.st
@@ -49,7 +49,7 @@ MethodPragmaTest >> pragma: aSymbol selector: aSelector times: anInteger [
 { #category : #running }
 MethodPragmaTest >> tearDown [
 
-	(self class organization methodSelectorsInProtocolNamed: self methodCategory) do: [ :each | self class removeSelectorSilently: each ].
+	(self class organization methodSelectorsInProtocol: self methodCategory) do: [ :each | self class removeSelectorSilently: each ].
 	self class organization removeProtocolNamed: self methodCategory.
 	super tearDown
 ]

--- a/src/OpalCompiler-Tests/OCTargetCompiler.class.st
+++ b/src/OpalCompiler-Tests/OCTargetCompiler.class.st
@@ -1,9 +1,3 @@
-"
-I am a ridiculous alternate compiler, that replaces any literal symbol #dontReturnThis with the symbol #expectedReturn.
-
-It's the simplest change to the compiler that I could imagine that doesn't interfere with the fact that the class-side `compilerClass` method can't be interfered with.
-
-"
 Class {
 	#name : #OCTargetCompiler,
 	#superclass : #OpalCompiler,

--- a/src/OpalCompiler-Tests/OCTargetCompiler.class.st
+++ b/src/OpalCompiler-Tests/OCTargetCompiler.class.st
@@ -1,3 +1,9 @@
+"
+I am a ridiculous alternate compiler, that replaces any literal symbol #dontReturnThis with the symbol #expectedReturn.
+
+It's the simplest change to the compiler that I could imagine that doesn't interfere with the fact that the class-side `compilerClass` method can't be interfered with.
+
+"
 Class {
 	#name : #OCTargetCompiler,
 	#superclass : #OpalCompiler,

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -756,8 +756,7 @@ RPackage >> importPackage: anRPackage [
 RPackage >> importProtocol: aProtocol forClass: aClass [
 	"import all the methods of a protocol as defined in the receiver."
 
-	(aClass organization methodsInProtocolNamed: aProtocol) do: [ :each |
-		aClass compiledMethodAt: each ifPresent: [ :method | method isFromTrait ifFalse: [ self addMethod: method ] ] ]
+	(aClass methodsInProtocol: aProtocol) do: [ :method | method isFromTrait ifFalse: [ self addMethod: method ] ]
 ]
 
 { #category : #testing }

--- a/src/Refactoring-Environment/RBBrowserEnvironment.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironment.class.st
@@ -774,7 +774,7 @@ RBBrowserEnvironment >> selectorsDo: aBlock [
 { #category : #accessing }
 RBBrowserEnvironment >> selectorsFor: aProtocol in: aClass [
 
-	^ (aClass organization methodsInProtocolNamed: aProtocol) select: [ :each | self includesSelector: each in: aClass ]
+	^ (aClass organization methodSelectorsInProtocolNamed: aProtocol) select: [ :each | self includesSelector: each in: aClass ]
 ]
 
 { #category : #accessing }

--- a/src/Refactoring-Environment/RBBrowserEnvironment.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironment.class.st
@@ -774,7 +774,7 @@ RBBrowserEnvironment >> selectorsDo: aBlock [
 { #category : #accessing }
 RBBrowserEnvironment >> selectorsFor: aProtocol in: aClass [
 
-	^ (aClass organization methodSelectorsInProtocolNamed: aProtocol) select: [ :each | self includesSelector: each in: aClass ]
+	^ (aClass organization methodSelectorsInProtocol: aProtocol) select: [ :each | self includesSelector: each in: aClass ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
When I renamed the categories of ClassOrganization I did a mistake in the name of this method. This PR fixes this mistake.

The name is pretty long but I plan to iterate over this part of the system still and the names will improve (most #protocolNamed: will just become #protocol: and accept real instances of protocol)

I also simplified RPackage>>importProtocol:forClass: and GoferCleanup>>cleanupProtocols: