### PR TITLE
Remove ClassOrganization>>#silentlyRenameProtocolNamed:toBe: in favor of always announcing the rename

### DIFF
--- a/src/Deprecated12/ClassOrganization.extension.st
+++ b/src/Deprecated12/ClassOrganization.extension.st
@@ -105,7 +105,7 @@ ClassOrganization >> renameCategory: oldName toBe: newName [
 ClassOrganization >> silentlyRenameCategory: oldName toBe: newName [
 
 	self
-		deprecated: 'Use #renameProtocolNamed:toBe: instead.'
+		deprecated: 'Use #renameProtocolNamed:toBe: instead. Since Pharo12 it is not possible to not announce a protocol rename anymore because we should always announce those changes.'
 		transformWith: '`@rcv silentlyRenameCategory: `@arg1 toBe: `@arg2' -> '`@rcv renameProtocolNamed: `@arg1 toBe: `@arg2'.
 	self renameProtocolNamed: oldName toBe: newName
 ]

--- a/src/Deprecated12/ClassOrganization.extension.st
+++ b/src/Deprecated12/ClassOrganization.extension.st
@@ -105,7 +105,7 @@ ClassOrganization >> renameCategory: oldName toBe: newName [
 ClassOrganization >> silentlyRenameCategory: oldName toBe: newName [
 
 	self
-		deprecated: 'Use #silentlyRenameProtocolNamed:toBe: instead.'
-		transformWith: '`@rcv silentlyRenameCategory: `@arg1 toBe: `@arg2' -> '`@rcv silentlyRenameProtocolNamed: `@arg1 toBe: `@arg2'.
-	self silentlyRenameProtocolNamed: oldName toBe: newName
+		deprecated: 'Use #renameProtocolNamed:toBe: instead.'
+		transformWith: '`@rcv silentlyRenameCategory: `@arg1 toBe: `@arg2' -> '`@rcv renameProtocolNamed: `@arg1 toBe: `@arg2'.
+	self renameProtocolNamed: oldName toBe: newName
 ]

--- a/src/EpiceaBrowsers-Tests/EpApplyTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpApplyTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#category : #'EpiceaBrowsers-Tests-Integration'
 }
 
-{ #category : #tests }
+{ #category : #helpers }
 EpApplyTest >> applyInputEntry [
 
 	EpLogBrowserOperationFactory new
@@ -12,6 +12,12 @@ EpApplyTest >> applyInputEntry [
 		entries: { inputEntry };
 		errorHandlerBlock: [:error | error signal ];
 		applyCodeChanges
+]
+
+{ #category : #helpers }
+EpApplyTest >> organization [
+
+	^ self class environment organization
 ]
 
 { #category : #tests }
@@ -34,54 +40,101 @@ EpApplyTest >> testBehaviorNameChange [
 { #category : #tests }
 EpApplyTest >> testCategoryAdditionWithCategoryRemoved [
 
-	| organization aCategory |
-	organization := self class environment organization.
+	| aCategory |
 	aCategory := classFactory defaultCategory.
-	organization addCategory: aCategory.
+	self organization addCategory: aCategory.
 	self setHeadAsInputEntry.
-	organization removeCategory: aCategory.
+	self organization removeCategory: aCategory.
 
 	self assert: inputEntry content class equals: EpCategoryAddition.
-	self deny: (organization includesCategory: aCategory).
+	self deny: (self organization includesCategory: aCategory).
 	self applyInputEntry.
-	self assert: (organization includesCategory: aCategory)
+	self assert: (self organization includesCategory: aCategory)
 ]
 
 { #category : #tests }
 EpApplyTest >> testCategoryRemovalWithCategoryAdded [
 
-	| organization aCategory |
-	organization := self class environment organization.
+	| aCategory |
 	aCategory := classFactory defaultCategory.
-	organization addCategory: aCategory.
-	organization removeCategory: aCategory.
+	self organization addCategory: aCategory.
+	self organization removeCategory: aCategory.
 	self setHeadAsInputEntry.
-	organization addCategory: aCategory.
+	self organization addCategory: aCategory.
 
 	self assert: inputEntry content class equals: EpCategoryRemoval.
-	self assert: (organization includesCategory: aCategory).
+	self assert: (self organization includesCategory: aCategory).
 	self applyInputEntry.
-	self deny: (organization includesCategory: aCategory)
+	self deny: (self organization includesCategory: aCategory)
 ]
 
 { #category : #tests }
 EpApplyTest >> testCategoryRename [
 
-	| organization aCategory anotherCategory |
-	organization := self class environment organization.
+	| aCategory anotherCategory |
 	aCategory := classFactory defaultCategory.
 	anotherCategory := aCategory, '2'.
+	self organization addCategory: aCategory.
+	self organization renameCategory: aCategory toBe: anotherCategory.
+	self setHeadAsInputEntry.
+	self organization renameCategory: anotherCategory toBe: aCategory. "Rollback"
+
+	self assert: inputEntry content class equals: EpCategoryRename.
+	self assert: (self organization includesCategory: aCategory).
+	self deny: (self organization includesCategory: anotherCategory).
+	self applyInputEntry.
+	self deny: (self organization includesCategory: aCategory).
+	self assert: (self organization includesCategory: anotherCategory)
+]
+
+{ #category : #tests }
+EpApplyTest >> testCategoryRenameWithClass [
+	"Let's rename a package with a class and see if the class has the right package after."
+
+	| organization aCategory anotherCategory aClass |
+	organization := self class environment organization.
+	aCategory := classFactory defaultCategory.
+	anotherCategory := aCategory , '2'.
 	organization addCategory: aCategory.
+
+	aClass := classFactory newClass.
+	aClass category: aCategory.
+
 	organization renameCategory: aCategory toBe: anotherCategory.
 	self setHeadAsInputEntry.
+
 	organization renameCategory: anotherCategory toBe: aCategory. "Rollback"
 
 	self assert: inputEntry content class equals: EpCategoryRename.
-	self assert: (organization includesCategory: aCategory).
-	self deny: (organization includesCategory: anotherCategory).
+	self assert: aClass category equals: aCategory.
 	self applyInputEntry.
-	self deny: (organization includesCategory: aCategory).
-	self assert: (organization includesCategory: anotherCategory)
+	self assert: aClass category equals: anotherCategory
+]
+
+{ #category : #tests }
+EpApplyTest >> testCategoryRenameWithExtension [
+	"Let's rename a package with a class and see if the class has the right package after."
+
+	| organization aCategory anotherCategory aClass |
+	organization := self class environment organization.
+	aCategory := classFactory defaultCategory.
+	anotherCategory := aCategory , '2'.
+	organization addCategory: aCategory.
+
+	aClass := classFactory newClass.
+	aClass category: aCategory , '3'.
+	aClass compile: 'fortyTwo ^42' classified: '*' , aCategory.
+
+	organization renameCategory: aCategory toBe: anotherCategory.
+	self setHeadAsInputEntry.
+
+	self assert: (aClass >> #fortyTwo) protocol equals: '*' , anotherCategory.
+	organization renameCategory: anotherCategory toBe: aCategory. "Rollback"
+
+	self assert: inputEntry content class equals: EpCategoryRename.
+	self assert: (aClass >> #fortyTwo) protocol equals: '*' , aCategory.
+	self applyInputEntry.
+	self assert: (aClass >> #fortyTwo) protocol equals: '*' , anotherCategory
 ]
 
 { #category : #tests }

--- a/src/Gofer-Tests/GoferOperationTest.class.st
+++ b/src/Gofer-Tests/GoferOperationTest.class.st
@@ -90,8 +90,8 @@ GoferOperationTest >> testCleanup [
 	class class organization addProtocol: #empty.
 	gofer cleanup.
 	self deny: (Smalltalk organization categories includes: #'GoferFoo-Empty').
-	self deny: (class organization protocolNames includes: #'GoferFoo-Empty').
-	self deny: (class class organization protocolNames includes: #'GoferFoo-Empty')
+	self deny: (class organization hasProtocol: #'GoferFoo-Empty').
+	self deny: (class class organization hasProtocol: #'GoferFoo-Empty')
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -49,7 +49,7 @@ ClassOrganizationTest >> testAddProtocol [
 
 	self organization addProtocol: 'test-protocol'.
 
-	self assert: (self organization protocolNames includes: 'test-protocol')
+	self assert: (self organization hasProtocol: 'test-protocol')
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -94,3 +94,16 @@ ClassOrganizationTest >> testRemoveProtocolIfEmpty [
 	self assert: self organization protocolNames size equals: 1.
 	self assert: self organization protocolNames first equals: 'one'
 ]
+
+{ #category : #tests }
+ClassOrganizationTest >> testRenameProtocolNamedToBe [
+
+	self assert: (self organization hasProtocol: #one).
+	self deny: (self organization hasProtocol: #two).
+	self assertCollection: (self organization protocolNamed: #one) methodSelectors hasSameElements: #( 'one' ).
+	self organization renameProtocolNamed: #one toBe: #two.
+
+	self assert: (self organization hasProtocol: #two).
+	self deny: (self organization hasProtocol: #one).
+	self assertCollection: (self organization protocolNamed: #two) methodSelectors hasSameElements: #( 'one' ).
+]

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -326,13 +326,17 @@ ClassOrganization >> removeProtocolIfEmpty: aProtocol [
 { #category : #removing }
 ClassOrganization >> renameProtocolNamed: oldName toBe: newName [
 
-	(self hasProtocol: oldName) ifFalse: [ ^ self ].
-
-	self silentlyRenameProtocolNamed: oldName toBe: newName.
-
-	"Announce the changes in the system if the name changed"
 	oldName = newName ifTrue: [ ^ self ].
 
+	(self hasProtocol: oldName) ifFalse: [ ^ self ].
+
+	(self hasProtocol: newName)
+		ifTrue: [
+			self moveMethodsFrom: oldName to: newName.
+			self removeProtocolIfEmpty: oldName ]
+		ifFalse: [ (self protocolNamed: oldName) name: newName ].
+
+	"Announce the changes in the system"
 	self notifyOfChangedProtocolNamesFrom: oldName to: newName.
 	SystemAnnouncer announce: (ProtocolRenamed in: self organizedClass from: oldName to: newName).
 
@@ -350,21 +354,6 @@ ClassOrganization >> reset [
 ClassOrganization >> setSubject: anObject [
 
 	organizedClass := anObject
-]
-
-{ #category : #private }
-ClassOrganization >> silentlyRenameProtocolNamed: oldName toBe: newName [
-
-	(self hasProtocol: oldName) ifFalse: [ ^ self ].
-
-	(self hasProtocol: newName)
-		ifTrue: [
-			self moveMethodsFrom: oldName to: newName.
-			self removeProtocolIfEmpty: oldName ]
-		ifFalse: [
-			^ (self protocolNamed: oldName)
-				  name: newName;
-				  yourself ]
 ]
 
 { #category : #'backward compatibility' }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -965,7 +965,7 @@ RPackageOrganizer >> renamePackage: rPackage from: oldName to: newName [
 
 	"we also rename all the extension protocols in the system with the new name"
 	classesAndProtocolsToRename := rPackage extensionMethods asIdentitySet.
-	classesAndProtocolsToRename do: [ :method | method methodClass organization silentlyRenameProtocolNamed: method category toBe: '*' , newName ]
+	classesAndProtocolsToRename do: [ :method | method methodClass organization renameProtocolNamed: method category toBe: '*' , newName ]
 ]
 
 { #category : #private }

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -373,14 +373,14 @@ RPackageOrganizerTest >> testRegistrationExtendingPackages [
 ]
 
 { #category : #'tests - extensions' }
-RPackageOrganizerTest >> testSilentlyRenameProtocolNamedToBe [
+RPackageOrganizerTest >> testRenameProtocolNamedToBe [
 
 	| class |
 	class := self createNewClassNamed: #ClassForTestAboutSilentRecategorization inCategory: 'RPackage-Tests'.
 	class organization addProtocol: #foo.
 	self assert: (class organization protocolNames includes: #foo).
 	self deny: (class organization protocolNames includes: #bar).
-	class organization silentlyRenameProtocolNamed: #foo toBe: #bar.
+	class organization renameProtocolNamed: #foo toBe: #bar.
 
 	self assert: (class organization protocolNames includes: #bar).
 	self deny: (class organization protocolNames includes: #foo)

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -372,20 +372,6 @@ RPackageOrganizerTest >> testRegistrationExtendingPackages [
 	self assert: (self packageOrganizer extendingPackagesOf: self quadrangleClass) anyOne name equals: #GraphElement
 ]
 
-{ #category : #'tests - extensions' }
-RPackageOrganizerTest >> testRenameProtocolNamedToBe [
-
-	| class |
-	class := self createNewClassNamed: #ClassForTestAboutSilentRecategorization inCategory: 'RPackage-Tests'.
-	class organization addProtocol: #foo.
-	self assert: (class organization protocolNames includes: #foo).
-	self deny: (class organization protocolNames includes: #bar).
-	class organization renameProtocolNamed: #foo toBe: #bar.
-
-	self assert: (class organization protocolNames includes: #bar).
-	self deny: (class organization protocolNames includes: #foo)
-]
-
 { #category : #tests }
 RPackageOrganizerTest >> testTestPackageNames [
 

--- a/src/TraitsV2-Tests/TraitMethodDescriptionTest.class.st
+++ b/src/TraitsV2-Tests/TraitMethodDescriptionTest.class.st
@@ -36,7 +36,7 @@ TraitMethodDescriptionTest >> testCategories [
 	self t1 compile: 'mA' classified: #catA.
 	self assert: (self t4 organization protocolNameOfElement: #mA) equals: #catA.
 	self t1 organization classify: #mA under: #cat1.
-	self assert: (self t4 organization protocolNames includes: #catA) not
+	self assert: (self t4 organization hasProtocol: #catA) not
 ]
 
 { #category : #tests }
@@ -90,7 +90,7 @@ TraitMethodDescriptionTest >> testConflictingCategories [
 	self assert: (self t4 organization protocolNameOfElement: #m11) equals: #catX.
 	self assert: (self t5 organization protocolNameOfElement: #m11) equals: #catY.
 	self assert: (t7 organization protocolNameOfElement: #m11) equals: #catY.
-	self deny: (t7 organization protocolNames includes: Protocol traitConflictName).
+	self deny: (t7 organization hasProtocol: Protocol traitConflictName).
 	self t1 compile: 'm11' classified: #cat1.
 	t8 := self createTraitNamed: #T8 uses: self t1 + self t2.
 	t8 organization classify: #m11 under: #cat1.


### PR DESCRIPTION
When we rename a protocol we announce the change in the image so that some tools like Epicea can manage this change.  Currently when renaming a RPackage, the extension renaming is not announced because it uses a silent rename.

I'm trying to avoid silent actions with protocol so let's see if anything breaks if we announce the change.

Since Epicea is one of the main consumer of the meta model change announcements, I added some missing tests to check that my changes to not impact Epicea's behavior. 