### PR TITLE
AST: starting visiting comments

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -2541,8 +2541,7 @@ RBCodeSnippet >> updateExpectations [
 	ast := self parse.
 	self formattedCode: ast formattedCode withSeparatorsCompacted.
 	self isParseFaulty: ast isFaulty.
-	self nodePositions:
-		(' ' repeat: ast start - 1) , ast asPositionDebugString.
+	self nodePositions: ast asPositionDebugString.
 	ast := self doSemanticAnalysis.
 	self isFaulty: ast isFaulty.
 	self isFaultyMinusUndeclared: self isFaulty

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -104,7 +104,7 @@ RBCodeSnippet class >> badExpressions [
 				            #( 1 2 3 ''')'' expected' ) )).
 		        (self new
 			         source: '#( ';
-			         nodeAt: '00';
+			         nodeAt: '00 ';
 			         notices: #( #( 1 2 4 ''')'' expected' ) )).
 		        (self new
 			         source: '[ ';
@@ -112,11 +112,11 @@ RBCodeSnippet class >> badExpressions [
 			         notices: #( #( 1 2 3 ''']'' expected' ) )).
 		        (self new
 			         source: '#[ ';
-			         nodeAt: '00';
+			         nodeAt: '00 ';
 			         notices: #( #( 1 2 4 ''']'' expected' ) )).
 		        (self new
 			         source: '{ ';
-			         nodeAt: '0';
+			         nodeAt: '0 ';
 			         notices: #( #( 1 1 3 '''}'' expected' ) )).
 		        (self new
 			         source: '{ [ ( ';
@@ -313,7 +313,7 @@ RBCodeSnippet class >> badExpressions [
 		        "Note: bad temporaries will be stored as error statements"
 		        (self new
 			         source: '| ';
-			         nodeAt: '0';
+			         nodeAt: '0 ';
 			         formattedCode: '| | ';
 			         notices: #( #( 1 1 3 '''|'' or variable expected' ) )).
 		        (self new
@@ -915,7 +915,7 @@ RBCodeSnippet class >> badPositions [
 			         value: 3).
 		        (self new
 			         source: ' | tmp | tmp := 1 . ^ tmp . ';
-			         nodeAt: ' 00111000444222230005566600';
+			         nodeAt: ' 00111000444222230005566600 ';
 			         formattedCode: '| tmp | tmp := 1. ^ tmp';
 			         value: 1).
 		        (self new
@@ -932,7 +932,7 @@ RBCodeSnippet class >> badPositions [
 			         value: 2).
 		        (self new
 			         source: ' ( [ :aaa : bbb | | ccc ddd | aaa . ] ) . ';
-			         nodeAt: ' 00000111000222000334443555333666330000';
+			         nodeAt: ' 00000111000222000334443555333666330000   ';
 			         formattedCode: '[ :aaa :bbb | | ccc ddd | aaa ]';
 			         value: 1;
 			         notices:
@@ -1571,21 +1571,21 @@ RBCodeSnippet class >> badTokens [
 		        "EFFormater is not the best here :("
 		        (self new
 			         source: '"" ';
-			         nodeAt: '';
+			         nodeAt: '22 ';
 			         isFaulty: false).
 		        (self new
 			         source: '"nothing" ';
-			         nodeAt: '';
+			         nodeAt: '222222222 ';
 			         isFaulty: false).
 		        (self new
 			         source: '"com"1"ment"';
-			         nodeAt: '     0';
+			         nodeAt: '333330444444';
 			         formattedCode: '1';
 			         isFaulty: false;
 			         value: 1). "The comments are in the AST, the formatter just do not know to show them because we format only the node and not the whole method body"
 		        (self new
 			         source: '"a" 1 "b". "c" 2 "d"';
-			         nodeAt: '    100000000005';
+			         nodeAt: '555 106660077708 AAA';
 			         formattedCode: '1. "a" "b" "c" 2 "d"';
 			         isFaulty: false;
 			         value: 2). "a and b moved around. Formatter issue. FIXME?"
@@ -1729,7 +1729,7 @@ RBCodeSnippet class >> badTokens [
 		        "These ones are correct, the number parser is very prermisive (except for radix, see above)"
 		        (self new
 			         source: '1.';
-			         nodeAt: '0';
+			         nodeAt: '0 ';
 			         formattedCode: '1';
 			         isFaulty: false;
 			         value: 1).
@@ -1842,7 +1842,7 @@ RBCodeSnippet class >> badTokens [
 			         value: 'Δ→ə').
 		        (self new
 			         source: '"Δ→ə" ';
-			         nodeAt: '';
+			         nodeAt: '22222 ';
 			         isFaulty: false).
 		        (self new
 			         source: '#''Δ→ə''';

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -1590,6 +1590,13 @@ RBCodeSnippet class >> badTokens [
 			         isFaulty: false;
 			         value: 2). "a and b moved around. Formatter issue. FIXME?"
 		        (self new
+			         source: ' "z" foo "a" 1 "b". "c" ^ 2 "d" ';
+			         nodeAt: '0DDD00000EEE04377733888399A0CCC0';
+			         formattedCode: 'foo "z" "a" 1. "b" "c" ^ 2 "d"';
+			         isMethod: true;
+			         isFaulty: false;
+			         value: 2). "z and b moved around. Formatter issue. FIXME?"
+		        (self new
 			         source: '"unfinished';
 			         nodeAt: '00000000000';
 			         notices: #( #( 1 11 12 'Unmatched " in comment.' ) )).

--- a/src/AST-Core-Tests/RBCodeSnippetTest.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippetTest.class.st
@@ -164,9 +164,7 @@ RBCodeSnippetTest >> testParse [
 	self assert: ast methodNode reformatSource isString.
 
 	snippet nodePositions ifNotNil: [
-		| positions |
-		positions := (' ' repeat: ast start - 1) , ast asPositionDebugString.
-		self assert: positions equals: snippet nodePositions ].
+		self assert: ast asPositionDebugString equals: snippet nodePositions ].
 
 	"Smoke test on each AST node (in alphabetic order of selectors)"
 	ast nodesDo: [ :node |

--- a/src/AST-Core-Traits/TRBProgramNodeVisitor.trait.st
+++ b/src/AST-Core-Traits/TRBProgramNodeVisitor.trait.st
@@ -56,6 +56,12 @@ TRBProgramNodeVisitor >> visitClassVariableNode: aNode [
 ]
 
 { #category : #visiting }
+TRBProgramNodeVisitor >> visitCommentNode: aRBComment [
+	"Note: currenlty, comment nodes are not automatically visited by `RBProgramNodeVisitor`.
+	This method can still be reached by custom visitors and direct visit on a comment node."
+]
+
+{ #category : #visiting }
 TRBProgramNodeVisitor >> visitEnglobingErrorNode: anEnglobingErrorNode [
 	anEnglobingErrorNode content do: [ :each | self visitNode: each ]
 ]

--- a/src/AST-Core/RBComment.class.st
+++ b/src/AST-Core/RBComment.class.st
@@ -66,10 +66,8 @@ RBComment >> = anObject [
 
 { #category : #visiting }
 RBComment >> acceptVisitor: aProgramNodeVisitor [
-	"At some point we will have to think what we do to visit comment.
-	It may have an impact on visitors so this should be done carefully.
-	Since by default previously comment node were not subclass of ProgramNode
-	we do nothing by default."
+
+	^ aProgramNodeVisitor visitCommentNode: self
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -225,10 +225,10 @@ RBProgramNode >> asPositionDebugString [
 			cpt := cpt + 1 ] ].
 
 	"Fill the result string"
-	result := String new: self stop - self start + 1.
-	self start to: self stop do: [ :i |
+	result := String new: self source size.
+	1 to: self source size do: [ :i |
 		result
-			at: i - self start + 1
+			at: i
 			put: (characters at: (self nodeForOffset: i)) ].
 	^ result
 ]

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -353,6 +353,16 @@ RBProgramNode >> children [
 	^#()
 ]
 
+{ #category : #accessing }
+RBProgramNode >> childrenAndComments [
+	
+	| result |
+	result := self children.
+	result ifEmpty: [ ^ self comments ].
+	self comments ifEmpty: [ ^ result ].
+	^ result , self comments
+]
+
 { #category : #replacing }
 RBProgramNode >> clearReplacements [
 	parent ifNil: [^self].

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -957,15 +957,17 @@ RBProgramNode >> nodeForOffset: anInteger [
 
 { #category : #iterating }
 RBProgramNode >> nodesDo: aBlock [
+	"Evaluate aBlock on self and all chindren nodes, including comments"
+
 	aBlock value: self.
-	self children do: [ :each | each nodesDo: aBlock ]
+	self childrenAndComments do: [ :each | each nodesDo: aBlock ]
 ]
 
 { #category : #iterating }
 RBProgramNode >> nodesPostorderDo: aBlock [
 	"Like RBProgramNode>>#nodesDo: but visit children first"
 
-	self children do: [ :each | each nodesPostorderDo: aBlock ].
+	self childrenAndComments do: [ :each | each nodesPostorderDo: aBlock ].
 	aBlock value: self
 ]
 

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -946,13 +946,16 @@ RBProgramNode >> newSource [
 
 { #category : #'node access' }
 RBProgramNode >> nodeForOffset: anInteger [
-	| children |
-	"choosing the best node on the specific offset"
-	children := self children.
-	"when we are on a leaf, we take the leaf node"
-	(children isEmpty) ifTrue: [ (self sourceInterval includes: anInteger) ifTrue: [^self]].
-	"if the node has children then we check the children"
-	children do: [:each | (each sourceInterval includes: anInteger) ifTrue: [^each nodeForOffset: anInteger] ]
+	"Choose the best node on the specific offset, including comments.
+	Because comments can be oustide the span of sourceInterval, we have to visit all children.
+	Return nil if anInteger is out of range."
+
+	self childrenAndComments do: [ :each |
+		(each nodeForOffset: anInteger) ifNotNil: [ :node | ^ node ] ].
+
+	^ (self sourceInterval includes: anInteger)
+		  ifTrue: [ self ]
+		  ifFalse: [ nil ]
 ]
 
 { #category : #iterating }

--- a/src/AST-Core/RBProgramNodeVisitor.class.st
+++ b/src/AST-Core/RBProgramNodeVisitor.class.st
@@ -69,6 +69,12 @@ RBProgramNodeVisitor >> visitClassVariableNode: aNode [
 ]
 
 { #category : #visiting }
+RBProgramNodeVisitor >> visitCommentNode: aRBComment [
+	"Note: currenlty, comment nodes are not automatically visited by `RBProgramNodeVisitor`.
+	This method can still be reached by custom visitors and direct visit on a comment node."
+]
+
+{ #category : #visiting }
 RBProgramNodeVisitor >> visitEnglobingErrorNode: anEnglobingErrorNode [
 	anEnglobingErrorNode contents do: [ :each | self visitNode: each ]
 ]

--- a/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
@@ -112,6 +112,12 @@ CoASTResultSetBuilder >> visitClassVariableNode: aRBVariableNode [
 ]
 
 { #category : #visiting }
+CoASTResultSetBuilder >> visitCommentNode: aRBComment [ 
+
+	^ self visitNode: aRBComment
+]
+
+{ #category : #visiting }
 CoASTResultSetBuilder >> visitEnglobingErrorNode: aRBVariableNode [
 	^ self visitNode: aRBVariableNode
 ]


### PR DESCRIPTION
Tries to make comments, first-class citizens of the AST. Or at least second-class citizens... Still better than the cargo hold.

This includes:

* new method `childrenAndComments` to have both (direct) children and (direct) comments
* `nodesDo:` (and related) visit comments
* `nodeForOffset:` can return a comment node
* add `visitCommentNode:` to the `RBProgramNodeVisitor`.

The first three should be safe since clients using them cannot expect specific nodes and just select what they need.
The last one should also be safe because comments are not automatically visited (yet!), but it might allow custom clients to use the hook for custom visit.

The API of `RBProgramNodeVisitor` need love, but there are a lot of clients, so it's not simple to improve it.
Maybe a simpler approach could be having a second visitor, then switch clients one by one.