### PR TITLE
Dependency Analyser title management

### DIFF
--- a/src/Tool-DependencyAnalyser-UI/DAAddPackagePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAAddPackagePresenter.class.st
@@ -82,6 +82,12 @@ DAAddPackagePresenter >> initializePresenters [
 ]
 
 { #category : #initialization }
+DAAddPackagePresenter >> initializeWindow: aWindowPresenter [
+
+	aWindowPresenter title: 'Choose packages to add'
+]
+
+{ #category : #initialization }
 DAAddPackagePresenter >> selectedItemsFromPackageList [
 	^ packageList chosenItems
 ]
@@ -90,9 +96,4 @@ DAAddPackagePresenter >> selectedItemsFromPackageList [
 DAAddPackagePresenter >> systemPackages [
 
 	^ (self packageOrganizer packages collect: [ :package | package packageName asString ]) asSortedCollection
-]
-
-{ #category : #protocol }
-DAAddPackagePresenter >> title [
-	^ 'Choose packages to add'
 ]

--- a/src/Tool-DependencyAnalyser-UI/DAAddPackagePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAAddPackagePresenter.class.st
@@ -13,6 +13,12 @@ Class {
 	#category : #'Tool-DependencyAnalyser-UI-Core'
 }
 
+{ #category : #specs }
+DAAddPackagePresenter class >> title [
+
+	^ 'Choose packages to add'
+]
+
 { #category : #protocol }
 DAAddPackagePresenter >> actionOnAddPackage [
 	| relationGraph packagesToAdd |
@@ -79,12 +85,6 @@ DAAddPackagePresenter >> initializePresenters [
 		yourself.
 
 	packageList := SpChooserPresenter new
-]
-
-{ #category : #initialization }
-DAAddPackagePresenter >> initializeWindow: aWindowPresenter [
-
-	aWindowPresenter title: 'Choose packages to add'
 ]
 
 { #category : #initialization }

--- a/src/Tool-DependencyAnalyser-UI/DACycleDetectionTreePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DACycleDetectionTreePresenter.class.st
@@ -35,6 +35,12 @@ DACycleDetectionTreePresenter class >> system [
 		(self packageOrganizer packages collect: [ :package | package packageName asString ])
 ]
 
+{ #category : #specs }
+DACycleDetectionTreePresenter class >> title [
+
+	^ 'Cycles analysis'
+]
+
 { #category : #accessing }
 DACycleDetectionTreePresenter >> analysis [
 	^ analysis
@@ -131,12 +137,6 @@ DACycleDetectionTreePresenter >> initializePresenters [
 			action: [ self reversedRoots  ].
 
 	self layout: self defaultLayout
-]
-
-{ #category : #initialization }
-DACycleDetectionTreePresenter >> initializeWindow: aWindowPresenter [
-
-	aWindowPresenter title: 'Cycles analysis'
 ]
 
 { #category : #initialization }

--- a/src/Tool-DependencyAnalyser-UI/DACycleDetectionTreePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DACycleDetectionTreePresenter.class.st
@@ -134,6 +134,12 @@ DACycleDetectionTreePresenter >> initializePresenters [
 ]
 
 { #category : #initialization }
+DACycleDetectionTreePresenter >> initializeWindow: aWindowPresenter [
+
+	aWindowPresenter title: 'Cycles analysis'
+]
+
+{ #category : #initialization }
 DACycleDetectionTreePresenter >> initializeWithPackageName: aCollection [
 
 	self analysis:  (DAPackageCycleDetector onPackagesNamed: aCollection) runAlgorithm.
@@ -152,9 +158,4 @@ DACycleDetectionTreePresenter >> refresh [
 { #category : #accessing }
 DACycleDetectionTreePresenter >> reversedRoots [
 	self tree roots: (self tree roots reversed)
-]
-
-{ #category : #protocol }
-DACycleDetectionTreePresenter >> title [
-	^ 'Cycles analysis'
 ]

--- a/src/Tool-DependencyAnalyser-UI/DADependencyTreePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DADependencyTreePresenter.class.st
@@ -256,6 +256,12 @@ DADependencyTreePresenter >> initializePresenters [
 	self initializeButtons
 ]
 
+{ #category : #initialization }
+DADependencyTreePresenter >> initializeWindow: aWindowPresenter [
+
+	aWindowPresenter title: 'Dependencies analysis'
+]
+
 { #category : #accessing }
 DADependencyTreePresenter >> initializeWithRPackageSet: aCollection [
 	self relationGraph: (DAPackageRelationGraph onPackages: (aCollection collect: [ :each | DAPackage on: each ]))
@@ -347,11 +353,6 @@ DADependencyTreePresenter >> seenPackagesName [
 { #category : #accessing }
 DADependencyTreePresenter >> sizeOfRoots [
 	^ self treeRoots size
-]
-
-{ #category : #protocol }
-DADependencyTreePresenter >> title [
-	^ 'Dependencies analysis'
 ]
 
 { #category : #accessing }

--- a/src/Tool-DependencyAnalyser-UI/DADependencyTreePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DADependencyTreePresenter.class.st
@@ -64,6 +64,12 @@ DADependencyTreePresenter class >> onPackagesNamed: aCollection [
 	^ self onPackages: (aCollection collect: [ :each | RPackageSet named: each ])
 ]
 
+{ #category : #specs }
+DADependencyTreePresenter class >> title [
+
+	^ 'Dependencies analysis'
+]
+
 { #category : #protocol }
 DADependencyTreePresenter >> actionOnAddPackage [
 	buttonAddPackage action: [ (DAAddPackagePresenter
@@ -254,12 +260,6 @@ DADependencyTreePresenter >> initializePresenters [
 		placeholder: 'Enter a package name';
 		entryCompletion: self packagesEntryCompletion.
 	self initializeButtons
-]
-
-{ #category : #initialization }
-DADependencyTreePresenter >> initializeWindow: aWindowPresenter [
-
-	aWindowPresenter title: 'Dependencies analysis'
 ]
 
 { #category : #accessing }

--- a/src/Tool-DependencyAnalyser-UI/DAPackageAnalyzerDiffTreePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAPackageAnalyzerDiffTreePresenter.class.st
@@ -44,6 +44,12 @@ DAPackageAnalyzerDiffTreePresenter >> initializePresenters [
 ]
 
 { #category : #initialization }
+DAPackageAnalyzerDiffTreePresenter >> initializeWindow: aWindowPresenter [
+
+	aWindowPresenter title: 'Package Dependencies Analysis Diff'
+]
+
+{ #category : #initialization }
 DAPackageAnalyzerDiffTreePresenter >> initializeWith: oldRelationGraph on: newRelationGraph [
 	packageRelationGraphDiff := DAPackageRelationGraphDiff new
 		oldRelationGraph: oldRelationGraph;
@@ -51,11 +57,6 @@ DAPackageAnalyzerDiffTreePresenter >> initializeWith: oldRelationGraph on: newRe
 	packageRelationGraphDiff make.
 
 	self buildRoots
-]
-
-{ #category : #protocol }
-DAPackageAnalyzerDiffTreePresenter >> title [
-	^ 'Package Dependencies Analysis Diff'
 ]
 
 { #category : #accessing }

--- a/src/Tool-DependencyAnalyser-UI/DAPackageAnalyzerDiffTreePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAPackageAnalyzerDiffTreePresenter.class.st
@@ -18,6 +18,12 @@ DAPackageAnalyzerDiffTreePresenter class >> newWith: oldRelationGraph on: newRel
 		yourself
 ]
 
+{ #category : #specs }
+DAPackageAnalyzerDiffTreePresenter class >> title [
+
+	^ 'Package Dependencies Analysis Diff'
+]
+
 { #category : #initialization }
 DAPackageAnalyzerDiffTreePresenter >> buildRoots [
 	self treeDiff roots: packageRelationGraphDiff packagesDiffToDisplay.
@@ -41,12 +47,6 @@ DAPackageAnalyzerDiffTreePresenter >> extent [
 DAPackageAnalyzerDiffTreePresenter >> initializePresenters [
 
 	treeDiff := self newTree
-]
-
-{ #category : #initialization }
-DAPackageAnalyzerDiffTreePresenter >> initializeWindow: aWindowPresenter [
-
-	aWindowPresenter title: 'Package Dependencies Analysis Diff'
 ]
 
 { #category : #initialization }

--- a/src/Tool-DependencyAnalyser-UI/DAPackageDependenciesPresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAPackageDependenciesPresenter.class.st
@@ -25,11 +25,10 @@ DAPackageDependenciesPresenter class >> system [
 	^ (self onPackagesNamed: self systemPackages) open
 ]
 
-{ #category : #initialization }
-DAPackageDependenciesPresenter >> initializeWindow: aWindowPresenter [
+{ #category : #specs }
+DAPackageDependenciesPresenter class >> title [
 
-	aWindowPresenter
-		title: 'Dependecy Analyser '
+	^ 'Dependecy Analyser'
 ]
 
 { #category : #initialization }

--- a/src/Tool-DependencyAnalyser-UI/DAPackageDependenciesPresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAPackageDependenciesPresenter.class.st
@@ -26,6 +26,13 @@ DAPackageDependenciesPresenter class >> system [
 ]
 
 { #category : #initialization }
+DAPackageDependenciesPresenter >> initializeWindow: aWindowPresenter [
+
+	aWindowPresenter
+		title: 'Dependecy Analyser '
+]
+
+{ #category : #initialization }
 DAPackageDependenciesPresenter >> initializeWithRelationGraph: aRelationGraph [
 	self model: (DAReverseTreePresenter onRelationGraph: aRelationGraph).
 	"self buildandAddAllMorph "

--- a/src/Tool-DependencyAnalyser-UI/DAReverseTreePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAReverseTreePresenter.class.st
@@ -59,6 +59,12 @@ DAReverseTreePresenter >> initializePresenters [
 	self buildRoots
 ]
 
+{ #category : #initialization }
+DAReverseTreePresenter >> initializeWindow: aWindowPresenter [
+
+	aWindowPresenter title: 'Package Dependencies Reverse Analysis'
+]
+
 { #category : #private }
 DAReverseTreePresenter >> nodesFor: anItemList [
 	^ anItemList collect:
@@ -86,11 +92,6 @@ DAReverseTreePresenter >> relationGraph [
 { #category : #initialization }
 DAReverseTreePresenter >> setModelBeforeInitialization: aRelationGraph [
 	relationGraph := aRelationGraph
-]
-
-{ #category : #accessing }
-DAReverseTreePresenter >> title [
-	^ 'Package Dependencies Reverse Analysis'
 ]
 
 { #category : #private }

--- a/src/Tool-DependencyAnalyser-UI/DAReverseTreePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAReverseTreePresenter.class.st
@@ -18,6 +18,12 @@ DAReverseTreePresenter class >> onRelationGraph: aRelationGraph [
 	^ self on: aRelationGraph
 ]
 
+{ #category : #specs }
+DAReverseTreePresenter class >> title [
+
+	^ 'Package Dependencies Reverse Analysis'
+]
+
 { #category : #private }
 DAReverseTreePresenter >> buildRoots [
 	| collectionOfWrapper |
@@ -57,12 +63,6 @@ DAReverseTreePresenter >> initializePresenters [
 
 	packageLabel := self newLabel label: 'Analysis of packages'.
 	self buildRoots
-]
-
-{ #category : #initialization }
-DAReverseTreePresenter >> initializeWindow: aWindowPresenter [
-
-	aWindowPresenter title: 'Package Dependencies Reverse Analysis'
 ]
 
 { #category : #private }

--- a/src/Tool-DependencyAnalyser-UI/DAWelcomePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAWelcomePresenter.class.st
@@ -26,6 +26,12 @@ DAWelcomePresenter class >> menuCommandOn: aBuilder [
 		action: [ self new open ]
 ]
 
+{ #category : #specs }
+DAWelcomePresenter class >> title [
+
+	^ 'Package Dependencies Browser'
+]
+
 { #category : #layout }
 DAWelcomePresenter >> defaultLayout [
 
@@ -60,7 +66,7 @@ DAWelcomePresenter >> initializePresenters [
 DAWelcomePresenter >> initializeWindow: aWindowPresenter [
 
 	aWindowPresenter
-		title: 'Package Dependencies Browser';
+		title: self class title;
 		initialExtent: self initialExtent
 ]
 

--- a/src/Tool-DependencyAnalyser-UI/DAWelcomePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAWelcomePresenter.class.st
@@ -57,10 +57,9 @@ DAWelcomePresenter >> initializePresenters [
 ]
 
 { #category : #initialization }
-DAWelcomePresenter >> initializeWindow: 	aWindowPresenter [
-	aWindowPresenter
-		title: self title;
-		initialExtent: self initialExtent
+DAWelcomePresenter >> initializeWindow: aWindowPresenter [
+
+	aWindowPresenter title: 'Package Dependencies Browser'
 ]
 
 { #category : #action }
@@ -77,9 +76,4 @@ DAWelcomePresenter >> selectedPackageNames [
 { #category : #accessing }
 DAWelcomePresenter >> selectedPackages [
 	^ choosePresenter chosenItems
-]
-
-{ #category : #accessing }
-DAWelcomePresenter >> title [
-	^ 'Package Dependencies Browser'
 ]

--- a/src/Tool-DependencyAnalyser-UI/DAWelcomePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAWelcomePresenter.class.st
@@ -59,7 +59,9 @@ DAWelcomePresenter >> initializePresenters [
 { #category : #initialization }
 DAWelcomePresenter >> initializeWindow: aWindowPresenter [
 
-	aWindowPresenter title: 'Package Dependencies Browser'
+	aWindowPresenter
+		title: 'Package Dependencies Browser';
+		initialExtent: self initialExtent
 ]
 
 { #category : #action }


### PR DESCRIPTION
Refactored Dependency Analyser title management. The `title` method will be deprecated. Now one needs to use the `initializeWindow:` method instead.