### PR TITLE
Remove ClassOrganization>>hasOrganizedClass

### DIFF
--- a/src/Deprecated12/ClassOrganization.extension.st
+++ b/src/Deprecated12/ClassOrganization.extension.st
@@ -45,28 +45,12 @@ ClassOrganization >> listAtCategoryNamed: aName [
 ]
 
 { #category : #'*Deprecated12' }
-ClassOrganization >> notifyOfAddedCategory: protocolName [
-
-	self deprecated: 'Use #notifyOfAddedProtocol: instead.' transformWith: '`@rcv notifyOfAddedCategory: `@arg' -> '`@rcv notifyOfAddedProtocol: `@arg'.
-	self notifyOfAddedProtocol: protocolName
-]
-
-{ #category : #'*Deprecated12' }
 ClassOrganization >> notifyOfChangedCategoriesFrom: oldProtocolName to: newProtocolName [
 
 	self
 		deprecated: 'Use #notifyOfChangedProtocolNamesFrom:to: instead.'
 		transformWith: '`@rcv notifyOfChangedCategoriesFrom: `@arg1 to: `@arg2' -> '`@rcv notifyOfChangedProtocolNamesFrom: `@arg1 to: `@arg2'.
 	self notifyOfChangedProtocolNamesFrom: oldProtocolName to: newProtocolName
-]
-
-{ #category : #'*Deprecated12' }
-ClassOrganization >> notifyOfChangedCategoryFrom: oldNameOrNil to: newNameOrNil [
-
-	self
-		deprecated: 'Use #notifyOfChangedProtocolNameFrom: instead.'
-		transformWith: '`@rcv notifyOfChangedCategoryFrom: `@arg1 to: `@arg2' -> '`@rcv notifyOfChangedProtocolNameFrom: `@arg1 to: `@arg2'.
-	self notifyOfChangedProtocolNameFrom: oldNameOrNil to: newNameOrNil
 ]
 
 { #category : #'*Deprecated12' }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -33,7 +33,7 @@ ClassOrganization >> addProtocolNamed: protocolName [
 	oldProtocols := self protocolNames copy.
 
 	protocol := self addSilentlyProtocolNamed: protocolName.
-	self notifyOfAddedProtocol: protocolName.
+	SystemAnnouncer uniqueInstance protocolAdded: protocolName inClass: self organizedClass.
 	self notifyOfChangedProtocolNamesFrom: oldProtocols to: self protocolNames.
 	^ protocol
 ]
@@ -213,20 +213,6 @@ ClassOrganization >> moveMethodsFrom: fromProtocolNamed to: toProtocolNamed [
 ]
 
 { #category : #notifications }
-ClassOrganization >> notifyOfAddedProtocol: protocolName [
-
-	SystemAnnouncer uniqueInstance protocolAdded: protocolName inClass: self organizedClass
-]
-
-{ #category : #notifications }
-ClassOrganization >> notifyOfChangedProtocolNameFrom: oldNameOrNil to: newNameOrNil [
-
-	oldNameOrNil ~= newNameOrNil ifFalse: [ ^ self ].
-	SystemAnnouncer uniqueInstance protocolRenamedFrom: oldNameOrNil to: newNameOrNil inClass: self organizedClass.
-	SystemAnnouncer uniqueInstance classReorganized: self organizedClass
-]
-
-{ #category : #notifications }
 ClassOrganization >> notifyOfChangedProtocolNamesFrom: oldProtocols to: newProtocols [
 
 	oldProtocols ~= newProtocols ifTrue: [ SystemAnnouncer uniqueInstance classReorganized: self organizedClass ]
@@ -359,9 +345,13 @@ ClassOrganization >> renameProtocolNamed: oldName toBe: newName [
 
 	self silentlyRenameProtocolNamed: oldName toBe: newName.
 
-	self notifyOfChangedProtocolNameFrom: oldName to: newName.
-	"I need to notify also the selector changes, otherwise RPackage will not notice"
-	(self protocolNamed: newName) methodSelectors do: [ :each | self notifyOfChangedSelector: each from: oldName to: newName ]
+	"Announce the changes in the system"
+	oldName ~= newName ifTrue: [
+		SystemAnnouncer uniqueInstance protocolRenamedFrom: oldName to: newName inClass: self organizedClass.
+		SystemAnnouncer uniqueInstance classReorganized: self organizedClass.
+
+		"I need to notify also the selector changes, otherwise RPackage will not notice"
+		(self protocolNamed: newName) methodSelectors do: [ :each | self notifyOfChangedSelector: each from: oldName to: newName ] ]
 ]
 
 { #category : #initialization }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -167,12 +167,6 @@ ClassOrganization >> hasComment [
 ]
 
 { #category : #testing }
-ClassOrganization >> hasOrganizedClass [
-
-	^ organizedClass isNotNil
-]
-
-{ #category : #testing }
 ClassOrganization >> hasProtocolNamed: aString [
 
 	^ self protocols anySatisfy: [ :each | each name = aString ]
@@ -221,15 +215,13 @@ ClassOrganization >> moveMethodsFrom: fromProtocolNamed to: toProtocolNamed [
 { #category : #notifications }
 ClassOrganization >> notifyOfAddedProtocol: protocolName [
 
-	self hasOrganizedClass ifFalse: [ ^ self ].
-
 	SystemAnnouncer uniqueInstance protocolAdded: protocolName inClass: self organizedClass
 ]
 
 { #category : #notifications }
 ClassOrganization >> notifyOfChangedProtocolNameFrom: oldNameOrNil to: newNameOrNil [
 
-	(self hasOrganizedClass and: [ oldNameOrNil ~= newNameOrNil ]) ifFalse: [ ^ self ].
+	oldNameOrNil ~= newNameOrNil ifFalse: [ ^ self ].
 	SystemAnnouncer uniqueInstance protocolRenamedFrom: oldNameOrNil to: newNameOrNil inClass: self organizedClass.
 	SystemAnnouncer uniqueInstance classReorganized: self organizedClass
 ]
@@ -237,19 +229,17 @@ ClassOrganization >> notifyOfChangedProtocolNameFrom: oldNameOrNil to: newNameOr
 { #category : #notifications }
 ClassOrganization >> notifyOfChangedProtocolNamesFrom: oldProtocols to: newProtocols [
 
-	(self hasOrganizedClass and: [ oldProtocols ~= newProtocols ]) ifTrue: [ SystemAnnouncer uniqueInstance classReorganized: self organizedClass ]
+	oldProtocols ~= newProtocols ifTrue: [ SystemAnnouncer uniqueInstance classReorganized: self organizedClass ]
 ]
 
 { #category : #notifications }
 ClassOrganization >> notifyOfChangedSelector: element from: oldProtocolName to: newProtocolName [
 
-	(self hasOrganizedClass and: [ oldProtocolName ~= newProtocolName ]) ifTrue: [ self organizedClass notifyOfRecategorizedSelector: element from: oldProtocolName to: newProtocolName ]
+	oldProtocolName ~= newProtocolName ifTrue: [ self organizedClass notifyOfRecategorizedSelector: element from: oldProtocolName to: newProtocolName ]
 ]
 
 { #category : #notifications }
 ClassOrganization >> notifyOfRemovedProtocolNamed: protocolName [
-
-	self hasOrganizedClass ifFalse: [ ^ self ].
 
 	SystemAnnouncer uniqueInstance protocolRemoved: protocolName inClass: self organizedClass
 ]
@@ -257,7 +247,7 @@ ClassOrganization >> notifyOfRemovedProtocolNamed: protocolName [
 { #category : #accessing }
 ClassOrganization >> organizedClass [
 
-	^ organizedClass
+	^ organizedClass ifNil: [ self error: 'ClassOrganization should always have an organized class associated.' ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
The announcement system of a class organization happens only if it has a class associated. But we should *always* have an associated class.  Since the long terme goal is to clean ClassOraganization and move the remaining behavior to ClassDescription, I propose to remove all those checks directly because once it will be in ClassDescription it will be absolutly sure that we have the organized class.

I also inlined 2 methods that became simpler and are called only in one place. This is to reduce ClassOrganization API size since we want to inline it in the future without polluting too much ClassDescription API.

Let's see if this will break something