### PR TITLE
Remove SystemOrganisation global

### DIFF
--- a/src/Pharo30Bootstrap/PBImageBuilder50.class.st
+++ b/src/Pharo30Bootstrap/PBImageBuilder50.class.st
@@ -289,7 +289,7 @@ PBImageBuilder50 >> createInitialObjects [
 	self bootstrapInterpreter evaluateCode:
 		'Smalltalk globals at: #Transcript put: nil.'.
 	self bootstrapInterpreter evaluateCode:
-		'Smalltalk globals at: #SystemOrganisation put: nil.'.
+		'Smalltalk globals at: #SystemOrganization put: nil.'.
 	self bootstrapInterpreter evaluateCode:
 		'Smalltalk globals at: #SourceFiles put: nil.'.
 

--- a/src/Pharo30Bootstrap/PBImageBuilder50.class.st
+++ b/src/Pharo30Bootstrap/PBImageBuilder50.class.st
@@ -289,8 +289,6 @@ PBImageBuilder50 >> createInitialObjects [
 	self bootstrapInterpreter evaluateCode:
 		'Smalltalk globals at: #Transcript put: nil.'.
 	self bootstrapInterpreter evaluateCode:
-		'Smalltalk globals at: #SystemOrganization put: nil.'.
-	self bootstrapInterpreter evaluateCode:
 		'Smalltalk globals at: #SourceFiles put: nil.'.
 
 


### PR DESCRIPTION
We have a SystemOrganization global variable (for now... It's the next one to kill on my list) but a type in the Bootstrap creates a SystemOrganisation (with an s instead of the z) global.

This removes this unwanted global.