### PR TITLE
Complete super message send

### DIFF
--- a/src/HeuristicCompletion-Model/CoSuperMessageHeuristic.class.st
+++ b/src/HeuristicCompletion-Model/CoSuperMessageHeuristic.class.st
@@ -24,13 +24,19 @@ CoSuperMessageHeuristic >> appliesForNode: aNode inContext: aContext [
 
 { #category : #requests }
 CoSuperMessageHeuristic >> buildFetcherFor: aNode inContext: completionContext [
-	| completionClass |
+	| completionClass fetcher entry |
 
 	"When in the playground, the completion class is not available.
 	But self is bound to nil"
 	completionClass := completionContext completionClass ifNil: [ nil class ].
 	"In Traits, superclass is nil"
-	completionClass superclass
-		ifNil: [ ^ CoEmptyFetcher new ].
-	^ self newMessageInHierarchyFetcherForClass: completionClass superclass inASTNode: aNode
+	fetcher := completionClass superclass
+		ifNil: [ CoEmptyFetcher new ]
+		ifNotNil: [ self newMessageInHierarchyFetcherForClass: completionClass superclass inASTNode: aNode ].
+
+	"Inject a synthetic fetcher with the expected full message send at first option because it is was is needed in most (>99%) situations"
+	aNode methodNode ifNotNil: [ :methodNode |
+		entry := (NECSelectorEntry contents: methodNode selectorAndArgumentNames node: aNode) selector: methodNode selector.
+		fetcher := (CoCollectionFetcher new collection: { entry }) , fetcher ].
+	^ fetcher
 ]


### PR DESCRIPTION
On super send, there is one preferred selector, the current selector (see ReSendsDifferentSuperRule).
So this PR teach completion to propose a full message send, including the arguments.

Fix #13054

See it in action: I redefine `printOn:` in some class then write `super p` and a popup appear with the first choice

![Capture d’écran du 2023-05-03 15-15-15](https://user-images.githubusercontent.com/135828/236022790-226d4a71-a903-4b12-81be-a01190fa42a2.png)

Then I just press enter, et voilà!

![Capture d’écran du 2023-05-03 15-24-29](https://user-images.githubusercontent.com/135828/236023381-08e43426-27fb-4bd7-b858-c288a5001b4b.png)
