### PR TITLE
Depends on DocumentBrowser v1.0.1

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -43,7 +43,7 @@ BaselineOfPharo class >> documentBrowser [
 		newName: 'DocumentBrowser' 
 		owner: 'pharo-spec' 
 		project: 'NewTools-DocumentBrowser' 
-		version: 'v1.0.0'
+		version: 'v1.0.1'
 ]
 
 { #category : #'repository urls' }


### PR DESCRIPTION
This update fixes the Iceberg dependency version of DocumentBrowser to use the same as in Pharo.