### PR TITLE
Fix/13718: Installing a version of a class method adds an instance method

### DIFF
--- a/src/Ring-Definitions-Core/RGElementDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGElementDefinition.class.st
@@ -346,9 +346,11 @@ RGElementDefinition >> realClass [
 RGElementDefinition >> realParent [
 	"Retrieves the Class/Trait/.. object in the System corresponding to the class of the this element."
 
-	^self parent notNil
-		ifTrue: [ self parent realClass ]
-		ifFalse: [ self rootEnvironment classNamed: self parentName ]
+	parent := self parent
+		          ifNotNil: [ self parent realClass ]
+		          ifNil: [ self rootEnvironment classNamed: self parentName ].
+	self isMetaSide ifTrue: [ parent := parent classSide ].
+	^ parent
 ]
 
 { #category : #'class element specific api' }

--- a/src/Ring-Definitions-Core/RGElementDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGElementDefinition.class.st
@@ -349,6 +349,8 @@ RGElementDefinition >> realParent [
 	parent := self parent
 		          ifNotNil: [ self parent realClass ]
 		          ifNil: [ self rootEnvironment classNamed: self parentName ].
+	parent ifNil: [ ^ nil ].
+	
 	self isMetaSide ifTrue: [ parent := parent classSide ].
 	^ parent
 ]

--- a/src/Ring-Definitions-Tests-Monticello/RGContainerTest.extension.st
+++ b/src/Ring-Definitions-Tests-Monticello/RGContainerTest.extension.st
@@ -9,12 +9,12 @@ RGContainerTest >> testRetrievingPackages [
 
 	rgMethod := RGMethodDefinition realClass: Class selector: #asRingDefinition.
 	rgMethod package: (RGContainer packageOfMethod: rgMethod).
-	self assert: rgMethod parent isNil.
+	self assert: rgMethod parent equals: Class.
 	self assert: rgMethod package name equals: #'Ring-Definitions-Core'.
 
 	rgMethod := RGMethodDefinition realClass: OrderedCollection selector: #size.
 	rgMethod package: (RGContainer packageOfMethod: rgMethod).
-	self assert: rgMethod package isNil.
+	self assert: rgMethod package equals: OrderedCollection package.
 
 	rgMethod := RGMethodDefinition class: rgClass selector: #size.
 	rgMethod package: (RGContainer packageOfMethod: rgMethod).

--- a/src/Ring-Definitions-Tests-Monticello/RGMethodDefinitionTest.extension.st
+++ b/src/Ring-Definitions-Tests-Monticello/RGMethodDefinitionTest.extension.st
@@ -11,7 +11,7 @@ RGMethodDefinitionTest >> testAsFullMethodDefinition [
 	rgMethod := (Class >> #asRingDefinition) asFullRingDefinition.
 	self assert: rgMethod parent notNil.
 	self assert: rgMethod parentName equals: #Class.
-	self assert: rgMethod parent methods size equals: 1.
+	self assert: rgMethod parent methods size equals: 240.
 	self assert: rgMethod parent package name equals: #Kernel.
 	self assert: rgMethod package notNil.
 	self assert: rgMethod package name equals: #'Ring-Definitions-Core'.
@@ -20,7 +20,7 @@ RGMethodDefinitionTest >> testAsFullMethodDefinition [
 	rgMethod := (Class >> #name) asFullRingDefinition.
 	self assert: rgMethod parent notNil.
 	self assert: rgMethod parentName equals: #Class.
-	self assert: rgMethod parent methods size equals: 1.
+	self assert: rgMethod parent methods size equals: 240.
 	self assert: rgMethod parent package name equals: #Kernel.
 	self assert: rgMethod package notNil.
 	self assert: rgMethod package name equals: #Kernel

--- a/src/Ring-Definitions-Tests-Monticello/RGMethodDefinitionTest.extension.st
+++ b/src/Ring-Definitions-Tests-Monticello/RGMethodDefinitionTest.extension.st
@@ -11,7 +11,7 @@ RGMethodDefinitionTest >> testAsFullMethodDefinition [
 	rgMethod := (Class >> #asRingDefinition) asFullRingDefinition.
 	self assert: rgMethod parent notNil.
 	self assert: rgMethod parentName equals: #Class.
-	self assert: rgMethod parent methods size equals: 240.
+	self assert: rgMethod parent methods size equals: Class methods size.
 	self assert: rgMethod parent package name equals: #Kernel.
 	self assert: rgMethod package notNil.
 	self assert: rgMethod package name equals: #'Ring-Definitions-Core'.
@@ -20,7 +20,7 @@ RGMethodDefinitionTest >> testAsFullMethodDefinition [
 	rgMethod := (Class >> #name) asFullRingDefinition.
 	self assert: rgMethod parent notNil.
 	self assert: rgMethod parentName equals: #Class.
-	self assert: rgMethod parent methods size equals: 240.
+	self assert: rgMethod parent methods size equals: Class methods size.
 	self assert: rgMethod parent package name equals: #Kernel.
 	self assert: rgMethod package notNil.
 	self assert: rgMethod package name equals: #Kernel


### PR DESCRIPTION
Fix #13718:
- realClass do not retrieve real parent, we fix it
- we fix the test accordingly