### PR TITLE
Rename #removeMethodTag: into #removeProtocolIfEmpty:

### DIFF
--- a/src/Calypso-SystemQueries/ClyTaggedMethodGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyTaggedMethodGroup.class.st
@@ -37,22 +37,23 @@ ClyTaggedMethodGroup >> importMethod: aMethod [
 
 { #category : #operations }
 ClyTaggedMethodGroup >> removeWithMethods [
+
 	super removeWithMethods.
-	methodQuery scope classesDo: [ :each | each removeMethodTag: self tag ]
+	methodQuery scope classesDo: [ :class | class removeProtocolIfEmpty: self tag ]
 ]
 
 { #category : #operations }
 ClyTaggedMethodGroup >> renameMethodTagTo: newTag [
 	newTag = self tag ifTrue: [ ^self ].
 
-	self methods do: [ :each |
-		each tagWith: newTag.
-		each untagFrom: self tag].
+	self methods do: [ :method |
+		method tagWith: newTag.
+		method untagFrom: self tag].
 
-	methodQuery scope classesDo:  [ :each |
-		(each tagsForMethods includes: newTag)
-			ifFalse: [ each addMethodTag: newTag ].
-		each removeMethodTag: self tag]
+	methodQuery scope classesDo:  [ :class |
+		(class tagsForMethods includes: newTag)
+			ifFalse: [ class addMethodTag: newTag ].
+		class removeProtocolIfEmpty: self tag]
 ]
 
 { #category : #accessing }

--- a/src/Deprecated12/ClassDescription.extension.st
+++ b/src/Deprecated12/ClassDescription.extension.st
@@ -94,3 +94,12 @@ ClassDescription >> copyCategory: protocolName from: aClass classified: newProto
 
 	self copyAll: (aClass organization methodSelectorsInProtocol: protocolName) from: aClass classified: newProtocolName
 ]
+
+{ #category : #'*Deprecated12' }
+ClassDescription >> removeMethodTag: aSymbol [
+
+	self
+		deprecated: 'Use #removeProtocolIfEmpty: instead since this previous name is missleading.'
+		transformWith: '`@rcv removeMethodTag: `@arg' -> '`@rcv removeProtocolIfEmpty: `@arg'.
+	^ self removeProtocolIfEmpty: aSymbol
+]

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -869,15 +869,6 @@ ClassDescription >> removeInstVarNamed: aString [
 	^self removeSlot: (self slotNamed: aString)
 ]
 
-{ #category : #'accessing - tags' }
-ClassDescription >> removeMethodTag: aSymbol [
-	"Any method could be tagged with multiple symbols for user purpose.
-	In class we could define what tags could be used for methods.
-	Here we could remove what we not need"
-
-	self organization removeProtocolIfEmpty: aSymbol
-]
-
 { #category : #'accessing - method dictionary' }
 ClassDescription >> removeProtocol: protocolName [
 	"Remove each of the messages categorized under aString in the method
@@ -885,6 +876,13 @@ ClassDescription >> removeProtocol: protocolName [
 
 	(self organization methodSelectorsInProtocol: protocolName) do: [ :sel | self removeSelector: sel ].
 	self organization removeProtocolIfEmpty: protocolName
+]
+
+{ #category : #'accessing - protocols' }
+ClassDescription >> removeProtocolIfEmpty: aProtocol [
+	"Remove a given protocol (the argument can also be a protocol name) if no method is present in it."
+
+	self organization removeProtocolIfEmpty: aProtocol
 ]
 
 { #category : #'accessing - method dictionary' }

--- a/src/SystemCommands-MethodCommands/SycSilentlyRemoveMethodStrategy.class.st
+++ b/src/SystemCommands-MethodCommands/SycSilentlyRemoveMethodStrategy.class.st
@@ -22,13 +22,11 @@ SycSilentlyRemoveMethodStrategy >> collectMethodTagsFrom: methods [
 SycSilentlyRemoveMethodStrategy >> removeMethods: methods [
 
 	| methodTags |
-	methodTags := self collectMethodTagsFrom: methods. "we will remove empty tags of removed methods".
+	methodTags := self collectMethodTagsFrom: methods. "we will remove empty tags of removed methods"
 
 	methods do: [ :each | each removeFromSystem ].
 
-	methodTags keysAndValuesDo: [:class :tags | tags do: [ :eachTag |
-		(class methodsTaggedWith: eachTag)
-			ifEmpty: [class removeMethodTag: eachTag] ]]
+	methodTags keysAndValuesDo: [ :class :tags | tags do: [ :eachTag | class removeProtocolIfEmpty: eachTag ] ]
 ]
 
 { #category : #removing }


### PR DESCRIPTION
#removeMethodTag: is a really bad name for three reasons:
- It uses another name than the rest of the system to talk about the protocols
- The "tag" vocabulary in the class is already present to designate its package tag, this creates a naming conflict in the API
- It does not let the user know that the action will be executed only if the protocol is empty. We can even see that in the way it was used. 

#removeProtocolIfEmpty: is improving the naming coherence and is revealing of the intention,