### PR TITLE
rapid click on two different items in a list gets interpreted as a double-click on the first item

### DIFF
--- a/src/Morphic-Core/MouseButtonEvent.class.st
+++ b/src/Morphic-Core/MouseButtonEvent.class.st
@@ -16,11 +16,8 @@ MouseButtonEvent >> asPseudoDoubleClickEvent [
 	| pseudoEvent secondEvent |
 	pseudoEvent := MouseButtonPseudoDoubleClickEvent new copyFrom: self.
 	secondEvent := self copy.
-	secondEvent
-		setType: self type
-		position: self hand cursorPoint
-		buttons: self buttons
-		hand: self hand.
+	secondEvent setPosition:
+		(self hand ifNil: [ self position ] ifNotNil: [ :h | h cursorPoint ]).
 	pseudoEvent secondEvent: secondEvent.
 	^ pseudoEvent
 ]

--- a/src/Morphic-Core/MouseButtonEvent.class.st
+++ b/src/Morphic-Core/MouseButtonEvent.class.st
@@ -11,6 +11,21 @@ Class {
 }
 
 { #category : #accessing }
+MouseButtonEvent >> asPseudoDoubleClickEvent [
+
+	| pseudoEvent secondEvent |
+	pseudoEvent := MouseButtonPseudoDoubleClickEvent new copyFrom: self.
+	secondEvent := self copy.
+	secondEvent
+		setType: self type
+		position: self hand cursorPoint
+		buttons: self buttons
+		hand: self hand.
+	pseudoEvent secondEvent: secondEvent.
+	^ pseudoEvent
+]
+
+{ #category : #accessing }
 MouseButtonEvent >> blueButtonChanged [
 	"Answer true if the blue mouse button has changed. This is the third mouse button or cmd+click on the Mac."
 

--- a/src/Morphic-Core/MouseButtonPseudoDoubleClickEvent.class.st
+++ b/src/Morphic-Core/MouseButtonPseudoDoubleClickEvent.class.st
@@ -1,0 +1,24 @@
+"
+I get created from a mouseDown MouseButtonEvent, adding the second mouseDown event by cloning the first event, and repositioning it to the current hand location.
+I can be usefull for refining some doubleClick: implementations. (as is done for FTTableMorph>>#doubleClick:)
+"
+Class {
+	#name : #MouseButtonPseudoDoubleClickEvent,
+	#superclass : #MouseButtonEvent,
+	#instVars : [
+		'secondEvent'
+	],
+	#category : #'Morphic-Core-Events'
+}
+
+{ #category : #accessing }
+MouseButtonPseudoDoubleClickEvent >> secondEvent [
+
+	^ secondEvent
+]
+
+{ #category : #accessing }
+MouseButtonPseudoDoubleClickEvent >> secondEvent: anObject [
+
+	secondEvent := anObject
+]

--- a/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
@@ -295,7 +295,27 @@ FTTableMorph >> disableFunction [
 
 { #category : #'event handling' }
 FTTableMorph >> doubleClick: event [
-	(self selectionModeStrategy selectableIndexContainingPoint: event cursorPoint) ifNotNil: [ :index | self doAnnounce: (FTStrongSelectionChanged index: index event: event) ]
+
+	(self selectionModeStrategy selectableIndexContainingPoint:
+		 event cursorPoint) ifNotNil: [ :firstClickedIndex |
+		| pdcEvent |
+		pdcEvent := event asPseudoDoubleClickEvent.
+		(self selectionModeStrategy selectableIndexContainingPoint:
+			 pdcEvent secondEvent position) ifNotNil: [ :secondClickedIndex |
+			firstClickedIndex = secondClickedIndex
+				ifFalse: [
+					self selectionStrategy
+						selectIndex: secondClickedIndex
+						event: pdcEvent secondEvent ]
+				ifTrue: [
+					self selectedIndexes
+						detect: [ :i | i = secondClickedIndex ]
+						ifNone: [
+							self selectionStrategy
+								selectIndex: secondClickedIndex
+								event: pdcEvent secondEvent ].
+					self doAnnounce:
+						(FTStrongSelectionChanged index: secondClickedIndex event: event) ] ] ]
 ]
 
 { #category : #drawing }


### PR DESCRIPTION
Fixes #14168



This PR solves the problem with 2 subsequent clicks (within double click timing) on 2 different items of FTTableMorph.
Before the fix, this would execute a double click command on the first clicked item.
The fix involves comparing the 2 click positions and resulting item indexes.

A second problem occurs when double clicking on an already selected item.
Before the fix, the item gets de-selected, and nothing further happend.
This PR ensures that item is selected before dispatching the double click command.
