### PR TITLE
Fix bug in slot names

### DIFF
--- a/src/Slot-Tests/SlotClassVariableTest.class.st
+++ b/src/Slot-Tests/SlotClassVariableTest.class.st
@@ -70,18 +70,18 @@ SlotClassVariableTest >> testSlotIsPersistedAfterRebuildOfClass [
 
 { #category : #tests }
 SlotClassVariableTest >> testWantsInitializationAddsInitializeSlot [
+
 	| class1 |
-
 	class1 := self make: [ :builder |
-		builder
-			name: self aClassName;
-			superclass: Object ].
+		          builder
+			          name: self aClassName;
+			          superclass: Object ].
 
-	class1 addSlot: WriteOnceSlot new.
+	class1 addSlot: #foo => WriteOnceSlot new.
 
 	self assert: class1 slots size equals: 1.
 
-	self assert: ((class1 >> #initialize) hasLiteral: #initializeSlots:).
+	self assert: (class1 >> #initialize hasLiteral: #initializeSlots:).
 	"validate 'self class initializeSlots: self' is the first message sent"
 	self assert: (class1 >> #initialize) literals first equals: #class.
 	self assert: (class1 >> #initialize) literals second equals: #initializeSlots:


### PR DESCRIPTION
A slot should have a name. If it is not the case, then the class builder will return a collection containing nil for #instVarNames. And some code in Pharo cannot deal with a nil in #instVarNames.


This commit is fixing a test adding an unnamed slot. This test is not failing because Epicea is catching the error raised :(