### PR TITLE
Synch bug in RPackage removal

### DIFF
--- a/src/FluidClassBuilder-Tests/FluidClassBuilderTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidClassBuilderTest.class.st
@@ -491,10 +491,11 @@ FluidClassBuilderTest >> testInstallMinimalMockClass [
 { #category : #'tests - classBuilder generation' }
 FluidClassBuilderTest >> testInstallSimplePoint2 [
 
-	[ | pt2Class |
+	[
+	| pt2Class |
 	self assert: (self class environment at: #Point2 ifAbsent: [ true ]).
 	builder := Object << #Point2.
-	builder slots: { #x . #y }.
+	builder slots: { #x. #y }.
 	builder package: 'FakedCore'.
 	builder install.
 
@@ -502,6 +503,6 @@ FluidClassBuilderTest >> testInstallSimplePoint2 [
 	self assert: pt2Class superclass equals: Object.
 	self assert: pt2Class name equals: #Point2.
 	self assert: pt2Class slots size equals: 2 ] ensure: [
-			self class environment removeKey: #Point2 ifAbsent: [self fail].
-			self assert: (self class environment at: #Point2 ifAbsent: [ true ])]
+		(self class environment at: #Point2 ifAbsent: [ self fail ]) removeFromSystem.
+		self assert: (self class environment at: #Point2 ifAbsent: [ true ]) ]
 ]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -612,21 +612,7 @@ OpalCompiler >> protocol: aProtocol [
 ]
 
 { #category : #accessing }
-OpalCompiler >> receiver [
-
-	^ self semanticScope ifNotNil: [ :scope |
-		  scope isDoItScope
-			  ifTrue: [ scope receiver ]
-			  ifFalse: [ nil ] ]
-]
-
-{ #category : #accessing }
 OpalCompiler >> receiver: anObject [
-	"Note: some clients set up a `receiver:` AFTER setting up a `context:`
-	BUT expect that the context remain,
-	so just noop if the receiver is already known, thus do not change the doit scope"
-
-	self receiver == anObject ifTrue: [ ^ self ].
 	self semanticScope: (OCReceiverDoItSemanticScope targetingReceiver: anObject)
 ]
 

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -612,7 +612,21 @@ OpalCompiler >> protocol: aProtocol [
 ]
 
 { #category : #accessing }
+OpalCompiler >> receiver [
+
+	^ self semanticScope ifNotNil: [ :scope |
+		  scope isDoItScope
+			  ifTrue: [ scope receiver ]
+			  ifFalse: [ nil ] ]
+]
+
+{ #category : #accessing }
 OpalCompiler >> receiver: anObject [
+	"Note: some clients set up a `receiver:` AFTER setting up a `context:`
+	BUT expect that the context remain,
+	so just noop if the receiver is already known, thus do not change the doit scope"
+
+	self receiver == anObject ifTrue: [ ^ self ].
 	self semanticScope: (OCReceiverDoItSemanticScope targetingReceiver: anObject)
 ]
 

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -1242,14 +1242,20 @@ RPackage >> removeClassesMatchingTag: aTag [
 
 { #category : #removing }
 RPackage >> removeFromSystem [
-	| extendedClasses |
 
+	| extendedClasses categories |
+	categories := (self classTags collect: [ :each | each categoryName ] as: Set)
+		              add: self name;
+		              yourself.
 	extendedClasses := self extendedClasses.
 
 	self definedClasses do: #removeFromSystem.
 	self extensionMethods do: #removeFromSystem.
 
-	extendedClasses do:[:each | each organization removeProtocolIfEmpty: ('*' , name) asSymbol].
+	extendedClasses do: [ :each | each organization removeProtocolIfEmpty: ('*' , name) asSymbol ].
+	"This is probably not the best place to unregister from the SystemOrganizer but later it's harder to find the categories. 
+	But anyway, SystemOrganizer should be removed in the next few months and we will be able to remove this code."
+	categories do: [ :cat | self organizer systemOrganizer removeCategory: cat ].
 	self unregister
 ]
 

--- a/src/RPackage-Tests/RPackageOrganizerAndSystemOrganizeSynchTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerAndSystemOrganizeSynchTest.class.st
@@ -1,0 +1,77 @@
+"
+Currently the system maintains 2 packages organisers. 
+- RPackageOrganizer default
+- SystemOrganizer default
+
+Both of them should stay in synch and this test class will ensure that. 
+
+Let's note that SystemOrganizer should vanish in the future so I'll probably vanish too, but in the meantime I'll ensure that we are in sync.
+"
+Class {
+	#name : #RPackageOrganizerAndSystemOrganizeSynchTest,
+	#superclass : #TestCase,
+	#category : #'RPackage-Tests'
+}
+
+{ #category : #helpers }
+RPackageOrganizerAndSystemOrganizeSynchTest >> packageName [
+	^ 'RPackageOragizationSynchPackageTest'
+]
+
+{ #category : #running }
+RPackageOrganizerAndSystemOrganizeSynchTest >> tearDown [
+
+	(self packageName asPackageIfAbsent: [ nil ]) ifNotNil: [ :package | package removeFromSystem ].
+	SystemOrganizer default removeCategory: self packageName.
+	super tearDown
+]
+
+{ #category : #tests }
+RPackageOrganizerAndSystemOrganizeSynchTest >> testAddingPackage [
+
+	SystemOrganizer default addCategory: self packageName.
+
+	self assert: (RPackageOrganizer default packageNames includes: self packageName).
+	self assert: (SystemOrganizer default includesCategory: self packageName)
+]
+
+{ #category : #tests }
+RPackageOrganizerAndSystemOrganizeSynchTest >> testRemovingPackage [
+	"Regression test because removing a RPackage from the system was not removing the category in SystemOrganizer."
+
+	SystemOrganizer default addCategory: self packageName.
+
+	self assert: (RPackageOrganizer default packageNames includes: self packageName).
+	self assert: (SystemOrganizer default includesCategory: self packageName).
+
+	self packageName asPackage removeFromSystem.
+
+	self deny: (RPackageOrganizer default packageNames includes: self packageName).
+	self deny: (SystemOrganizer default includesCategory: self packageName)
+]
+
+{ #category : #tests }
+RPackageOrganizerAndSystemOrganizeSynchTest >> testRemovingPackageWithTags [
+	"Regression test because removing a RPackage from the system was not removing the category in SystemOrganizer."
+
+	SystemOrganizer default addCategory: self packageName.
+	(Object << 'RPackageOragizationSynchClass1')
+		package: self packageName;
+		tag: 'tag1';
+		install.
+	(Object << 'RPackageOragizationSynchClass2')
+		package: self packageName;
+		tag: 'tag2';
+		install.
+	self assert: (RPackageOrganizer default packageNames includes: self packageName).
+	self assert: (SystemOrganizer default includesCategory: self packageName).
+	self assert: (SystemOrganizer default includesCategory: self packageName , '-tag1').
+	self assert: (SystemOrganizer default includesCategory: self packageName , '-tag2').
+
+	self packageName asPackage removeFromSystem.
+
+	self deny: (RPackageOrganizer default packageNames includes: self packageName).
+	self deny: (SystemOrganizer default includesCategory: self packageName).
+	self deny: (SystemOrganizer default includesCategory: self packageName , '-tag1').
+	self deny: (SystemOrganizer default includesCategory: self packageName , '-tag2')
+]

--- a/src/RPackage-Tests/RPackageOrganizerAndSystemOrganizeSynchTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerAndSystemOrganizeSynchTest.class.st
@@ -23,6 +23,7 @@ RPackageOrganizerAndSystemOrganizeSynchTest >> tearDown [
 
 	(self packageName asPackageIfAbsent: [ nil ]) ifNotNil: [ :package | package removeFromSystem ].
 	SystemOrganizer default removeCategory: self packageName.
+	SystemOrganizer default removeCategoriesMatching: self packageName , '-*'.
 	super tearDown
 ]
 

--- a/src/System-Support/SystemOrganizer.class.st
+++ b/src/System-Support/SystemOrganizer.class.st
@@ -176,7 +176,7 @@ SystemOrganizer >> removeCategory: category [
 
 	categoryMap
 		at: category
-		ifPresent: [ :classes | classes ifNotEmpty: [ ^ self error: 'cannot remove non-empty category ' , category ] ]
+		ifPresent: [ :classes | classes ifNotEmpty: [ ^ self error: 'Cannot remove non-empty category ' , category , '. Present classes: ' , classes printString ] ]
 		ifAbsent: [ ^ self ].
 
 	categoryMap removeKey: category.


### PR DESCRIPTION
Currently we have two organization in the system managing the packages. 
- SystemOrganizer that is used by the system deeply
- RPackageOrganizer that is not really yet part of the Pharo MM

The goal is to make RPackageOrganizer part of the MM and to remove SystemOrganizer. But until we succeed (I hope during Pharo 12), we need to be sure that both are always in synch. While improving the protocol management of Pharo I got a crash and while investigating on it, I found at least 3 synchronization problems. 

Here is a fix for the first one. If you send #removeFromSystem to a package of RPackageOragnizer, the package is unloaded but SystemOrganizer still has the categories corresponding in it.