### PR TITLE
Style literal arrays

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -182,7 +182,7 @@ RBCodeSnippet class >> badComments [
 		        (self new
 			         source: '"a" #( "b" 1 "c" two "d" ( "e" 3 "f" ) "g" ) "h"';
 			         nodeAt: 'CCC 000DDD080EEE099900000AAAAAABAAAAAA0HHH00 III';
-			         styled: '"""    """ n """ ###       """ n """   """   """';
+			         styled: '""" 00 """ n """ ###     1 """ n """ 1 """ 0 """';
 			         formattedCode: '#( 1 two #( 3 ) )';
 			         value: #( 1 #two #( 3 ) )).
 		        (self new
@@ -207,7 +207,7 @@ RBCodeSnippet class >> badComments [
 		        (self new
 			         source: '"a" #[ "b" 1 "c" 2 "d" ] "e"';
 			         nodeAt: '888 000999060AAA070BBB00 CCC';
-			         styled: '"""    """ n """ n """   """';
+			         styled: '""" 00 """ n """ n """ 0 """';
 			         formattedCode: '#[ 1 2 ]';
 			         value: #[ 1 2 ]).
 		        (self new
@@ -436,7 +436,7 @@ RBCodeSnippet class >> badExpressions [
 		        (self new
 			         source: '#(1]2}3)';
 			         nodeAt: '00123450';
-			         styled: '  n#n#n ';
+			         styled: '00n#n#n0';
 			         formattedCode: '#( 1 #'']'' 2 #''}'' 3 )';
 			         isFaulty: false;
 			         value: #( 1 #']' 2 #'}' 3 )). "`#(` can eat almost anything"
@@ -447,6 +447,70 @@ RBCodeSnippet class >> badExpressions [
 			         formattedCode: '#( 0 1 r2 4 )';
 			         notices:
 				         #( #( 6 6 7 'an integer greater than 1 as valid radix expected' ) )). "Almost anything..."
+		        (self new
+			         source: '#( ( 0 1 2 ) )';
+			         nodeAt: '00011213141100';
+			         styled: '00 1 n n n 1 0';
+			         formattedCode: '#( #( 0 1 2 ) )';
+			         isFaulty: false;
+			         value: #( #( 0 1 2 ) )).
+		        (self new
+			         source: '#( #( 0 1 2 ) )';
+			         nodeAt: '000111213141100';
+			         styled: '00 11 n n n 1 0';
+			         isFaulty: false;
+			         value: #( #( 0 1 2 ) )).
+		        (self new
+			         source: '#( #( 0 1 2 )';
+			         nodeAt: '0001112131411';
+			         styled: 'XX 00 n n n 0';
+			         notices: #( #( 1 13 14 ''')'' expected' ) )).
+		        (self new
+			         source: '#( #( 0 1r2 3 ) )';
+			         nodeAt: '00011121344151100';
+			         styled: 'XX XX n XX# n X X';
+			         formattedCode: '#( #( 0 1 r2 3 ) )';
+			         notices:
+				         #( #( 9 9 10 'an integer greater than 1 as valid radix expected' ) )).
+		        (self new
+			         source: '#( #( 0 1r2 3 )';
+			         nodeAt: '000111213441511';
+			         styled: 'XX XX n XX# n X';
+			         formattedCode: '#( #( 0 1 r2 3 )';
+			         notices:
+				         #( #( 9 9 10 'an integer greater than 1 as valid radix expected' )
+				            #( 1 15 16 ''')'' expected' ) )).
+		        (self new
+			         source: '#( #[ 0 1 2 ] )';
+			         nodeAt: '000111213141100';
+			         styled: '00 00 n n n 0 0';
+			         isFaulty: false;
+			         value: #( #[ 0 1 2 ] )).
+		        (self new
+			         source: '#( #[ 0 1000 2 ] )';
+			         nodeAt: '000111213333141100';
+			         styled: 'XX XX n XXXX n X X';
+			         notices: #( #( 9 12 9 '8-bit integer expected' ) )).
+		        (self new
+			         source: '#( #[ 0 1 2 )';
+			         nodeAt: '0001112131415';
+			         styled: 'XX XX n n n X';
+			         notices: #( #( 13 13 13 '8-bit integer expected' )
+				            #( 4 13 14 ''']'' expected' )
+				            #( 1 13 14 ''')'' expected' ) )).
+		        (self new
+			         source: '#( #[ 0 1 2 ]';
+			         nodeAt: '0001112131411';
+			         styled: 'XX 00 n n n 0';
+			         notices: #( #( 1 13 14 ''')'' expected' ) )).
+		        (self new
+			         source: '[(#("a"("b"###("c"###["d"]#["e"]["f"]))))]';
+			         nodeAt: '0222EEE88889999999AAAAAAAABBBBBBC999D98220';
+			         styled: '0011"""2"""3333"""1111"""111"""1#   #32100';
+			         formattedCode:
+				         '[ #( #( #( #[ ] #[ ] #''['' #'']'' ) ) ) "a" "b" "c" "d" "e" ]';
+			         isFaulty: false;
+			         value: #( #( #( #[  ] #[  ] #'[' #']' ) ) )). "dry [ and ] in lit array are symbols"
 		        (self new
 			         source: '#[ 1 ) 2 ]';
 			         nodeAt: '0001020300';
@@ -505,13 +569,13 @@ RBCodeSnippet class >> badExpressions [
 		        (self new
 			         source: '#( )';
 			         nodeAt: '0000';
-			         styled: '    ';
+			         styled: '00 0';
 			         isFaulty: false;
 			         value: #(  )).
 		        (self new
 			         source: '#[ ]';
 			         nodeAt: '0000';
-			         styled: '    ';
+			         styled: '00 0';
 			         isFaulty: false;
 			         value: #[  ]).
 		        (self new
@@ -579,13 +643,13 @@ RBCodeSnippet class >> badExpressions [
 		        (self new
 			         source: '#(1)#(2)';
 			         nodeAt: '22324454';
-			         styled: '  n X n ';
+			         styled: '00n0X0n0';
 			         formattedCode: '#( 1 ). #( 2 )';
 			         notices: #( #( 1 4 5 'End of statement expected' ) )).
 		        (self new
 			         source: '#[1]#[2]';
 			         nodeAt: '22324454';
-			         styled: '  n X n ';
+			         styled: '00n0X0n0';
 			         formattedCode: '#[ 1 ]. #[ 2 ]';
 			         notices: #( #( 1 4 5 'End of statement expected' ) )).
 
@@ -1060,7 +1124,7 @@ RBCodeSnippet class >> badMethods [
 		        (self new
 			         source: '#(foo bar)';
 			         nodeAt: '3344435553';
-			         styled: 'X ### ### ';
+			         styled: 'X0### ###0';
 			         formattedCode: ' . #( foo bar )';
 			         notices: #( #( 1 0 1 'Message pattern expected' ) )).
 
@@ -1956,7 +2020,7 @@ RBCodeSnippet class >> badSimpleExpressions [
 		        (self new
 			         source: '#(^1)';
 			         nodeAt: '00120';
-			         styled: '  #n ';
+			         styled: '00#n0';
 			         formattedCode: '#( #''^'' 1 )';
 			         isFaulty: false;
 			         value: #( #'^' 1 )). "Obviously..."
@@ -2347,6 +2411,16 @@ RBCodeSnippet class >> badTokens [
 			         styled: 'XX#X#X';
 			         formattedCode: '#( Δ → ə )';
 			         notices: #( #( 4 4 4 'Unknown character' ) )). "This one is faulty because → is a parse error"
+		        (self new
+			         source: '#( ( Δ → ə ) )';
+			         nodeAt: '00011213141100';
+			         styled: 'XX X # X # X X';
+			         notices: #( #( 8 8 8 'Unknown character' ) )). "This one is faulty because → is a parse error"
+		        (self new
+			         source: '#( #( Δ → ə ) )';
+			         nodeAt: '000111213141100';
+			         styled: 'XX XX # X # X X';
+			         notices: #( #( 9 9 9 'Unknown character' ) )). "This one is faulty because → is a parse error"
 		        (self new
 			         source: '#→';
 			         nodeAt: '12';

--- a/src/AST-Core/RBLiteralArrayNode.class.st
+++ b/src/AST-Core/RBLiteralArrayNode.class.st
@@ -11,7 +11,8 @@ Class {
 	#superclass : #RBLiteralNode,
 	#instVars : [
 		'isByteArray',
-		'contents'
+		'contents',
+		'openerSize'
 	],
 	#category : #'AST-Core-Nodes'
 }
@@ -112,6 +113,18 @@ RBLiteralArrayNode >> match: aNode inContext: aDictionary [
 		matchList: contents
 		against: aNode contents
 		inContext: aDictionary
+]
+
+{ #category : #accessing }
+RBLiteralArrayNode >> openerSize [
+
+	^ openerSize
+]
+
+{ #category : #accessing }
+RBLiteralArrayNode >> openerSize: anObject [
+
+	openerSize := anObject
 ]
 
 { #category : #copying }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -648,18 +648,18 @@ RBParser >> parseLiteralArray [
 	self step.
 	faulty ifTrue: [
 		^ RBLiteralArrayErrorNode new
-			value: '#(';
+			value: startToken value asString;
 		 	start: startToken start;
 			contents: literals;
 			valueAfter: ')';
 			stop: stop;
 			propertyAt: #notices put: OrderedCollection new;
 			yourself ].
-	^self literalArrayNodeClass
+	^(self literalArrayNodeClass
 		startPosition: startToken start
 		contents: literals
 		stopPosition: stop
-		isByteArray: false
+		isByteArray: false) openerSize: startToken length.
 ]
 
 { #category : #'private - parsing' }
@@ -700,18 +700,18 @@ RBParser >> parseLiteralByteArray [
 	self step.
 	faulty ifTrue: [
 		^ RBLiteralByteArrayErrorNode new
-			value: '#[';
+			value: startToken value asString;
 		 	start: startToken start;
 			contents: stream contents;
 			valueAfter: ']';
 			stop: stop;
 			propertyAt: #notices put: OrderedCollection new;
 			yourself ].
-	^self literalArrayNodeClass
+	^(self literalArrayNodeClass
 		startPosition: startToken start
 		contents: stream contents
 		stopPosition: stop
-		isByteArray: true
+		isByteArray: true) openerSize: startToken length.
 ]
 
 { #category : #'private - parsing' }

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -467,10 +467,10 @@ RBScanner >> scanLiteral [
 RBScanner >> scanLiteralArrayToken [
 	"This scan accepts any character but is only meant to be used when a # is followed by ( or [ ."
 	| token |
-	token := RBLiteralArrayToken
-				value: (String with: $# with: currentCharacter)
-				start: tokenStart.
 	self step.
+	token := RBLiteralArrayToken
+				value: (self scanBackFrom: tokenStart)
+				start: tokenStart.
 	^token
 ]
 

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -1005,12 +1005,12 @@ SHRBTextStyler >> visitLiteralArrayNode: aRBLiteralArrayNode [
 
 	self
 		addStyle: style
-		from: aRBLiteralArrayNode start
-		to: aRBLiteralArrayNode start + aRBLiteralArrayNode openerSize - 1.
+		from: aRBLiteralArrayNode startWithoutParentheses
+		to: aRBLiteralArrayNode startWithoutParentheses + aRBLiteralArrayNode openerSize - 1.
 	self
 		addStyle: style
-		from: aRBLiteralArrayNode stop
-		to: aRBLiteralArrayNode stop.
+		from: aRBLiteralArrayNode stopWithoutParentheses
+		to: aRBLiteralArrayNode stopWithoutParentheses.
 
 	aRBLiteralArrayNode contents do: [ :each | self visitNode: each ].
 

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -990,6 +990,36 @@ SHRBTextStyler >> visitEnglobingErrorNode: anEnglobingErrorNode [
 ]
 
 { #category : #visiting }
+SHRBTextStyler >> visitLiteralArrayNode: aRBLiteralArrayNode [
+	"We reuse the nested brackets/parenthesis style.
+	The main point it to easyly match opener and closer, nor necesarily to add type semanting"
+
+	| style |
+	aRBLiteralArrayNode isForByteArray
+		ifTrue: [
+			style := self bracketStyleName.
+			bracketLevel := bracketLevel + 1 ]
+		ifFalse: [
+			style := self parenthesisStyleName.
+			parentheseLevel := parentheseLevel + 1 ].
+
+	self
+		addStyle: style
+		from: aRBLiteralArrayNode start
+		to: aRBLiteralArrayNode start + aRBLiteralArrayNode openerSize - 1.
+	self
+		addStyle: style
+		from: aRBLiteralArrayNode stop
+		to: aRBLiteralArrayNode stop.
+
+	aRBLiteralArrayNode contents do: [ :each | self visitNode: each ].
+
+	aRBLiteralArrayNode isForByteArray
+		ifTrue: [ bracketLevel := bracketLevel - 1 ]
+		ifFalse: [ parentheseLevel := parentheseLevel - 1 ]
+]
+
+{ #category : #visiting }
 SHRBTextStyler >> visitLiteralValueNode: aLiteralValueNode [
 
 	| value attributes |


### PR DESCRIPTION
This depends on #13500 to avoid conflicts

Literal arrays and literal byte arrays were unstyled: openers and closers stay black, whereas parenthesis of values and brackets of blocks are so colorful.
The point of coloring openers and closers is to easily match them, and because literal arrays can be nested in parentheses, blocks, and even other literal arrays, using color to keep track of the nesting level make sense.

![Capture d’écran du 2023-04-20 19-47-40](https://user-images.githubusercontent.com/135828/233509329-84ae687f-b937-427f-b272-e72259de822a.png)

Because there is no style name for literal arrays, I reused the brackets & parenthesis ones. It is consistent, especially when there are a bunch of closers.

Note: to correctly style the openers, the size of the open token was missing in the AST node, and the scanner did not give back the truth (why?). This is important because both `#(())` and `#(#())` are equivalent (and also `####(####())` for some unknown reasons)