### PR TITLE
fix variable names in BlockClosureTest

### DIFF
--- a/src/Kernel-Tests-Extended/BlockClosureTest.extension.st
+++ b/src/Kernel-Tests-Extended/BlockClosureTest.extension.st
@@ -35,7 +35,7 @@ BlockClosureTest >> testCannotReturn [
 
 { #category : #'*Kernel-Tests-Extended' }
 BlockClosureTest >> testRunSimulated [
-	self assert: (Context runSimulated: aBlockContext) class equals: Rectangle
+	self assert: (Context runSimulated: aBlock) class equals: Rectangle
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
@@ -54,11 +54,11 @@ BlockClosureTest >> testTallyInstructions [
 		            ifTrue: [ 26 ]
 		            ifFalse: [ 27 ].
 	self
-		assert: (Context tallyInstructions: aBlockContext) size
+		assert: (Context tallyInstructions: aBlock) size
 		equals: expected
 ]
 
 { #category : #'*Kernel-Tests-Extended' }
 BlockClosureTest >> testTallyMethods [
-	self assert: (Context tallyMethods: aBlockContext) size equals: 7
+	self assert: (Context tallyMethods: aBlock) size equals: 7
 ]

--- a/src/Kernel-Tests/BlockClosureTest.class.st
+++ b/src/Kernel-Tests/BlockClosureTest.class.st
@@ -5,8 +5,8 @@ Class {
 	#name : #BlockClosureTest,
 	#superclass : #TestCase,
 	#instVars : [
-		'aBlockContext',
-		'contextOfaBlockContext'
+		'aBlock',
+		'contextOfaBlock'
 	],
 	#category : #'Kernel-Tests-Methods'
 }
@@ -21,8 +21,8 @@ BlockClosureTest >> blockWithNonLocalReturn: resultObject [
 BlockClosureTest >> setUp [
 	super setUp.
 	"we reference self to force a full block"
-	aBlockContext := [self . 100@100 corner: 200@200].
-	contextOfaBlockContext := thisContext
+	aBlock := [self . 100@100 corner: 200@200].
+	contextOfaBlock := thisContext
 ]
 
 { #category : #'tests - evaluating' }
@@ -187,7 +187,7 @@ BlockClosureTest >> testIsClean [
 	self deny: [^nil] isClean. "closes over home (^-return)"
 	self deny: [self] isClean. "closes over the receiver"
 	self deny: [super testIsClean] isClean. "closes over the receiver"
-	self deny: [contextOfaBlockContext] isClean. "closes over the receiver (to access the inst var contextOfaBlockContext)"
+	self deny: [contextOfaBlock] isClean. "closes over the receiver (to access the inst var contextOfaBlockContext)"
 	self deny: [local] isClean. "closes over local variable of outer context"
 ]
 
@@ -373,10 +373,10 @@ BlockClosureTest >> testPrintOnBlockDefinedInMethodWithoutSourceCode [
 BlockClosureTest >> testSetUp [
 	"Note: In addition to verifying that the setUp worked the way it was expected to, testSetUp is used to illustrate the meaning of the simple access methods, methods that are not normally otherwise 'tested'"
 
-	self assert: aBlockContext home equals: contextOfaBlockContext.
-	self assert: aBlockContext receiver equals: self.
+	self assert: aBlock home equals: contextOfaBlock.
+	self assert: aBlock receiver equals: self.
 	"Depending on the closure implementation, it's either a compiled block, a compiled method or nil."
-	self assert: (aBlockContext method isNil or: [ aBlockContext method isKindOf: CompiledCode ])
+	self assert: (aBlock method isNil or: [ aBlock method isKindOf: CompiledCode ])
 ]
 
 { #category : #tests }
@@ -473,9 +473,9 @@ BlockClosureTest >> testSuppressInformUsingStringMatchOptions [
 { #category : #'tests - evaluating' }
 BlockClosureTest >> testValueWithArguments [
 
-	self shouldnt: [ aBlockContext valueWithArguments: #() ] raise: ArgumentsCountMismatch.
+	self shouldnt: [ aBlock valueWithArguments: #() ] raise: ArgumentsCountMismatch.
 
-	self should: [ aBlockContext valueWithArguments: #(1) ] raise: ArgumentsCountMismatch
+	self should: [ aBlock valueWithArguments: #(1) ] raise: ArgumentsCountMismatch
 		withExceptionDo: [ :err |
 			self assert: err expectedArgumentsCount equals: 0.
 			self assert: err calledArgumentsCount equals: 1 ].
@@ -490,11 +490,11 @@ BlockClosureTest >> testValueWithArguments [
 BlockClosureTest >> testValueWithArgumentsWithOrderedCollection [
 
 	self
-		shouldnt: [ aBlockContext valueWithArguments: #() asOrderedCollection ]
+		shouldnt: [ aBlock valueWithArguments: #() asOrderedCollection ]
 		raise: ArgumentsCountMismatch.
 
 	self
-		should: [ aBlockContext valueWithArguments: #(1) asOrderedCollection ]
+		should: [ aBlock valueWithArguments: #(1) asOrderedCollection ]
 		raise: ArgumentsCountMismatch
 		withExceptionDo: [ :err |
 			self assert: err expectedArgumentsCount equals: 0.


### PR DESCRIPTION
The ivars in BlockClosureTest had misleading names: it's a block, not a context!