### PR TITLE
Extend Behavior>>handleFailingBasicNew:

### DIFF
--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -689,10 +689,22 @@ Behavior >> handleFailingBasicNew: sizeRequested [
 	<primitive: 71>
 	| bytesRequested |
 	bytesRequested := self byteSizeOfInstanceOfSize: sizeRequested.
-	Smalltalk garbageCollect < bytesRequested ifTrue:
-		[Smalltalk growMemoryByAtLeast: bytesRequested].
-	"retry after global garbage collect and possible grow"
-	^self handleFailingFailingBasicNew: sizeRequested
+	^ Smalltalk garbageCollect < bytesRequested ifTrue: 
+		[ Smalltalk growMemoryByAtLeast: bytesRequested. "retry after global garbage collect and possible grow"
+		self handleFailingFailingBasicNew: sizeRequested ]
+	ifFalse: 
+		[ self handleFailingBasicNewWithGC: sizeRequested ]
+]
+
+{ #category : #private }
+Behavior >> handleFailingBasicNewWithGC: sizeRequested [
+	"handleFailingBasicNewWithGC: gets sent after basicNew: has failed, a GC has been	performed and the allocation still fails even though enough memory was reported 	as available. Given that this has happened when there is plenty of virtual memory available, assume that the GC has reported incorrectly and try one more time anyway.	 Primitive. Answer an instance of this class with the number of indexable	 variables specified by the argument, sizeRequested.  Fail if this class is not	 indexable or if the argument is not a positive Integer, or if there is not	 enough memory available. Essential. See Object documentation whatIsAPrimitive."
+
+	<primitive: 71>
+	| bytesRequested |
+	bytesRequested := self byteSizeOfInstanceOfSize: sizeRequested.
+	Smalltalk growMemoryByAtLeast: bytesRequested.
+	^ self handleFailingFailingBasicNew: sizeRequested
 ]
 
 { #category : #private }


### PR DESCRIPTION
to handle the case where the process is interrupted between garbage collection and the second allocation attempt to grow memory if the second attempt fails.

Fixes: https://github.com/pharo-project/pharo/issues/14195