### PR TITLE
Autocompletion must replace from start of the word if case-insensitiv…

### DIFF
--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -328,7 +328,7 @@ CompletionEngine >> replaceTokenInEditorWith: aString [
 		to: wordEnd - 1.
 	old := self editor selection.
 
-	( old size >= aString size )
+	( NECPreferences caseSensitive not or: [ old size >= aString size ] )
 		ifTrue:[
 				self editor replaceSelectionWith: aString. ]
 		ifFalse: [


### PR DESCRIPTION
…e completions are turned on, otherwise wrongly-cased letters are not overwritten.