### PR TITLE
Completion: prepare for empty token

### DIFF
--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -70,6 +70,8 @@ CompletionEngine >> completionToken [
 { #category : #replacement }
 CompletionEngine >> completionTokenStart [
 	"This is the position in the editor where the completion token starts"
+	self editor caret <= 1 ifTrue: [ ^ self editor caret ].
+	(self editor isWordCharacterAt: self editor caret - 1 in: self editor text) ifFalse: [^ self editor caret ].	
 	^ self editor previousWord: self editor caret
 ]
 
@@ -323,17 +325,20 @@ CompletionEngine >> replaceTokenInEditorWith: aString [
 	The completion context uses this API to insert text into the text editor"
 
 	| wordEnd old positionAfterFirstKeyword offset firstKeyword wordStart |
-	"Try to correctly replace the current token in the word.
-	The code editor should be able to do it by himself"
-	wordEnd := (self editor nextWord: self editor caret - 1).
+
+	wordStart := self completionTokenStart.
+
+	"If completionToken is not empty, the end is the end of the whole word (according to the editor)"
+	wordEnd := wordStart = editor caret
+		ifTrue: [ wordStart ]
+		ifFalse: [ self editor nextWord: self editor caret - 1].
+
 	"Do not insert an aditional space if there is already one"
 	(aString last = $  and: [
 		wordEnd <= self editor text size and: [
 			(self editor text at: wordEnd) = $ ]]) ifTrue: [ wordEnd := wordEnd + 1 ].
 	"If the returned index is the size of the text that means that the caret is at the end of the text and there is no more word after, so add 1 to the index to be out of range to select the entierely word because of the selectInvisiblyFrom:to: remove 1 just after to be at the end of then final word"
 	wordEnd > self editor text size ifTrue:[ wordEnd := wordEnd + 1 ].
-
-	wordStart := self editor previousWord: self editor caret.
 
 	self editor
 		selectInvisiblyFrom: wordStart

--- a/src/NECompletion-Tests/CompletionEngineTest.class.st
+++ b/src/NECompletion-Tests/CompletionEngineTest.class.st
@@ -103,6 +103,17 @@ CompletionEngineTest >> setEditorText: aString [
 	editor selectAll; addString:  aString
 ]
 
+{ #category : #'tests - keyboard' }
+CompletionEngineTest >> setEditorTextWithCaret: aString [
+	"Helper method. `|` denotes the caret and is removed"
+
+	| index source |
+	index := aString indexOf: $|.
+	source := (aString copyFrom: 1 to: index-1) , (aString copyFrom: index+1 to: aString size).
+	self setEditorText: source.
+	self selectAt: index
+]
+
 { #category : #running }
 CompletionEngineTest >> setUp [
 	super setUp.
@@ -122,42 +133,222 @@ CompletionEngineTest >> tearDown [
 	super tearDown
 ]
 
-{ #category : #'tests - keyboard' }
-CompletionEngineTest >> testCompletionOnFirstLetter [
+{ #category : #tests }
+CompletionEngineTest >> testCompletionAfterKeyword [
 
-	| text |
-	text := 'self foo baz'.
-
-	self
-		setEditorText: text;
-		selectAt: 'self f' size + 1.
-
-	editor textArea openInWorld.
-	controller openMenu.
-	
-	self assert: controller completionToken equals: 'f'.
-
+	self setEditorTextWithCaret: 'self foo:| baz'.
+	self assert: controller completionToken equals: 'foo:'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self bar baz'
+	self assert: editor text asString equals: 'self bar baz'.
+
+	self setEditorTextWithCaret: 'self"x"foo:|"x"baz'.
+	self assert: controller completionToken equals: 'foo:'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self"x"bar"x"baz'.
+
+	self setEditorTextWithCaret: 'self.foo:|.baz'.
+	self assert: controller completionToken equals: 'foo:'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self.bar.baz'.
+
+	self setEditorTextWithCaret: 'self:=foo:|:=baz'.
+	self assert: controller completionToken equals: 'foo:'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self:=bar:=baz'.
+
+	self setEditorTextWithCaret: 'foo:|'.
+	self assert: controller completionToken equals: 'foo:'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'bar'
 ]
 
-{ #category : #'tests - keyboard' }
+{ #category : #tests }
+CompletionEngineTest >> testCompletionAfterWord [
+
+	self setEditorTextWithCaret: 'self foo| baz'.
+	self assert: controller completionToken equals: 'foo'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self bar baz'.
+
+	self setEditorTextWithCaret: 'self"x"foo|"x"baz'.
+	self assert: controller completionToken equals: 'foo'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self"x"bar"x"baz'.
+
+	self setEditorTextWithCaret: 'self.foo|.baz'.
+	self assert: controller completionToken equals: 'foo'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self.bar.baz'.
+
+	self setEditorTextWithCaret: 'self:=foo|:=baz'.
+	self assert: controller completionToken equals: 'foo'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self:=bar:=baz'.
+
+	self setEditorTextWithCaret: 'foo|'.
+	self assert: controller completionToken equals: 'foo'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'bar'
+]
+
+{ #category : #tests }
+CompletionEngineTest >> testCompletionBeforeKeywordColumn [
+
+	self setEditorTextWithCaret: 'self foo|: baz'.
+	self assert: controller completionToken equals: 'foo'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self bar baz'.
+
+	self setEditorTextWithCaret: 'self"x"foo|:"x"baz'.
+	self assert: controller completionToken equals: 'foo'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self"x"bar"x"baz'.
+
+	self setEditorTextWithCaret: 'self.foo|:.baz'.
+	self assert: controller completionToken equals: 'foo'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self.bar.baz'.
+
+	self setEditorTextWithCaret: 'self:=foo|::=baz'.
+	self assert: controller completionToken equals: 'foo'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self:=bar:=baz'.
+
+	self setEditorTextWithCaret: 'foo|:'.
+	self assert: controller completionToken equals: 'foo'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'bar'
+]
+
+{ #category : #tests }
+CompletionEngineTest >> testCompletionBeforeWord [
+
+	self setEditorTextWithCaret: 'self |foo baz'.
+	self assert: controller completionToken equals: ''.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self barfoo baz'.
+
+	self setEditorTextWithCaret: 'self"x"|foo"x"baz'.
+	self assert: controller completionToken equals: ''.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self"x"barfoo"x"baz'.
+
+	self setEditorTextWithCaret: 'self.|foo.baz'.
+	self assert: controller completionToken equals: ''.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self.barfoo.baz'.
+
+	self setEditorTextWithCaret: 'self:=|foo:=baz'.
+	self assert: controller completionToken equals: ''.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self:=barfoo:=baz'.
+
+	self setEditorTextWithCaret: '|foo'.
+	self assert: controller completionToken equals: ''.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'barfoo'
+]
+
+{ #category : #tests }
+CompletionEngineTest >> testCompletionOnBinary [
+	"For the moment, binary selectors cannot be completed."
+
+	self setEditorTextWithCaret: 'self +|+ baz'.
+	self assert: controller completionToken equals: ''.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self +bar+ baz'
+]
+
+{ #category : #tests }
+CompletionEngineTest >> testCompletionOnFirstLetter [
+
+	self setEditorTextWithCaret: 'self f|oo baz'.
+	self assert: controller completionToken equals: 'f'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self bar baz'.
+
+	self setEditorTextWithCaret: 'self"x"f|oo"x"baz'.
+	self assert: controller completionToken equals: 'f'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self"x"bar"x"baz'.
+
+	self setEditorTextWithCaret: 'self.f|oo.baz'.
+	self assert: controller completionToken equals: 'f'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self.bar.baz'.
+
+	self setEditorTextWithCaret: 'self:=f|oo:=baz'.
+	self assert: controller completionToken equals: 'f'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self:=bar:=baz'.
+
+	self setEditorTextWithCaret: 'f|oo'.
+	self assert: controller completionToken equals: 'f'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'bar'
+]
+
+{ #category : #tests }
+CompletionEngineTest >> testCompletionOnNoWord [
+
+	self setEditorTextWithCaret: 'self | baz'.
+	self assert: controller completionToken equals: ''.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self bar baz'.
+
+	self setEditorTextWithCaret: 'self"x"|"x"baz'.
+	self assert: controller completionToken equals: ''.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self"x"bar"x"baz'.
+
+	self setEditorTextWithCaret: 'self.|.baz'.
+	self assert: controller completionToken equals: ''.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self.bar.baz'.
+
+	self setEditorTextWithCaret: 'self:=|:=baz'.
+	self assert: controller completionToken equals: ''.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self:=bar:=baz'.
+
+	self setEditorTextWithCaret: ' | '.
+	self assert: controller completionToken equals: ''.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: ' bar '.
+
+	self setEditorTextWithCaret: '|'.
+	self assert: controller completionToken equals: ''.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'bar'
+]
+
+{ #category : #tests }
 CompletionEngineTest >> testCompletionOnSingleLetter [
 
-	| text |
-	text := 'self f baz'.
-
-	self
-		setEditorText: text;
-		selectAt: 'self f' size + 1.
-
-	editor textArea openInWorld.
-	controller openMenu.
-	
+	self setEditorTextWithCaret: 'self f| baz'.
 	self assert: controller completionToken equals: 'f'.
-
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self bar baz'
+	self assert: editor text asString equals: 'self bar baz'.
+
+	self setEditorTextWithCaret: 'self"x"f|"x"baz'.
+	self assert: controller completionToken equals: 'f'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self"x"bar"x"baz'.
+
+	self setEditorTextWithCaret: 'self.f|.baz'.
+	self assert: controller completionToken equals: 'f'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self.bar.baz'.
+
+	self setEditorTextWithCaret: 'self:=f|:=baz'.
+	self assert: controller completionToken equals: 'f'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'self:=bar:=baz'.
+
+	self setEditorTextWithCaret: 'f|'.
+	self assert: controller completionToken equals: 'f'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: editor text asString equals: 'bar'
 ]
 
 { #category : #'tests - keyboard' }
@@ -256,6 +447,7 @@ CompletionEngineTest >> testReplaceKeywordTokenWithCaretInTheEndOfWordAfterCaret
 	editor textArea openInWorld.
 	controller openMenu.
 
+	self assert: controller completionToken equals: 'mEthOdThatDoesNotExist:'.
 	controller context replaceTokenInEditorWith: 'mEthOdThatDoesNotExist:'.
 
 	self assert: editor text asString equals: 'self mEthOdThatDoesNotExist: something that follows'

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -811,8 +811,8 @@ RubSmalltalkEditor >> isWordCharacterAt: index in: aString [
 		 - but not by an assignment "
 		(character = $_) or: [
 			(character = $:) and: [
-				aString size > index
-					and: [  (aString at: index + 1) ~= $= ] ] ] ]
+				aString size = index
+					or: [  (aString at: index + 1) ~= $= ] ] ] ]
 ]
 
 { #category : #'menu messages' }


### PR DESCRIPTION
This PR was done while thinking about #9327, that is what about completing on an empty word. eg. `1 between: 3 | ` or `super |` (where `|` is the caret).

To solve that, there is some groundwork to do before: prepare the CompletionEngine base class to work on empty completion token, that involves recognizing them and performing correct replacements.
Up to now, CompletionEngine assumed that the caret was always after a word character. Otherwise, undefined behavior, and likely runtime errors, occurred. The PR fix that.

The fix is quite short (some ifs), the bulk of the PR are unit tests to check various positions of the caret with various surroundings.
Bonus, it allowed me to detect and fix a bug in Rubric editor when going next word (ctrl→) because the completion engine is tightly coupled with the editor and delegates to is most services about words, replacements, or motions.

The next steps should be:

* enable completion on empty word.
  Currently, `tab` is used to manually open the completion menu. There is a heuristic that opens the completion window if the caret follows a word character, and insert a tab character otherwise.
  I'm not sure what is the correct move here, enlarge the heuristic ? For instance, open the menu if not at the beginning of a line, tab character (to indent) otherwise? A different shortcut?
* add completion entries on the engine.
  Having a completion menu with a good context and functional replacement is nice, but if the menu is empty it's not that useful. So we need to gather some entries.
  The status of completions is not ideal. 3 engines according to the settings (CoCompletionEngine SpMorphicCodeCompletionEngine CoStatisticsCompletionEngine) with various levels of love and bitrusting, possible leftover code (NEC thing is weird), and too much overengineering for my taste. I will likely only do the minimum to have something that *seems to works*.