### PR TITLE
Fix missing Finder method

### DIFF
--- a/src/Tool-Finder/Finder.class.st
+++ b/src/Tool-Finder/Finder.class.st
@@ -137,7 +137,7 @@ Finder >> isClassSearch [
 { #category : #checkbox }
 Finder >> isPragmasSearch [
 
-	^ self searchStrategy isPragmaSearch
+	^ self searchStrategy isPragmasSearch
 ]
 
 { #category : #display }

--- a/src/Tool-Finder/FinderPragmasSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderPragmasSearchStrategy.class.st
@@ -48,6 +48,12 @@ FinderPragmasSearchStrategy >> findSelectedMethodIn: path [
 		  ifAbsent: [ nil ]
 ]
 
+{ #category : #testing }
+FinderPragmasSearchStrategy >> isPragmasSearch [
+
+	^ true
+]
+
 { #category : #actions }
 FinderPragmasSearchStrategy >> pragmaSearch [
 

--- a/src/Tool-Finder/FinderSearchStrategy.class.st
+++ b/src/Tool-Finder/FinderSearchStrategy.class.st
@@ -94,6 +94,12 @@ FinderSearchStrategy >> isClassesSearch [
 	^ false
 ]
 
+{ #category : #testing }
+FinderSearchStrategy >> isPragmasSearch [
+
+	^ false
+]
+
 { #category : #actions }
 FinderSearchStrategy >> methodSearch: aSelectBlock [
 


### PR DESCRIPTION
During my last refactoring I introduced a bug in the Finder that I am fixing here. I forgot to commit the method FinderPragmasSearchStrategy>>isPragmasSearch