### PR TITLE
13847-Typing-in-Class-definition-pane-in-Calypso-raises-error-at-each-keystroke

### DIFF
--- a/src/Calypso-Browser/ClyTextEditorToolMorph.class.st
+++ b/src/Calypso-Browser/ClyTextEditorToolMorph.class.st
@@ -205,7 +205,9 @@ ClyTextEditorToolMorph >> findAnyString: strings in: text [
 
 { #category : #'rubric interaction model' }
 ClyTextEditorToolMorph >> hasBindingOf: aString [
-	^self selectedClassOrMetaClass hasBindingOf: aString
+	^self selectedClassOrMetaClass 
+		ifNil: [ false ]
+		ifNotNil: [:class | class hasBindingOf: aString]
 ]
 
 { #category : #testing }


### PR DESCRIPTION
Due to removing #hasBindingOf: from Object, we call it in some cases on nil, we can fix that by checking for nil


This fixes #13847