### PR TITLE
Fix bug (issue #13663): enabling the setting ‘Show lines numbers for all browsers’ only showed line numbers for the first method selected in a class

### DIFF
--- a/src/Calypso-Browser/ClyTextLineNumbersSwitchMorph.class.st
+++ b/src/Calypso-Browser/ClyTextLineNumbersSwitchMorph.class.st
@@ -58,7 +58,7 @@ ClyTextLineNumbersSwitchMorph >> attachToTextMorph [
 	self updateLabel.
 	self addMorph: label.
 	self class showLineNumbers
-		ifTrue: [ self toggle ]
+		ifTrue: [ textMorph withLineNumbers ]
 ]
 
 { #category : #operations }


### PR DESCRIPTION
Scenario from the issue (#13663):

> * In the Settings, enable ‘Show lines numbers for all browsers’
> * In a System Browser, select a class and select a method (note that line numbers are shown)
> * Select another method (in the same class)
>
> Line numbers are unexpectedly not shown. When selecting another class and method, the line numbers reappear, then disappear again when another method is selected in the same class.