### PR TITLE
Remove some overriden methods in Monticello

### DIFF
--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -102,33 +102,6 @@ RPackageMCSynchronisationTest >> createMethodNamed: methodName inClassSideOfClas
 	^ aClass classSide compile: (methodName, ' ^nil') classified: aCategoryName.
 ]
 
-{ #category : #private }
-RPackageMCSynchronisationTest >> createNewClassNamed: aName [
-	
-	| cls |
-
-	cls := self class classInstaller make: [ :aClassBuilder | 
-		aClassBuilder 
-			name: aName;
-			package: 'RPackageTest' ].
-
-	^ cls
-]
-
-{ #category : #private }
-RPackageMCSynchronisationTest >> createNewTraitNamed: aName inCategory: aCategoryName [
-	
-	| trait |
-
-	trait := self class classInstaller make: [ :aBuilder |
-		aBuilder 
-			name: aName;
-			package: aCategoryName;
-			beTrait ].								
-			
-	^ trait
-]
-
 { #category : #accessing }
 RPackageMCSynchronisationTest >> emptyOrganizer [ 
 


### PR DESCRIPTION
Monticello is overriding some methods in its tests but it is not necessary to do so and it just makes things more complexe for nothing. Also I plan to update the methods in the superclass and I want the changes to impact the Monticello tests aswell