### PR TITLE
Always announce creation of new protocols

### DIFF
--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -846,11 +846,11 @@ ClassDescription >> organization [
 	"Answer the instance of ClassOrganizer that represents the organization
 	of the messages of the receiver."
 
-	self basicOrganization
-		ifNil: [ self basicOrganization: (self isTrait
-						ifTrue: [ ClassOrganization new ]
-						ifFalse: [ ClassOrganization forClass: self ]) ].
-	^self basicOrganization setSubject: self.	"Making sure that subject is set correctly. It should not be necessary."
+	self basicOrganization ifNil: [
+		| classOrganization |
+		self basicOrganization: (classOrganization := ClassOrganization new).
+		self isTrait ifFalse: [ classOrganization initializeClass: self ] ].
+	^ self basicOrganization setSubject: self "Making sure that subject is set correctly. It should not be necessary."
 ]
 
 { #category : #organization }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -32,16 +32,10 @@ ClassOrganization >> addProtocolNamed: protocolName [
 
 	oldProtocols := self protocolNames copy.
 
-	protocol := self addSilentlyProtocolNamed: protocolName.
+	protocol := self addProtocol: (Protocol name: protocolName).
 	SystemAnnouncer uniqueInstance protocolAdded: protocolName inClass: self organizedClass.
 	self notifyOfChangedProtocolNamesFrom: oldProtocols to: self protocolNames.
 	^ protocol
-]
-
-{ #category : #accessing }
-ClassOrganization >> addSilentlyProtocolNamed: protocolName [
-	
-	^ self addProtocol: (Protocol name: protocolName)
 ]
 
 { #category : #'backward compatibility' }
@@ -66,12 +60,7 @@ ClassOrganization >> classComment: aString [
 ClassOrganization >> classify: aSymbol inProtocolNamed: aProtocolName [
 
 	| protocol |
-	protocol := self protocolNamed: aProtocolName ifAbsent: [
-		            Smalltalk globals at: #Transcript ifPresent: [ :t |
-			            t
-				            show: 'Preparing to add protocol named ' , aProtocolName , ' to classify ' , aSymbol , ' into ' , organizedClass name;
-				            cr ].
-		            self addProtocolNamed: aProtocolName ].
+	protocol := self protocolNamed: aProtocolName ifAbsent: [ self addProtocolNamed: aProtocolName ].
 	"maybe here we should check if this method already belong to another protocol"
 	self protocols
 		select: [ :p | p includesSelector: aSymbol ]
@@ -193,7 +182,11 @@ ClassOrganization >> initializeClass: aClass [
 
 	self initialize.
 	organizedClass := aClass.
-	organizedClass selectors do: [ :each | self classify: each under: Protocol unclassified ]
+	organizedClass selectors ifNotEmpty: [ :selectors |
+		| protocol |
+		"We initialize silently the first protocol without announcing it because the announcements this early would lead to a new class initialization in the case of TraitedMetaclass and this would create an infinit loop."
+		protocol := self addProtocol: Protocol new.
+		selectors do: [ :each | self classify: each under: protocol ] ]
 ]
 
 { #category : #accessing }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -66,7 +66,9 @@ ClassOrganization >> classComment: aString [
 ClassOrganization >> classify: aSymbol inProtocolNamed: aProtocolName [
 
 	| protocol |
-	protocol := self protocolNamed: aProtocolName ifAbsent: [ self addProtocolNamed: aProtocolName ].
+	protocol := self protocolNamed: aProtocolName ifAbsent: [
+		            ('Preparing to add protocol named ' , aProtocolName , ' to classify ' , aSymbol , ' into ' , organizedClass name) traceCr.
+		            self addProtocolNamed: aProtocolName ].
 	"maybe here we should check if this method already belong to another protocol"
 	self protocols
 		select: [ :p | p includesSelector: aSymbol ]

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -66,11 +66,11 @@ ClassOrganization >> classComment: aString [
 ClassOrganization >> classify: aSymbol inProtocolNamed: aProtocolName [
 
 	| protocol |
+	protocol := self protocolNamed: aProtocolName ifAbsent: [ self addProtocolNamed: aProtocolName ].
 	"maybe here we should check if this method already belong to another protocol"
 	self protocols
 		select: [ :p | p includesSelector: aSymbol ]
 		thenDo: [ :p | p removeMethodSelector: aSymbol ].
-	protocol := self protocolNamed: aProtocolName ifAbsent: [ self addSilentlyProtocolNamed: aProtocolName ].
 
 	protocol addMethodSelector: aSymbol
 ]

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -182,7 +182,7 @@ ClassOrganization >> initializeClass: aClass [
 
 	self initialize.
 	organizedClass := aClass.
-	organizedClass selectors ifNotEmpty: [ :selectors | selectors do: [ :each | self classify: each under: Protocol unclassified ] ]
+	organizedClass selectors do: [ :each | self classify: each under: Protocol unclassified ]
 ]
 
 { #category : #accessing }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -182,11 +182,7 @@ ClassOrganization >> initializeClass: aClass [
 
 	self initialize.
 	organizedClass := aClass.
-	organizedClass selectors ifNotEmpty: [ :selectors |
-		| protocol |
-		"We initialize silently the first protocol without announcing it because the announcements this early would lead to a new class initialization in the case of TraitedMetaclass and this would create an infinit loop."
-		protocol := self addProtocol: Protocol new.
-		selectors do: [ :each | self classify: each under: protocol ] ]
+	organizedClass selectors ifNotEmpty: [ :selectors | selectors do: [ :each | self classify: each under: Protocol unclassified ] ]
 ]
 
 { #category : #accessing }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -67,7 +67,10 @@ ClassOrganization >> classify: aSymbol inProtocolNamed: aProtocolName [
 
 	| protocol |
 	protocol := self protocolNamed: aProtocolName ifAbsent: [
-		            ('Preparing to add protocol named ' , aProtocolName , ' to classify ' , aSymbol , ' into ' , organizedClass name) traceCr.
+		            Smalltalk globals at: #Transcript ifPresent: [ :t |
+			            t
+				            show: 'Preparing to add protocol named ' , aProtocolName , ' to classify ' , aSymbol , ' into ' , organizedClass name;
+				            cr ].
 		            self addProtocolNamed: aProtocolName ].
 	"maybe here we should check if this method already belong to another protocol"
 	self protocols


### PR DESCRIPTION
In the current Pharo, we do not always announce the creation of a new protocol.

In the recent past we had two classes to classify a protocol:
- ClassOrganization with #classify:under: 
- ProtocolOrganizer with #classify:inProtocolNamed: 

The problem is that ProtocolOrganizer was not announcing any change happening and it was the responsibility of ClassOrganization. This means that any user of #classify:inProtocolNamed: does not announce the creation of a new protocol if the protocol in parameter does not exist yet.

While merging ClassOrganization and ProtocolOrganizer I tried to merge both methods and unify the behavior but this caused the bootstrap to crash.

Today I am trying once again to announce all protocol creations. The origin of the previous crash is an infinite loop that was caused by the management of TraitedMetaclass. It was going like this:
- We want to load a class with traits and class side methods in the trait
- The class is added to the system
- The organization of the TraitedMetaclass is initialized
- Creating the organization adds all methods to #'as yet unclassified'
- Adding the methods to this protocol first create the protocol
- Creating the protocol announce the creation if we do not silently add the protocol
- RPackage listen to this event and ask the protocols of the class to do some checks
- To get the protocols we need the organization of the TraitedMetaclass
- The organization did not finish its initialization, the variable is still need, and here we go again in the defensive strategy.  Go back in step 3 and enjoy your ride of "We have an infinit loop"

With the removal of the silent add of this PR, I directly save the instance of ClassOrganization before initializing the protocols so that RPackage is happy and can ask the organization what are the current protocols. 

Let's see if that is enough to fix this bug of silent protocol add.
If this is not enough, I will have to keep the silent add, but I will use it **only** for the initialization of the class organization and nothing more. (We currently have 4 places in the system that use this silent protocol addition).

Little bonus: 1 less method in ClassOrganization (and no other method that got more complexe). This mean 1 tiny step toward a ClassOrganization we can inline in ClassDescription :)

This PR is really small but it was not easy to find the problem.