### PR TITLE
Introduce CompiledMethod>>#isClassified

### DIFF
--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -540,6 +540,12 @@ CompiledMethod >> isClassSide [
 ]
 
 { #category : #testing }
+CompiledMethod >> isClassified [
+
+	^ self protocol ~= Protocol unclassified
+]
+
+{ #category : #testing }
 CompiledMethod >> isCompiledMethod [
 
 	^ true

--- a/src/Monticello-Tests/RPackageExtensionMethodsSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageExtensionMethodsSynchronisationTest.class.st
@@ -156,7 +156,7 @@ RPackageExtensionMethodsSynchronisationTest >> testMoveClassInPackageWithExtensi
 	secondPackage addClass: class.
 
 	"Everything should now be in second package (and not listed as an extension)."
-	self assert: (class >> #stubMethod) category equals: Protocol unclassified.
+	self deny: (class >> #stubMethod) isClassified.
 	self assert: (secondPackage includesDefinedSelector: #stubMethod ofClass: class).
 	self deny: (secondPackage includesExtensionSelector: #stubMethod ofClass: class).
 	self assert: (class >> #stubMethod packageFromOrganizer: self organizer) equals: secondPackage
@@ -175,7 +175,7 @@ RPackageExtensionMethodsSynchronisationTest >> testMoveClassInPackageWithExtensi
 	secondPackage addClass: class.
 
 	"Everything should now be in second package (and not listed as an extension)."
-	self assert: (class >> #stubMethod) category equals: Protocol unclassified.
+	self deny: (class >> #stubMethod) isClassified.
 	self assert: (secondPackage includesDefinedSelector: #stubMethod ofClass: class).
 	self deny: (secondPackage includesExtensionSelector: #stubMethod ofClass: class).
 	self assert: (class >> #stubMethod packageFromOrganizer: self organizer) equals: secondPackage
@@ -196,7 +196,7 @@ RPackageExtensionMethodsSynchronisationTest >> testMoveClassInPackageWithExtensi
 
 	"Everything should now be in second package (and not listed as an extension, but instead as 'as yet unclassified')."
 
-	self assert: (class >> #stubMethod) category equals: Protocol unclassified.
+	self deny: (class >> #stubMethod) isClassified.
 	self assert: (secondPackage includesDefinedSelector: #stubMethod ofClass: class).
 	self deny: (secondPackage includesExtensionSelector: #stubMethod ofClass: class).
 	self assert: (class >> #stubMethod packageFromOrganizer: self organizer) equals: secondPackage.
@@ -205,7 +205,7 @@ RPackageExtensionMethodsSynchronisationTest >> testMoveClassInPackageWithExtensi
 
 	firstPackage addClass: class.
 
-	self assert: (class >> #stubMethod) category equals: Protocol unclassified.
+	self deny: (class >> #stubMethod) isClassified.
 	self assert: (firstPackage includesDefinedSelector: #stubMethod ofClass: class).
 	self deny: (secondPackage includesExtensionSelector: #stubMethod ofClass: class)
 ]

--- a/src/Tool-Base/MethodClassifier.class.st
+++ b/src/Tool-Base/MethodClassifier.class.st
@@ -262,7 +262,7 @@ MethodClassifier >> protocolByOtherImplementors: aMethod [
 		ifNotEmpty: [ :methods |
 			methods
 				do: [ :method |
-					((method protocol beginsWith: '*') or: [ method protocol = Protocol unclassified ])
+					((method protocol beginsWith: '*') or: [ method isClassified not ])
 						ifFalse: [ protocolBag add: method protocol ]]
 				without: aMethod ].
 


### PR DESCRIPTION
We don't have much senders yet some I am not sure this is the most useful method but I find it nicer to do `method isClassified` instead of `method protocol = Protocol unclassified` because Demeter likes it better.