### PR TITLE
Simplify check of category in RPackage

### DIFF
--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -208,12 +208,12 @@ RPackageMCSynchronisationTest >> tearDown [
 
 { #category : #tests }
 RPackageMCSynchronisationTest >> testCategoryMatching [
-	
-	self assert: (self organizer category: 'Compression-Archives' matches: 'Compression').
-	self deny: (self organizer category: 'Compression' matches: 'Compression-Archives').
-	self assert: (self organizer category: 'Compression' matches: 'Compression').
-	self assert: (self organizer category: 'Compression-Arh' matches: 'Compression').
-	self deny: (self organizer category: 'XXXX' matches: 'Compression-Archives').
+
+	self assert: ('Compression-Archives' isCategoryOf: 'Compression').
+	self deny: ('Compression' isCategoryOf: 'Compression-Archives').
+	self assert: ('Compression' isCategoryOf: 'Compression').
+	self assert: ('Compression-Arh' isCategoryOf: 'Compression').
+	self deny: ('XXXX' isCategoryOf: 'Compression-Archives')
 ]
 
 { #category : #tests }

--- a/src/Monticello/RPackageOrganizer.extension.st
+++ b/src/Monticello/RPackageOrganizer.extension.st
@@ -15,11 +15,8 @@ RPackageOrganizer >> allManagers [
 { #category : #'*Monticello-RPackage' }
 RPackageOrganizer >> isDefinedAsPackageOrSubPackageInMC: aSymbol [
 	"a category has been added. "
-	
-	^ self allManagers anySatisfy: [ :each | 
-		self 
-			category: each packageName asSymbol 
-			matches: aSymbol ]
+
+	^ self allManagers anySatisfy: [ :manager | manager packageName isCategoryOf: aSymbol ]
 ]
 
 { #category : #'*Monticello-RPackage' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -342,22 +342,6 @@ RPackage >> basicRemoveTag: tag [
 		classTagRemoved: tag name fromPackage: self
 ]
 
-{ #category : #'system compatibility' }
-RPackage >> category: categoryName matches: prefix [
-	"self default category: 'Compression-Archives' matches: 'Compression'"
-	"self default category: 'Compression' matches: 'Compression-Archives'"
-	"self default category: 'Compression' matches: 'Compression'"
-	"self default category: 'Compression-Arh' matches: 'Compression'"
-	| prefixSize catSize |
-	categoryName ifNil: [ ^false ].
-	catSize := categoryName size.
-	prefixSize := prefix size.
-	catSize < prefixSize ifTrue: [ ^false ].
-	(categoryName findString: prefix startingAt: 1 caseSensitive: false) = 1
-		ifFalse: [ ^false ].
-	^(categoryName at: prefix size + 1 ifAbsent: [ ^true ]) = $-
-]
-
 { #category : #slices }
 RPackage >> classDefinedSlicesDo: aBlock [
 	"This method iterates over the defined class and their associated selectors. a slice is a class * list of selectors. aBlock will be applied to all the extensions slices of the receiver. aBlok first argument is the class and the second argument a list of method selectors"
@@ -704,9 +688,10 @@ RPackage >> extensionSelectorsForClass: aClass [
 { #category : #'class tags' }
 RPackage >> extensionsForTag: aRPackageTag [
 
-	^ self extensionMethods select: [ :extensionMethod | | category |
-		category := extensionMethod protocol allButFirst.
-		self category: category matches: aRPackageTag categoryName ]
+	^ self extensionMethods select: [ :extensionMethod |
+		  | protocolName |
+		  protocolName := extensionMethod protocol allButFirst.
+		  protocolName isCategoryOf: aRPackageTag categoryName ]
 ]
 
 { #category : #properties }
@@ -886,7 +871,8 @@ RPackage >> includesSelector: aSelector ofMetaclassName: aClassName [
 
 { #category : #'system compatibility' }
 RPackage >> includesSystemCategory: categoryName [
-	^ self category: categoryName matches: self systemCategoryPrefix
+
+	^ categoryName isCategoryOf: self systemCategoryPrefix
 ]
 
 { #category : #initialization }
@@ -940,7 +926,7 @@ RPackage >> isTestPackage [
 { #category : #'system compatibility' }
 RPackage >> isYourClassExtension: protocolName [
 
-	^ protocolName isNotNil and: [ self category: protocolName asLowercase matches: self methodCategoryPrefix ]
+	^ protocolName isNotNil and: [ protocolName asLowercase isCategoryOf: self methodCategoryPrefix ]
 ]
 
 { #category : #queries }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -283,19 +283,6 @@ RPackageOrganizer >> categoriesMatching: matchString [
 	^ self categories select: [ :c | matchString match: c ]
 ]
 
-{ #category : #'system compatibility' }
-RPackageOrganizer >> category: categoryName matches: prefix [
-	| prefixSize catSize |
-
-	categoryName ifNil: [ ^false ].
-	catSize := categoryName size.
-	prefixSize := prefix size.
-	catSize < prefixSize ifTrue: [ ^false ].
-	(categoryName findString: prefix startingAt: 1 caseSensitive: false) = 1
-		ifFalse: [ ^false ].
-	^(categoryName at: prefix size + 1 ifAbsent: [ ^true ]) = $-
-]
-
 { #category : #'deprecated - SystemOrganizer leftovers' }
 RPackageOrganizer >> categoryOfBehavior: behavior [
 	"Answer the category associated with the argument. This method can take a Behavior or a Behavior name as parameter."
@@ -319,8 +306,8 @@ RPackageOrganizer >> categoryOfElement: behaviorName [
 
 { #category : #'private - registration' }
 RPackageOrganizer >> checkPackageExistsOrRegister: packageName [
-	(self packages
-		anySatisfy: [ :each | self category: packageName matches: each packageName ])
+
+	(self packages anySatisfy: [ :package | packageName isCategoryOf: package packageName ])
 		ifFalse: [ (self packageClass named: packageName capitalized) register ]
 ]
 

--- a/src/RPackage-Core/RPackageSet.class.st
+++ b/src/RPackage-Core/RPackageSet.class.st
@@ -84,11 +84,6 @@ RPackageSet >> asRPackageSet [
 	^self
 ]
 
-{ #category : #'system compatibility' }
-RPackageSet >> category: categoryName matches: prefix [
-	^ RPackageOrganizer default category: categoryName matches: prefix
-]
-
 { #category : #accessing }
 RPackageSet >> categoryNames [
 	^  self packages
@@ -165,8 +160,9 @@ RPackageSet >> isForeignClassExtension: categoryName [
 ]
 
 { #category : #'system compatibility' }
-RPackageSet >> isYourClassExtension: categoryName [
-	^ categoryName notNil and: [self category: categoryName asLowercase matches: self methodCategoryPrefix]
+RPackageSet >> isYourClassExtension: protocolName [
+
+	^ protocolName isNotNil and: [ protocolName asLowercase isCategoryOf: self methodCategoryPrefix ]
 ]
 
 { #category : #'system compatibility' }

--- a/src/RPackage-Core/String.extension.st
+++ b/src/RPackage-Core/String.extension.st
@@ -15,5 +15,10 @@ String >> asPackageIfAbsent: aBlock [
 String >> isCategoryOf: prefix [
 	"This method is used for the MC synchronization of RPackage with categorises. Since we want to remove the system of category, this method should not be used and has a vocation to be removed from the system."
 
-	^ self = prefix or: [ self beginsWith: prefix , '-' ]
+	| prefixSize catSize |
+	catSize := self size.
+	prefixSize := prefix size.
+	catSize < prefixSize ifTrue: [ ^ false ].
+	(self findString: prefix startingAt: 1 caseSensitive: false) = 1 ifFalse: [ ^ false ].
+	^ (self at: prefix size + 1 ifAbsent: [ ^ true ]) = $-
 ]

--- a/src/RPackage-Core/String.extension.st
+++ b/src/RPackage-Core/String.extension.st
@@ -10,3 +10,10 @@ String >> asPackageIfAbsent: aBlock [
 
 	^ Smalltalk organization packageNamed: self ifAbsent: aBlock
 ]
+
+{ #category : #'*RPackage-Core' }
+String >> isCategoryOf: prefix [
+	"This method is used for the MC synchronization of RPackage with categorises. Since we want to remove the system of category, this method should not be used and has a vocation to be removed from the system."
+
+	^ self = prefix or: [ self beginsWith: prefix , '-' ]
+]

--- a/src/Ring-Definitions-Containers/RGContainer.class.st
+++ b/src/Ring-Definitions-Containers/RGContainer.class.st
@@ -16,19 +16,6 @@ RGContainer class >> allManagers [
 ]
 
 { #category : #'image package loading' }
-RGContainer class >> category: categoryName matches: prefix [
-
-	| prefixSize catSize |
-	categoryName ifNil: [ ^false ].
-	catSize := categoryName size.
-	prefixSize := prefix size.
-	catSize < prefixSize ifTrue: [ ^false ].
-	(categoryName findString: prefix startingAt: 1 caseSensitive: true) = 1
-		ifFalse: [ ^false ].
-	^(categoryName at: prefix size + 1 ifAbsent: [ ^true ]) = $-
-]
-
-{ #category : #'image package loading' }
 RGContainer class >> packageKeys [
 
 	^ self allManagers collect: [ :pck | pck package name asSymbol -> ('*', pck package name asLowercase) ]
@@ -48,14 +35,17 @@ RGContainer class >> packageOfClass: aRGBehaviorDefinition [
 
 { #category : #'image package loading' }
 RGContainer class >> packageOfClass: aRGBehaviorDefinition using: packageNames [
-
 	"Looks for the package of aRGBehaviorDefinition from the image"
+
 	| pName |
-	aRGBehaviorDefinition ifNil:[ ^nil ].
-	pName := (packageNames
-				detect: [ :each| each = aRGBehaviorDefinition category ]
-				ifNone: [ packageNames detect:[ :each| self category: aRGBehaviorDefinition category matches: each ] ifNone:[ nil ] ]).
-	^ pName ifNotNil:[ RGPackageDefinition named: pName ]
+	aRGBehaviorDefinition ifNil: [ ^ nil ].
+	pName := packageNames
+		         detect: [ :each | each = aRGBehaviorDefinition category ]
+		         ifNone: [
+			         packageNames
+				         detect: [ :each | aRGBehaviorDefinition category isCategoryOf: each ]
+				         ifNone: [ nil ] ].
+	^ pName ifNotNil: [ RGPackageDefinition named: pName ]
 ]
 
 { #category : #'image package loading' }
@@ -66,17 +56,18 @@ RGContainer class >> packageOfMethod: aRGMethodDefinition [
 
 { #category : #'image package loading' }
 RGContainer class >> packageOfMethod: aRGMethodDefinition using: packageKeys [
-
 	"Looks for the package of aRGMethodDefinition from the image"
+
 	| pName parentPackage |
-	(aRGMethodDefinition protocol notNil and:[ aRGMethodDefinition protocol beginsWith: '*' ]) ifFalse:[
-		parentPackage := (aRGMethodDefinition parent ifNotNil:[ aRGMethodDefinition parent package ]).
-		^ parentPackage ifNil:[ self packageOfClass: aRGMethodDefinition parent ] ].
+	(aRGMethodDefinition protocol notNil and: [ aRGMethodDefinition protocol beginsWith: '*' ]) ifFalse: [
+		parentPackage := aRGMethodDefinition parent ifNotNil: [ aRGMethodDefinition parent package ].
+		^ parentPackage ifNil: [ self packageOfClass: aRGMethodDefinition parent ] ].
 
 	aRGMethodDefinition protocol ifNil: [ ^ nil ].
-	pName := (packageKeys
-				detect: [ :each| self category: aRGMethodDefinition protocol asLowercase matches: each value ] ifNone:[ nil ]).
-	^ pName ifNotNil:[ RGPackageDefinition named: pName key ]
+	pName := packageKeys
+		         detect: [ :each | aRGMethodDefinition protocol asLowercase isCategoryOf: each value ]
+		         ifNone: [ nil ].
+	^ pName ifNotNil: [ RGPackageDefinition named: pName key ]
 ]
 
 { #category : #'adding-removing' }
@@ -264,25 +255,28 @@ RGContainer >> extensionMethods [
 
 { #category : #'image package loading' }
 RGContainer >> findPackageOfClass: aRGBehaviorDefinition using: packageKeys [
-
 	"Look for the package of a class. It is nil when there is not a package created for a category in MC"
-	| pair |
+
 	self packages isEmpty ifTrue: [ ^ nil ].
-	^ self packages at: aRGBehaviorDefinition category ifAbsent:[
-		pair := packageKeys detect:[ :each| self class category: aRGBehaviorDefinition category matches: each key ] ifNone:[ nil ].
-		pair ifNotNil:[ self packages at: pair key ] ]
+	^ self packages at: aRGBehaviorDefinition category ifAbsent: [
+		  packageKeys
+			  detect: [ :pair | aRGBehaviorDefinition category isCategoryOf: pair key ]
+			  ifFound: [ :pair | self packages at: pair key ]
+			  ifNone: [ nil ] ]
 ]
 
 { #category : #'image package loading' }
 RGContainer >> findPackageOfMethod: aRGMethodDefinition using: packageKeys [
-
 	"Look for the package of an extension method. nil otherwise"
+
 	| pair lname |
-	self packages isEmpty ifTrue: [ ^nil ].
-	(aRGMethodDefinition protocol beginsWith: '*') ifFalse:[ ^ nil ].
+	self packages ifEmpty: [ ^ nil ].
+	(aRGMethodDefinition protocol beginsWith: '*') ifFalse: [ ^ nil ].
 	lname := aRGMethodDefinition protocol asLowercase.
- 	pair := packageKeys detect:[ :assoc| self class category: lname matches: assoc value ] ifNone:[ nil ].
-	^ pair ifNotNil:[ self packages at: pair key ]
+	pair := packageKeys
+		        detect: [ :assoc | lname isCategoryOf: assoc value ]
+		        ifNone: [ nil ].
+	^ pair ifNotNil: [ self packages at: pair key ]
 ]
 
 { #category : #testing }


### PR DESCRIPTION
RPackage implements a way to know in a string representing a category can be in a string presenting a package name. 

This method is too complexe for what it does and is implemented on 4 classes.

I propose a simplified version and to implement it only in one place. The place I selected is String because it is easy even if I don't like to add methods to the primitive types of Pharo. But since the goal is to remove the concept of categories, I think it's a good temporary solution to simplify the system and allow more cleanings.