### PR TITLE
RBNotice: add isSyntaxError and make it easier to sort them

### DIFF
--- a/src/AST-Core/RBNotice.class.st
+++ b/src/AST-Core/RBNotice.class.st
@@ -11,6 +11,14 @@ Class {
 	#category : #'AST-Core-Notice'
 }
 
+{ #category : #comparing }
+RBNotice >> <= other [
+
+	self errorLevel = other errorLevel ifFalse: [
+		^ self errorLevel > other errorLevel ]. "Errors before warnings"
+	^ self position <= other position
+]
+
 { #category : #accessing }
 RBNotice >> description [
 
@@ -29,6 +37,15 @@ RBNotice >> description [
 			  nextPutAll: self messageText;
 			  nextPutAll: '->';
 			  nextPutAll: (node sourceCode asString withBlanksCondensed truncateWithElipsisTo: 60) ]
+]
+
+{ #category : #'as yet unclassified' }
+RBNotice >> errorLevel [
+
+	self isSyntaxError ifTrue: [ ^ 3 ].
+	self isError ifTrue: [ ^ 2 ].
+	self isWarning ifTrue: [ ^ 1 ].
+	^ 0
 ]
 
 { #category : #inspecting }

--- a/src/AST-Core/RBNotice.class.st
+++ b/src/AST-Core/RBNotice.class.st
@@ -39,7 +39,7 @@ RBNotice >> description [
 			  nextPutAll: (node sourceCode asString withBlanksCondensed truncateWithElipsisTo: 60) ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'error handling' }
 RBNotice >> errorLevel [
 
 	self isSyntaxError ifTrue: [ ^ 3 ].

--- a/src/AST-Core/RBNotice.class.st
+++ b/src/AST-Core/RBNotice.class.st
@@ -45,6 +45,12 @@ RBNotice >> isError [
 ]
 
 { #category : #testing }
+RBNotice >> isSyntaxError [
+
+	^ false
+]
+
+{ #category : #testing }
 RBNotice >> isUndeclaredNotice [
 
 	^ false

--- a/src/AST-Core/RBSyntaxErrorNotice.class.st
+++ b/src/AST-Core/RBSyntaxErrorNotice.class.st
@@ -7,6 +7,12 @@ Class {
 	#category : #'AST-Core-Notice'
 }
 
+{ #category : #testing }
+RBSyntaxErrorNotice >> isSyntaxError [
+
+	^ true
+]
+
 { #category : #accessing }
 RBSyntaxErrorNotice >> messageText [
 

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -508,7 +508,7 @@ OpalCompiler >> parse [
 	self doSemanticAnalysis.
 
 	self permitFaulty ifFalse: [
-		ast allNotices do: [ :n |
+		ast allNotices sorted do: [ :n |
 			| check |
 			check := self checkNotice: n.
 			check ifNil: [ ^ ast ].

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -101,6 +101,21 @@ OCCompilerTest >> testAssignmentOfGlobalVarBinding [
 		compile
 ]
 
+{ #category : #tests }
+OCCompilerTest >> testErrorOrders [
+
+	| ast notices |
+	ast := OpalCompiler new parse: 'foo | b | ^ a + ¿. 5 "what'.
+	notices := ast allNotices sorted
+		           collect: [ :e |
+		           e position asString , ':' , e messageText ]
+		           as: Array.
+	self
+		assertCollection: notices
+		equals: #( '17:Unknown character' '27:Unmatched " in comment.'
+			   '13:Undeclared variable' '7:Unused variable' '20:Unreachable statement' )
+]
+
 { #category : #'tests - shadowing' }
 OCCompilerTest >> testInBlockArgumentInstanceVariableShadowing [
 	self initializeErrorMessage.


### PR DESCRIPTION
When you have multiple notices, you want to solve the syntax errors first, then the other errors, then the warnings.
Especially when popup menus might open.