### PR TITLE
Cleanup: change method name refactoring

### DIFF
--- a/src/Refactoring-Core/RBAddParameterRefactoring.class.st
+++ b/src/Refactoring-Core/RBAddParameterRefactoring.class.st
@@ -141,17 +141,6 @@ RBAddParameterRefactoring >> newSelectorString [
 	^stream contents
 ]
 
-{ #category : #private }
-RBAddParameterRefactoring >> parseTreeRewriter [
-	| rewriteRule oldString newString |
-	rewriteRule := self parseTreeRewriterClass new.
-	oldString := self buildSelectorString: oldSelector.
-	newString := self newSelectorString.
-	rewriteRule replace: '``@object ' , oldString
-		with: '``@object ' , newString.
-	^rewriteRule
-]
-
 { #category : #action }
 RBAddParameterRefactoring >> renameArgumentsIn: parseTree [
 	| newArgNames |

--- a/src/Refactoring-Core/RBChangeMethodNameRefactoring.class.st
+++ b/src/Refactoring-Core/RBChangeMethodNameRefactoring.class.st
@@ -88,13 +88,18 @@ RBChangeMethodNameRefactoring >> newSelector [
 	^newSelector
 ]
 
+{ #category : #'instance creation' }
+RBChangeMethodNameRefactoring >> newSelectorString [ 
+	^ self buildSelectorString: newSelector
+				withPermuteMap: permutation
+]
+
 { #category : #private }
 RBChangeMethodNameRefactoring >> parseTreeRewriter [
 	| rewriteRule oldString newString |
 	rewriteRule := self parseTreeRewriterClass new.
 	oldString := self buildSelectorString: oldSelector.
-	newString := self buildSelectorString: newSelector
-				withPermuteMap: permutation.
+	newString := self newSelectorString.
 	rewriteRule replace: '``@object ' , oldString
 		with: '``@object ' , newString.
 	^rewriteRule

--- a/src/Refactoring-Core/RBChangeMethodNameRefactoring.class.st
+++ b/src/Refactoring-Core/RBChangeMethodNameRefactoring.class.st
@@ -97,12 +97,20 @@ RBChangeMethodNameRefactoring >> newSelectorString [
 { #category : #private }
 RBChangeMethodNameRefactoring >> parseTreeRewriter [
 	| rewriteRule oldString newString |
-	rewriteRule := self parseTreeRewriterClass new.
+	
 	oldString := self buildSelectorString: oldSelector.
 	newString := self newSelectorString.
+	
+	rewriteRule := self parseTreeRewriterInstance.
 	rewriteRule replace: '``@object ' , oldString
 		with: '``@object ' , newString.
 	^rewriteRule
+]
+
+{ #category : #parsing }
+RBChangeMethodNameRefactoring >> parseTreeRewriterInstance [
+
+	^ self parseTreeRewriterClass new
 ]
 
 { #category : #preconditions }

--- a/src/Refactoring-Core/RBRenameMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenameMethodRefactoring.class.st
@@ -84,18 +84,15 @@ RBRenameMethodRefactoring >> myConditions [
 				, ' doesn''t have the correct number of arguments.'
 ]
 
-{ #category : #transforming }
-RBRenameMethodRefactoring >> parseTreeRewriter [
-	| rewriteRule oldString newString |
-	oldString := self buildSelectorString: oldSelector.
-	newString := self buildSelectorString: newSelector
-				withPermuteMap: permutation.
-	rewriteRule := self hasPermutedArguments
-				ifTrue: [self parseTreeRewriterClass new]
-				ifFalse: [self parseTreeRewriterClass replaceLiteral: oldSelector with: newSelector].
-	rewriteRule replace: '``@object ' , oldString
-		with: '``@object ' , newString.
-	^rewriteRule
+{ #category : #parsing }
+RBRenameMethodRefactoring >> parseTreeRewriterInstance [
+
+	^ self hasPermutedArguments
+		  ifTrue: [ self parseTreeRewriterClass new ]
+		  ifFalse: [
+			  self parseTreeRewriterClass
+				  replaceLiteral: oldSelector
+				  with: newSelector ]
 ]
 
 { #category : #preconditions }

--- a/src/Refactoring-Core/RBReplaceMessageSendTransformation.class.st
+++ b/src/Refactoring-Core/RBReplaceMessageSendTransformation.class.st
@@ -120,19 +120,6 @@ RBReplaceMessageSendTransformation >> newSelectorString [
 	^stream contents
 ]
 
-{ #category : #transforming }
-RBReplaceMessageSendTransformation >> parseTreeRewriter [
-
-	| rewriteRule oldString newString |
-	rewriteRule := self parseTreeRewriterClass new.
-	oldString := self buildSelectorString: oldSelector.
-	newString := self newSelectorString.
-	rewriteRule
-		replace: '``@object ' , oldString
-		with: '``@object ' , newString.
-	^ rewriteRule
-]
-
 { #category : #preconditions }
 RBReplaceMessageSendTransformation >> preconditions [
 


### PR DESCRIPTION
Remove code duplication by turning `parseTreeRewriter` into a template method and add hooks that subclasses can redefine.