### PR TITLE
Try to move workspace variables further

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -64,7 +64,7 @@ Context >> lookupVar: aSymbol [
 
 { #category : #'*Debugging-Core' }
 Context >> lookupVar: aSymbol declare: aBoolean [
-	^ self astScope lookupVar: aSymbol declare: aBoolean
+	^ self astScope lookupVar: aSymbol
 ]
 
 { #category : #'*Debugging-Core' }

--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -84,12 +84,6 @@ Behavior >> lookupVar: aName declare: aBoolean [
 ]
 
 { #category : #'*OpalCompiler-Core' }
-Behavior >> lookupVarForDeclaration: name [
-	"This is a version of #lookupVar: that skips the OCRequestorScope, from here on it is the same as lookupVar:"
-	^ self lookupVar: name
-]
-
-{ #category : #'*OpalCompiler-Core' }
 Behavior >> outerScope [
 	^self environment
 ]

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -699,7 +699,7 @@ CompilationContext >> requestor: anObject [
 	requestor := anObject
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #utilities }
 CompilationContext >> requestorCanDeclare: aRequestor [
 	"Heuristic to know if the possible (legagy) requestor can declare new bindings.
 	Because there is no sane API on requestors, we just typecheck until all requestors are dead and buried"

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -701,6 +701,22 @@ CompilationContext >> requestor: anObject [
 	requestor := anObject
 ]
 
+{ #category : #'as yet unclassified' }
+CompilationContext >> requestorCanDeclare: aRequestor [
+	"Heuristic to know if the possible (legagy) requestor can declare new bindings.
+	Because there is no sane API on requestors, we just typecheck until all requestors are dead and buried"
+
+	aRequestor ifNil: [ ^ false ].
+	(aRequestor isKindOf: SpCodeScriptingInteractionModel) ifTrue: [
+		^ true ].
+	(aRequestor respondsTo: #interactionModel) ifTrue: [
+		| req2 |
+		req2 := aRequestor interactionModel.
+		aRequestor = req2 ifTrue: [ ^ false ].
+		^ self requestorCanDeclare: req2 ].
+	^ false
+]
+
 { #category : #accessing }
 CompilationContext >> requestorScopeClass [
 	^ requestorScopeClass ifNil: [ requestorScopeClass := OCRequestorScope ]
@@ -717,8 +733,8 @@ CompilationContext >> scope [
 	| newScope |
 
 	newScope := semanticScope.
-	requestor ifNotNil: [
-		"the requestor is allowed to manage variables, the workspace is using it to auto-define vars"
+	(self requestorCanDeclare: requestor) ifTrue: [
+		"the requestor should not be allowed to manage bindings this way, but keep it for compatibility"
 		newScope := (self requestorScopeClass new
 			compilationContext: self;
 			requestor: requestor) outerScope: newScope].

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -512,7 +512,8 @@ CompilationContext >> interactive [
 	this should be simplified "
 	^ (requestor respondsTo: #interactive)
 		  ifTrue: [ requestor interactive ]
-		  ifFalse: [ true ]
+		  ifFalse: [
+			  requestor class name ~= #SpCodeNullInteractionModel "Some spec tests are broken with reparation menu, so skip them here until we fix them in Spec" ]
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -707,8 +707,8 @@ CompilationContext >> requestorCanDeclare: aRequestor [
 	aRequestor ifNil: [ ^ false ].
 	(aRequestor respondsTo: #canDeclareBindings) ifTrue: [
 		^ aRequestor canDeclareBindings ].
-	(aRequestor isKindOf: SpCodeScriptingInteractionModel) ifTrue: [
-		^ true ].
+	(#( #StPlaygroundInteractionModel #StSindarinContextInteractionModel )
+		 includes: aRequestor class name) ifTrue: [ ^ true ].
 	(aRequestor respondsTo: #interactionModel) ifTrue: [
 		| req2 |
 		req2 := aRequestor interactionModel.

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -707,6 +707,8 @@ CompilationContext >> requestorCanDeclare: aRequestor [
 	Because there is no sane API on requestors, we just typecheck until all requestors are dead and buried"
 
 	aRequestor ifNil: [ ^ false ].
+	(aRequestor respondsTo: #canDeclareBindings) ifTrue: [
+		^ aRequestor canDeclareBindings ].
 	(aRequestor isKindOf: SpCodeScriptingInteractionModel) ifTrue: [
 		^ true ].
 	(aRequestor respondsTo: #interactionModel) ifTrue: [

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -89,7 +89,7 @@ OCASTSemanticAnalyzer >> declareVariableNode: aVariableNode as: anOCTempVariable
 	| name var shadowing |
 	name := aVariableNode name.
 	"check if another variable with same name is visible"
-	shadowing := scope lookupVarForDeclaration: name.
+	shadowing := scope lookupVar: name.
 	var := scope addTemp: anOCTempVariable.
 	aVariableNode binding: var.
 	(shadowing notNil and: [ shadowing allowsShadowing not]) ifTrue: [self shadowing: shadowing withVariable: aVariableNode].

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -146,13 +146,13 @@ OCAbstractMethodScope >> lookupDefiningContextForVariable: var startingFrom: aCo
 ]
 
 { #category : #lookup }
-OCAbstractMethodScope >> lookupVar: name declare: aBoolean [
+OCAbstractMethodScope >> lookupVar: name [
 
 	copiedVars at: name ifPresent: [:v | ^ v].
 	tempVector at: name ifPresent: [:v | ^ v].
 	tempVars at: name ifPresent: [:v | ^ v].
 	name = self tempVectorName ifTrue: [ ^ self tempVectorVar ].
-	^self outerScope lookupVar: name declare: aBoolean
+	^self outerScope lookupVar: name
 ]
 
 { #category : #scope }

--- a/src/OpalCompiler-Core/OCAbstractScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractScope.class.st
@@ -48,22 +48,7 @@ OCAbstractScope >> isMethodScope [
 { #category : #lookup }
 OCAbstractScope >> lookupVar: name [
 	"search the scope (and the outer scopes) for a variable 'name' and return it"
-	^ self lookupVar: name declare: true
-]
-
-{ #category : #lookup }
-OCAbstractScope >> lookupVar: name declare: aBoolean [
-	"search the scope (and the outer scopes) for a variable 'name' and return it"
-	^self subclassResponsibility
-]
-
-{ #category : #lookup }
-OCAbstractScope >> lookupVarForDeclaration: name [
-	"This is a version of #lookupVar: that skips the OCRequestorScope.
-	When looking temp var declarations, we do not want the Requestor scope to automatically
-	create that variable. Subclasses override if they do not skip but do a lookup"
-
-	^ self lookupVar: name declare: false
+	^ self subclassResponsibility
 ]
 
 { #category : #lookup }

--- a/src/OpalCompiler-Core/OCAbstractScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractScope.class.st
@@ -77,3 +77,9 @@ OCAbstractScope >> outerScope: aSemScope [
 
 	outerScope := aSemScope
 ]
+
+{ #category : #'as yet unclassified' }
+OCAbstractScope >> registerVariables [
+
+	outerScope ifNotNil: [ :it | it registerVariables ]
+]

--- a/src/OpalCompiler-Core/OCAbstractScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractScope.class.st
@@ -63,7 +63,7 @@ OCAbstractScope >> outerScope: aSemScope [
 	outerScope := aSemScope
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #lookup }
 OCAbstractScope >> registerVariables [
 
 	outerScope ifNotNil: [ :it | it registerVariables ]

--- a/src/OpalCompiler-Core/OCContextualDoItSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCContextualDoItSemanticScope.class.st
@@ -81,11 +81,11 @@ OCContextualDoItSemanticScope >> initialize [
 ]
 
 { #category : #lookup }
-OCContextualDoItSemanticScope >> lookupVar: name declare: aBoolean [
+OCContextualDoItSemanticScope >> lookupVar: name [
 
-	(targetContext lookupVar: name declare: aBoolean) ifNotNil: [ :v | ^self importVariable: v].
+	(targetContext lookupVar: name) ifNotNil: [ :v | ^self importVariable: v].
 
-	^super lookupVar: name declare: aBoolean
+	^super lookupVar: name
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OCExtraBindingScope.class.st
+++ b/src/OpalCompiler-Core/OCExtraBindingScope.class.st
@@ -40,8 +40,8 @@ OCExtraBindingScope >> bindings: anObject [
 ]
 
 { #category : #lookup }
-OCExtraBindingScope >> lookupVar: name declare: aBoolean [
+OCExtraBindingScope >> lookupVar: name [
 	^(bindings bindingOf: name asSymbol)
 		ifNotNil: [ :var | var ]
-		ifNil: [ outerScope lookupVar: name declare: aBoolean]
+		ifNil: [ outerScope lookupVar: name]
 ]

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -32,7 +32,7 @@ OCRequestorScope >> compilationContext: anObject [
 ]
 
 { #category : #lookup }
-OCRequestorScope >> lookupVar: name declare: aBoolean [
+OCRequestorScope >> lookupVar: name [
 
 	(requestor hasBindingOf: name) ifTrue: [ ^ requestor bindingOf: name ].
 	"Note that is an outerscope is a requestor tant can declare, it will win the declaration.

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -10,7 +10,8 @@ Class {
 	#superclass : #OCAbstractScope,
 	#instVars : [
 		'requestor',
-		'compilationContext'
+		'compilationContext',
+		'variables'
 	],
 	#category : #'OpalCompiler-Core-Semantics'
 }
@@ -33,30 +34,29 @@ OCRequestorScope >> compilationContext: anObject [
 { #category : #lookup }
 OCRequestorScope >> lookupVar: name declare: aBoolean [
 
-	"the system normally allows any object as the name, but the requestor uses some
-	heuristics based on names of variables"
+	(requestor hasBindingOf: name) ifTrue: [ ^ requestor bindingOf: name ].
+	"Note that is an outerscope is a requestor tant can declare, it will win the declaration.
+	But maybe it is better this way."
+	(outerScope lookupVar: name) ifNotNil: [ :binding | ^ binding ].
+	
+	"Heuristic, assume the requestor does not want upercased variables.
+	A menu will likely open to offer reparation for class or global or something."
+	name first isUppercase ifTrue: [ ^ nil ].
+	
+	"We do not register it yet, to not fill the requestor with garbage variable during styling for instance"
+	^ self variables at: name ifAbsentPut: [ WorkspaceVariable key: name ]
+]
 
-	name isString ifFalse: [ ^ outerScope lookupVar: name declare: aBoolean ].
-	name isEmpty ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean ].
+{ #category : #'as yet unclassified' }
+OCRequestorScope >> registerVariables [
 
-	"reserved Variables are defined by the global scope, thus we look up in the outer scope"
-	(ReservedVariable nameIsReserved: name) ifTrue: [
-		^ outerScope lookupVar: name declare: aBoolean ].
-
-	"generated temps (e.g. for limits in to:do: should not create bindings"
-	name first = $0 ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean ].
-	"We do not want to auto define bindings for unknown Globals"
-	name first isUppercase ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean].
-	"do not 'create bindings' in requestor scope if we just want to style a possible unknown variable"
-	self flag: 'The faulty mode should not impact how variable are bound'.
-	((compilationContext permitFaulty or: [aBoolean not])
-		and: [ (requestor hasBindingOf: name) not ])
-		ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean ].
-
-	"the requestors #bindingOf may create a binding for not yet existing variables"
-	^(requestor bindingOf: name)
-		ifNotNil: [ :var | var ]
-		ifNil: [ outerScope lookupVar: name declare: aBoolean ]
+	self variables do: [ :each |
+		| var |
+		"Force the declaraction, if needed"
+		var := requestor bindingOf: each name.
+		"Because we no non control how requestor handle its variables, just update the one we used locally"
+		var == each ifFalse: [ each becomeForward: var ] ].
+	super registerVariables
 ]
 
 { #category : #accessing }
@@ -72,4 +72,10 @@ OCRequestorScope >> requestor: anObject [
 { #category : #accessing }
 OCRequestorScope >> scopeLevel [
 	^ 0
+]
+
+{ #category : #accessing }
+OCRequestorScope >> variables [
+
+	^ variables ifNil: [ variables := Dictionary new ].
 ]

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -47,7 +47,7 @@ OCRequestorScope >> lookupVar: name [
 	^ self variables at: name ifAbsentPut: [ WorkspaceVariable key: name ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #lookup }
 OCRequestorScope >> registerVariables [
 
 	self variables do: [ :each |

--- a/src/OpalCompiler-Core/OCSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCSemanticScope.class.st
@@ -76,11 +76,11 @@ OCSemanticScope >> isDoItScope [
 ]
 
 { #category : #lookup }
-OCSemanticScope >> lookupVar: name declare: aBoolean [
+OCSemanticScope >> lookupVar: name [
 
-	(self targetClass lookupVar: name declare: aBoolean) ifNotNil: [ :v | ^v ].
+	(self targetClass lookupVar: name) ifNotNil: [ :v | ^v ].
 
-	^outerScope ifNotNil: [ outerScope lookupVar: name declare: aBoolean ]
+	^outerScope ifNotNil: [ outerScope lookupVar: name ]
 ]
 
 { #category : #'code compilation' }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -264,7 +264,7 @@ OpalCompiler >> checkNotice: aNotice [
 		* require a requestor (because quirks mode, and also some reparations expect a requestor)
 		* require interactive mode (because GUI)
 		* require method definition becase some reparation assume it's a method body"
-		(self isInteractive and: [self compilationContext noPattern not]) ifTrue: [
+		self isInteractive ifTrue: [
 			aNotice reparator ifNotNil: [ :reparator |
 				| res |
 				res := reparator

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -334,6 +334,7 @@ OpalCompiler >> compile [
 	keep := compilationContext noPattern or: [ ast isFaulty ].
 	keep ifTrue: [ compilationContext parseOptions: #( + #optionEmbeddSources ) ].
 	self callPlugins.
+	ast scope registerVariables.
 	method := ast generateMethod.
 	keep ifTrue: [ method propertyAt: #ast put: ast ].
 	^ method

--- a/src/OpalCompiler-Tests/OCDoitTest.class.st
+++ b/src/OpalCompiler-Tests/OCDoitTest.class.st
@@ -14,6 +14,12 @@ OCDoitTest >> bindingOf: aSelector [
 		ifFalse:  [nil]
 ]
 
+{ #category : #testing }
+OCDoitTest >> canDeclareBindings [
+
+	^ true
+]
+
 { #category : #binding }
 OCDoitTest >> hasBindingOf: aSelector [
 	^aSelector == #requestorVarForTesting

--- a/src/Reflectivity/RFSemanticAnalyzer.class.st
+++ b/src/Reflectivity/RFSemanticAnalyzer.class.st
@@ -85,7 +85,7 @@ RFSemanticAnalyzer >> visitNode: aNode [
 RFSemanticAnalyzer >> visitStoreIntoTempNode: aNode [
 	| name var |
 	name := aNode name.
-	var := scope lookupVarForDeclaration: name.
+	var := scope lookupVar: name.
 	var	ifNil: [
 			var := scope addTemp: (TemporaryVariable named: aNode name) ].
 	aNode binding: var
@@ -95,7 +95,7 @@ RFSemanticAnalyzer >> visitStoreIntoTempNode: aNode [
 RFSemanticAnalyzer >> visitStorePopIntoTempNode: aNode [
 	| name var |
 	name := aNode name.
-	var := scope lookupVarForDeclaration: name.
+	var := scope lookupVar: name.
 	var	ifNil: [
 			var := scope addTemp: (TemporaryVariable named: aNode name) ].
 	aNode binding: var

--- a/src/Ring-Core/RGBehavior.class.st
+++ b/src/Ring-Core/RGBehavior.class.st
@@ -669,14 +669,6 @@ RGBehavior >> lookupVar: aName declare: aBoolean [
 	^ self lookupVar: aName
 ]
 
-{ #category : #lookup }
-RGBehavior >> lookupVarForDeclaration: aName [
-
-	"This is a version of #lookupVar: that skips the OCRequestorScope, from here on it is the same as lookupVar:"
-
-	^ self lookupVar: aName
-]
-
 { #category : #resolving }
 RGBehavior >> makeResolved [
 


### PR DESCRIPTION
( ... until they fell off the table?)

Workspace variables are a very problematic feature with a lot of defaults (UI, spec, implementation).

The compiler have to deal with heuristics and uncooperative requestors (GUI windows) to make them work, including:

* Having (and keeping) references on GUI windows when managing scope
* Heuristic trying to guess if we are compiling or not (just highlighting)
* Fear of asking if a variable exists, because asking so might create it

So this PR tries to clean up the current design (*implementation* design, not *GUI* design) a little.

I also tried to no impact the current UI and spec of (workspace variables are still as bad/good as before). Because it is out of scope of the PR, but also because changing what workspace variables are implies hacking GUI tools that lives in another repositories (and I'm not a GUI guy and PR synchronization between repository are a pain).

So, what is on the menu:

* Reactivate the "undeclared" menu on scripts/playground because it is useful in the playground for classes, for instance.
  It sill buggy, but Pharo11 (and some previous versions I assume) has the same bugs (or worse bugs)
* Do not add requestor in scopes *except* for workspace-type requestors, that still need it (grandfather clause) until I (or someone else) hack Spec/NewTools
* Handle workspace variables with the same idea that was used for undeclared  (see #VariableNotDeclared): get a local placeholder variable at parse/semantic-time and only register it (here to the requestor/GUI) at compile-time.
  This has a nice side effect: undeclared variable are now "blue" in the workspace (I can change that if you do not like it).
* remove most of the insane methods `lookupVar:declare:` and `lookupVarForDeclaration:` that are now unneeded (I suppose)