### PR TITLE
New flow for `MoveMethodsToClassSide`

### DIFF
--- a/src/Refactoring-Core/RBMoveMethodToClassSideRefactoring.class.st
+++ b/src/Refactoring-Core/RBMoveMethodToClassSideRefactoring.class.st
@@ -79,6 +79,20 @@ RBMoveMethodToClassSideRefactoring >> checkVariableNamed: aString [
 	^ (self parseTree allDefinedVariables includes: aString)
 ]
 
+{ #category : #refactoring }
+RBMoveMethodToClassSideRefactoring >> generateChanges [
+	
+	self applicabilityConditions check ifFalse: [
+		^ RBApplicabilityChecksFailedError signal:
+			  self applicabilityConditions errorString ].
+	self breakingChangeConditions check ifFalse: [
+		RBBreakingChangeChecksFailedWarning signal:
+			self breakingChangeConditions errorString ].
+
+	self transform.
+	^ self changes
+]
+
 { #category : #transforming }
 RBMoveMethodToClassSideRefactoring >> getNewInstSideSource [
 	| sender |

--- a/src/Refactoring-UI/RBMoveMethodsToClassSideDriver.class.st
+++ b/src/Refactoring-UI/RBMoveMethodsToClassSideDriver.class.st
@@ -28,67 +28,52 @@ RBMoveMethodsToClassSideDriver class >> model: aNamespace scopes: scopesList met
 	^ self new model: aNamespace scopes: scopesList methods: aCollectionOfMethods
 ]
 
-{ #category : #preconditions }
-RBMoveMethodsToClassSideDriver >> checkApplicability [
-
-	| checks |
-	checks := self refactorings collect: [ :each |
-		          each applicabilityConditions check ].
-	^ checks reduce: [ :a :b | a & b ]
-]
-
-{ #category : #preconditions }
-RBMoveMethodsToClassSideDriver >> checkBreakingChanges [
-
-	| checks |
-	checks := self refactorings collect: [ :each |
-		          each breakingChangeConditions check ].
-	^ checks reduce: [ :a :b | a & b ]
-]
-
-{ #category : #preconditions }
-RBMoveMethodsToClassSideDriver >> confirmBreakingChanges [
+{ #category : #execution }
+RBMoveMethodsToClassSideDriver >> displayErrors: errorsList [
 
 	| errorStrings |
-	errorStrings := self refactorings
-		                reject: [ :each | each breakingChangeConditions check ]
-		                thenCollect: [ :each |
-		                each breakingChangeConditions errorString ].
+
 	errorStrings := String streamContents: [ :stream |
-		                errorStrings
-			                do: [ :str | stream << str ]
+		                errorsList
+			                do: [ :err | stream << err messageText ]
 			                separatedBy: [ stream << String cr ] ].
-	errorStrings := errorStrings , String cr
-	                , ' Method(s) in the class side will be overwritten.'.
-	RBRefactoringWarning signal: errorStrings
+	^ RBRefactoringError signal: errorStrings
+]
+
+{ #category : #execution }
+RBMoveMethodsToClassSideDriver >> displayWarnings: errorsList [
+
+	| errorStrings |
+
+	errorStrings := String streamContents: [ :stream |
+		                errorsList
+			                do: [ :err | stream << err messageText ]
+			                separatedBy: [ stream << String cr ] ].
+	^ RBRefactoringWarning signal: errorStrings
 ]
 
 { #category : #execution }
 RBMoveMethodsToClassSideDriver >> execute [
 
-	self checkApplicability ifFalse: [ self refactoringError ].
-	self checkBreakingChanges ifFalse: [ "Open warning dialog. It throws an error if user answers No."
-		self confirmBreakingChanges ].
-	self executeRefactorings
-]
+	| compositeChangesList errors warnings |
+	errors := OrderedCollection new.
+	warnings := OrderedCollection new.
+	compositeChangesList := refactorings collect: [ :refactoring |
+		                   [
+		                   [ refactoring generateChanges ]
+			                   on: RBRefactoringError
+			                   do: [ :err |
+				                   errors add: err. nil ] ]
+			                   on: RBBreakingChangeChecksFailedWarning
+			                   do: [ :err |
+				                   warnings add: err. nil ] ]
+		thenReject: [ :ref | ref isNil ].
 
-{ #category : #execution }
-RBMoveMethodsToClassSideDriver >> executeRefactorings [
+	errors ifNotEmpty: [ self displayErrors: errors ].
 
-	refactorings do: [ :each |
-		each transform.
-		each performChanges ]
-]
+	warnings ifNotEmpty: [ self displayWarnings: warnings ].
 
-{ #category : #accessing }
-RBMoveMethodsToClassSideDriver >> generateRefactorings [
-
-	refactorings := methods collect: [ :each |
-		                RBMoveMethodToClassSideRefactoring
-			                model: model
-			                method: each
-			                class: each origin ].
-	^ refactorings
+	self openPreviewWithChanges: compositeChangesList
 ]
 
 { #category : #initialization }
@@ -102,25 +87,4 @@ RBMoveMethodsToClassSideDriver >> model: aNamespace scopes: scopesList methods: 
 			                model: model
 			                method: m
 			                class: m origin ]
-]
-
-{ #category : #error }
-RBMoveMethodsToClassSideDriver >> refactoringError [
-
-	| errorStrings |
-	errorStrings := self refactorings
-		                reject: [ :each | each applicabilityConditions check ]
-		                thenCollect: [ :each |
-		                each applicabilityConditions errorString ].
-	errorStrings := String streamContents: [ :stream |
-		                errorStrings
-			                do: [ :str | stream << str ]
-			                separatedBy: [ stream << String cr ] ].
-	RBRefactoringError signal: errorStrings
-]
-
-{ #category : #accessing }
-RBMoveMethodsToClassSideDriver >> refactorings [
-
-	^ refactorings ifNil: [ self generateRefactorings ]
 ]

--- a/src/Refactoring-UI/RBMoveMethodsToClassSideDriver.class.st
+++ b/src/Refactoring-UI/RBMoveMethodsToClassSideDriver.class.st
@@ -23,9 +23,9 @@ Class {
 }
 
 { #category : #'instance creation' }
-RBMoveMethodsToClassSideDriver class >> model: aNamespace methods: aCollectionOfMethods [
+RBMoveMethodsToClassSideDriver class >> model: aNamespace scopes: scopesList methods: aCollectionOfMethods [
 
-	^ self new model: aNamespace methods: aCollectionOfMethods
+	^ self new model: aNamespace scopes: scopesList methods: aCollectionOfMethods
 ]
 
 { #category : #preconditions }
@@ -92,9 +92,16 @@ RBMoveMethodsToClassSideDriver >> generateRefactorings [
 ]
 
 { #category : #initialization }
-RBMoveMethodsToClassSideDriver >> model: aNamespace methods: aCollection [
+RBMoveMethodsToClassSideDriver >> model: aNamespace scopes: scopesList methods: aCollection [
+
 	model := aNamespace.
-	methods := aCollection
+	scopes := scopesList.
+	methods := aCollection.
+	refactorings := methods collect: [ :m |
+		                RBMoveMethodToClassSideRefactoring
+			                model: model
+			                method: m
+			                class: m origin ]
 ]
 
 { #category : #error }

--- a/src/Refactoring-UI/RBPushDownMethodDriver.class.st
+++ b/src/Refactoring-UI/RBPushDownMethodDriver.class.st
@@ -46,7 +46,7 @@ RBPushDownMethodDriver >> execute [
 			           RBRefactoringWarning signal: err messageText.
 			           "If user answers no, error is being propagated."
 			           err resume ].
-	self openPreviewWithChanges: changes
+	self openPreviewWithChanges: { changes }
 ]
 
 { #category : #initialization }

--- a/src/Refactoring-UI/RBPushDownMethodInSomeClassesDriver.class.st
+++ b/src/Refactoring-UI/RBPushDownMethodInSomeClassesDriver.class.st
@@ -40,7 +40,7 @@ RBPushDownMethodInSomeClassesDriver >> execute [
 			           RBRefactoringWarning signal: err messageText.
 			           "If user answers no, error is being propagated."
 			           err resume ].
-	self openPreviewWithChanges: changes
+	self openPreviewWithChanges: { changes }
 ]
 
 { #category : #resources }

--- a/src/Refactoring-UI/RBPushUpMethodDriver.class.st
+++ b/src/Refactoring-UI/RBPushUpMethodDriver.class.st
@@ -52,7 +52,7 @@ RBPushUpMethodDriver >> execute [
 			           RBRefactoringWarning signal: err messageText.
 			           "If user answers no, error is being propagated."
 			           err resume ].
-	self openPreviewWithChanges: changes
+	self openPreviewWithChanges: { changes }
 ]
 
 { #category : #initialization }

--- a/src/Refactoring-UI/RBRemoveInstanceVariableDriver.class.st
+++ b/src/Refactoring-UI/RBRemoveInstanceVariableDriver.class.st
@@ -17,7 +17,7 @@ RBRemoveInstanceVariableDriver >> execute [
 		[ 
 			| changes |
 			changes := refactoring generateChanges.
-			self openPreviewWithChanges: changes ]
+			self openPreviewWithChanges: { changes } ]
 		           on: RBApplicabilityChecksFailedError
 		           do: [ :err |
 		           		^ RBRefactoringError signal: err messageText ] ]

--- a/src/Refactoring-UI/RBRenameMethodDriver.class.st
+++ b/src/Refactoring-UI/RBRenameMethodDriver.class.st
@@ -51,7 +51,7 @@ RBRenameMethodDriver >> execute [
 		refactoring renameMap: newMessage renameMap.
 		refactoring newNameDoesNotRequireRefactoringPreconditions check.
 		changes := refactoring generateChanges.
-		self openPreviewWithChanges: changes
+		self openPreviewWithChanges: { changes }
 		"arg postAction value." ]
 			on: RBApplicabilityChecksFailedError
 			do: [ :err | ^ RBRefactoringError signal: err messageText ] ]

--- a/src/Refactoring-UI/StRefactoringPreviewPresenter.class.st
+++ b/src/Refactoring-UI/StRefactoringPreviewPresenter.class.st
@@ -68,7 +68,8 @@ StRefactoringPreviewPresenter >> buildDiffFor: aChange [
 { #category : #initialization }
 StRefactoringPreviewPresenter >> changesFrom: aCompositeChange scopes: aCollection [
 
-	changes := aCompositeChange whatToDisplayIn: self.
+	changes := aCompositeChange collect: [ :each | each whatToDisplayIn: self].
+	changes := changes flattened.
 	scopes := aCollection.
 	self updateScopeList.
 	self updateChanges.

--- a/src/SystemCommands-MethodCommands/SycMoveMethodsToClassSideCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMoveMethodsToClassSideCommand.class.st
@@ -4,6 +4,9 @@ I am a command to move method to the class side of defining class
 Class {
 	#name : #SycMoveMethodsToClassSideCommand,
 	#superclass : #SycMethodCommand,
+	#instVars : [
+		'refactoringScopes'
+	],
 	#category : #'SystemCommands-MethodCommands'
 }
 
@@ -26,5 +29,12 @@ SycMoveMethodsToClassSideCommand >> defaultMenuItemName [
 { #category : #execution }
 SycMoveMethodsToClassSideCommand >> execute [
 
-	(RBMoveMethodsToClassSideDriver model: model methods: methods) execute
+	(RBMoveMethodsToClassSideDriver model: model scopes: refactoringScopes methods: methods) execute
+]
+
+{ #category : #execution }
+SycMoveMethodsToClassSideCommand >> prepareFullExecutionInContext: aToolContext [
+
+	super prepareFullExecutionInContext: aToolContext.
+	refactoringScopes := aToolContext refactoringScopes
 ]


### PR DESCRIPTION
Now this has better flow when user supplies multiple methods to move to class side. 
New flow aggregates all warnings and errors and changes. If there are errors, a pop-up is shown. If there are warnings a yes/no pop-up is shown whether user wants to continue. In the end changes are shown to the user.
`StRefactoringPreviewPresenter`s API is changed so that it supports bulk changes.

Right now it shows `RBRefactoringWarning` if there are breaking changes. On `no` it aborts execution, on `yes` continues without breaking changes included. What do you think if we would on `yes` include all changes (that is include breaking changes) and on `no` just perform the safe ones?