### PR TITLE
Remove unclassified hack

### DIFF
--- a/src/Kernel-Tests/ClassDescriptionTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionTest.class.st
@@ -116,7 +116,6 @@ ClassDescriptionTest >> testCompileClassifiedWithUnclassified [
 	| class method |
 	class := self createTestClass.
 
-	"During the first compilation if the protocol is nil we put it in Protocol unclassified."
 	class compile: 'foo ^3' classified: Protocol unclassified.
 	method := class >> #foo.
 
@@ -129,7 +128,7 @@ ClassDescriptionTest >> testCompileClassifiedWithUnclassified [
 	self assert: method sourceCode equals: 'foo ^3'.
 	self assert: method protocol equals: #protocol.
 
-	"If we give a nil protocol, we just keep the actual one."
+	"Protocol unclassified should work as any other protocol for the classification."
 	class compile: 'foo ^3' classified: Protocol unclassified.
 	method := class >> #foo.
 

--- a/src/Kernel-Tests/ClassDescriptionTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionTest.class.st
@@ -70,6 +70,33 @@ ClassDescriptionTest >> testCompileClassified [
 ]
 
 { #category : #'tests - compilation' }
+ClassDescriptionTest >> testCompileClassifiedWithNil [
+
+	| class method |
+	class := self createTestClass.
+
+	"During the first compilation if the protocol is nil we put it in Protocol unclassified."
+	class compile: 'foo ^3' classified: nil.
+	method := class >> #foo.
+
+	self assert: method sourceCode equals: 'foo ^3'.
+	self assert: method protocol equals: Protocol unclassified.
+
+	class compile: 'foo ^3' classified: #protocol.
+	method := class >> #foo.
+
+	self assert: method sourceCode equals: 'foo ^3'.
+	self assert: method protocol equals: #protocol.
+
+	"If we give a nil protocol, we just keep the actual one."
+	class compile: 'foo ^3' classified: nil.
+	method := class >> #foo.
+
+	self assert: method sourceCode equals: 'foo ^3'.
+	self assert: method protocol equals: #protocol
+]
+
+{ #category : #'tests - compilation' }
 ClassDescriptionTest >> testCompileClassifiedWithProtocolInstance [
 
 	| class method protocol |
@@ -81,6 +108,33 @@ ClassDescriptionTest >> testCompileClassifiedWithProtocolInstance [
 
 	self assert: method sourceCode equals: 'foo ^3'.
 	self assert: method protocol equals: protocol name
+]
+
+{ #category : #'tests - compilation' }
+ClassDescriptionTest >> testCompileClassifiedWithUnclassified [
+
+	| class method |
+	class := self createTestClass.
+
+	"During the first compilation if the protocol is nil we put it in Protocol unclassified."
+	class compile: 'foo ^3' classified: Protocol unclassified.
+	method := class >> #foo.
+
+	self assert: method sourceCode equals: 'foo ^3'.
+	self assert: method protocol equals: Protocol unclassified.
+
+	class compile: 'foo ^3' classified: #protocol.
+	method := class >> #foo.
+
+	self assert: method sourceCode equals: 'foo ^3'.
+	self assert: method protocol equals: #protocol.
+
+	"If we give a nil protocol, we just keep the actual one."
+	class compile: 'foo ^3' classified: Protocol unclassified.
+	method := class >> #foo.
+
+	self assert: method sourceCode equals: 'foo ^3'.
+	self assert: method protocol equals: Protocol unclassified
 ]
 
 { #category : #'tests - slots' }

--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -118,12 +118,12 @@ ClassOrganizationTest >> testClassifyUnderWithNil [
 	self assertCollection: self organization protocolNames hasSameElements: { #empty. #one. unclassified . #owl }.
 	self assertCollection: (self organization protocolNamed: #owl ) methodSelectors hasSameElements: #( #luz ).
 	
-	"Now let's test the behavior if we already have a protocol.
-	The behavior should change to not change the protocol but this test will ensure that the change is intentional and not a regression."
+	"In case we classify under nil while the method already has a protocol, we do not want to update the protocol."
 	self organization classify: #luz under: nil.
 
-	self assertCollection: self organization protocolNames hasSameElements: { #empty. #one. unclassified }.
-	self assertCollection: (self organization protocolNamed: unclassified ) methodSelectors hasSameElements: #( #king #luz ).
+	self assertCollection: self organization protocolNames hasSameElements: { #empty. #one. unclassified . #owl }.
+	self assertCollection: (self organization protocolNamed: unclassified ) methodSelectors hasSameElements: #( #king ).
+	self assertCollection: (self organization protocolNamed: #owl ) methodSelectors hasSameElements: #( #luz ).
 ]
 
 { #category : #tests }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -33,12 +33,7 @@ ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod 
 	priorMethodOrNil ifNotNil: [ priorOriginOrNil := priorMethodOrNil origin ].
 
 	oldProtocol := self organization protocolOfSelector: selector.
-	SystemAnnouncer uniqueInstance suspendAllWhile: [ "The next part is really ugly with the double if.. BUT! I will fix that in a new PR soon... I want to remove the usage of `Protocol unclassified` as a way to say 'Do not upatde the protocol' because this is counter intuitive."
-		self organization classify: selector under: ((protocol isString
-				  ifTrue: [ protocol ]
-				  ifFalse: [ protocol name ]) = Protocol unclassified
-				 ifTrue: [ oldProtocol ]
-				 ifFalse: [ protocol ]) ].
+	SystemAnnouncer uniqueInstance suspendAllWhile: [ self organization classify: selector under: protocol ].
 	newProtocol := self organization protocolOfSelector: selector.
 
 	self addSelectorSilently: selector withMethod: compiledMethod.
@@ -303,7 +298,7 @@ ClassDescription >> compile: sourceCode classified: protocol withStamp: changeSt
 ClassDescription >> compile: sourceCode notifying: requestor [
 	"Refer to the comment in Behavior|compile:notifying:."
 
-	^ self compile: sourceCode classified: Protocol unclassified notifying: requestor
+	^ self compile: sourceCode classified: nil notifying: requestor
 ]
 
 { #category : #compiling }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -47,7 +47,13 @@ ClassOrganization >> allMethodSelectors [
 ClassOrganization >> classify: selector under: aProtocol [
 
 	| oldProtocol newProtocol |
-	(newProtocol := self ensureProtocol: aProtocol) = (oldProtocol := self protocolOfSelector: selector) ifTrue: [ ^ self ].
+	oldProtocol := self protocolOfSelector: selector.
+
+	"In case the method is already classified and we say to classify it under nil, we do not update the protocol."
+	(aProtocol isNil and: [ oldProtocol isNotNil ]) ifTrue: [ ^ self ].
+	
+	"If old and new protocols are the same, we skip the classification."
+	(newProtocol := self ensureProtocol: aProtocol) = oldProtocol ifTrue: [ ^ self ].
 
 	oldProtocol ifNotNil: [
 		oldProtocol removeMethodSelector: selector.

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -555,18 +555,18 @@ OpalCompiler >> install [
 	method := self compile.
 	method ifNil: [ ^ method ].
 
-	protocol := class ensureProtocol: protocol.
 	changeStamp ifNil: [ changeStamp := Author changeStamp ].
 	logSource := self logged ifNil: [ class acceptsLoggingOfCompilation ].
 
+	class addAndClassifySelector: method selector withMethod: method inProtocol: protocol.
+	
 	logSource ifTrue: [
+		"For the log we do not use `protocol` because in case it is nil, we keep the current classification or we classify under uncategorize. So we ask to the method its protocol."
 		class
 			logMethodSource: source
 			forMethod: method
-			inProtocol: protocol
+			inProtocol: (class organization protocolOfSelector: method selector) "This should just be `method protocol` when it will return a real protocol and not a name."
 			withStamp: changeStamp ].
-
-	class addAndClassifySelector: method selector withMethod: method inProtocol: protocol.
 
 	class instanceSide noteCompilationOf: method meta: class isClassSide.
 


### PR DESCRIPTION
One thing that I hated in the protocol management is that classfying with `Protocol unclassified` is used to say "Do not update my protocol". But this leads to really bad behavior such as:

```st
MyClass compile: 'foo ^ 1' classified: #toto.
MyClass compile: 'foo ^ 1' classified: #'as yet unclassified'.
(MyClass>>#foo) protocol "#toto"
```

This means that if you want to unclassify your method you need to deal with the internal behavior of ClassOrganization.

I propose to use 'nil' as a way to "not update" the protocol and now Protocol unclassified works just like any other protocol! No more hack and if everywhere. This is the result of all the previous cleanings also :)

In order to do this I had to:
- update ClassDescription>>#addAndClassifySelector:withMethod:inProtocol: to remove the conditions
- update ClassDescription>>#compile:notifying: to just use nil as default value
- update ClassOrganization>>#classify:under: to use nil as a "do not update protocol" 
- update OpalCompiler>>#install to not cast nil into a Protocol unclassified

I also fixed a but where the sources were sometimes written with the wrong protocol (it used the one provided to Opal and not the final protocol of the method). This also includes new tests for this behavior.