### PR TITLE
CompiledMethodTrailer: more cleanup, do not use it for #endPC

### DIFF
--- a/src/Fuel-Tests-Core/FLCompiledMethodSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLCompiledMethodSerializationTest.class.st
@@ -24,7 +24,7 @@ FLCompiledMethodSerializationTest >> testDoIt [
 	self assert: theCompiledMethod isInstalled.
 	self deny: theCompiledMethod sourceCode isNil.
 	self assert: theCompiledMethod trailer isEmpty.
-	self deny: theCompiledMethod trailer hasSourcePointer.
+	self deny: theCompiledMethod hasSourcePointer.
 
 	materialized := self resultOfSerializeAndMaterialize: theCompiledMethod.
 	"not possible since it's a different instance"
@@ -33,7 +33,7 @@ FLCompiledMethodSerializationTest >> testDoIt [
 	"we serialized the source, trailer is cleared"
 	self assert: materialized sourceCode notNil.
 	self assert: materialized trailer isEmpty.
-	self deny: materialized trailer hasSourcePointer.
+	self deny: materialized hasSourcePointer.
 
 	self assert: (materialized isEqualRegardlessTrailerTo: theCompiledMethod)
 ]
@@ -47,7 +47,7 @@ FLCompiledMethodSerializationTest >> testInstalled [
 	self deny: theCompiledMethod isDoIt.
 	self deny: theCompiledMethod sourceCode isNil.
 	self deny: theCompiledMethod trailer isEmpty.
-	self assert: theCompiledMethod trailer hasSourcePointer.
+	self assert: theCompiledMethod hasSourcePointer.
 
 	"if installed but not different, the installed instance will be answered"
 	materialized := self resultOfSerializeAndMaterialize: theCompiledMethod.
@@ -64,7 +64,7 @@ FLCompiledMethodSerializationTest >> testInstalledModified [
 	self assert: theCompiledMethod isInstalled.
 	self deny: theCompiledMethod isDoIt.
 	self deny: theCompiledMethod trailer isEmpty.
-	self assert: theCompiledMethod trailer hasSourcePointer.
+	self assert: theCompiledMethod hasSourcePointer.
 
 	copy := theCompiledMethod copy.
 	"different instance can not be installed at the same time."
@@ -72,7 +72,7 @@ FLCompiledMethodSerializationTest >> testInstalledModified [
 	self deny: copy isDoIt.
 	self deny: theCompiledMethod sourceCode isNil.
 	self deny: copy trailer isEmpty.
-	self assert: copy trailer hasSourcePointer.
+	self assert: copy hasSourcePointer.
 
 	"if installed but not different, the installed instance will be answered"
 	materialized := self resultOfSerializeAndMaterialize: copy.
@@ -128,7 +128,7 @@ FLCompiledMethodSerializationTest >> testNotInstalled [
 	self deny: theCompiledMethod isInstalled.
 	self deny: theCompiledMethod isDoIt.
 	self assert: theCompiledMethod trailer isEmpty.
-	self deny: theCompiledMethod trailer hasSourcePointer.
+	self deny: theCompiledMethod hasSourcePointer.
 	
 	materialized := self resultOfSerializeAndMaterialize: theCompiledMethod.
 	self deny: materialized isInstalled.
@@ -136,7 +136,7 @@ FLCompiledMethodSerializationTest >> testNotInstalled [
 	"we serialized the source, trailer is empty"
 	self assert: materialized sourceCode notNil.
 	self assert: materialized trailer isEmpty.
-	self deny: materialized trailer hasSourcePointer.
+	self deny: materialized hasSourcePointer.
 	
 	self assert: (materialized isEqualRegardlessTrailerTo: theCompiledMethod)
 ]

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -310,6 +310,12 @@ CompiledMethod class >> toReturnSelfTrailerBytes: trailer [
 	^self newBytes: 3 trailerBytes: trailer nArgs: 0 nTemps: 0 nStack: 0 nLits: 2 primitive: 256
 ]
 
+{ #category : #constants }
+CompiledMethod class >> trailerSize [
+	"we use the last 4 byte to store the source pointer, this allows for 2GB .sources/.changes"
+	^ 4
+]
+
 { #category : #queries }
 CompiledMethod >> allIgnoredNotImplementedSelectors [
 
@@ -398,7 +404,7 @@ CompiledMethod >> displayStringOn: aStream [
 { #category : #accessing }
 CompiledMethod >> endPC [
 	"Answer the index of the last bytecode, as the trailer size varies we have to delegate"
-	^ self trailer endPC
+	^ self size - self class trailerSize
 ]
 
 { #category : #accessing }
@@ -1022,22 +1028,14 @@ CompiledMethod >> selector: aSelector [
 
 { #category : #'source code management' }
 CompiledMethod >> setSourcePointer: srcPointer [
-	"We can't change the trailer of existing method, since it could have completely different format.
-	Therefore we need to generate a copy with new trailer, containing scrPointer, and then become it."
 
-	| trailer |
+	| trailer start |
 	"Drop the #source property if any"
 	self removeProperty: #source.
 	
-	trailer := (CompiledMethodTrailer new sourcePointer: srcPointer) encode.
-	"If possible do a replace in place as an optimization"
-	(self trailer class == trailer class and: [ trailer size = self trailer size ])
-		ifTrue: [
-			| start |
-			start := self endPC + 1.
-			self replaceFrom: start to: self size with: trailer encodedData startingAt: 1 ]
-		ifFalse: [ self becomeForward: (self copyWithTrailerBytes: trailer) ].
-	^ self
+	trailer := CompiledMethodTrailer new sourcePointer: srcPointer.
+	start := self endPC + 1.
+	self replaceFrom: start to: self size with: trailer encodedData startingAt: 1.
 ]
 
 { #category : #accessing }
@@ -1057,7 +1055,7 @@ CompiledMethod >> sourceCodeOrNil [
 	trailer := self trailer.
 	trailer sourceCode ifNotNil: [ :code | ^ code ].
 	self propertyAt: #source ifPresent:  [ :code | ^ code ].
-	trailer hasSourcePointer ifFalse: [ ^ nil ].
+	self hasSourcePointer ifFalse: [ ^ nil ].
 	^ self getSourceFromFile ifEmpty: [ nil ]
 ]
 

--- a/src/Kernel/CompiledMethodTrailer.class.st
+++ b/src/Kernel/CompiledMethodTrailer.class.st
@@ -13,7 +13,6 @@ Class {
 	#instVars : [
 		'data',
 		'encodedData',
-		'kind',
 		'method'
 	],
 	#category : #'Kernel-Methods'
@@ -27,7 +26,6 @@ CompiledMethodTrailer class >> empty [
 
 { #category : #initialization }
 CompiledMethodTrailer >> clear [
-	kind := #NoTrailer.
 	data := 0.
 	encodedData :=  #[0 0 0 0].
 	method := nil
@@ -83,8 +81,8 @@ CompiledMethodTrailer >> hasSource [
 
 { #category : #testing }
 CompiledMethodTrailer >> hasSourcePointer [
-	encodedData = #[0 0 0 0] ifTrue: [ ^false ].
-	^ kind == #SourcePointer
+
+	^ encodedData ~= #[ 0 0 0 0 ]
 ]
 
 { #category : #initialization }
@@ -94,15 +92,8 @@ CompiledMethodTrailer >> initialize [
 
 { #category : #testing }
 CompiledMethodTrailer >> isEmpty [
-	^ kind == #NoTrailer or: [ kind == #ClearedTrailer or: [encodedData = #[0 0 0 0]]]
-]
 
-{ #category : #accessing }
-CompiledMethodTrailer >> kind [
-	"Answer a symbolic name of trailer kind.
-	See #trailerKinds on class side and class comment for details"
-
-	^ kind
+	^ encodedData = #[ 0 0 0 0 ]
 ]
 
 { #category : #accessing }
@@ -110,7 +101,6 @@ CompiledMethodTrailer >> method: aMethod [
 
 	| msz |
 	method := aMethod.
-	kind := #SourcePointer.
 	msz := method size.
 	encodedData := {
 		method at: msz-3.
@@ -135,16 +125,13 @@ CompiledMethodTrailer >> sourceCode [
 { #category : #accessing }
 CompiledMethodTrailer >> sourcePointer [
 
-	^ kind == #SourcePointer
-		ifTrue: [ data ]
-		ifFalse: [ 0 ]
+	^ data
 ]
 
 { #category : #accessing }
 CompiledMethodTrailer >> sourcePointer: ptr [
 
 	data := ptr.
-	kind := #SourcePointer.
 	self encode.
 	
 ]

--- a/src/OpalCompiler-Tests/OpalCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTest.class.st
@@ -86,7 +86,7 @@ OpalCompilerTest >> testCompileSource [
 	"Compiled but uninstalled methods have a #source but no sourcePointer"
 	result := MockForCompilation compiler compile: source.
 	self assert: (result valueWithReceiver: nil arguments: #()) equals: 7.
-	self deny: result trailer hasSourcePointer. "no sourcePointer"
+	self deny: result hasSourcePointer. "no sourcePointer"
 	self assert: (result propertyAt: #source) equals: source.
 	self assert: result sourceCodeOrNil equals: source.
 
@@ -94,7 +94,7 @@ OpalCompilerTest >> testCompileSource [
 	result := MockForCompilation compiler install: source.
 	self assert: result equals: MockForCompilation>>#tt.
 	self assert: (result valueWithReceiver: nil arguments: #()) equals: 7.
-	self assert: result trailer hasSourcePointer. "no sourcePointer"
+	self assert: result hasSourcePointer. "no sourcePointer"
 	self assert: (result propertyAt: #source) equals: nil.
 	self assert: result sourceCodeOrNil equals: source.
 
@@ -102,7 +102,7 @@ OpalCompilerTest >> testCompileSource [
 	MockForCompilation compiler install: 'tt ^42'.
 	self deny: result equals: MockForCompilation>>#tt.
 	self assert: (result valueWithReceiver: nil arguments: #()) equals: 7.
-	self assert: result trailer hasSourcePointer. "no sourcePointer"
+	self assert: result hasSourcePointer. "no sourcePointer"
 	self assert: (result propertyAt: #source) equals: nil.
 	self assert: result sourceCodeOrNil equals: source.
 	


### PR DESCRIPTION
- remove the kind ivar from CompiledMethodTrailer
- change CompiledMethod endPC to not instantiate a  CompiledMethodTrailer
- simplify setSourcePointer:
- less sends to #trailer