### PR TITLE
Skip windows broken tests

### DIFF
--- a/src/Kernel-Tests/AllocationTest.class.st
+++ b/src/Kernel-Tests/AllocationTest.class.st
@@ -12,10 +12,14 @@ AllocationTest >> testOneGBAllocation [
 	"Documentating a weird bug in the allocator"
 
 	| sz array failed |
+	"There is currently a bug in the latest VM opening a native window blocking the execution on Windows. This skip is to make the CI pass again. BUT this is an important issue and should be fixed soon."
+	Smalltalk os isWindows ifTrue: [ self skipOnPharoCITestingEnvironment ].
 	failed := false.
-	sz := 1024*1024*1024.
-	array := [ByteArray new: sz] on: OutOfMemory do: [:ex| failed := true].
-	self assert: (failed or:[array size = sz])
+	sz := 1024 * 1024 * 1024.
+	array := [ ByteArray new: sz ]
+		         on: OutOfMemory
+		         do: [ :ex | failed := true ].
+	self assert: (failed or: [ array size = sz ])
 ]
 
 { #category : #testing }
@@ -24,12 +28,15 @@ AllocationTest >> testOneGWordAllocation [
 
 	| sz array failed |
 	"This takes too much time to run"
-	self timeLimit: 3 minutes.
-
+	self timeLimit: 1 minutes.
+	"There is currently a bug in the latest VM opening a native window blocking the execution on Windows. This skip is to make the CI pass again. BUT this is an important issue and should be fixed soon."
+	Smalltalk os isWindows ifTrue: [ self skipOnPharoCITestingEnvironment ].
 	failed := false.
-	sz := 1024*1024*1024.
-	array := [Array new: sz] on: OutOfMemory do: [:ex| failed := true].
-	self assert: (failed or:[array size = sz])
+	sz := 1024 * 1024 * 1024.
+	array := [ Array new: sz ]
+		         on: OutOfMemory
+		         do: [ :ex | failed := true ].
+	self assert: (failed or: [ array size = sz ])
 ]
 
 { #category : #testing }


### PR DESCRIPTION
The windows CI is ending up in timeout since the latest used VM because two tests and ending un OutOfMemory and the VM currently opens a native window blocking the execution of Pharo.

This skips those two tests until this issue is fixed (And it should get fixed before P11 release in my opinion because that means that first it is impossible to allocate 1Go on windows but also if that happens the execution get blocked. This is a show stopper for me

Fixes #13282