### PR TITLE
Ensure #addSelector:withMethod: classifies methods

### DIFF
--- a/src/Kernel-Tests/ClassDescriptionTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionTest.class.st
@@ -38,6 +38,19 @@ ClassDescriptionTest >> tearDown [
 	super tearDown
 ]
 
+{ #category : #'tests - compilation' }
+ClassDescriptionTest >> testAddSelectorWithMethodClassifyMethod [
+
+	| class method |
+	class := self createTestClass.
+	class addSelector: #wammawink withMethod: (class compiler compile: 'wammawink ^ self').
+	method := class >> #wammawink.
+
+	self assert: method sourceCode equals: 'wammawink ^ self'.
+	self assert: method protocol equals: Protocol unclassified.
+	self assert: (class organization protocolOfSelector: #wammawink) name equals: Protocol unclassified
+]
+
 { #category : #'tests - slots' }
 ClassDescriptionTest >> testAllSlots [
 	self assert: Context allSlots size equals: 6

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -75,13 +75,18 @@ ClassDescription >> addMethodTag: aSymbol [
 
 { #category : #'accessing - method dictionary' }
 ClassDescription >> addSelector: selector withMethod: compiledMethod [
+
 	| priorMethodOrNil oldProtocol |
-	priorMethodOrNil := self compiledMethodAt: selector ifAbsent: [nil].
-	oldProtocol := priorMethodOrNil ifNotNil: [ priorMethodOrNil protocol ].
+	priorMethodOrNil := self compiledMethodAt: selector ifAbsent: [ nil ].
+	oldProtocol := self organization protocolOfSelector: selector.
+
+	"If there is no old protocol, then we want to ensure the method is at least in Protocol unclassified to not have protocolless methods."
+	oldProtocol ifNil: [ SystemAnnouncer uniqueInstance suspendAllWhile: [ self organization classify: selector under: nil ] ].
+
 	self addSelectorSilently: selector withMethod: compiledMethod.
 	priorMethodOrNil
-		ifNil: [SystemAnnouncer uniqueInstance methodAdded: compiledMethod ]
-		ifNotNil: [SystemAnnouncer uniqueInstance methodChangedFrom: priorMethodOrNil to: compiledMethod oldProtocol: oldProtocol ]
+		ifNil: [ SystemAnnouncer uniqueInstance methodAdded: compiledMethod ]
+		ifNotNil: [ SystemAnnouncer uniqueInstance methodChangedFrom: priorMethodOrNil to: compiledMethod oldProtocol: (oldProtocol ifNotNil: [ oldProtocol name ]) ]
 ]
 
 { #category : #'accessing - method dictionary' }


### PR DESCRIPTION
This method seems to be the last place were methods are added without been added to a protocol. 

Since it does not classify the method we just add it to Protocol unclassified to be sure it is at least in one protocol. 