### PR TITLE
Move system organizer to RPackage and remove references

### DIFF
--- a/src/RPackage-Core/SystemOrganizer.class.st
+++ b/src/RPackage-Core/SystemOrganizer.class.st
@@ -10,7 +10,7 @@ Class {
 		'environment',
 		'categoryMap'
 	],
-	#category : #'System-Support-Image'
+	#category : #'RPackage-Core-Base'
 }
 
 { #category : #cleanup }

--- a/src/RPackage-Tests/RPackageOrganizerAndSystemOrganizeSynchTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerAndSystemOrganizeSynchTest.class.st
@@ -22,40 +22,40 @@ RPackageOrganizerAndSystemOrganizeSynchTest >> packageName [
 RPackageOrganizerAndSystemOrganizeSynchTest >> tearDown [
 
 	(self packageName asPackageIfAbsent: [ nil ]) ifNotNil: [ :package | package removeFromSystem ].
-	SystemOrganizer default removeCategory: self packageName.
-	SystemOrganizer default removeCategoriesMatching: self packageName , '-*'.
+	Smalltalk organization systemOrganizer  removeCategory: self packageName.
+	Smalltalk organization systemOrganizer  removeCategoriesMatching: self packageName , '-*'.
 	super tearDown
 ]
 
 { #category : #tests }
 RPackageOrganizerAndSystemOrganizeSynchTest >> testAddingPackage [
 
-	SystemOrganizer default addCategory: self packageName.
+	Smalltalk organization systemOrganizer  addCategory: self packageName.
 
 	self assert: (Smalltalk organization packageNames includes: self packageName).
-	self assert: (SystemOrganizer default includesCategory: self packageName)
+	self assert: (Smalltalk organization systemOrganizer  includesCategory: self packageName)
 ]
 
 { #category : #tests }
 RPackageOrganizerAndSystemOrganizeSynchTest >> testRemovingPackage [
 	"Regression test because removing a RPackage from the system was not removing the category in SystemOrganizer."
 
-	SystemOrganizer default addCategory: self packageName.
+	Smalltalk organization systemOrganizer  addCategory: self packageName.
 
 	self assert: (Smalltalk organization packageNames includes: self packageName).
-	self assert: (SystemOrganizer default includesCategory: self packageName).
+	self assert: (Smalltalk organization systemOrganizer  includesCategory: self packageName).
 
 	self packageName asPackage removeFromSystem.
 
 	self deny: (Smalltalk organization packageNames includes: self packageName).
-	self deny: (SystemOrganizer default includesCategory: self packageName)
+	self deny: (Smalltalk organization systemOrganizer  includesCategory: self packageName)
 ]
 
 { #category : #tests }
 RPackageOrganizerAndSystemOrganizeSynchTest >> testRemovingPackageWithTags [
 	"Regression test because removing a RPackage from the system was not removing the category in SystemOrganizer."
 
-	SystemOrganizer default addCategory: self packageName.
+	Smalltalk organization systemOrganizer addCategory: self packageName.
 	(Object << 'RPackageOragizationSynchClass1')
 		package: self packageName;
 		tag: 'tag1';
@@ -65,14 +65,14 @@ RPackageOrganizerAndSystemOrganizeSynchTest >> testRemovingPackageWithTags [
 		tag: 'tag2';
 		install.
 	self assert: (Smalltalk organization packageNames includes: self packageName).
-	self assert: (SystemOrganizer default includesCategory: self packageName).
-	self assert: (SystemOrganizer default includesCategory: self packageName , '-tag1').
-	self assert: (SystemOrganizer default includesCategory: self packageName , '-tag2').
+	self assert: (Smalltalk organization systemOrganizer  includesCategory: self packageName).
+	self assert: (Smalltalk organization systemOrganizer  includesCategory: self packageName , '-tag1').
+	self assert: (Smalltalk organization systemOrganizer  includesCategory: self packageName , '-tag2').
 
 	self packageName asPackage removeFromSystem.
 
 	self deny: (Smalltalk organization packageNames includes: self packageName).
-	self deny: (SystemOrganizer default includesCategory: self packageName).
-	self deny: (SystemOrganizer default includesCategory: self packageName , '-tag1').
-	self deny: (SystemOrganizer default includesCategory: self packageName , '-tag2')
+	self deny: (Smalltalk organization systemOrganizer  includesCategory: self packageName).
+	self deny: (Smalltalk organization systemOrganizer  includesCategory: self packageName , '-tag1').
+	self deny: (Smalltalk organization systemOrganizer  includesCategory: self packageName , '-tag2')
 ]


### PR DESCRIPTION
SystemOrganizer is only used in RPackageOrganizer now so I moved it next to it. 

One of the next step is to inline it in RPackageOrganizer before killing the "category" concept so I also reduced the number of references. 