### PR TITLE
Finish Monticello decoupling in RPackage

### DIFF
--- a/src/RPackage-Core/ManifestRPackageCore.class.st
+++ b/src/RPackage-Core/ManifestRPackageCore.class.st
@@ -11,5 +11,5 @@ Class {
 ManifestRPackageCore class >> manuallyResolvedDependencies [
 
 	<ignoreForCoverage>
-	^ #(#Jobs #'Transcript-Core' #'Announcements-Core' #Monticello)
+	^ #( #Jobs #'Transcript-Core' #'Announcements-Core' )
 ]

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -966,22 +966,15 @@ RPackageOrganizer >> systemCategoryAddedActionFrom: ann [
 RPackageOrganizer >> systemCategoryRemovedActionFrom: ann [
 	"When a system category is removed, we may: remove a tag, or remove a rpackage. If we remove a RPackage, unregister the linked MCWorkingCopy. If it is a tag, do nothing? (from what I know of RPackage, the tag should already have disappeared because it would have been empty)."
 
-	| rPackage categoryName categoryNameSymbol managers |
-	categoryName := ann categoryName.
-	categoryNameSymbol := categoryName asSymbol.
-	self flag: #hack. "for decoupling MC"
-	managers := (self respondsTo: #allManagers)
-		            ifTrue: [ self allManagers ]
-		            ifFalse: [ #(  ) ].
-	"Reverse the test. First check that this is the root category of a RPackage. If yes, unregister the RPackage and the corresponding MCWorkingCopy."
-	rPackage := packages at: categoryNameSymbol ifAbsent: [ ^ self ].
+	| rPackage categoryName |
+	categoryName := ann categoryName asSymbol.
+
+	rPackage := packages at: categoryName ifAbsent: [ ^ self ].
+
 	"Consider that a rPackage with extension selectors or tags is not empty and shouldn't be removed."
-	(rPackage extensionSelectors notEmpty or: [ (rPackage classTags reject: [ :tag | tag name = categoryName ]) notEmpty ]) ifTrue: [ ^ self ].
+	(rPackage extensionSelectors isNotEmpty or: [ (rPackage classTags reject: [ :tag | tag name = categoryName ]) isNotEmpty ]) ifTrue: [ ^ self ].
 	categoryName = RPackage defaultPackageName ifTrue: [ ^ self ]. "We want to keep this default package."
-	self basicUnregisterPackageNamed: categoryNameSymbol.
-	(managers
-		 detect: [ :each | each packageName = categoryName ]
-		 ifNone: [  ]) ifNotNil: [ :mcWorkingCopy | mcWorkingCopy unregister ]
+	self unregisterPackage: rPackage
 ]
 
 { #category : #'system integration' }

--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -73,9 +73,9 @@ SystemDependenciesTest >> knownBasicToolsDependencies [
 SystemDependenciesTest >> knownCompilerDependencies [
 	"ideally this list should be empty"
 
-	"Note: #Monticello #'Transcript-Core' and brought by RPackage-Core but we want to kill those dependencies in the future because the kernel group should not depend on that."
+	"Note: #'Transcript-Core' is brought by RPackage-Core but we want to kill this dependencies in the future because the kernel group should not depend on that."
 
-	^ #( #'FileSystem-Core' #Monticello #'Transcript-Core' )
+	^ #( #'FileSystem-Core' #'Transcript-Core' )
 ]
 
 { #category : #'known dependencies' }
@@ -91,9 +91,9 @@ SystemDependenciesTest >> knownDisplayDependencies [
 SystemDependenciesTest >> knownFileSystemDependencies [
 	"ideally this list should be empty"
 
-	"Note: #Monticello #'Transcript-Core' are brought by RPackage-Core but we want to kill those dependencies in the future because the kernel group should not depend on that."
+	"Note: #'Transcript-Core' is brought by RPackage-Core but we want to kill this dependencies in the future because the kernel group should not depend on that."
 
-	^ #( #Monticello #'Transcript-Core' )
+	^ #( #'Transcript-Core' )
 ]
 
 { #category : #'known dependencies' }
@@ -108,9 +108,9 @@ SystemDependenciesTest >> knownIDEDependencies [
 SystemDependenciesTest >> knownKernelDependencies [
 	"ideally this list should be empty"
 
-	"Note: #Monticello #'Transcript-Core' #Jobs are brought by RPackage-Core but we want to kill those dependencies in the future because the kernel group should not depend on that."
+	"Note: #'Transcript-Core' #Jobs are brought by RPackage-Core but we want to kill those dependencies in the future because the kernel group should not depend on that."
 
-	^ #( #'FileSystem-Core' #Monticello #'Transcript-Core' #Jobs )
+	^ #( #'FileSystem-Core' #'Transcript-Core' #Jobs )
 ]
 
 { #category : #'known dependencies' }
@@ -172,9 +172,9 @@ SystemDependenciesTest >> knownSUnitDependencies [
 SystemDependenciesTest >> knownSUnitKernelDependencies [
 	"ideally this list should be empty"
 
-	"Note: #Monticello #''Transcript-Core'' are brought by RPackage-Core but we want to kill those dependencies in the future because the kernel group should not depend on that."
+	"Note: #'Transcript-Core' is brought by RPackage-Core but we want to kill this dependencies in the future because the kernel group should not depend on that."
 
-	^ #( #Monticello #'Transcript-Core' #'FileSystem-Core' )
+	^ #( #'Transcript-Core' #'FileSystem-Core' )
 ]
 
 { #category : #'known dependencies' }


### PR DESCRIPTION
With this PR there is not dependency of RPackage over Monticello anymore!

There are still some cleanings to do because there is still a ping pong between RPackage and Monticello through the announcements but that's another cleaning step to do :)

We also have a ping pong in RPackage between the categories and the packages/packageTags. So here we have a ping pong with 3 players and I will work toward the goal of reducing this.