### PR TITLE
Fix #menuBorderWidth display scaling

### DIFF
--- a/src/Polymorph-Widgets/PharoDarkTheme.class.st
+++ b/src/Polymorph-Widgets/PharoDarkTheme.class.st
@@ -110,7 +110,7 @@ PharoDarkTheme >> initialize [
 { #category : #accessing }
 PharoDarkTheme >> menuBorderWidth [
 
-	^ self borderWidth * self displayScaleFactor
+	^ self borderWidth
 ]
 
 { #category : #'fill-styles - scrollbars' }

--- a/src/Polymorph-Widgets/ThemeSettings.class.st
+++ b/src/Polymorph-Widgets/ThemeSettings.class.st
@@ -356,7 +356,7 @@ ThemeSettings >> menuBorderColor [
 ThemeSettings >> menuBorderWidth [
 	"Answer the value of menuColor"
 
-	^ 2
+	^ 2 scaledByDisplayScaleFactor
 ]
 
 { #category : #menu }

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -2123,7 +2123,7 @@ UITheme >> menuBorderColor [
 
 { #category : #accessing }
 UITheme >> menuBorderWidth [
-	^  self settings menuBorderWidth * self displayScaleFactor
+	^  self settings menuBorderWidth
 ]
 
 { #category : #'label-styles' }

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -4242,7 +4242,7 @@ UITheme >> setSystemProgressMorphDefaultParameters: aProgressMorph [
 	aProgressMorph color: self settings derivedMenuColor.
 	self settings preferRoundCorner
 		ifTrue: [aProgressMorph useRoundedCorners].
-	aProgressMorph borderWidth: self menuBorderWidth * self displayScaleFactor.
+	aProgressMorph borderWidth: self menuBorderWidth.
 	aProgressMorph borderColor: self menuBorderColor.
 	aProgressMorph updateColor
 ]


### PR DESCRIPTION
This pull request fixes some problems with the application of the display scale factor in `#menuBorderWidth`.

Note that I kept the override of UITheme’s `#menuBorderWidth` in PharoDarkTheme, though I’m not sure why it deviates from PharoLightTheme in that respect.