### PR TITLE
Clean #extensionCategoriesForClass:

### DIFF
--- a/src/Gofer-Core/GoferCleanup.class.st
+++ b/src/Gofer-Core/GoferCleanup.class.st
@@ -27,7 +27,7 @@ GoferCleanup >> cleanupCategories: aWorkingCopy [
 GoferCleanup >> cleanupProtocols: aWorkingCopy [
 
 	aWorkingCopy packageSet extendedClasses do: [ :class |
-		(aWorkingCopy packageSet extensionCategoriesForClass: class) do: [ :protocol | class removeProtocolIfEmpty: protocol ] ].
+		(aWorkingCopy packageSet extensionProtocolsForClass: class) do: [ :protocol | class removeProtocolIfEmpty: protocol ] ].
 
 	aWorkingCopy packageSet classesAndMetaClasses do: [ :class |
 		(aWorkingCopy packageSet coreCategoriesForClass: class) do: [ :category | class removeProtocolIfEmpty: category ] ]

--- a/src/Gofer-Core/GoferCleanup.class.st
+++ b/src/Gofer-Core/GoferCleanup.class.st
@@ -27,7 +27,7 @@ GoferCleanup >> cleanupCategories: aWorkingCopy [
 GoferCleanup >> cleanupProtocols: aWorkingCopy [
 
 	aWorkingCopy packageSet extendedClasses do: [ :class |
-		(aWorkingCopy packageSet extensionCategoriesForClass: class) do: [ :protocolName | class removeProtocolIfEmpty: protocolName ] ].
+		(aWorkingCopy packageSet extensionCategoriesForClass: class) do: [ :protocol | class removeProtocolIfEmpty: protocol ] ].
 
 	aWorkingCopy packageSet classesAndMetaClasses do: [ :class |
 		(aWorkingCopy packageSet coreCategoriesForClass: class) do: [ :category | class removeProtocolIfEmpty: category ] ]

--- a/src/Metacello-MC/MetacelloMCVersion.class.st
+++ b/src/Metacello-MC/MetacelloMCVersion.class.st
@@ -81,12 +81,6 @@ MetacelloMCVersion >> currentlyLoadedClassesInVersion [
 ]
 
 { #category : #querying }
-MetacelloMCVersion >> currentlyLoadedExtensionClassesInVersion [
-
-	^self spec currentlyLoadedExtensionClassesInVersion
-]
-
-{ #category : #querying }
 MetacelloMCVersion >> defaultPackageNamesToLoad [
 	"Answer the list of packages and projects to be loaded --> packages already loaded"
 	

--- a/src/Metacello-MC/MetacelloMCVersionSpec.class.st
+++ b/src/Metacello-MC/MetacelloMCVersionSpec.class.st
@@ -101,24 +101,6 @@ MetacelloMCVersionSpec >> currentlyLoadedClassesInVersion [
 ]
 
 { #category : #querying }
-MetacelloMCVersionSpec >> currentlyLoadedExtensionClassesInVersion [
-	| classes |
-	classes := Dictionary new.
-	self
-		projectDo: [ :ignored |  ]
-		packageDo: [ :packageSpec | 
-			([ packageSpec workingCopy ]
-				on: Error
-				do: [ :ex | ex return: nil ])
-				ifNotNil: [ :workingCopy | 
-					| packageInfo |
-					packageInfo := MetacelloPlatform current packageInfoFor: workingCopy.
-					packageInfo extendedClasses do: [ :cl | classes at: cl put: (packageInfo extensionCategoriesForClass: cl) ] ] ]
-		groupDo: [ :ignored |  ].
-	^ classes
-]
-
-{ #category : #querying }
 MetacelloMCVersionSpec >> difference: otherVersionSpec [
     "Return a dictionary of additions, removals and modifications"
 

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -649,8 +649,7 @@ RPackage >> extendsClass: aClass [
 { #category : #'system compatibility' }
 RPackage >> extensionCategoriesForClass: aClass [
 
-	self flag: #stef. "only used by goferCleanUp and PackageEnvironment of RB"
-	^ aClass protocolNames select: [ :cat | self isYourClassExtension: cat ]
+	^ aClass organization protocols select: [ :protocol | self isYourClassExtension: protocol name ]
 ]
 
 { #category : #accessing }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -649,7 +649,10 @@ RPackage >> extendsClass: aClass [
 { #category : #'system compatibility' }
 RPackage >> extensionCategoriesForClass: aClass [
 
-	^ aClass organization protocols select: [ :protocol | self isYourClassExtension: protocol name ]
+	self
+		deprecated: 'Use #extensionProtocolsForClass: instead.'
+		transformWith: '`@rcv extensionCategoriesForClass: `@arg' -> '`@rcv extensionProtocolsForClass: `@arg'.
+	^ self extensionProtocolsForClass: aClass
 ]
 
 { #category : #accessing }
@@ -671,6 +674,12 @@ RPackage >> extensionMethodsForClass: aClass [
 	"Change the set of extensions selectors to an Array to avoid compiled methods collisions in the resulting set."
 
 	^ (self extensionSelectorsForClass: aClass) asArray collect: [ :each | aClass >> each ]
+]
+
+{ #category : #'system compatibility' }
+RPackage >> extensionProtocolsForClass: aClass [
+
+	^ aClass organization protocols select: [ :protocol | self isYourClassExtension: protocol name ]
 ]
 
 { #category : #accessing }
@@ -928,8 +937,9 @@ RPackage >> isTestPackage [
 ]
 
 { #category : #'system compatibility' }
-RPackage >> isYourClassExtension: categoryName [
-	^ categoryName notNil and: [self category: categoryName asLowercase matches: self methodCategoryPrefix]
+RPackage >> isYourClassExtension: protocolName [
+
+	^ protocolName isNotNil and: [ self category: protocolName asLowercase matches: self methodCategoryPrefix ]
 ]
 
 { #category : #queries }

--- a/src/RPackage-Core/RPackageSet.class.st
+++ b/src/RPackage-Core/RPackageSet.class.st
@@ -114,7 +114,10 @@ RPackageSet >> extendedClasses [
 { #category : #'system compatibility' }
 RPackageSet >> extensionCategoriesForClass: aClass [
 
-	^ aClass organization protocols select: [ :protocol | self isYourClassExtension: protocol name ]
+	self
+		deprecated: 'Use #extensionProtocolsForClass: instead.'
+		transformWith: '`@rcv extensionCategoriesForClass: `@arg' -> '`@rcv extensionProtocolsForClass: `@arg'.
+	^ self extensionProtocolsForClass: aClass
 ]
 
 { #category : #accessing }
@@ -122,6 +125,12 @@ RPackageSet >> extensionMethods [
 	^ extensionMethods ifNil: [
 		extensionMethods :=
 		(self packages flatCollect: [ :p | p extensionMethods ] as: Set) asArray ]
+]
+
+{ #category : #'system compatibility' }
+RPackageSet >> extensionProtocolsForClass: aClass [
+
+	^ aClass organization protocols select: [ :protocol | self isYourClassExtension: protocol name ]
 ]
 
 { #category : #testing }

--- a/src/RPackage-Core/RPackageSet.class.st
+++ b/src/RPackage-Core/RPackageSet.class.st
@@ -114,7 +114,7 @@ RPackageSet >> extendedClasses [
 { #category : #'system compatibility' }
 RPackageSet >> extensionCategoriesForClass: aClass [
 
-	^ aClass protocolNames select: [ :cat | self isYourClassExtension: cat ]
+	^ aClass organization protocols select: [ :protocol | self isYourClassExtension: protocol name ]
 ]
 
 { #category : #accessing }

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -86,7 +86,17 @@ RPackageTag >> extendedClasses [
 
 { #category : #accessing }
 RPackageTag >> extensionCategoriesForClass: aClass [
-	^ self package extensionCategoriesForClass: aClass
+
+	self
+		deprecated: 'Use #extensionProtocolsForClass: instead.'
+		transformWith: '`@rcv extensionCategoriesForClass: `@arg' -> '`@rcv extensionProtocolsForClass: `@arg'.
+	^ self extensionProtocolsForClass: aClass
+]
+
+{ #category : #accessing }
+RPackageTag >> extensionProtocolsForClass: aClass [
+
+	^ self package extensionProtocolsForClass: aClass
 ]
 
 { #category : #testing }

--- a/src/Refactoring-Environment/RBPackageEnvironment.class.st
+++ b/src/Refactoring-Environment/RBPackageEnvironment.class.st
@@ -122,7 +122,7 @@ RBPackageEnvironment >> includesCategory: aCategory [
 RBPackageEnvironment >> includesClass: aClass [
 
 	^ (super includesClass: aClass) and: [
-		  self packages anySatisfy: [ :package | (package includesClass: aClass) or: [ (package extensionCategoriesForClass: aClass) isNotEmpty ] ] ]
+		  self packages anySatisfy: [ :package | (package includesClass: aClass) or: [ (package extensionProtocolsForClass: aClass) isNotEmpty ] ] ]
 ]
 
 { #category : #testing }

--- a/src/Refactoring-Environment/RBPackageEnvironment.class.st
+++ b/src/Refactoring-Environment/RBPackageEnvironment.class.st
@@ -120,10 +120,9 @@ RBPackageEnvironment >> includesCategory: aCategory [
 
 { #category : #testing }
 RBPackageEnvironment >> includesClass: aClass [
+
 	^ (super includesClass: aClass) and: [
-		self packages anySatisfy: [ :package |
-			(package includesClass: aClass) or: [
-			(package extensionCategoriesForClass: aClass) notEmpty ]]]
+		  self packages anySatisfy: [ :package | (package includesClass: aClass) or: [ (package extensionCategoriesForClass: aClass) isNotEmpty ] ] ]
 ]
 
 { #category : #testing }


### PR DESCRIPTION
- Make the method return protocols instead of names
- Remove senders that were dead code
- Rename it into extensionProtocolsForClass:

