### PR TITLE
14123-ReTestBasedTestCasesetUp-uses-old-style-class-creation-method

### DIFF
--- a/src/SUnit-Rules-Tests/ReTestBasedTestCase.class.st
+++ b/src/SUnit-Rules-Tests/ReTestBasedTestCase.class.st
@@ -20,12 +20,11 @@ ReTestBasedTestCase >> setUp [
 		named: #'Renraku-Programmatically-Created-Class-Tests') register.
 
 	"create tests in wrong package"
-	testClass := TestCase
-		subclass: 'RenrakuProgrammaticallyCreatedClassTest'
-		instanceVariableNames: ''
-		classVariableNames: ''
-		poolDictionaries: ''
-		package: testPackage name
+	testClass := self class classInstaller make: [ :builder |
+			builder
+				superclass: TestCase;
+				name: #RenrakuProgrammaticallyCreatedClassTest;
+				package: testPackage name ]
 ]
 
 { #category : #running }


### PR DESCRIPTION
fixes #14123