### PR TITLE
Allow repeated file-in (Named ChangeSet)

### DIFF
--- a/src/System-Changes-FileServices/ChangeSet.extension.st
+++ b/src/System-Changes-FileServices/ChangeSet.extension.st
@@ -5,7 +5,8 @@ ChangeSet class >> fileIntoNewChangeSet: fullName [
 	"File in all of the contents of the currently selected file, if any, into a new change set."
 	fullName ifNil: [^ self ].
 	fullName asFileReference readStreamDo: [ :readStream |
-		self newChangesFromStream: readStream named: fullName asFileReference basename ]
+		"Use UUID to avoid name collision. I'm not sure way a name is needed nor why is sould be unique BTW"
+		self newChangesFromStream: readStream named: fullName asFileReference basename withoutPeriodSuffix , '_' , UUID new asString ]
 ]
 
 { #category : #'*System-Changes-FileServices' }

--- a/src/System-Changes/ChangeSet.class.st
+++ b/src/System-Changes/ChangeSet.class.st
@@ -305,7 +305,7 @@ ChangeSet class >> newChangeSet: newName [
 	| newSet |
 	newName ifNil: [ ^ nil ].
 	(self named: newName) ifNotNil: [
-		self inform: 'Sorry that name is already used'.
+		self error: 'Sorry name "', newName , '" is already used'.
 		^ nil ].
 	newSet := self newNamed: newName.
 	AllChangeSets add: newSet.


### PR DESCRIPTION
For some reason, file-in (drag and drop a file the select "install",) goes trough the creation of a named changeset and fails if the same file is filed-in again.

Two issues, here:

* error is reported as an GUI info popup, so non actionable and non debuggable (and the error message is very bad and nonsensical to the user action).
* why the error exits at the first place?

The whole thing is complex and probably need love, in the meantime the issue is a showstopper. So the current PR is a quick workaround : append a UUID to avoid name collision.