### PR TITLE
Epicea: Use the right API to create a package

### DIFF
--- a/src/EpiceaBrowsers/EpApplyVisitor.class.st
+++ b/src/EpiceaBrowsers/EpApplyVisitor.class.st
@@ -115,7 +115,7 @@ EpApplyVisitor >> visitMethodRemoval: aMethodRemoval [
 { #category : #visitor }
 EpApplyVisitor >> visitPackageAddition: aPackageAddition [
 
-	self packageOrganizer ensureExistAndRegisterPackageNamed: aPackageAddition packageName
+	self packageOrganizer registerPackageNamed: aPackageAddition packageName
 ]
 
 { #category : #visitor }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -337,9 +337,13 @@ RPackageOrganizer >> defineUnpackagedClassesPackage [
 	^ self ensureExistAndRegisterPackageNamed: self packageClass defaultPackageName
 ]
 
-{ #category : #'private - registration' }
+{ #category : #'private - deprecated' }
 RPackageOrganizer >> ensureExistAndRegisterPackageNamed: aSymbol [
-	"A new package is now available and declared in the receiver."
+	"DO NOT USE ME!!!
+	
+	Use #registerPackageNamed: instead.
+	
+	I am bad because I do not update the SystemOrganizer and I do not announce the new packages. I am still here only because I am still needed in the bootstrap. But please do not use me."
 
 	^ (self includesPackageNamed: aSymbol)
 		  ifFalse: [ self basicRegisterPackage: (RPackage named: aSymbol) ]


### PR DESCRIPTION
#ensureExistAndRegisterPackageNamed: is a private API and should not be used. Here I replace it by the public API.