### PR TITLE
Classify method before installing them

### DIFF
--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -85,6 +85,31 @@ ClassOrganizationTest >> testClassifyUnder [
 ]
 
 { #category : #tests }
+ClassOrganizationTest >> testClassifyUnderWithNil [
+	"Set the base for the test"
+	| unclassified|
+	unclassified := Protocol unclassified.
+	self assertCollection: self organization protocolNames hasSameElements: #( #empty #one ).
+
+	self organization classify: #king under: nil.
+
+	self assertCollection: self organization protocolNames hasSameElements: { #empty. #one. unclassified }.
+	self assertCollection: (self organization protocolNamed: unclassified ) methodSelectors hasSameElements: #( #king ).
+	
+	self organization classify: #luz under: #owl.
+
+	self assertCollection: self organization protocolNames hasSameElements: { #empty. #one. unclassified . #owl }.
+	self assertCollection: (self organization protocolNamed: #owl ) methodSelectors hasSameElements: #( #luz ).
+	
+	"Now let's test the behavior if we already have a protocol.
+	The behavior should change to not change the protocol but this test will ensure that the change is intentional and not a regression."
+	self organization classify: #luz under: nil.
+
+	self assertCollection: self organization protocolNames hasSameElements: { #empty. #one. unclassified }.
+	self assertCollection: (self organization protocolNamed: unclassified ) methodSelectors hasSameElements: #( #king #luz ).
+]
+
+{ #category : #tests }
 ClassOrganizationTest >> testClassifyUnderWithProtocol [
 	"Set the base for the test"
 

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -33,8 +33,6 @@ ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod 
 	priorMethodOrNil := self compiledMethodAt: selector ifAbsent: [ nil ].
 	priorMethodOrNil ifNotNil: [ priorOriginOrNil := priorMethodOrNil origin ].
 
-	self addSelectorSilently: selector withMethod: compiledMethod.
-
 	oldProtocol := self organization protocolNameOfElement: selector.
 	SystemAnnouncer uniqueInstance suspendAllWhile: [ "The next part is really ugly with the double if.. BUT! I will fix that in a new PR soon... I want to remove the usage of `Protocol unclassified` as a way to say 'Do not upatde the protocol' because this is counter intuitive."
 		self organization classify: selector under: ((protocol isString
@@ -43,6 +41,8 @@ ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod 
 				 ifTrue: [ oldProtocol ]
 				 ifFalse: [ protocol ]) ].
 	newProtocol := self organization protocolNameOfElement: selector.
+
+	self addSelectorSilently: selector withMethod: compiledMethod.
 
 	self isAnonymous ifTrue: [ ^ self ].
 

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -52,9 +52,12 @@ ClassOrganization >> classify: selector under: aProtocol [
 	Some code was added to make it possible to classify giving a real protocol.
 	Here to keep a small change, I just ask the name to the protocol and use that for compatibility.
 	Later, I plan to update this code once more to directly use the actual object I'm givin instead of doing this little trick."
-	protocolName := aProtocol isString
-		                ifTrue: [ aProtocol ]
-		                ifFalse: [ aProtocol name ].
+	protocolName := aProtocol
+		                ifNil: [ Protocol unclassified ]
+		                ifNotNil: [
+			                aProtocol isString
+				                ifTrue: [ aProtocol ]
+				                ifFalse: [ aProtocol name ] ].
 	forceNotify := (self includesSelector: selector) not.
 	oldProtocolName := self protocolNameOfElement: selector.
 	(forceNotify or: [ oldProtocolName ~= protocolName or: [ protocolName ~= Protocol unclassified ] ]) ifFalse: [ ^ self ].


### PR DESCRIPTION
The management of protocol is currently hard to clean further because some hacks are present.

One of the hack is in #protocolNameOfElement:. This method check if an element is in the protocols of the class and if it is not, it will check if the method is included in the organized class. If it is, then it will return the unclassified protocol. 

One of the case where we rely on this hack is when we first compile a method. The method gets added to the method dictionary and then we classify it, meaning that it is not yet into any protocol. I would like to see what happens if we classify it before we add it to the method dictionary. Meaning that for the first compilation, the classification should have the behavior expected without the hack of #protocolNameOfElement:

Let's see if Pharo can handle that