### PR TITLE
Implement ClassDescription>>#protocolNameOfSelector:

### DIFF
--- a/src/Debugger-Model/DebugContext.class.st
+++ b/src/Debugger-Model/DebugContext.class.st
@@ -183,7 +183,7 @@ DebugContext >> selectedClass [
 DebugContext >> selectedMessageCategoryName [
 	"Answer the name of the message category of the message of the current context."
 
-	^ self selectedClass organization protocolNameOfElement: self selectedMessageName
+	^ self selectedClass protocolNameOfSelector: self selectedMessageName
 ]
 
 { #category : #accessing }

--- a/src/Deprecated12/ClassDescription.extension.st
+++ b/src/Deprecated12/ClassDescription.extension.st
@@ -42,7 +42,7 @@ ClassDescription >> copy: selector from: originClass classified: protocolName [
 
 	sourceCode ifNil: [ ^ self ].
 
-	protocol := protocolName ifNil: [ originClass organization protocolNameOfElement: selector ].
+	protocol := protocolName ifNil: [ originClass protocolNameOfSelector: selector ].
 
 	(self includesLocalSelector: selector) ifTrue: [
 		sourceCode asString = (self sourceCodeAt: selector) asString ifFalse: [ self error: self name , ' ' , selector , ' will be redefined if you proceed.' ] ].

--- a/src/Deprecated12/ClassOrganization.extension.st
+++ b/src/Deprecated12/ClassOrganization.extension.st
@@ -24,17 +24,19 @@ ClassOrganization >> categories [
 { #category : #'*Deprecated12' }
 ClassOrganization >> categoryOfElement: aSelector [
 
-	self deprecated: 'Use #protocolNameOfElement: instead.' transformWith: '`@rcv categoryOfElement: `@arg' -> '`@rcv protocolNameOfElement: `@arg'.
-	^ self protocolNameOfElement: aSelector
+	self
+		deprecated: 'Use #protocolNameOfSelector: on the organized class instead.'
+		transformWith: '`@rcv categoryOfElement: `@arg' -> '`@rcv organizedClass protocolNameOfSelector: `@arg'.
+	^ self organizedClass protocolNameOfSelector: aSelector
 ]
 
 { #category : #'*Deprecated12' }
 ClassOrganization >> categoryOfElement: aSelector ifAbsent: aBlock [
 
 	self
-		deprecated: 'Use #protocolNameOfElement: instead.'
-		transformWith: '`@rcv categoryOfElement: `@arg1 ifAbsent: `@arg2' -> '(`@rcv protocolNameOfElement: `@arg1) ifNil: `@arg2'.
-	^ (self protocolNameOfElement: aSelector) ifNil: aBlock
+		deprecated: 'Use #protocolNameOfSelector: on the organized class instead.'
+		transformWith: '`@rcv categoryOfElement: `@arg1 ifAbsent: `@arg2' -> '(`@rcv organizedClass protocolNameOfSelector: `@arg1) ifNil: `@arg2'.
+	^ (self organizedClass protocolNameOfSelector: aSelector) ifNil: aBlock
 ]
 
 { #category : #'*Deprecated12' }

--- a/src/Fuel-Tests-Core/FLCreateClassSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLCreateClassSerializationTest.class.st
@@ -462,7 +462,7 @@ FLCreateClassSerializationTest >> testCreateWithClassSideInitializeMethod [
 
 	self assert: (materializedClassOrTrait classSide includesSelector: #initialize).
 	self assertCollection: #(initialize) hasSameElements: materializedClassOrTrait classSide localSelectors.
-	self assert: category equals: (materializedClassOrTrait classSide whichCategoryIncludesSelector: #initialize)
+	self assert: category equals: (materializedClassOrTrait classSide protocolNameOfSelector: #initialize)
 ]
 
 { #category : #tests }

--- a/src/Fuel-Tests-Core/FLTCreateClassOrTraitSerializationTest.trait.st
+++ b/src/Fuel-Tests-Core/FLTCreateClassOrTraitSerializationTest.trait.st
@@ -110,7 +110,7 @@ FLTCreateClassOrTraitSerializationTest >> testCreateWithClassSideMethod [
 
 	self assert: (materializedClassOrTrait classSide includesSelector: #fortyTwo).
 	self assertCollection: #(fortyTwo) hasSameElements: materializedClassOrTrait classSide localSelectors.
-	self assert: category equals: (materializedClassOrTrait classSide whichCategoryIncludesSelector: #fortyTwo).
+	self assert: category equals: (materializedClassOrTrait classSide protocolNameOfSelector: #fortyTwo).
 	self assert: 42 equals: ((self newInstanceFrom: materializedClassOrTrait) class perform: #fortyTwo)
 ]
 
@@ -234,7 +234,7 @@ FLTCreateClassOrTraitSerializationTest >> testCreateWithMethod [
 
 	self assert: (materializedClassOrTrait includesSelector: #fortyTwo).
 	self assertCollection: #(fortyTwo) hasSameElements: materializedClassOrTrait localSelectors.
-	self assert: category equals: (materializedClassOrTrait whichCategoryIncludesSelector: #fortyTwo).
+	self assert: category equals: (materializedClassOrTrait protocolNameOfSelector: #fortyTwo).
 	self assert: 42 equals: ((self newInstanceFrom: materializedClassOrTrait) perform: #fortyTwo).
 ]
 

--- a/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
@@ -34,6 +34,18 @@ ClassDescriptionProtocolsTest >> tearDown [
 ]
 
 { #category : #tests }
+ClassDescriptionProtocolsTest >> testProtocolNameOfSelector [
+
+	class compiler
+		protocol: #titan;
+		install: 'king ^ 1'.
+
+	self assert: (class protocolNameOfSelector: #king) equals: #titan.
+	"In the future this should maybe be an error?"
+	self assert: (class protocolNameOfSelector: #luz) isNil
+]
+
+{ #category : #tests }
 ClassDescriptionProtocolsTest >> testProtocolNames [
 
 	class organization addProtocol: #titan.

--- a/src/Kernel-Tests/ClassDescriptionTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionTest.class.st
@@ -137,12 +137,6 @@ ClassDescriptionTest >> testSlots [
 	self assert: Context slots size equals: 6
 ]
 
-{ #category : #tests }
-ClassDescriptionTest >> testWhichCategoryIncludesSelector [
-	self assert: (ClassDescription whichCategoryIncludesSelector: #printOn:)  equals: #printing.
-	self assert: (ClassDescription whichCategoryIncludesSelector: #doesNotExist) equals: nil
-]
-
 { #category : #'tests - instance variables' }
 ClassDescriptionTest >> testclassThatDefinesInstVarNamed [
 	self assert: (Point classThatDefinesInstVarNamed: 'x') equals: Point.

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -816,7 +816,7 @@ ClassDescription >> removeSelector: selector [
 	| priorMethod priorProtocol origin |
 	priorMethod := self compiledMethodAt: selector ifAbsent: [^ nil].
 	origin := priorMethod origin.
-	priorProtocol := self whichCategoryIncludesSelector: selector.
+	priorProtocol := self protocolNameOfSelector: selector.
 	self organization removeElement: selector.
 
 	super removeSelector: selector.
@@ -1079,9 +1079,8 @@ ClassDescription >> wantsChangeSetLogging [
 
 { #category : #organization }
 ClassDescription >> whichCategoryIncludesSelector: aSelector [
-	"Answer the category of the argument, aSelector, in the organization of
-	the receiver, or answer nil if the receiver does not inlcude this selector."
 
+	self deprecated: 'Use #protocolNameOfSelector: instead.' transformWith: '`@rcv whichCategoryIncludeSelector: `@arg' -> '`@rcv protocolNameOfSelector: `@arg'.
 	^ self protocolNameOfSelector: aSelector
 ]
 

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -385,7 +385,7 @@ ClassDescription >> definitionStringFor: aConfiguredPrinter [
 	^ self subclassResponsibility
 ]
 
-{ #category : #'queries - protocols' }
+{ #category : #'accessing - protocols' }
 ClassDescription >> ensureProtocol: aProtocol [
 	"I can take a Protocol or a protocol name as paramater.
 	
@@ -756,6 +756,8 @@ ClassDescription >> printOn: aStream [
 
 { #category : #'accessing - protocols' }
 ClassDescription >> protocolNameOfSelector: aSelector [
+	"Return the protocol name including the method of the same name as the selector.
+	If the class does not includes a method of this name, returns nil. Maybe this should be changed for an error in the future."
 
 	^ (self protocolOfSelector: aSelector) ifNotNil: [ :protocol | protocol name ]
 ]
@@ -767,8 +769,10 @@ ClassDescription >> protocolNames [
 	^ self organization protocolNames copy
 ]
 
-{ #category : #protocol }
+{ #category : #'accessing - protocols' }
 ClassDescription >> protocolOfSelector: aSelector [
+	"Return the protocol including the method of the same name as the selector.
+	If the class does not includes a method of this name, returns nil. Maybe this should be changed for an error in the future."
 
 	^ self organization protocols
 		  detect: [ :each | each includesSelector: aSelector ]

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -755,6 +755,12 @@ ClassDescription >> printOn: aStream [
 ]
 
 { #category : #'accessing - protocols' }
+ClassDescription >> protocolNameOfSelector: aSelector [
+
+	^ (self protocolOfSelector: aSelector) ifNotNil: [ :protocol | protocol name ]
+]
+
+{ #category : #'accessing - protocols' }
 ClassDescription >> protocolNames [
 	"Return the list of all the protocol names included in this class."
 
@@ -1076,7 +1082,7 @@ ClassDescription >> whichCategoryIncludesSelector: aSelector [
 	"Answer the category of the argument, aSelector, in the organization of
 	the receiver, or answer nil if the receiver does not inlcude this selector."
 
-	^ self organization protocolNameOfElement: aSelector
+	^ self protocolNameOfSelector: aSelector
 ]
 
 { #category : #queries }

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -140,12 +140,6 @@ ClassOrganization >> printOn: aStream [
 ]
 
 { #category : #accessing }
-ClassOrganization >> protocolNameOfElement: aSelector [
-
-	^ (self protocolOfSelector: aSelector) ifNotNil: [ :protocol | protocol name ]
-]
-
-{ #category : #accessing }
 ClassOrganization >> protocolNamed: aString [
 
 	^ self protocolNamed: aString ifAbsent: [ NotFound signalFor: aString ]

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -229,7 +229,7 @@ CompiledMethod >> cachePragmas [
 CompiledMethod >> category [
 	"Please favor protocol instead of category. We want to have method protocol and class package and tag = a category"
 
-	^ self methodClass organization protocolNameOfElement: self selector
+	^ self methodClass protocolNameOfSelector: self selector
 ]
 
 { #category : #accessing }

--- a/src/Metacello-ToolBox/MetacelloToolBox.class.st
+++ b/src/Metacello-ToolBox/MetacelloToolBox.class.st
@@ -1887,7 +1887,7 @@ MetacelloToolBox >> modifyBaselineOf [
   methodSpec := MetacelloBaselineOfMethodSpec new
     project: project;
     selector: (MetacelloPlatform current selectorForPragma: pragma);
-    category: (baselineClass whichCategoryIncludesSelector: (MetacelloPlatform current selectorForPragma: pragma));
+    category: (baselineClass protocolNameOfSelector: (MetacelloPlatform current selectorForPragma: pragma));
     yourself.
   constructor methodSections
     do: [ :methodSection | self methodSpec methodSections add: methodSection ]
@@ -2026,7 +2026,7 @@ MetacelloToolBox >> modifySymbolicVersionMethodFor: versionSymbol symbolicVersio
     methodSpec := MetacelloSymbolicVersionMethodSpec new
         project: project;
         selector: (MetacelloPlatform current selectorForPragma: pragma);
-        category: (project configuration class whichCategoryIncludesSelector: (MetacelloPlatform current selectorForPragma: pragma));
+        category: (project configuration class protocolNameOfSelector: (MetacelloPlatform current selectorForPragma: pragma));
         versionString: versionSymbol;
         yourself.
     (constructor extractSymbolicVersionSpecsFor: versionSymbol)
@@ -2095,7 +2095,7 @@ MetacelloToolBox >> updateVersionMethodForVersion: inputVersionStringOrSymbol pr
     methodSpec := MetacelloVersionMethodSpec new
         project: project;
         selector: (MetacelloPlatform current selectorForPragma: pragma);
-        category: (project configuration class whichCategoryIncludesSelector: (MetacelloPlatform current selectorForPragma:  pragma));
+        category: (project configuration class protocolNameOfSelector: (MetacelloPlatform current selectorForPragma:  pragma));
         versionString: sourceVersionString;
         imports: imports;
         yourself.

--- a/src/Monticello/MCMethodDefinition.class.st
+++ b/src/Monticello/MCMethodDefinition.class.st
@@ -327,7 +327,7 @@ MCMethodDefinition >> removeSelector: aSelector fromClass: aClass [
 	to another package, but remove the category if it is empty."
 
 	| newProtocol |
-	newProtocol := aClass organization protocolNameOfElement: aSelector.
+	newProtocol := aClass protocolNameOfSelector: aSelector.
 	newProtocol ifNotNil: [ "If moved to and fro extension, ignore removal"
 		(category beginsWith: '*') = (newProtocol beginsWith: '*') ifFalse: [ ^ self ]. "Check if moved between different extension categories"
 		((category beginsWith: '*') and: [ category ~= newProtocol ]) ifTrue: [ ^ self ] ].

--- a/src/Monticello/MCMethodDefinition.class.st
+++ b/src/Monticello/MCMethodDefinition.class.st
@@ -326,13 +326,15 @@ MCMethodDefinition >> removeSelector: aSelector fromClass: aClass [
 	Be careful not to remove the selector when it has wandered
 	to another package, but remove the category if it is empty."
 
-	| newProtocol |
-	newProtocol := aClass protocolNameOfSelector: aSelector.
-	newProtocol ifNotNil: [ "If moved to and fro extension, ignore removal"
-		(category beginsWith: '*') = (newProtocol beginsWith: '*') ifFalse: [ ^ self ]. "Check if moved between different extension categories"
-		((category beginsWith: '*') and: [ category ~= newProtocol ]) ifTrue: [ ^ self ] ].
-	aClass removeSelector: aSelector.
-	aClass organization removeProtocolIfEmpty: category
+	(aClass protocolOfSelector: aSelector) ifNotNil: [ :newProtocol |
+		"If moved to and from extension, ignore removal"
+		(category beginsWith: '*') = newProtocol isExtensionProtocol ifFalse: [ ^ self ].
+		"Check if moved between different extension protocol"
+		((category beginsWith: '*') and: [ category ~= newProtocol name ]) ifTrue: [ ^ self ] ].
+
+	aClass
+		removeSelector: aSelector;
+		removeProtocolIfEmpty: category
 ]
 
 { #category : #comparing }

--- a/src/Monticello/MCPackageManager.class.st
+++ b/src/Monticello/MCPackageManager.class.st
@@ -166,7 +166,7 @@ MCPackageManager class >> managersForClass: aClass do: aBlock [
 { #category : #'system changes' }
 MCPackageManager class >> managersForClass: aClass selector: aSelector do: aBlock [
 
-	^ self managersForClass: aClass category: (aClass organization protocolNameOfElement: aSelector) do: aBlock
+	^ self managersForClass: aClass category: (aClass protocolNameOfSelector: aSelector) do: aBlock
 ]
 
 { #category : #'system changes' }

--- a/src/Monticello/MethodAddition.class.st
+++ b/src/Monticello/MethodAddition.class.st
@@ -48,7 +48,7 @@ MethodAddition >> createCompiledMethod [
 	selector := compiledMethod selector.
 	self writeSourceToLog.
 	priorMethodOrNil := myClass compiledMethodAt: selector ifAbsent: [ nil ].
-	priorCategoryOrNil := myClass organization protocolNameOfElement: selector
+	priorCategoryOrNil := myClass protocolNameOfSelector: selector
 ]
 
 { #category : #operations }

--- a/src/Refactoring-Core/RBProtocolRegexTransformation.class.st
+++ b/src/Refactoring-Core/RBProtocolRegexTransformation.class.st
@@ -12,18 +12,10 @@ Class {
 { #category : #transforming }
 RBProtocolRegexTransformation >> transform [
 
-	| original replacement |
-
-	self model
-		allClassesDo: [ :class |
-			class selectors
-				do: [ :selector |
-					original := ( class realClass whichCategoryIncludesSelector: selector ) asString.
-					original
-						ifNotNil: [ replacement := self execute: original.
-							replacement = original
-								ifFalse: [ class compile: ( class sourceCodeFor: selector ) classified: replacement ]
-							]
-					]
-			]
+	| replacement |
+	self model allClassesDo: [ :class |
+		class selectors do: [ :selector |
+			(class realClass protocolNameOfSelector: selector) asString ifNotNil: [ :original |
+				replacement := self execute: original.
+				replacement = original ifFalse: [ class compile: (class sourceCodeFor: selector) classified: replacement ] ] ] ]
 ]

--- a/src/Refactoring-Critics/RBSmalllintContext.class.st
+++ b/src/Refactoring-Critics/RBSmalllintContext.class.st
@@ -162,7 +162,8 @@ RBSmalllintContext >> printOn: aStream [
 
 { #category : #accessing }
 RBSmalllintContext >> protocol [
-	^self selectedClass whichCategoryIncludesSelector: self selector
+
+	^ self selectedClass protocolNameOfSelector: self selector
 ]
 
 { #category : #accessing }

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1492,7 +1492,7 @@ SmalltalkImage >> removeAllLineFeedsQuietlyCalling: aBlock [
 	authors at: 'OK' put: Set new.
 	self systemNavigation
 		allBehaviorsDo: [:cls | cls selectorsAndMethodsDo: [:selector :method |
-					| oldStamp newCodeString oldCodeString oldCategory nameString |
+					| oldStamp newCodeString oldCodeString oldProtocolName nameString |
 					aBlock cull: cls cull: selector.
 					oldCodeString := cls sourceCodeAt: selector.
 					(oldCodeString includes: Character lf)
@@ -1509,10 +1509,10 @@ SmalltalkImage >> removeAllLineFeedsQuietlyCalling: aBlock [
 										at: (oldStamp copyFrom: 1 to: (oldStamp findFirst: [ :c | c isAlphaNumeric not ]))
 										ifAbsentPut: [Set new])
 										add: nameString.
-									oldCategory := cls whichCategoryIncludesSelector: selector.
+									oldProtocolName := cls protocolNameOfSelector: selector.
 									cls
 										compile: newCodeString
-										classified: oldCategory
+										classified: oldProtocolName
 										withStamp: oldStamp
 										notifying: nil ]]]].
 	^ authors

--- a/src/Tool-Profilers/TimeProfiler.class.st
+++ b/src/Tool-Profilers/TimeProfiler.class.st
@@ -535,13 +535,9 @@ TimeProfiler >> selectedMethodCode: aString notifying: aController [
 	^ self selectedNode
 		ifNil: [ false ]
 		ifNotNil: [ :currNode |
-			| class oldSelector category newSelector |
-			class := currNode methodClass.
-			oldSelector := currNode selector.
-			class ifNil: [ ^ false ].	"Normal method accept"
-			category := class organization protocolNameOfElement: oldSelector.
-			newSelector := class compile: aString classified: category notifying: aController.
-			newSelector ifNil: [ ^ false ].
+			| class |
+			class := currNode methodClass ifNil: [ ^ false ].	"Normal method accept"
+			(class compile: aString notifying: aController) ifNil: [ ^ false ].
 			self changed: #selectedMethodCode.
 			true ]
 ]

--- a/src/TraitsV2/TraitChange.class.st
+++ b/src/TraitsV2/TraitChange.class.st
@@ -123,7 +123,7 @@ TraitChange >> remove: aSelector into: aClass changes: results [
 
 	(aClass methodDict includesKey: aSelector) ifTrue:[
 		priorMethod := aClass methodDict at: aSelector.
-		priorProtocol := aClass whichCategoryIncludesSelector: aSelector.
+		priorProtocol := aClass protocolNameOfSelector: aSelector.
 
 		aClass methodDict removeKey: aSelector.
 		aClass organization removeElement: aSelector.


### PR DESCRIPTION
This PR implements ClassDescription>>#protocolNameOfSelector: and do multiple cleanings around it:
- This new method is the equivalent of ClassOrganization>>#protocolNameOfElement: but inlined in ClassDescription
- Update senders
- Deprecate #whichCategoryIncludesSelector: in favor of this new method
- Add a test for it

Future work:
- I think this method should raise an error if the selector is not in the class instead of returning nil