### PR TITLE
13797-Monticello-can-not-create-the-class-CompileCode-subclasses 

### DIFF
--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -274,9 +274,9 @@ MCClassDefinition >> initializeWithName: nameString superclassName: superclassSt
 	traitComposition := traitCompositionString.
 	classTraitComposition := classTraitCompositionString.
 	category := categoryString.
-	name = #CompiledMethod
-		ifTrue: [ type := #compiledMethod ]
-		ifFalse: [ type := typeSymbol ].
+	 type := (#(#CompiledMethod #CompiledBlock #CompiledCode) includes: name)
+		ifTrue: [ #compiledMethod ]
+		ifFalse: [ typeSymbol ].
 	comment := commentString withInternalLineEndings.
 	commentStamp := stampStringOrNil ifNil: [ self defaultCommentStamp ].
 	variables := OrderedCollection new.


### PR DESCRIPTION
- add all the names of the classes that have CompiledMethodLayout to the hard coded way so we are able to create them

fixes #13797