### PR TITLE
ReGlobalVariablesUsageRule should ignore the aliases of deprecated classes

### DIFF
--- a/src/GeneralRules/ReGlobalVariablesUsageRule.class.st
+++ b/src/GeneralRules/ReGlobalVariablesUsageRule.class.st
@@ -20,7 +20,7 @@ ReGlobalVariablesUsageRule >> check: aMethod forCritiquesDo: aCriticBlock [
 		select: [ :node |
 				node isGlobalVariable and: [
 					node variable isGlobalClassNameBinding not and: [
-					(self isKnownGlobal: node name) not ] ] ]
+					(self isKnownGlobal: node name) not and: [	node variable isDeprecated not ] ] ] ]
 		thenDo: [ :node |
 			aCriticBlock cull: (self
 				createTrivialCritiqueOn: aMethod


### PR DESCRIPTION
if you use the new deprecated class alias feature, the rule detects those as globals. They are not