### PR TITLE
double click selection on symbols should include #

### DIFF
--- a/src/Rubric-Tests/RubTextEditorTest.class.st
+++ b/src/Rubric-Tests/RubTextEditorTest.class.st
@@ -107,6 +107,48 @@ RubTextEditorTest >> testPreviousWord [
 ]
 
 { #category : #tests }
+RubTextEditorTest >> testSelectWord [
+
+	string := '#Lorem #ipsum #dolor #sit #amet'.
+	editor addString: string.
+
+	editor selectWordMark: 0 point: 0.
+	editor selectWord.
+	
+	self assert: editor hasSelection.
+	self assert: editor selection equals: '#Lorem'.
+	
+	editor selectWordMark: 2 point: 4. "Lorem ipsum dolor sit amet >> [Lorem ]ipsum dolor sit amet "
+	editor selectWord.	
+	self assert: editor selection equals: '#Lorem'.
+	
+	editor selectWordMark: 9 point: 11. "Lorem ipsum dolor sit amet >> Lorem [ipsum] dolor sit amet "
+	editor selectWord.		
+	self assert: editor selection equals: '#ipsum'.
+	
+	editor selectWordMark: 9 point: 12. "Lorem ipsum dolor sit amet >> Lorem [ipsum ]dolor sit amet "
+	editor selectWord.	
+	self assert: editor selection equals: '#ipsum'.
+
+	editor selectWordMark: 3 point: 24. "Lorem ipsum dolor sit amet >> [Lorem ipsum dolor sit amet ]"
+	editor selectWord.	
+	self assert: editor selection equals: '#sit'.
+	
+	editor selectWordMark: 1 point: 26. "Lorem ipsum dolor sit amet >> [Lorem ipsum dolor sit amet ]"
+	editor selectWord.	
+	self assert: editor selection equals: '#amet'.
+	
+	editor selectWordMark: 1 point: 1. "Lorem ipsum dolor sit amet >> [Lorem] ipsum dolor sit amet"
+	editor selectWord.	
+	self assert: editor selection equals: '#Lorem'.
+
+	editor selectWordMark: 26 point: 26. "Lorem ipsum dolor sit amet >> Lorem ipsum dolor sit [amet ]"
+	editor selectWord.	
+	self assert: editor selection equals: '#amet'.
+
+]
+
+{ #category : #tests }
 RubTextEditorTest >> testSelectWordMarkPoint [
 
 	| textSize |

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -2159,7 +2159,7 @@ RubTextEditor >> selectWord [
 			[hereChar := string at: (here := here + direction).
 			match = 0
 				ifTrue: ["token scan goes left, then right"
-					hereChar tokenish
+					(hereChar tokenish or: [ hereChar = $# ])
 						ifTrue: [here = 1
 								ifTrue:
 									[start := 1.


### PR DESCRIPTION
For issue #14056.
Change in RubTextEditor scan characters behavior (selectWord method ) to include the Character numeral (#) on double click selection on symbols.
Add test.
