### PR TITLE
Remove announcement registration doing nothing

### DIFF
--- a/src/Monticello/RPackageOrganizer.extension.st
+++ b/src/Monticello/RPackageOrganizer.extension.st
@@ -1,15 +1,15 @@
 Extension { #name : #RPackageOrganizer }
 
 { #category : #'*Monticello-RPackage' }
-RPackageOrganizer class >> allManagers [
-
-	^ MCWorkingCopy allManagers
-]
-
-{ #category : #'*Monticello-RPackage' }
 RPackageOrganizer >> allManagers [
 
 	^ self class allManagers 
+]
+
+{ #category : #'*Monticello-RPackage' }
+RPackageOrganizer class >> allManagers [
+
+	^ MCWorkingCopy allManagers
 ]
 
 { #category : #'*Monticello-RPackage' }
@@ -27,9 +27,4 @@ RPackageOrganizer >> updateAfterNewMCPackageRegistred: anAnnouncement [
 	name := anAnnouncement package name.
 	(self packageExactlyMatchingExtensionName: name) 
 		ifNil: [ self ensureExistAndRegisterPackageNamed: name ]
-]
-
-{ #category : #'*Monticello-RPackage' }
-RPackageOrganizer >> updateAfterNewMCPackageUnregistred: anAnnouncement [
-
 ]

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -810,31 +810,27 @@ RPackageOrganizer >> registerExtendingPackage: aPackage forClassName: aClassName
 { #category : #'system integration' }
 RPackageOrganizer >> registerInterestToAnnouncer: anAnnouncer [
 	"There should be only one"
+
 	anAnnouncer unsubscribe: self.
 
 	anAnnouncer weak
 		when: CategoryAdded send: #systemCategoryAddedActionFrom: to: self;
 		when: CategoryRemoved send: #systemCategoryRemovedActionFrom: to: self;
 		when: CategoryRenamed send: #systemCategoryRenamedActionFrom: to: self;
-		when:  ClassAdded send: #systemClassAddedActionFrom: to: self;
-		when:  ClassRecategorized send: #systemClassRecategorizedActionFrom: to: self;
-		when:  ClassRemoved send: #systemClassRemovedActionFrom: to: self;
-		when:  ClassRenamed send: #systemClassRenamedActionFrom: to: self;
-		when:  ClassReorganized send: #systemClassReorganizedActionFrom: to: self;
-		when:  MethodAdded send: #systemMethodAddedActionFrom: to: self;
-		when:  MethodModified send: #systemMethodModifiedActionFrom: to: self;
-		when:  MethodRecategorized send: #systemMethodRecategorizedActionFrom: to: self;
-		when:  MethodRemoved send: #systemMethodRemovedActionFrom: to: self.
+		when: ClassAdded send: #systemClassAddedActionFrom: to: self;
+		when: ClassRecategorized send: #systemClassRecategorizedActionFrom: to: self;
+		when: ClassRemoved send: #systemClassRemovedActionFrom: to: self;
+		when: ClassRenamed send: #systemClassRenamedActionFrom: to: self;
+		when: ClassReorganized send: #systemClassReorganizedActionFrom: to: self;
+		when: MethodAdded send: #systemMethodAddedActionFrom: to: self;
+		when: MethodModified send: #systemMethodModifiedActionFrom: to: self;
+		when: MethodRecategorized send: #systemMethodRecategorizedActionFrom: to: self;
+		when: MethodRemoved send: #systemMethodRemovedActionFrom: to: self.
 
 	self flag: #hack. "for decoupling MC"
-	self class environment at: #MCWorkingCopy ifPresent: [
-		anAnnouncer weak
-			when: (self class environment at: #MCWorkingCopyCreated)
-				send: #updateAfterNewMCPackageRegistred:
-				to: self;
-			when: (self class environment at: #MCWorkingCopyDeleted)
-				send: #updateAfterNewMCPackageUnregistred:
-				to: self	]
+	self class environment
+		at: #MCWorkingCopy
+		ifPresent: [ anAnnouncer weak when: (self class environment at: #MCWorkingCopyCreated) send: #updateAfterNewMCPackageRegistred: to: self ]
 ]
 
 { #category : #'system integration' }


### PR DESCRIPTION
RPackage registers to Monticello in multiple places and one of those places does nothing. Let's remove this registration since it is an easy cleaning to reduce the dependency to Monticello