### PR TITLE
Change the `bench` method to return a `BenchmarkResult` instance

### DIFF
--- a/src/Kernel-Chronology-Extras/BenchmarkResult.class.st
+++ b/src/Kernel-Chronology-Extras/BenchmarkResult.class.st
@@ -91,8 +91,6 @@ BenchmarkResult >> printFrequenceOn: stream [
 
 { #category : #printing }
 BenchmarkResult >> printOn: stream [
-	super printOn: stream.
-	stream nextPut: $(.
 	self isEmpty
 		ifTrue: [
 			stream << ' empty' ]
@@ -102,8 +100,7 @@ BenchmarkResult >> printOn: stream [
 			stream << ' in '.
 			elapsedTime printHumanReadableOn: stream.
 			stream << '. '.
-			self printFrequenceOn: stream ].
-	stream nextPut: $)
+			self printFrequenceOn: stream ]
 ]
 
 { #category : #printing }

--- a/src/Kernel-Chronology-Extras/BlockClosure.extension.st
+++ b/src/Kernel-Chronology-Extras/BlockClosure.extension.st
@@ -8,9 +8,7 @@ BlockClosure >> bench [
 
 	"[3.14 printString] bench"
 
-	| benchmarkResult |
-	benchmarkResult := self benchFor: 5 seconds.
-	^ benchmarkResult shortPrintString
+	^ self benchFor: 5 seconds
 ]
 
 { #category : #'*Kernel-Chronology-Extras' }


### PR DESCRIPTION
Plus change `BenchmarkResult>>#printOn:` to look better.
@MarcusDenker's idea! :)