### PR TITLE
Remove some references to `RPackage class>>organizer`

### DIFF
--- a/src/Calypso-NavigationModel-Tests/ClyItemNameFilterTest.class.st
+++ b/src/Calypso-NavigationModel-Tests/ClyItemNameFilterTest.class.st
@@ -40,6 +40,6 @@ ClyItemNameFilterTest >> testFilterPackageWithName [
 
 	filter := ClyItemNameFilter substringPattern: 'kernel'.
 
-	self assert: (filter matches: (RPackage organizer packageNamed: #Kernel)).
-	self deny: (filter matches: (RPackage organizer packageNamed: #Jobs))
+	self assert: (filter matches: (self packageOrganizer packageNamed: #Kernel)).
+	self deny: (filter matches: (self packageOrganizer packageNamed: #Jobs))
 ]

--- a/src/Clap-Commands-Pharo/ClapTestRunner.class.st
+++ b/src/Clap-Commands-Pharo/ClapTestRunner.class.st
@@ -71,7 +71,7 @@ ClapTestRunner >> packagePatterns [
 ClapTestRunner >> packages [
 	^ self packagePatterns
 		flatCollect: [ :regex |
-			RPackage organizer packages
+			self packageOrganizer packages
 				select: [ :package | regex matches: package name ]]
 		as: Set
 ]

--- a/src/DrTests-CommentsToTests/DTCommentToTestPlugin.class.st
+++ b/src/DrTests-CommentsToTests/DTCommentToTestPlugin.class.st
@@ -47,8 +47,8 @@ DTCommentToTestPlugin >> itemsToBeAnalysedFor: packagesSelected [
 
 { #category : #api }
 DTCommentToTestPlugin >> packagesAvailableForAnalysis [
-	^ RPackage organizer packages
-		select: [ :p | p definedClasses anySatisfy: [ :c | c isTestCase not ] ]
+
+	^ self packageOrganizer packages select: [ :p | p definedClasses anySatisfy: [ :c | c isTestCase not ] ]
 ]
 
 { #category : #accessing }

--- a/src/DrTests-TestCoverage-Tests/DTTestCoverageTest.class.st
+++ b/src/DrTests-TestCoverage-Tests/DTTestCoverageTest.class.st
@@ -13,10 +13,9 @@ Class {
 DTTestCoverageTest >> setUp [
 
 	super setUp.
-	package := RPackage organizer
-		packageNamed: 'DrTests-TestCoverage-Tests-Mocks'.
+	package := self packageOrganizer packageNamed: 'DrTests-TestCoverage-Tests-Mocks'.
 	"The test classes are in the same package as classes under test."
-	pluginConfiguration := DTPluginConfiguration items: {package} packages: {package}.
+	pluginConfiguration := DTPluginConfiguration items: { package } packages: { package }.
 	plugin := DTTestCoveragePlugin new
 ]
 

--- a/src/DrTests-TestCoverage/DTTestCoveragePlugin.class.st
+++ b/src/DrTests-TestCoverage/DTTestCoveragePlugin.class.st
@@ -56,8 +56,8 @@ DTTestCoveragePlugin >> firstListLabel [
 
 { #category : #api }
 DTTestCoveragePlugin >> itemsToBeAnalysedFor: packagesSelected [
-	^ RPackage organizer packages
-		select: [ :p | p definedClasses anySatisfy: [ :c | c isTestCase not ] ]
+
+	^ self packageOrganizer packages select: [ :p | p definedClasses anySatisfy: [ :c | c isTestCase not ] ]
 ]
 
 { #category : #accessing }

--- a/src/DrTests-Tests/DrTestsTestRunnerTest.class.st
+++ b/src/DrTests-Tests/DrTestsTestRunnerTest.class.st
@@ -17,18 +17,14 @@ Class {
 
 { #category : #running }
 DrTestsTestRunnerTest >> setUp [
+
 	super setUp.
-	package := RPackage organizer
-		packageNamed: 'DrTests-TestCoverage-Tests-Mocks'.
-	testToReRun := DTCoverageMockTest
-		selector: #testMethod1forMock.
+	package := self packageOrganizer packageNamed: 'DrTests-TestCoverage-Tests-Mocks'.
+	testToReRun := DTCoverageMockTest selector: #testMethod1forMock.
 	testCase := DTCoverageMockTest.
 	conf := DTPluginConfiguration
-		items:
-			({package}
-				flatCollect:
-					[ :p | p definedClasses select: [ :c | c allSuperclasses includes: TestCase ] ])
-		packages: {package}.
+		        items: ({ package } flatCollect: [ :p | p definedClasses select: [ :c | c allSuperclasses includes: TestCase ] ])
+		        packages: { package }.
 	reRunconf := DTReRunConfiguration new.
 	plugin := DTTestsRunnerPlugin new
 ]

--- a/src/DrTests-TestsProfiling-Tests/DTTestProfilingTest.class.st
+++ b/src/DrTests-TestsProfiling-Tests/DTTestProfilingTest.class.st
@@ -12,12 +12,12 @@ Class {
 
 { #category : #running }
 DTTestProfilingTest >> setUp [
+
 	super setUp.
-	plugin := DTTestsProfilingPlugin  new.
-	package := RPackage organizer
-		packageNamed: 'DrTests-TestCoverage-Tests-Mocks'.
-	classes := plugin itemsToBeAnalysedFor: {package}.
-	dTconf := DTPluginConfiguration items: classes packages: {package}
+	plugin := DTTestsProfilingPlugin new.
+	package := self packageOrganizer packageNamed: 'DrTests-TestCoverage-Tests-Mocks'.
+	classes := plugin itemsToBeAnalysedFor: { package }.
+	dTconf := DTPluginConfiguration items: classes packages: { package }
 ]
 
 { #category : #running }

--- a/src/DrTests/DrTestsPlugin.class.st
+++ b/src/DrTests/DrTestsPlugin.class.st
@@ -101,8 +101,8 @@ DrTestsPlugin >> itemsToBeAnalysedFor: packagesSelected [
 
 { #category : #api }
 DrTestsPlugin >> packagesAvailableForAnalysis [
-	^ RPackage organizer packages
-		select: [ :p | p definedClasses anySatisfy: [ :c | c isTestCase ] ]
+
+	^ self packageOrganizer packages select: [ :p | p definedClasses anySatisfy: [ :c | c isTestCase ] ]
 ]
 
 { #category : #api }

--- a/src/Epicea/EpCategoryChange.class.st
+++ b/src/Epicea/EpCategoryChange.class.st
@@ -27,7 +27,10 @@ EpCategoryChange class >> named: aName packageName: aPackageName [
 
 { #category : #private }
 EpCategoryChange class >> packageNameFromCategoryName: aName [
-	^ (RPackage organizer packageMatchingExtensionName: aName) ifNotNil: [ :package | package name ] ifNil: [ aName ]
+
+	^ (self packageOrganizer packageMatchingExtensionName: aName)
+		  ifNotNil: [ :package | package name ]
+		  ifNil: [ aName ]
 ]
 
 { #category : #accessing }

--- a/src/Epicea/EpPlatform.class.st
+++ b/src/Epicea/EpPlatform.class.st
@@ -19,7 +19,7 @@ EpPlatform class >> current [
 { #category : #convenience }
 EpPlatform >> packageNameFor: aClassOrTrait [
 
-	^ (RPackage organizer packageOfClassNamed: aClassOrTrait name)
-		ifNotNil: [ :package | package name ]
-		ifNil: [ 'nil' ]
+	^ (self packageOrganizer packageOfClassNamed: aClassOrTrait name)
+		  ifNotNil: [ :package | package name ]
+		  ifNil: [ 'nil' ]
 ]

--- a/src/EpiceaBrowsers/EpDashboardPresenter.class.st
+++ b/src/EpiceaBrowsers/EpDashboardPresenter.class.st
@@ -150,8 +150,8 @@ EpDashboardPresenter >> openSettingsBrowser [
 
 	| settingsBrowser settingsWindow |
 	settingsBrowser := SettingBrowser new
-		changePackageSet: (RPackage organizer packageNamed: 'EpiceaBrowsers') asOrderedCollection;
-		yourself.
+		                   changePackageSet: (self packageOrganizer packageNamed: 'EpiceaBrowsers') asOrderedCollection;
+		                   yourself.
 	settingsWindow := settingsBrowser open.
 	settingsWindow position: Display extent - settingsWindow extent // 2.
 	settingsBrowser expandAll

--- a/src/FuzzyMatcher-Tests/FuzzyMatcherExample.class.st
+++ b/src/FuzzyMatcher-Tests/FuzzyMatcherExample.class.st
@@ -52,12 +52,12 @@ FuzzyMatcherExample class >> exampleClasses [
 
 { #category : #examples }
 FuzzyMatcherExample class >> examplePackages [
-	<example>
 
+	<example>
 	^ self new
-		pattern: '-st';
-		elements: (RPackage organizer packages collect: [:each | each name] );
-		open
+		  pattern: '-st';
+		  elements: (self packageOrganizer packages collect: [ :each | each name ]);
+		  open
 ]
 
 { #category : #examples }

--- a/src/JenkinsTools-Core/HDTestReport.class.st
+++ b/src/JenkinsTools-Core/HDTestReport.class.st
@@ -50,7 +50,8 @@ HDTestReport class >> runClasses: aCollectionOfClasses named: aString [
 
 { #category : #running }
 HDTestReport class >> runPackage: aString [
-	^ self runClasses: (RPackage organizer packageNamed: aString) definedClasses named: aString
+
+	^ self runClasses: (self packageOrganizer packageNamed: aString) definedClasses named: aString
 ]
 
 { #category : #running }

--- a/src/JenkinsTools-Core/TestCommandLineHandler.class.st
+++ b/src/JenkinsTools-Core/TestCommandLineHandler.class.st
@@ -45,34 +45,31 @@ TestCommandLineHandler >> activate [
 
 { #category : #accessing }
 TestCommandLineHandler >> addPackagesMatching: aString to: aSet [
+
 	| regex |
-	
-	[ regex := aString asRegex ] 
-		on: Error do: [ ].
+	[ regex := aString asRegex ]
+		on: Error
+		do: [  ].
 	regex ifNotNil: [ ^ self addPackagesMatchingRegex: regex to: aSet ].
-	
-	(aString includes: $*)
-		ifTrue: [ ^ self addPackagesMatchingGlob: aString to: aSet ].
-	
+
+	(aString includes: $*) ifTrue: [ ^ self addPackagesMatchingGlob: aString to: aSet ].
+
 	"exact match, and just those who actually have classes inside (to avoid 
 	 super-package duplications)"
-	((RPackage organizer includesPackageNamed: aString) 
-		and: [ (RPackage organizer packageNamed: aString) definedClasses notEmpty ])
-		ifTrue: [ aSet add: aString ]
+	((self packageOrganizer includesPackageNamed: aString) and: [ (self packageOrganizer packageNamed: aString) definedClasses notEmpty ]) ifTrue: [
+		aSet add: aString ]
 ]
 
 { #category : #accessing }
 TestCommandLineHandler >> addPackagesMatchingGlob: aGlobString to: aSet [
-	RPackage organizer packageNames do: [ :packageName|
-		(aGlobString match: packageName)
-			ifTrue: [ aSet add: packageName ]]
+
+	self packageOrganizer packageNames do: [ :packageName | (aGlobString match: packageName) ifTrue: [ aSet add: packageName ] ]
 ]
 
 { #category : #accessing }
 TestCommandLineHandler >> addPackagesMatchingRegex: aRegex to: aSet [
-	RPackage organizer packageNames do: [ :packageName|
-		(aRegex matches: packageName)
-			ifTrue: [ aSet add: packageName ]]
+
+	self packageOrganizer packageNames do: [ :packageName | (aRegex matches: packageName) ifTrue: [ aSet add: packageName ] ]
 ]
 
 { #category : #private }

--- a/src/JenkinsTools-ExtraReports/HDCoverageReport.class.st
+++ b/src/JenkinsTools-ExtraReports/HDCoverageReport.class.st
@@ -14,13 +14,11 @@ Class {
 
 { #category : #private }
 HDCoverageReport >> addTestsIn: aTestAsserter to: aSet [
-	(aTestAsserter isKindOf: TestSuite) ifTrue: [
-		aTestAsserter tests
-			do: [ :each | self addTestsIn: each to: aSet ] ].
+
+	(aTestAsserter isKindOf: TestSuite) ifTrue: [ aTestAsserter tests do: [ :each | self addTestsIn: each to: aSet ] ].
 	(aTestAsserter isKindOf: TestCase) ifTrue: [
 		(aTestAsserter class respondsTo: #packageNamesUnderTest) ifTrue: [
-			aTestAsserter class packageNamesUnderTest
-				do: [ :each | aSet add: (RPackage organizer packageNamed: each) ] ] ].
+			aTestAsserter class packageNamesUnderTest do: [ :each | aSet add: (self packageOrganizer packageNamed: each) ] ] ].
 	^ aSet
 ]
 

--- a/src/Kernel-Tests-Extended/ClassTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassTest.class.st
@@ -71,7 +71,7 @@ ClassTest >> setUp [
 ClassTest >> tearDown [
 	self deleteClass.
 	{self unclassifiedCategory. self categoryNameForTemporaryClasses} do: [:category|
-			RPackage organizer unregisterPackageNamed: category].
+			self packageOrganizer unregisterPackageNamed: category].
 	super tearDown
 ]
 

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -247,8 +247,9 @@ CompiledMethodTest >> shouldNotImplementMethod [
 
 { #category : #running }
 CompiledMethodTest >> tearDown [
-	RPackage organizer unregisterPackageNamed: self categoryNameForTemporaryClasses.
-	class ifNotNil: [ class removeFromSystem].
+
+	self packageOrganizer unregisterPackageNamed: self categoryNameForTemporaryClasses.
+	class ifNotNil: [ class removeFromSystem ].
 	super tearDown
 ]
 

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -770,13 +770,11 @@ ClassDescription >> notifyRepackage: selector method: compiledMethod oldProtocol
 	| oldPackage newPackage |
 	newProtocol = oldProtocol ifTrue: [ ^ self ].
 
-	"This indirection is because we need to abstract RPackage from the kernel"
-	self class environment at: #RPackage ifPresent: [ :rPackageClass |
-		newPackage := rPackageClass organizer packageForProtocol: newProtocol name inClass: self.
-		oldPackage := rPackageClass organizer packageForProtocol: oldProtocol name inClass: self.
+	newPackage := self packageOrganizer packageForProtocol: newProtocol name inClass: self.
+	oldPackage := self packageOrganizer packageForProtocol: oldProtocol name inClass: self.
 
-		"Announce recategorization"
-		newPackage = oldPackage ifFalse: [ SystemAnnouncer uniqueInstance methodRepackaged: compiledMethod from: oldPackage to: newPackage ] ].
+	"Announce recategorization"
+	newPackage = oldPackage ifFalse: [ SystemAnnouncer uniqueInstance methodRepackaged: compiledMethod from: oldPackage to: newPackage ].
 
 	SystemAnnouncer uniqueInstance methodRecategorized: compiledMethod oldProtocol: oldProtocol
 ]

--- a/src/RPackage-Core/ClassDescription.extension.st
+++ b/src/RPackage-Core/ClassDescription.extension.st
@@ -8,7 +8,7 @@ ClassDescription >> definedSelectors [
 { #category : #'*RPackage-Core' }
 ClassDescription >> extendingPackages [
 	"the extending packages of a class are the packages that extend it."
-	^ RPackage organizer extendingPackagesOf: self
+	^ self packageOrganizer extendingPackagesOf: self
 ]
 
 { #category : #'*RPackage-Core' }
@@ -37,7 +37,8 @@ ClassDescription >> isExtendedInPackage: aPackage [
 
 { #category : #'*RPackage-Core' }
 ClassDescription >> package [
-	^ RPackage organizer packageOf: self
+
+	^ self packageOrganizer packageOf: self
 ]
 
 { #category : #'*RPackage-Core' }

--- a/src/RPackage-Core/CompiledCode.extension.st
+++ b/src/RPackage-Core/CompiledCode.extension.st
@@ -2,7 +2,8 @@ Extension { #name : #CompiledCode }
 
 { #category : #'*RPackage-Core' }
 CompiledCode >> package [
-	^ self packageFromOrganizer: RPackage organizer
+
+	^ self packageFromOrganizer: self packageOrganizer
 ]
 
 { #category : #'*RPackage-Core' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -212,55 +212,35 @@ RPackage >> addClassDefinitionName: aClassName toClassTag: aSymbol [
 { #category : #'class tags' }
 RPackage >> addClassTag: aSymbol [
 	"Add the class tag from the receiver, if already added do nothing."
-	| tagName newTag |
 
+	| tagName newTag |
 	"strip package name if needed"
 	tagName := self toTagName: aSymbol.
 
-	^ self
-		classTagNamed: tagName
-		ifAbsent: [
-			self class organizer
-				validateCanBeAddedPackage: self
-				tagName: tagName.
-			newTag := self basicAddClassTag: tagName.
-			SystemAnnouncer uniqueInstance classTagAdded: tagName inPackage: self.
-			^newTag]
+	^ self classTagNamed: tagName ifAbsent: [
+		  self packageOrganizer validateCanBeAddedPackage: self tagName: tagName.
+		  newTag := self basicAddClassTag: tagName.
+		  SystemAnnouncer uniqueInstance classTagAdded: tagName inPackage: self.
+		  ^ newTag ]
 ]
 
 { #category : #'add method - compiled method' }
 RPackage >> addMethod: aCompiledMethod [
 	"Add the method to the receiver as a defined method if the class is  defined in it, else as an extension."
-	| methodClass |
 
+	| methodClass |
 	methodClass := aCompiledMethod methodClass.
-	(self includesClass: methodClass )
+	(self includesClass: methodClass)
 		ifTrue: [
 			methodClass isMeta
-				ifTrue: [
-					(metaclassDefinedSelectors
-						at: methodClass instanceSide name
-						ifAbsentPut: [ Set new ])
-						add: aCompiledMethod selector]
-				ifFalse: [
-					(classDefinedSelectors
-						at: methodClass name
-						ifAbsentPut: [ Set new ])
-						add: aCompiledMethod selector ] ]
-		ifFalse:  [
+				ifTrue: [ (metaclassDefinedSelectors at: methodClass instanceSide name ifAbsentPut: [ Set new ]) add: aCompiledMethod selector ]
+				ifFalse: [ (classDefinedSelectors at: methodClass name ifAbsentPut: [ Set new ]) add: aCompiledMethod selector ] ]
+		ifFalse: [
 			methodClass isMeta
-				ifTrue: [
-					(metaclassExtensionSelectors
-						at: methodClass instanceSide name
-						ifAbsentPut: [ Set new ])
-						add: aCompiledMethod selector.]
-				ifFalse: [
-					(classExtensionSelectors
-						at: methodClass name
-						ifAbsentPut: [ Set new ])
-						add: aCompiledMethod selector].
-				"we added a method extension so the receiver is an extending package of the class"
-				self organizer registerExtendingPackage: self forClass: methodClass ].
+				ifTrue: [ (metaclassExtensionSelectors at: methodClass instanceSide name ifAbsentPut: [ Set new ]) add: aCompiledMethod selector ]
+				ifFalse: [ (classExtensionSelectors at: methodClass name ifAbsentPut: [ Set new ]) add: aCompiledMethod selector ].
+			"we added a method extension so the receiver is an extending package of the class"
+			self packageOrganizer registerExtendingPackage: self forClass: methodClass ].
 
 	^ aCompiledMethod
 ]
@@ -545,21 +525,15 @@ RPackage >> definesOrExtendsClass: aClass [
 
 { #category : #converting }
 RPackage >> demoteToTagInPackageNamed: aString [
-	| newRPackage |
 
+	| newRPackage |
 	aString = self name ifTrue: [ ^ self ].
 
 	self unregister.
-	newRPackage := self class organizer
-		packageNamed: aString
-		ifAbsent:  [ (self class named: aString) register ].
+	newRPackage := self packageOrganizer packageNamed: aString ifAbsent: [ (self class named: aString) register ].
 	newRPackage importPackage: self.
 
-	newRPackage classes do: [ :each |
-		SystemAnnouncer uniqueInstance
-			classRepackaged: each
-			from: self
-			to: newRPackage ]
+	newRPackage classes do: [ :each | SystemAnnouncer uniqueInstance classRepackaged: each from: self to: newRPackage ]
 ]
 
 { #category : #properties }
@@ -1098,21 +1072,22 @@ RPackage >> propertyAt: propName put: propValue [
 
 { #category : #register }
 RPackage >> register [
-	self organizer registerPackage: self
+
+	self packageOrganizer registerPackage: self
 ]
 
 { #category : #'private - register' }
 RPackage >> registerClass: aClass [
 	"Private method that declares the mapping between a class and its package."
-	self organizer
-		registerPackage: self forClass: aClass
+
+	self packageOrganizer registerPackage: self forClass: aClass
 ]
 
 { #category : #'private - register' }
 RPackage >> registerClassName: aClassNameSymbol [
 	"Private method that declares the mapping between a class and its package."
-	self organizer
-		registerPackage: self forClassName: aClassNameSymbol
+
+	self packageOrganizer registerPackage: self forClassName: aClassNameSymbol
 ]
 
 { #category : #'private - register' }
@@ -1251,7 +1226,7 @@ RPackage >> removeFromSystem [
 	extendedClasses do: [ :class | class removeProtocolIfEmpty: ('*' , name) asSymbol ].
 	"This is probably not the best place to unregister from the SystemOrganizer but later it's harder to find the categories. 
 	But anyway, SystemOrganizer should be removed in the next few months and we will be able to remove this code."
-	categories do: [ :cat | self organizer removeCategory: cat ].
+	categories do: [ :cat | self packageOrganizer removeCategory: cat ].
 	self unregister
 ]
 
@@ -1308,17 +1283,11 @@ RPackage >> removeSelector: aSelector ofClassName: aClassName [
 	"Remove the method in the package but does not propagate to the class itself.  Note that this method does not remove the method from the class, it just records in the package that the method is not in the package anymore."
 
 	self basicRemoveSelector: aSelector ofClassName: aClassName.
-	(classExtensionSelectors at: aClassName ifAbsent: [ #() ]) ifEmpty: [
-		classExtensionSelectors removeKey: aClassName ifAbsent: [].
-	].
-	(classDefinedSelectors at: aClassName ifAbsent: [ #() ]) ifEmpty: [
-		classDefinedSelectors removeKey: aClassName ifAbsent: [].
-	].
+	(classExtensionSelectors at: aClassName ifAbsent: [ #(  ) ]) ifEmpty: [ classExtensionSelectors removeKey: aClassName ifAbsent: [  ] ].
+	(classDefinedSelectors at: aClassName ifAbsent: [ #(  ) ]) ifEmpty: [ classDefinedSelectors removeKey: aClassName ifAbsent: [  ] ].
 
-	((metaclassExtensionSelectors at: aClassName ifAbsent: [#()]) isEmpty and: [(classExtensionSelectors at: aClassName ifAbsent: [#()]) isEmpty])
-		ifTrue: [
-				self organizer unregisterExtendingPackage: self forClassName: aClassName
-	]
+	((metaclassExtensionSelectors at: aClassName ifAbsent: [ #(  ) ]) isEmpty and: [ (classExtensionSelectors at: aClassName ifAbsent: [ #(  ) ]) isEmpty ])
+		ifTrue: [ self packageOrganizer unregisterExtendingPackage: self forClassName: aClassName ]
 ]
 
 { #category : #'add method - selector' }
@@ -1326,17 +1295,11 @@ RPackage >> removeSelector: aSelector ofMetaclassName: aClassName [
 	"Remove the method in the package. Note that this method does not remove the method from the class, it just records in the package that the method is not in the package anymore. aClassName is the sole instance class name and not its metaclass one: i.e. adding Point class>>new is done as removeSelector: #new ofMetaclassName: #Point"
 
 	self basicRemoveSelector: aSelector ofMetaclassName: aClassName.
-	(metaclassExtensionSelectors at: aClassName ifAbsent: [ #() ]) ifEmpty: [
-		metaclassExtensionSelectors removeKey: aClassName ifAbsent: [].
-	].
-	(metaclassDefinedSelectors at: aClassName ifAbsent: [ #() ]) ifEmpty: [
-		metaclassDefinedSelectors removeKey: aClassName ifAbsent: [].
-	].
+	(metaclassExtensionSelectors at: aClassName ifAbsent: [ #(  ) ]) ifEmpty: [ metaclassExtensionSelectors removeKey: aClassName ifAbsent: [  ] ].
+	(metaclassDefinedSelectors at: aClassName ifAbsent: [ #(  ) ]) ifEmpty: [ metaclassDefinedSelectors removeKey: aClassName ifAbsent: [  ] ].
 
-	((metaclassExtensionSelectors at: aClassName ifAbsent: [#()]) isEmpty and: [(classExtensionSelectors at: aClassName ifAbsent: [#()]) isEmpty])
-		ifTrue: [
-				self organizer unregisterExtendingPackage: self forClassName: aClassName
-	]
+	((metaclassExtensionSelectors at: aClassName ifAbsent: [ #(  ) ]) isEmpty and: [ (classExtensionSelectors at: aClassName ifAbsent: [ #(  ) ]) isEmpty ])
+		ifTrue: [ self packageOrganizer unregisterExtendingPackage: self forClassName: aClassName ]
 ]
 
 { #category : #private }
@@ -1376,26 +1339,21 @@ RPackage >> renameTo: aSymbol [
 	oldName := self name.
 	newName := aSymbol asSymbol.
 	repositoryGroup := self mcPackage workingCopy repositoryGroup.
-	self organizer validatePackageDoesNotExist: aSymbol.
-	oldCategoryNames := (self classTags collect: [:each | each categoryName] as: Set)
-		add: self name;
-		difference: {newName}.
+	self packageOrganizer validatePackageDoesNotExist: aSymbol.
+	oldCategoryNames := (self classTags collect: [ :each | each categoryName ] as: Set)
+		                    add: self name;
+		                    difference: { newName }.
 	self name: aSymbol.
-	SystemAnnouncer uniqueInstance
-		suspendAllWhile: [ self definedClasses
-				do:
-					[ :each | each category: newName , (each category allButFirst: oldName size) ].
-			oldCategoryNames
-				do: [ :each | self organizer removeCategory: each ] ].
+	SystemAnnouncer uniqueInstance suspendAllWhile: [
+		self definedClasses do: [ :each | each category: newName , (each category allButFirst: oldName size) ].
+		oldCategoryNames do: [ :each | self packageOrganizer removeCategory: each ] ].
 	self renameTagsPrefixedWith: oldName to: newName.
 	self renameExtensionsPrefixedWith: oldName to: newName.
-	self organizer
+	self packageOrganizer
 		basicUnregisterPackageNamed: oldName;
 		basicRegisterPackage: self.
 	self mcPackage workingCopy repositoryGroup: repositoryGroup.
-	SystemAnnouncer uniqueInstance
-		announce:
-			(RPackageRenamed to: self oldName: oldName newName: newName)
+	SystemAnnouncer uniqueInstance announce: (RPackageRenamed to: self oldName: oldName newName: newName)
 ]
 
 { #category : #private }
@@ -1437,7 +1395,7 @@ RPackage >> selectorsForClass: aClass [
 { #category : #'system compatibility' }
 RPackage >> systemCategories [
 
-	^ self organizer categories select: [:cat | self includesSystemCategory: cat]
+	^ self packageOrganizer categories select: [ :cat | self includesSystemCategory: cat ]
 ]
 
 { #category : #'system compatibility' }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -8,7 +8,7 @@ The classPackageMapping and the classExtendingPackageMapping should be moved in 
 For tests or actions that could destroy the package organizer,  do not access directly the singleton of RPackageOrganizer.
 Use instead 
 		RPackage withOrganizer: aNewOrganizer do: ablock
-			or via RPackage organizer
+			or via self packageOrganizer
 		
 	
 RPackageOrganizer fillUp will fill up the system from the current PackageOrganizer
@@ -479,13 +479,6 @@ RPackageOrganizer >> hasRegistered [
 	"return true if this package organizer has already registered interest to system events and Monticello changes "
 
 	^ self announcer hasSubscriber: self
-
-	"|actionSequence|
-	self announcer subscriptions ifNil: [^ true].
-	actionSequence := self announcer subscriptions values
-								detect: [:each | each anySatisfy: [:anAction | anAction receiver = RPackage organizer]] ifNone: [nil].
-	self flag: #cyril.
-	^ (actionSequence isNil not) and: [(MCWorkingCopy myDependents includes: self)]"
 ]
 
 { #category : #'deprecated - SystemOrganizer leftovers' }

--- a/src/RPackage-Core/RPackageSet.class.st
+++ b/src/RPackage-Core/RPackageSet.class.st
@@ -147,11 +147,12 @@ RPackageSet >> includesSystemCategory: categoryName [
 
 { #category : #initialization }
 RPackageSet >> initialize: aString [
+
 	self initialize.
 	packageName := aString asSymbol.
-	packages := (RPackage organizer packageNamed: aString ifAbsent: [  nil ])
-		ifNotNil: [ :package | { package }  ]
-		ifNil: [ {} ]
+	packages := (self packageOrganizer packageNamed: aString ifAbsent: [ nil ])
+		            ifNotNil: [ :package | { package } ]
+		            ifNil: [ {  } ]
 ]
 
 { #category : #'system compatibility' }

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -183,19 +183,15 @@ RPackageTag >> promoteAsRPackage [
 	"This method converts this rpackage tag into an rpackage, removes the tag from the parent package with all classes included and registers the new package in the system.
 	The tag has to be removed before registering to avoid conflicts.
 	Smells like we could have an error and lose package tags! registerPackage should not fail because names Package-Tag are unique in the system."
-	| newRPackage |
 
+	| newRPackage |
 	newRPackage := self asRPackage.
-	self classes do: [ :each | self package removeClass: each  ].
+	self classes do: [ :each | self package removeClass: each ].
 	self package removeClassTag: self name.
 	self package removeMethods: newRPackage extensionMethods.
-	RPackage organizer registerPackage: newRPackage.
+	self packageOrganizer registerPackage: newRPackage.
 
-	newRPackage classes do: [ :each |
-		SystemAnnouncer uniqueInstance
-			classRepackaged: each
-			from: self package
-			to:  newRPackage ]
+	newRPackage classes do: [ :each | SystemAnnouncer uniqueInstance classRepackaged: each from: self package to: newRPackage ]
 ]
 
 { #category : #accessing }

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -66,7 +66,7 @@ RPackageIncrementalTest >> tearDown [
 		 		unregisterExtendingPackage: each forClass: extendedClass.]].
 	"all ***extending*** classes the packages are also unregistered from PackageOrganizer"
 	(createdClasses reject: [:c| c isObsolete]) do: [:cls|
-		"(RPackage organizer includesPackageBackPointerForClass: cls)
+		"(self packageOrganizer includesPackageBackPointerForClass: cls)
 			ifTrue: [cls package unregisterClass: cls.].
 		when RPackageOrganizer was not looking at system event we had to do the commented actions"
 		logging := false.

--- a/src/RPackage-Tests/RPackageTagTest.class.st
+++ b/src/RPackage-Tests/RPackageTagTest.class.st
@@ -109,11 +109,11 @@ RPackageTagTest >> testPromoteAsRPackage [
 
 { #category : #tests }
 RPackageTagTest >> testPromoteAsRPackageWithExtension [
-	| packageOriginal packagePromoted class classOther tag |
 
+	| packageOriginal packagePromoted class classOther tag |
 	packageOriginal := (self packageClass named: #Test1) register.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
-	class compile: 'foo ^42' classified: #'accessing'.
+	class compile: 'foo ^42' classified: #accessing.
 
 	classOther := self createNewClassNamed: 'TestClassOther' inCategory: 'XXXX'.
 	classOther compile: 'bar ^42' classified: #'*Test1-TAG1'.
@@ -121,11 +121,11 @@ RPackageTagTest >> testPromoteAsRPackageWithExtension [
 	tag := packageOriginal classTagNamed: 'TAG1'.
 	tag promoteAsRPackage.
 
-	packagePromoted:= RPackage organizer packageNamed: 'Test1-TAG1'.
+	packagePromoted := self packageOrganizer packageNamed: 'Test1-TAG1'.
 	self assert: packagePromoted notNil.
 	self assert: (packagePromoted classes includes: class).
-	self assert: (packagePromoted extensionMethods includes: classOther>>#bar).
-	self assert: (classOther>>#bar) protocol equals: '*Test1-TAG1'.
+	self assert: (packagePromoted extensionMethods includes: classOther >> #bar).
+	self assert: (classOther >> #bar) protocol equals: '*Test1-TAG1'.
 	self deny: (packageOriginal classes includes: class).
-	self deny: (packageOriginal extensionMethods includes: classOther>>#bar)
+	self deny: (packageOriginal extensionMethods includes: classOther >> #bar)
 ]

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -182,8 +182,8 @@ RPackageTest >> testDemoteToRPackageNamedMultilevelPackage2 [
 
 { #category : #tests }
 RPackageTest >> testDemoteToRPackageNamedWithExtension [
-	| packageOriginal packageDemoted class classOther |
 
+	| packageOriginal packageDemoted class classOther |
 	packageOriginal := (RPackage named: #'Test1-TAG1') register.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
 	class compile: 'foo ^42' classified: 'accessing'.
@@ -193,14 +193,16 @@ RPackageTest >> testDemoteToRPackageNamedWithExtension [
 
 	packageOriginal demoteToTagInPackageNamed: 'Test1'.
 
-	self deny: (RPackage organizer includesPackage: packageOriginal).
+	self deny: (self packageOrganizer includesPackage: packageOriginal).
 	packageDemoted := RPackage organizer packageNamed: 'Test1'.
 	self assert: packageDemoted notNil.
 	self assert: (packageDemoted classes includes: class).
 	self assert: ((packageDemoted classTagNamed: 'TAG1') classes includes: class).
-	self assert: (packageDemoted extensionMethods includes: classOther>>#bar).
-	self assert: ((classOther>>#bar) protocol) equals: '*Test1-TAG1'.
-	self assert: (packageDemoted classes	includesAll: {class. classOther})
+	self assert: (packageDemoted extensionMethods includes: classOther >> #bar).
+	self assert: (classOther >> #bar) protocol equals: '*Test1-TAG1'.
+	self assert: (packageDemoted classes includesAll: {
+				 class.
+				 classOther })
 ]
 
 { #category : #'tests - properties' }

--- a/src/Refactoring-Core/RBCopyPackageRefactoring.class.st
+++ b/src/Refactoring-Core/RBCopyPackageRefactoring.class.st
@@ -104,13 +104,15 @@ RBCopyPackageRefactoring >> copyPackage: aString1 in: aString2 [
 
 { #category : #preconditions }
 RBCopyPackageRefactoring >> preconditions [
-	^ super preconditions & (RBCondition withBlock: [ newName = packageName ifTrue:
-		[ self refactoringError: 'Use a different name' ].
-		true ]) &
-	(RBCondition withBlock: [ [RPackage organizer validatePackageDoesNotExist: newName. true]
-			on: Error
-			do: [ :e | self refactoringError: e messageText ]
-		])
+
+	^ super preconditions & (RBCondition withBlock: [
+		   newName = packageName ifTrue: [ self refactoringError: 'Use a different name' ].
+		   true ]) & (RBCondition withBlock: [
+		   [
+		   self packageOrganizer validatePackageDoesNotExist: newName.
+		   true ]
+			   on: Error
+			   do: [ :e | self refactoringError: e messageText ] ])
 ]
 
 { #category : #renaming }

--- a/src/Refactoring-Core/RBPackageRefactoring.class.st
+++ b/src/Refactoring-Core/RBPackageRefactoring.class.st
@@ -59,8 +59,9 @@ RBPackageRefactoring >> packageName: anObject [
 
 { #category : #preconditions }
 RBPackageRefactoring >> preconditions [
-	^ (RBCondition withBlock: [ [ RPackage organizer includesPackageNamed: packageName ]
-			on: Error
-			do: [ :e | self refactoringError: e messageText ]
-		])
+
+	^ RBCondition withBlock: [
+		  [ self packageOrganizer includesPackageNamed: packageName ]
+			  on: Error
+			  do: [ :e | self refactoringError: e messageText ] ]
 ]

--- a/src/Refactoring-Core/RBRegexRefactoring.class.st
+++ b/src/Refactoring-Core/RBRegexRefactoring.class.st
@@ -13,7 +13,7 @@ Here is a sample of a script that will change of the YK* classes of package Pref
 pkgPrefix := 'PrefixOfPackageNames'.
 newClassPrefix := 'ZG'.
 env := RBBrowserEnvironment new 
-			forPackageNames: (RPackage organizer packageNames select: [ : pkgName | (pkgName beginsWith: pkgPrefix) ]).
+			forPackageNames: (self packageOrganizer  packageNames select: [ : pkgName | (pkgName beginsWith: pkgPrefix) ]).
 model := (RBClassModelFactory rbNamespace onEnvironment: env) name: 'MyModel'; yourself.
 RBClassRegexRefactoring new
 	model: model;

--- a/src/Refactoring-Core/RBRenamePackageRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenamePackageRefactoring.class.st
@@ -52,13 +52,15 @@ RBRenamePackageRefactoring >> packageName: aName newName: aNewName [
 
 { #category : #preconditions }
 RBRenamePackageRefactoring >> preconditions [
-	^ super preconditions & (RBCondition withBlock: [ newName = package name ifTrue:
-		[ self refactoringError: 'Use a different name' ].
-		true ]) &
-	(RBCondition withBlock: [ [RPackage organizer validatePackageDoesNotExist: newName. true]
-			on: Error
-			do: [ :e | self refactoringError: e messageText ]
-		])
+
+	^ super preconditions & (RBCondition withBlock: [
+		   newName = package name ifTrue: [ self refactoringError: 'Use a different name' ].
+		   true ]) & (RBCondition withBlock: [
+		   [
+		   self packageOrganizer validatePackageDoesNotExist: newName.
+		   true ]
+			   on: Error
+			   do: [ :e | self refactoringError: e messageText ] ])
 ]
 
 { #category : #transforming }

--- a/src/Refactoring2-Transformations/RBPackageTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBPackageTransformation.class.st
@@ -41,8 +41,9 @@ RBPackageTransformation >> packageName: anObject [
 
 { #category : #preconditions }
 RBPackageTransformation >> preconditions [
-	^ (RBCondition withBlock: [ [ RPackage organizer includesPackageNamed: packageName ]
-			on: Error
-			do: [ :e | self refactoringError: e messageText ]
-		])
+
+	^ RBCondition withBlock: [
+		  [ self packageOrganizer includesPackageNamed: packageName ]
+			  on: Error
+			  do: [ :e | self refactoringError: e messageText ] ]
 ]

--- a/src/Refactoring2-Transformations/RBRenamePackageTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBRenamePackageTransformation.class.st
@@ -63,13 +63,15 @@ RBRenamePackageTransformation >> packageName: aName newName: aNewName [
 
 { #category : #executing }
 RBRenamePackageTransformation >> preconditions [
-	^ super preconditions & (RBCondition withBlock: [ newName = package name ifTrue:
-		[ self refactoringError: 'Use a different name' ].
-		true ]) &
-	(RBCondition withBlock: [ [RPackage organizer validatePackageDoesNotExist: newName. true]
-			on: Error
-			do: [ :e | self refactoringError: e messageText ]
-		])
+
+	^ super preconditions & (RBCondition withBlock: [
+		   newName = package name ifTrue: [ self refactoringError: 'Use a different name' ].
+		   true ]) & (RBCondition withBlock: [
+		   [
+		   self packageOrganizer validatePackageDoesNotExist: newName.
+		   true ]
+			   on: Error
+			   do: [ :e | self refactoringError: e messageText ] ])
 ]
 
 { #category : #executing }

--- a/src/SUnit-UI/TestRunner.class.st
+++ b/src/SUnit-UI/TestRunner.class.st
@@ -77,11 +77,10 @@ TestRunner >> addDeclaredPackagesUnderTestTo: listOfPackages [
 	"This method looks for #packageNamesUnderTest method in class side of classes defined packages in listOfPackages.
 	 If a class defines this method, then the coverage tool knows the methods of which packages should be spied to compute the coverage.
 	 Thus, it adds it to #listOfPackages collection provided as parameter."
+
 	classesSelected
-		select: [ :class | (class class includesSelector: #packageNamesUnderTest) ]
-		thenDo: [ :class |
-			class packageNamesUnderTest do: [ :name |
-				listOfPackages add: (RPackage organizer packageNamed: name) ] ]
+		select: [ :class | class class includesSelector: #packageNamesUnderTest ]
+		thenDo: [ :class | class packageNamesUnderTest do: [ :name | listOfPackages add: (self packageOrganizer packageNamed: name) ] ]
 ]
 
 { #category : #actions }

--- a/src/Tool-DependencyAnalyser/DADependenciesHTMLPublisher.class.st
+++ b/src/Tool-DependencyAnalyser/DADependenciesHTMLPublisher.class.st
@@ -98,10 +98,11 @@ DADependenciesHTMLPublisher >> htmlForDependency: dependencyPackageName of: aPac
 
 { #category : #publishing }
 DADependenciesHTMLPublisher >> htmlForIgnoredDependenciesOf: aPackageName [
+
 	^ String streamContents: [ :str |
-		(RPackage organizer packageNamed: aPackageName) ignoredDependencies
-			do: [ :dependency | str << (self warningLabel: dependency) ]
-			separatedBy: [ str space ] ]
+		  (self packageOrganizer packageNamed: aPackageName) ignoredDependencies
+			  do: [ :dependency | str << (self warningLabel: dependency) ]
+			  separatedBy: [ str space ] ]
 ]
 
 { #category : #publishing }

--- a/src/Tool-DependencyAnalyser/DADependencyChecker.class.st
+++ b/src/Tool-DependencyAnalyser/DADependencyChecker.class.st
@@ -84,7 +84,7 @@ DADependencyChecker >> dependenciesOf: aPackageName [
 
 { #category : #private }
 DADependencyChecker >> ignoredDependenciesOf: aPackageName [
-	^ (RPackage organizer packageNamed: aPackageName) ignoredDependencies
+	^ (self packageOrganizer packageNamed: aPackageName) ignoredDependencies
 ]
 
 { #category : #initialization }
@@ -95,7 +95,7 @@ DADependencyChecker >> initialize [
 
 { #category : #private }
 DADependencyChecker >> manuallyResolvedDependenciesOf: aPackageName [
-	^ (RPackage organizer packageNamed: aPackageName) manuallyResolvedDependencies
+	^ (self packageOrganizer packageNamed: aPackageName) manuallyResolvedDependencies
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
We have a tons of way to access the default RPackageOrganizer of the image and I removed at least 3 ways already.  In this process of unification I found yet another way to access it, via `RPackage class>> organizer`. 

This is a first step to unify the access to the default RPackageOrganizer for senders of #organizer. 

This is only a part of it because multiple senders are in external projects and there are more in Pharo but I didn't wanted to do a PR that would be a beast.