### PR TITLE
update-dependencies

### DIFF
--- a/src/Collections-Tests/ManifestCollectionsTests.class.st
+++ b/src/Collections-Tests/ManifestCollectionsTests.class.st
@@ -12,11 +12,6 @@ ManifestCollectionsTests class >> dependencies [
 	^ #(#'Collections-Streams' #'System-Finalization' #'Collections-Native' #'Collections-Abstract' #'Collections-Weak' #'Collections-Stack' #'Collections-Strings' #'Collections-Sequenceable' #'SUnit-Core' #Kernel #'Graphics-Primitives' #'Collections-Support' #'Collections-Unordered' #'System-Support' #'Collections-Atomic' #'Multilingual-Encodings')
 ]
 
-{ #category : #'meta-data - dependency analyser' }
-ManifestCollectionsTests class >> manuallyResolvedDependencies [
-	^ #(#'Math-Operations-Extensions')
-]
-
 { #category : #'meta-data' }
 ManifestCollectionsTests class >> packageName [
 	^ #CollectionsTests

--- a/src/Kernel/ManifestKernel.class.st
+++ b/src/Kernel/ManifestKernel.class.st
@@ -19,7 +19,7 @@ ManifestKernel class >> ignoredDependencies [
 
 { #category : #'meta-data - dependency analyser' }
 ManifestKernel class >> manuallyResolvedDependencies [
-	^ #(#'System-Settings-Core' #'System-Sources' #'System-Platforms' #'Shift-ClassBuilder' #'Regex-Core' #'RPackage-Core' #'Zinc-Character-Encoding-Core' #Reflectivity #'Shift-ClassInstaller')
+	^ #(#'System-Settings-Core' #'System-Sources' #'System-Platforms' #'Shift-ClassBuilder' #'Regex-Core' #'RPackage-Core' #Reflectivity #'Shift-ClassInstaller')
 ]
 
 { #category : #'meta-data' }


### PR DESCRIPTION
on the ci we see

```
*** Warning: DAPotentialOutDatedDependencyWarning: Collections-Tests: Math-Operations-Extensions dependency declared in the package Manifest as manuallyResolvedDependencies not detected as a dependency!

DAPotentialOutDatedDependencyWarning: Kernel: Zinc-Character-Encoding-Core dependency declared in the package Manifest as manuallyResolvedDependencies not detected as a dependency!
```

This pr tries to fix those