### PR TITLE
Removal of nonexisting protocol should not announce anything

### DIFF
--- a/src/Kernel-Tests/ProtocolAnnouncementsTest.class.st
+++ b/src/Kernel-Tests/ProtocolAnnouncementsTest.class.st
@@ -51,6 +51,30 @@ ProtocolAnnouncementsTest >> testClassifyUnderAnnounceNewProtocol [
 ]
 
 { #category : #tests }
+ProtocolAnnouncementsTest >> testRemoveProtocolIfEmptyWithNonExistingProtocolDoesNotAnnounceAnything [
+
+	self when: ProtocolRemoved do: [ :ann | self fail ].
+
+	self when: ClassReorganized do: [ :ann | self fail ].
+
+	organization removeProtocolIfEmpty: #nonexisting.
+
+	self assert: numberOfAnnouncements equals: 0
+]
+
+{ #category : #tests }
+ProtocolAnnouncementsTest >> testRemoveProtocolIfEmptyWithNonExistingProtocolDoesNotAnnounceAnything2 [
+
+	self when: ProtocolRemoved do: [ :ann | self fail ].
+
+	self when: ClassReorganized do: [ :ann | self fail ].
+
+	organization removeProtocolIfEmpty: (Protocol named: #nonexisting).
+
+	self assert: numberOfAnnouncements equals: 0
+]
+
+{ #category : #tests }
 ProtocolAnnouncementsTest >> testRenameProtocolAsAnnounceClassReorganizedOnce [
 	"This is a regerssion test because at some point the class reorganized announcement got duplicated."
 

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -209,9 +209,9 @@ ClassOrganization >> removeProtocolIfEmpty: aProtocol [
 	"I take a protocol or a protocol name and remvoe it if it is empty."
 
 	| protocol oldProtocolNames |
-	protocol := aProtocol isString
-		            ifTrue: [ self protocolNamed: aProtocol ifAbsent: [ ^ self ] ]
-		            ifFalse: [ aProtocol ].
+	(self hasProtocol: aProtocol) ifFalse: [ ^ self ].
+
+	protocol := aProtocol isString ifTrue: [ self protocolNamed: aProtocol ] ifFalse: [ aProtocol ].
 
 	protocol isEmpty ifFalse: [ ^ self ].
 


### PR DESCRIPTION
This fixes a bug where sometime we were announcing the removal of a protocol that did not even exist in the class. I added some tests around that.