### PR TITLE
Improve flacky test

### DIFF
--- a/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
@@ -98,7 +98,7 @@ ClassFactoryForTestCaseTest >> testPackageCleanUp [
 	self assert: (factory createdClasses allSatisfy: [ :class | class isObsolete ]).
 	allClasses := self environment allClasses.
 	self assert: (factory createdClasses noneSatisfy: [ :class | allClasses includes: class ]).
-	self assertEmpty: (self organization categoriesMatching: factory packageName , '*').
+	self assertEmpty: (self organization packages select: [ :package | package name beginsWith: factory packageName ]).
 	self class environment at: #ChangeSet ifPresent: [ :changeSet | self deny: (changeSet current changedClassNames includesAnyOf: createdClassNames) ]
 ]
 

--- a/src/SUnit-Tests/TestCaseTest.class.st
+++ b/src/SUnit-Tests/TestCaseTest.class.st
@@ -9,33 +9,41 @@ Class {
 
 { #category : #events }
 TestCaseTest >> testAnnouncement [
-	| collection oldCollection suite unitTest |
+
+	| announcements oldCollection suite unitTest result |
 	unitTest := ClassFactoryForTestCaseTest.
-	collection := OrderedCollection new.
+	announcements := Dictionary new.
 	unitTest resetAnnouncer.
 
 	self deny: unitTest shouldAnnounce.
 	self deny: unitTest new shouldAnnounce.
 
-	unitTest announcer when: TestCaseAnnouncement do: [ :ann | collection add: ann ] for: self.
+	unitTest announcer when: TestCaseAnnouncement do: [ :ann | (announcements at: ann class ifAbsentPut: [ OrderedCollection new ]) add: ann ] for: self.
 
 	self assert: unitTest shouldAnnounce.
 	self assert: unitTest new shouldAnnounce.
 
 	"We run SUnitTest"
 	suite := unitTest buildSuite.
-	suite run.
+	result := suite run.
 
-	self assert: collection size equals: suite tests size * 2.
-	self assert: (collection select: [ :c | c isKindOf: TestCaseStarted ]) size equals: collection size / 2.
-	self assert: (collection select: [ :c | c isKindOf: TestCaseEnded ]) size equals: collection size / 2.
-	self assert: (collection allSatisfy: #hasPassed).
-	self deny: (collection anySatisfy: #hasFailures).
+	self assertEmpty: result failures.
+	self assertEmpty: result errors.
 
-	oldCollection := collection copy.
+	self
+		assert: (announcements at: TestCaseStarted ifAbsent: [ self fail: 'We should have received some TestCaseStarted announcements.' ]) size
+		equals: suite tests size.
+	self
+		assert: (announcements at: TestCaseEnded ifAbsent: [ self fail: 'We should have received some TestCaseEnded announcements.' ]) size
+		equals: suite tests size.
+	self assertCollection: announcements keys hasSameElements: {
+			TestCaseStarted.
+			TestCaseEnded }.
+
+	oldCollection := announcements copy.
 	unitTest resetAnnouncer.
 	unitTest debug: #testClassCreationInDifferentTags.
-	self assert: collection equals: oldCollection
+	self assert: announcements equals: oldCollection
 ]
 
 { #category : #testing }

--- a/src/System-Support-Tests/SystemNavigationTest.class.st
+++ b/src/System-Support-Tests/SystemNavigationTest.class.st
@@ -104,7 +104,9 @@ SystemNavigationTest >> testIsMessageSentInSystemWithClassesActuallySendngTheMes
 	5 timesRepeat: [ self classFactory make: [ :aBuilder | aBuilder tag: #Two ] ].
 	classesSendingMessage := (self classFactory createdClasses asArray first: 2) , (self classFactory createdClasses asArray last: 3).
 	classesSendingMessage do: [ :class | class compileSilently: 'meth self ' , sentMessageSelector ].
-	self assert: (self systemNavigationToTest allSendersOf: sentMessageSelector) size equals: 5
+	self
+		assertCollection: (self systemNavigationToTest allSendersOf: sentMessageSelector)
+		hasSameElements: (classesSendingMessage collect: [ :class | class >> #meth ])
 ]
 
 { #category : #tests }
@@ -116,7 +118,9 @@ SystemNavigationTest >> testIsMessageSentInSystemWithTheSelectorInsideAnArray [
 	5 timesRepeat: [ self classFactory make: [ :aBuilder | aBuilder tag: #Two ] ].
 	classesSendingMessage := (self classFactory createdClasses asArray first: 2) , (self classFactory createdClasses asArray last: 3).
 	classesSendingMessage do: [ :class | class compileSilently: 'meth ^#(a b ' , sentMessageSelector , ' c)' ].
-	self assert: (self systemNavigationToTest allSendersOf: sentMessageSelector) size equals: 5
+	self
+		assertCollection: (self systemNavigationToTest allSendersOf: sentMessageSelector)
+		hasSameElements: (classesSendingMessage collect: [ :class | class >> #meth ])
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Recently some tests have been flacky on the CI. The goal of this change is to improve the tests so that they are less flacky and that they print better logs in case they still fail so that we can have an idea of the origin of the problem.