### PR TITLE
Start protocol announcements testing + add feature to Announcer

### DIFF
--- a/src/Announcements-Core-Tests/AnnouncerTest.class.st
+++ b/src/Announcements-Core-Tests/AnnouncerTest.class.st
@@ -143,6 +143,19 @@ AnnouncerTest >> testPreparationAnnouncementDeliveryWhenNoSubscriptions [
 ]
 
 { #category : #'tests - subscribing' }
+AnnouncerTest >> testPreventDuring [
+
+	| announcement instance |
+	announcer when: AnnouncementMockA do: [ self fail ] for: self.
+	announcer when: AnnouncementMockB do: [ :ann | announcement := ann ] for: self.
+
+	announcer prevent: AnnouncementMockA during: [
+		announcer announce: AnnouncementMockA.
+		instance := announcer announce: AnnouncementMockB ].
+	self assert: announcement equals: instance
+]
+
+{ #category : #'tests - subscribing' }
 AnnouncerTest >> testSubscribeBlock [
 	| announcement instance |
 	announcer when: AnnouncementMockA do: [ :ann | announcement := ann ] for: self.

--- a/src/Announcements-Core/Announcer.class.st
+++ b/src/Announcements-Core/Announcer.class.st
@@ -1,11 +1,15 @@
 "
 The implementation uses a threadsafe subscription registry, in the sense that registering, unregistering, and announcing from an announcer at the same time in different threads should never cause failures.
+
+
+The method #prevent:during: allows one to prevent the firing of some announcements during the execution of a block wile letting the other announcements go throuht.
 "
 Class {
 	#name : #Announcer,
 	#superclass : #Object,
 	#instVars : [
-		'registry'
+		'registry',
+		'preventedAnnouncements'
 	],
 	#category : #'Announcements-Core-Base'
 }
@@ -15,9 +19,11 @@ Announcer >> announce: anAnnouncement [
 
 	| announcement |
 	announcement := anAnnouncement asAnnouncement.
-	registry ifNotNil: [
-		registry deliver: announcement
-		].
+
+	"If the user required to prevent the current announcement, we stop here."
+	(self preventedAnnouncements handlesAnnouncement: announcement) ifTrue: [ ^ self ].
+
+	registry ifNotNil: [ registry deliver: announcement ].
 	^ announcement
 ]
 
@@ -49,6 +55,24 @@ Announcer >> initialize [
 { #category : #statistics }
 Announcer >> numberOfSubscriptions [
 	^ registry numberOfSubscriptions
+]
+
+{ #category : #announce }
+Announcer >> prevent: anAnnouncementClass during: aBlock [
+	"This method allows one to ensure that an Announcement class or an AnnouncementSet will never be announced during the execution of a block.
+	One of the goal can be for example to allow to send messages that should announce something without doing the announcement multiple times while letting the other announcements pass throught."
+
+	| previousValue |
+	previousValue := self preventedAnnouncements copy.
+	[
+	preventedAnnouncements := self preventedAnnouncements , anAnnouncementClass.
+	aBlock value ] ensure: [ preventedAnnouncements := previousValue ]
+]
+
+{ #category : #accessing }
+Announcer >> preventedAnnouncements [
+
+	^ preventedAnnouncements ifNil: [ preventedAnnouncements := AnnouncementSet new ]
 ]
 
 { #category : #subscription }

--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -17,12 +17,6 @@ ClassOrganizationTest >> organization [
 ]
 
 { #category : #running }
-ClassOrganizationTest >> runCase [
-	SystemAnnouncer uniqueInstance
-		suspendAllWhile: [ super runCase ]
-]
-
-{ #category : #running }
 ClassOrganizationTest >> setUp [
 
 	super setUp.

--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -3,11 +3,7 @@ SUnit tests for class organization
 "
 Class {
 	#name : #ClassOrganizationTest,
-	#superclass : #TestCase,
-	#instVars : [
-		'organization',
-		'class'
-	],
+	#superclass : #ProtocolTest,
 	#category : #'Kernel-Tests-Protocols'
 }
 
@@ -16,26 +12,20 @@ ClassOrganizationTest >> organization [
 	^ organization
 ]
 
+{ #category : #private }
+ClassOrganizationTest >> performTest [
+
+	SystemAnnouncer uniqueInstance suspendAllWhile: [ super performTest ]
+]
+
 { #category : #running }
 ClassOrganizationTest >> setUp [
 
 	super setUp.
 
-	class := self class classInstaller make: [ :aBuilder |
-		         aBuilder
-			         name: #ClassForTests;
-			         package: 'ClassOrganizer-Tests' ].
-
-	organization := ClassOrganization forClass: class.
 	organization addProtocol: 'empty'.
 	organization addProtocol: 'one'.
 	organization classify: #one under: 'one'
-]
-
-{ #category : #running }
-ClassOrganizationTest >> tearDown [
-	class removeFromSystem.
-	super tearDown
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/ProtocolAnnouncementsTest.class.st
+++ b/src/Kernel-Tests/ProtocolAnnouncementsTest.class.st
@@ -1,0 +1,54 @@
+"
+I am a test case specialized in checking that the announcements linked to protocol management are right.
+"
+Class {
+	#name : #ProtocolAnnouncementsTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'class',
+		'organization'
+	],
+	#category : #'Kernel-Tests-Protocols'
+}
+
+{ #category : #running }
+ProtocolAnnouncementsTest >> classNameForTests [
+
+	^ #ClassForTests
+]
+
+{ #category : #running }
+ProtocolAnnouncementsTest >> setUp [
+
+	super setUp.
+	class := self class classInstaller make: [ :aBuilder |
+		         aBuilder
+			         name: self classNameForTests;
+			         package: 'ClassOrganizer-Tests' ].
+
+	organization := class organization
+]
+
+{ #category : #running }
+ProtocolAnnouncementsTest >> tearDown [
+
+	class package removeFromSystem.
+	SystemAnnouncer uniqueInstance unsubscribe: self.
+	super tearDown
+]
+
+{ #category : #tests }
+ProtocolAnnouncementsTest >> testAddProtocolAnnouncement [
+
+	| gotAnnouncement |
+	gotAnnouncement := false.
+	SystemAnnouncer uniqueInstance
+		when: ProtocolAdded
+		do: [ :ann |
+			gotAnnouncement := true.
+			self assert: ann protocol name equals: #king.
+			self assert: ann classReorganized name equals: self classNameForTests ]
+		for: self.
+	organization addProtocol: #king.
+	self assert: gotAnnouncement
+]

--- a/src/Kernel-Tests/ProtocolAnnouncementsTest.class.st
+++ b/src/Kernel-Tests/ProtocolAnnouncementsTest.class.st
@@ -3,36 +3,13 @@ I am a test case specialized in checking that the announcements linked to protoc
 "
 Class {
 	#name : #ProtocolAnnouncementsTest,
-	#superclass : #TestCase,
-	#instVars : [
-		'class',
-		'organization'
-	],
+	#superclass : #ProtocolTest,
 	#category : #'Kernel-Tests-Protocols'
 }
 
 { #category : #running }
-ProtocolAnnouncementsTest >> classNameForTests [
-
-	^ #ClassForTests
-]
-
-{ #category : #running }
-ProtocolAnnouncementsTest >> setUp [
-
-	super setUp.
-	class := self class classInstaller make: [ :aBuilder |
-		         aBuilder
-			         name: self classNameForTests;
-			         package: 'ClassOrganizer-Tests' ].
-
-	organization := class organization
-]
-
-{ #category : #running }
 ProtocolAnnouncementsTest >> tearDown [
 
-	class package removeFromSystem.
 	SystemAnnouncer uniqueInstance unsubscribe: self.
 	super tearDown
 ]

--- a/src/Kernel-Tests/ProtocolAnnouncementsTest.class.st
+++ b/src/Kernel-Tests/ProtocolAnnouncementsTest.class.st
@@ -66,13 +66,16 @@ ProtocolAnnouncementsTest >> testRenameProtocolAsAnnounceClassReorganizedOnce [
 { #category : #tests }
 ProtocolAnnouncementsTest >> testRenameProtocolAsAnnounceNewProtocol [
 
+	self skip. "This hihglight the problem of https://github.com/pharo-project/pharo/pull/13494
+	But we still need to work on this to fix this test."
+
 	organization classify: #king under: #demon.
 
-	self when: ProtocolAdded do: [ :ann |1halt.
+	self when: ProtocolAdded do: [ :ann |
 		self assert: ann protocol name equals: #titan.
 		self assert: ann classReorganized name equals: self classNameForTests ].
 
-	self when: ClassReorganized do: [ :ann | 1halt.self assert: ann classReorganized name equals: self classNameForTests ].
+	self when: ClassReorganized do: [ :ann | self assert: ann classReorganized name equals: self classNameForTests ].
 
 	organization renameProtocol: #demon as: #titan.
 

--- a/src/Kernel-Tests/ProtocolAnnouncementsTest.class.st
+++ b/src/Kernel-Tests/ProtocolAnnouncementsTest.class.st
@@ -4,8 +4,18 @@ I am a test case specialized in checking that the announcements linked to protoc
 Class {
 	#name : #ProtocolAnnouncementsTest,
 	#superclass : #ProtocolTest,
+	#instVars : [
+		'numberOfAnnouncements'
+	],
 	#category : #'Kernel-Tests-Protocols'
 }
+
+{ #category : #running }
+ProtocolAnnouncementsTest >> setUp [
+
+	super setUp.
+	numberOfAnnouncements := 0
+]
 
 { #category : #running }
 ProtocolAnnouncementsTest >> tearDown [
@@ -17,15 +27,23 @@ ProtocolAnnouncementsTest >> tearDown [
 { #category : #tests }
 ProtocolAnnouncementsTest >> testAddProtocolAnnouncement [
 
-	| gotAnnouncement |
-	gotAnnouncement := false.
-	SystemAnnouncer uniqueInstance
-		when: ProtocolAdded
-		do: [ :ann |
-			gotAnnouncement := true.
-			self assert: ann protocol name equals: #king.
-			self assert: ann classReorganized name equals: self classNameForTests ]
-		for: self.
+	self when: ProtocolAdded do: [ :ann |
+		self assert: ann protocol name equals: #king.
+		self assert: ann classReorganized name equals: self classNameForTests ].
+
+	self when: ClassReorganized do: [ :ann | self assert: ann classReorganized name equals: self classNameForTests ].
+
 	organization addProtocol: #king.
-	self assert: gotAnnouncement
+	self assert: numberOfAnnouncements equals: 2
+]
+
+{ #category : #helpers }
+ProtocolAnnouncementsTest >> when: anAnnouncement do: aBlock [
+
+	SystemAnnouncer uniqueInstance
+		when: anAnnouncement
+		do: [ :ann |
+			numberOfAnnouncements := numberOfAnnouncements + 1.
+			aBlock cull: ann ]
+		for: self
 ]

--- a/src/Kernel-Tests/ProtocolAnnouncementsTest.class.st
+++ b/src/Kernel-Tests/ProtocolAnnouncementsTest.class.st
@@ -37,6 +37,48 @@ ProtocolAnnouncementsTest >> testAddProtocolAnnouncement [
 	self assert: numberOfAnnouncements equals: 2
 ]
 
+{ #category : #tests }
+ProtocolAnnouncementsTest >> testClassifyUnderAnnounceNewProtocol [
+
+	self when: ProtocolAdded do: [ :ann |
+		self assert: ann protocol name equals: #titan.
+		self assert: ann classReorganized name equals: self classNameForTests ].
+
+	self when: ClassReorganized do: [ :ann | self assert: ann classReorganized name equals: self classNameForTests ].
+
+	organization classify: #king under: #titan.
+	self assert: numberOfAnnouncements equals: 2
+]
+
+{ #category : #tests }
+ProtocolAnnouncementsTest >> testRenameProtocolAsAnnounceClassReorganizedOnce [
+	"This is a regerssion test because at some point the class reorganized announcement got duplicated."
+
+	organization classify: #king under: #demon.
+
+	self when: ClassReorganized do: [ :ann | self assert: ann classReorganized name equals: self classNameForTests ].
+
+	organization renameProtocol: #demon as: #titan.
+
+	self assert: numberOfAnnouncements equals: 1
+]
+
+{ #category : #tests }
+ProtocolAnnouncementsTest >> testRenameProtocolAsAnnounceNewProtocol [
+
+	organization classify: #king under: #demon.
+
+	self when: ProtocolAdded do: [ :ann |1halt.
+		self assert: ann protocol name equals: #titan.
+		self assert: ann classReorganized name equals: self classNameForTests ].
+
+	self when: ClassReorganized do: [ :ann | 1halt.self assert: ann classReorganized name equals: self classNameForTests ].
+
+	organization renameProtocol: #demon as: #titan.
+
+	self assert: numberOfAnnouncements equals: 2
+]
+
 { #category : #helpers }
 ProtocolAnnouncementsTest >> when: anAnnouncement do: aBlock [
 

--- a/src/Kernel-Tests/ProtocolTest.class.st
+++ b/src/Kernel-Tests/ProtocolTest.class.st
@@ -8,7 +8,7 @@ Class {
 	#category : #'Kernel-Tests-Protocols'
 }
 
-{ #category : #running }
+{ #category : #helpers }
 ProtocolTest >> classNameForTests [
 
 	^ #ClassForTests

--- a/src/Kernel-Tests/ProtocolTest.class.st
+++ b/src/Kernel-Tests/ProtocolTest.class.st
@@ -1,0 +1,34 @@
+Class {
+	#name : #ProtocolTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'organization',
+		'class'
+	],
+	#category : #'Kernel-Tests-Protocols'
+}
+
+{ #category : #running }
+ProtocolTest >> classNameForTests [
+
+	^ #ClassForTests
+]
+
+{ #category : #running }
+ProtocolTest >> setUp [
+
+	super setUp.
+	class := self class classInstaller make: [ :aBuilder |
+		         aBuilder
+			         name: self classNameForTests;
+			         package: 'ClassOrganizer-Tests' ].
+
+	organization := class organization
+]
+
+{ #category : #running }
+ProtocolTest >> tearDown [
+
+	class package removeFromSystem.
+	super tearDown
+]

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -240,28 +240,31 @@ ClassOrganization >> renameProtocol: anOldProtocol as: aNewProtocol [
 
 	(self hasProtocol: anOldProtocol) ifFalse: [ ^ self ].
 
-	oldProtocol := self ensureProtocol: anOldProtocol.
-	"This method still contains a hack. We do not announce the creation of the new protocol and removal of the old protocol if the new protocol does not exist in the class yet.
+	"We will announce the class reorganized later in this method. No need to duplicate the same announcement."
+	SystemAnnouncer uniqueInstance prevent: ClassReorganized during: [
+		oldProtocol := self ensureProtocol: anOldProtocol.
+
+		"This method still contains a hack. We do not announce the creation of the new protocol and removal of the old protocol if the new protocol does not exist in the class yet.
 	This is due to the fact that RPackage currently has a bug while listening to those events. We need to locate and fix this bug in order to do all announcements..."
-	(self hasProtocol: aNewProtocol)
-		ifTrue: [
-			newProtocol := self ensureProtocol: aNewProtocol.
+		(self hasProtocol: aNewProtocol)
+			ifTrue: [
+				newProtocol := self ensureProtocol: aNewProtocol.
 
-			oldProtocol = newProtocol ifTrue: [ ^ self ].
+				oldProtocol = newProtocol ifTrue: [ ^ self ].
 
-			newProtocol addAllMethodsFrom: oldProtocol ]
-		ifFalse: [ "Ideally the code in the #ifTrue: should be executed all the time and the #ifFalse: should be removed."
-			| newProtocolName |
-			newProtocolName := aNewProtocol isString
-				                   ifTrue: [ aNewProtocol ]
-				                   ifFalse: [ aNewProtocol name ].
-			oldProtocol name = newProtocolName ifTrue: [ ^ self ].
-			newProtocol := oldProtocol copy
-				               name: newProtocolName;
-				               yourself.
-			protocols := protocols copyWith: newProtocol ].
-	oldProtocol resetMethodSelectors.
-	self removeProtocolIfEmpty: oldProtocol.
+				newProtocol addAllMethodsFrom: oldProtocol ]
+			ifFalse: [ "Ideally the code in the #ifTrue: should be executed all the time and the #ifFalse: should be removed."
+				| newProtocolName |
+				newProtocolName := aNewProtocol isString
+					                   ifTrue: [ aNewProtocol ]
+					                   ifFalse: [ aNewProtocol name ].
+				oldProtocol name = newProtocolName ifTrue: [ ^ self ].
+				newProtocol := oldProtocol copy
+					               name: newProtocolName;
+					               yourself.
+				protocols := protocols copyWith: newProtocol ].
+		oldProtocol resetMethodSelectors.
+		self removeProtocolIfEmpty: oldProtocol ].
 
 	"Announce the changes in the system"
 	self notifyOfChangedProtocolNamesFrom: oldProtocol name to: newProtocol name.


### PR DESCRIPTION
The primary goal of this PR is to create the basic infrastructure to test the announcements related to protocols. 

Indeed, I added tests on protocols to ensure the behavior is correct but none of them checks the announcements. Here are a first bunch of tests about the addition of protocols. 

We have two special cases:
- testRenameProtocolAsAnnounceNewProtocol is skipped because the current behavior is buggy but not so easy to fix currently
- testRenameProtocolAsAnnounceClassReorganizedOnce was failing when I implemented it because the ClassReorganized event was fired two times by the method with the same values. This is a waste and we should fire the event only once.

To fix the double event firing I had to add a new feature on Announcer. 

The feature can be used with the method #prevent:during:. This method takes an announcement class or an annoucement set as parameter and will silence all announcements of this kind during the execution of a block.

Like this I can call methods that announce ClassReorganized without actually announcing it in my specific case. But other events such as ProtocolAdded can still be announced and are working just as expected.