### PR TITLE
Cut dependency from Collection-Streams to UIManager

### DIFF
--- a/src/Collections-Streams/ManifestCollectionsStreams.class.st
+++ b/src/Collections-Streams/ManifestCollectionsStreams.class.st
@@ -14,7 +14,8 @@ ManifestCollectionsStreams class >> dependencies [
 
 { #category : #'meta-data - dependency analyser' }
 ManifestCollectionsStreams class >> manuallyResolvedDependencies [
-	^ #(#UIManager #'Collections-Abstract')
+
+	^ #( #'Collections-Abstract' )
 ]
 
 { #category : #'meta-data' }

--- a/src/Collections-Streams/PositionableStream.class.st
+++ b/src/Collections-Streams/PositionableStream.class.st
@@ -750,37 +750,6 @@ PositionableStream >> uint32: anInteger [
 	self nextPut: (anInteger byteAt: 1)
 ]
 
-{ #category : #positioning }
-PositionableStream >> untilEnd: aBlock displayingProgress: aString [
-	aString
-		displayProgressFrom: 0 to: self size
-		during:
-			[:bar |
-			[self atEnd] whileFalse:
-				[bar current: self position.
-				aBlock value]]
-]
-
-{ #category : #positioning }
-PositionableStream >> untilEndWithFork: aBlock displayingProgress: aString [
-	| sem done result |
-	sem := Semaphore new.
-	done := false.
-	[
-	result := [ aBlock value ]
-		ensure: [
-			done := true.
-			sem signal ] ] fork.
-	self
-		untilEnd: [
-			done
-				ifTrue: [ ^ result ].
-			(Delay forSeconds: 0.2) wait ]
-		displayingProgress: aString.
-	sem wait.
-	^ result
-]
-
 { #category : #accessing }
 PositionableStream >> upTo: anObject [
 	"Answer a subcollection from the current access position to the

--- a/src/Deprecated12/PositionableStream.extension.st
+++ b/src/Deprecated12/PositionableStream.extension.st
@@ -1,0 +1,34 @@
+Extension { #name : #PositionableStream }
+
+{ #category : #'*Deprecated12' }
+PositionableStream >> untilEnd: aBlock displayingProgress: aString [
+	self deprecated: 'This method will be removed in Pharo 13. You can inline the code if you need it.'.
+	aString
+		displayProgressFrom: 0 to: self size
+		during:
+			[:bar |
+			[self atEnd] whileFalse:
+				[bar current: self position.
+				aBlock value]]
+]
+
+{ #category : #'*Deprecated12' }
+PositionableStream >> untilEndWithFork: aBlock displayingProgress: aString [
+	| sem done result |
+	self deprecated: 'This method will be removed in Pharo 13. You can inline the code if you need it.'.
+	sem := Semaphore new.
+	done := false.
+	[
+	result := [ aBlock value ]
+		ensure: [
+			done := true.
+			sem signal ] ] fork.
+	self
+		untilEnd: [
+			done
+				ifTrue: [ ^ result ].
+			(Delay forSeconds: 0.2) wait ]
+		displayingProgress: aString.
+	sem wait.
+	^ result
+]


### PR DESCRIPTION
Collection-Streams had 2 methods dealing with the UI which is a bad dependency IMO. I could have added thos methods as an extention of the UI packages but they have no sender in the image. I propose to deprecate them. If a user wants to deal with a display bar he can do it himself.