### PR TITLE
Do not compile method in advance in MethodAddition

### DIFF
--- a/src/Monticello/MCMethodDefinition.class.st
+++ b/src/Monticello/MCMethodDefinition.class.st
@@ -123,17 +123,15 @@ MCMethodDefinition >> actualClass [
 
 { #category : #installing }
 MCMethodDefinition >> addMethodAdditionTo: aCollection [
+
 	| methodAddition |
 	methodAddition := MethodAddition new
-		compile: source
-		classified: category
-		withStamp: timeStamp
-		logSource: true
-		inClass: self actualClass.
-	"This might raise an exception and never return"
-	methodAddition createCompiledMethod.
-	aCollection add: methodAddition.
-
+		                  compile: source
+		                  classified: category
+		                  withStamp: timeStamp
+		                  logSource: true
+		                  inClass: self actualClass.
+	aCollection add: methodAddition
 ]
 
 { #category : #'accessing - backward' }

--- a/src/Monticello/MCPackageLoader.class.st
+++ b/src/Monticello/MCPackageLoader.class.st
@@ -93,7 +93,6 @@ MCPackageLoader >> basicLoadDefinitions [
 	errorDefinitions do: [ :each | each addMethodAdditionTo: methodAdditions ] displayingProgress: 'Reloading erroneous definitions...'.
 	
 	methodAdditions do: [ :each | each installMethod ].
-	methodAdditions do: [ :each | each notifyObservers ].
 	additions       do: [ :each | each postloadOver: (self obsoletionFor: each) ] displayingProgress: 'Initializing...'.
 	
 ]

--- a/src/Monticello/MethodAddition.class.st
+++ b/src/Monticello/MethodAddition.class.st
@@ -11,9 +11,7 @@ Class {
 		'myClass',
 		'selector',
 		'compiledMethod',
-		'priorMethod',
-		'protocolName',
-		'priorProtocol'
+		'protocolName'
 	],
 	#category : #'Monticello-Loading'
 }
@@ -24,10 +22,7 @@ MethodAddition >> compile [
      This method should not normally be used, because the whole point of MethodAddition is to let
 	you first create a compiled method and then install the method later."
 
-	self
-		createCompiledMethod;
-		installMethod;
-		notifyObservers.
+	self installMethod.
 	^ selector
 ]
 
@@ -42,46 +37,31 @@ MethodAddition >> compile: aString classified: aProtocolName withStamp: aString2
 ]
 
 { #category : #operations }
-MethodAddition >> createCompiledMethod [
-	"CyrilFerlicot: Why do we need to explicitly write to the source? Why do we call the compiler?
-	
-	Can't we just call #compile:classfied: here?"
-	compiledMethod := myClass compiler permitUndeclared: true; compile: text asString.
-	selector := compiledMethod selector.
-	self writeSourceToLog.
-	priorMethod := myClass compiledMethodAt: selector ifAbsent: [ nil ].
-	priorProtocol := myClass protocolOfSelector: selector
-]
-
-{ #category : #operations }
 MethodAddition >> installMethod [
-	SystemAnnouncer uniqueInstance
-		suspendAllWhile: [ myClass addSelector: selector withMethod: compiledMethod ]
-]
 
-{ #category : #notifying }
-MethodAddition >> notifyObservers [
-	SystemAnnouncer uniqueInstance 
-		suspendAllWhile: [myClass classify: selector under: protocolName].
-	priorMethod 
-		ifNil: [ SystemAnnouncer uniqueInstance
-				methodAdded: compiledMethod
-				configuredWith: [ :event | 
-					event
-						propertyAt: #eventSource
-						put: #Monticello ] ]
+	| priorMethod priorProtocol |
+	compiledMethod := myClass compiler
+		                  permitUndeclared: true;
+		                  compile: text asString.
+
+	selector := compiledMethod selector.
+
+	self writeSourceToLog.
+
+	priorMethod := myClass compiledMethodAt: selector ifAbsent: [ nil ].
+	priorProtocol := myClass protocolOfSelector: selector.
+
+	SystemAnnouncer uniqueInstance suspendAllWhile: [
+		myClass addSelector: selector withMethod: compiledMethod.
+		myClass classify: selector under: protocolName ].
+
+	priorMethod
+		ifNil: [ SystemAnnouncer uniqueInstance methodAdded: compiledMethod configuredWith: [ :event | event propertyAt: #eventSource put: #Monticello ] ]
 		ifNotNil: [
 			SystemAnnouncer uniqueInstance methodChangedFrom: priorMethod to: compiledMethod oldProtocol: priorProtocol.
-			priorProtocol name = protocolName ifFalse: [
-       			SystemAnnouncer uniqueInstance methodRecategorized: compiledMethod oldProtocol: priorProtocol ] ].
+			priorProtocol name = protocolName ifFalse: [ SystemAnnouncer uniqueInstance methodRecategorized: compiledMethod oldProtocol: priorProtocol ] ].
 	"The following code doesn't seem to do anything."
-	myClass instanceSide noteCompilationOf: compiledMethod meta: myClass isClassSide.
-
-]
-
-{ #category : #accessing }
-MethodAddition >> priorProtocol [
-	^ priorProtocol
+	myClass instanceSide noteCompilationOf: compiledMethod meta: myClass isClassSide
 ]
 
 { #category : #operations }


### PR DESCRIPTION
This change group all the steps to install a method in MethodAddition. This is the first step to improve the compilation i Monticello.

Subpart of #14336