### PR TITLE
Bootstrap: allow to authetificate github requests during the bootstrap

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -265,13 +265,27 @@ BaselineOfIDE >> loadIceberg [
 		load.
 	(Smalltalk classNamed: #Iceberg) enableMetacelloIntegration: true.
 
+	Smalltalk os environment at: #GITHUB_TOKEN ifPresent: [ :token |
+		| credentials |
+		credentials := (Smalltalk classNamed: #IceTokenCredentials) new
+			               username:
+				               (Smalltalk os environment
+					                at: #GITHUB_USER
+					                ifAbsent: [ self error: 'Github token was found but not the github user associated to this token.' ]);
+			               token: token;
+			               host: 'github.com';
+			               yourself.
+
+		(Smalltalk classNamed: #IceCredentialStore) current storeCredential: credentials forHostname: 'github.com'.
+		'Using authentification for Github API' traceCr ].
+
 	self registerPharo.
-	self registerProject: 'Spec2' baseline: 'Spec2' otherBaselines: #('SpecCore').
+	self registerProject: 'Spec2' baseline: 'Spec2' otherBaselines: #( 'SpecCore' ).
 	self registerProject: 'NewTools'.
 	self registerProject: 'Roassal3'.
 	self registerProject: 'Microdown'.
 	self registerProject: 'BeautifulComments'.
-	self registerProject: 'DocumentBrowser' baseline: 'NewToolsDocumentBrowser' otherBaselines: #().
+	self registerProject: 'DocumentBrowser' baseline: 'NewToolsDocumentBrowser' otherBaselines: #(  ).
 	self registerIceberg
 ]
 

--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -101,6 +101,14 @@ BaselineOfPharo >> baseline: spec [
 
 { #category : #baseline }
 BaselineOfPharo >> postload: loader package: packageSpec [
-
 	"Here we will do something for the release announce"
+
+	"If we added a github token for the build, we remove it."
+	Smalltalk os environment at: #GITHUB_TOKEN ifPresent: [ :token |
+		| credential |
+		credential := (Smalltalk classNamed: #IceCredentialStore) current plaintextCredentialForHostname: 'github.com'.
+
+		credential password = token ifTrue: [ (Smalltalk classNamed: #IceCredentialStore) current removePlainTextCredential: credential ].
+
+		'Removing credential.' traceCr ]
 ]


### PR DESCRIPTION
On thing we might test to fix the Github limit rate problem on the CI we can try to authenticate the requests our github request. 

This PR adds this possibility. If GITHUB_TOKEN and GITHUB_USER environment variables are present, they will be used to build the image. And it will remove this credential at the end. Next step is to add credentials on Jenkins