### PR TITLE
CompiledMethod simplification: remove the last user of #copyWithSource:

### DIFF
--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -363,11 +363,6 @@ CompiledMethod >> containsHalt [
 	^ self hasProperty: #containsHalt
 ]
 
-{ #category : #'source code management' }
-CompiledMethod >> copyWithSource: aString [
-	^self copyWithTrailerBytes: (CompiledMethodTrailer new sourceCode: aString)
-]
-
 { #category : #initialization }
 CompiledMethod >> copyWithTrailerBytes: trailer [
 "Testing:

--- a/src/System-Sources/CompiledMethod.extension.st
+++ b/src/System-Sources/CompiledMethod.extension.st
@@ -25,5 +25,6 @@ CompiledMethod >> putSource: source withPreamble: preambleBlock [
 			"Update with new source pointer"
 			self setSourcePointer: newSourcePointer ]
 		onFail: [
-			self becomeForward: (self copyWithSource: source) ]
+			self traceCr: 'Warning, could not write sources'.
+			self propertyAt: #source put: source ]
 ]

--- a/src/System-Sources/CompiledMethod.extension.st
+++ b/src/System-Sources/CompiledMethod.extension.st
@@ -25,6 +25,6 @@ CompiledMethod >> putSource: source withPreamble: preambleBlock [
 			"Update with new source pointer"
 			self setSourcePointer: newSourcePointer ]
 		onFail: [
-			self traceCr: 'Warning, could not write sources'.
+			"if we can not store the source pointer, we put back the property"
 			self propertyAt: #source put: source ]
 ]


### PR DESCRIPTION
The idea is that we want to radically simplify the CompiledMethodTrailer. One step is to not support storing source in the trailer, but to instead put it as a methodProperty. This PR changes the "onFail:" when storing sources to log and store the sourse as  a property.