### PR TITLE
Deprecate Context>>#lookupTempVar:

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -51,10 +51,12 @@ Context >> instructionStream [
 
 { #category : #'*Debugging-Core' }
 Context >> lookupTempVar: aSymbol [
-	| var |
-	var := self lookupVar: aSymbol.
-	var isLocalVariable ifFalse: [ ^self error: var name, ' is not a temp but, ', var class name].
-	^var
+
+	self
+		deprecated: 'Use lookupVar: instead'
+		transformWith: '`@receiver lookupTempVar: `@argument'
+			-> '`@receiver lookupVar: `@argument'.
+	^ self lookupVar: aSymbol
 ]
 
 { #category : #'*Debugging-Core' }
@@ -373,14 +375,14 @@ Context class >> tallyMethods: aBlock [
 Context >> tempNamed: aName [
 	"Returns the value of the temporaries, aName"
 
-	^(self lookupTempVar: aName) readInContext: self
+	^(self lookupVar: aName) readInContext: self
 ]
 
 { #category : #'*Debugging-Core' }
 Context >> tempNamed: aName put: anObject [
 	"Assign the value of the temp with name in aContext"
 	
-	^(self lookupTempVar: aName) write: anObject inContext: self
+	^(self lookupVar: aName) write: anObject inContext: self
 ]
 
 { #category : #'*Debugging-Core' }
@@ -400,7 +402,7 @@ Context >> tempNames [
 Context >> temporaryVariableNamed: aName [
 	(self hasTemporaryVariableNamed: aName)
 		ifFalse: [ ^ nil ].
-	^self lookupTempVar: aName
+	^self lookupVar: aName
 ]
 
 { #category : #'*Debugging-Core' }

--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -374,15 +374,23 @@ Context class >> tallyMethods: aBlock [
 { #category : #'*Debugging-Core' }
 Context >> tempNamed: aName [
 	"Returns the value of the temporaries, aName"
-
-	^(self lookupVar: aName) readInContext: self
+	| var |
+	var := self lookupVar: aName.
+	"To be checked. if we keep the error, we should raise a dedicated exception, 
+	but no client would catch it, so why do we need it at all?"
+ 	var isLocalVariable ifFalse: [ ^self error: var name, ' is not a temp but, ', var class name].
+	^var readInContext: self
 ]
 
 { #category : #'*Debugging-Core' }
 Context >> tempNamed: aName put: anObject [
 	"Assign the value of the temp with name in aContext"
-	
-	^(self lookupVar: aName) write: anObject inContext: self
+	| var |
+	var := self lookupVar: aName.
+	"To be checked. if we keep the error, we should raise a dedicated exception, 
+	but no client would catch it, so why do we need it at all?"
+ 	var isLocalVariable ifFalse: [ ^self error: var name, ' is not a temp but, ', var class name].
+	^var write: anObject inContext: self
 ]
 
 { #category : #'*Debugging-Core' }

--- a/src/Reflectivity-Tests/LinkInstallerTest.class.st
+++ b/src/Reflectivity-Tests/LinkInstallerTest.class.st
@@ -144,7 +144,7 @@ LinkInstallerTest >> testLinkOnTempVar [
 	| methodNode link variable |
 	methodNode := (ReflectivityExamples2 >> #methodWithTempVarAccess) ast.
 	link := MetaLink new.
-	variable := (ReflectivityExamples2 >> #methodWithTempVarAccess) temporaryVariableNamed: #temp.
+	variable := (ReflectivityExamples2 >> #methodWithTempVarAccess) lookupVar: #temp.
 
 	link installOnVariable: variable
 		for: ReflectivityExamples2
@@ -157,7 +157,7 @@ LinkInstallerTest >> testLinkOnTempVar [
 	link uninstall.
 	self assert: link nodes isEmpty.
 
-	variable := (ReflectivityExamples2 >> #methodWithTempVarAccess) temporaryVariableNamed: #temp.
+	variable := (ReflectivityExamples2 >> #methodWithTempVarAccess) lookupVar: #temp.
 	link installOnVariable: variable
 		for: ReflectivityExamples2
 		option: #write
@@ -169,7 +169,7 @@ LinkInstallerTest >> testLinkOnTempVar [
 	link uninstall.
 	self assert: link nodes isEmpty.
 
-	variable := (ReflectivityExamples2 >> #methodWithTempVarAccess) temporaryVariableNamed: #temp.
+	variable := (ReflectivityExamples2 >> #methodWithTempVarAccess) lookupVar: #temp.
 	link installOnVariable: variable
 		for: ReflectivityExamples2
 		option: #all

--- a/src/Reflectivity/RFTempRead.class.st
+++ b/src/Reflectivity/RFTempRead.class.st
@@ -27,5 +27,5 @@ RFTempRead >> value [
 
 { #category : #accessing }
 RFTempRead >> variableName: aSymbol [
-	variable := context temporaryVariableNamed: aSymbol
+	variable := context lookupVar: aSymbol
 ]

--- a/src/Reflectivity/RFTempWrite.class.st
+++ b/src/Reflectivity/RFTempWrite.class.st
@@ -27,5 +27,5 @@ RFTempWrite >> value [
 
 { #category : #accessing }
 RFTempWrite >> variableName: aSymbol [
-	variable := context temporaryVariableNamed: aSymbol
+	variable := context lookupVar: aSymbol
 ]

--- a/src/Slot-Tests/TemporaryVariableTest.class.st
+++ b/src/Slot-Tests/TemporaryVariableTest.class.st
@@ -50,7 +50,7 @@ TemporaryVariableTest >> testPropertyAtPut [
 	| testValue temp |
 
 	testValue := Date today.
-	temp := thisContext temporaryVariableNamed:  #testValue.
+	temp := thisContext lookupVar:  #testValue.
 
 	temp propertyAt: #testKeySelector put: testValue.
 	self
@@ -66,15 +66,15 @@ TemporaryVariableTest >> testReadNodes [
 	| method |
 	"On the level of CompiledMethod, args include temps. This needs to be fixed"
 	method := OrderedCollection >> #do:.
-	self assert: (method temporaryVariableNamed: #aBlock) astNodes notEmpty
+	self assert: (method lookupVar: #aBlock) astNodes notEmpty
 ]
 
 { #category : #tests }
 TemporaryVariableTest >> testReadTemporaryVariablesMethod [
 	| tempVar |
-	tempVar := thisContext temporaryVariableNamed: #tempVar.
+	tempVar := thisContext lookupVar: #tempVar.
 
-	self assert: (tempVar readInContext: thisContext) class equals: TemporaryVariable
+	self assert: (tempVar readInContext: thisContext) equals: tempVar
 ]
 
 { #category : #tests }
@@ -104,13 +104,13 @@ TemporaryVariableTest >> testTemporaryVariablesMethod [
 	method := OrderedCollection >> #do:.
 	self assert: method temporaryVariables first name equals: #aBlock.
 	self assert: (method hasTemporaryVariableNamed: #aBlock).
-	self assert: (method temporaryVariableNamed: #aBlock) class equals: ArgumentVariable
+	self assert: (method lookupVar: #aBlock) class equals: ArgumentVariable
 ]
 
 { #category : #tests }
 TemporaryVariableTest >> testWriteTemporaryVariablesMethod [
 	| tempVar |
-	tempVar := thisContext temporaryVariableNamed: #tempVar.
+	tempVar := thisContext lookupVar: #tempVar.
 
 	tempVar write: 5 inContext: thisContext.
 	self assert: tempVar equals: 5


### PR DESCRIPTION
Variable lookup is still quite arcane. This PR is another tiny step to simplify.

- Context>>#lookupTempVar: was just checking if the var is a temp, but senders do not need the check, so we can deprecate this and just use #lookupVar:
	- #temporaryVariableNamed: checks already and returns nil
	- #tempNamed: and #tempNamed:put: can just use lookupVar:, too, for now ne conservative and add the check there
- Check all users of #temporaryVariableNamed:. Change all  (besides the ones from newtools, that is another PR)  to instead use #lookupVar:

In general,  clients reading variables normally do not needed to know which kind of variable they read, this PR is a small step to clean that up.