### PR TITLE
Compiler:  remove #lookupVar:declare:

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -63,11 +63,6 @@ Context >> lookupVar: aSymbol [
 ]
 
 { #category : #'*Debugging-Core' }
-Context >> lookupVar: aSymbol declare: aBoolean [
-	^ self astScope lookupVar: aSymbol
-]
-
-{ #category : #'*Debugging-Core' }
 Context >> methodReturnConstant: value [
 	"Simulate the action of a 'return constant' bytecode whose value is the
 	 argument, value. This corresponds to a source expression like '^0'."

--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -80,11 +80,6 @@ Behavior >> lookupVar: aName [
 ]
 
 { #category : #'*OpalCompiler-Core' }
-Behavior >> lookupVar: aName declare: aBoolean [
-	^ self lookupVar: aName
-]
-
-{ #category : #'*OpalCompiler-Core' }
 Behavior >> outerScope [
 	^self environment
 ]

--- a/src/Ring-Core/RGBehavior.class.st
+++ b/src/Ring-Core/RGBehavior.class.st
@@ -664,11 +664,6 @@ RGBehavior >> lookupVar: aName [
 		  ifNone: [ self bindingOf: aName ]
 ]
 
-{ #category : #lookup }
-RGBehavior >> lookupVar: aName declare: aBoolean [
-	^ self lookupVar: aName
-]
-
 { #category : #resolving }
 RGBehavior >> makeResolved [
 

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -260,11 +260,6 @@ SystemDictionary >> lookupVar: name [
 	^self reservedVariables at: name ifAbsent: [self bindingOf: name]
 ]
 
-{ #category : #'accessing - variable lookup' }
-SystemDictionary >> lookupVar: name declare: aBoolean [
-	^ self lookupVar: name
-]
-
 { #category : #'accessing - system attributes' }
 SystemDictionary >> maxIdentityHash [
 	"Answer the maximum identityHash value supported by the VM."


### PR DESCRIPTION
after fixing the sender in Spec and Newtools, we can remove #lookupVar:declare:

Deprecation not needed as I think this is not used external to the base of the tools