### PR TITLE
ClyJumpToTestMethodCommand>>#generateTestMethodNamed:in: use good protocol

### DIFF
--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyJumpToTestMethodCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyJumpToTestMethodCommand.class.st
@@ -77,7 +77,7 @@ ClyJumpToTestMethodCommand >> generateTestMethodNamed: aSymbol in: aClass [
 
 	self flag: #toImplement.
 	self assert: false' format: {aSymbol}.
-	aClass compile: body classified: 'test'
+	aClass compile: body classified: 'tests'
 ]
 
 { #category : #execution }


### PR DESCRIPTION
If you use `Jump to test method...` in Calypso, then the generated method belong to the `test` protocol instead of the `tests` one (with a `s`). Then you will get critiques, although you're the victim.