### PR TITLE
Some cleanings protocol announcements and announcements

### DIFF
--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -30,7 +30,7 @@ Class {
 { #category : #'private - announcements' }
 ASTCache class >> announceCacheReset [
 
-	SystemAnnouncer uniqueInstance announce: ASTCacheReset new
+	SystemAnnouncer announce: ASTCacheReset new
 ]
 
 { #category : #accessing }

--- a/src/CodeImport/DoItChunk.class.st
+++ b/src/CodeImport/DoItChunk.class.st
@@ -28,7 +28,7 @@ DoItChunk >> importFor: requestor logSource: logSource [
 
 	(contents beginsWith: '----') ifTrue: [ ^self ].
 
-	SystemAnnouncer uniqueInstance announce: (DoItChunkImported new
+	SystemAnnouncer announce: (DoItChunkImported new
 		contents: contents;
 		logSource: logSource;
 		yourself).

--- a/src/EnlumineurFormatter/EFFormatter.class.st
+++ b/src/EnlumineurFormatter/EFFormatter.class.st
@@ -49,7 +49,7 @@ Class {
 
 { #category : #private }
 EFFormatter class >> announceASettingChange [
-	SystemAnnouncer uniqueInstance announce: EFSettingChanged
+	SystemAnnouncer announce: EFSettingChanged
 ]
 
 { #category : #private }

--- a/src/Graphics-Display Objects/DisplayScreen.class.st
+++ b/src/Graphics-Display Objects/DisplayScreen.class.st
@@ -181,7 +181,7 @@ DisplayScreen >> fullscreen [
 { #category : #'screen managing' }
 DisplayScreen >> fullscreen: aBoolean [
 
-	SystemAnnouncer uniqueInstance announce: (FullscreenAnnouncement new
+	SystemAnnouncer announce: (FullscreenAnnouncement new
 		displayScreen: self;
 		fullscreen: (LastScreenModeSelected := aBoolean))
 ]

--- a/src/Hermes/HEInstaller.class.st
+++ b/src/Hermes/HEInstaller.class.st
@@ -170,10 +170,9 @@ HEInstaller >> installMethods: exportedClass into: aClass [
 
 { #category : #'installing package' }
 HEInstaller >> installPackage: aHEPackage [
-	| storedAnnouncements |
 
-	storedAnnouncements := SystemAnnouncer uniqueInstance suspendAllWhileStoring: [ self doInstallPackage: aHEPackage ].
-	storedAnnouncements do: [ :e | SystemAnnouncer uniqueInstance announce: e ]
+	(SystemAnnouncer uniqueInstance suspendAllWhileStoring: [ self doInstallPackage: aHEPackage ])
+		do: [ :storedAnnouncement | SystemAnnouncer announce: storedAnnouncement ]
 ]
 
 { #category : #messages }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -36,7 +36,7 @@ ClassOrganization >> addProtocolNamed: protocolName [
 	oldProtocols := self protocolNames copy.
 
 	protocol := self addProtocol: (Protocol name: protocolName).
-	SystemAnnouncer uniqueInstance protocolAdded: protocolName inClass: self organizedClass.
+	SystemAnnouncer uniqueInstance announce: (ProtocolAdded in: self organizedClass protocol: protocolName).
 	self notifyOfChangedProtocolNamesFrom: oldProtocols to: self protocolNames.
 	^ protocol
 ]
@@ -210,7 +210,7 @@ ClassOrganization >> moveMethodsFrom: fromProtocolNamed to: toProtocolNamed [
 { #category : #notifications }
 ClassOrganization >> notifyOfChangedProtocolNamesFrom: oldProtocols to: newProtocols [
 
-	oldProtocols ~= newProtocols ifTrue: [ SystemAnnouncer uniqueInstance classReorganized: self organizedClass ]
+	oldProtocols ~= newProtocols ifTrue: [ SystemAnnouncer uniqueInstance announce: (ClassReorganized class: self organizedClass) ]
 ]
 
 { #category : #notifications }
@@ -222,7 +222,7 @@ ClassOrganization >> notifyOfChangedSelector: element from: oldProtocolName to: 
 { #category : #notifications }
 ClassOrganization >> notifyOfRemovedProtocolNamed: protocolName [
 
-	SystemAnnouncer uniqueInstance protocolRemoved: protocolName inClass: self organizedClass
+	SystemAnnouncer uniqueInstance announce: (ProtocolRemoved in: self organizedClass protocol: protocolName)
 ]
 
 { #category : #accessing }
@@ -322,13 +322,14 @@ ClassOrganization >> renameProtocolNamed: oldName toBe: newName [
 
 	self silentlyRenameProtocolNamed: oldName toBe: newName.
 
-	"Announce the changes in the system"
-	oldName ~= newName ifTrue: [
-		SystemAnnouncer uniqueInstance protocolRenamedFrom: oldName to: newName inClass: self organizedClass.
-		SystemAnnouncer uniqueInstance classReorganized: self organizedClass.
+	"Announce the changes in the system if the name changed"
+	oldName = newName ifTrue: [ ^ self ].
 
-		"I need to notify also the selector changes, otherwise RPackage will not notice"
-		(self protocolNamed: newName) methodSelectors do: [ :each | self notifyOfChangedSelector: each from: oldName to: newName ] ]
+	self notifyOfChangedProtocolNamesFrom: oldName to: newName.
+	SystemAnnouncer uniqueInstance announce: (ProtocolRenamed in: self organizedClass from: oldName to: newName).
+
+	"I need to notify also the selector changes, otherwise RPackage will not notice"
+	(self protocolNamed: newName) methodSelectors do: [ :each | self notifyOfChangedSelector: each from: oldName to: newName ]
 ]
 
 { #category : #initialization }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -36,7 +36,7 @@ ClassOrganization >> addProtocolNamed: protocolName [
 	oldProtocols := self protocolNames copy.
 
 	protocol := self addProtocol: (Protocol name: protocolName).
-	SystemAnnouncer uniqueInstance announce: (ProtocolAdded in: self organizedClass protocol: protocolName).
+	SystemAnnouncer announce: (ProtocolAdded in: self organizedClass protocol: protocolName).
 	self notifyOfChangedProtocolNamesFrom: oldProtocols to: self protocolNames.
 	^ protocol
 ]
@@ -210,7 +210,7 @@ ClassOrganization >> moveMethodsFrom: fromProtocolNamed to: toProtocolNamed [
 { #category : #notifications }
 ClassOrganization >> notifyOfChangedProtocolNamesFrom: oldProtocols to: newProtocols [
 
-	oldProtocols ~= newProtocols ifTrue: [ SystemAnnouncer uniqueInstance announce: (ClassReorganized class: self organizedClass) ]
+	oldProtocols ~= newProtocols ifTrue: [ SystemAnnouncer announce: (ClassReorganized class: self organizedClass) ]
 ]
 
 { #category : #notifications }
@@ -222,7 +222,7 @@ ClassOrganization >> notifyOfChangedSelector: element from: oldProtocolName to: 
 { #category : #notifications }
 ClassOrganization >> notifyOfRemovedProtocolNamed: protocolName [
 
-	SystemAnnouncer uniqueInstance announce: (ProtocolRemoved in: self organizedClass protocol: protocolName)
+	SystemAnnouncer announce: (ProtocolRemoved in: self organizedClass protocol: protocolName)
 ]
 
 { #category : #accessing }
@@ -326,7 +326,7 @@ ClassOrganization >> renameProtocolNamed: oldName toBe: newName [
 	oldName = newName ifTrue: [ ^ self ].
 
 	self notifyOfChangedProtocolNamesFrom: oldName to: newName.
-	SystemAnnouncer uniqueInstance announce: (ProtocolRenamed in: self organizedClass from: oldName to: newName).
+	SystemAnnouncer announce: (ProtocolRenamed in: self organizedClass from: oldName to: newName).
 
 	"I need to notify also the selector changes, otherwise RPackage will not notice"
 	(self protocolNamed: newName) methodSelectors do: [ :each | self notifyOfChangedSelector: each from: oldName to: newName ]

--- a/src/Monticello/MCVersionLoader.class.st
+++ b/src/Monticello/MCVersionLoader.class.st
@@ -47,7 +47,7 @@ MCVersionLoader >> announceLoad: aString do: aBlock [
 
 { #category : #private }
 MCVersionLoader >> announceLoadStart: aString [
-	SystemAnnouncer uniqueInstance announce: (MCVersionLoaderStarted new
+	SystemAnnouncer announce: (MCVersionLoaderStarted new
 		versionLoader: self;
 		label: aString; 
 		yourself)
@@ -55,7 +55,7 @@ MCVersionLoader >> announceLoadStart: aString [
 
 { #category : #private }
 MCVersionLoader >> announceLoadStop: aString [
-	SystemAnnouncer uniqueInstance announce: (MCVersionLoaderStopped new
+	SystemAnnouncer announce: (MCVersionLoaderStopped new
 		versionLoader: self;
 		label: aString; 
 		yourself)

--- a/src/Polymorph-Widgets/ThemeIcons.class.st
+++ b/src/Polymorph-Widgets/ThemeIcons.class.st
@@ -105,7 +105,7 @@ ThemeIcons class >> current [
 ThemeIcons class >> current: aPack [
 	aPack hasIcons ifFalse: [ aPack loadIconsFromUrl ].
 	Current := aPack.
-	SystemAnnouncer uniqueInstance announce: IconSetChanged
+	SystemAnnouncer announce: IconSetChanged
 ]
 
 { #category : #accessing }

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -106,7 +106,7 @@ UITheme class >> current: aUITheme [
 	self currentWorld themeChanged.
 	(SystemWindow allSubInstances select:[:e | e owner isNil]) do: [ :each | each themeChanged ].
 
-	SystemAnnouncer uniqueInstance announce: UIThemeChanged
+	SystemAnnouncer announce: UIThemeChanged
 ]
 
 { #category : #accessing }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -410,7 +410,7 @@ RPackageOrganizer >> ensureExistAndRegisterPackageNamed: aSymbol [
 	package definedClasses do: [ :definedClass|
 			self registerPackage: package forClass: definedClass].
 
-	SystemAnnouncer uniqueInstance announce: (RPackageRegistered to: package).
+	SystemAnnouncer announce: (RPackageRegistered to: package).
 
 	^ package
 ]
@@ -902,7 +902,7 @@ RPackageOrganizer >> registerPackage: aPackage [
 	aPackage definedClasses
 		do: [ :definedClass | self registerPackage: aPackage forClass: definedClass].
 
-	SystemAnnouncer uniqueInstance announce: (RPackageRegistered to: aPackage).
+	SystemAnnouncer announce: (RPackageRegistered to: aPackage).
 
 	^ aPackage
 ]
@@ -1357,7 +1357,7 @@ RPackageOrganizer >> unregisterPackage: aPackage [
 		do: [ :extendedClass | self unregisterExtendingPackage: aPackage forClass: extendedClass].
 	aPackage definedClasses
 		do: [ :definedClass | self unregisterPackage: aPackage forClass: definedClass].
-	SystemAnnouncer uniqueInstance announce: (RPackageUnregistered to: aPackage).
+	SystemAnnouncer announce: (RPackageUnregistered to: aPackage).
 
 	^ aPackage
 ]

--- a/src/Reflectivity/Breakpoint.class.st
+++ b/src/Reflectivity/Breakpoint.class.st
@@ -156,7 +156,7 @@ Breakpoint class >> notifyBreakpointAdded: aBreakpoint [
 	announcement := BreakpointAdded
 		on: aBreakpoint
 		nodes: aBreakpoint link nodes.
-	SystemAnnouncer uniqueInstance announce: announcement
+	SystemAnnouncer announce: announcement
 ]
 
 { #category : #'observers - experimental' }
@@ -166,7 +166,7 @@ Breakpoint class >> notifyBreakpointHit: aBreakpoint inContext: aContext node: n
 	announcement := BreakpointHit
 		on: aBreakpoint
 		nodes: {node}.
-	SystemAnnouncer uniqueInstance announce: announcement
+	SystemAnnouncer announce: announcement
 ]
 
 { #category : #'observers - experimental' }
@@ -176,7 +176,7 @@ Breakpoint class >> notifyBreakpointRemoved: aBreakpoint fromNodes: nodes [
 	announcement := BreakpointRemoved
 		on: aBreakpoint
 		nodes: nodes.
-	SystemAnnouncer uniqueInstance announce: announcement
+	SystemAnnouncer announce: announcement
 ]
 
 { #category : #'class initialization' }

--- a/src/Reflectivity/MetaLink.class.st
+++ b/src/Reflectivity/MetaLink.class.st
@@ -94,17 +94,17 @@ MetaLink >> allReifications [
 
 { #category : #installing }
 MetaLink >> announceChange [
-	self optionAnnounce ifTrue: [SystemAnnouncer uniqueInstance announce: (MetalinkChanged new link: self)]
+	self optionAnnounce ifTrue: [SystemAnnouncer announce: (MetalinkChanged new link: self)]
 ]
 
 { #category : #installing }
 MetaLink >> announceInstall: node [
-	self optionAnnounce ifTrue: [SystemAnnouncer uniqueInstance announce: (MetalinkChanged linkAdded: self toNode: node)]
+	self optionAnnounce ifTrue: [SystemAnnouncer announce: (MetalinkChanged linkAdded: self toNode: node)]
 ]
 
 { #category : #installing }
 MetaLink >> announceRemove: node [
-	self optionAnnounce ifTrue: [SystemAnnouncer uniqueInstance announce: (MetalinkChanged linkRemoved: self fromNode: node)]
+	self optionAnnounce ifTrue: [SystemAnnouncer announce: (MetalinkChanged linkRemoved: self fromNode: node)]
 ]
 
 { #category : #accessing }

--- a/src/Reflectivity/VariableBreakpoint.class.st
+++ b/src/Reflectivity/VariableBreakpoint.class.st
@@ -46,7 +46,7 @@ VariableBreakpoint class >> notifyBreakpointHit: aBreakpoint inContext: aContext
 		on: aBreakpoint
 		nodes: {node}.
 	announcement valueOrNil: (node variableValueInContext: aContext).
-	SystemAnnouncer uniqueInstance announce: announcement
+	SystemAnnouncer announce: announcement
 ]
 
 { #category : #API }

--- a/src/System-Announcements-Tests/SystemAnnouncerTest.class.st
+++ b/src/System-Announcements-Tests/SystemAnnouncerTest.class.st
@@ -79,7 +79,7 @@ SystemAnnouncerTest >> testSuspendAllWhile [
 
 	self assert: value equals: 42. "The answer is always 42 :)"
 
-	SystemAnnouncer uniqueInstance announce: ClassAdded.
+	SystemAnnouncer announce: ClassAdded.
 
 	self assert: value equals: 43
 ]
@@ -89,7 +89,7 @@ SystemAnnouncerTest >> testSuspendAllWhileStoring [
 
 	| stored |
 
-	stored := SystemAnnouncer uniqueInstance suspendAllWhileStoring: [ SystemAnnouncer uniqueInstance announce: ClassAdded ].
+	stored := SystemAnnouncer uniqueInstance suspendAllWhileStoring: [ SystemAnnouncer announce: ClassAdded ].
 
 	self assert: stored size equals: 1.
 	self assert: ( stored at: 1 ) equals: ClassAdded
@@ -100,7 +100,7 @@ SystemAnnouncerTest >> testSuspendAllWhileStoringNested [
 	|  stored |
 
 	stored := SystemAnnouncer uniqueInstance suspendAllWhileStoring: [
-		SystemAnnouncer uniqueInstance suspendAllWhileStoring:[SystemAnnouncer uniqueInstance announce: ClassAdded ]
+		SystemAnnouncer uniqueInstance suspendAllWhileStoring:[SystemAnnouncer announce: ClassAdded ]
 	].
 
 	self assert: stored size equals: 1.

--- a/src/System-Announcements/ProtocolAdded.class.st
+++ b/src/System-Announcements/ProtocolAdded.class.st
@@ -6,3 +6,12 @@ Class {
 	#superclass : #ProtocolAnnouncement,
 	#category : #'System-Announcements-System-Protocols'
 }
+
+{ #category : #'class initialization' }
+ProtocolAdded class >> in: aClass protocol: aProtocolName [
+
+	^ self new
+		  classReorganized: aClass;
+		  protocol: aProtocolName;
+		  yourself
+]

--- a/src/System-Announcements/ProtocolRemoved.class.st
+++ b/src/System-Announcements/ProtocolRemoved.class.st
@@ -6,3 +6,12 @@ Class {
 	#superclass : #ProtocolAnnouncement,
 	#category : #'System-Announcements-System-Protocols'
 }
+
+{ #category : #'class initialization' }
+ProtocolRemoved class >> in: aClass protocol: aProtocolName [
+
+	^ self new
+		  classReorganized: aClass;
+		  protocol: aProtocolName;
+		  yourself
+]

--- a/src/System-Announcements/ProtocolRenamed.class.st
+++ b/src/System-Announcements/ProtocolRenamed.class.st
@@ -10,6 +10,16 @@ Class {
 	#category : #'System-Announcements-System-Protocols'
 }
 
+{ #category : #'class initialization' }
+ProtocolRenamed class >> in: aClass from: oldName to: newName [
+
+	^ self new
+		  classReorganized: aClass;
+		  oldProtocolName: oldName;
+		  newProtocolName: newName;
+		  yourself
+]
+
 { #category : #accessing }
 ProtocolRenamed >> newProtocolName [
 	^ newProtocolName

--- a/src/System-Announcements/SystemAnnouncer.class.st
+++ b/src/System-Announcements/SystemAnnouncer.class.st
@@ -235,29 +235,20 @@ SystemAnnouncer >> private [
 
 { #category : #triggering }
 SystemAnnouncer >> protocolAdded: aString inClass: aClass [
-	self announce: (ProtocolAdded new
-		classReorganized: aClass;
-		protocol: aString;
-		yourself)
+
+	self announce: (ProtocolAdded in: aClass protocol: aString)
 ]
 
 { #category : #triggering }
 SystemAnnouncer >> protocolRemoved: aString inClass: aClass [
-	self announce: (ProtocolRemoved new
-		classReorganized: aClass;
-		protocol: aString;
-		yourself)
+
+	self announce: (ProtocolRemoved in: aClass protocol: aString)
 ]
 
 { #category : #triggering }
 SystemAnnouncer >> protocolRenamedFrom: oldName to: newName inClass: aClass [
-	self
-		announce:
-			(ProtocolRenamed new
-				classReorganized: aClass;
-				oldProtocolName: oldName;
-				newProtocolName: newName;
-				yourself)
+
+	self announce: (ProtocolRenamed in: aClass from: oldName to: newName)
 ]
 
 { #category : #triggering }

--- a/src/System-Announcements/SystemAnnouncer.class.st
+++ b/src/System-Announcements/SystemAnnouncer.class.st
@@ -234,24 +234,6 @@ SystemAnnouncer >> private [
 ]
 
 { #category : #triggering }
-SystemAnnouncer >> protocolAdded: aString inClass: aClass [
-
-	self announce: (ProtocolAdded in: aClass protocol: aString)
-]
-
-{ #category : #triggering }
-SystemAnnouncer >> protocolRemoved: aString inClass: aClass [
-
-	self announce: (ProtocolRemoved in: aClass protocol: aString)
-]
-
-{ #category : #triggering }
-SystemAnnouncer >> protocolRenamedFrom: oldName to: newName inClass: aClass [
-
-	self announce: (ProtocolRenamed in: aClass from: oldName to: newName)
-]
-
-{ #category : #triggering }
 SystemAnnouncer >> snapshotDone: isNewImage [
 
 	self announce: (SnapshotDone isNewImage: isNewImage)

--- a/src/System-Announcements/SystemAnnouncer.class.st
+++ b/src/System-Announcements/SystemAnnouncer.class.st
@@ -17,6 +17,12 @@ Class {
 	#category : #'System-Announcements-Core'
 }
 
+{ #category : #announcer }
+SystemAnnouncer class >> announce: anAnnouncement [
+
+	^ self uniqueInstance announce: anAnnouncement
+]
+
 { #category : #accessing }
 SystemAnnouncer class >> announcer: anAnnouncer [
 	announcer := anAnnouncer

--- a/src/System-Changes/ChangeSet.class.st
+++ b/src/System-Changes/ChangeSet.class.st
@@ -344,7 +344,7 @@ ChangeSet class >> newChanges: aChangeSet withOld: old [
 		when: MethodRecategorized send: #methodRecategorized: to: aChangeSet;
 		when: DoItChunkImported send: #doItChunkImported: to: aChangeSet.
 
-	SystemAnnouncer uniqueInstance announce: (CurrentChangeSetChanged new old: old; new: aChangeSet ; yourself)
+	SystemAnnouncer announce: (CurrentChangeSetChanged new old: old; new: aChangeSet ; yourself)
 ]
 
 { #category : #services }


### PR DESCRIPTION
The main goal of this PR is to inline the use of protocol announcements from SystemAnnouncer to ClassOrganization.

The protocol announcement are announced only in one method in ClassOrganization. On top of that, it is dangerous for external tools to announce themselves such announcements. So I inlined them to reduce the API of SystemAnnouncer and make it more difficult to announce it outside of the class management of Pharo.

I also added SystemAnnouncer class>>announce: because we often do that in Pharo.

To keep a code really readable I added some "constructors" for protocol announcements.

One of my next step on this subject is to update the protocol announcements to manipulate a protocol instead of a protocol name.