### PR TITLE
Do not hardcode stylers

### DIFF
--- a/src/PharoDocComment/DocCommentIconStyler.class.st
+++ b/src/PharoDocComment/DocCommentIconStyler.class.st
@@ -7,6 +7,12 @@ Class {
 	#category : #'PharoDocComment-Styling'
 }
 
+{ #category : #testing }
+DocCommentIconStyler class >> isStaticStyler [
+
+	^ true
+]
+
 { #category : #private }
 DocCommentIconStyler >> exampleIsFaulty: aNode [
 	^ aNode comments

--- a/src/Reflectivity-Tools/BreakpointIconStyler.class.st
+++ b/src/Reflectivity-Tools/BreakpointIconStyler.class.st
@@ -7,6 +7,12 @@ Class {
 	#category : #'Reflectivity-Tools-Breakpoints'
 }
 
+{ #category : #testing }
+BreakpointIconStyler class >> isStaticStyler [
+
+	^ true
+]
+
 { #category : #defaults }
 BreakpointIconStyler >> highlightColor [
 	^(Color red alpha: 0.1)

--- a/src/Reflectivity-Tools/CounterIconStyler.class.st
+++ b/src/Reflectivity-Tools/CounterIconStyler.class.st
@@ -7,6 +7,12 @@ Class {
 	#category : #'Reflectivity-Tools-Watches'
 }
 
+{ #category : #testing }
+CounterIconStyler class >> isStaticStyler [
+
+	^ true
+]
+
 { #category : #defaults }
 CounterIconStyler >> iconBlock: aNode [
 	^[ :seg | ExecutionCounter removeFrom: aNode. seg delete]

--- a/src/Reflectivity-Tools/DisabledBreakpointIconStyler.class.st
+++ b/src/Reflectivity-Tools/DisabledBreakpointIconStyler.class.st
@@ -7,6 +7,12 @@ Class {
 	#category : #'Reflectivity-Tools-Breakpoints'
 }
 
+{ #category : #testing }
+DisabledBreakpointIconStyler class >> isStaticStyler [
+
+	^ true
+]
+
 { #category : #defaults }
 DisabledBreakpointIconStyler >> highlightColor [
 	^(Color darkGray alpha: 0.1)

--- a/src/Reflectivity-Tools/FlagIconStyler.class.st
+++ b/src/Reflectivity-Tools/FlagIconStyler.class.st
@@ -11,6 +11,12 @@ Class {
 	#category : #'Reflectivity-Tools-Breakpoints'
 }
 
+{ #category : #testing }
+FlagIconStyler class >> isStaticStyler [
+
+	^ true
+]
+
 { #category : #defaults }
 FlagIconStyler >> highlightColor [
 	^(Color yellow alpha: 0.3)

--- a/src/Reflectivity-Tools/HaltIconStyler.class.st
+++ b/src/Reflectivity-Tools/HaltIconStyler.class.st
@@ -7,6 +7,12 @@ Class {
 	#category : #'Reflectivity-Tools-Breakpoints'
 }
 
+{ #category : #testing }
+HaltIconStyler class >> isStaticStyler [
+
+	^ true
+]
+
 { #category : #defaults }
 HaltIconStyler >> highlightColor [
 	^(Color red alpha: 0.1)

--- a/src/Reflectivity-Tools/IconStyler.class.st
+++ b/src/Reflectivity-Tools/IconStyler.class.st
@@ -12,6 +12,12 @@ Class {
 	#category : #'Reflectivity-Tools-Breakpoints'
 }
 
+{ #category : #testing }
+IconStyler class >> isStaticStyler [
+
+	^ false
+]
+
 { #category : #style }
 IconStyler class >> withStaticStylers [
 	"Configure the receiver to invoke several static stylers. Now it is probably better to use the instance API:
@@ -22,8 +28,8 @@ IconStyler class >> withStaticStylers [
 	"
 
 	^ self new
-		stylerClasses:  {BreakpointIconStyler. CounterIconStyler. DisabledBreakpointIconStyler. FlagIconStyler. HaltIconStyler. MetaLinkIconStyler. SemanticWarningIconStyler. WatchIconStyler. DocCommentIconStyler};
-		yourself
+		  stylerClasses: (self allSubclasses select: #isStaticStyler);
+		  yourself
 ]
 
 { #category : #styling }

--- a/src/Reflectivity-Tools/MetaLinkIconStyler.class.st
+++ b/src/Reflectivity-Tools/MetaLinkIconStyler.class.st
@@ -7,6 +7,12 @@ Class {
 	#category : #'Reflectivity-Tools-Breakpoints'
 }
 
+{ #category : #testing }
+MetaLinkIconStyler class >> isStaticStyler [
+
+	^ true
+]
+
 { #category : #defaults }
 MetaLinkIconStyler >> highlightColor [
 	^(Color orange alpha: 0.1)

--- a/src/Reflectivity-Tools/SemanticWarningIconStyler.class.st
+++ b/src/Reflectivity-Tools/SemanticWarningIconStyler.class.st
@@ -7,6 +7,12 @@ Class {
 	#category : #'Reflectivity-Tools-Breakpoints'
 }
 
+{ #category : #testing }
+SemanticWarningIconStyler class >> isStaticStyler [
+
+	^ true
+]
+
 { #category : #defaults }
 SemanticWarningIconStyler >> highlightColor [
 	^(Color yellow alpha: 0.3)

--- a/src/Reflectivity-Tools/WatchIconStyler.class.st
+++ b/src/Reflectivity-Tools/WatchIconStyler.class.st
@@ -7,6 +7,12 @@ Class {
 	#category : #'Reflectivity-Tools-Watches'
 }
 
+{ #category : #testing }
+WatchIconStyler class >> isStaticStyler [
+
+	^ true
+]
+
 { #category : #defaults }
 WatchIconStyler >> highlightColor [
 	^(Color purple alpha: 0.1)


### PR DESCRIPTION
In the past I had some personnal IconStyler and I noticed now that they stopped working. So reason is that in the past all stylers were applied. Now I found a hardcoded list of stylers in IconStyler class>>#withStaticStylers.  This is really bad because it means that nobody can extend the styles. 

I now collect the stylers to apply in a way that allow to add your own. I think we can do better but this already improves the situation