### PR TITLE
Make protocols an array in ClassOrganization

### DIFF
--- a/src/CodeExport/ClassOrganization.extension.st
+++ b/src/CodeExport/ClassOrganization.extension.st
@@ -32,14 +32,14 @@ ClassOrganization >> putCommentOnFile: aFileStream forClass: aClass [
 ClassOrganization >> stringForFileOut [
 
 	^ String streamContents: [ :aStream |
-		  self protocols do: [ :p |
+		  self protocols do: [ :protocol |
 			  aStream
 				  nextPut: $(;
-				  nextPutAll: p name printString.
-			  p methodSelectors do: [ :m |
+				  nextPutAll: protocol name printString.
+			  protocol methodSelectors do: [ :selector |
 				  aStream
 					  space;
-					  nextPutAll: m ].
+					  nextPutAll: selector ].
 			  aStream
 				  nextPut: $);
 				  cr ] ]

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -21,7 +21,10 @@ ClassOrganization class >> forClass: aClass [
 { #category : #adding }
 ClassOrganization >> addProtocol: aProtocol [
 
-	^ protocols add: aProtocol
+	(self protocols includes: aProtocol) ifTrue: [ ^ aProtocol ].
+
+	protocols := protocols copyWith: aProtocol.
+	^ aProtocol
 ]
 
 { #category : #accessing }
@@ -64,15 +67,13 @@ ClassOrganization >> classComment: aString [
 
 { #category : #'protocol - adding' }
 ClassOrganization >> classify: aSymbol inProtocolNamed: aProtocolName [
-
-	| protocol |
 	"maybe here we should check if this method already belong to another protocol"
-	self protocols
-		select: [ :p | p includesSelector: aSymbol ]
-		thenDo: [ :p | p removeMethodSelector: aSymbol ].
-	protocol := self protocolNamed: aProtocolName ifAbsent: [ self addSilentlyProtocolNamed: aProtocolName ].
 
-	protocol addMethodSelector: aSymbol
+	self protocols
+		select: [ :protocol | protocol includesSelector: aSymbol ]
+		thenDo: [ :protocol | protocol removeMethodSelector: aSymbol ].
+	(self protocolNamed: aProtocolName ifAbsent: [ self addSilentlyProtocolNamed: aProtocolName ])
+		addMethodSelector: aSymbol
 ]
 
 { #category : #'backward compatibility' }
@@ -274,13 +275,13 @@ ClassOrganization >> protocolNames [
 { #category : #accessing }
 ClassOrganization >> protocols [
 
-	^ protocols asArray
+	^ protocols
 ]
 
 { #category : #protocol }
 ClassOrganization >> protocolsOfSelector: aSelector [
 
-	^ (self protocols select: [:each | each includesSelector: aSelector ]) asArray
+	^ self protocols select: [ :each | each includesSelector: aSelector ]
 ]
 
 { #category : #removing }
@@ -313,7 +314,7 @@ ClassOrganization >> removeProtocolIfEmpty: aProtocol [
 	protocol isEmpty ifFalse: [ ^ self ].
 
 	oldProtocolNames := self protocolNames copy.
-	protocols remove: protocol ifAbsent: [  ].
+	protocols := protocols copyWithout: protocol.
 	self notifyOfRemovedProtocolNamed: protocol name.
 	self notifyOfChangedProtocolNamesFrom: oldProtocolNames to: self protocolNames
 ]
@@ -337,7 +338,7 @@ ClassOrganization >> renameProtocolNamed: oldName toBe: newName [
 { #category : #initialization }
 ClassOrganization >> reset [
 
-	protocols := IdentitySet new
+	protocols := Array new
 ]
 
 { #category : #'backward compatibility' }


### PR DESCRIPTION
ClassOrganization is storing protocols into an Identity set but almost all operations applied on them  transform the protocols into an array. I think we will save memory and maybe even time by just keeping an array of protocols. Adding/Removing might be a tiny bit slower but we will avoid a lot of casting.

I also renamed some temporaries to make the code more readable.

I hope this will not break anything because I think some parts lack tests in ClassOrganization. I plan to add them, but I want to finish my cleanings before because some of the behaviors with missing tests I currently found are in methods on my killing list or my list of methods to improve.