### PR TITLE
Move Color startup registration

### DIFF
--- a/src/Colors/Color.class.st
+++ b/src/Colors/Color.class.st
@@ -427,9 +427,10 @@ Color class >> initialize [
 	color models used here, see Chapter 17 of Foley and van Dam,
 	Fundamentals of Interactive Computer Graphics, Addison-Wesley,
 	1982."
+
 	ComponentMask := 1023.
-	HalfComponentMask := 512.	"used to round up in integer calculations"
-	ComponentMax := 1023.0.	"a Float used to normalize components"
+	HalfComponentMask := 512. "used to round up in integer calculations"
+	ComponentMax := 1023.0. "a Float used to normalize components"
 	RedShift := 20.
 	GreenShift := 10.
 	BlueShift := 0.
@@ -437,9 +438,7 @@ Color class >> initialize [
 	self
 		initializeIndexedColors;
 		initializeColorRegistry;
-		initializeGrayToIndexMap.
-
-	SessionManager default registerGuiClassNamed: self name
+		initializeGrayToIndexMap
 ]
 
 { #category : #'private - initialization' }
@@ -861,13 +860,6 @@ Color class >> registeredNameOf: aColor [
 			value = aColor
 				ifTrue: [ colorName := key ] ].
 	^ colorName
-]
-
-{ #category : #'system startup' }
-Color class >> shutDown [
-	"Color shutDown"
-	CachedColormaps := nil.	"Maps to translate between color depths"
-	MaskingMap := nil	"Maps all colors except transparent to black for creating a mask"
 ]
 
 { #category : #'accessing - defaults' }

--- a/src/Graphics-Primitives/BitBlt.class.st
+++ b/src/Graphics-Primitives/BitBlt.class.st
@@ -148,7 +148,11 @@ BitBlt class >> destForm: df sourceForm: sf halftoneForm: hf combinationRule: cr
 
 { #category : #'class initialization' }
 BitBlt class >> initialize [
-	self recreateColorMaps
+
+	self recreateColorMaps.
+
+	"Graphics-Primitives packages adds some caches to Color in order to speed up some things. Those caches needs to be invalidated at shut down so we register the class to the startup list."
+	SessionManager default registerGuiClassNamed: #Color
 ]
 
 { #category : #private }

--- a/src/Graphics-Primitives/Color.extension.st
+++ b/src/Graphics-Primitives/Color.extension.st
@@ -299,3 +299,11 @@ Color class >> pixelScreenForDepth: depth [
 		with: mask
 		with: mask bitInvert32
 ]
+
+{ #category : #'*Graphics-Primitives' }
+Color class >> shutDown [
+
+	<script>
+	CachedColormaps := nil. "Maps to translate between color depths"
+	MaskingMap := nil "Maps all colors except transparent to black for creating a mask"
+]


### PR DESCRIPTION
Color has some caches to speed up Graphics-Primitives package. Those are invalidated at shut down. 

Since those caches are only for Graphics-Primitives I am moving the registration to the right package. This also reduces the number of dependencies on SessionManager in Kernel.