### PR TITLE
Clean manifest builder test and cut dependency to Monticello

### DIFF
--- a/src/Manifest-Tests/BuilderManifestTest.class.st
+++ b/src/Manifest-Tests/BuilderManifestTest.class.st
@@ -4,42 +4,35 @@ A ManifestBuilderTest is a class to test the behavior of ManifestBuilder
 Class {
 	#name : #BuilderManifestTest,
 	#superclass : #AbstractEnvironmentTestCase,
+	#instVars : [
+		'manifestBuilder'
+	],
 	#category : #'Manifest-Tests-Base'
 }
 
 { #category : #running }
 BuilderManifestTest >> setUp [
 
-	| cl |
 	super setUp.
-	cl := testingEnvironment at: #ManifestManifestResourcesTests ifAbsent: [ nil ].
-
-	cl
-		ifNotNil: [
-			cl
-				removeFromChanges;
-				removeFromSystem ]
+	manifestBuilder := TheManifestBuilder of: MFClassA
 ]
 
 { #category : #running }
 BuilderManifestTest >> tearDown [
 
-	| cl |
-	cl := testingEnvironment at: #ManifestManifestResourcesTests ifAbsent: [ nil ].
-	cl
-		ifNotNil: [
-			cl
-				removeFromChanges;
-				removeFromSystem ].
+	testingEnvironment at: #ManifestManifestResourcesTests ifPresent: [ :class |
+		class
+			removeFromChanges;
+			removeFromSystem ].
 	super tearDown
 ]
 
 { #category : #tests }
 BuilderManifestTest >> testAddAllFalsePositive [
-	| manifestBuilder array |
-	<ignoreNotImplementedSelectors: #(ruletestV0FalsePositive)>
-	array := {MFClassA . MFClassB}.
-	manifestBuilder := TheManifestBuilder of: MFClassA.
+
+	<ignoreNotImplementedSelectors: #( ruletestV0FalsePositive )>
+	| array |
+	array := { MFClassA . MFClassB }.
 	manifestBuilder installFalsePositiveOf: 'test' version: 0.
 
 	self deny: ((manifestBuilder falsePositiveOf: 'test' version: 0) anySatisfy: [ :each | each = MFClassA ]).
@@ -64,10 +57,9 @@ BuilderManifestTest >> testAddAllFalsePositive [
 
 { #category : #tests }
 BuilderManifestTest >> testAddAllToDo [
-	| manifestBuilder array |
+	| array |
 	<ignoreNotImplementedSelectors: #(ruletestV0TODO)>
 	array := {MFClassA . MFClassB}.
-	manifestBuilder := TheManifestBuilder of: MFClassA.
 	manifestBuilder installToDoOf: 'test' version: 0.
 
 	self deny: ((manifestBuilder toDoOf: 'test' version: 0) anySatisfy: [ :each | each = MFClassA ]).
@@ -86,71 +78,61 @@ BuilderManifestTest >> testAddAllToDo [
 { #category : #tests }
 BuilderManifestTest >> testAddClass [
 
-	| manifestBuilder|
+	self deny: (manifestBuilder rejectClasses anySatisfy: [ :each | each = MFClassA ]).
 
-	manifestBuilder := TheManifestBuilder of: MFClassA .
+	manifestBuilder addRejectClass: MFClassA.
 
-	self deny: ((manifestBuilder rejectClasses) anySatisfy: [:each| each = MFClassA]).
+	self assert: (manifestBuilder rejectClasses anySatisfy: [ :each | each = MFClassA ]).
 
-	manifestBuilder addRejectClass: MFClassA..
+	manifestBuilder removeRejectClass: MFClassA.
 
-	self assert: ((manifestBuilder rejectClasses) anySatisfy: [:each| each = MFClassA]).
-
-	manifestBuilder removeRejectClass: MFClassA.	.
-
-	self deny: ((manifestBuilder rejectClasses) anySatisfy: [:each| each = MFClassA])
+	self deny: (manifestBuilder rejectClasses anySatisfy: [ :each | each = MFClassA ])
 ]
 
 { #category : #tests }
 BuilderManifestTest >> testAddFalsePositive [
 
-	| manifestBuilder cl mth|
+	| cl mth |
 	cl := MFClassA.
 	mth := MFClassA >> #method.
-	manifestBuilder := TheManifestBuilder of: MFClassA .
-	manifestBuilder  installFalsePositiveOf: 'test' version: 0.
+	manifestBuilder installFalsePositiveOf: 'test' version: 0.
 
-	self deny: ((manifestBuilder falsePositiveOf: 'test' version: 0) anySatisfy: [:each| each = cl]).
-	self deny: ((manifestBuilder falsePositiveOf: 'test' version: 0) anySatisfy: [:each| each = mth]).
+	self deny: ((manifestBuilder falsePositiveOf: 'test' version: 0) anySatisfy: [ :each | each = cl ]).
+	self deny: ((manifestBuilder falsePositiveOf: 'test' version: 0) anySatisfy: [ :each | each = mth ]).
 
 	manifestBuilder addFalsePositive: cl of: 'test' version: 0.
 	manifestBuilder addFalsePositive: mth of: 'test' version: 0.
 
-	self assert: ((manifestBuilder falsePositiveOf: 'test' version: 0) anySatisfy: [:each| each = cl]).
-	self assert: ((manifestBuilder falsePositiveOf: 'test' version: 0) anySatisfy: [:each| each = mth]).
+	self assert: ((manifestBuilder falsePositiveOf: 'test' version: 0) anySatisfy: [ :each | each = cl ]).
+	self assert: ((manifestBuilder falsePositiveOf: 'test' version: 0) anySatisfy: [ :each | each = mth ]).
 
 	manifestBuilder removeFalsePositive: cl of: 'test' version: 0.
 	manifestBuilder removeFalsePositive: mth of: 'test' version: 0.
 
-	self deny: ((manifestBuilder falsePositiveOf: 'test' version: 0) anySatisfy: [:each| each = cl]).
-	self deny: ((manifestBuilder falsePositiveOf: 'test'version: 0) anySatisfy: [:each| each = mth])
+	self deny: ((manifestBuilder falsePositiveOf: 'test' version: 0) anySatisfy: [ :each | each = cl ]).
+	self deny: ((manifestBuilder falsePositiveOf: 'test' version: 0) anySatisfy: [ :each | each = mth ])
 ]
 
 { #category : #tests }
 BuilderManifestTest >> testAddRule [
 
-	| manifestBuilder|
-
-	manifestBuilder := TheManifestBuilder of: MFClassA .
-
-	self deny: ((manifestBuilder rejectRules) anySatisfy: [:each| each = 0]).
+	self deny: (manifestBuilder rejectRules anySatisfy: [ :each | each = 0 ]).
 
 	manifestBuilder addRejectRule: 0.
 
-	self assert: ((manifestBuilder rejectRules) anySatisfy: [:each| each = 0]).
+	self assert: (manifestBuilder rejectRules anySatisfy: [ :each | each = 0 ]).
 
 	manifestBuilder removeRejectRule: 0.
 
-	self deny: ((manifestBuilder rejectRules) anySatisfy: [:each| each = 0])
+	self deny: (manifestBuilder rejectRules anySatisfy: [ :each | each = 0 ])
 ]
 
 { #category : #tests }
 BuilderManifestTest >> testAddToDo [
 
-	| manifestBuilder cl mth|
+	| cl mth|
 	cl := MFClassA.
 	mth := MFClassA >> #method.
-	manifestBuilder := TheManifestBuilder of: MFClassA .
 	manifestBuilder  installToDoOf: 'test' version: 0.
 
 	self deny: ((manifestBuilder toDoOf: 'test' version: 0) anySatisfy: [:each| each = cl]).
@@ -171,8 +153,6 @@ BuilderManifestTest >> testAddToDo [
 
 { #category : #tests }
 BuilderManifestTest >> testCleanUpFP [
-	| manifestBuilder |
-	manifestBuilder := TheManifestBuilder of: MFClassA.
 	MFClassA compile: 'foo'.
 	manifestBuilder installFalsePositiveOf: 'test' version: 0.
 	manifestBuilder addFalsePositive: MFClassA >> #foo of: 'test' version: 0.
@@ -187,8 +167,6 @@ BuilderManifestTest >> testCleanUpFP [
 
 { #category : #tests }
 BuilderManifestTest >> testCleanUpTD [
-	| manifestBuilder |
-	manifestBuilder := TheManifestBuilder of: MFClassA.
 	MFClassA compile: 'foo'.
 	manifestBuilder installToDoOf: 'test' version: 0.
 	manifestBuilder addToDo: MFClassA >> #foo of: 'test' version: 0.
@@ -204,10 +182,6 @@ BuilderManifestTest >> testCleanUpTD [
 { #category : #tests }
 BuilderManifestTest >> testContainsFalsePositive [
 
-	| manifestBuilder |
-
-
-	manifestBuilder := TheManifestBuilder of: MFClassA .
 	manifestBuilder  installFalsePositiveOf: 'test' version: 0.
 
 	manifestBuilder addFalsePositive: MFClassA of: 'test' version: 0.
@@ -219,10 +193,6 @@ BuilderManifestTest >> testContainsFalsePositive [
 { #category : #tests }
 BuilderManifestTest >> testContainsToDo [
 
-	| manifestBuilder |
-
-
-	manifestBuilder := TheManifestBuilder of: MFClassA .
 	manifestBuilder  installToDoOf: 'test' version: 0.
 
 	manifestBuilder addToDo: MFClassA of: 'test' version: 0.
@@ -233,131 +203,114 @@ BuilderManifestTest >> testContainsToDo [
 
 { #category : #tests }
 BuilderManifestTest >> testCreationManifest [
-	| manifestBuilder cl |
-	manifestBuilder := TheManifestBuilder new.
 
-	cl := testingEnvironment at: #ManifestManifestResourcesTests ifAbsent: [ nil ].
-	cl
-		ifNotNil: [
-			cl
-				removeFromChanges;
-				removeFromSystemUnlogged ].
-	self assert: (manifestBuilder manifestOf: MFClassA ) isNil.
-	self assert: (manifestBuilder createManifestOf: MFClassA) notNil.
-	self assert: (manifestBuilder manifestOf: MFClassA) notNil
+	manifestBuilder := TheManifestBuilder new.
+	testingEnvironment at: #ManifestManifestResourcesTests ifPresent: [ :class |
+		class
+			removeFromChanges;
+			removeFromSystem ].
+	self assert: (manifestBuilder manifestOf: MFClassA) isNil.
+	self assert: (manifestBuilder createManifestOf: MFClassA) isNotNil.
+	self assert: (manifestBuilder manifestOf: MFClassA) isNotNil
 ]
 
 { #category : #tests }
 BuilderManifestTest >> testCreationManifestOn [
-	| manifestBuilder cl |
-	manifestBuilder := TheManifestBuilder new.
 
-	cl := testingEnvironment at: #ManifestManifestResourcesTests ifAbsent: [ nil ].
-	cl
-		ifNotNil: [
-			cl
-				removeFromChanges;
-				removeFromSystemUnlogged ].
-	self assert: (manifestBuilder manifestOf: MFClassA ) isNil.
-	self assert: (TheManifestBuilder of: MFClassA) notNil.
-	self assert: (manifestBuilder manifestOf: MFClassA) notNil
+	manifestBuilder := TheManifestBuilder new.
+	testingEnvironment at: #ManifestManifestResourcesTests ifPresent: [ :class |
+		class
+			removeFromChanges;
+			removeFromSystem ].
+	self assert: (manifestBuilder manifestOf: MFClassA) isNil.
+	self assert: (TheManifestBuilder of: MFClassA) isNotNil.
+	self assert: (manifestBuilder manifestOf: MFClassA) isNotNil
 ]
 
 { #category : #tests }
 BuilderManifestTest >> testDateOfFalsePositive [
 
-	| manifestBuilder date1 date2 |
+	| date1 date2 |
+	manifestBuilder installFalsePositiveOf: 'test' version: 0.
 
-
-	manifestBuilder := TheManifestBuilder of: MFClassA .
-	manifestBuilder  installFalsePositiveOf: 'test' version: 0.
-
-	date1 :=  DateAndTime current.
+	date1 := DateAndTime current.
 	manifestBuilder addFalsePositive: MFClassA of: 'test' version: 0.
-	date2 :=  DateAndTime current.
+	date2 := DateAndTime current.
 
-	self assert: (manifestBuilder dateOfFalsePositive: MFClassA onRule: 'test' version: 0) >= date1 .
+	self assert: (manifestBuilder dateOfFalsePositive: MFClassA onRule: 'test' version: 0) >= date1.
 	self assert: (manifestBuilder dateOfFalsePositive: MFClassA onRule: 'test' version: 0) <= date2
 ]
 
 { #category : #tests }
 BuilderManifestTest >> testDateOfToDo [
 
-	| manifestBuilder date1 date2 |
+	| date1 date2 |
+	manifestBuilder installToDoOf: 'test' version: 0.
 
-
-	manifestBuilder := TheManifestBuilder of: MFClassA .
-	manifestBuilder  installToDoOf: 'test' version: 0.
-
-	date1 :=  DateAndTime current.
+	date1 := DateAndTime current.
 	manifestBuilder addToDo: MFClassA of: 'test' version: 0.
-	date2 :=  DateAndTime current.
+	date2 := DateAndTime current.
 
-	self assert: (manifestBuilder dateOfToDo: MFClassA onRule: 'test' version: 0) >= date1 .
+	self assert: (manifestBuilder dateOfToDo: MFClassA onRule: 'test' version: 0) >= date1.
 	self assert: (manifestBuilder dateOfToDo: MFClassA onRule: 'test' version: 0) <= date2
 ]
 
 { #category : #tests }
 BuilderManifestTest >> testInstallFalsePositive [
-	| manifestBuilder |
-	manifestBuilder := TheManifestBuilder of: MFClassA. .
+
 	self deny: (manifestBuilder hasFalsePositiveOf: 'test' version: 0).
 	manifestBuilder installFalsePositiveOf: 'test' version: 0.
 	self assert: (manifestBuilder hasFalsePositiveOf: 'test' version: 0).
-	self assert: (manifestBuilder falsePositiveOf: 'test' version: 0) notNil
+	self assert: (manifestBuilder falsePositiveOf: 'test' version: 0) isNotNil
 ]
 
 { #category : #tests }
 BuilderManifestTest >> testInstallToDo [
-	| manifestBuilder |
 
-	manifestBuilder := TheManifestBuilder of: MFClassA. .
 	self deny: (manifestBuilder hasToDoOf: 'test' version: 0).
 	manifestBuilder installToDoOf: 'test' version: 0.
 	self assert: (manifestBuilder hasToDoOf: 'test' version: 0).
-	self assert: (manifestBuilder toDoOf: 'test' version: 0) notNil
+	self assert: (manifestBuilder toDoOf: 'test' version: 0) isNotNil
 ]
 
 { #category : #tests }
 BuilderManifestTest >> testIsClassAManifest [
 
 	self deny: Point isManifest.
-	TheManifestBuilder of: MFClassA.
-	self assert: ( (testingEnvironment at: #ManifestManifestResourcesTests) isManifest)
+	self assert: (testingEnvironment at: #ManifestManifestResourcesTests) isManifest
 ]
 
 { #category : #tests }
 BuilderManifestTest >> testIsFalsePositive [
 
-	| manifestBuilder cl mth|
+	| cl mth |
 	cl := MFClassA.
 	mth := cl >> #method.
-	manifestBuilder := TheManifestBuilder of: MFClassA .
-	self deny: (manifestBuilder isFalsePositive: mth onRule: 'test' version:0 ).
+	self deny: (manifestBuilder isFalsePositive: mth onRule: 'test' version: 0).
 
 	manifestBuilder addRejectClass: MFClassA.
-	self assert: (manifestBuilder isFalsePositive: mth onRule: 'test' version:0 ).
+	self assert: (manifestBuilder isFalsePositive: mth onRule: 'test' version: 0).
 
-	manifestBuilder removeRejectClass: MFClassA.	.
-	self deny: (manifestBuilder isFalsePositive: mth onRule: 'test' version:0 ).
+	manifestBuilder removeRejectClass: MFClassA.
+	self deny: (manifestBuilder isFalsePositive: mth onRule: 'test' version: 0).
 
 	manifestBuilder addRejectRule: 'test'.
-	self assert: (manifestBuilder isFalsePositive: mth onRule: 'test' version:0 ).
+	self assert: (manifestBuilder isFalsePositive: mth onRule: 'test' version: 0).
 
 	manifestBuilder removeRejectRule: 'test'.
-	self deny: (manifestBuilder isFalsePositive: mth onRule: 'test' version:0 ).
+	self deny: (manifestBuilder isFalsePositive: mth onRule: 'test' version: 0).
 
 	manifestBuilder installFalsePositiveOf: 'test' version: 0.
-	manifestBuilder addFalsePositive:  mth of: 'test' version: 0.
-	self assert: (manifestBuilder isFalsePositive: mth onRule: 'test' version:0 )
+	manifestBuilder addFalsePositive: mth of: 'test' version: 0.
+	self assert: (manifestBuilder isFalsePositive: mth onRule: 'test' version: 0)
 ]
 
 { #category : #tests }
 BuilderManifestTest >> testResetFalsePositive [
-	| manifestBuilder array |
-	<ignoreNotImplementedSelectors: #(ruletestV0FalsePositive)>
-	array := {MFClassA . MFClassB}.
-	manifestBuilder := TheManifestBuilder of: MFClassA.
+
+	<ignoreNotImplementedSelectors: #( ruletestV0FalsePositive )>
+	| array |
+	array := { MFClassA . MFClassB }.
 	manifestBuilder installFalsePositiveOf: 'test' version: 0.
 
 	manifestBuilder addAllFalsePositive: array of: 'test' version: 0.
@@ -372,10 +325,10 @@ BuilderManifestTest >> testResetFalsePositive [
 
 { #category : #tests }
 BuilderManifestTest >> testResetToDo [
-	| manifestBuilder array |
-	<ignoreNotImplementedSelectors: #(ruletestV0TODO)>
-	array := {MFClassA . MFClassB}.
-	manifestBuilder := TheManifestBuilder of: MFClassA.
+
+	<ignoreNotImplementedSelectors: #( ruletestV0TODO )>
+	| array |
+	array := { MFClassA . MFClassB }.
 	manifestBuilder installToDoOf: 'test' version: 0.
 
 	manifestBuilder addAllToDo: array of: 'test' version: 0.

--- a/src/Manifest-Tests/SmalllintManifestCheckerTest.class.st
+++ b/src/Manifest-Tests/SmalllintManifestCheckerTest.class.st
@@ -11,55 +11,40 @@ Class {
 }
 
 { #category : #running }
-SmalllintManifestCheckerTest >> cleaningResources [
-	testingEnvironment
-		at: #ManifestManifestResourcesTests
-		ifPresent: [ :cl |
-			cl
-				removeFromChanges;
-				removeFromSystem ]
-]
-
-{ #category : #private }
-SmalllintManifestCheckerTest >> package [
-	MCWorkingCopy managersForClass: MFClassA  do: [:p | ^ p packageSet packages first].
-	" should be equivalent to RPackageOrganizer default packageNamed: #'Manifest-Resources-Tests' "
-]
-
-{ #category : #running }
 SmalllintManifestCheckerTest >> setUp [
-	| bm |
+
 	super setUp.
-	self cleaningResources.
-	bm := TheManifestBuilder of: MFClassA.
-	bm installFalsePositiveOf: ReCodeCruftLeftInMethodsRule uniqueIdentifierName version: 1.
-	bm addFalsePositive: MFClassB >> #method3 of: ReCodeCruftLeftInMethodsRule uniqueIdentifierName version: 1.
-	bm installToDoOf: ReTemporaryNeitherReadNorWrittenRule uniqueIdentifierName version: 1.
-	bm
-		addAllToDo:
-			{(MFClassB >> #method3).
-			(MFClassA >> #method)}
-		of: ReTemporaryNeitherReadNorWrittenRule uniqueIdentifierName
-		version: 1.
-	checker := ReSmalllintChecker new
+
+	(TheManifestBuilder of: MFClassA)
+		installFalsePositiveOf: ReCodeCruftLeftInMethodsRule uniqueIdentifierName version: 1;
+		addFalsePositive: MFClassB >> #method3 of: ReCodeCruftLeftInMethodsRule uniqueIdentifierName version: 1;
+		installToDoOf: ReTemporaryNeitherReadNorWrittenRule uniqueIdentifierName version: 1;
+		addAllToDo: {
+				(MFClassB >> #method3).
+				(MFClassA >> #method) }
+		of: ReTemporaryNeitherReadNorWrittenRule uniqueIdentifierName version: 1.
+
+	checker := ReSmalllintChecker new.
+	checker
+		rule: (ReRuleManager visibleRuleClasses collect: [ :class | class new ]);
+		environment: MFClassA package asEnvironment;
+		run
 ]
 
 { #category : #running }
 SmalllintManifestCheckerTest >> tearDown [
 
-	self cleaningResources.
+	testingEnvironment at: #ManifestManifestResourcesTests ifPresent: [ :class |
+		class
+			removeFromChanges;
+			removeFromSystem ].
 	super tearDown
 ]
 
 { #category : #tests }
 SmalllintManifestCheckerTest >> testCriticsOf [
 
-	| rule critiques |
-	rule := ReRuleManager visibleRuleClasses collect: [:cl | cl new].
-	checker
-		rule: rule;
-		environment: self package asEnvironment;
-		run.
+	| critiques |
 	critiques := checker criticsOf: ReTemporaryNeitherReadNorWrittenRule new.
 	self assert: critiques size equals: 3.
 	self assert: (critiques anySatisfy: [ :each | each sourceAnchor entity = (MFClassB >> #method3) ]).
@@ -69,42 +54,20 @@ SmalllintManifestCheckerTest >> testCriticsOf [
 { #category : #tests }
 SmalllintManifestCheckerTest >> testIsFalsePositive [
 
-	| rule |
-	rule  := ReRuleManager visibleRuleClasses collect: [:cl | cl new].
-	checker
-		rule: rule;
-		environment: self package asEnvironment;
-		run.
-	self assert: (checker isFalsePositive:  (MFClassB>>#method3) forRuleId: (ReCodeCruftLeftInMethodsRule uniqueIdentifierName) versionId:  1).
-	self deny: (checker isFalsePositive:  (MFClassA>>#method) forRuleId: (ReCodeCruftLeftInMethodsRule uniqueIdentifierName) versionId:  1)
+	self assert: (checker isFalsePositive: MFClassB >> #method3 forRuleId: ReCodeCruftLeftInMethodsRule uniqueIdentifierName versionId: 1).
+	self deny: (checker isFalsePositive: MFClassA >> #method forRuleId: ReCodeCruftLeftInMethodsRule uniqueIdentifierName versionId: 1)
 ]
 
 { #category : #tests }
 SmalllintManifestCheckerTest >> testIsToDo [
 
-	| rule |
-	rule  := ReRuleManager visibleRuleClasses collect: [ :each | each new ].
-	checker
-		rule: rule;
-		environment: self package asEnvironment;
-		run.
-
-	self assert: (checker isToDo:  (MFClassB>>#method3) forRuleId: (ReTemporaryNeitherReadNorWrittenRule uniqueIdentifierName) versionId:  1).
-	self deny: (checker isToDo:  (MFClassB>>#method2) forRuleId: (ReTemporaryNeitherReadNorWrittenRule uniqueIdentifierName) versionId:  1)
+	self assert: (checker isToDo: MFClassB >> #method3 forRuleId: ReTemporaryNeitherReadNorWrittenRule uniqueIdentifierName versionId: 1).
+	self deny: (checker isToDo: MFClassB >> #method2 forRuleId: ReTemporaryNeitherReadNorWrittenRule uniqueIdentifierName versionId: 1)
 ]
 
 { #category : #tests }
 SmalllintManifestCheckerTest >> testToDoOf [
 
-	| rule |
-	rule := ReRuleManager visibleRuleClasses collect: [:cl | cl new].
-	checker
-		rule: rule;
-		environment: self package asEnvironment;
-		run.
-
-	self assert: (( checker toDoOf: ReTemporaryNeitherReadNorWrittenRule new) anySatisfy: [:each|
-		each sourceAnchor entity = (MFClassB>>#method3)]).
-	self deny: (( checker toDoOf: ReTemporaryNeitherReadNorWrittenRule new) anySatisfy: [:each|
-		each  sourceAnchor entity = (MFClassB>>#method2)])
+	self assert: ((checker toDoOf: ReTemporaryNeitherReadNorWrittenRule new) anySatisfy: [ :each | each sourceAnchor entity = (MFClassB >> #method3) ]).
+	self deny: ((checker toDoOf: ReTemporaryNeitherReadNorWrittenRule new) anySatisfy: [ :each | each sourceAnchor entity = (MFClassB >> #method2) ])
 ]


### PR DESCRIPTION
I started this change by cutting the dependency of ManifestBuilder to Monticello. Monticello was used as a way to get a system package but we can directly ask the package without this useless dependency.

I also did other cleanings such as removing duplicated cleanings or introducing a better setup for BuilderManifestTest and SmalllintManifestCheckerTest.  I also removed some things such as double point at the end of some statements.