### PR TITLE
Completion: replacement put caret at the right place

### DIFF
--- a/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
@@ -154,11 +154,14 @@ CoCompletionEngineTest >> testExitingWordClosesCompletionContext [
 	controller openMenu.
 
 	self assert: controller hasCompletionContext.
+	self assert: self editorTextWithCaret equals: 'self mEthOdThatDoesNotExis|t toto'.
 	self assert: controller completionToken equals: 'mEthOdThatDoesNotExis'.
 	editor keyDown: (self keyboardEventFor: Character arrowRight).
+	self assert: self editorTextWithCaret equals: 'self mEthOdThatDoesNotExist| toto'.
 	self assert: controller completionToken equals: 'mEthOdThatDoesNotExist'.
 	self assert: controller hasCompletionContext.
 	editor keyDown: (self keyboardEventFor: Character arrowRight).
+	self assert: self editorTextWithCaret equals: 'self mEthOdThatDoesNotExist |toto'.
 	self assert: controller completionToken equals: ''.
 	self deny: controller hasCompletionContext.
 
@@ -166,11 +169,14 @@ CoCompletionEngineTest >> testExitingWordClosesCompletionContext [
 	controller openMenu.
 
 	self assert: controller hasCompletionContext.
+	self assert: self editorTextWithCaret equals: 'self m|EthOdThatDoesNotExist toto'.
 	self assert: controller completionToken equals: 'm'.
 	editor keyDown: (self keyboardEventFor: Character arrowLeft).
+	self assert: self editorTextWithCaret equals: 'self |mEthOdThatDoesNotExist toto'.
 	self assert: controller completionToken equals: ''.
 	self assert: controller hasCompletionContext.
 	editor keyDown: (self keyboardEventFor: Character arrowLeft).
+	self assert: self editorTextWithCaret equals: 'self| mEthOdThatDoesNotExist toto'.
 	self assert: controller completionToken equals: 'self'.
 	self deny: controller hasCompletionContext
 ]

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -318,12 +318,17 @@ CompletionEngine >> openMenu [
 { #category : #replacement }
 CompletionEngine >> replaceTokenInEditorWith: aString [
 	"Main API with the completion context.
+
 	Replace the current completion token (as it was extracted by the completion context) by aString.
-	aString may contain a keyword selector string where each keyword is separated by two spaces (between:  and:)
-	After replacing, set the caret after the first keyword.
+	aString content is free and will inserted as a replacement as is, except for a possible ending space that will not be inserted if there is already a space in the text.
+
+	The caret will be moved at the end of the inserted string, or between the first double spaces.
+	This rule allows to put the cursor inside an inserted keyword selector where each keyword is separated by two spaces.
+	e.g. after replacing with `'between:  and:'`, the caret is set after the first keyword.
+
 	The completion context uses this API to insert text into the text editor"
 
-	| wordEnd old positionAfterFirstKeyword offset firstKeyword wordStart |
+	| wordEnd old doubleSpace wordStart |
 
 	wordStart := self completionTokenStart.
 
@@ -346,12 +351,8 @@ CompletionEngine >> replaceTokenInEditorWith: aString [
 
 	self editor replaceSelectionWith: aString.
 
-	offset := NECPreferences spaceAfterCompletion
-		ifTrue: [ 1 ]
-		ifFalse: [ 0 ].
-	firstKeyword := (aString copyUpTo: $ ) size.
-	positionAfterFirstKeyword := wordEnd + firstKeyword + offset - old size.
-	self editor selectAt: positionAfterFirstKeyword.
+	doubleSpace := aString indexOfSubCollection: '  ' startingAt: 1 ifAbsent: [ aString size ].
+	self editor selectAt: wordEnd + doubleSpace - old size.
 
 	self editor morph invalidRect: self editor morph bounds
 ]

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -328,8 +328,9 @@ CompletionEngine >> replaceTokenInEditorWith: aString [
 
 	The completion context uses this API to insert text into the text editor"
 
-	| wordEnd old doubleSpace wordStart |
+	| newString wordEnd old doubleSpace wordStart |
 
+	newString := aString.
 	wordStart := self completionTokenStart.
 
 	"If completionToken is not empty, the end is the end of the whole word (according to the editor)"
@@ -338,9 +339,9 @@ CompletionEngine >> replaceTokenInEditorWith: aString [
 		ifFalse: [ self editor nextWord: self editor caret - 1].
 
 	"Do not insert an aditional space if there is already one"
-	(aString last = $  and: [
+	(newString last = $  and: [
 		wordEnd <= self editor text size and: [
-			(self editor text at: wordEnd) = $ ]]) ifTrue: [ wordEnd := wordEnd + 1 ].
+			(self editor text at: wordEnd) = $ ]]) ifTrue: [ newString := newString copyWithoutIndex: newString size ].
 	"If the returned index is the size of the text that means that the caret is at the end of the text and there is no more word after, so add 1 to the index to be out of range to select the entierely word because of the selectInvisiblyFrom:to: remove 1 just after to be at the end of then final word"
 	wordEnd > self editor text size ifTrue:[ wordEnd := wordEnd + 1 ].
 
@@ -349,9 +350,9 @@ CompletionEngine >> replaceTokenInEditorWith: aString [
 		to: wordEnd - 1.
 	old := self editor selection.
 
-	self editor replaceSelectionWith: aString.
+	self editor replaceSelectionWith: newString.
 
-	doubleSpace := aString indexOfSubCollection: '  ' startingAt: 1 ifAbsent: [ aString size ].
+	doubleSpace := newString indexOfSubCollection: '  ' startingAt: 1 ifAbsent: [ newString size ].
 	self editor selectAt: wordEnd + doubleSpace - old size.
 
 	self editor morph invalidRect: self editor morph bounds

--- a/src/NECompletion-Tests/CompletionEngineTest.class.st
+++ b/src/NECompletion-Tests/CompletionEngineTest.class.st
@@ -148,27 +148,27 @@ CompletionEngineTest >> testCompletionAfterKeyword [
 	self setEditorTextWithCaret: 'self foo:| baz'.
 	self assert: controller completionToken equals: 'foo:'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self bar baz'.
+	self assert: self editorTextWithCaret equals: 'self bar| baz'.
 
 	self setEditorTextWithCaret: 'self"x"foo:|"x"baz'.
 	self assert: controller completionToken equals: 'foo:'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self"x"bar"x"baz'.
+	self assert: self editorTextWithCaret equals: 'self"x"bar|"x"baz'.
 
 	self setEditorTextWithCaret: 'self.foo:|.baz'.
 	self assert: controller completionToken equals: 'foo:'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self.bar.baz'.
+	self assert: self editorTextWithCaret equals: 'self.bar|.baz'.
 
 	self setEditorTextWithCaret: 'self:=foo:|:=baz'.
 	self assert: controller completionToken equals: 'foo:'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self:=bar:=baz'.
+	self assert: self editorTextWithCaret equals: 'self:=bar|:=baz'.
 
 	self setEditorTextWithCaret: 'foo:|'.
 	self assert: controller completionToken equals: 'foo:'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'bar'
+	self assert: self editorTextWithCaret equals: 'bar|'
 ]
 
 { #category : #tests }
@@ -177,27 +177,27 @@ CompletionEngineTest >> testCompletionAfterWord [
 	self setEditorTextWithCaret: 'self foo| baz'.
 	self assert: controller completionToken equals: 'foo'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self bar baz'.
+	self assert: self editorTextWithCaret equals: 'self bar| baz'.
 
 	self setEditorTextWithCaret: 'self"x"foo|"x"baz'.
 	self assert: controller completionToken equals: 'foo'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self"x"bar"x"baz'.
+	self assert: self editorTextWithCaret equals: 'self"x"bar|"x"baz'.
 
 	self setEditorTextWithCaret: 'self.foo|.baz'.
 	self assert: controller completionToken equals: 'foo'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self.bar.baz'.
+	self assert: self editorTextWithCaret equals: 'self.bar|.baz'.
 
 	self setEditorTextWithCaret: 'self:=foo|:=baz'.
 	self assert: controller completionToken equals: 'foo'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self:=bar:=baz'.
+	self assert: self editorTextWithCaret equals: 'self:=bar|:=baz'.
 
 	self setEditorTextWithCaret: 'foo|'.
 	self assert: controller completionToken equals: 'foo'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'bar'
+	self assert: self editorTextWithCaret equals: 'bar|'
 ]
 
 { #category : #tests }
@@ -206,27 +206,27 @@ CompletionEngineTest >> testCompletionBeforeKeywordColumn [
 	self setEditorTextWithCaret: 'self foo|: baz'.
 	self assert: controller completionToken equals: 'foo'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self bar baz'.
+	self assert: self editorTextWithCaret equals: 'self bar| baz'.
 
 	self setEditorTextWithCaret: 'self"x"foo|:"x"baz'.
 	self assert: controller completionToken equals: 'foo'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self"x"bar"x"baz'.
+	self assert: self editorTextWithCaret equals: 'self"x"bar|"x"baz'.
 
 	self setEditorTextWithCaret: 'self.foo|:.baz'.
 	self assert: controller completionToken equals: 'foo'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self.bar.baz'.
+	self assert: self editorTextWithCaret equals: 'self.bar|.baz'.
 
 	self setEditorTextWithCaret: 'self:=foo|::=baz'.
 	self assert: controller completionToken equals: 'foo'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self:=bar:=baz'.
+	self assert: self editorTextWithCaret equals: 'self:=bar|:=baz'.
 
 	self setEditorTextWithCaret: 'foo|:'.
 	self assert: controller completionToken equals: 'foo'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'bar'
+	self assert: self editorTextWithCaret equals: 'bar|'
 ]
 
 { #category : #tests }
@@ -235,27 +235,27 @@ CompletionEngineTest >> testCompletionBeforeWord [
 	self setEditorTextWithCaret: 'self |foo baz'.
 	self assert: controller completionToken equals: ''.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self barfoo baz'.
+	self assert: self editorTextWithCaret equals: 'self bar|foo baz'.
 
 	self setEditorTextWithCaret: 'self"x"|foo"x"baz'.
 	self assert: controller completionToken equals: ''.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self"x"barfoo"x"baz'.
+	self assert: self editorTextWithCaret equals: 'self"x"bar|foo"x"baz'.
 
 	self setEditorTextWithCaret: 'self.|foo.baz'.
 	self assert: controller completionToken equals: ''.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self.barfoo.baz'.
+	self assert: self editorTextWithCaret equals: 'self.bar|foo.baz'.
 
 	self setEditorTextWithCaret: 'self:=|foo:=baz'.
 	self assert: controller completionToken equals: ''.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self:=barfoo:=baz'.
+	self assert: self editorTextWithCaret equals: 'self:=bar|foo:=baz'.
 
 	self setEditorTextWithCaret: '|foo'.
 	self assert: controller completionToken equals: ''.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'barfoo'
+	self assert: self editorTextWithCaret equals: 'bar|foo'
 ]
 
 { #category : #tests }
@@ -265,7 +265,7 @@ CompletionEngineTest >> testCompletionOnBinary [
 	self setEditorTextWithCaret: 'self +|+ baz'.
 	self assert: controller completionToken equals: ''.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self +bar+ baz'
+	self assert: self editorTextWithCaret equals: 'self +bar|+ baz'
 ]
 
 { #category : #tests }
@@ -274,27 +274,27 @@ CompletionEngineTest >> testCompletionOnFirstLetter [
 	self setEditorTextWithCaret: 'self f|oo baz'.
 	self assert: controller completionToken equals: 'f'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self bar baz'.
+	self assert: self editorTextWithCaret equals: 'self bar| baz'.
 
 	self setEditorTextWithCaret: 'self"x"f|oo"x"baz'.
 	self assert: controller completionToken equals: 'f'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self"x"bar"x"baz'.
+	self assert: self editorTextWithCaret equals: 'self"x"bar|"x"baz'.
 
 	self setEditorTextWithCaret: 'self.f|oo.baz'.
 	self assert: controller completionToken equals: 'f'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self.bar.baz'.
+	self assert: self editorTextWithCaret equals: 'self.bar|.baz'.
 
 	self setEditorTextWithCaret: 'self:=f|oo:=baz'.
 	self assert: controller completionToken equals: 'f'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self:=bar:=baz'.
+	self assert: self editorTextWithCaret equals: 'self:=bar|:=baz'.
 
 	self setEditorTextWithCaret: 'f|oo'.
 	self assert: controller completionToken equals: 'f'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'bar'
+	self assert: self editorTextWithCaret equals: 'bar|'
 ]
 
 { #category : #tests }
@@ -303,32 +303,32 @@ CompletionEngineTest >> testCompletionOnNoWord [
 	self setEditorTextWithCaret: 'self | baz'.
 	self assert: controller completionToken equals: ''.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self bar baz'.
+	self assert: self editorTextWithCaret equals: 'self bar| baz'.
 
 	self setEditorTextWithCaret: 'self"x"|"x"baz'.
 	self assert: controller completionToken equals: ''.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self"x"bar"x"baz'.
+	self assert: self editorTextWithCaret equals: 'self"x"bar|"x"baz'.
 
 	self setEditorTextWithCaret: 'self.|.baz'.
 	self assert: controller completionToken equals: ''.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self.bar.baz'.
+	self assert: self editorTextWithCaret equals: 'self.bar|.baz'.
 
 	self setEditorTextWithCaret: 'self:=|:=baz'.
 	self assert: controller completionToken equals: ''.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self:=bar:=baz'.
+	self assert: self editorTextWithCaret equals: 'self:=bar|:=baz'.
 
 	self setEditorTextWithCaret: ' | '.
 	self assert: controller completionToken equals: ''.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: ' bar '.
+	self assert: self editorTextWithCaret equals: ' bar| '.
 
 	self setEditorTextWithCaret: '|'.
 	self assert: controller completionToken equals: ''.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'bar'
+	self assert: self editorTextWithCaret equals: 'bar|'
 ]
 
 { #category : #tests }
@@ -337,27 +337,27 @@ CompletionEngineTest >> testCompletionOnSingleLetter [
 	self setEditorTextWithCaret: 'self f| baz'.
 	self assert: controller completionToken equals: 'f'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self bar baz'.
+	self assert: self editorTextWithCaret equals: 'self bar| baz'.
 
 	self setEditorTextWithCaret: 'self"x"f|"x"baz'.
 	self assert: controller completionToken equals: 'f'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self"x"bar"x"baz'.
+	self assert: self editorTextWithCaret equals: 'self"x"bar|"x"baz'.
 
 	self setEditorTextWithCaret: 'self.f|.baz'.
 	self assert: controller completionToken equals: 'f'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self.bar.baz'.
+	self assert: self editorTextWithCaret equals: 'self.bar|.baz'.
 
 	self setEditorTextWithCaret: 'self:=f|:=baz'.
 	self assert: controller completionToken equals: 'f'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'self:=bar:=baz'.
+	self assert: self editorTextWithCaret equals: 'self:=bar|:=baz'.
 
 	self setEditorTextWithCaret: 'f|'.
 	self assert: controller completionToken equals: 'f'.
 	controller context replaceTokenInEditorWith: 'bar'.
-	self assert: editor text asString equals: 'bar'
+	self assert: self editorTextWithCaret equals: 'bar|'
 ]
 
 { #category : #'tests - keyboard' }

--- a/src/NECompletion-Tests/CompletionEngineTest.class.st
+++ b/src/NECompletion-Tests/CompletionEngineTest.class.st
@@ -689,6 +689,55 @@ CompletionEngineTest >> testReplaceWithSpaces [
 	self assert: self editorTextWithCaret equals: 'self bar | bar  baz'.
 ]
 
+{ #category : #tests }
+CompletionEngineTest >> testReplaceWithSpaces2 [
+
+	self setEditorTextWithCaret: 'self fo|o.'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: self editorTextWithCaret equals: 'self bar|.'.
+
+	self setEditorTextWithCaret: 'self fo|o.'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar '.
+	self assert: self editorTextWithCaret equals: 'self bar |.'.
+
+	self setEditorTextWithCaret: 'self fo|o.'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar  '.
+	self assert: self editorTextWithCaret equals: 'self bar | .'.
+
+	self setEditorTextWithCaret: 'self fo|o.'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar bar'.
+	self assert: self editorTextWithCaret equals: 'self bar bar|.'.
+
+	self setEditorTextWithCaret: 'self fo|o.'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar bar '.
+	self assert: self editorTextWithCaret equals: 'self bar bar |.'.
+
+	self setEditorTextWithCaret: 'self fo|o.'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar bar  '.
+	self assert: self editorTextWithCaret equals: 'self bar bar | .'.
+
+	self setEditorTextWithCaret: 'self fo|o.'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar  bar'.
+	self assert: self editorTextWithCaret equals: 'self bar | bar.'.
+
+	self setEditorTextWithCaret: 'self fo|o.'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar  bar '.
+	self assert: self editorTextWithCaret equals: 'self bar | bar .'.
+
+	self setEditorTextWithCaret: 'self fo|o.'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar  bar  '.
+	self assert: self editorTextWithCaret equals: 'self bar | bar  .'.
+]
+
 { #category : #'tests - keyboard' }
 CompletionEngineTest >> testSmartBackspace [
 	"Pressing backspace inside paired smart characters should remove both of them"

--- a/src/NECompletion-Tests/CompletionEngineTest.class.st
+++ b/src/NECompletion-Tests/CompletionEngineTest.class.st
@@ -651,7 +651,7 @@ CompletionEngineTest >> testReplaceWithSpaces [
 	self setEditorTextWithCaret: 'self fo|o baz'.
 	self assert: controller completionToken equals: 'fo'.
 	controller context replaceTokenInEditorWith: 'bar '.
-	self assert: self editorTextWithCaret equals: 'self bar |baz'.
+	self assert: self editorTextWithCaret equals: 'self bar| baz'.
 
 	self setEditorTextWithCaret: 'self fo|o baz'.
 	self assert: controller completionToken equals: 'fo'.
@@ -666,7 +666,7 @@ CompletionEngineTest >> testReplaceWithSpaces [
 	self setEditorTextWithCaret: 'self fo|o baz'.
 	self assert: controller completionToken equals: 'fo'.
 	controller context replaceTokenInEditorWith: 'bar bar '.
-	self assert: self editorTextWithCaret equals: 'self bar bar |baz'.
+	self assert: self editorTextWithCaret equals: 'self bar bar| baz'.
 
 	self setEditorTextWithCaret: 'self fo|o baz'.
 	self assert: controller completionToken equals: 'fo'.

--- a/src/NECompletion-Tests/CompletionEngineTest.class.st
+++ b/src/NECompletion-Tests/CompletionEngineTest.class.st
@@ -21,6 +21,15 @@ CompletionEngineTest >> allSmartCharacters [
 	^ self allSelfClosingCharacters , { '||'. '<>' }
 ]
 
+{ #category : #'tests - keyboard' }
+CompletionEngineTest >> editorTextWithCaret [
+	"The current test in the editor, with a `|` inserted at the caret position"
+
+	| source |
+	source := editor text asString.
+	^ (source copyFrom: 1 to: editor caret-1), '|', (source copyFrom: editor caret to: source size)
+]
+
 { #category : #accessing }
 CompletionEngineTest >> interactionModel [
 
@@ -629,6 +638,55 @@ CompletionEngineTest >> testReplaceTokenWithCaretOnEndOfWordReplacesEntireWord [
 	controller context replaceTokenInEditorWith: 'toto'.
 
 	self assert: editor text equals: 'self toto'
+]
+
+{ #category : #tests }
+CompletionEngineTest >> testReplaceWithSpaces [
+
+	self setEditorTextWithCaret: 'self fo|o baz'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: self editorTextWithCaret equals: 'self bar| baz'.
+
+	self setEditorTextWithCaret: 'self fo|o baz'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar '.
+	self assert: self editorTextWithCaret equals: 'self bar |baz'.
+
+	self setEditorTextWithCaret: 'self fo|o baz'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar  '.
+	self assert: self editorTextWithCaret equals: 'self bar | baz'.
+
+	self setEditorTextWithCaret: 'self fo|o baz'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar bar'.
+	self assert: self editorTextWithCaret equals: 'self bar bar| baz'.
+
+	self setEditorTextWithCaret: 'self fo|o baz'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar bar '.
+	self assert: self editorTextWithCaret equals: 'self bar bar |baz'.
+
+	self setEditorTextWithCaret: 'self fo|o baz'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar bar  '.
+	self assert: self editorTextWithCaret equals: 'self bar bar | baz'.
+
+	self setEditorTextWithCaret: 'self fo|o baz'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar  bar'.
+	self assert: self editorTextWithCaret equals: 'self bar | bar baz'.
+
+	self setEditorTextWithCaret: 'self fo|o baz'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar  bar '.
+	self assert: self editorTextWithCaret equals: 'self bar | bar baz'.
+
+	self setEditorTextWithCaret: 'self fo|o baz'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar  bar  '.
+	self assert: self editorTextWithCaret equals: 'self bar | bar  baz'.
 ]
 
 { #category : #'tests - keyboard' }


### PR DESCRIPTION
When replacing super send including arguments, the caret position was wrong.

This PR fix, rationalize, document and test the caret placement after a completion