### PR TITLE
Changes regarding issue #14139: TTaskScheduler>>#scheduleTaskExecution: sends #requirement

### DIFF
--- a/src/TaskIt/TTaskScheduler.trait.st
+++ b/src/TaskIt/TTaskScheduler.trait.st
@@ -78,7 +78,7 @@ TTaskScheduler >> schedule: aTask timeout: aTimeout [
 { #category : #schedulling }
 TTaskScheduler >> scheduleTaskExecution: aTaskExecution [
 
-	self requirement
+	self explicitRequirement
 ]
 
 { #category : #schedulling }


### PR DESCRIPTION
Changed `requirement` to `explicitRequirement`