### PR TITLE
Fix last inconsistancy in Fluid tests package generation

### DIFF
--- a/src/FluidClassBuilder-Tests/FluidClassBuilderTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidClassBuilderTest.class.st
@@ -357,7 +357,7 @@ FluidClassBuilderTest >> testExistingClassWithClassSlot [
 		               sharedVariables: { #BBB };
 		               sharedPools: { #TextConstants };
 		               tag: 'boring';
-		               package: 'Mock'.
+		               package: self packageNameForTest..
 
 	newClass := instBuilder install.
 


### PR DESCRIPTION
I recently did a PR to be sure Fluid tests left the image in the right state and I forgot one place during this cleaning. This is a fix of this last place.