### PR TITLE
#sourceCodeAt: should return nil in failure case

### DIFF
--- a/src/OpalCompiler-Core/IRMethod.class.st
+++ b/src/OpalCompiler-Core/IRMethod.class.st
@@ -125,9 +125,9 @@ IRMethod >> compiledBlock: scope [
 { #category : #translating }
 IRMethod >> compiledMethod [
 
-	^compiledMethod
+	^ compiledMethod 
 		ifNil: [self generate ]
-		ifNotNil: [compiledMethod]
+
 ]
 
 { #category : #translating }

--- a/src/System-Sources/SourceFileArray.class.st
+++ b/src/System-Sources/SourceFileArray.class.st
@@ -370,7 +370,7 @@ SourceFileArray >> sourceCodeAt: sourcePointer [
 	^ self
 		readStreamAt: sourcePointer
 		ifPresent: [ :stream | (ChunkReadStream on: stream) next ]
-		ifAbsent: [ '' ]
+		ifAbsent: [ nil ]
 ]
 
 { #category : #private }


### PR DESCRIPTION
we changed getSourceFromFile to return nil, but forgot that sourceCodeAt: in SourceFileArray returns '' in the failure case

Sadly not that easy to test 

In additon, simplify compiledMethod on IRMethod (not related, from a PR review)