### PR TITLE
Use real protocols in MCPackageManager

### DIFF
--- a/src/Manifest-Core/CompiledMethod.extension.st
+++ b/src/Manifest-Core/CompiledMethod.extension.st
@@ -33,8 +33,3 @@ CompiledMethod >> manifestBuilderForRuleChecker: aRuleChecker [
 
 	^ aRuleChecker manifestBuilderOfMethod: self
 ]
-
-{ #category : #'*Manifest-Core' }
-CompiledMethod >> mcWorkingCopy [
-	 MCWorkingCopy managersForClass: self methodClass selector: self selector do: [ :package | ^ package ]
-]

--- a/src/Monticello-Tests/MCPackageManagerTest.class.st
+++ b/src/Monticello-Tests/MCPackageManagerTest.class.st
@@ -76,7 +76,7 @@ MCPackageManagerTest >> testClassRemoved [
 ]
 
 { #category : #tests }
-MCPackageManagerTest >> testManagersForCategoryDo [
+MCPackageManagerTest >> testManagersForExtensionProtocolDo [
 	"Consider the following package structure:
 		Renraku
 		Renraku-Help
@@ -90,13 +90,13 @@ MCPackageManagerTest >> testManagersForCategoryDo [
 	self assert: (MCPackageManager registry includesKey: mcPackage2).
 
 	managers := OrderedCollection new.
-	MCPackageManager managersForCategory: mcPackage1 name do: [ :manager | managers add: manager ].
+	MCPackageManager managersForExtensionProtocol: (Protocol named: '*' , mcPackage1 name) do: [ :manager | managers add: manager ].
 
 	self assert: managers size equals: 1.
 	self assert: managers first package identicalTo: mcPackage1.
 
 	managers := OrderedCollection new.
-	MCPackageManager managersForCategory: mcPackage2 name do: [ :manager | managers add: manager ].
+	MCPackageManager managersForExtensionProtocol: (Protocol named: '*' , mcPackage2 name) do: [ :manager | managers add: manager ].
 
 	self assert: managers size equals: 1.
 	self assert: managers first package identicalTo: mcPackage2

--- a/src/Monticello/MCPackageManager.class.st
+++ b/src/Monticello/MCPackageManager.class.st
@@ -144,29 +144,19 @@ MCPackageManager class >> managersForCategory: aSystemCategory do: aBlock [
 ]
 
 { #category : #'system changes' }
-MCPackageManager class >> managersForClass: aClass category: methodCategory do: aBlock [
-	(methodCategory isEmptyOrNil or:[methodCategory first ~= $*]) ifTrue:[
-		"Not an extension method"
-		^self managersForClass: aClass do: aBlock.
-	].
-	self managersForCategory: methodCategory allButFirst do: aBlock.
-]
-
-{ #category : #'system changes' }
 MCPackageManager class >> managersForClass: aClass do: aBlock [
 
 	| rPackage |
 	rPackage := aClass package.
 
-	self registry do: [:mgr |
-		(mgr packageSet packages includes: rPackage)
-			ifTrue: [aBlock value: mgr]]
+	self registry do: [ :mgr | (mgr packageSet packages includes: rPackage) ifTrue: [ aBlock value: mgr ] ]
 ]
 
 { #category : #'system changes' }
-MCPackageManager class >> managersForClass: aClass selector: aSelector do: aBlock [
+MCPackageManager class >> managersForClass: aClass protocol: protocol do: aBlock [
 
-	^ self managersForClass: aClass category: (aClass protocolNameOfSelector: aSelector) do: aBlock
+	(protocol isNil or: [ protocol isExtensionProtocol ]) ifTrue: [ "Not an extension method" ^ self managersForClass: aClass do: aBlock ].
+	self managersForCategory: protocol name allButFirst do: aBlock
 ]
 
 { #category : #'system changes' }
@@ -192,7 +182,7 @@ MCPackageManager class >> methodModified: anEvent [
 		
 	^ self
 		managersForClass: anEvent methodClass
-		selector: anEvent selector
+		protocol: anEvent protocol
 		do: [ :mgr | mgr modified: true ]
 ]
 
@@ -205,7 +195,7 @@ MCPackageManager class >> methodMoved: anEvent [
 { #category : #'system changes' }
 MCPackageManager class >> methodRemoved: anEvent [
 
-	self managersForClass: anEvent methodClass category: anEvent protocol name do: [ :mgr | mgr modified: true ]
+	self managersForClass: anEvent methodClass protocol: anEvent protocol do: [ :mgr | mgr modified: true ]
 ]
 
 { #category : #'system changes' }

--- a/src/Monticello/MCPackageManager.class.st
+++ b/src/Monticello/MCPackageManager.class.st
@@ -110,40 +110,6 @@ MCPackageManager class >> initialize [
 ]
 
 { #category : #'system changes' }
-MCPackageManager class >> managersForCategory: aSystemCategory do: aBlock [
-	"Got to be careful here - we might get method categories where capitalization is problematic."
-	| cat foundOne index |
-	foundOne := false.
-	cat := aSystemCategory ifNil: [ ^nil ]. "yes this happens; for example in eToy projects"
-	"first ask PackageInfos, their package name might not match the category"
-	self
-		bestMatchingManagerForCategory: aSystemCategory
-		do: [ :mgr |
-			aBlock value: mgr.
-			foundOne := true ].
-
-   foundOne ifTrue: [ ^self ].
-	[  "Loop over categories until we found a matching one"
-		self registry keys detect: [ :aPackage | aPackage name sameAs: cat ]
-			ifFound: [:aPackage | | mgr | 
-				mgr := self registry at: aPackage.
-				aBlock value: mgr. 
-				foundOne := true. 
-				false] 
-			ifNone: [ 
-				index := cat lastIndexOf: $-.
-				index > 0]
-	] whileTrue: [
-		"Step up to next level package"
-		cat := cat copyFrom: 1 to: index-1 ].
-	
-	foundOne ifFalse: [
-		"Create a new (but only top-level)"
-		aBlock value: (MCWorkingCopy forPackage: (MCPackage named: aSystemCategory capitalized)).
-	].
-]
-
-{ #category : #'system changes' }
 MCPackageManager class >> managersForClass: aClass do: aBlock [
 
 	| rPackage |
@@ -155,8 +121,40 @@ MCPackageManager class >> managersForClass: aClass do: aBlock [
 { #category : #'system changes' }
 MCPackageManager class >> managersForClass: aClass protocol: protocol do: aBlock [
 
-	(protocol isNil or: [ protocol isExtensionProtocol ]) ifTrue: [ "Not an extension method" ^ self managersForClass: aClass do: aBlock ].
-	self managersForCategory: protocol name allButFirst do: aBlock
+	protocol ifNil: [ ^ nil ]. "This can happen if we are removing a method. Then its protocol will be nil."
+
+	^ protocol isExtensionProtocol
+		  ifTrue: [ self managersForExtensionProtocol: protocol do: aBlock ]
+		  ifFalse: [ self managersForClass: aClass do: aBlock ]
+]
+
+{ #category : #'system changes' }
+MCPackageManager class >> managersForExtensionProtocol: protocol do: aBlock [
+	"We know that the protocol in parameter is an extension protocol. We just got to be careful because the capitalization can be problematic."
+
+	| packageName foundOne index |
+	foundOne := false.
+	packageName := protocol name allButFirst.
+	"first ask PackageInfos, their package name might not match the protocol"
+	self bestMatchingManagerForCategory: packageName do: [ :mgr |
+		aBlock value: mgr.
+		foundOne := true ].
+
+	foundOne ifTrue: [ ^ self ].
+	[ "Loop over categories until we found a matching one"
+	self registry keys
+		detect: [ :aPackage | aPackage name sameAs: packageName ]
+		ifFound: [ :aPackage |
+			| mgr |
+			mgr := self registry at: aPackage.
+			aBlock value: mgr.
+			foundOne := true.
+			false ]
+		ifNone: [
+			index := packageName lastIndexOf: $-.
+			index > 0 ] ] whileTrue: [ "Step up to next level package" packageName := packageName copyFrom: 1 to: index - 1 ].
+
+	foundOne ifFalse: [ "Create a new (but only top-level)" aBlock value: (MCWorkingCopy forPackage: (MCPackage named: packageName capitalized)) ]
 ]
 
 { #category : #'system changes' }


### PR DESCRIPTION
Move from protocol names to real protocols in MCPackageManager.

I also removed CompiledMethod>>mcWorkingCopy that seems to be dead code.