### PR TITLE
Fix broken release tests + improve a test

### DIFF
--- a/src/Kernel-Tests/MockWithComplexSlot.class.st
+++ b/src/Kernel-Tests/MockWithComplexSlot.class.st
@@ -15,6 +15,7 @@ Class {
 { #category : #initialization }
 MockWithComplexSlot >> initialize [
 
+	<ignoreUnusedVariables: #( #aComplexSlot )>
 	self class initializeSlots: self.
 	super initialize
 ]

--- a/src/Refactoring-DataForTesting/RBDummyLintRuleTest.class.st
+++ b/src/Refactoring-DataForTesting/RBDummyLintRuleTest.class.st
@@ -67,6 +67,7 @@ RBDummyLintRuleTest >> hasConflicts [
 
 { #category : #initialization }
 RBDummyLintRuleTest >> initialize [
+	<ignoreUnusedVariables: #(#foo1)>
 	name := ''
 ]
 

--- a/src/Refactoring-DataForTesting/RBFooDummyLintRuleTest.class.st
+++ b/src/Refactoring-DataForTesting/RBFooDummyLintRuleTest.class.st
@@ -1,13 +1,10 @@
 Class {
 	#name : #RBFooDummyLintRuleTest,
 	#superclass : #RBDummyLintRuleTest,
-	#instVars : [
-		'result'
-	],
 	#category : #'Refactoring-DataForTesting-LittleHierarchy'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 RBFooDummyLintRuleTest >> foo [
 	^ 6
 ]

--- a/src/Refactoring-DataForTesting/RBFooLintRuleTestData.class.st
+++ b/src/Refactoring-DataForTesting/RBFooLintRuleTestData.class.st
@@ -1,13 +1,10 @@
 Class {
 	#name : #RBFooLintRuleTestData,
 	#superclass : #RBLintRuleTestData,
-	#instVars : [
-		'result'
-	],
 	#category : #'Refactoring-DataForTesting-LittleHierarchy'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 RBFooLintRuleTestData >> foo [
 	^ 6
 ]

--- a/src/Refactoring-DataForTesting/RBLintRuleTestData.class.st
+++ b/src/Refactoring-DataForTesting/RBLintRuleTestData.class.st
@@ -84,6 +84,7 @@ RBLintRuleTestData >> hasConflicts [
 
 { #category : #initialization }
 RBLintRuleTestData >> initialize [
+	<ignoreUnusedVariables: #(#foo1)>
 	name := ''
 ]
 

--- a/src/Refactoring-DataForTesting/RBTransformationDummyRuleTest.class.st
+++ b/src/Refactoring-DataForTesting/RBTransformationDummyRuleTest.class.st
@@ -290,10 +290,6 @@ RBTransformationDummyRuleTest >> isEmpty [
 	^builder changes isEmpty
 ]
 
-{ #category : #'as yet unclassified' }
-RBTransformationDummyRuleTest >> newUnclassifiedMethod [
-]
-
 { #category : #rules }
 RBTransformationDummyRuleTest >> parseTreeRewriter [
 	^ RBParseTreeRewriter new

--- a/src/Refactoring-Tests-Changes/RBRefactoringChangeMock.class.st
+++ b/src/Refactoring-Tests-Changes/RBRefactoringChangeMock.class.st
@@ -11,8 +11,6 @@ Class {
 		'SharedVar'
 	],
 	#classInstVars : [
-		'SharedVarPlus',
-		'instVarPlus',
 		'classInstVar'
 	],
 	#category : #'Refactoring-Tests-Changes'
@@ -29,6 +27,13 @@ RBRefactoringChangeMock >> accessAll [
 	instVar := 0. 
 	SharedVar := 0.
 	^ instVar + SharedVar 
+]
+
+{ #category : #initialization }
+RBRefactoringChangeMock >> initialize [
+
+	<ignoreUnusedVariables: #( #instVar )>
+	super initialize
 ]
 
 { #category : #accessing }

--- a/src/Refactoring2-Transformations-Tests/RBAbstractInstanceVariableParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAbstractInstanceVariableParametrizedTest.class.st
@@ -31,6 +31,7 @@ RBAbstractInstanceVariableParametrizedTest >> testAbstractInstanceVariable [
 	self assert: (class parseTreeForSelector: #name:) equals: (self parseMethod: 'name: aString
 	name := aString').
 	self assert: (class parseTreeForSelector: #initialize) equals: (self parseMethod: 'initialize
+	<ignoreUnusedVariables: #(#foo1)>
 	self name: ''''').
 	self assert: (class parseTreeForSelector: #printOn:) equals: (self parseMethod: 'printOn: aStream
 	self name ifNil: [ super printOn: aStream ] ifNotNil: [ aStream nextPutAll: self name ]')

--- a/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
+++ b/src/ReleaseTests/NoUnusedVariablesLeftTest.class.st
@@ -32,17 +32,18 @@ NoUnusedVariablesLeftTest >> testNoUnusedClassVariablesLeft [
 
 { #category : #testing }
 NoUnusedVariablesLeftTest >> testNoUnusedInstanceVariablesLeft [
-	| variables classes validExceptions remaining |
 
-	variables := Smalltalk globals allBehaviors flatCollect: [ :each | each instanceVariables ].
-	variables := variables reject: [ :each | each isReferenced ].
+	| variables classes |
+	variables := Smalltalk globals allBehaviors flatCollect: [ :class | class instanceVariables ].
+
+	variables := variables reject: [ :variable |
+		             variable isReferenced or: [
+			             variable definingClass pragmas anySatisfy: [ :pragma |
+				             pragma selector = #ignoreUnusedVariables: and: [ (pragma argumentAt: 1) includes: variable name ] ] ] ].
 
 	classes := variables collect: [ :each | each definingClass ] as: Set.
 
-	validExceptions := { RBFooLintRuleTestData . RBLintRuleTestData .RBFooDummyLintRuleTest . RBDummyLintRuleTest. MockWithComplexSlot }.
-
-	remaining := classes asOrderedCollection removeAll: validExceptions; yourself.
-	self assert: remaining isEmpty description: ('the following classes have unused instance variables and should be cleaned: ', remaining asString)
+	self assert: classes isEmpty description: 'the following classes have unused instance variables and should be cleaned: ' , classes asOrderedCollection asString
 ]
 
 { #category : #testing }

--- a/src/ReleaseTests/ProperMethodCategorizationTest.class.st
+++ b/src/ReleaseTests/ProperMethodCategorizationTest.class.st
@@ -166,7 +166,7 @@ ProperMethodCategorizationTest >> testNoUncategorizedMethods [
 
 
 	validExceptions := #( ClyClass2FromP1Mock #MCMock #'MCMock class' #'MCMockASubclass class' #'MCMockClassA class' #MCMockASubclass #MCMockClassD #'MCMockClassE class'
-	                      MFClassA MFClassB RBFooDummyLintRuleTest RBFooLintRuleTestData RBSmalllintTestObject RBTransformationDummyRuleTest
+	                      MFClassA MFClassB RBSmalllintTestObject
 	                      'RBTransformationRuleTestData1' StInspectorMockObjectSubclass StDebuggerCommand ).
 
 	remaining := violating asOrderedCollection reject: [ :each | validExceptions includes: each name ].


### PR DESCRIPTION
I fixed the two failing release tests. One by adding an exception and one by removing unused variables (tests referencing the class are green in my image).

I also updated testNoUnusedInstanceVariablesLeft to not hardcode the violations but let the users declare them. 

FInally, I fixed some other violations that were in the valid exceptions but did not make sense in reality.

Future steps:
- Use the new exception pragma in testNoUnusedClassVariablesLeft and testNoUnusedTemporaryVariablesLeft
- Take into account this pragma in the rules