### PR TITLE
Kill VariableNotDeclared

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -336,12 +336,14 @@ RBCodeSnippet class >> badExpressions [
 		        (self new
 			         source: 'a | ';
 			         nodeAt: '1000';
+			         raise: UndeclaredVariableRead;
 			         notices:
 				         #( #( 1 1 1 'Undeclared variable' )
 				            #( 5 4 5 'Variable or expression expected' ) )).
 		        (self new
 			         source: 'a || ';
 			         nodeAt: '10000';
+			         raise: UndeclaredVariableRead;
 			         notices:
 				         #( #( 1 1 1 'Undeclared variable' )
 				            #( 6 5 6 'Variable or expression expected' ) )).
@@ -847,6 +849,7 @@ RBCodeSnippet class >> badMethods [
 		        (self new
 			         source: 'foo < bar: baz > ';
 			         nodeAt: '00002222222666555';
+			         raise: UndeclaredVariableRead;
 			         notices: #( #( 12 11 12 'Literal constant expected' )
 				            #( 5 11 12 '''>'' expected' )
 				            #( 12 14 12 'Undeclared variable' )

--- a/src/Kernel/UndefinedObject.class.st
+++ b/src/Kernel/UndefinedObject.class.st
@@ -93,48 +93,11 @@ UndefinedObject >> deepCopy [
 	with self."
 ]
 
-{ #category : #'reflective operations' }
-UndefinedObject >> doesNotUnderstand: aMessage [
-
-	"Handle the fact that there was an attempt to send the given message to an Undeclared variable (nil), hence the receiver does not understand this message (typically #new)."
-
-	"Testing: (nil activeProcess)"
-
-	<debuggerCompleteToSender>
-	| exception resumeValue node |
-	[
-	node := self findUndeclaredVariableIn:
-		        thisContext outerContext sender sourceNodeExecuted ] onErrorDo: [ :ex |
-				"This is ugly, but we have a dependency with Opal compiler and
-				it should be extracted. If there is a failure during the bootstrap, this
-				dependency produces an infinite loop"
-		 ].
-	node ifNil: [ ^ super doesNotUnderstand: aMessage ].
-
-	(exception := VariableNotDeclared new)
-		message: aMessage;
-		variableNode: node;
-		receiver: self.
-
-	resumeValue := exception signal.
-	^ exception reachedDefaultHandler
-		  ifTrue: [ aMessage sentTo: self ]
-		  ifFalse: [ resumeValue ]
-]
-
 { #category : #'class hierarchy' }
 UndefinedObject >> environment [
 	"Necessary to support disjoint class hierarchies."
 
 	^self class environment
-]
-
-{ #category : #'reflective operations' }
-UndefinedObject >> findUndeclaredVariableIn: ast [
-	"Walk the ast of the current statment and find the undeclared variable node, or nil (if none).
-	Assumes there is only one such variable in an executing statement"
-
-	^ast variableNodes detect: [:node | node isUndeclaredVariable] ifNone: [ nil ]
 ]
 
 { #category : #testing }

--- a/src/Kernel/VariableNotDeclared.class.st
+++ b/src/Kernel/VariableNotDeclared.class.st
@@ -10,6 +10,11 @@ Class {
 	#category : #'Kernel-Exceptions'
 }
 
+{ #category : #testing }
+VariableNotDeclared class >> isDeprecated [
+	^true
+]
+
 { #category : #accessing }
 VariableNotDeclared >> classSymbol [
 	^ self variableNode name

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -744,20 +744,7 @@ OCASTTranslator >> visitVariableNode: aVariableNode [
 
 	"Because we are producing a CompiledMethod, register undeclared variables to `Undeclared`"
 	aVariableNode variable isUndeclaredVariable ifTrue: [
-		aVariableNode variable register.
-
-		(aVariableNode parent isMessage and: [ aVariableNode parent receiver == aVariableNode ]) ifTrue: [ 
-			"Let's try to hack a hack!
-			StDebugger expects some `VariableNotDeclared` (badly named class) when a message
-			is send to a `nil` that comes from an undeclared variable (awful fragile heuristics are used).
-			To be compatible, we can either emulate the hack (that seems to be very ugly and complex),
-			or we can just compile the undelared variable used as a receiver as a literal read.
-			Therefore, if the variable become declared, the emmited code is compatible, and if
-			the variable is still undeclared at runtime, then `nil` from an undeclared is used and
-			the debugger is fooled.
-			Once the debugger learn to deal with `UndeclaredVariableRead`, this hack can be removed."
-			methodBuilder pushLiteralVariable: aVariableNode variable.
-			^ self ] ].
+		aVariableNode variable register ].
 
 	aVariableNode variable emitValue: methodBuilder
 ]


### PR DESCRIPTION
Require: #13470 and https://github.com/pharo-spec/NewTools/pull/508

When introducing #13238, a special case was added to be compatible with the StDebugger that expected VariableNotDeclared. This exception was used because of the absence of specific runtime errors on undeclared variable accesses.