### PR TITLE
Fix class parser for non-fluid nil subclass definitions

### DIFF
--- a/src/ClassParser-Tests/CDNilSubclassParserTest.class.st
+++ b/src/ClassParser-Tests/CDNilSubclassParserTest.class.st
@@ -5,7 +5,30 @@ Class {
 }
 
 { #category : #helpers }
+CDNilSubclassParserTest >> classDefinitionString [
+	^ 'ProtoObject subclass: #ProtoObject
+	instanceVariableNames: ''first second''
+	classVariableNames: ''firstClass secondClass''
+	package: #MyPackage.
+ProtoObject superclass: nil'
+]
+
+{ #category : #helpers }
+CDNilSubclassParserTest >> className [
+	^ 'ProtoObject'
+]
+
+{ #category : #helpers }
 CDNilSubclassParserTest >> superclassName [
 
 	^ 'nil'
+]
+
+{ #category : #tests }
+CDNilSubclassParserTest >> testBestNodeForClassNameSelectionShouldBeClassNameNode [
+
+	| selectedNode selection |
+	selection := self selectionOf: 'ProtoObject'.
+	selectedNode := classDefinition bestNodeFor: selection.
+	self assert: selectedNode equals: classDefinition
 ]

--- a/src/ClassParser/CDClassDefinitionParser.class.st
+++ b/src/ClassParser/CDClassDefinitionParser.class.st
@@ -68,7 +68,12 @@ CDClassDefinitionParser >> handleTraitDefinitionFromNode: aNode [
 { #category : #testing }
 CDClassDefinitionParser >> isInstanceSideDefinition: aRBMessageNode [
 	"Based on the Point or Point class structure, returns whether the definition is a class or instance side definition."
-	^ aRBMessageNode receiver isMessage not
+	^ (aRBMessageNode isSequence 
+		"when defining a subclass of nil, we have two sends"
+		and: [aRBMessageNode statements size = 2
+		and: [aRBMessageNode statements second isMessage
+		and: [aRBMessageNode statements second selector == #superclass: ]]]) or: [
+	aRBMessageNode receiver isMessage not]
 ]
 
 { #category : #parsing }
@@ -125,4 +130,14 @@ CDClassDefinitionParser >> visitMessageNode: aRBMessageNode [
 		with: aRBMessageNode arguments
 		do: [ :selectorPart :argument |
 			self parseSelectorPart: selectorPart withArgument: argument ]
+]
+
+{ #category : #visiting }
+CDClassDefinitionParser >> visitSequenceNode: aRBSequenceNode [
+	"we end up here when parsing the definition of a class with nil superclass, e.g., ProtoObject"
+	self visitMessageNode: aRBSequenceNode statements first.
+	classDefinition superclassName: nil.
+	classDefinition classNameNode
+		originalNode: aRBSequenceNode statements second arguments first;
+		className: nil
 ]

--- a/src/ClassParser/CDClassDefinitionParser.class.st
+++ b/src/ClassParser/CDClassDefinitionParser.class.st
@@ -136,8 +136,8 @@ CDClassDefinitionParser >> visitMessageNode: aRBMessageNode [
 CDClassDefinitionParser >> visitSequenceNode: aRBSequenceNode [
 	"we end up here when parsing the definition of a class with nil superclass, e.g., ProtoObject"
 	self visitMessageNode: aRBSequenceNode statements first.
-	classDefinition superclassName: nil.
-	classDefinition classNameNode
+	classDefinition superclassName: 'nil'.
+	classDefinition superclassNameNode
 		originalNode: aRBSequenceNode statements second arguments first;
-		className: nil
+		className: 'nil'
 ]

--- a/src/ClassParser/CDClassNameNode.class.st
+++ b/src/ClassParser/CDClassNameNode.class.st
@@ -29,7 +29,7 @@ CDClassNameNode >> existingBindingIfAbsent: aBlock [
 
 	| binding |
 	binding := originalNode methodNode scope environment bindingOf: className.
-	^binding ifNil: aBlock
+	^binding ifNil: [ aBlock ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
fixes #7218 by adding support to the class parser to parse non-fluid nil subclass definitions