### PR TITLE
Merge addition of class definition in rpackage

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -181,7 +181,12 @@ RPackage >> addClass: aClass [
 RPackage >> addClassDefinition: aClass [
 	"Add only the class definition of aClass, as a class defined by the receiver. The term classdefinition denotes the fact that we do not treat its methods. aClass methods are not added to the package. aClass can be either a class or a metaclass"
 
-	self addClassDefinitionName: aClass instanceSide name
+	| aClassName |
+	aClassName := aClass instanceSide name asSymbol.
+	(classes includes: aClassName) ifTrue: [ ^ self ].
+	classes add: aClassName.
+	self extendedMethodsShouldBecomeDefinedWhenAddingClassName: aClassName.
+	self registerClassName: aClassName
 ]
 
 { #category : #'class tags' }
@@ -189,21 +194,6 @@ RPackage >> addClassDefinition: aClass toClassTag: aSymbol [
 	"Tags the class aClass with the tag aSymbol"
 
 	self addClassDefinitionName: aClass name toClassTag: aSymbol
-]
-
-{ #category : #'add class' }
-RPackage >> addClassDefinitionName: aClassName [
-	"aClassName should only be a class (and not a metaclass name)"
-
-	| aClassNameSymbol |
-	('* class' match: aClassName)
-		ifTrue: [ ^ self error: 'no metaclass name' ].
-	aClassNameSymbol := aClassName asSymbol.
-	(classes includes: aClassNameSymbol)
-		ifTrue: [ ^ self ].
-	classes add: aClassNameSymbol.
-	self extendedMethodsShouldBecomeDefinedWhenAddingClassName: aClassNameSymbol.
-	self registerClassName: aClassNameSymbol
 ]
 
 { #category : #'class tags' }

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -251,18 +251,6 @@ RPackageIncrementalTest >> testAddRemoveSelectorOfMetaclass [
 ]
 
 { #category : #'tests - class addition removal' }
-RPackageIncrementalTest >> testBogusClassAddition [
-	| p a1 |
-	p := self createNewPackageNamed: self p1Name.
-	a1 := self createNewClassNamed: #A1InPAckageP1 inCategory: self p1Name.
-	self assert: p definedClasses size equals: 0.
-	p addClassDefinitionName: a1 name.
-	self assert: p definedClasses size equals: 1.
-	self assert: (p includesClass: a1).
-	self should: [p addClassDefinitionName: a1 class name] raise: Error
-]
-
-{ #category : #'tests - class addition removal' }
 RPackageIncrementalTest >> testClassAddition [
 	| p a1 |
 	p := self createNewPackageNamed: self p1Name.
@@ -276,8 +264,8 @@ RPackageIncrementalTest >> testClassAddition [
 
 { #category : #'tests - class addition removal' }
 RPackageIncrementalTest >> testClassDefinitionRemoval [
-	| p a1 b1|
 
+	| p a1 b1 |
 	p := self createNewPackageNamed: self p1Name.
 	a1 := self createNewClassNamed: #A1InPAckageP1 inCategory: self p1Name.
 	b1 := self createNewClassNamed: #B1InPAckageP1 inCategory: self p1Name.
@@ -296,27 +284,6 @@ RPackageIncrementalTest >> testClassDefinitionRemoval [
 	self assert: (p includesClass: b1).
 
 	p removeClassDefinition: b1 class.
-	self deny: (p includesClass: b1)
-]
-
-{ #category : #'tests - class addition removal' }
-RPackageIncrementalTest >> testClassDefinitionRemovalName [
-	| p a1 b1|
-	p := self createNewPackageNamed: self p1Name.
-	a1 := self createNewClassNamed: #A1InPAckageP1 inCategory: self p1Name.
-	b1 := self createNewClassNamed: #B1InPAckageP1 inCategory: self p1Name.
-	self assert: p definedClasses size equals: 0.
-	p addClassDefinitionName: a1 name.
-	p addClassDefinitionName: b1 name.
-	self assert: p definedClasses size equals: 2.
-	self assert: (p includesClass: a1).
-	self assert: (p includesClass: b1).
-	p removeClassDefinitionName: a1 name.
-	self assert: p definedClasses size equals: 1.
-	self deny: (p includesClass: a1).
-	self assert: (p includesClass: b1).
-	self should: [p removeClassDefinitionName: b1 class name] raise: Error.
-	p removeClassDefinitionName: b1 name.
 	self deny: (p includesClass: b1)
 ]
 


### PR DESCRIPTION
One of my goal is to make sure packages use real classes instead of class names. Here is a small step toward that goal: I merged #addClassDefinition: and #addClassDefinitionNamed:

Next step is to merge removeClassDefinition: and #removeClassDefinitionNamed: but this is not as easy since this is used by the system.