### PR TITLE
8782-Pharo-8-Build-1145-File-Browser-error

### DIFF
--- a/src/Tool-FileList/FileListGridNode.class.st
+++ b/src/Tool-FileList/FileListGridNode.class.st
@@ -14,15 +14,18 @@ FileListGridNode >> fileName [
 
 { #category : #'user interface' }
 FileListGridNode >> filePermissions [
+	item isSymlink ifTrue: [ ^ 'symlink' ].
 	^ self theme newTextIn: self text: item permissions asString
 ]
 
 { #category : #'user interface' }
 FileListGridNode >> fileSize [
+	item isSymlink ifTrue: [ ^ 'symlink' ].
 	^ self theme newTextIn: self text: item humanReadableSize asString
 ]
 
 { #category : #'user interface' }
 FileListGridNode >> modificationDate [
+	item isSymlink ifTrue: [ ^ 'symlink' ].
 	^ self theme newTextIn: self text: item modificationTime asString
 ]


### PR DESCRIPTION
This PR allows to use the FileList with a directory that has symlinks which point to non-exisiting files.

The Symlink model of FileSystem seems to be not good, it always operates on the target of the symlink. This PR therefore hardens the FileList to not try to read size/date and permissions of symlinks (it would show the ones of the target, which is not waht you want)

Fixes #8782