### PR TITLE
Fix: `RBClassRegexRefactoring`

### DIFF
--- a/src/Refactoring-Core/RBClassRegexRefactoring.class.st
+++ b/src/Refactoring-Core/RBClassRegexRefactoring.class.st
@@ -85,7 +85,7 @@ RBClassRegexRefactoring >> initialize [
 RBClassRegexRefactoring >> rename: aClass name: aSymbol [
 	^ RBRenameClassRefactoring
 		model: self model
-		rename: aClass
+		rename: aClass name
 		to: aSymbol
 ]
 


### PR DESCRIPTION
rename class expects class name, and class regex refactoring was sending class object.