### PR TITLE
Compile 'thisContext' (and all other PseudoVariables) as DoitVariable in DoIts

### DIFF
--- a/src/AST-Core-Tests/ASTEvaluationTest.class.st
+++ b/src/AST-Core-Tests/ASTEvaluationTest.class.st
@@ -28,9 +28,8 @@ ASTEvaluationTest >> testEvaluateForContext [
 	node := RBVariableNode superNode.
 	self assert: (node evaluateForContext: thisContext) equals: thisContext receiver.
 
-	"thisContext is not the thisContext of this method though... it is the context of the evaluating doit"
 	node := RBVariableNode thisContextNode.
-	self deny: (node evaluateForContext: thisContext) equals: thisContext.
+	self assert: (node evaluateForContext: thisContext) equals: thisContext.
 
 	"reading ivars works, too"
 	node := RBVariableNode named: 'testSelector'.

--- a/src/Kernel/ReservedVariable.class.st
+++ b/src/Kernel/ReservedVariable.class.st
@@ -37,6 +37,11 @@ ReservedVariable class >> variableName [
 ]
 
 { #category : #converting }
+ReservedVariable >> asDoItVariableFrom: aContext [
+	^ DoItVariable fromContext: aContext variable: self
+]
+
+{ #category : #converting }
 ReservedVariable >> asString [
 
 	^ self name

--- a/src/Slot-Tests/ReservedVariableTest.class.st
+++ b/src/Slot-Tests/ReservedVariableTest.class.st
@@ -1,5 +1,0 @@
-Class {
-	#name : #ReservedVariableTest,
-	#superclass : #TestCase,
-	#category : #'Slot-Tests-VariablesAndSlots'
-}

--- a/src/Slot-Tests/ThisContextVariableTest.class.st
+++ b/src/Slot-Tests/ThisContextVariableTest.class.st
@@ -1,0 +1,21 @@
+Class {
+	#name : #ThisContextVariableTest,
+	#superclass : #TestCase,
+	#category : #'Slot-Tests-VariablesAndSlots'
+}
+
+{ #category : #tests }
+ThisContextVariableTest >> testReadInContext [
+
+	| var |
+	var := self class lookupVar: #thisContext.
+	self assert: (var readInContext: thisContext) identicalTo: thisContext
+]
+
+{ #category : #tests }
+ThisContextVariableTest >> testUsingMethods [
+
+	| var |
+	var := self class lookupVar: #thisContext.
+	self assert: (var usingMethods includes: thisContext method)
+]


### PR DESCRIPTION
- add #asDoItVariableFrom: to ReservedVariable
- add tests for ThisContextVariableTest
- remove empty ReservedVariableTest
- fix testEvaluateForContext 

fixes #13791