### PR TITLE
Packages should know their organizer

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -76,7 +76,8 @@ Class {
 		'metaclassExtensionSelectors',
 		'classes',
 		'name',
-		'classTags'
+		'classTags',
+		'organizer'
 	],
 	#classVars : [
 		'PackageGlobalOrganizer',
@@ -112,6 +113,14 @@ RPackage class >> named: aString [
 
 	^ self new
 		  name: aString;
+		  yourself
+]
+
+{ #category : #'instance creation' }
+RPackage class >> named: aString organizer: aPackageOrganizer [
+
+	^ (self named: aString)
+		  organizer: aPackageOrganizer;
 		  yourself
 ]
 
@@ -1033,7 +1042,15 @@ RPackage >> orderedClasses [
 
 { #category : #private }
 RPackage >> organizer [
-	^ self class organizer
+
+	self flag: #package.
+	^ organizer ifNil: [ self class organizer ]
+]
+
+{ #category : #accessing }
+RPackage >> organizer: anObject [
+
+	organizer := anObject
 ]
 
 { #category : #accessing }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -816,9 +816,8 @@ RPackageOrganizer >> registerPackage: aPackage forClassName: aClassNameSymbol [
 
 { #category : #registration }
 RPackageOrganizer >> registerPackageNamed: aString [
-	^ self
-		packageNamed: aString asSymbol
-		ifAbsent: [ (self packageClass named: aString asSymbol) register ]
+
+	^ self packageNamed: aString asSymbol ifAbsent: [ self registerPackage: (self packageClass named: aString organizer: self) ]
 ]
 
 { #category : #'deprecated - SystemOrganizer leftovers' }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -817,7 +817,7 @@ RPackageOrganizer >> registerPackage: aPackage forClassName: aClassNameSymbol [
 { #category : #registration }
 RPackageOrganizer >> registerPackageNamed: aString [
 
-	^ self packageNamed: aString asSymbol ifAbsent: [ self registerPackage: (self packageClass named: aString organizer: self) ]
+	^ self packageNamed: aString asSymbol ifAbsent: [ self registerPackage: (RPackage named: aString organizer: self) ]
 ]
 
 { #category : #'deprecated - SystemOrganizer leftovers' }


### PR DESCRIPTION
The RPackage instances do not directy know their organizer, instead they are pointing a class variable that can be updated with a weird method. This leads to really weird behavior. For example if you ask a new organizer instance to register a package, it end up registering it in another PackageOrganizer instance.  The goal of the PR is to allow to save the organizer in an instance variable. 

Since we have a lot of ways to register a package, this will not set the variable in all casses but this is a start. (I want to do small steps since it impacts **a lot** of things)