### PR TITLE
Cleanup OpalCompiler & CompilationContext

### DIFF
--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -628,8 +628,6 @@ CompilationContext >> optionSkipSemanticWarnings [
 { #category : #options }
 CompilationContext >> parseOptions: optionsArray [
 
-	(optionsArray includesAny: #( #optionParseErrors #optionParseErrorsNonInteractiveOnly #optionSkipSemanticWarnings )) ifTrue: [ permitFaulty := true ].
-
 	options parseOptions: optionsArray
 ]
 

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -34,9 +34,7 @@ Class {
 		'requestorScopeClass',
 		'bindings',
 		'compiledMethodClass',
-		'semanticScope',
-		'permitFaulty',
-		'permitUndeclared'
+		'semanticScope'
 	],
 	#classVars : [
 		'DefaultOptions',
@@ -654,30 +652,6 @@ CompilationContext >> parserClass [
 { #category : #accessing }
 CompilationContext >> parserClass: anObject [
 	parserClass := anObject
-]
-
-{ #category : #accessing }
-CompilationContext >> permitFaulty [
-
-	^ permitFaulty
-]
-
-{ #category : #accessing }
-CompilationContext >> permitFaulty: anObject [
-
-	permitFaulty := anObject
-]
-
-{ #category : #accessing }
-CompilationContext >> permitUndeclared [
-
-	^ permitUndeclared
-]
-
-{ #category : #accessing }
-CompilationContext >> permitUndeclared: anObject [
-
-	permitUndeclared := anObject
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -503,17 +503,6 @@ CompilationContext >> interactive [
 ]
 
 { #category : #accessing }
-CompilationContext >> logDoItEvaluation: aSourceString [
-	self logged ifNil: [ ^self ].
-	self logged ifFalse: [ ^self ].
-
-	Smalltalk globals
-			at: #SystemAnnouncer
-			ifPresent: [ :sysAnn |
-				semanticScope announceDoItEvaluation: aSourceString by: sysAnn uniqueInstance ]
-]
-
-{ #category : #accessing }
 CompilationContext >> logged [
 	^logged
 ]

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -17,7 +17,6 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'requestor',
-		'logged',
 		'compiledMethod',
 		'options',
 		'environment',
@@ -500,16 +499,6 @@ CompilationContext >> interactive [
 	^ (requestor respondsTo: #interactive)
 		  ifTrue: [ requestor interactive ]
 		  ifFalse: [ true ]
-]
-
-{ #category : #accessing }
-CompilationContext >> logged [
-	^logged
-]
-
-{ #category : #accessing }
-CompilationContext >> logged: anObject [
-	logged := anObject
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -17,7 +17,6 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'requestor',
-		'failBlock',
 		'logged',
 		'compiledMethod',
 		'options',
@@ -476,16 +475,6 @@ CompilationContext >> environment [
 { #category : #accessing }
 CompilationContext >> environment: anObject [
 	environment := anObject
-]
-
-{ #category : #accessing }
-CompilationContext >> failBlock [
-	^ failBlock
-]
-
-{ #category : #accessing }
-CompilationContext >> failBlock: anObject [
-	failBlock := anObject
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/IRMethod.class.st
+++ b/src/OpalCompiler-Core/IRMethod.class.st
@@ -146,8 +146,7 @@ IRMethod >> firstInstructionMatching: aBlock [
 
 { #category : #accessing }
 IRMethod >> forceLongForm [
-	compilationContext ifNil: [ ^ false ].
-	^compilationContext optionLongIvarAccessBytecodes
+	^ self compilationContext optionLongIvarAccessBytecodes
 ]
 
 { #category : #translating }
@@ -159,7 +158,7 @@ IRMethod >> generate [
 IRMethod >> generate: trailer [
 
 	| irTranslator |
-   irTranslator := IRTranslator context: compilationContext trailer: trailer.
+   irTranslator := IRTranslator context: self compilationContext trailer: trailer.
 	irTranslator
 		visitNode: self;
 		pragmas: pragmas.
@@ -177,7 +176,7 @@ IRMethod >> generate: trailer [
 { #category : #translating }
 IRMethod >> generateBlock: trailer withScope: scope [
 	| irTranslator |
-      irTranslator := IRTranslator context: compilationContext trailer: trailer.
+      irTranslator := IRTranslator context: self compilationContext trailer: trailer.
 	irTranslator
 		pushOuterVectors: scope;
 		visitNode: self;

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -18,8 +18,6 @@ Class {
 { #category : #api }
 OCASTSemanticAnalyzer >> analyze: aNode [
 
-	"Policy: simple semantic analysis is faulty by default"
-	compilationContext permitFaulty ifNil: [ compilationContext permitFaulty: true ].
 	self visitNode: aNode.
 	OCASTClosureAnalyzer new visitNode: aNode.
 	OCASTMethodMetadataAnalyser new visitNode: aNode

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -236,7 +236,7 @@ OCASTSemanticAnalyzer >> visitMethodNode: aMethodNode [
 
 	aMethodNode arguments size > 15 ifTrue: [ self error: 'Too many arguments' forNode: aMethodNode ].
 
-	scope := OCMethodScope new outerScope: compilationContext scope.
+	scope := OCMethodScope new outerScope: self compilationContext scope.
 	aMethodNode scope: scope.  scope node: aMethodNode.
 	aMethodNode arguments do: [:node | self declareArgumentNode: node ].
 	aMethodNode pragmas do: [:each | self visitNode: each].

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -35,6 +35,7 @@ Class {
 		'compilationContextClass',
 		'permitFaulty',
 		'permitUndeclared',
+		'failBlock',
 		'changeStamp',
 		'protocol'
 	],
@@ -419,12 +420,13 @@ OpalCompiler >> evaluate: textOrString [
 { #category : #accessing }
 OpalCompiler >> failBlock [
 
-	^ self compilationContext failBlock
+	^ failBlock
 ]
 
 { #category : #accessing }
 OpalCompiler >> failBlock: aBlock [
-	self compilationContext failBlock: aBlock
+
+	failBlock := aBlock
 ]
 
 { #category : #'public access' }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -33,6 +33,8 @@ Class {
 		'source',
 		'compilationContext',
 		'compilationContextClass',
+		'permitFaulty',
+		'permitUndeclared',
 		'changeStamp',
 		'protocol'
 	],
@@ -546,25 +548,25 @@ OpalCompiler >> parserClass [
 { #category : #'public access' }
 OpalCompiler >> permitFaulty [
 
-	^ self compilationContext permitFaulty
+	^ permitFaulty
 ]
 
 { #category : #'public access' }
 OpalCompiler >> permitFaulty: aBoolean [
 
-	self compilationContext permitFaulty: aBoolean
+	permitFaulty := aBoolean
 ]
 
 { #category : #'public access' }
 OpalCompiler >> permitUndeclared [
 
-	^ self compilationContext permitUndeclared
+	^ permitUndeclared
 ]
 
 { #category : #'public access' }
 OpalCompiler >> permitUndeclared: aBoolean [
 
-	self compilationContext permitUndeclared: aBoolean
+	permitUndeclared := aBoolean
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -405,7 +405,12 @@ OpalCompiler >> evaluate [
 	doItMethod := self compile.
 	ast ifNil: [ ^ doItMethod ].
 	value := self semanticScope evaluateDoIt: doItMethod.
-	self logDoIt.
+
+	self logged == true ifTrue: [
+		Smalltalk globals at: #SystemAnnouncer ifPresent: [ :sysAnn |
+			self semanticScope
+				announceDoItEvaluation: source
+				by: sysAnn uniqueInstance ] ].
 	^ value
 ]
 
@@ -455,7 +460,7 @@ OpalCompiler >> install [
 
 	protocol := class ensureProtocol: protocol.
 	changeStamp ifNil: [ changeStamp := Author changeStamp ].
-	logSource := compilationContext logged ifNil: [ class acceptsLoggingOfCompilation ].
+	logSource := self logged ifNil: [ class acceptsLoggingOfCompilation ].
 
 	logSource ifTrue: [
 		class
@@ -478,9 +483,9 @@ OpalCompiler >> install: aSource [
 	^ self install
 ]
 
-{ #category : #private }
-OpalCompiler >> logDoIt [
-	self compilationContext logDoItEvaluation: source
+{ #category : #accessing }
+OpalCompiler >> logged [
+	^ self compilationContext logged
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -36,6 +36,7 @@ Class {
 		'permitFaulty',
 		'permitUndeclared',
 		'failBlock',
+		'logged',
 		'changeStamp',
 		'protocol'
 	],
@@ -485,12 +486,12 @@ OpalCompiler >> install: aSource [
 
 { #category : #accessing }
 OpalCompiler >> logged [
-	^ self compilationContext logged
+	^ logged
 ]
 
 { #category : #accessing }
 OpalCompiler >> logged: aBoolean [
-	self compilationContext logged:  aBoolean
+	logged := aBoolean
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -495,6 +495,10 @@ OpalCompiler >> noPattern: aBoolean [
 
 { #category : #'public access' }
 OpalCompiler >> options: anOptionsArray [
+
+	"Compatibility for those options"
+	(anOptionsArray includesAny: #( #optionParseErrors #optionParseErrorsNonInteractiveOnly #optionSkipSemanticWarnings )) ifTrue: [ permitFaulty := true ].
+
 	self compilationContext parseOptions: anOptionsArray
 ]
 

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -263,7 +263,7 @@ OpalCompiler >> checkNotice: aNotice [
 		* require a requestor (because quirks mode, and also some reparations expect a requestor)
 		* require interactive mode (because GUI)
 		* require method definition becase some reparation assume it's a method body"
-		compilationContext interactive ifTrue: [
+		self compilationContext interactive ifTrue: [
 			aNotice reparator ifNotNil: [ :reparator |
 				| res |
 				res := reparator
@@ -332,7 +332,7 @@ OpalCompiler >> compile [
 	ast scope registerVariables.
 	method := ast generateMethod.
 	method propertyAt: #source put: source.
-	compilationContext noPattern ifTrue: [ method propertyAt: #ast put: ast ]. "Keep AST for scripts (for the moment)"
+	self compilationContext noPattern ifTrue: [ method propertyAt: #ast put: ast ]. "Keep AST for scripts (for the moment)"
 	^ method
 ]
 
@@ -589,7 +589,7 @@ OpalCompiler >> permitUndeclared: aBoolean [
 
 { #category : #accessing }
 OpalCompiler >> productionEnvironment: anObject [
-	compilationContext productionEnvironment: anObject
+	self compilationContext productionEnvironment: anObject
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -283,7 +283,7 @@ OpalCompiler >> checkNotice: aNotice [
 
 	"If a failBlock is provided in non-requestor mode,
 	we honor it and do not signal exceptions"
-	self compilationContext failBlock ifNotNil: [ ^ false ].
+	self failBlock ifNotNil: [ ^ false ].
 
 	aNotice signalError.
 
@@ -417,6 +417,12 @@ OpalCompiler >> evaluate: textOrString [
 ]
 
 { #category : #accessing }
+OpalCompiler >> failBlock [
+
+	^ self compilationContext failBlock
+]
+
+{ #category : #accessing }
 OpalCompiler >> failBlock: aBlock [
 	self compilationContext failBlock: aBlock
 ]
@@ -514,7 +520,7 @@ OpalCompiler >> parse [
 			check ifNil: [ ^ ast ].
 			check ifFalse: [
 				ast := nil.
-				^ self compilationContext failBlock ifNotNil: [ :block | block cull: n ] ifNil: [ nil ].
+				^ self failBlock ifNotNil: [ :block | block cull: n ] ifNil: [ nil ].
 				] ] ].
 
 	^ ast

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -7,9 +7,9 @@ RBMethodNode >> bcToASTCache [
 
 { #category : #'*OpalCompiler-Core' }
 RBMethodNode >> compiledMethod [
-	compilationContext compiledMethod
-		ifNil: [ compilationContext compiledMethod: self ir compiledMethod ].
-	^compilationContext compiledMethod
+	self compilationContext compiledMethod
+		ifNil: [ self compilationContext compiledMethod: self ir compiledMethod ].
+	^ self compilationContext compiledMethod
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/Reflectivity/RFSemanticAnalyzer.class.st
+++ b/src/Reflectivity/RFSemanticAnalyzer.class.st
@@ -64,7 +64,7 @@ RFSemanticAnalyzer >> visitAssignmentNode: aNode [
 { #category : #visiting }
 RFSemanticAnalyzer >> visitMethodNode: aMethodNode [
 
-	scope := OCMethodScope new outerScope: compilationContext scope.
+	scope := OCMethodScope new outerScope: self compilationContext scope.
 	aMethodNode scope: scope.  scope node: aMethodNode.
 	aMethodNode arguments do: [:node | self declareArgumentNode: node ].
 	aMethodNode pragmas do: [:each | self visitNode: each].


### PR DESCRIPTION
In the OpalCompiler ecosystem, cohesion was very low and coupling very high.
In order to pass around information (and worse, store it is some escaping objects like AST) between the various components, a god-dataclass (two smells in one!) called CompilationContext was used.

After a few weeks of intense cleaning, the cohesion is higher and coupling lower, and some data stored in CompilationContext is now used by only a single class: OpalCompiler. Therefore, the present PR move this data to the class that has the responsibility to use them.

* permitFaulty, permitUndeclared and failBlock. As they are now only used after the parse/semantic analysis to decide to abort the compilation pipeline or to continue.
* logged (boolean flag) used to fire announcement on evaluation or installation

Beside the increase of code quality, this has the advantage of reducing the memory footprint caused by escaping CompilationContext. (maybe it's not that much, it's hard to quantify).

What remain (for the moment) in CompilationContext are:

* All things related to scope and environment, including the badly named `noPattern`
* All things related to code optimization
* All "class methods" i.e. methods that return a class. It's used by reflectivity/metalinks
* Parse and transform plugins. Moving them breaks things. Need to investigate
