### PR TITLE
Rename packages announcements

### DIFF
--- a/src/Calypso-SystemQueries/PackageRenamed.extension.st
+++ b/src/Calypso-SystemQueries/PackageRenamed.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #PackageRenamed }
+
+{ #category : #'*Calypso-SystemQueries' }
+PackageRenamed >> canAffectResultOfMethodQuery: aMethodQuery [
+	^true
+]

--- a/src/Calypso-SystemQueries/RPackageRenamed.extension.st
+++ b/src/Calypso-SystemQueries/RPackageRenamed.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #RPackageRenamed }
-
-{ #category : #'*Calypso-SystemQueries' }
-RPackageRenamed >> canAffectResultOfMethodQuery: aMethodQuery [
-	^true
-]

--- a/src/Epicea/EpMonitor.class.st
+++ b/src/Epicea/EpMonitor.class.st
@@ -524,8 +524,8 @@ EpMonitor >> subscribeToSystemAnnouncer [
 	{	CategoryAdded -> #categoryAdded:.
 		CategoryRemoved -> #categoryRemoved:.
 		CategoryRenamed -> #categoryRenamed:.
-		RPackageRegistered -> #categoryRegistered:.
-		RPackageRenamed -> #packageRenamed:.
+		PackageAdded -> #categoryRegistered:.
+		PackageRenamed -> #packageRenamed:.
 		ClassAdded-> #behaviorAdded:.
 		ClassRemoved->#behaviorRemoved:.
 		MethodAdded -> #methodAdded:.

--- a/src/Monticello/MCPackageManager.class.st
+++ b/src/Monticello/MCPackageManager.class.st
@@ -221,7 +221,7 @@ MCPackageManager class >> packageRenamed: anAnnouncement [
 { #category : #'event registration' }
 MCPackageManager class >> registerInterestOnSystemChangesOnAnnouncer: anAnnouncer [
 	anAnnouncer weak
-		when: RPackageRenamed send: #packageRenamed: to: self;
+		when: PackageRenamed send: #packageRenamed: to: self;
 		when: ClassAdded, ClassModifiedClassDefinition, ClassCommented , ClassParentRenamed send: #classModified: to: self;
 		when: ClassRenamed send:#classRenamed: to:self;
 		when: ClassRepackaged send: #classMoved: to: self;

--- a/src/RPackage-Core/PackageAdded.class.st
+++ b/src/RPackage-Core/PackageAdded.class.st
@@ -1,0 +1,13 @@
+"
+I am a public announcement sent when a new RPackage is created
+"
+Class {
+	#name : #PackageAdded,
+	#superclass : #PackageAnnouncement,
+	#category : #'RPackage-Core-Announcements'
+}
+
+{ #category : #'class initialization' }
+PackageAdded class >> initialize [
+	self deprecatedAliases: { #RPackageRegistered }
+]

--- a/src/RPackage-Core/PackageAnnouncement.class.st
+++ b/src/RPackage-Core/PackageAnnouncement.class.st
@@ -2,7 +2,7 @@
 Common superclass for package related announcements
 "
 Class {
-	#name : #RPackageAnnouncement,
+	#name : #PackageAnnouncement,
 	#superclass : #SystemAnnouncement,
 	#instVars : [
 		'package'
@@ -10,26 +10,31 @@ Class {
 	#category : #'RPackage-Core-Announcements'
 }
 
+{ #category : #'class initialization' }
+PackageAnnouncement class >> initialize [
+	self deprecatedAliases: { #RPackageAnnouncement }
+]
+
 { #category : #'instance creation' }
-RPackageAnnouncement class >> to: aPackage [
+PackageAnnouncement class >> to: aPackage [
 
 	^ self new package: aPackage
 ]
 
 { #category : #testing }
-RPackageAnnouncement >> affectsPackages [
+PackageAnnouncement >> affectsPackages [
 
 	^true
 ]
 
 { #category : #accessing }
-RPackageAnnouncement >> package [
+PackageAnnouncement >> package [
 
 	^ package
 ]
 
 { #category : #accessing }
-RPackageAnnouncement >> package: anObject [
+PackageAnnouncement >> package: anObject [
 
 	package := anObject
 ]

--- a/src/RPackage-Core/PackageRemoved.class.st
+++ b/src/RPackage-Core/PackageRemoved.class.st
@@ -1,0 +1,13 @@
+"
+I am a public announcement sent when a new RPackage is unregistred ( kind  of removed from the system )
+"
+Class {
+	#name : #PackageRemoved,
+	#superclass : #PackageAnnouncement,
+	#category : #'RPackage-Core-Announcements'
+}
+
+{ #category : #'class initialization' }
+PackageRemoved class >> initialize [
+	self deprecatedAliases: { #RPackageUnregistered }
+]

--- a/src/RPackage-Core/PackageRenamed.class.st
+++ b/src/RPackage-Core/PackageRenamed.class.st
@@ -2,8 +2,8 @@
 I am a public announcement sent when a new RPackage is renamed
 "
 Class {
-	#name : #RPackageRenamed,
-	#superclass : #RPackageAnnouncement,
+	#name : #PackageRenamed,
+	#superclass : #PackageAnnouncement,
 	#instVars : [
 		'oldName',
 		'newName'
@@ -11,8 +11,14 @@ Class {
 	#category : #'RPackage-Core-Announcements'
 }
 
+{ #category : #'class initialization' }
+PackageRenamed class >> initialize [
+
+	self deprecatedAliases: { #RPackageRenamed }
+]
+
 { #category : #'instance creation' }
-RPackageRenamed class >> to: aPackage oldName: aSymbol newName: anotherSymbol [
+PackageRenamed class >> to: aPackage oldName: aSymbol newName: anotherSymbol [
 
 	^ (self to: aPackage)
 		oldName: aSymbol;
@@ -21,54 +27,54 @@ RPackageRenamed class >> to: aPackage oldName: aSymbol newName: anotherSymbol [
 ]
 
 { #category : #testing }
-RPackageRenamed >> affectsClass: aClass [
+PackageRenamed >> affectsClass: aClass [
 	^package == aClass package
 ]
 
 { #category : #testing }
-RPackageRenamed >> affectsMethod: aMethod [
+PackageRenamed >> affectsMethod: aMethod [
 	^package == aMethod package
 ]
 
 { #category : #testing }
-RPackageRenamed >> affectsMethods [
+PackageRenamed >> affectsMethods [
 	"methods belong to package which could be represented by tools as part of method"
 	^true
 ]
 
 { #category : #testing }
-RPackageRenamed >> affectsMethodsDefinedInClass: aClass [
+PackageRenamed >> affectsMethodsDefinedInClass: aClass [
 
 	^(package definesClass: aClass)
 		or: [ package extendsClass: aClass ]
 ]
 
 { #category : #testing }
-RPackageRenamed >> affectsMethodsDefinedInPackage: aPackage [
+PackageRenamed >> affectsMethodsDefinedInPackage: aPackage [
 
 	^package == aPackage
 ]
 
 { #category : #accessing }
-RPackageRenamed >> newName [
+PackageRenamed >> newName [
 
 	^ newName
 ]
 
 { #category : #accessing }
-RPackageRenamed >> newName: anObject [
+PackageRenamed >> newName: anObject [
 
 	newName := anObject
 ]
 
 { #category : #accessing }
-RPackageRenamed >> oldName [
+PackageRenamed >> oldName [
 
 	^ oldName
 ]
 
 { #category : #accessing }
-RPackageRenamed >> oldName: anObject [
+PackageRenamed >> oldName: anObject [
 
 	oldName := anObject
 ]

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -1395,7 +1395,7 @@ RPackage >> renameTo: aSymbol [
 	self mcPackage workingCopy repositoryGroup: repositoryGroup.
 	SystemAnnouncer uniqueInstance
 		announce:
-			(RPackageRenamed to: self oldName: oldName newName: newName)
+			(PackageRenamed to: self oldName: oldName newName: newName)
 ]
 
 { #category : #private }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -388,7 +388,7 @@ RPackageOrganizer >> ensureExistAndRegisterPackageNamed: aSymbol [
 	package definedClasses do: [ :definedClass|
 			self registerPackage: package forClass: definedClass].
 
-	SystemAnnouncer announce: (RPackageRegistered to: package).
+	SystemAnnouncer announce: (PackageAdded to: package).
 
 	^ package
 ]
@@ -857,7 +857,7 @@ RPackageOrganizer >> registerPackage: aPackage [
 	aPackage definedClasses
 		do: [ :definedClass | self registerPackage: aPackage forClass: definedClass].
 
-	SystemAnnouncer announce: (RPackageRegistered to: aPackage).
+	SystemAnnouncer announce: (PackageAdded to: aPackage).
 
 	^ aPackage
 ]
@@ -1326,7 +1326,7 @@ RPackageOrganizer >> unregisterPackage: aPackage [
 		do: [ :extendedClass | self unregisterExtendingPackage: aPackage forClass: extendedClass].
 	aPackage definedClasses
 		do: [ :definedClass | self unregisterPackage: aPackage forClass: definedClass].
-	SystemAnnouncer announce: (RPackageUnregistered to: aPackage).
+	SystemAnnouncer announce: (PackageRemoved to: aPackage).
 
 	^ aPackage
 ]

--- a/src/RPackage-Core/RPackageRegistered.class.st
+++ b/src/RPackage-Core/RPackageRegistered.class.st
@@ -1,8 +1,0 @@
-"
-I am a public announcement sent when a new RPackage is created
-"
-Class {
-	#name : #RPackageRegistered,
-	#superclass : #RPackageAnnouncement,
-	#category : #'RPackage-Core-Announcements'
-}

--- a/src/RPackage-Core/RPackageUnregistered.class.st
+++ b/src/RPackage-Core/RPackageUnregistered.class.st
@@ -1,8 +1,0 @@
-"
-I am a public announcement sent when a new RPackage is unregistred ( kind  of removed from the system )
-"
-Class {
-	#name : #RPackageUnregistered,
-	#superclass : #RPackageAnnouncement,
-	#category : #'RPackage-Core-Announcements'
-}

--- a/src/Ring-Core/RGEnvironment.class.st
+++ b/src/Ring-Core/RGEnvironment.class.st
@@ -51,7 +51,7 @@ RGEnvironment >> addPackage: anRGPackage [
 
 	self backend forPackage addPackage: anRGPackage to: self.
 
-	self announce: (RPackageRegistered to: anRGPackage)
+	self announce: (PackageAdded to: anRGPackage)
 ]
 
 { #category : #accessing }
@@ -797,7 +797,7 @@ RGEnvironment >> removePackage: anRGPackage [
 
 	self backend forPackage removePackage: anRGPackage from: self.
 
-	self announce: (RPackageUnregistered to: anRGPackage)
+	self announce: (PackageRemoved to: anRGPackage)
 ]
 
 { #category : #unpackaged }

--- a/src/Ring-Core/RGPackage.class.st
+++ b/src/Ring-Core/RGPackage.class.st
@@ -265,7 +265,7 @@ RGPackage >> name: aString [
 	oldName := self name.
 	super name: aString.
 
-	self announce: (RPackageRenamed
+	self announce: (PackageRenamed
 			to: self
 			oldName: oldName
 			newName: aString)


### PR DESCRIPTION
Here is a step toward the integration of RPackage in the Metamodel.

Announcements related to packages in the system are not consistent with the rest of the system currently:
- Their name does not match the other announcement names in the system such as ClassAdded or ProtocolAdded
- Their name starts with an R as all classes in RPackage. Since we are integrating them in the MM, we should drop the R to be consistent with the rest of Pharo MM
- We have a package announcement hierarchy and a category announcement hierarchy

This PR fixes the first two problems:
- RPackageRegistered -> PackageAdded
- RPackageRenamed -> PackageRenamed
- RPackageUnregistered -> PackageRemoved

**Future work:**
For the third problem we will have tp work some more. Currently the CategoryAdded announcement is fired each time we create a package or a package tag. PackageAdded is fired when a package is created. In the future I would like to have PackageAdded and PackageTag added and I want to remove CategoryAdded because I want to remove the system of Category that mixes Packages and PackageTags.