### PR TITLE
Bugfix: Fix double protocol request in Calypso

### DIFF
--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -437,6 +437,12 @@ CompiledMethod >> isExplicitlyRequired: marker [
 ]
 
 { #category : #testing }
+CompiledMethod >> isExtensionMethod [
+
+	^ self protocol isExtensionProtocol
+]
+
+{ #category : #testing }
 CompiledMethod >> isFaulty [
  	"check if this method was compiled from syntactically wrong code"
 	| ast |

--- a/src/ReleaseTests/ProperPackagesTest.class.st
+++ b/src/ReleaseTests/ProperPackagesTest.class.st
@@ -18,7 +18,7 @@ ProperPackagesTest >> testPackageExtensionsStartsWithProperPackageName [
 	"Method categories that represent extensions should start with a * followed by a package name that starts with an uppercase letter - ensure that"
 
 	self assertEmpty:
-		(SystemNavigation default allMethods select: [ :method | method protocol isExtensionProtocol and: [ method protocolName second isLowercase ] ])
+		(SystemNavigation default allMethods select: [ :method | method isExtensionMethod and: [ method protocolName second isLowercase ] ])
 ]
 
 { #category : #tests }

--- a/src/SystemCommands-MethodCommands/SycMoveMethodsToPackageDefiningClassCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMoveMethodsToPackageDefiningClassCommand.class.st
@@ -6,9 +6,6 @@ I am used to convert extension method to normal one
 Class {
 	#name : #SycMoveMethodsToPackageDefiningClassCommand,
 	#superclass : #SycMethodRepackagingCommand,
-	#instVars : [
-		'targetTagName'
-	],
 	#category : #'SystemCommands-MethodCommands'
 }
 
@@ -30,26 +27,7 @@ SycMoveMethodsToPackageDefiningClassCommand >> defaultMenuItemName [
 { #category : #execution }
 SycMoveMethodsToPackageDefiningClassCommand >> execute [
 
-	| classPackage |
-	methods do: [ :method |
-		classPackage := method origin package.
-		self moveMethod: method toPackage: classPackage.
-		method protocol: targetTagName ]
-]
-
-{ #category : #execution }
-SycMoveMethodsToPackageDefiningClassCommand >> prepareFullExecutionInContext: aToolContext [
-	super prepareFullExecutionInContext: aToolContext.
-
-	targetTagName := aToolContext requestSingleMethodTag: 'Choose protocol for methods'
-]
-
-{ #category : #accessing }
-SycMoveMethodsToPackageDefiningClassCommand >> targetTagName [
-	^ targetTagName
-]
-
-{ #category : #accessing }
-SycMoveMethodsToPackageDefiningClassCommand >> targetTagName: anObject [
-	targetTagName := anObject
+	methods
+		select: [ :method | method isExtensionMethod ]
+		thenDo: [ :method | self tagMethod: method ]
 ]

--- a/src/Tool-Base/MethodClassifier.class.st
+++ b/src/Tool-Base/MethodClassifier.class.st
@@ -291,7 +291,7 @@ MethodClassifier >> protocolByOtherImplementors: aMethod [
 
 	aMethod implementors ifEmpty: [ ^ self ] ifNotEmpty: [ :implementor |
 		implementor
-			do: [ :method | (method protocol isExtensionProtocol or: [ method isClassified not ]) ifFalse: [ protocolBag add: method protocolName ] ]
+			do: [ :method | (method isExtensionMethod or: [ method isClassified not ]) ifFalse: [ protocolBag add: method protocolName ] ]
 			without: aMethod ].
 
 	protocolBag ifEmpty: [ ^ self ].


### PR DESCRIPTION
When we select methods in Calypso, including extension methods, we can apply the "Move to class defining method" refactoring. In that case, we get asked two times the protocol of the methods to update.

This change fixes this by asking only once by method and ignoring methods that are already defined in their class. I also introduced CompiledMethod>>#isExtensionMethod