### PR TITLE
Compiler: remove #optionEmbeddSources 

### DIFF
--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -156,16 +156,6 @@ CompilationContext class >> optionConstantBlockClosure: aBoolean [
 ]
 
 { #category : #'options - settings API' }
-CompilationContext class >> optionEmbeddSources [
-	^ self readDefaultOption: #optionEmbeddSources
-]
-
-{ #category : #'options - settings API' }
-CompilationContext class >> optionEmbeddSources: aBoolean [
-	^ self writeDefaultOption: #optionEmbeddSources value: aBoolean
-]
-
-{ #category : #'options - settings API' }
 CompilationContext class >> optionInlineAndOr [
 	^ self readDefaultOption: #optionInlineAndOr
 ]
@@ -323,7 +313,6 @@ CompilationContext class >> optionsDescription [
 	(+ optionInlineRepeat 			'Inline repeat if specific conditions are met (See isInlineRepeat)')
 	(- optionInlineNone 				'To turn off all inlining options. Overrides the others')
 
-	(- optionEmbeddSources         'Embedd sources into CompiledMethod instead of storing in .changes')
 	(- optionBlockClosureOptionalOuter 			'Compiler compiles closure creation with outerContext only if it has a non-local return. Experimental')
 	(+ optionConstantBlockClosure 			'Compiler compiles closure creation to use ConstantBlockClosure for constant with 0-3 arguments. Experimental')
 	(- optionCleanBlockClosure 			'Compiler compiles closure creation to use CleanBlockClosure instead of FullBlockClosure for clean blocks. Experimental')
@@ -526,11 +515,6 @@ CompilationContext >> optionCleanBlockClosure [
 { #category : #options }
 CompilationContext >> optionConstantBlockClosure [
 	^ options includes: #optionConstantBlockClosure
-]
-
-{ #category : #options }
-CompilationContext >> optionEmbeddSources [
-	^ options includes: #optionEmbeddSources
 ]
 
 { #category : #options }

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -91,11 +91,7 @@ RBMethodNode >> generateIR [
 
 { #category : #'*OpalCompiler-Core' }
 RBMethodNode >> generateMethod [
-	| methodTrailer |
-	methodTrailer := self compilationContext optionEmbeddSources
-			ifTrue: [ CompiledMethodTrailer new sourceCode: source ]
-			ifFalse: [self compilationContext compiledMethodTrailer ].
-	^self generate: methodTrailer
+	^self generate: self compilationContext compiledMethodTrailer 
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Tests/OpalCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTest.class.st
@@ -68,26 +68,6 @@ OpalCompilerTest >> testBindingsWriteGlobals [
 ]
 
 { #category : #tests }
-OpalCompilerTest >> testCompileEmbeddsSource [
-	| result |
-	result := Smalltalk compiler
-		class: UndefinedObject;
-		options: #( + #optionEmbeddSources );
-		compile: 'tt ^3+4'.
-	self assert: (result valueWithReceiver: nil arguments: #()) equals: 7.
-	self deny: result trailer hasSourcePointer. "no sourcePointer"
-	self assert: result trailer hasSource.		 "but source embedded"
-
-	result := Smalltalk compiler
-		class: UndefinedObject;
-		options: #( - #optionEmbeddSources );
-		compile: 'tt ^3+4'.
-	self assert: (result valueWithReceiver: nil arguments: #()) equals: 7.
-	self deny: result trailer hasSourcePointer. "no sourcePointer"
-	self deny: result trailer hasSource.			 "and source embedded"
-]
-
-{ #category : #tests }
 OpalCompilerTest >> testCompileSource [
 	| source result |
 	source := 'tt ^3+4'.

--- a/src/Slot-Tests/DoItVariableTest.class.st
+++ b/src/Slot-Tests/DoItVariableTest.class.st
@@ -87,7 +87,7 @@ DoItVariableTest >> testReadCompilation [
 	var := DoItVariable named: #temp fromContext: thisContext.
 	ast := [ temp + 2 ] sourceNode body asDoit doSemanticAnalysis.
 	ast variableNodes first variable: var.
-	doIt := ast generateWithSource.
+	doIt := ast generate.
 
 	self assert: (doIt valueWithReceiver: self arguments: #()) equals: 102
 ]
@@ -119,7 +119,7 @@ DoItVariableTest >> testWriteCompilation [
 	var := DoItVariable named: #temp fromContext: thisContext.
 	ast := [ temp := 500 ] sourceNode body asDoit doSemanticAnalysis.
 	ast variableNodes first variable: var.
-	doIt := ast generateWithSource.
+	doIt := ast generate.
 	doIt valueWithReceiver: self arguments: #().
 
 	self assert: temp equals: 500

--- a/src/TraitsV2-Compatibility/TraitMethodDescription.class.st
+++ b/src/TraitsV2-Compatibility/TraitMethodDescription.class.st
@@ -77,7 +77,7 @@ TraitMethodDescription >> effectiveMethodCategoryCurrent: currentCategoryOrNil n
 
 { #category : #private }
 TraitMethodDescription >> generateMethod: aSelector withMarker: aSymbol forArgs: aNumber binary: aBoolean [
-	| source node keywords |
+	| source keywords method |
 	source := String streamContents: [:stream |
 		aNumber < 1
 			ifTrue: [stream nextPutAll: aSelector]
@@ -92,12 +92,12 @@ TraitMethodDescription >> generateMethod: aSelector withMarker: aSymbol forArgs:
 							nextPutAll: 'arg'; nextPutAll: argumentNumber asString; space]]].
 		stream cr; tab; nextPutAll: 'self '; nextPutAll: aSymbol].
 
-	node := self class compiler
+	method := self class compiler
 		source: source;
 		class: self class;
-		failBlock: [];
-		parse.
-	^(node generateWithSource) selector: aSelector; yourself
+		permitFaulty;
+		compile.
+	^method selector: aSelector; yourself
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
this PR removes the #optionEmbeddSources

The whole CompiledMethodTrailer concept is far too complex... this PR is a small step to allow to simplify alter. The compiler now sets the #source property for all  methods ot creates, thus we do not need the option to embedd in the Trailer on the level of the compiler This PR

- removes the  #optionEmbeddSources 
- reduces the users of #generateWithSource

The next step will be to remove generateWithSource and simplify CompiledMethodTrailer