### PR TITLE
Reduce cyclomatic complexity of #classify:under:

### DIFF
--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -46,23 +46,13 @@ ClassOrganization >> allMethodSelectors [
 { #category : #classification }
 ClassOrganization >> classify: selector under: aProtocol [
 
-	| oldProtocolName protocolName |
-	"The next section deserve more cleanings.
-	
-	Some code was added to make it possible to classify giving a real protocol.
-	Here to keep a small change, I just ask the name to the protocol and use that for compatibility.
-	Later, I plan to update this code once more to directly use the actual object I'm givin instead of doing this little trick."
-	protocolName := aProtocol
-		                ifNil: [ Protocol unclassified ]
-		                ifNotNil: [
-			                aProtocol isString
-				                ifTrue: [ aProtocol ]
-				                ifFalse: [ aProtocol name ] ].
+	| oldProtocolName newProtocol |
+	newProtocol := self ensureProtocol: aProtocol.
 	oldProtocolName := self protocolNameOfElement: selector.
-	((self includesSelector: selector) and: [ oldProtocolName = protocolName ]) ifTrue: [ ^ self ].
+	((self includesSelector: selector) and: [ oldProtocolName = newProtocol name ]) ifTrue: [ ^ self ].
 
-	self silentlyClassify: selector under: protocolName.
-	oldProtocolName ifNotNil: [ self notifyOfChangedSelector: selector from: oldProtocolName to: protocolName ]
+	self silentlyClassify: selector under: newProtocol.
+	oldProtocolName ifNotNil: [ self notifyOfChangedSelector: selector from: oldProtocolName to: newProtocol name ]
 ]
 
 { #category : #cleanup }


### PR DESCRIPTION
This is a new iteration on ClassOrganization>>#classify:under:.

The goal is to manipulate a real protocol for the new protocol to be classified under to avoid an imbricated if.

There are still improvements to do to this method but since the changes to it seems to impact a lot the system I'm still doing small iterations to find what breaks and does not breaks the system and ultimately find what hacks are currently been exploited by the system.

