### PR TITLE
OCASTSemanticAnalyzer chose the value of superOf of super-sends

### DIFF
--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -6,7 +6,7 @@ Instance Variables:
 	receiver	<RBValueNode>	the receiver's node
 	selector	<Symbol>	the selector we're sending
 	keywordsPositions	<IntegerArray | nil>	the positions of the selector keywords
-
+	superOf <Behavior> the current class (for super-send messages)
 
 "
 Class {
@@ -16,7 +16,8 @@ Class {
 		'receiver',
 		'selector',
 		'keywordsPositions',
-		'arguments'
+		'arguments',
+		'superOf'
 	],
 	#category : #'AST-Core-Nodes'
 }
@@ -494,4 +495,16 @@ RBMessageNode >> stopWithoutParentheses [
 	^arguments isEmpty
 		ifTrue: [self keywordsIntervals first last]
 		ifFalse: [arguments last stop]
+]
+
+{ #category : #accessing }
+RBMessageNode >> superOf [
+
+	^ superOf
+]
+
+{ #category : #accessing }
+RBMessageNode >> superOf: anObject [
+
+	superOf := anObject
 ]

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -227,6 +227,13 @@ OCASTSemanticAnalyzer >> visitInlinedBlockNode: aBlockNode [
 ]
 
 { #category : #visiting }
+OCASTSemanticAnalyzer >> visitMessageNode: aMessageNode [
+	
+	super visitMessageNode: aMessageNode.
+	aMessageNode isSuperSend ifTrue: [ aMessageNode superOf: self compilationContext getClass ]
+]
+
+{ #category : #visiting }
 OCASTSemanticAnalyzer >> visitMethodNode: aMethodNode [
 
 	aMethodNode arguments size > 15 ifTrue: [ self error: 'Too many arguments' forNode: aMethodNode ].

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -245,7 +245,7 @@ OCASTTranslator >> emitMessageNode: aMessageNode [
 	aMessageNode arguments do: [:each |
 		valueTranslator visitNode: each].
 	aMessageNode isSuperSend
-		ifTrue: [methodBuilder send: aMessageNode selector toSuperOf: self compilationContext getClass]
+		ifTrue: [methodBuilder send: aMessageNode selector toSuperOf: aMessageNode superOf ]
 		ifFalse: [methodBuilder send: aMessageNode selector]
 ]
 

--- a/src/Reflectivity/RFASTTranslator.class.st
+++ b/src/Reflectivity/RFASTTranslator.class.st
@@ -29,7 +29,7 @@ RFASTTranslator >> emitMessageNode: aMessageNode [
 		ifTrue: [ self emitMetaLinkInstead: aMessageNode ]
 		ifFalse: [
 			aMessageNode isSuperSend
-				ifTrue: [ methodBuilder send: aMessageNode selector toSuperOf: self compilationContext getClass ]
+				ifTrue: [ methodBuilder send: aMessageNode selector toSuperOf: aMessageNode superOf ]
 				ifFalse: [ methodBuilder send: aMessageNode selector ] ].
 	self emitMetaLinkAfterNoEnsure: aMessageNode
 ]


### PR DESCRIPTION
I'm trying to reduce the dependency on compilationContext and regroup semantic responsibility to OCASTSemanticAnalyzer.

This will help future code evolution