### PR TITLE
Use Protocol>>#unclassified instead of #defaultName

### DIFF
--- a/src/Kernel/Protocol.class.st
+++ b/src/Kernel/Protocol.class.st
@@ -17,12 +17,6 @@ Protocol class >> ambiguous [
 	^ #ambiguous
 ]
 
-{ #category : #accessing }
-Protocol class >> defaultName [
-
-	^  self unclassified
-]
-
 { #category : #'instance creation' }
 Protocol class >> name: nm [
 
@@ -82,7 +76,7 @@ Protocol >> initialize [
 	super initialize.
 
 	methodSelectors := IdentitySet new.
-	name := self class defaultName
+	name := self class unclassified
 ]
 
 { #category : #testing }

--- a/src/Monticello-Tests/RPackageExtensionMethodsSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageExtensionMethodsSynchronisationTest.class.st
@@ -156,7 +156,7 @@ RPackageExtensionMethodsSynchronisationTest >> testMoveClassInPackageWithExtensi
 	secondPackage addClass: class.
 
 	"Everything should now be in second package (and not listed as an extension)."
-	self assert: (class >> #stubMethod) category equals: Protocol defaultName.
+	self assert: (class >> #stubMethod) category equals: Protocol unclassified.
 	self assert: (secondPackage includesDefinedSelector: #stubMethod ofClass: class).
 	self deny: (secondPackage includesExtensionSelector: #stubMethod ofClass: class).
 	self assert: (class >> #stubMethod packageFromOrganizer: self organizer) equals: secondPackage
@@ -175,7 +175,7 @@ RPackageExtensionMethodsSynchronisationTest >> testMoveClassInPackageWithExtensi
 	secondPackage addClass: class.
 
 	"Everything should now be in second package (and not listed as an extension)."
-	self assert: (class >> #stubMethod) category equals: Protocol defaultName.
+	self assert: (class >> #stubMethod) category equals: Protocol unclassified.
 	self assert: (secondPackage includesDefinedSelector: #stubMethod ofClass: class).
 	self deny: (secondPackage includesExtensionSelector: #stubMethod ofClass: class).
 	self assert: (class >> #stubMethod packageFromOrganizer: self organizer) equals: secondPackage
@@ -196,7 +196,7 @@ RPackageExtensionMethodsSynchronisationTest >> testMoveClassInPackageWithExtensi
 
 	"Everything should now be in second package (and not listed as an extension, but instead as 'as yet unclassified')."
 
-	self assert: (class >> #stubMethod) category equals: Protocol defaultName.
+	self assert: (class >> #stubMethod) category equals: Protocol unclassified.
 	self assert: (secondPackage includesDefinedSelector: #stubMethod ofClass: class).
 	self deny: (secondPackage includesExtensionSelector: #stubMethod ofClass: class).
 	self assert: (class >> #stubMethod packageFromOrganizer: self organizer) equals: secondPackage.
@@ -205,7 +205,7 @@ RPackageExtensionMethodsSynchronisationTest >> testMoveClassInPackageWithExtensi
 
 	firstPackage addClass: class.
 
-	self assert: (class >> #stubMethod) category equals: Protocol defaultName.
+	self assert: (class >> #stubMethod) category equals: Protocol unclassified.
 	self assert: (firstPackage includesDefinedSelector: #stubMethod ofClass: class).
 	self deny: (secondPackage includesExtensionSelector: #stubMethod ofClass: class)
 ]

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -299,14 +299,12 @@ RPackage >> basicAddClassTag: tagName [
 RPackage >> basicImportClass: aClass [
 	"Add the class definition and all the selectors which are not extensions of other packages. If the class had an extension to us, then all methods in that extension are moved to 'as yet unclassified' and the extension protocol is deleted (should I use silently or not?)."
 
-	"Note: Protocol defaultName is #'as yet unclassified'"
-
 	"Question: should we check that for each extension, there is a real package behind or not?"
 
 	| protocols |
 	self addClassDefinition: aClass.
 	aClass organization protocolNames do: [ :each |
-		(self isYourClassExtension: each) ifTrue: [ aClass organization renameProtocolNamed: each toBe: Protocol defaultName ] ].
+		(self isYourClassExtension: each) ifTrue: [ aClass organization renameProtocolNamed: each toBe: Protocol unclassified ] ].
 	protocols := aClass organization protocolNames reject: [ :each | each first = $* ].
 	protocols do: [ :each | self importProtocol: each forClass: aClass ]
 ]
@@ -1136,7 +1134,7 @@ RPackage >> removeClass: aClass [
 	"Remove the class and all its methods from the receiver. If we have a protocol which looks like an extension of us, rename it to 'as yet unclassified' to avoid breaking things afterwards."
 
 	aClass organization protocolNames do: [ :each |
-		(self isYourClassExtension: each) ifTrue: [ aClass organization renameProtocolNamed: each toBe: Protocol defaultName ] ].
+		(self isYourClassExtension: each) ifTrue: [ aClass organization renameProtocolNamed: each toBe: Protocol unclassified ] ].
 	(self definedMethodsForClass: aClass instanceSide) do: [ :aCompiledMethod | self removeMethod: aCompiledMethod ].
 	"we also have also have to remove methods from class side"
 	(self definedMethodsForClass: aClass classSide) do: [ :aCompiledMethod | self removeMethod: aCompiledMethod ].


### PR DESCRIPTION
We have two getter to have the unclassified protocol name. #unclassified and #defaultName. This make the readability of the code harder and is useless since it is pretty obvious everywhere else in the code that by default we have an unclassified method.

I removed the need of #defaultName to use #unclassified everywhere.