### PR TITLE
T2TraitSlotScopeTest: use classinstaller instead of class creation method

### DIFF
--- a/src/TraitsV2-Tests/T2TraitSlotScopeTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitSlotScopeTest.class.st
@@ -231,13 +231,15 @@ T2TraitSlotScopeTest >> testSubClassWithTraitsAfterModificationOfParentSharedvar
 		with: #(otherSlot)
 		uses: t2.
 
-	c1 := Object
-		subclass: #C1
-		uses: t1
-		slots: #(aSlot)
-		classVariables: #(ClassVar)
-		poolDictionaries: ''
-		category: 'TraitsV2-Tests-TestClasses'.
+	c1 := self class classInstaller make: [ :builder |
+		  builder
+			  name: #C1;
+			  superclass: Object;
+			  slots: #(aSlot);
+			  sharedVariables: #(ClassVar);
+			  traitComposition: t1;
+			  category: 'TraitsV2-Tests-TestClasses' ].
+	createdClasses add: c1.
 
 	self assert: c2 classLayout slotScope parentScope identicalTo: c2 superclass classLayout slotScope.
 	self assert: c2 class classLayout slotScope parentScope identicalTo: c2 class superclass classLayout slotScope


### PR DESCRIPTION
fixes #14127