### PR TITLE
Remove references to SystemOrganization

### DIFF
--- a/bootstrap/scripts/emulation/shrink.st
+++ b/bootstrap/scripts/emulation/shrink.st
@@ -248,7 +248,7 @@
 	array at: 5 put: nil.
 	Smalltalk specialObjectsArray becomeForward: array.
 	ClassOrganization allInstancesDo: [ :org | org removeEmptyCategories ].
-	SystemOrganization removeEmptyCategories.
+	Smalltalk organization removeEmptyCategories.
 
 
 	" clean object memory, maybe can be simpler"

--- a/bootstrap/scripts/generateKernelHermesFiles.st
+++ b/bootstrap/scripts/generateKernelHermesFiles.st
@@ -18,7 +18,7 @@ packageNames := #BaselineOfPharoBootstrap asClass kernelPackageNames, toExport.
 environment := repository asRing2EnvironmentWith: packageNames.		
 
 environment fixProtoObjectClassSuperclass.
-environment addGlobalsNamed: #(Undeclared Smalltalk UTF8TextConverter MacRomanTextConverter FileStream ChangeSet Character Processor SystemOrganization).
+environment addGlobalsNamed: #(Undeclared Smalltalk UTF8TextConverter MacRomanTextConverter FileStream ChangeSet Character Processor).
 
 environment clean.
 

--- a/bootstrap/scripts/generateSUnitHermesFiles.st
+++ b/bootstrap/scripts/generateSUnitHermesFiles.st
@@ -19,7 +19,7 @@ packageNames := #BaselineOfPharoBootstrap asClass kernelPackageNames, #BaselineO
 environment := repository asRing2EnvironmentWith: packageNames.		
 
 environment fixProtoObjectClassSuperclass.
-environment addGlobalsNamed: #(Undeclared Smalltalk UTF8TextConverter MacRomanTextConverter FileStream ChangeSet Character Processor SystemOrganization).
+environment addGlobalsNamed: #(Undeclared Smalltalk UTF8TextConverter MacRomanTextConverter FileStream ChangeSet Character Processor).
 
 environment clean.
 

--- a/bootstrap/scripts/generateTraitsHermesFiles.st
+++ b/bootstrap/scripts/generateTraitsHermesFiles.st
@@ -19,7 +19,7 @@ packageNames := #BaselineOfPharoBootstrap asClass kernelPackageNames, toExport.
 environment := repository asRing2EnvironmentWith: packageNames.		
 
 environment fixProtoObjectClassSuperclass.
-environment addGlobalsNamed: #(Undeclared Smalltalk UTF8TextConverter MacRomanTextConverter FileStream ChangeSet Character Processor SystemOrganization).
+environment addGlobalsNamed: #(Undeclared Smalltalk UTF8TextConverter MacRomanTextConverter FileStream ChangeSet Character Processor).
 
 environment clean.
 

--- a/src/GeneralRules/ReGlobalVariablesUsageRule.class.st
+++ b/src/GeneralRules/ReGlobalVariablesUsageRule.class.st
@@ -43,7 +43,6 @@ ReGlobalVariablesUsageRule >> isKnownGlobal: aString [
 			Processor
 			Smalltalk
 			SourceFiles
-			SystemOrganization
 			Transcript
 			Undeclared
 			World

--- a/src/Pharo30Bootstrap/PBBootstrap.class.st
+++ b/src/Pharo30Bootstrap/PBBootstrap.class.st
@@ -399,7 +399,7 @@ PBBootstrap >> prepareEnvironmentForExport [
 			ringEnvironment removePackage: p].
 
 	ringEnvironment cleanGlobalVariables.
-	ringEnvironment addGlobalsNamed: #(#Smalltalk #SourceFiles #Transcript #Undeclared #Display #TextConstants  #Sensor #Processor #SystemOrganization).
+	ringEnvironment addGlobalsNamed: #(#Smalltalk #SourceFiles #Transcript #Undeclared #Display #TextConstants  #Sensor #Processor).
 	ringEnvironment clean
 
 ]
@@ -408,7 +408,7 @@ PBBootstrap >> prepareEnvironmentForExport [
 PBBootstrap >> prepareEnvironmentForHermes [
 	ringEnvironment := self originRepository asRing2EnvironmentWith: self allPackagesForHermes.
 	ringEnvironment fixProtoObjectClassSuperclass.
-	ringEnvironment addGlobalsNamed: #(Smalltalk Transcript FileStream MacRomanTextConverter ChangeSet SourceFiles Processor Display Sensor UTF8TextConverter SystemOrganization Undeclared TextConstants).
+	ringEnvironment addGlobalsNamed: #(Smalltalk Transcript FileStream MacRomanTextConverter ChangeSet SourceFiles Processor Display Sensor UTF8TextConverter Undeclared TextConstants).
 	ringEnvironment clean
 ]
 


### PR DESCRIPTION
SystemOrganization should not be used anymore and will be deprecated.

This PR aims to remove the references to it. Currently done:
- Remove it from known globals of the QualityAssistant global reference rule
- Remove it from the bootstrap. Let's see if we are able to build without declaring the global in Espell and Hermes.