### PR TITLE
use and expression instead of ifTrueifFalse

### DIFF
--- a/src/Rubric/RubCharacterBlock.class.st
+++ b/src/Rubric/RubCharacterBlock.class.st
@@ -28,8 +28,7 @@ RubCharacterBlock >> <= aCharacterBlock [
 { #category : #comparing }
 RubCharacterBlock >> = aCharacterBlock [
 	^ self species = aCharacterBlock species
-		ifTrue: [ stringIndex = aCharacterBlock stringIndex ]
-		ifFalse: [ false ]
+		and: [ stringIndex = aCharacterBlock stringIndex ]
 ]
 
 { #category : #comparing }

--- a/src/Rubric/RubTextLine.class.st
+++ b/src/Rubric/RubTextLine.class.st
@@ -36,8 +36,7 @@ RubTextLine class >> start: startInteger stop: stopInteger internalSpaces: space
 { #category : #comparing }
 RubTextLine >> = line [
 	^ self species = line species
-		ifTrue: [ ((firstIndex = line first and: [ lastIndex = line last ]) and: [ internalSpaces = line internalSpaces ]) and: [ paddingWidth = line paddingWidth ] ]
-		ifFalse: [ false ]
+		and: [ firstIndex = line first and: [ lastIndex = line last and: [ internalSpaces = line internalSpaces and: [ paddingWidth = line paddingWidth ] ] ] ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
use and: expression instead of ifTrue:ifFalse: in Rubric. also better nested and: expression.
fix: #13462 
