### PR TITLE
Make WorldState and ProfStef take the display scale factor into account for the world menu items with the #pharo icon

### DIFF
--- a/src/Morphic-Core/WorldState.class.st
+++ b/src/Morphic-Core/WorldState.class.st
@@ -172,7 +172,7 @@ WorldState class >> pharoItemsOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #Pharo)
 		label: 'Pharo';
-		icon: ((self iconNamed: #pharo) scaledToSize: 16 @ 16);
+		icon: ((self iconNamed: #pharo) scaledToSize: (16 @ 16) scaledByDisplayScaleFactor);
 		order: 0;
 		with: [
 			(aBuilder group: #Saving)

--- a/src/ProfStef-Core/ProfStef.class.st
+++ b/src/ProfStef-Core/ProfStef.class.st
@@ -130,7 +130,7 @@ ProfStef class >> menuCommandOn: aBuilder [
 		parent: #PharoHelp;
 		order: 3;
 		action: [ self openPharoZenWorkspace ];
-		icon: ((self iconNamed: #pharo) scaledToSize: 16@16);
+		icon: ((self iconNamed: #pharo) scaledToSize: (16@16) scaledByDisplayScaleFactor);
 		help: 'Pharo values.'
 ]
 


### PR DESCRIPTION
This pull request makes WorldState and ProfStef take the display scale factor into account for the world menu items with the #pharo icon.

Corresponding pull request for StWelcomeBrowser: https://github.com/pharo-spec/NewTools-WelcomeBrowser/pull/7