### PR TITLE
Fix bug in syntaxt highlighting of comments

### DIFF
--- a/src/PharoDocComment/SHRBTextStyler.extension.st
+++ b/src/PharoDocComment/SHRBTextStyler.extension.st
@@ -29,8 +29,8 @@ SHRBTextStyler >> styleDocExpression: aPharoDocExpression in: aRBComment [
 ]
 
 { #category : #'*PharoDocComment' }
-SHRBTextStyler >> visitMethodComments: comments [
-	comments do: [ :comment | self addStyle: #comment from: comment start to: comment stop ].
-	PharoDocCommentNode docCommentEnabled
-		ifTrue: [ comments do: [ :comment | self styleDocComment: comment ] ]
+SHRBTextStyler >> visitMethodComments: aNode [
+
+	self visitCommentNodes: aNode.
+	PharoDocCommentNode docCommentEnabled ifTrue: [ aNode comments do: [ :comment | self styleDocComment: comment ] ]
 ]

--- a/src/Shout-Tests/SHRBStyleAttributionTest.class.st
+++ b/src/Shout-Tests/SHRBStyleAttributionTest.class.st
@@ -320,6 +320,52 @@ SHRBStyleAttributionTest >> testCommentStyle [
 ]
 
 { #category : #tests }
+SHRBStyleAttributionTest >> testCommentsInLiteralValueNode [
+
+	| aText |
+	aText := 'test
+	(123 "comment")' asText.
+	self style: aText.
+
+	self
+		assertStyleOf: aText
+		between: 12
+		and: 20
+		shouldBe: #comment
+]
+
+{ #category : #tests }
+SHRBStyleAttributionTest >> testCommentsInVariaousPlaces [
+	"For now, the AST does not visit really well the comments. Some work is needed to do that and until it is done, this test will help to avoid regression."
+
+	| aText |
+	aText := 'test
+	("comment1" (123 "comment2")) + ("comment3" (self "comment4"))' asText.
+	self style: aText.
+
+	self
+		assertStyleOf: aText
+		between: 8
+		and: 17
+		shouldBe: #comment.
+	self
+		assertStyleOf: aText
+		between: 24
+		and: 33
+		shouldBe: #comment.
+	self
+		assertStyleOf: aText
+		between: 40
+		and: 49
+		shouldBe: #comment.
+	self
+		assertStyleOf: aText
+		between: 57
+		and: 66
+		shouldBe: #comment
+]
+
+{ #category : #tests }
 SHRBStyleAttributionTest >> testDefaultStyle [
 
 	| aText |

--- a/src/Shout-Tests/SHRBStyleAttributionTest.class.st
+++ b/src/Shout-Tests/SHRBStyleAttributionTest.class.st
@@ -320,6 +320,21 @@ SHRBStyleAttributionTest >> testCommentStyle [
 ]
 
 { #category : #tests }
+SHRBStyleAttributionTest >> testCommentsInLiteralArrayNode [
+
+	| aText |
+	aText := 'test
+	(#(123) "comment")' asText.
+	self style: aText.
+
+	self
+		assertStyleOf: aText
+		between: 15
+		and: 23
+		shouldBe: #comment
+]
+
+{ #category : #tests }
 SHRBStyleAttributionTest >> testCommentsInLiteralValueNode [
 
 	| aText |
@@ -362,6 +377,21 @@ SHRBStyleAttributionTest >> testCommentsInVariaousPlaces [
 		assertStyleOf: aText
 		between: 57
 		and: 66
+		shouldBe: #comment
+]
+
+{ #category : #tests }
+SHRBStyleAttributionTest >> testCommentsPragmaNode [
+
+	| aText |
+	aText := 'test
+	<test "comment">' asText.
+	self style: aText.
+
+	self
+		assertStyleOf: aText
+		between: 13
+		and: 21
 		shouldBe: #comment
 ]
 

--- a/src/Shout-Tests/SHRBStyleAttributionTest.class.st
+++ b/src/Shout-Tests/SHRBStyleAttributionTest.class.st
@@ -288,6 +288,24 @@ SHRBStyleAttributionTest >> testClassVarStyle [
 ]
 
 { #category : #tests }
+SHRBStyleAttributionTest >> testCommentOfVariableInParenthesis [
+	"Regression test for https://github.com/pharo-project/pharo/issues/13316"
+
+	| aText |
+	aText := 'test
+
+	| toto |
+	^ (toto "this returns nil")' asText.
+	self style: aText.
+
+	self
+		assertStyleOf: aText
+		between: 26
+		and: 43
+		shouldBe: #comment
+]
+
+{ #category : #tests }
 SHRBStyleAttributionTest >> testCommentStyle [
 
 	| aText |

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -1101,10 +1101,10 @@ SHRBTextStyler >> visitSequenceNode: aSequenceNode [
 
 { #category : #visiting }
 SHRBTextStyler >> visitVariableNode: aVariableNode [
-	self
-		addStyle: (self resolveStyleFor: aVariableNode)
-		attributes: (self resolveVariableAttributesFor: aVariableNode)
-		forNode: aVariableNode
+
+	self addStyle: (self resolveStyleFor: aVariableNode) attributes: (self resolveVariableAttributesFor: aVariableNode) forNode: aVariableNode.
+
+	self visitMethodComments: aVariableNode comments
 ]
 
 { #category : #accessing }

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -966,6 +966,12 @@ SHRBTextStyler >> visitCascadeNode: aCascadeNode [
 ]
 
 { #category : #visiting }
+SHRBTextStyler >> visitCommentNodes: anASTNode [
+
+	anASTNode comments do: [ :comment | self addStyle: #comment from: comment start to: comment stop ]
+]
+
+{ #category : #visiting }
 SHRBTextStyler >> visitEnglobingErrorNode: anEnglobingErrorNode [
 
 	self addStyle: #invalid from: anEnglobingErrorNode stop to: anEnglobingErrorNode stop + 1.
@@ -994,7 +1000,6 @@ SHRBTextStyler >> visitLiteralValueNode: aLiteralValueNode [
 	| value link |
 	value := aLiteralValueNode value.
 
-
 	"We can have 3 different kind of links from a literal:
 	- In case it is a symbol representing a class, we want to return a TextClassLink to browse the class or its references
 	- In case it is another symbol, we want to return a TextMethodLink to browser the implementors or senders of this selector
@@ -1006,7 +1011,8 @@ SHRBTextStyler >> visitLiteralValueNode: aLiteralValueNode [
 				        ifPresent: [ :aGlobal | TextClassLink className: value ]
 				        ifAbsent: [ TextMethodLink selector: value ] ]
 		        ifFalse: [ TextClassLink class: value class ].
-	self addStyle: (self literalStyleSymbol: value) attributes: { link } forNode: aLiteralValueNode
+	self addStyle: (self literalStyleSymbol: value) attributes: { link } forNode: aLiteralValueNode.
+	self visitCommentNodes: aLiteralValueNode
 ]
 
 { #category : #visiting }
@@ -1039,7 +1045,7 @@ SHRBTextStyler >> visitMessageNode: aMessageNode [
 { #category : #visiting }
 SHRBTextStyler >> visitMethodNode: aMethodNode [
 	| link |
-	self visitMethodComments: aMethodNode comments.
+	self visitMethodComments: aMethodNode.
 	aMethodNode arguments do: [ :argument | self addStyle: #patternArg forNode: argument ].
 	link := TextMethodLink selector: aMethodNode selector.
 	aMethodNode selectorParts
@@ -1104,7 +1110,7 @@ SHRBTextStyler >> visitVariableNode: aVariableNode [
 
 	self addStyle: (self resolveStyleFor: aVariableNode) attributes: (self resolveVariableAttributesFor: aVariableNode) forNode: aVariableNode.
 
-	self visitMethodComments: aVariableNode comments
+	self visitCommentNodes: aVariableNode
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
If we put a comment next to a variable in parenthesis, then the comment is part of the VariableNode in the AST.  Shout was not hanlding such comments until now.

This fixes the problem by visiting the comments of the variable nodes of the AST and adds a regression test.

Fixes #13316

Let's note that there is still a bug there because the closing parenthesis is considered part of the variable node. But this is not a but of Shout but of the parser (cf. https://github.com/pharo-project/pharo/issues/13318)