### PR TITLE
Do not reclassify already classified method

### DIFF
--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -85,6 +85,39 @@ ClassOrganizationTest >> testClassifyUnder [
 ]
 
 { #category : #tests }
+ClassOrganizationTest >> testClassifyUnderUnclassified [
+	"Ensure unclassified is acting as any other protocol because that was not the case in the past."
+
+	"Set the base for the test"
+	self assertCollection: self organization protocolNames hasSameElements: #( #empty #one ).
+
+	"Lets create a new protocol via classification"
+	self organization classify: #king under: Protocol unclassified.
+	self organization classify: #luz under: Protocol unclassified.
+
+	self assertCollection: self organization protocolNames hasSameElements: {#empty. #one. Protocol unclassified }.
+	self assertCollection: (self organization protocolNamed: Protocol unclassified) methodSelectors hasSameElements: #( #king #luz ).
+	
+	"This should do nothing."
+	self organization classify: #luz under: Protocol unclassified.
+
+	self assertCollection: self organization protocolNames hasSameElements: {#empty. #one. Protocol unclassified }.
+	self assertCollection: (self organization protocolNamed: Protocol unclassified) methodSelectors hasSameElements: #( #king #luz ).
+
+	"Now we move a method from unclassified to another protocol."
+	self organization classify: #luz under: #one.
+
+	self assertCollection: self organization protocolNames hasSameElements: {#empty. #one. Protocol unclassified }.
+	self assertCollection: (self organization protocolNamed: Protocol unclassified) methodSelectors hasSameElements: #( #king ).
+	
+	"Now we move back to unclassified."
+	self organization classify: #luz under: Protocol unclassified.
+
+	self assertCollection: self organization protocolNames hasSameElements: {#empty. #one. Protocol unclassified }.
+	self assertCollection: (self organization protocolNamed: Protocol unclassified) methodSelectors hasSameElements: #( #king #luz )
+]
+
+{ #category : #tests }
 ClassOrganizationTest >> testClassifyUnderWithNil [
 	"Set the base for the test"
 	| unclassified|

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -59,7 +59,7 @@ ClassOrganization >> classify: selector under: aProtocol [
 				                ifTrue: [ aProtocol ]
 				                ifFalse: [ aProtocol name ] ].
 	oldProtocolName := self protocolNameOfElement: selector.
-	((self includesSelector: selector) and: [ oldProtocolName = protocolName and: [ protocolName = Protocol unclassified ] ]) ifTrue: [ ^ self ].
+	((self includesSelector: selector) and: [ oldProtocolName = protocolName ]) ifTrue: [ ^ self ].
 
 	self silentlyClassify: selector under: protocolName.
 	oldProtocolName ifNotNil: [ self notifyOfChangedSelector: selector from: oldProtocolName to: protocolName ]


### PR DESCRIPTION
Currently the ClassOrganization has a guard to not reclassify a method if it is already in a protocol and the old and new protocol are the unclassified one.  I don't know why we would do that only in the case a protocol is unclassified. IMO as soon as the old and new protocols are the same we should get in the guard clause.

Doing tiny PR because this part of the system is currently really fragile. 