### PR TITLE
Start unification of package removal

### DIFF
--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -359,7 +359,7 @@ ClySystemEnvironment >> registerProjectManager: aPackageManager [
 { #category : #'package management' }
 ClySystemEnvironment >> removePackage: aPackage [
 
-	packageOrganizer unregisterPackage: aPackage
+	packageOrganizer removePackage: aPackage
 ]
 
 { #category : #subscription }

--- a/src/Deprecated12/RPackageOrganizer.extension.st
+++ b/src/Deprecated12/RPackageOrganizer.extension.st
@@ -16,3 +16,17 @@ RPackageOrganizer >> registerPackageNamed: aString [
 	self deprecated: 'Use #ensurePackage: instead.' transformWith: '`@rcv registerPackageNamed: `@arg' -> '`@rcv ensurePackage: `@arg'.
 	^ self ensurePackage: aString
 ]
+
+{ #category : #'*Deprecated12' }
+RPackageOrganizer >> unregisterPackage: aPackage [
+
+	self deprecated: 'Use #removePackage: instead.' transformWith: '`@rcv unregisterPackage: `@arg' -> '`@rcv removePackage: `@arg'.
+	^ self removePackage: aPackage
+]
+
+{ #category : #'*Deprecated12' }
+RPackageOrganizer >> unregisterPackageNamed: symbol [
+
+	self deprecated: 'Use #removePackage: instead.' transformWith: '`@rcv unregisterPackageNamed: `@arg' -> '`@rcv removePackage: `@arg'.
+	^ self removePackage: symbol
+]

--- a/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
+++ b/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
@@ -291,7 +291,7 @@ EpCodeChangeIntegrationTest >> testPackageRemoval [
 
 	self assert: (self countLogEventsWith: EpPackageRemoval) equals: 0.
 
-	self packageOrganizer unregisterPackageNamed: self packageNameForTesting.
+	self packageOrganizer removePackage: self packageNameForTesting.
 
 	self assert: (self countLogEventsWith: EpPackageRemoval) equals: 1.
 	self assert: (self allLogEventsWith: EpPackageRemoval) first affectedPackageName equals: self packageNameForTesting

--- a/src/EpiceaBrowsers-Tests/EpApplyTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpApplyTest.class.st
@@ -345,31 +345,29 @@ EpApplyTest >> testMethodRemovalWithMethodAdded [
 EpApplyTest >> testPackageAddition [
 
 	[
-	self packageOrganizer createPackageNamed: classFactory packageName.
+	self packageOrganizer ensurePackage: classFactory packageName.
 	self setHeadAsInputEntry.
-	self packageOrganizer unregisterPackageNamed: classFactory packageName.
+	self packageOrganizer removePackage: classFactory packageName.
 
 	self assert: inputEntry content class equals: EpPackageAddition.
 	self deny: (self packageOrganizer hasPackage: classFactory packageName).
 	self applyInputEntry.
-	self assert: (self packageOrganizer hasPackage: classFactory packageName) ] ensure: [
-		self packageOrganizer unregisterPackageNamed: classFactory packageName ]
+	self assert: (self packageOrganizer hasPackage: classFactory packageName) ] ensure: [ self packageOrganizer removePackage: classFactory packageName ]
 ]
 
 { #category : #tests }
 EpApplyTest >> testPackageRemoval [
 
 	[
-	self packageOrganizer createPackageNamed: classFactory packageName.
-	self packageOrganizer unregisterPackageNamed: classFactory packageName.
+	self packageOrganizer ensurePackage: classFactory packageName.
+	self packageOrganizer removePackage: classFactory packageName.
 	self setHeadAsInputEntry.
-	self packageOrganizer createPackageNamed: classFactory packageName.
+	self packageOrganizer ensurePackage: classFactory packageName.
 
 	self assert: inputEntry content class equals: EpPackageRemoval.
 	self assert: (self packageOrganizer hasPackage: classFactory packageName).
 	self applyInputEntry.
-	self deny: (self packageOrganizer hasPackage: classFactory packageName) ] ensure: [
-		self packageOrganizer unregisterPackageNamed: classFactory packageName ]
+	self deny: (self packageOrganizer hasPackage: classFactory packageName) ] ensure: [ self packageOrganizer removePackage: classFactory packageName ]
 ]
 
 { #category : #tests }

--- a/src/EpiceaBrowsers-Tests/EpLogBrowserOperationFactoryTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpLogBrowserOperationFactoryTest.class.st
@@ -29,7 +29,7 @@ EpLogBrowserOperationFactoryTest >> setMonitorLogAsInputEntries [
 EpLogBrowserOperationFactoryTest >> tearDown [
 
 	self flag: #categories. "This tear down should not be needed but it currently is."
-	self packageOrganizer unregisterPackageNamed: classFactory packageName.
-	self packageOrganizer unregisterPackageNamed: classFactory defaultCategory.
+	self packageOrganizer removePackage: classFactory packageName.
+	self packageOrganizer removePackage: classFactory defaultCategory.
 	super tearDown
 ]

--- a/src/EpiceaBrowsers/EpApplyVisitor.class.st
+++ b/src/EpiceaBrowsers/EpApplyVisitor.class.st
@@ -121,7 +121,7 @@ EpApplyVisitor >> visitPackageAddition: aPackageAddition [
 { #category : #visitor }
 EpApplyVisitor >> visitPackageRemoval: aPackageRemoval [
 
-	self packageOrganizer unregisterPackageNamed: aPackageRemoval packageName
+	self packageOrganizer removePackage: aPackageRemoval packageName
 ]
 
 { #category : #visitor }

--- a/src/Gofer-Core/GoferUnload.class.st
+++ b/src/Gofer-Core/GoferUnload.class.st
@@ -58,8 +58,7 @@ GoferUnload >> unregister: aWorkingCopy [
 { #category : #unregistering }
 GoferUnload >> unregisterPackageInfo: aWorkingCopy [
 
-	RPackageOrganizer default
-		unregisterPackageNamed: aWorkingCopy packageName
+	self packageOrganizer removePackage: aWorkingCopy packageName
 ]
 
 { #category : #unregistering }

--- a/src/Kernel-Tests-Extended/ClassTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassTest.class.st
@@ -69,9 +69,11 @@ ClassTest >> setUp [
 
 { #category : #running }
 ClassTest >> tearDown [
+
 	self deleteClass.
-	{self unclassifiedCategory. self categoryNameForTemporaryClasses} do: [:category|
-			RPackage organizer unregisterPackageNamed: category].
+	{
+		self unclassifiedCategory.
+		self categoryNameForTemporaryClasses } do: [ :category | self packageOrganizer removePackage: category ].
 	super tearDown
 ]
 

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -247,8 +247,9 @@ CompiledMethodTest >> shouldNotImplementMethod [
 
 { #category : #running }
 CompiledMethodTest >> tearDown [
-	RPackage organizer unregisterPackageNamed: self categoryNameForTemporaryClasses.
-	class ifNotNil: [ class removeFromSystem].
+
+	self packageOrganizer removePackage: self categoryNameForTemporaryClasses.
+	class ifNotNil: [ class removeFromSystem ].
 	super tearDown
 ]
 

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -1463,7 +1463,8 @@ RPackage >> toTagName: aSymbol [
 
 { #category : #register }
 RPackage >> unregister [
-	self organizer unregisterPackage: self
+
+	self organizer removePackage: self
 ]
 
 { #category : #'private - register' }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -968,10 +968,10 @@ RPackageOrganizer >> systemCategoryRemovedActionFrom: ann [
 	| categoryName |
 	categoryName := ann categoryName asSymbol.
 
-	(self packageMatchingExtensionName: categoryName) ifNotNil: [ :rPackage |
-		rPackage name = categoryName
-			ifTrue: [ self unregisterPackage: rPackage ]
-			ifFalse: [ rPackage classTagNamed: (categoryName withoutPrefix: rPackage name , '-') ifPresent: [ :tag | rPackage removeClassTag: tag name ] ] ]
+	(self packageMatchingExtensionName: categoryName) ifNotNil: [ :package |
+		package name = categoryName
+			ifTrue: [ self removePackage: package ]
+			ifFalse: [ package classTagNamed: (categoryName withoutPrefix: package name , '-') ifPresent: [ :tag | package removeClassTag: tag name ] ] ]
 ]
 
 { #category : #'system integration' }
@@ -1229,12 +1229,6 @@ RPackageOrganizer >> unregisterInterestToSystemAnnouncement [
 	SystemAnnouncer uniqueInstance unsubscribe: self
 ]
 
-{ #category : #registration }
-RPackageOrganizer >> unregisterPackage: aPackage [
-
-	self removePackage: aPackage
-]
-
 { #category : #'private - registration' }
 RPackageOrganizer >> unregisterPackage: aPackage forClass: aClass [
 	"unregister the back pointer mapping from classes to packages."
@@ -1252,12 +1246,6 @@ RPackageOrganizer >> unregisterPackage: aPackage forClassName: aClassName [
 		ifTrue:
 			[self error: aPackage name , ' still includes the class ' , aClassName asSymbol].
 	^classPackageMapping removeKey: aClassName asSymbol ifAbsent: [self reportBogusBehaviorOf: #unregisterPackage:forClassName:  ]
-]
-
-{ #category : #registration }
-RPackageOrganizer >> unregisterPackageNamed: symbol [
-
-	self removePackage: symbol
 ]
 
 { #category : #private }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -856,6 +856,24 @@ RPackageOrganizer >> removeEmptyPackages [
 			emptyPackages do: [ :emptyPackage | categoryMap removeKey: emptyPackage ] ]
 ]
 
+{ #category : #registration }
+RPackageOrganizer >> removePackage: aPackage [
+
+	| package |
+	(self hasPackage: aPackage) ifFalse: [ ^ self ].
+
+	package := aPackage isString
+		           ifTrue: [ self packageNamed: aPackage ]
+		           ifFalse: [ aPackage ].
+
+	self basicUnregisterPackageNamed: package name.
+	package extendedClasses do: [ :extendedClass | self unregisterExtendingPackage: package forClass: extendedClass ].
+	package definedClasses do: [ :definedClass | self unregisterPackage: package forClass: definedClass ].
+	SystemAnnouncer announce: (PackageRemoved to: package).
+
+	^ package
+]
+
 { #category : #'deprecated - SystemOrganizer leftovers' }
 RPackageOrganizer >> removeSystemCategory: category [
 	"remove all the classes and traits associated with the category"
@@ -1213,16 +1231,8 @@ RPackageOrganizer >> unregisterInterestToSystemAnnouncement [
 
 { #category : #registration }
 RPackageOrganizer >> unregisterPackage: aPackage [
-	"Unregister the specified package from the list of registered packages. Raise the announcement RPackageUnregistered."
 
-	self basicUnregisterPackageNamed: aPackage name.
-	aPackage extendedClasses
-		do: [ :extendedClass | self unregisterExtendingPackage: aPackage forClass: extendedClass].
-	aPackage definedClasses
-		do: [ :definedClass | self unregisterPackage: aPackage forClass: definedClass].
-	SystemAnnouncer announce: (PackageRemoved to: aPackage).
-
-	^ aPackage
+	self removePackage: aPackage
 ]
 
 { #category : #'private - registration' }
@@ -1246,13 +1256,8 @@ RPackageOrganizer >> unregisterPackage: aPackage forClassName: aClassName [
 
 { #category : #registration }
 RPackageOrganizer >> unregisterPackageNamed: symbol [
-	"Unregister the specified package from the list of registered packages. Raise the announcement RPackageUnregistered."
 
-	| aPackage |
-	aPackage := packages at: symbol asSymbol ifAbsent: [ nil].
-	aPackage
-		ifNotNil: [self unregisterPackage: aPackage].
-	^ aPackage
+	self removePackage: symbol
 ]
 
 { #category : #private }

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -221,56 +221,6 @@ RPackageOrganizerTest >> testFullRegistration [
 ]
 
 { #category : #tests }
-RPackageOrganizerTest >> testFullUnregistration [
-
-	| p1 p2 p3 a1 a2 b1 b2 a3 |
-	"taken from setup of RPackageReadOnlyCompleteSetup"
-
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
-	p3 := self createNewPackageNamed: self p3Name.
-
-	a1 :=  self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
-	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.
-	a2 := self createNewClassNamed: #A2DefinedInP2 inPackage: p2.
-	b2 := self createNewClassNamed: #B2DefinedInP2 inPackage: p2.
-	a3 := self createNewClassNamed: #A3DefinedInP3 inPackage: p3.
-
-	a1 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addMethod: (a1>>#methodDefinedInP1).
-	a1 compileSilently: 'anotherMethodDefinedInP1 ^ #anotherMethodDefinedInP1'.
-	p1 addMethod: (a1>>#anotherMethodDefinedInP1).
-
-	a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addMethod: (a2>>#methodDefinedInP1).
-
-	a2 compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2'.
-	p2 addMethod: (a2>>#methodDefinedInP2).
-
-	a2 compileSilently: 'methodDefinedInP3 ^ #methodDefinedInP3'.
-	p3 addMethod: (a2>>#methodDefinedInP3).
-
-	a2 class compileSilently: 'classSideMethodDefinedInP3 ^ #classSideMethodDefinedInP3'.
-	p3 addMethod: (a2 class>>#classSideMethodDefinedInP3).
-
-
-	self packageOrganizer registerPackage: p1.
-	self packageOrganizer registerPackage: p2.
-	self packageOrganizer registerPackage: p3.
-
-	self packageOrganizer unregisterPackage: p1.
-	self packageOrganizer unregisterPackage: p2.
-	self packageOrganizer unregisterPackage: p3.
-
-
-	self deny: (self packageOrganizer includesPackageBackPointerForClass: a1).
-	self deny: (self packageOrganizer includesPackageBackPointerForClass: a2).
-	self deny: (self packageOrganizer includesPackageBackPointerForClass: b1).
-	self deny: (self packageOrganizer includesPackageBackPointerForClass: b2).
-	self deny: (self packageOrganizer includesPackageBackPointerForClass: a3)
-]
-
-{ #category : #tests }
 RPackageOrganizerTest >> testHasPackage [
 
 	| organizer packageFromOtherOrganizer name package |
@@ -383,6 +333,54 @@ RPackageOrganizerTest >> testRegistrationExtendingPackages [
 	self packageOrganizer registerExtendingPackage: p forClass: self quadrangleClass.
 	self denyEmpty: (self packageOrganizer extendingPackagesOf: self quadrangleClass).
 	self assert: (self packageOrganizer extendingPackagesOf: self quadrangleClass) anyOne name equals: #GraphElement
+]
+
+{ #category : #tests }
+RPackageOrganizerTest >> testRemovePackage [
+
+	| p1 p2 p3 a1 a2 b1 b2 a3 |
+	"taken from setup of RPackageReadOnlyCompleteSetup"
+	p1 := self createNewPackageNamed: self p1Name.
+	p2 := self createNewPackageNamed: self p2Name.
+	p3 := self createNewPackageNamed: self p3Name.
+
+	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
+	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.
+	a2 := self createNewClassNamed: #A2DefinedInP2 inPackage: p2.
+	b2 := self createNewClassNamed: #B2DefinedInP2 inPackage: p2.
+	a3 := self createNewClassNamed: #A3DefinedInP3 inPackage: p3.
+
+	a1 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
+	p1 addMethod: a1 >> #methodDefinedInP1.
+	a1 compileSilently: 'anotherMethodDefinedInP1 ^ #anotherMethodDefinedInP1'.
+	p1 addMethod: a1 >> #anotherMethodDefinedInP1.
+
+	a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
+	p1 addMethod: a2 >> #methodDefinedInP1.
+
+	a2 compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2'.
+	p2 addMethod: a2 >> #methodDefinedInP2.
+
+	a2 compileSilently: 'methodDefinedInP3 ^ #methodDefinedInP3'.
+	p3 addMethod: a2 >> #methodDefinedInP3.
+
+	a2 class compileSilently: 'classSideMethodDefinedInP3 ^ #classSideMethodDefinedInP3'.
+	p3 addMethod: a2 class >> #classSideMethodDefinedInP3.
+
+
+	self packageOrganizer registerPackage: p1.
+	self packageOrganizer registerPackage: p2.
+	self packageOrganizer registerPackage: p3.
+
+	self packageOrganizer removePackage: p1.
+	self packageOrganizer removePackage: p2.
+	self packageOrganizer removePackage: p3.
+
+	self deny: (self packageOrganizer includesPackageBackPointerForClass: a1).
+	self deny: (self packageOrganizer includesPackageBackPointerForClass: a2).
+	self deny: (self packageOrganizer includesPackageBackPointerForClass: b1).
+	self deny: (self packageOrganizer includesPackageBackPointerForClass: b2).
+	self deny: (self packageOrganizer includesPackageBackPointerForClass: a3)
 ]
 
 { #category : #tests }


### PR DESCRIPTION
I found multiple ways to remove a package in the system. I would like to bring some unification to the package removal because depending on the method used, the cleanings done are not the same.

Here is a first step toward this unification. 
Two methods to remove a package were RPackageOrganizer>>#unregisterPackage: and #unregisterPackageNamed: 

This PR merges both into a method that has a name more coherent with the rest of the system: #removePackage: 

## Next steps 

Next step is to deprecate RPackage>>unregister and to merge the behavior of RPackage>>removeFromSystem and this new method introduced so that #removeFromSystem just has to be `self organizer removePackage: self`.