### PR TITLE
Deprecate CompiledMethod>>#tags

### DIFF
--- a/src/Calypso-SystemQueries/ClyUnclassifiedMethodsQuery.class.st
+++ b/src/Calypso-SystemQueries/ClyUnclassifiedMethodsQuery.class.st
@@ -10,17 +10,17 @@ Class {
 { #category : #printing }
 ClyUnclassifiedMethodsQuery >> description [
 
-	^'unclassified methods'
+	^ 'unclassified methods'
 ]
 
 { #category : #testing }
 ClyUnclassifiedMethodsQuery >> isResult: aQueryResult affectedBy: aSystemAnnouncement [
 
-	^aSystemAnnouncement affectsMethods
-		and: [ scope includesMethodsAffectedBy: aSystemAnnouncement]
+	^ aSystemAnnouncement affectsMethods and: [ scope includesMethodsAffectedBy: aSystemAnnouncement ]
 ]
 
 { #category : #testing }
 ClyUnclassifiedMethodsQuery >> selectsMethod: aMethod [
-	^aMethod tags isEmpty
+
+	^ aMethod isClassified not
 ]

--- a/src/Deprecated12/CompiledMethod.extension.st
+++ b/src/Deprecated12/CompiledMethod.extension.st
@@ -8,6 +8,21 @@ CompiledMethod >> tagWith: aSymbol [
 ]
 
 { #category : #'*Deprecated12' }
+CompiledMethod >> tags [
+	"Any method could be tagged with multiple symbols for user purpose.
+	For now we only define API to manage them implemented on top of method protocols.
+	Protocol unclassified means that method is not tagged by anything"
+
+	| protocol |
+	self deprecated:
+		'This method is missleading letting the user thing that there can be more than one protocol on a method. Most of the cases should just use #protocol(Name) and deal with the unclassified protocol if there is something special to do to it.'.
+	protocol := self protocolName.
+	protocol ifNil: [ ^ #(  ) ].
+	protocol = Protocol unclassified ifTrue: [ ^ #(  ) ].
+	^ { protocol }
+]
+
+{ #category : #'*Deprecated12' }
 CompiledMethod >> untagFrom: aSymbol [
 
 	self

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -973,18 +973,6 @@ CompiledMethod >> storeOn: aStream [
 	aStream nextPut: $)
 ]
 
-{ #category : #'accessing - tags' }
-CompiledMethod >> tags [
-	"Any method could be tagged with multiple symbols for user purpose.
-	For now we only define API to manage them implemented on top of method protocols.
-	Protocol unclassified means that method is not tagged by anything"
-	| protocol |
-	protocol := self protocolName.
-	protocol ifNil: [ ^#() ].
-	protocol = Protocol unclassified ifTrue: [ ^#() ].
-	^{protocol}
-]
-
 { #category : #'source code management' }
 CompiledMethod >> tempNames [
 	"on the level of the compiled method, tempNames includes argument names"

--- a/src/SystemCommands-MethodCommands/SycSilentlyRemoveMethodStrategy.class.st
+++ b/src/SystemCommands-MethodCommands/SycSilentlyRemoveMethodStrategy.class.st
@@ -8,25 +8,9 @@ Class {
 }
 
 { #category : #removing }
-SycSilentlyRemoveMethodStrategy >> collectMethodTagsFrom: methods [
-	"It will return map class->tags where tags are related to given methods"
-	| result tags |
-	result := IdentityDictionary new.
-	methods do: [ :each |
-		tags := result at: each origin ifAbsentPut: [IdentitySet new].
-		tags addAll: each tags].
-	^result
-]
-
-{ #category : #removing }
 SycSilentlyRemoveMethodStrategy >> removeMethods: methods [
 
-	| methodTags |
-	methodTags := self collectMethodTagsFrom: methods. "we will remove empty tags of removed methods"
-
-	methods do: [ :each | each removeFromSystem ].
-
-	methodTags keysAndValuesDo: [ :class :tags | tags do: [ :eachTag | class removeProtocolIfEmpty: eachTag ] ]
+	methods do: [ :method | method removeFromSystem ]
 ]
 
 { #category : #removing }


### PR DESCRIPTION
#tags is missleading because it lets the user think there are more than one protocol one a method and introduce an alternative way to deal with the unclassified protocol while the original API wanted to make it a protocol as any other. I propose to deprecate this method and I updated the last users in the image.

For #removeMethods: I removed all the management of protocols because a method will deal with the protocol removal itself if it is the last of the protocol