### PR TITLE
SHRBTextStyler class>>#blueStyleTable distinguish some variables

### DIFF
--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -94,13 +94,13 @@ SHRBTextStyler class >> blueStyleTable [
 			(argument 								(blue muchDarker))
 			(blockTempVar 						(blue muchDarker))
 			(blockPatternTempVar 					(blue muchDarker))
-			(instVar 								(blue muchDarker))
+			(instVar 								(cyan muchDarker))
 
 			(tempVar 								(blue muchDarker))
 			(patternTempVar 						(blue muchDarker))
-			(poolConstant 							(blue muchDarker))
-			(classVar 								(blue muchDarker))
-			(globalVar 								(blue muchDarker))
+			(poolConstant 							(cyan muchDarker))
+			(classVar 								(cyan muchDarker))
+			(globalVar 								(purple muchDarker))
 
 			(incompleteIdentifier 					blue italic)
 			(incompleteSelector 					nil  italic)


### PR DESCRIPTION
Update the default blue style of SHRBTextStyler to distinguish some category of variables.
I did not use too many colors here to avoid adding too much noise.

* local variables (including temps, args and block args) remain blue
* receiver/class based variables (ivars and shareds) become cyan (it is the color of self)
* global variables become purple (that color is not used in the default blue theme)

![Capture d’écran du 2023-04-20 16-09-26](https://user-images.githubusercontent.com/135828/233476988-032dfe2b-e354-4626-bd0a-5877defde9fb.png)
