### PR TITLE
Use Smalltalk organization in DependencyAnalyzer

### DIFF
--- a/src/Tool-DependencyAnalyser-UI/DAAddPackagePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAAddPackagePresenter.class.st
@@ -88,7 +88,8 @@ DAAddPackagePresenter >> selectedItemsFromPackageList [
 
 { #category : #accessing }
 DAAddPackagePresenter >> systemPackages [
-	^ (RPackageOrganizer default packages collect: [ :package | package packageName asString ] )asSortedCollection
+
+	^ (Smalltalk organization packages collect: [ :package | package packageName asString ]) asSortedCollection
 ]
 
 { #category : #protocol }

--- a/src/Tool-DependencyAnalyser-UI/DACycleDetectionTreePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DACycleDetectionTreePresenter.class.st
@@ -17,7 +17,7 @@ Class {
 { #category : #'instance creation' }
 DACycleDetectionTreePresenter class >> onPackagesMatch: match [
 	^ (self onPackagesNamed:
-			(RPackageOrganizer default packages
+			(Smalltalk organization packages
 				select: [ :package | match match: package packageName asString ]
 				thenCollect: [ :package | package packageName ]) )
 ]
@@ -32,7 +32,7 @@ DACycleDetectionTreePresenter class >> onPackagesNamed: aCollection [
 { #category : #'instance creation' }
 DACycleDetectionTreePresenter class >> system [
 	^ self onPackagesNamed:
-		(RPackageOrganizer default packages collect: [ :package | package packageName asString ])
+		(Smalltalk organization packages collect: [ :package | package packageName asString ])
 ]
 
 { #category : #accessing }

--- a/src/Tool-DependencyAnalyser-UI/DADependencyTreePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DADependencyTreePresenter.class.st
@@ -53,10 +53,10 @@ DADependencyTreePresenter class >> onPackages: aCollection [
 
 { #category : #examples }
 DADependencyTreePresenter class >> onPackagesMatch: match [
-	^ (self onPackagesNamed:
-			(RPackageOrganizer default packages
-				select: [ :package | match match: package packageName asString ]
-				thenCollect: [ :package | package packageName ]) )
+
+	^ self onPackagesNamed: (Smalltalk organization packages
+			   select: [ :package | match match: package packageName asString ]
+			   thenCollect: [ :package | package packageName ])
 ]
 
 { #category : #'instance creation' }
@@ -276,7 +276,7 @@ DADependencyTreePresenter >> nodesFor: anItemList [
 { #category : #accessing }
 DADependencyTreePresenter >> packagesEntryCompletion [
 	| applicants |
-	applicants := (RPackageOrganizer default packages collect: [ :package | package packageName asString ]).
+	applicants := (Smalltalk organization packages collect: [ :package | package packageName asString ]).
 
 	^ EntryCompletion new
 				dataSourceBlock: [:currText | applicants];

--- a/src/Tool-DependencyAnalyser-UI/DAPackageAnalyzerPresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAPackageAnalyzerPresenter.class.st
@@ -35,7 +35,7 @@ DAPackageAnalyzerPresenter class >> selectedPackagesFrom: aBuilder [
 
 { #category : #examples }
 DAPackageAnalyzerPresenter class >> systemPackages [
-	^ RPackageOrganizer default packages collect: [ :package | package packageName asString ]
+	^ Smalltalk organization packages collect: [ :package | package packageName asString ]
 ]
 
 { #category : #accessing }

--- a/src/Tool-DependencyAnalyser-UI/DAPackageDependenciesPresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAPackageDependenciesPresenter.class.st
@@ -15,7 +15,7 @@ DAPackageDependenciesPresenter class >> collections [
 { #category : #'instance creation' }
 DAPackageDependenciesPresenter class >> onPackagesMatch: match [
 	^ (self onPackagesNamed:
-			(RPackageOrganizer default packages
+			(Smalltalk organization packages
 				select: [ :package | match match: package packageName asString ]
 				thenCollect: [ :package | package packageName ]) )
 ]

--- a/src/Tool-DependencyAnalyser-UI/DAWelcomePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAWelcomePresenter.class.st
@@ -44,7 +44,7 @@ DAWelcomePresenter >> initialExtent [
 DAWelcomePresenter >> initializePresenters [
 
 	choosePresenter := SpChooserPresenter new
-		sourceItems: RPackageOrganizer default packages;
+		sourceItems: Smalltalk organization packages;
 		displayBlock: #packageName;
 		yourself.
 

--- a/src/Tool-DependencyAnalyser/DADependencyChecker.class.st
+++ b/src/Tool-DependencyAnalyser/DADependencyChecker.class.st
@@ -50,15 +50,14 @@ DADependencyChecker >> computeDependenciesOf: aPackageName visitedPackages: visi
 
 { #category : #'computing - dependencies' }
 DADependencyChecker >> computeImageDependencies [
+
 	| visited |
 	self newReport.
 	report
 		analysisRunString: 'Pharo image dependencies';
 		imageVersion: SystemVersion current.
 	visited := Set new.
-	RPackageOrganizer default packageNames
-		do: [ :packageName |
-			self computeDependenciesOf: packageName visitedPackages: visited ].
+	Smalltalk organization packageNames do: [ :packageName | self computeDependenciesOf: packageName visitedPackages: visited ].
 	^ report
 ]
 

--- a/src/Tool-DependencyAnalyser/DAMessageSendAnalyzer.class.st
+++ b/src/Tool-DependencyAnalyser/DAMessageSendAnalyzer.class.st
@@ -48,11 +48,10 @@ DAMessageSendAnalyzer >> implementedMessages [
 
 { #category : #computing }
 DAMessageSendAnalyzer >> implementedMessagesWithManuallyResolvedDependencies [
-	^ (self manuallyResolvedDependencies
-		flatCollect: [ :name | (RPackageOrganizer default packageNamed: name) selectors ]
-		as: Set)
-			addAll: self implementedMessages;
-			yourself
+
+	^ (self manuallyResolvedDependencies flatCollect: [ :name | (Smalltalk organization packageNamed: name) selectors ] as: Set)
+		  addAll: self implementedMessages;
+		  yourself
 ]
 
 { #category : #initialization }

--- a/src/Tool-DependencyAnalyser/DAPackageCycleDetector.class.st
+++ b/src/Tool-DependencyAnalyser/DAPackageCycleDetector.class.st
@@ -50,7 +50,7 @@ DAPackageCycleDetector class >> onPackagesNamed: aCollection [
 { #category : #'instance creation' }
 DAPackageCycleDetector class >> system [
 	^ (self onPackagesNamed:
-		(RPackageOrganizer default packages collect: [ :package | package packageName asString ])) runAlgorithm
+		(Smalltalk organization packages collect: [ :package | package packageName asString ])) runAlgorithm
 ]
 
 { #category : #adding }


### PR DESCRIPTION
This is a second step to replace `RPackageOrganizer default` by `Smalltalk organization`.