### PR TITLE
Deprecated CompiledMethod>>tagWith:

### DIFF
--- a/src/Calypso-SystemQueries/ClyExternalPackageMethodGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyExternalPackageMethodGroup.class.st
@@ -32,10 +32,11 @@ ClyExternalPackageMethodGroup class >> withMethodsFrom: aClassScope packagedIn: 
 
 { #category : #operations }
 ClyExternalPackageMethodGroup >> importMethod: aMethod [
+
 	super importMethod: aMethod.
 
 	self package addMethod: aMethod.
-	aMethod tagWith: ('*', self package name) asSymbol
+	aMethod protocol: '*' , self package name
 ]
 
 { #category : #accessing }

--- a/src/Calypso-SystemQueries/ClyMethodGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyMethodGroup.class.st
@@ -115,9 +115,9 @@ ClyMethodGroup >> asAsyncQueryGroup [
 ]
 
 { #category : #operations }
-ClyMethodGroup >> convertToMethodTag: aTagName [
+ClyMethodGroup >> convertToMethodTag: protocolName [
 
-	self methods do: [ :each | each tagWith: aTagName ]
+	self methods do: [ :method | method protocol: protocolName ]
 ]
 
 { #category : #decoration }

--- a/src/Calypso-SystemQueries/ClyNoTagClassGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyNoTagClassGroup.class.st
@@ -41,5 +41,5 @@ ClyNoTagClassGroup >> importClass: aClass [
 { #category : #operations }
 ClyNoTagClassGroup >> renameClassTagTo: newTag [
 
-	self classes do: [ :each | each tagWith: newTag]
+	self classes do: [ :class | class tagWith: newTag ]
 ]

--- a/src/Calypso-SystemQueries/ClyNoTagMethodGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyNoTagMethodGroup.class.st
@@ -29,7 +29,7 @@ ClyNoTagMethodGroup class >> withMethodsFrom: aMethodQuery [
 ]
 
 { #category : #operations }
-ClyNoTagMethodGroup >> renameMethodTagTo: newTag [
+ClyNoTagMethodGroup >> renameMethodTagTo: newProtocolName [
 
-	self methods do: [ :each | each tagWith: newTag]
+	self methods do: [ :method | method protocol: newProtocolName ]
 ]

--- a/src/Calypso-SystemQueries/ClyTaggedMethodGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyTaggedMethodGroup.class.st
@@ -30,9 +30,10 @@ ClyTaggedMethodGroup >> convertToMethodTag: aTagName [
 
 { #category : #operations }
 ClyTaggedMethodGroup >> importMethod: aMethod [
+
 	super importMethod: aMethod.
 
-	aMethod tagWith: self tag
+	aMethod protocol: self tag
 ]
 
 { #category : #operations }
@@ -49,7 +50,7 @@ ClyTaggedMethodGroup >> renameMethodTagTo: newTag [
 
 	self methods do: [ :method |
 		method
-			tagWith: newTag;
+			protocol: newTag;
 			untagFrom: self tag ].
 
 	methodQuery scope classesDo: [ :class |

--- a/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
@@ -227,15 +227,15 @@ ClyMethodEditorToolMorph >> tagAndPackageEditingMethod: aMethod [
 
 { #category : #operations }
 ClyMethodEditorToolMorph >> tagEditingMethod: aMethod [
+
 	| existingTags removedTags newTags |
 	self applyChangesBy: [
-		existingTags := aMethod tags reject: [:each | each beginsWith: '*'].
+		existingTags := aMethod tags reject: [ :each | each beginsWith: '*' ].
 		removedTags := existingTags reject: [ :each | methodTags includes: each ].
 		newTags := methodTags reject: [ :each | existingTags includes: each ].
 
-		newTags do: [ :each | aMethod tagWith: each asSymbol].
-		removedTags do: [ :each | aMethod untagFrom: each asSymbol]
-	]
+		newTags do: [ :protocolName | aMethod protocol: protocolName ].
+		removedTags do: [ :protocolName | aMethod untagFrom: protocolName ] ]
 ]
 
 { #category : #accessing }

--- a/src/Calypso-SystemTools-FullBrowser/ClyRenameMethodTagCommand.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyRenameMethodTagCommand.class.st
@@ -52,7 +52,7 @@ ClyRenameMethodTagCommand >> defaultMenuItemName [
 { #category : #execution }
 ClyRenameMethodTagCommand >> execute [
 
-	methodGroup renameMethodTagTo: newName asSymbol
+	methodGroup renameMethodTagTo: newName
 ]
 
 { #category : #accessing }

--- a/src/Deprecated12/CompiledMethod.extension.st
+++ b/src/Deprecated12/CompiledMethod.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #CompiledMethod }
+
+{ #category : #'*Deprecated12' }
+CompiledMethod >> tagWith: aSymbol [
+
+	self deprecated: 'Use #protocol: instead.' transformWith: '`@rcv tagWith: `@arg' -> '`@rcv protocol: `@arg'.
+	self protocol: aSymbol
+]

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -973,17 +973,6 @@ CompiledMethod >> storeOn: aStream [
 ]
 
 { #category : #'accessing - tags' }
-CompiledMethod >> tagWith: aSymbol [
-	"Any method could be tagged with multiple symbols for user purpose.
-	This method should apply new tag. All existing tags should not be changed.
-	But now we could only implemented tags with protocols.
-	So tagging method with tag removes all existing tags and add new one.
-	It should not be problem with single tag scenario which are now defined by single protocol"
-
-	self protocol: aSymbol
-]
-
-{ #category : #'accessing - tags' }
 CompiledMethod >> tags [
 	"Any method could be tagged with multiple symbols for user purpose.
 	For now we only define API to manage them implemented on top of method protocols.

--- a/src/SystemCommands-MethodCommands/SycMethodCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMethodCommand.class.st
@@ -64,5 +64,6 @@ SycMethodCommand >> prepareFullExecutionInContext: aToolContext [
 
 { #category : #categories }
 SycMethodCommand >> tagMethod: aMethod [
-	aMethod tagWith: (self newTagFor: aMethod) asSymbol
+
+	aMethod protocol: (self newTagFor: aMethod)
 ]

--- a/src/SystemCommands-MethodCommands/SycMethodRepackagingCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMethodRepackagingCommand.class.st
@@ -30,6 +30,6 @@ SycMethodRepackagingCommand >> moveMethod: aMethod toPackage: aPackage [
 	willBeExtension := aPackage ~~ aMethod origin package.
 	aPackage addMethod: aMethod.
 	willBeExtension
-		ifTrue: [ aMethod tagWith: ('*' , aPackage name) asSymbol ]
+		ifTrue: [ aMethod protocol: '*' , aPackage name ]
 		ifFalse: [ self tagMethod: aMethod ]
 ]

--- a/src/SystemCommands-MethodCommands/SycMoveMethodsToPackageDefiningClassCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMoveMethodsToPackageDefiningClassCommand.class.st
@@ -31,10 +31,10 @@ SycMoveMethodsToPackageDefiningClassCommand >> defaultMenuItemName [
 SycMoveMethodsToPackageDefiningClassCommand >> execute [
 
 	| classPackage |
-	methods do: [ :each |
-		classPackage := each origin package.
-		self moveMethod: each toPackage: classPackage.
-		each tagWith: targetTagName]
+	methods do: [ :method |
+		classPackage := method origin package.
+		self moveMethod: method toPackage: classPackage.
+		method protocol: targetTagName ]
 ]
 
 { #category : #execution }

--- a/src/SystemCommands-MethodCommands/SycTagMethodCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycTagMethodCommand.class.st
@@ -44,8 +44,8 @@ SycTagMethodCommand >> execute [
 	methods do: [ :aMethod |
 		| oldTags |
 		oldTags := aMethod tags.
-		aMethod tagWith: targetTag asSymbol.
-		oldTags do: [:old | aMethod untagFrom: old ]]
+		aMethod protocol: targetTag.
+		oldTags do: [ :old | aMethod untagFrom: old ] ]
 ]
 
 { #category : #execution }


### PR DESCRIPTION
#tagWith: is missleading because it let the user think that there can be multiple tags on a method, but that is not the case. There can be only one protocol.
This change deprecate it in favor of the already existing #protocol: method.

I also reduced the number of #asSymbol sent since the protocol management can deal with strings.