### PR TITLE
Run coverage button is enabled with unselected packages ( Dr Tests )

### DIFF
--- a/src/DrTests-TestCoverage/DTTestCoverageResult.class.st
+++ b/src/DrTests-TestCoverage/DTTestCoverageResult.class.st
@@ -18,15 +18,22 @@ Class {
 DTTestCoverageResult >> buildTreeForUI [
 	<dtTestCoverageResultTreeNamed: 'List of uncovered methods' order: 1>
 	^ DTTreeNode new
-		subResults:
-			{(DTTreeNode new
-				name: (percent * 100 printShowingDecimalPlaces: 2) , ' % Code Coverage';
-				subResults: {};
-				yourself).
-			(DTTreeNode new
-				name: 'Uncovered methods';
-				subResults: (self methodList collect: [:each | each asResultForDrTest]);
-				yourself)}
+		subResults: (self methodList 
+		ifNotNil: [
+        {(DTTreeNode new
+            name: (percent * 100 printShowingDecimalPlaces: 2) , ' % Code Coverage';
+            subResults: {};
+            yourself).
+        (DTTreeNode new
+            name: 'Uncovered methods';
+            subResults: (self methodList collect: [:each | each asResultForDrTest]);
+            yourself)}
+    	]ifNil: [
+       	 {(DTTreeNode new
+        	    name: 'no package has been selected';
+      	 	    subResults: {};
+             yourself)}
+    	])
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
#13806
This PR contains a modification to prevent the exception of "collect was sent to nil"