### PR TITLE
Simplify ClassOrganization>>removeElement: and remove protocol if empty

### DIFF
--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -158,6 +158,22 @@ ClassOrganizationTest >> testProtocolNames [
 ]
 
 { #category : #tests }
+ClassOrganizationTest >> testRemoveElement [
+
+	organization classify: #king under: #owl.
+	organization classify: #luz under: #owl.
+	self assert: (organization hasProtocol: #owl).
+	self assertCollection: (organization protocolNamed: #owl) methodSelectors hasSameElements: #( #king #luz ).
+
+	organization removeElement: #king.
+	self assert: (organization hasProtocol: #owl).
+	self assertCollection: (organization protocolNamed: #owl) methodSelectors hasSameElements: #( #luz ).
+
+	organization removeElement: #luz.
+	self deny: (organization hasProtocol: #owl)
+]
+
+{ #category : #tests }
 ClassOrganizationTest >> testRemoveNonExistingProtocol [
 
 	self organization removeProtocolIfEmpty: 'non-existent'

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -225,14 +225,12 @@ ClassOrganization >> protocols [
 ]
 
 { #category : #removing }
-ClassOrganization >> removeElement: aSymbol [
+ClassOrganization >> removeElement: aSelector [
 
-	| oldProtocol |
-	oldProtocol := self protocolNameOfElement: aSymbol.
-	self protocols
-		select: [ :protocol | protocol includesSelector: aSymbol ]
-		thenDo: [ :p | p removeMethodSelector: aSymbol ].
-	self notifyOfChangedSelector: aSymbol from: oldProtocol to: (self protocolNameOfElement: aSymbol)
+	(self protocolOfSelector: aSelector) ifNotNil: [ :protocol |
+		protocol removeMethodSelector: aSelector.
+		self removeProtocolIfEmpty: protocol.
+		self notifyOfChangedSelector: aSelector from: protocol name to: nil ]
 ]
 
 { #category : #removing }


### PR DESCRIPTION
This PR has 3 main interests:
- It simplifies #removeElement: to not use #protocolNameOfElement: that is a method with a big hack inside and make the code more readable
- If the element was the last selector of the protocol, we now remove the protocol
- Add a test about those new changes

It is possible that this will fail because the hack of #protocolNameOfElement: might be used. Let's find out with the CI.

Future steps:
- Rename this method since "Element" is a selector. But since the goal is to move the behavior in ClassDescription we will need a better name than #removeSelector:. Maybe something like #removeSelectorFromProtocols:?
- I want the announcement to use the protocol instead of the protocol name