### PR TITLE
Introduce RPackageOrganizer>>ensurePackage:

### DIFF
--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -348,6 +348,16 @@ RPackageOrganizer >> ensureExistAndRegisterPackageNamed: aSymbol [
 ]
 
 { #category : #registration }
+RPackageOrganizer >> ensurePackage: aPackage [
+
+	^ aPackage isString
+		  ifTrue: [ self packageNamed: aPackage ifAbsent: [ self registerPackage: (RPackage named: aPackage organizer: self) ] ]
+		  ifFalse: [
+			  (self hasPackage: aPackage) ifFalse: [ self registerPackage: aPackage ].
+			  aPackage ]
+]
+
+{ #category : #registration }
 RPackageOrganizer >> ensureTagNamed: aTagName inPackageNamed: aPackageName [
 
 	^ (self registerPackageNamed: aPackageName) addClassTag: aTagName
@@ -402,9 +412,9 @@ RPackageOrganizer >> globalPackageOf: aClass [
 RPackageOrganizer >> hasPackage: aPackage [
 	"Takes a package or a package name as parameter and return true if I include this package."
 
-	^ packages includesKey: (aPackage isString
-			   ifTrue: [ aPackage ]
-			   ifFalse: [ aPackage name ]) asSymbol
+	^ aPackage isString
+		  ifTrue: [ packages includesKey: aPackage asSymbol ]
+		  ifFalse: [ self packages includes: aPackage ]
 ]
 
 { #category : #'system integration' }
@@ -646,10 +656,9 @@ RPackageOrganizer >> packageNamed: aSymbol [
 ]
 
 { #category : #accessing }
-RPackageOrganizer >> packageNamed: aSymbol  ifAbsent: errorBlock [
-	^ packages
-		at: aSymbol asSymbol
-		ifAbsent: errorBlock
+RPackageOrganizer >> packageNamed: aSymbol ifAbsent: errorBlock [
+
+	^ packages at: aSymbol asSymbol ifAbsent: errorBlock
 ]
 
 { #category : #private }

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -284,8 +284,6 @@ RPackageOrganizerTest >> testHasPackage [
 	self assert: (organizer hasPackage: name).
 	self assert: (organizer hasPackage: package).
 
-	self skip.
-	self flag: #package. "In the future this next assertion should probably work in order to be able to have multiple PackageOrganizer but for now it does not work."
 	self deny: (organizer hasPackage: packageFromOtherOrganizer)
 ]
 


### PR DESCRIPTION
We have a ton of ways to create packages in Pharo and each of them have problems (bad names, inconsistant behaviors, raising or not announcements, ...). I plan to clean that and as a first step I'm introducing a method that should be the main entry point for package creation in the future because I did not find anything in the current API that seems good.

Here is a list of problems:
- #createPackageNamed: it raises an error if the package already exist, but most of the time we just want to "ensure" it exists and we don't want an error if it does.
- #registerPackage: The name "register" is not coherant with the rest of the MM
- #registerPackageNamed: The name "register" is not coherant with the rest of the MM
- #basicRegisterPackage: does not announce anything
- #checkPackageExistsOrRegister: has the category black magic and a bad name 
- #ensureExistAndRegisterPackageNamed: has a bad name and is not coherant with the clean way to register a package 

And some other ways are just dealing with the category black magic.

Once this method is integrated I'll try to deprecate most of the other methods to make this the main entry point for package creation.

For the tests, I'll adapt the tests of the other methods to test this one while I'll deprecate them (because yes, I did not add tests yet but it will come!)