### PR TITLE
Simplify ClyMethodEditorToolMorph

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
@@ -254,10 +254,11 @@ ClyMethodCodeEditorToolMorph >> methodClass [
 ]
 
 { #category : #accessing }
-ClyMethodCodeEditorToolMorph >> methodTags: tagsArray [
-	super methodTags: tagsArray.
+ClyMethodCodeEditorToolMorph >> methodProtocol: protocolName [
 
-	self hasUnacceptedEdits ifFalse: [ self tagEditingMethod: editingMethod]
+	super methodProtocol: protocolName.
+
+	self hasUnacceptedEdits ifFalse: [ self tagEditingMethod: editingMethod ]
 ]
 
 { #category : #testing }
@@ -380,6 +381,6 @@ ClyMethodCodeEditorToolMorph >> update [
 { #category : #updating }
 ClyMethodCodeEditorToolMorph >> updateMethodTagsAndPackage [
 
-	methodTags := editingMethod tags reject: [ :each | each beginsWith: '*' ].
-	extendingPackage := editingMethod isExtension ifTrue: [ editingMethod package ] ifFalse: [ nil ]
+	self methodProtocol: editingMethod protocolName.
+	editingMethod isExtension ifTrue: [ extendingPackage := editingMethod package ]
 ]

--- a/src/Calypso-SystemTools-Core/ClyMethodCreationToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodCreationToolMorph.class.st
@@ -42,16 +42,13 @@ ClyMethodCreationToolMorph >> applyChanges [
 	| newMethod selector selectedClass |
 	selectedClass := self chooseClassForNewMethodIfNone: [^false].
 
-	selector := methodTags
-		ifEmpty: [ selectedClass compile: self pendingText asString notifying: textMorph]
-		ifNotEmpty: [
-			selectedClass compile: self pendingText asString classified: methodTags anyOne notifying: textMorph].
+	selector := selectedClass compile: self pendingText asString classified: methodProtocol notifying: textMorph.
 
 	selector ifNil: [ ^false ].
 
 	newMethod := selectedClass >> selector.
-	MethodClassifier classify: newMethod fallbackProtocol: (methodTags ifEmpty: [ nil ] ifNotEmpty: [ :tags | tags anyOne]).
-	methodTags := newMethod tags.
+	MethodClassifier classify: newMethod fallbackProtocol: methodProtocol.
+	methodProtocol := newMethod protocolName.
 	self tagAndPackageEditingMethod: newMethod.
 
 	self removeFromBrowser.
@@ -98,7 +95,7 @@ ClyMethodCreationToolMorph >> isSimilarTo: anotherBrowserTool [
 	(super isSimilarTo: anotherBrowserTool) ifFalse: [ ^false ].
 
 	^methodClass == anotherBrowserTool methodClass
-		and: [ methodTags = anotherBrowserTool methodTags
+		and: [ methodProtocol = anotherBrowserTool methodProtocol
 				and: [ extendingPackage = anotherBrowserTool extendingPackage ] ]
 ]
 
@@ -126,16 +123,15 @@ ClyMethodCreationToolMorph >> restoreBrowserState [
 
 { #category : #initialization }
 ClyMethodCreationToolMorph >> setUpModelFromContext [
+
 	| selectedGroup |
 	super setUpModelFromContext.
 
 	methodClass := context selectedClassSide.
-	context isMethodGroupSelected ifFalse: [ ^self].
+	context isMethodGroupSelected ifFalse: [ ^ self ].
 	selectedGroup := context lastSelectedMethodGroup.
-	(selectedGroup isKindOf: ClyExternalPackageMethodGroup) ifTrue: [
-		^extendingPackage := selectedGroup package].
-	(selectedGroup isKindOf: ClyTaggedMethodGroup) ifTrue: [
-		^methodTags := {selectedGroup tag}]
+	(selectedGroup isKindOf: ClyExternalPackageMethodGroup) ifTrue: [ ^ extendingPackage := selectedGroup package ].
+	(selectedGroup isKindOf: ClyTaggedMethodGroup) ifTrue: [ ^ methodProtocol := selectedGroup tag ]
 ]
 
 { #category : #initialization }

--- a/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
@@ -20,14 +20,14 @@ Internal Representation and Key Implementation Points.
 
     Instance Variables
 	extendingPackage:		<RPackage>
-	methodTags:		<Array of<Symbol>>
+	methodProtocol:		<Symbol> represents the name of the method protocol
 "
 Class {
 	#name : #ClyMethodEditorToolMorph,
 	#superclass : #ClyTextEditorToolMorph,
 	#instVars : [
 		'ast',
-		'methodTags',
+		'methodProtocol',
 		'extendingPackage',
 		'targetClasses'
 	],
@@ -106,8 +106,9 @@ ClyMethodEditorToolMorph >> extendingPackage [
 
 { #category : #accessing }
 ClyMethodEditorToolMorph >> extendingPackage: aPackage [
+
 	extendingPackage := aPackage.
-	methodTags := #()
+	methodProtocol := nil
 ]
 
 { #category : #building }
@@ -138,13 +139,6 @@ ClyMethodEditorToolMorph >> formatTextIfNeeded [
 ]
 
 { #category : #initialization }
-ClyMethodEditorToolMorph >> initialize [
-	super initialize.
-
-	methodTags := #()
-]
-
-{ #category : #initialization }
 ClyMethodEditorToolMorph >> initializeAST [
 	"subclasses might get it from the method"
 	^ self currentEditedAST
@@ -167,13 +161,15 @@ ClyMethodEditorToolMorph >> methodClass [
 ]
 
 { #category : #accessing }
-ClyMethodEditorToolMorph >> methodTags [
-	^methodTags
+ClyMethodEditorToolMorph >> methodProtocol [
+
+	^ methodProtocol
 ]
 
 { #category : #accessing }
-ClyMethodEditorToolMorph >> methodTags: tagsArray [
-	methodTags := tagsArray.
+ClyMethodEditorToolMorph >> methodProtocol: protocolName [
+
+	methodProtocol := protocolName.
 	extendingPackage := nil
 ]
 
@@ -228,8 +224,7 @@ ClyMethodEditorToolMorph >> tagAndPackageEditingMethod: aMethod [
 { #category : #operations }
 ClyMethodEditorToolMorph >> tagEditingMethod: aMethod [
 
-	self applyChangesBy: [ "In the end we only have at max 1 protocol but for now this class hold a collection. This should be updated in the future."
-		methodTags do: [ :protocolName | aMethod protocol: protocolName ] ]
+	self applyChangesBy: [ aMethod protocol: methodProtocol ]
 ]
 
 { #category : #accessing }

--- a/src/Calypso-SystemTools-Core/ClyMethodTagsAndPackageEditorMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodTagsAndPackageEditorMorph.class.st
@@ -124,9 +124,7 @@ ClyMethodTagsAndPackageEditorMorph >> ownerTool: anObject [
 { #category : #printing }
 ClyMethodTagsAndPackageEditorMorph >> printMethodTags [
 
-	^ownerTool methodTags
-		ifEmpty: [ 'as yet unclassified' asText makeAllColor: Color red ]
-		ifNotEmpty: [ :tags | tags joinUsing: ', ' ]
+	^ ownerTool methodProtocol ifNil: [ Protocol unclassified asText makeAllColor: Color red ]
 ]
 
 { #category : #printing }
@@ -158,19 +156,18 @@ ClyMethodTagsAndPackageEditorMorph >> requestPackage [
 ClyMethodTagsAndPackageEditorMorph >> requestTag [
 
 	| selectedTag existingTag |
-	existingTag := ownerTool methodTags
-		ifEmpty: [ '' ] ifNotEmpty: [ :tags | tags anyOne ].
+	existingTag := ownerTool methodProtocol ifNil: [ '' ].
 
-	selectedTag := self ownerTool context
-		requestSingleMethodTag: 'New protocol name' suggesting: existingTag.
-	selectedTag = existingTag ifTrue: [ ^CmdCommandAborted signal ].
+	selectedTag := self ownerTool context requestSingleMethodTag: 'New protocol name' suggesting: existingTag.
+	selectedTag = existingTag ifTrue: [ ^ CmdCommandAborted signal ].
 
-	ownerTool methodTags: { selectedTag asSymbol }
+	ownerTool methodProtocol: selectedTag
 ]
 
 { #category : #operations }
 ClyMethodTagsAndPackageEditorMorph >> resetTagsAndPackage [
-	ownerTool methodTags: #().
+
+	ownerTool methodProtocol: nil.
 	self update
 ]
 

--- a/src/Calypso-SystemTools-Core/ClyMethodTagsEditorMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodTagsEditorMorph.class.st
@@ -45,14 +45,11 @@ ClyMethodTagsEditorMorph >> build [
 { #category : #operations }
 ClyMethodTagsEditorMorph >> printMethodTags [
 
-	^', ' join: ownerTool methodTags
+	^ ownerTool methodProtocol
 ]
 
 { #category : #operations }
-ClyMethodTagsEditorMorph >> setNewMethodTags: tagsString [
+ClyMethodTagsEditorMorph >> setNewMethodTags: protocolName [
 
-	| tags |
-	tags := (',' split: tagsString) collect: #trimBoth as: Array.
-
-	ownerTool methodTags: (tags reject: #isEmpty)
+	ownerTool methodProtocol: protocolName trimBoth
 ]

--- a/src/Deprecated12/ClyMethodEditorToolMorph.extension.st
+++ b/src/Deprecated12/ClyMethodEditorToolMorph.extension.st
@@ -1,0 +1,17 @@
+Extension { #name : #ClyMethodEditorToolMorph }
+
+{ #category : #'*Deprecated12' }
+ClyMethodEditorToolMorph >> methodTags [
+
+	self deprecated: 'Use #methodProtocol instead but note that it returns a protocol name and not a collection.'.
+	^ { self methodProtocol }
+]
+
+{ #category : #'*Deprecated12' }
+ClyMethodEditorToolMorph >> methodTags: tagsArray [
+
+	self deprecated: 'Use #methodProtocol: instead but be sure to give a protocol name and not a collection.'.
+	self methodProtocol: (tagsArray
+			 ifNotEmpty: [ tagsArray anyOne ]
+			 ifEmpty: [ nil ])
+]


### PR DESCRIPTION
A method can have only one protocol so here is a simplification to manipulate only one protocol instead of a collection.

This also reduces the number of senders of CompiledMethod>>#tags that is to be deprecated.