### PR TITLE
Diver cleanings around protocols

### DIFF
--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -804,8 +804,8 @@ CompiledMethod >> protocol [
 ]
 
 { #category : #accessing }
-CompiledMethod >> protocol: aString [
-	^ self methodClass organization classify: self selector under: aString
+CompiledMethod >> protocol: aProtocol [
+	^ self methodClass organization classify: self selector under: aProtocol
 ]
 
 { #category : #scanning }

--- a/src/System-Announcements/ProtocolAnnouncement.class.st
+++ b/src/System-Announcements/ProtocolAnnouncement.class.st
@@ -12,11 +12,11 @@ Class {
 }
 
 { #category : #'class initialization' }
-ProtocolAnnouncement class >> in: aClass protocol: aProtocolName [
+ProtocolAnnouncement class >> in: aClass protocol: aProtocol [
 
 	^ self new
 		  classReorganized: aClass;
-		  protocol: aProtocolName;
+		  protocol: aProtocol;
 		  yourself
 ]
 

--- a/src/System-Announcements/ProtocolRenamed.class.st
+++ b/src/System-Announcements/ProtocolRenamed.class.st
@@ -46,7 +46,7 @@ ProtocolRenamed >> oldProtocol [
 ]
 
 { #category : #accessing }
-ProtocolRenamed >> oldProtocol: aString [
+ProtocolRenamed >> oldProtocol: aProtocol [
 
-	self protocol: aString
+	self protocol: aProtocol
 ]

--- a/src/TraitsV2-Compatibility/TraitMethodDescription.class.st
+++ b/src/TraitsV2-Compatibility/TraitMethodDescription.class.st
@@ -50,31 +50,6 @@ TraitMethodDescription >> conflictMethod [
 		binary: binary
 ]
 
-{ #category : #accessing }
-TraitMethodDescription >> effectiveMethodCategory [
-	^ self effectiveMethodCategoryCurrent: nil new: nil
-]
-
-{ #category : #accessing }
-TraitMethodDescription >> effectiveMethodCategoryCurrent: currentCategoryOrNil new: newCategoryOrNil [
-	| result size isCurrent isConflict |
-	size := self size.
-	size = 0 ifTrue: [^ nil].
-	result := self locatedMethods anyOne category.
-	size = 1 ifTrue: [^ result].
-
-	isCurrent := currentCategoryOrNil isNil.
-	isConflict := false.
-	self locatedMethods do: [:each | | cat |
-		cat := each category.
-		isCurrent := isCurrent or: [cat == currentCategoryOrNil].
-		isConflict := isConflict or: [cat ~~ result]].
-	isConflict ifFalse: [^ result].
-	(isCurrent not and: [newCategoryOrNil notNil]) ifTrue: [^ newCategoryOrNil].
-
-	^ Protocol traitConflictName
-]
-
 { #category : #private }
 TraitMethodDescription >> generateMethod: aSelector withMarker: aSymbol forArgs: aNumber binary: aBoolean [
 	| source keywords method |

--- a/src/TraitsV2/TaAbstractComposition.class.st
+++ b/src/TraitsV2/TaAbstractComposition.class.st
@@ -112,15 +112,6 @@ TaAbstractComposition >> asTraitComposition [
 	^ self
 ]
 
-{ #category : #accessing }
-TaAbstractComposition >> categoryOfMethod: method withSelector: selector [
-	"I return the protocol of the method with the selector.
-	This is useful when the method is aliased or the method came from different traits or it is a conflicting protocol.
-	The basic implementation returns the protocol of the method"
-
-	^ method protocol
-]
-
 { #category : #testing }
 TaAbstractComposition >> changesSourceCode: aSelector [
 	"Checks if a selector should be compiled because its code has been rewritten."
@@ -143,7 +134,7 @@ TaAbstractComposition >> compile: selector into: aClass [
 
 	method := self compiledMethodAt: selector.
 	sourceCode := self sourceCodeAt: selector.
-	
+
 	newMethod := aClass compiler
 		             source: sourceCode;
 		             permitUndeclared: true;
@@ -155,7 +146,7 @@ TaAbstractComposition >> compile: selector into: aClass [
 		ifTrue: [ self saveSourceCode: sourceCode ofMethod: newMethod ]
 		ifFalse: [ newMethod setSourcePointer: method sourcePointer ].
 
-	aClass organization classify: selector under: (self categoryOfMethod: method withSelector: method selector).
+	aClass organization classify: selector under: (self protocolForMethod: method).
 
 	aClass addSelectorSilently: selector withMethod: newMethod.
 
@@ -371,6 +362,15 @@ TaAbstractComposition >> originSelectorOf: aSelector [
 TaAbstractComposition >> printOn: aStream [
 
 	aStream nextPutAll: self traitCompositionExpression
+]
+
+{ #category : #accessing }
+TaAbstractComposition >> protocolForMethod: method [
+	"I return the protocol of the method given as parameter.
+	This is useful when the method is aliased or the method came from different traits or it is a conflicting protocol.
+	The basic implementation returns the protocol of the method"
+
+	^ method protocol
 ]
 
 { #category : #querying }

--- a/src/TraitsV2/TaSequence.class.st
+++ b/src/TraitsV2/TaSequence.class.st
@@ -83,19 +83,6 @@ TaSequence >> allTraits [
 	^ members flatCollect: #allTraits
 ]
 
-{ #category : #accessing }
-TaSequence >> categoryOfMethod: aMethod withSelector: selector [
-
-	| protocols |
-	protocols := (self methods
-		              select: [ :method | method selector = selector ]
-		              thenCollect: #protocol) asSet.
-
-	^ protocols size = 1
-		  ifTrue: [ protocols anyOne ]
-		  ifFalse: [ Protocol traitConflictName ]
-]
-
 { #category : #testing }
 TaSequence >> changesSourceCode: aSelector [
 	"If the selector has conflicts it should be recompiled"
@@ -199,6 +186,21 @@ TaSequence >> name [
 TaSequence >> originSelectorOf: aSelector [
 
 	^ (self traitDefining: aSelector ifNone: [ ^aSelector ]) originSelectorOf: aSelector
+]
+
+{ #category : #accessing }
+TaSequence >> protocolForMethod: aMethod [
+
+	| protocols originalSelector |
+	originalSelector := aMethod selector.
+	protocols := (self methods
+		              select: [ :method | method selector = originalSelector ]
+		              thenCollect: #protocol) asSet.
+
+	"If we have more than a protocol, for example if there is an alias or if multiple traits have the same method, we return a conflicting protocol name."
+	^ protocols size = 1
+		  ifTrue: [ protocols anyOne ]
+		  ifFalse: [ Protocol traitConflictName ]
 ]
 
 { #category : #users }


### PR DESCRIPTION
- Rename some variables to have better names
- #effectiveMethodCategory is dead code and I removed it
- Rename #categoryOfMethod:withSelector: into #protocolForMethod: (and removed useless parameter)