### PR TITLE
Reduce Monticello coupling in RPackage

### DIFF
--- a/src/Deprecated12/RPackageOrganizer.extension.st
+++ b/src/Deprecated12/RPackageOrganizer.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #RPackageOrganizer }
+
+{ #category : #'*Deprecated12' }
+RPackageOrganizer >> packageExactlyMatchingExtensionName: anExtensionName [
+	"only look for a package for which the name match 'anExtensionName', making no difference about case. Return nil if no package is found"
+
+	self
+		deprecated: 'Use #packageNamedIgnoreCase:ifAbsent: instead.'
+		transformWith: '`@rcv packageExactlyMatchingExtensionName: `@arg' -> '`@rcv packageNamedIgnoreCase: `@arg ifAbsent: [ nil ]'.
+	^ self packageNamedIgnoreCase: anExtensionName ifAbsent: [ nil ]
+]

--- a/src/Monticello-Tests/RPackageMonticelloSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMonticelloSynchronisationTest.class.st
@@ -10,43 +10,38 @@ Class {
 { #category : #'tests - operations on MCPackages' }
 RPackageMonticelloSynchronisationTest >> testAddMCPackageCreatesAPackage [
 	"test that when we create a MCPackage, a corresponding package is created"
-	
-	MCWorkingCopy forPackage: (MCPackage new name: #Zork).
-	self assert: (self organizer includesPackageNamed: #Zork).
-		
-					  
+
+	MCWorkingCopy forPackage: (MCPackage new name: #Zork) packageOrganizer: self organizer.
+	self assert: (self organizer includesPackageNamed: #Zork)
 ]
 
 { #category : #'tests - operations on MCPackages' }
 RPackageMonticelloSynchronisationTest >> testAddMCPackageForCategoryAlreadyExistingDoesNotCreateAPackage [
 	"test that when we create a MCPackage and that a category of this name already exists, no package is created"
- 
-	|tmpPackage|
+
+	| tmpPackage |
 	testingEnvironment organization addCategory: 'Zork'.
 	tmpPackage := self organizer packageNamed: #Zork.
-	MCWorkingCopy forPackage: (MCPackage new name: #Zork).
-	self assert: tmpPackage equals: (self organizer packageNamed: #Zork).
-		
-		
-					  
+	MCWorkingCopy forPackage: (MCPackage new name: #Zork) packageOrganizer: self organizer.
+	self assert: tmpPackage equals: (self organizer packageNamed: #Zork)
 ]
 
 { #category : #'tests - operations on MCPackages' }
 RPackageMonticelloSynchronisationTest >> testUnloadMCPackageRemovesRPackage [
 	"test that when we remove a MC Package, the corresponding RPackage is removed from the organizer"
 
-	MCWorkingCopy forPackage: (MCPackage new name: 'XXXXX').
-	(self allManagers detect: [:each | each packageName = 'XXXXX']) unload.
+	MCWorkingCopy forPackage: (MCPackage new name: 'XXXXX') packageOrganizer: self organizer.
+	(self allManagers detect: [ :each | each packageName = 'XXXXX' ]) unload.
 
-	self deny: (self organizer includesPackageNamed: #XXXXX).
+	self deny: (self organizer includesPackageNamed: #XXXXX)
 ]
 
 { #category : #'tests - operations on MCPackages' }
 RPackageMonticelloSynchronisationTest >> testUnregisterMCPackageKeepsRPackage [
 	"test that when we remove a MC Package, the corresponding RPackage is removed from the organizer"
-	
-	MCWorkingCopy forPackage: (MCPackage new name: 'XXXXX').
-	(self allManagers detect: [:each | each packageName = 'XXXXX']) unregister.
-	
-	self assert: (self organizer includesPackageNamed: #XXXXX).
+
+	MCWorkingCopy forPackage: (MCPackage new name: 'XXXXX') packageOrganizer: self organizer.
+	(self allManagers detect: [ :each | each packageName = 'XXXXX' ]) unregister.
+
+	self assert: (self organizer includesPackageNamed: #XXXXX)
 ]

--- a/src/Monticello/MCPackageManager.class.st
+++ b/src/Monticello/MCPackageManager.class.st
@@ -92,20 +92,20 @@ MCPackageManager class >> classRenamed: anEvent [
 ]
 
 { #category : #accessing }
-MCPackageManager class >> ensureSystemPackageNamed: aPackageName [
-	"When creating a MC package and a working copy, we need to ensure we create a system package also in case someone creates a package without an associated system package."
+MCPackageManager class >> forPackage: aPackage [
 
-	self packageOrganizer packageNamedIgnoreCase: aPackageName ifAbsent: [ self packageOrganizer ensureExistAndRegisterPackageNamed: aPackageName ]
+	^ self forPackage: aPackage packageOrganizer: self packageOrganizer
 ]
 
 { #category : #accessing }
-MCPackageManager class >> forPackage: aPackage [
+MCPackageManager class >> forPackage: aPackage packageOrganizer: aPackageOrganizer [
 
 	^ self registry at: aPackage ifAbsent: [
 		  | mgr |
 		  mgr := self new initializeWithPackage: aPackage.
 		  self registry at: aPackage put: mgr.
-		  self ensureSystemPackageNamed: aPackage name.
+		  "When creating a MC package and a working copy, we need to ensure we create a system package also in case someone creates a package without an associated system package."
+		  aPackageOrganizer packageNamedIgnoreCase: aPackage name ifAbsent: [ aPackageOrganizer ensureExistAndRegisterPackageNamed: aPackage name ].
 		  self announcer announce: (MCWorkingCopyCreated workingCopy: mgr package: aPackage).
 		  mgr ]
 ]

--- a/src/Monticello/MCPackageManager.class.st
+++ b/src/Monticello/MCPackageManager.class.st
@@ -92,14 +92,22 @@ MCPackageManager class >> classRenamed: anEvent [
 ]
 
 { #category : #accessing }
+MCPackageManager class >> ensureSystemPackageNamed: aPackageName [
+	"When creating a MC package and a working copy, we need to ensure we create a system package also in case someone creates a package without an associated system package."
+
+	self packageOrganizer packageNamedIgnoreCase: aPackageName ifAbsent: [ self packageOrganizer ensureExistAndRegisterPackageNamed: aPackageName ]
+]
+
+{ #category : #accessing }
 MCPackageManager class >> forPackage: aPackage [
-	^ self registry 
-		at: aPackage 
-		ifAbsent: [|mgr|
-			mgr := self new initializeWithPackage: aPackage.
-			self registry at: aPackage put: mgr.
-			self announcer announce: (MCWorkingCopyCreated workingCopy: mgr package: aPackage).
-			mgr ]
+
+	^ self registry at: aPackage ifAbsent: [
+		  | mgr |
+		  mgr := self new initializeWithPackage: aPackage.
+		  self registry at: aPackage put: mgr.
+		  self ensureSystemPackageNamed: aPackage name.
+		  self announcer announce: (MCWorkingCopyCreated workingCopy: mgr package: aPackage).
+		  mgr ]
 ]
 
 { #category : #'class initialization' }

--- a/src/Monticello/RPackageOrganizer.extension.st
+++ b/src/Monticello/RPackageOrganizer.extension.st
@@ -18,13 +18,3 @@ RPackageOrganizer >> isDefinedAsPackageOrSubPackageInMC: aSymbol [
 
 	^ self allManagers anySatisfy: [ :manager | manager packageName isCategoryOf: aSymbol ]
 ]
-
-{ #category : #'*Monticello-RPackage' }
-RPackageOrganizer >> updateAfterNewMCPackageRegistred: anAnnouncement [
-	"User create a new package, MCWorkingCopy propagates changes. We react accordingly."
-	|  name |
-	
-	name := anAnnouncement package name.
-	(self packageExactlyMatchingExtensionName: name) 
-		ifNil: [ self ensureExistAndRegisterPackageNamed: name ]
-]

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -634,20 +634,6 @@ RPackageOrganizer >> packageDefiningOrExtendingSelector: aSelector inMetaclassNa
 ]
 
 { #category : #'system integration' }
-RPackageOrganizer >> packageExactlyMatchingExtensionName: anExtensionName [
-	"only look for a package for which the name match 'anExtensionName', making no difference about case. Return nil if no package is found"
-
-	| extension |
-	extension := anExtensionName asSymbol.
-
-	packages keysDo: [:aSymbol |
-		(aSymbol sameAs: extension)
-			ifTrue: [ ^ self packageNamed: aSymbol ]].
-
-	^ nil
-]
-
-{ #category : #'system integration' }
 RPackageOrganizer >> packageForProtocol: aProtocolName inClass: aClass [
 	"According aProtocolName is an extension protocol, will look for a matching package. If no matching package is found ,  return nil. If aProtocolName is not an extension protocol, return the parent package of aClass"
 
@@ -665,8 +651,7 @@ RPackageOrganizer >> packageMatchingExtensionName: anExtensionName [
 	| tmpPackageName |
 
 	"we first look if their is a package matching exactly the name specified"
-	(self packageExactlyMatchingExtensionName: anExtensionName)
-		ifNotNil: [ :package | ^ package ].
+	(self packageNamedIgnoreCase: anExtensionName ifAbsent: [ nil ]) ifNotNil: [ :package | ^ package ].
 
 	"if no package was found, we try to find one matching the begining of the name specified"
 	tmpPackageName := ''.
@@ -816,12 +801,7 @@ RPackageOrganizer >> registerInterestToAnnouncer: anAnnouncer [
 		when: MethodAdded send: #systemMethodAddedActionFrom: to: self;
 		when: MethodModified send: #systemMethodModifiedActionFrom: to: self;
 		when: MethodRecategorized send: #systemMethodRecategorizedActionFrom: to: self;
-		when: MethodRemoved send: #systemMethodRemovedActionFrom: to: self.
-
-	self flag: #hack. "for decoupling MC"
-	self class environment
-		at: #MCWorkingCopy
-		ifPresent: [ anAnnouncer weak when: (self class environment at: #MCWorkingCopyCreated) send: #updateAfterNewMCPackageRegistred: to: self ]
+		when: MethodRemoved send: #systemMethodRemovedActionFrom: to: self
 ]
 
 { #category : #'system integration' }


### PR DESCRIPTION
My goal is to kill all dependencies of RPackage to Monticello. Here is a new step.

Instead of making RPackage listen to the MCWorkingCopyCreated announcement, I make Monticello directly ensure we have the package in the system.

I also provided a small cleaning by deprecating #packageExactlyMatchingExtensionName: in favor of #packageNamedIgnoreCase:ifAbsent:. The reasons are that first I don't find the name really revealing. For me "extension" is about extension methods, but here we get a package name as parameter and this has nothing to do with extension methods. And also there is no need to have multiple methods doing the same things with a slight implementation change. This improves the consistance of RPackage.