### PR TITLE
Cleanup CDNode Hierarchy:  #acceptVisitor: 

### DIFF
--- a/src/ClassParser/CDClassTagNode.class.st
+++ b/src/ClassParser/CDClassTagNode.class.st
@@ -26,12 +26,6 @@ Class {
 	#category : #'ClassParser-Model'
 }
 
-{ #category : #visitor }
-CDClassTagNode >> acceptVisitor: aProgramNodeVisitor [
-
-	aProgramNodeVisitor visitTag: self
-]
-
 { #category : #accessing }
 CDClassTagNode >> name [
 	^ name

--- a/src/ClassParser/CDNode.class.st
+++ b/src/ClassParser/CDNode.class.st
@@ -32,12 +32,6 @@ CDNode class >> on: aRBMessageNode [
 		yourself
 ]
 
-{ #category : #visitor }
-CDNode >> acceptVisitor: aProgramNodeVisitor [
-
-	self subclassResponsibility
-]
-
 { #category : #accessing }
 CDNode >> addChild: aChild [
 

--- a/src/ClassParser/CDPackageNode.class.st
+++ b/src/ClassParser/CDPackageNode.class.st
@@ -10,12 +10,6 @@ Class {
 	#category : #'ClassParser-Model'
 }
 
-{ #category : #visitor }
-CDPackageNode >> acceptVisitor: aProgramNodeVisitor [
-
-	aProgramNodeVisitor visitPackage: self
-]
-
 { #category : #accessing }
 CDPackageNode >> packageName [
 	^ packageName

--- a/src/ClassParser/CDTraitDefinitionNode.class.st
+++ b/src/ClassParser/CDTraitDefinitionNode.class.st
@@ -12,9 +12,3 @@ Class {
 	#superclass : #CDClassDefinitionNode,
 	#category : #'ClassParser-Model'
 }
-
-{ #category : #visitor }
-CDTraitDefinitionNode >> acceptVisitor: aProgramNodeVisitor [
-
-	self visitTraitDefinition: self
-]


### PR DESCRIPTION
The CDNode Hierarchy had he start of a visitor implemented, but there are just the #acceptVisitor: methods, sending selectors that do not exist.

I propose that we remove it for now, this can be added back easily when we need it