### PR TITLE
Improve ClassOrganization copy

### DIFF
--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -53,6 +53,40 @@ ClassOrganizationTest >> testAddProtocol [
 ]
 
 { #category : #tests }
+ClassOrganizationTest >> testCopyFrom [
+
+    | newOrganization |
+    "First lets check the current state of the org."
+    self assertCollection: self organization protocolNames hasSameElements: #( 'empty' 'one' ).
+    self assertCollection: (self organization protocolNamed: 'one') methodSelectors hasSameElements: #( 'one' ).
+    self assertEmpty: (self organization protocolNamed: 'empty') methodSelectors.
+
+    "Now lets check that the new org has the same"
+    newOrganization := ClassOrganization new
+                           setSubject: self organization organizedClass;
+                           copyFrom: self organization;
+                           yourself.
+
+    self assertCollection: newOrganization protocolNames hasSameElements: #( 'empty' 'one' ).
+    self assertCollection: (newOrganization protocolNamed: 'one') methodSelectors hasSameElements: #( 'one' ).
+    self assertEmpty: (newOrganization protocolNamed: 'empty') methodSelectors.
+
+    "And now lets check that updating one does not update the other."
+    self organization addProtocol: 'two'.
+    newOrganization classify: 'new' under: 'init'.
+
+    self assertCollection: self organization protocolNames hasSameElements: #( 'empty' 'one' 'two' ).
+    self assertCollection: (self organization protocolNamed: 'one') methodSelectors hasSameElements: #( 'one' ).
+    self assertEmpty: (self organization protocolNamed: 'empty') methodSelectors.
+    self assertEmpty: (self organization protocolNamed: 'two') methodSelectors.
+
+    self assertCollection: newOrganization protocolNames hasSameElements: #( 'empty' 'one' 'init' ).
+    self assertCollection: (newOrganization protocolNamed: 'one') methodSelectors hasSameElements: #( 'one' ).
+    self assertEmpty: (newOrganization protocolNamed: 'empty') methodSelectors.
+    self assertCollection: (newOrganization protocolNamed: 'init') methodSelectors hasSameElements: #( 'new' )
+]
+
+{ #category : #tests }
 ClassOrganizationTest >> testMethodSelectorsInProtocol [
 
 	| methods |

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -127,7 +127,7 @@ ClassOrganization >> commentStamp [
 { #category : #copying }
 ClassOrganization >> copyFrom: otherOrganization [
 
-	otherOrganization protocols do: [ :protocol | protocol methodSelectors do: [ :m | self classify: m inProtocolNamed: protocol name ] ]
+	protocols := otherOrganization protocols copy
 ]
 
 { #category : #'queries - protocols' }


### PR DESCRIPTION
When recompiling a class, the new one copy the organization of the previous one. Currently it is done by iterating over all protocols and methods selectors to reclassify them silently.  Now we just copy the already existing protocols variable. 

Also I added a test.

This is a subpart of  #13373