### PR TITLE
Simplify MCWorkingCopy management

### DIFF
--- a/src/Monticello-Tests/MCChangeNotificationTest.class.st
+++ b/src/Monticello-Tests/MCChangeNotificationTest.class.st
@@ -33,7 +33,7 @@ MCChangeNotificationTest >> setUp [
                ifAbsent:[].
        PackageOrganizer default unregisterPackageNamed: 'MonticelloMocks'."
 		super setUp.	
-      workingCopy := MCWorkingCopy forPackage: self mockPackage.
+      workingCopy := MCWorkingCopy ensureForPackage: self mockPackage.
 ]
 
 { #category : #tests }

--- a/src/Monticello-Tests/MCMethodDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCMethodDefinitionTest.class.st
@@ -26,11 +26,6 @@ MCMethodDefinitionTest >> mockPackageName [
 ]
 
 { #category : #running }
-MCMethodDefinitionTest >> ownPackage [
-	^ MCWorkingCopy forPackage: (MCPackage named: 'Monticello')
-]
-
-{ #category : #running }
 MCMethodDefinitionTest >> secondExtensionPackageName [
 
 	^ 'MonticelloTestsSecondExtensionMockPackage-override'

--- a/src/Monticello-Tests/MCPackageManagerTest.class.st
+++ b/src/Monticello-Tests/MCPackageManagerTest.class.st
@@ -13,15 +13,17 @@ Class {
 
 { #category : #running }
 MCPackageManagerTest >> setUp [
+
 	super setUp.
-	package1 := (RPackage named: #A, UUID new asString36) register.
-	package2 := (RPackage named: package1 name, #'-SubPart') register.
-	mcPackage1 := MCPackage named: package1 name.
-	mcPackage2 := MCPackage named: package2 name.
-	"register MC packages"
+	package1 := self packageOrganizer createPackageNamed: #A , UUID new asString36.
+	package2 := self packageOrganizer createPackageNamed: package1 name , #'-SubPart'.
+	mcPackage1 := package1 mcPackage.
+	mcPackage2 := package2 mcPackage.
+
+	"We automatically register working copies in MCWorkingCopy, but since we test MCPackageManager here, we need to explicitly register it here"
 	MCPackageManager
-		forPackage: mcPackage1;
-		forPackage: mcPackage2
+		ensureForPackage: mcPackage1;
+		ensureForPackage: mcPackage2
 ]
 
 { #category : #running }

--- a/src/Monticello-Tests/MCSerializationTest.class.st
+++ b/src/Monticello-Tests/MCSerializationTest.class.st
@@ -57,7 +57,7 @@ MCSerializationTest >> assertVersionsMatchWith: writerClass [
 MCSerializationTest >> mockDiffyVersion [
 	| repos workingCopy base next |
 	repos := MCDictionaryRepository new.
-	workingCopy := MCWorkingCopy forPackage: self mockPackage.
+	workingCopy := MCWorkingCopy ensureForPackage: self mockPackage.
 	workingCopy repositoryGroup addRepository: repos.
 	MCRepositoryGroup default removeRepository: repos.
 	base := self mockVersion.

--- a/src/Monticello-Tests/MCSnapshotTest.class.st
+++ b/src/Monticello-Tests/MCSnapshotTest.class.st
@@ -32,7 +32,7 @@ MCSnapshotTest >> createSnapshotWithClassWithClassSideTraits [
 			classTraitComposition: t1 classTrait + t2 classTrait - #m1;
 			package: 'Monticello-Snapshot-Mock' ].
 
-	^ (MCWorkingCopy ofPackageNamed: 'Monticello-Snapshot-Mock') snapshot
+	^ (MCWorkingCopy forPackageNamed: 'Monticello-Snapshot-Mock') snapshot
 ]
 
 { #category : #running }
@@ -61,7 +61,7 @@ MCSnapshotTest >> createSnapshotWithTraitWithClassSideTraits [
 			      package: 'Monticello-Snapshot-Mock';
 			      beTrait ].
 
-	^ (MCWorkingCopy ofPackageNamed: 'Monticello-Snapshot-Mock') snapshot
+	^ (MCWorkingCopy forPackageNamed: 'Monticello-Snapshot-Mock') snapshot
 ]
 
 { #category : #utilities }

--- a/src/Monticello-Tests/MCSnapshotTest.class.st
+++ b/src/Monticello-Tests/MCSnapshotTest.class.st
@@ -11,59 +11,57 @@ Class {
 MCSnapshotTest >> createSnapshotWithClassWithClassSideTraits [
 
 	| t1 t2 |
-	
 	RPackageOrganizer default registerPackageNamed: 'Monticello-Snapshot-Mock'.
-	
+
 	t1 := self class classInstaller make: [ :aBuilder |
-		aBuilder 
-			name: #T1;
-			package:  'Monticello-Snapshot-Mock';
-			beTrait ].					
+		      aBuilder
+			      name: #T1;
+			      package: 'Monticello-Snapshot-Mock';
+			      beTrait ].
 
 	t2 := self class classInstaller make: [ :aBuilder |
-		aBuilder 
-			name: #T2;
-			package:  'Monticello-Snapshot-Mock';
-			beTrait ].					
+		      aBuilder
+			      name: #T2;
+			      package: 'Monticello-Snapshot-Mock';
+			      beTrait ].
 
-	self class classInstaller make: [ :aBuilder | 
-			aBuilder 
-				name: #C1;
-				traitComposition: t1 + t2;
-				classTraitComposition: (t1 classTrait + t2 classTrait - #m1);
-				package: 'Monticello-Snapshot-Mock'].
+	self class classInstaller make: [ :aBuilder |
+		aBuilder
+			name: #C1;
+			traitComposition: t1 + t2;
+			classTraitComposition: t1 classTrait + t2 classTrait - #m1;
+			package: 'Monticello-Snapshot-Mock' ].
 
-	^ (MCWorkingCopy forPackage: (MCPackage new name: 'Monticello-Snapshot-Mock')) snapshot. 
+	^ (MCWorkingCopy ofPackageNamed: 'Monticello-Snapshot-Mock') snapshot
 ]
 
 { #category : #running }
 MCSnapshotTest >> createSnapshotWithTraitWithClassSideTraits [
 
 	| t1 t2 t3 |
-	
 	RPackageOrganizer default registerPackageNamed: 'Monticello-Snapshot-Mock'.
 
 	t1 := self class classInstaller make: [ :aBuilder |
-		aBuilder 
-			name: #T1;
-			package:  'Monticello-Snapshot-Mock';
-			beTrait ].					
+		      aBuilder
+			      name: #T1;
+			      package: 'Monticello-Snapshot-Mock';
+			      beTrait ].
 
 	t2 := self class classInstaller make: [ :aBuilder |
-		aBuilder 
-			name: #T2;
-			package:  'Monticello-Snapshot-Mock';
-			beTrait ].					
+		      aBuilder
+			      name: #T2;
+			      package: 'Monticello-Snapshot-Mock';
+			      beTrait ].
 
 	t3 := self class classInstaller make: [ :aBuilder |
-		aBuilder 
-			name: #T3;
-			traitComposition: t1 + t2;
-			classTraitComposition: (t1 classTrait + t2 classTrait - #m1);
-			package:  'Monticello-Snapshot-Mock';
-			beTrait ].					
+		      aBuilder
+			      name: #T3;
+			      traitComposition: t1 + t2;
+			      classTraitComposition: t1 classTrait + t2 classTrait - #m1;
+			      package: 'Monticello-Snapshot-Mock';
+			      beTrait ].
 
-	^ (MCWorkingCopy forPackage: (MCPackage new name: 'Monticello-Snapshot-Mock')) snapshot. 
+	^ (MCWorkingCopy ofPackageNamed: 'Monticello-Snapshot-Mock') snapshot
 ]
 
 { #category : #utilities }

--- a/src/Monticello-Tests/MCWorkingCopyTest.class.st
+++ b/src/Monticello-Tests/MCWorkingCopyTest.class.st
@@ -75,22 +75,25 @@ MCWorkingCopyTest >> packageName [
 
 { #category : #running }
 MCWorkingCopyTest >> setUp [
+
 	| repos1 repos2 |
 	super setUp.
 	self clearPackageCache.
 	repositoryGroup := MCRepositoryGroup new.
 	repositoryGroup disableCache.
-	workingCopy := MCWorkingCopy forPackage: self mockPackage.
+	workingCopy := MCWorkingCopy ensureForPackage: self mockPackage.
 	versions := Dictionary new.
 	versions2 := Dictionary new.
 	repos1 := MCDictionaryRepository new dictionary: versions.
 	repos2 := MCDictionaryRepository new dictionary: versions2.
 	repositoryGroup addRepository: repos1.
 	repositoryGroup addRepository: repos2.
-	MCRepositoryGroup default removeRepository: repos1; removeRepository: repos2.
+	MCRepositoryGroup default
+		removeRepository: repos1;
+		removeRepository: repos2.
 	workingCopy repositoryGroup: repositoryGroup.
 	savedName := Author fullName.
-	Author fullName: 'abc'.
+	Author fullName: 'abc'
 ]
 
 { #category : #actions }

--- a/src/Monticello-Tests/RPackageMonticelloSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMonticelloSynchronisationTest.class.st
@@ -11,7 +11,7 @@ Class {
 RPackageMonticelloSynchronisationTest >> testAddMCPackageCreatesAPackage [
 	"test that when we create a MCPackage, a corresponding package is created"
 
-	MCWorkingCopy forPackage: (MCPackage new name: #Zork) packageOrganizer: self organizer.
+	MCWorkingCopy ensureForPackageNamed: #Zork packageOrganizer: self organizer.
 	self assert: (self organizer includesPackageNamed: #Zork)
 ]
 
@@ -22,7 +22,7 @@ RPackageMonticelloSynchronisationTest >> testAddMCPackageForCategoryAlreadyExist
 	| tmpPackage |
 	testingEnvironment organization addCategory: 'Zork'.
 	tmpPackage := self organizer packageNamed: #Zork.
-	MCWorkingCopy forPackage: (MCPackage new name: #Zork) packageOrganizer: self organizer.
+	MCWorkingCopy ensureForPackageNamed: #Zork packageOrganizer: self organizer.
 	self assert: tmpPackage identicalTo: (self organizer packageNamed: #Zork)
 ]
 
@@ -30,7 +30,7 @@ RPackageMonticelloSynchronisationTest >> testAddMCPackageForCategoryAlreadyExist
 RPackageMonticelloSynchronisationTest >> testUnloadMCPackageRemovesRPackage [
 	"test that when we remove a MC Package, the corresponding RPackage is removed from the organizer"
 
-	MCWorkingCopy forPackage: (MCPackage new name: 'XXXXX') packageOrganizer: self organizer.
+	MCWorkingCopy ensureForPackageNamed: 'XXXXX' packageOrganizer: self organizer.
 	(self allManagers detect: [ :each | each packageName = 'XXXXX' ]) unload.
 
 	self deny: (self organizer includesPackageNamed: #XXXXX)
@@ -40,7 +40,7 @@ RPackageMonticelloSynchronisationTest >> testUnloadMCPackageRemovesRPackage [
 RPackageMonticelloSynchronisationTest >> testUnregisterMCPackageKeepsRPackage [
 	"test that when we remove a MC Package, the corresponding RPackage is removed from the organizer"
 
-	MCWorkingCopy forPackage: (MCPackage new name: 'XXXXX') packageOrganizer: self organizer.
+	MCWorkingCopy ensureForPackageNamed: 'XXXXX' packageOrganizer: self organizer.
 	(self allManagers detect: [ :each | each packageName = 'XXXXX' ]) unregister.
 
 	self assert: (self organizer includesPackageNamed: #XXXXX)

--- a/src/Monticello-Tests/RPackageMonticelloSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMonticelloSynchronisationTest.class.st
@@ -23,7 +23,7 @@ RPackageMonticelloSynchronisationTest >> testAddMCPackageForCategoryAlreadyExist
 	testingEnvironment organization addCategory: 'Zork'.
 	tmpPackage := self organizer packageNamed: #Zork.
 	MCWorkingCopy forPackage: (MCPackage new name: #Zork) packageOrganizer: self organizer.
-	self assert: tmpPackage equals: (self organizer packageNamed: #Zork)
+	self assert: tmpPackage identicalTo: (self organizer packageNamed: #Zork)
 ]
 
 { #category : #'tests - operations on MCPackages' }

--- a/src/Monticello/MCPackage.class.st
+++ b/src/Monticello/MCPackage.class.st
@@ -112,5 +112,6 @@ MCPackage >> unload [
 
 { #category : #'working copies' }
 MCPackage >> workingCopy [
-	^ MCWorkingCopy forPackage: self.
+
+	^ MCWorkingCopy forPackage: self
 ]

--- a/src/Monticello/MCPackage.class.st
+++ b/src/Monticello/MCPackage.class.st
@@ -113,5 +113,5 @@ MCPackage >> unload [
 { #category : #'working copies' }
 MCPackage >> workingCopy [
 
-	^ MCWorkingCopy forPackage: self
+	^ MCWorkingCopy ensureForPackage: self
 ]

--- a/src/Monticello/MCPackageManager.class.st
+++ b/src/Monticello/MCPackageManager.class.st
@@ -92,6 +92,20 @@ MCPackageManager class >> classRenamed: anEvent [
 ]
 
 { #category : #accessing }
+MCPackageManager class >> ensureForPackageNamed: aPackageName [
+
+	^ self ensureForPackageNamed: aPackageName packageOrganizer: self packageOrganizer
+]
+
+{ #category : #accessing }
+MCPackageManager class >> ensureForPackageNamed: aPackageName packageOrganizer: aPackageOrganizer [
+
+	^ (self hasPackageNamed: aPackageName)
+		  ifTrue: [ self ofPackageNamed: aPackageName ]
+		  ifFalse: [ self registerPackage: (MCPackage named: aPackageName) packageOrganizer: aPackageOrganizer ]
+]
+
+{ #category : #accessing }
 MCPackageManager class >> forPackage: aPackage [
 
 	^ self forPackage: aPackage packageOrganizer: self packageOrganizer
@@ -100,14 +114,13 @@ MCPackageManager class >> forPackage: aPackage [
 { #category : #accessing }
 MCPackageManager class >> forPackage: aPackage packageOrganizer: aPackageOrganizer [
 
-	^ self registry at: aPackage ifAbsent: [
-		  | mgr |
-		  mgr := self new initializeWithPackage: aPackage.
-		  self registry at: aPackage put: mgr.
-		  "When creating a MC package and a working copy, we need to ensure we create a system package also in case someone creates a package without an associated system package."
-		  aPackageOrganizer packageNamedIgnoreCase: aPackage name ifAbsent: [ aPackageOrganizer ensureExistAndRegisterPackageNamed: aPackage name ].
-		  self announcer announce: (MCWorkingCopyCreated workingCopy: mgr package: aPackage).
-		  mgr ]
+	^ self registry at: aPackage ifAbsent: [ self registerPackage: aPackage packageOrganizer: aPackageOrganizer ]
+]
+
+{ #category : #querying }
+MCPackageManager class >> hasPackageNamed: aName [
+
+	^ self allManagers anySatisfy: [ :each | each packageName = aName ]
 ]
 
 { #category : #'class initialization' }
@@ -120,35 +133,30 @@ MCPackageManager class >> initialize [
 { #category : #'system changes' }
 MCPackageManager class >> managersForCategory: aSystemCategory do: aBlock [
 	"Got to be careful here - we might get method categories where capitalization is problematic."
+
 	| cat foundOne index |
 	foundOne := false.
-	cat := aSystemCategory ifNil: [ ^nil ]. "yes this happens; for example in eToy projects"
+	cat := aSystemCategory ifNil: [ ^ nil ]. "yes this happens; for example in eToy projects"
 	"first ask PackageInfos, their package name might not match the category"
-	self
-		bestMatchingManagerForCategory: aSystemCategory
-		do: [ :mgr |
-			aBlock value: mgr.
-			foundOne := true ].
+	self bestMatchingManagerForCategory: aSystemCategory do: [ :mgr |
+		aBlock value: mgr.
+		foundOne := true ].
 
-   foundOne ifTrue: [ ^self ].
-	[  "Loop over categories until we found a matching one"
-		self registry keys detect: [ :aPackage | aPackage name sameAs: cat ]
-			ifFound: [:aPackage | | mgr | 
-				mgr := self registry at: aPackage.
-				aBlock value: mgr. 
-				foundOne := true. 
-				false] 
-			ifNone: [ 
-				index := cat lastIndexOf: $-.
-				index > 0]
-	] whileTrue: [
-		"Step up to next level package"
-		cat := cat copyFrom: 1 to: index-1 ].
-	
-	foundOne ifFalse: [
-		"Create a new (but only top-level)"
-		aBlock value: (MCWorkingCopy forPackage: (MCPackage named: aSystemCategory capitalized)).
-	].
+	foundOne ifTrue: [ ^ self ].
+	[ "Loop over categories until we found a matching one"
+	self registry keys
+		detect: [ :aPackage | aPackage name sameAs: cat ]
+		ifFound: [ :aPackage |
+			| mgr |
+			mgr := self registry at: aPackage.
+			aBlock value: mgr.
+			foundOne := true.
+			false ]
+		ifNone: [
+			index := cat lastIndexOf: $-.
+			index > 0 ] ] whileTrue: [ "Step up to next level package" cat := cat copyFrom: 1 to: index - 1 ].
+
+	foundOne ifFalse: [ "Create a new (but only top-level)" aBlock value: (MCWorkingCopy ensureForPackageNamed: aSystemCategory capitalized) ]
 ]
 
 { #category : #'system changes' }
@@ -245,6 +253,18 @@ MCPackageManager class >> registerInterestOnSystemChangesOnAnnouncer: anAnnounce
 		when: MethodAdded, MethodModified, MethodRecategorized send: #methodModified: to: self;
 		when: MethodRepackaged send: #methodMoved: to: self;
 		when: MethodRemoved send: #methodRemoved: to: self.
+]
+
+{ #category : #accessing }
+MCPackageManager class >> registerPackage: aPackage packageOrganizer: aPackageOrganizer [
+
+	| workingCopy |
+	workingCopy := self new initializeWithPackage: aPackage.
+	self registry at: aPackage put: workingCopy.
+	"When creating a MC package and a working copy, we need to ensure we create a system package also in case someone creates a package without an associated system package."
+	aPackageOrganizer packageNamedIgnoreCase: aPackage name ifAbsent: [ aPackageOrganizer ensureExistAndRegisterPackageNamed: aPackage name ].
+	self announcer announce: (MCWorkingCopyCreated workingCopy: workingCopy package: aPackage).
+	^ workingCopy
 ]
 
 { #category : #accessing }

--- a/src/Monticello/MCPackageManager.class.st
+++ b/src/Monticello/MCPackageManager.class.st
@@ -216,6 +216,14 @@ MCPackageManager class >> methodRemoved: anEvent [
 	self managersForClass: anEvent methodClass category: anEvent protocol name do: [ :mgr | mgr modified: true ]
 ]
 
+{ #category : #accessing }
+MCPackageManager class >> ofPackageNamed: aPackageName [
+
+	^ self registry values
+		  detect: [ :workingCopy | workingCopy packageName = aPackageName ]
+		  ifNone: [ NotFound signalFor: aPackageName in: self ]
+]
+
 { #category : #'system changes' }
 MCPackageManager class >> packageRenamed: anAnnouncement [
 	self allManagers 

--- a/src/Monticello/MCPackageManager.class.st
+++ b/src/Monticello/MCPackageManager.class.st
@@ -92,6 +92,12 @@ MCPackageManager class >> classRenamed: anEvent [
 ]
 
 { #category : #accessing }
+MCPackageManager class >> ensureForPackage: aPackage [
+
+	^ self registry at: aPackage ifAbsent: [ self registerPackage: aPackage packageOrganizer: self packageOrganizer ]
+]
+
+{ #category : #accessing }
 MCPackageManager class >> ensureForPackageNamed: aPackageName [
 
 	^ self ensureForPackageNamed: aPackageName packageOrganizer: self packageOrganizer
@@ -101,20 +107,22 @@ MCPackageManager class >> ensureForPackageNamed: aPackageName [
 MCPackageManager class >> ensureForPackageNamed: aPackageName packageOrganizer: aPackageOrganizer [
 
 	^ (self hasPackageNamed: aPackageName)
-		  ifTrue: [ self ofPackageNamed: aPackageName ]
+		  ifTrue: [ self forPackageNamed: aPackageName ]
 		  ifFalse: [ self registerPackage: (MCPackage named: aPackageName) packageOrganizer: aPackageOrganizer ]
 ]
 
 { #category : #accessing }
 MCPackageManager class >> forPackage: aPackage [
 
-	^ self forPackage: aPackage packageOrganizer: self packageOrganizer
+	^ self registry at: aPackage ifAbsent: [ NotFound signalFor: aPackage in: self ]
 ]
 
 { #category : #accessing }
-MCPackageManager class >> forPackage: aPackage packageOrganizer: aPackageOrganizer [
+MCPackageManager class >> forPackageNamed: aPackageName [
 
-	^ self registry at: aPackage ifAbsent: [ self registerPackage: aPackage packageOrganizer: aPackageOrganizer ]
+	^ self registry values
+		  detect: [ :workingCopy | workingCopy packageName = aPackageName ]
+		  ifNone: [ NotFound signalFor: aPackageName in: self ]
 ]
 
 { #category : #querying }
@@ -224,14 +232,6 @@ MCPackageManager class >> methodRemoved: anEvent [
 	self managersForClass: anEvent methodClass category: anEvent protocol name do: [ :mgr | mgr modified: true ]
 ]
 
-{ #category : #accessing }
-MCPackageManager class >> ofPackageNamed: aPackageName [
-
-	^ self registry values
-		  detect: [ :workingCopy | workingCopy packageName = aPackageName ]
-		  ifNone: [ NotFound signalFor: aPackageName in: self ]
-]
-
 { #category : #'system changes' }
 MCPackageManager class >> packageRenamed: anAnnouncement [
 	self allManagers 
@@ -255,13 +255,14 @@ MCPackageManager class >> registerInterestOnSystemChangesOnAnnouncer: anAnnounce
 		when: MethodRemoved send: #methodRemoved: to: self.
 ]
 
-{ #category : #accessing }
+{ #category : #private }
 MCPackageManager class >> registerPackage: aPackage packageOrganizer: aPackageOrganizer [
 
 	| workingCopy |
 	workingCopy := self new initializeWithPackage: aPackage.
 	self registry at: aPackage put: workingCopy.
-	"When creating a MC package and a working copy, we need to ensure we create a system package also in case someone creates a package without an associated system package."
+	"When creating a MC package and a working copy, we need to ensure we create a system package also in case someone creates a package without an associated system package.
+	But we still check that the package does not exist because the working copy creation might be caused by the creation of the system package and we do not want to end up in a loop."
 	aPackageOrganizer packageNamedIgnoreCase: aPackage name ifAbsent: [ aPackageOrganizer ensureExistAndRegisterPackageNamed: aPackage name ].
 	self announcer announce: (MCWorkingCopyCreated workingCopy: workingCopy package: aPackage).
 	^ workingCopy

--- a/src/Monticello/MCWorkingCopy.class.st
+++ b/src/Monticello/MCWorkingCopy.class.st
@@ -46,12 +46,6 @@ MCWorkingCopy class >> ancestorsFromArray: anArray cache: cacheDictionary [
 	^ anArray collect: [:dict | self infoFromDictionary: dict cache: cacheDictionary]
 ]
 
-{ #category : #querying }
-MCWorkingCopy class >> hasPackageNamed: aName [
-
-	^ self allManagers anySatisfy: [ :each | each packageName = aName ]
-]
-
 { #category : #private }
 MCWorkingCopy class >> infoFromDictionary: aDictionary cache: cache [
 	| id |

--- a/src/Monticello/MCWorkingCopy.class.st
+++ b/src/Monticello/MCWorkingCopy.class.st
@@ -48,10 +48,8 @@ MCWorkingCopy class >> ancestorsFromArray: anArray cache: cacheDictionary [
 
 { #category : #querying }
 MCWorkingCopy class >> hasPackageNamed: aName [
-	" self hasPackageNamed: 'ConfigurationOfFuel' "
 
-	^ MCWorkingCopy allManagers
-		anySatisfy: [ :each | each packageName = aName ]
+	^ self allManagers anySatisfy: [ :each | each packageName = aName ]
 ]
 
 { #category : #private }

--- a/src/Monticello/MonticelloBootstrap.class.st
+++ b/src/Monticello/MonticelloBootstrap.class.st
@@ -71,13 +71,12 @@ MonticelloBootstrap >> bootstrapVersionsSatisfying: aBlock [
 
 { #category : #bootstrapping }
 MonticelloBootstrap >> createWorkingCopies [
-	
 	"For each of the packages inside the image, excepted by the Unpackaged package, create a monticello working copy.
 	This is achieved by creating an instance of a working copy and snapshotting it. This generates and registers the working copy automatically."
-	(RPackageOrganizer default packageNames) asSortedCollection do: [:packageName |
-		packageName = RPackage defaultPackageName ifFalse: [
-			SystemNotification signal: ('Creating Snapshot of: ', packageName).
-			(MCWorkingCopy forPackage: (MCPackage named: packageName)) snapshot ] ]
+
+	(RPackageOrganizer default packageNames copyWithout: RPackage defaultPackageName) asSortedCollection do: [ :packageName |
+		SystemNotification signal: 'Creating Snapshot of: ' , packageName.
+		(MCWorkingCopy forPackage: (MCPackage named: packageName)) snapshot ]
 ]
 
 { #category : #accessing }

--- a/src/Monticello/MonticelloBootstrap.class.st
+++ b/src/Monticello/MonticelloBootstrap.class.st
@@ -76,7 +76,7 @@ MonticelloBootstrap >> createWorkingCopies [
 
 	(RPackageOrganizer default packageNames copyWithout: RPackage defaultPackageName) asSortedCollection do: [ :packageName |
 		SystemNotification signal: 'Creating Snapshot of: ' , packageName.
-		(MCWorkingCopy forPackage: (MCPackage named: packageName)) snapshot ]
+		(MCWorkingCopy ensureForPackageNamed: packageName) snapshot ]
 ]
 
 { #category : #accessing }

--- a/src/MonticelloGUI/MCFileRepositoryInspector.class.st
+++ b/src/MonticelloGUI/MCFileRepositoryInspector.class.st
@@ -289,19 +289,16 @@ MCFileRepositoryInspector >> refresh [
 
 { #category : #'morphic ui' }
 MCFileRepositoryInspector >> saveChanges [
+
 	| currentRepository workingCopy |
-	
 	currentRepository := repository. "This can be changed elsewhere while processing"
-	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: selectedPackage).
-	(workingCopy newVersionIn: currentRepository) ifNotNil: [:v |
+	workingCopy := MCWorkingCopy ensureForPackageNamed: selectedPackage.
+	(workingCopy newVersionIn: currentRepository) ifNotNil: [ :v |
 		(MCVersionInspector new version: v) show.
-		Cursor wait showWhile: [currentRepository storeVersion: v].
-		MCCacheRepository uniqueInstance cacheAllFileNamesDuring: 
-			[currentRepository cacheAllFileNamesDuring: 
-				[v allAvailableDependenciesDo:
-					[:dep |
-					(currentRepository includesVersionNamed: dep info name)
-						ifFalse: [currentRepository storeVersion: dep]]]]]
+		Cursor wait showWhile: [ currentRepository storeVersion: v ].
+		MCCacheRepository uniqueInstance cacheAllFileNamesDuring: [
+			currentRepository cacheAllFileNamesDuring: [
+				v allAvailableDependenciesDo: [ :dep | (currentRepository includesVersionNamed: dep info name) ifFalse: [ currentRepository storeVersion: dep ] ] ] ] ]
 ]
 
 { #category : #accessing }

--- a/src/MonticelloGUI/MCWorkingCopyBrowser.class.st
+++ b/src/MonticelloGUI/MCWorkingCopyBrowser.class.st
@@ -99,42 +99,39 @@ MCWorkingCopyBrowser class >> workingCopySearchMaxSize [
 
 { #category : #actions }
 MCWorkingCopyBrowser >> addMetacelloConfiguration [
-	|name|
-	name := UIManager default 
-				request: 'Name of the new Metacello configuration (e.g., ConfigurationOfYourSoftware)' translated 
-				initialAnswer: 'ConfigurationOf'. 
-	name isEmptyOrNil ifFalse:
-		[ 
-			"Check if the class does not exist"
-			(Smalltalk globals includesKey: name asSymbol) ifTrue: [ self error: 'Class already exist'].
 
-			"Check if metacello is loaded"
-			(Smalltalk globals includesKey: #MetacelloConfigTemplate) ifFalse: 
-				[Gofer new
-  					squeaksource: 'MetacelloRepository';
-  					package: 'ConfigurationOfMetacello';
- 					 load.
-				(Smalltalk at: #ConfigurationOfMetacello) perform: #loadLatestVersion].
+	| name |
+	name := UIManager default request: 'Name of the new Metacello configuration (e.g., ConfigurationOfYourSoftware)' translated initialAnswer: 'ConfigurationOf'.
+	name isEmptyOrNil ifFalse: [ "Check if the class does not exist"
+		(Smalltalk globals includesKey: name asSymbol) ifTrue: [ self error: 'Class already exist' ].
 
-			"Create the configuration"
-			((Smalltalk globals at: #MetacelloConfigTemplate) duplicateClassWithNewName: name asSymbol)
-        			category: name asString.
+		"Check if metacello is loaded"
+		(Smalltalk globals includesKey: #MetacelloConfigTemplate) ifFalse: [
+			Gofer new
+				squeaksource: 'MetacelloRepository';
+				package: 'ConfigurationOfMetacello';
+				load.
+			(Smalltalk at: #ConfigurationOfMetacello) perform: #loadLatestVersion ].
 
-			"We create the package that has the same name"
-			RPackageOrganizer default registerPackageNamed: name.
-			
-			"Select the package"
-			workingCopy := MCWorkingCopy forPackage: (MCPackage new name: name).
-			repository ifNotNil: [ workingCopy repositoryGroup addRepository: repository ].
-			workingCopyWrapper := nil.
-			workingCopy modified: true.
-			self workingCopySelection: 0.
-			self repositorySelection: 0 ].
+		"Create the configuration"
+		((Smalltalk globals at: #MetacelloConfigTemplate) duplicateClassWithNewName: name asSymbol) category: name asString.
 
-	self workingCopyListChanged; 
+		"We create the package that has the same name"
+		RPackageOrganizer default registerPackageNamed: name.
+
+		"Select the package"
+		workingCopy := MCWorkingCopy ofPackageNamed: name.
+		repository ifNotNil: [ workingCopy repositoryGroup addRepository: repository ].
+		workingCopyWrapper := nil.
+		workingCopy modified: true.
+		self workingCopySelection: 0.
+		self repositorySelection: 0 ].
+
+	self
+		workingCopyListChanged;
 		changed: #workingCopySelection;
 		repositoryListChanged.
-	self changedButtons.
+	self changedButtons
 ]
 
 { #category : #actions }
@@ -211,20 +208,20 @@ MCWorkingCopyBrowser >> addRequiredPackage [
 
 { #category : #actions }
 MCWorkingCopyBrowser >> addWorkingCopy [
+
 	| name |
-	
 	name := UIManager default request: 'Name of package:'.
 	name isEmptyOrNil ifFalse: [
-		RPackageOrganizer default registerPackageNamed: name.		
-		workingCopy := MCWorkingCopy forPackage: (MCPackage new name: name).
+		RPackageOrganizer default registerPackageNamed: name.
+		workingCopy := MCWorkingCopy ofPackageNamed: name.
 		workingCopyWrapper := MCDependentsWrapper with: workingCopy model: self.
 		self repositorySelection: 0 ].
-	
-	self 
-		workingCopyListChanged; 
-		changed: #workingCopySelection; 
+
+	self
+		workingCopyListChanged;
+		changed: #workingCopySelection;
 		repositoryListChanged.
-	self changedButtons.
+	self changedButtons
 ]
 
 { #category : #actions }

--- a/src/MonticelloGUI/MCWorkingCopyBrowser.class.st
+++ b/src/MonticelloGUI/MCWorkingCopyBrowser.class.st
@@ -120,7 +120,7 @@ MCWorkingCopyBrowser >> addMetacelloConfiguration [
 		RPackageOrganizer default registerPackageNamed: name.
 
 		"Select the package"
-		workingCopy := MCWorkingCopy ofPackageNamed: name.
+		workingCopy := MCWorkingCopy forPackageNamed: name.
 		repository ifNotNil: [ workingCopy repositoryGroup addRepository: repository ].
 		workingCopyWrapper := nil.
 		workingCopy modified: true.
@@ -213,7 +213,7 @@ MCWorkingCopyBrowser >> addWorkingCopy [
 	name := UIManager default request: 'Name of package:'.
 	name isEmptyOrNil ifFalse: [
 		RPackageOrganizer default registerPackageNamed: name.
-		workingCopy := MCWorkingCopy ofPackageNamed: name.
+		workingCopy := MCWorkingCopy forPackageNamed: name.
 		workingCopyWrapper := MCDependentsWrapper with: workingCopy model: self.
 		self repositorySelection: 0 ].
 

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -226,14 +226,11 @@ RPackageOrganizer >> basicInitializeFromPackagesList: aPackagesList [
 RPackageOrganizer >> basicRegisterPackage: aPackage [
 	"A new package is now available and declared in the receiver. Note that it is a low level implementation method since it does not deal with package contained information and does not update the related mapping tables."
 
-	packages
-		at: aPackage name asSymbol
-		put: aPackage.
+	packages at: aPackage name asSymbol put: aPackage.
 
 	"register mc package"
 	self flag: #hack. "for decoupling MC"
-	self class environment at: #MCWorkingCopy ifPresent: [ :wc |
-		wc forPackage: ((self class environment at: #MCPackage) named: aPackage name)].
+	self class environment at: #MCWorkingCopy ifPresent: [ :wc | wc ensureForPackageNamed: aPackage name ].
 
 	^ aPackage
 ]

--- a/src/RPackage-Tests/RPackageRenameTest.class.st
+++ b/src/RPackage-Tests/RPackageRenameTest.class.st
@@ -34,7 +34,7 @@ RPackageRenameTest >> tearDown [
 	self class environment at: #TestClass2 ifPresent: [ :class | class removeFromSystem ].
 	self class environment at: #TestClass3 ifPresent: [ :class | class removeFromSystem ].
 
-	packageNamesToClean do: [ :aPackageName | (MCWorkingCopy hasPackageNamed: aPackageName) ifTrue: [ (MCWorkingCopy ofPackageNamed: aPackageName) unload ] ].
+	packageNamesToClean do: [ :aPackageName | (MCWorkingCopy hasPackageNamed: aPackageName) ifTrue: [ (MCWorkingCopy forPackageNamed: aPackageName) unload ] ].
 
 	super tearDown
 ]
@@ -47,7 +47,7 @@ RPackageRenameTest >> testRenamePackage [
 	self cleanWorkingCopiesInTearDown: #( 'TestRename' ).
 
 	package := self packageOrganizer registerPackageNamed: 'Test1'.
-	workingCopy := MCWorkingCopy ofPackageNamed: 'Test1'.
+	workingCopy := MCWorkingCopy forPackageNamed: 'Test1'.
 	class := (Object << #TestClass package: 'Test1-TAG') install.
 
 	self assert: (package includesClass: class).
@@ -64,7 +64,7 @@ RPackageRenameTest >> testRenamePackage [
 	self deny: (self packageOrganizer includesCategory: #Test1).
 	self deny: (MCWorkingCopy hasPackageNamed: #Test1).
 
-	workingCopy := MCWorkingCopy ofPackageNamed: 'TestRename'.
+	workingCopy := MCWorkingCopy forPackageNamed: 'TestRename'.
 	self assert: workingCopy modified
 ]
 
@@ -76,7 +76,7 @@ RPackageRenameTest >> testRenamePackageToOwnTagName [
 	self cleanWorkingCopiesInTearDown: #( 'Test1-Core' ).
 
 	package := self packageOrganizer registerPackageNamed: 'Test1'.
-	workingCopy := MCWorkingCopy ofPackageNamed: 'Test1'.
+	workingCopy := MCWorkingCopy forPackageNamed: 'Test1'.
 	class1 := (Object << #TestClass1 package: 'Test1-Core') install.
 	class2 := (Object << #TestClass2 package: 'Test1-Util') install.
 
@@ -90,7 +90,7 @@ RPackageRenameTest >> testRenamePackageToOwnTagName [
 	self assert: ((package classTagNamed: #Core ifAbsent: [ nil ]) includesClass: class1).
 	self assert: ((package classTagNamed: #Util ifAbsent: [ nil ]) includesClass: class2).
 
-	workingCopy := MCWorkingCopy ofPackageNamed: 'Test1-Core'.
+	workingCopy := MCWorkingCopy forPackageNamed: 'Test1-Core'.
 	self assert: workingCopy modified
 ]
 
@@ -102,7 +102,7 @@ RPackageRenameTest >> testRenamePackageToOwnTagNameWithClassesInRoot [
 	self cleanWorkingCopiesInTearDown: #( 'Test1-Core' ).
 
 	package := self packageOrganizer registerPackageNamed: 'Test1'.
-	workingCopy := MCWorkingCopy ofPackageNamed: 'Test1'.
+	workingCopy := MCWorkingCopy forPackageNamed: 'Test1'.
 	class1 := (Object << #TestClass1 package: 'Test1-Core') install.
 	class2 := (Object << #TestClass2 package: 'Test1-Util') install.
 	class3 := (Object << #TestClass3 package: 'Test1') install.
@@ -117,7 +117,7 @@ RPackageRenameTest >> testRenamePackageToOwnTagNameWithClassesInRoot [
 	self assert: (package classTagForClass: class2) name equals: #Util.
 	self assert: (package classTagForClass: class3) name equals: #'Test1-Core'.
 
-	workingCopy := MCWorkingCopy ofPackageNamed: 'Test1-Core'.
+	workingCopy := MCWorkingCopy forPackageNamed: 'Test1-Core'.
 	self assert: workingCopy modified
 ]
 
@@ -129,7 +129,7 @@ RPackageRenameTest >> testRenamePackageUppercase [
 	"preparation: creation of a pkg and its associated mcworkingcopy"
 	[
 	package := self packageOrganizer registerPackageNamed: 'Test1'.
-	oldWorkingCopy := MCWorkingCopy ofPackageNamed: 'Test1'.
+	oldWorkingCopy := MCWorkingCopy forPackageNamed: 'Test1'.
 	self assert: (self packageOrganizer includesPackageNamed: #Test1).
 	self assert: (MCWorkingCopy hasPackageNamed: #Test1) isNotNil.
 
@@ -155,12 +155,12 @@ RPackageRenameTest >> testRenamePackageWithExtensions [
 
 	| package workingCopy class extendedPackage extendedPackageWorkingCopy extension |
 	package := self packageOrganizer registerPackageNamed: 'OriginalPackage'.
-	workingCopy := MCWorkingCopy ofPackageNamed: 'OriginalPackage'.
+	workingCopy := MCWorkingCopy forPackageNamed: 'OriginalPackage'.
 
 	class := (Object << #TestClass package: 'OriginalPackage-TAG') install.
 
 	extendedPackage := self packageOrganizer registerPackageNamed: 'ExtendedPackage'.
-	extendedPackageWorkingCopy := MCWorkingCopy ofPackageNamed: 'ExtendedPackage'.
+	extendedPackageWorkingCopy := MCWorkingCopy forPackageNamed: 'ExtendedPackage'.
 
 	self cleanWorkingCopiesInTearDown: #( ExtendedPackage RenamedPackage OriginalPackage ).
 
@@ -189,12 +189,12 @@ RPackageRenameTest >> testRenamePackageWithExtensionsInClassSide [
 
 	| package workingCopy class extendedPackage extendedPackageWorkingCopy extension |
 	package := self packageOrganizer registerPackageNamed: 'OriginalPackage'.
-	workingCopy := MCWorkingCopy ofPackageNamed: 'OriginalPackage'.
+	workingCopy := MCWorkingCopy forPackageNamed: 'OriginalPackage'.
 
 	class := (Object << #TestClass package: 'OriginalPackage-TAG') install.
 
 	extendedPackage := self packageOrganizer registerPackageNamed: 'ExtendedPackage'.
-	extendedPackageWorkingCopy := MCWorkingCopy ofPackageNamed: 'ExtendedPackage'.
+	extendedPackageWorkingCopy := MCWorkingCopy forPackageNamed: 'ExtendedPackage'.
 
 	self cleanWorkingCopiesInTearDown: #( ExtendedPackage RenamedPackage OriginalPackage ).
 
@@ -226,7 +226,7 @@ RPackageRenameTest >> testUnregisterPackage [
 
 	| package workingCopy class |
 	package := self packageOrganizer registerPackageNamed: 'Test1'.
-	workingCopy := MCWorkingCopy ofPackageNamed: 'Test1'.
+	workingCopy := MCWorkingCopy forPackageNamed: 'Test1'.
 	class := (Object << #TestClass package: 'Test1-TAG') install.
 	self assert: (package includesClass: class).
 	self assert: (package classTagNamed: #TAG ifAbsent: [ nil ]) notNil.

--- a/src/RPackage-Tests/RPackageRenameTest.class.st
+++ b/src/RPackage-Tests/RPackageRenameTest.class.st
@@ -34,9 +34,7 @@ RPackageRenameTest >> tearDown [
 	self class environment at: #TestClass2 ifPresent: [ :class | class removeFromSystem ].
 	self class environment at: #TestClass3 ifPresent: [ :class | class removeFromSystem ].
 
-	packageNamesToClean do: [ :aPackageName | | workingCopy |
-		workingCopy := MCWorkingCopy forPackage: (MCPackage new name: aPackageName).
-		workingCopy unload].
+	packageNamesToClean do: [ :aPackageName | (MCWorkingCopy hasPackageNamed: aPackageName) ifTrue: [ (MCWorkingCopy ofPackageNamed: aPackageName) unload ] ].
 
 	super tearDown
 ]
@@ -49,7 +47,7 @@ RPackageRenameTest >> testRenamePackage [
 	self cleanWorkingCopiesInTearDown: #( 'TestRename' ).
 
 	package := self packageOrganizer registerPackageNamed: 'Test1'.
-	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'Test1').
+	workingCopy := MCWorkingCopy ofPackageNamed: 'Test1'.
 	class := (Object << #TestClass package: 'Test1-TAG') install.
 
 	self assert: (package includesClass: class).
@@ -66,7 +64,7 @@ RPackageRenameTest >> testRenamePackage [
 	self deny: (self packageOrganizer includesCategory: #Test1).
 	self deny: (MCWorkingCopy hasPackageNamed: #Test1).
 
-	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'TestRename').
+	workingCopy := MCWorkingCopy ofPackageNamed: 'TestRename'.
 	self assert: workingCopy modified
 ]
 
@@ -78,7 +76,7 @@ RPackageRenameTest >> testRenamePackageToOwnTagName [
 	self cleanWorkingCopiesInTearDown: #( 'Test1-Core' ).
 
 	package := self packageOrganizer registerPackageNamed: 'Test1'.
-	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'Test1').
+	workingCopy := MCWorkingCopy ofPackageNamed: 'Test1'.
 	class1 := (Object << #TestClass1 package: 'Test1-Core') install.
 	class2 := (Object << #TestClass2 package: 'Test1-Util') install.
 
@@ -92,7 +90,7 @@ RPackageRenameTest >> testRenamePackageToOwnTagName [
 	self assert: ((package classTagNamed: #Core ifAbsent: [ nil ]) includesClass: class1).
 	self assert: ((package classTagNamed: #Util ifAbsent: [ nil ]) includesClass: class2).
 
-	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'Test1-Core').
+	workingCopy := MCWorkingCopy ofPackageNamed: 'Test1-Core'.
 	self assert: workingCopy modified
 ]
 
@@ -104,7 +102,7 @@ RPackageRenameTest >> testRenamePackageToOwnTagNameWithClassesInRoot [
 	self cleanWorkingCopiesInTearDown: #( 'Test1-Core' ).
 
 	package := self packageOrganizer registerPackageNamed: 'Test1'.
-	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'Test1').
+	workingCopy := MCWorkingCopy ofPackageNamed: 'Test1'.
 	class1 := (Object << #TestClass1 package: 'Test1-Core') install.
 	class2 := (Object << #TestClass2 package: 'Test1-Util') install.
 	class3 := (Object << #TestClass3 package: 'Test1') install.
@@ -119,7 +117,7 @@ RPackageRenameTest >> testRenamePackageToOwnTagNameWithClassesInRoot [
 	self assert: (package classTagForClass: class2) name equals: #Util.
 	self assert: (package classTagForClass: class3) name equals: #'Test1-Core'.
 
-	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'Test1-Core').
+	workingCopy := MCWorkingCopy ofPackageNamed: 'Test1-Core'.
 	self assert: workingCopy modified
 ]
 
@@ -131,13 +129,12 @@ RPackageRenameTest >> testRenamePackageUppercase [
 	"preparation: creation of a pkg and its associated mcworkingcopy"
 	[
 	package := self packageOrganizer registerPackageNamed: 'Test1'.
-	oldWorkingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'Test1').
+	oldWorkingCopy := MCWorkingCopy ofPackageNamed: 'Test1'.
 	self assert: (self packageOrganizer includesPackageNamed: #Test1).
 	self assert: (MCWorkingCopy hasPackageNamed: #Test1) isNotNil.
 
 	"renaming"
 	package renameTo: 'TEST1'.
-
 
 	pkg := self packageOrganizer packageNamed: 'Test1' ifAbsent: [ nil ].
 	self assert: pkg isNil.
@@ -158,12 +155,12 @@ RPackageRenameTest >> testRenamePackageWithExtensions [
 
 	| package workingCopy class extendedPackage extendedPackageWorkingCopy extension |
 	package := self packageOrganizer registerPackageNamed: 'OriginalPackage'.
-	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'OriginalPackage').
+	workingCopy := MCWorkingCopy ofPackageNamed: 'OriginalPackage'.
 
 	class := (Object << #TestClass package: 'OriginalPackage-TAG') install.
 
 	extendedPackage := self packageOrganizer registerPackageNamed: 'ExtendedPackage'.
-	extendedPackageWorkingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'ExtendedPackage').
+	extendedPackageWorkingCopy := MCWorkingCopy ofPackageNamed: 'ExtendedPackage'.
 
 	self cleanWorkingCopiesInTearDown: #( ExtendedPackage RenamedPackage OriginalPackage ).
 
@@ -192,12 +189,12 @@ RPackageRenameTest >> testRenamePackageWithExtensionsInClassSide [
 
 	| package workingCopy class extendedPackage extendedPackageWorkingCopy extension |
 	package := self packageOrganizer registerPackageNamed: 'OriginalPackage'.
-	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'OriginalPackage').
+	workingCopy := MCWorkingCopy ofPackageNamed: 'OriginalPackage'.
 
 	class := (Object << #TestClass package: 'OriginalPackage-TAG') install.
 
 	extendedPackage := self packageOrganizer registerPackageNamed: 'ExtendedPackage'.
-	extendedPackageWorkingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'ExtendedPackage').
+	extendedPackageWorkingCopy := MCWorkingCopy ofPackageNamed: 'ExtendedPackage'.
 
 	self cleanWorkingCopiesInTearDown: #( ExtendedPackage RenamedPackage OriginalPackage ).
 
@@ -229,7 +226,7 @@ RPackageRenameTest >> testUnregisterPackage [
 
 	| package workingCopy class |
 	package := self packageOrganizer registerPackageNamed: 'Test1'.
-	workingCopy := MCWorkingCopy forPackage: (MCPackage new name: 'Test1').
+	workingCopy := MCWorkingCopy ofPackageNamed: 'Test1'.
 	class := (Object << #TestClass package: 'Test1-TAG') install.
 	self assert: (package includesClass: class).
 	self assert: (package classTagNamed: #TAG ifAbsent: [ nil ]) notNil.

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -259,7 +259,7 @@ RPackageTest >> testMcWorkingCopy [
 
 	| rPackage |
 	rPackage := self organizer registerPackageNamed: #Test1.
-	self assert: rPackage mcWorkingCopy equals: (MCWorkingCopy forPackage: (MCPackage new name: #Test1))
+	self assert: rPackage mcWorkingCopy identicalTo: (MCWorkingCopy ofPackageNamed: #Test1)
 ]
 
 { #category : #'tests - properties' }

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -259,7 +259,7 @@ RPackageTest >> testMcWorkingCopy [
 
 	| rPackage |
 	rPackage := self organizer registerPackageNamed: #Test1.
-	self assert: rPackage mcWorkingCopy identicalTo: (MCWorkingCopy ofPackageNamed: #Test1)
+	self assert: rPackage mcWorkingCopy identicalTo: (MCWorkingCopy forPackageNamed: #Test1)
 ]
 
 { #category : #'tests - properties' }


### PR DESCRIPTION
Monticello and RPackage are doing a lot of ping pong in their code which makes it hard to understand the code and spot bugs. Here is a proposition to simplify this ping pong. 

When you want to get a working copy of Monticello currently there is only one way that is to use #forPackage:. This method takes a MCPackage and return the associated working copy, but if it does not exists, it creates one (that creates a RPackage if there is not one yet).

This has two bad effect:
- You **need** a MCPackage to get your working copy and lot of code end up creating a new instance just to get the working copy (waste of memory)
- You don't really know while reading the code if you will end up creating a new RPackage or not because of the defensive strategy (while the name of the method do not even suggest that this might happen)

To clarify things I propose to have 4 methods instead:
- forPackage: will return the WC of a package and raise an error if the package does not exists
- forPackageNamed: will return the WC of a package based on its name and raise an error if the package does not exists
- ensureForPackage: will return the WC of a package and create the working copy if it does not exists
- ensureForPackageNamed: will return the WC of a package based on its name  and create the working copy if it does not exists

This allows the simplification of the code and to be sure in some places that we will not end up in a ping pong