### PR TITLE
ThisProcess: try to implement reflective read better

### DIFF
--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -853,6 +853,12 @@ Context >> findNextUnwindContextUpTo: aContext [
 	^nil
 ]
 
+{ #category : #query }
+Context >> findProcess [
+	"find the process that this context is part of"
+	^ Processor findProcessForContext: self
+]
+
 { #category : #'private - exceptions' }
 Context >> handleSignal: exception [
 	"Sent to handler (on:do:) contexts only.  If my exception class (first arg) handles exception then execute my handle block (second arg), otherwise forward this message to the next handler context.  If none left, execute exception's defaultAction (see nil>>handleSignal:)."

--- a/src/Kernel/Process.class.st
+++ b/src/Kernel/Process.class.st
@@ -317,6 +317,15 @@ Process >> evaluate: aBlock onBehalfOf: aProcess [
 	^aBlock ensure: [effectiveProcess := oldEffectiveProcess]
 ]
 
+{ #category : #debugging }
+Process >> hasContext: aContext [
+	"if aContext is somewhere in this Process, return true"
+
+	^ suspendedContext
+		  ifNotNil: [ :process | process callChainAnySatisfy: [ :context | context == aContext ] ]
+		  ifNil: [ false ]
+]
+
 { #category : #initialization }
 Process >> initialize [
 	super initialize.

--- a/src/Kernel/ProcessorScheduler.class.st
+++ b/src/Kernel/ProcessorScheduler.class.st
@@ -142,6 +142,14 @@ ProcessorScheduler >> backgroundProcess [
 	^ BackgroundProcess
 ]
 
+{ #category : #querying }
+ProcessorScheduler >> findProcessForContext: aContext [
+	 
+	^ Process allInstances 
+		detect: [ : process | process hasContext: aContext ]
+		ifNone: [  thisProcess ]
+]
+
 { #category : #'priority names' }
 ProcessorScheduler >> highIOPriority [
 	"Answer the priority at which the most time critical input/output

--- a/src/Kernel/ThisProcessVariable.class.st
+++ b/src/Kernel/ThisProcessVariable.class.st
@@ -25,6 +25,6 @@ ThisProcessVariable >> isThisProcessVariable [
 
 { #category : #debugging }
 ThisProcessVariable >> readInContext: aContext [
-	"We expect this method to be called either from the same process or by debugger process that will read the correct process. Otherwise we cannot guarantee to read the correct process"
-	^ Processor activeProcess
+
+	^ aContext findProcess 
 ]

--- a/src/Slot-Tests/ThisProcessVariableTest.class.st
+++ b/src/Slot-Tests/ThisProcessVariableTest.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : #ThisProcessVariableTest,
+	#superclass : #TestCase,
+	#category : #'Slot-Tests-VariablesAndSlots'
+}
+
+{ #category : #tests }
+ThisProcessVariableTest >> testReadInContext [
+
+	| var |
+	var := self class lookupVar: #thisProcess.
+	self assert: (var readInContext: thisContext) identicalTo: thisProcess
+]


### PR DESCRIPTION
This PR tries to implement reading of thisProcess... it searches all Processes for the context. if it does not find it, it retunes the current process (using thisProcess).

if you now print or inspect "thisProcess" in the debugger, it now returns the process that you expect. #testReadInContext shows that you can read reflectively from the current thisContext, too.

But I am not sure about the fallback, yet it seems to work