### PR TITLE
Add menu items ‘Indent’ and ‘Outdent’ to the menu built through #menuOn: in RubSmalltalkCodeMode

### DIFF
--- a/src/Rubric/RubSmalltalkCodeMode.class.st
+++ b/src/Rubric/RubSmalltalkCodeMode.class.st
@@ -112,6 +112,14 @@ RubSmalltalkCodeMode class >> menuOn: aBuilder [
 		selector: #pasteRecent;
 		help: nil;
 		iconName: #smallCopy.
+	(aBuilder item: #'Indent' translated)
+		keyText: 'R';
+		selector: #indent;
+		help: nil.
+	(aBuilder item: #'Outdent' translated)
+		keyText: 'L';
+		selector: #outdent;
+		help: nil.
 	(aBuilder item: #'Widen selection' translated)
 		keyText: '2';
 		selector: #widenSelectionOfIt;

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -1318,6 +1318,13 @@ RubTextEditor >> inOutdent: aKeyboardEvent delta: delta [
 	^ true
 ]
 
+{ #category : #'menu messages' }
+RubTextEditor >> indent [
+
+	^ self indent: nil
+
+]
+
 { #category : #'editing keys' }
 RubTextEditor >> indent: aKeyboardEvent [
 	"Add a tab at the front of every line occupied by the selection."
@@ -1694,6 +1701,13 @@ RubTextEditor >> openingDelimiters [
 { #category : #'accessing - selection' }
 RubTextEditor >> oppositeDelimiterSelection [
 	^ RubTextSelectionColor oppositeDelimiterSelection
+]
+
+{ #category : #'menu messages' }
+RubTextEditor >> outdent [
+
+	^ self outdent: nil
+
 ]
 
 { #category : #'editing keys' }


### PR DESCRIPTION
Drawing inspiration from pull request #13095, specifically commit 62cb2c029377ffc8, this adds menu items ‘Indent’ and ‘Outdent’ as well so that these actions can be performed through the menu while also making the keyboard shortcuts more discoverable.