### PR TITLE
Added the `LinkedList>>#rechain:` method to be able to replace multiple links/adding chains in one go in the middle of the `LinkedList`

### DIFF
--- a/src/Collections-Sequenceable-Tests/LinkedListTest.class.st
+++ b/src/Collections-Sequenceable-Tests/LinkedListTest.class.st
@@ -844,6 +844,93 @@ LinkedListTest >> testNewFromCollection [
 ]
 
 { #category : #tests }
+LinkedListTest >> testRechainNilValue [
+	
+	list addAll: (1 to: 5).
+	
+	list rechain: [ :listLink | listLink value % 2 = 1 ifTrue: [ listLink value ] ].
+	
+	self assert: list equals: #(1 3 5)
+]
+
+{ #category : #tests }
+LinkedListTest >> testRechainPreserveCutList [
+	
+	list addAll: (1 to: 5).
+	
+	list rechain: [ :listLink | listLink value % 2 = 1 ifTrue: [ listLink ] ].
+	
+	self assert: list equals: #(1 3 5)
+]
+
+{ #category : #tests }
+LinkedListTest >> testRechainPreserveList [
+	
+	list addAll: (1 to: 5).
+	
+	list rechain: [ :listLink | listLink ].
+	
+	self assert: list equals: (1 to: 5)
+]
+
+{ #category : #tests }
+LinkedListTest >> testRechainWithChains [
+	
+	list addAll: (1 to: 5).
+	
+	list rechain: [ :listLink | 
+		|tempLink|
+		tempLink := nil.
+		1 to: (listLink value) do: [ :_ |
+			|l|
+			l := listLink value asLink.
+			l nextLink: tempLink.
+			tempLink := l ].
+		tempLink ].
+	
+	self assert: list equals: #(1 2 2 3 3 3 4 4 4 4 5 5 5 5 5)
+]
+
+{ #category : #tests }
+LinkedListTest >> testRechainWithChainsAndNil [
+
+	list addAll: (1 to: 5).
+
+	list rechain: [ :listLink |
+		listLink value % 2 = 1 ifTrue: [
+			| tempLink |
+			tempLink := nil.
+			1 to: listLink value do: [ :_ |
+				| l |
+				l := listLink value asLink.
+				l nextLink: tempLink.
+				tempLink := l ].
+			tempLink ] ].
+
+	self assert: list equals: #( 1 3 3 3 5 5 5 5 5 )
+]
+
+{ #category : #tests }
+LinkedListTest >> testRechainWithChainsAndPreserve [
+
+	list addAll: (1 to: 5).
+
+	list rechain: [ :listLink |
+		listLink value % 2 = 1 ifTrue: [
+			| tempLink |
+			tempLink := nil.
+			1 to: listLink value do: [ :_ |
+				| l |
+				l := listLink value asLink.
+				l nextLink: tempLink.
+				tempLink := l ].
+			tempLink ]
+		ifFalse: [ listLink ] ].
+
+	self assert: list equals: #( 1 2 3 3 3 4 5 5 5 5 5 )
+]
+
+{ #category : #tests }
 LinkedListTest >> testRemoveAll [
 	| list2 |
 	list add: link1.

--- a/src/Collections-Sequenceable/LinkedList.class.st
+++ b/src/Collections-Sequenceable/LinkedList.class.st
@@ -400,6 +400,35 @@ LinkedList >> postCopy [
 ]
 
 { #category : #enumerating }
+LinkedList >> rechain: aBlock [
+	"Enumerates through the LinkedList replacing each link by the chain of links returned by the block or removing the link if nil is returned. Returning the same link preserves it, but returning any other link of the list WILL result in an infinite loop."
+
+	| aLink lastLinkKnown firstLinkKnown outputLink |
+	aLink := firstLink.
+	firstLinkKnown := nil.
+	lastLinkKnown := nil.
+	[ aLink == nil ] whileFalse: [
+		(aBlock value: aLink) ifNotNil: [ :output |
+			
+			outputLink := output asLink.
+			firstLinkKnown
+				ifNil: [ firstLinkKnown := outputLink ]
+				ifNotNil: [ lastLinkKnown nextLink: outputLink ].
+
+			"If the returned link is the same as the original, do not consider it as a chain. Otherwise add the entire chain"
+			outputLink == aLink ifFalse: [
+				[ outputLink nextLink ] whileNotNil: [
+					outputLink := outputLink nextLink ] ].
+
+			lastLinkKnown := outputLink ].
+		"Get the next link, then make sure that lastLinkKnown is actually the end of the list."
+		aLink := aLink nextLink.
+		lastLinkKnown ifNotNil: [ lastLinkKnown nextLink: nil ] ].
+	firstLink := firstLinkKnown.
+	lastLink := lastLinkKnown
+]
+
+{ #category : #enumerating }
 LinkedList >> reject: rejectBlock [
 	"Optimized version of SequenceableCollection>>#reject:"
 


### PR DESCRIPTION
### Explanation
There are currently ways to put links directly inside a `LinkedList` but there was no way to properly include a chain, so I implemented this that works kind of the same way as a `#collect:` would.

### Dangers:
Returning links from the original list other than the one being treated WILL loop infinitely

### Examples:

Multiplying all the links by 2:
```st
l := LinkedList new.
l addAll: (1 to: 5).
l rechain: [ :link | link value * 2 ].
l "a LinkedList(2 4 6 8 10)"
```


Multiplying all the links by 2 except for even links reusing the original links:
```st
l := LinkedList new.
l addAll: (1 to: 5).
l rechain: [ :link | 
	(link value % 2 = 1) 
	ifTrue: [ link value * 2 ] 
	ifFalse: [ link ] ].
l "a LinkedList(2 2 6 4 10)"
```

Multiplying all the links by 2 and discarding even links:
```st
l := LinkedList new.
l addAll: (1 to: 5).
l rechain: [ :link | (link value % 2 = 1) ifTrue: [ link value * 2 ] ].
l "a LinkedList(2 6 10)"
```

Finally it is possible to add whole chains in the middle of the LinkedList:
```st
l := LinkedList new.
l addAll: (1 to: 5).
l rechain: [ :listLink | 
		|tempLink|
		tempLink := nil.
		1 to: (listLink value) do: [ :_ |
			|l|
			l := listLink value asLink.
			l nextLink: tempLink.
			tempLink := l ].
		tempLink ].
l "a LinkedList(1 2 2 3 3 3 4 4 4 4 5 5 5 5 5)"
```