### PR TITLE
Fix the preconditions related to packages in refactorings

### DIFF
--- a/src/Refactoring-Core/RBCopyPackageRefactoring.class.st
+++ b/src/Refactoring-Core/RBCopyPackageRefactoring.class.st
@@ -104,13 +104,13 @@ RBCopyPackageRefactoring >> copyPackage: aString1 in: aString2 [
 
 { #category : #preconditions }
 RBCopyPackageRefactoring >> preconditions [
-	^ super preconditions & (RBCondition withBlock: [ newName = packageName ifTrue:
-		[ self refactoringError: 'Use a different name' ].
-		true ]) &
-	(RBCondition withBlock: [ [RPackage organizer validatePackageDoesNotExist: newName. true]
-			on: Error
-			do: [ :e | self refactoringError: e messageText ]
-		])
+
+	^ super preconditions
+		& (RBCondition withBlock: [ newName ~= packageName ] errorString: 'The new package name is the same as the old package name.')
+		& (RBCondition
+			   withBlock: [ "Cyril: I am not sure we should use #packageOrganizer. Maybe we should ask the environment the package manager. But currently the image does not know yet how to work with multiple package managers/modules."
+				   self packageOrganizer hasPackage: newName ]
+			   errorString: 'The system already includes a package named ' , newName)
 ]
 
 { #category : #renaming }

--- a/src/Refactoring-Core/RBCopyPackageRefactoring.class.st
+++ b/src/Refactoring-Core/RBCopyPackageRefactoring.class.st
@@ -109,7 +109,7 @@ RBCopyPackageRefactoring >> preconditions [
 		& (RBCondition withBlock: [ newName ~= packageName ] errorString: 'The new package name is the same as the old package name.')
 		& (RBCondition
 			   withBlock: [ "Cyril: I am not sure we should use #packageOrganizer. Maybe we should ask the environment the package manager. But currently the image does not know yet how to work with multiple package managers/modules."
-				   self packageOrganizer hasPackage: newName ]
+				   (self packageOrganizer hasPackage: newName) not ]
 			   errorString: 'The system already includes a package named ' , newName)
 ]
 

--- a/src/Refactoring-Core/RBPackageRefactoring.class.st
+++ b/src/Refactoring-Core/RBPackageRefactoring.class.st
@@ -59,8 +59,9 @@ RBPackageRefactoring >> packageName: anObject [
 
 { #category : #preconditions }
 RBPackageRefactoring >> preconditions [
-	^ (RBCondition withBlock: [ [ RPackage organizer includesPackageNamed: packageName ]
-			on: Error
-			do: [ :e | self refactoringError: e messageText ]
-		])
+
+	^ RBCondition
+		  withBlock: [ "Cyril: I am not sure we should use #packageOrganizer. Maybe we should ask the environment the package manager. But currently the image does not know yet how to work with multiple package managers/modules."
+			  self packageOrganizer hasPackage: packageName ]
+		  errorString: 'The package ' , packageName , ' does not exists in the system'
 ]

--- a/src/Refactoring-Core/RBRenamePackageRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenamePackageRefactoring.class.st
@@ -56,7 +56,7 @@ RBRenamePackageRefactoring >> preconditions [
 		& (RBCondition withBlock: [ newName ~= packageName ] errorString: 'The new package name is the same as the old package name.')
 		& (RBCondition
 			   withBlock: [ "Cyril: I am not sure we should use #packageOrganizer. Maybe we should ask the environment the package manager. But currently the image does not know yet how to work with multiple package managers/modules."
-				   self packageOrganizer hasPackage: newName ]
+				   (self packageOrganizer hasPackage: newName) not ]
 			   errorString: 'The system already includes a package named ' , newName)
 ]
 

--- a/src/Refactoring-Core/RBRenamePackageRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenamePackageRefactoring.class.st
@@ -52,13 +52,12 @@ RBRenamePackageRefactoring >> packageName: aName newName: aNewName [
 
 { #category : #preconditions }
 RBRenamePackageRefactoring >> preconditions [
-	^ super preconditions & (RBCondition withBlock: [ newName = package name ifTrue:
-		[ self refactoringError: 'Use a different name' ].
-		true ]) &
-	(RBCondition withBlock: [ [RPackage organizer validatePackageDoesNotExist: newName. true]
-			on: Error
-			do: [ :e | self refactoringError: e messageText ]
-		])
+	^ super preconditions
+		& (RBCondition withBlock: [ newName ~= packageName ] errorString: 'The new package name is the same as the old package name.')
+		& (RBCondition
+			   withBlock: [ "Cyril: I am not sure we should use #packageOrganizer. Maybe we should ask the environment the package manager. But currently the image does not know yet how to work with multiple package managers/modules."
+				   self packageOrganizer hasPackage: newName ]
+			   errorString: 'The system already includes a package named ' , newName)
 ]
 
 { #category : #transforming }

--- a/src/Refactoring-Tests-Environment/RBBrowserEnvironmentTest.class.st
+++ b/src/Refactoring-Tests-Environment/RBBrowserEnvironmentTest.class.st
@@ -307,7 +307,7 @@ RBBrowserEnvironmentTest >> testNotEnvironment [
 	self assertEmpty: (notPrintStringEnvironment referencesTo: #printString).
 	self assert: (notPrintStringEnvironment not includesClass: RBBrowserEnvironmentTest).
 	self assert: (notPrintStringEnvironment not includesSelector: #testNotEnvironment in: RBBrowserEnvironmentTest).
-	self deny: (notKernelEnvironment hasPackage: 'Kernel').
+	self deny: (notKernelEnvironment includesPackage: 'Kernel' asPackage).
 	self assertEmpty: (notKernelEnvironment & kernelEnvironment) packages
 ]
 

--- a/src/Refactoring-Tests-Environment/RBBrowserEnvironmentTest.class.st
+++ b/src/Refactoring-Tests-Environment/RBBrowserEnvironmentTest.class.st
@@ -307,7 +307,7 @@ RBBrowserEnvironmentTest >> testNotEnvironment [
 	self assertEmpty: (notPrintStringEnvironment referencesTo: #printString).
 	self assert: (notPrintStringEnvironment not includesClass: RBBrowserEnvironmentTest).
 	self assert: (notPrintStringEnvironment not includesSelector: #testNotEnvironment in: RBBrowserEnvironmentTest).
-	self assert: (notKernelEnvironment includesPackage: 'Kernel' asPackage) not.
+	self deny: (notKernelEnvironment hasPackage: 'Kernel').
 	self assertEmpty: (notKernelEnvironment & kernelEnvironment) packages
 ]
 

--- a/src/Refactoring2-Transformations/RBPackageTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBPackageTransformation.class.st
@@ -41,8 +41,9 @@ RBPackageTransformation >> packageName: anObject [
 
 { #category : #preconditions }
 RBPackageTransformation >> preconditions [
-	^ (RBCondition withBlock: [ [ RPackage organizer includesPackageNamed: packageName ]
-			on: Error
-			do: [ :e | self refactoringError: e messageText ]
-		])
+
+	^ RBCondition
+		  withBlock: [ "Cyril: I am not sure we should use #packageOrganizer. Maybe we should ask the environment the package manager. But currently the image does not know yet how to work with multiple package managers/modules."
+			  self packageOrganizer hasPackage: packageName ]
+		  errorString: 'The package ' , packageName , ' does not exsit in the system.'
 ]

--- a/src/Refactoring2-Transformations/RBRenamePackageTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBRenamePackageTransformation.class.st
@@ -67,7 +67,7 @@ RBRenamePackageTransformation >> preconditions [
 		& (RBCondition withBlock: [ newName ~= packageName ] errorString: 'The new package name is the same as the old package name.')
 		& (RBCondition
 			   withBlock: [ "Cyril: I am not sure we should use #packageOrganizer. Maybe we should ask the environment the package manager. But currently the image does not know yet how to work with multiple package managers/modules."
-				   self packageOrganizer hasPackage: newName ]
+				   (self packageOrganizer hasPackage: newName) not ]
 			   errorString: 'The system already includes a package named ' , newName)
 ]
 

--- a/src/Refactoring2-Transformations/RBRenamePackageTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBRenamePackageTransformation.class.st
@@ -63,13 +63,12 @@ RBRenamePackageTransformation >> packageName: aName newName: aNewName [
 
 { #category : #executing }
 RBRenamePackageTransformation >> preconditions [
-	^ super preconditions & (RBCondition withBlock: [ newName = package name ifTrue:
-		[ self refactoringError: 'Use a different name' ].
-		true ]) &
-	(RBCondition withBlock: [ [RPackage organizer validatePackageDoesNotExist: newName. true]
-			on: Error
-			do: [ :e | self refactoringError: e messageText ]
-		])
+	^ super preconditions
+		& (RBCondition withBlock: [ newName ~= packageName ] errorString: 'The new package name is the same as the old package name.')
+		& (RBCondition
+			   withBlock: [ "Cyril: I am not sure we should use #packageOrganizer. Maybe we should ask the environment the package manager. But currently the image does not know yet how to work with multiple package managers/modules."
+				   self packageOrganizer hasPackage: newName ]
+			   errorString: 'The system already includes a package named ' , newName)
 ]
 
 { #category : #executing }


### PR DESCRIPTION
This PR includes multiple cleanings in refacotrings related to packages.

- Use #hasPackage: instead of #includesPackage(Named): that will be deprecated
- Remove useless catch blocks that cannot be triggered
- Remove usage of validatePackageDoesNotExist: because this should be a private method of RPackageOrganizer and use #hasPackage: instead with a better error message
- Do not throw refactoring errors but use #errorString in the preconditions
- Use #packageOrganizer instead of `RPackage organizer` because the later will be deprecated soon 

There are still some things I am unsure about like the usage of #packageOrganizer because it will return the package organizer of the system. Maybe later we should access the packageOrganizer throught the environment? BUT! This should not change the current behavior so this is for a future change. (I'll probably not do it myself, or not before a long time sorry).

Another problem is that I think we have a duplication between RBRenamePackageRefactoring and RBRenamePackageTransformation. But I don't know how to fix that without reading more code of Refactorings and this is not in my current roadmap. Maybe @balsa-sarenac will know how to do that.

This depends on https://github.com/pharo-project/pharo/pull/14232. If you want to review this change before the PR is integrated, you can check the latest commit.