### PR TITLE
Cleanup TheManifestBuilder 

### DIFF
--- a/src/Manifest-Core/TheManifestBuilder.class.st
+++ b/src/Manifest-Core/TheManifestBuilder.class.st
@@ -511,47 +511,11 @@ TheManifestBuilder >> removeAllItem: aSet selector: selector [
 ]
 
 { #category : #'adding-removing' }
-TheManifestBuilder >> removeAllManifest [
-
-	self removeClasses: (self class allManifestClasses)
-]
-
-{ #category : #'adding-removing' }
 TheManifestBuilder >> removeAllToDo: fp of: ruleId version: versionId [
 
 	| selector |
 	selector := self selectorToDoOf: ruleId version: versionId.
 	self removeAllItem: fp selector: selector
-]
-
-{ #category : #class }
-TheManifestBuilder >> removeClasses: aCollection [
-	"Remove the selected classes from the system.  Check that the user really wants to do this, since it is not reversible.  Answer true if removal actually happened."
-
-	| classNames classesToRemove result |
-	aCollection isEmptyOrNil
-		ifTrue: [ ^ false ].
-	classesToRemove := aCollection collect: [:each | each instanceSide].
-	classNames := (classesToRemove collect: [:each | each name]) joinUsing: ', '.
-	(result := self confirm: (self removeClassesMessageFor: classNames))
-		ifTrue: [
-			classesToRemove
-				do: [ :classToRemove |
-					classToRemove subclasses notEmpty
-						ifTrue: [
-							(self confirm: (self removedClassHasSubclassesMessageFor: classToRemove name))
-								ifTrue: [ classToRemove removeFromSystem ] ]
-						ifFalse: [ classToRemove removeFromSystem ] ] ].
-	^ result
-]
-
-{ #category : #class }
-TheManifestBuilder >> removeClassesMessageFor: classNames [
-	^ 'Are you certain that you
-want to REMOVE the classes ' , classNames
-		,
-			'
-from the system?'
 ]
 
 { #category : #'adding-removing' }
@@ -610,13 +574,6 @@ TheManifestBuilder >> removeToDo: fp of: ruleId version: versionId [
 	| selector |
 	selector := self selectorToDoOf:ruleId version: versionId.
 	self removeItem: fp selector: selector
-]
-
-{ #category : #class }
-TheManifestBuilder >> removedClassHasSubclassesMessageFor: className [
-
-	^ className, ' has subclasses.
-Do you really want to REMOVE it from the system ?'
 ]
 
 { #category : #'adding-removing' }


### PR DESCRIPTION
remove the #removeClasses: methods, they are not needed as they are called  by removeAllManifest which is not used and makes no sense anymore