### PR TITLE
RPackage: Removing category should remove the tags

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyMethodCreationToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodCreationToolMorph.class.st
@@ -131,7 +131,7 @@ ClyMethodCreationToolMorph >> setUpModelFromContext [
 	context isMethodGroupSelected ifFalse: [ ^ self ].
 	selectedGroup := context lastSelectedMethodGroup.
 	(selectedGroup isKindOf: ClyExternalPackageMethodGroup) ifTrue: [ ^ extendingPackage := selectedGroup package ].
-	(selectedGroup isKindOf: ClyMethodsInProtocolGroup) ifTrue: [ ^ methodProtocol := selectedGroup tag ]
+	(selectedGroup isKindOf: ClyMethodsInProtocolGroup) ifTrue: [ ^ methodProtocol := selectedGroup protocol ]
 ]
 
 { #category : #initialization }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -975,15 +975,13 @@ RPackageOrganizer >> systemCategoryAddedActionFrom: ann [
 RPackageOrganizer >> systemCategoryRemovedActionFrom: ann [
 	"When a system category is removed, we may: remove a tag, or remove a rpackage. If we remove a RPackage, unregister the linked MCWorkingCopy. If it is a tag, do nothing? (from what I know of RPackage, the tag should already have disappeared because it would have been empty)."
 
-	| rPackage categoryName |
+	| categoryName |
 	categoryName := ann categoryName asSymbol.
 
-	rPackage := packages at: categoryName ifAbsent: [ ^ self ].
-
-	"Consider that a rPackage with extension selectors or tags is not empty and shouldn't be removed."
-	(rPackage extensionSelectors isNotEmpty or: [ (rPackage classTags reject: [ :tag | tag name = categoryName ]) isNotEmpty ]) ifTrue: [ ^ self ].
-	categoryName = RPackage defaultPackageName ifTrue: [ ^ self ]. "We want to keep this default package."
-	self unregisterPackage: rPackage
+	(self packageMatchingExtensionName: categoryName) ifNotNil: [ :rPackage |
+		rPackage name = categoryName
+			ifTrue: [ self unregisterPackage: rPackage ]
+			ifFalse: [ rPackage classTagNamed: (categoryName withoutPrefix: rPackage name , '-') ifPresent: [ :tag | rPackage removeClassTag: tag name ] ] ]
 ]
 
 { #category : #'system integration' }

--- a/src/RPackage-Tests/RPackageOrganizerAndSystemOrganizeSynchTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerAndSystemOrganizeSynchTest.class.st
@@ -37,6 +37,25 @@ RPackageOrganizerAndSystemOrganizeSynchTest >> testAddingPackage [
 ]
 
 { #category : #tests }
+RPackageOrganizerAndSystemOrganizeSynchTest >> testRemovingCategory [
+	"Regression test because removing a category corresponding to a tag from the system organizer was not removing the package tag from the system oprganizer."
+
+	| categoryName |
+	categoryName := self packageName , '-tag1'.
+	self packageOrganizer ensureTagNamed: 'tag1' inPackageNamed: self packageName.
+
+	self assert: (self packageOrganizer packageNames includes: self packageName).
+	self assert: ((self packageOrganizer packageNamed: self packageName) classTags anySatisfy: [ :tag | tag name = 'tag1' ]).
+	self assert: (self packageOrganizer includesCategory: categoryName).
+
+	self packageOrganizer removeCategory: categoryName.
+
+	self assert: (self packageOrganizer packageNames includes: self packageName).
+	self deny: ((self packageOrganizer packageNamed: self packageName) classTags includes: 'tag1').
+	self deny: (self packageOrganizer includesCategory: categoryName)
+]
+
+{ #category : #tests }
 RPackageOrganizerAndSystemOrganizeSynchTest >> testRemovingPackage [
 	"Regression test because removing a RPackage from the system was not removing the category in SystemOrganizer."
 


### PR DESCRIPTION
Currently we have the SystemOrganizer and the RpackageOrganizer that have duplicated info and are synchronized. But this synchronization have some bugs and one of the is that #removeCategory: does not remove RPackageTag when the category is not a package. This PR fixes that to be sure we remove the RPackageTag also.

This is necessary to be able to migrate Epicea from category management to Package/Tags management (and kill slowly categories)