### PR TITLE
13957--RBRefactoringonErrordo--should-accept-both-0-and-1-arg-block

### DIFF
--- a/src/Refactoring-Core/RBRefactoring.class.st
+++ b/src/Refactoring-Core/RBRefactoring.class.st
@@ -175,7 +175,7 @@ RBRefactoring >> onError: aBlock do: errorBlock [
 	^aBlock on: self class preconditionSignal
 		do:
 			[:ex |
-			errorBlock value.
+			errorBlock cull: ex.
 			ex return: nil]
 ]
 


### PR DESCRIPTION
RBRefactoring>>#onError:do:  is called with both 0 and 1 arg error bl…ocks. a 1-arg block feels natural, as on:do: takes an optional parameter, too.

This PR therefore changes #onError:do:  to work with both 1 and 0-arg error blocks

(the whole idea of #onError:do: is strange.. do we really want to hide why a refactoring can not be done?)

fixes #13957