### PR TITLE
Backport #13426: Make protocol of super method a priority in MethodClassifier

### DIFF
--- a/src/Tool-Base/MethodClassifier.class.st
+++ b/src/Tool-Base/MethodClassifier.class.st
@@ -198,8 +198,20 @@ MethodClassifier >> classifyAll: aCollectionOfMethods [
 { #category : #accessing }
 MethodClassifier >> listToFindProtocols [
 
-	^ #( #protocolByKnownMapping: #protocolAccessorFor: #protocolByKnownKeywordSuffix: #protocolByKnownPragma: #protocolByKnownPrefix: #protocolByOtherImplementors:
-	     #protocolInSuperclassProtocol: )
+	^ #( #protocolInSuperclassProtocol: #protocolByKnownMapping: #protocolAccessorFor: #protocolByKnownKeywordSuffix: #protocolByKnownPragma:
+	     #protocolByKnownPrefix: #protocolByOtherImplementors: )
+]
+
+{ #category : #accessing }
+MethodClassifier >> protocol [
+
+	^ protocol
+]
+
+{ #category : #accessing }
+MethodClassifier >> protocol: anObject [
+
+	^ protocol := anObject
 ]
 
 { #category : #'classification-rules' }

--- a/src/Tool-Base/MethodClassifier.class.st
+++ b/src/Tool-Base/MethodClassifier.class.st
@@ -208,12 +208,6 @@ MethodClassifier >> protocol [
 	^ protocol
 ]
 
-{ #category : #accessing }
-MethodClassifier >> protocol: anObject [
-
-	^ protocol := anObject
-]
-
 { #category : #'classification-rules' }
 MethodClassifier >> protocolAccessorFor: aMethod [
 	" If the method is a setter or getter for a  "

--- a/src/Tools-Tests/MethodClassifierMock.class.st
+++ b/src/Tools-Tests/MethodClassifierMock.class.st
@@ -1,0 +1,14 @@
+"
+I am a mock class to be able to test some protocol classification proposition of MethodClassifier.
+"
+Class {
+	#name : #MethodClassifierMock,
+	#superclass : #MethodClassifierMockSuperclass,
+	#category : #'Tools-Tests-Mocks'
+}
+
+{ #category : #protocol }
+MethodClassifierMock >> initializeNotInInitialize [
+
+	^ 4
+]

--- a/src/Tools-Tests/MethodClassifierMockSuperclass.class.st
+++ b/src/Tools-Tests/MethodClassifierMockSuperclass.class.st
@@ -1,0 +1,14 @@
+"
+I am a mock class to be able to test some protocol classification proposition of MethodClassifier.
+"
+Class {
+	#name : #MethodClassifierMockSuperclass,
+	#superclass : #Object,
+	#category : #'Tools-Tests-Mocks'
+}
+
+{ #category : #protocol }
+MethodClassifierMockSuperclass >> initializeNotInInitialize [
+
+	^ 1
+]

--- a/src/Tools-Tests/MethodClassifierTest.class.st
+++ b/src/Tools-Tests/MethodClassifierTest.class.st
@@ -8,6 +8,19 @@ Class {
 }
 
 { #category : #tests }
+MethodClassifierTest >> testOverridenMethodProtocolHasPriority [
+
+	"We want to check that the superclass method protocol has the priority so let's ensure no one messed with the mock first."
+	self assert: (MethodClassifierMockSuperclass >> #initializeNotInInitialize) protocol equals: #protocol.
+
+	"To test that the priority works, we need to make sure that another protocol suggestion strategy works"
+	self assert: (MethodClassifier new protocolByKnownPrefix: MethodClassifierMock >> #initializeNotInInitialize) protocol equals: #initialization.
+
+	"And now we check that the behavior we want has the priority!"
+	self assert: (MethodClassifier new suggestProtocolFor: MethodClassifierMock >> #initializeNotInInitialize) equals: #protocol
+]
+
+{ #category : #tests }
 MethodClassifierTest >> testProtocolForKnownKeywordSuffixOfSelector [
 	| classifier |
 	classifier := MethodClassifier new.


### PR DESCRIPTION
Backport the fact that the protocol of the super method has the priority in MethodClassifier