### PR TITLE
Simplify class removal in packages

### DIFF
--- a/src/Monticello-Tests/RPackageExtensionMethodsSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageExtensionMethodsSynchronisationTest.class.st
@@ -163,25 +163,6 @@ RPackageExtensionMethodsSynchronisationTest >> testMoveClassInPackageWithExtensi
 ]
 
 { #category : #'tests - operations on methods' }
-RPackageExtensionMethodsSynchronisationTest >> testMoveClassInPackageWithExtensionsOnClass2 [
-	"Move a class in package XXXXX (with extensions from XXXX) to package YYYYY."
-
-	| class secondPackage |
-	self addXYCategory.
-	secondPackage := self organizer packageNamed: #YYYYY.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*XXXXX'.
-
-	secondPackage addClass: class.
-
-	"Everything should now be in second package (and not listed as an extension)."
-	self deny: (class >> #stubMethod) isClassified.
-	self assert: (secondPackage includesDefinedSelector: #stubMethod ofClass: class).
-	self deny: (secondPackage includesExtensionSelector: #stubMethod ofClass: class).
-	self assert: (class >> #stubMethod packageFromOrganizer: self organizer) equals: secondPackage
-]
-
-{ #category : #'tests - operations on methods' }
 RPackageExtensionMethodsSynchronisationTest >> testMoveClassInPackageWithExtensionsOnClassAndBack [
 	"Move a class in package XXXXX (with extensions from YYYY) to package YYYYY."
 

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -1070,12 +1070,15 @@ RPackage >> removeAllMethodsFromClassNamed: aClassNameSymbol [
 RPackage >> removeClass: aClass [
 	"Remove the class and all its methods from the receiver. If we have a protocol which looks like an extension of us, rename it to 'as yet unclassified' to avoid breaking things afterwards."
 
+	| className |
 	aClass protocols do: [ :protocol | (self isYourClassExtension: protocol) ifTrue: [ aClass renameProtocol: protocol as: Protocol unclassified ] ].
 	(self definedMethodsForClass: aClass instanceSide) do: [ :aCompiledMethod | self removeMethod: aCompiledMethod ].
 	"we also have also have to remove methods from class side"
 	(self definedMethodsForClass: aClass classSide) do: [ :aCompiledMethod | self removeMethod: aCompiledMethod ].
-	self removeClassDefinitionWithoutCheckingMethods: aClass.
-	self removeClassTagsForClassNamed: aClass instanceSide name
+
+	className := aClass instanceSide name asSymbol.
+	self removeClassDefinitionNamed: className.
+	self removeClassTagsForClassNamed: className
 ]
 
 { #category : #'class tags' }
@@ -1107,17 +1110,13 @@ RPackage >> removeClassDefinitionNamed: aClassNameSymbol [
 	(classes remove: aClassNameSymbol ifAbsent: [ nil ]) ifNotNil: [ :removed | self unregisterClass: removed ]
 ]
 
-{ #category : #private }
-RPackage >> removeClassDefinitionWithoutCheckingMethods: aClass [
-	"Same than 'removeClassDefinition', excepts that it does not make any check to set defined methods as extensions"
-
-	self removeClassDefinitionNamed: aClass instanceSide name asSymbol
-]
-
 { #category : #removing }
-RPackage >> removeClassNamed: className [
+RPackage >> removeClassNamed: aClassName [
 
-	self removeAllMethodsFromClassNamed: className.
+	| className |
+	self removeAllMethodsFromClassNamed: aClassName.
+
+	className := aClassName asSymbol.
 	self removeClassDefinitionNamed: className asSymbol.
 	self removeClassTagsForClassNamed: className
 ]

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -1070,7 +1070,7 @@ RPackage >> removeAllMethodsFromClassNamed: aClassNameSymbol [
 
 { #category : #removing }
 RPackage >> removeClass: aClass [
-	"Remove the class and all its methods from the receiver. If we have a protocol which looks like an extension of us, rename it to 'as yet unclassified' to avoid breaking things afterwards."
+	"I remove the class, methods and potential empty tags from myself."
 
 	^ self removeClassNamed: aClass instanceSide name
 ]

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -443,44 +443,10 @@ RPackage >> definedClasses [
 	^ definedClasses
 ]
 
-{ #category : #private }
-RPackage >> definedMethodsBecomeExtendedForClass: aClassName [
-	"the package may contain defined methods and their class is removed to the receiver. The status of such methods should now be extended"
-	"Precondition: aClassName is in the defined list"
-
-	| ext |
-	(classDefinedSelectors keys includes: aClassName) ifFalse: [^ self].
-	ext := classDefinedSelectors at: aClassName.
-	classDefinedSelectors removeKey: aClassName ifAbsent: [self reportBogusBehaviorOf:   #definedMethodsBecomeExtendedForClass: ].
-	(classExtensionSelectors keys includes: aClassName) ifTrue: [self error: aClassName , ' should not be defined in extension'.]. "we should remove this check later"
-	classExtensionSelectors at: aClassName put: ext
-]
-
-{ #category : #private }
-RPackage >> definedMethodsBecomeExtendedForMetaclass: aClassName [
-	"the package may contain defined methods and their class is removed to the receiver. The status of such methods should now be extended"
-	"Precondition: aClassName is in the defined list"
-
-	| ext |
-	(metaclassDefinedSelectors keys includes: aClassName) ifFalse: [^ self].
-	ext := metaclassDefinedSelectors at: aClassName.
-	metaclassDefinedSelectors removeKey: aClassName ifAbsent: [self reportBogusBehaviorOf: #definedMethodsBecomeExtendedForMetaclass:].
-	(metaclassExtensionSelectors keys includes: aClassName) ifTrue: [self error: aClassName , ' should not be defined in extension'.]. "we should remove this check later"
-	metaclassDefinedSelectors at: aClassName put: ext
-]
-
 { #category : #accessing }
 RPackage >> definedMethodsForClass: aClass [
 
 	^ (self definedSelectorsForClass: aClass) asOrderedCollection collect: [ :each | aClass >> each ]
-]
-
-{ #category : #private }
-RPackage >> definedMethodsShouldBecomeExtensionWhenRemovingClass: aClassName [
-	"the package may contain defined methods and their class is removed from the receiver. The status of such methods should now be extensions"
-
-	self definedMethodsBecomeExtendedForClass: aClassName.
-	self definedMethodsBecomeExtendedForMetaclass: aClassName
 ]
 
 { #category : #accessing }
@@ -1109,13 +1075,7 @@ RPackage >> removeClass: aClass [
 	"we also have also have to remove methods from class side"
 	(self definedMethodsForClass: aClass classSide) do: [ :aCompiledMethod | self removeMethod: aCompiledMethod ].
 	self removeClassDefinitionWithoutCheckingMethods: aClass.
-	self removeClassTagsForClassNamed: aClass name
-]
-
-{ #category : #'add class' }
-RPackage >> removeClassDefinition: aClass [
-	"Remove the class definition from the package but not its methods."
-	^ self removeClassDefinitionName: aClass instanceSide originalName
+	self removeClassTagsForClassNamed: aClass instanceSide name
 ]
 
 { #category : #'class tags' }
@@ -1131,17 +1091,14 @@ RPackage >> removeClassDefinition: aClass fromClassTag: aSymbol [
 RPackage >> removeClassDefinitionName: aClassName [
 	"remove the class definition from the package but not its method"
 
-	| aClassNameSymbol |
 	(aClassName endsWith: ' class') ifTrue: [ ^ self error: 'no metaclass name' ].
-	aClassNameSymbol := aClassName asSymbol.
-	"clean up class tags"
+
 	classTags do: [ :tag |
 		tag removeClassNamed: aClassName.
 		tag isEmpty ifTrue: [ self basicRemoveTag: tag ] ].
+
 	"remove the class definition"
-	(classes remove: aClassNameSymbol ifAbsent: [ nil ]) ifNotNil: [ :removed |
-		self definedMethodsShouldBecomeExtensionWhenRemovingClass: aClassName.
-		self unregisterClass: aClassNameSymbol ]
+	self removeClassDefinitionNamed: aClassName asSymbol
 ]
 
 { #category : #'class tags' }
@@ -1173,8 +1130,9 @@ RPackage >> removeClassDefinitionWithoutCheckingMethods: aClass [
 
 { #category : #removing }
 RPackage >> removeClassNamed: className [
-	self removeClassDefinitionName: className.
+
 	self removeAllMethodsFromClassNamed: className.
+	self removeClassDefinitionName: className.
 	self removeClassTagsForClassNamed: className
 ]
 
@@ -1195,12 +1153,6 @@ RPackage >> removeClassTagsForClassNamed: aString [
 			self
 				removeClassDefinitionName: aString
 				fromClassTag: eachTag name ]
-]
-
-{ #category : #'class tags' }
-RPackage >> removeClassesMatchingTag: aTag [
-
-	aTag classes do: [ :class | self removeClassDefinition: class ]
 ]
 
 { #category : #'class tags' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -1060,25 +1060,19 @@ RPackage >> registerClassName: aClassNameSymbol [
 RPackage >> removeAllMethodsFromClassNamed: aClassNameSymbol [
 	"Remove all the methods (defined and extensions) that are related to class aClassNameSymbol. aClassNameSymbol is the name of a class and not a metaclass - see class comment."
 
-	classDefinedSelectors removeKey: aClassNameSymbol ifAbsent: [nil].
-	classExtensionSelectors removeKey: aClassNameSymbol ifAbsent: [nil].
-	metaclassDefinedSelectors removeKey: aClassNameSymbol ifAbsent: [nil].
-	metaclassExtensionSelectors removeKey: aClassNameSymbol ifAbsent: [nil]
+	classDefinedSelectors removeKey: aClassNameSymbol ifAbsent: [ nil ].
+	classExtensionSelectors removeKey: aClassNameSymbol ifAbsent: [ nil ].
+	metaclassDefinedSelectors removeKey: aClassNameSymbol ifAbsent: [ nil ].
+	metaclassExtensionSelectors removeKey: aClassNameSymbol ifAbsent: [ nil ].
+
+	self organizer unregisterExtendingPackage: self forClassName: aClassNameSymbol
 ]
 
 { #category : #removing }
 RPackage >> removeClass: aClass [
 	"Remove the class and all its methods from the receiver. If we have a protocol which looks like an extension of us, rename it to 'as yet unclassified' to avoid breaking things afterwards."
 
-	| className |
-	aClass protocols do: [ :protocol | (self isYourClassExtension: protocol) ifTrue: [ aClass renameProtocol: protocol as: Protocol unclassified ] ].
-	(self definedMethodsForClass: aClass instanceSide) do: [ :aCompiledMethod | self removeMethod: aCompiledMethod ].
-	"we also have also have to remove methods from class side"
-	(self definedMethodsForClass: aClass classSide) do: [ :aCompiledMethod | self removeMethod: aCompiledMethod ].
-
-	className := aClass instanceSide name asSymbol.
-	self removeClassDefinitionNamed: className.
-	self removeClassTagsForClassNamed: className
+	^ self removeClassNamed: aClass instanceSide name
 ]
 
 { #category : #'class tags' }
@@ -1114,10 +1108,9 @@ RPackage >> removeClassDefinitionNamed: aClassNameSymbol [
 RPackage >> removeClassNamed: aClassName [
 
 	| className |
-	self removeAllMethodsFromClassNamed: aClassName.
-
 	className := aClassName asSymbol.
-	self removeClassDefinitionNamed: className asSymbol.
+	self removeAllMethodsFromClassNamed: className.
+	self removeClassDefinitionNamed: className.
 	self removeClassTagsForClassNamed: className
 ]
 

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -1087,20 +1087,6 @@ RPackage >> removeClassDefinition: aClass fromClassTag: aSymbol [
 		fromClassTag: aSymbol
 ]
 
-{ #category : #'add class' }
-RPackage >> removeClassDefinitionName: aClassName [
-	"remove the class definition from the package but not its method"
-
-	(aClassName endsWith: ' class') ifTrue: [ ^ self error: 'no metaclass name' ].
-
-	classTags do: [ :tag |
-		tag removeClassNamed: aClassName.
-		tag isEmpty ifTrue: [ self basicRemoveTag: tag ] ].
-
-	"remove the class definition"
-	self removeClassDefinitionNamed: aClassName asSymbol
-]
-
 { #category : #'class tags' }
 RPackage >> removeClassDefinitionName: aClassName fromClassTag: aSymbol [
 	"Detags the class aClass with the tag aSymbol"
@@ -1132,7 +1118,7 @@ RPackage >> removeClassDefinitionWithoutCheckingMethods: aClass [
 RPackage >> removeClassNamed: className [
 
 	self removeAllMethodsFromClassNamed: className.
-	self removeClassDefinitionName: className.
+	self removeClassDefinitionNamed: className asSymbol.
 	self removeClassTagsForClassNamed: className
 ]
 

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -1152,10 +1152,7 @@ RPackageOrganizer >> unregisterExtendingPackage: aPackage forClass: aClass [
 { #category : #'private - registration' }
 RPackageOrganizer >> unregisterExtendingPackage: aPackage forClassName: aClassName [
 
-	| cur |
-
-	cur := classExtendingPackagesMapping at: aClassName asSymbol ifAbsent: [ nil ].
-	cur ifNotNil: [ cur remove: aPackage ifAbsent: [ "not happy with this one" ] ]
+	classExtendingPackagesMapping at: aClassName asSymbol ifPresent: [ :listOfPackages | listOfPackages remove: aPackage ifAbsent: [  ] ]
 ]
 
 { #category : #'system integration' }

--- a/src/RPackage-Tests/RPackageCompleteSetupButForModificationTest.class.st
+++ b/src/RPackage-Tests/RPackageCompleteSetupButForModificationTest.class.st
@@ -69,13 +69,13 @@ RPackageCompleteSetupButForModificationTest >> testBasicRemoveClass [
 	self assert: size equals: 2.
 	self assert: (p1 includesClass: a1).
 	self assert: (p1 includesClass: a1 class).
-	p1 removeClassDefinition: a1.
+	p1 removeClass: a1.
 	self assert: p1 definedClasses size equals: (size - 1).
 	self assert: (p1 includesClass: b1).
 	self assert: (p1 includesClass: b1 class).
 	self deny: (p1 includesClass: a1).
 	self deny: (p1 includesClass: a1 class).
-	p1 removeClassDefinition: b1.
+	p1 removeClass: b1.
 	self assert: p1 definedClasses size equals: (size - 2).
 	self deny: (p1 includesClass: b1).
 	self deny: (p1 includesClass: b1 class)

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -268,12 +268,12 @@ RPackageIncrementalTest >> testClassDefinitionRemoval [
 	self assert: (p includesClass: a1).
 	self assert: (p includesClass: b1).
 
-	p removeClassDefinition: a1.
+	p removeClass: a1.
 	self assert: p definedClasses size equals: 1.
 	self deny: (p includesClass: a1).
 	self assert: (p includesClass: b1).
 
-	p removeClassDefinition: b1 class.
+	p removeClass: b1 class.
 	self deny: (p includesClass: b1)
 ]
 
@@ -297,12 +297,12 @@ RPackageIncrementalTest >> testClassDefinitionWithTagsRemoval [
 	self assert: (p includesClass: a1).
 	self assert: (p includesClass: b1).
 
-	p removeClassDefinition: a1.
+	p removeClass: a1.
 	self assert: p definedClasses size equals: 1.
 	self deny: (p includesClass: a1).
 	self assert: (p includesClass: b1).
 
-	p removeClassDefinition: b1 class.
+	p removeClass: b1 class.
 	self deny: (p includesClass: b1).
 	self assert: p classTags size equals: 0
 ]
@@ -669,32 +669,6 @@ RPackageIncrementalTest >> testPrivateClassRegisterUnregister [
 	p definedClassNames remove: #A1InPackageP1.
 	p unregisterClass: a1.
 	self assert: (RPackage organizer packageOf: a1) isDefault
-]
-
-{ #category : #'tests - class addition removal' }
-RPackageIncrementalTest >> testRemoveClassAfterMethods [
-	| p1 a1 |
-	p1 := self createNewPackageNamed: self p1Name.
-	"the class is created but not added to the package for now"
-	a1 := self createNewClassNamed: #A1InPackageP1 inCategory: self p1Name.
-	p1 addClassDefinition: a1.
-	self assert: p1 definedClasses size equals: 1.
-	a1 compileSilently: 'newlyAddedToA1 ^ #methodDefinedInP1'.
-	p1 addMethod: (a1>>#newlyAddedToA1).
-
-	"now we add a new method to the class and the to the package: it is considered
-	as defined"
-	self deny: (p1 includesExtensionSelector: #newlyAddedToA1 ofClass: a1).
-	self assert: (p1 includesDefinedSelector: #newlyAddedToA1 ofClass: a1).
-
-	p1 removeClassDefinition: a1.
-	self assert: p1 definedClasses size equals: 0.
-
-	self assert: (p1 includesSelector: #newlyAddedToA1 ofClass: a1).
-	self assert: (p1 includesExtensionSelector: #newlyAddedToA1 ofClass: a1).
-	self deny: (p1 includesDefinedSelector: #newlyAddedToA1 ofClass: a1).
-
-	"Now we add the class and this means that the method is not defined anymore but an extension "
 ]
 
 { #category : #'tests - class addition removal' }


### PR DESCRIPTION
## Simplify cache cleaning

RPackage contains a lot of methods to update its caches. A bunch of them are there for the method #definedMethodsShouldBecomeExtensionWhenRemovingClass: to update the cache of the methods.

But this method is only called by two methods:
- One that remove all methods right after (making the update of the caches useless)
- One that is called only by tests

Since all those updates are not necessary and one of my mid-term goal is to remove the selectors caches, I'm proposing to just remove all this mess to make the system a little bit simpler.

## Unifying #removeClass: and #removeClassNamed:

With the previous simplification, it becomes more obvious how to unify #removeClass: and #removeClassNamed:. With this, I found that some operations such is the removal of the class from the class tags was sometimes duplicated and I removed this duplication.

Then I also removed a duplication on the methods removal and fixed a bug when removing all the methods was not removing a cache in RPackageOrganizer. (The cache to know which packages are extending a class)