### PR TITLE
Make Protocol announcements use real protocols

### DIFF
--- a/src/Calypso-SystemQueries/ClassDescription.extension.st
+++ b/src/Calypso-SystemQueries/ClassDescription.extension.st
@@ -5,7 +5,7 @@ ClassDescription >> tagsForAllMethods [
 	"I act as #tagsForMethods but I also takes into account methods comming from traits"
 
 	| allProtocols |
-	allProtocols := self organization protocols reject: [ :each | each name = Protocol unclassified | each isExtensionProtocol ].
+	allProtocols := self organization protocols reject: [ :each | each isUnclassifiedProtocol | each isExtensionProtocol ].
 
 	^ allProtocols
 		select: [ :protocol | protocol methodSelectors ifEmpty: [ true ] ifNotEmpty: [ :methods | methods anySatisfy: [ :method | self selectors includes: method ] ] ]

--- a/src/Calypso-SystemQueries/TraitedMetaclass.extension.st
+++ b/src/Calypso-SystemQueries/TraitedMetaclass.extension.st
@@ -5,9 +5,7 @@ TraitedMetaclass >> tagsForAllMethods [
 	"I act as #tagsForMethods but I also takes into account methods comming from traits"
 
 	| allProtocols selectors |
-
-	allProtocols := self organization protocols
-		reject: [ :each | each name = Protocol unclassified | each isExtensionProtocol ].
+	allProtocols := self organization protocols reject: [ :each | each isUnclassifiedProtocol | each isExtensionProtocol ].
 
 	selectors := self visibleMethods collect: [ :each | each selector ].
 

--- a/src/Deprecated12/ClassOrganization.extension.st
+++ b/src/Deprecated12/ClassOrganization.extension.st
@@ -135,15 +135,6 @@ ClassOrganization >> notifyOfChangedCategoriesFrom: oldProtocolName to: newProto
 ]
 
 { #category : #'*Deprecated12' }
-ClassOrganization >> notifyOfRemovedCategory: protocolName [
-
-	self
-		deprecated: 'Use #notifyOfRemovedProtocolNamed: instead.'
-		transformWith: '`@rcv notifyOfRemovedCategory: `@arg' -> '`@rcv notifyOfRemovedProtocolNamed: `@arg'.
-	self notifyOfRemovedProtocolNamed: protocolName
-]
-
-{ #category : #'*Deprecated12' }
 ClassOrganization >> removeCategory: protocolName [
 
 	self deprecated: 'Use #removeProtocolIfEmpty: instead.' transformWith: '`@rcv removeCategory: `@arg' -> '`@rcv removeProtocolIfEmpty: `@arg'.

--- a/src/Deprecated12/ProtocolRenamed.extension.st
+++ b/src/Deprecated12/ProtocolRenamed.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : #ProtocolRenamed }
+
+{ #category : #'*Deprecated12' }
+ProtocolRenamed >> newProtocolName [
+
+	self deprecated: 'Use #newProtocol instead' transformWith: '`@rcv newProtocolName' -> '`@rcv newProtocol'.
+	^ self newProtocol
+]
+
+{ #category : #'*Deprecated12' }
+ProtocolRenamed >> oldProtocolName [
+
+	self deprecated: 'Use #oldProtocol instead' transformWith: '`@rcv oldProtocolName' -> '`@rcv oldProtocol'.
+	^ self oldProtocol
+]

--- a/src/Epicea/EpMonitor.class.st
+++ b/src/Epicea/EpMonitor.class.st
@@ -548,7 +548,7 @@ EpMonitor >> protocolAdded: aProtocolAdded [
 EpMonitor >> protocolRemoved: aProtocolRemoved [
 
 	"Skip an irrelevant case"
-	aProtocolRemoved protocol name = Protocol unclassified ifTrue: [ ^self ].
+	aProtocolRemoved protocol isUnclassifiedProtocol ifTrue: [ ^self ].
 
 	self handleAnyErrorDuring: [
 		self addEvent:

--- a/src/Epicea/EpMonitor.class.st
+++ b/src/Epicea/EpMonitor.class.st
@@ -541,7 +541,7 @@ EpMonitor >> protocolAdded: aProtocolAdded [
 		self addEvent:
 			(EpProtocolAddition
 				behavior: aProtocolAdded classAffected
-				protocol: aProtocolAdded protocol)]
+				protocol: aProtocolAdded protocol name)]
 ]
 
 { #category : #'announcement handling' }

--- a/src/Epicea/EpMonitor.class.st
+++ b/src/Epicea/EpMonitor.class.st
@@ -548,13 +548,13 @@ EpMonitor >> protocolAdded: aProtocolAdded [
 EpMonitor >> protocolRemoved: aProtocolRemoved [
 
 	"Skip an irrelevant case"
-	aProtocolRemoved protocol = Protocol unclassified ifTrue: [ ^self ].
+	aProtocolRemoved protocol name = Protocol unclassified ifTrue: [ ^self ].
 
 	self handleAnyErrorDuring: [
 		self addEvent:
 			(EpProtocolRemoval
 				behavior: aProtocolRemoved classAffected
-				protocol: aProtocolRemoved protocol)]
+				protocol: aProtocolRemoved protocol name)]
 ]
 
 { #category : #'announcement handling' }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -1095,7 +1095,7 @@ ClassDescription >> tagsForMethods [
 	which is opposite to current Protocol implementation.
 	And extension protocol is not treated as tag"
 	| allProtocols |
-	allProtocols := self organization protocols reject: [ :each | each name = Protocol unclassified | each isExtensionProtocol ].
+	allProtocols := self organization protocols reject: [ :each | each isUnclassifiedProtocol | each isExtensionProtocol ].
 
 	^ allProtocols select: [ :each | self isLocalMethodsProtocol: each ] thenCollect: #name
 ]

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -32,7 +32,7 @@ ClassOrganization >> addProtocol: aProtocol [
 
 	protocols := protocols copyWith: protocol.
 
-	SystemAnnouncer announce: (ProtocolAdded in: self organizedClass protocol: aProtocol).
+	SystemAnnouncer announce: (ProtocolAdded in: self organizedClass protocol: protocol).
 	self notifyOfChangedProtocolNamesFrom: oldProtocols to: self protocolNames.
 	^ protocol
 ]

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -159,12 +159,6 @@ ClassOrganization >> notifyOfChangedSelector: element from: oldProtocolName to: 
 	oldProtocolName ~= newProtocolName ifTrue: [ self organizedClass notifyOfRecategorizedSelector: element from: oldProtocolName to: newProtocolName ]
 ]
 
-{ #category : #notifications }
-ClassOrganization >> notifyOfRemovedProtocolNamed: protocolName [
-
-	SystemAnnouncer announce: (ProtocolRemoved in: self organizedClass protocol: protocolName)
-]
-
 { #category : #accessing }
 ClassOrganization >> organizedClass [
 
@@ -261,7 +255,7 @@ ClassOrganization >> removeProtocolIfEmpty: aProtocol [
 
 	oldProtocolNames := self protocolNames copy.
 	protocols := protocols copyWithout: protocol.
-	self notifyOfRemovedProtocolNamed: protocol name.
+	SystemAnnouncer announce: (ProtocolRemoved in: self organizedClass protocol: protocol).
 	self notifyOfChangedProtocolNamesFrom: oldProtocolNames to: self protocolNames
 ]
 

--- a/src/Kernel/Protocol.class.st
+++ b/src/Kernel/Protocol.class.st
@@ -76,6 +76,12 @@ Protocol >> isExtensionProtocol [
 ]
 
 { #category : #testing }
+Protocol >> isUnclassifiedProtocol [
+
+	^ self name = self class unclassified
+]
+
+{ #category : #testing }
 Protocol >> isVirtualProtocol [
 	"A virtual protocol is a calculated one (it does not have any methods by it self)"
 	^ false

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -842,9 +842,7 @@ RPackageOrganizer >> registerInterestToAnnouncer: anAnnouncer [
 		when:  MethodAdded send: #systemMethodAddedActionFrom: to: self;
 		when:  MethodModified send: #systemMethodModifiedActionFrom: to: self;
 		when:  MethodRecategorized send: #systemMethodRecategorizedActionFrom: to: self;
-		when:  MethodRemoved send: #systemMethodRemovedActionFrom: to: self;
-		when:  ProtocolAdded send: #systemProtocolAddedActionFrom: to: self;
-		when:  ProtocolRemoved send: #systemProtocolRemovedActionFrom: to: self.
+		when:  MethodRemoved send: #systemMethodRemovedActionFrom: to: self.
 
 	self flag: #hack. "for decoupling MC"
 	self class environment at: #MCWorkingCopy ifPresent: [
@@ -1264,17 +1262,6 @@ RPackageOrganizer >> systemOrganizer [
 RPackageOrganizer >> systemOrganizer: anObject [
 
 	systemOrganizer := anObject
-]
-
-{ #category : #'system integration' }
-RPackageOrganizer >> systemProtocolAddedActionFrom: ann [
-
-	"for now I don't see anything to do'"
-]
-
-{ #category : #'system integration' }
-RPackageOrganizer >> systemProtocolRemovedActionFrom: ann [
-	"to be unregistered"
 ]
 
 { #category : #accessing }

--- a/src/SUnit-Core/ClassTestCase.class.st
+++ b/src/SUnit-Core/ClassTestCase.class.st
@@ -138,8 +138,7 @@ ClassTestCase >> testNew [
 ClassTestCase >> testUnCategorizedMethods [
 
 	| uncategorizedMethods |
-	uncategorizedMethods := self targetClass selectorsInProtocol:
-		                        Protocol unclassified.
+	uncategorizedMethods := self targetClass selectorsInProtocol: Protocol unclassified.
 	self
 		assert: uncategorizedMethods isEmpty
 		description: uncategorizedMethods asString

--- a/src/System-Announcements-Tests/SystemAnnouncerTest.class.st
+++ b/src/System-Announcements-Tests/SystemAnnouncerTest.class.st
@@ -42,7 +42,7 @@ SystemAnnouncerTest >> testProtocolAdded [
 
 	self assert: pass.
 	self assert: classReorganized equals: class.
-	self assert: protocolAdded equals: 'shiny-new-category'
+	self assert: protocolAdded name equals: 'shiny-new-category'
 ]
 
 { #category : #tests }

--- a/src/System-Announcements-Tests/SystemAnnouncerTest.class.st
+++ b/src/System-Announcements-Tests/SystemAnnouncerTest.class.st
@@ -63,7 +63,7 @@ SystemAnnouncerTest >> testProtocolRemoved [
 
 	self assert: pass.
 	self assert: classRemoved equals: class.
-	self assert: protocolRemoved equals: 'shiny-new-category'
+	self assert: protocolRemoved name equals: 'shiny-new-category'
 ]
 
 { #category : #tests }

--- a/src/System-Announcements/ProtocolAdded.class.st
+++ b/src/System-Announcements/ProtocolAdded.class.st
@@ -1,5 +1,7 @@
 "
-This class is not used, but should be used when we hook into the addition and removal of protocols. Right now, we only get ClassReorganizedAnnouncement
+I am an announcement raised when we add a new protocol in a class.
+
+I know the protocol that was added and allows users to react to it.
 "
 Class {
 	#name : #ProtocolAdded,

--- a/src/System-Announcements/ProtocolAdded.class.st
+++ b/src/System-Announcements/ProtocolAdded.class.st
@@ -1,7 +1,7 @@
 "
 I am an announcement raised when we add a new protocol in a class.
 
-I know the protocol that was added and allows users to react to it.
+I know the protocol that was added and allow users to react to it.
 "
 Class {
 	#name : #ProtocolAdded,

--- a/src/System-Announcements/ProtocolAdded.class.st
+++ b/src/System-Announcements/ProtocolAdded.class.st
@@ -8,12 +8,3 @@ Class {
 	#superclass : #ProtocolAnnouncement,
 	#category : #'System-Announcements-System-Protocols'
 }
-
-{ #category : #'class initialization' }
-ProtocolAdded class >> in: aClass protocol: aProtocolName [
-
-	^ self new
-		  classReorganized: aClass;
-		  protocol: aProtocolName;
-		  yourself
-]

--- a/src/System-Announcements/ProtocolAnnouncement.class.st
+++ b/src/System-Announcements/ProtocolAnnouncement.class.st
@@ -11,6 +11,15 @@ Class {
 	#category : #'System-Announcements-System-Protocols'
 }
 
+{ #category : #'class initialization' }
+ProtocolAnnouncement class >> in: aClass protocol: aProtocolName [
+
+	^ self new
+		  classReorganized: aClass;
+		  protocol: aProtocolName;
+		  yourself
+]
+
 { #category : #testing }
 ProtocolAnnouncement >> affectsMethodTagIn: aClass [
 

--- a/src/System-Announcements/ProtocolRemoved.class.st
+++ b/src/System-Announcements/ProtocolRemoved.class.st
@@ -1,5 +1,7 @@
 "
-This class is not used, but should be used when we hook into the addition and removal of protocols. Right now, we only get ClassReorganizedAnnouncement
+I am an announcement raised when we add a protocol is removed from a class.
+
+I know the protocol that was removed and allow users to react to it.
 "
 Class {
 	#name : #ProtocolRemoved,

--- a/src/System-Announcements/ProtocolRemoved.class.st
+++ b/src/System-Announcements/ProtocolRemoved.class.st
@@ -8,12 +8,3 @@ Class {
 	#superclass : #ProtocolAnnouncement,
 	#category : #'System-Announcements-System-Protocols'
 }
-
-{ #category : #'class initialization' }
-ProtocolRemoved class >> in: aClass protocol: aProtocolName [
-
-	^ self new
-		  classReorganized: aClass;
-		  protocol: aProtocolName;
-		  yourself
-]

--- a/src/System-Announcements/ProtocolRenamed.class.st
+++ b/src/System-Announcements/ProtocolRenamed.class.st
@@ -1,11 +1,13 @@
 "
-This is event about protocol rename. It should substitute ClassReorganized announcement 
+I am an announcement raised when we rename a protocol.
+
+I should not be used because I will soon be removed since a rename is an addition and a removal in the end.
 "
 Class {
 	#name : #ProtocolRenamed,
 	#superclass : #ProtocolAnnouncement,
 	#instVars : [
-		'newProtocolName'
+		'newProtocol'
 	],
 	#category : #'System-Announcements-System-Protocols'
 }
@@ -13,29 +15,31 @@ Class {
 { #category : #'class initialization' }
 ProtocolRenamed class >> in: aClass from: oldName to: newName [
 
-	^ self new
-		  classReorganized: aClass;
-		  oldProtocolName: oldName;
-		  newProtocolName: newName;
+	^ (self in: aClass protocol: oldName)
+		  newProtocol: newName;
 		  yourself
 ]
 
 { #category : #accessing }
-ProtocolRenamed >> newProtocolName [
-	^ newProtocolName
+ProtocolRenamed >> newProtocol [
+
+	^ newProtocol
 ]
 
 { #category : #accessing }
-ProtocolRenamed >> newProtocolName: anObject [
-	newProtocolName := anObject
+ProtocolRenamed >> newProtocol: anObject [
+
+	newProtocol := anObject
 ]
 
 { #category : #accessing }
-ProtocolRenamed >> oldProtocolName [
-	^ protocol
+ProtocolRenamed >> oldProtocol [
+
+	^ self protocol
 ]
 
 { #category : #accessing }
-ProtocolRenamed >> oldProtocolName: aString [
+ProtocolRenamed >> oldProtocol: aString [
+
 	self protocol: aString
 ]


### PR DESCRIPTION
Until now the Protocol announcements were wrapping a protocol name. Now I updated the announcements so that they return a real protocol. 

For now their users are asking the name to the protocol but in the next steps we can update that so that they also manipulate the real protocol. 

Here are some other improvements that are ship:
- Removal of #notifyOfRemovedProtocolNamed: that is called only at one place and should not be used be external users
- Introduce Protocol>>isUnclassifiedProtocol and use it to avoid some `p name = Protocol unclassified` (since I want to remove a maximum of reference to Protocol unclassified since it shows internal details)
- Remove two RPackageOrganizer registrations to the SystemAnnouncer that are not used (it just waste time)
- Add better comments to the announcements since the previous ones were out of date

## Next step 

The next step is to do the same thing in MethodAnnouncements and it will simplify the code of RPackage, but we are limited by the fact that CompileMethod>>protocol returns a string. 