### PR TITLE
 backport Pharo11: Fix doubleClick on tab and on text selection. 

### DIFF
--- a/src/Morphic-Base/MouseClickState.class.st
+++ b/src/Morphic-Base/MouseClickState.class.st
@@ -320,13 +320,12 @@ MouseClickState >> handleEvent: evt from: aHand [
 			"timed out after mouseUp - signal timeout and pass the event"
 			aHand resetClickState.
 			self doubleClickTimeout. "***"
-			^true].
+			^ true].
 		localEvt isMouseDown ifTrue:["double click"
 			clickState := #secondClickDown.
-			"We should not double click if not on the same element"
-			(clickClient containsPoint: localEvt position) ifTrue: [
-				self doubleClick.
-				^false] ] ].
+			self doubleClick.
+			^ false ]
+			].
 
 	clickState == #secondClickDown ifTrue: [
 		isDragSecond ifTrue: ["drag start"

--- a/src/Morphic-Base/Object.extension.st
+++ b/src/Morphic-Base/Object.extension.st
@@ -117,18 +117,18 @@ Object class >> taskbarIcon [
 ]
 
 { #category : #'*Morphic-Base' }
+Object class >> taskbarIconName [
+	"Answer the icon for an instance of the receiver in a task bar"
+
+	^#smallWindow
+]
+
+{ #category : #'*Morphic-Base' }
 Object >> taskbarIconName [
 	"Answer the icon for the receiver in a task bar
 	or nil for the default."
 
 	^self class taskbarIconName
-]
-
-{ #category : #'*Morphic-Base' }
-Object class >> taskbarIconName [
-	"Answer the icon for an instance of the receiver in a task bar"
-
-	^#smallWindow
 ]
 
 { #category : #'*Morphic-Base' }

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -2236,6 +2236,8 @@ Morph >> doesOwnRotation [
 Morph >> doubleClick: evt [
 	"Handle a double-click event. This message is only sent to clients that request it by sending #waitForClicksOrDrag:event: to the initiating hand in their mouseDown: method. This default implementation does nothing."
 
+	"We should not double click if not on the same element"
+	(self containsPoint: evt position) ifFalse: [ ^self ].
 	^ self eventHandler ifNotNil:
 		[self eventHandler doubleClick: evt fromMorph: self]
 ]

--- a/src/Morphic-Tests/MockMorph.class.st
+++ b/src/Morphic-Tests/MockMorph.class.st
@@ -28,5 +28,7 @@ MockMorph >> myMagicClick: event [
 
 { #category : #events }
 MockMorph >> myMagicDoubleClick: event [
+	"Each client should check if it contains the point"
+	(self containsPoint: event position) ifFalse: [ ^self ].
 	magicDoubleClick := event
 ]

--- a/src/Morphic-Tests/MorphicEventHandlerTest.class.st
+++ b/src/Morphic-Tests/MorphicEventHandlerTest.class.st
@@ -32,9 +32,18 @@ MorphicEventHandlerTest >> testClickFromMorph [
 
 { #category : #tests }
 MorphicEventHandlerTest >> testDoubleClickFromMorph [
+	| event |
+	event := MouseButtonEvent new
+		setType: #mouseDown
+		position: 0@0
+		which: 0
+		buttons: 4
+		hand: morph eventHandler
+		stamp: Time millisecondClockValue.
 	morph eventHandler on: #doubleClick send: #value to: true.
 
-	self assert: (morph doubleClick: nil) identicalTo: true
+
+	self assert: (morph doubleClick: event) identicalTo: true
 ]
 
 { #category : #tests }

--- a/src/Rubric-Tests/RubEditingAreaTest.class.st
+++ b/src/Rubric-Tests/RubEditingAreaTest.class.st
@@ -135,3 +135,19 @@ RubEditingAreaTest >> testMouseMoveAfterDoubleClick [
 	self assert: area markBlock stringIndex equals: 9.
 	self assert: area pointBlock stringIndex equals: 17
 ]
+
+{ #category : #tests }
+RubEditingAreaTest >> testSelectAllWithDoubleClickAfterLastLine [ 
+	| text index buttons |
+	text := 'one
+two
+three
+four'.
+	area setTextWith: text.
+	index := text size + 20. "an index out of bounds of string"
+	buttons := MouseButtonEvent redButton.
+	position := 20@100.
+	area simulateClickWith: buttons position: position.
+	self sendDoubleClickAt: index withShift: false.
+	self assert: area selection equals: text.
+]


### PR DESCRIPTION
Fix double click outside area not selecting text inside area.
https://github.com/pharo-project/pharo/issues/14149