### PR TITLE
14024-Searching-by-example-launches-a-PrimitiveFailed 

### DIFF
--- a/src/Kernel/BlockClosure.class.st
+++ b/src/Kernel/BlockClosure.class.st
@@ -44,6 +44,11 @@ Class {
 	#category : #'Kernel-Methods'
 }
 
+{ #category : #'method finder' }
+BlockClosure class >> approvedSelectorsForMethodFinder [
+	^#(value)
+]
+
 { #category : #testing }
 BlockClosure class >> isAbstract [
 

--- a/src/Tool-Finder/MethodFinder.class.st
+++ b/src/Tool-Finder/MethodFinder.class.st
@@ -38,7 +38,8 @@ MethodFinder >> possibleSolutionsForInput: inputCollection [
 				allSelectorsToTestInMethodFinderWithArity: inputCollection size - 1)
 				collect:
 					[ :method | MethodFinderSend
-									receiver: receiver deepCopy
+									"Workaround for blocks, they do not implement deepCopy for now"
+									receiver: ((receiver class == CompiledBlock) ifTrue: [ receiver deepCopy ] ifFalse: [ receiver ])
 									selector: method
 									withArguments: args deepCopy ].
 			sends addAll: foundPermutationSends ].


### PR DESCRIPTION
Workaround for supporting blocks in the finder, after we have #deepCopy working , we can simplify