### PR TITLE
Remove dependency of Collections-Abstract/Sequenceable over Random-Core

### DIFF
--- a/src/Collections-Abstract/SequenceableCollection.class.st
+++ b/src/Collections-Abstract/SequenceableCollection.class.st
@@ -2110,28 +2110,6 @@ SequenceableCollection >> seventh [
 	^ self at: 7
 ]
 
-{ #category : #shuffling }
-SequenceableCollection >> shuffle [
-	"Modify the receiver but with its elements in random positions.
-	This method use Random class as random generator"
-
-	^ self shuffleBy: Random new
-]
-
-{ #category : #shuffling }
-SequenceableCollection >> shuffleBy: aRandom [
-	"Durstenfeld's version of the Fisher-Yates shuffle"
-	"({1. 2. 3. 4. 5} shuffleBy: (Random seed: 42)) >>> #(2 5 4 3 1)"
-
-	self size to: 2 by: -1 do: [ :i |
-		self swap: i with: (aRandom nextInteger: i) ]
-]
-
-{ #category : #copying }
-SequenceableCollection >> shuffled [
-	^ self copy shuffle
-]
-
 { #category : #accessing }
 SequenceableCollection >> sixth [
 	"Answer the sixth element of the receiver.

--- a/src/Collections-Sequenceable-Tests/Heap.extension.st
+++ b/src/Collections-Sequenceable-Tests/Heap.extension.st
@@ -1,0 +1,62 @@
+Extension { #name : #Heap }
+
+{ #category : #'*Collections-Sequenceable-Tests' }
+Heap class >> heapExample [
+	"self heapExample"
+	"Create a sorted collection of numbers, remove the elements
+	sequentially and add new objects randomly.
+	Note: This is the kind of benchmark a heap is designed for."
+
+	^ String streamContents: [ :str |
+		| n rnd array time sorted |
+		n := 5000. "# of elements to sort"
+		rnd := Random new.
+		array := (1 to: n) collect:[:i| rnd next].
+		"First, the heap version"
+		time := Time millisecondsToRun:[
+		sorted := self withAll: array.
+			1 to: n do:[:i|
+				sorted removeFirst.
+				sorted add: rnd next].
+	].
+	str << 'Time for Heap: ' << time printString <<' msecs '; cr.
+	"The quicksort version"
+	time := Time millisecondsToRun:[
+		sorted := SortedCollection withAll: array.
+		1 to: n do:[:i|
+			sorted removeFirst.
+			sorted add: rnd next].
+	].
+	str << 'Time for SortedCollection: '<< time printString << ' msecs'.]
+]
+
+{ #category : #'*Collections-Sequenceable-Tests' }
+Heap class >> heapSortExample [
+	"self heapSortExample"
+	"Sort a random collection of Floats and compare the results with
+	SortedCollection (using the quick-sort algorithm) and
+	ArrayedCollection>>mergeSortFrom:to:by: (using the merge-sort algorithm)."
+
+	^ String streamContents: [ :str |
+		| n rnd array  time sorted |
+		n := 10000. "# of elements to sort"
+		rnd := Random new.
+		array := (1 to: n) collect:[:i| rnd next].
+		"First, the heap version"
+		time := Time millisecondsToRun:[
+			sorted := Heap withAll: array.
+			1 to: n do:[:i| sorted removeFirst].
+		].
+	str << 'Time for heap-sort: ' << time printString << ' msecs ';cr.
+	"The quicksort version"
+	time := Time millisecondsToRun:[
+		sorted := SortedCollection withAll: array.
+	].
+	str << 'Time for quick-sort: ' << time printString <<' msecs '; cr.
+	"The merge-sort version"
+	time := Time millisecondsToRun:[
+		array mergeSortFrom: 1 to: array size by: [:v1 :v2| v1 <= v2].
+	].
+	str << 'Time for merge-sort: ' << time printString  << ' msecs'; cr.
+	]
+]

--- a/src/Collections-Sequenceable/Array2D.class.st
+++ b/src/Collections-Sequenceable/Array2D.class.st
@@ -657,16 +657,6 @@ Array2D >> select: aBlock [
 	self shouldNotImplement
 ]
 
-{ #category : #copying }
-Array2D >> shuffled [
-	^self class rows: numberOfRows columns: numberOfColumns contents: (contents shuffled)
-]
-
-{ #category : #copying }
-Array2D >> shuffledBy: aRandom [
-	^self class rows: numberOfRows columns: numberOfColumns contents: (contents copy shuffleBy: aRandom)
-]
-
 { #category : #accessing }
 Array2D >> size [
 	^ contents size

--- a/src/Collections-Sequenceable/Heap.class.st
+++ b/src/Collections-Sequenceable/Heap.class.st
@@ -79,67 +79,6 @@ Heap class >> defaultSortBlock [
 		sortBlock := [ :a :b | a <= b]]
 ]
 
-{ #category : #examples }
-Heap class >> heapExample [
-	"self heapExample"
-	"Create a sorted collection of numbers, remove the elements
-	sequentially and add new objects randomly.
-	Note: This is the kind of benchmark a heap is designed for."
-
-	^ String streamContents: [ :str |
-		| n rnd array time sorted |
-		n := 5000. "# of elements to sort"
-		rnd := Random new.
-		array := (1 to: n) collect:[:i| rnd next].
-		"First, the heap version"
-		time := Time millisecondsToRun:[
-		sorted := self withAll: array.
-			1 to: n do:[:i|
-				sorted removeFirst.
-				sorted add: rnd next].
-	].
-	str << 'Time for Heap: ' << time printString <<' msecs '; cr.
-	"The quicksort version"
-	time := Time millisecondsToRun:[
-		sorted := SortedCollection withAll: array.
-		1 to: n do:[:i|
-			sorted removeFirst.
-			sorted add: rnd next].
-	].
-	str << 'Time for SortedCollection: '<< time printString << ' msecs'.]
-]
-
-{ #category : #examples }
-Heap class >> heapSortExample [
-	"self heapSortExample"
-	"Sort a random collection of Floats and compare the results with
-	SortedCollection (using the quick-sort algorithm) and
-	ArrayedCollection>>mergeSortFrom:to:by: (using the merge-sort algorithm)."
-
-	^ String streamContents: [ :str |
-		| n rnd array  time sorted |
-		n := 10000. "# of elements to sort"
-		rnd := Random new.
-		array := (1 to: n) collect:[:i| rnd next].
-		"First, the heap version"
-		time := Time millisecondsToRun:[
-			sorted := Heap withAll: array.
-			1 to: n do:[:i| sorted removeFirst].
-		].
-	str << 'Time for heap-sort: ' << time printString << ' msecs ';cr.
-	"The quicksort version"
-	time := Time millisecondsToRun:[
-		sorted := SortedCollection withAll: array.
-	].
-	str << 'Time for quick-sort: ' << time printString <<' msecs '; cr.
-	"The merge-sort version"
-	time := Time millisecondsToRun:[
-		array mergeSortFrom: 1 to: array size by: [:v1 :v2| v1 <= v2].
-	].
-	str << 'Time for merge-sort: ' << time printString  << ' msecs'; cr.
-	]
-]
-
 { #category : #'instance creation' }
 Heap class >> new [
 	^self new: 10

--- a/src/Collections-Sequenceable/Interval.class.st
+++ b/src/Collections-Sequenceable/Interval.class.st
@@ -378,12 +378,6 @@ Interval >> setFrom: startInteger to: stopInteger by: stepInteger [
 	step isZero ifTrue: [ ^ DomainError signal: 'Zero size steps not allowed' ]
 ]
 
-{ #category : #copying }
-Interval >> shuffled [
-	"Return an array that contains my elements shuffled in a random order"
-	^ self asArray shuffle
-]
-
 { #category : #accessing }
 Interval >> size [
 	"Answer how many elements the receiver contains."

--- a/src/Random-Core/Array2D.extension.st
+++ b/src/Random-Core/Array2D.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #Array2D }
+
+{ #category : #'*Random-Core' }
+Array2D >> shuffled [
+	^self class rows: numberOfRows columns: numberOfColumns contents: (contents shuffled)
+]
+
+{ #category : #'*Random-Core' }
+Array2D >> shuffledBy: aRandom [
+	^self class rows: numberOfRows columns: numberOfColumns contents: (contents copy shuffleBy: aRandom)
+]

--- a/src/Random-Core/Interval.extension.st
+++ b/src/Random-Core/Interval.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #Interval }
+
+{ #category : #'*Random-Core' }
+Interval >> shuffled [
+	"Return an array that contains my elements shuffled in a random order"
+	^ self asArray shuffle
+]

--- a/src/Random-Core/SequenceableCollection.extension.st
+++ b/src/Random-Core/SequenceableCollection.extension.st
@@ -10,3 +10,25 @@ SequenceableCollection >> atRandom: aGenerator [
 
 	^ self at: (aGenerator nextInteger: self size)
 ]
+
+{ #category : #'*Random-Core' }
+SequenceableCollection >> shuffle [
+	"Modify the receiver but with its elements in random positions.
+	This method use Random class as random generator"
+
+	^ self shuffleBy: Random new
+]
+
+{ #category : #'*Random-Core' }
+SequenceableCollection >> shuffleBy: aRandom [
+	"Durstenfeld's version of the Fisher-Yates shuffle"
+	"({1. 2. 3. 4. 5} shuffleBy: (Random seed: 42)) >>> #(2 5 4 3 1)"
+
+	self size to: 2 by: -1 do: [ :i |
+		self swap: i with: (aRandom nextInteger: i) ]
+]
+
+{ #category : #'*Random-Core' }
+SequenceableCollection >> shuffled [
+	^ self copy shuffle
+]

--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -14,6 +14,12 @@ Class {
 }
 
 { #category : #accessing }
+SystemDependenciesTest class >> defaultTimeLimit [
+
+	^ 1 minute
+]
+
+{ #category : #accessing }
 SystemDependenciesTest class >> dependenciesReport [
 
 	^ dependenciesReport ifNil: [ self rebuildDependenciesReport ]
@@ -152,12 +158,6 @@ SystemDependenciesTest >> knownUIDependencies [
 	#'Athens-Morphic' #'Refactoring-Critics' #'Refactoring-Environment' 'Reflectivity-Tools' #Shout #'Tool-Diff' #'Tool-FileList' #'Tool-Profilers' #'HeuristicCompletion-Model' 'NECompletion-Morphic' #VariablesLibrary #'Tools-CodeNavigation' #'Spec2-CommonWidgets')
 ]
 
-{ #category : #utilities }
-SystemDependenciesTest >> longTestCase [
-
-	self timeLimit: 60 seconds
-]
-
 { #category : #accessing }
 SystemDependenciesTest >> metacelloPackageNames [
 
@@ -199,8 +199,6 @@ SystemDependenciesTest >> testExternalBasicToolsDependencies [
 
 	| dependencies |
 
-	self longTestCase.
-
 	dependencies := self externalDependendiesOf: (
 		self metacelloPackageNames,
 		self tonelCorePackageNames,
@@ -236,8 +234,6 @@ SystemDependenciesTest >> testExternalCompilerDependencies [
 
 	| dependencies |
 
-	self longTestCase.
-
 	dependencies := self externalDependendiesOf: (
 		BaselineOfPharoBootstrap kernelPackageNames,
 		BaselineOfPharoBootstrap multilingualPackageNames,
@@ -251,8 +247,6 @@ SystemDependenciesTest >> testExternalCompilerDependencies [
 SystemDependenciesTest >> testExternalDisplayDependencies [
 
 	| dependencies |
-
-	self longTestCase.
 
 	dependencies := self externalDependendiesOf: (
 		self metacelloPackageNames,
@@ -268,8 +262,6 @@ SystemDependenciesTest >> testExternalFileSystemDependencies [
 
 	| dependencies |
 
-	self longTestCase.
-
 	dependencies := self externalDependendiesOf: (
 		BaselineOfPharoBootstrap kernelPackageNames,
 		BaselineOfPharoBootstrap multilingualPackageNames,
@@ -283,7 +275,6 @@ SystemDependenciesTest >> testExternalFileSystemDependencies [
 { #category : #tests }
 SystemDependenciesTest >> testExternalIDEDependencies [
 	| dependencies packages |
-	self longTestCase.
 	packages := self metacelloPackageNames , self tonelCorePackageNames , { BaselineOfPharoBootstrap name. BaselineOfMonticello name. BaselineOfMetacello name}.
 
 	{BaselineOfAthens.
@@ -365,7 +356,6 @@ If you will break or weaken this test, a puppy will die!!!
      (_(_/-(_/
 "
 	| dependencies |
-	self longTestCase.
 
 	dependencies := self
 		externalDependendiesOf: BaselineOfPharoBootstrap kernelPackageNames , BaselineOfPharoBootstrap multilingualPackageNames, BaselineOfPharoBootstrap kernelAdditionalPackagesNames.
@@ -377,8 +367,6 @@ If you will break or weaken this test, a puppy will die!!!
 SystemDependenciesTest >> testExternalLocalMonticelloDependencies [
 
 	| dependencies |
-
-	self longTestCase.
 
 	dependencies := self externalDependendiesOf: (
 		BaselineOfTraits corePackages,
@@ -399,8 +387,6 @@ SystemDependenciesTest >> testExternalMetacelloDependencies [
 
 	| dependencies |
 
-	self longTestCase.
-
 	dependencies := self externalDependendiesOf: self metacelloPackageNames, BaselineOfTraits corePackages.
 
 	self assert: dependencies isEmpty
@@ -410,8 +396,6 @@ SystemDependenciesTest >> testExternalMetacelloDependencies [
 SystemDependenciesTest >> testExternalMonticelloDependencies [
 
 	| dependencies |
-
-	self longTestCase.
 
 	dependencies := self externalDependendiesOf: (
 		BaselineOfTraits corePackages,
@@ -431,8 +415,6 @@ SystemDependenciesTest >> testExternalMorphicCoreDependencies [
 
 	| dependencies |
 
-	self longTestCase.
-
 	dependencies := self externalDependendiesOf: (
 		self metacelloPackageNames,
 		self tonelCorePackageNames,
@@ -450,8 +432,6 @@ SystemDependenciesTest >> testExternalMorphicCoreDependencies [
 SystemDependenciesTest >> testExternalMorphicDependencies [
 
 	| dependencies |
-
-	self longTestCase.
 
 	dependencies := self externalDependendiesOf: (
 		self metacelloPackageNames,
@@ -480,8 +460,6 @@ SystemDependenciesTest >> testExternalSUnitDependencies [
 
 	| dependencies |
 
-	self longTestCase.
-
 	dependencies := self externalDependendiesOf: (
 		BaselineOfTraits corePackages,
 		self metacelloPackageNames,
@@ -495,8 +473,6 @@ SystemDependenciesTest >> testExternalSUnitDependencies [
 SystemDependenciesTest >> testExternalSUnitKernelDependencies [
 
 	| dependencies |
-
-	self longTestCase.
 
 	dependencies := self externalDependendiesOf: (
 		BaselineOfPharoBootstrap compilerPackageNames,
@@ -513,8 +489,6 @@ SystemDependenciesTest >> testExternalSUnitKernelDependencies [
 SystemDependenciesTest >> testExternalSpec2Dependencies [
 
 	| dependencies |
-
-	self longTestCase.
 
 	dependencies := (self externalDependendiesOf: (
 		"Language"
@@ -555,8 +529,6 @@ SystemDependenciesTest >> testExternalUFFIDependencies [
 
 	| dependencies |
 
-	self longTestCase.
-
 	dependencies := self externalDependendiesOf: (
 		self metacelloPackageNames,
 		self tonelCorePackageNames,
@@ -572,8 +544,6 @@ SystemDependenciesTest >> testExternalUFFIDependencies [
 SystemDependenciesTest >> testExternalUIDependencies [
 
 	| dependencies |
-
-	self longTestCase.
 
 	dependencies := (self externalDependendiesOf: (
 		self metacelloPackageNames,

--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -185,6 +185,16 @@ SystemDependenciesTest >> packagesOfGroupNamed: aGroupName on: aBaseline [
 ]
 
 { #category : #tests }
+SystemDependenciesTest >> testCollectionsShouldNotDependOnRandom [
+	"In the past Random-Core was depending on Collection-Abstract and Collections-Sequenceable but both those packages also depended on Random-Core.
+	This dependency has been removed and this test is here to ensure it does not get added back in the future."
+
+	| dependencies |
+	dependencies := self externalDependendiesOf: #( 'Collections-Abstract' 'Collections-Sequenceable' ).
+	self deny: (dependencies includes: 'Random-Core')
+]
+
+{ #category : #tests }
 SystemDependenciesTest >> testExternalBasicToolsDependencies [
 
 	| dependencies |


### PR DESCRIPTION
Until now Random-Core was depending on Collection-Abstract and Collections-Sequenceable but both those packages also depended on Random-Core.

This PR removes the dependency of those collections over Random-Core. For now their tests are still depending on it and maybe the tests should be in Random-Tests instead, but this is a concern for later.

It also adds a test to ensure that it will not be added again in the future. The cherry on top is that I extracted the time limit of dependencies tests to apply for all tests. 