### PR TITLE
Do not rename category through announcements

### DIFF
--- a/src/Monticello-Tests/RPackageCategorySynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageCategorySynchronisationTest.class.st
@@ -49,7 +49,7 @@ RPackageCategorySynchronisationTest >> testRenameCategoryAlsoRenameAllExtensionP
 	self createMethodNamed: 'longNameExtensionFromXInClassInY' inClass: classInY inCategory: '*XXXXX-subcategory'.
 	self createMethodNamed: 'extensionFromXInClassInZ' inClass: classInZ inCategory: '*XXXXX'.
 
-	self packageOrganizer renameCategory: 'XXXXX' toBe: 'NewCategoryName'.
+	self organizer renameCategory: 'XXXXX' toBe: 'NewCategoryName'.
 
 	self assert: xPackage name equals: 'NewCategoryName'.
 	self assert: (classInY >> #extensionFromXInClassInY) protocolName equals: '*NewCategoryName'.
@@ -65,7 +65,7 @@ RPackageCategorySynchronisationTest >> testRenameCategoryChangeTheNameOfThePacka
 	self addXCategory.
 	xPackage := self organizer packageNamed: #XXXXX.
 
-	self packageOrganizer renameCategory: 'XXXXX' toBe: 'YYYYY'.
+	self organizer renameCategory: 'XXXXX' toBe: 'YYYYY'.
 	self assert: xPackage name equals: 'YYYYY'
 ]
 
@@ -77,17 +77,7 @@ RPackageCategorySynchronisationTest >> testRenameCategoryUpdateTheOrganizer [
 	self addXCategory.
 
 	xPackage := self organizer packageNamed: #XXXXX.
-	self packageOrganizer renameCategory: 'XXXXX' toBe: 'YYYYY'.
+	self organizer renameCategory: 'XXXXX' toBe: 'YYYYY'.
 	self assert: (self organizer packageNamed: 'YYYYY' asSymbol) equals: xPackage.
 	self deny: (self organizer hasPackage: #XXXXX)
-]
-
-{ #category : #'tests - operations on categories' }
-RPackageCategorySynchronisationTest >> testRenameUnknownCategoryCreatesNewRPackage [
-	"test that when we rename a category that is not registered in RPackage , it does not raise errors and simply create a new package. We need this behaviour as for now, create a new category with the class browser does not emit the corrects events, and therefore RPackage can not be directly updated"
-
-	SystemAnnouncer uniqueInstance suspendAllWhile: [ self addXCategory ].
-	self deny: (self organizer hasPackage: #XXXXX).
-	self packageOrganizer renameCategory: 'XXXXX' toBe: 'YYYYY'.
-	self assert: (self organizer hasPackage: #YYYYY)
 ]

--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -19,12 +19,12 @@ Class {
 
 { #category : #utilities }
 RPackageMCSynchronisationTest >> addXCategory [
-	testingEnvironment organization addCategory: 'XXXXX'.
+	self organizer addCategory: 'XXXXX'.
 ]
 
 { #category : #utilities }
 RPackageMCSynchronisationTest >> addXMatchCategory [
-	testingEnvironment organization addCategory: 'XXXXX-YYYY'.
+	self organizer addCategory: 'XXXXX-YYYY'.
 ]
 
 { #category : #utilities }
@@ -47,14 +47,14 @@ RPackageMCSynchronisationTest >> addXYZCategory [
 { #category : #utilities }
 RPackageMCSynchronisationTest >> addYCategory [
 
-	testingEnvironment organization addCategory: 'YYYYY'.
+	self organizer addCategory: 'YYYYY'.
 			
 ]
 
 { #category : #utilities }
 RPackageMCSynchronisationTest >> addZCategory [
 
-	testingEnvironment organization addCategory: 'ZZZZZ'.
+	self organizer addCategory: 'ZZZZZ'.
 			
 ]
 
@@ -70,7 +70,7 @@ RPackageMCSynchronisationTest >> cleanClassesPackagesAndCategories [
 		removeClassNamed: 'NewTrait';
 		removeClassNamed: 'ClassInYPackage';
 		removeClassNamed: 'ClassInZPackage'.
-	self packageOrganizer
+	self organizer
 		removeCategory: 'Zork';
 		removeCategory: 'XXXXX';
 		removeCategory: 'XXXXX-YYYY';

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -866,24 +866,27 @@ RPackageOrganizer >> removeSystemCategory: category [
 RPackageOrganizer >> renameCategory: oldCatString toBe: newCatString [
 	"Rename a category. No action if new name already exists, or if old name does not exist."
 
-	| oldName newName |
+	| oldName newName package announceChange |
 	oldName := oldCatString asSymbol.
 	newName := newCatString asSymbol.
+	announceChange := false.
 
 	categoryMap at: newName ifPresent: [ "new name exists, so no action" ^ self ].
 
 	categoryMap at: oldName ifPresent: [ :classes |
-		| package |
 		categoryMap
 			at: newName put: classes;
 			removeKey: oldName.
+		announceChange := true ].
 
-		package := (self packageMatchingExtensionName: oldName) ifNil: [ self ensurePackage: newName ].
-		package name = oldName ifTrue: [ self renamePackage: package from: oldName to: newName ].
+	"We do it in all cases because we have a few cases where a category was not created but a package was. It's bugs but since categories will vanish there is no reason to care too much."
+	package := (self packageMatchingExtensionName: oldName) ifNil: [ self ensurePackage: newName ].
+	package name = oldName ifTrue: [ self renamePackage: package from: oldName to: newName ].
 
-		package classTagNamed: oldName ifPresent: [ :tag | tag basicRenameTo: newName ].
+	package classTagNamed: oldName ifPresent: [ :tag | tag basicRenameTo: newName ].
 
-		SystemAnnouncer uniqueInstance classCategoryRenamedFrom: oldName to: newName ]
+	"I prefer to announce the category rename after updating the packages in case a listener to this announcement manipulates packages."
+	announceChange ifTrue: [ SystemAnnouncer uniqueInstance classCategoryRenamedFrom: oldName to: newName ]
 ]
 
 { #category : #'system integration' }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -732,7 +732,6 @@ RPackageOrganizer >> registerInterestToAnnouncer: anAnnouncer [
 
 	anAnnouncer weak
 		when: CategoryAdded send: #systemCategoryAddedActionFrom: to: self;
-		when: CategoryRenamed send: #systemCategoryRenamedActionFrom: to: self;
 		when: ClassAdded send: #systemClassAddedActionFrom: to: self;
 		when: ClassRecategorized send: #systemClassRecategorizedActionFrom: to: self;
 		when: ClassRemoved send: #systemClassRemovedActionFrom: to: self;
@@ -867,13 +866,24 @@ RPackageOrganizer >> removeSystemCategory: category [
 RPackageOrganizer >> renameCategory: oldCatString toBe: newCatString [
 	"Rename a category. No action if new name already exists, or if old name does not exist."
 
-	categoryMap at: newCatString ifPresent: [ "new name exists, so no action" ^ self ].
+	| oldName newName |
+	oldName := oldCatString asSymbol.
+	newName := newCatString asSymbol.
 
-	categoryMap at: oldCatString ifPresent: [ :classes |
+	categoryMap at: newName ifPresent: [ "new name exists, so no action" ^ self ].
+
+	categoryMap at: oldName ifPresent: [ :classes |
+		| package |
 		categoryMap
-			at: newCatString put: classes;
-			removeKey: oldCatString.
-		SystemAnnouncer uniqueInstance classCategoryRenamedFrom: oldCatString to: newCatString ]
+			at: newName put: classes;
+			removeKey: oldName.
+
+		package := (self packageMatchingExtensionName: oldName) ifNil: [ self ensurePackage: newName ].
+		package name = oldName ifTrue: [ self renamePackage: package from: oldName to: newName ].
+
+		package classTagNamed: oldName ifPresent: [ :tag | tag basicRenameTo: newName ].
+
+		SystemAnnouncer uniqueInstance classCategoryRenamedFrom: oldName to: newName ]
 ]
 
 { #category : #'system integration' }
@@ -938,24 +948,6 @@ RPackageOrganizer >> systemCategoryAddedActionFrom: ann [
 	| package |
 	package := (self packageMatchingExtensionName: ann categoryName) ifNil: [ self ensurePackage: ann categoryName ].
 	package name = ann categoryName ifFalse: [ package addClassTag: ann categoryName asSymbol ]
-]
-
-{ #category : #'system integration' }
-RPackageOrganizer >> systemCategoryRenamedActionFrom: ann [
-	| package oldName newName |
-
-	oldName := ann oldCategoryName asSymbol.
-	newName := ann newCategoryName asSymbol.
-	package := (self packageMatchingExtensionName: ann oldCategoryName) ifNil: [ (RPackage named: newName organizer: self) register ].
-	package name = ann oldCategoryName ifTrue: [
-		self
-			renamePackage: package
-			from: oldName
-			to: newName ].
-
-	package
-		classTagNamed: oldName
-		ifPresent: [ :tag | tag basicRenameTo: newName ]
 ]
 
 { #category : #'system integration' }


### PR DESCRIPTION
During a category renaming, synch RPackage directly instead of using announcements