### PR TITLE
Use real protocol in recategorization mecanism

### DIFF
--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -670,14 +670,13 @@ ClassDescription >> noteCompilationOf: aSelector meta: isMeta [
 ]
 
 { #category : #'organization updating' }
-ClassDescription >> notifyOfRecategorizedSelector: selector from: oldCategory to: newCategory [
+ClassDescription >> notifyOfRecategorizedSelector: selector from: oldProtocol to: newProtocol [
 	"If compiled method is not there, it meens it has been removed, not recategorized... so I skip
 	 the method recategorized announce"
-	(self compiledMethodAt: selector ifAbsent: [ nil ])
-		ifNotNil: [ :method |
-			SystemAnnouncer uniqueInstance
-				methodRecategorized: method
-				oldProtocol: oldCategory ]
+
+	self
+		compiledMethodAt: selector
+		ifPresent: [ :method | SystemAnnouncer uniqueInstance methodRecategorized: method oldProtocol: (oldProtocol ifNotNil: [ oldProtocol name ]) ]
 ]
 
 { #category : #private }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -56,7 +56,7 @@ ClassOrganization >> classify: selector under: aProtocol [
 	newProtocol addMethodSelector: selector.
 
 	"During the first classification of a method we dont need to announce the classification because users can subscribe to the method added announcement."
-	oldProtocol ifNotNil: [ self organizedClass notifyOfRecategorizedSelector: selector from: oldProtocol name to: newProtocol name ]
+	oldProtocol ifNotNil: [ self organizedClass notifyOfRecategorizedSelector: selector from: oldProtocol to: newProtocol ]
 ]
 
 { #category : #copying }
@@ -185,7 +185,7 @@ ClassOrganization >> removeElement: aSelector [
 	(self protocolOfSelector: aSelector) ifNotNil: [ :protocol |
 		protocol removeMethodSelector: aSelector.
 		self removeProtocolIfEmpty: protocol.
-		self organizedClass notifyOfRecategorizedSelector: aSelector from: protocol name to: nil ]
+		self organizedClass notifyOfRecategorizedSelector: aSelector from: protocol to: nil ]
 ]
 
 { #category : #removing }
@@ -259,7 +259,7 @@ ClassOrganization >> renameProtocol: anOldProtocol as: aNewProtocol [
 	SystemAnnouncer announce: (ClassReorganized class: self organizedClass).
 
 	"I need to notify also the selector changes, otherwise RPackage will not notice"
-	newProtocol methodSelectors do: [ :each | self organizedClass notifyOfRecategorizedSelector: each from: oldProtocol name to: newProtocol name ]
+	newProtocol methodSelectors do: [ :each | self organizedClass notifyOfRecategorizedSelector: each from: oldProtocol to: newProtocol ]
 ]
 
 { #category : #initialization }

--- a/src/SystemCommands-MessageCommands/SycInlineAllSendersMessageCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycInlineAllSendersMessageCommand.class.st
@@ -14,20 +14,17 @@ SycInlineAllSendersMessageCommand class >> canBeExecutedInContext: aToolContext 
 
 { #category : #execution }
 SycInlineAllSendersMessageCommand >> createRefactoring [
-	| refactoring methodOrigin |
 
+	| refactoring methodOrigin |
 	"Extract the method origin from the context.
 	The contextUser can be
 	  - a method (if selected from the method list)
 	  - an AST (if selected from the text editor).
 	Ask #method to resolve to the method, and then ask the origin, i.e. the class or trait where it is defined"
-	methodOrigin := originalMessage contextUser method origin.
-	refactoring := RBInlineAllSendersRefactoring
-		model: model
-		sendersOf: originalMessage selector
-		in: methodOrigin.
+	methodOrigin := originalMessage contextUser compiledMethod origin.
+	refactoring := RBInlineAllSendersRefactoring model: model sendersOf: originalMessage selector in: methodOrigin.
 	refactoring setOption: #inlineExpression toUse: [ :ref :aString |
-		(self confirm: ('Do you want to extract the expression ''<1s>'' into a variable in method ''<2s>''?' expandMacrosWith: aString with: ref sourceSelector)) not ] .
+		(self confirm: ('Do you want to extract the expression ''<1s>'' into a variable in method ''<2s>''?' expandMacrosWith: aString with: ref sourceSelector)) not ].
 	^ refactoring
 ]
 

--- a/src/TraitsV2/MetaclassForTraits.class.st
+++ b/src/TraitsV2/MetaclassForTraits.class.st
@@ -96,10 +96,11 @@ MetaclassForTraits >> name [
 ]
 
 { #category : #'organization updating' }
-MetaclassForTraits >> notifyOfRecategorizedSelector: selector from: oldCategory to: newCategory [
+MetaclassForTraits >> notifyOfRecategorizedSelector: selector from: oldProtocol to: newProtocol [
 	"When there is a recategorization of a selector, I propagate the changes to my users"
-	super notifyOfRecategorizedSelector: selector from: oldCategory to: newCategory.
-	self traitUsers do: [ :e | e recategorizeSelector: selector from: oldCategory to: newCategory ]
+
+	super notifyOfRecategorizedSelector: selector from: oldProtocol to: newProtocol.
+	self traitUsers do: [ :e | e recategorizeSelector: selector from: oldProtocol to: newProtocol ]
 ]
 
 { #category : #printing }

--- a/src/TraitsV2/Trait.class.st
+++ b/src/TraitsV2/Trait.class.st
@@ -305,10 +305,11 @@ Trait >> isUsed [
 ]
 
 { #category : #'organization updating' }
-Trait >> notifyOfRecategorizedSelector: selector from: oldCategory to: newCategory [
+Trait >> notifyOfRecategorizedSelector: selector from: oldProtocol to: newProtocol [
 	"When there is a recategorization of a selector, I propagate the changes to my users"
-	super notifyOfRecategorizedSelector: selector from: oldCategory to: newCategory.
-	self traitUsers do: [ :e | e recategorizeSelector: selector from: oldCategory to: newCategory ]
+
+	super notifyOfRecategorizedSelector: selector from: oldProtocol to: newProtocol.
+	self traitUsers do: [ :e | e recategorizeSelector: selector from: oldProtocol to: newProtocol ]
 ]
 
 { #category : #'accessing - method dictionary' }

--- a/src/TraitsV2/TraitedClass.class.st
+++ b/src/TraitsV2/TraitedClass.class.st
@@ -259,7 +259,7 @@ TraitedClass >> recategorizeSelector: selector from: oldProtocol to: newProtocol
 	newProtocol ifNil: [ ^ self ].
 
 	originalProtocol := (self organization protocolOfSelector: selector) ifNil: [ ^ self ].
-	originalProtocol = oldProtocol ifTrue: [ self organization classify: selector under: newProtocol ].
+	originalProtocol name = oldProtocol name ifTrue: [ self organization classify: selector under: newProtocol name ].
 
 	(self traitComposition reverseAlias: selector) do: [ :selectorAlias |
 		self recategorizeSelector: selectorAlias from: oldProtocol to: newProtocol.

--- a/src/TraitsV2/TraitedClass.class.st
+++ b/src/TraitsV2/TraitedClass.class.st
@@ -251,22 +251,19 @@ TraitedClass >> rebuildMethodDictionary [
 ]
 
 { #category : #categories }
-TraitedClass >> recategorizeSelector: selector from: oldProtocolName to: newProtocolName [
+TraitedClass >> recategorizeSelector: selector from: oldProtocol to: newProtocol [
 	"When a method is recategorized I have to classify the method, but also recategorize the aliases pointing to it"
 
 	| originalProtocol |
-	originalProtocol := (self organization protocolOfSelector: selector) ifNil: [ ^ self ].
-
 	"If it is nil is because it is a removal. It will removed when the method is removed."
-	newProtocolName ifNil: [ ^ self ].
+	newProtocol ifNil: [ ^ self ].
 
-	originalProtocol name = oldProtocolName ifTrue: [ self organization classify: selector under: newProtocolName ].
+	originalProtocol := (self organization protocolOfSelector: selector) ifNil: [ ^ self ].
+	originalProtocol = oldProtocol ifTrue: [ self organization classify: selector under: newProtocol ].
 
 	(self traitComposition reverseAlias: selector) do: [ :selectorAlias |
-		self recategorizeSelector: selectorAlias from: oldProtocolName to: newProtocolName.
-		self notifyOfRecategorizedSelector: selectorAlias from: oldProtocolName to: newProtocolName ].
-
-	self organization removeEmptyProtocols
+		self recategorizeSelector: selectorAlias from: oldProtocol to: newProtocol.
+		self notifyOfRecategorizedSelector: selectorAlias from: oldProtocol to: newProtocol ]
 ]
 
 { #category : #recompilation }

--- a/src/TraitsV2/TraitedMetaclass.class.st
+++ b/src/TraitsV2/TraitedMetaclass.class.st
@@ -268,22 +268,19 @@ TraitedMetaclass >> rebuildMethodDictionary [
 ]
 
 { #category : #categories }
-TraitedMetaclass >> recategorizeSelector: selector from: oldProtocolName to: newProtocolName [
+TraitedMetaclass >> recategorizeSelector: selector from: oldProtocol to: newProtocol [
 	"When a method is recategorized I have to classify the method, but also recategorize the aliases pointing to it"
 
 	| originalProtocol |
-	originalProtocol := (self organization protocolOfSelector: selector) ifNil: [ ^ self ].
-
 	"If it is nil is because it is a removal. It will removed when the method is removed."
-	newProtocolName ifNil: [ ^ self ].
+	newProtocol ifNil: [ ^ self ].
 
-	originalProtocol name = oldProtocolName ifTrue: [ self organization classify: selector under: newProtocolName ].
+	originalProtocol := (self organization protocolOfSelector: selector) ifNil: [ ^ self ].
+	originalProtocol = oldProtocol ifTrue: [ self organization classify: selector under: newProtocol ].
 
 	(self traitComposition reverseAlias: selector) do: [ :selectorAlias |
-		self recategorizeSelector: selectorAlias from: oldProtocolName to: newProtocolName.
-		self notifyOfRecategorizedSelector: selectorAlias from: oldProtocolName to: newProtocolName ].
-
-	self organization removeEmptyProtocols
+		self recategorizeSelector: selectorAlias from: oldProtocol to: newProtocol.
+		self notifyOfRecategorizedSelector: selectorAlias from: oldProtocol to: newProtocol ]
 ]
 
 { #category : #recompilation }

--- a/src/TraitsV2/TraitedMetaclass.class.st
+++ b/src/TraitsV2/TraitedMetaclass.class.st
@@ -276,7 +276,7 @@ TraitedMetaclass >> recategorizeSelector: selector from: oldProtocol to: newProt
 	newProtocol ifNil: [ ^ self ].
 
 	originalProtocol := (self organization protocolOfSelector: selector) ifNil: [ ^ self ].
-	originalProtocol = oldProtocol ifTrue: [ self organization classify: selector under: newProtocol ].
+	originalProtocol name = oldProtocol name ifTrue: [ self organization classify: selector under: newProtocol name ].
 
 	(self traitComposition reverseAlias: selector) do: [ :selectorAlias |
 		self recategorizeSelector: selectorAlias from: oldProtocol to: newProtocol.


### PR DESCRIPTION
Now that the system is able to handle more and more Protocol instances instead of handling their names, we can use real protocol instance in the recategorization mecanisme avoiding some "protocol name" in multiple places.

This reduces the number of lookup to transform a name into a protocol while recategorizing.

In the code I updated we still use the name only in one place that is the MethodRecategorized announcement, but this is part of the next things to update. And this is a necessary step to simplify this future change since we now have our protocol instance in the method announcing the change instead of having a protocol name.