### PR TITLE
ClassParser: parse non-fluid defintion of CompiledBlock

### DIFF
--- a/src/ClassParser-Tests/CDCompiledBlockClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDCompiledBlockClassParserTest.class.st
@@ -1,0 +1,66 @@
+Class {
+	#name : #CDCompiledBlockClassParserTest,
+	#superclass : #CDClassDefinitionParserTest,
+	#category : #'ClassParser-Tests'
+}
+
+{ #category : #helpers }
+CDCompiledBlockClassParserTest >> classDefinitionString [
+	"we just test the definition as it appears in the image"
+	^ 'CompiledCode variableByteSubclass: #CompiledBlock
+	instanceVariableNames: ''''
+	classVariableNames: ''''
+	package: #MyPackage'
+]
+
+{ #category : #accessing }
+CDCompiledBlockClassParserTest >> className [
+	^#CompiledBlock
+]
+
+{ #category : #accessing }
+CDCompiledBlockClassParserTest >> superclassName [
+	^#CompiledCode
+]
+
+{ #category : #tests }
+CDCompiledBlockClassParserTest >> testBestNodeForClassVariableSelectionShouldBeClassSlotNode [
+	"no Class Variables in CompileBlock"
+	self assert: classDefinition sharedVariableNodes isEmpty
+]
+
+{ #category : #tests }
+CDCompiledBlockClassParserTest >> testBestNodeForInstanceVariableSelectionShouldBeSlotNode [
+	"no slots for CompileBlock"
+	self assert: classDefinition slots isEmpty
+]
+
+{ #category : #tests }
+CDCompiledBlockClassParserTest >> testBestNodeForSecondInstanceVariableSelectionShouldBeSecondSlotNode [
+	"no slots for CompileBlock"
+	self assert: classDefinition slots isEmpty
+]
+
+{ #category : #tests }
+CDCompiledBlockClassParserTest >> testClassDefFromLegacyStringHasSharedSlots [
+	"no Class Variables in CompileBlock"
+	self assert: classDefinition sharedVariableNodes isEmpty
+]
+
+{ #category : #tests }
+CDCompiledBlockClassParserTest >> testClassDefFromLegacyStringHasSlots [
+	"no slots for CompileBlock"
+	self assert: classDefinition slots isEmpty
+]
+
+{ #category : #helpers }
+CDCompiledBlockClassParserTest >> testCompiledMethodClass [
+
+	self assert: classDefinition layoutClass equals: CompiledMethodLayout
+]
+
+{ #category : #tests }
+CDCompiledBlockClassParserTest >> testSlotNodesHaveParentReference [
+	"no slots for CompileBlock"
+	self assert: classDefinition slots isEmpty
+]

--- a/src/ClassParser/CDClassDefinitionParser.class.st
+++ b/src/ClassParser/CDClassDefinitionParser.class.st
@@ -20,7 +20,7 @@ CDClassDefinitionParser >> handleClassName: aNode withType: aSymbol [
 
 	"if we get back CompiledMethodLayout or ByteLayout, we need to check the class name"
 	(layoutClass = CompiledMethodLayout or: [ layoutClass = ByteLayout ]) ifTrue: [
-		layoutClass := (classDefinition className = 'CompiledMethod')
+		layoutClass :=  (#('CompiledMethod' 'CompiledBlock' 'CompiledCode') includes: classDefinition className)
 					ifTrue:  [  CompiledMethodLayout ]
 					ifFalse: [  ByteLayout ]].
 	classDefinition layoutClass: (layoutClass)


### PR DESCRIPTION
CDClassDefinitionParser>>#handleClassName:withType: was just checking for the name CompiledMethod, but the whole hierarchy of CompiledCode has the CompiledMethod Format.

-> improve #handleClassName:withType
-> add test for CompiledBlock old style class definition parsing