### PR TITLE
Backport fixe #13663: Enabling the setting ‘Show lines numbers for all browsers

### DIFF
--- a/src/Calypso-Browser/ClyTextLineNumbersSwitchMorph.class.st
+++ b/src/Calypso-Browser/ClyTextLineNumbersSwitchMorph.class.st
@@ -58,7 +58,7 @@ ClyTextLineNumbersSwitchMorph >> attachToTextMorph [
 	self updateLabel.
 	self addMorph: label.
 	self class showLineNumbers
-		ifTrue: [ self toggle ]
+		ifTrue: [ textMorph withLineNumbers ]
 ]
 
 { #category : #operations }


### PR DESCRIPTION
Since the bug related to line numbers in Calypso is really annoying I propose to backport it in Pharo 11.

The code does not impact Pharo in case the setting is in the default value, and Calypso is not really usable if the setting is updated anyway. So we don't rick much by backporting this fix.