### PR TITLE
Faulty code: improve highlight and icons

### DIFF
--- a/src/Reflectivity-Tools/ErrorNodeStyler.class.st
+++ b/src/Reflectivity-Tools/ErrorNodeStyler.class.st
@@ -36,10 +36,11 @@ ErrorNodeStyler >> shouldStyleNode: aNode [
 ErrorNodeStyler >> visitEnglobingErrorNode: anEnglobingNode [
 
 	| conf |
+	"Only add red underline at the error position (instead on the whole node)"
 	conf := RubConfigurationChange new.
 	conf configurationBlock: [ :text |
 		| r |
-		r := self segmentMorphClass from: anEnglobingNode stop to: anEnglobingNode stop + 1.
+		r := self segmentMorphClass from: anEnglobingNode errorPosition to: anEnglobingNode errorPosition.
 		text addSegment: r.
 		r label: (self iconLabelBlock: anEnglobingNode).
 		r icon: (self iconFor: anEnglobingNode).

--- a/src/Reflectivity-Tools/ErrorNodeStyler.class.st
+++ b/src/Reflectivity-Tools/ErrorNodeStyler.class.st
@@ -29,13 +29,16 @@ ErrorNodeStyler >> segmentMorphClass [
 
 { #category : #visiting }
 ErrorNodeStyler >> shouldStyleNode: aNode [
-	^ aNode isError
+	^ aNode isError and: [ aNode errorNotices isNotEmpty ]
 ]
 
 { #category : #visiting }
 ErrorNodeStyler >> visitEnglobingErrorNode: anEnglobingNode [
 
 	| conf |
+
+	(self shouldStyleNode: anEnglobingNode) ifFalse: [ ^ super visitEnglobingErrorNode: anEnglobingNode ].
+
 	"Only add red underline at the error position (instead on the whole node)"
 	conf := RubConfigurationChange new.
 	conf configurationBlock: [ :text |

--- a/src/Rubric/RubUnderlinedSegmentMorph.class.st
+++ b/src/Rubric/RubUnderlinedSegmentMorph.class.st
@@ -27,6 +27,7 @@ RubUnderlinedSegmentMorph >> computeVertices [
 			ifTrue: [ lastIndex ]
 			ifFalse: [ line last ].
 		rpos := (self characterBlockForIndex: cidx) bottomLeft.
+		rpos := rpos max: lpos + 5. "Force to have at least a non empty underlining"
 		underlineShape add: (self underlineShapeFromPosition: lpos toPosition: rpos) ]
 ]
 

--- a/src/Rubric/RubUnderlinedSegmentMorph.class.st
+++ b/src/Rubric/RubUnderlinedSegmentMorph.class.st
@@ -132,10 +132,10 @@ RubUnderlinedSegmentMorph >> underlineShapeFromPosition: firstPos toPosition: la
 		ifTrue: [ 0 ]
 		ifFalse: [ 1 ].
 	shape add: (pos := firstPos x @ (firstPos y + (ygap // 2))).
-	[ pos x < (lastPos x min: self right) ]
+	[ pos x < lastPos x ]
 		whileTrue: [
 			ygap := ygap negated.
-			pos := (pos x + 2 min: self right) @ (pos y + ygap).
+			pos := (pos x + 2 min: lastPos x) @ (pos y + ygap).
 			shape add: pos.
 			pos := pos + (1 @ 0) ].
 	^ shape

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -978,7 +978,10 @@ SHRBTextStyler >> visitCommentNodes: anASTNode [
 { #category : #visiting }
 SHRBTextStyler >> visitEnglobingErrorNode: anEnglobingErrorNode [
 
-	self addStyle: #invalid from: anEnglobingErrorNode stop to: anEnglobingErrorNode stop + 1.
+	anEnglobingErrorNode value ifNotEmpty: [
+		self addStyle: #invalid from: anEnglobingErrorNode startWithoutParentheses to: anEnglobingErrorNode startWithoutParentheses + anEnglobingErrorNode value size - 1 ].
+	anEnglobingErrorNode valueAfter ifNotEmpty: [
+		self addStyle: #invalid from: anEnglobingErrorNode stopWithoutParentheses to: anEnglobingErrorNode stopWithoutParentheses + anEnglobingErrorNode valueAfter size - 1 ].
 	anEnglobingErrorNode contents do: [:each | self visitNode: each ]
 ]
 

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -1078,7 +1078,10 @@ SHRBTextStyler >> visitNode: aNode [
 { #category : #visiting }
 SHRBTextStyler >> visitParseErrorNode: anErrorNode [
 
-	self addStyle: #invalid forNode: anErrorNode
+	self addStyle: #invalid forNode: anErrorNode.
+
+	"Also force whatever is at the error position to be marked (to see missing/unexpected tokens)"
+	self addStyle: #invalid from: anErrorNode errorPosition to: anErrorNode errorPosition
 ]
 
 { #category : #visiting }

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -870,9 +870,7 @@ SHRBTextStyler >> styleCloseParenthese: aMessageNode [
 SHRBTextStyler >> styleOpenBrace: anArrayNode [
 
 	| style |
-	style := anArrayNode isFaulty
-		         ifTrue: [ #invalid ]
-		         ifFalse: [ self braceStyleName ].
+	style := self braceStyleName.
 	self addStyle: style from: anArrayNode left to: anArrayNode left.
 	braceLevel := braceLevel + 1
 ]
@@ -880,9 +878,7 @@ SHRBTextStyler >> styleOpenBrace: anArrayNode [
 { #category : #private }
 SHRBTextStyler >> styleOpenBracket: aBlockNode [
 	| style |
-	style := aBlockNode isFaulty
-		ifTrue: [ #invalid ]
-		ifFalse: [ self bracketStyleName ].
+	style := self bracketStyleName.
 	self addStyle: style from: aBlockNode left to: aBlockNode left.
 	bracketLevel := bracketLevel + 1
 ]


### PR DESCRIPTION
Summary:

* correctly highlight opener/closer on error node with missing opener/closer or problematic content
* icons don't crash on bad byte literal
* ensure error position is marked (missing token, unexpected end of file)
* ensure 0-with underlining are visible (missing token, unexpected end of file)

```st
foo
{
#[ 1 256 2 ].
+ 10.
max:10.
10 max:.
10 10.
10).

```

Calypso screenshot (include icons and text segmentd):

![Capture d’écran du 2023-04-19 13-44-01](https://user-images.githubusercontent.com/135828/233157163-817ca3a5-af02-4c1d-ab80-92b490ccdaa1.png)

Playground screenshot (no icon or text segments):

![Capture d’écran du 2023-04-19 13-45-50](https://user-images.githubusercontent.com/135828/233157567-8c83c4be-155f-4548-8c8d-db1bdd260264.png)
