### PR TITLE
Simplify classify:under:

### DIFF
--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -46,7 +46,7 @@ ClassOrganization >> allMethodSelectors [
 { #category : #classification }
 ClassOrganization >> classify: selector under: aProtocol [
 
-	| oldProtocolName forceNotify oldProtocol protocolName |
+	| oldProtocolName protocolName |
 	"The next section deserve more cleanings.
 	
 	Some code was added to make it possible to classify giving a real protocol.
@@ -58,10 +58,8 @@ ClassOrganization >> classify: selector under: aProtocol [
 			                aProtocol isString
 				                ifTrue: [ aProtocol ]
 				                ifFalse: [ aProtocol name ] ].
-	forceNotify := (self includesSelector: selector) not.
 	oldProtocolName := self protocolNameOfElement: selector.
-	(forceNotify or: [ oldProtocolName ~= protocolName or: [ protocolName ~= Protocol unclassified ] ]) ifFalse: [ ^ self ].
-	oldProtocol := self protocolOfSelector: selector.
+	((self includesSelector: selector) and: [ oldProtocolName = protocolName = Protocol unclassified ]) ifTrue: [ ^ self ].
 
 	self silentlyClassify: selector under: protocolName.
 	oldProtocolName ifNotNil: [ self notifyOfChangedSelector: selector from: oldProtocolName to: protocolName ]

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -59,7 +59,7 @@ ClassOrganization >> classify: selector under: aProtocol [
 				                ifTrue: [ aProtocol ]
 				                ifFalse: [ aProtocol name ] ].
 	oldProtocolName := self protocolNameOfElement: selector.
-	((self includesSelector: selector) and: [ oldProtocolName = protocolName = Protocol unclassified ]) ifTrue: [ ^ self ].
+	((self includesSelector: selector) and: [ oldProtocolName = protocolName and: [ protocolName = Protocol unclassified ] ]) ifTrue: [ ^ self ].
 
 	self silentlyClassify: selector under: protocolName.
 	oldProtocolName ifNotNil: [ self notifyOfChangedSelector: selector from: oldProtocolName to: protocolName ]


### PR DESCRIPTION
This is one of the last method of ClassOrganization to improve to manage nils well and deal with real protocols.  I already tried to improve it but it causes troubles in the release tests. Here is a simple simplifcation of the method as a first step to improve it.