### PR TITLE
Can commit faulty code?

### DIFF
--- a/src/EpiceaBrowsers/EpLogBrowserOperationFactory.class.st
+++ b/src/EpiceaBrowsers/EpLogBrowserOperationFactory.class.st
@@ -84,11 +84,14 @@ EpLogBrowserOperationFactory >> events [
 EpLogBrowserOperationFactory >> handleErrorDuring: aBlock [
 	"TODO: do not catch *all* Errors.
 	This error handler exists as a workaround to skip any unexpected error when applying or reverting a code change from GUI.
-	For example, when user reverts the protocol addition of a protocol that is already not present, and such action signals an unexpected error. The error in such case should be avoided via testing API."
+	For example, when user reverts the protocol addition of a protocol that is already not present, and such action signals an unexpected error. The error in such case should be avoided via testing API.
+	
+	Rebutal: If you silent all errors, you will never fix the one you can fix, and you will silently ignore the ones that the user need to catch.
+	"
 
-	aBlock
-		on: Error
-		do: self errorHandlerBlock
+	aBlock value
+"		on: Error
+		do: self errorHandlerBlock"
 ]
 
 { #category : #private }

--- a/src/OpalCompiler-Tests/OpalCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTest.class.st
@@ -4,6 +4,10 @@ Class {
 	#category : #'OpalCompiler-Tests-Misc'
 }
 
+{ #category : #error }
+OpalCompilerTest >> faultySource [ ^ 1+¿
+]
+
 { #category : #'tests - bindings' }
 OpalCompilerTest >> testArrayBindingsWithUppercaseNameDoOverwriteGlobals [
 	| result |

--- a/src/OpalCompiler-Tests/OpalCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTest.class.st
@@ -5,7 +5,7 @@ Class {
 }
 
 { #category : #error }
-OpalCompilerTest >> faultySource [ ^ 1+¿
+OpalCompilerTest >> faultySource [ ^ 1+]
 ]
 
 { #category : #'tests - bindings' }


### PR DESCRIPTION
How far can faulty code goes?

* [x] installing a faulty method. OK.
  Note this require direct call to `OpalCompiler` or other MOP facility.
  Editors won't let you install any faulty methods.
* [x] Creating a commit.
  Iceberg has no issue to commit the method.
  However, there is a #error critique `ReMethodHasSyntaxErrorRule`, so you cannot push faulty code unwillingly :)
  * [ ] Can faulty code mess with the serialization format (tonel or whatever) and corrupt the file?
    Note that file corruption should already be handled, as bad command-line file edition can happen.
    But I don't know is the serialization format is fragile if the method contains garbage.
    → I checked, It seems that yes, the format is very fragile. It uses an ad hoc scanner and expect the content to be well-formed. This is bad because 1. it is uselessly complex code 2. it forces it to be synchronized with the language features (e.g. new literals or something) 3. it's limiting.
* [x] Removing the faulty method (switch to a sane branch). Unloading the code was ok.
* [x] Checkout back the branch with the faulty method
  * [x] The diff is shown in the "preview", with the syntax error visible in the diff, but nothing is done to alert you.
    However, up to my knowledge, Iceberg never tries to warn you on the diff anyway. So full check mark here.
  * [x] Proceeding "checkout" works until it shows a `CodeError` debugger.
    Inspection of the syntax error is "manual" but easy (just inspect `self`). While it could be improved, it is much better than the awful syntax error debugger I removed at the beginning of Pharo12 (#12910). So full check mark here.
  * [x] Closing the debugger, cancel the checkout.
    Since there is nothing else in the commit, I don't know if the system is left in the middle or if there is some kind of transaction/rollback. However, this is a "classic" iceberg issue of fault handling and not specifically related to faulty code with syntax errors, so full check mark here
  * [x] Proceeding "checkout" again, bring the same debugger, Now I "proceed ▶️" (the button is green because CodeError are resumable) and the faulty method is installed. The idea is that you can fix it at your own pace.
* [x] Code change. Go to Epicea and try to "Revert..." the faulty method.
  Epicea show you the diff and ask you to confirm. All fine and it revert the bad method
* [x] Return to the code change. Try to "Apply..." the faulty method.
  Epicea show you the diff and ask you to confirm. ~~But a growl (popup infobox in the lower left corner of the screen) show you the description of the CodeError, instead of launching a debugger. Why? Why you failed me Epicea?~~
  fixed by #13425

I'm quite happy about the current status.