### PR TITLE
Fix wrong double click

### DIFF
--- a/src/Morphic-Base/MouseClickState.class.st
+++ b/src/Morphic-Base/MouseClickState.class.st
@@ -323,8 +323,10 @@ MouseClickState >> handleEvent: evt from: aHand [
 			^true].
 		localEvt isMouseDown ifTrue:["double click"
 			clickState := #secondClickDown.
-			self doubleClick.
-			^false]].
+			"We should not double click if not on the same element"
+			(clickClient containsPoint: localEvt position) ifTrue: [
+				self doubleClick.
+				^false] ] ].
 
 	clickState == #secondClickDown ifTrue: [
 		isDragSecond ifTrue: ["drag start"

--- a/src/Morphic-Tests/MouseClickStateTest.class.st
+++ b/src/Morphic-Tests/MouseClickStateTest.class.st
@@ -45,6 +45,23 @@ MouseClickStateTest >> testClickFromMorph [
 ]
 
 { #category : #tests }
+MouseClickStateTest >> testDoubleClickShouldNotTriggerIfClickedOutsideBounds [
+	(hand mouseClickStateFor: morph event: event)
+		doubleClickSelector: #myMagicDoubleClick:.
+	"the first click does not do anything"
+	hand handleEvent: event.
+	event setType: #mouseUp.
+	hand handleEvent: event.
+
+	"Out of bounds"
+	event setPosition: morph bounds topRight + 100.
+	event setType: #mouseDown.
+	hand handleEvent: event.
+
+	self deny: morph hasMyMagicDoubleClickActivated
+]
+
+{ #category : #tests }
 MouseClickStateTest >> testHandleEventFrom [
 	hand
 		waitForClicksOrDrag: morph


### PR DESCRIPTION
Caused by: https://github.com/pharo-project/pharo/pull/11838

The symptom with an example:

In calypso, double clicking on a tab header should maximise the tab.
However, if a first click is done on the tab header, and a second click is done very quickly somewhere else, it is maximised too => this should not happen.

This PR checks that the second click happens within the bounds of the element of the first click.