### PR TITLE
OpalCompiler: permit clients to use receiver: after context: as (a noop)

### DIFF
--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -612,7 +612,21 @@ OpalCompiler >> protocol: aProtocol [
 ]
 
 { #category : #accessing }
+OpalCompiler >> receiver [
+
+	^ self semanticScope ifNotNil: [ :scope |
+		  scope isDoItScope
+			  ifTrue: [ scope receiver ]
+			  ifFalse: [ nil ] ]
+]
+
+{ #category : #accessing }
 OpalCompiler >> receiver: anObject [
+
+	"Note: some clients set up a `receiver:` AFTER setting up a `context:`
+	BUT expect that the context remain,
+	so just noop if the receiver is already known, thus do not change the doit scope"
+	self receiver == anObject ifTrue: [ ^self ].
 	self semanticScope: (OCReceiverDoItSemanticScope targetingReceiver: anObject)
 ]
 


### PR DESCRIPTION
Some clients (e.g. Spec/Newtools) use both `receiver:` and `context:` when setting up a compiler.
This PR implements the previous behavior where the context is not lost if a redundant receiver is set.

This fixes an issue where DoIt evaluation of temps in the debugger is currently broken