### PR TITLE
Completion browse with Ctrl-B

### DIFF
--- a/src/Calypso-Browser/ClyTextEditor.class.st
+++ b/src/Calypso-Browser/ClyTextEditor.class.st
@@ -57,21 +57,6 @@ ClyTextEditor >> notify: aString at: anInteger in: aStream [
 ]
 
 { #category : #operations }
-ClyTextEditor >> printIt [
-	"Treat the current text selection as an expression; evaluate it. Insert the
-	description of the result of evaluation after the selection and then make
-	this description the new text selection."
-
-	| printString |
-	self
-		evaluateSelectionAndDo: [ :result |
-			printString := [ result asScriptResultStringInCalypso ]
-				on: Error
-				do: [ '<error in printString: try ''Inspect it'' to debug>' ].
-			self afterSelectionInsertAndSelect: printString ]
-]
-
-{ #category : #operations }
 ClyTextEditor >> undo [
 
 	super undo.

--- a/src/Calypso-Browser/Object.extension.st
+++ b/src/Calypso-Browser/Object.extension.st
@@ -4,9 +4,3 @@ Extension { #name : #Object }
 Object class >> asCalypsoItemContext [
 	^ClyBrowserItemContext itemType: self
 ]
-
-{ #category : #'*Calypso-Browser' }
-Object >> asScriptResultStringInCalypso [
-
-	^self printString
-]

--- a/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
@@ -4,6 +4,12 @@ Class {
 	#category : #'HeuristicCompletion-Tests'
 }
 
+{ #category : #testing }
+CoCompletionEngineTest class >> shouldInheritSelectors [
+
+	^ true
+]
+
 { #category : #accessing }
 CoCompletionEngineTest >> doItContext [
 
@@ -14,12 +20,6 @@ CoCompletionEngineTest >> doItContext [
 CoCompletionEngineTest >> newCompletionEngine [
 
 	^ CoCompletionEngine new
-]
-
-{ #category : #asserting }
-CoCompletionEngineTest >> shouldInheritSelectors [
-
-	^ true
 ]
 
 { #category : #'tests - interaction' }

--- a/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
@@ -23,92 +23,53 @@ CoCompletionEngineTest >> newCompletionEngine [
 ]
 
 { #category : #'tests - interaction' }
-CoCompletionEngineTest >> testAdvanceWordDoesNotCloseCompletionContext [
-	"Because it will still be at the end of the current word"
-	| text |
-	text := 'self mEthOdThatDoesNotExist toto'.
-	self
-		setEditorText: text;
-		selectAt: text size - 10.
+CoCompletionEngineTest >> testCmdCtrlLeft [
+
+	self setEditorTextWithCaret: 'self asOrder|ed'.
 
 	editor textArea openInWorld.
 	controller openMenu.
-
-	"This is the current shortcut of the completion engine... Cmd+right for all platforms"
-	editor keyDown: (self keyboardEventFor: Character arrowRight useCommand: true).
-
-	self assert: controller hasCompletionContext
-]
-
-{ #category : #'tests - interaction' }
-CoCompletionEngineTest >> testAdvanceWordTwiceClosesCompletionContext [
-	"Because it exists current word"
-	| text |
-	text := 'self mEthOdThatDoesNotExist toto'.
-	self
-		setEditorText: text;
-		selectAt: text size - 10.
-
-	editor textArea openInWorld.
-	controller openMenu.
-
-	"This is the current shortcut of the completion engine... Cmd+right for all platforms"
-	2 timesRepeat: [
-		editor keystroke: (self keyboardEventFor: Character arrowRight useCommand: true) ].
-
-	self deny: controller hasCompletionContext
-]
-
-{ #category : #'tests - interaction' }
-CoCompletionEngineTest >> testCmdCtrlLeftClosesDetail [
-
-	"The start of a word does not close the completion menu"
-
-	| text |
-	text := 'self asOrdered'.
-	self
-		setEditorText: text;
-		selectAt: text size - 1.
-
-	editor textArea openInWorld.
-	controller openMenu.
-
-	"Detail already closed? open it"
-	controller hasDetail ifFalse: [ controller showDetail ].
-
 	"Force the drawing of the menu, so the detail can get its position..."
 	WorldMorph doOneCycle.
-	"This is the current shortcut to open the details of the completion engine... Cmd/ctrl+right for all platforms"
+
 	editor keyDown:
 		((self keyboardEventFor: Character arrowLeft) buttons:
 			 KMModifier meta eventCode).
 
-	self assert: controller hasDetail
+	self assert: self editorTextWithCaret equals: 'self |asOrdered'.
+	self assert: controller isMenuOpen.
+
+	editor keyDown:
+		((self keyboardEventFor: Character arrowLeft) buttons:
+			 KMModifier meta eventCode).
+
+	self assert: self editorTextWithCaret equals: '|self asOrdered'.
+	self deny: controller isMenuOpen
 ]
 
 { #category : #'tests - interaction' }
-CoCompletionEngineTest >> testCmdCtrlRightOpensDetail [
+CoCompletionEngineTest >> testCmdCtrlRight [
 
-	| text |
-	text := 'self asOrdered'.
-	self
-		setEditorText: text;
-		selectAt: text size - 1.
+	self setEditorTextWithCaret: 'self asOrder|ed trac'.
 
 	editor textArea openInWorld.
 	controller openMenu.
-
-	"Detail already open? close it"
-	controller hasDetail ifTrue: [ controller hideDetail ].
-
 	"Force the drawing of the menu, so the detail can get its position..."
 	WorldMorph doOneCycle.
-	"This is the current shortcut to open the details of the completion engine... Cmd/ctrl+right for all platforms"
+
 	editor keyDown:
 		((self keyboardEventFor: Character arrowRight) buttons:
 			 KMModifier meta eventCode).
 
-	self assert: controller hasDetail
+	self assert: self editorTextWithCaret equals: 'self asOrdered| trac'.
+	self assert: controller isMenuOpen.
+
+	editor keyDown:
+		((self keyboardEventFor: Character arrowRight) buttons:
+			 KMModifier meta eventCode).
+
+	self assert: self editorTextWithCaret equals: 'self asOrdered trac|'.
+	self deny: controller isMenuOpen
 ]
 
 { #category : #'tests - interaction' }
@@ -277,42 +238,6 @@ CoCompletionEngineTest >> testOpenMenuCreatesCompletionContext [
 	controller openMenu.
 
 	self assert: controller hasCompletionContext
-]
-
-{ #category : #'tests - interaction' }
-CoCompletionEngineTest >> testPreviousWordClosesCompletionContext [
-
-	| text |
-	text := 'self mEthOdThatDoesNotExist toto'.
-	self
-		setEditorText: text;
-		selectAt: text size.
-
-	editor textArea openInWorld.
-	controller openMenu.
-
-	"This is the current shortcut of the completion engine... Cmd+left for all platforms"
-	editor keystroke: (self keyboardEventFor: Character arrowLeft useCommand: true).
-
-	self deny: controller hasCompletionContext
-]
-
-{ #category : #'tests - interaction' }
-CoCompletionEngineTest >> testPreviousWordGoesToPreviousWord [
-
-	| text |
-	text := 'self mEthOdThatDoesNotExist toto'.
-	self
-		setEditorText: text;
-		selectAt: text size.
-
-	editor textArea openInWorld.
-	controller openMenu.
-
-	"This is the current shortcut of the completion engine... Cmd+left for all platforms"
-	editor keyDown: (self keyboardEventFor: Character arrowLeft useCommand: true).
-
-	self assert: editor caret equals: text size - 'toto' size + 1
 ]
 
 { #category : #'tests - interaction' }

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -146,10 +146,6 @@ CompletionEngine >> handleKeyDownBefore: aKeyboardEvent editor: anEditor [
 
 	self isMenuOpen ifFalse: [ ^ false ].
 
-	aKeyboardEvent asShortcut = KeyboardKey right meta ifTrue: [
-		menuMorph showDetail.
-		^ true ].
-
 	({
 		 KeyboardKey left.
 		 KeyboardKey right.

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -53,11 +53,6 @@ CompletionEngine >> browse [
 	menuMorph ifNil: [ ^ false ] ifNotNil: [ ^ menuMorph browse ]
 ]
 
-{ #category : #testing }
-CompletionEngine >> captureNavigationKeys [
-	^ NECPreferences captureNavigationKeys
-]
-
 { #category : #'menu morph' }
 CompletionEngine >> closeMenu [
 	self stopCompletionDelay.

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -47,6 +47,12 @@ CompletionEngine class >> isCompletionEnabled [
 	^NECPreferences enabled
 ]
 
+{ #category : #private }
+CompletionEngine >> browse [
+
+	menuMorph ifNil: [ ^ false ] ifNotNil: [ ^ menuMorph browse ]
+]
+
 { #category : #testing }
 CompletionEngine >> captureNavigationKeys [
 	^ NECPreferences captureNavigationKeys

--- a/src/NECompletion-Morphic/NECDetailMorph.class.st
+++ b/src/NECompletion-Morphic/NECDetailMorph.class.st
@@ -36,7 +36,7 @@ NECDetailMorph >> contentBounds [
 	factor := self itemHeight.
 	rectangle := self bounds top: self bounds top + 3.
 	rectangle := rectangle left: rectangle left + (factor * 2.0).
-	rectangle := rectangle bottom: rectangle bottom - factor.
+	rectangle := rectangle bottom: rectangle bottom.
 	^ rectangle
 ]
 
@@ -67,36 +67,9 @@ NECDetailMorph >> drawArrowOn: aCanvas [
 ]
 
 { #category : #drawing }
-NECDetailMorph >> drawMessageOn: aCanvas [
-	| factor rectangle width browseMessage |
-	factor := self itemHeight.
-	rectangle := self bounds top: self bounds bottom - factor.
-	rectangle := rectangle left: self contentBounds left.
-	aCanvas
-		line: rectangle topLeft
-		to: rectangle topRight
-		color: Color darkGray.
-	rectangle := rectangle top: rectangle top + 1.
-	aCanvas
-		drawString: '<- close detail'
-		in: rectangle
-		font: self messageFont
-		color: Color darkGray.
-	browseMessage := 'browse ->'.
-	width := self messageFont widthOfString: browseMessage.
-	aCanvas
-		drawString: browseMessage
-		in: (rectangle left: rectangle right - width)
-		font: self messageFont
-		color: Color darkGray
-]
-
-{ #category : #drawing }
 NECDetailMorph >> drawOn: aCanvas [
 	super drawOn: aCanvas.
-	arrowPosition ifNotNil: [
-		self drawArrowOn: aCanvas.
-		self drawMessageOn: aCanvas]
+	arrowPosition ifNotNil: [ self drawArrowOn: aCanvas ]
 ]
 
 { #category : #accessing }

--- a/src/NECompletion-Morphic/NECMenuMorph.class.st
+++ b/src/NECompletion-Morphic/NECMenuMorph.class.st
@@ -277,11 +277,9 @@ NECMenuMorph >> delete [
 { #category : #drawing }
 NECMenuMorph >> detailMessage [
 
-	^ String streamContents: [:stream |
-		NECPreferences captureNavigationKeys ifTrue: [
-			stream << (detailMorph
-				ifNil: ['cmd-> open detail']
-				ifNotNil: ['cmd<- close detail']	) ] ]
+	^ self itemsCount isZero
+		  ifTrue: [ 'no entries' ]
+		  ifFalse: [ 'cmd+B browse entry' ]
 ]
 
 { #category : #accessing }

--- a/src/NECompletion-Preferences/NECPreferences.class.st
+++ b/src/NECompletion-Preferences/NECPreferences.class.st
@@ -219,9 +219,6 @@ NECPreferences class >> settingsOn: aBuilder [
 					(aBuilder setting: #useEnterToAccept)
 						label: 'Use ENTER to accept a suggested completion';
 						default: self defaultUseEnterToAccept.
-					(aBuilder setting: #captureNavigationKeys)
-						default: true;
-						label: 'Use navigation keys for extended completion functionality'.
 					(aBuilder setting: #caseSensitive)
 						label: 'Case Sensitive';
 						default: true;

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -27,7 +27,7 @@ RubSmalltalkEditor class >> buildShortcutsOn: aBuilder [
 	(aBuilder shortcut: #browseFullClass)
 		category: RubSmalltalkEditor name
 		default: $b meta
-		do: [ :target | target editor browseFullClass ]
+		do: [ :target | target editor browseIt: nil ]
 		description: 'Do & browse its class'.
 
 	(aBuilder shortcut: #doIt)
@@ -273,6 +273,17 @@ RubSmalltalkEditor >> browseFullClass [
  	"Launch a browser for the class of the current selection, i.e. if you select 1+2 then you will get a class browser on class Point. Notice that this method handles also when the expression is a class."
 
  	self evaluateSelectionAndDo: [:result | result class instanceSide browse ].
+]
+
+{ #category : #'editing keys' }
+RubSmalltalkEditor >> browseIt: aKeyboardEvent [
+ 	"Browse the current selection.
+	If a completion menu is open, the current item is browsed instead"
+
+	completionEngine isMenuOpen ifTrue: [ ^ completionEngine browse ].
+
+ 	self browseFullClass.
+	^true
 ]
 
 { #category : #'menu messages' }

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -268,28 +268,11 @@ RubSmalltalkEditor >> browseClassFrom: aClassString [
 	self tools browser openOnClass: selectedClass
 ]
 
-{ #category : #'editing keys' }
-RubSmalltalkEditor >> browseClassOfExpression [
+{ #category : #'menu messages' }
+RubSmalltalkEditor >> browseFullClass [
  	"Launch a browser for the class of the current selection, i.e. if you select 1+2 then you will get a class browser on class Point. Notice that this method handles also when the expression is a class."
 
  	self evaluateSelectionAndDo: [:result | result class instanceSide browse ].
-	^ true
-]
-
-{ #category : #'menu messages' }
-RubSmalltalkEditor >> browseFullClass [
-	"Launch a browser for the class indicated by the current selection. Note that if the selection is a valid expression it will browse the class of the result. If multiple classes matching the selection exist, let the user choose among them."
-
-
-	"previous code was: self browseClassFrom: self findClassFromAST"
-	self browseClassOfExpression
-]
-
-{ #category : #'editing keys' }
-RubSmalltalkEditor >> browseFullClassIt: t1 [
-
-	self browseFullClass.
-	^ true
 ]
 
 { #category : #'menu messages' }


### PR DESCRIPTION
fix #13584 

Completion menu use Ctrl-B to browse instead of hijacking Ctrl-right (in fact unlike documentation says, Ctrl-left was not hijacked).

I needed to hack on browseIt actions (and related) on rubric/calypso, so I also did a small cleanup, by merging some methods and removing unused ones.

Help test still shows a hard-coded "Cmd-B" text info. I did not find a way to make the text platform independent reliably (and I don't even have mac)