### PR TITLE
Faulty code importers: use new compiler API

### DIFF
--- a/src/CodeImport/MethodChunk.class.st
+++ b/src/CodeImport/MethodChunk.class.st
@@ -64,12 +64,12 @@ MethodChunk >> handleMissingBehavior [
 MethodChunk >> importFor: requestor logSource: logSource [
 	self existsBehavior
 		ifFalse: [ self handleMissingBehavior ].
-	^ self targetClass
-		compile: contents
-		classified: categoryName
-		withStamp: stamp
-		notifying: nil
-		logSource: logSource
+	^ (self targetClass compiler
+		permitUndeclared: true;
+		protocol: categoryName;
+		changeStamp: stamp;
+		logged: logSource;
+		install: contents) selector
 ]
 
 { #category : #testing }

--- a/src/Monticello/MCMethodDefinition.class.st
+++ b/src/Monticello/MCMethodDefinition.class.st
@@ -258,11 +258,11 @@ MCMethodDefinition >> isOverrideMethod [
 { #category : #installing }
 MCMethodDefinition >> load [
 	| sel |
-	sel := self actualClass
-		compile: source
-		classified: category
-		withStamp: timeStamp
-		notifying: nil.
+	sel := (self actualClass compiler
+		protocol: category;
+		changeStamp: timeStamp;
+		permitUndeclared: true;
+		install: source) selector.
 	sel = selector ifTrue: [ ^ self ].
 	Warning signal: (
 		'Monticello: Selector missmatch. Got {1}, expected {2} for class {3}.'


### PR DESCRIPTION
Update CodeImporter and Monticello to use the new compiler API.
Also, explicitly set `permitUndeclared` to avoid relying on some random default.