### PR TITLE
Make `HaloMorph>>#handleSize` take the display scale factor into account

### DIFF
--- a/src/Morphic-Base/HaloMorph.class.st
+++ b/src/Morphic-Base/HaloMorph.class.st
@@ -970,7 +970,7 @@ HaloMorph >> handleListenEvent: anEvent [
 { #category : #private }
 HaloMorph >> handleSize [
 
-	^ 30
+	^ 30 scaledByDisplayScaleFactor
 ]
 
 { #category : #'meta-actions' }


### PR DESCRIPTION
This pull request makes `HaloMorph>>#handleSize` take the display scale factor into account.