### PR TITLE
Deprectaed #definedClassesDo:

### DIFF
--- a/src/Deprecated12/RPackage.extension.st
+++ b/src/Deprecated12/RPackage.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #RPackage }
+
+{ #category : #'*Deprecated12' }
+RPackage >> definedClassesDo: aBlock [
+
+	self deprecated:
+		'Use #definedClasses and a do instead because the name of this method is not explicit since it iterates over the *name* of the classes and not the classes themselves.'.
+	^ classes do: aBlock
+]

--- a/src/HeuristicCompletion-Model/CoBenchmarkPackage.class.st
+++ b/src/HeuristicCompletion-Model/CoBenchmarkPackage.class.st
@@ -23,10 +23,7 @@ CoBenchmarkPackage class >> on: aRPackage [
 { #category : #enumerating }
 CoBenchmarkPackage >> methodsDo: aBlockClosure [
 
-	package definedClassesDo: [ :each | | class |
-		class := self class environment at: each.
-		class isTrait ifFalse: [
-			(package definedMethodsForClass: class) do: aBlockClosure] ]
+	package definedClasses do: [ :class | class isTrait ifFalse: [ (package definedMethodsForClass: class) do: aBlockClosure ] ]
 ]
 
 { #category : #accessing }

--- a/src/HeuristicCompletion-Model/SystemNavigation.extension.st
+++ b/src/HeuristicCompletion-Model/SystemNavigation.extension.st
@@ -35,7 +35,6 @@ SystemNavigation >> allSentMessagesInPackage: aPackage [
 { #category : #'*HeuristicCompletion-Model' }
 SystemNavigation >> allSentMessagesInPackage: aPackage do: aBlock [
 	"Answer the set of selectors which are sent somewhere in the system."
-	aPackage definedClassesDo: [ :className | | class |
-		class := Smalltalk globals at: className.
-		self allSentMessagesInClass: class do: aBlock ]
+
+	aPackage definedClasses do: [ :class | self allSentMessagesInClass: class do: aBlock ]
 ]

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -450,13 +450,6 @@ RPackage >> definedClasses [
 	^ definedClasses
 ]
 
-{ #category : #iteration }
-RPackage >> definedClassesDo: aBlock [
-
-	classDefinedSelectors keysDo: aBlock.
-	metaclassDefinedSelectors keysDo: aBlock
-]
-
 { #category : #private }
 RPackage >> definedMethodsBecomeExtendedForClass: aClassName [
 	"the package may contain defined methods and their class is removed to the receiver. The status of such methods should now be extended"

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -175,16 +175,16 @@ RPackageOrganizer >> addMethod: method [
 	"we have to register the method in the parent RPackage of the class.
 	to do that, we first have to look if the method is an extension from an external package:"
 
-	| rPackage protocol |
+	| package protocol |
 	"If the class is not packaged yet, ignore the situation. This method is created during the creation of the class or on an anonymous class"
 	method methodClass package name = RPackage defaultPackageName ifTrue: [ ^ self ].
 
 	protocol := method protocolName.
-	rPackage := (self hasPackageForProtocol: protocol)
+	package := (self hasPackageForProtocol: protocol)
 		            ifTrue: [ self packageForProtocol: protocol inClass: method methodClass ]
 		            ifFalse: [ self ensurePackage: (protocol copyWithout: $*) ].
 
-	rPackage addMethod: method
+	package addMethod: method
 ]
 
 { #category : #'system integration' }
@@ -455,16 +455,14 @@ RPackageOrganizer >> initialize [
 
 { #category : #'initialization - data' }
 RPackageOrganizer >> initializeExtensionsFor: aBehavior protocol: aProtocol [
-	| package protocolName nonTraitMethods |
 
-	protocolName := (aProtocol name allButFirst) trimBoth.
+	| package protocolName nonTraitMethods |
+	protocolName := aProtocol name allButFirst trimBoth.
 	package := (self packageMatchingExtensionName: protocolName) ifNil: [ self basicRegisterPackage: (RPackage named: protocolName organizer: self) ].
-	nonTraitMethods := aProtocol methodSelectors
-		select: [ :eachSelector | (aBehavior >> eachSelector) origin = aBehavior ].
-	nonTraitMethods ifEmpty:[^ self].
+	nonTraitMethods := aProtocol methodSelectors select: [ :eachSelector | (aBehavior >> eachSelector) origin = aBehavior ].
+	nonTraitMethods ifEmpty: [ ^ self ].
 	self registerExtendingPackage: package forClass: aBehavior.
-	nonTraitMethods
-		do: [ :eachSelector | package addMethod: aBehavior >> eachSelector ]
+	nonTraitMethods do: [ :eachSelector | package addMethod: aBehavior >> eachSelector ]
 ]
 
 { #category : #'initialization - data' }

--- a/src/Ring-Core/RGReadOnlyImageBackend.class.st
+++ b/src/Ring-Core/RGReadOnlyImageBackend.class.st
@@ -89,15 +89,11 @@ RGReadOnlyImageBackend >> createUnresolvedClassGroupFor: anRGBehavior [
 { #category : #package }
 RGReadOnlyImageBackend >> definedBehaviorsFor: anRGPackage do: aBlock [
 
-	| realPackage |
-
-	realPackage := self realPackageFor: anRGPackage.
-	realPackage ifNotNil: [
-		realPackage definedClassesDo: [:behaviorName |
-			| def cls |
-			cls := Smalltalk classOrTraitNamed: behaviorName.
-			def := self definitionFor: cls ifAbsentRegister: [cls asRingMinimalDefinitionIn: anRGPackage environment].
-			aBlock value: def.]]
+	(self realPackageFor: anRGPackage) ifNotNil: [ :realPackage |
+		realPackage definedClasses do: [ :cls |
+			| def |
+			def := self definitionFor: cls ifAbsentRegister: [ cls asRingMinimalDefinitionIn: anRGPackage environment ].
+			aBlock value: def ] ]
 ]
 
 { #category : #'trait exclusion' }


### PR DESCRIPTION
The method #definedClassesDo: is bad in multiples aspects:
- It has duplicated elements and can iterate two times over the same classes
- It iterates over the **names** of the classes while the selector let us think that it iterates over the classes.
- It does not iterate over classes without any selector!
- It used two variables that I want to remove from RPackage :D

It is as simple to do `package definedClasses do:` and the call #name on the class if needed so I propose to just deprecate this one.

The little bonus is that I want to get rid of the variables #classDefinedSelectors and #metaclassDefinedSelectors and this PR remove one users for both