### PR TITLE
Factorize some unregistering code

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -1166,18 +1166,17 @@ RPackage >> removeClassDefinition: aClass fromClassTag: aSymbol [
 RPackage >> removeClassDefinitionName: aClassName [
 	"remove the class definition from the package but not its method"
 
-	| removed aClassNameSymbol |
-	('* class' match: aClassName) ifTrue: [^ self error: 'no metaclass name'].
+	| aClassNameSymbol |
+	(aClassName endsWith: ' class') ifTrue: [ ^ self error: 'no metaclass name' ].
 	aClassNameSymbol := aClassName asSymbol.
 	"clean up class tags"
-	classTags do: [ :tag| tag removeClassNamed: aClassName ].
-	(classTags select: #isEmpty)
-		do: [ :eachTag | self basicRemoveTag: eachTag ].
+	classTags do: [ :tag |
+		tag removeClassNamed: aClassName.
+		tag isEmpty ifTrue: [ self basicRemoveTag: tag ] ].
 	"remove the class definition"
-	removed := classes remove: aClassNameSymbol ifAbsent: [nil].
-	removed ifNotNil: [
+	(classes remove: aClassNameSymbol ifAbsent: [ nil ]) ifNotNil: [ :removed |
 		self definedMethodsShouldBecomeExtensionWhenRemovingClass: aClassName.
-		self unregisterClassName: aClassNameSymbol ]
+		self unregisterClass: aClassNameSymbol ]
 ]
 
 { #category : #'class tags' }
@@ -1197,20 +1196,14 @@ RPackage >> removeClassDefinitionNamed: aClassNameSymbol [
 
 	This method removes the class definition from the receiver and its organizer"
 
-	| removed |
-	removed := classes remove: aClassNameSymbol ifAbsent: [nil].
-	removed ifNotNil: [ self unregisterClassName: aClassNameSymbol.]
+	(classes remove: aClassNameSymbol ifAbsent: [ nil ]) ifNotNil: [ :removed | self unregisterClass: removed ]
 ]
 
 { #category : #private }
 RPackage >> removeClassDefinitionWithoutCheckingMethods: aClass [
 	"Same than 'removeClassDefinition', excepts that it does not make any check to set defined methods as extensions"
 
-	| removed aClassName|
-	aClassName := aClass instanceSide name.
-	removed := classes remove: aClassName ifAbsent: [nil].
-	removed ifNotNil: [
-		self unregisterClass: aClass.]
+	self removeClassDefinitionNamed: aClass instanceSide name asSymbol
 ]
 
 { #category : #removing }
@@ -1470,14 +1463,8 @@ RPackage >> unregister [
 { #category : #'private - register' }
 RPackage >> unregisterClass: aClass [
 	"Private method that declares the mapping between a class and its package."
-	self organizer
-		unregisterPackage: self forClass: aClass
-]
 
-{ #category : #'private - register' }
-RPackage >> unregisterClassName: aClassNameSymbol [
-	"Private method that declares the mapping between a class and its package."
-	self organizer unregisterPackage: self forClassName: aClassNameSymbol
+	self organizer unregisterPackage: self forClass: aClass
 ]
 
 { #category : #updating }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -1035,26 +1035,26 @@ RPackageOrganizer >> systemClassRemovedActionFrom: ann [
 RPackageOrganizer >> systemClassRenamedActionFrom: ann [
 	"When a class is renamed, we update its package as well as the organizer"
 
-	| newName oldName class rPackage extendingRPackages packageName |
+	| newName oldName class package extendingPackages packageName |
 	class := ann classAffected.
 	packageName := ann category.
 	oldName := ann oldName.
 	newName := ann newName.
-	rPackage := self packageOfClassNamed: oldName.
-	extendingRPackages := self extendingPackagesOfClassNamed: oldName.
+	package := self packageOfClassNamed: oldName.
+	extendingPackages := self extendingPackagesOfClassNamed: oldName.
 
-	rPackage updateDefinedClassNamed: oldName withNewName: newName.
+	package updateDefinedClassNamed: oldName withNewName: newName.
 	"we have to update all RPackages extending this class"
-	extendingRPackages do: [:aRPackage |
+	extendingPackages do: [:aRPackage |
 		aRPackage updateExtensionForClassNamed: oldName withNewName: newName].
 
 	"we have to update the RPackageOrganizer.
 	update the 'classPackageDictionary' to replace the key with the new class name"
-	self unregisterPackage: rPackage forClassName: oldName.
-	self registerPackage: rPackage forClassName: newName.
+	self unregisterPackage: package forClass: oldName.
+	self registerPackage: package forClassName: newName.
 
 	"update the 'classExtendingPackagesMapping' to replace the key with the new class name"
-	extendingRPackages do: [:aRPackage |
+	extendingPackages do: [:aRPackage |
 		self unregisterExtendingPackage: aRPackage forClassName: oldName.
 		self registerExtendingPackage:  aRPackage forClassName: newName
 		].
@@ -1231,19 +1231,12 @@ RPackageOrganizer >> unregisterInterestToSystemAnnouncement [
 RPackageOrganizer >> unregisterPackage: aPackage forClass: aClass [
 	"unregister the back pointer mapping from classes to packages."
 
-	^classPackageMapping
-		removeKey: aClass instanceSide name
-		ifAbsent: [ self reportExtraRemovalOf: aClass name ]
-]
+	| className |
+	className := (aClass isString
+		              ifTrue: [ aClass ]
+		              ifFalse: [ aClass instanceSide name ]) asSymbol.
 
-{ #category : #'private - registration' }
-RPackageOrganizer >> unregisterPackage: aPackage forClassName: aClassName [
-	"Unregister the package back pointer for a given class. The class should not belong to the package anymore before removing the back pointer."
-
-	(aPackage includesClassNamed: aClassName asSymbol)
-		ifTrue:
-			[self error: aPackage name , ' still includes the class ' , aClassName asSymbol].
-	^classPackageMapping removeKey: aClassName asSymbol ifAbsent: [self reportBogusBehaviorOf: #unregisterPackage:forClassName:  ]
+	^ classPackageMapping removeKey: className ifAbsent: [ self error: aPackage name , ' still includes the class ' , className ]
 ]
 
 { #category : #private }

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -713,7 +713,7 @@ RPackageIncrementalTest >> testPrivateClassRegisterUnregister [
 	p registerClassName: a1 name.
 	self assert: (RPackage organizer packageOf: a1) equals: p.
 	p definedClassNames remove: #A1InPackageP1.
-	p unregisterClassName: a1 name.
+	p unregisterClass: a1.
 	self assert: (RPackage organizer packageOf: a1) isDefault
 ]
 


### PR DESCRIPTION
This change factorize more unregistering code in RPackage.

RPackageOrganizer>>#unregisterPackage:forClassName: is integrated into RPackageOrganizer>>#unregisterPackage:forClass:
RPackage>>#unregisterClassName: is integrated into RPackage>>unregisterClass: 

RPackage>>removeClassDefinition* have a first pass at factorizing them