### PR TITLE
Fix reading "super" reflectively: same as reading self

### DIFF
--- a/src/Kernel/SuperVariable.class.st
+++ b/src/Kernel/SuperVariable.class.st
@@ -30,7 +30,9 @@ SuperVariable >> isSuperVariable [
 
 { #category : #debugging }
 SuperVariable >> readInContext: aContext [
-	^aContext receiver
+	"self in a block is the receiver of the home context
+	For clean blocks it might not be known (nil)"
+	^aContext home ifNotNil: [:home | home receiver ]
 ]
 
 { #category : #queries }

--- a/src/Kernel/SuperVariable.class.st
+++ b/src/Kernel/SuperVariable.class.st
@@ -19,7 +19,7 @@ SuperVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 
 { #category : #'code generation' }
 SuperVariable >> emitValue: methodBuilder [
-	"super references the receiver, send that follows is a super send (the message lookup starts in the superclass)"
+	"super references the receiver, send that follows is a super send (the message lookup starts in the superclass, see OCASTTranslator>>#emitMessageNode:)"
 	methodBuilder pushReceiver
 ]
 
@@ -30,15 +30,14 @@ SuperVariable >> isSuperVariable [
 
 { #category : #debugging }
 SuperVariable >> readInContext: aContext [
-	"self in a block is the receiver of the home context
+	"super in a block is the receiver of the home context
 	For clean blocks it might not be known (nil)"
 	^aContext home ifNotNil: [:home | home receiver ]
 ]
 
 { #category : #queries }
 SuperVariable >> usingMethods [
-	"as super is just a push Self, this detects real super sends, not accesses to super which
-	should never happen"
+	"As super is just a push Self, this detects real super sends, not accesses to super which should never happen"
 	^ environment allMethods select: [ :method |
 		  method sendsToSuper ]
 ]

--- a/src/Slot-Tests/SuperVariableTest.class.st
+++ b/src/Slot-Tests/SuperVariableTest.class.st
@@ -1,0 +1,36 @@
+Class {
+	#name : #SuperVariableTest,
+	#superclass : #TestCase,
+	#category : #'Slot-Tests-VariablesAndSlots'
+}
+
+{ #category : #tests }
+SuperVariableTest >> testReadInContext [
+
+	| var |
+	var := self class lookupVar: #super.
+	self assert: (var readInContext: thisContext) identicalTo: super.
+	"read from a block context"
+	self assert: [(var readInContext: thisContext)] value identicalTo: super
+]
+
+{ #category : #tests }
+SuperVariableTest >> testReadInContextClean [
+	<compilerOptions: #( +optionCleanBlockClosure)>
+	| var block |
+	"if context is one stack we can read"
+	block := [ (thisContext lookupVar: #super) readInContext: thisContext ].
+	self assert: block value equals: super.
+	"but no chance if not, then it is nil"
+	var := self class lookupVar: #self.
+	block :=  [ thisContext ].
+	self assert: (var readInContext: block value ) equals: nil
+]
+
+{ #category : #tests }
+SuperVariableTest >> testUsingMethods [
+
+	|  var |
+	var := super class lookupVar: #super.
+	self assert: (var usingMethods includes: thisContext method)
+]


### PR DESCRIPTION
Do the same for super that we did for self: in use the home of the context to reflectively read the receiver.