### PR TITLE
Move class comment export to ClassDescription

### DIFF
--- a/src/CodeExport/ClassDescription.extension.st
+++ b/src/CodeExport/ClassDescription.extension.st
@@ -50,7 +50,7 @@ ClassDescription >> fileOutOn: aFileStream [
 	"we for now file out old style class definitions"
 
 	aFileStream nextChunkPut: self oldPharoDefinition.
-	self organization putCommentOnFile: aFileStream forClass: self.
+	self putCommentOnFile: aFileStream.
 	self organization protocolNames do: [ :protocolName | self fileOutLocalMethodsInProtocolNamed: protocolName on: aFileStream ]
 ]
 
@@ -131,6 +131,32 @@ ClassDescription >> printProtocolChunk: protocol on: aFileStream withStamp: chan
 				 strm
 					 nextPutAll: ' prior: ';
 					 print: priorMethod sourcePointer ] ])
+]
+
+{ #category : #'*CodeExport' }
+ClassDescription >> putCommentOnFile: aFileStream [ 
+	"Store the comment about the class onto file, aFileStream."
+
+	| header |
+	self comment isEmptyOrNil ifTrue: [ ^ self ].
+
+	aFileStream
+		cr;
+		nextPut: $!.
+	header := String streamContents: [ :strm |
+		          strm
+			          nextPutAll: self name;
+			          nextPutAll: ' commentStamp: '.
+		          self commentStamp storeOn: strm.
+		          strm
+			          nextPutAll: ' prior: ';
+			          nextPutAll: '0' ].
+	aFileStream nextChunkPut: header.
+	self comment ifNotNil: [ :comment |
+		aFileStream
+			cr;
+			nextChunkPut: comment string ].
+	aFileStream cr
 ]
 
 { #category : #'*CodeExport' }

--- a/src/CodeExport/ClassOrganization.extension.st
+++ b/src/CodeExport/ClassOrganization.extension.st
@@ -1,34 +1,6 @@
 Extension { #name : #ClassOrganization }
 
 { #category : #'*CodeExport' }
-ClassOrganization >> fileOutCommentOn: aFileStream [
-	"Copy the class comment to aFileStream."
-
-	self classComment ifNil: [ ^ self ].
-	aFileStream
-		cr;
-		nextChunkPut: self classComment string
-]
-
-{ #category : #'*CodeExport' }
-ClassOrganization >> putCommentOnFile: aFileStream forClass: aClass [
-	"Store the comment about the class onto file, aFileStream."
-
-	| header |
-	self classComment isEmptyOrNil ifTrue:[ ^ self ].
-
-	aFileStream cr; nextPut: $!.
-	header := String streamContents: [:strm |
-			strm nextPutAll: aClass name;
-			nextPutAll: ' commentStamp: '.
-			self commentStamp storeOn: strm.
-			strm nextPutAll: ' prior: '; nextPutAll: '0'].
-	aFileStream nextChunkPut: header.
-	aClass organization fileOutCommentOn: aFileStream.
-	aFileStream cr
-]
-
-{ #category : #'*CodeExport' }
 ClassOrganization >> stringForFileOut [
 
 	^ String streamContents: [ :aStream |

--- a/src/CodeImport/ClassOrganization.extension.st
+++ b/src/CodeImport/ClassOrganization.extension.st
@@ -7,18 +7,11 @@ ClassOrganization >> changeFromString: aString [
 	| protocolSpecs |
 	protocolSpecs := aString parseLiterals.
 
-	"If nothing was scanned and I had no elements before, then default me"
-	(protocolSpecs isEmpty and: [ self protocols isEmpty ])
-		ifTrue: [ ^ self reset ].
-
-	^ self internalChangeFromString: protocolSpecs
-]
-
-{ #category : #'*CodeImport' }
-ClassOrganization >> internalChangeFromString: protocolSpecs [
-	"Parse the argument, aString, and make this be the receiver's structure."
-
 	self reset.
+
+	"If nothing was scanned and I had no elements before, then default me"
+	(protocolSpecs isEmpty and: [ self protocols isEmpty ]) ifTrue: [ ^ self ].
+
 	protocolSpecs do: [ :spec |
 		| name methods |
 		name := spec first asSymbol.

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -231,6 +231,17 @@ ClassOrganization >> organizedClass [
 	^ organizedClass ifNil: [ self error: 'ClassOrganization should always have an organized class associated.' ]
 ]
 
+{ #category : #printing }
+ClassOrganization >> printOn: aStream [
+
+	super printOn: aStream.
+
+	aStream
+		nextPutAll: ' (';
+		print: self organizedClass;
+		nextPut: $)
+]
+
 { #category : #accessing }
 ClassOrganization >> protocolNameOfElement: aSelector [
 

--- a/src/MonticelloGUI/MCCodeTool.class.st
+++ b/src/MonticelloGUI/MCCodeTool.class.st
@@ -107,9 +107,7 @@ MCCodeTool >> fileOutMessage [
 					ifNotNil:
 						[internalStream nextChunkPut: patchOp definition actualClass definition.
 						 patchOp definition comment ifNotNil:
-							[patchOp definition actualClass organization
-								putCommentOnFile: internalStream
-								forClass: patchOp definition actualClass]]
+							[ patchOp definition actualClass putCommentOnFile: internalStream ] ]
 					ifNil:
 						[internalStream nextChunkPut: patchOp definition className, ' removeFromSystem']]].
 		CodeExporter writeSourceCodeFrom: internalStream baseName: fileName isSt: true]

--- a/src/System-Changes/ChangeSet.class.st
+++ b/src/System-Changes/ChangeSet.class.st
@@ -881,9 +881,7 @@ ChangeSet >> fileOutClassDefinition: class on: stream [
 				vars in this class, warn author when new ones are added." ] ].
 	(self atClass: class includes: #comment)
 		ifFalse: [ ^ self ].
-	class instanceSide organization
-		putCommentOnFile: stream
-		forClass: class instanceSide.
+	class instanceSide putCommentOnFile: stream.
 	stream cr
 ]
 


### PR DESCRIPTION
A cleaning has started to move the comments managements from ClassOrganization to ClassDescription.  This PR deals with the code export.

Remove ClassOrganization>>#putCommentOnFile:forClass: in favor of ClassDescription>>#putCommentOnFile:

I also added a print method to ClassOrganization to help with the refactors I'm doing and I merged two code import methods that I wanted to merge since a while.

I like to see how the code is becoming simpler :) 
Like 
```st
patchOp definition actualClass organization
	putCommentOnFile: internalStream
	forClass: patchOp definition actualClass
```

Becoming

```st
patchOp definition actualClass putCommentOnFile: internalStream
```

