### PR TITLE
Remove dead code in RPackageOrganizer default instance

### DIFF
--- a/src/Monticello/RPackageOrganizer.extension.st
+++ b/src/Monticello/RPackageOrganizer.extension.st
@@ -13,27 +13,6 @@ RPackageOrganizer >> allManagers [
 ]
 
 { #category : #'*Monticello-RPackage' }
-RPackageOrganizer >> basicInitializeFromMC [
-
-	self basicInitializeFromPackagesList: (self allManagers collect: [ :workingCopy | workingCopy packageName]).
-]
-
-{ #category : #'*Monticello-RPackage' }
-RPackageOrganizer class >> initializeDefaultFromMC [
-
-	"self initializeDefaultFromMC"
-	self setDefault:  self new initializeFromMC.
-]
-
-{ #category : #'*Monticello-RPackage' }
-RPackageOrganizer >> initializeFromMC [
- 	self packageClass 
-		withOrganizer: self  
-		do:  [  self basicInitializeFromMC ].
-
-]
-
-{ #category : #'*Monticello-RPackage' }
 RPackageOrganizer >> isDefinedAsPackageOrSubPackageInMC: aSymbol [
 	"a category has been added. "
 	

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -111,9 +111,6 @@ Class {
 		'packageNames',
 		'systemOrganizer'
 	],
-	#classInstVars : [
-		'default'
-	],
 	#category : #'RPackage-Core-Base'
 }
 
@@ -164,29 +161,6 @@ RPackageOrganizer class >> registerInterestToSystemAnnouncement [
 	self default unregisterInterestToSystemAnnouncement.
 	"To make sure that we do not have it twice registered"
 	self default registerInterestToSystemAnnouncement
-]
-
-{ #category : #singleton }
-RPackageOrganizer class >> resetDefault [
-
-	"self resetDefault"
-	default  ifNotNil: [
-		"When an Organizer is not used anymore, we should always pay attention that these two actions are corretly done."
-		default unregisterInterestToSystemAnnouncement.
-
-		self flag: #hack. "for decoupling MC"
-		self class environment at: #MCWorkingCopy ifPresent: [ :wc |
-			wc removeDependent: default]].
-	default := self new.
-	self packageClass initialize
-]
-
-{ #category : #private }
-RPackageOrganizer class >> setDefault: anOrganizer [
-	default ifNotNil: [ default unregister ].
-	default := anOrganizer.
-	default register.
-	RPackage organizer: nil
 ]
 
 { #category : #'class initialization' }


### PR DESCRIPTION
RPackageOrganizer has a default organizer to use in the system. Now this instance is hold by SystemDictionary so there is no need for RPackageOrganizer to maintain a singleton. I removed the variable and all the dead code that was dealing with it. 

Next step: 
- Update code accessing the default instance via `RPackageOrganizer default` to use `Smalltalk organization` instead.
- Deprecated RPackageOrganizer class>>default