### PR TITLE
Deprecate ClassDescription>>#addMethodTag: 

### DIFF
--- a/src/Calypso-SystemQueries/ClyTaggedMethodGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyTaggedMethodGroup.class.st
@@ -44,16 +44,18 @@ ClyTaggedMethodGroup >> removeWithMethods [
 
 { #category : #operations }
 ClyTaggedMethodGroup >> renameMethodTagTo: newTag [
-	newTag = self tag ifTrue: [ ^self ].
+
+	newTag = self tag ifTrue: [ ^ self ].
 
 	self methods do: [ :method |
-		method tagWith: newTag.
-		method untagFrom: self tag].
+		method
+			tagWith: newTag;
+			untagFrom: self tag ].
 
-	methodQuery scope classesDo:  [ :class |
-		(class tagsForMethods includes: newTag)
-			ifFalse: [ class addMethodTag: newTag ].
-		class removeProtocolIfEmpty: self tag]
+	methodQuery scope classesDo: [ :class |
+		class
+			addProtocol: newTag;
+			removeProtocolIfEmpty: self tag ]
 ]
 
 { #category : #accessing }

--- a/src/Deprecated12/ClassDescription.extension.st
+++ b/src/Deprecated12/ClassDescription.extension.st
@@ -8,6 +8,14 @@ ClassDescription >> addCategory: aString [
 ]
 
 { #category : #'*Deprecated12' }
+ClassDescription >> addMethodTag: aSymbol [
+
+	self deprecated: 'Use #addProtocol: instead.' transformWith: '`@rcv addMethodTag: `@arg' -> '`@rcv addProtocol: `@arg'.
+
+	self addProtocol: aSymbol
+]
+
+{ #category : #'*Deprecated12' }
 ClassDescription >> allCategories [
 
 	self deprecated: 'Use #protocolNames instead.' transformWith: '`@rcv allCategories' -> '`@rcv protocolNames'.

--- a/src/Deprecated12/RGBehavior.extension.st
+++ b/src/Deprecated12/RGBehavior.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #RGBehavior }
+
+{ #category : #'*Deprecated12' }
+RGBehavior >> addMethodTag: aSymbol [
+
+	self deprecated: 'Use #addProtocol: instead.' transformWith: '`@rcv addMethodTag: `@arg' -> '`@rcv addProtocol: `@arg'.
+
+	self addProtocol: aSymbol
+]

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -65,14 +65,6 @@ ClassDescription >> addInstVarNamed: aString [
 	self subclassResponsibility
 ]
 
-{ #category : #'accessing - tags' }
-ClassDescription >> addMethodTag: aSymbol [
-
-	self deprecated: 'Use #addProtocol: instead.' transformWith: '`@rcv addMethodTag: `@arg' -> '`@rcv addProtocol: `@arg'.
-
-	self addProtocol: aSymbol
-]
-
 { #category : #protocols }
 ClassDescription >> addProtocol: aProtocol [
 

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -67,8 +67,8 @@ ClassDescription >> addInstVarNamed: aString [
 
 { #category : #'accessing - tags' }
 ClassDescription >> addMethodTag: aSymbol [
-	"Any method could be tagged with multiple symbols for user purpose.
-	In class we could define what tags could be used for methods"
+
+	self deprecated: 'Use #addProtocol: instead.' transformWith: '`@rcv addMethodTag: `@arg' -> '`@rcv addProtocol: `@arg'.
 
 	self addProtocol: aSymbol
 ]

--- a/src/Ring-Core/RGBehavior.class.st
+++ b/src/Ring-Core/RGBehavior.class.st
@@ -165,14 +165,6 @@ RGBehavior >> addLocalMethod: anRGMethod [
 ]
 
 { #category : #'accessing - backend' }
-RGBehavior >> addMethodTag: aSymbol [
-
-	self deprecated: 'Use #addProtocol: instead.' transformWith: '`@rcv addMethodTag: `@arg' -> '`@rcv addProtocol: `@arg'.
-
-	self addProtocol: aSymbol
-]
-
-{ #category : #'accessing - backend' }
 RGBehavior >> addProtocol: aSymbol [
 
 	self announceDefinitionChangeDuring: [ self backend forBehavior addMethodTag: aSymbol to: self ]

--- a/src/Ring-Core/RGBehavior.class.st
+++ b/src/Ring-Core/RGBehavior.class.st
@@ -167,14 +167,15 @@ RGBehavior >> addLocalMethod: anRGMethod [
 { #category : #'accessing - backend' }
 RGBehavior >> addMethodTag: aSymbol [
 
-	self announceDefinitionChangeDuring: [
-		self backend forBehavior addMethodTag: aSymbol to: self. ]
+	self deprecated: 'Use #addProtocol: instead.' transformWith: '`@rcv addMethodTag: `@arg' -> '`@rcv addProtocol: `@arg'.
+
+	self addProtocol: aSymbol
 ]
 
 { #category : #'accessing - backend' }
 RGBehavior >> addProtocol: aSymbol [
 
-	self addMethodTag: aSymbol
+	self announceDefinitionChangeDuring: [ self backend forBehavior addMethodTag: aSymbol to: self ]
 ]
 
 { #category : #'managing container' }
@@ -435,9 +436,11 @@ RGBehavior >> ensureLocalMethodNamed: aSymbol [
 { #category : #'queries - tags' }
 RGBehavior >> ensureMethodTagNamed: aSymbol [
 
-	^ self tagsForMethods detect: [ :each | each asSymbol = aSymbol ] ifNone: [
-		self addMethodTag: aSymbol.
-		aSymbol ]
+	^ self tagsForMethods
+		  detect: [ :each | each asSymbol = aSymbol ]
+		  ifNone: [
+			  self addProtocol: aSymbol.
+			  aSymbol ]
 ]
 
 { #category : #'queries - protocols' }

--- a/src/Ring-Core/RGMethod.class.st
+++ b/src/Ring-Core/RGMethod.class.st
@@ -489,8 +489,7 @@ RGMethod >> tagWith: aSymbol [
 
 	self changeProtocolDuring: [
 		self backend forMethod tagMethod: self with: aSymbol.
-		self parent addMethodTag: aSymbol.
-	]
+		self parent addProtocol: aSymbol ]
 ]
 
 { #category : #'accessing - model' }

--- a/src/Ring-Tests-Core/RGBehaviorTest.class.st
+++ b/src/Ring-Tests-Core/RGBehaviorTest.class.st
@@ -18,13 +18,14 @@ RGBehaviorTest >> testBadInstantiation [
 
 { #category : #tests }
 RGBehaviorTest >> testBehaviorWithMethodTags [
+
 	| newBehavior |
 	newBehavior := self behaviorClass named: #SomeClass.
 	self assert: newBehavior name equals: #SomeClass.
-	self assert: (newBehavior hasUnresolvedAll: #(superclass localMethods protocols)).
+	self assert: (newBehavior hasUnresolvedAll: #( superclass localMethods protocols )).
 	self assert: newBehavior methods isEmpty.
 
-	1 to: 10 do: [ :i | newBehavior addMethodTag: ('tag' , i asString) asSymbol ].
+	1 to: 10 do: [ :i | newBehavior addProtocol: ('tag' , i asString) asSymbol ].
 
 	self assert: (newBehavior hasResolved: #tagsForMethods).
 
@@ -39,13 +40,14 @@ RGBehaviorTest >> testBehaviorWithMethodTags [
 
 { #category : #tests }
 RGBehaviorTest >> testBehaviorWithProtocols [
+
 	| newBehavior |
 	newBehavior := self behaviorClass named: #SomeClass.
 	self assert: newBehavior name equals: #SomeClass.
-	self assert: (newBehavior hasUnresolvedAll: #(superclass localMethods protocols)).
+	self assert: (newBehavior hasUnresolvedAll: #( superclass localMethods protocols )).
 	self assert: newBehavior methods isEmpty.
 
-	1 to: 10 do: [ :i | newBehavior addMethodTag: ('tag' , i asString) asSymbol ].
+	1 to: 10 do: [ :i | newBehavior addProtocol: ('tag' , i asString) asSymbol ].
 
 	self assert: (newBehavior protocols allSatisfy: #isSymbol).
 

--- a/src/Ring-Tests-Core/RGClassTest.class.st
+++ b/src/Ring-Tests-Core/RGClassTest.class.st
@@ -339,7 +339,6 @@ RGClassTest >> testTagsForMethods [
 RGClassTest >> testTagsForMethodsCollection [
 
 	| class env tag1 tag2 tag3 |
-
 	class := RGClass unnamed.
 	env := class environment.
 
@@ -347,17 +346,17 @@ RGClassTest >> testTagsForMethodsCollection [
 	self assert: (class hasUnresolved: #tagsForMethods).
 
 	tag1 := #tag1.
-	class addMethodTag: #tag1.
+	class addProtocol: #tag1.
 	self assert: class tagsForMethods size equals: 1.
 
 	self assert: (class hasResolved: #tagsForMethods).
 
 	tag2 := #tag2.
-	class addMethodTag: tag2.
+	class addProtocol: tag2.
 	self assert: class tagsForMethods size equals: 2.
 
 	tag3 := #tag3.
-	class addMethodTag: tag3.
+	class addProtocol: tag3.
 	self assert: class tagsForMethods size equals: 3.
 
 	class removeMethodTag: tag3.

--- a/src/SystemCommands-ClassCommands/SycAddNewMethodTagCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycAddNewMethodTagCommand.class.st
@@ -36,7 +36,7 @@ SycAddNewMethodTagCommand >> defaultMenuItemName [
 { #category : #execution }
 SycAddNewMethodTagCommand >> execute [
 
-	targetClass addMethodTag: tagName asSymbol
+	targetClass addProtocol: tagName
 ]
 
 { #category : #execution }


### PR DESCRIPTION
This method just calls #addProtocol: and protocol is the name currently used in the system.