### PR TITLE
improved TempsReadBeforeWrittenRule

### DIFF
--- a/src/GeneralRules-Tests/ReTempsReadBeforeWrittenRuleTest.class.st
+++ b/src/GeneralRules-Tests/ReTempsReadBeforeWrittenRuleTest.class.st
@@ -15,11 +15,10 @@ ReTempsReadBeforeWrittenRuleTest >> mockMethod [
 { #category : #tests }
 ReTempsReadBeforeWrittenRuleTest >> testFoundTemporaries [
 
-	| critiques |
-	critiques := self myCritiquesOnMethod: self class >> #mockMethod.
+	| temporaries |
+	temporaries := self subjectUnderTest new
+		               findReadsBeforeWrittenTemporariesIn:
+		               self class >> #mockMethod.
 
-	self assert: critiques size equals: 1.
-	self
-		assertCollection: critiques first rule temps
-		hasSameElements: #( temp1 temp2 )
+	self assertCollection: temporaries hasSameElements: #( temp1 temp2 )
 ]

--- a/src/GeneralRules-Tests/ReTempsReadBeforeWrittenRuleTest.class.st
+++ b/src/GeneralRules-Tests/ReTempsReadBeforeWrittenRuleTest.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : #ReTempsReadBeforeWrittenRuleTest,
+	#superclass : #ReAbstractRuleTestCase,
+	#category : #'GeneralRules-Tests-Migrated'
+}
+
+{ #category : #helpers }
+ReTempsReadBeforeWrittenRuleTest >> mockMethod [
+	| temp1 temp2 temp3 |
+	temp3 := 1.
+	[ temp2 := 2 ] value.
+	^ { temp1 . temp2 . temp3 }
+]
+
+{ #category : #tests }
+ReTempsReadBeforeWrittenRuleTest >> testFoundTemporaries [
+
+	| critiques |
+	critiques := self myCritiquesOnMethod: self class >> #mockMethod.
+
+	self assert: critiques size equals: 1.
+	self
+		assertCollection: critiques first rule temps
+		hasSameElements: #( temp1 temp2 )
+]

--- a/src/GeneralRules/ReTempsReadBeforeWrittenRule.class.st
+++ b/src/GeneralRules/ReTempsReadBeforeWrittenRule.class.st
@@ -16,9 +16,6 @@ NOTE: This rule detects *many* false positives.
 Class {
 	#name : #ReTempsReadBeforeWrittenRule,
 	#superclass : #ReAbstractRule,
-	#instVars : [
-		'temps'
-	],
 	#category : #'GeneralRules-Migrated'
 }
 
@@ -35,9 +32,23 @@ ReTempsReadBeforeWrittenRule class >> uniqueIdentifierName [
 ]
 
 { #category : #running }
-ReTempsReadBeforeWrittenRule >> basicCheck: aMethod [
-	self temps: ((RBReadBeforeWrittenTester variablesReadBeforeWrittenIn: aMethod ast) array select: #isNotNil).
-	^ temps isNotEmpty
+ReTempsReadBeforeWrittenRule >> check: aMethod forCritiquesDo: aCriticBlock [
+
+	(self findReadsBeforeWrittenTemporariesIn: aMethod) ifNotEmpty: [
+		:temps |
+		aCriticBlock cull: ((self critiqueFor: aMethod)
+				 tinyHint: (String streamContents: [ :stream |
+							  temps
+								  do: [ :temporary | stream nextPutAll: temporary ]
+								  separatedBy: [ stream nextPutAll: ', ' ] ]);
+				 yourself) ]
+]
+
+{ #category : #running }
+ReTempsReadBeforeWrittenRule >> findReadsBeforeWrittenTemporariesIn: aMethod [
+
+	^ (RBReadBeforeWrittenTester variablesReadBeforeWrittenIn:
+		   aMethod ast) array select: #isNotNil
 ]
 
 { #category : #accessing }
@@ -48,20 +59,5 @@ ReTempsReadBeforeWrittenRule >> group [
 { #category : #accessing }
 ReTempsReadBeforeWrittenRule >> name [
 
-	^ String streamContents: [ :stream |
-		  stream nextPutAll: 'Temporaries may be read before written ('.
-		  self temps
-			  do: [ :temporary | stream nextPutAll: temporary ]
-			  separatedBy: [ stream nextPutAll: ', ' ].
-		  stream nextPut: $) ]
-]
-
-{ #category : #accessing }
-ReTempsReadBeforeWrittenRule >> temps [
-	^ temps
-]
-
-{ #category : #accessing }
-ReTempsReadBeforeWrittenRule >> temps: anArray [
-	temps:= anArray
+	^ 'Temporaries may be read before written'
 ]

--- a/src/GeneralRules/ReTempsReadBeforeWrittenRule.class.st
+++ b/src/GeneralRules/ReTempsReadBeforeWrittenRule.class.st
@@ -16,6 +16,9 @@ NOTE: This rule detects *many* false positives.
 Class {
 	#name : #ReTempsReadBeforeWrittenRule,
 	#superclass : #ReAbstractRule,
+	#instVars : [
+		'temps'
+	],
 	#category : #'GeneralRules-Migrated'
 }
 
@@ -33,7 +36,8 @@ ReTempsReadBeforeWrittenRule class >> uniqueIdentifierName [
 
 { #category : #running }
 ReTempsReadBeforeWrittenRule >> basicCheck: aMethod [
-	^ (RBReadBeforeWrittenTester variablesReadBeforeWrittenIn: aMethod ast) isNotEmpty
+	self temps: ((RBReadBeforeWrittenTester variablesReadBeforeWrittenIn: aMethod ast) array select: #isNotNil).
+	^ temps isNotEmpty
 ]
 
 { #category : #accessing }
@@ -43,5 +47,21 @@ ReTempsReadBeforeWrittenRule >> group [
 
 { #category : #accessing }
 ReTempsReadBeforeWrittenRule >> name [
-	^ 'Temporaries may be read before written'
+
+	^ String streamContents: [ :stream |
+		  stream nextPutAll: 'Temporaries may be read before written ('.
+		  self temps
+			  do: [ :temporary | stream nextPutAll: temporary ]
+			  separatedBy: [ stream nextPutAll: ', ' ].
+		  stream nextPut: $) ]
+]
+
+{ #category : #accessing }
+ReTempsReadBeforeWrittenRule >> temps [
+	^ temps
+]
+
+{ #category : #accessing }
+ReTempsReadBeforeWrittenRule >> temps: anArray [
+	temps:= anArray
 ]


### PR DESCRIPTION
When temporaries are read before written, those temporaries will be displayed in the rule warning