### PR TITLE
AST: add a scanner state

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -182,8 +182,8 @@ RBCodeSnippet class >> badComments [
 			         value: 1).
 		        (self new
 			         source: '"a" #( "b" 1 "c" two "d" ( "e" 3 "f" ) "g" ) "h"';
-			         nodeAt: 'CCC 000DDD080EEE099900000AAAAAABAAAAAA0HHH00 III';
-			         styled: '""" 00 """ n """ ###     1 """ n """ 1 """ 0 """';
+			         nodeAt: 'DDD 000EEE090FFF0AAA0GGG0BBBBBBCBBBBBB0JJJ00 KKK';
+			         styled: '""" 00 """ n """ ### """ 1 """ n """ 1 """ 0 """';
 			         formattedCode: '#( 1 two #( 3 ) )';
 			         value: #( 1 #two #( 3 ) )).
 		        (self new
@@ -306,6 +306,7 @@ RBCodeSnippet class >> badExpressions [
 			         source: '#( 1 + 2';
 			         nodeAt: '00010203';
 			         styled: 'XX n # n';
+			         formattedCode: '#( 1 #+ 2';
 			         notices: #( #( 1 8 9 ''')'' expected' ) )).
 		        (self new
 			         source: '[ 1 + 2';
@@ -1458,15 +1459,15 @@ RBCodeSnippet class >> badScanner [
 			         nodeAt: '00111111112222222223334455506770';
 			         styled: '00######################### ###0';
 			         formattedCode:
-				         '#( aa:bb:cc #''aa:bb:cc'' #cc == #''=='' = #= )';
-			         value: #( #aa:bb:cc #'aa:bb:cc' #cc #'==' #'==' #= #= )). "Identifiers, keywords and binary operators are implicitely transformed into symbols. Note that formatting is inconsistent."
+				         '#( aa:bb:cc #''aa:bb:cc'' #cc #''=='' #''=='' #= #= )';
+			         value: #( #'aa:bb:cc' #'aa:bb:cc' #cc #'==' #'==' #= #= )). "Identifiers, keywords and binary operators are implicitely transformed into symbols. Note that formatting is inconsistent."
 		        (self new
 			         source: '#(aa:bb:"A"cc"B"#aa:bb:cc"C"#cc"D"++"E"#++"F")';
-			         nodeAt: '0044444400055000666666666AAA777BBB88000999CCC0';
-			         styled: '00######   ##   #########"""###"""##   ###"""0';
+			         nodeAt: '00777777DDD88EEE999999999FFFAAAGGGBBHHHCCCIII0';
+			         styled: '00######"""##"""#########"""###"""##"""###"""0';
 			         formattedCode:
-				         '#( aa:bb: cc #''aa:bb:cc'' #cc ++ #''++'' )';
-			         value: #( #aa:bb: cc #'aa:bb:cc' #cc #'++' #'++' )). "Check if comments are lost"
+				         '#( aa:bb: cc #''aa:bb:cc'' #cc #''++'' #''++'' )';
+			         value: #( #aa:bb: #cc #'aa:bb:cc' #cc #'++' #'++' )). "Check if comments are lost"
 		        (self new
 			         source: '#(().:;[]{}^#a)';
 			         nodeAt: '001123456789AA0';
@@ -1504,19 +1505,19 @@ RBCodeSnippet class >> badScanner [
 				            #( 7 8 9 'Literal expected' ) )). "Check if comments are lost"
 		        (self new
 			         source: '#(:=aa:=:==bb:==#cc:==)';
-			         nodeAt: '001033345078889ABBBBCC0';
+			         nodeAt: '00102223405666778888990';
 			         styled: '00# ##### ############0';
 			         formattedCode:
-				         '#( #'':'' #= #aa: #= #'':'' #= = #bb: #= = #cc: == )';
+				         '#( #'':='' aa: #= #'':='' #= bb: #''=='' #cc: #''=='' )';
 			         value:
-				         #( #':' #= #aa: #= #':' #= #= #bb: #= #= #cc: #'==' )). "Assigments are split, creating symbols"
+				         #( #':=' #aa: #= #':=' #= #bb: #'==' #cc: #'==' )). "Assigments are split, creating symbols"
 		        (self new
 			         source: '#(:="A"aa:="B":=="C"cc:=="D")';
-			         nodeAt: '001000033340005070008889A0000';
-			         styled: '00#    ####   # #   #####   0';
+			         nodeAt: '00400005556BBB708CCC999AADDD0';
+			         styled: '00#    ####"""# #"""#####"""0';
 			         formattedCode:
-				         '#( #'':'' #= #aa: #= #'':'' #= = #cc: #= = )';
-			         value: #( #':' #= #aa: #= #':' #= #= #cc: #= #= )) "Check if comments are lost" }.
+				         '#( #'':='' aa: #= #'':='' #= cc: #''=='' )';
+			         value: #( #':=' #aa: #= #':=' #= #cc: #'==' )) "Check if comments are lost" }.
 	"Setup default values"
 	self new
 		group: #badScanner;

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -441,7 +441,9 @@ RBCodeSnippet class >> badExpressions [
 			         styled: '00n#n#n0';
 			         formattedCode: '#( 1 #'']'' 2 #''}'' 3 )';
 			         isFaulty: false;
-			         value: #( 1 #']' 2 #'}' 3 )). "`#(` can eat almost anything"
+			         value: #( 1 #']' 2 #'}' 3 );
+			         notices: #( #( 4 4 4 'Use a proper symbol literal' )
+				            #( 6 6 6 'Use a proper symbol literal' ) )). "`#(` can eat almost anything"
 		        (self new
 			         source: '#( 0 1r2 4 )';
 			         nodeAt: '000102330400';
@@ -507,12 +509,14 @@ RBCodeSnippet class >> badExpressions [
 			         notices: #( #( 1 13 14 ''')'' expected' ) )).
 		        (self new
 			         source: '[(#("a"("b"###("c"###["d"]#["e"]["f"]))))]';
-			         nodeAt: '0222EEE88889999999AAAAAAAABBBBBBC999D98220';
-			         styled: '0011"""2"""3333"""1111"""111"""1#   #32100';
+			         nodeAt: '0222FFF9999AAAAAAABBBBBBBBCCCCCCDAAAEA9220';
+			         styled: '0011"""2"""3333"""1111"""111"""1#"""#32100';
 			         formattedCode:
-				         '[ #( #( #( #[ ] #[ ] #''['' #'']'' ) ) ) "a" "b" "c" "d" "e" ]';
+				         '[ #( #( #( #[ ] #[ ] #''['' #'']'' ) ) ) "a" "b" "c" "d" "e" "f" ]';
 			         isFaulty: false;
-			         value: #( #( #( #[  ] #[  ] #'[' #']' ) ) )). "dry [ and ] in lit array are symbols"
+			         value: #( #( #( #[  ] #[  ] #'[' #']' ) ) );
+			         notices: #( #( 33 33 33 'Use a proper symbol literal' )
+				            #( 37 37 37 'Use a proper symbol literal' ) )). "dry [ and ] in lit array are symbols"
 		        (self new
 			         source: '#[ 1 ) 2 ]';
 			         nodeAt: '0001020300';
@@ -1475,14 +1479,30 @@ RBCodeSnippet class >> badScanner [
 			         formattedCode:
 				         '#( #( ) #''.'' #'':'' #'';'' #''['' #'']'' #''{'' #''}'' #''^'' #a )';
 			         value:
-				         #( #(  ) #'.' #':' #';' #'[' #']' #'{' #'}' #'^' #a )). "Most special characters are transformed into single character symbols, including brackets!"
+				         #( #(  ) #'.' #':' #';' #'[' #']' #'{' #'}' #'^' #a );
+			         notices: #( #( 5 5 5 'Use a proper symbol literal' )
+				            #( 6 6 6 'Use a proper symbol literal' )
+				            #( 7 7 7 'Use a proper symbol literal' )
+				            #( 8 8 8 'Use a proper symbol literal' )
+				            #( 9 9 9 'Use a proper symbol literal' )
+				            #( 10 10 10 'Use a proper symbol literal' )
+				            #( 11 11 11 'Use a proper symbol literal' )
+				            #( 12 12 12 'Use a proper symbol literal' ) )). "Most special characters are transformed into single character symbols, including brackets!"
 		        (self new
 			         source: '#(("A")"B"."C":"D";"E"["F"]"G"{"H"}"I"^"J")';
-			         nodeAt: '0033333DDD400050006000700080009000A000B0000';
-			         styled: '001"""1"""#   #   #   #   #   #   #   #   0';
+			         nodeAt: '00BBBBBLLLCMMMDNNNEOOOFPPPGQQQHRRRISSSJTTT0';
+			         styled: '001"""1"""#"""#"""#"""#"""#"""#"""#"""#"""0';
 			         formattedCode:
 				         '#( #( ) #''.'' #'':'' #'';'' #''['' #'']'' #''{'' #''}'' #''^'' )';
-			         value: #( #(  ) #'.' #':' #';' #'[' #']' #'{' #'}' #'^' )). "Check if comments are lost"
+			         value: #( #(  ) #'.' #':' #';' #'[' #']' #'{' #'}' #'^' );
+			         notices: #( #( 11 11 11 'Use a proper symbol literal' )
+				            #( 15 15 15 'Use a proper symbol literal' )
+				            #( 19 19 19 'Use a proper symbol literal' )
+				            #( 23 23 23 'Use a proper symbol literal' )
+				            #( 27 27 27 'Use a proper symbol literal' )
+				            #( 31 31 31 'Use a proper symbol literal' )
+				            #( 35 35 35 'Use a proper symbol literal' )
+				            #( 39 39 39 'Use a proper symbol literal' ) )). "Check if comments are lost"
 		        (self new
 			         source: '#(# ## #ab #10 #. 10)';
 			         nodeAt: '001022033304550670880';
@@ -1493,7 +1513,8 @@ RBCodeSnippet class >> badScanner [
 				         #( #( 3 3 4 'Literal expected' )
 				            #( 5 6 7 'Literal expected' )
 				            #( 12 12 13 'Literal expected' )
-				            #( 16 16 17 'Literal expected' ) )). "Lonely # are errors"
+				            #( 16 16 17 'Literal expected' )
+				            #( 17 17 17 'Use a proper symbol literal' ) )). "Lonely # are errors"
 		        (self new
 			         source: '#(#"A"##"B")';
 			         nodeAt: '003555446660';
@@ -1505,19 +1526,22 @@ RBCodeSnippet class >> badScanner [
 				            #( 7 8 9 'Literal expected' ) )). "Check if comments are lost"
 		        (self new
 			         source: '#(:=aa:=:==bb:==#cc:==)';
-			         nodeAt: '00102223405666778888990';
-			         styled: '00# ##### ############0';
+			         nodeAt: '00112223445666778888990';
+			         styled: '00####################0';
 			         formattedCode:
 				         '#( #'':='' aa: #= #'':='' #= bb: #''=='' #cc: #''=='' )';
-			         value:
-				         #( #':=' #aa: #= #':=' #= #bb: #'==' #cc: #'==' )). "Assigments are split, creating symbols"
+			         value: #( #':=' #aa: #= #':=' #= #bb: #'==' #cc: #'==' );
+			         notices: #( #( 3 4 3 'Use a proper symbol literal' )
+				            #( 9 10 9 'Use a proper symbol literal' ) )). "Assigments are split, creating symbols"
 		        (self new
 			         source: '#(:="A"aa:="B":=="C"cc:=="D")';
-			         nodeAt: '00400005556BBB708CCC999AADDD0';
-			         styled: '00#    ####"""# #"""#####"""0';
+			         nodeAt: '0055CCC6667DDD889EEEAAABBFFF0';
+			         styled: '00##"""####"""###"""#####"""0';
 			         formattedCode:
 				         '#( #'':='' aa: #= #'':='' #= cc: #''=='' )';
-			         value: #( #':=' #aa: #= #':=' #= #cc: #'==' )) "Check if comments are lost" }.
+			         value: #( #':=' #aa: #= #':=' #= #cc: #'==' );
+			         notices: #( #( 3 4 3 'Use a proper symbol literal' )
+				            #( 15 16 15 'Use a proper symbol literal' ) )) "Check if comments are lost" }.
 	"Setup default values"
 	self new
 		group: #badScanner;
@@ -2158,7 +2182,8 @@ RBCodeSnippet class >> badSimpleExpressions [
 			         styled: '00#n0';
 			         formattedCode: '#( #''^'' 1 )';
 			         isFaulty: false;
-			         value: #( #'^' 1 )). "Obviously..."
+			         value: #( #'^' 1 );
+			         notices: #( #( 3 3 3 'Use a proper symbol literal' ) )). "Obviously..."
 		        (self new
 			         source: '#[ ^ 1 ]';
 			         nodeAt: '00010200';

--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -1296,6 +1296,44 @@ RBParserTest >> testParseGivesMethod [
 	self assert: tree isMethod
 ]
 
+{ #category : #tests }
+RBParserTest >> testParseLiterals [
+
+	self assert: (RBParser parseLiterals: '') equals: #(  ).
+	self
+		assert: (RBParser parseLiterals: '10 1.1 true nil false')
+		equals: #( 10 1.1 true nil false ).
+	self
+		assert: (RBParser parseLiterals: '#foo #foo: #foo:bar:baz')
+		equals: #( #foo #foo: #'foo:bar:baz' ).
+	self
+		assert: (RBParser parseLiterals: 'foo foo: foo:bar:baz')
+		equals: #( #foo #foo: #'foo:bar:baz' ).
+	self
+		assert: (RBParser parseLiterals:
+				 '''foo'' ''foo:'' ''foo:bar:baz'' ''1'' ''true''')
+		equals: #( 'foo' 'foo:' 'foo:bar:baz' '1' 'true' ).
+	self
+		assert: (RBParser parseLiterals: '(1 2) #(1 2) #[1 2]')
+		equals: #( #( 1 2 ) #( 1 2 ) #[ 1 2 ] ).
+	self
+		assert: (RBParser parseLiterals: '.[];::=^')
+		equals: #( #'.' #'[' #']' #';' #':' #':=' #'^' ).
+
+	self
+		should: [ RBParser parseLiterals: '#( unclosed' ]
+		raise: CodeError.
+	self
+		should: [ RBParser parseLiterals: ') unopened' ]
+		raise: CodeError.
+	self
+		should: [ RBParser parseLiterals: '#[ 1 1000 2 ] bad subliteral' ]
+		raise: CodeError.
+	self
+		should: [ RBParser parseLiterals: 'syntax¿error' ]
+		raise: CodeError
+]
+
 { #category : #'tests - Pattern' }
 RBParserTest >> testParseMethodPatternGivesSelector [
 	#(#('+ a ^self + a' 				#+)

--- a/src/AST-Core/RBNotice.class.st
+++ b/src/AST-Core/RBNotice.class.st
@@ -25,18 +25,27 @@ RBNotice >> description [
 	^ String streamContents: [ :stream |
 		  stream
 			  nextPutAll: self class name;
-			  nextPutAll: ' ';
-			  nextPutAll: (node methodNode methodClass
-					   ifNotNil: [ :class | class name ]
-					   ifNil: [ '???' ]);
-			  nextPutAll: '>>#';
-			  nextPutAll: node methodNode selector;
+			  nextPutAll: ' '.
+		  node methodNode
+			  ifNotNil: [ :methodNode |
+				  stream
+					  nextPutAll: (methodNode methodClass
+							   ifNotNil: [ :class | class name ]
+							   ifNil: [ '???' ]);
+					  nextPutAll: '>>#';
+					  nextPutAll: node methodNode selector ]
+			  ifNil: [ '???>>#???' ].
+		  stream
 			  nextPutAll: ' ';
 			  print: self position;
 			  nextPutAll: ':';
-			  nextPutAll: self messageText;
-			  nextPutAll: '->';
-			  nextPutAll: (node sourceCode asString withBlanksCondensed truncateWithElipsisTo: 60) ]
+			  nextPutAll: self messageText.
+		  node methodNode ifNotNil: [
+			  stream
+				  nextPutAll: '->';
+				  nextPutAll:
+					  (node sourceCode asString withBlanksCondensed
+						   truncateWithElipsisTo: 60) ] ]
 ]
 
 { #category : #'error handling' }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -633,7 +633,9 @@ RBParser >> parseKeywordPragma [
 
 { #category : #'private - parsing' }
 RBParser >> parseLiteralArray [
-	| literals startToken stop faulty value |
+	| literals startToken stop faulty value prevState |
+	prevState := scanner state.
+	scanner state: #literalArray.
 	startToken := currentToken.
 	literals := (OrderedCollection new: 5).
 	faulty := false.
@@ -645,6 +647,7 @@ RBParser >> parseLiteralArray [
 	stop := currentToken stop.
 	(currentToken isSpecial: $))
 		ifFalse: [ ^ self parseEnglobingError: literals with: startToken errorMessage: ''')'' expected'].
+	scanner state: prevState.
 	self step.
 	faulty ifTrue: [
 		^ RBLiteralArrayErrorNode new

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -685,7 +685,6 @@ RBParser >> parseLiteralArrayObject [
 
 	currentToken isError ifTrue:[ |errorNode| errorNode :=  self parseErrorNode: currentToken cause.
 		 ^ errorNode].
-	currentToken isLiteralToken ifFalse: [self patchLiteralArrayToken].
 
 	"For the moment, special tokens are transformed into symbol."
 	(currentToken isAssignment or: [ currentToken isSpecial ])
@@ -1195,73 +1194,6 @@ RBParser >> parseVariableNode [
 			self step ] ].
 
 	^ errorNode
-]
-
-{ #category : #private }
-RBParser >> patchLiteralArrayToken [
-	(currentToken isIdentifier and:
-			[self nextToken isAssignment
-				and: [currentToken isTouching: self nextToken]])
-		ifTrue:
-			[currentToken := RBLiteralToken
-						value: (currentToken value , ':') asSymbol
-						start: currentToken start
-						stop: self nextToken start.
-			nextToken := RBLiteralToken
-						value: #=
-						start: nextToken stop
-						stop: nextToken stop.
-			^self].
-	currentToken isAssignment
-		ifTrue:
-			[currentToken := RBLiteralToken
-						value: #':'
-						start: currentToken start
-						stop: currentToken start.
-			nextToken := RBLiteralToken
-						value: #=
-						start: currentToken stop
-						stop: currentToken stop.
-			^self].
-	currentToken isSpecial
-		ifTrue:
-			[currentToken := RBLiteralToken
-						value: (String with: currentToken value) asSymbol
-						start: currentToken start
-						stop: currentToken stop.
-			^self].
-
-	"Build super symbol (selector) by combining keywords and identifiers.
-	So that `#(foo:bar)` is the same as `#(#foo:bar)`"
-	(currentToken isIdentifier or: [currentToken isKeyword]) ifTrue: [
-		| value start |
-		start := currentToken start.
-		value := nil.
-		[ (currentToken isTouching: self nextToken)
-			and: [self nextToken isIdentifier
-				or: [self nextToken isKeyword
-					or: [self nextToken isSpecial: $:]]] ] whileTrue: [
-			value ifNil: [
-				value := currentToken value asString. "Start accumulating"
-			].
-			self step. "Consume current token"
-			value := value , currentToken value asString "Extends" ].
-		value ifNotNil: [
-			currentToken := RBLiteralToken
-				value: value asSymbol
-				start: start
-				stop: currentToken stop
-				source: value asString.
-			^ self ] ].
-
-	(currentToken isIdentifier
-		or: [currentToken isBinary or: [currentToken isKeyword]])
-			ifFalse: [^self parseErrorNode: 'Invalid token'].
-	currentToken := RBLiteralToken
-				value: currentToken value asSymbol
-				start: currentToken start
-				stop: currentToken stop
-				source: currentToken value asString
 ]
 
 { #category : #private }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -679,6 +679,7 @@ RBParser >> parseLiteralArrayObject [
 
 	currentToken isError ifTrue:[ |errorNode| errorNode :=  self parseErrorNode: currentToken cause.
 		 ^ errorNode].
+	currentToken isLiteralToken ifFalse: [self patchLiteralArrayToken].
 
 	"For the moment, special tokens are transformed into symbol."
 	(currentToken isAssignment or: [ currentToken isSpecial ])

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -55,9 +55,15 @@ RBParser class >> parseFaultyMethod: aString [
 
 { #category : #parsing }
 RBParser class >> parseLiterals: aString [
-	^ self new
-		  initializeParserWith: aString;
-		  parseLiterals: aString
+
+	| scanner parser |
+	parser := self new.
+	scanner := parser scannerClass on: (ReadStream on: aString).
+	scanner state: #literalArray.
+	^ parser
+		  source: aString;
+		  scanner: scanner;
+		  parseLiterals
 ]
 
 { #category : #parsing }
@@ -749,13 +755,22 @@ RBParser >> parseLiteralByteArrayObject [
 ]
 
 { #category : #'private - parsing' }
-RBParser >> parseLiterals: aString [
+RBParser >> parseLiterals [
+
 	| stream |
 	stream := (Array new: 5) writeStream.
-	[self atEnd or: [currentToken isSpecial: $)]]
-		whileFalse: [stream nextPut: self parseLiteralArrayObject].
-	self atEnd ifFalse: [ ^ self parseErrorNode: 'Unknown input at end'].
-	^stream contents collect: [ :each | each value ]
+	[ self atEnd ] whileFalse: [
+		| node |
+		node := (currentToken isSpecial: $))
+			        ifTrue: [
+			        self parseErrorNode: 'Unexpected closing parenthesis' ]
+			        ifFalse: [ self parseLiteralArrayObject ].
+		node isError ifTrue: [ node checkFaulty: nil ].
+		"parseLiterals always success, and in case of syntax error just returns the problematic token as a symbol"
+		stream nextPut: (node isError
+				 ifTrue: [ node value asSymbol ]
+				 ifFalse: [ node value ]) ].
+	^ stream contents
 ]
 
 { #category : #'private - parsing' }

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -765,10 +765,7 @@ RBParser >> parseLiterals [
 			        self parseErrorNode: 'Unexpected closing parenthesis' ]
 			        ifFalse: [ self parseLiteralArrayObject ].
 		node isError ifTrue: [ node checkFaulty: nil ].
-		"parseLiterals always success, and in case of syntax error just returns the problematic token as a symbol"
-		stream nextPut: (node isError
-				 ifTrue: [ node value asSymbol ]
-				 ifFalse: [ node value ]) ].
+		stream nextPut: node value ].
 	^ stream contents
 ]
 

--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -676,9 +676,22 @@ RBParser >> parseLiteralArrayObject [
 			[^currentToken isForByteArray
 				ifTrue: [self parseLiteralByteArray]
 				ifFalse: [self parseLiteralArray]].
+
 	currentToken isError ifTrue:[ |errorNode| errorNode :=  self parseErrorNode: currentToken cause.
 		 ^ errorNode].
-	currentToken isLiteralToken ifFalse: [self patchLiteralArrayToken].
+
+	"For the moment, special tokens are transformed into symbol."
+	(currentToken isAssignment or: [ currentToken isSpecial ])
+		ifTrue: [
+			|node|
+			node := self literalValueNodeClass
+				value: currentToken value asSymbol
+				start: currentToken start
+				stop: currentToken stop.
+			node addWarning: 'Use a proper symbol literal'.
+			self step. "special"
+			^node ].
+
 	^self parsePrimitiveLiteral
 ]
 

--- a/src/AST-Core/RBPatternParser.class.st
+++ b/src/AST-Core/RBPatternParser.class.st
@@ -133,13 +133,6 @@ RBPatternParser >> parseWrapperPatternBlockWith: wrappedNode [
 	^ node
 ]
 
-{ #category : #private }
-RBPatternParser >> patchLiteralArrayToken [
-	(currentToken isIdentifier and: [currentToken isPatternVariable])
-		ifTrue: [^self].
-	super patchLiteralArrayToken
-]
-
 { #category : #'private - classes' }
 RBPatternParser >> pragmaNodeClass [
 	^RBPatternPragmaNode

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -32,7 +32,8 @@ Class {
 		'characterType',
 		'classificationTable',
 		'comments',
-		'nextToken'
+		'nextToken',
+		'state'
 	],
 	#classVars : [
 		'CascadePatternCharacter',
@@ -619,6 +620,18 @@ RBScanner >> scanUnknownCharacter [
 	errorToken := self scanError: 'Unknown character'.
 	errorToken location: tokenStart. "Unlike other scanner errors, error location is here before the bad token"
 	^ errorToken
+]
+
+{ #category : #accessing }
+RBScanner >> state [
+
+	^ state
+]
+
+{ #category : #accessing }
+RBScanner >> state: anObject [
+
+	state := anObject
 ]
 
 { #category : #private }

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -599,11 +599,17 @@ RBScanner >> scanToken [
 	case statement. Didn't use Dictionary because lookup is pretty slow."
 
 	characterType = #eof ifTrue: [ ^ RBEOFToken start: tokenStart + 1 ]. "The EOF token should occur after the end of input"
-	characterType = #alphabetic ifTrue: [^self scanIdentifierOrKeyword].
+	characterType = #alphabetic ifTrue: [
+		^ state = #literalArray
+			ifTrue: [self scanSymbolOrNamedLiteral]
+			ifFalse: [self scanIdentifierOrKeyword]].
 	(characterType = #digit
 		or: [currentCharacter = $- and: [(self classify: stream peek) = #digit]])
 			ifTrue: [^self scanNumber].
-	characterType = #binary ifTrue: [^self scanBinarySelector].
+	characterType = #binary ifTrue: [
+		^ state = #literalArray
+			ifTrue: [ self scanLiteralBinary]
+			ifFalse: [ self scanBinarySelector]].
 	characterType = #special ifTrue: [^self scanSpecialCharacter].
 	currentCharacter = $' ifTrue: [^self scanLiteralString].
 	currentCharacter = $# ifTrue: [^self scanLiteral].

--- a/src/AST-Core/RBScanner.class.st
+++ b/src/AST-Core/RBScanner.class.st
@@ -222,19 +222,19 @@ RBScanner >> isSelector [
 RBScanner >> isSelectorNonBinary [
 	<script: '(ZnEasy getPng: ''http://www.plantuml.com/plantuml/png/RO-n2i8m48RtUugRXRn0XzBg98wEuX2R4mlNHE8LwTkRL4Xxa2cNx_z2_ki-OgFC4mF8A4nu9QP1GeJRuOx6j7WSlOqBDlXOXy9xVhzipy5Joco-m0vfeoQuP9n2cjFp8PygRJ7_qo259m2ide8REliBBTyGNQa16p9LGUUw1C1_uThk9TBrEl9kdlW7'') inspect'>
 
-	| state |
-	state := #alphaAlone.
+	| aState |
+	aState := #alphaAlone.
 	[ characterType = #alphabetic ]
-		whileTrue: [ state = #colon
-				ifTrue: [ state := #inKeyword ].
+		whileTrue: [ aState = #colon
+				ifTrue: [ aState := #inKeyword ].
 			self scanName.
 			characterType = #eof
-				ifTrue: [ ^ state = #alphaAlone ].
+				ifTrue: [ ^ aState = #alphaAlone ].
 			currentCharacter = $:
-				ifTrue: [ state := #colon.
+				ifTrue: [ aState := #colon.
 					self step ] ].
 	characterType = #eof
-		ifTrue: [ ^ state = #colon ].
+		ifTrue: [ ^ aState = #colon ].
 	^ false
 
 	"Diagram by:


### PR DESCRIPTION
#13553 identified issues on the parsing of array literals.
#13554 tried to improve the situation with combined keyword and identifiers in literal arrays, but inconsistencies remains.

The main issue is the presence of `RBParser>>#patchLiteralArrayToken` that takes tokens returned by the scanner and tries to recombine them, but does a bad job because it's very complex to do correctly, especially if you don't want to lose information.

The solution proposed by this PR is to solve the problem at the origin: in the scanner, freeing the parser of retrofitting some lexer job.
The classical approach to solve this problem is to use *lexer states* (not to be confused with automaton states) that correspond to scanning policy. Basically, the state controls what the next token is.
I added a `state` ivar to the scanner and use it to have alternative paths in `scanToken`. This way identifiers and binops are treated as identifiers and binops in the default state but are treated as symbols in the *literalArray* state.
The state is currently controlled by the parser in `RBParser>>#parseLiteralArray`.
Lexer states are notorious tricky (because you have to think about lookaheads), but they do the job when used correctly, and they simplify the code a lot.

I also needed to do some factorization in the scanner to prevent code duplication. Especially because true, false and nil are named literal values that need special care.

So, what are the free benefits? i.e. things that now fixed out of the box

* Retrieve some lost comments
* Fix some highlighting issue
* Fix some formatting issue
* Correctly parse `#(foo:==)` as `#(#foo: #==)` whereas the bad `patchLiteralArrayToken` produced `#(#foo: #= #=)`

What remains to do?

Special characters in literal arrays are still parsed as symbols. As a remainder, they are `^[]{}:;.` (note `()#` are also special but are meaningful in arrays)
I'm not sure if this is a good idea, so I let them the current `patchLiteralArrayToken` (it is basically only what remain here) and I did not push up that to the scanner state. In a future PR I will finish the job (kill or move).
So what do you prefer for `#(a . b c`... ?

* `#(#a #'.' #b #c`... current behavior. Accept most garbage and try to make them symbols.
  Note: I don't like this one for a lot of reasons. It also confuses newbies `{1. 2}` (ok)  vs. `{1 2}` (an error) vs. `#(1 2)` (ok) vs. `#(1. 2)` (ok but not what you might expect)
* `#(#a <syntax error unexpected '.' literal wanted> #b #c`... first alternative. Report an error and continue the parsing of array elements
* `#(#a <missing closing parenthesis>. b c`... second alternative. Report an error and assume the array is now finished. This one make sense when programming, as an unclosed literal arrays will be detected earlier and not consume the rest of the source code