### PR TITLE
Debugger fixes

### DIFF
--- a/src/Debugger-Model/DebugContext.class.st
+++ b/src/Debugger-Model/DebugContext.class.st
@@ -48,23 +48,27 @@ DebugContext class >> forContext: aContext [
 DebugContext >> blockNotFoundDialog: aMethod with: aText [
 
 	| message result newMethod |
-
 	message := 'Method for block not found on stack, can''t edit and continue'.
 
 	"shouldn't edit doits"
-	aMethod selector isDoIt
-		ifTrue: [ ^ self inform: message ].
+	aMethod selector isDoIt ifTrue: [ ^ self inform: message ].
 
-	result := UIManager default
-						confirm: message
-						trueChoice: 'Compile and Browse'
-						falseChoice: 'Cancel'.
+	result := self
+		          confirm: message
+		          trueChoice: 'Compile and Browse'
+		          falseChoice: 'Cancel'.
 
 	"possible return values are true | false | nil"
 	result ifFalse: [ ^ self ].
 
 	newMethod := self recompileCurrentMethodTo: aText notifying: nil.
-	newMethod ifNotNil: [newMethod browse]
+	newMethod ifNotNil: [ self browseMethod: newMethod ]
+]
+
+{ #category : #private }
+DebugContext >> browseMethod: aMethod [
+
+	aMethod browse
 ]
 
 { #category : #private }
@@ -75,6 +79,15 @@ DebugContext >> checkSelectorUnchanged: aSelector [
 	unchanged
 		ifFalse: [ self inform: 'can''t change selector' ].
 	^ unchanged
+]
+
+{ #category : #'ui requests' }
+DebugContext >> confirm: message trueChoice: trueChoice falseChoice: falseChoice [
+
+	^ UIManager default
+		confirm: message
+		trueChoice: trueChoice
+		falseChoice: falseChoice
 ]
 
 { #category : #private }

--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -307,7 +307,7 @@ DebugSession >> recompileMethodTo: text inContext: aContext notifying: aNotifyer
 	| newMethod recompilationContext canRewind |
 	canRewind := (self isContextPostMortem: self interruptedContext) not.
 	"Do not try to recompile a doIt method"
-	aContext method isDoIt
+	aContext homeMethod isDoIt
 		ifTrue: [ UIManager default alert:  'Can not modify a DoIt-Method.'.
 			^ false ].
 	(recompilationContext := (self createModelForContext: aContext) locateClosureHomeWithContent: text) ifNil: [ ^ false ].


### PR DESCRIPTION
Avoid DNU when redefining block in do it
Extract methods to allow redefinitions in newtools (newtools PR coming)

Required by https://github.com/pharo-spec/NewTools/pull/513