### PR TITLE
Deprecate CompiledMethod>>untagFrom:

### DIFF
--- a/src/Calypso-SystemQueries/ClyAllMethodGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyAllMethodGroup.class.st
@@ -31,8 +31,7 @@ ClyAllMethodGroup class >> withMethodsInheritedFrom: aClassScope [
 
 { #category : #operations }
 ClyAllMethodGroup >> importMethod: aMethod [
-	"To support some people scenario to unclassify methods
-	by drag and drop into this group (which was with ALL name in past)"
+	"To support some people scenario to unclassify methods by drag and drop into this group (which was with ALL name in past)"
 
-	aMethod tags do: [ :each | aMethod untagFrom: each ]
+	aMethod unclassify
 ]

--- a/src/Calypso-SystemQueries/ClyTaggedMethodGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyTaggedMethodGroup.class.st
@@ -44,19 +44,13 @@ ClyTaggedMethodGroup >> removeWithMethods [
 ]
 
 { #category : #operations }
-ClyTaggedMethodGroup >> renameMethodTagTo: newTag [
+ClyTaggedMethodGroup >> renameMethodTagTo: newProtocolName [
 
-	newTag = self tag ifTrue: [ ^ self ].
+	newProtocolName = self tag ifTrue: [ ^ self ].
 
-	self methods do: [ :method |
-		method
-			protocol: newTag;
-			untagFrom: self tag ].
+	self methods do: [ :method | method protocol: newProtocolName ].
 
-	methodQuery scope classesDo: [ :class |
-		class
-			addProtocol: newTag;
-			removeProtocolIfEmpty: self tag ]
+	methodQuery scope classesDo: [ :class | class removeProtocolIfEmpty: self tag ]
 ]
 
 { #category : #accessing }

--- a/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
@@ -228,14 +228,8 @@ ClyMethodEditorToolMorph >> tagAndPackageEditingMethod: aMethod [
 { #category : #operations }
 ClyMethodEditorToolMorph >> tagEditingMethod: aMethod [
 
-	| existingTags removedTags newTags |
-	self applyChangesBy: [
-		existingTags := aMethod tags reject: [ :each | each beginsWith: '*' ].
-		removedTags := existingTags reject: [ :each | methodTags includes: each ].
-		newTags := methodTags reject: [ :each | existingTags includes: each ].
-
-		newTags do: [ :protocolName | aMethod protocol: protocolName ].
-		removedTags do: [ :protocolName | aMethod untagFrom: protocolName ] ]
+	self applyChangesBy: [ "In the end we only have at max 1 protocol but for now this class hold a collection. This should be updated in the future."
+		methodTags do: [ :protocolName | aMethod protocol: protocolName ] ]
 ]
 
 { #category : #accessing }

--- a/src/Deprecated12/CompiledMethod.extension.st
+++ b/src/Deprecated12/CompiledMethod.extension.st
@@ -6,3 +6,13 @@ CompiledMethod >> tagWith: aSymbol [
 	self deprecated: 'Use #protocol: instead.' transformWith: '`@rcv tagWith: `@arg' -> '`@rcv protocol: `@arg'.
 	self protocol: aSymbol
 ]
+
+{ #category : #'*Deprecated12' }
+CompiledMethod >> untagFrom: aSymbol [
+
+	self
+		deprecated:
+		'This method is missleading letting the user thing that there can be more than one protocol on a method. Most of the cases should just use #protocol: to update the protocol or #unclassify.'
+		transformWith: '`@rcv untagFrom: `@arg' -> '`@rcv protocolName = `@arg ifTrue: [ `@rcv unclassify ]'.
+	self protocolName = aSymbol ifTrue: [ self unclassify ]
+]

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -780,19 +780,19 @@ CompiledMethod >> propertyKeysAndValuesDo: aBlock [
 		[propertiesOrSelector propertyKeysAndValuesDo: aBlock]
 ]
 
-{ #category : #accessing }
+{ #category : #protocols }
 CompiledMethod >> protocol [
 	"Return in which protocol (conceptual groups of methods) the receiver is grouped into."
 
 	^ self methodClass protocolOfSelector: self selector
 ]
 
-{ #category : #accessing }
+{ #category : #protocols }
 CompiledMethod >> protocol: aProtocol [
 	^ self methodClass classify: self selector under: aProtocol
 ]
 
-{ #category : #accessing }
+{ #category : #protocols }
 CompiledMethod >> protocolName [
 	"Return the name of the protocol (conceptual groups of methods) in which the receiver is grouped into."
 
@@ -996,14 +996,10 @@ CompiledMethod >> trailer [
 	^self deprecated: 'CompiledMethodTrailer has been removed in Pharo12. Just use sourcePointer / sourcePointer to read and set. See class comment of CompiledMethodTrailer for more information'
 ]
 
-{ #category : #'accessing - tags' }
-CompiledMethod >> untagFrom: aSymbol [
-	"Any method could be tagged with multiple symbols for user purpose.
-	This method should remove given tag from it. All other tags should not be changed.
-	But now we could implemented tags with protocols which allow only tag for method.
-	And to remove tag from method we must change it protocol to Protocol unclassified"
-	self protocolName = aSymbol ifTrue: [
-		self protocol: Protocol unclassified]
+{ #category : #protocols }
+CompiledMethod >> unclassify [
+
+	self protocol: Protocol unclassified
 ]
 
 { #category : #testing }

--- a/src/Ring-Core/RGBehavior.class.st
+++ b/src/Ring-Core/RGBehavior.class.st
@@ -982,7 +982,8 @@ RGBehavior >> removeMethodTag: aSymbol [
 
 	self backend forPackage removeMethodTag: aSymbol from: self.
 
-	self localMethodsDo: [ :method | method protocol = aSymbol ifTrue: [ method unclassify ] ]
+	self localMethodsDo: [ :method |
+		method untagFrom: aSymbol ]
 ]
 
 { #category : #'accessing - backend' }

--- a/src/Ring-Core/RGBehavior.class.st
+++ b/src/Ring-Core/RGBehavior.class.st
@@ -982,8 +982,7 @@ RGBehavior >> removeMethodTag: aSymbol [
 
 	self backend forPackage removeMethodTag: aSymbol from: self.
 
-	self localMethodsDo: [ :method |
-		method untagFrom: aSymbol ]
+	self localMethodsDo: [ :method | method protocol = aSymbol ifTrue: [ method unclassify ] ]
 ]
 
 { #category : #'accessing - backend' }

--- a/src/SystemCommands-MethodCommands/SycMethodRepackagingCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMethodRepackagingCommand.class.st
@@ -25,8 +25,6 @@ SycMethodRepackagingCommand >> moveMethod: aMethod toPackage: aPackage [
 	existingPackage := aMethod package.
 	existingPackage == aPackage ifTrue: [ ^ self ].
 
-	aMethod isExtension ifTrue: [ aMethod untagFrom: ('*' , existingPackage name) asSymbol ].
-
 	willBeExtension := aPackage ~~ aMethod origin package.
 	aPackage addMethod: aMethod.
 	willBeExtension

--- a/src/SystemCommands-MethodCommands/SycTagMethodCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycTagMethodCommand.class.st
@@ -41,11 +41,7 @@ SycTagMethodCommand >> defaultMenuItemName [
 { #category : #execution }
 SycTagMethodCommand >> execute [
 
-	methods do: [ :aMethod |
-		| oldTags |
-		oldTags := aMethod tags.
-		aMethod protocol: targetTag.
-		oldTags do: [ :old | aMethod untagFrom: old ] ]
+	methods do: [ :aMethod | aMethod protocol: targetTag ]
 ]
 
 { #category : #execution }


### PR DESCRIPTION
#untagFrom: is missleading because it let the user think a method can have multiple protocols while there can be only one. Checking at the senders, almost all of them had code more complexe that it should have.  Most users can be replaced by just calling #protocol: and for the others I implemented a method CompiledMethod>>unclassify that has a more explicit name.