### PR TITLE
Use thisProcess in some tests

### DIFF
--- a/src/Debugger-Model-Tests/DebugSessionContextsTest.class.st
+++ b/src/Debugger-Model-Tests/DebugSessionContextsTest.class.st
@@ -13,8 +13,8 @@ DebugSessionContextsTest >> setUp [
 
 	super setUp.
 	process := [ | debugSession |
-	debugSession := Processor activeProcess newDebugSessionNamed: 'test' startedAt: (debuggedThisContext := thisContext).
-	Processor activeProcess suspend ] fork.
+	debugSession := thisProcess newDebugSessionNamed: 'test' startedAt: (debuggedThisContext := thisContext).
+	thisProcess suspend ] fork.
 	"The line under is a bit dirty. It is to make sure that the debugged process has suspended itself before it is being examined by the test methods."
 	[ process isSuspended ] whileFalse: [ 100 milliSeconds wait ]
 ]

--- a/src/Debugger-Oups-Tests/OupsDebugRequestTest.class.st
+++ b/src/Debugger-Oups-Tests/OupsDebugRequestTest.class.st
@@ -39,7 +39,7 @@ OupsDebugRequestTest >> testDebugSession [
 OupsDebugRequestTest >> testDefaultProcess [
 	| dr |
 	dr := OupsDebugRequest basicNew.
-	self assert: dr process identicalTo: Processor activeProcess
+	self assert: dr process identicalTo: thisProcess
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests-Extended/ClassUsedInInstructionStreamTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassUsedInInstructionStreamTest.class.st
@@ -11,7 +11,7 @@ Class {
 { #category : #examples }
 ClassUsedInInstructionStreamTest >> aMethodSuspendedBeforeTheTerminateOfAnotherProcess [
 
-	Processor activeProcess suspend.
+	thisProcess suspend.
 
 	aProcess terminate.
 
@@ -23,21 +23,21 @@ ClassUsedInInstructionStreamTest >> aMethodWithHalt [
 
 	<haltOrBreakpointForTesting>
 
-	Processor activeProcess suspend.
+	thisProcess suspend.
 	self halt
 ]
 
 { #category : #examples }
 ClassUsedInInstructionStreamTest >> aMethodWithMNU [
 
-	Processor activeProcess suspend.
+	thisProcess suspend.
 	self iAmAnMNUMessage
 ]
 
 { #category : #examples }
 ClassUsedInInstructionStreamTest >> aMethodWithMustBeBooleanMNU [
 
-	Processor activeProcess suspend.
+	thisProcess suspend.
 
 	^ 2 ifTrue: [ 5 ] ifFalse: [ 7 ]
 ]

--- a/src/Kernel-Tests-Extended/WriteBarrierTest.class.st
+++ b/src/Kernel-Tests-Extended/WriteBarrierTest.class.st
@@ -36,7 +36,7 @@ WriteBarrierTest >> alwaysWritableObjects [
 	"Objects that currently can't be immutable"
 	^ { ContextInstance .
 		Processor .
-		Processor activeProcess }
+		thisProcess }
 ]
 
 { #category : #'guinea pigs' }

--- a/src/Kernel-Tests/MyVariableNotDeclaredDummyClassForTest.class.st
+++ b/src/Kernel-Tests/MyVariableNotDeclaredDummyClassForTest.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #MyVariableNotDeclaredDummyClassForTest,
-	#superclass : #VariableNotDeclared,
+	#superclass : #MessageNotUnderstood,
 	#category : #'Kernel-Tests-Exceptions'
 }
 

--- a/src/Kernel-Tests/OutOfMemoryTest.class.st
+++ b/src/Kernel-Tests/OutOfMemoryTest.class.st
@@ -37,7 +37,7 @@ OutOfMemoryTest >> testSignalOfTheLowSpaceFromTheVM [
 	"I emulate the execution when the signal is send by the VM"
 
 	self should: [
-		Smalltalk specialObjectsArray at: 23 put: Processor activeProcess.
+		Smalltalk specialObjectsArray at: 23 put: thisProcess.
 		Smalltalk signalLowSpace.
 		s wait] raise: OutOfMemory
 ]

--- a/src/Kernel-Tests/ProcessSpecificTest.class.st
+++ b/src/Kernel-Tests/ProcessSpecificTest.class.st
@@ -66,7 +66,7 @@ ProcessSpecificTest >> testDynamicVariableAccessFromDifferentProcess [
 	sem := Semaphore new.
 	process := [ TestDynamicVariable value: 123 during: [ sem wait ] ] fork.
 	Processor yield.
-	Processor activeProcess evaluate: [ result := TestDynamicVariable value ] onBehalfOf: process.
+	thisProcess evaluate: [ result := TestDynamicVariable value ] onBehalfOf: process.
 	sem signal.
 	self assert: result equals: 123
 ]
@@ -84,7 +84,7 @@ ProcessSpecificTest >> testDynamicVariableRemovedAfterUse [
 		value: 3
 		during: [  ].
 
-	self assert: (Processor activeProcess psValueAt: TestDynamicVariable soleInstance index) equals: nil
+	self assert: (thisProcess psValueAt: TestDynamicVariable soleInstance index) equals: nil
 ]
 
 { #category : #testing }

--- a/src/Kernel-Tests/ProcessTerminateBugTest.class.st
+++ b/src/Kernel-Tests/ProcessTerminateBugTest.class.st
@@ -18,7 +18,7 @@ ProcessTerminateBugTest >> testSchedulerTermination [
 	           sema signal.
 	           sema2 wait.
 	           "will be suspended here"
-	           gotHere := true "e.g., we must *never* get here" ] forkAt: Processor activeProcess priority.
+	           gotHere := true "e.g., we must *never* get here" ] forkAt: thisProcess priority.
 	sema wait. "until process gets scheduled"
 	process terminate.
 	sema2 signal.
@@ -154,7 +154,7 @@ ProcessTerminateBugTest >> testTerminationDuringNestedUnwindS1 [
 		[
 			[
 				[ ] ensure: [
-					[Processor activeProcess suspend] ensure: [
+					[thisProcess suspend] ensure: [
 						x1 := true].
 					x2 := true]
 			] ensure: [
@@ -182,7 +182,7 @@ ProcessTerminateBugTest >> testTerminationDuringNestedUnwindS2 [
 			[
 				[ ] ensure: [
 					[ ] ensure: [
-						Processor activeProcess suspend.
+						thisProcess suspend.
 						x1 := true].
 					x2 := true]
 			] ensure: [

--- a/src/Kernel-Tests/SemaphoreTest.class.st
+++ b/src/Kernel-Tests/SemaphoreTest.class.st
@@ -18,7 +18,7 @@ SemaphoreTest >> classToBeTested [
 
 { #category : #private }
 SemaphoreTest >> criticalError [
-	Processor activeProcess terminate
+	thisProcess terminate
 ]
 
 { #category : #tests }
@@ -132,10 +132,10 @@ SemaphoreTest >> testSchedulesFIFO [
 
 	[
 		semaphore wait.
-		waitingLongestResumed := true ] forkAt: Processor activeProcess priority + 10.
+		waitingLongestResumed := true ] forkAt: thisProcess priority + 10.
 	[
 		semaphore wait.
-		higherPriorityResumed := true ] forkAt: Processor activeProcess priority + 20.
+		higherPriorityResumed := true ] forkAt: thisProcess priority + 20.
 
 	self deny: waitingLongestResumed.
 	self deny: higherPriorityResumed.

--- a/src/SUnit-Core/TestExecutionEnvironment.class.st
+++ b/src/SUnit-Core/TestExecutionEnvironment.class.st
@@ -211,7 +211,7 @@ TestExecutionEnvironment >> isMainTestProcess: aProcess [
 
 { #category : #testing }
 TestExecutionEnvironment >> isMainTestProcessActive [
-	^self isMainTestProcess: Processor activeProcess
+	^self isMainTestProcess: thisProcess
 ]
 
 { #category : #testing }

--- a/src/SUnit-Tests/ProcessMonitorTestServiceTest.class.st
+++ b/src/SUnit-Tests/ProcessMonitorTestServiceTest.class.st
@@ -70,7 +70,7 @@ ProcessMonitorTestServiceTest >> testAlwaysPassBackgroundHalt [
 
 	haltWasPassed := false.
 	halt := Halt new.
-	process := self fork: [ Processor activeProcess suspend. halt signal ].
+	process := self fork: [ thisProcess suspend. halt signal ].
 	testService handleNewProcess: process.
 
 	process on: Halt do: [ :actual |
@@ -173,7 +173,7 @@ ProcessMonitorTestServiceTest >> testDisableRunningProcessesCleanupWhenPassBackg
 ProcessMonitorTestServiceTest >> testDoesNotRaiseForkedProcessFailureWhenFailuresWerePassedAndMainProcessAlsoFails [
 
 	self fork: [ testService suspendBackgroundFailure: Error new.
-		Processor activeProcess suspend "To emulate process under debugger" ].
+		thisProcess suspend "To emulate process under debugger" ].
 
 	testService passBackgroundFailures.
 	testService recordTestFailure: Error new.
@@ -237,7 +237,7 @@ ProcessMonitorTestServiceTest >> testDoesNotRaiseLeftRunningProcessWhenThereWasM
 ProcessMonitorTestServiceTest >> testFailTestWhenBackgroundFailureWasPassedButMainProcessCompletesSuccessfully [
 
 	self fork: [ testService suspendBackgroundFailure: Error new.
-		Processor activeProcess suspend "To emulate process under debugger" ].
+		thisProcess suspend "To emulate process under debugger" ].
 
 	testService passBackgroundFailures.
 
@@ -418,7 +418,7 @@ ProcessMonitorTestServiceTest >> testPassBackgroundFailuresWhenSuspensionLogicIs
 	self skip.
 	errorWasPassed := false.
 	error := Error new messageText: 'test error'.
-	process := self fork: [ Processor activeProcess suspend. error signal ].
+	process := self fork: [ thisProcess suspend. error signal ].
 
 	testService disableBackgroudFailuresSuspension.
 	self deny: testService shouldSuspendBackgroundFailures.
@@ -439,7 +439,7 @@ ProcessMonitorTestServiceTest >> testRecordMainTestProcessError [
 	testService handleException: error.
 
 	self
-		assert: (testService testFailures at: Processor activeProcess)
+		assert: (testService testFailures at: thisProcess)
 		equals: error
 ]
 
@@ -452,7 +452,7 @@ ProcessMonitorTestServiceTest >> testRecordMainTestProcessUnhandledError [
 	testService handleException: error.
 
 	self
-		assert: (testService testFailures at: Processor activeProcess)
+		assert: (testService testFailures at: thisProcess)
 		equals: error
 ]
 
@@ -490,7 +490,7 @@ ProcessMonitorTestServiceTest >> testResumeFailedProcessesWhenHaltIsSignaledInBa
 	| processWithHalt executed |
 	executed := false.
 	self fork: [ testService suspendBackgroundFailure: Error new. executed := true ].
-	processWithHalt := self fork: [ Processor activeProcess suspend. Halt new signal ].
+	processWithHalt := self fork: [ thisProcess suspend. Halt new signal ].
 
 	processWithHalt on: Halt do: [ :actual | ].
 	processWithHalt resume.

--- a/src/SUnit-Tests/TestExecutionEnvironmentTest.class.st
+++ b/src/SUnit-Tests/TestExecutionEnvironmentTest.class.st
@@ -62,7 +62,7 @@ TestExecutionEnvironmentTest >> testActivationShouldSetUpMainTestProcess [
 
 	executionEnvironment activated.
 
-	self assert: executionEnvironment mainTestProcess equals: Processor activeProcess
+	self assert: executionEnvironment mainTestProcess equals: thisProcess
 ]
 
 { #category : #tests }
@@ -239,7 +239,7 @@ TestExecutionEnvironmentTest >> testIgnoreLongTestWhenItIsSuspendedAsUnderDebug 
 		executionEnvironment activated.
 		[ self runTestWith: [
 				executionEnvironment maxTimeForTest: 10 milliSeconds.
-				Processor activeProcess suspend "it simulates the under debugger condition"]
+				thisProcess suspend "it simulates the under debugger condition"]
 		] on: TestTookTooMuchTime do: [ :err | timeOutSignaled := true ]
 	] forkAt: Processor activePriority + 1.
 
@@ -260,7 +260,7 @@ TestExecutionEnvironmentTest >> testIsMainTestProcess [
 
 	executionEnvironment activated.
 
-	self assert: (executionEnvironment isMainTestProcess: Processor activeProcess).
+	self assert: (executionEnvironment isMainTestProcess: thisProcess).
 
 	self deny: (executionEnvironment isMainTestProcess: [] newProcess)
 ]

--- a/src/TaskIt-Tests/TKTFutureTest.class.st
+++ b/src/TaskIt-Tests/TKTFutureTest.class.st
@@ -539,7 +539,7 @@ TKTFutureTest >> testFutureSuccessCallbackExecutesInNewProcess [
 	future := runner future: [ 1 + 1 ].
 
 	30 timesRepeat: [
-		future onSuccessDo: [ :r | processIds nextPut: Processor activeProcess identityHash ] ].
+		future onSuccessDo: [ :r | processIds nextPut: thisProcess identityHash ] ].
 
 	1 second wait.
 

--- a/src/TaskIt-Tests/TKTLocalProcessTaskRunnerTest.class.st
+++ b/src/TaskIt-Tests/TKTLocalProcessTaskRunnerTest.class.st
@@ -22,10 +22,10 @@ TKTLocalProcessTaskRunnerTest >> testLocalProcessTaskRunnerRunsInLocalProcess [
 
 	| runner future got |
 	runner := TKTLocalProcessTaskRunner new.
-	future := runner future: [ Processor activeProcess identityHash ].
+	future := runner future: [ thisProcess identityHash ].
 
 	future onSuccessDo: [ :value | got := value ].
 	future waitForCompletion: 2 seconds.
 
-	self assert: got equals: Processor activeProcess identityHash
+	self assert: got equals: thisProcess identityHash
 ]

--- a/src/TaskIt-Tests/TKTNewProcessTaskRunnerTest.class.st
+++ b/src/TaskIt-Tests/TKTNewProcessTaskRunnerTest.class.st
@@ -29,7 +29,7 @@ TKTNewProcessTaskRunnerTest >> testNewProcessTaskRunnerRunsInNewProcessEveryTime
 	runner := TKTNewProcessTaskRunner new.
 	hashes := AtomicSharedQueue new.
 
-	futures := (1 to: 10) collect: [ :i | (runner future: [ Processor activeProcess identityHash ]) onSuccessDo: [ :v | hashes nextPut: v ] ].
+	futures := (1 to: 10) collect: [ :i | (runner future: [ thisProcess identityHash ]) onSuccessDo: [ :v | hashes nextPut: v ] ].
 
 	futures do: [ :each | each waitForCompletion: 2 seconds ].
 
@@ -45,7 +45,7 @@ TKTNewProcessTaskRunnerTest >> testNewProcessTaskRunnerRunsNeverInLocalProcess [
 	runner := TKTNewProcessTaskRunner new.
 	hashes := AtomicSharedQueue new.
 
-	futures := (1 to: 10) collect: [ :i | (runner future: [ Processor activeProcess identityHash ]) onSuccessDo: [ :v | hashes nextPut: v ] ].
+	futures := (1 to: 10) collect: [ :i | (runner future: [ thisProcess identityHash ]) onSuccessDo: [ :v | hashes nextPut: v ] ].
 
 	futures do: [ :each | each waitForCompletion: 2 seconds ].
 

--- a/src/TaskIt-Tests/TKTWorkerTest.class.st
+++ b/src/TaskIt-Tests/TKTWorkerTest.class.st
@@ -103,7 +103,7 @@ TKTWorkerTest >> testWorkerRunsAlwaysInSameProcess [
 	worker := TKTWorker new.
 	worker start.
 
-	futures := (1 to: 10) collect: [ :i | worker future: [ hash := Processor activeProcess identityHash ] ].
+	futures := (1 to: 10) collect: [ :i | worker future: [ hash := thisProcess identityHash ] ].
 	hashes := futures collect: [ :each | each synchronizeTimeout: 1 hour ].
 
 	self assert: hashes asSet size equals: 1
@@ -116,8 +116,8 @@ TKTWorkerTest >> testWorkerRunsInSeparateProcess [
 	worker := TKTWorker new.
 	worker start.
 
-	future := worker future: [ hash := Processor activeProcess identityHash ].
+	future := worker future: [ hash := thisProcess identityHash ].
 	future waitForCompletion: 1 hour.
 
-	self assert: hash ~= Processor activeProcess identityHash
+	self assert: hash ~= thisProcess identityHash
 ]


### PR DESCRIPTION
This PR changes some methods to use thisProcess instead of "Processor activeProcess"

- Just in tests for now
- after this, we have 80 usages of activeProcess remaining