### PR TITLE
CompletionEngine do not automatically open empty completion menus

### DIFF
--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -299,10 +299,21 @@ CompletionEngine >> newSmartCharacterInsertionStringForLeft: left right: right [
 
 { #category : #'menu morph' }
 CompletionEngine >> openMenu [
-	| theMenu |
+
+	self openMenuForced: true
+
+]
+
+{ #category : #'menu morph' }
+CompletionEngine >> openMenuForced: forced [
+
+	| theMenu theContext |
 	self stopCompletionDelay.
 
-	context := self createContext.
+	theContext := self createContext.
+	(forced or: [ theContext hasEntries ]) ifFalse: [ ^ self ].
+	context := theContext.
+	
 	theMenu := self menuMorphClass
 				engine: self
 				position: (editor selectionPosition: context completionToken).
@@ -365,7 +376,7 @@ CompletionEngine >> resetCompletionDelay [
 	completionDelay := [
 			(Delay forMilliseconds: NECPreferences popupAutomaticDelay) wait.
 			UIManager default defer:  [
-				editor atCompletionPosition ifTrue: [ self openMenu ]]
+				editor atCompletionPosition ifTrue: [ self openMenuForced: false ]]
 		] fork
 ]
 


### PR DESCRIPTION
Completion menu is not displayed after completion delay when it is empty.
For context, the delay starts when the last keyboard input is a plain letter.

An empty menu is still presented on explicit `tab`. It's the right behavior, as it gives an explicit GUI feedback.

Fix #13571