### PR TITLE
Fix System Browser scaling

### DIFF
--- a/src/Calypso-Browser/ClyBrowserMorph.class.st
+++ b/src/Calypso-Browser/ClyBrowserMorph.class.st
@@ -348,7 +348,7 @@ ClyBrowserMorph >> ignoreNavigationDuring: aBlock [
 
 { #category : #initialization }
 ClyBrowserMorph >> initialExtent [
-	^ 850@620
+	^ 850@620 * self currentWorld displayScaleFactor
 ]
 
 { #category : #initialization }

--- a/src/Calypso-Browser/ClyNotebookPageActionButtonMorph.class.st
+++ b/src/Calypso-Browser/ClyNotebookPageActionButtonMorph.class.st
@@ -52,7 +52,7 @@ ClyNotebookPageActionButtonMorph >> forAction: anAction [
 		passiveEnabledOverDownFillStyle: (self theme buttonPressedFillStyleFor: self);
 		addUpAction: [ anAction action value ];
 		setBalloonText: anAction label;
-		extent: 16@16.
+		extent: 16@16 * self currentWorld displayScaleFactor.
 
 	icon := anAction icon.
 

--- a/src/Calypso-Browser/ClyNotebookPageMorph.class.st
+++ b/src/Calypso-Browser/ClyNotebookPageMorph.class.st
@@ -79,7 +79,7 @@ ClyNotebookPageMorph >> initialize [
 	But this is not good, think a better way."
 	labelMorph := labelPresenter build
 		              hResizing: #rigid;
-		              width: 120;
+		              width: 120 * self currentWorld displayScaleFactor;
 		              yourself
 ]
 

--- a/src/Calypso-Browser/ClyToolbarMorph.class.st
+++ b/src/Calypso-Browser/ClyToolbarMorph.class.st
@@ -61,7 +61,7 @@ ClyToolbarMorph >> browser: anObject [
 
 { #category : #initialization }
 ClyToolbarMorph >> defaultHeight [
-	^30
+	^ 30 * self currentWorld displayScaleFactor
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
This pull request fixes some methods in ‘Calypso-Browser’ that used width and height constants without taking the display scale factor into account.

Screenshot of a System Browser after these changes:

<p align="center">
<img width="500" src="https://github.com/pharo-project/pharo/assets/1611248/a67216e2-795a-47db-9b9e-45bcf63dfc79">
</p>

The above screenshot was made after doing the snippets for ‘Retina display’ scaling from the comments in pull request #13767 (the message sent to SpFontStyle requires merging [Spec pull request 1397](https://github.com/pharo-spec/Spec/pull/1397)):

```smalltalk
WorldMorph displayScaleFactor: 2.
SourceCodeFonts setSourceCodeFonts: SourceCodeFonts sizeSmall * WorldMorph displayScaleFactor.
ToggleWithSymbolMenuItemShortcut
	classVarNamed: 'SymbolFont'
		put: (LogicalFont familyName: 'Lucida Grande' pointSize: 10 * WorldMorph displayScaleFactor);
	classVarNamed: 'SymbolTable' put: nil.
ThemeIcons current: ((ThemeIcons named: 'svgPack') in: [ :themeIcons |
	(themeIcons respondsTo: #loadIconsFromUrlUsingScale:) ifTrue: [
		themeIcons loadIconsFromUrlUsingScale: WorldMorph displayScaleFactor ] ];
	yourself).
World scaleFactor: WorldMorph displayScaleFactor reciprocal.
SpFontStyle applyDisplayScaleFactor: false.
```