### PR TITLE
Add benchmark comparison

### DIFF
--- a/src/Kernel-Chronology-Extras/BenchmarkComparison.class.st
+++ b/src/Kernel-Chronology-Extras/BenchmarkComparison.class.st
@@ -1,0 +1,60 @@
+Class {
+	#name : #BenchmarkComparison,
+	#superclass : #Object,
+	#instVars : [
+		'referenceResult',
+		'comparisonResult'
+	],
+	#category : #'Kernel-Chronology-Extras'
+}
+
+{ #category : #accessing }
+BenchmarkComparison >> comparisonResult [
+
+	^ comparisonResult
+]
+
+{ #category : #accessing }
+BenchmarkComparison >> comparisonResult: aBenchmarkResult [
+
+	comparisonResult := aBenchmarkResult
+]
+
+{ #category : #printing }
+BenchmarkComparison >> frequencyFactor [
+
+	^ comparisonResult frequency / referenceResult frequency
+]
+
+{ #category : #testing }
+BenchmarkComparison >> isEmpty [
+
+	^ (referenceResult isNil | comparisonResult isNil or: [
+		   referenceResult isEmpty or: [ comparisonResult isEmpty ] ]) not
+]
+
+{ #category : #printing }
+BenchmarkComparison >> printOn: stream [
+
+	self isEmpty
+		ifFalse: [ stream << 'empty' ]
+		ifTrue: [
+			referenceResult frequency printOn: stream showingDecimalPlaces: 3.
+			stream << '/s * '.
+			self frequencyFactor printOn: stream showingDecimalPlaces: 3.
+			stream << ' = '.
+			comparisonResult frequency printOn: stream showingDecimalPlaces: 3.
+			stream << '/s' ]
+]
+
+{ #category : #accessing }
+BenchmarkComparison >> referenceResult [
+
+	^ referenceResult
+]
+
+{ #category : #accessing }
+BenchmarkComparison >> referenceResult: aBenchmarkResult [
+
+	referenceResult := aBenchmarkResult
+]

--- a/src/Kernel-Chronology-Extras/BenchmarkComparison.class.st
+++ b/src/Kernel-Chronology-Extras/BenchmarkComparison.class.st
@@ -1,3 +1,10 @@
+"
+I am the BenchmarkComparison class, responsible for comparing two BenchmarkResult instances and providing insight into their relative performance.
+
+My instances can be created using `BlockClosure>>#benchCompareTo:`, which takes another block as an argument.
+
+I provide the #frequencyFactor and #periodFactor methods to access and analyze the comparison factors.
+"
 Class {
 	#name : #BenchmarkComparison,
 	#superclass : #Object,

--- a/src/Kernel-Chronology-Extras/BenchmarkComparison.class.st
+++ b/src/Kernel-Chronology-Extras/BenchmarkComparison.class.st
@@ -27,7 +27,7 @@ BenchmarkComparison >> comparisonResult: aBenchmarkResult [
 	comparisonResult := aBenchmarkResult
 ]
 
-{ #category : #printing }
+{ #category : #comparing }
 BenchmarkComparison >> frequencyFactor [
 
 	^ comparisonResult frequency / referenceResult frequency
@@ -38,6 +38,12 @@ BenchmarkComparison >> isEmpty [
 
 	^ (referenceResult isNil | comparisonResult isNil or: [
 		   referenceResult isEmpty or: [ comparisonResult isEmpty ] ]) not
+]
+
+{ #category : #comparing }
+BenchmarkComparison >> periodFactor [
+
+	^ comparisonResult period / referenceResult period
 ]
 
 { #category : #printing }

--- a/src/Kernel-Chronology-Extras/BenchmarkResult.class.st
+++ b/src/Kernel-Chronology-Extras/BenchmarkResult.class.st
@@ -25,6 +25,14 @@ Class {
 	#category : #'Kernel-Chronology-Extras'
 }
 
+{ #category : #comparing }
+BenchmarkResult >> compareTo: aBenchmarkResult [
+
+	^ BenchmarkComparison new
+		  referenceResult: self;
+		  comparisonResult: aBenchmarkResult
+]
+
 { #category : #accessing }
 BenchmarkResult >> elapsedTime [
 	"Return the duration of the total execution time"

--- a/src/Kernel-Chronology-Extras/BenchmarkResult.class.st
+++ b/src/Kernel-Chronology-Extras/BenchmarkResult.class.st
@@ -1,7 +1,7 @@
 "
 I am BenchmarkResult. 
 
-I know how much iterations where executed in a specific elapsed time duration.
+I know how many iterations where executed in a specific elapsed time duration.
 
 I am the result of running the same piece of code multiple times.
 
@@ -93,7 +93,7 @@ BenchmarkResult >> printFrequenceOn: stream [
 BenchmarkResult >> printOn: stream [
 	self isEmpty
 		ifTrue: [
-			stream << ' empty' ]
+			stream << 'empty' ]
 		ifFalse: [
 			iterations printWithCommasOn: stream.
 			stream space; << ('iteration' asPluralBasedOn: iterations).

--- a/src/Kernel-Chronology-Extras/BenchmarkResult.class.st
+++ b/src/Kernel-Chronology-Extras/BenchmarkResult.class.st
@@ -1,13 +1,13 @@
 "
 I am BenchmarkResult. 
 
-I know how many iterations where executed in a specific elapsed time duration.
+I know how many iterations have been executed in a given elapsed time.
 
 I am the result of running the same piece of code multiple times.
 
-I can compute my average #frequencey (#executionsPerSecond) and #period (#timePerExecution).
+I can calculate my average #frequency (#executionsPerSecond) and #period (#timePerExecution).
 
-I have a human friendly print representation.
+I have a human-readable print representation.
 
 BenchmarkResult new
 	iterations: 20000;

--- a/src/Kernel-Chronology-Extras/BlockClosure.extension.st
+++ b/src/Kernel-Chronology-Extras/BlockClosure.extension.st
@@ -10,6 +10,13 @@ BlockClosure >> bench [
 ]
 
 { #category : #'*Kernel-Chronology-Extras' }
+BlockClosure >> benchCompareTo: aBlock [
+	"Answer a BenchmarkComparison of the receiver to the argument."
+
+	^ self bench compareTo: aBlock bench
+]
+
+{ #category : #'*Kernel-Chronology-Extras' }
 BlockClosure >> benchFor: duration [
 
 	"Run me for duration and return a BenchmarkResult"

--- a/src/Kernel-Chronology-Extras/BlockClosure.extension.st
+++ b/src/Kernel-Chronology-Extras/BlockClosure.extension.st
@@ -2,9 +2,7 @@ Extension { #name : #BlockClosure }
 
 { #category : #'*Kernel-Chronology-Extras' }
 BlockClosure >> bench [
-	"Return how many times the receiver can get executed in 5 seconds.
-	Answer a string with meaningful description.
-	See #benchFor: which returns a BenchmarkResult"
+	"Answer a BenchmarkResult with the number of times the receiver was executed in 5 seconds"
 
 	"[3.14 printString] bench"
 

--- a/src/Kernel-Chronology-Extras/DateParser.class.st
+++ b/src/Kernel-Chronology-Extras/DateParser.class.st
@@ -56,7 +56,7 @@ DateParser >> createDate [
 
 { #category : #'private - parsing' }
 DateParser >> currentMillenium [
-	^ (Date current year / 100) asInteger * 100
+	^ (Date current year // 100) * 100
 ]
 
 { #category : #'private - parsing' }


### PR DESCRIPTION
A BenchmarkComparison class has been added in the same spirit as BenchmarkResult.
An instance prints the frequency of both results and the factor between them:
```st
[ (Date current year / 100) asInteger * 100 ] benchCompareTo: [
  (Date current year // 100) * 100 ]. "694997.401/s * 1.203 = 836151.770/s"
```

Plus some updates to the Kernel-Chronology-Extras package.