### PR TITLE
Small cleanup on protocol cleaning

### DIFF
--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -32,7 +32,7 @@ ClassOrganizationTest >> setUp [
 			         name: #ClassForTests;
 			         package: 'ClassOrganizer-Tests' ].
 
-	organization := ClassOrganization forClass: class.
+	organization := class organization.
 	organization addProtocol: 'empty'.
 	organization addProtocol: 'one'.
 	organization classify: #one under: 'one'
@@ -247,6 +247,37 @@ ClassOrganizationTest >> testRemoveProtocolIfEmpty [
 	self organization removeProtocolIfEmpty: 'empty'.
 	self assert: self organization protocolNames size equals: 1.
 	self assert: self organization protocolNames first equals: 'one'
+]
+
+{ #category : #tests }
+ClassOrganizationTest >> testRemoveUnexistingSelectorsFromProtocols [
+
+	class compiler
+		protocol: #one;
+		install: 'one 1'.
+
+	class compiler
+		protocol: #one;
+		install: 'oneBis 1'.
+
+	class compiler
+		protocol: #two;
+		install: 'two 2'.
+
+	organization removeEmptyProtocols.
+
+	self assertCollection: organization protocolNames hasSameElements: #( one two ).
+	self assertCollection: (organization protocolNamed: #one) methodSelectors hasSameElements: #( one oneBis ).
+	self assertCollection: (organization protocolNamed: #two) methodSelectors hasSameElements: #( two ).
+
+	"Now that we asserted the actual state is good, we can test the actual method."
+	class methodDict
+		removeKey: #oneBis;
+		removeKey: #two.
+	organization removeUnexistingSelectorsFromProtocols.
+
+	self assertCollection: organization protocolNames hasSameElements: #( one ).
+	self assertCollection: (organization protocolNamed: #one) methodSelectors hasSameElements: #( one )
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -268,7 +268,7 @@ ClassOrganizationTest >> testRemoveUnexistingSelectorsFromProtocols [
 	class methodDict
 		removeKey: #oneBis;
 		removeKey: #two.
-	organization removeUnexistingSelectorsFromProtocols.
+	organization removeNonexistentSelectorsFromProtocols.
 
 	self assertCollection: organization protocolNames hasSameElements: #( one ).
 	self assertCollection: (organization protocolNamed: #one) methodSelectors hasSameElements: #( one )

--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -226,25 +226,7 @@ ClassOrganizationTest >> testRemoveElement [
 ]
 
 { #category : #tests }
-ClassOrganizationTest >> testRemoveNonExistingProtocol [
-
-	self organization removeProtocolIfEmpty: 'non-existent'
-]
-
-{ #category : #tests }
-ClassOrganizationTest >> testRemoveProtocolIfEmpty [
-
-	self assert: self organization protocolNames size equals: 2.
-	"just ignore removing of non empty categories"
-	self organization removeProtocolIfEmpty: 'one'.
-	self assert: self organization protocolNames size equals: 2.
-	self organization removeProtocolIfEmpty: 'empty'.
-	self assert: self organization protocolNames size equals: 1.
-	self assert: self organization protocolNames first equals: 'one'
-]
-
-{ #category : #tests }
-ClassOrganizationTest >> testRemoveUnexistingSelectorsFromProtocols [
+ClassOrganizationTest >> testRemoveNonexistentSelectorsFromProtocols [
 
 	class compiler
 		protocol: #one;
@@ -272,6 +254,24 @@ ClassOrganizationTest >> testRemoveUnexistingSelectorsFromProtocols [
 
 	self assertCollection: organization protocolNames hasSameElements: #( one ).
 	self assertCollection: (organization protocolNamed: #one) methodSelectors hasSameElements: #( one )
+]
+
+{ #category : #tests }
+ClassOrganizationTest >> testRemoveNonexistingProtocol [
+
+	self organization removeProtocolIfEmpty: 'non-existent'
+]
+
+{ #category : #tests }
+ClassOrganizationTest >> testRemoveProtocolIfEmpty [
+
+	self assert: self organization protocolNames size equals: 2.
+	"just ignore removing of non empty categories"
+	self organization removeProtocolIfEmpty: 'one'.
+	self assert: self organization protocolNames size equals: 2.
+	self organization removeProtocolIfEmpty: 'empty'.
+	self assert: self organization protocolNames size equals: 1.
+	self assert: self organization protocolNames first equals: 'one'
 ]
 
 { #category : #tests }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -55,13 +55,6 @@ ClassOrganization >> classify: selector under: aProtocol [
 	oldProtocol ifNotNil: [ self notifyOfChangedSelector: selector from: oldProtocol name to: newProtocol name ]
 ]
 
-{ #category : #cleanup }
-ClassOrganization >> cleanUpProtocolsForClass: aClass [
-	"remove all entries that have no methods"
-
-	self allMethodSelectors do: [ :each | (aClass includesSelector: each) ifFalse: [ self removeElement: each ] ]
-]
-
 { #category : #copying }
 ClassOrganization >> copyFrom: otherOrganization [
 
@@ -230,6 +223,15 @@ ClassOrganization >> removeProtocolIfEmpty: aProtocol [
 	protocols := protocols copyWithout: protocol.
 	SystemAnnouncer announce: (ProtocolRemoved in: self organizedClass protocol: protocol).
 	self notifyOfChangedProtocolNamesFrom: oldProtocolNames to: self protocolNames
+]
+
+{ #category : #cleanup }
+ClassOrganization >> removeUnexistingSelectorsFromProtocols [
+	"For each protocol, remove the selectors that are not present in the class."
+
+	self allMethodSelectors
+		reject: [ :selector | self organizedClass includesSelector: selector ]
+		thenDo: [ :selector | self removeElement: selector ]
 ]
 
 { #category : #removing }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -195,6 +195,15 @@ ClassOrganization >> removeEmptyProtocols [
 	self protocols copy do: [ :protocol | self removeProtocolIfEmpty: protocol ]
 ]
 
+{ #category : #cleanup }
+ClassOrganization >> removeNonexistentSelectorsFromProtocols [
+	"For each protocol, remove the selectors that are not present in the class."
+
+	self allMethodSelectors
+		reject: [ :selector | self organizedClass includesSelector: selector ]
+		thenDo: [ :selector | self removeElement: selector ]
+]
+
 { #category : #removing }
 ClassOrganization >> removeProtocolIfEmpty: aProtocol [
 	"I take a protocol or a protocol name and remvoe it if it is empty."
@@ -210,15 +219,6 @@ ClassOrganization >> removeProtocolIfEmpty: aProtocol [
 	protocols := protocols copyWithout: protocol.
 	SystemAnnouncer announce: (ProtocolRemoved in: self organizedClass protocol: protocol).
 	SystemAnnouncer announce: (ClassReorganized class: self organizedClass)
-]
-
-{ #category : #cleanup }
-ClassOrganization >> removeUnexistingSelectorsFromProtocols [
-	"For each protocol, remove the selectors that are not present in the class."
-
-	self allMethodSelectors
-		reject: [ :selector | self organizedClass includesSelector: selector ]
-		thenDo: [ :selector | self removeElement: selector ]
 ]
 
 { #category : #removing }

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -200,11 +200,9 @@ ShiftClassBuilder >> compareWithOldClass [
 
 { #category : #compiling }
 ShiftClassBuilder >> compileMethods [
-	| toRemove |
-	newClass compileAllFrom: self oldClass.
 
-	toRemove := newClass organization allMethodSelectors reject: [ :aSelector | newClass includesSelector: aSelector ].
-	toRemove do: [ :aSelector | newClass organization removeElement: aSelector  ]
+	newClass compileAllFrom: self oldClass.
+	newClass organization removeUnexistingSelectorsFromProtocols
 ]
 
 { #category : #building }

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -202,7 +202,7 @@ ShiftClassBuilder >> compareWithOldClass [
 ShiftClassBuilder >> compileMethods [
 
 	newClass compileAllFrom: self oldClass.
-	newClass organization removeUnexistingSelectorsFromProtocols
+	newClass organization removeNonexistentSelectorsFromProtocols
 ]
 
 { #category : #building }

--- a/src/TraitsV2/TraitBuilderEnhancer.class.st
+++ b/src/TraitsV2/TraitBuilderEnhancer.class.st
@@ -35,8 +35,8 @@ TraitBuilderEnhancer class >> isApplicableFor: aBuilder [
 TraitBuilderEnhancer >> afterMethodsCompiled: aBuilder [
 	"we need to remove the categories leftover after removing Traits"
 
-	aBuilder newClass organization cleanUpProtocolsForClass: aBuilder newClass.
-	aBuilder newClass class organization cleanUpProtocolsForClass: aBuilder newClass class.
+	aBuilder newClass organization removeUnexistingSelectorsFromProtocols.
+	aBuilder newClass class organization removeUnexistingSelectorsFromProtocols.
 
 	(self isTraitedMetaclass: aBuilder) ifFalse: [ ^ self ].
 

--- a/src/TraitsV2/TraitBuilderEnhancer.class.st
+++ b/src/TraitsV2/TraitBuilderEnhancer.class.st
@@ -35,8 +35,8 @@ TraitBuilderEnhancer class >> isApplicableFor: aBuilder [
 TraitBuilderEnhancer >> afterMethodsCompiled: aBuilder [
 	"we need to remove the categories leftover after removing Traits"
 
-	aBuilder newClass organization removeUnexistingSelectorsFromProtocols.
-	aBuilder newClass class organization removeUnexistingSelectorsFromProtocols.
+	aBuilder newClass organization removeNonexistentSelectorsFromProtocols.
+	aBuilder newClass class organization removeNonexistentSelectorsFromProtocols.
 
 	(self isTraitedMetaclass: aBuilder) ifFalse: [ ^ self ].
 


### PR DESCRIPTION
- cleanUpProtocolsForClass: is always called with the organized class as parameter ==> Remove the parameter
- The name is not really explicit. What cleanup? I propose removeUnexistingSelectorsFromProtocols
- The method had no test which is now fixed 

Bonus: ClassOrganizationTest should use the actual organization of the class and not create a duplicated one to keep coherence in the tests.