### PR TITLE
Move Monticello diffs to its own package

### DIFF
--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -70,6 +70,7 @@ BaselineOfBasicTools >> baseline: spec [
 		spec package: 'Metacello-Reference'.
 		spec package: 'Metacello-Tutorial'.
 		spec package: 'MonticelloGUI'.
+		spec package: 'Monticello-GUI-Diff' with: [ spec requires: #( 'Tool-Diff' ) ].
 		spec package: 'System-Changes-Tests'. "<= Not sure this one should be here but it is where the classes were loaded before been extracted from Tests package."
 		spec package: 'System-Sources-Tests'. "<= Not sure this one should be here but it is where the classes were loaded before been extracted from Tests package."
 		spec package: 'System-Announcements-Tests'. "<= Not sure this one should be here but it is where the classes were loaded before been extracted from Tests package."

--- a/src/Monticello-GUI-Diff/CommandLineUIManager.extension.st
+++ b/src/Monticello-GUI-Diff/CommandLineUIManager.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #CommandLineUIManager }
 
-{ #category : #'*Monticello' }
+{ #category : #'*Monticello-GUI-Diff' }
 CommandLineUIManager >> merge: merger informing: aString [
 	"Check for conflicts, if there are none, just continue. 
 	 Merger will accept all conflicts"

--- a/src/Monticello-GUI-Diff/DummyUIManager.extension.st
+++ b/src/Monticello-GUI-Diff/DummyUIManager.extension.st
@@ -1,0 +1,5 @@
+Extension { #name : #DummyUIManager }
+
+{ #category : #'*Monticello-GUI-Diff' }
+DummyUIManager >> merge: merger informing: aString [
+]

--- a/src/Monticello-GUI-Diff/MCMergeResolutionRequest.extension.st
+++ b/src/Monticello-GUI-Diff/MCMergeResolutionRequest.extension.st
@@ -1,13 +1,13 @@
 Extension { #name : #MCMergeResolutionRequest }
 
-{ #category : #'*Tool-Diff' }
+{ #category : #'*Monticello-GUI-Diff' }
 MCMergeResolutionRequest >> defaultAction [
 	"Modally open a merge tool."
 
 	^self viewMerger
 ]
 
-{ #category : #'*Tool-Diff' }
+{ #category : #'*Monticello-GUI-Diff' }
 MCMergeResolutionRequest >> viewMerger [
 	"Open a model browser to perform the merge and answer wheter merged."
 
@@ -18,7 +18,7 @@ MCMergeResolutionRequest >> viewMerger [
 					label: messageText) showModally]
 ]
 
-{ #category : #'*Tool-Diff' }
+{ #category : #'*Monticello-GUI-Diff' }
 MCMergeResolutionRequest >> viewPatchMerger [
 	"Open a modal diff tools browser to perform the merge."
 

--- a/src/Monticello-GUI-Diff/MCModification.extension.st
+++ b/src/Monticello-GUI-Diff/MCModification.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #MCModification }
 
-{ #category : #'*Tool-Diff' }
+{ #category : #'*Monticello-GUI-Diff' }
 MCModification >> diff [
 	"Open a diff browser on the changes."
 
@@ -12,7 +12,7 @@ MCModification >> diff [
 			openInWindowLabeled: 'Diff' translated
 ]
 
-{ #category : #'*Tool-Diff' }
+{ #category : #'*Monticello-GUI-Diff' }
 MCModification >> diffFromSource [
 	"Answer fromSource of the modification. If a class patch then answer
 	the fromSource with the class-side definition and comment appended."
@@ -25,7 +25,7 @@ MCModification >> diffFromSource [
 		ifFalse: [obsoletion diffSource]
 ]
 
-{ #category : #'*Tool-Diff' }
+{ #category : #'*Monticello-GUI-Diff' }
 MCModification >> diffToSource [
 	"Answer toSource of the modification. If a class patch then answer
 	the toSource with the class-side definition and comment appended."

--- a/src/Monticello-GUI-Diff/MCOrganizationDefinition.extension.st
+++ b/src/Monticello-GUI-Diff/MCOrganizationDefinition.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #MCOrganizationDefinition }
 
-{ #category : #'*Tool-Diff' }
+{ #category : #'*Monticello-GUI-Diff' }
 MCOrganizationDefinition >> patchWrapper [
 	"Answer a wrapper for a patch tree for the receiver."
 

--- a/src/Monticello-GUI-Diff/MCPatchBrowser.extension.st
+++ b/src/Monticello-GUI-Diff/MCPatchBrowser.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #MCPatchBrowser }
 
-{ #category : #'*Tool-Diff' }
+{ #category : #'*Monticello-GUI-Diff' }
 MCPatchBrowser >> diffSelection [
 	"Open a diff browser on the selection."
 
@@ -8,7 +8,7 @@ MCPatchBrowser >> diffSelection [
 		[selection diff]
 ]
 
-{ #category : #'*Tool-Diff' }
+{ #category : #'*Monticello-GUI-Diff' }
 MCPatchBrowser >> methodListMenu: aMenu [
 
 	selection

--- a/src/Monticello-GUI-Diff/MCPatchOperation.extension.st
+++ b/src/Monticello-GUI-Diff/MCPatchOperation.extension.st
@@ -1,46 +1,46 @@
 Extension { #name : #MCPatchOperation }
 
-{ #category : #'*Tool-Diff' }
+{ #category : #'*Monticello-GUI-Diff' }
 MCPatchOperation >> diff [
 	"Open a diff browser on the changes."
 ]
 
-{ #category : #'*Tool-Diff' }
+{ #category : #'*Monticello-GUI-Diff' }
 MCPatchOperation >> diffFromSource [
 	"Answer fromSource of the operation for a diff tool."
 
 	^self fromSource
 ]
 
-{ #category : #'*Tool-Diff' }
+{ #category : #'*Monticello-GUI-Diff' }
 MCPatchOperation >> diffToSource [
 	"Answer toSource of the operation for a diff tool."
 
 	^self toSource
 ]
 
-{ #category : #'*Tool-Diff' }
+{ #category : #'*Monticello-GUI-Diff' }
 MCPatchOperation >> patchWrapper [
 	"Answer a wrapper for a patch tree for the receiver."
 
 	^PSMCPatchOperationWrapper with: self
 ]
 
-{ #category : #'*Tool-Diff' }
+{ #category : #'*Monticello-GUI-Diff' }
 MCPatchOperation >> shortSummary [
 	"Answer a short summary of the receiver."
 
 	^self shortSummaryPrefix , self shortSummarySuffix
 ]
 
-{ #category : #'*Tool-Diff' }
+{ #category : #'*Monticello-GUI-Diff' }
 MCPatchOperation >> shortSummaryPrefix [
 	"Answer a short summary prefix of the receiver."
 
 	^ self definition summary
 ]
 
-{ #category : #'*Tool-Diff' }
+{ #category : #'*Monticello-GUI-Diff' }
 MCPatchOperation >> shortSummarySuffix [
 	"Answer a short summary suffix of the receiver."
 
@@ -49,7 +49,7 @@ MCPatchOperation >> shortSummarySuffix [
 		ifFalse: ['']
 ]
 
-{ #category : #'*Tool-Diff' }
+{ #category : #'*Monticello-GUI-Diff' }
 MCPatchOperation >> targetClassName [
 	"Answer the full class *name* of the target since the class may no longer exist."
 

--- a/src/Monticello-GUI-Diff/MCVersionHistoryBrowser.extension.st
+++ b/src/Monticello-GUI-Diff/MCVersionHistoryBrowser.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #MCVersionHistoryBrowser }
 
-{ #category : #'*Tool-Diff' }
+{ #category : #'*Monticello-GUI-Diff' }
 MCVersionHistoryBrowser >> viewChanges [
 	"View the changes between a prior version and this version."
 
@@ -10,7 +10,7 @@ MCVersionHistoryBrowser >> viewChanges [
 		to: ancestry name
 ]
 
-{ #category : #'*Tool-Diff' }
+{ #category : #'*Monticello-GUI-Diff' }
 MCVersionHistoryBrowser >> viewChanges: otherInfo [
 	"View the changes between a prior version and this version."
 
@@ -20,7 +20,7 @@ MCVersionHistoryBrowser >> viewChanges: otherInfo [
 		to: self selectedInfo name
 ]
 
-{ #category : #'*Tool-Diff' }
+{ #category : #'*Monticello-GUI-Diff' }
 MCVersionHistoryBrowser >> viewChanges: patch from: fromDescription to: toDescription [
 	"Open a browser on the patch."
 

--- a/src/Monticello-GUI-Diff/MCVersionInspector.extension.st
+++ b/src/Monticello-GUI-Diff/MCVersionInspector.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #MCVersionInspector }
 
-{ #category : #'*Tool-Diff' }
+{ #category : #'*Monticello-GUI-Diff' }
 MCVersionInspector >> viewChanges: patch from: fromDescription to: toDescription [
 	"Open a patch morph for the changes."
 

--- a/src/Monticello-GUI-Diff/MCWorkingCopyBrowser.extension.st
+++ b/src/Monticello-GUI-Diff/MCWorkingCopyBrowser.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #MCWorkingCopyBrowser }
 
-{ #category : #'*Tool-Diff' }
+{ #category : #'*Monticello-GUI-Diff' }
 MCWorkingCopyBrowser >> viewChanges [
 	"View the changes made in the working copy."
 
@@ -25,7 +25,7 @@ MCWorkingCopyBrowser >> viewChanges [
 					to: ('Modified {1}' translated format: {workingCopy description})]]
 ]
 
-{ #category : #'*Tool-Diff' }
+{ #category : #'*Monticello-GUI-Diff' }
 MCWorkingCopyBrowser >> viewChanges: patch from: fromDescription to: toDescription [
 	"Open a browser on the given patch."
 

--- a/src/Monticello-GUI-Diff/MorphicUIManager.extension.st
+++ b/src/Monticello-GUI-Diff/MorphicUIManager.extension.st
@@ -1,0 +1,16 @@
+Extension { #name : #MorphicUIManager }
+
+{ #category : #'*Monticello-GUI-Diff' }
+MorphicUIManager >> merge: merger informing: aString [
+
+	| mergeMorph  window |
+	mergeMorph := PSMCMergeMorph forMerger: merger.
+	mergeMorph
+		fromDescription: 'Working copy' translated;
+		toDescription: aString.
+	window := mergeMorph newWindow
+		title: aString;
+		yourself.
+	window openModal.
+	^ mergeMorph merged
+]

--- a/src/Monticello-GUI-Diff/NonInteractiveUIManager.extension.st
+++ b/src/Monticello-GUI-Diff/NonInteractiveUIManager.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #NonInteractiveUIManager }
 
-{ #category : #'*Monticello' }
+{ #category : #'*Monticello-GUI-Diff' }
 NonInteractiveUIManager >> merge: merger informing: aString [
 	"Check for conflicts, if there are none, just continue. 
 	 Merger will accept all conflicts"

--- a/src/Monticello-GUI-Diff/PSMCChangeWrapper.class.st
+++ b/src/Monticello-GUI-Diff/PSMCChangeWrapper.class.st
@@ -4,7 +4,7 @@ Abstract superclass for changes wrapper (for patch tree)
 Class {
 	#name : #PSMCChangeWrapper,
 	#superclass : #ListItemWrapper,
-	#category : #'Tool-Diff-Wrapper'
+	#category : #'Monticello-GUI-Diff'
 }
 
 { #category : #accessing }

--- a/src/Monticello-GUI-Diff/PSMCChangesGrouper.class.st
+++ b/src/Monticello-GUI-Diff/PSMCChangesGrouper.class.st
@@ -11,7 +11,7 @@ Class {
 		'currentOperation',
 		'classChanges'
 	],
-	#category : #'Tool-Diff-Utilities'
+	#category : #'Monticello-GUI-Diff'
 }
 
 { #category : #'helper methods' }

--- a/src/Monticello-GUI-Diff/PSMCClassChangeWrapper.class.st
+++ b/src/Monticello-GUI-Diff/PSMCClassChangeWrapper.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'contents'
 	],
-	#category : #'Tool-Diff-Wrapper'
+	#category : #'Monticello-GUI-Diff'
 }
 
 { #category : #accessing }

--- a/src/Monticello-GUI-Diff/PSMCMergeMorph.class.st
+++ b/src/Monticello-GUI-Diff/PSMCMergeMorph.class.st
@@ -9,7 +9,7 @@ Class {
 		'codeMorph',
 		'merged'
 	],
-	#category : #'Tool-Diff-Morphs'
+	#category : #'Monticello-GUI-Diff'
 }
 
 { #category : #'instance creation' }

--- a/src/Monticello-GUI-Diff/PSMCMergePatchMorph.class.st
+++ b/src/Monticello-GUI-Diff/PSMCMergePatchMorph.class.st
@@ -4,7 +4,7 @@ Display Monticello merge patchs
 Class {
 	#name : #PSMCMergePatchMorph,
 	#superclass : #PSMCPatchMorph,
-	#category : #'Tool-Diff-Morphs'
+	#category : #'Monticello-GUI-Diff'
 }
 
 { #category : #accessing }

--- a/src/Monticello-GUI-Diff/PSMCOrganizationChangeWrapper.class.st
+++ b/src/Monticello-GUI-Diff/PSMCOrganizationChangeWrapper.class.st
@@ -4,5 +4,5 @@ Wrapper for changes on organization
 Class {
 	#name : #PSMCOrganizationChangeWrapper,
 	#superclass : #PSMCPatchOperationWrapper,
-	#category : #'Tool-Diff-Wrapper'
+	#category : #'Monticello-GUI-Diff'
 }

--- a/src/Monticello-GUI-Diff/PSMCPatchMorph.class.st
+++ b/src/Monticello-GUI-Diff/PSMCPatchMorph.class.st
@@ -12,7 +12,7 @@ Class {
 	#classVars : [
 		'UsedByDefault'
 	],
-	#category : #'Tool-Diff-Morphs'
+	#category : #'Monticello-GUI-Diff'
 }
 
 { #category : #settings }

--- a/src/Monticello-GUI-Diff/PSMCPatchOperationWrapper.class.st
+++ b/src/Monticello-GUI-Diff/PSMCPatchOperationWrapper.class.st
@@ -4,7 +4,7 @@ Wrapper for patch operations
 Class {
 	#name : #PSMCPatchOperationWrapper,
 	#superclass : #PSMCChangeWrapper,
-	#category : #'Tool-Diff-Wrapper'
+	#category : #'Monticello-GUI-Diff'
 }
 
 { #category : #converting }

--- a/src/Monticello-GUI-Diff/UIManager.extension.st
+++ b/src/Monticello-GUI-Diff/UIManager.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #UIManager }
+
+{ #category : #'*Monticello-GUI-Diff' }
+UIManager >> merge: merger informing: aString [
+
+	self subclassResponsibility
+]

--- a/src/Monticello-GUI-Diff/package.st
+++ b/src/Monticello-GUI-Diff/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Monticello-GUI-Diff' }

--- a/src/Monticello/RPackageOrganizer.extension.st
+++ b/src/Monticello/RPackageOrganizer.extension.st
@@ -1,15 +1,15 @@
 Extension { #name : #RPackageOrganizer }
 
 { #category : #'*Monticello-RPackage' }
-RPackageOrganizer >> allManagers [
-
-	^ self class allManagers 
-]
-
-{ #category : #'*Monticello-RPackage' }
 RPackageOrganizer class >> allManagers [
 
 	^ MCWorkingCopy allManagers
+]
+
+{ #category : #'*Monticello-RPackage' }
+RPackageOrganizer >> allManagers [
+
+	^ self class allManagers 
 ]
 
 { #category : #'*Monticello-RPackage' }

--- a/src/Polymorph-Widgets/MorphicUIManager.class.st
+++ b/src/Polymorph-Widgets/MorphicUIManager.class.st
@@ -424,21 +424,6 @@ Here are some suggestions:
 '
 ]
 
-{ #category : #'ui requests' }
-MorphicUIManager >> merge: merger informing: aString [
-
-	| mergeMorph  window |
-	mergeMorph := PSMCMergeMorph forMerger: merger.
-	mergeMorph
-		fromDescription: 'Working copy' translated;
-		toDescription: aString.
-	window := mergeMorph newWindow
-		title: aString;
-		yourself.
-	window openModal.
-	^ mergeMorph merged
-]
-
 { #category : #accessing }
 MorphicUIManager >> modalMorph [
 	"Answer the morph that should be used to handle modality."

--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -155,7 +155,7 @@ SystemDependenciesTest >> knownMorphicCoreDependencies [
 SystemDependenciesTest >> knownMorphicDependencies [
 	"ideally this list should be empty"
 
-	^ #(#'Refactoring-Critics' #'Refactoring-Environment' #'Spec2-Core' #'Tool-Diff' #'Tool-FileList' #'Tool-Profilers'
+	^ #(#'Refactoring-Critics' #'Refactoring-Environment' #'Spec2-Core' #'Tool-FileList' #'Tool-Profilers'
 	#'Athens-Morphic' #'Tools-CodeNavigation' "Rubric has a dependency on It" 'Debugger-Oups')
 ]
 

--- a/src/Tool-ExternalBrowser/ExternalChangesBrowser.class.st
+++ b/src/Tool-ExternalBrowser/ExternalChangesBrowser.class.st
@@ -198,7 +198,7 @@ ExternalChangesBrowser >> compareToCurrent: aMethodDeclaration [
 	sourceString := (class >> aMethodDeclaration methodSelector) sourceCode.
 
 	self
-		openComparisonFrom: aMethodDeclaration contents
+		openPolymorphComparisonFrom: aMethodDeclaration contents
 		to: sourceString
 		belongingTo: class
 		from: aMethodDeclaration
@@ -268,48 +268,15 @@ ExternalChangesBrowser >> initializeWindow: aWindow [
 ]
 
 { #category : #private }
-ExternalChangesBrowser >> openComparisonFrom: targetMethodSource
-					to: originalMethodSource
-					belongingTo: aClass
-					from: aChange
-					labeled: aLabel
-					inWindowLabeled: aWindowLabel [
-
-	| diffBuilder difference  |
-
-	PSMCPatchMorph usedByDefault
-		ifTrue: [ ^ self openPolymorphComparisonFrom: originalMethodSource
-					to: targetMethodSource
-					belongingTo: aClass
-					from: aChange
-					labeled: aLabel
-					inWindowLabeled: aWindowLabel   ].
-
-	diffBuilder :=  TextDiffBuilder
-			from: originalMethodSource
-			to: targetMethodSource.
-
-	difference := diffBuilder buildDisplayPatch.
-
-	UIManager default edit: difference label: aLabel
-]
-
-{ #category : #private }
-ExternalChangesBrowser >> openPolymorphComparisonFrom: targetMethodSource
-					to: originalMethodSource
-					belongingTo: aClass
-					from: aChange
-					labeled: aLabel
-					inWindowLabeled: aWindowLabel [
+ExternalChangesBrowser >> openPolymorphComparisonFrom: targetMethodSource to: originalMethodSource belongingTo: aClass from: aChange labeled: aLabel inWindowLabeled: aWindowLabel [
 
 	| diffMorph |
-
 	diffMorph := DiffChangeMorph
-		from: targetMethodSource
-		label: aChange stamp
-		to: originalMethodSource
-		label: (aClass compiledMethodAt: aChange methodSelector) timeStamp
-		contextClass: aClass.
+		             from: targetMethodSource
+		             label: aChange stamp
+		             to: originalMethodSource
+		             label: (aClass compiledMethodAt: aChange methodSelector) timeStamp
+		             contextClass: aClass.
 
 	diffMorph openInWindowLabeled: aWindowLabel
 ]

--- a/src/UIManager/DummyUIManager.class.st
+++ b/src/UIManager/DummyUIManager.class.st
@@ -94,10 +94,6 @@ DummyUIManager >> lowSpaceWatcherDefaultAction [
 ]
 
 { #category : #'ui requests' }
-DummyUIManager >> merge: merger informing: aString [
-]
-
-{ #category : #'ui requests' }
 DummyUIManager >> multiLineRequest: queryString initialAnswer: defaultAnswer answerHeight: answerHeight [
 ]
 

--- a/src/UIManager/UIManager.class.st
+++ b/src/UIManager/UIManager.class.st
@@ -486,12 +486,6 @@ UIManager >> lowSpaceWatcherDefaultAction: preemptedProcess [
 ]
 
 { #category : #'ui requests' }
-UIManager >> merge: merger informing: aString [
-
-	self subclassResponsibility
-]
-
-{ #category : #'ui requests' }
 UIManager >> multiLineRequest: queryString initialAnswer: defaultAnswer answerHeight: answerHeight [
 	"Create a multi-line instance of me whose question is queryString with
 	 the given initial answer. Invoke it centered at the given point, and


### PR DESCRIPTION
Alternative to #14062

The package Tool-Diff implements morphs to do diffs. But it also contains all the code of the diffs of Monticello. IMO this is not the place of this code so I'm proposing to move the Diff code specific to Monticello in Monticello-GUI-Diff