### PR TITLE
Refactoring: reuse `RBAddMethodTransformRefactoring`

### DIFF
--- a/src/Refactoring-Core/RBAbstractClassVariableReferencesRefactoring.class.st
+++ b/src/Refactoring-Core/RBAbstractClassVariableReferencesRefactoring.class.st
@@ -60,7 +60,7 @@ RBAbstractClassVariableReferencesRefactoring >> accessorsRefactoring [
 
 { #category : #transforming }
 RBAbstractClassVariableReferencesRefactoring >> createAccessors [
-	self performCompositeRefactoring: self accessorsRefactoring
+	self generateCompositeChangesFor: self accessorsRefactoring
 ]
 
 { #category : #preconditions }

--- a/src/Refactoring-Core/RBAbstractInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBAbstractInstanceVariableRefactoring.class.st
@@ -51,7 +51,7 @@ RBAbstractInstanceVariableRefactoring >> accessorsRefactoring [
 
 { #category : #transforming }
 RBAbstractInstanceVariableRefactoring >> createAccessors [
-	self performCompositeRefactoring: self accessorsRefactoring
+	self generateCompositeChangesFor: self accessorsRefactoring
 ]
 
 { #category : #preconditions }

--- a/src/Refactoring-Core/RBAbstractTransformation.class.st
+++ b/src/Refactoring-Core/RBAbstractTransformation.class.st
@@ -218,16 +218,6 @@ RBAbstractTransformation >> preconditions [
 	self subclassResponsibility
 ]
 
-{ #category : #preconditions }
-RBAbstractTransformation >> protocolExist [
-
-	^ RBCondition
-		  withBlock: [
-			  ((model environment protocolsFor: self definingClass realClass)
-				   includes: protocol) not ]
-		  errorString: 'Protocol named ' , protocol , ' already exists'
-]
-
 { #category : #exceptions }
 RBAbstractTransformation >> refactoringConfirmWarning: aString [
 	| ret |

--- a/src/Refactoring-Core/RBAbstractVariablesRefactoring.class.st
+++ b/src/Refactoring-Core/RBAbstractVariablesRefactoring.class.st
@@ -51,7 +51,7 @@ RBAbstractVariablesRefactoring >> abstractClassVariable: aString [
 		               variable: aString
 		               class: nonMetaClass
 		               classVariable: true.
-	self performCompositeRefactoring: refactoring.
+	self generateCompositeChangesFor: refactoring.
 	rewriter := self parseTreeRewriter.
 	fromClass isMeta
 		ifTrue: [
@@ -91,7 +91,7 @@ RBAbstractVariablesRefactoring >> abstractInstanceVariable: aString [
 		               variable: aString
 		               class: fromClass
 		               classVariable: false.
-	self performCompositeRefactoring: refactoring.
+	self generateCompositeChangesFor: refactoring.
 	rewriter := self parseTreeRewriter.
 	rewriter
 		replace: aString , ' := ``@object'
@@ -127,7 +127,7 @@ RBAbstractVariablesRefactoring >> abstractVariablesIn: aBRProgramNode from: from
 				forMethod: tree
 				fromClass: fromClass
 				toClasses: toClasses.
-	self performCompositeRefactoring: poolRefactoring.
+	self generateCompositeChangesFor: poolRefactoring.
 	self computeVariablesToAbstract
 ]
 

--- a/src/Refactoring-Core/RBChildrenToSiblingsRefactoring.class.st
+++ b/src/Refactoring-Core/RBChildrenToSiblingsRefactoring.class.st
@@ -56,7 +56,7 @@ RBChildrenToSiblingsRefactoring >> abstractSuperclass [
 
 { #category : #transforming }
 RBChildrenToSiblingsRefactoring >> addSuperclass [
-	self performCompositeRefactoring: (RBInsertNewClassRefactoring
+	self generateCompositeChangesFor: (RBInsertNewClassRefactoring
 				model: self model
 				addClass: className
 				superclass: parent superclass
@@ -125,7 +125,7 @@ RBChildrenToSiblingsRefactoring >> pullUpClassInstanceVariables [
 	newSuperclass := self abstractSuperclass classSide.
 	parent classSide instanceVariableNames do:
 		[ :each |
-		self performCompositeRefactoring: (RBPullUpInstanceVariableRefactoring
+		self generateCompositeChangesFor: (RBPullUpInstanceVariableRefactoring
 				model: self model
 				variable: each
 				class: newSuperclass) ]
@@ -137,7 +137,7 @@ RBChildrenToSiblingsRefactoring >> pullUpClassVariables [
 	newSuperclass := self abstractSuperclass.
 	parent classVariableNames do:
 			[:each |
-			self performCompositeRefactoring: (RBPullUpClassVariableRefactoring
+			self generateCompositeChangesFor: (RBPullUpClassVariableRefactoring
 						model: self model
 						variable: each
 						class: newSuperclass)]
@@ -149,7 +149,7 @@ RBChildrenToSiblingsRefactoring >> pullUpInstanceVariables [
 	newSuperclass := self abstractSuperclass.
 	parent instanceVariableNames do:
 			[:each |
-			self performCompositeRefactoring: (RBPullUpInstanceVariableRefactoring
+			self generateCompositeChangesFor: (RBPullUpInstanceVariableRefactoring
 						model: self model
 						variable: each
 						class: newSuperclass)]

--- a/src/Refactoring-Core/RBChildrenToSiblingsRefactoring.class.st
+++ b/src/Refactoring-Core/RBChildrenToSiblingsRefactoring.class.st
@@ -93,7 +93,11 @@ RBChildrenToSiblingsRefactoring >> createSubclassResponsibilityFor: aSelector in
 		ifTrue: [ ^ self ].
 	source := self subclassResponsibilityFor: aSelector in: aClass.
 	source ifNil: [ ^ self ].
-	aClass superclass compile: source classified: ( aClass protocolsFor: aSelector )
+	self generateCompositeChangesFor:
+		(RBAddMethodTransformRefactoring
+			addMethod: source
+			toClass: aClass superclass
+			inProtocols: (aClass protocolsFor: aSelector))
 ]
 
 { #category : #initialization }
@@ -178,7 +182,11 @@ RBChildrenToSiblingsRefactoring >> pushUp: aSelector in: aClass [
 
 	source := aClass sourceCodeFor: aSelector.
 	source
-		ifNotNil: [ aClass superclass compile: source classified: ( aClass protocolsFor: aSelector ) ]
+		ifNotNil: [ 	self generateCompositeChangesFor:
+		(RBAddMethodTransformRefactoring
+			addMethod: source
+			toClass: aClass superclass
+			inProtocols: (aClass protocolsFor: aSelector)) ]
 ]
 
 { #category : #'private - methods' }

--- a/src/Refactoring-Core/RBClassRegexRefactoring.class.st
+++ b/src/Refactoring-Core/RBClassRegexRefactoring.class.st
@@ -36,9 +36,11 @@ RBClassRegexRefactoring >> copyFrom: aSourceClass to: aTargetClass [
 		aSourceClass sharedPoolNames
 			do: [ :each | aTargetClass addPoolDictionary: each ] ].
 	aSourceClass selectors do: [ :each |
-		aTargetClass
-			compile: (aSourceClass sourceCodeFor: each)
-			classified: (aSourceClass protocolsFor: each) ]
+		self generateCompositeChangesFor:
+			(RBAddMethodTransformRefactoring
+				addMethod: (aSourceClass sourceCodeFor: each)
+				toClass: aTargetClass
+				inProtocols: (aSourceClass protocolsFor: each))]
 ]
 
 { #category : #transforming }

--- a/src/Refactoring-Core/RBCopyClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBCopyClassRefactoring.class.st
@@ -63,7 +63,7 @@ RBCopyClassRefactoring >> category: aSymbol [
 
 { #category : #transforming }
 RBCopyClassRefactoring >> copyClass [
-	self performCompositeRefactoring: (RBInsertNewClassRefactoring
+	self generateCompositeChangesFor: (RBInsertNewClassRefactoring
 		model: self model
 		addClass: className
 		superclass: aClass superclass
@@ -90,7 +90,7 @@ RBCopyClassRefactoring >> copyMethods [
 RBCopyClassRefactoring >> copyMethodsOf: rbClass1 in: rbClass2 [
 	rbClass1 selectors do: [ :symbol | | rbMethod |
 		rbMethod := rbClass1 methodFor: symbol.
-		self performCompositeRefactoring:
+		self generateCompositeChangesFor:
 			(RBAddMethodTransformRefactoring 
 				model: self model
 				addMethod: rbMethod source
@@ -102,13 +102,13 @@ RBCopyClassRefactoring >> copyMethodsOf: rbClass1 in: rbClass2 [
 { #category : #transforming }
 RBCopyClassRefactoring >> copyVariables [
 	aClass instanceVariableNames do: [ :varName |
-		self performCompositeRefactoring: (RBAddInstanceVariableRefactoring
+		self generateCompositeChangesFor: (RBAddInstanceVariableRefactoring
 		model: self model
 		variable: varName
 		class: className) ].
 
 	aClass classVariableNames do: [ :varName |
-		self performCompositeRefactoring: (RBAddClassVariableRefactoring
+		self generateCompositeChangesFor: (RBAddClassVariableRefactoring
 		model: self model
 		variable: varName
 		class: className) ]

--- a/src/Refactoring-Core/RBCopyClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBCopyClassRefactoring.class.st
@@ -90,8 +90,8 @@ RBCopyClassRefactoring >> copyMethods [
 RBCopyClassRefactoring >> copyMethodsOf: rbClass1 in: rbClass2 [
 	rbClass1 selectors do: [ :symbol | | rbMethod |
 		rbMethod := rbClass1 methodFor: symbol.
-		self performCompositeRefactoringThroughWarning:
-			(RBAddMethodRefactoring
+		self performCompositeRefactoring:
+			(RBAddMethodTransformRefactoring 
 				model: self model
 				addMethod: rbMethod source
 				toClass: rbClass2

--- a/src/Refactoring-Core/RBCopyPackageRefactoring.class.st
+++ b/src/Refactoring-Core/RBCopyPackageRefactoring.class.st
@@ -86,7 +86,7 @@ RBCopyPackageRefactoring >> copyAllClasses [
 	^ self classes collect: [ :symbol |
 		| copyClassName |
 		copyClassName := (self classMappings at: symbol) asSymbol.
-		self performCompositeRefactoring:
+		self generateCompositeChangesFor:
 			(RBCopyClassRefactoring
 				model: self model
 				copyClass: symbol

--- a/src/Refactoring-Core/RBCreateAccessorsForVariableTransformation.class.st
+++ b/src/Refactoring-Core/RBCreateAccessorsForVariableTransformation.class.st
@@ -119,7 +119,7 @@ RBCreateAccessorsForVariableTransformation >> createSetterAccessor [
 { #category : #transforming }
 RBCreateAccessorsForVariableTransformation >> defineGetterMethod [
 
-	self performCompositeRefactoring: 
+	self generateCompositeChangesFor: 
 		(RBAddMethodTransformRefactoring
 			 addMethod: ('<1s><r><r><t>^ <2s>'
 					  expandMacrosWith: self selector
@@ -141,7 +141,7 @@ RBCreateAccessorsForVariableTransformation >> defineSetterMethod [
 						safeMethodNameFor: definingClass
 						basedOn: variableName asString , ':'.
 						
-	self performCompositeRefactoring: 
+	self generateCompositeChangesFor: 
 		(RBAddMethodTransformRefactoring
 		 	 addMethod: (string expandMacrosWith: selector with: variableName)
 			 toClass: definingClass

--- a/src/Refactoring-Core/RBCreateAccessorsForVariableTransformation.class.st
+++ b/src/Refactoring-Core/RBCreateAccessorsForVariableTransformation.class.st
@@ -119,12 +119,13 @@ RBCreateAccessorsForVariableTransformation >> createSetterAccessor [
 { #category : #transforming }
 RBCreateAccessorsForVariableTransformation >> defineGetterMethod [
 
-	(RBAddMethodTransformRefactoring
-		 addMethod: ('<1s><r><r><t>^ <2s>'
-				  expandMacrosWith: self selector
-				  with: variableName)
-		 toClass: self definingClass
-		 inProtocols: #( #accessing )) execute.
+	self performCompositeRefactoring: 
+		(RBAddMethodTransformRefactoring
+			 addMethod: ('<1s><r><r><t>^ <2s>'
+					  expandMacrosWith: self selector
+					  with: variableName)
+			 toClass: self definingClass
+			 inProtocols: #( #accessing )).
 
 	^ selector
 ]
@@ -140,10 +141,11 @@ RBCreateAccessorsForVariableTransformation >> defineSetterMethod [
 						safeMethodNameFor: definingClass
 						basedOn: variableName asString , ':'.
 						
-	(RBAddMethodTransformRefactoring
-		 addMethod: (string expandMacrosWith: selector with: variableName)
-		 toClass: definingClass
-		 inProtocols: #( #accessing )) execute.
+	self performCompositeRefactoring: 
+		(RBAddMethodTransformRefactoring
+		 	 addMethod: (string expandMacrosWith: selector with: variableName)
+			 toClass: definingClass
+		 	 inProtocols: #( #accessing )).
 
 	^selector
 ]

--- a/src/Refactoring-Core/RBCreateLazyAccessorsForVariableTransformation.class.st
+++ b/src/Refactoring-Core/RBCreateLazyAccessorsForVariableTransformation.class.st
@@ -103,7 +103,7 @@ RBCreateLazyAccessorsForVariableTransformation >> defaultValue: aString [
 { #category : #transforming }
 RBCreateLazyAccessorsForVariableTransformation >> defineGetterMethod [
 
-	self performCompositeRefactoring:
+	self generateCompositeChangesFor:
 		(RBAddMethodTransformRefactoring
 			 addMethod: ('<1s><r><r><t>^ <2s> ifNil: [ <2s> := <3s> ]'
 					  expandMacrosWith: self selector

--- a/src/Refactoring-Core/RBCreateLazyAccessorsForVariableTransformation.class.st
+++ b/src/Refactoring-Core/RBCreateLazyAccessorsForVariableTransformation.class.st
@@ -103,13 +103,14 @@ RBCreateLazyAccessorsForVariableTransformation >> defaultValue: aString [
 { #category : #transforming }
 RBCreateLazyAccessorsForVariableTransformation >> defineGetterMethod [
 
-	(RBAddMethodTransformRefactoring
-		 addMethod: ('<1s><r><r><t>^ <2s> ifNil: [ <2s> := <3s> ]'
-				  expandMacrosWith: self selector
-				  with: variableName
-				  with: self defaultValue)
-		 toClass: self definingClass
-		 inProtocols: #( #accessing )) execute.
+	self performCompositeRefactoring:
+		(RBAddMethodTransformRefactoring
+			 addMethod: ('<1s><r><r><t>^ <2s> ifNil: [ <2s> := <3s> ]'
+					  expandMacrosWith: self selector
+					  with: variableName
+					  with: self defaultValue)
+			 toClass: self definingClass
+			 inProtocols: #( #accessing )).
 
 	^ selector
 ]

--- a/src/Refactoring-Core/RBDeprecateClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBDeprecateClassRefactoring.class.st
@@ -35,6 +35,16 @@ RBDeprecateClassRefactoring class >> model: aRBSmalltalk deprecate: aClass in: a
 		yourself
 ]
 
+{ #category : #adding }
+RBDeprecateClassRefactoring >> addMethod: source to: aClass in: aProtocol [
+
+	self generateCompositeChangesFor: 
+		(RBAddMethodTransformRefactoring 
+			addMethod: source
+			toClass: aClass
+			inProtocols: aProtocol)
+]
+
 { #category : #initialization }
 RBDeprecateClassRefactoring >> className: aName newName: aNewName [
 	className := aName asSymbol.
@@ -61,19 +71,21 @@ RBDeprecateClassRefactoring >> convertDeprecatedToSubclass [
 	deprecatedClass classSide selectors do: [ :symbol |
 		(deprecatedClass realClass classSide compiledMethodAt: symbol) isExtension
 			ifFalse: [ deprecatedClass classSide removeMethod: symbol ] ].
-	deprecatedClass classSide compile: 'isDeprecated
+	self addMethod: 'isDeprecated
 		" Uses ', newName, ' instead of ', className,'"
-		^ true' classified: {'testing'}
+		^ true'
+			to: deprecatedClass classSide
+			in: 'testing'
 ]
 
 { #category : #transforming }
 RBDeprecateClassRefactoring >> copyExtensionMethods [
 
 	(self instanceSideExtensionMethodsOf: deprecatedClass)
-		do: [ :each | self newClass instanceSide compile: each source classified: each protocols ].
+		do: [ :each | self addMethod: each source to: self newClass instanceSide in: each protocols ].
 
 	(self classSideExtensionMethodsOf: deprecatedClass)
-		do: [ :each | self newClass classSide compile: each source classified: each protocols ]
+		do: [ :each | self addMethod: each source to: self newClass classSide in: each protocols ]
 ]
 
 { #category : #accessing }

--- a/src/Refactoring-Core/RBDeprecateMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBDeprecateMethodRefactoring.class.st
@@ -181,5 +181,10 @@ RBDeprecateMethodRefactoring >> transform [
 	parseTree := method parseTree.
 	node := self parserClass parseExpression: self callDeprecationMethod.
 	parseTree body addNodeFirst: node.
-	class compile: parseTree newSource classified: method protocols
+
+	self generateCompositeChangesFor:
+		(RBAddMethodTransformRefactoring
+			 addMethod: parseTree newSource
+			 toClass: class
+			 inProtocols: method protocols)
 ]

--- a/src/Refactoring-Core/RBExtractMethodAndOccurrences.class.st
+++ b/src/Refactoring-Core/RBExtractMethodAndOccurrences.class.st
@@ -47,7 +47,7 @@ RBExtractMethodAndOccurrences >> extractMethod [
 		               extract: extractionInterval
 		               from: selector
 		               in: class.
-	self performCompositeRefactoring: refactoring.
+	self generateCompositeChangesFor: refactoring.
 	^ refactoring newExtractedSelector
 ]
 
@@ -84,7 +84,7 @@ RBExtractMethodAndOccurrences >> findOccurrencesOf: aSelector [
 				               find: aSelector
 				               of: class
 				               inWholeHierarchy: self shouldSearchInHierarchy.
-			self performCompositeRefactoring: refactoring ]
+			self generateCompositeChangesFor: refactoring ]
 		ifFalse: [
 			self refactoringError:
 				aSelector , ' is not a valid selector name.' ]

--- a/src/Refactoring-Core/RBExtractMethodToComponentRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodToComponentRefactoring.class.st
@@ -58,7 +58,7 @@ RBExtractMethodToComponentRefactoring >> extractMethod [
 			methodName
 				selector: extractedMethodSelector;
 				yourself].
-	self performCompositeRefactoring: refactoring
+	self generateCompositeChangesFor: refactoring
 ]
 
 { #category : #transforming }
@@ -69,7 +69,7 @@ RBExtractMethodToComponentRefactoring >> inlineForwarder [
 				sendersOf: extractedMethodSelector
 				in: class.
 	refactoring setOption: #inlineExpression toUse: [:ref :string | true].
-	self performCompositeRefactoring: refactoring
+	self generateCompositeChangesFor: refactoring
 ]
 
 { #category : #transforming }
@@ -84,7 +84,7 @@ RBExtractMethodToComponentRefactoring >> moveMethod [
 		selector: extractedMethodSelector
 		class: class
 		variable: variable.
-	self performCompositeRefactoring: refactoring
+	self generateCompositeChangesFor: refactoring
 ]
 
 { #category : #preconditions }

--- a/src/Refactoring-Core/RBExtractSetUpMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractSetUpMethodRefactoring.class.st
@@ -78,7 +78,7 @@ RBExtractSetUpMethodRefactoring >> checkSingleAssignment: varName [
 				[self
 					refactoringError: 'Cannot extract assignments to temporaries without all references'].
 	modifiedParseTree body removeTemporaryNamed: varName.
-	self performCompositeRefactoring: (RBTemporaryToInstanceVariableRefactoring
+	self generateCompositeChangesFor: (RBTemporaryToInstanceVariableRefactoring
 		model: self model
 		class: class
 		selector: selector

--- a/src/Refactoring-Core/RBExtractSetUpMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractSetUpMethodRefactoring.class.st
@@ -130,7 +130,11 @@ RBExtractSetUpMethodRefactoring >> transform [
 	existingSelector ifNil: [
 		self renameAllParameters.
 		extractedParseTree body addNodeFirst: (RBParser parseExpression: 'super setUp').
-		class compile: extractedParseTree newSource classified: #running ].
+		self generateCompositeChangesFor:
+			(RBAddMethodTransformRefactoring
+				addMethod: extractedParseTree newSource
+				toClass: class
+				inProtocols: #running)].
 	modifiedParseTree body removeNode: (modifiedParseTree body statements at: 1).
 	class compileTree: modifiedParseTree
 ]

--- a/src/Refactoring-Core/RBFindAndReplaceTransformation.class.st
+++ b/src/Refactoring-Core/RBFindAndReplaceTransformation.class.st
@@ -107,7 +107,7 @@ RBFindAndReplaceTransformation >> extract: occurrence of: rbMethod [
 	refactoring setOption: #existingSelector toUse:  [ :ref |
 			ref parameters: (self argumentsOf: occurrence value).
 			selector].
-	self performCompositeRefactoring: refactoring ] on: Exception do: [ :e | e ]
+	self generateCompositeChangesFor: refactoring ] on: Exception do: [ :e | e ]
 ]
 
 { #category : #accessing }

--- a/src/Refactoring-Core/RBGenerateEqualHashTransformation.class.st
+++ b/src/Refactoring-Core/RBGenerateEqualHashTransformation.class.st
@@ -118,7 +118,11 @@ RBGenerateEqualHashTransformation >> compileEqual [
 	method
 		addNode: statement;
 		addReturn.
-	self theClass compile: method formattedCode classified: #(comparing)
+	self generateCompositeChangesFor:
+		(RBAddMethodTransformRefactoring
+			addMethod: method formattedCode
+			toClass: self theClass
+			inProtocols: #comparing)
 ]
 
 { #category : #transforming }
@@ -143,7 +147,11 @@ RBGenerateEqualHashTransformation >> compileHash [
 	method
 		addNode: statement;
 		addReturn.
-	self theClass compile: method formattedCode classified: #(comparing)
+	self generateCompositeChangesFor:
+		(RBAddMethodTransformRefactoring
+			addMethod: method formattedCode
+			toClass: self theClass
+			inProtocols: #comparing)
 ]
 
 { #category : #preconditions }

--- a/src/Refactoring-Core/RBGeneratePrintOnTransformation.class.st
+++ b/src/Refactoring-Core/RBGeneratePrintOnTransformation.class.st
@@ -90,7 +90,11 @@ RBGeneratePrintOnTransformation >> transform [
 					(self parserClass
 						parseExpression:
 							('aStream nextPutAll: '' <1s>: ''; print: <1s>' expandMacrosWith: each)) ].
-	self theClass compile: method formattedCode classified: #(printing)
+	self generateCompositeChangesFor:
+		(RBAddMethodTransformRefactoring
+			addMethod: method formattedCode
+			toClass: self theClass
+			inProtocols: #printing)
 ]
 
 { #category : #accessing }

--- a/src/Refactoring-Core/RBInlineAllSendersRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineAllSendersRefactoring.class.st
@@ -85,7 +85,7 @@ RBInlineAllSendersRefactoring >> inlineMessagesInClass: aClass andSelector: aSel
 				previousCountOfMessages := messagesToInline.
 				node := self selfSendIn: (aClass parseTreeForSelector: aSelector).
 				self onError:
-						[self performCompositeRefactoring: ((RBInlineMethodRefactoring
+						[self generateCompositeChangesFor: ((RBInlineMethodRefactoring
 									model: self model
 									inline: node sourceInterval
 									inMethod: aSelector
@@ -130,7 +130,7 @@ RBInlineAllSendersRefactoring >> preconditions [
 { #category : #transforming }
 RBInlineAllSendersRefactoring >> removeMethod [
 	self onError:
-			[self performCompositeRefactoring: (RBRemoveMethodRefactoring
+			[self generateCompositeChangesFor: (RBRemoveMethodRefactoring
 						model: self model
 						removeMethods: (Array with: selector)
 						from: class)]

--- a/src/Refactoring-Core/RBInlineMethodFromComponentRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineMethodFromComponentRefactoring.class.st
@@ -19,7 +19,7 @@ RBInlineMethodFromComponentRefactoring >> abstractVariableReferences [
 				abstractVariablesIn: inlineParseTree
 				from: self classOfTheMethodToInline
 				toAll: (Array with: class).
-	self performCompositeRefactoring: refactoring.
+	self generateCompositeChangesFor: refactoring.
 	inlineParseTree := refactoring parseTree
 ]
 

--- a/src/Refactoring-Core/RBMoveMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBMoveMethodRefactoring.class.st
@@ -60,7 +60,7 @@ RBMoveMethodRefactoring class >> selector: aSymbol class: aClass variable: aVari
 
 { #category : #transforming }
 RBMoveMethodRefactoring >> abstractVariables [
-	self performCompositeRefactoring: self abstractVariablesRefactoring.
+	self generateCompositeChangesFor: self abstractVariablesRefactoring.
 	parseTree := self abstractVariablesRefactoring parseTree
 ]
 

--- a/src/Refactoring-Core/RBMoveMethodToClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBMoveMethodToClassRefactoring.class.st
@@ -78,5 +78,9 @@ RBMoveMethodToClassRefactoring >> transform [
 	originalProtocol := method protocolName.
 	oldClass removeMethod: method selector.
 	newClass addMethod: rbMethod.
-	newClass compile: rbMethod source classified: {originalProtocol}
+	self generateCompositeChangesFor:
+		(RBAddMethodTransformRefactoring
+			addMethod: rbMethod source
+			toClass: newClass
+			inProtocols: originalProtocol)
 ]

--- a/src/Refactoring-Core/RBMoveMethodToClassSideRefactoring.class.st
+++ b/src/Refactoring-Core/RBMoveMethodToClassSideRefactoring.class.st
@@ -54,7 +54,11 @@ RBMoveMethodToClassSideRefactoring >> accessorsFor: variableName [
 { #category : #transforming }
 RBMoveMethodToClassSideRefactoring >> addMethod: rbMethod to: aClass toProtocol: protocol [
 	aClass addMethod: rbMethod.
-	aClass compile: rbMethod source classified: {protocol}
+	self generateCompositeChangesFor:
+		(RBAddMethodTransformRefactoring
+			addMethod: rbMethod source
+			toClass: aClass
+			inProtocols: protocol)
 ]
 
 { #category : #preconditions }

--- a/src/Refactoring-Core/RBMoveMethodToClassSideRefactoring.class.st
+++ b/src/Refactoring-Core/RBMoveMethodToClassSideRefactoring.class.st
@@ -160,7 +160,7 @@ RBMoveMethodToClassSideRefactoring >> removeInstVariableReferences [
 	references do: [ :e |
 		| replacer accessorsRefactoring |
 		accessorsRefactoring := self accessorsFor: e.
-		self performCompositeRefactoring: accessorsRefactoring.
+		self generateCompositeChangesFor: accessorsRefactoring.
 		replacer := self parseTreeRewriterClass
 			            variable: e
 			            getter: accessorsRefactoring getterMethodName

--- a/src/Refactoring-Core/RBPrettyPrintCodeTransformation.class.st
+++ b/src/Refactoring-Core/RBPrettyPrintCodeTransformation.class.st
@@ -31,5 +31,9 @@ RBPrettyPrintCodeTransformation >> transform [
 											(source ~= formatted
 												and: [ (self parserClass parseMethod: formatted) = tree ])
 												ifTrue:
-													[ class compile: formatted classified: (class protocolsFor: selector) ] ] ] ] ] ]
+													[ 	self generateCompositeChangesFor:
+															(RBAddMethodTransformRefactoring
+																addMethod: formatted
+																toClass: class
+																inProtocols: (class protocolsFor: selector)) ] ] ] ] ] ]
 ]

--- a/src/Refactoring-Core/RBProtectInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBProtectInstanceVariableRefactoring.class.st
@@ -34,7 +34,7 @@ RBProtectInstanceVariableRefactoring >> getterSetterMethods [
 { #category : #transforming }
 RBProtectInstanceVariableRefactoring >> inline: aSelector [
 	self onError:
-			[self performCompositeRefactoring: (RBInlineAllSendersRefactoring
+			[self generateCompositeChangesFor: (RBInlineAllSendersRefactoring
 						model: self model
 						sendersOf: aSelector
 						in: class)]

--- a/src/Refactoring-Core/RBProtocolRegexTransformation.class.st
+++ b/src/Refactoring-Core/RBProtocolRegexTransformation.class.st
@@ -17,5 +17,9 @@ RBProtocolRegexTransformation >> transform [
 		class selectors do: [ :selector |
 			(class realClass protocolNameOfSelector: selector) asString ifNotNil: [ :original |
 				replacement := self execute: original.
-				replacement = original ifFalse: [ class compile: (class sourceCodeFor: selector) classified: replacement ] ] ] ]
+				replacement = original ifFalse: [ self generateCompositeChangesFor:
+																(RBAddMethodTransformRefactoring
+																	addMethod: (class sourceCodeFor: selector)
+																	toClass: class
+																	inProtocols: replacement)] ] ] ]
 ]

--- a/src/Refactoring-Core/RBPullUpMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBPullUpMethodRefactoring.class.st
@@ -234,7 +234,11 @@ RBPullUpMethodRefactoring >> copyDownMethod: aSelector [
 				fromClass: superclassDefiner
 				toClasses: subclasses.
 	self generateCompositeChangesFor: refactoring.
-	subclasses do: [:each | each compile: oldSource classified: oldProtocol]
+	subclasses do: [:each | 	self generateCompositeChangesFor:
+										(RBAddMethodTransformRefactoring
+											addMethod: oldSource
+											toClass: each
+											inProtocols: oldProtocol)]
 ]
 
 { #category : #transforming }
@@ -274,8 +278,11 @@ RBPullUpMethodRefactoring >> pullUp: aSelector [
 				fromClass: class
 				toClasses: (Array with: targetSuperclass).
 	self generateCompositeChangesFor: refactoring.
-	targetSuperclass compile: source
-		classified: (class protocolsFor: aSelector)
+	self generateCompositeChangesFor:
+		(RBAddMethodTransformRefactoring
+			addMethod: source
+			toClass: targetSuperclass 
+			inProtocols: (class protocolsFor: aSelector))
 ]
 
 { #category : #initialization }

--- a/src/Refactoring-Core/RBPullUpMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBPullUpMethodRefactoring.class.st
@@ -233,7 +233,7 @@ RBPullUpMethodRefactoring >> copyDownMethod: aSelector [
 				forMethod: (superclassDefiner parseTreeForSelector: aSelector)
 				fromClass: superclassDefiner
 				toClasses: subclasses.
-	self performCompositeRefactoring: refactoring.
+	self generateCompositeChangesFor: refactoring.
 	subclasses do: [:each | each compile: oldSource classified: oldProtocol]
 ]
 
@@ -273,7 +273,7 @@ RBPullUpMethodRefactoring >> pullUp: aSelector [
 				forMethod: (class parseTreeForSelector: aSelector)
 				fromClass: class
 				toClasses: (Array with: targetSuperclass).
-	self performCompositeRefactoring: refactoring.
+	self generateCompositeChangesFor: refactoring.
 	targetSuperclass compile: source
 		classified: (class protocolsFor: aSelector)
 ]
@@ -304,7 +304,7 @@ RBPullUpMethodRefactoring >> pushUpVariable: aVariable [
 			model: self model
 			variable: aVariable
 			class: targetSuperclass.
-	self performCompositeRefactoring: refactoring
+	self generateCompositeChangesFor: refactoring
 ]
 
 { #category : #transforming }

--- a/src/Refactoring-Core/RBPushDownMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBPushDownMethodRefactoring.class.st
@@ -95,7 +95,11 @@ RBPushDownMethodRefactoring >> pushDown: aSelector [
 	self generateCompositeChangesFor: refactoring.
 	self allClasses do: [ :each |
 		(each directlyDefinesMethod: aSelector) ifFalse: [
-			each compile: code classified: protocols ] ]
+			self generateCompositeChangesFor:
+				(RBAddMethodTransformRefactoring
+					addMethod: code
+					toClass: each
+					inProtocols: protocols) ] ]
 ]
 
 { #category : #initialization }

--- a/src/Refactoring-Core/RBPushDownMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBPushDownMethodRefactoring.class.st
@@ -92,7 +92,7 @@ RBPushDownMethodRefactoring >> pushDown: aSelector [
 		               forMethod: (class parseTreeForSelector: aSelector)
 		               fromClass: class
 		               toClasses: self allClasses.
-	self performCompositeRefactoring: refactoring.
+	self generateCompositeChangesFor: refactoring.
 	self allClasses do: [ :each |
 		(each directlyDefinesMethod: aSelector) ifFalse: [
 			each compile: code classified: protocols ] ]

--- a/src/Refactoring-Core/RBRefactoring.class.st
+++ b/src/Refactoring-Core/RBRefactoring.class.st
@@ -167,6 +167,9 @@ RBRefactoring >> performChanges [
 
 { #category : #transforming }
 RBRefactoring >> performCompositeRefactoring: aRefactoring [
+	"I will generate changes and save them in the model, BUT I will not apply them!
+	Use me when a refactorings is composed of multiple other refactorings"
+
 	"Execute the argument but passing the receiver options to that refactoring"
 	aRefactoring copyOptionsFrom: self options.
 	aRefactoring primitiveExecute

--- a/src/Refactoring-Core/RBRefactoring.class.st
+++ b/src/Refactoring-Core/RBRefactoring.class.st
@@ -138,6 +138,16 @@ RBRefactoring >> execute [
 ]
 
 { #category : #transforming }
+RBRefactoring >> generateCompositeChangesFor: aRefactoring [
+	"I will generate changes and save them in the model, BUT I will not apply them!
+	Use me when a refactorings is composed of multiple other refactorings"
+
+	"Execute the argument but passing the receiver options to that refactoring"
+	aRefactoring copyOptionsFrom: self options.
+	aRefactoring primitiveExecute
+]
+
+{ #category : #transforming }
 RBRefactoring >> model [
 
 	^ model
@@ -163,16 +173,6 @@ RBRefactoring >> performChanges [
 	RBRefactoryChangeManager instance
 		performChange: self changes;
 		addUndoPointer: RBRefactoryChangeManager nextCounter
-]
-
-{ #category : #transforming }
-RBRefactoring >> performCompositeRefactoring: aRefactoring [
-	"I will generate changes and save them in the model, BUT I will not apply them!
-	Use me when a refactorings is composed of multiple other refactorings"
-
-	"Execute the argument but passing the receiver options to that refactoring"
-	aRefactoring copyOptionsFrom: self options.
-	aRefactoring primitiveExecute
 ]
 
 { #category : #transforming }

--- a/src/Refactoring-Core/RBRefactoring.class.st
+++ b/src/Refactoring-Core/RBRefactoring.class.st
@@ -175,13 +175,6 @@ RBRefactoring >> performChanges [
 		addUndoPointer: RBRefactoryChangeManager nextCounter
 ]
 
-{ #category : #transforming }
-RBRefactoring >> performCompositeRefactoringThroughWarning: aRefactoring [
-	[ aRefactoring copyOptionsFrom: self options.
-	aRefactoring primitiveExecute ]
-	on: RBRefactoringWarning do: [ :ex | ex resume ]
-]
-
 { #category : #private }
 RBRefactoring >> primitiveExecute [
 	

--- a/src/Refactoring-Core/RBRemoveAllSendersRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveAllSendersRefactoring.class.st
@@ -70,7 +70,7 @@ RBRemoveAllSendersRefactoring >> preconditions [
 
 { #category : #removing }
 RBRemoveAllSendersRefactoring >> removeMethod: aMethod of: node [
-	self performCompositeRefactoring: (RBRemoveSenderRefactoring
+	self generateCompositeChangesFor: (RBRemoveSenderRefactoring
 		model: self model
 		remove: node sourceInterval
 		inMethod: aMethod selector

--- a/src/Refactoring-Core/RBRemoveHierarchyMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveHierarchyMethodRefactoring.class.st
@@ -29,7 +29,7 @@ RBRemoveHierarchyMethodRefactoring class >> removeMethods: selectorCollection fr
 { #category : #transforming }
 RBRemoveHierarchyMethodRefactoring >> delete: selector in: aClass [
 	 (aClass realClass includesSelector: selector) ifTrue: [
-		 [self performCompositeRefactoring: (RBRemoveMethodRefactoring
+		 [self generateCompositeChangesFor: (RBRemoveMethodRefactoring
 									model: self model
 									removeMethods: { selector }
 									from: aClass) ]

--- a/src/Refactoring-Core/RBRenameInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenameInstanceVariableRefactoring.class.st
@@ -140,7 +140,11 @@ RBRenameInstanceVariableRefactoring >> renameAccessorsReferences [
 	senders
 		do: [ :each |
 			(each selector = newName or: [ each selector asString = (newName asString , ':') ])
-				ifFalse: [ (model classNamed: class name) compile: each source classified: each protocols ] ]
+				ifFalse: [ self generateCompositeChangesFor:
+								(RBAddMethodTransformRefactoring
+									addMethod: each source
+									toClass: (model classNamed: class name)
+									inProtocols: each protocols) ] ]
 ]
 
 { #category : #transforming }

--- a/src/Refactoring-Core/RBRenamePackageRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenamePackageRefactoring.class.st
@@ -69,7 +69,7 @@ RBRenamePackageRefactoring >> renameManifestClass [
 		model: self model
 		rename: manifest name
 		to: (self manifestClassNameFor: newName).
-	self performCompositeRefactoring: refactoring]
+	self generateCompositeChangesFor: refactoring]
 ]
 
 { #category : #transforming }

--- a/src/Refactoring-Core/RBSourceRegexTransformation.class.st
+++ b/src/Refactoring-Core/RBSourceRegexTransformation.class.st
@@ -39,7 +39,11 @@ RBSourceRegexTransformation >> transform [
 								ifNotNil: [ protocols := class protocolsFor: selector.
 									( self parseSelector: replacement ) = selector
 										ifFalse: [ class removeMethod: selector ].
-									class compile: replacement classified: protocols
+										self generateCompositeChangesFor:
+											(RBAddMethodTransformRefactoring
+												addMethod: replacement
+												toClass: class
+												inProtocols: protocols)
 									]
 							]
 					]

--- a/src/Refactoring-Core/RBSplitClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBSplitClassRefactoring.class.st
@@ -71,7 +71,7 @@ RBSplitClassRefactoring >> abstractReferenceTo: each [
 		               variable: each
 		               class: newClass
 		               classVariable: false.
-	self performCompositeRefactoring: accessorRef.
+	self generateCompositeChangesFor: accessorRef.
 	getterMethod := accessorRef getterMethodName.
 	setterMethod := accessorRef setterMethodName.
 	replacer := self parseTreeRewriterClass
@@ -84,7 +84,7 @@ RBSplitClassRefactoring >> abstractReferenceTo: each [
 		select: [ :aClass |
 		aClass whichSelectorsReferToInstanceVariable: each ]
 		using: replacer.
-	self performCompositeRefactoring:
+	self generateCompositeChangesFor:
 		(RBRemoveInstanceVariableRefactoring2 remove: each from: class)
 ]
 
@@ -95,7 +95,7 @@ RBSplitClassRefactoring >> abstractVariableReferences [
 
 { #category : #'private - transforming' }
 RBSplitClassRefactoring >> addClass [
-	self performCompositeRefactoring: (RBInsertNewClassRefactoring
+	self generateCompositeChangesFor: (RBInsertNewClassRefactoring
 				model: self model
 				addClass: newClassName
 				superclass: Object
@@ -108,7 +108,7 @@ RBSplitClassRefactoring >> addClass [
 RBSplitClassRefactoring >> addInstanceVariables [
 	instanceVariables do:
 			[:each |
-			self performCompositeRefactoring: (RBAddInstanceVariableRefactoring
+			self generateCompositeChangesFor: (RBAddInstanceVariableRefactoring
 						model: self model
 						variable: each
 						class: newClass)]
@@ -131,7 +131,7 @@ RBSplitClassRefactoring >> createNewClass [
 
 { #category : #transforming }
 RBSplitClassRefactoring >> createReference [
-	self performCompositeRefactoring: (RBAddInstanceVariableRefactoring
+	self generateCompositeChangesFor: (RBAddInstanceVariableRefactoring
 				variable: referenceVariableName
 				class: class)
 ]

--- a/src/Refactoring-Core/RBSwapMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBSwapMethodRefactoring.class.st
@@ -54,6 +54,11 @@ RBSwapMethodRefactoring >> swapMethod: aSelector in: aClass [
 
 { #category : #transforming }
 RBSwapMethodRefactoring >> transform [
-	target compile: (class sourceCodeFor: selector) classified: (class protocolsFor: selector).
+
+	self generateCompositeChangesFor:
+		(RBAddMethodTransformRefactoring
+			addMethod: (class sourceCodeFor: selector)
+			toClass: target
+			inProtocols: (class protocolsFor: selector)).
 	class removeMethod: selector
 ]


### PR DESCRIPTION
Reused `RBAddMethodTransformRefactoring` where possible.
Renamed `performCompositeRefactoring:` to `generateCompositeChangesFor` to better reflect its behaviour.