### PR TITLE
Rename #allManagers into #allWorkingCopies

### DIFF
--- a/src/Deprecated12/MCWorkingCopy.extension.st
+++ b/src/Deprecated12/MCWorkingCopy.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #MCWorkingCopy }
+
+{ #category : #'*Deprecated12' }
+MCWorkingCopy class >> allManagers [
+
+	self deprecated: 'Use #allWorkingCopies instead' transformWith: '`@rcv allManagers' -> '`@rcv allWorkingCopies'.
+	^ self allWorkingCopies
+]

--- a/src/Deprecated12/RGContainer.extension.st
+++ b/src/Deprecated12/RGContainer.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #RGContainer }
+
+{ #category : #'*Deprecated12' }
+RGContainer class >> allManagers [
+
+	self deprecated: 'Use #allWorkingCopies instead' transformWith: '`@rcv allManagers' -> '`@rcv allWorkingCopies'.
+	^ self allWorkingCopies
+]

--- a/src/Gofer-Core/GoferReference.class.st
+++ b/src/Gofer-Core/GoferReference.class.st
@@ -111,7 +111,7 @@ GoferReference >> workingCopy [
 GoferReference >> workingCopyIfAbsent: aBlock [
 	"Answer a working copy or throw an error if not present."
 
-	^ MCWorkingCopy allManagers
-		detect: [ :each | self packageName = each packageName ]
-		ifNone: aBlock
+	^ MCWorkingCopy allWorkingCopies
+		  detect: [ :each | self packageName = each packageName ]
+		  ifNone: aBlock
 ]

--- a/src/Gofer-Core/GoferUnload.class.st
+++ b/src/Gofer-Core/GoferUnload.class.st
@@ -72,11 +72,8 @@ GoferUnload >> unregisterPackageSet: aWorkingCopy [
 GoferUnload >> unregisterRepositories: aWorkingCopy [
 
 	aWorkingCopy repositoryGroup repositories allButFirst do: [ :repository |
-		MCWorkingCopy allManagers do: [ :copy |
-			(copy repositoryGroup includes: repository)
-				ifTrue: [ ^ self ] ].
-		MCRepositoryGroup default
-			removeRepository: repository ]
+		MCWorkingCopy allWorkingCopies do: [ :copy | (copy repositoryGroup includes: repository) ifTrue: [ ^ self ] ].
+		MCRepositoryGroup default removeRepository: repository ]
 ]
 
 { #category : #unregistering }

--- a/src/Gofer-Tests/GoferOperationTest.class.st
+++ b/src/Gofer-Tests/GoferOperationTest.class.st
@@ -10,12 +10,6 @@ Class {
 	#category : #'Gofer-Tests-Tests'
 }
 
-{ #category : #utilities }
-GoferOperationTest >> allManagers [
-
-	^ MCWorkingCopy allManagers
-]
-
 { #category : #accessing }
 GoferOperationTest >> environment [
 	^ environment
@@ -42,13 +36,13 @@ GoferOperationTest >> hasClass: aSymbol selector: aSelector [
 { #category : #utilities }
 GoferOperationTest >> hasPackage: aString [
 
-	^ self allManagers anySatisfy: [ :package | package packageName = aString ]
+	^ MCWorkingCopy allWorkingCopies anySatisfy: [ :package | package packageName = aString ]
 ]
 
 { #category : #utilities }
 GoferOperationTest >> hasVersion: aString [
 
-	^ self allManagers anySatisfy: [ :version | version ancestry ancestorString = aString ]
+	^ MCWorkingCopy allWorkingCopies anySatisfy: [ :version | version ancestry ancestorString = aString ]
 ]
 
 { #category : #running }

--- a/src/Metacello-Base/ConfigurationOf.class.st
+++ b/src/Metacello-Base/ConfigurationOf.class.st
@@ -230,11 +230,10 @@ ConfigurationOf class >> unloadMetacello [
 
 	<apiDocumentation>
 	| gofer |
-	gofer := (Smalltalk at: #Gofer) new.
-	MCWorkingCopy allManagers do: [:wc |
-		((wc packageName beginsWith: 'Metacello') or: [ wc packageName beginsWith: 'OB-Metacello' ])
-			ifTrue: [ gofer package: wc packageName ]].
-	gofer unload.
+	gofer := Gofer new.
+	MCWorkingCopy allWorkingCopies do: [ :wc |
+		((wc packageName beginsWith: 'Metacello') or: [ wc packageName beginsWith: 'OB-Metacello' ]) ifTrue: [ gofer package: wc packageName ] ].
+	gofer unload
 ]
 
 { #category : #accessing }

--- a/src/Metacello-Cypress/MetacelloCypressPackageSpec.class.st
+++ b/src/Metacello-Cypress/MetacelloCypressPackageSpec.class.st
@@ -19,10 +19,11 @@ MetacelloCypressPackageSpec >> compareCurrentVersion: anOperator targetVersionSt
 
 { #category : #querying }
 MetacelloCypressPackageSpec >> isPackageLoaded: aLoader [
-  MCWorkingCopy allManagers
-    detect: [ :wc | wc packageName = self file ]
-    ifNone: [ ^ false ].
-  ^ true
+
+	MCWorkingCopy allWorkingCopies
+		detect: [ :wc | wc packageName = self file ]
+		ifNone: [ ^ false ].
+	^ true
 ]
 
 { #category : #fetching }

--- a/src/Metacello-MC/MetacelloCachingGoferResolvedReference.class.st
+++ b/src/Metacello-MC/MetacelloCachingGoferResolvedReference.class.st
@@ -20,9 +20,9 @@ MetacelloCachingGoferResolvedReference >> workingCopy [
 	"Answer a working copy or throw an error if not present."
 
 	| pName |
-	cachedVersion == nil ifTrue: [ ^super workingCopy ].
+	cachedVersion == nil ifTrue: [ ^ super workingCopy ].
 	pName := cachedVersion package name.
-	^MCWorkingCopy allManagers
-		detect: [ :each | pName = each packageName ]
-		ifNone: [ self error: 'Working copy for ' , self name , ' not found' ]
+	^ MCWorkingCopy allWorkingCopies
+		  detect: [ :wc | pName = wc packageName ]
+		  ifNone: [ self error: 'Working copy for ' , self name , ' not found' ]
 ]

--- a/src/Metacello-MC/MetacelloGoferPackage.class.st
+++ b/src/Metacello-MC/MetacelloGoferPackage.class.st
@@ -58,9 +58,9 @@ MetacelloGoferPackage >> findWorkingCopy [
 	"Answer a working copy, or nil if the package is not loaded."
 
 	| wcs |
-	wcs := MCWorkingCopy allManagers select: [ :each | self matchesWorkingCopy: each ].
-	wcs isEmpty ifTrue: [ ^nil ].
-	^wcs detectMax: [:ea | ea package name size ]
+	wcs := MCWorkingCopy allWorkingCopies select: [ :each | self matchesWorkingCopy: each ].
+	wcs isEmpty ifTrue: [ ^ nil ].
+	^ wcs detectMax: [ :ea | ea package name size ]
 ]
 
 { #category : #initialization }

--- a/src/Metacello-TestsMC/MetacelloDictionaryRepositoryTest.class.st
+++ b/src/Metacello-TestsMC/MetacelloDictionaryRepositoryTest.class.st
@@ -32,8 +32,7 @@ MetacelloDictionaryRepositoryTest >> doSilently [
 { #category : #utilities }
 MetacelloDictionaryRepositoryTest >> hasPackage: aString [
 
-	^ MCWorkingCopy allManagers
-		anySatisfy: [ :each | each packageName = aString ]
+	^ MCWorkingCopy allWorkingCopies anySatisfy: [ :each | each packageName = aString ]
 ]
 
 { #category : #accessing }
@@ -92,27 +91,28 @@ MetacelloDictionaryRepositoryTest >> runCase [
 
 { #category : #running }
 MetacelloDictionaryRepositoryTest >> setUp [
-  | repo |
-  super setUp.
-  MetacelloPlatform current clearPackageCache.
-  MetacelloConfigurationResource projectAttributes: nil.
-  repo := self monticelloRepository.
-  self tempRepositories add: repo.
-  gofer repository: repo.
-  testingEnvironment at: #'Metacello_Gofer_Test_Repository' put: repo.
-  repo := self alternateRepository.
-  self tempRepositories add: repo.
-  testingEnvironment at: #'Metacello_Configuration_Test_Alternate_Repository' put: repo.
-  repo := self configurationRepository.
-  self tempRepositories add: repo.
-  testingEnvironment at: #'Metacello_Configuration_Test_Repository' put: repo.
-  initialWorkingCopyList := MCWorkingCopy allManagers
-    collect: [ :each | each packageName ].
-  undefinedSymbols := MetacelloPlatform current disableUndefinedSybolUpdates
+
+	| repo |
+	super setUp.
+	MetacelloPlatform current clearPackageCache.
+	MetacelloConfigurationResource projectAttributes: nil.
+	repo := self monticelloRepository.
+	self tempRepositories add: repo.
+	gofer repository: repo.
+	testingEnvironment at: #Metacello_Gofer_Test_Repository put: repo.
+	repo := self alternateRepository.
+	self tempRepositories add: repo.
+	testingEnvironment at: #Metacello_Configuration_Test_Alternate_Repository put: repo.
+	repo := self configurationRepository.
+	self tempRepositories add: repo.
+	testingEnvironment at: #Metacello_Configuration_Test_Repository put: repo.
+	initialWorkingCopyList := MCWorkingCopy allWorkingCopies collect: [ :wc | wc packageName ].
+	undefinedSymbols := MetacelloPlatform current disableUndefinedSybolUpdates
 ]
 
 { #category : #running }
 MetacelloDictionaryRepositoryTest >> tearDown [
+
 	| aGofer finalWorkingCopyList diff |
 	aGofer := Gofer new.
 	self tearDownPackages: aGofer.
@@ -122,11 +122,9 @@ MetacelloDictionaryRepositoryTest >> tearDown [
 	testingEnvironment removeKey: #Metacello_Configuration_Test_Alternate_Repository ifAbsent: [  ].
 	self tempRepositories do: [ :repo | MCRepositoryGroup default removeIdenticalRepository: repo ].
 	MetacelloPlatform current reenableUndefinedSybolUpdates: undefinedSymbols.
-	finalWorkingCopyList := MCWorkingCopy allManagers collect: [ :each | each packageName ].
+	finalWorkingCopyList := MCWorkingCopy allWorkingCopies collect: [ :wc | wc packageName ].
 	diff := finalWorkingCopyList difference: initialWorkingCopyList.
-	diff
-		do: [ :leak | 
-			self crTrace: 'leaked package from ' , self printString , ' -> ' , leak printString ].
+	diff do: [ :leak | self crTrace: 'leaked package from ' , self printString , ' -> ' , leak printString ].
 	self assertEmpty: diff.
 	super tearDown
 ]

--- a/src/Metacello-TestsMC/MetacelloIssueTestCase.class.st
+++ b/src/Metacello-TestsMC/MetacelloIssueTestCase.class.st
@@ -17,10 +17,11 @@ MetacelloIssueTestCase >> configurationRepository [
 
 { #category : #utilities }
 MetacelloIssueTestCase >> hasPackage: aString [
+
 	| package |
-	package := MCWorkingCopy allManagers
-		detect: [ :each | each packageName = aString ]
-		ifNone: [ nil ].
+	package := MCWorkingCopy allWorkingCopies
+		           detect: [ :wc | wc packageName = aString ]
+		           ifNone: [ nil ].
 	^ package notNil
 ]
 
@@ -70,47 +71,39 @@ MetacelloIssueTestCase >> runCase [
 
 { #category : #running }
 MetacelloIssueTestCase >> setUp [
-  | repo |
-  super setUp.
-  MetacelloPlatform current clearPackageCache.
-  repo := self monticelloRepository.
-  gofer := Gofer new.
-  gofer disablePackageCache.
-  gofer repository: repo.
-  testingEnvironment at: #'Metacello_Gofer_Test_Repository' put: repo.
-  repo := self configurationRepository.
-  gofer repository: repo.
-  testingEnvironment at: #'Metacello_Configuration_Test_Repository' put: repo.
-  initialWorkingCopyList := MCWorkingCopy allManagers
-    collect: [ :each | each packageName ]
+
+	| repo |
+	super setUp.
+	MetacelloPlatform current clearPackageCache.
+	repo := self monticelloRepository.
+	gofer := Gofer new.
+	gofer disablePackageCache.
+	gofer repository: repo.
+	testingEnvironment at: #Metacello_Gofer_Test_Repository put: repo.
+	repo := self configurationRepository.
+	gofer repository: repo.
+	testingEnvironment at: #Metacello_Configuration_Test_Repository put: repo.
+	initialWorkingCopyList := MCWorkingCopy allWorkingCopies collect: [ :wc | wc packageName ]
 ]
 
 { #category : #running }
 MetacelloIssueTestCase >> tearDown [
-  | aGofer finalWorkingCopyList diff |
-  aGofer := Gofer new.
-  self tearDownPackageNames
-    do: [ :pName | 
-      (self hasPackage: pName)
-        ifTrue: [ aGofer package: pName ] ].
-  aGofer references notEmpty
-    ifTrue: [ aGofer metacelloUnload ].
-  MCRepositoryGroup default
-    removeIdenticalRepository:
-        (testingEnvironment at: #'Metacello_Gofer_Test_Repository' ifAbsent: [  ]);
-    removeIdenticalRepository:
-        (testingEnvironment at: #'Metacello_Configuration_Test_Repository' ifAbsent: [  ]);
-    yourself.
-  testingEnvironment removeKey: #'Metacello_Gofer_Test_Repository' ifAbsent: [  ].
-  testingEnvironment removeKey: #'Metacello_Configuration_Test_Repository' ifAbsent: [  ].
-  finalWorkingCopyList := MCWorkingCopy allManagers
-    collect: [ :each | each packageName ].
-  diff := finalWorkingCopyList difference: initialWorkingCopyList.
-  diff
-    do: [ :leak | 
-      MetacelloNotification signal: ('leaked package from ' , self printString , ' -> ' , leak printString) ].
-  self assert: diff isEmpty.
-  super tearDown
+
+	| aGofer finalWorkingCopyList diff |
+	aGofer := Gofer new.
+	self tearDownPackageNames do: [ :pName | (self hasPackage: pName) ifTrue: [ aGofer package: pName ] ].
+	aGofer references notEmpty ifTrue: [ aGofer metacelloUnload ].
+	MCRepositoryGroup default
+		removeIdenticalRepository: (testingEnvironment at: #Metacello_Gofer_Test_Repository ifAbsent: [  ]);
+		removeIdenticalRepository: (testingEnvironment at: #Metacello_Configuration_Test_Repository ifAbsent: [  ]);
+		yourself.
+	testingEnvironment removeKey: #Metacello_Gofer_Test_Repository ifAbsent: [  ].
+	testingEnvironment removeKey: #Metacello_Configuration_Test_Repository ifAbsent: [  ].
+	finalWorkingCopyList := MCWorkingCopy allWorkingCopies collect: [ :wc | wc packageName ].
+	diff := finalWorkingCopyList difference: initialWorkingCopyList.
+	diff do: [ :leak | MetacelloNotification signal: 'leaked package from ' , self printString , ' -> ' , leak printString ].
+	self assert: diff isEmpty.
+	super tearDown
 ]
 
 { #category : #running }

--- a/src/Metacello-TestsMC/MetacelloScriptingStdTstHarnessTestCase.class.st
+++ b/src/Metacello-TestsMC/MetacelloScriptingStdTstHarnessTestCase.class.st
@@ -24,8 +24,7 @@ MetacelloScriptingStdTstHarnessTestCase >> doSilently [
 { #category : #utilities }
 MetacelloScriptingStdTstHarnessTestCase >> hasPackage: aString [
 
-	^ MCWorkingCopy allManagers
-		anySatisfy: [ :each | each packageName = aString ]
+	^ MCWorkingCopy allWorkingCopies anySatisfy: [ :wc | wc packageName = aString ]
 ]
 
 { #category : #running }
@@ -42,16 +41,15 @@ MetacelloScriptingStdTstHarnessTestCase >> runCase [
 
 { #category : #running }
 MetacelloScriptingStdTstHarnessTestCase >> setUp [
-  super setUp.
-  MetacelloPlatform current clearPackageCache.
-  registry := MetacelloProjectRegistration registry.
-  self setUpRepositories.
-  self setUpRepositoryContents.
-  MetacelloProjectRegistration resetRegistry.
-  initialWorkingCopyList := MCWorkingCopy allManagers
-    collect: [ :each | each packageName ].
-  self disableUndefinedSymbolTracking
-    ifTrue: [ undefinedSymbols := MetacelloPlatform current disableUndefinedSybolUpdates ]
+
+	super setUp.
+	MetacelloPlatform current clearPackageCache.
+	registry := MetacelloProjectRegistration registry.
+	self setUpRepositories.
+	self setUpRepositoryContents.
+	MetacelloProjectRegistration resetRegistry.
+	initialWorkingCopyList := MCWorkingCopy allWorkingCopies collect: [ :wc | wc packageName ].
+	self disableUndefinedSymbolTracking ifTrue: [ undefinedSymbols := MetacelloPlatform current disableUndefinedSybolUpdates ]
 ]
 
 { #category : #running }
@@ -64,20 +62,17 @@ MetacelloScriptingStdTstHarnessTestCase >> setUpRepositoryContents [
 
 { #category : #running }
 MetacelloScriptingStdTstHarnessTestCase >> tearDown [
-  | finalWorkingCopyList diff |  
-  self tearDownPackages.
-  self tearDownRepositories.
-  MetacelloProjectRegistration registry: registry.
-  self disableUndefinedSymbolTracking
-    ifTrue: [ MetacelloPlatform current reenableUndefinedSybolUpdates: undefinedSymbols ].
-  finalWorkingCopyList := MCWorkingCopy allManagers
-    collect: [ :each | each packageName ].
-  diff := finalWorkingCopyList difference: initialWorkingCopyList.
-  diff
-    do: [ :leak | 
-      MetacelloNotification signal: ('leaked package from ' , self printString , ' -> ' , leak printString) ].
-  self assert: diff isEmpty.
-  super tearDown
+
+	| finalWorkingCopyList diff |
+	self tearDownPackages.
+	self tearDownRepositories.
+	MetacelloProjectRegistration registry: registry.
+	self disableUndefinedSymbolTracking ifTrue: [ MetacelloPlatform current reenableUndefinedSybolUpdates: undefinedSymbols ].
+	finalWorkingCopyList := MCWorkingCopy allWorkingCopies collect: [ :wc | wc packageName ].
+	diff := finalWorkingCopyList difference: initialWorkingCopyList.
+	diff do: [ :leak | MetacelloNotification signal: 'leaked package from ' , self printString , ' -> ' , leak printString ].
+	self assert: diff isEmpty.
+	super tearDown
 ]
 
 { #category : #running }
@@ -146,22 +141,27 @@ MetacelloScriptingStdTstHarnessTestCase >> validateProjects: specArrays [
 
 { #category : #utilities }
 MetacelloScriptingStdTstHarnessTestCase >> verify: packageName loadedFrom: repositoryDescription [
-    | externalCoreWorkingCopy |
-    externalCoreWorkingCopy := MCWorkingCopy allManagers detect: [ :wc | wc packageName = packageName ].
-    self
-        assert:
-            (externalCoreWorkingCopy repositoryGroup repositories
-                includes: (MetacelloMCProject new repositorySpec description: repositoryDescription) createRepository)
+
+	| externalCoreWorkingCopy |
+	externalCoreWorkingCopy := MCWorkingCopy allWorkingCopies detect: [ :wc | wc packageName = packageName ].
+	self assert:
+		(externalCoreWorkingCopy repositoryGroup repositories includes: (MetacelloMCProject new repositorySpec description: repositoryDescription) createRepository)
 ]
 
 { #category : #utilities }
 MetacelloScriptingStdTstHarnessTestCase >> verify: packageName version: fileName [
-	| externalCoreWorkingCopy x |
-	externalCoreWorkingCopy := MCWorkingCopy allManagers detect: [ :wc | wc packageName = packageName ].
-	self assert: (x := externalCoreWorkingCopy ancestors first name) equals: fileName
+
+	| externalCoreWorkingCopy |
+	externalCoreWorkingCopy := MCWorkingCopy allWorkingCopies detect: [ :wc | wc packageName = packageName ].
+	self assert: externalCoreWorkingCopy ancestors first name equals: fileName
 ]
 
 { #category : #utilities }
 MetacelloScriptingStdTstHarnessTestCase >> verifyPackageNotLoaded: packageName [
-	self assert: (MCWorkingCopy allManagers detect: [ :wc | wc packageName = packageName ] ifNone: [  ]) identicalTo: nil
+
+	self
+		assert: (MCWorkingCopy allWorkingCopies
+				 detect: [ :wc | wc packageName = packageName ]
+				 ifNone: [  ])
+		identicalTo: nil
 ]

--- a/src/Monticello/MCWorkingCopy.class.st
+++ b/src/Monticello/MCWorkingCopy.class.st
@@ -37,13 +37,6 @@ Class {
 }
 
 { #category : #accessing }
-MCWorkingCopy class >> allManagers [
-	"Do not use. This will be deprecated."
-
-	^ self allWorkingCopies
-]
-
-{ #category : #accessing }
 MCWorkingCopy class >> allWorkingCopies [
 	^ self registry values
 ]
@@ -172,7 +165,7 @@ MCWorkingCopy class >> forPackageNamed: aPackageName [
 { #category : #querying }
 MCWorkingCopy class >> hasPackageNamed: aName [
 
-	^ self allManagers anySatisfy: [ :each | each packageName = aName ]
+	^ self allWorkingCopies anySatisfy: [ :each | each packageName = aName ]
 ]
 
 { #category : #private }

--- a/src/MonticelloGUI/MCConfigurationBrowser.class.st
+++ b/src/MonticelloGUI/MCConfigurationBrowser.class.st
@@ -398,27 +398,22 @@ MCConfigurationBrowser >> pickRepositorySatisfying: aBlock [
 ]
 
 { #category : #'morphic ui' }
-MCConfigurationBrowser >> pickWorkingCopiesSatisfying: aBlock [ 
+MCConfigurationBrowser >> pickWorkingCopiesSatisfying: aBlock [
+
 	| copies item |
-	copies := (self allManagers select: aBlock)
-				asSortedCollection: [:a :b | a packageName <= b packageName].
-	item := UIManager default
-				chooseFrom: ({'match ...' translated} , (copies
-						collect: [:ea | ea packageName]))
-				lines: #(1 )
-				title: 'Package:' translated. 
-	item = 1
-		ifTrue: [| pattern | 
-			pattern := UIManager default request: 'Packages matching:' translated initialAnswer: '*'.
-			^ pattern isEmptyOrNil
-				ifTrue: [#()]
-				ifFalse: [(pattern includes: $*)
-						ifFalse: [pattern := '*' , pattern , '*'].
-					copies
-						select: [:ea | pattern match: ea packageName]]].
+	copies := (MCWorkingCopy allWorkingCopies select: aBlock) asSortedCollection: [ :a :b | a packageName <= b packageName ].
+	item := UIManager default chooseFrom: { 'match ...' translated } , (copies collect: [ :ea | ea packageName ]) lines: #( 1 ) title: 'Package:' translated.
+	item = 1 ifTrue: [
+		| pattern |
+		pattern := UIManager default request: 'Packages matching:' translated initialAnswer: '*'.
+		^ pattern isEmptyOrNil
+			  ifTrue: [ #(  ) ]
+			  ifFalse: [
+				  (pattern includes: $*) ifFalse: [ pattern := '*' , pattern , '*' ].
+				  copies select: [ :ea | pattern match: ea packageName ] ] ].
 	^ item = 0
-		ifTrue: [#()]
-		ifFalse: [{copies at: item - 1}]
+		  ifTrue: [ #(  ) ]
+		  ifFalse: [ { (copies at: item - 1) } ]
 ]
 
 { #category : #actions }

--- a/src/MonticelloGUI/MCTool.class.st
+++ b/src/MonticelloGUI/MCTool.class.st
@@ -40,12 +40,6 @@ MCTool >> accept [
 	" do nothing by default"
 ]
 
-{ #category : #utilities }
-MCTool >> allManagers [
-
-	^ MCWorkingCopy allManagers 
-]
-
 { #category : #'morphic ui' }
 MCTool >> answer: anObject [
 	modalValue := anObject.

--- a/src/Ring-Definitions-Containers/RGContainer.class.st
+++ b/src/Ring-Definitions-Containers/RGContainer.class.st
@@ -8,23 +8,24 @@ Class {
 }
 
 { #category : #'image package loading' }
-RGContainer class >> allManagers [
+RGContainer class >> allWorkingCopies [
 
-	^ Smalltalk globals at: #MCWorkingCopy
-		ifPresent: [:mcwc | mcwc allManagers ]
-		ifAbsent: [OrderedCollection new ]
+	^ Smalltalk globals
+		  at: #MCWorkingCopy
+		  ifPresent: [ :class | class allWorkingCopies ]
+		  ifAbsent: [ OrderedCollection new ]
 ]
 
 { #category : #'image package loading' }
 RGContainer class >> packageKeys [
 
-	^ self allManagers collect: [ :pck | pck package name asSymbol -> ('*', pck package name asLowercase) ]
+	^ self allWorkingCopies collect: [ :pck | pck package name asSymbol -> ('*' , pck package name asLowercase) ]
 ]
 
 { #category : #'image package loading' }
 RGContainer class >> packageNames [
 
-	^ self allManagers collect: [ :pck | pck package name asSymbol ]
+	^ self allWorkingCopies collect: [ :pck | pck package name asSymbol ]
 ]
 
 { #category : #'image package loading' }
@@ -370,9 +371,9 @@ RGContainer >> loadPackagesFromImage [
 
 	| rgPackage rgPackageKeys |
 	rgPackageKeys := OrderedCollection new.
-	self class allManagers do: [ :pck |
+	self class allWorkingCopies do: [ :pck |
 		rgPackage := RGPackageDefinition named: pck package name asSymbol.
-		rgPackageKeys add: (rgPackage name -> ('*', rgPackage name asLowercase)).
+		rgPackageKeys add: rgPackage name -> ('*' , rgPackage name asLowercase).
 		self addPackage: rgPackage ].
 	^ rgPackageKeys
 ]

--- a/src/TraitsV2-Tests/TimeMeasuringTest.class.st
+++ b/src/TraitsV2-Tests/TimeMeasuringTest.class.st
@@ -67,8 +67,8 @@ TimeMeasuringTest >> setToDebug [
 
 { #category : #utilities }
 TimeMeasuringTest >> versionInfoForWorkingCopiesThat: wcPredicate [
-	^(MCWorkingCopy allManagers select: wcPredicate) inject: ''
-		into: [:s :e | s , e description]
+
+	^ (MCWorkingCopy allWorkingCopies select: wcPredicate) inject: '' into: [ :s :e | s , e description ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Rename MCWrokingCopy>>#allManagers to #allWorkingCopies because it returns all the working copies and I don't see any reason to call them "managers".

After this PR I'll do a pass over the API to finish remove all "managers" and use "working copies" instead.