### PR TITLE
Change `Object>>#split:` definition as recomended by pharo-project/Pharo#13656

### DIFF
--- a/src/Collections-Abstract/Object.extension.st
+++ b/src/Collections-Abstract/Object.extension.st
@@ -28,7 +28,7 @@ Object >> split: aSequenceableCollection [
 	"([:c| c isSeparator] split: 'aa bb cc dd')>>> #('aa' 'bb' 'cc' 'dd') asOrderedCollection"
 
 	| result |
-	result := OrderedCollection new: (aSequenceableCollection size / 2) asInteger.
+	result := OrderedCollection new: aSequenceableCollection size //2.
 	self split: aSequenceableCollection do: [ :item |
 		result add: item ].
 	^ result


### PR DESCRIPTION
Change `Object>>#split:` definition as recomended by pharo-project/Pharo#13656