### PR TITLE
Simplify category management

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -263,14 +263,7 @@ Class >> category [
 	category name stored in the ivar is still correct and only if this fails look it up
 	(latter is much more expensive)"
 
-	| result |
-	self basicCategory ifNotNil: [ :symbol | ((self packageOrganizer listAtCategoryNamed: symbol) includes: self name) ifTrue: [ ^ symbol ] ].
-	result := (self environment organization categoryOfBehavior: self)
-		          ifNil: [ #Unclassified ]
-		          ifNotNil: [ :value | value ].
-	self basicCategory: result.
-
-	^ result
+	^ self basicCategory ifNil: [ self error: 'Category should not be nil' ]
 ]
 
 { #category : #organization }
@@ -280,13 +273,9 @@ Class >> category: aString [
 
 	| oldCategory |
 	oldCategory := self basicCategory.
-	aString isString
-		ifTrue: [
-			self basicCategory: aString asSymbol.
-			self packageOrganizer classify: self name under: self basicCategory ]
-		ifFalse: [self errorCategoryName].
-	SystemAnnouncer uniqueInstance
-		class: self recategorizedFrom: oldCategory to: self basicCategory
+	self basicCategory: aString asSymbol.
+	self packageOrganizer classify: self name under: self basicCategory.
+	SystemAnnouncer uniqueInstance class: self recategorizedFrom: oldCategory to: self basicCategory
 ]
 
 { #category : #'subclass creation - variableByte' }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -476,11 +476,6 @@ ClassDescription >> ensureProtocol: aProtocol [
 	^ self addProtocol: aProtocol
 ]
 
-{ #category : #private }
-ClassDescription >> errorCategoryName [
-	self error: 'Category name must be a String'
-]
-
 { #category : #fileout }
 ClassDescription >> expandedDefinitionString [
 	"Return the string of the class definition, each of my subclass may tell the printer how to printer it. A kind of double dispatch since we have multiple printers and multiple entities to be printed."


### PR DESCRIPTION
Classes have a fallback when they do not know their category or if the category is wrong but I wonder if we even end up in that case. Since I want to remove the categories I'd like to check first if we can simplify its management to ease the migration to packages/tags. 

Let's see if the produced image is working with this simplification