### PR TITLE
Remove ClassFactoryForTestCaseTest>>#testDuplicateClassWithNewName

### DIFF
--- a/src/SUnit-Core/ClassFactoryForTestCase.class.st
+++ b/src/SUnit-Core/ClassFactoryForTestCase.class.st
@@ -137,15 +137,6 @@ ClassFactoryForTestCase >> deleteTraits [
 	self createdTraits do: [ :trait | self delete: trait ]
 ]
 
-{ #category : #creating }
-ClassFactoryForTestCase >> duplicateClass: aClass withNewName: name [
-
-	| newClass |
-	newClass := aClass duplicateClassWithNewName: name.
-	self createdClasses add: newClass.
-	^ newClass
-]
-
 { #category : #initialization }
 ClassFactoryForTestCase >> initialize [
 

--- a/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
@@ -86,19 +86,6 @@ ClassFactoryForTestCaseTest >> testDefaultCategoryCleanUp [
 ]
 
 { #category : #testing }
-ClassFactoryForTestCaseTest >> testDuplicateClassWithNewName [
-	| createdClass |
-
-	"Skip this tests if no compiler is available. Do not use #skip because it breaks an announcements tests"
-
-	Smalltalk compilerClass ifNotNil: [
-		createdClass := factory duplicateClass: TestCase withNewName: #MyTestClass.
-		self assert: (factory createdClasses allSatisfy: [:class| self class environment includesKey: class name ]).
-		factory cleanUp.
-		self assert: (factory createdClasses allSatisfy: [:class| class isObsolete]) ]
-]
-
-{ #category : #testing }
 ClassFactoryForTestCaseTest >> testMultipleClassCreation [
 	5 timesRepeat: [ factory newClass ].
 	self assert: (SystemNavigation new allClasses includesAll: factory createdClasses).


### PR DESCRIPTION
It has no sender and the test associated creates obsolete classes in the system.