### PR TITLE
Remove references to SystemOrganizer

### DIFF
--- a/src/Fuel-Platform-Core/FLPlatform.class.st
+++ b/src/Fuel-Platform-Core/FLPlatform.class.st
@@ -95,25 +95,9 @@ FLPlatform class >> extensionProtocolName [
 FLPlatform class >> fixMetacello [
 ]
 
-{ #category : #accessing }
-FLPlatform class >> hacksCategoryName [
-	^ 'FuelPlatformHacks'
-]
-
 { #category : #testing }
 FLPlatform class >> isResponsibleForCurrentPlatform [
 	^ self subclassResponsibility
-]
-
-{ #category : #'private-convenience' }
-FLPlatform class >> removeModifications [
-
-	((Smalltalk globals at: #( Smalltalk globals at: #PackageInfo )) named: self extensionProtocolName) extensionMethods do: [ :methodReference |
-		methodReference actualClass removeSelector: methodReference selector ].
-	((Smalltalk globals at: #( Smalltalk globals at: #PackageInfo )) named: self hacksCategoryName) in: [ :hacks |
-		hacks classes do: [ :classOrTrait | classOrTrait removeFromSystem ].
-		(Smalltalk globals at: #PackageOrganizer) default unregisterPackage: hacks ].
-	Smalltalk organization removeCategory: self hacksCategoryName
 ]
 
 { #category : #'class initialization' }

--- a/src/Fuel-Platform-Core/FLPlatform.class.st
+++ b/src/Fuel-Platform-Core/FLPlatform.class.st
@@ -107,13 +107,13 @@ FLPlatform class >> isResponsibleForCurrentPlatform [
 
 { #category : #'private-convenience' }
 FLPlatform class >> removeModifications [
-	((Smalltalk globals at: #(Smalltalk globals at: #PackageInfo)) named: self extensionProtocolName) extensionMethods do: [ :methodReference |
+
+	((Smalltalk globals at: #( Smalltalk globals at: #PackageInfo )) named: self extensionProtocolName) extensionMethods do: [ :methodReference |
 		methodReference actualClass removeSelector: methodReference selector ].
-	((Smalltalk globals at: #(Smalltalk globals at: #PackageInfo)) named: self hacksCategoryName) in: [ :hacks |
-		hacks classes do: [ :classOrTrait |
-			classOrTrait removeFromSystem ].
-		(Smalltalk globals at: #PackageOrganizer) default  unregisterPackage: hacks ].
-	SystemOrganizer default removeCategory: self hacksCategoryName
+	((Smalltalk globals at: #( Smalltalk globals at: #PackageInfo )) named: self hacksCategoryName) in: [ :hacks |
+		hacks classes do: [ :classOrTrait | classOrTrait removeFromSystem ].
+		(Smalltalk globals at: #PackageOrganizer) default unregisterPackage: hacks ].
+	Smalltalk organization removeCategory: self hacksCategoryName
 ]
 
 { #category : #'class initialization' }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -124,7 +124,7 @@ RPackageOrganizer class >> default [
 
 	^ default ifNil: [
 		  default := self new
-			             systemOrganizer: Smalltalk globals organization;
+			             systemOrganizer: Smalltalk organization;
 			             yourself ]
 ]
 

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1532,7 +1532,7 @@ SmalltalkImage >> removeEmptyMessageCategories [
 
 	self garbageCollect.
 	ClassOrganization allInstancesDo: [ :org | org removeEmptyProtocols ].
-	SystemOrganizer removeEmptyPackages
+	Smalltalk organization removeEmptyPackages
 ]
 
 { #category : #shrinking }


### PR DESCRIPTION
SystemOrganizer will probably be removed and the new organizer will be RPackageOrganizer. 

In order to plan this change I propose to remove all the references to SystemOrganizer.

This goes with: https://github.com/pharo-spec/NewTools-DocumentBrowser