### PR TITLE
Make initial extent of SettingBrowser, ThreadSafeTranscript, FinderUI, EpUnifiedBrowserPresenter and EpLogBrowserPresenter take the display scale factor into account

### DIFF
--- a/src/EpiceaBrowsers/EpLogBrowserPresenter.class.st
+++ b/src/EpiceaBrowsers/EpLogBrowserPresenter.class.st
@@ -552,7 +552,7 @@ EpLogBrowserPresenter >> initializePresenters [
 
 { #category : #initialization }
 EpLogBrowserPresenter >> initializeWindow: aWindowPresenter [
-	aWindowPresenter initialExtent: 550 @ 700
+	aWindowPresenter initialExtent: (550 @ 700) scaledByDisplayScaleFactor
 ]
 
 { #category : #'menu - operations' }

--- a/src/EpiceaBrowsers/EpUnifiedBrowserPresenter.class.st
+++ b/src/EpiceaBrowsers/EpUnifiedBrowserPresenter.class.st
@@ -116,7 +116,7 @@ EpUnifiedBrowserPresenter >> initializeToolbar [
 EpUnifiedBrowserPresenter >> initializeWindow: aWindowPresenter [
 	aWindowPresenter
 		title: 'Epicea - Code Changes';
-		initialExtent: 950 @ 650;
+		initialExtent: (950 @ 650) scaledByDisplayScaleFactor;
 		whenClosedDo: [ self updatesAnnouncer unsubscribe: self ]
 ]
 

--- a/src/System-Settings-Browser/SettingBrowser.class.st
+++ b/src/System-Settings-Browser/SettingBrowser.class.st
@@ -225,7 +225,7 @@ SettingBrowser class >> forKeywords: aCollectionOfKeywords [
 { #category : #accessing }
 SettingBrowser class >> initialExtent [
 	"Initial extent of the SettingBrowser window"
-	^ 900@600
+	^ (900@600) scaledByDisplayScaleFactor
 ]
 
 { #category : #'world menu' }

--- a/src/Tool-Finder-UI/FinderUI.class.st
+++ b/src/Tool-Finder-UI/FinderUI.class.st
@@ -618,7 +618,7 @@ FinderUI >> inheritanceButtonState [
 
 { #category : #display }
 FinderUI >> initialExtent [
-	^ 700@500
+	^ (700@500) scaledByDisplayScaleFactor
 ]
 
 { #category : #initialization }

--- a/src/Transcript-Core/ThreadSafeTranscript.class.st
+++ b/src/Transcript-Core/ThreadSafeTranscript.class.st
@@ -137,7 +137,7 @@ ThreadSafeTranscript >> flush [
 { #category : #'ui building' }
 ThreadSafeTranscript >> initialExtent [
 
-	^447@300
+	^ (447@300) scaledByDisplayScaleFactor
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
This pull request makes the initial extent of SettingBrowser, ThreadSafeTranscript, FinderUI, EpUnifiedBrowserPresenter and EpLogBrowserPresenter take the display scale factor into account.