### PR TITLE
ClassInstaller: improve #update:to: to do the #fillFor:

### DIFF
--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1563,11 +1563,7 @@ Behavior >> superclass: aClass [
 			].	"If the class is not nil it should update the class hierarchy correctly, using the classs builder"
 	^ self classInstaller
 		update: self
-		to: [ :builder |
-			builder
-				fillFor: self;
-				superclass: aClass
-			]
+		to: [ :builder | builder superclass: aClass ]
 ]
 
 { #category : #initialization }

--- a/src/Kernel/Metaclass.class.st
+++ b/src/Kernel/Metaclass.class.st
@@ -338,9 +338,7 @@ Metaclass >> slots: slotCollection [
 	theClass := self instanceSide.
 
 	theClass := theClass classInstaller update: theClass to: [ :builder |
-		builder
-			fillFor: theClass;
-			classSlots: slotCollection ].
+		builder classSlots: slotCollection ].
 	^ theClass classSide
 ]
 

--- a/src/Shift-ClassInstaller/Class.extension.st
+++ b/src/Shift-ClassInstaller/Class.extension.st
@@ -5,17 +5,15 @@ Class >> addClassSlot: aSlot [
 
 	^ self classInstaller update: self to: [ :builder |
 		builder
-			fillFor: self;
 			classSlots: (self class classLayout slots copyWith: aSlot)]
 ]
 
 { #category : #'*Shift-ClassInstaller' }
 Class >> addSlot: aSlot [
 
-	^self classInstaller update: self to: [ :builder |
-		builder
-			fillFor: self;
-			slots: (self localSlots copyWith: aSlot)]
+	^ self classInstaller
+		  update: self
+		  to: [ :builder | builder slots: (self localSlots copyWith: aSlot) ]
 ]
 
 { #category : #'*Shift-ClassInstaller' }
@@ -23,18 +21,15 @@ Class >> removeClassSlot: aSlot [
 
 	^ self classInstaller update: self to: [ :builder |
 		builder
-			fillFor: self;
 			classSlots: (self class classLayout slots copyWithout: aSlot)]
 ]
 
 { #category : #'*Shift-ClassInstaller' }
 Class >> removeSlot: aSlot [
 
-	(self classLayout slots includes: aSlot)
-		ifFalse: [self error: aSlot name , ' is not one of my slots'].
+	(self classLayout slots includes: aSlot) ifFalse: [
+		self error: aSlot name , ' is not one of my slots' ].
 
-	^self classInstaller update: self to: [ :builder |
-		builder
-			fillFor: self;
-			slots: (self classLayout slots copyWithout: aSlot)]
+	^ self classInstaller update: self to: [ :builder |
+		  builder slots: (self classLayout slots copyWithout: aSlot) ]
 ]

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -48,8 +48,9 @@ ShiftClassInstaller class >> make: aBlock [
 { #category : #building }
 ShiftClassInstaller class >> update: oldClass to: aBlock [
 	^ self new
+		fillFor: oldClass;
 		oldClass: oldClass;
-		make:aBlock
+		make: aBlock
 ]
 
 { #category : #validating }
@@ -102,6 +103,11 @@ ShiftClassInstaller >> copyObject: oldObject to: newClass [
 	oldObject setIsReadOnlyObject: false.
 
 	^ newObject
+]
+
+{ #category : #building }
+ShiftClassInstaller >> fillFor: aClassOrTrait [
+	builder fillFor: aClassOrTrait
 ]
 
 { #category : #building }

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -105,7 +105,7 @@ ShiftClassInstaller >> copyObject: oldObject to: newClass [
 	^ newObject
 ]
 
-{ #category : #building }
+{ #category : #initialization }
 ShiftClassInstaller >> fillFor: aClassOrTrait [
 	builder fillFor: aClassOrTrait
 ]
@@ -216,7 +216,7 @@ ShiftClassInstaller >> make: aBlock [
 	^self make
 ]
 
-{ #category : #'to sort' }
+{ #category : #initialization }
 ShiftClassInstaller >> makeWithBuilder: aBuilder [
 
 	builder := aBuilder.

--- a/src/TraitsV2/Class.extension.st
+++ b/src/TraitsV2/Class.extension.st
@@ -33,11 +33,8 @@ Class >> immediateSubclass: aName uses: aTraitComposition instanceVariableNames:
 Class >> setTraitComposition: aTraitComposition [
 
 	^ self classInstaller
-		update: self to: [ :builder |
-			builder
-				fillFor: self;
-				traitComposition: aTraitComposition;
-				classTraitComposition: aTraitComposition asTraitComposition classComposition ]
+		  update: self
+		  to: [ :builder | builder traitComposition: aTraitComposition ]
 ]
 
 { #category : #'*TraitsV2' }

--- a/src/TraitsV2/Metaclass.extension.st
+++ b/src/TraitsV2/Metaclass.extension.st
@@ -38,7 +38,6 @@ Metaclass >> trait: aTraitCompositionOrArray slots: slotArray [
 		update: theClass
 		to: [ :builder |
 			builder
-				fillFor: theClass;
 				classTraitComposition: aTraitCompositionOrArray asTraitComposition;
 				classSlots: slotArray ].
 	^ theClass classSide
@@ -66,7 +65,6 @@ Metaclass >> uses: aTraitCompositionOrArray slots: slotArray [
 		update: theClass
 		to: [ :builder |
 			builder
-				fillFor: theClass;
 				classTraitComposition: aTraitCompositionOrArray asTraitComposition;
 				classSlots: slotArray ].
 	^ theClass classSide


### PR DESCRIPTION
The change is backward compatible as calling #fillFor: twice is not a problem. 

using #update:to:  without the fillFor: made no sense, as the class then would loose everything (ivars, layout, superclass)

fixes  #14084