### PR TITLE
Introduce strategy design pattern in Finder model

### DIFF
--- a/src/Tool-Finder/Finder.class.st
+++ b/src/Tool-Finder/Finder.class.st
@@ -52,29 +52,6 @@ Finder class >> registerToolsOn: registry [
 	registry register: self as: #finder
 ]
 
-{ #category : #private }
-Finder >> classSearch: aSelectBlock [
-	| result |
-	result := OrderedCollection new.
-	self packagesSelection classesAndTraitsDo:[ :class |
-			(aSelectBlock value: class)
-				ifTrue: [ result add: class ] ].
-	^ result
-]
-
-{ #category : #'private - class' }
-Finder >> computeListOfClasses: aString [
-	"Compute in the case I'm searching class names"
-
-	^ self useRegEx
-		ifTrue: [ | regex |
-			regex := aString asRegex.
-			self classSearch: [ :class | regex search: class name ]]
-		ifFalse: [
-			self classSearch: [ :class |
-				class name includesSubstring: aString caseSensitive: false ]]
-]
-
 { #category : #'private - example' }
 Finder >> computeWithMethodFinder: aString [
 	"Compute the selectors for the single example of receiver and args, in the very top pane"
@@ -103,36 +80,18 @@ Finder >> computeWithMethodFinder: aString [
 	^ result
 ]
 
-{ #category : #'private - class' }
-Finder >> constructClassNamesDictionary [
-	"Construct the dictionary in the case I'm searching in class names"
-
-	| result listOfClasses |
-	listOfClasses := self computeListOfClasses: self searchingString.
-	result := Dictionary new.
-	listOfClasses do: [:each |
-		result at: each put: (each selectors sort: [:a :b | a < b])].
-	self resultDictionary: result
-]
-
 { #category : #private }
 Finder >> constructDictionary [
 	"I construct the adequate dictionary regarding the search mode"
 
-	self searchingString isEmpty ifTrue: [ ^self resultDictionary: Dictionary new ].
-	[ :job|
-		job title: 'Searching...' translated.
-		self isSelectorsSymbol
-			ifTrue: [ self constructDictionaryWithMessagesNameSearch: self searchingString ].
-		self isClassNamesSymbol
-			ifTrue: [ self constructClassNamesDictionary ].
-		self isSourceSymbol
-			ifTrue: [ self constructSourceDictionary ].
-		self isExamplesSymbol
-			ifTrue: [ self constructDictionaryWithMethodFinder: self searchingString].
-		self isPragmasSymbol
-			ifTrue: [ self constructDictionaryWithPragmaSearch: self searchingString ].
-	] asJob run
+	self searchingString isEmpty ifTrue: [ ^ self resultDictionary: Dictionary new ].
+	[ :job |
+	job title: 'Searching...' translated.
+	self isSelectorsSymbol ifTrue: [ self constructDictionaryWithMessagesNameSearch: self searchingString ].
+	self isClassNamesSymbol ifTrue: [ self searchStrategy constructDictionaryOf: self ].
+	self isSourceSymbol ifTrue: [ self constructSourceDictionary ].
+	self isExamplesSymbol ifTrue: [ self constructDictionaryWithMethodFinder: self searchingString ].
+	self isPragmasSymbol ifTrue: [ self constructDictionaryWithPragmaSearch: self searchingString ] ] asJob run
 ]
 
 { #category : #'private - selector' }

--- a/src/Tool-Finder/Finder.class.st
+++ b/src/Tool-Finder/Finder.class.st
@@ -129,13 +129,13 @@ Finder >> initialize [
 ]
 
 { #category : #checkbox }
-Finder >> isClassNamesSymbol [
+Finder >> isClassSearch [
 
 	^ self searchStrategy isClassesSearch
 ]
 
 { #category : #checkbox }
-Finder >> isPragmasSymbol [
+Finder >> isPragmasSearch [
 
 	^ self searchStrategy isPragmaSearch
 ]

--- a/src/Tool-Finder/Finder.class.st
+++ b/src/Tool-Finder/Finder.class.st
@@ -145,27 +145,9 @@ Finder >> isClassNamesSymbol [
 ]
 
 { #category : #checkbox }
-Finder >> isExamplesSymbol [
-
-	^ self searchStrategy isExamplesSearch
-]
-
-{ #category : #checkbox }
 Finder >> isPragmasSymbol [
 
 	^ self searchStrategy isPragmaSearch
-]
-
-{ #category : #checkbox }
-Finder >> isSelectorsSymbol [
-
-	^ self searchStrategy isSelectorsSearch
-]
-
-{ #category : #checkbox }
-Finder >> isSourceSymbol [
-
-	^ self searchStrategy isSourceSearch
 ]
 
 { #category : #display }

--- a/src/Tool-Finder/Finder.class.st
+++ b/src/Tool-Finder/Finder.class.st
@@ -277,46 +277,22 @@ Finder >> selectedMethod: aMethod [
 { #category : #accessing }
 Finder >> selection: aSelectionHolder [
 	"anObject is a selection holder"
+
 	"Depending of the value of currentSearchMode, I fill selectedMethod and SelectedClass with the good items."
+
 	"Then, I update the source code text area"
 
-	| path methodNode method classNode class |
-	(aSelectionHolder isNil or: [aSelectionHolder selectedNodePath isNil]) ifTrue: [
+	| path |
+	(aSelectionHolder isNil or: [ aSelectionHolder selectedNodePath isNil ]) ifTrue: [
 		self selectedClass: nil.
 		self selectedMethod: nil.
-		^self].
+		^ self ].
 	path := aSelectionHolder selectedNodePath.
-	self isSelectorsSymbol
-		ifTrue: [
-			path first isSingle
-				ifTrue: [
-					method := path first itemMethod selector.
-					class := path first itemMethod methodClass ]
-				ifFalse: [
-					methodNode := path first.
-					classNode := path at: 2 ifAbsent: [ nil ]]].
-	self isClassNamesSymbol
-		ifTrue: [
-			classNode := path first.
-			methodNode := path at: 2 ifAbsent:[nil]].
-	self isSourceSymbol
-		ifTrue: [
-			methodNode := path first.
-			classNode := path at: 2 ifAbsent:[nil]].
-	self isExamplesSymbol
-		ifTrue: [
-			methodNode := path first.
-			classNode := path at: 2 ifAbsent:[nil]].
-	self isPragmasSymbol
-		ifTrue: [
-			methodNode := path at:2 ifAbsent: [ nil ].
-			classNode := path at: 3 ifAbsent:[nil]].
 
-	classNode ifNotNil: [ class := classNode item ].
-	self selectedClass: class.
 
-	methodNode ifNotNil: [ method := methodNode item ].
-	self selectedMethod: method.
+	self selectedClass: (self searchStrategy findSelectedClassIn: path).
+
+	self selectedMethod: (self searchStrategy findSelectedMethodIn: path).
 
 	self triggerEvent: #updateSourceCode
 ]

--- a/src/Tool-Finder/Finder.class.st
+++ b/src/Tool-Finder/Finder.class.st
@@ -52,34 +52,6 @@ Finder class >> registerToolsOn: registry [
 	registry register: self as: #finder
 ]
 
-{ #category : #'private - example' }
-Finder >> computeWithMethodFinder: aString [
-	"Compute the selectors for the single example of receiver and args, in the very top pane"
-
-	| data result dataObjects |
-	(aString includes: $.)
-		ifFalse: [ ^ #() ].	"delete trailing period. This should be fixed in the Parser!"
-	data := aString trimRight: [ :char | char isSeparator or: [ char = $. ] ].
-
-	[ dataObjects := Smalltalk compiler evaluate: '{' , data , '}' ]
-		on: CodeError, RuntimeSyntaxError
-		do: [ :e |
-			self inform: 'Error: ' , e messageText.
-			^ #() ].	"#( data1 data2 result )"
-
-	dataObjects size < 2
-		ifTrue: [
-			self
-				inform:
-					'If you are giving an example of receiver, \args, and result, please put periods between the parts.\Otherwise just type one selector fragment'
-						withCRs.
-			^ #() ].
-
-	result := MethodFinder new findMethodsByExampleInput: dataObjects allButLast andExpectedResult: dataObjects last.
-	result isEmpty ifTrue: [ self inform: 'no single method'. ^ #()].
-	^ result
-]
-
 { #category : #private }
 Finder >> constructDictionary [
 	"I construct the adequate dictionary regarding the search mode"
@@ -87,88 +59,7 @@ Finder >> constructDictionary [
 	self searchingString isEmpty ifTrue: [ ^ self resultDictionary: Dictionary new ].
 	[ :job |
 	job title: 'Searching...' translated.
-	self isSelectorsSymbol ifTrue: [ self constructDictionaryWithMessagesNameSearch: self searchingString ].
-	self isClassNamesSymbol ifTrue: [ self searchStrategy constructDictionaryOf: self ].
-	self isSourceSymbol ifTrue: [ self constructSourceDictionary ].
-	self isExamplesSymbol ifTrue: [ self constructDictionaryWithMethodFinder: self searchingString ].
-	self isPragmasSymbol ifTrue: [ self constructDictionaryWithPragmaSearch: self searchingString ] ] asJob run
-]
-
-{ #category : #'private - selector' }
-Finder >> constructDictionaryWithMessagesNameSearch: aString [
-	"Construct dictionary when searching for selector"
-
-	| result listOfMethods |
-	result := Dictionary new.
-	listOfMethods := self messagesNameSearch: aString.
-	listOfMethods do: [:method || key value |
-			key := method selector.
-			value := method methodClass.
-			(result includesKey: key)
-				ifTrue: [ (result at: key) add: value]
-				ifFalse: [ result at: key put: (OrderedCollection new add: value; yourself)]].
-	self resultDictionary: result
-]
-
-{ #category : #'private - example' }
-Finder >> constructDictionaryWithMethodFinder: aString [
-	"construct dictionary when searching patterns"
-
-	| result listOfResults listOfSelectors |
-	result := Dictionary new.
-	listOfResults := self computeWithMethodFinder: aString.
-	listOfSelectors := listOfResults collect: [ :each | each selector ].
-	self packagesSelection classesDo:[ :class |
-			class methodsDo:  [ :method |
-					| index |
-					(index := listOfSelectors indexOf: method selector) = 0
-						ifFalse: [
-							| key value |
-							key := listOfResults at: index.
-							value := method methodClass.
-							(result includesKey: key)
-								ifTrue: [ (result at: key) add: value ]
-								ifFalse: [
-									result
-										at: key
-										put:
-											(OrderedCollection new
-												add: value;
-												yourself) ] ] ] ].
-	self resultDictionary: result
-]
-
-{ #category : #'private - pragma' }
-Finder >> constructDictionaryWithPragmaSearch: aString [
-	"construct dictionary when searching for pragmas"
-
-	| dictionary |
-	dictionary := self pragmaSearch: aString.
-	dictionary keysDo:[ :k || result |
-		result := Dictionary new.
-		(dictionary at: k) do: [:method || key value |
-				key := method selector.
-				value := method methodClass.
-				(result
-					at: key
-					ifAbsentPut: OrderedCollection new ) add: value].
-		dictionary at: k put: result ].
-	self resultDictionary: dictionary
-]
-
-{ #category : #private }
-Finder >> constructSourceDictionary [
-"construct dictionary when searching source"
-	| result listOfMethods |
-	result := Dictionary new.
-	listOfMethods := self sourceSearch: self searchingString.
-	listOfMethods do: [:method || key value |
-		key := method selector.
-		value := method methodClass.
-		(result includesKey: key)
-			ifTrue: [ (result at: key) add: value]
-			ifFalse: [ result at: key put: (OrderedCollection new add: value; yourself)]].
-	self resultDictionary: result
+	self searchStrategy constructDictionary ] asJob run
 ]
 
 { #category : #accessing }
@@ -190,7 +81,7 @@ Finder >> currentSearchMode: aSymbol [
 
 	"If #Examples is selected, I disable the RegEx checkbo. Then I rebuild the resultDictionary"
 
-	searchStrategy := (FinderSearchStrategy strategyNamed: aSymbol) new.
+	searchStrategy := (FinderSearchStrategy strategyNamed: aSymbol) finder: self.
 	self isExamplesSymbol
 		ifTrue: [ self disableUseRegEx ]
 		ifFalse: [ self enableUseRegEx ].
@@ -240,12 +131,13 @@ Finder >> environment: aCollection [
 
 { #category : #initialization }
 Finder >> initialize [
+
 	super initialize.
 	searchingString := self defaultString.
 	environment := self defaultEnvironment.
 	packagesSelection := self defaultPackagesSelection.
 	resultDictionary := Dictionary new.
-	searchStrategy := FinderSelectorsSearchStrategy new.
+	searchStrategy := FinderSelectorsSearchStrategy finder: self.
 	useRegEx := false
 ]
 
@@ -279,42 +171,6 @@ Finder >> isSourceSymbol [
 	^ self searchStrategy isSourceSearch
 ]
 
-{ #category : #'private - selector' }
-Finder >> messageSearchBlockFrom: aString [
-	| exactMatch |
-	exactMatch := aString first = $" and: [ aString last = $" ].
-
-	exactMatch ifFalse: [ ^ [ :method | method selector includesSubstring: aString caseSensitive: false ] ].
-
-	^ (Symbol findInterned: (aString copyFrom: 2 to: aString size - 1)) ifNotNil: [ :aSymbol | [ :method | method selector = aSymbol ] ]
-]
-
-{ #category : #'private - selector' }
-Finder >> messagesNameSearch: aString [
-	"I'm searching for selectors"
-	^ self useRegEx
-		ifTrue: [ | regex |
-			regex := aString asRegex.
-			self methodSearch: [ :method| 	regex search: method selector asString ]]
-		ifFalse: [
-			self methodSearch: (self messageSearchBlockFrom: aString)]
-]
-
-{ #category : #private }
-Finder >> methodSearch: aSelectBlock [
-	| result |
-	result := OrderedCollection new.
-	aSelectBlock ifNil: [ ^result ].
-	self packagesSelection classesAndTraits do:[ :class |
-			class methodsDo: [ :method |
-				(aSelectBlock value: method) ifTrue: [ result add: method ]].
-			class classSide methodsDo: [ :method |
-				(aSelectBlock value: method) ifTrue: [ result add: method ]]
-			]
-			displayingProgress: [ :aClass | aClass name ].
-	^ result
-]
-
 { #category : #display }
 Finder >> open [
 	<script: 'self new open'>
@@ -334,23 +190,6 @@ Finder >> packagesSelection: aCollection [
 
 	packagesSelection :=  aCollection.
 	self constructDictionary
-]
-
-{ #category : #'private - pragma' }
-Finder >> pragmaSearch: aString [
-	| result byCondition |
-	"I choose a dictionary here because the next step is to group result by pragmas."
-	result := Dictionary new.
-
-	byCondition :=  self useRegEx
-		ifTrue: [[ :pragma | pragma selector matchesRegexIgnoringCase: aString ]]
-		ifFalse: [[ :pragma | pragma selector includesSubstring: aString caseSensitive: false ]].
-
-	(Pragma all select: byCondition)
-		do: [ :pragma |
-			(result at: (pragma selector) ifAbsentPut: OrderedCollection new)
-				add: pragma method ].
-	^ result
 ]
 
 { #category : #private }
@@ -480,28 +319,6 @@ Finder >> selection: aSelectionHolder [
 	self selectedMethod: method.
 
 	self triggerEvent: #updateSourceCode
-]
-
-{ #category : #private }
-Finder >> sourceRegexSearch: aSearchString [
-	| regex |
-	regex := aSearchString asRegex.
-	^ self methodSearch: [ :method | regex search: method sourceCode ]
-]
-
-{ #category : #private }
-Finder >> sourceSearch: aSearchString [
-	"I'm searching in sources"
-	^ self useRegEx
-		ifTrue: [ self sourceRegexSearch: aSearchString ]
-		ifFalse:[ self sourceStringSearch: aSearchString ]
-]
-
-{ #category : #private }
-Finder >> sourceStringSearch: aSearchString [
-	^ self
-		methodSearch: [ :method |
-			method sourceCode includesSubstring: aSearchString caseSensitive: false ]
 ]
 
 { #category : #accessing }

--- a/src/Tool-Finder/Finder.class.st
+++ b/src/Tool-Finder/Finder.class.st
@@ -92,16 +92,6 @@ Finder >> defaultEnvironment [
 	 ^ RBBrowserEnvironment new
 ]
 
-{ #category : #default }
-Finder >> defaultPackagesSelection [
-	 ^ self environment
-]
-
-{ #category : #default }
-Finder >> defaultString [
-	^ ''
-]
-
 { #category : #private }
 Finder >> disableUseRegEx [
 	"send a disable useRegEx dropbox event"
@@ -130,9 +120,9 @@ Finder >> environment: aCollection [
 Finder >> initialize [
 
 	super initialize.
-	searchingString := self defaultString.
+	searchingString := ''.
 	environment := self defaultEnvironment.
-	packagesSelection := self defaultPackagesSelection.
+	packagesSelection := self environment.
 	resultDictionary := Dictionary new.
 	searchStrategy := FinderSelectorsSearchStrategy finder: self.
 	useRegEx := false

--- a/src/Tool-Finder/Finder.class.st
+++ b/src/Tool-Finder/Finder.class.st
@@ -12,10 +12,10 @@ Class {
 		'selectedMethod',
 		'selectedClass',
 		'packagesSelection',
-		'currentSearchMode',
 		'environment',
 		'resultDictionary',
-		'useRegEx'
+		'useRegEx',
+		'searchStrategy'
 	],
 	#category : #'Tool-Finder-Base'
 }
@@ -215,24 +215,26 @@ Finder >> constructSourceDictionary [
 { #category : #accessing }
 Finder >> currentSearchMode [
 	"Getter"
+
 	"I shoud answer a Symbol in :
 		- #Selectors
 		- #Classes
 		- #Source
 		- #Examples"
 
-	 ^ currentSearchMode
+	^ self searchStrategy class strategyName
 ]
 
 { #category : #accessing }
 Finder >> currentSearchMode: aSymbol [
 	"Setter"
+
 	"If #Examples is selected, I disable the RegEx checkbo. Then I rebuild the resultDictionary"
 
-	currentSearchMode := aSymbol.
+	searchStrategy := (FinderSearchStrategy strategyNamed: aSymbol) new.
 	self isExamplesSymbol
-		ifTrue: [ self disableUseRegEx]
-		ifFalse:[ self enableUseRegEx].
+		ifTrue: [ self disableUseRegEx ]
+		ifFalse: [ self enableUseRegEx ].
 
 	self update: #sourceCode.
 	self constructDictionary
@@ -284,38 +286,38 @@ Finder >> initialize [
 	environment := self defaultEnvironment.
 	packagesSelection := self defaultPackagesSelection.
 	resultDictionary := Dictionary new.
-	currentSearchMode := #Selectors.
+	searchStrategy := FinderSelectorsSearchStrategy new.
 	useRegEx := false
 ]
 
 { #category : #checkbox }
 Finder >> isClassNamesSymbol [
-	"answer if the current mode is Classes"
-	^self currentSearchMode = #Classes
+
+	^ self searchStrategy isClassesSearch
 ]
 
 { #category : #checkbox }
 Finder >> isExamplesSymbol [
-	"Answer if the current mode is Examples"
-	^self currentSearchMode = #Examples
+
+	^ self searchStrategy isExamplesSearch
 ]
 
 { #category : #checkbox }
 Finder >> isPragmasSymbol [
-	"Answer if the current mode is Pragmas"
-	^self currentSearchMode = #Pragmas
+
+	^ self searchStrategy isPragmaSearch
 ]
 
 { #category : #checkbox }
 Finder >> isSelectorsSymbol [
-	"Answer if the current mode is Selectors"
-	^self currentSearchMode = #Selectors
+
+	^ self searchStrategy isSelectorsSearch
 ]
 
 { #category : #checkbox }
 Finder >> isSourceSymbol [
-	"Answer if the current mode is Source"
-	^self currentSearchMode = #Source
+
+	^ self searchStrategy isSourceSearch
 ]
 
 { #category : #'private - selector' }
@@ -414,6 +416,18 @@ Finder >> resultDictionary: aDictionary [
 	self selectedMethod: nil.
 	self selectedClass: nil.
 	self triggerEvent: #updateSourceCode
+]
+
+{ #category : #accessing }
+Finder >> searchStrategy [
+
+	^ searchStrategy
+]
+
+{ #category : #accessing }
+Finder >> searchStrategy: anObject [
+
+	searchStrategy := anObject
 ]
 
 { #category : #accessing }

--- a/src/Tool-Finder/Finder.class.st
+++ b/src/Tool-Finder/Finder.class.st
@@ -82,9 +82,6 @@ Finder >> currentSearchMode: aSymbol [
 	"If #Examples is selected, I disable the RegEx checkbo. Then I rebuild the resultDictionary"
 
 	searchStrategy := (FinderSearchStrategy strategyNamed: aSymbol) finder: self.
-	self isExamplesSymbol
-		ifTrue: [ self disableUseRegEx ]
-		ifFalse: [ self enableUseRegEx ].
 
 	self update: #sourceCode.
 	self constructDictionary
@@ -289,9 +286,7 @@ Finder >> selection: aSelectionHolder [
 		^ self ].
 	path := aSelectionHolder selectedNodePath.
 
-
 	self selectedClass: (self searchStrategy findSelectedClassIn: path).
-
 	self selectedMethod: (self searchStrategy findSelectedMethodIn: path).
 
 	self triggerEvent: #updateSourceCode

--- a/src/Tool-Finder/FinderClassesSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderClassesSearchStrategy.class.st
@@ -11,28 +11,28 @@ FinderClassesSearchStrategy class >> strategyName [
 ]
 
 { #category : #actions }
-FinderClassesSearchStrategy >> computeListOfClassesFor: aFinder [
+FinderClassesSearchStrategy >> computeListOfClasses [
 
 	| regex result |
-	regex := aFinder searchingString asRegex.
+	regex := finder searchingString asRegex.
 
 	result := OrderedCollection new.
 
-	aFinder packagesSelection classesAndTraitsDo: [ :class |
-		(aFinder useRegEx
+	finder packagesSelection classesAndTraitsDo: [ :class |
+		(finder useRegEx
 			 ifTrue: [ regex search: class name ]
-			 ifFalse: [ class name includesSubstring: aFinder searchingString caseSensitive: false ]) ifTrue: [ result add: class ] ].
+			 ifFalse: [ class name includesSubstring: finder searchingString caseSensitive: false ]) ifTrue: [ result add: class ] ].
 
 	^ result
 ]
 
 { #category : #actions }
-FinderClassesSearchStrategy >> constructDictionaryOf: aFinder [
+FinderClassesSearchStrategy >> constructDictionary [
 
 	| result |
 	result := Dictionary new.
-	(self computeListOfClassesFor: aFinder) do: [ :class | result at: class put: (class selectors sort: #yourself ascending) ].
-	aFinder resultDictionary: result
+	self computeListOfClasses do: [ :class | result at: class put: (class selectors sort: #yourself ascending) ].
+	finder resultDictionary: result
 ]
 
 { #category : #testing }

--- a/src/Tool-Finder/FinderClassesSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderClassesSearchStrategy.class.st
@@ -35,6 +35,21 @@ FinderClassesSearchStrategy >> constructDictionary [
 	finder resultDictionary: result
 ]
 
+{ #category : #accessing }
+FinderClassesSearchStrategy >> findSelectedClassIn: path [
+
+	^ path first item
+]
+
+{ #category : #accessing }
+FinderClassesSearchStrategy >> findSelectedMethodIn: path [
+
+	^ path
+		  at: 2
+		  ifPresent: [ :node | node item ]
+		  ifAbsent: [ nil ]
+]
+
 { #category : #testing }
 FinderClassesSearchStrategy >> isClassesSearch [
 

--- a/src/Tool-Finder/FinderClassesSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderClassesSearchStrategy.class.st
@@ -55,3 +55,9 @@ FinderClassesSearchStrategy >> isClassesSearch [
 
 	^ true
 ]
+
+{ #category : #accessing }
+FinderClassesSearchStrategy >> rootNodeClassForResult: aCollection [
+
+	^ FinderClassNode
+]

--- a/src/Tool-Finder/FinderClassesSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderClassesSearchStrategy.class.st
@@ -9,3 +9,9 @@ FinderClassesSearchStrategy class >> strategyName [
 
 	^ #Classes
 ]
+
+{ #category : #testing }
+FinderClassesSearchStrategy >> isClassesSearch [
+
+	^ true
+]

--- a/src/Tool-Finder/FinderClassesSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderClassesSearchStrategy.class.st
@@ -10,6 +10,31 @@ FinderClassesSearchStrategy class >> strategyName [
 	^ #Classes
 ]
 
+{ #category : #actions }
+FinderClassesSearchStrategy >> computeListOfClassesFor: aFinder [
+
+	| regex result |
+	regex := aFinder searchingString asRegex.
+
+	result := OrderedCollection new.
+
+	aFinder packagesSelection classesAndTraitsDo: [ :class |
+		(aFinder useRegEx
+			 ifTrue: [ regex search: class name ]
+			 ifFalse: [ class name includesSubstring: aFinder searchingString caseSensitive: false ]) ifTrue: [ result add: class ] ].
+
+	^ result
+]
+
+{ #category : #actions }
+FinderClassesSearchStrategy >> constructDictionaryOf: aFinder [
+
+	| result |
+	result := Dictionary new.
+	(self computeListOfClassesFor: aFinder) do: [ :class | result at: class put: (class selectors sort: #yourself ascending) ].
+	aFinder resultDictionary: result
+]
+
 { #category : #testing }
 FinderClassesSearchStrategy >> isClassesSearch [
 

--- a/src/Tool-Finder/FinderClassesSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderClassesSearchStrategy.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #FinderClassesSearchStrategy,
+	#superclass : #FinderSearchStrategy,
+	#category : #'Tool-Finder-Base'
+}
+
+{ #category : #accessing }
+FinderClassesSearchStrategy class >> strategyName [
+
+	^ #Classes
+]

--- a/src/Tool-Finder/FinderClassesSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderClassesSearchStrategy.class.st
@@ -1,3 +1,6 @@
+"
+I am a Finder search mode when we are looking for classes in the system.
+"
 Class {
 	#name : #FinderClassesSearchStrategy,
 	#superclass : #FinderSearchStrategy,

--- a/src/Tool-Finder/FinderExamplesSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderExamplesSearchStrategy.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #FinderExamplesSearchStrategy,
+	#superclass : #FinderSearchStrategy,
+	#category : #'Tool-Finder-Base'
+}
+
+{ #category : #accessing }
+FinderExamplesSearchStrategy class >> strategyName [
+
+	^ #Examples
+]

--- a/src/Tool-Finder/FinderExamplesSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderExamplesSearchStrategy.class.st
@@ -59,6 +59,21 @@ FinderExamplesSearchStrategy >> constructDictionary [
 	finder resultDictionary: result
 ]
 
+{ #category : #accessing }
+FinderExamplesSearchStrategy >> findSelectedClassIn: path [
+
+	^ path
+		  at: 2
+		  ifPresent: [ :node | node item ]
+		  ifAbsent: [ nil ]
+]
+
+{ #category : #accessing }
+FinderExamplesSearchStrategy >> findSelectedMethodIn: path [
+
+	^ path first item
+]
+
 { #category : #testing }
 FinderExamplesSearchStrategy >> isExamplesSearch [
 

--- a/src/Tool-Finder/FinderExamplesSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderExamplesSearchStrategy.class.st
@@ -1,3 +1,6 @@
+"
+I am a finder search mode used when searching the system based on a example
+"
 Class {
 	#name : #FinderExamplesSearchStrategy,
 	#superclass : #FinderSearchStrategy,
@@ -134,12 +137,6 @@ FinderExamplesSearchStrategy >> findSelectedClassIn: path [
 FinderExamplesSearchStrategy >> findSelectedMethodIn: path [
 
 	^ path first item
-]
-
-{ #category : #testing }
-FinderExamplesSearchStrategy >> isExamplesSearch [
-
-	^ true
 ]
 
 { #category : #accessing }

--- a/src/Tool-Finder/FinderExamplesSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderExamplesSearchStrategy.class.st
@@ -60,6 +60,68 @@ FinderExamplesSearchStrategy >> constructDictionary [
 ]
 
 { #category : #accessing }
+FinderExamplesSearchStrategy >> defaultExplanation [
+
+	^ 'Use an example to find a method in the system.
+
+   ''a''. ''b''. ''ab''       will find the message #, for strings concatenation
+   2. -2                will find the message #negated
+   3. 6                 will find the message #factorial
+   20. 10. 15. 15       will find the message #min:max:
+
+It works on collections too:
+
+   {2. 4. 5. 1}. 5. 3   will find the message #indexOf:
+   {2. 5. 1}. 5. true   will find the message #includes:
+
+An example is made up of the following two or more items separated by a period:
+
+	receiver. answer
+	receiver. argument1. answer
+	receiver. argument1. argument2. answer
+	etc...
+
+For example, type: 3. 4. 7. into the search box and click <Search>
+
+Take care on separating spaces because of floating point numbers.
+
+ 	3.4.7      will find nothing, it is interpreted two numbers, 3.4 and. 7
+	3. 4. 7    will find you the message #+
+
+The examples array should contain one object for the receiver, one object per expected argument and then a final object with the expected result.
+
+In other words
+ - a unary method example expects an array of input objects #( receiver ) and an expected result
+ - a binary method example expects an array with two input objects #( receiver argument ) and an expected result
+ - a keyword method example expects an array with at least two elements  #( receiver argument1 argument2 ... ) and an expected results
+
+The method finder will take the input objects (receiver and arguments) and perform their permutation to be able to find more results.
+Then, it will lookup in the receiver''s hierarchy the approved and forbidden methods to run on the hierarchy and run them on the permutation of objects.
+
+Receiver and arguments do not have to be in the right order.
+
+Alternatively, in this bottom pane or in the Playground, use #findMethodsByExampleInput:andExpectedResult: directly to find a method in the system.  Select this line of code and choose "print it" or "inspect it.
+
+	MethodFinder new findMethodsByExampleInput: #( 1 2 ) andExpectedResult: 3.
+
+It is useful when you want to look for computed objects:
+
+	MethodFinder new
+		findMethodsByExampleInput: {''29 Apr 1999'' asDate}
+		andExpectedResult: ''30 Apr 1999'' asDate.
+
+This will find the message #next.
+
+	MethodFinder new
+		findMethodsByExampleInput: {''30 Apr 1999'' asDate}
+		andExpectedResult: ''Friday''.
+
+This will find the message #dayOfWeekName
+
+The Method Finder is not trying all methods in the system so if it will find nothing, a method with requested behavior may still exist. '
+]
+
+{ #category : #accessing }
 FinderExamplesSearchStrategy >> findSelectedClassIn: path [
 
 	^ path
@@ -84,6 +146,12 @@ FinderExamplesSearchStrategy >> isExamplesSearch [
 FinderExamplesSearchStrategy >> rootNodeClassForResult: aCollection [
 
 	^ FinderExampleMethodNode
+]
+
+{ #category : #accessing }
+FinderExamplesSearchStrategy >> sourceCodeClass: class method: method [
+
+	^ (class >> method selector) sourceCode
 ]
 
 { #category : #private }

--- a/src/Tool-Finder/FinderExamplesSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderExamplesSearchStrategy.class.st
@@ -10,6 +10,55 @@ FinderExamplesSearchStrategy class >> strategyName [
 	^ #Examples
 ]
 
+{ #category : #'private - example' }
+FinderExamplesSearchStrategy >> computeWithMethodFinder [
+	"Compute the selectors for the single example of receiver and args, in the very top pane"
+
+	| data result dataObjects |
+	(finder searchingString includes: $.) ifFalse: [ ^ #(  ) ]. "delete trailing period. This should be fixed in the Parser!"
+	data := finder searchingString trimRight: [ :char | char isSeparator or: [ char = $. ] ].
+
+	[ dataObjects := Smalltalk compiler evaluate: '{' , data , '}' ]
+		on: CodeError , RuntimeSyntaxError
+		do: [ :e |
+			self inform: 'Error: ' , e messageText.
+			^ #(  ) ]. "#( data1 data2 result )"
+
+	dataObjects size < 2 ifTrue: [
+		self inform:
+			'If you are giving an example of receiver, \args, and result, please put periods between the parts.\Otherwise just type one selector fragment' withCRs.
+		^ #(  ) ].
+
+	result := MethodFinder new findMethodsByExampleInput: dataObjects allButLast andExpectedResult: dataObjects last.
+	result isEmpty ifTrue: [
+		self inform: 'no single method'.
+		^ #(  ) ].
+	^ result
+]
+
+{ #category : #actions }
+FinderExamplesSearchStrategy >> constructDictionary [
+
+	| result listOfResults listOfSelectors |
+	result := Dictionary new.
+	listOfResults := self computeWithMethodFinder.
+	listOfSelectors := listOfResults collect: [ :each | each selector ].
+	finder packagesSelection classesDo: [ :class |
+		class methodsDo: [ :method |
+			| index |
+			(index := listOfSelectors indexOf: method selector) = 0 ifFalse: [
+				| key value |
+				key := listOfResults at: index.
+				value := method methodClass.
+				(result includesKey: key)
+					ifTrue: [ (result at: key) add: value ]
+					ifFalse: [
+						result at: key put: (OrderedCollection new
+								 add: value;
+								 yourself) ] ] ] ].
+	finder resultDictionary: result
+]
+
 { #category : #testing }
 FinderExamplesSearchStrategy >> isExamplesSearch [
 

--- a/src/Tool-Finder/FinderExamplesSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderExamplesSearchStrategy.class.st
@@ -10,7 +10,7 @@ FinderExamplesSearchStrategy class >> strategyName [
 	^ #Examples
 ]
 
-{ #category : #'private - example' }
+{ #category : #private }
 FinderExamplesSearchStrategy >> computeWithMethodFinder [
 	"Compute the selectors for the single example of receiver and args, in the very top pane"
 
@@ -78,4 +78,16 @@ FinderExamplesSearchStrategy >> findSelectedMethodIn: path [
 FinderExamplesSearchStrategy >> isExamplesSearch [
 
 	^ true
+]
+
+{ #category : #accessing }
+FinderExamplesSearchStrategy >> rootNodeClassForResult: aCollection [
+
+	^ FinderExampleMethodNode
+]
+
+{ #category : #private }
+FinderExamplesSearchStrategy >> updateRegexUsage [
+
+	finder disableUseRegEx
 ]

--- a/src/Tool-Finder/FinderExamplesSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderExamplesSearchStrategy.class.st
@@ -9,3 +9,9 @@ FinderExamplesSearchStrategy class >> strategyName [
 
 	^ #Examples
 ]
+
+{ #category : #testing }
+FinderExamplesSearchStrategy >> isExamplesSearch [
+
+	^ true
+]

--- a/src/Tool-Finder/FinderMethodNode.class.st
+++ b/src/Tool-Finder/FinderMethodNode.class.st
@@ -47,7 +47,7 @@ FinderMethodNode >> childNodeClassFromItem: anItem [
 FinderMethodNode >> childrenItems [
 	"I search the children, if I have not got any, I call my super method"
 
-	self model isPragmasSymbol
+	self model isPragmasSearch
 		ifTrue: [ ^ (self model resultDictionary at: parentNode item ifAbsent: [ ^ super childrenItems ])
 				at: self item
 				ifAbsent: [ ^ super childrenItems ] ].

--- a/src/Tool-Finder/FinderPragmasSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderPragmasSearchStrategy.class.st
@@ -1,3 +1,6 @@
+"
+I am a Finder search mode used when looking for the pragmas in the system.
+"
 Class {
 	#name : #FinderPragmasSearchStrategy,
 	#superclass : #FinderSearchStrategy,
@@ -43,12 +46,6 @@ FinderPragmasSearchStrategy >> findSelectedMethodIn: path [
 		  at: 2
 		  ifPresent: [ :node | node item ]
 		  ifAbsent: [ nil ]
-]
-
-{ #category : #testing }
-FinderPragmasSearchStrategy >> isPragmasSearch [
-
-	^ true
 ]
 
 { #category : #actions }

--- a/src/Tool-Finder/FinderPragmasSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderPragmasSearchStrategy.class.st
@@ -10,8 +10,40 @@ FinderPragmasSearchStrategy class >> strategyName [
 	^ #Pragmas
 ]
 
+{ #category : #actions }
+FinderPragmasSearchStrategy >> constructDictionary [
+
+	| dictionary |
+	dictionary := self pragmaSearch.
+	dictionary keysDo: [ :k |
+		| result |
+		result := Dictionary new.
+		(dictionary at: k) do: [ :method |
+			| key value |
+			key := method selector.
+			value := method methodClass.
+			(result at: key ifAbsentPut: OrderedCollection new) add: value ].
+		dictionary at: k put: result ].
+	finder resultDictionary: dictionary
+]
+
 { #category : #testing }
 FinderPragmasSearchStrategy >> isPragmasSearch [
 
 	^ true
+]
+
+{ #category : #actions }
+FinderPragmasSearchStrategy >> pragmaSearch [
+
+	| result byCondition |
+	"I choose a dictionary here because the next step is to group result by pragmas."
+	result := Dictionary new.
+
+	byCondition := finder useRegEx
+		               ifTrue: [ [ :pragma | pragma selector matchesRegexIgnoringCase: finder searchingString ] ]
+		               ifFalse: [ [ :pragma | pragma selector includesSubstring: finder searchingString caseSensitive: false ] ].
+
+	(Pragma all select: byCondition) do: [ :pragma | (result at: pragma selector ifAbsentPut: OrderedCollection new) add: pragma method ].
+	^ result
 ]

--- a/src/Tool-Finder/FinderPragmasSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderPragmasSearchStrategy.class.st
@@ -65,3 +65,9 @@ FinderPragmasSearchStrategy >> pragmaSearch [
 	(Pragma all select: byCondition) do: [ :pragma | (result at: pragma selector ifAbsentPut: OrderedCollection new) add: pragma method ].
 	^ result
 ]
+
+{ #category : #accessing }
+FinderPragmasSearchStrategy >> rootNodeClassForResult: aCollection [
+
+	^ FinderPragmaNode
+]

--- a/src/Tool-Finder/FinderPragmasSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderPragmasSearchStrategy.class.st
@@ -9,3 +9,9 @@ FinderPragmasSearchStrategy class >> strategyName [
 
 	^ #Pragmas
 ]
+
+{ #category : #testing }
+FinderPragmasSearchStrategy >> isPragmasSearch [
+
+	^ true
+]

--- a/src/Tool-Finder/FinderPragmasSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderPragmasSearchStrategy.class.st
@@ -27,6 +27,24 @@ FinderPragmasSearchStrategy >> constructDictionary [
 	finder resultDictionary: dictionary
 ]
 
+{ #category : #accessing }
+FinderPragmasSearchStrategy >> findSelectedClassIn: path [
+
+	^ path
+		  at: 3
+		  ifPresent: [ :node | node item ]
+		  ifAbsent: [ nil ]
+]
+
+{ #category : #accessing }
+FinderPragmasSearchStrategy >> findSelectedMethodIn: path [
+
+	^ path
+		  at: 2
+		  ifPresent: [ :node | node item ]
+		  ifAbsent: [ nil ]
+]
+
 { #category : #testing }
 FinderPragmasSearchStrategy >> isPragmasSearch [
 

--- a/src/Tool-Finder/FinderPragmasSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderPragmasSearchStrategy.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #FinderPragmasSearchStrategy,
+	#superclass : #FinderSearchStrategy,
+	#category : #'Tool-Finder-Base'
+}
+
+{ #category : #accessing }
+FinderPragmasSearchStrategy class >> strategyName [
+
+	^ #Pragmas
+]

--- a/src/Tool-Finder/FinderSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderSearchStrategy.class.st
@@ -22,6 +22,12 @@ FinderSearchStrategy class >> strategyNamed: aSymbol [
 	^ self subclasses detect: [ :class | class strategyName = aSymbol ]
 ]
 
+{ #category : #actions }
+FinderSearchStrategy >> constructDictionaryOf: aFinder [
+
+	self subclassResponsibility
+]
+
 { #category : #testing }
 FinderSearchStrategy >> isClassesSearch [
 

--- a/src/Tool-Finder/FinderSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderSearchStrategy.class.st
@@ -1,8 +1,19 @@
 Class {
 	#name : #FinderSearchStrategy,
 	#superclass : #Object,
+	#instVars : [
+		'finder'
+	],
 	#category : #'Tool-Finder-Base'
 }
+
+{ #category : #accessing }
+FinderSearchStrategy class >> finder: aFinder [
+
+	^ self new
+		  finder: aFinder;
+		  yourself
+]
 
 { #category : #testing }
 FinderSearchStrategy class >> isAbstract [
@@ -23,9 +34,21 @@ FinderSearchStrategy class >> strategyNamed: aSymbol [
 ]
 
 { #category : #actions }
-FinderSearchStrategy >> constructDictionaryOf: aFinder [
+FinderSearchStrategy >> constructDictionary [
 
 	self subclassResponsibility
+]
+
+{ #category : #accessing }
+FinderSearchStrategy >> finder [
+
+	^ finder
+]
+
+{ #category : #accessing }
+FinderSearchStrategy >> finder: anObject [
+
+	finder := anObject
 ]
 
 { #category : #testing }
@@ -56,4 +79,18 @@ FinderSearchStrategy >> isSelectorsSearch [
 FinderSearchStrategy >> isSourceSearch [
 
 	^ false
+]
+
+{ #category : #actions }
+FinderSearchStrategy >> methodSearch: aSelectBlock [
+
+	| result |
+	result := OrderedCollection new.
+	aSelectBlock ifNil: [ ^ result ].
+	finder packagesSelection classesAndTraits
+		do: [ :class |
+			class methodsDo: [ :method | (aSelectBlock value: method) ifTrue: [ result add: method ] ].
+			class classSide methodsDo: [ :method | (aSelectBlock value: method) ifTrue: [ result add: method ] ] ]
+		displayingProgress: [ :aClass | aClass name ].
+	^ result
 ]

--- a/src/Tool-Finder/FinderSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderSearchStrategy.class.st
@@ -1,3 +1,8 @@
+"
+I am an abstract class to define the behavior of the Finder related to the search strategy used.
+
+I implement a strategy design pattern and my subclasses will manage the different search modes.
+"
 Class {
 	#name : #FinderSearchStrategy,
 	#superclass : #Object,
@@ -85,30 +90,6 @@ FinderSearchStrategy >> finder: anObject [
 
 { #category : #testing }
 FinderSearchStrategy >> isClassesSearch [
-
-	^ false
-]
-
-{ #category : #testing }
-FinderSearchStrategy >> isExamplesSearch [
-
-	^ false
-]
-
-{ #category : #testing }
-FinderSearchStrategy >> isPragmasSearch [
-
-	^ false
-]
-
-{ #category : #testing }
-FinderSearchStrategy >> isSelectorsSearch [
-
-	^ false
-]
-
-{ #category : #testing }
-FinderSearchStrategy >> isSourceSearch [
 
 	^ false
 ]

--- a/src/Tool-Finder/FinderSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderSearchStrategy.class.st
@@ -40,6 +40,18 @@ FinderSearchStrategy >> constructDictionary [
 ]
 
 { #category : #accessing }
+FinderSearchStrategy >> findSelectedClassIn: path [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+FinderSearchStrategy >> findSelectedMethodIn: path [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
 FinderSearchStrategy >> finder [
 
 	^ finder

--- a/src/Tool-Finder/FinderSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderSearchStrategy.class.st
@@ -60,7 +60,8 @@ FinderSearchStrategy >> finder [
 { #category : #accessing }
 FinderSearchStrategy >> finder: anObject [
 
-	finder := anObject
+	finder := anObject.
+	self updateRegexUsage
 ]
 
 { #category : #testing }
@@ -105,4 +106,16 @@ FinderSearchStrategy >> methodSearch: aSelectBlock [
 			class classSide methodsDo: [ :method | (aSelectBlock value: method) ifTrue: [ result add: method ] ] ]
 		displayingProgress: [ :aClass | aClass name ].
 	^ result
+]
+
+{ #category : #accessing }
+FinderSearchStrategy >> rootNodeClassForResult: aCollection [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #private }
+FinderSearchStrategy >> updateRegexUsage [
+
+	finder enableUseRegEx
 ]

--- a/src/Tool-Finder/FinderSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderSearchStrategy.class.st
@@ -21,3 +21,33 @@ FinderSearchStrategy class >> strategyNamed: aSymbol [
 
 	^ self subclasses detect: [ :class | class strategyName = aSymbol ]
 ]
+
+{ #category : #testing }
+FinderSearchStrategy >> isClassesSearch [
+
+	^ false
+]
+
+{ #category : #testing }
+FinderSearchStrategy >> isExamplesSearch [
+
+	^ false
+]
+
+{ #category : #testing }
+FinderSearchStrategy >> isPragmasSearch [
+
+	^ false
+]
+
+{ #category : #testing }
+FinderSearchStrategy >> isSelectorsSearch [
+
+	^ false
+]
+
+{ #category : #testing }
+FinderSearchStrategy >> isSourceSearch [
+
+	^ false
+]

--- a/src/Tool-Finder/FinderSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderSearchStrategy.class.st
@@ -40,6 +40,25 @@ FinderSearchStrategy >> constructDictionary [
 ]
 
 { #category : #accessing }
+FinderSearchStrategy >> defaultExplanation [
+
+	^ 'The Finder can be used in 4 different ways:
+	- Selectors: your research is done among selectors
+	- Classes : your research is done among classes names
+	- Source : your research is done among all the source code
+	- Pragmas: your research is done among pragmas
+	- Examples : your research uses the Method Finder behavior
+			   (for further informations, print ''FinderUI methodFinderExplanation'')
+
+
+In these four modes, you can also tick the ''Use RegEx'' checkbox.
+If you pick this box, your search will be done using regular expressions instead of just matching.
+
+The ''Select classes'' button opened a dialog window  to select which classes will be used for the search.
+The ''All classes'' button is used to reset the classes selection.'
+]
+
+{ #category : #accessing }
 FinderSearchStrategy >> findSelectedClassIn: path [
 
 	^ self subclassResponsibility
@@ -112,6 +131,12 @@ FinderSearchStrategy >> methodSearch: aSelectBlock [
 FinderSearchStrategy >> rootNodeClassForResult: aCollection [
 
 	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+FinderSearchStrategy >> sourceCodeClass: class method: method [
+
+	^ (class >> method) sourceCode
 ]
 
 { #category : #private }

--- a/src/Tool-Finder/FinderSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderSearchStrategy.class.st
@@ -1,0 +1,23 @@
+Class {
+	#name : #FinderSearchStrategy,
+	#superclass : #Object,
+	#category : #'Tool-Finder-Base'
+}
+
+{ #category : #testing }
+FinderSearchStrategy class >> isAbstract [
+
+	^ self = FinderSearchStrategy
+]
+
+{ #category : #accessing }
+FinderSearchStrategy class >> strategyName [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+FinderSearchStrategy class >> strategyNamed: aSymbol [
+
+	^ self subclasses detect: [ :class | class strategyName = aSymbol ]
+]

--- a/src/Tool-Finder/FinderSelectorsSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderSelectorsSearchStrategy.class.st
@@ -10,8 +10,50 @@ FinderSelectorsSearchStrategy class >> strategyName [
 	^ #Selectors
 ]
 
+{ #category : #actions }
+FinderSelectorsSearchStrategy >> constructDictionary [
+
+	| result |
+	result := Dictionary new.
+	self messagesNameSearch do: [ :method |
+		| key value |
+		key := method selector.
+		value := method methodClass.
+		(result includesKey: key)
+			ifTrue: [ (result at: key) add: value ]
+			ifFalse: [
+				result at: key put: (OrderedCollection new
+						 add: value;
+						 yourself) ] ].
+	finder resultDictionary: result
+]
+
 { #category : #testing }
 FinderSelectorsSearchStrategy >> isSelectorsSearch [
 
 	^ true
+]
+
+{ #category : #actions }
+FinderSelectorsSearchStrategy >> messageSearchBlock [
+
+	| exactMatch aString |
+	aString := finder searchingString.
+	exactMatch := aString first = $" and: [ aString last = $" ].
+
+	exactMatch ifFalse: [ ^ [ :method | method selector includesSubstring: aString caseSensitive: false ] ].
+
+	^ (Symbol findInterned: (aString copyFrom: 2 to: aString size - 1)) ifNotNil: [ :aSymbol | [ :method | method selector = aSymbol ] ]
+]
+
+{ #category : #actions }
+FinderSelectorsSearchStrategy >> messagesNameSearch [
+	"I'm searching for selectors"
+
+	^ finder useRegEx
+		  ifTrue: [
+			  | regex |
+			  regex := finder searchingString asRegex.
+			  self methodSearch: [ :method | regex search: method selector asString ] ]
+		  ifFalse: [ self methodSearch: self messageSearchBlock ]
 ]

--- a/src/Tool-Finder/FinderSelectorsSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderSelectorsSearchStrategy.class.st
@@ -1,3 +1,6 @@
+"
+I am a Finder search mode used when looking for methods in the system.
+"
 Class {
 	#name : #FinderSelectorsSearchStrategy,
 	#superclass : #FinderSearchStrategy,
@@ -46,12 +49,6 @@ FinderSelectorsSearchStrategy >> findSelectedMethodIn: path [
 	^ path first isSingle
 		  ifTrue: [ path first itemMethod selector ]
 		  ifFalse: [ path first item ]
-]
-
-{ #category : #testing }
-FinderSelectorsSearchStrategy >> isSelectorsSearch [
-
-	^ true
 ]
 
 { #category : #actions }

--- a/src/Tool-Finder/FinderSelectorsSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderSelectorsSearchStrategy.class.st
@@ -77,3 +77,11 @@ FinderSelectorsSearchStrategy >> messagesNameSearch [
 			  self methodSearch: [ :method | regex search: method selector asString ] ]
 		  ifFalse: [ self methodSearch: self messageSearchBlock ]
 ]
+
+{ #category : #accessing }
+FinderSelectorsSearchStrategy >> rootNodeClassForResult: aCollection [
+
+	^ aCollection size > 1
+		  ifTrue: [ FinderMethodNode ]
+		  ifFalse: [ FinderSingleMethodNode ]
+]

--- a/src/Tool-Finder/FinderSelectorsSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderSelectorsSearchStrategy.class.st
@@ -9,3 +9,9 @@ FinderSelectorsSearchStrategy class >> strategyName [
 
 	^ #Selectors
 ]
+
+{ #category : #testing }
+FinderSelectorsSearchStrategy >> isSelectorsSearch [
+
+	^ true
+]

--- a/src/Tool-Finder/FinderSelectorsSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderSelectorsSearchStrategy.class.st
@@ -28,6 +28,26 @@ FinderSelectorsSearchStrategy >> constructDictionary [
 	finder resultDictionary: result
 ]
 
+{ #category : #accessing }
+FinderSelectorsSearchStrategy >> findSelectedClassIn: path [
+
+	^ path first isSingle
+		  ifTrue: [ path first itemMethod methodClass ]
+		  ifFalse: [
+			  path
+				  at: 2
+				  ifPresent: [ :node | node item ]
+				  ifAbsent: [ nil ] ]
+]
+
+{ #category : #accessing }
+FinderSelectorsSearchStrategy >> findSelectedMethodIn: path [
+
+	^ path first isSingle
+		  ifTrue: [ path first itemMethod selector ]
+		  ifFalse: [ path first item ]
+]
+
 { #category : #testing }
 FinderSelectorsSearchStrategy >> isSelectorsSearch [
 

--- a/src/Tool-Finder/FinderSelectorsSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderSelectorsSearchStrategy.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #FinderSelectorsSearchStrategy,
+	#superclass : #FinderSearchStrategy,
+	#category : #'Tool-Finder-Base'
+}
+
+{ #category : #accessing }
+FinderSelectorsSearchStrategy class >> strategyName [
+
+	^ #Selectors
+]

--- a/src/Tool-Finder/FinderSourceSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderSourceSearchStrategy.class.st
@@ -30,6 +30,21 @@ FinderSourceSearchStrategy >> constructDictionary [
 	finder resultDictionary: result
 ]
 
+{ #category : #accessing }
+FinderSourceSearchStrategy >> findSelectedClassIn: path [
+
+	^ path
+		  at: 2
+		  ifPresent: [ :node | node item ]
+		  ifAbsent: [ nil ]
+]
+
+{ #category : #accessing }
+FinderSourceSearchStrategy >> findSelectedMethodIn: path [
+
+	^ path first item
+]
+
 { #category : #testing }
 FinderSourceSearchStrategy >> isSourceSearch [
 

--- a/src/Tool-Finder/FinderSourceSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderSourceSearchStrategy.class.st
@@ -51,6 +51,12 @@ FinderSourceSearchStrategy >> isSourceSearch [
 	^ true
 ]
 
+{ #category : #accessing }
+FinderSourceSearchStrategy >> rootNodeClassForResult: aCollection [
+
+	^ FinderMethodNode
+]
+
 { #category : #actions }
 FinderSourceSearchStrategy >> sourceRegexSearch [
 

--- a/src/Tool-Finder/FinderSourceSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderSourceSearchStrategy.class.st
@@ -10,8 +10,42 @@ FinderSourceSearchStrategy class >> strategyName [
 	^ #Source
 ]
 
+{ #category : #actions }
+FinderSourceSearchStrategy >> constructDictionary [
+
+	| result |
+	result := Dictionary new.
+	(finder useRegEx
+		 ifTrue: [ self sourceRegexSearch ]
+		 ifFalse: [ self sourceStringSearch ]) do: [ :method |
+		| key value |
+		key := method selector.
+		value := method methodClass.
+		(result includesKey: key)
+			ifTrue: [ (result at: key) add: value ]
+			ifFalse: [
+				result at: key put: (OrderedCollection new
+						 add: value;
+						 yourself) ] ].
+	finder resultDictionary: result
+]
+
 { #category : #testing }
 FinderSourceSearchStrategy >> isSourceSearch [
 
 	^ true
+]
+
+{ #category : #actions }
+FinderSourceSearchStrategy >> sourceRegexSearch [
+
+	| regex |
+	regex := finder searchingString asRegex.
+	^ self methodSearch: [ :method | regex search: method sourceCode ]
+]
+
+{ #category : #actions }
+FinderSourceSearchStrategy >> sourceStringSearch [
+
+	^ self methodSearch: [ :method | method sourceCode includesSubstring: finder searchingString caseSensitive: false ]
 ]

--- a/src/Tool-Finder/FinderSourceSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderSourceSearchStrategy.class.st
@@ -9,3 +9,9 @@ FinderSourceSearchStrategy class >> strategyName [
 
 	^ #Source
 ]
+
+{ #category : #testing }
+FinderSourceSearchStrategy >> isSourceSearch [
+
+	^ true
+]

--- a/src/Tool-Finder/FinderSourceSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderSourceSearchStrategy.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #FinderSourceSearchStrategy,
+	#superclass : #FinderSearchStrategy,
+	#category : #'Tool-Finder-Base'
+}
+
+{ #category : #accessing }
+FinderSourceSearchStrategy class >> strategyName [
+
+	^ #Source
+]

--- a/src/Tool-Finder/FinderSourceSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderSourceSearchStrategy.class.st
@@ -1,3 +1,6 @@
+"
+I am a Finder search mode used to look for a string inside the whole Pharo image source code.
+"
 Class {
 	#name : #FinderSourceSearchStrategy,
 	#superclass : #FinderSearchStrategy,
@@ -43,12 +46,6 @@ FinderSourceSearchStrategy >> findSelectedClassIn: path [
 FinderSourceSearchStrategy >> findSelectedMethodIn: path [
 
 	^ path first item
-]
-
-{ #category : #testing }
-FinderSourceSearchStrategy >> isSourceSearch [
-
-	^ true
 ]
 
 { #category : #accessing }

--- a/src/Tool-Finder/FinderUI.class.st
+++ b/src/Tool-Finder/FinderUI.class.st
@@ -569,7 +569,8 @@ FinderUI >> implementorsButtonLabel [
 
 { #category : #'buttons behavior' }
 FinderUI >> implementorsButtonState [
-	^ self selectedMethod isNil | self isClassNamesSymbol
+
+	^ self selectedMethod isNil or: [ self isClassSearch ]
 ]
 
 { #category : #private }
@@ -592,7 +593,8 @@ FinderUI >> inheritanceButtonLabel [
 
 { #category : #'buttons behavior' }
 FinderUI >> inheritanceButtonState [
-	^ self selectedClass isNil | self isClassNamesSymbol
+
+	^ self selectedClass isNil or: [ self isClassSearch ]
 ]
 
 { #category : #display }
@@ -607,14 +609,14 @@ FinderUI >> initialize [
 ]
 
 { #category : #'mode list' }
-FinderUI >> isClassNamesSymbol [
+FinderUI >> isClassSearch [
 
-	^self finder isClassNamesSymbol
+	^self finder isClassSearch
 ]
 
 { #category : #'mode list' }
-FinderUI >> isPragmasSymbol [
-	^self finder isPragmasSymbol
+FinderUI >> isPragmasSearch [
+	^self finder isPragmasSearch
 ]
 
 { #category : #private }
@@ -796,7 +798,8 @@ FinderUI >> sendersButtonLabel [
 
 { #category : #'buttons behavior' }
 FinderUI >> sendersButtonState [
-	^ self selectedMethod isNil | self isClassNamesSymbol
+
+	^ self selectedMethod isNil or: [ self isClassSearch ]
 ]
 
 { #category : #'text areas behavior' }
@@ -863,7 +866,8 @@ FinderUI >> versionsButtonLabel [
 
 { #category : #'buttons behavior' }
 FinderUI >> versionsButtonState [
-	^self selectedClass isNil | self isClassNamesSymbol
+
+	^ self selectedClass isNil or: [ self isClassSearch ]
 ]
 
 { #category : #'events handling' }

--- a/src/Tool-Finder/FinderUI.class.st
+++ b/src/Tool-Finder/FinderUI.class.st
@@ -34,72 +34,6 @@ FinderUI class >> icon [
 	^ self iconNamed: #smallFind
 ]
 
-{ #category : #explanations }
-FinderUI class >> methodFinderExplanation [
-	"The comment in the bottom pane"
-
-	MethodFinder new findMethodsByExampleInput: #( 1 2 ) andExpectedResult: 3.
-		"to keep the method methodFor: from being removed from the system"
-
-	^ 'Use an example to find a method in the system.
-
-   ''a''. ''b''. ''ab''       will find the message #, for strings concatenation
-   2. -2                will find the message #negated
-   3. 6                 will find the message #factorial
-   20. 10. 15. 15       will find the message #min:max:
-
-It works on collections too:
-
-   {2. 4. 5. 1}. 5. 3   will find the message #indexOf:
-   {2. 5. 1}. 5. true   will find the message #includes:
-
-An example is made up of the following two or more items separated by a period:
-
-	receiver. answer
-	receiver. argument1. answer
-	receiver. argument1. argument2. answer
-	etc...
-
-For example, type: 3. 4. 7. into the search box and click <Search>
-
-Take care on separating spaces because of floating point numbers.
-
- 	3.4.7      will find nothing, it is interpreted two numbers, 3.4 and. 7
-	3. 4. 7    will find you the message #+
-
-The examples array should contain one object for the receiver, one object per expected argument and then a final object with the expected result.
-
-In other words
- - a unary method example expects an array of input objects #( receiver ) and an expected result
- - a binary method example expects an array with two input objects #( receiver argument ) and an expected result
- - a keyword method example expects an array with at least two elements  #( receiver argument1 argument2 ... ) and an expected results
-
-The method finder will take the input objects (receiver and arguments) and perform their permutation to be able to find more results.
-Then, it will lookup in the receiver''s hierarchy the approved and forbidden methods to run on the hierarchy and run them on the permutation of objects.
-
-Receiver and arguments do not have to be in the right order.
-
-Alternatively, in this bottom pane or in the Playground, use #findMethodsByExampleInput:andExpectedResult: directly to find a method in the system.  Select this line of code and choose "print it" or "inspect it.
-
-	MethodFinder new findMethodsByExampleInput: #( 1 2 ) andExpectedResult: 3.
-
-It is useful when you want to look for computed objects:
-
-	MethodFinder new
-		findMethodsByExampleInput: {''29 Apr 1999'' asDate}
-		andExpectedResult: ''30 Apr 1999'' asDate.
-
-This will find the message #next.
-
-	MethodFinder new
-		findMethodsByExampleInput: {''30 Apr 1999'' asDate}
-		andExpectedResult: ''Friday''.
-
-This will find the message #dayOfWeekName
-
-The Method Finder is not trying all methods in the system so if it will find nothing, a method with requested behavior may still exist. '
-]
-
 { #category : #'instance creation' }
 FinderUI class >> on: aFinder [
 
@@ -497,25 +431,6 @@ FinderUI >> currentSearchMode: aSymbol [
 	self finder currentSearchMode: aSymbol
 ]
 
-{ #category : #private }
-FinderUI >> defaultExplanation [
-^
-'The Finder can be used in 4 different ways:
-	- Selectors: your research is done among selectors
-	- Classes : your research is done among classes names
-	- Source : your research is done among all the source code
-	- Pragmas: your research is done among pragmas
-	- Examples : your research uses the Method Finder behavior
-			   (for further informations, print ''FinderUI methodFinderExplanation'')
-
-
-In these four modes, you can also tick the ''Use RegEx'' checkbox.
-If you pick this box, your search will be done using regular expressions instead of just matching.
-
-The ''Select classes'' button opened a dialog window  to select which classes will be used for the search.
-The ''All classes'' button is used to reset the classes selection.'
-]
-
 { #category : #'items creation' }
 FinderUI >> defaultTreeMorph [
 	|  col |
@@ -697,23 +612,8 @@ FinderUI >> isClassNamesSymbol [
 ]
 
 { #category : #'mode list' }
-FinderUI >> isExamplesSymbol [
-	^self finder isExamplesSymbol
-]
-
-{ #category : #'mode list' }
 FinderUI >> isPragmasSymbol [
 	^self finder isPragmasSymbol
-]
-
-{ #category : #'mode list' }
-FinderUI >> isSelectorsSymbol [
-	^self finder isSelectorsSymbol
-]
-
-{ #category : #'mode list' }
-FinderUI >> isSourceSymbol [
-	^self finder isSourceSymbol
 ]
 
 { #category : #private }
@@ -917,20 +817,11 @@ FinderUI >> shoutAboutToStyle: aPluggableShoutMorphOrView [
 FinderUI >> sourceCode [
 
 	^ self selectedClass
-		ifNil: [
-			self isExamplesSymbol
-				ifTrue: [ self class methodFinderExplanation ]
-				ifFalse: [ self defaultExplanation]]
-		ifNotNil:[
-			self selectedMethod
-				ifNil: [
-					self buildDescriptionOf: self selectedClass]
-				ifNotNil:[
-					| selector |
-					selector := self isExamplesSymbol
-								ifTrue: [self selectedMethod selector]
-								ifFalse: [self selectedMethod].
-					(self selectedClass >> selector) sourceCode]]
+		  ifNil: [ self finder searchStrategy defaultExplanation ]
+		  ifNotNil: [ :class |
+			  self selectedMethod
+				  ifNil: [ self buildDescriptionOf: class ]
+				  ifNotNil: [ :method | self finder searchStrategy sourceCodeClass: class method: method ] ]
 ]
 
 { #category : #accessing }

--- a/src/Tool-Finder/FinderUI.class.st
+++ b/src/Tool-Finder/FinderUI.class.st
@@ -385,7 +385,8 @@ FinderUI >> buildVersionsButton [
 
 { #category : #'text areas behavior' }
 FinderUI >> collectFromPackages: aCollection [
-	self packagesSelection: (self environment forPackageNames: aCollection)
+
+	self finder packagesSelection: (self environment forPackageNames: aCollection)
 ]
 
 { #category : #'text areas behavior' }
@@ -658,12 +659,6 @@ FinderUI >> openPackageChooser [
 { #category : #private }
 FinderUI >> packagesSelection [
 	^self finder packagesSelection
-]
-
-{ #category : #private }
-FinderUI >> packagesSelection: aCollection [
-
-	self finder packagesSelection: aCollection
 ]
 
 { #category : #private }

--- a/src/Tool-Finder/FinderUI.class.st
+++ b/src/Tool-Finder/FinderUI.class.st
@@ -606,21 +606,6 @@ FinderUI >> finder: aFinder [
 	finder := aFinder
 ]
 
-{ #category : #searching }
-FinderUI >> forSelectorsDo: selectorBlock forClassNamesDo: classNamesBlock forSourceDo: sourceBlock forExamplesDo: exampleBlock forPragmasDo: pragmaBlock [
-
-	self isSelectorsSymbol
-		ifTrue: [^selectorBlock value].
-	self isClassNamesSymbol
-		ifTrue: [^classNamesBlock value].
-	self isSourceSymbol
-		ifTrue: [^sourceBlock value].
-	self isExamplesSymbol
-		ifTrue: [^exampleBlock value].
-	self isPragmasSymbol
-		ifTrue: [^pragmaBlock value]
-]
-
 { #category : #accessing }
 FinderUI >> forceSearch [
 	^ forceSearch ifNil: [ forceSearch := false ]
@@ -741,7 +726,7 @@ FinderUI >> labelFont [
 	^StandardFonts defaultFont
 ]
 
-{ #category : #'t - accessing' }
+{ #category : #accessing }
 FinderUI >> menu: menu shifted: b [
 	self selectedNode ifNil: [ ^menu ].
 	^ self selectedNode menu: menu shifted: b
@@ -796,19 +781,12 @@ FinderUI >> rootItems [
 	^ self resultDictionary keys sort: [ :a :b | a asString < b asString ]
 ]
 
-{ #category : #'t - accessing' }
+{ #category : #accessing }
 FinderUI >> rootNodeClassFromItem: anItem [
 	"To have the good class for my nodes, I ask my owner,
 	because he is the only one who knows his state"
 
-	^ self
-		forSelectorsDo: [ (self resultDictionary at: anItem) size > 1
-				ifTrue: [ FinderMethodNode ]
-				ifFalse: [ FinderSingleMethodNode ] ]
-		forClassNamesDo: [ FinderClassNode ]
-		forSourceDo: [ FinderMethodNode ]
-		forExamplesDo: [ FinderExampleMethodNode ]
-		forPragmasDo: [ FinderPragmaNode ]
+	^ self finder searchStrategy rootNodeClassForResult: (self resultDictionary at: anItem)
 ]
 
 { #category : #'buttons behavior' }


### PR DESCRIPTION
The Finder as an instance variable to know which search mode it is using. Do do that it saves a symbol and does a lot of conditionals to know what to do.

This tool is one of the tool that is still in Morphic and that we need to migrate to Spec. So I wanted to improve the model in order to make it easier to build a clean interface later. 

The main change is that I introduced a Strategy design pattern to manage the search mode instead of saving a symbol. 
There are still a lot of dirty things such as method with bad code, bad method names, the model storing informations in the model (like the usage of regex)... But it is already way simpler with the design pattern