### PR TITLE
OpalCompiler restore undeclared menu on the playground

### DIFF
--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -259,7 +259,7 @@ OpalCompiler >> checkNotice: aNotice [
 		* require a requestor (because quirks mode, and also some reparations expect a requestor)
 		* require interactive mode (because GUI)
 		* require method definition becase some reparation assume it's a method body"
-		(self compilationContext interactive and: [self compilationContext noPattern not]) ifTrue: [
+		compilationContext interactive ifTrue: [
 			aNotice reparator ifNotNil: [ :reparator |
 				| res |
 				res := reparator


### PR DESCRIPTION
Fix #13391

Reactivate the "undeclared" menu on scripts/playground because it is useful in the playground for classes, for instance.
It sill buggy, but Pharo11 (and some previous versions I assume) has the same bugs (or worse bugs).

Extracted from #13323