### PR TITLE
Add tests for Calypso's item filter

### DIFF
--- a/src/Calypso-NavigationModel-Tests/ClyItemNameFilterTest.class.st
+++ b/src/Calypso-NavigationModel-Tests/ClyItemNameFilterTest.class.st
@@ -18,10 +18,28 @@ ClyItemNameFilterTest >> testComparisonWithAnotherFilter [
 ]
 
 { #category : #tests }
-ClyItemNameFilterTest >> testFilterObjectWithName [
+ClyItemNameFilterTest >> testFilterClassWithName [
 
 	filter := ClyItemNameFilter substringPattern: 'ject'. "Object"
 
 	self assert: (filter matches: Object).
 	self deny: (filter matches: Array)
+]
+
+{ #category : #tests }
+ClyItemNameFilterTest >> testFilterMethodWithSelector [
+
+	filter := ClyItemNameFilter substringPattern: 'collect'.
+
+	self assert: (filter matches: Collection >> #collect:).
+	self deny: (filter matches: Collection >> #add:)
+]
+
+{ #category : #tests }
+ClyItemNameFilterTest >> testFilterPackageWithName [
+
+	filter := ClyItemNameFilter substringPattern: 'kernel'.
+
+	self assert: (filter matches: (RPackage organizer packageNamed: #Kernel)).
+	self deny: (filter matches: (RPackage organizer packageNamed: #Jobs))
 ]


### PR DESCRIPTION
Following the change made in #13778.

Renamed the existing test `testFilterObjectWithName` to `testFilterClassWithName` to clearly separate the three possible receivers of `calypsoName`: `RPackage`, `Class` and `CompiledMethod` (omitting `ClyBrowserItem`).