### PR TITLE
Remove usage of #protocolNameOfElement:ifAbsent: in traits

### DIFF
--- a/src/TraitsV2/TraitedClass.class.st
+++ b/src/TraitsV2/TraitedClass.class.st
@@ -252,19 +252,19 @@ TraitedClass >> rebuildMethodDictionary [
 
 { #category : #categories }
 TraitedClass >> recategorizeSelector: selector from: oldProtocolName to: newProtocolName [
-
-	| original |
 	"When a method is recategorized I have to classify the method, but also recategorize the aliases pointing to it"
-	original := self organization protocolNameOfElement: selector ifAbsent: [ ^ self ].
+
+	| originalProtocol |
+	originalProtocol := (self organization protocolOfSelector: selector) ifNil: [ ^ self ].
 
 	"If it is nil is because it is a removal. It will removed when the method is removed."
 	newProtocolName ifNil: [ ^ self ].
 
-	original = oldProtocolName ifTrue: [ self organization classify: selector under: newProtocolName ].
+	originalProtocol name = oldProtocolName ifTrue: [ self organization classify: selector under: newProtocolName ].
 
-	(self traitComposition reverseAlias: selector) do: [ :e |
-		self recategorizeSelector: e from: oldProtocolName to: newProtocolName.
-		self notifyOfRecategorizedSelector: e from: oldProtocolName to: newProtocolName ].
+	(self traitComposition reverseAlias: selector) do: [ :selectorAlias |
+		self recategorizeSelector: selectorAlias from: oldProtocolName to: newProtocolName.
+		self notifyOfRecategorizedSelector: selectorAlias from: oldProtocolName to: newProtocolName ].
 
 	self organization removeEmptyProtocols
 ]

--- a/src/TraitsV2/TraitedMetaclass.class.st
+++ b/src/TraitsV2/TraitedMetaclass.class.st
@@ -269,19 +269,19 @@ TraitedMetaclass >> rebuildMethodDictionary [
 
 { #category : #categories }
 TraitedMetaclass >> recategorizeSelector: selector from: oldProtocolName to: newProtocolName [
-
-	| original |
 	"When a method is recategorized I have to classify the method, but also recategorize the aliases pointing to it"
-	original := self organization protocolNameOfElement: selector ifAbsent: [ ^ self ].
+
+	| originalProtocol |
+	originalProtocol := (self organization protocolOfSelector: selector) ifNil: [ ^ self ].
 
 	"If it is nil is because it is a removal. It will removed when the method is removed."
 	newProtocolName ifNil: [ ^ self ].
 
-	original = oldProtocolName ifTrue: [ self organization classify: selector under: newProtocolName ].
+	originalProtocol name = oldProtocolName ifTrue: [ self organization classify: selector under: newProtocolName ].
 
-	(self traitComposition reverseAlias: selector) do: [ :e |
-		self recategorizeSelector: e from: oldProtocolName to: newProtocolName.
-		self notifyOfRecategorizedSelector: e from: oldProtocolName to: newProtocolName ].
+	(self traitComposition reverseAlias: selector) do: [ :selectorAlias |
+		self recategorizeSelector: selectorAlias from: oldProtocolName to: newProtocolName.
+		self notifyOfRecategorizedSelector: selectorAlias from: oldProtocolName to: newProtocolName ].
 
 	self organization removeEmptyProtocols
 ]


### PR DESCRIPTION
#protocolNameOfElement:ifAbsent: has a hack I am trying to remove from the system in it. This removes the users to replace it by a method that does not have this hack. 

Let's see if the CI accepts this.

I also cleaned some temporary names