### PR TITLE
Faulty code: move code reparator to RBNotice

### DIFF
--- a/src/OpalCompiler-Core/OCUndeclaredVariableNotice.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariableNotice.class.st
@@ -4,6 +4,12 @@ Class {
 	#category : #'OpalCompiler-Core-FrontEnd'
 }
 
+{ #category : #correcting }
+OCUndeclaredVariableNotice >> reparator [
+
+	^ OCCodeReparator new node: self node
+]
+
 { #category : #signalling }
 OCUndeclaredVariableNotice >> signalError [
 

--- a/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
@@ -65,7 +65,7 @@ OCUndeclaredVariableWarning >> position [
 { #category : #correcting }
 OCUndeclaredVariableWarning >> reparator [
 
-	^ OCCodeReparator new node: self node
+	^ notice reparator
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
@@ -62,12 +62,6 @@ OCUndeclaredVariableWarning >> position [
 	^ self notice position
 ]
 
-{ #category : #correcting }
-OCUndeclaredVariableWarning >> reparator [
-
-	^ notice reparator
-]
-
 { #category : #accessing }
 OCUndeclaredVariableWarning >> sourceCode [
 

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -251,35 +251,32 @@ OpalCompiler >> checkNotice: aNotice [
 	This method is a little long because it handles the requestor (quirks) mode.
 	"
 
-	| requestor |
 	aNotice isWarning ifTrue: [ ^ true ].
 
-	requestor := self compilationContext requestor.
-
-	requestor ifNotNil: [ "A requestor is available. We are in quirks mode and are expected to do UI things."
-		aNotice class = OCUndeclaredVariableNotice ifTrue: [
-			self isInteractive ifFalse: [ "For compatibility, we signal the notification and continue.
-				Note that non-interactive requestors are only used in unit tests, so we might change the policy"
-				aNotice signalError.
-				^ true ].
-
-			"The menu is in fact broken on 'noPattern' mode (expression/script/doit) because some reparation assume it's a method body, so just continue as an error"
-			self compilationContext noPattern ifFalse: [
+	self compilationContext requestor ifNotNil: [ :requestor |
+		"A requestor is available. We are in quirks mode and are expected to do UI things."
+		"Reparation menu in quirks mode:
+		* require a requestor (because quirks mode, and also some reparations expect a requestor)
+		* require interactive mode (because GUI)
+		* require method definition becase some reparation assume it's a method body"
+		(self isInteractive and: [self compilationContext noPattern not]) ifTrue: [
+			aNotice reparator ifNotNil: [ :reparator |
 				| res |
-				"I do not like the API that much. Reparator can have 3 outcomes"
-				res := OCCodeReparator new
-					       node: aNotice node;
-					       requestor: requestor;
-					       openMenu.
+				res := reparator
+					requestor: requestor;
+					openMenu.
 				res ifNil: [ ^ true "reparation unneded, let AST as is" ].
 				res ifFalse: [ ^ false "operation cancelled, fail" ].
 				self parse: requestor text. "some reparation was done, reparse"
 				^ nil ] ].
 
+		"Quirks mode: otherwise, push the error message to the requestor"
 		requestor
 			notify: aNotice messageText , ' ->'
 			at: aNotice position
 			in: aNotice node source.
+		
+		"Quirks mode: Then leave"
 		^ false ].
 
 	"If a failBlock is provided in non-requestor mode,

--- a/src/OpalCompiler-Core/RBNotice.extension.st
+++ b/src/OpalCompiler-Core/RBNotice.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #RBNotice }
+
+{ #category : #'*OpalCompiler-Core' }
+RBNotice >> reparator [
+
+	^ nil
+]

--- a/src/OpalCompiler-Tests/OCCodeReparatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCCodeReparatorTest.class.st
@@ -29,6 +29,31 @@ OCCodeReparatorTest >> testDeclareClassVar [
 ]
 
 { #category : #tests }
+OCCodeReparatorTest >> testDeclareClassVarBlock [
+
+	| compiler requestor method goo |
+	requestor := OCMockRequestor new.
+	requestor text: 'griffle ^ goo'.
+
+	goo := MockForCompilation classVariableNamed: #goo ifAbsent: [ nil ].
+	goo ifNotNil: [ MockForCompilation removeClassVariable: goo ].
+
+	method := (compiler := OpalCompiler new)
+		class: MockForCompilation;
+		failBlock: [ :notice |
+			notice reparator declareClassVar.
+			compiler compile ];
+		compile: requestor text.
+
+	self assert: requestor text withSeparatorsCompacted equals: 'griffle ^ goo'.
+	self assert: method isCompiledMethod.
+	goo := MockForCompilation classVariableNamed: #goo.
+	self assert: method literals first equals: goo.
+
+	MockForCompilation removeClassVariable: goo
+]
+
+{ #category : #tests }
 OCCodeReparatorTest >> testDeclareGlobal [
 
 	| requestor method |
@@ -42,6 +67,30 @@ OCCodeReparatorTest >> testDeclareGlobal [
 		do: [ :e |
 			e reparator declareGlobal.
 			e retry ].
+
+	self assert: requestor text withSeparatorsCompacted equals: 'griffle ^ goo'.
+	self assert: method isCompiledMethod.
+	self assert: method literals first equals: (Smalltalk globals associationAt: #goo).
+	self assert: method sourceCode withSeparatorsCompacted equals: 'griffle ^ goo'.
+
+	Smalltalk globals removeKey: #goo ifAbsent: []
+]
+
+{ #category : #tests }
+OCCodeReparatorTest >> testDeclareGlobalBlock [
+
+	| compiler requestor method |
+	requestor := OCMockRequestor new.
+	requestor text: 'griffle ^ goo'.
+
+	Smalltalk globals removeKey: #goo ifAbsent: [].
+
+	method := (compiler := OpalCompiler new)
+		class: MockForCompilation;
+		failBlock: [ :notice |
+			notice reparator declareGlobal.
+			compiler compile ];
+		compile: requestor text.
 
 	self assert: requestor text withSeparatorsCompacted equals: 'griffle ^ goo'.
 	self assert: method isCompiledMethod.
@@ -77,6 +126,32 @@ OCCodeReparatorTest >> testDeclareInstVar [
 ]
 
 { #category : #tests }
+OCCodeReparatorTest >> testDeclareInstVarBlock [
+
+	| compiler requestor method |
+	requestor := OCMockRequestor new.
+	requestor text: 'griffle ^ goo'.
+
+	(MockForCompilation hasInstVarNamed: #goo) ifTrue: [
+		MockForCompilation removeInstVarNamed: #goo ].
+
+	self deny: (MockForCompilation hasInstVarNamed: #goo).
+
+	method := (compiler := OpalCompiler new)
+		class: MockForCompilation;
+		failBlock: [ :notice |
+			notice reparator declareInstVar: #goo.
+			compiler compile ];
+		compile: requestor text.
+
+	self assert: requestor text withSeparatorsCompacted equals: 'griffle ^ goo'.
+	self assert: method isCompiledMethod.
+	self assert: (MockForCompilation hasInstVarNamed: #goo).
+
+	MockForCompilation removeInstVarNamed: #goo
+]
+
+{ #category : #tests }
 OCCodeReparatorTest >> testDeclareTempAndPaste [
 
 	| requestor method |
@@ -90,6 +165,27 @@ OCCodeReparatorTest >> testDeclareTempAndPaste [
 				requestor: requestor;
 				declareTempAndPaste: 'goo'.
 			e retry ].
+
+	self assert: requestor text withSeparatorsCompacted equals: 'griffle | goo | ^ goo'.
+	self assert: method isCompiledMethod.
+	self assert: method sourceCode withSeparatorsCompacted equals: 'griffle | tmp1 | ^ tmp1' "good enough"
+]
+
+{ #category : #tests }
+OCCodeReparatorTest >> testDeclareTempAndPasteBlock [
+
+	| compiler requestor method |
+	requestor := OCMockRequestor new.
+	requestor text: 'griffle ^ goo'.
+
+	method := (compiler := OpalCompiler new)
+		class: MockForCompilation;
+		failBlock: [ :notice |
+			notice reparator
+				requestor: requestor;
+				declareTempAndPaste: 'goo'.
+			compiler compile: requestor text ];
+		compile: requestor text.
 
 	self assert: requestor text withSeparatorsCompacted equals: 'griffle | goo | ^ goo'.
 	self assert: method isCompiledMethod.
@@ -115,6 +211,22 @@ OCCodeReparatorTest >> testPossibleVariablesFor [
 ]
 
 { #category : #tests }
+OCCodeReparatorTest >> testPossibleVariablesForBlock [
+
+	| compiler requestor names |
+	requestor := OCMockRequestor new.
+	requestor text: 'griffle | foo | ^ goo'.
+
+	names := (compiler := OpalCompiler new)
+		class: MockForCompilation;
+		failBlock: [ :notice |
+			notice reparator possibleVariablesFor: #goo ];
+		compile: requestor text.
+
+	self assert: (names includes: #foo)
+]
+
+{ #category : #tests }
 OCCodeReparatorTest >> testSubstituteVariableAtInterval [
 
 	| requestor method |
@@ -128,6 +240,27 @@ OCCodeReparatorTest >> testSubstituteVariableAtInterval [
 				requestor: requestor;
 				substituteVariable: 'foo' atInterval: e node sourceInterval.
 			e retry ].
+
+	self assert: requestor text withSeparatorsCompacted equals: 'griffle | foo | ^ foo'.
+	self assert: method isCompiledMethod.
+	self assert: method sourceCode withSeparatorsCompacted equals: 'griffle | tmp1 | ^ tmp1' "good enough"
+]
+
+{ #category : #tests }
+OCCodeReparatorTest >> testSubstituteVariableAtIntervalBlock [
+
+	| compiler requestor method |
+	requestor := OCMockRequestor new.
+	requestor text: 'griffle | foo | ^ goo'.
+
+	method := (compiler := OpalCompiler new)
+		class: MockForCompilation;
+		failBlock: [ :notice |
+			notice reparator
+				requestor: requestor;
+				substituteVariable: 'foo' atInterval: notice node sourceInterval.
+			compiler compile: requestor text ];
+		compile: requestor text.
 
 	self assert: requestor text withSeparatorsCompacted equals: 'griffle | foo | ^ foo'.
 	self assert: method isCompiledMethod.

--- a/src/OpalCompiler-Tests/OCCodeReparatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCCodeReparatorTest.class.st
@@ -14,7 +14,7 @@ OCCodeReparatorTest >> testDeclareClassVar [
 	goo := MockForCompilation classVariableNamed: #goo ifAbsent: [ nil ].
 	goo ifNotNil: [ MockForCompilation removeClassVariable: goo ].
 
-	method := [ OpalCompiler new requestor: requestor; class: MockForCompilation ; compile: requestor text ]
+	method := [ OpalCompiler new class: MockForCompilation ; compile: requestor text ]
 		on: OCUndeclaredVariableWarning
 		do: [ :e |
 			e reparator declareClassVar.
@@ -62,7 +62,7 @@ OCCodeReparatorTest >> testDeclareGlobal [
 
 	Smalltalk globals removeKey: #goo ifAbsent: [].
 
-	method := [ OpalCompiler new requestor: requestor; compile: requestor text ]
+	method := [ OpalCompiler new compile: requestor text ]
 		on: OCUndeclaredVariableWarning
 		do: [ :e |
 			e reparator declareGlobal.
@@ -112,7 +112,7 @@ OCCodeReparatorTest >> testDeclareInstVar [
 
 	self deny: (MockForCompilation hasInstVarNamed: #goo).
 
-	method := [ OpalCompiler new requestor: requestor; class: MockForCompilation ; compile: requestor text ]
+	method := [ OpalCompiler new class: MockForCompilation ; compile: requestor text ]
 		on: OCUndeclaredVariableWarning
 		do: [ :e |
 			e reparator declareInstVar: #goo.
@@ -158,7 +158,7 @@ OCCodeReparatorTest >> testDeclareTempAndPaste [
 	requestor := OCMockRequestor new.
 	requestor text: 'griffle ^ goo'.
 
-	method := [ OpalCompiler new requestor: requestor; compile: requestor text ]
+	method := [ OpalCompiler new compile: requestor text ]
 		on: OCUndeclaredVariableWarning
 		do: [ :e |
 			e reparator
@@ -199,7 +199,7 @@ OCCodeReparatorTest >> testPossibleVariablesFor [
 	requestor := OCMockRequestor new.
 	requestor text: 'griffle | foo | ^ goo'.
 
-	names := [ OpalCompiler new requestor: requestor; compile: requestor text ]
+	names := [ OpalCompiler new compile: requestor text ]
 		on: OCUndeclaredVariableWarning
 		do: [ :e |
 			e reparator
@@ -233,7 +233,7 @@ OCCodeReparatorTest >> testSubstituteVariableAtInterval [
 	requestor := OCMockRequestor new.
 	requestor text: 'griffle | foo | ^ goo'.
 
-	method := [ OpalCompiler new requestor: requestor; compile: requestor text ]
+	method := [ OpalCompiler new compile: requestor text ]
 		on: OCUndeclaredVariableWarning
 		do: [ :e |
 			e reparator
@@ -275,7 +275,7 @@ OCCodeReparatorTest >> testUndeclaredVariable [
 	requestor text: 'griffle ^ goo'.
 
 	flag := false.
-	method := [ OpalCompiler new requestor: requestor; compile: requestor text ]
+	method := [ OpalCompiler new compile: requestor text ]
 		on: OCUndeclaredVariableWarning
 		do: [ :e |
 			flag := true.

--- a/src/OpalCompiler-Tests/OCCodeReparatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCCodeReparatorTest.class.st
@@ -17,7 +17,7 @@ OCCodeReparatorTest >> testDeclareClassVar [
 	method := [ OpalCompiler new class: MockForCompilation ; compile: requestor text ]
 		on: OCUndeclaredVariableWarning
 		do: [ :e |
-			e reparator declareClassVar.
+			e notice reparator declareClassVar.
 			e retry ].
 
 	self assert: requestor text withSeparatorsCompacted equals: 'griffle ^ goo'.
@@ -65,7 +65,7 @@ OCCodeReparatorTest >> testDeclareGlobal [
 	method := [ OpalCompiler new compile: requestor text ]
 		on: OCUndeclaredVariableWarning
 		do: [ :e |
-			e reparator declareGlobal.
+			e notice reparator declareGlobal.
 			e retry ].
 
 	self assert: requestor text withSeparatorsCompacted equals: 'griffle ^ goo'.
@@ -115,7 +115,7 @@ OCCodeReparatorTest >> testDeclareInstVar [
 	method := [ OpalCompiler new class: MockForCompilation ; compile: requestor text ]
 		on: OCUndeclaredVariableWarning
 		do: [ :e |
-			e reparator declareInstVar: #goo.
+			e notice reparator declareInstVar: #goo.
 			e retry ].
 
 	self assert: requestor text withSeparatorsCompacted equals: 'griffle ^ goo'.
@@ -161,7 +161,7 @@ OCCodeReparatorTest >> testDeclareTempAndPaste [
 	method := [ OpalCompiler new compile: requestor text ]
 		on: OCUndeclaredVariableWarning
 		do: [ :e |
-			e reparator
+			e notice reparator
 				requestor: requestor;
 				declareTempAndPaste: 'goo'.
 			e retry ].
@@ -202,7 +202,7 @@ OCCodeReparatorTest >> testPossibleVariablesFor [
 	names := [ OpalCompiler new compile: requestor text ]
 		on: OCUndeclaredVariableWarning
 		do: [ :e |
-			e reparator
+			e notice reparator
 				requestor: requestor;
 				possibleVariablesFor: #goo.
 			].
@@ -236,7 +236,7 @@ OCCodeReparatorTest >> testSubstituteVariableAtInterval [
 	method := [ OpalCompiler new compile: requestor text ]
 		on: OCUndeclaredVariableWarning
 		do: [ :e |
-			e reparator
+			e notice reparator
 				requestor: requestor;
 				substituteVariable: 'foo' atInterval: e node sourceInterval.
 			e retry ].

--- a/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
@@ -93,11 +93,14 @@ RBCodeSnippetTest >> testCompileWithRequestor [
 		          noPattern: snippet isMethod not;
 		          requestor: requestor;
 		          failBlock: [ "When a requestion is set, a failBlock MUST also be set or compilation might crash internally"
-			| n |
+			          | n |
 			          self assert: requestor notifyList size equals: 1.
-			n := requestor notifyList first.
-						self assert: (snippet hasNotice: (n first allButLast: 3) at: n second).
-			          self assert: snippet isFaulty.
+			          n := requestor notifyList first.
+			          self assert:
+					          (snippet
+						           hasNotice: (n first allButLast: 3)
+						           at: n second).
+			          self assert: snippet isFaulty | snippet hasUndeclared.
 			          ^ self ];
 		          compile: snippet source.
 


### PR DESCRIPTION
This PR is a simple cleanup, but I do not like big PR.

The original idea was to simplify `OpalCompiler >> checkNotice:` by removing conditions and type checks.
A simple solution was to move the reparation concern to the RBNotice.

Currently, OCCodeReparator is still the fragile and limited class that was extracted from the original OCUndeclaredVariableWarning, but there is no reason that clients have to deal with too much detail about that.
So let's imagine that any RBNotice might propose some possible ways to repair itself. It simplifies the client code that do not have to deal about specific errors and warnings.