### PR TITLE
Fix trait definition in Calypso when fluid is enabled

### DIFF
--- a/src/Calypso-SystemPlugins-Traits-Queries/ClySystemEnvironment.extension.st
+++ b/src/Calypso-SystemPlugins-Traits-Queries/ClySystemEnvironment.extension.st
@@ -3,24 +3,14 @@ Extension { #name : #ClySystemEnvironment }
 { #category : #'*Calypso-SystemPlugins-Traits-Queries' }
 ClySystemEnvironment >> defineTrait: defString notifying: aController startingFrom: aClass [
 
-	| defTokens keywdIx oldTrait newTraitName trait |
-	aClass isTrait ifTrue:[oldTrait := aClass].
-	defTokens := defString findTokens: Character separators.
-	keywdIx := defTokens findFirst: [:x | x = 'category'].
-	keywdIx := defTokens findFirst: [:x | x = 'named:'].
-	newTraitName := (defTokens at: keywdIx+1) copyWithoutAll: '#()'.
-	((oldTrait isNil or: [oldTrait instanceSide name asString ~= newTraitName])
-		and: [self includesClassNamed: newTraitName asSymbol]) ifTrue:
-			["Attempting to define new class/trait over existing one when
-				not looking at the original one in this browser..."
-			(self confirm: ((newTraitName , ' might have been edited from another editor.
-Redefining it might override these changes.
-Is this really what you want to do?') asText makeBoldFrom: 1 to: newTraitName size))
-				ifFalse: [^ nil ]].
-
+	| trait |
 	trait := self defaultClassCompiler
 		source: defString; requestor: aController;
 		logged: true;
 		evaluate.
+		
+	"mild ugly hack for fluid traits"
+	(trait isKindOf: FluidTraitBuilder) ifTrue: [ trait := trait fluidInstall ].
+
 	^trait isTrait ifTrue: [ trait ] ifFalse: [ nil ]
 ]

--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -135,15 +135,7 @@ ClySystemEnvironment >> compileANewClassFrom: newClassDefinitionString notifying
 		 (self confirmToOverrideExistingClassNamed: newClassName) not ])
 		ifTrue: [ ^ nil ].
 
-	(self isFluidDefinition: newClassDefinitionString)
-		ifTrue: [
-			ClassDefinitionPrinter showFluidClassDefinition: true.
-			^ self
-				  defineNewClassFrom: newClassDefinitionString
-				  notifying: aController
-				  startingFrom: oldClass ]
-		ifFalse: [
-			(self isTraitDefinition: newClassDefinitionString)
+		(self isTraitDefinition: newClassDefinitionString)
 				ifTrue: [
 					^ self
 						  defineTrait: newClassDefinitionString
@@ -156,7 +148,7 @@ ClySystemEnvironment >> compileANewClassFrom: newClassDefinitionString notifying
 							  defineNewClassFrom: newClassDefinitionString
 							  notifying: aController
 							  startingFrom: oldClass ]
-						ifFalse: [ ^ nil ] ] ]
+						ifFalse: [ ^ nil ] ]
 ]
 
 { #category : #'class management' }
@@ -200,8 +192,8 @@ ClySystemEnvironment >> defineNewClassFrom: newClassDefinitionString notifying: 
 		            failBlock: [ ^ nil ];
 		            logged: true;
 		            evaluate.
-	"mild ugly hack for fluid classes (and traits)"
-	(newClass isKindOf: FluidClassBuilder) ifTrue: [ newClass := newClass install ].
+	"mild ugly hack for fluid classes"
+	(newClass isKindOf: FluidClassBuilder) ifTrue: [ newClass := newClass fluidInstall ].
 
 	^ newClass isBehavior
 		  ifTrue: [ newClass ]


### PR DESCRIPTION
- ClySystemEnvironment>>#defineTrait:notifying:startingFrom: needs to use #fluidInstall
- The check is done already in the caller (for both classes and traits), removed (just like for classes already done)
- ClySystemEnvironment>>#defineNewClassFrom:notifying:startingFrom: should call #fluidInstall
- simplify ClySystemEnvironment>>#compileANewClassFrom:notifying:startingFrom:, we do not need to handle fluid specially

Minimal changes, more cleanups needed later (there is an issue for #compileANewClassFrom:notifying:startingFrom: already)

fixes #13345