### PR TITLE
13468-Calypso-New-Trait-command-does-not-create-the-Trait

### DIFF
--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -187,25 +187,22 @@ ClySystemEnvironment >> defaultClassCompiler [
 ClySystemEnvironment >> defineNewClassFrom: newClassDefinitionString notifying: aController startingFrom: oldClass [
 
 	"Note: newClassDefinitionString can be a fluid class of a standars one"
+	| fluidClassBuilderOrBehavior |
 
-	| newClass |
 	"On parser & semantic errors (including undeclared because we are in the legacy scripting interactive mode),
 	there is UI notification.
 	On execution, some methods might be recompiled and cause issues:
 	* Warnings (undeclared/shadowed) are sillently passed, but should be fixed by the user later.
 	* Errors are unlikely (method should be already broken), but cause (resumable) syntax error for now."
-	newClass := (self classCompilerFor: oldClass)
+	fluidClassBuilderOrBehavior := (self classCompilerFor: oldClass)
 		            source: newClassDefinitionString;
 		            requestor: aController;
 		            failBlock: [ ^ nil ];
 		            logged: true;
 		            evaluate.
-	"mild ugly hack for fluid classes (and traits)"
-	(newClass isKindOf: FluidClassBuilder) ifTrue: [ newClass := newClass install ].
 
-	^ newClass isBehavior
-		  ifTrue: [ newClass ]
-		  ifFalse: [ nil ]
+	"We can send #fluidInstall as it is polymorphic with Behavior and FluidBuilder"
+	^ fluidClassBuilderOrBehavior ifNotNil: [fluidClassBuilderOrBehavior fluidInstall]
 ]
 
 { #category : #'package management' }


### PR DESCRIPTION
We can remove the isKindOf: message by using teh fluidInstall message that is implemented in Behavior and in the FluidBuilders.

Fix #13468