### PR TITLE
Do not remove classes through announcement

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -985,7 +985,7 @@ Class >> removeFromSystem: logged [
 	Keep the class name and category for triggering the system change message. If we wait to long, then we get obsolete information which is not what we want.
 	Tell class to deactivate and unload itself-- two separate events in the module system"
 
-	| myCategory |
+	| myCategory package |
 	self release.
 	self unload.
 
@@ -995,13 +995,14 @@ Class >> removeFromSystem: logged [
 	if this class is loaded again. We do not check if references exist as it is too slow"
 	Undeclared declare: self name asSymbol from: Smalltalk globals.
 	myCategory := self category.
+	package := self package.
 	self environment forgetClass: self logged: logged.
 
 	"In case the class has deprecated aliases we need to remove them from the system dictionary.
 	We deal also with a special case that is the case a class of the same name than the alias is installed in the image after the alias. In that case we do not remove it. It's the reason we check if the global of the alias is the same as self."
 	self deprecatedAliases do: [ :alias | self environment at: alias ifPresent: [ :class | class = self ifTrue: [ self environment removeKey: alias ] ] ].
 	self obsolete.
-	logged ifTrue: [ SystemAnnouncer uniqueInstance classRemoved: self fromCategory: myCategory ]
+	logged ifTrue: [ SystemAnnouncer announce: (ClassRemoved class: self package: package category: myCategory) ]
 ]
 
 { #category : #initialization }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -669,7 +669,6 @@ RPackageOrganizer >> registerInterestToAnnouncer: anAnnouncer [
 		when: CategoryAdded send: #systemCategoryAddedActionFrom: to: self;
 		when: ClassAdded send: #systemClassAddedActionFrom: to: self;
 		when: ClassRecategorized send: #systemClassRecategorizedActionFrom: to: self;
-		when: ClassRemoved send: #systemClassRemovedActionFrom: to: self;
 		when: ClassRenamed send: #systemClassRenamedActionFrom: to: self;
 		when: ProtocolAnnouncement send: #systemClassReorganizedActionFrom: to: self;
 		when: MethodAdded send: #systemMethodAddedActionFrom: to: self;
@@ -913,13 +912,6 @@ RPackageOrganizer >> systemClassRecategorizedActionFrom: announcement [
 	newPackageTag := newPackage addClassTag: newPackageName.
 
 	newPackage moveClass: class fromPackage: oldPackage toTag: newPackageTag
-]
-
-{ #category : #'system integration' }
-RPackageOrganizer >> systemClassRemovedActionFrom: ann [
-	"A class has been removed, we should update the package adequately."
-
-	self removeClass: ann classRemoved
 ]
 
 { #category : #'system integration' }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -704,6 +704,7 @@ RPackageOrganizer >> registerPackage: aPackage [
 RPackageOrganizer >> registerPackage: aPackage forClass: aClass [
 
 	(aPackage includesClass: aClass) ifFalse: [ self error: aPackage name , ' does not includes the class ' , aClass name ].
+
 	^ classPackageMapping at: aClass instanceSide originalName put: aPackage
 ]
 

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -39,13 +39,11 @@ RPackageTag >> addClassNamed: aSymbol [
 { #category : #private }
 RPackageTag >> asRPackage [
 	"Create a new RPackage with the same contents as this rpackage tag"
-	| newRPackage |
 
-	newRPackage := RPackage named: self categoryName.
-	self classes
-		do: [ :className | newRPackage importClass: className ].
-	(self package extensionsForTag: self)
-		do: [ :extensionMethod | newRPackage addMethod: extensionMethod ].
+	| newRPackage |
+	newRPackage := RPackage named: self categoryName organizer: self organizer.
+	self classes do: [ :className | newRPackage importClass: className ].
+	(self package extensionsForTag: self) do: [ :extensionMethod | newRPackage addMethod: extensionMethod ].
 
 	^ newRPackage
 ]

--- a/src/RPackage-Tests/RPackageTagTest.class.st
+++ b/src/RPackage-Tests/RPackageTagTest.class.st
@@ -10,9 +10,7 @@ Class {
 { #category : #running }
 RPackageTagTest >> tearDown [
 
-	#(TestClass TestClassOther)
-		do: [ :each |
-			self class environment at: each ifPresent: #removeFromSystem ].
+	#( TestClass TestClassOther ) do: [ :each | testEnvironment at: each ifPresent: #removeFromSystem ].
 	super tearDown
 ]
 

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -30,18 +30,18 @@ RPackageTest >> testActualClassTags [
 
 { #category : #tests }
 RPackageTest >> testAddClass [
-	| package1 package2 class done |
 
-	package1 := (RPackage named: #Test1) register.
+	| package1 package2 class done |
+	package1 := (self createNewPackageNamed: #Test1) register.
 	done := 0.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG'.
-	SystemAnnouncer uniqueInstance when: ClassRecategorized do: [ done := done + 1] for: self.
+	SystemAnnouncer uniqueInstance when: ClassRecategorized do: [ done := done + 1 ] for: self.
 
 	self assert: (package1 includesClass: class).
 	self assert: (package1 classTagNamed: #TAG ifAbsent: [ nil ]) notNil.
 	self assert: ((package1 classTagNamed: #TAG ifAbsent: [ nil ]) includesClass: class).
 
-	package2 := (RPackage named: #Test2) register.
+	package2 := (self createNewPackageNamed: #Test2) register.
 
 	package2 addClass: class.
 
@@ -54,14 +54,14 @@ RPackageTest >> testAddClass [
 
 { #category : #tests }
 RPackageTest >> testAddClassFromTag [
-	| package1 package2 class |
 
-	package1 := (RPackage named: #Test1) register.
+	| package1 package2 class |
+	package1 := (self createNewPackageNamed: #Test1) register.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG'.
 
 	self assert: (package1 includesClass: class).
 
-	package2 := (RPackage named: #Test2) register.
+	package2 := (self createNewPackageNamed: #Test2) register.
 
 	package2 addClass: class.
 
@@ -73,9 +73,9 @@ RPackageTest >> testAddClassFromTag [
 
 { #category : #tests }
 RPackageTest >> testAllUnsentMessages [
-	| package class1 class2 |
 
-	package := (RPackage named: #Test1) register.
+	| package class1 class2 |
+	package := (self createNewPackageNamed: #Test1) register.
 
 	class1 := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG'.
 	class2 := self createNewClassNamed: 'TestClassOther' inCategory: 'Test1-TAG'.
@@ -91,7 +91,9 @@ RPackageTest >> testAllUnsentMessages [
 
 	self assert: package allUnsentMessages size equals: 3.
 
-	self assert: package allUnsentMessages equals: (#('nonexistingMethodName1' 'nonexistingMethodName3' 'nonexistingMethodName4') collect: [:each | each asSymbol]) asSet
+	self
+		assert: package allUnsentMessages
+		equals: (#( 'nonexistingMethodName1' 'nonexistingMethodName3' 'nonexistingMethodName4' ) collect: [ :each | each asSymbol ]) asSet
 ]
 
 { #category : #tests }
@@ -320,9 +322,9 @@ RPackageTest >> testRemoveEmptyTags [
 
 { #category : #tests }
 RPackageTest >> testRenameToMakesMCDirty [
-	| package |
 
-	package := (RPackage named: #'Test1') register.
+	| package |
+	package := (self createNewPackageNamed: #Test1) register.
 	self createNewClassNamed: 'TestClass' inCategory: 'Test1'.
 
 	package renameTo: 'Test2'

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -298,7 +298,7 @@ ShiftClassInstaller >> recategorize: aClass to: newCategory [
 		ifTrue: [ ^ self ].
 
 	self installingEnvironment organization
-		ifNotNil: [ :e | e classify: aClass name under: newCategory ].
+		ifNotNil: [ :systemOrganizer | systemOrganizer classify: aClass name under: newCategory ].
 
 	(oldCategory isNil or:[ oldCategory = #Unclassified])
 		ifTrue: [ SystemAnnouncer uniqueInstance classAdded: aClass inCategory: newCategory ]

--- a/src/System-Announcements/ClassRemoved.class.st
+++ b/src/System-Announcements/ClassRemoved.class.st
@@ -8,7 +8,7 @@ Class {
 	#instVars : [
 		'categoryName',
 		'classRemoved',
-		'ownerPackage'
+		'affectedPackage'
 	],
 	#category : #'System-Announcements-System-Classes'
 }
@@ -19,6 +19,19 @@ ClassRemoved class >> class: aClass category: aCategoryName [
 			classRemoved: aClass;
 			categoryName: aCategoryName;
 			yourself
+]
+
+{ #category : #'instance creation' }
+ClassRemoved class >> class: aClass package: aPackage category: aCategoryName [
+
+	^ (self class: aClass category: aCategoryName)
+		  affectedPackage: aPackage;
+		  yourself
+]
+
+{ #category : #accessing }
+ClassRemoved >> affectedPackage: aPackage [
+	affectedPackage := aPackage
 ]
 
 { #category : #testing }
@@ -41,7 +54,7 @@ ClassRemoved >> affectsMethodsDefinedInClass: aClass [
 { #category : #testing }
 ClassRemoved >> affectsMethodsDefinedInPackage: aPackage [
 
-	^ownerPackage == aPackage
+	^affectedPackage == aPackage
 ]
 
 { #category : #testing }
@@ -77,15 +90,21 @@ ClassRemoved >> classRemoved [
 ClassRemoved >> classRemoved: aClass [
 
 	classRemoved := aClass.
-	ownerPackage := aClass package
+	affectedPackage := aClass package
 ]
 
 { #category : #accessing }
 ClassRemoved >> classTagAffected [
-	^ownerPackage toTagName: categoryName
+	^affectedPackage toTagName: categoryName
 ]
 
 { #category : #accessing }
 ClassRemoved >> packageAffected [
-	^ownerPackage
+	^affectedPackage
+]
+
+{ #category : #accessing }
+ClassRemoved >> packageAffected: aPackage [
+
+	affectedPackage := aPackage
 ]

--- a/src/System-Announcements/SystemAnnouncer.class.st
+++ b/src/System-Announcements/SystemAnnouncer.class.st
@@ -127,11 +127,6 @@ SystemAnnouncer >> classParentOf: aClass renamedFrom: oldName to: newName [
 ]
 
 { #category : #triggering }
-SystemAnnouncer >> classRemoved: aClass fromCategory: aCategoryName [
-	self announce: (ClassRemoved class: aClass category: aCategoryName)
-]
-
-{ #category : #triggering }
 SystemAnnouncer >> classRenamed: aClass from: oldClassName to: newClassName inCategory: aCategoryName [
 	self announce: (ClassRenamed
 				class: aClass

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -208,7 +208,9 @@ SystemDictionary >> forgetClass: aClass logged: aBool [
 	"Delete the class, aClass, from the system.
 	Note that this doesn't do everything required to dispose of a class - to do that use Class>>removeFromSystem."
 
+	self flag: #package. "Unify categories and packages to have only one removal to do and not two."
 	self organization removeBehavior: aClass.
+	self organization removeClass: aClass.
 	SessionManager default unregisterClassNamed: aClass name.
 	self removeKey: aClass name ifAbsent: [  ]
 ]


### PR DESCRIPTION
RPackage currently uses announcements to sync with the system. Since the goal is to integrate it in the MM, this should be removed to let the MM directly sync RPackage.

Here is a first step: Trying to remove the registration to ClassRemoved to remove a class for the packages.

Redo of #14289