### PR TITLE
Cleanup transformation/refactoring hierarchy

### DIFF
--- a/src/Refactoring-Core/RBAbstractTransformation.class.st
+++ b/src/Refactoring-Core/RBAbstractTransformation.class.st
@@ -135,6 +135,13 @@ RBAbstractTransformation >> emptyCondition [
 	^ RBCondition true
 ]
 
+{ #category : #transforming }
+RBAbstractTransformation >> execute [
+	"Check precondition, execute the transformation that produces changes and finally execute the changes"
+	self primitiveExecute.
+	self performChanges
+]
+
 { #category : #accessing }
 RBAbstractTransformation >> model: aRBNamespace [
 
@@ -195,6 +202,14 @@ RBAbstractTransformation >> parserClass [
 	^ RBParser
 ]
 
+{ #category : #transforming }
+RBAbstractTransformation >> performChanges [
+
+	RBRefactoryChangeManager instance
+		performChange: self changes;
+		addUndoPointer: RBRefactoryChangeManager nextCounter
+]
+
 { #category : #accessing }
 RBAbstractTransformation >> poolVariableNamesFor: aClass [
 	| pools |
@@ -214,6 +229,12 @@ RBAbstractTransformation >> poolVariableNamesIn: poolName [
 
 { #category : #preconditions }
 RBAbstractTransformation >> preconditions [
+
+	self subclassResponsibility
+]
+
+{ #category : #private }
+RBAbstractTransformation >> primitiveExecute [ 
 
 	self subclassResponsibility
 ]

--- a/src/Refactoring-Core/RBRefactoring.class.st
+++ b/src/Refactoring-Core/RBRefactoring.class.st
@@ -131,13 +131,6 @@ RBRefactoring >> copyOptionsFrom: aDictionary [
 ]
 
 { #category : #transforming }
-RBRefactoring >> execute [
-	"Check precondition, execute the transformation that produces changes and finally execute the changes"
-	self primitiveExecute.
-	self performChanges
-]
-
-{ #category : #transforming }
 RBRefactoring >> generateChangesFor: aRefactoring [
 	"I will generate changes and save them in the model, BUT I will not apply them!
 	Use me when a refactorings is composed of multiple other refactorings"
@@ -165,14 +158,6 @@ RBRefactoring >> onError: aBlock do: errorBlock [
 			[:ex |
 			errorBlock cull: ex.
 			ex return: nil]
-]
-
-{ #category : #transforming }
-RBRefactoring >> performChanges [
-
-	RBRefactoryChangeManager instance
-		performChange: self changes;
-		addUndoPointer: RBRefactoryChangeManager nextCounter
 ]
 
 { #category : #private }

--- a/src/Refactoring2-Transformations-Tests/RBRemoveAllMessageSendsTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveAllMessageSendsTransformationTest.class.st
@@ -12,7 +12,6 @@ RBRemoveAllMessageSendsTransformationTest >> testClassDoesNotExist [
 				messageSend: #foo:
 				inMethod: #badMessage1
 				inClass: #ADoesNotExistClass).
-	trans preconditionChecking: true.
 	self should: [ trans checkPreconditions ] raise: trans refactoringErrorClass.
 	self should: [ trans transform ] raise: trans refactoringErrorClass.
 ]
@@ -25,7 +24,6 @@ RBRemoveAllMessageSendsTransformationTest >> testFailureNonExistantSelector [
 				messageSend: #foo:
 				inMethod: #checkClass1:
 				inClass: #RBClassDataForRefactoringTest).
-	trans preconditionChecking: true.
 	self should: [ trans checkPreconditions ] raise: trans refactoringErrorClass.
 	self should: [ trans transform ] raise: trans refactoringErrorClass.
 ]
@@ -38,7 +36,6 @@ RBRemoveAllMessageSendsTransformationTest >> testMethodDoesNotExist [
 				messageSend: #foo:
 				inMethod: #badMessage1
 				inClass: #RBClassDataForRefactoringTest).
-	trans preconditionChecking: true.
 	self should: [ trans checkPreconditions ] raise: trans refactoringErrorClass.
 	self should: [ trans transform ] raise: trans refactoringErrorClass.
 ]
@@ -51,7 +48,6 @@ RBRemoveAllMessageSendsTransformationTest >> testRemoveMessageInsideBlock [
 				messageSend: #printString
 				inMethod: #caller1
 				inClass: #RBClassDataForRefactoringTest).
-	trans preconditionChecking: true.
 	trans transform.
 
 	self assert: ((trans model classNamed: #RBClassDataForRefactoringTest) parseTreeForSelector: #caller1) equals: (self parseMethod: 'caller1
@@ -82,7 +78,6 @@ RBRemoveAllMessageSendsTransformationTest >> testRemoveSenderIntoCascaded2Messag
 				messageSend: #inlineMethod
 				inMethod: #inlineMethod
 				inClass: #RBClassDataForRefactoringTest).
-	trans preconditionChecking: true.
 	trans transform.
 	transformedMethod := ((trans model classNamed: #RBClassDataForRefactoringTest) parseTreeForSelector: #inlineMethod).
 	self assert: (transformedMethod = afterRefactoring1 or: [ transformedMethod = afterRefactoring2])
@@ -125,7 +120,6 @@ RBRemoveAllMessageSendsTransformationTest >> testRemoveSenderIntoCascaded3Messag
 				messageSend: #errorBlock:
 				inMethod: #referencesConditionFor:
 				inClass: #RBClassDataForRefactoringTest).
-	trans preconditionChecking: true.
 	trans transform.
 	transformedMethod := ((trans model classNamed: #RBClassDataForRefactoringTest) parseTreeForSelector: #referencesConditionFor:).
 	self assert: (transformedMethod = afterRefactoring1 or: [ transformedMethod = afterRefactoring2])
@@ -139,7 +133,6 @@ RBRemoveAllMessageSendsTransformationTest >> testRemoveSenderIntoCascadedMessage
 				messageSend: #cr
 				inMethod: (#called:, #on:) asSymbol
 				inClass: #RBClassDataForRefactoringTest).
-	trans preconditionChecking: true.
 	trans transform.
 
 	self assert: ((trans model classNamed: #RBClassDataForRefactoringTest) parseTreeForSelector: (#called:, #on:) asSymbol)
@@ -164,7 +157,6 @@ RBRemoveAllMessageSendsTransformationTest >> testRemoveSimpleSenderOfMessage [
 				messageSend: #called:on1:
 				inMethod: #caller1
 				inClass: #RBClassDataForRefactoringTest).
-	trans preconditionChecking: true.
 	trans transform.
 	transformedMethod := ((trans model classNamed: #RBClassDataForRefactoringTest) parseTreeForSelector: #caller1).
 	self assert: (transformedMethod = afterRefactoring1 or: [ transformedMethod = afterRefactoring2])

--- a/src/Refactoring2-Transformations/RBRemoveAllMessageSendsTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBRemoveAllMessageSendsTransformation.class.st
@@ -123,3 +123,10 @@ RBRemoveAllMessageSendsTransformation >> storeOn: aStream [
 	class storeOn: aStream.
 	aStream nextPut: $)
 ]
+
+{ #category : #executing }
+RBRemoveAllMessageSendsTransformation >> transform [
+
+	self checkPreconditions.
+	self privateTransform
+]

--- a/src/Refactoring2-Transformations/RBTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBTransformation.class.st
@@ -110,14 +110,6 @@ RBTransformation >> copyOptionsFrom: aDictionary [
 	self options: dict
 ]
 
-{ #category : #execution }
-RBTransformation >> execute [
-	self primitiveExecute.
-	RBRefactoryChangeManager instance
-		performChange: self changes;
-		addUndoPointer: (RBRefactoryChangeManager nextCounter)
-]
-
 { #category : #initialization }
 RBTransformation >> initialize [
 	super initialize.


### PR DESCRIPTION
Clean-up Refactoring-Transformation hierarchy by pushing-up some duplicated methods.
Start removing usages of `preconditionChecking`. `preconditionChecking` is now only difference between base RBTransformation and RBRefactoring.