### PR TITLE
fix iceberg version for Pharo 11

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -74,7 +74,7 @@ BaselineOfPharo class >> iceberg [
 		newName: 'Iceberg' 
 		owner: 'pharo-vcs' 
 		project: 'iceberg' 
-		version: 'dev-2.0' 
+		version: 'v2.1.0' 
 		sourceDir: nil
 ]
 


### PR DESCRIPTION
use v2.1.0 for Pharo 11