### PR TITLE
Deprecate RPackageOrganizer>>#registerPackageNamed:

### DIFF
--- a/src/Deprecated12/RPackageOrganizer.extension.st
+++ b/src/Deprecated12/RPackageOrganizer.extension.st
@@ -9,3 +9,10 @@ RPackageOrganizer >> packageExactlyMatchingExtensionName: anExtensionName [
 		transformWith: '`@rcv packageExactlyMatchingExtensionName: `@arg' -> '`@rcv packageNamedIgnoreCase: `@arg ifAbsent: [ nil ]'.
 	^ self packageNamedIgnoreCase: anExtensionName ifAbsent: [ nil ]
 ]
+
+{ #category : #'*Deprecated12' }
+RPackageOrganizer >> registerPackageNamed: aString [
+
+	self deprecated: 'Use #ensurePackage: instead.' transformWith: '`@rcv registerPackageNamed: `@arg' -> '`@rcv ensurePackage: `@arg'.
+	^ self ensurePackage: aString
+]

--- a/src/FluidClassBuilder-Tests/FluidClassBuilderAbstractTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidClassBuilderAbstractTest.class.st
@@ -19,7 +19,7 @@ FluidClassBuilderAbstractTest >> categoryHack [
 	This is due to the category mess in RPackage and it will not be fixed until the category mess is cleaned. Until then, to make sure the tests are in a right state, we register the package without the tag before creating the class to ensure the tag is not added as part of the package name.
 	This is ugly but it is currently hard to do better."
 
-	self packageOrganizer registerPackageNamed: self packageNameForTest
+	self packageOrganizer ensurePackage: self packageNameForTest
 ]
 
 { #category : #accessing }

--- a/src/Hermes/HEInstaller.class.st
+++ b/src/Hermes/HEInstaller.class.st
@@ -93,7 +93,7 @@ HEInstaller >> doInstallPackage: aHEPackage [
 	| newTraits newClasses |
 	"Creating the package. It requires a number of steps.
 	1. Register the package in the organizer."
-	RPackageOrganizer default registerPackageNamed: aHEPackage packageName.
+	self packageOrganizer ensurePackage: aHEPackage packageName.
 
 	"2. Install the traits"
 	newTraits := aHEPackage traits collect: [ :exportedTrait | self buildTrait: exportedTrait ].

--- a/src/Monticello-Tests/MCSnapshotTest.class.st
+++ b/src/Monticello-Tests/MCSnapshotTest.class.st
@@ -11,7 +11,7 @@ Class {
 MCSnapshotTest >> createSnapshotWithClassWithClassSideTraits [
 
 	| t1 t2 |
-	RPackageOrganizer default registerPackageNamed: 'Monticello-Snapshot-Mock'.
+	self packageOrganizer ensurePackage: 'Monticello-Snapshot-Mock'.
 
 	t1 := self class classInstaller make: [ :aBuilder |
 		      aBuilder
@@ -39,7 +39,7 @@ MCSnapshotTest >> createSnapshotWithClassWithClassSideTraits [
 MCSnapshotTest >> createSnapshotWithTraitWithClassSideTraits [
 
 	| t1 t2 t3 |
-	RPackageOrganizer default registerPackageNamed: 'Monticello-Snapshot-Mock'.
+	self packageOrganizer ensurePackage: 'Monticello-Snapshot-Mock'.
 
 	t1 := self class classInstaller make: [ :aBuilder |
 		      aBuilder

--- a/src/Monticello-Tests/MCWorkingCopyForExtensionsTest.class.st
+++ b/src/Monticello-Tests/MCWorkingCopyForExtensionsTest.class.st
@@ -23,8 +23,8 @@ MCWorkingCopyForExtensionsTest >> tearDown [
 MCWorkingCopyForExtensionsTest >> testAddingExtensionMethodNotMatchingPackage [
 
 	| aClass |
-	self packageOrganizer createPackageNamed: 'ATestPackage'.
-	self packageOrganizer createPackageNamed: 'AnotherTestPackage'.
+	self packageOrganizer ensurePackage: 'ATestPackage'.
+	self packageOrganizer ensurePackage: 'AnotherTestPackage'.
 
 	aClass := self class classInstaller make: [ :aBuilder |
 		          aBuilder

--- a/src/Monticello/MCVersionLoader.class.st
+++ b/src/Monticello/MCVersionLoader.class.st
@@ -114,7 +114,7 @@ MCVersionLoader >> depAgeIsOk: aDependency [
 
 { #category : #private }
 MCVersionLoader >> ensurePackage: mcPackage [ 
-	RPackageOrganizer default registerPackageNamed: mcPackage name 
+	self packageOrganizer ensurePackage: mcPackage name 
 		
 ]
 

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -304,12 +304,9 @@ RPackageOrganizer >> classifyAll: aCollection under: categoryName [
 { #category : #registration }
 RPackageOrganizer >> createPackageNamed: aString [
 
-	| instance |
 	self validatePackageDoesNotExist: aString.
 
-	instance := RPackage named: aString organizer: self.
-	self registerPackage: instance.
-	^ instance
+	^ self ensurePackage: aString
 ]
 
 { #category : #'private - testing' }
@@ -360,7 +357,7 @@ RPackageOrganizer >> ensurePackage: aPackage [
 { #category : #registration }
 RPackageOrganizer >> ensureTagNamed: aTagName inPackageNamed: aPackageName [
 
-	^ (self registerPackageNamed: aPackageName) addClassTag: aTagName
+	^ (self ensurePackage: aPackageName) addClassTag: aTagName
 ]
 
 { #category : #'deprecated - SystemOrganizer leftovers' }
@@ -809,12 +806,6 @@ RPackageOrganizer >> registerPackage: aPackage forClassName: aClassNameSymbol [
 	^classPackageMapping at: aClassNameSymbol put: aPackage
 ]
 
-{ #category : #registration }
-RPackageOrganizer >> registerPackageNamed: aString [
-
-	^ self packageNamed: aString asSymbol ifAbsent: [ self registerPackage: (RPackage named: aString organizer: self) ]
-]
-
 { #category : #'deprecated - SystemOrganizer leftovers' }
 RPackageOrganizer >> removeBehavior: behavior [
 	"Remove the behavior from all categories. I can take a Behavior or a Behavior name as argument."
@@ -880,14 +871,11 @@ RPackageOrganizer >> renameCategory: oldCatString toBe: newCatString [
 
 	categoryMap at: newCatString ifPresent: [ "new name exists, so no action" ^ self ].
 
-	categoryMap
-		at: oldCatString
-		ifPresent: [ :classes |
-			categoryMap at: newCatString put: classes.
-			categoryMap removeKey: oldCatString ]
-		ifAbsent: [ "old name not found, so no action" ^ self ].
-
-	SystemAnnouncer uniqueInstance classCategoryRenamedFrom: oldCatString to: newCatString
+	categoryMap at: oldCatString ifPresent: [ :classes |
+		categoryMap
+			at: newCatString put: classes;
+			removeKey: oldCatString.
+		SystemAnnouncer uniqueInstance classCategoryRenamedFrom: oldCatString to: newCatString ]
 ]
 
 { #category : #'system integration' }

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -275,11 +275,11 @@ RPackageOrganizerTest >> testHasPackage [
 	| organizer packageFromOtherOrganizer name package |
 	name := 'TestPackageNameForPackageOrganizer'.
 	organizer := RPackageOrganizer new.
-	packageFromOtherOrganizer := RPackageOrganizer new createPackageNamed: name.
+	packageFromOtherOrganizer := RPackageOrganizer new ensurePackage: name.
 	self deny: (organizer hasPackage: name).
 	self deny: (organizer hasPackage: packageFromOtherOrganizer).
 
-	package := organizer createPackageNamed: name.
+	package := organizer ensurePackage: name.
 
 	self assert: (organizer hasPackage: name).
 	self assert: (organizer hasPackage: package).

--- a/src/RPackage-Tests/RPackageRenameTest.class.st
+++ b/src/RPackage-Tests/RPackageRenameTest.class.st
@@ -48,7 +48,7 @@ RPackageRenameTest >> testRenamePackage [
 	| package workingCopy class |
 	self cleanWorkingCopiesInTearDown: #( 'TestRename' ).
 
-	package := self packageOrganizer registerPackageNamed: 'Test1'.
+	package := self packageOrganizer ensurePackage: 'Test1'.
 	workingCopy := MCWorkingCopy forPackageNamed: 'Test1'.
 	class := (Object << #TestClass package: 'Test1-TAG') install.
 
@@ -77,7 +77,7 @@ RPackageRenameTest >> testRenamePackageToOwnTagName [
 	| package workingCopy class1 class2 |
 	self cleanWorkingCopiesInTearDown: #( 'Test1-Core' ).
 
-	package := self packageOrganizer registerPackageNamed: 'Test1'.
+	package := self packageOrganizer ensurePackage: 'Test1'.
 	workingCopy := MCWorkingCopy forPackageNamed: 'Test1'.
 	class1 := (Object << #TestClass1 package: 'Test1-Core') install.
 	class2 := (Object << #TestClass2 package: 'Test1-Util') install.
@@ -103,7 +103,7 @@ RPackageRenameTest >> testRenamePackageToOwnTagNameWithClassesInRoot [
 	| package workingCopy class1 class2 class3 |
 	self cleanWorkingCopiesInTearDown: #( 'Test1-Core' ).
 
-	package := self packageOrganizer registerPackageNamed: 'Test1'.
+	package := self packageOrganizer ensurePackage: 'Test1'.
 	workingCopy := MCWorkingCopy forPackageNamed: 'Test1'.
 	class1 := (Object << #TestClass1 package: 'Test1-Core') install.
 	class2 := (Object << #TestClass2 package: 'Test1-Util') install.
@@ -130,7 +130,7 @@ RPackageRenameTest >> testRenamePackageUppercase [
 	| package pkg oldWorkingCopy |
 	"preparation: creation of a pkg and its associated mcworkingcopy"
 	[
-	package := self packageOrganizer registerPackageNamed: 'Test1'.
+	package := self packageOrganizer ensurePackage: 'Test1'.
 	oldWorkingCopy := MCWorkingCopy forPackageNamed: 'Test1'.
 	self assert: (self packageOrganizer hasPackage: #Test1).
 	self assert: (MCWorkingCopy hasPackageNamed: #Test1) isNotNil.
@@ -155,14 +155,12 @@ RPackageRenameTest >> testRenamePackageUppercase [
 { #category : #tests }
 RPackageRenameTest >> testRenamePackageWithExtensions [
 
-	| package workingCopy class extendedPackage extendedPackageWorkingCopy extension |
-	package := self packageOrganizer registerPackageNamed: 'OriginalPackage'.
-	workingCopy := MCWorkingCopy forPackageNamed: 'OriginalPackage'.
+	| package class extendedPackage extension |
+	package := self packageOrganizer ensurePackage: 'OriginalPackage'.
 
 	class := (Object << #TestClass package: 'OriginalPackage-TAG') install.
 
-	extendedPackage := self packageOrganizer registerPackageNamed: 'ExtendedPackage'.
-	extendedPackageWorkingCopy := MCWorkingCopy forPackageNamed: 'ExtendedPackage'.
+	extendedPackage := self packageOrganizer ensurePackage: 'ExtendedPackage'.
 
 	self cleanWorkingCopiesInTearDown: #( ExtendedPackage RenamedPackage OriginalPackage ).
 
@@ -189,14 +187,12 @@ RPackageRenameTest >> testRenamePackageWithExtensions [
 { #category : #tests }
 RPackageRenameTest >> testRenamePackageWithExtensionsInClassSide [
 
-	| package workingCopy class extendedPackage extendedPackageWorkingCopy extension |
-	package := self packageOrganizer registerPackageNamed: 'OriginalPackage'.
-	workingCopy := MCWorkingCopy forPackageNamed: 'OriginalPackage'.
+	| package class extendedPackage extension |
+	package := self packageOrganizer ensurePackage: 'OriginalPackage'.
 
 	class := (Object << #TestClass package: 'OriginalPackage-TAG') install.
 
-	extendedPackage := self packageOrganizer registerPackageNamed: 'ExtendedPackage'.
-	extendedPackageWorkingCopy := MCWorkingCopy forPackageNamed: 'ExtendedPackage'.
+	extendedPackage := self packageOrganizer ensurePackage: 'ExtendedPackage'.
 
 	self cleanWorkingCopiesInTearDown: #( ExtendedPackage RenamedPackage OriginalPackage ).
 
@@ -227,7 +223,7 @@ RPackageRenameTest >> testUnregisterPackage [
 	"Test that we do unregister the package as expected."
 
 	| package workingCopy class |
-	package := self packageOrganizer registerPackageNamed: 'Test1'.
+	package := self packageOrganizer ensurePackage: 'Test1'.
 	workingCopy := MCWorkingCopy forPackageNamed: 'Test1'.
 	class := (Object << #TestClass package: 'Test1-TAG') install.
 	self assert: (package includesClass: class).

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -263,7 +263,7 @@ RPackageTest >> testIsTestPackage [
 RPackageTest >> testMcPackage [
 
 	| rPackage |
-	rPackage := self organizer registerPackageNamed: #Test1.
+	rPackage := self organizer ensurePackage: #Test1.
 	self assert: rPackage mcPackage equals: (MCPackage new name: #Test1)
 ]
 
@@ -271,7 +271,7 @@ RPackageTest >> testMcPackage [
 RPackageTest >> testMcWorkingCopy [
 
 	| rPackage |
-	rPackage := self organizer registerPackageNamed: #Test1.
+	rPackage := self organizer ensurePackage: #Test1.
 	self assert: rPackage mcWorkingCopy identicalTo: (MCWorkingCopy forPackageNamed: #Test1)
 ]
 

--- a/src/Refactoring-Changes/RBAddPackageChange.class.st
+++ b/src/Refactoring-Changes/RBAddPackageChange.class.st
@@ -34,7 +34,7 @@ RBAddPackageChange >> primitiveExecute [
 { #category : #printing }
 RBAddPackageChange >> printOn: aStream [
 	aStream
-		nextPutAll: 'RPackageOrganizer default ';
+		nextPutAll: 'self packageOrganizer ';
 		nextPutAll: #createPackageNamed:;
 		nextPutAll: packageName;
 		nextPut: $!


### PR DESCRIPTION
Use #ensurePackage: instead because the previous name was using "register" vocabulary that is not consistant with the other parts of the MM and also it was not revealing the fact that it would return an existing package if there was one.

I also removed some unused statements in some tests and I replaced some users of #createPackageNamed: to use #ensurePackage: in places where we do not care if the package already exists.