### PR TITLE
BlockPath

### DIFF
--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -289,6 +289,24 @@ CompiledMethodTest >> testAsString [
 	self assert: thisContext method asString isString
 ]
 
+{ #category : #tests }
+CompiledMethodTest >> testBlockViaLiteralPath [
+	| block innerCompiledBlock |
+	block := [ self class . [self] "a real block" ].
+	innerCompiledBlock := block compiledBlock literals second.
+	
+	self 
+		assert: (thisContext method blockViaLiteralPath: innerCompiledBlock literalPath) 
+		equals: innerCompiledBlock.
+		
+	block := [ self class . [#clean] "a constant block" ].
+	innerCompiledBlock := block compiledBlock literals second.
+	
+	self 
+		assert: (thisContext method blockViaLiteralPath: innerCompiledBlock literalPath) 
+		equals: innerCompiledBlock
+]
+
 { #category : #'tests - accessing' }
 CompiledMethodTest >> testBytecode [
 	"The result of this test depends on the used bytecode set.

--- a/src/Kernel-Tests/CompiledBlockTest.class.st
+++ b/src/Kernel-Tests/CompiledBlockTest.class.st
@@ -25,6 +25,18 @@ CompiledBlockTest >> testLiteralEqual [
 ]
 
 { #category : #tests }
+CompiledBlockTest >> testLiteralPath [
+	| block innerCompiledBlock |
+	block := [ self class . [self] "a real block" ].
+	innerCompiledBlock := block compiledBlock literals second.
+	self assert: innerCompiledBlock literalPath equals: #(1 2).
+	
+	block := [ self class . [#clean] "a constant block" ].
+	innerCompiledBlock := block compiledBlock literals second.
+	self assert: innerCompiledBlock literalPath equals: #(8 2)
+]
+
+{ #category : #tests }
 CompiledBlockTest >> testPcInOuter [
 	| methodToTest compiledBlocks |
 	methodToTest := self class compiler compile: 'testWrongHeightlightSingleValue

--- a/src/Kernel/CompiledBlock.class.st
+++ b/src/Kernel/CompiledBlock.class.st
@@ -102,6 +102,21 @@ CompiledBlock >> literalEqual: other [
 ]
 
 { #category : #literals }
+CompiledBlock >> literalPath [
+	"return an array with the offsets in the literals from the homeMethod to here"
+	| current path |
+	path := OrderedCollection new.
+	current := self.
+	"we go up till we reach a compiled method, recording the offsets"
+	[ current isCompiledBlock ] whileTrue: [
+		| outerCode |
+		outerCode := current outerCode.
+		path add: (outerCode indexOfLiteral: current).
+		current := outerCode ].
+	^ path asArray reversed
+]
+
+{ #category : #literals }
 CompiledBlock >> literalsToSkip [
 
 	^ 1

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -151,6 +151,13 @@ CompiledCode >> author [
 	^''
 ]
 
+{ #category : #literals }
+CompiledCode >> blockViaLiteralPath: anArray [
+	"return the compiledBlock for a path (see CompiledBlock>>literalPath)"
+	anArray ifEmpty: [ ^self ].
+	^ (self literals at: anArray first) blockViaLiteralPath: anArray copyWithoutFirst
+]
+
 { #category : #accessing }
 CompiledCode >> bytecode [
 	self

--- a/src/Kernel/ConstantBlockClosure.class.st
+++ b/src/Kernel/ConstantBlockClosure.class.st
@@ -38,9 +38,22 @@ ConstantBlockClosure class >> numArgs: numArgs literal: aLiteral [
 		literal: aLiteral
 ]
 
+{ #category : #literals }
+ConstantBlockClosure >> blockViaLiteralPath: anArray [ 
+	"return the compiledBlock for a path (see CompiledBlock>>literalPath)"
+	^ self
+]
+
 { #category : #accessing }
 ConstantBlockClosure >> literal: anObject [
 	 literal := anObject
+]
+
+{ #category : #accessing }
+ConstantBlockClosure >> literalPath [
+	"return an array with the offsets in the literals from the homeMethod to here"
+	
+	 ^self outerCode literalPath, {self outerCode indexOfLiteral: self}
 ]
 
 { #category : #evaluating }


### PR DESCRIPTION
this PR adds #literalPath for CompiledBlocks. This allows a serializer that operates under the assumption that code is the same between the system that serializes and that materializes to store bocks by storing the class name, selector and path of the block, similar to how it would store classes and methods (by class name and class name  + #selector).

This for now supports  normal blocks and constant blocks, but can be easily extenden for general clean blocks.