### PR TITLE
Improve ClassDescription API of package tags

### DIFF
--- a/src/Calypso-SystemQueries/ClyNoTagClassGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyNoTagClassGroup.class.st
@@ -27,15 +27,15 @@ ClyNoTagClassGroup class >> priority [
 
 { #category : #operations }
 ClyNoTagClassGroup >> importClass: aClass [
+
 	| newPackages |
 	super importClass: aClass.
 	newPackages := OrderedCollection new.
-	classQuery scope packagesDo: [ :each |
-		each = aClass package ifFalse: [ newPackages add: each ]].
-	newPackages size > 1 ifTrue: [ ^self error: 'You should select single package for import!' ].
+	classQuery scope packagesDo: [ :each | each = aClass package ifFalse: [ newPackages add: each ] ].
+	newPackages size > 1 ifTrue: [ ^ self error: 'You should select single package for import!' ].
 
-	newPackages ifNotEmpty: [ ^newPackages first addClass: aClass ].
-	aClass tags do: [:eachTag | aClass untagFrom: eachTag ]
+	newPackages ifNotEmpty: [ ^ newPackages first addClass: aClass ].
+	aClass packageTagName ifNotNil: [ :tag | aClass untagFrom: tag ]
 ]
 
 { #category : #operations }

--- a/src/Calypso-SystemQueries/ClyNoTagClassGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyNoTagClassGroup.class.st
@@ -35,11 +35,12 @@ ClyNoTagClassGroup >> importClass: aClass [
 	newPackages size > 1 ifTrue: [ ^ self error: 'You should select single package for import!' ].
 
 	newPackages ifNotEmpty: [ ^ newPackages first addClass: aClass ].
-	aClass packageTagName ifNotNil: [ :tag | aClass untagFrom: tag ]
+	self flag: #package. "I'm not sure this next line even makes sens after moving the class from package. The tag should be removed automatically?"
+	aClass removePackageTag
 ]
 
 { #category : #operations }
 ClyNoTagClassGroup >> renameClassTagTo: newTag [
 
-	self classes do: [ :class | class tagWith: newTag ]
+	self classes do: [ :class | class packageTag: newTag ]
 ]

--- a/src/Calypso-SystemQueries/ClyRestUntaggedClassesQuery.class.st
+++ b/src/Calypso-SystemQueries/ClyRestUntaggedClassesQuery.class.st
@@ -41,5 +41,6 @@ ClyRestUntaggedClassesQuery >> description [
 
 { #category : #testing }
 ClyRestUntaggedClassesQuery >> selectsClass: aClass [
-	^aClass tags isEmpty
+
+	^ aClass packageTag isNil
 ]

--- a/src/Calypso-SystemQueries/ClyTaggedClassGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyTaggedClassGroup.class.st
@@ -48,7 +48,7 @@ ClyTaggedClassGroup >> importClass: aClass [
 		each = aClass package ifFalse: [ newPackages add: each ]].
 	newPackages size > 1 ifTrue: [ ^self error: 'You should select single package for import!' ].
 	newPackages ifNotEmpty: [ newPackages first addClass: aClass].
-	aClass tagWith: self tag
+	aClass packageTag: self tag
 ]
 
 { #category : #operations }
@@ -61,14 +61,12 @@ ClyTaggedClassGroup >> removeWithClasses [
 
 { #category : #operations }
 ClyTaggedClassGroup >> renameClassTagTo: newTag [
-	self classes do: [ :each |
-		each tagWith: newTag.
-		each untagFrom: self tag].
 
-	classQuery scope packagesDo: [ :each |
-		(each tagsForClasses includes: newTag)
-			ifFalse: [ each addClassTag: newTag ].
-		each removeClassTag: self tag]
+	self classes do: [ :class | class packageTag: newTag ].
+
+	classQuery scope packagesDo: [ :package |
+		(package tagsForClasses includes: newTag) ifFalse: [ package addClassTag: newTag ].
+		package removeClassTag: self tag ]
 ]
 
 { #category : #accessing }

--- a/src/Calypso-SystemQueries/ClyUntaggedClassesQuery.class.st
+++ b/src/Calypso-SystemQueries/ClyUntaggedClassesQuery.class.st
@@ -15,5 +15,6 @@ ClyUntaggedClassesQuery >> description [
 
 { #category : #testing }
 ClyUntaggedClassesQuery >> selectsClass: aClass [
-	^aClass tags isEmpty
+
+	^ aClass packageTag isNil
 ]

--- a/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserMorph.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserMorph.class.st
@@ -601,9 +601,9 @@ ClyFullBrowserMorph >> selectClass: aClass [
 			(self isPackageSelected: classDefinition definingPackage)
 				ifTrue: [ ^self classSelection selectItems: foundItems ]].
 
-		aClass tags
-			ifEmpty: [ self selectPackage: aClass package]
-			ifNotEmpty: [:tags | self selectPackage: aClass package atClassTag: tags anyOne].
+		aClass packageTagName
+			ifNil: [ self selectPackage: aClass package]
+			ifNotNil: [ :tag | self selectPackage: aClass package atClassTag: tag ].
 		self packageSelection isEmpty ifTrue: [ ^self ].
 
 		self showsFullClassHierarchy ifTrue: [ self switchToFullClassHierarchyOf: aClass ].
@@ -729,9 +729,9 @@ ClyFullBrowserMorph >> silentlySelectPackageOfSelectedClass [
 	selectedClass := self classSelection lastSelectedItem actualObject.
 
 	packageView ignoreNavigationDuring: [
-		selectedClass tags
-			ifEmpty: [ self selectPackage: selectedClass package]
-			ifNotEmpty: [:tags | self selectPackage: selectedClass package atClassTag: tags anyOne]]
+		selectedClass packageTagName
+			ifNil: [ self selectPackage: selectedClass package]
+			ifNotNil: [ :tag | self selectPackage: selectedClass package atClassTag: tag ] ]
 ]
 
 { #category : #navigation }

--- a/src/Deprecated12/ClassDescription.extension.st
+++ b/src/Deprecated12/ClassDescription.extension.st
@@ -270,6 +270,13 @@ ClassDescription >> subject [
 ]
 
 { #category : #'*Deprecated12' }
+ClassDescription >> tagWith: aSymbol [
+
+	self deprecated: 'Use #packageTag: instead.' transformWith: '`@rcv tagWith: `@arg' -> '`@rcv packageTag: `@arg'.
+	^ self packageTag: aSymbol
+]
+
+{ #category : #'*Deprecated12' }
 ClassDescription >> tags [
 
 	self deprecated: 'Since a class can have only one tag, it is easier to just call the method #packageTag.'.
@@ -283,6 +290,22 @@ ClassDescription >> tagsForMethods [
 
 	self deprecated: 'Use #protocolNames instead.' transformWith: '`@rcv tagsForMethods' -> '`@rcv protocolNames'.
 	^ self protocolNames
+]
+
+{ #category : #'*Deprecated12' }
+ClassDescription >> untagFrom: aSymbol [
+
+	| package packageTag |
+	self deprecated: 'A class can have only one package tag so it is easier to use #removePackageTag.'.
+	"Any class or trait could be tagged by multiple symbols for user purpose.
+	For now we could only model single tag with RPackageTag"
+	package := self package.
+	packageTag := package classTagForClass: self.
+	packageTag ifNil: [ ^ #(  ) ].
+	packageTag isRoot ifTrue: [ ^ #(  ) ].
+	packageTag name = aSymbol ifFalse: [ ^ self ].
+	packageTag removeClass: self.
+	package addClass: self
 ]
 
 { #category : #'*Deprecated12' }

--- a/src/Deprecated12/ClassDescription.extension.st
+++ b/src/Deprecated12/ClassDescription.extension.st
@@ -270,6 +270,15 @@ ClassDescription >> subject [
 ]
 
 { #category : #'*Deprecated12' }
+ClassDescription >> tags [
+
+	self deprecated: 'Since a class can have only one tag, it is easier to just call the method #packageTag.'.
+	^ self packageTagName
+		  ifNil: [ {  } ]
+		  ifNotNil: [ :tag | { tag } ]
+]
+
+{ #category : #'*Deprecated12' }
 ClassDescription >> tagsForMethods [
 
 	self deprecated: 'Use #protocolNames instead.' transformWith: '`@rcv tagsForMethods' -> '`@rcv protocolNames'.

--- a/src/GeneralRules/ReClassNotCategorizedRule.class.st
+++ b/src/GeneralRules/ReClassNotCategorizedRule.class.st
@@ -24,9 +24,10 @@ ReClassNotCategorizedRule class >> uniqueIdentifierName [
 
 { #category : #running }
 ReClassNotCategorizedRule >> basicCheck: aClass [
+
 	aClass isMeta ifTrue: [ ^ false ].
 
-	^aClass tags isEmpty and: [ aClass package classTags size > 1 ]
+	^ aClass packageTag isNil and: [ aClass package classTags size > 1 ]
 ]
 
 { #category : #accessing }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -1130,17 +1130,6 @@ ClassDescription >> superclass: aSuperclass withLayoutType: layoutType slots: sl
 		layout: newLayout
 ]
 
-{ #category : #'accessing - tags' }
-ClassDescription >> tagWith: aSymbol [
-	| package packageTag |
-	"Any class or trait could be tagged by multiple symbols for user purpose.
-	For now we could only model single tag with RPackageTag"
-
-	package := self package.
-	packageTag := package addClassTag: aSymbol.
-	packageTag addClass: self
-]
-
 { #category : #'accessing - deprecated parallel hierarchy' }
 ClassDescription >> theMetaClass [
 	"This method is deprecated so consider to migrate."
@@ -1161,20 +1150,6 @@ ClassDescription >> theNonMetaClass [
 ClassDescription >> uncategorizedSelectors [
 
 	^ self selectorsInProtocol: Protocol unclassified
-]
-
-{ #category : #'accessing - tags' }
-ClassDescription >> untagFrom: aSymbol [
-	| package packageTag |
-	"Any class or trait could be tagged by multiple symbols for user purpose.
-	For now we could only model single tag with RPackageTag"
-	package := self package.
-	packageTag := package classTagForClass: self.
-	packageTag ifNil: [ ^#() ].
-	packageTag isRoot ifTrue: [ ^#() ].
-	packageTag name = aSymbol ifFalse: [ ^self ].
-	packageTag removeClass: self.
-	package addClass: self
 ]
 
 { #category : #'pool variable' }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -1141,19 +1141,6 @@ ClassDescription >> tagWith: aSymbol [
 	packageTag addClass: self
 ]
 
-{ #category : #'accessing - tags' }
-ClassDescription >> tags [
-
-	| packageTag |
-	"Any class or trait could be tagged by multiple symbols for user purpose.
-	For now we only define API to manage them on top of RPackageTag"
-	packageTag := self package classTagForClass: self.
-	packageTag ifNil: [ ^ #(  ) ].
-	packageTag isRoot ifTrue: [ ^ #(  ) ].
-
-	^ { packageTag name }
-]
-
 { #category : #'accessing - deprecated parallel hierarchy' }
 ClassDescription >> theMetaClass [
 	"This method is deprecated so consider to migrate."

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -657,7 +657,7 @@ ClassDescription >> isMeta [
 { #category : #testing }
 ClassDescription >> isTaggedWith: aSymbol [
 
-	^ self packageTag
+	^ self packageTagName
 		  ifNil: [ false ]
 		  ifNotNil: [ :tag | tag = aSymbol ]
 ]

--- a/src/Manifest-Core/TheManifestBuilder.class.st
+++ b/src/Manifest-Core/TheManifestBuilder.class.st
@@ -340,7 +340,7 @@ TheManifestBuilder >> createManifestNamed: packageName [
 			package: packageName ].
 
 	manifestClass
-		tagWith: self class manifestTag;
+		packageTag: self class manifestTag;
 		comment: self class manifestClassComment.
 	^ manifestClass
 ]

--- a/src/RPackage-Core/ClassDescription.extension.st
+++ b/src/RPackage-Core/ClassDescription.extension.st
@@ -57,6 +57,13 @@ ClassDescription >> packageTag [
 ]
 
 { #category : #'*RPackage-Core' }
+ClassDescription >> packageTag: aSymbol [
+
+	self flag: #package. "In the future this method should work with a real package tag also."
+	(self package addClassTag: aSymbol) addClass: self
+]
+
+{ #category : #'*RPackage-Core' }
 ClassDescription >> packageTagName [
 	"Package tags are sub categories of packages to have a better organization of the packages. I return the name of my package tag or nil if the class is uncategorized."
 
@@ -68,4 +75,12 @@ ClassDescription >> packages [
 	"the extending packages of a class are the packages that extend it."
 
 	^  self extendingPackages asSet copy add: self package; yourself
+]
+
+{ #category : #'*RPackage-Core' }
+ClassDescription >> removePackageTag [
+
+	self packageTag ifNotNil: [ :tag |
+		tag removeClass: self.
+		self package addClass: self ]
 ]

--- a/src/RPackage-Core/ClassDescription.extension.st
+++ b/src/RPackage-Core/ClassDescription.extension.st
@@ -48,15 +48,19 @@ ClassDescription >> packageFromOrganizer: anOrganizer [
 
 { #category : #'*RPackage-Core' }
 ClassDescription >> packageTag [
+	"Package tags are sub categories of packages to have a better organization of the packages. I return my package tag or nil if the class is uncategorized."
 
 	| packageTag |
-	"Any class or trait could be tagged by a symbol for user purpose.
-	For now we only define API to manage them on top of RPackageTag"
-	packageTag := self package classTagForClass: self.
-	packageTag ifNil: [ ^ nil ].
+	packageTag := (self package classTagForClass: self) ifNil: [ ^ nil ].
 	packageTag isRoot ifTrue: [ ^ nil ].
+	^ packageTag
+]
 
-	^ packageTag name
+{ #category : #'*RPackage-Core' }
+ClassDescription >> packageTagName [
+	"Package tags are sub categories of packages to have a better organization of the packages. I return the name of my package tag or nil if the class is uncategorized."
+
+	^ self packageTag ifNotNil: [ :tag | tag name ]
 ]
 
 { #category : #'*RPackage-Core' }

--- a/src/Ring-Core/RGReadOnlyImageBackend.class.st
+++ b/src/Ring-Core/RGReadOnlyImageBackend.class.st
@@ -302,10 +302,7 @@ RGReadOnlyImageBackend >> superclassFor: anRGBehavior [
 { #category : #behavior }
 RGReadOnlyImageBackend >> tagsForClass: anRGBehavior do: aBlock [
 
-	| realClass |
-
-	realClass := self realBehaviorFor: anRGBehavior.
-	realClass tags do: [:tag | aBlock value: tag ]
+	(self realBehaviorFor: anRGBehavior) packageTagName ifNotNil: [ :tag | aBlock value: tag ]
 ]
 
 { #category : #method }


### PR DESCRIPTION
ClassDescription API for package tag was not really consistant. The main problem was that it led the user to think we could have multiple package tag while this is not true (at least now).

Here are a summary of the changes:
- Deprecate #tags in favor of #packageTag
- Deprecate #tagWith: in favor of #packageTag:
- Deprecated #untagFrom: in favor of #removePackageTag
- Add #packageTagName
- Make #packageTag return a package tag