### PR TITLE
Fix bug in tag creation while creating a category

### DIFF
--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -942,7 +942,7 @@ RPackageOrganizer >> systemCategoryAddedActionFrom: ann [
 	| package |
 	package := (self packageMatchingExtensionName: ann categoryName asString) ifNil: [
 		           self registerPackage: (RPackage named: ann categoryName asSymbol organizer: self) ].
-	package addClassTag: ann categoryName asSymbol
+	package name = ann categoryName ifFalse: [ package addClassTag: ann categoryName asSymbol ]
 ]
 
 { #category : #'system integration' }

--- a/src/RPackage-Tests/RPackageOrganizerAndSystemOrganizeSynchTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerAndSystemOrganizeSynchTest.class.st
@@ -28,12 +28,23 @@ RPackageOrganizerAndSystemOrganizeSynchTest >> tearDown [
 ]
 
 { #category : #tests }
-RPackageOrganizerAndSystemOrganizeSynchTest >> testAddingPackage [
+RPackageOrganizerAndSystemOrganizeSynchTest >> testAddingCategory [
 
 	self packageOrganizer addCategory: self packageName.
 
 	self assert: (self packageOrganizer packageNames includes: self packageName).
 	self assert: (self packageOrganizer includesCategory: self packageName)
+]
+
+{ #category : #tests }
+RPackageOrganizerAndSystemOrganizeSynchTest >> testAddingCategoryWithoutDashDoesNotCreateTag [
+	"Regression test because creating a category without dash was creating a tag of the same name which is wrong."
+
+	self packageOrganizer addCategory: self packageName.
+
+	self assert: (self packageOrganizer packageNames includes: self packageName).
+	self assert: (self packageOrganizer includesCategory: self packageName).
+	self assertEmpty: (self packageOrganizer packageNamed: self packageName) classTags
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Still in my effort to kill the categories, I'm doing this PR.

There is an inconsistancy while creating a category and this cause problems in the package model. Before killing the categories, it would be nice that the system behave in the correct way. 

Here is the bug: If we create a category that has no dash in the name, then a package of the same name is created BUT a tag of the same name is also created in the package which is wrong.

I updated the mecanism to not create the tag and added a test about that. All RPackage tests are green but I expect failures in other part of the system. Let's see