### PR TITLE
Introduce ClassDescription>>protocolOfSelector:

### DIFF
--- a/src/Kernel-Tests/ClassDescriptionTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionTest.class.st
@@ -109,6 +109,25 @@ ClassDescriptionTest >> testOrganization [
 	self assert: (aClassOrganizer isKindOf: ClassOrganization)
 ]
 
+{ #category : #tests }
+ClassDescriptionTest >> testProtocolOfSelector [
+	"First let's check the protocol of a local method."
+
+	self assert: (self classToBeTested includesSelector: #protocolOfSelector:).
+	self assert: (self classToBeTested allSelectors includes: #protocolOfSelector:).
+	self assert: (self classToBeTested protocolOfSelector: #protocolOfSelector:) name equals: #'accessing - protocols'.
+
+	"Then the protocol of a method present in the superclass"
+	self deny: (self classToBeTested includesSelector: #originalName).
+	self assert: (self classToBeTested allSelectors includes: #originalName).
+	self assert: (self classToBeTested protocolOfSelector: #originalName) name equals: #initialization.
+
+	"Now a method that does not exists."
+	self deny: (self classToBeTested includesSelector: #king).
+	self deny: (self classToBeTested allSelectors includes: #king).
+	self assert: (self classToBeTested protocolOfSelector: #king) isNil
+]
+
 { #category : #'tests - slots' }
 ClassDescriptionTest >> testSlotNamed [
 	self assert: (Point slotNamed: #x) name equals: #x

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -855,6 +855,17 @@ ClassDescription >> printOn: aStream [
 	aStream nextPutAll: self name
 ]
 
+{ #category : #'accessing - protocols' }
+ClassDescription >> protocolOfSelector: aSelector [
+	"I return the protocol of a given selector.
+	If the selector is in one of my superclass I still return its protocol.
+	If I do not include this selector, I return nil."
+
+	(self isLocalSelector: aSelector) ifTrue: [ ^ self organization protocolOfSelector: aSelector ].
+
+	^ self superclass ifNotNil: [ :superClass | superClass protocolOfSelector: aSelector ]
+]
+
 { #category : #compiling }
 ClassDescription >> reformatAll [
 	"Reformat all methods in this class"


### PR DESCRIPTION
In the current system we have ClassOrganization>>protocolNameOfElement:ifAbsent:. that includes a hack when a method is present in the class but is not in its protocols (and some logs I added on the CI suggest that this is used a lot to get the protocol of a method in a superclass). In that case it returns Protocol unclassified.

I wan to remove totally the use of the method anyway to just manipulate protocols and not protocol names. If someone need the name they can just call #name of the protocol.

In order to do two birds one stone, I suggest the addtion of #protocolOfSelector on class description directly. This method would return the protocol of the method even if it is in a super class. I might update this PR to start replacing the users of #protocolNameOfElement:ifAbsent: by this one