### PR TITLE
Fix fuel tests

### DIFF
--- a/src/Fuel-Core-Tests/FLEnvironmentProtectingWrapper.class.st
+++ b/src/Fuel-Core-Tests/FLEnvironmentProtectingWrapper.class.st
@@ -176,10 +176,9 @@ FLEnvironmentProtectingWrapper >> doesNotUnderstand: aMessage [
 ]
 
 { #category : #'classes and traits' }
-FLEnvironmentProtectingWrapper >> forgetClass: aBehavior logged: aBoolean [
-	self
-		removeKey: aBehavior name
-		ifAbsent: []
+FLEnvironmentProtectingWrapper >> forgetClass: aBehavior [
+
+	self removeKey: aBehavior name ifAbsent: [  ]
 ]
 
 { #category : #testing }


### PR DESCRIPTION
A change integrated this morning broke some fuel tests. Here is a fix.

The problem is that a parameter got removed from a method of the kernel but a polymorphic method was not updated.

Culprit: https://github.com/pharo-project/pharo/pull/14389