### PR TITLE
14191 failing tests rb code snippet testtest styler

### DIFF
--- a/src/Shout-Tests/RBCodeSnippet.extension.st
+++ b/src/Shout-Tests/RBCodeSnippet.extension.st
@@ -5,7 +5,9 @@ RBCodeSnippet >> mockedStyledText [
 
 	| text |
 	text := self source asText.
-	SHRBMockTextStyler new style: text ast: self doSemanticAnalysis.
+	SHRBMockTextStyler new
+		declared: #(#< #> #| #+ #- #-- #a #a: #abs #bar #e #foo #foo: #ifTrue:ifFalse: #max: #min: #sign #sign: #signal: #value value: );
+		style: text ast: self doSemanticAnalysis.
 
 	^ (1 to: text size)
 		  collect: [ :index |

--- a/src/Shout-Tests/SHRBMockTextStyler.class.st
+++ b/src/Shout-Tests/SHRBMockTextStyler.class.st
@@ -4,6 +4,9 @@ I am a styler for tests that will add instances of SHRBTextFlagAttributes to the
 Class {
 	#name : #SHRBMockTextStyler,
 	#superclass : #SHRBTextStyler,
+	#instVars : [
+		'declared'
+	],
 	#classVars : [
 		'PatternStyleDictionary'
 	],
@@ -103,4 +106,30 @@ SHRBMockTextStyler class >> patternStyleTable [
 SHRBMockTextStyler >> attributesFor: aSymbol [
 
 	^ { (SHRBTextFlagAttribute named: aSymbol) }
+]
+
+{ #category : #accessing }
+SHRBMockTextStyler >> declared [
+
+	^ declared
+]
+
+{ #category : #accessing }
+SHRBMockTextStyler >> declared: anObject [
+
+	declared := anObject
+]
+
+{ #category : #visiting }
+SHRBMockTextStyler >> formatIncompleteSelector: aSymbol [
+
+	(declared includes: aSymbol) ifTrue: [ ^ nil ].
+	^ (declared anySatisfy: [ :each | each beginsWith: aSymbol ]) ifTrue: [ #incompleteSelector ] ifFalse: [ #undefinedSelector ]
+]
+
+{ #category : #initialization }
+SHRBMockTextStyler >> initialize [
+
+	super initialize.
+	declared := OrderedCollection new
 ]

--- a/src/Shout-Tests/SHRBStyleAttributionTest.class.st
+++ b/src/Shout-Tests/SHRBStyleAttributionTest.class.st
@@ -35,6 +35,7 @@ SHRBStyleAttributionTest >> setUp [
 
 	super setUp.
 	styler := SHRBMockTextStyler new.
+	styler declared: #( #/ #setUp #style: testKeywordStyle ).
 	oldSetting := SHRBMockTextStyler instVarNamed: #formatIncompleteIdentifiers
 ]
 

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -712,9 +712,10 @@ SHRBTextStyler >> classOrMetaClass: aBehavior [
 ]
 
 { #category : #visiting }
-SHRBTextStyler >> formatIncompleteSelector: aMessageNode [
+SHRBTextStyler >> formatIncompleteSelector: aSymbol [
 
-	^ (self class formatIncompleteIdentifiers and: [ (Symbol selectorThatStartsCaseSensitive: aMessageNode selector asString skipping: nil) isNotNil ])
+	aSymbol isSelectorSymbol ifTrue: [ ^ nil ].
+	^ (self class formatIncompleteIdentifiers and: [ (Symbol selectorThatStartsCaseSensitive: aSymbol asString skipping: nil) isNotNil ])
 		  ifTrue: [ #incompleteSelector ]
 		  ifFalse: [ #undefinedSelector ]
 ]
@@ -1074,12 +1075,10 @@ SHRBTextStyler >> visitLiteralValueNode: aLiteralValueNode [
 { #category : #visiting }
 SHRBTextStyler >> visitMessageNode: aMessageNode [
 
-	| style link styleName |
+	| style link |
 	
-	styleName := aMessageNode isAnnotation ifTrue: [ #pragma ] ifFalse: [ #selector ].
-	style := aMessageNode selector isSelectorSymbol
-		         ifTrue: [ styleName ]
-		         ifFalse: [ self formatIncompleteSelector: aMessageNode ].
+	style := (self formatIncompleteSelector: aMessageNode selector) ifNil: [
+		aMessageNode isAnnotation ifTrue: [ #pragma ] ifFalse: [ #selector ] ].
 
 	link := TextMethodLink sourceNode: aMessageNode.
 


### PR DESCRIPTION
Teach `SHRBMockTextStyler`  to use its own collection of defined symbols instead of relying on the `Symbol` methods that query the whole image.
Tests should now be more robust and more independent of the image content.

fix #14191
fix #14201