### PR TITLE
This PR removes dead code related to VTerm output classes

### DIFF
--- a/src/System-CommandLine/VTermOutputBackground.class.st
+++ b/src/System-CommandLine/VTermOutputBackground.class.st
@@ -20,9 +20,3 @@ VTermOutputBackground >> = aBackground [
 VTermOutputBackground >> hash [
 	^ self color hash
 ]
-
-{ #category : #styling }
-VTermOutputBackground >> setInDriver: aVTermOutputDriver [
-
-	aVTermOutputDriver setBackgroundColor: color
-]

--- a/src/System-CommandLine/VTermOutputFont.class.st
+++ b/src/System-CommandLine/VTermOutputFont.class.st
@@ -18,8 +18,3 @@ VTermOutputFont >> = aFont [
 VTermOutputFont >> hash [
 	^ self color hash
 ]
-
-{ #category : #styling }
-VTermOutputFont >> setInDriver: aVTermOutputDriver [
-	aVTermOutputDriver setFontColor: color
-]

--- a/src/System-CommandLine/VTermOutputStyle.class.st
+++ b/src/System-CommandLine/VTermOutputStyle.class.st
@@ -51,14 +51,6 @@ VTermOutputStyle >> postCopy [
 ]
 
 { #category : #styling }
-VTermOutputStyle >> setInDriver: aVTermOutputDriver [
-	font setInDriver: aVTermOutputDriver.
-	background setInDriver: aVTermOutputDriver.
-	self styles do: [ :each | aVTermOutputDriver set: each ].
-	aVTermOutputDriver installedStyle: self
-]
-
-{ #category : #styling }
 VTermOutputStyle >> styles [
 	^styles
 ]

--- a/src/System-CommandLine/VTermOutputStyleElement.class.st
+++ b/src/System-CommandLine/VTermOutputStyleElement.class.st
@@ -22,24 +22,10 @@ VTermOutputStyleElement >> black [
 ]
 
 { #category : #'text coloring' }
-VTermOutputStyleElement >> black: aString [
-	"Change the color of writing of aString and set it back to default color afterward"
-
-	self print: aString withColor: Color black
-]
-
-{ #category : #'text coloring' }
 VTermOutputStyleElement >> blue [
 	"Change the current color of writing"
 
 	self color: Color blue
-]
-
-{ #category : #'text coloring' }
-VTermOutputStyleElement >> blue: aString [
-	"Change the color of writing of aString and set it back to default color afterward"
-
-	self print: aString withColor: Color blue
 ]
 
 { #category : #accessing }
@@ -63,24 +49,10 @@ VTermOutputStyleElement >> cyan [
 ]
 
 { #category : #'text coloring' }
-VTermOutputStyleElement >> cyan: aString [
-	"Change the color of writing of aString and set it back to default color afterward"
-
-	self print: aString withColor: Color cyan
-]
-
-{ #category : #'text coloring' }
 VTermOutputStyleElement >> green [
 	"Change the current color of writing"
 
 	self color: Color green
-]
-
-{ #category : #'text coloring' }
-VTermOutputStyleElement >> green: aString [
-	"Change the color of writing of aString and set it back to default color afterward"
-
-	self print: aString withColor: Color green
 ]
 
 { #category : #initialization }
@@ -97,13 +69,6 @@ VTermOutputStyleElement >> magenta [
 	self color: Color magenta
 ]
 
-{ #category : #'text coloring' }
-VTermOutputStyleElement >> magenta: aString [
-	"Change the color of writing of aString and set it back to default color afterward"
-
-	self print: aString withColor: Color magenta
-]
-
 { #category : #copying }
 VTermOutputStyleElement >> postCopy [
 	color := self color copy
@@ -117,18 +82,6 @@ VTermOutputStyleElement >> red [
 ]
 
 { #category : #'text coloring' }
-VTermOutputStyleElement >> red: aString [
-	"Change the color of writing of aString and set it back to default color afterward"
-
-	self print: aString withColor: Color red
-]
-
-{ #category : #styling }
-VTermOutputStyleElement >> setInDriver: aVTermOutputDriver [
-	self subclassResponsibility
-]
-
-{ #category : #'text coloring' }
 VTermOutputStyleElement >> white [
 	"Change the current color of writing"
 
@@ -136,22 +89,8 @@ VTermOutputStyleElement >> white [
 ]
 
 { #category : #'text coloring' }
-VTermOutputStyleElement >> white: aString [
-	"Change the color of writing of aString and set it back to default color afterward"
-
-	self print: aString withColor: Color white
-]
-
-{ #category : #'text coloring' }
 VTermOutputStyleElement >> yellow [
 	"Change the current color of writing"
 
 	self color: Color yellow
-]
-
-{ #category : #'text coloring' }
-VTermOutputStyleElement >> yellow: aString [
-	"Change the color of writing of aString and set it back to default color afterward"
-
-	self print: aString withColor: Color yellow
 ]


### PR DESCRIPTION
- remove method on VTermOutputStyleElement that sent non-existing selectors
- remove #setInDriver: which has no senders, but on one method it sends non-existing selector