### PR TITLE
Fluid: show empty slots on the class side, too

### DIFF
--- a/src/Kernel/FluidClassDefinitionPrinter.class.st
+++ b/src/Kernel/FluidClassDefinitionPrinter.class.st
@@ -292,7 +292,9 @@ FluidClassDefinitionPrinter >> metaclassDefinitionString [
 									nextPutAll: forClass name ] ]
 			ifNil: [ strm nextPutAll: 'ProtoObject ' ].
 		self lastTraitsOn: strm.
-		forClass slots ifNotEmpty: [ self lastSlotsOn: strm ] ]
+		self class displayEmptySlots
+				ifTrue: [ self slotsOn: strm ]
+		  		ifFalse: [forClass slots ifNotEmpty: [ self slotsOn: strm ]]]
 ]
 
 { #category : #'elementary operations' }

--- a/src/Kernel/FluidClassDefinitionPrinter.class.st
+++ b/src/Kernel/FluidClassDefinitionPrinter.class.st
@@ -293,8 +293,8 @@ FluidClassDefinitionPrinter >> metaclassDefinitionString [
 			ifNil: [ strm nextPutAll: 'ProtoObject ' ].
 		self lastTraitsOn: strm.
 		self class displayEmptySlots
-				ifTrue: [ self slotsOnLast: strm ]
-		  		ifFalse: [forClass slots ifNotEmpty: [ self slotsOnLast: strm ]]]
+				ifTrue: [ self lastSlotsOn: strm ]
+		  		ifFalse: [forClass slots ifNotEmpty: [ self lastSlotsOn: strm ]]]
 ]
 
 { #category : #'elementary operations' }
@@ -390,17 +390,8 @@ FluidClassDefinitionPrinter >> slotShiftOn: aStream [
 FluidClassDefinitionPrinter >> slotsOn: s [
 	"uses: can the last part of a definition so watch out for terminating ;"
 
-	self slotsOnLast: s.
+	self lastSlotsOn: s.
 	s nextPutAll: ';'
-]
-
-{ #category : #'elementary operations' }
-FluidClassDefinitionPrinter >> slotsOnLast: stream [
-	"print slots, but no ;"
-
-	stream crtab;
-	  nextPutAll: 'slots: '.
-	self slotDefinitionsOn: stream.
 ]
 
 { #category : #'expanded double dispatch API' }

--- a/src/Kernel/FluidClassDefinitionPrinter.class.st
+++ b/src/Kernel/FluidClassDefinitionPrinter.class.st
@@ -293,8 +293,8 @@ FluidClassDefinitionPrinter >> metaclassDefinitionString [
 			ifNil: [ strm nextPutAll: 'ProtoObject ' ].
 		self lastTraitsOn: strm.
 		self class displayEmptySlots
-				ifTrue: [ self slotsOn: strm ]
-		  		ifFalse: [forClass slots ifNotEmpty: [ self slotsOn: strm ]]]
+				ifTrue: [ self slotsOnLast: strm ]
+		  		ifFalse: [forClass slots ifNotEmpty: [ self slotsOnLast: strm ]]]
 ]
 
 { #category : #'elementary operations' }
@@ -390,10 +390,17 @@ FluidClassDefinitionPrinter >> slotShiftOn: aStream [
 FluidClassDefinitionPrinter >> slotsOn: s [
 	"uses: can the last part of a definition so watch out for terminating ;"
 
-	s crtab.
-	s nextPutAll: 'slots: '.
-	self slotDefinitionsOn: s.
+	self slotsOnLast: s.
 	s nextPutAll: ';'
+]
+
+{ #category : #'elementary operations' }
+FluidClassDefinitionPrinter >> slotsOnLast: stream [
+	"print slots, but no ;"
+
+	stream crtab;
+	  nextPutAll: 'slots: '.
+	self slotDefinitionsOn: stream.
 ]
 
 { #category : #'expanded double dispatch API' }


### PR DESCRIPTION
Fluid shows empty slots on the instance side so it is easy to add more. But on the class side, it does not.

This PR just applies the same #displayEmptySlots check