### PR TITLE
Deprecate comment management of ClassOrganization

### DIFF
--- a/src/Deprecated12/ClassOrganization.extension.st
+++ b/src/Deprecated12/ClassOrganization.extension.st
@@ -79,6 +79,46 @@ ClassOrganization >> comment: aString [
 ]
 
 { #category : #'*Deprecated12' }
+ClassOrganization >> commentSourcePointer [
+
+	self
+		deprecated: 'The organization is not responsible for the class comment anymore. Ask the comment to the class directly.'
+		on: '18 April 2023'
+		in: 'Pharo-12.0.0+build.183.sha.cf9b49f2a83f05bb9f02ac5831035d1bda76a14a (64 Bit)'.
+	^ organizedClass commentSourcePointer
+]
+
+{ #category : #'*Deprecated12' }
+ClassOrganization >> commentSourcePointer: anObject [
+
+	self
+		deprecated: 'The organization is not responsible for the class comment anymore. Ask the comment to the class directly.'
+		on: '18 April 2023'
+		in: 'Pharo-12.0.0+build.183.sha.cf9b49f2a83f05bb9f02ac5831035d1bda76a14a (64 Bit)'.
+	organizedClass commentSourcePointer: anObject
+]
+
+{ #category : #'*Deprecated12' }
+ClassOrganization >> commentStamp [
+
+	self
+		deprecated: 'The organization is not responsible for the class comment anymore. Ask the comment to the class directly.'
+		on: '18 April 2023'
+		in: 'Pharo-12.0.0+build.183.sha.cf9b49f2a83f05bb9f02ac5831035d1bda76a14a (64 Bit)'.
+	^ organizedClass commentStamp
+]
+
+{ #category : #'*Deprecated12' }
+ClassOrganization >> hasComment [
+
+	self
+		deprecated: 'The organization is not responsible for the class comment anymore. Ask the comment to the class directly.'
+		on: '18 April 2023'
+		in: 'Pharo-12.0.0+build.183.sha.cf9b49f2a83f05bb9f02ac5831035d1bda76a14a (64 Bit)'.
+	^ organizedClass hasComment
+]
+
+{ #category : #'*Deprecated12' }
 ClassOrganization >> listAtCategoryNamed: aName [
 
 	self deprecated: 'Use #methodsInProtocolNamed: instead.' transformWith: '`@rcv listAtCategoryNamed: `@arg' -> '`@rcv methodSelectorsInProtocol: `@arg'.
@@ -149,4 +189,11 @@ ClassOrganization >> silentlyRenameCategory: oldName toBe: newName [
 		deprecated: 'Use #renameProtocolNamed:toBe: instead. Since Pharo12 it is not possible to not announce a protocol rename anymore because we should always announce those changes.'
 		transformWith: '`@rcv silentlyRenameCategory: `@arg1 toBe: `@arg2' -> '`@rcv renameProtocolNamed: `@arg1 toBe: `@arg2'.
 	self renameProtocolNamed: oldName toBe: newName
+]
+
+{ #category : #'*Deprecated12' }
+ClassOrganization >> subject [
+
+	self deprecated: 'Use #organizedClass instead.' transformWith: '`@rcv subject' -> '`@rcv organizedClass'.
+	^ self organizedClass
 ]

--- a/src/Deprecated12/ClassOrganization.extension.st
+++ b/src/Deprecated12/ClassOrganization.extension.st
@@ -38,6 +38,47 @@ ClassOrganization >> categoryOfElement: aSelector ifAbsent: aBlock [
 ]
 
 { #category : #'*Deprecated12' }
+ClassOrganization >> classComment [
+
+	self
+		deprecated: 'The organization is not responsible for the class comment anymore. Ask the comment to the class directly.'
+		on: '18 April 2023'
+		in: 'Pharo-12.0.0+build.183.sha.cf9b49f2a83f05bb9f02ac5831035d1bda76a14a (64 Bit)'.
+
+	^ self comment
+]
+
+{ #category : #'*Deprecated12' }
+ClassOrganization >> classComment: aString [
+
+	self
+		deprecated: 'The organization is not responsible for the class comment anymore. Ask the comment to the class directly.'
+		on: '18 April 2023'
+		in: 'Pharo-12.0.0+build.183.sha.cf9b49f2a83f05bb9f02ac5831035d1bda76a14a (64 Bit)'.
+	self comment: aString
+]
+
+{ #category : #'*Deprecated12' }
+ClassOrganization >> comment [
+
+	self
+		deprecated: 'The organization is not responsible for the class comment anymore. Ask the comment to the class directly.'
+		on: '18 April 2023'
+		in: 'Pharo-12.0.0+build.183.sha.cf9b49f2a83f05bb9f02ac5831035d1bda76a14a (64 Bit)'.
+	^ organizedClass comment
+]
+
+{ #category : #'*Deprecated12' }
+ClassOrganization >> comment: aString [
+
+	self
+		deprecated: 'The organization is not responsible for the class comment anymore. Ask the comment to the class directly.'
+		on: '18 April 2023'
+		in: 'Pharo-12.0.0+build.183.sha.cf9b49f2a83f05bb9f02ac5831035d1bda76a14a (64 Bit)'.
+	organizedClass comment: aString
+]
+
+{ #category : #'*Deprecated12' }
 ClassOrganization >> listAtCategoryNamed: aName [
 
 	self deprecated: 'Use #methodsInProtocolNamed: instead.' transformWith: '`@rcv listAtCategoryNamed: `@arg' -> '`@rcv methodSelectorsInProtocol: `@arg'.

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -337,7 +337,7 @@ ClassDescription >> commentStamp [
 { #category : #'file in/out' }
 ClassDescription >> commentStamp: changeStamp [
 	"update the changeStamp"
-	self comment: self instanceSide organization comment stamp: changeStamp
+	self comment: self instanceSide comment stamp: changeStamp
 ]
 
 { #category : #compiling }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -85,22 +85,6 @@ ClassOrganization >> cleanUpProtocolsForClass: aClass [
 	self allMethodSelectors do: [ :each | (aClass includesSelector: each) ifFalse: [ self removeElement: each ] ]
 ]
 
-{ #category : #accessing }
-ClassOrganization >> commentSourcePointer [
-	^ organizedClass commentSourcePointer
-]
-
-{ #category : #accessing }
-ClassOrganization >> commentSourcePointer: anObject [
-	organizedClass commentSourcePointer: anObject
-]
-
-{ #category : #accessing }
-ClassOrganization >> commentStamp [
-
-	^ organizedClass commentStamp
-]
-
 { #category : #copying }
 ClassOrganization >> copyFrom: otherOrganization [
 
@@ -127,11 +111,6 @@ ClassOrganization >> ensureProtocol: aProtocol [
 { #category : #accessing }
 ClassOrganization >> extensionProtocols [
 	^ self protocols select: #isExtensionProtocol
-]
-
-{ #category : #testing }
-ClassOrganization >> hasComment [
-	^ organizedClass hasComment
 ]
 
 { #category : #testing }
@@ -331,11 +310,4 @@ ClassOrganization >> reset [
 ClassOrganization >> setSubject: anObject [
 
 	organizedClass := anObject
-]
-
-{ #category : #'backward compatibility' }
-ClassOrganization >> subject [
-
-	self deprecated: 'Use #organizedClass instead.' transformWith: '`@rcv subject' -> '`@rcv organizedClass'.
-	^ self organizedClass
 ]

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -43,18 +43,6 @@ ClassOrganization >> allMethodSelectors [
 	^ self protocols flatCollect: [ :p | p methodSelectors ]
 ]
 
-{ #category : #'backward compatibility' }
-ClassOrganization >> classComment [
-
-	^ self comment
-]
-
-{ #category : #'backward compatibility' }
-ClassOrganization >> classComment: aString [
-
-	self comment: aString
-]
-
 { #category : #'protocol - adding' }
 ClassOrganization >> classify: aSymbol inProtocolNamed: aProtocolName [
 
@@ -95,17 +83,6 @@ ClassOrganization >> cleanUpProtocolsForClass: aClass [
 	"remove all entries that have no methods"
 
 	self allMethodSelectors do: [ :each | (aClass includesSelector: each) ifFalse: [ self removeElement: each ] ]
-]
-
-{ #category : #accessing }
-ClassOrganization >> comment [
-
-	^ organizedClass comment
-]
-
-{ #category : #accessing }
-ClassOrganization >> comment: aString [
-	organizedClass comment: aString
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
I'm trying to check what is the minimal set of methods really needed in ClassOrganization with the goal of inlining it in the near future un ClassDescription. So I'm deprecating the methods that are already not used anymore in the system.