### PR TITLE
Deprecated CompiledMethod tag API

### DIFF
--- a/src/Calypso-SystemQueries-Tests/ClyAllMethodGroupsQueryTest.class.st
+++ b/src/Calypso-SystemQueries-Tests/ClyAllMethodGroupsQueryTest.class.st
@@ -40,12 +40,12 @@ ClyAllMethodGroupsQueryTest >> testFromSingleClass [
 
 	self queryFromScope: ClyInstanceSideScope of: ClyClass1FromP1Mock.
 
-	self assert: (resultItems collect: #class as: Set) equals: {
+	self assertCollection: (resultItems collect: #class) hasSameElements: {
 			ClyAllMethodGroup.
-			ClyMethodsInProtocolGroup } asSet.
+			ClyMethodsInProtocolGroup }.
 	self
-		assert: (resultItems
+		assertCollection: (resultItems
 				 select: [ :each | each class = ClyMethodsInProtocolGroup ]
-				 thenCollect: #protocol) asSet
-		equals: ClyClass1FromP1Mock tagsForMethods asSet
+				 thenCollect: #protocol)
+		hasSameElements: ClyClass1FromP1Mock protocolNames
 ]

--- a/src/Calypso-SystemQueries-Tests/ClyClassScopeTest.class.st
+++ b/src/Calypso-SystemQueries-Tests/ClyClassScopeTest.class.st
@@ -80,14 +80,14 @@ ClyClassScopeTest >> testMethodGroupsEnumeration [
 
 	scope methodGroupsDo: [ :each | result add: each ].
 
-	self assert: (result collect: #class as: Set) equals: {
+	self assertCollection: (result collect: #class) hasSameElements: {
 			ClyAllMethodGroup.
-			ClyMethodsInProtocolGroup } asSet.
+			ClyMethodsInProtocolGroup }.
 	self
-		assert: (result
+		assertCollection: (result
 				 select: [ :each | each class = ClyMethodsInProtocolGroup ]
-				 thenCollect: [ :group | group protocol ]) sorted asArray
-		equals: ClyClass1FromP1Mock tagsForMethods sorted asArray
+				 thenCollect: [ :group | group protocol ])
+		hasSameElements: ClyClass1FromP1Mock protocolNames
 ]
 
 { #category : #tests }

--- a/src/Calypso-SystemQueries-Tests/ClyMethodsInProtocolGroupProviderTest.class.st
+++ b/src/Calypso-SystemQueries-Tests/ClyMethodsInProtocolGroupProviderTest.class.st
@@ -20,14 +20,9 @@ ClyMethodsInProtocolGroupProviderTest >> testCreateGroupsForEveryProtocol [
 	| groups query |
 	self buildGroupsFor: ClySubclassN1OfClass1FromP1Mock.
 
-	groups := builtGroups select: [ :each |
-		          each isKindOf: ClyMethodsInProtocolGroup ].
-	self
-		assert: (groups collect: [ :group | group protocol ] as: Set)
-		equals: ClySubclassN1OfClass1FromP1Mock tagsForMethods asSet.
+	groups := builtGroups select: [ :each | each isKindOf: ClyMethodsInProtocolGroup ].
+	self assertCollection: (groups collect: [ :group | group protocol ]) hasSameElements: ClySubclassN1OfClass1FromP1Mock protocolNames.
 	query := groups first methodQuery.
 	self assert: query class equals: ClyMethodsInProtocolQuery.
-	self
-		assert: query scope
-		equals: (ClyClassScope of: ClySubclassN1OfClass1FromP1Mock)
+	self assert: query scope equals: (ClyClassScope of: ClySubclassN1OfClass1FromP1Mock)
 ]

--- a/src/Deprecated12/ClassDescription.extension.st
+++ b/src/Deprecated12/ClassDescription.extension.st
@@ -178,6 +178,13 @@ ClassDescription >> listAtCategoryNamed: aName [
 ]
 
 { #category : #'*Deprecated12' }
+ClassDescription >> methodsTaggedWith: aSymbol [
+
+	self deprecated: 'Use methodsInProtocol: instead.' transformWith: '`@rcv methodsTaggedWith: `@arg' -> '`@rcv methodsInProtocol: `@arg'.
+	^ self methodsInProtocol: aSymbol
+]
+
+{ #category : #'*Deprecated12' }
 ClassDescription >> organization [
 	"Answer the instance of ClassOrganizer that represents the organization
 	of the messages of the receiver."
@@ -260,6 +267,13 @@ ClassDescription >> subject [
 
 	self deprecated: 'ClassOrganization was inlined and we do not need an organized class anymore.' transformWith: '`@rcv subject' -> '`@rcv'.
 	^ self
+]
+
+{ #category : #'*Deprecated12' }
+ClassDescription >> tagsForMethods [
+
+	self deprecated: 'Use #protocolNames instead.' transformWith: '`@rcv tagsForMethods' -> '`@rcv protocolNames'.
+	^ self protocolNames
 ]
 
 { #category : #'*Deprecated12' }

--- a/src/Deprecated12/CompiledMethod.extension.st
+++ b/src/Deprecated12/CompiledMethod.extension.st
@@ -1,6 +1,14 @@
 Extension { #name : #CompiledMethod }
 
 { #category : #'*Deprecated12' }
+CompiledMethod >> isTaggedWith: aSymbol [
+
+	self deprecated: 'You should compare the protocol instead of using this method.' transformWith: '`@rcv isTaggedWith: `@arg' -> '`@rcv protocolName == `@arg'.
+
+	^ self protocolName == aSymbol
+]
+
+{ #category : #'*Deprecated12' }
 CompiledMethod >> tagWith: aSymbol [
 
 	self deprecated: 'Use #protocol: instead.' transformWith: '`@rcv tagWith: `@arg' -> '`@rcv protocol: `@arg'.

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -649,13 +649,6 @@ ClassDescription >> isInstanceSide [
 ]
 
 { #category : #testing }
-ClassDescription >> isLocalMethodsProtocol: aProtocol [
-	aProtocol methodSelectors ifEmpty: [ ^ true ].
-
-	^ aProtocol methodSelectors anySatisfy: [ :each | self isLocalSelector: each ]
-]
-
-{ #category : #testing }
 ClassDescription >> isLocalSelector: aSelector [
 
 	^ self methodDict includesKey: aSelector
@@ -696,16 +689,6 @@ ClassDescription >> localSlots [
 ClassDescription >> methodsInProtocol: protocol [
 
 	^ (self selectorsInProtocol: protocol) collect: [ :selector | self compiledMethodAt: selector ]
-]
-
-{ #category : #'accessing - tags' }
-ClassDescription >> methodsTaggedWith: aSymbol [
-	"Any method could be tagged with multiple symbols for user purpose.
-	And class contains all method tags which used or not used yet by methods.
-	This method select all methods marked by given tag.
-	Tags are not inherited from traits. So we only select local methods"
-
-	^self localMethods select: [ :each | each isTaggedWith: aSymbol ]
 ]
 
 { #category : #slots }
@@ -1182,20 +1165,6 @@ ClassDescription >> tags [
 	packageTag isRoot ifTrue: [ ^ #(  ) ].
 
 	^ { packageTag name }
-]
-
-{ #category : #'accessing - tags' }
-ClassDescription >> tagsForMethods [
-	"Any method could be tagged with multiple symbols for user purpose.
-	And class contains all method tags which used or not used yet by methods.
-	For now we could only implemented it on top of Protocol.
-	It supposed to not include any method tags inherited from Traits
-	which is opposite to current Protocol implementation.
-	And extension protocol is not treated as tag"
-	| allProtocols |
-	allProtocols := self protocols reject: [ :each | each isUnclassifiedProtocol | each isExtensionProtocol ].
-
-	^ allProtocols select: [ :each | self isLocalMethodsProtocol: each ] thenCollect: #name
 ]
 
 { #category : #'accessing - deprecated parallel hierarchy' }

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -528,13 +528,6 @@ CompiledMethod >> isSubclassResponsibility: marker [
 	^ marker == self class subclassResponsibilityMarker
 ]
 
-{ #category : #testing }
-CompiledMethod >> isTaggedWith: aSymbol [
-	"Not methods tags implemented by protocols. Look #tags comment"
-
-	^ self protocolName == aSymbol
-]
-
 { #category : #'source code management' }
 CompiledMethod >> linesOfCode [
 	"An approximate measure of lines of code.

--- a/src/Ring-Tests-Core/RGClassTest.class.st
+++ b/src/Ring-Tests-Core/RGClassTest.class.st
@@ -291,16 +291,16 @@ RGClassTest >> testTagsForMethods [
 
 	class := RGClass unnamed.
 
-	self assert: class tagsForMethods isEmpty.
+	self assertEmpty: class tagsForMethods.
 	self assert: (class hasUnresolved: #tagsForMethods).
 
 	method1 := class ensureLocalMethodNamed: #method1.
 	method2 := class ensureLocalMethodNamed: #method2.
 
-	self assert: class tagsForMethods isEmpty.
+	self assertEmpty: class tagsForMethods.
 	self assert: (class hasResolved: #tagsForMethods).
 
-	self assert: (class methodsTaggedWith: #tag1) isEmpty.
+	self assertEmpty: (class methodsTaggedWith: #tag1).
 
 	method1 tagWith: #tag1.
 	self assert: method1 tags equals: #(#tag1).
@@ -330,9 +330,9 @@ RGClassTest >> testTagsForMethods [
 	class removeLocalMethod: method2.
 	self assert: class tagsForMethods sorted equals: #(#tag1 #tag2 #tag3).
 
-	self assert: (class methodsTaggedWith: #tag1) isEmpty.
-	self assert: (class methodsTaggedWith: #tag2) isEmpty.
-	self assert: (class methodsTaggedWith: #tag3) isEmpty
+	self assertEmpty: (class methodsTaggedWith: #tag1).
+	self assertEmpty: (class methodsTaggedWith: #tag2).
+	self assertEmpty: (class methodsTaggedWith: #tag3)
 ]
 
 { #category : #tests }

--- a/src/TraitsV2/TraitedClass.class.st
+++ b/src/TraitsV2/TraitedClass.class.st
@@ -202,14 +202,6 @@ TraitedClass >> isLocalAliasSelector: aSymbol [
 ]
 
 { #category : #testing }
-TraitedClass >> isLocalMethodsProtocol: aProtocol [
-	"Checks if the protocol has local selectors"
-
-	aProtocol methodSelectors ifEmpty: [ ^ true ].
-	^ aProtocol methodSelectors anySatisfy: [ :each | self isLocalSelector: each ]
-]
-
-{ #category : #testing }
 TraitedClass >> isLocalSelector: aSelector [
 
 	^ self localMethodDict includesKey: aSelector


### PR DESCRIPTION
This changes deprecates the last CompiledMethod and ClassDescription methods using the "tag" vocabulary for protocols.

I also improved some assertions in tests