### PR TITLE
faulty code: test runtimeSyntaxError

### DIFF
--- a/src/Kernel-Tests-WithCompiler/RuntimeSyntaxErrorTest.class.st
+++ b/src/Kernel-Tests-WithCompiler/RuntimeSyntaxErrorTest.class.st
@@ -21,7 +21,7 @@ RuntimeSyntaxErrorTest >> testFaultyInstalledMethod [
 			self
 				assert: error description
 				equals: 'RuntimeSyntaxError: Unknown character'.
-			ctx := error signalContext skipDebuggerComplete.
+			ctx := error signalContext filterDebuggerStack.
 			self assert: ctx sourceNodeExecuted sourceCode equals: '¿' ].
 
 	method removeFromSystem
@@ -42,7 +42,7 @@ RuntimeSyntaxErrorTest >> testFaultyScript [
 			self
 				assert: error description
 				equals: 'RuntimeSyntaxError: Unknown character'.
-			ctx := error signalContext skipDebuggerComplete.
+			ctx := error signalContext filterDebuggerStack.
 			self assert: ctx sourceNodeExecuted sourceCode equals: '¿' ]
 ]
 
@@ -63,6 +63,6 @@ RuntimeSyntaxErrorTest >> testFaultyUninstalledMethod [
 			self
 				assert: error description
 				equals: 'RuntimeSyntaxError: Unknown character'.
-			ctx := error signalContext skipDebuggerComplete.
+			ctx := error signalContext filterDebuggerStack.
 			self assert: ctx sourceNodeExecuted sourceCode equals: '¿' ]
 ]

--- a/src/Kernel-Tests-WithCompiler/RuntimeSyntaxErrorTest.class.st
+++ b/src/Kernel-Tests-WithCompiler/RuntimeSyntaxErrorTest.class.st
@@ -1,0 +1,68 @@
+Class {
+	#name : #RuntimeSyntaxErrorTest,
+	#superclass : #TestCase,
+	#category : #'Kernel-Tests-WithCompiler'
+}
+
+{ #category : #tests }
+RuntimeSyntaxErrorTest >> testFaultyInstalledMethod [
+
+	| method |
+	method := self class compiler
+		          permitFaulty: true;
+		          install: 'faultyMethodExample 1+¿'.
+
+	[ self faultyMethodExample ]
+		on: RuntimeSyntaxError
+		do: [ :error |
+			| ctx |
+			self assert: error class equals: RuntimeSyntaxError.
+			self assert: error messageText equals: 'Unknown character'.
+			self
+				assert: error description
+				equals: 'RuntimeSyntaxError: Unknown character'.
+			ctx := error signalContext skipDebuggerComplete.
+			self assert: ctx sourceNodeExecuted sourceCode equals: '¿' ].
+
+	method removeFromSystem
+]
+
+{ #category : #tests }
+RuntimeSyntaxErrorTest >> testFaultyScript [
+
+	[
+	OpalCompiler new
+		permitFaulty: true;
+		evaluate: '1+¿' ]
+		on: RuntimeSyntaxError
+		do: [ :error |
+			| ctx |
+			self assert: error class equals: RuntimeSyntaxError.
+			self assert: error messageText equals: 'Unknown character'.
+			self
+				assert: error description
+				equals: 'RuntimeSyntaxError: Unknown character'.
+			ctx := error signalContext skipDebuggerComplete.
+			self assert: ctx sourceNodeExecuted sourceCode equals: '¿' ]
+]
+
+{ #category : #tests }
+RuntimeSyntaxErrorTest >> testFaultyUninstalledMethod [
+
+	| method |
+	method := OpalCompiler new
+		          permitFaulty: true;
+		          compile: 'foo 1+¿'.
+
+	[ nil executeMethod: method ]
+		on: RuntimeSyntaxError
+		do: [ :error |
+			| ctx |
+			self assert: error class equals: RuntimeSyntaxError.
+			self assert: error messageText equals: 'Unknown character'.
+			self
+				assert: error description
+				equals: 'RuntimeSyntaxError: Unknown character'.
+			ctx := error signalContext skipDebuggerComplete.
+			self assert: ctx sourceNodeExecuted sourceCode equals: '¿' ]
+]

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -2015,6 +2015,15 @@ Context >> size [
 ]
 
 { #category : #'debugger access' }
+Context >> skipDebuggerComplete [
+	"Answer the self or the first sender that do not have the pragma `debuggerCompleteToSender`"
+
+	(self method hasPragmaNamed: #debuggerCompleteToSender) ifFalse: [
+		^ self ].
+	^ sender ifNotNil: [ sender skipDebuggerComplete ]
+]
+
+{ #category : #'debugger access' }
 Context >> sourceCode [
 	^self compiledCode sourceCode
 ]

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -2016,11 +2016,12 @@ Context >> size [
 
 { #category : #'debugger access' }
 Context >> skipDebuggerComplete [
-	"Answer the self or the first sender that do not have the pragma `debuggerCompleteToSender`"
+	"Answer self or the first sender that do not have the pragma `debuggerCompleteToSender` or belong to the `Exception` class hierarchy"
 
-	(self method hasPragmaNamed: #debuggerCompleteToSender) ifFalse: [
-		^ self ].
-	^ sender ifNotNil: [ sender skipDebuggerComplete ]
+	^ ((self method methodClass instanceSide includesBehavior: Exception)
+		   or: [ self method hasPragmaNamed: #debuggerCompleteToSender ])
+		  ifTrue: [ sender ifNotNil: [ sender skipDebuggerComplete ] ]
+		  ifFalse: [ self ]
 ]
 
 { #category : #'debugger access' }

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -775,6 +775,16 @@ Context >> failPrimitiveWith: maybePrimFailToken [
 		[self at: stackp put: maybePrimFailToken last]
 ]
 
+{ #category : #'debugger access' }
+Context >> filterDebuggerStack [
+	"Answer self or the first sender that do not have the pragma `debuggerCompleteToSender` or belong to the `Exception` class hierarchy"
+
+	^ ((self method methodClass instanceSide includesBehavior: Exception)
+		   or: [ self method hasPragmaNamed: #debuggerCompleteToSender ])
+		  ifTrue: [ sender ifNotNil: [ sender filterDebuggerStack ] ]
+		  ifFalse: [ self ]
+]
+
 { #category : #query }
 Context >> findContextSuchThat: testBlock [
 	"Search self and my sender chain for first one that satisfies testBlock.  Return nil if none satisfy"
@@ -2012,16 +2022,6 @@ Context >> size [
 	<primitive: 212>
 	"The number of indexable fields of fixed-length objects is 0"
 	^self primitiveFail
-]
-
-{ #category : #'debugger access' }
-Context >> skipDebuggerComplete [
-	"Answer self or the first sender that do not have the pragma `debuggerCompleteToSender` or belong to the `Exception` class hierarchy"
-
-	^ ((self method methodClass instanceSide includesBehavior: Exception)
-		   or: [ self method hasPragmaNamed: #debuggerCompleteToSender ])
-		  ifTrue: [ sender ifNotNil: [ sender skipDebuggerComplete ] ]
-		  ifFalse: [ self ]
 ]
 
 { #category : #'debugger access' }

--- a/src/Kernel/RuntimeSyntaxError.class.st
+++ b/src/Kernel/RuntimeSyntaxError.class.st
@@ -6,32 +6,12 @@ This way the debugger opens and the programmer can easily fix the faulty method
 Class {
 	#name : #RuntimeSyntaxError,
 	#superclass : #Error,
-	#instVars : [
-		'errorNode'
-	],
 	#category : #'Kernel-Exceptions'
 }
 
 { #category : #signalling }
-RuntimeSyntaxError class >> signalSyntaxError: aNode [
+RuntimeSyntaxError class >> signalSyntaxError: aString [
 	"we use signalSyntaxError: instead of signal: so we can quickly check
 	compiledMethods for syntax errors by checking the literals"
-
-	<debuggerCompleteToSender>
-	^ (self new errorNode: aNode) signal
-]
-
-{ #category : #accessing }
-RuntimeSyntaxError >> errorMessage [
-	^errorNode errorMessage
-]
-
-{ #category : #accessing }
-RuntimeSyntaxError >> errorNode: aNode [
-	errorNode := aNode
-]
-
-{ #category : #accessing }
-RuntimeSyntaxError >> messageText [
-	^self errorMessage
+	^ self signal: aString
 ]

--- a/src/Kernel/RuntimeSyntaxError.class.st
+++ b/src/Kernel/RuntimeSyntaxError.class.st
@@ -16,7 +16,9 @@ Class {
 RuntimeSyntaxError class >> signalSyntaxError: aNode [
 	"we use signalSyntaxError: instead of signal: so we can quickly check
 	compiledMethods for syntax errors by checking the literals"
-	^(self new errorNode: aNode) signal
+
+	<debuggerCompleteToSender>
+	^ (self new errorNode: aNode) signal
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -282,9 +282,14 @@ OCASTTranslator >> emitRepeat: aMessageNode [
 OCASTTranslator >> emitRuntimeError: aNode [
 	"Runtime errors should only be emited on faulty code"
 
+	| errors |
+	errors := aNode allErrorNotices.
+
 	methodBuilder
 		pushLiteralVariable: RuntimeSyntaxError binding;
-		pushLiteral: aNode errorMessage;
+		pushLiteral: (errors isEmpty
+				 ifTrue: [ 'Syntax error' ]
+				 ifFalse: [ errors first messageText ]);
 		send: #signalSyntaxError:
 ]
 

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -284,7 +284,7 @@ OCASTTranslator >> emitRuntimeError: aNode [
 
 	methodBuilder
 		pushLiteralVariable: RuntimeSyntaxError binding;
-		pushLiteral: aNode;
+		pushLiteral: aNode errorMessage;
 		send: #signalSyntaxError:
 ]
 


### PR DESCRIPTION
New Kernel tests that ensure that signaled `RuntimeSyntaxError` exceptions are correct and that their contexts are sane with usable source code information.

Because of all the good work about faulty compilation, there is no special case and faulty code is correctly caught and the source code information is useful. So debugger should behave correctly.
These tests check 3 scenarios: doit (scripts), installed method, and uninstalled method. And they will help to prevent future regressions.

Note: I understand what `debuggerCompleteToSender` does, but I have trouble understanding the English of the symbol string. What "*complete*" means here?

Update: I did another pass and added commits

I removed the AST node from the Exception `RuntimeSyntaxError`. That make the model saner. And the node was superfluous. Because the context (and debuggers and everything) can (now) retrieve the original source code and AST node exactly like other exceptions.
So now, the exception only have a `messageText` like most other exceptions, and is computed early at compile time.
Doing so, I realized the that `RuntimeSyntaxError` what the general runtime exception also for other kind of runtime semantic error. It could be improved because there is "*syntax*" in `RuntimeSyntaxError` (it's hidden in the middle if you don't see it).