### PR TITLE
Clean #affectsMethodsTaggedWith:

### DIFF
--- a/src/Calypso-SystemPlugins-InheritanceAnalysis-Queries/ClyOverriddenSuperclassesChanged.class.st
+++ b/src/Calypso-SystemPlugins-InheritanceAnalysis-Queries/ClyOverriddenSuperclassesChanged.class.st
@@ -39,12 +39,11 @@ ClyOverriddenSuperclassesChanged >> affectsMethodsDefinedInPackage: aPackage [
 ]
 
 { #category : #testing }
-ClyOverriddenSuperclassesChanged >> affectsMethodsTaggedWith: tagName [
+ClyOverriddenSuperclassesChanged >> affectsMethodsInProtocol: protocol [
 
-	overridingSubclass allSuperclassesDo: [:each |
-		(each tagsForMethods includes: tagName) ifTrue: [ ^true ] ].
+	overridingSubclass allSuperclassesDo: [ :superclass | (superclass protocolNames includes: protocol) ifTrue: [ ^ true ] ].
 
-	^false
+	^ false
 ]
 
 { #category : #accessing }

--- a/src/Calypso-SystemPlugins-InheritanceAnalysis-Queries/ClyOverridingMethodsChanged.class.st
+++ b/src/Calypso-SystemPlugins-InheritanceAnalysis-Queries/ClyOverridingMethodsChanged.class.st
@@ -39,7 +39,7 @@ ClyOverridingMethodsChanged >> affectsMethodsDefinedInPackage: aPackage [
 ]
 
 { #category : #testing }
-ClyOverridingMethodsChanged >> affectsMethodsTaggedWith: tagName [
+ClyOverridingMethodsChanged >> affectsMethodsInProtocol: protocol [
 
 	^announcerPlugin isMethodOverridden: method
 ]

--- a/src/Calypso-SystemPlugins-InheritanceAnalysis-Queries/ClyOverridingSubclassesChanged.class.st
+++ b/src/Calypso-SystemPlugins-InheritanceAnalysis-Queries/ClyOverridingSubclassesChanged.class.st
@@ -41,12 +41,11 @@ ClyOverridingSubclassesChanged >> affectsMethodsDefinedInPackage: aPackage [
 ]
 
 { #category : #testing }
-ClyOverridingSubclassesChanged >> affectsMethodsTaggedWith: tagName [
+ClyOverridingSubclassesChanged >> affectsMethodsInProtocol: protocol [
 
-	overriddenSuperclass withAllSubclassesDo: [:each |
-		(each tagsForMethods includes: tagName) ifTrue: [ ^true ] ].
+	overriddenSuperclass withAllSubclassesDo: [ :superclass | (superclass protocolNames includes: protocol) ifTrue: [ ^ true ] ].
 
-	^false
+	^ false
 ]
 
 { #category : #accessing }

--- a/src/Calypso-SystemPlugins-SUnit-Queries/ClyTestCaseRan.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Queries/ClyTestCaseRan.class.st
@@ -45,9 +45,10 @@ ClyTestCaseRan >> affectsMethodsDefinedInPackage: aPackage [
 	^testCase package == aPackage or: [ aPackage extendsClass: testCase ]
 ]
 
-{ #category : #'event processing' }
-ClyTestCaseRan >> affectsMethodsTaggedWith: tagName [
-	^testCase tagsForMethods includes: tagName
+{ #category : #testing }
+ClyTestCaseRan >> affectsMethodsInProtocol: protocol [
+
+	^ testCase protocolNames includes: protocol
 ]
 
 { #category : #'event processing' }

--- a/src/Calypso-SystemQueries/ClyMethodsInProtocolQuery.class.st
+++ b/src/Calypso-SystemQueries/ClyMethodsInProtocolQuery.class.st
@@ -63,7 +63,7 @@ ClyMethodsInProtocolQuery >> hash [
 { #category : #'system changes' }
 ClyMethodsInProtocolQuery >> isResult: aQueryResult affectedBy: aSystemAnnouncement [
 
-	^ (aSystemAnnouncement affectsMethodsTaggedWith: protocol) and: [ scope includesMethodsAffectedBy: aSystemAnnouncement ]
+	^ (aSystemAnnouncement affectsMethodsInProtocol: protocol) and: [ scope includesMethodsAffectedBy: aSystemAnnouncement ]
 ]
 
 { #category : #printing }

--- a/src/Deprecated12/Announcement.extension.st
+++ b/src/Deprecated12/Announcement.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #Announcement }
+
+{ #category : #'*Deprecated12' }
+Announcement >> affectsMethodsTaggedWith: protocol [
+
+	self deprecated: 'Use #affectsMethodsInProtocol: instead.' transformWith: '`@rcv affectsMethodsTaggedWith: `@arg' -> '`@rcv affectsMethodsInProtocol: `@arg'.
+	^ self affectsMethodsInProtocol: protocol
+]

--- a/src/System-Announcements/Announcement.extension.st
+++ b/src/System-Announcements/Announcement.extension.st
@@ -51,8 +51,9 @@ Announcement >> affectsMethodsDefinedInPackage: aPackage [
 ]
 
 { #category : #'*System-Announcements' }
-Announcement >> affectsMethodsTaggedWith: tagName [
-	^false
+Announcement >> affectsMethodsInProtocol: protocol [
+
+	^ false
 ]
 
 { #category : #'*System-Announcements' }

--- a/src/System-Announcements/ClassRemoved.class.st
+++ b/src/System-Announcements/ClassRemoved.class.st
@@ -45,8 +45,9 @@ ClassRemoved >> affectsMethodsDefinedInPackage: aPackage [
 ]
 
 { #category : #testing }
-ClassRemoved >> affectsMethodsTaggedWith: tagName [
-	^classRemoved tagsForMethods includes: tagName
+ClassRemoved >> affectsMethodsInProtocol: protocol [
+
+	^ classRemoved protocolNames includes: protocol
 ]
 
 { #category : #accessing }

--- a/src/System-Announcements/ClassRenamed.class.st
+++ b/src/System-Announcements/ClassRenamed.class.st
@@ -50,8 +50,9 @@ ClassRenamed >> affectsMethodsDefinedInPackage: aPackage [
 ]
 
 { #category : #testing }
-ClassRenamed >> affectsMethodsTaggedWith: tagName [
-	^classRenamed tagsForMethods includes: tagName
+ClassRenamed >> affectsMethodsInProtocol: protocol [
+
+	^ classRenamed protocolNames includes: protocol
 ]
 
 { #category : #testing }

--- a/src/System-Announcements/ClassRepackaged.class.st
+++ b/src/System-Announcements/ClassRepackaged.class.st
@@ -40,8 +40,9 @@ ClassRepackaged >> affectsMethodsDefinedInPackage: aPackage [
 ]
 
 { #category : #testing }
-ClassRepackaged >> affectsMethodsTaggedWith: tagName [
-	^classRepackaged tagsForMethods includes: tagName
+ClassRepackaged >> affectsMethodsInProtocol: protocol [
+
+	^ classRepackaged protocolNames includes: protocol
 ]
 
 { #category : #accessing }

--- a/src/System-Announcements/MethodAnnouncement.class.st
+++ b/src/System-Announcements/MethodAnnouncement.class.st
@@ -43,8 +43,9 @@ MethodAnnouncement >> affectsMethodsDefinedInPackage: aPackage [
 ]
 
 { #category : #testing }
-MethodAnnouncement >> affectsMethodsTaggedWith: tagName [
-	^method isTaggedWith: tagName asSymbol
+MethodAnnouncement >> affectsMethodsInProtocol: protocol [
+
+	^ method protocolName == protocol
 ]
 
 { #category : #testing }

--- a/src/System-Announcements/MethodModified.class.st
+++ b/src/System-Announcements/MethodModified.class.st
@@ -35,9 +35,9 @@ MethodModified >> affectsMethodsDefinedInPackage: aPackage [
 ]
 
 { #category : #testing }
-MethodModified >> affectsMethodsTaggedWith: tagName [
+MethodModified >> affectsMethodsInProtocol: protocol [
 
-	^ (super affectsMethodsTaggedWith: tagName) or: [ self oldProtocol name = tagName ]
+	^ (super affectsMethodsInProtocol: protocol) or: [ self oldProtocol name = protocol ]
 ]
 
 { #category : #accessing }

--- a/src/System-Announcements/MethodRecategorized.class.st
+++ b/src/System-Announcements/MethodRecategorized.class.st
@@ -23,9 +23,9 @@ MethodRecategorized class >> method: aCompiledMethod oldProtocol: anOldProtocol 
 ]
 
 { #category : #testing }
-MethodRecategorized >> affectsMethodsTaggedWith: tagName [
+MethodRecategorized >> affectsMethodsInProtocol: protocol [
 
-	^ (super affectsMethodsTaggedWith: tagName) or: [ self oldProtocol name = tagName ]
+	^ (super affectsMethodsInProtocol: protocol) or: [ self oldProtocol name = protocol ]
 ]
 
 { #category : #accessing }

--- a/src/System-Announcements/MethodRemoved.class.st
+++ b/src/System-Announcements/MethodRemoved.class.st
@@ -23,9 +23,9 @@ MethodRemoved class >> methodRemoved: aCompiledMethod protocol: aProtocol origin
 ]
 
 { #category : #testing }
-MethodRemoved >> affectsMethodsTaggedWith: tagName [
+MethodRemoved >> affectsMethodsInProtocol: aProtocol [
 
-	^ (super affectsMethodsTaggedWith: tagName) or: [ self protocol name = tagName ]
+	^ self protocol name = aProtocol
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This PR does multiple cleanings on #affectsMethodsTaggedWith:
- Rename it into #affectsMethodsInProtocol:
- Rename variables from tagName to protocol
- Move from the tag API to the Protocol API
- Clean some of the methods

Before this method was excluding Protocol unclassified and extensions but I have the impression that this is never called with those protocol as parameter. Since this was added on System-Announcement and not in Calypso packages, I think we should not do this kind of sorting of what we accept to be impacted or not. We should check the protocol independently of what is the used protocol.