### PR TITLE
Make sure packages created with protocols are announced

### DIFF
--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -1133,9 +1133,13 @@ RPackageOrganizer >> systemMethodRecategorizedActionFrom: ann [
 	method origin = ann methodClass ifFalse: [ ^ self ].
 	(self packageOfClassNamed: ann methodClass instanceSide name) ifNil: [ ^ self ].
 
-	newProtocol := ann newProtocol ifNotNil: [ :protocol | protocol name ] ifNil: [ ^ self ].
+	newProtocol := ann newProtocol
+		               ifNotNil: [ :protocol | protocol name ]
+		               ifNil: [ ^ self ].
 
-	oldProtocol := ann oldProtocol ifNotNil: [ :protocol | protocol name ] ifNil: [ '' ].
+	oldProtocol := ann oldProtocol
+		               ifNotNil: [ :protocol | protocol name ]
+		               ifNil: [ '' ].
 
 	methodPackage := method packageFromOrganizer: self.
 	newProtocol asLowercase = oldProtocol asLowercase ifTrue: [ ^ self ].
@@ -1144,7 +1148,7 @@ RPackageOrganizer >> systemMethodRecategorizedActionFrom: ann [
 		                      ifTrue: [ self packageForProtocol: newProtocol inClass: method methodClass ]
 		                      ifFalse: [
 			                      (newProtocol beginsWith: '*')
-				                      ifTrue: [ self ensureExistAndRegisterPackageNamed: newProtocol allButFirst capitalized ]
+				                      ifTrue: [ self ensurePackage: newProtocol allButFirst capitalized ]
 				                      ifFalse: [ method methodClass package ] ].
 
 	methodPackage := (self hasPackageForProtocol: oldProtocol)


### PR DESCRIPTION
When we create an extension method in a package that does not exist, a package is created. For now, the way to create the package is not nice and does not announce the creation. 

Let's try to announce it and see if the bootstrap work.