### PR TITLE
Treat Integers and Fractions as having scale 0 in ScaledDecimal arithmetic (fixes #14238)

### DIFF
--- a/src/Kernel-Tests/ScaledDecimalTest.class.st
+++ b/src/Kernel-Tests/ScaledDecimalTest.class.st
@@ -232,7 +232,22 @@ ScaledDecimalTest >> testLiteral [
 ScaledDecimalTest >> testMultiplicationDoesNotLoosePrecision [
 	"Check that not only the largest scale is considered but the sum of the two scales. See issue #8668"
 
-	self assert: 1.003s3 * 1.006s4 equals: 1.0090180s7
+	self assert: 1.003s3 * 1.006s4 equals: 1.0090180s7.
+	self assert: (1.003s3 * 1.006s4) scale equals: 7.
+]
+
+{ #category : #tests }
+ScaledDecimalTest >> testMultiplicationWithNonScaledDecimalDoesNotGainPrecision [
+	"Check that integer/fraction does not contribute to the resulting scale, regardless of argument order.
+	The behavior previously differed depending on argument ordering. See issue #14238"
+
+	self assert: (1.003s3 * 2) scale equals: 3.
+	self assert: (2 * 1.003s3) scale equals: 3.
+	self assert: (2.05s * (1 / 2)) scale equals: 2.
+	self assert: (1 / 2 * 2.05s) scale equals: 2.
+	"We don't try to compute the needed precision for the fraction, just use that from the ScaledDecimal"
+	self assert: (2.05s * (1 / 8)) scale equals: 2.
+	self assert: (1 / 8 * 2.05s) scale equals: 2
 ]
 
 { #category : #tests }

--- a/src/Kernel/ScaledDecimal.class.st
+++ b/src/Kernel/ScaledDecimal.class.st
@@ -84,14 +84,14 @@ ScaledDecimal >> >= aNumber [
 ScaledDecimal >> adaptToFraction: rcvr andSend: selector [
 	"If I am involved in arithmetic with a Fraction, convert it to a ScaledDecimal."
 
-	^(rcvr asScaledDecimal: scale) perform: selector with: self
+	^(rcvr asScaledDecimal: 0) perform: selector with: self
 ]
 
 { #category : #converting }
 ScaledDecimal >> adaptToInteger: rcvr andSend: selector [
 	"If I am involved in arithmetic with an Integer, convert it to a ScaledDecimal."
 
-	^(rcvr asScaledDecimal: scale) perform: selector with: self
+	^(rcvr asScaledDecimal: 0) perform: selector with: self
 ]
 
 { #category : #converting }


### PR DESCRIPTION
This takes the approach of treating all non-ScaledDecimals as having an effective scale of 0 when participating in arithmetic with a ScaledDecimal. The underlying precision of the result is always retained in full, but the declared scale will come only from the ScaledDecimal operand. This is already the case when the ScaledDecimal itself is the receiver/left operand, so any other approach would require considerably more thought and broader changes.