### PR TITLE
Cleanup-Tests-CompiledMethodTrailer 

### DIFF
--- a/src/Kernel-Tests/CompiledMethodTrailerTest.class.st
+++ b/src/Kernel-Tests/CompiledMethodTrailerTest.class.st
@@ -8,23 +8,6 @@ Class {
 }
 
 { #category : #tests }
-CompiledMethodTrailerTest >> testEncodingNoTrailer [
-	| trailer |
-	trailer := CompiledMethodTrailer new.
-
-	"by default it should be a no-trailer, 4 byte wide so it can be used to store a sourcePointer"
-	self assert: trailer kind identicalTo: #NoTrailer.
-	self assert: trailer size equals: 4.
-
-	trailer := trailer testEncoding.
-
-	self assert: trailer kind identicalTo: #NoTrailer.
-	self assert: trailer size equals: 4.
-	"the last bytecode index must be at 0"
-	self assert: trailer endPC equals: 0
-]
-
-{ #category : #tests }
 CompiledMethodTrailerTest >> testEncodingSourcePointer [
 	| trailer |
 	trailer := CompiledMethodTrailer new.
@@ -36,25 +19,6 @@ CompiledMethodTrailerTest >> testEncodingSourcePointer [
 			self assert: (ptr := method sourcePointer) identicalTo: trailer sourcePointer.
 			"the last bytecode index must be at 0"
 			ptr ~= 0 ifTrue: [ self assert: method endPC equals: trailer endPC ] ]
-]
-
-{ #category : #tests }
-CompiledMethodTrailerTest >> testEncodingVarLengthSourcePointer [
-
-	| trailer newTrailer |
-
-	trailer := CompiledMethodTrailer new.
-
-	trailer sourcePointer: 1.
-	newTrailer := trailer testEncoding.
-
-	self assert: newTrailer sourcePointer equals: 1.
-
-	trailer sourcePointer: 16r100000000000000.
-	newTrailer := trailer testEncoding.
-	self assert: newTrailer sourcePointer equals: 16r100000000000000.
-	"the last bytecode index must be at 0"
-	self assert: newTrailer endPC equals: 0
 ]
 
 { #category : #tests }


### PR DESCRIPTION
remove two tests that fail in the manually created PR #13527 (they test encodings that are removed there.

