### PR TITLE
Add compiler option to not optimise special sends

### DIFF
--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -89,7 +89,7 @@ CompilationContext class >> default [
 
 { #category : #options }
 CompilationContext class >> defaultOptions [
-	^ DefaultOptions ifNil: [ DefaultOptions := Set new parseOptions: self fallBackDefaultOptions ]
+	^ DefaultOptions ifNil: [ DefaultOptions := Set new parseOptions: self initialDefaultOptions ]
 ]
 
 { #category : #accessing }
@@ -112,7 +112,8 @@ CompilationContext class >> defaultTransformationPlugins: anObject [
 ]
 
 { #category : #options }
-CompilationContext class >> fallBackDefaultOptions [
+CompilationContext class >> initialDefaultOptions [
+	"Skip the comment of each option"
 	^ (self optionsDescription collect: [ :each | each allButLast ]) flattened
 ]
 
@@ -252,6 +253,20 @@ CompilationContext class >> optionLongIvarAccessBytecodes: aBoolean [
 	^ self writeDefaultOption: #optionLongIvarAccessBytecodes value: aBoolean
 ]
 
+{ #category : #options }
+CompilationContext class >> optionOptimiseSpecialSends [
+
+	^ self readDefaultOption: #optionOptimiseSpecialSends
+]
+
+{ #category : #options }
+CompilationContext class >> optionOptimiseSpecialSends: aBoolean [
+
+	^ self
+		  writeDefaultOption: #optionOptimiseSpecialSends
+		  value: aBoolean
+]
+
 { #category : #'options - settings API' }
 CompilationContext class >> optionOptimizeIR [
 	^ self readDefaultOption: #optionOptimizeIR
@@ -300,6 +315,7 @@ CompilationContext class >> optionsDescription [
 
 	"each entry is fall-back default value (+/-), option name, description"
 	^ #(
+	(+ optionOptimiseSpecialSends 'Use optimised bytecodes for special selectors. These bytecodes hint the VM to do static type predictions')
 	(+ optionInlineIf 					'Inline ifTrue:, ifFalse:, ifTrue:ifFalse:, ifFalse:ifTrue: if specific conditions are met (See isInlineIf)')
 	(+ optionInlineIfNil 				'Inline ifNil:, ifNotNil:, ifNil:ifNotNil:, ifNotNil:ifNil: if specific conditions are met (See isInlineIfNil)')
 	(+ optionInlineAndOr 				'Inline and:, or: if specific conditions are met (See isInlineAndOr)')
@@ -506,6 +522,11 @@ CompilationContext >> optionInlineWhile [
 { #category : #options }
 CompilationContext >> optionLongIvarAccessBytecodes [
 	^ options includes: #optionLongIvarAccessBytecodes
+]
+
+{ #category : #options }
+CompilationContext >> optionOptimiseSpecialSends [
+	^ options includes: #optionOptimiseSpecialSends
 ]
 
 { #category : #options }

--- a/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
+++ b/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
@@ -639,11 +639,16 @@ IRBytecodeGenerator >> saveLastJump: message [
 
 { #category : #instructions }
 IRBytecodeGenerator >> send: selector [
+
 	| nArgs |
 	nArgs := selector numArgs.
 	stack pop: nArgs.
-	(self encoderClass specialSelectors includes: selector)
-		ifTrue: [ ^ encoder genSendSpecial: (self encoderClass specialSelectors indexOf: selector) numArgs: nArgs ].
+	(compilationContext optionOptimiseSpecialSends and: [
+		 self encoderClass specialSelectors includes: selector ]) ifTrue: [
+		^ encoder
+			  genSendSpecial:
+			  (self encoderClass specialSelectors indexOf: selector)
+			  numArgs: nArgs ].
 	encoder genSend: (self literalIndexOf: selector) numArgs: nArgs
 ]
 

--- a/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
@@ -214,13 +214,6 @@ OCASTTranslatorTest >> testExamplePrimitiveModuleError [
 	self assert: ir tempKeys equals: #(#errorCode)
 ]
 
-{ #category : #'tests - simple' }
-OCASTTranslatorTest >> testSendSpecialBinaryMessage [
-
-	self assert: (Smalltalk specialSelectors includes: #+).
-	self assert: (self testExample: #exampleReturn1plus2) equals: 3
-]
-
 { #category : #support }
 OCASTTranslatorTest >> testSource: sourceCode [
 

--- a/src/OpalCompiler-Tests/OCBytecodeGeneratorTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeGeneratorTest.class.st
@@ -11,7 +11,10 @@ OCBytecodeGeneratorTest class >> packageNamesUnderTest [
 
 { #category : #helper }
 OCBytecodeGeneratorTest >> bytecodeGenerator [
-	^ IRBytecodeGenerator newWithEncoderClass: EncoderForSistaV1
+
+	^ (IRBytecodeGenerator newWithEncoderClass: EncoderForSistaV1)
+		  compilationContext: CompilationContext new;
+		  yourself
 ]
 
 { #category : #'tests - execution' }

--- a/src/OpalCompiler-Tests/OCCalledMethodProxy.class.st
+++ b/src/OpalCompiler-Tests/OCCalledMethodProxy.class.st
@@ -1,0 +1,73 @@
+Class {
+	#name : #OCCalledMethodProxy,
+	#superclass : #Object,
+	#instVars : [
+		'originalMethod',
+		'called'
+	],
+	#category : #'OpalCompiler-Tests-AST'
+}
+
+{ #category : #'instance creation' }
+OCCalledMethodProxy class >> on: aMethod [
+
+	^ self new
+		  originalMethod: aMethod;
+		  yourself
+]
+
+{ #category : #'accessing - pragmas & properties' }
+OCCalledMethodProxy >> cachePragmas [
+	
+	^ originalMethod cachePragmas
+]
+
+{ #category : #accessing }
+OCCalledMethodProxy >> called [
+
+	^ called
+]
+
+{ #category : #initialization }
+OCCalledMethodProxy >> initialize [
+
+	super initialize.
+	called := false
+]
+
+{ #category : #accessing }
+OCCalledMethodProxy >> methodClass: aClass [ 
+	
+	originalMethod methodClass: aClass
+]
+
+{ #category : #accessing }
+OCCalledMethodProxy >> originalMethod [
+
+	^ originalMethod
+]
+
+{ #category : #accessing }
+OCCalledMethodProxy >> originalMethod: anObject [
+
+	originalMethod := anObject
+]
+
+{ #category : #evaluation }
+OCCalledMethodProxy >> run: aSelector with: arguments in: aReceiver [
+
+	called := true.
+	^ originalMethod valueWithReceiver: aReceiver arguments: arguments
+]
+
+{ #category : #accessing }
+OCCalledMethodProxy >> selector: aString [ 
+	
+	originalMethod selector: aString
+]
+
+{ #category : #testing }
+OCCalledMethodProxy >> wasCalled [
+	
+	^ called
+]

--- a/src/OpalCompiler-Tests/OCOpalExamples.class.st
+++ b/src/OpalCompiler-Tests/OCOpalExamples.class.st
@@ -583,7 +583,8 @@ OCOpalExamples >> exampleSimpleBlockReturn [
 
 { #category : #'examples - blocks' }
 OCOpalExamples >> exampleSimpleBlockiVar [
-	^[iVar] value
+
+	^ [ iVar ] value
 ]
 
 { #category : #'examples - variables' }

--- a/src/OpalCompiler-Tests/OCSpecialSelectorTest.class.st
+++ b/src/OpalCompiler-Tests/OCSpecialSelectorTest.class.st
@@ -1,0 +1,135 @@
+Class {
+	#name : #OCSpecialSelectorTest,
+	#superclass : #OCASTTranslatorTest,
+	#instVars : [
+		'optimisationsActive',
+		'replacedMethods'
+	],
+	#category : #'OpalCompiler-Tests-AST'
+}
+
+{ #category : #'tests - simple' }
+OCSpecialSelectorTest >> compilationContext [
+
+	| context |
+	context := super compilationContext.
+
+	context parseOptions: {
+			(optimisationsActive
+				 ifTrue: [ #+ ]
+				 ifFalse: [ #- ]).
+			#optionOptimiseSpecialSends }.
+	^ context
+]
+
+{ #category : #'tests - simple' }
+OCSpecialSelectorTest >> proxy: aMethod [
+	"Replace the method by the proxy and keep the original one to restore it on tearDown"
+
+	| proxy |
+	proxy := OCCalledMethodProxy on: aMethod.
+	self replace: aMethod with: proxy.
+	^ proxy
+]
+
+{ #category : #'tests - simple' }
+OCSpecialSelectorTest >> replace: aMethod with: aReplacement [
+
+	"Replace the method in its class and remember it to restore it at the end."
+	replacedMethods add: aMethod.
+	
+	"Make sure we install the method after remembering it to avoid calling it when adding it in the collection"
+	aMethod methodClass
+		addSelectorSilently: aMethod selector
+		withMethod: aReplacement.
+]
+
+{ #category : #running }
+OCSpecialSelectorTest >> setUp [
+
+	super setUp.
+	optimisationsActive := true.
+	replacedMethods := Set new
+]
+
+{ #category : #running }
+OCSpecialSelectorTest >> tearDown [
+	"Restore methods replaced during the test"
+
+	replacedMethods do: [ :e |
+		e methodClass addSelectorSilently: e selector withMethod: e ].
+	super tearDown
+]
+
+{ #category : #'tests - simple' }
+OCSpecialSelectorTest >> testOptimisedPlusSpecialSendsMessageDoesNotCaptureSend [
+	"Turn on optimisation, then compile & run"
+
+	| proxy |
+	optimisationsActive := true.
+	self compileExample: #exampleReturn1plus2.
+
+	[
+		proxy := self proxy: SmallInteger >> #+.
+
+		self deny: proxy wasCalled.
+		self assert: (self executeMethod: method onReceiver: instance) equals: 3.
+		self deny: proxy wasCalled.
+	] valueUnpreemptively
+]
+
+{ #category : #'tests - simple' }
+OCSpecialSelectorTest >> testOptimisedValueSpecialSendsMessageDoesNotCaptureSend [
+	"Turn on optimisation, then compile & run"
+
+	| proxy |
+	optimisationsActive := true.
+	self compileExample: #exampleSimpleBlockiVar.
+	instance iVar: #valueToTest.
+	[
+		self replace: OCOpalExamples >> #exampleSimpleBlockiVar with: method.
+		proxy := self proxy: BlockClosure >> #value.
+
+		self deny: proxy wasCalled.
+		"Do not directly execute the method here.
+		Executing a method through valueWithReceiver: forces JIT compilation, which does not optimise #value sends.
+		Instead, send a message to go through the interpreter and have an optimised execution that does not invoke the proxy"
+		self assert: instance exampleSimpleBlockiVar equals: #valueToTest.
+		self deny: proxy wasCalled.
+	] valueUnpreemptively
+]
+
+{ #category : #'tests - simple' }
+OCSpecialSelectorTest >> testUnoptimisedPlusSpecialSendsMessageCapturesSend [
+	"Turn off optimisation, then compile & run"
+
+	| proxy |
+	optimisationsActive := false.
+	self compileExample: #exampleReturn1plus2.
+	[
+	proxy := self proxy: SmallInteger >> #+.
+
+	self deny: proxy wasCalled.
+	self
+		assert: (self executeMethod: method onReceiver: instance)
+		equals: 3.
+	self assert: proxy wasCalled ] valueUnpreemptively
+]
+
+{ #category : #'tests - simple' }
+OCSpecialSelectorTest >> testUnoptimisedValueSpecialSendsMessageCapturesSend [
+	"Turn off optimisation, then compile & run"
+
+	| proxy |
+	optimisationsActive := false.
+	self compileExample: #exampleSimpleBlockiVar.
+	instance iVar: #valueToTest.
+	[
+	proxy := self proxy: BlockClosure >> #value.
+
+	self deny: proxy wasCalled.
+	self
+		assert: (self executeMethod: method onReceiver: instance)
+		equals: #valueToTest.
+	self assert: proxy wasCalled ] valueUnpreemptively
+]


### PR DESCRIPTION
This helps in having method proxies that capture everything.
Otherwise, optimised sends are doing static type predictions, avoiding message sends (thus lookup and method proxies).

Done with @PalumboN , @tesonep , @jordanmontt , @BastouP411