### PR TITLE
Add values and valuesDo: methods to FinalizationRegistry

### DIFF
--- a/src/System-Finalization/FinalizationRegistry.class.st
+++ b/src/System-Finalization/FinalizationRegistry.class.st
@@ -178,3 +178,15 @@ FinalizationRegistry >> size [
 
 	^ ephemeronCollection size
 ]
+
+{ #category : #accessing }
+FinalizationRegistry >> values [
+
+	^ ephemeronCollection collect: [ :e | e value ]
+]
+
+{ #category : #enumerating }
+FinalizationRegistry >> valuesDo: aBlock [
+
+	^ self values do: aBlock
+]


### PR DESCRIPTION
Added the methods `values` and `valuesDo:` to the `FinalizationRegistry` class. 
There is already the method `keys` do these other two methods are complementary ones.