### PR TITLE
Compiler: doSemanticAnalysis yourself

### DIFF
--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -479,17 +479,6 @@ CompilationContext >> interactive [
 		  ifFalse: [ true ]
 ]
 
-{ #category : #testing }
-CompilationContext >> needRequestorScope [
-	"The requestor scope allows the requestor to bind exsiting and new variables, like worspaces variables.
-	Modern requestors should not register temselves but use `bindings:`."
-
-	requestor ifNil: [ ^ false ].
-	"Because requestor do not have a real API, introspection is used."
-	(requestor respondsTo: #needRequestorScope) ifFalse: [ ^ false ].
-	^ requestor needRequestorScope
-]
-
 { #category : #accessing }
 CompilationContext >> noPattern [
 	^semanticScope isDoItScope
@@ -632,24 +621,6 @@ CompilationContext >> requestorScopeClass [
 CompilationContext >> requestorScopeClass: anObject [
 	"clients can set their own subclass of OCRequestorScope if needed"
 	requestorScopeClass := anObject
-]
-
-{ #category : #accessing }
-CompilationContext >> scope [
-	| newScope |
-
-	newScope := semanticScope.
-	self needRequestorScope ifTrue: [
-		"the requestor is allowed to manage variables, the workspace is using it to auto-define vars"
-		newScope := (self requestorScopeClass new
-			requestor: requestor) outerScope: newScope].
-
-	bindings ifNotNil: [
-		"if we passed additional bindings in, setup a scope here"
-		newScope := (OCExtraBindingScope  new
-			bindings: bindings) outerScope: newScope].
-
-	^newScope
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -109,7 +109,7 @@ OCASTSemanticAnalyzer >> invalidVariables [
 { #category : #accessing }
 OCASTSemanticAnalyzer >> outerScope [
 
-	^ outerScope ifNil: [ outerScope := self compilationContext scope ]
+	^ outerScope
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -7,6 +7,7 @@ Class {
 	#superclass : #RBProgramNodeVisitor,
 	#instVars : [
 		'scope',
+		'outerScope',
 		'compilationContext',
 		'blockCounter',
 		'undeclared',
@@ -103,6 +104,18 @@ OCASTSemanticAnalyzer >> error: aMessage forNode: aNode [
 { #category : #accessing }
 OCASTSemanticAnalyzer >> invalidVariables [
 	^ invalidVariables ifNil: [ invalidVariables := Dictionary new ]
+]
+
+{ #category : #accessing }
+OCASTSemanticAnalyzer >> outerScope [
+
+	^ outerScope ifNil: [ outerScope := self compilationContext scope ]
+]
+
+{ #category : #accessing }
+OCASTSemanticAnalyzer >> outerScope: anObject [
+
+	outerScope := anObject
 ]
 
 { #category : #variables }
@@ -247,7 +260,7 @@ OCASTSemanticAnalyzer >> visitMethodNode: aMethodNode [
 
 	aMethodNode arguments size > 15 ifTrue: [ self error: 'Too many arguments' forNode: aMethodNode ].
 
-	scope := OCMethodScope new outerScope: self compilationContext scope.
+	scope := OCMethodScope new outerScope: self outerScope.
 	aMethodNode scope: scope.  scope node: aMethodNode.
 	aMethodNode arguments do: [:node | self declareArgumentNode: node ].
 	aMethodNode pragmas do: [:each | self visitNode: each].

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -397,7 +397,12 @@ OpalCompiler >> decompileMethod: aCompiledMethod [
 
 { #category : #private }
 OpalCompiler >> doSemanticAnalysis [
-	^ ast doSemanticAnalysis
+
+	self callParsePlugins.
+	self compilationContext semanticAnalyzerClass new
+		  compilationContext: self compilationContext;
+		  analyze: ast.
+	^ ast
 ]
 
 { #category : #plugins }
@@ -556,7 +561,6 @@ OpalCompiler >> parse [
 	ast := self compilationContext noPattern ifTrue: [ parser parseDoIt ] ifFalse: [ parser parseMethod ].
 
 	ast methodNode compilationContext: self compilationContext.
-	self callParsePlugins.
 	self doSemanticAnalysis.
 
 	self permitFaulty ifFalse: [

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -231,6 +231,24 @@ OpalCompiler >> bindings: aDictionary [
 ]
 
 { #category : #private }
+OpalCompiler >> buildOuterScope [
+	| newScope |
+
+	newScope := self semanticScope.
+	self needRequestorScope ifTrue: [
+		"the requestor is allowed to manage variables, the workspace is using it to auto-define vars"
+		newScope := (self compilationContext requestorScopeClass new
+			requestor: self requestor) outerScope: newScope].
+
+	self bindings ifNotNil: [
+		"if we passed additional bindings in, setup a scope here"
+		newScope := (OCExtraBindingScope  new
+			bindings: self bindings) outerScope: newScope].
+
+	^newScope
+]
+
+{ #category : #private }
 OpalCompiler >> callParsePlugins [
 	| plugins |
 
@@ -411,8 +429,9 @@ OpalCompiler >> doSemanticAnalysis [
 
 	self callParsePlugins.
 	self compilationContext semanticAnalyzerClass new
-		  compilationContext: self compilationContext;
-		  analyze: ast.
+		compilationContext: self compilationContext;
+		outerScope: self buildOuterScope;
+		analyze: ast.
 	^ ast
 ]
 
@@ -537,6 +556,17 @@ OpalCompiler >> logged [
 { #category : #accessing }
 OpalCompiler >> logged: aBoolean [
 	logged := aBoolean
+]
+
+{ #category : #testing }
+OpalCompiler >> needRequestorScope [
+	"The requestor scope allows the requestor to bind exsiting and new variables, like worspaces variables.
+	Modern requestors should not register temselves but use `bindings:`."
+
+	self requestor ifNil: [ ^ false ].
+	"Because requestor do not have a real API, introspection is used."
+	(self requestor respondsTo: #needRequestorScope) ifFalse: [ ^ false ].
+	^ self requestor needRequestorScope
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -220,6 +220,11 @@ OpalCompiler >> ast: anObject [
 ]
 
 { #category : #accessing }
+OpalCompiler >> bindings [
+	^ self compilationContext bindings
+]
+
+{ #category : #accessing }
 OpalCompiler >> bindings: aDictionary [
 	"allows to define additional binding, note: Globals are not shadowed"
 	self compilationContext bindings: aDictionary
@@ -665,6 +670,11 @@ OpalCompiler >> receiver: anObject [
 	so just noop if the receiver is already known, thus do not change the doit scope"
 	self receiver == anObject ifTrue: [ ^self ].
 	self semanticScope: (OCReceiverDoItSemanticScope targetingReceiver: anObject)
+]
+
+{ #category : #accessing }
+OpalCompiler >> requestor [
+	^ self compilationContext requestor
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -210,7 +210,13 @@ OpalCompiler >> ast [
 OpalCompiler >> ast: anObject [
 
 	ast := anObject.
-	source := ast source
+	source := ast source.
+
+	"If a compilation context exists in the AST, we use this one.
+	Otherwise, we assign our"
+	ast compilationContext
+		ifNil: [ ast compilationContext: self compilationContext ]
+		ifNotNil: [ self compilationContext: ast compilationContext ]
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -27,10 +27,10 @@ RBMethodNode >> doSemanticAnalysis [
 
 	self compilationContext ifNil: [ self methodClass: nil class ].
 
-	self
-		compilationContext semanticAnalyzerClass new
-			compilationContext: self compilationContext;
-			analyze: self
+	self methodClass compiler
+		ast: self;
+		compilationContext: self compilationContext;
+		doSemanticAnalysis
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -26,11 +26,9 @@ RBMethodNode >> compiledMethod: aCompiledMethod [
 RBMethodNode >> compiler [
 	"Return a compiler configured with self as the AST"
 
-	self methodClass ifNil: [ self methodClass: nil class ].
-
-	^ self methodClass compiler
-		  compilationContext: self compilationContext;
-		  ast: self
+	| class |
+	class := self methodClass ifNil: [ nil class ].
+	^ class compiler ast: self
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -23,14 +23,20 @@ RBMethodNode >> compiledMethod: aCompiledMethod [
 ]
 
 { #category : #'*OpalCompiler-Core' }
+RBMethodNode >> compiler [
+	"Return a compiler configured with self as the AST"
+
+	self methodClass ifNil: [ self methodClass: nil class ].
+
+	^ self methodClass compiler
+		  compilationContext: self compilationContext;
+		  ast: self
+]
+
+{ #category : #'*OpalCompiler-Core' }
 RBMethodNode >> doSemanticAnalysis [
 
-	self compilationContext ifNil: [ self methodClass: nil class ].
-
-	self methodClass compiler
-		ast: self;
-		compilationContext: self compilationContext;
-		doSemanticAnalysis
+	self compiler doSemanticAnalysis
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTCheckerTest.class.st
@@ -8,8 +8,11 @@ Class {
 OCASTCheckerTest >> nameAnalysisNoClosureIn: class for: ast [
 	"Look up vars in classOrScope.  My tree will be annotated with bindings to Scopes and Variables."
 
+	| compiler |
+	compiler := class compiler.
 	OCASTSemanticAnalyzer new
-		compilationContext: class compiler compilationContext;
+		compilationContext: compiler compilationContext;
+		outerScope: compiler buildOuterScope;
 		visitNode: ast
 ]
 

--- a/src/Reflectivity/RFSemanticAnalyzer.class.st
+++ b/src/Reflectivity/RFSemanticAnalyzer.class.st
@@ -64,7 +64,7 @@ RFSemanticAnalyzer >> visitAssignmentNode: aNode [
 { #category : #visiting }
 RFSemanticAnalyzer >> visitMethodNode: aMethodNode [
 
-	scope := OCMethodScope new outerScope: self compilationContext scope.
+	scope := OCMethodScope new outerScope: self outerScope.
 	aMethodNode scope: scope.  scope node: aMethodNode.
 	aMethodNode arguments do: [:node | self declareArgumentNode: node ].
 	aMethodNode pragmas do: [:each | self visitNode: each].


### PR DESCRIPTION
Another step towards #13508

This basically does three things (in order):

* move the doSemanticAnalysis responsibility to the compiler (and do it correctly, including plugins)
  This will also help to split OCASTSemanticAnalyzer into smaller concerns (some future job)
* add an explicit outerScope ivar to OCASTSemanticAnalyzer, reducing its reliance on compilationContext (there is still some, but less)
  The idea is to move most of the scope related concerns from CompilationContext to OpalCompiler, so OCASTSemanticAnalyzer has to be initialized with the scope
* move the preparation of the scope from CompilationContext to OpalCompiler. ivar will be moved in a future PR to simplify the diff
  Co precise the idea, I want to move `requestor` first

This is a small reorganization (easy to review) but an important one (might break CI in fun ways)