### PR TITLE
Epicea: Add test on PackageAddition event

### DIFF
--- a/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
+++ b/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
@@ -275,10 +275,10 @@ EpCodeChangeIntegrationTest >> testPackageAddition [
 
 	self assert: (self countLogEventsWith: EpPackageAddition) equals: 0.
 
-	self packageOrganizer createPackageNamed: self categoryNameForTesting.
+	self packageOrganizer createPackageNamed: self packageNameForTesting.
 
 	self assert: (self countLogEventsWith: EpPackageAddition) equals: 1.
-	self assert: (self allLogEventsWith: EpPackageAddition) first affectedPackageName equals: self categoryNameForTesting
+	self assert: (self allLogEventsWith: EpPackageAddition) first affectedPackageName equals: self packageNameForTesting
 ]
 
 { #category : #tests }

--- a/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
+++ b/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
@@ -16,7 +16,7 @@ EpCodeChangeIntegrationTest >> categoryNameForTesting [
 { #category : #running }
 EpCodeChangeIntegrationTest >> tearDown [
 
-	self class environment organization removeCategory: self categoryNameForTesting.
+	self packageOrganizer removeCategory: self categoryNameForTesting.
 	super tearDown
 ]
 
@@ -35,7 +35,7 @@ EpCodeChangeIntegrationTest >> testCategoryAddition [
 
 	self assert: (self countLogEventsWith: EpCategoryAddition) equals: 0.
 
-	self class environment organization addCategory: self categoryNameForTesting.
+	self packageOrganizer addCategory: self categoryNameForTesting.
 
 	self assert: (self countLogEventsWith: EpCategoryAddition) equals: 1.
 	self
@@ -46,10 +46,10 @@ EpCodeChangeIntegrationTest >> testCategoryAddition [
 { #category : #tests }
 EpCodeChangeIntegrationTest >> testCategoryRemoval [
 
-	self class environment organization addCategory: self categoryNameForTesting.
+	self packageOrganizer addCategory: self categoryNameForTesting.
 	self assert: (self countLogEventsWith: EpCategoryRemoval) equals: 0.
 
-	self class environment organization removeCategory: self categoryNameForTesting.
+	self packageOrganizer removeCategory: self categoryNameForTesting.
 	self assert: (self countLogEventsWith: EpCategoryRemoval) equals: 1.
 	self
 		assert: (self allLogEventsWith: EpCategoryRemoval) first affectedPackageName

--- a/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
+++ b/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
@@ -10,13 +10,20 @@ Class {
 { #category : #tests }
 EpCodeChangeIntegrationTest >> categoryNameForTesting [
 
-	^ #'EpiceaTestingWith-A-Really-WeirdCategoryName'
+	^ (self packageNameForTesting , '-WeirdCategoryName') asSymbol
+]
+
+{ #category : #tests }
+EpCodeChangeIntegrationTest >> packageNameForTesting [
+
+	^ #'EpiceaTestingWith-A-Really-WeirdPackageName'
 ]
 
 { #category : #running }
 EpCodeChangeIntegrationTest >> tearDown [
 
 	self packageOrganizer removeCategory: self categoryNameForTesting.
+	(self packageNameForTesting asPackageIfAbsent: [ nil ]) ifNotNil: [ :package | package removeFromSystem ].
 	super tearDown
 ]
 
@@ -261,6 +268,17 @@ EpCodeChangeIntegrationTest >> testMethodRecompilationShouldNotLog [
 	aClass compile: 'fortyTwo ^42'.
 
 	self assert: monitor log head identicalTo: headBeforeRecompiling
+]
+
+{ #category : #tests }
+EpCodeChangeIntegrationTest >> testPackageAddition [
+
+	self assert: (self countLogEventsWith: EpPackageAddition) equals: 0.
+
+	self packageOrganizer createPackageNamed: self categoryNameForTesting.
+
+	self assert: (self countLogEventsWith: EpPackageAddition) equals: 1.
+	self assert: (self allLogEventsWith: EpPackageAddition) first affectedPackageName equals: self categoryNameForTesting
 ]
 
 { #category : #tests }

--- a/src/EpiceaBrowsers-Tests/EpApplyPreviewerTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpApplyPreviewerTest.class.st
@@ -112,9 +112,9 @@ EpApplyPreviewerTest >> testBehaviorNameChange [
 { #category : #tests }
 EpApplyPreviewerTest >> testCategoryAdditionWithCategoryRemoved [
 
-	self class environment organization addCategory: classFactory defaultCategory.
+	self packageOrganizer addCategory: classFactory defaultCategory.
 	self setHeadAsInputEntry.
-	self class environment organization removeCategory: classFactory defaultCategory.
+	self packageOrganizer removeCategory: classFactory defaultCategory.
 
 	self assertOutputsAnEventWith: [:output |
 		self assert: output class equals: EpCategoryAddition.
@@ -125,11 +125,11 @@ EpApplyPreviewerTest >> testCategoryAdditionWithCategoryRemoved [
 { #category : #tests }
 EpApplyPreviewerTest >> testCategoryRemovalWithCategoryAdded [
 
-	self class environment organization addCategory: classFactory defaultCategory.
-	self class environment organization removeCategory: classFactory defaultCategory.
+	self packageOrganizer addCategory: classFactory defaultCategory.
+	self packageOrganizer removeCategory: classFactory defaultCategory.
 	self setHeadAsInputEntry.
 
-	self class environment organization addCategory: classFactory defaultCategory.
+	self packageOrganizer addCategory: classFactory defaultCategory.
 
 	self assertOutputsAnEventWith: [:output |
 		self assert: output class equals: EpCategoryRemoval.
@@ -141,7 +141,7 @@ EpApplyPreviewerTest >> testCategoryRemovalWithCategoryAdded [
 EpApplyPreviewerTest >> testCategoryRenameWithPreviousRollback [
 
 	| organization aCategory anotherCategory |
-	organization := self class environment organization.
+	organization := self packageOrganizer.
 	aCategory := classFactory defaultCategory.
 	anotherCategory := aCategory, '2'.
 	organization addCategory: aCategory.
@@ -446,7 +446,7 @@ EpApplyPreviewerTest >> testRedundantBehaviorCommentChangeWithAbsentBehavior [
 { #category : #tests }
 EpApplyPreviewerTest >> testRedundantCategoryAddition [
 
-	self class environment organization addCategory: classFactory defaultCategory.
+	self packageOrganizer addCategory: classFactory defaultCategory.
 	self setHeadAsInputEntry.
 
 	self assertEmptyPreviewLog
@@ -455,8 +455,8 @@ EpApplyPreviewerTest >> testRedundantCategoryAddition [
 { #category : #tests }
 EpApplyPreviewerTest >> testRedundantCategoryRemoval [
 
-	self class environment organization addCategory: classFactory defaultCategory.
-	self class environment organization removeCategory: classFactory defaultCategory.
+	self packageOrganizer addCategory: classFactory defaultCategory.
+	self packageOrganizer removeCategory: classFactory defaultCategory.
 	self setHeadAsInputEntry.
 
 	self assertEmptyPreviewLog
@@ -466,7 +466,7 @@ EpApplyPreviewerTest >> testRedundantCategoryRemoval [
 EpApplyPreviewerTest >> testRedundantCategoryRenameWithAbsentCategory [
 
 	| organization aCategory anotherCategory |
-	organization := self class environment organization.
+	organization := self packageOrganizer.
 	aCategory := classFactory defaultCategory.
 	anotherCategory := aCategory, '2'.
 	organization addCategory: aCategory.

--- a/src/EpiceaBrowsers-Tests/EpApplyTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpApplyTest.class.st
@@ -14,12 +14,6 @@ EpApplyTest >> applyInputEntry [
 		applyCodeChanges
 ]
 
-{ #category : #helpers }
-EpApplyTest >> organization [
-
-	^ self class environment organization
-]
-
 { #category : #tests }
 EpApplyTest >> testBehaviorNameChange [
 
@@ -42,14 +36,14 @@ EpApplyTest >> testCategoryAdditionWithCategoryRemoved [
 
 	| aCategory |
 	aCategory := classFactory defaultCategory.
-	self organization addCategory: aCategory.
+	self packageOrganizer addCategory: aCategory.
 	self setHeadAsInputEntry.
-	self organization removeCategory: aCategory.
+	self packageOrganizer removeCategory: aCategory.
 
 	self assert: inputEntry content class equals: EpCategoryAddition.
-	self deny: (self organization includesCategory: aCategory).
+	self deny: (self packageOrganizer includesCategory: aCategory).
 	self applyInputEntry.
-	self assert: (self organization includesCategory: aCategory)
+	self assert: (self packageOrganizer includesCategory: aCategory)
 ]
 
 { #category : #tests }
@@ -57,15 +51,15 @@ EpApplyTest >> testCategoryRemovalWithCategoryAdded [
 
 	| aCategory |
 	aCategory := classFactory defaultCategory.
-	self organization addCategory: aCategory.
-	self organization removeCategory: aCategory.
+	self packageOrganizer addCategory: aCategory.
+	self packageOrganizer removeCategory: aCategory.
 	self setHeadAsInputEntry.
-	self organization addCategory: aCategory.
+	self packageOrganizer addCategory: aCategory.
 
 	self assert: inputEntry content class equals: EpCategoryRemoval.
-	self assert: (self organization includesCategory: aCategory).
+	self assert: (self packageOrganizer includesCategory: aCategory).
 	self applyInputEntry.
-	self deny: (self organization includesCategory: aCategory)
+	self deny: (self packageOrganizer includesCategory: aCategory)
 ]
 
 { #category : #tests }
@@ -73,18 +67,18 @@ EpApplyTest >> testCategoryRename [
 
 	| aCategory anotherCategory |
 	aCategory := classFactory defaultCategory.
-	anotherCategory := aCategory, '2'.
-	self organization addCategory: aCategory.
-	self organization renameCategory: aCategory toBe: anotherCategory.
+	anotherCategory := aCategory , '2'.
+	self packageOrganizer addCategory: aCategory.
+	self packageOrganizer renameCategory: aCategory toBe: anotherCategory.
 	self setHeadAsInputEntry.
-	self organization renameCategory: anotherCategory toBe: aCategory. "Rollback"
+	self packageOrganizer renameCategory: anotherCategory toBe: aCategory. "Rollback"
 
 	self assert: inputEntry content class equals: EpCategoryRename.
-	self assert: (self organization includesCategory: aCategory).
-	self deny: (self organization includesCategory: anotherCategory).
+	self assert: (self packageOrganizer includesCategory: aCategory).
+	self deny: (self packageOrganizer includesCategory: anotherCategory).
 	self applyInputEntry.
-	self deny: (self organization includesCategory: aCategory).
-	self assert: (self organization includesCategory: anotherCategory)
+	self deny: (self packageOrganizer includesCategory: aCategory).
+	self assert: (self packageOrganizer includesCategory: anotherCategory)
 ]
 
 { #category : #tests }
@@ -92,7 +86,7 @@ EpApplyTest >> testCategoryRenameWithClass [
 	"Let's rename a package with a class and see if the class has the right package after."
 
 	| organization aCategory anotherCategory aClass |
-	organization := self class environment organization.
+	organization := self packageOrganizer.
 	aCategory := classFactory defaultCategory.
 	anotherCategory := aCategory , '2'.
 	organization addCategory: aCategory.
@@ -116,7 +110,7 @@ EpApplyTest >> testCategoryRenameWithExtension [
 	"Let's rename a package with a class and see if the class has the right package after."
 
 	| organization aCategory anotherCategory aClass |
-	organization := self class environment organization.
+	organization := self packageOrganizer.
 	aCategory := classFactory defaultCategory.
 	anotherCategory := aCategory , '2'.
 	organization addCategory: aCategory.

--- a/src/EpiceaBrowsers-Tests/EpRevertTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpRevertTest.class.st
@@ -62,7 +62,7 @@ EpRevertTest >> testBehaviorNameChange [
 EpRevertTest >> testCategoryAdditionWithCategoryRemoved [
 
 	| organization aCategory |
-	organization := self class environment organization.
+	organization := self packageOrganizer.
 	aCategory := classFactory defaultCategory.
 	organization addCategory: aCategory.
 	self setHeadAsInputEntry.
@@ -76,7 +76,7 @@ EpRevertTest >> testCategoryAdditionWithCategoryRemoved [
 EpRevertTest >> testCategoryRemovalWithCategoryAdded [
 
 	| organization aCategory |
-	organization := self class environment organization.
+	organization := self packageOrganizer.
 	aCategory := classFactory defaultCategory.
 	organization addCategory: aCategory.
 	organization removeCategory: aCategory.
@@ -91,7 +91,7 @@ EpRevertTest >> testCategoryRemovalWithCategoryAdded [
 EpRevertTest >> testCategoryRename [
 
 	| organization aCategory anotherCategory |
-	organization := self class environment organization.
+	organization := self packageOrganizer.
 	aCategory := classFactory defaultCategory.
 	anotherCategory := aCategory, '2'.
 	organization addCategory: aCategory.

--- a/src/Morphic-Base/Object.extension.st
+++ b/src/Morphic-Base/Object.extension.st
@@ -103,18 +103,18 @@ Object >> taskbarIcon [
 ]
 
 { #category : #'*Morphic-Base' }
-Object class >> taskbarIconName [
-	"Answer the icon for an instance of the receiver in a task bar"
-
-	^#smallWindow
-]
-
-{ #category : #'*Morphic-Base' }
 Object >> taskbarIconName [
 	"Answer the icon for the receiver in a task bar
 	or nil for the default."
 
 	^self class taskbarIconName
+]
+
+{ #category : #'*Morphic-Base' }
+Object class >> taskbarIconName [
+	"Answer the icon for an instance of the receiver in a task bar"
+
+	^#smallWindow
 ]
 
 { #category : #'*Morphic-Base' }

--- a/src/Morphic-Base/StringMorph.class.st
+++ b/src/Morphic-Base/StringMorph.class.st
@@ -89,7 +89,7 @@ StringMorph class >> exampleManyStringMorphs [
 
 	| c |
 	c := AlignmentMorph newColumn.
-	self class environment organization categories do:
+	self packageOrganizer categories do:
 		[:cat | c addMorph: (StringMorph new contents: cat)].
 	^ c position: 100@50;
 			openInWorld

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -230,23 +230,21 @@ RPackageTag >> renameTo: newTagName [
 	self basicRenameTo: newTagName.
 	SystemAnnouncer uniqueInstance suspendAllWhile: [
 		self classes do: [ :each | each category: categoryName ].
-		self class environment organization renameCategory: oldName toBe: categoryName ].
+		self packageOrganizer renameCategory: oldName toBe: categoryName ].
 	SystemAnnouncer announce: (PackageTagRenamed to: self oldName: oldName newName: newTagName)
 ]
 
 { #category : #accessing }
 RPackageTag >> renameTo: aString category: categoryName [
-	| oldName |
 
+	| oldName |
 	oldName := self toCategoryName: self name.
 	oldName = categoryName ifTrue: [ ^ self ].
 
 	self basicRenameTo: aString.
 	SystemAnnouncer uniqueInstance suspendAllWhile: [
 		self classes do: [ :each | each category: categoryName ].
-		self class environment organization
-			renameCategory: oldName
-			toBe: categoryName. ]
+		self packageOrganizer renameCategory: oldName toBe: categoryName ]
 ]
 
 { #category : #private }

--- a/src/RPackage-Tests/RPackageOrganizerSystemTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerSystemTest.class.st
@@ -26,6 +26,6 @@ RPackageOrganizerSystemTest >> testThatExistingPackageNamesDoesNotContainIllegal
 
 	illegalCharacters := #( $\ $/ $: $* $? $" $< $> $| ).
 
-	self class environment organization categories do: [ :aPackageName |
+	self packageOrganizer categories do: [ :aPackageName |
 		self deny: (aPackageName includesAnyOf: illegalCharacters) ]
 ]

--- a/src/Slot-Tests/SlotAnnouncementsTest.class.st
+++ b/src/Slot-Tests/SlotAnnouncementsTest.class.st
@@ -171,11 +171,11 @@ SlotAnnouncementsTest >> testClassAddedToNewCategoryShouldAnnounceCategoryAdded 
 
 	self subscribeOn: CategoryAdded.
 
-	self deny: (self class environment organization includesCategory: self aCategory).
+	self deny: (self packageOrganizer includesCategory: self aCategory).
 
 	self createClass.
 
-	self assert: (self class environment organization includesCategory: self aCategory).
+	self assert: (self packageOrganizer includesCategory: self aCategory).
 
 	self assert: self collectedAnnouncements size equals: 1
 ]

--- a/src/TraitsV2-Tests/TraitFileOutTest.class.st
+++ b/src/TraitsV2-Tests/TraitFileOutTest.class.st
@@ -26,7 +26,7 @@ TraitFileOutTest >> categoryName [
 { #category : #running }
 TraitFileOutTest >> setUp [
 	super setUp.
-	self class environment organization addCategory: self categoryName.
+	self packageOrganizer addCategory: self categoryName.
 
 	td := self createTraitNamed: #TD uses: {}.
 	td compile: 'd' classified: #cat1.
@@ -53,7 +53,7 @@ TraitFileOutTest >> tearDown [
 	self createdClassesAndTraits, self resourceClassesAndTraits  do: [:each |
 		(dir / each asString,'st') ensureDelete ] .
 	(dir / self categoryName,'st') ensureDelete.
-	self class environment organization removeSystemCategory: self categoryName.
+	self packageOrganizer removeSystemCategory: self categoryName.
 	"Ensure cleaning of obsoletes refs"
 	ca := cb := ta := tb := tc := td := nil.
 	super tearDown
@@ -65,8 +65,8 @@ TraitFileOutTest >> testFileOutCategory [
 	file them in again."
 
 	self timeLimit: 30 seconds.
-	self class environment organization fileOutCategory: self categoryName.
-	self class environment organization removeSystemCategory: self categoryName.
+	self packageOrganizer fileOutCategory: self categoryName.
+	self packageOrganizer removeSystemCategory: self categoryName.
 	self deny: (testingEnvironment keys asSet includesAnyOf: #(#CA #CB #TA #TB #TC #TD)).
 
 	CodeImporter evaluateFileNamed: (self categoryName , '.st').


### PR DESCRIPTION
Add a test on PackageAddition event of Epicea.

We still have some missing tests on package addition execution and reversal but those feature are not even present yet.

I also updated some code to use #packageOrganization method and simplify code