### PR TITLE
14034 debugger does not evaluate in the context of the receiver

### DIFF
--- a/src/OpalCompiler-Core/OCContextualDoItSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCContextualDoItSemanticScope.class.st
@@ -86,11 +86,6 @@ OCContextualDoItSemanticScope >> receiver [
 ]
 
 { #category : #accessing }
-OCContextualDoItSemanticScope >> targetClass [
-	^targetContext compiledCode methodClass
-]
-
-{ #category : #accessing }
 OCContextualDoItSemanticScope >> targetContext [
 
 	^ targetContext

--- a/src/OpalCompiler-Core/OCDoItSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCDoItSemanticScope.class.st
@@ -35,3 +35,8 @@ OCDoItSemanticScope >> isDoItScope [
 OCDoItSemanticScope >> receiver [
 	^ self subclassResponsibility
 ]
+
+{ #category : #accessing }
+OCDoItSemanticScope >> targetClass [
+	^ self receiver class
+]

--- a/src/OpalCompiler-Core/OCReceiverDoItSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCReceiverDoItSemanticScope.class.st
@@ -45,11 +45,6 @@ OCReceiverDoItSemanticScope >> receiver: anObject [
 ]
 
 { #category : #accessing }
-OCReceiverDoItSemanticScope >> targetClass [
-	^targetReceiver class
-]
-
-{ #category : #accessing }
 OCReceiverDoItSemanticScope >> targetReceiver [
 
 	^ targetReceiver

--- a/src/OpalCompiler-Tests/OCDoitTest.class.st
+++ b/src/OpalCompiler-Tests/OCDoitTest.class.st
@@ -56,6 +56,22 @@ OCDoitTest >> testDoItContextReadIvar [
 ]
 
 { #category : #tests }
+OCDoitTest >> testDoItContextReadIvarSubclass [
+
+	| ctx value method |
+	"Cet a method compiled for a base class"
+	method := Object compiler compile: 'foo ^thisContext'.
+	ctx := self executeMethod: method.
+
+	ivarForTesting := #someValue.
+	value := ctx compiler evaluate: 'ivarForTesting'.
+	self assert: value equals: #someValue.
+
+	value := ctx compiler evaluate: 'ivarForTesting := #someOtherValue'.
+	ivarForTesting := #someOtherValue
+]
+
+{ #category : #tests }
 OCDoitTest >> testDoItContextReadTemp [
 	| tempForTesting value |
 	"we can read this temp from a doit when executing against thisContext"


### PR DESCRIPTION
`OCContextualDoItSemanticScope` considers the class of the current receiver and not the class of the original method, therefore ivars and cie are related to the current receiver.
The new behaviour is done through a small refactorization. Code is now simpler \o/
Also add a test.

fix #14034