### PR TITLE
Demoting to package with tag should keep the organizer

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -553,21 +553,16 @@ RPackage >> definesOrExtendsClass: aClass [
 
 { #category : #converting }
 RPackage >> demoteToTagInPackageNamed: aString [
-	| newRPackage |
 
+	| newPackage |
 	aString = self name ifTrue: [ ^ self ].
 
 	self unregister.
-	newRPackage := self class organizer
-		packageNamed: aString
-		ifAbsent:  [ (self class named: aString) register ].
-	newRPackage importPackage: self.
+	newPackage := self class organizer packageNamed: aString ifAbsent: [ (self class named: aString organizer: self organizer) register ].
+	newPackage importPackage: self.
 
-	newRPackage classes do: [ :each |
-		SystemAnnouncer uniqueInstance
-			classRepackaged: each
-			from: self
-			to: newRPackage ]
+	newPackage classes do: [ :each | SystemAnnouncer uniqueInstance classRepackaged: each from: self to: newPackage ].
+	^ newPackage
 ]
 
 { #category : #properties }
@@ -741,11 +736,11 @@ RPackage >> importClass: aClass inTag: aTag [
 
 { #category : #private }
 RPackage >> importPackage: anRPackage [
-	anRPackage definedClasses
-		do: [ :className | self importClass: className ].
+
+	anRPackage definedClasses do: [ :className | self importClass: className ].
 	"new rpackage inherits the extentions"
-	classExtensionSelectors :=  classExtensionSelectors, (anRPackage classExtensionSelectors).
-	metaclassExtensionSelectors := metaclassExtensionSelectors, (anRPackage metaclassExtensionSelectors)
+	classExtensionSelectors := classExtensionSelectors , anRPackage classExtensionSelectors.
+	metaclassExtensionSelectors := metaclassExtensionSelectors , anRPackage metaclassExtensionSelectors
 ]
 
 { #category : #private }

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -112,16 +112,16 @@ RPackageTest >> testAnonymousClassAndSelector [
 
 { #category : #tests }
 RPackageTest >> testDemoteToRPackageNamed [
-	| package1 package2 class  |
 
-	package1 := (self packageClass named: #'Test1-TAG1') register.
+	| package1 package2 class |
+	package1 := (RPackage named: #'Test1-TAG1') register.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
 	class compile: 'foo ^42' classified: 'accessing'.
 
 	package1 demoteToTagInPackageNamed: 'Test1'.
 
-	self deny: (self packageClass organizer includesPackage: package1).
-	package2 := self packageClass organizer packageNamed: 'Test1'.
+	self deny: (RPackage organizer includesPackage: package1).
+	package2 := RPackage organizer packageNamed: 'Test1'.
 	self assert: package2 notNil.
 	self assert: (package2 classes includes: class).
 	self assert: ((package2 classTagNamed: 'TAG1') classes includes: class)
@@ -129,17 +129,17 @@ RPackageTest >> testDemoteToRPackageNamed [
 
 { #category : #tests }
 RPackageTest >> testDemoteToRPackageNamedExistingPackage [
-	| package1 package2 packageExisting class  |
 
-	package1 := (self packageClass named: #'Test1-TAG1') register.
-	packageExisting := (self packageClass named: #'Test1') register.
+	| package1 package2 packageExisting class |
+	package1 := (RPackage named: #'Test1-TAG1') register.
+	packageExisting := (RPackage named: #Test1) register.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
 	class compile: 'foo ^42' classified: 'accessing'.
 
 	package1 demoteToTagInPackageNamed: 'Test1'.
 
-	self deny: (self packageClass organizer includesPackage: package1).
-	package2 := self packageClass organizer packageNamed: 'Test1'.
+	self deny: (RPackage organizer includesPackage: package1).
+	package2 := RPackage organizer packageNamed: 'Test1'.
 	self assert: package2 notNil.
 	self assert: package2 equals: packageExisting.
 	self assert: (package2 classes includes: class).
@@ -147,17 +147,30 @@ RPackageTest >> testDemoteToRPackageNamedExistingPackage [
 ]
 
 { #category : #tests }
-RPackageTest >> testDemoteToRPackageNamedMultilevelPackage1 [
-	| package1 package2  class  |
+RPackageTest >> testDemoteToRPackageNamedKeepOrganizer [
 
-	package1 := (self packageClass named: #'Test1-TAG1-X1') register.
+	| newOrganizer package renamedPackage |
+	newOrganizer := RPackageOrganizer new.
+
+	package := (RPackage named: #'Test1-TAG1' organizer: newOrganizer) register.
+
+	renamedPackage := package demoteToTagInPackageNamed: 'Test1'.
+
+	self assert: renamedPackage organizer identicalTo: newOrganizer
+]
+
+{ #category : #tests }
+RPackageTest >> testDemoteToRPackageNamedMultilevelPackage1 [
+
+	| package1 package2 class |
+	package1 := (RPackage named: #'Test1-TAG1-X1') register.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1-X1'.
 	class compile: 'foo ^42' classified: 'accessing'.
 
 	package1 demoteToTagInPackageNamed: 'Test1'.
 
-	self deny: (self packageClass organizer includesPackage: package1).
-	package2 := self packageClass organizer packageNamed: 'Test1'.
+	self deny: (RPackage organizer includesPackage: package1).
+	package2 := RPackage organizer packageNamed: 'Test1'.
 	self assert: package2 notNil.
 	self assert: (package2 classes includes: class).
 	self assert: ((package2 classTagNamed: 'TAG1-X1') classes includes: class)
@@ -165,16 +178,16 @@ RPackageTest >> testDemoteToRPackageNamedMultilevelPackage1 [
 
 { #category : #tests }
 RPackageTest >> testDemoteToRPackageNamedMultilevelPackage2 [
-	| package1 package2  class  |
 
-	package1 := (self packageClass named: #'Test1-TAG1-X1') register.
+	| package1 package2 class |
+	package1 := (RPackage named: #'Test1-TAG1-X1') register.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1-X1'.
 	class compile: 'foo ^42' classified: 'accessing'.
 
 	package1 demoteToTagInPackageNamed: 'Test1-TAG1'.
 
-	self deny: (self packageClass organizer includesPackage: package1).
-	package2 := self packageClass organizer packageNamed: 'Test1-TAG1'.
+	self deny: (RPackage organizer includesPackage: package1).
+	package2 := RPackage organizer packageNamed: 'Test1-TAG1'.
 	self assert: package2 notNil.
 	self assert: (package2 classes includes: class).
 	self assert: ((package2 classTagNamed: 'X1') classes includes: class)


### PR DESCRIPTION
I started to make sure package know their organizer. Here I am updating the demotion to a package with tag to keep the organizer.

I also started to replave `self packageClass` by `RPackage` because there is no reason to not have a high coupling on RPackage in the packages RPackage and RPackage-Tests and it makes the code more readable and easier to browse.