### PR TITLE
RBMethodMode: compiledMethod sould be a simple accessor

### DIFF
--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -462,8 +462,9 @@ RBMethodNode >> matchPragmas: matchNodes against: pragmaNodes inContext: aDictio
 
 { #category : #'accessing - compiled method' }
 RBMethodNode >> method [
-	"return the method that I have been compiled for"
-	^ self propertyAt: #compiledMethod ifAbsent: [ nil ]
+	
+	self deprecated: 'use compiledMethod' transformWith: '`@recv method' -> '`@recv compiledMethod'.
+	^ self compiledMethod
 ]
 
 { #category : #'accessing - compiled method' }

--- a/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
@@ -275,7 +275,10 @@ ClyMethodCodeEditorToolMorph >> printContext [
 { #category : #initialization }
 ClyMethodCodeEditorToolMorph >> resetASTCache [
 	"when the AST cache is cleared, we have to rescue the AST we are looking at"
-	ASTCache default at: ast compiledMethod ifAbsentPut: ast
+	| cm |
+	cm := ast compiledMethod.
+	cm ifNil: [  ^ self ].
+	ASTCache default at: cm ifAbsentPut: ast
 ]
 
 { #category : #'selecting text' }

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -8,7 +8,7 @@ RBMethodNode >> bcToASTCache [
 { #category : #'*OpalCompiler-Core' }
 RBMethodNode >> compiledMethod [
 	"Retrieve the associated CompiledMethod (cached version).
-	If no CompiledMethod was was generated, nil is returned.
+	If no CompiledMethod was generated, nil is returned.
 
 	When the AST is recompiled (see `generateMethod`), the cache is updated.
 	However, the cache is not reset if the AST is modified."

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -7,13 +7,13 @@ RBMethodNode >> bcToASTCache [
 
 { #category : #'*OpalCompiler-Core' }
 RBMethodNode >> compiledMethod [
-	"Retrieve or generate a CompiledMethod (cached version).
-	The cache is not reset even is the AST is modified but can be overrided with `compiledMethod:`.
-	See limitations in `generateMethod`.
-	
-	To get a CompiledMethod without compiling it, see `method`"
+	"Retrieve the associated CompiledMethod (cached version).
+	If no CompiledMethod was was generated, nil is returned.
 
-	^ self propertyAt: #compiledMethod ifAbsentPut: [ self generateMethod ]
+	When the AST is recompiled (see `generateMethod`), the cache is updated.
+	However, the cache is not reset if the AST is modified."
+
+	^ self propertyAt: #compiledMethod ifAbsent: [ nil ]
 ]
 
 { #category : #'*OpalCompiler-Core' }
@@ -114,7 +114,10 @@ RBMethodNode >> generateMethod [
 	by OpalCompiler in a full compilation chain might be missing.
 	So use this method if you know what you are doing."
 
-	^ self generate: self compilationContext compiledMethodTrailer
+	| cm |
+	cm := self generate: self compilationContext compiledMethodTrailer.
+	self compiledMethod: cm.
+	^ cm
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Tests/OCCompileWithFailureTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompileWithFailureTest.class.st
@@ -31,28 +31,28 @@ OCCompileWithFailureTest >> testEmptyBlockArg [
 
 { #category : #tests }
 OCCompileWithFailureTest >> testEvalSimpleMethodWithError [
-	| ast cm |
-	ast := OpalCompiler new
+	| compiler cm |
+	cm := (compiler := OpalCompiler new)
 				source: 'method 3+';
-				parse.
+				permitFaulty: true;
+				compile.
 
-	self assert: ast isMethod.
-	self assert: ast isFaulty.
+	self assert: compiler ast isMethod.
+	self assert: compiler ast isFaulty.
 
-	cm := ast compiledMethod.
 	self should: [cm valueWithReceiver: nil arguments: #()] raise: RuntimeSyntaxError
 ]
 
 { #category : #tests }
 OCCompileWithFailureTest >> testParenthesis [
-	| result cm |
-	result := UndefinedObject compiler
+	| compiler cm |
+	cm := (compiler := UndefinedObject compiler)
     source: 'self assert: pragma( numArgs equals: 0.';
     isScripting: true;
     requestor: self;
-    parse.
-	self assert: result isDoIt.
-	self assert: result isFaulty.
-	cm := result compiledMethod.
+    permitFaulty: true;
+    compile.
+	self assert: compiler ast isDoIt.
+	self assert: compiler ast isFaulty.
 	self should: [cm valueWithReceiver: nil arguments: #()] raise: RuntimeSyntaxError
 ]

--- a/src/OpalCompiler-Tests/OCPragmaTest.class.st
+++ b/src/OpalCompiler-Tests/OCPragmaTest.class.st
@@ -72,19 +72,19 @@ OCPragmaTest >> methodSinglePragma [
 
 { #category : #tests }
 OCPragmaTest >> testDoublePragma [
-	| aRBMethode |
-	aRBMethode := OpalCompiler new parse: self methodDoublePragma.
+	| aCompiledMethod |
+	aCompiledMethod := OpalCompiler new compile: self methodDoublePragma.
 
-	self assert: aRBMethode compiledMethod pragmas first selector equals: #hello:.
-	self assert: aRBMethode compiledMethod pragmas second selector equals: #hello:
+	self assert: aCompiledMethod pragmas first selector equals: #hello:.
+	self assert: aCompiledMethod pragmas second selector equals: #hello:
 ]
 
 { #category : #tests }
 OCPragmaTest >> testIsPrimitive [
-	| aRBMethode |
+	| aRBMethod |
 
-	aRBMethode := OpalCompiler new parse: self methodPrimitive.
-	self assert: aRBMethode isPrimitive
+	aRBMethod := OpalCompiler new parse: self methodPrimitive.
+	self assert: aRBMethod isPrimitive
 ]
 
 { #category : #tests }
@@ -95,63 +95,62 @@ OCPragmaTest >> testNoPragma [
 
 { #category : #tests }
 OCPragmaTest >> testPragmaAfterBeforTemp [
-	| aRBMethode |
-	aRBMethode := OpalCompiler new parse: self methodPragmaAfterBeforTemps.
+	| aComiledMethod |
+	aComiledMethod := OpalCompiler new compile: self methodPragmaAfterBeforTemps.
 
-	self assert: aRBMethode compiledMethod pragmas first selector equals: #hello:.
-	self assert: aRBMethode compiledMethod pragmas second selector equals: #world:
+	self assert: aComiledMethod pragmas first selector equals: #hello:.
+	self assert: aComiledMethod pragmas second selector equals: #world:
 ]
 
 { #category : #tests }
 OCPragmaTest >> testPragmaTwoParam [
-	| aRBMethode |
-	aRBMethode := OpalCompiler new parse: self methodPragmaTwoParam.
+	| aCompiledMethod |
+	aCompiledMethod := OpalCompiler new compile: self methodPragmaTwoParam.
 
-
-	self assert: aRBMethode compiledMethod pragmas first selector equals: #hello:by:
+	self assert: aCompiledMethod pragmas first selector equals: #hello:by:
 ]
 
 { #category : #tests }
 OCPragmaTest >> testPragmaUnarayMessage [
-	| aRBMethode |
-	aRBMethode := OpalCompiler new parse: self methodPragmaUnarayMessage.
+	| aCompiledMethod |
+	aCompiledMethod := OpalCompiler new compile: self methodPragmaUnarayMessage.
 
-	self assert: aRBMethode compiledMethod pragmas first selector equals: #hello
+	self assert: aCompiledMethod pragmas first selector equals: #hello
 ]
 
 { #category : #tests }
 OCPragmaTest >> testPrimitiveNumber [
-	| aRBMethode |
-	aRBMethode := OpalCompiler new parse: self methodPrimitive.
-	self assert: aRBMethode compiledMethod primitive equals: 4
+	| aCompiledMethod |
+	aCompiledMethod := OpalCompiler new compile: self methodPrimitive.
+	self assert: aCompiledMethod primitive equals: 4
 ]
 
 { #category : #tests }
 OCPragmaTest >> testPrimitivePragmaNumber [
-	| aRBMethode |
-	aRBMethode := OpalCompiler new parse: self methodPrimitivePragma.
-	self assert: aRBMethode compiledMethod primitive equals: 4
+	| aCompiledMethod |
+	aCompiledMethod := OpalCompiler new compile: self methodPrimitivePragma.
+	self assert: aCompiledMethod primitive equals: 4
 ]
 
 { #category : #tests }
 OCPragmaTest >> testPrimitiveString [
-	| aRBMethode |
-	aRBMethode := OpalCompiler new parse: self methodPrimitiveString.
+	| aCompiledMethod |
+	aCompiledMethod := OpalCompiler new compile: self methodPrimitiveString.
 
-	self assert: aRBMethode compiledMethod primitive equals: 117
+	self assert: aCompiledMethod primitive equals: 117
 ]
 
 { #category : #tests }
 OCPragmaTest >> testPrimitiveStringModule [
-	| aRBMethode |
-	aRBMethode := OpalCompiler new parse: self methodPrimitiveStringModule.
+	| aCompiledMethod |
+	aCompiledMethod := OpalCompiler new compile: self methodPrimitiveStringModule.
 
-	self assert: aRBMethode compiledMethod primitive equals: 117
+	self assert: aCompiledMethod primitive equals: 117
 ]
 
 { #category : #tests }
 OCPragmaTest >> testSinglePragma [
-	| aRBMethode |
-	aRBMethode := OpalCompiler new parse: self methodSinglePragma.
-	self assert: aRBMethode compiledMethod pragmas first selector equals: #hello:
+	| aCompiledMethod |
+	aCompiledMethod := OpalCompiler new compile: self methodSinglePragma.
+	self assert: aCompiledMethod pragmas first selector equals: #hello:
 ]

--- a/src/Reflectivity/MetaLinkInstaller.class.st
+++ b/src/Reflectivity/MetaLinkInstaller.class.st
@@ -243,12 +243,15 @@ MetaLinkInstaller >> nodesForPermaLink: permalink toBeInstalledIn: method [
 	"Looking for nodes from method where to install the permalink.
 	That means that each of these nodes has no links,
 	or that the link hosted by permalink is not present in their link set."
+
 	| slotOrVar persistenceType nodes |
 	slotOrVar := permalink slotOrVariable.
 	persistenceType := permalink persistenceType.
 	nodes := (slotOrVar accessingNodesFor: persistenceType) asIdentitySet
-					select: [ :node | node methodNode method = method ].
-	^ nodes select: [ :node | node hasMetaLinks not or: [ (node links includes: permalink link) not ] ]
+		         select: [ :node | node methodNode compiledMethod = method ].
+	^ nodes select: [ :node |
+		  node hasMetaLinks not or: [
+			  (node links includes: permalink link) not ] ]
 ]
 
 { #category : #links }

--- a/src/Reflectivity/RBProgramNode.extension.st
+++ b/src/Reflectivity/RBProgramNode.extension.st
@@ -136,7 +136,8 @@ RBProgramNode >> insteadLinks [
 
 { #category : #'*Reflectivity' }
 RBProgramNode >> invalidate [
-	self methodNode method invalidate
+
+	self methodNode compiledMethod invalidate
 ]
 
 { #category : #'*Reflectivity' }
@@ -148,13 +149,18 @@ RBProgramNode >> isEquivalentTo: aNode [
 
 { #category : #'*Reflectivity' }
 RBProgramNode >> link: aMetaLink [
-	(aMetaLink checkForCompatibilityWith: self)
-		ifFalse: [ self error: 'link requests reification that can not be provided by this node' ].
-	(self propertyAt: #links ifAbsentPut: [ OrderedCollection new ]) add: aMetaLink.
+
+	(aMetaLink checkForCompatibilityWith: self) ifFalse: [
+		self error:
+			'link requests reification that can not be provided by this node' ].
+	(self propertyAt: #links ifAbsentPut: [ OrderedCollection new ])
+		add: aMetaLink.
 	aMetaLink installOn: self.
 	self clearReflectivityAnnotations.
-	self methodNode method installLink: aMetaLink.
-	aMetaLink linkInstaller propagateLinkAddition: aMetaLink forNode: self.
+	self methodNode compiledMethod installLink: aMetaLink.
+	aMetaLink linkInstaller
+		propagateLinkAddition: aMetaLink
+		forNode: self.
 	aMetaLink announceInstall: self
 ]
 
@@ -200,14 +206,14 @@ RBProgramNode >> removeBreakpoint: aBreakpoint [
 
 { #category : #'*Reflectivity' }
 RBProgramNode >> removeLink: aMetaLink [
-	self hasMetalink
-		ifFalse: [ ^ self ].
+
+	self hasMetalink ifFalse: [ ^ self ].
 	self links remove: aMetaLink ifAbsent: [  ].
 	self links ifEmpty: [ self removeProperty: #links ].
 	self clearReflectivityAnnotations.
-	(self methodNode methodClass methodDict includesKey: self methodNode selector)
-		ifFalse: [ ^ self ].
-	self methodNode method removeLink: aMetaLink.
+	(self methodNode methodClass methodDict includesKey:
+		 self methodNode selector) ifFalse: [ ^ self ].
+	self methodNode compiledMethod removeLink: aMetaLink.
 	aMetaLink linkInstaller propagateLinkRemoval: aMetaLink forNode: self.
 	aMetaLink announceRemove: self
 ]

--- a/src/Reflectivity/RFMethodReification.class.st
+++ b/src/Reflectivity/RFMethodReification.class.st
@@ -25,5 +25,5 @@ RFMethodReification class >> key [
 RFMethodReification >> genForRBProgramNode [
 	^RBMessageNode
 		receiver: (RBMessageNode receiver: (RBLiteralNode value: entity) selector: #methodNode)
-		selector: #method
+		selector: #compiledMethod
 ]

--- a/src/Reflectivity/RFOriginalMethodReification.class.st
+++ b/src/Reflectivity/RFOriginalMethodReification.class.st
@@ -21,5 +21,6 @@ RFOriginalMethodReification class >> key [
 
 { #category : #generate }
 RFOriginalMethodReification >> genForRBProgramNode [
-	^RBLiteralNode value: entity methodNode method
+
+	^ RBLiteralNode value: entity methodNode compiledMethod
 ]

--- a/src/Reflectivity/VariableBreakpoint.class.st
+++ b/src/Reflectivity/VariableBreakpoint.class.st
@@ -220,8 +220,10 @@ VariableBreakpoint >> removeFromClass: aClass [
 
 { #category : #removing }
 VariableBreakpoint >> removeFromMethod: aMethod [
-	(self link nodes select: [ :n | n methodNode method == aMethod ])
-		do: [ :n | self link removeNode: n ]
+
+	(self link nodes select: [ :n |
+		 n methodNode compiledMethod == aMethod ]) do: [ :n |
+		self link removeNode: n ]
 ]
 
 { #category : #removing }


### PR DESCRIPTION
RBMethodNode had two confusing methods:

* `method` that returns the associated compiled method if one exists (nil otherwise)
* `compiledMethod` that does the same but forces a compilation (with a possible limited context) if none exists.

While #13514 cleaned up the implementation, it did not touch the name or the semantic.
After analysis of the clients, it appears that almost none use `method` (the name is bad anyway) and most expect that `compiledMethod` is a simple accessor that does not necessarily trigger a compilation (I might have the same expectation, in fact).
Only two groups of tests seems to use `compiledMethod` to have a compilation (and are updated).

So, the PR propose to have:

* `compiledMethod` does not compile and may return nil
* `method` is deprecated in favor of `compiledMethod`