### PR TITLE
another simplification of class builder users: Traits

### DIFF
--- a/src/Fuel-Platform-Pharo-Core/FLPharoPlatform.class.st
+++ b/src/Fuel-Platform-Pharo-Core/FLPharoPlatform.class.st
@@ -82,7 +82,6 @@ FLPharoPlatform >> newSubclassOf: aClass named: className uses: aTraitCompositio
 			name: className;
 			superclass: aClass;
 			traitComposition: aTraitComposition;
-			classTraitComposition: aTraitComposition asTraitComposition classComposition;
 			slotsFromString: ivNamesString;
 			sharedVariablesFromString: classVarsString;
 			sharedPools: poolNamesString;

--- a/src/SUnit-Core/ClassFactoryForTestCase.class.st
+++ b/src/SUnit-Core/ClassFactoryForTestCase.class.st
@@ -363,7 +363,7 @@ ClassFactoryForTestCase >> redefineClass: aClass subclassOf: aSuperclass uses: a
 			            name: aClass name;
 			            superclass: aSuperclass;
 			            traitComposition: aTraitComposition;
-			            slots: ivNamesString asSlotCollection;
+			            slotsFromString: ivNamesString;
 			            sharedVariablesFromString: classVarsString;
 			            sharedPools: poolNamesString;
 			            package: aPackageName asSymbol ].

--- a/src/SUnit-Core/ClassFactoryWithOrganization.class.st
+++ b/src/SUnit-Core/ClassFactoryWithOrganization.class.st
@@ -52,9 +52,8 @@ ClassFactoryWithOrganization >> newClassNamed: aString subclassOf: aClass instan
 			            superclass: aClass;
 			            name: aString;
 			            layoutClass: aClass classLayout class;
-			            slots: ivNamesString asSlotCollection;
+			            slotsFromString: ivNamesString;
 			            sharedVariablesFromString: classVarsString;
-			            sharedPools: '';
 			            category: category asSymbol;
 			            environment: self organization environment ].
 	self createdClasses add: newClass.
@@ -81,9 +80,8 @@ ClassFactoryWithOrganization >> newSubclassOf: aClass instanceVariableNames: ivN
 			            superclass: aClass;
 			            name: self newClassName;
 			            layoutClass: aClass classLayout class;
-			            slots: ivNamesString asSlotCollection;
+			            slotsFromString: ivNamesString;
 			            sharedVariablesFromString: classVarsString;
-			            sharedPools: '';
 			            category: category asSymbol;
 			            environment: self organization environment ].
 	self createdClasses add: newClass.

--- a/src/TraitsV2-Tests/T2TraitChangesTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitChangesTest.class.st
@@ -11,13 +11,15 @@ T2TraitChangesTest >> testGeneratingTheSameTraitDoesNotProduceChanges [
 
 	t1 := self newTrait: #T1 with: {}.
 
-	builder := ShiftClassBuilder new.
-	builder buildEnvironment: ShSmalltalkGlobalsEnvironment new.
-
-	Trait configureBuilder: builder withName: #T1 traitComposition: TEmpty slots: {}  packageName: 'TraitsV2-Tests-TestClasses'.
-
-	builder tryToFillOldClass.
-	builder detectBuilderEnhancer.
+	builder := ShiftClassBuilder new
+		buildEnvironment: ShSmalltalkGlobalsEnvironment new;
+		name: #T1;
+		category: 'TraitsV2-Tests-TestClasses';
+		traitComposition: TEmpty;
+		tryToFillOldClass;
+		detectBuilderEnhancer;
+		beTrait.
+		
 	builder builderEnhancer validateRedefinition: builder oldClass.
 
 	builder validateSuperclass.
@@ -36,7 +38,11 @@ T2TraitChangesTest >> testUpdatingTheSameTraitDoesNotProduceChanges [
 	builder := ShiftClassBuilder new.
 	builder buildEnvironment: ShSmalltalkGlobalsEnvironment new.
 
-	Trait configureBuilder: builder withName: #T1 traitComposition: TEmpty slots: {}  packageName: 'TraitsV2-Tests-TestClasses'.
+	builder
+		name: #T1;
+		category: 'TraitsV2-Tests-TestClasses';
+		traitComposition: TEmpty;
+		beTrait.
 
 	builder oldClass: t1.
 
@@ -55,9 +61,12 @@ T2TraitChangesTest >> testconfigureBuilderWithNameTraitCompositionInstanceVariab
 
 	| builder |
 
-	builder := ShiftClassBuilder new.
-	builder buildEnvironment: ShSmalltalkGlobalsEnvironment new.
-	Trait configureBuilder: builder withName: #T1 traitComposition: {} instanceVariableNames: 'a b'  packageName: 'TraitsV2-Tests-TestClasses'.
+	builder := ShiftClassBuilder new
+	 	buildEnvironment: ShSmalltalkGlobalsEnvironment new;
+		name: #T1;
+		beTrait;
+		slotsFromString: 'a b';
+		category: 'TraitsV2-Tests-TestClasses'.
 
 	self assert: builder slots size equals: 2.
 	self assert: builder slots first name equals: 'a'.

--- a/src/TraitsV2-Tests/TraitTest.class.st
+++ b/src/TraitsV2-Tests/TraitTest.class.st
@@ -108,7 +108,7 @@ TraitTest >> testErrorClassCreation [
 		aSubclass := self class classInstaller make: [ :aClassBuilder |
 			aClassBuilder
 				name: #AClass2;
-				traitComposition: trait asTraitComposition;
+				traitComposition: trait;
 				superclass: aClass;
 				package: tmpCategory ].
 

--- a/src/TraitsV2/Class.extension.st
+++ b/src/TraitsV2/Class.extension.st
@@ -2,7 +2,6 @@ Extension { #name : #Class }
 
 { #category : #'*TraitsV2' }
 Class >> immediateSubclass: aClassName uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames package: aCategory [
-	"Added to allow for a simplified subclass creation experience. "
 
 	^ self classInstaller make: [ :builder |
 		  builder
@@ -18,17 +17,16 @@ Class >> immediateSubclass: aClassName uses: aTraitCompositionOrArray instanceVa
 { #category : #'*TraitsV2' }
 Class >> immediateSubclass: aName uses: aTraitComposition instanceVariableNames: someInstanceVariableNames classVariableNames: someClassVariableNames poolDictionaries: someSharedPoolNames package: aCategory [
 
-	^ self classInstaller
-		make: [ :builder |
-			builder
-				name: aName;
-				superclass: self;
-				slotsFromString: someInstanceVariableNames;
-				layoutClass: ImmediateLayout;
-				sharedVariablesFromString: someClassVariableNames;
-				sharedPools: someSharedPoolNames;
-				traitComposition: aTraitComposition;
-				category: aCategory ]
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  superclass: self;
+			  slotsFromString: someInstanceVariableNames;
+			  layoutClass: ImmediateLayout;
+			  sharedVariablesFromString: someClassVariableNames;
+			  sharedPools: someSharedPoolNames;
+			  traitComposition: aTraitComposition;
+			  category: aCategory ]
 ]
 
 { #category : #'*TraitsV2' }
@@ -43,38 +41,39 @@ Class >> setTraitComposition: aTraitComposition [
 ]
 
 { #category : #'*TraitsV2' }
-Class >> subclass: t uses: aTraitComposition [
+Class >> subclass: aName uses: aTraitComposition [
 
-	^ self
-		subclass: t
-		uses: aTraitComposition
-		instanceVariableNames: ''
-		classVariableNames: ''
-		poolDictionaries: ''
-		category: 'Unclassified'
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  superclass: self;
+			  traitComposition: aTraitComposition ]
 ]
 
 { #category : #'*TraitsV2' }
-Class >> subclass: aTraitName uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames category: cat [
+Class >> subclass: aName uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames category: aCategory [
 
-	^ self
-		subclass: aTraitName
-		uses: aTraitCompositionOrArray
-		instanceVariableNames: instVarNameList
-		classVariableNames: classVarNames
-		poolDictionaries: ''
-		category: cat
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  superclass: self;
+			  slotsFromString: instVarNameList;
+			  sharedVariablesFromString: classVarNames;
+			  traitComposition: aTraitCompositionOrArray;
+			  category: aCategory ]
 ]
 
 { #category : #'*TraitsV2' }
-Class >> subclass: aTraitName uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames package: cat [
+Class >> subclass: aName uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames package: aCategory [
 
-	^ self
-		subclass: aTraitName
-		uses: aTraitCompositionOrArray
-		instanceVariableNames: instVarNameList
-		classVariableNames: classVarNames
-		category: cat
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  superclass: self;
+			  slotsFromString: instVarNameList;
+			  sharedVariablesFromString: classVarNames;
+			  traitComposition: aTraitCompositionOrArray;
+			  category: aCategory ]
 ]
 
 { #category : #'*TraitsV2' }
@@ -237,14 +236,15 @@ Class >> subclass: aSubclassSymbol uses: aTraitCompositionOrArray slots: slotDef
 { #category : #'*TraitsV2' }
 Class >> subclass: aSubclassSymbol uses: aTraitCompositionOrArray slots: slotDefinition classVariables: classVarDefinition poolDictionaries: someSharedPoolNames package: aCategorySymbol [
 
-	^ self
-		subclass: aSubclassSymbol
-		uses: aTraitCompositionOrArray
-		layout: self classLayout class
-		slots: slotDefinition
-		classVariables: classVarDefinition
-		poolDictionaries: someSharedPoolNames
-		category: aCategorySymbol
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aSubclassSymbol;
+			  superclass: self;
+			  slots: slotDefinition;
+			  sharedVariables: classVarDefinition;
+			  sharedPools: someSharedPoolNames;
+			  traitComposition: aTraitCompositionOrArray;
+			  category: aCategorySymbol ]
 ]
 
 { #category : #'*TraitsV2' }
@@ -279,37 +279,45 @@ Class >> variableByteSubclass: aName uses: aTraitComposition instanceVariableNam
 		ifTrue: [ CompiledMethodLayout ]
 		ifFalse: [ ByteLayout ].
 
-	^ self
-		subclass: aName
-		uses: aTraitComposition
-		layout: actualLayoutClass
-		slots: someInstanceVariableNames asSlotCollection
-		classVariablesNames: someClassVariableNames
-		poolDictionaries: someSharedPoolNames
-		category: aCategory
+	^ self classInstaller
+		make: [ :builder |
+			builder
+				name: aName;
+				superclass: self;
+				slotsFromString: someInstanceVariableNames;
+				layoutClass: actualLayoutClass;
+				sharedVariablesFromString: someClassVariableNames;
+				sharedPools: someSharedPoolNames;
+				traitComposition: aTraitComposition;
+				category: aCategory ]
 ]
 
 { #category : #'*TraitsV2' }
-Class >> variableSubclass: aClassName uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames category: cat [
+Class >> variableSubclass: aClassName uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames category: aCategory [
 
-	^ self
-		variableSubclass: aClassName
-		uses: aTraitCompositionOrArray
-		instanceVariableNames: instVarNameList
-		classVariableNames: classVarNames
-		poolDictionaries: ''
-		category: cat
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aClassName;
+			  superclass: self;
+			  layoutClass: VariableLayout;
+			  slotsFromString: instVarNameList;
+			  sharedVariablesFromString: classVarNames;
+			  traitComposition: aTraitCompositionOrArray;
+			  category: aCategory ]
 ]
 
 { #category : #'*TraitsV2' }
-Class >> variableSubclass: aClassName uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames package: cat [
+Class >> variableSubclass: aClassName uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames package: aCategory [
 
-	^ self
-		variableSubclass: aClassName
-		uses: aTraitCompositionOrArray
-		instanceVariableNames: instVarNameList
-		classVariableNames: classVarNames
-		category: cat
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aClassName;
+			  superclass: self;
+			  layoutClass: VariableLayout;
+			  slotsFromString: instVarNameList;
+			  sharedVariablesFromString: classVarNames;
+			  traitComposition: aTraitCompositionOrArray;
+			  category: aCategory ]
 ]
 
 { #category : #'*TraitsV2' }
@@ -319,6 +327,7 @@ Class >> variableSubclass: aName uses: aTraitComposition instanceVariableNames: 
 		  builder
 			  name: aName;
 			  superclass: self;
+			  layoutClass: VariableLayout;
 			  slotsFromString: someInstanceVariableNames;
 			  sharedVariablesFromString: someClassVariableNames;
 			  sharedPools: someSharedPoolNames;
@@ -329,24 +338,30 @@ Class >> variableSubclass: aName uses: aTraitComposition instanceVariableNames: 
 { #category : #'*TraitsV2' }
 Class >> variableSubclass: aName uses: aTraitComposition instanceVariableNames: someInstanceVariableNames classVariableNames: someClassVariableNames poolDictionaries: someSharedPoolNames package: aCategory [
 
-	^ self
-		variableSubclass: aName
-		uses: aTraitComposition
-		instanceVariableNames: someInstanceVariableNames
-		classVariableNames: someClassVariableNames
-		poolDictionaries: someSharedPoolNames
-		category: aCategory
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  superclass: self;
+			  layoutClass: VariableLayout;
+			  slotsFromString: someInstanceVariableNames;
+			  sharedVariablesFromString: someClassVariableNames;
+			  sharedPools: someSharedPoolNames;
+			  traitComposition: aTraitComposition;
+			  category: aCategory ]
 ]
 
 { #category : #'*TraitsV2' }
-Class >> variableWordSubclass: className uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames category: cat [
+Class >> variableWordSubclass: className uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames category: aCategory [
 
-	^ self
-		variableWordSubclass: className
-		uses: aTraitCompositionOrArray
-		instanceVariableNames: instVarNameList
-		classVariableNames: classVarNames
-		package: cat
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: className;
+			  superclass: self;
+			  slotsFromString: instVarNameList;
+			  layoutClass: WordLayout;
+			  sharedVariablesFromString: classVarNames;
+			  traitComposition: aTraitCompositionOrArray;
+			  category: aCategory ]
 ]
 
 { #category : #'*TraitsV2' }

--- a/src/TraitsV2/Class.extension.st
+++ b/src/TraitsV2/Class.extension.st
@@ -1,29 +1,34 @@
 Extension { #name : #Class }
 
 { #category : #'*TraitsV2' }
-Class >> immediateSubclass: aClassName uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList
-	classVariableNames: classVarNames package: cat [
+Class >> immediateSubclass: aClassName uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames package: aCategory [
 	"Added to allow for a simplified subclass creation experience. "
 
-	^ self immediateSubclass: aClassName
-		uses: aTraitCompositionOrArray
-		instanceVariableNames: instVarNameList
-		classVariableNames: classVarNames
-		poolDictionaries: ''
-		package: cat
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aClassName;
+			  superclass: self;
+			  slotsFromString: instVarNameList;
+			  layoutClass: ImmediateLayout;
+			  sharedVariablesFromString: classVarNames;
+			  traitComposition: aTraitCompositionOrArray;
+			  category: aCategory ]
 ]
 
 { #category : #'*TraitsV2' }
 Class >> immediateSubclass: aName uses: aTraitComposition instanceVariableNames: someInstanceVariableNames classVariableNames: someClassVariableNames poolDictionaries: someSharedPoolNames package: aCategory [
 
-	^ self
-		subclass: aName
-		uses: aTraitComposition
-		layout: ImmediateLayout
-		slots: someInstanceVariableNames asSlotCollection
-		classVariablesNames: someClassVariableNames
-		poolDictionaries: someSharedPoolNames
-		category: aCategory
+	^ self classInstaller
+		make: [ :builder |
+			builder
+				name: aName;
+				superclass: self;
+				slotsFromString: someInstanceVariableNames;
+				layoutClass: ImmediateLayout;
+				sharedVariablesFromString: someClassVariableNames;
+				sharedPools: someSharedPoolNames;
+				traitComposition: aTraitComposition;
+				category: aCategory ]
 ]
 
 { #category : #'*TraitsV2' }
@@ -75,27 +80,29 @@ Class >> subclass: aTraitName uses: aTraitCompositionOrArray instanceVariableNam
 { #category : #'*TraitsV2' }
 Class >> subclass: aName uses: aTraitCompositionOrArray instanceVariableNames: someInstanceVariableNames classVariableNames: someClassVariableNames poolDictionaries: someSharedPoolNames category: aCategory [
 
-	^ self
-		subclass: aName
-		uses: aTraitCompositionOrArray
-		layout: self classLayout class
-		slots: someInstanceVariableNames asSlotCollection
-		classVariablesNames: someClassVariableNames
-		poolDictionaries: someSharedPoolNames
-		category: aCategory
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  superclass: self;
+			  slotsFromString: someInstanceVariableNames;
+			  sharedVariablesFromString: someClassVariableNames;
+			  sharedPools: someSharedPoolNames;
+			  traitComposition: aTraitCompositionOrArray;
+			  category: aCategory ]
 ]
 
 { #category : #'*TraitsV2' }
 Class >> subclass: aName uses: aTraitCompositionOrArray instanceVariableNames: someInstanceVariableNames classVariableNames: someClassVariableNames poolDictionaries: someSharedPoolNames package: aCategory [
 
-	^ self
-		subclass: aName
-		uses: aTraitCompositionOrArray
-		layout: self classLayout class
-		slots: someInstanceVariableNames asSlotCollection
-		classVariablesNames: someClassVariableNames
-		poolDictionaries: someSharedPoolNames
-		category: aCategory
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  superclass: self;
+			  slotsFromString: someInstanceVariableNames;
+			  sharedVariablesFromString: someClassVariableNames;
+			  sharedPools: someSharedPoolNames;
+			  traitComposition: aTraitCompositionOrArray;
+			  category: aCategory ]
 ]
 
 { #category : #'*TraitsV2' }
@@ -137,7 +144,6 @@ Class >> subclass: subclassName uses: aTraitComposition layout: aLayout slots: s
 				sharedVariables: someClassVariables;
 				sharedPools: somePoolDictionaries;
 				traitComposition: aTraitComposition;
-				classTraitComposition: aTraitComposition asTraitComposition classComposition;
 				category: aCategory ]
 ]
 
@@ -154,7 +160,6 @@ Class >> subclass: subclassName uses: aTraitComposition layout: aLayout slots: s
 				sharedVariables: someClassVariables;
 				sharedPools: somePoolDictionaries;
 				traitComposition: aTraitComposition;
-				classTraitComposition: aTraitComposition asTraitComposition classComposition;
 				category: aCategory ]
 ]
 
@@ -171,7 +176,6 @@ Class >> subclass: subclassName uses: aTraitComposition layout: aLayout slots: s
 				sharedVariablesFromString: someClassVariablesNames;
 				sharedPools: somePoolDictionaries;
 				traitComposition: aTraitComposition;
-				classTraitComposition: aTraitComposition asTraitComposition classComposition;
 				category: aCategory ]
 ]
 
@@ -188,7 +192,6 @@ Class >> subclass: subclassName uses: aTraitComposition layout: aLayout slots: s
 				sharedVariablesFromString: someClassVariablesNames;
 				sharedPools: somePoolDictionaries;
 				traitComposition: aTraitComposition;
-				classTraitComposition: aTraitComposition asTraitComposition classComposition;
 				category: aCategory ]
 ]
 
@@ -312,14 +315,15 @@ Class >> variableSubclass: aClassName uses: aTraitCompositionOrArray instanceVar
 { #category : #'*TraitsV2' }
 Class >> variableSubclass: aName uses: aTraitComposition instanceVariableNames: someInstanceVariableNames classVariableNames: someClassVariableNames poolDictionaries: someSharedPoolNames category: aCategory [
 
-	^ self
-		subclass: aName
-		uses: aTraitComposition
-		layout: VariableLayout
-		slots: someInstanceVariableNames asSlotCollection
-		classVariablesNames: someClassVariableNames
-		poolDictionaries: someSharedPoolNames
-		category: aCategory
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  superclass: self;
+			  slotsFromString: someInstanceVariableNames;
+			  sharedVariablesFromString: someClassVariableNames;
+			  sharedPools: someSharedPoolNames;
+			  traitComposition: aTraitComposition;
+			  category: aCategory ]
 ]
 
 { #category : #'*TraitsV2' }
@@ -346,85 +350,103 @@ Class >> variableWordSubclass: className uses: aTraitCompositionOrArray instance
 ]
 
 { #category : #'*TraitsV2' }
-Class >> variableWordSubclass: className uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames package: cat [
-	^ self
-		variableWordSubclass: className
-		uses: aTraitCompositionOrArray
-		instanceVariableNames: instVarNameList
-		classVariableNames: classVarNames
-		poolDictionaries: ''
-		package: cat
+Class >> variableWordSubclass: className uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames package: aCategory [
+
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: className;
+			  superclass: self;
+			  slotsFromString: instVarNameList;
+			  layoutClass: WordLayout;
+			  sharedVariablesFromString: classVarNames;
+			  traitComposition: aTraitCompositionOrArray;
+			  category: aCategory ]
 ]
 
 { #category : #'*TraitsV2' }
 Class >> variableWordSubclass: aName uses: aTraitComposition instanceVariableNames: someInstanceVariableNames classVariableNames: someClassVariableNames poolDictionaries: someSharedPoolNames category: aCategory [
 
-	^ self
-		variableWordSubclass: aName
-		uses: aTraitComposition
-		instanceVariableNames: someInstanceVariableNames
-		classVariableNames: someClassVariableNames
-		poolDictionaries: someSharedPoolNames
-		package: aCategory
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  superclass: self;
+			  slotsFromString: someInstanceVariableNames;
+			  layoutClass: WordLayout;
+			  sharedVariablesFromString: someClassVariableNames;
+			  sharedPools: someSharedPoolNames;
+			  traitComposition: aTraitComposition;
+			  category: aCategory ]
 ]
 
 { #category : #'*TraitsV2' }
 Class >> variableWordSubclass: aName uses: aTraitComposition instanceVariableNames: someInstanceVariableNames classVariableNames: someClassVariableNames poolDictionaries: someSharedPoolNames package: aCategory [
 
-	^ self
-		subclass: aName
-		uses: aTraitComposition
-		layout: WordLayout
-		slots: someInstanceVariableNames asSlotCollection
-		classVariablesNames: someClassVariableNames
-		poolDictionaries: someSharedPoolNames
-		category: aCategory
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  superclass: self;
+			  slotsFromString: someInstanceVariableNames;
+			  layoutClass: WordLayout;
+			  sharedVariablesFromString: someClassVariableNames;
+			  sharedPools: someSharedPoolNames;
+			  traitComposition: aTraitComposition;
+			  category: aCategory ]
 ]
 
 { #category : #'*TraitsV2' }
-Class >> weakSubclass: className uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames category: cat [
+Class >> weakSubclass: className uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames category: aCategory [
 
-	^ self
-		weakSubclass: className
-		uses: aTraitCompositionOrArray
-		instanceVariableNames: instVarNameList
-		classVariableNames: classVarNames
-		poolDictionaries: ''
-		category: cat
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: className;
+			  superclass: self;
+			  slotsFromString: instVarNameList;
+			  layoutClass: WeakLayout;
+			  sharedVariablesFromString: classVarNames;
+			  traitComposition: aTraitCompositionOrArray;
+			  category: aCategory ]
 ]
 
 { #category : #'*TraitsV2' }
-Class >> weakSubclass: className uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames package: cat [
+Class >> weakSubclass: className uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames package: aCategory [
 
-	^ self
-		weakSubclass: className
-		uses: aTraitCompositionOrArray
-		instanceVariableNames: instVarNameList
-		classVariableNames: classVarNames
-		category: cat
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: className;
+			  superclass: self;
+			  slotsFromString: instVarNameList;
+			  layoutClass: WeakLayout;
+			  sharedVariablesFromString: classVarNames;
+			  traitComposition: aTraitCompositionOrArray;
+			  category: aCategory ]
 ]
 
 { #category : #'*TraitsV2' }
 Class >> weakSubclass: aName uses: aTraitComposition instanceVariableNames: someInstanceVariableNames classVariableNames: someClassVariableNames poolDictionaries: someSharedPoolNames category: aCategory [
 
-	^ self
-		subclass: aName
-		uses: aTraitComposition
-		layout: WeakLayout
-		slots: someInstanceVariableNames asSlotCollection
-		classVariablesNames: someClassVariableNames
-		poolDictionaries: someSharedPoolNames
-		category: aCategory
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  superclass: self;
+			  slotsFromString: someInstanceVariableNames;
+			  layoutClass: WeakLayout;
+			  sharedVariablesFromString: someClassVariableNames;
+			  sharedPools: someSharedPoolNames;
+			  traitComposition: aTraitComposition;
+			  category: aCategory ]
 ]
 
 { #category : #'*TraitsV2' }
 Class >> weakSubclass: aName uses: aTraitComposition instanceVariableNames: someInstanceVariableNames classVariableNames: someClassVariableNames poolDictionaries: someSharedPoolNames package: aCategory [
 
-	^ self
-		weakSubclass: aName
-		uses: aTraitComposition
-		instanceVariableNames: someInstanceVariableNames
-		classVariableNames: someClassVariableNames
-		poolDictionaries: someSharedPoolNames
-		category: aCategory
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  superclass: self;
+			  slotsFromString: someInstanceVariableNames;
+			  layoutClass: WeakLayout;
+			  sharedVariablesFromString: someClassVariableNames;
+			  sharedPools: someSharedPoolNames;
+			  traitComposition: aTraitComposition;
+			  category: aCategory ]
 ]

--- a/src/TraitsV2/Trait.class.st
+++ b/src/TraitsV2/Trait.class.st
@@ -24,165 +24,160 @@ Class {
 	#category : #'TraitsV2-Base'
 }
 
-{ #category : #private }
-Trait class >> configureBuilder: builder withName: aName traitComposition: aTraitCompositionOrCollection instanceVariableNames: aString packageName: aPackageName [
-
-	^ self
-		  configureBuilder: builder
-		  withName: aName
-		  traitComposition: aTraitCompositionOrCollection
-		  slots: aString asSlotCollection
-		  packageName: aPackageName
-]
-
-{ #category : #private }
-Trait class >> configureBuilder: builder withName: aName traitComposition: aTraitCompositionOrCollection slots: someSlots packageName: aPackageName [
-
-	^ builder
-		name: aName;
-		beTrait;
-		slots: someSlots;
-		sharedVariables: '';
-		sharedPools: '';
-		category: aPackageName;
-		traitComposition: aTraitCompositionOrCollection;
-		classTraitComposition: aTraitCompositionOrCollection asTraitComposition classComposition
-]
-
 { #category : #'old pharo 8 syntax' }
-Trait class >> named: aSymbol [
-	^ self named: aSymbol uses: {} package: 'Unclassified'
+Trait class >> named: aName [
+
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  beTrait ]
 ]
 
 { #category : #'old pharo 8 syntax' }
 Trait class >> named: aName instanceVariableNames: aString package: aPackageName [
 
-	^ self named: aName
-		uses: {}
-		instanceVariableNames: aString
-		package: aPackageName
-		env: self environment
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  slotsFromString: aString;
+			  category: aPackageName;
+			  beTrait ]
 ]
 
 { #category : #'old pharo 8 syntax' }
-Trait class >> named: aSymbol package: aString [
-	^ self
-		named: aSymbol
-		uses: {}
-		package: aString
-		env: self environment
+Trait class >> named: aName package: aString [
+
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  category: aString;
+			  beTrait ]
 ]
 
 { #category : #'old pharo 8 syntax' }
-Trait class >> named: aSymbol uses: aCompositionOrArray [
-	^ self named: aSymbol uses: aCompositionOrArray package: 'Unclassified'
+Trait class >> named: aName uses: aCompositionOrArray [
+
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  traitComposition: aCompositionOrArray;
+			  beTrait ]
 ]
 
 { #category : #deprecated }
-Trait class >> named: aSymbol uses: aTraitCompositionOrCollection category: aString [
-	^ self
-		named: aSymbol
-		uses: aTraitCompositionOrCollection
-		package: aString
-		env: self environment
+Trait class >> named: aName uses: aTraitCompositionOrCollection category: aPackageName [
+
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  category: aPackageName;
+			  traitComposition: aTraitCompositionOrCollection;
+			  beTrait ]
 ]
 
 { #category : #deprecated }
-Trait class >> named: aName uses: aTraitCompositionOrCollection category: aString env: anEnvironment [
-	^ self
-		named: aName
-		uses: aTraitCompositionOrCollection
-		slots: #()
-		package: aString
-		env: anEnvironment
+Trait class >> named: aName uses: aTraitCompositionOrCollection category: aPackageName env: anEnvironment [
+
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  category: aPackageName;
+			  traitComposition: aTraitCompositionOrCollection;
+			  beTrait ]
 ]
 
 { #category : #'old pharo 8 syntax' }
 Trait class >> named: aName uses: aTraitCompositionOrCollection instanceVariableNames: aString package: aPackageName [
 
-	^ self named: aName
-		uses: aTraitCompositionOrCollection
-		instanceVariableNames: aString
-		package: aPackageName
-		env: self environment
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  slotsFromString: aString;
+			  category: aPackageName;
+			  traitComposition: aTraitCompositionOrCollection;
+			  beTrait ]
 ]
 
 { #category : #'old pharo 8 syntax' }
 Trait class >> named: aName uses: aTraitCompositionOrCollection instanceVariableNames: aString package: aPackageName env: anEnvironment [
-	| trait |
-	trait := self classInstaller
-		make: [ :builder |
-			self
-				configureBuilder: builder
-				withName: aName
-				traitComposition: aTraitCompositionOrCollection
-				slots: aString asSlotCollection
-				packageName: aPackageName ].
-	self assert: [ trait class class = MetaclassForTraits ].
-	self assert: [ trait class superclass = Trait ].
-	^ trait
+
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  slotsFromString: aString;
+			  category: aPackageName;
+			  traitComposition: aTraitCompositionOrCollection;
+			  beTrait ]
 ]
 
 { #category : #'old pharo 8 syntax' }
-Trait class >> named: aSymbol uses: aTraitCompositionOrCollection package: aString [
-	^ self
-		named: aSymbol
-		uses: aTraitCompositionOrCollection
-		package: aString
-		env: self environment
+Trait class >> named: aName uses: aTraitCompositionOrCollection package: aString [
+
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  category: aString;
+			  traitComposition: aTraitCompositionOrCollection;
+			  beTrait ]
 ]
 
 { #category : #'old pharo 8 syntax' }
 Trait class >> named: aName uses: aTraitCompositionOrCollection package: aString env: anEnvironment [
-	^ self
-		named: aName
-		uses: aTraitCompositionOrCollection
-		slots: #()
-		package: aString
-		env: anEnvironment
+
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  category: aString;
+			  traitComposition: aTraitCompositionOrCollection;
+			  beTrait ]
 ]
 
 { #category : #deprecated }
 Trait class >> named: aName uses: aTraitCompositionOrCollection slots: someSlots category: aCategory [
 
-	^ self named: aName
-		uses: aTraitCompositionOrCollection
-		slots: someSlots
-		package: aCategory
-		env: self environment
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  slots: someSlots;
+			  category: aCategory;
+			  traitComposition: aTraitCompositionOrCollection;
+			  beTrait ]
 ]
 
 { #category : #deprecated }
 Trait class >> named: aName uses: aTraitCompositionOrCollection slots: someSlots category: aCategory env: anEnvironment [
-	"It is unclear that it is not use by low level library such as MC so we should not use it but we do not remove it for now."
 
-	^ self named: aName uses: aTraitCompositionOrCollection slots: someSlots package: aCategory env: anEnvironment
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  slots: someSlots;
+			  category: aCategory;
+			  traitComposition: aTraitCompositionOrCollection;
+			  beTrait ]
 ]
 
 { #category : #'old pharo 8 syntax' }
 Trait class >> named: aName uses: aTraitCompositionOrCollection slots: someSlots package: aPackageName [
 
-	^ self named: aName
-		uses: aTraitCompositionOrCollection
-		slots: someSlots
-		package: aPackageName
-		env: self environment
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  slots: someSlots;
+			  category: aPackageName;
+			  traitComposition: aTraitCompositionOrCollection;
+			  beTrait ]
 ]
 
 { #category : #'old pharo 8 syntax' }
 Trait class >> named: aName uses: aTraitCompositionOrCollection slots: someSlots package: aPackageName env: anEnvironment [
-	| trait |
-	trait := self classInstaller
-		make: [ :builder |
-			self
-				configureBuilder: builder
-				withName: aName
-				traitComposition: aTraitCompositionOrCollection
-				slots: someSlots
-				packageName: aPackageName ].
-	self assert: [ trait class class = MetaclassForTraits ].
-	self assert: [ trait class superclass = Trait ].
-	^ trait
+
+	^ self classInstaller make: [ :builder |
+		  builder
+			  name: aName;
+			  slots: someSlots;
+			  category: aPackageName;
+			  traitComposition: aTraitCompositionOrCollection;
+			  beTrait ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
- use classbuilder directly
- do not set defaults again (like empty pools)
- no need to set class side using #classTraitComposition:, this is done by #traitComposition:
- more uses of #slotsFromString:


Not all done, more to come later in another PR