### PR TITLE
Cleanup: Move as "Arrayed" tagged test classes from generic "Collections-Tests" package to specific "Collections-Native-Tests" package

### DIFF
--- a/src/BaselineOfKernelTests/BaselineOfKernelTests.class.st
+++ b/src/BaselineOfKernelTests/BaselineOfKernelTests.class.st
@@ -13,6 +13,7 @@ BaselineOfKernelTests >> baseline: spec [
 
 			package: 	'Collections-Abstract-Tests';					
 			package: 	'Collections-Atomic-Tests';
+			package: 'Collections-Native-Tests';	
 			package:	'Collections-Sequenceable-Tests';
 			package: 	'Collections-Stack-Tests';	
 			package: 	'Collections-Streams-Tests';		
@@ -20,7 +21,7 @@ BaselineOfKernelTests >> baseline: spec [
 			package: 	'Collections-Support-Tests';								
 			package: 	'Collections-Unordered-Tests';
 			package: 	'Collections-Weak-Tests' with: [ spec requires: #('Collections-Unordered-Tests') ];					
-			package: 	'Collections-Tests' with: [ spec requires: #('Collections-Abstract-Tests' 'Collections-Atomic-Tests' 'Collections-Sequenceable-Tests'  
+			package: 	'Collections-Tests' with: [ spec requires: #('Collections-Abstract-Tests' 'Collections-Atomic-Tests' 'Collections-Native-Tests' 'Collections-Sequenceable-Tests'  
 					   'Collections-Streams-Tests' 'Collections-Strings-Tests' 'Collections-Support-Tests' 'Collections-Stack-Tests' 'Collections-Weak-Tests') ];
 			package: 	'Kernel-Tests'; 
 			package: 	'Kernel-Tests-Extended' ;

--- a/src/Collections-Native-Tests/ByteArrayTest.class.st
+++ b/src/Collections-Native-Tests/ByteArrayTest.class.st
@@ -9,7 +9,7 @@ Class {
 	#instVars : [
 		'collectionWith5Elements'
 	],
-	#category : #'Collections-Tests-Arrayed'
+	#category : #'Collections-Native-Tests-Base'
 }
 
 { #category : #requirements }

--- a/src/Collections-Native-Tests/Float32ArrayTest.class.st
+++ b/src/Collections-Native-Tests/Float32ArrayTest.class.st
@@ -22,7 +22,7 @@ Class {
 		'replacementCollectionSameSize',
 		'sortedCollection'
 	],
-	#category : #'Collections-Tests-Arrayed'
+	#category : #'Collections-Native-Tests-Base'
 }
 
 { #category : #requirements }

--- a/src/Collections-Native-Tests/Float64ArrayTest.class.st
+++ b/src/Collections-Native-Tests/Float64ArrayTest.class.st
@@ -19,7 +19,7 @@ Class {
 		'replacementCollectionSameSize',
 		'sortedCollection'
 	],
-	#category : #'Collections-Tests-Arrayed'
+	#category : #'Collections-Native-Tests-Base'
 }
 
 { #category : #requirements }

--- a/src/Collections-Native-Tests/IntegerArrayTest.class.st
+++ b/src/Collections-Native-Tests/IntegerArrayTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for integer arrays
 Class {
 	#name : #IntegerArrayTest,
 	#superclass : #TestCase,
-	#category : #'Collections-Tests-Arrayed'
+	#category : #'Collections-Native-Tests-Base'
 }
 
 { #category : #tests }

--- a/src/Collections-Native-Tests/NativeArrayTest.class.st
+++ b/src/Collections-Native-Tests/NativeArrayTest.class.st
@@ -4,7 +4,7 @@ SUnit tests for ByteArray, DoubleByteArray, WordArray and DoubleWordArray.
 Class {
 	#name : #NativeArrayTest,
 	#superclass : #TestCase,
-	#category : #'Collections-Tests-Arrayed'
+	#category : #'Collections-Native-Tests-Base'
 }
 
 { #category : #utilities }

--- a/src/Collections-Native-Tests/package.st
+++ b/src/Collections-Native-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Collections-Native-Tests' }


### PR DESCRIPTION
Fix #13335