### PR TITLE
TestRunner should not rely on category announcements

### DIFF
--- a/src/SUnit-UI/TestRunner.class.st
+++ b/src/SUnit-UI/TestRunner.class.st
@@ -679,7 +679,7 @@ TestRunner >> initialize [
 	super initialize.
 	failedList := errorList := Array new.
 	SystemAnnouncer uniqueInstance weak
-		when: ClassAdded, PackageTagAdded, ClassRemoved, CategoryRemoved, ClassRenamed, CategoryRenamed, ClassRecategorized
+		when: ClassAdded, PackageTagAnnouncement, ClassRemoved, ClassRenamed, ClassRecategorized
 			send: #update
 			to: self.
 	self update; resetResult


### PR DESCRIPTION
Instead I make it use the tag announcements. 

Tests runner, Epicea and RPackage are the only two last users of the category announcements. I already did a PR to fix Epicea and I am trying to update RPAckage alos even if the bootstrap does not seems to like it. But once those 3 changes are integrated, we can remove those announcements!