### PR TITLE
Removing the use options in transformation. All test green

### DIFF
--- a/src/Refactoring2-Transformations-Tests/RBExtractMethodTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBExtractMethodTransformationTest.class.st
@@ -15,12 +15,12 @@ RBExtractMethodTransformationTest >> sourceCodeAt: anInterval forMethod: aSelect
 RBExtractMethodTransformationTest >> testExtractUsingExistingMethodRefactoring [
 
 	| transformation class |
+
 	transformation := (RBExtractMethodTransformation
 		extract: 'rewriteRule tree printString'
 		from: #checkMethod:
 		to: #bar
 		in: #RBTransformationRuleTestData).
-	transformation setOption: #useExistingMethod toUse: [ :re :sel | true ].
 	transformation asRefactoring transform.
 	self assert: transformation model changes changes size equals: 1.
 
@@ -37,37 +37,6 @@ RBExtractMethodTransformationTest >> testExtractUsingExistingMethodRefactoring [
 				in: class
 				classified: aSmalllintContext protocols ] ]').
 	self deny: (class directlyDefinesMethod: #bar)
-]
-
-{ #category : #tests }
-RBExtractMethodTransformationTest >> testExtractWithoutUseExistingMethodRefactoring [
-
-	| transformation class |
-	transformation := (RBExtractMethodTransformation
-		extract: 'rewriteRule tree printString'
-		from: #checkMethod:
-		to: #bar
-		in: #RBTransformationRuleTestData).
-	transformation setOption: #useExistingMethod toUse: [ :re :sel | false ].
-	transformation asRefactoring transform.
-	self assert: transformation model changes changes size equals: 2.
-
-	class := transformation model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeForSelector: #checkMethod:)
-		  equals: (self parseMethod: 'checkMethod: aSmalllintContext
-	class := aSmalllintContext selectedClass.
-	(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: [
-		(RecursiveSelfRule
-			 executeTree: rewriteRule tree
-			 initialAnswer: false) ifFalse: [
-			builder
-				compile: self bar
-				in: class
-				classified: aSmalllintContext protocols ] ]').
-	self assert: (class parseTreeForSelector: #bar)
-		equals: (self parseMethod: 'bar
-		rewriteRule tree printString').
-	self assert: (class directlyDefinesMethod: #bar)
 ]
 
 { #category : #'tests - failures' }

--- a/src/Refactoring2-Transformations/RBExtractMethodTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBExtractMethodTransformation.class.st
@@ -71,54 +71,57 @@ RBExtractMethodTransformation >> buildTransformations [
 
 	subtree := self calculateSubtree.
 
-	existingSelector ifNotNil: [
-		^ OrderedCollection with: (self parseTreeRewriterClass
-			replaceCode: subtree
-			byMessageSendTo: existingSelector
-			in: (self definingClass methodFor: self calculateTree selector))
-	]
-	ifNil: [
-	^ (parseTree isNil or: [ subtree isNil ])
-		ifTrue: [ OrderedCollection new ]
-		ifFalse: [
-			| tempsToRemove |
-			arguments := self calculateArguments.
-			temporaries := self calculateTemporaries.
-			assignments := self calculateAssignments.
-			tempsToRemove := self calculateTemporariesToRemove.
+	existingSelector
+		ifNotNil: [
+			^ OrderedCollection with: (self parseTreeRewriterClass 
+					   replaceCode: subtree
+					   byMessageSendTo: existingSelector
+					   in:
+					   (self definingClass methodFor: self calculateTree selector)) ]
+		ifNil: [
+			^ (parseTree isNil or: [ subtree isNil ])
+				  ifTrue: [ OrderedCollection new ]
+				  ifFalse: [
+					  | tempsToRemove |
+					  arguments := self calculateArguments.
+					  temporaries := self calculateTemporaries.
+					  assignments := self calculateAssignments.
+					  tempsToRemove := self calculateTemporariesToRemove.
 
-			assignments size > 1
-			ifTrue: [ OrderedCollection new ]
-			ifFalse: [
-				| newMethodName newArguments messageSend needsReturn |
-				newMethodName := self newMethodName.
-				newMethodName ifNil: [ ^ OrderedCollection new ].
+					  assignments size > 1
+						  ifTrue: [ OrderedCollection new ]
+						  ifFalse: [
+							  | newMethodName newArguments messageSend needsReturn |
+							  newMethodName := self newMethodName.
+							  newMethodName ifNil: [ ^ OrderedCollection new ].
 
-				needsReturn := self calculateIfReturnIsNeeded.
-				newMethod := self generateNewMethodWith: newMethodName.
-				newArguments := self calculateNewArgumentsIn: newMethodName.
-				messageSend := self messageSendWith: newMethodName
-									and: newArguments needsReturn: needsReturn.
+							  needsReturn := self calculateIfReturnIsNeeded.
+							  newMethod := self generateNewMethodWith: newMethodName.
+							  newArguments := self calculateNewArgumentsIn: newMethodName.
+							  messageSend := self
+								                 messageSendWith: newMethodName
+								                 and: newArguments
+								                 needsReturn: needsReturn.
 
-				OrderedCollection new
-					add: (RBAddMethodTransformation
-							model: self model
-							sourceCode: newMethod newSource
-							in: class
-							withProtocols: {Protocol unclassified});
-					add: (RBReplaceSubtreeTransformation
-							model: self model
-							replace: sourceCode
-							to: messageSend
-							inMethod: selector
-							inClass: class);
-					addAll: (tempsToRemove collect: [ :temporary |
-							RBRemoveTemporaryVariableTransformation
-							model: self model
-							variable: temporary
-							inMethod: selector
-							inClass: class ]);
-					yourself ] ] ]
+							  OrderedCollection new
+								  add: (RBAddMethodTransformation
+										   model: self model
+										   sourceCode: newMethod newSource
+										   in: class
+										   withProtocols: { Protocol unclassified });
+								  add: (RBReplaceSubtreeTransformation
+										   model: self model
+										   replace: sourceCode
+										   to: messageSend
+										   inMethod: selector
+										   inClass: class);
+								  addAll: (tempsToRemove collect: [ :temporary |
+											   RBRemoveTemporaryVariableTransformation
+												   model: self model
+												   variable: temporary
+												   inMethod: selector
+												   inClass: class ]);
+								  yourself ] ] ]
 ]
 
 { #category : #querying }
@@ -288,8 +291,7 @@ RBExtractMethodTransformation >> newMethodName [
 	[ newAttempt ] whileTrue: [
 		methodName := (RBMethodNameEditor openOn: methodName) methodName.
 		methodName
-			ifNil: [ "self inform: 'Please provide a name for the method.'.
-						methodName := RBMethodName new arguments: arguments" newAttempt := false ]
+			ifNil: [ newAttempt := false ]
 			ifNotNil: [ :newMethodName |
 				newSelector := newMethodName selector.
 				newAttempt := newSelector isNil.
@@ -314,41 +316,48 @@ RBExtractMethodTransformation >> preconditions [
 	aSubtree := self calculateSubtree.
 
 	^ (RBCondition withBlock: [
-		aSubtree ifNil: [ self refactoringError: 'Cannot extract code.' ]. true ])
-		"subtree containsReturn
-		ifTrue: [ self refactoringError: 'Cannot extract code because it contains a return.' ]."
-		& (RBCondition withBlock: [
-			aSubtree parent isCascade ifTrue: [
-				self refactoringError: 'Cannot extract code in a cascaded message' ]. true])
-		& (RBCondition withBlock: [
-			| tempVariables |
-			tempVariables := self calculateTemporaries.
-			(RBReadBeforeWrittenTester readBeforeWritten: tempVariables in: aSubtree) ifNotEmpty: [
-				self refactoringError: 'Cannot extract temporaries if they are read before written.' ]. true ])
-		& (RBCondition withBlock: [
-			self calculateAssignments size > 1 ifTrue: [
-				self refactoringError: 'Cannot extract two or more assignments to temporaries without also extracting all the references.' ]. true ])
-		& (RBCondition withBlock: [
-			| assignmentCollection |
-			assignmentCollection := self calculateAssignments.
-			assignmentCollection ifNotEmpty: [
-			((RBReadBeforeWrittenTester isVariable: assignmentCollection first
-				readBeforeWrittenIn: aSubtree)
-				or: [aSubtree containsReturn])
-				ifTrue: [ self refactoringError: ('Cannot extract assignment to <1s> without also extracting all the references.' expandMacrosWith: assignments asString)] ]. true ])
-		& (RBCondition withBlock: [
-			| searchSpace |
-			searchSpace := (self class
-				allMethodsInHierarchyOf: self definingClass)
-				reject: [ :m | m selector = selector ].
+		   aSubtree ifNil: [ self refactoringError: 'Cannot extract code.' ].
+		   true ]) & (RBCondition withBlock: [
+		   aSubtree parent isCascade ifTrue: [
+			   self refactoringError:
+				   'Cannot extract code in a cascaded message' ].
+		   true ]) & (RBCondition withBlock: [
+		   | tempVariables |
+		   tempVariables := self calculateTemporaries.
+		   (RBReadBeforeWrittenTester
+			    readBeforeWritten: tempVariables
+			    in: aSubtree) ifNotEmpty: [
+			   self refactoringError:
+				   'Cannot extract temporaries if they are read before written.' ].
+		   true ]) & (RBCondition withBlock: [
+		   self calculateAssignments size > 1 ifTrue: [
+			   self refactoringError:
+				   'Cannot extract two or more assignments to temporaries without also extracting all the references.' ].
+		   true ]) & (RBCondition withBlock: [
+		   | assignmentCollection |
+		   assignmentCollection := self calculateAssignments.
+		   assignmentCollection ifNotEmpty: [
+			   ((RBReadBeforeWrittenTester
+				     isVariable: assignmentCollection first
+				     readBeforeWrittenIn: aSubtree) or: [ aSubtree containsReturn ])
+				   ifTrue: [
+					   self refactoringError:
+						   ('Cannot extract assignment to <1s> without also extracting all the references.'
+							    expandMacrosWith: assignments asString) ] ].
+		   true ]) & (RBCondition withBlock: [
+		   | searchSpace |
+		   searchSpace := (self class allMethodsInHierarchyOf:
+			                   self definingClass) reject: [ :m |
+			                  m selector = selector ].
 
-			(self parseTreeSearcherClass whichMethodIn: searchSpace matches: aSubtree)
-				ifNotEmpty: [ :opportunities |
-					existingSelector := opportunities anyOne.
-					(self shouldUseExistingMethod: existingSelector selector)
-					ifFalse: [ existingSelector := nil ].
-					true ]
-				ifEmpty: [ true ] ])
+		   (self parseTreeSearcherClass
+			    whichMethodIn: searchSpace
+			    matches: aSubtree)
+			   ifNotEmpty: [ :opportunities | "we found one method with similar body so we will use it instead of creating a new one"
+				   existingSelector := opportunities anyOne.
+				   true ]
+			   ifEmpty: [ true ] ])
+	
 ]
 
 { #category : #printing }


### PR DESCRIPTION
Cleaning Extract method Transformation to not use the options.
We always want to reuse existing method instead of creating a duplicated one.