### PR TITLE
Move Margin from Kernel to Graphics

### DIFF
--- a/src/Graphics-Display Objects/Margin.class.st
+++ b/src/Graphics-Display Objects/Margin.class.st
@@ -21,7 +21,7 @@ Class {
 		'left',
 		'top'
 	],
-	#category : #'Kernel-BasicObjects'
+	#category : #'Graphics-Display Objects-Utilities'
 }
 
 { #category : #'instance creation' }

--- a/src/Graphics-Display Objects/Number.extension.st
+++ b/src/Graphics-Display Objects/Number.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #Number }
+
+{ #category : #'*Graphics-Display Objects' }
+Number >> asMargin [
+	^ Margin fromNumber: self
+]

--- a/src/Graphics-Display Objects/Point.extension.st
+++ b/src/Graphics-Display Objects/Point.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #Point }
+
+{ #category : #'*Graphics-Display Objects' }
+Point >> asMargin [
+	"Return a margin instance based on the receiver. aMargin is an object representing either 1, 2 or 4 numbers. It represents the space between a rectangular area and this rectangular area augmented by the margin"
+
+	^ Margin fromPoint: self
+]

--- a/src/Graphics-Display Objects/Rectangle.extension.st
+++ b/src/Graphics-Display Objects/Rectangle.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #Rectangle }
+
+{ #category : #'*Graphics-Display Objects' }
+Rectangle >> asMargin [
+
+	^ Margin fromRectangle: self
+]

--- a/src/Graphics-Display Objects/Screenshot.class.st
+++ b/src/Graphics-Display Objects/Screenshot.class.st
@@ -8,7 +8,7 @@ The method #makeAScreenshot handles the menu option to make screen shots.
 Class {
 	#name : #Screenshot,
 	#superclass : #Object,
-	#category : #'Graphics-Display Objects'
+	#category : #'Graphics-Display Objects-Utilities'
 }
 
 { #category : #'world menu items' }

--- a/src/Kernel/Number.class.st
+++ b/src/Kernel/Number.class.st
@@ -193,11 +193,6 @@ Number >> asInteger [
 ]
 
 { #category : #converting }
-Number >> asMargin [
-	^ Margin fromNumber: self
-]
-
-{ #category : #converting }
 Number >> asNumber [
 	^ self
 ]

--- a/src/Kernel/Point.class.st
+++ b/src/Kernel/Point.class.st
@@ -193,13 +193,6 @@ Point >> asIntegerPoint [
 ]
 
 { #category : #converting }
-Point >> asMargin [
-	"Return a margin instance based on the receiver. aMargin is an object representing either 1, 2 or 4 numbers. It represents the space between a rectangular area and this rectangular area augmented by the margin"
-
-	^ Margin fromPoint: self
-]
-
-{ #category : #converting }
 Point >> asNonFractionalPoint [
 	"Convert a point to a float point if necessary i.e., if one of its constituents are fractions."
 

--- a/src/Kernel/Rectangle.class.st
+++ b/src/Kernel/Rectangle.class.st
@@ -235,12 +235,6 @@ Rectangle >> areasOutside: aRectangle [
 			[ aStream nextPut: (aRectangle corner x @ yOrigin corner: corner x @ yCorner) ] ]
 ]
 
-{ #category : #converting }
-Rectangle >> asMargin [
-
-	^ Margin fromRectangle: self
-]
-
 { #category : #'rectangle functions' }
 Rectangle >> bordersOn: her along: herSide [
 	((herSide = #right and: [self left = her right])


### PR DESCRIPTION
Margin is a class that is only there for graphical things in Pharo. Its place is more in the Graphics packages than the kernel ones.  The tests related to Margin are already in Graphics-Tests.