### PR TITLE
Completion: improve completion on super

### DIFF
--- a/src/HeuristicCompletion-Model/CoSuperMessageHeuristic.class.st
+++ b/src/HeuristicCompletion-Model/CoSuperMessageHeuristic.class.st
@@ -30,13 +30,14 @@ CoSuperMessageHeuristic >> buildFetcherFor: aNode inContext: completionContext [
 	But self is bound to nil"
 	completionClass := completionContext completionClass ifNil: [ nil class ].
 	"In Traits, superclass is nil"
-	fetcher := completionClass superclass
-		ifNil: [ CoEmptyFetcher new ]
-		ifNotNil: [ self newMessageInHierarchyFetcherForClass: completionClass superclass inASTNode: aNode ].
+	completionClass superclass ifNil: [ ^ CoEmptyFetcher new ].
+	
+	fetcher := self newMessageInHierarchyFetcherForClass: completionClass superclass inASTNode: aNode.
 
 	"Inject a synthetic fetcher with the expected full message send at first option because it is was is needed in most (>99%) situations"
 	aNode methodNode ifNotNil: [ :methodNode |
-		entry := (NECSelectorEntry contents: methodNode selectorAndArgumentNames node: aNode) selector: methodNode selector.
-		fetcher := (CoCollectionFetcher new collection: { entry }) , fetcher ].
+		(completionClass superclass canUnderstand: methodNode selector) ifTrue: [ 
+			entry := (NECSelectorEntry contents: methodNode selectorAndArgumentNames node: aNode) selector: methodNode selector.
+			fetcher := (CoCollectionFetcher new collection: { entry }) , fetcher ] ].
 	^ fetcher
 ]

--- a/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
@@ -111,6 +111,85 @@ CoCompletionEngineTest >> testCmdCtrlRightOpensDetail [
 	self assert: controller hasDetail
 ]
 
+{ #category : #tests }
+CoCompletionEngineTest >> testCompleteSuper [
+
+	| entries |
+	"Unary"
+	controller menuClosed. "clear the controler"
+	self setEditorTextWithCaret: 'postCopy ^ super |'.
+	self assert: controller completionToken equals: ''.
+	controller context completionClass: Point.
+	entries := controller context entries.
+	self assert: entries first contents equals: 'postCopy'.
+
+	controller menuClosed. "clear the controler"
+	self setEditorTextWithCaret: 'postCopy ^ super po|'.
+	self assert: controller completionToken equals: 'po'.
+	controller context completionClass: Point.
+	entries := controller context entries.
+	self assert: entries first contents equals: 'postCopy'.
+
+	controller menuClosed. "clear the controler"
+	self setEditorTextWithCaret: 'postCopy ^ super xx|'.
+	self assert: controller completionToken equals: 'xx'.
+	controller context completionClass: Point.
+	entries := controller context entries.
+	self deny: entries first contents equals: 'postCopy'.
+
+	"Binary"
+	controller menuClosed. "clear the controler"
+	self setEditorTextWithCaret: '= aaa ^ super |'.
+	self assert: controller completionToken equals: ''.
+	controller context completionClass: Point.
+	entries := controller context entries.
+	self assert: entries first contents equals: '= aaa'.
+
+	controller menuClosed. "clear the controler"
+	self setEditorTextWithCaret: '= aaa ^ super xx|'.
+	self assert: controller completionToken equals: 'xx'.
+	controller context completionClass: Point.
+	entries := controller context entries.
+	self deny: entries first contents equals: '= aaa'.
+
+	"Keyword"
+	controller menuClosed. "clear the controler"
+	self setEditorTextWithCaret: 'at: bbb put: ccc ^ super |'.
+	self assert: controller completionToken equals: ''.
+	controller context completionClass: Point.
+	entries := controller context entries.
+	self assert: entries first contents equals: 'at: bbb put: ccc'.
+
+	controller menuClosed. "clear the controler"
+	self setEditorTextWithCaret: 'at: bbb put: ccc ^ super a|'.
+	self assert: controller completionToken equals: 'a'.
+	controller context completionClass: Point.
+	entries := controller context entries.
+	self assert: entries first contents equals: 'at: bbb put: ccc'.
+
+	controller menuClosed. "clear the controler"
+	self setEditorTextWithCaret: 'at: bbb put: ccc ^ super xx|'.
+	self assert: controller completionToken equals: 'xx'.
+	controller context completionClass: Point.
+	entries := controller context entries.
+	self deny: entries first contents equals: 'at: bbb put: ccc'.
+
+	"Message unknown in superclass, so does not appear in super completion"
+	controller menuClosed. "clear the controler"
+	self setEditorTextWithCaret: 'notARedefinition ^ super |'.
+	self assert: controller completionToken equals: ''.
+	controller context completionClass: Point.
+	entries := controller context entries.
+	self deny: entries first contents equals: 'notARedefinition'.
+
+	controller menuClosed. "clear the controler"
+	self setEditorTextWithCaret: 'notARedefinition ^ super notARedefinitio|'.
+	self assert: controller completionToken equals: 'notARedefinitio'.
+	controller context completionClass: Point.
+	entries := controller context entries.
+	self assertEmpty: entries
+]
+
 { #category : #'tests - interaction' }
 CoCompletionEngineTest >> testEndClosesCompletionContext [
 


### PR DESCRIPTION
When completing on super, the current message is proposed only if it is a redefinition.

This PR also add tests (in fact, most person-hours was spent on the test part)