### PR TITLE
FluidClassBuilder tests should clean the system

### DIFF
--- a/src/FluidClassBuilder-Tests/FluidClassBuilderTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidClassBuilderTest.class.st
@@ -45,6 +45,11 @@ FluidClassBuilderTest >> tearDown [
 	(RPackageOrganizer default packageNamed: #'Mock' ifAbsent: [ nil ])
 		ifNotNil: [:x | x removeFromSystem ].
 
+	(RPackageOrganizer default packageNamed: #'FakedCore' ifAbsent: [ nil ])
+		ifNotNil: [:x | x removeFromSystem ].
+		
+		
+
 	super tearDown
 ]
 
@@ -295,7 +300,7 @@ FluidClassBuilderTest >> testCreateClassWithFullExpandedDefinitionKeepsTheMinimu
 	sharedVariables: {};
 	tag: '''' ;
 	sharedPools: {};
-	package: ''MyPackage'''.
+	package: ''Mock'''.
 	builder build.
 	shiftClassBuilder := builder shiftClassBuilder.
 


### PR DESCRIPTION
FluidClassBuilder created 3 packages that it does not remove.

This makes sure to remove two of them. The first is more complicated since it is produced by a bug.