### PR TITLE
Extract Monticello from package renmaing

### DIFF
--- a/src/Monticello/MCWorkingCopy.class.st
+++ b/src/Monticello/MCWorkingCopy.class.st
@@ -287,12 +287,14 @@ MCWorkingCopy class >> methodRemoved: anEvent [
 
 { #category : #'system changes' }
 MCWorkingCopy class >> packageRenamed: anAnnouncement [
-	self allManagers 
+
+	| repositoryGroup |
+	repositoryGroup := (self forPackageNamed: anAnnouncement oldName) repositoryGroup.
+	self allManagers
 		detect: [ :each | each packageName = anAnnouncement newName ]
 		ifFound: [ :newPackage | newPackage modified: true ].
-	(self allManagers 
-		detect: [ :each | each packageName = anAnnouncement oldName ])
-		unload.
+	(self allManagers detect: [ :each | each packageName = anAnnouncement oldName ]) unload.
+	anAnnouncement package mcWorkingCopy repositoryGroup: repositoryGroup
 ]
 
 { #category : #'event registration' }

--- a/src/Monticello/RPackageOrganizer.extension.st
+++ b/src/Monticello/RPackageOrganizer.extension.st
@@ -1,15 +1,15 @@
 Extension { #name : #RPackageOrganizer }
 
 { #category : #'*Monticello-RPackage' }
-RPackageOrganizer >> allManagers [
-
-	^ self class allManagers 
-]
-
-{ #category : #'*Monticello-RPackage' }
 RPackageOrganizer class >> allManagers [
 
 	^ MCWorkingCopy allManagers
+]
+
+{ #category : #'*Monticello-RPackage' }
+RPackageOrganizer >> allManagers [
+
+	^ self class allManagers 
 ]
 
 { #category : #'*Monticello-RPackage' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -1376,30 +1376,23 @@ RPackage >> renameTagsPrefixedWith: oldName to: newName [
 RPackage >> renameTo: aSymbol [
 	"Rename a package with a different name, provided as a symbol"
 
-	| oldName newName oldCategoryNames repositoryGroup |
+	| oldName newName oldCategoryNames |
 	oldName := self name.
 	newName := aSymbol asSymbol.
-	repositoryGroup := self mcPackage workingCopy repositoryGroup.
 	self organizer validatePackageDoesNotExist: aSymbol.
-	oldCategoryNames := (self classTags collect: [:each | each categoryName] as: Set)
-		add: self name;
-		difference: {newName}.
+	oldCategoryNames := (self classTags collect: [ :each | each categoryName ] as: Set)
+		                    add: self name;
+		                    difference: { newName }.
 	self name: aSymbol.
-	SystemAnnouncer uniqueInstance
-		suspendAllWhile: [ self definedClasses
-				do:
-					[ :each | each category: newName , (each category allButFirst: oldName size) ].
-			oldCategoryNames
-				do: [ :each | self organizer removeCategory: each ] ].
+	SystemAnnouncer uniqueInstance suspendAllWhile: [
+		self definedClasses do: [ :each | each category: newName , (each category allButFirst: oldName size) ].
+		oldCategoryNames do: [ :each | self organizer removeCategory: each ] ].
 	self renameTagsPrefixedWith: oldName to: newName.
 	self renameExtensionsPrefixedWith: oldName to: newName.
 	self organizer
 		basicUnregisterPackageNamed: oldName;
 		basicRegisterPackage: self.
-	self mcPackage workingCopy repositoryGroup: repositoryGroup.
-	SystemAnnouncer uniqueInstance
-		announce:
-			(PackageRenamed to: self oldName: oldName newName: newName)
+	SystemAnnouncer uniqueInstance announce: (PackageRenamed to: self oldName: oldName newName: newName)
 ]
 
 { #category : #private }


### PR DESCRIPTION
RPackage should not depend on Monticello. This change is to remove the dependency during the package renaming. Instead of updating the repository group in RPackage, we update it in the monticello code listening to the package renaming.

This should be a step toward getting https://github.com/pharo-project/pharo/pull/14036 to pass