### PR TITLE
Fixed `String>>#keywords`

### DIFF
--- a/src/Collections-Strings-Tests/StringTest.class.st
+++ b/src/Collections-Strings-Tests/StringTest.class.st
@@ -1462,6 +1462,14 @@ StringTest >> testIsWideString [
 ]
 
 { #category : #tests }
+StringTest >> testKeywords [
+
+	self assert: (#foo: keywords) equals: #('foo:').
+	self assert: (#foo:bar: keywords) equals: #('foo:' 'bar:').
+	
+]
+
+{ #category : #tests }
 StringTest >> testLastSpacePosition [
 
 	self assert: 'fred the bear' lastSpacePosition equals: 9.

--- a/src/Collections-Strings-Tests/SymbolTest.class.st
+++ b/src/Collections-Strings-Tests/SymbolTest.class.st
@@ -371,6 +371,15 @@ SymbolTest >> testIsSelectorSymbol [
 	self assert: #assert:equals: isSelectorSymbol
 ]
 
+{ #category : #tests }
+SymbolTest >> testKeywordsStrict [
+
+	self assert: #foo: keywordsStrict equals: #( 'foo:' ).
+	self assert: #foo:bar: keywordsStrict equals: #( 'foo:' 'bar:' ).
+	self assert: #foo keywordsStrict equals: #(  ).
+	self assert: #+ keywordsStrict equals: #(  )
+]
+
 { #category : #requirements }
 SymbolTest >> testNew [
 

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -2085,7 +2085,7 @@ String >> join: aCollection [
 
 { #category : #converting }
 String >> keywords [
-	"Assumes the reciever is a valid keyword based selector (@reciever isKeyword > true). Returns the keywords of the provided selector"
+	"Returns the keywords of the provided selector. Assumes the reciever is a valid keyword based selector (@reciever isKeyword > true). Prefer using Symbol>>#keywordsStrict if you're not sure if the reciever is keyword-based."
 
 	"#foo: keywords >>> #('foo:')"
 

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -2085,25 +2085,26 @@ String >> join: aCollection [
 
 { #category : #converting }
 String >> keywords [
-	"Answer an array of the keywords that compose the receiver."
+	"Assumes the reciever is a valid keyword based selector (@reciever isKeyword > true). Returns the keywords of the provided selector"
+
+	"#foo: keywords >>> #('foo:')"
+
+	"#foo:bar: keywords >>> #('foo:' 'bar:')"
+
 	| keywords |
-	keywords := Array streamContents:
-		[:kwds | | char kwd | kwd := (String new: 16) writeStream.
-		1 to: self size do:
-			[:i |
-			kwd nextPut: (char := self at: i).
-			char = $: ifTrue:
-					[kwds nextPut: kwd contents.
-					kwd reset]].
-		(kwd position = 0) ifFalse: [kwds nextPut: kwd contents]].
-	(keywords size >= 1 and: [(keywords at: 1) = ':']) ifTrue:
-		["Has an initial keyword, as in #:if:then:else:"
-		keywords := keywords allButFirst].
-	(keywords size >= 2 and: [(keywords at: keywords size - 1) = ':']) ifTrue:
-		["Has a final keyword, as in #nextPut::andCR"
-		keywords := keywords copyReplaceFrom: keywords size - 1
-								to: keywords size with: {':' , keywords last}].
+	keywords := Array streamContents: [ :kwds |
+		            | kwd |
+		            kwd := (String new: 16) writeStream.
+
+		            self do: [ :char |
+			            kwd nextPut: char.
+			            char = $: ifTrue: [
+				            kwds nextPut: kwd contents.
+				            kwd reset ] ].
+
+		            kwd position = 0 ifFalse: [ kwds nextPut: kwd contents ] ].
 	^ keywords
+	
 ]
 
 { #category : #testing }

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -2090,6 +2090,10 @@ String >> keywords [
 	"#foo: keywords >>> #('foo:')"
 
 	"#foo:bar: keywords >>> #('foo:' 'bar:')"
+	
+	"#foo keywords >>> #('foo')" "Invalid input/output !"
+	
+	"#+ keywords >>> #('+')" "Invalid input/output !"
 
 	| keywords |
 	keywords := Array streamContents: [ :kwds |

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -497,11 +497,19 @@ Symbol >> isUnary [
 
 { #category : #sorting }
 Symbol >> keywordsStrict [
-	"Returns the keywords of the provided selector. Does not assume that the reciever is keyword-based."
+	"Returns the keywords of the provided selector. If the receiver is not keyword-based, an empty array is returned."
+
+	"#foo: keywordsStrict >>> #('foo:')"
+
+	"#foo:bar: keywordsStrict >>> #('foo:' 'bar:')"
+
+	"#foo keywordsStrict >>> #()"
+
+	"#+ keywordsStrict >>> #()"
 
 	^ self isKeyword
 		  ifTrue: [ self keywords ]
-		  ifFalse: [ #() ]
+		  ifFalse: [ #(  ) ]
 ]
 
 { #category : #comparing }

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -495,6 +495,15 @@ Symbol >> isUnary [
 	^ self precedence = 1
 ]
 
+{ #category : #sorting }
+Symbol >> keywordsStrict [
+	"Returns the keywords of the provided selector. Does not assume that the reciever is keyword-based."
+
+	^ self isKeyword
+		  ifTrue: [ self keywords ]
+		  ifFalse: [ #() ]
+]
+
 { #category : #comparing }
 Symbol >> literalEqual: other [
 


### PR DESCRIPTION
Fixed problem from pharo-project/pharo#14140

Added comment and tests for method `String>>#keywords`.
Created `Symbol>>#keywordsStrict` and tests for new usages.

The final goal is to deprecate `String>>#keywords`.