### PR TITLE
Clean MCWorkingCopy

### DIFF
--- a/src/Manifest-Core/ClassDescription.extension.st
+++ b/src/Manifest-Core/ClassDescription.extension.st
@@ -27,5 +27,6 @@ ClassDescription >> manifestBuilderForRuleChecker: aRuleChecker [
 
 { #category : #'*Manifest-Core' }
 ClassDescription >> mcWorkingCopy [
-	MCWorkingCopy managersForClass:  self do: [: package | ^ package ]
+
+	MCWorkingCopy workingCopiesForClass: self do: [ :package | ^ package ]
 ]

--- a/src/Manifest-Core/CompiledMethod.extension.st
+++ b/src/Manifest-Core/CompiledMethod.extension.st
@@ -36,5 +36,6 @@ CompiledMethod >> manifestBuilderForRuleChecker: aRuleChecker [
 
 { #category : #'*Manifest-Core' }
 CompiledMethod >> mcWorkingCopy [
-	 MCWorkingCopy managersForClass: self methodClass selector: self selector do: [ :package | ^ package ]
+
+	MCWorkingCopy workingCopiesForClass: self methodClass protocol: self protocol do: [ :package | ^ package ]
 ]

--- a/src/Metacello-MC/MetacelloMCProject.class.st
+++ b/src/Metacello-MC/MetacelloMCProject.class.st
@@ -53,11 +53,11 @@ MetacelloMCProject >> fetchProject: aLoaderPolicy [
 	mcLoader loaderPolicy: aLoaderPolicy.
 	mcLoader doingLoads: [ 
 		MCWorkingCopy
-			managersForClass: self configuration class
-			do: [:mgr | | pkg |
+			workingCopiesForClass: self configuration class
+			do: [:workingCopy | | pkg |
 				pkg := self packageSpec.
-				mgr repositoryGroup repositories do: [:repo | pkg repositories repository: (repo asRepositorySpecFor: self) ].
-				pkg name: mgr packageName.
+				workingCopy repositoryGroup repositories do: [:repo | pkg repositories repository: (repo asRepositorySpecFor: self) ].
+				pkg name: workingCopy packageName.
 				pkg fetchUsing: mcLoader.
 				^true ]].
 	^true
@@ -118,15 +118,15 @@ MetacelloMCProject >> projectForScriptEngine: aMetacelloScriptEngine uncondition
 { #category : #'development support' }
 MetacelloMCProject >> projectPackage [
   MCWorkingCopy
-    managersForClass: self configuration class
-    do: [ :mgr | 
+    workingCopiesForClass: self configuration class
+    do: [ :workingCopy | 
       | pkgSpec repo |
       pkgSpec := self packageSpec
-        name: mgr packageName;
+        name: workingCopy packageName;
         yourself.
-      mgr ancestors notEmpty
-        ifTrue: [ pkgSpec file: mgr ancestors first name ].
-      repo := mgr repositoryGroup repositories
+      workingCopy ancestors notEmpty
+        ifTrue: [ pkgSpec file: workingCopy ancestors first name ].
+      repo := workingCopy repositoryGroup repositories
         detect: [ :each | each ~~ MetacelloPlatform current defaultPackageCache ]
         ifNone: [ 
           MetacelloNotification signal: ('Using cache repository for ' , self label , ' project package').
@@ -211,12 +211,12 @@ MetacelloMCProject >> updateProject: aLoaderPolicy [
 	mcLoader
 		doingLoads: [ 
 			MCWorkingCopy
-				managersForClass: self configuration class
-				do: [ :mgr | 
+				workingCopiesForClass: self configuration class
+				do: [ :workingCopy | 
 					| pkg ar |
 					pkg := self packageSpec.
-					mgr repositoryGroup repositories do: [ :repo | pkg repositories repository: (repo asRepositorySpecFor: self) ].
-					ar := mgr metacelloPackageNameWithBranch.
+					workingCopy repositoryGroup repositories do: [ :repo | pkg repositories repository: (repo asRepositorySpecFor: self) ].
+					ar := workingCopy metacelloPackageNameWithBranch.
 					pkg name: (ar at: 1).
 					(ar at: 2) notEmpty
 						ifTrue: [ pkg file: (ar at: 2) ].

--- a/src/Monticello-Tests/MCWorkingCopyManagementTest.class.st
+++ b/src/Monticello-Tests/MCWorkingCopyManagementTest.class.st
@@ -73,7 +73,7 @@ MCWorkingCopyManagementTest >> testClassRemoved [
 ]
 
 { #category : #tests }
-MCWorkingCopyManagementTest >> testManagersForCategoryDo [
+MCWorkingCopyManagementTest >> testWorkingCopiesForExtensionProtocolDo [
 	"Consider the following package structure:
 		Renraku
 		Renraku-Help
@@ -82,19 +82,19 @@ MCWorkingCopyManagementTest >> testManagersForCategoryDo [
 		MCWorkingCopy>>methodModified: should only mark 'Renraku' as modified,
 		not 'Renraku-Help'"
 
-	| managers |
+	| workingCopies |
 	self assert: (MCWorkingCopy registry includesKey: mcPackage1).
 	self assert: (MCWorkingCopy registry includesKey: mcPackage2).
 
-	managers := OrderedCollection new.
-	MCWorkingCopy managersForCategory: mcPackage1 name do: [ :manager | managers add: manager ].
+	workingCopies := OrderedCollection new.
+	MCWorkingCopy workingCopiesForExtensionProtocol: mcPackage1 name do: [ :workingCopy | workingCopies add: workingCopy ].
 
-	self assert: managers size equals: 1.
-	self assert: managers first package identicalTo: mcPackage1.
+	self assert: workingCopies size equals: 1.
+	self assert: workingCopies first package identicalTo: mcPackage1.
 
-	managers := OrderedCollection new.
-	MCWorkingCopy managersForCategory: mcPackage2 name do: [ :manager | managers add: manager ].
+	workingCopies := OrderedCollection new.
+	MCWorkingCopy workingCopiesForExtensionProtocol: mcPackage2 name do: [ :workingCopy | workingCopies add: workingCopy ].
 
-	self assert: managers size equals: 1.
-	self assert: managers first package identicalTo: mcPackage2
+	self assert: workingCopies size equals: 1.
+	self assert: workingCopies first package identicalTo: mcPackage2
 ]

--- a/src/Monticello/MCMethodDefinition.class.st
+++ b/src/Monticello/MCMethodDefinition.class.st
@@ -77,8 +77,8 @@ MCMethodDefinition class >> flushMethodCache [
 
 { #category : #'class initialization' }
 MCMethodDefinition class >> initialize [
-	SessionManager default
-		registerSystemClassNamed: self name
+
+	SessionManager default registerSystemClassNamed: self name
 ]
 
 { #category : #settings }

--- a/src/Monticello/MCWorkingCopy.class.st
+++ b/src/Monticello/MCWorkingCopy.class.st
@@ -312,7 +312,10 @@ MCWorkingCopy class >> workingCopiesForExtensionProtocol: extensionName do: aBlo
 MCWorkingCopy class >> workingCopiesForPackage: aPackage do: aBlock [
 
 	self registry
-		select: [ :workingCopy | workingCopy systemPackage includesSystemCategory: aPackage name ]
+		select: [ :workingCopy |
+			workingCopy systemPackage
+				ifNil: [ false ]
+				ifNotNil: [ :package | package includesSystemCategory: aPackage name ] ]
 		thenDo: aBlock
 ]
 

--- a/src/Monticello/MCWorkingCopy.class.st
+++ b/src/Monticello/MCWorkingCopy.class.st
@@ -79,15 +79,14 @@ MCWorkingCopy class >> announcer: anAnnouncer [
 
 { #category : #'system changes' }
 MCWorkingCopy class >> classModified: anEvent [
-	self 
-		managersForClass: anEvent classAffected 
-		do:[ :mgr | mgr modified: true ].
+
+	self workingCopiesForClass: anEvent classAffected do: [ :wc | wc modified: true ]
 ]
 
 { #category : #'system changes' }
 MCWorkingCopy class >> classMoved: anEvent [
-	self managersForPackage: anEvent oldPackage do: [ :mgr | mgr modified: true ].
-	self managersForPackage: anEvent newPackage do: [ :mgr | mgr modified: true ].
+	self workingCopiesForPackage: anEvent oldPackage do: [ :mgr | mgr modified: true ].
+	self workingCopiesForPackage: anEvent newPackage do: [ :mgr | mgr modified: true ].
 ]
 
 { #category : #'system changes' }
@@ -105,9 +104,9 @@ MCWorkingCopy class >> classRemoved: anEvent [
 
 { #category : #'system changes' }
 MCWorkingCopy class >> classRenamed: anEvent [
+
 	self classModified: anEvent.
-	anEvent classAffected extendingPackages
-		do: [ :pkg | self managersForPackage: pkg do: [ :mgr | mgr modified: true ] ]
+	anEvent classAffected extendingPackages do: [ :pkg | self workingCopiesForPackage: pkg do: [ :workingCopy | workingCopy modified: true ] ]
 ]
 
 { #category : #accessing }
@@ -174,97 +173,28 @@ MCWorkingCopy class >> initialize [
 ]
 
 { #category : #'system changes' }
-MCWorkingCopy class >> managersForCategory: aSystemCategory do: aBlock [
-	"Got to be careful here - we might get method categories where capitalization is problematic."
-
-	| cat foundOne index |
-	aSystemCategory ifNil: [ ^ nil ]. "yes this happens; for example when we remove a method and there is not protocol associated anymore."
-
-	"We first check if a working copy associated to a package in the system matches the name."
-	(self registry select: [ :workingCopy | workingCopy systemPackage isNotNil and: [ workingCopy packageName sameAs: aSystemCategory ] ]) ifNotEmpty: [
-		:matchingCopies | ^ aBlock value: (matchingCopies detectMin: [ :workingCopy | workingCopy packageName size ]) ].
-
-	foundOne := false.
-	cat := aSystemCategory.
-	[ "Loop over categories until we found a matching one"
-	self registry keys
-		detect: [ :aPackage | aPackage name sameAs: cat ]
-		ifFound: [ :aPackage |
-			| workingCopy |
-			workingCopy := self registry at: aPackage.
-			aBlock value: workingCopy.
-			foundOne := true.
-			false ]
-		ifNone: [
-			index := cat lastIndexOf: $-.
-			index > 0 ] ] whileTrue: [ "Step up to next level package" cat := cat copyFrom: 1 to: index - 1 ].
-
-	foundOne ifFalse: [ "Create a new (but only top-level)" aBlock value: (self ensureForPackageNamed: aSystemCategory capitalized) ]
-]
-
-{ #category : #'system changes' }
-MCWorkingCopy class >> managersForClass: aClass category: methodCategory do: aBlock [
-	(methodCategory isEmptyOrNil or:[methodCategory first ~= $*]) ifTrue:[
-		"Not an extension method"
-		^self managersForClass: aClass do: aBlock.
-	].
-	self managersForCategory: methodCategory allButFirst do: aBlock.
-]
-
-{ #category : #'system changes' }
-MCWorkingCopy class >> managersForClass: aClass do: aBlock [
-
-	| rPackage |
-	rPackage := aClass package.
-
-	self registry do: [:mgr |
-		(mgr packageSet packages includes: rPackage)
-			ifTrue: [aBlock value: mgr]]
-]
-
-{ #category : #'system changes' }
-MCWorkingCopy class >> managersForClass: aClass selector: aSelector do: aBlock [
-
-	^ self managersForClass: aClass category: (aClass protocolNameOfSelector: aSelector) do: aBlock
-]
-
-{ #category : #'system changes' }
-MCWorkingCopy class >> managersForPackage: aPackage do: aBlock [
-	self registry do: [:mgr | 
-		(mgr packageSet includesSystemCategory: aPackage name) ifTrue: [
-			aBlock value: mgr.
-		]
-	].
-]
-
-{ #category : #'system changes' }
 MCWorkingCopy class >> methodModified: anEvent [
 
 	"If the method has just been loaded by monticello itself, do not mark it as dirty"
-	anEvent propertyAt: #eventSource ifPresent: [ :source |
-		source == self class package name
-			ifTrue: [ ^ self ]].
+	anEvent propertyAt: #eventSource ifPresent: [ :source | source == self class package name ifTrue: [ ^ self ] ].
 
-   "trait methods aren't handled here"
-	anEvent isProvidedByATrait
-		ifTrue: [ ^ self ].
-		
-	^ self
-		managersForClass: anEvent methodClass
-		selector: anEvent selector
-		do: [ :mgr | mgr modified: true ]
+	"trait methods aren't handled here"
+	anEvent isProvidedByATrait ifTrue: [ ^ self ].
+
+	^ self workingCopiesForClass: anEvent methodClass protocol: anEvent protocol do: [ :wc | wc modified: true ]
 ]
 
 { #category : #'system changes' }
 MCWorkingCopy class >> methodMoved: anEvent [
-	self managersForPackage: anEvent oldPackage do: [ :mgr | mgr modified: true ].
-	self managersForPackage: anEvent newPackage do: [ :mgr | mgr modified: true ].
+
+	self workingCopiesForPackage: anEvent oldPackage do: [ :workingCopy | workingCopy modified: true ].
+	self workingCopiesForPackage: anEvent newPackage do: [ :workingCopy | workingCopy modified: true ]
 ]
 
 { #category : #'system changes' }
 MCWorkingCopy class >> methodRemoved: anEvent [
 
-	self managersForClass: anEvent methodClass category: anEvent protocol name do: [ :mgr | mgr modified: true ]
+	self workingCopiesForClass: anEvent methodClass protocol: anEvent protocol do: [ :wc | wc modified: true ]
 ]
 
 { #category : #'system changes' }
@@ -339,6 +269,51 @@ MCWorkingCopy class >> registry [
 { #category : #'event registration' }
 MCWorkingCopy class >> unregisterForNotifications [
 	SystemAnnouncer uniqueInstance unsubscribe: self
+]
+
+{ #category : #'system changes' }
+MCWorkingCopy class >> workingCopiesForClass: aClass do: aBlock [
+
+	| package |
+	package := aClass package.
+
+	self registry
+		select: [ :workingCopy | workingCopy systemPackage = package ]
+		thenDo: aBlock
+]
+
+{ #category : #'system changes' }
+MCWorkingCopy class >> workingCopiesForClass: aClass protocol: protocol do: aBlock [
+
+	protocol ifNil: [ ^ self ]. "This can happen, for example when a method recategorised is raised at a method removal."
+
+	protocol isExtensionProtocol ifFalse: [ ^ self workingCopiesForClass: aClass do: aBlock ].
+
+	self workingCopiesForExtensionProtocol: protocol name allButFirst do: aBlock
+]
+
+{ #category : #'system changes' }
+MCWorkingCopy class >> workingCopiesForExtensionProtocol: extensionName do: aBlock [
+
+	| packageName |
+	packageName := extensionName.
+	[ "Loop over package tags until we found a matching one"
+	self registry
+		detect: [ :workingCopy | "We might get a protocol name case insensitive." workingCopy packageName sameAs: packageName ]
+		ifFound: [ :workingCopy | ^ aBlock value: workingCopy ].
+
+	packageName includes: $- ] whileTrue: [ "Step up to next level package" packageName := packageName copyUpToLast: $- ].
+
+	"If no match was found, create a new (but only top-level)"
+	aBlock value: (self ensureForPackageNamed: extensionName capitalized)
+]
+
+{ #category : #'system changes' }
+MCWorkingCopy class >> workingCopiesForPackage: aPackage do: aBlock [
+
+	self registry
+		select: [ :workingCopy | workingCopy systemPackage includesSystemCategory: aPackage name ]
+		thenDo: aBlock
 ]
 
 { #category : #operations }

--- a/src/Monticello/RPackageOrganizer.extension.st
+++ b/src/Monticello/RPackageOrganizer.extension.st
@@ -4,5 +4,5 @@ Extension { #name : #RPackageOrganizer }
 RPackageOrganizer >> isDefinedAsPackageOrSubPackageInMC: aSymbol [
 	"a category has been added. "
 
-	^ MCWorkingCopy allWorkingCopies anySatisfy: [ :manager | manager packageName isCategoryOf: aSymbol ]
+	^ MCWorkingCopy allWorkingCopies anySatisfy: [ :workingCopy | workingCopy packageName isCategoryOf: aSymbol ]
 ]

--- a/src/Zinc-HTTP/ZnConstants.class.st
+++ b/src/Zinc-HTTP/ZnConstants.class.st
@@ -40,11 +40,6 @@ ZnConstants class >> frameworkLicense [
 ]
 
 { #category : #accessing }
-ZnConstants class >> frameworkMCVersion [
-	MCWorkingCopy workingCopiesForClass: self class do: [ :workingCopy | ^ workingCopy ancestors first name ]
-]
-
-{ #category : #accessing }
 ZnConstants class >> frameworkName [
 	^ 'Zinc HTTP Components'
 ]

--- a/src/Zinc-HTTP/ZnConstants.class.st
+++ b/src/Zinc-HTTP/ZnConstants.class.st
@@ -41,7 +41,7 @@ ZnConstants class >> frameworkLicense [
 
 { #category : #accessing }
 ZnConstants class >> frameworkMCVersion [
-	MCWorkingCopy managersForClass: self class do: [ :each | ^ each ancestors first name ]
+	MCWorkingCopy workingCopiesForClass: self class do: [ :workingCopy | ^ workingCopy ancestors first name ]
 ]
 
 { #category : #accessing }

--- a/src/Zinc-HTTP/ZnUtils.class.st
+++ b/src/Zinc-HTTP/ZnUtils.class.st
@@ -195,17 +195,10 @@ ZnUtils class >> readUpToEnd: inputStream limit: limit [
 
 { #category : #streaming }
 ZnUtils class >> signalProgress: amount total: total [
-	(ZnCurrentOptions at: #signalProgress)
-		ifTrue: [
-			total
-				ifNil: [
-					HTTPProgress new
-						signal: ('Transferred {1} bytes ...' format: { amount humanReadableSIByteSize }) ]
-				ifNotNil: [
-					HTTPProgress new
-						total: total;
-						amount: amount;
-						signal: 'Transferring...' ] ]
+  (ZnCurrentOptions at: #signalProgress) ifTrue: [ total ifNil: [ HTTPProgress new signal: ('Transferred {1} bytes ...' format: {amount humanReadableSISizeString}) ] ifNotNil: [ HTTPProgress new
+                 total: total;
+                 amount: amount;
+                 signal: 'Transferring...' ] ]
 ]
 
 { #category : #streaming }

--- a/src/Zinc-HTTP/ZnUtils.class.st
+++ b/src/Zinc-HTTP/ZnUtils.class.st
@@ -195,10 +195,17 @@ ZnUtils class >> readUpToEnd: inputStream limit: limit [
 
 { #category : #streaming }
 ZnUtils class >> signalProgress: amount total: total [
-  (ZnCurrentOptions at: #signalProgress) ifTrue: [ total ifNil: [ HTTPProgress new signal: ('Transferred {1} bytes ...' format: {amount humanReadableSISizeString}) ] ifNotNil: [ HTTPProgress new
-                 total: total;
-                 amount: amount;
-                 signal: 'Transferring...' ] ]
+	(ZnCurrentOptions at: #signalProgress)
+		ifTrue: [
+			total
+				ifNil: [
+					HTTPProgress new
+						signal: ('Transferred {1} bytes ...' format: { amount humanReadableSIByteSize }) ]
+				ifNotNil: [
+					HTTPProgress new
+						total: total;
+						amount: amount;
+						signal: 'Transferring...' ] ]
 ]
 
 { #category : #streaming }


### PR DESCRIPTION
This changes finish 3 work that were started on Monticello recently.

The first is to use protocols instead of protocol names were it could simplify the code.

The second was to rename "manager" into "workingCopy" in the code to unify things and make the code more understandable. 

The third was to reduce the "category" dependency of RPackage since we want to remove this in the future. 

The cherry on the cake is that I simplified a lot some parts of the impacted code. Especially #managersForCategory:do: (now called #workingCopiesForExtensionProtocol:do:). And this was already simplified in a recent PR! If you check the code in Pharo 11 and the code now, things are much simpler.