### PR TITLE
Fix case were method is in a class but not in a protocol

### DIFF
--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -68,6 +68,7 @@ ShiftClassBuilder >> allSlots [
 
 { #category : #building }
 ShiftClassBuilder >> build [
+
 	self tryToFillOldClass.
 	self detectBuilderEnhancer.
 	self builderEnhancer validateRedefinition: self oldClass.
@@ -81,21 +82,21 @@ ShiftClassBuilder >> build [
 	We need to check if there is no conflicts with existing subclasses.
 	If we are in a remake, it have been done when building the superclass modified before."
 
-	self isInRemake
-		ifFalse: [ self layoutDefinition validate ].
+	self isInRemake ifFalse: [ self layoutDefinition validate ].
 
 	self createMetaclass.
 	self createClass.
+
+	self oldClass ifNotNil: [
+		self newClass basicCategory: self oldClass basicCategory.
+		self copyOrganization.
+		self newClass commentSourcePointer: self oldClass commentSourcePointer ].
 
 	self createSharedVariables.
 
 	self installSlotsAndVariables.
 
-	self oldClass ifNotNil: [
-			self newClass basicCategory: self oldClass basicCategory.
-			self copyOrganization.
-			self newClass commentSourcePointer: self oldClass commentSourcePointer.
-			self builderEnhancer compileMethodsFor: self. ].
+	self oldClass ifNotNil: [ self builderEnhancer compileMethodsFor: self ].
 
 	self builderEnhancer afterMethodsCompiled: self.
 	^ newClass

--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -55,6 +55,22 @@ ShClassInstallerTest >> tearDown [
 ]
 
 { #category : #tests }
+ShClassInstallerTest >> testBuildingClassesWithSlotsClassifiesItsMethods [
+	"This is a regression test. 
+	What was happening before was that the slots were generating a method to initialize themselves and after that the old class organization was copied. The problem is that during the first class creation, this was reseting the protocol of the generated slot methods."
+
+	newClass := self newClass: #ShCITestClass slots: { (#anInstanceVariable => BooleanSlot) }.
+
+	self assertCollection: newClass selectors hasSameElements: { #initialize }.
+	self assert: (newClass organization protocolOfSelector: #initialize) isNotNil.
+
+	newClass2 := newClass duplicateClassWithNewName: #ShCITestClass2.
+
+	self assertCollection: newClass2 selectors hasSameElements: { #initialize }.
+	self assert: (newClass2 organization protocolOfSelector: #initialize) isNotNil
+]
+
+{ #category : #tests }
 ShClassInstallerTest >> testChangingASharedPoolUpdatesCorrectlyUsers [
 
 	newClass := ShiftClassInstaller


### PR DESCRIPTION
When a class has a slot, it generates an initialization method. But during the first creation of a class, this method got removed from its protocol when the class copied the organization of the old class.

This PR puts the organization copy before the initialization of slots to ensure the slot stay classified. It also adds a test.

This problem was detected by: #13533