### PR TITLE
Remove dead method ClassDescription>>#zapOrganization

### DIFF
--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -1144,13 +1144,3 @@ ClassDescription >> whichSelectorsWrite: instVarName [
 		ifFound: [ :slot | self selectors select: [ :sel | slot isWrittenIn: self >> sel ] ]
 		ifNone: [ #() ]
 ]
-
-{ #category : #organization }
-ClassDescription >> zapOrganization [
-	"Remove the organization of this class by message categories.
-	This is typically done to save space in small systems.  Classes and methods
-	created or filed in subsequently will, nonetheless, be organized"
-
-	self organization: nil.
-	self isClassSide ifFalse: [self classSide zapOrganization]
-]


### PR DESCRIPTION
ClassOrganization will probably be removed in Pharo12. This remove a dead method dealing with the organization.