### PR TITLE
10568-hardcoded-class-definition-in-opal

### DIFF
--- a/src/Kernel/ClassDefinitionPrinter.class.st
+++ b/src/Kernel/ClassDefinitionPrinter.class.st
@@ -186,7 +186,7 @@ ClassDefinitionPrinter >> classDefinitionTemplateInPackage: aPackageName [
 	^ self classDefinitionTemplateInPackage: aPackageName named: #MyClass
 ]
 
-{ #category : #printing }
+{ #category : #template }
 ClassDefinitionPrinter >> classDefinitionTemplateInPackage: aPackageName named: aClassName [
 	^ self subclassResponsibility
 ]

--- a/src/Kernel/ClassDefinitionPrinter.class.st
+++ b/src/Kernel/ClassDefinitionPrinter.class.st
@@ -183,11 +183,11 @@ ClassDefinitionPrinter >> classDefinitionString [
 
 { #category : #accessing }
 ClassDefinitionPrinter >> classDefinitionTemplateInPackage: aPackageName [
-	^ self classDefinitionTemplateInPackage: aPackageName forClass: #MyClass
+	^ self classDefinitionTemplateInPackage: aPackageName named: #MyClass
 ]
 
 { #category : #printing }
-ClassDefinitionPrinter >> classDefinitionTemplateInPackage: aPackageName forClass: aClassName [
+ClassDefinitionPrinter >> classDefinitionTemplateInPackage: aPackageName named: aClassName [
 	^ self subclassResponsibility
 ]
 
@@ -226,6 +226,16 @@ ClassDefinitionPrinter >> testClassDefinitionTemplateInPackage: aString [
 
 { #category : #'public api' }
 ClassDefinitionPrinter >> traitDefinitionString [
+	^ self subclassResponsibility
+]
+
+{ #category : #template }
+ClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aString [
+	^ self traitDefinitionTemplateInPackage: aString named: #TMyTrait
+]
+
+{ #category : #template }
+ClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aPackageName named: aTraitName [ 
 	^ self subclassResponsibility
 ]
 

--- a/src/Kernel/FluidClassDefinitionPrinter.class.st
+++ b/src/Kernel/FluidClassDefinitionPrinter.class.st
@@ -62,18 +62,18 @@ FluidClassDefinitionPrinter >> classDefinitionString [
 		  self packageOn: s ]
 ]
 
-{ #category : #printing }
+{ #category : #template }
 FluidClassDefinitionPrinter >> classDefinitionTemplateInPackage: aPackageName named: aClassName [
 
 		^ String streamContents: [ :s |
-						s nextPutAll: 'Object << '. aClassName asSymbol printOn: s. s crtab.
+						s nextPutAll: 'Object << '; print: aClassName asSymbol; crtab.
 						s nextPutAll: 'layout: FixedLayout;'; crtab.
 						s nextPutAll: 'traits: {};'; crtab.
 						s nextPutAll: 'slots: {};'; crtab.
 						s nextPutAll: 'sharedVariables: {};'; crtab.
 						s nextPutAll: 'sharedPools: {};'; crtab.
 						s nextPutAll: 'tag: '''' ;';crtab.
-						s nextPutAll: 'package: ''', aPackageName, '''' ]
+						s nextPutAll: 'package: '''; nextPutAll: aPackageName; nextPutAll: '''' ]
 ]
 
 { #category : #'elementary operations' }
@@ -437,7 +437,9 @@ FluidClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aPackageName na
 
 	^ String streamContents: [ :s |
 		  s
-			  nextPutAll: 'Trait << '. aTraitName asSymbol printOn: s. s crtab.
+			  nextPutAll: 'Trait << ';
+			  print: aTraitName asSymbol;
+			  crtab.
 		  s
 			  nextPutAll: 'traits: {};';
 			  crtab.

--- a/src/Kernel/FluidClassDefinitionPrinter.class.st
+++ b/src/Kernel/FluidClassDefinitionPrinter.class.st
@@ -63,7 +63,7 @@ FluidClassDefinitionPrinter >> classDefinitionString [
 ]
 
 { #category : #printing }
-FluidClassDefinitionPrinter >> classDefinitionTemplateInPackage: aPackageName forClass: aClassName [
+FluidClassDefinitionPrinter >> classDefinitionTemplateInPackage: aPackageName named: aClassName [
 
 		^ String streamContents: [ :s |
 						s nextPutAll: 'Object << '. aClassName asSymbol printOn: s. s crtab.
@@ -432,13 +432,12 @@ FluidClassDefinitionPrinter >> traitDefinitionString [
 			self packageOn: strm ]
 ]
 
-{ #category : #printing }
-FluidClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aPackageName [
+{ #category : #template }
+FluidClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aPackageName named: aTraitName [
 
 	^ String streamContents: [ :s |
 		  s
-			  nextPutAll: 'Trait << #TMyTrait';
-			  crtab.
+			  nextPutAll: 'Trait << '. aTraitName asSymbol printOn: s. s crtab.
 		  s
 			  nextPutAll: 'traits: {};';
 			  crtab.

--- a/src/Kernel/LegacyClassDefinitionPrinter.class.st
+++ b/src/Kernel/LegacyClassDefinitionPrinter.class.st
@@ -124,7 +124,7 @@ LegacyClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aString named:
 	^ String streamContents: [ :s |
 		  s
 			  nextPutAll: 'Trait named: ';
-			  nextPutAll: aTraitName;
+			  print: aTraitName asSymbol;
 			  nextPutAll: ' uses: {}
 	 package: '''.
 		  s

--- a/src/Kernel/LegacyClassDefinitionPrinter.class.st
+++ b/src/Kernel/LegacyClassDefinitionPrinter.class.st
@@ -51,7 +51,7 @@ LegacyClassDefinitionPrinter >> classDefinitionString [
 ]
 
 { #category : #template }
-LegacyClassDefinitionPrinter >> classDefinitionTemplateInPackage: aString forClass: aClassName [
+LegacyClassDefinitionPrinter >> classDefinitionTemplateInPackage: aString named: aClassName [
 
 	^ String streamContents: [ :s |
 			s nextPutAll: 'Object subclass: '. aClassName asSymbol printOn: s. s crtab.
@@ -104,6 +104,17 @@ LegacyClassDefinitionPrinter >> traitDefinitionString [
 			nextPutAll: ' package: ';
 			nextPutAll: forClass category asString printString
 	]
+]
+
+{ #category : #template }
+LegacyClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aString named: aTraitName [
+
+	^ String streamContents: [ :s |
+			s nextPutAll: 'Trait named: ';
+				nextPutAll: aTraitName;
+				nextPutAll: ' uses: {}
+	 package: '''.
+			s nextPutAll: aString; nextPut: $' ]
 ]
 
 { #category : #'public API' }

--- a/src/Kernel/LegacyClassDefinitionPrinter.class.st
+++ b/src/Kernel/LegacyClassDefinitionPrinter.class.st
@@ -54,11 +54,23 @@ LegacyClassDefinitionPrinter >> classDefinitionString [
 LegacyClassDefinitionPrinter >> classDefinitionTemplateInPackage: aString named: aClassName [
 
 	^ String streamContents: [ :s |
-			s nextPutAll: 'Object subclass: '. aClassName asSymbol printOn: s. s crtab.
-			s nextPutAll: 'instanceVariableNames: '''' '; crtab.
-			s nextPutAll: 'classVariableNames: '''''; crtab.
-			s nextPutAll: 'poolDictionaries: '''''; crtab.
-			s nextPutAll: 'category ''', aString, '''' ]
+		  s
+			  nextPutAll: 'Object subclass: ';
+			  print: aClassName asSymbol;
+			  crtab.
+		  s
+			  nextPutAll: 'instanceVariableNames: '''' ';
+			  crtab.
+		  s
+			  nextPutAll: 'classVariableNames: ''''';
+			  crtab.
+		  s
+			  nextPutAll: 'poolDictionaries: ''''';
+			  crtab.
+		  s
+			  nextPutAll: 'category ''';
+			  nextPutAll: aString;
+			  nextPutAll: '''' ]
 ]
 
 { #category : #delegating }
@@ -110,11 +122,14 @@ LegacyClassDefinitionPrinter >> traitDefinitionString [
 LegacyClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aString named: aTraitName [
 
 	^ String streamContents: [ :s |
-			s nextPutAll: 'Trait named: ';
-				nextPutAll: aTraitName;
-				nextPutAll: ' uses: {}
+		  s
+			  nextPutAll: 'Trait named: ';
+			  nextPutAll: aTraitName;
+			  nextPutAll: ' uses: {}
 	 package: '''.
-			s nextPutAll: aString; nextPut: $' ]
+		  s
+			  nextPutAll: aString;
+			  nextPut: $' ]
 ]
 
 { #category : #'public API' }

--- a/src/Kernel/OldPharoClassDefinitionPrinter.class.st
+++ b/src/Kernel/OldPharoClassDefinitionPrinter.class.st
@@ -206,7 +206,7 @@ OldPharoClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aString name
 	^ String streamContents: [ :s |
 		  s
 			  nextPutAll: 'Trait named: ';
-			  nextPutAll: aTraitName;
+			  print: aTraitName asSymbol;
 			  nextPutAll: ' uses: {}
 	 package: '''.
 		  s

--- a/src/Kernel/OldPharoClassDefinitionPrinter.class.st
+++ b/src/Kernel/OldPharoClassDefinitionPrinter.class.st
@@ -84,7 +84,7 @@ OldPharoClassDefinitionPrinter >> classDefinitionString [
 ]
 
 { #category : #template }
-OldPharoClassDefinitionPrinter >> classDefinitionTemplateInPackage: aString forClass: aClassName [
+OldPharoClassDefinitionPrinter >> classDefinitionTemplateInPackage: aString named: aClassName [
 
 	^ String streamContents: [ :s |
 			s nextPutAll: 'Object subclass: '. aClassName asSymbol printOn: s. s crtab.
@@ -191,11 +191,12 @@ OldPharoClassDefinitionPrinter >> traitDefinitionString [
 ]
 
 { #category : #template }
-OldPharoClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aString [
+OldPharoClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aString named: aTraitName [
 
 	^ String streamContents: [ :s |
-			s nextPutAll: 'Trait named: #TMyTraits
-	 uses: {}
+			s nextPutAll: 'Trait named: ';
+				nextPutAll: aTraitName;
+				nextPutAll: ' uses: {}
 	 package: '''.
 			s nextPutAll: aString; nextPut: $' ]
 ]

--- a/src/Kernel/OldPharoClassDefinitionPrinter.class.st
+++ b/src/Kernel/OldPharoClassDefinitionPrinter.class.st
@@ -87,10 +87,20 @@ OldPharoClassDefinitionPrinter >> classDefinitionString [
 OldPharoClassDefinitionPrinter >> classDefinitionTemplateInPackage: aString named: aClassName [
 
 	^ String streamContents: [ :s |
-			s nextPutAll: 'Object subclass: '. aClassName asSymbol printOn: s. s crtab.
-			s nextPutAll: 'instanceVariableNames: '''' '; crtab.
-			s nextPutAll: 'classVariableNames: '''''; crtab.
-			s nextPutAll: 'package: ''', aString, '''' ]
+		  s 
+			nextPutAll: 'Object subclass: ';
+		  	print: aClassName asSymbol; 
+		  	crtab.
+		  s
+			  nextPutAll: 'instanceVariableNames: '''' ';
+			  crtab.
+		  s
+			  nextPutAll: 'classVariableNames: ''''';
+			  crtab.
+		  s
+			  nextPutAll: 'package: ''';
+			  nextPutAll: aString;
+			  nextPutAll: '''' ]
 ]
 
 { #category : #'low-level elements' }
@@ -194,11 +204,14 @@ OldPharoClassDefinitionPrinter >> traitDefinitionString [
 OldPharoClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aString named: aTraitName [
 
 	^ String streamContents: [ :s |
-			s nextPutAll: 'Trait named: ';
-				nextPutAll: aTraitName;
-				nextPutAll: ' uses: {}
+		  s
+			  nextPutAll: 'Trait named: ';
+			  nextPutAll: aTraitName;
+			  nextPutAll: ' uses: {}
 	 package: '''.
-			s nextPutAll: aString; nextPut: $' ]
+		  s
+			  nextPutAll: aString;
+			  nextPut: $' ]
 ]
 
 { #category : #'public API' }

--- a/src/OpalCompiler-Core/OCCodeReparator.class.st
+++ b/src/OpalCompiler-Core/OCCodeReparator.class.st
@@ -66,29 +66,39 @@ OCCodeReparator >> declareTempAndPaste: name [
 ]
 
 { #category : #correcting }
-OCCodeReparator >> defineClass: className [
+OCCodeReparator >> defineClass: classSymbol [
 	"Prompts the user to define a new class."
 
-	| classSymbol systemCategory classDefinition classBinding result |
-	classSymbol := className asSymbol.
-	systemCategory := node methodNode methodClass category
-		ifNil: [ 'Unknown' ].
-	classDefinition := ClassDefinitionPrinter new classDefinitionTemplateInPackage: systemCategory forClass: classSymbol.
-	classDefinition := UIManager default
-		multiLineRequest: 'Edit class definition:'
-		initialAnswer: classDefinition
+	| systemCategory classDefinition |
+	systemCategory := node methodNode methodClass category ifNil: [ 'Unknown' ].
+	classDefinition := ClassDefinitionPrinter new
+		                   classDefinitionTemplateInPackage: systemCategory
+		                   named: classSymbol.
+	^ self
+		  defineClassOrTrait: classSymbol
+		  definitionString: classDefinition
+]
+
+{ #category : #correcting }
+OCCodeReparator >> defineClassOrTrait: aSymbol definitionString: aString [
+	"Prompts the user to define a new class oe trait."
+
+	| classBinding result definitionString |
+	definitionString := UIManager default
+		multiLineRequest: 'Edit definition:'
+		initialAnswer: aString
 		answerHeight: 200.
-	(classDefinition isNil or: [ classDefinition isEmpty ])
+	aString isEmptyOrNil
 		ifTrue: [ ^ Abort signal ].
 	result := self class compiler
-		source: classDefinition;
+		source: aString;
 		logged: true;
 		evaluate.
 	"Because some class definition syntax the (fuild one) does not evaluate to a
 	class but a class builder, we must call `fluidInstall`.
 	(that is a noop on real classes)."
 	result fluidInstall.
-	classBinding := node owningScope lookupVar: className.
+	classBinding := node owningScope lookupVar: aSymbol.
 	"make sure to recompile all methods referencing this class"
 	classBinding usingMethods do: [:method | method recompile].
 	^classBinding
@@ -100,23 +110,14 @@ OCCodeReparator >> defineTrait: traitName [
 
 	| traitSymbol systemCategory traitDefinition |
 	traitSymbol := traitName asSymbol.
-	systemCategory := node methodNode methodClass category
-		ifNil: [ 'Unknown' ].
-	traitDefinition := 'Trait named: #' , traitSymbol , '
-		uses:{}
-		package: ''' , systemCategory , ''''.
-	traitDefinition := UIManager default
-		multiLineRequest: 'Edit trait definition:'
-		initialAnswer: traitDefinition
-		answerHeight: 150.
-	(traitDefinition isNil or: [ traitDefinition isEmpty ])
-		ifTrue: [ ^ Abort signal ].
-	self class compiler
-		source: traitDefinition;
-		logged: true;
-		evaluate.
-	^ (node owningScope lookupVar: traitSymbol)
-		ifNil: [self error: 'should be not happen']
+	
+	systemCategory := node methodNode methodClass category ifNil: [ 'Unknown' ].
+	traitDefinition := ClassDefinitionPrinter new
+		                   traitDefinitionTemplateInPackage: systemCategory
+		                   named: traitSymbol.
+	^ self
+		  defineClassOrTrait: traitSymbol
+		  definitionString: traitDefinition
 ]
 
 { #category : #accessing }
@@ -159,7 +160,7 @@ OCCodeReparator >> openMenu [
 			labels add: 'Define new class'.
 			actions
 				add: [
-					[ self defineClass: name ]
+					[ self defineClass: name asSymbol ]
 						on: Abort
 						do: [ self openMenu ] ].
 			labels add: 'Declare new global'.
@@ -170,7 +171,7 @@ OCCodeReparator >> openMenu [
 			labels add: 'Define new trait'.
 			actions
 				add: [
-					[ self defineTrait: name ]
+					[ self defineTrait: name asSymbol ]
 						on: Abort
 						do: [ self openMenu ] ] ].
 	lines add: labels size.

--- a/src/OpalCompiler-Tests/OCCodeReparatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCCodeReparatorTest.class.st
@@ -286,3 +286,31 @@ OCCodeReparatorTest >> testUndeclaredVariable [
 	self assert: method literals first isUndeclaredVariable.
 	self assert: method sourceCode withSeparatorsCompacted equals: 'griffle ^ goo'
 ]
+
+{ #category : #tests }
+OCCodeReparatorTest >> testdefineClass [
+	
+	[ OCCodeReparator new
+		node: (self class>>#testdefineClass) ast;
+		defineClass: 'MyTestClassForDefineClass'
+	]
+		on: ProvideAnswerNotification
+		do: [ :e | e resume: true ].
+		
+	self assert: (Smalltalk globals hasClassNamed: #MyTestClassForDefineClass).
+	Smalltalk globals removeClassNamed:  #MyTestClassForDefineClass
+]
+
+{ #category : #tests }
+OCCodeReparatorTest >> testdefineTrait [
+	
+	[ OCCodeReparator new
+		node: (self class>>#testdefineTrait) ast;
+		defineTrait: 'MyTestTraitForDefineTrait'
+	]
+		on: ProvideAnswerNotification
+		do: [ :e | e resume: true ].
+		
+	self assert: (Smalltalk traitNames includes: #MyTestTraitForDefineTrait).
+	Smalltalk globals removeClassNamed:  #MyTestTraitForDefineTrait
+]


### PR DESCRIPTION
This PR fixes #10568

- add a parametrized version of #traitDefinitionTemplateInPackage: to the classPrinter
- reactor / unify #classDefinitionTemplateInPackage:

the #classDefinitionTemplateInPackage:named: name is not that great (it's a name for the package, too), but that we can later unify an use a package.  The second parameter now makes clear we use a name, noit a class.

These are tested by the system with existing tests

- use the new parametrized version in OCCodeReparator>>#defineTrait: