### PR TITLE
#optionInlineNone suppresses #optionInlineX at CompilationContext level (fixes #14323)

### DIFF
--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -496,22 +496,29 @@ CompilationContext >> optionConstantBlockClosure [
 
 { #category : #options }
 CompilationContext >> optionInlineAndOr [
-	^ options includes: #optionInlineAndOr
+
+	^ self optionInlineNone not and: [
+		  options includes: #optionInlineAndOr ]
 ]
 
 { #category : #options }
 CompilationContext >> optionInlineCase [
-	^ options includes: #optionInlineCase
+
+	^ self optionInlineNone not and: [
+		  options includes: #optionInlineCase ]
 ]
 
 { #category : #options }
 CompilationContext >> optionInlineIf [
-	^ options includes: #optionInlineIf
+
+	^ self optionInlineNone not and: [ options includes: #optionInlineIf ]
 ]
 
 { #category : #options }
 CompilationContext >> optionInlineIfNil [
-	^ options includes: #optionInlineIfNil
+
+	^ self optionInlineNone not and: [
+		  options includes: #optionInlineIfNil ]
 ]
 
 { #category : #options }
@@ -521,22 +528,30 @@ CompilationContext >> optionInlineNone [
 
 { #category : #options }
 CompilationContext >> optionInlineRepeat [
-	^ options includes: #optionInlineRepeat
+
+	^ self optionInlineNone not and: [
+		  options includes: #optionInlineRepeat ]
 ]
 
 { #category : #options }
 CompilationContext >> optionInlineTimesRepeat [
-	^ options includes: #optionInlineTimesRepeat
+
+	^ self optionInlineNone not and: [
+		  options includes: #optionInlineTimesRepeat ]
 ]
 
 { #category : #options }
 CompilationContext >> optionInlineToDo [
-	^ options includes: #optionInlineToDo
+
+	^ self optionInlineNone not and: [
+		  options includes: #optionInlineToDo ]
 ]
 
 { #category : #options }
 CompilationContext >> optionInlineWhile [
-	^ options includes: #optionInlineWhile
+
+	^ self optionInlineNone not and: [
+		  options includes: #optionInlineWhile ]
 ]
 
 { #category : #options }

--- a/src/OpalCompiler-Core/RBBlockNode.extension.st
+++ b/src/OpalCompiler-Core/RBBlockNode.extension.st
@@ -40,6 +40,7 @@ RBBlockNode >> isClean [
 { #category : #'*OpalCompiler-Core' }
 RBBlockNode >> isInlined [
 	parent isMessage ifFalse: [ ^ false ].
+	parent methodCompilationContextOrNil ifNotNil:[:c | c optionInlineNone ifTrue: [ ^false ]].
 	parent isInlineAndOr ifTrue: [^ true].
 	parent isInlineIf ifTrue: [^ true].
 	parent isInlineIfNil ifTrue: [^ true].

--- a/src/OpalCompiler-Tests/OCASTAndOrTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTAndOrTranslatorTest.class.st
@@ -6,9 +6,10 @@ Class {
 
 { #category : #'building suites' }
 OCASTAndOrTranslatorTest class >> testParameters [
-	^ super testParameters *
-		(ParametrizedTestMatrix new
-			forSelector: #optimization addOptions: { #optionInlineAndOr . #optionInlineNone })
+
+	^ super testParameters * (ParametrizedTestMatrix new
+		   forSelector: #optimization
+		   addOptions: (self inliningOptionsFor: #optionInlineAndOr))
 ]
 
 { #category : #'tests - and & or' }

--- a/src/OpalCompiler-Tests/OCASTDoubleBranchConditionalTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTDoubleBranchConditionalTranslatorTest.class.st
@@ -8,7 +8,7 @@ Class {
 OCASTDoubleBranchConditionalTranslatorTest class >> testParameters [
 	^ super testParameters *
 		(ParametrizedTestMatrix new
-			forSelector: #optimization addOptions: { #optionInlineIf . #optionInlineIfNil . #optionInlineNone })
+			forSelector: #optimization addOptions: {#() . #(#optionInlineIf) . #(#optionInlineIfNil) . #( #optionInlineNone) . #(#optionInlineIf #optionInlineIfNil #optionInlineNone)})
 ]
 
 { #category : #'tests - conditionals' }

--- a/src/OpalCompiler-Tests/OCASTRepeatTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTRepeatTranslatorTest.class.st
@@ -8,7 +8,7 @@ Class {
 OCASTRepeatTranslatorTest class >> testParameters [
 	^ super testParameters *
 		(ParametrizedTestMatrix new
-			forSelector: #optimization addOptions: { #optionInlineRepeat . #optionInlineNone })
+			forSelector: #optimization addOptions: (self inliningOptionsFor: #optionInlineRepeat))
 ]
 
 { #category : #'tests - blocks - optimized' }

--- a/src/OpalCompiler-Tests/OCASTSingleBranchConditionalTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTSingleBranchConditionalTranslatorTest.class.st
@@ -8,7 +8,7 @@ Class {
 OCASTSingleBranchConditionalTranslatorTest class >> testParameters [
 	^ super testParameters *
 		(ParametrizedTestMatrix new
-			forSelector: #optimization addOptions: { #optionInlineIf . #optionInlineIfNil . #optionInlineNone })
+			forSelector: #optimization addOptions: {#() . #(#optionInlineIf) . #(#optionInlineIfNil) . #( #optionInlineNone) . #(#optionInlineIf #optionInlineIfNil #optionInlineNone)})
 ]
 
 { #category : #'tests - ifFalse' }

--- a/src/OpalCompiler-Tests/OCASTTimesRepeatTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTTimesRepeatTranslatorTest.class.st
@@ -8,7 +8,7 @@ Class {
 OCASTTimesRepeatTranslatorTest class >> testParameters [
 	^ super testParameters *
 		(ParametrizedTestMatrix new
-			forSelector: #optimization addOptions: { #optionInlineTimesRepeat . #optionInlineNone })
+			forSelector: #optimization addOptions: (self inliningOptionsFor: #optionInlineTimesRepeat))
 ]
 
 { #category : #tests }

--- a/src/OpalCompiler-Tests/OCASTToDoTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTToDoTranslatorTest.class.st
@@ -8,7 +8,7 @@ Class {
 OCASTToDoTranslatorTest class >> testParameters [
 	^ super testParameters *
 		(ParametrizedTestMatrix new
-			forSelector: #optimization addOptions: { #optionInlineToDo . #optionInlineNone })
+			forSelector: #optimization addOptions: (self inliningOptionsFor: #optionInlineToDo))
 ]
 
 { #category : #'tests - blocks - optimized' }

--- a/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
@@ -12,6 +12,17 @@ Class {
 }
 
 { #category : #'building suites' }
+OCASTTranslatorTest class >> inliningOptionsFor: enableOption [
+
+	^ {
+		  #(  ). "No options supplied"
+		  { enableOption }. "Explicitly enable this type of inlining"
+		  #( #optionInlineNone ). "Disable all inlining"
+		  "Disable all inlining, *but* the specific option is also set (and should be ignored). See bug #14323."
+		  { enableOption. #optionInlineNone }}
+]
+
+{ #category : #'building suites' }
 OCASTTranslatorTest class >> testParameters [
 
 	^ super testParameters
@@ -26,7 +37,7 @@ OCASTTranslatorTest >> compilationContext [
 	context := CompilationContext new
 		encoderClass: self encoder;
 		bindings: globals;
-		parseOptions: { #'+' . optimization };
+		parseOptions: #(#+) , optimization;
 		yourself.	
 	
 	^ context

--- a/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
@@ -35,11 +35,10 @@ OCASTTranslatorTest >> compilationContext [
 
 	| context |
 	context := CompilationContext new
-		encoderClass: self encoder;
-		bindings: globals;
-		parseOptions: #(#+) , optimization;
-		yourself.	
-	
+		           encoderClass: self encoder;
+		           bindings: globals;
+		           yourself.
+	self optimization ifNotNil: [ :a | context parseOptions: #( #+ ) , a ].
 	^ context
 ]
 

--- a/src/OpalCompiler-Tests/OCASTWhileFalseTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTWhileFalseTranslatorTest.class.st
@@ -8,7 +8,7 @@ Class {
 OCASTWhileFalseTranslatorTest class >> testParameters [
 	^ super testParameters *
 		(ParametrizedTestMatrix new
-			forSelector: #optimization addOptions: { #optionInlineWhile . #optionInlineNone })
+			forSelector: #optimization addOptions: (self inliningOptionsFor: #optionInlineWhile))
 ]
 
 { #category : #'tests - blocks - optimized' }

--- a/src/OpalCompiler-Tests/OCASTWhileTrueTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTWhileTrueTranslatorTest.class.st
@@ -8,7 +8,7 @@ Class {
 OCASTWhileTrueTranslatorTest class >> testParameters [
 	^ super testParameters *
 		(ParametrizedTestMatrix new
-			forSelector: #optimization addOptions: { #optionInlineWhile . #optionInlineNone })
+			forSelector: #optimization addOptions: (self inliningOptionsFor: #optionInlineWhile))
 ]
 
 { #category : #'tests - blocks - optimized' }


### PR DESCRIPTION
Also added an early-out in RBBlockNode>>isInlined similar to the one in RBMessageNode. Either approach--suppression on CompilationContext, or checking on RBBlockNode--is sufficient on its own, but the CompilationContext approach is safer (others who ask #optionInlineX don't need to know about #optionInlineNone to get the correct behavior), while the early-out is more performant when #optionInlineNone is set, and seems like a reasonable thing to do.

Expanded test parameters on OCAST*TranslatorTest to include a sanity-check run using no parameters at all, and one where both the relevant enabling option and #optionInlineNone are both explicitly set. Without the fixes this does cause failures of e.g. OCASTAndOrTranslatorTest>>#testAndWithLeftFalseShortcircuitsRight with optimization #(#optionInlineAndOr #optionInlineNone), which is the situation reported in #14323.