### PR TITLE
Improve some error logging

### DIFF
--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -441,7 +441,12 @@ Object >> basicAt: index [
 	Object documentation whatIsAPrimitive."
 
 	<primitive: 60>
-	index isInteger ifTrue: [self errorSubscriptBounds: index].
+	index isInteger ifTrue: [
+		SubscriptOutOfBounds
+			signalFor: index
+			lowerBound: 1
+			upperBound: self basicSize
+			in: self ].
 	self errorNonIntegerIndex
 ]
 

--- a/src/Kernel/SubscriptOutOfBounds.class.st
+++ b/src/Kernel/SubscriptOutOfBounds.class.st
@@ -69,17 +69,19 @@ SubscriptOutOfBounds >> standardMessageText [
 	"Generate a standard textual description"
 
 	^ String streamContents: [ :stream |
-		self subscript
-			ifNil: [
-				stream << 'subscript' ]
-			ifNotNil: [
-				stream print: self subscript ].
-		(self lowerBound notNil and: [ self upperBound notNil])
-			ifTrue: [
-				stream << ' is not between '.
-				stream print: self lowerBound.
-				stream << ' and '.
-				stream print: self upperBound ] ]
+		  self subscript
+			  ifNil: [ stream << 'subscript' ]
+			  ifNotNil: [ stream print: self subscript ].
+		  (self lowerBound notNil and: [ self upperBound notNil ]) ifTrue: [
+			  stream
+				  << ' is not between ';
+				  print: self lowerBound;
+				  << ' and ';
+				  print: self upperBound ].
+		  self signaler ifNotNil: [
+			  stream
+				  nextPutAll: ' in ';
+				  print: self signaler ] ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This updates two things:
- Subscript out of bounds prints the signaler in the error message when the signaler is known
- #basicAt: has better logging when we are out of bounds

This will help debug error in #13456 and multiple other PRs