### PR TITLE
Make width constants in RubTextSegmentIconDisplayer take the display scale factor into account

### DIFF
--- a/src/Morphic-Core/Number.extension.st
+++ b/src/Morphic-Core/Number.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #Number }
+
+{ #category : #'*Morphic-Core' }
+Number >> scaledByDisplayScaleFactor [
+
+	^ self * self currentWorld displayScaleFactor
+]

--- a/src/Rubric/RubTextSegmentIconDisplayer.class.st
+++ b/src/Rubric/RubTextSegmentIconDisplayer.class.st
@@ -133,12 +133,12 @@ RubTextSegmentIconDisplayer >> handlesMouseOver: evt [
 
 { #category : #geometry }
 RubTextSegmentIconDisplayer >> horizontalGapAfter [
-	^ 1
+	^ 1 scaledByDisplayScaleFactor
 ]
 
 { #category : #geometry }
 RubTextSegmentIconDisplayer >> horizontalGapBefore [
-	^ 1
+	^ 1 scaledByDisplayScaleFactor
 ]
 
 { #category : #drawing }
@@ -176,7 +176,7 @@ RubTextSegmentIconDisplayer >> invokeIconMenuOfSegments: aSegmentList event: anE
 
 { #category : #accessing }
 RubTextSegmentIconDisplayer >> itemWidth [
-	^ 16
+	^ 16 scaledByDisplayScaleFactor
 ]
 
 { #category : #accessing }
@@ -232,5 +232,5 @@ RubTextSegmentIconDisplayer >> verticalSeparatorColor [
 
 { #category : #accessing }
 RubTextSegmentIconDisplayer >> verticalSeparatorWidth [
-	^ 1
+	^ 1 scaledByDisplayScaleFactor
 ]


### PR DESCRIPTION
This pull request makes the methods used in `#computedWidthFrom:` in RubTextSegmentIconDisplayer take the display scale factor into account.