### PR TITLE
Update the way we deal with protocols from other classes

### DIFF
--- a/src/CodeImport/ClassOrganizationChunk.class.st
+++ b/src/CodeImport/ClassOrganizationChunk.class.st
@@ -52,11 +52,7 @@ ClassOrganizationChunk >> importFor: aRequestor logSource: logSource [
 	"If nothing was scanned and I had no elements before, then default me"
 	(protocolSpecs isEmpty and: [ targetClass protocols isEmpty ]) ifTrue: [ ^ self ].
 
-	protocolSpecs do: [ :spec |
-		| protocolName methods |
-		protocolName := spec first asSymbol.
-		methods := spec allButFirst asSet.
-		targetClass addProtocol: (Protocol name: protocolName methodSelectors: methods) ]
+	protocolSpecs do: [ :spec | (targetClass addProtocol: (Protocol named: spec first)) methodSelectors: spec allButFirst asSet ]
 ]
 
 { #category : #testing }

--- a/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
@@ -34,6 +34,20 @@ ClassDescriptionProtocolsTest >> testAddProtocolWithExistingProtocol [
 ]
 
 { #category : #tests }
+ClassDescriptionProtocolsTest >> testAddProtocolWithProtocolFromOtherClass [
+
+	| titan |
+	"This protocol is not from the class we are testing."
+	titan := Protocol named: #titan.
+
+	class addProtocol: titan.
+
+	"The class should have created a new protocol of the same name."
+	self assert: (class hasProtocol: #titan).
+	self deny: (class protocolNamed: #titan) identicalTo: titan
+]
+
+{ #category : #tests }
 ClassDescriptionProtocolsTest >> testAddProtocolWithRealProtocol [
 
 	| titan |

--- a/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
@@ -4,7 +4,7 @@ I am a test case responsible of testing ClassDescription protocol management.
 Class {
 	#name : #ClassDescriptionProtocolsTest,
 	#superclass : #ProtocolTest,
-	#category : #'Kernel-Tests-Protocols'
+	#category : #'Kernel-Tests-Classes'
 }
 
 { #category : #private }
@@ -19,6 +19,30 @@ ClassDescriptionProtocolsTest >> testAddProtocol [
 	class addProtocol: #titan.
 
 	self assert: (class hasProtocol: #titan)
+]
+
+{ #category : #tests }
+ClassDescriptionProtocolsTest >> testAddProtocolWithExistingProtocol [
+
+	| titan |
+	titan := class addProtocol: #titan.
+
+	self assert: (class hasProtocol: titan).
+
+	"Adding a second time should just return the same instance."
+	self assert: (class addProtocol: #titan) identicalTo: titan
+]
+
+{ #category : #tests }
+ClassDescriptionProtocolsTest >> testAddProtocolWithRealProtocol [
+
+	| titan |
+	titan := class addProtocol: #titan.
+
+	self assert: (class hasProtocol: titan).
+
+	"Adding a second time should just return the same instance."
+	self assert: (class addProtocol: titan) identicalTo: titan
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
@@ -154,16 +154,31 @@ ClassDescriptionProtocolsTest >> testClassifyUnderWithProtocol [
 ]
 
 { #category : #tests }
+ClassDescriptionProtocolsTest >> testClassifyUnderWithProtocolFromOtherClass [
+
+	| which |
+	class classify: #luz under: (which := Protocol named: #which).
+
+	self assertCollection: class protocolNames hasSameElements: #( #which ).
+	self assertCollection: (class selectorsInProtocol: #which) hasSameElements: #( #luz ).
+
+	"Since the protocol was not from the class, it should not be the same instance."
+	self deny: (class protocolNamed: #which) identicalTo: which
+]
+
+{ #category : #tests }
 ClassDescriptionProtocolsTest >> testEnsureProtocol [
 
-	| protocol |
+	| protocol outsideProtocol |
 	class addProtocol: #titan.
 	protocol := class protocolNamed: #titan.
+	outsideProtocol := Protocol named: #titan.
 
 	self assertCollection: class protocolNames hasSameElements: { #titan }.
 	self assert: (class ensureProtocol: #titan) equals: protocol.
 	self assert: (class ensureProtocol: protocol) equals: protocol.
-	self should: [ class ensureProtocol: (Protocol named: #notFromClass) ] raise: Error.
+	self assert: (class ensureProtocol: outsideProtocol) equals: protocol.
+	self deny: (class ensureProtocol: outsideProtocol) identicalTo: outsideProtocol.
 
 	self assert: (class ensureProtocol: nil) name equals: Protocol unclassified.
 	self assertCollection: class protocolNames hasSameElements: {
@@ -199,6 +214,13 @@ ClassDescriptionProtocolsTest >> testHasProtocol [
 
 	self assert: (class hasProtocol: (class protocolNamed: #titan)).
 	self deny: (class hasProtocol: (Protocol named: #human))
+]
+
+{ #category : #tests }
+ClassDescriptionProtocolsTest >> testHasProtocolWithProtocolFromOtherClass [
+
+	class addProtocol: #titan.
+	self assert: (class hasProtocol: (Protocol named: #titan))
 ]
 
 { #category : #tests }
@@ -375,6 +397,23 @@ ClassDescriptionProtocolsTest >> testRemoveProtocolIfEmptyOnNonExistingProtocol 
 
 	self deny: (class hasProtocol: #titan).
 	self shouldnt: [ class removeProtocolIfEmpty: #titan ] raise: Error
+]
+
+{ #category : #tests }
+ClassDescriptionProtocolsTest >> testRemoveProtocolIfEmptyWithProtocolFromOtherClass [
+
+	class addProtocol: #titan.
+	class addProtocol: #human.
+	class addProtocol: #witch.
+	class compiler
+		protocol: #titan;
+		install: 'king ^1'.
+	self assert: class protocolNames size equals: 3.
+	self assertCollection: (class selectorsInProtocol: #titan) hasSameElements: #( #king ).
+
+	"just ignore removing of non empty categories"
+	class removeProtocolIfEmpty: (Protocol named: #titan).
+	self assert: class protocolNames size equals: 3
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests/ProtocolAnnouncementsTest.class.st
+++ b/src/Kernel-Tests/ProtocolAnnouncementsTest.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'numberOfAnnouncements'
 	],
-	#category : #'Kernel-Tests-Protocols'
+	#category : #'Kernel-Tests-Classes'
 }
 
 { #category : #running }

--- a/src/Kernel-Tests/ProtocolTest.class.st
+++ b/src/Kernel-Tests/ProtocolTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'class'
 	],
-	#category : #'Kernel-Tests-Protocols'
+	#category : #'Kernel-Tests-Classes'
 }
 
 { #category : #helpers }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -471,15 +471,11 @@ ClassDescription >> ensureProtocol: aProtocol [
 	"I can take a Protocol or a protocol name as paramater.
 	
 	If my parameter is a name, I'll return a protocol associated with it. A new one if needed.
-	If my parameter is a Protocol, I'll ensure that it comes from me, else I'll throw an error."
+	If my parameter is a Protocol, I'll return it if it comes from me or I'll create one of the same name."
 
 	aProtocol ifNil: [ ^ self ensureProtocol: Protocol unclassified ].
 
-	aProtocol isString ifFalse: [
-		(self protocols includes: aProtocol)
-			ifTrue: [ ^ aProtocol ]
-			ifFalse: [ self error: 'I received a real protocol but this one is not part of me.' ] ].
-	^ self protocolNamed: aProtocol ifAbsent: [ self addProtocol: aProtocol ]
+	^ self addProtocol: aProtocol
 ]
 
 { #category : #private }
@@ -951,7 +947,7 @@ ClassDescription >> removeProtocolIfEmpty: aProtocol [
 	| protocol oldProtocolNames |
 	(self hasProtocol: aProtocol) ifFalse: [ ^ self ].
 
-	protocol := aProtocol isString ifTrue: [ self protocolNamed: aProtocol ] ifFalse: [ aProtocol ].
+	protocol := self ensureProtocol: aProtocol.
 
 	protocol isEmpty ifFalse: [ ^ self ].
 

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -68,12 +68,12 @@ ClassDescription >> addInstVarNamed: aString [
 { #category : #protocols }
 ClassDescription >> addProtocol: aProtocol [
 
-	| oldProtocols protocol |
-	
-	(self hasProtocol: aProtocol) ifTrue: [
-		^ self protocolNamed: (aProtocol isString ifTrue: [ aProtocol ] ifFalse: [ aProtocol name ]) ].
+	| oldProtocols protocol protocolName |
+	protocolName := aProtocol isString ifTrue: [ aProtocol ] ifFalse: [ aProtocol name ].
 
-	protocol := aProtocol isString ifTrue: [ Protocol named: aProtocol ] ifFalse: [ aProtocol ].
+	(self hasProtocol: aProtocol) ifTrue: [ ^ self protocolNamed: protocolName ].
+
+	protocol := Protocol named: protocolName.
 
 	oldProtocols := self protocolNames copy.
 


### PR DESCRIPTION
When I started to use real protocols instead of protocol names, I updated the protocol API to raise an error if we used a protocol from another class in a class. 

Now that I have more insight on how protocols are managed, I think that the system would be way simpler if the API could accept those and adapt to create/use a protocol of the same name instead. This is the goal of this PR.

Some example of times where it is useful:
- In traits when they categorize the methods because the protocol can come from the user class for example.
- In refactoring when you do a push up/down


Most changes are tests added