### PR TITLE
Completion complete empty tokens

### DIFF
--- a/src/AST-Core/RBEnglobingErrorNode.class.st
+++ b/src/AST-Core/RBEnglobingErrorNode.class.st
@@ -105,6 +105,15 @@ RBEnglobingErrorNode >> isEnglobingError [
 	^true
 ]
 
+{ #category : #replacing }
+RBEnglobingErrorNode >> replaceNode: aNode withNode: anotherNode [
+
+	self contents: (contents collect: [ :each |
+			 each == aNode
+				 ifTrue: [ anotherNode ]
+				 ifFalse: [ each ] ])
+]
+
 { #category : #accessing }
 RBEnglobingErrorNode >> stop: anInterger [
 	stop := anInterger

--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -365,7 +365,7 @@ RBMessageNode >> replaceNode: aNode withNode: anotherNode [
 		ifTrue:
 			[self receiver: anotherNode.
 			(parent notNil and: [parent isCascade])
-				ifTrue: [parent messages do: [:each | each receiver: anotherNode]]].
+				ifTrue: [parent messages do: [:each | each isMessage ifTrue: [ each receiver: anotherNode]]]].
 	self arguments: (arguments
 				collect: [:each | each == aNode ifTrue: [anotherNode] ifFalse: [each]])
 ]

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -973,9 +973,9 @@ RBProgramNode >> nodeBeforeOffset: anInteger [
 	| offset |
 	offset := anInteger.
 	[
-	offset > self source size or: [ (self source at: offset) isSeparator ] ]
+	offset > 0 and: [ offset > self source size or: [ (self source at: offset) isSeparator ] ] ]
 		whileTrue: [ offset := offset - 1 ].
-	^ self nodeForOffset: offset
+	^ self nodeForOffset: offset.
 ]
 
 { #category : #'node access' }

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -966,6 +966,19 @@ RBProgramNode >> newSource [
 ]
 
 { #category : #'node access' }
+RBProgramNode >> nodeBeforeOffset: anInteger [
+	"Return the node at offset `anInteger` or at the first non-separator previous character.
+	Ignoring space corresponds to what is the visible current or previous node in IDE."
+
+	| offset |
+	offset := anInteger.
+	[
+	offset > self source size or: [ (self source at: offset) isSeparator ] ]
+		whileTrue: [ offset := offset - 1 ].
+	^ self nodeForOffset: offset
+]
+
+{ #category : #'node access' }
 RBProgramNode >> nodeForOffset: anInteger [
 	"Choose the best node on the specific offset, including comments.
 	Because comments can be oustide the span of sourceInterval, we have to visit all children.

--- a/src/HeuristicCompletion-Model/CoASTHeuristicsResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoASTHeuristicsResultSetBuilder.class.st
@@ -67,6 +67,8 @@ CoASTHeuristicsResultSetBuilder >> variablesHeuristic [
 { #category : #visiting }
 CoASTHeuristicsResultSetBuilder >> visitLiteralValueNode: aNode [
 
+	completionContext completionToken ifEmpty: [ ^ super visitLiteralValueNode: aNode ].
+
 	^ self
 		configureFetcherForNode: aNode
 		usingHeuristicAvoidingRepetitions: self symbolsHeuristic
@@ -74,7 +76,9 @@ CoASTHeuristicsResultSetBuilder >> visitLiteralValueNode: aNode [
 
 { #category : #visiting }
 CoASTHeuristicsResultSetBuilder >> visitMessageNode: aRBMessageNode [ 
-	
+
+	completionContext completionToken ifEmpty: [ ^ super visitMessageNode: aRBMessageNode ].
+
 	^ self
 		configureFetcherForNode: aRBMessageNode
 		usingHeuristicAvoidingRepetitions: self messageHeuristic
@@ -83,6 +87,8 @@ CoASTHeuristicsResultSetBuilder >> visitMessageNode: aRBMessageNode [
 { #category : #visiting }
 CoASTHeuristicsResultSetBuilder >> visitMethodNode: aRBMethodNode [
 
+	completionContext completionToken ifEmpty: [ ^ super visitMethodNode: aRBMethodNode ].
+
 	^ self
 		configureFetcherForNode: aRBMethodNode
 		usingHeuristicAvoidingRepetitions: self methodNodeHeuristic
@@ -90,6 +96,8 @@ CoASTHeuristicsResultSetBuilder >> visitMethodNode: aRBMethodNode [
 
 { #category : #visiting }
 CoASTHeuristicsResultSetBuilder >> visitVariableNode: aRBVariableNode [
+
+	completionContext completionToken ifEmpty: [ ^ super visitVariableNode: aRBVariableNode ].
 
 	^ self
 		configureFetcherForNode: aRBVariableNode

--- a/src/HeuristicCompletion-Model/CoASTHeuristicsResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoASTHeuristicsResultSetBuilder.class.st
@@ -95,6 +95,31 @@ CoASTHeuristicsResultSetBuilder >> visitMethodNode: aRBMethodNode [
 ]
 
 { #category : #visiting }
+CoASTHeuristicsResultSetBuilder >> visitValueNode: aNode [
+
+	| offset |
+	offset := completionContext completionTokenStart.
+	completionContext completionToken isEmpty ifTrue: [
+		offset > aNode stopWithoutParentheses ifTrue: [
+			| aMessageNode |
+			"We are after a value node with a empty completion token.
+			So, try to complete a message send from scratch with the value node as the receiver.
+			In order to be compatible with the current complex completion framework,
+			we just inject a synthetic message node in the AST with an empty selector.
+			This empty selector will then be completed according to the existing rules and heuristics.
+			It is a little hackish but we believe in magic."
+			aMessageNode := RBMessageNode new.
+			aNode replaceWith: aMessageNode.
+			aMessageNode receiver: aNode.
+			aMessageNode selector: #''.
+			^ self
+				  configureFetcherForNode: aMessageNode
+				  usingHeuristicAvoidingRepetitions: self messageHeuristic ] ].
+
+	^ super visitValueNode: aNode
+]
+
+{ #category : #visiting }
 CoASTHeuristicsResultSetBuilder >> visitVariableNode: aRBVariableNode [
 
 	completionContext completionToken ifEmpty: [ ^ super visitVariableNode: aRBVariableNode ].

--- a/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
@@ -72,7 +72,7 @@ CoASTResultSetBuilder >> parseNode [
 		(completionContext completionClass compiler
 			source: completionContext source;
 			isScripting: completionContext isScripting;
-			parse) nodeForOffset: completionContext position ]
+			parse) nodeBeforeOffset: completionContext position ]
 ]
 
 { #category : #visiting }

--- a/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
@@ -68,11 +68,13 @@ CoASTResultSetBuilder >> node: aNode [
 { #category : #'API - building' }
 CoASTResultSetBuilder >> parseNode [
 
+	| n |
 	^ node ifNil: [
-		(completionContext completionClass compiler
+		n := completionContext completionClass compiler
 			source: completionContext source;
 			isScripting: completionContext isScripting;
-			parse) nodeBeforeOffset: completionContext position ]
+			parse.
+		(n nodeBeforeOffset: completionContext position) ifNil: [ n ] ]
 ]
 
 { #category : #visiting }

--- a/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
@@ -76,6 +76,12 @@ CoASTResultSetBuilder >> parseNode [
 ]
 
 { #category : #visiting }
+CoASTResultSetBuilder >> visitAnnotationMarkNode: aRBAnnotationMarkNode [
+
+	^ self visitValueNode: aRBAnnotationMarkNode
+]
+
+{ #category : #visiting }
 CoASTResultSetBuilder >> visitArgumentVariableNode: anArgumentNode [
 
 	^ self visitVariableNode: anArgumentNode

--- a/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoASTResultSetBuilder.class.st
@@ -84,25 +84,25 @@ CoASTResultSetBuilder >> visitArgumentVariableNode: anArgumentNode [
 { #category : #visiting }
 CoASTResultSetBuilder >> visitArrayNode: aRBArrayNode [
 
-	^ self visitNode: aRBArrayNode
+	^ self visitValueNode: aRBArrayNode
 ]
 
 { #category : #visiting }
 CoASTResultSetBuilder >> visitAssignmentNode: aRBAssignmentNode [
 
-	^ self visitNode: aRBAssignmentNode
+	^ self visitValueNode: aRBAssignmentNode
 ]
 
 { #category : #visiting }
 CoASTResultSetBuilder >> visitBlockNode: aRBBlockNode [
 
-	^ self visitNode: aRBBlockNode
+	^ self visitValueNode: aRBBlockNode
 ]
 
 { #category : #visiting }
 CoASTResultSetBuilder >> visitCascadeNode: aRBCascadeNode [
 
-	^ self visitNode: aRBCascadeNode
+	^ self visitValueNode: aRBCascadeNode
 ]
 
 { #category : #visiting }
@@ -136,13 +136,13 @@ CoASTResultSetBuilder >> visitInstanceVariableNode: aRBVariableNode [
 { #category : #visiting }
 CoASTResultSetBuilder >> visitLiteralArrayNode: aRBLiteralArrayNode [
 
-	^ self visitNode: aRBLiteralArrayNode
+	^ self visitValueNode: aRBLiteralArrayNode
 ]
 
 { #category : #visiting }
 CoASTResultSetBuilder >> visitLiteralValueNode: aRBLiteralValueNode [
 
-	^ self visitNode: aRBLiteralValueNode
+	^ self visitValueNode: aRBLiteralValueNode
 ]
 
 { #category : #visiting }
@@ -153,7 +153,7 @@ CoASTResultSetBuilder >> visitLiteralVariableNode: aRBVariableNode [
 { #category : #visiting }
 CoASTResultSetBuilder >> visitMessageNode: aRBMessageNode [
 
-	^ self visitNode: aRBMessageNode
+	^ self visitValueNode: aRBMessageNode
 ]
 
 { #category : #visiting }
@@ -189,7 +189,7 @@ CoASTResultSetBuilder >> visitReturnNode: aRBReturnNode [
 { #category : #visiting }
 CoASTResultSetBuilder >> visitSelfNode: aRBSelfNode [
 
-	^ self visitNode: aRBSelfNode
+	^ self visitValueNode: aRBSelfNode
 ]
 
 { #category : #visiting }
@@ -201,7 +201,7 @@ CoASTResultSetBuilder >> visitSequenceNode: aRBSequenceNode [
 { #category : #visiting }
 CoASTResultSetBuilder >> visitSuperNode: aRBSuperNode [
 
-	^ self visitNode: aRBSuperNode
+	^ self visitValueNode: aRBSuperNode
 ]
 
 { #category : #visiting }
@@ -213,11 +213,17 @@ CoASTResultSetBuilder >> visitTemporaryVariableNode: anArgumentNode [
 { #category : #visiting }
 CoASTResultSetBuilder >> visitThisContextNode: aRBThisContextNode [
 
-	^ self visitNode: aRBThisContextNode
+	^ self visitValueNode: aRBThisContextNode
+]
+
+{ #category : #visiting }
+CoASTResultSetBuilder >> visitValueNode: aRBVariableNode [
+
+	^ self visitNode: aRBVariableNode
 ]
 
 { #category : #visiting }
 CoASTResultSetBuilder >> visitVariableNode: aRBVariableNode [
 
-	^ self visitNode: aRBVariableNode
+	^ self visitValueNode: aRBVariableNode
 ]

--- a/src/HeuristicCompletion-Model/CoCompletionContext.class.st
+++ b/src/HeuristicCompletion-Model/CoCompletionContext.class.st
@@ -89,6 +89,12 @@ CoCompletionContext >> completionToken [
 ]
 
 { #category : #accessing }
+CoCompletionContext >> completionTokenStart [
+
+	^ self engine completionTokenStart
+]
+
+{ #category : #accessing }
 CoCompletionContext >> doItContext [
 
 	^ engine doItContext

--- a/src/HeuristicCompletion-Model/CoSuperMessageHeuristic.class.st
+++ b/src/HeuristicCompletion-Model/CoSuperMessageHeuristic.class.st
@@ -24,13 +24,19 @@ CoSuperMessageHeuristic >> appliesForNode: aNode inContext: aContext [
 
 { #category : #requests }
 CoSuperMessageHeuristic >> buildFetcherFor: aNode inContext: completionContext [
-	| completionClass |
+	| completionClass fetcher entry |
 
 	"When in the playground, the completion class is not available.
 	But self is bound to nil"
 	completionClass := completionContext completionClass ifNil: [ nil class ].
 	"In Traits, superclass is nil"
-	completionClass superclass
-		ifNil: [ ^ CoEmptyFetcher new ].
-	^ self newMessageInHierarchyFetcherForClass: completionClass superclass inASTNode: aNode
+	fetcher := completionClass superclass
+		ifNil: [ CoEmptyFetcher new ]
+		ifNotNil: [ self newMessageInHierarchyFetcherForClass: completionClass superclass inASTNode: aNode ].
+
+	"Inject a synthetic fetcher with the expected full message send at first option because it is was is needed in most (>99%) situations"
+	aNode methodNode ifNotNil: [ :methodNode |
+		entry := (NECSelectorEntry contents: methodNode selectorAndArgumentNames node: aNode) selector: methodNode selector.
+		fetcher := (CoCollectionFetcher new collection: { entry }) , fetcher ].
+	^ fetcher
 ]

--- a/src/HeuristicCompletion-Tests/CoCompletionEngineCodeSnippetTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoCompletionEngineCodeSnippetTest.class.st
@@ -1,0 +1,30 @@
+Class {
+	#name : #CoCompletionEngineCodeSnippetTest,
+	#superclass : #RBCodeSnippetTest,
+	#category : #'HeuristicCompletion-Tests-Core'
+}
+
+{ #category : #tests }
+CoCompletionEngineCodeSnippetTest >> testCompletion [
+	"Smoke test for completion. Try to get completion entries on each position for each code snippet.
+	This single test is a little slow (~15s) so it is in its own subclass."
+
+	| editor controller completions |
+	editor := RubSmalltalkEditor forTextArea: RubEditingArea new beForSmalltalkCode.
+	controller := CoCompletionEngine new.
+	controller setEditor: editor.
+	editor completionEngine: controller.
+	editor textArea model: CoCompletionEngineTest new.
+
+	editor
+		selectAll;
+		addString: snippet source.
+	self assert: editor string equals: snippet source.
+
+	completions := (2 to: snippet source size + 1) collect: [ :i |
+		editor selectFrom: i to: i - 1. "out carret"
+		editor completionEngine createContext entries
+			ifEmpty: [ nil ]
+			ifNotEmpty: [ :e | e first contents ] ].
+	self flag: 'do something with completion?'
+]

--- a/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
@@ -62,6 +62,10 @@ CoCompletionEngineTest >> testAdvanceWordTwiceClosesCompletionContext [
 { #category : #'tests - interaction' }
 CoCompletionEngineTest >> testCmdCtrlLeftClosesDetail [
 
+	<expectedFailure>
+	"GUI/test issue caused by the fact that the begin of a word is now a valid completion point, thus the completion menu remains open.
+	Will be fixed late once we decide what we want"
+
 	| text |
 	text := 'self asOrdered'.
 	self

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -144,7 +144,6 @@ CompletionEngine >> handleKeyDownBefore: aKeyboardEvent editor: anEditor [
 		menuMorph showDetail.
 		^ true ].
 
-
 	({
 		 KeyboardKey left.
 		 KeyboardKey right.

--- a/src/Rubric-Tests/RubTextEditorTest.class.st
+++ b/src/Rubric-Tests/RubTextEditorTest.class.st
@@ -22,6 +22,38 @@ RubTextEditorTest >> setUp [
 ]
 
 { #category : #tests }
+RubTextEditorTest >> testLineIndentationStart [
+
+	| starts |
+	string := 'foo<r>  a b<r><t><t>a<t>b<r><r><r> <t><r> ' expandMacros.
+	editor textArea privateText: string.
+	self assert: editor string equals: string.
+
+	starts := (1 to: string size + 1) collect: [ :i |
+		          editor lineIndentationStart: i ].
+	self
+		assert: starts
+		equals:
+		#( 1 1 1 1 7 7 7 7 7 7 13 13 13 13 13 13 17 18 21 21 21 23 23 )
+]
+
+{ #category : #tests }
+RubTextEditorTest >> testLineStart [
+
+	| starts |
+	string := 'foo<r>  a b<r><t><t>a<t>b<r><r><r> <t><r> ' expandMacros.
+	editor textArea privateText: string.
+	self assert: editor string equals: string.
+
+	starts := (1 to: string size + 1) collect: [ :i |
+		          editor lineStart: i ].
+	self
+		assert: starts
+		equals:
+		#( 1 1 1 1 5 5 5 5 5 5 11 11 11 11 11 11 17 18 19 19 19 22 22 )
+]
+
+{ #category : #tests }
 RubTextEditorTest >> testNextWord [
 
 	| textSize |

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -139,7 +139,7 @@ RubSmalltalkEditor >> atCompletionPosition [
 	| cursorPosition |
 	cursorPosition := self startIndex.
 	cursorPosition < 2 ifTrue: [ ^ false ].
-	^ (self text at: cursorPosition - 1) isCompletionCharacter
+	^ (self lineIndentationStart: cursorPosition) < cursorPosition
 ]
 
 { #category : #'do-its' }

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -1447,12 +1447,37 @@ RubTextEditor >> lf: aKeyboardEvent [
 	^false
 ]
 
+{ #category : #private }
+RubTextEditor >> lineIndentationStart: aPosition [
+	"The offset of the start of the line of `aPostion`, but skip leading spaces and tabs"
+
+	| string position spaces |
+	string := self string.
+	position := self lineStart: aPosition.
+	spaces := {Character tab. Character space}. "Only space and tab, so do not skip `Character cr` ending the line"
+	[ position <= string size and: [
+		spaces includes: (string at: position) ] ] whileTrue: [
+		position := position + 1 ].
+
+	^ position
+]
+
 { #category : #'menu messages' }
 RubTextEditor >> lineSelectAndEmptyCheck: returnBlock [
 	"If the current selection is an insertion point, expand it to be the entire current line; if after that's done the selection is still empty, then evaluate the returnBlock, which will typically consist of '[^ self]' in the caller -- check senders of this method to understand this."
 
 	self selectLine.  "if current selection is an insertion point, then first select the entire line in which occurs before proceeding"
 	self hasSelection ifFalse: [textArea flash.  ^ returnBlock value]
+]
+
+{ #category : #private }
+RubTextEditor >> lineStart: position [
+	"The offset of the start of the line of `postion`"
+
+	^ (self string
+		   lastIndexOf: Character cr
+		   startingAt: position - 1
+		   ifAbsent: [ 0 ]) + 1
 ]
 
 { #category : #private }


### PR DESCRIPTION
This is the second part of the journey. In one big PR. The first part was #13636

A big PR because there are some changes (and fixes) in various parts of the system, but that don't have much sense alone.
If reviewers think that is too much, I can move cleaning and refactoring in a distinct *prior* PR.

The first 3 commits are about `RubSmalltalkEditor>>#atCompletionPosition` that extends the completion point to anywhere in the code except in the indentation space (between the beginning of the line and the first non separator character). So `tab` will try to complete almost anywhere — the important word here is *try* :)

The following commits are about corresponding the caret position to some AST node. Some methods already exists (like `RBProgramNode>>#nodeForOffset:`) but focuses on a precise position. But code completion is related to what is before the cursor. So I introduce and use `RBProgramNode >> nodeBeforeOffset:`.

The magic commit is *CoASTHeuristicsResultSetBuilder>>#visitValueNode:  add the possibility to complete a new message send after any value*.
What it does is detecting the situation of an empty token completion after a value node, then tries to complete a message send from scratch with this node as a receiver. There is some magic involved, but because of the complexity of CoCompletionEngine I did not manage to find a cleaner way.

The rest of the commits are small bugfixes that I added after playing with it for a while.

OK. But is all this useful?

yes in some cases...

For `foo between: bar |`, where `|` is the caret, if you press *tab*, the completion menu opens and proposes `and:` at the first choice.

![Capture d’écran du 2023-05-03 17-42-44](https://user-images.githubusercontent.com/135828/236056409-e9be5b79-b4e0-4c49-8ca6-82bc93f2473b.png)

`Point |` proposes `x:y:` at the first choice.

![Capture d’écran du 2023-05-03 17-45-37](https://user-images.githubusercontent.com/135828/236056939-9cd766c8-918a-4b0b-8840-be954f517675.png)

`printOn: aStream   super |` proposes the full message send `printOn: aStream` at the first choice (require #13637 )

![Capture d’écran du 2023-05-03 18-09-02](https://user-images.githubusercontent.com/135828/236060855-bc91378c-3b8b-4239-998c-66937e5a10d0.png)

and less in other cases because existing heuristics are sometime very poor, thus asking for a completion on an empty prefix can give a lot of unfiltered garbage.
So heuristics could be improved anyway (or just rewrite from scratch because I was forced to hack it and I don't like the code at all).

The GUI need also some love (and tweaks), the completion menu closes itself less often (because current closing rely on invalid completion positions, but now most completion positions are valid) and I noticed some minor graphical glitches (tool still functional). I fixed all runtime errors I noticed when trying to complete weird things at weird places, so it should just work for you (or at least not crash)

About tests. ~~There are no tests on the completion part~~ because I don't understand the testing framework of the completion engine. I will try to add at least some smoke tests to ensure that completion menu open and don't crash on various kinds of empty tokens, maybe by extending the ones I added in #13636.
**Update:** I added an extensive smoke test with code snippets, this forces to try to get completion results on corner case source codes. It allowed me to spot and fix another bug.

Should fix #9327