### PR TITLE
Replace 'controling' protocol with 'controlling'

### DIFF
--- a/src/Calypso-Browser/ClyBrowserModeSwitchMorph.class.st
+++ b/src/Calypso-Browser/ClyBrowserModeSwitchMorph.class.st
@@ -53,7 +53,7 @@ ClyBrowserModeSwitchMorph >> isModeActive [
 	^activator isCommandAppliedToBrowser
 ]
 
-{ #category : #controling }
+{ #category : #controlling }
 ClyBrowserModeSwitchMorph >> toggleMode: aBool [
 
 	self executeCommand

--- a/src/Calypso-SystemTools-FullBrowser/ClySwitchToMethodGroupsCommand.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClySwitchToMethodGroupsCommand.class.st
@@ -8,7 +8,7 @@ Class {
 	#category : #'Calypso-SystemTools-FullBrowser-Commands-MethodGroups'
 }
 
-{ #category : #controling }
+{ #category : #controlling }
 ClySwitchToMethodGroupsCommand >> execute [
 	browser switchToMethodGroups
 ]

--- a/src/Calypso-SystemTools-FullBrowser/ClySwitchToVariablesCommand.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClySwitchToVariablesCommand.class.st
@@ -8,7 +8,7 @@ Class {
 	#category : #'Calypso-SystemTools-FullBrowser-Commands-MethodGroups'
 }
 
-{ #category : #controling }
+{ #category : #controlling }
 ClySwitchToVariablesCommand >> execute [
 	browser switchToVariables
 ]


### PR DESCRIPTION
The correct spelling is 'controlling'.