### PR TITLE
Compiler-Reserved-Vars-are-just-readOnly

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -1747,24 +1747,21 @@ RBCodeSnippet class >> badSemantic [
 			         styled: 'XXXXXXXXXXXX';
 			         isFaulty: true;
 			         numberOfCritiques: 1;
-			         notices: #( #( 1 4 1 'Assigment to reserved variable' )
-				            #( 1 4 1 'Assignment to read-only variable' ) )).
+			         notices: #(#( 1 4 1 'Assignment to read-only variable' ) )).
 		        (self new
 			         source: 'super := super';
 			         nodeAt: '22222000011111';
 			         styled: 'XXXXXXXXXXXXXX';
 			         isFaulty: true;
 			         numberOfCritiques: 1;
-			         notices: #( #( 1 5 1 'Assigment to reserved variable' )
-				            #( 1 5 1 'Assignment to read-only variable' ) )).
+			         notices: #( #( 1 5 1 'Assignment to read-only variable' ) )).
 		        (self new
 			         source: 'thisContext := thisContext';
 			         nodeAt: '22222222222000011111111111';
 			         styled: 'XXXXXXXXXXXXXXXXXXXXXXXXXX';
 			         isFaulty: true;
 			         numberOfCritiques: 1;
-			         notices: #( #( 1 11 1 'Assigment to reserved variable' )
-				            #( 1 11 1 'Assignment to read-only variable' ) )).
+			         notices: #(#( 1 11 1 'Assignment to read-only variable' ) )).
 		        (self new
 			         source: 'Object := Object';
 			         nodeAt: '2222220000111111';

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -146,12 +146,6 @@ OCASTSemanticAnalyzer >> storeIntoReadOnlyVariable: variableNode [
 	variableNode addError: 'Assignment to read-only variable'
 ]
 
-{ #category : #'error handling' }
-OCASTSemanticAnalyzer >> storeIntoReservedVariable: variableNode [
-
-	variableNode addError: 'Assigment to reserved variable'
-]
-
 { #category : #accessing }
 OCASTSemanticAnalyzer >> undeclared [
 

--- a/src/OpalCompiler-Core/Variable.extension.st
+++ b/src/OpalCompiler-Core/Variable.extension.st
@@ -9,7 +9,5 @@ Variable >> analyzeRead: aVariableNode by: aSemanticAnalyzer [
 { #category : #'*OpalCompiler-Core' }
 Variable >> analyzeWrite: aVariableNode by: aSemanticAnalyzer [
 
-	self isReservedVariable ifTrue: [ aSemanticAnalyzer storeIntoReservedVariable: aVariableNode ].
-
 	self isWritable ifFalse: [ aSemanticAnalyzer storeIntoReadOnlyVariable: aVariableNode ]
 ]

--- a/src/OpalCompiler-Tests/OCCompilerNotifyingTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerNotifyingTest.class.st
@@ -115,7 +115,7 @@ OCCompilerNotifyingTest >> setUpForErrorsIn: aTextWithErrorsEnclosedInBackQuote 
 { #category : #tests }
 OCCompilerNotifyingTest >> testAssignmentOfSelf [
 
-	self setUpForErrorsIn: '` Assigment to reserved variable ->`self := 1. ^self'.
+	self setUpForErrorsIn: '` Assignment to read-only variable ->`self := 1. ^self'.
 	self enumerateAllSelections
 ]
 


### PR DESCRIPTION
This PR simplifies what happens when you try to assign to a pseudvariable.

Right now, we get a special error message 'Assigment to reserved variable'. We need to rename the term anyway (they should not be "reserved", and in documentation we use PseudoVariable).

While starting to look at that, I wonderd: does it really add anything to have the special error notice? There is already 'Assignment to read-only variable', and these variables are just one case of those.

This PR thus simplifies to remove the special check, #analyzeWrite:by: now just checks for #isWritable