### PR TITLE
Add logs on Debugger-Oups-Tests to find error

### DIFF
--- a/src/Debugger-Oups-Tests/OupsDebugRequestTest.class.st
+++ b/src/Debugger-Oups-Tests/OupsDebugRequestTest.class.st
@@ -7,6 +7,14 @@ Class {
 	#category : #'Debugger-Oups-Tests-Tests - infrastructure'
 }
 
+{ #category : #private }
+OupsDebugRequestTest >> performTest [
+	"Temporary printing to find more information about https://github.com/pharo-project/pharo/issues/12502"
+
+	('Running: ' , testSelector asString , ' from ' , self class name) traceCr.
+	self perform: testSelector asSymbol
+]
+
 { #category : #tests }
 OupsDebugRequestTest >> testCreationFromException [
 	| error dr |

--- a/src/Debugger-Oups-Tests/OupsDebuggerSelectionStrategyTest.class.st
+++ b/src/Debugger-Oups-Tests/OupsDebuggerSelectionStrategyTest.class.st
@@ -4,6 +4,14 @@ Class {
 	#category : #'Debugger-Oups-Tests-Tests - strategies'
 }
 
+{ #category : #private }
+OupsDebuggerSelectionStrategyTest >> performTest [
+	"Temporary printing to find more information about https://github.com/pharo-project/pharo/issues/12502"
+
+	('Running: ' , testSelector asString , ' from ' , self class name) traceCr.
+	self perform: testSelector asSymbol
+]
+
 { #category : #'tests - debugging' }
 OupsDebuggerSelectionStrategyTest >> testHandled [
 	self deny: OupsDebuggerSelectionStrategy new handled

--- a/src/Debugger-Oups-Tests/OupsDebuggerSelectorTest.class.st
+++ b/src/Debugger-Oups-Tests/OupsDebuggerSelectorTest.class.st
@@ -8,6 +8,14 @@ Class {
 	#category : #'Debugger-Oups-Tests-Tests - strategies'
 }
 
+{ #category : #private }
+OupsDebuggerSelectorTest >> performTest [
+	"Temporary printing to find more information about https://github.com/pharo-project/pharo/issues/12502"
+
+	('Running: ' , testSelector asString , ' from ' , self class name) traceCr.
+	self perform: testSelector asSymbol
+]
+
 { #category : #helper }
 OupsDebuggerSelectorTest >> session [
 	^OupsDummyDebugger dummySession

--- a/src/Debugger-Oups-Tests/OupsDebuggerSystemTest.class.st
+++ b/src/Debugger-Oups-Tests/OupsDebuggerSystemTest.class.st
@@ -34,6 +34,14 @@ OupsDebuggerSystemTest >> createDummyDebugRequestForUIProcess [
 		  yourself
 ]
 
+{ #category : #private }
+OupsDebuggerSystemTest >> performTest [
+	"Temporary printing to find more information about https://github.com/pharo-project/pharo/issues/12502"
+
+	('Running: ' , testSelector asString , ' from ' , self class name) traceCr.
+	self perform: testSelector asSymbol
+]
+
 { #category : #running }
 OupsDebuggerSystemTest >> setUp [
 	super setUp.

--- a/src/Debugger-Oups-Tests/OupsSingleDebuggerSelectorTest.class.st
+++ b/src/Debugger-Oups-Tests/OupsSingleDebuggerSelectorTest.class.st
@@ -8,6 +8,14 @@ Class {
 	#category : #'Debugger-Oups-Tests-Tests - strategies'
 }
 
+{ #category : #private }
+OupsSingleDebuggerSelectorTest >> performTest [
+	"Temporary printing to find more information about https://github.com/pharo-project/pharo/issues/12502"
+
+	('Running: ' , testSelector asString , ' from ' , self class name) traceCr.
+	self perform: testSelector asSymbol
+]
+
 { #category : #running }
 OupsSingleDebuggerSelectorTest >> setUp [
 	"Hooks that subclasses may override to define the fixture of test."


### PR DESCRIPTION
The error of issue https://github.com/pharo-project/pharo/issues/12502 is really hard to find.
To help to locate the source of the error I propose to log the tests. At least we will be able to locate which test is crashing.

To be reverted later