### PR TITLE
More type analysis

### DIFF
--- a/src/AST-Core-Tests/ASTTypingVisitorTest.class.st
+++ b/src/AST-Core-Tests/ASTTypingVisitorTest.class.st
@@ -18,6 +18,35 @@ ASTTypingVisitorTest >> assertTypedTree: aNode [
 ]
 
 { #category : #examples }
+ASTTypingVisitorTest >> exampleKernel: arg1 and: arg2 [
+	"DO NOT REFORMAT, or type expectations (in special comments) will be lost"
+	"List of special kernel method"
+	
+	(arg1 = arg2) "<Boolean>".
+	(arg1 ~= arg2) "<Boolean>".
+	(arg1 == arg2) "<Boolean>".
+	(arg1 ~~ arg2) "<Boolean>".
+	(arg1 < arg2) "<Boolean>".
+	(arg1 <= arg2) "<Boolean>".
+	(arg1 > arg2) "<Boolean>".
+	(arg1 >= arg2) "<Boolean>".
+	(arg1 isNil) "<Boolean>".
+	(arg1 isNotNil) "<Boolean>".
+	(arg1 isEmpty) "<Boolean>".
+	(arg1 size) "<Integer>".
+	(arg1 at: arg2) "<>". "not special"
+
+	(5 yourself) "<SmallInteger>".
+	(5 class) "<SmallInteger class>".
+	(Object new) "<Object>".
+	(Array new: 1) "<Array>".
+	(Object basicNew) "<Object>".
+	(Array basicNew: 1) "<Array>".
+	(5 at: 1) "<>" "not special".
+	(Object at: 1) "<>" "not special"
+]
+
+{ #category : #examples }
 ASTTypingVisitorTest >> exampleLoop [
 	"DO NOT REFORMAT, or type expectations (in special comments) will be lost"
 
@@ -77,6 +106,16 @@ ASTTypingVisitorTest >> expectedNodeType: aNode [
 			^ self class compiler evaluate:
 				  (comment contents copyFrom: 2 to: comment contents size - 1) ].
 	^ nil
+]
+
+{ #category : #tests }
+ASTTypingVisitorTest >> testExampleKernel [
+
+	| typeVisitor ast |
+	typeVisitor := ASTTypingVisitor new.
+	ast := (self class >> #exampleKernel:and:) parseTree.
+	typeVisitor visitNode: ast.
+	self assertTypedTree: ast
 ]
 
 { #category : #tests }

--- a/src/AST-Core-Tests/ASTTypingVisitorTest.class.st
+++ b/src/AST-Core-Tests/ASTTypingVisitorTest.class.st
@@ -18,6 +18,19 @@ ASTTypingVisitorTest >> assertTypedTree: aNode [
 ]
 
 { #category : #examples }
+ASTTypingVisitorTest >> exampleCHA [
+	"DO NOT REFORMAT, or type expectations (in special comments) will be lost"
+
+	| bool |
+	true "<True>".
+	true not "<False>".
+
+	bool := self hash > 1000.
+	bool "<Boolean>".
+	bool not "<Boolean>" "Without CHA, type is nil as Boolean>>#not is subclass responsibility"
+]
+
+{ #category : #examples }
 ASTTypingVisitorTest >> exampleKernel: arg1 and: arg2 [
 	"DO NOT REFORMAT, or type expectations (in special comments) will be lost"
 	"List of special kernel method"
@@ -106,6 +119,23 @@ ASTTypingVisitorTest >> expectedNodeType: aNode [
 			^ self class compiler evaluate:
 				  (comment contents copyFrom: 2 to: comment contents size - 1) ].
 	^ nil
+]
+
+{ #category : #tests }
+ASTTypingVisitorTest >> testExampleCHA [
+
+	| typeVisitor ast methods |
+	typeVisitor := ASTTypingVisitor new.
+	typeVisitor cha: true.
+	methods := {
+		           (Boolean >> #not).
+		           (True >> #not).
+		           (False >> #not).
+		           (self class >> #exampleCHA) }.
+	methods do: [ :m |
+		ast := m parseTree.
+		typeVisitor fixedPointAnalysis: ast ].
+	self assertTypedTree: ast
 ]
 
 { #category : #tests }

--- a/src/AST-Core/ASTTypingVisitor.class.st
+++ b/src/AST-Core/ASTTypingVisitor.class.st
@@ -50,6 +50,18 @@ ASTTypingVisitor >> cha: anObject [
 	cha := anObject
 ]
 
+{ #category : #accessing }
+ASTTypingVisitor >> dirty [
+
+	^ dirty
+]
+
+{ #category : #accessing }
+ASTTypingVisitor >> dirty: anObject [
+
+	dirty := anObject
+]
+
 { #category : #analyzing }
 ASTTypingVisitor >> fixedPointAnalysis: aNode [
 	"Repeat the analysis until a fixed point is reached.

--- a/src/AST-Core/ASTTypingVisitor.class.st
+++ b/src/AST-Core/ASTTypingVisitor.class.st
@@ -38,6 +38,18 @@ Class {
 	#category : #'AST-Core-Type'
 }
 
+{ #category : #accessing }
+ASTTypingVisitor >> cha [
+
+	^ cha
+]
+
+{ #category : #accessing }
+ASTTypingVisitor >> cha: anObject [
+
+	cha := anObject
+]
+
 { #category : #analyzing }
 ASTTypingVisitor >> fixedPointAnalysis: aNode [
 	"Repeat the analysis until a fixed point is reached.
@@ -52,10 +64,44 @@ ASTTypingVisitor >> fixedPointAnalysis: aNode [
 { #category : #initialization }
 ASTTypingVisitor >> initialize [
 
-	variableTypes := Dictionary new.
-	returnTypes := Dictionary new.
-	unknownMethod := Set new.
-	shortcutKernelMessages := true
+	variableTypes := IdentityDictionary new.
+	returnTypes := IdentityDictionary new.
+	unknownMethods := Set new.
+	shortcutKernelMessages := true.
+	cha := false
+]
+
+{ #category : #accessing }
+ASTTypingVisitor >> lookupMethod: aSelector type: recvType [
+
+	| method methods type |
+	method := recvType lookupSelector: aSelector.
+
+	"Without CHA (Class Hierarchy Analysis), only look at a sigle method.
+	This is not sound (not even monotonous!) because we only consider a sigle static type and a single method,
+	at runtime, the concrete receiver type might be numerous and different"
+	cha ifFalse: [
+		^ returnTypes at: method ifAbsent: [
+			  unknownMethods add: method.
+			  nil ] ].
+
+	methods := Set new.
+	method ifNotNil: [ methods add: method ].
+
+	"Look for potential redefinitions in subclasses (CHA!)"
+	recvType subclasses do: [ :c |
+		c methodDictionary at: aSelector ifPresent: [ :m | methods add: m ] ].
+	methods ifEmpty: [ ^ nil ].
+
+	"Merge all possible return types"
+	type := nil.
+	methods do: [ :m |
+		returnTypes
+			at: m
+			ifPresent: [ :type2 | type := self merge: type with: type2 ]
+			ifAbsent: [ unknownMethods add: m ] ].
+
+	^ type
 ]
 
 { #category : #lattice }
@@ -195,7 +241,7 @@ ASTTypingVisitor >> visitLiteralNode: aLiteralNode [
 { #category : #visiting }
 ASTTypingVisitor >> visitMessageNode: aNode [
 
-	| recvType method |
+	| recvType type |
 	super visitMessageNode: aNode.
 
 	"Fast path for some special Kernel selectors (type of the receiver is not important)"
@@ -214,16 +260,14 @@ ASTTypingVisitor >> visitMessageNode: aNode [
 			 #( new new: basicNew basicNew: ) includes: aNode selector ])
 			ifTrue: [ ^ self typeNode: aNode with: recvType instanceSide ].
 
+		aNode selector == #yourself ifTrue: [
+			^ self typeNode: aNode with: recvType ].
 		aNode selector == #class ifTrue: [
 			^ self typeNode: aNode with: recvType class ] ].
 
-	"Method lookup. This one is not sound because we only consider a sigle static type and a single method,
-	at runtime, the concrete receiver type might be numerous and different."
-	method := recvType lookupSelector: aNode selector.
-	returnTypes
-		at: method
-		ifPresent: [ :type | ^ self typeNode: aNode with: type ].
-	unknownMethod add: method
+
+	type := self lookupMethod: aNode selector type: recvType.
+	type ifNotNil: [ self typeNode: aNode with: type ]
 ]
 
 { #category : #visiting }

--- a/src/AST-Core/ASTTypingVisitor.class.st
+++ b/src/AST-Core/ASTTypingVisitor.class.st
@@ -29,10 +29,11 @@ Class {
 	#superclass : #RBProgramNodeVisitor,
 	#instVars : [
 		'variableTypes',
-		'unknownMethod',
 		'shortcutKernelMessages',
 		'returnTypes',
-		'dirty'
+		'dirty',
+		'cha',
+		'unknownMethods'
 	],
 	#category : #'AST-Core-Type'
 }
@@ -140,9 +141,9 @@ ASTTypingVisitor >> typeVariable: aVariable with: aClass [
 ]
 
 { #category : #accessing }
-ASTTypingVisitor >> unknownMethod [
+ASTTypingVisitor >> unknownMethods [
 
-	^ unknownMethod
+	^ unknownMethods
 ]
 
 { #category : #visiting }

--- a/src/AST-Core/ASTTypingVisitor.class.st
+++ b/src/AST-Core/ASTTypingVisitor.class.st
@@ -162,14 +162,18 @@ ASTTypingVisitor >> typeMethod: aCompilerMethod with: aClass [
 
 { #category : #lattice }
 ASTTypingVisitor >> typeNode: aNode with: aClass [
-	"We assume monotonicity here, so no need to merge with the oldType."
 
-	aNode
-		propertyAt: #type
-		ifPresent: [ :oldType | oldType = aClass ifTrue: [ ^ self ] ].
+	| type |
+	type := aClass.
+	aNode propertyAt: #type ifPresent: [ :oldType |
+		oldType = type ifTrue: [ ^ self ].
+		"We expect that the analysis is monotonous, but it might not be always the case.
+		Se perform a join to rorce some kind of monotonicity."
+		type := self merge: oldType with: type.
+		oldType = type ifTrue: [ ^ self ] ].
 
 	dirty := true.
-	aNode propertyAt: #type put: aClass
+	aNode propertyAt: #type put: type
 ]
 
 { #category : #lattice }

--- a/src/AST-Core/ASTTypingVisitor.class.st
+++ b/src/AST-Core/ASTTypingVisitor.class.st
@@ -38,6 +38,141 @@ Class {
 	#category : #'AST-Core-Type'
 }
 
+{ #category : #benchmarking }
+ASTTypingVisitor class >> bench: trees [
+
+	| report valueNodes duration count visitor steps moreTrees knownMethods |
+	report := WriteStream on: ''.
+	report
+		nextPutAll: 'Number of AST: ';
+		print: trees size;
+		cr.
+
+	valueNodes := (trees flatCollect: #allChildren) select: #isValue.
+	report
+		nextPutAll: 'Number of value nodes: ';
+		print: valueNodes size;
+		cr.
+
+	valueNodes do: [ :node | node removeProperty: #type ifAbsent: [  ] ].
+	duration := [ trees do: [ :tree | self new visit: tree ] ] timeToRun.
+	report
+		nextPutAll: 'Individual typing';
+		cr;
+		nextPutAll: '  duration:';
+		print: duration;
+		cr;
+		nextPutAll: '  typed nodes: ';
+		nextPutAll: (self printTypedNodeCount: valueNodes);
+		cr.
+
+	valueNodes do: [ :node | node removeProperty: #type ifAbsent: [  ] ].
+	visitor := self new.
+	duration := [ trees do: [ :tree | visitor visit: tree ] ] timeToRun.
+	count := valueNodes count: [ :x | x hasProperty: #type ].
+	report
+		nextPutAll: 'Agretated typing';
+		cr;
+		nextPutAll: '  duration:';
+		print: duration;
+		cr;
+		nextPutAll: '  typed nodes: ';
+		nextPutAll: (self printTypedNodeCount: valueNodes);
+		cr.
+
+	valueNodes do: [ :node | node removeProperty: #type ifAbsent: [  ] ].
+	visitor := self new.
+	steps := 0.
+	duration := [
+	            [
+	            steps := steps + 1.
+	            visitor dirty: false.
+	            trees do: [ :tree | visitor visit: tree ].
+	            visitor dirty ] whileTrue ] timeToRun.
+	count := valueNodes count: [ :x | x hasProperty: #type ].
+	report
+		nextPutAll: '+fixed point typing';
+		cr;
+		nextPutAll: '  duration:';
+		print: duration;
+		cr;
+		nextPutAll: '  steps:';
+		print: steps;
+		cr;
+		nextPutAll: '  typed nodes: ';
+		nextPutAll: (self printTypedNodeCount: valueNodes);
+		cr.
+
+	valueNodes do: [ :node | node removeProperty: #type ifAbsent: [  ] ].
+	visitor := self new.
+	visitor cha: true.
+	steps := 0.
+	duration := [
+	            [
+	            steps := steps + 1.
+	            visitor dirty: false.
+	            trees do: [ :tree | visitor visit: tree ].
+	            visitor dirty ] whileTrue ] timeToRun.
+	count := valueNodes count: [ :x | x hasProperty: #type ].
+	report
+		nextPutAll: '+CHA';
+		cr;
+		nextPutAll: '  duration:';
+		print: duration;
+		cr;
+		nextPutAll: '  steps:';
+		print: steps;
+		cr;
+		nextPutAll: '  typed nodes: ';
+		nextPutAll: (self printTypedNodeCount: valueNodes);
+		cr.
+
+	moreTrees := OrderedCollection newFrom: trees.
+	knownMethods := trees collect: [ :tree | tree compiledMethod ] as: Set.
+	visitor unknownMethods do: [ :method |
+		(knownMethods includes: method) ifFalse: [ 
+		moreTrees add: method parseTree ].
+		].
+	valueNodes do: [ :node | node removeProperty: #type ifAbsent: [  ] ].
+	visitor := self new.
+	visitor cha: true.
+	steps := 0.
+	duration := [
+	            [
+	            steps := steps + 1.
+	            visitor dirty: false.
+	            moreTrees do: [ :tree | visitor visit: tree ].
+	            visitor dirty ] whileTrue ] timeToRun.
+	count := valueNodes count: [ :x | x hasProperty: #type ].
+	report
+		nextPutAll: '+CHA';
+		cr;
+		nextPutAll: '  duration:';
+		print: duration;
+		cr;
+		nextPutAll: '  steps:';
+		print: steps;
+		cr;
+		nextPutAll: '  typed nodes: ';
+		nextPutAll: (self printTypedNodeCount: valueNodes);
+		cr.
+	valueNodes groupedBy: [ :n | n propertyAt: #type ifAbsent: [ nil ] ].
+	^ report contents
+]
+
+{ #category : #printing }
+ASTTypingVisitor class >> printTypedNodeCount: valueNodes [
+
+	| count |
+	count := valueNodes count: [ :x | x hasProperty: #type ].
+	^ String streamContents: [ :aStream |
+		  aStream
+			  print: count;
+			  nextPutAll: ' (';
+			  print: (100.0 * count / valueNodes size) rounded;
+			  nextPutAll: '%)' ]
+]
+
 { #category : #accessing }
 ASTTypingVisitor >> cha [
 


### PR DESCRIPTION
Some additions and a bugfix on ASTTypingVisitor

* add a `bench:` method to help the evaluation.
* use `IndentityDictionary` instead of simple dictionary (this is the bugfix)
* add kernel shortcut for `#yourself`
* add `cha` flag to activate a more sound analysis on lookup
* add more tests