### PR TITLE
Remove the need to give a SystemOrganizer to SystemDictionary

### DIFF
--- a/src/Pharo30Bootstrap/PBBootstrap30.class.st
+++ b/src/Pharo30Bootstrap/PBBootstrap30.class.st
@@ -265,7 +265,7 @@ PBBootstrap30 >> createInitialObjects [
 	self bootstrapInterpreter evaluateCode: 'DangerousClassNotifier disable'.
 	self bootstrapInterpreter evaluateCode: 'Undeclared := Dictionary new.'.
 	self bootstrapInterpreter evaluateCode: 'Smalltalk := SmalltalkImage basicNew.'.
-	self bootstrapInterpreter evaluateCode: 'Smalltalk instVarAt: 1 put: (SystemDictionary withOrganizer: SystemOrganizer new).'.
+	self bootstrapInterpreter evaluateCode: 'Smalltalk instVarAt: 1 put: SystemDictionary new.'.
 	self bootstrapInterpreter evaluateCode: 'Smalltalk at: #Smalltalk put: Smalltalk.'.
 	self bootstrapInterpreter evaluateCode: 'Smalltalk at: #Undeclared put: Undeclared.'.
 	

--- a/src/Pharo30Bootstrap/PBImageBuilder50.class.st
+++ b/src/Pharo30Bootstrap/PBImageBuilder50.class.st
@@ -277,7 +277,7 @@ PBImageBuilder50 >> createInitialObjects [
 	self bootstrapInterpreter evaluateCode:
 		'Smalltalk := SmalltalkImage basicNew.'.
 	self bootstrapInterpreter evaluateCode:
-		'Smalltalk instVarAt: 1 put: (SystemDictionary withOrganizer: SystemOrganizer new).'.
+		'Smalltalk instVarAt: 1 put: SystemDictionary new.'.
 	self bootstrapInterpreter evaluateCode:
 		'Smalltalk globals at: #Smalltalk put: Smalltalk.'.
 	self bootstrapInterpreter evaluateCode:

--- a/src/SUnit-Tests/ClassFactoryWithOrganizationTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryWithOrganizationTest.class.st
@@ -19,7 +19,7 @@ ClassFactoryWithOrganizationTest >> assertEnvironmentOf: aBehavior [
 ClassFactoryWithOrganizationTest >> setUp [
 	| environment |
 	super setUp.
-	environment := SystemDictionary withOrganizer: SystemOrganizer new.
+	environment := SystemDictionary new.
 	factory := ClassFactoryWithOrganization newWithOrganization: environment organization
 ]
 

--- a/src/System-Support-Tests/SystemDictionaryTest.class.st
+++ b/src/System-Support-Tests/SystemDictionaryTest.class.st
@@ -124,6 +124,17 @@ SystemDictionaryTest >> testSmalltalkSelfEvaluating [
 	self assert: Smalltalk isSelfEvaluating
 ]
 
+{ #category : #'tests - printing' }
+SystemDictionaryTest >> testStoreOnWithNegativeInteger [
+
+	| dictionary |
+	dictionary := { ('x' -> -1) } as: self classToBeTested.
+
+	self
+		assert: (String streamContents: [ :s | dictionary storeOn: s ])
+		equals: '((SystemDictionary new) add: (#SystemOrganization->(SystemOrganizer new categoryMap: ((Dictionary new)); yourself)); add: (''x''-> -1); yourself)'
+]
+
 { #category : #tests }
 SystemDictionaryTest >> testUnCategorizedMethods [
 

--- a/src/System-Support-Tests/SystemDictionaryTest.class.st
+++ b/src/System-Support-Tests/SystemDictionaryTest.class.st
@@ -43,9 +43,7 @@ SystemDictionaryTest >> testClassOrTraitNamedReturnsNilForGlobals [
 { #category : #tests }
 SystemDictionaryTest >> testEnvironmentOfOrganization [
 
-	| aDictionary |
-	aDictionary := SystemDictionary withOrganizer: SystemOrganizer new.
-	self assert: aDictionary organization environment equals: aDictionary
+	self assert: SystemDictionary new organization environment equals: SystemDictionary new
 ]
 
 { #category : #tests }
@@ -59,10 +57,7 @@ SystemDictionaryTest >> testHasBindingThatBeginsWith [
 { #category : #tests }
 SystemDictionaryTest >> testOrganizationPerInstance [
 
-	| aDictionary otherDictionary |
-	aDictionary := SystemDictionary withOrganizer: SystemOrganizer new.
-	otherDictionary := SystemDictionary withOrganizer: SystemOrganizer new.
-	self deny: aDictionary organization equals: otherDictionary organization
+	self deny: SystemDictionary new organization equals: SystemDictionary new organization
 ]
 
 { #category : #tests }

--- a/src/System-Support-Tests/SystemDictionaryTest.class.st
+++ b/src/System-Support-Tests/SystemDictionaryTest.class.st
@@ -43,7 +43,9 @@ SystemDictionaryTest >> testClassOrTraitNamedReturnsNilForGlobals [
 { #category : #tests }
 SystemDictionaryTest >> testEnvironmentOfOrganization [
 
-	self assert: SystemDictionary new organization environment equals: SystemDictionary new
+	| aDictionary |
+	aDictionary := SystemDictionary new.
+	self assert: aDictionary organization environment equals: aDictionary
 ]
 
 { #category : #tests }

--- a/src/System-Support-Tests/SystemDictionaryTest.class.st
+++ b/src/System-Support-Tests/SystemDictionaryTest.class.st
@@ -124,17 +124,6 @@ SystemDictionaryTest >> testSmalltalkSelfEvaluating [
 	self assert: Smalltalk isSelfEvaluating
 ]
 
-{ #category : #'tests - printing' }
-SystemDictionaryTest >> testStoreOnWithNegativeInteger [
-
-	| dictionary |
-	dictionary := { ('x' -> -1) } as: self classToBeTested.
-
-	self
-		assert: (String streamContents: [ :s | dictionary storeOn: s ])
-		equals: '((SystemDictionary new) add: (#SystemOrganization->(SystemOrganizer new categoryMap: ((Dictionary new)); yourself)); add: (''x''-> -1); yourself)'
-]
-
 { #category : #tests }
 SystemDictionaryTest >> testUnCategorizedMethods [
 

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -31,15 +31,6 @@ Class {
 	#category : #'System-Support-Utilities'
 }
 
-{ #category : #'instance creation' }
-SystemDictionary class >> withOrganizer: anOrganizer [
-
-	| dictionary |
-	dictionary := self new.
-	dictionary organization: anOrganizer. "update too the back pointer"
-	^ dictionary
-]
-
 { #category : #'accessing - classes and traits' }
 SystemDictionary >> allBehaviors [
 	"Return all the classes and traits defined in the Smalltalk SystemDictionary"
@@ -261,6 +252,13 @@ SystemDictionary >> hasClassOrTraitNamed: aString [
 		ifTrue: [ :aSymbol |
 		^ (self at: aSymbol ifAbsent: [ nil ]) isClassOrTrait ].
 	^ false
+]
+
+{ #category : #initialization }
+SystemDictionary >> initialize: aSize [
+
+	super initialize: aSize.
+	self organization: SystemOrganizer new
 ]
 
 { #category : #'accessing - variable lookup' }

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -254,13 +254,6 @@ SystemDictionary >> hasClassOrTraitNamed: aString [
 	^ false
 ]
 
-{ #category : #initialization }
-SystemDictionary >> initialize: aSize [
-
-	super initialize: aSize.
-	self organization: SystemOrganizer new
-]
-
 { #category : #'accessing - variable lookup' }
 SystemDictionary >> lookupVar: name [
 	"Return a var with this name.  Return nil if none found"
@@ -297,7 +290,9 @@ SystemDictionary >> nonClassNames [
 SystemDictionary >> organization [
 	"Return the organizer for the receiver"
 
-	^ self at: #SystemOrganization ifAbsent: nil
+	^ self at: #SystemOrganization ifAbsent: [
+		  self organization: SystemOrganizer new.
+		  self at: #SystemOrganization ]
 ]
 
 { #category : #accessing }

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -50,18 +50,6 @@ SystemOrganizer >> categoriesMatching: matchString [
 	^ self categories select: [ :c | matchString match: c ]
 ]
 
-{ #category : #accessing }
-SystemOrganizer >> categoryMap [
-
-	^ categoryMap
-]
-
-{ #category : #accessing }
-SystemOrganizer >> categoryMap: anObject [
-
-	categoryMap := anObject
-]
-
 { #category : #queries }
 SystemOrganizer >> categoryOfBehavior: behavior [
 	"Answer the category associated with the argument. This method can take a Behavior or a Behavior name as parameter."
@@ -228,19 +216,6 @@ SystemOrganizer >> renameCategory: oldCatString toBe: newCatString [
 		ifAbsent: [ "old name not found, so no action" ^ self ].
 
 	SystemAnnouncer uniqueInstance classCategoryRenamedFrom: oldCatString to: newCatString
-]
-
-{ #category : #printing }
-SystemOrganizer >> storeOn: aStream [
-	"This is a hack to not store the environment that would end up in an infinit loop.
-	SystemOrganizer should be removed in the future so it should not be too much of a problem to have this hack."
-
-	aStream
-		nextPut: $(;
-		nextPutAll: self class name;
-		nextPutAll: ' new categoryMap: ';
-		store: categoryMap;
-		nextPutAll: '; yourself)'
 ]
 
 { #category : #queries }

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -50,6 +50,18 @@ SystemOrganizer >> categoriesMatching: matchString [
 	^ self categories select: [ :c | matchString match: c ]
 ]
 
+{ #category : #accessing }
+SystemOrganizer >> categoryMap [
+
+	^ categoryMap
+]
+
+{ #category : #accessing }
+SystemOrganizer >> categoryMap: anObject [
+
+	categoryMap := anObject
+]
+
 { #category : #queries }
 SystemOrganizer >> categoryOfBehavior: behavior [
 	"Answer the category associated with the argument. This method can take a Behavior or a Behavior name as parameter."
@@ -216,6 +228,19 @@ SystemOrganizer >> renameCategory: oldCatString toBe: newCatString [
 		ifAbsent: [ "old name not found, so no action" ^ self ].
 
 	SystemAnnouncer uniqueInstance classCategoryRenamedFrom: oldCatString to: newCatString
+]
+
+{ #category : #printing }
+SystemOrganizer >> storeOn: aStream [
+	"This is a hack to not store the environment that would end up in an infinit loop.
+	SystemOrganizer should be removed in the future so it should not be too much of a problem to have this hack."
+
+	aStream
+		nextPut: $(;
+		nextPutAll: self class name;
+		nextPutAll: ' new categoryMap: ';
+		store: categoryMap;
+		nextPutAll: '; yourself)'
 ]
 
 { #category : #queries }


### PR DESCRIPTION
SystemDictionary needs a SystemOrganizer to add or remove classes. Currently, users creating a SystemDictionary are creating this by hand. This PR simplifies it by doing that during the initialization.

This also remove a bunch of other SystemOrganizer references a little everywhere in the system and the bootstrap which will help to replace the SystemOrganizer by a RPackageOrganizer.