### PR TITLE
Adjust icon and key text spacing in ToggleMenuItemMorph

### DIFF
--- a/src/Morphic-Base/MenuMorph.class.st
+++ b/src/Morphic-Base/MenuMorph.class.st
@@ -1040,6 +1040,15 @@ MenuMorph >> leftArrowStroked: evt [
 ]
 
 { #category : #accessing }
+MenuMorph >> maxItemsIconWidth [
+
+	^ self menuItems inject: 0 into: [ :maxWidth :menuItemMorph |
+		menuItemMorph hasIcon
+			ifTrue: [ maxWidth max: menuItemMorph iconForm width ]
+			ifFalse: [ maxWidth ] ]
+]
+
+{ #category : #accessing }
 MenuMorph >> menuItems [
 	^submorphs select: [ :m | m isMenuItemMorph ]
 ]

--- a/src/Morphic-Base/ToggleMenuItemMorph.class.st
+++ b/src/Morphic-Base/ToggleMenuItemMorph.class.st
@@ -41,7 +41,7 @@ ToggleMenuItemMorph >> balloonText: aText [
 ToggleMenuItemMorph >> basicDrawOn: aCanvas [
 	"Draw on the canvas. Taken from MenuItemMorph for minor refactoring."
 
-	| stringColor stringBounds|
+	| stringColor stringBounds maxItemsIconWidth |
 	stringColor := self stringColorToUse.
 	stringBounds := self stringBoundsToUse.
 	(self isSelected and: [self isEnabled]) ifTrue: [
@@ -51,8 +51,10 @@ ToggleMenuItemMorph >> basicDrawOn: aCanvas [
 			borderStyle: self selectionBorderStyle].
 	self hasIcon ifTrue: [ |iconForm|
 		iconForm := self icon.
-		self drawIcon: iconForm on: aCanvas in: stringBounds.
-		stringBounds := stringBounds left: stringBounds left + (iconForm width) + (2*self displayScaleFactor)].
+		self drawIcon: iconForm on: aCanvas in: stringBounds ].
+	maxItemsIconWidth := self owner maxItemsIconWidth.
+	maxItemsIconWidth > 0 ifTrue: [
+		stringBounds := stringBounds left: stringBounds left + maxItemsIconWidth + (2*self displayScaleFactor) ].
 	self hasMarker ifTrue: [
 		stringBounds := stringBounds left: stringBounds left + self submorphBounds width + (8 * self displayScaleFactor)].
 	stringBounds := stringBounds top: stringBounds top + stringBounds bottom - self fontToUse height // 2.

--- a/src/Morphic-Base/ToggleMenuItemShortcut.class.st
+++ b/src/Morphic-Base/ToggleMenuItemShortcut.class.st
@@ -101,7 +101,7 @@ ToggleMenuItemShortcut >> boundsForKeyText: aString font: aFont [
 	| ktp ktw b |
 
 	ktp := self owner hasSubMenu
-		ifTrue: [ self owner right - self owner subMenuMarker width ]
+		ifTrue: [ self owner right - self owner subMenuMarker width - (2 * self owner displayScaleFactor) ]
 		ifFalse: [ self owner right ].
 	ktp := ktp - (ktw := aFont widthOfString: aString).
 	b := ktp @ ((self owner bounds top + self owner bounds bottom - aFont height) // 2) extent: ktw @ self owner height.


### PR DESCRIPTION
See the messages in commits 61d43abbfeaf9099 and b02c232ac7082544. Before&after screenshots of the method context menu in the System Browser are shown below. The first change is that the text for ‘Do it’, ‘Do & print it’ and ‘Accept’ is slightly shifted to the right so that these align with the text of the other menu items, which is most noticeable for the first two compared to the other ‘Do …’ menu items. The second change is that on the items ‘Source code’, ‘Breakpoints’ and ‘Debugging’, the keyboard shortcuts are shifted slightly to the left so that they are more clearly separated from the submenu markers.

<p align="center">
<img width="302" alt="Before" src="https://github.com/pharo-project/pharo/assets/1611248/3e024e15-65ed-41d5-aab0-ae030bf29bf6"> <img width="302" alt="After" src="https://github.com/pharo-project/pharo/assets/1611248/170df2d5-0eb4-4487-862d-a75301a8f4ff">
</p>

