### PR TITLE
Fix/filter

### DIFF
--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -5265,7 +5265,7 @@ Morph >> replaceSubmorph: oldMorph by: newMorph [
 Morph >> requestStopTextEditing [
 
 	"Used by a morph to request stop text edition capabilities.
-	The rendering backend can use this, for example, close the IME (input-method-editor).
+	The rendering backend uses this to stop all text input.
 	Use it in pair with requestTextEditingAt:
 
 	By default, propagate the request to the owner.

--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -1236,7 +1236,6 @@ RubAbstractTextArea >> keyboardFocusChange: aBoolean [
 			self showOverEditableTextCursor ]
 		ifFalse: [
 			self hasFocus: false.
-			self requestStopTextEditing.
 			editing = true ifTrue: [ editing := false ].
 			self hideOverEditableTextCursor ].
 	super keyboardFocusChange: aBoolean


### PR DESCRIPTION
Second iteration on fix #13214.

Nowadays, the fast table filter works the first time.
And as soon as the filter text box loses focus it does not work anymore.
This is because the system is disabling text events, and they are re-enabled when a text editor regains focus.