### PR TITLE
Improve CompiledMethod>>#isExtension

### DIFF
--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -457,6 +457,24 @@ CompiledMethodTest >> testIsDeprecated [
 			ifFalse: [ self deny: (self class >> each) isDeprecated ] ]
 ]
 
+{ #category : #'tests - abstract' }
+CompiledMethodTest >> testIsExtension [
+
+	[
+	| method |
+	self class compile: 'isExtensionTestMethod ^ 1' classified: 'protocol'.
+	self deny: (self class >> #isExtensionTestMethod) isExtension.
+
+	self class compile: 'isExtensionTestMethod ^ 1' classified: '*Kernel-Tests-Generated-Package'.
+	method := self class >> #isExtensionTestMethod.
+	self assert: method isExtension.
+
+	self class removeSelector: #isExtensionTestMethod.
+	self deny: method isExtension ] ensure: [
+		(self packageOrganizer packageNamed: 'Kernel-Tests-Generated-Package' ifAbsent: [ nil ]) ifNotNil: [ :package | package removeFromSystem ].
+		self class compiledMethodAt: #isExtensionTestMethod ifPresent: [ :method | method removeFromSystem ] ]
+]
+
 { #category : #'tests - testing' }
 CompiledMethodTest >> testIsFaulty [
 	|  cm |

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -438,6 +438,15 @@ CompiledMethod >> isExplicitlyRequired: marker [
 
 { #category : #testing }
 CompiledMethod >> isExtension [
+	"I return true if a method is an extension method. Which means that the methods is not packaged in the package of the class containing the method, but in another package.
+	
+	Note: In the future we want to go away from the usage of protocols to define an extension method. But in the meantime it is the fastest way to know if a method is an extension.
+	
+	In the future we should check if the package of the method is the package of the class containing the method. If it is the case, the method is not an extension. Keep also in mind that a package that is nil for the method means that it is not an extension but a method that is uninstalled.
+	Before we can use packages, we'll need to speedup the methods CompiledMethod>>#package and ClassDescription>>#package which are quite slow currently because of the state of RPackage."
+
+	"(self >> #isExtension) isExtension >>> false"
+	"(self >> #traitSource) isExtension >>> true"
 
 	^ self protocol
 		  ifNil: [ false ]

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -437,6 +437,14 @@ CompiledMethod >> isExplicitlyRequired: marker [
 ]
 
 { #category : #testing }
+CompiledMethod >> isExtension [
+
+	^ self protocol
+		  ifNil: [ false ]
+		  ifNotNil: [ :protocol | protocol isExtensionProtocol ]
+]
+
+{ #category : #testing }
 CompiledMethod >> isExtensionMethod [
 
 	^ self protocol isExtensionProtocol

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -445,12 +445,6 @@ CompiledMethod >> isExtension [
 ]
 
 { #category : #testing }
-CompiledMethod >> isExtensionMethod [
-
-	^ self protocol isExtensionProtocol
-]
-
-{ #category : #testing }
 CompiledMethod >> isFaulty [
  	"check if this method was compiled from syntactically wrong code"
 	| ast |

--- a/src/RPackage-Core/CompiledMethod.extension.st
+++ b/src/RPackage-Core/CompiledMethod.extension.st
@@ -6,14 +6,6 @@ CompiledMethod >> isDefinedInPackage: anRPackage [
 ]
 
 { #category : #'*RPackage-Core' }
-CompiledMethod >> isExtension [
-
-	^ self protocol
-		  ifNil: [ false ]
-		  ifNotNil: [ :protocol | protocol isExtensionProtocol ]
-]
-
-{ #category : #'*RPackage-Core' }
 CompiledMethod >> isExtensionInPackage: anRPackage [
 	^ anRPackage includesExtensionSelector: self selector ofClass: self methodClass
 ]

--- a/src/RPackage-Core/CompiledMethod.extension.st
+++ b/src/RPackage-Core/CompiledMethod.extension.st
@@ -7,7 +7,10 @@ CompiledMethod >> isDefinedInPackage: anRPackage [
 
 { #category : #'*RPackage-Core' }
 CompiledMethod >> isExtension [
-	^ self origin package ~= self package
+
+	^ self protocol
+		  ifNil: [ false ]
+		  ifNotNil: [ :protocol | protocol isExtensionProtocol ]
 ]
 
 { #category : #'*RPackage-Core' }

--- a/src/ReleaseTests/ProperPackagesTest.class.st
+++ b/src/ReleaseTests/ProperPackagesTest.class.st
@@ -18,7 +18,7 @@ ProperPackagesTest >> testPackageExtensionsStartsWithProperPackageName [
 	"Method categories that represent extensions should start with a * followed by a package name that starts with an uppercase letter - ensure that"
 
 	self assertEmpty:
-		(SystemNavigation default allMethods select: [ :method | method isExtensionMethod and: [ method protocolName second isLowercase ] ])
+		(SystemNavigation default allMethods select: [ :method | method isExtension and: [ method protocolName second isLowercase ] ])
 ]
 
 { #category : #tests }

--- a/src/SystemCommands-MethodCommands/SycMoveMethodsToTheDefiningClassCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMoveMethodsToTheDefiningClassCommand.class.st
@@ -30,6 +30,6 @@ SycMoveMethodsToTheDefiningClassCommand >> defaultMenuItemName [
 SycMoveMethodsToTheDefiningClassCommand >> execute [
 
 	methods
-		select: [ :method | method isExtensionMethod ]
+		select: [ :method | method isExtension ]
 		thenDo: [ :method | self classifyMethod: method ]
 ]

--- a/src/Tool-Base/MethodClassifier.class.st
+++ b/src/Tool-Base/MethodClassifier.class.st
@@ -291,7 +291,7 @@ MethodClassifier >> protocolByOtherImplementors: aMethod [
 
 	aMethod implementors ifEmpty: [ ^ self ] ifNotEmpty: [ :implementor |
 		implementor
-			do: [ :method | (method isExtensionMethod or: [ method isClassified not ]) ifFalse: [ protocolBag add: method protocolName ] ]
+			do: [ :method | (method isExtension or: [ method isClassified not ]) ifFalse: [ protocolBag add: method protocolName ] ]
 			without: aMethod ].
 
 	protocolBag ifEmpty: [ ^ self ].


### PR DESCRIPTION
In my RPackage cleanings I want to remove all the dictionaries of names to manipulated the MM directly to get the right informations. This would simplify a lot the code and would remove all the bugs linked to synchronization. In order to do that without losing too much performance I want to speed up some operations first.

In this change I speed up CompiledMethod>>#isExtension and also I fixed a bug in it where every method that was removed from a class was answering true to #isExtension. Now it answers false since the method is unpackaged. I also added a tests to ensure this behavior.

Here are some bench:

```st
[ SystemNavigation default methods do: [ :m | m isExtension ] ] bench

"Before the change: 30 iterations in 5 seconds 13 milliseconds. 5.984 per second"

"After the change: 10 iterations in 5 seconds 436 milliseconds. 1.840 per second"
```

I also removed #isExtensionMethod that I introduced this week and that already had an equivalent.