### PR TITLE
Ensure methods are in a protocol

### DIFF
--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -86,8 +86,13 @@ ClassDescription >> addSelector: selector withMethod: compiledMethod [
 
 { #category : #'accessing - method dictionary' }
 ClassDescription >> addSelectorSilently: selector withMethod: compiledMethod [
+
 	super addSelectorSilently: selector withMethod: compiledMethod.
-	self instanceSide noteAddedSelector: selector meta: self isMeta
+	self instanceSide noteAddedSelector: selector meta: self isMeta.
+
+	"In case we silently add a method without classification, we want to be sure that the method is classified. So we add it to the unclassified protocol if it has not been classified before."
+	(self organization protocolOfSelector: selector) ifNil: [
+		SystemAnnouncer uniqueInstance suspendAllWhile: [ self organization silentlyClassify: selector under: Protocol unclassified ] ]
 ]
 
 { #category : #'instance variables' }

--- a/src/TraitsV2/TaAbstractComposition.class.st
+++ b/src/TraitsV2/TaAbstractComposition.class.st
@@ -157,9 +157,8 @@ TaAbstractComposition >> compile: selector into: aClass [
 		ifTrue: [ self saveSourceCode: sourceCode ofMethod: newMethod ]
 		ifFalse: [ newMethod setSourcePointer: method sourcePointer ].
 
-	aClass addSelectorSilently: selector withMethod: newMethod.
-
 	aClass organization silentlyClassify: selector under: (self categoryOfMethod: method withSelector: method selector).
+	aClass addSelectorSilently: selector withMethod: newMethod.
 
 	aClass >> selector propertyAt: #traitSource put: traitDefining.
 	^ true
@@ -215,11 +214,8 @@ TaAbstractComposition >> copyMethod: aSelector into: aClass replacing: replacing
 
 	newMethod setSourcePointer: aCompiledMethod sourcePointer.
 
-	aClass addSelectorSilently: aSelector withMethod: newMethod.
-
 	aClass organization silentlyClassify: aSelector under: aCompiledMethod protocol.
-
-	aClass organization removeEmptyProtocols.
+	aClass addSelectorSilently: aSelector withMethod: newMethod.
 
 	aClass >> aSelector propertyAt: #traitSource put: traitDefining.
 


### PR DESCRIPTION
All methods should be in a protocol when installed in a class.  Currently, this is not the case. Some methods are added silently and never added to the class protocols. Then we have hacks that check if a method is classified or not in the protocol management.

Here I ensure that if a method is not classified while been added to a class, we put it in the unclassified protocol.  If the method is installed by Opal or if the method was already classified in the past, then this will do nothing.

I hope that this move will help me to deal with the hacks in protocols preventing me from simplifying further the protocol management.