### PR TITLE
Fix #13478: Filter on `calypsoName` instead of `name`

### DIFF
--- a/src/Calypso-NavigationModel/Class.extension.st
+++ b/src/Calypso-NavigationModel/Class.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #Class }
+
+{ #category : #'*Calypso-NavigationModel' }
+Class >> calypsoName [
+
+	^ self name
+]

--- a/src/Calypso-NavigationModel/ClyBrowserItem.class.st
+++ b/src/Calypso-NavigationModel/ClyBrowserItem.class.st
@@ -162,6 +162,12 @@ ClyBrowserItem >> asCalypsoBrowserItem [
 	^self
 ]
 
+{ #category : #accessing }
+ClyBrowserItem >> calypsoName [
+
+	^ name
+]
+
 { #category : #copying }
 ClyBrowserItem >> copy [
 	| copy |

--- a/src/Calypso-NavigationModel/ClyItemNameFilter.class.st
+++ b/src/Calypso-NavigationModel/ClyItemNameFilter.class.st
@@ -12,5 +12,5 @@ Class {
 { #category : #testing }
 ClyItemNameFilter >> matches: anEnvironmentItem [
 
-	^pattern matches: anEnvironmentItem name
+	^pattern matches: anEnvironmentItem calypsoName
 ]

--- a/src/Calypso-NavigationModel/CompiledMethod.extension.st
+++ b/src/Calypso-NavigationModel/CompiledMethod.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #CompiledMethod }
+
+{ #category : #'*Calypso-NavigationModel' }
+CompiledMethod >> calypsoName [
+
+	^ self selector
+]

--- a/src/Calypso-NavigationModel/RPackage.extension.st
+++ b/src/Calypso-NavigationModel/RPackage.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #RPackage }
+
+{ #category : #'*Calypso-NavigationModel' }
+RPackage >> calypsoName [
+
+	^ name
+]


### PR DESCRIPTION
As discussed with @jecisc in #13758 regarding #13478.

Add the new `calypsoName` method to RPackage, Class, CompiledMethod and ClyBrowserItem (are there others?).
For a CompiledMethod, this method answers its selector, fixing the issue.
For the others, it has the same behavior as calling the `name` method.