### PR TITLE
14226-nil-cannot-be-pinned-in-memory

### DIFF
--- a/src/Kernel/Boolean.class.st
+++ b/src/Kernel/Boolean.class.st
@@ -188,6 +188,12 @@ Boolean >> or: alternativeBlock [
 	self subclassResponsibility
 ]
 
+{ #category : #pinning }
+Boolean >> setPinnedInMemory: aBoolean [
+
+	self error: self printString , ' cannot be pinned.'
+]
+
 { #category : #copying }
 Boolean >> shallowCopy [
 	"Receiver has two concrete subclasses, True and False.

--- a/src/Kernel/UndefinedObject.class.st
+++ b/src/Kernel/UndefinedObject.class.st
@@ -197,6 +197,12 @@ UndefinedObject >> removeSubclass: aClass [
 	"Ignored -- necessary to support disjoint class hierarchies"
 ]
 
+{ #category : #pinning }
+UndefinedObject >> setPinnedInMemory: aBoolean [
+
+	self error: 'nil cannot be pinned.'
+]
+
 { #category : #copying }
 UndefinedObject >> shallowCopy [
 	"Only one instance of UndefinedObject should ever be made, so answer


### PR DESCRIPTION
Fix #14226
Pinning nil, true or false leaves the VM in an invalid state