### PR TITLE
Allow-Slots-Shadow-PseudoVariables 

### DIFF
--- a/src/Kernel/Slot.class.st
+++ b/src/Kernel/Slot.class.st
@@ -43,17 +43,11 @@ Slot class >> checkValidName: aSymbol [
 	aSymbol startsWithDigit ifTrue: [
 		^ InvalidSlotName signalFor: aSymbol ].
 	
-	(self isPseudovariableName: aSymbol) ifTrue: [
+	(#(#true #false #nil) includes: aSymbol) ifTrue: [
 		^ InvalidSlotName signalFor: aSymbol ].
-
 
 	(aSymbol allSatisfy: [ :aCharacter | aCharacter isAlphaNumeric or: [ aCharacter = $_ ] ]) ifFalse: [
 		^ InvalidSlotName signalFor: aSymbol ]
-]
-
-{ #category : #testing }
-Slot class >> isPseudovariableName: aSymbol [
-	^ #('self' 'true' 'false' 'nil' 'thisContext' 'thisProcess' 'super') includes: aSymbol
 ]
 
 { #category : #testing }

--- a/src/Kernel/Slot.class.st
+++ b/src/Kernel/Slot.class.st
@@ -43,9 +43,6 @@ Slot class >> checkValidName: aSymbol [
 	aSymbol startsWithDigit ifTrue: [
 		^ InvalidSlotName signalFor: aSymbol ].
 	
-	(#(#true #false #nil) includes: aSymbol) ifTrue: [
-		^ InvalidSlotName signalFor: aSymbol ].
-
 	(aSymbol allSatisfy: [ :aCharacter | aCharacter isAlphaNumeric or: [ aCharacter = $_ ] ]) ifFalse: [
 		^ InvalidSlotName signalFor: aSymbol ]
 ]

--- a/src/Slot-Tests/SlotErrorsTest.class.st
+++ b/src/Slot-Tests/SlotErrorsTest.class.st
@@ -77,16 +77,6 @@ SlotErrorsTest >> testClassSlotDuplicationConflict [
 ]
 
 { #category : #tests }
-SlotErrorsTest >> testClassSlotWithReservedName [
-
-	#(#true #false #nil) do: [:reservedName |
-		self should: [
-			self make: [ :builder |
-				builder classSlots: { reservedName } ] ]
-			raise: InvalidSlotName ]
-]
-
-{ #category : #tests }
 SlotErrorsTest >> testDangerousClassesConditions [
 
 	| specialObjectsArrayItem |
@@ -183,16 +173,6 @@ SlotErrorsTest >> testSlotDuplicationConflict [
 				name: self anotherClassName;
 				slots: { #a } ] ]
 		raise: DuplicatedSlotName
-]
-
-{ #category : #tests }
-SlotErrorsTest >> testSlotWithReservedName [
-
-	#(#true #false #nil) do: [:reservedName |
-		self should: [
-			self make: [ :builder |
-				builder slots: { reservedName } ] ]
-			raise: InvalidSlotName ]
 ]
 
 { #category : #tests }

--- a/src/Slot-Tests/SlotErrorsTest.class.st
+++ b/src/Slot-Tests/SlotErrorsTest.class.st
@@ -79,7 +79,7 @@ SlotErrorsTest >> testClassSlotDuplicationConflict [
 { #category : #tests }
 SlotErrorsTest >> testClassSlotWithReservedName [
 
-	#(#self #super #thisContext #thisProcess #true #false #nil) do: [:reservedName |
+	#(#true #false #nil) do: [:reservedName |
 		self should: [
 			self make: [ :builder |
 				builder classSlots: { reservedName } ] ]
@@ -188,7 +188,7 @@ SlotErrorsTest >> testSlotDuplicationConflict [
 { #category : #tests }
 SlotErrorsTest >> testSlotWithReservedName [
 
-	#(#self #super #thisContext #true #false #nil) do: [:reservedName |
+	#(#true #false #nil) do: [:reservedName |
 		self should: [
 			self make: [ :builder |
 				builder slots: { reservedName } ] ]


### PR DESCRIPTION
This is maybe a bit controversial:

PseudoVariables are just Variables, there is nothing that should, on the level of the class builder, raise a hard error if you want to shadow "self" with a slot named "self".

The tools will warn you that the variable is shadowing an existing variable of that name already, we could add a special rule (or improve the description) for this case in addition.

A side effect is that this means that thisProcess as a instance variable would now still be possible and thus introducing thisProcess is less of a backward compatibility problem.