### PR TITLE
Remove some Monticello dependencies from RPackage

### DIFF
--- a/src/Monticello/RPackageOrganizer.extension.st
+++ b/src/Monticello/RPackageOrganizer.extension.st
@@ -21,18 +21,3 @@ RPackageOrganizer >> isDefinedAsPackageOrSubPackageInMC: aSymbol [
 			category: each packageName asSymbol 
 			matches: aSymbol ]
 ]
-
-{ #category : #'*Monticello-RPackage' }
-RPackageOrganizer >> updateAfterNewMCPackageRegistred: anAnnouncement [
-	"User create a new package, MCWorkingCopy propagates changes. We react accordingly."
-	|  name |
-	
-	name := anAnnouncement package name.
-	(self packageExactlyMatchingExtensionName: name) 
-		ifNil: [ self ensureExistAndRegisterPackageNamed: name ]
-]
-
-{ #category : #'*Monticello-RPackage' }
-RPackageOrganizer >> updateAfterNewMCPackageUnregistred: anAnnouncement [
-
-]

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -787,31 +787,22 @@ RPackageOrganizer >> registerExtendingPackage: aPackage forClassName: aClassName
 { #category : #'system integration' }
 RPackageOrganizer >> registerInterestToAnnouncer: anAnnouncer [
 	"There should be only one"
+
 	anAnnouncer unsubscribe: self.
 
 	anAnnouncer weak
 		when: CategoryAdded send: #systemCategoryAddedActionFrom: to: self;
 		when: CategoryRemoved send: #systemCategoryRemovedActionFrom: to: self;
 		when: CategoryRenamed send: #systemCategoryRenamedActionFrom: to: self;
-		when:  ClassAdded send: #systemClassAddedActionFrom: to: self;
-		when:  ClassRecategorized send: #systemClassRecategorizedActionFrom: to: self;
-		when:  ClassRemoved send: #systemClassRemovedActionFrom: to: self;
-		when:  ClassRenamed send: #systemClassRenamedActionFrom: to: self;
-		when:  ClassReorganized send: #systemClassReorganizedActionFrom: to: self;
-		when:  MethodAdded send: #systemMethodAddedActionFrom: to: self;
-		when:  MethodModified send: #systemMethodModifiedActionFrom: to: self;
-		when:  MethodRecategorized send: #systemMethodRecategorizedActionFrom: to: self;
-		when:  MethodRemoved send: #systemMethodRemovedActionFrom: to: self.
-
-	self flag: #hack. "for decoupling MC"
-	self class environment at: #MCWorkingCopy ifPresent: [
-		anAnnouncer weak
-			when: (self class environment at: #MCWorkingCopyCreated)
-				send: #updateAfterNewMCPackageRegistred:
-				to: self;
-			when: (self class environment at: #MCWorkingCopyDeleted)
-				send: #updateAfterNewMCPackageUnregistred:
-				to: self	]
+		when: ClassAdded send: #systemClassAddedActionFrom: to: self;
+		when: ClassRecategorized send: #systemClassRecategorizedActionFrom: to: self;
+		when: ClassRemoved send: #systemClassRemovedActionFrom: to: self;
+		when: ClassRenamed send: #systemClassRenamedActionFrom: to: self;
+		when: ClassReorganized send: #systemClassReorganizedActionFrom: to: self;
+		when: MethodAdded send: #systemMethodAddedActionFrom: to: self;
+		when: MethodModified send: #systemMethodModifiedActionFrom: to: self;
+		when: MethodRecategorized send: #systemMethodRecategorizedActionFrom: to: self;
+		when: MethodRemoved send: #systemMethodRemovedActionFrom: to: self
 ]
 
 { #category : #'system integration' }


### PR DESCRIPTION
RPackage should not depend on Monticello. Instead Monticello should listen to the system announcements and do what it needs to do.  It is really hard to understand how all those announcements are managed. I found some cases where Montciello already listen to some announcements to do what it needs to do so let's see if we can just remove some of the couplings and check if we have failing tests.