### PR TITLE
Improve package API used by Calypso

### DIFF
--- a/src/Calypso-SystemPlugins-SUnit-Browser/TClyGenerateTestClass.trait.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/TClyGenerateTestClass.trait.st
@@ -62,7 +62,7 @@ TClyGenerateTestClass >> testClassFor: inputClass [
 		ifPresent: [ :class | resultClass := class ]
 		ifAbsent: [
 			(self isValidClass: inputClass) ifFalse: [ ClyInvalidClassForTestClassGeneration signalFor: inputClass ].
-			self systemEnvironment ensureExistAndRegisterPackageNamed: inputClass package name asString , '-Tests'.
+			self systemEnvironment ensurePackage: inputClass package name asString , '-Tests'.
 
 			resultClass := self class classInstaller make: [ :aBuilder |
 				aBuilder name: className;

--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -179,8 +179,9 @@ ClySystemEnvironment >> defaultClassCompiler [
 ]
 
 { #category : #'package management' }
-ClySystemEnvironment >> ensureExistAndRegisterPackageNamed: packageName [
-	^packageOrganizer ensureExistAndRegisterPackageNamed: packageName
+ClySystemEnvironment >> ensurePackage: packageName [
+
+	^ packageOrganizer ensurePackage: packageName
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Calypso is using a package API that is not good because it does not announce package creation. 

This change fixes it. With other PR I did, all places uring this API should be removed and we should be able to deprecate the method #ensureExistAndRegisterPackageNamed: