### PR TITLE
Completion can extends keyword messages

### DIFF
--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -190,7 +190,7 @@ RBMessageNode >> isHaltNode [
 
 { #category : #testing }
 RBMessageNode >> isKeyword [
-	^(self selector indexOf: $:) ~= 0
+	^ self selector isKeyword
 ]
 
 { #category : #testing }

--- a/src/AST-Core/RBPragmaNode.class.st
+++ b/src/AST-Core/RBPragmaNode.class.st
@@ -133,7 +133,7 @@ RBPragmaNode >> isFaulty [
 
 { #category : #testing }
 RBPragmaNode >> isKeyword [
-	^(selector indexOf: $:) ~= 0
+	^ selector isKeyword
 ]
 
 { #category : #testing }

--- a/src/HeuristicCompletion-Model/CoGlobalSelectorFetcher.class.st
+++ b/src/HeuristicCompletion-Model/CoGlobalSelectorFetcher.class.st
@@ -12,7 +12,19 @@ Class {
 { #category : #enumerating }
 CoGlobalSelectorFetcher >> entriesDo: aBlock [
 
+	astNode ifNotNil: [ :node | node parent ifNotNil: [ :parent | "Try first to continue the parent keyword message"
+		(parent isMessage and: [ parent isKeyword ]) ifTrue: [
+			self systemNavigation
+				allSelectorsStartingWith:
+				parent selector , filter completionString
+				do: [ :e |
+					aBlock value: (NECSelectorEntry
+							 contents: (e copyFrom: parent selector size + 1 to: e size)
+							 node: astNode) ] ] ] ].
+
+	"Otherwise, just go wide"
 	self systemNavigation
 		allSelectorsStartingWith: filter completionString
-		do: [ :e | aBlock value: (NECSelectorEntry contents: e node: astNode) ]
+		do: [ :e |
+		aBlock value: (NECSelectorEntry contents: e node: astNode) ]
 ]


### PR DESCRIPTION
Completion is sometime very frustrating (but the code is worse).
One thing that did bug me enough to hack the code is the absence of completion on keyword messages after the first argument.

Now it tries to complete an existing keyword message with additional keyword parts.

![Capture d’écran du 2023-04-11 20-27-57](https://user-images.githubusercontent.com/135828/231316798-91e8251d-6f61-4b5e-8c9d-4e41ae5b1287.png)

Note: also replace `isKeyword` on some AST nodes with something more general and more efficient