### PR TITLE
Use PackageTagAdded instead of CategoryAdded

### DIFF
--- a/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
+++ b/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
@@ -147,18 +147,17 @@ RBRefactoryChangeManager >> clearUndoRedoList [
 
 { #category : #initialization }
 RBRefactoryChangeManager >> connectToChanges [
+
 	SystemAnnouncer uniqueInstance weak
-		when: CategoryAdded,
-			CategoryRemoved,
-			CategoryRenamed,
-			ClassAdded,
-			ClassModifiedClassDefinition,
-			ClassRemoved,
-			ClassRenamed,
-			MethodAdded,
-			MethodModified,
-			MethodRemoved,
-			ProtocolAnnouncement
+		when: PackageTagAnnouncement,
+				ClassAdded,
+				ClassModifiedClassDefinition,
+				ClassRemoved,
+				ClassRenamed,
+				MethodAdded,
+				MethodModified,
+				MethodRemoved, 
+				ProtocolAnnouncement
 		send: #update:
 		to: self
 ]

--- a/src/SUnit-UI/TestRunner.class.st
+++ b/src/SUnit-UI/TestRunner.class.st
@@ -679,7 +679,7 @@ TestRunner >> initialize [
 	super initialize.
 	failedList := errorList := Array new.
 	SystemAnnouncer uniqueInstance weak
-		when: ClassAdded, CategoryAdded, ClassRemoved, CategoryRemoved, ClassRenamed, CategoryRenamed, ClassRecategorized
+		when: ClassAdded, PackageTagAdded, ClassRemoved, CategoryRemoved, ClassRenamed, CategoryRenamed, ClassRecategorized
 			send: #update
 			to: self.
 	self update; resetResult


### PR DESCRIPTION
Make the system use PackageTagAdded instead of CategoryAdded since I want to deprecate CategoryAdded. 

Only two users left:
- Epicea that is been dealt with in another PR
- RPackage that still relies on it to update since changing that is breaking the bootstrap :(