### PR TITLE
Fix #13478: Method search now only applies to selector

### DIFF
--- a/src/Calypso-Browser/ClyQueryViewMorph.class.st
+++ b/src/Calypso-Browser/ClyQueryViewMorph.class.st
@@ -343,7 +343,11 @@ ClyQueryViewMorph >> enableFilter: anItemStringFilterClass using: aStringPattern
 { #category : #controlling }
 ClyQueryViewMorph >> enableFilterUsing: aStringPattern [
 
-	self enableFilter: ClyItemNameFilter using: aStringPattern
+	self
+		enableFilter: (selection rootDataSource query isMethodQuery
+				 ifTrue: [ ClyItemSelectorFilter ]
+				 ifFalse: [ ClyItemNameFilter ])
+		using: aStringPattern
 ]
 
 { #category : #controlling }

--- a/src/Calypso-NavigationModel/ClyCompositeQuery.class.st
+++ b/src/Calypso-NavigationModel/ClyCompositeQuery.class.st
@@ -99,6 +99,12 @@ ClyCompositeQuery >> hash [
 	^super hash bitXor: subqueries hash
 ]
 
+{ #category : #testing }
+ClyCompositeQuery >> isMethodQuery [
+
+	^ subqueries allSatisfy: #isMethodQuery
+]
+
 { #category : #'system changes' }
 ClyCompositeQuery >> isResult: aQueryResult affectedBy: aSystemAnnouncement [
 

--- a/src/Calypso-NavigationModel/ClyItemNameFilter.class.st
+++ b/src/Calypso-NavigationModel/ClyItemNameFilter.class.st
@@ -1,7 +1,7 @@
 "
 I filter objects by name using given string filter.
 
-So I am compatible with objects which respond to the #name
+So I am compatible with objects which respond to #name.
 "
 Class {
 	#name : #ClyItemNameFilter,

--- a/src/Calypso-NavigationModel/ClyItemSelectorFilter.class.st
+++ b/src/Calypso-NavigationModel/ClyItemSelectorFilter.class.st
@@ -1,0 +1,16 @@
+"
+I filter objects by their selector using given string filter.
+
+So I am compatible with objects which respond to #selector.
+"
+Class {
+	#name : #ClyItemSelectorFilter,
+	#superclass : #ClyItemStringFilter,
+	#category : #'Calypso-NavigationModel-Model'
+}
+
+{ #category : #testing }
+ClyItemSelectorFilter >> matches: anEnvironmentItem [
+
+	^ pattern matches: anEnvironmentItem selector
+]

--- a/src/Calypso-NavigationModel/ClyQuery.class.st
+++ b/src/Calypso-NavigationModel/ClyQuery.class.st
@@ -308,6 +308,12 @@ ClyQuery >> isExecutedFromSingleScope [
 	^scope isBasedOnSingleBasis
 ]
 
+{ #category : #testing }
+ClyQuery >> isMethodQuery [
+
+	^ false
+]
+
 { #category : #'system changes' }
 ClyQuery >> isResult: aQueryResult affectedBy: aSystemAnnouncement [
 

--- a/src/Calypso-SystemQueries/ClyMethodQuery.class.st
+++ b/src/Calypso-SystemQueries/ClyMethodQuery.class.st
@@ -47,6 +47,12 @@ ClyMethodQuery >> isAffectedByChangedMethod: aMethod [
 	^self selectsMethod: aMethod
 ]
 
+{ #category : #testing }
+ClyMethodQuery >> isMethodQuery [
+
+	^ true
+]
+
 { #category : #'system changes' }
 ClyMethodQuery >> isResult: aQueryResult affectedBy: aSystemAnnouncement [
 


### PR DESCRIPTION
The issue was that the query was using `ClyItemNameFilter` which sends `name` to a `CompiledMethod`, which returns something like `MyClass>>mySelector`.
This fix proposes to add `ClyItemSelectorFilter` specialized for methods (and possibly other items?) that only ask for the `selector`.
To determine which to use, the `isMethodQuery` testing method is added to the `ClyQuery` hierarchy, and `ClyQueryViewMorph>>#enableFilterUsing:` is modified to use it to make the choice.