### PR TITLE
Reduce references to Smalltalk

### DIFF
--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -149,7 +149,7 @@ BaselineOfMorphic >> cleanUpAfterMorphicInitialization [
 	Symbol rehash.
 
 	"Remove empty packages and protocols"
-	Smalltalk organization removeEmptyPackages.
+	self packageOrganizer removeEmptyPackages.
 	Smalltalk allClassesAndTraitsDo: [ :class |
 		class removeEmptyProtocols.
 		class class removeEmptyProtocols  ].

--- a/src/CodeExport/RPackageOrganizer.extension.st
+++ b/src/CodeExport/RPackageOrganizer.extension.st
@@ -6,8 +6,8 @@ RPackageOrganizer >> fileOut [
 
 	| internalStream |
 	internalStream := (String new: 30000) writeStream.
-	internalStream nextPutAll: 'Smalltalk organization changeFromCategorySpecs: #('; cr;
-		print: Smalltalk organization;  "ends with a cr"
+	internalStream nextPutAll: 'self packageOrganizer changeFromCategorySpecs: #('; cr;
+		print: self packageOrganizer;  "ends with a cr"
 		nextPutAll: ')!'; cr.
 
 	CodeExporter

--- a/src/CodeExport/RPackageTag.extension.st
+++ b/src/CodeExport/RPackageTag.extension.st
@@ -6,7 +6,7 @@ RPackageTag >> fileOut [
 
 	internalStream := (String new: 1000) writeStream.
 
-	Smalltalk organization
+	self packageOrganizer
 		fileOutCategory: self categoryName
 		on: internalStream.
 

--- a/src/Epicea/EpMonitor.class.st
+++ b/src/Epicea/EpMonitor.class.st
@@ -221,7 +221,7 @@ EpMonitor >> behaviorRemoved: aClassRemovedAnnouncement [
 EpMonitor >> behaviorRemovedImpliesMethodRemoved: aMethodInAnObsoleteBehavior defaultPackageName: aSymbol [
 
 	| packageName |
-	packageName := ((Smalltalk organization packageForProtocol: aMethodInAnObsoleteBehavior protocolName inClass: aMethodInAnObsoleteBehavior methodClass) ifNil: [
+	packageName := ((self packageOrganizer packageForProtocol: aMethodInAnObsoleteBehavior protocolName inClass: aMethodInAnObsoleteBehavior methodClass) ifNil: [
 		                aMethodInAnObsoleteBehavior methodClass package ]) name.
 
 	"If the method is local, (belongs to the class being removed) then the package was wrong,  and we fix it"
@@ -458,7 +458,7 @@ EpMonitor >> methodRemoved: aMethodRemovedAnnouncement [
 	self addEvent: (EpMethodRemoval method: (aMethodRemovedAnnouncement methodAffected asEpiceaRingDefinition
 				  protocol: aMethodRemovedAnnouncement protocol name;
 				  package:
-					  ((Smalltalk organization packageForProtocol: aMethodRemovedAnnouncement protocol name inClass: aMethodRemovedAnnouncement methodAffected methodClass)
+					  ((self packageOrganizer packageForProtocol: aMethodRemovedAnnouncement protocol name inClass: aMethodRemovedAnnouncement methodAffected methodClass)
 						   ifNil: [ aMethodRemovedAnnouncement methodAffected methodClass package ]) name;
 				  yourself))
 ]

--- a/src/FluidClassBuilder-Tests/FluidClassBuilderAbstractTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidClassBuilderAbstractTest.class.st
@@ -19,7 +19,7 @@ FluidClassBuilderAbstractTest >> categoryHack [
 	This is due to the category mess in RPackage and it will not be fixed until the category mess is cleaned. Until then, to make sure the tests are in a right state, we register the package without the tag before creating the class to ensure the tag is not added as part of the package name.
 	This is ugly but it is currently hard to do better."
 
-	Smalltalk organization registerPackageNamed: self packageNameForTest
+	self packageOrganizer registerPackageNamed: self packageNameForTest
 ]
 
 { #category : #accessing }
@@ -31,7 +31,7 @@ FluidClassBuilderAbstractTest >> packageNameForTest [
 { #category : #running }
 FluidClassBuilderAbstractTest >> tearDown [
 
-	(Smalltalk organization packageNamed: self packageNameForTest ifAbsent: [ nil ]) ifNotNil: [ :x | x removeFromSystem ].
+	(self packageOrganizer packageNamed: self packageNameForTest ifAbsent: [ nil ]) ifNotNil: [ :x | x removeFromSystem ].
 
 	super tearDown
 ]

--- a/src/Fuel-Tests-Core/FLClassFactoryForTestCase.class.st
+++ b/src/Fuel-Tests-Core/FLClassFactoryForTestCase.class.st
@@ -317,12 +317,6 @@ FLClassFactoryForTestCase >> nextCount [
 ]
 
 { #category : #accessing }
-FLClassFactoryForTestCase >> packageOrganizer [
-
-	^ Smalltalk organization
-]
-
-{ #category : #accessing }
 FLClassFactoryForTestCase >> registerBehavior: aBehavior [
 	(aBehavior isTrait
 		ifTrue: [ self createdTraits ]

--- a/src/Fuel-Tests-Core/FLFullBasicSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLFullBasicSerializationTest.class.st
@@ -101,8 +101,8 @@ FLFullBasicSerializationTest >> testCreateClassWithChangedSuperclassFormat [
 FLFullBasicSerializationTest >> testMethodDictionaries [
 	"Tests correct serialization of all the method dictionaries in the System package."
 
-	(Smalltalk organization categoriesMatching: 'System*') do: [ :category |
-		(Smalltalk organization classesInCategory: category) do: [ :class | self resultOfSerializeAndMaterializeMethodDictionary: class methodDictionary ] ]
+	(self packageOrganizer categoriesMatching: 'System*') do: [ :category |
+		(self packageOrganizer classesInCategory: category) do: [ :class | self resultOfSerializeAndMaterializeMethodDictionary: class methodDictionary ] ]
 ]
 
 { #category : #tests }

--- a/src/Gofer-Core/GoferCleanup.class.st
+++ b/src/Gofer-Core/GoferCleanup.class.st
@@ -11,7 +11,7 @@ Class {
 GoferCleanup >> cleanup: aWorkingCopy [
 
 	| packageOrganizer |
-	packageOrganizer := Smalltalk organization.
+	packageOrganizer := self packageOrganizer.
 	aWorkingCopy packageSet systemCategories
 		select: [ :category | (packageOrganizer classesInCategory: category) isEmpty ]
 		thenDo: [ :category | packageOrganizer removeSystemCategory: category ]

--- a/src/Gofer-Tests/GoferOperationTest.class.st
+++ b/src/Gofer-Tests/GoferOperationTest.class.st
@@ -89,7 +89,7 @@ GoferOperationTest >> testCleanup [
 	class addProtocol: #empty.
 	class class addProtocol: #empty.
 	gofer cleanup.
-	self deny: (Smalltalk organization categories includes: #'GoferFoo-Empty').
+	self deny: (self packageOrganizer categories includes: #'GoferFoo-Empty').
 	self deny: (class hasProtocol: #'GoferFoo-Empty').
 	self deny: (class class hasProtocol: #'GoferFoo-Empty')
 ]

--- a/src/JenkinsTools-Core/HDReport.class.st
+++ b/src/JenkinsTools-Core/HDReport.class.st
@@ -14,7 +14,7 @@ HDReport class >> runCategories: aCollectionOfStrings [
 
 { #category : #running }
 HDReport class >> runCategory: aString [
-	^ self runClasses: (Smalltalk organization classesInCategory: aString) named: aString
+	^ self runClasses: (self packageOrganizer classesInCategory: aString) named: aString
 ]
 
 { #category : #running }

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1273,6 +1273,12 @@ Behavior >> originalName [
 	^obsName asSymbol
 ]
 
+{ #category : #accessing }
+Behavior >> packageOrganizer [
+
+	^ self environment organization
+]
+
 { #category : #copying }
 Behavior >> postCopy [
 	super postCopy.

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1540,6 +1540,12 @@ Object >> okToChange [
 	^ true
 ]
 
+{ #category : #accessing }
+Object >> packageOrganizer [
+
+	^ self class packageOrganizer
+]
+
 { #category : #'message performing' }
 Object >> perform: aSymbol [
 	"Send the unary selector, aSymbol, to the receiver.

--- a/src/Metacello-PharoCommonPlatform/MetacelloPharoCommonPlatform.class.st
+++ b/src/Metacello-PharoCommonPlatform/MetacelloPharoCommonPlatform.class.st
@@ -52,7 +52,7 @@ MetacelloPharoCommonPlatform >> copyClass: oldClass as: newName inCategory: newC
 	(Smalltalk globals includesKey: copysName) ifTrue: [ ^ self error: copysName , ' already exists' ].
 	newDefinition := oldClass definition copyReplaceAll: '#' , oldClass name asString with: '#' , copysName asString printString.
 	newDefinition := newDefinition
-		                 copyReplaceAll: 'category: ' , (Smalltalk organization categoryOfBehavior: oldClass) asString printString
+		                 copyReplaceAll: 'category: ' , (self packageOrganizer categoryOfBehavior: oldClass) asString printString
 		                 with: 'category: ' , newCategoryName printString.
 	class := self compiler
 		         logged: true;

--- a/src/Monticello-Tests/MCOrganizationTest.class.st
+++ b/src/Monticello-Tests/MCOrganizationTest.class.st
@@ -9,9 +9,9 @@ MCOrganizationTest >> testLoadAndUnload [
 
 	| category |
 	category := 'TestPackageToUnload'.
-	Smalltalk organization addCategory: category.
+	self packageOrganizer addCategory: category.
 	(MCOrganizationDefinition categories: { category }) unload.
-	self deny: (Smalltalk organization includesCategory: category)
+	self deny: (self packageOrganizer includesCategory: category)
 ]
 
 { #category : #tests }

--- a/src/Monticello-Tests/MCWorkingCopyForExtensionsTest.class.st
+++ b/src/Monticello-Tests/MCWorkingCopyForExtensionsTest.class.st
@@ -23,8 +23,8 @@ MCWorkingCopyForExtensionsTest >> tearDown [
 MCWorkingCopyForExtensionsTest >> testAddingExtensionMethodNotMatchingPackage [
 
 	| aClass |
-	Smalltalk organization createPackageNamed: 'ATestPackage'.
-	Smalltalk organization createPackageNamed: 'AnotherTestPackage'.
+	self packageOrganizer createPackageNamed: 'ATestPackage'.
+	self packageOrganizer createPackageNamed: 'AnotherTestPackage'.
 
 	aClass := self class classInstaller make: [ :aBuilder |
 		          aBuilder
@@ -33,7 +33,7 @@ MCWorkingCopyForExtensionsTest >> testAddingExtensionMethodNotMatchingPackage [
 
 	aClass compile: 'testingMethod ^ 42 ' classified: '*atestpackage-something-else'.
 
-	self deny: (Smalltalk organization includesPackageNamed: 'Atestpackage-something-else').
+	self deny: (self packageOrganizer includesPackageNamed: 'Atestpackage-something-else').
 	self assert: ('ATestPackage' asPackage extendedClasses includes: aClass).
 
 	MCWorkingCopy registry at: (MCPackage named: 'atestpackage-something-else') ifPresent: [ self fail ]

--- a/src/Monticello-Tests/RPackageCategorySynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageCategorySynchronisationTest.class.st
@@ -34,13 +34,13 @@ RPackageCategorySynchronisationTest >> testAddCategoryIsAlreadyAPackageDoesNotCr
 RPackageCategorySynchronisationTest >> testRenameCategoryAlsoRenameAllExtensionProtocols [
 	"test that when we rename a category, all corresponding extension protocols in the system are renamed"
 
-	| XPackage YPackage ZPackage classInY classInZ |
+	| xPackage yPackage zPackage classInY classInZ |
 	self addXCategory.
 	self addYCategory.
 	self addZCategory.
-	XPackage := self organizer packageNamed: #XXXXX.
-	YPackage := self organizer packageNamed: #YYYYY.
-	ZPackage := self organizer packageNamed: #ZZZZZ.
+	xPackage := self organizer packageNamed: #XXXXX.
+	yPackage := self organizer packageNamed: #YYYYY.
+	zPackage := self organizer packageNamed: #ZZZZZ.
 
 	classInY := self createNewClassNamed: 'ClassInYPackage' inCategory: 'YYYYY'.
 	classInZ := self createNewClassNamed: 'ClassInZPackage' inCategory: 'ZZZZZ'.
@@ -49,9 +49,9 @@ RPackageCategorySynchronisationTest >> testRenameCategoryAlsoRenameAllExtensionP
 	self createMethodNamed: 'longNameExtensionFromXInClassInY' inClass: classInY inCategory: '*XXXXX-subcategory'.
 	self createMethodNamed: 'extensionFromXInClassInZ' inClass: classInZ inCategory: '*XXXXX'.
 
-	Smalltalk organization renameCategory: 'XXXXX' toBe: 'NewCategoryName'.
+	self packageOrganizer renameCategory: 'XXXXX' toBe: 'NewCategoryName'.
 
-	self assert: XPackage name equals: 'NewCategoryName'.
+	self assert: xPackage name equals: 'NewCategoryName'.
 	self assert: (classInY >> #extensionFromXInClassInY) category equals: '*NewCategoryName'.
 	self assert: (classInY >> #longNameExtensionFromXInClassInY) category equals: '*NewCategoryName'.
 	self assert: (classInZ >> #extensionFromXInClassInZ) category equals: '*NewCategoryName'
@@ -61,24 +61,24 @@ RPackageCategorySynchronisationTest >> testRenameCategoryAlsoRenameAllExtensionP
 RPackageCategorySynchronisationTest >> testRenameCategoryChangeTheNameOfThePackage [
 	"test that when we rename a category, the RPackage corresponding is updated with this new name"
 
-	| XPackage |
+	| xPackage |
 	self addXCategory.
-	XPackage := self organizer packageNamed: #XXXXX.
+	xPackage := self organizer packageNamed: #XXXXX.
 
-	Smalltalk organization renameCategory: 'XXXXX' toBe: 'YYYYY'.
-	self assert: XPackage name equals: 'YYYYY'
+	self packageOrganizer renameCategory: 'XXXXX' toBe: 'YYYYY'.
+	self assert: xPackage name equals: 'YYYYY'
 ]
 
 { #category : #'tests - operations on categories' }
 RPackageCategorySynchronisationTest >> testRenameCategoryUpdateTheOrganizer [
 	"test that when we rename a category, the organizer dictionary is update with this new name, so that we can access the package with this new name as key"
 
-	| XPackage |
+	| xPackage |
 	self addXCategory.
 
-	XPackage := self organizer packageNamed: #XXXXX.
-	Smalltalk organization renameCategory: 'XXXXX' toBe: 'YYYYY'.
-	self assert: (self organizer packageNamed: 'YYYYY' asSymbol) equals: XPackage.
+	xPackage := self organizer packageNamed: #XXXXX.
+	self packageOrganizer renameCategory: 'XXXXX' toBe: 'YYYYY'.
+	self assert: (self organizer packageNamed: 'YYYYY' asSymbol) equals: xPackage.
 	self deny: (self organizer includesPackageNamed: #XXXXX)
 ]
 
@@ -90,6 +90,6 @@ RPackageCategorySynchronisationTest >> testRenameUnknownCategoryCreatesNewRPacka
 		self addXCategory.
 		].
 	self deny: (self organizer includesPackageNamed: #XXXXX).
-	Smalltalk organization renameCategory: 'XXXXX' toBe: 'YYYYY'.
+	self packageOrganizer renameCategory: 'XXXXX' toBe: 'YYYYY'.
 	self assert: (self organizer includesPackageNamed: #YYYYY).
 ]

--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -61,56 +61,70 @@ RPackageMCSynchronisationTest >> addZCategory [
 { #category : #setup }
 RPackageMCSynchronisationTest >> cleanClassesPackagesAndCategories [
 
-		|mCPackage|
-		Smalltalk removeClassNamed: 'NewClass'.
-		Smalltalk removeClassNamed: 'RPackageNewStubClass'.
-		Smalltalk removeClassNamed: 'RPackageOldStubClass'.
-		Smalltalk removeClassNamed: 'Foo'.
-		Smalltalk removeClassNamed: 'FooOther'.
-		Smalltalk removeClassNamed: 'NewTrait'.
-		Smalltalk removeClassNamed: 'ClassInYPackage'.
-		Smalltalk removeClassNamed: 'ClassInZPackage'.
-		Smalltalk organization removeCategory: 'Zork'.
-		Smalltalk organization removeCategory: 'XXXXX'.
-		Smalltalk organization removeCategory: 'XXXXX-YYYY'.
-		Smalltalk organization removeCategory: 'XXXX'.
-		Smalltalk organization removeCategory: 'YYYYY'.
-		Smalltalk organization removeCategory: 'ZZZZZ'.
-		Smalltalk organization removeCategory: 'FooPackage-Core'.
-		Smalltalk organization removeCategory: 'FooPackage-Other'.
-		Smalltalk organization removeCategory: 'FooPackage'.
-		Smalltalk organization removeCategory: 'OriginalCategory'.
-		Smalltalk organization removeCategory: 'NewCategoryName'.
-		Smalltalk organization removeCategory: 'Y'.
-		mCPackage := (self allManagers detect: [:each | each packageName = 'OriginalCategory'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].
-		mCPackage := (self allManagers detect: [:each | each packageName = 'XXXXX'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].
-		mCPackage := (self allManagers detect: [:each | each packageName = 'XXXX'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].
-		mCPackage := (self allManagers detect: [:each | each packageName = 'YYYYY'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].
-		mCPackage := (self allManagers detect: [:each | each packageName = 'YYYY'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].
-		mCPackage := (self allManagers detect: [:each | each packageName = 'Yyyyy'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].	
-		mCPackage := (self allManagers detect: [:each | each packageName = 'YyYyY'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].
-		mCPackage := (self allManagers detect: [:each | each packageName = 'Y'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].
-		mCPackage := (self allManagers detect: [:each | each packageName = 'ZZZZZ'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].	
-		mCPackage := (self allManagers detect: [:each | each packageName = 'Zzzzz'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].
-		mCPackage := (self allManagers detect: [:each | each packageName = 'FooPackage-Core'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].
-		mCPackage := (self allManagers detect: [:each | each packageName = 'FooPackage-Other'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].
-		mCPackage := (self allManagers detect: [:each | each packageName = 'FooPackage'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].
-		mCPackage := (self allManagers detect: [:each | each packageName = 'Zork'] ifNone: [nil]) .
-		mCPackage ifNotNil: [mCPackage unregister].
-			
+	Smalltalk
+		removeClassNamed: 'NewClass';
+		removeClassNamed: 'RPackageNewStubClass';
+		removeClassNamed: 'RPackageOldStubClass';
+		removeClassNamed: 'Foo';
+		removeClassNamed: 'FooOther';
+		removeClassNamed: 'NewTrait';
+		removeClassNamed: 'ClassInYPackage';
+		removeClassNamed: 'ClassInZPackage'.
+	self packageOrganizer
+		removeCategory: 'Zork';
+		removeCategory: 'XXXXX';
+		removeCategory: 'XXXXX-YYYY';
+		removeCategory: 'XXXX';
+		removeCategory: 'YYYYY';
+		removeCategory: 'ZZZZZ';
+		removeCategory: 'FooPackage-Core';
+		removeCategory: 'FooPackage-Other';
+		removeCategory: 'FooPackage';
+		removeCategory: 'OriginalCategory';
+		removeCategory: 'NewCategoryName';
+		removeCategory: 'Y'.
+	self allManagers
+		detect: [ :each | each packageName = 'OriginalCategory' ]
+		ifFound: [ :mCPackage | mCPackage unregister ].
+	self allManagers
+		detect: [ :each | each packageName = 'XXXXX' ]
+		ifFound: [ :mCPackage | mCPackage unregister ].
+	self allManagers
+		detect: [ :each | each packageName = 'XXXX' ]
+		ifFound: [ :mCPackage | mCPackage unregister ].
+	self allManagers
+		detect: [ :each | each packageName = 'YYYYY' ]
+		ifFound: [ :mCPackage | mCPackage unregister ].
+	self allManagers
+		detect: [ :each | each packageName = 'YYYY' ]
+		ifFound: [ :mCPackage | mCPackage unregister ].
+	self allManagers
+		detect: [ :each | each packageName = 'Yyyyy' ]
+		ifFound: [ :mCPackage | mCPackage unregister ].
+	self allManagers
+		detect: [ :each | each packageName = 'YyYyY' ]
+		ifFound: [ :mCPackage | mCPackage unregister ].
+	self allManagers
+		detect: [ :each | each packageName = 'Y' ]
+		ifFound: [ :mCPackage | mCPackage unregister ].
+	self allManagers
+		detect: [ :each | each packageName = 'ZZZZZ' ]
+		ifFound: [ :mCPackage | mCPackage unregister ].
+	self allManagers
+		detect: [ :each | each packageName = 'Zzzzz' ]
+		ifFound: [ :mCPackage | mCPackage unregister ].
+	self allManagers
+		detect: [ :each | each packageName = 'FooPackage-Core' ]
+		ifFound: [ :mCPackage | mCPackage unregister ].
+	self allManagers
+		detect: [ :each | each packageName = 'FooPackage-Other' ]
+		ifFound: [ :mCPackage | mCPackage unregister ].
+	self allManagers
+		detect: [ :each | each packageName = 'FooPackage' ]
+		ifFound: [ :mCPackage | mCPackage unregister ].
+	self allManagers
+		detect: [ :each | each packageName = 'Zork' ]
+		ifFound: [ :mCPackage | mCPackage unregister ]
 ]
 
 { #category : #private }

--- a/src/Monticello/MCOrganizationDefinition.class.st
+++ b/src/Monticello/MCOrganizationDefinition.class.st
@@ -147,5 +147,5 @@ MCOrganizationDefinition >> summary [
 { #category : #unloading }
 MCOrganizationDefinition >> unload [
 
-	categories do: [ :category | (Smalltalk organization isEmptyCategoryNamed: category) ifTrue: [ Smalltalk organization removeCategory: category ] ]
+	categories do: [ :category | (self packageOrganizer isEmptyCategoryNamed: category) ifTrue: [ self packageOrganizer removeCategory: category ] ]
 ]

--- a/src/Monticello/MCPackage.class.st
+++ b/src/Monticello/MCPackage.class.st
@@ -27,7 +27,7 @@ MCPackage >> = other [
 { #category : #accessing }
 MCPackage >> correspondingRPackage [
 
-	^ Smalltalk organization packageNamed: self name asSymbol ifAbsent: [ nil ]
+	^ self packageOrganizer packageNamed: self name asSymbol ifAbsent: [ nil ]
 ]
 
 { #category : #printing }

--- a/src/Monticello/MCPackageManager.class.st
+++ b/src/Monticello/MCPackageManager.class.st
@@ -75,12 +75,12 @@ MCPackageManager class >> classMoved: anEvent [
 MCPackageManager class >> classRemoved: anEvent [
 	"Informs the registry who use to keep this class that its changed. Unlike #classModified:, class is not anymore in RPackages so it will not be found, that's why we look for system category instead if class is included or not"
 
-	(Smalltalk organization packageMatchingExtensionName: anEvent categoryName) ifNotNil: [ :package |
+	(self packageOrganizer packageMatchingExtensionName: anEvent categoryName) ifNotNil: [ :package |
 		package mcWorkingCopy ifNotNil: [ :workingCopy | workingCopy modified: true ] ].
 
 	anEvent classAffected protocolNames , anEvent classAffected classSide protocolNames do: [ :aProtocolName |
 		(aProtocolName beginsWith: '*') ifTrue: [
-			(Smalltalk organization packageMatchingExtensionName: aProtocolName allButFirst trimBoth) ifNotNil: [ :package |
+			(self packageOrganizer packageMatchingExtensionName: aProtocolName allButFirst trimBoth) ifNotNil: [ :package |
 				package mcWorkingCopy ifNotNil: [ :workingCopy | workingCopy modified: true ] ] ] ]
 ]
 

--- a/src/RPackage-Core/ClassDescription.extension.st
+++ b/src/RPackage-Core/ClassDescription.extension.st
@@ -47,12 +47,6 @@ ClassDescription >> packageFromOrganizer: anOrganizer [
 ]
 
 { #category : #'*RPackage-Core' }
-ClassDescription >> packageOrganizer [
-	"Returns the organizer of this class"
-	^ RPackage organizer
-]
-
-{ #category : #'*RPackage-Core' }
 ClassDescription >> packageTag [
 
 	| packageTag |

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -118,7 +118,7 @@ RPackage class >> named: aString [
 { #category : #'protected only for tests' }
 RPackage class >> organizer [
 
-	^ PackageGlobalOrganizer ifNil: [ Smalltalk organization ]
+	^ PackageGlobalOrganizer ifNil: [ self packageOrganizer ]
 ]
 
 { #category : #'protected only for tests' }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -117,9 +117,9 @@ Class {
 
 { #category : #singleton }
 RPackageOrganizer class >> default [
-	"Warning: Use 'Smalltalk organization' since I will be removed in the future."
+	"Warning: Use 'self packageOrganizer' since I will be removed in the future."
 
-	^ Smalltalk organization
+	^ self packageOrganizer
 ]
 
 { #category : #'class initialization' }
@@ -146,7 +146,7 @@ RPackageOrganizer class >> methodAdded: anEvent [
 	(methodCategory isEmptyOrNil or:[ methodCategory first ~= $* ])
 		ifFalse: [
 			(self isPackageDefinedForClass: anEvent methodClass)
-					ifFalse: [self packageClass new named: (Smalltalk organization categoryOfBehavior: anEvent methodClass instanceSide) ].
+					ifFalse: [self packageClass new named: (self packageOrganizer categoryOfBehavior: anEvent methodClass instanceSide) ].
 		]
 ]
 
@@ -159,9 +159,9 @@ RPackageOrganizer class >> packageClass [
 { #category : #'class initialization' }
 RPackageOrganizer class >> registerInterestToSystemAnnouncement [
 
-	Smalltalk organization unregisterInterestToSystemAnnouncement.
+	self packageOrganizer unregisterInterestToSystemAnnouncement.
 	"To make sure that we do not have it twice registered"
-	Smalltalk organization registerInterestToSystemAnnouncement
+	self packageOrganizer registerInterestToSystemAnnouncement
 ]
 
 { #category : #'class initialization' }

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -76,7 +76,7 @@ RPackageTag >> classes [
 RPackageTag >> ensureSystemCategory [
 	"We should not hardcode the global variable but ask the package organizer for the organization."
 
-	Smalltalk organization addCategory: self categoryName
+	self packageOrganizer addCategory: self categoryName
 ]
 
 { #category : #accessing }

--- a/src/RPackage-Core/String.extension.st
+++ b/src/RPackage-Core/String.extension.st
@@ -8,5 +8,5 @@ String >> asPackage [
 { #category : #'*RPackage-Core' }
 String >> asPackageIfAbsent: aBlock [
 
-	^ Smalltalk organization packageNamed: self ifAbsent: aBlock
+	^ self packageOrganizer packageNamed: self ifAbsent: aBlock
 ]

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -75,7 +75,7 @@ RPackageIncrementalTest >> tearDown [
 		"but this also means that the consistency cannot be ensured by internal system announcer too."
 		].
 	createdCategories do: [:each |
-		Smalltalk organization removeCategory: each.
+		self packageOrganizer removeCategory: each.
 		 ].
 	super tearDown
 ]

--- a/src/RPackage-Tests/RPackageOrganizerAndSystemOrganizeSynchTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerAndSystemOrganizeSynchTest.class.st
@@ -22,40 +22,40 @@ RPackageOrganizerAndSystemOrganizeSynchTest >> packageName [
 RPackageOrganizerAndSystemOrganizeSynchTest >> tearDown [
 
 	(self packageName asPackageIfAbsent: [ nil ]) ifNotNil: [ :package | package removeFromSystem ].
-	Smalltalk organization removeCategory: self packageName.
-	Smalltalk organization removeCategoriesMatching: self packageName , '-*'.
+	self packageOrganizer removeCategory: self packageName.
+	self packageOrganizer removeCategoriesMatching: self packageName , '-*'.
 	super tearDown
 ]
 
 { #category : #tests }
 RPackageOrganizerAndSystemOrganizeSynchTest >> testAddingPackage [
 
-	Smalltalk organization addCategory: self packageName.
+	self packageOrganizer addCategory: self packageName.
 
-	self assert: (Smalltalk organization packageNames includes: self packageName).
-	self assert: (Smalltalk organization includesCategory: self packageName)
+	self assert: (self packageOrganizer packageNames includes: self packageName).
+	self assert: (self packageOrganizer includesCategory: self packageName)
 ]
 
 { #category : #tests }
 RPackageOrganizerAndSystemOrganizeSynchTest >> testRemovingPackage [
 	"Regression test because removing a RPackage from the system was not removing the category in SystemOrganizer."
 
-	Smalltalk organization addCategory: self packageName.
+	self packageOrganizer addCategory: self packageName.
 
-	self assert: (Smalltalk organization packageNames includes: self packageName).
-	self assert: (Smalltalk organization includesCategory: self packageName).
+	self assert: (self packageOrganizer packageNames includes: self packageName).
+	self assert: (self packageOrganizer includesCategory: self packageName).
 
 	self packageName asPackage removeFromSystem.
 
-	self deny: (Smalltalk organization packageNames includes: self packageName).
-	self deny: (Smalltalk organization includesCategory: self packageName)
+	self deny: (self packageOrganizer packageNames includes: self packageName).
+	self deny: (self packageOrganizer includesCategory: self packageName)
 ]
 
 { #category : #tests }
 RPackageOrganizerAndSystemOrganizeSynchTest >> testRemovingPackageWithTags [
 	"Regression test because removing a RPackage from the system was not removing the category in SystemOrganizer."
 
-	Smalltalk organization addCategory: self packageName.
+	self packageOrganizer addCategory: self packageName.
 	(Object << 'RPackageOragizationSynchClass1')
 		package: self packageName;
 		tag: 'tag1';
@@ -64,15 +64,15 @@ RPackageOrganizerAndSystemOrganizeSynchTest >> testRemovingPackageWithTags [
 		package: self packageName;
 		tag: 'tag2';
 		install.
-	self assert: (Smalltalk organization packageNames includes: self packageName).
-	self assert: (Smalltalk organization includesCategory: self packageName).
-	self assert: (Smalltalk organization includesCategory: self packageName , '-tag1').
-	self assert: (Smalltalk organization includesCategory: self packageName , '-tag2').
+	self assert: (self packageOrganizer packageNames includes: self packageName).
+	self assert: (self packageOrganizer includesCategory: self packageName).
+	self assert: (self packageOrganizer includesCategory: self packageName , '-tag1').
+	self assert: (self packageOrganizer includesCategory: self packageName , '-tag2').
 
 	self packageName asPackage removeFromSystem.
 
-	self deny: (Smalltalk organization packageNames includes: self packageName).
-	self deny: (Smalltalk organization includesCategory: self packageName).
-	self deny: (Smalltalk organization includesCategory: self packageName , '-tag1').
-	self deny: (Smalltalk organization includesCategory: self packageName , '-tag2')
+	self deny: (self packageOrganizer packageNames includes: self packageName).
+	self deny: (self packageOrganizer includesCategory: self packageName).
+	self deny: (self packageOrganizer includesCategory: self packageName , '-tag1').
+	self deny: (self packageOrganizer includesCategory: self packageName , '-tag2')
 ]

--- a/src/RPackage-Tests/RPackageOrganizerSystemTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerSystemTest.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #tests }
 RPackageOrganizerSystemTest >> testDefault [
 
-	self assert: Smalltalk organization identicalTo: self class environment organization
+	self assert: self packageOrganizer identicalTo: self class environment organization
 ]
 
 { #category : #tests }

--- a/src/RPackage-Tests/RPackageRenameTest.class.st
+++ b/src/RPackage-Tests/RPackageRenameTest.class.st
@@ -48,7 +48,7 @@ RPackageRenameTest >> testRenamePackage [
 	| package workingCopy class |
 	self cleanWorkingCopiesInTearDown: #( 'TestRename' ).
 
-	package := Smalltalk organization registerPackageNamed: 'Test1'.
+	package := self packageOrganizer registerPackageNamed: 'Test1'.
 	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'Test1').
 	class := (Object << #TestClass package: 'Test1-TAG') install.
 
@@ -63,7 +63,7 @@ RPackageRenameTest >> testRenamePackage [
 	self assert: (package classTagNamed: #TAG ifAbsent: [ nil ]) notNil.
 	self assert: ((package classTagNamed: #TAG ifAbsent: [ nil ]) includesClass: class).
 	self assert: class category equals: #'TestRename-TAG'.
-	self deny: (Smalltalk organization includesCategory: #Test1).
+	self deny: (self packageOrganizer includesCategory: #Test1).
 	self deny: (MCWorkingCopy hasPackageNamed: #Test1).
 
 	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'TestRename').
@@ -77,7 +77,7 @@ RPackageRenameTest >> testRenamePackageToOwnTagName [
 	| package workingCopy class1 class2 |
 	self cleanWorkingCopiesInTearDown: #( 'Test1-Core' ).
 
-	package := Smalltalk organization registerPackageNamed: 'Test1'.
+	package := self packageOrganizer registerPackageNamed: 'Test1'.
 	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'Test1').
 	class1 := (Object << #TestClass1 package: 'Test1-Core') install.
 	class2 := (Object << #TestClass2 package: 'Test1-Util') install.
@@ -103,7 +103,7 @@ RPackageRenameTest >> testRenamePackageToOwnTagNameWithClassesInRoot [
 	| package workingCopy class1 class2 class3 |
 	self cleanWorkingCopiesInTearDown: #( 'Test1-Core' ).
 
-	package := Smalltalk organization registerPackageNamed: 'Test1'.
+	package := self packageOrganizer registerPackageNamed: 'Test1'.
 	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'Test1').
 	class1 := (Object << #TestClass1 package: 'Test1-Core') install.
 	class2 := (Object << #TestClass2 package: 'Test1-Util') install.
@@ -130,26 +130,26 @@ RPackageRenameTest >> testRenamePackageUppercase [
 	| package pkg oldWorkingCopy |
 	"preparation: creation of a pkg and its associated mcworkingcopy"
 	[
-	package := Smalltalk organization registerPackageNamed: 'Test1'.
+	package := self packageOrganizer registerPackageNamed: 'Test1'.
 	oldWorkingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'Test1').
-	self assert: (Smalltalk organization includesPackageNamed: #Test1).
+	self assert: (self packageOrganizer includesPackageNamed: #Test1).
 	self assert: (MCWorkingCopy hasPackageNamed: #Test1) isNotNil.
 
 	"renaming"
 	package renameTo: 'TEST1'.
 
 
-	pkg := Smalltalk organization packageNamed: 'Test1' ifAbsent: [ nil ].
+	pkg := self packageOrganizer packageNamed: 'Test1' ifAbsent: [ nil ].
 	self assert: pkg isNil.
 	self assert: 'TEST1' asPackage isNotNil.
 	self deny: 'TEST1' asPackage mcWorkingCopy equals: oldWorkingCopy.
 	self assert: 'TEST1' asPackage mcWorkingCopy isNotNil.
-	self assert: (Smalltalk organization includesPackageNamed: #TEST1).
+	self assert: (self packageOrganizer includesPackageNamed: #TEST1).
 	self assert: (MCWorkingCopy hasPackageNamed: #TEST1) isNotNil ] ensure: [ "cleaning"
 		'TEST1' asPackage removeFromSystem.
-		self deny: (Smalltalk organization includesPackageNamed: #TEST1).
+		self deny: (self packageOrganizer includesPackageNamed: #TEST1).
 		self deny: (MCWorkingCopy hasPackageNamed: #TEST1).
-		self deny: (Smalltalk organization includesPackageNamed: #Test1).
+		self deny: (self packageOrganizer includesPackageNamed: #Test1).
 		self deny: (MCWorkingCopy hasPackageNamed: #Test1) ]
 ]
 
@@ -157,12 +157,12 @@ RPackageRenameTest >> testRenamePackageUppercase [
 RPackageRenameTest >> testRenamePackageWithExtensions [
 
 	| package workingCopy class extendedPackage extendedPackageWorkingCopy extension |
-	package := Smalltalk organization registerPackageNamed: 'OriginalPackage'.
+	package := self packageOrganizer registerPackageNamed: 'OriginalPackage'.
 	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'OriginalPackage').
 
 	class := (Object << #TestClass package: 'OriginalPackage-TAG') install.
 
-	extendedPackage := Smalltalk organization registerPackageNamed: 'ExtendedPackage'.
+	extendedPackage := self packageOrganizer registerPackageNamed: 'ExtendedPackage'.
 	extendedPackageWorkingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'ExtendedPackage').
 
 	self cleanWorkingCopiesInTearDown: #( ExtendedPackage RenamedPackage OriginalPackage ).
@@ -191,12 +191,12 @@ RPackageRenameTest >> testRenamePackageWithExtensions [
 RPackageRenameTest >> testRenamePackageWithExtensionsInClassSide [
 
 	| package workingCopy class extendedPackage extendedPackageWorkingCopy extension |
-	package := Smalltalk organization registerPackageNamed: 'OriginalPackage'.
+	package := self packageOrganizer registerPackageNamed: 'OriginalPackage'.
 	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'OriginalPackage').
 
 	class := (Object << #TestClass package: 'OriginalPackage-TAG') install.
 
-	extendedPackage := Smalltalk organization registerPackageNamed: 'ExtendedPackage'.
+	extendedPackage := self packageOrganizer registerPackageNamed: 'ExtendedPackage'.
 	extendedPackageWorkingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'ExtendedPackage').
 
 	self cleanWorkingCopiesInTearDown: #( ExtendedPackage RenamedPackage OriginalPackage ).
@@ -228,7 +228,7 @@ RPackageRenameTest >> testUnregisterPackage [
 	"Test that we do unregister the package as expected."
 
 	| package workingCopy class |
-	package := Smalltalk organization registerPackageNamed: 'Test1'.
+	package := self packageOrganizer registerPackageNamed: 'Test1'.
 	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'Test1').
 	class := (Object << #TestClass package: 'Test1-TAG') install.
 	self assert: (package includesClass: class).
@@ -238,6 +238,6 @@ RPackageRenameTest >> testUnregisterPackage [
 
 	package unregister.
 
-	self deny: (Smalltalk organization includesPackageNamed: #Test1).
+	self deny: (self packageOrganizer includesPackageNamed: #Test1).
 	self deny: (MCWorkingCopy hasPackageNamed: #Test1)
 ]

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -20,11 +20,11 @@ RPackageTest >> tearDown [
 RPackageTest >> testActualClassTags [
 
 	| packageWithoutClassTags packageWithClassTags |
-	packageWithoutClassTags := Smalltalk organization packageOf: StartupAction.
+	packageWithoutClassTags := self packageOrganizer packageOf: StartupAction.
 	self denyEmpty: packageWithoutClassTags classTags.
 	self assertEmpty: packageWithoutClassTags actualClassTags.
 
-	packageWithClassTags := Smalltalk organization packageOf: Object.
+	packageWithClassTags := self packageOrganizer packageOf: Object.
 	self assert: packageWithClassTags actualClassTags equals: packageWithClassTags classTags
 ]
 
@@ -221,7 +221,7 @@ RPackageTest >> testHasProperty [
 RPackageTest >> testHierarchyRoots [
 
 	| roots |
-	roots := (Smalltalk organization packageNamed: #'RPackage-Tests') hierarchyRoots.
+	roots := (self packageOrganizer packageNamed: #'RPackage-Tests') hierarchyRoots.
 	roots := roots collect: [ :each | each name ].
 	#( RPackageTestCase ) do: [ :each | roots includes: each ]
 ]
@@ -293,7 +293,7 @@ RPackageTest >> testRenameToMakesMCDirty [
 RPackageTest >> testRoots [
 
 	| roots |
-	roots := (Smalltalk organization packageNamed: #'RPackage-Tests') roots.
+	roots := (self packageOrganizer packageNamed: #'RPackage-Tests') roots.
 	roots := roots collect: [ :each | each name ].
 	#( RPackageStringExtensionTest RPackageRenameTest TestRPackagePrequisites RPackageTestCase RPackageWithDoTest ) do: [ :each | roots includes: each ]
 ]

--- a/src/RPackage-Tests/RPackageTraitTest.class.st
+++ b/src/RPackage-Tests/RPackageTraitTest.class.st
@@ -99,7 +99,7 @@ RPackageTraitTest >> testPackageOfClassMethodFromTraitIsTraitPackage [
 	"test that a class method coming from a trait is packaged in the trait package"
 
 	self assert: (a1 >> #traitMethodDefinedInP4 packageFromOrganizer: self packageClass organizer) equals: p4.
-	self assert: (a1 >> #traitMethodDefinedInP5 packageFromOrganizer: Smalltalk organization) equals: p5
+	self assert: (a1 >> #traitMethodDefinedInP5 packageFromOrganizer: self packageOrganizer) equals: p5
 ]
 
 { #category : #tests }
@@ -107,7 +107,7 @@ RPackageTraitTest >> testPackageOfClassMethodIsClassPackage [
 	"The package of a local method (not defined in a trait) is the package of its class"
 
 	self assert: (a1 >> #localMethodDefinedInP1 packageFromOrganizer: self packageClass organizer) equals: p4.
-	self assert: (a1 >> #anotherLocalMethodDefinedInP1 packageFromOrganizer: Smalltalk organization) equals: p4.
+	self assert: (a1 >> #anotherLocalMethodDefinedInP1 packageFromOrganizer: self packageOrganizer) equals: p4.
 	self assert: (a1 >> #anotherLocalMethodDefinedInP1 packageFromOrganizer: self packageClass organizer) equals: p4
 ]
 
@@ -116,7 +116,7 @@ RPackageTraitTest >> testPackageOfTraitMethodIsTraitPackage [
 	"The package of a trait method is the package of its trait."
 
 	self assert: (a1 >> #traitMethodDefinedInP5 packageFromOrganizer: self packageClass organizer) equals: p5.
-	self assert: (a1 >> #traitMethodDefinedInP5 packageFromOrganizer: Smalltalk organization) equals: p5.
+	self assert: (a1 >> #traitMethodDefinedInP5 packageFromOrganizer: self packageOrganizer) equals: p5.
 	self assert: (a1 >> #traitMethodDefinedInP4 packageFromOrganizer: self packageClass organizer) equals: p4
 ]
 

--- a/src/RPackage-Tests/RPackageWithDoTest.class.st
+++ b/src/RPackage-Tests/RPackageWithDoTest.class.st
@@ -93,10 +93,10 @@ RPackageWithDoTest >> testOnDo [
 RPackageWithDoTest >> testOrganizerContainsPackages [
 
 	self
-		assert: Smalltalk organization packageNames isNotEmpty
+		assert: self packageOrganizer packageNames isNotEmpty
 		description: 'RPackageOrganizer should contains package names since an image should at least contains one package.'.
 	self
-		assert: Smalltalk organization packages isNotEmpty
+		assert: self packageOrganizer packages isNotEmpty
 		description: 'RPackageOrganizer should not be empty since an image should at least contains one package.'
 ]
 
@@ -104,7 +104,7 @@ RPackageWithDoTest >> testOrganizerContainsPackages [
 RPackageWithDoTest >> testWithDoIsCorrectlyReinstallingDefault [
 
 	| current empty |
-	current := Smalltalk organization.
+	current := self packageOrganizer.
 	empty := self packageOrganizerClass basicNew initialize.
 	empty debuggingName: 'empty from PackageWithDoTest'.
 	self packageClass withOrganizer: empty do: [
@@ -126,7 +126,7 @@ RPackageWithDoTest >> testWithDoIsCorrectlyReinstallingDefault [
 RPackageWithDoTest >> testWithDoIsCorrectlyReinstallingDefaultEvenIfHalt [
 
 	| current empty |
-	current := Smalltalk organization.
+	current := self packageOrganizer.
 	empty := self packageOrganizerClass basicNew initialize.
 	[
 	self packageClass withOrganizer: empty do: [

--- a/src/Refactoring-Environment/RBBrowserEnvironment.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironment.class.st
@@ -596,12 +596,6 @@ RBBrowserEnvironment >> packageAt: aName ifAbsent: absentBlock [
 		ifFalse: absentBlock
 ]
 
-{ #category : #private }
-RBBrowserEnvironment >> packageOrganizer [
-
-	^ RPackageOrganizer default
-]
-
 { #category : #'accessing - packages' }
 RBBrowserEnvironment >> packages [
 

--- a/src/ReleaseTests/ProperPackagesTest.class.st
+++ b/src/ReleaseTests/ProperPackagesTest.class.st
@@ -30,7 +30,7 @@ ProperPackagesTest >> testProperClassTagCasing [
 
 	| violations |
 	violations := OrderedCollection new.
-	Smalltalk organization packages do: [ :package |
+	self packageOrganizer packages do: [ :package |
 		package classTags do: [ :classTag | classTag name first isLowercase ifTrue: [ violations add: package -> classTag ] ] ].
 	self assert: violations isEmpty description: 'Class Tags should be uppercase'
 ]

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -239,7 +239,7 @@ ReleaseTest >> testNoEmptyPackages [
 	"Test that we have no empty packages left"
 
 	| violating |
-	violating := Smalltalk organization packages select: #isEmpty.
+	violating := self packageOrganizer packages select: #isEmpty.
 	self assertEmpty: violating
 ]
 
@@ -393,7 +393,7 @@ ReleaseTest >> testRPackageOrganizer [
 		description: 'There are multiple (' , RPackageOrganizer allInstances size asString , ') instances of RPackageOrganizer'.
 
 	self
-		assert: RPackageOrganizer allInstances first == Smalltalk organization
+		assert: RPackageOrganizer allInstances first == self packageOrganizer
 		description: 'The default package organizer is the not the only instance of RPackageOrganizer'
 ]
 
@@ -505,7 +505,7 @@ ReleaseTest >> testUnknownProcesses [
 ReleaseTest >> testUnpackagedClasses [
 
 	| unpackagedClasses |
-	unpackagedClasses := Smalltalk allClassesAndTraits select: [ :each | (Smalltalk organization packageOf: each) packageName = RPackage defaultPackageName ].
+	unpackagedClasses := Smalltalk allClassesAndTraits select: [ :each | (self packageOrganizer packageOf: each) packageName = RPackage defaultPackageName ].
 	self assert: unpackagedClasses isEmpty description: (String streamContents: [ :s |
 			 s nextPutAll: 'Found the following unpackaged classes: '.
 			 unpackagedClasses do: [ :cls | s tab print: cls ] separatedBy: [ s cr ] ])
@@ -515,7 +515,7 @@ ReleaseTest >> testUnpackagedClasses [
 ReleaseTest >> testUnpackagedPackageShouldBeEmpty [
 
 	| unpackagePackage |
-	unpackagePackage := Smalltalk organization packageNamed: RPackage defaultPackageName.
+	unpackagePackage := self packageOrganizer packageNamed: RPackage defaultPackageName.
 	"The unpackage package should not have any defined class or extended classes"
 	self assertEmpty: unpackagePackage classes
 ]

--- a/src/Ring-OldChunkImporter/RingChunkImporter.class.st
+++ b/src/Ring-OldChunkImporter/RingChunkImporter.class.st
@@ -19,7 +19,7 @@ Class {
 RingChunkImporter class >> example [
 	| internalStream |
 	internalStream := (String new: 1000) writeStream.
-	Smalltalk organization
+	self packageOrganizer
 		fileOutCategory: 'Ring-Deprecated-ChunkImporter-Base'
 		on: internalStream.
 	(RingChunkImporter fromStream: internalStream contents readStream)

--- a/src/SUnit-Core/ClassFactoryForTestCase.class.st
+++ b/src/SUnit-Core/ClassFactoryForTestCase.class.st
@@ -128,7 +128,7 @@ ClassFactoryForTestCase >> deleteClasses [
 { #category : #cleaning }
 ClassFactoryForTestCase >> deletePackage [
 
-	Smalltalk organization removeCategoriesMatching: self packageName , '-*'
+	self packageOrganizer removeCategoriesMatching: self packageName , '-*'
 ]
 
 { #category : #cleaning }

--- a/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
@@ -15,12 +15,6 @@ ClassFactoryForTestCaseTest class >> lastStoredRun [
 	^ ((Dictionary new) add: (#passed->((Set new) add: #testDefaultCategoryCleanUp; add: #testPackageCleanUp; add: #testSingleClassCreation; add: #testClassCreationInDifferentCategories; add: #testClassFastCreationInDifferentCategories; add: #testMultipleClassCreation; add: #testSingleClassFastCreation; yourself)); add: (#timeStamp->'22 November 2008 10:11:35 pm'); add: (#failures->((Set new))); add: (#errors->((Set new))); yourself)
 ]
 
-{ #category : #accessing }
-ClassFactoryForTestCaseTest >> packageOrganizer [
-
-	^ Smalltalk organization
-]
-
 { #category : #running }
 ClassFactoryForTestCaseTest >> setUp [
 	super setUp.

--- a/src/SUnit-UI/TestRunner.class.st
+++ b/src/SUnit-UI/TestRunner.class.st
@@ -599,7 +599,7 @@ TestRunner >> findClassesForPackages: aCollection [
 		ifTrue: [ ^ self baseClass withAllSubclasses asSet ].
 	items := aCollection
 		flatCollect: [ :category |
-			((Smalltalk organization listAtCategoryNamed: category)
+			((self packageOrganizer listAtCategoryNamed: category)
 				collect: [ :each | Smalltalk globals at: each ])
 				select: [ :each | each includesBehavior: self baseClass ] ].
 	^ items asSet
@@ -613,7 +613,7 @@ TestRunner >> findPackages [
 		each category ifNotNil: [ :category |
 			visible add: category ] ].
 	^ Array streamContents: [ :stream |
-		Smalltalk organization categories do: [ :each |
+		self packageOrganizer categories do: [ :each |
 			((visible includes: each)
 					and: [ packagePattern isNil or: [ (packagePattern matchesIn: each) isNotEmpty]])
 				ifTrue: [ stream nextPut: each ] ] ]

--- a/src/Shift-ClassInstaller-Tests/ShAnonymousClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShAnonymousClassInstallerTest.class.st
@@ -16,5 +16,5 @@ ShAnonymousClassInstallerTest >> testSubclasses [
 	self assert: aSubClass superclass equals: Point.
 	self deny: (Smalltalk hasClassNamed: #AnotherPoint).
 
-	self assert: (Smalltalk organization packageOfClassNamed: #AnotherPoint) equals: nil
+	self assert: (self packageOrganizer packageOfClassNamed: #AnotherPoint) equals: nil
 ]

--- a/src/Slot-Tests/SlotClassBuilderTest.class.st
+++ b/src/Slot-Tests/SlotClassBuilderTest.class.st
@@ -104,7 +104,7 @@ SlotClassBuilderTest >> tearDown [
 		cleanUpTrait: TOne;
 		cleanUpTrait: TTwo.
 
-	Smalltalk organization removeCategory: self aCategory.
+	self packageOrganizer removeCategory: self aCategory.
 	(RPackageOrganizer default
 		packageNamed: self aCategory
 		ifAbsent: [ ^ self ])

--- a/src/System-Settings-Tests/SettingBrowserTest.class.st
+++ b/src/System-Settings-Tests/SettingBrowserTest.class.st
@@ -21,7 +21,7 @@ SettingBrowserTest >> testOpening [
 SettingBrowserTest >> testOpeningOnPackage [
 
 	settingBrowser := SettingBrowser new
-		                  changePackageSet: { (Smalltalk organization packageNamed: 'System-Settings-Core') };
+		                  changePackageSet: { (self packageOrganizer packageNamed: 'System-Settings-Core') };
 		                  open.
 	settingBrowser close
 ]

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1531,7 +1531,7 @@ SmalltalkImage >> removeEmptyMessageCategories [
 
 	self garbageCollect.
 	SystemNavigation default allBehaviorsDo: [ :class | class removeEmptyProtocols ].
-	Smalltalk organization removeEmptyPackages
+	self packageOrganizer removeEmptyPackages
 ]
 
 { #category : #shrinking }

--- a/src/Tool-DependencyAnalyser-Tests/DATarjanAlgorithmTest.class.st
+++ b/src/Tool-DependencyAnalyser-Tests/DATarjanAlgorithmTest.class.st
@@ -49,7 +49,7 @@ DATarjanAlgorithmTest >> testNoOutgoingDependenciesAfterTarjan [
 	"test if we have 0 outgoing dependencies in each SCC after the algorithm"
 
 	| aRelation aCollection sccs |
-	aCollection := OrderedCollection withAll: (Smalltalk organization packages
+	aCollection := OrderedCollection withAll: (self packageOrganizer packages
 			                select: [ :package | '*Collections*' match: package packageName asString ]
 			                thenCollect: [ :package | package packageName ]).
 	aRelation := DAPackageRelationGraph onPackages: (aCollection collect: [ :each | DAPackage on: (RPackageSet named: each) ]).

--- a/src/Tool-DependencyAnalyser-UI/DAAddPackagePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAAddPackagePresenter.class.st
@@ -89,7 +89,7 @@ DAAddPackagePresenter >> selectedItemsFromPackageList [
 { #category : #accessing }
 DAAddPackagePresenter >> systemPackages [
 
-	^ (Smalltalk organization packages collect: [ :package | package packageName asString ]) asSortedCollection
+	^ (self packageOrganizer packages collect: [ :package | package packageName asString ]) asSortedCollection
 ]
 
 { #category : #protocol }

--- a/src/Tool-DependencyAnalyser-UI/DACycleDetectionTreePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DACycleDetectionTreePresenter.class.st
@@ -17,7 +17,7 @@ Class {
 { #category : #'instance creation' }
 DACycleDetectionTreePresenter class >> onPackagesMatch: match [
 	^ (self onPackagesNamed:
-			(Smalltalk organization packages
+			(self packageOrganizer packages
 				select: [ :package | match match: package packageName asString ]
 				thenCollect: [ :package | package packageName ]) )
 ]
@@ -32,7 +32,7 @@ DACycleDetectionTreePresenter class >> onPackagesNamed: aCollection [
 { #category : #'instance creation' }
 DACycleDetectionTreePresenter class >> system [
 	^ self onPackagesNamed:
-		(Smalltalk organization packages collect: [ :package | package packageName asString ])
+		(self packageOrganizer packages collect: [ :package | package packageName asString ])
 ]
 
 { #category : #accessing }

--- a/src/Tool-DependencyAnalyser-UI/DADependencyTreePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DADependencyTreePresenter.class.st
@@ -54,7 +54,7 @@ DADependencyTreePresenter class >> onPackages: aCollection [
 { #category : #examples }
 DADependencyTreePresenter class >> onPackagesMatch: match [
 
-	^ self onPackagesNamed: (Smalltalk organization packages
+	^ self onPackagesNamed: (self packageOrganizer packages
 			   select: [ :package | match match: package packageName asString ]
 			   thenCollect: [ :package | package packageName ])
 ]
@@ -276,7 +276,7 @@ DADependencyTreePresenter >> nodesFor: anItemList [
 { #category : #accessing }
 DADependencyTreePresenter >> packagesEntryCompletion [
 	| applicants |
-	applicants := (Smalltalk organization packages collect: [ :package | package packageName asString ]).
+	applicants := (self packageOrganizer packages collect: [ :package | package packageName asString ]).
 
 	^ EntryCompletion new
 				dataSourceBlock: [:currText | applicants];

--- a/src/Tool-DependencyAnalyser-UI/DAPackageAnalyzerPresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAPackageAnalyzerPresenter.class.st
@@ -35,7 +35,7 @@ DAPackageAnalyzerPresenter class >> selectedPackagesFrom: aBuilder [
 
 { #category : #examples }
 DAPackageAnalyzerPresenter class >> systemPackages [
-	^ Smalltalk organization packages collect: [ :package | package packageName asString ]
+	^ self packageOrganizer packages collect: [ :package | package packageName asString ]
 ]
 
 { #category : #accessing }

--- a/src/Tool-DependencyAnalyser-UI/DAPackageDependenciesPresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAPackageDependenciesPresenter.class.st
@@ -15,7 +15,7 @@ DAPackageDependenciesPresenter class >> collections [
 { #category : #'instance creation' }
 DAPackageDependenciesPresenter class >> onPackagesMatch: match [
 	^ (self onPackagesNamed:
-			(Smalltalk organization packages
+			(self packageOrganizer packages
 				select: [ :package | match match: package packageName asString ]
 				thenCollect: [ :package | package packageName ]) )
 ]

--- a/src/Tool-DependencyAnalyser-UI/DAWelcomePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAWelcomePresenter.class.st
@@ -44,7 +44,7 @@ DAWelcomePresenter >> initialExtent [
 DAWelcomePresenter >> initializePresenters [
 
 	choosePresenter := SpChooserPresenter new
-		sourceItems: Smalltalk organization packages;
+		sourceItems: self packageOrganizer packages;
 		displayBlock: #packageName;
 		yourself.
 

--- a/src/Tool-DependencyAnalyser/DADependencyChecker.class.st
+++ b/src/Tool-DependencyAnalyser/DADependencyChecker.class.st
@@ -57,7 +57,7 @@ DADependencyChecker >> computeImageDependencies [
 		analysisRunString: 'Pharo image dependencies';
 		imageVersion: SystemVersion current.
 	visited := Set new.
-	Smalltalk organization packageNames do: [ :packageName | self computeDependenciesOf: packageName visitedPackages: visited ].
+	self packageOrganizer packageNames do: [ :packageName | self computeDependenciesOf: packageName visitedPackages: visited ].
 	^ report
 ]
 

--- a/src/Tool-DependencyAnalyser/DAMessageSendAnalyzer.class.st
+++ b/src/Tool-DependencyAnalyser/DAMessageSendAnalyzer.class.st
@@ -43,13 +43,13 @@ DAMessageSendAnalyzer >> implementedMessages [
 
 	^ (self packageStaticDependencies
 		   add: self packageName;
-		   yourself) flatCollect: [ :name | (Smalltalk organization packageNamed: name) selectors ]
+		   yourself) flatCollect: [ :name | (self packageOrganizer packageNamed: name) selectors ]
 ]
 
 { #category : #computing }
 DAMessageSendAnalyzer >> implementedMessagesWithManuallyResolvedDependencies [
 
-	^ (self manuallyResolvedDependencies flatCollect: [ :name | (Smalltalk organization packageNamed: name) selectors ] as: Set)
+	^ (self manuallyResolvedDependencies flatCollect: [ :name | (self packageOrganizer packageNamed: name) selectors ] as: Set)
 		  addAll: self implementedMessages;
 		  yourself
 ]
@@ -79,7 +79,7 @@ DAMessageSendAnalyzer >> missingMethods [
 DAMessageSendAnalyzer >> missingMethodsImplementedIn: aPackageName [
 
 	| rPackage |
-	rPackage := Smalltalk organization packageNamed: aPackageName ifAbsent: [
+	rPackage := self packageOrganizer packageNamed: aPackageName ifAbsent: [
 		            DAUnknownManuallyResolvedPackage signalOn: aPackageName.
 		            ^ self missingMethods ].
 

--- a/src/Tool-DependencyAnalyser/DAPackageCycleDetector.class.st
+++ b/src/Tool-DependencyAnalyser/DAPackageCycleDetector.class.st
@@ -50,7 +50,7 @@ DAPackageCycleDetector class >> onPackagesNamed: aCollection [
 { #category : #'instance creation' }
 DAPackageCycleDetector class >> system [
 	^ (self onPackagesNamed:
-		(Smalltalk organization packages collect: [ :package | package packageName asString ])) runAlgorithm
+		(self packageOrganizer packages collect: [ :package | package packageName asString ])) runAlgorithm
 ]
 
 { #category : #adding }

--- a/src/Tool-DependencyAnalyser/DAPackageRelationGraph.class.st
+++ b/src/Tool-DependencyAnalyser/DAPackageRelationGraph.class.st
@@ -484,11 +484,9 @@ DAPackageRelationGraph >> successors: aPackage [
 { #category : #queries }
 DAPackageRelationGraph >> systemPackageContaining: aClass [
 
-	| packageName |
-	packageName := (Smalltalk organization packageOf: aClass) packageName.
-	^ packageName
+	^ (self packageOrganizer packageOf: aClass) packageName
 		  ifNil: [ self error: 'Package for ' , aClass name , ' not found.' ]
-		  ifNotNil: [ DAPackage on: (RPackageSet named: packageName asString) ]
+		  ifNotNil: [ :packageName | DAPackage on: (RPackageSet named: packageName asString) ]
 ]
 
 { #category : #computing }

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -211,7 +211,7 @@ ImageCleaner >> removeEmptyCategories [
 	"Remove empty categories, which are not in MC packages, because MC does
 	not do this (this script does not make packages dirty)"
 
-	Smalltalk organization removeEmptyPackages.
+	self packageOrganizer removeEmptyPackages.
 	Smalltalk allClassesAndTraitsDo: [ :class |
 		class removeEmptyProtocols.
 		class class removeEmptyProtocols ]

--- a/src/TraitsV2-Tests/T2TraitWithPackagesTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitWithPackagesTest.class.st
@@ -20,13 +20,13 @@ T2TraitWithPackagesTest >> packageName2 [
 { #category : #tests }
 T2TraitWithPackagesTest >> packageUnderTest [
 
-	^ Smalltalk organization packageNamed: self packageName
+	^ self packageOrganizer packageNamed: self packageName
 ]
 
 { #category : #tests }
 T2TraitWithPackagesTest >> packageUnderTest2 [
 
-	^ Smalltalk organization packageNamed: self packageName2
+	^ self packageOrganizer packageNamed: self packageName2
 ]
 
 { #category : #tests }
@@ -156,15 +156,15 @@ T2TraitWithPackagesTest >> testPackageOfMethodFromTraitsRemoved [
 	self assert: (t1 >> #m1) package equals: self packageUnderTest.
 	self assert: (t2 >> #m1) package equals: self packageUnderTest.
 
-	self assert: (Smalltalk organization packageDefiningOrExtendingSelector: #m1 inClassNamed: #T1) equals: self packageUnderTest.
+	self assert: (self packageOrganizer packageDefiningOrExtendingSelector: #m1 inClassNamed: #T1) equals: self packageUnderTest.
 
 	t1 removeSelector: #m1.
 
 	self assert: (t1 protocolOfSelector: #m1) isNil.
 	self assert: (t2 protocolOfSelector: #m1) isNil.
 
-	self assert: (Smalltalk organization packageDefiningOrExtendingSelector: #m1 inClassNamed: #T1) isNil.
-	self assert: (Smalltalk organization packageDefiningOrExtendingSelector: #m1 inClassNamed: #T2) isNil
+	self assert: (self packageOrganizer packageDefiningOrExtendingSelector: #m1 inClassNamed: #T1) isNil.
+	self assert: (self packageOrganizer packageDefiningOrExtendingSelector: #m1 inClassNamed: #T2) isNil
 ]
 
 { #category : #tests }
@@ -185,18 +185,18 @@ T2TraitWithPackagesTest >> testPackageOfRemovedTrait [
 	self assert: t1 package equals: self packageUnderTest.
 	self assert: t2 package equals: self packageUnderTest2.
 
-	self assert: (Smalltalk organization packageOfClassNamed: #T1) equals: self packageUnderTest.
-	self assert: (Smalltalk organization packageOfClassNamed: #T2) equals: self packageUnderTest2.
+	self assert: (self packageOrganizer packageOfClassNamed: #T1) equals: self packageUnderTest.
+	self assert: (self packageOrganizer packageOfClassNamed: #T2) equals: self packageUnderTest2.
 
 	t2 removeFromSystem.
 
-	self assert: (Smalltalk organization packageOfClassNamed: #T1) equals: self packageUnderTest.
-	self assert: (Smalltalk organization packageOfClassNamed: #T2) isNil.
+	self assert: (self packageOrganizer packageOfClassNamed: #T1) equals: self packageUnderTest.
+	self assert: (self packageOrganizer packageOfClassNamed: #T2) isNil.
 
 	t1 removeFromSystem.
 
-	self assert: (Smalltalk organization packageOfClassNamed: #T1) isNil.
-	self assert: (Smalltalk organization packageOfClassNamed: #T2) isNil
+	self assert: (self packageOrganizer packageOfClassNamed: #T1) isNil.
+	self assert: (self packageOrganizer packageOfClassNamed: #T2) isNil
 ]
 
 { #category : #tests }


### PR DESCRIPTION
To access the RPackageOrganizer of the system we had a lot of ways in the past. I removed multiple of them to replace them by `Smalltalk organization`. But referencing globals is not that good. It's hard to find the best solution, but there is already the concept of #environment in the system and the environment knows the default package organizer. So we can just go through this environment to get it, thus reducing the references to a global. 

Under the hood it will still kinda access a global, but when the environment will be managed well, the package organizer will automatically work well too with this change.