### PR TITLE
Fix bug of method returning a text as source code

### DIFF
--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -785,8 +785,8 @@ OpalCompiler >> semanticScope: anObject [
 
 { #category : #accessing }
 OpalCompiler >> source: aString [
+	"source should be a string, but call contents for old clients that send streams. Some users can also send text and so we transform it into a string. If we don't do this transformation, the compiled method #sourceCode method will return a Text instead of a String which can break its users."
 
-	"source should be a string, but call contents for old clients that send streams"
-	source := aString contents.
+	source := aString contents asString.
 	ast := nil
 ]

--- a/src/OpalCompiler-Tests/OpalCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTest.class.st
@@ -79,6 +79,17 @@ OpalCompilerTest >> testCompileFromAnalysedAST [
 ]
 
 { #category : #tests }
+OpalCompilerTest >> testCompileFromText [
+
+	| source result |
+	source := 'tt ^3+4' asText.
+
+	result := MockForCompilation compiler compile: source.
+	self assert: result sourceCode isString.
+	self assert: result sourceCode equals: source asString
+]
+
+{ #category : #tests }
 OpalCompilerTest >> testCompileSource [
 	| source result |
 	source := 'tt ^3+4'.


### PR DESCRIPTION
In the past, we were logging a method before installing it in the system. This was not good because the installation could change some values of the method such as the protocol and the logged info was wrong.

Now we are installing the method and then we log it. The problem that arise is that the installation of the method might need the source code. In that case, instead of reading the source code from the change file, we use a property saved in memory. But this property was wrong in case we provided a text to the compiler because it stored the text instead of the string.

I propose to convert the text as a string in the setter of the compiler.

Fixes #14355