### PR TITLE
Remove some more categories in Epicea

### DIFF
--- a/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
+++ b/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
@@ -10,13 +10,19 @@ Class {
 { #category : #tests }
 EpCodeChangeIntegrationTest >> categoryNameForTesting [
 
-	^ (self packageNameForTesting , '-WeirdCategoryName') asSymbol
+	^ (self packageNameForTesting , '-' , self packageTagNameForTesting) asSymbol
 ]
 
 { #category : #tests }
 EpCodeChangeIntegrationTest >> packageNameForTesting [
 
 	^ #'EpiceaTestingWith-A-Really-WeirdPackageName'
+]
+
+{ #category : #tests }
+EpCodeChangeIntegrationTest >> packageTagNameForTesting [
+
+	^ 'WeirdCategoryName'
 ]
 
 { #category : #running }
@@ -42,25 +48,22 @@ EpCodeChangeIntegrationTest >> testCategoryAddition [
 
 	self assert: (self countLogEventsWith: EpCategoryAddition) equals: 0.
 
-	self packageOrganizer addCategory: self categoryNameForTesting.
+	self packageOrganizer ensureTagNamed: self packageTagNameForTesting inPackageNamed: self packageNameForTesting.
 
 	self assert: (self countLogEventsWith: EpCategoryAddition) equals: 1.
-	self
-		assert: (self allLogEventsWith: EpCategoryAddition) first affectedPackageName
-		equals: self categoryNameForTesting
+	self assert: (self allLogEventsWith: EpCategoryAddition) first categoryName equals: self categoryNameForTesting
 ]
 
 { #category : #tests }
 EpCodeChangeIntegrationTest >> testCategoryRemoval [
 
-	self packageOrganizer addCategory: self categoryNameForTesting.
+	self packageOrganizer ensureTagNamed: self packageTagNameForTesting inPackageNamed: self packageNameForTesting.
 	self assert: (self countLogEventsWith: EpCategoryRemoval) equals: 0.
 
 	self packageOrganizer removeCategory: self categoryNameForTesting.
+
 	self assert: (self countLogEventsWith: EpCategoryRemoval) equals: 1.
-	self
-		assert: (self allLogEventsWith: EpCategoryRemoval) first affectedPackageName
-		equals: self categoryNameForTesting
+	self assert: (self allLogEventsWith: EpCategoryRemoval) first categoryName equals: self categoryNameForTesting
 ]
 
 { #category : #tests }

--- a/src/EpiceaBrowsers-Tests/EpApplyPreviewerTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpApplyPreviewerTest.class.st
@@ -128,12 +128,11 @@ EpApplyPreviewerTest >> testCategoryRemovalWithCategoryAdded [
 	self packageOrganizer removeCategory: classFactory defaultCategory.
 	self setHeadAsInputEntry.
 
-	self packageOrganizer addCategory: classFactory defaultCategory.
+	self packageOrganizer ensureTagNamed: classFactory defaultTagPostfix inPackageNamed: classFactory packageName.
 
-	self assertOutputsAnEventWith: [:output |
+	self assertOutputsAnEventWith: [ :output |
 		self assert: output class equals: EpCategoryRemoval.
-		self assert: output categoryName equals: classFactory defaultCategory.
-		]
+		self assert: output categoryName equals: classFactory defaultCategory ]
 ]
 
 { #category : #tests }

--- a/src/EpiceaBrowsers-Tests/EpApplyTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpApplyTest.class.st
@@ -56,7 +56,7 @@ EpApplyTest >> testCategoryRemovalWithCategoryAdded [
 	self packageOrganizer ensureTagNamed: classFactory defaultTagPostfix inPackageNamed: classFactory packageName.
 	self packageOrganizer removeCategory: aCategory.
 	self setHeadAsInputEntry.
-	self packageOrganizer addCategory: aCategory.
+	self packageOrganizer ensureTagNamed: classFactory defaultTagPostfix inPackageNamed: classFactory packageName.
 
 	self assert: inputEntry content class equals: EpCategoryRemoval.
 	self assert: (self packageOrganizer includesCategory: aCategory).

--- a/src/EpiceaBrowsers-Tests/EpLogBrowserOperationFactoryTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpLogBrowserOperationFactoryTest.class.st
@@ -30,5 +30,6 @@ EpLogBrowserOperationFactoryTest >> tearDown [
 
 	self flag: #categories. "This tear down should not be needed but it currently is."
 	self packageOrganizer unregisterPackageNamed: classFactory packageName.
+	self packageOrganizer unregisterPackageNamed: classFactory defaultCategory.
 	super tearDown
 ]

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -227,7 +227,7 @@ RPackage >> addClassTag: aSymbol [
 	tagName := self toTagName: aSymbol.
 
 	^ self classTagNamed: tagName ifAbsent: [
-		  self class organizer validateCanBeAddedPackage: self tagName: tagName.
+		  self organizer validateCanBeAddedPackage: self tagName: tagName.
 		  newTag := self basicAddClassTag: tagName.
 		  SystemAnnouncer announce: (PackageTagAdded to: newTag).
 		  ^ newTag ]


### PR DESCRIPTION
Now that I fixed a RPackage bug we can remove some more category usage in Epicea. There are still some category usage due to other bugs in RPackage but I'll fix that later.