### PR TITLE
Improve package cleaning API

### DIFF
--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -149,11 +149,11 @@ BaselineOfMorphic >> cleanUpAfterMorphicInitialization [
 	Symbol rehash.
 
 	"Remove empty packages and protocols"
-	self packageOrganizer removeEmptyPackages.
+	self packageOrganizer removeEmptyPackagesAndTags.
 	Smalltalk allClassesAndTraitsDo: [ :class |
 		class removeEmptyProtocols.
-		class class removeEmptyProtocols  ].
-  
+		class class removeEmptyProtocols ].
+
 	ChangeSet removeChangeSetsNamedSuchThat: [ :each | true ].
 	ChangeSet resetCurrentToNewUnnamedChangeSet.
 	Smalltalk garbageCollect.

--- a/src/Deprecated12/RPackageOrganizer.extension.st
+++ b/src/Deprecated12/RPackageOrganizer.extension.st
@@ -1,6 +1,27 @@
 Extension { #name : #RPackageOrganizer }
 
 { #category : #'*Deprecated12' }
+RPackageOrganizer >> categoryOfElement: behaviorName [
+
+	self deprecated: 'Use #categoryOfBehavior: instead' transformWith: '`@rcv categoryOfElement: `@arg' -> '`@rcv categoryOfBehavior: `@arg'.
+	^ self categoryOfBehavior: behaviorName
+]
+
+{ #category : #'*Deprecated12' }
+RPackageOrganizer >> includesPackage: aPackage [
+
+	self deprecated: 'Use #hasPackage: instead.' transformWith: '`@rcv includesPackage: `@arg' -> '`@rcv hasPackage: `@arg'.
+	^ self hasPackage: aPackage
+]
+
+{ #category : #'*Deprecated12' }
+RPackageOrganizer >> includesPackageNamed: aSymbol [
+
+	self deprecated: 'Use #hasPackage: instead.' transformWith: '`@rcv includesPackageNamed: `@arg' -> '`@rcv hasPackage: `@arg'.
+	^ self hasPackage: aSymbol
+]
+
+{ #category : #'*Deprecated12' }
 RPackageOrganizer >> packageExactlyMatchingExtensionName: anExtensionName [
 	"only look for a package for which the name match 'anExtensionName', making no difference about case. Return nil if no package is found"
 
@@ -15,6 +36,20 @@ RPackageOrganizer >> registerPackageNamed: aString [
 
 	self deprecated: 'Use #ensurePackage: instead.' transformWith: '`@rcv registerPackageNamed: `@arg' -> '`@rcv ensurePackage: `@arg'.
 	^ self ensurePackage: aString
+]
+
+{ #category : #'*Deprecated12' }
+RPackageOrganizer >> removeElement: behaviorName [
+
+	self deprecated: 'Use #removeBehavior: instead' transformWith: '`@rcv removeElement: `@arg' -> '`@rcv removeBehavior: `@arg'.
+	^ self removeBehavior: behaviorName
+]
+
+{ #category : #'*Deprecated12' }
+RPackageOrganizer >> removeEmptyPackages [
+
+	self deprecated: 'Use #removeEmptyPackagesAndTags instead' transformWith: '`@rcv removeEmptyPackages' -> '`@rcv removeEmptyPackagesAndTags'.
+	self removeEmptyPackagesAndTags
 ]
 
 { #category : #'*Deprecated12' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -1218,6 +1218,12 @@ RPackage >> removeClassesMatchingTag: aTag [
 	aTag classes do: [ :class | self removeClassDefinition: class ]
 ]
 
+{ #category : #'class tags' }
+RPackage >> removeEmptyTags [
+
+	(self classTags select: [ :tag | tag isEmpty ]) do: [ :emptyTag | self removeClassTag: emptyTag name ]
+]
+
 { #category : #removing }
 RPackage >> removeFromSystem [
 

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -878,8 +878,9 @@ RPackage >> isDeprecated [
 
 { #category : #testing }
 RPackage >> isEmpty [
-	self name = self class defaultPackageName ifTrue: [ ^false ].
-	^self classes isEmpty and: [ self extensionSelectors isEmpty]
+
+	self name = self class defaultPackageName ifTrue: [ ^ false ].
+	^ self classes isEmpty and: [ self extensionSelectors isEmpty ]
 ]
 
 { #category : #'system compatibility' }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -256,13 +256,6 @@ RPackageOrganizer >> categoryOfBehavior: behavior [
 	^ nil
 ]
 
-{ #category : #'deprecated - SystemOrganizer leftovers' }
-RPackageOrganizer >> categoryOfElement: behaviorName [
-
-	self deprecated: 'Use #categoryOfBehavior: instead' transformWith: '`@rcv categoryOfElement: `@arg' -> '`@rcv categoryOfBehavior: `@arg'.
-	^ self categoryOfBehavior: behaviorName
-]
-
 { #category : #'private - registration' }
 RPackageOrganizer >> checkPackageExistsOrRegister: packageName [
 
@@ -457,24 +450,10 @@ RPackageOrganizer >> includesCategory: aString [
 		  ifNotNil: [ :categories | categories includes: aString ]
 ]
 
-{ #category : #deprecated }
-RPackageOrganizer >> includesPackage: aPackage [
-
-	self deprecated: 'Use #hasPackage: instead.' transformWith: '`@rcv includesPackage: `@arg' -> '`@rcv hasPackage: `@arg'.
-	^ self hasPackage: aPackage
-]
-
 { #category : #'private - testing' }
 RPackageOrganizer >> includesPackageBackPointerForClass: aClass [
 
 	^ classPackageMapping includesKey: aClass instanceSide name asSymbol
-]
-
-{ #category : #deprecated }
-RPackageOrganizer >> includesPackageNamed: aSymbol [
-
-	self deprecated: 'Use #hasPackage: instead.' transformWith: '`@rcv includesPackageNamed: `@arg' -> '`@rcv hasPackage: `@arg'.
-	^ self hasPackage: aSymbol
 ]
 
 { #category : #initialization }
@@ -840,20 +819,12 @@ RPackageOrganizer >> removeCategory: category [
 	SystemAnnouncer uniqueInstance classCategoryRemoved: category
 ]
 
-{ #category : #'deprecated - SystemOrganizer leftovers' }
-RPackageOrganizer >> removeElement: behaviorName [
+{ #category : #cleanup }
+RPackageOrganizer >> removeEmptyPackagesAndTags [
+	"Remove empty packages and tags."
 
-	self deprecated: 'Use #removeBehavior: instead' transformWith: '`@rcv removeElement: `@arg' -> '`@rcv removeBehavior: `@arg'.
-	^ self removeBehavior: behaviorName
-]
-
-{ #category : #'deprecated - SystemOrganizer leftovers' }
-RPackageOrganizer >> removeEmptyPackages [
-	"Remove empty packages."
-
-	(categoryMap select: [ :classes | classes isEmpty ]) keys
-		ifNotEmpty: [ :emptyPackages |
-			emptyPackages do: [ :emptyPackage | categoryMap removeKey: emptyPackage ] ]
+	self packages do: [ :package | package removeEmptyTags ].
+	(self packages select: [ :package | package isEmpty ]) do: [ :emptyPackage | self removePackage: emptyPackage ]
 ]
 
 { #category : #registration }

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -310,6 +310,53 @@ RPackageOrganizerTest >> testRegistrationExtendingPackages [
 ]
 
 { #category : #tests }
+RPackageOrganizerTest >> testRemoveEmptyPackagesAndTags [
+
+	| organizer package1 package2 package3 package4 class tag1 tag2 |
+	"This one will contain a class"
+	package1 := (self createNewPackageNamed: #Test1) register.
+	"This one will contain an extension method"
+	package2 := (self createNewPackageNamed: #Test2) register.
+	"This one will contain a tag with a class and an empty tag"
+	package3 := (self createNewPackageNamed: #Test3) register.
+	"This one will be empty"
+	package4 := (self createNewPackageNamed: #Test4) register.
+
+	tag1 := package3 addClassTag: #Tag1.
+	tag2 := package3 addClassTag: #Tag2.
+
+	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1'.
+	class compile: 'extension ^ 1' classified: '*Test2'.
+	
+	class := self createNewClassNamed: 'TestClass2' inCategory: 'Test3-Tag1'.
+
+	self flag: #package. "Use the organizer provided by the tests later."
+	organizer := package1 organizer.
+
+	self assert: (organizer hasPackage: package1).
+	self deny: package1 isEmpty.
+	self assert: (organizer hasPackage: package2).
+	self deny: package2 isEmpty.
+	self assert: (organizer hasPackage: package3).
+	self deny: package3 isEmpty.
+	self deny: tag1 isEmpty.
+	self assert: tag2 isEmpty.
+	self assert: (package3 includesClassTagNamed: #Tag1).
+	self assert: (package3 includesClassTagNamed: #Tag2).
+	self assert: (organizer hasPackage: package4).
+	self assert: package4 isEmpty.
+
+	organizer removeEmptyPackagesAndTags.
+
+	self assert: (organizer hasPackage: package1).
+	self assert: (organizer hasPackage: package2).
+	self assert: (organizer hasPackage: package3).
+	self assert: (package3 includesClassTagNamed: #Tag1).
+	self deny: (package3 includesClassTagNamed: #Tag2).
+	self deny: (organizer hasPackage: package4)
+]
+
+{ #category : #tests }
 RPackageOrganizerTest >> testRemovePackage [
 
 	| p1 p2 p3 a1 a2 b1 b2 a3 |

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -293,6 +293,30 @@ RPackageTest >> testPropertyAtPut [
 ]
 
 { #category : #tests }
+RPackageTest >> testRemoveEmptyTags [
+
+	| package class tag1 tag2 |
+	package := (self createNewPackageNamed: #Test1) register.
+
+	tag1 := package addClassTag: #Tag1.
+	tag2 := package addClassTag: #Tag2.
+
+	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-Tag1'.
+
+	self assert: (tag1 includesClass: class).
+	self deny: tag1 isEmpty.
+	self assert: tag2 isEmpty.
+
+	self assert: (package includesClassTagNamed: #Tag1).
+	self assert: (package includesClassTagNamed: #Tag2).
+
+	package removeEmptyTags.
+
+	self assert: (package includesClassTagNamed: #Tag1).
+	self deny: (package includesClassTagNamed: #Tag2)
+]
+
+{ #category : #tests }
 RPackageTest >> testRenameToMakesMCDirty [
 	| package |
 

--- a/src/SUnit-Core/ClassFactoryWithOrganization.class.st
+++ b/src/SUnit-Core/ClassFactoryWithOrganization.class.st
@@ -22,11 +22,9 @@ ClassFactoryWithOrganization class >> newWithOrganization: aSystemOrganizer [
 { #category : #cleaning }
 ClassFactoryWithOrganization >> deletePackage [
 
-	| categoriesMatchString |
-	categoriesMatchString := self packageName , '-*'.
 	self organization
-		removeCategoriesMatching: categoriesMatchString;
-		removeEmptyPackages
+		removeCategoriesMatching: self packageName , '-*';
+		removeEmptyPackagesAndTags
 ]
 
 { #category : #creating }

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1526,7 +1526,7 @@ SmalltalkImage >> removeEmptyMessageCategories [
 
 	self garbageCollect.
 	SystemNavigation default allBehaviorsDo: [ :class | class removeEmptyProtocols ].
-	self packageOrganizer removeEmptyPackages
+	self packageOrganizer removeEmptyPackagesAndTags
 ]
 
 { #category : #shrinking }

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -210,7 +210,7 @@ ImageCleaner >> removeEmptyCategories [
 	"Remove empty categories, which are not in MC packages, because MC does
 	not do this (this script does not make packages dirty)"
 
-	self packageOrganizer removeEmptyPackages.
+	self packageOrganizer removeEmptyPackagesAndTags.
 	Smalltalk allClassesAndTraitsDo: [ :class |
 		class removeEmptyProtocols.
 		class class removeEmptyProtocols ]


### PR DESCRIPTION
The cleaning of the system is mostly done through the SystemOrganizer currently. In order to remove more users of the SystemOrganizer I want to improve the cleaning API of RPackage.

First this PR adds RPackage>>#removeEmptyTags with a test.
It also adds RPAckageOrganizer>>#removeEmptyPackagesAndTags with a test.

It deprecates #removeEmptyPackages and updates the senders for two reasons:
- The implementation was based on the SystemOrganizer and we want to get rid of it
- The name was not fitting since it let the user think we were removing only the packages and not the tags.