### PR TITLE
11476-TestAsserter--shouldnt-raise-whoseDescriptionIncludes-description-is-sending-an-unimplemented-messsage

### DIFF
--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -449,6 +449,16 @@ TestAsserter >> executeShould: aBlock inScopeOf: anExceptionalEvent [
 		  do: [ :ex | ex return: true ]
 ]
 
+{ #category : #private }
+TestAsserter >> executeShould: aBlock inScopeOf: anExceptionalEvent withDescriptionContaining: aString [
+
+	^ [
+	  aBlock value.
+	  false ]
+		  on: anExceptionalEvent
+		  do: [ :ex | ex return: (ex description includesSubstring: aString) ]
+]
+
 { #category : #asserting }
 TestAsserter >> executeShould: aBlock inScopeOf: anExceptionalEvent withDescriptionNotContaining: aString [
 	"I check if the giving block (aBlock) evaluation raises the giving exception (anExceptionalEvent)"

--- a/src/SUnit-Core/TestCase.class.st
+++ b/src/SUnit-Core/TestCase.class.st
@@ -681,16 +681,6 @@ TestCase >> defaultTimeLimit [
 	^self class defaultTimeLimit
 ]
 
-{ #category : #private }
-TestCase >> executeShould: aBlock inScopeOf: anExceptionalEvent withDescriptionContaining: aString [
-
-	^ [
-	  aBlock value.
-	  false ]
-		  on: anExceptionalEvent
-		  do: [ :ex | ex return: (ex description includesSubstring: aString) ]
-]
-
 { #category : #accessing }
 TestCase >> executionEnvironment [
 	^CurrentExecutionEnvironment value


### PR DESCRIPTION
Move method to superclass

fixes #11475
fixes  #11476