### PR TITLE
Fix System Browser tables scaling

### DIFF
--- a/src/Calypso-Browser/ClyMainItemCellMorph.class.st
+++ b/src/Calypso-Browser/ClyMainItemCellMorph.class.st
@@ -74,7 +74,7 @@ ClyMainItemCellMorph >> addBarForLabelIndentation [
 	mainItemsCount := placeForExpansionRequired ifTrue: [ 2 ] ifFalse: [ 1 ].
 	absentItemsCount := mainItemsCount - submorphs size.
 
-	requiredWidth := absentItemsCount * 16 + (self itemDepth * 8).
+	requiredWidth := (absentItemsCount * 16 + (self itemDepth * 8)) * self currentWorld displayScaleFactor.
 	requiredWidth = 0 ifTrue: [ ^self ].
 
 	self addMorphBack: (self emptyBarWithWidth: requiredWidth)

--- a/src/Calypso-Browser/ClyMainItemCellMorph.class.st
+++ b/src/Calypso-Browser/ClyMainItemCellMorph.class.st
@@ -60,7 +60,7 @@ ClyMainItemCellMorph >> addBarForFullIndentation [
 	mainItemsCount := 0.
 	absentItemsCount := mainItemsCount - submorphs size.
 
-	requiredWidth := absentItemsCount * 16 + (self itemDepth * 8).
+	requiredWidth := (absentItemsCount * 16 + (self itemDepth * 8)) * self currentWorld displayScaleFactor.
 	requiredWidth = 0 ifTrue: [ ^self ].
 
 	self addMorphBack: (self emptyBarWithWidth: requiredWidth)

--- a/src/Calypso-Browser/ClyMainItemCellMorph.class.st
+++ b/src/Calypso-Browser/ClyMainItemCellMorph.class.st
@@ -141,13 +141,13 @@ ClyMainItemCellMorph >> buildWithLabelIndentation [
 		expansionButton := self currentExpansionButton.
 		self addMorphBack: expansionButton].
 	definitionMorph ifNotNil: [
-		definitionMorph width: 16.
+		definitionMorph width: 16 * self currentWorld displayScaleFactor.
 		 self addMorphBack: definitionMorph].
 
 	self addBarForLabelIndentation.
 	self addMorphBack: label.
 	extraToolMorphs ifNotNil: [ extraToolMorphs do: [:each |
-			each width: 16.
+			each width: 16 * self currentWorld displayScaleFactor.
 			 self addMorphBack: each  ] ]
 ]
 

--- a/src/Calypso-SystemPlugins-InheritanceAnalysis-Browser/ClyOverriddenMethodTableDecorator.class.st
+++ b/src/Calypso-SystemPlugins-InheritanceAnalysis-Browser/ClyOverriddenMethodTableDecorator.class.st
@@ -23,7 +23,7 @@ ClyOverriddenMethodTableDecorator class >> createMultiIconMorph [
 		listDirection: #topToBottom;
 		listCentering: #center;
 		wrapCentering: #center;
-		extent: 16@16;
+		extent: 16@16 * self currentWorld displayScaleFactor;
 		color: Color transparent
 ]
 

--- a/src/Morphic-Core/BorderStyle.class.st
+++ b/src/Morphic-Core/BorderStyle.class.st
@@ -40,7 +40,7 @@ BorderStyle class >> default [
 
 { #category : #'instance creation' }
 BorderStyle class >> thinGray [
-	^ self width: 1 color: Color gray
+	^ self width: 1 * self currentWorld displayScaleFactor color: Color gray
 ]
 
 { #category : #'instance creation' }

--- a/src/Morphic-Widgets-Basic/IconicButtonMorph.class.st
+++ b/src/Morphic-Widgets-Basic/IconicButtonMorph.class.st
@@ -81,7 +81,7 @@ IconicButtonMorph >> extent: newExtent [
 { #category : #accessing }
 IconicButtonMorph >> extraBorder [
 
-	^ 6
+	^ 6 * self currentWorld displayScaleFactor
 ]
 
 { #category : #accessing }

--- a/src/Morphic-Widgets-FastTable/FTTreeDataSource.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTreeDataSource.class.st
@@ -88,7 +88,7 @@ FTTreeDataSource class >> defaultSearchStrategies [
 FTTreeDataSource class >> emptyMorph [
 	| icon |
 	icon := (Smalltalk ui icons iconNamed: #empty) asMorph.
-	icon form: (icon form scaledToSize: 16 @ 16).
+	icon form: (icon form scaledToSize: 16 @ 16 * self currentWorld displayScaleFactor).
 	^ icon
 ]
 


### PR DESCRIPTION
This pull request fixes methods related to the tables at the top of a System Browser that used width and height constants without taking the display scale factor into account.

Screenshot after these changes (compare with the one in pull request #13848):

<p align="center">
<img width="500" src="https://github.com/pharo-project/pharo/assets/1611248/45de58ae-f955-4d60-af8c-d9d872bab646">
</p>
