### PR TITLE
Compiler simplify OCSemanticScope

### DIFF
--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -542,11 +542,9 @@ CompilationContext >> noPattern [
 
 { #category : #accessing }
 CompilationContext >> noPattern: anObject [
-	anObject ifTrue: [
-		semanticScope := semanticScope asDoItScope.
-		"when we compile an expression, embedd sources, as the resulting method will never be installed"
-		self parseOptions: #(+ #optionEmbeddSources).
-	 ]
+
+	(anObject and: [ self noPattern not ]) ifTrue: [
+		semanticScope := OCReceiverDoItSemanticScope targetingNilReceiver ]
 ]
 
 { #category : #options }

--- a/src/OpalCompiler-Core/OCContextualDoItSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCContextualDoItSemanticScope.class.st
@@ -37,14 +37,6 @@ OCContextualDoItSemanticScope >> announceDoItEvaluation: aSourceString by: aSyst
 	aSystemAnnouncer evaluated: aSourceString context: targetContext
 ]
 
-{ #category : #converting }
-OCContextualDoItSemanticScope >> asDoItScopeForReceiver: anObject [
-	anObject == targetContext receiver ifFalse: [
-		self error: 'Receiver is not same as context receiver' ].
-
-	^self
-]
-
 { #category : #testing }
 OCContextualDoItSemanticScope >> hasBindingThatBeginsWith: aString [
 

--- a/src/OpalCompiler-Core/OCDoItSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCDoItSemanticScope.class.st
@@ -31,12 +31,6 @@ OCDoItSemanticScope >> isDoItScope [
 	^true
 ]
 
-{ #category : #parsing }
-OCDoItSemanticScope >> parseASTBy: aParser [
-
-	^aParser parseDoIt
-]
-
 { #category : #accessing }
 OCDoItSemanticScope >> receiver [
 	^ self subclassResponsibility

--- a/src/OpalCompiler-Core/OCDoItSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCDoItSemanticScope.class.st
@@ -20,11 +20,6 @@ OCDoItSemanticScope class >> isAbstract [
 	^self = OCDoItSemanticScope
 ]
 
-{ #category : #converting }
-OCDoItSemanticScope >> asDoItScope [
-	^self
-]
-
 { #category : #'code evaluation' }
 OCDoItSemanticScope >> evaluateDoIt: doItMethod [
 

--- a/src/OpalCompiler-Core/OCMethodSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCMethodSemanticScope.class.st
@@ -22,11 +22,6 @@ OCMethodSemanticScope class >> targetingClass: aClass [
 		targetClass: aClass
 ]
 
-{ #category : #converting }
-OCMethodSemanticScope >> asDoItScope [
-	^self asDoItScopeForReceiver: nil
-]
-
 { #category : #'code compilation' }
 OCMethodSemanticScope >> parseASTBy: aParser [
 

--- a/src/OpalCompiler-Core/OCMethodSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCMethodSemanticScope.class.st
@@ -22,12 +22,6 @@ OCMethodSemanticScope class >> targetingClass: aClass [
 		targetClass: aClass
 ]
 
-{ #category : #'code compilation' }
-OCMethodSemanticScope >> parseASTBy: aParser [
-
-	^aParser parseMethod
-]
-
 { #category : #accessing }
 OCMethodSemanticScope >> targetClass [
 

--- a/src/OpalCompiler-Core/OCSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCSemanticScope.class.st
@@ -47,21 +47,6 @@ OCSemanticScope >> announceDoItEvaluation: aSourceString by: aSystemAnnouncer [
 	aSystemAnnouncer evaluated: aSourceString context: nil
 ]
 
-{ #category : #converting }
-OCSemanticScope >> asDoItScope [
-	self subclassResponsibility
-]
-
-{ #category : #converting }
-OCSemanticScope >> asDoItScopeForContext: aContext [
-	^OCContextualDoItSemanticScope targetingContext: aContext
-]
-
-{ #category : #converting }
-OCSemanticScope >> asDoItScopeForReceiver: anObject [
-	^OCReceiverDoItSemanticScope targetingReceiver: anObject
-]
-
 { #category : #testing }
 OCSemanticScope >> hasBindingThatBeginsWith: aString [
 

--- a/src/OpalCompiler-Core/OCSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCSemanticScope.class.st
@@ -68,11 +68,6 @@ OCSemanticScope >> lookupVar: name declare: aBoolean [
 	^outerScope ifNotNil: [ outerScope lookupVar: name declare: aBoolean ]
 ]
 
-{ #category : #'code compilation' }
-OCSemanticScope >> parseASTBy: aParser [
-	self subclassResponsibility
-]
-
 { #category : #printing }
 OCSemanticScope >> scopeLevel [
 	^0

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -511,7 +511,7 @@ OpalCompiler >> parse [
 
 	parser := self parserClass new.
 	parser initializeParserWith: source.
-	ast := self semanticScope parseASTBy: parser.
+	ast := self compilationContext noPattern ifTrue: [ parser parseDoIt ] ifFalse: [ parser parseMethod ].
 
 	ast methodNode compilationContext: self compilationContext.
 	self callParsePlugins.

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -366,7 +366,7 @@ OpalCompiler >> context: aContext [
 		The nil context here means to do nothing in such scenarious. So no need to touch the scope here"
 		^self ].
 
-	self semanticScope: (self semanticScope asDoItScopeForContext: aContext)
+	self semanticScope: (OCContextualDoItSemanticScope targetingContext: aContext)
 ]
 
 { #category : #'public access' }
@@ -591,7 +591,7 @@ OpalCompiler >> protocol: aProtocol [
 
 { #category : #accessing }
 OpalCompiler >> receiver: anObject [
-	self semanticScope: (self semanticScope asDoItScopeForReceiver: anObject)
+	self semanticScope: (OCReceiverDoItSemanticScope targetingReceiver: anObject)
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Tests/OCClosureCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCClosureCompilerTest.class.st
@@ -329,7 +329,6 @@ OCClosureCompilerTest >> doTestDebuggerTempAccessWith: one with: two [
 OCClosureCompilerTest >> evaluate: aString in: aContext to: anObject [
 	^self class compiler source: aString;
 		context: aContext;
-		receiver: anObject;
 		evaluate
 ]
 


### PR DESCRIPTION
The class hierarchy `OCSemanticScope` is used to abstract the contextual semantic of a source code: method definition, basic script, or advanced script in a context (for debugger).

For some reason, the current code is far more complex than required. This PR tries to simplify it.