### PR TITLE
Update more users of #protocol

### DIFF
--- a/src/EpiceaBrowsers/EpMorphVisitor.class.st
+++ b/src/EpiceaBrowsers/EpMorphVisitor.class.st
@@ -199,17 +199,13 @@ EpMorphVisitor >> visitMonticelloVersionsLoad: aMonticelloVersionLoaded [
 { #category : #visitor }
 EpMorphVisitor >> visitProtocolAddition: aProtocolChange [
 
-	^ self
-		displayClass: aProtocolChange behaviorAffectedName
-		protocol: aProtocolChange protocol asString
+	^ self displayClass: aProtocolChange behaviorAffectedName protocol: aProtocolChange protocol
 ]
 
 { #category : #visitor }
 EpMorphVisitor >> visitProtocolRemoval: aProtocolChange [
 
-	^ self
-		displayClass: aProtocolChange behaviorAffectedName
-		protocol: aProtocolChange protocol asString
+	^ self displayClass: aProtocolChange behaviorAffectedName protocol: aProtocolChange protocol
 ]
 
 { #category : #visitor }

--- a/src/EpiceaBrowsers/EpNewStateVisitor.class.st
+++ b/src/EpiceaBrowsers/EpNewStateVisitor.class.st
@@ -68,9 +68,8 @@ EpNewStateVisitor >> visitLogCommentModification: anEvent [
 
 { #category : #visitor }
 EpNewStateVisitor >> visitMethodAddition: aMethodCreatedChange [
-	^ self
-		printProtocol: aMethodCreatedChange protocol
-		sourceCode: aMethodCreatedChange sourceCode
+
+	^ self printProtocol: aMethodCreatedChange protocol sourceCode: aMethodCreatedChange sourceCode
 ]
 
 { #category : #visitor }

--- a/src/EpiceaBrowsers/EpOldStateVisitor.class.st
+++ b/src/EpiceaBrowsers/EpOldStateVisitor.class.st
@@ -66,9 +66,7 @@ EpOldStateVisitor >> visitMethodModification: aMethodModification [
 { #category : #visitor }
 EpOldStateVisitor >> visitMethodRemoval: aMethodRemoval [
 
-	^ self
-		printProtocol: aMethodRemoval protocol
-		sourceCode: aMethodRemoval sourceCode
+	^ self printProtocol: aMethodRemoval protocol sourceCode: aMethodRemoval sourceCode
 ]
 
 { #category : #visitor }

--- a/src/GeneralRules/ReInconsistentMethodClassificationRule.class.st
+++ b/src/GeneralRules/ReInconsistentMethodClassificationRule.class.st
@@ -23,28 +23,26 @@ ReInconsistentMethodClassificationRule class >> uniqueIdentifierName [
 
 { #category : #running }
 ReInconsistentMethodClassificationRule >> check: aMethod forCritiquesDo: aCritiqueBlock [
+
 	| ownerProtocol |
-	ownerProtocol := aMethod protocol.
-	ownerProtocol ifNil: [ ^ self ].
-	((#('as yet unclassified' 'deprecation') includes: ownerProtocol)
-				or: [ ownerProtocol first = $*	 ]) ifTrue: [ ^ self ].
+	self flag: #CompileMethodProtocolMiration.
+	ownerProtocol := aMethod protocolName ifNil: [ ^ self ].
+	((#( 'as yet unclassified' 'deprecation' ) includes: ownerProtocol) or: [ ownerProtocol first = $* ]) ifTrue: [ ^ self ].
 
 	aMethod methodClass superclass ifNotNil: [ :superclass |
-			(superclass lookupSelector: aMethod selector) ifNotNil: [ :superMethod |
-				| superProtocol |
-				superProtocol := superMethod protocol.
-				(superProtocol isNil or: [
-			 	 superProtocol == #'as yet unclassified' or: [
-			 	 superProtocol first = $*	 ] ]) ifFalse: [
-					ownerProtocol ~= superProtocol ifTrue: [
-        aCritiqueBlock cull: ((self critiqueFor: aMethod) tinyHint: 'superclass categorizes as: ' , superProtocol) ]] ] ]
+		(superclass lookupSelector: aMethod selector) ifNotNil: [ :superMethod |
+			| superProtocol |
+			superProtocol := superMethod protocolName ifNil: [ ^ self ].
+			(superProtocol isNil or: [ superProtocol == #'as yet unclassified' or: [ superProtocol first = $* ] ]) ifFalse: [
+				ownerProtocol ~= superProtocol ifTrue: [ aCritiqueBlock cull: ((self critiqueFor: aMethod) tinyHint: 'superclass categorizes as: ' , superProtocol) ] ] ] ]
 ]
 
 { #category : #helpers }
 ReInconsistentMethodClassificationRule >> critiqueFor: aMethod [
 
 	| protocolInSuperclass |
-	protocolInSuperclass := (aMethod methodClass superclass lookupSelector: aMethod selector) protocol.
+	self flag: #CompileMethodProtocolMiration.
+	protocolInSuperclass := (aMethod methodClass superclass lookupSelector: aMethod selector) protocolName.
 
 	^ (ReRefactoringCritique withAnchor: (self anchorFor: aMethod) by: self) refactoring:
 		  (RBMethodProtocolTransformation protocol: { protocolInSuperclass } inMethod: aMethod selector inClass: aMethod methodClass name) asRefactoring

--- a/src/Kernel-Tests/ClassDescriptionTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionTest.class.st
@@ -48,7 +48,7 @@ ClassDescriptionTest >> testAddSelectorWithMethodClassifyMethod [
 
 	self assert: method sourceCode equals: 'wammawink ^ self'.
 	self flag: #CompileMethodProtocolMiration.
-	self assert: method protocol equals: Protocol unclassified.
+	self assert: method protocolName equals: Protocol unclassified.
 	self assert: (class protocolOfSelector: #wammawink) name equals: Protocol unclassified
 ]
 
@@ -82,7 +82,7 @@ ClassDescriptionTest >> testCompileClassifiedWithProtocolInstance [
 
 	self assert: method sourceCode equals: 'foo ^3'.
 	self flag: #CompileMethodProtocolMiration.
-	self assert: method protocol equals: protocol name
+	self assert: method protocolName equals: protocol name
 ]
 
 { #category : #'tests - slots' }

--- a/src/Kernel-Tests/MyVariableNotDeclaredDummyClassForTest.class.st
+++ b/src/Kernel-Tests/MyVariableNotDeclaredDummyClassForTest.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #MyVariableNotDeclaredDummyClassForTest,
-	#superclass : #MessageNotUnderstood,
+	#superclass : #VariableNotDeclared,
 	#category : #'Kernel-Tests-Exceptions'
 }
 

--- a/src/Kernel-Tests/MyVariableNotDeclaredDummyClassForTest.class.st
+++ b/src/Kernel-Tests/MyVariableNotDeclaredDummyClassForTest.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #MyVariableNotDeclaredDummyClassForTest,
-	#superclass : #VariableNotDeclared,
+	#superclass : #MessageNotUnderstood,
 	#category : #'Kernel-Tests-Exceptions'
 }
 

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -389,7 +389,7 @@ CompiledMethod >> isClassSide [
 CompiledMethod >> isClassified [
 
 	self flag: #CompileMethodProtocolMiration.
-	^ self protocol ~= Protocol unclassified
+	^ self protocolName ~= Protocol unclassified
 ]
 
 { #category : #testing }

--- a/src/ReleaseTests/ProperPackagesTest.class.st
+++ b/src/ReleaseTests/ProperPackagesTest.class.st
@@ -20,7 +20,7 @@ ProperPackagesTest >> testPackageExtensionsStartsWithProperPackageName [
 	| condition badCases |
 	self flag: #CompileMethodProtocolMiration.
 	condition := [ :protocol | (protocol beginsWith: '*') and: [ protocol second isLowercase ] ].
-	badCases := CompiledMethod allInstances select: [ :method | method protocol isNotNil and: [ condition value: method protocol ] ].
+	badCases := CompiledMethod allInstances select: [ :method | method protocol isNotNil and: [ condition value: method protocolName ] ].
 
 	self assert: badCases isEmpty
 ]

--- a/src/Tool-Base/MethodClassifier.class.st
+++ b/src/Tool-Base/MethodClassifier.class.st
@@ -290,7 +290,7 @@ MethodClassifier >> protocolByOtherImplementors: aMethod [
 
 	aMethod implementors ifEmpty: [ ^ self ] ifNotEmpty: [ :methods |
 		self flag: #CompileMethodProtocolMiration.
-		methods do: [ :method | ((method protocol beginsWith: '*') or: [ method isClassified not ]) ifFalse: [ protocolBag add: method protocolName ] ] without: aMethod ].
+		methods do: [ :method | ((method protocolName beginsWith: '*') or: [ method isClassified not ]) ifFalse: [ protocolBag add: method protocolName ] ] without: aMethod ].
 
 	protocolBag ifEmpty: [ ^ self ].
 	protocol := protocolBag sortedCounts first value
@@ -360,7 +360,7 @@ MethodClassifier >> superclassProtocol: aMethod [
 		(currentClass includesSelector: aMethod selector) ifTrue: [
 			| possibleProtocol |
 			self flag: #CompileMethodProtocolMiration.
-			possibleProtocol := (currentClass >> aMethod selector) protocol.
+			possibleProtocol := (currentClass >> aMethod selector) protocolName.
 			((possibleProtocol beginsWith: '*') or: possibleProtocol asSymbol = currentClass package name) ifFalse: [ ^ possibleProtocol ] ] ].
 	^ nil
 ]

--- a/src/TraitsV2-Tests/T2TraitWithCategoriesTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitWithCategoriesTest.class.st
@@ -16,8 +16,8 @@ T2TraitWithCategoriesTest >> testPackageOfMethodFromTraits [
 
 	t2 := self newTrait: #T2 with: #() uses: t1.
 
-	self assert: (t1 >> #m1) protocol equals: 'aProtocol'.
-	self assert: (t2 >> #m1) protocol equals: 'aProtocol'
+	self assert: (t1 >> #m1) protocolName equals: 'aProtocol'.
+	self assert: (t2 >> #m1) protocolName equals: 'aProtocol'
 ]
 
 { #category : #tests }
@@ -28,8 +28,8 @@ T2TraitWithCategoriesTest >> testPackageOfMethodFromTraitsAfterCreation [
 	t2 := self newTrait: #T2 with: #() uses: t1.
 	t1 compile: 'm1 ^42.' classified: 'aProtocol'.
 
-	self assert: (t1 >> #m1) protocol equals: 'aProtocol'.
-	self assert: (t2 >> #m1) protocol equals: 'aProtocol'
+	self assert: (t1 >> #m1) protocolName equals: 'aProtocol'.
+	self assert: (t2 >> #m1) protocolName equals: 'aProtocol'
 ]
 
 { #category : #tests }
@@ -43,8 +43,8 @@ T2TraitWithCategoriesTest >> testPackageOfMethodFromTraitsChanged [
 
 	t1 compile: 'm1 ^42.' classified: 'anotherProtocol'.
 
-	self assert: (t1 >> #m1) protocol equals: 'anotherProtocol'.
-	self assert: (t2 >> #m1) protocol equals: 'anotherProtocol'
+	self assert: (t1 >> #m1) protocolName equals: 'anotherProtocol'.
+	self assert: (t2 >> #m1) protocolName equals: 'anotherProtocol'
 ]
 
 { #category : #tests }
@@ -58,8 +58,8 @@ T2TraitWithCategoriesTest >> testPackageOfMethodFromTraitsChangedWithoutCompile 
 
 	trait1 classify: #m1 under: 'anotherProtocol'.
 
-	self assert: (trait1 >> #m1) protocol equals: 'anotherProtocol'.
-	self assert: (trait2 >> #m1) protocol equals: 'anotherProtocol'
+	self assert: (trait1 >> #m1) protocolName equals: 'anotherProtocol'.
+	self assert: (trait2 >> #m1) protocolName equals: 'anotherProtocol'
 ]
 
 { #category : #tests }
@@ -72,8 +72,8 @@ T2TraitWithCategoriesTest >> testPackageOfMethodFromTraitsOverriden [
 	t2 := self newTrait: #T2 with: #() uses: t1.
 	t2 compile: 'm1 ^42.' classified: 'anotherProtocol'.
 
-	self assert: (t1 >> #m1) protocol equals: 'aProtocol'.
-	self assert: (t2 >> #m1) protocol equals: 'anotherProtocol'
+	self assert: (t1 >> #m1) protocolName equals: 'aProtocol'.
+	self assert: (t2 >> #m1) protocolName equals: 'anotherProtocol'
 ]
 
 { #category : #tests }
@@ -88,8 +88,8 @@ T2TraitWithCategoriesTest >> testPackageOfMethodFromTraitsRenamedCategory [
 
 	t1 renameProtocol: 'aProtocol' as: 'anotherProtocol'.
 
-	self assert: (t1 >> #m1) protocol equals: 'anotherProtocol'.
-	self assert: (t2 >> #m1) protocol equals: 'anotherProtocol'.
-	self assert: (t1 >> #m2) protocol equals: 'anotherProtocol'.
-	self assert: (t2 >> #m2) protocol equals: 'anotherProtocol'
+	self assert: (t1 >> #m1) protocolName equals: 'anotherProtocol'.
+	self assert: (t2 >> #m1) protocolName equals: 'anotherProtocol'.
+	self assert: (t1 >> #m2) protocolName equals: 'anotherProtocol'.
+	self assert: (t2 >> #m2) protocolName equals: 'anotherProtocol'
 ]


### PR DESCRIPTION
Here is a new step to be able to make CompiledMethod>>protocol return a real protocol by using more #protocolName and tagging the places that should be updated to use #protocol again in the future but with some code changes