### PR TITLE
Use date and time as Stdio windows file name distinguisher

### DIFF
--- a/src/Files/ManifestFiles.class.st
+++ b/src/Files/ManifestFiles.class.st
@@ -9,7 +9,9 @@ Class {
 
 { #category : #'meta-data - dependency analyser' }
 ManifestFiles class >> manuallyResolvedDependencies [
-	^ #(#'System-Support' #'Zinc-Character-Encoding-Core' #'FileSystem-Core' #'Collections-Abstract' #'System-Platforms')
+
+	<ignoreForCoverage>
+	^ #(#'Kernel-Chronology-Extras' #'Collections-Abstract' #'System-Platforms' #'System-Support')
 ]
 
 { #category : #'code-critics' }

--- a/src/Files/Stdio.class.st
+++ b/src/Files/Stdio.class.st
@@ -43,13 +43,14 @@ Stdio class >> cleanStdioHandles [
 
 { #category : #private }
 Stdio class >> createStdioFileFor: moniker [
-	^ [[ self createWriteStreamBlock cull: moniker asString ]
-		on: CannotDeleteFileException
-		do:
-			[ "HACK: if the image is opened a second time windows barks about the already opened locked file"
-			 self createWriteStreamBlock
-				cull: moniker asString , '_' , (Random new nextInteger: SmallInteger maxVal) asString ]
-	 ] on: FileException do: [ NullStream new ]
+
+	^ [
+	  [ self createWriteStreamBlock cull: moniker asString ]
+		  on: CannotDeleteFileException
+		  do: [ "HACK: if the image is opened a second time windows barks about the already opened locked file"
+			  self createWriteStreamBlock cull: moniker asString , '_' , DateAndTime now asFileNameCompatibleString ] ]
+		  on: FileException
+		  do: [ NullStream new ]
 ]
 
 { #category : #accessing }

--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -593,6 +593,16 @@ SystemDependenciesTest >> testExternalUIDependencies [
 	self assertCollection: dependencies hasSameElements: self knownUIDependencies
 ]
 
+{ #category : #tests }
+SystemDependenciesTest >> testFilesShouldNotDependOnRandom [
+	"In the past Files was depending on Random-Core only to print a random number in a file name.
+	Now, there is no dependency between Files and Random-Core and if possible we would like to keep it this way in order to extract Random-Core from the KernelGroup of the Bootstrap (and maybe of the bootstrap in itself generally)"
+
+	| dependencies |
+	dependencies := self externalDependendiesOf: #( 'Files' ).
+	self deny: (dependencies includes: 'Random-Core')
+]
+
 { #category : #accessing }
 SystemDependenciesTest >> tonelCorePackageNames [
 


### PR DESCRIPTION
Stdio on windows will sometimes create a new file and since we can have multiple ones, we were generating a random number in the file name. Since the is the only dependency to Random-Core and that I would like to extract it from the KernelGroup of the bootstrap, I propose to use a timestamp instead.

I also added a test to be sure the dependency does not get added again. One last change is the update of the manually resolved dependencies of Files package