### PR TITLE
Inline protocol removal from ClassOrganization

### DIFF
--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -151,8 +151,8 @@ BaselineOfMorphic >> cleanUpAfterMorphicInitialization [
 	"Remove empty packages and protocols"
 	Smalltalk organization removeEmptyPackages.
 	Smalltalk allClassesAndTraitsDo: [ :class |
-		class organization removeEmptyProtocols.
-    class class organization removeEmptyProtocols  ].
+		class removeEmptyProtocols.
+		class class removeEmptyProtocols  ].
   
 	ChangeSet removeChangeSetsNamedSuchThat: [ :each | true ].
 	ChangeSet resetCurrentToNewUnnamedChangeSet.

--- a/src/Deprecated12/ClassOrganization.extension.st
+++ b/src/Deprecated12/ClassOrganization.extension.st
@@ -137,8 +137,8 @@ ClassOrganization >> removeCategory: protocolName [
 { #category : #'*Deprecated12' }
 ClassOrganization >> removeEmptyCategories [
 
-	self deprecated: 'Use #removeEmptyProtocols instead.' transformWith: '`@rcv removeEmptyCategories' -> '`@rcv removeEmptyProtocols'.
-	self removeEmptyProtocols
+	self deprecated: 'Use #removeEmptyProtocols on the organized class instead.' transformWith: '`@rcv removeEmptyCategories' -> '`@rcv organizedClass removeEmptyProtocols'.
+	self organizedClass removeEmptyProtocols
 ]
 
 { #category : #'*Deprecated12' }

--- a/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
@@ -103,7 +103,7 @@ ClassDescriptionProtocolsTest >> testRemoveNonexistentSelectorsFromProtocols [
 		protocol: #titan;
 		install: 'king ^ 2'.
 
-	class organization removeEmptyProtocols.
+	class removeEmptyProtocols.
 
 	self assertCollection: class protocolNames hasSameElements: #( human titan ).
 	self assertCollection: (class organization protocolNamed: #human) methodSelectors hasSameElements: #( luz camila ).

--- a/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
@@ -89,6 +89,37 @@ ClassDescriptionProtocolsTest >> testRemoveFromProtocols [
 ]
 
 { #category : #tests }
+ClassDescriptionProtocolsTest >> testRemoveNonexistentSelectorsFromProtocols [
+
+	class compiler
+		protocol: #human;
+		install: 'luz ^ 1'.
+
+	class compiler
+		protocol: #human;
+		install: 'camila ^ 1'.
+
+	class compiler
+		protocol: #titan;
+		install: 'king ^ 2'.
+
+	class organization removeEmptyProtocols.
+
+	self assertCollection: class protocolNames hasSameElements: #( human titan ).
+	self assertCollection: (class organization protocolNamed: #human) methodSelectors hasSameElements: #( luz camila ).
+	self assertCollection: (class organization protocolNamed: #titan) methodSelectors hasSameElements: #( king ).
+
+	"Now that we asserted the actual state is good, we can test the actual method."
+	class methodDict
+		removeKey: #camila;
+		removeKey: #king.
+	class removeNonexistentSelectorsFromProtocols.
+
+	self assertCollection: class protocolNames hasSameElements: #( human ).
+	self assertCollection: (class organization protocolNamed: #human) methodSelectors hasSameElements: #( luz )
+]
+
+{ #category : #tests }
 ClassDescriptionProtocolsTest >> testRemoveProtocol [
 
 	class organization addProtocol: #titan.

--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -204,37 +204,6 @@ ClassOrganizationTest >> testProtocolNamed [
 ]
 
 { #category : #tests }
-ClassOrganizationTest >> testRemoveNonexistentSelectorsFromProtocols [
-
-	class compiler
-		protocol: #one;
-		install: 'one 1'.
-
-	class compiler
-		protocol: #one;
-		install: 'oneBis 1'.
-
-	class compiler
-		protocol: #two;
-		install: 'two 2'.
-
-	organization removeEmptyProtocols.
-
-	self assertCollection: organization protocolNames hasSameElements: #( one two ).
-	self assertCollection: (organization protocolNamed: #one) methodSelectors hasSameElements: #( one oneBis ).
-	self assertCollection: (organization protocolNamed: #two) methodSelectors hasSameElements: #( two ).
-
-	"Now that we asserted the actual state is good, we can test the actual method."
-	class methodDict
-		removeKey: #oneBis;
-		removeKey: #two.
-	organization removeNonexistentSelectorsFromProtocols.
-
-	self assertCollection: organization protocolNames hasSameElements: #( one ).
-	self assertCollection: (organization protocolNamed: #one) methodSelectors hasSameElements: #( one )
-]
-
-{ #category : #tests }
 ClassOrganizationTest >> testRenameProtocolAs [
 
 	self assert: (self organization hasProtocol: #one).

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -803,6 +803,15 @@ ClassDescription >> removeInstVarNamed: aString [
 ]
 
 { #category : #protocols }
+ClassDescription >> removeNonexistentSelectorsFromProtocols [
+	"For each protocol, remove the selectors that are not present in the class."
+
+	self organization allMethodSelectors
+		reject: [ :selector | self includesSelector: selector ]
+		thenDo: [ :selector | self removeFromProtocols: selector ]
+]
+
+{ #category : #protocols }
 ClassDescription >> removeProtocol: aProtocol [
 	"Remove all methods present in the given protocol (or protocol name) and remove the protocol.
 	Does nothing if the protocol does not exists."

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -787,6 +787,13 @@ ClassDescription >> reformatAll [
 ]
 
 { #category : #protocols }
+ClassDescription >> removeEmptyProtocols [
+
+	"We copy protocols because it is usually bad to remove elements of a collection while iterating on it"
+	self protocols copy do: [ :protocol | self removeProtocolIfEmpty: protocol ]
+]
+
+{ #category : #protocols }
 ClassDescription >> removeFromProtocols: aSelector [
 
 	(self protocolOfSelector: aSelector) ifNotNil: [ :protocol |

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -177,13 +177,6 @@ ClassOrganization >> removeElement: aSelector [
 	^ self organizedClass removeFromProtocols: aSelector
 ]
 
-{ #category : #removing }
-ClassOrganization >> removeEmptyProtocols [
-
-	"We copy protocols because it is usually bad to remove elements of a collection while iterating on it"
-	self protocols copy do: [ :protocol | self removeProtocolIfEmpty: protocol ]
-]
-
 { #category : #inlined }
 ClassOrganization >> removeProtocolIfEmpty: aProtocol [
 	"I take a protocol or a protocol name and remvoe it if it is empty."

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -153,13 +153,13 @@ ClassOrganization >> protocolNamed: aString ifAbsent: aBlock [
 		  ifNone: aBlock
 ]
 
-{ #category : #accessing }
+{ #category : #inlined }
 ClassOrganization >> protocolNames [
 
 	^ self protocols collect: [ :protocol | protocol name ]
 ]
 
-{ #category : #protocol }
+{ #category : #inlined }
 ClassOrganization >> protocolOfSelector: aSelector [
 
 	^ self organizedClass protocolOfSelector: aSelector
@@ -171,7 +171,7 @@ ClassOrganization >> protocols [
 	^ protocols
 ]
 
-{ #category : #removing }
+{ #category : #inlined }
 ClassOrganization >> removeElement: aSelector [
 	self deprecated: 'Use #removeFromProtocols: from the organized class instead.' transformWith: '`@rcv removeElement: `@arg' -> '`@rcv organizedClass removeFromProtocols: `@arg'. 
 	^ self organizedClass removeFromProtocols: aSelector
@@ -184,16 +184,7 @@ ClassOrganization >> removeEmptyProtocols [
 	self protocols copy do: [ :protocol | self removeProtocolIfEmpty: protocol ]
 ]
 
-{ #category : #cleanup }
-ClassOrganization >> removeNonexistentSelectorsFromProtocols [
-	"For each protocol, remove the selectors that are not present in the class."
-
-	self allMethodSelectors
-		reject: [ :selector | self organizedClass includesSelector: selector ]
-		thenDo: [ :selector | self organizedClass removeFromProtocols: selector ]
-]
-
-{ #category : #removing }
+{ #category : #inlined }
 ClassOrganization >> removeProtocolIfEmpty: aProtocol [
 	"I take a protocol or a protocol name and remvoe it if it is empty."
 

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -201,8 +201,9 @@ ShiftClassBuilder >> compareWithOldClass [
 { #category : #compiling }
 ShiftClassBuilder >> compileMethods [
 
-	newClass compileAllFrom: self oldClass.
-	newClass organization removeNonexistentSelectorsFromProtocols
+	newClass
+		compileAllFrom: self oldClass;
+		removeNonexistentSelectorsFromProtocols
 ]
 
 { #category : #building }

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1530,7 +1530,7 @@ SmalltalkImage >> removeEmptyMessageCategories [
 	"Smalltalk removeEmptyMessageCategories"
 
 	self garbageCollect.
-	ClassOrganization allInstancesDo: [ :org | org removeEmptyProtocols ].
+	SystemNavigation default allBehaviorsDo: [ :class | class removeEmptyProtocols ].
 	Smalltalk organization removeEmptyPackages
 ]
 

--- a/src/SystemCommands-ClassCommands/SycRemoveEmptyMethodTagsCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycRemoveEmptyMethodTagsCommand.class.st
@@ -20,7 +20,7 @@ SycRemoveEmptyMethodTagsCommand >> defaultMenuItemName [
 { #category : #execution }
 SycRemoveEmptyMethodTagsCommand >> execute [
 
-	classes do: [ :each | each organization removeEmptyProtocols ]
+	classes do: [ :class | class removeEmptyProtocols ]
 ]
 
 { #category : #execution }

--- a/src/SystemCommands-MethodCommands/SycMoveMethodsToClassCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMoveMethodsToClassCommand.class.st
@@ -37,7 +37,7 @@ SycMoveMethodsToClassCommand >> execute [
 	methods
 		collect: [ :each | RBMoveMethodToClassRefactoring model: model method: each class: targetClass ]
 		thenDo: [ :each | each execute ].
-	methods do: [ :each | each origin organization removeEmptyProtocols ]
+	methods do: [ :each | each origin removeEmptyProtocols ]
 ]
 
 { #category : #'drag and drop support' }

--- a/src/SystemCommands-MethodCommands/SycMoveMethodsToPackageCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMoveMethodsToPackageCommand.class.st
@@ -38,7 +38,7 @@ SycMoveMethodsToPackageCommand >> execute [
 
 	methods do: [ :each |
 		self moveMethod: each toPackage: package.
-		each origin organization removeEmptyProtocols ]
+		each origin removeEmptyProtocols ]
 ]
 
 { #category : #accessing }

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -213,8 +213,8 @@ ImageCleaner >> removeEmptyCategories [
 
 	Smalltalk organization removeEmptyPackages.
 	Smalltalk allClassesAndTraitsDo: [ :class |
-		class organization removeEmptyProtocols.
-		class class organization removeEmptyProtocols ]
+		class removeEmptyProtocols.
+		class class removeEmptyProtocols ]
 ]
 
 { #category : #cleaning }

--- a/src/TraitsV2/TraitBuilderEnhancer.class.st
+++ b/src/TraitsV2/TraitBuilderEnhancer.class.st
@@ -35,8 +35,8 @@ TraitBuilderEnhancer class >> isApplicableFor: aBuilder [
 TraitBuilderEnhancer >> afterMethodsCompiled: aBuilder [
 	"we need to remove the categories leftover after removing Traits"
 
-	aBuilder newClass organization removeNonexistentSelectorsFromProtocols.
-	aBuilder newClass class organization removeNonexistentSelectorsFromProtocols.
+	aBuilder newClass removeNonexistentSelectorsFromProtocols.
+	aBuilder newClass class removeNonexistentSelectorsFromProtocols.
 
 	(self isTraitedMetaclass: aBuilder) ifFalse: [ ^ self ].
 


### PR DESCRIPTION
Inline form ClassOrganization to ClassDescription the methods #removeEmptyProtocols and #removeNonexistentSelectorsFromProtocols