### PR TITLE
Move CompiledMethod>> basicNew: and basicNew to CompiledCode

### DIFF
--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -36,6 +36,18 @@ Class {
 }
 
 { #category : #'instance creation' }
+CompiledCode class >> basicNew [
+
+	self error: 'CompiledMethods may only be created with newMethod:header:'
+]
+
+{ #category : #'instance creation' }
+CompiledCode class >> basicNew: size [
+
+	self error: 'CompiledMethods may only be created with newMethod:header:'
+]
+
+{ #category : #'instance creation' }
 CompiledCode class >> newMethod: numberOfBytes header: headerWord [
 	"Primitive. Answer an instance of me. The number of literals (and other
 	 information) is specified by the headerWord (see my class comment).

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -38,13 +38,13 @@ Class {
 { #category : #'instance creation' }
 CompiledCode class >> basicNew [
 
-	self error: 'CompiledMethods may only be created with newMethod:header:'
+	self error: 'CompiledMethods and CompiledBlocks may only be created with newMethod:header:'
 ]
 
 { #category : #'instance creation' }
 CompiledCode class >> basicNew: size [
 
-	self error: 'CompiledMethods may only be created with newMethod:header:'
+	self error: 'CompiledMethods and CompiledBlocks may only be created with newMethod:header:'
 ]
 
 { #category : #'instance creation' }

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -23,18 +23,6 @@ CompiledMethod class >> abstractMarker [
 	^ #subclassResponsibility
 ]
 
-{ #category : #'instance creation' }
-CompiledMethod class >> basicNew [
-
-	self error: 'CompiledMethods may only be created with newMethod:header:'
-]
-
-{ #category : #'instance creation' }
-CompiledMethod class >> basicNew: size [
-
-	self error: 'CompiledMethods may only be created with newMethod:header:'
-]
-
 { #category : #'class initialization' }
 CompiledMethod class >> checkBytecodeSetConflictsInMethodsWith: aBlock [
 


### PR DESCRIPTION

CompiledMethod has overrides for #basicNew and #basicNew:

But CompiledBlock does not override them. This is bad, as both can not be created with basicNew

This PR moves the method to CompiledCode