### PR TITLE
Clean MCMethodDefinitionTest

### DIFF
--- a/src/Monticello-Tests/MCMethodDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCMethodDefinitionTest.class.st
@@ -9,8 +9,10 @@ Class {
 	#category : #'Monticello-Tests-Base'
 }
 
-{ #category : #mocks }
-MCMethodDefinitionTest >> override [ ^ 1
+{ #category : #running }
+MCMethodDefinitionTest >> extensionPackageName [
+
+	^ 'FooBarBaz'
 ]
 
 { #category : #running }
@@ -30,13 +32,14 @@ MCMethodDefinitionTest >> setUp [
 
 { #category : #running }
 MCMethodDefinitionTest >> tearDown [
-      self restoreMocks.
-      extensionPackage unregister.
-		extensionPackage := nil.
-      self class compile: 'override ^ 1' classified: 'mocks'.
-      self ownPackage modified: isModified.
-		super tearDown
-       "FIXME: Unregister Monticellomocks if it got created implicitly.
+
+	self restoreMocks.
+	extensionPackage unregister.
+	self class compiledMethodAt: #override ifPresent: [ :method | method removeFromSystem ].
+	(self extensionPackageName asPackageIfAbsent: [ nil ]) ifNotNil: [ :package | package removeFromSystem ].
+	self ownPackage modified: isModified.
+	super tearDown
+	"FIXME: Unregister Monticellomocks if it got created implicitly.
        This avoids a nasty failure of MCChangeNotificationTest due to
        some inconsistency about whether package names are case sensitive
        or not. They're treated as case insensitive in some name lookups but not
@@ -46,7 +49,7 @@ MCMethodDefinitionTest >> tearDown [
        in MCChangeNotificationTest is MonticelloMocks and an instance of
        MCMockPackageInfo. Since *that* lookup is case insensitive it can
        find Monticellomocks instead of MonticelloMocks and fail."
-       "PackageOrganizer default unregisterPackageNamed: 'MonticelloMocks'."
+	"PackageOrganizer default unregisterPackageNamed: 'MonticelloMocks'."
 ]
 
 { #category : #testing }
@@ -133,9 +136,11 @@ MCMethodDefinitionTest >> testRevertOldMethod [
 
 { #category : #testing }
 MCMethodDefinitionTest >> testRevertOverrideMethod [
+
 	| definition |
+	self class compile: 'override ^ 1' classified: 'mocks'.
 	self class compile: 'override ^ 2' classified: self mockOverrideMethodCategory.
-	definition := (self class>>#override) asMCMethodDefinition.
+	definition := (self class >> #override) asMCMethodDefinition.
 	self assert: definition isOverrideMethod.
 	self assert: self override equals: 2.
 	definition unload.

--- a/src/Monticello-Tests/MCMethodDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCMethodDefinitionTest.class.st
@@ -1,18 +1,28 @@
 Class {
 	#name : #MCMethodDefinitionTest,
 	#superclass : #MCTestCase,
-	#instVars : [
-		'navigation',
-		'isModified',
-		'extensionPackage'
-	],
 	#category : #'Monticello-Tests-Base'
 }
 
 { #category : #running }
 MCMethodDefinitionTest >> extensionPackageName [
 
-	^ 'FooBarBaz'
+	^ 'MonticelloTestsFirstExtensionMockPackage'
+]
+
+{ #category : #accessing }
+MCMethodDefinitionTest >> mockClass [
+
+	^ self class classInstaller make: [ :builder |
+		  builder
+			  name: 'MonticelloTestsMockClass';
+			  package: self mockPackageName ]
+]
+
+{ #category : #accessing }
+MCMethodDefinitionTest >> mockPackageName [
+
+	^ 'MonticelloTestsMockPackage'
 ]
 
 { #category : #running }
@@ -21,47 +31,30 @@ MCMethodDefinitionTest >> ownPackage [
 ]
 
 { #category : #running }
-MCMethodDefinitionTest >> setUp [
-	super setUp.
-	extensionPackage := (MCWorkingCopy forPackage: (MCPackage named: 'FooBarBaz')).
-	navigation := (testingEnvironment hasClassNamed: #SystemNavigation)
-		ifTrue: [ (testingEnvironment at: #SystemNavigation) new ]
-		ifFalse: [ Smalltalk ].
-	isModified := self ownPackage modified
+MCMethodDefinitionTest >> secondExtensionPackageName [
+
+	^ 'MonticelloTestsSecondExtensionMockPackage-override'
 ]
 
 { #category : #running }
 MCMethodDefinitionTest >> tearDown [
 
-	self restoreMocks.
-	extensionPackage unregister.
-	self class compiledMethodAt: #override ifPresent: [ :method | method removeFromSystem ].
-	(self extensionPackageName asPackageIfAbsent: [ nil ]) ifNotNil: [ :package | package removeFromSystem ].
-	self ownPackage modified: isModified.
+	{ self secondExtensionPackageName . self extensionPackageName . self mockPackageName }
+		do: [ :packageName | (packageName asPackageIfAbsent: [ nil ]) ifNotNil: [ :package | package removeFromSystem ] ].
 	super tearDown
-	"FIXME: Unregister Monticellomocks if it got created implicitly.
-       This avoids a nasty failure of MCChangeNotificationTest due to
-       some inconsistency about whether package names are case sensitive
-       or not. They're treated as case insensitive in some name lookups but not
-       in others; most importantly PackageOrganizer default treats package
-       names as being case sensitive. The package created here is Monticellomocks
-       (lower case mocks) and an instance of PackageInfo; the package expected
-       in MCChangeNotificationTest is MonticelloMocks and an instance of
-       MCMockPackageInfo. Since *that* lookup is case insensitive it can
-       find Monticellomocks instead of MonticelloMocks and fail."
-	"PackageOrganizer default unregisterPackageNamed: 'MonticelloMocks'."
 ]
 
 { #category : #testing }
 MCMethodDefinitionTest >> testCannotLoad [
+
 	| definition |
 	definition := self
-		mockMethod: #kjahs87
-		class: 'NoSuchClass'
-		source: 'kjahs87 ^self'
-		meta: false.
+		              mockMethod: #kjahs87
+		              class: 'NoSuchClass'
+		              source: 'kjahs87 ^self'
+		              meta: false.
 	self should: [ definition load ] raise: Error.
-	self assertEmpty: (navigation allImplementorsOf: #kjahs87)
+	self assertEmpty: (SystemNavigation new allImplementorsOf: #kjahs87)
 ]
 
 { #category : #testing }
@@ -84,13 +77,21 @@ MCMethodDefinitionTest >> testComparison [
 
 { #category : #testing }
 MCMethodDefinitionTest >> testLoadAndUnload [
-	|definition|
-	definition := self mockMethod: #one class: 'MCMockClassA' source: 'one ^2' meta: false.
-	self assert: self mockInstanceA one equals: 1.
+
+	| definition mockClass mockClassInstance |
+	mockClass := self mockClass.
+	mockClassInstance := mockClass new.
+	mockClass compile: 'one ^ 1'.
+	definition := self
+		              mockMethod: #one
+		              class: mockClass name
+		              source: 'one ^2'
+		              meta: false.
+	self assert: mockClassInstance one equals: 1.
 	definition load.
-	self assert: self mockInstanceA one equals: 2.
+	self assert: mockClassInstance one equals: 2.
 	definition unload.
-	self deny: (self mockInstanceA respondsTo: #one)
+	self deny: (mockClassInstance respondsTo: #one)
 ]
 
 { #category : #testing }
@@ -105,31 +106,36 @@ MCMethodDefinitionTest >> testMethodDefinitionWithEmptyProtocolIsClassifiedAsAsY
 			timeStamp: nil
 			source: 'name
 	^ self printString').
-	self assert: methodDef category equals: #'as yet unclassified'.
+	self assert: methodDef protocol equals: #'as yet unclassified'.
 ]
 
 { #category : #testing }
 MCMethodDefinitionTest >> testPartiallyRevertOverrideMethod [
-	| definition |
-	self class compile: 'override ^ 2' classified: '*foobarbaz'.
-	self class compile: 'override ^ 3' classified: self mockOverrideMethodCategory.
-	self class compile: 'override ^ 4' classified: self mockOverrideMethodCategory.
-	definition := (self class>>#override) asMCMethodDefinition.
+
+	| definition mockClass mockClassInstance |
+	mockClass := self mockClass.
+	mockClassInstance := mockClass new.
+	mockClass compile: 'override ^ 2' classified: '*' , self extensionPackageName.
+	mockClass compile: 'override ^ 3' classified: '*' , self secondExtensionPackageName.
+	mockClass compile: 'override ^ 4' classified: '*' , self secondExtensionPackageName.
+	definition := (mockClass >> #override) asMCMethodDefinition.
 	self assert: definition isOverrideMethod.
-	self assert: self override equals: 4.
+	self assert: mockClassInstance override equals: 4.
 	definition unload.
-	self assert: self override equals: 2.
-	self assert: (self class>>#override) category equals: '*foobarbaz'
+	self assert: mockClassInstance override equals: 2.
+	self assert: (mockClass >> #override) protocol equals: '*' , self extensionPackageName
 ]
 
 { #category : #testing }
 MCMethodDefinitionTest >> testRevertOldMethod [
 
-	| definition changeRecord |
-	Object compile: 'yourself ^ self' classified: '*MonticelloMocks'.
-	definition := (Object >> #yourself) asMCMethodDefinition.
+	| definition changeRecord mockClass |
+	mockClass := self mockClass.
+	mockClass compile: 'yourself ^ self' classified: 'accessing'.
+	mockClass compile: 'yourself ^ self' classified: '*MonticelloMocks'.
+	definition := (mockClass >> #yourself) asMCMethodDefinition.
 	changeRecord := definition overridenMethodOrNil.
-	self assert: changeRecord notNil.
+	self assert: changeRecord isNotNil.
 	self assert: changeRecord protocol equals: 'accessing'.
 	changeRecord fileIn
 ]
@@ -137,13 +143,15 @@ MCMethodDefinitionTest >> testRevertOldMethod [
 { #category : #testing }
 MCMethodDefinitionTest >> testRevertOverrideMethod [
 
-	| definition |
-	self class compile: 'override ^ 1' classified: 'mocks'.
-	self class compile: 'override ^ 2' classified: self mockOverrideMethodCategory.
-	definition := (self class >> #override) asMCMethodDefinition.
+	| definition mockClass mockClassInstance |
+	mockClass := self mockClass.
+	mockClassInstance := mockClass new.
+	mockClass compile: 'override ^ 1' classified: 'mocks'.
+	mockClass compile: 'override ^ 2' classified: '*' , self secondExtensionPackageName.
+	definition := (mockClass >> #override) asMCMethodDefinition.
 	self assert: definition isOverrideMethod.
-	self assert: self override equals: 2.
+	self assert: mockClassInstance override equals: 2.
 	definition unload.
-	self assert: self override equals: 1.
-	self assert: (RGMethodDefinition realClass: self class selector: #override) category equals: 'mocks'
+	self assert: mockClassInstance override equals: 1.
+	self assert: (RGMethodDefinition realClass: mockClass selector: #override) protocol equals: 'mocks'
 ]


### PR DESCRIPTION
This issue is one of the many steps needed to fix #13349.

MCMethodDefinitionTest is not really nice and leaves the system in a dirty states.
First it generates a package that it does not remove.
Second it recompiles its own code 
Third it updates the Monticello mock package present in the image

This is an cleaning so that every code compilation happening is done in generated packages that get cleaned so that we do not dirty the code commited to Pharo.