### PR TITLE
SHRBTextStyler-simplify-stylehandling 

### DIFF
--- a/src/Shout/ClassVariable.extension.st
+++ b/src/Shout/ClassVariable.extension.st
@@ -3,6 +3,7 @@ Extension { #name : #ClassVariable }
 { #category : #'*Shout' }
 ClassVariable >> styleNameIn: aRBVariableNode [
 
-	self isPoolVariable ifTrue: [ ^ #poolConstant ].
-	^ #classVar
+	^ self isPoolVariable
+		  ifTrue: [ #poolConstant ]
+		  ifFalse: [ #classVar ]
 ]

--- a/src/Shout/RBVariableNode.extension.st
+++ b/src/Shout/RBVariableNode.extension.st
@@ -3,6 +3,7 @@ Extension { #name : #RBVariableNode }
 { #category : #'*Shout' }
 RBVariableNode >> styleName [
 
-	self variable ifNil: [ ^ #default ].
-	^ self variable styleNameIn: self
+	^ self variable
+		  ifNil: [ #default ]
+		  ifNotNil: [ :var | var styleNameIn: self ]
 ]

--- a/src/Shout/SHPreferences.class.st
+++ b/src/Shout/SHPreferences.class.st
@@ -164,11 +164,8 @@ SHPreferences class >> setStyleTable: anArray [
 
 { #category : #settings }
 SHPreferences class >> setStyleTableNamed: aString [
-	self setStyleTable: (((Pragma allNamed: #styleTable: in: SHRBTextStyler class)
-		detect: [ :each | (each argumentAt: 1) = aString ])
-		method
-			valueWithReceiver: SHRBTextStyler class
-			arguments: #())
+
+	self setStyleTable: (SHRBTextStyler styleTableNamed: aString)
 ]
 
 { #category : #settings }

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -416,8 +416,8 @@ SHRBTextStyler class >> styleTable: anArray [
 
 { #category : #styles }
 SHRBTextStyler class >> styleTableNamed: aString [
-		
-	^ (Pragma allNamed: #styleTable: in: self)
+
+	^ (Pragma allNamed: #styleTable: in: self class)
 		detect: [ :each | (each argumentAt: 1) = aString ]
 		ifFound: [ :each | self perform: each methodSelector ]
 		ifNone: [ nil ]


### PR DESCRIPTION
 the pragma was read both in #setStyleTableNamed: of the preferences and #styleTableNamed: of  SHRBTextStyler.

- just querry in #styleTableNamed:, this will make changes later simpler
- fix a bug introduced before (class missing)
- move return out of blocks in some #styleNameIn: methods (to unify style with the others)