### PR TITLE
Cleanup: methods duplicated in the hierarchy / tag selectors

### DIFF
--- a/src/Fuel-Platform-Pharo-Core/FLPharoPlatform.class.st
+++ b/src/Fuel-Platform-Pharo-Core/FLPharoPlatform.class.st
@@ -60,11 +60,6 @@ FLPharoPlatform >> isPharo [
 	^ true
 ]
 
-{ #category : #testing }
-FLPharoPlatform >> isSpur [
-	^ true
-]
-
 { #category : #'tests-compilation' }
 FLPharoPlatform >> newAnonymousSubclassOf: aClass named: aString [
 	^ aClass newAnonymousSubclass

--- a/src/Fuel-Tests-Core/FLFileReferenceStreamBasicSerializationTest.class.st
+++ b/src/Fuel-Tests-Core/FLFileReferenceStreamBasicSerializationTest.class.st
@@ -3,8 +3,3 @@ Class {
 	#superclass : #FLBasicSerializationTest,
 	#category : #'Fuel-Tests-Core-Base'
 }
-
-{ #category : #running }
-FLFileReferenceStreamBasicSerializationTest >> setUpStreamStrategy [
-	streamStrategy := FLFileReferenceStreamStrategy new
-]

--- a/src/Morphic-Core/MorphicShortcutHandler.class.st
+++ b/src/Morphic-Core/MorphicShortcutHandler.class.st
@@ -7,12 +7,6 @@ Class {
 	#category : #'Morphic-Core-Events'
 }
 
-{ #category : #tools }
-MorphicShortcutHandler class >> registerToolsOn: aToolRegistry [
-	"commente out as Smalltalk resetTools might register this handler and break keybindings"
-	"aToolRegistry register: self new as: #shortcuts"
-]
-
 { #category : #'shortcut-handling' }
 MorphicShortcutHandler >> handleKeystroke: aKeystrokeEvent inMorph: aMorph [
 

--- a/src/OpalCompiler-Core/InvalidVariable.class.st
+++ b/src/OpalCompiler-Core/InvalidVariable.class.st
@@ -20,13 +20,6 @@ InvalidVariable >> isInvalidVariable [
 	^true
 ]
 
-{ #category : #'read/write usage' }
-InvalidVariable >> isUninitialized [
-	"Not really initialized, but need to silence warnings"
-
-	^ false
-]
-
 { #category : #testing }
 InvalidVariable >> isUsed [
 	"Not really used, but need to silence warnings"

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -3356,7 +3356,7 @@ UITheme >> newTaskListButtonIn: aTasklist for: aTask [
 		ifTrue: [ lab emphasis: 1 "1 -> bold" ].
 	lm := self
 		newRowIn: aTasklist
-		for: {(aTask icon ifNil: [self smallWindowIcon]) asMorph. lab}.
+		for: {(aTask icon ifNil: [self iconNamed: #smallWindow]) asMorph. lab}.
 	button := self
 		newButtonIn: aTasklist
 		for: aTask morph

--- a/src/Refactoring-UI/RBPushDownMethodInSomeClassesDriver.class.st
+++ b/src/Refactoring-UI/RBPushDownMethodInSomeClassesDriver.class.st
@@ -20,12 +20,6 @@ Class {
 	#category : #'Refactoring-UI'
 }
 
-{ #category : #initialization }
-RBPushDownMethodInSomeClassesDriver class >> model: aRBNamespace scopes: refactoringScopes pushDown: methods [
-
-	^ self new model: aRBNamespace scopes: refactoringScopes pushDown: methods
-]
-
 { #category : #execution }
 RBPushDownMethodInSomeClassesDriver >> execute [
 

--- a/src/Reflectivity-Tests/VariableBreakpointTest.class.st
+++ b/src/Reflectivity-Tests/VariableBreakpointTest.class.st
@@ -442,6 +442,7 @@ VariableBreakpointTest >> testNewForClass [
 VariableBreakpointTest >> testNoRemoveAfterSubclassRemoved [
 	"Removing the class where the target variable of a variable breakpoint is defined should uninstall the variable breakpoint"
 	|testClassNode testSubclassNode|
+	<ignoreNotImplementedSelectors: #(accessingV1)>
 	self compileTestClass.
 	self compileTestClass2.
 	testClassNode := (testClass >> #accessingV1) ast allChildren detect:[:n| n isVariable].
@@ -567,6 +568,7 @@ VariableBreakpointTest >> testRemoveAfterClassRemoved [
 VariableBreakpointTest >> testRemoveAfterClassWithTempVarRemoved [
 	"Removing the class where the target temporary variable of a variable breakpoint is defined should uninstall the variable breakpoint"
 	|testClassNodes|
+	<ignoreNotImplementedSelectors: #(accessingtemp)>
 	self compileTestClass.
 	testClassNodes := (testClass >> #accessingtemp) ast allChildren.
 
@@ -584,6 +586,7 @@ VariableBreakpointTest >> testRemoveAfterClassWithTempVarRemoved [
 VariableBreakpointTest >> testRemoveAfterSuperclassRemoved [
 	"Removing the class where the target variable of a variable breakpoint is defined should uninstall the variable breakpoint"
 	|testClassNodes|
+		<ignoreNotImplementedSelectors: #(accessingV1)>
 	self compileTestClass.
 	self compileTestClass2.
 	testClassNodes := (testClass >> #accessingV1) ast allChildren.

--- a/src/Slot-Tests/SlotBasicTest.class.st
+++ b/src/Slot-Tests/SlotBasicTest.class.st
@@ -230,7 +230,7 @@ SlotBasicTest >> testWithSharedPool [
 
 { #category : #'tests - shared variables' }
 SlotBasicTest >> testWithSharedVariable [
-
+	<ignoreNotImplementedSelectors: #(var:)>
 	aClass := self make: [ :builder |
 		builder sharedVariablesFromString: 'Var' ].
 	aClass class

--- a/src/Slot-Tests/UnlimitedInstanceVariableSlotTest.class.st
+++ b/src/Slot-Tests/UnlimitedInstanceVariableSlotTest.class.st
@@ -7,6 +7,7 @@ Class {
 { #category : #'test - unlimited ivars' }
 UnlimitedInstanceVariableSlotTest >> testExampleIvarSlot [
 	| object slot |
+	<ignoreNotImplementedSelectors: #(slot1: slot1)>
 	slot := #slot1 => UnlimitedInstanceVariableSlot.
 
 	aClass := self make: [ :builder | builder slots: {slot} ].

--- a/src/Slot-Tests/WriteOnceSlotTest.class.st
+++ b/src/Slot-Tests/WriteOnceSlotTest.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #tests }
 WriteOnceSlotTest >> testRead [
 	| slot |
-	<ignoreNotImplementedSelectors: #(slot1:)>
+	<ignoreNotImplementedSelectors: #(slot1)>
 	slot := #slot1 => WriteOnceSlot.
 	aClass := self make: [ :builder | builder slots: {slot} ].
 

--- a/src/TraitsV2-Tests/TraitFileOutTest.class.st
+++ b/src/TraitsV2-Tests/TraitFileOutTest.class.st
@@ -126,6 +126,7 @@ TraitFileOutTest >> testRemovingMethods [
 	updated."
 
 	"Classes"
+	<ignoreNotImplementedSelectors: #(m12)>
 	self c2 compile: 'm12 ^0' classified: #xxx.
 	self assert: (self c2 includesLocalSelector: #m12).
 	self c2 removeSelector: #m12.

--- a/src/TraitsV2-Tests/TraitMethodDescriptionTest.class.st
+++ b/src/TraitsV2-Tests/TraitMethodDescriptionTest.class.st
@@ -21,7 +21,7 @@ TraitMethodDescriptionTest >> testConflictMethodCreation [
 	"Generate conflicting methods between t1 and t2
 	and check the resulting method in Trait t5 (or c2).
 	Also test selectors like foo:x (without space) or selectors with CRs."
-
+		<ignoreNotImplementedSelectors: #(zork: m12 zork1:zork2: )>
 	"unary"
 
 	self t2 compile: 'm12 ^false'.

--- a/src/TraitsV2-Tests/TraitPureBehaviorTest.class.st
+++ b/src/TraitsV2-Tests/TraitPureBehaviorTest.class.st
@@ -190,7 +190,7 @@ TraitPureBehaviorTest >> testOwnMethodsTakePrecedenceOverTraitsMethods [
 	self assert: (trait methodDict at: #m12) sourceCode equals: 'm12 ^12'
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'tests - applying trait composition' }
 TraitPureBehaviorTest >> testPropagationOfChangesInTraits [
 	<ignoreNotImplementedSelectors: #(zork m21 m12)>
 	| aC2 |

--- a/src/TraitsV2-Tests/TraitPureBehaviorTest.class.st
+++ b/src/TraitsV2-Tests/TraitPureBehaviorTest.class.st
@@ -190,8 +190,9 @@ TraitPureBehaviorTest >> testOwnMethodsTakePrecedenceOverTraitsMethods [
 	self assert: (trait methodDict at: #m12) sourceCode equals: 'm12 ^12'
 ]
 
-{ #category : #'tests - applying trait composition' }
+{ #category : #'as yet unclassified' }
 TraitPureBehaviorTest >> testPropagationOfChangesInTraits [
+	<ignoreNotImplementedSelectors: #(zork m21 m12)>
 	| aC2 |
 	aC2 := self c2 new.
 	self assert: self c2 methodDict size equals: 9.
@@ -209,6 +210,7 @@ TraitPureBehaviorTest >> testPropagationOfChangesInTraits [
 { #category : #'tests - applying trait composition' }
 TraitPureBehaviorTest >> testPropagationOfChangesInTraitsToAliasMethods [
 	| anObject |
+	<ignoreNotImplementedSelectors: #(m22Alias)>
 	anObject := (self createClassNamed: #AliasTestClass superclass: Object uses: self t6) new.
 	self assert: anObject m22Alias equals: 22.
 
@@ -268,7 +270,7 @@ TraitPureBehaviorTest >> testRemovingMethods [
 	"When removing a local method, assure that the method
 	from the trait is installed instead and that the users are
 	updated."
-
+	<ignoreNotImplementedSelectors: #(m12)>
 	"Classes"
 	self c2 compile: 'm12 ^0' classified: #xxx.
 	self assert: (self c2 includesLocalSelector: #m12).
@@ -308,7 +310,7 @@ TraitPureBehaviorTest >> testReshapeClass [
 
 { #category : #'tests - applying trait composition' }
 TraitPureBehaviorTest >> testSuperSends [
-
+	<ignoreNotImplementedSelectors: #(m51)>
 	| aC2 |
 	aC2 := self c2 new.
 	self assert: aC2 m51.
@@ -354,28 +356,4 @@ TraitPureBehaviorTest >> testUpdateWhenLocalMethodRemoved [
 	self deny: aC2 foo.
 	self c2 removeSelector: #foo.
 	self assert: aC2 foo equals: 123
-]
-
-{ #category : #tests }
-TraitPureBehaviorTest >> traitOrClassOfSelector [
-
-	"locally defined in trait or class"
-	self assert: (self t1 traitOrClassOfSelector: #m12) equals: self t1.
-	self assert: (self c1 traitOrClassOfSelector: #foo) equals: self c1.
-
-	"not locally defined - simple"
-	self assert: (self t4 traitOrClassOfSelector: #m21) equals: self t2.
-	self assert: (self c2 traitOrClassOfSelector: #m51) equals: self t5.
-
-	"not locally defined - into nested traits"
-	self assert: (self c2 traitOrClassOfSelector: #m22) equals: self t2.
-
-	"not locally defined - aliases"
-	self assert: (self t6 traitOrClassOfSelector: #m22Alias) equals: self t2.
-
-	"class side"
-	self assert: (self t2 classSide traitOrClassOfSelector: #m2ClassSide:)
-		  equals: self t2 classSide.
-	self assert: (self t6 classSide traitOrClassOfSelector: #m2ClassSide:)
-		  equals: self t2 classSide
 ]

--- a/src/TraitsV2-Tests/TraitTest.class.st
+++ b/src/TraitsV2-Tests/TraitTest.class.st
@@ -30,6 +30,7 @@ TraitTest >> createTrait [
 { #category : #tests }
 TraitTest >> testAddAndRemoveMethodsFromSubtraits [
 	| aC2 |
+	<ignoreNotImplementedSelectors: #(m51)>
 	aC2 := self c2 new.
 	self assert: aC2 m51.
 	self t5 removeSelector: #m51.
@@ -44,6 +45,7 @@ TraitTest >> testAddAndRemoveMethodsFromSubtraits [
 { #category : #tests }
 TraitTest >> testAddAndRemoveMethodsInClassOrTrait [
 	| aC2 |
+	<ignoreNotImplementedSelectors: #(m51)>
 	aC2 := self c2 new.
 	self assert: aC2 m51.
 	self c2 compile: 'm51 ^123'.
@@ -232,6 +234,8 @@ TraitTest >> testExplicitRequirementWithSuperclassImplementatiosAlwaysReturnsThe
 
 	"C9 inherits from Object. C10 inherits from C9.  Each Ci uses the trait Ti."
 
+
+	<ignoreNotImplementedSelectors: #(m1 m2)>
 	self t10 compile: 'm1 ^self explicitRequirement'.
 	self t10 compile: 'm2 self explicitRequirement'.
 	self t9 compile: 'm1 ^2'.

--- a/src/VariablesLibrary-Tests/WeakClassVariableTest.class.st
+++ b/src/VariablesLibrary-Tests/WeakClassVariableTest.class.st
@@ -18,6 +18,7 @@ WeakClassVariableTest >> testCreateClassWithWeakClassVariable [
 { #category : #tests }
 WeakClassVariableTest >> testReadWriteWeakClassVarCompiled [
 	| classVar object valuetoTest |
+	<ignoreNotImplementedSelectors: #(ClassVar ClassVar:)>
 	classVar := #ClassVar => WeakClassVariable.
 	aClass := self make: [ :builder | builder sharedVariables: {classVar} ].
 


### PR DESCRIPTION
- remove some methods duplicated in the hierarchy 
- tag some tests that use selectors that they compile
- remove #traitOrClassOfSelector (dead code)