### PR TITLE
Cleanup: Fuel does not need to use #copyWithTrailerBytes:

### DIFF
--- a/src/Fuel-Core/FLCompiledMethodCluster.class.st
+++ b/src/Fuel-Core/FLCompiledMethodCluster.class.st
@@ -36,7 +36,8 @@ FLCompiledMethodCluster class >> setTrailerWithSourceCode [
 	^ self transformationForSerializing: [:aCompiledMethod |
 		"we set the source as a property, not yet installed methods already have
 		it, but for installed methods we put it back "
-		(aCompiledMethod copyWithTrailerBytes: CompiledMethodTrailer empty)
+		aCompiledMethod copy
+			setSourcePointer: 0;
 			propertyAt: #source put: aCompiledMethod sourceCode;
 			yourself
 		]

--- a/src/Fuel-Tests-Core/CompiledMethod.extension.st
+++ b/src/Fuel-Tests-Core/CompiledMethod.extension.st
@@ -2,5 +2,5 @@ Extension { #name : #CompiledMethod }
 
 { #category : #'*Fuel-Tests-Core' }
 CompiledMethod >> isEqualRegardlessTrailerTo: aCompiledMethod [
-	^ (self copyWithTrailerBytes: CompiledMethodTrailer empty) = (aCompiledMethod copyWithTrailerBytes: CompiledMethodTrailer empty)
+	^ (self copy setSourcePointer: 0) = (aCompiledMethod copy setSourcePointer: 0)
 ]

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -325,22 +325,6 @@ CompiledMethod >> containsHalt [
 	^ self hasProperty: #containsHalt
 ]
 
-{ #category : #initialization }
-CompiledMethod >> copyWithTrailerBytes: trailer [
-
-	| copy end start penultimateLiteral |
-	start := self initialPC.
-	end := self endPC.
-	copy := self class newMethod: end - start + 1 + self class trailerSize header: self header.
-	1 to: self numLiterals do: [:i | copy literalAt: i put: (self literalAt: i)].
-	(penultimateLiteral := self penultimateLiteral) isMethodProperties ifTrue:
-		[copy penultimateLiteral: (penultimateLiteral copy
-									setMethod: copy;
-									yourself)].
-	start to: end do: [:i | copy at: i put: (self at: i)].
-	^copy
-]
-
 { #category : #accessing }
 CompiledMethod >> defaultSelector [
 	"Invent and answer an appropriate message selector (a Symbol) for me,


### PR DESCRIPTION
fix the last two users of copyWithTrailerBytes: to instead just copy and set the sourcePointer to 0