### PR TITLE
ASTCache add statistics, then use LRUCache

### DIFF
--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -91,6 +91,17 @@ ASTCache >> at: aCompiledMethod [
 				  self class cacheMissStrategy getASTFor: aCompiledMethod ] ]
 ]
 
+{ #category : #printing }
+ASTCache >> printElementsOn: stream [
+
+	stream
+		nextPut: $#;
+		print: self size;
+		space;
+		print: (self statistics hitRatio * 100.0) rounded;
+		nextPut: $%
+]
+
 { #category : #initialization }
 ASTCache >> reset [
 	self removeAll.

--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -99,7 +99,7 @@ ASTCache >> at: aCollection ifAbsentPut: aRBMethodNode [
 { #category : #accessing }
 ASTCache >> at: aCollection put: aRBMethodNode [
 
-	self cache at: aCollection put: [ aRBMethodNode ]
+	self cache at: aCollection put: aRBMethodNode
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -108,7 +108,7 @@ ASTCache >> cache [
 	^ cache ifNil: [ "I don't want to depend on System-Caching. So, no system caching, no cache :P"
 		  Smalltalk globals
 			  at: #LRUCache
-			  ifPresent: [ :class | cache := class new ] ]
+			  ifPresent: [ :class | cache := class new beThreadSafe; keyIndex: IdentityDictionary new ] ]
 ]
 
 { #category : #printing }

--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -88,6 +88,12 @@ ASTCache >> at: aCompiledMethod [
 ]
 
 { #category : #accessing }
+ASTCache >> at: aCollection ifAbsentPut: aRBMethodNode [
+
+	self cache at: aCollection ifAbsentPut: aRBMethodNode
+]
+
+{ #category : #accessing }
 ASTCache >> cache [
 
 	^ cache ifNil: [ cache := LRUCache new ]

--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -79,34 +79,39 @@ ASTCache class >> shutDown [
 
 { #category : #accessing }
 ASTCache >> at: aCompiledMethod [
-	"For doit methods, the AST is stored in the method property"
 
-	(aCompiledMethod propertyAt: #reflectiveMethod) ifNotNil: [
-		:reflectiveMethod | ^ reflectiveMethod ast ].
-
-	^ aCompiledMethod propertyAt: #ast ifAbsent: [
-		weakdict at: aCompiledMethod ifPresent: [ :ast | ^ ast ].
-		  self cache
-			  ifNil: [ self getASTFor: aCompiledMethod ]
-			  ifNotNil: [
-				  self cache
-					  at: aCompiledMethod
-					  ifAbsentPut: [
-					  self getASTFor: aCompiledMethod ] ] ]
+	^ self
+		  at: aCompiledMethod
+		  ifAbsentPut: [ self getASTFor: aCompiledMethod ]
 ]
 
 { #category : #accessing }
 ASTCache >> at: aCompiledMethod ifAbsentPut: aBlock [
+	"Reflective methods have a strongly held AST (with possible metalink)"
 
-	self weakdict at: aCompiledMethod ifAbsentPut: aBlock.
-	self cache at: aCompiledMethod ifAbsentPut: aBlock
+	(aCompiledMethod propertyAt: #reflectiveMethod) ifNotNil: [
+		:reflectiveMethod | ^ reflectiveMethod ast ].
+
+	"For doit methods, the AST is stored in the method property"
+	^ aCompiledMethod
+		  propertyAt: #ast
+		  ifAbsent: [ "Otherwise look at the weak dictionaly to resuse existing (non collected) AST"
+			  weakdict at: aCompiledMethod ifPresent: [ :ast | ^ ast ].
+			  "Otherwise look at the LRU cache, for recent AST"
+			  self cache
+				  ifNil: [ aBlock value ]
+				  ifNotNil: [ self cache at: aCompiledMethod ifAbsentPut: aBlock ] ]
 ]
 
 { #category : #accessing }
-ASTCache >> at: aCollection put: aRBMethodNode [
+ASTCache >> at: aCompiledMethod put: aRBMethodNode [
+	"weakdict is bad and can become large, a cleaning method exists in as an extension method in calypso..."
 
-	self weakdict at: aCollection put: aRBMethodNode.
-	self cache at: aCollection put: aRBMethodNode
+	(weakdict respondsTo: #clyCleanGarbage) ifTrue: [
+		weakdict clyCleanGarbage ].
+
+	weakdict at: aCompiledMethod put: aRBMethodNode.
+	self cache ifNotNil: [ self cache at: aCompiledMethod put: aRBMethodNode ]
 ]
 
 { #category : #accessing }
@@ -125,11 +130,7 @@ ASTCache >> getASTFor: aCompiledMethod [
 
 	| ast |
 	ast := self class cacheMissStrategy getASTFor: aCompiledMethod.
-	"weakdict is bad and can become large, a cleaning method exists in as an extension method in calypso..."
-	(weakdict respondsTo: #clyCleanGarbage) ifTrue: [
-		weakdict clyCleanGarbage ].
-	weakdict at: aCompiledMethod put: ast.
-	cache ifNotNil: [ cache at: aCompiledMethod put: ast ].
+	self at: aCompiledMethod put: ast.
 	^ ast
 ]
 
@@ -137,6 +138,9 @@ ASTCache >> getASTFor: aCompiledMethod [
 ASTCache >> printOn: aStream [
 
 	super printOn: aStream.
+	aStream nextPutAll: ' dict#'.
+	aStream print: weakdict size.
+	aStream nextPutAll: ' LRU'.
 	self cache printElementsOn: aStream
 ]
 

--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -17,9 +17,9 @@ Code that wants to modify the AST without making sure the compiledMethod is in s
 "
 Class {
 	#name : #ASTCache,
-	#superclass : #WeakIdentityKeyDictionary,
+	#superclass : #Object,
 	#instVars : [
-		'statistics'
+		'cache'
 	],
 	#classVars : [
 		'CacheMissStrategy'
@@ -81,35 +81,27 @@ ASTCache >> at: aCompiledMethod [
 	"For doit methods, the AST is stored in the method property"
 
 	^ aCompiledMethod propertyAt: #ast ifAbsent: [
-		  self
+		  self cache
 			  at: aCompiledMethod
-			  ifPresent: [ :it |
-				  self statistics addHit.
-				  it ]
 			  ifAbsentPut: [
-				  self statistics addMiss.
-				  self class cacheMissStrategy getASTFor: aCompiledMethod ] ]
+			  self class cacheMissStrategy getASTFor: aCompiledMethod ] ]
+]
+
+{ #category : #accessing }
+ASTCache >> cache [
+
+	^ cache ifNil: [ cache := LRUCache new ]
 ]
 
 { #category : #printing }
-ASTCache >> printElementsOn: stream [
+ASTCache >> printOn: aStream [
 
-	stream
-		nextPut: $#;
-		print: self size;
-		space;
-		print: (self statistics hitRatio * 100.0) rounded;
-		nextPut: $%
+	super printOn: aStream.
+	self cache printElementsOn: aStream
 ]
 
 { #category : #initialization }
 ASTCache >> reset [
-	self removeAll.
-	statistics := nil
-]
 
-{ #category : #accessing }
-ASTCache >> statistics [
-
-	^ statistics ifNil: [ statistics := CacheStatistics new ]
+	self cache removeAll
 ]

--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -82,9 +82,12 @@ ASTCache >> at: aCompiledMethod [
 
 	^ aCompiledMethod propertyAt: #ast ifAbsent: [
 		  self cache
-			  at: aCompiledMethod
-			  ifAbsentPut: [
-			  self class cacheMissStrategy getASTFor: aCompiledMethod ] ]
+			  ifNil: [ self class cacheMissStrategy getASTFor: aCompiledMethod ]
+			  ifNotNil: [
+				  self cache
+					  at: aCompiledMethod
+					  ifAbsentPut: [
+					  self class cacheMissStrategy getASTFor: aCompiledMethod ] ] ]
 ]
 
 { #category : #accessing }
@@ -96,7 +99,10 @@ ASTCache >> at: aCollection ifAbsentPut: aRBMethodNode [
 { #category : #accessing }
 ASTCache >> cache [
 
-	^ cache ifNil: [ cache := LRUCache new ]
+	^ cache ifNil: [ "I don't want to depend on System-Caching. So, no system caching, no cache :P"
+		  Smalltalk globals
+			  at: #LRUCache
+			  ifPresent: [ :class | cache := class new ] ]
 ]
 
 { #category : #printing }
@@ -109,5 +115,6 @@ ASTCache >> printOn: aStream [
 { #category : #initialization }
 ASTCache >> reset [
 
-	self cache removeAll
+	self cache removeAll.
+	cache := nil
 ]

--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -96,10 +96,10 @@ ASTCache >> at: aCompiledMethod [
 ]
 
 { #category : #accessing }
-ASTCache >> at: aCollection ifAbsentPut: aRBMethodNode [
+ASTCache >> at: aCompiledMethod ifAbsentPut: aBlock [
 
-	self weakdict at: aCollection ifAbsentPut: [ aRBMethodNode ].
-	self cache at: aCollection ifAbsentPut: [ aRBMethodNode ]
+	self weakdict at: aCompiledMethod ifAbsentPut: aBlock.
+	self cache at: aCompiledMethod ifAbsentPut: aBlock
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -97,6 +97,12 @@ ASTCache >> at: aCollection ifAbsentPut: aRBMethodNode [
 ]
 
 { #category : #accessing }
+ASTCache >> at: aCollection put: aRBMethodNode [
+
+	self cache at: aCollection put: [ aRBMethodNode ]
+]
+
+{ #category : #accessing }
 ASTCache >> cache [
 
 	^ cache ifNil: [ "I don't want to depend on System-Caching. So, no system caching, no cache :P"

--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -90,7 +90,7 @@ ASTCache >> at: aCompiledMethod [
 { #category : #accessing }
 ASTCache >> at: aCollection ifAbsentPut: aRBMethodNode [
 
-	self cache at: aCollection ifAbsentPut: aRBMethodNode
+	self cache at: aCollection ifAbsentPut: [ aRBMethodNode ]
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -19,7 +19,8 @@ Class {
 	#name : #ASTCache,
 	#superclass : #Object,
 	#instVars : [
-		'cache'
+		'cache',
+		'weakdict'
 	],
 	#classVars : [
 		'CacheMissStrategy'
@@ -80,25 +81,31 @@ ASTCache class >> shutDown [
 ASTCache >> at: aCompiledMethod [
 	"For doit methods, the AST is stored in the method property"
 
+	(aCompiledMethod propertyAt: #reflectiveMethod) ifNotNil: [
+		:reflectiveMethod | ^ reflectiveMethod ast ].
+
 	^ aCompiledMethod propertyAt: #ast ifAbsent: [
+		weakdict at: aCompiledMethod ifPresent: [ :ast | ^ ast ].
 		  self cache
-			  ifNil: [ self class cacheMissStrategy getASTFor: aCompiledMethod ]
+			  ifNil: [ self getASTFor: aCompiledMethod ]
 			  ifNotNil: [
 				  self cache
 					  at: aCompiledMethod
 					  ifAbsentPut: [
-					  self class cacheMissStrategy getASTFor: aCompiledMethod ] ] ]
+					  self getASTFor: aCompiledMethod ] ] ]
 ]
 
 { #category : #accessing }
 ASTCache >> at: aCollection ifAbsentPut: aRBMethodNode [
 
+	self weakdict at: aCollection ifAbsentPut: [ aRBMethodNode ].
 	self cache at: aCollection ifAbsentPut: [ aRBMethodNode ]
 ]
 
 { #category : #accessing }
 ASTCache >> at: aCollection put: aRBMethodNode [
 
+	self weakdict at: aCollection put: aRBMethodNode.
 	self cache at: aCollection put: aRBMethodNode
 ]
 
@@ -106,9 +113,24 @@ ASTCache >> at: aCollection put: aRBMethodNode [
 ASTCache >> cache [
 
 	^ cache ifNil: [ "I don't want to depend on System-Caching. So, no system caching, no cache :P"
-		  Smalltalk globals
-			  at: #LRUCache
-			  ifPresent: [ :class | cache := class new beThreadSafe; keyIndex: IdentityDictionary new ] ]
+		  Smalltalk globals at: #LRUCache ifPresent: [ :class |
+			  cache := class new
+				           beThreadSafe;
+				           maximumWeight: 1; "Force 1-slot LRU"
+				           keyIndex: IdentityDictionary new ] ]
+]
+
+{ #category : #accessing }
+ASTCache >> getASTFor: aCompiledMethod [
+
+	| ast |
+	ast := self class cacheMissStrategy getASTFor: aCompiledMethod.
+	"weakdict is bad and can become large, a cleaning method exists in as an extension method in calypso..."
+	(weakdict respondsTo: #clyCleanGarbage) ifTrue: [
+		weakdict clyCleanGarbage ].
+	weakdict at: aCompiledMethod put: ast.
+	cache ifNotNil: [ cache at: aCompiledMethod put: ast ].
+	^ ast
 ]
 
 { #category : #printing }
@@ -122,5 +144,12 @@ ASTCache >> printOn: aStream [
 ASTCache >> reset [
 
 	self cache removeAll.
+	self weakdict removeAll.
 	cache := nil
+]
+
+{ #category : #accessing }
+ASTCache >> weakdict [
+
+	^ weakdict ifNil: [ weakdict := WeakIdentityValueDictionary new ]
 ]

--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -18,6 +18,9 @@ Code that wants to modify the AST without making sure the compiledMethod is in s
 Class {
 	#name : #ASTCache,
 	#superclass : #WeakIdentityKeyDictionary,
+	#instVars : [
+		'statistics'
+	],
 	#classVars : [
 		'CacheMissStrategy'
 	],
@@ -76,14 +79,26 @@ ASTCache class >> shutDown [
 { #category : #accessing }
 ASTCache >> at: aCompiledMethod [
 	"For doit methods, the AST is stored in the method property"
+
 	^ aCompiledMethod propertyAt: #ast ifAbsent: [
 		  self
 			  at: aCompiledMethod
+			  ifPresent: [ :it |
+				  self statistics addHit.
+				  it ]
 			  ifAbsentPut: [
-			  self class cacheMissStrategy getASTFor: aCompiledMethod ] ]
+				  self statistics addMiss.
+				  self class cacheMissStrategy getASTFor: aCompiledMethod ] ]
 ]
 
 { #category : #initialization }
 ASTCache >> reset [
-	self removeAll
+	self removeAll.
+	statistics := nil
+]
+
+{ #category : #accessing }
+ASTCache >> statistics [
+
+	^ statistics ifNil: [ statistics := CacheStatistics new ]
 ]

--- a/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
@@ -275,7 +275,7 @@ ClyMethodCodeEditorToolMorph >> printContext [
 { #category : #initialization }
 ClyMethodCodeEditorToolMorph >> resetASTCache [
 	"when the AST cache is cleared, we have to rescue the AST we are looking at"
-	ASTCache default at: ast compiledMethod ifAbsentPut: ast
+	ASTCache default at: ast compiledMethod ifAbsentPut: [ ast ]
 ]
 
 { #category : #'selecting text' }

--- a/src/System-Caching/LRUCache.class.st
+++ b/src/System-Caching/LRUCache.class.st
@@ -183,6 +183,14 @@ LRUCache >> isEmpty [
 	^ keyIndex isEmpty
 ]
 
+{ #category : #accessing }
+LRUCache >> keyIndex: anObject [
+	"Use you own dictionary"
+
+	self removeAll.
+	keyIndex := anObject
+]
+
 { #category : #enumerating }
 LRUCache >> keysAndValuesDo: block [
 	"Execute block with each key and value present in me.


### PR DESCRIPTION
Solving resource issues need precise numbers, so in order to understand  #8984 I added a cache statistic to the ASTCache, then used a LRUCache instead.

Note that ASTCache is a subclass of WeakIdentityKeyDictionary that associates a compiled method to an AST. Most compiled methods rests in the system for long time, but actively developed part of the system should have a higher turn over. However, using a weak dictionary here seems a bad idea. The weak part permits unused method to be garbage collected (the cache do not hold then strongly), but long living method (most of them!) will stay in the cache forever.

Some stats with WeakIdentityKeyDictionary

* after a full `Smalltalk recompile` then a `ASTCache reset`: `an ASTCache#9 0%`
* after DrTest all tests (1248) of `OpalCompiler-Tests`: `an ASTCache#67 74%`
* (reset astcache)  all critiques on Kernel (that has the most methods, 4153): `an ASTCache#4317 99%` make sense because the same AST is used again and again
* (reset astcache)  a single critique 'Dead Block' on Kernel (that has the most methods, 4153): `an ASTCache#4317 0%` make sense because the same AST is not reused

Some stats with LRUCache

* after a full `Smalltalk recompile` then a `ASTCache reset`: `an ASTCache#3 3/16 [ 1 ] 99%`
* after DrTest all tests (1248) of `OpalCompiler-Tests`: `an ASTCache#16 16/16 [ 1 ] 99%`
* (reset astcache)  all critiques on Kernel (that has the most methods, 4153): `an ASTCache#16 16/16 [ 1 ] 99%`
* (reset astcache)  a single critique 'Dead Block' on Kernel: `an ASTCache#16 16/16 [ 1 ] 98%`