### PR TITLE
Update MethodAddition to use #protocol

### DIFF
--- a/src/CodeExport/ClassDescription.extension.st
+++ b/src/CodeExport/ClassDescription.extension.st
@@ -129,9 +129,7 @@ ClassDescription >> printProtocolChunk: protocol on: aFileStream withStamp: chan
 			 strm
 				 nextPutAll: self name;
 				 nextPutAll: ' methodsFor: ';
-				 print: (protocol isString
-						  ifTrue: [ protocol asString ]
-						  ifFalse: [ protocol name ]).
+				 print: protocol name asString.
 			 (changeStamp isNotNil and: [ changeStamp size > 0 or: [ priorMethod isNotNil ] ]) ifTrue: [
 				 strm
 					 nextPutAll: ' stamp: ';

--- a/src/Monticello/MethodAddition.class.st
+++ b/src/Monticello/MethodAddition.class.st
@@ -6,34 +6,36 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'text',
-		'category',
 		'changeStamp',
 		'logSource',
 		'myClass',
 		'selector',
 		'compiledMethod',
-		'priorMethodOrNil',
-		'priorCategoryOrNil'
+		'priorMethod',
+		'protocolName',
+		'priorProtocol'
 	],
 	#category : #'Monticello-Loading'
 }
 
 { #category : #compilation }
 MethodAddition >> compile [
-    "This method is the how compiling a method used to work.  All these steps were done at once.
+	"This method is the how compiling a method used to work.  All these steps were done at once.
      This method should not normally be used, because the whole point of MethodAddition is to let
 	you first create a compiled method and then install the method later."
-	self createCompiledMethod.
-	self installMethod.
-	self notifyObservers.
-	^selector
+
+	self
+		createCompiledMethod;
+		installMethod;
+		notifyObservers.
+	^ selector
 ]
 
 { #category : #compilation }
-MethodAddition >> compile: aString classified: aString1 withStamp: aString2 logSource: aBoolean inClass: aClass [
+MethodAddition >> compile: aString classified: aProtocolName withStamp: aString2 logSource: aBoolean inClass: aClass [
 
 	text := aString.
-	category := aString1.
+	protocolName := aProtocolName.
 	changeStamp := aString2.
 	logSource := aBoolean.
 	myClass := aClass
@@ -47,8 +49,8 @@ MethodAddition >> createCompiledMethod [
 	compiledMethod := myClass compiler permitUndeclared: true; compile: text asString.
 	selector := compiledMethod selector.
 	self writeSourceToLog.
-	priorMethodOrNil := myClass compiledMethodAt: selector ifAbsent: [ nil ].
-	priorCategoryOrNil := myClass protocolOfSelector: selector
+	priorMethod := myClass compiledMethodAt: selector ifAbsent: [ nil ].
+	priorProtocol := myClass protocolOfSelector: selector
 ]
 
 { #category : #operations }
@@ -60,8 +62,8 @@ MethodAddition >> installMethod [
 { #category : #notifying }
 MethodAddition >> notifyObservers [
 	SystemAnnouncer uniqueInstance 
-		suspendAllWhile: [myClass classify: selector under: category].
-	priorMethodOrNil 
+		suspendAllWhile: [myClass classify: selector under: protocolName].
+	priorMethod 
 		ifNil: [ SystemAnnouncer uniqueInstance
 				methodAdded: compiledMethod
 				configuredWith: [ :event | 
@@ -69,22 +71,17 @@ MethodAddition >> notifyObservers [
 						propertyAt: #eventSource
 						put: #Monticello ] ]
 		ifNotNil: [
-			SystemAnnouncer uniqueInstance methodChangedFrom: priorMethodOrNil to: compiledMethod oldProtocol: priorCategoryOrNil.
-			priorCategoryOrNil name = category ifFalse: [
-       			SystemAnnouncer uniqueInstance methodRecategorized: compiledMethod oldProtocol: priorCategoryOrNil ] ].
+			SystemAnnouncer uniqueInstance methodChangedFrom: priorMethod to: compiledMethod oldProtocol: priorProtocol.
+			priorProtocol name = protocolName ifFalse: [
+       			SystemAnnouncer uniqueInstance methodRecategorized: compiledMethod oldProtocol: priorProtocol ] ].
 	"The following code doesn't seem to do anything."
 	myClass instanceSide noteCompilationOf: compiledMethod meta: myClass isClassSide.
 
 ]
 
 { #category : #accessing }
-MethodAddition >> priorCategoryOrNil [
-	^ priorCategoryOrNil
-]
-
-{ #category : #accessing }
-MethodAddition >> priorCategoryOrNil: anObject [
-	priorCategoryOrNil := anObject
+MethodAddition >> priorProtocol [
+	^ priorProtocol
 ]
 
 { #category : #operations }
@@ -94,6 +91,6 @@ MethodAddition >> writeSourceToLog [
 		myClass
 			logMethodSource: text
 			forMethod: compiledMethod
-			inProtocol: (myClass ensureProtocol: category)
+			inProtocol: (myClass ensureProtocol: protocolName)
 			withStamp: changeStamp ]
 ]


### PR DESCRIPTION
MethodAddition use #category in its vocabulary. This updates it to use #protocol instead.

I also simplified a method of class description since we now only pass it a protocol and never a protocol name.