### PR TITLE
Faulty Code: compiler honor failBlock

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -1437,7 +1437,19 @@ RBCodeSnippet class >> badSemantic [
 				         'a1: a1 a2: a2 a3: a3 a4: a4 a5: a5 a6: a6 a7: a7 a8: a8 a9: a9 a10: a10 a11: a11 a12: a12 a13: a13 a14: a14 a15: a15 a16: a16 ^ a1';
 			         isMethod: true;
 			         isFaulty: true;
-			         notices: #( #( 1 130 1 'Too many arguments' ) )) "Too many arguments" }.
+			         notices: #( #( 1 130 1 'Too many arguments' ) )). "Too many arguments"
+
+		        (self new
+			         source: 'CodeError signal: ''false error''';
+			         raise: CodeError;
+			         skip: #testEvaluateOnErrorResume). "evaluate cannot distinguishes runtime errors and compiletime errors"
+		        (self new
+			         source:
+				         'OCUndeclaredVariableWarning signal: ''false error''';
+			         raise: OCUndeclaredVariableWarning). "same, but warning are silently ignored"
+		        (self new
+			         source: 'RuntimeSyntaxError signal: ''false error''';
+			         raise: RuntimeSyntaxError) "runtime errors are not special" }.
 	"Setup default values"
 	self new
 		group: #badSemantic;

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -523,7 +523,7 @@ OpalCompiler >> parse [
 			check ifNil: [ ^ ast ].
 			check ifFalse: [
 				ast := nil.
-				^ self compilationContext failBlock ifNotNil: [ :block | block value ] ifNil: [ nil ].
+				^ self compilationContext failBlock ifNotNil: [ :block | block cull: n ] ifNil: [ nil ].
 				] ] ].
 
 	^ ast

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -231,33 +231,37 @@ OpalCompiler >> changeStamp: aString [
 ]
 
 { #category : #private }
-OpalCompiler >> checkNotice: aNotice quitBlock: quitBlock [
+OpalCompiler >> checkNotice: aNotice [
 	"This method handles all the logic of error handling.
 	
 	Error handing in the compiler is only performed at one place, after the parsing/semantic analysis/other parse plugins.
 	Each RBNotice in the AST is then checked with this method.
 
-	There is only two outcomes:
-	* If this method returns, then the work of the compiler can continue.
+	There is only three outcomes:
+	* If this method returns true (OK), then the work of the compiler can continue.
 	  Next notice is then processed.
 	  Or, if this that was the last notice, compilation and cie can be performed.
-	* If quitBlock is evaluated, then the compilation is cancelled.
-	  The value argument used with quitBlock will be the result given to the user.
-	
+	* If this method returns false (not OK), then the compilation is cancelled.
+	  The failBlock will be invoked.
+	* If this method returns nil (stop checking), then skip the rest of the notice checks.
+	  This one is used in case of reparation, where a new (checked) AST is produced.
+
 	Errors that may happen later in the backend are consireded internal errors and should not occur (bugs).
-	
+
 	This method is a little long because it handles the requestor (quirks) mode.
 	"
 
-	| requestor fBlock |
-	aNotice isWarning ifTrue: [ ^ self ].
+	| requestor |
+	aNotice isWarning ifTrue: [ ^ true ].
 
 	requestor := self compilationContext requestor.
-	fBlock := self compilationContext failBlock.
 
 	requestor ifNotNil: [ "A requestor is available. We are in quirks mode and are expected to do UI things."
 		aNotice class = OCUndeclaredVariableNotice ifTrue: [
-			self isInteractive ifFalse: [ ^ aNotice signalError ].
+			self isInteractive ifFalse: [ "For compatibility, we signal the notification and continue.
+				Note that non-interactive requestors are only used in unit tests, so we might change the policy"
+				aNotice signalError.
+				^ true ].
 
 			"The menu is in fact broken on 'noPattern' mode (expression/script/doit) because some reparation assume it's a method body, so just continue as an error"
 			self compilationContext noPattern ifFalse: [
@@ -267,17 +271,20 @@ OpalCompiler >> checkNotice: aNotice quitBlock: quitBlock [
 					       node: aNotice node;
 					       requestor: requestor;
 					       openMenu.
-				res ifNil: [ ^ self "reparation unneded, let AST as is" ].
-				res ifFalse: [ ^ quitBlock value: fBlock value "operation cancelled, fail" ].
-				^ self parse: requestor text "reparation done, reparse" ] ].
+				res ifNil: [ ^ true "reparation unneded, let AST as is" ].
+				res ifFalse: [ ^ false "operation cancelled, fail" ].
+				self parse: requestor text. "some reparation was done, reparse"
+				^ nil ] ].
 
 		requestor
 			notify: aNotice messageText , ' ->'
 			at: aNotice position
 			in: aNotice node source.
-		^ quitBlock value: fBlock value ].
+		^ false ].
 
-	aNotice signalError
+	aNotice signalError.
+
+	^ true "Error was resumed, so we consider it's OK to continue"
 ]
 
 { #category : #accessing }
@@ -507,9 +514,13 @@ OpalCompiler >> parse [
 
 	self permitFaulty ifFalse: [
 		ast allNotices do: [ :n |
-			self checkNotice: n quitBlock: [ :v |
+			| check |
+			check := self checkNotice: n.
+			check ifNil: [ ^ ast ].
+			check ifFalse: [
 				ast := nil.
-				^ v ] ] ].
+				^ self compilationContext failBlock ifNotNil: [ :block | block value ] ifNil: [ nil ].
+				] ] ].
 
 	^ ast
 ]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -282,6 +282,10 @@ OpalCompiler >> checkNotice: aNotice [
 			in: aNotice node source.
 		^ false ].
 
+	"If a failBlock is provided in non-requestor mode,
+	we honor it and do not signal exceptions"
+	self compilationContext failBlock ifNotNil: [ ^ false ].
+
 	aNotice signalError.
 
 	^ true "Error was resumed, so we consider it's OK to continue"

--- a/src/OpalCompiler-Tests/RBCodeSnippetScriptingTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetScriptingTest.extension.st
@@ -1,6 +1,27 @@
 Extension { #name : #RBCodeSnippetScriptingTest }
 
 { #category : #'*OpalCompiler-Tests' }
+RBCodeSnippetScriptingTest >> testEvaluateFailBlock [
+
+	| runBlock error |
+	self skipIf: #exec.
+
+	error := nil.
+	runBlock := [
+		OpalCompiler new
+			failBlock: [ :e | error := e. #tag ];
+			evaluate: snippet source ].
+
+	snippet isFaulty | snippet hasUndeclared
+		ifTrue: [
+			self assert: runBlock value equals: #tag.
+			self assert: (snippet hasNotice: error) ]
+		ifFalse: [
+			self assert: error isNil.
+			self testExecuteBlock: runBlock ]
+]
+
+{ #category : #'*OpalCompiler-Tests' }
 RBCodeSnippetScriptingTest >> testEvaluateFaulty [
 
 	| runBlock |

--- a/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
@@ -1,6 +1,30 @@
 Extension { #name : #RBCodeSnippetTest }
 
 { #category : #'*OpalCompiler-Tests' }
+RBCodeSnippetTest >> testCompileFailBlock [
+
+	| method error |
+	error := nil.
+	method := OpalCompiler new
+		          noPattern: snippet isMethod not;
+		          failBlock: [ :e |
+			          self assert: (snippet hasNotice: e).
+			          self assert: error isNil. "single invocation"
+			          error := e.
+			          #tag ];
+		          compile: snippet source.
+
+	snippet isFaulty | snippet hasUndeclared
+		ifTrue: [
+			self assert: error isNotNil.
+			self assert: method equals: #tag ]
+		ifFalse: [
+			self assert: error isNil.
+			self assert: method isCompiledMethod.
+			self testExecute: method ]
+]
+
+{ #category : #'*OpalCompiler-Tests' }
 RBCodeSnippetTest >> testCompileFaulty [
 
 	| method |


### PR DESCRIPTION
failBlock in OpalCompiler are used with requestor to exit the call.
Without a requestor, they were silently ignored.

The PR promote failBlock to general usage.
Having a reliable failBlock is important because it's the only way for `evaluate` to distinguish compile-time errors from runtime errors. Exceptions are too broad and cannot distinguish them.

Tests are also added
* compilation with a failblock
* evaluation with a failblock
* code snippets that signal compilation-related exceptions (to stress the tests!)

This PR also fix a bug introduced in a previous PR with the undeclared variable GUI reparation
It required a change in the internal API parse->checkNotice