### PR TITLE
Compiler: allow shadowing of PseudoVariables

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -1776,23 +1776,20 @@ RBCodeSnippet class >> badSemantic [
 			         source: '| self | self := 1. ^ self';
 			         nodeAt: '00111100044442222300556666';
 			         styled: '| TTTT | tttt    n. ^ tttt';
-			         isFaulty: true;
 			         value: 1;
-			         notices: #( #( 3 6 3 'Reserved variable name' ) )).
+			         notices: #( #( 3 6 3 'Name already defined' ) )).
 		        (self new
 			         source: '| super | super := 1. ^ super';
 			         nodeAt: '00111110004444422223005566666';
 			         styled: '| TTTTT | ttttt    n. ^ ttttt';
-			         isFaulty: true;
 			         value: 1;
-			         notices: #( #( 3 7 3 'Reserved variable name' ) )).
+			         notices: #( #( 3 7 3 'Name already defined' ) )).
 		        (self new
 			         source: '| thisContext | thisContext := 1. ^ thisContext';
 			         nodeAt: '00111111111110004444444444422223005566666666666';
 			         styled: '| TTTTTTTTTTT | ttttttttttt    n. ^ ttttttttttt';
-			         isFaulty: true;
 			         value: 1;
-			         notices: #( #( 3 13 3 'Reserved variable name' ) )).
+			         notices: #( #( 3 13 3 'Name already defined' ) )).
 		        (self new
 			         source: '| Object | Object := 1. ^ Object';
 			         nodeAt: '00111111000444444222230055666666';
@@ -1804,25 +1801,22 @@ RBCodeSnippet class >> badSemantic [
 			         nodeAt: '00000111103355554446';
 			         styled: 'pppp AAAA ^ aaaa s n';
 			         isScripting: false;
-			         isFaulty: true;
 			         value: 2;
-			         notices: #( #( 6 9 6 'Reserved variable name' ) )).
+			         notices: #( #( 6 9 6 'Name already defined' ) )).
 		        (self new
 			         source: 'foo: super ^ super + 1';
 			         nodeAt: '0000011111033555554446';
 			         styled: 'pppp AAAAA ^ aaaaa s n';
 			         isScripting: false;
-			         isFaulty: true;
 			         value: 2;
-			         notices: #( #( 6 10 6 'Reserved variable name' ) )).
+			         notices: #( #( 6 10 6 'Name already defined' ) )).
 		        (self new
 			         source: 'foo: thisContext ^ thisContext + 1';
 			         nodeAt: '0000011111111111033555555555554446';
 			         styled: 'pppp AAAAAAAAAAA ^ aaaaaaaaaaa s n';
 			         isScripting: false;
-			         isFaulty: true;
 			         value: 2;
-			         notices: #( #( 6 16 6 'Reserved variable name' ) )).
+			         notices: #( #( 6 16 6 'Name already defined' ) )).
 		        (self new
 			         source: 'foo: Object ^ Object + 1';
 			         nodeAt: '000001111110335555554446';
@@ -1834,23 +1828,20 @@ RBCodeSnippet class >> badSemantic [
 			         source: '[ :self | self + 1 ]';
 			         nodeAt: '00011110004444333500';
 			         styled: '0 :BBBB | bbbb s n 0';
-			         isFaulty: true;
 			         value: 2;
-			         notices: #( #( 4 7 4 'Reserved variable name' ) )).
+			         notices: #( #( 4 7 4 'Name already defined' ) )).
 		        (self new
 			         source: '[ :super | super + 1 ]';
 			         nodeAt: '0001111100044444333500';
 			         styled: '0 :BBBBB | bbbbb s n 0';
-			         isFaulty: true;
 			         value: 2;
-			         notices: #( #( 4 8 4 'Reserved variable name' ) )).
+			         notices: #( #( 4 8 4 'Name already defined' ) )).
 		        (self new
 			         source: '[ :thisContext | thisContext + 1 ]';
 			         nodeAt: '0001111111111100044444444444333500';
 			         styled: '0 :BBBBBBBBBBB | bbbbbbbbbbb s n 0';
-			         isFaulty: true;
 			         value: 2;
-			         notices: #( #( 4 14 4 'Reserved variable name' ) )).
+			         notices: #( #( 4 14 4 'Name already defined' ) )).
 		        (self new
 			         source: '[ :Object | Object + 1 ]';
 			         nodeAt: '000111111000444444333500';

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -135,9 +135,7 @@ OCASTSemanticAnalyzer >> scope: aSemScope [
 { #category : #'error handling' }
 OCASTSemanticAnalyzer >> shadowing: var withVariable: aNode [
 
-	var isPseudoVariable
-		ifTrue: [ self error: 'Reserved variable name' forNode: aNode ]
-		ifFalse: [ aNode addWarning: 'Name already defined' ]
+	aNode addWarning: 'Name already defined'
 ]
 
 { #category : #'error handling' }

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -95,12 +95,6 @@ OCASTSemanticAnalyzer >> declareVariableNode: aVariableNode as: anOCTempVariable
 	^ var
 ]
 
-{ #category : #errors }
-OCASTSemanticAnalyzer >> error: aMessage forNode: aNode [
-
-	aNode addError: aMessage
-]
-
 { #category : #accessing }
 OCASTSemanticAnalyzer >> invalidVariables [
 	^ invalidVariables ifNil: [ invalidVariables := Dictionary new ]
@@ -188,9 +182,9 @@ OCASTSemanticAnalyzer >> visitAnnotationMarkNode: aRBAnnotationValueNode [
 	(aRBAnnotationValueNode parent isNotNil and: [
 		 aRBAnnotationValueNode parent isMessage ]) ifTrue: [
 		aRBAnnotationValueNode isHandled ifFalse: [
-			self error: 'Unknown annotation' forNode: aRBAnnotationValueNode parent ].
+			aRBAnnotationValueNode parent addError:  'Unknown annotation' ].
 		^ self ].
-	self error: 'Unexpected token' forNode: aRBAnnotationValueNode
+	aRBAnnotationValueNode addError: 'Unexpected token'
 ]
 
 { #category : #visiting }
@@ -204,7 +198,7 @@ OCASTSemanticAnalyzer >> visitAssignmentNode: anAssignmentNode [
 
 { #category : #visiting }
 OCASTSemanticAnalyzer >> visitBlockNode: aBlockNode [
-	aBlockNode arguments size >15 ifTrue: [self error: 'Too many arguments' forNode: aBlockNode ].
+	aBlockNode arguments size >15 ifTrue: [ aBlockNode addError: 'Too many arguments' ].
 
 	blockCounter := self blockCounter + 1.
 
@@ -250,7 +244,7 @@ OCASTSemanticAnalyzer >> visitMessageNode: aMessageNode [
 { #category : #visiting }
 OCASTSemanticAnalyzer >> visitMethodNode: aMethodNode [
 
-	aMethodNode arguments size > 15 ifTrue: [ self error: 'Too many arguments' forNode: aMethodNode ].
+	aMethodNode arguments size > 15 ifTrue: [ aMethodNode addError:  'Too many arguments' ].
 
 	scope := OCMethodScope new outerScope: self outerScope.
 	aMethodNode scope: scope.  scope node: aMethodNode.

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -129,6 +129,18 @@ OCCompilerTest >> testInBlockArgumentInstanceVariableShadowing [
 ]
 
 { #category : #'tests - shadowing' }
+OCCompilerTest >> testInBlockArgumentPseudoVariableShadowing [
+	self initializeErrorMessage.
+	text := 'temp [:thisProcess | ]'.
+
+	self compile.
+
+	self assert: errorMessage equals: nil.
+	self assert: errorLocation equals: nil.
+	self assert: errorSource equals: nil
+]
+
+{ #category : #'tests - shadowing' }
 OCCompilerTest >> testInBlockTempArgumentShadowing [
 
 	self initializeErrorMessage.
@@ -182,6 +194,19 @@ OCCompilerTest >> testNoShadowing [
 	self compileWithFailBlock: [
 		self fail.
 		^nil ]
+]
+
+{ #category : #'tests - shadowing' }
+OCCompilerTest >> testPseudoVariableShadowing [
+
+	self initializeErrorMessage.
+	text := 'var1 |thisContext| ^thisContext'.
+
+	self compile.
+
+	self assert: errorMessage equals: nil.
+	self assert: errorLocation equals: nil.
+	self assert: errorSource equals: nil
 ]
 
 { #category : #literals }

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -184,40 +184,6 @@ OCCompilerTest >> testNoShadowing [
 		^nil ]
 ]
 
-{ #category : #'tests - shadowing' }
-OCCompilerTest >> testReservedNameAsBlockArgumentShadowing [
-	#('self' 'super' 'thisContext' 'true' 'false' 'nil')
-		do: [ :each |
-			self initializeErrorMessage.
-			[ :exit |
-			OpalCompiler new
-				source: 'temp ^ [ :' , each , ' | ^ ' , each , ' ]';
-				class: MockForCompilation;
-				requestor: self;
-				failBlock: [ exit value ];
-				compile.
-			self fail ] valueWithExit.
-			self assert: (errorMessage = 'Variable name expected ->' or: [ errorMessage = 'Reserved variable name ->' ]).
-			self assert: errorLocation equals: 11 ]
-]
-
-{ #category : #'tests - shadowing' }
-OCCompilerTest >> testReservedNameAsMethodArgumentShadowing [
-	#('self' 'super' 'thisContext' 'true' 'false' 'nil')
-		do: [ :each |
-			self initializeErrorMessage.
-			[ :exit |
-			OpalCompiler new
-				source: 'temp: ' , each , ' ^ ' , each;
-				class: MockForCompilation;
-				requestor: self;
-				failBlock: [ exit value ];
-				compile.
-			self fail ] valueWithExit.
-			self assert: (errorMessage = 'Variable name expected ->' or: [ errorMessage = 'Reserved variable name ->' ]).
-			self assert: errorLocation equals: 7 ]
-]
-
 { #category : #literals }
 OCCompilerTest >> testScaledDecimalLiterals [
 	"Equal ScaledDecimal with different scales should use different slots

--- a/src/OpalCompiler-Tests/OpalCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTest.class.st
@@ -239,3 +239,12 @@ OpalCompilerTest >> testInstallRequestor [
 	self assert: method isNil.
 	self assert: requestor notifyList first first equals: 'Unknown character ->'
 ]
+
+{ #category : #tests }
+OpalCompilerTest >> testShadowPseudoVariable [
+	"We can shadw PseudoVariables (here thisContext) and it works"
+	| result |
+	result := Smalltalk compiler
+       evaluate: '| thisContext | thisContext := 42. ^thisContext'.
+	self assert: result equals: 42
+]


### PR DESCRIPTION
This PR unified how variable shadowing is handled: the compiler allows it now for *all* variables, on the level of the tool we warn the user.

Why is this good?

- Uniform, no variable is special due to it's name. There is no use of #isPseudoVariable anywhere anymore!

- if people used thisProcess as a tamp or arg name, it will now work and not raise a hard error. Good for backward compatibility

- removes one  case of  a hard compiler error. Instead accept the code and show the user the error so it can be fixed.