### PR TITLE
Fix regex doc

### DIFF
--- a/doc/Regex/1-Introduction.md
+++ b/doc/Regex/1-Introduction.md
@@ -3,7 +3,7 @@
 A regular expression is a template specifying a class of strings. A regular expression matcher is a tool that determines whether a string belongs to a class specified by a regular expression. This is a common task of a user input validation code, and the use of regular expressions can greatly simplify and speed up the development of such code. As an example, here is how to verify that a string is a valid hexadecimal number in Smalltalk notation, using this matcher package:
 
 ```st
-	astring matchesRegex: '16r[[:xdigit:]]+'
+	aString matchesRegex: '16r[[:xdigit:]]+'
 ```
 
 (coding the same 'the hard way' is an exercise for a curious reader).

--- a/doc/Regex/3-Syntax.md
+++ b/doc/Regex/3-Syntax.md
@@ -3,9 +3,9 @@
 The simplest regular expression is a single character. It matches exactly that character. A sequence of characters matches a string with exactly the same sequence of characters:
 
 ```st
-	'a' matchesRegex: 'a'.              "true"
-	'foobar' matchesRegex: 'foobar'.    "true"
-	'blorple' matchesRegex: 'foobar'.   "false"
+	'a' matchesRegex: 'a'.				"true"
+	'foobar' matchesRegex: 'foobar'.	"true"
+	'blorple' matchesRegex: 'foobar'.	"false"
 ```
 
 The above paragraph introduced a primitive regular expression (a character), and an operator (sequencing). Operators are applied to regular expressions to produce more complex regular expressions. Sequencing (placing expressions one after another) as an operator is, in a certain sense, 'invisible' — yet it is arguably the most common.
@@ -13,55 +13,55 @@ The above paragraph introduced a primitive regular expression (a character), and
 A more 'visible' operator is Kleene closure, more often simply referred to as 'a star'. A regular expression followed by an asterisk matches any number (including 0) of matches of the original expression. For example:
 
 ```st
-	'ab' matchesRegex: 'a*b'.           "true"
-	'aaaaab' matchesRegex: 'a*b'.       "true"
-	'b' matchesRegex: 'a*b'.            "true"
-	'aac' matchesRegex: 'a*b'.          "false: b does not match"
+	'ab' matchesRegex: 'a*b'.			"true"
+	'aaaaab' matchesRegex: 'a*b'.		"true"
+	'b' matchesRegex: 'a*b'.			"true"
+	'aac' matchesRegex: 'a*b'.			"false: b does not match"
 ```
 
 A star's precedence is higher than that of sequencing. A star applies to the shortest possible subexpression that precedes it. For example, 'ab*' means 'a followed by zero or more occurrences of b', not 'zero or more occurrences of ab':
 
 ```st
-	'abbb' matchesRegex: 'ab*'.         "true"
-	'abab' matchesRegex: 'ab*'.         "false"
+	'abbb' matchesRegex: 'ab*'.		"true"
+	'abab' matchesRegex: 'ab*'.		"false"
 ```
 
 To actually make a regex matching 'zero or more occurrences of ab', 'ab' is enclosed in parentheses:
 
 ```st
-	'abab' matchesRegex: '(ab)*'.       "true"
-	'abcab' matchesRegex: '(ab)*'.      "false: c spoils the fun"
+	'abab' matchesRegex: '(ab)*'.		"true"
+	'abcab' matchesRegex: '(ab)*'.		"false: c spoils the fun"
 ```
 
 Two other operators similar to '*' are '+' and '?'. '+' (positive closure, or simply 'plus') matches one or more occurrences of the original expression. '?' ('optional') matches zero or one, but never more, occurrences.
 
 ```st
-	'ac' matchesRegex: 'ab*c'.          "true"
-	'ac' matchesRegex: 'ab+c'.          "false: need at least one b"
-	'abbc' matchesRegex: 'ab+c'.        "true"
-	'abbc' matchesRegex: 'ab?c'.        "false: too many b's"
+	'ac' matchesRegex: 'ab*c'.			"true"
+	'ac' matchesRegex: 'ab+c'.			"false: need at least one b"
+	'abbc' matchesRegex: 'ab+c'.		"true"
+	'abbc' matchesRegex: 'ab?c'.		"false: too many b's"
 ```
 
-As we have seen, characters '*', '+', '?', '(', and ')' have special meaning in regular expressions. If one of them is to be used literally, it should be quoted: preceded with a backslash. (Thus, backslash is also special character, and needs to be quoted for a literal match--as well as any other special character described further).
+As we have seen, characters '*', '+', '?', '(', and ')' have special meaning in regular expressions. If one of them is to be used literally, it should be quoted: preceded with a backslash. (Thus, backslash is also special character, and needs to be quoted for a literal match - as well as any other special character described further).
 
 ```st
-	'ab*' matchesRegex: 'ab*'.          "false: star in the right string is special"
-	'ab*' matchesRegex: 'ab\*'.         "true"
-	'a\c' matchesRegex: 'a\\c'.         "true"
+	'ab*' matchesRegex: 'ab*'.			"false: star in the right string is special"
+	'ab*' matchesRegex: 'ab\*'.		"true"
+	'a\c' matchesRegex: 'a\\c'.			"true"
 ```
 
 The last operator is `'|'` meaning 'or'. It is placed between two regular expressions, and the resulting expression matches if one of the expressions matches. It has the lowest possible precedence (lower than sequencing). For example, `'ab*|ba*'` means 'a followed by any number of b's, or b followed by any number of a's':
 
 ```st
-	'abb' matchesRegex: 'ab*|ba*'.      "true"
-	'baa' matchesRegex: 'ab*|ba*'.      "true"
-	'baab' matchesRegex: 'ab*|ba*'.     "false"
+	'abb' matchesRegex: 'ab*|ba*'.		"true"
+	'baa' matchesRegex: 'ab*|ba*'.		"true"
+	'baab' matchesRegex: 'ab*|ba*'.	"false"
 ```
 
 A bit more complex example is the following expression, matching the name of any of the Lisp-style 'car', 'cdr', 'caar', 'cadr',
 
 ```st
-	'cadr' matchesRegex: 'c(a|d)+r'.    "true"
+	'cadr' matchesRegex: 'c(a|d)+r'.	"true"
 ```
 
 It is possible to write an expression matching an empty string, for example: 'a|'. However, it is an error to apply '*', '+', or '?' to such expression: '(a|)*' is an invalid expression.
@@ -71,23 +71,23 @@ So far, we have used only characters as the 'smallest' components of regular exp
 A character set is a string of characters enclosed in square brackets. It matches any single character if it appears between the brackets. For example, `'[01]'` matches either `'0'` or `'1'`:
 
 ```st
-	'0' matchesRegex: '[01]'.           "true"
-	'3' matchesRegex: '[01]'.           "false"
-	'11' matchesRegex: '[01]'.          "false: a set matches only one character"
+	'0' matchesRegex: '[01]'.			"true"
+	'3' matchesRegex: '[01]'.			"false"
+	'11' matchesRegex: '[01]'.			"false: a set matches only one character"
 ```
 
 Using plus operator, we can build the following binary number recognizer:
 
 ```st
-	'10010100' matchesRegex: '[01]+'.   "true"
-	'10001210' matchesRegex: '[01]+'.   "false"
+	'10010100' matchesRegex: '[01]+'.	"true"
+	'10001210' matchesRegex: '[01]+'.	"false"
 ```
 
 If the first character after the opening bracket is `'^'`, the set is inverted: it matches any single character *not* appearing between the brackets:
 
 ```st
-	'0' matchesRegex: '[^01]'.          "false"
-	'3' matchesRegex: '[^01]'.          "true"
+	'0' matchesRegex: '[^01]'.			"false"
+	'3' matchesRegex: '[^01]'.			"true"
 ```
 
 For convenience, a set may include ranges: pairs of characters separated with '-'. This is equivalent to listing all characters between them: '[0-9]' is the same as '[0123456789]'.
@@ -151,10 +151,10 @@ The last group of special primitive expressions includes:
 - `\>`: an empty string at the end of a word
 
 ```st
-	'axyzb' matchesRegex: 'a.+b'.       "true"
-	'ax zb' matchesRegex: 'a.+b'.       "true (space is matched by '.')"
+	'axyzb' matchesRegex: 'a.+b'.		"true"
+	'ax zb' matchesRegex: 'a.+b'.		"true (space is matched by '.')"
 	'ax
-zb' matchesRegex: 'a.+b'.               "true (carriage return is matched by '.')"
+zb' matchesRegex: 'a.+b'.			"true (carriage return is matched by '.')"
 ```
 
 Again, the dot ., caret ^ and dollar $ characters are special and should be quoted to be matched literally.

--- a/doc/Regex/4-Usage.md
+++ b/doc/Regex/4-Usage.md
@@ -6,15 +6,17 @@ The preceding section covered the syntax of regular expressions. It used the sim
 
 A `String` also understands these messages:
 
+```text
 	prefixMatchesRegex: regexString
 	matchesRegexIgnoringCase: regexString
 	prefixMatchesRegexIgnoringCase: regexString
+```
 
 `String>>#prefixMatchesRegex:` is just like `String>>#matchesRegex:`, except that the whole receiver is not expected to match the regular expression passed as the argument; matching just a prefix of it is enough. For example:
 
 ```st
-	'abcde' matchesRegex: '(a|b)+'.         "false"
-	'abcde' prefixMatchesRegex: '(a|b)+'.   "true"
+	'abcde' matchesRegex: '(a|b)+'.		"false"
+	'abcde' prefixMatchesRegex: '(a|b)+'.	"true"
 ```
 
 The last two messages are case-insensitive versions of matching.
@@ -65,14 +67,14 @@ If you repeatedly match several strings against the same regular expression usin
 
 You can create a matcher using one of the following methods:
 
-- using `RxMatcher>>#forString:ignoreCase:` message, with the regular expression string and a Boolean indicating whether the case is ignored as arguments.
+- using `RxMatcher class>>#forString:ignoreCase:` message, with the regular expression string and a Boolean indicating whether the case is ignored as arguments.
 - Sending #forString: message. It is equivalent to `<aString forString: regexString ignoreCase: false>`.
 
 A more convenient way is using one of the two matcher-created messages understood by String.
 
-- `String>>#asRegex` is equivalent to `RxMatcher>>#forString:`
+- `String>>#asRegex` is equivalent to `RxMatcher class>>#forString:`
 
-- `String>>#asRegexIgnoringCase` is equivalent to `RxMatcher>>#forString:ignoreCase:`.
+- `String>>#asRegexIgnoringCase` is equivalent to `RxMatcher class>>#forString:ignoreCase:`.
 
 Here are four examples of creating a matcher:
 
@@ -88,7 +90,7 @@ Here are four examples of creating a matcher:
 The matcher understands these messages (all of them return true to indicate successful match or search, and false otherwise):
 
 - `RxMatcher>>#matches:`: True if the whole target string (aString) matches.
-- `Rxmatcher>>#matchesPrefix:`: True if some prefix of the string (not necessarily the whole string) matches.
+- `RxMatcher>>#matchesPrefix:`: True if some prefix of the string (not necessarily the whole string) matches.
 - `RxMatcher>>#search:`: Search the string for the first occurrence of a matching substring. (Note that the first two methods only try matching from the very beginning of the string). Using the above example with a matcher for `a+`, this method would answer success given a string `baaa`, while the previous two would fail.
 - `RxMatcher>>#matchesStream:`, `RxMatcher>>#matchesStreamPrefix:`, and `RxMatcher>>#searchStream:`: Respective analogs of the first three methods, taking input from a stream instead of a string. The stream must be positionable and peekable.
 
@@ -135,6 +137,7 @@ This facility provides a convenient way of extracting parts of the input strings
 The enumeration and replacement protocols exposed in `String`
 are actually implemented by the matcher. The following messages are understood:
 
+```text
 	matchesIn: aString
 	matchesIn: aString do: aBlock
 	matchesIn: aString collect: aBlock
@@ -147,6 +150,7 @@ are actually implemented by the matcher. The following messages are understood:
 	matchesOnStream: aStream collect: aBlock
 	copy: sourceStream to: targetStream replacingMatchesWith: replacementString
 	copy: sourceStream to: targetStream translatingMatchesWith: aBlock
+```
 
 Note that in those methods that take a block, the block may refer to the `RxMatcher` itself, e.g. to collect information about the position where the match occurred, or the subexpressions of the match. An example can be seen in `RxMatcher>>#matchingRangesIn:`
 

--- a/doc/Regex/5-ImplementationNotes.md
+++ b/doc/Regex/5-ImplementationNotes.md
@@ -1,9 +1,9 @@
 # Implementation notes
 
-Version:        1.1
-Released:       October 1999
-Mail to:        Vassili Bykov <vassili@parcplace.com>, <v_bykov@yahoo.com>
-Flames to:      /dev/null
+Version:			1.1
+Released:		October 1999
+Mail to:			Vassili Bykov <vassili@parcplace.com>, <v_bykov@yahoo.com>
+Flames to:		/dev/null
 
 ## What To Look At First
 - `String>>#matchesRegex:` in 90% of cases this method is all you need to access the package.

--- a/doc/Regex/7-History.md
+++ b/doc/Regex/7-History.md
@@ -3,21 +3,21 @@
 1. Updated documentation of character classes, making clear the problems of locale - an area for future improvement
 
 ## Version 1.3 (September 2008)
-1. \w now matches underscore as well as alphanumerics, in line with most other regex libraries (and our documentation!!).
-2. \W rejects underscore as well as alphanumerics
+1. `\w` now matches underscore as well as alphanumerics, in line with most other regex libraries (and our documentation!!).
+2. `\W` rejects underscore as well as alphanumerics
 3. added tests for this at the end of the test suite
 4. updated documentation and added notes to old incorrect comments in version 1.1 below
 
 ## Version 1.2.3 (November 2007)
 
-1. Regexs with `^` or `$` applied to copy empty strings caused infinite loops, e.g. ('' copyWithRegex: '^.*$' matchesReplacedWith: 'foo'). Applied a similar correction to that from version 1.1c to #copyStream:to:(replacingMatchesWith:|translatingMatchesUsing:).
+1. Regexs with `^` or `$` applied to copy empty strings caused infinite loops, e.g. `'' copyWithRegex: '^.*$' matchesReplacedWith: 'fo'`. Applied a similar correction to that from version 1.1c to #copyStream:to:(replacingMatchesWith:|translatingMatchesUsing:).
 2. Extended RxParser testing to run each test for #copy:translatingMatchesUsing: as well as #search:.
 3. Corrected #testSuite test that a dot does not match a null, which was passing by luck with Smalltalk code in a literal array.
 4. Added test to the end of the test suite for fix 1 above.
 
 ## Version 1.2.2 (November 2006)
 
-There was no way to specify a backslash in a character set. Now [\\] is accepted.
+There was no way to specify a backslash in a character set. Now `[\\]` is accepted.
 
 ## Version 1.2.1 (August 2006)
 
@@ -47,8 +47,9 @@ Changes valueNowOrOnUnwindDo: to ensure:, plus incorporates some earlier fixes.
 
 Regular expression syntax corrections and enhancements:
 
-1. Backslash escapes similar to those in Perl are allowed in patterns:
+\1. Backslash escapes similar to those in Perl are allowed in patterns:
 
+```text
 	\w any word constituent character (equivalent to [a-zA-Z0-9_]) *** underscore only since 1.3 ***
 	\W any character but a word constituent (equivalent to [^a-xA-Z0-9_]) *** underscore only since 1.3 ***
 	\d a digit (same as [0-9])
@@ -59,15 +60,19 @@ Regular expression syntax corrections and enhancements:
 	\B an empty string not at a word boundary
 	\< an empty string at the beginning of a word
 	\> an empty string at the end of a word
+```
 
-For example, '\w+' is now a valid expression matching any word.
+For example, `'\w+'` is now a valid expression matching any word.
 
-2. The following backslash escapes are also allowed in character sets (between square brackets):
+\2. The following backslash escapes are also allowed in character sets (between square brackets):
 
+```text
 	\w, \W, \d, \D, \s, and \S.
+```
 
-3. The following grep(1)-compatible named character classes are recognized in character sets as well:
+\3. The following grep(1)-compatible named character classes are recognized in character sets as well:
 
+```text
 	[:alnum:]
 	[:alpha:]
 	[:cntrl:]
@@ -79,26 +84,32 @@ For example, '\w+' is now a valid expression matching any word.
 	[:space:]
 	[:upper:]
 	[:xdigit:]
+```
 
 For example, the following patterns are equivalent:
 
+```text
 	'[[:alnum:]_]+' '\w+' '[\w]+' '[a-zA-Z0-9_]+' *** underscore only since 1.3 ***
+```
 
-4. Some non-printable characters can be represented in regular expressions using a common backslash notation:
+\4. Some non-printable characters can be represented in regular expressions using a common backslash notation:
 
+```text
 	\t  tab (Character tab)
 	\n  newline (Character lf)
 	\r  carriage return (Character cr)
 	\f  form feed (Character newPage)
 	\e  escape (Character esc)
+```
 
-5. A dot is correctly interpreted as 'any character but a newline'
+\5. A dot is correctly interpreted as 'any character but a newline'
 instead of 'anything but whitespace'.
 
-6. Case-insensitive matching. The easiest access to it are new messages that CharacterArray understands: #asRegexIgnoringCase, #matchesRegexIgnoringCase:, #prefixMatchesRegexIgnoringCase:.
+\6. Case-insensitive matching. The easiest access to it are new messages that CharacterArray understands: #asRegexIgnoringCase, #matchesRegexIgnoringCase:, #prefixMatchesRegexIgnoringCase:.
 
-7. The matcher (an instance of RxMatcher, the result of `String>>asRegex`) now provides a collection-like interface to matches in a particular string or on a particular stream, as well as substitution protocol. The interface includes the following messages:
+\7. The matcher (an instance of RxMatcher, the result of `String>>asRegex`) now provides a collection-like interface to matches in a particular string or on a particular stream, as well as substitution protocol. The interface includes the following messages:
 
+```text
 	matchesIn: aString
 	matchesIn: aString collect: aBlock
 	matchesIn: aString do: aBlock
@@ -112,6 +123,7 @@ instead of 'anything but whitespace'.
 
 	copyStream: aStream to: writeStream translatingMatchesUsing: aBlock
 	copyStream: aStream to: writeStream replacingMatchesWith: aString
+```
 
 Examples:
 


### PR DESCRIPTION
Follow-up on #14328.

Correct spacing in code blocks (a shame Microdown doesn't use a monospace font there).
Reinstated code blocks for plain text.
Fixed some broken references.

Had to escape the numbers in the ordered list at the end of History because code blocks in-between items break the order (this is a common markdown issue).