### PR TITLE
Decouple Monticello and RPackage on package removal

### DIFF
--- a/src/Monticello/MCWorkingCopy.class.st
+++ b/src/Monticello/MCWorkingCopy.class.st
@@ -288,24 +288,27 @@ MCWorkingCopy class >> methodRemoved: anEvent [
 { #category : #'system changes' }
 MCWorkingCopy class >> packageAdded: anAnnouncement [
 
-	self ensureForPackageNamed: anAnnouncement package name packageOrganizer: anAnnouncement package organizer
+	^ self ensureForPackageNamed: anAnnouncement package name packageOrganizer: anAnnouncement package organizer
+]
+
+{ #category : #'system changes' }
+MCWorkingCopy class >> packageRemoved: anAnnouncement [
+
+	anAnnouncement package mcWorkingCopy ifNotNil: [ :wc | wc unregister ]
 ]
 
 { #category : #'system changes' }
 MCWorkingCopy class >> packageRenamed: anAnnouncement [
 
-	| repositoryGroup |
-	repositoryGroup := (self forPackageNamed: anAnnouncement oldName) repositoryGroup.
+	| oldWorkingCopy |
+	oldWorkingCopy := self forPackageNamed: anAnnouncement oldName.
 
-	"Let's make sure we have a working copy for this new package"
-	self packageAdded: anAnnouncement.
+	"Let's make sure we have a working copy for this new package and unregister the old one."
+	(self packageAdded: anAnnouncement)
+		modified: true;
+		repositoryGroup: oldWorkingCopy repositoryGroup.
 
-	self allManagers
-		detect: [ :each | each packageName = anAnnouncement newName ]
-		ifFound: [ :newPackage | newPackage modified: true ].
-	(self allManagers detect: [ :each | each packageName = anAnnouncement oldName ]) unload.
-
-	anAnnouncement package mcWorkingCopy repositoryGroup: repositoryGroup
+	oldWorkingCopy unload
 ]
 
 { #category : #'event registration' }
@@ -319,16 +322,18 @@ MCWorkingCopy class >> registerForNotifications [
 
 { #category : #'event registration' }
 MCWorkingCopy class >> registerInterestOnSystemChangesOnAnnouncer: anAnnouncer [
+
 	anAnnouncer weak
 		when: PackageAdded send: #packageAdded: to: self;
 		when: PackageRenamed send: #packageRenamed: to: self;
-		when: ClassAdded, ClassModifiedClassDefinition, ClassCommented , ClassParentRenamed send: #classModified: to: self;
-		when: ClassRenamed send:#classRenamed: to:self;
+		when: PackageRemoved send: #packageRemoved: to: self;
+		when: ClassAdded , ClassModifiedClassDefinition , ClassCommented , ClassParentRenamed send: #classModified: to: self;
+		when: ClassRenamed send: #classRenamed: to: self;
 		when: ClassRepackaged send: #classMoved: to: self;
 		when: ClassRemoved send: #classRemoved: to: self;
-		when: MethodAdded, MethodModified, MethodRecategorized send: #methodModified: to: self;
+		when: MethodAdded , MethodModified , MethodRecategorized send: #methodModified: to: self;
 		when: MethodRepackaged send: #methodMoved: to: self;
-		when: MethodRemoved send: #methodRemoved: to: self.
+		when: MethodRemoved send: #methodRemoved: to: self
 ]
 
 { #category : #private }

--- a/src/Monticello/RPackage.extension.st
+++ b/src/Monticello/RPackage.extension.st
@@ -23,9 +23,8 @@ RPackage >> mcPackage [
 
 { #category : #'*Monticello-RPackage' }
 RPackage >> mcWorkingCopy [
-	
-	^ MCWorkingCopy allManagers 
-		detect: [ :each | each package name = name ]
-		ifNone: [ nil ].
-	
+
+	^ (MCWorkingCopy hasPackageNamed: name)
+		  ifTrue: [ MCWorkingCopy forPackageNamed: name ]
+		  ifFalse: [ nil ]
 ]

--- a/src/Monticello/RPackageOrganizer.extension.st
+++ b/src/Monticello/RPackageOrganizer.extension.st
@@ -1,15 +1,15 @@
 Extension { #name : #RPackageOrganizer }
 
 { #category : #'*Monticello-RPackage' }
-RPackageOrganizer class >> allManagers [
-
-	^ MCWorkingCopy allManagers
-]
-
-{ #category : #'*Monticello-RPackage' }
 RPackageOrganizer >> allManagers [
 
 	^ self class allManagers 
+]
+
+{ #category : #'*Monticello-RPackage' }
+RPackageOrganizer class >> allManagers [
+
+	^ MCWorkingCopy allManagers
 ]
 
 { #category : #'*Monticello-RPackage' }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -233,12 +233,7 @@ RPackageOrganizer >> basicRegisterPackage: aPackage [
 RPackageOrganizer >> basicUnregisterPackageNamed: aPackageName [
 	"Unregister the specified package from the list of registered packages. Raise the RPackageUnregistered announcement. This is a low level action. It does not unregister the back pointer from classes to packages or any other information managed by the organizer"
 
-	| package |
-	package := packages removeKey: aPackageName ifAbsent: [ ^ self reportExtraRemovalOf: aPackageName ].
-
-	"unregister also mc package"
-	self flag: #hack. "for decoupling MC"
-	self class environment at: #MCWorkingCopy ifPresent: [ package mcPackage ifNotNil: [ :mcPackage | mcPackage workingCopy unregister ] ]
+	^ packages removeKey: aPackageName ifAbsent: [ self reportExtraRemovalOf: aPackageName ]
 ]
 
 { #category : #'deprecated - SystemOrganizer leftovers' }
@@ -976,7 +971,7 @@ RPackageOrganizer >> systemCategoryRemovedActionFrom: ann [
 	categoryNameSymbol := categoryName asSymbol.
 	self flag: #hack. "for decoupling MC"
 	managers := (self respondsTo: #allManagers)
-		            ifTrue: [ self perform: #allManagers ]
+		            ifTrue: [ self allManagers ]
 		            ifFalse: [ #(  ) ].
 	"Reverse the test. First check that this is the root category of a RPackage. If yes, unregister the RPackage and the corresponding MCWorkingCopy."
 	rPackage := packages at: categoryNameSymbol ifAbsent: [ ^ self ].


### PR DESCRIPTION
Move Monticello unregistering code to Monticello. I also simplified the renaming code.