### PR TITLE
Completion: better update

### DIFF
--- a/src/HeuristicCompletion-Model/CoCompletionContext.class.st
+++ b/src/HeuristicCompletion-Model/CoCompletionContext.class.st
@@ -25,7 +25,6 @@ CoCompletionContext class >> engine: aCompletionEngine class: aClass source: aSt
 	^ self new
 		completionClass: aClass;
 		engine: aCompletionEngine;
-		completionTokenStart: aCompletionEngine completionTokenStart;
 		source: aString;
 		position: anInteger;
 		yourself
@@ -97,12 +96,6 @@ CoCompletionContext >> completionToken [
 CoCompletionContext >> completionTokenStart [
 
 	^ completionTokenStart
-]
-
-{ #category : #accessing }
-CoCompletionContext >> completionTokenStart: anObject [
-
-	completionTokenStart := anObject
 ]
 
 { #category : #accessing }

--- a/src/HeuristicCompletion-Model/CoCompletionContext.class.st
+++ b/src/HeuristicCompletion-Model/CoCompletionContext.class.st
@@ -40,8 +40,6 @@ CoCompletionContext >> activateEntryAt: anIndex [
 CoCompletionContext >> completion [
 
 	completion ifNotNil: [ ^ completion ].
-	completionTokenStart := engine completionTokenStart.
-	completionToken := engine completionToken.
 	completion := self completionBuilder
 		completionContext: self;
 		buildCompletion.
@@ -117,7 +115,9 @@ CoCompletionContext >> engine [
 
 { #category : #accessing }
 CoCompletionContext >> engine: anObject [
-	engine := anObject
+	engine := anObject.
+	completionTokenStart := anObject completionTokenStart.
+	completionToken := anObject completionToken
 ]
 
 { #category : #accessing }

--- a/src/HeuristicCompletion-Model/CoCompletionContext.class.st
+++ b/src/HeuristicCompletion-Model/CoCompletionContext.class.st
@@ -13,7 +13,8 @@ Class {
 		'completionTokenStart',
 		'completionBuilder',
 		'completionClass',
-		'completion'
+		'completion',
+		'completionToken'
 	],
 	#category : #'HeuristicCompletion-Model-SystemIntegration'
 }
@@ -40,6 +41,8 @@ CoCompletionContext >> activateEntryAt: anIndex [
 CoCompletionContext >> completion [
 
 	completion ifNotNil: [ ^ completion ].
+	completionTokenStart := engine completionTokenStart.
+	completionToken := engine completionToken.
 	completion := self completionBuilder
 		completionContext: self;
 		buildCompletion.
@@ -87,7 +90,7 @@ CoCompletionContext >> completionClass: aClass [
 { #category : #accessing }
 CoCompletionContext >> completionToken [
 
-	^ self engine completionToken
+	^ completionToken
 ]
 
 { #category : #accessing }
@@ -169,6 +172,7 @@ CoCompletionContext >> isScripting [
 { #category : #narrowing }
 CoCompletionContext >> narrowWith: aString [
 
+	completionToken := aString.
 	self completion replaceFilterWith: (CoBeginsWithFilter caseSensitive: NECPreferences caseSensitive filterString: aString)
 ]
 

--- a/src/HeuristicCompletion-Tests/CoMockEngine.class.st
+++ b/src/HeuristicCompletion-Tests/CoMockEngine.class.st
@@ -9,3 +9,8 @@ CoMockEngine >> completionToken [
 	"This is the token used to autocomplete"
 	^ 'token'
 ]
+
+{ #category : #replacement }
+CoMockEngine >> completionTokenStart [ 
+	^ 1
+]

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -605,6 +605,6 @@ CompletionEngine >> updateCompletionAfterEdition: aParagraphEditor [
 	"Do not update the content nor refresh the menu if the context token is the same"
 	context completionToken = self completionToken ifTrue: [ ^self ].
 
-	context narrowWith: aParagraphEditor wordAtCaret.
+	context narrowWith: self completionToken.
 	menuMorph refreshSelection
 ]

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -308,7 +308,7 @@ CompletionEngine >> openMenu [
 	context := self createContext.
 	theMenu := self menuMorphClass
 				engine: self
-				position: (editor selectionPosition: context completionToken).
+				position: (editor selectionPosition: self completionToken).
 
 	theMenu isClosed ifFalse: [ 
 		menuMorph := theMenu.

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -602,5 +602,9 @@ CompletionEngine >> updateCompletionAfterEdition: aParagraphEditor [
 
 	context completionTokenStart = self completionTokenStart ifFalse: [ ^ self closeMenu ].
 
-	context narrowWith: aParagraphEditor wordAtCaret
+	"Do not update the content nor refresh the menu if the context token is the same"
+	context completionToken = self completionToken ifTrue: [ ^self ].
+
+	context narrowWith: aParagraphEditor wordAtCaret.
+	menuMorph refreshSelection
 ]


### PR DESCRIPTION
The completion menu was updated on every key down (even unrelated, like a lone control key down) but the menuMorph was not refreshed (because refreshing cause the selection to be reset).
This caused graphical glitches when the menu content did not fit the initial completion menu area.

This PR store the current completion token into the completion context, so it becomes easy to see if the completion need an update and the menu need a refresh.

This should remove the last GUI issue with the completion menu (no issue number but I wanted to fix it anyway)
Feel free to open new ones :)