### PR TITLE
Push tag API in the class builder

### DIFF
--- a/src/FluidClassBuilder/FluidBuilder.class.st
+++ b/src/FluidClassBuilder/FluidBuilder.class.st
@@ -110,17 +110,11 @@ FluidBuilder >> fillShiftClassBuilder [
 		                     name: nameToBuild;
 		                     slots: slotsToBuild;
 		                     traitComposition: uses;
-		                     yourself.
-
-	(tagToBuild isNil or: [ tagToBuild isEmpty ])
-		ifTrue: [ shiftClassBuilder category: packageName ]
-		ifFalse: [
-		tagToBuild
-			ifEmpty: [ shiftClassBuilder category: packageName ]
-			ifNotEmpty: [ shiftClassBuilder category: packageName , '-' , tagToBuild asString ] ].
-
-	shiftClassBuilder classSlots: classSlotsToBuild.
-	shiftClassBuilder classTraitComposition: classTraitsToBuild
+		                     package: packageName;
+		                     tag: tagToBuild;
+		                     classSlots: classSlotsToBuild;
+		                     classTraitComposition: classTraitsToBuild;
+		                     yourself
 ]
 
 { #category : #building }

--- a/src/SUnit-Core/ClassFactoryForTestCase.class.st
+++ b/src/SUnit-Core/ClassFactoryForTestCase.class.st
@@ -248,7 +248,8 @@ ClassFactoryForTestCase >> newSubclassOf: aClass uses: aTraitComposition instanc
 			            slotsFromString: ivNamesString;
 			            sharedVariablesFromString: classVarsString;
 			            sharedPools: poolNamesString;
-			            package: (self packageName , '-' , category) asSymbol ].
+			            package: self packageName;
+			            tag: category ].
 
 	self createdClasses add: newClass.
 	^ newClass
@@ -299,7 +300,8 @@ ClassFactoryForTestCase >> newTraitNamed: aTraitName uses: aTraitComposition tag
 		            aBuilder
 			            name: aTraitName;
 			            traitComposition: aTraitComposition;
-			            package: (self packageName , '-' , aTag) asSymbol;
+			            package: self packageName;
+			            tag: aTag;
 			            beTrait ].
 
 	self createdTraits add: newTrait.

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -21,7 +21,6 @@ Class {
 		'comment',
 		'commentStamp',
 		'superclass',
-		'category',
 		'newMetaclass',
 		'newClass',
 		'oldClass',
@@ -33,7 +32,9 @@ Class {
 		'changes',
 		'metaSuperclass',
 		'superclassResolver',
-		'inRemake'
+		'inRemake',
+		'package',
+		'tag'
 	],
 	#classVars : [
 		'BuilderEnhancer'
@@ -127,12 +128,23 @@ ShiftClassBuilder >> builderEnhancer: anObject [
 
 { #category : #accessing }
 ShiftClassBuilder >> category [
-	^ category
+
+	self flag: #package. "Category is an old concept mixing packages and tag. For now this is what is used by the system but in the future we should go away from it."
+	^ self tag
+		  ifNotNil: [ :packageTag | self package , '-' , packageTag ]
+		  ifNil: [ self package ]
 ]
 
-{ #category : #accessing }
-ShiftClassBuilder >> category: anObject [
-	category := anObject
+{ #category : #deprecated }
+ShiftClassBuilder >> category: aString [
+
+	self flag: #package. "Category is an old concept mixing packages and tag. For now this is what is used by the system but in the future we should go away from it."
+	(aString includes: $-)
+		ifTrue: [
+			self
+				package: (aString copyUpToLast: $-);
+				tag: (aString copyAfterLast: $-) ]
+		ifFalse: [ self package: aString ]
 ]
 
 { #category : #accessing }
@@ -336,7 +348,7 @@ ShiftClassBuilder >> initialize [
 	changeComparers := OrderedCollection new.
 	changes := Set new.
 
-	category := 'Unclassified'.
+	package := 'Unclassified'.
 	inRemake := false.
 
 	buildEnvironment := self class environment
@@ -452,9 +464,15 @@ ShiftClassBuilder >> oldMetaclass [
 ]
 
 { #category : #accessing }
-ShiftClassBuilder >> package: anObject [
+ShiftClassBuilder >> package [
 
-	self category: anObject
+	^ package
+]
+
+{ #category : #accessing }
+ShiftClassBuilder >> package: aString [
+
+	package := aString
 ]
 
 { #category : #changes }
@@ -547,6 +565,18 @@ ShiftClassBuilder >> superclassName: anObject [
 { #category : #accessing }
 ShiftClassBuilder >> superclassResolver: asuperclassResolver [
 	superclassResolver:= asuperclassResolver
+]
+
+{ #category : #accessing }
+ShiftClassBuilder >> tag [
+
+	^ tag
+]
+
+{ #category : #accessing }
+ShiftClassBuilder >> tag: anObject [
+
+	tag := anObject
 ]
 
 { #category : #building }


### PR DESCRIPTION
The class builder is currently using the concept of categories to classify the classes in the system. 

We want to get away from the category API so the method #package: was added. But this is not enough because the users of #package: are once again mixing packages and tags. 
I propose to rely on the #category getter for now to build a class, but to use #package: and #tags: in the API to define the class. Like this, we can start to write the code we want to see once the categories will be removed.

To see an example check the changes in ClassFactoryForTestCase that I just did. Once this is integrated it will allow me to clean further ClassFactoryForTestCase in order to deplecate the old class building API and rely more on the #make: way to create classes.