### PR TITLE
Completion autoclose menu

### DIFF
--- a/src/HeuristicCompletion-Model/CoCompletionContext.class.st
+++ b/src/HeuristicCompletion-Model/CoCompletionContext.class.st
@@ -10,6 +10,7 @@ Class {
 		'engine',
 		'source',
 		'position',
+		'completionTokenStart',
 		'completionBuilder',
 		'completionClass',
 		'completion'
@@ -23,6 +24,7 @@ CoCompletionContext class >> engine: aCompletionEngine class: aClass source: aSt
 	^ self new
 		completionClass: aClass;
 		engine: aCompletionEngine;
+		completionTokenStart: aCompletionEngine completionTokenStart;
 		source: aString;
 		position: anInteger;
 		yourself
@@ -91,7 +93,13 @@ CoCompletionContext >> completionToken [
 { #category : #accessing }
 CoCompletionContext >> completionTokenStart [
 
-	^ self engine completionTokenStart
+	^ completionTokenStart
+]
+
+{ #category : #accessing }
+CoCompletionContext >> completionTokenStart: anObject [
+
+	completionTokenStart := anObject
 ]
 
 { #category : #accessing }

--- a/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
@@ -148,6 +148,36 @@ CoCompletionEngineTest >> testEndGoesToEndOfLine [
 ]
 
 { #category : #'tests - interaction' }
+CoCompletionEngineTest >> testExitingWordClosesCompletionContext [
+
+	self setEditorTextWithCaret: 'self mEthOdThatDoesNotExis|t toto'.
+
+	editor textArea openInWorld.
+	controller openMenu.
+
+	self assert: controller hasCompletionContext.
+	self assert: controller completionToken equals: 'mEthOdThatDoesNotExis'.
+	editor keyDown: (self keyboardEventFor: Character arrowRight).
+	self assert: controller completionToken equals: 'mEthOdThatDoesNotExist'.
+	self assert: controller hasCompletionContext.
+	editor keyDown: (self keyboardEventFor: Character arrowRight).
+	self assert: controller completionToken equals: ''.
+	self deny: controller hasCompletionContext.
+
+	self setEditorTextWithCaret: 'self m|EthOdThatDoesNotExist toto'.
+	controller openMenu.
+
+	self assert: controller hasCompletionContext.
+	self assert: controller completionToken equals: 'm'.
+	editor keyDown: (self keyboardEventFor: Character arrowLeft).
+	self assert: controller completionToken equals: ''.
+	self assert: controller hasCompletionContext.
+	editor keyDown: (self keyboardEventFor: Character arrowLeft).
+	self assert: controller completionToken equals: 'self'.
+	self deny: controller hasCompletionContext
+]
+
+{ #category : #'tests - interaction' }
 CoCompletionEngineTest >> testHomeClosesCompletionContext [
 
 	| text |

--- a/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
@@ -62,9 +62,7 @@ CoCompletionEngineTest >> testAdvanceWordTwiceClosesCompletionContext [
 { #category : #'tests - interaction' }
 CoCompletionEngineTest >> testCmdCtrlLeftClosesDetail [
 
-	<expectedFailure>
-	"GUI/test issue caused by the fact that the begin of a word is now a valid completion point, thus the completion menu remains open.
-	Will be fixed late once we decide what we want"
+	"The start of a word does not close the completion menu"
 
 	| text |
 	text := 'self asOrdered'.
@@ -85,7 +83,7 @@ CoCompletionEngineTest >> testCmdCtrlLeftClosesDetail [
 		((self keyboardEventFor: Character arrowLeft) buttons:
 			 KMModifier meta eventCode).
 
-	self deny: controller hasDetail
+	self assert: controller hasDetail
 ]
 
 { #category : #'tests - interaction' }

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -598,7 +598,6 @@ CompletionEngine >> updateCompletionAfterEdition: aParagraphEditor [
 	(aParagraphEditor isNil or: [ self isMenuOpen not ]) ifTrue: [
 		^ self ].
 
-	aParagraphEditor atCompletionPosition ifFalse: [ ^ self closeMenu ].
 	context completionTokenStart = self completionTokenStart ifFalse: [ ^ self closeMenu ].
 
 	context narrowWith: aParagraphEditor wordAtCaret

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -599,6 +599,7 @@ CompletionEngine >> updateCompletionAfterEdition: aParagraphEditor [
 		^ self ].
 
 	aParagraphEditor atCompletionPosition ifFalse: [ ^ self closeMenu ].
+	context completionTokenStart = self completionTokenStart ifFalse: [ ^ self closeMenu ].
 
 	context narrowWith: aParagraphEditor wordAtCaret
 ]

--- a/src/NECompletion/CompletionContext.class.st
+++ b/src/NECompletion/CompletionContext.class.st
@@ -51,6 +51,12 @@ CompletionContext >> completionToken [
 	^ completionToken ifNil: [ ^ ''  ]
 ]
 
+{ #category : #replacement }
+CompletionContext >> completionTokenStart [
+	
+	^ engine completionTokenStart
+]
+
 { #category : #accessing }
 CompletionContext >> engine [
 	^ engine


### PR DESCRIPTION
Follow up of  #13638
This reproduces the previous behavior of the completion menu that closes itself when "exiting" a word (with left and right arrows, for instance).
And it also adds a test because this behavior was not tested.

Previous behavior used `atCompletionPosition` to close the menu, but that does not work anymore because we almost always at a completion position now.
To reproduces the behavior, we need to check that the current completion context is still valid for the current caret. To do that, I just store the start of the completion token in the completion context as an identifier. If the start changes, it means that the current context is not appliable, so the menu is closed.

The difference with the previous behavior is the start of words does not close the menu.
It's not perfect, but it's better.