### PR TITLE
Adapt check in RBAddMethodChange>>protocols: now that the argument may be a first-class Protocol (fixes #14324)

### DIFF
--- a/src/Refactoring-Changes/RBAddMethodChange.class.st
+++ b/src/Refactoring-Changes/RBAddMethodChange.class.st
@@ -214,11 +214,11 @@ RBAddMethodChange >> protocols [
 ]
 
 { #category : #'initialize-release' }
-RBAddMethodChange >> protocols: aCollectionOrString [
+RBAddMethodChange >> protocols: aCollectionOrProtocol [
 
-	protocols := aCollectionOrString isString
-		             ifTrue: [ { aCollectionOrString } ]
-		             ifFalse: [ aCollectionOrString ]
+	protocols := (aCollectionOrProtocol isCollection and: [ aCollectionOrProtocol isString not])
+		             ifTrue: [ aCollectionOrProtocol ]
+		             ifFalse: [  { aCollectionOrProtocol } ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Check if it's already a collection-but-not-a-string, otherwise wrap in an array, rather than checking if it *is* a string and wrapping in an array if so.

Fixes #14324