### PR TITLE
Rename Protocol class>>#ambiguous into #traitConflictName

### DIFF
--- a/src/Kernel/Protocol.class.st
+++ b/src/Kernel/Protocol.class.st
@@ -13,11 +13,6 @@ Class {
 }
 
 { #category : #'instance creation' }
-Protocol class >> ambiguous [
-	^ #ambiguous
-]
-
-{ #category : #'instance creation' }
 Protocol class >> name: nm [
 
 	^ self new

--- a/src/TraitsV2-Compatibility/TraitMethodDescription.class.st
+++ b/src/TraitsV2-Compatibility/TraitMethodDescription.class.st
@@ -72,7 +72,7 @@ TraitMethodDescription >> effectiveMethodCategoryCurrent: currentCategoryOrNil n
 	isConflict ifFalse: [^ result].
 	(isCurrent not and: [newCategoryOrNil notNil]) ifTrue: [^ newCategoryOrNil].
 
-	^ Protocol ambiguous
+	^ Protocol traitConflictName
 ]
 
 { #category : #private }

--- a/src/TraitsV2-Tests/TraitMethodDescriptionTest.class.st
+++ b/src/TraitsV2-Tests/TraitMethodDescriptionTest.class.st
@@ -83,19 +83,19 @@ TraitMethodDescriptionTest >> testConflictingCategories [
 	| t7 t8 |
 	self t2 compile: 'm11' classified: #catY.
 	self assert: (self t4 organization protocolNameOfElement: #m11) equals: #catX.
-	self assert: (self t5 organization protocolNameOfElement: #m11) equals: Protocol ambiguous.
+	self assert: (self t5 organization protocolNameOfElement: #m11) equals: Protocol traitConflictName.
 	t7 := self createTraitNamed: #T7 uses: self t1 + self t2.
-	self assert: (t7 organization protocolNameOfElement: #m11) equals: Protocol ambiguous.
+	self assert: (t7 organization protocolNameOfElement: #m11) equals: Protocol traitConflictName.
 	self t1 removeSelector: #m11.
 	self assert: (self t4 organization protocolNameOfElement: #m11) equals: #catX.
 	self assert: (self t5 organization protocolNameOfElement: #m11) equals: #catY.
 	self assert: (t7 organization protocolNameOfElement: #m11) equals: #catY.
-	self assert: (t7 organization protocolNames includes: Protocol ambiguous) not.
+	self deny: (t7 organization protocolNames includes: Protocol traitConflictName).
 	self t1 compile: 'm11' classified: #cat1.
 	t8 := self createTraitNamed: #T8 uses: self t1 + self t2.
 	t8 organization classify: #m11 under: #cat1.
 	self t1 organization classify: #m11 under: #catZ.
 	self assert: (self t4 organization protocolNameOfElement: #m11) equals: #catX.
-	self assert: (self t5 organization protocolNameOfElement: #m11) equals: Protocol ambiguous.
+	self assert: (self t5 organization protocolNameOfElement: #m11) equals: Protocol traitConflictName.
 	self assert: (t8 organization protocolNameOfElement: #m11) equals: #catZ
 ]

--- a/src/TraitsV2/Protocol.extension.st
+++ b/src/TraitsV2/Protocol.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #Protocol }
+
+{ #category : #'*TraitsV2' }
+Protocol class >> traitConflictName [
+	"I am protocol used when traits are bringing a method and a protocol conflict happens."
+
+	^ #'trait protocol conflict'
+]

--- a/src/TraitsV2/TaAbstractComposition.class.st
+++ b/src/TraitsV2/TaAbstractComposition.class.st
@@ -114,10 +114,11 @@ TaAbstractComposition >> asTraitComposition [
 
 { #category : #accessing }
 TaAbstractComposition >> categoryOfMethod: method withSelector: selector [
-	"I return the category of the method with the selector.
-	This is useful when the method is aliased or the method came from different traits or it is a conflicting category.
-	The basic implementation returns the category of the method"
-	^ method category
+	"I return the protocol of the method with the selector.
+	This is useful when the method is aliased or the method came from different traits or it is a conflicting protocol.
+	The basic implementation returns the protocol of the method"
+
+	^ method protocol
 ]
 
 { #category : #testing }

--- a/src/TraitsV2/TaSequence.class.st
+++ b/src/TraitsV2/TaSequence.class.st
@@ -84,14 +84,16 @@ TaSequence >> allTraits [
 ]
 
 { #category : #accessing }
-TaSequence >> categoryOfMethod: method withSelector: selector [
-	| categories |
+TaSequence >> categoryOfMethod: aMethod withSelector: selector [
 
-	categories := (self methods select: [ :e | e selector = selector ] thenCollect: #category) asSet.
+	| protocols |
+	protocols := (self methods
+		              select: [ :method | method selector = selector ]
+		              thenCollect: #protocol) asSet.
 
-	^ categories size = 1
-		ifTrue: [ ^ categories anyOne ]
-		ifFalse: [ Protocol ambiguous ]
+	^ protocols size = 1
+		  ifTrue: [ protocols anyOne ]
+		  ifFalse: [ Protocol traitConflictName ]
 ]
 
 { #category : #testing }


### PR DESCRIPTION
'ambiguous' is an ambiguous name in itself because it is hard to understand how it is useful with just the name. I propose to rename it into Protocol class>>traitConflictName.

Also, since it is an implementation detail of traits, I propose to move it to the TraitsV2 package.

I finally did some renamings toward the goal of removing the "category" vocabulary.