### PR TITLE
Add test on installing a class in a non default environment

### DIFF
--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -52,7 +52,6 @@ ShClassInstallerTest >> newClass: className superclass: aSuperclass slots: slots
 ShClassInstallerTest >> tearDown [
 
 	(self generatedClassesPackageName asPackageIfAbsent: [ nil ]) ifNotNil: [ :package | package removeFromSystem ].
-
 	super tearDown
 ]
 
@@ -286,6 +285,30 @@ ShClassInstallerTest >> testDuplicatedInstanceVariableInSuperclassMetaclass [
 		on: DuplicatedSlotName
 		do: [ :ex | self deny: ex isResumable ].
 	self deny: ((superClass class slots collect: [:e | e name]) includes: 'aSlot')
+]
+
+{ #category : #tests }
+ShClassInstallerTest >> testInstallInSpecificEnvironment [
+
+	| newEnvironment |
+	newEnvironment := SystemDictionary new.
+	newClass := ShiftClassInstaller new
+		            installingEnvironment: (ShSmalltalkGlobalsEnvironment new
+				             environment: newEnvironment;
+				             yourself);
+		            make: [ :builder |
+			            builder
+				            name: #SHClassForTest;
+				            superclass: Object;
+				            category: self generatedClassesPackageName ].
+
+	self class environment at: #SHClassForTest ifPresent: [ self fail: 'The default environment should not have the class installed.' ].
+	newEnvironment at: #SHClassForTest ifAbsent: [ self fail: 'The default environment should not have the class installed.' ].
+	
+	self skip. 
+	self flag: #package. "ShiftClassInstaller>>#recategorize:to: is using the old SystemOrganizer system to classify classes, but this does not add the classes to the instance of RPackageOrganizer but to the default package organizer of the image instead. Until we can fix this, we cannot have the next assertions working. They are clearly a bug but it'll be hard to fix this bug in short term........ :("
+	self deny: (self packageOrganizer includesPackageNamed: self generatedClassesPackageName).
+	self assert: (newEnvironment organization includesPackageNamed: self generatedClassesPackageName)
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Adding a test about adding a class in a non default environment because I didn't see this done in the image and it made it harder for me to find how to do that.

The problem is that we currently can install a package in another environment but the package organizer it ends up added to is the wrong one! It is always the one of the system and not the one we ask :( For now I added assertions that I skipped but it is important we are able to make them pass at some point if we want to be able to have tests generating code in the non default environment to not dirty the image.


I also find the installation in a non default environment too difficult but I opened https://github.com/pharo-project/pharo/issues/14221 for this