### PR TITLE
implements RBBlockErrorNode>>#argumentNames

### DIFF
--- a/src/AST-Core/RBBlockErrorNode.class.st
+++ b/src/AST-Core/RBBlockErrorNode.class.st
@@ -31,6 +31,12 @@ RBBlockErrorNode class >> error: aToken withNodes: aCollection [
 ]
 
 { #category : #accessing }
+RBBlockErrorNode >> argumentNames [
+
+	^ self arguments collect: [:each | each name] as: Array
+]
+
+{ #category : #accessing }
 RBBlockErrorNode >> arguments [
 	^arguments
 ]


### PR DESCRIPTION
Fix #13380

Completion did not expect to find statements in an unfinished block.
The method is missing since a long time, and statements in unfinished block are in fact quite common while editing.
So it's weird to have this bug report so late.

With the new method, you can autocomplete block parameters in an unfinished block!

![Capture d’écran du 2023-04-10 18-08-26](https://user-images.githubusercontent.com/135828/231008967-7e68fd6b-48b3-41a3-8f44-5c4d093a5276.png)
