### PR TITLE
Class are created with the wrong environment

### DIFF
--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -14,6 +14,7 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'buildEnvironment',
+		'installingEnvironment',
 		'superclassName',
 		'name',
 		'layoutDefinition',
@@ -224,7 +225,7 @@ ShiftClassBuilder >> createClass [
 		withLayoutType: self layoutDefinition layoutClass
 		slots: self layoutDefinition slots.
 
-	newClass environment: self buildEnvironment environment.
+	newClass environment: self installingEnvironment environment.
 
 	self builderEnhancer classCreated: self
 ]
@@ -339,6 +340,19 @@ ShiftClassBuilder >> installSlotsAndVariables [
 	newClass classLayout slots do: [ :each | each installingIn: newClass ].
 	newClass class classLayout slots do: [ :each | each installingIn: newClass class ].
 	newClass classVariables do: [ :each | each installingIn: newClass ]
+]
+
+{ #category : #accessing }
+ShiftClassBuilder >> installingEnvironment [
+	"The build environment is used to find the classes used during the building of a class such as the layouts, and the installing environment is the environment in which the class should be installed."
+
+	^ installingEnvironment ifNil: [ self buildEnvironment ]
+]
+
+{ #category : #accessing }
+ShiftClassBuilder >> installingEnvironment: anObject [
+
+	installingEnvironment := anObject
 ]
 
 { #category : #accessing }

--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -304,8 +304,10 @@ ShClassInstallerTest >> testInstallInSpecificEnvironment [
 
 	self class environment at: #SHClassForTest ifPresent: [ self fail: 'The default environment should not have the class installed.' ].
 	newEnvironment at: #SHClassForTest ifAbsent: [ self fail: 'The default environment should not have the class installed.' ].
-	
-	self skip. 
+
+	self assert: newClass environment identicalTo: newEnvironment.
+
+	self skip.
 	self flag: #package. "ShiftClassInstaller>>#recategorize:to: is using the old SystemOrganizer system to classify classes, but this does not add the classes to the instance of RPackageOrganizer but to the default package organizer of the image instead. Until we can fix this, we cannot have the next assertions working. They are clearly a bug but it'll be hard to fix this bug in short term........ :("
 	self deny: (self packageOrganizer hasPackage: self generatedClassesPackageName).
 	self assert: (newEnvironment organization hasPackage: self generatedClassesPackageName)

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -23,8 +23,7 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'oldClass',
-		'builder',
-		'installingEnvironment'
+		'builder'
 	],
 	#category : #'Shift-ClassInstaller-Base'
 }
@@ -155,13 +154,13 @@ ShiftClassInstaller >> installSubclassInSuperclass: newClass [
 { #category : #building }
 ShiftClassInstaller >> installingEnvironment [
 
-	^ installingEnvironment ifNil: [ builder buildEnvironment ]
+	^ builder installingEnvironment
 ]
 
 { #category : #building }
 ShiftClassInstaller >> installingEnvironment: anEnvironment [
 
-	installingEnvironment := anEnvironment
+	builder installingEnvironment: anEnvironment
 ]
 
 { #category : #building }


### PR DESCRIPTION
A class knows the environment it is installed in (Class>>#environment). But in fact this is not working because the environment set to the class is the building environment and not the installing environment.

This change adds an assertion in a test to show this bug and propose a fix by moving the instralling environment from the class installer to the class builder and using this environment as the environment of the class.