### PR TITLE
Scope: generalize target class

### DIFF
--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -470,7 +470,7 @@ RBMethodNode >> method [
 { #category : #'accessing - compiled method' }
 RBMethodNode >> methodClass [
 
-	^ self compilationContext ifNotNil: [ :ctxt | ctxt getClass ]
+	^ self scope ifNotNil: [ :s | s targetClass ]
 ]
 
 { #category : #'accessing - compiled method' }

--- a/src/ClassParser/CDClassNameNode.class.st
+++ b/src/ClassParser/CDClassNameNode.class.st
@@ -28,7 +28,7 @@ CDClassNameNode >> className: aString [
 CDClassNameNode >> existingBindingIfAbsent: aBlock [
 
 	| binding |
-	binding := originalNode methodNode compilationContext environment bindingOf: className.
+	binding := originalNode methodNode scope environment bindingOf: className.
 	^binding ifNil: aBlock
 ]
 

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -454,11 +454,6 @@ CompilationContext >> environment: anObject [
 	environment := anObject
 ]
 
-{ #category : #accessing }
-CompilationContext >> getClass [
-	^ semanticScope targetClass
-]
-
 { #category : #initialization }
 CompilationContext >> initialize [
 

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -446,7 +446,7 @@ CompilationContext >> encoderClass: anObject [
 
 { #category : #accessing }
 CompilationContext >> environment [
-	^ environment ifNil: [ environment := semanticScope targetEnvironment ]
+	^ environment ifNil: [ environment := semanticScope environment ]
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -252,7 +252,7 @@ OCASTSemanticAnalyzer >> visitInlinedBlockNode: aBlockNode [
 OCASTSemanticAnalyzer >> visitMessageNode: aMessageNode [
 	
 	super visitMessageNode: aMessageNode.
-	aMessageNode isSuperSend ifTrue: [ aMessageNode superOf: self compilationContext getClass ]
+	aMessageNode isSuperSend ifTrue: [ aMessageNode superOf: scope targetClass ]
 ]
 
 { #category : #visiting }

--- a/src/OpalCompiler-Core/OCAbstractScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractScope.class.st
@@ -15,6 +15,11 @@ OCAbstractScope class >> isAbstract [
 	^self = OCAbstractScope
 ]
 
+{ #category : #accessing }
+OCAbstractScope >> environment [
+	^self targetClass environment
+]
+
 { #category : #lookup }
 OCAbstractScope >> hasBindingThatBeginsWith: aString [
 	"check weather there are any variables defined that start with aString"
@@ -73,9 +78,4 @@ OCAbstractScope >> registerVariables [
 { #category : #accessing }
 OCAbstractScope >> targetClass [
 	^outerScope ifNotNil: [ :it | it targetClass ]
-]
-
-{ #category : #accessing }
-OCAbstractScope >> targetEnvironment [
-	^self targetClass environment
 ]

--- a/src/OpalCompiler-Core/OCAbstractScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractScope.class.st
@@ -69,3 +69,13 @@ OCAbstractScope >> registerVariables [
 
 	outerScope ifNotNil: [ :it | it registerVariables ]
 ]
+
+{ #category : #accessing }
+OCAbstractScope >> targetClass [
+	^outerScope ifNotNil: [ :it | it targetClass ]
+]
+
+{ #category : #accessing }
+OCAbstractScope >> targetEnvironment [
+	^self targetClass environment
+]

--- a/src/OpalCompiler-Core/OCSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCSemanticScope.class.st
@@ -67,13 +67,3 @@ OCSemanticScope >> lookupVar: name [
 
 	^ super lookupVar: name
 ]
-
-{ #category : #accessing }
-OCSemanticScope >> targetClass [
-	self subclassResponsibility
-]
-
-{ #category : #accessing }
-OCSemanticScope >> targetEnvironment [
-	^self targetClass environment
-]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -428,6 +428,12 @@ OpalCompiler >> decompileMethod: aCompiledMethod [
 { #category : #private }
 OpalCompiler >> doSemanticAnalysis [
 
+	|scope|
+	"First thing is to attach a initial scope to the method,
+	so plugins can have something to rely on for their analysis and transformations"
+	scope := OCMethodScope new outerScope: self buildOuterScope.
+	ast scope: scope.  scope node: ast.
+
 	self callParsePlugins.
 	self compilationContext semanticAnalyzerClass new
 		compilationContext: self compilationContext;


### PR DESCRIPTION
For the semantic analysis, scopes are nested objects, so demanding a variable binding is either answer or delegated to an outer scope.
Except for `targetClass` and `targetEnvironment` that were only available at a single scope level (the weirdly named SemanticScope).
So this PR push up `targetClass` and `targetEnvironement` (renamed as environment) so all scope can access it, and update some clients.

Especially, it updates `RBMetodNode>>methodClass` to simply rely on its scope instead of asking compilationContext.
The side effect is that `RBMetodNode scope` must be setup earlier in the semantic analysis, as some plugin examples expect it.
This feel like a good move, but I'm willing to consider alternatives if someone have a better idea.