### PR TITLE
Cleanup-instanceCreationCompiledMethod

### DIFF
--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -167,51 +167,6 @@ CompiledMethod class >> new [
 ]
 
 { #category : #'instance creation' }
-CompiledMethod class >> newBytes: numberOfBytes trailerBytes: trailer nArgs: nArgs nTemps: nTemps nStack: stackSize nLits: nLits primitive: primitiveIndex [
-	"Answer an instance of me. The header is specified by the message
-	 arguments. The remaining parts are not as yet determined."
-
-	^ self
-		  newBytes: numberOfBytes
-		  trailerBytes: trailer
-		  nArgs: nArgs
-		  nTemps: nTemps
-		  nStack: stackSize
-		  nLits: nLits
-		  primitive: primitiveIndex
-		  flag: false
-]
-
-{ #category : #'instance creation' }
-CompiledMethod class >> newBytes: numberOfBytes trailerBytes: trailer nArgs: nArgs nTemps: nTemps nStack: stackSize nLits: nLits primitive: primitiveIndex flag: flag [
-	"Answer an instance of me. The header is specified by the message
-	 arguments. The remaining parts are not as yet determined."
-	| method pc |
-	nArgs > 15 ifTrue:
-		[^self error: 'Cannot compile -- too many arguments'].
-	nTemps > 63 ifTrue:
-		[^self error: 'Cannot compile -- too many temporary variables'].
-	nLits > 65535 ifTrue:
-		[^self error: 'Cannot compile -- too many literals'].
-
-	method := self
-				newMethod: numberOfBytes
-				header:    (nArgs bitShift: 24)
-						+ (nTemps bitShift: 18)
-						+ ((nTemps + stackSize) > SmallFrame ifTrue: [1 bitShift: 17] ifFalse: [0])
-						+ nLits
-						+ (primitiveIndex > 0 ifTrue: [1 bitShift: 16] ifFalse: [0])
-						+ (flag ifTrue: [1 bitShift: 29] ifFalse: [0]).
-	primitiveIndex > 0 ifTrue:
-		[pc := method initialPC.
-		 method
-			at: pc + 0 put: method encoderClass callPrimitiveCode;
-			at: pc + 1 put: (primitiveIndex bitAnd: 16rFF);
-			at: pc + 2 put: (primitiveIndex bitShift: -8)].
-	^method
-]
-
-{ #category : #'instance creation' }
 CompiledMethod class >> newFrom: aCompiledMethod [
 	| inst |
 	inst := super basicNew: aCompiledMethod size.
@@ -232,27 +187,6 @@ CompiledMethod class >> newInstanceFrom: oldInstance variable: variable size: in
 			[new instVarAt: offset
 					put: (oldInstance instVarAt: (map at: offset))]].
 	^new
-]
-
-{ #category : #'instance creation' }
-CompiledMethod class >> primitive: primNum numArgs: numArgs numTemps: numTemps stackSize: stackSize literals: literals bytecodes: bytecodes trailer: trailerBytes [
-	"Create method with given attributes.  numTemps includes numArgs.  stackSize does not include numTemps."
-
-	| compiledMethod |
-	compiledMethod := self
-		newBytes: bytecodes size
-		trailerBytes: trailerBytes
-		nArgs: numArgs
-		nTemps: numTemps
-		nStack: 0
-		nLits: literals size
-		primitive: primNum.
-	(WriteStream with: compiledMethod)
-		position: compiledMethod initialPC - 1;
-		nextPutAll: bytecodes.
-	literals withIndexDo: [:obj :i | compiledMethod literalAt: i put: obj].
-	compiledMethod needsFrameSize: stackSize.
-	^ compiledMethod
 ]
 
 { #category : #'class initialization' }


### PR DESCRIPTION
CompiledMethod has some low-level instance creation methods that are not used

I propose to delete them. If you want to create a method, just use IRBuilder