### PR TITLE
Refactor: Move methods to class that only uses them

### DIFF
--- a/src/Refactoring-Core/RBChangeMethodNameRefactoring.class.st
+++ b/src/Refactoring-Core/RBChangeMethodNameRefactoring.class.st
@@ -29,6 +29,28 @@ RBChangeMethodNameRefactoring class >> isAbstract [
 	^ self == RBChangeMethodNameRefactoring
 ]
 
+{ #category : #support }
+RBChangeMethodNameRefactoring >> convertAllReferencesTo: aSymbol of: classes using: searchReplacer [
+	(self model allReferencesTo: aSymbol in: classes)
+		do:
+			[:method |
+			self
+				convertMethod: method selector
+				for: method modelClass
+				using: searchReplacer]
+]
+
+{ #category : #support }
+RBChangeMethodNameRefactoring >> convertAllReferencesTo: aSymbol using: searchReplacer [
+
+	(self model allReferencesTo: aSymbol)
+		reject: [ :rbMethod | "We reject methods from trait to not recompile them in the class and duplicate the code."
+			rbMethod method
+				ifNil: [ false ]
+				ifNotNil: #isFromTrait ]
+		thenDo: [ :method | self convertMethod: method selector for: method modelClass using: searchReplacer ]
+]
+
 { #category : #testing }
 RBChangeMethodNameRefactoring >> hasPermutedArguments [
 	oldSelector numArgs = newSelector numArgs ifFalse: [^true].

--- a/src/Refactoring-Core/RBRefactoring.class.st
+++ b/src/Refactoring-Core/RBRefactoring.class.st
@@ -93,28 +93,6 @@ RBRefactoring >> classObjectFor: anObject [
 ]
 
 { #category : #support }
-RBRefactoring >> convertAllReferencesTo: aSymbol of: classes using: searchReplacer [
-	(self model allReferencesTo: aSymbol in: classes)
-		do:
-			[:method |
-			self
-				convertMethod: method selector
-				for: method modelClass
-				using: searchReplacer]
-]
-
-{ #category : #support }
-RBRefactoring >> convertAllReferencesTo: aSymbol using: searchReplacer [
-
-	(self model allReferencesTo: aSymbol)
-		reject: [ :rbMethod | "We reject methods from trait to not recompile them in the class and duplicate the code."
-			rbMethod method
-				ifNil: [ false ]
-				ifNotNil: #isFromTrait ]
-		thenDo: [ :method | self convertMethod: method selector for: method modelClass using: searchReplacer ]
-]
-
-{ #category : #support }
 RBRefactoring >> convertAllReferencesToClass: aRBClass using: searchReplacer [
 	self model allReferencesToClass: aRBClass
 		do:


### PR DESCRIPTION
This commit moves methods for converting references of a method to another method to `RBChangeMethodNameRefactoring` which is the only method that uses them.