### PR TITLE
Do not poluate Monticello cache in tests

### DIFF
--- a/src/Monticello-Tests/MCWorkingCopyTest.class.st
+++ b/src/Monticello-Tests/MCWorkingCopyTest.class.st
@@ -40,17 +40,6 @@ MCWorkingCopyTest >> basicMerge: aVersion [
 	aVersion merge
 ]
 
-{ #category : #running }
-MCWorkingCopyTest >> clearPackageCache [
-	| dir |
-	dir := MCCacheRepository uniqueInstance directory.
-"	(dir filesMatching: 'MonticelloMocks*') do: [:ea | ea ensureDeleted ]."
-	(dir filesMatching: 'MonticelloTest*') do: [:ea | ea ensureDelete].
-	(dir filesMatching: 'rev*') do: [:ea | ea ensureDelete].
-	(dir filesMatching: 'foo-*') do: [:ea | ea ensureDelete].
-	(dir filesMatching: 'foo2-*') do: [:ea | ea ensureDelete].
-]
-
 { #category : #accessing }
 MCWorkingCopyTest >> description [
 	^ self class name
@@ -74,10 +63,16 @@ MCWorkingCopyTest >> packageName [
 ]
 
 { #category : #running }
+MCWorkingCopyTest >> runCase [
+
+	MCCacheRepository uniqueInstance useDirectory: FileSystem memory / 'test' during: [ super runCase ]
+]
+
+{ #category : #running }
 MCWorkingCopyTest >> setUp [
+
 	| repos1 repos2 |
 	super setUp.
-	self clearPackageCache.
 	repositoryGroup := MCRepositoryGroup new.
 	repositoryGroup disableCache.
 	workingCopy := MCWorkingCopy forPackage: self mockPackage.
@@ -87,10 +82,12 @@ MCWorkingCopyTest >> setUp [
 	repos2 := MCDictionaryRepository new dictionary: versions2.
 	repositoryGroup addRepository: repos1.
 	repositoryGroup addRepository: repos2.
-	MCRepositoryGroup default removeRepository: repos1; removeRepository: repos2.
+	MCRepositoryGroup default
+		removeRepository: repos1;
+		removeRepository: repos2.
 	workingCopy repositoryGroup: repositoryGroup.
 	savedName := Author fullName.
-	Author fullName: 'abc'.
+	Author fullName: 'abc'
 ]
 
 { #category : #actions }
@@ -105,9 +102,9 @@ MCWorkingCopyTest >> snapshot [
 
 { #category : #running }
 MCWorkingCopyTest >> tearDown [
+
 	workingCopy unregister.
 	self restoreMocks.
-	self clearPackageCache.
 	Author fullName: savedName.
 	super tearDown
 ]

--- a/src/Monticello/MCCacheRepository.class.st
+++ b/src/Monticello/MCCacheRepository.class.st
@@ -155,6 +155,16 @@ MCCacheRepository >> storeVersion: aVersion [
 	^ super storeVersion: aVersion.
 ]
 
+{ #category : #utilities }
+MCCacheRepository >> useDirectory: aFolder during: aBlock [
+
+	| oldDirectory |
+	oldDirectory := self directory.
+	[
+	self directory: aFolder.
+	aBlock value ] ensure: [ self directory: oldDirectory ]
+]
+
 { #category : #accessing }
 MCCacheRepository >> versionInfoForFileNamed: aString [
 	^ self infoCache 


### PR DESCRIPTION
MCWorkingCopyTest is generating content in the tests in the Monticello cache and does multiple cleanings to remove them. 

In order to not impact the filse of the user and also to speed up the tests when we have a big cache, I propose to put the cache in memory during the execution of the tests. On my machine tests went from 3min to 12seconds.