### PR TITLE
Remove ClassOrganization>>#protocolNameOfElement:ifAbsent:

### DIFF
--- a/src/Deprecated12/ClassOrganization.extension.st
+++ b/src/Deprecated12/ClassOrganization.extension.st
@@ -32,9 +32,9 @@ ClassOrganization >> categoryOfElement: aSelector [
 ClassOrganization >> categoryOfElement: aSelector ifAbsent: aBlock [
 
 	self
-		deprecated: 'Use #protocolNameOfElement:ifAbsent: instead.'
-		transformWith: '`@rcv categoryOfElement: `@arg1 ifAbsent: `@arg2' -> '`@rcv protocolNameOfElement: `@arg1 ifAbsent: `@arg2'.
-	^ self protocolNameOfElement: aSelector ifAbsent: aBlock
+		deprecated: 'Use #protocolNameOfElement: instead.'
+		transformWith: '`@rcv categoryOfElement: `@arg1 ifAbsent: `@arg2' -> '(`@rcv protocolNameOfElement: `@arg1) ifNil: `@arg2'.
+	^ (self protocolNameOfElement: aSelector) ifNil: aBlock
 ]
 
 { #category : #'*Deprecated12' }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -169,14 +169,11 @@ ClassOrganization >> printOn: aStream [
 { #category : #accessing }
 ClassOrganization >> protocolNameOfElement: aSelector [
 
-	^ self protocolNameOfElement: aSelector ifAbsent: nil
-]
-
-{ #category : #accessing }
-ClassOrganization >> protocolNameOfElement: aSelector ifAbsent: aBlock [
-
 	^ (self protocolOfSelector: aSelector)
-		  ifNil: [ (organizedClass includesSelector: aSelector) ifTrue: [ Protocol unclassified ] ifFalse: [ aBlock value ] ]
+		  ifNil: [
+			  (organizedClass includesSelector: aSelector)
+				  ifTrue: [ Protocol unclassified ]
+				  ifFalse: [ nil ] ]
 		  ifNotNil: [ :protocol | protocol name ]
 ]
 

--- a/src/Refactoring-Environment/RBBrowserEnvironment.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironment.class.st
@@ -877,8 +877,11 @@ RBBrowserEnvironment >> whichCategoryIncludes: aClassName [
 
 { #category : #accessing }
 RBBrowserEnvironment >> whichProtocolIncludes: aSelector in: aClass [
+	"CyrilFerlicot: We should check if it is not better to return a protocol instead of a protocol name here and adapt the clients."
 
-	^ (aClass organization protocolOfSelector: aSelector) ifNil: [ Protocol unclassified ]
+	^ (aClass organization protocolOfSelector: aSelector)
+		  ifNotNil: [ :protocol | protocol name ]
+		  ifNil: [ Protocol unclassified ]
 ]
 
 { #category : #environments }

--- a/src/Refactoring-Environment/RBBrowserEnvironment.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironment.class.st
@@ -878,7 +878,7 @@ RBBrowserEnvironment >> whichCategoryIncludes: aClassName [
 { #category : #accessing }
 RBBrowserEnvironment >> whichProtocolIncludes: aSelector in: aClass [
 
-	^ aClass organization protocolNameOfElement: aSelector ifAbsent: [ Protocol unclassified ]
+	^ (aClass organization protocolOfSelector: aSelector) ifNil: [ Protocol unclassified ]
 ]
 
 { #category : #environments }


### PR DESCRIPTION
ClassOrganization>>#protocolNameOfElement:ifAbsent: has some problems
- "Element" is pretty vague
- We are trying to use more protocol instances instead of protocol instances names (now we have #protocolOfSelector: that we prefer use)
- It has a hack that I am trying to remover where it returns Protocol unclassified when a method is in a class but not in a protocol, and I am trying to fix our system to not have this case anymore

This removes the last user and remove the method updating the original deprected method. Next on the list is #protocolNameOfElement: