### PR TITLE
Clean the way to get the selectors in a protocol

### DIFF
--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -190,7 +190,7 @@ RBMessageNode >> isHaltNode [
 		   includes: self selector) or: [
 		  self receiver isGlobalVariable and: [
 			  self receiver variable value = Halt and: [
-				  (Halt class selectorsInCategory: #halting) includes:
+				  (Halt class selectorsInProtocol: #halting) includes:
 					  self selector ] ] ]
 ]
 

--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -186,12 +186,8 @@ RBMessageNode >> isFirstCascaded [
 { #category : #testing }
 RBMessageNode >> isHaltNode [
 
-	^ (#( #halt #halt: #haltIf: #haltOnce #haltIfNil #haltOnCount: )
-		   includes: self selector) or: [
-		  self receiver isGlobalVariable and: [
-			  self receiver variable value = Halt and: [
-				  (Halt class selectorsInProtocol: #halting) includes:
-					  self selector ] ] ]
+	^ (#( #halt #halt: #haltIf: #haltOnce #haltIfNil #haltOnCount: ) includes: self selector) or: [
+		  self receiver isGlobalVariable and: [ self receiver variable value = Halt and: [ (Halt class selectorsInProtocol: #halting) includes: self selector ] ] ]
 ]
 
 { #category : #testing }

--- a/src/Collections-Sequenceable-Tests/OrderedDictionaryTest.class.st
+++ b/src/Collections-Sequenceable-Tests/OrderedDictionaryTest.class.st
@@ -742,7 +742,7 @@ OrderedDictionaryTest >> testDictionaryPublicProtocolCompatibility [
 		(dictionary -> Dictionary).
 		(dictionary class -> Dictionary class) } do: [ :assoc |
 		assoc value protocolNames
-			reject: [ :protocol | #( 'private' 'print' 'undeclared' 'copy' 'compar' '*' ) anySatisfy: [ :each | protocol asString beginsWith: each ] ]
+			reject: [ :protocol | #( 'private' 'print' 'undeclared' 'copy' 'compar' '*' ) anySatisfy: [ :each | protocol beginsWith: each ] ]
 			thenDo: [ :protocol | (assoc value selectorsInProtocol: protocol) do: [ :each | self assert: (assoc key respondsTo: each) ] ] ]
 ]
 

--- a/src/Deprecated12/ClassDescription.extension.st
+++ b/src/Deprecated12/ClassDescription.extension.st
@@ -92,7 +92,7 @@ ClassDescription >> copyCategory: protocolName from: aClass classified: newProto
 
 	self deprecated: 'This method will be removed in the next version of Pharo.'.
 
-	self copyAll: (aClass organization methodSelectorsInProtocol: protocolName) from: aClass classified: newProtocolName
+	self copyAll: (aClass methodSelectorsInProtocol: protocolName) from: aClass classified: newProtocolName
 ]
 
 { #category : #'*Deprecated12' }

--- a/src/Deprecated12/ClassDescription.extension.st
+++ b/src/Deprecated12/ClassDescription.extension.st
@@ -92,7 +92,7 @@ ClassDescription >> copyCategory: protocolName from: aClass classified: newProto
 
 	self deprecated: 'This method will be removed in the next version of Pharo.'.
 
-	self copyAll: (aClass methodSelectorsInProtocol: protocolName) from: aClass classified: newProtocolName
+	self copyAll: (aClass selectorsInProtocol: protocolName) from: aClass classified: newProtocolName
 ]
 
 { #category : #'*Deprecated12' }

--- a/src/Deprecated12/ClassOrganization.extension.st
+++ b/src/Deprecated12/ClassOrganization.extension.st
@@ -123,8 +123,8 @@ ClassOrganization >> hasComment [
 { #category : #'*Deprecated12' }
 ClassOrganization >> listAtCategoryNamed: aName [
 
-	self deprecated: 'Use #methodsInProtocolNamed: on organized class instead.' transformWith: '`@rcv listAtCategoryNamed: `@arg' -> '`@rcv organizedClass methodSelectorsInProtocol: `@arg'.
-	^ self organizedClass methodSelectorsInProtocol: aName
+	self deprecated: 'Use #selectorsInProtocol: on organized class instead.' transformWith: '`@rcv listAtCategoryNamed: `@arg' -> '`@rcv organizedClass selectorsInProtocol: `@arg'.
+	^ self organizedClass selectorsInProtocol: aName
 ]
 
 { #category : #'*Deprecated12' }

--- a/src/Deprecated12/ClassOrganization.extension.st
+++ b/src/Deprecated12/ClassOrganization.extension.st
@@ -123,8 +123,8 @@ ClassOrganization >> hasComment [
 { #category : #'*Deprecated12' }
 ClassOrganization >> listAtCategoryNamed: aName [
 
-	self deprecated: 'Use #methodsInProtocolNamed: instead.' transformWith: '`@rcv listAtCategoryNamed: `@arg' -> '`@rcv methodSelectorsInProtocol: `@arg'.
-	^ self methodSelectorsInProtocol: aName
+	self deprecated: 'Use #methodsInProtocolNamed: on organized class instead.' transformWith: '`@rcv listAtCategoryNamed: `@arg' -> '`@rcv organizedClass methodSelectorsInProtocol: `@arg'.
+	^ self organizedClass methodSelectorsInProtocol: aName
 ]
 
 { #category : #'*Deprecated12' }

--- a/src/EpiceaBrowsers/EpHasImpactVisitor.class.st
+++ b/src/EpiceaBrowsers/EpHasImpactVisitor.class.st
@@ -166,7 +166,7 @@ EpHasImpactVisitor >> visitProtocolRemoval: aProtocolRemoved [
 
 	self behaviorNamed: aProtocolRemoved behaviorAffectedName ifPresent: [ :behavior |
 		(behavior organization hasProtocol: aProtocolRemoved) ifFalse: [ ^ false ].
-		((behavior selectorsInProtocol: aProtocolRemoved) allSatisfy: [ :each | (behavior compiledMethodAt: each) isFromTrait ]) ifTrue: [ ^ false ] ].
+		((behavior methodsInProtocol: aProtocolRemoved) allSatisfy: [ :method | method isFromTrait ]) ifTrue: [ ^ false ] ].
 
 	^ true
 ]

--- a/src/EpiceaBrowsers/EpHasImpactVisitor.class.st
+++ b/src/EpiceaBrowsers/EpHasImpactVisitor.class.st
@@ -165,9 +165,8 @@ EpHasImpactVisitor >> visitProtocolRemoval: aProtocolRemoved [
 	- there are methods in the protocol that are not trait methods"
 
 	self behaviorNamed: aProtocolRemoved behaviorAffectedName ifPresent: [ :behavior |
-		| selectors |
-		selectors := (behavior organization protocolNamed: aProtocolRemoved protocol ifAbsent: [ ^ false ]) methodSelectors.
-		(selectors allSatisfy: [ :each | (behavior compiledMethodAt: each) isFromTrait ]) ifTrue: [ ^ false ] ].
+		(behavior organization hasProtocol: aProtocolRemoved) ifFalse: [ ^ false ].
+		((behavior selectorsInProtocol: aProtocolRemoved) allSatisfy: [ :each | (behavior compiledMethodAt: each) isFromTrait ]) ifTrue: [ ^ false ] ].
 
 	^ true
 ]

--- a/src/EpiceaBrowsers/EpHasImpactVisitor.class.st
+++ b/src/EpiceaBrowsers/EpHasImpactVisitor.class.st
@@ -165,8 +165,8 @@ EpHasImpactVisitor >> visitProtocolRemoval: aProtocolRemoved [
 	- there are methods in the protocol that are not trait methods"
 
 	self behaviorNamed: aProtocolRemoved behaviorAffectedName ifPresent: [ :behavior |
-		(behavior organization hasProtocol: aProtocolRemoved) ifFalse: [ ^ false ].
-		((behavior methodsInProtocol: aProtocolRemoved) allSatisfy: [ :method | method isFromTrait ]) ifTrue: [ ^ false ] ].
+		(behavior organization hasProtocol: aProtocolRemoved protocol) ifFalse: [ ^ false ].
+		((behavior methodsInProtocol: aProtocolRemoved protocol) allSatisfy: [ :method | method isFromTrait ]) ifTrue: [ ^ false ] ].
 
 	^ true
 ]

--- a/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
@@ -78,11 +78,11 @@ ClassDescriptionProtocolsTest >> testRemoveFromProtocols [
 	class organization classify: #amity under: #witch.
 	class organization classify: #edalyn under: #witch.
 	self assert: (class organization hasProtocol: #witch).
-	self assertCollection: (class organization protocolNamed: #witch) methodSelectors hasSameElements: #( #amity #edalyn ).
+	self assertCollection: (class selectorsInProtocol: #witch) hasSameElements: #( #amity #edalyn ).
 
 	class removeFromProtocols: #amity.
 	self assert: (class organization hasProtocol: #witch).
-	self assertCollection: (class organization protocolNamed: #witch) methodSelectors hasSameElements: #( #edalyn ).
+	self assertCollection: (class selectorsInProtocol: #witch) hasSameElements: #( #edalyn ).
 
 	class removeFromProtocols: #edalyn.
 	self deny: (class organization hasProtocol: #witch)
@@ -98,7 +98,7 @@ ClassDescriptionProtocolsTest >> testRemoveProtocol [
 		protocol: #titan;
 		install: 'king ^1'.
 	self assert: class protocolNames size equals: 3.
-	self assertCollection: (class organization protocolNamed: #titan) methodSelectors hasSameElements: #( #king ).
+	self assertCollection: (class selectorsInProtocol: #titan) hasSameElements: #( #king ).
 
 	class removeProtocol: #human.
 	self assert: class protocolNames size equals: 2.
@@ -120,7 +120,7 @@ ClassDescriptionProtocolsTest >> testRemoveProtocolIfEmpty [
 		protocol: #titan;
 		install: 'king ^1'.
 	self assert: class protocolNames size equals: 3.
-	self assertCollection: (class organization protocolNamed: #titan) methodSelectors hasSameElements: #( #king ).
+	self assertCollection: (class selectorsInProtocol: #titan) hasSameElements: #( #king ).
 
 	"just ignore removing of non empty categories"
 	class removeProtocolIfEmpty: #titan.
@@ -148,7 +148,7 @@ ClassDescriptionProtocolsTest >> testRemoveProtocolIfEmptyWithRealProtocol [
 		protocol: #titan;
 		install: 'king ^1'.
 	self assert: class protocolNames size equals: 3.
-	self assertCollection: (class organization protocolNamed: #titan) methodSelectors hasSameElements: #( #king ).
+	self assertCollection: (class selectorsInProtocol: #titan) hasSameElements: #( #king ).
 
 	"just ignore removing of non empty categories"
 	class removeProtocolIfEmpty: (class organization protocolNamed: #titan).
@@ -176,7 +176,7 @@ ClassDescriptionProtocolsTest >> testRemoveProtocolWithRealProtocol [
 		protocol: #titan;
 		install: 'king ^1'.
 	self assert: class protocolNames size equals: 3.
-	self assertCollection: (class organization protocolNamed: #titan) methodSelectors hasSameElements: #( #king ).
+	self assertCollection: (class selectorsInProtocol: #titan) hasSameElements: #( #king ).
 
 	class removeProtocol: (class organization protocolNamed: #human).
 	self assert: class protocolNames size equals: 2.

--- a/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
@@ -34,6 +34,30 @@ ClassDescriptionProtocolsTest >> tearDown [
 ]
 
 { #category : #tests }
+ClassDescriptionProtocolsTest >> testMethodSelectorsInProtocol [
+
+	self assertEmpty: (class methodSelectorsInProtocol: #titan).
+
+	class compiler
+		protocol: #titan;
+		install: 'king ^ 1'.
+
+	self assertCollection: (class methodSelectorsInProtocol: #titan) hasSameElements: #( #king )
+]
+
+{ #category : #tests }
+ClassDescriptionProtocolsTest >> testMethodSelectorsInProtocolWithRealProtocol [
+
+	self assertEmpty: (Protocol named: #titan).
+
+	class compiler
+		protocol: #titan;
+		install: 'king ^ 1'.
+
+	self assertCollection: (class methodSelectorsInProtocol: (class organization protocolNamed: #titan)) hasSameElements: #( #king )
+]
+
+{ #category : #tests }
 ClassDescriptionProtocolsTest >> testProtocolNameOfSelector [
 
 	class compiler

--- a/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
@@ -34,30 +34,6 @@ ClassDescriptionProtocolsTest >> tearDown [
 ]
 
 { #category : #tests }
-ClassDescriptionProtocolsTest >> testMethodSelectorsInProtocol [
-
-	self assertEmpty: (class methodSelectorsInProtocol: #titan).
-
-	class compiler
-		protocol: #titan;
-		install: 'king ^ 1'.
-
-	self assertCollection: (class methodSelectorsInProtocol: #titan) hasSameElements: #( #king )
-]
-
-{ #category : #tests }
-ClassDescriptionProtocolsTest >> testMethodSelectorsInProtocolWithRealProtocol [
-
-	self assertEmpty: (Protocol named: #titan).
-
-	class compiler
-		protocol: #titan;
-		install: 'king ^ 1'.
-
-	self assertCollection: (class methodSelectorsInProtocol: (class organization protocolNamed: #titan)) hasSameElements: #( #king )
-]
-
-{ #category : #tests }
 ClassDescriptionProtocolsTest >> testProtocolNameOfSelector [
 
 	class compiler
@@ -210,4 +186,28 @@ ClassDescriptionProtocolsTest >> testRemoveProtocolWithRealProtocol [
 	class removeProtocol: (class organization protocolNamed: #titan).
 	self assert: class protocolNames size equals: 1.
 	self deny: (class isLocalSelector: #king)
+]
+
+{ #category : #tests }
+ClassDescriptionProtocolsTest >> testSelectorsInProtocol [
+
+	self assertEmpty: (class selectorsInProtocol: #titan).
+
+	class compiler
+		protocol: #titan;
+		install: 'king ^ 1'.
+
+	self assertCollection: (class selectorsInProtocol: #titan) hasSameElements: #( #king )
+]
+
+{ #category : #tests }
+ClassDescriptionProtocolsTest >> testSelectorsInProtocolWithRealProtocol [
+
+	self assertEmpty: (Protocol named: #titan).
+
+	class compiler
+		protocol: #titan;
+		install: 'king ^ 1'.
+
+	self assertCollection: (class selectorsInProtocol: (class organization protocolNamed: #titan)) hasSameElements: #( #king )
 ]

--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -185,18 +185,6 @@ ClassOrganizationTest >> testHasProtocol [
 ]
 
 { #category : #tests }
-ClassOrganizationTest >> testMethodSelectorsInProtocol [
-
-	| methods |
-	methods := self organization methodSelectorsInProtocol: 'empty'.
-	self assertEmpty: methods.
-
-	methods := self organization methodSelectorsInProtocol: 'one'.
-	self assert: methods size equals: 1.
-	self assert: methods first equals: #one
-]
-
-{ #category : #tests }
 ClassOrganizationTest >> testProtocolNamed [
 
 	self assert: (self organization protocolNamed: 'empty') name equals: 'empty'.

--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -192,40 +192,6 @@ ClassOrganizationTest >> testProtocolNamed [
 ]
 
 { #category : #tests }
-<<<<<<< HEAD
-ClassOrganizationTest >> testRemoveNonexistentSelectorsFromProtocols [
-
-	class compiler
-		protocol: #one;
-		install: 'one 1'.
-
-	class compiler
-		protocol: #one;
-		install: 'oneBis 1'.
-
-	class compiler
-		protocol: #two;
-		install: 'two 2'.
-
-	organization removeEmptyProtocols.
-
-	self assertCollection: organization protocolNames hasSameElements: #( one two ).
-	self assertCollection: (class selectorsInProtocol: #one) hasSameElements: #( one oneBis ).
-	self assertCollection: (class selectorsInProtocol: #two) hasSameElements: #( two ).
-
-	"Now that we asserted the actual state is good, we can test the actual method."
-	class methodDict
-		removeKey: #oneBis;
-		removeKey: #two.
-	organization removeNonexistentSelectorsFromProtocols.
-
-	self assertCollection: organization protocolNames hasSameElements: #( one ).
-	self assertCollection: (class selectorsInProtocol: #one) hasSameElements: #( one )
-]
-
-{ #category : #tests }
-=======
->>>>>>> Pharo12
 ClassOrganizationTest >> testRenameProtocolAs [
 
 	self assert: (self organization hasProtocol: #one).

--- a/src/Kernel-Tests/ClassOrganizationTest.class.st
+++ b/src/Kernel-Tests/ClassOrganizationTest.class.st
@@ -47,25 +47,25 @@ ClassOrganizationTest >> testClassifyUnder [
 	self organization classify: #luz under: #owl.
 
 	self assertCollection: self organization protocolNames hasSameElements: #( #empty #one #owl ).
-	self assertCollection: (self organization protocolNamed: #owl) methodSelectors hasSameElements: #( #king #luz ).
+	self assertCollection: (class selectorsInProtocol: #owl) hasSameElements: #( #king #luz ).
 
 	"Move a method"
 	self organization classify: #luz under: #one.
 	self assertCollection: self organization protocolNames hasSameElements: #( #empty #one #owl ).
-	self assertCollection: (self organization protocolNamed: #owl) methodSelectors hasSameElements: #( #king ).
-	self assertCollection: (self organization protocolNamed: #one) methodSelectors hasSameElements: #( #one #luz ).
+	self assertCollection: (class selectorsInProtocol: #owl) hasSameElements: #( #king ).
+	self assertCollection: (class selectorsInProtocol: #one) hasSameElements: #( #one #luz ).
 
 	"Move last method"
 	self organization classify: #king under: #two.
 	self assertCollection: self organization protocolNames hasSameElements: #( #empty #one #two ).
-	self assertCollection: (self organization protocolNamed: #one) methodSelectors hasSameElements: #( #one #luz ).
-	self assertCollection: (self organization protocolNamed: #two) methodSelectors hasSameElements: #( #king ).
+	self assertCollection: (class selectorsInProtocol: #one) hasSameElements: #( #one #luz ).
+	self assertCollection: (class selectorsInProtocol: #two) hasSameElements: #( #king ).
 
 	"Nothing should change if the new protocol is the same than the old one"
 	self organization classify: #king under: #two.
 	self assertCollection: self organization protocolNames hasSameElements: #( #empty #one #two ).
-	self assertCollection: (self organization protocolNamed: #one) methodSelectors hasSameElements: #( #one #luz ).
-	self assertCollection: (self organization protocolNamed: #two) methodSelectors hasSameElements: #( #king )
+	self assertCollection: (class selectorsInProtocol: #one) hasSameElements: #( #one #luz ).
+	self assertCollection: (class selectorsInProtocol: #two) hasSameElements: #( #king )
 ]
 
 { #category : #tests }
@@ -80,25 +80,25 @@ ClassOrganizationTest >> testClassifyUnderUnclassified [
 	self organization classify: #luz under: Protocol unclassified.
 
 	self assertCollection: self organization protocolNames hasSameElements: {#empty. #one. Protocol unclassified }.
-	self assertCollection: (self organization protocolNamed: Protocol unclassified) methodSelectors hasSameElements: #( #king #luz ).
+	self assertCollection: class uncategorizedSelectors hasSameElements: #( #king #luz ).
 	
 	"This should do nothing."
 	self organization classify: #luz under: Protocol unclassified.
 
 	self assertCollection: self organization protocolNames hasSameElements: {#empty. #one. Protocol unclassified }.
-	self assertCollection: (self organization protocolNamed: Protocol unclassified) methodSelectors hasSameElements: #( #king #luz ).
+	self assertCollection: class uncategorizedSelectors hasSameElements: #( #king #luz ).
 
 	"Now we move a method from unclassified to another protocol."
 	self organization classify: #luz under: #one.
 
 	self assertCollection: self organization protocolNames hasSameElements: {#empty. #one. Protocol unclassified }.
-	self assertCollection: (self organization protocolNamed: Protocol unclassified) methodSelectors hasSameElements: #( #king ).
+	self assertCollection: class uncategorizedSelectors hasSameElements: #( #king ).
 	
 	"Now we move back to unclassified."
 	self organization classify: #luz under: Protocol unclassified.
 
 	self assertCollection: self organization protocolNames hasSameElements: {#empty. #one. Protocol unclassified }.
-	self assertCollection: (self organization protocolNamed: Protocol unclassified) methodSelectors hasSameElements: #( #king #luz )
+	self assertCollection: class uncategorizedSelectors hasSameElements: #( #king #luz )
 ]
 
 { #category : #tests }
@@ -111,19 +111,19 @@ ClassOrganizationTest >> testClassifyUnderWithNil [
 	self organization classify: #king under: nil.
 
 	self assertCollection: self organization protocolNames hasSameElements: { #empty. #one. unclassified }.
-	self assertCollection: (self organization protocolNamed: unclassified ) methodSelectors hasSameElements: #( #king ).
+	self assertCollection: (class selectorsInProtocol: unclassified) hasSameElements: #( #king ).
 	
 	self organization classify: #luz under: #owl.
 
 	self assertCollection: self organization protocolNames hasSameElements: { #empty. #one. unclassified . #owl }.
-	self assertCollection: (self organization protocolNamed: #owl ) methodSelectors hasSameElements: #( #luz ).
+	self assertCollection: (class selectorsInProtocol: #owl) hasSameElements: #( #luz ).
 	
 	"Now let's test the behavior if we already have a protocol.
 	The behavior should change to not change the protocol but this test will ensure that the change is intentional and not a regression."
 	self organization classify: #luz under: nil.
 
 	self assertCollection: self organization protocolNames hasSameElements: { #empty. #one. unclassified }.
-	self assertCollection: (self organization protocolNamed: unclassified ) methodSelectors hasSameElements: #( #king #luz ).
+	self assertCollection: (class selectorsInProtocol: unclassified) hasSameElements: #( #king #luz ).
 ]
 
 { #category : #tests }
@@ -137,7 +137,7 @@ ClassOrganizationTest >> testClassifyUnderWithProtocol [
 	self organization classify: #luz under: (self organization protocolNamed: #owl).
 
 	self assertCollection: self organization protocolNames hasSameElements: #( #empty #one #owl ).
-	self assertCollection: (self organization protocolNamed: #owl) methodSelectors hasSameElements: #( #king #luz )
+	self assertCollection: (class selectorsInProtocol: #owl) hasSameElements: #( #king #luz )
 ]
 
 { #category : #tests }
@@ -146,8 +146,8 @@ ClassOrganizationTest >> testCopyFrom [
     | newOrganization |
     "First lets check the current state of the org."
     self assertCollection: self organization protocolNames hasSameElements: #( 'empty' 'one' ).
-    self assertCollection: (self organization protocolNamed: 'one') methodSelectors hasSameElements: #( 'one' ).
-    self assertEmpty: (self organization protocolNamed: 'empty') methodSelectors.
+    self assertCollection: (class selectorsInProtocol: #one) hasSameElements: #( 'one' ).
+    self assertEmpty: (class selectorsInProtocol: #empty).
 
     "Now lets check that the new org has the same"
     newOrganization := ClassOrganization new
@@ -156,22 +156,22 @@ ClassOrganizationTest >> testCopyFrom [
                            yourself.
 
     self assertCollection: newOrganization protocolNames hasSameElements: #( 'empty' 'one' ).
-    self assertCollection: (newOrganization protocolNamed: 'one') methodSelectors hasSameElements: #( 'one' ).
-    self assertEmpty: (newOrganization protocolNamed: 'empty') methodSelectors.
+    self assertCollection: (newOrganization protocolNamed: #one) methodSelectors hasSameElements: #( 'one' ).
+    self assertEmpty: (newOrganization protocolNamed: #empty) methodSelectors.
 
     "And now lets check that updating one does not update the other."
     self organization addProtocol: 'two'.
     newOrganization classify: 'new' under: 'init'.
 
     self assertCollection: self organization protocolNames hasSameElements: #( 'empty' 'one' 'two' ).
-    self assertCollection: (self organization protocolNamed: 'one') methodSelectors hasSameElements: #( 'one' ).
-    self assertEmpty: (self organization protocolNamed: 'empty') methodSelectors.
-    self assertEmpty: (self organization protocolNamed: 'two') methodSelectors.
+    self assertCollection: (class selectorsInProtocol: #one) hasSameElements: #( 'one' ).
+    self assertEmpty: (class selectorsInProtocol: #empty).
+    self assertEmpty: (class selectorsInProtocol: #two).
 
     self assertCollection: newOrganization protocolNames hasSameElements: #( 'empty' 'one' 'init' ).
-    self assertCollection: (newOrganization protocolNamed: 'one') methodSelectors hasSameElements: #( 'one' ).
-    self assertEmpty: (newOrganization protocolNamed: 'empty') methodSelectors.
-    self assertCollection: (newOrganization protocolNamed: 'init') methodSelectors hasSameElements: #( 'new' )
+    self assertCollection: (newOrganization protocolNamed: #one) methodSelectors hasSameElements: #( 'one' ).
+    self assertEmpty: (newOrganization protocolNamed: #empty) methodSelectors.
+    self assertCollection: (newOrganization protocolNamed: #init) methodSelectors hasSameElements: #( 'new' )
 ]
 
 { #category : #tests }
@@ -209,8 +209,8 @@ ClassOrganizationTest >> testRemoveNonexistentSelectorsFromProtocols [
 	organization removeEmptyProtocols.
 
 	self assertCollection: organization protocolNames hasSameElements: #( one two ).
-	self assertCollection: (organization protocolNamed: #one) methodSelectors hasSameElements: #( one oneBis ).
-	self assertCollection: (organization protocolNamed: #two) methodSelectors hasSameElements: #( two ).
+	self assertCollection: (class selectorsInProtocol: #one) hasSameElements: #( one oneBis ).
+	self assertCollection: (class selectorsInProtocol: #two) hasSameElements: #( two ).
 
 	"Now that we asserted the actual state is good, we can test the actual method."
 	class methodDict
@@ -219,7 +219,7 @@ ClassOrganizationTest >> testRemoveNonexistentSelectorsFromProtocols [
 	organization removeNonexistentSelectorsFromProtocols.
 
 	self assertCollection: organization protocolNames hasSameElements: #( one ).
-	self assertCollection: (organization protocolNamed: #one) methodSelectors hasSameElements: #( one )
+	self assertCollection: (class selectorsInProtocol: #one) hasSameElements: #( one )
 ]
 
 { #category : #tests }
@@ -227,12 +227,12 @@ ClassOrganizationTest >> testRenameProtocolAs [
 
 	self assert: (self organization hasProtocol: #one).
 	self deny: (self organization hasProtocol: #two).
-	self assertCollection: (self organization protocolNamed: #one) methodSelectors hasSameElements: #( 'one' ).
+	self assertCollection: (class selectorsInProtocol: #one) hasSameElements: #( 'one' ).
 	self organization renameProtocol: #one as: #two.
 
 	self assert: (self organization hasProtocol: #two).
 	self deny: (self organization hasProtocol: #one).
-	self assertCollection: (self organization protocolNamed: #two) methodSelectors hasSameElements: #( 'one' ).
+	self assertCollection: (class selectorsInProtocol: #two) hasSameElements: #( 'one' ).
 ]
 
 { #category : #tests }
@@ -242,13 +242,13 @@ ClassOrganizationTest >> testRenameProtocolAsWithExistingProtocol [
 
 	self assert: (self organization hasProtocol: #one).
 	self assert: (self organization hasProtocol: #two).
-	self assertCollection: (self organization protocolNamed: #one) methodSelectors hasSameElements: #( 'one' ).
-	self assertCollection: (self organization protocolNamed: #two) methodSelectors hasSameElements: #( 'king' ).
+	self assertCollection: (class selectorsInProtocol: #one) hasSameElements: #( 'one' ).
+	self assertCollection: (class selectorsInProtocol: #two) hasSameElements: #( 'king' ).
 	self organization renameProtocol: #one as: #two.
 
 	self assert: (self organization hasProtocol: #two).
 	self deny: (self organization hasProtocol: #one).
-	self assertCollection: (self organization protocolNamed: #two) methodSelectors hasSameElements: #( 'one' 'king' )
+	self assertCollection: (class selectorsInProtocol: #two) hasSameElements: #( 'one' 'king' )
 ]
 
 { #category : #tests }
@@ -276,13 +276,13 @@ ClassOrganizationTest >> testRenameProtocolAsWithNil [
 
 	self assert: (self organization hasProtocol: #one).
 	self deny: (self organization hasProtocol: #two).
-	self assertCollection: (self organization protocolNamed: #one) methodSelectors hasSameElements: #( 'one' ).
+	self assertCollection: (class selectorsInProtocol: #one) hasSameElements: #( 'one' ).
 
 	self organization renameProtocol: #one as: nil.
 	"Check that nothing changed."
 	self assert: (self organization hasProtocol: #one).
 	self deny: (self organization hasProtocol: #two).
-	self assertCollection: (self organization protocolNamed: #one) methodSelectors hasSameElements: #( 'one' )
+	self assertCollection: (class selectorsInProtocol: #one) hasSameElements: #( 'one' )
 ]
 
 { #category : #tests }
@@ -290,13 +290,13 @@ ClassOrganizationTest >> testRenameProtocolAsWithNil2 [
 
 	self assert: (self organization hasProtocol: #one).
 	self deny: (self organization hasProtocol: #two).
-	self assertCollection: (self organization protocolNamed: #one) methodSelectors hasSameElements: #( 'one' ).
+	self assertCollection: (class selectorsInProtocol: #one) hasSameElements: #( 'one' ).
 
 	self organization renameProtocol: nil as: #two.
 	"Check that nothing changed."
 	self assert: (self organization hasProtocol: #one).
 	self deny: (self organization hasProtocol: #two).
-	self assertCollection: (self organization protocolNamed: #one) methodSelectors hasSameElements: #( 'one' )
+	self assertCollection: (class selectorsInProtocol: #one) hasSameElements: #( 'one' )
 ]
 
 { #category : #tests }
@@ -304,13 +304,13 @@ ClassOrganizationTest >> testRenameProtocolAsWithNil3 [
 
 	self assert: (self organization hasProtocol: #one).
 	self deny: (self organization hasProtocol: #two).
-	self assertCollection: (self organization protocolNamed: #one) methodSelectors hasSameElements: #( 'one' ).
+	self assertCollection: (class selectorsInProtocol: #one) hasSameElements: #( 'one' ).
 
 	self organization renameProtocol: nil as: nil.
 	"Check that nothing changed."
 	self assert: (self organization hasProtocol: #one).
 	self deny: (self organization hasProtocol: #two).
-	self assertCollection: (self organization protocolNamed: #one) methodSelectors hasSameElements: #( 'one' )
+	self assertCollection: (class selectorsInProtocol: #one) hasSameElements: #( 'one' )
 ]
 
 { #category : #tests }
@@ -318,13 +318,13 @@ ClassOrganizationTest >> testRenameProtocolAsWithNonExistingProtocol [
 
 	self assert: (self organization hasProtocol: #one).
 	self deny: (self organization hasProtocol: #two).
-	self assertCollection: (self organization protocolNamed: #one) methodSelectors hasSameElements: #( 'one' ).
+	self assertCollection: (class selectorsInProtocol: #one) hasSameElements: #( 'one' ).
 
 	self organization renameProtocol: #two as: #one.
 	"Check that nothing changed."
 	self assert: (self organization hasProtocol: #one).
 	self deny: (self organization hasProtocol: #two).
-	self assertCollection: (self organization protocolNamed: #one) methodSelectors hasSameElements: #( 'one' )
+	self assertCollection: (class selectorsInProtocol: #one) hasSameElements: #( 'one' )
 ]
 
 { #category : #tests }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -860,14 +860,15 @@ ClassDescription >> reorganize [
 
 { #category : #'accessing - method dictionary' }
 ClassDescription >> selectorsInCategory: aName [
-	"Answer a list of the selectors of the receiver that are in category named aName"
 
-	^ (self methodSelectorsInProtocol: aName) asSet asArray sort
+	self deprecated: 'Use #selectorsInProtocol: instead.' transformWith: '`@rcv selectorsInCategory: `@arg' -> '`@rcv selectorsInProtocol: `@arg'.
+
+	^ self selectorsInProtocol: aName
 ]
 
 { #category : #'accessing - method dictionary' }
 ClassDescription >> selectorsInProtocol: aName [
-	"Answer a list of the selectors of the receiver that are in category named aName"
+	"Answer a list of the selectors of the receiver that are in specific protocol (or protocol name)"
 
 	^ (self methodSelectorsInProtocol: aName) asSet asArray sort
 ]

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -592,14 +592,6 @@ ClassDescription >> localSlots [
 	^ self slots select: [ :aSlot | aSlot isDefinedByOwningClass ]
 ]
 
-{ #category : #protocols }
-ClassDescription >> methodSelectorsInProtocol: aProtocol [
-
-	(self organization hasProtocol: aProtocol) ifFalse: [ ^ #(  ) ].
-
-	^ (self organization ensureProtocol: aProtocol) methodSelectors
-]
-
 { #category : #organization }
 ClassDescription >> methodsInProtocol: aString [
 
@@ -866,7 +858,7 @@ ClassDescription >> selectorsInCategory: aName [
 	^ self selectorsInProtocol: aName
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : #protocols }
 ClassDescription >> selectorsInProtocol: aProtocol [
 	"Answer a list of the selectors of the receiver that are in specific protocol (or protocol name)"
 

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -128,7 +128,7 @@ ClassDescription >> allSelectorsInProtocol: aName [
 	"Answer a list of all the methods of the receiver and all its
 	superclasses that are in the protocol named aName"
 
-	^ self withAllSuperclasses flatCollectAsSet: [ :class | class organization methodSelectorsInProtocol: aName ]
+	^ self withAllSuperclasses flatCollectAsSet: [ :class | class methodSelectorsInProtocol: aName ]
 ]
 
 { #category : #'pool variable' }
@@ -592,10 +592,18 @@ ClassDescription >> localSlots [
 	^ self slots select: [ :aSlot | aSlot isDefinedByOwningClass ]
 ]
 
+{ #category : #protocols }
+ClassDescription >> methodSelectorsInProtocol: aProtocol [
+
+	(self organization hasProtocol: aProtocol) ifFalse: [ ^ #(  ) ].
+
+	^ (self organization ensureProtocol: aProtocol) methodSelectors
+]
+
 { #category : #organization }
 ClassDescription >> methodsInProtocol: aString [
 
-	^ (self organization methodSelectorsInProtocol: aString) collect: [ :each | self compiledMethodAt: each ]
+	^ (self methodSelectorsInProtocol: aString) collect: [ :each | self compiledMethodAt: each ]
 ]
 
 { #category : #'accessing - tags' }
@@ -854,14 +862,14 @@ ClassDescription >> reorganize [
 ClassDescription >> selectorsInCategory: aName [
 	"Answer a list of the selectors of the receiver that are in category named aName"
 
-	^ (self organization methodSelectorsInProtocol: aName) asSet asArray sort
+	^ (self methodSelectorsInProtocol: aName) asSet asArray sort
 ]
 
 { #category : #'accessing - method dictionary' }
 ClassDescription >> selectorsInProtocol: aName [
 	"Answer a list of the selectors of the receiver that are in category named aName"
 
-	^ (self organization methodSelectorsInProtocol: aName) asSet asArray sort
+	^ (self methodSelectorsInProtocol: aName) asSet asArray sort
 ]
 
 { #category : #'pool variable' }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -128,7 +128,7 @@ ClassDescription >> allSelectorsInProtocol: aName [
 	"Answer a list of all the methods of the receiver and all its
 	superclasses that are in the protocol named aName"
 
-	^ self withAllSuperclasses flatCollectAsSet: [ :class | class methodSelectorsInProtocol: aName ]
+	^ self withAllSuperclasses flatCollectAsSet: [ :class | class selectorsInProtocol: aName ]
 ]
 
 { #category : #'pool variable' }
@@ -603,7 +603,7 @@ ClassDescription >> methodSelectorsInProtocol: aProtocol [
 { #category : #organization }
 ClassDescription >> methodsInProtocol: aString [
 
-	^ (self methodSelectorsInProtocol: aString) collect: [ :each | self compiledMethodAt: each ]
+	^ (self selectorsInProtocol: aString) collect: [ :each | self compiledMethodAt: each ]
 ]
 
 { #category : #'accessing - tags' }
@@ -867,10 +867,12 @@ ClassDescription >> selectorsInCategory: aName [
 ]
 
 { #category : #'accessing - method dictionary' }
-ClassDescription >> selectorsInProtocol: aName [
+ClassDescription >> selectorsInProtocol: aProtocol [
 	"Answer a list of the selectors of the receiver that are in specific protocol (or protocol name)"
 
-	^ (self methodSelectorsInProtocol: aName) asSet asArray sort
+	(self organization hasProtocol: aProtocol) ifFalse: [ ^ #(  ) ].
+
+	^ (self organization ensureProtocol: aProtocol) methodSelectors
 ]
 
 { #category : #'pool variable' }
@@ -1063,6 +1065,7 @@ ClassDescription >> theNonMetaClass [
 
 { #category : #'accessing - method dictionary' }
 ClassDescription >> uncategorizedSelectors [
+
 	^ self selectorsInProtocol: Protocol unclassified
 ]
 

--- a/src/Kernel/ClassOrganization.class.st
+++ b/src/Kernel/ClassOrganization.class.st
@@ -117,12 +117,6 @@ ClassOrganization >> initializeClass: aClass [
 ]
 
 { #category : #accessing }
-ClassOrganization >> methodSelectorsInProtocol: aName [
-
-	^ (self protocolNamed: aName ifAbsent: [ ^ #(  ) ]) methodSelectors asArray
-]
-
-{ #category : #accessing }
 ClassOrganization >> organizedClass [
 
 	^ organizedClass ifNil: [ self error: 'ClassOrganization should always have an organized class associated.' ]

--- a/src/Morphic-Examples/PackageClassNodeExample.class.st
+++ b/src/Morphic-Examples/PackageClassNodeExample.class.st
@@ -23,6 +23,7 @@ PackageClassNodeExample >> childrenItems [
 ]
 
 { #category : #menu }
-PackageClassNodeExample >> methodsInCategory: aCat [
-	^ self item  selectorsInProtocol: aCat
+PackageClassNodeExample >> methodsInCategory: aProtocol [
+
+	^ self item selectorsInProtocol: aProtocol
 ]

--- a/src/Morphic-Examples/PackageMethodCategoryNodeExample.class.st
+++ b/src/Morphic-Examples/PackageMethodCategoryNodeExample.class.st
@@ -14,5 +14,6 @@ PackageMethodCategoryNodeExample >> childNodeClassFromItem: anItem [
 
 { #category : #accessing }
 PackageMethodCategoryNodeExample >> childrenItems [
+
 	^ self parentNode item selectorsInProtocol: self item
 ]

--- a/src/OpalCompiler-Tests/MethodPragmaTest.class.st
+++ b/src/OpalCompiler-Tests/MethodPragmaTest.class.st
@@ -49,7 +49,7 @@ MethodPragmaTest >> pragma: aSymbol selector: aSelector times: anInteger [
 { #category : #running }
 MethodPragmaTest >> tearDown [
 
-	(self class methodSelectorsInProtocol: self methodCategory) do: [ :each | self class removeSelectorSilently: each ].
+	(self class selectorsInProtocol: self methodCategory) do: [ :each | self class removeSelectorSilently: each ].
 	self class removeProtocolIfEmpty: self methodCategory.
 	super tearDown
 ]

--- a/src/OpalCompiler-Tests/MethodPragmaTest.class.st
+++ b/src/OpalCompiler-Tests/MethodPragmaTest.class.st
@@ -49,8 +49,8 @@ MethodPragmaTest >> pragma: aSymbol selector: aSelector times: anInteger [
 { #category : #running }
 MethodPragmaTest >> tearDown [
 
-	(self class organization methodSelectorsInProtocol: self methodCategory) do: [ :each | self class removeSelectorSilently: each ].
-	self class organization removeProtocolIfEmpty: self methodCategory.
+	(self class methodSelectorsInProtocol: self methodCategory) do: [ :each | self class removeSelectorSilently: each ].
+	self class removeProtocolIfEmpty: self methodCategory.
 	super tearDown
 ]
 

--- a/src/Refactoring-Environment/RBBrowserEnvironment.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironment.class.st
@@ -774,7 +774,7 @@ RBBrowserEnvironment >> selectorsDo: aBlock [
 { #category : #accessing }
 RBBrowserEnvironment >> selectorsFor: aProtocol in: aClass [
 
-	^ (aClass methodSelectorsInProtocol: aProtocol) select: [ :each | self includesSelector: each in: aClass ]
+	^ (aClass selectorsInProtocol: aProtocol) select: [ :each | self includesSelector: each in: aClass ]
 ]
 
 { #category : #accessing }

--- a/src/Refactoring-Environment/RBBrowserEnvironment.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironment.class.st
@@ -774,7 +774,7 @@ RBBrowserEnvironment >> selectorsDo: aBlock [
 { #category : #accessing }
 RBBrowserEnvironment >> selectorsFor: aProtocol in: aClass [
 
-	^ (aClass organization methodSelectorsInProtocol: aProtocol) select: [ :each | self includesSelector: each in: aClass ]
+	^ (aClass methodSelectorsInProtocol: aProtocol) select: [ :each | self includesSelector: each in: aClass ]
 ]
 
 { #category : #accessing }

--- a/src/Refactoring-Environment/RBNotEnvironment.class.st
+++ b/src/Refactoring-Environment/RBNotEnvironment.class.st
@@ -40,7 +40,9 @@ RBNotEnvironment >> includesPackage: aRPackage [
 { #category : #testing }
 RBNotEnvironment >> includesProtocol: aProtocol in: aClass [
 
-	^ (aClass organization protocolNamed: aProtocol ifAbsent: [ ^ false ]) methodSelectors anySatisfy: [ :selector | self includesSelector: selector in: aClass ]
+	(aClass organization hasProtocol: aProtocol) ifFalse: [ ^ false ].
+
+	^ (aClass selectorsInProtocol: aProtocol) anySatisfy: [ :selector | self includesSelector: selector in: aClass ]
 ]
 
 { #category : #testing }

--- a/src/Ring-Core/RGEnvironmentAnnouncer.class.st
+++ b/src/Ring-Core/RGEnvironmentAnnouncer.class.st
@@ -111,8 +111,15 @@ RGEnvironmentAnnouncer >> methodAdded: aMethod [
 
 { #category : #triggering }
 RGEnvironmentAnnouncer >> methodRemoved: aMethod [
+	"For the protocol we should just send #protocol to the method when #protocol will return a protocol and not a symbol."
 
-	self announce: (MethodRemoved methodRemoved: aMethod protocol: aMethod protocol origin: aMethod parent)
+	self announce: (MethodRemoved
+			 methodRemoved: aMethod
+			 protocol: (self class environment
+					  at: aMethod methodClass
+					  ifPresent: [ :class | class protocolNamed: aMethod protocol ]
+					  ifAbsent: [ aMethod protocol ])
+			 origin: aMethod parent)
 ]
 
 { #category : #accessing }

--- a/src/SUnit-Core/ClassTestCase.class.st
+++ b/src/SUnit-Core/ClassTestCase.class.st
@@ -131,7 +131,5 @@ ClassTestCase >> testNew [
 { #category : #tests }
 ClassTestCase >> testUnCategorizedMethods [
 
-	| uncategorizedMethods |
-	uncategorizedMethods := self targetClass selectorsInProtocol: Protocol unclassified.
-	self assertEmpty: uncategorizedMethods
+	self assertEmpty: self targetClass uncategorizedSelectors
 ]


### PR DESCRIPTION
This PR add multiple cleanings in the way we can get the selectors in a protocol from a class.
- #selectorsInCategory: was the same than #selectorsInProtocol: so I deprecated it
- #selectorsInProtocol: was removing duplicates but it should never be able to have a duplicates so I removed this extra step that was done with two cast of a collection
- #selectorsInProtocol: was sorting the selectors but no sender was caring about the order. This method is not the place to do sorting. So I removed the sort
- I inlined #methodSelectorsInProtocol: from ClassOrganization to ClassDescription>>#selectorsInProtocol:
- I added missing tests on #selectorsInProtocol: with one tests showing that it was not able to deal with real protocols
- I updated #selectorsInProtocol: to be able to deal with real protocols and not just a protocol name
- I replaced some `(class organization protocolNamed: x) methodSelectors` to call `class selectorsInProtocol: x` which is more readable

This cleans a lot of code, reduces some API while making the existing API more robust! This will also help to clean other parts of the system more easily afterward :)