### PR TITLE
Reference RPackage in RPackage packages

### DIFF
--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -191,7 +191,7 @@ RPackageMCSynchronisationTest >> runCase [
 	[
 	self initializeAnnouncers.
 
-	^ self packageClass withOrganizer: self setupOrganizer do: [
+	^ RPackage withOrganizer: self setupOrganizer do: [
 		  self resources do: [ :each | each availableFor: self ].
 		  self setUp.
 		  self performTest ] ] ensure: [
@@ -205,7 +205,7 @@ RPackageMCSynchronisationTest >> setUp [
 	super setUp.
 	
 	emptyOrganizer := self organizer debuggingName: 'MCSynchronisation Package Organizer'; yourself.
-	emptyOrganizer registerPackage: (self packageClass named: 'as yet unclassified').
+	emptyOrganizer registerPackage: (RPackage named: 'as yet unclassified').
 
 	Author fullName 
 		ifNil: [ Author fullName: 'Tester' ].

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -142,17 +142,9 @@ RPackageOrganizer class >> methodAdded: anEvent [
 
 	| methodCategory |
 	methodCategory := anEvent protocol.
-	(methodCategory isEmptyOrNil or:[ methodCategory first ~= $* ])
-		ifFalse: [
-			(self isPackageDefinedForClass: anEvent methodClass)
-					ifFalse: [self packageClass new named: (self packageOrganizer categoryOfBehavior: anEvent methodClass instanceSide) ].
-		]
-]
-
-{ #category : #private }
-RPackageOrganizer class >> packageClass [
-
-	^ RPackage
+	(methodCategory isEmptyOrNil or: [ methodCategory first ~= $* ]) ifFalse: [
+		(self isPackageDefinedForClass: anEvent methodClass) ifFalse: [
+			RPackage new named: (self packageOrganizer categoryOfBehavior: anEvent methodClass instanceSide) ] ]
 ]
 
 { #category : #'class initialization' }
@@ -190,7 +182,7 @@ RPackageOrganizer >> addMethod: method [
 	protocol := method protocolName.
 	rPackage := (self hasPackageForProtocol: protocol)
 		            ifTrue: [ self packageForProtocol: protocol inClass: method methodClass ]
-		            ifFalse: [ self registerPackage: (self packageClass named: (protocol copyWithout: $*)) ].
+		            ifFalse: [ self registerPackage: (RPackage named: (protocol copyWithout: $*)) ].
 
 	rPackage addMethod: method
 ]
@@ -204,7 +196,7 @@ RPackageOrganizer >> announcer [
 RPackageOrganizer >> basicInitializeFromPackagesList: aPackagesList [
 
 	aPackagesList
-		do: [ :packageName | packages at: packageName asSymbol put: (self packageClass named: packageName) ]
+		do: [ :packageName | packages at: packageName asSymbol put: (RPackage named: packageName) ]
 		displayingProgress: 'Importing monticello packages'.
 
 	Smalltalk allClassesAndTraits do: [ :behavior | self initializeFor: behavior ] displayingProgress: 'Importing behaviors'.
@@ -275,7 +267,7 @@ RPackageOrganizer >> categoryOfElement: behaviorName [
 RPackageOrganizer >> checkPackageExistsOrRegister: packageName [
 
 	(self packages anySatisfy: [ :package | packageName isCategoryOf: package packageName ])
-		ifFalse: [ (self packageClass named: packageName capitalized) register ]
+		ifFalse: [ (RPackage named: packageName capitalized) register ]
 ]
 
 { #category : #'deprecated - SystemOrganizer leftovers' }
@@ -315,7 +307,7 @@ RPackageOrganizer >> createPackageNamed: aString [
 	| instance |
 	self validatePackageDoesNotExist: aString.
 
-	instance := self packageClass named: aString.
+	instance := RPackage named: aString.
 	self registerPackage: instance.
 	^ instance
 ]
@@ -334,7 +326,7 @@ RPackageOrganizer >> debuggingName: aString [
 
 { #category : #initialization }
 RPackageOrganizer >> defineUnpackagedClassesPackage [
-	^ self ensureExistAndRegisterPackageNamed: self packageClass defaultPackageName
+	^ self ensureExistAndRegisterPackageNamed: RPackage defaultPackageName
 ]
 
 { #category : #'private - deprecated' }
@@ -504,7 +496,7 @@ RPackageOrganizer >> initializeExtensionsFor: aBehavior protocol: aProtocol [
 	protocolName := (aProtocol name allButFirst) trimBoth.
 	package := self packageMatchingExtensionName: protocolName.
 	package ifNil: [
-		package := self basicRegisterPackage: (self packageClass named: protocolName) ].
+		package := self basicRegisterPackage: (RPackage named: protocolName) ].
 	nonTraitMethods := aProtocol methodSelectors
 		select: [ :eachSelector | (aBehavior >> eachSelector) origin = aBehavior ].
 	nonTraitMethods ifEmpty:[^ self].
@@ -521,7 +513,7 @@ RPackageOrganizer >> initializeFor: aBehavior [
 	package ifNil: [
 		"It should not happen.
 		 But actually could happen that one class is in a SystemCategory and not in a MC"
-		package := self basicRegisterPackage: (self packageClass named: aBehavior category) ].
+		package := self basicRegisterPackage: (RPackage named: aBehavior category) ].
 	package addClassDefinition: aBehavior.
 	package
 		addClassDefinition: aBehavior
@@ -569,13 +561,6 @@ RPackageOrganizer >> orderedTraitsIn: category [
 	traits := behaviors select: [ :each | each isTrait ].
 	traits := traits asSortedCollection: [ :t1 :t2 | (t2 traitComposition allTraits includes: t1) or: [ (t1 traitComposition allTraits includes: t2) not ] ].
 	^ traits asArray
-]
-
-{ #category : #accessing }
-RPackageOrganizer >> packageClass [
-	"Return the system class that represent packages."
-
-	^ RPackage
 ]
 
 { #category : #accessing }
@@ -702,7 +687,7 @@ RPackageOrganizer >> packageOf: aClass [
 
 	^ classPackageMapping
 		at: aClass instanceSide originalName
-		ifAbsent: [self packageNamed: self packageClass defaultPackageName]
+		ifAbsent: [self packageNamed: RPackage defaultPackageName]
 ]
 
 { #category : #'package - access from class' }
@@ -967,7 +952,7 @@ RPackageOrganizer >> systemCategoryAddedActionFrom: ann [
 
 	package := self packageMatchingExtensionName: ann categoryName asString.
 	package ifNil: [
-		package := self registerPackage: (self packageClass named: ann categoryName asSymbol) ].
+		package := self registerPackage: (RPackage named: ann categoryName asSymbol) ].
 	package addClassTag: ann categoryName asSymbol
 ]
 
@@ -991,7 +976,7 @@ RPackageOrganizer >> systemCategoryRenamedActionFrom: ann [
 	oldName := ann oldCategoryName asSymbol.
 	newName := ann newCategoryName asSymbol.
 	rPackage := self packageMatchingExtensionName: ann oldCategoryName.
-	rPackage ifNil: [ rPackage := (self packageClass named: newName) register ].
+	rPackage ifNil: [ rPackage := (RPackage named: newName) register ].
 	rPackage name = ann oldCategoryName ifTrue: [
 		self
 			renamePackage: rPackage
@@ -1011,7 +996,7 @@ RPackageOrganizer >> systemClassAddedActionFrom: ann [
 
 	categoryNameSymbol := class category.
 	rPackage := (self packageMatchingExtensionName: categoryNameSymbol)
-		ifNil: [ self registerPackage: (self packageClass named: categoryNameSymbol) ].
+		ifNil: [ self registerPackage: (RPackage named: categoryNameSymbol) ].
 
 	rPackage importClass: class
 ]
@@ -1026,7 +1011,7 @@ RPackageOrganizer >> systemClassRecategorizedActionFrom: announcement [
 	oldPackageName := announcement oldCategory.
 	newPackageName = oldPackageName ifTrue: [ ^ self ].
 	oldRPackage := self packageMatchingExtensionName: oldPackageName includingClass: class.
-	newRPackage := (self packageMatchingExtensionName: newPackageName) ifNil: [ self registerPackage: (self packageClass named: newPackageName) ].
+	newRPackage := (self packageMatchingExtensionName: newPackageName) ifNil: [ self registerPackage: (RPackage named: newPackageName) ].
 
 	newRPackageTag := newRPackage addClassTag: newPackageName.
 

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -62,7 +62,7 @@ RPackageIncrementalTest >> tearDown [
 							ifNone: [nil].
 		mCPackage ifNotNil: [mCPackage unregister].
 		each extendedClasses do: [ :extendedClass|
-			self packageClass organizer
+			RPackage organizer
 		 		unregisterExtendingPackage: each forClass: extendedClass.]].
 	"all ***extending*** classes the packages are also unregistered from PackageOrganizer"
 	(createdClasses reject: [:c| c isObsolete]) do: [:cls|
@@ -711,18 +711,18 @@ RPackageIncrementalTest >> testPrivateClassRegisterUnregister [
 		"ugly but necessary to test registerClass: independantly from addClassDefinition:"
 		"No event should be raised."
 	p registerClass: a1.
-	self assert: (self packageClass organizer packageOf: a1) equals: p.
+	self assert: (RPackage organizer packageOf: a1) equals: p.
 	p definedClassNames remove: #A1InPackageP1.
 	p unregisterClass: a1.
-	self assert: (self packageClass organizer packageOf: a1) isDefault.
+	self assert: (RPackage organizer packageOf: a1) isDefault.
 
 	p definedClassNames add: #A1InPackageP1.
 		"ugly but necessary to test registerClass: independant from addClassDefinition:"
 	p registerClassName: a1 name.
-	self assert: (self packageClass organizer packageOf: a1) equals: p.
+	self assert: (RPackage organizer packageOf: a1) equals: p.
 	p definedClassNames remove: #A1InPackageP1.
 	p unregisterClassName: a1 name.
-	self assert: (self packageClass organizer packageOf: a1) isDefault
+	self assert: (RPackage organizer packageOf: a1) isDefault
 ]
 
 { #category : #'tests - class addition removal' }

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -51,7 +51,7 @@ RPackageOrganizerTest >> packageOrganizer [
 { #category : #'tests - extending' }
 RPackageOrganizerTest >> pointRectangleInGraphElement [
 	| p |
-	p := self packageClass named: #GraphElement.
+	p := RPackage named: #GraphElement.
 	p addClassDefinition: Point.
 	p addMethod: Point>>#x.
 	p addMethod: Point>>#rotateBy:about:.
@@ -81,7 +81,7 @@ RPackageOrganizerTest >> setUp [
 { #category : #'tests - extending' }
 RPackageOrganizerTest >> stringCharacterInCollPackage [
 	| p |
-	p := self packageClass named: #CollPackage.
+	p := RPackage named: #CollPackage.
 	p addClassDefinition: String.
 	p addClassDefinition: Character.
 	p addMethod: String>>#indexOf:.
@@ -97,13 +97,8 @@ RPackageOrganizerTest >> tearDown [
 
 	Author fullName: previousAuthor.
 
-	(createdClasses reject: [:c| c isObsolete])
-		do: [:cls|
-				"(self packageClass organizer includesClass: cls)
-					ifTrue: [self packageOrganizer unregisterClass: cls.]."
-				cls removeFromSystem ].
-	"createdPackages do:
-		[:each | self packageOrganizer unregisterPackage: each]"
+	(createdClasses reject: [ :c | c isObsolete ]) do: [ :cls | cls removeFromSystem ].
+
 	super tearDown
 ]
 
@@ -154,7 +149,7 @@ RPackageOrganizerTest >> testDefinedClassesInstanceAndMetaSideAPI [
 RPackageOrganizerTest >> testEmpty [
 
 	self assert: self packageOrganizer packageNames size equals: 1.
-	self assert: (self packageOrganizer packageNames includes: self packageClass defaultPackageName)
+	self assert: (self packageOrganizer packageNames includes: RPackage defaultPackageName)
 ]
 
 { #category : #tests }
@@ -281,7 +276,7 @@ RPackageOrganizerTest >> testRegisterPackageConflictWithPackage [
 	package1 := self createNewPackageNamed: 'P1'.
 	package1 register.
 
-	package2 := self packageClass named: 'P1'.
+	package2 := RPackage named: 'P1'.
 	self
 		should: [ package2 register ]
 		raise: Error

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -185,9 +185,9 @@ RPackageReadOnlyCompleteSetupTest >> testCompiledMethodPackageFromOrganizer [
 
 	| method |
 	method := (testingEnvironment at: #A1DefinedInP1) >> #methodDefinedInP1.
-	self assert: (method packageFromOrganizer: self packageClass organizer) equals: p1.
+	self assert: (method packageFromOrganizer: RPackage organizer) equals: p1.
 	method := (testingEnvironment at: #A2DefinedInP2) >> #methodDefinedInP1.
-	self assert: (method packageFromOrganizer: self packageClass organizer) equals: p1
+	self assert: (method packageFromOrganizer: RPackage  organizer) equals: p1
 ]
 
 { #category : #'tests - situation' }

--- a/src/RPackage-Tests/RPackageTagTest.class.st
+++ b/src/RPackage-Tests/RPackageTagTest.class.st
@@ -20,12 +20,12 @@ RPackageTagTest >> tearDown [
 RPackageTagTest >> testAddClass [
 	| package1 package2 class |
 
-	package1 := (self packageClass named: #Test1) register.
+	package1 := (RPackage named: #Test1) register.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1'.
 
 	self assert: (package1 includesClass: class).
 
-	package2 := (self packageClass named: #Test2) register.
+	package2 := (RPackage named: #Test2) register.
 
 	(package2 addClassTag: #TAG) addClass: class.
 
@@ -39,14 +39,14 @@ RPackageTagTest >> testAddClass [
 RPackageTagTest >> testAddClassFromTag [
 	| package1 package2 class |
 
-	package1 := (self packageClass named: #Test1) register.
+	package1 := (RPackage named: #Test1) register.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
 
 	self assert: (package1 includesClass: class).
 	self assert: (package1 classTagNamed: #TAG1 ifAbsent: [ nil ]) notNil.
 	self assert: ((package1 classTagNamed: #TAG1 ifAbsent: [ nil ]) includesClass: class).
 
-	package2 := (self packageClass named: #Test2) register.
+	package2 := (RPackage named: #Test2) register.
 
 	(package2 addClassTag: #TAG2) addClass: class.
 
@@ -60,7 +60,7 @@ RPackageTagTest >> testAddClassFromTag [
 RPackageTagTest >> testAsRPackage [
 	| package1 tag convertedTag class |
 
-	package1 := (self packageClass named: #Test1) register.
+	package1 := (RPackage named: #Test1) register.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
 	class compile: 'foo ^42' classified: 'accessing'.
 
@@ -75,10 +75,10 @@ RPackageTagTest >> testAsRPackage [
 { #category : #tests }
 RPackageTagTest >> testAsRPackageWithExtensionMethods [
 	| package1 convertedTag class |
-	package1 := (self packageClass named: #Test1) register.
+	package1 := (RPackage named: #Test1) register.
 	package1 addClassTag: #TAG1.
 
-	(self packageClass named: #Test2) register.
+	(RPackage named: #Test2) register.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test2'.
 
 	class compile: 'foo ^42' classified: '*Test1-TAG1'.
@@ -93,7 +93,7 @@ RPackageTagTest >> testAsRPackageWithExtensionMethods [
 RPackageTagTest >> testPromoteAsRPackage [
 	| package1 package2 class tag1 |
 
-	package1 := (self packageClass named: #Test1) register.
+	package1 := (RPackage named: #Test1) register.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
 	class compile: 'foo ^42' classified: 'accessing'.
 
@@ -101,7 +101,7 @@ RPackageTagTest >> testPromoteAsRPackage [
 
 	tag1 promoteAsRPackage.
 
-	package2:= self packageClass organizer packageNamed: 'Test1-TAG1'.
+	package2:= RPackage organizer packageNamed: 'Test1-TAG1'.
 	self assert: package2 notNil.
 	self assert: (package2 classes includes: class).
 	self deny: (package1 classes includes: class)
@@ -111,7 +111,7 @@ RPackageTagTest >> testPromoteAsRPackage [
 RPackageTagTest >> testPromoteAsRPackageWithExtension [
 	| packageOriginal packagePromoted class classOther tag |
 
-	packageOriginal := (self packageClass named: #Test1) register.
+	packageOriginal := (RPackage named: #Test1) register.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
 	class compile: 'foo ^42' classified: #'accessing'.
 

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -56,12 +56,12 @@ RPackageTest >> testAddClass [
 RPackageTest >> testAddClassFromTag [
 	| package1 package2 class |
 
-	package1 := (self packageClass named: #Test1) register.
+	package1 := (RPackage named: #Test1) register.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG'.
 
 	self assert: (package1 includesClass: class).
 
-	package2 := (self packageClass named: #Test2) register.
+	package2 := (RPackage named: #Test2) register.
 
 	package2 addClass: class.
 
@@ -296,7 +296,7 @@ RPackageTest >> testPropertyAtPut [
 RPackageTest >> testRenameToMakesMCDirty [
 	| package |
 
-	package := (self packageClass named: #'Test1') register.
+	package := (RPackage named: #'Test1') register.
 	self createNewClassNamed: 'TestClass' inCategory: 'Test1'.
 
 	package renameTo: 'Test2'

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -57,7 +57,7 @@ RPackageTestCase >> createNewPackageNamed: aName [
 
 	| pack |
 	self removePackage: aName.
-	pack := self packageClass named: aName.
+	pack := RPackage named: aName.
 	createdPackages add: pack.
 	^ pack
 ]
@@ -100,13 +100,7 @@ RPackageTestCase >> namesOfMockTestPackages [
 { #category : #accessing }
 RPackageTestCase >> organizer [
 	"This method will access the organizer that will temporarily swapped using the withOrganizer:do: method"
-	^ self packageClass organizer
-]
-
-{ #category : #accessing }
-RPackageTestCase >> packageClass [
-	"returns the system class that represents Packages"
-	^ RPackage
+	^ RPackage organizer
 ]
 
 { #category : #accessing }
@@ -117,14 +111,14 @@ RPackageTestCase >> packageOrganizerClass [
 
 { #category : #utilities }
 RPackageTestCase >> removePackage: aName [
-	self packageClass organizer basicUnregisterPackageNamed: aName
+	RPackage organizer basicUnregisterPackageNamed: aName
 ]
 
 { #category : #running }
 RPackageTestCase >> runCase [
 
 	[
-	^ self packageClass withOrganizer: self setupOrganizer do: [
+	^ RPackage withOrganizer: self setupOrganizer do: [
 		  self resources do: [ :each | each availableFor: self ].
 		  self setUp.
 		  self performTest ] ] ensure: [

--- a/src/RPackage-Tests/RPackageTraitTest.class.st
+++ b/src/RPackage-Tests/RPackageTraitTest.class.st
@@ -89,16 +89,16 @@ RPackageTraitTest >> testPackageOfClassMethodFromTraitExtensionIsExtendingPackag
 
 	"The package of a method in A1 (which is coming from the trait T1 used by A1) is the package of T1"
 
-	self assert: (a1 >> #traitMethodExtendedFromP4 packageFromOrganizer: self packageClass organizer) equals: p4.
+	self assert: (a1 >> #traitMethodExtendedFromP4 packageFromOrganizer: RPackage  organizer) equals: p4.
 	"The package of a method in A1 (which is coming from the trait T1 used by A1 but extended in package T2) is the package of T2"
-	self assert: (a1 >> #traitMethodExtendedFromP6 packageFromOrganizer: self packageClass organizer) equals: p6
+	self assert: (a1 >> #traitMethodExtendedFromP6 packageFromOrganizer: RPackage  organizer) equals: p6
 ]
 
 { #category : #tests }
 RPackageTraitTest >> testPackageOfClassMethodFromTraitIsTraitPackage [
 	"test that a class method coming from a trait is packaged in the trait package"
 
-	self assert: (a1 >> #traitMethodDefinedInP4 packageFromOrganizer: self packageClass organizer) equals: p4.
+	self assert: (a1 >> #traitMethodDefinedInP4 packageFromOrganizer: RPackage organizer) equals: p4.
 	self assert: (a1 >> #traitMethodDefinedInP5 packageFromOrganizer: self packageOrganizer) equals: p5
 ]
 
@@ -106,18 +106,18 @@ RPackageTraitTest >> testPackageOfClassMethodFromTraitIsTraitPackage [
 RPackageTraitTest >> testPackageOfClassMethodIsClassPackage [
 	"The package of a local method (not defined in a trait) is the package of its class"
 
-	self assert: (a1 >> #localMethodDefinedInP1 packageFromOrganizer: self packageClass organizer) equals: p4.
+	self assert: (a1 >> #localMethodDefinedInP1 packageFromOrganizer: RPackage organizer) equals: p4.
 	self assert: (a1 >> #anotherLocalMethodDefinedInP1 packageFromOrganizer: self packageOrganizer) equals: p4.
-	self assert: (a1 >> #anotherLocalMethodDefinedInP1 packageFromOrganizer: self packageClass organizer) equals: p4
+	self assert: (a1 >> #anotherLocalMethodDefinedInP1 packageFromOrganizer: RPackage organizer) equals: p4
 ]
 
 { #category : #tests }
 RPackageTraitTest >> testPackageOfTraitMethodIsTraitPackage [
 	"The package of a trait method is the package of its trait."
 
-	self assert: (a1 >> #traitMethodDefinedInP5 packageFromOrganizer: self packageClass organizer) equals: p5.
+	self assert: (a1 >> #traitMethodDefinedInP5 packageFromOrganizer: RPackage organizer) equals: p5.
 	self assert: (a1 >> #traitMethodDefinedInP5 packageFromOrganizer: self packageOrganizer) equals: p5.
-	self assert: (a1 >> #traitMethodDefinedInP4 packageFromOrganizer: self packageClass organizer) equals: p4
+	self assert: (a1 >> #traitMethodDefinedInP4 packageFromOrganizer: RPackage organizer) equals: p4
 ]
 
 { #category : #tests }

--- a/src/RPackage-Tests/RPackageWithDoTest.class.st
+++ b/src/RPackage-Tests/RPackageWithDoTest.class.st
@@ -44,11 +44,6 @@ RPackageWithDoTest >> organizerAnnouncer [
 ]
 
 { #category : #tests }
-RPackageWithDoTest >> packageClass [
-	^ RPackage
-]
-
-{ #category : #tests }
 RPackageWithDoTest >> packageOrganizerClass [
 	^ RPackageOrganizer
 ]
@@ -107,7 +102,7 @@ RPackageWithDoTest >> testWithDoIsCorrectlyReinstallingDefault [
 	current := self packageOrganizer.
 	empty := self packageOrganizerClass basicNew initialize.
 	empty debuggingName: 'empty from PackageWithDoTest'.
-	self packageClass withOrganizer: empty do: [
+	RPackage withOrganizer: empty do: [
 		self
 			assert: (self organizerAnnouncer hasSubscriber: empty)
 			description: 'During #withOrganizer:do:, the system announcer should have the organizer as parameter in its subscriber.'.
@@ -129,7 +124,7 @@ RPackageWithDoTest >> testWithDoIsCorrectlyReinstallingDefaultEvenIfHalt [
 	current := self packageOrganizer.
 	empty := self packageOrganizerClass basicNew initialize.
 	[
-	self packageClass withOrganizer: empty do: [
+	RPackage withOrganizer: empty do: [
 		self
 			assert: (self organizerAnnouncer hasSubscriber: empty)
 			description: 'During #withOrganizer:do:, the system announcer should have the organizer as parameter in its subscriber.'.


### PR DESCRIPTION
There is no reason to not directly reference RPAckage class in RPackage packages. There is nothing bad about having a high coupling there. This will help me with the retro engineering for my future changes to just be able to browse the references to RPackage without to have to look at the senders of #packageClass on top of it.

Also, I plan to kill half of those references that are used to access class methods that are not good (like the one to access the global organizer since it's the instances of packages that should know the organizer)