### PR TITLE
This fixes #isClean as described in #14141

### DIFF
--- a/src/Kernel-Tests/BlockClosureTest.class.st
+++ b/src/Kernel-Tests/BlockClosureTest.class.st
@@ -186,9 +186,18 @@ BlockClosureTest >> testIsClean [
 	self assert: [:a :b| | s | s := a + b. s even] isClean. "accesses only local variables"
 	self deny: [^nil] isClean. "closes over home (^-return)"
 	self deny: [self] isClean. "closes over the receiver"
+	self deny: [ aBlock ] isClean. "accesses ivar"
 	self deny: [super testIsClean] isClean. "closes over the receiver"
 	self deny: [contextOfaBlock] isClean. "closes over the receiver (to access the inst var contextOfaBlockContext)"
 	self deny: [local] isClean. "closes over local variable of outer context"
+	
+	"an inner non-clean block does not mean that the outer block is not clean"
+	self assert: [ :x | x do: [ x + 1 ] ] isClean.
+	"but if we access self or return, it is"
+	self deny: [ :x | x do: [ ^x] ] isClean.
+	self deny: [ :x | x do: [ self] ] isClean.
+	self deny: [ :x | x do: [ super testIsClean ] ] isClean.
+	self deny: [ :x | x do: [ aBlock] ] isClean
 ]
 
 { #category : #tests }

--- a/src/OpalCompiler-Core/OCBlockScope.class.st
+++ b/src/OpalCompiler-Core/OCBlockScope.class.st
@@ -9,7 +9,7 @@ Class {
 
 { #category : #testing }
 OCBlockScope >> hasEscapingVars [
-	^ (copiedVars isEmpty and: [tempVector isEmpty]) not
+	^ self inComingCopiedVarNames isNotEmpty
 ]
 
 { #category : #accessing }

--- a/src/OpalCompiler-Core/RBBlockNode.extension.st
+++ b/src/OpalCompiler-Core/RBBlockNode.extension.st
@@ -31,10 +31,15 @@ RBBlockNode >> irInstruction [
 
 { #category : #'*OpalCompiler-Core' }
 RBBlockNode >> isClean [
-	"a block is clean if it has no escaping vars, has no non local return and its children are clean"
+	"a block is clean if..."
+	"it or any embedded blocks do not need self"
+	self isAccessingSelf ifTrue: [ ^ false ].
+	"it or any embedded blocks do not need the outer context to return"
+	self hasNonLocalReturn ifTrue: [ ^ false ].
+	"there are no escaping vars accessed from the outer"
 	self scope hasEscapingVars ifTrue: [ ^ false ].
-	self hasBlockReturn ifTrue: [ ^ false ].
-	^ super isClean
+	^true
+
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Core/RBProgramNode.extension.st
+++ b/src/OpalCompiler-Core/RBProgramNode.extension.st
@@ -18,8 +18,9 @@ RBProgramNode >> irInstruction [
 ]
 
 { #category : #'*OpalCompiler-Core' }
-RBProgramNode >> isClean [
-	^ self children allSatisfy: [ :child | child isClean ]
+RBProgramNode >> isAccessingSelf [
+	"return true if accessing an ivar, self or super"
+	^ self children anySatisfy: [ :child | child isAccessingSelf ]
 ]
 
 { #category : #'*OpalCompiler-Core' }

--- a/src/OpalCompiler-Core/RBVariableNode.extension.st
+++ b/src/OpalCompiler-Core/RBVariableNode.extension.st
@@ -11,8 +11,8 @@ RBVariableNode >> binding: aSemVar [
 ]
 
 { #category : #'*OpalCompiler-Core' }
-RBVariableNode >> isClean [
-	^ (self isInstanceVariable | self isSelfVariable | self isSuperVariable) not
+RBVariableNode >> isAccessingSelf [
+	^ self isInstanceVariable or: [ self isSelfVariable or: [self isSuperVariable]]
 ]
 
 { #category : #'*OpalCompiler-Core' }


### PR DESCRIPTION
- #hasEscapingVars should only care about incomming copied vars
- add #isAccessingSelf, similar to #hasNonLocalReturn
- rewrite RBBlockNode>>#isClean in terms of checking for accessing self, return and escaping vars

- add the cases to BlockClosureTest>>#testIsClean

(we keep  #14141 open until this is backported to Pharo11)