### PR TITLE
ClassBuilder: reduce the need of #asSlotCollection and  #asTraitComposition

### DIFF
--- a/src/FluidClassBuilder/FluidBuilder.class.st
+++ b/src/FluidClassBuilder/FluidBuilder.class.st
@@ -112,7 +112,7 @@ FluidBuilder >> fillShiftClassBuilder [
 		name: nameToBuild.
 
 	shiftClassBuilder slots: slotsToBuild.
-	shiftClassBuilder traitComposition: uses asTraitComposition.
+	shiftClassBuilder traitComposition: uses.
 
 	(tagToBuild isNil or: [ tagToBuild isEmpty ])
 		ifTrue: [ shiftClassBuilder category: packageName ]

--- a/src/Fuel-Platform-Pharo-Core/FLPharoPlatform.class.st
+++ b/src/Fuel-Platform-Pharo-Core/FLPharoPlatform.class.st
@@ -81,9 +81,9 @@ FLPharoPlatform >> newSubclassOf: aClass named: className uses: aTraitCompositio
 			environment: anEnvironment;
 			name: className;
 			superclass: aClass;
-			traitComposition: aTraitComposition asTraitComposition;
+			traitComposition: aTraitComposition;
 			classTraitComposition: aTraitComposition asTraitComposition classComposition;
-			slots: ivNamesString asSlotCollection;
+			slotsFromString: ivNamesString;
 			sharedVariablesFromString: classVarsString;
 			sharedPools: poolNamesString;
 			package: packageName ]
@@ -95,8 +95,8 @@ FLPharoPlatform >> newTraitNamed: aString uses: aTraitComposition instanceVariab
 		aBuilder
 			environment: anEnvironment;
 			name: aString;
-			slots: iVarString asSlotCollection;
-			traitComposition: aTraitComposition asTraitComposition;
+			slotsFromString: iVarString;
+			traitComposition: aTraitComposition;
 			package: packageName;
 			beTrait ]
 ]

--- a/src/Kernel-Tests-Extended/ClassTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassTest.class.st
@@ -529,7 +529,7 @@ ClassTest >> testSubclassInstanceVariableNames [
 	cls := self class classInstaller make: [ :aBuilder |
 		aBuilder
 			name: #SubclassExample;
-			slots: 'x y' asSlotCollection].
+			slotsFromString: 'x y'].
 
 	self assert: (testEnvironment includesKey: #SubclassExample).
 

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -628,7 +628,7 @@ Class >> ephemeronSubclass: className instanceVariableNames: instVarNameList cla
 					superclass: self;
 					name: className;
 					layoutClass: EphemeronLayout;
-					slots: instVarNameList asSlotCollection;
+					slotsFromString: instVarNameList;
 					sharedVariablesFromString: classVarNames;
 					category: cat;
 					environment: self environment ]
@@ -642,7 +642,7 @@ Class >> ephemeronSubclass: t instanceVariableNames: f classVariableNames: d poo
 			  superclass: self;
 			  name: t;
 			  layoutClass: EphemeronLayout;
-			  slots: f asSlotCollection;
+			  slotsFromString: f;
 			  sharedVariablesFromString: d;
 			  sharedPools: s;
 			  category: cat;
@@ -659,7 +659,7 @@ Class >> ephemeronSubclass: t instanceVariableNames: f classVariableNames: d poo
 				superclass: self;
 				name: t;
 				layoutClass: EphemeronLayout;
-				slots: f asSlotCollection;
+				slotsFromString: f;
 				sharedVariablesFromString: d;
 				sharedPools: s;
 				category: cat;
@@ -759,7 +759,7 @@ Class >> immediateSubclass: className instanceVariableNames: instVarNameList cla
 			superclass: self;
 			name: className;
 			layoutClass: ImmediateLayout;
-			slots: instVarNameList asSlotCollection;
+			slotsFromString: instVarNameList;
 			sharedVariablesFromString: classVarNames;
 			category: cat;
 			environment: self environment ]
@@ -772,7 +772,7 @@ Class >> immediateSubclass: t instanceVariableNames: f classVariableNames: d poo
 			superclass: self;
 			name: t;
 			layoutClass: ImmediateLayout;
-			slots: f asSlotCollection;
+			slotsFromString: f;
 			sharedVariablesFromString: d;
 			sharedPools: s;
 			category: cat;
@@ -790,7 +790,7 @@ Class >> immediateSubclass: t instanceVariableNames: f classVariableNames: d poo
 			superclass: self;
 			name: t;
 			layoutClass: ImmediateLayout;
-			slots: f asSlotCollection;
+			slotsFromString: f;
 			sharedVariablesFromString: d;
 			sharedPools: s;
 			category: cat;
@@ -1166,7 +1166,7 @@ Class >> subclass: t instanceVariableNames: ins [
 			builder
 				superclass: self; 
 				name: t;
-				slots: ins asSlotCollection;
+				slotsFromString: ins;
 				environment: self environment ]
 ]
 
@@ -1180,7 +1180,7 @@ Class >> subclass: aSubclassSymbol instanceVariableNames: instVarNameList classV
 				superclass: self; 
 				name: aSubclassSymbol;
 				sharedVariablesFromString: classVarNames;
-				slots: instVarNameList asSlotCollection;
+				slotsFromString: instVarNameList;
 				environment: self environment ]
 ]
 
@@ -1193,7 +1193,7 @@ Class >> subclass: aSubclassSymbol instanceVariableNames: instVarNameList classV
 			builder
 				superclass: self;
 				name: aSubclassSymbol;
-				slots: instVarNameList asSlotCollection;
+				slotsFromString: instVarNameList;
 				sharedVariablesFromString: classVarNames;
 				category: aPackageSymbol;
 				environment: self environment ]
@@ -1206,7 +1206,7 @@ Class >> subclass: t instanceVariableNames: f classVariableNames: d poolDictiona
 			builder
 				superclass: self;
 				name: t;
-				slots: f asSlotCollection;
+				slotsFromString: f;
 				sharedVariablesFromString: d;
 				sharedPools: s;
 				category: cat;
@@ -1222,7 +1222,7 @@ Class >> subclass: t instanceVariableNames: f classVariableNames: d poolDictiona
 				superclass: self;
 				name: t;
 				layoutClass: self classLayout class;
-				slots: f asSlotCollection;
+				slotsFromString: f;
 				sharedVariablesFromString: d;
 				sharedPools: s;
 				category: cat;
@@ -1386,7 +1386,7 @@ Class >> variableByteSubclass: t instanceVariableNames: f classVariableNames: d 
 				superclass: self;
 				name: t;
 				layoutClass: actualLayoutClass;
-				slots: f asSlotCollection;
+				slotsFromString: f;
 				sharedVariablesFromString: d;
 				sharedPools: s;
 				category: cat;
@@ -1402,7 +1402,7 @@ Class >> variableDoubleByteSubclass: className instanceVariableNames: instVarNam
 				superclass: self;
 				name: className;
 				layoutClass: DoubleByteLayout;
-				slots: instVarNameList asSlotCollection;
+				slotsFromString: instVarNameList;
 				sharedVariablesFromString: classVarNames;
 				category: cat;
 				environment: self environment ]
@@ -1417,7 +1417,7 @@ Class >> variableDoubleWordSubclass: className instanceVariableNames: instVarNam
 				superclass: self;
 				name: className;
 				layoutClass: DoubleWordLayout;
-				slots: instVarNameList asSlotCollection;
+				slotsFromString: instVarNameList;
 				sharedVariablesFromString: classVarNames;
 				category: cat;
 				environment: self environment ]
@@ -1431,7 +1431,7 @@ Class >> variableSubclass: className instanceVariableNames: instVarNameList clas
 			  superclass: self;
 			  name: className;
 			  layoutClass: VariableLayout;
-			  slots: instVarNameList asSlotCollection;
+			  slotsFromString: instVarNameList;
 			  sharedVariablesFromString: classVarNames;
 			  category: cat;
 			  environment: self environment ]
@@ -1445,7 +1445,7 @@ Class >> variableSubclass: className instanceVariableNames: instVarNameList clas
 			  superclass: self;
 			  name: className;
 			  layoutClass: VariableLayout;
-			  slots: instVarNameList asSlotCollection;
+			  slotsFromString: instVarNameList;
 			  sharedVariablesFromString: classVarNames;
 			  category: cat;
 			  environment: self environment ]
@@ -1459,7 +1459,7 @@ Class >> variableSubclass: className instanceVariableNames: instVarNameList clas
 			  superclass: self;
 			  name: className;
 			  layoutClass: VariableLayout;
-			  slots: instVarNameList asSlotCollection;
+			  slotsFromString: instVarNameList;
 			  sharedVariablesFromString: classVarNames;
 			  sharedPools: s;
 			  category: cat;
@@ -1478,7 +1478,7 @@ Class >> variableSubclass: t instanceVariableNames: f classVariableNames: d pool
 				superclass: self;
 				name: t;
 				layoutClass: VariableLayout;
-				slots: f asSlotCollection;
+				slotsFromString: f;
 				sharedVariablesFromString: d;
 				sharedPools: s;
 				category: cat;
@@ -1494,7 +1494,7 @@ Class >> variableWordSubclass: className instanceVariableNames: instVarNameList 
 			  superclass: self;
 			  name: className;
 			  layoutClass: WordLayout;
-			  slots: instVarNameList asSlotCollection;
+			  slotsFromString: instVarNameList;
 			  sharedVariablesFromString: classVarNames;
 			  category: cat;
 			  environment: self environment ]
@@ -1511,7 +1511,7 @@ Class >> variableWordSubclass: className instanceVariableNames: instVarNameList 
 			  superclass: self;
 			  name: className;
 			  layoutClass: WordLayout;
-			  slots: instVarNameList asSlotCollection;
+			  slotsFromString: instVarNameList;
 			  sharedVariablesFromString: classVarNames;
 			  category: cat;
 			  environment: self environment ]
@@ -1525,7 +1525,7 @@ Class >> variableWordSubclass: t instanceVariableNames: f classVariableNames: d 
 			  superclass: self;
 			  name: t;
 			  layoutClass: WordLayout;
-			  slots: f asSlotCollection;
+			  slotsFromString: f;
 			  sharedVariablesFromString: d;
 			  sharedPools: s;
 			  category: cat;
@@ -1542,7 +1542,7 @@ Class >> variableWordSubclass: t instanceVariableNames: f classVariableNames: d 
 				superclass: self;
 				name: t;
 				layoutClass: WordLayout;
-				slots: f asSlotCollection;
+				slotsFromString: f;
 				sharedVariablesFromString: d;
 				sharedPools: s;
 				category: cat;
@@ -1558,7 +1558,7 @@ Class >> weakSubclass: className instanceVariableNames: instVarNameList classVar
 			  superclass: self;
 			  name: className;
 			  layoutClass: WeakLayout;
-			  slots: instVarNameList asSlotCollection;
+			  slotsFromString: instVarNameList;
 			  sharedVariablesFromString: classVarNames;
 			  category: cat;
 			  environment: self environment ]
@@ -1573,7 +1573,7 @@ Class >> weakSubclass: className instanceVariableNames: instVarNameList classVar
 			  superclass: self;
 			  name: className;
 			  layoutClass: WeakLayout;
-			  slots: instVarNameList asSlotCollection;
+			  slotsFromString: instVarNameList;
 			  sharedVariablesFromString: classVarNames;
 			  category: cat;
 			  environment: self environment ]
@@ -1587,7 +1587,7 @@ Class >> weakSubclass: t instanceVariableNames: f classVariableNames: d poolDict
 			  superclass: self;
 			  name: t;
 			  layoutClass: WeakLayout;
-			  slots: f asSlotCollection;
+			  slotsFromString: f;
 			  sharedVariablesFromString: d;
 			  sharedPools: s;
 			  category: cat;
@@ -1604,7 +1604,7 @@ Class >> weakSubclass: t instanceVariableNames: f classVariableNames: d poolDict
 				superclass: self;
 				name: t;
 				layoutClass: WeakLayout;
-				slots: f asSlotCollection;
+				slotsFromString: f;
 				sharedVariablesFromString: d;
 				sharedPools: s;
 				category: cat;

--- a/src/Kernel/UndefinedObject.class.st
+++ b/src/Kernel/UndefinedObject.class.st
@@ -220,7 +220,7 @@ UndefinedObject >> subclass: nameOfClass instanceVariableNames: instVarNameList 
 		  builder
 			  superclass: nil;
 			  name: nameOfClass;
-			  slots: instVarNameList asSlotCollection;
+			  slotsFromString: instVarNameList;
 			  sharedVariablesFromString: classVarNames;
 			  sharedPools: poolDictnames;
 			  category: category;

--- a/src/SUnit-Core/ClassFactoryForTestCase.class.st
+++ b/src/SUnit-Core/ClassFactoryForTestCase.class.st
@@ -244,8 +244,8 @@ ClassFactoryForTestCase >> newSubclassOf: aClass uses: aTraitComposition instanc
 		            aBuilder
 			            name: self newClassName;
 			            superclass: aClass;
-			            traitComposition: aTraitComposition asTraitComposition;
-			            slots: ivNamesString asSlotCollection;
+			            traitComposition: aTraitComposition;
+			            slotsFromString: ivNamesString;
 			            sharedVariablesFromString: classVarsString;
 			            sharedPools: poolNamesString;
 			            package: (self packageName , '-' , category) asSymbol ].
@@ -298,7 +298,7 @@ ClassFactoryForTestCase >> newTraitNamed: aTraitName uses: aTraitComposition tag
 	newTrait := self class classInstaller make: [ :aBuilder |
 		            aBuilder
 			            name: aTraitName;
-			            traitComposition: aTraitComposition asTraitComposition;
+			            traitComposition: aTraitComposition;
 			            package: (self packageName , '-' , aTag) asSymbol;
 			            beTrait ].
 
@@ -362,7 +362,7 @@ ClassFactoryForTestCase >> redefineClass: aClass subclassOf: aSuperclass uses: a
 		            aBuilder
 			            name: aClass name;
 			            superclass: aSuperclass;
-			            traitComposition: aTraitComposition asTraitComposition;
+			            traitComposition: aTraitComposition;
 			            slots: ivNamesString asSlotCollection;
 			            sharedVariablesFromString: classVarsString;
 			            sharedPools: poolNamesString;

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -496,6 +496,11 @@ ShiftClassBuilder >> slots: aCollection [
 ]
 
 { #category : #accessing }
+ShiftClassBuilder >> slotsFromString: aString [
+	self slots: aString asSlotCollection
+]
+
+{ #category : #accessing }
 ShiftClassBuilder >> superclass [
 	^ superclass ifNil: [ superclassName ifNotNil: [buildEnvironment classNamed: (self superclassName) ]]
 ]

--- a/src/Slot-Tests/SlotIntegrationTest.class.st
+++ b/src/Slot-Tests/SlotIntegrationTest.class.st
@@ -324,7 +324,7 @@ SlotIntegrationTest >> testReshapeClassPropagatesToDeepHierarchyClassInterface [
 	aClass := self class classInstaller make: [ :aClassBuilder |
 		aClassBuilder
 			name: self aClassName;
-			slots: 'x' asSlotCollection;
+			slotsFromString: 'x';
 			package: self aCategory ].
 
 	self assert: aClass instVarNames equals: #(x).
@@ -350,7 +350,7 @@ SlotIntegrationTest >> testReshapeClassWithClassSlot [
 	aClass := self class classInstaller make: [ :aClassBuilder |
 		aClassBuilder
 			name: self aClassName;
-			slots: 'x' asSlotCollection;
+			slotsFromString: 'x';
 			package: self aCategory ].
 
 	self assert: aClass class instVarNames equals: #(x)

--- a/src/TraitsV2-Tests/T2AbstractTest.class.st
+++ b/src/TraitsV2-Tests/T2AbstractTest.class.st
@@ -37,7 +37,7 @@ T2AbstractTest >> newClass: aName superclass: aSuperclass with: slots trait: aCo
 			name: aName;
 			superclass: aSuperclass;
 			slots: slots;
-			traitComposition: aComposition asTraitComposition;
+			traitComposition: aComposition;
 			package: category ].
 
 	createdClasses add:class.
@@ -61,7 +61,7 @@ T2AbstractTest >> newClass: aName superclass: aSuperclass with: slots uses: aCom
 			name: aName;
 			superclass: aSuperclass;
 			slots: slots;
-			traitComposition: aComposition asTraitComposition;
+			traitComposition: aComposition;
 			package: category ].
 
 	createdClasses add:class.
@@ -95,7 +95,7 @@ T2AbstractTest >> newTrait: aName with: slots trait: aComposition category: cate
 	class := self class classInstaller make: [ :aBuilder |
 		aBuilder
 			name: aName;
-			traitComposition: aComposition asTraitComposition;
+			traitComposition: aComposition;
 			slots: slots;
 			package: category;
 			beTrait ].
@@ -116,7 +116,7 @@ T2AbstractTest >> newTrait: aName with: slots uses: aComposition category: categ
 	class := self class classInstaller make: [ :aBuilder |
 		aBuilder
 			name: aName;
-			traitComposition: aComposition asTraitComposition;
+			traitComposition: aComposition;
 			slots: slots;
 			package: category;
 			beTrait ].

--- a/src/TraitsV2-Tests/T2TraitSlotScopeTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitSlotScopeTest.class.st
@@ -210,7 +210,7 @@ T2TraitSlotScopeTest >> testSubClassWithTraitsAfterModificationOfParentSharedPoo
 	c1 := self class classInstaller make: [ :aClassBuilder |
 		aClassBuilder
 			name: #C1;
-			traitComposition: t1 asTraitComposition;
+			traitComposition: t1;
 			sharedPools: 'X1';
 			package: 'TraitsV2-Tests-TestClasses' ].
 

--- a/src/TraitsV2-Tests/TraitPureBehaviorTest.class.st
+++ b/src/TraitsV2-Tests/TraitPureBehaviorTest.class.st
@@ -180,7 +180,7 @@ TraitPureBehaviorTest >> testOwnMethodsTakePrecedenceOverTraitsMethods [
 	self class classInstaller make: [ :aBuilder |
 		aBuilder
 			name: #T;
-			traitComposition: self t1 asTraitComposition;
+			traitComposition: self t1;
 			package: self class category;
 			beTrait ].
 
@@ -258,7 +258,7 @@ TraitPureBehaviorTest >> testPropagationWhenTraitCompositionModifications [
 	self class classInstaller make: [ :aBuilder |
 		aBuilder
 			name: #T2;
-			traitComposition: self t3 asTraitComposition;
+			traitComposition: self t3;
 			package: self class category;
 			beTrait ].
 

--- a/src/TraitsV2-Tests/TraitTest.class.st
+++ b/src/TraitsV2-Tests/TraitTest.class.st
@@ -9,7 +9,7 @@ TraitTest >> createClassUsing: aTrait [
 
 	^ self class classInstaller make: [ :aBuilder |
 		aBuilder name: #AClassForTests;
-			traitComposition: aTrait asTraitComposition;
+			traitComposition: aTrait;
 			package: 'AAA' ]
 ]
 

--- a/src/TraitsV2-Tests/TraitsResource.class.st
+++ b/src/TraitsV2-Tests/TraitsResource.class.st
@@ -157,7 +157,7 @@ TraitsResource >> createClassNamed: aSymbol superclass: aClass uses: aTraitCompo
 	class := self class classInstaller make: [ :aBuilder |
 		aBuilder name: aSymbol;
 			superclass: aClass;
-			traitComposition: aTraitComposition asTraitComposition;
+			traitComposition: aTraitComposition;
 			package: self categoryName ].
 
 	self createdClassesAndTraits add: class.
@@ -171,7 +171,7 @@ TraitsResource >> createTraitNamed: aSymbol uses: aTraitComposition [
 	trait := self class classInstaller make: [ :aBuilder |
 		aBuilder
 			name: aSymbol;
-			traitComposition: aTraitComposition asTraitComposition;
+			traitComposition: aTraitComposition;
 			package: self categoryName;
 			beTrait ].
 

--- a/src/TraitsV2-Tests/TraitsTestCase.class.st
+++ b/src/TraitsV2-Tests/TraitsTestCase.class.st
@@ -90,7 +90,7 @@ TraitsTestCase >> createClassNamed: aSymbol superclass: aClass uses: aTraitCompo
 	class := self class classInstaller make: [ :aBuilder |
 		aBuilder name: aSymbol;
 			superclass: aClass;
-			traitComposition: aTraitComposition asTraitComposition;
+			traitComposition: aTraitComposition;
 			package: self categoryName ].
 
 	self createdClassesAndTraits add: class.
@@ -104,7 +104,7 @@ TraitsTestCase >> createTraitNamed: aSymbol uses: aTraitComposition [
 	trait := self class classInstaller make: [ :aBuilder |
 		aBuilder
 			name: aSymbol;
-			traitComposition: aTraitComposition asTraitComposition;
+			traitComposition: aTraitComposition;
 			package: self categoryName;
 			beTrait ].
 

--- a/src/TraitsV2/Class.extension.st
+++ b/src/TraitsV2/Class.extension.st
@@ -34,7 +34,7 @@ Class >> setTraitComposition: aTraitComposition [
 			builder
 				fillFor: self;
 				traitComposition: aTraitComposition;
-				classTraitComposition: aTraitComposition classComposition]
+				classTraitComposition: aTraitComposition asTraitComposition classComposition ]
 ]
 
 { #category : #'*TraitsV2' }

--- a/src/TraitsV2/Class.extension.st
+++ b/src/TraitsV2/Class.extension.st
@@ -33,8 +33,8 @@ Class >> setTraitComposition: aTraitComposition [
 		update: self to: [ :builder |
 			builder
 				fillFor: self;
-				traitComposition: aTraitComposition asTraitComposition;
-				classTraitComposition: aTraitComposition asTraitComposition classComposition]
+				traitComposition: aTraitComposition;
+				classTraitComposition: aTraitComposition classComposition]
 ]
 
 { #category : #'*TraitsV2' }
@@ -136,7 +136,7 @@ Class >> subclass: subclassName uses: aTraitComposition layout: aLayout slots: s
 				layoutClass: aLayout;
 				sharedVariables: someClassVariables;
 				sharedPools: somePoolDictionaries;
-				traitComposition: aTraitComposition asTraitComposition;
+				traitComposition: aTraitComposition;
 				classTraitComposition: aTraitComposition asTraitComposition classComposition;
 				category: aCategory ]
 ]
@@ -153,7 +153,7 @@ Class >> subclass: subclassName uses: aTraitComposition layout: aLayout slots: s
 				layoutClass: aLayout;
 				sharedVariables: someClassVariables;
 				sharedPools: somePoolDictionaries;
-				traitComposition: aTraitComposition asTraitComposition;
+				traitComposition: aTraitComposition;
 				classTraitComposition: aTraitComposition asTraitComposition classComposition;
 				category: aCategory ]
 ]
@@ -170,7 +170,7 @@ Class >> subclass: subclassName uses: aTraitComposition layout: aLayout slots: s
 				layoutClass: aLayout;
 				sharedVariablesFromString: someClassVariablesNames;
 				sharedPools: somePoolDictionaries;
-				traitComposition: aTraitComposition asTraitComposition;
+				traitComposition: aTraitComposition;
 				classTraitComposition: aTraitComposition asTraitComposition classComposition;
 				category: aCategory ]
 ]
@@ -187,7 +187,7 @@ Class >> subclass: subclassName uses: aTraitComposition layout: aLayout slots: s
 				layoutClass: aLayout;
 				sharedVariablesFromString: someClassVariablesNames;
 				sharedPools: somePoolDictionaries;
-				traitComposition: aTraitComposition asTraitComposition;
+				traitComposition: aTraitComposition;
 				classTraitComposition: aTraitComposition asTraitComposition classComposition;
 				category: aCategory ]
 ]

--- a/src/TraitsV2/Trait.class.st
+++ b/src/TraitsV2/Trait.class.st
@@ -45,7 +45,7 @@ Trait class >> configureBuilder: builder withName: aName traitComposition: aTrai
 		sharedVariables: '';
 		sharedPools: '';
 		category: aPackageName;
-		traitComposition: aTraitCompositionOrCollection asTraitComposition;
+		traitComposition: aTraitCompositionOrCollection;
 		classTraitComposition: aTraitCompositionOrCollection asTraitComposition classComposition
 ]
 


### PR DESCRIPTION
improve the usage/api of ClassBuilder:
- reduce the need of #asSlotCollection by adding #slotsFromString: following the existing #sharedVariablesFromString:
- reduce the sends of #asTraitComposition,  this is done by the #traitComposition: method of the class builder