### PR TITLE
Make sure class parser tests clean the system

### DIFF
--- a/src/ClassParser-Tests/ASTClassBuilderTest.class.st
+++ b/src/ClassParser-Tests/ASTClassBuilderTest.class.st
@@ -111,15 +111,14 @@ ASTClassBuilderTest >> testCreateNormalClassSuperClass [
 
 	| ast class |
 	ast := self parserClass parse: 'Xcrd subclass: #TestSubClass'.
+	[
 	class := ShiftClassBuilder new
 		         useUndefinedClass;
 		         buildEnvironment: self environment;
 		         buildFromAST: ast;
 		         build.
 
-	self
-		assert: class superclass
-		equals: (self environment classNamed: 'Xcrd')
+	self assert: class superclass equals: (self environment classNamed: 'Xcrd') ] ensure: [ (self environment classNamed: 'Xcrd') ifNotNil: #removeFromSystem ]
 ]
 
 { #category : #tests }
@@ -403,11 +402,12 @@ ASTClassBuilderTest >> testUseUndefinedClass [
 
 	| ast |
 	ast := self parserClass parse: 'PoPouet subclass: #TestClass'.
+	[
 	ShiftClassInstaller new make: [ :builder |
 		builder
 			useUndefinedClass;
 			buildEnvironment: self environment;
 			buildFromAST: ast ].
-	self assert: [
-		(ShSmalltalkGlobalsEnvironment new classNamed: #PoPouet) isUndefined ]
+	self assert: [ (ShSmalltalkGlobalsEnvironment new classNamed: #PoPouet) isUndefined ] ] ensure: [
+		(ShSmalltalkGlobalsEnvironment new classNamed: #PoPouet) ifNotNil: #removeFromSystem ]
 ]


### PR DESCRIPTION
Class parser tests are currently leaving 2 generated classes in the _UnpackagedPackage. This adds some cleaning to not leave the system in a dirty state.

This was discovered in #13349