### PR TITLE
13591-Clean-Blocks-self-is-nil-on-Debugger 

### DIFF
--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -918,8 +918,8 @@ Context >> home [
 	"Answer the context in which the receiver was defined, i.e. the context from which an ^-return ] should return from."
 
 	closureOrNil ifNil: [ ^ self ].
-	"this happens for clean blocks. We should later check if it is not better to return nil"
-	closureOrNil outerContext ifNil: [ ^ self ].
+	"this happens for clean blocks, we try to find the home on the stack"
+	closureOrNil outerContext ifNil: [ ^ self activeHome ].
 	^ closureOrNil outerContext home
 ]
 

--- a/src/Kernel/SelfVariable.class.st
+++ b/src/Kernel/SelfVariable.class.st
@@ -18,7 +18,7 @@ SelfVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 	^ aProgramNodeVisitor visitSelfNode: aNode
 ]
 
-{ #category : #emitting }
+{ #category : #'code generation' }
 SelfVariable >> emitValue: methodBuilder [
 
 	methodBuilder pushReceiver
@@ -32,7 +32,7 @@ SelfVariable >> isSelfVariable [
 { #category : #debugging }
 SelfVariable >> readInContext: aContext [
 	"self in a block is the receiver of the home context
-	For clean blocks it mght not be known (nil)"
+	For clean blocks it might not be known (nil)"
 	^aContext home ifNotNil: [:home | home receiver ]
 ]
 

--- a/src/Kernel/SelfVariable.class.st
+++ b/src/Kernel/SelfVariable.class.st
@@ -31,7 +31,9 @@ SelfVariable >> isSelfVariable [
 
 { #category : #debugging }
 SelfVariable >> readInContext: aContext [
-	^aContext receiver
+	"self in a block is the receiver of the home context
+	For clean blocks it mght not be known (nil)"
+	^aContext home ifNotNil: [:home | home receiver ]
 ]
 
 { #category : #queries }

--- a/src/Kernel/SuperVariable.class.st
+++ b/src/Kernel/SuperVariable.class.st
@@ -17,7 +17,7 @@ SuperVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 	^ aProgramNodeVisitor visitSuperNode: aNode
 ]
 
-{ #category : #emitting }
+{ #category : #'code generation' }
 SuperVariable >> emitValue: methodBuilder [
 	"super references the receiver, send that follows is a super send (the message lookup starts in the superclass)"
 	methodBuilder pushReceiver

--- a/src/Kernel/ThisContextVariable.class.st
+++ b/src/Kernel/ThisContextVariable.class.st
@@ -17,7 +17,7 @@ ThisContextVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 	^ aProgramNodeVisitor visitThisContextNode: aNode
 ]
 
-{ #category : #emitting }
+{ #category : #'code generation' }
 ThisContextVariable >> emitValue: methodBuilder [
 
 	methodBuilder pushThisContext

--- a/src/Slot-Tests/SelfVariableTest.class.st
+++ b/src/Slot-Tests/SelfVariableTest.class.st
@@ -5,6 +5,29 @@ Class {
 }
 
 { #category : #tests }
+SelfVariableTest >> testReadInContext [
+
+	| var |
+	var := self class lookupVar: #self.
+	self assert: (var readInContext: thisContext) identicalTo: self.
+	"read from a block context"
+	self assert: [(var readInContext: thisContext)] value identicalTo: self
+]
+
+{ #category : #tests }
+SelfVariableTest >> testReadInContextClean [
+	<compilerOptions: #( +optionCleanBlockClosure)>
+	| var block |
+	"if context is one stack we can read"
+	block := [ (thisContext lookupVar: #self) readInContext: thisContext ].
+	self assert: block value equals: self.
+	"but no chance if not, then it it is nil"
+	var := self class lookupVar: #self.
+	block :=  [ thisContext ].
+	self assert: (var readInContext: block value ) equals: nil
+]
+
+{ #category : #tests }
 SelfVariableTest >> testUsingMethods [
 
 	|  var |

--- a/src/Slot-Tests/SelfVariableTest.class.st
+++ b/src/Slot-Tests/SelfVariableTest.class.st
@@ -21,7 +21,7 @@ SelfVariableTest >> testReadInContextClean [
 	"if context is one stack we can read"
 	block := [ (thisContext lookupVar: #self) readInContext: thisContext ].
 	self assert: block value equals: self.
-	"but no chance if not, then it it is nil"
+	"but no chance if not, then it is nil"
 	var := self class lookupVar: #self.
 	block :=  [ thisContext ].
 	self assert: (var readInContext: block value ) equals: nil


### PR DESCRIPTION
- #readInContext: reads the receiver of the home context
- change Context>>#home to fall back on #activeHome
- add two tests

fixes #13591