### PR TITLE
Deprecate ProtocolRenamed

### DIFF
--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -255,7 +255,6 @@ ClassOrganization >> renameProtocol: anOldProtocol as: aNewProtocol [
 
 	"Announce the changes in the system"
 	SystemAnnouncer announce: (ClassReorganized class: self organizedClass).
-	SystemAnnouncer announce: (ProtocolRenamed in: self organizedClass from: oldProtocol name to: newProtocol name).
 
 	"I need to notify also the selector changes, otherwise RPackage will not notice"
 	newProtocol methodSelectors do: [ :each | self organizedClass notifyOfRecategorizedSelector: each from: oldProtocol name to: newProtocol name ]

--- a/src/System-Announcements/ProtocolRenamed.class.st
+++ b/src/System-Announcements/ProtocolRenamed.class.st
@@ -20,6 +20,13 @@ ProtocolRenamed class >> in: aClass from: oldName to: newName [
 		  yourself
 ]
 
+{ #category : #testing }
+ProtocolRenamed class >> isDeprecated [
+	"Renaming is a composition of ProtocolAdded and ProtocolRemoved. To act on a renaming, those two are the announcements to listen to."
+
+	^ true
+]
+
 { #category : #accessing }
 ProtocolRenamed >> newProtocol [
 


### PR DESCRIPTION
Currently when we rename a protocol we have multiple things announced:
- ProtocolAdded if the new protocol does not exist yet
- ProtocolRemoved 
- ClassReorganized
- ProtocolRenamed

Nobody listens to ProtocolRenamed because all clients are using ProtocolAdded and ProtocolRemoved to deal with renamings. I propose to remove this extra announcement to limit the number of things we announce in the system.