### PR TITLE
Improve RPackageOrganizer>>ensureExistAndRegisterPackageNamed:

### DIFF
--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -374,23 +374,14 @@ RPackageOrganizer >> defineUnpackagedClassesPackage [
 RPackageOrganizer >> ensureExistAndRegisterPackageNamed: aSymbol [
 	"A new package is now available and declared in the receiver."
 
-	| package |
-
-	package := packages
-		at: aSymbol asSymbol
-		ifAbsentPut: [
-			"I add the package to the packageName cache"
-			self addPackageNameToCache: aSymbol asSymbol.
-			self packageClass named: aSymbol ].
-
-	package extendedClasses do: [ :extendedClass|
-			self registerExtendingPackage: package forClass: extendedClass].
-	package definedClasses do: [ :definedClass|
-			self registerPackage: package forClass: definedClass].
-
-	SystemAnnouncer announce: (PackageAdded to: package).
-
-	^ package
+	^ (self includesPackageNamed: aSymbol)
+		  ifFalse: [ self basicRegisterPackage: (RPackage named: aSymbol) ]
+		  ifTrue: [
+			  | package |
+			  package := self packageNamed: aSymbol.
+			  package extendedClasses do: [ :extendedClass | self registerExtendingPackage: package forClass: extendedClass ].
+			  package definedClasses do: [ :definedClass | self registerPackage: package forClass: definedClass ].
+			  package ]
 ]
 
 { #category : #'deprecated - SystemOrganizer leftovers' }


### PR DESCRIPTION
The code of RPackage is really complexe (more than it should) and not really consistent.

It is hard to decide what are the best first steps to clean this because the code has a lot of interactions with the system and with its differents states/caches. Here is a first try at improving the situation with RPackageOrganizer>>ensureExistAndRegisterPackageNamed:.

List of changes:
- Factorize the code that register the package by using #basicRegisterPackage:. This has the effect that for now depending on the API used, the Monticello working copy was created or not. We should find a way to remove the dependencies to Monticello but this will be easier if the code is more consistent.
- Ensure the registrations of classes happens only if we already had a package of this name, not if we just created one that should be empty
- Raise PackageAdded only if the package is created because for now it was fired even if the package already existed

We can still improve a lot this code but this already has a lot of impact on the system (Monticello + Announcements + management of the classes) so I want to see if the system keep working with this change.