### PR TITLE
Remove usage of Protocol>>#canBeRemoved

### DIFF
--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -84,14 +84,18 @@ ClassOrganization >> classify: selector under: protocol [
 	Some code was added to make it possible to classify giving a real protocol.
 	Here to keep a small change, I just ask the name to the protocol and use that for compatibility.
 	Later, I plan to update this code once more to directly use the actual object I'm givin instead of doing this little trick."
-	protocolName := protocol isString ifTrue: [ protocol ] ifFalse: [ protocol name ].
+	protocolName := protocol isString
+		                ifTrue: [ protocol ]
+		                ifFalse: [ protocol name ].
 	forceNotify := (self includesSelector: selector) not.
 	oldProtocolName := self protocolNameOfElement: selector.
 	(forceNotify or: [ oldProtocolName ~= protocolName or: [ protocolName ~= Protocol unclassified ] ]) ifFalse: [ ^ self ].
 	oldProtocols := self protocolsOfSelector: selector.
 
 	self classify: selector inProtocolNamed: protocolName.
-	(oldProtocols select: #canBeRemoved) do: [ :e | self removeProtocol: e ].
+	oldProtocols
+		select: #isEmpty
+		thenDo: [ :aProtocol | self removeProtocol: aProtocol ].
 	oldProtocolName ifNotNil: [ self notifyOfChangedSelector: selector from: oldProtocolName to: protocolName ]
 ]
 
@@ -323,7 +327,7 @@ ClassOrganization >> removeEmptyProtocols [
 	oldProtocolNames := self protocolNames copy.
 
 	removedProtocols := protocols
-		                    select: [ :protocol | protocol canBeRemoved ]
+		                    select: [ :protocol | protocol isEmpty ]
 		                    thenDo: [ :protocol |
 			                    self removeProtocol: protocol.
 			                    self notifyOfRemovedProtocolNamed: protocol name ].
@@ -335,7 +339,7 @@ ClassOrganization >> removeEmptyProtocols [
 ClassOrganization >> removeProtocol: aProtocol [
 
 	| oldProtocolNames |
-	aProtocol canBeRemoved ifFalse: [ ^ self ].
+	aProtocol isEmpty ifFalse: [ ^ self ].
 
 	oldProtocolNames := self protocolNames copy.
 	protocols remove: aProtocol ifAbsent: [  ].
@@ -349,7 +353,7 @@ ClassOrganization >> removeProtocolIfEmpty: protocolName [
 
 	| protocol |
 	protocol := self protocolNamed: protocolName ifAbsent: [ ^ self ].
-	(protocol isEmpty and: [ protocol canBeRemoved ]) ifTrue: [ self removeProtocol: protocol ]
+	protocol isEmpty ifTrue: [ self removeProtocol: protocol ]
 ]
 
 { #category : #accessing }

--- a/src/Kernel/Protocol.class.st
+++ b/src/Kernel/Protocol.class.st
@@ -60,11 +60,6 @@ Protocol >> addMethodSelector: aSymbol [
 	^ methodSelectors add: aSymbol
 ]
 
-{ #category : #private }
-Protocol >> canBeRemoved [
-	^ self isEmpty
-]
-
 { #category : #testing }
 Protocol >> canBeRenamed [
 	^ true

--- a/src/Refactoring2-Transformations/RBRemoveProtocolTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBRemoveProtocolTransformation.class.st
@@ -54,9 +54,6 @@ RBRemoveProtocolTransformation >> preconditions [
 			includes: protocol ]
 			errorString: 'Protocol named ', protocol, ' does not exist' )
 		& ( RBCondition
-			withBlock: [ (self definingClass realClass organization protocolNamed: protocol ) canBeRemoved ]
-			errorString: 'Protocol named ', protocol, ' is a virtual protocol and it cannot be removed' )
-		& ( RBCondition
 			withBlock: [ (self definingClass realClass organization protocolNamed: protocol ) isEmpty ]
 			errorString: 'Protocol named ', protocol, ' is not empty and it cannot be removed' )
 ]

--- a/src/ReleaseTests/ProperMethodCategorizationTest.class.st
+++ b/src/ReleaseTests/ProperMethodCategorizationTest.class.st
@@ -147,14 +147,13 @@ ProperMethodCategorizationTest >> testInstanceSideInitializeMethodNeedsToBeInIni
 ProperMethodCategorizationTest >> testNoEmptyProtocols [
 	"Check that we have no protocols left without methods"
 
-	| violating protocolsWithoutMethods |
-	violating := Dictionary new.
-	ProtoObject withAllSubclasses
-		do: [ :cls |
-			protocolsWithoutMethods := cls organization protocols select: [ :e | e isEmpty and: [ e canBeRemoved ] ].
-			protocolsWithoutMethods notEmpty ifTrue: [ violating at: cls put: protocolsWithoutMethods ] ].
+	| violations |
+	violations := Dictionary new.
+	ProtoObject withAllSubclasses do: [ :cls |
+		(cls organization protocols select: [ :protocol | protocol isEmpty ])
+			ifNotEmpty: [ :emptyProtocols | violations at: cls put: emptyProtocols ] ].
 
-	self assertEmpty: violating
+	self assertEmpty: violations
 ]
 
 { #category : #tests }


### PR DESCRIPTION
This is a subset of #13305 to find which part of the PR crashes the bootstrap.

#canBeRemoved was a method present to deal with virtual protocols. Since virtual protocols do not exist anymore, we can just remove this method and use #isEmpty instead because we can remove a protocol only if it is empty. The code is still readable and explicit enough. For example:

```st
oldProtocols
		select: #isEmpty
		thenDo: [ :aProtocol | self removeProtocol: aProtocol ].
```

I think it is easy to understand that we want to remove the empty protocols only