### PR TITLE
Introduce ClassDescription>>#protocolNames and start using it

### DIFF
--- a/src/Collections-Sequenceable-Tests/OrderedDictionaryTest.class.st
+++ b/src/Collections-Sequenceable-Tests/OrderedDictionaryTest.class.st
@@ -735,19 +735,15 @@ OrderedDictionaryTest >> testDictionary [
 
 { #category : #tests }
 OrderedDictionaryTest >> testDictionaryPublicProtocolCompatibility [
-	| dictionary |
 
+	| dictionary |
 	dictionary := self emptyDictionary.
-	{dictionary -> Dictionary.
-	dictionary class -> Dictionary class}
-		do: [:assoc |
-			assoc value protocols
-				reject: [:protocol |
-					#('private' 'print' 'undeclared' 'copy' 'compar' '*')
-						anySatisfy: [:each | protocol asString beginsWith: each]]
-				thenDo: [:protocol |
-					(assoc value selectorsInProtocol: protocol)
-						do: [:each | self assert: (assoc key respondsTo: each)]]]
+	{
+		(dictionary -> Dictionary).
+		(dictionary class -> Dictionary class) } do: [ :assoc |
+		assoc value protocolNames
+			reject: [ :protocol | #( 'private' 'print' 'undeclared' 'copy' 'compar' '*' ) anySatisfy: [ :each | protocol asString beginsWith: each ] ]
+			thenDo: [ :protocol | (assoc value selectorsInProtocol: protocol) do: [ :each | self assert: (assoc key respondsTo: each) ] ] ]
 ]
 
 { #category : #tests }

--- a/src/Collections-Unordered-Tests/DictionaryTest.class.st
+++ b/src/Collections-Unordered-Tests/DictionaryTest.class.st
@@ -443,7 +443,7 @@ DictionaryTest >> testDictionaryPublicProtocolCompatibility [
 	{(dict -> Dictionary).
 	(dict class -> Dictionary class)}
 		do: [ :assoc |
-			assoc value protocols
+			assoc value protocolNames
 				reject: [ :protocol |
 					#('private' 'print' 'undeclared' 'copy' 'compar' '*')
 						anySatisfy: [ :each | protocol asString beginsWith: each ] ]

--- a/src/FuzzyMatcher-Tests/FuzzyMatcherTest.class.st
+++ b/src/FuzzyMatcher-Tests/FuzzyMatcherTest.class.st
@@ -65,7 +65,7 @@ FuzzyMatcherTest >> testChangePattern [
 FuzzyMatcherTest >> testClassSideAPI [
 
 	"If the protocol is changed, so should the class comment."
-	FuzzyMatcher class protocols detect: [ :p | p = #'utilities - api' ].
+	FuzzyMatcher class protocolNames detect: [ :p | p = #'utilities - api' ].
 
 	self
 		assert: (FuzzyMatcher allMatching: #a in: #(a b ab))

--- a/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
@@ -1,0 +1,48 @@
+"
+I am a test case responsible of testing ClassDescription protocol management.
+"
+Class {
+	#name : #ClassDescriptionProtocolsTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'class'
+	],
+	#category : #'Kernel-Tests-Protocols'
+}
+
+{ #category : #helpers }
+ClassDescriptionProtocolsTest >> classNameForTests [
+
+	^ #ClassForTests
+]
+
+{ #category : #running }
+ClassDescriptionProtocolsTest >> setUp [
+
+	super setUp.
+	class := self class classInstaller make: [ :aBuilder |
+		         aBuilder
+			         name: self classNameForTests;
+			         package: 'ClassOrganizer-Tests' ]
+]
+
+{ #category : #running }
+ClassDescriptionProtocolsTest >> tearDown [
+
+	class package removeFromSystem.
+	super tearDown
+]
+
+{ #category : #tests }
+ClassDescriptionProtocolsTest >> testProtocolNames [
+
+	class organization addProtocol: #titan.
+	class organization addProtocol: #human.
+	class organization addProtocol: #witch.
+
+	self assertCollection: class protocolNames hasSameElements: #( #titan #human #witch ).
+
+	class organization removeProtocolIfEmpty: #titan.
+
+	self assertCollection: class protocolNames hasSameElements: #( #human #witch )
+]

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -754,6 +754,13 @@ ClassDescription >> printOn: aStream [
 	aStream nextPutAll: self name
 ]
 
+{ #category : #'accessing - protocols' }
+ClassDescription >> protocolNames [
+	"Return the list of all the protocol names included in this class."
+
+	^ self organization protocolNames copy
+]
+
 { #category : #compiling }
 ClassDescription >> reformatAll [
 	"Reformat all methods in this class"

--- a/src/Monticello/MCPackageManager.class.st
+++ b/src/Monticello/MCPackageManager.class.st
@@ -80,7 +80,7 @@ MCPackageManager class >> classRemoved: anEvent [
 		packageMatchingExtensionName: anEvent categoryName) ifNotNil: [ :package |
 			package mcWorkingCopy ifNotNil: [ :workingCopy | workingCopy modified: true ] ].
 		
-	anEvent classAffected protocols, anEvent classAffected classSide protocols
+	anEvent classAffected protocolNames, anEvent classAffected classSide protocolNames
 		do: [ :aProtocolName | 
 			(aProtocolName beginsWith: '*')
 				ifTrue:

--- a/src/ReleaseTests/ProperMethodCategorizationTest.class.st
+++ b/src/ReleaseTests/ProperMethodCategorizationTest.class.st
@@ -166,16 +166,17 @@ ProperMethodCategorizationTest >> testNoLeadingOrTrailingSpacesInCategoryNames [
 ProperMethodCategorizationTest >> testNoUncategorizedMethods [
 	"Check that we have no #'as yet unclassified' protocols left"
 
-	| violating validExceptions remaining|
-	violating := Smalltalk globals allBehaviors select: [ :class |
-		             class protocols includes: Protocol unclassified ].
+	| violating validExceptions remaining |
+	violating := Smalltalk globals allBehaviors select: [ :class | class protocolNames includes: Protocol unclassified ].
 
 
-	validExceptions := #(ClyClass2FromP1Mock #MCMock #'MCMock class' #'MCMockASubclass class' #'MCMockClassA class' #MCMockASubclass #MCMockClassD #'MCMockClassE class' MFClassA MFClassB RBFooDummyLintRuleTest RBFooLintRuleTestData RBSmalllintTestObject RBTransformationDummyRuleTest 'RBTransformationRuleTestData1' RBDummyRefactoryTestDataApp StInspectorMockObjectSubclass StDebuggerCommand).
+	validExceptions := #( ClyClass2FromP1Mock #MCMock #'MCMock class' #'MCMockASubclass class' #'MCMockClassA class' #MCMockASubclass #MCMockClassD #'MCMockClassE class'
+	                      MFClassA MFClassB RBFooDummyLintRuleTest RBFooLintRuleTestData RBSmalllintTestObject RBTransformationDummyRuleTest
+	                      'RBTransformationRuleTestData1' RBDummyRefactoryTestDataApp StInspectorMockObjectSubclass StDebuggerCommand ).
 
-	remaining := violating asOrderedCollection reject: [ :each  | validExceptions includes: each name].
+	remaining := violating asOrderedCollection reject: [ :each | validExceptions includes: each name ].
 
-	self assert: remaining isEmpty description: ('the following classes have uncategorized methods: ', remaining asString)
+	self assert: remaining isEmpty description: 'the following classes have uncategorized methods: ' , remaining asString
 ]
 
 { #category : #tests }
@@ -183,13 +184,10 @@ ProperMethodCategorizationTest >> testNoUtilsMethods [
 	"Check that we have no #'utils' protocols left, the protocol should be 'utilities' "
 
 	| violating |
-	violating := Smalltalk globals allBehaviors select: [ :class |
-		             class protocols includes: #'utils' ].
+	violating := Smalltalk globals allBehaviors select: [ :class | class protocolNames includes: #utils ].
 
 	"we lock in the number of problematic classes, this way it can only improve"
-	self 
-		assert: violating size <= 4
-		description: '#utils protocols left, the protocol should be ''utilities'': ' , violating asString
+	self assert: violating size <= 4 description: '#utils protocols left, the protocol should be ''utilities'': ' , violating asString
 ]
 
 { #category : #'tests - object' }

--- a/src/ReleaseTests/ProtocolConventionsTest.class.st
+++ b/src/ReleaseTests/ProtocolConventionsTest.class.st
@@ -13,7 +13,7 @@ Class {
 ProtocolConventionsTest >> assertProtocolName: aProtocolName notAcceptingProtocolNamesLike: aCollectionOfSelectors [
 	| violations |
 	violations := self class environment allClassesAndTraits
-		select: [ :c | (c protocols includesAny: aCollectionOfSelectors) or: [ c class protocols includesAny: aCollectionOfSelectors ] ].
+		select: [ :c | (c protocolNames includesAny: aCollectionOfSelectors) or: [ c class protocols includesAny: aCollectionOfSelectors ] ].
 	self
 		assert: violations isEmpty
 		description: [ 'In the default Pharo images, the protocol #{1} should be used instead of {2}.
@@ -34,7 +34,7 @@ Some classes are violating this convention:
 ProtocolConventionsTest >> assertProtocolName: aProtocolName notAcceptingProtocolNamesLike: aCollectionOfSelectors notMoreViolationsThan: aCount [
 	| violations |
 	violations := self class environment allClassesAndTraits
-		select: [ :c | (c protocols includesAny: aCollectionOfSelectors) or: [ c class protocols includesAny: aCollectionOfSelectors ] ].
+		select: [ :c | (c protocolNames includesAny: aCollectionOfSelectors) or: [ c class protocols includesAny: aCollectionOfSelectors ] ].
 	self
 		assert: violations size <= aCount
 		description: [ 'In the default Pharo images, the protocol #{1} should be used instead of {2}.

--- a/src/ReleaseTests/ProtocolConventionsTest.class.st
+++ b/src/ReleaseTests/ProtocolConventionsTest.class.st
@@ -32,23 +32,23 @@ Some classes are violating this convention:
 
 { #category : #asserting }
 ProtocolConventionsTest >> assertProtocolName: aProtocolName notAcceptingProtocolNamesLike: aCollectionOfSelectors notMoreViolationsThan: aCount [
+
 	| violations |
-	violations := self class environment allClassesAndTraits
-		select: [ :c | (c protocolNames includesAny: aCollectionOfSelectors) or: [ c class protocols includesAny: aCollectionOfSelectors ] ].
-	self
-		assert: violations size <= aCount
-		description: [ 'In the default Pharo images, the protocol #{1} should be used instead of {2}.
+	violations := self class environment allClassesAndTraits select: [ :c |
+		              (c protocolNames includesAny: aCollectionOfSelectors) or: [ c class protocolNames includesAny: aCollectionOfSelectors ] ].
+	self assert: violations size <= aCount description: [
+		'In the default Pharo images, the protocol #{1} should be used instead of {2}.
 Some classes are violating this convention:
-{3}'
-				format:
-					{aProtocolName . aCollectionOfSelectors asString . (String
-						streamContents: [ :s |
-							violations
-								do: [ :c |
-									s
-										<< '- ';
-										print: c ]
-								separatedBy: [ s cr ] ])} ]
+{3}' format: {
+				aProtocolName.
+				aCollectionOfSelectors asString.
+				(String streamContents: [ :s |
+					 violations
+						 do: [ :c |
+							 s
+								 << '- ';
+								 print: c ]
+						 separatedBy: [ s cr ] ]) } ]
 ]
 
 { #category : #utilities }

--- a/src/Ring-Core/RGReadOnlyImageBackend.class.st
+++ b/src/Ring-Core/RGReadOnlyImageBackend.class.st
@@ -320,7 +320,7 @@ RGReadOnlyImageBackend >> tagsForMethod: anRGMethod do: aBlock [
 { #category : #method }
 RGReadOnlyImageBackend >> tagsForMethodsFor: anRGBehavior do: aBlock [
 
-	(self realBehaviorFor: anRGBehavior) protocols do: aBlock
+	(self realBehaviorFor: anRGBehavior) protocolNames do: aBlock
 ]
 
 { #category : #method }

--- a/src/Ring-Definitions-Core/Behavior.extension.st
+++ b/src/Ring-Definitions-Core/Behavior.extension.st
@@ -5,9 +5,3 @@ Behavior >> methodNamed: aSelector [
 
 	^ self methodDict at: aSelector
 ]
-
-{ #category : #'*Ring-Definitions-Core' }
-Behavior >> protocols [
-
-	^ self organization protocolNames copy
-]

--- a/src/Ring-Definitions-Core/ClassDescription.extension.st
+++ b/src/Ring-Definitions-Core/ClassDescription.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #ClassDescription }
+
+{ #category : #'*Ring-Definitions-Core' }
+ClassDescription >> protocols [
+
+	^ self organization protocolNames copy
+]

--- a/src/Ring-Definitions-Core/ClassDescription.extension.st
+++ b/src/Ring-Definitions-Core/ClassDescription.extension.st
@@ -2,6 +2,6 @@ Extension { #name : #ClassDescription }
 
 { #category : #'*Ring-Definitions-Core' }
 ClassDescription >> protocols [
-
+1haltOnce.
 	^ self organization protocolNames copy
 ]

--- a/src/Ring-Definitions-Core/ClassDescription.extension.st
+++ b/src/Ring-Definitions-Core/ClassDescription.extension.st
@@ -2,6 +2,9 @@ Extension { #name : #ClassDescription }
 
 { #category : #'*Ring-Definitions-Core' }
 ClassDescription >> protocols [
-1haltOnce.
+
+	self
+		deprecated: 'Use #protocolNames instead because I should return real protocols and not just names.'
+		transformWith: '`@rcv protocols' -> '`@rcv protocolNames'.
 	^ self organization protocolNames copy
 ]

--- a/src/Ring-Tests-Core/RGReadOnlyImageBackendTest.class.st
+++ b/src/Ring-Tests-Core/RGReadOnlyImageBackendTest.class.st
@@ -94,7 +94,7 @@ RGReadOnlyImageBackendTest >> testClassTrait [
 	self assert: classTrait superclass name equals: #Trait.
 	self assert: classTrait comment content equals: RGTestTrait comment.
 	self assert: classTrait localMethods size equals: RGTestTrait classTrait localMethods size.
-	self assert: classTrait protocols asSortedCollection equals: RGTestTrait classTrait protocols asSortedCollection.
+	self assert: classTrait protocols asSortedCollection equals: RGTestTrait classTrait protocolNames asSortedCollection.
 	self assert: classTrait metaclass name equals: #MetaclassForTraits.
 	self assert: classTrait package name equals: 'Ring-Tests-Core'
 ]
@@ -273,7 +273,7 @@ RGReadOnlyImageBackendTest >> testTrait [
 	self assert: trait superclass identicalTo: trait.	"cycle, nil in reality"
 	self assert: trait comment content equals: RGTestTrait comment.
 	self assert: trait localMethods size equals: RGTestTrait localMethods size.
-	self assert: trait protocols asSortedCollection equals: RGTestTrait protocols asSortedCollection.
+	self assert: trait protocols asSortedCollection equals: RGTestTrait protocolNames asSortedCollection.
 	self assert: trait metaclass name equals: 'RGTestTrait classTrait'.
 	self assert: trait metaclass superclass name equals: 'Trait'.
 	self assert: trait package name equals: 'Ring-Tests-Core'

--- a/src/System-Support-Tests/SystemNavigationTest.class.st
+++ b/src/System-Support-Tests/SystemNavigationTest.class.st
@@ -68,14 +68,13 @@ SystemNavigationTest >> testAllClassesImplementing [
 SystemNavigationTest >> testAllExistingProtocolsFor [
 
 	| instSideProtocols classSideProtocols |
-
 	instSideProtocols := self systemNavigationToTest allExistingProtocolsFor: true.
 	classSideProtocols := self systemNavigationToTest allExistingProtocolsFor: false.
 
 	self assert: (instSideProtocols allSatisfy: #isSymbol).
 	self assert: (classSideProtocols allSatisfy: #isSymbol).
-	self assert: (instSideProtocols includesAll: (Object protocols)).
-	self assert: (classSideProtocols includesAll: (Object class protocols))
+	self assert: (instSideProtocols includesAll: Object protocolNames).
+	self assert: (classSideProtocols includesAll: Object class protocolNames)
 ]
 
 { #category : #tests }

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -81,7 +81,10 @@ SystemNavigation >> allClassesImplementing: aSelector [
 SystemNavigation >> allExistingProtocolsFor: instanceSide [
 	"Answer all protocols on instance or class side"
 
-	^self allClasses flatCollectAsSet: [ :class | instanceSide ifTrue: [class protocols] ifFalse: [ class class protocols ] ]
+	^ self allClasses flatCollectAsSet: [ :class |
+		  instanceSide
+			  ifTrue: [ class protocolNames ]
+			  ifFalse: [ class class protocolNames ] ]
 ]
 
 { #category : #private }

--- a/src/SystemCommands-RefactoringSupport/RBEnvironmentVisitor.class.st
+++ b/src/SystemCommands-RefactoringSupport/RBEnvironmentVisitor.class.st
@@ -47,7 +47,7 @@ RBEnvironmentVisitor >> visitPackageEnv: rbPackageEnv [
 { #category : #visiting }
 RBEnvironmentVisitor >> visitProtocolEnv: rbProtocolEnv [
 	| list selectedList methodName items dialog |
-	list := rbProtocolEnv definedClass protocols sorted.
+	list := rbProtocolEnv definedClass protocolNames sorted.
 	selectedList := rbProtocolEnv protocols sorted.
 	methodName := #yourself.
 	items := OrderedCollection new.

--- a/src/Tool-ExternalBrowser/ExternalBrowser.class.st
+++ b/src/Tool-ExternalBrowser/ExternalBrowser.class.st
@@ -212,7 +212,7 @@ ExternalBrowser >> protocols [
 { #category : #'structure accessing' }
 ExternalBrowser >> protocolsOfClass: aClass [
 
-	^ aClass protocols
+	^ aClass protocolNames
 ]
 
 { #category : #refresh }
@@ -258,8 +258,7 @@ ExternalBrowser >> selectorsOfProtocol: aProtocol [
 { #category : #'structure accessing' }
 ExternalBrowser >> showClassDefinition [
 
-	method text:
-		(self classes selectedItem definition ifNil: [ '' ])
+	method text: (self classes selectedItem definitionString ifNil: [ '' ])
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This PR is the first step toward #10856.

It does multiple things:
- Push down Behavior>>#protocols to ClassDescription because Behavior is not responsible for protocol management
- It introduces ClassDescription>>#protocolNames as a first step to inline ClassOrganization in it
- It migrates most of the users of #protocols to use #protocolNames. The last user I found is in an external project D=
- Deprecate #protocolNames even if this deprecation will probably not survive until the release, it's to see if I forgot a user somewhere and have logs in the CI. 
- Introduce ClassDescriptionProtocolsTest that will test everything related to protocols in ClassDescription. Most of the code that will end up here will be the code of ClassOrganizationTest, but it allows me to keep track of the migration and be sure everything is well tested

Next steps on this issue:
- Replace the usage of #protocols in Microdown once this PR is integrated
- Move #protocols from Ring to ClassDescription and make it return the real protocols and not the protocol names
- Update all the code doing `x organization protocols` to `x protocols`