### PR TITLE
Fix random failure of Ombu in windows.

### DIFF
--- a/src/Ombu-Tests/OmSessionStoreTest.class.st
+++ b/src/Ombu-Tests/OmSessionStoreTest.class.st
@@ -27,6 +27,16 @@ OmSessionStoreTest >> tearDown [
 ]
 
 { #category : #tests }
+OmSessionStoreTest >> testNextStoreName [
+
+	| names |
+	names := OrderedCollection new.
+	100 timesRepeat: [ names add: store nextStoreName ].
+	self assertCollection: names hasSameElements: names asSet.
+	self assert: names size equals: names asSet size
+]
+
+{ #category : #tests }
 OmSessionStoreTest >> testResetWithNextStoreNameWithRandomSuffix [
 	| aFileReference anotherFileReference |
 	store storeNameStrategy: OmRandomSuffixStrategy new.

--- a/src/Ombu/OmTimeStampSuffixStrategy.class.st
+++ b/src/Ombu/OmTimeStampSuffixStrategy.class.st
@@ -9,6 +9,14 @@ Class {
 
 { #category : #accessing }
 OmTimeStampSuffixStrategy >> nextSuffix [
+	"There is a hack here because of a difference of behavior between Windows and Unix systems.
+	Unix systems gives a time at the nanosecond while windows only does at the millisecond.
+	
+	To make sure windows generates different store names we wait to be sure that the date and time will be different.
+	
+	Maybe this will get fixed in the  future? Check https://github.com/pharo-project/pharo/issues/13447 and if it's the case, remove the hack :)
+	OmSessionStoreTest>>#testNextStoreName is here to make sure we have no regression while running it on Windows, so if the hack is still needed you will know it."
 
+	Smalltalk os isWindows ifTrue: [ 1 milliSeconds wait ].
 	^ DateAndTime now asNanoSeconds printStringHex
 ]


### PR DESCRIPTION
The problems comes from the fact that we use the current time to set the name of Ombu stores.  But here we create 2 stores in less than 1 millisecond and DateAndTime on windows is sadly not able to give us a precision under 1 millisecond for now... See https://github.com/pharo-project/pharo/issues/13447.

So here is a quick hack to wait 1 millisecond before producing a new name on windows.

This was really not easy to locate :(