### PR TITLE
Inline ClassOrganization>>#removeElement: in ClassDescription

### DIFF
--- a/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
@@ -73,6 +73,22 @@ ClassDescriptionProtocolsTest >> testProtocolOfSelector [
 ]
 
 { #category : #tests }
+ClassDescriptionProtocolsTest >> testRemoveFromProtocols [
+
+	class organization classify: #amity under: #witch.
+	class organization classify: #edalyn under: #witch.
+	self assert: (class organization hasProtocol: #witch).
+	self assertCollection: (class organization protocolNamed: #witch) methodSelectors hasSameElements: #( #amity #edalyn ).
+
+	class removeFromProtocols: #amity.
+	self assert: (class organization hasProtocol: #witch).
+	self assertCollection: (class organization protocolNamed: #witch) methodSelectors hasSameElements: #( #edalyn ).
+
+	class removeFromProtocols: #edalyn.
+	self deny: (class organization hasProtocol: #witch)
+]
+
+{ #category : #tests }
 ClassDescriptionProtocolsTest >> testRemoveProtocol [
 
 	class organization addProtocol: #titan.

--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -204,28 +204,6 @@ ClassOrganizationTest >> testProtocolNamed [
 ]
 
 { #category : #tests }
-ClassOrganizationTest >> testProtocolNames [
-
-	self assertCollection: self organization protocolNames hasSameElements: #( #empty #one )
-]
-
-{ #category : #tests }
-ClassOrganizationTest >> testRemoveElement [
-
-	organization classify: #king under: #owl.
-	organization classify: #luz under: #owl.
-	self assert: (organization hasProtocol: #owl).
-	self assertCollection: (organization protocolNamed: #owl) methodSelectors hasSameElements: #( #king #luz ).
-
-	organization removeElement: #king.
-	self assert: (organization hasProtocol: #owl).
-	self assertCollection: (organization protocolNamed: #owl) methodSelectors hasSameElements: #( #luz ).
-
-	organization removeElement: #luz.
-	self deny: (organization hasProtocol: #owl)
-]
-
-{ #category : #tests }
 ClassOrganizationTest >> testRemoveNonexistentSelectorsFromProtocols [
 
 	class compiler

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -385,7 +385,7 @@ ClassDescription >> definitionStringFor: aConfiguredPrinter [
 	^ self subclassResponsibility
 ]
 
-{ #category : #'accessing - protocols' }
+{ #category : #protocols }
 ClassDescription >> ensureProtocol: aProtocol [
 	"I can take a Protocol or a protocol name as paramater.
 	
@@ -754,7 +754,7 @@ ClassDescription >> printOn: aStream [
 	aStream nextPutAll: self name
 ]
 
-{ #category : #'accessing - protocols' }
+{ #category : #protocols }
 ClassDescription >> protocolNameOfSelector: aSelector [
 	"Return the protocol name including the method of the same name as the selector.
 	If the class does not includes a method of this name, returns nil. Maybe this should be changed for an error in the future."
@@ -762,14 +762,14 @@ ClassDescription >> protocolNameOfSelector: aSelector [
 	^ (self protocolOfSelector: aSelector) ifNotNil: [ :protocol | protocol name ]
 ]
 
-{ #category : #'accessing - protocols' }
+{ #category : #protocols }
 ClassDescription >> protocolNames [
 	"Return the list of all the protocol names included in this class."
 
 	^ self organization protocolNames copy
 ]
 
-{ #category : #'accessing - protocols' }
+{ #category : #protocols }
 ClassDescription >> protocolOfSelector: aSelector [
 	"Return the protocol including the method of the same name as the selector.
 	If the class does not includes a method of this name, returns nil. Maybe this should be changed for an error in the future."
@@ -786,6 +786,15 @@ ClassDescription >> reformatAll [
 	self methods do: [ :method | method reformat ]
 ]
 
+{ #category : #protocols }
+ClassDescription >> removeFromProtocols: aSelector [
+
+	(self protocolOfSelector: aSelector) ifNotNil: [ :protocol |
+		protocol removeMethodSelector: aSelector.
+		self removeProtocolIfEmpty: protocol.
+		self notifyOfRecategorizedSelector: aSelector from: protocol to: nil ]
+]
+
 { #category : #'instance variables' }
 ClassDescription >> removeInstVarNamed: aString [
 	"Remove the argument, aString, as one of the receiver's instance variables."
@@ -793,7 +802,7 @@ ClassDescription >> removeInstVarNamed: aString [
 	^self removeSlot: (self slotNamed: aString)
 ]
 
-{ #category : #'accessing - protocols' }
+{ #category : #protocols }
 ClassDescription >> removeProtocol: aProtocol [
 	"Remove all methods present in the given protocol (or protocol name) and remove the protocol.
 	Does nothing if the protocol does not exists."
@@ -805,7 +814,7 @@ ClassDescription >> removeProtocol: aProtocol [
 		self removeProtocolIfEmpty: protocol ]
 ]
 
-{ #category : #'accessing - protocols' }
+{ #category : #protocols }
 ClassDescription >> removeProtocolIfEmpty: aProtocol [
 	"Remove a given protocol (the argument can also be a protocol name) if no method is present in it."
 
@@ -818,10 +827,10 @@ ClassDescription >> removeSelector: selector [
 	dictionary of the receiver, if it is there. Answer nil otherwise."
 
 	| priorMethod priorProtocol origin |
-	priorMethod := self compiledMethodAt: selector ifAbsent: [^ nil].
+	priorMethod := self compiledMethodAt: selector ifAbsent: [ ^ nil ].
 	origin := priorMethod origin.
 	priorProtocol := self protocolNameOfSelector: selector.
-	self organization removeElement: selector.
+	self removeFromProtocols: selector.
 
 	super removeSelector: selector.
 

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -173,11 +173,8 @@ ClassOrganization >> protocols [
 
 { #category : #removing }
 ClassOrganization >> removeElement: aSelector [
-
-	(self protocolOfSelector: aSelector) ifNotNil: [ :protocol |
-		protocol removeMethodSelector: aSelector.
-		self removeProtocolIfEmpty: protocol.
-		self organizedClass notifyOfRecategorizedSelector: aSelector from: protocol to: nil ]
+	self deprecated: 'Use #removeFromProtocols: from the organized class instead.' transformWith: '`@rcv removeElement: `@arg' -> '`@rcv organizedClass removeFromProtocols: `@arg'. 
+	^ self organizedClass removeFromProtocols: aSelector
 ]
 
 { #category : #removing }
@@ -193,7 +190,7 @@ ClassOrganization >> removeNonexistentSelectorsFromProtocols [
 
 	self allMethodSelectors
 		reject: [ :selector | self organizedClass includesSelector: selector ]
-		thenDo: [ :selector | self removeElement: selector ]
+		thenDo: [ :selector | self organizedClass removeFromProtocols: selector ]
 ]
 
 { #category : #removing }

--- a/src/TraitsV2/TraitChange.class.st
+++ b/src/TraitsV2/TraitChange.class.st
@@ -126,7 +126,7 @@ TraitChange >> remove: aSelector into: aClass changes: results [
 		priorProtocol := aClass protocolNameOfSelector: aSelector.
 
 		aClass methodDict removeKey: aSelector.
-		aClass organization removeElement: aSelector.
+		aClass removeFromProtocols: aSelector.
 
 		SystemAnnouncer uniqueInstance methodRemoved: priorMethod protocol: priorProtocol origin: aClass
 	].

--- a/src/TraitsV2/TraitedClass.class.st
+++ b/src/TraitsV2/TraitedClass.class.st
@@ -115,28 +115,24 @@ TraitedClass >> allTraits [
 
 { #category : #initialization }
 TraitedClass >> doRebuildMethodDictionary [
-	| selectors removedSelectors removeFromOrganization modified|
 
+	| selectors removedSelectors modified |
 	"During the creation of the class or after a change in the traitComposition, the whole method dictionary is calculated.
-	If I return true, my users should be updated"
-
-	"1. I recreate the local methodDict"
+	If I return true, my users should be updated""1. I recreate the local methodDict"
 	modified := false.
-	self methodDict valuesDo: [ :m | m traitSource ifNil: [ self localMethodDict at: m selector put: m ]].
+	self methodDict valuesDo: [ :m | m traitSource ifNil: [ self localMethodDict at: m selector put: m ] ].
 
 	"2. I filter the selectors from the trait composition, rejecting the ones that are locally defined.
 	And then I install the methods in myself. The trait composition only install the method if it is needed."
-	selectors := self traitComposition selectors reject: [ :e | (self localMethodDict includesKey: e) ].
-	selectors do: [ :e | modified := modified | (self traitComposition installSelector: e into: self replacing: false)].
+	selectors := self traitComposition selectors reject: [ :e | self localMethodDict includesKey: e ].
+	selectors do: [ :e | modified := modified | (self traitComposition installSelector: e into: self replacing: false) ].
 
 	"3. I handle the methods that I have and they are no more in the traitComposition."
-	removedSelectors := self methodDict keys reject: [ :aSelector | (selectors includes: aSelector) or: [ self localMethodDict includesKey: aSelector] ].
-	modified := modified | (removedSelectors isNotEmpty).
-	removedSelectors do: [ :aSelector | self methodDict removeKey: aSelector ].
-
-	"4. Finally, I remove these methods from my class organization"
-	removeFromOrganization := self organization allMethodSelectors reject: [:e | self methodDict includesKey: e ].
-	removeFromOrganization do: [ :aSelector | self organization removeElement: aSelector ].
+	removedSelectors := self methodDict keys reject: [ :aSelector | (selectors includes: aSelector) or: [ self localMethodDict includesKey: aSelector ] ].
+	modified := modified | removedSelectors isNotEmpty.
+	removedSelectors do: [ :aSelector |
+		self methodDict removeKey: aSelector.
+		self removeFromProtocols: aSelector ].
 
 	^ modified
 ]

--- a/src/TraitsV2/TraitedMetaclass.class.st
+++ b/src/TraitsV2/TraitedMetaclass.class.st
@@ -261,8 +261,9 @@ TraitedMetaclass >> rebuildMethodDictionary [
 
 	removedSelectors := self methodDict keys reject: [ :aSelector | (selectors includes: aSelector) or: [ self isSelectorToKeep: aSelector ] ].
 	modified := modified | (removedSelectors isNotEmpty).
-	removedSelectors do: [ :aSelector | self methodDict removeKey: aSelector ].
-	removedSelectors do: [ :aSelector | self organization removeElement: aSelector ].
+	removedSelectors do: [ :aSelector |
+		self methodDict removeKey: aSelector.
+		self removeFromProtocols: aSelector  ].
 
 	^ modified
 ]


### PR DESCRIPTION
Inline ClassOrganization>>#removeElement: in ClassDescription.

Since the name is not really explicit I renamed it #removeFromProtocols: in class description.

I also improved a little some of the methods calling this one.

The removal of #testProtocolNames is done because there is now a better version in ClassDescriptionProtocolsTest and we don't need this duplication of tests