### PR TITLE
Remove references to SystemOrganization

### DIFF
--- a/src/CodeExport/RPackage.extension.st
+++ b/src/CodeExport/RPackage.extension.st
@@ -2,22 +2,21 @@ Extension { #name : #RPackage }
 
 { #category : #'*CodeExport' }
 RPackage >> fileOut [
-	| internalStream |
 
+	| internalStream |
 	internalStream := (String new: 1000) writeStream.
 
-	self classTags do: [ :each |
-		SystemOrganization
-			fileOutCategory: each categoryName
-			on: internalStream ].
+	self classTags do: [ :each | self systemOrganization fileOutCategory: each categoryName on: internalStream ].
 
 	classExtensionSelectors keysAndValuesDo: [ :className :selectors |
-		selectors do: [ :selector | | extendedClass |
+		selectors do: [ :selector |
+			| extendedClass |
 			extendedClass := self class environment classNamed: className.
 			extendedClass fileOutMethod: selector on: internalStream ] ].
 
 	metaclassExtensionSelectors keysAndValuesDo: [ :className :selectors |
-		selectors do: [ :selector | | extendedClass |
+		selectors do: [ :selector |
+			| extendedClass |
 			extendedClass := self class environment classNamed: className.
 			extendedClass classSide fileOutMethod: selector on: internalStream ] ].
 

--- a/src/CodeExport/RPackageTag.extension.st
+++ b/src/CodeExport/RPackageTag.extension.st
@@ -6,7 +6,7 @@ RPackageTag >> fileOut [
 
 	internalStream := (String new: 1000) writeStream.
 
-	SystemOrganization
+	Smalltalk organization
 		fileOutCategory: self categoryName
 		on: internalStream.
 

--- a/src/CodeExport/SystemOrganizer.extension.st
+++ b/src/CodeExport/SystemOrganizer.extension.st
@@ -6,8 +6,8 @@ SystemOrganizer >> fileOut [
 
 	| internalStream |
 	internalStream := (String new: 30000) writeStream.
-	internalStream nextPutAll: 'SystemOrganization changeFromCategorySpecs: #('; cr;
-		print: SystemOrganization;  "ends with a cr"
+	internalStream nextPutAll: 'Smalltalk organization changeFromCategorySpecs: #('; cr;
+		print: Smalltalk organization;  "ends with a cr"
 		nextPutAll: ')!'; cr.
 
 	CodeExporter

--- a/src/Fuel-Tests-Core/FLClassFactoryForTestCase.class.st
+++ b/src/Fuel-Tests-Core/FLClassFactoryForTestCase.class.st
@@ -70,12 +70,10 @@ FLClassFactoryForTestCase >> cleanUpSystemOrganization [
 	"This method is necessary because we create classes in a non-default environment. The
 	SystemOrganization is global and ClassFactoryForTestCase interacts with it to clean out
 	categories."
-	| categoriesMatchString categories |
-	categoriesMatchString := self defaultPackageName, '-*'.
-	categories := SystemOrganization categoriesMatching: categoriesMatchString.
-	categories do: [ :category |
-		(SystemOrganization listAtCategoryNamed: category) do: [ :behaviorName |
-			SystemOrganization removeBehavior: behaviorName ] ]
+
+	| categories |
+	categories := self packageOrganizer categoriesMatching: self defaultPackageName , '-*'.
+	categories do: [ :category | (self packageOrganizer listAtCategoryNamed: category) do: [ :behaviorName | self packageOrganizer removeBehavior: behaviorName ] ]
 ]
 
 { #category : #accessing }
@@ -154,9 +152,8 @@ FLClassFactoryForTestCase >> deleteClasses [
 
 { #category : #'private-cleaning' }
 FLClassFactoryForTestCase >> deletePackage [
-	| categoriesMatchString |
-	categoriesMatchString := self defaultPackageName, '-*'.
-	SystemOrganization removeCategoriesMatching: categoriesMatchString
+
+	self packageOrganizer removeCategoriesMatching: self defaultPackageName , '-*'
 ]
 
 { #category : #'private-cleaning' }
@@ -317,6 +314,12 @@ FLClassFactoryForTestCase >> newTraitNamed: aTraitName uses: aTraitComposition i
 FLClassFactoryForTestCase >> nextCount [
 	"Global counter to avoid name clash between test runs, in case of some previous failure."
 	^ Counter := (Counter ifNil: [ 0 ]) + 1.
+]
+
+{ #category : #accessing }
+FLClassFactoryForTestCase >> packageOrganizer [
+
+	^ Smalltalk organization
 ]
 
 { #category : #accessing }

--- a/src/Fuel-Tests-Core/FLFullBasicSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLFullBasicSerializationTest.class.st
@@ -101,9 +101,8 @@ FLFullBasicSerializationTest >> testCreateClassWithChangedSuperclassFormat [
 FLFullBasicSerializationTest >> testMethodDictionaries [
 	"Tests correct serialization of all the method dictionaries in the System package."
 
-	(SystemOrganization categoriesMatching: 'System*') do: [ :category |
-		(SystemOrganization classesInCategory: category) do: [ :class |
-			self resultOfSerializeAndMaterializeMethodDictionary: class methodDictionary ] ]
+	(Smalltalk organization categoriesMatching: 'System*') do: [ :category |
+		(Smalltalk organization classesInCategory: category) do: [ :class | self resultOfSerializeAndMaterializeMethodDictionary: class methodDictionary ] ]
 ]
 
 { #category : #tests }

--- a/src/Metacello-PharoCommonPlatform/MetacelloPharoCommonPlatform.class.st
+++ b/src/Metacello-PharoCommonPlatform/MetacelloPharoCommonPlatform.class.st
@@ -47,7 +47,7 @@ MetacelloPharoCommonPlatform >> copyClass: oldClass as: newName inCategory: newC
 	(Smalltalk globals includesKey: copysName) ifTrue: [ ^ self error: copysName , ' already exists' ].
 	newDefinition := oldClass definition copyReplaceAll: '#' , oldClass name asString with: '#' , copysName asString printString.
 	newDefinition := newDefinition
-		                 copyReplaceAll: 'category: ' , (SystemOrganization categoryOfBehavior: oldClass) asString printString
+		                 copyReplaceAll: 'category: ' , (Smalltalk organization categoryOfBehavior: oldClass) asString printString
 		                 with: 'category: ' , newCategoryName printString.
 	class := self compiler
 		         logged: true;

--- a/src/Monticello-Tests/MCOrganizationTest.class.st
+++ b/src/Monticello-Tests/MCOrganizationTest.class.st
@@ -6,11 +6,12 @@ Class {
 
 { #category : #tests }
 MCOrganizationTest >> testLoadAndUnload [
+
 	| category |
 	category := 'TestPackageToUnload'.
-	SystemOrganization addCategory: category.
+	Smalltalk organization addCategory: category.
 	(MCOrganizationDefinition categories: { category }) unload.
-	self deny: (SystemOrganization includesCategory: category)
+	self deny: (Smalltalk organization includesCategory: category)
 ]
 
 { #category : #tests }

--- a/src/Monticello/MCOrganizationDefinition.class.st
+++ b/src/Monticello/MCOrganizationDefinition.class.st
@@ -146,8 +146,6 @@ MCOrganizationDefinition >> summary [
 
 { #category : #unloading }
 MCOrganizationDefinition >> unload [
-	categories
-		do: [ :category | 
-			(SystemOrganization isEmptyCategoryNamed: category)
-				ifTrue: [ SystemOrganization removeCategory: category ] ]
+
+	categories do: [ :category | (Smalltalk organization isEmptyCategoryNamed: category) ifTrue: [ Smalltalk organization removeCategory: category ] ]
 ]

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -74,7 +74,9 @@ RPackageTag >> classes [
 
 { #category : #accessing }
 RPackageTag >> ensureSystemCategory [
-	SystemOrganization addCategory: self categoryName
+	"We should not hardcode the global variable but ask the package organizer for the organization."
+
+	Smalltalk organization addCategory: self categoryName
 ]
 
 { #category : #accessing }

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -75,7 +75,7 @@ RPackageIncrementalTest >> tearDown [
 		"but this also means that the consistency cannot be ensured by internal system announcer too."
 		].
 	createdCategories do: [:each |
-		SystemOrganization removeCategory: each.
+		self systemOrganization removeCategory: each.
 		 ].
 	super tearDown
 ]

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -75,7 +75,7 @@ RPackageIncrementalTest >> tearDown [
 		"but this also means that the consistency cannot be ensured by internal system announcer too."
 		].
 	createdCategories do: [:each |
-		self systemOrganization removeCategory: each.
+		Smalltalk organization removeCategory: each.
 		 ].
 	super tearDown
 ]

--- a/src/Ring-OldChunkImporter/RingChunkImporter.class.st
+++ b/src/Ring-OldChunkImporter/RingChunkImporter.class.st
@@ -19,7 +19,7 @@ Class {
 RingChunkImporter class >> example [
 	| internalStream |
 	internalStream := (String new: 1000) writeStream.
-	SystemOrganization
+	Smalltalk organization
 		fileOutCategory: 'Ring-Deprecated-ChunkImporter-Base'
 		on: internalStream.
 	(RingChunkImporter fromStream: internalStream contents readStream)

--- a/src/SUnit-Core/ClassFactoryForTestCase.class.st
+++ b/src/SUnit-Core/ClassFactoryForTestCase.class.st
@@ -128,9 +128,7 @@ ClassFactoryForTestCase >> deleteClasses [
 { #category : #cleaning }
 ClassFactoryForTestCase >> deletePackage [
 
-	| categoriesMatchString |
-	categoriesMatchString := self packageName , '-*'.
-	SystemOrganization removeCategoriesMatching: categoriesMatchString
+	Smalltalk organization removeCategoriesMatching: self packageName , '-*'
 ]
 
 { #category : #cleaning }

--- a/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
@@ -80,7 +80,7 @@ ClassFactoryForTestCaseTest >> testDefaultCategoryCleanUp [
 
 	self assert: (factory createdClasses noneSatisfy: [:class| allClasses includes: class]).
 	self assert: (factory createdTraits noneSatisfy: [:trait| allTraits includes: trait]).
-	self deny: (Smalltalk organization categories includes: factory defaultCategory).
+	self deny: (self packageOrganizer categories includes: factory defaultCategory).
 	self class environment at: #ChangeSet ifPresent: [:changeSet |
 		self deny: (changeSet current changedClassNames includesAnyOf: createdClassNames) ]
 ]

--- a/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
@@ -15,6 +15,12 @@ ClassFactoryForTestCaseTest class >> lastStoredRun [
 	^ ((Dictionary new) add: (#passed->((Set new) add: #testDefaultCategoryCleanUp; add: #testPackageCleanUp; add: #testSingleClassCreation; add: #testClassCreationInDifferentCategories; add: #testClassFastCreationInDifferentCategories; add: #testMultipleClassCreation; add: #testSingleClassFastCreation; yourself)); add: (#timeStamp->'22 November 2008 10:11:35 pm'); add: (#failures->((Set new))); add: (#errors->((Set new))); yourself)
 ]
 
+{ #category : #accessing }
+ClassFactoryForTestCaseTest >> packageOrganizer [
+
+	^ Smalltalk organization
+]
+
 { #category : #running }
 ClassFactoryForTestCaseTest >> setUp [
 	super setUp.
@@ -74,7 +80,7 @@ ClassFactoryForTestCaseTest >> testDefaultCategoryCleanUp [
 
 	self assert: (factory createdClasses noneSatisfy: [:class| allClasses includes: class]).
 	self assert: (factory createdTraits noneSatisfy: [:trait| allTraits includes: trait]).
-	self deny: (SystemOrganization categories includes: factory defaultCategory).
+	self deny: (Smalltalk organization categories includes: factory defaultCategory).
 	self class environment at: #ChangeSet ifPresent: [:changeSet |
 		self deny: (changeSet current changedClassNames includesAnyOf: createdClassNames) ]
 ]
@@ -97,7 +103,7 @@ ClassFactoryForTestCaseTest >> testMultipleClassCreation [
 	5 timesRepeat: [ factory newClass ].
 	self assert: (SystemNavigation new allClasses includesAll: factory createdClasses).
 	self assert: factory createdClassNames asSet size equals: 5.
-	self assert: (SystemOrganization listAtCategoryNamed: factory defaultCategory) asSet equals: factory createdClassNames asSet
+	self assert: (self packageOrganizer listAtCategoryNamed: factory defaultCategory) asSet equals: factory createdClassNames asSet
 ]
 
 { #category : #testing }
@@ -110,7 +116,7 @@ ClassFactoryForTestCaseTest >> testPackageCleanUp [
 	self assert: (factory createdClasses allSatisfy: [ :class | class isObsolete ]).
 	allClasses := SystemNavigation new allClasses.
 	self assert: (factory createdClasses noneSatisfy: [ :class | allClasses includes: class ]).
-	self assertEmpty: (SystemOrganization categoriesMatching: factory packageName , '*').
+	self assertEmpty: (self packageOrganizer categoriesMatching: factory packageName , '*').
 	self class environment at: #ChangeSet ifPresent: [ :changeSet | self deny: (changeSet current changedClassNames includesAnyOf: createdClassNames) ]
 ]
 
@@ -119,7 +125,7 @@ ClassFactoryForTestCaseTest >> testSingleClassCreation [
 	| class elementsInCategoryForTest |
 	class := factory newSubclassOf: Object instanceVariableNames: 'a b c' classVariableNames: 'X Y'.
 	self assert: (SystemNavigation new allClasses includes: class).
-	elementsInCategoryForTest := SystemOrganization listAtCategoryNamed: factory defaultCategory.
+	elementsInCategoryForTest := self packageOrganizer listAtCategoryNamed: factory defaultCategory.
 	self assert: elementsInCategoryForTest equals: {class name}.
 	self assert: class instVarNames equals: #(a b c).
 	self assert: class classPool keys asSet equals: #(X Y) asSet
@@ -130,7 +136,7 @@ ClassFactoryForTestCaseTest >> testSingleClassFastCreation [
 	| class elementsInCategoryForTest |
 	class := factory newClass.
 	self assert: (SystemNavigation new allClasses includes: class).
-	elementsInCategoryForTest := SystemOrganization listAtCategoryNamed: factory defaultCategory.
+	elementsInCategoryForTest := self packageOrganizer listAtCategoryNamed: factory defaultCategory.
 	self assert: elementsInCategoryForTest equals: {class name}.
 	self assertEmpty: class instVarNames.
 	self assertEmpty: class classPool

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -17,7 +17,7 @@ Class {
 SystemOrganizer class >> cleanUp: agressive [
 	"Remove empty categories when cleaning aggressively"
 
-	agressive ifTrue: [ SystemOrganization removeEmptyPackages ]
+	agressive ifTrue: [ Smalltalk organization removeEmptyPackages ]
 ]
 
 { #category : #'instance creation' }


### PR DESCRIPTION
SystemOrganization is a global variable holding the default SystemOrganizer. But this value can also be accessed via `Smalltalk organizer`. 

In order to avoid the multiple global variables, I am removing in the PR all references to SystemOrganization and in a future pull request I will kill this global variable and instead just save its instance un a normal instance variable of SystemDectionary, or better, SmalltalkImage if it is not to hard (because why the hell would it be the SystemDictionary that holds the PackageOrganizer?!)

Also, some classes of RPackage already have a method to access the SystemOrganizer of their organization. So I use this instead of using the global