### PR TITLE
Compiler: explicit the need of requestor scope

### DIFF
--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -501,6 +501,17 @@ CompilationContext >> interactive [
 		  ifFalse: [ true ]
 ]
 
+{ #category : #testing }
+CompilationContext >> needRequestorScope [
+	"The requestor scope allows the requestor to bind exsiting and new variables, like worspaces variables.
+	Modern requestors should not register temselves but use `bindings:`."
+
+	requestor ifNil: [ ^ false ].
+	"Because requestor do not have a real API, introspection is used."
+	(requestor respondsTo: #needRequestorScope) ifFalse: [ ^ false ].
+	^ requestor needRequestorScope
+]
+
 { #category : #accessing }
 CompilationContext >> noPattern [
 	^semanticScope isDoItScope
@@ -655,7 +666,7 @@ CompilationContext >> scope [
 	| newScope |
 
 	newScope := semanticScope.
-	requestor ifNotNil: [
+	self needRequestorScope ifTrue: [
 		"the requestor is allowed to manage variables, the workspace is using it to auto-define vars"
 		newScope := (self requestorScopeClass new
 			requestor: requestor) outerScope: newScope].

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -21,25 +21,15 @@ OCRequestorScope >> allTemps [
 ]
 
 { #category : #testing }
-OCRequestorScope >> canDeclareVariableName: name [
+OCRequestorScope >> canAddBindingOf: name [
 	"Test for free workspace declaration"
 
 	"Empty names come from faulty parameters. Ignore them"
 	name ifEmpty: [ ^ false ].
 
-	"Ensure compatibility with old requestors"
-	(requestor respondsTo: #canDeclareVariableName:) ifTrue: [
-		^ requestor canDeclareVariableName: name ].
-
-	"Supported legacy: only the workspace"
-	requestor class name = #StPlaygroundInteractionModel ifFalse: [
-		^ false ].
-
-	"Heuristic, assume the requestor does not want upercased variables.
-	A menu will likely open to offer reparation for class or global or something."
-	name first isUppercase ifTrue: [ ^ false ].
-
-	^ true
+	"Because requestor do not have a real API, introspection is used."
+	(requestor respondsTo: #canAddBindingOf:) ifFalse: [ ^ false ].
+	^ requestor canAddBindingOf: name
 ]
 
 { #category : #lookup }
@@ -51,7 +41,7 @@ OCRequestorScope >> lookupVar: name [
 	(super lookupVar: name) ifNotNil: [ :binding | ^ binding ].
 
 	"Can we have a free workspace variable or not?"
-	(self canDeclareVariableName: name) ifFalse: [ ^nil ].
+	(self canAddBindingOf: name) ifFalse: [ ^nil ].
 	"We do not register it yet, to not fill the requestor with garbage variable during styling for instance"
 	^ self variables at: name ifAbsentPut: [ WorkspaceVariable key: name ]
 ]

--- a/src/OpalCompiler-Tests/OCDoitTest.class.st
+++ b/src/OpalCompiler-Tests/OCDoitTest.class.st
@@ -19,6 +19,11 @@ OCDoitTest >> hasBindingOf: aSelector [
 	^aSelector == #requestorVarForTesting
 ]
 
+{ #category : #binding }
+OCDoitTest >> needRequestorScope [
+	^true
+]
+
 { #category : #'interactive error protocol' }
 OCDoitTest >> notify: aString at: anInteger in: aString3 [
 	"we ignore"


### PR DESCRIPTION
Require https://github.com/pharo-spec/Spec/pull/1377

This is the remaining part of  #13323 that was missing in #13393

Requestors that need special bindings or the ability to declare new bindings by themselves must announce it.
Because there is no requestor API, introspection is used. Previously hard-coded class names are removed.

Note: I renamed `canDeclareVariableName:` to `canAddBindingOf:` to be more consistent with existing `*binding*` selectors.