### PR TITLE
Do not use announcements for category addition sync

### DIFF
--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -173,9 +173,15 @@ RPackageOrganizer class >> unregisterInterestToSystemAnnouncement [
 RPackageOrganizer >> addCategory: catString [
 	"Add a new category named catString"
 
-	categoryMap at: catString asSymbol ifPresent: [ ^ self ] ifAbsentPut: [ OrderedCollection new ].
+	| package category |
+	category := catString asSymbol.
 
-	SystemAnnouncer uniqueInstance classCategoryAdded: catString
+	categoryMap at: category ifPresent: [ ^ self ] ifAbsentPut: [ OrderedCollection new ].
+
+	package := (self packageMatchingExtensionName: category) ifNil: [ self registerPackage: (self packageClass named: category) ].
+	package addClassTag: category.
+
+	SystemAnnouncer uniqueInstance classCategoryAdded: category
 ]
 
 { #category : #private }
@@ -757,7 +763,6 @@ RPackageOrganizer >> registerInterestToAnnouncer: anAnnouncer [
 	anAnnouncer unsubscribe: self.
 
 	anAnnouncer weak
-		when: CategoryAdded send: #systemCategoryAddedActionFrom: to: self;
 		when: CategoryRemoved send: #systemCategoryRemovedActionFrom: to: self;
 		when: CategoryRenamed send: #systemCategoryRenamedActionFrom: to: self;
 		when: ClassAdded send: #systemClassAddedActionFrom: to: self;
@@ -950,16 +955,6 @@ RPackageOrganizer >> superclassOrder: category [
 	behaviors := (self listAtCategoryNamed: category) collect: [ :title | self environment at: title ].
 	classes := behaviors select: [ :each | each isBehavior ].
 	^ Class superclassOrder: classes
-]
-
-{ #category : #'system integration' }
-RPackageOrganizer >> systemCategoryAddedActionFrom: ann [
-	| package |
-
-	package := self packageMatchingExtensionName: ann categoryName asString.
-	package ifNil: [
-		package := self registerPackage: (self packageClass named: ann categoryName asSymbol) ].
-	package addClassTag: ann categoryName asSymbol
 ]
 
 { #category : #'system integration' }


### PR DESCRIPTION
Currently we have to synchronize the categories and packages/tags. This is currently done via announcements, here I propose to do it without announcements.

Subpart of https://github.com/pharo-project/pharo/pull/14086