### PR TITLE
Faulty code: fix syntax error on empty closers

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -152,21 +152,17 @@ RBCodeSnippet class >> badExpressions [
 				            #( 1 6 7 '''}'' expected' ) )).
 		        (self new
 			         source: ' )';
-			         notices: #( #( 2 1 2 'Variable or expression expected' )
-				            #( 2 2 2 'Missing opener for closer: )' ) )).
+			         notices: #( #( 2 2 2 'Missing opener for closer: )' ) )).
 		        (self new
 			         source: ' ]';
-			         notices: #( #( 2 1 2 'Variable or expression expected' )
-				            #( 2 2 2 'Missing opener for closer: ]' ) );
+			         notices: #( #( 2 2 2 'Missing opener for closer: ]' ) );
 			         skip: #testCodeImporter). "FIXME. code importer do not like rogue starting `]`"
 		        (self new
 			         source: ' }';
-			         notices: #( #( 2 1 2 'Variable or expression expected' )
-				            #( 2 2 2 'Missing opener for closer: }' ) )).
+			         notices: #( #( 2 2 2 'Missing opener for closer: }' ) )).
 		        (self new
 			         source: ' ) ] }';
-			         notices: #( #( 2 1 2 'Variable or expression expected' )
-				            #( 2 2 2 'Missing opener for closer: )' )
+			         notices: #( #( 2 2 2 'Missing opener for closer: )' )
 				            #( 2 4 4 'Missing opener for closer: ]' )
 				            #( 2 6 6 'Missing opener for closer: }' ) )).
 
@@ -1461,7 +1457,6 @@ RBCodeSnippet class >> badVariableAndScopes [
 			         notices:
 				         #( #( 6 6 6 'Undeclared variable' )
 				            #( 1 1 1 'Undeclared variable' )
-				            #( 16 15 16 'Variable or expression expected' )
 				            #( 16 16 16 'Missing opener for closer: }' )
 				            #( 11 24 25 ''']'' expected' )
 				            #( 9 24 25 '''}'' expected' ) )). "OK, but maybe the `}` could close the `{` and consider the `[` unfinished?"
@@ -1489,7 +1484,6 @@ RBCodeSnippet class >> badVariableAndScopes [
 			         notices:
 				         #( #( 6 6 6 'Undeclared variable' )
 				            #( 1 1 1 'Undeclared variable' )
-				            #( 18 17 18 'Variable or expression expected' )
 				            #( 18 18 18 'Missing opener for closer: }' )
 				            #( 11 26 27 ''']'' expected' )
 				            #( 9 26 27 '''}'' expected' ) )).

--- a/src/AST-Core/RBEnglobingErrorNode.class.st
+++ b/src/AST-Core/RBEnglobingErrorNode.class.st
@@ -53,9 +53,16 @@ RBEnglobingErrorNode class >> error: aToken withNodes: aCollection [
 RBEnglobingErrorNode class >> from: aParseErrorNode contents: anArrayOfNodes [
 	"Transform a simple error node into a englobing one while preserving most information"
 
+	| start stop |
+	start := aParseErrorNode start.
+	stop := aParseErrorNode stop.
+	anArrayOfNodes ifNotEmpty: [
+		start := start min: (anArrayOfNodes min: #start).
+		stop := stop max: (anArrayOfNodes max: #stop) ].
+
 	^ self new
-		start: (aParseErrorNode start min: (anArrayOfNodes min: #start));
-		stop: (aParseErrorNode stop max: (anArrayOfNodes max: #stop));
+		start: start;
+		stop: stop;
 		errorPosition: aParseErrorNode errorPosition;
 		errorMessage: aParseErrorNode errorMessage;
 		valueAfter: aParseErrorNode value;

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -941,8 +941,11 @@ RBParser >> parseStatementInto: statementList periodList: periods withAcceptedSt
 	[(')]}' includes: currentToken value)
 		and: [ (aCollectionOfClosers includes: currentToken value) not ]]
 			whileTrue: [
+				| contents |
 				err := self parseErrorNode: 'Missing opener for closer: ', currentToken value asString.
-				node := (RBUnfinishedStatementErrorNode from: err contents: { node })
+				"If the parsing failed because it did not match anything, there was nothing before the unexpected closer"
+				contents := startOfStatementToken = currentToken ifTrue: [ #() ] ifFalse: [ { node } ].
+				node := (RBUnfinishedStatementErrorNode from: err contents: contents)
 					valueAfter: currentToken value asString;
 					stop: currentToken stop.
 				self step ].


### PR DESCRIPTION
On empty unexpected closer like `]` with no opener and no contents, the parser emitted two errors, a generic ''Variable or expression expected" and a more specific "Missing opener for closer". The first one is superfluous (and wrong since `[]` is legal)