### PR TITLE
Iterate over a copy of the actionMap in Object>>removeActionsSatisfying: (fixes #14317)

### DIFF
--- a/src/System-Object Events-Tests/EventManagerTest.class.st
+++ b/src/System-Object Events-Tests/EventManagerTest.class.st
@@ -209,6 +209,35 @@ EventManagerTest >> testRemoveActionsWithReceiver [
 	self assert: ((eventSource hasActionsWithReceiver: self) not)
 ]
 
+{ #category : #'running - remove actions' }
+EventManagerTest >> testRemoveManyActionsSatisfying [
+	"See issue #14317--removing many actions wwould sometimes fail due to modification-under-iteration."
+
+	1 to: 10 do: [ :i |
+		eventSource
+			when: (#event , i printString) asSymbol
+			send: (#message , i printString) asSymbol
+			to: self ].
+	self assert: (eventSource hasActionsWithReceiver: self).
+	"Real code should use #removeActionsWithReceiver:, but this is a convenient condition to use here."
+	eventSource removeActionsSatisfying: [ :each | each receiver == self ].
+	self deny: (eventSource hasActionsWithReceiver: self)
+]
+
+{ #category : #'running - remove actions' }
+EventManagerTest >> testRemoveManyActionsWithReceiver [
+	"See issue #14317--removing many actions wwould sometimes fail due to modification-under-iteration."
+
+	1 to: 10 do: [ :i |
+		eventSource
+			when: (#event , i printString) asSymbol
+			send: (#message , i printString) asSymbol
+			to: self ].
+	self assert: (eventSource hasActionsWithReceiver: self).
+	eventSource removeActionsWithReceiver: self.
+	self deny: (eventSource hasActionsWithReceiver: self)
+]
+
 { #category : #'running - dependent value' }
 EventManagerTest >> testReturnValueWithManyListeners [
 

--- a/src/System-Object Events/Object.extension.st
+++ b/src/System-Object Events/Object.extension.st
@@ -96,7 +96,7 @@ Object >> removeActionsForEvent: anEventSelector [
 { #category : #'*System-Object Events' }
 Object >> removeActionsSatisfying: aBlock [
 
-	self actionMap keysDo:
+	self actionMap copy keysDo:
 		[:eachEventSelector |
 			self
    				removeActionsSatisfying: aBlock
@@ -118,12 +118,8 @@ forEvent: anEventSelector [
 { #category : #'*System-Object Events' }
 Object >> removeActionsWithReceiver: anObject [
 
-	self actionMap copy keysDo:
-		[:eachEventSelector |
-			self
-   				removeActionsSatisfying: [:anAction | anAction receiver == anObject]
-				forEvent: eachEventSelector
-		]
+	self removeActionsSatisfying: [ :anAction |
+		anAction receiver == anObject ]
 ]
 
 { #category : #'*System-Object Events' }


### PR DESCRIPTION
Defer to this implementation rather than reimplementing it for #removeActionsWithReceiver:

Fixes #14317