### PR TITLE
Use Compiler not #copyWithTrailerBytes

### DIFF
--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -997,6 +997,17 @@ CompiledMethodTest >> testUsesUndeclareds [
 ]
 
 { #category : #'tests - evaluating' }
+CompiledMethodTest >> testValueWithReceiver [
+
+	| method value |
+
+	method := self class compiledMethodAt: #returnTrue.
+
+	value := method valueWithReceiver: nil .
+	self assert: value equals: true.
+]
+
+{ #category : #'tests - evaluating' }
 CompiledMethodTest >> testValueWithReceiverArguments [
 
 	| method value |

--- a/src/Kernel-Tests/BlockClosureTest.class.st
+++ b/src/Kernel-Tests/BlockClosureTest.class.st
@@ -359,19 +359,14 @@ BlockClosureTest >> testPrintOn [
 
 { #category : #'tests - printing' }
 BlockClosureTest >> testPrintOnBlockDefinedInMethodWithoutSourceCode [
-	| method copy start block |
-	"Generating method with source code"
-	UndefinedObject compile: 'method ^ [ 1 + 2 ]'.
-	method := UndefinedObject >> #method.
-	["Removing the source code of method"
-		copy := method copyWithTrailerBytes: CompiledMethodTrailer new.
-		start := method endPC + 1.
-		method replaceFrom: start to: method size with: copy startingAt: start.
-		block := nil method.
+	| method block |
+	method := OpalCompiler new compile: 'method ^ [ 1 + 2 ]'.
+	method removeProperty: #source.
+	self deny: method hasSourceCode.
+	
+	block := method valueWithReceiver: nil.
 
-		self deny: method hasSourceCode.
-		self assert: (RBParser parseExpression: block printString) equals: (RBParser parseExpression: '[ 1 + 2 ]').
-	] ensure: [ method removeFromSystem ]
+	self assert: block printString equals: '[ 1 + 2 ]'
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/BlockClosureTest.class.st
+++ b/src/Kernel-Tests/BlockClosureTest.class.st
@@ -365,8 +365,8 @@ BlockClosureTest >> testPrintOnBlockDefinedInMethodWithoutSourceCode [
 	self deny: method hasSourceCode.
 	
 	block := method valueWithReceiver: nil.
-
-	self assert: block printString equals: '[ 1 + 2 ]'
+	"we compare the ast to not depend on pretty printer settings"
+	self assert: (RBParser parseExpression: block printString) equals: (RBParser parseExpression: '[ 1 + 2 ]').
 ]
 
 { #category : #tests }

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -1155,6 +1155,11 @@ CompiledMethod >> usesUndeclareds [
 ]
 
 { #category : #evaluating }
+CompiledMethod >> valueWithReceiver: aReceiver [
+	^self receiver: aReceiver withArguments: #() executeMethod: self
+]
+
+{ #category : #evaluating }
 CompiledMethod >> valueWithReceiver: aReceiver arguments: anArray [
 	^self receiver: aReceiver withArguments: anArray executeMethod: self
 ]

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -938,7 +938,13 @@ CompiledMethod >> readsField: varIndex [
 ]
 
 { #category : #evaluating }
-CompiledMethod >> receiver: aReceiver withArguments: anArray executeMethod: anObject [
+CompiledMethod >> receiver: aReceiver withArguments: anArray executeMethod: aMethod [
+	"execute aMethod.
+	This method takes aMethod as an argument so we can call primitive 188.
+	Clients should use #valueWithReceiver:arguments:
+	
+	We have this method here in addition to ProtoObject>>#withArgs:executeMethod:
+	so we can execute a method without sending a message to aReceiver"
 	<primitive: 188>
 	self primitiveFailed
 ]

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -162,10 +162,7 @@ Context class >> initializeTryNamedPrimitiveTemplateMethod [
 	execute primitives. See Object documentation whatIsAPrimitive."
 	<primitive:'' module:'' error: errorCode>
 	^ Context primitiveFailTokenFor: errorCode'.
-	TryNamedPrimitiveTemplateMethod := Smalltalk compiler
-				class: UndefinedObject;
-				source: source;
-				compile
+	TryNamedPrimitiveTemplateMethod := Smalltalk compiler compile: source
 ]
 
 { #category : #'instance creation' }

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -156,17 +156,16 @@ Context class >> initializePrimitiveSimulators [
 
 { #category : #simulation }
 Context class >> initializeTryNamedPrimitiveTemplateMethod [
-	| source method |
+	| source |
 	source := 'tryNamedPrimitive
 	"This method is a template that the Smalltalk simulator uses to
 	execute primitives. See Object documentation whatIsAPrimitive."
 	<primitive:'' module:'' error: errorCode>
 	^ Context primitiveFailTokenFor: errorCode'.
-	method := Smalltalk compiler
+	TryNamedPrimitiveTemplateMethod := Smalltalk compiler
 				class: UndefinedObject;
 				source: source;
-				compile.
-	TryNamedPrimitiveTemplateMethod := method copyWithSource: source
+				compile
 ]
 
 { #category : #'instance creation' }

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -138,20 +138,6 @@ ReleaseTest >> testExplicitRequirementMethodsShouldBeImplementedInTheirUsers [
 ]
 
 { #category : #tests }
-ReleaseTest >> testInstalledMethodsWithIncorrectTrailerKind [
-	| incorrectMethods |
-
-	incorrectMethods := SystemNavigation new installedMethodsWithIncorrectTrailerKind.
-
-	self
-		assert: incorrectMethods isEmpty
-		description: [ String streamContents: [ :s|
-			s
-				nextPutAll: 'Found methods with incorrect trailer kind: ';
-				print: incorrectMethods ]]
-]
-
-{ #category : #tests }
 ReleaseTest >> testInstanceSideMethodsWithNilKeyInLastLiteral [
 	| instanceSideMethodsWithNilKeyInLastLiteral |
 

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -306,14 +306,6 @@ SystemNavigation >> initialize [
 ]
 
 { #category : #query }
-SystemNavigation >> installedMethodsWithIncorrectTrailerKind [
-
-	^ self allMethodsSelect:
-		[ :each | (#(#SourcePointer #VarLengthSourcePointer #NativeCodeTrailer)
-							includes: each trailer kind) not and: [ each isInstalled ] ]
-]
-
-{ #category : #query }
 SystemNavigation >> instanceSideMethodsWithNilKeyInLastLiteral [
 	"This answers all the instance side methods that has NIL as the key in their last literal. There should be none (only class side methods have this)"
 


### PR DESCRIPTION
- Context>>#initializeTryNamedPrimitiveTemplateMethod can just use the compiler, no #copyWithSource: needed
- testPrintOnBlockDefinedInMethodWithoutSourceCode can use the compiler
- remove testInstalledMethodsWithIncorrectTrailerKind,  a step to remove all other trailer kinds
- add CompiledMethod>>valueWithReceiver: and test