### PR TITLE
Ensure all tests are loaded 

### DIFF
--- a/src/BaselineOfCalypso/BaselineOfCalypso.class.st
+++ b/src/BaselineOfCalypso/BaselineOfCalypso.class.st
@@ -141,8 +141,8 @@ BaselineOfCalypso >> baseline: spec [
 			package: #'Calypso-SystemPlugins-DependencyAnalyser-Browser' with: [
 				spec requires: #(#'Calypso-SystemTools-Core' ) ];			
 			
-			package: #'Calypso-Browser' with: [
-				spec requires: #(#'Calypso-NavigationModel' 'Commander' ). ];
+			package: #'Calypso-Browser' with: [ spec requires: #(#'Calypso-NavigationModel' #'Commander' ). ];
+			package: #'Calypso-Browser-Tests' with: [ spec requires: #(#'Calypso-Browser' ). ];
 
 			package: #'Calypso-SystemTools-Core' with: [
 				spec requires: #(#'Calypso-SystemQueries' #'Calypso-Browser' 'SystemCommands' ). ];
@@ -182,7 +182,7 @@ BaselineOfCalypso >> baseline: spec [
 			
 			group: 'MinimalEnvironmentTests' with: #(#'Calypso-NavigationModel-Tests' #'Calypso-SystemQueries-Tests' #'Calypso-SystemPlugins-Traits-Queries-Tests' 'Calypso-SystemPlugins-InheritanceAnalysis-Queries-Tests' #'Calypso-SystemPlugins-Deprecation-Queries-Tests' #'Calypso-SystemPlugins-SUnit-Queries-Tests' #'Calypso-SystemPlugins-Undeclared-Queries-Tests' #'Calypso-SystemPlugins-FFI-Queries-Tests' #'Calypso-SystemPlugins-Flags-Queries-Tests' #'Calypso-SystemPlugins-ClassScripts-Queries-Tests');
 						
-			group: 'Tests' with: #('MinimalEnvironmentTests' #'Calypso-SystemTools-FullBrowser-Tests' #'Calypso-SystemTools-QueryBrowser-Tests' #'Calypso-SystemPlugins-Reflectivity-Queries-Tests' #'Calypso-SystemPlugins-Reflectivity-Browser-Tests' #'Calypso-SystemPlugins-Critic-Queries-Tests');
+			group: 'Tests' with: #('MinimalEnvironmentTests' #'Calypso-SystemTools-FullBrowser-Tests' #'Calypso-SystemTools-QueryBrowser-Tests' #'Calypso-SystemPlugins-Reflectivity-Queries-Tests' #'Calypso-SystemPlugins-Reflectivity-Browser-Tests' #'Calypso-SystemPlugins-Critic-Queries-Tests' #'Calypso-Browser-Tests');
 			
 			group: 'ProcessEnvironment' with: #(#'Calypso-ProcessQueries');
 			group: 'ProcessBrowser' with: #(#'Calypso-SystemTools-ProcessBrowser');

--- a/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
+++ b/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
@@ -61,6 +61,7 @@ BaselineOfGeneralTests >> baseline: spec [
 			package: 'Tool-FileList-Tests';
 			package: 'Tool-Finder-Tests';
 			package: 'Tool-Profilers-Tests';
+			package: 'Tool-ImageCleaner-Tests';
 			package: 'Tool-Workspace-Tests';
 			package: 'Tools-CodeNavigation-Tests';
 			package: 'Tools-Tests';

--- a/src/BaselineOfRefactoring/BaselineOfRefactoring.class.st
+++ b/src/BaselineOfRefactoring/BaselineOfRefactoring.class.st
@@ -10,6 +10,7 @@ BaselineOfRefactoring >> baseline: spec [
 	spec for: #'common' do: [
 		spec 
 			package: 'SUnit-Rules';
+			package: 'SUnit-Rules-Tests' with: [ spec requires: #( 'SUnit-Rules' ) ];
 			package: 'Kernel-Tests-Rules';
 			package: 'Polymorph-Widgets-Rules';
 			package: 'System-Settings-Rules';
@@ -22,6 +23,6 @@ BaselineOfRefactoring >> baseline: spec [
 			package: 'Refactoring-Tests-Environment'.
 		spec 
 			group: 'Rules' with: #('SUnit-Rules' 'Kernel-Tests-Rules' 'Polymorph-Widgets-Rules' 'System-Settings-Rules' 'GeneralRules' 'Rubric-Rules');
-			group: 'Tests' with: #('Refactoring-Tests-Core' 'Refactoring-Tests-Changes' 'Refactoring-Tests-Critics' 'Refactoring-Tests-Environment');
+			group: 'Tests' with: #('Refactoring-Tests-Core' 'Refactoring-Tests-Changes' 'Refactoring-Tests-Critics' 'Refactoring-Tests-Environment' 'SUnit-Rules-Tests');
 			group: 'default' with: #('Rules' 'Tests') ]
 ]

--- a/src/BaselineOfSUnit/BaselineOfSUnit.class.st
+++ b/src/BaselineOfSUnit/BaselineOfSUnit.class.st
@@ -40,6 +40,7 @@ BaselineOfSUnit >> baseline: spec [
 				package: 'SUnit-Visitor' with: [ spec requires: #('SUnit-Core') ];
 				package: 'SUnit-Visitor-Tests' with: [ spec requires: #('SUnit-Visitor') ];
 				package: 'SUnit-MockObjects' with: [ spec requires: #('SUnit-Core') ];
+				package: 'SUnit-MockObjects-Tests' with: [ spec requires: #('SUnit-MockObjects') ];
 				package: 'SUnit-UI' with: [ spec requires: #('Coverage') ];
 				package: 'SUnit-Support-UITesting-Tests';
 				package: 'SUnit-Support-UITesting';
@@ -50,7 +51,7 @@ BaselineOfSUnit >> baseline: spec [
 				group: 'Core' with: #('SUnit-Core' 'SUnit-Core-Traits' 'SUnit-Visitor');
 				group: 'MockObjects' with: #('SUnit-MockObjects');
 				group: 'UI' with: #('SUnit-UI' 'SUnit-Support-UITesting' 'Coverage');
-				group: 'Tests' with: #('SUnit-Tests' 'SUnit-Support-UITesting-Tests' 'SUnit-Visitor-Tests');
+				group: 'Tests' with: #('SUnit-Tests' 'SUnit-Support-UITesting-Tests' 'SUnit-Visitor-Tests' 'SUnit-MockObjects-Tests');
 				group: 'JenkinsSupport' with: #('JenkinsTools-Core' 'JenkinsTools-ExtraReports');
 				group: 'default' with: #('SUnit-Core' 'SUnit-Core-Traits' 'SUnit-Tests' 'JenkinsTools-Core' 'JenkinsTools-ExtraReports' 'SUnit-MockObjects') ]
 ]

--- a/src/Calypso-Browser-Tests/ClyNotebookPageRecyclerTest.class.st
+++ b/src/Calypso-Browser-Tests/ClyNotebookPageRecyclerTest.class.st
@@ -62,7 +62,7 @@ ClyNotebookPageRecyclerTest >> testToolsToInstall [
 		contexts: { self methodContext }.
 	
 	self assert: recycler toolsToInstall size equals: 1.
-	self assert: recycler toolsToInstall anyOne equals: ClyMethodCodeEditorToolMorph.
+	self assert: recycler toolsToInstall anyOne activation toolClass equals: ClyMethodCodeEditorToolMorph.
 ]
 
 { #category : #tests }

--- a/src/FormCanvas-Core-Tests/package.st
+++ b/src/FormCanvas-Core-Tests/package.st
@@ -1,1 +1,0 @@
-Package { #name : #'FormCanvas-Core-Tests' }

--- a/src/FormCanvas-Tests/BalloonEngineTest.class.st
+++ b/src/FormCanvas-Tests/BalloonEngineTest.class.st
@@ -4,7 +4,7 @@ A BalloonEngineTest is a test class for testing the behavior of BalloonEngine
 Class {
 	#name : #BalloonEngineTest,
 	#superclass : #TestCase,
-	#category : #'FormCanvas-Core-Tests-BalloonEngine'
+	#category : #'FormCanvas-Tests'
 }
 
 { #category : #tests }

--- a/src/SUnit-MockObjects-Tests/MyClassUsingMock2Test.class.st
+++ b/src/SUnit-MockObjects-Tests/MyClassUsingMock2Test.class.st
@@ -26,7 +26,7 @@ MyClassUsingMock2Test >> setUp [
 
 { #category : #running }
 MyClassUsingMock2Test >> testMeaningOfLife [
-
+	<ignoreNotImplementedSelectors: #(meaningOfLife: secondMeaning:and:)>
 	self assert: (mock meaningOfLife: 22) equals: 42.
 	self assert: (mock secondMeaning: 32 and: 64) equals: 84
 ]
@@ -34,6 +34,6 @@ MyClassUsingMock2Test >> testMeaningOfLife [
 { #category : #running }
 MyClassUsingMock2Test >> testMeaningOfLifeDoesNotPassCorrectValue [
 
-	self should: [ self assert: (mock meaningOfLife: 33) equals: 42] raise: TestFailure
-
+	<ignoreNotImplementedSelectors: #(meaningOfLife:)>
+	self should: [ self assert: (mock meaningOfLife: 33) equals: 42 ] raise: TestFailure
 ]

--- a/src/SUnit-MockObjects-Tests/MyClassUsingMock2Test.class.st
+++ b/src/SUnit-MockObjects-Tests/MyClassUsingMock2Test.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : #MyClassUsingMock2,
+	#name : #MyClassUsingMock2Test,
 	#superclass : #TestCase,
 	#instVars : [
 		'mock'
@@ -8,7 +8,7 @@ Class {
 }
 
 { #category : #running }
-MyClassUsingMock2 >> setUp [
+MyClassUsingMock2Test >> setUp [
 
 	super setUp.
 	mock := MockObject new.
@@ -25,14 +25,14 @@ MyClassUsingMock2 >> setUp [
 ]
 
 { #category : #running }
-MyClassUsingMock2 >> testMeaningOfLife [
+MyClassUsingMock2Test >> testMeaningOfLife [
 
 	self assert: (mock meaningOfLife: 22) equals: 42.
 	self assert: (mock secondMeaning: 32 and: 64) equals: 84
 ]
 
 { #category : #running }
-MyClassUsingMock2 >> testMeaningOfLifeDoesNotPassCorrectValue [
+MyClassUsingMock2Test >> testMeaningOfLifeDoesNotPassCorrectValue [
 
 	self should: [ self assert: (mock meaningOfLife: 33) equals: 42] raise: TestFailure
 

--- a/src/SUnit-MockObjects-Tests/MyClassUsingMock3Test.class.st
+++ b/src/SUnit-MockObjects-Tests/MyClassUsingMock3Test.class.st
@@ -21,13 +21,15 @@ MyClassUsingMock3Test >> setUp [
 { #category : #running }
 MyClassUsingMock3Test >> testVerify [
 
-	mock meaningOfLife: 3.
+	<ignoreNotImplementedSelectors: #( meaningOfLife: )>
+	mock meaningOfLife: 3
 ]
 
 { #category : #running }
 MyClassUsingMock3Test >> testVerify2 [
 	"When the arguments are correct, the verify block is executed and it should return true."
-	
+
+	<ignoreNotImplementedSelectors: #( meaningOfLife: )>
 	mock meaningOfLife: 12.
-	self verify: mock.
+	self verify: mock
 ]

--- a/src/SUnit-MockObjects-Tests/MyClassUsingMock3Test.class.st
+++ b/src/SUnit-MockObjects-Tests/MyClassUsingMock3Test.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : #MyClassUsingMock3,
+	#name : #MyClassUsingMock3Test,
 	#superclass : #TestCase,
 	#instVars : [
 		'mock'
@@ -8,7 +8,7 @@ Class {
 }
 
 { #category : #running }
-MyClassUsingMock3 >> setUp [
+MyClassUsingMock3Test >> setUp [
 
 	super setUp.
 	mock := MockObject new.
@@ -19,13 +19,13 @@ MyClassUsingMock3 >> setUp [
 ]
 
 { #category : #running }
-MyClassUsingMock3 >> testVerify [
+MyClassUsingMock3Test >> testVerify [
 
 	mock meaningOfLife: 3.
 ]
 
 { #category : #running }
-MyClassUsingMock3 >> testVerify2 [
+MyClassUsingMock3Test >> testVerify2 [
 	"When the arguments are correct, the verify block is executed and it should return true."
 	
 	mock meaningOfLife: 12.

--- a/src/SUnit-MockObjects-Tests/MyClassUsingMockTest.class.st
+++ b/src/SUnit-MockObjects-Tests/MyClassUsingMockTest.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : #MyClassUsingMock,
+	#name : #MyClassUsingMockTest,
 	#superclass : #TestCase,
 	#instVars : [
 		'mock'
@@ -8,7 +8,7 @@ Class {
 }
 
 { #category : #running }
-MyClassUsingMock >> setUp [
+MyClassUsingMockTest >> setUp [
 
 	super setUp.
 	mock := MockObject new.
@@ -22,7 +22,7 @@ MyClassUsingMock >> setUp [
 ]
 
 { #category : #running }
-MyClassUsingMock >> testMeaningOfLife [
+MyClassUsingMockTest >> testMeaningOfLife [
 
 	self assert: mock meaningOfLife equals: 42.
 	self should: [ self verify: mock ] raise: TestFailure.
@@ -30,7 +30,7 @@ MyClassUsingMock >> testMeaningOfLife [
 ]
 
 { #category : #running }
-MyClassUsingMock >> testMeaningOfLifeIsFirst [
+MyClassUsingMockTest >> testMeaningOfLifeIsFirst [
 
 	self assert: mock meaningOfLife equals: 42.
 	self assert: mock secondMeaning equals: 84.
@@ -38,7 +38,7 @@ MyClassUsingMock >> testMeaningOfLifeIsFirst [
 ]
 
 { #category : #running }
-MyClassUsingMock >> testMeaningOfLifeIsSentOnce [
+MyClassUsingMockTest >> testMeaningOfLifeIsSentOnce [
 	"A simple mock object can answer a message only once and in the same order."
 	
 	self assert: mock meaningOfLife equals: 42.
@@ -47,7 +47,7 @@ MyClassUsingMock >> testMeaningOfLifeIsSentOnce [
 ]
 
 { #category : #running }
-MyClassUsingMock >> testMeaningOfLifeIsSentTwice [
+MyClassUsingMockTest >> testMeaningOfLifeIsSentTwice [
 	
 	mock meaningOfLife.
 	self should: [self assert: mock meaningOfLife equals: 42] raise: TestFailure.
@@ -56,7 +56,7 @@ MyClassUsingMock >> testMeaningOfLifeIsSentTwice [
 ]
 
 { #category : #running }
-MyClassUsingMock >> testVerifyChecksThatAllTheMessageGotSent [
+MyClassUsingMockTest >> testVerifyChecksThatAllTheMessageGotSent [
 
 	self assert: mock meaningOfLife equals: 42.
 	self assert: mock secondMeaning equals: 84.
@@ -65,7 +65,7 @@ MyClassUsingMock >> testVerifyChecksThatAllTheMessageGotSent [
 ]
 
 { #category : #running }
-MyClassUsingMock >> testVerifyFailsWhenMessageShouldBeSent [
+MyClassUsingMockTest >> testVerifyFailsWhenMessageShouldBeSent [
 
 	self assert: mock meaningOfLife equals: 42.
 	self should: [ self verify: mock ] raise: TestFailure.

--- a/src/SUnit-MockObjects-Tests/MyClassUsingMockTest.class.st
+++ b/src/SUnit-MockObjects-Tests/MyClassUsingMockTest.class.st
@@ -24,6 +24,7 @@ MyClassUsingMockTest >> setUp [
 { #category : #running }
 MyClassUsingMockTest >> testMeaningOfLife [
 
+	<ignoreNotImplementedSelectors: #(meaningOfLife secondMeaning)>
 	self assert: mock meaningOfLife equals: 42.
 	self should: [ self verify: mock ] raise: TestFailure.
 	self assert: mock secondMeaning equals: 84
@@ -32,42 +33,40 @@ MyClassUsingMockTest >> testMeaningOfLife [
 { #category : #running }
 MyClassUsingMockTest >> testMeaningOfLifeIsFirst [
 
+	<ignoreNotImplementedSelectors: #( meaningOfLife secondMeaning )>
 	self assert: mock meaningOfLife equals: 42.
-	self assert: mock secondMeaning equals: 84.
-		
+	self assert: mock secondMeaning equals: 84
 ]
 
 { #category : #running }
 MyClassUsingMockTest >> testMeaningOfLifeIsSentOnce [
 	"A simple mock object can answer a message only once and in the same order."
-	
-	self assert: mock meaningOfLife equals: 42.
 
-	
+	<ignoreNotImplementedSelectors: #( meaningOfLife )>
+	self assert: mock meaningOfLife equals: 42
 ]
 
 { #category : #running }
 MyClassUsingMockTest >> testMeaningOfLifeIsSentTwice [
-	
-	mock meaningOfLife.
-	self should: [self assert: mock meaningOfLife equals: 42] raise: TestFailure.
 
-	
+	<ignoreNotImplementedSelectors: #( meaningOfLife )>
+	mock meaningOfLife.
+	self should: [ self assert: mock meaningOfLife equals: 42 ] raise: TestFailure
 ]
 
 { #category : #running }
 MyClassUsingMockTest >> testVerifyChecksThatAllTheMessageGotSent [
 
+	<ignoreNotImplementedSelectors: #( meaningOfLife secondMeaning )>
 	self assert: mock meaningOfLife equals: 42.
 	self assert: mock secondMeaning equals: 84.
 	self verify: mock
-		
 ]
 
 { #category : #running }
 MyClassUsingMockTest >> testVerifyFailsWhenMessageShouldBeSent [
 
+	<ignoreNotImplementedSelectors: #( meaningOfLife )>
 	self assert: mock meaningOfLife equals: 42.
-	self should: [ self verify: mock ] raise: TestFailure.
-		
+	self should: [ self verify: mock ] raise: TestFailure
 ]

--- a/src/System-Hashing-Testing/package.st
+++ b/src/System-Hashing-Testing/package.st
@@ -1,1 +1,0 @@
-Package { #name : #'System-Hashing-Testing' }

--- a/src/Tool-ImageCleaner-Tests/ImageCleanerTest.class.st
+++ b/src/Tool-ImageCleaner-Tests/ImageCleanerTest.class.st
@@ -15,16 +15,10 @@ ImageCleanerTest >> imageCleanerClass [
 
 { #category : #test }
 ImageCleanerTest >> testTestPackages [
-
 	"ImageCleaner testPackages method returns just symbols. Maybe it should be renamed."
 
-	self
-		assert: (self imageCleanerClass testPackages allSatisfy: #isSymbol)
-		equals: true.
+	self assert: (self imageCleanerClass testPackages allSatisfy: #isSymbol).
 
 	"All test package names are candidates for cleanup, except ReleaseTests package"
-	self
-		assert: (self imageCleanerClass testPackages noneSatisfy: [ :aSymbol | 
-				 aSymbol = #'ReleaseTests' ])
-		equals: true
+	self assert: (self imageCleanerClass testPackages noneSatisfy: [ :aSymbol | aSymbol = #ReleaseTests ])
 ]

--- a/src/Tool-ImageCleaner-Tests/ImageCleanerTest.class.st
+++ b/src/Tool-ImageCleaner-Tests/ImageCleanerTest.class.st
@@ -13,7 +13,7 @@ ImageCleanerTest >> imageCleanerClass [
 	^ ImageCleaner
 ]
 
-{ #category : #test }
+{ #category : #tests }
 ImageCleanerTest >> testTestPackages [
 	"ImageCleaner testPackages method returns just symbols. Maybe it should be renamed."
 

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -62,11 +62,10 @@ ImageCleaner class >> shareLiterals [
 
 { #category : #accessing }
 ImageCleaner class >> testPackages [
+	"All test packages to wipe out, except ReleeaseTests package."
 
 	<script: 'self testPackages inspect'>
-	"All test packages to wipe out, except ReleeaseTests package."
-	^ RPackageOrganizer default testPackageNames copyWithout:
-		  'ReleaseTests'
+	^ RPackageOrganizer default testPackageNames copyWithout: 'ReleaseTests'
 ]
 
 { #category : #api }


### PR DESCRIPTION
We have multiple packages with tests that are currently not loaded in Pharo.

The goal of this PR is to clean this:
- Load SUnit-MockObjects-Tests
- Load SUnit-Rules-Tests
- Load Calypso-Browser-Tests
- Load Tool-ImageCleaner-Tests
- Move content of FormCanvas-Core-Tests into FormCanvas-Tests and remove the package
- Remove empty System-Hashing-Testing

I also did some fixes in those tests