### PR TITLE
Completion mini fixes

### DIFF
--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -353,7 +353,7 @@ CompletionEngine >> replaceTokenInEditorWith: aString [
 	self editor replaceSelectionWith: newString.
 
 	doubleSpace := newString indexOfSubCollection: '  ' startingAt: 1 ifAbsent: [ newString size ].
-	self editor selectAt: wordEnd + doubleSpace - old size.
+	self editor selectAt: wordStart + doubleSpace.
 
 	self editor morph invalidRect: self editor morph bounds
 ]

--- a/src/NECompletion-Tests/CompletionEngineTest.class.st
+++ b/src/NECompletion-Tests/CompletionEngineTest.class.st
@@ -738,6 +738,55 @@ CompletionEngineTest >> testReplaceWithSpaces2 [
 	self assert: self editorTextWithCaret equals: 'self bar | bar  .'.
 ]
 
+{ #category : #tests }
+CompletionEngineTest >> testReplaceWithSpaces3 [
+
+	self setEditorTextWithCaret: 'self fo|'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar'.
+	self assert: self editorTextWithCaret equals: 'self bar|'.
+
+	self setEditorTextWithCaret: 'self fo|'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar '.
+	self assert: self editorTextWithCaret equals: 'self bar |'.
+
+	self setEditorTextWithCaret: 'self fo|'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar  '.
+	self assert: self editorTextWithCaret equals: 'self bar | '.
+
+	self setEditorTextWithCaret: 'self fo|'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar bar'.
+	self assert: self editorTextWithCaret equals: 'self bar bar|'.
+
+	self setEditorTextWithCaret: 'self fo|'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar bar '.
+	self assert: self editorTextWithCaret equals: 'self bar bar |'.
+
+	self setEditorTextWithCaret: 'self fo|'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar bar  '.
+	self assert: self editorTextWithCaret equals: 'self bar bar | '.
+
+	self setEditorTextWithCaret: 'self fo|'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar  bar'.
+	self assert: self editorTextWithCaret equals: 'self bar | bar'.
+
+	self setEditorTextWithCaret: 'self fo|'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar  bar '.
+	self assert: self editorTextWithCaret equals: 'self bar | bar '.
+
+	self setEditorTextWithCaret: 'self fo|'.
+	self assert: controller completionToken equals: 'fo'.
+	controller context replaceTokenInEditorWith: 'bar  bar  '.
+	self assert: self editorTextWithCaret equals: 'self bar | bar  '.
+]
+
 { #category : #'tests - keyboard' }
 CompletionEngineTest >> testSmartBackspace [
 	"Pressing backspace inside paired smart characters should remove both of them"

--- a/src/NECompletion/NECSelectorEntry.class.st
+++ b/src/NECompletion/NECSelectorEntry.class.st
@@ -42,6 +42,7 @@ NECSelectorEntry >> findMethodAndDo: foundBlock ifAbsent: notfoundBlock [
 							ref realClass lookupSelector: ref selector]
 						ifFalse: [^ notfoundBlock value: self selector]]
 				ifNotNil: [theClass lookupSelector: self selector ].
+	result ifNil: [^ notfoundBlock value: self selector].
 	^ foundBlock value: result
 ]
 


### PR DESCRIPTION
Two small fixes:

* #13687 added #type property on some AST node. NECCompletion knows to process them, but was not robust enough. Fix that.
* Fix the bad caret position when completing at the end of the text. Fix one half of #13686. And add more tests