### PR TITLE
CommentSourcePointer-move-methods-down 

### DIFF
--- a/src/Kernel-Tests/ClassDescriptionTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionTest.class.st
@@ -139,7 +139,7 @@ ClassDescriptionTest >> testSlots [
 
 { #category : #tests }
 ClassDescriptionTest >> testWhichCategoryIncludesSelector [
-	self assert: (ClassDescription whichCategoryIncludesSelector: #comment) equals: #'accessing - comment'.
+	self assert: (ClassDescription whichCategoryIncludesSelector: #printOn:)  equals: ##printing.
 	self assert: (ClassDescription whichCategoryIncludesSelector: #doesNotExist) equals: nil
 ]
 

--- a/src/Kernel-Tests/ClassDescriptionTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionTest.class.st
@@ -139,7 +139,7 @@ ClassDescriptionTest >> testSlots [
 
 { #category : #tests }
 ClassDescriptionTest >> testWhichCategoryIncludesSelector [
-	self assert: (ClassDescription whichCategoryIncludesSelector: #printOn:)  equals: ##printing.
+	self assert: (ClassDescription whichCategoryIncludesSelector: #printOn:)  equals: #printing.
 	self assert: (ClassDescription whichCategoryIncludesSelector: #doesNotExist) equals: nil
 ]
 

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -461,7 +461,7 @@ Class >> comment [
 Class >> comment: aStringOrText [
 	"Set the receiver's comment to be the argument, aStringOrText."
 
-	self instanceSide classComment: aStringOrText
+	self classComment: aStringOrText
 ]
 
 { #category : #'accessing - comment' }

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -313,6 +313,50 @@ Class >> classBuilder [
 		^ self classInstaller new builder
 ]
 
+{ #category : #'accessing - comment' }
+Class >> classComment: aString [
+	"Store the comment, aString or Text or RemoteString, associated with the class we are orgainzing.  Empty string gets stored only if had a non-empty one before."
+	^ self comment: aString stamp: '<historical>'
+]
+
+{ #category : #'accessing - comment' }
+Class >> classComment: aString stamp: aStamp [
+	"Store the comment, aString or Text or RemoteString, associated with the class we are organizing.  Empty string gets stored only if had a non-empty one before."
+
+	| pointer header oldComment oldStamp preamble |
+	oldComment := self comment.
+	oldStamp := self commentStamp.
+
+	aString string = oldComment string ifTrue: [ ^ self ].
+
+	pointer := self instanceSide commentSourcePointer ifNil: [0].
+
+
+	preamble := String streamContents: [ :file |
+		file cr; nextPut: $!.
+		header := String streamContents: [:strm |
+			strm
+				nextPutAll: self name;
+				nextPutAll: ' commentStamp: '.
+			aStamp storeOn: strm.
+			strm nextPutAll: ' prior: '; nextPutAll: pointer printString ].
+		file nextChunkPut: header; cr ].
+
+	SourceFiles
+		writeSource: aString
+		preamble: preamble
+		onSuccess: [ :newSourcePointer |
+			self instanceSide commentSourcePointer: newSourcePointer]
+		onFail: [ "ignore" ].
+
+	SystemAnnouncer uniqueInstance
+		class: self
+		oldComment: oldComment
+		newComment: aString
+		oldStamp: oldStamp
+		newStamp: aStamp
+]
+
 { #category : #'subclass creation' }
 Class >> classInstaller [
 	"Answer the class responsible of creating subclasses of myself in the system."
@@ -404,6 +448,45 @@ Class >> classVariables [
 Class >> classVariablesNeedFullDefinition [
 
 	^ self classVariables anySatisfy: [ :each | each needsFullDefinition ]
+]
+
+{ #category : #'accessing - comment' }
+Class >> comment [
+    ^ self commentSourcePointer
+		  ifNil: [ '' ]
+		  ifNotNil: [ :ptr | SourceFiles sourceCodeAt: ptr ]
+]
+
+{ #category : #'accessing - comment' }
+Class >> comment: aStringOrText [
+	"Set the receiver's comment to be the argument, aStringOrText."
+
+	self instanceSide classComment: aStringOrText
+]
+
+{ #category : #'accessing - comment' }
+Class >> comment: aStringOrText stamp: aStamp [
+	"Set the receiver's comment to be the argument, aStringOrText."
+
+	self classComment: aStringOrText stamp: aStamp
+]
+
+{ #category : #'accessing - comment' }
+Class >> commentSourcePointer [
+	^ commentSourcePointer
+]
+
+{ #category : #'accessing - comment' }
+Class >> commentSourcePointer: anObject [
+	commentSourcePointer := anObject
+]
+
+{ #category : #'accessing - comment' }
+Class >> commentStamp [
+
+	^ self commentSourcePointer
+		  ifNil: [ '' ]
+		  ifNotNil: [:sourcePointer | SourceFiles commentTimeStampAt: sourcePointer ]
 ]
 
 { #category : #'accessing - class hierarchy' }
@@ -616,6 +699,12 @@ Class >> hasClassVariable: aGlobal [
 	"Return whether the receiver has a class variables (shared variables among its class and subclasses) named: aString"
 
 	^ self classVariables identityIncludes: aGlobal
+]
+
+{ #category : #'accessing - comment' }
+Class >> hasComment [
+	"Return whether this class truly has a comment other than the default"
+	^ self commentSourcePointer isNotNil
 ]
 
 { #category : #testing }

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -329,7 +329,7 @@ Class >> classComment: aString stamp: aStamp [
 
 	aString string = oldComment string ifTrue: [ ^ self ].
 
-	pointer := self instanceSide commentSourcePointer ifNil: [0].
+	pointer := self commentSourcePointer ifNil: [0].
 
 
 	preamble := String streamContents: [ :file |

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -346,7 +346,7 @@ Class >> classComment: aString stamp: aStamp [
 		writeSource: aString
 		preamble: preamble
 		onSuccess: [ :newSourcePointer |
-			self instanceSide commentSourcePointer: newSourcePointer]
+			self commentSourcePointer: newSourcePointer]
 		onFail: [ "ignore" ].
 
 	SystemAnnouncer uniqueInstance

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -489,6 +489,12 @@ Class >> commentStamp [
 		  ifNotNil: [:sourcePointer | SourceFiles commentTimeStampAt: sourcePointer ]
 ]
 
+{ #category : #'accessing - comment' }
+Class >> commentStamp: changeStamp [
+	"update the changeStamp"
+	self comment: self comment stamp: changeStamp
+]
+
 { #category : #'accessing - class hierarchy' }
 Class >> commonSuperclassWith: aClass [
 	"return the next common superclass between me and aClass. If I am the superclass of aClass, that is me"

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -256,12 +256,6 @@ ClassDescription >> classVariablesString [
 	^ String streamContents: [ :stream | self classVariablesOn: stream ]
 ]
 
-{ #category : #'file in/out' }
-ClassDescription >> commentStamp: changeStamp [
-	"update the changeStamp"
-	self comment: self instanceSide comment stamp: changeStamp
-]
-
 { #category : #compiling }
 ClassDescription >> compile: sourceCode classified: protocol [
 	"Compile the source code in the context of the receiver and install the result in the receiver's method dictionary under the given protocol (this can be a protocol or a protocol name).

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -166,50 +166,6 @@ ClassDescription >> baseClass [
 ]
 
 { #category : #'accessing - comment' }
-ClassDescription >> classComment: aString [
-	"Store the comment, aString or Text or RemoteString, associated with the class we are orgainzing.  Empty string gets stored only if had a non-empty one before."
-	^ self comment: aString stamp: '<historical>'
-]
-
-{ #category : #'accessing - comment' }
-ClassDescription >> classComment: aString stamp: aStamp [
-	"Store the comment, aString or Text or RemoteString, associated with the class we are organizing.  Empty string gets stored only if had a non-empty one before."
-
-	| pointer header oldComment oldStamp preamble |
-	oldComment := self comment.
-	oldStamp := self commentStamp.
-
-	aString string = oldComment string ifTrue: [ ^ self ].
-
-	pointer := self instanceSide commentSourcePointer ifNil: [0].
-
-
-	preamble := String streamContents: [ :file |
-		file cr; nextPut: $!.
-		header := String streamContents: [:strm |
-			strm
-				nextPutAll: self name;
-				nextPutAll: ' commentStamp: '.
-			aStamp storeOn: strm.
-			strm nextPutAll: ' prior: '; nextPutAll: pointer printString ].
-		file nextChunkPut: header; cr ].
-
-	SourceFiles
-		writeSource: aString
-		preamble: preamble
-		onSuccess: [ :newSourcePointer |
-			self instanceSide commentSourcePointer: newSourcePointer]
-		onFail: [ "ignore" ].
-
-	SystemAnnouncer uniqueInstance
-		class: self
-		oldComment: oldComment
-		newComment: aString
-		oldStamp: oldStamp
-		newStamp: aStamp
-]
-
-{ #category : #'accessing - comment' }
 ClassDescription >> classCommentBlank [
 	"Classes can override this method to show another template."
 
@@ -298,45 +254,6 @@ ClassDescription >> classVariablesString [
 	"Answer a string of my class variable names separated by spaces."
 
 	^ String streamContents: [ :stream | self classVariablesOn: stream ]
-]
-
-{ #category : #'accessing - comment' }
-ClassDescription >> comment [
-    ^ self instanceSide commentSourcePointer
-		  ifNil: [ '' ]
-		  ifNotNil: [ :ptr | SourceFiles sourceCodeAt: ptr ]
-]
-
-{ #category : #'accessing - comment' }
-ClassDescription >> comment: aStringOrText [
-	"Set the receiver's comment to be the argument, aStringOrText."
-
-	self instanceSide classComment: aStringOrText
-]
-
-{ #category : #'accessing - comment' }
-ClassDescription >> comment: aStringOrText stamp: aStamp [
-	"Set the receiver's comment to be the argument, aStringOrText."
-
-	self instanceSide classComment: aStringOrText stamp: aStamp
-]
-
-{ #category : #'accessing - comment' }
-ClassDescription >> commentSourcePointer [
-	^ commentSourcePointer
-]
-
-{ #category : #'accessing - comment' }
-ClassDescription >> commentSourcePointer: anObject [
-	commentSourcePointer := anObject
-]
-
-{ #category : #'accessing - comment' }
-ClassDescription >> commentStamp [
-
-	^ self instanceSide commentSourcePointer
-		  ifNil: [ '' ]
-		  ifNotNil: [ SourceFiles commentTimeStampAt: commentSourcePointer]
 ]
 
 { #category : #'file in/out' }
@@ -519,12 +436,6 @@ ClassDescription >> forceNewFrom: anArray [
 { #category : #'accessing - parallel hierarchy' }
 ClassDescription >> hasClassSide [
 	^self subclassResponsibility
-]
-
-{ #category : #'accessing - comment' }
-ClassDescription >> hasComment [
-	"Return whether this class truly has a comment other than the default"
-	^ self instanceSide commentSourcePointer isNotNil
 ]
 
 { #category : #'instance variables' }

--- a/src/Kernel/Metaclass.class.st
+++ b/src/Kernel/Metaclass.class.st
@@ -121,6 +121,25 @@ Metaclass >> classVariables [
 ]
 
 { #category : #'accessing - comment' }
+Metaclass >> comment [
+    ^ self instanceSide comment
+]
+
+{ #category : #'accessing - comment' }
+Metaclass >> comment: aStringOrText [
+	"Set the receiver's comment to be the argument, aStringOrText."
+
+	self instanceSide comment: aStringOrText
+]
+
+{ #category : #'accessing - comment' }
+Metaclass >> comment: aStringOrText stamp: aStamp [
+	"Set the receiver's comment to be the argument, aStringOrText."
+
+	self instanceSide comment: aStringOrText stamp: aStamp
+]
+
+{ #category : #'accessing - comment' }
 Metaclass >> commentSourcePointer [
 	^ self instanceSide commentSourcePointer
 ]
@@ -128,6 +147,12 @@ Metaclass >> commentSourcePointer [
 { #category : #'accessing - comment' }
 Metaclass >> commentSourcePointer: anObject [
 	^ self instanceSide commentSourcePointer: anObject
+]
+
+{ #category : #'accessing - comment' }
+Metaclass >> commentStamp [
+
+	^ self instanceSide commentStamp
 ]
 
 { #category : #fileout }
@@ -165,6 +190,12 @@ Metaclass >> hasClassVarNamed: aString [
 	^self instanceSide
 		ifNil: [ false ]
 		ifNotNil: [ :class | class hasClassVarNamed: aString ]
+]
+
+{ #category : #'accessing - comment' }
+Metaclass >> hasComment [
+	"Return whether this class truly has a comment other than the default"
+	^ self instanceSide hasComment
 ]
 
 { #category : #compiling }

--- a/src/Kernel/Metaclass.class.st
+++ b/src/Kernel/Metaclass.class.st
@@ -155,6 +155,11 @@ Metaclass >> commentStamp [
 	^ self instanceSide commentStamp
 ]
 
+{ #category : #'accessing - comment' }
+Metaclass >> commentStamp: changeStamp [
+	self instanceSide commentStamp: changeStamp
+]
+
 { #category : #fileout }
 Metaclass >> definitionStringFor: aConfiguredPrinter [
 


### PR DESCRIPTION
to prepare moving the commentSourcePointer ivar down to class (as it is nil for MetaClass), this PR

- adds forwarding methods to MetaClass
- move methods down to Class