### PR TITLE
Compiler: Cleanup for trailer removal in IRByteCodeGenerator 

### DIFF
--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -421,7 +421,7 @@ CompilationContext >> compiledMethodClass: aCompiledMethodClass [
 
 { #category : #accessing }
 CompilationContext >> compiledMethodTrailer [
-	^ compiledMethodTrailer ifNil: [ compiledMethodTrailer := CompiledMethodTrailer empty ]
+	^ compiledMethodTrailer
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
+++ b/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
@@ -155,7 +155,7 @@ IRBytecodeGenerator >> compilationContext: aCompilationContext [
 ]
 
 { #category : #results }
-IRBytecodeGenerator >> compiledBlockWith: trailer [
+IRBytecodeGenerator >> compiledBlock [
 	| lits quickPrimitive header cb |
 	lits := self literals allButLast "1 free only for compiledBlock".
 	quickPrimitive := self quickMethodPrim.
@@ -180,12 +180,6 @@ IRBytecodeGenerator >> compiledBlockWith: trailer [
 
 { #category : #results }
 IRBytecodeGenerator >> compiledMethod [
-
-	^ self compiledMethodWith: CompiledMethodTrailer empty
-]
-
-{ #category : #results }
-IRBytecodeGenerator >> compiledMethodWith: trailer [
 	| lits quickPrimitive |
 	lits := self literals.
 	quickPrimitive := self quickMethodPrim.
@@ -196,11 +190,11 @@ IRBytecodeGenerator >> compiledMethodWith: trailer [
 		encoder stream: primitiveBytes.
 		encoder genCallPrimitive: quickPrimitive.
 	].
-	^ self compiledMethodWith: trailer header: (self spurVMHeader: lits size) literals: lits
+	^ self compiledMethodHeader: (self spurVMHeader: lits size) literals: lits
 ]
 
 { #category : #results }
-IRBytecodeGenerator >> compiledMethodWith: trailer header: header literals: lits [
+IRBytecodeGenerator >> compiledMethodHeader: header literals: lits [
 	| cm cmClass|
 	"we look up the class in the productionEnvironment"
 	cmClass := self compilationContext compiledMethodClass.

--- a/src/OpalCompiler-Core/IRMethod.class.st
+++ b/src/OpalCompiler-Core/IRMethod.class.st
@@ -153,7 +153,7 @@ IRMethod >> generate [
 IRMethod >> generate: trailer [
 
 	| irTranslator |
-   irTranslator := IRTranslator context: self compilationContext trailer: trailer.
+   irTranslator := IRTranslator context: self compilationContext.
 	irTranslator
 		visitNode: self;
 		pragmas: pragmas.
@@ -171,7 +171,7 @@ IRMethod >> generate: trailer [
 { #category : #translating }
 IRMethod >> generateBlock: trailer withScope: scope [
 	| irTranslator |
-      irTranslator := IRTranslator context: self compilationContext trailer: trailer.
+      irTranslator := IRTranslator context: self compilationContext.
 	irTranslator
 		pushOuterVectors: scope;
 		visitNode: self;

--- a/src/OpalCompiler-Core/IRMethod.class.st
+++ b/src/OpalCompiler-Core/IRMethod.class.st
@@ -118,7 +118,7 @@ IRMethod >> compilationContext: aCompilationContext [
 IRMethod >> compiledBlock: scope [
 
 	^compiledMethod
-		ifNil: [self generateBlock: CompiledMethodTrailer empty withScope: scope ]
+		ifNil: [self generateBlockWithScope: scope ]
 		ifNotNil: [compiledMethod]
 ]
 
@@ -169,7 +169,7 @@ IRMethod >> generate: trailer [
 ]
 
 { #category : #translating }
-IRMethod >> generateBlock: trailer withScope: scope [
+IRMethod >> generateBlockWithScope: scope [
 	| irTranslator |
       irTranslator := IRTranslator context: self compilationContext.
 	irTranslator

--- a/src/OpalCompiler-Core/IRTranslator.class.st
+++ b/src/OpalCompiler-Core/IRTranslator.class.st
@@ -15,16 +15,15 @@ Class {
 }
 
 { #category : #'instance creation' }
-IRTranslator class >> context: aCompilationContext trailer: aCompiledMethodTrailer [
+IRTranslator class >> context: aCompilationContext [
 	^self basicNew
 		initialize;
-		compilationContext: aCompilationContext;
-		trailer: aCompiledMethodTrailer
+		compilationContext: aCompilationContext
 ]
 
 { #category : #'instance creation' }
 IRTranslator class >> new [
-	^self context: CompilationContext default trailer: CompiledMethodTrailer empty
+	^self context: CompilationContext default
 ]
 
 { #category : #accessing }
@@ -41,18 +40,18 @@ IRTranslator >> compilationContext: aContext [
 
 { #category : #results }
 IRTranslator >> compiledBlock [
-	^ gen compiledBlockWith: trailer
+	^ gen compiledBlock
 ]
 
 { #category : #results }
 IRTranslator >> compiledMethod [
-	^ gen compiledMethodWith: trailer
+	^ gen compiledMethod
 ]
 
 { #category : #results }
 IRTranslator >> compiledMethodWith: aTrailer [
 
-	^ gen compiledMethodWith: aTrailer
+	^ gen compiledMethod
 ]
 
 { #category : #private }


### PR DESCRIPTION
THis PR simplifies IRBytecodeGenerator now that it does not use the trailer anymore.

The frontend for now still has the API with the trailer, we can cleanup more after this