### PR TITLE
Do not prevent all announcements during method classification

### DIFF
--- a/src/Kernel-Tests/ProtocolAnnouncementsTest.class.st
+++ b/src/Kernel-Tests/ProtocolAnnouncementsTest.class.st
@@ -50,6 +50,19 @@ ProtocolAnnouncementsTest >> testAddProtocolAnnouncement2 [
 	self assert: numberOfAnnouncements equals: 2
 ]
 
+{ #category : #'tests - adding' }
+ProtocolAnnouncementsTest >> testAddProtocolAnnouncementDuringCompilation [
+
+	self when: ProtocolAdded do: [ :ann |
+		self assert: ann protocol name equals: #titan.
+		self assert: ann classReorganized name equals: self classNameForTests ].
+
+	self when: ClassReorganized do: [ :ann | self assert: ann classReorganized name equals: self classNameForTests ].
+
+	class compile: 'king ^1' classified: #titan.
+	self assert: numberOfAnnouncements equals: 2
+]
+
 { #category : #tests }
 ProtocolAnnouncementsTest >> testClassifyUnderAnnounceNewProtocol [
 
@@ -126,6 +139,22 @@ ProtocolAnnouncementsTest >> testRemoveProtocolAnnouncement4 [
 	self when: ClassReorganized do: [ :ann | self assert: ann classReorganized name equals: self classNameForTests ].
 
 	class removeProtocol: #titan.
+
+	self assert: numberOfAnnouncements equals: 2
+]
+
+{ #category : #'tests - removing' }
+ProtocolAnnouncementsTest >> testRemoveProtocolAnnouncementDuringCompilation [
+
+	class compile: 'king ^1' classified: #titan.
+
+	self when: ProtocolRemoved do: [ :ann |
+		self assert: ann protocol name equals: #titan.
+		self assert: ann classReorganized name equals: self classNameForTests ].
+
+	self when: ClassReorganized do: [ :ann | self assert: ann classReorganized name equals: self classNameForTests ].
+
+	class compile: 'king ^1' classified: #demon.
 
 	self assert: numberOfAnnouncements equals: 2
 ]

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -34,12 +34,14 @@ ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod 
 		priorOrigin := method origin ].
 
 	oldProtocol := self protocolOfSelector: selector.
-	SystemAnnouncer uniqueInstance suspendAllWhile: [ "The next part is really ugly with the double if.. BUT! I will fix that in a new PR soon... I want to remove the usage of `Protocol unclassified` as a way to say 'Do not upatde the protocol' because this is counter intuitive."
-		self classify: selector under: ((protocol isString
-				  ifTrue: [ protocol ]
-				  ifFalse: [ protocol name ]) = Protocol unclassified
-				 ifTrue: [ oldProtocol ]
-				 ifFalse: [ protocol ]) ].
+	SystemAnnouncer uniqueInstance
+		prevent: MethodRecategorized , ClassReorganized
+		during: [ "The next part is really ugly with the double if.. BUT! I will fix that in a new PR soon... I want to remove the usage of `Protocol unclassified` as a way to say 'Do not upatde the protocol' because this is counter intuitive."
+			self classify: selector under: ((protocol isString
+					  ifTrue: [ protocol ]
+					  ifFalse: [ protocol name ]) = Protocol unclassified
+					 ifTrue: [ oldProtocol ]
+					 ifFalse: [ protocol ]) ].
 	newProtocol := self protocolOfSelector: selector.
 
 	self addSelectorSilently: selector withMethod: compiledMethod.


### PR DESCRIPTION
Currently when we classify a method we prevent all announcements. But this is wrong because some of those announcements are important! I updated the announcement management to prevent only some of the announcements and I added two regression tests of announcements that were lost but important.