### PR TITLE
Do not disable system announcements during rpackage tests

### DIFF
--- a/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
@@ -494,36 +494,37 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRemovingExtensionCate
 ]
 
 { #category : #'tests - operations on protocols' }
-RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingClassicCategoryToExtensionCategoryMoveAllMethodsFromParentPackageToExtendingPackage [	 
+RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingClassicCategoryToExtensionCategoryMoveAllMethodsFromParentPackageToExtendingPackage [
 	"test that when we reoganized a class by renaming a  classic category (a category not beginning with '*') to an extension category, all the methods are moved from the  parent package of the class to the extending package"
-	|XPackage YPackage class| 
+
+	| XPackage YPackage class |
 	self addXYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
-	YPackage  := self organizer packageNamed: #YYYYY.
+	YPackage := self organizer packageNamed: #YYYYY.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	
-	self createMethodNamed: 'stubMethod' inClass: class  inCategory: 'classic category'.
-	self createMethodNamed: 'stubMethod2' inClass: class  inCategory: 'classic category'.
-	
-	class organization renameCategory: 'classic category' toBe: '*yyyyy'.
-	
+
+	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
+	self createMethodNamed: 'stubMethod2' inClass: class inCategory: 'classic category'.
+
+	class organization renameProtocolNamed: 'classic category' toBe: '*yyyyy'.
+
 	self assert: (YPackage includesExtensionSelector: #stubMethod ofClass: class).
 	self assert: (YPackage includesExtensionSelector: #stubMethod2 ofClass: class).
 	self deny: (XPackage includesDefinedSelector: #stubMethod ofClass: class).
-	self deny: (XPackage includesDefinedSelector: #stubMethod2 ofClass: class).
+	self deny: (XPackage includesDefinedSelector: #stubMethod2 ofClass: class)
 ]
 
 { #category : #'tests - operations on protocols' }
 RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingClassicCategoryToExtensionCategoryMoveMethodsFromParentPackageToExtendingPackage [
 	"test that when we reoganized a class by renaming a  classic category (a category not beginning with '*') to an extension category, all the methods are moved from the  parent package of the class to the extending package"
 
-	|XPackage YPackage class| 
+	| XPackage YPackage class |
 	self addXYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
-	YPackage  := self organizer packageNamed: #YYYYY.
+	YPackage := self organizer packageNamed: #YYYYY.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	self createMethodNamed: 'stubMethod' inClass: class  inCategory: 'classic category'.
-	class organization renameCategory: 'classic category' toBe: '*yyyyy'.
+	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
+	class organization renameProtocolNamed: 'classic category' toBe: '*yyyyy'.
 	self assert: (YPackage includesExtensionSelector: #stubMethod ofClass: class).
 	self deny: (XPackage includesDefinedSelector: #stubMethod ofClass: class)
 ]
@@ -531,15 +532,15 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingClassicCatego
 { #category : #'tests - operations on protocols' }
 RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingExtensionCategoryToAnotherExtensionCategoryAddMethodsToTheNewPackage [
 	"test that when we reoganized a class by renaming an extension category (a category beginning with '*') to another extension category, all the methods are moved to the new extendingPackage"
-	
-	|XPackage YPackage ZPackage class| 
+
+	| XPackage YPackage ZPackage class |
 	self addXYZCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
-	YPackage  := self organizer packageNamed: #YYYYY.
-	ZPackage  := self organizer packageNamed: #ZZZZZ.
+	YPackage := self organizer packageNamed: #YYYYY.
+	ZPackage := self organizer packageNamed: #ZZZZZ.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	self createMethodNamed: 'stubMethod' inClass: class  inCategory: '*yyyyy'.
-	class organization renameCategory: '*yyyyy' toBe: '*zzzzz'.
+	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
+	class organization renameProtocolNamed: '*yyyyy' toBe: '*zzzzz'.
 	self assert: (ZPackage includesExtensionSelector: #stubMethod ofClass: class).
 	self deny: (YPackage includesExtensionSelector: #stubMethod ofClass: class).
 	self deny: (XPackage includesDefinedSelector: #stubMethod ofClass: class)
@@ -548,35 +549,35 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingExtensionCate
 { #category : #'tests - operations on protocols' }
 RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingExtensionCategoryToClassicCategoryMoveAllMethodsFromExtendingPackageToParentPackage [
 	"test that when we reoganized a class by renaming an extension category (a category beginning with '*') to a classic category, all the methods are moved from the  extendingPackage to the parent package of the class"
-	
-	|XPackage YPackage class| 
+
+	| XPackage YPackage class |
 	self addXYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
-	YPackage  := self organizer packageNamed: #YYYYY.
+	YPackage := self organizer packageNamed: #YYYYY.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	
-	self createMethodNamed: 'stubMethod' inClass: class  inCategory: '*yyyyy'.
-	self createMethodNamed: 'stubMethod2' inClass: class  inCategory: '*yyyyy'.
-	
-	class organization renameCategory: '*yyyyy' toBe: 'classic category'.
-	
+
+	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
+	self createMethodNamed: 'stubMethod2' inClass: class inCategory: '*yyyyy'.
+
+	class organization renameProtocolNamed: '*yyyyy' toBe: 'classic category'.
+
 	self deny: (YPackage includesExtensionSelector: #stubMethod ofClass: class).
 	self deny: (YPackage includesExtensionSelector: #stubMethod2 ofClass: class).
 	self assert: (XPackage includesDefinedSelector: #stubMethod ofClass: class).
-	self assert: (XPackage includesDefinedSelector: #stubMethod2 ofClass: class).
+	self assert: (XPackage includesDefinedSelector: #stubMethod2 ofClass: class)
 ]
 
 { #category : #'tests - operations on protocols' }
 RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingExtensionCategoryToClassicCategoryMoveMethodsFromExtendingPackageToParentPackage [
 	"test that when we reoganized a class by renaming an extension category (a category beginning with '*') to a classic category, all the methods are moved from the  extendingPackage to the parent package of the class"
-	
-	|XPackage YPackage class| 
+
+	| XPackage YPackage class |
 	self addXYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
-	YPackage  := self organizer packageNamed: #YYYYY.
+	YPackage := self organizer packageNamed: #YYYYY.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	self createMethodNamed: 'stubMethod' inClass: class  inCategory: '*yyyyy'.
-	class organization renameCategory: '*yyyyy' toBe: 'classic category'.
+	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
+	class organization renameProtocolNamed: '*yyyyy' toBe: 'classic category'.
 	self deny: (YPackage includesExtensionSelector: #stubMethod ofClass: class).
 	self assert: (XPackage includesDefinedSelector: #stubMethod ofClass: class)
 ]

--- a/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
@@ -51,26 +51,22 @@ RPackageClassesSynchronisationTest >> testAddClassUpdateTheOrganizerMappings [
 { #category : #'tests - recategorizing class' }
 RPackageClassesSynchronisationTest >> testRecategorizeClassRaisesClassRepackagedEvent [
 	"test that when we recategorize a class, the organizer is updated so that the class name point the the new RPackage"
-	
+
 	| XPackage YPackage class ann |
-	
 	ann := nil.
-	SystemAnnouncer uniqueInstance
-		when: ClassRepackaged do: [ :a |
-			ann := a.
-		].
-	
+	SystemAnnouncer uniqueInstance weak when: ClassRepackaged do: [ :a | ann := a ].
+
 	self addXCategory.
 	self addYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
 	YPackage := self organizer packageNamed: #YYYYY.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	class category: 'YYYYY'.	
-	
+	class category: 'YYYYY'.
+
 	self assert: ann notNil.
 	self assert: ann classRepackaged equals: class.
 	self assert: ann oldPackage equals: XPackage.
-	self assert: ann newPackage equals: YPackage.
+	self assert: ann newPackage equals: YPackage
 ]
 
 { #category : #'tests - recategorizing class' }

--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -199,9 +199,11 @@ RPackageMCSynchronisationTest >> setUp [
 
 { #category : #running }
 RPackageMCSynchronisationTest >> tearDown [
+
 	MCWorkingCopy removeDependent: self emptyOrganizer.
 	self cleanClassesPackagesAndCategories.
-	super tearDown.
+	SystemAnnouncer uniqueInstance unsubscribe: self.
+	super tearDown
 ]
 
 { #category : #tests }
@@ -230,66 +232,60 @@ RPackageMCSynchronisationTest >> testIsDefinedAsPackageOrSubPackageInMC [
 
 { #category : #'to move to a simple RPackage test case' }
 RPackageMCSynchronisationTest >> testNotRepackagedAnnouncementWhenModifyMethodByMovingInSameExtensionCategory [
-	
-	| ann class firstPackage secondPackage|
-	
+
+	| ann class firstPackage secondPackage |
 	ann := nil.
-	SystemAnnouncer uniqueInstance
-		when: MethodRepackaged do: [ :a | ann := a ].
-	
-	self addXYCategory. 
-	firstPackage := self organizer  packageNamed: #XXXXX.
-	secondPackage := self organizer  packageNamed: #YYYYY.
+	SystemAnnouncer uniqueInstance weak when: MethodRepackaged do: [ :a | ann := a ].
+
+	self addXYCategory.
+	firstPackage := self organizer packageNamed: #XXXXX.
+	secondPackage := self organizer packageNamed: #YYYYY.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
 
-	self createMethodNamed: 'stubMethod' inClass:  class inCategory: '*yyyyy'.
-	
+	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
+
 	self assert: ann isNil.
 
 	class organization classify: #stubMethod under: '*yyyyy-suncategory'.
 
-	self assert: ann isNil.
+	self assert: ann isNil
 ]
 
 { #category : #'to move to a simple RPackage test case' }
 RPackageMCSynchronisationTest >> testNotRepackagedAnnouncementWhenMovingClassicCategories [
 
-	| ann class firstPackage secondPackage|
-	
+	| ann class firstPackage secondPackage |
 	ann := nil.
-	SystemAnnouncer uniqueInstance
-		when: MethodRepackaged do: [ :a | ann := a ].
-	
-	self addXYCategory. 
-	firstPackage := self organizer  packageNamed: #XXXXX.
-	secondPackage := self organizer  packageNamed: #YYYYY.
+	SystemAnnouncer uniqueInstance weak when: MethodRepackaged do: [ :a | ann := a ].
+
+	self addXYCategory.
+	firstPackage := self organizer packageNamed: #XXXXX.
+	secondPackage := self organizer packageNamed: #YYYYY.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
 
-	self createMethodNamed: 'stubMethod' inClass:  class inCategory: 'classic'.
-	
+	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic'.
+
 	self assert: ann isNil.
 
 	class organization classify: #stubMethod under: 'another classic one'.
 
-	self assert: ann isNil.
+	self assert: ann isNil
 ]
 
 { #category : #'to move to a simple RPackage test case' }
 RPackageMCSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMovingFromClassicCategoryToExtensionCategory [
-	
-	| ann class firstPackage secondPackage|
-	
+
+	| ann class firstPackage secondPackage |
 	ann := nil.
-	SystemAnnouncer uniqueInstance
-		when: MethodRepackaged do: [ :a | ann := a ].
-	
-	self addXYCategory. 
-	firstPackage := self organizer  packageNamed: #XXXXX.
-	secondPackage := self organizer  packageNamed: #YYYYY.
+	SystemAnnouncer uniqueInstance weak when: MethodRepackaged do: [ :a | ann := a ].
+
+	self addXYCategory.
+	firstPackage := self organizer packageNamed: #XXXXX.
+	secondPackage := self organizer packageNamed: #YYYYY.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	self createMethodNamed: 'stubMethod' inClass:  class inCategory: 'classic category'.
-	
-	class organization classify: #stubMethod under: '*yyyyy'.		
+	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
+
+	class organization classify: #stubMethod under: '*yyyyy'.
 
 	self assert: ann notNil.
 	self assert: ann methodRepackaged selector equals: #stubMethod.
@@ -299,53 +295,49 @@ RPackageMCSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMov
 
 	class organization classify: #stubMethod under: '*yyyyy-suncategory'.
 
-	self assert: ann isNil.
+	self assert: ann isNil
 ]
 
 { #category : #'to move to a simple RPackage test case' }
 RPackageMCSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMovingFromDifferentExtensionCategories [
 
 	| ann class firstPackage secondPackage thirdPackage |
-	
 	ann := nil.
-	SystemAnnouncer uniqueInstance
-		when: MethodRepackaged do: [ :a | ann := a ].
-	
-	self addXYZCategory. 
-	firstPackage := self organizer  packageNamed: #XXXXX.
+	SystemAnnouncer uniqueInstance weak when: MethodRepackaged do: [ :a | ann := a ].
+
+	self addXYZCategory.
+	firstPackage := self organizer packageNamed: #XXXXX.
 	secondPackage := self organizer packageNamed: #YYYYY.
 	thirdPackage := self organizer packageNamed: #ZZZZZ.
-	
+
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	self createMethodNamed: 'stubMethod' inClass:  class inCategory: '*yyyyy'.
-	
+	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
+
 	class organization classify: #stubMethod under: '*zzzzz'.
 
 	self assert: ann notNil.
 	self assert: ann methodRepackaged selector equals: #stubMethod.
 	self assert: ann oldPackage equals: secondPackage.
-	self assert: ann newPackage equals: thirdPackage.
+	self assert: ann newPackage equals: thirdPackage
 ]
 
 { #category : #'to move to a simple RPackage test case' }
 RPackageMCSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMovingFromExtensionCategoryToClassicCategory [
 
-	| ann class firstPackage secondPackage|
-	
+	| ann class firstPackage secondPackage |
 	ann := nil.
-	SystemAnnouncer uniqueInstance
-		when: MethodRepackaged do: [ :a | ann := a ].
-	
-	self addXYCategory. 
-	firstPackage := self organizer  packageNamed: #XXXXX.
-	secondPackage := self organizer  packageNamed: #YYYYY.
+	SystemAnnouncer uniqueInstance weak when: MethodRepackaged do: [ :a | ann := a ].
+
+	self addXYCategory.
+	firstPackage := self organizer packageNamed: #XXXXX.
+	secondPackage := self organizer packageNamed: #YYYYY.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	self createMethodNamed: 'stubMethod' inClass:  class inCategory: '*yyyyy'.
-	
-	class organization classify: #stubMethod under: 'classic one'.		
+	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
+
+	class organization classify: #stubMethod under: 'classic one'.
 
 	self assert: ann notNil.
 	self assert: ann methodRepackaged selector equals: #stubMethod.
 	self assert: ann oldPackage equals: secondPackage.
-	self assert: ann newPackage equals: firstPackage.
+	self assert: ann newPackage equals: firstPackage
 ]

--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -160,16 +160,30 @@ RPackageMCSynchronisationTest >> emptyOrganizer [
 
 { #category : #'announcer handling' }
 RPackageMCSynchronisationTest >> initializeAnnouncers [
-	super initializeAnnouncers.
-	
+
 	oldAnnouncer := MCWorkingCopy announcer.
-	MCWorkingCopy announcer: announcerForTest.
+	MCWorkingCopy announcer: SystemAnnouncer uniqueInstance
 ]
 
 { #category : #'announcer handling' }
 RPackageMCSynchronisationTest >> restoreAnnouncers [
-	super restoreAnnouncers.
-	MCWorkingCopy announcer: oldAnnouncer.
+
+	MCWorkingCopy announcer: oldAnnouncer
+]
+
+{ #category : #running }
+RPackageMCSynchronisationTest >> runCase [
+
+	[
+	self initializeAnnouncers.
+
+	^ self packageClass withOrganizer: self setupOrganizer do: [
+		  self resources do: [ :each | each availableFor: self ].
+		  self setUp.
+		  self performTest ] ] ensure: [
+		self tearDown.
+		self restoreAnnouncers.
+		self cleanUpInstanceVariables ]
 ]
 
 { #category : #running }

--- a/src/RPackage-Tests/RPackageObsoleteTest.class.st
+++ b/src/RPackage-Tests/RPackageObsoleteTest.class.st
@@ -17,15 +17,15 @@ RPackageObsoleteTest >> setNotRun [
 
 { #category : #tests }
 RPackageObsoleteTest >> testAnnouncementClassRemovedIsRaisedOnRemoveFromSystem [
+
 	| foo |
-	[ notRun := false.
-	  SystemAnnouncer uniqueInstance
-		when: ClassRemoved send: #setNotRun to: self.
+	[
+	notRun := false.
+	SystemAnnouncer uniqueInstance weak when: ClassRemoved send: #setNotRun to: self.
 	foo := self createNewClassNamed: #FooForTest2.
 	self deny: notRun.
 	foo removeFromSystem.
-	self assert: notRun ]
-ensure: [ SystemAnnouncer uniqueInstance unsubscribe: self ]
+	self assert: notRun ] ensure: [ SystemAnnouncer uniqueInstance unsubscribe: self ]
 ]
 
 { #category : #tests }

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -34,7 +34,7 @@ RPackageTest >> testAddClass [
 	package1 := (RPackage named: #Test1) register.
 	done := 0.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG'.
-	SystemAnnouncer uniqueInstance when: ClassRecategorized do: [ done := done + 1].
+	SystemAnnouncer uniqueInstance weak when: ClassRecategorized do: [ done := done + 1].
 
 	self assert: (package1 includesClass: class).
 	self assert: (package1 classTagNamed: #TAG ifAbsent: [ nil ]) notNil.

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -5,8 +5,6 @@ Class {
 	#name : #RPackageTestCase,
 	#superclass : #AbstractEnvironmentTestCase,
 	#instVars : [
-		'announcerForTest',
-		'oldSystemAnnouncer',
 		'createdClasses',
 		'createdPackages',
 		'createdCategories'
@@ -93,13 +91,6 @@ RPackageTestCase >> createNewTraitNamed: aName inPackage: p [
 	^ cls
 ]
 
-{ #category : #'announcer handling' }
-RPackageTestCase >> initializeAnnouncers [
-	oldSystemAnnouncer := SystemAnnouncer uniqueInstance.
-
-	SystemAnnouncer announcer: (announcerForTest := SystemAnnouncer new)
-]
-
 { #category : #utilities }
 RPackageTestCase >> namesOfMockTestPackages [
 
@@ -129,28 +120,16 @@ RPackageTestCase >> removePackage: aName [
 	self packageClass organizer basicUnregisterPackageNamed: aName
 ]
 
-{ #category : #'announcer handling' }
-RPackageTestCase >> restoreAnnouncers [
-	SystemAnnouncer announcer: oldSystemAnnouncer
-]
-
 { #category : #running }
 RPackageTestCase >> runCase [
-	[
-	self initializeAnnouncers.
 
-	^ self packageClass
-		withOrganizer: self setupOrganizer
-		do: [
-			self resources do: [:each | each availableFor: self].
-			self setUp.
-			self performTest
-			]
-	] ensure: [
+	[
+	^ self packageClass withOrganizer: self setupOrganizer do: [
+		  self resources do: [ :each | each availableFor: self ].
+		  self setUp.
+		  self performTest ] ] ensure: [
 		self tearDown.
-		self restoreAnnouncers.
-		self cleanUpInstanceVariables
-	]
+		self cleanUpInstanceVariables ]
 ]
 
 { #category : #running }


### PR DESCRIPTION
RPackage tests were disable the system announcer but this causes multiple problems such as:
- Automatic transformation was happening but no tool were aware of it (Calypso did not update the source, Iceberg did not catch the change...)
- Coding in debugger was dangerous because no system announcements were happening 
- The system was vulnerable during the execution of those tests

So I propose to just keep the system announcer while testing RPackage

Also I shipped some deprecation rewrites now that Iceberg notice them :)