### PR TITLE
Keep pushing protocols usage

### DIFF
--- a/src/Deprecated12/ClassOrganization.extension.st
+++ b/src/Deprecated12/ClassOrganization.extension.st
@@ -3,8 +3,8 @@ Extension { #name : #ClassOrganization }
 { #category : #'*Deprecated12' }
 ClassOrganization >> addCategory: aString [
 
-	self deprecated: 'Use #addProtocolNamed: instead.' transformWith: '`@rcv addCategory: `@arg' -> '`@rcv addProtocolNamed: `@arg'.
-	self addProtocolNamed: aString
+	self deprecated: 'Use #addProtocol: instead.' transformWith: '`@rcv addCategory: `@arg' -> '`@rcv addProtocol: `@arg'.
+	self addProtocol: aString
 ]
 
 { #category : #'*Deprecated12' }

--- a/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
+++ b/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
@@ -267,7 +267,7 @@ EpCodeChangeIntegrationTest >> testMethodRecompilationShouldNotLog [
 EpCodeChangeIntegrationTest >> testProtocolAddition [
 
 	aClass := classFactory newClass.
-	aClass organization addProtocolNamed: #testing42.
+	aClass organization addProtocol: #testing42.
 
 	self assert: (self countLogEventsWith: EpProtocolAddition) equals: 1
 ]

--- a/src/EpiceaBrowsers-Tests/EpApplyPreviewerTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpApplyPreviewerTest.class.st
@@ -365,7 +365,7 @@ EpApplyPreviewerTest >> testProtocolAdditionWithProtocolRemoved [
 
 	| aClass |
 	aClass := classFactory newClass.
-	aClass organization addProtocolNamed: 'protocol'.
+	aClass organization addProtocol: 'protocol'.
 	self setHeadAsInputEntry.
 	aClass removeProtocol: 'protocol'.
 
@@ -379,10 +379,10 @@ EpApplyPreviewerTest >> testProtocolRemovalWithProtocolAdded [
 
 	| aClass |
 	aClass := classFactory newClass.
-	aClass organization addProtocolNamed: 'protocol'.
+	aClass organization addProtocol: 'protocol'.
 	aClass removeProtocol: 'protocol'.
 	self setHeadAsInputEntry.
-	aClass organization addProtocolNamed: 'protocol'.
+	aClass organization addProtocol: 'protocol'.
 
 	self assertOutputsAnEventWith: [ :output |
 		self assert: output class equals: EpProtocolRemoval.
@@ -548,7 +548,7 @@ EpApplyPreviewerTest >> testRedundantProtocolAddition [
 
 	| aClass |
 	aClass := classFactory newClass.
-	aClass organization addProtocolNamed: 'protocol'.
+	aClass organization addProtocol: 'protocol'.
 	self setHeadAsInputEntry.
 
 	self assertEmptyPreviewLog
@@ -559,7 +559,7 @@ EpApplyPreviewerTest >> testRedundantProtocolRemoval [
 
 	| aClass |
 	aClass := classFactory newClass.
-	aClass organization addProtocolNamed: 'protocol'.
+	aClass organization addProtocol: 'protocol'.
 	aClass removeProtocol: 'protocol'.
 	self setHeadAsInputEntry.
 

--- a/src/EpiceaBrowsers-Tests/EpApplyTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpApplyTest.class.st
@@ -295,7 +295,7 @@ EpApplyTest >> testProtocolAddition [
 
 	| aClass |
 	aClass := classFactory newClass.
-	aClass organization addProtocolNamed: 'protocol'.
+	aClass organization addProtocol: 'protocol'.
 	self setHeadAsInputEntry.
 	aClass removeProtocol: 'protocol'.
 
@@ -310,10 +310,10 @@ EpApplyTest >> testProtocolRemoval [
 
 	| aClass |
 	aClass := classFactory newClass.
-	aClass organization addProtocolNamed: 'protocol'.
+	aClass organization addProtocol: 'protocol'.
 	aClass removeProtocol: 'protocol'.
 	self setHeadAsInputEntry.
-	aClass organization addProtocolNamed: 'protocol'.
+	aClass organization addProtocol: 'protocol'.
 
 	self assert: inputEntry content class equals: EpProtocolRemoval.
 	self assert: (aClass organization hasProtocolNamed: 'protocol').

--- a/src/EpiceaBrowsers-Tests/EpApplyTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpApplyTest.class.st
@@ -300,9 +300,9 @@ EpApplyTest >> testProtocolAddition [
 	aClass removeProtocol: 'protocol'.
 
 	self assert: inputEntry content class equals: EpProtocolAddition.
-	self deny: (aClass organization hasProtocolNamed: 'protocol').
+	self deny: (aClass organization hasProtocol: 'protocol').
 	self applyInputEntry.
-	self assert: (aClass organization hasProtocolNamed: 'protocol')
+	self assert: (aClass organization hasProtocol: 'protocol')
 ]
 
 { #category : #tests }
@@ -316,9 +316,9 @@ EpApplyTest >> testProtocolRemoval [
 	aClass organization addProtocol: 'protocol'.
 
 	self assert: inputEntry content class equals: EpProtocolRemoval.
-	self assert: (aClass organization hasProtocolNamed: 'protocol').
+	self assert: (aClass organization hasProtocol: 'protocol').
 	self applyInputEntry.
-	self deny: (aClass organization hasProtocolNamed: 'protocol')
+	self deny: (aClass organization hasProtocol: 'protocol')
 ]
 
 { #category : #tests }

--- a/src/EpiceaBrowsers-Tests/EpRevertTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpRevertTest.class.st
@@ -298,9 +298,9 @@ EpRevertTest >> testProtocolAddition [
 	self setHeadAsInputEntry.
 
 	self assert: inputEntry content class equals: EpProtocolAddition.
-	self assert: (aClass organization hasProtocolNamed: 'protocol').
+	self assert: (aClass organization hasProtocol: 'protocol').
 	self revertInputEntry.
-	self deny: (aClass organization hasProtocolNamed: 'protocol')
+	self deny: (aClass organization hasProtocol: 'protocol')
 ]
 
 { #category : #tests }
@@ -313,9 +313,9 @@ EpRevertTest >> testProtocolRemoval [
 	self setHeadAsInputEntry.
 
 	self assert: inputEntry content class equals: EpProtocolRemoval.
-	self deny: (aClass organization hasProtocolNamed: 'protocol').
+	self deny: (aClass organization hasProtocol: 'protocol').
 	self revertInputEntry.
-	self assert: (aClass organization hasProtocolNamed: 'protocol')
+	self assert: (aClass organization hasProtocol: 'protocol')
 ]
 
 { #category : #tests }

--- a/src/EpiceaBrowsers-Tests/EpRevertTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpRevertTest.class.st
@@ -294,7 +294,7 @@ EpRevertTest >> testProtocolAddition [
 
 	| aClass |
 	aClass := classFactory newClass.
-	aClass organization addProtocolNamed: 'protocol'.
+	aClass organization addProtocol: 'protocol'.
 	self setHeadAsInputEntry.
 
 	self assert: inputEntry content class equals: EpProtocolAddition.
@@ -308,7 +308,7 @@ EpRevertTest >> testProtocolRemoval [
 
 	| aClass |
 	aClass := classFactory newClass.
-	aClass organization addProtocolNamed: 'protocol'.
+	aClass organization addProtocol: 'protocol'.
 	aClass removeProtocol: 'protocol'.
 	self setHeadAsInputEntry.
 

--- a/src/EpiceaBrowsers/EpApplyPreviewer.class.st
+++ b/src/EpiceaBrowsers/EpApplyPreviewer.class.st
@@ -203,7 +203,7 @@ EpApplyPreviewer >> visitMethodRemoval: aChange [
 EpApplyPreviewer >> visitProtocolAddition: aChange [
 
 	self behaviorNamed: aChange behaviorAffectedName ifPresent: [ :behavior |
-		^ (behavior organization hasProtocolNamed: aChange protocol)
+		^ (behavior organization hasProtocol: aChange protocol)
 			  ifTrue: [ #(  ) ]
 			  ifFalse: [ { (EpProtocolAddition behavior: behavior protocol: aChange protocol) } ] ].
 
@@ -214,7 +214,7 @@ EpApplyPreviewer >> visitProtocolAddition: aChange [
 EpApplyPreviewer >> visitProtocolRemoval: aChange [
 
 	self behaviorNamed: aChange behaviorAffectedName ifPresent: [ :behavior |
-		^ (behavior organization hasProtocolNamed: aChange protocol)
+		^ (behavior organization hasProtocol: aChange protocol)
 			  ifTrue: [ { (EpProtocolRemoval behavior: behavior protocol: aChange protocol) } ]
 			  ifFalse: [ #(  ) ] ].
 

--- a/src/EpiceaBrowsers/EpApplyVisitor.class.st
+++ b/src/EpiceaBrowsers/EpApplyVisitor.class.st
@@ -123,7 +123,7 @@ EpApplyVisitor >> visitMethodRemoval: aMethodRemoval [
 { #category : #visitor }
 EpApplyVisitor >> visitProtocolAddition: aProtocolAddition [
 
-	self behaviorNamed: aProtocolAddition behaviorAffectedName ifPresent: [ :behavior | behavior organization addProtocolNamed: aProtocolAddition protocol ]
+	self behaviorNamed: aProtocolAddition behaviorAffectedName ifPresent: [ :behavior | behavior organization addProtocol: aProtocolAddition protocol ]
 ]
 
 { #category : #visitor }

--- a/src/EpiceaBrowsers/EpHasImpactVisitor.class.st
+++ b/src/EpiceaBrowsers/EpHasImpactVisitor.class.st
@@ -153,7 +153,7 @@ EpHasImpactVisitor >> visitProtocolAddition: aProtocolAddition [
 
 	self
 		behaviorNamed: aProtocolAddition behaviorAffectedName
-		ifPresent: [ :behavior | ^ (behavior organization hasProtocolNamed: aProtocolAddition protocol) not ].
+		ifPresent: [ :behavior | ^ (behavior organization hasProtocol: aProtocolAddition protocol) not ].
 
 	^ true
 ]

--- a/src/Gofer-Tests/GoferOperationTest.class.st
+++ b/src/Gofer-Tests/GoferOperationTest.class.st
@@ -86,8 +86,8 @@ GoferOperationTest >> testCleanup [
 		load.
 	class := environment classNamed: #GoferFoo.
 	environment organization addCategory: #'GoferFoo-Empty'.
-	class organization addProtocolNamed: #empty.
-	class class organization addProtocolNamed: #empty.
+	class organization addProtocol: #empty.
+	class class organization addProtocol: #empty.
 	gofer cleanup.
 	self deny: (Smalltalk organization categories includes: #'GoferFoo-Empty').
 	self deny: (class organization protocolNames includes: #'GoferFoo-Empty').

--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -33,8 +33,8 @@ ClassOrganizationTest >> setUp [
 			         package: 'ClassOrganizer-Tests' ].
 
 	organization := ClassOrganization forClass: class.
-	organization addProtocolNamed: 'empty'.
-	organization addProtocolNamed: 'one'.
+	organization addProtocol: 'empty'.
+	organization addProtocol: 'one'.
 	organization classify: #one under: 'one'
 ]
 
@@ -45,9 +45,9 @@ ClassOrganizationTest >> tearDown [
 ]
 
 { #category : #tests }
-ClassOrganizationTest >> testAddProtocolNamed [
+ClassOrganizationTest >> testAddProtocol [
 
-	self organization addProtocolNamed: 'test-protocol'.
+	self organization addProtocol: 'test-protocol'.
 
 	self assert: (self organization protocolNames includes: 'test-protocol')
 ]

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -70,7 +70,7 @@ ClassDescription >> addMethodTag: aSymbol [
 	"Any method could be tagged with multiple symbols for user purpose.
 	In class we could define what tags could be used for methods"
 
-	self organization addProtocolNamed: aSymbol
+	self organization addProtocol: aSymbol
 ]
 
 { #category : #'accessing - method dictionary' }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -18,25 +18,21 @@ ClassOrganization class >> forClass: aClass [
 		yourself
 ]
 
-{ #category : #adding }
+{ #category : #accessing }
 ClassOrganization >> addProtocol: aProtocol [
 
-	(self protocols includes: aProtocol) ifTrue: [ ^ aProtocol ].
-
-	protocols := protocols copyWith: aProtocol.
-	^ aProtocol
-]
-
-{ #category : #accessing }
-ClassOrganization >> addProtocolNamed: protocolName [
-
 	| oldProtocols protocol |
-	(self hasProtocolNamed: protocolName) ifTrue: [ ^ self ].
+	protocol := aProtocol isString
+		            ifTrue: [ Protocol name: aProtocol ]
+		            ifFalse: [ aProtocol ].
+
+	(self protocols includes: protocol) ifTrue: [ ^ protocol ].
 
 	oldProtocols := self protocolNames copy.
 
-	protocol := self addProtocol: (Protocol name: protocolName).
-	SystemAnnouncer announce: (ProtocolAdded in: self organizedClass protocol: protocolName).
+	protocols := protocols copyWith: protocol.
+
+	SystemAnnouncer announce: (ProtocolAdded in: self organizedClass protocol: aProtocol).
 	self notifyOfChangedProtocolNamesFrom: oldProtocols to: self protocolNames.
 	^ protocol
 ]
@@ -63,7 +59,7 @@ ClassOrganization >> classComment: aString [
 ClassOrganization >> classify: aSymbol inProtocolNamed: aProtocolName [
 
 	| protocol |
-	protocol := self protocolNamed: aProtocolName ifAbsent: [ self addProtocolNamed: aProtocolName ].
+	protocol := self protocolNamed: aProtocolName ifAbsent: [ self addProtocol: aProtocolName ].
   
 	self protocols
 		select: [ :p | p includesSelector: aSymbol ]
@@ -148,7 +144,7 @@ ClassOrganization >> ensureProtocol: aProtocol [
 		(self protocols includes: aProtocol)
 			ifTrue: [ ^ aProtocol ]
 			ifFalse: [ self error: 'I received a real protocol but this one is not part of me.' ] ].
-	^ self protocolNamed: aProtocol ifAbsent: [ self addProtocolNamed: aProtocol ]
+	^ self protocolNamed: aProtocol ifAbsent: [ self addProtocol: aProtocol ]
 ]
 
 { #category : #accessing }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -22,11 +22,11 @@ ClassOrganization class >> forClass: aClass [
 ClassOrganization >> addProtocol: aProtocol [
 
 	| oldProtocols protocol |
-	protocol := aProtocol isString
-		            ifTrue: [ Protocol name: aProtocol ]
-		            ifFalse: [ aProtocol ].
+	
+	(self hasProtocol: aProtocol) ifTrue: [
+		^ self protocolNamed: (aProtocol isString ifTrue: [ aProtocol ] ifFalse: [ aProtocol name ]) ].
 
-	(self protocols includes: protocol) ifTrue: [ ^ protocol ].
+	protocol := aProtocol isString ifTrue: [ Protocol name: aProtocol ] ifFalse: [ aProtocol ].
 
 	oldProtocols := self protocolNames copy.
 
@@ -158,9 +158,11 @@ ClassOrganization >> hasComment [
 ]
 
 { #category : #testing }
-ClassOrganization >> hasProtocolNamed: aString [
+ClassOrganization >> hasProtocol: aProtocol [
 
-	^ self protocols anySatisfy: [ :each | each name = aString ]
+	| protocolName |
+	protocolName := aProtocol isString ifTrue: [ aProtocol ] ifFalse: [ aProtocol name ].
+	^ self protocols anySatisfy: [ :each | each name = protocolName ]
 ]
 
 { #category : #testing }
@@ -324,7 +326,7 @@ ClassOrganization >> removeProtocolIfEmpty: aProtocol [
 { #category : #removing }
 ClassOrganization >> renameProtocolNamed: oldName toBe: newName [
 
-	(self hasProtocolNamed: oldName) ifFalse: [ ^ self ].
+	(self hasProtocol: oldName) ifFalse: [ ^ self ].
 
 	self silentlyRenameProtocolNamed: oldName toBe: newName.
 
@@ -353,9 +355,9 @@ ClassOrganization >> setSubject: anObject [
 { #category : #private }
 ClassOrganization >> silentlyRenameProtocolNamed: oldName toBe: newName [
 
-	(self hasProtocolNamed: oldName) ifFalse: [ ^ self ].
+	(self hasProtocol: oldName) ifFalse: [ ^ self ].
 
-	(self hasProtocolNamed: newName)
+	(self hasProtocol: newName)
 		ifTrue: [
 			self moveMethodsFrom: oldName to: newName.
 			self removeProtocolIfEmpty: oldName ]

--- a/src/Monticello-Tests/MCPackageTest.class.st
+++ b/src/Monticello-Tests/MCPackageTest.class.st
@@ -26,7 +26,7 @@ MCPackageTest >> testUnload [
 	self mockPackage unload.
 	self deny: (testingEnvironment hasClassNamed: #MCMockClassA).
 	self deny: (MCSnapshotTest includesSelector: #mockClassExtension).
-	self deny: (MCSnapshotTest organization hasProtocolNamed: self mockExtensionMethodCategory).
+	self deny: (MCSnapshotTest organization hasProtocol: self mockExtensionMethodCategory).
 	mock := testingEnvironment at: #MCMock.
 	self assert: (mock subclasses
 			 detect: [ :c | c name = #MCMockClassA ]
@@ -43,7 +43,7 @@ MCPackageTest >> testUnloadWithAdditionalTracking [
 	self mockPackage unload.
 	self deny: (testingEnvironment hasClassNamed: #MCMockClassA).
 	self deny: (MCSnapshotTest includesSelector: #mockClassExtension).
-	self deny: (MCSnapshotTest organization hasProtocolNamed: self mockExtensionMethodCategory).
+	self deny: (MCSnapshotTest organization hasProtocol: self mockExtensionMethodCategory).
 	mock := testingEnvironment at: #MCMock.
 	self assert: (mock subclasses
 			 detect: [ :c | c name = #MCMockClassA ]

--- a/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
@@ -436,7 +436,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByAddingExtensionProtoc
 
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
 	self createMethodNamed: 'newMethod' inClass: class inCategory: 'xxxxx'.
-	class organization addProtocolNamed: '*yyyyy'.
+	class organization addProtocol: '*yyyyy'.
 
 	self assert: (self organizer includesPackageNamed: #Yyyyy)
 ]
@@ -450,7 +450,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByAddingNewProtocolDoes
 	XPackage := self organizer packageNamed: #XXXXX.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
 	self createMethodNamed: 'newMethod' inClass: class inCategory: 'xxxxx'.
-	class organization addProtocolNamed: 'accessing'.
+	class organization addProtocol: 'accessing'.
 
 	self assert: (XPackage includesClass: class).
 	self assert: (XPackage includesDefinedSelector: #newMethod ofClass: class).

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -377,7 +377,7 @@ RPackageOrganizerTest >> testSilentlyRenameProtocolNamedToBe [
 
 	| class |
 	class := self createNewClassNamed: #ClassForTestAboutSilentRecategorization inCategory: 'RPackage-Tests'.
-	class organization addProtocolNamed: #foo.
+	class organization addProtocol: #foo.
 	self assert: (class organization protocolNames includes: #foo).
 	self deny: (class organization protocolNames includes: #bar).
 	class organization silentlyRenameProtocolNamed: #foo toBe: #bar.

--- a/src/Refactoring-Changes/RBAddProtocolChange.class.st
+++ b/src/Refactoring-Changes/RBAddProtocolChange.class.st
@@ -31,7 +31,7 @@ RBAddProtocolChange >> changeString [
 { #category : #private }
 RBAddProtocolChange >> primitiveExecute [
 
-	self changeClass organization addProtocolNamed: protocol
+	self changeClass organization addProtocol: protocol
 ]
 
 { #category : #printing }

--- a/src/Refactoring2-Transformations-Tests/RBMethodProtocolTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMethodProtocolTransformationTest.class.st
@@ -28,7 +28,7 @@ RBMethodProtocolTransformationTest >> testMethodDoesNotExist [
 RBMethodProtocolTransformationTest >> testRefactoring [
 
 	| refactoring |
-	self deny: (RBDummyEmptyClass organization hasProtocolNamed: 'empty protocol 2').
+	self deny: (RBDummyEmptyClass organization hasProtocol: 'empty protocol 2').
 
 	refactoring := (RBMethodProtocolTransformation protocol: 'empty protocol 2' inMethod: #someMethod inClass: #RBDummyEmptyClass) asRefactoring transform.
 	RBRefactoryChangeManager instance performChange: refactoring changes.
@@ -38,14 +38,14 @@ RBMethodProtocolTransformationTest >> testRefactoring [
 	refactoring := (RBMethodProtocolTransformation protocol: 'empty protocol 1' inMethod: #someMethod inClass: #RBDummyEmptyClass) asRefactoring transform.
 	RBRefactoryChangeManager instance performChange: refactoring changes.
 
-	self deny: (RBDummyEmptyClass organization hasProtocolNamed: 'empty protocol 2')
+	self deny: (RBDummyEmptyClass organization hasProtocol: 'empty protocol 2')
 ]
 
 { #category : #tests }
 RBMethodProtocolTransformationTest >> testTransform [
 
 	| transformation |
-	self deny: (RBDummyEmptyClass organization hasProtocolNamed: 'empty protocol 2').
+	self deny: (RBDummyEmptyClass organization hasProtocol: 'empty protocol 2').
 
 	transformation := (RBMethodProtocolTransformation new protocol: 'empty protocol 2' inMethod: #someMethod inClass: #RBDummyEmptyClass) transform.
 	RBRefactoryChangeManager instance performChange: transformation changes.
@@ -54,5 +54,5 @@ RBMethodProtocolTransformationTest >> testTransform [
 
 	transformation := (RBMethodProtocolTransformation new protocol: 'empty protocol 1' inMethod: #someMethod inClass: #RBDummyEmptyClass) transform.
 	RBRefactoryChangeManager instance performChange: transformation changes.
-	self deny: (RBDummyEmptyClass organization hasProtocolNamed: 'empty protocol 2')
+	self deny: (RBDummyEmptyClass organization hasProtocol: 'empty protocol 2')
 ]

--- a/src/System-Announcements-Tests/SystemAnnouncerTest.class.st
+++ b/src/System-Announcements-Tests/SystemAnnouncerTest.class.st
@@ -38,7 +38,7 @@ SystemAnnouncerTest >> testProtocolAdded [
 		protocolAdded := ann protocol ].
 
 	class := factory newClass.
-	class organization addProtocolNamed: 'shiny-new-category'.
+	class organization addProtocol: 'shiny-new-category'.
 
 	self assert: pass.
 	self assert: classReorganized equals: class.
@@ -57,9 +57,9 @@ SystemAnnouncerTest >> testProtocolRemoved [
 		protocolRemoved := ann protocol ].
 
 	class := factory newClass.
-	class organization addProtocolNamed: 'shiny-new-category'.
+	class organization addProtocol: 'shiny-new-category'.
 
-	class organization removeProtocolNamed: 'shiny-new-category'.
+	class organization removeProtocolIfEmpty: 'shiny-new-category'.
 
 	self assert: pass.
 	self assert: classRemoved equals: class.


### PR DESCRIPTION
The goal is to keep pushing the fact that we can use Protocols directly as parameter of ClassOrganizer methods and reduce the API size in order to move this in ClassDescription later.

#addProtocol: and #addProtocolNamed: are now merged and #hasProtocolNamed: become #hasProtocol: