### PR TITLE
Move #protocolOfSelector: to ClassDescription

### DIFF
--- a/src/CodeExport/ClassDescription.extension.st
+++ b/src/CodeExport/ClassDescription.extension.st
@@ -70,7 +70,7 @@ ClassDescription >> printMethodChunk: selector on: outStream [
 	"Copy the source code for the method associated with selector onto the fileStream."
 
 	| preamble method |
-	preamble := self name, ' methodsFor: ', (self organization protocolOfSelector: selector) name asString printString.
+	preamble := self name, ' methodsFor: ', (self protocolOfSelector: selector) name asString printString.
 	method := self methodDict
 		at: selector
 		ifAbsent: [

--- a/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
@@ -48,6 +48,19 @@ ClassDescriptionProtocolsTest >> testProtocolNames [
 ]
 
 { #category : #tests }
+ClassDescriptionProtocolsTest >> testProtocolOfSelector [
+
+	class compiler
+		protocol: #titan;
+		install: 'king ^ 1'.
+
+	self assert: (class protocolOfSelector: #king) identicalTo: (class organization protocolNamed: #titan).
+	self assert: (class protocolOfSelector: #king) name equals: #titan.
+	"In the future this should maybe be an error?"
+	self assert: (class protocolOfSelector: #luz) isNil
+]
+
+{ #category : #tests }
 ClassDescriptionProtocolsTest >> testRemoveProtocol [
 
 	class organization addProtocol: #titan.

--- a/src/Kernel-Tests/ClassDescriptionTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionTest.class.st
@@ -48,7 +48,7 @@ ClassDescriptionTest >> testAddSelectorWithMethodClassifyMethod [
 
 	self assert: method sourceCode equals: 'wammawink ^ self'.
 	self assert: method protocol equals: Protocol unclassified.
-	self assert: (class organization protocolOfSelector: #wammawink) name equals: Protocol unclassified
+	self assert: (class protocolOfSelector: #wammawink) name equals: Protocol unclassified
 ]
 
 { #category : #'tests - slots' }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -33,7 +33,7 @@ ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod 
 		priorMethod := method.
 		priorOrigin := method origin ].
 
-	oldProtocol := self organization protocolOfSelector: selector.
+	oldProtocol := self protocolOfSelector: selector.
 	SystemAnnouncer uniqueInstance suspendAllWhile: [ "The next part is really ugly with the double if.. BUT! I will fix that in a new PR soon... I want to remove the usage of `Protocol unclassified` as a way to say 'Do not upatde the protocol' because this is counter intuitive."
 		self organization classify: selector under: ((protocol isString
 				  ifTrue: [ protocol ]
@@ -78,7 +78,7 @@ ClassDescription >> addSelector: selector withMethod: compiledMethod [
 
 	| priorMethodOrNil oldProtocol |
 	priorMethodOrNil := self compiledMethodAt: selector ifAbsent: [ nil ].
-	oldProtocol := self organization protocolOfSelector: selector.
+	oldProtocol := self protocolOfSelector: selector.
 
 	"If there is no old protocol, then we want to ensure the method is at least in Protocol unclassified to not have protocolless methods."
 	oldProtocol ifNil: [ SystemAnnouncer uniqueInstance suspendAllWhile: [ self organization classify: selector under: nil ] ].
@@ -759,6 +759,14 @@ ClassDescription >> protocolNames [
 	"Return the list of all the protocol names included in this class."
 
 	^ self organization protocolNames copy
+]
+
+{ #category : #protocol }
+ClassDescription >> protocolOfSelector: aSelector [
+
+	^ self organization protocols
+		  detect: [ :each | each includesSelector: aSelector ]
+		  ifNone: [ nil ]
 ]
 
 { #category : #compiling }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -168,9 +168,7 @@ ClassOrganization >> protocolNames [
 { #category : #protocol }
 ClassOrganization >> protocolOfSelector: aSelector [
 
-	^ self protocols
-		  detect: [ :each | each includesSelector: aSelector ]
-		  ifNone: [ nil ]
+	^ self organizedClass protocolOfSelector: aSelector
 ]
 
 { #category : #accessing }

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -229,7 +229,7 @@ CompiledMethod >> cachePragmas [
 CompiledMethod >> category [
 	"Please favor protocol instead of category. We want to have method protocol and class package and tag = a category"
 
-	^ (self methodClass organization protocolOfSelector: self selector) ifNotNil: #name
+	^ self methodClass organization protocolNameOfElement: self selector
 ]
 
 { #category : #accessing }

--- a/src/Refactoring-Environment/RBBrowserEnvironment.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironment.class.st
@@ -879,7 +879,7 @@ RBBrowserEnvironment >> whichCategoryIncludes: aClassName [
 RBBrowserEnvironment >> whichProtocolIncludes: aSelector in: aClass [
 	"CyrilFerlicot: We should check if it is not better to return a protocol instead of a protocol name here and adapt the clients."
 
-	^ (aClass organization protocolOfSelector: aSelector)
+	^ (aClass protocolOfSelector: aSelector)
 		  ifNotNil: [ :protocol | protocol name ]
 		  ifNil: [ Protocol unclassified ]
 ]

--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -64,12 +64,12 @@ ShClassInstallerTest >> testBuildingClassesWithSlotsClassifiesItsMethods [
 	newClass := self newClass: #ShCITestClass slots: { (#anInstanceVariable => BooleanSlot) }.
 
 	self assertCollection: newClass selectors hasSameElements: { #initialize }.
-	self assert: (newClass organization protocolOfSelector: #initialize) isNotNil.
+	self assert: (newClass protocolOfSelector: #initialize) isNotNil.
 
 	newClass2 := newClass duplicateClassWithNewName: #ShCITestClass2.
 
 	self assertCollection: newClass2 selectors hasSameElements: { #initialize }.
-	self assert: (newClass2 organization protocolOfSelector: #initialize) isNotNil
+	self assert: (newClass2 protocolOfSelector: #initialize) isNotNil
 ]
 
 { #category : #tests }

--- a/src/TraitsV2-Tests/ClassTraitTest.class.st
+++ b/src/TraitsV2-Tests/ClassTraitTest.class.st
@@ -19,12 +19,12 @@ ClassTraitTest >> testChanges [
 	self assert: (self c2 class methodDict includesKey: #m1ClassSide).
 	self c2 m1ClassSide.
 	self assert: self c2 m1ClassSide equals: 17. "category"
-	self assert: (self c2 class organization protocolOfSelector: #m1ClassSide) name equals: 'mycategory'. "conflicts"
+	self assert: (self c2 class protocolOfSelector: #m1ClassSide) name equals: 'mycategory'. "conflicts"
 	self t2 classSide compile: 'm1ClassSide' classified: 'mycategory'.
 	self assert: (self c2 class methodDict includesKey: #m1ClassSide).
 	self deny: (self c2 class includesLocalSelector: #m1ClassSide).
 	self should: [ self c2 m1ClassSide ] raise: Error. "conflict category"
-	self assert: (self c2 class organization protocolOfSelector: #m1ClassSide) name equals: #mycategory
+	self assert: (self c2 class protocolOfSelector: #m1ClassSide) name equals: #mycategory
 ]
 
 { #category : #tests }

--- a/src/TraitsV2-Tests/T2TraitWithPackagesTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitWithPackagesTest.class.st
@@ -160,8 +160,8 @@ T2TraitWithPackagesTest >> testPackageOfMethodFromTraitsRemoved [
 
 	t1 removeSelector: #m1.
 
-	self assert: (t1 organization protocolOfSelector: #m1) isNil.
-	self assert: (t2 organization protocolOfSelector: #m1) isNil.
+	self assert: (t1 protocolOfSelector: #m1) isNil.
+	self assert: (t2 protocolOfSelector: #m1) isNil.
 
 	self assert: (Smalltalk organization packageDefiningOrExtendingSelector: #m1 inClassNamed: #T1) isNil.
 	self assert: (Smalltalk organization packageDefiningOrExtendingSelector: #m1 inClassNamed: #T2) isNil

--- a/src/TraitsV2-Tests/TraitMethodDescriptionTest.class.st
+++ b/src/TraitsV2-Tests/TraitMethodDescriptionTest.class.st
@@ -59,43 +59,43 @@ TraitMethodDescriptionTest >> testConflictingProtocols [
 
 	| t7 t8 |
 	self t2 compile: 'm11' classified: #catY.
-	self assert: (self t4 organization protocolOfSelector: #m11) name equals: #catX.
-	self assert: (self t5 organization protocolOfSelector: #m11) name equals: Protocol traitConflictName.
+	self assert: (self t4 protocolOfSelector: #m11) name equals: #catX.
+	self assert: (self t5 protocolOfSelector: #m11) name equals: Protocol traitConflictName.
 	t7 := self createTraitNamed: #T7 uses: self t1 + self t2.
-	self assert: (t7 organization protocolOfSelector: #m11) name equals: Protocol traitConflictName.
+	self assert: (t7 protocolOfSelector: #m11) name equals: Protocol traitConflictName.
 	self t1 removeSelector: #m11.
-	self assert: (self t4 organization protocolOfSelector: #m11) name equals: #catX.
-	self assert: (self t5 organization protocolOfSelector: #m11) name equals: #catY.
-	self assert: (t7 organization protocolOfSelector: #m11) name equals: #catY.
+	self assert: (self t4 protocolOfSelector: #m11) name equals: #catX.
+	self assert: (self t5 protocolOfSelector: #m11) name equals: #catY.
+	self assert: (t7 protocolOfSelector: #m11) name equals: #catY.
 	self deny: (t7 organization hasProtocol: Protocol traitConflictName).
 	self t1 compile: 'm11' classified: #cat1.
 	t8 := self createTraitNamed: #T8 uses: self t1 + self t2.
 	t8 organization classify: #m11 under: #cat1.
 	self t1 organization classify: #m11 under: #catZ.
-	self assert: (self t4 organization protocolOfSelector: #m11) name equals: #catX.
-	self assert: (self t5 organization protocolOfSelector: #m11) name equals: Protocol traitConflictName.
-	self assert: (t8 organization protocolOfSelector: #m11) name equals: #catZ
+	self assert: (self t4 protocolOfSelector: #m11) name equals: #catX.
+	self assert: (self t5 protocolOfSelector: #m11) name equals: Protocol traitConflictName.
+	self assert: (t8 protocolOfSelector: #m11) name equals: #catZ
 ]
 
 { #category : #tests }
 TraitMethodDescriptionTest >> testProtocols [
 
-	self assert: (self t4 organization protocolOfSelector: #m21) name equals: #cat1.
-	self assert: (self t4 organization protocolOfSelector: #m22) name equals: #cat2.
-	self assert: (self t4 organization protocolOfSelector: #m11) name equals: #catX.
-	self assert: (self t4 organization protocolOfSelector: #m12) name equals: #cat2.
-	self assert: (self t4 organization protocolOfSelector: #m13) name equals: #cat3.
-	self assert: (self t6 organization protocolOfSelector: #m22Alias) name equals: #cat2.
+	self assert: (self t4 protocolOfSelector: #m21) name equals: #cat1.
+	self assert: (self t4 protocolOfSelector: #m22) name equals: #cat2.
+	self assert: (self t4 protocolOfSelector: #m11) name equals: #catX.
+	self assert: (self t4 protocolOfSelector: #m12) name equals: #cat2.
+	self assert: (self t4 protocolOfSelector: #m13) name equals: #cat3.
+	self assert: (self t6 protocolOfSelector: #m22Alias) name equals: #cat2.
 	self t2 organization classify: #m22 under: #catX.
-	self assert: (self t4 organization protocolOfSelector: #m22) name equals: #catX.
-	self assert: (self t6 organization protocolOfSelector: #m22Alias) name equals: #catX.
+	self assert: (self t4 protocolOfSelector: #m22) name equals: #catX.
+	self assert: (self t6 protocolOfSelector: #m22Alias) name equals: #catX.
 	self t6 organization classify: #m22 under: #catY.
 	self t6 organization classify: #m22Alias under: #catY.
 	self t2 organization classify: #m22 under: #catZ.
-	self assert: (self t6 organization protocolOfSelector: #m22) name equals: #catY.
-	self assert: (self t6 organization protocolOfSelector: #m22Alias) name equals: #catY.
+	self assert: (self t6 protocolOfSelector: #m22) name equals: #catY.
+	self assert: (self t6 protocolOfSelector: #m22Alias) name equals: #catY.
 	self t1 compile: 'mA' classified: #catA.
-	self assert: (self t4 organization protocolOfSelector: #mA) name equals: #catA.
+	self assert: (self t4 protocolOfSelector: #mA) name equals: #catA.
 	self t1 organization classify: #mA under: #cat1.
 	self assert: (self t4 organization hasProtocol: #catA) not
 ]

--- a/src/TraitsV2-Tests/TraitPureBehaviorTest.class.st
+++ b/src/TraitsV2-Tests/TraitPureBehaviorTest.class.st
@@ -159,11 +159,11 @@ TraitPureBehaviorTest >> testMethodClass [
 TraitPureBehaviorTest >> testMethodProtocolUpdate [
 
 	self t1 compile: 'm1' classified: 'category1'.
-	self assert: (self t5 organization protocolOfSelector: #m1) name equals: #category1.
-	self assert: (self c2 organization protocolOfSelector: #m1) name equals: #category1.
+	self assert: (self t5 protocolOfSelector: #m1) name equals: #category1.
+	self assert: (self c2 protocolOfSelector: #m1) name equals: #category1.
 	self t1 organization classify: #m1 under: #category2.
-	self assert: (self t5 organization protocolOfSelector: #m1) name equals: #category2.
-	self assert: (self c2 organization protocolOfSelector: #m1) name equals: #category2
+	self assert: (self t5 protocolOfSelector: #m1) name equals: #category2.
+	self assert: (self c2 protocolOfSelector: #m1) name equals: #category2
 ]
 
 { #category : #'tests - applying trait composition' }

--- a/src/TraitsV2/TraitedClass.class.st
+++ b/src/TraitsV2/TraitedClass.class.st
@@ -258,7 +258,7 @@ TraitedClass >> recategorizeSelector: selector from: oldProtocol to: newProtocol
 	"If it is nil is because it is a removal. It will removed when the method is removed."
 	newProtocol ifNil: [ ^ self ].
 
-	originalProtocol := (self organization protocolOfSelector: selector) ifNil: [ ^ self ].
+	originalProtocol := (self protocolOfSelector: selector) ifNil: [ ^ self ].
 	originalProtocol name = oldProtocol name ifTrue: [ self organization classify: selector under: newProtocol name ].
 
 	(self traitComposition reverseAlias: selector) do: [ :selectorAlias |

--- a/src/TraitsV2/TraitedMetaclass.class.st
+++ b/src/TraitsV2/TraitedMetaclass.class.st
@@ -275,7 +275,7 @@ TraitedMetaclass >> recategorizeSelector: selector from: oldProtocol to: newProt
 	"If it is nil is because it is a removal. It will removed when the method is removed."
 	newProtocol ifNil: [ ^ self ].
 
-	originalProtocol := (self organization protocolOfSelector: selector) ifNil: [ ^ self ].
+	originalProtocol := (self protocolOfSelector: selector) ifNil: [ ^ self ].
 	originalProtocol name = oldProtocol name ifTrue: [ self organization classify: selector under: newProtocol name ].
 
 	(self traitComposition reverseAlias: selector) do: [ :selectorAlias |


### PR DESCRIPTION
Migrate #protocolOfSelector: from ClassOrganization to ClassDescription and simplify users. I kept a version in ClassOrganization that redirects to ClassDescription while we do the inlining.