### PR TITLE
CompiledCodeTest>>#testMessages should not assume order of elements

### DIFF
--- a/src/Kernel-Tests/CompiledCodeTest.class.st
+++ b/src/Kernel-Tests/CompiledCodeTest.class.st
@@ -312,7 +312,7 @@ CompiledCodeTest >> testLocalMessages [
 CompiledCodeTest >> testMessages [
 	| method |
 	method := self class compiler compile: 'method self doit. [Object class]'.
-	self assert: method messages asArray equals: #(#doit #class).
+	self assertCollection: method messages asArray hasSameElements: #(#doit #class).
 ]
 
 { #category : #'tests - testing' }


### PR DESCRIPTION
I think that the failures of #13421 were unrelated.
This PR should fix the underlying issue.