### PR TITLE
The decompiler had an extension method on the encoder but the method …

### DIFF
--- a/src/Flashback-Decompiler/BytecodeEncoder.extension.st
+++ b/src/Flashback-Decompiler/BytecodeEncoder.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #BytecodeEncoder }
-
-{ #category : #'*Flashback-Decompiler' }
-BytecodeEncoder class >> skipTemps: numTemps for: aDecompiler [
-	numTemps timesRepeat: [ aDecompiler goToNextInstruction ]
-]

--- a/src/Flashback-Decompiler/EncoderForSistaV1.extension.st
+++ b/src/Flashback-Decompiler/EncoderForSistaV1.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #EncoderForSistaV1 }
-
-{ #category : #'*Flashback-Decompiler' }
-EncoderForSistaV1 class >> skipTemps: numTemps for: aDecompiler [
-	numTemps > 0 ifTrue: [ aDecompiler goToNextInstruction ]
-]

--- a/src/Flashback-Decompiler/FBDDecompiler.class.st
+++ b/src/Flashback-Decompiler/FBDDecompiler.class.st
@@ -610,11 +610,6 @@ FBDDecompiler >> shouldUseOriginalMethod: aCompiledMethod [
 ]
 
 { #category : #'data flow instructions' }
-FBDDecompiler >> skipTemps: numTemps [
-	instructionStream method encoderClass skipTemps: numTemps for: self
-]
-
-{ #category : #'data flow instructions' }
 FBDDecompiler >> storeIntoLiteralVariable: association [
 	simulatedStack addLast: (builder codeAssignment: simulatedStack removeLast to: (builder codeVariable: association key))
 ]


### PR DESCRIPTION
The decompiler had an extension method on the encoder but the method #skipTemps: that uses it is dead code.

This PR cleans that up