### PR TITLE
Compiler: expose the AST

### DIFF
--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -201,6 +201,19 @@ OpalCompiler >> addPlugin: aClass [
 ]
 
 { #category : #accessing }
+OpalCompiler >> ast [
+
+	^ ast
+]
+
+{ #category : #accessing }
+OpalCompiler >> ast: anObject [
+
+	ast := anObject.
+	source := ast source
+]
+
+{ #category : #accessing }
 OpalCompiler >> bindings: aDictionary [
 	"allows to define additional binding, note: Globals are not shadowed"
 	self compilationContext bindings: aDictionary
@@ -325,8 +338,9 @@ OpalCompiler >> compile [
 	"Policy: compiling is non-faulty by default"
 	self permitFaulty ifNil: [ self permitFaulty: false ].
 
-	result := self parse.
-	ast ifNil: [ ^ result ]. "some failBlock"
+	ast ifNil: [
+		result := self parse.
+		ast ifNil: [ ^ result ] "some failBlock" ].
 
 	self callPlugins.
 	ast scope registerVariables.
@@ -627,5 +641,6 @@ OpalCompiler >> semanticScope: anObject [
 OpalCompiler >> source: aString [
 
 	"source should be a string, but call contents for old clients that send streams"
-	source := aString contents
+	source := aString contents.
+	ast := nil
 ]

--- a/src/OpalCompiler-Tests/OpalCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTest.class.st
@@ -68,6 +68,17 @@ OpalCompilerTest >> testBindingsWriteGlobals [
 ]
 
 { #category : #tests }
+OpalCompilerTest >> testCompileFromAnalysedAST [
+
+	| source ast value |
+	source := 'foo |a| a := 3. ^a+4'.
+	
+	ast := MockForCompilation compiler parse: source.
+	value := MockForCompilation compiler ast: ast; evaluate.
+	self assert: value equals: 7.
+]
+
+{ #category : #tests }
 OpalCompilerTest >> testCompileSource [
 	| source result |
 	source := 'tt ^3+4'.


### PR DESCRIPTION
AST is stored internally in the compiler but is not exposed.
Exposing it clearly reduces the encapsulation, but it has the following benefits:

* Clients can get the AST if they care. To recover from so kind of error, for instance. Or unit testing methods can access the ast to assert some predicate.
* Clients can invoke the compiler with an AST as the entry point, instead of the source code.
  Note that to avoid inconsistencies, `ast:` and `source:` are mutually exclusive, the last one wins.

Note that multiple job invocations on the same compiler instance will not do the parsing/semantic analysis twice.
