### PR TITLE
fix calculous of layout when morph is not visible 

### DIFF
--- a/src/Morphic-Base/TableLayout.class.st
+++ b/src/Morphic-Base/TableLayout.class.st
@@ -477,7 +477,7 @@ TableLayout >> layout: aMorph in: box [
 { #category : #layout }
 TableLayout >> layoutLeftToRight: aMorph in: newBounds [
 	"An optimized left-to-right list layout"
-	| inset extent block posX posY centering extraPerCell amount minX minY maxX maxY n width extra last cell size height sum vFill first |
+	| inset extent block posX posY centering extraPerCell amount minX minY maxX maxY n width extra last cell size height sum vFill first submorphs |
 	size := properties minCellSize asPoint. minX := size x. minY := size y.
 	size := properties maxCellSize asPoint. maxX := size x. maxY := size y.
 	inset := properties cellInset asPoint x.
@@ -511,9 +511,13 @@ TableLayout >> layoutLeftToRight: aMorph in: newBounds [
 			sizeY > height ifTrue:[height := sizeY].
 		].
 	].
-	properties reverseTableCells
-		ifTrue:[aMorph submorphsReverseDo: block]
-		ifFalse:[aMorph submorphsDo: block].
+
+	submorphs := aMorph submorphs.
+	properties reverseTableCells ifTrue:[ submorphs := submorphs reversed ].
+	submorphs do: [ :each |
+		each visible 
+			ifTrue: [ block value: each ]
+			ifFalse: [ each privateBounds: (each bounds topLeft extent: 0@0) ] ].
 
 	n > 1 ifTrue:[width := width + (n-1 * inset)].
 
@@ -571,7 +575,7 @@ TableLayout >> layoutLeftToRight: aMorph in: newBounds [
 { #category : #nil }
 TableLayout >> layoutTopToBottom: aMorph in: newBounds [
 	"An optimized top-to-bottom list layout"
-	| inset extent block posX posY centering extraPerCell amount minX minY maxX maxY n height extra last cell size width sum vFill first |
+	| inset extent block posX posY centering extraPerCell amount minX minY maxX maxY n height extra last cell size width sum vFill first submorphs |
 	size := properties minCellSize asPoint. minX := size x. minY := size y.
 	size := properties maxCellSize asPoint. maxX := size x. maxY := size y.
 	inset := properties cellInset asPoint y.
@@ -605,9 +609,13 @@ TableLayout >> layoutTopToBottom: aMorph in: newBounds [
 			sizeX > width ifTrue:[width := sizeX].
 		].
 	].
-	properties reverseTableCells
-		ifTrue:[aMorph submorphsReverseDo: block]
-		ifFalse:[aMorph submorphsDo: block].
+
+	submorphs := aMorph submorphs.
+	properties reverseTableCells ifTrue:[ submorphs := submorphs reversed ].
+	submorphs do: [ :each |
+		each visible 
+			ifTrue: [ block value: each ]
+			ifFalse: [ each privateBounds: (each bounds topLeft extent: 0@0) ] ].
 
 	n > 1 ifTrue:[height := height + (n-1 * inset)].
 

--- a/src/Morphic-Tests/TableLayoutTest.class.st
+++ b/src/Morphic-Tests/TableLayoutTest.class.st
@@ -1,0 +1,67 @@
+Class {
+	#name : #TableLayoutTest,
+	#superclass : #TestCase,
+	#category : #'Morphic-Tests-Layouts'
+}
+
+{ #category : #tests }
+TableLayoutTest >> testNotVisibleMorphIsNotGettingAnExtent [
+
+	self 
+		testNotVisibleMorphIsNotGettingAnExtent: #topToBottom 
+		compareSelector: #height.
+		
+	self 
+		testNotVisibleMorphIsNotGettingAnExtent: #leftToRight 
+		compareSelector: #width
+]
+
+{ #category : #tests }
+TableLayoutTest >> testNotVisibleMorphIsNotGettingAnExtent: direction compareSelector: aSelector [
+	| morph m1 m2 |
+	
+	morph := Morph new
+		layoutPolicy: TableLayout new;
+		hResizing: #spaceFill;
+		vResizing: #spaceFill;
+		listDirection: direction;
+		cellPositioning: #topLeft;
+		listCentering: #topLeft;
+		wrapCentering: #topLeft;
+		cellInset: 0;
+		borderWidth: 0;
+		extent: 100@100;
+		yourself.
+	
+	morph addMorphBack: (m1 := Morph new 
+		color: Color red;
+		hResizing: #spaceFill;
+		vResizing: #spaceFill;
+		yourself).
+	morph addMorphBack: (m2 := Morph new 
+		color: Color yellow;
+		hResizing: #spaceFill;
+		vResizing: #spaceFill;
+		yourself).
+	
+	[  morph openInWorld.
+	   self assert: (m1 perform: aSelector) equals: 50.
+		self assert: (m2 perform: aSelector) equals: 50 ]
+	ensure: [ morph delete ].
+	
+	m1 visible: false.
+	[  morph openInWorld.
+	   self assert: (m1 perform: aSelector) equals: 0.
+		self assert: (m2 perform: aSelector) equals: 100 ]
+	ensure: [ morph delete ].
+	
+	m1 visible: true.
+	[  morph openInWorld.
+	   self assert: (m1 perform: aSelector) equals: 50.
+		self assert: (m2 perform: aSelector) equals: 50.
+		m1 visible: false.
+		self currentWorld doOneCycle.
+	   self assert: (m1 perform: aSelector) equals: 0.
+		self assert: (m2 perform: aSelector) equals: 100 ]
+	ensure: [ morph delete ]
+]


### PR DESCRIPTION
it should not take a place, allowing the rest of the elements to arrange themselves as  if invisible morph wouldn't be there.