### PR TITLE
Fix: update changes preview table when changing active scope

### DIFF
--- a/src/Refactoring-UI/StRefactoringPreviewPresenter.class.st
+++ b/src/Refactoring-UI/StRefactoringPreviewPresenter.class.st
@@ -102,7 +102,7 @@ StRefactoringPreviewPresenter >> connectPresenters [
 		selection selectedItem ifNotNil: [
 			self buildDiffFor: selection selectedItem ] ].
 
-	scopeDropList whenSelectedItemChangedDo: [ :scope | self updateActiveScope; updateChanges ].
+	scopeDropList whenSelectedItemChangedDo: [ :scope | self updateActiveScope; updateChanges; updateTablePresenter ].
 
 	buttonCancel action: [ self closeWindow ].
 	buttonOk action: [ self accept ]


### PR DESCRIPTION
When changing active scope refactoring preview presenter didn't update preview for changes that are going to be applied so it always displayed changes for the whole image. Note that it worked okay just the UI was wrong.