### PR TITLE
Introduce annotations

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -47,6 +47,7 @@ Class {
 RBCodeSnippet class >> allSnippets [
 
 	^ {
+		  self badAnnotations.
 		  self badSimpleExpressions.
 		  self badExpressions.
 		  self badTokens.
@@ -54,6 +55,64 @@ RBCodeSnippet class >> allSnippets [
 		  self badSemantic.
 		  self badPositions.
 		  self badVariableAndScopes } flattened
+]
+
+{ #category : #accessing }
+RBCodeSnippet class >> badAnnotations [
+
+	<script: 'self styleWithError: self badAnnotations'>
+	| list |
+	list := {
+		        (self new
+			         source: '@';
+			         nodeAt: '0';
+			         isParseFaulty: false;
+			         notices: #( #( 1 1 1 'Unexpected token' ) )).
+		        (self new
+			         source: '@5';
+			         nodeAt: '23';
+			         formattedCode: '@. 5';
+			         notices:
+				         #( #( 1 1 1 'Unexpected token' )
+				            #( 1 1 2 'End of statement expected' ) )).
+		        (self new
+			         source: 'a := @';
+			         nodeAt: '200001';
+			         isParseFaulty: false;
+			         notices:
+				         #( #( 6 6 6 'Unexpected token' )
+				            #( 1 1 1 'Undeclared variable' ) )).
+		        (self new
+			         source: '^ @';
+			         nodeAt: '001';
+			         isParseFaulty: false;
+			         notices: #( #( 3 3 3 'Unexpected token' ) )).
+		        (self new
+			         source: '@foo';
+			         nodeAt: '1000';
+			         formattedCode: '@ foo';
+			         isParseFaulty: false;
+			         notices: #( #( 1 4 1 'Unknown annotation' ) )).
+		        (self new
+			         source: '@foo:';
+			         nodeAt: '10000';
+			         formattedCode: '@ foo: ';
+			         notices: #( #( 6 5 6 'Variable or expression expected' )
+				            #( 1 5 1 'Unknown annotation' ) )).
+		        (self new
+			         source: '@foo:5';
+			         nodeAt: '100002';
+			         formattedCode: '@ foo: 5';
+			         isParseFaulty: false;
+			         notices: #( #( 1 6 1 'Unknown annotation' ) )) }.
+
+	"Setup default values"
+	self new
+		group: #badAnnotations;
+		isMethod: false;
+		isFaulty: true;
+		applyDefaultTo: list.
+	^ list
 ]
 
 { #category : #accessing }

--- a/src/AST-Core-Traits/TRBProgramNodeVisitor.trait.st
+++ b/src/AST-Core-Traits/TRBProgramNodeVisitor.trait.st
@@ -7,6 +7,10 @@ Trait {
 }
 
 { #category : #visiting }
+TRBProgramNodeVisitor >> visitAnnotationMarkNode: aRBAnnotationMarkNode [
+]
+
+{ #category : #visiting }
 TRBProgramNodeVisitor >> visitArgumentNode: anArgumentNode [
 	"Sent *each time* an argument node is found"
 	^ self visitVariableNode: anArgumentNode

--- a/src/AST-Core/RBAnnotationMarkNode.class.st
+++ b/src/AST-Core/RBAnnotationMarkNode.class.st
@@ -1,0 +1,58 @@
+"
+Annotations are message send witout receiver and starting with `@`.
+
+```st
+@something
+```
+
+In order to keep a simple and powerful parser, annotations are implemented as classic message sends on a special receiver `@`. The current class models this receiver.
+AST validations and transformations will deal with this.
+
+Note: it's not a variable, merly a placeholder.
+"
+Class {
+	#name : #RBAnnotationMarkNode,
+	#superclass : #RBValueNode,
+	#instVars : [
+		'start'
+	],
+	#category : #'AST-Core-Nodes'
+}
+
+{ #category : #visiting }
+RBAnnotationMarkNode >> acceptVisitor: aProgramNodeVisitor [
+	^ aProgramNodeVisitor visitAnnotationMarkNode: self
+]
+
+{ #category : #initialization }
+RBAnnotationMarkNode >> initialize [
+	super initialize.
+	start := 0
+]
+
+{ #category : #testing }
+RBAnnotationMarkNode >> isAnnotationMark [
+	^ true
+]
+
+{ #category : #testing }
+RBAnnotationMarkNode >> needsParenthesis [
+	^false
+]
+
+{ #category : #accessing }
+RBAnnotationMarkNode >> start: aPosition [
+	"Beware, start is in fact `startWithoutParentheses` as in RBValueNode, start includes parentheses"
+
+	start := aPosition
+]
+
+{ #category : #accessing }
+RBAnnotationMarkNode >> startWithoutParentheses [
+	^ start
+]
+
+{ #category : #accessing }
+RBAnnotationMarkNode >> stopWithoutParentheses [
+	^ start + 1
+]

--- a/src/AST-Core/RBAnnotationMarkNode.class.st
+++ b/src/AST-Core/RBAnnotationMarkNode.class.st
@@ -14,7 +14,8 @@ Class {
 	#name : #RBAnnotationMarkNode,
 	#superclass : #RBValueNode,
 	#instVars : [
-		'start'
+		'start',
+		'emitValueBlock'
 	],
 	#category : #'AST-Core-Nodes'
 }

--- a/src/AST-Core/RBAnnotationMarkNode.class.st
+++ b/src/AST-Core/RBAnnotationMarkNode.class.st
@@ -1,14 +1,22 @@
 "
 Annotations are message send witout receiver and starting with `@`.
 
+E.g.
 ```st
-@something
+@foo.
+@foo: 5 bar: self something.
+foo := @bar
 ```
 
 In order to keep a simple and powerful parser, annotations are implemented as classic message sends on a special receiver `@`. The current class models this receiver.
-AST validations and transformations will deal with this.
 
-Note: it's not a variable, merly a placeholder.
+AST validations and transformations (and most likely compiler plugins) have the responsibility to handle the annotations:
+
+* checking the correct syntaxic and semantic usage (parsePlugin);
+* transforming the AST;
+* and/or attaching a custom IR emiter (see `emitValue:` and `emitValueBlock`).
+
+Note: the node is not a value nor a variable, it is a placeholder at best.
 "
 Class {
 	#name : #RBAnnotationMarkNode,
@@ -72,5 +80,5 @@ RBAnnotationMarkNode >> startWithoutParentheses [
 
 { #category : #accessing }
 RBAnnotationMarkNode >> stopWithoutParentheses [
-	^ start + 1
+	^ start
 ]

--- a/src/AST-Core/RBAnnotationMarkNode.class.st
+++ b/src/AST-Core/RBAnnotationMarkNode.class.st
@@ -19,9 +19,21 @@ Class {
 	#category : #'AST-Core-Nodes'
 }
 
+{ #category : #comparing }
+RBAnnotationMarkNode >> = anObject [
+	"All annotation marks are equivalent"
+	^self class = anObject class
+]
+
 { #category : #visiting }
 RBAnnotationMarkNode >> acceptVisitor: aProgramNodeVisitor [
 	^ aProgramNodeVisitor visitAnnotationMarkNode: self
+]
+
+{ #category : #comparing }
+RBAnnotationMarkNode >> hash [
+
+	^ self class hash
 ]
 
 { #category : #initialization }
@@ -38,6 +50,11 @@ RBAnnotationMarkNode >> isAnnotationMark [
 { #category : #testing }
 RBAnnotationMarkNode >> needsParenthesis [
 	^false
+]
+
+{ #category : #accessing }
+RBAnnotationMarkNode >> precedence [
+	^0
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBAnnotationMarkNode.class.st
+++ b/src/AST-Core/RBAnnotationMarkNode.class.st
@@ -57,6 +57,12 @@ RBAnnotationMarkNode >> isAnnotationMark [
 ]
 
 { #category : #testing }
+RBAnnotationMarkNode >> isHandled [
+
+	^ self emitValueBlock isNotNil
+]
+
+{ #category : #testing }
 RBAnnotationMarkNode >> needsParenthesis [
 	^false
 ]

--- a/src/AST-Core/RBBinarySelectorToken.class.st
+++ b/src/AST-Core/RBBinarySelectorToken.class.st
@@ -12,3 +12,8 @@ Class {
 RBBinarySelectorToken >> isBinary [
 	^true
 ]
+
+{ #category : #testing }
+RBBinarySelectorToken >> isBinary: aString [
+	^ value = aString
+]

--- a/src/AST-Core/RBDumpVisitor.class.st
+++ b/src/AST-Core/RBDumpVisitor.class.st
@@ -37,6 +37,13 @@ RBDumpVisitor >> stream [
 ]
 
 { #category : #visiting }
+RBDumpVisitor >> visitAnnotationMarkNode: aRBAnnotationValueNode [
+	stream
+		nextPutAll: aRBAnnotationValueNode class name;
+		nextPutAll: ' new'
+]
+
+{ #category : #visiting }
 RBDumpVisitor >> visitArrayNode: anArrayNode [
 	stream
 		nextPutAll: anArrayNode class name;

--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -152,6 +152,11 @@ RBMessageNode >> hash [
 ]
 
 { #category : #testing }
+RBMessageNode >> isAnnotation [
+	^ self receiver isAnnotationMark
+]
+
+{ #category : #testing }
 RBMessageNode >> isBinary [
 	^(self isUnary or: [self isKeyword]) not
 ]

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -800,7 +800,7 @@ RBParser >> parsePragma [
 	startToken := currentToken.
 	self step. "<"
 	pragma := self basicParsePragma.
-	(currentToken isBinary and: [ currentToken value == #> ]) ifFalse: [
+	(currentToken isBinary: #>) ifFalse: [
 		pragma isPragma ifTrue: [
 			pragma
 				left: startToken start;
@@ -835,7 +835,7 @@ RBParser >> parsePragmaLiteral [
 { #category : #'private - parsing' }
 RBParser >> parsePragmas [
 
-	[ currentToken isBinary and: [ currentToken value = #< ] ]
+	[ currentToken isBinary: #< ]
 		whileTrue: [ self parsePragma ]
 ]
 

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -900,6 +900,13 @@ RBParser >> parsePrimitiveObject [
 			currentToken value = $( ifTrue: [^self parseParenthesizedExpression].
 			currentToken value = ${ ifTrue: [^self parseArray]].
 
+	"Annotations are implemented as a magic receiver '@'"
+	(currentToken isBinary: #@) ifTrue: [
+		| position |
+		position := currentToken start.
+		self step. "@"
+		^ RBAnnotationMarkNode new start: position ].
+
 	":id is only acceptable at the begin of a block. So just consume them as unexpected"
 	((currentToken isSpecial: $:) and: [ self nextToken isIdentifier ])
 		ifTrue: [

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -590,6 +590,11 @@ RBProgramNode >> intersectsInterval: anInterval [
 ]
 
 { #category : #testing }
+RBProgramNode >> isAnnotationMark [
+	^ false
+]
+
+{ #category : #testing }
 RBProgramNode >> isArgumentVariable [
 	^ false
 ]

--- a/src/AST-Core/RBProgramNodeVisitor.class.st
+++ b/src/AST-Core/RBProgramNodeVisitor.class.st
@@ -21,6 +21,10 @@ RBProgramNodeVisitor >> visit: aRBMessageNode [
 ]
 
 { #category : #visiting }
+RBProgramNodeVisitor >> visitAnnotationMarkNode: aRBAnnotationValueNode [
+]
+
+{ #category : #visiting }
 RBProgramNodeVisitor >> visitArgumentNode: anArgumentNode [
 	"Sent *each time* an argument node is found"
 

--- a/src/AST-Core/RBSimpleFormatter.class.st
+++ b/src/AST-Core/RBSimpleFormatter.class.st
@@ -387,6 +387,12 @@ RBSimpleFormatter >> traditionalBinaryPrecedenceArray [
 ]
 
 { #category : #visiting }
+RBSimpleFormatter >> visitAnnotationMarkNode: aRBAnnotationValueNode [
+
+	codeStream nextPut: $@
+]
+
+{ #category : #visiting }
 RBSimpleFormatter >> visitArrayNode: anArrayNode [
 	self bracketWith: '{}' around: [ self formatArray: anArrayNode ]
 ]

--- a/src/AST-Core/RBToken.class.st
+++ b/src/AST-Core/RBToken.class.st
@@ -51,6 +51,11 @@ RBToken >> isBinary [
 ]
 
 { #category : #testing }
+RBToken >> isBinary: aString [
+	^false
+]
+
+{ #category : #testing }
 RBToken >> isComment [
 	^false
 ]

--- a/src/EnlumineurFormatter/EFFormatter.class.st
+++ b/src/EnlumineurFormatter/EFFormatter.class.st
@@ -2085,6 +2085,12 @@ EFFormatter >> useBasicCommentFormat: aBoolean [
 ]
 
 { #category : #visiting }
+EFFormatter >> visitAnnotationMarkNode: aRBAnnotationValueNode [
+
+	codeStream nextPut: $@
+]
+
+{ #category : #visiting }
 EFFormatter >> visitArrayNode: anArrayNode [
 	self bracketWith: '{}' around: [ self formatArray: anArrayNode ]
 ]

--- a/src/Kernel-ExtraUtils/ClassHierarchyPrinterTest.class.st
+++ b/src/Kernel-ExtraUtils/ClassHierarchyPrinterTest.class.st
@@ -49,6 +49,7 @@ ClassHierarchyPrinterTest >> testOnlyRBASTNodes [
 		RBReturnNode
 		RBSequenceNode
 		RBValueNode
+			RBAnnotationMarkNode
 			RBArrayNode
 			RBAssignmentNode
 			RBBlockNode

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -182,8 +182,12 @@ OCASTSemanticAnalyzer >> unusedVariable: variableNode [
 { #category : #visiting }
 OCASTSemanticAnalyzer >> visitAnnotationMarkNode: aRBAnnotationValueNode [
 
-	(aRBAnnotationValueNode parent isNil or: [ aRBAnnotationValueNode parent isMessage ]) ifTrue: [ ^ self ].
-	self error: 'Bad annotation' forNode: aRBAnnotationValueNode
+	(aRBAnnotationValueNode parent isNotNil and: [
+		 aRBAnnotationValueNode parent isMessage ]) ifTrue: [
+		aRBAnnotationValueNode isHandled ifFalse: [
+			self error: 'Unknown annotation' forNode: aRBAnnotationValueNode parent ].
+		^ self ].
+	self error: 'Unexpected token' forNode: aRBAnnotationValueNode
 ]
 
 { #category : #visiting }

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -180,6 +180,13 @@ OCASTSemanticAnalyzer >> unusedVariable: variableNode [
 ]
 
 { #category : #visiting }
+OCASTSemanticAnalyzer >> visitAnnotationMarkNode: aRBAnnotationValueNode [
+
+	(aRBAnnotationValueNode parent isNil or: [ aRBAnnotationValueNode parent isMessage ]) ifTrue: [ ^ self ].
+	self error: 'Bad annotation' forNode: aRBAnnotationValueNode
+]
+
+{ #category : #visiting }
 OCASTSemanticAnalyzer >> visitAssignmentNode: anAssignmentNode [
 	| var |
 	self visitNode: anAssignmentNode value.

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -479,6 +479,12 @@ OCASTTranslator >> translateFullBlock: aBlockNode [
 	^ aBlockNode ir compiledBlock: aBlockNode scope
 ]
 
+{ #category : #visiting }
+OCASTTranslator >> visitAnnotationMarkNode: aRBAnnotationValueNode [
+
+	self emitRuntimeError: aRBAnnotationValueNode
+]
+
 { #category : #'visitor - double dispatching' }
 OCASTTranslator >> visitArrayNode: anArrayNode [
 

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -653,6 +653,10 @@ OCASTTranslator >> visitLiteralNode: aLiteralNode [
 
 { #category : #'visitor - double dispatching' }
 OCASTTranslator >> visitMessageNode: aMessageNode [
+
+	aMessageNode isAnnotation ifTrue: [
+		^ aMessageNode receiver emitValue: methodBuilder ].
+
 	aMessageNode isInlined ifTrue: [
 		methodBuilder addLiteral: aMessageNode selector. "so searching for senders will work"
 		^self

--- a/src/OpalCompiler-Core/RBAnnotationMarkNode.extension.st
+++ b/src/OpalCompiler-Core/RBAnnotationMarkNode.extension.st
@@ -5,9 +5,9 @@ RBAnnotationMarkNode >> emitValue: methodBuilder [
 
 	emitValueBlock ifNotNil: [ ^ emitValueBlock value: methodBuilder ].
 	methodBuilder
-		pushLiteralVariable: Error binding;
-		pushLiteral: 'Error: untransformed annotation';
-		send: #signal:
+		pushLiteralVariable: RuntimeSyntaxError binding;
+		pushLiteral: 'Unhandled annotation';
+		send: #signalSyntaxError:
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Core/RBAnnotationMarkNode.extension.st
+++ b/src/OpalCompiler-Core/RBAnnotationMarkNode.extension.st
@@ -1,0 +1,23 @@
+Extension { #name : #RBAnnotationMarkNode }
+
+{ #category : #'*OpalCompiler-Core' }
+RBAnnotationMarkNode >> emitValue: methodBuilder [
+
+	emitValueBlock ifNotNil: [ ^ emitValueBlock value: methodBuilder ].
+	methodBuilder
+		pushLiteralVariable: Error binding;
+		pushLiteral: 'Error: untransformed annotation';
+		send: #signal:
+]
+
+{ #category : #'*OpalCompiler-Core' }
+RBAnnotationMarkNode >> emitValueBlock [
+
+	^ emitValueBlock
+]
+
+{ #category : #'*OpalCompiler-Core' }
+RBAnnotationMarkNode >> emitValueBlock: anObject [
+
+	emitValueBlock := anObject
+]

--- a/src/OpalCompiler-Tests/OCAnnotationTest.class.st
+++ b/src/OpalCompiler-Tests/OCAnnotationTest.class.st
@@ -30,3 +30,31 @@ OCAnnotationTest >> testAnnotationAST [
 		assert: result
 		equals: { 'meaning of life'. 'no meaning'. 'no meaning'. 42 }
 ]
+
+{ #category : #tests }
+OCAnnotationTest >> testAnnotationIR [
+
+	| plugin result |
+	plugin := OCDynamicASTCompilerPlugin
+		          newFromTransformBlock: [ :ast | "In fact, there is no transformation. Just an addition to the annotation mark"
+			          (RBParseTreeSearcher new
+				           matches: '@ meaning: `@arg'
+				           do: [ :node :ans |
+					           node receiver emitValueBlock: [ :methodBuilder |
+						           methodBuilder pushLiteral:
+							           ((node arguments first isLiteralNode and: [
+								             node arguments first value = 42 ])
+								            ifTrue: [ 'meaning of life' ]
+								            ifFalse: [ 'no meaning' ]) ] ]) executeTree: ast.
+			          ast ]
+		          andPriority: 0.
+
+	"Use plugin with compiler"
+	result := Object compiler
+		          addPlugin: plugin;
+		          evaluate:
+			          '{@meaning: 42. @meaning: 12. @meaning: self error. 42}'.
+	self
+		assert: result
+		equals: { 'meaning of life'. 'no meaning'. 'no meaning'. 42 }
+]

--- a/src/OpalCompiler-Tests/OCAnnotationTest.class.st
+++ b/src/OpalCompiler-Tests/OCAnnotationTest.class.st
@@ -6,12 +6,16 @@ Class {
 
 { #category : #tests }
 OCAnnotationTest >> testAnnotationAST [
+	"This test uses an AST plugin to detect and transform a custom annotation `@meaning:`
+	(using `OCDynamicASTCompilerPlugin` and `RBParseTreeRewriter`).
+	
+	The annotation (the full message node) is transformed into a simple literal node."
 
 	| plugin result |
 	plugin := OCDynamicASTCompilerPlugin
 		          newFromTransformBlock: [ :ast |
 			          (RBParseTreeRewriter new
-				           replace: '@ meaning: `@arg'
+				           replace: '@meaning: `@arg'
 				           withValueFrom: [ :node |
 					           RBLiteralNode value:
 						           ((node arguments first isLiteralNode and: [
@@ -23,7 +27,7 @@ OCAnnotationTest >> testAnnotationAST [
 
 	"Use plugin with compiler"
 	result := Object compiler
-		          addPlugin: plugin;
+		          addParsePlugin: plugin;
 		          evaluate:
 			          '{@meaning: 42. @meaning: 12. @meaning: self error. 42}'.
 	self
@@ -33,12 +37,19 @@ OCAnnotationTest >> testAnnotationAST [
 
 { #category : #tests }
 OCAnnotationTest >> testAnnotationIR [
+	"This test uses an AST plugin to detect a custom annotation `@meaning:`
+	(using `OCDynamicASTCompilerPlugin` and `RBParseTreeSearcher`)
+	and attach a custom `emitValueBlock` to it.
+	It does not transform the AST.
+
+	At translation-time (AST->IR), the annotation (the full message node) is
+	compiled with the help of the attached `emitValueBlock`."
 
 	| plugin result |
 	plugin := OCDynamicASTCompilerPlugin
 		          newFromTransformBlock: [ :ast | "In fact, there is no transformation. Just an addition to the annotation mark"
 			          (RBParseTreeSearcher new
-				           matches: '@ meaning: `@arg'
+				           matches: '@meaning: `@arg'
 				           do: [ :node :ans |
 					           node receiver emitValueBlock: [ :methodBuilder |
 						           methodBuilder pushLiteral:
@@ -51,7 +62,7 @@ OCAnnotationTest >> testAnnotationIR [
 
 	"Use plugin with compiler"
 	result := Object compiler
-		          addPlugin: plugin;
+		          addParsePlugin: plugin;
 		          evaluate:
 			          '{@meaning: 42. @meaning: 12. @meaning: self error. 42}'.
 	self

--- a/src/OpalCompiler-Tests/OCAnnotationTest.class.st
+++ b/src/OpalCompiler-Tests/OCAnnotationTest.class.st
@@ -1,0 +1,32 @@
+Class {
+	#name : #OCAnnotationTest,
+	#superclass : #TestCase,
+	#category : #'OpalCompiler-Tests-Plugins'
+}
+
+{ #category : #tests }
+OCAnnotationTest >> testAnnotationAST [
+
+	| plugin result |
+	plugin := OCDynamicASTCompilerPlugin
+		          newFromTransformBlock: [ :ast |
+			          (RBParseTreeRewriter new
+				           replace: '@ meaning: `@arg'
+				           withValueFrom: [ :node |
+					           RBLiteralNode value:
+						           ((node arguments first isLiteralNode and: [
+							             node arguments first value = 42 ])
+							            ifTrue: [ 'meaning of life' ]
+							            ifFalse: [ 'no meaning' ]) ]) executeTree: ast.
+			          ast ]
+		          andPriority: 0.
+
+	"Use plugin with compiler"
+	result := Object compiler
+		          addPlugin: plugin;
+		          evaluate:
+			          '{@meaning: 42. @meaning: 12. @meaning: self error. 42}'.
+	self
+		assert: result
+		equals: { 'meaning of life'. 'no meaning'. 'no meaning'. 42 }
+]

--- a/src/OpalCompiler-Tests/OCAnnotationTest.class.st
+++ b/src/OpalCompiler-Tests/OCAnnotationTest.class.st
@@ -36,6 +36,142 @@ OCAnnotationTest >> testAnnotationAST [
 ]
 
 { #category : #tests }
+OCAnnotationTest >> testAnnotationBinding [
+	"A more advanced usage.
+	The `@binding:` example annotation takes a variable and push its binding instead of reading it.
+	This example takes care of errors at parse-time, so the user can statically be informed of missuses of the annotation.
+	
+	Note: the example nests of lot of concerns into a single statement.
+	Real uses in production will likely involve a better design with more classes and methods."
+
+	| plugin result |
+	plugin := OCDynamicASTCompilerPlugin
+		          newFromTransformBlock: [ :ast | "In fact, there is no transformation"
+			          (RBParseTreeSearcher new
+				           matches: '@binding: `@arg'
+				           do: [ :node :ans | "Static syntax check"
+					           node arguments first isVariable
+						           ifFalse: [ "Not a variable, add a syntax error"
+							           node arguments first addError: 'Variable expected'.
+							           "Also add a compile-time error for faulty modes"
+							           node receiver emitValueBlock: [ :methodBuilder |
+								           methodBuilder
+									           pushLiteralVariable: RuntimeSyntaxError binding;
+									           pushLiteral: 'Variable expected';
+									           send: #signal: ] ]
+						           ifTrue: [ "It's a real variable, to use the binding.
+						              Note: currenlty variables are not bound yet, but they will be when the block is evaluated"
+							           node receiver emitValueBlock: [ :methodBuilder |
+								           methodBuilder pushLiteral:
+									           node arguments first variable ] ] ]) executeTree:
+				          ast.
+			          ast ]
+		          andPriority: 0.
+
+	"Use plugin with compiler"
+	result := Object compiler
+		          addParsePlugin: plugin;
+		          evaluate: '@binding: Object'.
+	self assert: result class equals: GlobalVariable.
+	self assert: result key equals: #Object.
+	self assert: result value equals: Object.
+
+	result := Object compiler
+		          addParsePlugin: plugin;
+		          evaluate: '@binding: self'.
+	self assert: result class equals: SelfVariable.
+
+	result := Object compiler
+		          addParsePlugin: plugin;
+		          failBlock: [ :n |
+			          self assert: n messageText equals: 'Variable expected'.
+			          #failed ];
+		          evaluate: '@binding: 42'.
+	self assert: result equals: #failed.
+
+	self
+		should: [
+			Object compiler
+				addParsePlugin: plugin;
+				permitFaulty: true;
+				evaluate: '@binding: 42' ]
+		raise: RuntimeSyntaxError
+]
+
+{ #category : #tests }
+OCAnnotationTest >> testAnnotationConstexprAST [
+	"This advanced example shows a `@constexpr:` annotation that evaluates its argument at compile-time.
+	You might think about `##()` in some Smalltalk dialects for instance.
+	
+	Here the implementation use an AST approach that transform the whole annotation into a literal node"
+
+	| plugin result |
+	plugin := OCDynamicASTCompilerPlugin
+		          newFromTransformBlock: [ :ast |
+			          (RBParseTreeRewriter new
+				           replace: '@constexpr: `@arg'
+				           withValueFrom: [ :node |
+					           | value |
+					           "Evaluate the argument, self is bound to the class"
+					           value := node arguments first evaluateForReceiver:
+						                    node methodNode methodClass instanceSide.
+					           RBLiteralNode value: value ]) executeTree: ast.
+			          ast ]
+		          andPriority: 0.
+
+	result := Object compiler
+		          addParsePlugin: plugin;
+		          compile:
+			          'foo ^ @constexpr: ''The answer is '' , (19+23) asString'.
+	self assert: (result literals includes: 'The answer is 42').
+	self assert: (nil executeMethod: result) equals: 'The answer is 42'.
+
+	result := Float compiler
+		          addParsePlugin: plugin;
+		          compile: 'foo ^ @constexpr: self pi'.
+	self assert: (result literals includes: Float pi).
+	self assert: (nil executeMethod: result) equals: Float pi
+]
+
+{ #category : #tests }
+OCAnnotationTest >> testAnnotationConstexprIR [
+	"This advanced example shows a `@constexpr:` annotation that evaluates its argument at compile-time.
+	You might think about `##()` in some Smalltalk dialects for instance.
+	
+	Here the implementation use an IR approach and store the value directly as a literal of the method"
+
+	| plugin result |
+	plugin := OCDynamicASTCompilerPlugin
+		          newFromTransformBlock: [ :ast | "In fact, there is no transformation. Just an addition to the annotation mark"
+			          (RBParseTreeSearcher new
+				           matches: '@constexpr: `@arg'
+				           do: [ :node :ans |
+					           | value |
+					           "Evaluate the argument, self is bound to the class"
+					           value := node arguments first evaluateForReceiver:
+						                    node methodNode methodClass instanceSide.
+					           "IR is just to store the value in literals and retrieve it at runtime"
+					           node receiver emitValueBlock: [ :methodBuilder |
+						           methodBuilder pushLiteral: value ] ]) executeTree:
+				          ast.
+			          ast ]
+		          andPriority: 0.
+
+	result := Object compiler
+		          addParsePlugin: plugin;
+		          compile:
+			          'foo ^ @constexpr: ''The answer is '' , (19+23) asString'.
+	self assert: (result literals includes: 'The answer is 42').
+	self assert: (nil executeMethod: result) equals: 'The answer is 42'.
+
+	result := Float compiler
+		          addParsePlugin: plugin;
+		          compile: 'foo ^ @constexpr: self pi'.
+	self assert: (result literals includes: Float pi).
+	self assert: (nil executeMethod: result) equals: Float pi
+]
+
+{ #category : #tests }
 OCAnnotationTest >> testAnnotationIR [
 	"This test uses an AST plugin to detect a custom annotation `@meaning:`
 	(using `OCDynamicASTCompilerPlugin` and `RBParseTreeSearcher`)


### PR DESCRIPTION
Playing with the compiler, AST transformations, IR manipulations and language extensions is fun, but sometimes you wish having some sane way to isolate your experimentation attempts from the compiler code base.

Currently, OpalCompiler can be extended with plugins (two set of them, one for the frontend and one for the backend).
It is used by the FFI for instance (I don't know the detail that much).
Another approach is to subclass some core classes of the compiler and use them instead of the vanilla ones. This is what reflectivity/metalinks does, but has a great cost: a strong binding to the compiler architecture (with a lot of fragile base class issues). Moreover, multiple users of such a radical approach cannot be easily combined.
On the parser front, there is no plugin available. Subclassing is always an option (it is what the pattern parser does) but has drawbacks. Alternative approaches like extensible grammars are not available in Pharo, but are always a nightmare anyway.

This PR is a proposal to be able to experiment on independent and integrated extensions of OpalCompiler that include the parser and the IR generation. It is based on the existing plugin infrastructure.

On the parser front, there is a single extension point: a new *annotation* syntax based on a pseudo-message syntax (like pragma) with a selector and possible arguments.
The use of selectors (instead of a soup of random characters) force each extension to be named. They can be searched (like pragmas). They are also more understandable by random users, which might guess what such an extension does by its name.
To distinguish from normal selectors, there are two things: they have no receiver (like pragma), and they start with `@`. This symbol was chosen because it's the one used by some other languages (python and java for instance) for their own annotations.
Besides that, they can be used anywhere a message send is expected (with the same parsing precedence), and with the same kind of arguments (including other annotations).

```st
@foo. "a unary annotation `@foo`"
@foo: x bar: y. "a keyword annotation `@foo:bar:`"
^ x := y foo: (@bar: z + 1). "a keyword annotation `@bar:` in an expression that takes an expression"
```

About language theory. There is no conflict nor ambiguity. `@` in annotations was previously parsed as a syntax error (binary operator with a missing receiver).
For the AST representation, there is a simple (and nice) trick: annotations are genuine message send nodes, but with a new AST node `RBAnnotationMarkNode` (that corresponds to a lone `@`) used as a receiver.

On the processing front.
By default, annotations are simply rejected by the compiler (*unknown annotation*).
In order to manipulate them, plugins with the responsibility to handle them must be attached to the compiler.
They can do classic AST search and transformation to handle the annotations they know about.
Node replacements are an effective approach since they make the annotation disappear (so the compiler won't signal an error).

AST transformations are pleasant, but what if we want to play also with the IR?
`RBAnnotationMarkNode` are usable by the AST→IR transformer to emit IR code thanks to `emitValue:`.
This idea is similar to that is done for variables with their `emitValue:` and `emitStore:` methods.
Therefore, plugins can replace instances of `RBAnnotationMarkNode` with instances of their own subclasses and provide meaningful `emitValue:` implementations.

An alternative lightweight approach is to use `emitValueBlock:` to assign a custom IR generation block to annotation instances in the AST. In this case, no need to have a subclass, and plugins can simply use the existing instances.

Fun fact: new `RBAnnotationMarkNode` instances can also be injected in AST by some plugin where they were not present in order to use their `emitValue:` facility.

And it's basically all. Most of the needed code is already available. The PR is in fact very small, tests and examples takes the major part of it.
By the way, you might want to look at the examples (and, by the law of lexicographic order, they are at the end of the diff).
There are two examples that introduces a toy `@meaning:` annotation to show basic usage (one with AST transformation, the other one with IR emission).
There are more realistic examples. One proposes `@binding:` to get the binding of a variable (so you get a `Variable` instance at runtime, instead of the value of the variable). The last twos propose `@constexpr:` to evaluate an expression at compile-time (one example with AST transformation, the other with IR emission).

Limitation and future work:

* The AST injector point (annotation node) is limited to values (aka expressions). This is not a big limitation because most things are expressions, and for most things that are not expressions, you can enclose them in a block.
* The plugin API can be rough with nested classes and blocks. But "production" code should be able to use block-less approaches with classes and correctly assigned responsibilities.
* The annotation API is very simple (by design) but it might not be its final form.