### PR TITLE
Remove references to #allManagers in RPackage

### DIFF
--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -83,48 +83,11 @@ RPackageMCSynchronisationTest >> cleanClassesPackagesAndCategories [
 		removeCategory: 'OriginalCategory';
 		removeCategory: 'NewCategoryName';
 		removeCategory: 'Y'.
-	self allManagers
-		detect: [ :each | each packageName = 'OriginalCategory' ]
-		ifFound: [ :mCPackage | mCPackage unregister ].
-	self allManagers
-		detect: [ :each | each packageName = 'XXXXX' ]
-		ifFound: [ :mCPackage | mCPackage unregister ].
-	self allManagers
-		detect: [ :each | each packageName = 'XXXX' ]
-		ifFound: [ :mCPackage | mCPackage unregister ].
-	self allManagers
-		detect: [ :each | each packageName = 'YYYYY' ]
-		ifFound: [ :mCPackage | mCPackage unregister ].
-	self allManagers
-		detect: [ :each | each packageName = 'YYYY' ]
-		ifFound: [ :mCPackage | mCPackage unregister ].
-	self allManagers
-		detect: [ :each | each packageName = 'Yyyyy' ]
-		ifFound: [ :mCPackage | mCPackage unregister ].
-	self allManagers
-		detect: [ :each | each packageName = 'YyYyY' ]
-		ifFound: [ :mCPackage | mCPackage unregister ].
-	self allManagers
-		detect: [ :each | each packageName = 'Y' ]
-		ifFound: [ :mCPackage | mCPackage unregister ].
-	self allManagers
-		detect: [ :each | each packageName = 'ZZZZZ' ]
-		ifFound: [ :mCPackage | mCPackage unregister ].
-	self allManagers
-		detect: [ :each | each packageName = 'Zzzzz' ]
-		ifFound: [ :mCPackage | mCPackage unregister ].
-	self allManagers
-		detect: [ :each | each packageName = 'FooPackage-Core' ]
-		ifFound: [ :mCPackage | mCPackage unregister ].
-	self allManagers
-		detect: [ :each | each packageName = 'FooPackage-Other' ]
-		ifFound: [ :mCPackage | mCPackage unregister ].
-	self allManagers
-		detect: [ :each | each packageName = 'FooPackage' ]
-		ifFound: [ :mCPackage | mCPackage unregister ].
-	self allManagers
-		detect: [ :each | each packageName = 'Zork' ]
-		ifFound: [ :mCPackage | mCPackage unregister ]
+	#( 'OriginalCategory' 'XXXXX' 'XXXX' 'YYYYY' 'YYYY' 'Yyyyy' 'YyYyY' 'Y' 'ZZZZZ' 'Zzzzz' 'FooPackage-Core' 'FooPackage-Other' 'FooPackage' 'Zork' ) do: [
+		:packageName |
+		self allWorkingCopies
+			detect: [ :each | each packageName = packageName ]
+			ifFound: [ :mCPackage | mCPackage unregister ] ]
 ]
 
 { #category : #private }

--- a/src/Monticello-Tests/RPackageMonticelloSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMonticelloSynchronisationTest.class.st
@@ -31,7 +31,7 @@ RPackageMonticelloSynchronisationTest >> testUnloadMCPackageRemovesRPackage [
 	"test that when we remove a MC Package, the corresponding RPackage is removed from the organizer"
 
 	MCWorkingCopy ensureForPackageNamed: 'XXXXX' packageOrganizer: self organizer.
-	(self allManagers detect: [ :each | each packageName = 'XXXXX' ]) unload.
+	(self allWorkingCopies detect: [ :each | each packageName = 'XXXXX' ]) unload.
 
 	self deny: (self organizer includesPackageNamed: #XXXXX)
 ]
@@ -41,7 +41,7 @@ RPackageMonticelloSynchronisationTest >> testUnregisterMCPackageKeepsRPackage [
 	"test that when we remove a MC Package, the corresponding RPackage is removed from the organizer"
 
 	MCWorkingCopy ensureForPackageNamed: 'XXXXX' packageOrganizer: self organizer.
-	(self allManagers detect: [ :each | each packageName = 'XXXXX' ]) unregister.
+	(self allWorkingCopies detect: [ :each | each packageName = 'XXXXX' ]) unregister.
 
 	self assert: (self organizer includesPackageNamed: #XXXXX)
 ]

--- a/src/Monticello/MCWorkingCopy.class.st
+++ b/src/Monticello/MCWorkingCopy.class.st
@@ -38,6 +38,13 @@ Class {
 
 { #category : #accessing }
 MCWorkingCopy class >> allManagers [
+	"Do not use. This will be deprecated."
+
+	^ self allWorkingCopies
+]
+
+{ #category : #accessing }
+MCWorkingCopy class >> allWorkingCopies [
 	^ self registry values
 ]
 

--- a/src/Monticello/RPackageOrganizer.extension.st
+++ b/src/Monticello/RPackageOrganizer.extension.st
@@ -1,20 +1,8 @@
 Extension { #name : #RPackageOrganizer }
 
 { #category : #'*Monticello-RPackage' }
-RPackageOrganizer >> allManagers [
-
-	^ self class allManagers 
-]
-
-{ #category : #'*Monticello-RPackage' }
-RPackageOrganizer class >> allManagers [
-
-	^ MCWorkingCopy allManagers
-]
-
-{ #category : #'*Monticello-RPackage' }
 RPackageOrganizer >> isDefinedAsPackageOrSubPackageInMC: aSymbol [
 	"a category has been added. "
 
-	^ self allManagers anySatisfy: [ :manager | manager packageName isCategoryOf: aSymbol ]
+	^ MCWorkingCopy allWorkingCopies anySatisfy: [ :manager | manager packageName isCategoryOf: aSymbol ]
 ]

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -52,31 +52,23 @@ RPackageIncrementalTest >> setUp [
 RPackageIncrementalTest >> tearDown [
 
 	| logging |
-	createdPackages  do: [:each | self removePackage: each name].
+	createdPackages do: [ :each | self removePackage: each name ].
 	"just remove package from package organizer dictionary"
 
-	createdPackages  do: [:each |
-		|mCPackage|
-		mCPackage := self allManagers
-							detect: [:mcPackage | mcPackage packageName = each packageName asString]
-							ifNone: [nil].
-		mCPackage ifNotNil: [mCPackage unregister].
-		each extendedClasses do: [ :extendedClass|
-			RPackage organizer
-		 		unregisterExtendingPackage: each forClass: extendedClass.]].
+	createdPackages do: [ :each |
+		self allWorkingCopies
+			detect: [ :mcPackage | mcPackage packageName = each packageName asString ]
+			ifFound: [ :mcPackage | mcPackage unregister ].
+		each extendedClasses do: [ :extendedClass | RPackage organizer unregisterExtendingPackage: each forClass: extendedClass ] ].
 	"all ***extending*** classes the packages are also unregistered from PackageOrganizer"
-	(createdClasses reject: [:c| c isObsolete]) do: [:cls|
-		"(RPackage organizer includesPackageBackPointerForClass: cls)
+	(createdClasses reject: [ :c | c isObsolete ]) do: [ :cls | "(RPackage organizer includesPackageBackPointerForClass: cls)
 			ifTrue: [cls package unregisterClass: cls.].
 		when RPackageOrganizer was not looking at system event we had to do the commented actions"
 		logging := false.
-		cls removeFromSystem: logging.
+		cls removeFromSystem: logging
 		"not logging so no event are raised"
-		"but this also means that the consistency cannot be ensured by internal system announcer too."
-		].
-	createdCategories do: [:each |
-		self packageOrganizer removeCategory: each.
-		 ].
+		"but this also means that the consistency cannot be ensured by internal system announcer too." ].
+	createdCategories do: [ :each | self packageOrganizer removeCategory: each ].
 	super tearDown
 ]
 

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -13,9 +13,9 @@ Class {
 }
 
 { #category : #accessing }
-RPackageTestCase >> allManagers [
+RPackageTestCase >> allWorkingCopies [
 
-	^ MCWorkingCopy allManagers
+	^ MCWorkingCopy allWorkingCopies
 ]
 
 { #category : #utilities }


### PR DESCRIPTION
MCWorkingCopy>>#allManagers returns all the working copies. I propose to rename it to #allWorkingCopies. Here is a first step renaming it in RPackage.