### PR TITLE
ASTCache: use a double weak dictionary

### DIFF
--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -105,9 +105,12 @@ ASTCache >> at: aCompiledMethod ifAbsentPut: aBlock [
 ASTCache >> at: aCompiledMethod put: aRBMethodNode [
 
 	"Cleanup weak AST. Note `associations` return a copy, so the iteration is safe"
+	| weakRef |
 	self weakDictionary associations do: [ :each |
 		(each value at: 1) ifNil: [ self weakDictionary removeKey: each key ] ].
-	self weakDictionary at: aCompiledMethod put: aRBMethodNode asWeakReference.
+	weakRef := WeakArray new: 1.
+	weakRef at: 1 put: aRBMethodNode.
+	self weakDictionary at: aCompiledMethod put: weakRef.
 	^ aRBMethodNode
 ]
 

--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -95,7 +95,7 @@ ASTCache >> at: aCompiledMethod ifAbsentPut: aBlock [
 	(aCompiledMethod propertyAt: #reflectiveMethod) ifNotNil: [ :rf | ^ rf ast ].
 
 	"Look in the (almost infinite) cache"
-	self weakDictionary at: aCompiledMethod ifPresent: [ :ast | ^ ast ].
+	self weakDictionary at: aCompiledMethod ifPresent: [ :wa | (wa at: 1) ifNotNil: [ :ast | ^ast ] ].
 
 	"We tried everything we could. So compute and store it"
 	^ self at: aCompiledMethod put: aBlock value
@@ -104,7 +104,11 @@ ASTCache >> at: aCompiledMethod ifAbsentPut: aBlock [
 { #category : #accessing }
 ASTCache >> at: aCompiledMethod put: aRBMethodNode [
 
-	^ self weakDictionary at: aCompiledMethod put: aRBMethodNode
+	"Cleanup weak AST. Note `associations` return a copy, so the iteration is safe"
+	self weakDictionary associations do: [ :each |
+		(each value at: 1) ifNil: [ self weakDictionary removeKey: each key ] ].
+	self weakDictionary at: aCompiledMethod put: aRBMethodNode asWeakReference.
+	^ aRBMethodNode
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -19,7 +19,8 @@ Class {
 	#name : #ASTCache,
 	#superclass : #Object,
 	#instVars : [
-		'weakDictionary'
+		'weakDictionary',
+		'statistics'
 	],
 	#classVars : [
 		'CacheMissStrategy'
@@ -89,14 +90,22 @@ ASTCache >> at: aCompiledMethod ifAbsentPut: aBlock [
 	"Get an AST using strongly held information, or failback to aBlock (that might compute a new AST)"
 
 	"For doit methods, the AST is stored in the method property"
-	(aCompiledMethod propertyAt: #ast) ifNotNil: [ :ast | ^ ast ].
+
+	(aCompiledMethod propertyAt: #ast) ifNotNil: [ :ast |
+		self statistics addHit.
+		^ ast ].
 
 	"Reflective methods have a strongly held AST, return this one"
-	(aCompiledMethod propertyAt: #reflectiveMethod) ifNotNil: [ :rf | ^ rf ast ].
+	(aCompiledMethod propertyAt: #reflectiveMethod) ifNotNil: [ :rf |
+		self statistics addHit.
+		^ rf ast ].
 
 	"Look in the (almost infinite) cache"
-	self weakDictionary at: aCompiledMethod ifPresent: [ :wa | (wa at: 1) ifNotNil: [ :ast | ^ast ] ].
-
+	self weakDictionary at: aCompiledMethod ifPresent: [ :wa |
+		(wa at: 1) ifNotNil: [ :ast |
+			self statistics addHit.
+			^ ast ] ].
+	self statistics addMiss.
 	"We tried everything we could. So compute and store it"
 	^ self at: aCompiledMethod put: aBlock value
 ]
@@ -123,7 +132,8 @@ ASTCache >> getASTFor: aCompiledMethod [
 { #category : #copying }
 ASTCache >> postCopy [
 
-	weakDictionary := weakDictionary copy
+	weakDictionary := weakDictionary copy.
+	statistics := statistics copy
 ]
 
 { #category : #printing }
@@ -132,13 +142,23 @@ ASTCache >> printOn: aStream [
 	super printOn: aStream.
 	aStream
 		nextPutAll: '#';
-		print: self weakDictionary size
+		print: self weakDictionary size;
+		space;
+		print: (self statistics hitRatio * 100.0) rounded;
+		nextPut: $%
 ]
 
 { #category : #initialization }
 ASTCache >> reset [
 	self weakDictionary removeAll.
 	weakDictionary := nil.
+	self statistics reset.
+]
+
+{ #category : #accessing }
+ASTCache >> statistics [
+
+	^ statistics ifNil: [ statistics := CacheStatistics new ]
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -77,6 +77,18 @@ ASTCache class >> shutDown [
 	self reset
 ]
 
+{ #category : #adding }
+ASTCache >> addHit [
+
+	self statistics ifNotNil: [ statistics addHit ]
+]
+
+{ #category : #adding }
+ASTCache >> addMiss [
+
+	self statistics ifNotNil: [ statistics addMiss ]
+]
+
 { #category : #accessing }
 ASTCache >> at: aCompiledMethod [
 
@@ -92,21 +104,22 @@ ASTCache >> at: aCompiledMethod ifAbsentPut: aBlock [
 	"For doit methods, the AST is stored in the method property"
 
 	(aCompiledMethod propertyAt: #ast) ifNotNil: [ :ast |
-		self statistics addHit.
+		self addHit.
 		^ ast ].
 
 	"Reflective methods have a strongly held AST, return this one"
 	(aCompiledMethod propertyAt: #reflectiveMethod) ifNotNil: [ :rf |
-		self statistics addHit.
+		self addHit.
 		^ rf ast ].
 
 	"Look in the (almost infinite) cache"
 	self weakDictionary at: aCompiledMethod ifPresent: [ :wa |
 		(wa at: 1) ifNotNil: [ :ast |
-			self statistics addHit.
+			self addHit.
 			^ ast ] ].
-	self statistics addMiss.
+
 	"We tried everything we could. So compute and store it"
+	self addMiss.
 	^ self at: aCompiledMethod put: aBlock value
 ]
 
@@ -129,6 +142,13 @@ ASTCache >> getASTFor: aCompiledMethod [
 	^ self class cacheMissStrategy getASTFor: aCompiledMethod
 ]
 
+{ #category : #'accessing - statistics' }
+ASTCache >> hitRatio [
+
+	self statistics ifNil: [ ^ 0 ].
+	^ self statistics hitRatio
+]
+
 { #category : #copying }
 ASTCache >> postCopy [
 
@@ -144,7 +164,7 @@ ASTCache >> printOn: aStream [
 		nextPutAll: '#';
 		print: self weakDictionary size;
 		space;
-		print: (self statistics hitRatio * 100.0) rounded;
+		print: (self hitRatio * 100.0) rounded;
 		nextPut: $%
 ]
 
@@ -152,13 +172,16 @@ ASTCache >> printOn: aStream [
 ASTCache >> reset [
 	self weakDictionary removeAll.
 	weakDictionary := nil.
-	self statistics reset.
+	statistics := nil.
 ]
 
 { #category : #accessing }
 ASTCache >> statistics [
 
-	^ statistics ifNil: [ statistics := CacheStatistics new ]
+	^ statistics ifNil: [ "CacheStatistics comes from another package. It does not worth the dependency"
+		  Smalltalk globals
+			  at: #CacheStatistics
+			  ifPresent: [ :CS | statistics := CS new ] ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Based on #13378 for the refactor. Look at the last commit only.

Instead of a `WeakIdentityKeyDictionary`, that keep forever uninteresting AST.
Use a `WeakIdentityKeyWeakValueDictionary`! But because this class does not exist, and because I do not want to implement is (and because ephemerons are coming), I just simulate it with a `WeakIdentityKeyDictionary` of single-cell `WeakArrays`, and a special loop to remove garbage collected value.

For the rationale, look at https://github.com/pharo-project/pharo/pull/13371#issuecomment-1501517196
