### PR TITLE
Rubric editors (thus calypso) execute doit actions in faulty mode

### DIFF
--- a/src/Rubric-Tests/RubSmalltalkEditorTest.class.st
+++ b/src/Rubric-Tests/RubSmalltalkEditorTest.class.st
@@ -526,6 +526,19 @@ RubSmalltalkEditorTest >> testBestNodeWithValidValueMidSource [
 		assertNodeValue: 3
 ]
 
+{ #category : #tests }
+RubSmalltalkEditorTest >> testCompileForIn [
+
+	| editor method |
+	editor := RubSmalltalkEditor new.
+
+	method := editor compile: '40+2' for: nil in: nil.
+	self assert: (nil executeMethod: method) equals: 42.
+
+	method := editor compile: '40+¿' for: nil in: nil.
+	self should: [ nil executeMethod: method ] raise: RuntimeSyntaxError
+]
+
 { #category : #'tests - copy' }
 RubSmalltalkEditorTest >> testCopySelection [
 
@@ -557,6 +570,24 @@ RubSmalltalkEditorTest >> testDefaultCompletionIsNilIfNoGlobalClass [
 	textEditor := RubSmalltalkEditor new.
 	RubSmalltalkEditor noCompletion.
 	self assert: textEditor completionEngine isNil
+]
+
+{ #category : #tests }
+RubSmalltalkEditorTest >> testEvaluateAndDo [
+
+	| editor result |
+	editor := RubSmalltalkEditor new.
+	editor textArea: RubEditingArea new.
+
+	result := editor evaluate: '40+2' andDo: [ :value |
+		          self assert: value equals: 42.
+		          #flag ].
+	self assert: result equals: #flag.
+
+	self
+		should: [
+		editor evaluate: '40+¿' andDo: [ :value | self error: 'DEADCODE' ] ]
+		raise: RuntimeSyntaxError
 ]
 
 { #category : #'tests - completion' }

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -320,9 +320,8 @@ RubSmalltalkEditor >> compile: aStream for: anObject in: evalContext [
 		source: aStream;
 		class: methodClass;
 		context: evalContext;
-		requestor: self morph;
 		noPattern: true;
-		failBlock: [ ^ nil ];
+		permitFaulty: true;
 		compile
 ]
 
@@ -524,8 +523,7 @@ RubSmalltalkEditor >> evaluate: aStream andDo: aBlock [
 			source: aStream;
 			context: ctxt;
 			receiver: rcvr;
-			requestor: self morph  "don't set it to self.. The receiver can be destroyed as a result of evaluateSelection";
-			failBlock:  [self morph flash. ^ nil];
+			permitFaulty: true;
 			evaluate.
 
 	^ aBlock value: result


### PR DESCRIPTION
When evaluating a random selection (or a random line), having a static syntax errors are not that useful and are badly reported in the editor anyway. So this PR proposes to have runtime syntax errors instead, that opens a debugger.

This PR checks part of checkbox of  #11944. Newtools are in a different repository 
