### PR TITLE
Fix reaction of Epicea to protocol removal

### DIFF
--- a/src/Epicea-Tests/EpAnnouncementsTest.class.st
+++ b/src/Epicea-Tests/EpAnnouncementsTest.class.st
@@ -10,12 +10,9 @@ EpAnnouncementsTest >> assertMonitorAnnouncesUpdateWhen: aBlock [
 	| wasAnnounced |
 	wasAnnounced := false.
 
-	monitor announcer
-		when: EpMonitorStateUpdated
-		do: [ :announcement | wasAnnounced := true ].
+	monitor announcer when: EpMonitorStateUpdated do: [ :announcement | wasAnnounced := true ] for: self.
 
-	aBlock
-		ensure: [ monitor announcer unsubscribe: self ].
+	aBlock ensure: [ monitor announcer unsubscribe: self ].
 
 	self assert: wasAnnounced
 ]

--- a/src/Epicea/EpMonitor.class.st
+++ b/src/Epicea/EpMonitor.class.st
@@ -499,7 +499,7 @@ EpMonitor >> methodRecategorized: aMethodRecategorized [
 			             protocol: aMethodRecategorized oldProtocol name;
 			             yourself.
 		newMethod := aMethodRecategorized methodRecategorized asEpiceaRingDefinition
-			             protocol: aMethodRecategorized newProtocol name;
+			             protocol: (aMethodRecategorized newProtocol ifNotNil: [ :protocol | protocol name ]);
 			             yourself.
 
 		self addEvent: (EpMethodModification oldMethod: oldMethod newMethod: newMethod) ]


### PR DESCRIPTION
This failure was hidden by the catch all of EpMonitor. https://github.com/pharo-project/pharo/pull/13798 should make this error visible in the future. 

Also update a deprecated call.

Fixes #13796