### PR TITLE
Faulty code: make undeclared write resumable with the right value

### DIFF
--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -1003,6 +1003,38 @@ CompiledMethodTest >> testWritesSlot [
 	self assert: ((Point>>#setX:setY:) writesSlot: (Point slotNamed: #x))
 ]
 
+{ #category : #'tests - testing' }
+CompiledMethodTest >> testWritesUndeclared [
+	| method |
+	
+	"x is an ivar"
+	method := self class compiler compile: 'x ^ x := 0'.
+	self deny: method usesUndeclareds.
+	self assert: (self executeMethod: method) equals: 0.
+
+	"undeclaredxyz is not declared"
+	method := self class compiler permitFaulty: true; compile: 'z ^ undeclaredxyz := 1'.
+	self assert: method usesUndeclareds.
+	self should: [ self executeMethod: method ] raise: UndeclaredVariableWrite.
+	self
+		assert:
+			([ self executeMethod: method ]
+				on: UndeclaredVariableWrite
+				do: [:e | e resume])
+		equals: 1.
+
+	"check same behavior in blocks"
+	method := self class compiler permitFaulty: true; compile: 'msg ^ self in: [ :anObject | undeclaredxyz := 2 ]'.
+	self assert: method usesUndeclareds.
+	self should: [ self executeMethod: method ] raise: UndeclaredVariableWrite.
+	self
+		assert:
+			([ self executeMethod: method ]
+				on: UndeclaredVariableWrite
+				do: [:e | e resume])
+		equals: 2
+]
+
 { #category : #examples }
 CompiledMethodTest >> writeX [
 

--- a/src/Kernel/UndeclaredVariable.class.st
+++ b/src/Kernel/UndeclaredVariable.class.st
@@ -83,7 +83,7 @@ UndeclaredVariable >> register [
 UndeclaredVariable >> runtimeUndeclaredWrite: anObject [
 
 	<debuggerCompleteToSender>
-	UndeclaredVariableWrite new
+	^ UndeclaredVariableWrite new
 		messageText: 'Attempt to write to undeclared variable ' , self name;
 		variable: self;
 		signal

--- a/src/Kernel/UndeclaredVariable.class.st
+++ b/src/Kernel/UndeclaredVariable.class.st
@@ -86,6 +86,7 @@ UndeclaredVariable >> runtimeUndeclaredWrite: anObject [
 	^ UndeclaredVariableWrite new
 		messageText: 'Attempt to write to undeclared variable ' , self name;
 		variable: self;
+		value: anObject;
 		signal
 ]
 

--- a/src/Kernel/UndeclaredVariableWrite.class.st
+++ b/src/Kernel/UndeclaredVariableWrite.class.st
@@ -10,6 +10,13 @@ Class {
 	#category : #'Kernel-Exceptions'
 }
 
+{ #category : #testing }
+UndeclaredVariableWrite >> isResumable [
+	"The undeclared variable write become a no-op"
+
+	^ true
+]
+
 { #category : #accessing }
 UndeclaredVariableWrite >> variable [
 

--- a/src/Kernel/UndeclaredVariableWrite.class.st
+++ b/src/Kernel/UndeclaredVariableWrite.class.st
@@ -5,16 +5,35 @@ Class {
 	#name : #UndeclaredVariableWrite,
 	#superclass : #Error,
 	#instVars : [
-		'variable'
+		'variable',
+		'value'
 	],
 	#category : #'Kernel-Exceptions'
 }
+
+{ #category : #testing }
+UndeclaredVariableWrite >> defaultResumeValue [
+
+	^ value
+]
 
 { #category : #testing }
 UndeclaredVariableWrite >> isResumable [
 	"The undeclared variable write become a no-op"
 
 	^ true
+]
+
+{ #category : #accessing }
+UndeclaredVariableWrite >> value [
+
+	^ value
+]
+
+{ #category : #accessing }
+UndeclaredVariableWrite >> value: anObject [
+
+	value := anObject
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Kernel runtime error `UndeclaredVariableWrite` is now resumable, and keep the right value (pun on *correct* and *rvalue*). The value is stored in the exception, so easy to access if someone cares.

This is a different (and better) implementation than the one in (not yet merged) PR #13238.
And also contains a test.