### PR TITLE
delete unneeded tools registry redefinition

### DIFF
--- a/src/Tool-Base/ToolShortcutsCategory.class.st
+++ b/src/Tool-Base/ToolShortcutsCategory.class.st
@@ -73,8 +73,3 @@ ToolShortcutsCategory >> saveImage [
 			(Smalltalk snapshot: true andQuit: false)
 				ifFalse: [ UIManager default inform: 'Image saved' ] ]
 ]
-
-{ #category : #accessing }
-ToolShortcutsCategory >> tools [
-	^ PharoCommonTools new
-]


### PR DESCRIPTION
- tools registration is not taken into account by shortcuts because they always use default tools.
- this PR remove the override so tools use the registry

This fix is required for Moose11 (https://github.com/moosetechnology/MooseIDE/issues/844)