### PR TITLE
Detach compilationContext a little

### DIFF
--- a/src/NECompletion/RBVariableNode.extension.st
+++ b/src/NECompletion/RBVariableNode.extension.st
@@ -18,7 +18,7 @@ RBVariableNode >> classVarEntriesForClass: lookupClass [
 RBVariableNode >> completionEntries: offset [
 	| methodNode lookupClass |
 	methodNode := self methodNode.
-	lookupClass := methodNode compilationContext getClass.
+	lookupClass := methodNode methodClass.
 	self isDefinition
 		ifTrue: [ ^ self possibleSelectorEntries ].
 

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -261,7 +261,7 @@ OCASTSemanticAnalyzer >> visitPragmaNode: aPragmaNode [
 	super visitPragmaNode: aPragmaNode.
 	aPragmaNode selector = #compilerOptions: ifTrue: [
 		aPragmaNode asPragma sendTo:
-			aPragmaNode methodNode compilationContext ].
+			self compilationContext ].
 
 	"if the pragma is a primitive that defines an error variable, we need to declare a temp
 	for it"

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -449,6 +449,13 @@ OCASTTranslator >> privateMethodBuilder [
 	^ methodBuilder
 ]
 
+{ #category : #private }
+OCASTTranslator >> subTranslator [
+	"Return a new translator that can be used on blocks"
+
+	^ self compilationContext astTranslatorClass new compilationContext: self compilationContext
+]
+
 { #category : #'visitor - double dispatching' }
 OCASTTranslator >> translateConstantBlock: aBlockNode [
 	| ir |
@@ -534,7 +541,7 @@ OCASTTranslator >> visitBlockNode: aBlockNode [
 	(self compilationContext optionConstantBlockClosure and: [aBlockNode isConstant and: [ aBlockNode numArgs < 4  ]]) ifTrue: [ ^ self visitConstantBlockNode: aBlockNode].
 	(self compilationContext optionCleanBlockClosure and: [ aBlockNode isClean ]) ifTrue: [ ^ self visitCleanBlockNode: aBlockNode].
 
-	compiledBlock := self compilationContext astTranslatorClass new translateFullBlock: aBlockNode.
+	compiledBlock := self subTranslator translateFullBlock: aBlockNode.
 
 	self compilationContext optionBlockClosureOptionalOuter
 		ifTrue: [ methodBuilder pushFullClosureCompiledBlock: compiledBlock copiedValues: aBlockNode scope inComingCopiedVarNames outerContextNeeded: aBlockNode hasNonLocalReturn  ]
@@ -559,8 +566,7 @@ OCASTTranslator >> visitCleanBlockNode: aBlockNode [
 
 	| compiledBlock cleanBlock |
 
-	compiledBlock := self compilationContext astTranslatorClass new
-		                 translateFullBlock: aBlockNode.
+	compiledBlock := self subTranslator translateFullBlock: aBlockNode.
 	cleanBlock := CleanBlockClosure compiledBlock: compiledBlock.
 
 	methodBuilder pushLiteral: cleanBlock

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -475,7 +475,6 @@ OCASTTranslator >> translateConstantBlock: aBlockNode [
 OCASTTranslator >> translateFullBlock: aBlockNode [
 
 	methodBuilder mapToNode: aBlockNode.
-	methodBuilder compilationContext: aBlockNode methodNode compilationContext.
 
 	"args, then copied, then temps"
 	methodBuilder addTemps: aBlockNode argumentNames.
@@ -686,7 +685,6 @@ OCASTTranslator >> visitMethodNode: aMethodNode [
 
 	aMethodNode isError ifTrue: [self emitRuntimeError: aMethodNode ].
 
-	methodBuilder compilationContext: aMethodNode compilationContext.
 	methodBuilder addTemps: aMethodNode scope tempVarNames.
 
 	methodBuilder properties: aMethodNode methodProperties.

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -58,6 +58,11 @@ OCASTTranslator >> compilationContext [
 	^methodBuilder compilationContext
 ]
 
+{ #category : #accessing }
+OCASTTranslator >> compilationContext: anObject [
+	methodBuilder compilationContext: anObject
+]
+
 { #category : #'inline messages factored' }
 OCASTTranslator >> emitAllButLastCases: cases [
 

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -84,6 +84,7 @@ RBMethodNode >> generateIR [
 	].
 
  	ir := (self compilationContext astTranslatorClass new
+			compilationContext: self compilationContext;
 			visitNode: self)
 			ir.
 	^ self ir: ir

--- a/src/Reflectivity/RFASTTranslator.class.st
+++ b/src/Reflectivity/RFASTTranslator.class.st
@@ -37,7 +37,7 @@ RFASTTranslator >> emitMetaLinkAfterEnsure: aNode [
 	(aNode parent scope copiedVars, aNode parent scope tempVars) do: [ :var |
 		ensureBlock scope addCopyingTempToAllScopesUpToDefTemp: var].
 
-	compiledBlock := self compilationContext astTranslatorClass new translateFullBlock: ensureBlock.
+	compiledBlock := self subTranslator translateFullBlock: ensureBlock.
 	methodBuilder pushFullClosureCompiledBlock: compiledBlock copiedValues: ensureBlock scope copiedVarNames.
 	methodBuilder send: #ensure:
 ]
@@ -114,7 +114,7 @@ RFASTTranslator >> visitBlockNode: aBlockNode [
 	aBlockNode hasMetalinkInstead
 				ifTrue: [ self emitMetaLinkInstead: aBlockNode ]
 				ifFalse: [
-	compiledBlock := self compilationContext astTranslatorClass new translateFullBlock: aBlockNode.
+	compiledBlock := self subTranslator translateFullBlock: aBlockNode.
 	(self compilationContext optionCleanBlockClosure and: [ aBlockNode isClean ])
 		ifTrue: [ methodBuilder pushLiteral: (CleanBlockClosure compiledBlock: compiledBlock)]
 		ifFalse: [methodBuilder pushFullClosureCompiledBlock: compiledBlock copiedValues: aBlockNode scope inComingCopiedVarNames  ].
@@ -303,7 +303,7 @@ RFASTTranslator >> visitSequenceWithAfter: aSequenceNode [
 	 (aSequenceNode parent scope copiedVars, aSequenceNode parent scope tempVars) do: [ :var |
 		wrappedBlock scope addCopyingTempToAllScopesUpToDefTemp: var].
 
-	compiledBlock := self compilationContext astTranslatorClass new translateFullBlock: wrappedBlock.
+	compiledBlock := self subTranslator translateFullBlock: wrappedBlock.
 	methodBuilder pushFullClosureCompiledBlock: compiledBlock copiedValues: wrappedBlock scope copiedVarNames.
 	self emitMetaLinkAfterEnsure: aSequenceNode
 ]

--- a/src/Reflectivity/RFASTTranslator.class.st
+++ b/src/Reflectivity/RFASTTranslator.class.st
@@ -214,7 +214,6 @@ RFASTTranslator >> visitMethodNode: aMethodNode [
 
 	aMethodNode isError ifTrue: [self emitRuntimeError: aMethodNode ].
 
-	methodBuilder compilationContext: aMethodNode compilationContext.
 	methodBuilder addTemps: aMethodNode scope tempVarNames.
 
 	aMethodNode isPrimitive ifFalse: [self emitPreamble: aMethodNode. self emitMetaLinkBefore: aMethodNode].


### PR DESCRIPTION
A first cleaning step for #13508 that reduces the usage of on `RBMethodNode>>compilationContext`

* Two low-hanging fruits: `RBVariableNode>>#completionEntries:` and `OCASTSemanticAnalyzer>>#visitPragmaNode`
* OCASTTranslator (and subclasses) configure the compilation context earlier (so do not rely on the same one attached to the AST node). It also simplifies the code