### PR TITLE
Deprecated CompiledMethod>>category

### DIFF
--- a/src/Deprecated12/CompiledMethod.extension.st
+++ b/src/Deprecated12/CompiledMethod.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #CompiledMethod }
+
+{ #category : #'*Deprecated12' }
+CompiledMethod >> category [
+
+	self deprecated: 'Use #protocolName instead.' transformWith: '`@rcv category' -> '`@rcv protocolName'.
+	^ self protocolName
+]

--- a/src/Deprecated12/CompiledMethod.extension.st
+++ b/src/Deprecated12/CompiledMethod.extension.st
@@ -1,8 +1,0 @@
-Extension { #name : #CompiledMethod }
-
-{ #category : #'*Deprecated12' }
-CompiledMethod >> category [
-
-	self deprecated: 'Use #protocolName instead.' transformWith: '`@rcv category' -> '`@rcv protocolName'.
-	^ self protocolName
-]

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -213,6 +213,13 @@ CompiledMethod >> cachePragmas [
 	self pragmas do: [ :pragma | pragma class addToCache: pragma ]
 ]
 
+{ #category : #deprecated }
+CompiledMethod >> category [
+
+	self deprecated: 'Use #protocolName instead.' transformWith: '`@rcv category' -> '`@rcv protocolName'.
+	^ self protocolName
+]
+
 { #category : #accessing }
 CompiledMethod >> classBinding [
 	"answer the association to the class that I am installed in, or nil if none."

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -213,12 +213,6 @@ CompiledMethod >> cachePragmas [
 	self pragmas do: [ :pragma | pragma class addToCache: pragma ]
 ]
 
-{ #category : #'accessing - backward compatible' }
-CompiledMethod >> category [
-
-	^ self protocolName
-]
-
 { #category : #accessing }
 CompiledMethod >> classBinding [
 	"answer the association to the class that I am installed in, or nil if none."

--- a/src/OpalCompiler-Core/CompiledMethod.extension.st
+++ b/src/OpalCompiler-Core/CompiledMethod.extension.st
@@ -33,7 +33,8 @@ CompiledMethod >> recompile [
 
 { #category : #'*OpalCompiler-Core' }
 CompiledMethod >> reformat [
-	self methodClass compile: self ast formattedCode classified:  self category
+
+	self methodClass compile: self ast formattedCode classified: self protocol
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -191,7 +191,6 @@ OpalCompiler class >> stopUsingOverlayForDevelopment [
 ]
 
 { #category : #plugins }
-
 OpalCompiler >> addParsePlugin: aClass [
 	self compilationContext addParseASTTransformationPlugin: aClass
 ]

--- a/src/Ring-Definitions-Core/CompiledMethod.extension.st
+++ b/src/Ring-Definitions-Core/CompiledMethod.extension.st
@@ -37,7 +37,7 @@ CompiledMethod >> asHistoricalRingDefinition [
 
 	self sourcePointer isZero
 		ifTrue: [ "this should not happen but sometimes the system looks corrupted"
-			ring protocol: self category;
+			ring protocol: self protocolName;
 				sourceCode: self sourceCode;
 				stamp: self timeStamp ]
 		ifFalse: [
@@ -56,7 +56,7 @@ CompiledMethod >> asPassiveRingDefinition [
 		 	name: self selector;
 			parentName: self methodClass name;
 			isMetaSide: self methodClass isMeta;
-			protocol: self category;
+			protocol: self protocolName;
 			sourceCode: self sourceCode;
 			stamp: self timeStamp;
 			asPassive

--- a/src/Ring-Definitions-Core/RGMethodDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGMethodDefinition.class.st
@@ -257,14 +257,12 @@ RGMethodDefinition >> fromActiveToPassive [
 	"If the receiver was generated as an active method, it can be converted to a passive one by reading the data of the compiled method (if exists)"
 
 	| compiledMethod |
-	self isActive
-		ifFalse: [ ^ self ].
+	self isActive ifFalse: [ ^ self ].
 	compiledMethod := self compiledMethod.
-	compiledMethod notNil
-		ifTrue: [
-			self protocol: compiledMethod category.
-			self sourceCode: compiledMethod sourceCode.
-			self stamp: compiledMethod timeStamp ].
+	compiledMethod notNil ifTrue: [
+		self protocol: compiledMethod protocolName.
+		self sourceCode: compiledMethod sourceCode.
+		self stamp: compiledMethod timeStamp ].
 	self asPassive
 ]
 

--- a/src/System-SourcesCondenser/PharoChangesCondenser.class.st
+++ b/src/System-SourcesCondenser/PharoChangesCondenser.class.st
@@ -214,7 +214,7 @@ PharoChangesCondenser >> writeMethodSource: aMethod [
 		strm
 			nextPutAll: aMethod methodClass name;
 			nextPutAll: ' methodsFor: ';
-			store: aMethod category asString;
+			store: aMethod protocolName asString;
 			nextPutAll: ' stamp: ';
 			store: aMethod timeStamp ].
 


### PR DESCRIPTION
Update the last senders I found (I might have missed one or two since there are so many) and deprecated this method in favor of #protocol and #protocolName.