### PR TITLE
Clean monticello class definition management

### DIFF
--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -171,7 +171,7 @@ MCClassDefinition >> createClass [
 		ifTrue: [ Context comment = comment 
 						ifFalse: [ Context comment: comment stamp: commentStamp ].
 					^ self ].
-	superClass := superclassName == #nil
+	superClass := superclassName = #nil
 		ifFalse: [ Smalltalk globals at: superclassName ].
 	^ [ Smalltalk classInstaller
 		make: [ :builder | 
@@ -265,55 +265,25 @@ MCClassDefinition >> hash [
 ]
 
 { #category : #initializing }
-MCClassDefinition >> initializeWithName: nameString
-superclassName: superclassString
-category: categoryString 
-instVarNames: ivarArray
-classVarNames: cvarArray
-poolDictionaryNames: poolArray
-classInstVarNames: civarArray
-type: typeSymbol
-comment: commentString
-commentStamp: stampStringOrNil [
-	name := nameString asSymbol.
-	superclassName := superclassString ifNil: ['nil'] ifNotNil: [superclassString asSymbol].
-	category := categoryString.
-	name = #CompiledMethod ifTrue: [type := #compiledMethod] ifFalse: [type := typeSymbol].
-	comment := commentString withInternalLineEndings.
-	commentStamp := stampStringOrNil ifNil: [self defaultCommentStamp].
-	variables := OrderedCollection  new.
-	self addVariables: ivarArray ofType: MCInstanceVariableDefinition.
-	self addVariables: cvarArray asSortedCollection ofType: MCClassVariableDefinition.
-	self addVariables: poolArray asSortedCollection ofType: MCPoolImportDefinition.
-	self addVariables: civarArray ofType: MCClassInstanceVariableDefinition.
-]
+MCClassDefinition >> initializeWithName: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray classInstVarNames: civarArray type: typeSymbol comment: commentString commentStamp: stampStringOrNil [
 
-{ #category : #initializing }
-MCClassDefinition >> initializeWithName: nameString
-superclassName: superclassString
-traitComposition: traitCompositionString
-classTraitComposition: classTraitCompositionString
-category: categoryString 
-instVarNames: ivarArray
-classVarNames: cvarArray
-poolDictionaryNames: poolArray
-classInstVarNames: civarArray
-type: typeSymbol
-comment: commentString
-commentStamp: stampStringOrNil [
 	name := nameString asSymbol.
-	superclassName := superclassString ifNil: ['nil'] ifNotNil: [superclassString asSymbol].
+	superclassName := superclassString
+		                  ifNil: [ #nil ]
+		                  ifNotNil: [ superclassString asSymbol ].
 	traitComposition := traitCompositionString.
 	classTraitComposition := classTraitCompositionString.
 	category := categoryString.
-	name = #CompiledMethod ifTrue: [type := #compiledMethod] ifFalse: [type := typeSymbol].
+	name = #CompiledMethod
+		ifTrue: [ type := #compiledMethod ]
+		ifFalse: [ type := typeSymbol ].
 	comment := commentString withInternalLineEndings.
-	commentStamp := stampStringOrNil ifNil: [self defaultCommentStamp].
-	variables := OrderedCollection  new.
+	commentStamp := stampStringOrNil ifNil: [ self defaultCommentStamp ].
+	variables := OrderedCollection new.
 	self addVariables: ivarArray ofType: MCInstanceVariableDefinition.
 	self addVariables: cvarArray asSortedCollection ofType: MCClassVariableDefinition.
 	self addVariables: poolArray asSortedCollection ofType: MCPoolImportDefinition.
-	self addVariables: civarArray ofType: MCClassInstanceVariableDefinition.
+	self addVariables: civarArray ofType: MCClassInstanceVariableDefinition
 ]
 
 { #category : #accessing }
@@ -461,9 +431,10 @@ MCClassDefinition >> provisions [
 
 { #category : #comparing }
 MCClassDefinition >> requirements [
-	^ ((superclassName == #nil) or: [superclassName asString beginsWith: 'AnObsolete'])
-		ifTrue: [self poolDictionaries]
-		ifFalse: [{superclassName}, self poolDictionaries]
+
+	^ (superclassName = #nil or: [ superclassName asString beginsWith: 'AnObsolete' ])
+		  ifTrue: [ self poolDictionaries ]
+		  ifFalse: [ { superclassName } , self poolDictionaries ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
* Remove a dead method
* Use #nil instead of 'nil' for superclassname since it's a symbol when it is not nil
* Use simple equality instead of pointers equality to compare superclass names in case a string is still lingering somewhere (if both are symbols it'll be fast anyway)

A future step could be to store a real nil instead of a symbol nil when there is no superclass but that's a bigger change for later.