### PR TITLE
Reflectivity: make tests more reliable (and fix a bug)

### DIFF
--- a/src/Reflectivity-Tests/LinkInstallerTest.class.st
+++ b/src/Reflectivity-Tests/LinkInstallerTest.class.st
@@ -31,9 +31,6 @@ LinkInstallerTest >> setUp [
 LinkInstallerTest >> tearDown [
 	ReflectivityExamples2 new removeModifiedMethodWithInstVarAccess.
 	ReflectivityExamples new removeTemporaryMethods.
-	Smalltalk garbageCollectMost.
-	MetaLink uninstallAll.
-	Smalltalk garbageCollectMost.
 	super tearDown
 ]
 

--- a/src/Reflectivity-Tests/LinkInstallerTest.class.st
+++ b/src/Reflectivity-Tests/LinkInstallerTest.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #LinkInstallerTest,
-	#superclass : #TestCase,
+	#superclass : #ReflectivityTestCase,
 	#instVars : [
 		'obj1',
 		'obj2',
@@ -498,7 +498,10 @@ LinkInstallerTest >> testPropagateClassScopedLinks [
 	anonNode := metalink linkInstaller findSubNode: node in: (obj1 class >> #exampleIfTrueIfFalse) ast.
 
 	self assert: anonNode links size equals: 2.
-	self assert: (anonNode links includes: metalink)
+	self assert: (anonNode links includes: metalink).
+	
+	metalink uninstall.
+	metalink2 uninstall
 ]
 
 { #category : #'links - updating' }
@@ -518,7 +521,10 @@ LinkInstallerTest >> testPropagateClassScopedLinksOnMethodNode [
 
 	anonNode := (obj1 class >> #exampleIfTrueIfFalse) ast.
 
-	self assert: (anonNode links includes: metalink)
+	self assert: (anonNode links includes: metalink).
+	
+	metalink uninstall.
+	metalink2 uninstall
 ]
 
 { #category : #'links - updating' }
@@ -584,7 +590,11 @@ LinkInstallerTest >> testPropagateLinksOnRBProgramNode [
 
 	self assert: objectSpecificVarNode links size equals: 2.
 	self assert: (objectSpecificVarNode links includes: link).
-	self assert: (objectSpecificVarNode links includes: link2)
+	self assert: (objectSpecificVarNode links includes: link2).
+	
+	
+	link uninstall.
+	link2 uninstall
 ]
 
 { #category : #'links - updating' }
@@ -606,7 +616,10 @@ LinkInstallerTest >> testPropagateNewClassScopedLinks [
 	"After adding a link to the base class, it must be present on the copied node
 	in the anonymous subclass"
 	node link: metalink.
-	self assert: (anonNode links includes: metalink)
+	self assert: (anonNode links includes: metalink).
+
+	metalink uninstall.
+	metalink2 uninstall
 ]
 
 { #category : #'links - updating' }
@@ -628,7 +641,10 @@ LinkInstallerTest >> testPropagateNewClassScopedLinksOnMethodNode [
 	"After adding a link to the base class, it must be present on the copied node
 	in the anonymous subclass"
 	node link: metalink.
-	self assert: (anonNode links includes: metalink)
+	self assert: (anonNode links includes: metalink).
+	
+	metalink uninstall.
+	metalink2 uninstall
 ]
 
 { #category : #'links - removing' }
@@ -886,7 +902,9 @@ LinkInstallerTest >> testUninstallLinkFromNode [
 
 	self deny: obj1 class isAnonymous.
 	self assert: metalink nodes size equals: 1.
-	self assert: (metalink nodes includes: node)
+	self assert: (metalink nodes includes: node).
+	
+	metalink uninstall
 ]
 
 { #category : #permalinks }

--- a/src/Reflectivity-Tests/MetaLinkObjectAPITest.class.st
+++ b/src/Reflectivity-Tests/MetaLinkObjectAPITest.class.st
@@ -39,12 +39,6 @@ MetaLinkObjectAPITest >> tagExec: aTag [
 	tag add: aTag
 ]
 
-{ #category : #running }
-MetaLinkObjectAPITest >> tearDown [
-	MetaLink uninstallAll.
-	super tearDown
-]
-
 { #category : #'class api' }
 MetaLinkObjectAPITest >> testLinkClassToAST [
 	| link instance |

--- a/src/Reflectivity-Tests/MetaLinkObjectAPITest.class.st
+++ b/src/Reflectivity-Tests/MetaLinkObjectAPITest.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #MetaLinkObjectAPITest,
-	#superclass : #TestCase,
+	#superclass : #ReflectivityTestCase,
 	#instVars : [
 		'tag'
 	],
@@ -55,7 +55,9 @@ MetaLinkObjectAPITest >> testLinkClassToAST [
 	instance := ReflectivityExamples2 new.
 	instance exampleMethod.
 	self assert: tag size equals: 1.
-	self assert: tag first identicalTo: instance
+	self assert: tag first identicalTo: instance.
+	
+	link uninstall
 ]
 
 { #category : #'class api' }
@@ -70,7 +72,9 @@ MetaLinkObjectAPITest >> testLinkClassToClassVarNamed [
 	instance methodWithClassVarAccess.
 
 	self assert: tag size equals: 2.
-	self assert: (tag allSatisfy: [ :t | t == instance ])
+	self assert: (tag allSatisfy: [ :t | t == instance ]).
+
+	link uninstall
 ]
 
 { #category : #'class api' }
@@ -85,7 +89,9 @@ MetaLinkObjectAPITest >> testLinkClassToSlotNamed [
 	instance methodWithInstVarAccess.
 
 	self assert: tag size equals: 2.
-	self assert: (tag allSatisfy: [ :t | t == instance ])
+	self assert: (tag allSatisfy: [ :t | t == instance ]).
+
+	link uninstall
 ]
 
 { #category : #'class api' }
@@ -116,7 +122,9 @@ MetaLinkObjectAPITest >> testLinkClassToTempVarNamed [
 	instance methodWithTempVarAccess.
 
 	self assert: tag size equals: 4.
-	self assert: (tag allSatisfy: [ :t | t = 'ok' ])
+	self assert: (tag allSatisfy: [ :t | t = 'ok' ]).
+
+	link uninstall
 ]
 
 { #category : #'object - api' }

--- a/src/Reflectivity-Tests/MetaLinkRegistryTest.class.st
+++ b/src/Reflectivity-Tests/MetaLinkRegistryTest.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #MetaLinkRegistryTest,
-	#superclass : #TestCase,
+	#superclass : #ReflectivityTestCase,
 	#instVars : [
 		'registry',
 		'permalink'

--- a/src/Reflectivity-Tests/MetaLinkTest.class.st
+++ b/src/Reflectivity-Tests/MetaLinkTest.class.st
@@ -3,7 +3,7 @@ Tests for MetaLink
 "
 Class {
 	#name : #MetaLinkTest,
-	#superclass : #TestCase,
+	#superclass : #ReflectivityTestCase,
 	#category : #'Reflectivity-Tests-Base'
 }
 

--- a/src/Reflectivity-Tests/ReflectiveMethodTest.class.st
+++ b/src/Reflectivity-Tests/ReflectiveMethodTest.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #ReflectiveMethodTest,
-	#superclass : #AbstractEnvironmentTestCase,
+	#superclass : #ReflectivityTestCase,
 	#instVars : [
 		'selector'
 	],
@@ -146,7 +146,9 @@ ReflectiveMethodTest >> testSetLinkOnClassVariable [
 
 	self assert: (classVar links includes: link).
 	self assert: (ReflectivityExamples >> #exampleClassVarRead) class equals: ReflectiveMethod.
-	classVar removeProperty: #links
+	link uninstall.
+	classVar removeProperty: #links.
+
 ]
 
 { #category : #'tests - variables' }

--- a/src/Reflectivity-Tests/ReflectiveMethodTest.class.st
+++ b/src/Reflectivity-Tests/ReflectiveMethodTest.class.st
@@ -7,13 +7,6 @@ Class {
 	#category : #'Reflectivity-Tests-Base'
 }
 
-{ #category : #running }
-ReflectiveMethodTest >> tearDown [
-	selector ifNotNil: [
-		ReflectivityExamples recompile: selector].
-	super tearDown
-]
-
 { #category : #tests }
 ReflectiveMethodTest >> testASTCacheIsCleanedAfterMetaLinkRemoval [
 	| method bcToASTCache |

--- a/src/Reflectivity-Tests/ReflectivityControlTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityControlTest.class.st
@@ -3,7 +3,7 @@ Tests for Reflective method
 "
 Class {
 	#name : #ReflectivityControlTest,
-	#superclass : #TestCase,
+	#superclass : #ReflectivityTestCase,
 	#instVars : [
 		'tag',
 		'link'

--- a/src/Reflectivity-Tests/ReflectivityControlTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityControlTest.class.st
@@ -34,9 +34,6 @@ ReflectivityControlTest >> tagExec: aTag [
 { #category : #running }
 ReflectivityControlTest >> tearDown [
 	link ifNotNil: [ link uninstall ].
-	"Force a recompilation to remove leaking ReflectiveMethods"
-	"TODO fail the test if things are leaking"
-	ReflectivityExamples recompile.
 	super tearDown
 ]
 

--- a/src/Reflectivity-Tests/ReflectivityReificationTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityReificationTest.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : #TestCase,
 	#instVars : [
 		'tag',
-		'link'
+		'link',
+		'link2'
 	],
 	#category : #'Reflectivity-Tests-Base'
 }
@@ -21,8 +22,12 @@ ReflectivityReificationTest >> tagExec: aTag [
 { #category : #running }
 ReflectivityReificationTest >> tearDown [
 	link ifNotNil: [ link uninstall ].
+	link2 ifNotNil: [ link2 uninstall ].
 	"Unfortunately, uninstall is not enough, so force a recompilation"
-	ReflectivityExamples recompile.
+	ReflectivityExamples methods do: [ :m |
+		m hasMetaLinks ifTrue: [
+			m recompile.
+			self fail: 'Leaked metalinks' ] ].
 	super tearDown
 ]
 
@@ -1585,12 +1590,12 @@ ReflectivityReificationTest >> testReifySendArgumentsInstead [
 
 { #category : #'tests - sends' }
 ReflectivityReificationTest >> testReifySendArgumentsInsteadAndBefore [
-	| sendNode instance beforeLink executed |
+	| sendNode instance executed |
 	sendNode := (ReflectivityExamples >> #exampleMethod) ast body
 		statements first value.
 
 	executed := false.
-	beforeLink :=  MetaLink new
+	link2 :=  MetaLink new
 		metaObject: [:args | executed := true ];
 		selector: #value:;
 		arguments: #(arguments).
@@ -1600,7 +1605,7 @@ ReflectivityReificationTest >> testReifySendArgumentsInsteadAndBefore [
 		selector: #tagExec:;
 		control: #instead;
 		arguments: #(arguments).
-	sendNode link: beforeLink.
+	sendNode link: link2.
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
 	self assert: (ReflectivityExamples >> #exampleMethod) class equals: ReflectiveMethod.
@@ -1648,12 +1653,12 @@ ReflectivityReificationTest >> testReifySendMethodToExecute [
 
 { #category : #'tests - sends' }
 ReflectivityReificationTest >> testReifySendOperationInsteadAndBefore [
-	| sendNode instance beforeLink executed |
+	| sendNode instance executed |
 	sendNode := (ReflectivityExamples >> #exampleMethod) ast body
 		statements first value.
 
 	executed := false.
-	beforeLink :=  MetaLink new
+	link2 :=  MetaLink new
 		metaObject: [:args | executed := true ];
 		selector: #value:;
 		arguments: #(operation).
@@ -1663,7 +1668,7 @@ ReflectivityReificationTest >> testReifySendOperationInsteadAndBefore [
 		selector: #tagExec:;
 		control: #instead;
 		arguments: #(operation).
-	sendNode link: beforeLink.
+	sendNode link: link2.
 	sendNode link: link.
 	self assert: sendNode hasMetalink.
 	self assert: (ReflectivityExamples >> #exampleMethod) class equals: ReflectiveMethod.

--- a/src/Reflectivity-Tests/ReflectivityReificationTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityReificationTest.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #ReflectivityReificationTest,
-	#superclass : #TestCase,
+	#superclass : #ReflectivityTestCase,
 	#instVars : [
 		'tag',
 		'link',
@@ -23,11 +23,6 @@ ReflectivityReificationTest >> tagExec: aTag [
 ReflectivityReificationTest >> tearDown [
 	link ifNotNil: [ link uninstall ].
 	link2 ifNotNil: [ link2 uninstall ].
-	"Unfortunately, uninstall is not enough, so force a recompilation"
-	ReflectivityExamples methods do: [ :m |
-		m hasMetaLinks ifTrue: [
-			m recompile.
-			self fail: 'Leaked metalinks' ] ].
 	super tearDown
 ]
 

--- a/src/Reflectivity-Tests/ReflectivityTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityTest.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #ReflectivityTest,
-	#superclass : #TestCase,
+	#superclass : #ReflectivityTestCase,
 	#instVars : [
 		'count',
 		'tag',
@@ -39,7 +39,6 @@ ReflectivityTest >> tearDown [
 	link2 ifNotNil: [link2 uninstall].
 	tag := nil.
 	count := 0.
-	(ReflectivityExamples>>#exampleWithArg:) recompile.
 	ASTCache default: cache.
 	super tearDown
 ]

--- a/src/Reflectivity-Tests/ReflectivityTestCase.class.st
+++ b/src/Reflectivity-Tests/ReflectivityTestCase.class.st
@@ -1,0 +1,14 @@
+Class {
+	#name : #ReflectivityTestCase,
+	#superclass : #AbstractEnvironmentTestCase,
+	#category : #'Reflectivity-Tests-Base'
+}
+
+{ #category : #running }
+ReflectivityTestCase >> tearDown [
+	self class package methods do: [ :m |
+		m hasMetaLinks ifTrue: [
+			m recompile.
+			self fail: 'Leaked metalinks' ] ].
+	super tearDown
+]

--- a/src/Reflectivity/RFASTTranslator.class.st
+++ b/src/Reflectivity/RFASTTranslator.class.st
@@ -337,7 +337,9 @@ RFASTTranslator >> visitVariableValue: aVariable [
 	self emitPreamble: aVariable.
 	self emitMetaLinkBefore: aVariable.
 	aVariable hasMetalinkInstead
-		ifTrue: [self emitMetaLinkInstead: aVariable]
+		ifTrue: [
+			methodBuilder addLiteral: aVariable.
+			self emitMetaLinkInstead: aVariable]
 		ifFalse: [aVariable emitValue: methodBuilder].
 	self emitMetaLinkAfterNoEnsure: aVariable
 ]

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -31,6 +31,17 @@ ReflectiveMethod >> ast [
 ]
 
 { #category : #evaluation }
+ReflectiveMethod >> compileAST [
+
+	OCASTSemanticCleaner clean: ast.
+	ast compilationContext
+		semanticAnalyzerClass: RFSemanticAnalyzer;
+		astTranslatorClass: RFASTTranslator.
+	ast doSemanticAnalysis. "force semantic analysis"
+	^ ast generate: compiledMethod trailer
+]
+
+{ #category : #evaluation }
 ReflectiveMethod >> compileAndInstallCompiledMethod [
 	self wrapperNeeded ifTrue: [ self generatePrimitiveWrapper ].
 	self recompileAST.
@@ -82,12 +93,7 @@ ReflectiveMethod >> flushCache [
 { #category : #evaluation }
 ReflectiveMethod >> generatePrimitiveWrapper [
 	| wrappedMethod send wrapperMethod assignmentNode |
-	OCASTSemanticCleaner clean: ast.
-	ast compilationContext
-		semanticAnalyzerClass: RFSemanticAnalyzer;
-		astTranslatorClass: RFASTTranslator.
-	ast doSemanticAnalysis. "force semantic analysis"
-	wrappedMethod := ast generate: compiledMethod trailer.
+	wrappedMethod := self compileAST.
 
 	send := RBMessageNode
 		receiver: RBVariableNode selfNode
@@ -200,12 +206,7 @@ ReflectiveMethod >> printOn: aStream [
 { #category : #evaluation }
 ReflectiveMethod >> recompileAST [
 
-	OCASTSemanticCleaner clean: ast.
-	ast compilationContext
-		semanticAnalyzerClass: RFSemanticAnalyzer;
-		astTranslatorClass: RFASTTranslator.
-	ast doSemanticAnalysis. "force semantic analysis"
-	compiledMethod := ast generate: compiledMethod trailer.
+	compiledMethod := self compileAST.
 	ast compiledMethod: compiledMethod.
 	compiledMethod reflectiveMethod: self
 ]


### PR DESCRIPTION
should fix #13516

Tests teardown in metalinks were limited and some leaked metalinks cause failure on retry.
Moreover, unexpected leaks could make the test green but fail subsequent tests.

The PR forces each test to clean after itself. Failure to do so means an error in the test or elsewhere and should be investigated.

* add missing link uninstallations on tests that missed some
* new superclass ReflectivityTestCase that offer a teardown that detect metalink leaks, fails the corresponding test, and try to clean the leak.
* fix a bug preventing removal of *instead* metalinks on global variables. When using instead, the global is no more read, thus the method with the *instead* instrumentation won't be listed on `usingMethods`, thus the instrumentation won't be removed. The solution is to inject the global as a forced literal to be present on `usingMethods`.