### PR TITLE
AST check compilation clients

### DIFF
--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -688,7 +688,7 @@ RBMethodNode >> selectorParts [
 
 { #category : #'accessing compiled method' }
 RBMethodNode >> semanticScope: aSemanticScope [
-	self error: 'test for clients'.
+	"self error: 'test for clients'."
 	compilationContext ifNil: [
 		compilationContext := aSemanticScope targetClass compiler compilationContext].
 

--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -688,6 +688,7 @@ RBMethodNode >> selectorParts [
 
 { #category : #'accessing compiled method' }
 RBMethodNode >> semanticScope: aSemanticScope [
+	self error: 'test for clients'.
 	compilationContext ifNil: [
 		compilationContext := aSemanticScope targetClass compiler compilationContext].
 

--- a/src/ClassParser/CDClassNameNode.class.st
+++ b/src/ClassParser/CDClassNameNode.class.st
@@ -28,7 +28,7 @@ CDClassNameNode >> className: aString [
 CDClassNameNode >> existingBindingIfAbsent: aBlock [
 
 	| binding |
-	binding := originalNode methodNode compilationContext environment bindingOf: className.
+	binding := originalNode methodNode scope lookupVar: className.
 	^binding ifNil: aBlock
 ]
 

--- a/src/OpalCompiler-Core/LocalVariable.class.st
+++ b/src/OpalCompiler-Core/LocalVariable.class.st
@@ -242,7 +242,7 @@ LocalVariable >> markWrite [
 
 { #category : #queries }
 LocalVariable >> method [
-	^scope node methodNode compiledMethod
+	^scope node methodNode method
 ]
 
 { #category : #accessing }
@@ -304,7 +304,7 @@ LocalVariable >> usage: anObject [
 { #category : #queries }
 LocalVariable >> usingMethods [
 
-	^ self isUsed ifTrue: [ { self method } ] ifFalse: [ #(  ) ]
+	^ self isUsed ifTrue: [ self method ifNotNil: [ { self method } ] ] ifFalse: [ #(  ) ]
 ]
 
 { #category : #debugging }

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -12,7 +12,7 @@ RBMethodNode >> compiledMethod [
 	See limitations in `generateMethod`.
 	
 	To get a CompiledMethod without compiling it, see `method`"
-
+	self error: 'test for clients'.
 	^ self propertyAt: #compiledMethod ifAbsentPut: [ self generateMethod ]
 ]
 

--- a/src/OpalCompiler-Tests/OCCompileWithFailureTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompileWithFailureTest.class.st
@@ -31,28 +31,28 @@ OCCompileWithFailureTest >> testEmptyBlockArg [
 
 { #category : #tests }
 OCCompileWithFailureTest >> testEvalSimpleMethodWithError [
-	| ast cm |
-	ast := OpalCompiler new
+	| compiler cm |
+	cm := (compiler := OpalCompiler new)
 				source: 'method 3+';
-				parse.
+				permitFaulty: true;
+				compile.
 
-	self assert: ast isMethod.
-	self assert: ast isFaulty.
+	self assert: compiler ast isMethod.
+	self assert: compiler ast isFaulty.
 
-	cm := ast compiledMethod.
 	self should: [cm valueWithReceiver: nil arguments: #()] raise: RuntimeSyntaxError
 ]
 
 { #category : #tests }
 OCCompileWithFailureTest >> testParenthesis [
-	| result cm |
-	result := UndefinedObject compiler
+	| compiler cm |
+	cm := (compiler := UndefinedObject compiler)
     source: 'self assert: pragma( numArgs equals: 0.';
     isScripting: true;
     requestor: self;
-    parse.
-	self assert: result isDoIt.
-	self assert: result isFaulty.
-	cm := result compiledMethod.
+    permitFaulty: true;
+    compile.
+	self assert: compiler ast isDoIt.
+	self assert: compiler ast isFaulty.
 	self should: [cm valueWithReceiver: nil arguments: #()] raise: RuntimeSyntaxError
 ]

--- a/src/OpalCompiler-Tests/OCPragmaTest.class.st
+++ b/src/OpalCompiler-Tests/OCPragmaTest.class.st
@@ -72,19 +72,19 @@ OCPragmaTest >> methodSinglePragma [
 
 { #category : #tests }
 OCPragmaTest >> testDoublePragma [
-	| aRBMethode |
-	aRBMethode := OpalCompiler new parse: self methodDoublePragma.
+	| aCompiledMethod |
+	aCompiledMethod := OpalCompiler new compile: self methodDoublePragma.
 
-	self assert: aRBMethode compiledMethod pragmas first selector equals: #hello:.
-	self assert: aRBMethode compiledMethod pragmas second selector equals: #hello:
+	self assert: aCompiledMethod pragmas first selector equals: #hello:.
+	self assert: aCompiledMethod pragmas second selector equals: #hello:
 ]
 
 { #category : #tests }
 OCPragmaTest >> testIsPrimitive [
-	| aRBMethode |
+	| aRBMethod |
 
-	aRBMethode := OpalCompiler new parse: self methodPrimitive.
-	self assert: aRBMethode isPrimitive
+	aRBMethod := OpalCompiler new parse: self methodPrimitive.
+	self assert: aRBMethod isPrimitive
 ]
 
 { #category : #tests }
@@ -95,63 +95,62 @@ OCPragmaTest >> testNoPragma [
 
 { #category : #tests }
 OCPragmaTest >> testPragmaAfterBeforTemp [
-	| aRBMethode |
-	aRBMethode := OpalCompiler new parse: self methodPragmaAfterBeforTemps.
+	| aComiledMethod |
+	aComiledMethod := OpalCompiler new compile: self methodPragmaAfterBeforTemps.
 
-	self assert: aRBMethode compiledMethod pragmas first selector equals: #hello:.
-	self assert: aRBMethode compiledMethod pragmas second selector equals: #world:
+	self assert: aComiledMethod pragmas first selector equals: #hello:.
+	self assert: aComiledMethod pragmas second selector equals: #world:
 ]
 
 { #category : #tests }
 OCPragmaTest >> testPragmaTwoParam [
-	| aRBMethode |
-	aRBMethode := OpalCompiler new parse: self methodPragmaTwoParam.
+	| aCompiledMethod |
+	aCompiledMethod := OpalCompiler new compile: self methodPragmaTwoParam.
 
-
-	self assert: aRBMethode compiledMethod pragmas first selector equals: #hello:by:
+	self assert: aCompiledMethod pragmas first selector equals: #hello:by:
 ]
 
 { #category : #tests }
 OCPragmaTest >> testPragmaUnarayMessage [
-	| aRBMethode |
-	aRBMethode := OpalCompiler new parse: self methodPragmaUnarayMessage.
+	| aCompiledMethod |
+	aCompiledMethod := OpalCompiler new compile: self methodPragmaUnarayMessage.
 
-	self assert: aRBMethode compiledMethod pragmas first selector equals: #hello
+	self assert: aCompiledMethod pragmas first selector equals: #hello
 ]
 
 { #category : #tests }
 OCPragmaTest >> testPrimitiveNumber [
-	| aRBMethode |
-	aRBMethode := OpalCompiler new parse: self methodPrimitive.
-	self assert: aRBMethode compiledMethod primitive equals: 4
+	| aCompiledMethod |
+	aCompiledMethod := OpalCompiler new compile: self methodPrimitive.
+	self assert: aCompiledMethod primitive equals: 4
 ]
 
 { #category : #tests }
 OCPragmaTest >> testPrimitivePragmaNumber [
-	| aRBMethode |
-	aRBMethode := OpalCompiler new parse: self methodPrimitivePragma.
-	self assert: aRBMethode compiledMethod primitive equals: 4
+	| aCompiledMethod |
+	aCompiledMethod := OpalCompiler new compile: self methodPrimitivePragma.
+	self assert: aCompiledMethod primitive equals: 4
 ]
 
 { #category : #tests }
 OCPragmaTest >> testPrimitiveString [
-	| aRBMethode |
-	aRBMethode := OpalCompiler new parse: self methodPrimitiveString.
+	| aCompiledMethod |
+	aCompiledMethod := OpalCompiler new compile: self methodPrimitiveString.
 
-	self assert: aRBMethode compiledMethod primitive equals: 117
+	self assert: aCompiledMethod primitive equals: 117
 ]
 
 { #category : #tests }
 OCPragmaTest >> testPrimitiveStringModule [
-	| aRBMethode |
-	aRBMethode := OpalCompiler new parse: self methodPrimitiveStringModule.
+	| aCompiledMethod |
+	aCompiledMethod := OpalCompiler new compile: self methodPrimitiveStringModule.
 
-	self assert: aRBMethode compiledMethod primitive equals: 117
+	self assert: aCompiledMethod primitive equals: 117
 ]
 
 { #category : #tests }
 OCPragmaTest >> testSinglePragma [
-	| aRBMethode |
-	aRBMethode := OpalCompiler new parse: self methodSinglePragma.
-	self assert: aRBMethode compiledMethod pragmas first selector equals: #hello:
+	| aCompiledMethod |
+	aCompiledMethod := OpalCompiler new compile: self methodSinglePragma.
+	self assert: aCompiledMethod pragmas first selector equals: #hello:
 ]

--- a/src/Reflectivity/MetaLink.class.st
+++ b/src/Reflectivity/MetaLink.class.st
@@ -336,7 +336,7 @@ MetaLink >> metaObject: anObject [
 MetaLink >> methods [
 	^nodes flatCollect: [ :entity |
 		(entity isKindOf: RBProgramNode)
-			ifTrue: [ {entity methodNode compiledMethod}  ]
+			ifTrue: [ { entity methodNode method } ]
 			ifFalse: [ entity usingMethods ] ]
 ]
 


### PR DESCRIPTION
When a selector is used a lot, or might be used trough different code path, a good way to detect the clients is to run them