### PR TITLE
[P11] Traits has to install method when is generated code

### DIFF
--- a/src/TraitsV2/TaAbstractComposition.class.st
+++ b/src/TraitsV2/TaAbstractComposition.class.st
@@ -320,14 +320,10 @@ TaAbstractComposition >> installSelector: aSelector into: aClass replacing: repl
 	It is probable the aliased method does not exists any more in the trait composition. This situation is checked when creating the trait composition."
 
 
-	[
-		^ (self needsRecompilation: aSelector)
+	^ (self needsRecompilation: aSelector)
 			ifTrue:[ self compile: aSelector into: aClass	]
 			ifFalse:[ self copyMethod: aSelector into: aClass replacing: replacing ].
-	 ] on: NotFound
-		do: [ ^ true ].
 
-	^ true
 ]
 
 { #category : #testing }

--- a/src/TraitsV2/TaCompositionElement.class.st
+++ b/src/TraitsV2/TaCompositionElement.class.st
@@ -123,11 +123,12 @@ TaCompositionElement >> name [
 
 { #category : #testing }
 TaCompositionElement >> needsRecompilation: aSelector [
-
 	"We need to recompile if there is a supersend"
 
-	^ (innerClass >> aSelector) sendsToSuper or: [
-		  super needsRecompilation: aSelector ]
+	^ innerClass
+		  compiledMethodAt: aSelector
+		  ifPresent: [ :aMethod | aMethod sendsToSuper or: [ super needsRecompilation: aSelector ] ]
+		  ifAbsent: [ true ]
 ]
 
 { #category : #users }


### PR DESCRIPTION
When a method is not in the trait, we install it always.
It is useful to generate methods used by Talents.