### PR TITLE
14039-P12-RBVariableisDefinition-does-not-return-true-when-it-should 

### DIFF
--- a/src/AST-Core-Tests/RBVariableNodeTest.class.st
+++ b/src/AST-Core-Tests/RBVariableNodeTest.class.st
@@ -42,24 +42,29 @@ RBVariableNodeTest >> testIsDefinedByBlock [
 
 { #category : #tests }
 RBVariableNodeTest >> testIsDefinition [
+
 	| ast temps |
-	ast := self class compiler
-		parse:
-			'myMethod: arg
-  | test |
+	ast := self class compiler parse: 'myMethod: arg
+  | test testCopied testTempVector|
   test := 2.
   test.
+  [ testCopied. testTempVector := 1 ].
   ^test'.
-	temps := ast allChildren select: [:each | each isTempVariable].
+	temps := ast allChildren select: [ :each | each isTempVariable ].
 
 	"arguments define variables"
 	self assert: ast arguments first isDefinition.
 	"this is the || definition"
+	self assert: temps first variable class identicalTo: TemporaryVariable.
 	self assert: temps first isDefinition.
+	self assert: temps second variable class identicalTo: CopiedLocalVariable.
+	self assert: temps second isDefinition.
+	self assert: temps third variable class identicalTo: OCVectorTempVariable .
+	self assert: temps third isDefinition.
 	"all the rest are just uses"
-	self deny: temps second isDefinition.
-	self deny: temps third isDefinition.
-	self deny: temps fourth isDefinition
+	self deny: temps fourth isDefinition.
+	self deny: (temps at: 5) isDefinition.
+	self deny: (temps at: 6) isDefinition
 ]
 
 { #category : #tests }

--- a/src/OpalCompiler-Core/CopiedLocalVariable.class.st
+++ b/src/OpalCompiler-Core/CopiedLocalVariable.class.st
@@ -17,7 +17,9 @@ CopiedLocalVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 
 { #category : #queries }
 CopiedLocalVariable >> definingNode [
-	^originalVar definingNode
+	^ scope node temporaries
+		detect: [ :each | each variable == self ]
+		ifNone: [ nil ]
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -191,7 +191,6 @@ OpalCompiler class >> stopUsingOverlayForDevelopment [
 ]
 
 { #category : #plugins }
-
 OpalCompiler >> addParsePlugin: aClass [
 	self compilationContext addParseASTTransformationPlugin: aClass
 ]

--- a/src/Slot-Tests/ArgumentVariableTest.class.st
+++ b/src/Slot-Tests/ArgumentVariableTest.class.st
@@ -5,7 +5,7 @@ Class {
 }
 
 { #category : #tests }
-ArgumentVariableTest >> testDeclaringNode [
+ArgumentVariableTest >> testDefiningNode [
 	| method declaringNode declaringNodeViaVariable|
 
 	method := OrderedCollection >> #do:.

--- a/src/Slot-Tests/TemporaryVariableTest.class.st
+++ b/src/Slot-Tests/TemporaryVariableTest.class.st
@@ -8,17 +8,20 @@ Class {
 }
 
 { #category : #tests }
-TemporaryVariableTest >> testDeclaringNode [
-	| method declaringNode declaringNodeViaVariable|
-	method := self class >> #testTemporaryVariablesMethod.
-	declaringNode := method ast body temporaries first.
-	declaringNodeViaVariable := method assignmentNodes first variable variable definingNode.
-	self assert: declaringNodeViaVariable equals: declaringNode.
+TemporaryVariableTest >> testDefiningNode [
+	"test for normal temps, copied and tempvector"
+	| ast tempsNodes tempDefintions  tempUses |
+	ast := self class compiler parse: 'myMethod: arg
+ 	 | test testCopied testTempVector|
+ 	 test := 2.
+  	 test.
+  	 [ testCopied. testTempVector := 1 ].
+    ^test'.
+	tempsNodes := ast allChildren select: [ :each | each isTempVariable ].
+	tempDefintions := tempsNodes select:  [ :each | each isDefinition ].
+	tempUses := tempsNodes reject:  [ :each | each isDefinition ].
+	tempUses do: [ :use | self assert: (tempDefintions includes: use variable definingNode)].
 
-	method := OrderedCollection >> #do:.
-	declaringNode := method ast arguments first.
-	declaringNodeViaVariable := method ast variableReadNodes third variable definingNode.
-	self assert: declaringNodeViaVariable equals: declaringNode
 ]
 
 { #category : #tests }


### PR DESCRIPTION
- rename testDeclaringNode to testDefiningNode
-  improve testIsDefinition   for copied and tempvector
- imporve testDefiningNode for copied and tempvector
- make test grenn by fixing #definingNode of CopiedLocalVariable

fixes #14039