### PR TITLE
Drop use of Paragraph from #drawOn: in ToggleWithSymbolMenuItemShortcut to fix menu item alignment

### DIFF
--- a/src/Morphic-Base/ToggleWithSymbolMenuItemShortcut.class.st
+++ b/src/Morphic-Base/ToggleWithSymbolMenuItemShortcut.class.st
@@ -63,22 +63,15 @@ ToggleWithSymbolMenuItemShortcut class >> symbolTableAt: anObject ifAbsent: aBlo
 
 { #category : #drawing }
 ToggleWithSymbolMenuItemShortcut >> drawOn: aCanvas [
-	| text paragraph keyBounds keyFont |
+	| text keyBounds keyFont |
 
 	text := self text.
 	keyFont := self class symbolFont.
 
 	keyBounds := self boundsForKeyText: text string font: keyFont.
-	paragraph := Paragraph new
-		compose: text
-			style: (TextStyle fontArray: { keyFont })
-			from: 1
-			in: (0@0 corner: keyBounds corner);
-		yourself.
-
-	aCanvas
-		paragraph: paragraph
-		bounds: keyBounds
+	aCanvas drawString: text
+		in: keyBounds
+		font: keyFont
 		color: self color
 ]
 


### PR DESCRIPTION
This fixes the vertical alignment of menu items, before&after:

<p align="center">
<img src="https://github.com/pharo-project/pharo/assets/1611248/43ea7428-a913-42f2-9045-7ef9b0a2fadf">
<img src="https://github.com/pharo-project/pharo/assets/1611248/a52b8dec-c171-47f3-95fe-2984b1d16382">
</p>

The above screenshots show the following Morph:

```smalltalk
Morph new
	color: Color transparent;
	addMorph: (MenuMorph new
		in: [ :menuMorph | (menuMorph add: 'Implementors' target: nil selector: #yourself) keyText: 'm' ];
		yourself);
	addMorph: (155@18 in: [ :endPoint | LineMorph from: 0 @ endPoint y to: endPoint color: Color red width: 1 ]);
	yourself.
```
