### PR TITLE
13938-Changing-a-class-side-Slot-to-a-WriteOnceSlot-renders-a-NonBooleanReceiver-proceed-for-truth

### DIFF
--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -229,7 +229,10 @@ ShiftClassInstaller >> migrateClassTo: newClass [
 	newClass subclasses: oldClass subclasses.
 
 	slotsToMigrate := newClass class allSlots reject:[:e | builder builderEnhancer hasToSkipSlot: e ].
-	slotsToMigrate do: [ :newSlot | oldClass class slotNamed: newSlot name ifFound: [ :oldSlot | newSlot write: (oldSlot read: oldClass) to: newClass ] ].
+	slotsToMigrate do: [ :newSlot | 
+		"the slot might need to initialize the new class"
+		newSlot wantsInitialization ifTrue: [ newSlot initialize: newClass ].
+		oldClass class slotNamed: newSlot name ifFound: [ :oldSlot | newSlot write: (oldSlot read: oldClass) to: newClass ] ].
 
 	oldClassVariables := OrderedCollection new.
 	newClassVariables := OrderedCollection new.

--- a/src/Slot-Tests/WriteOnceSlotTest.class.st
+++ b/src/Slot-Tests/WriteOnceSlotTest.class.st
@@ -8,6 +8,18 @@ Class {
 }
 
 { #category : #tests }
+WriteOnceSlotTest >> testClassSide [
+	"test that we can change a normal slot into a WriteOnceSlot. Tests class side slot init"
+	| slot |
+	slot := #slot1 => InstanceVariableSlot.
+	aClass := self make: [ :builder | builder classSlots: {slot} ].
+	slot := #slot1 => WriteOnceSlot.
+	aClass := self make: [ :builder | builder classSlots: {slot} ].
+
+	self assert: (aClass class hasSlotNamed: #slot1)
+]
+
+{ #category : #tests }
 WriteOnceSlotTest >> testRead [
 	| slot |
 	<ignoreNotImplementedSelectors: #(slot1)>


### PR DESCRIPTION
- make sure to give the slot a chance to initialize a class side slot
- add test (using WriteOnceSlot)

fixes #13938