### PR TITLE
Refactor: Add "(T)" prefix to Find and Replace transformation

### DIFF
--- a/src/SystemCommands-MessageCommands/SycFindAndReplaceMethodCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycFindAndReplaceMethodCommand.class.st
@@ -31,9 +31,16 @@ SycFindAndReplaceMethodCommand >> createRefactoring [
 		inWholeHierarchy: self searchInTheWholeHierarchy
 ]
 
-{ #category : #execution }
+{ #category : #accessing }
 SycFindAndReplaceMethodCommand >> defaultMenuItemName [
-	^'Find and replace'
+
+	^ self refactoringClass menuItemString
+]
+
+{ #category : #'factory method' }
+SycFindAndReplaceMethodCommand >> refactoringClass [
+
+	^ RBFindAndReplaceTransformation
 ]
 
 { #category : #execution }


### PR DESCRIPTION
Transformations should have "(T)" prefix to let the users know they can break their applications. Find and replace transformation had hardcoded name and which is what this PR addresses.