### PR TITLE
do not compute message sends dependencies  in browser dependencies tool

### DIFF
--- a/src/Tool-DependencyAnalyser-UI-Tab/DABrowserToolMorph.class.st
+++ b/src/Tool-DependencyAnalyser-UI-Tab/DABrowserToolMorph.class.st
@@ -41,7 +41,9 @@ DABrowserToolMorph >> build [
 { #category : #private }
 DABrowserToolMorph >> daPackageFor: aPackageName [
 
-	^ DADependencyChecker new daPackageFor: aPackageName
+	^ DADependencyChecker new 
+		shouldComputeMessageSendDependencies: false; "Message sends dependencies are not displayed and they take time to compute"
+		daPackageFor: aPackageName
 ]
 
 { #category : #initialization }

--- a/src/Tool-DependencyAnalyser/DADependencyChecker.class.st
+++ b/src/Tool-DependencyAnalyser/DADependencyChecker.class.st
@@ -12,14 +12,17 @@ Class {
 	#name : #DADependencyChecker,
 	#superclass : #Object,
 	#instVars : [
-		'report'
+		'report',
+		'shouldComputeMessageSendDependencies'
 	],
 	#category : #'Tool-DependencyAnalyser-Report'
 }
 
 { #category : #private }
 DADependencyChecker >> buildPackageRelationGraphFor: aPackageName [
-	^ [ (DAPackageRelationGraph onPackagesNamed: { aPackageName }) build ]
+	^ [ (DAPackageRelationGraph onPackagesNamed: { aPackageName })
+		 	shouldComputeMessageSendDependencies: self shouldComputeMessageSendDependencies;
+			build ]
 		on: DAPotentialOutDatedDependencyWarning
 		do: [ :ex | report addWarning: ex. ex resume ]
 ]
@@ -121,6 +124,16 @@ DADependencyChecker >> shortestPathToPackageIntroducingDependency: dependencyPac
 			dijkstra edges: { packageName } from: [ :ignored | packageName ] to: [ :ignored | dependency ] ] ].
 	dijkstra runFrom: aPackageName to: dependencyPackageName.
 	^ dijkstra reconstructPath
+]
+
+{ #category : #accessing }
+DADependencyChecker >> shouldComputeMessageSendDependencies [
+	^ shouldComputeMessageSendDependencies ifNil: [ true ]
+]
+
+{ #category : #accessing }
+DADependencyChecker >> shouldComputeMessageSendDependencies: aBoolean [
+	shouldComputeMessageSendDependencies := aBoolean 
 ]
 
 { #category : #'computing - dependencies' }

--- a/src/Tool-DependencyAnalyser/DAPackageRelationGraph.class.st
+++ b/src/Tool-DependencyAnalyser/DAPackageRelationGraph.class.st
@@ -11,7 +11,8 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'packages',
-		'classMapping'
+		'classMapping',
+		'shouldComputeMessageSendDependencies'
 	],
 	#category : #'Tool-DependencyAnalyser-Core'
 }
@@ -239,7 +240,8 @@ DAPackageRelationGraph >> computeStaticDependencies: aPackage [
 	self addReferenceDependencies: aPackage.
 	self addPoolDictionaryDependencies: aPackage.
 	self addTraitDependencies: aPackage.
-	self addMessageSendDependencies: aPackage
+	self shouldComputeMessageSendDependencies 
+		ifTrue: [ self addMessageSendDependencies: aPackage ]
 ]
 
 { #category : #accessing }
@@ -452,6 +454,18 @@ DAPackageRelationGraph >> seenPackagesWithFilter: aFilter [
 { #category : #actions }
 DAPackageRelationGraph >> seenPackagesWithoutExtension [
 	^ self packages select: [ :each | each isSeen ]
+]
+
+{ #category : #accessing }
+DAPackageRelationGraph >> shouldComputeMessageSendDependencies [
+
+	^ shouldComputeMessageSendDependencies ifNil: [ true ]
+]
+
+{ #category : #accessing }
+DAPackageRelationGraph >> shouldComputeMessageSendDependencies: aBoolean [
+
+	shouldComputeMessageSendDependencies := aBoolean
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
do not compute message sends dependencies  in browser dependencies tool because it is slow and is done quite often within Calypso