### PR TITLE
AST: cleanup compiler API (and clients)

### DIFF
--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -285,12 +285,6 @@ RBMethodNode >> copyInContext: aDictionary [
 		yourself
 ]
 
-{ #category : #accessing }
-RBMethodNode >> decompileString [
-
-	^ self formattedCode
-]
-
 { #category : #testing }
 RBMethodNode >> defines: aName [
 	^ (arguments anySatisfy: [ :each | each name = aName ])

--- a/src/AST-Core/RBValueNode.class.st
+++ b/src/AST-Core/RBValueNode.class.st
@@ -55,13 +55,13 @@ RBValueNode >> evaluateForContext: aContext [
 ]
 
 { #category : #evaluating }
-RBValueNode >> evaluateForReceiver: aReceicer [
-	"evaluate the AST without taking variables into account"
-	| methodNode |
+RBValueNode >> evaluateForReceiver: aReceiver [
+	"evaluate the AST binding self to the receiver and taking its variables"
 
-	methodNode := self asDoit.
-	methodNode methodClass: aReceicer class.
-	^methodNode generateMethod valueWithReceiver: aReceicer
+	^ aReceiver class compiler
+		  ast: self asDoit;
+		  receiver: aReceiver;
+		  evaluate
 ]
 
 { #category : #testing }

--- a/src/AST-Core/RBValueNode.class.st
+++ b/src/AST-Core/RBValueNode.class.st
@@ -49,8 +49,9 @@ RBValueNode >> evaluate [
 { #category : #evaluating }
 RBValueNode >> evaluateForContext: aContext [
 	"evaluate the AST taking variables from the context"
-	^(self asDoItForContext: aContext)
-		generateMethod valueWithReceiver: aContext receiver
+	^ aContext compiler
+		  ast: self asDoit;
+		  evaluate
 ]
 
 { #category : #evaluating }

--- a/src/Flashback-Decompiler/FBDASTBuilder.class.st
+++ b/src/Flashback-Decompiler/FBDASTBuilder.class.st
@@ -118,10 +118,10 @@ FBDASTBuilder >> codeMessage: selector receiver: rcvr arguments:args [
 
 { #category : #building }
 FBDASTBuilder >> codeMethod: selector arguments: args body: body pragmas: pragmas class: class [
-	^ ((RBMethodNode selector: selector arguments: args body: body)
+
+	^ (RBMethodNode selector: selector arguments: args body: body)
 		pragmas: pragmas;
-		methodClass: class;
-		yourself) doSemanticAnalysis
+		doSemanticAnalysisIn: class
 ]
 
 { #category : #building }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -363,13 +363,14 @@ OpalCompiler >> compilationContextClass: aClass [
 OpalCompiler >> compile [
 
 	| result method |
-	
 	"Policy: compiling is non-faulty by default"
 	self permitFaulty ifNil: [ self permitFaulty: false ].
 
-	ast ifNil: [
-		result := self parse.
-		ast ifNil: [ ^ result ] "some failBlock" ].
+	ast
+		ifNil: [
+			result := self parse.
+			ast ifNil: [ "some failBlock" ^ result ] ]
+		ifNotNil: [ ast scope ifNil: [ self doSemanticAnalysis ] ].
 
 	self callPlugins.
 	ast scope registerVariables.

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -39,8 +39,10 @@ RBMethodNode >> doSemanticAnalysis [
 
 { #category : #'*OpalCompiler-Core' }
 RBMethodNode >> doSemanticAnalysisIn: behavior [
-	behavior ifNotNil: [self methodClass: behavior].
-	self doSemanticAnalysis
+
+	behavior compiler
+		ast: self
+		doSemanticAnalysis
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Core/RBProgramNode.extension.st
+++ b/src/OpalCompiler-Core/RBProgramNode.extension.st
@@ -1,14 +1,6 @@
 Extension { #name : #RBProgramNode }
 
 { #category : #'*OpalCompiler-Core' }
-RBProgramNode >> asDoItForContext: aContext [
-	"The VM can only evaluate methods. wrap this ast in a doitIn MethodNode to evaluate in a context"
-
-	^ self asDoit semanticScope:
-		  (OCContextualDoItSemanticScope targetingContext: aContext)
-]
-
-{ #category : #'*OpalCompiler-Core' }
 RBProgramNode >> doSemanticAnalysis [
 	self methodNode ifNil: [ ^self ].
 	^ self methodNode doSemanticAnalysis

--- a/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
@@ -43,7 +43,10 @@ OCASTTranslatorTest >> compileSource: source [
 	| ir ast |
 	ast := RBParser parseMethod: source.
 	ast compilationContext: self compilationContext.
-	ast doSemanticAnalysisIn: OCOpalExamples.
+	ast compiler
+		class: OCOpalExamples;
+		bindings: globals;
+		doSemanticAnalysis.
 	ast checkFaulty: nil.
 	ir := ast ir.
 	^ 	method := ir compiledMethod


### PR DESCRIPTION
Another step toward #13508
This PR is mostly cleanup. Some methods of RBMethodNode related to compilation are replaced with better implementation (using directly the compiler for instance), some unused ones are removed, and some clients are adapted to use better methods