### PR TITLE
rename ReservedVariable to PseudoVariable 

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -1747,24 +1747,21 @@ RBCodeSnippet class >> badSemantic [
 			         styled: 'XXXXXXXXXXXX';
 			         isFaulty: true;
 			         numberOfCritiques: 1;
-			         notices: #( #( 1 4 1 'Assigment to reserved variable' )
-				            #( 1 4 1 'Assignment to read-only variable' ) )).
+			         notices: #( #( 1 4 1 'Assignment to read-only variable' ) )).
 		        (self new
 			         source: 'super := super';
 			         nodeAt: '22222000011111';
 			         styled: 'XXXXXXXXXXXXXX';
 			         isFaulty: true;
 			         numberOfCritiques: 1;
-			         notices: #( #( 1 5 1 'Assigment to reserved variable' )
-				            #( 1 5 1 'Assignment to read-only variable' ) )).
+			         notices: #( #( 1 5 1 'Assignment to read-only variable' ) )).
 		        (self new
 			         source: 'thisContext := thisContext';
 			         nodeAt: '22222222222000011111111111';
 			         styled: 'XXXXXXXXXXXXXXXXXXXXXXXXXX';
 			         isFaulty: true;
 			         numberOfCritiques: 1;
-			         notices: #( #( 1 11 1 'Assigment to reserved variable' )
-				            #( 1 11 1 'Assignment to read-only variable' ) )).
+			         notices: #( #( 1 11 1 'Assignment to read-only variable' ) )).
 		        (self new
 			         source: 'Object := Object';
 			         nodeAt: '2222220000111111';

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -791,7 +791,7 @@ RBProgramNode >> isPragmaError [
 ]
 
 { #category : #testing }
-RBProgramNode >> isReservedVariable [
+RBProgramNode >> isPseudoVariable [
 	^false
 ]
 

--- a/src/AST-Core/RBVariableNode.class.st
+++ b/src/AST-Core/RBVariableNode.class.st
@@ -163,13 +163,13 @@ RBVariableNode >> isLocalVariable [
 ]
 
 { #category : #testing }
-RBVariableNode >> isRead [
-	^ self isWrite not and: [ self isUsed ]
+RBVariableNode >> isPseudoVariable [
+	^ variable isPseudoVariable
 ]
 
 { #category : #testing }
-RBVariableNode >> isReservedVariable [
-	^ variable isReservedVariable
+RBVariableNode >> isRead [
+	^ self isWrite not and: [ self isUsed ]
 ]
 
 { #category : #testing }

--- a/src/Kernel/DoItVariable.class.st
+++ b/src/Kernel/DoItVariable.class.st
@@ -135,8 +135,8 @@ DoItVariable >> isLocalVariable [
 ]
 
 { #category : #testing }
-DoItVariable >> isReservedVariable [
-	^actualVariable isReservedVariable
+DoItVariable >> isPseudoVariable [
+	^actualVariable isPseudoVariable
 ]
 
 { #category : #testing }

--- a/src/Kernel/PseudoVariable.class.st
+++ b/src/Kernel/PseudoVariable.class.st
@@ -1,8 +1,8 @@
 "
-I model self, thisContext and super
+I model self, super, thisContext, and thisProcess
 "
 Class {
-	#name : #ReservedVariable,
+	#name : #PseudoVariable,
 	#superclass : #Variable,
 	#instVars : [
 		'environment'
@@ -11,18 +11,18 @@ Class {
 }
 
 { #category : #accessing }
-ReservedVariable class >> instance [
+PseudoVariable class >> instance [
 	self deprecated: 'use new to get a new instance or #lookupVar: for the shared instance'.
 	^self new.
 ]
 
 { #category : #testing }
-ReservedVariable class >> isAbstract [
-	^self = ReservedVariable
+PseudoVariable class >> isAbstract [
+	^self = PseudoVariable
 ]
 
 { #category : #compiler }
-ReservedVariable class >> lookupDictionary [
+PseudoVariable class >> lookupDictionary [
 	"create a loopup table name -> instance for Semantic Analysis"
 
 	^ (self subclasses collect: [ :class |
@@ -32,69 +32,69 @@ ReservedVariable class >> lookupDictionary [
 ]
 
 { #category : #accessing }
-ReservedVariable class >> variableName [
+PseudoVariable class >> variableName [
 	^self subclassResponsibility
 ]
 
 { #category : #converting }
-ReservedVariable >> asDoItVariableFrom: aContext [
+PseudoVariable >> asDoItVariableFrom: aContext [
 	^ DoItVariable fromContext: aContext variable: self
 ]
 
 { #category : #converting }
-ReservedVariable >> asString [
+PseudoVariable >> asString [
 
 	^ self name
 ]
 
 { #category : #'code generation' }
-ReservedVariable >> emitStore: methodBuilder [
+PseudoVariable >> emitStore: methodBuilder [
 
 	self shouldNotImplement
 ]
 
 { #category : #initialization }
-ReservedVariable >> initialize [
+PseudoVariable >> initialize [
 	environment := Smalltalk globals.
 	name := self class variableName
 ]
 
 { #category : #testing }
-ReservedVariable >> isReservedVariable [
+PseudoVariable >> isPseudoVariable [
 	^true
 ]
 
 { #category : #testing }
-ReservedVariable >> isWritable [
+PseudoVariable >> isWritable [
 	^ false
 ]
 
 { #category : #accessing }
-ReservedVariable >> name: aSymbol [
+PseudoVariable >> name: aSymbol [
 	"names of ReservedVariables are fixed and can not be changed"
 	self shouldNotImplement
 ]
 
 { #category : #printing }
-ReservedVariable >> printOn: stream [
+PseudoVariable >> printOn: stream [
 
 	stream nextPutAll: self name
 ]
 
 { #category : #accessing }
-ReservedVariable >> scope [
+PseudoVariable >> scope [
 	^ environment
 ]
 
 { #category : #queries }
-ReservedVariable >> usingMethods [
+PseudoVariable >> usingMethods [
 	"first call is very slow as it creates all ASTs"
 	^environment allMethods select: [ : method |
 		method ast variableNodes anySatisfy: [ :varNode | varNode variable == self]]
 ]
 
 { #category : #debugging }
-ReservedVariable >> write: aValue inContext: aContext [
+PseudoVariable >> write: aValue inContext: aContext [
 
 	self error: name, ' is reserved word and cant be modified'
 ]

--- a/src/Kernel/SelfVariable.class.st
+++ b/src/Kernel/SelfVariable.class.st
@@ -1,9 +1,9 @@
 "
-I model ""self"" keyword 
+I model ""self""
 "
 Class {
 	#name : #SelfVariable,
-	#superclass : #ReservedVariable,
+	#superclass : #PseudoVariable,
 	#category : #'Kernel-Variables'
 }
 

--- a/src/Kernel/SuperVariable.class.st
+++ b/src/Kernel/SuperVariable.class.st
@@ -1,9 +1,9 @@
 "
-I model ""super"" keyword
+I model ""super""
 "
 Class {
 	#name : #SuperVariable,
-	#superclass : #ReservedVariable,
+	#superclass : #PseudoVariable,
 	#category : #'Kernel-Variables'
 }
 

--- a/src/Kernel/ThisContextVariable.class.st
+++ b/src/Kernel/ThisContextVariable.class.st
@@ -1,9 +1,9 @@
 "
-I model thisContext keyword
+I model thisContext
 "
 Class {
 	#name : #ThisContextVariable,
-	#superclass : #ReservedVariable,
+	#superclass : #PseudoVariable,
 	#category : #'Kernel-Variables'
 }
 

--- a/src/Kernel/ThisProcessVariable.class.st
+++ b/src/Kernel/ThisProcessVariable.class.st
@@ -1,9 +1,9 @@
 "
-I model thisProcess keyword
+I model thisProcess
 "
 Class {
 	#name : #ThisProcessVariable,
-	#superclass : #ReservedVariable,
+	#superclass : #PseudoVariable,
 	#category : #'Kernel-Variables'
 }
 

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -184,6 +184,12 @@ Variable >> isPoolVariable [
 ]
 
 { #category : #testing }
+Variable >> isPseudoVariable [
+	"thisContext, super, self are reserved variables (true, false and nil are literals)"
+	^false
+]
+
+{ #category : #testing }
 Variable >> isReadIn: aCompiledCode [
 	^aCompiledCode ast readNodes
 		 anySatisfy: [ :node | node binding == self ]
@@ -192,12 +198,6 @@ Variable >> isReadIn: aCompiledCode [
 { #category : #testing }
 Variable >> isReferenced [
 	^ self usingMethods isNotEmpty
-]
-
-{ #category : #testing }
-Variable >> isReservedVariable [
-	"thisContext, super, self are reserved variables (true, false and nil are literals)"
-	^false
 ]
 
 { #category : #testing }

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -135,7 +135,7 @@ OCASTSemanticAnalyzer >> scope: aSemScope [
 { #category : #'error handling' }
 OCASTSemanticAnalyzer >> shadowing: var withVariable: aNode [
 
-	var isReservedVariable
+	var isPseudoVariable
 		ifTrue: [ self error: 'Reserved variable name' forNode: aNode ]
 		ifFalse: [ aNode addWarning: 'Name already defined' ]
 ]
@@ -144,12 +144,6 @@ OCASTSemanticAnalyzer >> shadowing: var withVariable: aNode [
 OCASTSemanticAnalyzer >> storeIntoReadOnlyVariable: variableNode [
 
 	variableNode addError: 'Assignment to read-only variable'
-]
-
-{ #category : #'error handling' }
-OCASTSemanticAnalyzer >> storeIntoReservedVariable: variableNode [
-
-	variableNode addError: 'Assigment to reserved variable'
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/Variable.extension.st
+++ b/src/OpalCompiler-Core/Variable.extension.st
@@ -9,7 +9,5 @@ Variable >> analyzeRead: aVariableNode by: aSemanticAnalyzer [
 { #category : #'*OpalCompiler-Core' }
 Variable >> analyzeWrite: aVariableNode by: aSemanticAnalyzer [
 
-	self isReservedVariable ifTrue: [ aSemanticAnalyzer storeIntoReservedVariable: aVariableNode ].
-
 	self isWritable ifFalse: [ aSemanticAnalyzer storeIntoReadOnlyVariable: aVariableNode ]
 ]

--- a/src/OpalCompiler-Tests/OCCompilerNotifyingTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerNotifyingTest.class.st
@@ -115,7 +115,7 @@ OCCompilerNotifyingTest >> setUpForErrorsIn: aTextWithErrorsEnclosedInBackQuote 
 { #category : #tests }
 OCCompilerNotifyingTest >> testAssignmentOfSelf [
 
-	self setUpForErrorsIn: '` Assigment to reserved variable ->`self := 1. ^self'.
+	self setUpForErrorsIn: '` Assignment to read-only variable ->`self := 1. ^self'.
 	self enumerateAllSelections
 ]
 

--- a/src/Ring-Core/RGEnvironment.class.st
+++ b/src/Ring-Core/RGEnvironment.class.st
@@ -89,7 +89,7 @@ RGEnvironment >> bindingOf: aSymbol [
 
 	| behavior result |
 
-	ReservedVariable lookupDictionary at: aSymbol ifPresent: [ :val | ^ val ].
+	PseudoVariable lookupDictionary at: aSymbol ifPresent: [ :val | ^ val ].
 	self globalVariablesBindings at: aSymbol ifPresent: [ :val | ^ val ].
 
 	self ask globalVariables detect: [ :each | each name = aSymbol  ] ifFound: [ :found |

--- a/src/Ring-Core/RGVariable.class.st
+++ b/src/Ring-Core/RGVariable.class.st
@@ -64,7 +64,7 @@ RGVariable >> isPoolVariable [
 ]
 
 { #category : #testing }
-RGVariable >> isReservedVariable [
+RGVariable >> isPseudoVariable [
 	"Ring2 does not model self, super, thisContext"
 	^false
 ]

--- a/src/Shout/PseudoVariable.extension.st
+++ b/src/Shout/PseudoVariable.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #PseudoVariable }
+
+{ #category : #'*Shout' }
+PseudoVariable >> styleNameIn: aRBVariableNode [
+
+	^ self class variableName
+]

--- a/src/Shout/ReservedVariable.extension.st
+++ b/src/Shout/ReservedVariable.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #ReservedVariable }
-
-{ #category : #'*Shout' }
-ReservedVariable >> styleNameIn: aRBVariableNode [
-
-	^ self class variableName
-]

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -218,7 +218,7 @@ SystemDictionary >> hasBindingThatBeginsWith: aString [
 	"Use the cached class and non-class names for better performance."
 
 	| name searchBlock |
-	(self reservedVariables hasBindingThatBeginsWith: aString) ifTrue: [
+	(self pseudoVariables hasBindingThatBeginsWith: aString) ifTrue: [
 		^ true ].
 	searchBlock := [ :element |
 	               (element beginsWith: aString)
@@ -257,7 +257,7 @@ SystemDictionary >> hasClassOrTraitNamed: aString [
 { #category : #'accessing - variable lookup' }
 SystemDictionary >> lookupVar: name [
 	"Return a var with this name.  Return nil if none found"
-	^self reservedVariables at: name ifAbsent: [self bindingOf: name]
+	^self pseudoVariables at: name ifAbsent: [self bindingOf: name]
 ]
 
 { #category : #'accessing - system attributes' }
@@ -332,6 +332,14 @@ SystemDictionary >> poolUsers [
 SystemDictionary >> printElementsOn: aStream [
 
 	aStream nextPutAll: '(lots of globals)'
+]
+
+{ #category : #'accessing - variable lookup' }
+SystemDictionary >> pseudoVariables [
+	"We cache the variables for speed"
+
+	^ reservedVariables ifNil: [
+		  reservedVariables := PseudoVariable lookupDictionary ]
 ]
 
 { #category : #'accessing - classes and traits' }
@@ -410,14 +418,6 @@ SystemDictionary >> renameClassNamed: oldName as: newName [
 			, ' does not exist.'.
 		^ self ].
 	oldClass rename: newName
-]
-
-{ #category : #'accessing - variable lookup' }
-SystemDictionary >> reservedVariables [
-	"We cache the variables for speed"
-
-	^ reservedVariables ifNil: [
-		  reservedVariables := ReservedVariable lookupDictionary ]
 ]
 
 { #category : #'accessing - variable lookup' }


### PR DESCRIPTION
- rename ReservedVariable to PseudoVariable to be in sync with how wecall them

- test method is #isPseudoVariable
- do not check specially for storing: they are read-only, not reserved

This PR does not change the ivar in SystemDictionary (for later), it keep the hard error for shadowing for now

No deprecation needed as this is internal, not public API