### PR TITLE
13791-PseudoVariables-should-be-read-via-DoItVariable 

### DIFF
--- a/src/Kernel/ReservedVariable.class.st
+++ b/src/Kernel/ReservedVariable.class.st
@@ -37,6 +37,11 @@ ReservedVariable class >> variableName [
 ]
 
 { #category : #converting }
+ReservedVariable >> asDoItVariableFrom: aContext [
+	^ DoItVariable fromContext: aContext variable: self
+]
+
+{ #category : #converting }
 ReservedVariable >> asString [
 
 	^ self name

--- a/src/Slot-Tests/ReservedVariableTest.class.st
+++ b/src/Slot-Tests/ReservedVariableTest.class.st
@@ -1,5 +1,0 @@
-Class {
-	#name : #ReservedVariableTest,
-	#superclass : #TestCase,
-	#category : #'Slot-Tests-VariablesAndSlots'
-}

--- a/src/Slot-Tests/ThisContextVariableTest.class.st
+++ b/src/Slot-Tests/ThisContextVariableTest.class.st
@@ -1,0 +1,21 @@
+Class {
+	#name : #ThisContextVariableTest,
+	#superclass : #TestCase,
+	#category : #'Slot-Tests-VariablesAndSlots'
+}
+
+{ #category : #tests }
+ThisContextVariableTest >> testReadInContext [
+
+	| var |
+	var := self class lookupVar: #thisContext.
+	self assert: (var readInContext: thisContext) identicalTo: thisContext
+]
+
+{ #category : #tests }
+ThisContextVariableTest >> testUsingMethods [
+
+	|  var |
+	var := self class lookupVar: #thisContext.
+	self assert: (var usingMethods includes: thisContext method)
+]


### PR DESCRIPTION
- add #asDoItVariableFrom: to ReservedVariable
- add tests for ThisContextVariableTest 
- remove empty ReservedVariableTest

fixes #13791