### PR TITLE
Reflectivity: thisProcess and remove  #rfactiveProcess and #rfeffectiveProcess

### DIFF
--- a/src/Reflectivity-Tests/ReflectivityControlTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityControlTest.class.st
@@ -13,7 +13,7 @@ Class {
 
 { #category : #tagging }
 ReflectivityControlTest >> recordLevel [
-	tag := Processor activeProcess level
+	tag := thisProcess level
 ]
 
 { #category : #tagging }
@@ -847,7 +847,7 @@ ReflectivityControlTest >> testConditionMetaLevel [
 	link := MetaLink new
 		metaObject: self;
 		selector: #tagExec:;
-		condition: [ self assert: Processor activeProcess level identicalTo: 1.
+		condition: [ self assert: thisProcess level identicalTo: 1.
 			true ];
 		level: 0;
 		arguments: #(#node).

--- a/src/Reflectivity-Tests/ReflectivityReificationTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityReificationTest.class.st
@@ -258,9 +258,9 @@ ReflectivityReificationTest >> testReifyArguments2level [
 	self assert: (ReflectivityExamples >> #exampleSendTwoArgs) class equals: ReflectiveMethod.
 	self assert: tag isNil.
 	instance := ReflectivityExamples new.
-	self deny: (Processor activeProcess isMeta).
+	self deny: thisProcess isMeta.
 	self assert: instance exampleSendTwoArgs equals: #(1 2).
-	self deny: (Processor activeProcess isMeta).
+	self deny: thisProcess isMeta.
 	self assert: tag equals: #(1 2)
 ]
 

--- a/src/Reflectivity/MetaLink.class.st
+++ b/src/Reflectivity/MetaLink.class.st
@@ -547,7 +547,7 @@ MetaLink >> unlinkFromNode: aNode forObject: anObject [
 MetaLink >> valueInContext: aBlock [
 	| process |
 	"We need to take care that all code called here can not have active metalinks. We use copies of methods if we call system methods"
-	process := Processor rfactiveProcess.
+	process := thisProcess.
 	(process isActiveInMetaLevel: self level)
 		ifFalse: [ ^ self ].
 	process shiftLevelUp.

--- a/src/Reflectivity/Process.extension.st
+++ b/src/Reflectivity/Process.extension.st
@@ -1,8 +1,0 @@
-Extension { #name : #Process }
-
-{ #category : #'*Reflectivity' }
-Process >> rfeffectiveProcess [
-	"same as #effectiveProcess but for internal use for metalink activation"
-	<metaLinkOptions: #( + optionDisabledLink)>
-	^effectiveProcess ifNil: [self]
-]

--- a/src/Reflectivity/ProcessorScheduler.extension.st
+++ b/src/Reflectivity/ProcessorScheduler.extension.st
@@ -1,8 +1,0 @@
-Extension { #name : #ProcessorScheduler }
-
-{ #category : #'*Reflectivity' }
-ProcessorScheduler >> rfactiveProcess [
-	"Answer the currently running Process."
-	<metaLinkOptions: #( + optionDisabledLink)>
-	^activeProcess rfeffectiveProcess
-]


### PR DESCRIPTION
- use thisProcess in Reflectivity
- this allows us to remove #rfactiveProcess
- rfeffectiveProcess is not used, we can remove it