### PR TITLE
Remove brittle method in RPackage

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -268,16 +268,6 @@ RPackage >> addMethod: aCompiledMethod [
 ]
 
 { #category : #'add method - selector' }
-RPackage >> addSelector: aSelector ofClassName: aClassName [
-	"Add the method to the receiver. If the class is not locally defined in that package then the method is defined as a method extension: ie extending another package. Note that this method does not add the method to the class, it just records in the package that the method is packaged."
-
-	( self includesClassNamed: aClassName)
-		ifFalse: [(classExtensionSelectors at: aClassName asSymbol ifAbsentPut: [Set new]) add: aSelector]
-		ifTrue: [(classDefinedSelectors at: aClassName asSymbol ifAbsentPut: [Set new]) add: aSelector].
-	^ aSelector
-]
-
-{ #category : #'add method - selector' }
 RPackage >> addSelector: aSelector ofMetaclassName: aClassName [
 	"Add the method to the receiver. If the class is not locally defined in that package then the method is defined as a method extension: ie extending another package. Note that this method does not add the method to the class, it just records in the package that the method is packaged. aClassName is the sole instance class name and not its metaclass one: i.e. adding Point class>>new is done as addSelector: #new ofMetaclassName: #Point"
 

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -1163,22 +1163,18 @@ RPackageOrganizer >> systemMethodRecategorizedActionFrom: ann [
 { #category : #'system integration' }
 RPackageOrganizer >> systemMethodRemovedActionFrom: ann [
 
-	| method methodPackage |
+	| method |
 	method := ann method.
 	"If the method is provided by a trait, we do not care about it"
-	ann isProvidedByATrait ifTrue: [^ self].
+	ann isProvidedByATrait ifTrue: [ ^ self ].
 
 	ann methodClass isMeta
 		ifFalse: [
-			methodPackage := self packageDefiningOrExtendingSelector: ann selector inClassNamed: ann methodClass instanceSide originalName.
-			methodPackage ifNotNil: [
-				methodPackage removeSelector: ann selector ofClassName: ann methodClass instanceSide originalName].
-		]
+			(self packageDefiningOrExtendingSelector: ann selector inClassNamed: ann methodClass instanceSide originalName) ifNotNil: [ :methodPackage |
+				methodPackage removeSelector: ann selector ofClassName: ann methodClass instanceSide originalName ] ]
 		ifTrue: [
-			methodPackage := self packageDefiningOrExtendingSelector: ann selector inMetaclassNamed: ann methodClass instanceSide originalName.
-			methodPackage ifNotNil: [
-				methodPackage removeSelector: ann selector ofMetaclassName: ann methodClass instanceSide originalName].
-		]
+			(self packageDefiningOrExtendingSelector: ann selector inMetaclassNamed: ann methodClass instanceSide originalName) ifNotNil: [ :methodPackage |
+				methodPackage removeSelector: ann selector ofMetaclassName: ann methodClass instanceSide originalName ] ]
 ]
 
 { #category : #accessing }

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -189,18 +189,17 @@ RPackageIncrementalTest >> testAddRemoveMethod [
 
 { #category : #'tests - method addition removal' }
 RPackageIncrementalTest >> testAddRemoveSelector [
-	| p1 p2 p3 a2   a2Name |
+
+	| p1 p2 p3 a2 a2Name |
 	a2Name := #A2InPackageP2.
 	p1 := self createNewPackageNamed: 'P1'.
 	p2 := self createNewPackageNamed: 'P2'.
 	p3 := self createNewPackageNamed: 'P3'.
 	a2 := self createNewClassNamed: a2Name inPackage: p2.
-	a2 compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2'.
-	p2 addSelector: #methodDefinedInP2 ofClassName: a2Name.
-	a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addSelector: #methodDefinedInP1 ofClassName: a2Name.
-	a2 compileSilently: 'methodDefinedInP3 ^ #methodDefinedInP3'.
-	p3 addSelector: #methodDefinedInP3 ofClassName: a2Name.
+
+	p2 addMethod: a2 >> (a2 compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2').
+	p1 addMethod: a2 >> (a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1').
+	p3 addMethod: a2 >> (a2 compileSilently: 'methodDefinedInP3 ^ #methodDefinedInP3').
 
 	self assert: (p2 includesDefinedSelector: #methodDefinedInP2 ofClassName: a2Name).
 	self deny: (p2 includesExtensionSelector: #methodDefinedInP2 ofClassName: a2Name).
@@ -209,11 +208,11 @@ RPackageIncrementalTest >> testAddRemoveSelector [
 	self assert: (p1 includesExtensionSelector: #methodDefinedInP1 ofClassName: a2Name).
 	self deny: (p3 includesDefinedSelector: #methodDefinedInP1 ofClassName: a2Name).
 
-	p2 removeSelector: #methodDefinedInP2 ofClassName:  a2Name.
+	p2 removeSelector: #methodDefinedInP2 ofClassName: a2Name.
 	self deny: (p2 includesDefinedSelector: #methodDefinedInP2 ofClassName: a2Name).
 	self deny: (p2 includesExtensionSelector: #methodDefinedInP2 ofClassName: a2Name).
 
-	p1 removeSelector: #methodDefinedInP1 ofClassName:  a2Name.
+	p1 removeSelector: #methodDefinedInP1 ofClassName: a2Name.
 	self deny: (p1 includesDefinedSelector: #methodDefinedInP3 ofClassName: a2Name).
 	self deny: (p1 includesExtensionSelector: #methodDefinedInP3 ofClassName: a2Name)
 ]
@@ -370,7 +369,8 @@ RPackageIncrementalTest >> testDefinedClassesAndDefinedClassNames [
 
 { #category : #'tests - extension' }
 RPackageIncrementalTest >> testExtensionClassNames [
-	| p1 p2  a2 b2 |
+
+	| p1 p2 a2 b2 |
 	p1 := self createNewPackageNamed: 'P1'.
 	p2 := self createNewPackageNamed: 'P2'.
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
@@ -379,25 +379,21 @@ RPackageIncrementalTest >> testExtensionClassNames [
 	self assert: (p2 includesClass: b2).
 	self assert: (p2 includesClass: a2).
 
-	a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addSelector: #methodDefinedInP1 ofClassName: a2 name.
+	p1 addMethod: a2 >> (a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1').
 
 	self assert: p1 extensionSelectors size equals: 1.
 	self assert: p1 extensionMethods size equals: 1.
 	self assert: (p1 extendedClassNames includes: #A2InPackageP2).
-	self deny: (p1 includesClass: a2).
-	"method extension class are not included in packages"
+	self deny: (p1 includesClass: a2). "method extension class are not included in packages"
 
-	b2 compile: 'firstMethodInB2PackagedInP1 ^ 1'.
-	p1 addSelector: #firstMethodInB2PackagedInP1 ofClassName: b2 name.
+	p1 addMethod: b2 >> (b2 compile: 'firstMethodInB2PackagedInP1 ^ 1').
 
 	self assert: p1 extensionSelectors size equals: 2.
 	self assert: p1 extensionMethods size equals: 2.
 	self assert: (p1 extendedClassNames includes: #B2InPackageP2).
 	self deny: (p1 includesClass: b2).
 
-	b2 compileSilently: 'secondMethodInB2PackagedInP1 ^ 2'.
-	p1 addSelector: #secondMethodInB2PackagedInP1 ofClassName: b2 name.
+	p1 addMethod: b2 >> (b2 compileSilently: 'secondMethodInB2PackagedInP1 ^ 2').
 
 	self assert: p1 extensionSelectors size equals: 3.
 	self assert: p1 extensionMethods size equals: 3.


### PR DESCRIPTION
RPackage contains a brittle method to add a selector to a class. Using this method can lead to a state breaking the integrity of a package.

Since it is use only in tests I propose to remove this and use the better API. (It is also brittle but less)