### PR TITLE
Compiler-canAddBindingOf-Check-Synthezised 

### DIFF
--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -23,9 +23,13 @@ OCRequestorScope >> allTemps [
 { #category : #testing }
 OCRequestorScope >> canAddBindingOf: name [
 	"Test for free workspace declaration"
-
+	
+	"MD: Question: Do we really need to delegate this to the requestor?"
+	
 	"Empty names come from faulty parameters. Ignore them"
 	name ifEmpty: [ ^ false ].
+	"names startign with digits are variables from optimized contructs"
+	name startsWithDigit ifTrue: [ ^false ].
 
 	"Because requestor do not have a real API, introspection is used."
 	(requestor respondsTo: #canAddBindingOf:) ifFalse: [ ^ false ].

--- a/src/OpalCompiler-Tests/OCDoitTest.class.st
+++ b/src/OpalCompiler-Tests/OCDoitTest.class.st
@@ -15,6 +15,11 @@ OCDoitTest >> bindingOf: aSelector [
 ]
 
 { #category : #binding }
+OCDoitTest >> canAddBindingOf: aSymbol [
+	^ true
+]
+
+{ #category : #binding }
 OCDoitTest >> hasBindingOf: aSelector [
 	^aSelector == #requestorVarForTesting
 ]
@@ -96,6 +101,22 @@ OCDoitTest >> testDoItRequestorEvalError [
 	evaluate: '1('.
 
 	self assert: value isNil
+]
+
+{ #category : #tests }
+OCDoitTest >> testDoItRequestorOptimized [
+
+	| value  |
+	"Check optimzied to:do:, we call lookupVar: on the synthesized limit var, see canAddBindingOf:"
+	value := OpalCompiler new
+		          requestor: self;
+		          evaluate: '
+							| sum |
+							sum := 0.
+							1 to: requestorVarForTesting do: [:each | sum :=sum+1].
+							sum'.
+
+	self assert: value equals: 5
 ]
 
 { #category : #tests }


### PR DESCRIPTION
make sure to not try to define bindings in the requestor for var names of synthezied variables generated by #to:do: and #timesRepeat.

Add test testDoItRequestorOptimized