### PR TITLE
Handle single-sized collection in stdev method.

### DIFF
--- a/src/Collections-Arithmetic-Tests/CollectionArithmeticTest.class.st
+++ b/src/Collections-Arithmetic-Tests/CollectionArithmeticTest.class.st
@@ -127,3 +127,25 @@ CollectionArithmeticTest >> testRunningMin [
 
 	self assert: result equals: {1 . 1 . 2 . 2}
 ]
+
+{ #category : #tests }
+CollectionArithmeticTest >> testStdev [
+
+	| collection |
+	collection := #(1 2 3).
+	self assert: collection stdev equals: 1
+]
+
+{ #category : #tests }
+CollectionArithmeticTest >> testStdevIfEmpty [
+
+	self should: [ #() stdev ] raise: CollectionIsEmpty
+]
+
+{ #category : #tests }
+CollectionArithmeticTest >> testStdevSingleElement [
+
+	| collection |
+	collection := #(1).
+	self assert: collection stdev equals: 0
+]

--- a/src/Collections-Arithmetic/Collection.extension.st
+++ b/src/Collections-Arithmetic/Collection.extension.st
@@ -259,6 +259,8 @@ Collection >> stdev [
 	| avg sample sum |
 	"In statistics, the standard deviation is a measure that is used to quantify the amount of variation or dispersion of a set of data values.
 	For details about implementation see comment in self sum."
+	
+	self size = 1 ifTrue: [ ^ 0 ].
 	avg := self average.
 	sample := self anyOne.
 	sum := self inject: sample into: [ :accum :each | accum + (each - avg) squared ].


### PR DESCRIPTION
This PR solves the issue https://github.com/pharo-project/pharo/issues/13993

Single-sized collection will raise a ZeroDivide exception when stdev is received. However, we can determine the standard deviation for a single value, althouth it might not be useful, it is better zero to avoid unnecessary raising of exceptions.

Add standard deviation tests for collection of 3 numbers, empty and single-element case.
