### PR TITLE
Simplify API of RPackage

### DIFF
--- a/src/Deprecated12/RPackage.extension.st
+++ b/src/Deprecated12/RPackage.extension.st
@@ -25,6 +25,22 @@ RPackage >> includesDefinedSelector: aSelector ofMetaclassName: aClassName [
 ]
 
 { #category : #'*Deprecated12' }
+RPackage >> includesExtensionSelector: aSelector ofClassName: aClassName [
+	"Return true if the receiver includes the method of selector aSelector. Only checks methods extending other packages"
+
+	self deprecated: 'Use #includesExtensionSelector:ofClass: with the class directly'.
+	^ self includesExtensionSelector: aSelector ofClass: (self environment at: aClassName)
+]
+
+{ #category : #'*Deprecated12' }
+RPackage >> includesExtensionSelector: aSelector ofMetaclassName: aClassName [
+	"Return true if the receiver includes the method of selector aSelector. Only checks methods extending other packages"
+
+	self deprecated: 'Use #includesExtensionSelector:ofClass: with the class side of the class directly'.
+	^ self includesExtensionSelector: aSelector ofClass: (self environment at: aClassName) class
+]
+
+{ #category : #'*Deprecated12' }
 RPackage >> includesSelector: aSelector ofClassName: aClassName [
 	"Return true if the receiver includes the method of selector aSelector. Checks methods defined locally as well as extending other packages"
 

--- a/src/Deprecated12/RPackage.extension.st
+++ b/src/Deprecated12/RPackage.extension.st
@@ -9,6 +9,38 @@ RPackage >> definedClassesDo: aBlock [
 ]
 
 { #category : #'*Deprecated12' }
+RPackage >> includesDefinedSelector: aSelector ofClassName: aClassName [
+	"Return true if the receiver includes the method of selector aSelector. Only checks methods defined (not extended by other packages or package extensions)"
+
+	self deprecated: 'Use #includesDefinedSelector:ofClass: with the class directly'.
+	^ self includesDefinedSelector: aSelector ofClass: (self environment at: aClassName)
+]
+
+{ #category : #'*Deprecated12' }
+RPackage >> includesDefinedSelector: aSelector ofMetaclassName: aClassName [
+	"Return true if the receiver includes the method of selector aSelector. Only checks methods defined (not extended by other packages or package extensions)"
+
+	self deprecated: 'Use #includesDefinedSelector:ofClass: with the class side of the class directly'.
+	^ self includesDefinedSelector: aSelector ofClass: (self environment at: aClassName) class
+]
+
+{ #category : #'*Deprecated12' }
+RPackage >> includesSelector: aSelector ofClassName: aClassName [
+	"Return true if the receiver includes the method of selector aSelector. Checks methods defined locally as well as extending other packages"
+
+	self deprecated: 'Use #includesSelector:ofClass: directly with the class.'.
+	^ self includesSelector: aSelector ofClass: (self environment at: aClassName)
+]
+
+{ #category : #'*Deprecated12' }
+RPackage >> includesSelector: aSelector ofMetaclassName: aClassName [
+	"Return true if the receiver includes the method of selector aSelector. Checks methods defined locally as well as extending other packages"
+
+	self deprecated: 'Use #includesSelector:ofClass: directly with the class.'.
+	^ self includesSelector: aSelector ofClass: (self environment at: aClassName)
+]
+
+{ #category : #'*Deprecated12' }
 RPackage >> removeClassNamed: aClassName [
 
 	self deprecated: 'Use #removeClass: with a real class instead.'.

--- a/src/Deprecated12/RPackage.extension.st
+++ b/src/Deprecated12/RPackage.extension.st
@@ -1,11 +1,54 @@
 Extension { #name : #RPackage }
 
 { #category : #'*Deprecated12' }
+RPackage >> classDefinedSlicesDo: aBlock [
+
+	self deprecated:
+		'The API of RPackage is been cleaned and this method is not generic enough to stay in RPackage. You can look at the implementation of this method to know how to reproduce its behavior.'.
+	self definedClasses
+		reject: [ :class | class isMeta ]
+		thenDo: [ :class | (self definedSelectorsForClass: class) ifNotEmpty: [ :selectors | aBlock value: class name value: selectors ] ]
+]
+
+{ #category : #'*Deprecated12' }
+RPackage >> classExtensionSlicesDo: aBlock [
+	"This method iterates over the class extensions and their associated selectors. A slice is a class * list of selectors. aBlock will be applied to all the extensions slices of the receiver. aBlock first argument is the class and the second argument a list of method selectors"
+
+	self deprecated:
+		'The API of RPackage is been cleaned and this method is not generic enough to stay in RPackage. You can look at the implementation of this method to know how to reproduce its behavior.'.
+
+	self extendedClasses
+		reject: [ :class | class isMeta ]
+		thenDo: [ :class | (self extensionSelectorsForClass: class) ifNotEmpty: [ :selectors | aBlock value: class name value: selectors ] ]
+]
+
+{ #category : #'*Deprecated12' }
+RPackage >> classNamesAndExtensionSelectorsDo: aBlock [
+	"Iterate over the extended methods grouped by classes and apply the argument.
+	The block will be passed a class name and each individual selectors.
+	Only classes with methods are paired with their methods"
+
+	self deprecated:
+		'The API of RPackage is been cleaned and this method is not generic enough to stay in RPackage. You can look at the implementation of this method to know how to reproduce its behavior.'.
+	self extendedClasses do: [ :class |
+		(self extensionSelectorsForClass: class) ifNotEmpty: [ :selectors | selectors do: [ :selector | aBlock value: class name value: selector ] ] ]
+]
+
+{ #category : #'*Deprecated12' }
 RPackage >> definedClassesDo: aBlock [
 
 	self deprecated:
 		'Use #definedClasses and a do instead because the name of this method is not explicit since it iterates over the *name* of the classes and not the classes themselves.'.
 	^ self definedClassNames do: aBlock
+]
+
+{ #category : #'*Deprecated12' }
+RPackage >> extensionCategoriesForClass: aClass [
+
+	self
+		deprecated: 'Use #extensionProtocolsForClass: instead.'
+		transformWith: '`@rcv extensionCategoriesForClass: `@arg' -> '`@rcv extensionProtocolsForClass: `@arg'.
+	^ self extensionProtocolsForClass: aClass
 ]
 
 { #category : #'*Deprecated12' }
@@ -54,6 +97,30 @@ RPackage >> includesSelector: aSelector ofMetaclassName: aClassName [
 
 	self deprecated: 'Use #includesSelector:ofClass: directly with the class.'.
 	^ self includesSelector: aSelector ofClass: (self environment at: aClassName)
+]
+
+{ #category : #'*Deprecated12' }
+RPackage >> metaclassDefinedSlicesDo: aBlock [
+	"This method iterates over the defined class and their associated selectors. a slice is a class * list of selectors. aBlock will be applied to all the extensions slices of the receiver. aBlok first argument is the class and the second argument a list of method selectors"
+
+	self deprecated:
+		'The API of RPackage is been cleaned and this method is not generic enough to stay in RPackage. You can look at the implementation of this method to know how to reproduce its behavior.'.
+
+	self definedClasses
+		select: [ :class | class isMeta ]
+		thenDo: [ :class | (self definedSelectorsForClass: class) ifNotEmpty: [ :selectors | aBlock value: class instanceSide name value: selectors ] ]
+]
+
+{ #category : #'*Deprecated12' }
+RPackage >> metaclassExtensionSlicesDo: aBlock [
+	"This method iterates over the metaclass extensions and their associated selectors. A slice is a class * list of selectors. aBlock will be applied to all the extensions slices of the receiver. aBlok first argument is the class and second argument a list of selectors"
+
+	self deprecated:
+		'The API of RPackage is been cleaned and this method is not generic enough to stay in RPackage. You can look at the implementation of this method to know how to reproduce its behavior.'.
+
+	self extendedClasses
+		select: [ :class | class isMeta ]
+		thenDo: [ :class | (self extensionSelectorsForClass: class) ifNotEmpty: [ :selectors | aBlock value: class instanceSide name value: selectors ] ]
 ]
 
 { #category : #'*Deprecated12' }

--- a/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
@@ -217,31 +217,28 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassUpdateTheOrganizerMap
 
 { #category : #'tests - recategorizing class' }
 RPackageClassesSynchronisationTest >> testRecategorizeClassWithMetaClassMethodsRegisterAllClassMethodsInTheNewPackage [
-
 	"test that when we recategorize a class (having methods defined in both instance and class side), the new package in which it is defined include all the methods (from instance and class side) defined in this class (not extensions)"
-	
-	| XPackage YPackage ZPackage class|
+
+	| xPackage yPackage zPackage class |
 	self addXCategory.
 	self addYCategory.
 	self addZCategory.
-	XPackage := self organizer packageNamed: #XXXXX.
-	YPackage := self organizer packageNamed: #YYYYY.
-	ZPackage := self organizer packageNamed: #ZZZZZ.
-	
+	xPackage := self organizer packageNamed: #XXXXX.
+	yPackage := self organizer packageNamed: #YYYYY.
+	zPackage := self organizer packageNamed: #ZZZZZ.
+
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	
-	self createMethodNamed: 'method1' inClass: class classSide inCategory: 'category'.
-	self createMethodNamed: 'method2' inClass: class classSide inCategory: '*yyyyy'.
-	self createMethodNamed: 'method3' inClass: class classSide inCategory: '*zzzzz'.
-	
+
+	self createMethodNamed: 'method1' inClass: class class inCategory: 'category'.
+	self createMethodNamed: 'method2' inClass: class class inCategory: '*yyyyy'.
+	self createMethodNamed: 'method3' inClass: class class inCategory: '*zzzzz'.
+
 	class category: 'YYYYY'.
-	
+
 	"lets check metaclass methods"
-	self assert: (YPackage includesDefinedSelector: #method1 ofMetaclassName: class name).
-	
-	self assert: (YPackage includesDefinedSelector: #method2 ofMetaclassName: class name). 
-	
-	self assert: (ZPackage includesExtensionSelector: #method3 ofMetaclassName: class name ).
+	self assert: (yPackage includesDefinedSelector: #method1 ofClass: class class).
+	self assert: (yPackage includesDefinedSelector: #method2 ofClass: class class).
+	self assert: (zPackage includesExtensionSelector: #method3 ofClass: class class)
 ]
 
 { #category : #'tests - recategorizing class' }
@@ -335,17 +332,16 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateClassDefinedInThePare
 { #category : #'tests - operations on classes' }
 RPackageClassesSynchronisationTest >> testRenameClassUpdateClassDefinedSelectorsInTheParentPackage [
 	"test that when we rename a class, the  'classDefinedSelectors' dictionary of the parent package is updated with the new name. There fore we test that we can correctly access the selector from the package by specifying the right name (the new name)"
-	
-	| XPackage  class |
+
+	| xPackage class |
 	self addXCategory.
-	XPackage := self organizer packageNamed: #XXXXX.
+	xPackage := self organizer packageNamed: #XXXXX.
 	class := self createNewClassNamed: 'RPackageOldStubClass' asSymbol inCategory: 'XXXXX'.
-	self createMethodNamed: 'stubMethod' inClass: class  inCategory: 'classic category'.
-	
+	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
+
 	class rename: 'RPackageNewStubClass'.
-	
-	self assert: (XPackage includesDefinedSelector: #stubMethod ofClassName: 'RPackageNewStubClass' asSymbol ). 
-	self deny: (XPackage includesDefinedSelector: #stubMethod ofClassName: 'RPackageOldStubClass' asSymbol ).
+
+	self assert: (xPackage includesDefinedSelector: #stubMethod ofClass: class)
 ]
 
 { #category : #'tests - operations on classes' }
@@ -368,17 +364,16 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateClassExtensionSelecto
 { #category : #'tests - operations on classes' }
 RPackageClassesSynchronisationTest >> testRenameClassUpdateMetaclassDefinedSelectorsInTheParentPackage [
 	"test that when we rename a class, the  'metaclassDefinedSelectors' dictionary of the parent package is updated with the new name. Ther fore we test that we can correctly access the selector from the package by specifying the right name (the new name)"
-	
-	| XPackage  class |
+
+	| xPackage class |
 	self addXYCategory.
-	XPackage := self organizer packageNamed: #XXXXX.
+	xPackage := self organizer packageNamed: #XXXXX.
 	class := self createNewClassNamed: 'RPackageOldStubClass' asSymbol inCategory: 'XXXXX'.
-	self createMethodNamed: 'stubMethod' inClassSideOfClass: class  inCategory: 'classic category'.
-	
+	self createMethodNamed: 'stubMethod' inClassSideOfClass: class inCategory: 'classic category'.
+
 	class rename: 'RPackageNewStubClass'.
-	
-	self assert: (XPackage  includesDefinedSelector: #stubMethod ofMetaclassName: 'RPackageNewStubClass' asSymbol ). 
-	self deny: (XPackage  includesDefinedSelector: #stubMethod ofMetaclassName: 'RPackageOldStubClass' asSymbol ).
+
+	self assert: (xPackage includesDefinedSelector: #stubMethod ofClass: class class)
 ]
 
 { #category : #'tests - operations on classes' }

--- a/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
@@ -348,17 +348,16 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateClassDefinedSelectors
 RPackageClassesSynchronisationTest >> testRenameClassUpdateClassExtensionSelectorsInTheExtendingPackages [
 	"test that when we rename a class, the  'classExtensionSelectors' dictionaries of the extending packages  are updated with the new name. Therfore we test that we can correctly access the selectors from the package by specifying the right name (the new name)"
 
-	| XPackage YPackage class |
+	| xPackage yPackage class |
 	self addXYCategory.
-	XPackage := self organizer packageNamed: #XXXXX.
-	YPackage := self organizer packageNamed: #YYYYY.
+	xPackage := self organizer packageNamed: #XXXXX.
+	yPackage := self organizer packageNamed: #YYYYY.
 	class := self createNewClassNamed: 'RPackageOldStubClass' asSymbol inCategory: 'XXXXX'.
-	self createMethodNamed: 'stubMethod' inClass: class  inCategory: '*yyyyy'.
-	
+	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
+
 	class rename: 'RPackageNewStubClass'.
-	
-	self assert: (YPackage includesExtensionSelector: #stubMethod ofClassName: 'RPackageNewStubClass' asSymbol ). 
-	self deny: (YPackage includesExtensionSelector: #stubMethod ofClassName: 'RPackageOldStubClass' asSymbol ).
+
+	self assert: (yPackage includesExtensionSelector: #stubMethod ofClass: class)
 ]
 
 { #category : #'tests - operations on classes' }
@@ -379,18 +378,17 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateMetaclassDefinedSelec
 { #category : #'tests - operations on classes' }
 RPackageClassesSynchronisationTest >> testRenameClassUpdateMetaclassExtensionSelectorsInTheExtendingPackages [
 	"test that when we rename a class, the  'metaclassExtensionSelectors' dictionaries of the extending packages  are updated with the new name. Ther fore we test that we can correctly access the selectors from the package by specifying the right name (the new name)"
-	
-	| XPackage YPackage class |
+
+	| xPackage yPackage class |
 	self addXYCategory.
-	XPackage := self organizer packageNamed: #XXXXX.
-	YPackage := self organizer packageNamed: #YYYYY.
+	xPackage := self organizer packageNamed: #XXXXX.
+	yPackage := self organizer packageNamed: #YYYYY.
 	class := self createNewClassNamed: 'RPackageOldStubClass' asSymbol inCategory: 'XXXXX'.
-	self createMethodNamed: 'stubMethod' inClassSideOfClass: class  inCategory: '*yyyyy'.
-	
+	self createMethodNamed: 'stubMethod' inClassSideOfClass: class inCategory: '*yyyyy'.
+
 	class rename: 'RPackageNewStubClass'.
-	
-	self assert: (YPackage includesExtensionSelector: #stubMethod ofMetaclassName: 'RPackageNewStubClass' asSymbol ). 
-	self deny: (YPackage includesExtensionSelector: #stubMethod ofMetaclassName: 'RPackageOldStubClass' asSymbol ).
+
+	self assert: (yPackage includesExtensionSelector: #stubMethod ofClass: class class)
 ]
 
 { #category : #'tests - operations on classes' }

--- a/src/RPackage-Core/CompiledCode.extension.st
+++ b/src/RPackage-Core/CompiledCode.extension.st
@@ -10,10 +10,7 @@ CompiledCode >> extensionPackage [
 	class := self origin.
 
 	^ class extendingPackages
-		  detect: [ :extendedPackage |
-			  class isMeta
-				  ifFalse: [ extendedPackage includesExtensionSelector: originSelector ofClassName: class instanceSide originalName ]
-				  ifTrue: [ extendedPackage includesExtensionSelector: originSelector ofMetaclassName: class instanceSide originalName ] ]
+		  detect: [ :extendedPackage | extendedPackage includesExtensionSelector: originSelector ofClass: class ]
 		  ifNone: [ nil ]
 ]
 

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -488,39 +488,18 @@ RPackage >> extendedClasses [
 ]
 
 { #category : #private }
-RPackage >> extendedMethodsBecomeDefinedForClass: aClassName [
-	"the package may contain extension methods and their class is added to the receiver. The status of such methods should now be defined"
-	"Precondition: aClassName is in the defined list"
-
-	| ext |
-	(classExtensionSelectors keys includes: aClassName) ifFalse: [^ self].
-	ext := classExtensionSelectors at: aClassName.
-	classExtensionSelectors removeKey: aClassName ifAbsent: [self reportBogusBehaviorOf:   #extendedMethodsBecomeDefinedForClass: ].
-	(classDefinedSelectors keys includes: aClassName) ifTrue: [self error: aClassName , ' should not be defined in extension'.]. "we should remove this check later"
-	classDefinedSelectors at: aClassName put: ext
-]
-
-{ #category : #private }
-RPackage >> extendedMethodsBecomeDefinedForMetaclass: aClassName [
-	"the package may contain extension methods and their class is added to the receiver. The status of such methods should now be defined"
-	"Precondition: aClassName is in the defined list"
-
-	| ext |
-	(metaclassExtensionSelectors keys includes: aClassName) ifFalse: [^ self].
-	ext := metaclassExtensionSelectors at: aClassName.
-	metaclassExtensionSelectors removeKey: aClassName  ifAbsent: [self reportBogusBehaviorOf:  #extendedMethodsBecomeDefinedForMetaclass: ].
-	(metaclassDefinedSelectors keys includes: aClassName)
-			ifTrue: [self error: aClassName , ' should not be defined in extension'.]. "we should remove this check later"
-	metaclassDefinedSelectors at: aClassName put: ext
-]
-
-{ #category : #private }
 RPackage >> extendedMethodsShouldBecomeDefinedWhenAddingClassName: aClassName [
 	"the package may contain extension methods and their class is added to the receiver. The status of such methods should now be defined"
+
 	"Precondition: aClassName is in the defined list"
 
-	self extendedMethodsBecomeDefinedForClass: aClassName.
-	self extendedMethodsBecomeDefinedForMetaclass: aClassName
+	(classExtensionSelectors keys includes: aClassName) ifTrue: [
+		(classDefinedSelectors keys includes: aClassName) ifTrue: [ self error: aClassName , ' should not be defined in extension' ].
+		classDefinedSelectors at: aClassName put: (classExtensionSelectors removeKey: aClassName) ].
+
+	(metaclassExtensionSelectors keys includes: aClassName) ifTrue: [
+		(metaclassDefinedSelectors keys includes: aClassName) ifTrue: [ self error: aClassName , ' should not be defined in extension' ].
+		metaclassDefinedSelectors at: aClassName put: (metaclassExtensionSelectors removeKey: aClassName) ]
 ]
 
 { #category : #testing }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -679,27 +679,7 @@ RPackage >> includesClassesAffectedBy: aSystemAnnouncement [
 RPackage >> includesDefinedSelector: aSelector ofClass: aClass [
 	"Return true if the receiver includes the method of selector aSelector. Only checks methods defined in this package"
 
-	| sels |
-	sels := self definedSelectorsForClass: aClass.
-	^ sels includes: aSelector asSymbol
-]
-
-{ #category : #testing }
-RPackage >> includesDefinedSelector: aSelector ofClassName: aClassName [
-	"Return true if the receiver includes the method of selector aSelector. Only checks methods defined (not extended by other packages or package extensions)"
-
-	| sels |
-	sels := classDefinedSelectors at: aClassName ifAbsent: [^ false].
-	^ sels includes: aSelector asSymbol
-]
-
-{ #category : #testing }
-RPackage >> includesDefinedSelector: aSelector ofMetaclassName: aClassName [
-	"Return true if the receiver includes the method of selector aSelector. Only checks methods defined (not extended by other packages or package extensions)"
-
-	| sels |
-	sels := metaclassDefinedSelectors at: aClassName ifAbsent: [^ false].
-	^ sels includes: aSelector asSymbol
+	^ (self definedSelectorsForClass: aClass) includes: aSelector asSymbol
 ]
 
 { #category : #testing }
@@ -745,25 +725,7 @@ RPackage >> includesProtocol: protocol ofClass: aClass [
 RPackage >> includesSelector: aSelector ofClass: aClass [
 	"Return true if the receiver includes the method of selector aSelector. Checks methods defined locally as well as extending other packages"
 
-	^ aClass isMeta
-		ifTrue: [ self includesSelector: aSelector ofMetaclassName: aClass instanceSide name  ]
-		ifFalse: [ self includesSelector: aSelector ofClassName: aClass name  ]
-]
-
-{ #category : #testing }
-RPackage >> includesSelector: aSelector ofClassName: aClassName [
-	"Return true if the receiver includes the method of selector aSelector. Checks methods defined locally as well as extending other packages"
-
-	^ (self includesDefinedSelector: aSelector ofClassName: aClassName)
-		or: [(self includesExtensionSelector: aSelector ofClassName: aClassName)]
-]
-
-{ #category : #testing }
-RPackage >> includesSelector: aSelector ofMetaclassName: aClassName [
-	"Return true if the receiver includes the method of selector aSelector. Checks methods defined locally as well as extending other packages"
-
-	^ (self includesDefinedSelector: aSelector ofMetaclassName: aClassName)
-		or: [(self includesExtensionSelector: aSelector ofMetaclassName: aClassName)]
+	^ (self includesDefinedSelector: aSelector ofClass: aClass) or: [ self includesExtensionSelector: aSelector ofClass: aClass ]
 ]
 
 { #category : #'system compatibility' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -285,38 +285,9 @@ RPackage >> basicRemoveTag: tag [
 	SystemAnnouncer announce: (PackageTagRemoved to: tag)
 ]
 
-{ #category : #slices }
-RPackage >> classDefinedSlicesDo: aBlock [
-	"This method iterates over the defined class and their associated selectors. a slice is a class * list of selectors. aBlock will be applied to all the extensions slices of the receiver. aBlok first argument is the class and the second argument a list of method selectors"
-
-	classDefinedSelectors keysAndValuesDo: aBlock
-]
-
 { #category : #private }
 RPackage >> classExtensionSelectors [
 	^ classExtensionSelectors
-]
-
-{ #category : #slices }
-RPackage >> classExtensionSlicesDo: aBlock [
-	"This method iterates over the class extensions and their associated selectors. A slice is a class * list of selectors. aBlock will be applied to all the extensions slices of the receiver. aBlock first argument is the class and the second argument a list of method selectors"
-
-	classExtensionSelectors keysAndValuesDo: aBlock
-]
-
-{ #category : #slices }
-RPackage >> classNamesAndExtensionSelectorsDo: aBlock [
-	"Iterate over the extended methods grouped by classes and apply the argument.
-	The block will be passed a class name and each individual selectors.
-	Only classes with methods are paired with their methods"
-
-	classExtensionSelectors keysAndValuesDo: [ :classSymbol :methods |
-			methods do: [ :sel |  aBlock value: classSymbol	value: sel]].
-
-	metaclassExtensionSelectors keysAndValuesDo: [ :classSymbol :methods |
-			methods do: [ :sel |  aBlock
-									value: (classSymbol, '_class') asSymbol
-									value: sel]]
 ]
 
 { #category : #'class tags' }
@@ -509,15 +480,6 @@ RPackage >> extendsClass: aClass [
 	| canonizedName |
 	canonizedName := aClass instanceSide name.
 	^ self extendedClassNames includes: canonizedName
-]
-
-{ #category : #'system compatibility' }
-RPackage >> extensionCategoriesForClass: aClass [
-
-	self
-		deprecated: 'Use #extensionProtocolsForClass: instead.'
-		transformWith: '`@rcv extensionCategoriesForClass: `@arg' -> '`@rcv extensionProtocolsForClass: `@arg'.
-	^ self extensionProtocolsForClass: aClass
 ]
 
 { #category : #accessing }
@@ -760,23 +722,9 @@ RPackage >> linesOfCode [
 	^self methods inject: 0 into: [:sum :each | sum + each linesOfCode]
 ]
 
-{ #category : #slices }
-RPackage >> metaclassDefinedSlicesDo: aBlock [
-	"This method iterates over the defined class and their associated selectors. a slice is a class * list of selectors. aBlock will be applied to all the extensions slices of the receiver. aBlok first argument is the class and the second argument a list of method selectors"
-
-	metaclassDefinedSelectors keysAndValuesDo: aBlock
-]
-
 { #category : #private }
 RPackage >> metaclassExtensionSelectors [
 	^ metaclassExtensionSelectors
-]
-
-{ #category : #slices }
-RPackage >> metaclassExtensionSlicesDo: aBlock [
-	"This method iterates over the metaclass extensions and their associated selectors. A slice is a class * list of selectors. aBlock will be applied to all the extensions slices of the receiver. aBlok first argument is the class and second argument a list of selectors"
-
-	metaclassExtensionSelectors keysAndValuesDo: aBlock
 ]
 
 { #category : #'system compatibility' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -686,27 +686,7 @@ RPackage >> includesDefinedSelector: aSelector ofClass: aClass [
 RPackage >> includesExtensionSelector: aSelector ofClass: aClass [
 	"Return true if the receiver includes the method of selector aSelector. Only checks methods extending other packages"
 
-	| sels |
-	sels := self extensionSelectorsForClass: aClass.
-	^ sels includes: aSelector asSymbol
-]
-
-{ #category : #testing }
-RPackage >> includesExtensionSelector: aSelector ofClassName: aClassName [
-	"Return true if the receiver includes the method of selector aSelector. Only checks methods extending other packages"
-
-	| sels |
-	sels := classExtensionSelectors at: aClassName ifAbsent: [^ false].
-	^ sels includes: aSelector asSymbol
-]
-
-{ #category : #testing }
-RPackage >> includesExtensionSelector: aSelector ofMetaclassName: aClassName [
-	"Return true if the receiver includes the method of selector aSelector. Only checks methods extending other packages"
-
-	| sels |
-	sels := metaclassExtensionSelectors at: aClassName ifAbsent: [^ false].
-	^ sels includes: aSelector asSymbol
+	^ (self extensionSelectorsForClass: aClass) includes: aSelector asSymbol
 ]
 
 { #category : #testing }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -250,16 +250,6 @@ RPackage >> addMethod: aCompiledMethod [
 	^ aCompiledMethod
 ]
 
-{ #category : #'add method - selector' }
-RPackage >> addSelector: aSelector ofMetaclassName: aClassName [
-	"Add the method to the receiver. If the class is not locally defined in that package then the method is defined as a method extension: ie extending another package. Note that this method does not add the method to the class, it just records in the package that the method is packaged. aClassName is the sole instance class name and not its metaclass one: i.e. adding Point class>>new is done as addSelector: #new ofMetaclassName: #Point"
-
-	( self includesClassNamed: aClassName)
-		ifFalse: [(metaclassExtensionSelectors at: aClassName asSymbol ifAbsentPut: [Set new]) add: aSelector]
-		ifTrue: [(metaclassDefinedSelectors at: aClassName asSymbol ifAbsentPut: [Set new]) add: aSelector].
-	^ aSelector
-]
-
 { #category : #private }
 RPackage >> basicAddClassTag: tagName [
 	| packageTag |

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -511,22 +511,6 @@ RPackageOrganizer >> orderedTraitsIn: category [
 ]
 
 { #category : #accessing }
-RPackageOrganizer >> packageDefiningOrExtendingSelector: aSelector inClassNamed: aClassNameSymbol [
-	"this implementation is slower
-		aClass packages detect: [:each | each includesSelector: aSelector ofClass: aClass ]"
-	| classPackage |
-
-	classPackage := self packageOfClassNamed: aClassNameSymbol.
-	classPackage ifNil: [ ^ nil ].
-	(classPackage includesSelector: aSelector ofClassName: aClassNameSymbol)
-		ifTrue: [ ^classPackage ].
-
-	^(self extendingPackagesOfClassNamed: aClassNameSymbol)
-		detect: [ :p | p includesSelector: aSelector ofClassName: aClassNameSymbol ]
-		ifNone: [ nil ]
-]
-
-{ #category : #accessing }
 RPackageOrganizer >> packageDefiningOrExtendingSelector: aSelector inMetaclassNamed: aClassNameSymbol [
 	"this implementation is slower
 		aClass packages detect: [:each | each includesSelector: aSelector ofClass: aClass ]"

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -510,22 +510,6 @@ RPackageOrganizer >> orderedTraitsIn: category [
 	^ traits asArray
 ]
 
-{ #category : #accessing }
-RPackageOrganizer >> packageDefiningOrExtendingSelector: aSelector inMetaclassNamed: aClassNameSymbol [
-	"this implementation is slower
-		aClass packages detect: [:each | each includesSelector: aSelector ofClass: aClass ]"
-	| classPackage |
-
-	classPackage := self packageOfClassNamed: aClassNameSymbol.
-	classPackage ifNil: [ ^ nil ].
-	(classPackage includesSelector: aSelector ofMetaclassName: aClassNameSymbol)
-		ifTrue: [ ^classPackage ].
-
-	^(self extendingPackagesOfClassNamed: aClassNameSymbol)
-		detect: [ :p | p includesSelector: aSelector ofMetaclassName: aClassNameSymbol ]
-		ifNone: [ nil ]
-]
-
 { #category : #'system integration' }
 RPackageOrganizer >> packageForProtocol: aProtocolName inClass: aClass [
 	"According aProtocolName is an extension protocol, will look for a matching package. If no matching package is found ,  return nil. If aProtocolName is not an extension protocol, return the parent package of aClass"

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -208,39 +208,6 @@ RPackageIncrementalTest >> testAddRemoveSelector [
 	self deny: (p1 includesExtensionSelector: #methodDefinedInP3 ofClassName: a2Name)
 ]
 
-{ #category : #'tests - method addition removal' }
-RPackageIncrementalTest >> testAddRemoveSelectorOfMetaclass [
-
-	| p1 p2 p3 a2 a2Name a2class |
-	a2Name := #A2InPackageP2.
-	p1 := self createNewPackageNamed: 'P1'.
-	p2 := self createNewPackageNamed: 'P2'.
-	p3 := self createNewPackageNamed: 'P3'.
-	a2 := self createNewClassNamed: a2Name inPackage: p2.
-	a2class := a2 class.
-	a2class compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2'.
-	p2 addSelector: #methodDefinedInP2 ofMetaclassName: a2Name.
-	a2class compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addSelector: #methodDefinedInP1 ofMetaclassName: a2Name.
-	a2class compileSilently: 'methodDefinedInP3 ^ #methodDefinedInP3'.
-	p3 addSelector: #methodDefinedInP3 ofMetaclassName: a2Name.
-
-	self assert: (p2 includesDefinedSelector: #methodDefinedInP2 ofMetaclassName: a2Name).
-	self deny: (p2 includesExtensionSelector: #methodDefinedInP2 ofMetaclassName: a2Name).
-	self deny: (p3 includesDefinedSelector: #methodDefinedInP3 ofMetaclassName: a2Name).
-	self assert: (p3 includesExtensionSelector: #methodDefinedInP3 ofMetaclassName: a2Name).
-	self assert: (p1 includesExtensionSelector: #methodDefinedInP1 ofMetaclassName: a2Name).
-	self deny: (p3 includesDefinedSelector: #methodDefinedInP1 ofMetaclassName: a2Name).
-
-	p2 removeMethod: a2 class >> #methodDefinedInP2.
-	self deny: (p2 includesDefinedSelector: #methodDefinedInP2 ofMetaclassName: a2Name).
-	self deny: (p2 includesExtensionSelector: #methodDefinedInP2 ofMetaclassName: a2Name).
-
-	p1 removeMethod: a2 class >> #methodDefinedInP1.
-	self deny: (p1 includesDefinedSelector: #methodDefinedInP3 ofMetaclassName: a2Name).
-	self deny: (p1 includesExtensionSelector: #methodDefinedInP3 ofMetaclassName: a2Name)
-]
-
 { #category : #'tests - class addition removal' }
 RPackageIncrementalTest >> testClassAddition [
 	| p a1 |

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -147,35 +147,35 @@ RPackageIncrementalTest >> testAddClassDefinitionNoDuplicate [
 
 { #category : #'tests - method addition removal' }
 RPackageIncrementalTest >> testAddRemoveMethod [
-	| p1 p2 p3 a2   a2Name |
-	a2Name := #A2InPackageP2.
+
+	| p1 p2 p3 a2 |
 	p1 := self createNewPackageNamed: 'P1'.
 	p2 := self createNewPackageNamed: 'P2'.
 	p3 := self createNewPackageNamed: 'P3'.
-	a2 := self createNewClassNamed: a2Name inPackage: p2.
+	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	a2 compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2'.
 
-	p2 addMethod: (a2>>#methodDefinedInP2).
+	p2 addMethod: a2 >> #methodDefinedInP2.
 	a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addMethod: (a2>>#methodDefinedInP1).
+	p1 addMethod: a2 >> #methodDefinedInP1.
 	a2 compileSilently: 'methodDefinedInP3 ^ #methodDefinedInP3'.
-	p3 addMethod: (a2>>#methodDefinedInP3).
+	p3 addMethod: a2 >> #methodDefinedInP3.
 
-	self assert: (p2 includesDefinedSelector: #methodDefinedInP2 ofClassName: a2Name).
-	self deny: (p2 includesExtensionSelector: #methodDefinedInP2 ofClassName: a2Name).
-	self deny: (p3 includesDefinedSelector: #methodDefinedInP3 ofClassName: a2Name).
-	self assert: (p3 includesExtensionSelector: #methodDefinedInP3 ofClassName: a2Name).
-	self assert: (p1 includesExtensionSelector: #methodDefinedInP1 ofClassName: a2Name).
-	self deny: (p3 includesDefinedSelector: #methodDefinedInP1 ofClassName: a2Name).
+	self assert: (p2 includesDefinedSelector: #methodDefinedInP2 ofClass: a2).
+	self deny: (p2 includesExtensionSelector: #methodDefinedInP2 ofClass: a2).
+	self deny: (p3 includesDefinedSelector: #methodDefinedInP3 ofClass: a2).
+	self assert: (p3 includesExtensionSelector: #methodDefinedInP3 ofClass: a2).
+	self assert: (p1 includesExtensionSelector: #methodDefinedInP1 ofClass: a2).
+	self deny: (p3 includesDefinedSelector: #methodDefinedInP1 ofClass: a2).
 
 	"removeMethod by default removes from defined methods and not extension"
-	p2 removeMethod: (a2>>#methodDefinedInP2).
-	self deny: (p2 includesDefinedSelector: #methodDefinedInP2 ofClassName: a2Name).
-	self deny: (p2 includesExtensionSelector: #methodDefinedInP2 ofClassName: a2Name).
+	p2 removeMethod: a2 >> #methodDefinedInP2.
+	self deny: (p2 includesDefinedSelector: #methodDefinedInP2 ofClass: a2).
+	self deny: (p2 includesExtensionSelector: #methodDefinedInP2 ofClass: a2).
 
-	p1 removeMethod: (a2>>#methodDefinedInP1).
-	self deny: (p1 includesDefinedSelector: #methodDefinedInP3 ofClassName: a2Name).
-	self deny: (p1 includesExtensionSelector: #methodDefinedInP3 ofClassName: a2Name)
+	p1 removeMethod: a2 >> #methodDefinedInP1.
+	self deny: (p1 includesDefinedSelector: #methodDefinedInP3 ofClass: a2).
+	self deny: (p1 includesExtensionSelector: #methodDefinedInP3 ofClass: a2)
 ]
 
 { #category : #'tests - method addition removal' }
@@ -192,20 +192,20 @@ RPackageIncrementalTest >> testAddRemoveSelector [
 	p1 addMethod: a2 >> (a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1').
 	p3 addMethod: a2 >> (a2 compileSilently: 'methodDefinedInP3 ^ #methodDefinedInP3').
 
-	self assert: (p2 includesDefinedSelector: #methodDefinedInP2 ofClassName: a2Name).
-	self deny: (p2 includesExtensionSelector: #methodDefinedInP2 ofClassName: a2Name).
-	self deny: (p3 includesDefinedSelector: #methodDefinedInP3 ofClassName: a2Name).
-	self assert: (p3 includesExtensionSelector: #methodDefinedInP3 ofClassName: a2Name).
-	self assert: (p1 includesExtensionSelector: #methodDefinedInP1 ofClassName: a2Name).
-	self deny: (p3 includesDefinedSelector: #methodDefinedInP1 ofClassName: a2Name).
+	self assert: (p2 includesDefinedSelector: #methodDefinedInP2 ofClass: a2).
+	self deny: (p2 includesExtensionSelector: #methodDefinedInP2 ofClass: a2).
+	self deny: (p3 includesDefinedSelector: #methodDefinedInP3 ofClass: a2).
+	self assert: (p3 includesExtensionSelector: #methodDefinedInP3 ofClass: a2).
+	self assert: (p1 includesExtensionSelector: #methodDefinedInP1 ofClass: a2).
+	self deny: (p3 includesDefinedSelector: #methodDefinedInP1 ofClass: a2).
 
 	p2 removeMethod: a2 >> #methodDefinedInP2.
-	self deny: (p2 includesDefinedSelector: #methodDefinedInP2 ofClassName: a2Name).
-	self deny: (p2 includesExtensionSelector: #methodDefinedInP2 ofClassName: a2Name).
+	self deny: (p2 includesDefinedSelector: #methodDefinedInP2 ofClass: a2).
+	self deny: (p2 includesExtensionSelector: #methodDefinedInP2 ofClass: a2).
 
 	p1 removeMethod: a2 >> #methodDefinedInP1.
-	self deny: (p1 includesDefinedSelector: #methodDefinedInP3 ofClassName: a2Name).
-	self deny: (p1 includesExtensionSelector: #methodDefinedInP3 ofClassName: a2Name)
+	self deny: (p1 includesDefinedSelector: #methodDefinedInP3 ofClass: a2).
+	self deny: (p1 includesExtensionSelector: #methodDefinedInP3 ofClass: a2)
 ]
 
 { #category : #'tests - class addition removal' }
@@ -456,90 +456,91 @@ RPackageIncrementalTest >> testIncludeClassMore [
 
 { #category : #'tests - extension' }
 RPackageIncrementalTest >> testIncludeSelectorOfClass [
-	| p1 p2 p3 a2  |
+
+	| p1 p2 p3 a2 |
 	p1 := self createNewPackageNamed: 'P1'.
 	p2 := self createNewPackageNamed: 'P2'.
 	p3 := self createNewPackageNamed: 'P3'.
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	a2 compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2'.
-	p2 addMethod: (a2>>#methodDefinedInP2).
+	p2 addMethod: a2 >> #methodDefinedInP2.
 	a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addMethod: (a2>>#methodDefinedInP1).
+	p1 addMethod: a2 >> #methodDefinedInP1.
 	a2 compileSilently: 'methodDefinedInP3 ^ #methodDefinedInP3'.
-	p3 addMethod: (a2>>#methodDefinedInP3).
+	p3 addMethod: a2 >> #methodDefinedInP3.
 
 	"includesSelector checks both in defined and extension so we test both"
 	self assert: (p2 includesSelector: #methodDefinedInP2 ofClass: a2).
-	self assert: (p2 includesDefinedSelector: #methodDefinedInP2 ofClassName: a2 name).
-	self deny: (p2 includesExtensionSelector: #methodDefinedInP2 ofClassName: a2 name).
+	self assert: (p2 includesDefinedSelector: #methodDefinedInP2 ofClass: a2).
+	self deny: (p2 includesExtensionSelector: #methodDefinedInP2 ofClass: a2).
 
 	self deny: (p2 includesSelector: #methodDefinedInP3 ofClass: a2).
-	self assert: (p3 includesExtensionSelector: #methodDefinedInP3 ofClassName: a2 name).
-	self deny: (p3 includesDefinedSelector: #methodDefinedInP3 ofClassName: a2 name).
+	self assert: (p3 includesExtensionSelector: #methodDefinedInP3 ofClass: a2).
+	self deny: (p3 includesDefinedSelector: #methodDefinedInP3 ofClass: a2).
 
 	self deny: (p2 includesSelector: #methodDefinedInP1 ofClass: a2).
-	self assert: (p1 includesExtensionSelector: #methodDefinedInP1 ofClassName: a2 name).
-	self deny: (p3 includesDefinedSelector: #methodDefinedInP1 ofClassName: a2 name)
+	self assert: (p1 includesExtensionSelector: #methodDefinedInP1 ofClass: a2).
+	self deny: (p3 includesDefinedSelector: #methodDefinedInP1 ofClass: a2)
 ]
 
 { #category : #'tests - extension' }
 RPackageIncrementalTest >> testIncludeSelectorOfMetaClass [
-	| p1 p2 p3 a2  a2class |
+
+	| p1 p2 p3 a2 a2class |
 	p1 := self createNewPackageNamed: 'P1'.
 	p2 := self createNewPackageNamed: 'P2'.
 	p3 := self createNewPackageNamed: 'P3'.
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	a2class := a2 class.
 	a2class compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2'.
-	p2 addMethod: (a2class>>#methodDefinedInP2).
+	p2 addMethod: a2class >> #methodDefinedInP2.
 	a2class compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addMethod: (a2class>>#methodDefinedInP1).
+	p1 addMethod: a2class >> #methodDefinedInP1.
 	a2class compileSilently: 'methodDefinedInP3 ^ #methodDefinedInP3'.
-	p3 addMethod: (a2class>>#methodDefinedInP3).
+	p3 addMethod: a2class >> #methodDefinedInP3.
 
 	"includesSelector checks both in defined and extension so we test both"
 	self assert: (p2 includesSelector: #methodDefinedInP2 ofClass: a2class).
-	self assert: (p2 includesDefinedSelector: #methodDefinedInP2 ofMetaclassName: a2 name).
+	self assert: (p2 includesDefinedSelector: #methodDefinedInP2 ofClass: a2 class).
 	self assert: (p2 includesDefinedSelector: #methodDefinedInP2 ofClass: a2class).
-	self deny: (p2 includesExtensionSelector: #methodDefinedInP2 ofMetaclassName: a2 name).
+	self deny: (p2 includesExtensionSelector: #methodDefinedInP2 ofClass: a2 class).
 
 	self deny: (p2 includesSelector: #methodDefinedInP3 ofClass: a2).
-	self assert: (p3 includesExtensionSelector: #methodDefinedInP3 ofMetaclassName: a2 name).
-	self deny: (p3 includesDefinedSelector: #methodDefinedInP3 ofMetaclassName: a2 name).
+	self assert: (p3 includesExtensionSelector: #methodDefinedInP3 ofClass: a2 class).
+	self deny: (p3 includesDefinedSelector: #methodDefinedInP3 ofClass: a2 class).
 
-	self deny: (p2 includesSelector: #methodDefinedInP1 ofMetaclassName: a2).
-	self assert: (p1 includesExtensionSelector: #methodDefinedInP1 ofMetaclassName: a2 name).
+	self deny: (p2 includesSelector: #methodDefinedInP1 ofClass: a2 class).
 	self assert: (p1 includesExtensionSelector: #methodDefinedInP1 ofClass: a2 class).
-	self deny: (p3 includesDefinedSelector: #methodDefinedInP1 ofClassName: a2 name).
+	self deny: (p3 includesDefinedSelector: #methodDefinedInP1 ofClass: a2 class).
 	self deny: (p3 includesDefinedSelector: #methodDefinedInP1 ofClass: a2)
 ]
 
 { #category : #'tests - extension' }
 RPackageIncrementalTest >> testIncludesMethodOfClassInPresenceOfOtherPackageExtensions [
-	| p1 p2 p3 a2  a2name |
+
+	| p1 p2 p3 a2 |
 	p1 := self createNewPackageNamed: 'P1'.
 	p2 := self createNewPackageNamed: 'P2'.
 	p3 := self createNewPackageNamed: 'P3'.
-	a2name := #A2InPackageP2.
-	a2 := self createNewClassNamed: a2name inPackage: p2.
+	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 
 	a2 compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2'.
-	p2 addMethod: (a2>>#methodDefinedInP2).
-	self assert: (p2 includesDefinedSelector: #methodDefinedInP2 ofClassName: a2name).
+	p2 addMethod: a2 >> #methodDefinedInP2.
+	self assert: (p2 includesDefinedSelector: #methodDefinedInP2 ofClass: a2).
 
 	a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addMethod: (a2>>#methodDefinedInP1).
-	self assert: (p1 includesExtensionSelector: #methodDefinedInP1 ofClassName: a2name).
+	p1 addMethod: a2 >> #methodDefinedInP1.
+	self assert: (p1 includesExtensionSelector: #methodDefinedInP1 ofClass: a2).
 
 	a2 compileSilently: 'methodDefinedInP3 ^ #methodDefinedInP3'.
-	p3 addMethod: (a2>>#methodDefinedInP3).
-	self assert: (p3 includesExtensionSelector: #methodDefinedInP3 ofClassName: a2name).
+	p3 addMethod: a2 >> #methodDefinedInP3.
+	self assert: (p3 includesExtensionSelector: #methodDefinedInP3 ofClass: a2).
 
-	self assert: (p2 includesDefinedSelector: #methodDefinedInP2 ofClassName: a2name).
-	self deny: (p2 includesDefinedSelector: #methodDefinedInP3 ofClassName: a2name).
-	self deny: (p2 includesExtensionSelector: #methodDefinedInP3 ofClassName: a2name).
-	self deny: (p2 includesDefinedSelector: #methodDefinedInP1 ofClassName: a2name).
-	self deny: (p2 includesExtensionSelector: #methodDefinedInP1 ofClassName: a2name)
+	self assert: (p2 includesDefinedSelector: #methodDefinedInP2 ofClass: a2).
+	self deny: (p2 includesDefinedSelector: #methodDefinedInP3 ofClass: a2).
+	self deny: (p2 includesExtensionSelector: #methodDefinedInP3 ofClass: a2).
+	self deny: (p2 includesDefinedSelector: #methodDefinedInP1 ofClass: a2).
+	self deny: (p2 includesExtensionSelector: #methodDefinedInP1 ofClass: a2)
 ]
 
 { #category : #'tests - extension' }

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -277,9 +277,7 @@ RPackageReadOnlyCompleteSetupTest >> testExtensionSelectorsForClass [
 { #category : #'tests - situation' }
 RPackageReadOnlyCompleteSetupTest >> testMetaclassHasExtensions [
 
-	self assert: (p3 includesExtensionSelector: #methodDefinedInP3 ofClassName: a2  name).
 	self assert: (p3 includesExtensionSelector: #methodDefinedInP3 ofClass: a2).
-	self assert: (p3 includesExtensionSelector: #classSideMethodDefinedInP3 ofMetaclassName: a2 name).
 	self assert: (p3 includesExtensionSelector: #classSideMethodDefinedInP3 ofClass: a2 class)
 ]
 

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -141,35 +141,6 @@ RPackageReadOnlyCompleteSetupTest >> testClassIsExtendedInPackage [
 	self assert: (p1 extendsClass: a2)
 ]
 
-{ #category : #'tests - slice' }
-RPackageReadOnlyCompleteSetupTest >> testClassNamesAndExtensionSelectorsDo [
-	self assert: (String streamContents: [:stream |
-		{p1 . p2 .p3} do: [:p |
-			p classNamesAndExtensionSelectorsDo: [:aClassName :selector |
-				stream nextPutAll: aClassName  ; nextPutAll: ' ' ; nextPutAll:  selector asString; cr ]]])
-		equals: 'A2DefinedInP2 methodDefinedInP1
-A2DefinedInP2 methodDefinedInP3
-A2DefinedInP2_class classSideMethodDefinedInP3
-'
-]
-
-{ #category : #'tests - slice' }
-RPackageReadOnlyCompleteSetupTest >> testClassesAndExtensionMethodsDo [
-	| block |
-	self assert: (String streamContents: [:stream |
-		block := [ :aClassName :selectors |
-				stream nextPutAll: aClassName ; nextPutAll: ' '.
-				selectors do: [ :selector | stream nextPutAll: selector asString].
-				stream cr.].
-		{p1 . p2 . p3} do: [ :p |
-			p classExtensionSlicesDo: block.
-			p metaclassExtensionSlicesDo: block.]])
-		equals: 'A2DefinedInP2 methodDefinedInP1
-A2DefinedInP2 methodDefinedInP3
-A2DefinedInP2 classSideMethodDefinedInP3
-'
-]
-
 { #category : #'tests - compiled method' }
 RPackageReadOnlyCompleteSetupTest >> testCompiledMethodIsDefinedInPackage [
 
@@ -240,19 +211,8 @@ RPackageReadOnlyCompleteSetupTest >> testExtendingPackagesOfClass [
 RPackageReadOnlyCompleteSetupTest >> testExtensionMethods [
 	"a package can extend several classes, either the class or  the meta-class side. 'extensionMethods' should list all the methods involved in shuch extensions. P3 extend a2 and a2 class"
 
-	| package extensionMethods cpt |
-	package := p3.
-	extensionMethods := package extensionMethods.	"self assert: (extensionMethods size = 2)."
-	self assert: (extensionMethods includes: a2 >> #methodDefinedInP3).
-	self assert: (extensionMethods includes: a2 class >> #classSideMethodDefinedInP3).
-	cpt := 0.
-	package
-		metaclassExtensionSlicesDo: [ :className :listOfSelectors | (className = a2 name and: [ listOfSelectors includes: #classSideMethodDefinedInP3 ]) ifTrue: [ cpt := cpt + 1 ] ].
-	self assert: cpt equals: 1.
-	cpt := 0.
-	package
-		classExtensionSlicesDo: [ :className :listOfSelectors | (className = a2 name and: [ listOfSelectors includes: #methodDefinedInP3 ]) ifTrue: [ cpt := cpt + 1 ] ].
-	self assert: cpt equals: 1
+	self assert: (p3 extensionMethods includes: a2 >> #methodDefinedInP3).
+	self assert: (p3 extensionMethods includes: a2 class >> #classSideMethodDefinedInP3)
 ]
 
 { #category : #'tests - situation' }

--- a/src/TraitsV2-Tests/T2TraitWithPackagesTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitWithPackagesTest.class.st
@@ -165,15 +165,16 @@ T2TraitWithPackagesTest >> testPackageOfMethodFromTraitsRemoved [
 	self assert: (t1 >> #m1) package equals: self packageUnderTest.
 	self assert: (t2 >> #m1) package equals: self packageUnderTest.
 
-	self assert: (self packageOrganizer packageDefiningOrExtendingSelector: #m1 inClassNamed: #T1) equals: self packageUnderTest.
+	self packageUnderTest includesSelector: #m1 ofClass: t1.
 
 	t1 removeSelector: #m1.
 
 	self assert: (t1 protocolOfSelector: #m1) isNil.
 	self assert: (t2 protocolOfSelector: #m1) isNil.
 
-	self assert: (self packageOrganizer packageDefiningOrExtendingSelector: #m1 inClassNamed: #T1) isNil.
-	self assert: (self packageOrganizer packageDefiningOrExtendingSelector: #m1 inClassNamed: #T2) isNil
+	self packageOrganizer packages do: [ :package |
+		self deny: (package includesSelector: #m1 ofClass: t1).
+		self deny: (package includesSelector: #m1 ofClass: t2) ]
 ]
 
 { #category : #tests }


### PR DESCRIPTION
RPackage API is huge and is exposing a lot of internal behavior about its caches to the users. 

In this PR I am doing an iteration on the cleaning of this API. I removed two low level methods that were used only in a trait test and I used a better RPackage API to do the same.

But the main change here is that I deprecated a lot of other methods that should mostly be used by the system to reduce a lot the API without making the code more complex.

For example:

```st
package includesDefinedSelector: #method1 ofClassName: class name.
package includesDefinedSelector: #method1 ofMetaclassName: class name
```

Can be replaced by

```st
package includesDefinedSelector: #method1 ofClass: class.
package includesDefinedSelector: #method1 ofClass: class class
```