### PR TITLE
Update RPackage API of slot tests

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -324,6 +324,9 @@ RPackage >> basicRemoveTag: tag [
 
 	classTags remove: tag ifAbsent: [  ].
 
+	self flag: #package. "This next line should be removed in the future with the system organizer."
+	self organizer removeCategory: tag categoryName.
+
 	SystemAnnouncer announce: (PackageTagRemoved to: tag)
 ]
 
@@ -1221,17 +1224,9 @@ RPackage >> removeClassesMatchingTag: aTag [
 { #category : #removing }
 RPackage >> removeFromSystem [
 
-	| categories |
-	categories := (self classTags collect: [ :each | each categoryName ] as: Set)
-		              add: self name;
-		              yourself.
-
 	self definedClasses do: #removeFromSystem.
 	self extensionMethods do: #removeFromSystem.
 
-	"This is probably not the best place to unregister from the SystemOrganizer but later it's harder to find the categories. 
-	But anyway, SystemOrganizer should be removed in the next few months and we will be able to remove this code."
-	categories do: [ :category | self organizer removeCategory: category ].
 	self unregister
 ]
 

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -869,6 +869,9 @@ RPackageOrganizer >> removePackage: aPackage [
 	self basicUnregisterPackageNamed: package name.
 	package extendedClasses do: [ :extendedClass | self unregisterExtendingPackage: package forClass: extendedClass ].
 	package definedClasses do: [ :definedClass | self unregisterPackage: package forClass: definedClass ].
+
+	self flag: #package. "The next line should be removed with the system organizer later."
+	self removeCategory: package name.
 	SystemAnnouncer announce: (PackageRemoved to: package).
 
 	^ package

--- a/src/RPackage-Tests/RPackageOrganizerAndSystemOrganizeSynchTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerAndSystemOrganizeSynchTest.class.st
@@ -82,6 +82,21 @@ RPackageOrganizerAndSystemOrganizeSynchTest >> testRemovingPackage [
 ]
 
 { #category : #tests }
+RPackageOrganizerAndSystemOrganizeSynchTest >> testRemovingPackage2 [
+	"Regression test because removing a RPackage from the system was not removing the category in SystemOrganizer."
+
+	self packageOrganizer addCategory: self packageName.
+
+	self assert: (self packageOrganizer packageNames includes: self packageName).
+	self assert: (self packageOrganizer includesCategory: self packageName).
+
+	self packageOrganizer removePackage: self packageName.
+
+	self deny: (self packageOrganizer packageNames includes: self packageName).
+	self deny: (self packageOrganizer includesCategory: self packageName)
+]
+
+{ #category : #tests }
 RPackageOrganizerAndSystemOrganizeSynchTest >> testRemovingPackageWithTags [
 	"Regression test because removing a RPackage from the system was not removing the category in SystemOrganizer."
 

--- a/src/Slot-Tests/SlotAnnouncementsTest.class.st
+++ b/src/Slot-Tests/SlotAnnouncementsTest.class.st
@@ -167,9 +167,9 @@ SlotAnnouncementsTest >> testChangeInSuperclassShouldNotAnnounceSubclassModified
 ]
 
 { #category : #'tests - integration' }
-SlotAnnouncementsTest >> testClassAddedToNewCategoryShouldAnnounceCategoryAdded [
+SlotAnnouncementsTest >> testClassAddedToNewPackageShouldAnnouncePackageAdded [
 
-	self subscribeOn: CategoryAdded.
+	self subscribeOn: PackageAdded.
 
 	self deny: (self packageOrganizer hasPackage: self slotTestPackageName).
 
@@ -198,12 +198,12 @@ SlotAnnouncementsTest >> testClassRecategorizationShouldAnnounceClassModified [
 	self subscribeOn: ClassRecategorized.
 
 	aClass := self make: [ :builder | builder package: self slotTestPackageName ].
-	anotherClass := self make: [ :builder | builder package: self anotherCategory ].
+	anotherClass := self make: [ :builder | builder package: self slotTestPackageName , '2' ].
 
 	self assert: self collectedAnnouncements size equals: 1.
 	announcement := self collectedAnnouncements first.
 	self assert: announcement oldCategory equals: self slotTestPackageName.
-	self assert: announcement newCategory equals: self anotherCategory.
+	self assert: announcement newCategory equals: self slotTestPackageName , '2'.
 	self assert: announcement classRecategorized identicalTo: anotherClass
 ]
 

--- a/src/Slot-Tests/SlotAnnouncementsTest.class.st
+++ b/src/Slot-Tests/SlotAnnouncementsTest.class.st
@@ -38,7 +38,7 @@ SlotAnnouncementsTest >> createClassWithLayout: aLayoutClass traitComposition: a
 			name: self aClassName;
 			layoutClass: aLayoutClass;
 			traitComposition: aTraitComposition asTraitComposition;
-			package: self aCategory ]
+			package: self slotTestPackageName ]
 ]
 
 { #category : #'tests - integration' }
@@ -171,11 +171,11 @@ SlotAnnouncementsTest >> testClassAddedToNewCategoryShouldAnnounceCategoryAdded 
 
 	self subscribeOn: CategoryAdded.
 
-	self deny: (self packageOrganizer includesCategory: self aCategory).
+	self deny: (self packageOrganizer hasPackage: self slotTestPackageName).
 
 	self createClass.
 
-	self assert: (self packageOrganizer includesCategory: self aCategory).
+	self assert: (self packageOrganizer hasPackage: self slotTestPackageName).
 
 	self assert: self collectedAnnouncements size equals: 1
 ]
@@ -194,14 +194,15 @@ SlotAnnouncementsTest >> testClassCreationShouldAnnounceClassAdded [
 
 { #category : #tests }
 SlotAnnouncementsTest >> testClassRecategorizationShouldAnnounceClassModified [
+
 	self subscribeOn: ClassRecategorized.
 
-	aClass := self make: [ :builder | builder category: self aCategory ].
-	anotherClass := self make: [ :builder | builder category: self anotherCategory ].
+	aClass := self make: [ :builder | builder package: self slotTestPackageName ].
+	anotherClass := self make: [ :builder | builder package: self anotherCategory ].
 
 	self assert: self collectedAnnouncements size equals: 1.
 	announcement := self collectedAnnouncements first.
-	self assert: announcement oldCategory equals: self aCategory.
+	self assert: announcement oldCategory equals: self slotTestPackageName.
 	self assert: announcement newCategory equals: self anotherCategory.
 	self assert: announcement classRecategorized identicalTo: anotherClass
 ]

--- a/src/Slot-Tests/SlotClassBuilderTest.class.st
+++ b/src/Slot-Tests/SlotClassBuilderTest.class.st
@@ -10,11 +10,6 @@ Class {
 }
 
 { #category : #'helpers-names' }
-SlotClassBuilderTest >> aCategory [
-	^ 'SlotTestsTmp'
-]
-
-{ #category : #'helpers-names' }
 SlotClassBuilderTest >> aClassName [
 	^ #SlotTestsClassA
 ]
@@ -65,7 +60,7 @@ SlotClassBuilderTest >> make: anUnaryBlock [
 			  superclass: Object;
 			  name: self aClassName;
 			  layoutClass: FixedLayout;
-			  package: self aCategory.
+			  package: self slotTestPackageName.
 		  anUnaryBlock value: builder ]
 ]
 
@@ -87,6 +82,11 @@ SlotClassBuilderTest >> makeWithLayout: aClassLayout andSlots: someSlots [
 		]
 ]
 
+{ #category : #'helpers-names' }
+SlotClassBuilderTest >> slotTestPackageName [
+	^ 'SlotTestsTmp'
+]
+
 { #category : #running }
 SlotClassBuilderTest >> tearDown [
 	"We remove the classes that could have been created during test run"
@@ -104,9 +104,7 @@ SlotClassBuilderTest >> tearDown [
 		cleanUpTrait: TOne;
 		cleanUpTrait: TTwo.
 
-	self flag: #package. "This category line should be removed be it's not yet possible."
-	self packageOrganizer removeCategory: self aCategory.
-	self packageOrganizer removePackage: self aCategory.
+	self packageOrganizer removePackage: self slotTestPackageName.
 
 	super tearDown
 ]

--- a/src/Slot-Tests/SlotClassBuilderTest.class.st
+++ b/src/Slot-Tests/SlotClassBuilderTest.class.st
@@ -15,11 +15,6 @@ SlotClassBuilderTest >> aClassName [
 ]
 
 { #category : #'helpers-names' }
-SlotClassBuilderTest >> anotherCategory [
-	^ 'SlotTestsTmp-Another'
-]
-
-{ #category : #'helpers-names' }
 SlotClassBuilderTest >> anotherClassName [
 	^ #SlotTestsClassB
 ]

--- a/src/Slot-Tests/SlotClassBuilderTest.class.st
+++ b/src/Slot-Tests/SlotClassBuilderTest.class.st
@@ -60,14 +60,13 @@ SlotClassBuilderTest >> layoutClassesWithSlots [
 SlotClassBuilderTest >> make: anUnaryBlock [
 	"I build a class for testing, providing basic default values, but eventually customized by the received unary block."
 
-	^Smalltalk classInstaller make: [:builder|
-		builder
-			superclass: Object;
-			name: self aClassName;
-			layoutClass: FixedLayout;
-			category: self aCategory.
-		anUnaryBlock value: builder
-		]
+	^ Smalltalk classInstaller make: [ :builder |
+		  builder
+			  superclass: Object;
+			  name: self aClassName;
+			  layoutClass: FixedLayout;
+			  package: self aCategory.
+		  anUnaryBlock value: builder ]
 ]
 
 { #category : #'helpers-building' }
@@ -93,10 +92,11 @@ SlotClassBuilderTest >> tearDown [
 	"We remove the classes that could have been created during test run"
 
 	SystemAnnouncer uniqueInstance suspendAllWhile: [
-		{ self aClassName. self anotherClassName. self yetAnotherClassName. self yetYetAnotherClassName } do: [ :each |
-			testingEnvironment
-				at: each
-				ifPresent: [ :class | class removeFromSystem ]]].
+		{
+			self aClassName.
+			self anotherClassName.
+			self yetAnotherClassName.
+			self yetYetAnotherClassName } do: [ :each | testingEnvironment at: each ifPresent: [ :class | class removeFromSystem ] ] ].
 
 	SystemAnnouncer uniqueInstance unsubscribe: self.
 
@@ -104,11 +104,9 @@ SlotClassBuilderTest >> tearDown [
 		cleanUpTrait: TOne;
 		cleanUpTrait: TTwo.
 
+	self flag: #package. "This category line should be removed be it's not yet possible."
 	self packageOrganizer removeCategory: self aCategory.
-	(RPackageOrganizer default
-		packageNamed: self aCategory
-		ifAbsent: [ ^ self ])
-		unregister.
+	self packageOrganizer removePackage: self aCategory.
 
 	super tearDown
 ]

--- a/src/Slot-Tests/SlotErrorsTest.class.st
+++ b/src/Slot-Tests/SlotErrorsTest.class.st
@@ -218,7 +218,7 @@ SlotErrorsTest >> testUndeclareSlotFixWhenSlotIsLoaded [
 		aClassBuilder
 			name: self anotherClassName;
 			superclass: PropertySlot;
-			package: self aCategory ].
+			package: self slotTestPackageName ].
 
 	self assert: (slot read: instance) equals: nil.
 

--- a/src/Slot-Tests/SlotIntegrationTest.class.st
+++ b/src/Slot-Tests/SlotIntegrationTest.class.st
@@ -276,7 +276,7 @@ SlotIntegrationTest >> testReshapeClassPropagatesToDeepHierarchyClassInterface [
 	aClass := self class classInstaller make: [ :aClassBuilder |
 		aClassBuilder
 			name: self aClassName;
-			package: self aCategory ].
+			package: self slotTestPackageName ].
 
 	self assertEmpty: aClass subclasses.
 	aClass classLayout checkIntegrity.
@@ -285,7 +285,7 @@ SlotIntegrationTest >> testReshapeClassPropagatesToDeepHierarchyClassInterface [
 		aClassBuilder
 			name: self anotherClassName;
 			superclass: aClass;
-			package: self aCategory ].
+			package: self slotTestPackageName ].
 
 	self assert: aClass subclasses equals: {anotherClass}.
 	self assertEmpty: anotherClass subclasses.
@@ -296,7 +296,7 @@ SlotIntegrationTest >> testReshapeClassPropagatesToDeepHierarchyClassInterface [
 		aClassBuilder
 			name: self yetAnotherClassName;
 			superclass: anotherClass;
-			package: self aCategory ].
+			package: self slotTestPackageName ].
 
 
 	self assert: aClass subclasses equals: {anotherClass}.
@@ -309,7 +309,7 @@ SlotIntegrationTest >> testReshapeClassPropagatesToDeepHierarchyClassInterface [
 	"level 4"
 	yetYetAnotherClass := (yetAnotherClass
 		<< self yetYetAnotherClassName
-		package: self aCategory) install.
+		package: self slotTestPackageName) install.
 
 	self assert: aClass subclasses equals: {anotherClass}.
 	self assert: anotherClass subclasses equals: {yetAnotherClass}.
@@ -325,7 +325,7 @@ SlotIntegrationTest >> testReshapeClassPropagatesToDeepHierarchyClassInterface [
 		aClassBuilder
 			name: self aClassName;
 			slotsFromString: 'x';
-			package: self aCategory ].
+			package: self slotTestPackageName ].
 
 	self assert: aClass instVarNames equals: #(x).
 	aClass classLayout checkIntegrity.
@@ -340,7 +340,7 @@ SlotIntegrationTest >> testReshapeClassWithClassSlot [
 	aClass := self class classInstaller make: [ :aClassBuilder |
 		aClassBuilder
 			name: self aClassName;
-			package: self aCategory ].
+			package: self slotTestPackageName ].
 
 	aClass class
 		instanceVariableNames: #x.
@@ -351,7 +351,7 @@ SlotIntegrationTest >> testReshapeClassWithClassSlot [
 		aClassBuilder
 			name: self aClassName;
 			slotsFromString: 'x';
-			package: self aCategory ].
+			package: self slotTestPackageName ].
 
 	self assert: aClass class instVarNames equals: #(x)
 ]


### PR DESCRIPTION
This change is updating the slots tests to use the Package API instead of the categories API.

Depends on https://github.com/pharo-project/pharo/pull/14309