### PR TITLE
safer morph access in NECMenuMorph>>#mouseDown:

### DIFF
--- a/src/NECompletion-Morphic/NECMenuMorph.class.st
+++ b/src/NECompletion-Morphic/NECMenuMorph.class.st
@@ -516,9 +516,15 @@ NECMenuMorph >> mouseDown: evt [
 	super mouseDown: evt.
 	evt wasHandled: false.
 	self flag: #pharoFixMe "ugly hack".
-	engine editor morph owner owner
-		takeKeyboardFocus;
-		handleMouseDown: evt.
+	
+	engine editor morph ifNotNil: [ :aMorph | 
+		aMorph owner ifNotNil: [ :anOwner | 
+			anOwner owner ifNotNil: [ :ownersOwner |
+				ownersOwner
+					takeKeyboardFocus;
+					handleMouseDown: evt.
+		 ] ] ].
+
 	self close
 ]
 


### PR DESCRIPTION
When the mouse even processing happens, the owning morph may not exist anymore.