### PR TITLE
Do not rely on #protocolNameOfElement: in Traits

### DIFF
--- a/src/TraitsV2-Tests/ClassTraitTest.class.st
+++ b/src/TraitsV2-Tests/ClassTraitTest.class.st
@@ -19,12 +19,12 @@ ClassTraitTest >> testChanges [
 	self assert: (self c2 class methodDict includesKey: #m1ClassSide).
 	self c2 m1ClassSide.
 	self assert: self c2 m1ClassSide equals: 17. "category"
-	self assert: (self c2 class organization protocolNameOfElement: #m1ClassSide) equals: 'mycategory'. "conflicts"
+	self assert: (self c2 class organization protocolOfSelector: #m1ClassSide) name equals: 'mycategory'. "conflicts"
 	self t2 classSide compile: 'm1ClassSide' classified: 'mycategory'.
 	self assert: (self c2 class methodDict includesKey: #m1ClassSide).
 	self deny: (self c2 class includesLocalSelector: #m1ClassSide).
 	self should: [ self c2 m1ClassSide ] raise: Error. "conflict category"
-	self assert: (self c2 class organization protocolNameOfElement: #m1ClassSide) equals: #mycategory
+	self assert: (self c2 class organization protocolOfSelector: #m1ClassSide) name equals: #mycategory
 ]
 
 { #category : #tests }

--- a/src/TraitsV2-Tests/T2TraitWithPackagesTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitWithPackagesTest.class.st
@@ -158,8 +158,8 @@ T2TraitWithPackagesTest >> testPackageOfMethodFromTraitsRemoved [
 
 	t1 removeSelector: #m1.
 
-	self assert: (t1 organization protocolNameOfElement: #m1) isNil.
-	self assert: (t2 organization protocolNameOfElement: #m1) isNil.
+	self assert: (t1 organization protocolOfSelector: #m1) isNil.
+	self assert: (t2 organization protocolOfSelector: #m1) isNil.
 
 	self assert: (RPackageOrganizer default packageDefiningOrExtendingSelector: #m1 inClassNamed: #T1) isNil.
 	self assert: (RPackageOrganizer default packageDefiningOrExtendingSelector: #m1 inClassNamed: #T2) isNil

--- a/src/TraitsV2-Tests/TraitMethodDescriptionTest.class.st
+++ b/src/TraitsV2-Tests/TraitMethodDescriptionTest.class.st
@@ -17,29 +17,6 @@ TraitMethodDescriptionTest >> testArgumentNames [
 ]
 
 { #category : #tests }
-TraitMethodDescriptionTest >> testCategories [
-
-	self assert: (self t4 organization protocolNameOfElement: #m21) equals: #cat1.
-	self assert: (self t4 organization protocolNameOfElement: #m22) equals: #cat2.
-	self assert: (self t4 organization protocolNameOfElement: #m11) equals: #catX.
-	self assert: (self t4 organization protocolNameOfElement: #m12) equals: #cat2.
-	self assert: (self t4 organization protocolNameOfElement: #m13) equals: #cat3.
-	self assert: (self t6 organization protocolNameOfElement: #m22Alias) equals: #cat2.
-	self t2 organization classify: #m22 under: #catX.
-	self assert: (self t4 organization protocolNameOfElement: #m22) equals: #catX.
-	self assert: (self t6 organization protocolNameOfElement: #m22Alias) equals: #catX.
-	self t6 organization classify: #m22 under: #catY.
-	self t6 organization classify: #m22Alias under: #catY.
-	self t2 organization classify: #m22 under: #catZ.
-	self assert: (self t6 organization protocolNameOfElement: #m22) equals: #catY.
-	self assert: (self t6 organization protocolNameOfElement: #m22Alias) equals: #catY.
-	self t1 compile: 'mA' classified: #catA.
-	self assert: (self t4 organization protocolNameOfElement: #mA) equals: #catA.
-	self t1 organization classify: #mA under: #cat1.
-	self assert: (self t4 organization hasProtocol: #catA) not
-]
-
-{ #category : #tests }
 TraitMethodDescriptionTest >> testConflictMethodCreation [
 	"Generate conflicting methods between t1 and t2
 	and check the resulting method in Trait t5 (or c2).
@@ -78,24 +55,47 @@ TraitMethodDescriptionTest >> testConflictMethodCreation [
 ]
 
 { #category : #tests }
-TraitMethodDescriptionTest >> testConflictingCategories [
+TraitMethodDescriptionTest >> testConflictingProtocols [
 
 	| t7 t8 |
 	self t2 compile: 'm11' classified: #catY.
-	self assert: (self t4 organization protocolNameOfElement: #m11) equals: #catX.
-	self assert: (self t5 organization protocolNameOfElement: #m11) equals: Protocol traitConflictName.
+	self assert: (self t4 organization protocolOfSelector: #m11) name equals: #catX.
+	self assert: (self t5 organization protocolOfSelector: #m11) name equals: Protocol traitConflictName.
 	t7 := self createTraitNamed: #T7 uses: self t1 + self t2.
-	self assert: (t7 organization protocolNameOfElement: #m11) equals: Protocol traitConflictName.
+	self assert: (t7 organization protocolOfSelector: #m11) name equals: Protocol traitConflictName.
 	self t1 removeSelector: #m11.
-	self assert: (self t4 organization protocolNameOfElement: #m11) equals: #catX.
-	self assert: (self t5 organization protocolNameOfElement: #m11) equals: #catY.
-	self assert: (t7 organization protocolNameOfElement: #m11) equals: #catY.
+	self assert: (self t4 organization protocolOfSelector: #m11) name equals: #catX.
+	self assert: (self t5 organization protocolOfSelector: #m11) name equals: #catY.
+	self assert: (t7 organization protocolOfSelector: #m11) name equals: #catY.
 	self deny: (t7 organization hasProtocol: Protocol traitConflictName).
 	self t1 compile: 'm11' classified: #cat1.
 	t8 := self createTraitNamed: #T8 uses: self t1 + self t2.
 	t8 organization classify: #m11 under: #cat1.
 	self t1 organization classify: #m11 under: #catZ.
-	self assert: (self t4 organization protocolNameOfElement: #m11) equals: #catX.
-	self assert: (self t5 organization protocolNameOfElement: #m11) equals: Protocol traitConflictName.
-	self assert: (t8 organization protocolNameOfElement: #m11) equals: #catZ
+	self assert: (self t4 organization protocolOfSelector: #m11) name equals: #catX.
+	self assert: (self t5 organization protocolOfSelector: #m11) name equals: Protocol traitConflictName.
+	self assert: (t8 organization protocolOfSelector: #m11) name equals: #catZ
+]
+
+{ #category : #tests }
+TraitMethodDescriptionTest >> testProtocols [
+
+	self assert: (self t4 organization protocolOfSelector: #m21) name equals: #cat1.
+	self assert: (self t4 organization protocolOfSelector: #m22) name equals: #cat2.
+	self assert: (self t4 organization protocolOfSelector: #m11) name equals: #catX.
+	self assert: (self t4 organization protocolOfSelector: #m12) name equals: #cat2.
+	self assert: (self t4 organization protocolOfSelector: #m13) name equals: #cat3.
+	self assert: (self t6 organization protocolOfSelector: #m22Alias) name equals: #cat2.
+	self t2 organization classify: #m22 under: #catX.
+	self assert: (self t4 organization protocolOfSelector: #m22) name equals: #catX.
+	self assert: (self t6 organization protocolOfSelector: #m22Alias) name equals: #catX.
+	self t6 organization classify: #m22 under: #catY.
+	self t6 organization classify: #m22Alias under: #catY.
+	self t2 organization classify: #m22 under: #catZ.
+	self assert: (self t6 organization protocolOfSelector: #m22) name equals: #catY.
+	self assert: (self t6 organization protocolOfSelector: #m22Alias) name equals: #catY.
+	self t1 compile: 'mA' classified: #catA.
+	self assert: (self t4 organization protocolOfSelector: #mA) name equals: #catA.
+	self t1 organization classify: #mA under: #cat1.
+	self assert: (self t4 organization hasProtocol: #catA) not
 ]

--- a/src/TraitsV2-Tests/TraitPureBehaviorTest.class.st
+++ b/src/TraitsV2-Tests/TraitPureBehaviorTest.class.st
@@ -139,17 +139,6 @@ TraitPureBehaviorTest >> testLocalSelectors [
 	self assert: (self c2 localSelectors includesAll: #(#foo #bar ))
 ]
 
-{ #category : #tests }
-TraitPureBehaviorTest >> testMethodCategoryReorganization [
-
-	self t1 compile: 'm1' classified: 'category1'.
-	self assert: (self t5 organization protocolNameOfElement: #m1) equals: #category1.
-	self assert: (self c2 organization protocolNameOfElement: #m1) equals: #category1.
-	self t1 organization classify: #m1 under: #category2.
-	self assert: (self t5 organization protocolNameOfElement: #m1) equals: #category2.
-	self assert: (self c2 organization protocolNameOfElement: #m1) equals: #category2
-]
-
 { #category : #'tests - applying trait composition' }
 TraitPureBehaviorTest >> testMethodClass [
 	"Test sharing of compiled methods between traits and their users. Methods are installed in exactly one behavior, however, the source pointers of methods are shared (unless sources or changes have been condensed). Verify	that methodClass properties are set correctly."
@@ -164,6 +153,17 @@ TraitPureBehaviorTest >> testMethodClass [
 	self deny: m1 identicalTo: m2.
 
 	self assert: m1 sourcePointer equals: m2 sourcePointer
+]
+
+{ #category : #tests }
+TraitPureBehaviorTest >> testMethodProtocolUpdate [
+
+	self t1 compile: 'm1' classified: 'category1'.
+	self assert: (self t5 organization protocolOfSelector: #m1) name equals: #category1.
+	self assert: (self c2 organization protocolOfSelector: #m1) name equals: #category1.
+	self t1 organization classify: #m1 under: #category2.
+	self assert: (self t5 organization protocolOfSelector: #m1) name equals: #category2.
+	self assert: (self c2 organization protocolOfSelector: #m1) name equals: #category2
 ]
 
 { #category : #'tests - applying trait composition' }

--- a/src/TraitsV2/TaAbstractComposition.class.st
+++ b/src/TraitsV2/TaAbstractComposition.class.st
@@ -155,9 +155,9 @@ TaAbstractComposition >> compile: selector into: aClass [
 		ifTrue: [ self saveSourceCode: sourceCode ofMethod: newMethod ]
 		ifFalse: [ newMethod setSourcePointer: method sourcePointer ].
 
-	aClass addSelectorSilently: selector withMethod: newMethod.
-
 	aClass organization silentlyClassify: selector under: (self categoryOfMethod: method withSelector: method selector).
+
+	aClass addSelectorSilently: selector withMethod: newMethod.
 
 	aClass >> selector propertyAt: #traitSource put: traitDefining.
 	^ true
@@ -213,11 +213,9 @@ TaAbstractComposition >> copyMethod: aSelector into: aClass replacing: replacing
 
 	newMethod setSourcePointer: aCompiledMethod sourcePointer.
 
-	aClass addSelectorSilently: aSelector withMethod: newMethod.
-
 	aClass organization silentlyClassify: aSelector under: aCompiledMethod protocol.
 
-	aClass organization removeEmptyProtocols.
+	aClass addSelectorSilently: aSelector withMethod: newMethod.
 
 	aClass >> aSelector propertyAt: #traitSource put: traitDefining.
 


### PR DESCRIPTION
#protocolNameOfElement: is a method containing a hack that I aim to remove. I updated some trait API and tests to use #protofolOfSelector: instead and keep pushing this hack removal.

Some bonus:
- categorize methods before adding them to the method dictionary to be sure we do not rely on the hack of #protocolNameOfElement: (this will help me with future improvements and should not change the behavior)
- Remove a useless #removeEmptyProtocols because nor #silentlyClassify:under: is taking care of removing the empty protocols
- Rename some category into protocol