### PR TITLE
Remove #protocolsOfSelector: and implement #protocolOfSelector:

### DIFF
--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -75,7 +75,7 @@ ClassOrganization >> classify: aSymbol inProtocolNamed: aProtocolName [
 { #category : #'backward compatibility' }
 ClassOrganization >> classify: selector under: aProtocol [
 
-	| oldProtocolName forceNotify oldProtocols protocolName |
+	| oldProtocolName forceNotify oldProtocol protocolName |
 	"The next section deserve more cleanings.
 	
 	Some code was added to make it possible to classify giving a real protocol.
@@ -87,10 +87,10 @@ ClassOrganization >> classify: selector under: aProtocol [
 	forceNotify := (self includesSelector: selector) not.
 	oldProtocolName := self protocolNameOfElement: selector.
 	(forceNotify or: [ oldProtocolName ~= protocolName or: [ protocolName ~= Protocol unclassified ] ]) ifFalse: [ ^ self ].
-	oldProtocols := self protocolsOfSelector: selector.
+	oldProtocol := self protocolOf: selector.
 
 	self classify: selector inProtocolNamed: protocolName.
-	oldProtocols do: [ :protocol | self removeProtocolIfEmpty: protocol ].
+	oldProtocol ifNotNil: [ self removeProtocolIfEmpty: oldProtocol ].
 	oldProtocolName ifNotNil: [ self notifyOfChangedSelector: selector from: oldProtocolName to: protocolName ]
 ]
 
@@ -240,12 +240,9 @@ ClassOrganization >> protocolNameOfElement: aSelector [
 { #category : #accessing }
 ClassOrganization >> protocolNameOfElement: aSelector ifAbsent: aBlock [
 
-	^ (self protocolsOfSelector: aSelector)
-		  ifEmpty: [
-			  (organizedClass includesSelector: aSelector)
-				  ifTrue: [ Protocol unclassified ]
-				  ifFalse: [ aBlock value ] ]
-		  ifNotEmpty: [ :col | col first name ]
+	^ (self protocolOf: aSelector)
+		  ifNil: [ aBlock value ]
+		  ifNotNil: [ :protocol | protocol name ]
 ]
 
 { #category : #accessing }
@@ -268,16 +265,18 @@ ClassOrganization >> protocolNames [
 	^ self protocols collect: [ :protocol | protocol name ]
 ]
 
+{ #category : #protocol }
+ClassOrganization >> protocolOf: aSelector [
+
+	^ self protocols
+		  detect: [ :each | each includesSelector: aSelector ]
+		  ifNone: [ nil ]
+]
+
 { #category : #accessing }
 ClassOrganization >> protocols [
 
 	^ protocols
-]
-
-{ #category : #protocol }
-ClassOrganization >> protocolsOfSelector: aSelector [
-
-	^ self protocols select: [ :each | each includesSelector: aSelector ]
 ]
 
 { #category : #removing }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -241,7 +241,7 @@ ClassOrganization >> protocolNameOfElement: aSelector [
 ClassOrganization >> protocolNameOfElement: aSelector ifAbsent: aBlock [
 
 	^ (self protocolOfSelector: aSelector)
-		  ifNil: [ aBlock value ]
+		  ifNil: [ (organizedClass includesSelector: aSelector) ifTrue: [ Protocol unclassified ] ifFalse: [ aBlock value ] ]
 		  ifNotNil: [ :protocol | protocol name ]
 ]
 

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -87,7 +87,7 @@ ClassOrganization >> classify: selector under: aProtocol [
 	forceNotify := (self includesSelector: selector) not.
 	oldProtocolName := self protocolNameOfElement: selector.
 	(forceNotify or: [ oldProtocolName ~= protocolName or: [ protocolName ~= Protocol unclassified ] ]) ifFalse: [ ^ self ].
-	oldProtocol := self protocolOf: selector.
+	oldProtocol := self protocolOfSelector: selector.
 
 	self classify: selector inProtocolNamed: protocolName.
 	oldProtocol ifNotNil: [ self removeProtocolIfEmpty: oldProtocol ].
@@ -240,7 +240,7 @@ ClassOrganization >> protocolNameOfElement: aSelector [
 { #category : #accessing }
 ClassOrganization >> protocolNameOfElement: aSelector ifAbsent: aBlock [
 
-	^ (self protocolOf: aSelector)
+	^ (self protocolOfSelector: aSelector)
 		  ifNil: [ aBlock value ]
 		  ifNotNil: [ :protocol | protocol name ]
 ]
@@ -266,7 +266,7 @@ ClassOrganization >> protocolNames [
 ]
 
 { #category : #protocol }
-ClassOrganization >> protocolOf: aSelector [
+ClassOrganization >> protocolOfSelector: aSelector [
 
 	^ self protocols
 		  detect: [ :each | each includesSelector: aSelector ]


### PR DESCRIPTION
This remove #protocolsOfSelector: because a selector has only 1 protocol, so why should we manipulate a collection when we can only have 0 or 1 element?

Instead I created a method #protocolOf: that returns the protocol of a method selector or nil. I adapted the users accordingly to make the code cleaner.

In future PR this will also help me to clean more code.
I plan to deprecate #protocolNameOfSelector:[ifAbsent:] to use this new method. Some senders can use a real protocol, and others can just send #name to the return of #protocolOf: