### PR TITLE
Change Protocol  to use an array for methodSelectors directly

### DIFF
--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -202,7 +202,7 @@ ClassOrganization >> moveMethodsFrom: fromProtocolNamed to: toProtocolNamed [
 	toProtocol := self protocolNamed: toProtocolNamed.
 
 	toProtocol addAllMethodsFrom: fromProtocol.
-	fromProtocol removeAllMethodSelectors.
+	fromProtocol resetMethodSelectors.
 
 	^ toProtocol
 ]

--- a/src/Kernel/Protocol.class.st
+++ b/src/Kernel/Protocol.class.st
@@ -40,7 +40,9 @@ Protocol >> addAllMethodsFrom: aProtocol [
 
 { #category : #'adding-removing' }
 Protocol >> addMethodSelector: aSymbol [
-	^ methodSelectors add: aSymbol
+	(methodSelectors includes: aSymbol) ifTrue: [ ^ self ].
+	
+	methodSelectors := methodSelectors copyWith: aSymbol
 ]
 
 { #category : #testing }
@@ -59,7 +61,7 @@ Protocol >> initialize [
 
 	super initialize.
 
-	methodSelectors := IdentitySet new.
+	methodSelectors := Array empty.
 	name := self class unclassified
 ]
 
@@ -113,12 +115,12 @@ Protocol >> printOn: aStream [
 
 { #category : #'adding-removing' }
 Protocol >> removeAllMethodSelectors [
-	^ methodSelectors removeAll
+	methodSelectors := Array empty
 ]
 
 { #category : #'adding-removing' }
 Protocol >> removeMethodSelector: aSymbol [
-	^ methodSelectors remove: aSymbol
+	methodSelectors := methodSelectors copyWithout: aSymbol
 ]
 
 { #category : #accessing }

--- a/src/Kernel/Protocol.class.st
+++ b/src/Kernel/Protocol.class.st
@@ -60,8 +60,8 @@ Protocol >> includesSelector: selector [
 Protocol >> initialize [
 
 	super initialize.
-
-	methodSelectors := Array empty.
+	
+	self resetMethodSelectors.
 	name := self class unclassified
 ]
 
@@ -114,11 +114,6 @@ Protocol >> printOn: aStream [
 ]
 
 { #category : #'adding-removing' }
-Protocol >> removeAllMethodSelectors [
-	methodSelectors := Array empty
-]
-
-{ #category : #'adding-removing' }
 Protocol >> removeMethodSelector: aSymbol [
 	methodSelectors := methodSelectors copyWithout: aSymbol
 ]
@@ -127,4 +122,9 @@ Protocol >> removeMethodSelector: aSymbol [
 Protocol >> rename: newName [
 
 	self name: newName
+]
+
+{ #category : #'adding-removing' }
+Protocol >> resetMethodSelectors [
+	methodSelectors := Array empty
 ]


### PR DESCRIPTION
- 40K less IdentitySets alocated
- all the arrays are much smaller

I changed the API slghtly to be more sane and return "self", not the added element or the collection changed.