### PR TITLE
Migrate variables of VariableLayout only if old instance was also variable

### DIFF
--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -74,26 +74,28 @@ ShiftClassInstaller >> copyClassSlotsFromExistingClass [
 
 { #category : #copying }
 ShiftClassInstaller >> copyObject: oldObject to: newClass [
-	| newObject hiddenSlots |
 
-	newObject := (newClass isVariable and: [oldClass isVariable])
-		ifTrue: [ newClass basicNew: oldObject basicSize ]
-		ifFalse: [ newClass basicNew ].
+	| newObject hiddenSlots |
+	newObject := (newClass isVariable and: [ oldClass isVariable ])
+		             ifTrue: [
+			             | createdObject |
+			             createdObject := newClass basicNew: oldObject basicSize.
+			             "Copying the variabls"
+			             1 to: oldObject basicSize do: [ :offset | createdObject basicAt: offset put: (oldObject basicAt: offset) ].
+			             createdObject ]
+		             ifFalse: [ newClass basicNew ].
 
 	"first initialize all hidden slots"
-	hiddenSlots := newClass classLayout allSlots reject: [:each | each isVisible].
+	hiddenSlots := newClass classLayout allSlots reject: [ :each | each isVisible ].
 	hiddenSlots do: [ :newSlot |
-			newSlot initialize: newObject.
-			oldObject class slotNamed: newSlot name ifFound: [ :oldSlot |
-				newSlot write: (oldSlot read: oldObject) to: newObject ]  ].
+		newSlot initialize: newObject.
+		oldObject class slotNamed: newSlot name ifFound: [ :oldSlot | newSlot write: (oldSlot read: oldObject) to: newObject ] ].
 
 	"the initialize all visible slots"
-	newClass allSlots do: [ :newSlot | oldObject class slotNamed: newSlot name ifFound: [ :oldSlot |
+	newClass allSlots do: [ :newSlot |
+		oldObject class slotNamed: newSlot name ifFound: [ :oldSlot |
 			newSlot initialize: newObject.
-		   newSlot write: (oldSlot read: oldObject) to: newObject ] ].
-
-	newClass isVariable
-		ifTrue: [ 1 to: oldObject basicSize do: [ :offset | newObject basicAt: offset put: (oldObject basicAt: offset) ] ].
+			newSlot write: (oldSlot read: oldObject) to: newObject ] ].
 
 	"Clearing the readonly-ness in the old objects so the become is able to work"
 	oldObject setIsReadOnlyObject: false.

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -75,7 +75,7 @@ ShiftClassInstaller >> copyClassSlotsFromExistingClass [
 { #category : #copying }
 ShiftClassInstaller >> copyObject: oldObject to: newClass [
 
-	| newObject hiddenSlots |
+	| newObject |
 	newObject := (newClass isVariable and: [ oldClass isVariable ])
 		             ifTrue: [
 			             | createdObject |
@@ -86,10 +86,11 @@ ShiftClassInstaller >> copyObject: oldObject to: newClass [
 		             ifFalse: [ newClass basicNew ].
 
 	"first initialize all hidden slots"
-	hiddenSlots := newClass classLayout allSlots reject: [ :each | each isVisible ].
-	hiddenSlots do: [ :newSlot |
-		newSlot initialize: newObject.
-		oldObject class slotNamed: newSlot name ifFound: [ :oldSlot | newSlot write: (oldSlot read: oldObject) to: newObject ] ].
+	newClass classLayout allSlots
+		reject: [ :aSlot | aSlot isVisible ]
+		thenDo: [ :newHiddenSlot |
+			newHiddenSlot initialize: newObject.
+			oldObject class slotNamed: newHiddenSlot name ifFound: [ :oldSlot | newHiddenSlot write: (oldSlot read: oldObject) to: newObject ] ].
 
 	"the initialize all visible slots"
 	newClass allSlots do: [ :newSlot |


### PR DESCRIPTION
When we recompile a class with a variable layout, we migrate the variables from the old objects to the new instances. But we should not do that if the old object was not a variable layout already because then it will try to access fields that are not accessible via #basicAt: