### PR TITLE
Faulty code: don't permit undeclared by default

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -299,12 +299,14 @@ RBCodeSnippet class >> badExpressions [
 			         source: '| | a';
 			         formattedCode: 'a';
 			         isParseFaulty: false;
+			         isFaultyMinusUndeclared: false;
 			         value: nil;
 			         notices: #( #( 5 5 5 'Undeclared variable' ) )). "This one is legal, it is an empty list of temporaries, the | are dismissed"
 		        (self new
 			         source: '|| a';
 			         formattedCode: 'a';
 			         isParseFaulty: false;
+			         isFaultyMinusUndeclared: false;
 			         value: nil;
 			         notices: #( #( 4 4 4 'Undeclared variable' ) )). "Same, but are messing with the Scanner"
 		        (self new
@@ -490,6 +492,7 @@ RBCodeSnippet class >> badExpressions [
 			         source: '[:a| | |b]';
 			         formattedCode: '[ :a | b ]';
 			         isParseFaulty: false;
+			         isFaultyMinusUndeclared: false;
 			         value: nil;
 			         notices: #( #( 9 9 9 'Undeclared variable' ) )). "Explicit empty list of temporaries"
 		        (self new
@@ -768,6 +771,7 @@ RBCodeSnippet class >> badSemantic [
 		        (self new
 			         source: 'a := 10. ^ a';
 			         isFaulty: true;
+			         isFaultyMinusUndeclared: false;
 			         raise: UndeclaredVariableWrite;
 			         notices:
 				         #( #( 1 1 1 'Undeclared variable' )
@@ -775,6 +779,7 @@ RBCodeSnippet class >> badSemantic [
 		        (self new
 			         source: '^ a';
 			         isFaulty: true;
+			         isFaultyMinusUndeclared: false;
 			         value: nil;
 			         notices: #( #( 3 3 3 'Undeclared variable' ) )).
 
@@ -994,7 +999,6 @@ RBCodeSnippet class >> badSemantic [
 			         isMethod: true;
 			         isFaulty: true;
 			         notices: #( #( 1 130 1 'Too many arguments' ) )). "Too many arguments"
-
 		        (self new
 			         source: 'CodeError signal: ''false error''';
 			         raise: CodeError;
@@ -1465,6 +1469,7 @@ RBCodeSnippet class >> badTokens [
 		        (self new
 			         source: 'Δə';
 			         isParseFaulty: false;
+			         isFaultyMinusUndeclared: false;
 			         value: nil;
 			         notices: #( #( 1 2 1 'Undeclared variable' ) )). "valid identifier"
 		        (self new
@@ -1490,7 +1495,6 @@ RBCodeSnippet class >> badTokens [
 		        (self new
 			         source: Character nbsp asString;
 			         notices: #( #( 1 1 1 'Unknown character' ) )). "Unknown character. Not isSeparator"
-
 		        (self new
 			         source: '$→';
 			         isFaulty: false;

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -27,6 +27,7 @@ Class {
 		'isMethod',
 		'isParseFaulty',
 		'isFaulty',
+		'isFaultyMinusUndeclared',
 		'notices',
 		'value',
 		'hasValue',
@@ -1952,6 +1953,18 @@ RBCodeSnippet >> isFaulty [
 RBCodeSnippet >> isFaulty: anObject [
 
 	isFaulty := anObject
+]
+
+{ #category : #accessing }
+RBCodeSnippet >> isFaultyMinusUndeclared [
+
+	^ isFaultyMinusUndeclared
+]
+
+{ #category : #accessing }
+RBCodeSnippet >> isFaultyMinusUndeclared: anObject [
+
+	isFaultyMinusUndeclared := anObject
 ]
 
 { #category : #accessing }

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -1760,6 +1760,7 @@ RBCodeSnippet >> applyDefaultTo: aCollection [
 		each isFaulty ifNil: [ each isFaulty: self isFaulty ].
 		each isParseFaulty ifNil: [ each isParseFaulty: self isParseFaulty ].
 		each isParseFaulty ifNil: [ each isParseFaulty: each isFaulty ].
+		each isFaultyMinusUndeclared ifNil: [ each isFaultyMinusUndeclared: each isFaulty ].
 		each formattedCode ifNil: [ each formattedCode: each source ].
 	]
 ]
@@ -1821,6 +1822,10 @@ RBCodeSnippet >> dumpDefinition [
 			  aStream
 				  nextPutAll: '; isParseFaulty: ';
 				  print: self isParseFaulty ].
+		  self isFaultyMinusUndeclared ~= self isFaulty ifTrue: [
+			  aStream
+				  nextPutAll: '; isFaultyMinusUndeclared: ';
+				  print: self isFaultyMinusUndeclared ].
 		  self dumpDefinitionValue: aStream.
 		  self numberOfCritiques ifNotNil: [
 			  aStream
@@ -2158,6 +2163,7 @@ RBCodeSnippet >> updateExpectations [
 	self isParseFaulty: ast isFaulty.
 	ast := self doSemanticAnalysis.
 	self isFaulty: ast isFaulty.
+	self isFaultyMinusUndeclared: self isFaulty & (ast allErrorNotices allSatisfy: #isUndeclaredNotice) not.
 	self notices: (ast allNotices
 			 collect: [ :each |
 				 {

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -297,12 +297,14 @@ RBCodeSnippet class >> badExpressions [
 		        (self new
 			         source: '| | a';
 			         formattedCode: 'a';
-			         isFaulty: false;
+			         isParseFaulty: false;
+			         value: nil;
 			         notices: #( #( 5 5 5 'Undeclared variable' ) )). "This one is legal, it is an empty list of temporaries, the | are dismissed"
 		        (self new
 			         source: '|| a';
 			         formattedCode: 'a';
-			         isFaulty: false;
+			         isParseFaulty: false;
+			         value: nil;
 			         notices: #( #( 4 4 4 'Undeclared variable' ) )). "Same, but are messing with the Scanner"
 		        (self new
 			         source: ' ||| a';
@@ -486,7 +488,8 @@ RBCodeSnippet class >> badExpressions [
 		        (self new
 			         source: '[:a| | |b]';
 			         formattedCode: '[ :a | b ]';
-			         isFaulty: false;
+			         isParseFaulty: false;
+			         value: nil;
 			         notices: #( #( 9 9 9 'Undeclared variable' ) )). "Explicit empty list of temporaries"
 		        (self new
 			         source: '[:a| ||a]';
@@ -763,12 +766,15 @@ RBCodeSnippet class >> badSemantic [
 	list := {
 		        (self new
 			         source: 'a := 10. ^ a';
+			         isFaulty: true;
 			         raise: UndeclaredVariableWrite;
 			         notices:
 				         #( #( 1 1 1 'Undeclared variable' )
 				            #( 12 12 12 'Undeclared variable' ) )).
 		        (self new
 			         source: '^ a';
+			         isFaulty: true;
+			         value: nil;
 			         notices: #( #( 3 3 3 'Undeclared variable' ) )).
 
 		        "Uninitialized variable"
@@ -1250,7 +1256,7 @@ RBCodeSnippet class >> badTokens [
 	"This list focuses on bad literal, malformed tokens, unexpected character and other scanner related issue.
 	It contains various (and possibly systematic) variations of faulty inputs (and some correct ones for good measure).
 	Unless specifically testing token handling (e.g. in the scanner) try to use the formater format `formattedCode` as the source to simplify this file"
-	
+
 	<script: 'self styleWithError: self badTokens'>
 	| list |
 	list := {
@@ -1457,7 +1463,8 @@ RBCodeSnippet class >> badTokens [
 		        "$ə isLetter >>> true" "$ə asInteger >>> 16r0259" "Latin Small Letter Schwa"
 		        (self new
 			         source: 'Δə';
-			         isFaulty: false;
+			         isParseFaulty: false;
+			         value: nil;
 			         notices: #( #( 1 2 1 'Undeclared variable' ) )). "valid identifier"
 		        (self new
 			         source: '| Δə | Δə := 1. Δə + 1';

--- a/src/AST-Core-Tests/RBCodeSnippetTest.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippetTest.class.st
@@ -135,7 +135,7 @@ RBCodeSnippetTest >> testMonticello [
 	MCMockClassE methods copy do: [ :m | MCMockClassE removeSelector: m selector ].
 	self assert: MCMockClassE methods size equals: 0.
 
-	snippet isFaulty ifTrue: [
+	snippet isFaultyMinusUndeclared ifTrue: [
 			self should: [ 	[ definition load ] on: Warning do: [ :e | e resume ]. "Ignore Selector missmatches" ] raise: CodeError.
 			self assert: MCMockClassE methods size equals: 0.
 			^ self ].

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -385,6 +385,7 @@ ClassDescription >> compile: sourceCode classified: protocol withStamp: changeSt
 		source: sourceCode;
 		requestor: requestor;
 		failBlock: (requestor ifNotNil: [ [ ^ nil ] ]); "no failblock if no requestor"
+		permitUndeclared: (requestor isNil); "compatibility: permit undeclared if no requestor"
 		protocol: protocol;
 		changeStamp: changeStamp;
 		logged: logSource;

--- a/src/Monticello/MethodAddition.class.st
+++ b/src/Monticello/MethodAddition.class.st
@@ -44,7 +44,7 @@ MethodAddition >> createCompiledMethod [
 	"CyrilFerlicot: Why do we need to explicitly write to the source? Why do we call the compiler?
 	
 	Can't we just call #compile:classfied: here?"
-	compiledMethod := myClass compiler compile: text asString.
+	compiledMethod := myClass compiler permitUndeclared: true; compile: text asString.
 	selector := compiledMethod selector.
 	self writeSourceToLog.
 	priorMethodOrNil := myClass compiledMethodAt: selector ifAbsent: [ nil ].

--- a/src/OpalCompiler-Core/OCUndeclaredVariableNotice.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariableNotice.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #OCUndeclaredVariableNotice,
-	#superclass : #RBNotice,
+	#superclass : #RBErrorNotice,
 	#category : #'OpalCompiler-Core-FrontEnd'
 }
 

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -507,7 +507,7 @@ OpalCompiler >> parse [
 	"Policy: simple parsing is faulty by default"
 	self permitFaulty ifNil: [ self permitFaulty: true ].
 	"Compatible policy: undeclared if failBlock present"
-	self permitUndeclared ifNil: [ self permitUndeclared: self compilationContext failBlock isNil ].
+	self permitUndeclared ifNil: [ self permitUndeclared: false ].
 
 	parser := self parserClass new.
 	parser initializeParserWith: source.

--- a/src/OpalCompiler-Tests/OCCodeReparatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCCodeReparatorTest.class.st
@@ -15,7 +15,7 @@ OCCodeReparatorTest >> testDeclareClassVar [
 	goo ifNotNil: [ MockForCompilation removeClassVariable: goo ].
 
 	method := [ OpalCompiler new class: MockForCompilation ; compile: requestor text ]
-		on: OCUndeclaredVariableWarning
+		on: OCUndeclaredVariableWarning , CodeError
 		do: [ :e |
 			e notice reparator declareClassVar.
 			e retry ].
@@ -63,7 +63,7 @@ OCCodeReparatorTest >> testDeclareGlobal [
 	Smalltalk globals removeKey: #goo ifAbsent: [].
 
 	method := [ OpalCompiler new compile: requestor text ]
-		on: OCUndeclaredVariableWarning
+		on: OCUndeclaredVariableWarning , CodeError
 		do: [ :e |
 			e notice reparator declareGlobal.
 			e retry ].
@@ -113,7 +113,7 @@ OCCodeReparatorTest >> testDeclareInstVar [
 	self deny: (MockForCompilation hasInstVarNamed: #goo).
 
 	method := [ OpalCompiler new class: MockForCompilation ; compile: requestor text ]
-		on: OCUndeclaredVariableWarning
+		on: OCUndeclaredVariableWarning , CodeError
 		do: [ :e |
 			e notice reparator declareInstVar: #goo.
 			e retry ].
@@ -159,7 +159,7 @@ OCCodeReparatorTest >> testDeclareTempAndPaste [
 	requestor text: 'griffle ^ goo'.
 
 	method := [ OpalCompiler new compile: requestor text ]
-		on: OCUndeclaredVariableWarning
+		on: OCUndeclaredVariableWarning , CodeError
 		do: [ :e |
 			e notice reparator
 				requestor: requestor;
@@ -200,7 +200,7 @@ OCCodeReparatorTest >> testPossibleVariablesFor [
 	requestor text: 'griffle | foo | ^ goo'.
 
 	names := [ OpalCompiler new compile: requestor text ]
-		on: OCUndeclaredVariableWarning
+		on: OCUndeclaredVariableWarning , CodeError
 		do: [ :e |
 			e notice reparator
 				requestor: requestor;
@@ -234,7 +234,7 @@ OCCodeReparatorTest >> testSubstituteVariableAtInterval [
 	requestor text: 'griffle | foo | ^ goo'.
 
 	method := [ OpalCompiler new compile: requestor text ]
-		on: OCUndeclaredVariableWarning
+		on: OCUndeclaredVariableWarning , CodeError
 		do: [ :e |
 			e notice reparator
 				requestor: requestor;
@@ -276,7 +276,7 @@ OCCodeReparatorTest >> testUndeclaredVariable [
 
 	flag := false.
 	method := [ OpalCompiler new compile: requestor text ]
-		on: OCUndeclaredVariableWarning
+		on: OCUndeclaredVariableWarning , CodeError
 		do: [ :e |
 			flag := true.
 			e resume "continue" ].

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -246,15 +246,6 @@ OCCompilerTest >> testUndefinedVariable [
 	Undeclared removeKey: #undefinedName123 ifAbsent: [ ].
 	self
 		assert: {
-			OpalCompiler new evaluate: 'undefinedName123'.
-			[ OpalCompiler new evaluate: 'undefinedName123 := 1. undefinedName123' ] on: UndeclaredVariableWrite do: [ UndeclaredVariableWrite ].
-			OpalCompiler new evaluate: 'undefinedName123'.
-			}
-		equals: { nil. UndeclaredVariableWrite. nil. }.
-
-	Undeclared removeKey: #undefinedName123 ifAbsent: [ ].
-	self
-		assert: {
 			OpalCompiler new
 				permitFaulty: true;
 				evaluate: 'undefinedName123'.

--- a/src/OpalCompiler-Tests/RBCodeSnippetScriptingTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetScriptingTest.extension.st
@@ -12,7 +12,7 @@ RBCodeSnippetScriptingTest >> testEvaluateFailBlock [
 			failBlock: [ :e | error := e. #tag ];
 			evaluate: snippet source ].
 
-	snippet isFaulty | snippet hasUndeclared
+	snippet isFaulty
 		ifTrue: [
 			self assert: runBlock value equals: #tag.
 			self assert: (snippet hasNotice: error) ]

--- a/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
@@ -82,6 +82,31 @@ RBCodeSnippetTest >> testCompileOnErrorResume [
 ]
 
 { #category : #'*OpalCompiler-Tests' }
+RBCodeSnippetTest >> testCompileUndeclaredFaultyFailBlock [
+
+	| method error |
+	error := nil.
+	method := OpalCompiler new
+		          noPattern: snippet isMethod not;
+		          permitUndeclared: true;
+		          failBlock: [ :e |
+			          self assert: (snippet hasNotice: e).
+			          self assert: error isNil. "single invocation"
+			          error := e.
+			          #tag ];
+		          compile: snippet source.
+
+	snippet isFaultyMinusUndeclared
+		ifTrue: [
+			self assert: error isNotNil.
+			self assert: method equals: #tag ]
+		ifFalse: [
+			self assert: error isNil.
+			self assert: method isCompiledMethod.
+			self testExecute: method ]
+]
+
+{ #category : #'*OpalCompiler-Tests' }
 RBCodeSnippetTest >> testCompileWithRequestor [
 
 	| requestor method |

--- a/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
@@ -14,7 +14,7 @@ RBCodeSnippetTest >> testCompileFailBlock [
 			          #tag ];
 		          compile: snippet source.
 
-	snippet isFaulty | snippet hasUndeclared
+	snippet isFaulty
 		ifTrue: [
 			self assert: error isNotNil.
 			self assert: method equals: #tag ]
@@ -100,7 +100,7 @@ RBCodeSnippetTest >> testCompileWithRequestor [
 					          (snippet
 						           hasNotice: (n first allButLast: 3)
 						           at: n second).
-			          self assert: snippet isFaulty | snippet hasUndeclared.
+			          self assert: snippet isFaulty.
 			          ^ self ];
 		          compile: snippet source.
 

--- a/src/TraitsV2/TaAbstractComposition.class.st
+++ b/src/TraitsV2/TaAbstractComposition.class.st
@@ -146,9 +146,9 @@ TaAbstractComposition >> compile: selector into: aClass [
 
 	newMethod := aClass compiler
 		             source: sourceCode;
-		             class: aClass;
 		             compiledMethodTrailer: trailer;
-		             compile. "Assume OK after proceed from SyntaxError"
+		             permitUndeclared: true;
+		             compile.
 
 	selector == newMethod selector ifFalse: [ self error: 'selector changed!' ].
 


### PR DESCRIPTION
This PR defaults `permitUndeclared` to false, meaning that unless instructed otherwise with the setter `permitUndeclared:`, `OpalCompiler` will consider the (static) use of undeclared variables to be errors.
Moreover, `OCUndeclaredVariableNotice` is officially promoted to `RBErrorNotice`. Until now, it was in some limbo state, neither an error nor a warning. This change means that an AST node with such a notice will answer true to `isFaulty`.

In order for this change to be successful, the following clients are adapted:
* Traits: `TaAbstractComposition` sets permitUndeclared
* Monticello: `MethodAddition` sets permitUndeclared
* All clients of `ClassDescription>>compile:*`, that includes CodeImport and some tests in newtools, permitUndeclared is set according to a heuristic (is a requestor present) that is comparible with the current usage.
  I think that's the right move since I consider `ClassDescription>>compile:*` a legacy API, so maintaining its behavior make sense.

Tests are also added. `RBCodeSnippet` gains a new ivar `isFaultyMinusUndeclared` (the name is not nice, but it is not used that much) that correspond to being faulty, while `permitUndeclared` is set to true.
It is used for the Monticello test on snippets and for a new test explicitly made to check `permitUndeclared:`

There are many small changes with specific goals, so there are a lot of commits (oneliner sometime).
The global diff is less big than I expected.