### PR TITLE
Cleanup: CompiledMethodTrailer should not create methods

### DIFF
--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -170,29 +170,16 @@ CompiledMethod class >> new [
 CompiledMethod class >> newBytes: numberOfBytes trailerBytes: trailer nArgs: nArgs nTemps: nTemps nStack: stackSize nLits: nLits primitive: primitiveIndex [
 	"Answer an instance of me. The header is specified by the message
 	 arguments. The remaining parts are not as yet determined."
-	| method pc |
-	nArgs > 15 ifTrue:
-		[^self error: 'Cannot compile -- too many arguments'].
-	nTemps > 63 ifTrue:
-		[^self error: 'Cannot compile -- too many temporary variables'].
-	nLits > 65535 ifTrue:
-		[^self error: 'Cannot compile -- too many literals'].
 
-	method := trailer
-				createMethod: numberOfBytes
-				class: self
-				header:    (nArgs bitShift: 24)
-						+ (nTemps bitShift: 18)
-						+ ((nTemps + stackSize) > SmallFrame ifTrue: [1 bitShift: 17] ifFalse: [0])
-						+ nLits
-						+ (primitiveIndex > 0 ifTrue: [1 bitShift: 16] ifFalse: [0]).
-	primitiveIndex > 0 ifTrue:
-		[pc := method initialPC.
-		 method
-			at: pc + 0 put: method encoderClass callPrimitiveCode;
-			at: pc + 1 put: (primitiveIndex bitAnd: 16rFF);
-			at: pc + 2 put: (primitiveIndex bitShift: -8)].
-	^method
+	^ self
+		  newBytes: numberOfBytes
+		  trailerBytes: trailer
+		  nArgs: nArgs
+		  nTemps: nTemps
+		  nStack: stackSize
+		  nLits: nLits
+		  primitive: primitiveIndex
+		  flag: false
 ]
 
 { #category : #'instance creation' }
@@ -207,9 +194,8 @@ CompiledMethod class >> newBytes: numberOfBytes trailerBytes: trailer nArgs: nAr
 	nLits > 65535 ifTrue:
 		[^self error: 'Cannot compile -- too many literals'].
 
-	method := trailer
-				createMethod: numberOfBytes
-				class: self
+	method := self
+				newMethod: numberOfBytes
 				header:    (nArgs bitShift: 24)
 						+ (nTemps bitShift: 18)
 						+ ((nTemps + stackSize) > SmallFrame ifTrue: [1 bitShift: 17] ifFalse: [0])
@@ -280,36 +266,6 @@ CompiledMethod class >> subclassResponsibilityMarker [
 	^ #subclassResponsibility
 ]
 
-{ #category : #'instance creation' }
-CompiledMethod class >> toReturnConstant: index trailerBytes: trailer [
-	"Answer an instance of me that is a quick return of the constant
-	indexed in (true false nil -1 0 1 2)."
-
-	^self newBytes: 3 trailerBytes: trailer nArgs: 0 nTemps: 0 nStack: 0 nLits: 2 primitive: 256 + index
-]
-
-{ #category : #'instance creation' }
-CompiledMethod class >> toReturnField: field trailerBytes: trailer [
-	"Answer an instance of me that is a quick return of the instance variable
-	indexed by the argument, field."
-
-	^self newBytes: 3 trailerBytes: trailer nArgs: 0 nTemps: 0 nStack: 0 nLits: 2 primitive: 264 + field
-]
-
-{ #category : #'instance creation' }
-CompiledMethod class >> toReturnSelf [
-	"Answer an instance of me that is a quick return of the instance (^self)."
-
-	^ self toReturnSelfTrailerBytes: CompiledMethodTrailer empty
-]
-
-{ #category : #'instance creation' }
-CompiledMethod class >> toReturnSelfTrailerBytes: trailer [
-	"Answer an instance of me that is a quick return of the instance (^self)."
-
-	^self newBytes: 3 trailerBytes: trailer nArgs: 0 nTemps: 0 nStack: 0 nLits: 2 primitive: 256
-]
-
 { #category : #constants }
 CompiledMethod class >> trailerSize [
 	"we use the last 4 byte to store the source pointer, this allows for 2GB .sources/.changes"
@@ -371,14 +327,11 @@ CompiledMethod >> containsHalt [
 
 { #category : #initialization }
 CompiledMethod >> copyWithTrailerBytes: trailer [
-"Testing:
-	(CompiledMethod compiledMethodAt: #copyWithTrailerBytes:)
-		tempNamesPut: 'copy end '
-"
+
 	| copy end start penultimateLiteral |
 	start := self initialPC.
 	end := self endPC.
-	copy := trailer createMethod: end - start + 1 class: self class header: self header.
+	copy := self class newMethod: end - start + 1 header: self header.
 	1 to: self numLiterals do: [:i | copy literalAt: i put: (self literalAt: i)].
 	(penultimateLiteral := self penultimateLiteral) isMethodProperties ifTrue:
 		[copy penultimateLiteral: (penultimateLiteral copy
@@ -496,7 +449,7 @@ CompiledMethod >> hasSourceCode [
 
 { #category : #testing }
 CompiledMethod >> hasSourcePointer [
-	^ self trailer hasSourcePointer
+	^ self sourcePointer ~= 0
 ]
 
 { #category : #testing }

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -331,7 +331,7 @@ CompiledMethod >> copyWithTrailerBytes: trailer [
 	| copy end start penultimateLiteral |
 	start := self initialPC.
 	end := self endPC.
-	copy := self class newMethod: end - start + 1 header: self header.
+	copy := self class newMethod: end - start + 1 + self class trailerSize header: self header.
 	1 to: self numLiterals do: [:i | copy literalAt: i put: (self literalAt: i)].
 	(penultimateLiteral := self penultimateLiteral) isMethodProperties ifTrue:
 		[copy penultimateLiteral: (penultimateLiteral copy

--- a/src/Kernel/CompiledMethodTrailer.class.st
+++ b/src/Kernel/CompiledMethodTrailer.class.st
@@ -24,32 +24,6 @@ CompiledMethodTrailer class >> empty [
 	^ self new
 ]
 
-{ #category : #'creating a method' }
-CompiledMethodTrailer >> createMethod: numberOfBytesForAllButTrailer class: aCompiledMethodClass header: headerWord [
-	| meth size |
-	"Instantiates a compiled method with this trailer.
-	- numberOfBytesForAllButTrailer specifies the number of bytes needed to encode the literals and the bytecode.
-	- aCompiledMethodClass specifies the concrete class of the compiled method.
-	- headerWord specifies the header used for the compiled method.
-
-	This method will create a compiled method instance of the correct size, set it's header and trailing bytes. The bytecode and literals must be set by the caller."
-	size := CompiledMethod trailerSize.
-	encodedData := data asByteArrayOfSize: size.
-	
-	meth := aCompiledMethodClass newMethod: numberOfBytesForAllButTrailer + size header: headerWord.
-	"copy the encoded trailer data"
-	1 to: size do:
-		[:i | meth at: meth size - size + i put: (encodedData at: i)].
-
-	^meth
-]
-
-{ #category : #testing }
-CompiledMethodTrailer >> hasSourcePointer [
-
-	^ encodedData ~= #[ 0 0 0 0 ]
-]
-
 { #category : #initialization }
 CompiledMethodTrailer >> initialize [
 	data := 0.
@@ -74,12 +48,6 @@ CompiledMethodTrailer >> method: aMethod [
 CompiledMethodTrailer >> size [
 	"Answer the size of method's trailer , in bytes"
 	^ CompiledMethod trailerSize
-]
-
-{ #category : #accessing }
-CompiledMethodTrailer >> sourceCode [
-	"Not supported anymore, trailers never encode source"
-	^ nil
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
+++ b/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
@@ -204,7 +204,7 @@ IRBytecodeGenerator >> compiledMethodWith: trailer header: header literals: lits
 	| cm cmClass|
 	"we look up the class in the productionEnvironment"
 	cmClass := self compilationContext compiledMethodClass.
-	cm := trailer createMethod: self bytecodes size class: cmClass header: header.
+	cm := cmClass newMethod: self bytecodes size + CompiledMethod trailerSize header: header.
 	(WriteStream with: cm)
 		position: cm initialPC - 1;
 		nextPutAll: self bytecodes.

--- a/src/OpalCompiler-Tests/MethodMapTest.class.st
+++ b/src/OpalCompiler-Tests/MethodMapTest.class.st
@@ -15,7 +15,7 @@ MethodMapTest >> compileAndRunExample: aSelector [
 { #category : #utilities }
 MethodMapTest >> compileMethod: aMethod [
 
-	^aMethod parseTree generate: aMethod trailer
+	^ aMethod parseTree generateMethod setSourcePointer: aMethod sourcePointer
 ]
 
 { #category : #'tests - ast mapping' }

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -32,13 +32,16 @@ ReflectiveMethod >> ast [
 
 { #category : #evaluation }
 ReflectiveMethod >> compileAST [
-
+	| method |
 	OCASTSemanticCleaner clean: ast.
 	ast compilationContext
 		semanticAnalyzerClass: RFSemanticAnalyzer;
 		astTranslatorClass: RFASTTranslator.
 	ast doSemanticAnalysis. "force semantic analysis"
-	^ ast generateMethod setSourcePointer: compiledMethod sourcePointer
+	method := ast generate: CompiledMethodTrailer empty.
+	method setSourcePointer: compiledMethod sourcePointer.
+	ast compiledMethod: method.
+	^method.
 ]
 
 { #category : #evaluation }

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -38,7 +38,7 @@ ReflectiveMethod >> compileAST [
 		semanticAnalyzerClass: RFSemanticAnalyzer;
 		astTranslatorClass: RFASTTranslator.
 	ast doSemanticAnalysis. "force semantic analysis"
-	^ ast generate: compiledMethod trailer
+	^ ast generate setSourcePointer: compiledMethod sourcePointer
 ]
 
 { #category : #evaluation }

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -38,7 +38,7 @@ ReflectiveMethod >> compileAST [
 		semanticAnalyzerClass: RFSemanticAnalyzer;
 		astTranslatorClass: RFASTTranslator.
 	ast doSemanticAnalysis. "force semantic analysis"
-	^ ast generate setSourcePointer: compiledMethod sourcePointer
+	^ ast generateMethod setSourcePointer: compiledMethod sourcePointer
 ]
 
 { #category : #evaluation }

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -40,7 +40,6 @@ ReflectiveMethod >> compileAST [
 	ast doSemanticAnalysis. "force semantic analysis"
 	method := ast generate: CompiledMethodTrailer empty.
 	method setSourcePointer: compiledMethod sourcePointer.
-	ast compiledMethod: method.
 	^method.
 ]
 

--- a/src/UnifiedFFI-Tests/FFICalloutMethodBuilderTestContext.class.st
+++ b/src/UnifiedFFI-Tests/FFICalloutMethodBuilderTestContext.class.st
@@ -80,8 +80,3 @@ FFICalloutMethodBuilderTestContext >> selector [
 FFICalloutMethodBuilderTestContext >> selector: anObject [
 	selector := anObject
 ]
-
-{ #category : #accessing }
-FFICalloutMethodBuilderTestContext >> trailer [
-	^ CompiledMethodTrailer empty
-]

--- a/src/UnifiedFFI-Tests/FFIMockCalloutMethodBuilder.class.st
+++ b/src/UnifiedFFI-Tests/FFIMockCalloutMethodBuilder.class.st
@@ -52,9 +52,3 @@ FFIMockCalloutMethodBuilder >> methodProperties [
 	"To mock the creation of the IR..."
 	^ nil
 ]
-
-{ #category : #compatibility }
-FFIMockCalloutMethodBuilder >> methodTrailer [
-
-	^ CompiledMethodTrailer empty
-]

--- a/src/UnifiedFFI/FFICalloutMethodBuilder.class.st
+++ b/src/UnifiedFFI/FFICalloutMethodBuilder.class.st
@@ -126,7 +126,7 @@ FFICalloutMethodBuilder >> generateFFICallout: builder spec: functionSpec ffiLib
 
 { #category : #private }
 FFICalloutMethodBuilder >> generateMethodFromSpec: functionSpec [
-	| ir ffiLibrary properties |
+	| ir ffiLibrary properties method |
 	functionSpec resolveUsing: self requestor.
 
 	ffiLibrary := self extractLibrary.
@@ -147,7 +147,9 @@ FFICalloutMethodBuilder >> generateMethodFromSpec: functionSpec [
 		r := self generateFFICallout: builder spec: functionSpec ffiLibrary: ffiLibrary.
 		ffiLibrary postMethodBuildContext: sender builder: builder spec: functionSpec.
 		r].
-	^ ir generate: self methodTrailer
+	method := ir generate.
+	self method isCompiledMethod ifTrue: [method setSourcePointer: self method sourcePointer  ].
+	^method
 ]
 
 { #category : #initialization }
@@ -187,12 +189,6 @@ FFICalloutMethodBuilder >> libraryName [
 { #category : #accessing }
 FFICalloutMethodBuilder >> method [
 	^ self sender homeMethod
-]
-
-{ #category : #compatibility }
-FFICalloutMethodBuilder >> methodTrailer [
-
- 	^ self method trailer
 ]
 
 { #category : #private }


### PR DESCRIPTION
- fix the last clients that hand the trailer to the compiler
- Change  IRBytecodeGenerator to not delegate to the trailer
- cleanup CompiledMethod instance creation methods a bit