### PR TITLE
this PR introduces CompiledMethod>>#clearSourcePointer and #sourcePointer:

### DIFF
--- a/src/Fuel-Core/FLCompiledMethodCluster.class.st
+++ b/src/Fuel-Core/FLCompiledMethodCluster.class.st
@@ -34,13 +34,7 @@ FLCompiledMethodCluster class >> setTrailerWithSourceCode [
 	"Make compiled methods be serialized without source code."
 
 	^ self transformationForSerializing: [:aCompiledMethod |
-		"we set the source as a property, not yet installed methods already have
-		it, but for installed methods we put it back "
-		aCompiledMethod copy
-			setSourcePointer: 0;
-			propertyAt: #source put: aCompiledMethod sourceCode;
-			yourself
-		]
+		aCompiledMethod copy clearSourcePointer ]
 ]
 
 { #category : #accessing }

--- a/src/Fuel-Tests-Core/CompiledMethod.extension.st
+++ b/src/Fuel-Tests-Core/CompiledMethod.extension.st
@@ -2,5 +2,5 @@ Extension { #name : #CompiledMethod }
 
 { #category : #'*Fuel-Tests-Core' }
 CompiledMethod >> isEqualRegardlessTrailerTo: aCompiledMethod [
-	^ (self copy setSourcePointer: 0) = (aCompiledMethod copy setSourcePointer: 0)
+	^ self copy clearSourcePointer = aCompiledMethod copy clearSourcePointer
 ]

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -244,6 +244,12 @@ CompiledMethod >> classBinding: aBinding [
        ^self literalAt: self numLiterals put: aBinding
 ]
 
+{ #category : #'source code management' }
+CompiledMethod >> clearSourcePointer [
+	"we use #setSourcePointer: to not clear the property #source"
+	self setSourcePointer: 0
+]
+
 { #category : #accessing }
 CompiledMethod >> codeForNoSource [
 	"if everything fails, decompile the bytecode"
@@ -936,6 +942,14 @@ CompiledMethod >> sourcePointer [
 	endPC := self endPC.
 	endPC+1 to: self size do: [:n | bytes at: n-endPC put: (self at: n) ].
 	^ bytes asInteger
+]
+
+{ #category : #'source code management' }
+CompiledMethod >> sourcePointer: srcPointer [
+
+	"Drop the #source property if any"
+	self removeProperty: #source.
+	self setSourcePointer: srcPointer
 ]
 
 { #category : #'debugger support' }

--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -122,7 +122,7 @@ Behavior >> recompileBasic: selector from: oldClass [
 				class: self;
 				permitFaulty: true;
 				compile.   "Assume OK after proceed from SyntaxError"
-	newMethod setSourcePointer: method sourcePointer.
+	newMethod sourcePointer: method sourcePointer.
 	selector == newMethod selector ifFalse: [self error: 'selector changed!'].
 	^ newMethod
 ]

--- a/src/OpalCompiler-Tests/MethodMapTest.class.st
+++ b/src/OpalCompiler-Tests/MethodMapTest.class.st
@@ -15,7 +15,7 @@ MethodMapTest >> compileAndRunExample: aSelector [
 { #category : #utilities }
 MethodMapTest >> compileMethod: aMethod [
 
-	^ aMethod parseTree generateMethod setSourcePointer: aMethod sourcePointer
+	^ aMethod parseTree generateMethod sourcePointer: aMethod sourcePointer
 ]
 
 { #category : #'tests - ast mapping' }

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -41,7 +41,7 @@ ReflectiveMethod >> compileAST [
 	method := ast generateMethod.
 	"#generateMethod sets the generated method as a property, put back the old"
 	ast compiledMethod: compiledMethod.
-	method setSourcePointer: compiledMethod sourcePointer.
+	method sourcePointer: compiledMethod sourcePointer.
 	^method.
 ]
 

--- a/src/System-Sources/CompiledMethod.extension.st
+++ b/src/System-Sources/CompiledMethod.extension.st
@@ -23,7 +23,7 @@ CompiledMethod >> putSource: source withPreamble: preambleBlock [
 			"Method chunk needs a final ! !"
 			(SourceChunkWriteStream on: theChangesFileStream) nextPut: ' '.
 			"Update with new source pointer"
-			self setSourcePointer: newSourcePointer ]
+			self sourcePointer: newSourcePointer ]
 		onFail: [
 			"if we can not store the source pointer, we put back the property"
 			self propertyAt: #source put: source ]

--- a/src/TraitsV2/TaAbstractComposition.class.st
+++ b/src/TraitsV2/TaAbstractComposition.class.st
@@ -148,7 +148,7 @@ TaAbstractComposition >> compile: selector into: aClass [
 		             source: sourceCode;
 		             permitUndeclared: true;
 		             compile.
-	newMethod setSourcePointer: method sourcePointer.
+	newMethod sourcePointer: method sourcePointer.
 	selector == newMethod selector ifFalse: [ self error: 'selector changed!' ].
 
 	(selector ~= method selector or: [ self changesSourceCode: selector ])

--- a/src/UnifiedFFI/FFICalloutMethodBuilder.class.st
+++ b/src/UnifiedFFI/FFICalloutMethodBuilder.class.st
@@ -148,7 +148,7 @@ FFICalloutMethodBuilder >> generateMethodFromSpec: functionSpec [
 		ffiLibrary postMethodBuildContext: sender builder: builder spec: functionSpec.
 		r].
 	method := ir generate.
-	self method isCompiledMethod ifTrue: [method setSourcePointer: self method sourcePointer  ].
+	self method isCompiledMethod ifTrue: [method sourcePointer: self method sourcePointer  ].
 	^method
 ]
 


### PR DESCRIPTION
it splits setSourcPointer: into two #sourcePointer that removes the property, 

- while setSourcPointer: does the setting (and is used by #clearSourcePointer, where you do not want t remove the property)