### PR TITLE
Use {} instead of "Array with:" for some usages

### DIFF
--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -318,13 +318,13 @@ RBParser >> parseBinaryMessageWith: aNode [
 	| binaryNode |
 	binaryNode := self selectorNodeClass
 		value: currentToken value
-		keywordPositions: (Array with: currentToken start).
+		keywordPositions: { currentToken start }.
 	self step.
 	^self messageNodeClass
 		receiver: aNode
 		selector:  binaryNode
 		keywordsPositions: binaryNode keywordPositions
-		arguments: (Array with: self parseUnaryMessage)
+		arguments: { self parseUnaryMessage }
 ]
 
 { #category : #'private - parsing' }
@@ -1107,7 +1107,7 @@ RBParser >> parseUnaryMessage [
 { #category : #'private - parsing' }
 RBParser >> parseUnaryMessageWith: aNode [
 	| selector |
-	selector := self selectorNodeClass value: currentToken value keywordPositions: (Array with: currentToken start).
+	selector := self selectorNodeClass value: currentToken value keywordPositions: {currentToken start}.
 	self step.
 	^self messageNodeClass
 		receiver: aNode
@@ -1123,7 +1123,7 @@ RBParser >> parseUnaryPattern [
 	self step.
 	^self methodNodeClass
 		selector: selector value asSymbol
-		keywordsPositions: (Array with: selector start)
+		keywordsPositions: {selector start}
 		arguments: #()
 ]
 

--- a/src/Collections-Sequenceable/Array.class.st
+++ b/src/Collections-Sequenceable/Array.class.st
@@ -61,64 +61,6 @@ Array class >> braceStream: nElements [
 	^ WriteStream basicNew braceArray: (self new: nElements)
 ]
 
-{ #category : #'brace support' }
-Array class >> braceWith: a [
-	"This method is used in compilation of brace constructs.
-	It MUST NOT be deleted or altered."
-
-	| array |
-	array := self new: 1.
-	array at: 1 put: a.
-	^ array
-]
-
-{ #category : #'brace support' }
-Array class >> braceWith: a with: b [
-	"This method is used in compilation of brace constructs.
-	It MUST NOT be deleted or altered."
-
-	| array |
-	array := self new: 2.
-	array at: 1 put: a.
-	array at: 2 put: b.
-	^ array
-]
-
-{ #category : #'brace support' }
-Array class >> braceWith: a with: b with: c [
-	"This method is used in compilation of brace constructs.
-	It MUST NOT be deleted or altered."
-
-	| array |
-	array := self new: 3.
-	array at: 1 put: a.
-	array at: 2 put: b.
-	array at: 3 put: c.
-	^ array
-]
-
-{ #category : #'brace support' }
-Array class >> braceWith: a with: b with: c with: d [
-	"This method is used in compilation of brace constructs.
-	It MUST NOT be deleted or altered."
-
-	| array |
-	array := self new: 4.
-	array at: 1 put: a.
-	array at: 2 put: b.
-	array at: 3 put: c.
-	array at: 4 put: d.
-	^ array
-]
-
-{ #category : #'brace support' }
-Array class >> braceWithNone [
-	"This method is used in compilation of brace constructs.
-	It MUST NOT be deleted or altered."
-
-	^ self new: 0
-]
-
 { #category : #'instance creation' }
 Array class >> empty [
 	"A canonicalized empty Array instance."

--- a/src/Collections-Support/RunArray.class.st
+++ b/src/Collections-Support/RunArray.class.st
@@ -41,7 +41,7 @@ RunArray class >> new: size withAll: value [
 	argument, value."
 
 	size = 0 ifTrue: [^self new].
-	^self runs: (Array with: size) values: (Array with: value)
+	^self runs: { size } values: { value }
 ]
 
 { #category : #'instance creation' }
@@ -325,7 +325,7 @@ RunArray >> copyFrom: start to: stop [
 	self at: stop setRunOffsetAndValue: [:r :o :value2 | run2 := r. offset2 := o. value2].
 	run1 = run2
 		ifTrue:
-			[newRuns := Array with: offset2 - offset1 + 1]
+			[newRuns := { offset2 - offset1 + 1} ]
 		ifFalse:
 			[newRuns := runs copyFrom: run1 to: run2.
 			newRuns at: 1 put: (newRuns at: 1) - offset1.

--- a/src/Kernel/Rectangle.class.st
+++ b/src/Kernel/Rectangle.class.st
@@ -777,8 +777,10 @@ Rectangle >> quickMergePoint: aPoint [
 
 { #category : #'rectangle functions' }
 Rectangle >> rectanglesAt: y height: ht [
-	(y+ht) > self bottom ifTrue: [^ Array new].
-	^ Array with: (origin x @ y corner: corner x @ (y+ht))
+
+	^ y + ht > self bottom
+		  ifTrue: [ #(  ) ]
+		  ifFalse: [ { (origin x @ y corner: corner x @ (y + ht)) } ]
 ]
 
 { #category : #accessing }

--- a/src/MenuRegistration/PragmaMenuBuilder.class.st
+++ b/src/MenuRegistration/PragmaMenuBuilder.class.st
@@ -97,7 +97,7 @@ PragmaMenuBuilder class >> orderAssignBlock [
 { #category : #'instance creation' }
 PragmaMenuBuilder class >> pragmaKeyword: aPragmaKeyword model: aModel [
 	"Build a builder using aPragmaKeyword as the pragma keyword and aModel a the model of the resulting builder"
-	^ self withAllPragmaKeywords: (Array with: aPragmaKeyword) model: aModel
+	^ self withAllPragmaKeywords: {aPragmaKeyword} model: aModel
 ]
 
 { #category : #'instance creation' }

--- a/src/Monticello/Class.extension.st
+++ b/src/Monticello/Class.extension.st
@@ -48,5 +48,5 @@ Class >> asClassDefinition [
 
 { #category : #'*Monticello' }
 Class >> classDefinitions [
-	^ Array with: self asClassDefinition
+	^ { self asClassDefinition }
 ]

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -224,7 +224,7 @@ MCClassDefinition >> definitionString [
 
 { #category : #accessing }
 MCClassDefinition >> description [
-	^ Array with: name
+	^ { name }
 
 ]
 
@@ -456,14 +456,14 @@ MCClassDefinition >> printMetaDefinitionOn: stream [
 
 { #category : #comparing }
 MCClassDefinition >> provisions [
-	^ Array with: name
+	^ { name }
 ]
 
 { #category : #comparing }
 MCClassDefinition >> requirements [
 	^ ((superclassName == #nil) or: [superclassName asString beginsWith: 'AnObsolete'])
 		ifTrue: [self poolDictionaries]
-		ifFalse: [(Array with: superclassName), self poolDictionaries]
+		ifFalse: [{superclassName}, self poolDictionaries]
 ]
 
 { #category : #accessing }

--- a/src/Monticello/MCClassTraitDefinition.class.st
+++ b/src/Monticello/MCClassTraitDefinition.class.st
@@ -128,7 +128,7 @@ MCClassTraitDefinition >> printDefinitionOn: stream [
 
 { #category : #accessing }
 MCClassTraitDefinition >> requirements [
-	^Array with: baseTrait
+	^ { baseTrait }
 ]
 
 { #category : #accessing }

--- a/src/Monticello/MCMethodDefinition.class.st
+++ b/src/Monticello/MCMethodDefinition.class.st
@@ -337,7 +337,7 @@ MCMethodDefinition >> removeSelector: aSelector fromClass: aClass [
 
 { #category : #comparing }
 MCMethodDefinition >> requirements [
-	^ Array with: className
+	^ { className }
 ]
 
 { #category : #accessing }

--- a/src/Monticello/MCTraitDefinition.class.st
+++ b/src/Monticello/MCTraitDefinition.class.st
@@ -234,7 +234,7 @@ MCTraitDefinition >> requirements [
 	(and thus not a special character such as {, # etc.)"
 
 	self hasTraitComposition
-		ifFalse: [ ^ Array new ].
+		ifFalse: [ ^ #() ].
 
 	^ (((RBParser parseExpression: self traitCompositionString)
 		allChildren select: [ :e | e isVariable ])

--- a/src/MonticelloFileTree-Core/MCFileTreeStSnapshotWriter.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStSnapshotWriter.class.st
@@ -15,8 +15,8 @@ Class {
 
 { #category : #accessing }
 MCFileTreeStSnapshotWriter >> classDefinitions [
-    classDefinitions ifNil: [ classDefinitions := Dictionary new ].
-    ^ classDefinitions
+    ^ classDefinitions ifNil: [ classDefinitions := Dictionary new ]
+   
 ]
 
 { #category : #accessing }

--- a/src/Morphic-Base/Object.extension.st
+++ b/src/Morphic-Base/Object.extension.st
@@ -117,18 +117,18 @@ Object class >> taskbarIcon [
 ]
 
 { #category : #'*Morphic-Base' }
+Object class >> taskbarIconName [
+	"Answer the icon for an instance of the receiver in a task bar"
+
+	^#smallWindow
+]
+
+{ #category : #'*Morphic-Base' }
 Object >> taskbarIconName [
 	"Answer the icon for the receiver in a task bar
 	or nil for the default."
 
 	^self class taskbarIconName
-]
-
-{ #category : #'*Morphic-Base' }
-Object class >> taskbarIconName [
-	"Answer the icon for an instance of the receiver in a task bar"
-
-	^#smallWindow
 ]
 
 { #category : #'*Morphic-Base' }

--- a/src/Morphic-Base/TextContainer.class.st
+++ b/src/Morphic-Base/TextContainer.class.st
@@ -122,7 +122,7 @@ TextContainer >> rectanglesAt: lineY height: lineHeight [
 	Cache the results for later retrieval if the owner does not change."
 
 	| hProfile rects thisWidth thisX count pair outerWidth lineRect lineForm |
-	pair := Array with: lineY with: lineHeight.
+	pair := { lineY . lineHeight }.
 	rects := rectangleCache at: pair ifAbsent: [nil].
 	rects ifNotNil: [^rects].
 	outerWidth := minWidth + (2 * OuterMargin).
@@ -132,9 +132,9 @@ TextContainer >> rectanglesAt: lineY height: lineHeight [
 	lineForm := shadowForm copy: lineRect.
 
 	"Check for a full line -- frequent case"
-	(lineForm tallyPixelValues second) = lineRect area
+	lineForm tallyPixelValues second = lineRect area
 		ifTrue:
-			[rects := Array with: (shadowForm offset x @ lineY extent: lineRect extent)]
+			[rects := {shadowForm offset x @ lineY extent: lineRect extent}]
 		ifFalse:
 			["No such luck -- scan the horizontal profile for segments of minWidth"
 

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -4892,7 +4892,7 @@ Morph >> privateAddMorph: aMorph atIndex: index [
 					oldOwner privateRemove: aMorph.
 					oldOwner removedMorph: aMorph ].
 			aMorph privateOwner: self.
-			submorphs := submorphs copyReplaceFrom: index to: index - 1 with: (Array with: aMorph).
+			submorphs := submorphs copyReplaceFrom: index to: index - 1 with: { aMorph } .
 			itsWorld == myWorld
 				ifFalse: [ aMorph intoWorld: myWorld ] ].
 	myWorld ifNotNil: [ self privateInvalidateMorph: aMorph ].

--- a/src/Polymorph-Widgets/SystemWindow.extension.st
+++ b/src/Polymorph-Widgets/SystemWindow.extension.st
@@ -159,7 +159,7 @@ SystemWindow >> addMorph: aMorph fullFrame: aLayoutFrame [
 
 	super addMorph: aMorph fullFrame: frame.
 
-	paneMorphs := paneMorphs copyReplaceFrom: 1 to: 0 with: (Array with: aMorph).
+	paneMorphs := paneMorphs copyReplaceFrom: 1 to: 0 with: {aMorph}.
 	"aMorph adoptPaneColor: self paneColor."
 	aMorph
 		borderStyle: (self theme windowPaneBorderStyleFor: aMorph in: self).

--- a/src/Rubric/RubParagraph.class.st
+++ b/src/Rubric/RubParagraph.class.st
@@ -192,7 +192,7 @@ RubParagraph >> defaultCharacterBlock [
 
 { #category : #private }
 RubParagraph >> defaultEmptyText [
-	^ Text string: '' attributes: (Array with: self defaultFontChange)
+	^ Text string: '' attributes: { self defaultFontChange }
 ]
 
 { #category : #private }
@@ -562,7 +562,7 @@ RubParagraph >> selectionRectsFrom: characterBlock1 to: characterBlock2 [
 	line1 := self lineIndexOfCharacterIndex: cb1 stringIndex.
 	line2 := self lineIndexOfCharacterIndex: cb2 stringIndex.
 	line1 = line2
-		ifTrue: [ ^ Array with: (cb1 topLeft corner: cb2 bottomRight) ].
+		ifTrue: [ ^ {cb1 topLeft corner: cb2 bottomRight} ].
 	^ Array
 		streamContents: [ :strm |
 			| last |

--- a/src/Text-Core/Text.class.st
+++ b/src/Text-Core/Text.class.st
@@ -211,11 +211,9 @@ Text >> attributesAt: characterIndex do: aBlock [
 { #category : #emphasis }
 Text >> attributesAt: characterIndex forStyle: aTextStyle [
 	"Answer the code for characters in the run beginning at characterIndex."
-	| attributes |
 	self size = 0
-		ifTrue: [^ Array with: (TextFontChange new fontNumber: aTextStyle defaultFontIndex)].  "null text tolerates access"
-	attributes := runs at: characterIndex.
-	^ attributes
+		ifTrue: [^ {TextFontChange new fontNumber: aTextStyle defaultFontIndex}].  "null text tolerates access"
+	^ runs at: characterIndex
 ]
 
 { #category : #copying }


### PR DESCRIPTION
- remove unused #braceWith: methods (the compiler does not create code with those anymore)

- replace some "Array with:" with {} that are called during normal use
	- faster
	- simpler 
	
{} is faster than "Array with:", but of course this will not lead to any noticalble speedup