### PR TITLE
Deprecate RPackageOrganizer>>#ensureExistAndRegisterPackageNamed:

### DIFF
--- a/src/Calypso-SystemPlugins-SUnit-Browser/TClyGenerateTestClass.trait.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/TClyGenerateTestClass.trait.st
@@ -62,7 +62,7 @@ TClyGenerateTestClass >> testClassFor: inputClass [
 		ifPresent: [ :class | resultClass := class ]
 		ifAbsent: [
 			(self isValidClass: inputClass) ifFalse: [ ClyInvalidClassForTestClassGeneration signalFor: inputClass ].
-			self systemEnvironment ensureExistAndRegisterPackageNamed: inputClass package name asString , '-Tests'.
+			self systemEnvironment registerPackageNamed: inputClass package name asString , '-Tests'.
 
 			resultClass := self class classInstaller make: [ :aBuilder |
 				aBuilder name: className;

--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -200,11 +200,6 @@ ClySystemEnvironment >> defineNewClassFrom: newClassDefinitionString notifying: 
 		  ifFalse: [ nil ]
 ]
 
-{ #category : #'package management' }
-ClySystemEnvironment >> ensureExistAndRegisterPackageNamed: packageName [
-	^packageOrganizer ensureExistAndRegisterPackageNamed: packageName
-]
-
 { #category : #accessing }
 ClySystemEnvironment >> environment [
 	^ RBBrowserEnvironment new
@@ -370,6 +365,11 @@ ClySystemEnvironment >> projectManager: anObject [
 { #category : #accessing }
 ClySystemEnvironment >> projects [
 	^projectManager projects
+]
+
+{ #category : #'package management' }
+ClySystemEnvironment >> registerPackageNamed: packageName [
+	^packageOrganizer registerPackageNamed: packageName
 ]
 
 { #category : #'package management' }

--- a/src/Deprecated12/RPackageOrganizer.extension.st
+++ b/src/Deprecated12/RPackageOrganizer.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : #RPackageOrganizer }
 
 { #category : #'*Deprecated12' }
+RPackageOrganizer >> ensureExistAndRegisterPackageNamed: aSymbol [
+
+	self deprecated: 'Use #registerPackageNamed: instead.' transformWith: '`@rcv  ensureExistAndRegisterPackageNamed: `@arg' -> '`@rcv registerPackageNamed: `@arg'.
+	^ self registerPackageNamed: aSymbol
+]
+
+{ #category : #'*Deprecated12' }
 RPackageOrganizer >> packageExactlyMatchingExtensionName: anExtensionName [
 	"only look for a package for which the name match 'anExtensionName', making no difference about case. Return nil if no package is found"
 

--- a/src/EpiceaBrowsers/EpApplyVisitor.class.st
+++ b/src/EpiceaBrowsers/EpApplyVisitor.class.st
@@ -115,7 +115,7 @@ EpApplyVisitor >> visitMethodRemoval: aMethodRemoval [
 { #category : #visitor }
 EpApplyVisitor >> visitPackageAddition: aPackageAddition [
 
-	self packageOrganizer ensureExistAndRegisterPackageNamed: aPackageAddition packageName
+	self packageOrganizer registerPackageNamed: aPackageAddition packageName
 ]
 
 { #category : #visitor }

--- a/src/Monticello/MCWorkingCopy.class.st
+++ b/src/Monticello/MCWorkingCopy.class.st
@@ -344,7 +344,7 @@ MCWorkingCopy class >> registerPackage: aPackage packageOrganizer: aPackageOrgan
 	self registry at: aPackage put: workingCopy.
 	"When creating a MC package and a working copy, we need to ensure we create a system package also in case someone creates a package without an associated system package.
 	But we still check that the package does not exist because the working copy creation might be caused by the creation of the system package and we do not want to end up in a loop."
-	aPackageOrganizer packageNamedIgnoreCase: aPackage name ifAbsent: [ aPackageOrganizer ensureExistAndRegisterPackageNamed: aPackage name ].
+	aPackageOrganizer packageNamedIgnoreCase: aPackage name ifAbsent: [ aPackageOrganizer registerPackageNamed: aPackage name ].
 	self announcer announce: (MCWorkingCopyCreated workingCopy: workingCopy package: aPackage).
 	^ workingCopy
 ]

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -334,21 +334,7 @@ RPackageOrganizer >> debuggingName: aString [
 
 { #category : #initialization }
 RPackageOrganizer >> defineUnpackagedClassesPackage [
-	^ self ensureExistAndRegisterPackageNamed: self packageClass defaultPackageName
-]
-
-{ #category : #'private - registration' }
-RPackageOrganizer >> ensureExistAndRegisterPackageNamed: aSymbol [
-	"A new package is now available and declared in the receiver."
-
-	^ (self includesPackageNamed: aSymbol)
-		  ifFalse: [ self basicRegisterPackage: (RPackage named: aSymbol) ]
-		  ifTrue: [
-			  | package |
-			  package := self packageNamed: aSymbol.
-			  package extendedClasses do: [ :extendedClass | self registerExtendingPackage: package forClass: extendedClass ].
-			  package definedClasses do: [ :definedClass | self registerPackage: package forClass: definedClass ].
-			  package ]
+	^ self registerPackageNamed: self packageClass defaultPackageName
 ]
 
 { #category : #'deprecated - SystemOrganizer leftovers' }
@@ -1150,7 +1136,7 @@ RPackageOrganizer >> systemMethodRecategorizedActionFrom: ann [
 		                      ifTrue: [ self packageForProtocol: newProtocol inClass: method methodClass ]
 		                      ifFalse: [
 			                      (newProtocol beginsWith: '*')
-				                      ifTrue: [ self ensureExistAndRegisterPackageNamed: newProtocol allButFirst capitalized ]
+				                      ifTrue: [ self registerPackageNamed: newProtocol allButFirst capitalized ]
 				                      ifFalse: [ method methodClass package ] ].
 
 	methodPackage := (self hasPackageForProtocol: oldProtocol)


### PR DESCRIPTION
RPackageOrganizer>>#ensureExistAndRegisterPackageNamed: is bad because it does not register the new category in the SystemOrganizer (and even if I want to kill the SystemOrganizer, we still need it until everything using it is migrated) and it does not launch any PackageAdded event, and this is necessary if we want to remove the CategoryAdded event.

I propose to deprecate it and to make the users use #registerPackageNamed: instead (this method also does the check that the package exists).

Requires #14110