### PR TITLE
Ensure copied references in filesystem are resolved before copy

### DIFF
--- a/src/FileSystem-Core/FileSystem.class.st
+++ b/src/FileSystem-Core/FileSystem.class.st
@@ -174,7 +174,7 @@ FileSystem >> copy: aPath toReference: destinationReference [
 
 	^self = destinationReference fileSystem
 		ifTrue: [ self copy: aPath to: destinationReference resolve path ]
-		ifFalse: [ self copy: aPath toRemote: destinationReference ]
+		ifFalse: [ self copy: aPath toRemote: destinationReference resolve ]
 ]
 
 { #category : #public }

--- a/src/FileSystem-Tests-Core/FileSystemTest.class.st
+++ b/src/FileSystem-Tests-Core/FileSystemTest.class.st
@@ -224,6 +224,23 @@ FileSystemTest >> testCopyDestExists [
 ]
 
 { #category : #tests }
+FileSystemTest >> testCopyFileLocator [
+	| fromFile toFile |
+	fromFile := FileSystem memory root / 'foo.txt'.
+	fromFile writeStreamDo: [ :aStream | aStream nextPutAll: 'hello' ].
+
+	toFile := FileLocator temp / 'example' / 'bar.txt'.
+	toFile ensureDelete.
+	toFile parent ensureCreateDirectory.
+
+	fromFile copyTo: toFile.
+
+	self assert: toFile contents equals: 'hello'.
+
+	toFile parent ensureDeleteAll
+]
+
+{ #category : #tests }
 FileSystemTest >> testCopySourceDoesntExist [
 	self
 		should: [filesystem copy: 'plonk' to: 'griffle']


### PR DESCRIPTION
This tackles #14338 and adds a regression test.

Cheers