### PR TITLE
9778-InstructionStream-selectorToSendOrSelf-returns-GlobalVariable-bindings-too 

### DIFF
--- a/src/Debugging-Core/CompiledCode.extension.st
+++ b/src/Debugging-Core/CompiledCode.extension.st
@@ -49,28 +49,6 @@ CompiledCode >> localHasInstVarRef [
 ]
 
 { #category : #'*Debugging-Core' }
-CompiledCode >> localMessages [
-	"Answer a Set of all the message selectors sent by this method."
-
-	| scanner aSet |
-	aSet := IdentitySet new.
-	scanner := InstructionStream on: self.
-	scanner	scanFor: [:x | 
-			scanner addSelectorTo: aSet.
-			false	"keep scanning"].
-	^aSet
-]
-
-{ #category : #'*Debugging-Core' }
-CompiledCode >> messages [
-	"Answer a Set of all the message selectors sent by this method."
-	| aSet |
-	aSet := self localMessages.
-	self innerCompiledBlocksDo: [ :cb | aSet := aSet , cb messages ].
-	^ aSet
-]
-
-{ #category : #'*Debugging-Core' }
 CompiledCode >> pcPreviousTo: pc [
 	| scanner prevPc |
 	pc > self endPC ifTrue: [^self endPC].

--- a/src/Kernel-Tests/CompiledCodeTest.class.st
+++ b/src/Kernel-Tests/CompiledCodeTest.class.st
@@ -300,6 +300,21 @@ CompiledCodeTest >> testLiteralsEvenTheOnesInTheInnerCleanBlocks [
 		equals: #( 'b' #tempNamed: )
 ]
 
+{ #category : #'tests - scanning' }
+CompiledCodeTest >> testLocalMessages [
+	| method |
+	method := self class compiler compile: 'method self doit. [Object class]'.
+	self assert: method localMessages asArray equals: #(#doit) .
+	
+]
+
+{ #category : #'tests - scanning' }
+CompiledCodeTest >> testMessages [
+	| method |
+	method := self class compiler compile: 'method self doit. [Object class]'.
+	self assert: method messages asArray equals: #(#doit #class).
+]
+
 { #category : #'tests - testing' }
 CompiledCodeTest >> testMethodReturnSpecial [
 

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -530,6 +530,19 @@ CompiledCode >> literalsToSkip [
 ]
 
 { #category : #scanning }
+CompiledCode >> localMessages [
+	"Answer a Set of all the message selectors sent by this method."
+
+	| scanner aSet |
+	aSet := IdentitySet new.
+	scanner := InstructionStream on: self.
+	scanner scanFor: [:x | 
+			scanner addSelectorTo: aSet.
+			false	"keep scanning"].
+	^aSet
+]
+
+{ #category : #scanning }
 CompiledCode >> localReadsRef: literalAssociation [
 	"Answer whether the receiver loads the argument."
 	| litIndex scanner |
@@ -589,6 +602,15 @@ CompiledCode >> longPrintOn: aStream [
 		self printPrimitiveOn: aStream.
 	].
 	self symbolicBytecodes do: [ :each | each printOn: aStream ] separatedBy: [ aStream cr ]
+]
+
+{ #category : #scanning }
+CompiledCode >> messages [
+	"Answer a Set of all the message selectors sent by this method."
+	| aSet |
+	aSet := self localMessages.
+	self innerCompiledBlocksDo: [ :cb | aSet := aSet , cb messages ].
+	^ aSet
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
- move #messages and #localMessages away from Debugging-Core, as they are part of the queries we support that are not just used by the debugger

  (see "scanning", there are many)
- add tests

The bug was fixed in the meantime

Of course, this part of the system is very odd: we have #messages, but it is too slow, so we scan the literals instead, which omits too much, thus we have the hack to nevertheless scan for special selector sends... we really need to fix this for real.

fixes #9778