### PR TITLE
Simplify ReservedVariable: #styleNameIn and remove #nameIsReserved:

### DIFF
--- a/src/Kernel/ReservedVariable.class.st
+++ b/src/Kernel/ReservedVariable.class.st
@@ -28,11 +28,6 @@ ReservedVariable class >> lookupDictionary [
 		   class instance name -> class new ]) asDictionary
 ]
 
-{ #category : #testing }
-ReservedVariable class >> nameIsReserved: aName [
-	^self subclasses anySatisfy: [ :class | class variableName = aName ]
-]
-
 { #category : #accessing }
 ReservedVariable class >> variableName [
 	^self subclassResponsibility

--- a/src/Ring-Core/RGEnvironment.class.st
+++ b/src/Ring-Core/RGEnvironment.class.st
@@ -89,9 +89,7 @@ RGEnvironment >> bindingOf: aSymbol [
 
 	| behavior result |
 
-	(ReservedVariable nameIsReserved: aSymbol)
-		ifTrue: [ ^ ReservedVariable lookupDictionary at: aSymbol ].
-
+	ReservedVariable lookupDictionary at: aSymbol ifPresent: [ :val | ^ val ].
 	self globalVariablesBindings at: aSymbol ifPresent: [ :val | ^ val ].
 
 	self ask globalVariables detect: [ :each | each name = aSymbol  ] ifFound: [ :found |

--- a/src/Ring-Tests-Core/RGReadOnlyImageBackendTest.class.st
+++ b/src/Ring-Tests-Core/RGReadOnlyImageBackendTest.class.st
@@ -221,6 +221,7 @@ RGReadOnlyImageBackendTest >> testMethod [
 
 { #category : #tests }
 RGReadOnlyImageBackendTest >> testProtocols [
+
 	| env1 point method method2 protocol protocol2 |
 	env1 := RGEnvironment new.
 	env1 backend: (RGReadOnlyImageBackend for: env1).
@@ -239,7 +240,11 @@ RGReadOnlyImageBackendTest >> testProtocols [
 	self assert: protocol isSymbol.
 	self assert: protocol equals: 'accessing'.
 
-	self should: [ (Protocol name: 'aProtocol') asRingMinimalDefinitionIn: RGEnvironment new ] raise: Error
+	self
+		should: [
+			(Protocol named: 'aProtocol') asRingMinimalDefinitionIn:
+				RGEnvironment new ]
+		raise: Error
 ]
 
 { #category : #tests }

--- a/src/Shout/ReservedVariable.extension.st
+++ b/src/Shout/ReservedVariable.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #ReservedVariable }
+
+{ #category : #'*Shout' }
+ReservedVariable >> styleNameIn: aRBVariableNode [
+
+	^ self class variableName
+]

--- a/src/Shout/SelfVariable.extension.st
+++ b/src/Shout/SelfVariable.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #SelfVariable }
-
-{ #category : #'*Shout' }
-SelfVariable >> styleNameIn: aRBVariableNode [
-
-	^ #self
-]

--- a/src/Shout/SuperVariable.extension.st
+++ b/src/Shout/SuperVariable.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #SuperVariable }
-
-{ #category : #'*Shout' }
-SuperVariable >> styleNameIn: aRBVariableNode [
-
-	^ #super
-]

--- a/src/Shout/ThisContextVariable.extension.st
+++ b/src/Shout/ThisContextVariable.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #ThisContextVariable }
-
-{ #category : #'*Shout' }
-ThisContextVariable >> styleNameIn: aRBVariableNode [
-
-	^ #thisContext
-]

--- a/src/Shout/ThisProcessVariable.extension.st
+++ b/src/Shout/ThisProcessVariable.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #ThisProcessVariable }
-
-{ #category : #'*Shout' }
-ThisProcessVariable >> styleNameIn: aRBVariableNode [
-
-	^ #thisProcess
-]

--- a/src/Slot-Tests/ReservedVariableTest.class.st
+++ b/src/Slot-Tests/ReservedVariableTest.class.st
@@ -3,16 +3,3 @@ Class {
 	#superclass : #TestCase,
 	#category : #'Slot-Tests-VariablesAndSlots'
 }
-
-{ #category : #tests }
-ReservedVariableTest >> testNameIsReserved [
- 	"we have these reserved vars: self, super, thisContext"
- 	self assert: (ReservedVariable nameIsReserved: 'self').
- 	self assert: (ReservedVariable nameIsReserved: 'super').
- 	self assert: (ReservedVariable nameIsReserved: 'thisContext').
-
-  	"true and false and nil are compiled as literals, not reserved vars"
- 	self deny: (ReservedVariable nameIsReserved: 'true').
- 	self deny: (ReservedVariable nameIsReserved: 'false').
- 	self deny: (ReservedVariable nameIsReserved: 'nil')
-]


### PR DESCRIPTION
- We can implement styleNameIn:   by  "self class variableName"
- It is a bad idea to treat these variables special: everything we do is done by taking a name, looking up a var and then delegating to that Variable. No need to ever check for names explicitly. As a first step, remove #nameIsReserved: and test
