### PR TITLE
Fix bug in parenthesis highlight

### DIFF
--- a/src/Shout-Tests/SHRBStyleAttributionTest.class.st
+++ b/src/Shout-Tests/SHRBStyleAttributionTest.class.st
@@ -580,6 +580,22 @@ SHRBStyleAttributionTest >> testParenthesisStyle [
 ]
 
 { #category : #tests }
+SHRBStyleAttributionTest >> testParenthesisSurroundingVar [
+
+	| aText |
+	aText := 'm |var| ^ (var)' asText.
+	self style: aText.
+
+	self assertStyleOf: aText at: 11 shouldBe: #parenthesis.
+	self
+		assertStyleOf: aText
+		between: 12
+		and: 14
+		shouldBe: #tempVar.
+	self assertStyleOf: aText at: 15 shouldBe: #parenthesis
+]
+
+{ #category : #tests }
 SHRBStyleAttributionTest >> testPatternArgStyle [
 
 	| aText |

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -622,18 +622,14 @@ SHRBTextStyler >> addASTTransformationPlugin: aPlugin [
 
 { #category : #formatting }
 SHRBTextStyler >> addAttributes: attributes forNode: anRBNode [
-	self
-		addAttributes: attributes
-		from: anRBNode start
-		to: anRBNode stop
+
+	self addAttributes: attributes from: anRBNode startWithoutParentheses to: anRBNode stopWithoutParentheses
 ]
 
 { #category : #formatting }
 SHRBTextStyler >> addAttributes: attributes from: start to: stop [
-	charAttr
-		from: (start max: 1)
-		to: (stop min: charAttr size)
-		put: attributes
+
+	charAttr from: (start max: 1) to: (stop min: charAttr size) put: attributes
 ]
 
 { #category : #converting }
@@ -903,6 +899,14 @@ SHRBTextStyler >> styleOpenParenthese: aMessageNode [
 					parentheseLevel := parentheseLevel + 1 ]]
 ]
 
+{ #category : #visiting }
+SHRBTextStyler >> styleParenthesisOf: aNode around: aBlock [
+
+	self styleOpenParenthese: aNode.
+	aBlock value.
+	self styleCloseParenthese: aNode
+]
+
 { #category : #private }
 SHRBTextStyler >> styleTempBars: aSequenceNode [
 	| tempBarAttribute |
@@ -1020,29 +1024,25 @@ SHRBTextStyler >> visitLiteralValueNode: aLiteralValueNode [
 
 { #category : #visiting }
 SHRBTextStyler >> visitMessageNode: aMessageNode [
-	| style link |
 
+	| style link |
 	style := aMessageNode selector isSelectorSymbol
-		ifTrue: [ #selector ]
-		ifFalse: [ self formatIncompleteSelector: aMessageNode ].
+		         ifTrue: [ #selector ]
+		         ifFalse: [ self formatIncompleteSelector: aMessageNode ].
 
 	link := TextMethodLink sourceNode: aMessageNode.
-	self styleOpenParenthese: aMessageNode.
 
-	aMessageNode selectorParts
-		with: aMessageNode keywordsPositions
-		do: [ :keyword :position |
+	self styleParenthesisOf: aMessageNode around: [
+		aMessageNode selectorParts with: aMessageNode keywordsPositions do: [ :keyword :position |
 			self
 				addStyle: style
 				attribute: link
 				from: position
 				to: position + keyword size - 1 ].
 
-	(aMessageNode isCascaded not or: [ aMessageNode isFirstCascaded ])
-		ifTrue: [ self visitNode: aMessageNode receiver ].
+		(aMessageNode isCascaded not or: [ aMessageNode isFirstCascaded ]) ifTrue: [ self visitNode: aMessageNode receiver ].
 
-	aMessageNode arguments do: [ :each | self visitNode: each ].
-	self styleCloseParenthese: aMessageNode
+		aMessageNode arguments do: [ :each | self visitNode: each ] ]
 ]
 
 { #category : #visiting }
@@ -1111,9 +1111,9 @@ SHRBTextStyler >> visitSequenceNode: aSequenceNode [
 { #category : #visiting }
 SHRBTextStyler >> visitVariableNode: aVariableNode [
 
-	self addStyle: (self resolveStyleFor: aVariableNode) attributes: (self resolveVariableAttributesFor: aVariableNode) forNode: aVariableNode.
-
-	self visitCommentNodes: aVariableNode
+	self styleParenthesisOf: aVariableNode around: [
+		self addStyle: (self resolveStyleFor: aVariableNode) attributes: (self resolveVariableAttributesFor: aVariableNode) forNode: aVariableNode.
+		self visitCommentNodes: aVariableNode ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
In case we had parenthesis around a variable node, the style was wrong.  This fixes the problem and adds a regression bug. 

I think we might have the same problem for other nodes too. 

I think we should add #visitValueNode: to the RB visitor so that we can manage it there directly for all nodes with parenthesis.