### PR TITLE
Debug can recompile doit and uninstalled method

### DIFF
--- a/src/Debugger-Model-Tests/RecompileTest.class.st
+++ b/src/Debugger-Model-Tests/RecompileTest.class.st
@@ -1,0 +1,112 @@
+Class {
+	#name : #RecompileTest,
+	#superclass : #DebuggerTest,
+	#category : #'Debugger-Model-Tests-Core'
+}
+
+{ #category : #tests }
+RecompileTest >> testRecompileDoIt [
+
+	| method node |
+	method := nil compiler
+		          noPattern: true;
+		          compile: '| a | a := 42'.
+	self settingUpSessionAndProcessAndContextForBlock: [
+		nil executeMethod: method ].
+	[ session interruptedContext compiledCode = method ] whileFalse: [
+		session stepInto ].
+
+	node := method sourceNodeForPC: session interruptedContext pc.
+	self assert: node isAssignment.
+	self assert: node variable name equals: #a.
+
+	session stepOver.
+	self assert: (session interruptedContext tempNamed: #a) equals: 42.
+
+	session
+		recompileMethodTo: '|c| c := 43'
+		inContext: session interruptedContext
+		notifying: nil.
+	method := session interruptedContext method.
+
+	node := method sourceNodeForPC: session interruptedContext pc.
+	self assert: node isAssignment.
+	self assert: node variable name equals: #c.
+	self assert: (session interruptedContext tempNamed: #c) equals: nil.
+
+	session stepOver.
+	self assert: (session interruptedContext tempNamed: #c) equals: 43
+]
+
+{ #category : #tests }
+RecompileTest >> testRecompileInstalled [
+
+	| method node |
+	method := self class compiler install: 'foo | a | a := 42'.
+	self
+		assert: (self class >> #foo) sourceCode
+		equals: 'foo | a | a := 42'.
+
+	self settingUpSessionAndProcessAndContextForBlock: [
+		nil executeMethod: method ].
+	[ session interruptedContext compiledCode = method ] whileFalse: [
+		session stepInto ].
+
+	node := method sourceNodeForPC: session interruptedContext pc.
+	self assert: node isAssignment.
+	self assert: node variable name equals: #a.
+
+	session stepOver.
+	self assert: (session interruptedContext tempNamed: #a) equals: 42.
+
+	session
+		recompileMethodTo: 'foo | c | c := 43'
+		inContext: session interruptedContext
+		notifying: nil.
+	method := session interruptedContext method.
+
+	node := method sourceNodeForPC: session interruptedContext pc.
+	self assert: node isAssignment.
+	self assert: node variable name equals: #c.
+	self assert: (session interruptedContext tempNamed: #c) equals: nil.
+
+	session stepOver.
+	self assert: (session interruptedContext tempNamed: #c) equals: 43.
+
+	self
+		assert: (self class >> #foo) sourceCode
+		equals: 'foo | c | c := 43'.
+	(self class >> #foo) removeFromSystem
+]
+
+{ #category : #tests }
+RecompileTest >> testRecompileUninstalled [
+
+	| method node |
+	method := self class compiler compile: 'foo | a | a := 42'.
+	self settingUpSessionAndProcessAndContextForBlock: [
+		nil executeMethod: method ].
+	[ session interruptedContext compiledCode = method ] whileFalse: [
+		session stepInto ].
+
+	node := method sourceNodeForPC: session interruptedContext pc.
+	self assert: node isAssignment.
+	self assert: node variable name equals: #a.
+
+	session stepOver.
+	self assert: (session interruptedContext tempNamed: #a) equals: 42.
+
+	session
+		recompileMethodTo: 'foo | c | c := 43'
+		inContext: session interruptedContext
+		notifying: nil.
+	method := session interruptedContext method.
+
+	node := method sourceNodeForPC: session interruptedContext pc.
+	self assert: node isAssignment.
+	self assert: node variable name equals: #c.
+	self assert: (session interruptedContext tempNamed: #c) equals: nil.
+
+	session stepOver.
+	self assert: (session interruptedContext tempNamed: #c) equals: 43
+]

--- a/src/Debugger-Model-Tests/StepIntoTest.class.st
+++ b/src/Debugger-Model-Tests/StepIntoTest.class.st
@@ -38,6 +38,48 @@ StepIntoTest >> testStepIntoDeadContext [
 ]
 
 { #category : #tests }
+StepIntoTest >> testStepIntoDoIt [
+
+	| method node |
+	method := nil compiler
+		          noPattern: true;
+		          compile: '| a b | a := 40. b := a + 2. ^ b'.
+	self settingUpSessionAndProcessAndContextForBlock: [
+		nil executeMethod: method ].
+	[ session interruptedContext compiledCode = method ] whileFalse: [
+		session stepInto ].
+
+	node := method sourceNodeForPC: session interruptedContext pc.
+	self assert: node isAssignment.
+	self assert: node variable name equals: #a.
+
+	session stepInto.
+
+	node := method sourceNodeForPC: session interruptedContext pc.
+	self assert: node isMessage.
+	self assert: node selector equals: #+.
+
+	session stepInto.
+
+	node := method sourceNodeForPC: session interruptedContext pc.
+	self assert: node isAssignment.
+	self assert: node variable name equals: #b.
+
+	session stepInto.
+
+	node := method sourceNodeForPC: session interruptedContext pc.
+	self assert: node isReturn.
+
+	session stepInto.
+
+	self deny: session interruptedContext method equals: method.
+
+	[ session interruptedProcess isTerminated ] whileFalse: [
+		session stepInto ].
+	self assert: session interruptedProcess isTerminated
+]
+
+{ #category : #tests }
 StepIntoTest >> testStepIntoMethodCallShouldActivateIt [
 	"Stepping into a method call should create a context for it at the top of the context stack"
 	self settingUpSessionAndProcessAndContextForBlock: [ self stepA1 ].

--- a/src/Debugger-Model/DebugContext.class.st
+++ b/src/Debugger-Model/DebugContext.class.st
@@ -149,18 +149,27 @@ DebugContext >> receiverClass [
 DebugContext >> recompileCurrentMethodTo: aText notifying: aNotifyer [
 	| classOrTraitOfMethod selector |
 
-	selector := self selectedClass compiler parseSelector: aText.
-	(self checkSelectorUnchanged: selector) ifFalse: [ ^ nil ].
+	self context method isDoIt ifFalse: [
+		selector := self selectedClass compiler parseSelector: aText.
+		(self checkSelectorUnchanged: selector) ifFalse: [ ^ nil ] ].
+
+	self context method isInstalled ifFalse: [
+		^ self selectedClass compiler
+			protocol: self selectedMessageCategoryName;
+			noPattern: self selectedMessageName isDoIt;
+			requestor: aNotifyer;
+			compile: aText.
+	].
+	
 	classOrTraitOfMethod := self confirmOnTraitOverwrite: selector inClass: self selectedClass.
+	classOrTraitOfMethod ifNil:[ ^ nil] .
 
-	classOrTraitOfMethod ifNil:[ ^ nil].
+	^ classOrTraitOfMethod compiler
+		protocol: self selectedMessageCategoryName;
+		noPattern: self selectedMessageName isDoIt;
+		requestor: aNotifyer;
+		install: aText.
 
-	selector := classOrTraitOfMethod
-		compile: aText
-		classified: self selectedMessageCategoryName
-		notifying: aNotifyer.
-	^ selector
-		ifNotNil: [ classOrTraitOfMethod compiledMethodAt: selector ]
 ]
 
 { #category : #accessing }

--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -306,10 +306,6 @@ DebugSession >> recompileMethodTo: text inContext: aContext notifying: aNotifyer
 
 	| newMethod recompilationContext canRewind |
 	canRewind := (self isContextPostMortem: self interruptedContext) not.
-	"Do not try to recompile a doIt method"
-	aContext method isDoIt
-		ifTrue: [ UIManager default alert:  'Can not modify a DoIt-Method.'.
-			^ false ].
 	(recompilationContext := (self createModelForContext: aContext) locateClosureHomeWithContent: text) ifNil: [ ^ false ].
 	canRewind
 		ifFalse: [ (self confirm: 'Can not rewind post mortem context for new method.\ Accept anyway ?' withCRs) or: [ ^ false ] ].


### PR DESCRIPTION
The debugger prevents you to recompile doit method.
And crash when you recompile an uninstalled method.

Fix #12931

Note: methods from Debugger-Model do some GUI interventions: inform, confirm, menu.
That is not really "modely", and make testing more difficult.