### PR TITLE
7218-CDClassDefinitionParser-raises-an-error-when-copying-ProtoObject-definition

### DIFF
--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -265,6 +265,8 @@ ClySystemEnvironment >> initialize [
 ClySystemEnvironment >> isClassDefinition: newClassDefinitionString [
 	| defTokens |
 	defTokens := newClassDefinitionString findTokens: Character separators.
+	"first case is creating a class with nil as superclass"
+	defTokens first = 'nil' ifTrue: [ ^true ].
 	^ (self class environment classNamed: defTokens first) isNotNil
 ]
 

--- a/src/Kernel-Tests/LegacyClassDefinitionPrinterTest.class.st
+++ b/src/Kernel-Tests/LegacyClassDefinitionPrinterTest.class.st
@@ -101,12 +101,11 @@ LegacyClassDefinitionPrinterTest >> testProtoObject [
 
 	self
 		assert: (self forClass: ProtoObject)
-		equals: 'ProtoObject subclass: #ProtoObject
+		equals: 'nil subclass: #ProtoObject
 	instanceVariableNames: ''''
 	classVariableNames: ''''
 	poolDictionaries: ''''
-	category: ''Kernel-Objects''.
-ProtoObject superclass: nil'
+	category: ''Kernel-Objects'''
 ]
 
 { #category : #'tests - metaclasses' }

--- a/src/Kernel-Tests/OldClassDefinitionPrinterTest.class.st
+++ b/src/Kernel-Tests/OldClassDefinitionPrinterTest.class.st
@@ -104,11 +104,10 @@ OldClassDefinitionPrinterTest >> testPoint [
 { #category : #'tests - classes' }
 OldClassDefinitionPrinterTest >> testProtoObject [
 
-	self assert: (self forClass: ProtoObject) equals: 'ProtoObject subclass: #ProtoObject
+	self assert: (self forClass: ProtoObject) equals: 'nil subclass: #ProtoObject
 	instanceVariableNames: ''''
 	classVariableNames: ''''
-	package: ''Kernel-Objects''.
-ProtoObject superclass: nil'
+	package: ''Kernel-Objects'''
 ]
 
 { #category : #'tests - metaclasses' }

--- a/src/Kernel/LegacyClassDefinitionPrinter.class.st
+++ b/src/Kernel/LegacyClassDefinitionPrinter.class.st
@@ -26,7 +26,7 @@ LegacyClassDefinitionPrinter >> classDefinitionString [
 	| aStream |
 	aStream := (String new: 800) writeStream.
 	forClass superclass
-		ifNil: [aStream nextPutAll: 'ProtoObject']
+		ifNil: [aStream nextPutAll: 'nil']
 		ifNotNil: [aStream nextPutAll: forClass superclass name].
 	aStream nextPutAll: forClass kindOfSubclass;
 			store: forClass name.
@@ -41,12 +41,6 @@ LegacyClassDefinitionPrinter >> classDefinitionString [
 			store: forClass sharedPoolsString.
 	aStream cr; tab; nextPutAll: 'category: ';
 			store: forClass category asString.
-
-	forClass superclass ifNil: [
-		aStream nextPutAll: '.'; cr.
-		aStream nextPutAll: forClass name.
-		aStream space; nextPutAll: 'superclass: nil'. ].
-
 	^ aStream contents
 ]
 

--- a/src/Kernel/OldPharoClassDefinitionPrinter.class.st
+++ b/src/Kernel/OldPharoClassDefinitionPrinter.class.st
@@ -19,7 +19,7 @@ OldPharoClassDefinitionPrinter >> basicClassDefinitionString [
 	stream := (String new: 800) writeStream.
 	forClass superclass
 		ifNotNil: [ stream nextPutAll: forClass superclass name ]
-		ifNil: [ stream nextPutAll: 'ProtoObject' ].
+		ifNil: [ stream nextPutAll: 'nil' ].
 	stream
 		nextPutAll: forClass kindOfSubclass;
 		store: forClass name.
@@ -28,14 +28,6 @@ OldPharoClassDefinitionPrinter >> basicClassDefinitionString [
 	self classVariablesOn: stream.
 	self poolOn: stream.
 	self packageOn: stream.
-	forClass superclass ifNil: [
-		stream
-			nextPutAll: '.';
-			cr.
-		stream nextPutAll: forClass name.
-		stream
-			space;
-			nextPutAll: 'superclass: nil' ].
 	^ stream contents
 ]
 

--- a/src/Kernel/UndefinedObject.class.st
+++ b/src/Kernel/UndefinedObject.class.st
@@ -211,19 +211,25 @@ UndefinedObject >> storeOn: aStream [
 ]
 
 { #category : #'class hierarchy' }
-UndefinedObject >> subclass: nameOfClass
-	instanceVariableNames: instVarNameList
-	classVariableNames: classVarNames
-	poolDictionaries: poolDictnames
-	category: category [
-	"Calling this method is now considered an accident.  If you really want to create a class with a nil superclass, then create the class and then set the superclass using #superclass:"
-	Warning signal: ('Attempt to create ', nameOfClass, ' as a subclass of nil.  Possibly a class is being loaded before its superclass.').
-	^ Object
+UndefinedObject >> subclass: nameOfClass instanceVariableNames: instVarNameList classVariableNames: classVarNames package: packageName [
+	
+	"Retained for backward compatibility. With fluid class defintions, we never use this"
+	| subClass |
+	subClass := ProtoObject
 		subclass: nameOfClass
 		instanceVariableNames: instVarNameList
 		classVariableNames: classVarNames
-		poolDictionaries: poolDictnames
-		category: category
+		poolDictionaries: ''
+		package: packageName.
+	subClass superclass: nil.
+	^ subClass.
+]
+
+{ #category : #'class hierarchy' }
+UndefinedObject >> subclass: nameOfClass instanceVariableNames: instVarNameList classVariableNames: classVarNames poolDictionaries: poolDictnames category: packageName [
+	
+	"Retained for backward compatibility. With fluid class defintions, we never use this"
+	^ self subclass: nameOfClass instanceVariableNames: instVarNameList classVariableNames: classVarNames package: packageName
 ]
 
 { #category : #'class hierarchy' }


### PR DESCRIPTION
This fixes #7218

When defining nil subclasses with non-fluid, at some point the ST80 idea of having class creation methods on nil was replaced by doing a subclass of ProtoObject and then changing the superclass. This was done as due to the explosion of creation methods, the old way did not scale.

With fluid, we are back with nil subclass. Why not do this for non-fluid, too? We just need to support the old method and the one printed now in case fluid is disabled