### PR TITLE
Remove rpackage presence check

### DIFF
--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -767,13 +767,11 @@ ClassDescription >> notifyRepackage: selector method: compiledMethod oldProtocol
 	| oldPackage newPackage |
 	newProtocol = oldProtocol ifTrue: [ ^ self ].
 
-	"This indirection is because we need to abstract RPackage from the kernel"
-	self class environment at: #RPackage ifPresent: [ :rPackageClass |
-		newPackage := rPackageClass organizer packageForProtocol: newProtocol name inClass: self.
-		oldPackage := rPackageClass organizer packageForProtocol: oldProtocol name inClass: self.
+	newPackage := self packageOrganizer packageForProtocol: newProtocol name inClass: self.
+	oldPackage := self packageOrganizer packageForProtocol: oldProtocol name inClass: self.
 
-		"Announce recategorization"
-		newPackage = oldPackage ifFalse: [ SystemAnnouncer uniqueInstance methodRepackaged: compiledMethod from: oldPackage to: newPackage ] ].
+	"Announce recategorization"
+	newPackage = oldPackage ifFalse: [ SystemAnnouncer uniqueInstance methodRepackaged: compiledMethod from: oldPackage to: newPackage ].
 
 	SystemAnnouncer uniqueInstance methodRecategorized: compiledMethod oldProtocol: oldProtocol
 ]


### PR DESCRIPTION
RPackage should be renamed Package and should be integrated in the metamodel during this iteration of Pharo. This means that we should remove the code acting only if RPackage is loaded