### PR TITLE
Small cleanings in tests

### DIFF
--- a/src/SUnit-Core/ClassTestCase.class.st
+++ b/src/SUnit-Core/ClassTestCase.class.st
@@ -33,12 +33,6 @@ ClassTestCase class >> mustTestCoverage [
 	^ false
 ]
 
-{ #category : #private }
-ClassTestCase >> categoriesForClass: aClass [
-
-	^ aClass organization allMethodSelectors collect: [ :each | aClass organization protocolNameOfElement: each ]
-]
-
 { #category : #coverage }
 ClassTestCase >> classToBeTested [
 
@@ -139,7 +133,5 @@ ClassTestCase >> testUnCategorizedMethods [
 
 	| uncategorizedMethods |
 	uncategorizedMethods := self targetClass selectorsInProtocol: Protocol unclassified.
-	self
-		assert: uncategorizedMethods isEmpty
-		description: uncategorizedMethods asString
+	self assertEmpty: uncategorizedMethods
 ]

--- a/src/SUnit-Core/ManifestSUnitCore.class.st
+++ b/src/SUnit-Core/ManifestSUnitCore.class.st
@@ -16,8 +16,3 @@ ManifestSUnitCore class >> ruleExcessiveArgumentsRuleV1FalsePositive [
 ManifestSUnitCore class >> ruleStringConcatenationRuleV1FalsePositive [
 	^ #(#(#(#RGMethodDefinition #(#ClassFactoryForTestCase #cleanUpChangeSetForClassNames: #false)) #'2021-12-05T23:07:46.009058+01:00') )
 ]
-
-{ #category : #'code-critics' }
-ManifestSUnitCore class >> ruleUtilityMethodsRuleV1FalsePositive [
-	^ #(#(#(#RGMethodDefinition #(#ClassTestCase #categoriesForClass: #false)) #'2021-12-05T23:37:26.237093+01:00') )
-]

--- a/src/System-Support-Tests/SystemDictionaryTest.class.st
+++ b/src/System-Support-Tests/SystemDictionaryTest.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #'building suites' }
 SystemDictionaryTest class >> shouldInheritSelectors [
 
-^true
+	^ true
 ]
 
 { #category : #requirements }
@@ -124,13 +124,4 @@ SystemDictionaryTest >> testSmalltalkPrintString [
 SystemDictionaryTest >> testSmalltalkSelfEvaluating [
 
 	self assert: Smalltalk isSelfEvaluating
-]
-
-{ #category : #tests }
-SystemDictionaryTest >> testUnCategorizedMethods [
-
-	| categories slips |
-	categories := self categoriesForClass: self targetClass.
-	slips := categories select: [ :each | each = #'as yet unclassified' ].
-	self assertEmpty: slips
 ]


### PR DESCRIPTION
- #testUnCategorizedMethods of SystemDictionaryTest is overriding a test doing the same things but in a more readable way => Let's remove it (I checked and the class inherits superclasses tests)
- #categoriesForClass: was used only by SystemDictionaryTest>>#testUnCategorizedMethods so we can now remove it. It also removes one of the users of #protocolNameOfElement: that is on the kill list
- Use #assertEmpty: for better logs in case of failure