### PR TITLE
Faulty code: add permitUndeclared

### DIFF
--- a/src/AST-Core/RBNotice.class.st
+++ b/src/AST-Core/RBNotice.class.st
@@ -45,6 +45,12 @@ RBNotice >> isError [
 ]
 
 { #category : #testing }
+RBNotice >> isUndeclaredNotice [
+
+	^ false
+]
+
+{ #category : #testing }
 RBNotice >> isWarning [
 
 	^ false

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -35,7 +35,8 @@ Class {
 		'bindings',
 		'compiledMethodClass',
 		'semanticScope',
-		'permitFaulty'
+		'permitFaulty',
+		'permitUndeclared'
 	],
 	#classVars : [
 		'DefaultOptions',
@@ -666,6 +667,18 @@ CompilationContext >> permitFaulty [
 CompilationContext >> permitFaulty: anObject [
 
 	permitFaulty := anObject
+]
+
+{ #category : #accessing }
+CompilationContext >> permitUndeclared [
+
+	^ permitUndeclared
+]
+
+{ #category : #accessing }
+CompilationContext >> permitUndeclared: anObject [
+
+	permitUndeclared := anObject
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OCUndeclaredVariableNotice.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariableNotice.class.st
@@ -15,11 +15,3 @@ OCUndeclaredVariableNotice >> reparator [
 
 	^ OCCodeReparator new node: self node
 ]
-
-{ #category : #signalling }
-OCUndeclaredVariableNotice >> signalError [
-
-	OCUndeclaredVariableWarning new
-		notice: self;
-		signal
-]

--- a/src/OpalCompiler-Core/OCUndeclaredVariableNotice.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariableNotice.class.st
@@ -4,6 +4,12 @@ Class {
 	#category : #'OpalCompiler-Core-FrontEnd'
 }
 
+{ #category : #testing }
+OCUndeclaredVariableNotice >> isUndeclaredNotice [
+
+	^ true
+]
+
 { #category : #correcting }
 OCUndeclaredVariableNotice >> reparator [
 

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -252,6 +252,11 @@ OpalCompiler >> checkNotice: aNotice [
 	"
 
 	aNotice isWarning ifTrue: [ ^ true ].
+	(aNotice isUndeclaredNotice and: [ self permitUndeclared ]) ifTrue: [
+		OCUndeclaredVariableWarning new
+			notice: aNotice;
+			signal.
+		^ true ].
 
 	self compilationContext requestor ifNotNil: [ :requestor |
 		"A requestor is available. We are in quirks mode and are expected to do UI things."
@@ -501,6 +506,8 @@ OpalCompiler >> parse [
 	| parser |
 	"Policy: simple parsing is faulty by default"
 	self permitFaulty ifNil: [ self permitFaulty: true ].
+	"Compatible policy: undeclared if failBlock present"
+	self permitUndeclared ifNil: [ self permitUndeclared: self compilationContext failBlock isNil ].
 
 	parser := self parserClass new.
 	parser initializeParserWith: source.

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -560,6 +560,18 @@ OpalCompiler >> permitFaulty: aBoolean [
 	self compilationContext permitFaulty: aBoolean
 ]
 
+{ #category : #'public access' }
+OpalCompiler >> permitUndeclared [
+
+	^ self compilationContext permitUndeclared
+]
+
+{ #category : #'public access' }
+OpalCompiler >> permitUndeclared: aBoolean [
+
+	self compilationContext permitUndeclared: aBoolean
+]
+
 { #category : #accessing }
 OpalCompiler >> productionEnvironment: anObject [
 	compilationContext productionEnvironment: anObject

--- a/src/OpalCompiler-Tests/MockForCompilation.class.st
+++ b/src/OpalCompiler-Tests/MockForCompilation.class.st
@@ -1,6 +1,3 @@
-"
-A simple mock with an ivar used by tests to check compilation, instance variable shadowing and other
-"
 Class {
 	#name : #MockForCompilation,
 	#superclass : #Object,


### PR DESCRIPTION
~~This PR is based on #13277 (6 first commits).~~ (was merged)

Currently, the static status of undeclared variables is not great. Basically, they are statically accepted unless some heuristics in the compiler decided that you are in an interactive text editor or something, and you get a GUI menu instead.
The lack of a precise specification of the Pharo language cause confusion for users (or at least for myself).

Unfortunately, recent experiments (#13172 then #13244) showed that some important parts of Pharo rely on variables statically undeclared (with the hope that they will be repaired later), including CodeImport, Monticello and Traits.
Therefore, currently, forbidding globally the static use of undeclared variable seems very hard.

So, I would like to try another (easier) approach: do not let the compiler decide with some uncontrollable heuristic but make it an explicit parameter: `permitUndeclared`.

The PR defines the infrastructure for it, and sets up a default value that is (I hope) sufficiently compatible with the current policy. Now the heuristic is at a single place, at least :)

Future PR will then be able to update clients to use a better explicit value and drop the heuristic to use a sane static default value. I would like that `permitUndeclared` be false by default unless specific tool require it to be true, but we'll see.

Note: I initially wanted `permitFaulty` to play the role of `permitUndeclared`, but this was complex to have without breaking too many things (mostly tests), and possibly introducing unexpected side effects and complex bug.
So maybe in the long run `permitUndeclared` will be merged with `permitFaulty`, but I do not know yet.