### PR TITLE
Cleanup-optionInlineRepeat-is-default 

### DIFF
--- a/src/Collections-Streams/Stream.class.st
+++ b/src/Collections-Streams/Stream.class.st
@@ -135,8 +135,6 @@ Stream >> next: anInteger [
 
 { #category : #accessing }
 Stream >> next: anInteger put: anObject [
-	<compilerOptions: #(+ optionInlineTimesRepeat)>
-
 	"Make anObject be the next anInteger number of objects accessible by the
 	receiver. Answer anObject."
 

--- a/src/Flashback-Decompiler-Tests/FBDExamples.class.st
+++ b/src/Flashback-Decompiler-Tests/FBDExamples.class.st
@@ -979,8 +979,6 @@ FBDExamples >> examplePushBigArray [
 
 { #category : #'examples - loops' }
 FBDExamples >> exampleRepeatEffect [
-	<sampleInstance>
-	<compilerOptions: #(+ #optionInlineRepeat)>
 
 	| i |
 	i := 1.
@@ -992,8 +990,6 @@ FBDExamples >> exampleRepeatEffect [
 
 { #category : #'examples - loops' }
 FBDExamples >> exampleRepeatValue [
-	<sampleInstance>
-	<compilerOptions: #(+ #optionInlineRepeat)>
 
 	| i |
 	i := 1.

--- a/src/OpalCompiler-Tests/OCOpalExamples.class.st
+++ b/src/OpalCompiler-Tests/OCOpalExamples.class.st
@@ -463,7 +463,6 @@ OCOpalExamples >> examplePushTemporaryVariable [
 
 { #category : #'examples - blocks-optimized' }
 OCOpalExamples >> exampleRepeatEffect [
-	<compilerOptions: #(+ #optionInlineRepeat)>
 	| i |
 	i := 1.
 	[
@@ -474,7 +473,6 @@ OCOpalExamples >> exampleRepeatEffect [
 
 { #category : #'examples - blocks-optimized' }
 OCOpalExamples >> exampleRepeatValue [
-	<compilerOptions: #(+ #optionInlineRepeat)>
 	| i |
 	i := 1.
 	^ [


### PR DESCRIPTION
optionInlineRepeat and optionInlineTimesRepeat are now enabled by default, we can do a little cleanup from before when they were not