### PR TITLE
Do not use deprecated API to create the default package

### DIFF
--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -323,7 +323,8 @@ RPackageOrganizer >> debuggingName: aString [
 
 { #category : #initialization }
 RPackageOrganizer >> defineUnpackagedClassesPackage [
-	^ self ensureExistAndRegisterPackageNamed: RPackage defaultPackageName
+
+	^ self ensurePackage: RPackage defaultPackageName
 ]
 
 { #category : #'private - deprecated' }


### PR DESCRIPTION
See title.
Tiny change because removing all references to ensureExistAndRegisterPackageNamed: breaks the bootstrap