### PR TITLE
Clean info of MethodChangeRecord

### DIFF
--- a/src/System-Changes/ChangeSet.class.st
+++ b/src/System-Changes/ChangeSet.class.st
@@ -1107,9 +1107,7 @@ ChangeSet >> methodRemoved: anEvent [
 		removeSelector: anEvent selector
 		class: anEvent methodClass
 		priorMethod: anEvent method
-		lastMethodInfo: {
-				anEvent method sourcePointer.
-				anEvent protocol }
+		lastSourcePointer: anEvent method sourcePointer
 ]
 
 { #category : #testing }
@@ -1342,14 +1340,11 @@ ChangeSet >> removePreamble [
 ]
 
 { #category : #'change logging' }
-ChangeSet >> removeSelector: selector class: class priorMethod: priorMethod lastMethodInfo: info [
-	"Include indication that a method has been forgotten.
-	info is a pair of the source code pointer and message category
-	for the method that was removed."
+ChangeSet >> removeSelector: selector class: class priorMethod: priorMethod lastSourcePointer: lastSourcePointer [
+	"Include indication that a method has been forgotten."
 
-	class wantsChangeSetLogging ifFalse: [^ self].
-	(self changeRecorderFor: class)
-		noteRemoveSelector: selector priorMethod: priorMethod lastMethodInfo: info
+	class wantsChangeSetLogging ifFalse: [ ^ self ].
+	(self changeRecorderFor: class) noteRemoveSelector: selector priorMethod: priorMethod lastSourcePointer: lastSourcePointer
 ]
 
 { #category : #'method changes' }

--- a/src/System-Changes/ClassChangeRecord.class.st
+++ b/src/System-Changes/ClassChangeRecord.class.st
@@ -83,10 +83,9 @@ ClassChangeRecord >> assimilateAllChangesIn: otherRecord [
 		changeType := changeRecord changeType.
 		(changeType == #remove or: [changeType == #addedThenRemoved])
 			ifTrue:
-				[changeType == #addedThenRemoved
-					ifTrue: [self atSelector: selector put: #add].
-				self noteRemoveSelector: selector priorMethod: nil
-						lastMethodInfo: changeRecord methodInfoFromRemoval]
+				[ 
+				changeType == #addedThenRemoved ifTrue: [ self atSelector: selector put: #add ].
+				self noteRemoveSelector: selector priorMethod: nil lastSourcePointer: changeRecord lastSourcePointer ]
 			ifFalse:
 				[self atSelector: selector put: changeType]]
 ]
@@ -269,17 +268,16 @@ ClassChangeRecord >> notePriorDefinition: oldClass [
 ]
 
 { #category : #'method changes' }
-ClassChangeRecord >> noteRemoveSelector: selector priorMethod: priorMethod lastMethodInfo: infoOrNil [
+ClassChangeRecord >> noteRemoveSelector: selector priorMethod: priorMethod lastSourcePointer: lastSourcePointer [
 
 	| methodChange |
 	methodChange := self findOrMakeMethodChangeAt: selector priorMethod: priorMethod.
-	methodChange changeType == #add
-		ifTrue: [methodChange noteChangeType: #addedThenRemoved]
-		ifFalse: [methodChange noteChangeType: #remove].
+	methodChange noteChangeType: (methodChange changeType == #add
+			 ifTrue: [ #addedThenRemoved ]
+			 ifFalse: [ #remove ]).
 
-	infoOrNil ifNotNil:
-		["Save the source code pointer and category so can still browse old versions"
-		methodChange noteMethodInfoFromRemoval: infoOrNil]
+	"Save the source code pointer so we can still browse old versions"
+	methodChange lastSourcePointer: lastSourcePointer
 ]
 
 { #category : #definition }

--- a/src/System-Changes/MethodChangeRecord.class.st
+++ b/src/System-Changes/MethodChangeRecord.class.st
@@ -1,5 +1,5 @@
 "
-MethodChangeRecords are used to record method changes.  Here is a simple summary of the relationship between the changeType symbol and the recording of prior state
+MethodChangeRecords are used to record method changes. Here is a simple summary of the relationship between the changeType symbol and the recording of prior state
 
 			|	prior == nil			|	prior not nil	
 	---------	|----------------------------	|--------------------
@@ -12,10 +12,7 @@ changeType			symbol -- as summarized above
 currentMethod	method
 				This is the current version of the method.
 				It can be used to assert this change upon entry to a layer. 
-infoFromRemoval -- an array of size 2.
-				The first element is the source index of the last version of the method.
-				The second element is the category in which it was defined, so it
-				can be put back there if re-accepted from a version browser.
+lastSourcePointer -- The source index of the last version of the method.
 
 Note that the above states each have an associated revoke action:
 	add --> remove
@@ -29,7 +26,7 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'changeType',
-		'infoFromRemoval'
+		'lastSourcePointer'
 	],
 	#category : #'System-Changes-Records'
 }
@@ -40,15 +37,17 @@ MethodChangeRecord >> changeType [
 	^ changeType
 ]
 
-{ #category : #infos }
-MethodChangeRecord >> methodInfoFromRemoval [
-	"Return an array with the source index of the last version of the method,
-	and the category in which it was defined (so it can be put back there if
-	re-accepted from a version browser)."
+{ #category : #accessing }
+MethodChangeRecord >> lastSourcePointer [
 
-	^ (changeType == #remove or: [ changeType == #addedThenRemoved ])
-		ifTrue: [ infoFromRemoval ]
-		ifFalse: [ nil ]
+	^ lastSourcePointer
+]
+
+{ #category : #accessing }
+MethodChangeRecord >> lastSourcePointer: sourcePointer [
+	"Store the source index of the last version of the method so it can be put back there if re-accepted from a version browser."
+
+	lastSourcePointer := sourcePointer
 ]
 
 { #category : #'all changes' }
@@ -58,18 +57,12 @@ MethodChangeRecord >> noteChangeType: newChangeType [
 		ifFalse: [ newChangeType ]
 ]
 
-{ #category : #infos }
-MethodChangeRecord >> noteMethodInfoFromRemoval: info [
-	"Store an array with the source index of the last version of the method,
-	and the category in which it was defined (so it can be put back there if
-	re-accepted from a version browser)."
-
-	infoFromRemoval := info
-]
-
 { #category : #printing }
 MethodChangeRecord >> printOn: strm [
 
 	super printOn: strm.
-	strm nextPutAll: ' ('; print: changeType; nextPutAll: ')'
+	strm
+		nextPutAll: ' (';
+		print: changeType;
+		nextPutAll: ')'
 ]


### PR DESCRIPTION
MethodChangeRecord saves an #info variable that contains first the last source pointer and the protocol of a removed method. The protocol is never used so I propose to remove it and transform this ugly array (why? why? why an array?!)  into a variable storing the last source pointer.

I have the impression that the changes source code can be improved further but that will be for another time (or maybe it will be removed before)