### PR TITLE
Completion menu: some love on the detail window

### DIFF
--- a/src/HeuristicCompletion-Model/CoGlobalSelectorFetcher.class.st
+++ b/src/HeuristicCompletion-Model/CoGlobalSelectorFetcher.class.st
@@ -18,9 +18,11 @@ CoGlobalSelectorFetcher >> entriesDo: aBlock [
 				allSelectorsStartingWith:
 				parent selector , filter completionString
 				do: [ :e |
-					aBlock value: (NECSelectorEntry
+					aBlock value: ((NECSelectorEntry
 							 contents: (e copyFrom: parent selector size + 1 to: e size)
-							 node: astNode) ] ] ] ].
+							 node: astNode)
+							 selector: e)
+							 ] ] ] ].
 
 	"Otherwise, just go wide"
 	self systemNavigation

--- a/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
@@ -60,6 +60,31 @@ CoCompletionEngineTest >> testAdvanceWordTwiceClosesCompletionContext [
 ]
 
 { #category : #'tests - interaction' }
+CoCompletionEngineTest >> testCmdCtrlLeftClosesDetail [
+
+	| text |
+	text := 'self asOrdered'.
+	self
+		setEditorText: text;
+		selectAt: text size - 1.
+
+	editor textArea openInWorld.
+	controller openMenu.
+
+	"Detail already closed? open it"
+	controller hasDetail ifFalse: [ controller showDetail ].
+
+	"Force the drawing of the menu, so the detail can get its position..."
+	WorldMorph doOneCycle.
+	"This is the current shortcut to open the details of the completion engine... Cmd/ctrl+right for all platforms"
+	editor keyDown:
+		((self keyboardEventFor: Character arrowLeft) buttons:
+			 KMModifier meta eventCode).
+
+	self deny: controller hasDetail
+]
+
+{ #category : #'tests - interaction' }
 CoCompletionEngineTest >> testCmdCtrlRightOpensDetail [
 
 	| text |
@@ -70,6 +95,9 @@ CoCompletionEngineTest >> testCmdCtrlRightOpensDetail [
 
 	editor textArea openInWorld.
 	controller openMenu.
+
+	"Detail already open? close it"
+	controller hasDetail ifTrue: [ controller hideDetail ].
 
 	"Force the drawing of the menu, so the detail can get its position..."
 	WorldMorph doOneCycle.

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -303,7 +303,9 @@ CompletionEngine >> openMenu [
 				engine: self
 				position: (editor selectionPosition: context completionToken).
 
-	theMenu isClosed ifFalse: [ menuMorph := theMenu ]
+	theMenu isClosed ifFalse: [ 
+		menuMorph := theMenu.
+		theMenu showDetail ]
 ]
 
 { #category : #replacement }

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -237,6 +237,12 @@ CompletionEngine >> hasDetail [
 	^ self isMenuOpen and: [ menuMorph hasDetail ]
 ]
 
+{ #category : #actions }
+CompletionEngine >> hideDetail [
+
+	menuMorph hideDetail
+]
+
 { #category : #keyboard }
 CompletionEngine >> invalidateEditorMorph [
 		editor morph invalidRect: editor morph bounds
@@ -370,6 +376,12 @@ CompletionEngine >> setEditor: anObject [
 	editor := anObject.
 	editor morph onAnnouncement: MorphLostFocus send: #closeMenu to: self.
 	editor morph onAnnouncement: MorphClosePopups send: #closeMenu to: self
+]
+
+{ #category : #actions }
+CompletionEngine >> showDetail [
+
+	menuMorph showDetail
 ]
 
 { #category : #keyboard }

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -584,6 +584,5 @@ CompletionEngine >> updateCompletionAfterEdition: aParagraphEditor [
 
 	aParagraphEditor atCompletionPosition ifFalse: [ ^ self closeMenu ].
 
-	context narrowWith: aParagraphEditor wordAtCaret.
-	menuMorph refreshSelection
+	context narrowWith: aParagraphEditor wordAtCaret
 ]

--- a/src/NECompletion-Morphic/NECMenuMorph.class.st
+++ b/src/NECompletion-Morphic/NECMenuMorph.class.st
@@ -663,6 +663,7 @@ NECMenuMorph >> takesKeyboardFocus [
 NECMenuMorph >> updateDetail [
 	detailMorph
 		ifNil: [^ self].
+	detailPosition ifNil: [^ self].
 	detailMorph
 		entryDescription: (self selectedEntry description);
 		position: detailPosition menuWidth: self width;

--- a/src/NECompletion/NECSelectorEntry.class.st
+++ b/src/NECompletion/NECSelectorEntry.class.st
@@ -4,6 +4,9 @@ I represent a selector of a method
 Class {
 	#name : #NECSelectorEntry,
 	#superclass : #NECSymbolEntry,
+	#instVars : [
+		'selector'
+	],
 	#category : #'NECompletion-Model'
 }
 
@@ -11,7 +14,7 @@ Class {
 NECSelectorEntry >> browse [
 	| class |
 	class := node receiver propertyAt: #type ifAbsent: nil.
-	class ifNil: [ SystemNavigation new browseAllImplementorsOf: contents. ^true].
+	class ifNil: [ SystemNavigation new browseAllImplementorsOf: self selector. ^true].
 
 	^ self
 		findMethodAndDo: [ :method |
@@ -30,13 +33,13 @@ NECSelectorEntry >> findMethodAndDo: foundBlock ifAbsent: notfoundBlock [
 	| theClass result implementors |
 	theClass := node receiver propertyAt: #type ifAbsent: nil.
 	result := theClass
-				ifNil: [implementors := self systemNavigation allImplementorsOf: contents.
+				ifNil: [implementors := self systemNavigation allImplementorsOf: self selector.
 					implementors size == 1
 						ifTrue: [| ref |
 							ref := implementors first.
 							ref realClass lookupSelector: ref selector]
-						ifFalse: [^ notfoundBlock value: contents]]
-				ifNotNil: [theClass lookupSelector: contents ].
+						ifFalse: [^ notfoundBlock value: self selector]]
+				ifNotNil: [theClass lookupSelector: self selector ].
 	^ foundBlock value: result
 ]
 
@@ -48,4 +51,16 @@ NECSelectorEntry >> label [
 		propertyAt: #type
 		ifPresent:  [ 'method' ]
 		ifAbsent:  [ 'class' ]
+]
+
+{ #category : #accessing }
+NECSelectorEntry >> selector [
+
+	^ selector ifNil: [ contents ]
+]
+
+{ #category : #accessing }
+NECSelectorEntry >> selector: anObject [
+
+	selector := anObject
 ]

--- a/src/NECompletion/NECSelectorEntry.class.st
+++ b/src/NECompletion/NECSelectorEntry.class.st
@@ -22,9 +22,9 @@ NECSelectorEntry >> browse [
 				openOnClass: method methodClass
 				selector: method selector.
 			true ]
-		ifAbsent: [ :selector |
+		ifAbsent: [ :sel |
 			SystemNavigation new
-				browseAllImplementorsOf: selector.
+				browseAllImplementorsOf: sel.
 			true ]
 ]
 

--- a/src/NECompletion/NECSelectorEntry.class.st
+++ b/src/NECompletion/NECSelectorEntry.class.st
@@ -31,7 +31,9 @@ NECSelectorEntry >> browse [
 { #category : #private }
 NECSelectorEntry >> findMethodAndDo: foundBlock ifAbsent: notfoundBlock [
 	| theClass result implementors |
-	theClass := node receiver propertyAt: #type ifAbsent: nil.
+	theClass := node isMessage
+		ifTrue: [ node receiver propertyAt: #type ifAbsent: nil ]
+		ifFalse: [ nil ].
 	result := theClass
 				ifNil: [implementors := self systemNavigation allImplementorsOf: self selector.
 					implementors size == 1
@@ -45,8 +47,9 @@ NECSelectorEntry >> findMethodAndDo: foundBlock ifAbsent: notfoundBlock [
 
 { #category : #accessing }
 NECSelectorEntry >> label [
-	"I return whether the variable is a class or a method."
+	node isMessage ifFalse: [ ^ '' ].
 
+	"I return whether the variable is a class or a method."
 	 ^node receiver
 		propertyAt: #type
 		ifPresent:  [ 'method' ]

--- a/src/NECompletion/NECSymbolEntry.class.st
+++ b/src/NECompletion/NECSymbolEntry.class.st
@@ -11,7 +11,7 @@ Class {
 NECSymbolEntry >> browse [
 	| class |
 	class := node propertyAt: #type ifAbsent: nil.
-	class ifNil: [ SystemNavigation new browseAllImplementorsOf: contents. ^true].
+	class ifNil: [ SystemNavigation new browseAllImplementorsOf: self selector. ^true].
 
 	^ self
 		findMethodAndDo: [ :method |
@@ -42,12 +42,12 @@ NECSymbolEntry >> createDescription [
 NECSymbolEntry >> findMethodAndDo: foundBlock ifAbsent: notfoundBlock [
 	| result  implementors |
 
-	implementors := self systemNavigation allImplementorsOf: contents.
+	implementors := self systemNavigation allImplementorsOf: self selector.
 	implementors size == 1
 						ifTrue: [| ref |
 							ref := implementors first.
 							result := ref realClass lookupSelector: ref selector]
-						ifFalse: [^ notfoundBlock value: contents].
+						ifFalse: [^ notfoundBlock value: self selector ].
 
 	^ foundBlock value: result
 ]
@@ -85,4 +85,10 @@ NECSymbolEntry >> methodSourceDescription: aClass method: aCompiledMethod [
 		label: self label
 		title: aClass printString
 		description: styledText
+]
+
+{ #category : #accessing }
+NECSymbolEntry >> selector [
+
+	^ contents
 ]

--- a/src/NECompletion/NECSymbolEntry.class.st
+++ b/src/NECompletion/NECSymbolEntry.class.st
@@ -64,7 +64,7 @@ NECSymbolEntry >> implementorsDescription: aSymbol [
 			description: 'This is just symbol.' ].
 	implementors do: [ :each |
 		output
-			nextPutAll: each className printString;
+			nextPutAll: each methodClass printString;
 			cr ].
 	^ NECEntryDescription
 		label: self label


### PR DESCRIPTION
* Details in completion menu showed a bunch of `'CompiledMethod'` instead of the correct class names
* Forced reset after unhandled keyboard event makes control commands unusable. So disable it.
* Open the detail window by default. What is the point of hiding it and making it very hard to discover?
* Provide correct detail information for completion when continuing a keyword selector with many arguments.