### PR TITLE
[do not merge] Add outerscope to SemanticAnalysis

### DIFF
--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -477,7 +477,7 @@ RBMethodNode >> method [
 { #category : #'accessing - compiled method' }
 RBMethodNode >> methodClass [
 
-	^ methodClass ifNil: [ self compilationContext ifNotNil: [ :ctxt | ctxt getClass ] ]
+	^ methodClass
 ]
 
 { #category : #'accessing - compiled method' }

--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -31,7 +31,8 @@ Class {
 		'replacements',
 		'nodeReplacements',
 		'compilationContext',
-		'bcToASTCache'
+		'bcToASTCache',
+		'methodClass'
 	],
 	#category : #'AST-Core-Nodes'
 }
@@ -476,12 +477,13 @@ RBMethodNode >> method [
 { #category : #'accessing - compiled method' }
 RBMethodNode >> methodClass [
 
-	^ self compilationContext ifNotNil: [ :ctxt | ctxt getClass ]
+	^ methodClass ifNil: [ self compilationContext ifNotNil: [ :ctxt | ctxt getClass ] ]
 ]
 
 { #category : #'accessing - compiled method' }
 RBMethodNode >> methodClass: aClass [
-	self semanticScope: (OCMethodSemanticScope targetingClass: aClass)
+
+	methodClass := aClass
 ]
 
 { #category : #accessing }

--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -243,6 +243,15 @@ RBMethodNode >> compilationContext: aCompilationContext [
 	compilationContext := aCompilationContext
 ]
 
+{ #category : #'accessing - compiled method' }
+RBMethodNode >> compilationContextOrDefault [
+	"If no compilation context, allocate a minimal one based on the method class (or nil class if none).
+	This is needed because dependency injection and to get a correct default set of compilation options"
+
+	^ compilationContext ifNil: [
+		  compilationContext := self methodClass compiler compilationContext ]
+]
+
 { #category : #'accessing - conceptual' }
 RBMethodNode >> conceptualArgumentSize [
 	"Return the cumulted length of the parameters (yes parameters are called arguments in Pharo - not good!). It does not count spaces and the selectors.

--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -695,14 +695,6 @@ RBMethodNode >> selectorParts [
 	^ self keywords collect: [:each | each asSymbol]
 ]
 
-{ #category : #'accessing compiled method' }
-RBMethodNode >> semanticScope: aSemanticScope [
-	compilationContext ifNil: [
-		compilationContext := aSemanticScope targetClass compiler compilationContext].
-
-	self compilationContext semanticScope: aSemanticScope
-]
-
 { #category : #accessing }
 RBMethodNode >> source [
 	^source

--- a/src/AST-Core/RBValueNode.class.st
+++ b/src/AST-Core/RBValueNode.class.st
@@ -49,8 +49,12 @@ RBValueNode >> evaluate [
 { #category : #evaluating }
 RBValueNode >> evaluateForContext: aContext [
 	"evaluate the AST taking variables from the context"
-	^(self asDoItForContext: aContext)
-		generateWithSource valueWithReceiver: aContext receiver arguments: #()
+	| methodNode scope |
+	methodNode := self asDoit.
+	scope := OCContextualDoItSemanticScope targetingContext: aContext.
+	methodNode semanticScope: scope.
+	methodNode doSemanticAnalysis: scope.
+	^ methodNode generate valueWithReceiver: aContext receiver
 ]
 
 { #category : #evaluating }

--- a/src/AST-Core/RBValueNode.class.st
+++ b/src/AST-Core/RBValueNode.class.st
@@ -52,7 +52,6 @@ RBValueNode >> evaluateForContext: aContext [
 	| methodNode scope |
 	methodNode := self asDoit.
 	scope := OCContextualDoItSemanticScope targetingContext: aContext.
-	methodNode semanticScope: scope.
 	methodNode doSemanticAnalysis: scope.
 	^ methodNode generate valueWithReceiver: aContext receiver
 ]

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -251,7 +251,7 @@ OCASTSemanticAnalyzer >> visitInlinedBlockNode: aBlockNode [
 OCASTSemanticAnalyzer >> visitMessageNode: aMessageNode [
 	
 	super visitMessageNode: aMessageNode.
-	aMessageNode isSuperSend ifTrue: [ aMessageNode superOf: self compilationContext getClass ]
+	aMessageNode isSuperSend ifTrue: [ aMessageNode superOf: self outerScope targetClass ]
 ]
 
 { #category : #visiting }

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -108,8 +108,7 @@ OCASTSemanticAnalyzer >> invalidVariables [
 
 { #category : #accessing }
 OCASTSemanticAnalyzer >> outerScope [
-
-	^ outerScope ifNil: [ outerScope := self compilationContext scope ]
+	^ outerScope
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -7,6 +7,7 @@ Class {
 	#superclass : #RBProgramNodeVisitor,
 	#instVars : [
 		'scope',
+		'outerScope',
 		'compilationContext',
 		'blockCounter',
 		'undeclared',
@@ -103,6 +104,18 @@ OCASTSemanticAnalyzer >> error: aMessage forNode: aNode [
 { #category : #accessing }
 OCASTSemanticAnalyzer >> invalidVariables [
 	^ invalidVariables ifNil: [ invalidVariables := Dictionary new ]
+]
+
+{ #category : #accessing }
+OCASTSemanticAnalyzer >> outerScope [
+
+	^ outerScope ifNil: [ outerScope := self compilationContext scope ]
+]
+
+{ #category : #accessing }
+OCASTSemanticAnalyzer >> outerScope: anObject [
+
+	outerScope := anObject
 ]
 
 { #category : #variables }
@@ -247,7 +260,7 @@ OCASTSemanticAnalyzer >> visitMethodNode: aMethodNode [
 
 	aMethodNode arguments size > 15 ifTrue: [ self error: 'Too many arguments' forNode: aMethodNode ].
 
-	scope := OCMethodScope new outerScope: self compilationContext scope.
+	scope := OCMethodScope new outerScope: self outerScope.
 	aMethodNode scope: scope.  scope node: aMethodNode.
 	aMethodNode arguments do: [:node | self declareArgumentNode: node ].
 	aMethodNode pragmas do: [:each | self visitNode: each].

--- a/src/OpalCompiler-Core/OCAbstractScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractScope.class.st
@@ -69,3 +69,14 @@ OCAbstractScope >> registerVariables [
 
 	outerScope ifNotNil: [ :it | it registerVariables ]
 ]
+
+{ #category : #accessing }
+OCAbstractScope >> targetClass [
+
+	^ outerScope ifNotNil: [ :it | it targetClass ]
+]
+
+{ #category : #accessing }
+OCAbstractScope >> targetEnvironment [
+	^self targetClass environment
+]

--- a/src/OpalCompiler-Core/OCSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCSemanticScope.class.st
@@ -67,13 +67,3 @@ OCSemanticScope >> lookupVar: name [
 
 	^ super lookupVar: name
 ]
-
-{ #category : #accessing }
-OCSemanticScope >> targetClass [
-	self subclassResponsibility
-]
-
-{ #category : #accessing }
-OCSemanticScope >> targetEnvironment [
-	^self targetClass environment
-]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -556,6 +556,7 @@ OpalCompiler >> parse [
 	ast := self compilationContext noPattern ifTrue: [ parser parseDoIt ] ifFalse: [ parser parseMethod ].
 
 	ast methodNode compilationContext: self compilationContext.
+	ast methodClass: self compilationContext semanticScope targetClass.
 	self callParsePlugins.
 	self doSemanticAnalysis.
 

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -397,7 +397,7 @@ OpalCompiler >> decompileMethod: aCompiledMethod [
 
 { #category : #private }
 OpalCompiler >> doSemanticAnalysis [
-	^ ast doSemanticAnalysis
+	^ ast doSemanticAnalysis: self compilationContext scope
 ]
 
 { #category : #plugins }

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -16,7 +16,7 @@ RBMethodNode >> compiledMethod [
 RBMethodNode >> doSemanticAnalysis [
 
 	| outerScope |
-	outerScope := OCMethodSemanticScope targetingClass: methodClass.
+	outerScope := OCMethodSemanticScope targetingClass: (methodClass ifNil: [ nil class ]).
 	self doSemanticAnalysis: outerScope
 ]
 
@@ -30,7 +30,7 @@ RBMethodNode >> doSemanticAnalysis: outerScope [
 		This is needed because dependency injection and to get a correct default set of compilation options"
 		ctx := outerScope targetClass compiler compilationContext.
 		self compilationContext: ctx ].
-	self methodClass: outerScope targetClass.
+	"self methodClass: outerScope targetClass."
 
 	ctx semanticAnalyzerClass new
 		outerScope: outerScope;

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -16,9 +16,15 @@ RBMethodNode >> compiledMethod [
 RBMethodNode >> doSemanticAnalysis [
 
 	self compilationContext ifNil: [ self methodClass: nil class ].
+	self doSemanticAnalysis: self compilationContext scope
+]
+
+{ #category : #'*OpalCompiler-Core' }
+RBMethodNode >> doSemanticAnalysis: outerScope [
 
 	self
 		compilationContext semanticAnalyzerClass new
+			outerScope: outerScope;
 			compilationContext: self compilationContext;
 			analyze: self
 ]

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -30,6 +30,7 @@ RBMethodNode >> doSemanticAnalysis: outerScope [
 		This is needed because dependency injection and to get a correct default set of compilation options"
 		ctx := outerScope targetClass compiler compilationContext.
 		self compilationContext: ctx ].
+	self methodClass: outerScope targetClass.
 
 	ctx semanticAnalyzerClass new
 		outerScope: outerScope;

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -22,6 +22,12 @@ RBMethodNode >> doSemanticAnalysis [
 { #category : #'*OpalCompiler-Core' }
 RBMethodNode >> doSemanticAnalysis: outerScope [
 
+	| ctx |
+	ctx := self compilationContext ifNil: [ 
+		self compilationContext: outerScope targetClass compiler compilationContext.
+		self compilationContext
+		 ].
+
 	self
 		compilationContext semanticAnalyzerClass new
 			outerScope: outerScope;

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -15,8 +15,9 @@ RBMethodNode >> compiledMethod [
 { #category : #'*OpalCompiler-Core' }
 RBMethodNode >> doSemanticAnalysis [
 
-	self compilationContext ifNil: [ self methodClass: nil class ].
-	self doSemanticAnalysis: self compilationContext scope
+	| outerScope |
+	outerScope := OCMethodSemanticScope targetingClass: methodClass.
+	self doSemanticAnalysis: outerScope
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -23,16 +23,17 @@ RBMethodNode >> doSemanticAnalysis [
 RBMethodNode >> doSemanticAnalysis: outerScope [
 
 	| ctx |
-	ctx := self compilationContext ifNil: [ 
-		self compilationContext: outerScope targetClass compiler compilationContext.
-		self compilationContext
-		 ].
+	ctx := self compilationContext.
+	ctx ifNil: [
+		"If no compilation context, allocate a minimal one based on the target class.
+		This is needed because dependency injection and to get a correct default set of compilation options"
+		ctx := outerScope targetClass compiler compilationContext.
+		self compilationContext: ctx ].
 
-	self
-		compilationContext semanticAnalyzerClass new
-			outerScope: outerScope;
-			compilationContext: self compilationContext;
-			analyze: self
+	ctx semanticAnalyzerClass new
+		outerScope: outerScope;
+		compilationContext: ctx;
+		analyze: self
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -34,13 +34,8 @@ RBMethodNode >> doSemanticAnalysis [
 RBMethodNode >> doSemanticAnalysis: outerScope [
 
 	| ctx |
-	ctx := self compilationContext.
-	ctx ifNil: [
-		"If no compilation context, allocate a minimal one based on the target class.
-		This is needed because dependency injection and to get a correct default set of compilation options"
-		ctx := outerScope targetClass compiler compilationContext.
-		self compilationContext: ctx ].
-	"self methodClass: outerScope targetClass."
+	self methodClass: outerScope targetClass.
+	ctx := self compilationContextOrDefault.
 
 	ctx semanticAnalyzerClass new
 		outerScope: outerScope;
@@ -122,7 +117,7 @@ RBMethodNode >> generateMethod [
 	by OpalCompiler in a full compilation chain might be missing.
 	So use this method if you know what you are doing."
 
-	^ self generate: self compilationContext compiledMethodTrailer
+	^ self generate: self compilationContextOrDefault compiledMethodTrailer
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Core/RBProgramNode.extension.st
+++ b/src/OpalCompiler-Core/RBProgramNode.extension.st
@@ -1,14 +1,6 @@
 Extension { #name : #RBProgramNode }
 
 { #category : #'*OpalCompiler-Core' }
-RBProgramNode >> asDoItForContext: aContext [
-	"The VM can only evaluate methods. wrap this ast in a doitIn MethodNode to evaluate in a context"
-
-	^ self asDoit semanticScope:
-		  (OCContextualDoItSemanticScope targetingContext: aContext)
-]
-
-{ #category : #'*OpalCompiler-Core' }
 RBProgramNode >> doSemanticAnalysis [
 	self methodNode ifNil: [ ^self ].
 	^ self methodNode doSemanticAnalysis

--- a/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
@@ -8,8 +8,11 @@ Class {
 OCASTCheckerTest >> nameAnalysisNoClosureIn: class for: ast [
 	"Look up vars in classOrScope.  My tree will be annotated with bindings to Scopes and Variables."
 
+	| ctx |
+	ctx := class compiler compilationContext.
 	OCASTSemanticAnalyzer new
-		compilationContext: class compiler compilationContext;
+		outerScope: ctx scope;
+		compilationContext: ctx;
 		visitNode: ast
 ]
 

--- a/src/Reflectivity/RFSemanticAnalyzer.class.st
+++ b/src/Reflectivity/RFSemanticAnalyzer.class.st
@@ -64,7 +64,7 @@ RFSemanticAnalyzer >> visitAssignmentNode: aNode [
 { #category : #visiting }
 RFSemanticAnalyzer >> visitMethodNode: aMethodNode [
 
-	scope := OCMethodScope new outerScope: self compilationContext scope.
+	scope := OCMethodScope new outerScope: self outerScope.
 	aMethodNode scope: scope.  scope node: aMethodNode.
 	aMethodNode arguments do: [:node | self declareArgumentNode: node ].
 	aMethodNode pragmas do: [:each | self visitNode: each].

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -201,7 +201,7 @@ ReflectiveMethod >> printOn: aStream [
 ReflectiveMethod >> recompileAST [
 
 	OCASTSemanticCleaner clean: ast.
-	ast compilationContext
+	ast compilationContextOrDefault
 		semanticAnalyzerClass: RFSemanticAnalyzer;
 		astTranslatorClass: RFASTTranslator.
 	ast doSemanticAnalysis. "force semantic analysis"


### PR DESCRIPTION
Add a way to call the semantic analysis with a given outer scope (initial scope).
The idea is to reduce again the dependency on the compilation context.