### PR TITLE
Compiled method drop last property

### DIFF
--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -731,7 +731,7 @@ CompiledMethodTest >> testPragmaAt [
 	self assert: (method pragmaAt: #hello) equals: nil
 ]
 
-{ #category : #test }
+{ #category : #tests }
 CompiledMethodTest >> testProperties [
 
 	| method tmp |

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -731,6 +731,53 @@ CompiledMethodTest >> testPragmaAt [
 	self assert: (method pragmaAt: #hello) equals: nil
 ]
 
+{ #category : #test }
+CompiledMethodTest >> testProperties [
+
+	| method tmp |
+	method := self class >> #returnTrue.
+	
+	"No property. Unlike classic collections, nil is returned on absence"
+	self deny: method hasProperties.
+	self deny: (method hasProperty: #doesNotExist).
+	self assert: (method propertyAt: #doesNotExist) equals: nil.
+	self assert: (method propertyAt: #doesNotExist ifAbsent: [ #tag ]) equals: #tag.
+	self assert: (method removeProperty: #doesNotExist) equals: nil.
+	self assert: (method removeProperty: #doesNotExist ifAbsent: [ #tag ]) equals: #tag.
+	
+	"Add a property"
+	self assert: (method propertyAt: #doesNotExist put: #yesItDoes) equals: #yesItDoes.
+	self assert: method hasProperties.
+	self assert: (method hasProperty: #doesNotExist).
+	self assert: (method propertyAt: #doesNotExist) equals: #yesItDoes.
+	self assert: (method propertyAt: #doesNotExist ifAbsent: [ #tag ]) equals: #yesItDoes.
+
+	"Remove it"
+	self assert: (method removeProperty: #doesNotExist) equals: #yesItDoes.
+	self deny: method hasProperties.
+	self assert: (method removeProperty: #doesNotExist) equals: nil.
+
+	"Add it back"
+	self assert: (method propertyAt: #doesNotExist ifAbsentPut: [ #yesItDoesAgain ]) equals: #yesItDoesAgain.
+	self assert: method hasProperties.
+	self assert: (method propertyAt: #doesNotExist) equals: #yesItDoesAgain.
+
+	"Add a second one"
+	self assert: (method propertyAt: #doesExist put: #yesItDoes) equals: #yesItDoes.
+	
+	tmp := OrderedCollection new.
+	method propertyKeysAndValuesDo: [ :key :value | tmp add: { key . value } ].
+	self assertCollection: tmp hasSameElements: #( #( #doesNotExist #yesItDoesAgain ) #(#doesExist #yesItDoes) ).
+	
+	"Remove both"
+	method removeProperty: #doesNotExist.
+	self assert: method hasProperties.
+	self assert: (method propertyAt: #doesNotExist) equals: nil.
+	self assert: (method propertyAt: #doesExist) equals: #yesItDoes.
+	method removeProperty: #doesExist.
+	self deny: method hasProperties
+]
+
 { #category : #'tests - instance variable' }
 CompiledMethodTest >> testReadsField [
 	| method |

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -981,6 +981,9 @@ CompiledMethod >> removeProperty: propName [
 									(Association
 										key: propName
 										value: value)).
+
+	"Remove unneded AdditionalMethodState"
+	self penultimateLiteral size = 0 ifTrue: [ self penultimateLiteral: self selector ].
 	^value
 ]
 


### PR DESCRIPTION
As mentioned by https://github.com/pharo-project/pharo/pull/13359#issuecomment-1501570551 compiled method can keep an empty additional state.
This is inefficient, but worse could be considered a bug because `hasProperties` did remain true even if the last property is removed.

This PR fixes that, and add tests