### PR TITLE
Try to move workspace variables further (lite)

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -64,7 +64,7 @@ Context >> lookupVar: aSymbol [
 
 { #category : #'*Debugging-Core' }
 Context >> lookupVar: aSymbol declare: aBoolean [
-	^ self astScope lookupVar: aSymbol declare: aBoolean
+	^ self astScope lookupVar: aSymbol
 ]
 
 { #category : #'*Debugging-Core' }

--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -85,12 +85,6 @@ Behavior >> lookupVar: aName declare: aBoolean [
 ]
 
 { #category : #'*OpalCompiler-Core' }
-Behavior >> lookupVarForDeclaration: name [
-	"This is a version of #lookupVar: that skips the OCRequestorScope, from here on it is the same as lookupVar:"
-	^ self lookupVar: name
-]
-
-{ #category : #'*OpalCompiler-Core' }
 Behavior >> outerScope [
 	^self environment
 ]

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -719,7 +719,6 @@ CompilationContext >> scope [
 	requestor ifNotNil: [
 		"the requestor is allowed to manage variables, the workspace is using it to auto-define vars"
 		newScope := (self requestorScopeClass new
-			compilationContext: self;
 			requestor: requestor) outerScope: newScope].
 
 	bindings ifNotNil: [

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -89,7 +89,7 @@ OCASTSemanticAnalyzer >> declareVariableNode: aVariableNode as: anOCTempVariable
 	| name var shadowing |
 	name := aVariableNode name.
 	"check if another variable with same name is visible"
-	shadowing := scope lookupVarForDeclaration: name.
+	shadowing := scope lookupVar: name.
 	var := scope addTemp: anOCTempVariable.
 	aVariableNode binding: var.
 	(shadowing notNil and: [ shadowing allowsShadowing not]) ifTrue: [self shadowing: shadowing withVariable: aVariableNode].

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -146,13 +146,13 @@ OCAbstractMethodScope >> lookupDefiningContextForVariable: var startingFrom: aCo
 ]
 
 { #category : #lookup }
-OCAbstractMethodScope >> lookupVar: name declare: aBoolean [
+OCAbstractMethodScope >> lookupVar: name [
 
 	copiedVars at: name ifPresent: [:v | ^ v].
 	tempVector at: name ifPresent: [:v | ^ v].
 	tempVars at: name ifPresent: [:v | ^ v].
 	name = self tempVectorName ifTrue: [ ^ self tempVectorVar ].
-	^self outerScope lookupVar: name declare: aBoolean
+	^self outerScope lookupVar: name
 ]
 
 { #category : #scope }

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -152,7 +152,7 @@ OCAbstractMethodScope >> lookupVar: name [
 	tempVector at: name ifPresent: [:v | ^ v].
 	tempVars at: name ifPresent: [:v | ^ v].
 	name = self tempVectorName ifTrue: [ ^ self tempVectorVar ].
-	^self outerScope lookupVar: name
+	^ super lookupVar: name
 ]
 
 { #category : #scope }

--- a/src/OpalCompiler-Core/OCAbstractScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractScope.class.st
@@ -48,22 +48,7 @@ OCAbstractScope >> isMethodScope [
 { #category : #lookup }
 OCAbstractScope >> lookupVar: name [
 	"search the scope (and the outer scopes) for a variable 'name' and return it"
-	^ self lookupVar: name declare: true
-]
-
-{ #category : #lookup }
-OCAbstractScope >> lookupVar: name declare: aBoolean [
-	"search the scope (and the outer scopes) for a variable 'name' and return it"
-	^self subclassResponsibility
-]
-
-{ #category : #lookup }
-OCAbstractScope >> lookupVarForDeclaration: name [
-	"This is a version of #lookupVar: that skips the OCRequestorScope.
-	When looking temp var declarations, we do not want the Requestor scope to automatically
-	create that variable. Subclasses override if they do not skip but do a lookup"
-
-	^ self lookupVar: name declare: false
+	^ self subclassResponsibility
 ]
 
 { #category : #lookup }

--- a/src/OpalCompiler-Core/OCAbstractScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractScope.class.st
@@ -48,7 +48,8 @@ OCAbstractScope >> isMethodScope [
 { #category : #lookup }
 OCAbstractScope >> lookupVar: name [
 	"search the scope (and the outer scopes) for a variable 'name' and return it"
-	^ self subclassResponsibility
+
+	^ outerScope ifNotNil: [ :it | it lookupVar: name ]
 ]
 
 { #category : #lookup }

--- a/src/OpalCompiler-Core/OCAbstractScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractScope.class.st
@@ -77,3 +77,9 @@ OCAbstractScope >> outerScope: aSemScope [
 
 	outerScope := aSemScope
 ]
+
+{ #category : #lookup }
+OCAbstractScope >> registerVariables [
+
+	outerScope ifNotNil: [ :it | it registerVariables ]
+]

--- a/src/OpalCompiler-Core/OCContextualDoItSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCContextualDoItSemanticScope.class.st
@@ -73,11 +73,11 @@ OCContextualDoItSemanticScope >> initialize [
 ]
 
 { #category : #lookup }
-OCContextualDoItSemanticScope >> lookupVar: name declare: aBoolean [
+OCContextualDoItSemanticScope >> lookupVar: name [
 
-	(targetContext lookupVar: name declare: aBoolean) ifNotNil: [ :v | ^self importVariable: v].
+	(targetContext lookupVar: name) ifNotNil: [ :v | ^self importVariable: v].
 
-	^super lookupVar: name declare: aBoolean
+	^super lookupVar: name
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OCExtraBindingScope.class.st
+++ b/src/OpalCompiler-Core/OCExtraBindingScope.class.st
@@ -40,8 +40,8 @@ OCExtraBindingScope >> bindings: anObject [
 ]
 
 { #category : #lookup }
-OCExtraBindingScope >> lookupVar: name declare: aBoolean [
+OCExtraBindingScope >> lookupVar: name [
 	^(bindings bindingOf: name asSymbol)
 		ifNotNil: [ :var | var ]
-		ifNil: [ outerScope lookupVar: name declare: aBoolean]
+		ifNil: [ outerScope lookupVar: name]
 ]

--- a/src/OpalCompiler-Core/OCExtraBindingScope.class.st
+++ b/src/OpalCompiler-Core/OCExtraBindingScope.class.st
@@ -43,5 +43,5 @@ OCExtraBindingScope >> bindings: anObject [
 OCExtraBindingScope >> lookupVar: name [
 	^(bindings bindingOf: name asSymbol)
 		ifNotNil: [ :var | var ]
-		ifNil: [ outerScope lookupVar: name]
+		ifNil: [ super lookupVar: name ]
 ]

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -10,7 +10,8 @@ Class {
 	#superclass : #OCAbstractScope,
 	#instVars : [
 		'requestor',
-		'compilationContext'
+		'compilationContext',
+		'variables'
 	],
 	#category : #'OpalCompiler-Core-Semantics'
 }
@@ -33,30 +34,29 @@ OCRequestorScope >> compilationContext: anObject [
 { #category : #lookup }
 OCRequestorScope >> lookupVar: name declare: aBoolean [
 
-	"the system normally allows any object as the name, but the requestor uses some
-	heuristics based on names of variables"
+	(requestor hasBindingOf: name) ifTrue: [ ^ requestor bindingOf: name ].
+	"Note that is an outerscope is a requestor tant can declare, it will win the declaration.
+	But maybe it is better this way."
+	(outerScope lookupVar: name) ifNotNil: [ :binding | ^ binding ].
+	
+	"Heuristic, assume the requestor does not want upercased variables.
+	A menu will likely open to offer reparation for class or global or something."
+	name first isUppercase ifTrue: [ ^ nil ].
+	
+	"We do not register it yet, to not fill the requestor with garbage variable during styling for instance"
+	^ self variables at: name ifAbsentPut: [ WorkspaceVariable key: name ]
+]
 
-	name isString ifFalse: [ ^ outerScope lookupVar: name declare: aBoolean ].
-	name isEmpty ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean ].
+{ #category : #lookup }
+OCRequestorScope >> registerVariables [
 
-	"reserved Variables are defined by the global scope, thus we look up in the outer scope"
-	(ReservedVariable nameIsReserved: name) ifTrue: [
-		^ outerScope lookupVar: name declare: aBoolean ].
-
-	"generated temps (e.g. for limits in to:do: should not create bindings"
-	name first = $0 ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean ].
-	"We do not want to auto define bindings for unknown Globals"
-	name first isUppercase ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean].
-	"do not 'create bindings' in requestor scope if we just want to style a possible unknown variable"
-	self flag: 'The faulty mode should not impact how variable are bound'.
-	((compilationContext permitFaulty or: [aBoolean not])
-		and: [ (requestor hasBindingOf: name) not ])
-		ifTrue: [ ^ outerScope lookupVar: name declare: aBoolean ].
-
-	"the requestors #bindingOf may create a binding for not yet existing variables"
-	^(requestor bindingOf: name)
-		ifNotNil: [ :var | var ]
-		ifNil: [ outerScope lookupVar: name declare: aBoolean ]
+	self variables do: [ :each |
+		| var |
+		"Force the declaraction, if needed"
+		var := requestor bindingOf: each name.
+		"Because we no non control how requestor handle its variables, just update the one we used locally"
+		var == each ifFalse: [ each becomeForward: var ] ].
+	super registerVariables
 ]
 
 { #category : #accessing }
@@ -67,4 +67,10 @@ OCRequestorScope >> requestor [
 { #category : #accessing }
 OCRequestorScope >> requestor: anObject [
 	requestor := anObject
+]
+
+{ #category : #accessing }
+OCRequestorScope >> variables [
+
+	^ variables ifNil: [ variables := Dictionary new ].
 ]

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -10,7 +10,6 @@ Class {
 	#superclass : #OCAbstractScope,
 	#instVars : [
 		'requestor',
-		'compilationContext',
 		'variables'
 	],
 	#category : #'OpalCompiler-Core-Semantics'
@@ -41,16 +40,6 @@ OCRequestorScope >> canDeclareVariableName: name [
 	name first isUppercase ifTrue: [ ^ false ].
 
 	^ true
-]
-
-{ #category : #accessing }
-OCRequestorScope >> compilationContext [
-	^ compilationContext
-]
-
-{ #category : #accessing }
-OCRequestorScope >> compilationContext: anObject [
-	compilationContext := anObject
 ]
 
 { #category : #lookup }

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -32,7 +32,7 @@ OCRequestorScope >> compilationContext: anObject [
 ]
 
 { #category : #lookup }
-OCRequestorScope >> lookupVar: name declare: aBoolean [
+OCRequestorScope >> lookupVar: name [
 
 	(requestor hasBindingOf: name) ifTrue: [ ^ requestor bindingOf: name ].
 	"Note that is an outerscope is a requestor tant can declare, it will win the declaration.

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -28,6 +28,14 @@ OCRequestorScope >> canDeclareVariableName: name [
 	"Empty names come from faulty parameters. Ignore them"
 	name ifEmpty: [ ^ false ].
 
+	"Ensure compatibility with old requestors"
+	(requestor respondsTo: #canDeclareVariableName:) ifTrue: [
+		^ requestor canDeclareVariableName: name ].
+
+	"Supported legacy: only the workspace"
+	requestor class name = #StPlaygroundInteractionModel ifFalse: [
+		^ false ].
+
 	"Heuristic, assume the requestor does not want upercased variables.
 	A menu will likely open to offer reparation for class or global or something."
 	name first isUppercase ifTrue: [ ^ false ].

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -55,7 +55,7 @@ OCRequestorScope >> registerVariables [
 		"Force the declaraction, if needed"
 		var := requestor bindingOf: each name.
 		"Because we no non control how requestor handle its variables, just update the one we used locally"
-		var == each ifFalse: [ each becomeForward: var ] ].
+		(var isNotNil and: [ var ~= each ]) ifTrue: [ each becomeForward: var ] ].
 	super registerVariables
 ]
 

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -21,6 +21,17 @@ OCRequestorScope >> allTemps [
 	^#()
 ]
 
+{ #category : #testing }
+OCRequestorScope >> canDeclareVariableName: name [
+	"Test for free workspace declaration"
+
+	"Heuristic, assume the requestor does not want upercased variables.
+	A menu will likely open to offer reparation for class or global or something."
+	name first isUppercase ifTrue: [ ^ false ].
+
+	^ true
+]
+
 { #category : #accessing }
 OCRequestorScope >> compilationContext [
 	^ compilationContext
@@ -38,11 +49,9 @@ OCRequestorScope >> lookupVar: name [
 	"Note that is an outerscope is a requestor tant can declare, it will win the declaration.
 	But maybe it is better this way."
 	(super lookupVar: name) ifNotNil: [ :binding | ^ binding ].
-	
-	"Heuristic, assume the requestor does not want upercased variables.
-	A menu will likely open to offer reparation for class or global or something."
-	name first isUppercase ifTrue: [ ^ nil ].
-	
+
+	"Can we have a free workspace variable or not?"
+	(self canDeclareVariableName: name) ifFalse: [ ^nil ].
 	"We do not register it yet, to not fill the requestor with garbage variable during styling for instance"
 	^ self variables at: name ifAbsentPut: [ WorkspaceVariable key: name ]
 ]

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -37,7 +37,7 @@ OCRequestorScope >> lookupVar: name [
 	(requestor hasBindingOf: name) ifTrue: [ ^ requestor bindingOf: name ].
 	"Note that is an outerscope is a requestor tant can declare, it will win the declaration.
 	But maybe it is better this way."
-	(outerScope lookupVar: name) ifNotNil: [ :binding | ^ binding ].
+	(super lookupVar: name) ifNotNil: [ :binding | ^ binding ].
 	
 	"Heuristic, assume the requestor does not want upercased variables.
 	A menu will likely open to offer reparation for class or global or something."

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -25,6 +25,9 @@ OCRequestorScope >> allTemps [
 OCRequestorScope >> canDeclareVariableName: name [
 	"Test for free workspace declaration"
 
+	"Empty names come from faulty parameters. Ignore them"
+	name ifEmpty: [ ^ false ].
+
 	"Heuristic, assume the requestor does not want upercased variables.
 	A menu will likely open to offer reparation for class or global or something."
 	name first isUppercase ifTrue: [ ^ false ].

--- a/src/OpalCompiler-Core/OCSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCSemanticScope.class.st
@@ -61,11 +61,11 @@ OCSemanticScope >> isDoItScope [
 ]
 
 { #category : #lookup }
-OCSemanticScope >> lookupVar: name declare: aBoolean [
+OCSemanticScope >> lookupVar: name [
 
-	(self targetClass lookupVar: name declare: aBoolean) ifNotNil: [ :v | ^v ].
+	(self targetClass lookupVar: name) ifNotNil: [ :v | ^v ].
 
-	^outerScope ifNotNil: [ outerScope lookupVar: name declare: aBoolean ]
+	^outerScope ifNotNil: [ outerScope lookupVar: name ]
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OCSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCSemanticScope.class.st
@@ -65,7 +65,7 @@ OCSemanticScope >> lookupVar: name [
 
 	(self targetClass lookupVar: name) ifNotNil: [ :v | ^v ].
 
-	^outerScope ifNotNil: [ outerScope lookupVar: name ]
+	^ super lookupVar: name
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -325,6 +325,7 @@ OpalCompiler >> compile [
 	ast ifNil: [ ^ result ]. "some failBlock"
 
 	self callPlugins.
+	ast scope registerVariables.
 	method := ast generateMethod.
 	method propertyAt: #source put: source.
 	compilationContext noPattern ifTrue: [ method propertyAt: #ast put: ast ]. "Keep AST for scripts (for the moment)"

--- a/src/Reflectivity/RFSemanticAnalyzer.class.st
+++ b/src/Reflectivity/RFSemanticAnalyzer.class.st
@@ -85,7 +85,7 @@ RFSemanticAnalyzer >> visitNode: aNode [
 RFSemanticAnalyzer >> visitStoreIntoTempNode: aNode [
 	| name var |
 	name := aNode name.
-	var := scope lookupVarForDeclaration: name.
+	var := scope lookupVar: name.
 	var	ifNil: [
 			var := scope addTemp: (TemporaryVariable named: aNode name) ].
 	aNode binding: var
@@ -95,7 +95,7 @@ RFSemanticAnalyzer >> visitStoreIntoTempNode: aNode [
 RFSemanticAnalyzer >> visitStorePopIntoTempNode: aNode [
 	| name var |
 	name := aNode name.
-	var := scope lookupVarForDeclaration: name.
+	var := scope lookupVar: name.
 	var	ifNil: [
 			var := scope addTemp: (TemporaryVariable named: aNode name) ].
 	aNode binding: var

--- a/src/Ring-Core/RGBehavior.class.st
+++ b/src/Ring-Core/RGBehavior.class.st
@@ -669,14 +669,6 @@ RGBehavior >> lookupVar: aName declare: aBoolean [
 	^ self lookupVar: aName
 ]
 
-{ #category : #lookup }
-RGBehavior >> lookupVarForDeclaration: aName [
-
-	"This is a version of #lookupVar: that skips the OCRequestorScope, from here on it is the same as lookupVar:"
-
-	^ self lookupVar: aName
-]
-
 { #category : #resolving }
 RGBehavior >> makeResolved [
 


### PR DESCRIPTION
This is a reroll of #13323 ~~without~~ with less sugar or GUI concern

Workspace variables are a very problematic feature with a lot of defaults (UI, spec, implementation).

The compiler have to deal with heuristics and uncooperative requestors (GUI windows) to make them work, including:

* Having (and keeping) references on GUI windows when managing scope
* Heuristic trying to guess if we are compiling or not (just highlighting)
* Fear of asking if a variable exists, because asking so might create it

So this PR tries to clean up the current design (*implementation* design, not *GUI* design) a little.

I also tried to no impact the current UI and spec of (workspace variables are still as bad/good as before). Because it is out of scope of the PR, but also because changing what workspace variables are implies hacking GUI tools that lives in another repositories (and I'm not a GUI guy and PR synchronization between repository are a pain).

So, what is on the (reduced) menu:

* Handle workspace variables with the same idea that was used for undeclared  (see #VariableNotDeclared): get a local placeholder variable at parse/semantic-time and only register it (here to the requestor/GUI) at compile-time.
  This has a nice side effect: undeclared variable are now "blue" in the workspace (I can change that if you do not like it).
* remove most of the insane methods `lookupVar:declare:` and `lookupVarForDeclaration:` that are now unneeded (I suppose)

What was removed:

* Reactivate the "undeclared" menu → #13392
* Do not add requestor in scopes *except* for workspace-type requestors, that still need → wait for open season in spec/newtools