### PR TITLE
Improve deprecated slot

### DIFF
--- a/src/VariablesLibrary/DeprecatedSlot.class.st
+++ b/src/VariablesLibrary/DeprecatedSlot.class.st
@@ -59,18 +59,25 @@ DeprecatedSlot >> printOn: aStream [
 
 { #category : #'meta-object-protocol' }
 DeprecatedSlot >> read: anObject [
-	SlotDeprecation new
-		context: thisContext;
-		explanation: self message;
-		signal.
+
+	"In case this is ShiftClassInstaller then we are migrating the instances and we should not raise a deprecation"
+	thisContext sender class = ShiftClassInstaller ifFalse: [
+		SlotDeprecation new
+			context: thisContext;
+			explanation: self message;
+			signal ].
 	super read: anObject
 ]
 
 { #category : #'meta-object-protocol' }
 DeprecatedSlot >> write: aValue to: anObject [
-	SlotDeprecation new
-		context: thisContext;
-		explanation: self message;
-		signal.
+
+	"In case this is ShiftClassInstaller then we are migrating the instances and we should not raise a deprecation"
+	thisContext sender class = ShiftClassInstaller ifFalse: [
+		SlotDeprecation new
+			context: thisContext;
+			explanation: self message;
+			signal ].
+
 	super write: aValue to: anObject
 ]

--- a/src/VariablesLibrary/SlotDeprecation.class.st
+++ b/src/VariablesLibrary/SlotDeprecation.class.st
@@ -20,7 +20,7 @@ SlotDeprecation >> messageText [
 				nextPutAll: 'The instance variable ';
 				nextPutAll: context receiver name;
 				nextPutAll: ' accessed in ';
-				nextPutAll: context sender method name;
+				nextPutAll: context sender homeMethod name;
 				nextPutAll: ' has been deprecated. ';
 				nextPutAll: self explanationString ]
 ]


### PR DESCRIPTION
This change improves the DeprecatedSlot in two ways:
- The code was raising an error when the read or write of the slot was happening in a bloc (to have Context>>#method return a bloc is a low blow :'( )
- The deprecation is not triggered by the class builder migration of slots anymore