### PR TITLE
Reduce usage of compilationContext from IR* Classes

### DIFF
--- a/src/OpalCompiler-Core/IRBuilder.class.st
+++ b/src/OpalCompiler-Core/IRBuilder.class.st
@@ -184,7 +184,8 @@ IRBuilder >> initialize [
 { #category : #results }
 IRBuilder >> ir [
 
-	^ ir optimize
+	self optimize.
+	^ ir
 ]
 
 { #category : #accessing }
@@ -266,6 +267,15 @@ IRBuilder >> mapToNode: object [
 IRBuilder >> numArgs: anInteger [
 	ir numArgs: anInteger.
 	ir sourceNode: self sourceNode
+]
+
+{ #category : #optimizing }
+IRBuilder >> optimize [
+	"Perform configured optimizations"
+
+	ir removeEmptyStart.
+	self compilationContext optionOptimizeIR ifFalse: [^self].
+	ir absorbJumpsToSingleInstrs
 ]
 
 { #category : #mapping }

--- a/src/OpalCompiler-Core/IRMethod.class.st
+++ b/src/OpalCompiler-Core/IRMethod.class.st
@@ -258,8 +258,9 @@ IRMethod >> numArgs: anInteger [
 
 { #category : #optimizing }
 IRMethod >> optimize [
+	"Perform all optimizations"
+
 	self removeEmptyStart.
-	self compilationContext optionOptimizeIR ifFalse: [^self].
 	self absorbJumpsToSingleInstrs
 ]
 

--- a/src/OpalCompiler-Core/IRMethod.class.st
+++ b/src/OpalCompiler-Core/IRMethod.class.st
@@ -144,11 +144,6 @@ IRMethod >> firstInstructionMatching: aBlock [
 	^nil
 ]
 
-{ #category : #accessing }
-IRMethod >> forceLongForm [
-	^ self compilationContext optionLongIvarAccessBytecodes
-]
-
 { #category : #translating }
 IRMethod >> generate [
 	^self generate: CompiledMethodTrailer empty

--- a/src/OpalCompiler-Core/IRTranslator.class.st
+++ b/src/OpalCompiler-Core/IRTranslator.class.st
@@ -145,7 +145,7 @@ IRTranslator >> visitMethod: anIr [
 	gen numArgs: anIr numArgs.
 	gen properties: anIr properties.
 	gen numTemps: (anIr tempMap size).
-	gen forceLongForm: anIr forceLongForm.
+	gen forceLongForm: self compilationContext optionLongIvarAccessBytecodes.
 	self visitSequences: anIr allSequences.
 	"Literals for sends and pushLiteral: are added later, here we
 	add all the additionalLiterals from e.g. optimized constructs like #ifTrue:.


### PR DESCRIPTION
In relation with, #13508 I looked what is the usage of compilationContext in IR related classes.
I did not find that much easy improvement to make.