### PR TITLE
Reduces the references to RPackageOrganizer class>>default

### DIFF
--- a/src/Epicea/EpMonitor.class.st
+++ b/src/Epicea/EpMonitor.class.st
@@ -231,22 +231,18 @@ EpMonitor >> behaviorRemoved: aClassRemovedAnnouncement [
 
 { #category : #'announcement handling' }
 EpMonitor >> behaviorRemovedImpliesMethodRemoved: aMethodInAnObsoleteBehavior defaultPackageName: aSymbol [
+
 	| packageName |
-	packageName := (RPackageOrganizer default
-		packageForProtocol: aMethodInAnObsoleteBehavior protocol
-		inClass: aMethodInAnObsoleteBehavior methodClass) name.
+	packageName := (Smalltalk organization packageForProtocol: aMethodInAnObsoleteBehavior protocol inClass: aMethodInAnObsoleteBehavior methodClass) name.
 
 	"If the method is local, (belongs to the class being removed) then the package was wrong,  and we fix it"
-	packageName = RPackage defaultPackageName
-		ifTrue: [ packageName := aSymbol ].
+	packageName = RPackage defaultPackageName ifTrue: [ packageName := aSymbol ].
 
-	self addEvent:
-		(EpMethodRemoval method:
-			(aMethodInAnObsoleteBehavior asEpiceaRingDefinition
-				parentName: aMethodInAnObsoleteBehavior methodClass originalName;
-				protocol: aMethodInAnObsoleteBehavior protocol;
-				package: packageName;
-				yourself))
+	self addEvent: (EpMethodRemoval method: (aMethodInAnObsoleteBehavior asEpiceaRingDefinition
+				  parentName: aMethodInAnObsoleteBehavior methodClass originalName;
+				  protocol: aMethodInAnObsoleteBehavior protocol;
+				  package: packageName;
+				  yourself))
 ]
 
 { #category : #'announcement handling' }
@@ -515,14 +511,11 @@ EpMonitor >> methodRemoved: aMethodRemovedAnnouncement [
 	"RPackage already unregistered the method so we have to workaround protocol and package."
 
 	self handleAnyErrorDuring: [
-		self addEvent:
-			(EpMethodRemoval method:
-				(aMethodRemovedAnnouncement methodAffected asEpiceaRingDefinition
-					protocol: aMethodRemovedAnnouncement protocol;
-					package: (RPackageOrganizer default
-						packageForProtocol: aMethodRemovedAnnouncement protocol
-						inClass: aMethodRemovedAnnouncement methodAffected methodClass) name;
-					yourself))]
+		self addEvent: (EpMethodRemoval method: (aMethodRemovedAnnouncement methodAffected asEpiceaRingDefinition
+					  protocol: aMethodRemovedAnnouncement protocol;
+					  package:
+						  (Smalltalk organization packageForProtocol: aMethodRemovedAnnouncement protocol inClass: aMethodRemovedAnnouncement methodAffected methodClass) name;
+					  yourself)) ]
 ]
 
 { #category : #'announcement handling' }

--- a/src/FluidClassBuilder-Tests/FluidClassBuilderTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidClassBuilderTest.class.st
@@ -38,17 +38,13 @@ FluidClassBuilderTest >> setUp [
 { #category : #running }
 FluidClassBuilderTest >> tearDown [
 
-	self class environment
-		at: #Point2
-		ifPresent: [ :cl | cl removeFromSystem  ].
+	self class environment at: #Point2 ifPresent: [ :cl | cl removeFromSystem ].
 
-	(RPackageOrganizer default packageNamed: #'Mock' ifAbsent: [ nil ])
-		ifNotNil: [:x | x removeFromSystem ].
+	(Smalltalk organization packageNamed: #Mock ifAbsent: [ nil ]) ifNotNil: [ :x | x removeFromSystem ].
 
-	(RPackageOrganizer default packageNamed: #'FakedCore' ifAbsent: [ nil ])
-		ifNotNil: [:x | x removeFromSystem ].
-		
-		
+	(Smalltalk organization packageNamed: #FakedCore ifAbsent: [ nil ]) ifNotNil: [ :x | x removeFromSystem ].
+
+
 
 	super tearDown
 ]
@@ -190,25 +186,23 @@ FluidClassBuilderTest >> testBuilderWithTag [
 FluidClassBuilderTest >> testChevronIsWorkingOnClassSide [
 
 	| instBuilder newClass clasBuilder |
+	Smalltalk organization registerPackageNamed: #Mock.
 
-	RPackageOrganizer default registerPackageNamed: #'Mock'.
-
-	instBuilder := (Object << #Point2
-		slots: { #a. #b };
-		layout: WeakLayout;
-		traits: {TViewModelMock };
-		sharedVariables: { #AAA};
-		sharedPools: { #TextConstants};
-		tag: 'boring' ;
-		package: 'Mock').
+	instBuilder := (Object << #Point2)
+		               slots: { #a. #b };
+		               layout: WeakLayout;
+		               traits: { TViewModelMock };
+		               sharedVariables: { #AAA };
+		               sharedPools: { #TextConstants };
+		               tag: 'boring';
+		               package: 'Mock'.
 
 	"Ideally we should not install the class but just build it (sending instBuilder build)
 	the problem is that category and tag are lost by the class builder.
 	Hence we cannot test for real."
 	newClass := instBuilder install.
 
-	clasBuilder := Object class << newClass class
-		traits: {TViewModelMock classTrait}.
+	clasBuilder := Object class << newClass class traits: { TViewModelMock classTrait }.
 
 	self assert: clasBuilder packageToBuild equals: instBuilder packageToBuild.
 	self assert: clasBuilder superclassToBuild equals: instBuilder superclassToBuild.

--- a/src/Monticello-Tests/MCWorkingCopyForExtensionsTest.class.st
+++ b/src/Monticello-Tests/MCWorkingCopyForExtensionsTest.class.st
@@ -23,18 +23,18 @@ MCWorkingCopyForExtensionsTest >> tearDown [
 MCWorkingCopyForExtensionsTest >> testAddingExtensionMethodNotMatchingPackage [
 
 	| aClass |
-	RPackageOrganizer default createPackageNamed: 'ATestPackage'.
-	RPackageOrganizer default createPackageNamed: 'AnotherTestPackage'.
+	Smalltalk organization createPackageNamed: 'ATestPackage'.
+	Smalltalk organization createPackageNamed: 'AnotherTestPackage'.
 
-	aClass := self class classInstaller make: [ :aBuilder | 
-		aBuilder 
-			name: #ATestClass;
-			package: 'AnotherTestPackage'].
+	aClass := self class classInstaller make: [ :aBuilder |
+		          aBuilder
+			          name: #ATestClass;
+			          package: 'AnotherTestPackage' ].
 
 	aClass compile: 'testingMethod ^ 42 ' classified: '*atestpackage-something-else'.
-	
-	self deny: (RPackageOrganizer default includesPackageNamed: 'Atestpackage-something-else').
+
+	self deny: (Smalltalk organization includesPackageNamed: 'Atestpackage-something-else').
 	self assert: ('ATestPackage' asPackage extendedClasses includes: aClass).
 
-	MCWorkingCopy registry at: (MCPackage named: 'atestpackage-something-else') ifPresent: [ self fail ].	
+	MCWorkingCopy registry at: (MCPackage named: 'atestpackage-something-else') ifPresent: [ self fail ]
 ]

--- a/src/Monticello/MCPackage.class.st
+++ b/src/Monticello/MCPackage.class.st
@@ -27,7 +27,7 @@ MCPackage >> = other [
 { #category : #accessing }
 MCPackage >> correspondingRPackage [
 
-	^ RPackageOrganizer default packageNamed: self name asSymbol ifAbsent: [ nil ]
+	^ Smalltalk organization packageNamed: self name asSymbol ifAbsent: [ nil ]
 ]
 
 { #category : #printing }

--- a/src/Monticello/MCPackageManager.class.st
+++ b/src/Monticello/MCPackageManager.class.st
@@ -76,19 +76,14 @@ MCPackageManager class >> classRemoved: anEvent [
 	"Informs the registry who use to keep this class that its changed. Unlike #classModified:, class is not anymore in RPackages so it will not be found, that's why we look for system category instead if class is included or not"
 
 	"Note. Class protocols returns symbols and not Protocol instances!"
-	(RPackageOrganizer default
-		packageMatchingExtensionName: anEvent categoryName) ifNotNil: [ :package |
-			package mcWorkingCopy ifNotNil: [ :workingCopy | workingCopy modified: true ] ].
-		
-	anEvent classAffected protocols, anEvent classAffected classSide protocols
-		do: [ :aProtocolName | 
-			(aProtocolName beginsWith: '*')
-				ifTrue:
-					[ (RPackageOrganizer default
-						packageMatchingExtensionName: aProtocolName allButFirst trimBoth)
-							ifNotNil: [ :package |
-								package mcWorkingCopy ifNotNil: [ :workingCopy |
-									workingCopy modified: true ] ] ] ]
+
+	(Smalltalk organization packageMatchingExtensionName: anEvent categoryName) ifNotNil: [ :package |
+		package mcWorkingCopy ifNotNil: [ :workingCopy | workingCopy modified: true ] ].
+
+	anEvent classAffected protocols , anEvent classAffected classSide protocols do: [ :aProtocolName |
+		(aProtocolName beginsWith: '*') ifTrue: [
+			(Smalltalk organization packageMatchingExtensionName: aProtocolName allButFirst trimBoth) ifNotNil: [ :package |
+				package mcWorkingCopy ifNotNil: [ :workingCopy | workingCopy modified: true ] ] ] ]
 ]
 
 { #category : #'system changes' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -117,7 +117,8 @@ RPackage class >> named: aString [
 
 { #category : #'protected only for tests' }
 RPackage class >> organizer [
-	^ PackageGlobalOrganizer ifNil: [ RPackageOrganizer default ]
+
+	^ PackageGlobalOrganizer ifNil: [ Smalltalk organization ]
 ]
 
 { #category : #'protected only for tests' }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -158,9 +158,9 @@ RPackageOrganizer class >> packageClass [
 { #category : #'class initialization' }
 RPackageOrganizer class >> registerInterestToSystemAnnouncement [
 
-	self default unregisterInterestToSystemAnnouncement.
+	Smalltalk organization unregisterInterestToSystemAnnouncement.
 	"To make sure that we do not have it twice registered"
-	self default registerInterestToSystemAnnouncement
+	Smalltalk organization registerInterestToSystemAnnouncement
 ]
 
 { #category : #'class initialization' }

--- a/src/RPackage-Core/String.extension.st
+++ b/src/RPackage-Core/String.extension.st
@@ -7,5 +7,6 @@ String >> asPackage [
 
 { #category : #'*RPackage-Core' }
 String >> asPackageIfAbsent: aBlock [
-	^ RPackageOrganizer default packageNamed: self ifAbsent: aBlock
+
+	^ Smalltalk organization packageNamed: self ifAbsent: aBlock
 ]

--- a/src/RPackage-Tests/RPackageOrganizerAndSystemOrganizeSynchTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerAndSystemOrganizeSynchTest.class.st
@@ -32,7 +32,7 @@ RPackageOrganizerAndSystemOrganizeSynchTest >> testAddingPackage [
 
 	SystemOrganizer default addCategory: self packageName.
 
-	self assert: (RPackageOrganizer default packageNames includes: self packageName).
+	self assert: (Smalltalk organization packageNames includes: self packageName).
 	self assert: (SystemOrganizer default includesCategory: self packageName)
 ]
 
@@ -42,12 +42,12 @@ RPackageOrganizerAndSystemOrganizeSynchTest >> testRemovingPackage [
 
 	SystemOrganizer default addCategory: self packageName.
 
-	self assert: (RPackageOrganizer default packageNames includes: self packageName).
+	self assert: (Smalltalk organization packageNames includes: self packageName).
 	self assert: (SystemOrganizer default includesCategory: self packageName).
 
 	self packageName asPackage removeFromSystem.
 
-	self deny: (RPackageOrganizer default packageNames includes: self packageName).
+	self deny: (Smalltalk organization packageNames includes: self packageName).
 	self deny: (SystemOrganizer default includesCategory: self packageName)
 ]
 
@@ -64,14 +64,14 @@ RPackageOrganizerAndSystemOrganizeSynchTest >> testRemovingPackageWithTags [
 		package: self packageName;
 		tag: 'tag2';
 		install.
-	self assert: (RPackageOrganizer default packageNames includes: self packageName).
+	self assert: (Smalltalk organization packageNames includes: self packageName).
 	self assert: (SystemOrganizer default includesCategory: self packageName).
 	self assert: (SystemOrganizer default includesCategory: self packageName , '-tag1').
 	self assert: (SystemOrganizer default includesCategory: self packageName , '-tag2').
 
 	self packageName asPackage removeFromSystem.
 
-	self deny: (RPackageOrganizer default packageNames includes: self packageName).
+	self deny: (Smalltalk organization packageNames includes: self packageName).
 	self deny: (SystemOrganizer default includesCategory: self packageName).
 	self deny: (SystemOrganizer default includesCategory: self packageName , '-tag1').
 	self deny: (SystemOrganizer default includesCategory: self packageName , '-tag2')

--- a/src/RPackage-Tests/RPackageOrganizerSystemTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerSystemTest.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #tests }
 RPackageOrganizerSystemTest >> testDefault [
 
-	self assert: RPackageOrganizer default identicalTo: self class environment organization
+	self assert: Smalltalk organization identicalTo: self class environment organization
 ]
 
 { #category : #tests }

--- a/src/RPackage-Tests/RPackageRenameTest.class.st
+++ b/src/RPackage-Tests/RPackageRenameTest.class.st
@@ -46,17 +46,16 @@ RPackageRenameTest >> testRenamePackage [
 	"Test that we do rename the package as expected."
 
 	| package workingCopy class |
+	self cleanWorkingCopiesInTearDown: #( 'TestRename' ).
 
-	self cleanWorkingCopiesInTearDown: #('TestRename').
-
-	package := RPackageOrganizer default registerPackageNamed: 'Test1'.
+	package := Smalltalk organization registerPackageNamed: 'Test1'.
 	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'Test1').
 	class := Object
-		subclass: #TestClass
-		instanceVariableNames: ''
-		classVariableNames: ''
-		poolDictionaries: ''
-		category: 'Test1-TAG'.
+		         subclass: #TestClass
+		         instanceVariableNames: ''
+		         classVariableNames: ''
+		         poolDictionaries: ''
+		         category: 'Test1-TAG'.
 
 	self assert: (package includesClass: class).
 	self assert: (package classTagNamed: #TAG ifAbsent: [ nil ]) notNil.
@@ -79,24 +78,32 @@ RPackageRenameTest >> testRenamePackage [
 { #category : #tests }
 RPackageRenameTest >> testRenamePackageToOwnTagName [
 	"If we rename a package to the (full)category name of one of its tags"
+
 	| package workingCopy class1 class2 |
+	self cleanWorkingCopiesInTearDown: #( 'Test1-Core' ).
 
-	self cleanWorkingCopiesInTearDown: #('Test1-Core').
-
-	package := RPackageOrganizer default registerPackageNamed: 'Test1'.
+	package := Smalltalk organization registerPackageNamed: 'Test1'.
 	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'Test1').
-	class1 := Object subclass: #TestClass1 instanceVariableNames: '' classVariableNames: '' package: 'Test1-Core'.
-	class2 := Object subclass: #TestClass2 instanceVariableNames: '' classVariableNames: '' package: 'Test1-Util'.
+	class1 := Object
+		          subclass: #TestClass1
+		          instanceVariableNames: ''
+		          classVariableNames: ''
+		          package: 'Test1-Core'.
+	class2 := Object
+		          subclass: #TestClass2
+		          instanceVariableNames: ''
+		          classVariableNames: ''
+		          package: 'Test1-Util'.
 
 	self assert: (package classTagNamed: #Core ifAbsent: [ nil ]) notNil.
 	self assert: (package classTagNamed: #Util ifAbsent: [ nil ]) notNil.
 	package renameTo: 'Test1-Core'.
 	self assert: (package includesClass: class1).
 	self assert: (package includesClass: class2).
-	self assert: (package classTagNamed: #'Core' ifAbsent: [ nil ]) notNil.
-	self assert: (package classTagNamed: #'Util' ifAbsent: [ nil ]) notNil.
-	self assert: ((package classTagNamed: #'Core' ifAbsent: [ nil ]) includesClass: class1).
-	self assert: ((package classTagNamed: #'Util' ifAbsent: [ nil ]) includesClass: class2).
+	self assert: (package classTagNamed: #Core ifAbsent: [ nil ]) notNil.
+	self assert: (package classTagNamed: #Util ifAbsent: [ nil ]) notNil.
+	self assert: ((package classTagNamed: #Core ifAbsent: [ nil ]) includesClass: class1).
+	self assert: ((package classTagNamed: #Util ifAbsent: [ nil ]) includesClass: class2).
 
 	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'Test1-Core').
 	self assert: workingCopy modified
@@ -105,15 +112,27 @@ RPackageRenameTest >> testRenamePackageToOwnTagName [
 { #category : #tests }
 RPackageRenameTest >> testRenamePackageToOwnTagNameWithClassesInRoot [
 	"If we rename a package to the (full)category name of one of its tags and the (non-tag)package is not empty"
-	| package workingCopy class1 class2 class3|
 
-	self cleanWorkingCopiesInTearDown: #('Test1-Core').
+	| package workingCopy class1 class2 class3 |
+	self cleanWorkingCopiesInTearDown: #( 'Test1-Core' ).
 
-	package := RPackageOrganizer default registerPackageNamed: 'Test1'.
+	package := Smalltalk organization registerPackageNamed: 'Test1'.
 	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'Test1').
-	class1 := Object subclass: #TestClass1 instanceVariableNames: '' classVariableNames: '' package: 'Test1-Core'.
-	class2 := Object subclass: #TestClass2 instanceVariableNames: '' classVariableNames: '' package: 'Test1-Util'.
-	class3 := Object subclass: #TestClass3 instanceVariableNames: '' classVariableNames: '' package: 'Test1'.
+	class1 := Object
+		          subclass: #TestClass1
+		          instanceVariableNames: ''
+		          classVariableNames: ''
+		          package: 'Test1-Core'.
+	class2 := Object
+		          subclass: #TestClass2
+		          instanceVariableNames: ''
+		          classVariableNames: ''
+		          package: 'Test1-Util'.
+	class3 := Object
+		          subclass: #TestClass3
+		          instanceVariableNames: ''
+		          classVariableNames: ''
+		          package: 'Test1'.
 
 	self assert: (package classTagNamed: #Core ifAbsent: [ nil ]) notNil.
 	self assert: (package classTagNamed: #Util ifAbsent: [ nil ]) notNil.
@@ -131,65 +150,59 @@ RPackageRenameTest >> testRenamePackageToOwnTagNameWithClassesInRoot [
 
 { #category : #tests }
 RPackageRenameTest >> testRenamePackageUppercase [
-
 	"Test that we do rename the package as expected."
 
 	| package pkg oldWorkingCopy |
 	"preparation: creation of a pkg and its associated mcworkingcopy"
 	[
-		package := RPackageOrganizer default registerPackageNamed: 'Test1'.
-		oldWorkingCopy := MCWorkingCopy forPackage:
-			                  (MCPackage new name: 'Test1').
-		self assert: (RPackageOrganizer default includesPackageNamed: #Test1).
-		self assert: (MCWorkingCopy hasPackageNamed: #Test1) isNotNil.
+	package := Smalltalk organization registerPackageNamed: 'Test1'.
+	oldWorkingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'Test1').
+	self assert: (Smalltalk organization includesPackageNamed: #Test1).
+	self assert: (MCWorkingCopy hasPackageNamed: #Test1) isNotNil.
 
-		"renaming"
-		package renameTo: 'TEST1'.
+	"renaming"
+	package renameTo: 'TEST1'.
 
 
-		pkg := RPackageOrganizer default
-			       packageNamed: 'Test1'
-			       ifAbsent: [ nil ].
-		self assert: pkg isNil.
-		self assert: 'TEST1' asPackage isNotNil.
-		self deny: 'TEST1' asPackage mcWorkingCopy equals: oldWorkingCopy.
-		self assert: 'TEST1' asPackage mcWorkingCopy isNotNil.
-		self assert: (RPackageOrganizer default includesPackageNamed: #TEST1).
-		self assert: (MCWorkingCopy hasPackageNamed: #TEST1) isNotNil ]
-	ensure: [ "cleaning"
-			'TEST1' asPackage removeFromSystem.
-			self deny: (RPackageOrganizer default includesPackageNamed: #TEST1).
-			self deny: (MCWorkingCopy hasPackageNamed: #TEST1).
-			self deny: (RPackageOrganizer default includesPackageNamed: #Test1).
-			self deny: (MCWorkingCopy hasPackageNamed: #Test1) ]
+	pkg := Smalltalk organization packageNamed: 'Test1' ifAbsent: [ nil ].
+	self assert: pkg isNil.
+	self assert: 'TEST1' asPackage isNotNil.
+	self deny: 'TEST1' asPackage mcWorkingCopy equals: oldWorkingCopy.
+	self assert: 'TEST1' asPackage mcWorkingCopy isNotNil.
+	self assert: (Smalltalk organization includesPackageNamed: #TEST1).
+	self assert: (MCWorkingCopy hasPackageNamed: #TEST1) isNotNil ] ensure: [ "cleaning"
+		'TEST1' asPackage removeFromSystem.
+		self deny: (Smalltalk organization includesPackageNamed: #TEST1).
+		self deny: (MCWorkingCopy hasPackageNamed: #TEST1).
+		self deny: (Smalltalk organization includesPackageNamed: #Test1).
+		self deny: (MCWorkingCopy hasPackageNamed: #Test1) ]
 ]
 
 { #category : #tests }
 RPackageRenameTest >> testRenamePackageWithExtensions [
 
 	| package workingCopy class extendedPackage extendedPackageWorkingCopy extension |
-
-	package := RPackageOrganizer default registerPackageNamed: 'OriginalPackage'.
+	package := Smalltalk organization registerPackageNamed: 'OriginalPackage'.
 	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'OriginalPackage').
 
 	class := Object
-		subclass: #TestClass
-		instanceVariableNames: ''
-		classVariableNames: ''
-		poolDictionaries: ''
-		category: 'OriginalPackage-TAG'.
+		         subclass: #TestClass
+		         instanceVariableNames: ''
+		         classVariableNames: ''
+		         poolDictionaries: ''
+		         category: 'OriginalPackage-TAG'.
 
-	extendedPackage := RPackageOrganizer default registerPackageNamed: 'ExtendedPackage'.
+	extendedPackage := Smalltalk organization registerPackageNamed: 'ExtendedPackage'.
 	extendedPackageWorkingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'ExtendedPackage').
 
-	self cleanWorkingCopiesInTearDown: #(ExtendedPackage RenamedPackage OriginalPackage).
+	self cleanWorkingCopiesInTearDown: #( ExtendedPackage RenamedPackage OriginalPackage ).
 
 	class := Object
-		subclass: #TestExtendedClass
-		instanceVariableNames: ''
-		classVariableNames: ''
-		poolDictionaries: ''
-		category: 'ExtendedPackage'.
+		         subclass: #TestExtendedClass
+		         instanceVariableNames: ''
+		         classVariableNames: ''
+		         poolDictionaries: ''
+		         category: 'ExtendedPackage'.
 
 	class compile: 'm ^ 42' classified: '*OriginalPackage'.
 	extension := class >> #m.
@@ -213,28 +226,27 @@ RPackageRenameTest >> testRenamePackageWithExtensions [
 RPackageRenameTest >> testRenamePackageWithExtensionsInClassSide [
 
 	| package workingCopy class extendedPackage extendedPackageWorkingCopy extension |
-
-	package := RPackageOrganizer default registerPackageNamed: 'OriginalPackage'.
+	package := Smalltalk organization registerPackageNamed: 'OriginalPackage'.
 	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'OriginalPackage').
 
 	class := Object
-		subclass: #TestClass
-		instanceVariableNames: ''
-		classVariableNames: ''
-		poolDictionaries: ''
-		category: 'OriginalPackage-TAG'.
+		         subclass: #TestClass
+		         instanceVariableNames: ''
+		         classVariableNames: ''
+		         poolDictionaries: ''
+		         category: 'OriginalPackage-TAG'.
 
-	extendedPackage := RPackageOrganizer default registerPackageNamed: 'ExtendedPackage'.
+	extendedPackage := Smalltalk organization registerPackageNamed: 'ExtendedPackage'.
 	extendedPackageWorkingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'ExtendedPackage').
 
-	self cleanWorkingCopiesInTearDown: #(ExtendedPackage RenamedPackage OriginalPackage).
+	self cleanWorkingCopiesInTearDown: #( ExtendedPackage RenamedPackage OriginalPackage ).
 
 	class := Object
-		subclass: #TestExtendedClass
-		instanceVariableNames: ''
-		classVariableNames: ''
-		poolDictionaries: ''
-		category: 'ExtendedPackage'.
+		         subclass: #TestExtendedClass
+		         instanceVariableNames: ''
+		         classVariableNames: ''
+		         poolDictionaries: ''
+		         category: 'ExtendedPackage'.
 
 	class := class class.
 
@@ -259,16 +271,16 @@ RPackageRenameTest >> testRenamePackageWithExtensionsInClassSide [
 { #category : #tests }
 RPackageRenameTest >> testUnregisterPackage [
 	"Test that we do unregister the package as expected."
-	| package workingCopy class |
 
-	package := RPackageOrganizer default registerPackageNamed: 'Test1'.
+	| package workingCopy class |
+	package := Smalltalk organization registerPackageNamed: 'Test1'.
 	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'Test1').
 	class := Object
-		subclass: #TestClass
-		instanceVariableNames: ''
-		classVariableNames: ''
-		poolDictionaries: ''
-		category: 'Test1-TAG'.
+		         subclass: #TestClass
+		         instanceVariableNames: ''
+		         classVariableNames: ''
+		         poolDictionaries: ''
+		         category: 'Test1-TAG'.
 	self assert: (package includesClass: class).
 	self assert: (package classTagNamed: #TAG ifAbsent: [ nil ]) notNil.
 	self assert: ((package classTagNamed: #TAG ifAbsent: [ nil ]) includesClass: class).
@@ -276,6 +288,6 @@ RPackageRenameTest >> testUnregisterPackage [
 
 	package unregister.
 
-	self deny: (RPackageOrganizer default includesPackageNamed: #Test1).
+	self deny: (Smalltalk organization includesPackageNamed: #Test1).
 	self deny: (MCWorkingCopy hasPackageNamed: #Test1)
 ]

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -18,12 +18,13 @@ RPackageTest >> tearDown [
 
 { #category : #tests }
 RPackageTest >> testActualClassTags [
+
 	| packageWithoutClassTags packageWithClassTags |
-	packageWithoutClassTags := RPackageOrganizer default packageOf: StartupAction.
+	packageWithoutClassTags := Smalltalk organization packageOf: StartupAction.
 	self denyEmpty: packageWithoutClassTags classTags.
 	self assertEmpty: packageWithoutClassTags actualClassTags.
 
-	packageWithClassTags := RPackageOrganizer default packageOf: Object.
+	packageWithClassTags := Smalltalk organization packageOf: Object.
 	self assert: packageWithClassTags actualClassTags equals: packageWithClassTags classTags
 ]
 
@@ -218,11 +219,11 @@ RPackageTest >> testHasProperty [
 
 { #category : #'tests - queries' }
 RPackageTest >> testHierarchyRoots [
+
 	| roots |
-	roots := (RPackageOrganizer default packageNamed: #'RPackage-Tests') hierarchyRoots.
+	roots := (Smalltalk organization packageNamed: #'RPackage-Tests') hierarchyRoots.
 	roots := roots collect: [ :each | each name ].
-	#(RPackageTestCase)
-		do: [ :each | roots includes: each ]
+	#( RPackageTestCase ) do: [ :each | roots includes: each ]
 ]
 
 { #category : #tests }
@@ -290,8 +291,9 @@ RPackageTest >> testRenameToMakesMCDirty [
 
 { #category : #'tests - queries' }
 RPackageTest >> testRoots [
+
 	| roots |
-	roots := (RPackageOrganizer default packageNamed: #'RPackage-Tests') roots.
+	roots := (Smalltalk organization packageNamed: #'RPackage-Tests') roots.
 	roots := roots collect: [ :each | each name ].
-	#(RPackageStringExtensionTest RPackageRenameTest TestRPackagePrequisites RPackageTestCase RPackageWithDoTest) do: [ :each | roots includes: each ]
+	#( RPackageStringExtensionTest RPackageRenameTest TestRPackagePrequisites RPackageTestCase RPackageWithDoTest ) do: [ :each | roots includes: each ]
 ]

--- a/src/RPackage-Tests/RPackageTraitTest.class.st
+++ b/src/RPackage-Tests/RPackageTraitTest.class.st
@@ -99,7 +99,7 @@ RPackageTraitTest >> testPackageOfClassMethodFromTraitIsTraitPackage [
 	"test that a class method coming from a trait is packaged in the trait package"
 
 	self assert: (a1 >> #traitMethodDefinedInP4 packageFromOrganizer: self packageClass organizer) equals: p4.
-	self assert: (a1 >> #traitMethodDefinedInP5 packageFromOrganizer: self packageOrganizerClass default) equals: p5
+	self assert: (a1 >> #traitMethodDefinedInP5 packageFromOrganizer: Smalltalk organization) equals: p5
 ]
 
 { #category : #tests }
@@ -107,7 +107,7 @@ RPackageTraitTest >> testPackageOfClassMethodIsClassPackage [
 	"The package of a local method (not defined in a trait) is the package of its class"
 
 	self assert: (a1 >> #localMethodDefinedInP1 packageFromOrganizer: self packageClass organizer) equals: p4.
-	self assert: (a1 >> #anotherLocalMethodDefinedInP1 packageFromOrganizer: self packageOrganizerClass default) equals: p4.
+	self assert: (a1 >> #anotherLocalMethodDefinedInP1 packageFromOrganizer: Smalltalk organization) equals: p4.
 	self assert: (a1 >> #anotherLocalMethodDefinedInP1 packageFromOrganizer: self packageClass organizer) equals: p4
 ]
 
@@ -116,7 +116,7 @@ RPackageTraitTest >> testPackageOfTraitMethodIsTraitPackage [
 	"The package of a trait method is the package of its trait."
 
 	self assert: (a1 >> #traitMethodDefinedInP5 packageFromOrganizer: self packageClass organizer) equals: p5.
-	self assert: (a1 >> #traitMethodDefinedInP5 packageFromOrganizer: self packageOrganizerClass default) equals: p5.
+	self assert: (a1 >> #traitMethodDefinedInP5 packageFromOrganizer: Smalltalk organization) equals: p5.
 	self assert: (a1 >> #traitMethodDefinedInP4 packageFromOrganizer: self packageClass organizer) equals: p4
 ]
 

--- a/src/RPackage-Tests/RPackageWithDoTest.class.st
+++ b/src/RPackage-Tests/RPackageWithDoTest.class.st
@@ -91,36 +91,58 @@ RPackageWithDoTest >> testOnDo [
 
 { #category : #tests }
 RPackageWithDoTest >> testOrganizerContainsPackages [
-	self assert: self packageOrganizerClass default packageNames isNotEmpty description: 'RPackageOrganizer should contains package names since an image should at least contains one package.'.
-	self assert: self packageOrganizerClass default packages isNotEmpty description: 'RPackageOrganizer should not be empty since an image should at least contains one package.'
+
+	self
+		assert: Smalltalk organization packageNames isNotEmpty
+		description: 'RPackageOrganizer should contains package names since an image should at least contains one package.'.
+	self
+		assert: Smalltalk organization packages isNotEmpty
+		description: 'RPackageOrganizer should not be empty since an image should at least contains one package.'
 ]
 
 { #category : #tests }
 RPackageWithDoTest >> testWithDoIsCorrectlyReinstallingDefault [
+
 	| current empty |
-	current := self packageOrganizerClass default.
+	current := Smalltalk organization.
 	empty := self packageOrganizerClass basicNew initialize.
 	empty debuggingName: 'empty from PackageWithDoTest'.
-	self packageClass
-		withOrganizer: empty
-		do: [ self assert: (self organizerAnnouncer hasSubscriber: empty) description: 'During #withOrganizer:do:, the system announcer should have the organizer as parameter in its subscriber.'.
-			self deny: (self organizerAnnouncer hasSubscriber: current) description: 'During #withOrganizer:do:, the system announcer shouldn''t have the default organizer in its subscriber.' ].
-	self assert: (self organizerAnnouncer hasSubscriber: current) description: 'After the use of #withOrganizer:do:, the default organizer should be reinstalled in system announcer subscribers.'.
-	self deny: (self organizerAnnouncer hasSubscriber: empty) description: 'After the use of #withOrganizer:do:, the empty organizer should be removed from the system announcer subscribers.'
+	self packageClass withOrganizer: empty do: [
+		self
+			assert: (self organizerAnnouncer hasSubscriber: empty)
+			description: 'During #withOrganizer:do:, the system announcer should have the organizer as parameter in its subscriber.'.
+		self
+			deny: (self organizerAnnouncer hasSubscriber: current)
+			description: 'During #withOrganizer:do:, the system announcer shouldn''t have the default organizer in its subscriber.' ].
+	self
+		assert: (self organizerAnnouncer hasSubscriber: current)
+		description: 'After the use of #withOrganizer:do:, the default organizer should be reinstalled in system announcer subscribers.'.
+	self
+		deny: (self organizerAnnouncer hasSubscriber: empty)
+		description: 'After the use of #withOrganizer:do:, the empty organizer should be removed from the system announcer subscribers.'
 ]
 
 { #category : #tests }
 RPackageWithDoTest >> testWithDoIsCorrectlyReinstallingDefaultEvenIfHalt [
+
 	| current empty |
-	current := self packageOrganizerClass default.
+	current := Smalltalk organization.
 	empty := self packageOrganizerClass basicNew initialize.
-	[ self packageClass
-		withOrganizer: empty
-		do: [ self assert: (self organizerAnnouncer hasSubscriber: empty) description: 'During #withOrganizer:do:, the system announcer should have the organizer as parameter in its subscriber.'.
-			self deny: (self organizerAnnouncer hasSubscriber: current) description: 'During #withOrganizer:do:, the system announcer shouldn''t have the default organizer in its subscriber.'.
-			self error ] ]
+	[
+	self packageClass withOrganizer: empty do: [
+		self
+			assert: (self organizerAnnouncer hasSubscriber: empty)
+			description: 'During #withOrganizer:do:, the system announcer should have the organizer as parameter in its subscriber.'.
+		self
+			deny: (self organizerAnnouncer hasSubscriber: current)
+			description: 'During #withOrganizer:do:, the system announcer shouldn''t have the default organizer in its subscriber.'.
+		self error ] ]
 		on: Error
 		do: [ :ex |  ].
-	self assert: (self organizerAnnouncer hasSubscriber: current) description: 'After the use of #withOrganizer:do:, the default organizer should be reinstalled in system announcer subscribers.'.
-	self deny: (self organizerAnnouncer hasSubscriber: empty) description: 'After the use of #withOrganizer:do:, the empty organizer should be removed from the system announcer subscribers.'
+	self
+		assert: (self organizerAnnouncer hasSubscriber: current)
+		description: 'After the use of #withOrganizer:do:, the default organizer should be reinstalled in system announcer subscribers.'.
+	self
+		deny: (self organizerAnnouncer hasSubscriber: empty)
+		description: 'After the use of #withOrganizer:do:, the empty organizer should be removed from the system announcer subscribers.'
 ]

--- a/src/ReleaseTests/ProperPackagesTest.class.st
+++ b/src/ReleaseTests/ProperPackagesTest.class.st
@@ -29,11 +29,12 @@ ProperPackagesTest >> testPackageExtensionsStartsWithProperPackageName [
 
 { #category : #tests }
 ProperPackagesTest >> testProperClassTagCasing [
-	|violations|
+
+	| violations |
 	violations := OrderedCollection new.
-	RPackageOrganizer default packages
-        do: [:package | package classTags do: [:classTag | classTag name first isLowercase ifTrue: [ violations add: (package -> classTag) ] ] ].
-	self assert:  violations isEmpty description: 'Class Tags should be uppercase'
+	Smalltalk organization packages do: [ :package |
+		package classTags do: [ :classTag | classTag name first isLowercase ifTrue: [ violations add: package -> classTag ] ] ].
+	self assert: violations isEmpty description: 'Class Tags should be uppercase'
 ]
 
 { #category : #'tests - manifest' }

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -239,7 +239,7 @@ ReleaseTest >> testNoEmptyPackages [
 	"Test that we have no empty packages left"
 
 	| violating |
-	violating := RPackageOrganizer default packages select: #isEmpty.
+	violating := Smalltalk organization packages select: #isEmpty.
 	self assertEmpty: violating
 ]
 
@@ -384,15 +384,16 @@ ReleaseTest >> testProperManifestClasses [
 { #category : #'tests - rpackage' }
 ReleaseTest >> testRPackageOrganizer [
 	"Ensure other tests temporary created organizers are collected"
+
 	3 timesRepeat: [ Smalltalk garbageCollect ].
 
 	"Now check :)"
 	self
 		assert: RPackageOrganizer allInstances size = 1
-		description: 'There are multiple (', RPackageOrganizer allInstances size asString, ') instances of RPackageOrganizer'.
+		description: 'There are multiple (' , RPackageOrganizer allInstances size asString , ') instances of RPackageOrganizer'.
 
 	self
-		assert: RPackageOrganizer allInstances first == RPackageOrganizer default
+		assert: RPackageOrganizer allInstances first == Smalltalk organization
 		description: 'The default package organizer is the not the only instance of RPackageOrganizer'
 ]
 
@@ -501,22 +502,19 @@ ReleaseTest >> testUnknownProcesses [
 
 { #category : #'tests - rpackage' }
 ReleaseTest >> testUnpackagedClasses [
+
 	| unpackagedClasses |
-	unpackagedClasses := Smalltalk allClassesAndTraits select: [:each |
-		(RPackageOrganizer default packageOf: each) packageName = RPackage defaultPackageName ].
-	self
-		assert: unpackagedClasses isEmpty
-		description: (String streamContents: [ :s|
-			s nextPutAll: 'Found the following unpackaged classes: '.
-			unpackagedClasses
-				do: [ :cls| s tab print: cls ]
-				separatedBy: [ s cr ]])
+	unpackagedClasses := Smalltalk allClassesAndTraits select: [ :each | (Smalltalk organization packageOf: each) packageName = RPackage defaultPackageName ].
+	self assert: unpackagedClasses isEmpty description: (String streamContents: [ :s |
+			 s nextPutAll: 'Found the following unpackaged classes: '.
+			 unpackagedClasses do: [ :cls | s tab print: cls ] separatedBy: [ s cr ] ])
 ]
 
 { #category : #'tests - rpackage' }
 ReleaseTest >> testUnpackagedPackageShouldBeEmpty [
+
 	| unpackagePackage |
-	unpackagePackage := RPackageOrganizer default packageNamed: RPackage defaultPackageName.
+	unpackagePackage := Smalltalk organization packageNamed: RPackage defaultPackageName.
 	"The unpackage package should not have any defined class or extended classes"
 	self assertEmpty: unpackagePackage classes
 ]

--- a/src/Shift-ClassInstaller-Tests/ShAnonymousClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShAnonymousClassInstallerTest.class.st
@@ -6,15 +6,15 @@ Class {
 
 { #category : #tests }
 ShAnonymousClassInstallerTest >> testSubclasses [
+
 	| aSubClass |
 	aSubClass := Smalltalk anonymousClassInstaller make: [ :builder |
-		builder superclass: Point.
-		builder name: #AnotherPoint.
-	].
+		             builder superclass: Point.
+		             builder name: #AnotherPoint ].
 
 	self deny: (Point subclasses includes: aSubClass).
 	self assert: aSubClass superclass equals: Point.
 	self deny: (Smalltalk hasClassNamed: #AnotherPoint).
 
-	self assert: (RPackageOrganizer default packageOfClassNamed: #AnotherPoint) equals: nil
+	self assert: (Smalltalk organization packageOfClassNamed: #AnotherPoint) equals: nil
 ]

--- a/src/System-Settings-Tests/SettingBrowserTest.class.st
+++ b/src/System-Settings-Tests/SettingBrowserTest.class.st
@@ -20,6 +20,8 @@ SettingBrowserTest >> testOpening [
 { #category : #tests }
 SettingBrowserTest >> testOpeningOnPackage [
 
-	settingBrowser := SettingBrowser new changePackageSet: { (RPackageOrganizer default packageNamed: 'System-Settings-Core') }; open.
+	settingBrowser := SettingBrowser new
+		                  changePackageSet: { (Smalltalk organization packageNamed: 'System-Settings-Core') };
+		                  open.
 	settingBrowser close
 ]

--- a/src/Tool-DependencyAnalyser-Tests/DATarjanAlgorithmTest.class.st
+++ b/src/Tool-DependencyAnalyser-Tests/DATarjanAlgorithmTest.class.st
@@ -49,13 +49,10 @@ DATarjanAlgorithmTest >> testNoOutgoingDependenciesAfterTarjan [
 	"test if we have 0 outgoing dependencies in each SCC after the algorithm"
 
 	| aRelation aCollection sccs |
-	aCollection := OrderedCollection
-		withAll:
-			(RPackageOrganizer default packages
-				select: [ :package | '*Collections*' match: package packageName asString ]
-				thenCollect: [ :package | package packageName ]).
-	aRelation := DAPackageRelationGraph
-		onPackages: (aCollection collect: [ :each | DAPackage on: (RPackageSet named: each) ]).
+	aCollection := OrderedCollection withAll: (Smalltalk organization packages
+			                select: [ :package | '*Collections*' match: package packageName asString ]
+			                thenCollect: [ :package | package packageName ]).
+	aRelation := DAPackageRelationGraph onPackages: (aCollection collect: [ :each | DAPackage on: (RPackageSet named: each) ]).
 	aRelation
 		computeStaticDependencies;
 		removeInternalDependencies;

--- a/src/Tool-DependencyAnalyser/DAMessageSendAnalyzer.class.st
+++ b/src/Tool-DependencyAnalyser/DAMessageSendAnalyzer.class.st
@@ -40,10 +40,10 @@ DAMessageSendAnalyzer class >> packagesProvidingSelector: aSelector [
 
 { #category : #computing }
 DAMessageSendAnalyzer >> implementedMessages [
+
 	^ (self packageStaticDependencies
-		add: self packageName;
-		yourself)
-		flatCollect: [ :name | (RPackageOrganizer default packageNamed: name) selectors ]
+		   add: self packageName;
+		   yourself) flatCollect: [ :name | (Smalltalk organization packageNamed: name) selectors ]
 ]
 
 { #category : #computing }
@@ -80,7 +80,7 @@ DAMessageSendAnalyzer >> missingMethods [
 DAMessageSendAnalyzer >> missingMethodsImplementedIn: aPackageName [
 
 	| rPackage |
-	rPackage := RPackageOrganizer default packageNamed: aPackageName ifAbsent: [
+	rPackage := Smalltalk organization packageNamed: aPackageName ifAbsent: [
 		            DAUnknownManuallyResolvedPackage signalOn: aPackageName.
 		            ^ self missingMethods ].
 

--- a/src/Tool-DependencyAnalyser/DAPackageRelationGraph.class.st
+++ b/src/Tool-DependencyAnalyser/DAPackageRelationGraph.class.st
@@ -483,11 +483,12 @@ DAPackageRelationGraph >> successors: aPackage [
 
 { #category : #queries }
 DAPackageRelationGraph >> systemPackageContaining: aClass [
+
 	| packageName |
-	packageName := (RPackageOrganizer default packageOf: aClass) packageName.
+	packageName := (Smalltalk organization packageOf: aClass) packageName.
 	^ packageName
-		ifNil: [ self error: 'Package for ' , aClass name , ' not found.' ]
-		ifNotNil: [ DAPackage on: (RPackageSet named: packageName asString) ]
+		  ifNil: [ self error: 'Package for ' , aClass name , ' not found.' ]
+		  ifNotNil: [ DAPackage on: (RPackageSet named: packageName asString) ]
 ]
 
 { #category : #computing }

--- a/src/TraitsV2-Tests/T2TraitWithPackagesTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitWithPackagesTest.class.st
@@ -19,12 +19,14 @@ T2TraitWithPackagesTest >> packageName2 [
 
 { #category : #tests }
 T2TraitWithPackagesTest >> packageUnderTest [
-	^ RPackageOrganizer default packageNamed: self packageName
+
+	^ Smalltalk organization packageNamed: self packageName
 ]
 
 { #category : #tests }
 T2TraitWithPackagesTest >> packageUnderTest2 [
-	^ RPackageOrganizer default packageNamed: self packageName2
+
+	^ Smalltalk organization packageNamed: self packageName2
 ]
 
 { #category : #tests }
@@ -154,38 +156,47 @@ T2TraitWithPackagesTest >> testPackageOfMethodFromTraitsRemoved [
 	self assert: (t1 >> #m1) package equals: self packageUnderTest.
 	self assert: (t2 >> #m1) package equals: self packageUnderTest.
 
-	self assert: (RPackageOrganizer default packageDefiningOrExtendingSelector: #m1 inClassNamed: #T1) equals: self packageUnderTest.
+	self assert: (Smalltalk organization packageDefiningOrExtendingSelector: #m1 inClassNamed: #T1) equals: self packageUnderTest.
 
 	t1 removeSelector: #m1.
 
 	self assert: (t1 organization protocolOfSelector: #m1) isNil.
 	self assert: (t2 organization protocolOfSelector: #m1) isNil.
 
-	self assert: (RPackageOrganizer default packageDefiningOrExtendingSelector: #m1 inClassNamed: #T1) isNil.
-	self assert: (RPackageOrganizer default packageDefiningOrExtendingSelector: #m1 inClassNamed: #T2) isNil
+	self assert: (Smalltalk organization packageDefiningOrExtendingSelector: #m1 inClassNamed: #T1) isNil.
+	self assert: (Smalltalk organization packageDefiningOrExtendingSelector: #m1 inClassNamed: #T2) isNil
 ]
 
 { #category : #tests }
 T2TraitWithPackagesTest >> testPackageOfRemovedTrait [
+
 	| t1 t2 |
-	t1 := self newTrait: #T1 with: #() uses: {} category: self packageName.
-	t2 := self newTrait: #T2 with: #() uses: t1 category: self packageName2.
+	t1 := self
+		      newTrait: #T1
+		      with: #(  )
+		      uses: {  }
+		      category: self packageName.
+	t2 := self
+		      newTrait: #T2
+		      with: #(  )
+		      uses: t1
+		      category: self packageName2.
 
 	self assert: t1 package equals: self packageUnderTest.
 	self assert: t2 package equals: self packageUnderTest2.
 
-	self assert: (RPackageOrganizer default packageOfClassNamed: #T1) equals: self packageUnderTest.
-	self assert: (RPackageOrganizer default packageOfClassNamed: #T2) equals: self packageUnderTest2.
+	self assert: (Smalltalk organization packageOfClassNamed: #T1) equals: self packageUnderTest.
+	self assert: (Smalltalk organization packageOfClassNamed: #T2) equals: self packageUnderTest2.
 
 	t2 removeFromSystem.
 
-	self assert: (RPackageOrganizer default packageOfClassNamed: #T1) equals: self packageUnderTest.
-	self assert: (RPackageOrganizer default packageOfClassNamed: #T2) isNil.
+	self assert: (Smalltalk organization packageOfClassNamed: #T1) equals: self packageUnderTest.
+	self assert: (Smalltalk organization packageOfClassNamed: #T2) isNil.
 
 	t1 removeFromSystem.
 
-	self assert: (RPackageOrganizer default packageOfClassNamed: #T1) isNil.
-	self assert: (RPackageOrganizer default packageOfClassNamed: #T2) isNil
+	self assert: (Smalltalk organization packageOfClassNamed: #T1) isNil.
+	self assert: (Smalltalk organization packageOfClassNamed: #T2) isNil
 ]
 
 { #category : #tests }


### PR DESCRIPTION
The default RPackageOrganizer has currently two entry point. The orginal one that was `RPackageOrganizer default` and now `Smalltalk organization`.

I don't like to have multiple entry points to kind of singletons so here is a first step to migrate references to `RPackageOrganizer default` to `Smalltalk organization`