### PR TITLE
Code Completion: multiple fixes on replacements annoying bugs

### DIFF
--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -326,6 +326,10 @@ CompletionEngine >> replaceTokenInEditorWith: aString [
 	"Try to correctly replace the current token in the word.
 	The code editor should be able to do it by himself"
 	wordEnd := (self editor nextWord: self editor caret - 1).
+	"Do not insert an aditional space if there is already one"
+	(aString last = $  and: [
+		wordEnd <= self editor text size and: [
+			(self editor text at: wordEnd) = $ ]]) ifTrue: [ wordEnd := wordEnd + 1 ].
 	"If the returned index is the size of the text that means that the caret is at the end of the text and there is no more word after, so add 1 to the index to be out of range to select the entierely word because of the selectInvisiblyFrom:to: remove 1 just after to be at the end of then final word"
 	wordEnd > self editor text size ifTrue:[ wordEnd := wordEnd + 1 ].
 

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -336,13 +336,7 @@ CompletionEngine >> replaceTokenInEditorWith: aString [
 		to: wordEnd - 1.
 	old := self editor selection.
 
-	( old size >= aString size )
-		ifTrue:[
-				self editor replaceSelectionWith: aString. ]
-		ifFalse: [
-				self editor selectInvisiblyFrom: wordEnd	to: wordEnd - 1.
-				rest := aString asString copyFrom: old size + 1 to: aString size.
-				self editor replaceSelectionWith: rest ].
+	self editor replaceSelectionWith: aString.
 
 	offset := NECPreferences spaceAfterCompletion
 		ifTrue: [ 1 ]

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -70,7 +70,7 @@ CompletionEngine >> completionToken [
 { #category : #replacement }
 CompletionEngine >> completionTokenStart [
 	"This is the position in the editor where the completion token starts"
-	^ self editor previousWord: self editor caret - 1
+	^ self editor previousWord: self editor caret
 ]
 
 { #category : #accessing }
@@ -333,7 +333,7 @@ CompletionEngine >> replaceTokenInEditorWith: aString [
 	"If the returned index is the size of the text that means that the caret is at the end of the text and there is no more word after, so add 1 to the index to be out of range to select the entierely word because of the selectInvisiblyFrom:to: remove 1 just after to be at the end of then final word"
 	wordEnd > self editor text size ifTrue:[ wordEnd := wordEnd + 1 ].
 
-	wordStart := self editor previousWord: (self editor caret - 1).
+	wordStart := self editor previousWord: self editor caret.
 
 	self editor
 		selectInvisiblyFrom: wordStart

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -322,7 +322,7 @@ CompletionEngine >> replaceTokenInEditorWith: aString [
 	After replacing, set the caret after the first keyword.
 	The completion context uses this API to insert text into the text editor"
 
-	| wordEnd old positionAfterFirstKeyword offset firstKeyword wordStart rest |
+	| wordEnd old positionAfterFirstKeyword offset firstKeyword wordStart |
 	"Try to correctly replace the current token in the word.
 	The code editor should be able to do it by himself"
 	wordEnd := (self editor nextWord: self editor caret - 1).

--- a/src/NECompletion-Tests/CompletionEngineTest.class.st
+++ b/src/NECompletion-Tests/CompletionEngineTest.class.st
@@ -123,6 +123,44 @@ CompletionEngineTest >> tearDown [
 ]
 
 { #category : #'tests - keyboard' }
+CompletionEngineTest >> testCompletionOnFirstLetter [
+
+	| text |
+	text := 'self foo baz'.
+
+	self
+		setEditorText: text;
+		selectAt: 'self f' size + 1.
+
+	editor textArea openInWorld.
+	controller openMenu.
+	
+	self assert: controller completionToken equals: 'f'.
+
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self bar baz'
+]
+
+{ #category : #'tests - keyboard' }
+CompletionEngineTest >> testCompletionOnSingleLetter [
+
+	| text |
+	text := 'self f baz'.
+
+	self
+		setEditorText: text;
+		selectAt: 'self f' size + 1.
+
+	editor textArea openInWorld.
+	controller openMenu.
+	
+	self assert: controller completionToken equals: 'f'.
+
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self bar baz'
+]
+
+{ #category : #'tests - keyboard' }
 CompletionEngineTest >> testCompletionOpenOnUnderscore [
 
 	"If the caret is at the end of a word, replace the entire word"

--- a/src/NECompletion-Tests/CompletionEngineTest.class.st
+++ b/src/NECompletion-Tests/CompletionEngineTest.class.st
@@ -283,6 +283,26 @@ CompletionEngineTest >> testReplaceTokenAfterMovingCaretToMiddleOfWordWithFollow
 	self assert: editor text equals: 'self toto something that follows'
 ]
 
+{ #category : #'tests - interaction' }
+CompletionEngineTest >> testReplaceTokenWithAditionalSpace [
+
+	"If the caret is at the end of a word, replace the entire word"
+
+	| text |
+	text := 'self mEthOdThatDoesNotExist something that follows'.
+
+	self
+		setEditorText: text;
+		selectAt: 'self mEthOdThatDoesNotExist' size + 1.
+
+	editor textArea openInWorld.
+	controller openMenu.
+
+	controller context replaceTokenInEditorWith: 'toto '.
+
+	self assert: editor text equals: 'self toto something that follows'
+]
+
 { #category : #tests }
 CompletionEngineTest >> testReplaceTokenWithCaretBeforeEndOfTextWithSpecialCharacterReplacesEntireWord [
 

--- a/src/NECompletion-Tests/CompletionEngineTest.class.st
+++ b/src/NECompletion-Tests/CompletionEngineTest.class.st
@@ -344,6 +344,25 @@ CompletionEngineTest >> testReplaceTokenWithCaretInTheMiddleOfWordWithFollowingW
 ]
 
 { #category : #'tests - interaction' }
+CompletionEngineTest >> testReplaceTokenWithCaretInTheMiddleOfWordWithFollowingWordsReplacesEntireWord2 [
+
+	| text |
+	text := 'self foo something that follows'.
+
+	self
+		setEditorText: text;
+		selectAt: 'self foo' size + 1.
+
+	editor textArea openInWorld.
+	controller openMenu.
+	editor keyDown: (self keyboardEventFor: Character arrowLeft).
+
+	controller context replaceTokenInEditorWith: 'aLongString'.
+
+	self assert: editor text asString equals: 'self aLongString something that follows'
+]
+
+{ #category : #'tests - interaction' }
 CompletionEngineTest >> testReplaceTokenWithCaretOnEndOfWordReplacesEntireWord [
 
 	"If the caret is at the end of a word, replace the entire word"


### PR DESCRIPTION
Code replacement was broken if the old string what shorter than the new one and was not a prefix.
I assume it was some old hard-coded expectation on completion, but new completion engines are better.

e.g.

1. write `a foo`
2. completion menu open
3. go back 1 character
4. chose `fontNumber`
5. old behavior: you get `a footNumber` (a possible valid selector, but not the same concern)
5. new fixed behavior: you get `a fontNumber`

The second fix is related to "Put a space after completion" setting (that is true by default) that added a space even it there was already a space. Forcing the programmer to remove one

e.g.
1. write `a fo bar`
2. go back at the end of `fo` and add a `n`
3. completion menu open
4. chose `fontNumber`
5. old behavior: you get `a fontNumber  bar` (with two spaces and the cursor in the middle of them)
5. new behavior: you get `a fontNumber bar` (with a single space and the cursor after it)

Update: fixed a third bug. The completion was broken when completing at the 2nd position. i.e. between the first and the second characters of the word, i.e. with a single character prefix.
Both completion and the replacement were broken because of two additional (but broken) `- 1` when calling `previousWord:`. With a single character prefix, the prefix started at the previous word (including possible spaces and newlines), preventing the completion heuristic to find something meaningful and making replacements hazardous.

e.g.
1. write `a f`
2. press tab
3. previous behavior: you get no completion suggestions
3. new fixed behavior: you get plenty of completion suggestions

e.g.
1. write `a fx`
2. completion menu open
3. go back 1 character
4. chose `fontNumber`
5. previous behavior: you get `a fxNumber` (yes `nt` vanished)
5. previous behavior without the update: you get `fontNumber` (yes `a ` vanished)
6. new fixed behavior after the update: you get `a fontNumber`

Fix #9329 I assume