### PR TITLE
Clean #dependentClasses

### DIFF
--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -576,27 +576,6 @@ Behavior >> definedVariables [
 	^ self slots
 ]
 
-{ #category : #dependencies }
-Behavior >> dependentClasses [
-	"Return the list of classes used myself"
-
-	"Morph dependentClasses"
-	| cll |
-	cll := Set new.
-	"A class depends on its superclass"
-	self superclass ifNotNil: [ cll add: self superclass ].
-
-	"We unify a class and its metaclass"
-	(self methods, self classSide methods)
-		do: [ :m | m literalsDo: [ :l |
-					"We also check if the method is not an extension"
-					(l isVariableBinding
-					and: [ l isGlobalClassNameBinding
-					and: [ m category notEmpty
-					and: [ m category first ~= $* ]]])  ifTrue: [ cll add: l value ] ] ] .
-	^ cll asArray
-]
-
 { #category : #'accessing - instances and variables' }
 Behavior >> elementSize [
 	"Answer the size in bytes of an element in the receiver.  The formats are

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -411,6 +411,26 @@ ClassDescription >> definitionStringFor: aConfiguredPrinter [
 	^ self subclassResponsibility
 ]
 
+{ #category : #dependencies }
+ClassDescription >> dependentClasses [
+	"Return the list of classes used myself"
+
+	| classes |
+	classes := Set new.
+
+	"A class depends on its superclass"
+	self superclass ifNotNil: [ :class | classes add: class ].
+
+	"We unify a class and its metaclass"
+	self methods , self classSide methods do: [ :method |
+		method literalsDo: [ :literal | "We also check if the method is not an extension"
+			self flag: #CompileMethodProtocolMiration.
+			(literal isVariableBinding and: [ literal isGlobalClassNameBinding and: [ method protocolName isNotEmpty and: [ method protocolName first ~= $* ] ] ])
+				ifTrue: [ classes add: literal value ] ] ].
+
+	^ classes asArray
+]
+
 { #category : #accessing }
 ClassDescription >> deprecatedAliases [
 	"I return a potential list of alias names for myself that are deprecated."


### PR DESCRIPTION
Push it down from Behavior to ClassDescription and clean a little the method. The push down is because it calls a method only present in ClassDescription

I added a flag because it will be improved further soon