### PR TITLE
Disable automated transform for deprecation of Object>>asOrderedCollection

### DIFF
--- a/src/Deprecated11/Object.extension.st
+++ b/src/Deprecated11/Object.extension.st
@@ -6,7 +6,8 @@ Object >> asOrderedCollection [
 	self
 		deprecated:
 		'The usage of this method is not recommended. We want to have a smaller Object api. We will remove this method in the next Pharo version.'
-		transformWith: '`@receiver asOrderedCollection' -> 'OrderedCollection with: `@receiver'.
+		"Automatic transform removed. See https://github.com/pharo-project/pharo/issues/14197"
+		"transformWith: '`@receiver asOrderedCollection' -> 'OrderedCollection with: `@receiver'".
 	^ OrderedCollection with: self
 ]
 


### PR DESCRIPTION
See #14197 for the reasoning.

I opted to comment out the transform. The method and comment will disappear in Pharo 12 anway.