### PR TITLE
Deprecate SHRBTextStyler>>#format:

### DIFF
--- a/src/Deprecated12/SHRBTextStyler.extension.st
+++ b/src/Deprecated12/SHRBTextStyler.extension.st
@@ -7,6 +7,13 @@ SHRBTextStyler >> font: aFont [
 ]
 
 { #category : #'*Deprecated12' }
+SHRBTextStyler >> format: aText [
+
+	self deprecated: 'This method does nothing except returning the argument and should be inlined' transformWith: '`@rcv format: `@arg' -> '`@arg'.
+	^ aText
+]
+
+{ #category : #'*Deprecated12' }
 SHRBTextStyler class >> initialTextAttributesForPixelHeight: aNumber [
 
 	self deprecated: 'Use #initialTextAttributes instead.' transformWith: '`@rcv initialTextAttributesForPixelHeight: `@arg1' -> '`@rcv initialTextAttributes'.

--- a/src/Rubric-Styling/RubShoutStylerDecorator.class.st
+++ b/src/Rubric-Styling/RubShoutStylerDecorator.class.st
@@ -69,14 +69,13 @@ RubShoutStylerDecorator >> refreshStyling [
 
 { #category : #editing }
 RubShoutStylerDecorator >> replaceFrom: start to: stop with: aText [
-	self okToStyle
-		ifFalse: [ ^ next replaceFrom: start to: stop with: aText ].
+
+	self okToStyle ifFalse: [ ^ next replaceFrom: start to: stop with: aText ].
 
 	self paragraph disableDrawingWhile: [
-
 		aText addAttribute: self paragraph defaultFontChange.
 		text ifNil: [ text := self text ].
-		text replaceFrom: start to: stop with: (self styler format: aText).
+		text replaceFrom: start to: stop with: aText.
 		replaceStart := start.
 		replaceStop := stop.
 		self style: text.
@@ -85,10 +84,7 @@ RubShoutStylerDecorator >> replaceFrom: start to: stop with: aText [
 		self paragraph ifNotNil: [ :paragraph |
 			paragraph recomposeFrom: start to: start + aText size - 1 delta: aText size - (stop - start + 1).
 			paragraph textArea paragraphWasComposedFrom: start to: start + aText size - 1.
-			paragraph textArea paragraphReplacedTextFrom: start to: stop with: aText
-		]
-
-	]
+			paragraph textArea paragraphReplacedTextFrom: start to: stop with: aText ] ]
 ]
 
 { #category : #shout }
@@ -167,15 +163,14 @@ RubShoutStylerDecorator >> text [
 
 { #category : #accessing }
 RubShoutStylerDecorator >> text: aText [
-	self okToStyle
-		ifFalse: [ ^ next text: aText ].
-	self
-		disableDrawingWhile: [
-			aText addAttribute: self defaultFontChange.
-			next text: (text := (self styler format: aText)).
-			replaceStart := 1.
-			replaceStop := text size.
-			self style: text]
+
+	self okToStyle ifFalse: [ ^ next text: aText ].
+	self disableDrawingWhile: [
+		aText addAttribute: self defaultFontChange.
+		next text: (text := aText).
+		replaceStart := 1.
+		replaceStop := text size.
+		self style: text ]
 ]
 
 { #category : #private }

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -688,12 +688,6 @@ SHRBTextStyler >> classOrMetaClass: aBehavior [
 	classOrMetaClass := aBehavior
 ]
 
-{ #category : #formatting }
-SHRBTextStyler >> format: aText [
-
-	^ aText
-]
-
 { #category : #visiting }
 SHRBTextStyler >> formatIncompleteSelector: aMessageNode [
 


### PR DESCRIPTION
The #format: method does nothing except returning the argument. This is really really really bad for code understanding. I would expect `styler format: aText` to style the text, but no, it does nothing.  I propose to deprecate this method. And it had senders in the image! I don't know if the senders where expecting this method to do something, but it clearly was not doing anything in the current state of the image.