### PR TITLE
Package: Save extension selectors under real classes

### DIFF
--- a/src/Calypso-SystemQueries/RPackage.extension.st
+++ b/src/Calypso-SystemQueries/RPackage.extension.st
@@ -23,13 +23,13 @@ RPackage >> definesOverridesOf: aMethod [
 
 	aMethod origin isInstanceSide
 		ifTrue: [
-			(self definesOverridesOf: aMethod in: classDefinedSelectors) ifTrue: [^true].
-			(self definesOverridesOf: aMethod in: classExtensionSelectors) ifTrue: [^true]]
+			(self definesOverridesOf: aMethod in: classDefinedSelectors) ifTrue: [ ^ true ].
+			(self definesOverridesOf: aMethod in: classExtensionSelectors) ifTrue: [ ^ true ] ]
 		ifFalse: [
-			(self definesOverridesOfClassSide: aMethod in: metaclassDefinedSelectors) ifTrue: [^true].
-			(self definesOverridesOfClassSide: aMethod in: metaclassExtensionSelectors) ifTrue: [^true]].
+			(self definesOverridesOfClassSide: aMethod in: metaclassDefinedSelectors) ifTrue: [ ^ true ].
+			(self definesOverridesOfClassSide: aMethod in: metaclassExtensionSelectors) ifTrue: [ ^ true ] ].
 
-	^false
+	^ false
 ]
 
 { #category : #'*Calypso-SystemQueries' }
@@ -40,10 +40,7 @@ RPackage >> definesOverridesOf: aMethod in: classAndSelectors [
 	selector := aMethod selector.
 
 	classAndSelectors keysAndValuesDo: [ :class :selectors |
-		((selectors includes: selector) and: [
-			 (class isString
-				  ifTrue: [ self environment classNamed: class ]
-				  ifFalse: [ class ]) inheritsFrom: methodClass ]) ifTrue: [ ^ true ] ].
+		((selectors includes: selector) and: [ class inheritsFrom: methodClass ]) ifTrue: [ ^ true ] ].
 	^ false
 ]
 
@@ -55,10 +52,7 @@ RPackage >> definesOverridesOfClassSide: aMethod in: classAndSelectors [
 	selector := aMethod selector.
 
 	classAndSelectors keysAndValuesDo: [ :class :selectors |
-		((selectors includes: selector) and: [
-			 (class isString
-				  ifTrue: [ self environment classNamed: class ]
-				  ifFalse: [ class ]) classSide inheritsFrom: methodClass ]) ifTrue: [ ^ true ] ].
+		((selectors includes: selector) and: [ class classSide inheritsFrom: methodClass ]) ifTrue: [ ^ true ] ].
 	^ false
 ]
 

--- a/src/CodeExport/RPackage.extension.st
+++ b/src/CodeExport/RPackage.extension.st
@@ -8,17 +8,9 @@ RPackage >> fileOut [
 
 	self classTags do: [ :each | self organizer fileOutCategory: each categoryName on: internalStream ].
 
-	classExtensionSelectors keysAndValuesDo: [ :className :selectors |
-		selectors do: [ :selector |
-			| extendedClass |
-			extendedClass := self class environment classNamed: className.
-			extendedClass fileOutMethod: selector on: internalStream ] ].
+	classExtensionSelectors keysAndValuesDo: [ :class :selectors | selectors do: [ :selector | class fileOutMethod: selector on: internalStream ] ].
 
-	metaclassExtensionSelectors keysAndValuesDo: [ :className :selectors |
-		selectors do: [ :selector |
-			| extendedClass |
-			extendedClass := self class environment classNamed: className.
-			extendedClass classSide fileOutMethod: selector on: internalStream ] ].
+	metaclassExtensionSelectors keysAndValuesDo: [ :class :selectors | selectors do: [ :selector | class classSide fileOutMethod: selector on: internalStream ] ].
 
 	^ CodeExporter writeSourceCodeFrom: internalStream baseName: self name isSt: true
 ]

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -224,8 +224,8 @@ RPackage >> addMethod: aCompiledMethod [
 				ifFalse: [ (classDefinedSelectors at: methodClass ifAbsentPut: [ IdentitySet new ]) add: aCompiledMethod selector ] ]
 		ifFalse: [
 			methodClass isMeta
-				ifTrue: [ (metaclassExtensionSelectors at: methodClass instanceSide name ifAbsentPut: [ IdentitySet new ]) add: aCompiledMethod selector ]
-				ifFalse: [ (classExtensionSelectors at: methodClass name ifAbsentPut: [ IdentitySet new ]) add: aCompiledMethod selector ].
+				ifTrue: [ (metaclassExtensionSelectors at: methodClass instanceSide ifAbsentPut: [ IdentitySet new ]) add: aCompiledMethod selector ]
+				ifFalse: [ (classExtensionSelectors at: methodClass ifAbsentPut: [ IdentitySet new ]) add: aCompiledMethod selector ].
 			"we added a method extension so the receiver is an extending package of the class"
 			self organizer registerExtendingPackage: self forClass: methodClass ].
 
@@ -428,18 +428,14 @@ RPackage >> environment [
 RPackage >> extendedClassNames [
 	"Return the name of the classes which are extended by the receiver package. if a metaclass is extended, just get its sole instance class name."
 
-	^ classExtensionSelectors keys union: metaclassExtensionSelectors keys
+	^ (classExtensionSelectors keys union: metaclassExtensionSelectors keys) collect: [ :class | class name ]
 ]
 
 { #category : #accessing }
 RPackage >> extendedClasses [
 	"Return classes and metaclasses that are extended in the receiver. They represent the classes of method extensions"
 
-	^ (metaclassExtensionSelectors keys
-		   select: [ :each | self environment includesKey: each ]
-		   thenCollect: [ :each | (self environment at: each) classSide ]) union: (classExtensionSelectors keys
-			   select: [ :each | self environment includesKey: each ]
-			   thenCollect: [ :each | self environment at: each ])
+	^ (metaclassExtensionSelectors keys collect: [ :class | class classSide ]) union: classExtensionSelectors keys
 ]
 
 { #category : #testing }
@@ -457,10 +453,8 @@ RPackage >> extensionMethods [
 
 	| allExtensionMethods |
 	allExtensionMethods := OrderedCollection new.
-	classExtensionSelectors keysAndValuesDo: [ :classSymbol :methods |
-		methods do: [ :selector | allExtensionMethods add: (self environment at: classSymbol) >> selector ] ].
-	metaclassExtensionSelectors keysAndValuesDo: [ :classSymbol :methods |
-		methods do: [ :selector | allExtensionMethods add: (self environment at: classSymbol) classSide >> selector ] ].
+	classExtensionSelectors keysAndValuesDo: [ :class :selectors | allExtensionMethods addAll: (selectors collect: [ :selector | class >> selector ]) ].
+	metaclassExtensionSelectors keysAndValuesDo: [ :class :selectors | allExtensionMethods addAll: (selectors collect: [ :selector | class classSide >> selector ]) ].
 
 	^ allExtensionMethods
 ]
@@ -482,19 +476,19 @@ RPackage >> extensionProtocolsForClass: aClass [
 RPackage >> extensionSelectors [
 	"Extension methods are methods defined on classes that are not defined in the receiver"
 
-	| classSels |
-	classSels := Set new.
-	classExtensionSelectors valuesDo: [ :each | classSels addAll: each ].
-	metaclassExtensionSelectors valuesDo: [ :each | classSels addAll: each ].
-	^ classSels
+	| allSelectors |
+	allSelectors := Set new.
+	classExtensionSelectors valuesDo: [ :selectors | allSelectors addAll: selectors ].
+	metaclassExtensionSelectors valuesDo: [ :selectors | allSelectors addAll: selectors ].
+	^ allSelectors
 ]
 
 { #category : #accessing }
 RPackage >> extensionSelectorsForClass: aClass [
 
 	^ aClass isMeta
-		ifTrue: [ metaclassExtensionSelectors at: aClass instanceSide originalName ifAbsent: [ #() ] ]
-		ifFalse: [ classExtensionSelectors at: aClass originalName ifAbsent: [ #() ] ]
+		  ifTrue: [ metaclassExtensionSelectors at: aClass instanceSide ifAbsent: [ #(  ) ] ]
+		  ifFalse: [ classExtensionSelectors at: aClass ifAbsent: [ #(  ) ] ]
 ]
 
 { #category : #'class tags' }
@@ -708,8 +702,8 @@ RPackage >> methods [
 	| methods |
 	methods := OrderedCollection new.
 
-	metaclassExtensionSelectors keysAndValuesDo: [ :key :val | val do: [ :sel | methods add: (self environment at: key) classSide >> sel ] ].
-	classExtensionSelectors keysAndValuesDo: [ :key :val | val do: [ :sel | methods add: (self environment at: key) >> sel ] ].
+	metaclassExtensionSelectors keysAndValuesDo: [ :class :selectors | methods addAll: (selectors collect: [ :selector | class classSide >> selector ]) ].
+	classExtensionSelectors keysAndValuesDo: [ :class :selectors | methods addAll: (selectors collect: [ :selector | class >> selector ]) ].
 
 	metaclassDefinedSelectors keysAndValuesDo: [ :class :selectors | methods addAll: (selectors collect: [ :selector | class classSide >> selector ]) ].
 	classDefinedSelectors keysAndValuesDo: [ :class :selectors | methods addAll: (selectors collect: [ :selector | class >> selector ]) ].
@@ -861,8 +855,8 @@ RPackage >> removeAllMethodsFromClass: aClass [
 	aClassNameSymbol := aClass originalName asSymbol.
 	classDefinedSelectors removeKey: aClass ifAbsent: [  ].
 	metaclassDefinedSelectors removeKey: aClass ifAbsent: [  ].
-	classExtensionSelectors removeKey: aClassNameSymbol ifAbsent: [  ].
-	metaclassExtensionSelectors removeKey: aClassNameSymbol ifAbsent: [  ].
+	classExtensionSelectors removeKey: aClass ifAbsent: [  ].
+	metaclassExtensionSelectors removeKey: aClass ifAbsent: [  ].
 
 	self organizer unregisterExtendingPackage: self forClassName: aClassNameSymbol
 ]
@@ -942,16 +936,16 @@ RPackage >> removeMethod: aCompiledMethod [
 		ifFalse: [
 			methodClass isMeta
 				ifTrue: [
-					metaclassExtensionSelectors at: methodClass instanceSide originalName ifPresent: [ :methods |
+					metaclassExtensionSelectors at: methodClass instanceSide ifPresent: [ :methods |
 						methods remove: aCompiledMethod selector ifAbsent: [  ].
-						methods ifEmpty: [ metaclassExtensionSelectors removeKey: methodClass instanceSide originalName ] ] ]
+						methods ifEmpty: [ metaclassExtensionSelectors removeKey: methodClass instanceSide ] ] ]
 				ifFalse: [
-					classExtensionSelectors at: methodClass originalName ifPresent: [ :methods |
+					classExtensionSelectors at: methodClass ifPresent: [ :methods |
 						methods remove: aCompiledMethod selector ifAbsent: [  ].
-						methods ifEmpty: [ classExtensionSelectors removeKey: methodClass originalName ] ] ] ].
+						methods ifEmpty: [ classExtensionSelectors removeKey: methodClass ] ] ] ].
 
-	((metaclassExtensionSelectors at: methodClass instanceSide originalName ifAbsent: [ #(  ) ]) isEmpty and: [
-		 (classExtensionSelectors at: methodClass instanceSide originalName ifAbsent: [ #(  ) ]) isEmpty ]) ifTrue: [
+	((metaclassExtensionSelectors at: methodClass instanceSide ifAbsent: [ #(  ) ]) isEmpty and: [
+		 (classExtensionSelectors at: methodClass instanceSide ifAbsent: [ #(  ) ]) isEmpty ]) ifTrue: [
 		self organizer unregisterExtendingPackage: self forClassName: methodClass instanceSide originalName ].
 
 	^ aCompiledMethod
@@ -1058,8 +1052,8 @@ RPackage >> selectors [
 
 	| allSelectors |
 	allSelectors := Set new.
-	metaclassExtensionSelectors valuesDo: [ :each | allSelectors addAll: each ].
-	classExtensionSelectors valuesDo: [ :each | allSelectors addAll: each ].
+	metaclassExtensionSelectors valuesDo: [ :selectors | allSelectors addAll: selectors ].
+	classExtensionSelectors valuesDo: [ :selectors | allSelectors addAll: selectors ].
 	metaclassDefinedSelectors valuesDo: [ :selectors | allSelectors addAll: selectors ].
 	classDefinedSelectors valuesDo: [ :selectors | allSelectors addAll: selectors ].
 	^ allSelectors
@@ -1140,36 +1134,15 @@ RPackage >> updateDefinedSelector: oldSelector inClass: aClass withNewSelector: 
 ]
 
 { #category : #updating }
-RPackage >> updateExtensionForClassNamed: oldString withNewName: newString [
-
-	"=> update the 'classExtensionsSelectors' dictionary (replace the old key by the new one)
-        => update the 'metaclassclassExtensionsSelectors' dictionary (replace the old key by the new one)"
-	"classes remove: oldString.
-	classes add: newString."
-
-	(metaclassExtensionSelectors at: oldString ifAbsent: [nil]) ifNotNil: [
-		metaclassExtensionSelectors at: newString put: (metaclassExtensionSelectors at: oldString).
-		metaclassExtensionSelectors removeKey: oldString  ifAbsent: [self reportBogusBehaviorOf: #updateExtensionForClassNamed:withNewName:   ]
-		].
-
-	(classExtensionSelectors at: oldString ifAbsent: [nil]) ifNotNil: [
-		classExtensionSelectors at: newString put: (classExtensionSelectors at: oldString).
-		classExtensionSelectors removeKey: oldString ifAbsent: [self reportBogusBehaviorOf: #updateExtensionForClassNamed:withNewName:   ]
-		]
-]
-
-{ #category : #updating }
 RPackage >> updateExtensionSelector: oldSelector inClass: aClass withNewSelector: newSelector [
 
 	aClass isMeta
 		ifTrue: [
-			(metaclassExtensionSelectors at: aClass instanceSide name asSymbol) remove: oldSelector.
-			(metaclassExtensionSelectors at: aClass instanceSide name asSymbol) add: newSelector.
-			]
+			(metaclassExtensionSelectors at: aClass instanceSide) remove: oldSelector.
+			(metaclassExtensionSelectors at: aClass instanceSide) add: newSelector ]
 		ifFalse: [
-			(classExtensionSelectors  at: aClass name asSymbol) remove: oldSelector.
-			(classExtensionSelectors  at: aClass name asSymbol) add: newSelector.
-			]
+			(classExtensionSelectors at: aClass) remove: oldSelector.
+			(classExtensionSelectors at: aClass) add: newSelector ]
 ]
 
 { #category : #updating }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -829,8 +829,6 @@ RPackageOrganizer >> renameClass: class from: oldName to: newName [
 	extendingPackages := self extendingPackagesOfClassNamed: oldName.
 
 	package updateDefinedClassNamed: oldName withNewName: newName.
-	"we have to update all RPackages extending this class"
-	extendingPackages do: [ :extendingPackage | extendingPackage updateExtensionForClassNamed: oldName withNewName: newName ].
 
 	"we have to update the package organizer.
 	update the 'classPackageDictionary' to replace the key with the new class name"


### PR DESCRIPTION
This change propose to save extension selectors under real classes in the package instead of saving them under a class name to simplify the update of RPackage.