### PR TITLE
Do not use global environment in RPackage

### DIFF
--- a/src/Calypso-SystemQueries/RPackage.extension.st
+++ b/src/Calypso-SystemQueries/RPackage.extension.st
@@ -41,7 +41,7 @@ RPackage >> definesOverridesOf: aMethod in: classAndSelectors [
 
 	classAndSelectors keysAndValuesDo: [ :className :selectors |
 		((selectors includes: selector)
-			and: [ (Smalltalk globals classNamed: className) inheritsFrom: methodClass ])
+			and: [ (self environment classNamed: className) inheritsFrom: methodClass ])
 				ifTrue: [ ^true ] ].
 	^false
 ]
@@ -55,7 +55,7 @@ RPackage >> definesOverridesOfClassSide: aMethod in: classAndSelectors [
 
 	classAndSelectors keysAndValuesDo: [ :className :selectors |
 		((selectors includes: selector)
-			and: [ (Smalltalk globals classNamed: className) classSide inheritsFrom: methodClass ])
+			and: [ (self environment classNamed: className) classSide inheritsFrom: methodClass ])
 				ifTrue: [ ^true ] ].
 	^false
 ]

--- a/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
@@ -272,7 +272,7 @@ RPackageClassesSynchronisationTest >> testRemoveClassUnregisterTheClassDefinedMe
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass: class  inCategory: 'classic category'. 
 	
-	Smalltalk removeClassNamed: 'NewClass'. 
+	self organizer environment removeClassNamed: 'NewClass'. 
 	self deny: (XPackage includesSelector: #stubMethod ofClass: class). 
 ]
 
@@ -287,7 +287,7 @@ RPackageClassesSynchronisationTest >> testRemoveClassUnregisterTheClassExtension
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass: class  inCategory: '*yyyyy'. 
 	
-	Smalltalk removeClassNamed: 'NewClass'. 
+	self organizer environment removeClassNamed: 'NewClass'. 
 	self deny: (YPackage includesSelector: #stubMethod ofClass: class). 
 ]
 
@@ -300,20 +300,20 @@ RPackageClassesSynchronisationTest >> testRemoveClassUnregisterTheClassFromItsPa
 	XPackage := self organizer packageNamed: #XXXXX.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
 	
-	Smalltalk removeClassNamed: 'NewClass'. 
+	self organizer environment removeClassNamed: 'NewClass'. 
 	self deny: (XPackage includesClass: class)
 ]
 
 { #category : #'tests - removing classes' }
 RPackageClassesSynchronisationTest >> testRemoveClassUpdateTheOrganizerMappings [
 	"test that when we remove a class, the organizer is updated so that the class is no longer present in the  'classPackageDictionary' dictionary"
-	
-	|XPackage  class|
+
+	| XPackage class |
 	self addXCategory.
 	XPackage := self organizer packageNamed: #XXXXX.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
 
-	Smalltalk removeClassNamed: 'NewClass'. 
+	self organizer environment removeClassNamed: 'NewClass'.
 	self deny: (self organizer includesPackageBackPointerForClass: class)
 ]
 

--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -61,7 +61,7 @@ RPackageMCSynchronisationTest >> addZCategory [
 { #category : #setup }
 RPackageMCSynchronisationTest >> cleanClassesPackagesAndCategories [
 
-	Smalltalk
+	self organizer environment
 		removeClassNamed: 'NewClass';
 		removeClassNamed: 'RPackageNewStubClass';
 		removeClassNamed: 'RPackageOldStubClass';

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -439,7 +439,7 @@ RPackage >> definedClasses [
 
 	| definedClasses |
 	definedClasses := Set new: classes size.
-	classes do: [ :each | Smalltalk globals at: each ifPresent: [ :aClass | definedClasses add: aClass ] ].
+	classes do: [ :each | self environment at: each ifPresent: [ :aClass | definedClasses add: aClass ] ].
 	^ definedClasses
 ]
 
@@ -499,6 +499,12 @@ RPackage >> ensureProperties [
 ]
 
 { #category : #accessing }
+RPackage >> environment [
+
+	^ self organizer environment
+]
+
+{ #category : #accessing }
 RPackage >> extendedClassNames [
 	"Return the name of the classes which are extended by the receiver package. if a metaclass is extended, just get its sole instance class name."
 
@@ -508,12 +514,12 @@ RPackage >> extendedClassNames [
 { #category : #accessing }
 RPackage >> extendedClasses [
 	"Return classes and metaclasses that are extended in the receiver. They represent the classes of method extensions"
+
 	^ (metaclassExtensionSelectors keys
-		select: [ :each| Smalltalk globals includesKey: each ]
-		thenCollect: [:each | (Smalltalk globals at: each) classSide])
-			union:  (classExtensionSelectors keys
-						select: [ :each| Smalltalk globals includesKey: each ]
-						thenCollect: [:each | Smalltalk globals at: each])
+		   select: [ :each | self environment includesKey: each ]
+		   thenCollect: [ :each | (self environment at: each) classSide ]) union: (classExtensionSelectors keys
+			   select: [ :each | self environment includesKey: each ]
+			   thenCollect: [ :each | self environment at: each ])
 ]
 
 { #category : #private }
@@ -573,13 +579,13 @@ RPackage >> extensionCategoriesForClass: aClass [
 { #category : #accessing }
 RPackage >> extensionMethods [
 	"Extension methods are methods defined on classes that are not defined in the receiver"
-	| allExtensionMethods |
 
+	| allExtensionMethods |
 	allExtensionMethods := OrderedCollection new.
 	classExtensionSelectors keysAndValuesDo: [ :classSymbol :methods |
-		methods do: [ :selector | allExtensionMethods add: ((Smalltalk globals at: classSymbol) >> selector) ] ].
+		methods do: [ :selector | allExtensionMethods add: (self environment at: classSymbol) >> selector ] ].
 	metaclassExtensionSelectors keysAndValuesDo: [ :classSymbol :methods |
-		methods do: [ :selector | allExtensionMethods add: ((Smalltalk globals at: classSymbol) classSide >> selector) ] ].
+		methods do: [ :selector | allExtensionMethods add: (self environment at: classSymbol) classSide >> selector ] ].
 
 	^ allExtensionMethods
 ]
@@ -895,19 +901,15 @@ RPackage >> methodCategoryPrefix [
 { #category : #accessing }
 RPackage >> methods [
 	"Return all the methods defined in this package. Including extension methods (i.e., methods defined on a class that is not defined by me)"
-	| methods |
 
+	| methods |
 	methods := OrderedCollection new.
 
-	metaclassExtensionSelectors keysAndValuesDo: [:key :val |
-		val do: [:sel | 	methods add: ((Smalltalk globals at: key) classSide >> sel)]].
-	classExtensionSelectors keysAndValuesDo: [:key :val |
-		val do: [:sel | methods add: ((Smalltalk globals at: key) >> sel)]].
+	metaclassExtensionSelectors keysAndValuesDo: [ :key :val | val do: [ :sel | methods add: (self environment at: key) classSide >> sel ] ].
+	classExtensionSelectors keysAndValuesDo: [ :key :val | val do: [ :sel | methods add: (self environment at: key) >> sel ] ].
 
-	metaclassDefinedSelectors keysAndValuesDo: [:key :val |
-		val do: [:sel | methods add: ((Smalltalk globals at: key) classSide >> sel)]].
-	classDefinedSelectors keysAndValuesDo: [:key :val |
-		val do: [:sel | methods add: ((Smalltalk globals at: key) >> sel)]].
+	metaclassDefinedSelectors keysAndValuesDo: [ :key :val | val do: [ :sel | methods add: (self environment at: key) classSide >> sel ] ].
+	classDefinedSelectors keysAndValuesDo: [ :key :val | val do: [ :sel | methods add: (self environment at: key) >> sel ] ].
 
 	^ methods
 ]

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -69,7 +69,8 @@ RPackageTag >> classNames [
 
 { #category : #accessing }
 RPackageTag >> classes [
-	^ self classNames collect: [ :each | self class environment at: each ]
+
+	^ self classNames collect: [ :each | self environment at: each ]
 ]
 
 { #category : #accessing }
@@ -77,6 +78,12 @@ RPackageTag >> ensureSystemCategory [
 	"We should not hardcode the global variable but ask the package organizer for the organization."
 
 	self packageOrganizer addCategory: self categoryName
+]
+
+{ #category : #accessing }
+RPackageTag >> environment [
+
+	^ self package environment
 ]
 
 { #category : #accessing }
@@ -122,9 +129,8 @@ RPackageTag >> includesProtocol: protocol ofClass: aClass [
 
 { #category : #testing }
 RPackageTag >> includesSelector: aSelector ofClass: aClass [
-	^ self package
-		includesSelector: aSelector
-		ofClass: aClass
+
+	^ self package includesSelector: aSelector ofClass: aClass
 ]
 
 { #category : #initialization }

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -52,7 +52,7 @@ RPackageOrganizerTest >> pointRectangleInGraphElement [
 
 { #category : #utilities }
 RPackageOrganizerTest >> quadrangleClass [
-	^ self class environment at: #QuadrangleForTesting
+	^ self organizer environment at: #QuadrangleForTesting
 ]
 
 { #category : #tests }

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -132,12 +132,13 @@ RPackageReadOnlyCompleteSetupTest >> testAddTagsToAClass [
 
 { #category : #'tests - compiled method' }
 RPackageReadOnlyCompleteSetupTest >> testClassIsExtendedInPackage [
-	self deny: ((testingEnvironment at: #A1DefinedInP1) isExtendedInPackage: p1).
-	self assert: (p1 includesClass: (testingEnvironment at: #A1DefinedInP1)).
-	self deny: (p1 extendsClass: (testingEnvironment at: #A1DefinedInP1)).
-	self assert: ((testingEnvironment at: #A2DefinedInP2) isExtendedInPackage: p1).
-	self deny: (p1 includesClass: (testingEnvironment at: #A2DefinedInP2)).
-	self assert: (p1 extendsClass: (testingEnvironment at: #A2DefinedInP2))
+
+	self deny: (a1 isExtendedInPackage: p1).
+	self assert: (p1 includesClass: a1).
+	self deny: (p1 extendsClass: a1).
+	self assert: (a2 isExtendedInPackage: p1).
+	self deny: (p1 includesClass: a2).
+	self assert: (p1 extendsClass: a2)
 ]
 
 { #category : #'tests - slice' }
@@ -172,25 +173,22 @@ A2DefinedInP2 classSideMethodDefinedInP3
 { #category : #'tests - compiled method' }
 RPackageReadOnlyCompleteSetupTest >> testCompiledMethodIsDefinedInPackage [
 
-	self assert: ((testingEnvironment at: #A1DefinedInP1) >> #methodDefinedInP1 isDefinedInPackage: p1).
-	self deny: ((testingEnvironment at: #A2DefinedInP2) >> #methodDefinedInP1 isDefinedInPackage: p1)
+	self assert: (a1 >> #methodDefinedInP1 isDefinedInPackage: p1).
+	self deny: (a2 >> #methodDefinedInP1 isDefinedInPackage: p1)
 ]
 
 { #category : #'tests - compiled method' }
 RPackageReadOnlyCompleteSetupTest >> testCompiledMethodIsExtensionInPackage [
 
-	self deny: ((testingEnvironment at: #A1DefinedInP1) >> #methodDefinedInP1 isExtensionInPackage: p1).
-	self assert: ((testingEnvironment at: #A2DefinedInP2) >> #methodDefinedInP1 isExtensionInPackage: p1)
+	self deny: (a1 >> #methodDefinedInP1 isExtensionInPackage: p1).
+	self assert: (a2 >> #methodDefinedInP1 isExtensionInPackage: p1)
 ]
 
 { #category : #'tests - compiled method' }
-RPackageReadOnlyCompleteSetupTest >> testCompiledMethodPackageFromOrganizer [
+RPackageReadOnlyCompleteSetupTest >> testCompiledMethodPackage [
 
-	| method |
-	method := (testingEnvironment at: #A1DefinedInP1) >> #methodDefinedInP1.
-	self assert: (method packageFromOrganizer: RPackage organizer) equals: p1.
-	method := (testingEnvironment at: #A2DefinedInP2) >> #methodDefinedInP1.
-	self assert: (method packageFromOrganizer: RPackage  organizer) equals: p1
+	self assert: (a1 >> #methodDefinedInP1) package equals: p1.
+	self assert: (a2 >> #methodDefinedInP1) package equals: p1
 ]
 
 { #category : #'tests - situation' }
@@ -206,11 +204,12 @@ RPackageReadOnlyCompleteSetupTest >> testDefinedSelectors [
 
 { #category : #'tests - situation' }
 RPackageReadOnlyCompleteSetupTest >> testDefinedSelectorsForClass [
+
 	self assert: (p1 definedSelectorsForClass: a1) size equals: 2.
 	self assert: (p1 definedMethodsForClass: a1) size equals: 2.
 	self assert: ((p1 definedSelectorsForClass: a1) includes: #methodDefinedInP1).
 	self assert: ((p1 definedSelectorsForClass: a1) includes: #anotherMethodDefinedInP1).
-	self assert: ((p1 definedMethodsForClass: a1) includes: (testingEnvironment at: #A1DefinedInP1) >> #methodDefinedInP1).
+	self assert: ((p1 definedMethodsForClass: a1) includes: a1 >> #methodDefinedInP1).
 	self assertEmpty: (p1 definedSelectorsForClass: Object).
 	self assertEmpty: (p1 definedSelectorsForClass: Object class)
 ]
@@ -267,9 +266,10 @@ RPackageReadOnlyCompleteSetupTest >> testExtensionSelectors [
 
 { #category : #'tests - situation' }
 RPackageReadOnlyCompleteSetupTest >> testExtensionSelectorsForClass [
+
 	self assert: (p1 extensionSelectorsForClass: a2) size equals: 1.
 	self assert: ((p1 extensionSelectorsForClass: a2) includes: #methodDefinedInP1).
-	self assert: ((p1 extensionMethodsForClass: a2) includes: (testingEnvironment at: #A2DefinedInP2) >> #methodDefinedInP1).
+	self assert: ((p1 extensionMethodsForClass: a2) includes: a2 >> #methodDefinedInP1).
 	self assertEmpty: (p1 extensionSelectorsForClass: Object).
 	self assertEmpty: (p1 extensionSelectorsForClass: Object class)
 ]
@@ -300,17 +300,18 @@ RPackageReadOnlyCompleteSetupTest >> testMethods [
 
 { #category : #'tests - situation' }
 RPackageReadOnlyCompleteSetupTest >> testMethodsForClass [
+
 	self assert: (p1 methodsForClass: a1) size equals: 2.
-	self assert: ((p1 methodsForClass: a1) includes: (testingEnvironment at: #A1DefinedInP1) >> #methodDefinedInP1).
-	self assert: ((p1 methodsForClass: a1) includes: (testingEnvironment at: #A1DefinedInP1) >> #anotherMethodDefinedInP1).
+	self assert: ((p1 methodsForClass: a1) includes: a1 >> #methodDefinedInP1).
+	self assert: ((p1 methodsForClass: a1) includes: a1 >> #anotherMethodDefinedInP1).
 	self assertEmpty: (p1 methodsForClass: b1).
 	self assertEmpty: (p1 methodsForClass: Object).
 	self assertEmpty: (p1 methodsForClass: Object class).
 
 	self assert: (p3 methodsForClass: a2) size equals: 1.
-	self assert: ((p3 methodsForClass: a2) includes: (testingEnvironment at: #A2DefinedInP2) >> #methodDefinedInP3).
+	self assert: ((p3 methodsForClass: a2) includes: a2 >> #methodDefinedInP3).
 	self assert: (p3 methodsForClass: a2 class) size equals: 1.
-	self assert: ((p3 methodsForClass: a2 class) includes: (testingEnvironment at: #A2DefinedInP2) class >> #classSideMethodDefinedInP3)
+	self assert: ((p3 methodsForClass: a2 class) includes: a2 class >> #classSideMethodDefinedInP3)
 ]
 
 { #category : #'tests - accessing' }

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -75,6 +75,7 @@ RPackageTestCase >> createNewTraitNamed: aName inCategory: cat [
 		       aBuilder
 			       name: aName;
 			       package: cat;
+			       installingEnvironment: self organizer environment;
 			       beTrait ].
 
 	createdClasses add: cls.

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -35,6 +35,7 @@ RPackageTestCase >> createNewClassNamed: aName inCategory: cat [
 	cls := self class classInstaller make: [ :aClassBuilder |
 		       aClassBuilder
 			       name: aName;
+			       installingEnvironment: self organizer environment;
 			       package: cat ].
 
 	createdClasses add: cls.
@@ -130,7 +131,7 @@ RPackageTestCase >> setUp [
 { #category : #accessing }
 RPackageTestCase >> setupOrganizer [
 
-	^ RPackageOrganizer new
+	^ self class environment class new organization
 		  debuggingName: 'Organizer for RPackageTest';
 		  yourself
 ]

--- a/src/System-Support/RPackage.extension.st
+++ b/src/System-Support/RPackage.extension.st
@@ -2,5 +2,8 @@ Extension { #name : #RPackage }
 
 { #category : #'*System-Support' }
 RPackage >> allUnsentMessages [
-	^SystemNavigation new allUnsentMessagesIn: (self methods collect: [ :cm | cm selector ]) asSet
+
+	^ SystemNavigation new
+		  environment: self environment;
+		  allUnsentMessagesIn: (self methods collect: [ :cm | cm selector ]) asSet
 ]


### PR DESCRIPTION
RPackage needs to know an environment to do some operations such as getting a real class from a class name. For now, the environment used was always the global environment. But in reality the package can be from another environment. 

This change update RPackage and RPackageTag to use the organizer environment to lookup for classes and methods and update the tests so that classes get added to the right environment and remove the hard coded global environment lookup.

This is a big step toward the goal of been able to have multiple enviornment, for example to be able to generate code in tests in special environments