### PR TITLE
CI-Test with ASTCache disabled (do not merge)

### DIFF
--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -95,7 +95,7 @@ ASTCache >> at: aCompiledMethod ifAbsentPut: aBlock [
 	(aCompiledMethod propertyAt: #reflectiveMethod) ifNotNil: [ :rf | ^ rf ast ].
 
 	"Look in the (almost infinite) cache"
-	self weakDictionary at: aCompiledMethod ifPresent: [ :ast | ^ ast ].
+	"self weakDictionary at: aCompiledMethod ifPresent: [ :ast | ^ ast ]."
 
 	"We tried everything we could. So compute and store it"
 	^ self at: aCompiledMethod put: aBlock value

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -228,13 +228,13 @@ OCAbstractMethodScope >> removeTemp: tempVar [
 OCAbstractMethodScope >> setCopyingTempToAllScopesUpToDefTemp: aVar to: aValue from: aContext [
 	"we need to update all the copies if we change the value of a copied temp"
 
-	self = aVar scope
-		ifTrue: [ ^ aVar writeFromLocalContext: aContext put: aValue ].
-	(self lookupVar: aVar name) writeFromLocalContext: aContext put: aValue.
-	^self outerScope
-		setCopyingTempToAllScopesUpToDefTemp: aVar
-		to: aValue
-		from: (self nextOuterScopeContextOf: aContext)
+	(self lookupVar: aVar name)
+		writeFromLocalContext: aContext
+		put: aValue.
+	^ super
+		  setCopyingTempToAllScopesUpToDefTemp: aVar
+		  to: aValue
+		  from: aContext
 ]
 
 { #category : #'temp vars' }

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -140,7 +140,8 @@ OCAbstractMethodScope >> localTemps [
 OCAbstractMethodScope >> lookupDefiningContextForVariable: var startingFrom: aContext [
 	"Is this the definition context for var? If it not, we look in the outer context using the corresponding outer scope. If found, we return the context"
 
-	^self = var scope
+	"Because AST are not reliable, we do the correspondance on var names"
+	^ (self localTempNames includes: var name)
 		ifFalse: [ self outerScope lookupDefiningContextForVariable: var startingFrom: (self nextOuterScopeContextOf: aContext) ]
 		ifTrue: [ aContext ]
 ]

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -133,6 +133,7 @@ OCAbstractMethodScope >> localTemps [
 					var isStoringTempVector
 						ifTrue: [ var originalVar scope tempVector
 								do: [ :tempVectorVars | str nextPut: tempVectorVars ] ] ].
+			self hasTempVector ifTrue: [ str nextPut: self tempVectorVar ].
 			str nextPutAll: tempVars values]
 ]
 

--- a/src/OpalCompiler-Core/OCAbstractScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractScope.class.st
@@ -77,3 +77,12 @@ OCAbstractScope >> outerScope: aSemScope [
 
 	outerScope := aSemScope
 ]
+
+{ #category : #initialization }
+OCAbstractScope >> setCopyingTempToAllScopesUpToDefTemp: aVar to: aValue from: aContext [ 
+
+	^ self outerScope ifNotNil: [  outerScope
+		setCopyingTempToAllScopesUpToDefTemp: aVar
+		to: aValue
+		from: (self nextOuterScopeContextOf: aContext) ]
+]

--- a/src/OpalCompiler-Tests/MethodMapTest.class.st
+++ b/src/OpalCompiler-Tests/MethodMapTest.class.st
@@ -41,7 +41,7 @@ MethodMapTest >> testBlockAndContextSourceNode [
 	block value.
 	blockNodeViaClosure := block sourceNode.
 
-	self assert: blockNodeViaContext identicalTo: blockNodeViaClosure
+	self assert: blockNodeViaContext equals: blockNodeViaClosure
 ]
 
 { #category : #'tests - ast mapping' }

--- a/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
@@ -19,12 +19,12 @@ OCBytecodeToASTCacheTest >> setUp [
 { #category : #helpers }
 OCBytecodeToASTCacheTest >> testCacheInInterval: interval equalsNode: aNode [
 	interval do: [ :i |
-		self assert: (cache nodeForPC: i) identicalTo: aNode ]
+		self assert: (cache nodeForPC: i) equals: aNode ]
 ]
 
 { #category : #tests }
 OCBytecodeToASTCacheTest >> testCachedMethodNode [
-	self assert: cache methodOrBlockNode identicalTo: compiledMethod ast
+	self assert: cache methodOrBlockNode equals: compiledMethod ast
 ]
 
 { #category : #tests }
@@ -36,7 +36,7 @@ OCBytecodeToASTCacheTest >> testFirstBCOffsetTest [
 OCBytecodeToASTCacheTest >> testFirstBCOffsetWithBlock [
 	compiledMethod := (MethodMapExamples >> #helperMethod14:).
 	cache := OCBytecodeToASTCache generateForNode: compiledMethod ast.
-	self assert: (cache nodeForPC: cache firstBcOffset) identicalTo: compiledMethod ast statements first receiver
+	self assert: (cache nodeForPC: cache firstBcOffset) equals: compiledMethod ast statements first receiver
 ]
 
 { #category : #tests }
@@ -44,11 +44,11 @@ OCBytecodeToASTCacheTest >> testFirstBCOffsetWithQuickReturn [
 	compiledMethod := ( MethodMapExamples >> #ivar).
 	cache := OCBytecodeToASTCache generateForNode: compiledMethod ast.
 	self assert: cache firstBcOffset equals: compiledMethod initialPC.
-	self assert: (cache nodeForPC: cache firstBcOffset) identicalTo: compiledMethod ast.
-	self assert: (cache nodeForPC: cache lastBcOffset) identicalTo: compiledMethod ast statements last.
+	self assert: (cache nodeForPC: cache firstBcOffset) equals: compiledMethod ast.
+	self assert: (cache nodeForPC: cache lastBcOffset) equals: compiledMethod ast statements last.
 
 	cache firstBcOffset to: cache lastBcOffset - 1 do:[:pc|
-		self assert: (cache nodeForPC: pc) identicalTo: compiledMethod ast]
+		self assert: (cache nodeForPC: pc) equals: compiledMethod ast]
 ]
 
 { #category : #tests }
@@ -86,7 +86,7 @@ OCBytecodeToASTCacheTest >> testHigherThanLastBCOffsetAccessTest [
 	"if we are beyond the last bc, we map to the whole method"
 	self
 		assert: (cache nodeForPC: pc)
-		identicalTo: compiledMethod ast
+		equals: compiledMethod ast
 ]
 
 { #category : #tests }

--- a/src/SUnit-Core/TestCase.class.st
+++ b/src/SUnit-Core/TestCase.class.st
@@ -879,6 +879,7 @@ TestCase >> setTestSelector: aSymbol [
 { #category : #running }
 TestCase >> setUp [
 	"Hooks that subclasses may override to define the fixture of test."
+	self class package name = 'Reflectivity-Tests' ifTrue: [ self skip ]
 ]
 
 { #category : #events }


### PR DESCRIPTION
While cache invalidation is one of the two hard things in computer science, knowing that a cache is a cache is an easy one.

This PR is not intended to be merged, but is here to understand possible issues with #13368 (and also #8984)