### PR TITLE
FileBrowser. View as hex not working

### DIFF
--- a/src/FileSystem-Core/AbstractFileReference.class.st
+++ b/src/FileSystem-Core/AbstractFileReference.class.st
@@ -840,13 +840,6 @@ AbstractFileReference >> size [
 	^ self resolve size
 ]
 
-{ #category : #streams }
-AbstractFileReference >> streamWritable: writable do: aBlock [
-	^ writable
-		ifTrue: [ self writeStreamDo: aBlock ]
-		ifFalse: [ self readStreamDo: aBlock ]
-]
-
 { #category : #accessing }
 AbstractFileReference >> targetPath [
 	^ self resolve targetPath

--- a/src/Tool-FileList/FileList.class.st
+++ b/src/Tool-FileList/FileList.class.st
@@ -1147,52 +1147,44 @@ FileList >> readContentsBrief: brevityFlag [
 
 { #category : #private }
 FileList >> readContentsHex: brevity [
-
 	"retrieve the contents from the external file unless it is too long.
 	  Don't create a file here.  Check if exists."
 
 	| size data hexData s |
+	self reference readStreamEncoded: ZnNullEncoder new do: [ :f |
+		f ifNil: [ ^ 'For some reason, this file cannot be read' translated ].
+		(size := f size) > 5000 & brevity
+			ifTrue: [
+				data := f next: 10000.
+				f close.
+				brevityState := #briefHex ]
+			ifFalse: [
+				data := f contents.
+				brevityState := #fullHex ].
 
-	self reference
-		streamWritable: false
-		do: [ :f |
-			f ifNil: [ ^ 'For some reason, this file cannot be read' translated ].
-			f binary.
-			( size := f size ) > 5000 & brevity
-				ifTrue: [ data := f next: 10000.
-					f close.
-					brevityState := #briefHex
-					]
-				ifFalse: [ data := f contentsOfEntireFile.
-					brevityState := #fullHex
-					].
-
-			s := ( String new: data size * 4 ) writeStream.
-			0 to: data size - 1 by: 16 do: [ :loc |
+		s := (String new: data size * 4) writeStream.
+		0 to: data size - 1 by: 16 do: [ :loc |
+			s
+				nextPutAll: loc printStringHex;
+				space;
+				nextPut: $(;
+				print: loc;
+				nextPut: $);
+				space;
+				tab.
+			loc + 1 to: (loc + 16 min: data size) do: [ :i |
 				s
-					nextPutAll: loc printStringHex;
-					space;
-					nextPut: $(;
-					print: loc;
-					nextPut: $);
-					space;
-					tab.
-				loc + 1 to: ( loc + 16 min: data size ) do: [ :i |
-					s
-						nextPutAll: ( data at: i ) printStringHex;
-						space
-					].
-				s cr
-				].
-			hexData := s contents
-			].
+					nextPutAll: (data at: i) printStringHex;
+					space ].
+			s cr ].
+		hexData := s contents ].
 
 	^ contents := size > 5000 & brevity
-		ifTrue: [ '{1}
+		              ifTrue: [
+			              '{1}
 ------------------------------------------
-... end of the first 5000 characters.' translated format: {hexData}
-			]
-		ifFalse: [ hexData ]
+... end of the first 5000 characters.' translated format: { hexData } ]
+		              ifFalse: [ hexData ]
 ]
 
 { #category : #'file list' }

--- a/src/Tool-FileList/FileList.class.st
+++ b/src/Tool-FileList/FileList.class.st
@@ -1030,13 +1030,13 @@ FileList >> okayAndCancelServices [
 
 { #category : #'own services' }
 FileList >> openImageInWindow [
-	"Handle five file formats: GIF, JPG, PNG, Form stoteOn: (run coded), and
-	BMP. Fail if file format is not recognized."
-	| image |
-	self reference streamWritable: false do: [ :stream|
-		image := Form fromBinaryStream: stream].
+	"Handle five file formats: GIF, JPG, PNG, Form stoteOn: (run coded), and BMP. 
+	Fail if file format is not recognized."
 
-	(ImageMorph withForm: image) openInWorld
+	| image |
+	image := self reference binaryReadStreamDo: [ :stream |
+		         Form fromBinaryStream: stream ].
+	(ImageMorph withForm: image) openInWindow
 ]
 
 { #category : #initialization }
@@ -1147,37 +1147,37 @@ FileList >> readContentsBrief: brevityFlag [
 
 { #category : #private }
 FileList >> readContentsHex: brevity [
-	"retrieve the contents from the external file unless it is too long.
-	  Don't create a file here.  Check if exists."
+	"Retrieve the contents from the external file unless it is too long.
+	Don't create a file here.  Check if exists."
 
-	| size data hexData s |
-	self reference binaryReadStreamDo: [ :f |
-		f ifNil: [ ^ 'For some reason, this file cannot be read' translated ].
-		(size := f size) > 5000 & brevity
-			ifTrue: [
-				data := f next: 10000.
-				brevityState := #briefHex ]
-			ifFalse: [
-				data := f upToEnd.
-				brevityState := #fullHex ].
-
-		s := (String new: data size * 4) writeStream.
-		0 to: data size - 1 by: 16 do: [ :loc |
-			s
-				nextPutAll: loc printStringHex;
-				space;
-				nextPut: $(;
-				print: loc;
-				nextPut: $);
-				space;
-				tab.
-			loc + 1 to: (loc + 16 min: data size) do: [ :i |
-				s
-					nextPutAll: (data at: i) printStringHex;
-					space ].
-			s cr ].
-		hexData := s contents ].
-
+	| size data hexData stream |
+	size := 0.
+	hexData := self reference binaryReadStreamDo: [ :f |
+		           f ifNil: [
+			           ^ 'For some reason, this file cannot be read' translated ].
+		           data := (size := f size) > 5000 & brevity
+			                   ifTrue: [
+				                   brevityState := #briefHex.
+				                   f next: 10000 ]
+			                   ifFalse: [
+				                   brevityState := #fullHex.
+				                   f upToEnd ].
+		           stream := (String new: data size * 4) writeStream.
+		           0 to: data size - 1 by: 16 do: [ :loc |
+			           stream
+				           nextPutAll: loc printStringHex;
+				           space;
+				           nextPut: $(;
+				           print: loc;
+				           nextPut: $);
+				           space;
+				           tab.
+			           loc + 1 to: (loc + 16 min: data size) do: [ :i |
+				           stream
+					           nextPutAll: (data at: i) printStringHex;
+					           space ].
+			           stream cr ].
+		           stream contents ].
 	^ contents := size > 5000 & brevity
 		              ifTrue: [
 			              '{1}
@@ -1640,8 +1640,10 @@ FileList >> viewContents [
 	"View the contents of my selected file in a new text window"
 
 	| aString |
-	self reference streamWritable: false do: [ :stream | aString := stream upToEnd ].
-	UIManager default edit: aString label: 'Contents from ' , self reference basename
+	aString := self reference readStreamDo: [ :stream | stream upToEnd ].
+	UIManager default
+		edit: aString
+		label: 'Contents from ' , self reference basename
 ]
 
 { #category : #'own services' }
@@ -1649,7 +1651,7 @@ FileList >> viewContentsInWorkspace [
 	"View the contents of my selected file in a new workspace"
 
 	| aString |
-	self reference streamWritable: false do: [ :stream | aString := stream upToEnd ].
+	aString := self reference readStreamDo: [ :stream | stream upToEnd ].
 	Smalltalk tools workspace openContents: aString
 ]
 

--- a/src/Tool-FileList/FileList.class.st
+++ b/src/Tool-FileList/FileList.class.st
@@ -1151,15 +1151,14 @@ FileList >> readContentsHex: brevity [
 	  Don't create a file here.  Check if exists."
 
 	| size data hexData s |
-	self reference readStreamEncoded: ZnNullEncoder new do: [ :f |
+	self reference binaryReadStreamDo: [ :f |
 		f ifNil: [ ^ 'For some reason, this file cannot be read' translated ].
 		(size := f size) > 5000 & brevity
 			ifTrue: [
 				data := f next: 10000.
-				f close.
 				brevityState := #briefHex ]
 			ifFalse: [
-				data := f contents.
+				data := f upToEnd.
 				brevityState := #fullHex ].
 
 		s := (String new: data size * 4) writeStream.

--- a/src/Zinc-Character-Encoding-Core/ZnCharacterReadStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnCharacterReadStream.class.st
@@ -13,11 +13,6 @@ Class {
 	#category : #'Zinc-Character-Encoding-Core'
 }
 
-{ #category : #configuration }
-ZnCharacterReadStream >> binary [
- encoder := ZnNullEncoder new.
-]
-
 { #category : #accessing }
 ZnCharacterReadStream >> collectionSpecies [
 	^ String

--- a/src/Zinc-Character-Encoding-Core/ZnCharacterReadStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnCharacterReadStream.class.st
@@ -13,6 +13,11 @@ Class {
 	#category : #'Zinc-Character-Encoding-Core'
 }
 
+{ #category : #configuration }
+ZnCharacterReadStream >> binary [
+ encoder := ZnNullEncoder new.
+]
+
 { #category : #accessing }
 ZnCharacterReadStream >> collectionSpecies [
 	^ String


### PR DESCRIPTION
#14209
 Fix proposal

#binary message was sent to ZnCharacterReadStream which was not implemented.
This implementation fixes the issue, at least for Pharo 12..., although it looks naive... 
 