### PR TITLE
MethodMapTest-use-Compiler

### DIFF
--- a/src/OpalCompiler-Tests/MethodMapTest.class.st
+++ b/src/OpalCompiler-Tests/MethodMapTest.class.st
@@ -6,16 +6,10 @@ Class {
 
 { #category : #utilities }
 MethodMapTest >> compileAndRunExample: aSelector [
-	| cm |
-
-	cm := self compileMethod:  MethodMapExamples>>aSelector.
-	^cm valueWithReceiver:  MethodMapExamples new arguments: #()
-]
-
-{ #category : #utilities }
-MethodMapTest >> compileMethod: aMethod [
-
-	^ aMethod parseTree generateMethod sourcePointer: aMethod sourcePointer
+	| oldMethod recompiledMethod |
+	oldMethod := MethodMapExamples>>aSelector.
+	recompiledMethod := oldMethod methodClass compiler compile: oldMethod sourceCode.
+	^recompiledMethod valueWithReceiver: MethodMapExamples new
 ]
 
 { #category : #'tests - ast mapping' }


### PR DESCRIPTION
change #compileAndRunExample: to use the compiler instead of #generateMethod