### PR TITLE
Use "protocol" vocabulary in MCTestCase

### DIFF
--- a/src/Monticello-Tests/MCPackageTest.class.st
+++ b/src/Monticello-Tests/MCPackageTest.class.st
@@ -8,8 +8,8 @@ Class {
 MCPackageTest >> aMethodRemoved: anEvent [
 	"Force cleaning of the protocol."
 
-	(anEvent protocol name = self mockExtensionMethodCategory and: [ anEvent methodClass == MCSnapshotTest ]) ifTrue: [
-		anEvent methodClass removeProtocolIfEmpty: self mockExtensionMethodCategory ]
+	(anEvent protocol name = self mockExtensionProtocol and: [ anEvent methodClass == MCSnapshotTest ]) ifTrue: [
+		anEvent methodClass removeProtocolIfEmpty: self mockExtensionProtocol ]
 ]
 
 { #category : #running }
@@ -26,7 +26,7 @@ MCPackageTest >> testUnload [
 	self mockPackage unload.
 	self deny: (testingEnvironment hasClassNamed: #MCMockClassA).
 	self deny: (MCSnapshotTest includesSelector: #mockClassExtension).
-	self deny: (MCSnapshotTest hasProtocol: self mockExtensionMethodCategory).
+	self deny: (MCSnapshotTest hasProtocol: self mockExtensionProtocol).
 	mock := testingEnvironment at: #MCMock.
 	self assert: (mock subclasses
 			 detect: [ :c | c name = #MCMockClassA ]
@@ -43,7 +43,7 @@ MCPackageTest >> testUnloadWithAdditionalTracking [
 	self mockPackage unload.
 	self deny: (testingEnvironment hasClassNamed: #MCMockClassA).
 	self deny: (MCSnapshotTest includesSelector: #mockClassExtension).
-	self deny: (MCSnapshotTest hasProtocol: self mockExtensionMethodCategory).
+	self deny: (MCSnapshotTest hasProtocol: self mockExtensionProtocol).
 	mock := testingEnvironment at: #MCMock.
 	self assert: (mock subclasses
 			 detect: [ :c | c name = #MCMockClassA ]

--- a/src/Monticello-Tests/MCTestCase.class.st
+++ b/src/Monticello-Tests/MCTestCase.class.st
@@ -52,10 +52,8 @@ MCTestCase >> assertVersionInfo: actual matches: expected [
 
 { #category : #compiling }
 MCTestCase >> change: aSelector toReturn: anObject [
-	self 
-		compileClass: self mockClassA 
-		source: aSelector, ' ^ ', anObject printString 
-		category: 'numeric'
+
+	self mockClassA compileSilently: aSelector , ' ^ ' , anObject printString classified: 'numeric'
 ]
 
 { #category : #mocks }
@@ -66,11 +64,6 @@ MCTestCase >> commentForClass: name [
 { #category : #mocks }
 MCTestCase >> commentStampForClass: name [
 	^ 'tester-', name,  ' 1/1/2000 00:00'
-]
-
-{ #category : #compiling }
-MCTestCase >> compileClass: aClass source: source category: category [
-	aClass compileSilently: source classified: category
 ]
 
 { #category : #mocks }
@@ -117,6 +110,13 @@ MCTestCase >> mockEmptyPackage [
 
 { #category : #mocks }
 MCTestCase >> mockExtensionMethodCategory [
+
+	self deprecated: 'Use mockExtensionProtocol instead.' transformWith: '`@rcv mockExtensionMethodCategory' -> '`@rcv mockExtensionProtocol'.
+	^ self mockExtensionProtocol
+]
+
+{ #category : #mocks }
+MCTestCase >> mockExtensionProtocol [
 	^ '*MonticelloMocks'
 ]
 
@@ -140,11 +140,6 @@ MCTestCase >> mockMethod: aSymbol class: className source: sourceString meta: aB
 		  category: Protocol unclassified
 		  timeStamp: ''
 		  source: sourceString
-]
-
-{ #category : #mocks }
-MCTestCase >> mockOverrideMethodCategory [
-	^ self mockExtensionMethodCategory, '-override'
 ]
 
 { #category : #mocks }


### PR DESCRIPTION
Use "Protocol" instead of "Category" in MCTestCase