### PR TITLE
4074-Transcript-should-be-able-to-clear-the-contents-of-the-transcript

### DIFF
--- a/src/Transcript-Core/ThreadSafeTranscript.class.st
+++ b/src/Transcript-Core/ThreadSafeTranscript.class.st
@@ -70,14 +70,23 @@ ThreadSafeTranscript >> characterLimit [
 
 { #category : #streaming }
 ThreadSafeTranscript >> clear [
-"	Clear all characters by resetting the stream and voiding any previously flagged deferredEndEntry.
-	Redisplays the view by signalling for #step to send #changed: .
-"
-	self
-		critical: [
-			deferredClear := true.
-			deferredEndEntry := false.
-			stream reset ]
+	"Clear all characters by resetting the stream and voiding any previously flagged deferredEndEntry.
+	Redisplays the view by signalling for #step to send #changed:"
+
+	self critical: [
+		deferredClear := true.
+		deferredEndEntry := false.
+		stream reset ]
+]
+
+{ #category : #streaming }
+ThreadSafeTranscript >> clearEverything [
+	"identical to #clear but installs a new stream instead of starting it at the beginning"
+
+	self critical: [
+		deferredClear := true.
+		deferredEndEntry := false.
+		stream := String new writeStream ]
 ]
 
 { #category : #streaming }

--- a/src/Transcript-Core/ThreadSafeTranscript.class.st
+++ b/src/Transcript-Core/ThreadSafeTranscript.class.st
@@ -76,16 +76,6 @@ ThreadSafeTranscript >> clear [
 	self critical: [
 		deferredClear := true.
 		deferredEndEntry := false.
-		stream reset ]
-]
-
-{ #category : #streaming }
-ThreadSafeTranscript >> clearEverything [
-	"identical to #clear but installs a new stream instead of starting it at the beginning"
-
-	self critical: [
-		deferredClear := true.
-		deferredEndEntry := false.
 		stream := String new writeStream ]
 ]
 


### PR DESCRIPTION
add #clearEverything as described in the issue. I wonder if that should not be the default for #clear

fixes #4074