### PR TITLE
Some simple cleanups (lookupVar: category, #home use ifNotNil...)

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -60,11 +60,6 @@ Context >> lookupTempVar: aSymbol [
 ]
 
 { #category : #'*Debugging-Core' }
-Context >> lookupVar: aSymbol [
-	^ self astScope lookupVar: aSymbol
-]
-
-{ #category : #'*Debugging-Core' }
 Context >> methodReturnConstant: value [
 	"Simulate the action of a 'return constant' bytecode whose value is the
 	 argument, value. This corresponds to a source expression like '^0'."

--- a/src/Fuel-Tests-Core/FLEnvironmentProtectingWrapper.class.st
+++ b/src/Fuel-Tests-Core/FLEnvironmentProtectingWrapper.class.st
@@ -250,7 +250,7 @@ FLEnvironmentProtectingWrapper >> keyAtValue: anObject ifAbsent: aBlock [
 				ifAbsent: aBlock ]
 ]
 
-{ #category : #binding }
+{ #category : #lookup }
 FLEnvironmentProtectingWrapper >> lookupVar: aString [
 	^ (overlay lookupVar: aString) ifNil: [
 		environment lookupVar: aString ]

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1153,6 +1153,14 @@ Behavior >> lookupSelector: selector [
 	^ nil
 ]
 
+{ #category : #lookup }
+Behavior >> lookupVar: aName [
+	^ self classLayout
+		resolveSlot: aName asSymbol
+		ifFound: [:var | var]
+		ifNone: [self bindingOf: aName]
+]
+
 { #category : #accessing }
 Behavior >> methodDict [
        "The method dictionary of a class can be nil when we want to use the #cannotInterpret: hook. Indeed when a class dictionary is nil, the VM sends the message cannotInterpret: to the receiver but starting the look up in the superclass of the class whose method dictionary was nil.

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -555,11 +555,6 @@ CompiledMethod >> literalsToSkip [
 	^ 2
 ]
 
-{ #category : #lookup }
-CompiledMethod >> lookupVar: aString [
-	^self ast scope lookupVar: aString
-]
-
 { #category : #private }
 CompiledMethod >> markerOrNil [
 	^ self encoderClass markerOrNilFor: self

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -919,8 +919,9 @@ Context >> home [
 
 	closureOrNil ifNil: [ ^ self ].
 	"this happens for clean blocks, we try to find the home on the stack"
-	closureOrNil outerContext ifNil: [ ^ self activeHome ].
-	^ closureOrNil outerContext home
+	^ closureOrNil outerContext 
+		ifNil: [ self activeHome ]
+		ifNotNil: [:outer | outer home ]
 ]
 
 { #category : #accessing }

--- a/src/Kernel/ProcessorScheduler.class.st
+++ b/src/Kernel/ProcessorScheduler.class.st
@@ -218,9 +218,7 @@ ProcessorScheduler >> nextReadyProcess [
 
 	quiescentProcessLists reverseDo: [ :list |
 		list ifNotEmpty: [
-			| proc |
-			proc := list first.
-			proc suspendedContext ifNotNil: [ ^ proc ] ] ].
+			list first suspendedContext ifNotNil: [:proc | ^ proc ] ] ].
 	^ nil
 ]
 

--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -72,14 +72,6 @@ Behavior >> evaluate: aString [
 ]
 
 { #category : #'*OpalCompiler-Core' }
-Behavior >> lookupVar: aName [
-	^ self classLayout
-		resolveSlot: aName asSymbol
-		ifFound: [:var | var]
-		ifNone: [self bindingOf: aName]
-]
-
-{ #category : #'*OpalCompiler-Core' }
 Behavior >> outerScope [
 	^self environment
 ]

--- a/src/OpalCompiler-Core/CompiledMethod.extension.st
+++ b/src/OpalCompiler-Core/CompiledMethod.extension.st
@@ -16,6 +16,11 @@ CompiledMethod >> decompileIR [
 ]
 
 { #category : #'*OpalCompiler-Core' }
+CompiledMethod >> lookupVar: aString [
+	^self ast scope lookupVar: aString
+]
+
+{ #category : #'*OpalCompiler-Core' }
 CompiledMethod >> methodNode [
 	"returns an AST for this method, do not cache it. (see #ast for the cached alternative)"
 	^self parseTree

--- a/src/OpalCompiler-Core/Context.extension.st
+++ b/src/OpalCompiler-Core/Context.extension.st
@@ -60,6 +60,11 @@ Context >> isReturnAt: aPC [
 ]
 
 { #category : #'*OpalCompiler-Core' }
+Context >> lookupVar: aSymbol [
+	^ self astScope lookupVar: aSymbol
+]
+
+{ #category : #'*OpalCompiler-Core' }
 Context >> sourceNode [
 	"Return the source node that created the method or the block of this context"
 


### PR DESCRIPTION
- move some #lookupVar: to the compiler package from debugging (a bit better place), some to "lookup" where the compiler is not used (e.g. Behavior).
- trivial clean nextReadyProcess
- trivial cleanup to Context>>#home from the mail