### PR TITLE
Make #renameProtocolNamed:toBe: manage nils

### DIFF
--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -130,6 +130,64 @@ ClassOrganizationTest >> testRemoveProtocolIfEmpty [
 ]
 
 { #category : #tests }
+ClassOrganizationTest >> testRenameProtocolIntoWithExistingProtocol [
+
+	self organization classify: 'king' under: 'two'.
+
+	self assert: (self organization hasProtocol: #one).
+	self assert: (self organization hasProtocol: #two).
+	self assertCollection: (self organization protocolNamed: #one) methodSelectors hasSameElements: #( 'one' ).
+	self assertCollection: (self organization protocolNamed: #two) methodSelectors hasSameElements: #( 'king' ).
+	self organization renameProtocolNamed: #one toBe: #two.
+
+	self assert: (self organization hasProtocol: #two).
+	self deny: (self organization hasProtocol: #one).
+	self assertCollection: (self organization protocolNamed: #two) methodSelectors hasSameElements: #( 'one' 'king' )
+]
+
+{ #category : #tests }
+ClassOrganizationTest >> testRenameProtocolIntoWithNil [
+
+	self assert: (self organization hasProtocol: #one).
+	self deny: (self organization hasProtocol: #two).
+	self assertCollection: (self organization protocolNamed: #one) methodSelectors hasSameElements: #( 'one' ).
+
+	self organization renameProtocolNamed: #one toBe: nil.
+	"Check that nothing changed."
+	self assert: (self organization hasProtocol: #one).
+	self deny: (self organization hasProtocol: #two).
+	self assertCollection: (self organization protocolNamed: #one) methodSelectors hasSameElements: #( 'one' )
+]
+
+{ #category : #tests }
+ClassOrganizationTest >> testRenameProtocolIntoWithNil2 [
+
+	self assert: (self organization hasProtocol: #one).
+	self deny: (self organization hasProtocol: #two).
+	self assertCollection: (self organization protocolNamed: #one) methodSelectors hasSameElements: #( 'one' ).
+
+	self organization renameProtocolNamed: nil toBe: #two.
+	"Check that nothing changed."
+	self assert: (self organization hasProtocol: #one).
+	self deny: (self organization hasProtocol: #two).
+	self assertCollection: (self organization protocolNamed: #one) methodSelectors hasSameElements: #( 'one' )
+]
+
+{ #category : #tests }
+ClassOrganizationTest >> testRenameProtocolIntoWithNil3 [
+
+	self assert: (self organization hasProtocol: #one).
+	self deny: (self organization hasProtocol: #two).
+	self assertCollection: (self organization protocolNamed: #one) methodSelectors hasSameElements: #( 'one' ).
+
+	self organization renameProtocolNamed: nil toBe: nil.
+	"Check that nothing changed."
+	self assert: (self organization hasProtocol: #one).
+	self deny: (self organization hasProtocol: #two).
+	self assertCollection: (self organization protocolNamed: #one) methodSelectors hasSameElements: #( 'one' )
+]
+
+{ #category : #tests }
 ClassOrganizationTest >> testRenameProtocolNamedToBe [
 
 	self assert: (self organization hasProtocol: #one).

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -268,6 +268,7 @@ ClassOrganization >> removeProtocolIfEmpty: aProtocol [
 { #category : #removing }
 ClassOrganization >> renameProtocolNamed: oldName toBe: newName [
 
+	(oldName isNil or: [ newName isNil ]) ifTrue: [ ^ self ].
 	oldName = newName ifTrue: [ ^ self ].
 
 	(self hasProtocol: oldName) ifFalse: [ ^ self ].


### PR DESCRIPTION
Currently there is a hack in the protocol management that returns Protocol unclassified as the protocol of some methods we cannot find the protocol of. 

I am hunting those, and in some cases the methods will say their protocol is nil if they are not in any protocol. To have a smooth transition, I'm making the API deal with nils. This is not my favorite way, later I would like to have exceptions instead if possible. But I need to have a better understanding on how the system manipulates the protocols, so as a first step, I'm making the method silently cancel its action if one of the parameter is nil.

This is a subpart of #13466