### PR TITLE
Refactoring rotten green test on Context

### DIFF
--- a/src/Kernel-Tests/ContextTest.class.st
+++ b/src/Kernel-Tests/ContextTest.class.st
@@ -184,11 +184,11 @@ ContextTest >> testHasNonLocalReturn [
 	self deny: thisContext hasNonLocalReturn.
 	"this block context has no non-local return"
 	[ self deny: thisContext hasNonLocalReturn] value.
-	"but this"
-	[ self assert: thisContext hasNonLocalReturn. ^self] value.
 	"again, this is about the context locally, nested blocks to not count"
-	[ self deny: thisContext hasNonLocalReturn. [^self]] value.
-	[ self deny: thisContext hasNonLocalReturn. [self assert: thisContext hasNonLocalReturn. ^self]] value
+	[ self deny: thisContext hasNonLocalReturn. [ ^ self ] ] value.
+	[ self deny: thisContext hasNonLocalReturn ] value.
+	"We need to have the ^ self but as this assertion is at the end is not a problem if we return"
+	[ self assert: thisContext hasNonLocalReturn. ^ self ] value.
 ]
 
 { #category : #tests }


### PR DESCRIPTION
The test `ContextTest>>#testHasNonLocalReturn` is a rotten green test because:

```st
ContextTest>>#testHasNonLocalReturn
1.	"the method has a non-local return, in some block inside"
2.	self assert: thisContext method hasNonLocalReturn.
3.	"but the context that executes not (as it is later another block context"
4.	self deny: thisContext hasNonLocalReturn.
5.	"this block context has no non-local return"
6.	[ self deny: thisContext hasNonLocalReturn] value.
7.	"but this"
8.	[ self assert: thisContext hasNonLocalReturn. ^self] value.
9.	"again, this is about the context locally, nested blocks to not count"
10.	[ self deny: thisContext hasNonLocalReturn. [^self]] value.
11.	[ self deny: thisContext hasNonLocalReturn. [self assert: thisContext hasNonLocalReturn. ^self]] value
```

1) in the line 8 there is return so none of the following assertions are done.
2) In the line 11 the second inner block has an assertion that is never execution


In this PR I propose to refactor this test to move the line 8 to the end. The assertion is needed. The return is in the last line so it's not a problem. Remove the second inner block of line 11 as it has exactly the same assertion as the one in line 8.