### PR TITLE
Cleaning of #classify:inProtocolNamed:

### DIFF
--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -94,3 +94,49 @@ ClassOrganizationTest >> testRemoveProtocolIfEmpty [
 	self assert: self organization protocolNames size equals: 1.
 	self assert: self organization protocolNames first equals: 'one'
 ]
+
+{ #category : #tests }
+ClassOrganizationTest >> testSilentlyClassifyUnder [
+	"Set the base for the test"
+
+	self assertCollection: self organization protocolNames hasSameElements: #( #empty #one ).
+
+	"Lets create a new protocol via classification"
+	self organization silentlyClassify: #king under: #owl.
+	self organization silentlyClassify: #luz under: #owl.
+
+	self assertCollection: self organization protocolNames hasSameElements: #( #empty #one #owl ).
+	self assertCollection: (self organization protocolNamed: #owl) methodSelectors hasSameElements: #( #king #luz).
+
+	"Move a method"
+	self organization silentlyClassify: #luz under: #one.
+	self assertCollection: self organization protocolNames hasSameElements: #( #empty #one #owl ).
+	self assertCollection: (self organization protocolNamed: #owl) methodSelectors hasSameElements: #( #king ).
+	self assertCollection: (self organization protocolNamed: #one) methodSelectors hasSameElements: #( #one #luz).
+
+	"Move last method"
+	self organization silentlyClassify: #king under: #two.
+	self assertCollection: self organization protocolNames hasSameElements: #( #empty #one #two ).
+	self assertCollection: (self organization protocolNamed: #one) methodSelectors hasSameElements: #( #one #luz).
+	self assertCollection: (self organization protocolNamed: #two) methodSelectors hasSameElements: #( #king ).
+
+	"Nothing should change if the new protocol is the same than the old one"
+	self organization silentlyClassify: #king under: #two.
+	self assertCollection: self organization protocolNames hasSameElements: #( #empty #one #two ).
+	self assertCollection: (self organization protocolNamed: #one) methodSelectors hasSameElements: #( #one #luz).
+	self assertCollection: (self organization protocolNamed: #two) methodSelectors hasSameElements: #( #king )
+]
+
+{ #category : #tests }
+ClassOrganizationTest >> testSilentlyClassifyUnderWithProtocol [
+	"Set the base for the test"
+
+	self assertCollection: self organization protocolNames hasSameElements: #( #empty #one ).
+
+	"Lets create a new protocol via classification"
+	self organization silentlyClassify: #king under: #owl.
+	self organization silentlyClassify: #luz under: (self organization protocolNamed: #owl).
+
+	self assertCollection: self organization protocolNames hasSameElements: #( #empty #one #owl ).
+	self assertCollection: (self organization protocolNamed: #owl) methodSelectors hasSameElements: #( #king #luz )
+]

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -55,19 +55,6 @@ ClassOrganization >> classComment: aString [
 	self comment: aString
 ]
 
-{ #category : #'protocol - adding' }
-ClassOrganization >> classify: aSymbol inProtocolNamed: aProtocolName [
-
-	| protocol |
-	protocol := self protocolNamed: aProtocolName ifAbsent: [ self addProtocol: aProtocolName ].
-  
-	self protocols
-		select: [ :p | p includesSelector: aSymbol ]
-		thenDo: [ :p | p removeMethodSelector: aSymbol ].
-
-		protocol addMethodSelector: aSymbol
-]
-
 { #category : #'backward compatibility' }
 ClassOrganization >> classify: selector under: aProtocol [
 
@@ -85,8 +72,7 @@ ClassOrganization >> classify: selector under: aProtocol [
 	(forceNotify or: [ oldProtocolName ~= protocolName or: [ protocolName ~= Protocol unclassified ] ]) ifFalse: [ ^ self ].
 	oldProtocol := self protocolOfSelector: selector.
 
-	self classify: selector inProtocolNamed: protocolName.
-	oldProtocol ifNotNil: [ self removeProtocolIfEmpty: oldProtocol ].
+	self silentlyClassify: selector under: protocolName.
 	oldProtocolName ifNotNil: [ self notifyOfChangedSelector: selector from: oldProtocolName to: protocolName ]
 ]
 
@@ -127,7 +113,7 @@ ClassOrganization >> commentStamp [
 { #category : #copying }
 ClassOrganization >> copyFrom: otherOrganization [
 
-	otherOrganization protocols do: [ :protocol | protocol methodSelectors do: [ :m | self classify: m inProtocolNamed: protocol name ] ]
+	otherOrganization protocols do: [ :protocol | protocol methodSelectors do: [ :m | self silentlyClassify: m under: protocol name ] ]
 ]
 
 { #category : #'queries - protocols' }
@@ -350,6 +336,17 @@ ClassOrganization >> reset [
 ClassOrganization >> setSubject: anObject [
 
 	organizedClass := anObject
+]
+
+{ #category : #'protocol - adding' }
+ClassOrganization >> silentlyClassify: aSelector under: aProtocol [
+
+	(self protocolOfSelector: aSelector) ifNotNil: [ :oldProtocol |
+		oldProtocol removeMethodSelector: aSelector.
+		self removeProtocolIfEmpty: oldProtocol ].
+
+
+	(self ensureProtocol: aProtocol) addMethodSelector: aSelector
 ]
 
 { #category : #private }

--- a/src/TraitsV2/TaAbstractComposition.class.st
+++ b/src/TraitsV2/TaAbstractComposition.class.st
@@ -159,7 +159,7 @@ TaAbstractComposition >> compile: selector into: aClass [
 
 	aClass addSelectorSilently: selector withMethod: newMethod.
 
-	aClass organization classify: selector inProtocolNamed: (self categoryOfMethod: method withSelector: method selector).
+	aClass organization silentlyClassify: selector under: (self categoryOfMethod: method withSelector: method selector).
 
 	aClass >> selector propertyAt: #traitSource put: traitDefining.
 	^ true
@@ -217,7 +217,7 @@ TaAbstractComposition >> copyMethod: aSelector into: aClass replacing: replacing
 
 	aClass addSelectorSilently: aSelector withMethod: newMethod.
 
-	aClass organization classify: aSelector inProtocolNamed: aCompiledMethod category asSymbol.
+	aClass organization silentlyClassify: aSelector under: aCompiledMethod category asSymbol.
 
 	aClass organization removeEmptyProtocols.
 


### PR DESCRIPTION
I updated #classify:inProtocolNamed: in multiple ways:

- Now the method can take a protocol name OR a real protocol as parameter
- If the method is been reclassified and the old protocol becomes empty, we remove it. In the past this was only done if this method was invoked through #classify:under:
- In the end, this method was doing exactly the same as #classify:under: but without the reclassification announcement. Since I had to rename the method to remove the "inProtocolNamed:" I decided to rename it #silentlyClassify:under: in mirror of #classify:under:
- Now this method has tests