### PR TITLE
Vocabulary: propose "script" in compiler

### DIFF
--- a/src/Debugger-Model-Tests/StepIntoTest.class.st
+++ b/src/Debugger-Model-Tests/StepIntoTest.class.st
@@ -42,7 +42,7 @@ StepIntoTest >> testStepIntoDoIt [
 
 	| method node |
 	method := nil compiler
-		          noPattern: true;
+		          isScripting: true;
 		          compile: '| a b | a := 40. b := a + 2. ^ b'.
 	self settingUpSessionAndProcessAndContextForBlock: [
 		nil executeMethod: method ].

--- a/src/Debugger-Model/DebugContext.class.st
+++ b/src/Debugger-Model/DebugContext.class.st
@@ -156,7 +156,7 @@ DebugContext >> recompileCurrentMethodTo: aText notifying: aNotifyer [
 	self context method isInstalled ifFalse: [
 		^ self selectedClass compiler
 			protocol: self selectedMessageCategoryName;
-			noPattern: self selectedMessageName isDoIt;
+			isScripting: self selectedMessageName isDoIt;
 			requestor: aNotifyer;
 			compile: aText.
 	].
@@ -166,7 +166,7 @@ DebugContext >> recompileCurrentMethodTo: aText notifying: aNotifyer [
 
 	^ classOrTraitOfMethod compiler
 		protocol: self selectedMessageCategoryName;
-		noPattern: self selectedMessageName isDoIt;
+		isScripting: self selectedMessageName isDoIt;
 		requestor: aNotifyer;
 		install: aText.
 

--- a/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
@@ -71,7 +71,7 @@ CoASTResultSetBuilder >> parseNode [
 	^ node ifNil: [
 		(completionContext completionClass compiler
 			source: completionContext source;
-			noPattern: completionContext isScripting;
+			isScripting: completionContext isScripting;
 			parse) nodeForOffset: completionContext position ]
 ]
 

--- a/src/Monticello-Tests/MCStWriterTest.class.st
+++ b/src/Monticello-Tests/MCStWriterTest.class.st
@@ -19,7 +19,7 @@ MCStWriterTest >> assertChunkIsWellFormed: chunk [
 	self class compiler
 		source: chunk;
 		class: UndefinedObject;
-		noPattern: true;
+		isScripting: true;
 		compile
 ]
 

--- a/src/NECompletion/CompletionContext.class.st
+++ b/src/NECompletion/CompletionContext.class.st
@@ -124,7 +124,7 @@ CompletionContext >> node [
 CompletionContext >> parseSource [
 	ast := class compiler
 		source: source;
-		noPattern: self isScripting;
+		isScripting: self isScripting;
 		parse.
 	TypingVisitor new visitNode: ast
 ]

--- a/src/OpalCompiler-Core/Context.extension.st
+++ b/src/OpalCompiler-Core/Context.extension.st
@@ -19,6 +19,14 @@ Context >> astScope [
 ]
 
 { #category : #'*OpalCompiler-Core' }
+Context >> compiler [
+	"Return a compiler set up to parse/compile/evaluate scripts on the current context.
+	The compiler is also setup according to the class of the receiver"
+
+	^ self receiver class compiler context: self
+]
+
+{ #category : #'*OpalCompiler-Core' }
 Context >> executedPC [
 	"Deeper in the stack the pc was already advanced one bytecode, so we need to go back
 	this one bytecode, which can consist of multiple bytes. But on IR, we record the *last*

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -416,7 +416,7 @@ OpalCompiler >> evaluate [
 	 the system no longer creates Doit method litter on errors."
 
 	| value doItMethod |
-	self noPattern: true.
+	self isScripting: true.
 	doItMethod := self compile.
 	ast ifNil: [ ^ doItMethod ].
 	value := self semanticScope evaluateDoIt: doItMethod.
@@ -515,7 +515,7 @@ OpalCompiler >> logged: aBoolean [
 
 { #category : #accessing }
 OpalCompiler >> noPattern: aBoolean [
-	self compilationContext noPattern: aBoolean
+	self isScripting: aBoolean
 ]
 
 { #category : #'public access' }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -499,6 +499,11 @@ OpalCompiler >> install: aSource [
 ]
 
 { #category : #accessing }
+OpalCompiler >> isScripting: aBoolean [
+	self compilationContext noPattern: aBoolean
+]
+
+{ #category : #accessing }
 OpalCompiler >> logged [
 	^ logged
 ]
@@ -563,6 +568,13 @@ OpalCompiler >> parse: textOrString [
 { #category : #'public access' }
 OpalCompiler >> parseLiterals: aString [
 	^self parserClass parseLiterals: aString
+]
+
+{ #category : #'public access' }
+OpalCompiler >> parseScript: aString [
+
+	self isScripting: true.
+	^ self parse: aString
 ]
 
 { #category : #'public access' }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -499,6 +499,11 @@ OpalCompiler >> install: aSource [
 ]
 
 { #category : #accessing }
+OpalCompiler >> isScripting [
+	^ self compilationContext noPattern
+]
+
+{ #category : #accessing }
 OpalCompiler >> isScripting: aBoolean [
 	self compilationContext noPattern: aBoolean
 ]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -371,6 +371,11 @@ OpalCompiler >> compiledMethodTrailer: bytes [
 
 { #category : #accessing }
 OpalCompiler >> context: aContext [
+	"Prepare self to parse/compile/evaluate according to a context.
+	This impacts the scope (for name resolutions) and toggles `isScripting` to true.
+	Note that you may prefer to use `Context>>#compiler` that also takes in account
+	the compilation preferences of the class of the receiver (e.g. plugins)."
+
 	aContext ifNil: [
 		"There are such users which sets up all parameters (doItContext and doItReceiver).
 		For example check SpCodePresenter>>#evaluate:onCompileError:onError:.

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -525,6 +525,11 @@ OpalCompiler >> logged: aBoolean [
 
 { #category : #accessing }
 OpalCompiler >> noPattern: aBoolean [
+
+	self
+		deprecated: 'Use #isScripting: instead'
+		transformWith: '`@receiver noPattern: `@arg' -> '`@receiver isScripting: `@arg'.
+
 	self isScripting: aBoolean
 ]
 

--- a/src/OpalCompiler-Tests/OCCompileWithFailureTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompileWithFailureTest.class.st
@@ -22,7 +22,7 @@ OCCompileWithFailureTest >> testEmptyBlockArg [
 	"parse [:] in parse error mode, this results in arg vars with an empty string as a name"
 	result := UndefinedObject compiler
     source: '^[ :]';
-    noPattern: true;
+    isScripting: true;
     requestor: self;
     parse.
 	self assert: result isDoIt.
@@ -48,7 +48,7 @@ OCCompileWithFailureTest >> testParenthesis [
 	| result cm |
 	result := UndefinedObject compiler
     source: 'self assert: pragma( numArgs equals: 0.';
-    noPattern: true;
+    isScripting: true;
     requestor: self;
     parse.
 	self assert: result isDoIt.

--- a/src/OpalCompiler-Tests/OCDoitTest.class.st
+++ b/src/OpalCompiler-Tests/OCDoitTest.class.st
@@ -116,10 +116,8 @@ OCDoitTest >> testDoItRequestorReadRequestorVar [
 	| value  |
 	"we can read a variable from a requestor"
 	value := OpalCompiler new
-		          source: 'requestorVarForTesting';
-		          noPattern: true;
 		          requestor: self;
-		          evaluate.
+		          evaluate: 'requestorVarForTesting'.
 
 	self assert: value equals: 5
 ]
@@ -130,10 +128,8 @@ OCDoitTest >> testDoItRequestorShadow [
 	| value  |
 	"we can shadow a var defined in the requestor without error"
 	value := OpalCompiler new
-		          source: '|requestorVarForTesting| requestorVarForTesting';
-		          noPattern: true;
 		          requestor: self;
-		          evaluate.
+		          evaluate: '|requestorVarForTesting| requestorVarForTesting'.
 
 	self assert: value equals: nil
 ]

--- a/src/OpalCompiler-Tests/OCDoitTest.class.st
+++ b/src/OpalCompiler-Tests/OCDoitTest.class.st
@@ -34,11 +34,7 @@ OCDoitTest >> testDoItContextReadGlobal [
 	"we can read a global from a doit when executing against a context"
 
 	|  value |
-	value := OpalCompiler new
-		source: 'Object';
-		context: thisContext;
-		evaluate.
-
+	value := thisContext compiler evaluate: 'Object'.
 	self assert: value equals: Object
 ]
 
@@ -49,12 +45,7 @@ OCDoitTest >> testDoItContextReadIvar [
 	"we can read this ivar from a doit when executing against thisContext"
 	ivarForTesting := #someValue.
 
-	method := OpalCompiler new
-		          source: 'ivarForTesting';
-		          noPattern: true;
-		          context: thisContext;
-		          compile.
-
+	method := thisContext compiler compile: 'ivarForTesting'.
 	value := method valueWithReceiver: self arguments: #().
 	self assert: value equals: #someValue
 ]
@@ -65,10 +56,7 @@ OCDoitTest >> testDoItContextReadTemp [
 	"we can read this temp from a doit when executing against thisContext"
 	tempForTesting := #someValue.
 
-	value := OpalCompiler new
-		source: 'tempForTesting';
-		context: thisContext;
-		evaluate.
+	value := thisContext compiler evaluate: 'tempForTesting'.
 
 	self assert: value equals: #someValue
 ]
@@ -139,11 +127,7 @@ OCDoitTest >> testDoitContextCheckClass [
 	"if we create a parse tree for a doit in a context, the class should be correctly set"
 
 	| ast method |
-	method := OpalCompiler new
-		source: 'true';
-		noPattern: true;
-		context: thisContext;
-		compile.
+	method := thisContext compiler compile: 'self'.
 	ast := method ast.
 	"we expect that the class is set to the class of the context, which is self class"
 	self assert: ast methodClass equals: self class

--- a/src/OpalCompiler-Tests/RBCodeSnippet.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippet.extension.st
@@ -5,7 +5,7 @@ RBCodeSnippet >> compile [
 
 	^ [ OpalCompiler new
 		  permitFaulty: true;
-		  noPattern: isMethod not;
+		  isScripting: isMethod not;
 		  compile: self source ]
 	on: CodeError do: [ :e |
 		"Compilation should success, because its the *faulty* mode".
@@ -19,7 +19,7 @@ RBCodeSnippet >> compile [
 RBCodeSnippet >> compileOnError: aBlock [
 
 	^ [ OpalCompiler new
-		  noPattern: isMethod not;
+		  isScripting: isMethod not;
 		  compile: self source ] on: CodeError do: [ :e | aBlock cull: e ]
 ]
 
@@ -34,7 +34,7 @@ RBCodeSnippet >> doSemanticAnalysis [
 	So just ask the compiler."
 
 	^ OpalCompiler new
-		  noPattern: isMethod not;
+		  isScripting: isMethod not;
 		  parse: self source "Note: `parse:` also does the semantic analysis and return the AST"
 ]
 
@@ -42,7 +42,7 @@ RBCodeSnippet >> doSemanticAnalysis [
 RBCodeSnippet >> doSemanticAnalysisOnError: aBlock [
 
 	^ [ OpalCompiler new
-		  noPattern: isMethod not;
+		  isScripting: isMethod not;
 		  permitFaulty: false;
 		  parse: self source ] on: CodeError do: [ :e | aBlock value: e ]
 ]

--- a/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
@@ -6,7 +6,7 @@ RBCodeSnippetTest >> testCompileFailBlock [
 	| method error |
 	error := nil.
 	method := OpalCompiler new
-		          noPattern: snippet isMethod not;
+		          isScripting: snippet isMethod not;
 		          failBlock: [ :e |
 			          self assert: (snippet hasNotice: e).
 			          self assert: error isNil. "single invocation"
@@ -87,7 +87,7 @@ RBCodeSnippetTest >> testCompileUndeclaredFaultyFailBlock [
 	| method error |
 	error := nil.
 	method := OpalCompiler new
-		          noPattern: snippet isMethod not;
+		          isScripting: snippet isMethod not;
 		          permitUndeclared: true;
 		          failBlock: [ :e |
 			          self assert: (snippet hasNotice: e).
@@ -115,7 +115,7 @@ RBCodeSnippetTest >> testCompileWithRequestor [
 	requestor isScripting: nil.
 	requestor text: nil.
 	method := OpalCompiler new
-		          noPattern: snippet isMethod not;
+		          isScripting: snippet isMethod not;
 		          requestor: requestor;
 		          failBlock: [ "When a requestion is set, a failBlock MUST also be set or compilation might crash internally"
 			          | n |

--- a/src/ProfilerUI/ProfilerModel.class.st
+++ b/src/ProfilerUI/ProfilerModel.class.st
@@ -156,9 +156,8 @@ ProfilerModel >> profileCode: someCode notifying: requestor [
 
 	compiledMethod := Smalltalk compiler
 		                  source: (self doItSourceCodeFrom: someCode);
-		                  context: nil;
 		                  requestor: requestor;
-		                  noPattern: true;
+		                  isScripting: true;
 		                  failBlock: [ ^ self ];
 		                  compile.
 	compiledMethod valueWithReceiver: self arguments: #(  )

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -320,7 +320,7 @@ RubSmalltalkEditor >> compile: aStream for: anObject in: evalContext [
 		source: aStream;
 		class: methodClass;
 		context: evalContext;
-		noPattern: true;
+		isScripting: true;
 		permitFaulty: true;
 		compile
 ]

--- a/src/Shout-Tests/SHRBStyleAttributionTest.class.st
+++ b/src/Shout-Tests/SHRBStyleAttributionTest.class.st
@@ -42,11 +42,7 @@ SHRBStyleAttributionTest >> setUp [
 SHRBStyleAttributionTest >> style: aText [
 
 	| ast |
-	ast := self class compiler
-		       source: aText asString;
-		       noPattern: false;
-		       class: self class;
-		       parse.
+	ast := self class compiler parse: aText asString.
 	styler style: aText ast: ast.
 
 	^ ast

--- a/src/Shout-Tests/SHRBTextStylerTest.class.st
+++ b/src/Shout-Tests/SHRBTextStylerTest.class.st
@@ -21,10 +21,7 @@ SHRBTextStylerTest >> style: aText [
 
 	| ast |
 
-	ast := self class compiler
-		source: aText asString;
-		noPattern: false ;
-		parse.
+	ast := self class compiler parse: aText asString.
 	styler style: aText ast: ast.
 
 	^ ast

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -791,7 +791,7 @@ SHRBTextStyler >> privateStyle: aText [
 	aText ifEmpty: [ ^ self ].
 	compiler := classOrMetaClass compiler
 		source: aText asString;
-		noPattern: self isForWorkspace ;
+		isScripting: self isForWorkspace;
 		requestor: workspace.
 
 	self plugins do: [ :each | compiler addParsePlugin: each ].

--- a/src/Slot-Tests/DoItVariableTest.class.st
+++ b/src/Slot-Tests/DoItVariableTest.class.st
@@ -46,7 +46,7 @@ DoItVariableTest >> testDoItCompilation [
 	doIt := thisContext class compiler
 		source: 'temp + 2';
 		context: thisContext;
-		noPattern: true;
+		isScripting: true;
 		bindings: { var };
 		compile.
 	self assert: (doIt valueWithReceiver: self arguments: #()) equals: 102

--- a/src/Tool-Profilers/TimeProfiler.class.st
+++ b/src/Tool-Profilers/TimeProfiler.class.st
@@ -164,7 +164,6 @@ TimeProfiler >> blockCode: aString notifying: aRequestor [
 		source: ('self runBlock: [', aString, ']');
 		context: self doItContext;
 		requestor: self;
-		noPattern: true;
 		failBlock: [^self];
 		compile.
 	self showResult: ( compiledMethod valueWithReceiver: self arguments: #()).


### PR DESCRIPTION
`OpalCompiler>>noPattern` is historic and bad:

 * it conflicts with *pattern code* the thing with ``` ` ``` and `@` to match AST (in rewriting tools for instance)
 * it has a negation, and you should not have a negation in the name of boolean flag
 * I'm not sure that all people understand what the method pattern is
 
I tried to look at various parts of the Pharo tools to see what is the used vocabulary.

* `RBParser` use `expression`, like in `parseExpression` That is ok but misleading since sequences of statements (`|x| x:=self. x bar`) or return statements (`^ 42`) are parsed the same but technically aren't expressions. See  #7233
* `ExpressionEvaluated` is a `SystemAnnouncement` used when someone runs a DoIt (or other action). (I do not understand why you need to announce them, but it's not the focus here)
* `CodeImport` use `DoIt`, like in `DoItChunk`. That is better than `noPattern` but maybe too specific?
* Various GUI editor seems to use `isScripting`, or `beForScripting` I kind of like it (see title)
* `Monticello` use `script`, like in `MCScriptDefinition` and related
* but `Metacello` seems to use `DoIt`, as in `preLoadDoIt`
* `SHRBTextStyler` have `isForWorkspace`, that can be used to highlight source code outside the workspace :) and seems the only one to use "workspace" this way.
* Surprisingly, `playground` seems not used
* `script:` is also a pragma, that takes a string to evaluate

Since I'm cleaning up the compiler API, I would like to have your input.
And if nobody cares, I will go ahead with "script".
The commit is a simple preview of what it might look like.