### PR TITLE
Clean blocks for announcement

### DIFF
--- a/doc/Announcements/Announcements.md
+++ b/doc/Announcements/Announcements.md
@@ -32,17 +32,17 @@ Announcement subclass: #GameLostAnnouncement
 	   
 ### Step 2 - Publishers and subscribers
 
-If an object wants to announce an event it needs someone to make the announcement to. This is typically an instance of class `Announcer` which acts as the mediator between the object that has to announce something (publisher) and one or many (anonymous) subscribers who are interested in the event.
+If an object wants to announce an event it needs someone to make the announcement to. This is typically an instance of class `Announcer` which acts as the mediator between the object that has to announce something (publisher) and one or many (subscriber) subscribers who are interested in the event.
 
 ```st
 | announcer |
 announcer := Announcer new.
-announcer announce: MyInterestingAnnouncement new
 ```
 
-Using `announce:` we can make an announcement - but since nobody is interested yet nothing will happen.
+#### Example 1 - Sending a message to the subscriber
 
-Lets add some consumers/subscribers. Subscribers just register on the Announcer instance to note that they are interested on a particular event/announcement: 
+For example, if anytime an interesting announcement is made we want to inform two consumers with a specific message. (Still nothing happens - we have to additionally make the announcement later).
+Subscribers just register on the Announcer instance to note that they are interested in a particular announcement (event): 
 
 ```st
 | announcer |
@@ -51,7 +51,7 @@ announcer when: MyInterestingAnnouncement send: #open to: Browser.
 announcer when: MyInterestingAnnouncement send: #inspect to: Smalltalk.    	
 ```
 
-So anytime an interesting announcement is made we want to inform the two consumers with a specific message. Still nothing happens - we have to additionally make the announcement:
+Then using `announce:` we can make an announcement.
 
 ```st
 | announcer |
@@ -63,25 +63,38 @@ announcer announce: MyInterestingAnnouncement new
 
 Note that the subscribers are decoupled from the original announcement publisher. They dont have to know each other. Decoupling is the key thing here ... subscribers can register for particular events/announcements and remain anonymous to the original publisher. 
 
-### Step 3 - More examples
 
-In Pharo there is a global called `World` pointing to the desktop morph. This world also has an announcer we can use to demonstrate the features of the framework:
+
+#### Example 2 - Executing a block closure
+
+There is another way to register subscriber using a block closure as action instead of sending a message to the subscriber.
+
+For example, if we want to show some text in the transcript when any interested announcement is raised:
 
 ```st
-World announcer 
-	when: WindowOpened 
-	send: #value 
-	to: [ Transcript show: 'A new window was opened';cr].
+| announcer |
+Transcript open.
+
+announcer := Announcer new.	
+announcer when: MyInterestingAnnouncement do: [ Transcript show: 'Interesting announcement appeared!' ] for: anObject.
+announcer announce: MyInterestingAnnouncement new
 ```
 
-So anytime a window is opened in the system a message is shown in the transcript:
+Note that when the announcement happends just the block closure is evaluated, subsccriber is not involved.
+Anyway, subscriber object is needed for others aspect of the framework API: unsubscribe, query subscriptors, etc. (See SubscriptionRegistry class for more information)
+
+
+#### Example 3 - Using global announcer
+
+In Pharo there is a global called `World` pointing to the desktop morph. This world also has an announcer we can use to demonstrate the features of the framework.
+
+In the next example, anytime a window is opened in the system a message is shown in the transcript:
 
 ```st
 Transcript open.
 	
 World announcer 
 	when: WindowOpened 
-	send: #value 
-	to: [ Transcript show: 'A new window was opened';cr].
+	do: [ Transcript show: 'A new window was opened';cr]
+	for: self.
 ```
-

--- a/src/Announcements-Core-Tests/AnnouncerSubscriberMockA.class.st
+++ b/src/Announcements-Core-Tests/AnnouncerSubscriberMockA.class.st
@@ -22,8 +22,6 @@ AnnouncerSubscriberMockA >> announcer: anAnnouncer [
 
 { #category : #events }
 AnnouncerSubscriberMockA >> registerEvents [
-	"We do not use constant blocks here, instead use a clean block.
-	Using Constant blocks with announcements makes no senese, as they do nothing."
 
-	self announcer when: AnnouncementMockA do: [ nil yourself ] for: self
+	self announcer when: AnnouncementMockA do: [ nil ] for: self
 ]

--- a/src/Announcements-Core-Tests/AnnouncerSubscriberMockA.class.st
+++ b/src/Announcements-Core-Tests/AnnouncerSubscriberMockA.class.st
@@ -22,10 +22,8 @@ AnnouncerSubscriberMockA >> announcer: anAnnouncer [
 
 { #category : #events }
 AnnouncerSubscriberMockA >> registerEvents [
-	"we do not use constant blocks here, instead use a clean block.
+	"We do not use constant blocks here, instead use a clean block.
+	Using Constant blocks with announcements makes no senese, as they do nothing."
 
-	Using Constant blocks with announcements makes no senese, as they do nothing.
-
-   For Clean Blocks, we have to the Announcments API as they  require to access the receiver of the home context, for clean blocks this has to be fixed, see https://github.com/pharo-project/pharo/issues/11220"
-	self announcer when: AnnouncementMockA do: [ :evt | nil yourself " something" ]
+	self announcer when: AnnouncementMockA do: [ nil yourself ] for: self
 ]

--- a/src/Announcements-Core-Tests/AnnouncerTest.class.st
+++ b/src/Announcements-Core-Tests/AnnouncerTest.class.st
@@ -68,7 +68,7 @@ AnnouncerTest >> testAnnounceInstance [
 AnnouncerTest >> testAnnounceWorkWithinExceptionHandlerBlocks [
 	|  found |
 
-	announcer when: Announcement do: [ found := true ].
+	announcer when: Announcement do: [ found := true ] for: self.
 
 	[ NotFound signal ]
 		on: NotFound
@@ -90,7 +90,7 @@ AnnouncerTest >> testAnnouncingReentrant [
 			bool := true.
 		announcer announce:  Announcement new. ]
 		ifTrue: [ ok := true ]
-	].
+	] for: self.
 
 	self should: [ announcer announce: Announcement new. ] notTakeMoreThan: 1 second.
 	self assert: ok
@@ -112,7 +112,7 @@ AnnouncerTest >> testNoArgBlock [
 
 	| counter |
 	counter := nil.
-	announcer when: AnnouncementMockA do: [ counter := 1 ].
+	announcer when: AnnouncementMockA do: [ counter := 1 ] for: self.
 	announcer announce: AnnouncementMockA new.
 	self assert: counter equals: 1
 ]
@@ -147,7 +147,7 @@ AnnouncerTest >> testPreparationAnnouncementDeliveryWhenNoSubscriptions [
 { #category : #'tests - subscribing' }
 AnnouncerTest >> testSubscribeBlock [
 	| announcement instance |
-	announcer when: AnnouncementMockA do: [ :ann | announcement := ann ].
+	announcer when: AnnouncementMockA do: [ :ann | announcement := ann ] for: self.
 	announcement := nil.
 	instance := announcer announce: AnnouncementMockA.
 	self assert: announcement equals: instance.
@@ -161,7 +161,8 @@ AnnouncerTest >> testSubscribeClassWithExclusion [
 	| announcement instance |
 	announcer
 		when: AnnouncementMockB - AnnouncementMockC
-		do: [ :ann | announcement := ann ].
+		do: [ :ann | announcement := ann ]
+		for: self.
 	announcement := nil.
 	instance := announcer announce: AnnouncementMockB.
 	self assert: announcement equals: instance.
@@ -175,7 +176,8 @@ AnnouncerTest >> testSubscribeOnSpecificAnnouncer [
 	| announcement instance |
 	announcer
 		when: (AnnouncementMockB where: [ :ann | ann parameter = #expectedParam ])
-		do: [ :ann | announcement := ann ].
+		do: [ :ann | announcement := ann ]
+		for: self.
 	announcement := nil.
 	instance := announcer announce: AnnouncementMockA.
 	self assert: announcement equals: nil.
@@ -214,7 +216,8 @@ AnnouncerTest >> testSubscribeSet [
 	| announcement instance |
 	announcer
 		when: AnnouncementMockA , AnnouncementMockC
-		do: [ :ann | announcement := ann ].
+		do: [ :ann | announcement := ann ]
+		for: self.
 	announcement := nil.
 	instance := announcer announce: AnnouncementMockA.
 	self assert: announcement equals: instance.
@@ -231,7 +234,8 @@ AnnouncerTest >> testSubscribeSetWithExclusion [
 	| announcement instance |
 	announcer
 		when: (AnnouncementMockA , AnnouncementMockB) - AnnouncementMockC
-		do: [ :ann | announcement := ann ].
+		do: [ :ann | announcement := ann ]
+		for: self.
 	announcement := nil.
 	instance := announcer announce: AnnouncementMockA.
 	self assert: announcement equals: instance.
@@ -250,7 +254,8 @@ AnnouncerTest >> testSubscribeSetWithExclusionOfMultipleAnnouncements [
 		when:
 			(AnnouncementMockA , AnnouncementMockB) - AnnouncementMockC
 				- AnnouncementMockA
-		do: [ :ann | announcement := ann ].
+		do: [ :ann | announcement := ann ]
+		for: self.
 	announcement := nil.
 	instance := announcer announce: AnnouncementMockA.
 	self assert: announcement isNil.
@@ -267,7 +272,8 @@ AnnouncerTest >> testSubscribeSetWithExclusionOfSetItem [
 	| announcement instance |
 	announcer
 		when: (AnnouncementMockA , AnnouncementMockC) - AnnouncementMockA
-		do: [ :ann | announcement := ann ].
+		do: [ :ann | announcement := ann ]
+		for: self.
 	announcement := nil.
 	instance := announcer announce: AnnouncementMockA.
 	self assert: announcement isNil.
@@ -279,7 +285,7 @@ AnnouncerTest >> testSubscribeSetWithExclusionOfSetItem [
 { #category : #'tests - subscribing' }
 AnnouncerTest >> testSubscribeSubclass [
 	| announcement instance |
-	announcer when: AnnouncementMockB do: [ :ann | announcement := ann ].
+	announcer when: AnnouncementMockB do: [ :ann | announcement := ann ] for: self.
 	announcement := nil.
 	instance := announcer announce: AnnouncementMockA.
 	self assert: announcement isNil.
@@ -335,7 +341,8 @@ AnnouncerTest >> testTwoArgBlock [
 	flag := false.
 	announcer
 		when: AnnouncementMockA
-		do: [ :ann :announcer2 | flag := announcer2 == announcer ].
+		do: [ :ann :announcer2 | flag := announcer2 == announcer ]
+		for: self.
 	announcer announce: AnnouncementMockA new.
 	self assert: flag
 ]

--- a/src/Announcements-Core-Tests/AnnouncerTest.class.st
+++ b/src/Announcements-Core-Tests/AnnouncerTest.class.st
@@ -35,18 +35,17 @@ AnnouncerTest >> setUp [
 
 { #category : #'tests - subscribers' }
 AnnouncerTest >> testAccessingSubscribers [
+
 	| subscribers |
 	subscribers := announcer subscriptionsForClass: self class.
 	self assert: subscribers size equals: 0.
 
-	"We do not use constant blocks here, instead use a clean block.
-	Using Constant blocks with announcements makes no senese, as they do nothing."
-	announcer when: AnnouncementMockA do: [ nil yourself ] for: self.
-	announcer when: AnnouncementMockB do: [ nil yourself ] for: self.
+	announcer when: AnnouncementMockA do: [ nil ] for: self.
+	announcer when: AnnouncementMockB do: [ nil ] for: self.
 	subscribers := announcer subscriptionsForClass: self class.
 	self assert: subscribers size equals: 2.
 
-	subscribers do: [ :subscriber |	announcer unsubscribe: subscriber ].
+	subscribers do: [ :subscriber | announcer unsubscribe: subscriber ].
 
 	subscribers := announcer subscriptionsForClass: self class.
 	self assert: subscribers size equals: 0
@@ -98,9 +97,8 @@ AnnouncerTest >> testAnnouncingReentrant [
 
 { #category : #'tests - subscribers' }
 AnnouncerTest >> testHandleSubscriberClass [
-	"We do not use constant blocks here, instead use a clean block.
-	Using Constant blocks with announcements makes no senese, as they do nothing."
-	announcer when: AnnouncementMockA do: [ nil yourself ] for: self.
+
+	announcer when: AnnouncementMockA do: [ nil ] for: self.
 
 	self assert: (announcer handleSubscriberClass: self class).
 	self deny: (announcer handleSubscriberClass: AnnouncementMockA)

--- a/src/Announcements-Core-Tests/AnnouncerTest.class.st
+++ b/src/Announcements-Core-Tests/AnnouncerTest.class.st
@@ -39,13 +39,10 @@ AnnouncerTest >> testAccessingSubscribers [
 	subscribers := announcer subscriptionsForClass: self class.
 	self assert: subscribers size equals: 0.
 
-	"we do not use constant blocks here, instead use a clean block.
-
-	Using Constant blocks with announcements makes no senese, as they do nothing.
-
-   For Clean Blocks, we have to the Announcments API as they  require to access the receiver of the home context, for clean blocks this has to be fixed, see https://github.com/pharo-project/pharo/issues/11220"
-	announcer when: AnnouncementMockA do: [ nil yourself ]."1"
-	announcer when: AnnouncementMockB do: [ nil yourself ]."2"
+	"We do not use constant blocks here, instead use a clean block.
+	Using Constant blocks with announcements makes no senese, as they do nothing."
+	announcer when: AnnouncementMockA do: [ nil yourself ] for: self.
+	announcer when: AnnouncementMockB do: [ nil yourself ] for: self.
 	subscribers := announcer subscriptionsForClass: self class.
 	self assert: subscribers size equals: 2.
 
@@ -101,12 +98,10 @@ AnnouncerTest >> testAnnouncingReentrant [
 
 { #category : #'tests - subscribers' }
 AnnouncerTest >> testHandleSubscriberClass [
-	"we do not use constant blocks here, instead use a clean block.
+	"We do not use constant blocks here, instead use a clean block.
+	Using Constant blocks with announcements makes no senese, as they do nothing."
+	announcer when: AnnouncementMockA do: [ nil yourself ] for: self.
 
-	Using Constant blocks with announcements makes no senese, as they do nothing.
-
-   For Clean Blocks, we have to the Announcments API as they  require to access the receiver of the home context, for clean blocks this has to be fixed, see https://github.com/pharo-project/pharo/issues/11220"
-	announcer when: AnnouncementMockA do: [ nil yourself ].
 	self assert: (announcer handleSubscriberClass: self class).
 	self deny: (announcer handleSubscriberClass: AnnouncementMockA)
 ]
@@ -310,8 +305,8 @@ AnnouncerTest >> testSubscribersForClass [
 
 	self assert: announcer numberOfSubscriptions > 0.
 	subscribers := announcer subscriptionsForClass: AnnouncerSubscriberMockA.
-	self assert: subscribers size equals: 2.
 	"AnnouncerSubscriberMockB inherits AnnouncerSubscriberMockA"
+	self assert: subscribers size equals: 2.
 	subscribers := announcer subscriptionsForClass: AnnouncerSubscriberMockB.
 	self assert: subscribers size equals: 1.
 	subscribers := announcer subscriptionsForClass: self class.
@@ -348,7 +343,7 @@ AnnouncerTest >> testTwoArgBlock [
 { #category : #'tests - unsubscribing' }
 AnnouncerTest >> testUnsubscribeBlock [
 	| announcement |
-	announcer when: AnnouncementMockA do: [ :ann | announcement := ann ].
+	announcer when: AnnouncementMockA do: [ :ann | announcement := ann ] for: self.
 	announcer unsubscribe: self.
 	announcement := nil.
 	announcer announce: AnnouncementMockA new.
@@ -371,7 +366,8 @@ AnnouncerTest >> testUnsubscribeSet [
 	| announcement |
 	announcer
 		when: AnnouncementMockA , AnnouncementMockB
-		do: [ :ann | announcement := ann ].
+		do: [ :ann | announcement := ann ]
+		for: self.
 	announcer unsubscribe: self.
 	announcement := nil.
 	announcer announce: AnnouncementMockA new.

--- a/src/Announcements-Core-Tests/WeakAnnouncerTest.class.st
+++ b/src/Announcements-Core-Tests/WeakAnnouncerTest.class.st
@@ -88,7 +88,7 @@ WeakAnnouncerTest >> testNoWeakBlock [
 
 	counter := 0.
 
-	(announcer when: AnnouncementMockA do: [ :ann | counter := counter + 1 ]) makeWeak.
+	(announcer when: AnnouncementMockA do: [ :ann | counter := counter + 1 ] for: self) makeWeak.
 
 	Smalltalk garbageCollect.
 	announcer announce: AnnouncementMockA.

--- a/src/Announcements-Core/Announcer.class.st
+++ b/src/Announcements-Core/Announcer.class.st
@@ -88,22 +88,16 @@ Announcer >> weak [
 	^ WeakSubscriptionBuilder on: self
 ]
 
-{ #category : #'registration api' }
-Announcer >> when: anAnnouncementClass do: aValuable [
-	"Declare that when anAnnouncementClass is raised, aValuable is executed.  Pay attention that such method as well as #when:do: should not be used on weak announcer since the block holds the receiver and more strongly."
-
-	^ registry add: (
-		AnnouncementSubscription new
-			announcer: self;
-			announcementClass: anAnnouncementClass;
-			valuable: aValuable)
-]
-
 { #category : #subscription }
 Announcer >> when: anAnnouncementClass do: aValuable for: aSubscriber [
 	"Declare that when anAnnouncementClass is raised, aValuable is executed and define the subscriber."
 
-    ^ (self when: anAnnouncementClass do: aValuable) subscriber: aSubscriber; yourself
+	^ registry add: (AnnouncementSubscription new
+			   announcer: self;
+			   announcementClass: anAnnouncementClass;
+			   action: aValuable;
+			   subscriber: aSubscriber;
+			   yourself)
 ]
 
 { #category : #'registration api' }

--- a/src/Announcements-Core/Announcer.class.st
+++ b/src/Announcements-Core/Announcer.class.st
@@ -111,4 +111,5 @@ Announcer >> when: anAnnouncementClass send: aSelector to: anObject [
 	^ self
 		when: anAnnouncementClass
 		do: (MessageSend receiver: anObject selector: aSelector)
+		for: anObject
 ]

--- a/src/Announcements-Core/Announcer.class.st
+++ b/src/Announcements-Core/Announcer.class.st
@@ -90,7 +90,8 @@ Announcer >> weak [
 
 { #category : #subscription }
 Announcer >> when: anAnnouncementClass do: aValuable for: aSubscriber [
-	"Declare that when anAnnouncementClass is raised, aValuable is executed and define the subscriber."
+	"Subscribe aSubscriber to announcements of anAnnouncementClass class. 
+	 When the announcement is raised, aValuable is executed."
 
 	^ registry add: (AnnouncementSubscription new
 			   announcer: self;

--- a/src/Announcements-Core/WeakAnnouncementSubscription.class.st
+++ b/src/Announcements-Core/WeakAnnouncementSubscription.class.st
@@ -12,7 +12,9 @@ Class {
 	#name : #WeakAnnouncementSubscription,
 	#superclass : #AbstractAnnouncementSubscription,
 	#type : #weak,
-	#instVars : [ 'next' ],
+	#instVars : [
+		'next'
+	],
 	#category : #'Announcements-Core-Subscription'
 }
 

--- a/src/Announcements-Core/WeakSubscriptionBuilder.class.st
+++ b/src/Announcements-Core/WeakSubscriptionBuilder.class.st
@@ -33,16 +33,20 @@ WeakSubscriptionBuilder >> weak [
 ]
 
 { #category : #'wrapped protocol' }
-WeakSubscriptionBuilder >> when: anAnnouncementClass do: aValuable [
+WeakSubscriptionBuilder >> when: anAnnouncementClass do: aValuable for: receiver [
 	"Do not use this message on weak announcer because it does not work. The block will hold strongly the receiver and more.
 	 We need ephemerons for that'"
+	
 	"aValuable isBlock ifTrue: [
 		self error: 'Do not use this message on weak and block because it does not work. We need ephemerons for that']."
+	
 	^	announcer basicSubscribe: (
 			WeakAnnouncementSubscription new
 				announcer: announcer;
 				announcementClass: anAnnouncementClass;
-				valuable: aValuable)
+				action: aValuable;
+				subscriber: receiver; 
+				yourself) 
 ]
 
 { #category : #'wrapped protocol' }

--- a/src/Announcements-Core/WeakSubscriptionBuilder.class.st
+++ b/src/Announcements-Core/WeakSubscriptionBuilder.class.st
@@ -51,5 +51,9 @@ WeakSubscriptionBuilder >> when: anAnnouncementClass do: aValuable for: receiver
 
 { #category : #'wrapped protocol' }
 WeakSubscriptionBuilder >> when: anAnnouncementClass send: aSelector to: anObject [
-	^ self when: anAnnouncementClass do: (WeakMessageSend receiver: anObject selector: aSelector)
+
+	^ self
+		  when: anAnnouncementClass
+		  do: (WeakMessageSend receiver: anObject selector: aSelector)
+		  for: anObject
 ]

--- a/src/Clap-Commands-Pharo/ClapTestRunner.class.st
+++ b/src/Clap-Commands-Pharo/ClapTestRunner.class.st
@@ -47,9 +47,11 @@ ClapTestRunner >> execute [
 	self outputStreamDo: [ :out |
 		self suite
 			when: TestAnnouncement
-			do: [ :ann | out nextPutAll: ann test name; lf ];
+			do: [ :ann | out nextPutAll: ann test name; lf ]
+			for: self;
 			when: TestCaseAnnouncement
-			do: [ :ann | out space; space; nextPutAll: ann testSelector; lf ].
+			do: [ :ann | out space; space; nextPutAll: ann testSelector; lf ]
+			for: self.
 		result := [ self suite run ]
 			ensure: [ self suite unsubscribe: TestAnnouncement ].
 		out print: result; lf

--- a/src/Deprecated11/Announcer.extension.st
+++ b/src/Deprecated11/Announcer.extension.st
@@ -8,8 +8,7 @@ Announcer >> when: anAnnouncementClass do: aValuable [
 		self error:
 			'You must specify a subscriber object for this subscription. Please use #when:do:for: method.' ].
 
-	subscriberForDeprecation := thisContext sender receiver
-	                            = aValuable receiver
+	subscriberForDeprecation := thisContext sender receiver = aValuable receiver
 		                            ifTrue: [ 'self' ]
 		                            ifFalse: [ '`@arg2 receiver' ].
 	self
@@ -17,7 +16,9 @@ Announcer >> when: anAnnouncementClass do: aValuable [
 			'Since there are some block closures (Clean and Constant) without a receiver, the API of announcements was changed to send the subscriber explicitly. 
 			We are deprecating this method because it was asking for the receiver of the block to use it as the subscriber.'
 		transformWith: '`@receiver when: `@arg1 do: `@arg2'
-			->	('`@receiver when: `@arg1 do: `@arg2 for: ', subscriberForDeprecation).
+			->
+			('`@receiver when: `@arg1 do: `@arg2 for: '
+			 , subscriberForDeprecation).
 
 	self when: anAnnouncementClass do: aValuable for: aValuable receiver
 ]

--- a/src/Deprecated11/Announcer.extension.st
+++ b/src/Deprecated11/Announcer.extension.st
@@ -1,0 +1,23 @@
+Extension { #name : #Announcer }
+
+{ #category : #'*Deprecated11' }
+Announcer >> when: anAnnouncementClass do: aValuable [
+
+	| subscriberForDeprecation |
+	aValuable receiver ifNil: [
+		self error:
+			'You must specify a subscriber object for this subscription. Please use #when:do:for: method.' ].
+
+	subscriberForDeprecation := thisContext sender receiver
+	                            = aValuable receiver
+		                            ifTrue: [ 'self' ]
+		                            ifFalse: [ '`@arg2 receiver' ].
+	self
+		deprecated:
+			'Since there are some block closures (Clean and Constant) without a receiver, the API of announcements was changed to send the subscriber explicitly. 
+			We are deprecating this method because it was asking for the receiver of the block to use it as the subscriber.'
+		transformWith: '`@receiver when: `@arg1 do: `@arg2'
+			->	('`@receiver when: `@arg1 do: `@arg2 for: ', subscriberForDeprecation).
+
+	self when: anAnnouncementClass do: aValuable for: aValuable receiver
+]

--- a/src/Deprecated11/ToolRegistry.extension.st
+++ b/src/Deprecated11/ToolRegistry.extension.st
@@ -1,0 +1,53 @@
+Extension { #name : #ToolRegistry }
+
+{ #category : #'*Deprecated11' }
+ToolRegistry >> whenToolRegistered: aBlock [
+
+	| subscriberForDeprecation |
+	aBlock receiver ifNil: [
+		self error:
+			'You must specify a subscriber object for this subscription. Please use #whenToolRegisteredDo:for: method.' ].
+
+	subscriberForDeprecation := thisContext sender receiver
+	                            = aBlock receiver
+		                            ifTrue: [ 'self' ]
+		                            ifFalse: [ '`@arg1 receiver' ].
+	self
+		deprecated:
+			'Since there are some block closures (Clean and Constant) without a receiver, the API of announcements was changed to send the subscriber explicitly. 
+			We are deprecating this method because it was asking for the receiver of the block to use it as the subscriber.'
+		transformWith: '`@receiver whenToolRegistered: `@arg1'
+			-> ('`@receiver whenToolRegisteredDo: `@arg1 for: '
+				 , subscriberForDeprecation).
+
+	self announcer weak
+		when: ToolRegistryToolRegistered
+		do: aBlock
+		for: aBlock receiver
+]
+
+{ #category : #'*Deprecated11' }
+ToolRegistry >> whenToolUnregistered: aBlock [
+
+	| subscriberForDeprecation |
+	aBlock receiver ifNil: [
+		self error:
+			'You must specify a subscriber object for this subscription. Please use #whenToolUnregisteredDo:for: method.' ].
+
+	subscriberForDeprecation := thisContext sender receiver
+	                            = aBlock receiver
+		                            ifTrue: [ 'self' ]
+		                            ifFalse: [ '`@arg1 receiver' ].
+	self
+		deprecated:
+			'Since there are some block closures (Clean and Constant) without a receiver, the API of announcements was changed to send the subscriber explicitly. 
+			We are deprecating this method because it was asking for the receiver of the block to use it as the subscriber.'
+		transformWith: '`@receiver whenToolUnregistered: `@arg1'
+			-> ('`@receiver whenToolUnregisteredDo: `@arg1 for: '
+				 , subscriberForDeprecation).
+
+	self announcer weak
+		when: ToolRegistryToolUnregistered
+		do: aBlock
+		for: aBlock receiver
+]

--- a/src/Deprecated11/package.st
+++ b/src/Deprecated11/package.st
@@ -1,1 +1,0 @@
-Package { #name : #Deprecated11 }

--- a/src/Deprecated12/Announcer.extension.st
+++ b/src/Deprecated12/Announcer.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #Announcer }
 
-{ #category : #'*Deprecated11' }
+{ #category : #'*Deprecated12' }
 Announcer >> when: anAnnouncementClass do: aValuable [
 
 	| subscriberForDeprecation |

--- a/src/Deprecated12/ToolRegistry.extension.st
+++ b/src/Deprecated12/ToolRegistry.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #ToolRegistry }
 
-{ #category : #'*Deprecated11' }
+{ #category : #'*Deprecated12' }
 ToolRegistry >> whenToolRegistered: aBlock [
 
 	| subscriberForDeprecation |
@@ -26,7 +26,7 @@ ToolRegistry >> whenToolRegistered: aBlock [
 		for: aBlock receiver
 ]
 
-{ #category : #'*Deprecated11' }
+{ #category : #'*Deprecated12' }
 ToolRegistry >> whenToolUnregistered: aBlock [
 
 	| subscriberForDeprecation |

--- a/src/Deprecated12/WeakSubscriptionBuilder.extension.st
+++ b/src/Deprecated12/WeakSubscriptionBuilder.extension.st
@@ -1,0 +1,24 @@
+Extension { #name : #WeakSubscriptionBuilder }
+
+{ #category : #'*Deprecated12' }
+WeakSubscriptionBuilder >> when: anAnnouncementClass do: aValuable [
+
+	| subscriberForDeprecation |
+	aValuable receiver ifNil: [
+		self error:
+			'You must specify a subscriber object for this subscription. Please use #when:do:for: method.' ].
+
+	subscriberForDeprecation := thisContext sender receiver = aValuable receiver
+		                            ifTrue: [ 'self' ]
+		                            ifFalse: [ '`@arg2 receiver' ].
+	self
+		deprecated:
+			'Since there are some block closures (Clean and Constant) without a receiver, the API of announcements was changed to send the subscriber explicitly. 
+			We are deprecating this method because it was asking for the receiver of the block to use it as the subscriber.'
+		transformWith: '`@receiver when: `@arg1 do: `@arg2'
+			->
+			('`@receiver when: `@arg1 do: `@arg2 for: '
+			 , subscriberForDeprecation).
+
+	self when: anAnnouncementClass do: aValuable for: aValuable receiver
+]

--- a/src/DrTests-CommentsToTests/DTCommentToTestPlugin.class.st
+++ b/src/DrTests-CommentsToTests/DTCommentToTestPlugin.class.st
@@ -73,7 +73,8 @@ DTCommentToTestPlugin >> runSuite: aTestSuite withResult: aResult [
 	aTestSuite
 		when: TestAnnouncement
 		do: [ :testAnnouncement |
-			self announceStatusChanged: ('Running test {1}.' format: {testAnnouncement test asString}) ].
+			self announceStatusChanged: ('Running test {1}.' format: {testAnnouncement test asString}) ]
+		for: self.
 	[ aTestSuite run: aResult ]
 		ensure: [ aTestSuite unsubscribe: TestAnnouncement ]
 ]

--- a/src/DrTests-TestCoverage/DTTestCoveragePlugin.class.st
+++ b/src/DrTests-TestCoverage/DTTestCoveragePlugin.class.st
@@ -91,7 +91,8 @@ DTTestCoveragePlugin >> runForConfiguration: aDTpluginConfiguration [
 DTTestCoveragePlugin >> runSuite: aTestSuite withResult: aResult [
 
 	aTestSuite when: TestAnnouncement do: [ :testAnnouncement |
-		self announceStatusChanged: ('Running test {1}.' format: { testAnnouncement test asString }) ].
+		self announceStatusChanged: ('Running test {1}.' format: { testAnnouncement test asString }) ]
+	for: self.
 	[ aTestSuite run: aResult ] ensure: [
 		aTestSuite unsubscribe: TestAnnouncement ]
 ]

--- a/src/DrTests-TestsRunner/DTTestsRunnerPlugin.class.st
+++ b/src/DrTests-TestsRunner/DTTestsRunnerPlugin.class.st
@@ -124,7 +124,8 @@ DTTestsRunnerPlugin >> runSuite: aTestSuite withResult: aResult [
 		self flag: #TODO. "Dirty"
 		testAnnouncement test class = TestSuite ifTrue: [
 			self announceStatusChanged:
-				('Running test {1}.' format: { testAnnouncement test name }) ] ].
+				('Running test {1}.' format: { testAnnouncement test name }) ] ]
+		for: self.
 	[ aResult mergeWith: (aTestSuite run) ] ensure: [
 		aTestSuite unsubscribe: TestAnnouncement ]
 ]

--- a/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
@@ -54,8 +54,11 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassRaisesClassRepackaged
 
 	| XPackage YPackage class ann |
 	ann := nil.
-	SystemAnnouncer uniqueInstance weak when: ClassRepackaged do: [ :a | ann := a ].
-
+	SystemAnnouncer uniqueInstance
+		when: ClassRepackaged do: [ :a |
+			ann := a.
+		] for: self.
+	
 	self addXCategory.
 	self addYCategory.
 	XPackage := self organizer packageNamed: #XXXXX.

--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -235,11 +235,12 @@ RPackageMCSynchronisationTest >> testNotRepackagedAnnouncementWhenModifyMethodBy
 
 	| ann class firstPackage secondPackage |
 	ann := nil.
-	SystemAnnouncer uniqueInstance weak when: MethodRepackaged do: [ :a | ann := a ].
-
-	self addXYCategory.
-	firstPackage := self organizer packageNamed: #XXXXX.
-	secondPackage := self organizer packageNamed: #YYYYY.
+	SystemAnnouncer uniqueInstance
+		when: MethodRepackaged do: [ :a | ann := a ] for: self.
+	
+	self addXYCategory. 
+	firstPackage := self organizer  packageNamed: #XXXXX.
+	secondPackage := self organizer  packageNamed: #YYYYY.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
 
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
@@ -256,11 +257,12 @@ RPackageMCSynchronisationTest >> testNotRepackagedAnnouncementWhenMovingClassicC
 
 	| ann class firstPackage secondPackage |
 	ann := nil.
-	SystemAnnouncer uniqueInstance weak when: MethodRepackaged do: [ :a | ann := a ].
-
-	self addXYCategory.
-	firstPackage := self organizer packageNamed: #XXXXX.
-	secondPackage := self organizer packageNamed: #YYYYY.
+	SystemAnnouncer uniqueInstance
+		when: MethodRepackaged do: [ :a | ann := a ] for: self.
+	
+	self addXYCategory. 
+	firstPackage := self organizer  packageNamed: #XXXXX.
+	secondPackage := self organizer  packageNamed: #YYYYY.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
 
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic'.
@@ -277,11 +279,12 @@ RPackageMCSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMov
 
 	| ann class firstPackage secondPackage |
 	ann := nil.
-	SystemAnnouncer uniqueInstance weak when: MethodRepackaged do: [ :a | ann := a ].
-
-	self addXYCategory.
-	firstPackage := self organizer packageNamed: #XXXXX.
-	secondPackage := self organizer packageNamed: #YYYYY.
+	SystemAnnouncer uniqueInstance
+		when: MethodRepackaged do: [ :a | ann := a ] for: self.
+	
+	self addXYCategory. 
+	firstPackage := self organizer  packageNamed: #XXXXX.
+	secondPackage := self organizer  packageNamed: #YYYYY.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
 
@@ -303,10 +306,11 @@ RPackageMCSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMov
 
 	| ann class firstPackage secondPackage thirdPackage |
 	ann := nil.
-	SystemAnnouncer uniqueInstance weak when: MethodRepackaged do: [ :a | ann := a ].
-
-	self addXYZCategory.
-	firstPackage := self organizer packageNamed: #XXXXX.
+	SystemAnnouncer uniqueInstance
+		when: MethodRepackaged do: [ :a | ann := a ] for: self.
+	
+	self addXYZCategory. 
+	firstPackage := self organizer  packageNamed: #XXXXX.
 	secondPackage := self organizer packageNamed: #YYYYY.
 	thirdPackage := self organizer packageNamed: #ZZZZZ.
 
@@ -326,11 +330,12 @@ RPackageMCSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMov
 
 	| ann class firstPackage secondPackage |
 	ann := nil.
-	SystemAnnouncer uniqueInstance weak when: MethodRepackaged do: [ :a | ann := a ].
-
-	self addXYCategory.
-	firstPackage := self organizer packageNamed: #XXXXX.
-	secondPackage := self organizer packageNamed: #YYYYY.
+	SystemAnnouncer uniqueInstance
+		when: MethodRepackaged do: [ :a | ann := a ] for: self.
+	
+	self addXYCategory. 
+	firstPackage := self organizer  packageNamed: #XXXXX.
+	secondPackage := self organizer  packageNamed: #YYYYY.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -4479,7 +4479,11 @@ Morph >> okayToRotateEasily [
 
 { #category : #announcements }
 Morph >> onAnnouncement: anAnnouncement do: aValuable [
-	self announcer when: anAnnouncement do: aValuable
+
+	self announcer
+		when: anAnnouncement
+		do: aValuable
+		for: aValuable receiver
 ]
 
 { #category : #announcements }

--- a/src/Morphic-Tests/WindowAnnouncementTest.class.st
+++ b/src/Morphic-Tests/WindowAnnouncementTest.class.st
@@ -19,7 +19,7 @@ WindowAnnouncementTest >> testCollapsing [
 	window := SystemWindow labelled: 'foo'.
 	t := 0.
 	window openInWorld.
-	window announcer when: WindowCollapsed do: [ :ann | t := t + 1 ].
+	window announcer when: WindowCollapsed do: [ :ann | t := t + 1 ] for: self.
 	self assert: t equals: 0.
 	window collapse.
 	self assert: t equals: 1
@@ -38,7 +38,8 @@ WindowAnnouncementTest >> testMoving [
 		when: WindowMoved
 		do: [ :ann |
 			t := t + 1.
-			event := ann ].
+			event := ann ]
+		for: self.
 
 	self assert: t equals: 0.
 	self assert: event isNil.
@@ -66,7 +67,7 @@ WindowAnnouncementTest >> testResizing [
 	t := 0.
 	window openInWorld.
 	oldBounds := window bounds.
-	window announcer when: WindowResizing do: [ :ann | t := t + 1 ].
+	window announcer when: WindowResizing do: [ :ann | t := t + 1 ] for: self.
 	self assert: t equals: 0.
 	window extent: 50 @ 60.
 	newBounds := window bounds.
@@ -79,7 +80,7 @@ WindowAnnouncementTest >> testResizingClosing [
 	window := SystemWindow labelled: 'foo'.
 	coll := OrderedCollection new.
 	window openInWorld.
-	window announcer when: WindowAnnouncement do: [ :ann | coll add: ann ].
+	window announcer when: WindowAnnouncement do: [ :ann | coll add: ann ] for: self.
 	self assertEmpty: coll.
 	window minimizeOrRestore.
 
@@ -113,7 +114,7 @@ WindowAnnouncementTest >> testScrolling [
 	window addMorph: pane fullFrame: LayoutFrame identity.
 	t := 0 @ 0.
 	window openInWorld.
-	window announcer when: WindowScrolling do: [ :ann | t := t + ann step ].
+	window announcer when: WindowScrolling do: [ :ann | t := t + ann step ] for: self.
 	pane hScrollBarValue: 10.
 	pane vScrollBarValue: 5.
 
@@ -127,12 +128,12 @@ WindowAnnouncementTest >> testScrolling [
 WindowAnnouncementTest >> testWindowCreation [
 	| t oldBounds newBounds |
 	t := 0.
-	self currentWorld announcer when: WindowResizing do: [ :ann | t := t + 1 ].
+	self currentWorld announcer when: WindowResizing do: [ :ann | t := t + 1 ] for: self.
 	window := SystemWindow labelled: 'foo'.
 	window setProperty: #minimumExtent toValue: 1 @ 1.
 	window openInWorld.
 	oldBounds := window bounds.
-	window announcer when: WindowResizing do: [ :ann | t := t + 1 ].
+	window announcer when: WindowResizing do: [ :ann | t := t + 1 ] for: self.
 	self assert: t equals: 0.
 	window extent: 50 @ 60.
 	newBounds := window bounds.
@@ -147,12 +148,14 @@ WindowAnnouncementTest >> testWindowCreationAndDeletion [
 		when: WindowOpened
 		do: [ :ann |
 			t := t + 1.
-			newWindowCreated := ann window ].
+			newWindowCreated := ann window ]
+		for: self.
 	self currentWorld announcer
 		when: WindowClosed
 		do: [ :ann |
 			t := t + 10.
-			newWindowCreated := ann window ].
+			newWindowCreated := ann window ]
+		for: self.
 	window := SystemWindow labelled: 'foo'.
 	window openInWorld.
 
@@ -174,7 +177,8 @@ WindowAnnouncementTest >> testWindowLabelling [
 		when: WindowLabelled
 		do: [ :ann |
 			win := ann window.
-			labels := labels copyWith: ann label ].
+			labels := labels copyWith: ann label ]
+		for: self.
 	window := SystemWindow labelled: 'foo'.
 	window openInWorld.
 	self assert: win equals: window.

--- a/src/NewValueHolder-Core/CollectionValueHolder.class.st
+++ b/src/NewValueHolder-Core/CollectionValueHolder.class.st
@@ -333,12 +333,12 @@ CollectionValueHolder >> valueRemoved: oldValue [
 CollectionValueHolder >> whenAddedDo: aBlock [
 	"Culled block [ :newValue :announcement | ]"
 
-	self announcer when: ValueAdded do: [ :ann | aBlock cull: ann newValue cull: ann ]
+	self announcer when: ValueAdded do: [ :ann | aBlock cull: ann newValue cull: ann ] for: self
 ]
 
 { #category : #announcements }
 CollectionValueHolder >> whenRemovedDo: aBlock [
 	"Culled block [ :oldValue :announcement | ]"
 
-	self announcer when: ValueRemoved do: [ :ann | aBlock cull: ann oldValue cull: ann ]
+	self announcer when: ValueRemoved do: [ :ann | aBlock cull: ann oldValue cull: ann ] for: self
 ]

--- a/src/OSWindow-Core/GLMOSWindowWorldMorph.class.st
+++ b/src/OSWindow-Core/GLMOSWindowWorldMorph.class.st
@@ -44,5 +44,11 @@ GLMOSWindowWorldMorph >> toolbarBox: anObject [
 { #category : #announcing }
 GLMOSWindowWorldMorph >> when: anAnnouncement do: aBlock [
 	"TODO: REMOVE THIS METHOD"
-	^ self announcer when: anAnnouncement do: aBlock for: self
+	^ self announcer when: anAnnouncement do: aBlock for: aBlock receiver
+]
+
+{ #category : #announcing }
+GLMOSWindowWorldMorph >> when: anAnnouncement do: aBlock for: subscriber [
+
+	^ self announcer when: anAnnouncement do: aBlock for: subscriber
 ]

--- a/src/OSWindow-Core/GLMOSWindowWorldMorph.class.st
+++ b/src/OSWindow-Core/GLMOSWindowWorldMorph.class.st
@@ -43,5 +43,6 @@ GLMOSWindowWorldMorph >> toolbarBox: anObject [
 
 { #category : #announcing }
 GLMOSWindowWorldMorph >> when: anAnnouncement do: aBlock [
-	^ self announcer when: anAnnouncement do: aBlock
+	"TODO: REMOVE THIS METHOD"
+	^ self announcer when: anAnnouncement do: aBlock for: self
 ]

--- a/src/Ombu-Tests/OmSessionStoreTest.class.st
+++ b/src/Ombu-Tests/OmSessionStoreTest.class.st
@@ -92,7 +92,8 @@ OmSessionStoreTest >> testResetWithStoreNamedDoesAnnounce [
 
 	store announcer
 		when: OmSessionStoreUpdated
-		do: [ :announcement | wasAnnounced := true ].
+		do: [ :announcement | wasAnnounced := true ]
+		for: self.
 
 	[ store resetWithStoreNamed: 'new' ]
 		ensure: [ store announcer unsubscribe: self ].

--- a/src/Polymorph-Widgets/MorphicUIManager.class.st
+++ b/src/Polymorph-Widgets/MorphicUIManager.class.st
@@ -314,7 +314,7 @@ MorphicUIManager >> edit: aText label: labelString accept: aBlockOrNil [
 				setText: aText asString;
 				yourself.
 	aBlockOrNil ifNotNil: [
-		pane announcer when: RubTextAcceptRequest do: [:aRequest | aBlockOrNil value: aRequest morph text]].
+		pane announcer when: RubTextAcceptRequest do: [:aRequest | aBlockOrNil value: aRequest morph text] for: self].
 	window addMorph: pane frame: (0@0 corner: 1@1); openInWorld.
 	^ window
 ]

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -34,7 +34,7 @@ RPackageTest >> testAddClass [
 	package1 := (RPackage named: #Test1) register.
 	done := 0.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG'.
-	SystemAnnouncer uniqueInstance weak when: ClassRecategorized do: [ done := done + 1].
+	SystemAnnouncer uniqueInstance when: ClassRecategorized do: [ done := done + 1] for: self.
 
 	self assert: (package1 includesClass: class).
 	self assert: (package1 classTagNamed: #TAG ifAbsent: [ nil ]) notNil.

--- a/src/Ring-Tests-Core/RGAnnouncementsTest.class.st
+++ b/src/Ring-Tests-Core/RGAnnouncementsTest.class.st
@@ -4,6 +4,32 @@ Class {
 	#category : #'Ring-Tests-Core'
 }
 
+{ #category : #announcements }
+RGAnnouncementsTest >> installAnnouncementsFor: aRGClass in: aRGEnvironment when: anEvent [
+
+	| announcements |
+	announcements := OrderedCollection new.
+	aRGEnvironment announcer
+		when: anEvent
+		do: [ :announcement |
+			announcement classAffected == aRGClass ifTrue: [
+				announcements add: announcement ] ]
+		for: self.
+	^ announcements
+]
+
+{ #category : #announcements }
+RGAnnouncementsTest >> installAnnouncementsIn: aRGEnvironment when: anEvent [
+
+	| announcements |
+	announcements := OrderedCollection new.
+	aRGEnvironment announcer
+		when: anEvent
+		do: [ :announcement | announcements add: announcement ]
+		for: self.
+	^ announcements
+]
+
 { #category : #tests }
 RGAnnouncementsTest >> testAnnouncementTimestamps [
 
@@ -11,8 +37,7 @@ RGAnnouncementsTest >> testAnnouncementTimestamps [
 
 	start := DateAndTime now.
 	env := RGEnvironment new.
-	announcements := OrderedCollection new.
-	env announcer when: ClassAdded do: [ :announcement | announcements add: announcement ].
+	announcements := self installAnnouncementsIn: env when: ClassAdded. 
 
 	env ensureClassNamed: #SomeClass1.
 	10 milliSeconds wait.
@@ -35,8 +60,7 @@ RGAnnouncementsTest >> testAnnouncerSuspending [
 	| env announcements behavior |
 
 	env := RGEnvironment new.
-	announcements := OrderedCollection new.
-	env announcer when: ClassAdded do: [ :announcement | announcements add: announcement ].
+	announcements := self installAnnouncementsIn: env when: ClassAdded. 
 
 	env announcer suspendAllWhile: [
 		behavior := env ensureClassNamed: #SomeClass.].
@@ -50,8 +74,7 @@ RGAnnouncementsTest >> testAnnouncerSuspendingWithStoring [
 	| env announcements behavior stored |
 
 	env := RGEnvironment new.
-	announcements := OrderedCollection new.
-	env announcer when: ClassAdded do: [ :announcement | announcements add: announcement ].
+	announcements := self installAnnouncementsIn: env when: ClassAdded. 
 
 	stored := env announcer suspendAllWhileStoring: [
 		behavior := env ensureClassNamed: #SomeClass.].
@@ -65,8 +88,7 @@ RGAnnouncementsTest >> testAnnouncerSuspendingWithStoring [
 RGAnnouncementsTest >> testBehaviorAdded [
 	| env announcements behavior |
 	env := RGEnvironment new.
-	announcements := OrderedCollection new.
-	env announcer when: ClassAdded do: [ :announcement | announcements add: announcement ].
+	announcements := self installAnnouncementsIn: env when: ClassAdded. 
 
 	behavior := env ensureClassNamed: #SomeClass.
 	self assert: announcements size equals: 4.
@@ -81,8 +103,7 @@ RGAnnouncementsTest >> testBehaviorCommentModified [
 	| env announcements behavior |
 
 	env := RGEnvironment new.
-	announcements := OrderedCollection new.
-	env announcer when: ClassCommented do: [ :announcement | announcements add: announcement ].
+	announcements := self installAnnouncementsIn: env when: ClassCommented. 
 
 	behavior := env ensureClassNamed: #SomeClass.
 	self assert: announcements isEmpty.
@@ -102,10 +123,7 @@ RGAnnouncementsTest >> testBehaviorDefinitionModifiedForCategory [
 	env := RGEnvironment new.
 	class := env ensureClassNamed: #SomeClass.
 
-	announcements := OrderedCollection new.
-	env announcer when: ClassModifiedClassDefinition do: [ :announcement |
-		(announcement classAffected == class) ifTrue: [
-			announcements add: announcement]].
+	announcements := self installAnnouncementsFor: class in: env when: ClassModifiedClassDefinition. 
 
 	class category: 'some category'.
 	self assert: announcements size equals: 1
@@ -123,10 +141,7 @@ RGAnnouncementsTest >> testBehaviorDefinitionModifiedForSuperclass [
 
 	class superclass: superclass1.
 
-	announcements := OrderedCollection new.
-	env announcer when: ClassModifiedClassDefinition do: [ :announcement |
-		(announcement classAffected == class) ifTrue: [
-			announcements add: announcement]].
+	announcements := self installAnnouncementsFor: class in: env when: ClassModifiedClassDefinition.  
 
 	class name: #NewName.
 	self assert: announcements size equals: 1.
@@ -147,10 +162,7 @@ RGAnnouncementsTest >> testBehaviorParentRenamed [
 
 	class superclass: superclass.
 
-	announcements := OrderedCollection new.
-	env announcer when: ClassParentRenamed do: [ :announcement |
-		(announcement classAffected == class) ifTrue: [
-			announcements add: announcement]].
+	announcements := self installAnnouncementsFor: class in: env when: ClassParentRenamed. 
 
 	class name: #NewName.
 	self assert: announcements size equals: 0.
@@ -162,8 +174,7 @@ RGAnnouncementsTest >> testBehaviorParentRenamed [
 RGAnnouncementsTest >> testDirectAnnouncement [
 	| def announcements |
 	def := RGBehavior new.
-	announcements := OrderedCollection new.
-	def environment announcer when: ClassAdded do: [ :announcement | announcements add: announcement ].
+	announcements := self installAnnouncementsIn: def when: ClassAdded. 
 	def announce: (ClassAdded class: def category: nil).
 
 	self assert: announcements size equals: 1.
@@ -176,8 +187,7 @@ RGAnnouncementsTest >> testUnsubscribe [
 	| env announcements behavior |
 
 	env := RGEnvironment new.
-	announcements := OrderedCollection new.
-	env announcer when: ClassAdded do: [ :announcement | announcements add: announcement ].
+	announcements := self installAnnouncementsIn: env when: ClassAdded. 
 	env announcer unsubscribe: self.
 
 	behavior := env ensureClassNamed: #SomeClass.

--- a/src/SUnit-Core/TestSuite.class.st
+++ b/src/SUnit-Core/TestSuite.class.st
@@ -179,6 +179,7 @@ TestSuite >> unsubscribe: anAnnouncementClass [
 ]
 
 { #category : #announcements }
-TestSuite >> when: aAnnouncement do: aBlock [
-	self testSuiteAnnouncer when: aAnnouncement do: aBlock
+TestSuite >> when: aAnnouncement do: aBlock for: aSubscriber [
+
+	self testSuiteAnnouncer when: aAnnouncement do: aBlock for: aSubscriber
 ]

--- a/src/SUnit-Tests/TestCaseTest.class.st
+++ b/src/SUnit-Tests/TestCaseTest.class.st
@@ -17,7 +17,7 @@ TestCaseTest >> testAnnouncement [
 	self deny: unitTest shouldAnnounce.
 	self deny: unitTest new shouldAnnounce.
 
-	unitTest announcer when: TestCaseAnnouncement do: [ :ann | collection add: ann ].
+	unitTest announcer when: TestCaseAnnouncement do: [ :ann | collection add: ann ] for: self.
 
 	self assert: unitTest shouldAnnounce.
 	self assert: unitTest new shouldAnnounce.

--- a/src/SUnit-UI/TestRunner.class.st
+++ b/src/SUnit-UI/TestRunner.class.st
@@ -488,7 +488,7 @@ TestRunner >> excludeClassesNotUnderTestFrom: methods [
 { #category : #processing }
 TestRunner >> executeSuite: aTestSuite as: aBlock [
 " The block defines how to interact with the suite. run with a result or debug "
-	aTestSuite when:TestAnnouncement do: self updateUIBlock.
+	aTestSuite when:TestAnnouncement do: self updateUIBlock for: self.
 	[ aBlock cull: aTestSuite cull: result  ] ensure: [
 		aTestSuite unsubscribe:TestAnnouncement.
 	]

--- a/src/System-Announcements-Tests/SystemAnnouncerTest.class.st
+++ b/src/System-Announcements-Tests/SystemAnnouncerTest.class.st
@@ -32,10 +32,12 @@ SystemAnnouncerTest >> testProtocolAdded [
 	| pass class classReorganized protocolAdded |
 	pass := false.
 
-	SystemAnnouncer uniqueInstance when: ProtocolAdded do: [ :ann |
-		pass := true.
-		classReorganized := ann classReorganized.
-		protocolAdded := ann protocol ].
+	SystemAnnouncer uniqueInstance
+		when: ProtocolAdded do: [ :ann |
+			pass := true.
+			classReorganized := ann classReorganized.
+			protocolAdded := ann protocol ]
+		for: self.
 
 	class := factory newClass.
 	class organization addProtocol: 'shiny-new-category'.
@@ -51,10 +53,12 @@ SystemAnnouncerTest >> testProtocolRemoved [
 	| pass class classRemoved protocolRemoved |
 	pass := false.
 
-	SystemAnnouncer uniqueInstance when: ProtocolRemoved do: [ :ann |
-		pass := true.
-		classRemoved := ann classReorganized.
-		protocolRemoved := ann protocol ].
+	SystemAnnouncer uniqueInstance
+		when: ProtocolRemoved do: [ :ann |
+			pass := true.
+			classRemoved := ann classReorganized.
+			protocolRemoved := ann protocol ]
+		for: self.
 
 	class := factory newClass.
 	class organization addProtocol: 'shiny-new-category'.
@@ -74,7 +78,7 @@ SystemAnnouncerTest >> testSuspendAllWhile [
 
 	SystemAnnouncer uniqueInstance suspendAllWhile: [
 		SystemAnnouncer uniqueInstance
-			when: ClassAdded do: [ value := value + 1 ];
+			when: ClassAdded do: [ value := value + 1 ] for: self;
 			announce: ClassAdded ].
 
 	self assert: value equals: 42. "The answer is always 42 :)"

--- a/src/System-Model/Model.class.st
+++ b/src/System-Model/Model.class.st
@@ -239,12 +239,12 @@ Model >> whenChangedDo: aBlock [
 
 	| block |
 	block := [ :announcement :ann |
-	aBlock
-		cull: announcement newValue
-		cull: announcement oldValue
-		cull: announcement
-		cull: ann ].
-	self announcer when: ValueChanged do: block
+	         aBlock
+		         cull: announcement newValue
+		         cull: announcement oldValue
+		         cull: announcement
+		         cull: ann ].
+	self announcer when: ValueChanged do: block for: aBlock receiver
 ]
 
 { #category : #announcing }

--- a/src/Tool-Registry/ToolRegistry.class.st
+++ b/src/Tool-Registry/ToolRegistry.class.st
@@ -229,15 +229,20 @@ ToolRegistry >> using: aToolName do: aBlock [
 ]
 
 { #category : #announcer }
-ToolRegistry >> whenToolRegistered: aBlock [
+ToolRegistry >> whenToolRegisteredDo: aBlock for: aSubscriber [
 
-	self flag: #TOCHECK. "Use self or get receiver by param?"
-	self announcer weak when: ToolRegistryToolRegistered do: aBlock for: self
+	self announcer weak
+		when: ToolRegistryToolRegistered
+		do: aBlock
+		for: aSubscriber
+		
 ]
 
 { #category : #announcer }
-ToolRegistry >> whenToolUnregistered: aBlock [
+ToolRegistry >> whenToolUnregisteredDo: aBlock for: aSubscriber [
 
-	self flag: #TOCHECK. "Use self or get receiver by param?"
-	self announcer weak when: ToolRegistryToolUnregistered do: aBlock for: self
+	self announcer weak
+		when: ToolRegistryToolUnregistered
+		do: aBlock
+		for: aSubscriber
 ]

--- a/src/Tool-Registry/ToolRegistry.class.st
+++ b/src/Tool-Registry/ToolRegistry.class.st
@@ -231,11 +231,13 @@ ToolRegistry >> using: aToolName do: aBlock [
 { #category : #announcer }
 ToolRegistry >> whenToolRegistered: aBlock [
 
-	self announcer weak when: ToolRegistryToolRegistered do: aBlock
+	self flag: #TOCHECK. "Use self or get receiver by param?"
+	self announcer weak when: ToolRegistryToolRegistered do: aBlock for: self
 ]
 
 { #category : #announcer }
 ToolRegistry >> whenToolUnregistered: aBlock [
 
-	self announcer weak when: ToolRegistryToolUnregistered do: aBlock
+	self flag: #TOCHECK. "Use self or get receiver by param?"
+	self announcer weak when: ToolRegistryToolUnregistered do: aBlock for: self
 ]

--- a/src/Zinc-HTTP/ZnLogEvent.class.st
+++ b/src/Zinc-HTTP/ZnLogEvent.class.st
@@ -38,7 +38,7 @@ ZnLogEvent class >> initialize [
 { #category : #convenience }
 ZnLogEvent class >> logToTranscript [
 	self stopLoggingToTranscript.
-	^ self announcer when: ZnLogEvent do: [ :event | self crTrace: event ]
+	^ self announcer when: ZnLogEvent do: [ :event | self crTrace: event ] for: self
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
_Come from PR https://github.com/pharo-project/pharo/pull/13270_
Fix https://github.com/pharo-project/pharo/issues/11220

The current Announcement API assumes as the subscriber _the object where the action block is created_. 

https://github.com/pharo-project/pharo/blob/d9f862003a88bfc9a17ff12ab7a11abf1fe154a9/src/Announcements-Core/AnnouncementSubscription.class.st#L99-L104

This has two main issues:
1. Could exist cases where the action block is not created in the "subscriber object" (some utils method chain).
2. It does **not work with blocks without context** (like clean or constant blocks) 😢 

So, I changed the Announcement API to send the subscriber object explicitly. Changing all
```
when: event do: action
```
by
```
when: event do: action for: subscriber
```
using a smart deprecation rewrite 👀 