### PR TITLE
Some cleanings in RPackage related to protocols

### DIFF
--- a/src/GeneralRules/ReCodeCruftLeftInMethodsRule.class.st
+++ b/src/GeneralRules/ReCodeCruftLeftInMethodsRule.class.st
@@ -46,8 +46,7 @@ ReCodeCruftLeftInMethodsRule >> debuggingPatterns [
 { #category : #private }
 ReCodeCruftLeftInMethodsRule >> debuggingSelectors [
 
-	^ (Object allSelectorsInProtocol: 'flagging'),
-	(Object allSelectorsInProtocol: 'debugging')
+	^ (Object allSelectorsInProtocol: 'flagging') , (Object allSelectorsInProtocol: 'debugging')
 ]
 
 { #category : #accessing }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -135,11 +135,10 @@ ClassDescription >> allLocalCallsOn: aSymbol [
 ]
 
 { #category : #'accessing - method dictionary' }
-ClassDescription >> allSelectorsInProtocol: aName [
-	"Answer a list of all the methods of the receiver and all its
-	superclasses that are in the protocol named aName"
+ClassDescription >> allSelectorsInProtocol: protocol [
+	"Answer a list of all the method selectors of the receiver and all its superclasses that are in the protocol as parameter."
 
-	^ self withAllSuperclasses flatCollectAsSet: [ :class | class selectorsInProtocol: aName ]
+	^ self withAllSuperclasses flatCollectAsSet: [ :class | class selectorsInProtocol: protocol ]
 ]
 
 { #category : #'pool variable' }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -678,10 +678,10 @@ ClassDescription >> localSlots [
 	^ self slots select: [ :aSlot | aSlot isDefinedByOwningClass ]
 ]
 
-{ #category : #organization }
-ClassDescription >> methodsInProtocol: aString [
+{ #category : #protocols }
+ClassDescription >> methodsInProtocol: protocol [
 
-	^ (self selectorsInProtocol: aString) collect: [ :each | self compiledMethodAt: each ]
+	^ (self selectorsInProtocol: protocol) collect: [ :selector | self compiledMethodAt: selector ]
 ]
 
 { #category : #'accessing - tags' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -306,7 +306,7 @@ RPackage >> basicImportClass: aClass [
 	aClass protocolNames do: [ :protocolName | (self isYourClassExtension: protocolName) ifTrue: [ aClass renameProtocol: protocolName as: Protocol unclassified ] ].
 	aClass protocols
 		reject: [ :protocol | protocol isExtensionProtocol ]
-		thenDo: [ :protocol | self importProtocol: protocol name forClass: aClass ]
+		thenDo: [ :protocol | self importProtocol: protocol forClass: aClass ]
 ]
 
 { #category : #'add method - selector' }
@@ -760,9 +760,11 @@ RPackage >> importPackage: anRPackage [
 
 { #category : #private }
 RPackage >> importProtocol: aProtocol forClass: aClass [
-	"import all the methods of a protocol as defined in the receiver."
+	"import all the local methods of a protocol as defined in the receiver."
 
-	(aClass methodsInProtocol: aProtocol) do: [ :method | method isFromTrait ifFalse: [ self addMethod: method ] ]
+	(aClass methodsInProtocol: aProtocol)
+		reject: [ :method | method isFromTrait ]
+		thenDo: [ :method | self addMethod: method ]
 ]
 
 { #category : #testing }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -847,17 +847,16 @@ RPackage >> includesExtensionSelector: aSelector ofMetaclassName: aClassName [
 	^ sels includes: aSelector
 ]
 
-{ #category : #'system compatibility' }
-RPackage >> includesMethodCategory: categoryName ofClass: aClass [
-	^ (self isYourClassExtension: categoryName)
-		or: [(self includesClass: aClass)
-				and: [(self isForeignClassExtension: categoryName) not]]
-]
-
 { #category : #testing }
 RPackage >> includesMethodsAffectedBy: aSystemAnnouncement [
 
 	^aSystemAnnouncement affectsMethodsDefinedInPackage: self
+]
+
+{ #category : #'system compatibility' }
+RPackage >> includesProtocol: categoryName ofClass: aClass [
+
+	^ (self isYourClassExtension: categoryName) or: [ (self includesClass: aClass) and: [ (self isForeignClassExtension: categoryName) not ] ]
 ]
 
 { #category : #testing }

--- a/src/RPackage-Core/RPackageSet.class.st
+++ b/src/RPackage-Core/RPackageSet.class.st
@@ -139,10 +139,9 @@ RPackageSet >> includesClass: aClass [
 ]
 
 { #category : #'system compatibility' }
-RPackageSet >> includesMethodCategory: categoryName ofClass: aClass [
-	^ (self isYourClassExtension: categoryName)
-		or: [(self includesClass: aClass)
-				and: [(self isForeignClassExtension: categoryName) not ]]
+RPackageSet >> includesProtocol: categoryName ofClass: aClass [
+
+	^ (self isYourClassExtension: categoryName) or: [ (self includesClass: aClass) and: [ (self isForeignClassExtension: categoryName) not ] ]
 ]
 
 { #category : #'system compatibility' }

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -115,10 +115,9 @@ RPackageTag >> includesClass: aClass [
 ]
 
 { #category : #testing }
-RPackageTag >> includesMethodCategory: aProtocol ofClass: aClass [
-	^ self package
-		includesMethodCategory: aProtocol
-		ofClass: aClass
+RPackageTag >> includesProtocol: aProtocol ofClass: aClass [
+
+	^ self package includesProtocol: aProtocol ofClass: aClass
 ]
 
 { #category : #testing }

--- a/src/Refactoring-Environment/RBPackageEnvironment.class.st
+++ b/src/Refactoring-Environment/RBPackageEnvironment.class.st
@@ -127,7 +127,7 @@ RBPackageEnvironment >> includesClass: aClass [
 
 { #category : #testing }
 RBPackageEnvironment >> includesProtocol: aProtocol in: aClass [
-	^ (environment includesProtocol: aProtocol in: aClass) and: [ self packages anySatisfy: [ :package | package includesMethodCategory: aProtocol ofClass: aClass ] ]
+	^ (environment includesProtocol: aProtocol in: aClass) and: [ self packages anySatisfy: [ :package | package includesProtocol: aProtocol ofClass: aClass ] ]
 ]
 
 { #category : #testing }

--- a/src/Refactoring-Tests-Environment/RBBrowserEnvironmentTest.class.st
+++ b/src/Refactoring-Tests-Environment/RBBrowserEnvironmentTest.class.st
@@ -341,7 +341,7 @@ RBBrowserEnvironmentTest >> testOrEnvironment [
 	self assert: orEnvironment classNames asSortedCollection equals: universalEnvironment classNames asSortedCollection.
 	self
 		assert: (orEnvironment protocolsFor: Object)
-		equals: ((universalEnvironment protocolsFor: Object) reject: [ :each | (Object allSelectorsInProtocol: each) isEmpty ])
+		equals: ((universalEnvironment protocolsFor: Object) reject: [ :protocolName | (Object allSelectorsInProtocol: protocolName) isEmpty ])
 ]
 
 { #category : #'tests - environments' }


### PR DESCRIPTION
Here is a step to clean the usage of protocols in RPackage

- Rename some temporaries to explicit better what arguments can be used
- Improve some categorization
- Make some methods deal with real protocols instead of symbols
- Rename includesMethodCategory:ofClass:into includesProtocol:ofClass:

Next step is to push further the usage of real protocols to simplify the code