### PR TITLE
Rename Protocol class>>#name: into #named:

### DIFF
--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -26,7 +26,7 @@ ClassOrganization >> addProtocol: aProtocol [
 	(self hasProtocol: aProtocol) ifTrue: [
 		^ self protocolNamed: (aProtocol isString ifTrue: [ aProtocol ] ifFalse: [ aProtocol name ]) ].
 
-	protocol := aProtocol isString ifTrue: [ Protocol name: aProtocol ] ifFalse: [ aProtocol ].
+	protocol := aProtocol isString ifTrue: [ Protocol named: aProtocol ] ifFalse: [ aProtocol ].
 
 	oldProtocols := self protocolNames copy.
 

--- a/src/Kernel/Protocol.class.st
+++ b/src/Kernel/Protocol.class.st
@@ -13,19 +13,26 @@ Class {
 }
 
 { #category : #'instance creation' }
-Protocol class >> name: nm [
+Protocol class >> name: aString [
 
-	^ self new
-		name: nm asSymbol;
-		yourself
+	self deprecated: 'Use #named: instead' transformWith: '`@rcv name: `@arg' -> '`@rcv named: `@arg'.
+	^ self named: aString
 ]
 
 { #category : #'instance creation' }
-Protocol class >> name: nm methodSelectors: methods [
+Protocol class >> name: aString methodSelectors: methods [
+
+	^ (self named: aString)
+		  methodSelectors: methods;
+		  yourself
+]
+
+{ #category : #'instance creation' }
+Protocol class >> named: aStrings [
+
 	^ self new
-		methodSelectors: methods;
-		name: nm asSymbol;
-		yourself
+		  name: aStrings;
+		  yourself
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This sound better in english. I also improved a little the code:
- Better variable names
- Reuse of code
- Remove duplicated #asSymbol (since it is already done in Protocol>>name:)