### PR TITLE
Bring back coverage test

### DIFF
--- a/src/Coverage/CoverageCollectorTest.class.st
+++ b/src/Coverage/CoverageCollectorTest.class.st
@@ -90,17 +90,16 @@ CoverageCollectorTest >> testCallgraph [
 CoverageCollectorTest >> testExample [
 
 	| collector coverage |
-	self skipOnPharoCITestingEnvironment.
-	"see https://github.com/pharo-project/pharo/issues/13746"
 	collector := CoverageCollector new. "Instantiate"
-	collector methods: Point methods , Rectangle methods. "Configure with the methods to watch."
+	"We skip the method with special selectors because them might not be detected by the coverage collector in case they are optimized by the VM."
+	collector methods: (Point methods , Rectangle methods reject: [ :method | BytecodeEncoder specialSelectors includes: method selector ]). "Configure with the methods to watch."
 	coverage := collector runOn: [ (1 @ 1 corner: 2 @ 2) center ]. "Setup, execute and teardown."
 	self
 		assertCollection: (coverage methods collect: [ :method | method name ])
 		hasSameElements:
-			#( 'Point>>#+' 'Point>>#''//''' 'Point>>#y' 'Point>>#corner:' 'Point>>#x' 'Point>>#isPoint' 'Rectangle>>#setPoint:point:' 'Rectangle>>#topLeft'
+			#( 'Point>>#corner:' 'Point>>#isPoint' 'Rectangle>>#setPoint:point:' 'Rectangle>>#topLeft'
 			   'Rectangle>>#bottomRight' 'Rectangle>>#center' ). "Inspect the results"
-	self assert: coverage nodes size equals: 12 "Covered paths are also available"
+	self assert: coverage nodes size equals: 6 "Covered paths are also available"
 ]
 
 { #category : #tests }


### PR DESCRIPTION
One coverage tests has been disabled after failing randomly on the CI. The problems comes from some VM optimizations on the VM. In linux, special selectors  are running in the interpreter so the messages Point >> #x and Point >> #y are never executed. In OSX, the method is compiled to machine code and the messages are sent.

To have a more robust test, I excluded the special selectors from the list of methods to cover