### PR TITLE
Cleanup: do not reference CompiledMethodTrailer in ReflectiveMethod

### DIFF
--- a/src/Kernel/CompiledBlock.class.st
+++ b/src/Kernel/CompiledBlock.class.st
@@ -22,7 +22,7 @@ CompiledBlock >> displayStringOn: stream [
 
 { #category : #accessing }
 CompiledBlock >> endPC [
-	"Answer the index of the last bytecode."
+	"Answer the index of the last bytecode"
 	^ self size
 ]
 

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -274,7 +274,7 @@ CompiledMethod >> displayStringOn: aStream [
 
 { #category : #accessing }
 CompiledMethod >> endPC [
-	"Answer the index of the last bytecode, as the trailer size varies we have to delegate"
+	"Answer the index of the last bytecode"
 	^ self size - self class trailerSize
 ]
 
@@ -998,8 +998,7 @@ CompiledMethod >> tempNames [
 
 { #category : #accessing }
 CompiledMethod >> trailer [
-	"Answer the receiver's trailer"
-	^ CompiledMethodTrailer new method: self
+	^self deprecated: 'CompiledMethodTrailer has been removed in Pharo12. Just use setSourcePointer: / sourcePointer to read and set. See class comment of CompiledMethodTrailer for more information'
 ]
 
 { #category : #'accessing - tags' }

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -38,7 +38,9 @@ ReflectiveMethod >> compileAST [
 		semanticAnalyzerClass: RFSemanticAnalyzer;
 		astTranslatorClass: RFASTTranslator.
 	ast doSemanticAnalysis. "force semantic analysis"
-	method := ast generate: CompiledMethodTrailer empty.
+	method := ast generateMethod.
+	"#generateMethod sets the generated method as a property, put back the old"
+	ast compiledMethod: compiledMethod.
 	method setSourcePointer: compiledMethod sourcePointer.
 	^method.
 ]


### PR DESCRIPTION
- do not use generate: in ReflectiveMethod
- start deprecation, for now just deprecated #trailer (and keep it in the package for now)
- fix comment #endPC