### PR TITLE
Do not remove classes from packages using the name

### DIFF
--- a/src/Deprecated12/RPackage.extension.st
+++ b/src/Deprecated12/RPackage.extension.st
@@ -7,3 +7,10 @@ RPackage >> definedClassesDo: aBlock [
 		'Use #definedClasses and a do instead because the name of this method is not explicit since it iterates over the *name* of the classes and not the classes themselves.'.
 	^ classes do: aBlock
 ]
+
+{ #category : #'*Deprecated12' }
+RPackage >> removeClassNamed: aClassName [
+
+	self deprecated: 'Use #removeClass: with a real class instead.'.
+	^ self removeClass: (self organizer environment at: aClassName)
+]

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -1074,40 +1074,23 @@ RPackage >> removeAllMethodsFromClass: aClass [
 RPackage >> removeClass: aClass [
 	"I remove the class, methods and potential empty tags from myself."
 
-	| className |
-	className := aClass instanceSide originalName asSymbol.
+	"First I remove all the methods of the class from myself."
 	self removeAllMethodsFromClass: aClass.
-	self removeClassDefinitionNamed: className.
-	self removeClassTagsForClassNamed: className
+
+	"Then I remove the class from myself."
+	(classes remove: aClass originalName asSymbol ifAbsent: [ nil ]) ifNotNil: [ self unregisterClass: aClass ].
+
+	"Lastly I unregister it from the tags"
+	(self classTags select: [ :eachTag | eachTag includesClass: aClass ]) do: [ :eachTag | self removeClassDefinition: aClass fromClassTag: eachTag name ]
 ]
 
 { #category : #'class tags' }
 RPackage >> removeClassDefinition: aClass fromClassTag: aSymbol [
-	"Detags the class aClass with the tag aSymbol"
 
-	self
-		removeClassDefinitionName: aClass name
-		fromClassTag: aSymbol
-]
-
-{ #category : #'class tags' }
-RPackage >> removeClassDefinitionName: aClassName fromClassTag: aSymbol [
-	"Detags the class aClass with the tag aSymbol"
 	| tag |
-
 	tag := self classTagNamed: (self toTagName: aSymbol) ifAbsent: [ ^ self ].
-	tag removeClassNamed: aClassName.
-	tag isEmpty
-		ifTrue: [ self basicRemoveTag: tag ]
-]
-
-{ #category : #'private - register' }
-RPackage >> removeClassDefinitionNamed: aClassNameSymbol [
-	"aClassNameSymbol should be the name of a class and not a metaclass to be coherent with the class invariant that classes are only class names and not metaclass ones.
-
-	This method removes the class definition from the receiver and its organizer"
-
-	(classes remove: aClassNameSymbol ifAbsent: [ nil ]) ifNotNil: [ :removed | self unregisterClass: removed ]
+	tag removeClass: aClass.
+	tag isEmpty ifTrue: [ self basicRemoveTag: tag ]
 ]
 
 { #category : #'class tags' }
@@ -1117,16 +1100,6 @@ RPackage >> removeClassTag: aSymbol [
 	self basicRemoveTag: (self
 		classTagNamed:  (self toTagName: aSymbol)
 		ifAbsent: [ ^ self ])
-]
-
-{ #category : #'class tags' }
-RPackage >> removeClassTagsForClassNamed: aString [
-	(self classTags
-		select: [ :eachTag | eachTag hasClassNamed: aString ])
-		do: [ :eachTag |
-			self
-				removeClassDefinitionName: aString
-				fromClassTag: eachTag name ]
 ]
 
 { #category : #'class tags' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -1057,9 +1057,11 @@ RPackage >> registerClassName: aClassNameSymbol [
 ]
 
 { #category : #'private - register' }
-RPackage >> removeAllMethodsFromClassNamed: aClassNameSymbol [
-	"Remove all the methods (defined and extensions) that are related to class aClassNameSymbol. aClassNameSymbol is the name of a class and not a metaclass - see class comment."
+RPackage >> removeAllMethodsFromClass: aClass [
+	"Remove all the methods (defined and extensions) that are related to the class as parameter. The class should always be instance side."
 
+	| aClassNameSymbol |
+	aClassNameSymbol := aClass originalName asSymbol.
 	classDefinedSelectors removeKey: aClassNameSymbol ifAbsent: [ nil ].
 	classExtensionSelectors removeKey: aClassNameSymbol ifAbsent: [ nil ].
 	metaclassDefinedSelectors removeKey: aClassNameSymbol ifAbsent: [ nil ].
@@ -1072,7 +1074,11 @@ RPackage >> removeAllMethodsFromClassNamed: aClassNameSymbol [
 RPackage >> removeClass: aClass [
 	"I remove the class, methods and potential empty tags from myself."
 
-	^ self removeClassNamed: aClass instanceSide originalName
+	| className |
+	className := aClass instanceSide originalName asSymbol.
+	self removeAllMethodsFromClass: aClass.
+	self removeClassDefinitionNamed: className.
+	self removeClassTagsForClassNamed: className
 ]
 
 { #category : #'class tags' }
@@ -1102,16 +1108,6 @@ RPackage >> removeClassDefinitionNamed: aClassNameSymbol [
 	This method removes the class definition from the receiver and its organizer"
 
 	(classes remove: aClassNameSymbol ifAbsent: [ nil ]) ifNotNil: [ :removed | self unregisterClass: removed ]
-]
-
-{ #category : #removing }
-RPackage >> removeClassNamed: aClassName [
-
-	| className |
-	className := aClassName asSymbol.
-	self removeAllMethodsFromClassNamed: className.
-	self removeClassDefinitionNamed: className.
-	self removeClassTagsForClassNamed: className
 ]
 
 { #category : #'class tags' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -186,7 +186,7 @@ RPackage >> addClassDefinition: aClass [
 	(classes includes: aClassName) ifTrue: [ ^ self ].
 	classes add: aClassName.
 	self extendedMethodsShouldBecomeDefinedWhenAddingClassName: aClassName.
-	self registerClassName: aClassName
+	self registerClass: aClass
 ]
 
 { #category : #'class tags' }
@@ -1045,15 +1045,8 @@ RPackage >> register [
 { #category : #'private - register' }
 RPackage >> registerClass: aClass [
 	"Private method that declares the mapping between a class and its package."
-	self organizer
-		registerPackage: self forClass: aClass
-]
 
-{ #category : #'private - register' }
-RPackage >> registerClassName: aClassNameSymbol [
-	"Private method that declares the mapping between a class and its package."
-	self organizer
-		registerPackage: self forClassName: aClassNameSymbol
+	self organizer registerPackage: self forClass: aClass
 ]
 
 { #category : #'private - register' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -1072,7 +1072,7 @@ RPackage >> removeAllMethodsFromClassNamed: aClassNameSymbol [
 RPackage >> removeClass: aClass [
 	"I remove the class, methods and potential empty tags from myself."
 
-	^ self removeClassNamed: aClass instanceSide name
+	^ self removeClassNamed: aClass instanceSide originalName
 ]
 
 { #category : #'class tags' }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -1165,7 +1165,7 @@ RPackageOrganizer >> unregisterPackage: aPackage forClass: aClass [
 	| className |
 	className := (aClass isString
 		              ifTrue: [ aClass ]
-		              ifFalse: [ aClass instanceSide name ]) asSymbol.
+		              ifFalse: [ aClass instanceSide originalName ]) asSymbol.
 
 	^ classPackageMapping removeKey: className ifAbsent: [ self error: aPackage name , ' still includes the class ' , className ]
 ]

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -798,8 +798,9 @@ RPackageOrganizer >> removeCategory: aCategory [
 RPackageOrganizer >> removeClass: class [
 	"Remove the class, the class backpointer, the extensions and the extension backPointer from the receiver and the class involved with the class named: className. className is a class name and should not be a metaclass one. "
 
+	class isClassSide ifTrue: [ self error: 'We should only be able to remove classes and not instances of metaclass.' ].
 	(self packageOf: class) removeClass: class.
-	(self extendingPackagesOf: class) do: [ :extendedPackage | extendedPackage removeAllMethodsFromClassNamed: class originalName ]
+	(self extendingPackagesOf: class) do: [ :extendedPackage | extendedPackage removeAllMethodsFromClass: class ]
 ]
 
 { #category : #cleanup }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -735,20 +735,9 @@ RPackageOrganizer >> registerPackage: aPackage [
 
 { #category : #'private - registration' }
 RPackageOrganizer >> registerPackage: aPackage forClass: aClass [
-	(aPackage includesClass: aClass)
-		ifFalse:
-			[self error: aPackage name , ' does not includes the class ' , aClass name].
-	^classPackageMapping at: aClass instanceSide name put: aPackage
-]
 
-{ #category : #'private - registration' }
-RPackageOrganizer >> registerPackage: aPackage forClassName: aClassNameSymbol [
-	"Register aPackage as the package of the class aClassNameSymbol. The package should contain the class in its class definitions."
-
-	(aPackage includesClassNamed: aClassNameSymbol asSymbol)
-		ifFalse:
-			[self error: aPackage name , ' does not include the class ' , aClassNameSymbol].
-	^classPackageMapping at: aClassNameSymbol put: aPackage
+	(aPackage includesClass: aClass) ifFalse: [ self error: aPackage name , ' does not includes the class ' , aClass name ].
+	^ classPackageMapping at: aClass instanceSide originalName put: aPackage
 ]
 
 { #category : #'deprecated - SystemOrganizer leftovers' }
@@ -985,7 +974,7 @@ RPackageOrganizer >> systemClassRenamedActionFrom: ann [
 	"we have to update the RPackageOrganizer.
 	update the 'classPackageDictionary' to replace the key with the new class name"
 	self unregisterPackage: package forClass: oldName.
-	self registerPackage: package forClassName: newName.
+	self registerPackage: package forClass: class.
 
 	"update the 'classExtendingPackagesMapping' to replace the key with the new class name"
 	extendingPackages do: [:aRPackage |

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -349,7 +349,8 @@ RPackageOrganizer >> environment: aSystemDictionary [
 { #category : #'package - access from class' }
 RPackageOrganizer >> extendingPackagesOf: aClass [
 	"Returns the packages extending the class aClass"
-	^ classExtendingPackagesMapping at: aClass instanceSide name ifAbsent: [#()]
+
+	^ self extendingPackagesOfClassNamed: aClass instanceSide originalName
 ]
 
 { #category : #'package - access from class' }
@@ -797,11 +798,8 @@ RPackageOrganizer >> removeCategory: aCategory [
 RPackageOrganizer >> removeClass: class [
 	"Remove the class, the class backpointer, the extensions and the extension backPointer from the receiver and the class involved with the class named: className. className is a class name and should not be a metaclass one. "
 
-	| rPackage className |
-	className := class originalName.
-	rPackage := (self packageOfClassNamed: className) ifNil: [ ^ self ].
-	rPackage removeClassNamed: className.
-	(self extendingPackagesOfClassNamed: className) do: [ :each | each removeAllMethodsFromClassNamed: className ]
+	(self packageOf: class) removeClass: class.
+	(self extendingPackagesOf: class) do: [ :extendedPackage | extendedPackage removeAllMethodsFromClassNamed: class originalName ]
 ]
 
 { #category : #cleanup }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -358,16 +358,6 @@ RPackageOrganizer >> extendingPackagesOfClassNamed: aName [
 	^ classExtendingPackagesMapping at: aName asSymbol ifAbsent: [#()]
 ]
 
-{ #category : #'system integration' }
-RPackageOrganizer >> fullyRemoveClassNamed: className [
-	"Remove the class, the class backpointer, the extensions and the extension backPointer from the receiver and the class involved with the class named: className. className is a class name and should not be a metaclass one. "
-
-	| rPackage |
-	rPackage := (self packageOfClassNamed: className) ifNil: [ ^ self ].
-	rPackage removeClassNamed: className.
-	(self extendingPackagesOfClassNamed: className) do: [ :each | each removeAllMethodsFromClassNamed: className ]
-]
-
 { #category : #'package - access from class' }
 RPackageOrganizer >> globalPackageOf: aClass [
 	"this method should return the 'global' parent package of aClass, that means the package holding the (possible) subcategory in which aClass is concretely defined. For example, 'Object package' returns Kernel-Object, whereas 'PackageOrganizer packageOf: Object' returns Kernel. So I guess that all use of 'packageOf' should be replaced by this method  "
@@ -803,6 +793,17 @@ RPackageOrganizer >> removeCategory: aCategory [
 	SystemAnnouncer uniqueInstance classCategoryRemoved: category
 ]
 
+{ #category : #'system integration' }
+RPackageOrganizer >> removeClass: class [
+	"Remove the class, the class backpointer, the extensions and the extension backPointer from the receiver and the class involved with the class named: className. className is a class name and should not be a metaclass one. "
+
+	| rPackage className |
+	className := class originalName.
+	rPackage := (self packageOfClassNamed: className) ifNil: [ ^ self ].
+	rPackage removeClassNamed: className.
+	(self extendingPackagesOfClassNamed: className) do: [ :each | each removeAllMethodsFromClassNamed: className ]
+]
+
 { #category : #cleanup }
 RPackageOrganizer >> removeEmptyPackagesAndTags [
 	"Remove empty packages and tags."
@@ -962,11 +963,7 @@ RPackageOrganizer >> systemClassRecategorizedActionFrom: announcement [
 RPackageOrganizer >> systemClassRemovedActionFrom: ann [
 	"A class has been removed, we should update the package adequately."
 
-	| class className |
-	class := ann classRemoved.
-	className  := class originalName.
-
-	self fullyRemoveClassNamed: className
+	self removeClass: ann classRemoved
 ]
 
 { #category : #'system integration' }

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -650,21 +650,14 @@ RPackageIncrementalTest >> testPackageOfClassForDefinedClasses [
 { #category : #'tests - registration' }
 RPackageIncrementalTest >> testPrivateClassRegisterUnregister [
 	"Verify that when we register a class, the package organizer register it."
+
 	| p a1 |
 	p := self createNewPackageNamed: 'P1'.
 	a1 := self createNewClassNamed: #A1InPackageP1.
 	p definedClassNames add: #A1InPackageP1.
-		"ugly but necessary to test registerClass: independantly from addClassDefinition:"
-		"No event should be raised."
+	"ugly but necessary to test registerClass: independantly from addClassDefinition:"
+	"No event should be raised."
 	p registerClass: a1.
-	self assert: (RPackage organizer packageOf: a1) equals: p.
-	p definedClassNames remove: #A1InPackageP1.
-	p unregisterClass: a1.
-	self assert: (RPackage organizer packageOf: a1) isDefault.
-
-	p definedClassNames add: #A1InPackageP1.
-		"ugly but necessary to test registerClass: independant from addClassDefinition:"
-	p registerClassName: a1 name.
 	self assert: (RPackage organizer packageOf: a1) equals: p.
 	p definedClassNames remove: #A1InPackageP1.
 	p unregisterClass: a1.

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -273,7 +273,7 @@ RPackageIncrementalTest >> testClassDefinitionRemoval [
 	self deny: (p includesClass: a1).
 	self assert: (p includesClass: b1).
 
-	p removeClass: b1 class.
+	p removeClass: b1.
 	self deny: (p includesClass: b1)
 ]
 
@@ -302,7 +302,7 @@ RPackageIncrementalTest >> testClassDefinitionWithTagsRemoval [
 	self deny: (p includesClass: a1).
 	self assert: (p includesClass: b1).
 
-	p removeClass: b1 class.
+	p removeClass: b1.
 	self deny: (p includesClass: b1).
 	self assert: p classTags size equals: 0
 ]

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -360,21 +360,21 @@ RPackageReadOnlyCompleteSetupTest >> testRemoveTaggedClasses [
 	p1 addClassDefinition: a1 toClassTag: #foo.
 	p1 addClassDefinition: b1 toClassTag: #foo.
 	p1 addClassDefinition: b1 toClassTag: #zork.
-	self assert: (((p1 classesForClassTag: #foo) collect: [:each | each name]) includes: #A1DefinedInP1).
-	self assert: (((p1 classesForClassTag: #foo) collect: [:each | each name]) includes: #B1DefinedInP1).
+	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
+	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
 	self assert: (p1 classesForClassTag: #foo) size equals: 2.
-	self deny: (((p1 classesForClassTag: #zork) collect: [:each | each name]) includes: #A1DefinedInP1).
-	self assert: (((p1 classesForClassTag: #zork) collect: [:each | each name]) includes: #B1DefinedInP1).	"now when we remove a class"	"from an existing tags list"
-	p1 removeClassDefinitionName: #A1DefinedInP1 fromClassTag: #foo.
-	self deny: (((p1 classesForClassTag: #foo) collect: [:each | each name]) includes: #A1DefinedInP1).
-	self assert: (((p1 classesForClassTag: #foo) collect: [:each | each name]) includes: #B1DefinedInP1).
-	self assert: (p1 classesForClassTag: #foo) size equals: 1.	"from a nonexisting tag list"
-	p1 removeClassDefinitionName: #B1DefinedInP1 fromClassTag: #taz.
-	self assert: (((p1 classesForClassTag: #foo) collect: [:each | each name]) includes: #B1DefinedInP1).
-	self assert: (((p1 classesForClassTag: #zork) collect: [:each | each name]) includes: #B1DefinedInP1).	"with a class not registered to a tag list"
-	p1 removeClassDefinitionName: #Tagada fromClassTag: #foo.
-	self deny: (((p1 classesForClassTag: #foo) collect: [:each | each name]) includes: #A1DefinedInP1).
-	self assert: (((p1 classesForClassTag: #foo) collect: [:each | each name]) includes: #B1DefinedInP1).
+	self deny: (((p1 classesForClassTag: #zork) collect: [ :each | each name ]) includes: #A1DefinedInP1).
+	self assert: (((p1 classesForClassTag: #zork) collect: [ :each | each name ]) includes: #B1DefinedInP1). "now when we remove a class" "from an existing tags list"
+	p1 removeClassDefinition: a1 fromClassTag: #foo.
+	self deny: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
+	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+	self assert: (p1 classesForClassTag: #foo) size equals: 1. "from a nonexisting tag list"
+	p1 removeClassDefinition: b1 fromClassTag: #taz.
+	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+	self assert: (((p1 classesForClassTag: #zork) collect: [ :each | each name ]) includes: #B1DefinedInP1). "with a class not registered to a tag list"
+	p1 removeClassDefinition: self class fromClassTag: #foo.
+	self deny: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
+	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
 	self assert: (p1 classesForClassTag: #foo) size equals: 1
 ]
 


### PR DESCRIPTION
One of my mid term goal in the simplification of RPackage is to use real classes instead of manipulating class names everywhere.

Here is on step. 

RPackage has two ways of removing a class. #removeClass: and #removeClassNamed: and the version using the class directly call multiple methods in which I found bugs because it was not taking into account obsolete classes. 
Of course, the system currently uses #removeClassNamed: to remove a class. 

I propose in this change to first fix the bugs I found and then to use #removeClass: and to remove all the code based on the names since I want to have real classes in packages in the future.

I also started to remove the name management from the registration.