### PR TITLE
Directly update source pointer without creating an additional compiled method

### DIFF
--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -1024,19 +1024,18 @@ CompiledMethod >> setSourcePointer: srcPointer [
 	"We can't change the trailer of existing method, since it could have completely different format.
 	Therefore we need to generate a copy with new trailer, containing scrPointer, and then become it."
 
-	| trailer copy |
+	| trailer |
 	"Drop the #source property if any"
 	self removeProperty: #source.
 	
-	trailer := CompiledMethodTrailer new sourcePointer: srcPointer.
-	copy := self copyWithTrailerBytes: trailer.
+	trailer := (CompiledMethodTrailer new sourcePointer: srcPointer) encode.
 	"If possible do a replace in place as an optimization"
-	(self trailer class == trailer class and: [ self size = copy size ])
+	(self trailer class == trailer class and: [ trailer size = self trailer size ])
 		ifTrue: [
 			| start |
 			start := self endPC + 1.
-			self replaceFrom: start to: self size with: copy startingAt: start ]
-		ifFalse: [ self becomeForward: copy ].
+			self replaceFrom: start to: self size with: trailer encodedData startingAt: 1 ]
+		ifFalse: [ self becomeForward: (self copyWithTrailerBytes: trailer) ].
 	^ self
 ]
 

--- a/src/Kernel/CompiledMethodTrailer.class.st
+++ b/src/Kernel/CompiledMethodTrailer.class.st
@@ -532,6 +532,11 @@ CompiledMethodTrailer >> encodeVarLengthSourcePointer [
 ]
 
 { #category : #accessing }
+CompiledMethodTrailer >> encodedData [
+	^encodedData
+]
+
+{ #category : #accessing }
 CompiledMethodTrailer >> endPC [
 	"Answer the index of the last bytecode."
 


### PR DESCRIPTION
#setSourcePointer: was creating always a new compiledMethod using #copyWithTrailerBytes:, just to then copy over the trailer to the existing method if the pointer is not too large (and it normally is not for the .changes, as we start with an empty one).

This PR uses the CompiledMethodTrailer directly to do the check, avoiding to create a compiledMethod

A next step could be to have a larger empty trailer (it is now 4 bytes) and use a fixed trailer size always, but we have to get rid of the source embedding Trailer first to be able to do that.