### PR TITLE
Remove #colorTransform: from BalloonEngine

### DIFF
--- a/src/Athens-Balloon/AthensBalloonEngine.class.st
+++ b/src/Athens-Balloon/AthensBalloonEngine.class.st
@@ -65,7 +65,6 @@ AthensBalloonEngine >> fastReset [
 
 	self primSetEdgeTransform: edgeTransform.
 	self primSetClipRect: clipRect.
-	self primSetColorTransform: colorTransform.
 	self primSetDepth: self primGetDepth + 1.
 
 	postFlushNeeded := false.
@@ -221,8 +220,7 @@ AthensBalloonEngine >> reset [
 		primSetAALevel: 4;
 		primSetOffset: 0@0;
 		primSetClipRect: clipRect;
-		primSetEdgeTransform: edgeTransform;
-		primSetColorTransform: colorTransform.
+		primSetEdgeTransform: edgeTransform.
 
 	forms := #()
 ]

--- a/src/FormCanvas-Core/BalloonEngine.class.st
+++ b/src/FormCanvas-Core/BalloonEngine.class.st
@@ -14,7 +14,6 @@ Class {
 		'externals',
 		'aaLevel',
 		'edgeTransform',
-		'colorTransform',
 		'deferred',
 		'postFlushNeeded'
 	],
@@ -290,16 +289,6 @@ BalloonEngine >> clipRect [
 { #category : #accessing }
 BalloonEngine >> clipRect: aRect [
 	clipRect := aRect truncated
-]
-
-{ #category : #accessing }
-BalloonEngine >> colorTransform [
-	^colorTransform
-]
-
-{ #category : #accessing }
-BalloonEngine >> colorTransform: aColorTransform [
-	colorTransform := aColorTransform
 ]
 
 { #category : #copying }
@@ -630,12 +619,6 @@ BalloonEngine >> primSetClipRect: rect [
 ]
 
 { #category : #'primitives - access' }
-BalloonEngine >> primSetColorTransform: transform [
-	<primitive: 'primitiveSetColorTransform' module: 'B2DPlugin'>
-	^self primitiveFailed
-]
-
-{ #category : #'primitives - access' }
 BalloonEngine >> primSetDepth: depth [
 	<primitive: 'primitiveSetDepth' module: 'B2DPlugin'>
 	^self primitiveFailed
@@ -723,21 +706,20 @@ BalloonEngine >> registerFill: fill1 and: fill2 [
 BalloonEngine >> registerFills: fills [
 
 	| fillIndexList index fillIndex |
-	((colorTransform notNil and:[colorTransform isAlphaTransform]) or:[
-		fills anySatisfy: [:any| any notNil and:[any isTranslucent]]])
-			ifTrue:[	self flush.
-					self reset.
-					postFlushNeeded := true].
+	(fills anySatisfy: [ :any | any notNil and: [ any isTranslucent ] ]) ifTrue: [
+		self flush.
+		self reset.
+		postFlushNeeded := true ].
 	fillIndexList := WordArray new: fills size.
 	index := 1.
-	[index <= fills size] whileTrue:[
+	[ index <= fills size ] whileTrue: [
 		fillIndex := self registerFill: (fills at: index).
 		fillIndex == nil
-			ifTrue:[index := 1] "Need to start over"
-			ifFalse:[fillIndexList at: index put: fillIndex.
-					index := index+1]
-	].
-	^fillIndexList
+			ifTrue: [ "Need to start over" index := 1 ]
+			ifFalse: [
+				fillIndexList at: index put: fillIndex.
+				index := index + 1 ] ].
+	^ fillIndexList
 ]
 
 { #category : #initialize }
@@ -756,7 +738,6 @@ BalloonEngine >> reset [
 	self primSetOffset: destOffset.
 	self primSetClipRect: clipRect.
 	self primSetEdgeTransform: edgeTransform.
-	self primSetColorTransform: colorTransform.
 	forms := #()
 ]
 
@@ -764,7 +745,6 @@ BalloonEngine >> reset [
 BalloonEngine >> resetIfNeeded [
 	workBuffer ifNil:[self reset].
 	self primSetEdgeTransform: edgeTransform.
-	self primSetColorTransform: colorTransform.
 	self primSetDepth: self primGetDepth + 1.
 	postFlushNeeded := false
 ]

--- a/src/FormCanvas-Core/FormCanvas.class.st
+++ b/src/FormCanvas-Core/FormCanvas.class.st
@@ -262,16 +262,15 @@ FormCanvas >> drawString: aString from: firstIndex to: lastIndex in: bounds font
 
 { #category : #'private - balloon engine' }
 FormCanvas >> ensuredEngine [
-	engine := BalloonEngine new.
-	engine aaLevel: 1.
-	engine bitBlt: port.
-	engine destOffset: origin.
-	engine clipRect: clipRect.
-	engine deferred: false.
 
-	engine colorTransform: colorTransform.
-	engine edgeTransform: self transform.
-	^engine
+	^ BalloonEngine new
+		  aaLevel: 1;
+		  bitBlt: port;
+		  destOffset: origin;
+		  clipRect: clipRect;
+		  deferred: false;
+		  edgeTransform: self transform;
+		  yourself
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
BalloonEngine has a variable called #colorTransform: and some code managing it, but this code invoke a non existing method in the case the color is not nil. This means that the code cannot work if the variable is set.  I propose to remove it. 

WARNING: My image acts weird when I do this change but I would like to see how a bootstraped image act. Maybe this is just due to the migration of the instances in my image.