### PR TITLE
Clean fluid class builder tests

### DIFF
--- a/src/FluidClassBuilder-Tests/FluidClassBuilderAbstractTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidClassBuilderAbstractTest.class.st
@@ -1,0 +1,28 @@
+Class {
+	#name : #FluidClassBuilderAbstractTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'builder'
+	],
+	#category : #'FluidClassBuilder-Tests-Base'
+}
+
+{ #category : #accessing }
+FluidClassBuilderAbstractTest >> builder [
+
+	^ builder
+]
+
+{ #category : #accessing }
+FluidClassBuilderAbstractTest >> packageNameForTest [
+
+	^ #FakedCore
+]
+
+{ #category : #running }
+FluidClassBuilderAbstractTest >> tearDown [
+
+	(Smalltalk organization packageNamed: self packageNameForTest ifAbsent: [ nil ]) ifNotNil: [ :x | x removeFromSystem ].
+
+	super tearDown
+]

--- a/src/FluidClassBuilder-Tests/FluidClassBuilderAbstractTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidClassBuilderAbstractTest.class.st
@@ -13,6 +13,15 @@ FluidClassBuilderAbstractTest >> builder [
 	^ builder
 ]
 
+{ #category : #private }
+FluidClassBuilderAbstractTest >> categoryHack [
+	"Currently there is a bug in Fluid class builder that is that when we define a tag X with a package Y it can generate a package Y-X instead. 
+	This is due to the category mess in RPackage and it will not be fixed until the category mess is cleaned. Until then, to make sure the tests are in a right state, we register the package without the tag before creating the class to ensure the tag is not added as part of the package name.
+	This is ugly but it is currently hard to do better."
+
+	Smalltalk organization registerPackageNamed: self packageNameForTest
+]
+
 { #category : #accessing }
 FluidClassBuilderAbstractTest >> packageNameForTest [
 

--- a/src/FluidClassBuilder-Tests/FluidClassBuilderTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidClassBuilderTest.class.st
@@ -154,8 +154,7 @@ FluidClassBuilderTest >> testBuilderWithTag [
 FluidClassBuilderTest >> testChevronIsWorkingOnClassSide [
 
 	| instBuilder newClass clasBuilder |
-	"Next line is a hack because of the category mess of RPackage."
-	Smalltalk organization registerPackageNamed: self packageNameForTest.
+	self categoryHack.
 
 	instBuilder := (Object << #Point2)
 		               slots: { #a. #b };
@@ -278,8 +277,7 @@ FluidClassBuilderTest >> testCreateClassWithFullExpandedDefinitionKeepsTheMinimu
 FluidClassBuilderTest >> testCreatedClassHasAllElements [
 
 	| instBuilder newClass |
-	"Next line is a hack because of the category mess of RPackage."
-	Smalltalk organization registerPackageNamed: self packageNameForTest.
+	self categoryHack.
 
 	instBuilder := (Object << #Point2)
 		               slots: { #a. #b };
@@ -331,8 +329,7 @@ FluidClassBuilderTest >> testCreatedEmptyClassHasDefaultElements [
 FluidClassBuilderTest >> testExistingClassWithClassSlot [
 
 	| instBuilder newClass |
-	"Next line is a hack because of the category mess of RPackage."
-	Smalltalk organization registerPackageNamed: self packageNameForTest.
+		self categoryHack.
 
 	"We are creating a class with a class slot. This class slot is defined in the class side of the fluid definition.
 	When redefining the instance side, the class slot should not be lost."
@@ -371,8 +368,7 @@ FluidClassBuilderTest >> testExistingClassWithClassSlot [
 FluidClassBuilderTest >> testExistingClassWithClassSlotThenWeRemoveIt [
 
 	| instBuilder newClass classBuilder |
-	"Next line is a hack because of the category mess of RPackage."
-	Smalltalk organization registerPackageNamed: self packageNameForTest.
+	self categoryHack.
 
 	"We are creating a class with a class slot. This class slot is defined in the class side of the fluid definition.
 	Then we are removing the classSlot, it should remove it"

--- a/src/FluidClassBuilder-Tests/FluidClassBuilderTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidClassBuilderTest.class.st
@@ -3,33 +3,9 @@ This class contains tests for `FluidClassBuilder`
 "
 Class {
 	#name : #FluidClassBuilderTest,
-	#superclass : #TestCase,
-	#instVars : [
-		'builder'
-	],
+	#superclass : #FluidClassBuilderAbstractTest,
 	#category : #'FluidClassBuilder-Tests-Base'
 }
-
-{ #category : #accessing }
-FluidClassBuilderTest >> builder [
-
-	^ builder
-]
-
-{ #category : #accessing }
-FluidClassBuilderTest >> packageNameForTest [
-
-	^ #FakedCore
-]
-
-{ #category : #'private - cleanup' }
-FluidClassBuilderTest >> removeTestArtifactsFromSystem [
-
-	self class environment
-		at: #MyClass
-		ifPresent: [ :p | p removeFromSystem: false ]
-		ifAbsent: [  ]
-]
 
 { #category : #running }
 FluidClassBuilderTest >> setUp [
@@ -39,14 +15,6 @@ FluidClassBuilderTest >> setUp [
 		           superclassToBuild: Object;
 		           nameToBuild: #Point33;
 		           package: 'FakedPackage'
-]
-
-{ #category : #running }
-FluidClassBuilderTest >> tearDown [
-
-	(Smalltalk organization packageNamed: self packageNameForTest ifAbsent: [ nil ]) ifNotNil: [ :x | x removeFromSystem ].
-
-	super tearDown
 ]
 
 { #category : #'tests - hidden protocols' }
@@ -186,6 +154,7 @@ FluidClassBuilderTest >> testBuilderWithTag [
 FluidClassBuilderTest >> testChevronIsWorkingOnClassSide [
 
 	| instBuilder newClass clasBuilder |
+	"Next line is a hack because of the category mess of RPackage."
 	Smalltalk organization registerPackageNamed: self packageNameForTest.
 
 	instBuilder := (Object << #Point2)
@@ -457,8 +426,6 @@ FluidClassBuilderTest >> testFillShiftClassBuilder [
 FluidClassBuilderTest >> testInstallMinimalMockClass [
 
 	| shiftClassBuilder installedClass |
-	self removeTestArtifactsFromSystem.
-	[
 	builder := self class compilerClass new evaluate: 'Object << #MyClass
 	layout: FixedLayout;
 	traits: {};
@@ -479,7 +446,7 @@ FluidClassBuilderTest >> testInstallMinimalMockClass [
 	self assert: installedClass slots isEmpty.
 	self assert: installedClass traitComposition isEmpty.
 	self assert: installedClass classVariables isEmpty.
-	self assert: installedClass sharedPools isEmpty ] ensure: [ self removeTestArtifactsFromSystem ]
+	self assert: installedClass sharedPools isEmpty
 ]
 
 { #category : #'tests - classBuilder generation' }

--- a/src/FluidClassBuilder-Tests/FluidClassBuilderTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidClassBuilderTest.class.st
@@ -16,6 +16,12 @@ FluidClassBuilderTest >> builder [
 	^ builder
 ]
 
+{ #category : #accessing }
+FluidClassBuilderTest >> packageNameForTest [
+
+	^ #FakedCore
+]
+
 { #category : #'private - cleanup' }
 FluidClassBuilderTest >> removeTestArtifactsFromSystem [
 
@@ -38,13 +44,7 @@ FluidClassBuilderTest >> setUp [
 { #category : #running }
 FluidClassBuilderTest >> tearDown [
 
-	self class environment at: #Point2 ifPresent: [ :cl | cl removeFromSystem ].
-
-	(Smalltalk organization packageNamed: #Mock ifAbsent: [ nil ]) ifNotNil: [ :x | x removeFromSystem ].
-
-	(Smalltalk organization packageNamed: #FakedCore ifAbsent: [ nil ]) ifNotNil: [ :x | x removeFromSystem ].
-
-
+	(Smalltalk organization packageNamed: self packageNameForTest ifAbsent: [ nil ]) ifNotNil: [ :x | x removeFromSystem ].
 
 	super tearDown
 ]
@@ -58,7 +58,7 @@ FluidClassBuilderTest >> testBuildClassSlotsAPI [
 	builder classSlots: {#classX . #classY}.
 	"pay attention classSlots: is not to be sent by the user.
 	users should only send slots:"
-	builder package: 'FakedCore'.
+	builder package: self packageNameForTest.
 	clas := builder build.
 
 	self assert: clas superclass equals: Object.
@@ -75,7 +75,7 @@ FluidClassBuilderTest >> testBuildClassTraitsAPI [
 	builder classTraits: { TViewModelMock2 classTrait }.
 	"pay attention classTraits: is not to be sent by the user.
 	users should only send traits:"
-	builder package: 'FakedCore'.
+	builder package: self packageNameForTest.
 	clas := builder build.
 
 	self assert: clas superclass equals: Object.
@@ -99,14 +99,14 @@ FluidClassBuilderTest >> testBuildSimplePoint2 [
 	| clas |
 	builder := Object << #Point2.
 	builder slots: { #x . #y }.
-	builder package: 'FakedCore'.
+	builder package: self packageNameForTest.
 	clas := builder build.
 
 	self assert: clas superclass equals: Object.
 	self assert: clas name equals: #Point2.
 	self assert: clas slots size equals: 2.
 	self flag: #askPablo.
-	"self assert: clas package packageName equals: 'FakedCore'"
+	"self assert: clas package packageName equals: self packageNameForTest"
 ]
 
 { #category : #'tests - gathering' }
@@ -186,7 +186,7 @@ FluidClassBuilderTest >> testBuilderWithTag [
 FluidClassBuilderTest >> testChevronIsWorkingOnClassSide [
 
 	| instBuilder newClass clasBuilder |
-	Smalltalk organization registerPackageNamed: #Mock.
+	Smalltalk organization registerPackageNamed: self packageNameForTest.
 
 	instBuilder := (Object << #Point2)
 		               slots: { #a. #b };
@@ -195,7 +195,7 @@ FluidClassBuilderTest >> testChevronIsWorkingOnClassSide [
 		               sharedVariables: { #AAA };
 		               sharedPools: { #TextConstants };
 		               tag: 'boring';
-		               package: 'Mock'.
+		               package: self packageNameForTest.
 
 	"Ideally we should not install the class but just build it (sending instBuilder build)
 	the problem is that category and tag are lost by the class builder.
@@ -223,8 +223,7 @@ FluidClassBuilderTest >> testChevronIsWorkingOnClassSide [
 FluidClassBuilderTest >> testChevronIsWorkingOnClassSideOnEmpty [
 
 	| instBuilder newClass clasBuilder |
-	instBuilder := (Object << #Point2
-		package: 'Mock').
+	instBuilder := Object << #Point2 package: self packageNameForTest.
 
 	"Ideally we should not install the class but just build it (sending instBuilder build)
 	the problem is that category and tag are lost by the class builder.
@@ -282,19 +281,17 @@ FluidClassBuilderTest >> testCreateBuilderWithNil [
 
 { #category : #'tests - mandatory' }
 FluidClassBuilderTest >> testCreateClassWithFullExpandedDefinitionKeepsTheMinimum [
-
 	"check ClassDescription>>#definitionFullExpanded"
 
 	| shiftClassBuilder |
-	builder := self class compilerClass new
-		           evaluate: 'Object << #MyClass
+	builder := self class compilerClass new evaluate: 'Object << #MyClass
 	layout: FixedLayout;
 	traits: {};
 	slots: {};
 	sharedVariables: {};
 	tag: '''' ;
 	sharedPools: {};
-	package: ''Mock'''.
+	package: ''' , self packageNameForTest , ''''.
 	builder build.
 	shiftClassBuilder := builder shiftClassBuilder.
 
@@ -312,14 +309,17 @@ FluidClassBuilderTest >> testCreateClassWithFullExpandedDefinitionKeepsTheMinimu
 FluidClassBuilderTest >> testCreatedClassHasAllElements [
 
 	| instBuilder newClass |
-	instBuilder := (Object << #Point2
-		slots: { #a. #b };
-		layout: WeakLayout;
-		traits: {TViewModelMock };
-		sharedVariables: { #AAA};
-		sharedPools: { #TextConstants};
-		tag: 'boring' ;
-		package: 'Mock').
+	"Next line is a hack because of the category mess of RPackage."
+	Smalltalk organization registerPackageNamed: self packageNameForTest.
+
+	instBuilder := (Object << #Point2)
+		               slots: { #a. #b };
+		               layout: WeakLayout;
+		               traits: { TViewModelMock };
+		               sharedVariables: { #AAA };
+		               sharedPools: { #TextConstants };
+		               tag: 'boring';
+		               package: self packageNameForTest.
 
 	"Ideally we should not install the class but just build it (sending instBuilder build)
 	the problem is that category and tag are lost by the class builder.
@@ -328,21 +328,20 @@ FluidClassBuilderTest >> testCreatedClassHasAllElements [
 
 	self assert: newClass name equals: #Point2.
 	self assert: newClass slots size equals: 2.
-	self assert: newClass slotNames equals: #(a b).
+	self assert: newClass slotNames equals: #( a b ).
 	self assert: newClass classLayout class equals: WeakLayout.
-	self assert: newClass traitComposition equals: {TViewModelMock} asTraitComposition.
-	self assert: newClass class traitComposition equals: {TViewModelMock classSide} asTraitComposition.
-	self assert: newClass classVarNames equals: #(AAA).
-	self assertCollection: newClass sharedPools hasSameElements: {TextConstants}.
-	self assert: newClass category equals: 'Mock-boring'
+	self assert: newClass traitComposition equals: { TViewModelMock } asTraitComposition.
+	self assert: newClass class traitComposition equals: { TViewModelMock classSide } asTraitComposition.
+	self assert: newClass classVarNames equals: #( AAA ).
+	self assertCollection: newClass sharedPools hasSameElements: { TextConstants }.
+	self assert: newClass category equals: self packageNameForTest , '-boring'
 ]
 
 { #category : #'tests - class creation' }
 FluidClassBuilderTest >> testCreatedEmptyClassHasDefaultElements [
 
 	| instBuilder newClass |
-	instBuilder := (Object << #Point2
-		package: 'Mock').
+	instBuilder := Object << #Point2 package: self packageNameForTest.
 
 	"Ideally we should not install the class but just build it (sending instBuilder build)
 	the problem is that category and tag are lost by the class builder.
@@ -350,32 +349,33 @@ FluidClassBuilderTest >> testCreatedEmptyClassHasDefaultElements [
 	newClass := instBuilder install.
 
 	self assert: newClass name equals: #Point2.
-	self assert: newClass slotNames equals: #().
+	self assert: newClass slotNames equals: #(  ).
 	self assert: newClass classLayout class equals: FixedLayout.
-	self assert: newClass traitComposition equals: {} asTraitComposition.
-	self assert: newClass class traitComposition equals: {} asTraitComposition.
-	self assert: newClass classVarNames equals: #().
-	self assertCollection: newClass sharedPools hasSameElements: {}.
-	self assert: newClass category equals: 'Mock'
+	self assert: newClass traitComposition equals: {  } asTraitComposition.
+	self assert: newClass class traitComposition equals: {  } asTraitComposition.
+	self assert: newClass classVarNames equals: #(  ).
+	self assertCollection: newClass sharedPools hasSameElements: {  }.
+	self assert: newClass category equals: self packageNameForTest
 ]
 
 { #category : #'tests - class creation' }
 FluidClassBuilderTest >> testExistingClassWithClassSlot [
 
 	| instBuilder newClass |
+	"Next line is a hack because of the category mess of RPackage."
+	Smalltalk organization registerPackageNamed: self packageNameForTest.
 
 	"We are creating a class with a class slot. This class slot is defined in the class side of the fluid definition.
 	When redefining the instance side, the class slot should not be lost."
-
-	instBuilder := (Object << #Point2
-		slots: { #a. #b };
-		layout: WeakLayout;
-		traits: {TViewModelMock };
-		sharedVariables: { #BBB};
-		classSlots: #(AAA);
-		sharedPools: { #TextConstants};
-		tag: 'boring' ;
-		package: 'Mock').
+	instBuilder := (Object << #Point2)
+		               slots: { #a. #b };
+		               layout: WeakLayout;
+		               traits: { TViewModelMock };
+		               sharedVariables: { #BBB };
+		               classSlots: #( AAA );
+		               sharedPools: { #TextConstants };
+		               tag: 'boring';
+		               package: self packageNameForTest.
 
 	"Ideally we should not install the class but just build it (sending instBuilder build)
 	the problem is that category and tag are lost by the class builder.
@@ -384,14 +384,14 @@ FluidClassBuilderTest >> testExistingClassWithClassSlot [
 
 	self assert: newClass class slots first name equals: #AAA.
 
-	instBuilder := (Object << #Point2
-		slots: { #a. #b. #c };
-		layout: WeakLayout;
-		traits: {TViewModelMock };
-		sharedVariables: { #BBB};
-		sharedPools: { #TextConstants};
-		tag: 'boring' ;
-		package: 'Mock').
+	instBuilder := (Object << #Point2)
+		               slots: { #a. #b. #c };
+		               layout: WeakLayout;
+		               traits: { TViewModelMock };
+		               sharedVariables: { #BBB };
+		               sharedPools: { #TextConstants };
+		               tag: 'boring';
+		               package: 'Mock'.
 
 	newClass := instBuilder install.
 
@@ -402,19 +402,21 @@ FluidClassBuilderTest >> testExistingClassWithClassSlot [
 FluidClassBuilderTest >> testExistingClassWithClassSlotThenWeRemoveIt [
 
 	| instBuilder newClass classBuilder |
+	"Next line is a hack because of the category mess of RPackage."
+	Smalltalk organization registerPackageNamed: self packageNameForTest.
 
 	"We are creating a class with a class slot. This class slot is defined in the class side of the fluid definition.
 	Then we are removing the classSlot, it should remove it"
 
-	instBuilder := (Object << #Point2
-		slots: { #a. #b };
-		layout: WeakLayout;
-		traits: {TViewModelMock };
-		sharedVariables: { #BBB};
-		classSlots: #(AAA);
-		sharedPools: { #TextConstants};
-		tag: 'boring' ;
-		package: 'Mock').
+	instBuilder := (Object << #Point2)
+		               slots: { #a. #b };
+		               layout: WeakLayout;
+		               traits: { TViewModelMock };
+		               sharedVariables: { #BBB };
+		               classSlots: #( AAA );
+		               sharedPools: { #TextConstants };
+		               tag: 'boring';
+		               package: self packageNameForTest.
 
 	"Ideally we should not install the class but just build it (sending instBuilder build)
 	the problem is that category and tag are lost by the class builder.
@@ -427,7 +429,7 @@ FluidClassBuilderTest >> testExistingClassWithClassSlotThenWeRemoveIt [
 
 	newClass := classBuilder install.
 
-	self assert: newClass class slots equals: #()
+	self assert: newClass class slots equals: #(  )
 ]
 
 { #category : #'tests - classBuilder generation' }
@@ -439,16 +441,16 @@ FluidClassBuilderTest >> testFillShiftClassBuilder [
 	builder sharedVariables: {  #Share1 . #Share2 }.
 	builder sharedPools: { ChronologyConstants }.
 	builder tag: 'Mafia'.
-	builder package: 'FakedCore'.
+	builder package: self packageNameForTest.
 	builder fillShiftClassBuilder.
 	shift := builder shiftClassBuilder.
 	self assert: shift superclass equals: Object.
 	self assert: shift name equals: #Point2.
 	self assert: shift slots size equals: 2.
 	self assert: shift sharedPools equals: {ChronologyConstants}.
-	self assert: shift category equals: 'FakedCore-Mafia'.
+	self assert: shift category equals: self packageNameForTest, '-Mafia'.
 	self flag: #askPablo.
-	"self assert: clas package packageName equals: 'FakedCore'"
+	"self assert: clas package packageName equals: self packageNameForTest"
 ]
 
 { #category : #'tests - mandatory' }
@@ -457,20 +459,19 @@ FluidClassBuilderTest >> testInstallMinimalMockClass [
 	| shiftClassBuilder installedClass |
 	self removeTestArtifactsFromSystem.
 	[
-	builder := self class compilerClass new
-		           evaluate: 'Object << #MyClass
+	builder := self class compilerClass new evaluate: 'Object << #MyClass
 	layout: FixedLayout;
 	traits: {};
 	slots: {};
 	sharedVariables: {};
 	tag: '''' ;
 	sharedPools: {};
-	package: ''MyPackage'''.
+	package: ''' , self packageNameForTest , ''''.
 	builder build.
 	shiftClassBuilder := builder shiftClassBuilder.
 	ShiftClassInstaller new makeWithBuilder: shiftClassBuilder.
 
-	installedClass := self class environment at: #MyClass ifAbsent: [self fail].
+	installedClass := self class environment at: #MyClass ifAbsent: [ self fail ].
 
 	self assert: installedClass superclass equals: Object.
 	self assert: installedClass name equals: #MyClass.
@@ -478,8 +479,7 @@ FluidClassBuilderTest >> testInstallMinimalMockClass [
 	self assert: installedClass slots isEmpty.
 	self assert: installedClass traitComposition isEmpty.
 	self assert: installedClass classVariables isEmpty.
-	self assert: installedClass sharedPools isEmpty]
-		ensure: [ self removeTestArtifactsFromSystem ]
+	self assert: installedClass sharedPools isEmpty ] ensure: [ self removeTestArtifactsFromSystem ]
 ]
 
 { #category : #'tests - classBuilder generation' }
@@ -490,7 +490,7 @@ FluidClassBuilderTest >> testInstallSimplePoint2 [
 	self assert: (self class environment at: #Point2 ifAbsent: [ true ]).
 	builder := Object << #Point2.
 	builder slots: { #x. #y }.
-	builder package: 'FakedCore'.
+	builder package: self packageNameForTest.
 	builder install.
 
 	pt2Class := self class environment at: #Point2.

--- a/src/FluidClassBuilder-Tests/FluidClassSideClassBuilderTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidClassSideClassBuilderTest.class.st
@@ -3,10 +3,7 @@ This class contains tests for `FluidClassSideClassBuilder`
 "
 Class {
 	#name : #FluidClassSideClassBuilderTest,
-	#superclass : #TestCase,
-	#instVars : [
-		'builder'
-	],
+	#superclass : #FluidClassBuilderAbstractTest,
 	#category : #'FluidClassBuilder-Tests-Base'
 }
 

--- a/src/FluidClassBuilder-Tests/FluidClassSideTraitBuilderTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidClassSideTraitBuilderTest.class.st
@@ -23,9 +23,9 @@ FluidClassSideTraitBuilderTest >> setUp [
 FluidClassSideTraitBuilderTest >> testSlots [
 
 	| trait |
-	builder := Trait << TViewModelMock classTrait
-					slots: { #x . #y };
-					package: 'FakedCore'.
+	builder := (Trait << TViewModelMock classTrait)
+		           slots: { #x. #y };
+		           package: self packageNameForTest.
 	trait := builder build.
 
 	self assert: trait name equals: #TViewModelMock.

--- a/src/FluidClassBuilder-Tests/FluidClassSideTraitBuilderTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidClassSideTraitBuilderTest.class.st
@@ -3,10 +3,7 @@ This class contains tests for `FluidClassSideTraitBuilder`
 "
 Class {
 	#name : #FluidClassSideTraitBuilderTest,
-	#superclass : #TestCase,
-	#instVars : [
-		'builder'
-	],
+	#superclass : #FluidClassBuilderAbstractTest,
 	#category : #'FluidClassBuilder-Tests-Base'
 }
 

--- a/src/FluidClassBuilder-Tests/FluidTraitBuilderTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidTraitBuilderTest.class.st
@@ -66,8 +66,7 @@ FluidTraitBuilderTest >> testCreatingEmptyTraitHasDefaultElements [
 FluidTraitBuilderTest >> testCreatingFullTraitHasAllElements [
 
 	| instBuilder newTrait |
-	"Next line is a hack because of the category mess of RPackage."
-	Smalltalk organization registerPackageNamed: self packageNameForTest.
+	self categoryHack.
 	instBuilder := (Trait << #TTestTrait)
 		               slots: #( a b c );
 		               traits: { TViewModelMock };
@@ -136,8 +135,7 @@ FluidTraitBuilderTest >> testExistingTraitWithSlotsArePreservedIfChangingClassSi
 FluidTraitBuilderTest >> testFillShiftClassBuilder [
 
 	| shift |
-	"Next line is a hack because of the category mess of RPackage."
-	Smalltalk organization registerPackageNamed: self packageNameForTest.
+	self categoryHack.
 	builder := (Trait << #TPoint2)
 		           slots: { #x. #y };
 		           traits: { TViewModelMock };

--- a/src/FluidClassBuilder-Tests/FluidTraitBuilderTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidTraitBuilderTest.class.st
@@ -41,7 +41,7 @@ FluidTraitBuilderTest >> testBuildSimplePoint2 [
 	| trait |
 	builder := Trait << #TPoint2
 					slots: { #x . #y };
-					package: 'FakedCore'.
+					package: self packageNameForTest.
 	trait := builder build.
 
 	self assert: trait name equals: #TPoint2.
@@ -151,14 +151,14 @@ FluidTraitBuilderTest >> testFillShiftClassBuilder [
 	builder slots: { #x. #y }.
 	builder traits: { TViewModelMock }.
 	builder tag: 'Mafia'.
-	builder package: 'FakedCore'.
+	builder package: self packageNameForTest.
 	builder fillShiftClassBuilder.
 	shift := builder shiftClassBuilder.
 	self assert: shift name equals: #TPoint2.
 	self assert: shift slots size equals: 2.
-	self assert: shift category equals: 'FakedCore-Mafia'.
+	self assert: shift category equals: self packageNameForTest , '-Mafia'.
 	self flag: #askPablo
-	"self assert: clas package packageName equals: 'FakedCore'"
+	"self assert: clas package packageName equals: self packageNameForTest"
 ]
 
 { #category : #'tests - install' }
@@ -188,18 +188,19 @@ FluidTraitBuilderTest >> testInstallMinimalMockClass [
 { #category : #'tests - install' }
 FluidTraitBuilderTest >> testInstallSimplePoint2 [
 
-	[ | trait |
+	[
+	| trait |
 	self assert: (self class environment at: #TPoint2 ifAbsent: [ true ]).
 
-	builder := Trait << #TPoint2
-					slots: { #x . #y };
-					package: 'FakedCore'.
+	builder := (Trait << #TPoint2)
+		           slots: { #x. #y };
+		           package: self packageNameForTest.
 	builder install.
 	trait := self class environment at: #TPoint2.
 	self assert: trait name equals: #TPoint2.
 	self assert: trait slots size equals: 2 ] ensure: [
-			self class environment removeKey: #TPoint2 ifAbsent: [self fail].
-			self assert: (self class environment at: #TPoint2 ifAbsent: [ true ])]
+		self class environment removeKey: #TPoint2 ifAbsent: [ self fail ].
+		self assert: (self class environment at: #TPoint2 ifAbsent: [ true ]) ]
 ]
 
 { #category : #tests }

--- a/src/FluidClassBuilder-Tests/FluidTraitBuilderTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidTraitBuilderTest.class.st
@@ -3,21 +3,9 @@ This class contains tests for `FluidTraitBuilder`
 "
 Class {
 	#name : #FluidTraitBuilderTest,
-	#superclass : #TestCase,
-	#instVars : [
-		'builder'
-	],
+	#superclass : #FluidClassBuilderAbstractTest,
 	#category : #'FluidClassBuilder-Tests-Base'
 }
-
-{ #category : #'private - cleanup' }
-FluidTraitBuilderTest >> removeTestArtifactsFromSystem [
-
-	self class environment
-		at: #TMyClass
-		ifPresent: [ :p | p removeFromSystem: false ]
-		ifAbsent: [ ]
-]
 
 { #category : #running }
 FluidTraitBuilderTest >> setUp [
@@ -29,9 +17,9 @@ FluidTraitBuilderTest >> setUp [
 { #category : #running }
 FluidTraitBuilderTest >> tearDown [
 
-	self class environment
+	"self class environment
 		at: #TTestTrait
-		ifPresent: [ :cl | cl removeFromSystem  ].
+		ifPresent: [ :cl | cl removeFromSystem  ]."
 	super tearDown
 ]
 
@@ -59,8 +47,7 @@ FluidTraitBuilderTest >> testClassSlots [
 FluidTraitBuilderTest >> testCreatingEmptyTraitHasDefaultElements [
 
 	| instBuilder newTrait |
-	instBuilder := (Trait << #TTestTrait
-		package: 'Mock').
+	instBuilder := Trait << #TTestTrait package: self packageNameForTest.
 
 	"Ideally we should not install the class but just build it (sending instBuilder build)
 	the problem is that category and tag are lost by the class builder.
@@ -68,22 +55,24 @@ FluidTraitBuilderTest >> testCreatingEmptyTraitHasDefaultElements [
 	newTrait := instBuilder install.
 
 	self assert: newTrait name equals: #TTestTrait.
-	self assert: newTrait slotNames equals: #().
-	self assert: newTrait traitComposition equals: {} asTraitComposition.
-	self assert: newTrait class traitComposition equals: {} asTraitComposition.
-	self assert: newTrait classVarNames equals: #().
-	self assert: newTrait category equals: 'Mock'
+	self assert: newTrait slotNames equals: #(  ).
+	self assert: newTrait traitComposition equals: {  } asTraitComposition.
+	self assert: newTrait class traitComposition equals: {  } asTraitComposition.
+	self assert: newTrait classVarNames equals: #(  ).
+	self assert: newTrait category equals: self packageNameForTest
 ]
 
 { #category : #'tests - class creation' }
 FluidTraitBuilderTest >> testCreatingFullTraitHasAllElements [
 
 	| instBuilder newTrait |
-	instBuilder := (Trait << #TTestTrait
-		slots: #(a b c);
-		traits: {TViewModelMock};
-		tag: 'lala';
-		package: 'Mock').
+	"Next line is a hack because of the category mess of RPackage."
+	Smalltalk organization registerPackageNamed: self packageNameForTest.
+	instBuilder := (Trait << #TTestTrait)
+		               slots: #( a b c );
+		               traits: { TViewModelMock };
+		               tag: 'lala';
+		               package: self packageNameForTest.
 
 	"Ideally we should not install the class but just build it (sending instBuilder build)
 	the problem is that category and tag are lost by the class builder.
@@ -91,68 +80,71 @@ FluidTraitBuilderTest >> testCreatingFullTraitHasAllElements [
 	newTrait := instBuilder install.
 
 	self assert: newTrait name equals: #TTestTrait.
-	self assert: newTrait slotNames equals: #(a b c).
-	self assert: newTrait traitComposition equals: {TViewModelMock} asTraitComposition.
-	self assert: newTrait class traitComposition equals: {TViewModelMock classSide} asTraitComposition.
-	self assert: newTrait classVarNames equals: #().
-	self assert: newTrait category equals: 'Mock-lala'
+	self assert: newTrait slotNames equals: #( a b c ).
+	self assert: newTrait traitComposition equals: { TViewModelMock } asTraitComposition.
+	self assert: newTrait class traitComposition equals: { TViewModelMock classSide } asTraitComposition.
+	self assert: newTrait classVarNames equals: #(  ).
+	self assert: newTrait category equals: self packageNameForTest , '-lala'
 ]
 
 { #category : #'tests - class creation' }
 FluidTraitBuilderTest >> testExistingTraitWithClassSlotsArePreservedIfChangingInstanceSide [
 
 	| instBuilder newTrait |
-	instBuilder := (Trait << #TTestTrait
-		classSlots: #(AAA);
-		package: 'Mock').
+	instBuilder := (Trait << #TTestTrait)
+		               classSlots: #( AAA );
+		               package: self packageNameForTest.
 
 	"Ideally we should not install the class but just build it (sending instBuilder build)
 	the problem is that category and tag are lost by the class builder.
 	Hence we cannot test for real."
 	newTrait := instBuilder install.
 
-	instBuilder := (Trait << #TTestTrait
-		slots: #(aaa);
-		package: 'Mock').
+	instBuilder := (Trait << #TTestTrait)
+		               slots: #( aaa );
+		               package: self packageNameForTest.
 
 	newTrait := instBuilder install.
 
-	self assert: newTrait class slotNames equals: #(AAA)
+	self assert: newTrait class slotNames equals: #( AAA )
 ]
 
 { #category : #'tests - class creation' }
 FluidTraitBuilderTest >> testExistingTraitWithSlotsArePreservedIfChangingClassSide [
 
 	| instBuilder newTrait classBuilder |
-	instBuilder := (Trait << #TTestTrait
-		slots: #(aaa);
-		package: 'Mock').
+	instBuilder := (Trait << #TTestTrait)
+		               slots: #( aaa );
+		               package: self packageNameForTest.
 
 	"Ideally we should not install the class but just build it (sending instBuilder build)
 	the problem is that category and tag are lost by the class builder.
 	Hence we cannot test for real."
 	newTrait := instBuilder install.
 
-	classBuilder := (Trait << newTrait classTrait
-		slots: #(AAA);
-		package: 'Mock').
+	classBuilder := (Trait << newTrait classTrait)
+		                slots: #( AAA );
+		                package: self packageNameForTest.
 
 	newTrait := classBuilder install.
 
-	self assert: newTrait class slotNames equals: #(AAA)	.
-	self assert: newTrait slotNames equals: #(aaa)
+	self assert: newTrait class slotNames equals: #( AAA ).
+	self assert: newTrait slotNames equals: #( aaa )
 ]
 
 { #category : #'tests - classBuilder generation' }
 FluidTraitBuilderTest >> testFillShiftClassBuilder [
 
 	| shift |
-	builder := Trait << #TPoint2.
-	builder slots: { #x. #y }.
-	builder traits: { TViewModelMock }.
-	builder tag: 'Mafia'.
-	builder package: self packageNameForTest.
-	builder fillShiftClassBuilder.
+	"Next line is a hack because of the category mess of RPackage."
+	Smalltalk organization registerPackageNamed: self packageNameForTest.
+	builder := (Trait << #TPoint2)
+		           slots: { #x. #y };
+		           traits: { TViewModelMock };
+		           tag: 'Mafia';
+		           package: self packageNameForTest;
+		           fillShiftClassBuilder;
+		           yourself.
 	shift := builder shiftClassBuilder.
 	self assert: shift name equals: #TPoint2.
 	self assert: shift slots size equals: 2.
@@ -165,32 +157,27 @@ FluidTraitBuilderTest >> testFillShiftClassBuilder [
 FluidTraitBuilderTest >> testInstallMinimalMockClass [
 
 	| shiftClassBuilder installedClass |
-	self removeTestArtifactsFromSystem.
-	[
-	builder := self class compilerClass new
-		           evaluate: 'Trait << #TMyClass
+	builder := self class compilerClass new evaluate: 'Trait << #TMyClass
 	traits: {};
 	slots: {};
 	tag: '''' ;
-	package: ''MyPackage'''.
+	package: ''' , self packageNameForTest , ''''.
 	shiftClassBuilder := builder shiftClassBuilder.
 	ShiftClassInstaller new makeWithBuilder: shiftClassBuilder.
 
-	installedClass := self class environment at: #TMyClass ifAbsent: [self fail].
+	installedClass := self class environment at: #TMyClass ifAbsent: [ self fail ].
 
 	self assert: installedClass name equals: #TMyClass.
 	self assert: installedClass isFixed.
 	self assert: installedClass slots isEmpty.
-	self assert: installedClass traitComposition isEmpty ]
-		ensure: [ self removeTestArtifactsFromSystem ]
+	self assert: installedClass traitComposition isEmpty
 ]
 
 { #category : #'tests - install' }
 FluidTraitBuilderTest >> testInstallSimplePoint2 [
 
-	[
 	| trait |
-	self assert: (self class environment at: #TPoint2 ifAbsent: [ true ]).
+	self class environment at: #TPoint2 ifPresent: [ self fail ].
 
 	builder := (Trait << #TPoint2)
 		           slots: { #x. #y };
@@ -198,9 +185,7 @@ FluidTraitBuilderTest >> testInstallSimplePoint2 [
 	builder install.
 	trait := self class environment at: #TPoint2.
 	self assert: trait name equals: #TPoint2.
-	self assert: trait slots size equals: 2 ] ensure: [
-		self class environment removeKey: #TPoint2 ifAbsent: [ self fail ].
-		self assert: (self class environment at: #TPoint2 ifAbsent: [ true ]) ]
+	self assert: trait slots size equals: 2
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Make sure all tests generates their classes in the same package and unify the removal of the generated code.

This also workaround a bug in RPackage category mess that cause to confuse packages and tags. This just hides the problem, but anyway all assertions showing the problem are commented and this category mess should be resolved in the next few months (I hope)