### PR TITLE
Make shift tests more robust

### DIFF
--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -12,6 +12,12 @@ Class {
 }
 
 { #category : #'instance creation' }
+ShClassInstallerTest >> generatedClassesPackageName [
+
+	^ 'Shift-ClassInstallerTests-GeneratedPackage'
+]
+
+{ #category : #'instance creation' }
 ShClassInstallerTest >> newClass: className slots: slots [
 	^ self newClass: className superclass: Object slots: slots
 ]
@@ -30,26 +36,22 @@ ShClassInstallerTest >> newClass: className superclass: aSuperclass slots: slots
 
 { #category : #'instance creation' }
 ShClassInstallerTest >> newClass: className superclass: aSuperclass slots: slots metaclassSlots: metaclassSlots [
-	^ ShiftClassInstaller
-		make: [ :builder |
-			builder
-				name: className;
-				superclass: aSuperclass;
-				slots: slots;
-				classSlots: metaclassSlots;
-				sharedVariables: '';
-				sharedPools: '';
-				category: 'Shift-ClassInstaller-Tests' ]
+
+	^ ShiftClassInstaller make: [ :builder |
+		  builder
+			  name: className;
+			  superclass: aSuperclass;
+			  slots: slots;
+			  classSlots: metaclassSlots;
+			  sharedVariables: '';
+			  sharedPools: '';
+			  category: self generatedClassesPackageName ]
 ]
 
 { #category : #running }
 ShClassInstallerTest >> tearDown [
-	newClass ifNotNil: #removeFromSystem.
-	newClass2 ifNotNil: #removeFromSystem.
 
-	subClass ifNotNil: #removeFromSystem.
-	superClass ifNotNil: #removeFromSystem.
-	superClass2 ifNotNil: #removeFromSystem.
+	(self generatedClassesPackageName asPackageIfAbsent: [ nil ]) ifNotNil: [ :package | package removeFromSystem ].
 
 	super tearDown
 ]
@@ -57,32 +59,29 @@ ShClassInstallerTest >> tearDown [
 { #category : #tests }
 ShClassInstallerTest >> testChangingASharedPoolUpdatesCorrectlyUsers [
 
-	newClass := ShiftClassInstaller
-		make: [ :builder |
-			builder
-				name: #ShCITestSharedPool;
-				superclass: SharedPool;
-				sharedVariables: #(A B C);
-				category: 'Shift-ClassInstaller-Tests' ].
+	newClass := ShiftClassInstaller make: [ :builder |
+		            builder
+			            name: #ShCITestSharedPool;
+			            superclass: SharedPool;
+			            sharedVariables: #( A B C );
+			            category: self generatedClassesPackageName ].
 
-	newClass2 := ShiftClassInstaller
-		make: [ :builder |
-			builder
-				name: #ShCITestClass;
-				sharedPools: 'ShCITestSharedPool';
-				category: 'Shift-ClassInstaller-Tests' ].
+	newClass2 := ShiftClassInstaller make: [ :builder |
+		             builder
+			             name: #ShCITestClass;
+			             sharedPools: 'ShCITestSharedPool';
+			             category: self generatedClassesPackageName ].
 
 	newClass2 compile: 'a ^A'.
 
 	self assert: ((newClass2 >> #a) literals at: 1) identicalTo: (newClass classVariableNamed: #A).
 
-	newClass := ShiftClassInstaller
-		make: [ :builder |
-			builder
-				name: #ShCITestSharedPool;
-				superclass: SharedPool;
-				sharedVariables: #(A B C D);
-				category: 'Shift-ClassInstaller-Tests' ].
+	newClass := ShiftClassInstaller make: [ :builder |
+		            builder
+			            name: #ShCITestSharedPool;
+			            superclass: SharedPool;
+			            sharedVariables: #( A B C D );
+			            category: self generatedClassesPackageName ].
 
 	self assert: ((newClass2 >> #a) literals at: 1) identicalTo: (newClass classVariableNamed: #A)
 ]
@@ -153,17 +152,17 @@ ShClassInstallerTest >> testChangingSuperclassToOther [
 
 { #category : #tests }
 ShClassInstallerTest >> testClassWithComment [
-	newClass := ShiftClassInstaller
-		make: [ :builder |
-			builder
-				name: #SHClassWithComment;
-				superclass: Object;
-				slots: #();
-				sharedVariables: '';
-				sharedPools: '';
-				category: 'Shift-ClassInstaller-Tests';
-				comment: 'I have a comment';
-				commentStamp: 'anStamp' ].
+
+	newClass := ShiftClassInstaller make: [ :builder |
+		            builder
+			            name: #SHClassWithComment;
+			            superclass: Object;
+			            slots: #(  );
+			            sharedVariables: '';
+			            sharedPools: '';
+			            category: self generatedClassesPackageName;
+			            comment: 'I have a comment';
+			            commentStamp: 'anStamp' ].
 
 	self assert: newClass comment equals: 'I have a comment'.
 	self assert: newClass commentStamp equals: 'anStamp'
@@ -196,13 +195,12 @@ ShClassInstallerTest >> testClassWithSlotHasInitializeMethodWithInitializeSlots 
 { #category : #tests }
 ShClassInstallerTest >> testDuplicateClassPreserveClassSlots [
 
-	newClass := ShiftClassInstaller
-		make: [ :builder |
-			builder
-				name: #ShCITestClass;
-				superclass: Object;
-				classSlots: {#aClassInstanceVariable => InstanceVariableSlot};
-				category: 'Shift-ClassInstaller-Tests' ].
+	newClass := ShiftClassInstaller make: [ :builder |
+		            builder
+			            name: #ShCITestClass;
+			            superclass: Object;
+			            classSlots: { (#aClassInstanceVariable => InstanceVariableSlot) };
+			            category: self generatedClassesPackageName ].
 
 	newClass2 := newClass duplicateClassWithNewName: #ShCITestClass2.
 


### PR DESCRIPTION
Currently the shift test is removing from the system the generated classes. But a problem arise when the test fail during the class creation because the class was generated in the system but the variable was not set since an error happened before that.  I propose to just generate the classes in a specific package that we remove in the tear down. Like this, even if the class creation fails, we can still remove the code and avoid getting the "Class XXX already exists" error