### PR TITLE
[Refactor] unified refactoring/transformation execution API

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -2827,9 +2827,7 @@ RBCodeSnippet class >> updateSnippets: snippets [
 	snippets
 		do: [ :snippet |
 			snippet definitionRefactoring ifNotNil: [ :refactoring |
-				refactoring
-					transform;
-					execute ] ]
+				refactoring execute ] ]
 		displayingProgress: 'Updating snippets...'
 ]
 
@@ -3277,9 +3275,7 @@ RBCodeSnippet >> updateDefinition [
 	"Do the update of the definition of self in the method (class-side) that defines it"
 
 	self definitionRefactoring ifNotNil: [ :transformation |
-		transformation
-			transform;
-			execute ]
+		transformation execute ]
 ]
 
 { #category : #updating }

--- a/src/GeneralRules/ReInconsistentMethodClassificationRule.class.st
+++ b/src/GeneralRules/ReInconsistentMethodClassificationRule.class.st
@@ -42,10 +42,16 @@ ReInconsistentMethodClassificationRule >> check: aMethod forCritiquesDo: aCritiq
 ReInconsistentMethodClassificationRule >> critiqueFor: aMethod [
 
 	| protocolInSuperclass |
-	protocolInSuperclass := (aMethod methodClass superclass lookupSelector: aMethod selector) protocolName.
+	protocolInSuperclass := (aMethod methodClass superclass
+		                         lookupSelector: aMethod selector)
+		                        protocolName.
 
-	^ (ReRefactoringCritique withAnchor: (self anchorFor: aMethod) by: self) refactoring:
-		  (RBMethodProtocolTransformation protocol: { protocolInSuperclass } inMethod: aMethod selector inClass: aMethod methodClass name) asRefactoring
+	^ (ReRefactoringCritique
+		   withAnchor: (self anchorFor: aMethod)
+		   by: self) refactoring: (RBMethodProtocolTransformation
+			   protocol: { protocolInSuperclass }
+			   inMethod: aMethod selector
+			   inClass: aMethod methodClass name)
 ]
 
 { #category : #accessing }

--- a/src/GeneralRules/ReNoSpaceAroundProtocolRule.class.st
+++ b/src/GeneralRules/ReNoSpaceAroundProtocolRule.class.st
@@ -35,8 +35,12 @@ ReNoSpaceAroundProtocolRule >> critiqueFor: aMethod [
 	| proposedProtocol |
 	proposedProtocol := protocolName trimBoth.
 
-	^ (ReRefactoringCritique withAnchor: (self anchorFor: aMethod) by: self) refactoring:
-		  (RBMethodProtocolTransformation protocol: { proposedProtocol } inMethod: aMethod selector inClass: aMethod methodClass name asSymbol) asRefactoring
+	^ (ReRefactoringCritique
+		   withAnchor: (self anchorFor: aMethod)
+		   by: self) refactoring: (RBMethodProtocolTransformation
+			   protocol: { proposedProtocol }
+			   inMethod: aMethod selector
+			   inClass: aMethod methodClass name asSymbol)
 ]
 
 { #category : #accessing }

--- a/src/Refactoring-Core/RBAbstractClassVariableReferencesRefactoring.class.st
+++ b/src/Refactoring-Core/RBAbstractClassVariableReferencesRefactoring.class.st
@@ -73,7 +73,7 @@ RBAbstractClassVariableReferencesRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
-RBAbstractClassVariableReferencesRefactoring >> transform [
+RBAbstractClassVariableReferencesRefactoring >> privateTransform [
 	self createAccessors.
 	self abstractInstanceSideReferences.
 	self abstractClassSideReferences

--- a/src/Refactoring-Core/RBAbstractInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBAbstractInstanceVariableRefactoring.class.st
@@ -60,7 +60,7 @@ RBAbstractInstanceVariableRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
-RBAbstractInstanceVariableRefactoring >> transform [
+RBAbstractInstanceVariableRefactoring >> privateTransform [
 	self createAccessors.
 	self abstractReferences
 ]

--- a/src/Refactoring-Core/RBAbstractTransformation.class.st
+++ b/src/Refactoring-Core/RBAbstractTransformation.class.st
@@ -103,6 +103,19 @@ RBAbstractTransformation >> checkMethodName: aName in: aClass [
 ]
 
 { #category : #preconditions }
+RBAbstractTransformation >> checkPreconditions [
+
+	| conditions block |
+	conditions := self preconditions.
+	conditions check ifTrue: [ ^ self ].
+	block := conditions errorBlock.
+	block
+		ifNotNil: [
+		self refactoringWarning: conditions errorString with: block ]
+		ifNil: [ self refactoringError: conditions errorString ]
+]
+
+{ #category : #preconditions }
 RBAbstractTransformation >> classExist [
 
 	| className |
@@ -233,10 +246,21 @@ RBAbstractTransformation >> preconditions [
 	self subclassResponsibility
 ]
 
-{ #category : #'private hook' }
-RBAbstractTransformation >> primitiveExecute [ 
+{ #category : #executing }
+RBAbstractTransformation >> primitiveExecute [
+	"compatibility method RBRefactoring"
 
-	self subclassResponsibility
+	self checkPreconditions.
+	self privateTransform
+	
+	"below executes the refactoring without prompt"
+	"RBRefactoringManager instance addRefactoring: self"
+]
+
+{ #category : #transforming }
+RBAbstractTransformation >> privateTransform [ 
+
+	self subclassResponsibility 
 ]
 
 { #category : #exceptions }

--- a/src/Refactoring-Core/RBAbstractTransformation.class.st
+++ b/src/Refactoring-Core/RBAbstractTransformation.class.st
@@ -239,6 +239,12 @@ RBAbstractTransformation >> primitiveExecute [
 	self subclassResponsibility
 ]
 
+{ #category : #'private hook' }
+RBAbstractTransformation >> privateTransform [
+
+	self subclassResponsibility 
+]
+
 { #category : #exceptions }
 RBAbstractTransformation >> refactoringConfirmWarning: aString [
 	| ret |

--- a/src/Refactoring-Core/RBAbstractTransformation.class.st
+++ b/src/Refactoring-Core/RBAbstractTransformation.class.st
@@ -239,12 +239,6 @@ RBAbstractTransformation >> primitiveExecute [
 	self subclassResponsibility
 ]
 
-{ #category : #'private hook' }
-RBAbstractTransformation >> privateTransform [
-
-	self subclassResponsibility 
-]
-
 { #category : #exceptions }
 RBAbstractTransformation >> refactoringConfirmWarning: aString [
 	| ret |
@@ -333,6 +327,7 @@ RBAbstractTransformation >> shouldUseExistingMethod: aSelector [
 { #category : #transforming }
 RBAbstractTransformation >> transform [
 	"Do the actual operations."
+	self deprecated: 'Use primitiveExecute or privateTransform instead. Check subclasses for more details.'. 
 	
 	self subclassResponsibility
 ]

--- a/src/Refactoring-Core/RBAbstractVariablesRefactoring.class.st
+++ b/src/Refactoring-Core/RBAbstractVariablesRefactoring.class.st
@@ -178,6 +178,17 @@ RBAbstractVariablesRefactoring >> preconditions [
 	^ self trueCondition
 ]
 
+{ #category : #transforming }
+RBAbstractVariablesRefactoring >> privateTransform [
+	self hasVariablesToAbstract
+		ifTrue:
+			[self
+				refactoringWarning: 'This method has direct variable references which<n>will need to be converted to getter/setters.<n>Proceed anyway?'
+						expandMacros].
+	self abstractInstanceVariables.
+	self abstractClassVariables
+]
+
 { #category : #'for driver' }
 RBAbstractVariablesRefactoring >> processAssignmentNode: aNode [
 	| varName |
@@ -216,15 +227,4 @@ RBAbstractVariablesRefactoring >> removeDefinedClassVariables [
 		ifNone: [ nil ]) notNil ].
 	classVarReaders := classVarReaders select: selectionBlock.
 	classVarWriters := classVarWriters select: selectionBlock
-]
-
-{ #category : #transforming }
-RBAbstractVariablesRefactoring >> transform [
-	self hasVariablesToAbstract
-		ifTrue:
-			[self
-				refactoringWarning: 'This method has direct variable references which<n>will need to be converted to getter/setters.<n>Proceed anyway?'
-						expandMacros].
-	self abstractInstanceVariables.
-	self abstractClassVariables
 ]

--- a/src/Refactoring-Core/RBAddClassVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBAddClassVariableRefactoring.class.st
@@ -32,6 +32,6 @@ RBAddClassVariableRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
-RBAddClassVariableRefactoring >> transform [
+RBAddClassVariableRefactoring >> privateTransform [
 	class addClassVariable: variableName
 ]

--- a/src/Refactoring-Core/RBAddInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBAddInstanceVariableRefactoring.class.st
@@ -29,6 +29,6 @@ RBAddInstanceVariableRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
-RBAddInstanceVariableRefactoring >> transform [
+RBAddInstanceVariableRefactoring >> privateTransform [
 	class addInstanceVariable: variableName
 ]

--- a/src/Refactoring-Core/RBAddMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBAddMethodRefactoring.class.st
@@ -70,6 +70,12 @@ RBAddMethodRefactoring >> preconditions [
 	^ (RBCondition canUnderstand: transformation selector in: class) not
 ]
 
+{ #category : #transforming }
+RBAddMethodRefactoring >> privateTransform [
+
+	transformation privateTransform
+]
+
 { #category : #printing }
 RBAddMethodRefactoring >> storeOn: aStream [
 	aStream nextPut: $(.
@@ -82,10 +88,4 @@ RBAddMethodRefactoring >> storeOn: aStream [
 	aStream nextPutAll: ' inProtocols: '.
 	protocols storeOn: aStream.
 	aStream nextPut: $)
-]
-
-{ #category : #transforming }
-RBAddMethodRefactoring >> transform [
-
-	transformation transform
 ]

--- a/src/Refactoring-Core/RBAddMethodTransformRefactoring.class.st
+++ b/src/Refactoring-Core/RBAddMethodTransformRefactoring.class.st
@@ -73,6 +73,11 @@ RBAddMethodTransformRefactoring >> preconditions [
 	^ self trueCondition
 ]
 
+{ #category : #transforming }
+RBAddMethodTransformRefactoring >> privateTransform [
+	class compile: source classified: protocols
+]
+
 { #category : #accessing }
 RBAddMethodTransformRefactoring >> selector [
 
@@ -91,9 +96,4 @@ RBAddMethodTransformRefactoring >> storeOn: aStream [
 	aStream nextPutAll: ' inProtocols: '.
 	protocols storeOn: aStream.
 	aStream nextPut: $)
-]
-
-{ #category : #transforming }
-RBAddMethodTransformRefactoring >> transform [
-	class compile: source classified: protocols
 ]

--- a/src/Refactoring-Core/RBChangeMethodNameRefactoring.class.st
+++ b/src/Refactoring-Core/RBChangeMethodNameRefactoring.class.st
@@ -154,6 +154,13 @@ RBChangeMethodNameRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
+RBChangeMethodNameRefactoring >> privateTransform [
+	self renameImplementors.
+	self renameMessageSends.
+	self removeRenamedImplementors
+]
+
+{ #category : #transforming }
 RBChangeMethodNameRefactoring >> removeRenamedImplementors [
 	oldSelector = newSelector
 		ifTrue: [ ^ self ].
@@ -224,11 +231,4 @@ RBChangeMethodNameRefactoring >> renameMethod: aSelector in: aClass to: newSel p
 	self renameMethod: aSelector asSymbol in: aClass.
 	newSelector := newSel asSymbol.
 	permutation := aMap
-]
-
-{ #category : #transforming }
-RBChangeMethodNameRefactoring >> transform [
-	self renameImplementors.
-	self renameMessageSends.
-	self removeRenamedImplementors
 ]

--- a/src/Refactoring-Core/RBChildrenToSiblingsRefactoring.class.st
+++ b/src/Refactoring-Core/RBChildrenToSiblingsRefactoring.class.st
@@ -123,6 +123,16 @@ RBChildrenToSiblingsRefactoring >> preconditions [
 					& (RBCondition isImmediateSubclass: each of: parent)]
 ]
 
+{ #category : #transforming }
+RBChildrenToSiblingsRefactoring >> privateTransform [
+	self
+		addSuperclass;
+		pushUpVariables;
+		pullUpMethods;
+		changeIsKindOfReferences;
+		reparentSubclasses
+]
+
 { #category : #'private - variables' }
 RBChildrenToSiblingsRefactoring >> pullUpClassInstanceVariables [
 	| newSuperclass |
@@ -257,14 +267,4 @@ RBChildrenToSiblingsRefactoring >> subclassResponsibilityFor: aSelector in: aCla
 		ifFalse: [ methodNode arguments last stop ].
 	^ '<1s><n><t>self subclassResponsibility'
 		expandMacrosWith: (source copyFrom: 1 to: position)
-]
-
-{ #category : #transforming }
-RBChildrenToSiblingsRefactoring >> transform [
-	self
-		addSuperclass;
-		pushUpVariables;
-		pullUpMethods;
-		changeIsKindOfReferences;
-		reparentSubclasses
 ]

--- a/src/Refactoring-Core/RBClassRegexRefactoring.class.st
+++ b/src/Refactoring-Core/RBClassRegexRefactoring.class.st
@@ -84,6 +84,19 @@ RBClassRegexRefactoring >> initialize [
 ]
 
 { #category : #transforming }
+RBClassRegexRefactoring >> privateTransform [
+	| replacement refactoring |
+	self model allClassesDo: [ :class |
+		(class isNil or: [ class isMeta ]) ifFalse: [
+			replacement := self execute: class name.
+			replacement = class name asString ifFalse: [
+				refactoring := self perform: mode
+					with: class with: replacement asSymbol.
+				(refactoring notNil and: [ refactoring preconditions check ])
+					ifTrue: [ refactoring privateTransform ] ] ] ]
+]
+
+{ #category : #transforming }
 RBClassRegexRefactoring >> rename: aClass name: aSymbol [
 	^ RBRenameClassRefactoring
 		model: self model
@@ -104,17 +117,4 @@ RBClassRegexRefactoring >> rootClass [
 { #category : #initialization }
 RBClassRegexRefactoring >> rootClass: aClass [
 	rootClass := aClass instanceSide
-]
-
-{ #category : #transforming }
-RBClassRegexRefactoring >> transform [
-	| replacement refactoring |
-	self model allClassesDo: [ :class |
-		(class isNil or: [ class isMeta ]) ifFalse: [
-			replacement := self execute: class name.
-			replacement = class name asString ifFalse: [
-				refactoring := self perform: mode
-					with: class with: replacement asSymbol.
-				(refactoring notNil and: [ refactoring preconditions check ])
-					ifTrue: [ refactoring transform ] ] ] ]
 ]

--- a/src/Refactoring-Core/RBCopyClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBCopyClassRefactoring.class.st
@@ -121,7 +121,7 @@ RBCopyClassRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
-RBCopyClassRefactoring >> transform [
+RBCopyClassRefactoring >> privateTransform [
 	self copyClass.
 	self copyVariables.
 	self copyMethods

--- a/src/Refactoring-Core/RBCopyPackageRefactoring.class.st
+++ b/src/Refactoring-Core/RBCopyPackageRefactoring.class.st
@@ -113,6 +113,16 @@ RBCopyPackageRefactoring >> preconditions [
 			   errorString: 'The system already includes a package named ' , newName)
 ]
 
+{ #category : #transforming }
+RBCopyPackageRefactoring >> privateTransform [
+	| copyClasses |
+
+	self model addPackageNamed: newName.
+	copyClasses := self copyAllClasses.
+	self changeReferencesOf: self classes with: copyClasses.
+	self reparent: self classes with: copyClasses
+]
+
 { #category : #renaming }
 RBCopyPackageRefactoring >> renameReferencesOf: aClass1 with: aClass2 [
 	| replacer |
@@ -165,14 +175,4 @@ RBCopyPackageRefactoring >> storeOn: aStream [
 		nextPutAll: ' in: #';
 		nextPutAll: newName;
 		nextPut: $)
-]
-
-{ #category : #transforming }
-RBCopyPackageRefactoring >> transform [
-	| copyClasses |
-
-	self model addPackageNamed: newName.
-	copyClasses := self copyAllClasses.
-	self changeReferencesOf: self classes with: copyClasses.
-	self reparent: self classes with: copyClasses
 ]

--- a/src/Refactoring-Core/RBCreateAccessorsForVariableTransformation.class.st
+++ b/src/Refactoring-Core/RBCreateAccessorsForVariableTransformation.class.st
@@ -253,6 +253,13 @@ RBCreateAccessorsForVariableTransformation >> preconditions [
 ]
 
 { #category : #transforming }
+RBCreateAccessorsForVariableTransformation >> privateTransform [
+	self
+		createGetterAccessor;
+		createSetterAccessor
+]
+
+{ #category : #transforming }
 RBCreateAccessorsForVariableTransformation >> selector [
 	^ selector ifNil: [
 		selector := self safeMethodNameFor: self definingClass
@@ -283,13 +290,6 @@ RBCreateAccessorsForVariableTransformation >> storeOn: aStream [
 	aStream nextPutAll: ' classVariable: '.
 	classVariable storeOn: aStream.
 	aStream nextPut: $)
-]
-
-{ #category : #transforming }
-RBCreateAccessorsForVariableTransformation >> transform [
-	self
-		createGetterAccessor;
-		createSetterAccessor
 ]
 
 { #category : #testing }

--- a/src/Refactoring-Core/RBCreateCascadeRefactoring.class.st
+++ b/src/Refactoring-Core/RBCreateCascadeRefactoring.class.st
@@ -130,13 +130,13 @@ RBCreateCascadeRefactoring >> preconditions [
 		true ])
 ]
 
+{ #category : #transforming }
+RBCreateCascadeRefactoring >> privateTransform [
+	self combineMessages.
+	self compileCode
+]
+
 { #category : #accessing }
 RBCreateCascadeRefactoring >> selectedSource [
 	^  self parseTree source copyFrom: selectedInterval first to: selectedInterval last
-]
-
-{ #category : #transforming }
-RBCreateCascadeRefactoring >> transform [
-	self combineMessages.
-	self compileCode
 ]

--- a/src/Refactoring-Core/RBDeprecateClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBDeprecateClassRefactoring.class.st
@@ -131,6 +131,22 @@ RBDeprecateClassRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
+RBDeprecateClassRefactoring >> privateTransform [
+
+	self shouldFixSubclasses
+		ifTrue: [ self renameSuperclassOfSubclasses.
+			self convertDeprecatedToSubclass ].
+
+	self renameReferences.
+
+	self shouldCopyExtensions
+		ifTrue: [ self copyExtensionMethods ].
+
+	self shouldRemoveExtensions
+		ifTrue: [ self removeExtensionMethods ]
+]
+
+{ #category : #transforming }
 RBDeprecateClassRefactoring >> removeExtensionMethods [
 
 	(self instanceSideExtensionMethodsOf: deprecatedClass)
@@ -207,20 +223,4 @@ RBDeprecateClassRefactoring >> storeOn: aStream [
 		nextPutAll: ' to: #';
 		nextPutAll: newName;
 		nextPut: $)
-]
-
-{ #category : #transforming }
-RBDeprecateClassRefactoring >> transform [
-
-	self shouldFixSubclasses
-		ifTrue: [ self renameSuperclassOfSubclasses.
-			self convertDeprecatedToSubclass ].
-
-	self renameReferences.
-
-	self shouldCopyExtensions
-		ifTrue: [ self copyExtensionMethods ].
-
-	self shouldRemoveExtensions
-		ifTrue: [ self removeExtensionMethods ]
 ]

--- a/src/Refactoring-Core/RBDeprecateMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBDeprecateMethodRefactoring.class.st
@@ -131,7 +131,7 @@ RBDeprecateMethodRefactoring >> generateChanges [
 		RBBreakingChangeChecksFailedWarning signal:
 			self breakingChangeConditions errorString ].
 
-	self transform.
+	self privateTransform.
 	^ self changes
 ]
 
@@ -158,6 +158,22 @@ RBDeprecateMethodRefactoring >> preconditions [
 	^ self applicabilityConditions & self breakingChangeConditions
 ]
 
+{ #category : #transforming }
+RBDeprecateMethodRefactoring >> privateTransform [
+
+	| node parseTree method |
+	method := class methodFor: oldSelector.
+	parseTree := method parseTree.
+	node := self parserClass parseExpression: self callDeprecationMethod.
+	parseTree body addNodeFirst: node.
+
+	self generateChangesFor:
+		(RBAddMethodTransformRefactoring
+			 addMethod: parseTree newSource
+			 toClass: class
+			 inProtocols: method protocols)
+]
+
 { #category : #printing }
 RBDeprecateMethodRefactoring >> storeOn: aStream [
 	aStream nextPut: $(.
@@ -171,20 +187,4 @@ RBDeprecateMethodRefactoring >> storeOn: aStream [
 		nextPutAll: ' using: #';
 		nextPutAll: newSelector.
 	aStream nextPut: $)
-]
-
-{ #category : #transforming }
-RBDeprecateMethodRefactoring >> transform [
-
-	| node parseTree method |
-	method := class methodFor: oldSelector.
-	parseTree := method parseTree.
-	node := self parserClass parseExpression: self callDeprecationMethod.
-	parseTree body addNodeFirst: node.
-
-	self generateChangesFor:
-		(RBAddMethodTransformRefactoring
-			 addMethod: parseTree newSource
-			 toClass: class
-			 inProtocols: method protocols)
 ]

--- a/src/Refactoring-Core/RBExpandReferencedPoolsRefactoring.class.st
+++ b/src/Refactoring-Core/RBExpandReferencedPoolsRefactoring.class.st
@@ -93,7 +93,7 @@ RBExpandReferencedPoolsRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
-RBExpandReferencedPoolsRefactoring >> transform [
+RBExpandReferencedPoolsRefactoring >> privateTransform [
 	self computePoolsToMove.
 	self hasPoolsToMove
 		ifTrue:

--- a/src/Refactoring-Core/RBExtractMethodAndOccurrences.class.st
+++ b/src/Refactoring-Core/RBExtractMethodAndOccurrences.class.st
@@ -96,6 +96,13 @@ RBExtractMethodAndOccurrences >> preconditions [
 	^ self trueCondition
 ]
 
+{ #category : #transforming }
+RBExtractMethodAndOccurrences >> privateTransform [
+	| newExtractedSelector |
+	newExtractedSelector := self extractMethod.
+	self findOccurrencesOf: newExtractedSelector
+]
+
 { #category : #asserting }
 RBExtractMethodAndOccurrences >> shouldSearchInHierarchy [
 	^(self options at: #searchInWholeHierarchy) value: self value: class
@@ -113,11 +120,4 @@ RBExtractMethodAndOccurrences >> storeOn: aStream [
 		nextPutAll: ' in: '.
 	class storeOn: aStream.
 	aStream nextPut: $)
-]
-
-{ #category : #transforming }
-RBExtractMethodAndOccurrences >> transform [
-	| newExtractedSelector |
-	newExtractedSelector := self extractMethod.
-	self findOccurrencesOf: newExtractedSelector
 ]

--- a/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
@@ -361,6 +361,18 @@ RBExtractMethodRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
+RBExtractMethodRefactoring >> privateTransform [
+
+	| existingSelector |
+	existingSelector := self existingSelector.
+	self nameNewMethod: (existingSelector
+			 ifNil: [ newExtractedSelector ifNil: [ self getNewMethodName ] ]
+			 ifNotNil: [ existingSelector ]).
+	existingSelector ifNil: [ self compileExtractedMethod ].
+	class compileTree: modifiedParseTree
+]
+
+{ #category : #transforming }
 RBExtractMethodRefactoring >> remainingTemporaries [
 	| temps |
 	temps := modifiedParseTree allDefinedVariables asSet.
@@ -439,18 +451,6 @@ RBExtractMethodRefactoring >> storeOn: aStream [
 { #category : #accessing }
 RBExtractMethodRefactoring >> targetClass [
 	^ class
-]
-
-{ #category : #transforming }
-RBExtractMethodRefactoring >> transform [
-
-	| existingSelector |
-	existingSelector := self existingSelector.
-	self nameNewMethod: (existingSelector
-			 ifNil: [ newExtractedSelector ifNil: [ self getNewMethodName ] ]
-			 ifNotNil: [ existingSelector ]).
-	existingSelector ifNil: [ self compileExtractedMethod ].
-	class compileTree: modifiedParseTree
 ]
 
 { #category : #transforming }

--- a/src/Refactoring-Core/RBExtractMethodToComponentRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodToComponentRefactoring.class.st
@@ -93,6 +93,14 @@ RBExtractMethodToComponentRefactoring >> preconditions [
 	^ self trueCondition
 ]
 
+{ #category : #transforming }
+RBExtractMethodToComponentRefactoring >> privateTransform [
+	self
+		extractMethod;
+		moveMethod;
+		inlineForwarder
+]
+
 { #category : #printing }
 RBExtractMethodToComponentRefactoring >> storeOn: aStream [
 	aStream nextPut: $(.
@@ -105,12 +113,4 @@ RBExtractMethodToComponentRefactoring >> storeOn: aStream [
 		nextPutAll: ' in: '.
 	class storeOn: aStream.
 	aStream nextPut: $)
-]
-
-{ #category : #transforming }
-RBExtractMethodToComponentRefactoring >> transform [
-	self
-		extractMethod;
-		moveMethod;
-		inlineForwarder
 ]

--- a/src/Refactoring-Core/RBExtractSetUpMethodAndOccurrences.class.st
+++ b/src/Refactoring-Core/RBExtractSetUpMethodAndOccurrences.class.st
@@ -70,7 +70,7 @@ RBExtractSetUpMethodAndOccurrences >> findOccurrencesClass [
 ]
 
 { #category : #transforming }
-RBExtractSetUpMethodAndOccurrences >> transform [
+RBExtractSetUpMethodAndOccurrences >> privateTransform [
 	self extractMethod.
 	self findOccurrencesOf: #setUp
 ]

--- a/src/Refactoring-Core/RBExtractSetUpMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractSetUpMethodRefactoring.class.st
@@ -109,20 +109,7 @@ RBExtractSetUpMethodRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
-RBExtractSetUpMethodRefactoring >> shouldExtractAssignmentTo: name [
-	^ true
-]
-
-{ #category : #transforming }
-RBExtractSetUpMethodRefactoring >> startLimit: aNumber [
-	| node |
-	node := class parseTreeForSelector: selector.
-	^ node statements ifEmpty: [ node body start ]
-		ifNotEmpty: [ node statements first start ]
-]
-
-{ #category : #transforming }
-RBExtractSetUpMethodRefactoring >> transform [
+RBExtractSetUpMethodRefactoring >> privateTransform [
 
 	| existingSelector |
 	existingSelector := self existingSelector.
@@ -137,6 +124,19 @@ RBExtractSetUpMethodRefactoring >> transform [
 				inProtocols: #running)].
 	modifiedParseTree body removeNode: (modifiedParseTree body statements at: 1).
 	class compileTree: modifiedParseTree
+]
+
+{ #category : #transforming }
+RBExtractSetUpMethodRefactoring >> shouldExtractAssignmentTo: name [
+	^ true
+]
+
+{ #category : #transforming }
+RBExtractSetUpMethodRefactoring >> startLimit: aNumber [
+	| node |
+	node := class parseTreeForSelector: selector.
+	^ node statements ifEmpty: [ node body start ]
+		ifNotEmpty: [ node statements first start ]
 ]
 
 { #category : #transforming }

--- a/src/Refactoring-Core/RBExtractToTemporaryRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractToTemporaryRefactoring.class.st
@@ -111,6 +111,13 @@ RBExtractToTemporaryRefactoring >> preconditions [
 						true])
 ]
 
+{ #category : #transforming }
+RBExtractToTemporaryRefactoring >> privateTransform [
+	self
+		insertTemporary;
+		compileNewMethod
+]
+
 { #category : #'private - accessing' }
 RBExtractToTemporaryRefactoring >> selectedSource [
 
@@ -138,13 +145,6 @@ RBExtractToTemporaryRefactoring >> storeOn: aStream [
 		nextPutAll: ' in: '.
 	class storeOn: aStream.
 	aStream nextPut: $)
-]
-
-{ #category : #transforming }
-RBExtractToTemporaryRefactoring >> transform [
-	self
-		insertTemporary;
-		compileNewMethod
 ]
 
 { #category : #preconditions }

--- a/src/Refactoring-Core/RBFindAndReplaceTransformation.class.st
+++ b/src/Refactoring-Core/RBFindAndReplaceTransformation.class.st
@@ -233,6 +233,16 @@ RBFindAndReplaceTransformation >> preconditions [
 	^ condition
 ]
 
+{ #category : #transforming }
+RBFindAndReplaceTransformation >> privateTransform [
+	|classes|
+	classes :=replacesAllHierarchy ifFalse: [ { class } ] ifTrue: [ class withAllSubclasses ].
+	classes do: [ :cls | (self selectorsFor: cls) do: [ :sel | |rbMethod|
+		rbMethod := cls methodFor: sel.
+		self findOccurrencesIn: rbMethod] ].
+	self inform: occurrences asString, ' occurrences were found and changed.'
+]
+
 { #category : #accessing }
 RBFindAndReplaceTransformation >> replaceArgumentsByPattern: sourceCode [
 	|newSource|
@@ -262,14 +272,4 @@ RBFindAndReplaceTransformation >> storeOn: aStream [
 		nextPutAll: ' inAllHierarchy: '.
 	replacesAllHierarchy storeOn: aStream.
 	aStream nextPut: $)
-]
-
-{ #category : #transforming }
-RBFindAndReplaceTransformation >> transform [
-	|classes|
-	classes :=replacesAllHierarchy ifFalse: [ { class } ] ifTrue: [ class withAllSubclasses ].
-	classes do: [ :cls | (self selectorsFor: cls) do: [ :sel | |rbMethod|
-		rbMethod := cls methodFor: sel.
-		self findOccurrencesIn: rbMethod] ].
-	self inform: occurrences asString, ' occurrences were found and changed.'
 ]

--- a/src/Refactoring-Core/RBGenerateEqualHashTransformation.class.st
+++ b/src/Refactoring-Core/RBGenerateEqualHashTransformation.class.st
@@ -166,15 +166,15 @@ RBGenerateEqualHashTransformation >> preconditions [
 			  (RBCondition definesInstanceVariable: variable in: self theClass) ]
 ]
 
+{ #category : #transforming }
+RBGenerateEqualHashTransformation >> privateTransform [
+	self compileHash.
+	self compileEqual
+]
+
 { #category : #accessing }
 RBGenerateEqualHashTransformation >> theClass [
 	^ (self classObjectFor: className) instanceSide
-]
-
-{ #category : #transforming }
-RBGenerateEqualHashTransformation >> transform [
-	self compileHash.
-	self compileEqual
 ]
 
 { #category : #accessing }

--- a/src/Refactoring-Core/RBGeneratePrintOnTransformation.class.st
+++ b/src/Refactoring-Core/RBGeneratePrintOnTransformation.class.st
@@ -69,13 +69,8 @@ RBGeneratePrintOnTransformation >> preconditions [
 			  (RBCondition definesInstanceVariable: variable in: self theClass) ]
 ]
 
-{ #category : #accessing }
-RBGeneratePrintOnTransformation >> theClass [
-	^ (self classObjectFor: className) instanceSide
-]
-
 { #category : #transforming }
-RBGeneratePrintOnTransformation >> transform [
+RBGeneratePrintOnTransformation >> privateTransform [
 	| method |
 	method := self parserClass
 		parseMethod:
@@ -95,6 +90,11 @@ RBGeneratePrintOnTransformation >> transform [
 			addMethod: method formattedCode
 			toClass: self theClass
 			inProtocols: #printing)
+]
+
+{ #category : #accessing }
+RBGeneratePrintOnTransformation >> theClass [
+	^ (self classObjectFor: className) instanceSide
 ]
 
 { #category : #accessing }

--- a/src/Refactoring-Core/RBInlineAllSendersRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineAllSendersRefactoring.class.st
@@ -128,6 +128,14 @@ RBInlineAllSendersRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
+RBInlineAllSendersRefactoring >> privateTransform [
+	self
+		inlineSelfSends;
+		removeMethod;
+		checkInlinedMethods
+]
+
+{ #category : #transforming }
 RBInlineAllSendersRefactoring >> removeMethod [
 	self onError:
 			[self generateChangesFor: (RBRemoveMethodRefactoring
@@ -169,12 +177,4 @@ RBInlineAllSendersRefactoring >> storeOn: aStream [
 		nextPutAll: ' in: '.
 	class storeOn: aStream.
 	aStream nextPut: $)
-]
-
-{ #category : #transforming }
-RBInlineAllSendersRefactoring >> transform [
-	self
-		inlineSelfSends;
-		removeMethod;
-		checkInlinedMethods
 ]

--- a/src/Refactoring-Core/RBInlineMethodFromComponentRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineMethodFromComponentRefactoring.class.st
@@ -129,6 +129,13 @@ RBInlineMethodFromComponentRefactoring >> newNameForSelf [
 ]
 
 { #category : #transforming }
+RBInlineMethodFromComponentRefactoring >> privateTransform [
+	self abstractVariableReferences.
+	self renameSelfReferences.
+	super privateTransform
+]
+
+{ #category : #transforming }
 RBInlineMethodFromComponentRefactoring >> renameSelfReferences [
 	self addSelfReferenceToSourceMessage.
 	self addSelfReferenceToInlineParseTree
@@ -153,11 +160,4 @@ RBInlineMethodFromComponentRefactoring >> safeVariableNameBasedOn: aString [
 				[i := i + 1.
 				newString := baseString , i printString].
 	^newString
-]
-
-{ #category : #transforming }
-RBInlineMethodFromComponentRefactoring >> transform [
-	self abstractVariableReferences.
-	self renameSelfReferences.
-	super transform
 ]

--- a/src/Refactoring-Core/RBInlineMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineMethodRefactoring.class.st
@@ -299,6 +299,14 @@ RBInlineMethodRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
+RBInlineMethodRefactoring >> privateTransform [
+	self
+		renameConflictingTemporaries;
+		insertInlinedMethod;
+		compileMethod
+]
+
+{ #category : #transforming }
 RBInlineMethodRefactoring >> removeEmptyIfTrues [
 	| rewriter |
 	rewriter := self parseTreeRewriter.
@@ -435,14 +443,6 @@ RBInlineMethodRefactoring >> storeOn: aStream [
 		nextPutAll: ' forClass: '.
 	class storeOn: aStream.
 	aStream nextPut: $)
-]
-
-{ #category : #transforming }
-RBInlineMethodRefactoring >> transform [
-	self
-		renameConflictingTemporaries;
-		insertInlinedMethod;
-		compileMethod
 ]
 
 { #category : #transforming }

--- a/src/Refactoring-Core/RBInlineTemporaryRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineTemporaryRefactoring.class.st
@@ -66,6 +66,14 @@ RBInlineTemporaryRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
+RBInlineTemporaryRefactoring >> privateTransform [
+	self
+		replaceAssignment;
+		replaceReferences;
+		compileMethod
+]
+
+{ #category : #transforming }
 RBInlineTemporaryRefactoring >> replaceAssignment [
 	assignmentNode parent isSequence
 		ifTrue: [assignmentNode parent removeNode: assignmentNode]
@@ -94,14 +102,6 @@ RBInlineTemporaryRefactoring >> storeOn: aStream [
 		nextPutAll: ' in: '.
 	class storeOn: aStream.
 	aStream nextPut: $)
-]
-
-{ #category : #transforming }
-RBInlineTemporaryRefactoring >> transform [
-	self
-		replaceAssignment;
-		replaceReferences;
-		compileMethod
 ]
 
 { #category : #preconditions }

--- a/src/Refactoring-Core/RBInsertNewClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBInsertNewClassRefactoring.class.st
@@ -86,6 +86,19 @@ RBInsertNewClassRefactoring >> preconditions [
 					errorMacro: 'Invalid category name')
 ]
 
+{ #category : #transforming }
+RBInsertNewClassRefactoring >> privateTransform [
+
+	| classDefinitionString |
+	classDefinitionString := '<1p> %<%< #<2s> package: <3p>'
+		                         expandMacrosWith: superclass
+		                         with: className
+		                         with: category asString.
+	self model
+		defineClass: classDefinitionString withComment: comment;
+		reparentClasses: subclasses to: (self model classNamed: className asSymbol)
+]
+
 { #category : #printing }
 RBInsertNewClassRefactoring >> storeOn: aStream [
 	aStream nextPut: $(.
@@ -100,17 +113,4 @@ RBInsertNewClassRefactoring >> storeOn: aStream [
 	aStream nextPutAll: ' category: '.
 	category storeOn: aStream.
 	aStream nextPut: $)
-]
-
-{ #category : #transforming }
-RBInsertNewClassRefactoring >> transform [
-
-	| classDefinitionString |
-	classDefinitionString := '<1p> %<%< #<2s> package: <3p>'
-		                         expandMacrosWith: superclass
-		                         with: className
-		                         with: category asString.
-	self model
-		defineClass: classDefinitionString withComment: comment;
-		reparentClasses: subclasses to: (self model classNamed: className asSymbol)
 ]

--- a/src/Refactoring-Core/RBMakeClassAbstractTransformation.class.st
+++ b/src/Refactoring-Core/RBMakeClassAbstractTransformation.class.st
@@ -43,15 +43,8 @@ RBMakeClassAbstractTransformation >> preconditions [
 	^ self skippingPreconditions
 ]
 
-{ #category : #preconditions }
-RBMakeClassAbstractTransformation >> skippingPreconditions [
-	"We cannot validate that the class is actually not used and not receiving a message new."
-	
-	^ (RBCondition isAbstractClass: targetClass) not
-]
-
 { #category : #transforming }
-RBMakeClassAbstractTransformation >> transform [
+RBMakeClassAbstractTransformation >> privateTransform [
 
 	(RBAddMethodTransformRefactoring
 		 addMethod: 'isAbstract
@@ -59,4 +52,11 @@ RBMakeClassAbstractTransformation >> transform [
 	^ self == ' , targetClass asString
 		 toClass: targetClass classSide
 		 inProtocols: #( #testing )) execute
+]
+
+{ #category : #preconditions }
+RBMakeClassAbstractTransformation >> skippingPreconditions [
+	"We cannot validate that the class is actually not used and not receiving a message new."
+	
+	^ (RBCondition isAbstractClass: targetClass) not
 ]

--- a/src/Refactoring-Core/RBMergeInstanceVariableIntoAnother.class.st
+++ b/src/Refactoring-Core/RBMergeInstanceVariableIntoAnother.class.st
@@ -50,16 +50,7 @@ RBMergeInstanceVariableIntoAnother >> preconditions [
 ]
 
 { #category : #transforming }
-RBMergeInstanceVariableIntoAnother >> renameVariable [
-	model
-		renameInstanceVariable: variableName
-		to: newName
-		in: class
-		around: [ self renameReferences ]
-]
-
-{ #category : #transforming }
-RBMergeInstanceVariableIntoAnother >> transform [
+RBMergeInstanceVariableIntoAnother >> privateTransform [
 	renameAccessors ifTrue: [
 		self removeOldAccessors
 	].
@@ -69,4 +60,13 @@ RBMergeInstanceVariableIntoAnother >> transform [
 	renameAccessors ifFalse: [ ^ self ].
 	self addNewAccessors.
 	self renameAccessorsReferences
+]
+
+{ #category : #transforming }
+RBMergeInstanceVariableIntoAnother >> renameVariable [
+	model
+		renameInstanceVariable: variableName
+		to: newName
+		in: class
+		around: [ self renameReferences ]
 ]

--- a/src/Refactoring-Core/RBMoveMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBMoveMethodRefactoring.class.st
@@ -329,6 +329,17 @@ RBMoveMethodRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
+RBMoveMethodRefactoring >> privateTransform [
+	self
+		abstractVariables;
+		addSelfReturn;
+		replaceSelfReferences;
+		replaceVariableReferences;
+		compileNewMethods;
+		compileDelegatorMethod
+]
+
+{ #category : #transforming }
 RBMoveMethodRefactoring >> removeArgument [
 	"Removes the excess argument if any.
 	This argument is the variable which is
@@ -387,17 +398,6 @@ RBMoveMethodRefactoring >> storeOn: aStream [
 		nextPutAll: ' variable: ''';
 		nextPutAll: variable;
 		nextPutAll: ''')'
-]
-
-{ #category : #transforming }
-RBMoveMethodRefactoring >> transform [
-	self
-		abstractVariables;
-		addSelfReturn;
-		replaceSelfReferences;
-		replaceVariableReferences;
-		compileNewMethods;
-		compileDelegatorMethod
 ]
 
 { #category : #transforming }

--- a/src/Refactoring-Core/RBMoveMethodToClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBMoveMethodToClassRefactoring.class.st
@@ -56,21 +56,8 @@ RBMoveMethodToClassRefactoring >> preconditions [
 	^(RBCondition definesSelector: method selector in: class) not
 ]
 
-{ #category : #printing }
-RBMoveMethodToClassRefactoring >> storeOn: aStream [
-	aStream nextPut: $(.
-	self class storeOn: aStream.
-	aStream
-		nextPutAll: ' selector: #';
-		nextPutAll:  method selector;
-		nextPutAll: ' class: '.
-	class storeOn: aStream.
-	aStream
-		nextPutAll: ''')'
-]
-
 { #category : #transforming }
-RBMoveMethodToClassRefactoring >> transform [
+RBMoveMethodToClassRefactoring >> privateTransform [
 	| oldClass newClass rbMethod originalProtocol |
 	oldClass := self classModelOf: method methodClass.
 	newClass := self classModelOf: class.
@@ -83,4 +70,17 @@ RBMoveMethodToClassRefactoring >> transform [
 			addMethod: rbMethod source
 			toClass: newClass
 			inProtocols: originalProtocol)
+]
+
+{ #category : #printing }
+RBMoveMethodToClassRefactoring >> storeOn: aStream [
+	aStream nextPut: $(.
+	self class storeOn: aStream.
+	aStream
+		nextPutAll: ' selector: #';
+		nextPutAll:  method selector;
+		nextPutAll: ' class: '.
+	class storeOn: aStream.
+	aStream
+		nextPutAll: ''')'
 ]

--- a/src/Refactoring-Core/RBMoveMethodToClassSideRefactoring.class.st
+++ b/src/Refactoring-Core/RBMoveMethodToClassSideRefactoring.class.st
@@ -93,7 +93,7 @@ RBMoveMethodToClassSideRefactoring >> generateChanges [
 		RBBreakingChangeChecksFailedWarning signal:
 			self breakingChangeConditions errorString ].
 
-	self transform.
+	self privateTransform.
 	^ self changes
 ]
 
@@ -155,6 +155,23 @@ RBMoveMethodToClassSideRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
+RBMoveMethodToClassSideRefactoring >> privateTransform [
+	| oldClass newClass rbMethod rbMethod2 newSource originalProtocol newSource2 |
+	newSource := self getNewInstSideSource.
+	originalProtocol := method protocolName.
+	oldClass := class.
+	self removeInstVariableReferences.
+	method := class methodFor: method selector.
+	newClass := self model classNamed: class name, ' class'.
+	newSource2 := self getNewSource.
+	rbMethod := RBClassModelFactory rbMethod for: newClass source: newSource2 selector: method selector.
+	rbMethod2 := RBClassModelFactory rbMethod for: oldClass source: newSource selector: method selector.
+	oldClass removeMethod: method selector.
+	self addMethod: rbMethod to: newClass toProtocol: originalProtocol.
+	self addMethod: rbMethod2 to: oldClass toProtocol: originalProtocol
+]
+
+{ #category : #transforming }
 RBMoveMethodToClassSideRefactoring >> removeInstVariableReferences [
 
 	| rbMethod references |
@@ -196,21 +213,4 @@ RBMoveMethodToClassSideRefactoring >> temporaryName [
 	whileTrue: [ counter := counter + 1.
 		tempName := aString , counter asString ].
 	^ tempName
-]
-
-{ #category : #transforming }
-RBMoveMethodToClassSideRefactoring >> transform [
-	| oldClass newClass rbMethod rbMethod2 newSource originalProtocol newSource2 |
-	newSource := self getNewInstSideSource.
-	originalProtocol := method protocolName.
-	oldClass := class.
-	self removeInstVariableReferences.
-	method := class methodFor: method selector.
-	newClass := self model classNamed: class name, ' class'.
-	newSource2 := self getNewSource.
-	rbMethod := RBClassModelFactory rbMethod for: newClass source: newSource2 selector: method selector.
-	rbMethod2 := RBClassModelFactory rbMethod for: oldClass source: newSource selector: method selector.
-	oldClass removeMethod: method selector.
-	self addMethod: rbMethod to: newClass toProtocol: originalProtocol.
-	self addMethod: rbMethod2 to: oldClass toProtocol: originalProtocol
 ]

--- a/src/Refactoring-Core/RBMoveVariableDefinitionToSmallestValidScopeRefactoring.class.st
+++ b/src/Refactoring-Core/RBMoveVariableDefinitionToSmallestValidScopeRefactoring.class.st
@@ -95,6 +95,13 @@ RBMoveVariableDefinitionToSmallestValidScopeRefactoring >> preconditions [
 					true])
 ]
 
+{ #category : #transforming }
+RBMoveVariableDefinitionToSmallestValidScopeRefactoring >> privateTransform [
+	definingNode removeTemporaryNamed: name.
+	blockNodes do: [:each | each body addTemporaryNamed: name].
+	class compileTree: parseTree
+]
+
 { #category : #printing }
 RBMoveVariableDefinitionToSmallestValidScopeRefactoring >> storeOn: aStream [
 	aStream nextPut: $(.
@@ -122,13 +129,6 @@ RBMoveVariableDefinitionToSmallestValidScopeRefactoring >> subblocksIn: aParseTr
 	^ searcher
 		executeTree: aParseTree
 		initialAnswer: OrderedCollection new
-]
-
-{ #category : #transforming }
-RBMoveVariableDefinitionToSmallestValidScopeRefactoring >> transform [
-	definingNode removeTemporaryNamed: name.
-	blockNodes do: [:each | each body addTemporaryNamed: name].
-	class compileTree: parseTree
 ]
 
 { #category : #transforming }

--- a/src/Refactoring-Core/RBPrettyPrintCodeTransformation.class.st
+++ b/src/Refactoring-Core/RBPrettyPrintCodeTransformation.class.st
@@ -16,7 +16,7 @@ RBPrettyPrintCodeTransformation >> preconditions [
 ]
 
 { #category : #transforming }
-RBPrettyPrintCodeTransformation >> transform [
+RBPrettyPrintCodeTransformation >> privateTransform [
 	| source tree formatted |
 	self model
 		allClassesDo: [ :class |

--- a/src/Refactoring-Core/RBProtectInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBProtectInstanceVariableRefactoring.class.st
@@ -47,7 +47,7 @@ RBProtectInstanceVariableRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
-RBProtectInstanceVariableRefactoring >> transform [
+RBProtectInstanceVariableRefactoring >> privateTransform [
 	self setOption: #inlineExpression toUse: [:ref :string | true].
 	self getterSetterMethods do: [:each | self inline: each]
 ]

--- a/src/Refactoring-Core/RBProtocolRegexTransformation.class.st
+++ b/src/Refactoring-Core/RBProtocolRegexTransformation.class.st
@@ -10,7 +10,7 @@ Class {
 }
 
 { #category : #transforming }
-RBProtocolRegexTransformation >> transform [
+RBProtocolRegexTransformation >> privateTransform [
 
 	| replacement |
 	self model allClassesDo: [ :class |

--- a/src/Refactoring-Core/RBPullUpClassVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBPullUpClassVariableRefactoring.class.st
@@ -12,6 +12,14 @@ RBPullUpClassVariableRefactoring >> preconditions [
 	^(RBCondition isMetaclass: class) not
 ]
 
+{ #category : #transforming }
+RBPullUpClassVariableRefactoring >> privateTransform [
+	| subclass |
+	subclass := self subclassDefiningVariable.
+	subclass removeClassVariable: variableName.
+	class addClassVariable: variableName
+]
+
 { #category : #'private - accessing' }
 RBPullUpClassVariableRefactoring >> subclassDefiningVariable [
 	| subclasses |
@@ -21,12 +29,4 @@ RBPullUpClassVariableRefactoring >> subclassDefiningVariable [
 	subclasses size > 1
 		ifTrue: [ self refactoringError: 'Multiple subclasses define ' , variableName ].
 	^ subclasses asArray first
-]
-
-{ #category : #transforming }
-RBPullUpClassVariableRefactoring >> transform [
-	| subclass |
-	subclass := self subclassDefiningVariable.
-	subclass removeClassVariable: variableName.
-	class addClassVariable: variableName
 ]

--- a/src/Refactoring-Core/RBPullUpInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBPullUpInstanceVariableRefactoring.class.st
@@ -22,7 +22,7 @@ RBPullUpInstanceVariableRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
-RBPullUpInstanceVariableRefactoring >> transform [
+RBPullUpInstanceVariableRefactoring >> privateTransform [
 	class allSubclasses do:
 			[:each |
 			(each directlyDefinesInstanceVariable: variableName)

--- a/src/Refactoring-Core/RBPullUpMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBPullUpMethodRefactoring.class.st
@@ -268,6 +268,15 @@ RBPullUpMethodRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
+RBPullUpMethodRefactoring >> privateTransform [
+	self
+		copyDownMethods;
+		pullUpMethods;
+		removePulledUpMethods;
+		removeDuplicateMethods
+]
+
+{ #category : #transforming }
 RBPullUpMethodRefactoring >> pullUp: aSelector [
 	| source refactoring |
 	source := class sourceCodeFor: aSelector.
@@ -380,13 +389,4 @@ RBPullUpMethodRefactoring >> superClass: anObject [
 { #category : #initialization }
 RBPullUpMethodRefactoring >> targetClass [
 	^ class
-]
-
-{ #category : #transforming }
-RBPullUpMethodRefactoring >> transform [
-	self
-		copyDownMethods;
-		pullUpMethods;
-		removePulledUpMethods;
-		removeDuplicateMethods
 ]

--- a/src/Refactoring-Core/RBPushDownClassVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBPushDownClassVariableRefactoring.class.st
@@ -41,6 +41,14 @@ RBPushDownClassVariableRefactoring >> preconditions [
 					true])
 ]
 
+{ #category : #transforming }
+RBPushDownClassVariableRefactoring >> privateTransform [
+
+	class removeClassVariable: variableName.
+	destinationClass ifNil: [ ^ self ].
+	destinationClass addClassVariable: variableName
+]
+
 { #category : #preconditions }
 RBPushDownClassVariableRefactoring >> signalMultipleReferenceError [
 	self signalReferenceError: ('Multiple subclasses reference <1s>'
@@ -69,12 +77,4 @@ RBPushDownClassVariableRefactoring >> signalStillReferencedError [
 	self signalReferenceError: ('<1p> has references to <2s>'
 				expandMacrosWith: class
 				with: variableName)
-]
-
-{ #category : #transforming }
-RBPushDownClassVariableRefactoring >> transform [
-
-	class removeClassVariable: variableName.
-	destinationClass ifNil: [ ^ self ].
-	destinationClass addClassVariable: variableName
 ]

--- a/src/Refactoring-Core/RBPushDownInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBPushDownInstanceVariableRefactoring.class.st
@@ -25,7 +25,7 @@ RBPushDownInstanceVariableRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
-RBPushDownInstanceVariableRefactoring >> transform [
+RBPushDownInstanceVariableRefactoring >> privateTransform [
 	class removeInstanceVariable: variableName.
 	class subclasses do: [:each | each addInstanceVariable: variableName]
 ]

--- a/src/Refactoring-Core/RBPushDownMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBPushDownMethodRefactoring.class.st
@@ -82,6 +82,12 @@ RBPushDownMethodRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
+RBPushDownMethodRefactoring >> privateTransform [
+	selectors do: [:each | self pushDown: each].
+	selectors do: [:each | class removeMethod: each]
+]
+
+{ #category : #transforming }
 RBPushDownMethodRefactoring >> pushDown: aSelector [
 
 	| code protocols refactoring |
@@ -139,10 +145,4 @@ RBPushDownMethodRefactoring >> storeOn: aStream [
 { #category : #preconditions }
 RBPushDownMethodRefactoring >> targetClass [
 	^ class
-]
-
-{ #category : #transforming }
-RBPushDownMethodRefactoring >> transform [
-	selectors do: [:each | self pushDown: each].
-	selectors do: [:each | class removeMethod: each]
 ]

--- a/src/Refactoring-Core/RBRefactoring.class.st
+++ b/src/Refactoring-Core/RBRefactoring.class.st
@@ -218,6 +218,12 @@ RBRefactoring >> setOption: aSymbol toUse: aBlock [
 	self options: dict
 ]
 
+{ #category : #transforming }
+RBRefactoring >> transform [ 
+
+	self deprecated: 'Use privateTransform instead' transformWith: '`@rec transform' -> '`@rec privateTransform'
+]
+
 { #category : #private }
 RBRefactoring >> uniqueMethodNameFor: anInteger [
 	| before after index name |

--- a/src/Refactoring-Core/RBRefactoring.class.st
+++ b/src/Refactoring-Core/RBRefactoring.class.st
@@ -164,7 +164,7 @@ RBRefactoring >> onError: aBlock do: errorBlock [
 RBRefactoring >> primitiveExecute [
 	
 	self checkPreconditions.
-	self transform
+	self privateTransform
 ]
 
 { #category : #removing }

--- a/src/Refactoring-Core/RBRefactoring.class.st
+++ b/src/Refactoring-Core/RBRefactoring.class.st
@@ -71,19 +71,6 @@ RBRefactoring >> checkClass: aRBClass selector: aSelector using: aMatcher [
 	^aMatcher answer
 ]
 
-{ #category : #preconditions }
-RBRefactoring >> checkPreconditions [
-
-	| conditions block |
-	conditions := self preconditions.
-	conditions check ifTrue: [ ^ self ].
-	block := conditions errorBlock.
-	block
-		ifNotNil: [
-		self refactoringWarning: conditions errorString with: block ]
-		ifNil: [ self refactoringError: conditions errorString ]
-]
-
 { #category : #private }
 RBRefactoring >> classObjectFor: anObject [
 
@@ -160,13 +147,6 @@ RBRefactoring >> onError: aBlock do: errorBlock [
 			[:ex |
 			errorBlock cull: ex.
 			ex return: nil]
-]
-
-{ #category : #private }
-RBRefactoring >> primitiveExecute [
-	
-	self checkPreconditions.
-	self privateTransform
 ]
 
 { #category : #removing }

--- a/src/Refactoring-Core/RBRefactoring.class.st
+++ b/src/Refactoring-Core/RBRefactoring.class.st
@@ -43,6 +43,8 @@ RBRefactoring class >> preconditionSignal [
 
 { #category : #converting }
 RBRefactoring >> asRefactoring [
+
+	self deprecated: 'This method is a no-op and can be removed' transformWith: '`@rec asRefactoring' -> '`@rec'.
 	^ self
 ]
 

--- a/src/Refactoring-Core/RBRemoveAllSendersRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveAllSendersRefactoring.class.st
@@ -68,6 +68,11 @@ RBRemoveAllSendersRefactoring >> preconditions [
 	^ self trueCondition
 ]
 
+{ #category : #transforming }
+RBRemoveAllSendersRefactoring >> privateTransform [
+	self removeSelfSenders
+]
+
 { #category : #removing }
 RBRemoveAllSendersRefactoring >> removeMethod: aMethod of: node [
 	self generateChangesFor: (RBRemoveSenderRefactoring
@@ -117,9 +122,4 @@ RBRemoveAllSendersRefactoring >> storeOn: aStream [
 	aStream nextPutAll: ' removeSendersOf: '.
 	aStream nextPutAll: selector.
 	aStream nextPut: $)
-]
-
-{ #category : #transforming }
-RBRemoveAllSendersRefactoring >> transform [
-	self removeSelfSenders
 ]

--- a/src/Refactoring-Core/RBRemoveClassKeepingSubclassesRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveClassKeepingSubclassesRefactoring.class.st
@@ -53,6 +53,14 @@ RBRemoveClassKeepingSubclassesRefactoring >> preconditions [
 ]
 
 { #category : #preconditions }
+RBRemoveClassKeepingSubclassesRefactoring >> privateTransform [
+	self initalizeRefactorings.
+	refactorings do: [ :ref | ref primitiveExecute ].
+	self reparentSubclasses.
+	self removeClasses
+]
+
+{ #category : #preconditions }
 RBRemoveClassKeepingSubclassesRefactoring >> pushDownClassVarsOf: class [
 	class realClass classVariables do: [ :e |
 		refactorings add: (RBPushDownClassVariableRefactoring
@@ -80,12 +88,4 @@ RBRemoveClassKeepingSubclassesRefactoring >> pushDownMethodsOf: class [
 { #category : #preconditions }
 RBRemoveClassKeepingSubclassesRefactoring >> removeClasses [
 	classNames do: [:each | self model removeClassKeepingSubclassesNamed: each]
-]
-
-{ #category : #preconditions }
-RBRemoveClassKeepingSubclassesRefactoring >> transform [
-	self initalizeRefactorings.
-	refactorings do: [ :ref | ref primitiveExecute ].
-	self reparentSubclasses.
-	self removeClasses
 ]

--- a/src/Refactoring-Core/RBRemoveClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveClassRefactoring.class.st
@@ -105,6 +105,13 @@ RBRemoveClassRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
+RBRemoveClassRefactoring >> privateTransform [
+	self
+		reparentSubclasses;
+		removeClasses
+]
+
+{ #category : #transforming }
 RBRemoveClassRefactoring >> removeClasses [
 	classNames do: [:each | self model removeClassNamed: each]
 ]
@@ -125,11 +132,4 @@ RBRemoveClassRefactoring >> storeOn: aStream [
 	aStream nextPutAll: ' classNames: '.
 	classNames asArray storeOn: aStream.
 	aStream nextPut: $)
-]
-
-{ #category : #transforming }
-RBRemoveClassRefactoring >> transform [
-	self
-		reparentSubclasses;
-		removeClasses
 ]

--- a/src/Refactoring-Core/RBRemoveClassVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveClassVariableRefactoring.class.st
@@ -38,6 +38,6 @@ RBRemoveClassVariableRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
-RBRemoveClassVariableRefactoring >> transform [
+RBRemoveClassVariableRefactoring >> privateTransform [
 	class removeClassVariable: variableName
 ]

--- a/src/Refactoring-Core/RBRemoveHierarchyMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveHierarchyMethodRefactoring.class.st
@@ -61,6 +61,11 @@ RBRemoveHierarchyMethodRefactoring >> preconditions [
 		  cond & (RBCondition definesSelector: selector in: class) ]
 ]
 
+{ #category : #transforming }
+RBRemoveHierarchyMethodRefactoring >> privateTransform [
+	self deleteSelectors
+]
+
 { #category : #removing }
 RBRemoveHierarchyMethodRefactoring >> removeMethods: selectorCollection from: aClass [
 	class := self classObjectFor: aClass.
@@ -76,9 +81,4 @@ RBRemoveHierarchyMethodRefactoring >> storeOn: aStream [
 	aStream nextPutAll: ' from: '.
 	class storeOn: aStream.
 	aStream nextPut: $)
-]
-
-{ #category : #transforming }
-RBRemoveHierarchyMethodRefactoring >> transform [
-	self deleteSelectors
 ]

--- a/src/Refactoring-Core/RBRemoveInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveInstanceVariableRefactoring.class.st
@@ -37,7 +37,7 @@ RBRemoveInstanceVariableRefactoring >> generateChanges [
 		RBBreakingChangeChecksFailedWarning signal:
 			self breakingChangeConditions errorString ].
 
-	self transform.
+	self privateTransform.
 	^ self changes
 ]
 
@@ -47,12 +47,12 @@ RBRemoveInstanceVariableRefactoring >> preconditions [
 	^ self applicabilityConditions & self breakingChangeConditions 
 ]
 
+{ #category : #transforming }
+RBRemoveInstanceVariableRefactoring >> privateTransform [
+	class removeInstanceVariable: variableName
+]
+
 { #category : #accessing }
 RBRemoveInstanceVariableRefactoring >> refactoredClass [
 	^ class
-]
-
-{ #category : #transforming }
-RBRemoveInstanceVariableRefactoring >> transform [
-	class removeInstanceVariable: variableName
 ]

--- a/src/Refactoring-Core/RBRemoveMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveMethodRefactoring.class.st
@@ -147,6 +147,11 @@ RBRemoveMethodRefactoring >> preconditions [
 			   true ])
 ]
 
+{ #category : #transforming }
+RBRemoveMethodRefactoring >> privateTransform [
+	selectors do: [:each | class removeMethod: each]
+]
+
 { #category : #initialization }
 RBRemoveMethodRefactoring >> removeMethods: selectorCollection from: aClass [
 	class := self classObjectFor: aClass.
@@ -175,9 +180,4 @@ RBRemoveMethodRefactoring >> superclassEquivalentlyDefines: aSelector [
 	( superTree isNil or: [ myTree isNil ] )
 		ifTrue: [ ^ false ].
 	^ superTree equalTo: myTree exceptForVariables: #()
-]
-
-{ #category : #transforming }
-RBRemoveMethodRefactoring >> transform [
-	selectors do: [:each | class removeMethod: each]
 ]

--- a/src/Refactoring-Core/RBRemoveSenderRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveSenderRefactoring.class.st
@@ -104,6 +104,17 @@ RBRemoveSenderRefactoring >> preconditions [
 					true])
 ]
 
+{ #category : #transforming }
+RBRemoveSenderRefactoring >> privateTransform [
+	self inlineParseTree.
+	self renameConflictingTemporaries.
+	self renameSelfReferences.
+	self
+		renameConflictingTemporaries;
+		insertInlinedMethod;
+		compileMethod
+]
+
 { #category : #removing }
 RBRemoveSenderRefactoring >> remove: anInterval inMethod: aSelector forClass: aClass [
 	sourceSelector := aSelector.
@@ -123,15 +134,4 @@ RBRemoveSenderRefactoring >> storeOn: aStream [
 		nextPutAll: ' forClass: '.
 	class storeOn: aStream.
 	aStream nextPut: $)
-]
-
-{ #category : #transforming }
-RBRemoveSenderRefactoring >> transform [
-	self inlineParseTree.
-	self renameConflictingTemporaries.
-	self renameSelfReferences.
-	self
-		renameConflictingTemporaries;
-		insertInlinedMethod;
-		compileMethod
 ]

--- a/src/Refactoring-Core/RBRemoveSharedVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveSharedVariableRefactoring.class.st
@@ -42,7 +42,7 @@ RBRemoveSharedVariableRefactoring >> generateChanges [
 		RBBreakingChangeChecksFailedWarning signal:
 			self breakingChangeConditions errorString ].
 
-	self transform.
+	self privateTransform.
 	^ self changes
 ]
 
@@ -52,13 +52,13 @@ RBRemoveSharedVariableRefactoring >> preconditions [
 	^ self applicabilityConditions & self breakingChangeConditions 
 ]
 
+{ #category : #transforming }
+RBRemoveSharedVariableRefactoring >> privateTransform [
+	class removeClassVariable: variableName
+]
+
 { #category : #accessing }
 RBRemoveSharedVariableRefactoring >> refactoredClass [
 
 	^ class
-]
-
-{ #category : #transforming }
-RBRemoveSharedVariableRefactoring >> transform [
-	class removeClassVariable: variableName
 ]

--- a/src/Refactoring-Core/RBRenameArgumentOrTemporaryRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenameArgumentOrTemporaryRefactoring.class.st
@@ -62,6 +62,21 @@ RBRenameArgumentOrTemporaryRefactoring >> preconditions [
 ]
 
 { #category : #tranforming }
+RBRenameArgumentOrTemporaryRefactoring >> privateTransform [
+	| definingNode variableNode |
+	parseTree := class parseTreeForSelector: selector.
+	variableNode := self whichVariableNode: parseTree inInterval: interval name: oldName.
+	(variableNode isNil or: [ variableNode isVariable not ])
+		ifTrue: [ self refactoringError: oldName asString , ' isn''t a valid variable' ].
+	variableNode name = oldName
+		ifFalse: [ self refactoringError: 'Invalid selection' ].
+	definingNode := variableNode whoDefines: oldName.
+	definingNode ifNil: [ self refactoringError: oldName asString , ' isn''t defined by the method' ].
+	self renameNode: definingNode.
+	class compileTree: parseTree
+]
+
+{ #category : #tranforming }
 RBRenameArgumentOrTemporaryRefactoring >> renameNode: aParseTree [
 	(aParseTree whoDefines: newName)
 		ifNotNil: [ self refactoringError: newName asString , ' is already defined' ].
@@ -85,19 +100,4 @@ RBRenameArgumentOrTemporaryRefactoring >> storeOn: aStream [
 		nextPutAll: ' selector: #';
 		nextPutAll: selector.
 	aStream nextPut: $)
-]
-
-{ #category : #tranforming }
-RBRenameArgumentOrTemporaryRefactoring >> transform [
-	| definingNode variableNode |
-	parseTree := class parseTreeForSelector: selector.
-	variableNode := self whichVariableNode: parseTree inInterval: interval name: oldName.
-	(variableNode isNil or: [ variableNode isVariable not ])
-		ifTrue: [ self refactoringError: oldName asString , ' isn''t a valid variable' ].
-	variableNode name = oldName
-		ifFalse: [ self refactoringError: 'Invalid selection' ].
-	definingNode := variableNode whoDefines: oldName.
-	definingNode ifNil: [ self refactoringError: oldName asString , ' isn''t defined by the method' ].
-	self renameNode: definingNode.
-	class compileTree: parseTree
 ]

--- a/src/Refactoring-Core/RBRenameClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenameClassRefactoring.class.st
@@ -51,6 +51,14 @@ RBRenameClassRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
+RBRenameClassRefactoring >> privateTransform [
+	self model
+		renameClass: class
+		to: newName
+		around: [self renameReferences]
+]
+
+{ #category : #transforming }
 RBRenameClassRefactoring >> renameReferences [
 
 	| replacer |
@@ -76,12 +84,4 @@ RBRenameClassRefactoring >> storeOn: aStream [
 		nextPutAll: ' to: #';
 		nextPutAll: newName;
 		nextPut: $)
-]
-
-{ #category : #transforming }
-RBRenameClassRefactoring >> transform [
-	self model
-		renameClass: class
-		to: newName
-		around: [self renameReferences]
 ]

--- a/src/Refactoring-Core/RBRenameClassVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenameClassVariableRefactoring.class.st
@@ -51,6 +51,14 @@ RBRenameClassVariableRefactoring >> preconditions [
 			& (RBCondition isGlobal: newName asString in: self model) not
 ]
 
+{ #category : #transforming }
+RBRenameClassVariableRefactoring >> privateTransform [
+	class
+		renameClassVariable: variableName
+		to: newName
+		around: [self renameReferences]
+]
+
 { #category : #initialization }
 RBRenameClassVariableRefactoring >> rename: aVarName to: aName in: aClass [
 	self variable: aVarName class: aClass.
@@ -82,12 +90,4 @@ RBRenameClassVariableRefactoring >> storeOn: aStream [
 		nextPutAll: ''' in: '.
 	class storeOn: aStream.
 	aStream nextPut: $)
-]
-
-{ #category : #transforming }
-RBRenameClassVariableRefactoring >> transform [
-	class
-		renameClassVariable: variableName
-		to: newName
-		around: [self renameReferences]
 ]

--- a/src/Refactoring-Core/RBRenameInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenameInstanceVariableRefactoring.class.st
@@ -97,6 +97,19 @@ RBRenameInstanceVariableRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
+RBRenameInstanceVariableRefactoring >> privateTransform [
+	renameAccessors ifTrue: [
+		self removeOldAccessors
+	].
+
+	class renameInstanceVariable: variableName to: newName around: [ self renameReferences ].
+
+	renameAccessors ifFalse: [ ^ self ].
+	self addNewAccessors.
+	self renameAccessorsReferences
+]
+
+{ #category : #transforming }
 RBRenameInstanceVariableRefactoring >> removeOldAccessors [
 	| oldAccessors |
 	oldAccessors := (class allSelectors
@@ -176,17 +189,4 @@ RBRenameInstanceVariableRefactoring >> storeOn: aStream [
 		nextPutAll: ''' in: '.
 	class storeOn: aStream.
 	aStream nextPut: $)
-]
-
-{ #category : #transforming }
-RBRenameInstanceVariableRefactoring >> transform [
-	renameAccessors ifTrue: [
-		self removeOldAccessors
-	].
-
-	class renameInstanceVariable: variableName to: newName around: [ self renameReferences ].
-
-	renameAccessors ifFalse: [ ^ self ].
-	self addNewAccessors.
-	self renameAccessorsReferences
 ]

--- a/src/Refactoring-Core/RBRenameMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenameMethodRefactoring.class.st
@@ -84,7 +84,7 @@ RBRenameMethodRefactoring >> generateChanges [
 		RBBreakingChangeChecksFailedWarning signal:
 			self breakingChangeConditions errorString ].
 
-	self transform.
+	self privateTransform.
 	^ self changes
 ]
 

--- a/src/Refactoring-Core/RBRenamePackageRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenamePackageRefactoring.class.st
@@ -61,6 +61,13 @@ RBRenamePackageRefactoring >> preconditions [
 ]
 
 { #category : #transforming }
+RBRenamePackageRefactoring >> privateTransform [
+
+	self renamePackage.
+	self renameManifestClass
+]
+
+{ #category : #transforming }
 RBRenamePackageRefactoring >> renameManifestClass [
 	|refactoring manifest|
 	manifest := package realPackage packageManifestOrNil.
@@ -87,11 +94,4 @@ RBRenamePackageRefactoring >> storeOn: aStream [
 		nextPutAll: ' to: #';
 		nextPutAll: newName;
 		nextPut: $)
-]
-
-{ #category : #transforming }
-RBRenamePackageRefactoring >> transform [
-
-	self renamePackage.
-	self renameManifestClass
 ]

--- a/src/Refactoring-Core/RBReplaceMessageSendTransformation.class.st
+++ b/src/Refactoring-Core/RBReplaceMessageSendTransformation.class.st
@@ -138,6 +138,13 @@ RBReplaceMessageSendTransformation >> preconditions [
 	^ conditions
 ]
 
+{ #category : #transforming }
+RBReplaceMessageSendTransformation >> privateTransform [
+	self replaceInAllClasses
+		ifTrue: [ self renameMessageSends ]
+		ifFalse: [ self renameMessageSendsIn: {class} ]
+]
+
 { #category : #initialization }
 RBReplaceMessageSendTransformation >> replaceCallMethod: aSelector in: aClass to: newSel permutation: aMap [
 
@@ -157,11 +164,4 @@ RBReplaceMessageSendTransformation >> replaceCallMethod: aSelector in: aClass to
 { #category : #accessing }
 RBReplaceMessageSendTransformation >> replaceInAllClasses [
 	^ replaceInAllClasses ifNil: [ replaceInAllClasses := false ]
-]
-
-{ #category : #transforming }
-RBReplaceMessageSendTransformation >> transform [
-	self replaceInAllClasses
-		ifTrue: [ self renameMessageSends ]
-		ifFalse: [ self renameMessageSendsIn: {class} ]
 ]

--- a/src/Refactoring-Core/RBSourceRegexTransformation.class.st
+++ b/src/Refactoring-Core/RBSourceRegexTransformation.class.st
@@ -24,7 +24,7 @@ RBSourceRegexTransformation >> parseSelector: aSelector [
 ]
 
 { #category : #transforming }
-RBSourceRegexTransformation >> transform [
+RBSourceRegexTransformation >> privateTransform [
 
 	| original replacement protocols |
 

--- a/src/Refactoring-Core/RBSplitCascadeRefactoring.class.st
+++ b/src/Refactoring-Core/RBSplitCascadeRefactoring.class.st
@@ -112,6 +112,12 @@ RBSplitCascadeRefactoring >> preconditions [
 		true ])
 ]
 
+{ #category : #transforming }
+RBSplitCascadeRefactoring >> privateTransform [
+	self extractReceiver.
+	self splitCascade
+]
+
 { #category : #initialization }
 RBSplitCascadeRefactoring >> split: anInterval from: aSelector in: aClass [
 	class := self classObjectFor: aClass.
@@ -144,10 +150,4 @@ RBSplitCascadeRefactoring >> storeOn: aStream [
 		nextPutAll: ' forClass: '.
 	class storeOn: aStream.
 	aStream nextPut: $)
-]
-
-{ #category : #transforming }
-RBSplitCascadeRefactoring >> transform [
-	self extractReceiver.
-	self splitCascade
 ]

--- a/src/Refactoring-Core/RBSplitClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBSplitClassRefactoring.class.st
@@ -148,6 +148,14 @@ RBSplitClassRefactoring >> preconditions [
 					not
 ]
 
+{ #category : #transforming }
+RBSplitClassRefactoring >> privateTransform [
+	self
+		createNewClass;
+		createReference;
+		abstractVariableReferences
+]
+
 { #category : #printing }
 RBSplitClassRefactoring >> storeOn: aStream [
 	aStream nextPut: $(.
@@ -162,12 +170,4 @@ RBSplitClassRefactoring >> storeOn: aStream [
 		nextPutAll: ' referenceVariableName: ''';
 		nextPutAll: referenceVariableName;
 		nextPutAll: ''')'
-]
-
-{ #category : #transforming }
-RBSplitClassRefactoring >> transform [
-	self
-		createNewClass;
-		createReference;
-		abstractVariableReferences
 ]

--- a/src/Refactoring-Core/RBSwapMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBSwapMethodRefactoring.class.st
@@ -43,17 +43,8 @@ RBSwapMethodRefactoring >> preconditions [
 		& (RBCondition withBlock: [ self checkInstVars. true ])
 ]
 
-{ #category : #initialization }
-RBSwapMethodRefactoring >> swapMethod: aSelector in: aClass [
-	class := self classObjectFor: aClass.
-	target := self classObjectFor: (class isMeta
-			ifTrue: [ class instanceSide ]
-			ifFalse: [ class classSide ]).
-	selector := aSelector
-]
-
 { #category : #transforming }
-RBSwapMethodRefactoring >> transform [
+RBSwapMethodRefactoring >> privateTransform [
 
 	self generateChangesFor:
 		(RBAddMethodTransformRefactoring
@@ -61,4 +52,13 @@ RBSwapMethodRefactoring >> transform [
 			toClass: target
 			inProtocols: (class protocolsFor: selector)).
 	class removeMethod: selector
+]
+
+{ #category : #initialization }
+RBSwapMethodRefactoring >> swapMethod: aSelector in: aClass [
+	class := self classObjectFor: aClass.
+	target := self classObjectFor: (class isMeta
+			ifTrue: [ class instanceSide ]
+			ifFalse: [ class classSide ]).
+	selector := aSelector
 ]

--- a/src/Refactoring-Core/RBTemporaryToInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBTemporaryToInstanceVariableRefactoring.class.st
@@ -133,6 +133,17 @@ RBTemporaryToInstanceVariableRefactoring >> preconditions [
 						true])
 ]
 
+{ #category : #transforming }
+RBTemporaryToInstanceVariableRefactoring >> privateTransform [
+
+	self removeTemporaryOfClass: class.
+	class allSubclasses do: [ :cls |
+		(cls definesInstanceVariable: temporaryVariableName)
+			ifTrue: [ cls removeInstanceVariable: temporaryVariableName ]
+			ifFalse: [ self removeTemporaryOfClass: cls ] ].
+	class addInstanceVariable: temporaryVariableName
+]
+
 { #category : #removing }
 RBTemporaryToInstanceVariableRefactoring >> removeTemporaryOfClass: aClass [
 	aClass selectors do: [ :aSymbol | self removeTemporaryOfMethod: aSymbol in: aClass ]
@@ -163,15 +174,4 @@ RBTemporaryToInstanceVariableRefactoring >> storeOn: aStream [
 		nextPutAll: temporaryVariableName;
 		nextPut: $'.
 	aStream nextPut: $)
-]
-
-{ #category : #transforming }
-RBTemporaryToInstanceVariableRefactoring >> transform [
-
-	self removeTemporaryOfClass: class.
-	class allSubclasses do: [ :cls |
-		(cls definesInstanceVariable: temporaryVariableName)
-			ifTrue: [ cls removeInstanceVariable: temporaryVariableName ]
-			ifFalse: [ self removeTemporaryOfClass: cls ] ].
-	class addInstanceVariable: temporaryVariableName
 ]

--- a/src/Refactoring2-Transformations-Tests/RBAbstractRefactoringTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAbstractRefactoringTest.class.st
@@ -13,14 +13,18 @@ RBAbstractRefactoringTest >> constructor [
 
 { #category : #helpers }
 RBAbstractRefactoringTest >> createRefactoringWithArguments: aParameterCollection [
-	^ (rbClass perform: self constructor
-			withArguments: aParameterCollection) asRefactoring
+
+	^ rbClass
+		  perform: self constructor
+		  withArguments: aParameterCollection
 ]
 
 { #category : #helpers }
 RBAbstractRefactoringTest >> createRefactoringWithModel: aRBNamespace andArguments: aParameterCollection [
-	^ (rbClass perform: #model: , self constructor
-			withArguments: {aRBNamespace} , aParameterCollection) asRefactoring
+
+	^ rbClass
+		  perform: #model: , self constructor
+		  withArguments: { aRBNamespace } , aParameterCollection
 ]
 
 { #category : #parsing }

--- a/src/Refactoring2-Transformations-Tests/RBAbstractTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAbstractTransformationTest.class.st
@@ -55,7 +55,9 @@ RBAbstractTransformationTest >> setUp [
 RBAbstractTransformationTest >> shouldFail: aRefactoring [
 
 	self proceedThroughWarning: [
-		self should: [ aRefactoring transform ] raise: RBRefactoringError ]
+		self
+			should: [ aRefactoring primitiveExecute ]
+			raise: RBRefactoringError ]
 ]
 
 { #category : #tests }

--- a/src/Refactoring2-Transformations-Tests/RBAddAccessorsForClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddAccessorsForClassTransformationTest.class.st
@@ -8,28 +8,37 @@ Class {
 RBAddAccessorsForClassTransformationTest >> testRefactoring [
 
 	| refactoring class |
-	refactoring := (RBAddAccessorsForClassTransformation className: #RBVariableTransformation) asRefactoring transform.
+	refactoring := (RBAddAccessorsForClassTransformation className:
+		                #RBVariableTransformation) asRefactoring
+		               primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 4.
 
 	class := refactoring model classNamed: #RBVariableTransformation.
-	self assert: (class parseTreeForSelector: #variableName)
-		  equals: (self parseMethod: 'variableName ^variableName').
-	self assert: (class parseTreeForSelector: #variableName:)
-		  equals: (self parseMethod: 'variableName: anObject variableName := anObject')
+	self
+		assert: (class parseTreeForSelector: #variableName)
+		equals: (self parseMethod: 'variableName ^variableName').
+	self
+		assert: (class parseTreeForSelector: #variableName:)
+		equals:
+		(self parseMethod: 'variableName: anObject variableName := anObject')
 ]
 
 { #category : #tests }
 RBAddAccessorsForClassTransformationTest >> testTransform [
 
 	| transformation class |
-	transformation := (RBAddAccessorsForClassTransformation className: self changeMockClass name) transform.
+	transformation := (RBAddAccessorsForClassTransformation className:
+		                   self changeMockClass name) primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 2.
 
-	class := transformation model classNamed: self changeMockClass name asSymbol.
-	self assert: (class parseTreeForSelector: #instVar)
-		  equals: (self parseMethod: 'instVar ^instVar').
-	self assert: (class parseTreeForSelector: #instVar:)
-		  equals: (self parseMethod: 'instVar: anObject instVar := anObject')
+	class := transformation model classNamed:
+		         self changeMockClass name asSymbol.
+	self
+		assert: (class parseTreeForSelector: #instVar)
+		equals: (self parseMethod: 'instVar ^instVar').
+	self
+		assert: (class parseTreeForSelector: #instVar:)
+		equals: (self parseMethod: 'instVar: anObject instVar := anObject')
 ]

--- a/src/Refactoring2-Transformations-Tests/RBAddAccessorsForClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddAccessorsForClassTransformationTest.class.st
@@ -9,8 +9,7 @@ RBAddAccessorsForClassTransformationTest >> testRefactoring [
 
 	| refactoring class |
 	refactoring := (RBAddAccessorsForClassTransformation className:
-		                #RBVariableTransformation) asRefactoring
-		               primitiveExecute.
+		                #RBVariableTransformation) primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 4.
 

--- a/src/Refactoring2-Transformations-Tests/RBAddAssignmentTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddAssignmentTransformationTest.class.st
@@ -46,18 +46,26 @@ RBAddAssignmentTransformationTest >> testRefactoring [
 
 	| refactoring class |
 	refactoring := (RBAddAssignmentTransformation
-						variable: 'variable'
-						value: '1 asString'
-						inMethod: #methodBefore
-						inClass: #RBAddAssignmentTransformationTest)
-						asRefactoring transform.
+		                variable: 'variable'
+		                value: '1 asString'
+		                inMethod: #methodBefore
+		                inClass: #RBAddAssignmentTransformationTest)
+		               asRefactoring primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 1.
 
-	class := refactoring model classNamed: #RBAddAssignmentTransformationTest.
+	class := refactoring model classNamed:
+		         #RBAddAssignmentTransformationTest.
 	self assert: (class directlyDefinesMethod: #methodBefore).
-	self assert: (class parseTreeForSelector: #methodBefore) body statements size equals: 2.
-	self assert: (class parseTreeForSelector: #methodBefore) body statements last value sourceCode equals: '1 asString'
+	self
+		assert:
+		(class parseTreeForSelector: #methodBefore) body statements size
+		equals: 2.
+	self
+		assert:
+			(class parseTreeForSelector: #methodBefore) body statements last
+				value sourceCode
+		equals: '1 asString'
 ]
 
 { #category : #tests }
@@ -65,17 +73,17 @@ RBAddAssignmentTransformationTest >> testTransform [
 
 	| transformation class |
 	transformation := (RBAddAssignmentTransformation new
-		variable: 'variable'
-		value: '1 asString'
-		inMethod: #methodBefore
-		inClass: self class name)
-		transform.
+		                   variable: 'variable'
+		                   value: '1 asString'
+		                   inMethod: #methodBefore
+		                   inClass: self class name) primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 
 	class := transformation model classNamed: self class name.
-	self assert: (class parseTreeForSelector: #methodBefore) body
-			equals: (class parseTreeForSelector: #methodAfter) body
+	self
+		assert: (class parseTreeForSelector: #methodBefore) body
+		equals: (class parseTreeForSelector: #methodAfter) body
 ]
 
 { #category : #tests }

--- a/src/Refactoring2-Transformations-Tests/RBAddAssignmentTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddAssignmentTransformationTest.class.st
@@ -23,22 +23,20 @@ RBAddAssignmentTransformationTest >> methodBefore [
 RBAddAssignmentTransformationTest >> testClassDoesNotExist [
 
 	self shouldFail: (RBAddAssignmentTransformation
-							variable: 'variable'
-							value: '1 asString'
-							inMethod: #methodBefore
-							inClass: #RBAssignmentTransformationTest)
-							asRefactoring
+			 variable: 'variable'
+			 value: '1 asString'
+			 inMethod: #methodBefore
+			 inClass: #RBAssignmentTransformationTest)
 ]
 
 { #category : #tests }
 RBAddAssignmentTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBAddAssignmentTransformation
-							variable: 'variable'
-							value: '1 asString'
-							inMethod: #method
-							inClass: #RBAddAssignmentTransformationTest)
-							asRefactoring
+			 variable: 'variable'
+			 value: '1 asString'
+			 inMethod: #method
+			 inClass: #RBAddAssignmentTransformationTest)
 ]
 
 { #category : #tests }
@@ -50,7 +48,7 @@ RBAddAssignmentTransformationTest >> testRefactoring [
 		                value: '1 asString'
 		                inMethod: #methodBefore
 		                inClass: #RBAddAssignmentTransformationTest)
-		               asRefactoring primitiveExecute.
+		               primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 1.
 
@@ -90,9 +88,8 @@ RBAddAssignmentTransformationTest >> testTransform [
 RBAddAssignmentTransformationTest >> testVariableDoesNotExist [
 
 	self shouldFail: (RBAddAssignmentTransformation
-							variable: 'variable1'
-							value: '1 asString'
-							inMethod: #methodBefore
-							inClass: #RBAddAssignmentTransformationTest)
-							asRefactoring
+			 variable: 'variable1'
+			 value: '1 asString'
+			 inMethod: #methodBefore
+			 inClass: #RBAddAssignmentTransformationTest)
 ]

--- a/src/Refactoring2-Transformations-Tests/RBAddMessageSendTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddMessageSendTransformationTest.class.st
@@ -23,30 +23,27 @@ RBAddMessageSendTransformationTest >> methodBefore [
 RBAddMessageSendTransformationTest >> testClassDoesNotExist [
 
 	self shouldFail: (RBAddMessageSendTransformation
-							messageSend: 'variable byteAt: 1'
-							inMethod: #methodBefore
-							inClass: #RBMessageSendTransformationTest)
-							asRefactoring
+			 messageSend: 'variable byteAt: 1'
+			 inMethod: #methodBefore
+			 inClass: #RBMessageSendTransformationTest)
 ]
 
 { #category : #tests }
 RBAddMessageSendTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBAddMessageSendTransformation
-							messageSend: 'variable byteAt: 1'
-							inMethod: #method
-							inClass: #RBAddMessageSendTransformationTest)
-							asRefactoring
+			 messageSend: 'variable byteAt: 1'
+			 inMethod: #method
+			 inClass: #RBAddMessageSendTransformationTest)
 ]
 
 { #category : #tests }
 RBAddMessageSendTransformationTest >> testReceiverDoesNotExist [
 
 	self shouldFail: (RBAddMessageSendTransformation
-							messageSend: 'variable2 byteAt: 1'
-							inMethod: #methodBefore
-							inClass: #RBAddMessageSendTransformationTest)
-							asRefactoring
+			 messageSend: 'variable2 byteAt: 1'
+			 inMethod: #methodBefore
+			 inClass: #RBAddMessageSendTransformationTest)
 ]
 
 { #category : #tests }
@@ -57,7 +54,7 @@ RBAddMessageSendTransformationTest >> testRefactoring [
 		                messageSend: 'variable byteAt: 1'
 		                inMethod: #methodBefore
 		                inClass: #RBAddMessageSendTransformationTest)
-		               asRefactoring primitiveExecute.
+		               primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 1.
 

--- a/src/Refactoring2-Transformations-Tests/RBAddMessageSendTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddMessageSendTransformationTest.class.st
@@ -54,16 +54,18 @@ RBAddMessageSendTransformationTest >> testRefactoring [
 
 	| refactoring class |
 	refactoring := (RBAddMessageSendTransformation
-						messageSend: 'variable byteAt: 1'
-						inMethod: #methodBefore
-						inClass: #RBAddMessageSendTransformationTest)
-						asRefactoring transform.
+		                messageSend: 'variable byteAt: 1'
+		                inMethod: #methodBefore
+		                inClass: #RBAddMessageSendTransformationTest)
+		               asRefactoring primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 1.
 
-	class := refactoring model classNamed: #RBAddMessageSendTransformationTest.
-	self assert: (class parseTreeForSelector: #methodBefore) body
-			equals: (class parseTreeForSelector: #methodAfter) body
+	class := refactoring model classNamed:
+		         #RBAddMessageSendTransformationTest.
+	self
+		assert: (class parseTreeForSelector: #methodBefore) body
+		equals: (class parseTreeForSelector: #methodAfter) body
 ]
 
 { #category : #tests }
@@ -71,14 +73,14 @@ RBAddMessageSendTransformationTest >> testTransform [
 
 	| transformation class |
 	transformation := (RBAddMessageSendTransformation new
-		messageSend: 'variable byteAt: 1'
-		inMethod: #methodBefore
-		inClass: self class name)
-		transform.
+		                   messageSend: 'variable byteAt: 1'
+		                   inMethod: #methodBefore
+		                   inClass: self class name) primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 
 	class := transformation model classNamed: self class name.
-	self assert: (class parseTreeForSelector: #methodBefore) body
-			equals: (class parseTreeForSelector: #methodAfter) body
+	self
+		assert: (class parseTreeForSelector: #methodBefore) body
+		equals: (class parseTreeForSelector: #methodAfter) body
 ]

--- a/src/Refactoring2-Transformations-Tests/RBAddPragmaTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddPragmaTransformationTest.class.st
@@ -23,30 +23,27 @@ RBAddPragmaTransformationTest >> methodBefore [
 RBAddPragmaTransformationTest >> testClassDoesNotExist [
 
 	self shouldFail: (RBAddPragmaTransformation
-							pragma: '<pragmaForTesting: 56>'
-							inMethod: #methodBefore
-							inClass: #RBPragmaTransformationTest)
-							asRefactoring
+			 pragma: '<pragmaForTesting: 56>'
+			 inMethod: #methodBefore
+			 inClass: #RBPragmaTransformationTest)
 ]
 
 { #category : #tests }
 RBAddPragmaTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBAddPragmaTransformation
-							pragma: '<pragmaForTesting: 56>'
-							inMethod: #method
-							inClass: #RBAddPragmaTransformationTest)
-							asRefactoring
+			 pragma: '<pragmaForTesting: 56>'
+			 inMethod: #method
+			 inClass: #RBAddPragmaTransformationTest)
 ]
 
 { #category : #tests }
 RBAddPragmaTransformationTest >> testPragmaAlreadyExists [
 
 	self shouldFail: (RBAddPragmaTransformation
-							pragma: '<pragmaForTesting: 56>'
-							inMethod: #methodAfter
-							inClass: #RBAddPragmaTransformationTest)
-							asRefactoring
+			 pragma: '<pragmaForTesting: 56>'
+			 inMethod: #methodAfter
+			 inClass: #RBAddPragmaTransformationTest)
 ]
 
 { #category : #tests }
@@ -57,7 +54,7 @@ RBAddPragmaTransformationTest >> testRefactoring [
 		                pragma: '<pragmaForTesting: 56>'
 		                inMethod: #methodBefore
 		                inClass: #RBAddPragmaTransformationTest)
-		               asRefactoring primitiveExecute.
+		               primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 1.
 

--- a/src/Refactoring2-Transformations-Tests/RBAddPragmaTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddPragmaTransformationTest.class.st
@@ -54,16 +54,17 @@ RBAddPragmaTransformationTest >> testRefactoring [
 
 	| refactoring class |
 	refactoring := (RBAddPragmaTransformation
-						pragma: '<pragmaForTesting: 56>'
-						inMethod: #methodBefore
-						inClass: #RBAddPragmaTransformationTest)
-						asRefactoring transform.
+		                pragma: '<pragmaForTesting: 56>'
+		                inMethod: #methodBefore
+		                inClass: #RBAddPragmaTransformationTest)
+		               asRefactoring primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 1.
 
 	class := refactoring model classNamed: #RBAddPragmaTransformationTest.
-	self assert: (class parseTreeForSelector: #methodBefore) body
-			equals: (class parseTreeForSelector: #methodAfter) body
+	self
+		assert: (class parseTreeForSelector: #methodBefore) body
+		equals: (class parseTreeForSelector: #methodAfter) body
 ]
 
 { #category : #tests }
@@ -71,14 +72,14 @@ RBAddPragmaTransformationTest >> testTransform [
 
 	| transformation class |
 	transformation := (RBAddPragmaTransformation new
-		pragma: '<pragmaForTesting: 56>'
-		inMethod: #methodBefore
-		inClass: self class name)
-		transform.
+		                   pragma: '<pragmaForTesting: 56>'
+		                   inMethod: #methodBefore
+		                   inClass: self class name) primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 
 	class := transformation model classNamed: self class name.
-	self assert: (class parseTreeForSelector: #methodBefore) body
-			equals: (class parseTreeForSelector: #methodAfter) body
+	self
+		assert: (class parseTreeForSelector: #methodBefore) body
+		equals: (class parseTreeForSelector: #methodAfter) body
 ]

--- a/src/Refactoring2-Transformations-Tests/RBAddReturnStatementTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddReturnStatementTransformationTest.class.st
@@ -64,16 +64,18 @@ RBAddReturnStatementTransformationTest >> testRefactoring [
 
 	| refactoring class |
 	refactoring := (RBAddReturnStatementTransformation
-						return: '^ variable'
-						inMethod: #methodBefore
-						inClass: #RBAddReturnStatementTransformationTest)
-						asRefactoring transform.
+		                return: '^ variable'
+		                inMethod: #methodBefore
+		                inClass: #RBAddReturnStatementTransformationTest)
+		               asRefactoring primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 1.
 
-	class := refactoring model classNamed: #RBAddReturnStatementTransformationTest.
-	self assert: (class parseTreeForSelector: #methodBefore) body
-			equals: (class parseTreeForSelector: #methodAfter) body
+	class := refactoring model classNamed:
+		         #RBAddReturnStatementTransformationTest.
+	self
+		assert: (class parseTreeForSelector: #methodBefore) body
+		equals: (class parseTreeForSelector: #methodAfter) body
 ]
 
 { #category : #tests }
@@ -81,14 +83,14 @@ RBAddReturnStatementTransformationTest >> testTransform [
 
 	| transformation class |
 	transformation := (RBAddReturnStatementTransformation new
-		return: '^ variable'
-		inMethod: #methodBefore
-		inClass: self class name)
-		transform.
+		                   return: '^ variable'
+		                   inMethod: #methodBefore
+		                   inClass: self class name) primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 
 	class := transformation model classNamed: self class name.
-	self assert: (class parseTreeForSelector: #methodBefore) body
-			equals: (class parseTreeForSelector: #methodAfter) body
+	self
+		assert: (class parseTreeForSelector: #methodBefore) body
+		equals: (class parseTreeForSelector: #methodAfter) body
 ]

--- a/src/Refactoring2-Transformations-Tests/RBAddReturnStatementTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddReturnStatementTransformationTest.class.st
@@ -23,40 +23,36 @@ RBAddReturnStatementTransformationTest >> methodBefore [
 RBAddReturnStatementTransformationTest >> testAccessIsNotDefined [
 
 	self shouldFail: (RBAddReturnStatementTransformation
-							return: '^ variable2'
-							inMethod: #methodBefore
-							inClass: #RBAddReturnStatementTransformationTest)
-							asRefactoring
+			 return: '^ variable2'
+			 inMethod: #methodBefore
+			 inClass: #RBAddReturnStatementTransformationTest)
 ]
 
 { #category : #tests }
 RBAddReturnStatementTransformationTest >> testAlreadyDefinesReturn [
 
 	self shouldFail: (RBAddReturnStatementTransformation
-							return: '^ variable'
-							inMethod: #methodAfter
-							inClass: #RBAddReturnStatementTransformationTest)
-							asRefactoring
+			 return: '^ variable'
+			 inMethod: #methodAfter
+			 inClass: #RBAddReturnStatementTransformationTest)
 ]
 
 { #category : #tests }
 RBAddReturnStatementTransformationTest >> testClassDoesNotExist [
 
 	self shouldFail: (RBAddReturnStatementTransformation
-							return: '^ variable'
-							inMethod: #methodBefore
-							inClass: #RBReturnStatementTransformationTest)
-							asRefactoring
+			 return: '^ variable'
+			 inMethod: #methodBefore
+			 inClass: #RBReturnStatementTransformationTest)
 ]
 
 { #category : #tests }
 RBAddReturnStatementTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBAddReturnStatementTransformation
-							return: '^ variable'
-							inMethod: #method
-							inClass: #RBAddReturnStatementTransformationTest)
-							asRefactoring
+			 return: '^ variable'
+			 inMethod: #method
+			 inClass: #RBAddReturnStatementTransformationTest)
 ]
 
 { #category : #tests }
@@ -67,7 +63,7 @@ RBAddReturnStatementTransformationTest >> testRefactoring [
 		                return: '^ variable'
 		                inMethod: #methodBefore
 		                inClass: #RBAddReturnStatementTransformationTest)
-		               asRefactoring primitiveExecute.
+		               primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 1.
 

--- a/src/Refactoring2-Transformations-Tests/RBAddSubtreeTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddSubtreeTransformationTest.class.st
@@ -29,17 +29,15 @@ RBAddSubtreeTransformationTest >> testRefactoring [
 
 	self
 		shouldFail: (RBAddSubtreeTransformation
-							interval: (0 to: 1)
-							with: ':= 123'
-							from: #selector:from:
-							in: #RBRemoveMethodTransformation)
-							asRefactoring;
+				 interval: (0 to: 1)
+				 with: ':= 123'
+				 from: #selector:from:
+				 in: #RBRemoveMethodTransformation);
 		shouldFail: (RBAddSubtreeTransformation
-							interval: (0 to: 1)
-							with: '^ selector'
-							from: #selector:for:
-							in: #RBRemoveMethodTransformation)
-							asRefactoring
+				 interval: (0 to: 1)
+				 with: '^ selector'
+				 from: #selector:for:
+				 in: #RBRemoveMethodTransformation)
 ]
 
 { #category : #tests }

--- a/src/Refactoring2-Transformations-Tests/RBAddSubtreeTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddSubtreeTransformationTest.class.st
@@ -47,15 +47,17 @@ RBAddSubtreeTransformationTest >> testTransform [
 
 	| transformation class |
 	transformation := (RBAddSubtreeTransformation
-		interval: (0 to: 1)
-		with: 'self printString'
-		from: #one
-		in: self changeMockClass name)
-		transform.
+		                   interval: (0 to: 1)
+		                   with: 'self printString'
+		                   from: #one
+		                   in: self changeMockClass name) primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 
-	class := transformation model classNamed: self changeMockClass name asSymbol.
+	class := transformation model classNamed:
+		         self changeMockClass name asSymbol.
 	self assert: (class directlyDefinesMethod: #one).
-	self assert: (class parseTreeForSelector: #one) body statements size equals: 2
+	self
+		assert: (class parseTreeForSelector: #one) body statements size
+		equals: 2
 ]

--- a/src/Refactoring2-Transformations-Tests/RBAddVariableAccessorsParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddVariableAccessorsParametrizedTest.class.st
@@ -20,24 +20,26 @@ RBAddVariableAccessorsParametrizedTest >> setUp [
 
 { #category : #tests }
 RBAddVariableAccessorsParametrizedTest >> testExistingClassVariableAccessors [
+
 	| refactoring |
 	refactoring := rbClass
-		classVariable: 'Name1'
-		class: #RBLintRuleTestData.
+		               classVariable: 'Name1'
+		               class: #RBLintRuleTestData.
 
-	self executeRefactoring: refactoring asRefactoring.
+	self executeRefactoring: refactoring.
 
 	self assertEmpty: refactoring changes changes
 ]
 
 { #category : #tests }
 RBAddVariableAccessorsParametrizedTest >> testExistingInstanceVariableAccessors [
+
 	| refactoring |
 	refactoring := rbClass
-		instanceVariable: 'name'
-		class: #RBLintRuleTestData.
+		               instanceVariable: 'name'
+		               class: #RBLintRuleTestData.
 
-	self executeRefactoring: refactoring asRefactoring.
+	self executeRefactoring: refactoring.
 
 	self assertEmpty: refactoring changes changes
 ]
@@ -47,7 +49,6 @@ RBAddVariableAccessorsParametrizedTest >> testFailureNonExistantClassVariable [
 
 	self shouldFail:
 		(rbClass classVariable: 'Foo' class: #RBBasicLintRuleTestData)
-			asRefactoring
 ]
 
 { #category : #'failure tests' }
@@ -55,35 +56,44 @@ RBAddVariableAccessorsParametrizedTest >> testFailureNonExistantInstanceVariable
 
 	self shouldFail:
 		(rbClass instanceVariable: 'foo' class: #RBBasicLintRuleTestData)
-			asRefactoring
 ]
 
 { #category : #tests }
 RBAddVariableAccessorsParametrizedTest >> testNewClassVariableAccessors [
+
 	| refactoring class |
 	refactoring := rbClass
-		classVariable: 'Foo1'
-		class: #RBLintRuleTestData.
+		               classVariable: 'Foo1'
+		               class: #RBLintRuleTestData.
 
-	self executeRefactoring: refactoring asRefactoring.
+	self executeRefactoring: refactoring.
 
 	class := refactoring model metaclassNamed: #RBLintRuleTestData.
 	self denyEmpty: refactoring changes changes.
-	self assert: (class parseTreeForSelector: #foo1) equals: (self parseMethod: 'foo1 ^Foo1').
-	self assert: (class parseTreeForSelector: #foo1:) equals: (self parseMethod: 'foo1: anObject Foo1 := anObject')
+	self
+		assert: (class parseTreeForSelector: #foo1)
+		equals: (self parseMethod: 'foo1 ^Foo1').
+	self
+		assert: (class parseTreeForSelector: #foo1:)
+		equals: (self parseMethod: 'foo1: anObject Foo1 := anObject')
 ]
 
 { #category : #tests }
 RBAddVariableAccessorsParametrizedTest >> testNewInstanceVariableAccessors [
+
 	| refactoring class |
 	refactoring := rbClass
-		instanceVariable: 'foo1'
-		class: #RBLintRuleTestData.
+		               instanceVariable: 'foo1'
+		               class: #RBLintRuleTestData.
 
-	self executeRefactoring: refactoring asRefactoring.
+	self executeRefactoring: refactoring.
 
 	class := refactoring model classNamed: #RBLintRuleTestData.
 	self denyEmpty: refactoring changes changes.
-	self assert: (class parseTreeForSelector: #foo1) equals: (self parseMethod: 'foo1 ^foo1').
-	self assert: (class parseTreeForSelector: #foo1:) equals: (self parseMethod: 'foo1: anObject foo1 := anObject')
+	self
+		assert: (class parseTreeForSelector: #foo1)
+		equals: (self parseMethod: 'foo1 ^foo1').
+	self
+		assert: (class parseTreeForSelector: #foo1:)
+		equals: (self parseMethod: 'foo1: anObject foo1 := anObject')
 ]

--- a/src/Refactoring2-Transformations-Tests/RBCopyPackageParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBCopyPackageParametrizedTest.class.st
@@ -15,14 +15,14 @@ RBCopyPackageParametrizedTest class >> testParameters [
 RBCopyPackageParametrizedTest >> addMethodWithRefTo: classRefName inClass: className [
 
 	(RBAddMethodTransformation
-		sourceCode: (String streamContents: [ : stream |
-									stream << 'foo';
-										cr;
-										<< '	^ ';
-										<< classRefName ])
-		in: className asSymbol
-		withProtocols: { #accessing })
-			asRefactoring execute
+		 sourceCode: (String streamContents: [ :stream |
+				  stream
+					  << 'foo';
+					  cr;
+					  << '	^ ';
+					  << classRefName ])
+		 in: className asSymbol
+		 withProtocols: { #accessing }) execute
 ]
 
 { #category : #accessing }
@@ -35,14 +35,14 @@ RBCopyPackageParametrizedTest >> createPackageNamed: packageName withClasses: aC
 
 	self packageOrganizer ensurePackage: packageName.
 
-	aCollection do: [ : className |
+	aCollection do: [ :className |
 		| refactoring |
 		refactoring := RBInsertNewClassTransformation
-						addClass: className
-						superclass: #Object
-						subclasses: #()
-						category: packageName.
-		refactoring asRefactoring execute ]
+			               addClass: className
+			               superclass: #Object
+			               subclasses: #(  )
+			               category: packageName.
+		refactoring execute ]
 ]
 
 { #category : #accessing }

--- a/src/Refactoring2-Transformations-Tests/RBExtractMethodTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBExtractMethodTransformationTest.class.st
@@ -59,23 +59,31 @@ RBExtractMethodTransformationTest >> testFailureBadInterval [
 RBExtractMethodTransformationTest >> testFailureExtract [
 
 	self shouldFail: (RBExtractMethodTransformation
-			extract: (self sourceCodeAt: (80 to: 269)
-						forMethod: #subclassOf:overrides: in: RBBasicLintRuleTestData class)
-			from: #subclassOf:overrides:
-			to: #foo in: #'RBBasicLintRuleTestData class').
+			 extract: (self
+					  sourceCodeAt: (80 to: 269)
+					  forMethod: #subclassOf:overrides:
+					  in: RBBasicLintRuleTestData class)
+			 from: #subclassOf:overrides:
+			 to: #foo
+			 in: #'RBBasicLintRuleTestData class').
 
 	self shouldFail: (RBExtractMethodTransformation
-			extract: (self sourceCodeAt: (53 to: 56)
-						forMethod: #subclassOf:overrides: in: RBBasicLintRuleTestData class)
-			from: #subclassOf:overrides:
-			to: #foo in: #'RBBasicLintRuleTestData class').
+			 extract: (self
+					  sourceCodeAt: (53 to: 56)
+					  forMethod: #subclassOf:overrides:
+					  in: RBBasicLintRuleTestData class)
+			 from: #subclassOf:overrides:
+			 to: #foo
+			 in: #'RBBasicLintRuleTestData class').
 
 	self shouldFail: (RBExtractMethodTransformation
-			extract: (self sourceCodeAt: (77 to: 222)
-						forMethod: #subclassResponsibilityNotDefined in: RBBasicLintRuleTestData class)
-			from: #subclassResponsibilityNotDefined
-			to: #foo in: #'RBBasicLintRuleTestData class')
-			asRefactoring
+			 extract: (self
+					  sourceCodeAt: (77 to: 222)
+					  forMethod: #subclassResponsibilityNotDefined
+					  in: RBBasicLintRuleTestData class)
+			 from: #subclassResponsibilityNotDefined
+			 to: #foo
+			 in: #'RBBasicLintRuleTestData class')
 ]
 
 { #category : #'tests - failures' }

--- a/src/Refactoring2-Transformations-Tests/RBExtractMethodTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBExtractMethodTransformationTest.class.st
@@ -15,17 +15,19 @@ RBExtractMethodTransformationTest >> sourceCodeAt: anInterval forMethod: aSelect
 RBExtractMethodTransformationTest >> testExtractUsingExistingMethodRefactoring [
 
 	| transformation class |
-	transformation := (RBExtractMethodTransformation
-		extract: 'rewriteRule tree printString'
-		from: #checkMethod:
-		to: #bar
-		in: #RBTransformationRuleTestData).
-	transformation transform.
+	transformation := RBExtractMethodTransformation
+		                  extract: 'rewriteRule tree printString'
+		                  from: #checkMethod:
+		                  to: #bar
+		                  in: #RBTransformationRuleTestData.
+	transformation primitiveExecute.
 	self assert: transformation model changes changes size equals: 1.
 
-	class := transformation model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeForSelector: #checkMethod:)
-		  equals: (self parseMethod: 'checkMethod: aSmalllintContext
+	class := transformation model classNamed:
+		         #RBTransformationRuleTestData.
+	self
+		assert: (class parseTreeForSelector: #checkMethod:)
+		equals: (self parseMethod: 'checkMethod: aSmalllintContext
 	class := aSmalllintContext selectedClass.
 	(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue: [
 		(RecursiveSelfRule
@@ -92,22 +94,24 @@ RBExtractMethodTransformationTest >> testNeedsReturn [
 
 	| refactoring class |
 	refactoring := (RBExtractMethodTransformation
-						extract: 'rules isEmpty ifTrue: [^self].
+		                extract: 'rules isEmpty ifTrue: [^self].
 						rules size == 1 ifTrue: [^rules first viewResults]'
-						from: #openEditor
-						to: #foo: in: #RBDummyLintRuleTest)
-						transform.
+		                from: #openEditor
+		                to: #foo:
+		                in: #RBDummyLintRuleTest) primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 2.
 
 	class := refactoring model classNamed: #RBDummyLintRuleTest.
-	self assert: (class parseTreeForSelector: #openEditor)
-		  equals: (self parseMethod: 'openEditor
+	self
+		assert: (class parseTreeForSelector: #openEditor)
+		equals: (self parseMethod: 'openEditor
 				| rules |
 				rules := self failedRules.
 				^self foo: rules').
-	self assert: (class parseTreeForSelector: #foo:)
-		  equals: (self parseMethod: 'foo: rules
+	self
+		assert: (class parseTreeForSelector: #foo:)
+		equals: (self parseMethod: 'foo: rules
 				rules isEmpty ifTrue: [^self].
 				rules size == 1 ifTrue: [^rules first viewResults]')
 ]
@@ -117,25 +121,30 @@ RBExtractMethodTransformationTest >> testRefactoring [
 
 	| transformation class |
 	transformation := (RBExtractMethodTransformation
-		extract: '(RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
+		                   extract:
+			                   '(RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
 			ifFalse: [builder
 						compile: rewriteRule tree printString
 						in: class
 						classified: aSmalllintContext protocols]'
-		from: #checkMethod:
-		to: #foo:
-		in: #RBTransformationRuleTestData) transform.
+		                   from: #checkMethod:
+		                   to: #foo:
+		                   in: #RBTransformationRuleTestData)
+		                  primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 2.
 
-	class := transformation model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeForSelector: #checkMethod:)
-		  equals: (self parseMethod: 'checkMethod: aSmalllintContext
+	class := transformation model classNamed:
+		         #RBTransformationRuleTestData.
+	self
+		assert: (class parseTreeForSelector: #checkMethod:)
+		equals: (self parseMethod: 'checkMethod: aSmalllintContext
 			class := aSmalllintContext selectedClass.
 			(rewriteRule executeTree: aSmalllintContext parseTree)
 				ifTrue: [self foo: aSmalllintContext]').
-	self assert: (class parseTreeForSelector: #foo:)
-		  equals: (self parseMethod: 'foo: aSmalllintContext
+	self
+		assert: (class parseTreeForSelector: #foo:)
+		equals: (self parseMethod: 'foo: aSmalllintContext
 			(RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
 				ifFalse: [ builder
 							compile: rewriteRule tree printString
@@ -148,36 +157,36 @@ RBExtractMethodTransformationTest >> testTransform [
 
 	| transformation class |
 	transformation := (RBAddMethodTransformation
-					sourceCode: 'foo
+		                   sourceCode: 'foo
 									| temp bar |
 									bar := 5.
 									temp := bar * bar.
 									Transcript show: temp printString; cr.
 									^temp * temp'
-					in: self changeMockClass name
-					withProtocols: {#accessing})
-					transform.
+		                   in: self changeMockClass name
+		                   withProtocols: { #accessing }) primitiveExecute.
 
 	transformation := (RBExtractMethodTransformation
-				model: transformation model
-				extract: 'bar := 5.
+		                   model: transformation model
+		                   extract: 'bar := 5.
 							temp := bar * bar.
 							Transcript show: temp printString; cr'
-				from: #foo
-				to: #foobar
-				in: self changeMockClass name)
-				transform.
+		                   from: #foo
+		                   to: #foobar
+		                   in: self changeMockClass name) primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 4.
 
 	class := transformation model classNamed: self changeMockClass name.
-	self assert: (class parseTreeForSelector: #foo)
-		  equals: (self parseMethod: 'foo
+	self
+		assert: (class parseTreeForSelector: #foo)
+		equals: (self parseMethod: 'foo
 													| temp |
 													temp := self foobar.
 													^temp * temp').
-	self assert: (class parseTreeForSelector: #foobar)
-		  equals: (self parseMethod: 'foobar
+	self
+		assert: (class parseTreeForSelector: #foobar)
+		equals: (self parseMethod: 'foobar
 													| temp bar |
 													bar := 5.
 													temp := bar * bar.
@@ -190,22 +199,26 @@ RBExtractMethodTransformationTest >> testWithArgument [
 
 	| refactoring class |
 	refactoring := (RBExtractMethodTransformation
-		extract: (self sourceCodeAt: (143 to: 340)
-					 forMethod: #checkMethod: in: RBTransformationRuleTestData)
-		from: #checkMethod:
-		to: #foo:
-		in: #RBTransformationRuleTestData) transform.
+		                extract: (self
+				                 sourceCodeAt: (143 to: 340)
+				                 forMethod: #checkMethod:
+				                 in: RBTransformationRuleTestData)
+		                from: #checkMethod:
+		                to: #foo:
+		                in: #RBTransformationRuleTestData) primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 2.
 
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeForSelector: #checkMethod:)
-		  equals: (self parseMethod: 'checkMethod: aSmalllintContext
+	self
+		assert: (class parseTreeForSelector: #checkMethod:)
+		equals: (self parseMethod: 'checkMethod: aSmalllintContext
 					class := aSmalllintContext selectedClass.
 					(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue:
 						[self foo: aSmalllintContext]').
-	self assert: (class parseTreeForSelector: #foo:)
-		  equals: (self parseMethod: 'foo: aSmalllintContext
+	self
+		assert: (class parseTreeForSelector: #foo:)
+		equals: (self parseMethod: 'foo: aSmalllintContext
 					(RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
 						ifFalse:
 							[builder compile: rewriteRule tree printString
@@ -219,22 +232,24 @@ RBExtractMethodTransformationTest >> testWithTemporariesSelected [
 	| class refactoring |
 	model := RBNamespace new.
 	class := model classNamed: self class name.
-	class compile: 'foo [| temp | temp := 5. temp * temp] value'
-		classified: #(#accessing).
+	class
+		compile: 'foo [| temp | temp := 5. temp * temp] value'
+		classified: #( #accessing ).
 
 	refactoring := (RBExtractMethodTransformation
-		model: model
-		extract: '| temp | temp := 5. temp * temp'
-		from: #foo
-		to: #foobar
-		in: class)
-		transform.
+		                model: model
+		                extract: '| temp | temp := 5. temp * temp'
+		                from: #foo
+		                to: #foobar
+		                in: class) primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 4.
-	self assert: (class parseTreeForSelector: #foo)
-		  equals: (self parseMethod: 'foo [self foobar] value').
-	self assert: (class parseTreeForSelector: #foobar)
-		  equals: (self parseMethod: 'foobar |temp | temp := 5. ^temp * temp')
+	self
+		assert: (class parseTreeForSelector: #foo)
+		equals: (self parseMethod: 'foo [self foobar] value').
+	self
+		assert: (class parseTreeForSelector: #foobar)
+		equals: (self parseMethod: 'foobar |temp | temp := 5. ^temp * temp')
 ]
 
 { #category : #tests }
@@ -249,20 +264,24 @@ RBExtractMethodTransformationTest >> testWithTemporaryAssigned [
 			temp := bar * bar.
 			Transcript show: temp printString; cr.
 			^temp * temp'.
-	class compile: method classified: #(#accessing).
+	class compile: method classified: #( #accessing ).
 
 	refactoring := (RBExtractMethodTransformation
-			model: model
-			extract: (method copyFrom: 24 to: 98)
-			from: #foo
-			to: #foobar
-			in: class) transform.
+		                model: model
+		                extract: (method copyFrom: 24 to: 98)
+		                from: #foo
+		                to: #foobar
+		                in: class) primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 4.
-	self assert: (class parseTreeForSelector: #foo)
-		  equals: (self parseMethod: 'foo | temp | temp := self foobar. ^temp * temp').
-	self assert: (class parseTreeForSelector: #foobar)
-		  equals: (self parseMethod: 'foobar | temp bar | bar := 5. temp := bar * bar. Transcript show: temp printString; cr. ^temp.')
+	self
+		assert: (class parseTreeForSelector: #foo)
+		equals:
+		(self parseMethod: 'foo | temp | temp := self foobar. ^temp * temp').
+	self
+		assert: (class parseTreeForSelector: #foobar)
+		equals: (self parseMethod:
+				 'foobar | temp bar | bar := 5. temp := bar * bar. Transcript show: temp printString; cr. ^temp.')
 ]
 
 { #category : #tests }
@@ -270,20 +289,26 @@ RBExtractMethodTransformationTest >> testWithTemporaryVariable [
 
 	| refactoring class |
 	refactoring := (RBExtractMethodTransformation
-		extract: (self sourceCodeAt: (22 to: 280) forMethod: #superSends in: RBTransformationRuleTestData)
-		from: #superSends
-		to: #foo1 in: #RBTransformationRuleTestData) transform.
+		                extract: (self
+				                 sourceCodeAt: (22 to: 280)
+				                 forMethod: #superSends
+				                 in: RBTransformationRuleTestData)
+		                from: #superSends
+		                to: #foo1
+		                in: #RBTransformationRuleTestData) primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 2.
 
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeForSelector: #superSends)
-		  equals: (self parseMethod: 'superSends
+	self
+		assert: (class parseTreeForSelector: #superSends)
+		equals: (self parseMethod: 'superSends
 				| rule |
 				rule := self foo1.
 				self rewriteUsing: rule').
-	self assert: (class parseTreeForSelector: #foo1)
-		  equals: (self parseMethod: 'foo1 | rule |
+	self
+		assert: (class parseTreeForSelector: #foo1)
+		equals: (self parseMethod: 'foo1 | rule |
 				rule := RBParseTreeRewriter new.
 				rule addSearch: ''super `@message: ``@args''
 					-> ([:aNode |
@@ -299,22 +324,27 @@ RBExtractMethodTransformationTest >> testWithTemporaryVariable2 [
 
 	| refactoring class |
 	refactoring := (RBExtractMethodTransformation
-		extract: (self sourceCodeAt: (78 to: 197) forMethod: #displayName in: RBDummyLintRuleTest)
-		from: #displayName
-		to: #foo:
-		in: #RBDummyLintRuleTest) transform.
+		                extract: (self
+				                 sourceCodeAt: (78 to: 197)
+				                 forMethod: #displayName
+				                 in: RBDummyLintRuleTest)
+		                from: #displayName
+		                to: #foo:
+		                in: #RBDummyLintRuleTest) primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 2.
 
 	class := refactoring model classNamed: #RBDummyLintRuleTest.
-	self assert: (class parseTreeForSelector: #displayName)
-		  equals: (self parseMethod: 'displayName
+	self
+		assert: (class parseTreeForSelector: #displayName)
+		equals: (self parseMethod: 'displayName
 					| nameStream |
 					nameStream := WriteStream on: (String new: 64).
 					self foo: nameStream.
 					^nameStream contents').
-	self assert: (class parseTreeForSelector: #foo:)
-		  equals: (self parseMethod: 'foo: nameStream
+	self
+		assert: (class parseTreeForSelector: #foo:)
+		equals: (self parseMethod: 'foo: nameStream
 					nameStream nextPutAll: self name;
 								nextPutAll: '' (''.
 					self problemCount printOn: nameStream.

--- a/src/Refactoring2-Transformations-Tests/RBMethodProtocolTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMethodProtocolTransformationTest.class.st
@@ -30,12 +30,21 @@ RBMethodProtocolTransformationTest >> testRefactoring [
 	| refactoring |
 	self deny: (RBDummyEmptyClass hasProtocol: 'empty protocol 2').
 
-	refactoring := (RBMethodProtocolTransformation protocol: 'empty protocol 2' inMethod: #someMethod inClass: #RBDummyEmptyClass) asRefactoring transform.
+	refactoring := (RBMethodProtocolTransformation
+		                protocol: 'empty protocol 2'
+		                inMethod: #someMethod
+		                inClass: #RBDummyEmptyClass) asRefactoring
+		               primitiveExecute.
 	RBRefactoryChangeManager instance performChange: refactoring changes.
 
-	self deny: (RBDummyEmptyClass protocolNamed: 'empty protocol 2') isEmpty.
+	self deny:
+		(RBDummyEmptyClass protocolNamed: 'empty protocol 2') isEmpty.
 
-	refactoring := (RBMethodProtocolTransformation protocol: 'empty protocol 1' inMethod: #someMethod inClass: #RBDummyEmptyClass) asRefactoring transform.
+	refactoring := (RBMethodProtocolTransformation
+		                protocol: 'empty protocol 1'
+		                inMethod: #someMethod
+		                inClass: #RBDummyEmptyClass) asRefactoring
+		               primitiveExecute.
 	RBRefactoryChangeManager instance performChange: refactoring changes.
 
 	self deny: (RBDummyEmptyClass hasProtocol: 'empty protocol 2')
@@ -47,12 +56,21 @@ RBMethodProtocolTransformationTest >> testTransform [
 	| transformation |
 	self deny: (RBDummyEmptyClass hasProtocol: 'empty protocol 2').
 
-	transformation := (RBMethodProtocolTransformation new protocol: 'empty protocol 2' inMethod: #someMethod inClass: #RBDummyEmptyClass) transform.
-	RBRefactoryChangeManager instance performChange: transformation changes.
+	transformation := (RBMethodProtocolTransformation new
+		                   protocol: 'empty protocol 2'
+		                   inMethod: #someMethod
+		                   inClass: #RBDummyEmptyClass) primitiveExecute.
+	RBRefactoryChangeManager instance performChange:
+		transformation changes.
 
-	self deny: (RBDummyEmptyClass protocolNamed: 'empty protocol 2') isEmpty.
+	self deny:
+		(RBDummyEmptyClass protocolNamed: 'empty protocol 2') isEmpty.
 
-	transformation := (RBMethodProtocolTransformation new protocol: 'empty protocol 1' inMethod: #someMethod inClass: #RBDummyEmptyClass) transform.
-	RBRefactoryChangeManager instance performChange: transformation changes.
+	transformation := (RBMethodProtocolTransformation new
+		                   protocol: 'empty protocol 1'
+		                   inMethod: #someMethod
+		                   inClass: #RBDummyEmptyClass) primitiveExecute.
+	RBRefactoryChangeManager instance performChange:
+		transformation changes.
 	self deny: (RBDummyEmptyClass hasProtocol: 'empty protocol 2')
 ]

--- a/src/Refactoring2-Transformations-Tests/RBMethodProtocolTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMethodProtocolTransformationTest.class.st
@@ -8,20 +8,18 @@ Class {
 RBMethodProtocolTransformationTest >> testClassDoesNotExist [
 
 	self shouldFail: (RBMethodProtocolTransformation
-							protocol: 'empty protocol 2'
-							inMethod: #someMethod
-							inClass: #RBDummyEmptyClass123)
-							asRefactoring
+			 protocol: 'empty protocol 2'
+			 inMethod: #someMethod
+			 inClass: #RBDummyEmptyClass123)
 ]
 
 { #category : #tests }
 RBMethodProtocolTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBMethodProtocolTransformation
-							protocol: 'empty protocol 2'
-							inMethod: #method
-							inClass: #RBDummyEmptyClass)
-							asRefactoring
+			 protocol: 'empty protocol 2'
+			 inMethod: #method
+			 inClass: #RBDummyEmptyClass)
 ]
 
 { #category : #tests }
@@ -33,8 +31,7 @@ RBMethodProtocolTransformationTest >> testRefactoring [
 	refactoring := (RBMethodProtocolTransformation
 		                protocol: 'empty protocol 2'
 		                inMethod: #someMethod
-		                inClass: #RBDummyEmptyClass) asRefactoring
-		               primitiveExecute.
+		                inClass: #RBDummyEmptyClass) primitiveExecute.
 	RBRefactoryChangeManager instance performChange: refactoring changes.
 
 	self deny:
@@ -43,8 +40,7 @@ RBMethodProtocolTransformationTest >> testRefactoring [
 	refactoring := (RBMethodProtocolTransformation
 		                protocol: 'empty protocol 1'
 		                inMethod: #someMethod
-		                inClass: #RBDummyEmptyClass) asRefactoring
-		               primitiveExecute.
+		                inClass: #RBDummyEmptyClass) primitiveExecute.
 	RBRefactoryChangeManager instance performChange: refactoring changes.
 
 	self deny: (RBDummyEmptyClass hasProtocol: 'empty protocol 2')

--- a/src/Refactoring2-Transformations-Tests/RBMoveClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveClassTransformationTest.class.st
@@ -8,9 +8,8 @@ Class {
 RBMoveClassTransformationTest >> testBadCategoryName [
 
 	self shouldFail: (RBMoveClassTransformation
-							move: self class name
-							to: #'Refactoring2-Transformations-Test')
-							asRefactoring
+			 move: self class name
+			 to: #'Refactoring2-Transformations-Test')
 ]
 
 { #category : #tests }
@@ -24,7 +23,7 @@ RBMoveClassTransformationTest >> testRefactoring [
 	transformation := (RBMoveClassTransformation
 		                   move: self class name
 		                   to: #'Refactoring2-Transformations-Utilities')
-		                  asRefactoring primitiveExecute.
+		                  primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 

--- a/src/Refactoring2-Transformations-Tests/RBMoveClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveClassTransformationTest.class.st
@@ -17,32 +17,41 @@ RBMoveClassTransformationTest >> testBadCategoryName [
 RBMoveClassTransformationTest >> testRefactoring [
 
 	| transformation class |
-	self assert: self class category equals: #'Refactoring2-Transformations-Tests-Test'.
+	self
+		assert: self class category
+		equals: #'Refactoring2-Transformations-Tests-Test'.
 
 	transformation := (RBMoveClassTransformation
-							move: self class name
-							to: #'Refactoring2-Transformations-Utilities')
-							asRefactoring transform.
+		                   move: self class name
+		                   to: #'Refactoring2-Transformations-Utilities')
+		                  asRefactoring primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 
 	class := transformation model classNamed: self class name.
-	self assert: class category equals: #'Refactoring2-Transformations-Utilities'
+	self
+		assert: class category
+		equals: #'Refactoring2-Transformations-Utilities'
 ]
 
 { #category : #tests }
 RBMoveClassTransformationTest >> testTransform [
 
 	| transformation class |
-	self assert: self changeMockClass category equals: #'Refactoring-Tests-Changes'.
+	self
+		assert: self changeMockClass category
+		equals: #'Refactoring-Tests-Changes'.
 
 	transformation := (RBMoveClassTransformation
-							move: self changeMockClass name
-							to: #'Refactoring2-Transformations-Tests-Test')
-							transform.
+		                   move: self changeMockClass name
+		                   to: #'Refactoring2-Transformations-Tests-Test')
+		                  primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 
-	class := transformation model classNamed: self changeMockClass name asSymbol.
-	self assert: class category equals: #'Refactoring2-Transformations-Tests-Test'
+	class := transformation model classNamed:
+		         self changeMockClass name asSymbol.
+	self
+		assert: class category
+		equals: #'Refactoring2-Transformations-Tests-Test'
 ]

--- a/src/Refactoring2-Transformations-Tests/RBMoveInstanceVariableToClassParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveInstanceVariableToClassParametrizedTest.class.st
@@ -49,7 +49,7 @@ RBMoveInstanceVariableToClassParametrizedTest >> testRefactoring [
 		(oldClass directlyDefinesInstanceVariable: 'methodBlock').
 	self deny: (newClass directlyDefinesInstanceVariable: 'methodBlock').
 
-	refactoring transform.
+	refactoring primitiveExecute.
 	self assert: refactoring model changes changes size equals: 2.
 	oldClass := refactoring model classNamed: #RBBasicLintRuleTestData.
 	newClass := refactoring model classNamed: #RBFooLintRuleTestData.

--- a/src/Refactoring2-Transformations-Tests/RBMoveTemporaryVariableDefinitionTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveTemporaryVariableDefinitionTransformationTest.class.st
@@ -18,13 +18,14 @@ RBMoveTemporaryVariableDefinitionTransformationTest >> testMoveDefinition [
 
 	| transformation class |
 	transformation := (RBMoveTemporaryVariableDefinitionTransformation
-							variable: #temp
-							inMethod: #moveDefinition
-							inClass: #RBClassDataForRefactoringTest)
-							transform.
+		                   variable: #temp
+		                   inMethod: #moveDefinition
+		                   inClass: #RBClassDataForRefactoringTest)
+		                  primitiveExecute.
 
-	class := transformation model classNamed: #RBClassDataForRefactoringTest.
-	self 
+	class := transformation model classNamed:
+		         #RBClassDataForRefactoringTest.
+	self
 		assert: (class parseTreeForSelector: #moveDefinition)
 		equals: (self parseMethod: 'moveDefinition
 								^(self collect:
@@ -44,14 +45,16 @@ RBMoveTemporaryVariableDefinitionTransformationTest >> testMoveDefinitionIntoBlo
 
 	| transformation class |
 	transformation := (RBMoveTemporaryVariableDefinitionTransformation
-							variable: #association
-							inMethod: #referencesConditionFor:
-							inClass: #RBClassDataForRefactoringTest)
-							asRefactoring transform.
+		                   variable: #association
+		                   inMethod: #referencesConditionFor:
+		                   inClass: #RBClassDataForRefactoringTest)
+		                  asRefactoring primitiveExecute.
 
-	class := transformation model classNamed: #RBClassDataForRefactoringTest.
-	self assert: (class parseTreeForSelector: #referencesConditionFor:)
-		  equals: (self parseMethod: 'referencesConditionFor: aClass
+	class := transformation model classNamed:
+		         #RBClassDataForRefactoringTest.
+	self
+		assert: (class parseTreeForSelector: #referencesConditionFor:)
+		equals: (self parseMethod: 'referencesConditionFor: aClass
 						| environment  |
 						^(RBCondition withBlock:
 								[| association |association := Smalltalk globals associationAt: aClass name

--- a/src/Refactoring2-Transformations-Tests/RBMoveTemporaryVariableDefinitionTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveTemporaryVariableDefinitionTransformationTest.class.st
@@ -48,7 +48,7 @@ RBMoveTemporaryVariableDefinitionTransformationTest >> testMoveDefinitionIntoBlo
 		                   variable: #association
 		                   inMethod: #referencesConditionFor:
 		                   inClass: #RBClassDataForRefactoringTest)
-		                  asRefactoring primitiveExecute.
+		                  primitiveExecute.
 
 	class := transformation model classNamed:
 		         #RBClassDataForRefactoringTest.
@@ -71,31 +71,27 @@ RBMoveTemporaryVariableDefinitionTransformationTest >> testMoveDefinitionIntoBlo
 RBMoveTemporaryVariableDefinitionTransformationTest >> testNowhereToMove [
 
 	| transformation |
-	transformation := (RBMoveTemporaryVariableDefinitionTransformation
-							variable: #temp
-							inMethod: #noMoveDefinition
-							inClass: #RBClassDataForRefactoringTest).
-	self 
-		assert: transformation model changes changes size 
-		equals: 0.
+	transformation := RBMoveTemporaryVariableDefinitionTransformation
+		                  variable: #temp
+		                  inMethod: #noMoveDefinition
+		                  inClass: #RBClassDataForRefactoringTest.
+	self assert: transformation model changes changes size equals: 0.
 
 	self shouldFail: (RBMoveTemporaryVariableDefinitionTransformation
-							variable: #temp
-							inMethod: #noMoveDefinition
-							inClass: #RBClassDataForRefactoringTest)
-							asRefactoring
+			 variable: #temp
+			 inMethod: #noMoveDefinition
+			 inClass: #RBClassDataForRefactoringTest)
 ]
 
 { #category : #tests }
 RBMoveTemporaryVariableDefinitionTransformationTest >> testVariableDoesNotExist [
 
 	self shouldFail: (RBMoveTemporaryVariableDefinitionTransformation
-							variable: #temp
-							inMethod: #displayName
-							inClass: #RBDummyLintRuleTest).
+			 variable: #temp
+			 inMethod: #displayName
+			 inClass: #RBDummyLintRuleTest).
 	self shouldFail: (RBMoveTemporaryVariableDefinitionTransformation
-							variable: #temp
-							inMethod: #displayName
-							inClass: #RBDummyLintRuleTest)
-							asRefactoring
+			 variable: #temp
+			 inMethod: #displayName
+			 inClass: #RBDummyLintRuleTest)
 ]

--- a/src/Refactoring2-Transformations-Tests/RBProtectVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBProtectVariableTransformationTest.class.st
@@ -18,7 +18,7 @@ RBProtectVariableTransformationTest >> testAccessorsAlreadyExist [
 	(RBProtectVariableTransformation
 		 model: model
 		 instanceVariable: 'instVarName1'
-		 class: #Foo) asRefactoring primitiveExecute.
+		 class: #Foo) primitiveExecute.
 
 	class := model classNamed: #Foo.
 	self
@@ -46,7 +46,7 @@ RBProtectVariableTransformationTest >> testClassVariable [
 	| refactoring class |
 	refactoring := (RBProtectVariableTransformation
 		                classVariable: 'RecursiveSelfRule'
-		                class: #RBTransformationRuleTestData) asRefactoring
+		                class: #RBTransformationRuleTestData)
 		               primitiveExecute.
 
 	class := (refactoring model classNamed: #RBTransformationRuleTestData)
@@ -90,7 +90,7 @@ RBProtectVariableTransformationTest >> testClassVariableInModel [
 	(RBProtectVariableTransformation
 		 model: model
 		 classVariable: 'ClassVarName1'
-		 class: #Foo) asRefactoring primitiveExecute.
+		 class: #Foo) primitiveExecute.
 
 	class := (model classNamed: #Foo) classSide.
 	self
@@ -138,7 +138,7 @@ RBProtectVariableTransformationTest >> testMetaclass [
 	(RBProtectVariableTransformation
 		 model: model
 		 instanceVariable: 'foo'
-		 class: class) asRefactoring primitiveExecute.
+		 class: class) primitiveExecute.
 
 	self
 		assert: (class parseTreeForSelector: #foo1)
@@ -157,9 +157,8 @@ RBProtectVariableTransformationTest >> testMetaclass [
 RBProtectVariableTransformationTest >> testMetaclassFailure [
 
 	self shouldFail: (RBProtectVariableTransformation
-							classVariable: #RecursiveSelfRule
-							class: RBTransformationRuleTestData class)
-							asRefactoring
+			 classVariable: #RecursiveSelfRule
+			 class: RBTransformationRuleTestData class)
 ]
 
 { #category : #tests }
@@ -168,7 +167,7 @@ RBProtectVariableTransformationTest >> testRefactoring [
 	| refactoring class |
 	refactoring := (RBProtectVariableTransformation
 		                instanceVariable: 'builder'
-		                class: #RBTransformationRuleTestData) asRefactoring
+		                class: #RBTransformationRuleTestData)
 		               primitiveExecute.
 
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
@@ -243,13 +242,11 @@ RBProtectVariableTransformationTest >> testVariableDoesNotExist [
 
 	self
 		shouldFail: (RBProtectVariableTransformation
-						instanceVariable: 'foo'
-						class: #RBBasicLintRuleTestData)
-						asRefactoring;
+				 instanceVariable: 'foo'
+				 class: #RBBasicLintRuleTestData);
 		shouldFail: (RBProtectVariableTransformation
-						classVariable: #Foo
-						class: #RBBasicLintRuleTestData)
-						asRefactoring
+				 classVariable: #Foo
+				 class: #RBBasicLintRuleTestData)
 ]
 
 { #category : #tests }
@@ -277,18 +274,15 @@ RBProtectVariableTransformationTest >> testVariableNotDirectlyDefined [
 
 	self
 		shouldFail: (RBProtectVariableTransformation
-						instanceVariable: 'name'
-						class: #RBBasicLintRuleTestData)
-						asRefactoring;
+				 instanceVariable: 'name'
+				 class: #RBBasicLintRuleTestData);
 		shouldFail: (RBProtectVariableTransformation
-						classVariable: #DependentsFields
-						class: #RBBasicLintRuleTestData)
-						asRefactoring;
+				 classVariable: #DependentsFields
+				 class: #RBBasicLintRuleTestData);
 		shouldFail: (RBProtectVariableTransformation
-						model: model
-						classVariable: 'ClassVarName2'
-						class: #Bar)
-						asRefactoring
+				 model: model
+				 classVariable: 'ClassVarName2'
+				 class: #Bar)
 ]
 
 { #category : #tests }
@@ -298,7 +292,7 @@ RBProtectVariableTransformationTest >> testWithAssignment [
 	refactoring := (RBProtectVariableTransformation
 		                model: model
 		                instanceVariable: 'instVarName2'
-		                class: #Foo) asRefactoring primitiveExecute.
+		                class: #Foo) primitiveExecute.
 
 	class := model classNamed: #Foo.
 	self

--- a/src/Refactoring2-Transformations-Tests/RBProtectVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBProtectVariableTransformationTest.class.st
@@ -16,23 +16,26 @@ RBProtectVariableTransformationTest >> testAccessorsAlreadyExist [
 
 	| class |
 	(RBProtectVariableTransformation
-		model: model
-		instanceVariable: 'instVarName1'
-		class: #Foo)
-		asRefactoring transform.
+		 model: model
+		 instanceVariable: 'instVarName1'
+		 class: #Foo) asRefactoring primitiveExecute.
 
 	class := model classNamed: #Foo.
-	self assert: (class parseTreeForSelector: #bar)
+	self
+		assert: (class parseTreeForSelector: #bar)
 		equals: (self parseMethod: 'bar
 			"Add one to instVarName1"
 			self instVarName11: self instVarName11 + 1').
-	self assert: (class parseTreeForSelector: #instVarName11:)
+	self
+		assert: (class parseTreeForSelector: #instVarName11:)
 		equals: (self parseMethod: 'instVarName11: anObject
 			instVarName1 := anObject').
-	self assert: (class parseTreeForSelector: #instVarName11)
+	self
+		assert: (class parseTreeForSelector: #instVarName11)
 		equals: (self parseMethod: 'instVarName11 ^instVarName1').
 
-	self assert: ((model classNamed: #Bar) parseTreeForSelector: #foo)
+	self
+		assert: ((model classNamed: #Bar) parseTreeForSelector: #foo)
 		equals: (self parseMethod: 'foo
 			self instVarName11: self instVarName11 + instVarName2 + ClassVarName1')
 ]
@@ -42,26 +45,35 @@ RBProtectVariableTransformationTest >> testClassVariable [
 
 	| refactoring class |
 	refactoring := (RBProtectVariableTransformation
-						classVariable: 'RecursiveSelfRule'
-						class: #RBTransformationRuleTestData)
-						asRefactoring transform.
+		                classVariable: 'RecursiveSelfRule'
+		                class: #RBTransformationRuleTestData) asRefactoring
+		               primitiveExecute.
 
-	class := (refactoring model classNamed: #RBTransformationRuleTestData) classSide.
-	self assert: (class parseTreeForSelector: #recursiveSelfRule)
-			equals: (self parseMethod: 'recursiveSelfRule ^RecursiveSelfRule').
-	self assert: (class parseTreeForSelector: #recursiveSelfRule:)
-			equals: (self parseMethod: 'recursiveSelfRule: anObject RecursiveSelfRule := anObject').
+	class := (refactoring model classNamed: #RBTransformationRuleTestData)
+		         classSide.
+	self
+		assert: (class parseTreeForSelector: #recursiveSelfRule)
+		equals: (self parseMethod: 'recursiveSelfRule ^RecursiveSelfRule').
+	self
+		assert: (class parseTreeForSelector: #recursiveSelfRule:)
+		equals: (self parseMethod:
+				 'recursiveSelfRule: anObject RecursiveSelfRule := anObject').
 
-	self assert: (class parseTreeForSelector: #nuke)
-			equals: (self parseMethod: 'nuke self recursiveSelfRule: nil').
-	self assert: (class parseTreeForSelector: #initializeAfterLoad1)
-			equals: (self parseMethod: 'initializeAfterLoad1
+	self
+		assert: (class parseTreeForSelector: #nuke)
+		equals: (self parseMethod: 'nuke self recursiveSelfRule: nil').
+	self
+		assert: (class parseTreeForSelector: #initializeAfterLoad1)
+		equals: (self parseMethod: 'initializeAfterLoad1
 				self recursiveSelfRule: self parseTreeSearcher.
 				self recursiveSelfRule
 					addMethodSearches: #(''`@methodName: `@args | `@temps | self `@methodName: `@args'' ''`@methodName: `@args | `@temps | ^self `@methodName: `@args'')
 					-> [:aNode :answer | true]').
-	self assert: ((refactoring model classNamed: #RBTransformationRuleTestData) parseTreeForSelector: #checkMethod:)
-			equals: (self parseMethod: 'checkMethod: aSmalllintContext
+	self
+		assert:
+			((refactoring model classNamed: #RBTransformationRuleTestData)
+				 parseTreeForSelector: #checkMethod:)
+		equals: (self parseMethod: 'checkMethod: aSmalllintContext
 				class := aSmalllintContext selectedClass.
 				(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue:
 					[(self class recursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
@@ -76,26 +88,33 @@ RBProtectVariableTransformationTest >> testClassVariableInModel [
 
 	| class |
 	(RBProtectVariableTransformation
-		model: model
-		classVariable: 'ClassVarName1'
-		class: #Foo)
-		asRefactoring transform.
+		 model: model
+		 classVariable: 'ClassVarName1'
+		 class: #Foo) asRefactoring primitiveExecute.
 
 	class := (model classNamed: #Foo) classSide.
-	self assert: (class parseTreeForSelector: #classVarName1)
-			equals: (self parseMethod: 'classVarName1 ^ClassVarName1').
-	self assert: (class parseTreeForSelector: #classVarName1:)
-			equals: (self parseMethod: 'classVarName1: anObject ClassVarName1 := anObject').
+	self
+		assert: (class parseTreeForSelector: #classVarName1)
+		equals: (self parseMethod: 'classVarName1 ^ClassVarName1').
+	self
+		assert: (class parseTreeForSelector: #classVarName1:)
+		equals:
+		(self parseMethod:
+			 'classVarName1: anObject ClassVarName1 := anObject').
 
-	self assert: (class parseTreeForSelector: #foo)
-			equals: (self parseMethod: 'foo
+	self
+		assert: (class parseTreeForSelector: #foo)
+		equals: (self parseMethod: 'foo
 				^self classVarName1: self classVarName1 * self classVarName1 * self classVarName1').
 
-	self assert: (class instanceSide parseTreeForSelector: #classVarName1)
-			equals: (self parseMethod: 'classVarName1 ^self class classVarName1').
-	self assert: (class instanceSide parseTreeForSelector: #classVarName1:)
-			equals: (self parseMethod: 'classVarName1: anObject
-				^self class classVarName1: anObject').
+	self
+		assert: (class instanceSide parseTreeForSelector: #classVarName1)
+		equals:
+		(self parseMethod: 'classVarName1 ^self class classVarName1').
+	self
+		assert: (class instanceSide parseTreeForSelector: #classVarName1:)
+		equals: (self parseMethod: 'classVarName1: anObject
+				^self class classVarName1: anObject')
 
 	"self assert: (class instanceSide parseTreeFor: #asdf)
 			equals: (RBParser parseMethod: 'asdf
@@ -114,21 +133,24 @@ RBProtectVariableTransformationTest >> testMetaclass [
 	| class |
 	class := model metaclassNamed: #Foo.
 	class addInstanceVariable: 'foo'.
-	class compile: 'zzz ^foo := foo + foo * 2' classified: #(#testing).
+	class compile: 'zzz ^foo := foo + foo * 2' classified: #( #testing ).
 
 	(RBProtectVariableTransformation
-		model: model
-		instanceVariable: 'foo'
-		class: class)
-		asRefactoring transform.
+		 model: model
+		 instanceVariable: 'foo'
+		 class: class) asRefactoring primitiveExecute.
 
-	self assert: (class parseTreeForSelector: #foo1)
-			equals: (self parseMethod: 'foo1 ^foo').
-	self assert: (class parseTreeForSelector: #foo:)
-			equals: (self parseMethod: 'foo: anObject foo := anObject').
+	self
+		assert: (class parseTreeForSelector: #foo1)
+		equals: (self parseMethod: 'foo1 ^foo').
+	self
+		assert: (class parseTreeForSelector: #foo:)
+		equals: (self parseMethod: 'foo: anObject foo := anObject').
 
-	self assert: (class parseTreeForSelector: #zzz)
-			equals: (self parseMethod: 'zzz ^self foo: self foo1 + self foo1 * 2')
+	self
+		assert: (class parseTreeForSelector: #zzz)
+		equals:
+		(self parseMethod: 'zzz ^self foo: self foo1 + self foo1 * 2')
 ]
 
 { #category : #tests }
@@ -145,18 +167,26 @@ RBProtectVariableTransformationTest >> testRefactoring [
 
 	| refactoring class |
 	refactoring := (RBProtectVariableTransformation
-						instanceVariable: 'builder'
-						class: #RBTransformationRuleTestData)
-						asRefactoring transform.
+		                instanceVariable: 'builder'
+		                class: #RBTransformationRuleTestData) asRefactoring
+		               primitiveExecute.
 
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeForSelector: #builder) equals: (self parseMethod: 'builder ^builder').
-	self assert: (class parseTreeForSelector: #builder:) equals: (self parseMethod: 'builder: anObject
+	self
+		assert: (class parseTreeForSelector: #builder)
+		equals: (self parseMethod: 'builder ^builder').
+	self
+		assert: (class parseTreeForSelector: #builder:)
+		equals: (self parseMethod: 'builder: anObject
 	builder := anObject').
-	self assert: (class parseTreeForSelector: #viewResults) equals: (self parseMethod: 'viewResults
+	self
+		assert: (class parseTreeForSelector: #viewResults)
+		equals: (self parseMethod: 'viewResults
 		self builder inspect.
 		self resetResult').
-	self assert: (class parseTreeForSelector: #checkMethod:) equals: (self parseMethod: 'checkMethod: aSmalllintContext
+	self
+		assert: (class parseTreeForSelector: #checkMethod:)
+		equals: (self parseMethod: 'checkMethod: aSmalllintContext
 	class := aSmalllintContext selectedClass.
 	(rewriteRule executeTree: aSmalllintContext parseTree)
 		ifTrue:
@@ -173,16 +203,18 @@ RBProtectVariableTransformationTest >> testTransform [
 
 	| transformation class |
 	transformation := (RBProtectVariableTransformation
-							instanceVariable: 'class'
-							class: #RBTransformationRuleTestData)
-							transform.
+		                   instanceVariable: 'class'
+		                   class: #RBTransformationRuleTestData)
+		                  primitiveExecute.
 
-	class := transformation model classNamed: #RBTransformationRuleTestData.
+	class := transformation model classNamed:
+		         #RBTransformationRuleTestData.
 	self assert: (class directlyDefinesLocalMethod: #class1).
 	self assert: (class directlyDefinesLocalMethod: #class:).
 
-	self assert: (class parseTreeForSelector: #superSends) equals: (self parseMethod:
-	'superSends
+	self
+		assert: (class parseTreeForSelector: #superSends)
+		equals: (self parseMethod: 'superSends
 		| rule |
 		rule := RBParseTreeRewriter new.
 		rule addSearch: ''super `@message: ``@args''
@@ -194,8 +226,9 @@ RBProtectVariableTransformationTest >> testTransform [
 						-> ''self `@message: ``@args'').
 		self rewriteUsing: rule').
 
-	self assert: (class parseTreeForSelector: #checkMethod:) equals: (self parseMethod:
-	'checkMethod: aSmalllintContext
+	self
+		assert: (class parseTreeForSelector: #checkMethod:)
+		equals: (self parseMethod: 'checkMethod: aSmalllintContext
 		self class: aSmalllintContext selectedClass.
 		(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue:
 			[(RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false) ifFalse:
@@ -224,14 +257,15 @@ RBProtectVariableTransformationTest >> testVariableIsNotAccessed [
 
 	| transformation class |
 	transformation := RBProtectVariableTransformation
-							instanceVariable: 'instVar'
-							class: self changeMockClass name.
+		                  instanceVariable: 'instVar'
+		                  class: self changeMockClass name.
 
-	class := transformation model classNamed: self changeMockClass name asSymbol.
+	class := transformation model classNamed:
+		         self changeMockClass name asSymbol.
 	self deny: (class directlyDefinesLocalMethod: #instVar).
 	self deny: (class directlyDefinesLocalMethod: #instVar:).
 
-	transformation transform.
+	transformation primitiveExecute.
 	self assert: transformation model changes changes size equals: 3.
 	"the accessors and the method using the variables"
 	self assert: (class directlyDefinesLocalMethod: #instVar).
@@ -262,20 +296,24 @@ RBProtectVariableTransformationTest >> testWithAssignment [
 
 	| refactoring class |
 	refactoring := (RBProtectVariableTransformation
-						model: model
-						instanceVariable: 'instVarName2'
-						class: #Foo)
-						asRefactoring transform.
+		                model: model
+		                instanceVariable: 'instVarName2'
+		                class: #Foo) asRefactoring primitiveExecute.
 
 	class := model classNamed: #Foo.
-	self assert: (class parseTreeForSelector: #instVarName2:)
-		equals: (self parseMethod: 'instVarName2: anObject instVarName2 := anObject').
-	self assert: (class parseTreeForSelector: #instVarName2)
+	self
+		assert: (class parseTreeForSelector: #instVarName2:)
+		equals:
+		(self parseMethod: 'instVarName2: anObject instVarName2 := anObject').
+	self
+		assert: (class parseTreeForSelector: #instVarName2)
 		equals: (self parseMethod: 'instVarName2 ^instVarName2').
 
-	self assert: (class parseTreeForSelector: #foo)
+	self
+		assert: (class parseTreeForSelector: #foo)
 		equals: (self parseMethod: 'foo ^self instVarName2: 3').
-	self assert: ((model classNamed: #Bar) parseTreeForSelector: #foo)
+	self
+		assert: ((model classNamed: #Bar) parseTreeForSelector: #foo)
 		equals: (self parseMethod: 'foo
 			instVarName1 := instVarName1 + self instVarName2 + ClassVarName1')
 ]

--- a/src/Refactoring2-Transformations-Tests/RBPushDownMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBPushDownMethodParametrizedTest.class.st
@@ -24,7 +24,7 @@ RBPushDownMethodParametrizedTest >> testFailurePushDownMethodOnNonAbstractClass 
 	refactoring := self createRefactoringWithArguments: {
 			               #( #isArray ).
 			               Array }.
-	self shouldFail: refactoring asRefactoring
+	self shouldFail: refactoring
 ]
 
 { #category : #'failure tests' }
@@ -48,7 +48,7 @@ RBPushDownMethodParametrizedTest >> testFailurePushDownMethodSubclassesReferToSe
 		               model: model
 		               pushDown: #( #yourself )
 		               from: (model classNamed: #Superclass).
-	self shouldFail: refactoring asRefactoring
+	self shouldFail: refactoring
 ]
 
 { #category : #'failure tests' }
@@ -58,34 +58,37 @@ RBPushDownMethodParametrizedTest >> testFailurePushDownNonExistantMenu [
 	refactoring := self createRefactoringWithArguments: {
 			               #( #someMethodThatDoesNotExist ).
 			               RBLintRuleTestData }.
-	self shouldFail: refactoring asRefactoring
+	self shouldFail: refactoring
 ]
 
 { #category : #tests }
 RBPushDownMethodParametrizedTest >> testPushDownMethod [
+
 	| refactoring class |
-	refactoring := self createRefactoringWithArguments:
-		{ #(#name: ) . RBLintRuleTestData }.
-	self executeRefactoring: refactoring asRefactoring.
+	refactoring := self createRefactoringWithArguments: {
+			               #( #name: ).
+			               RBLintRuleTestData }.
+	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBLintRuleTestData.
 	self deny: (class directlyDefinesMethod: #name:).
-	class subclasses do:
-		[ :each |
-		self assert: (each parseTreeForSelector: #name:)
+	class subclasses do: [ :each |
+		self
+			assert: (each parseTreeForSelector: #name:)
 			equals: (self parseMethod: 'name: aString name := aString') ]
 ]
 
 { #category : #tests }
 RBPushDownMethodParametrizedTest >> testPushDownMethodThatReferencesPoolDictionary [
+
 	| refactoring class parseTree |
 	parseTree := RBLintRuleTestData parseTreeForSelector: #junk.
-	refactoring := self createRefactoringWithArguments:
-		{ #(#junk ) . RBLintRuleTestData }.
-	self executeRefactoring: refactoring asRefactoring.
+	refactoring := self createRefactoringWithArguments: {
+			               #( #junk ).
+			               RBLintRuleTestData }.
+	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBLintRuleTestData.
 	self deny: (class directlyDefinesMethod: #junk).
-	class subclasses do:
-		[ :each |
+	class subclasses do: [ :each |
 		self assert: (each parseTreeForSelector: #junk) equals: parseTree.
 		self assert: (each definesPoolDictionary: 'TextConstants' asSymbol) ]
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveAllMessageSendsTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveAllMessageSendsTransformationTest.class.st
@@ -13,7 +13,7 @@ RBRemoveAllMessageSendsTransformationTest >> testClassDoesNotExist [
 				inMethod: #badMessage1
 				inClass: #ADoesNotExistClass).
 	self should: [ trans checkPreconditions ] raise: trans refactoringErrorClass.
-	self should: [ trans transform ] raise: trans refactoringErrorClass.
+	self should: [ trans privateTransform ] raise: trans refactoringErrorClass.
 ]
 
 { #category : #'failure tests' }
@@ -25,7 +25,7 @@ RBRemoveAllMessageSendsTransformationTest >> testFailureNonExistantSelector [
 				inMethod: #checkClass1:
 				inClass: #RBClassDataForRefactoringTest).
 	self should: [ trans checkPreconditions ] raise: trans refactoringErrorClass.
-	self should: [ trans transform ] raise: trans refactoringErrorClass.
+	self should: [ trans privateTransform ] raise: trans refactoringErrorClass.
 ]
 
 { #category : #'failure tests' }
@@ -37,7 +37,7 @@ RBRemoveAllMessageSendsTransformationTest >> testMethodDoesNotExist [
 				inMethod: #badMessage1
 				inClass: #RBClassDataForRefactoringTest).
 	self should: [ trans checkPreconditions ] raise: trans refactoringErrorClass.
-	self should: [ trans transform ] raise: trans refactoringErrorClass.
+	self should: [ trans privateTransform ] raise: trans refactoringErrorClass.
 ]
 
 { #category : #tests }
@@ -48,7 +48,7 @@ RBRemoveAllMessageSendsTransformationTest >> testRemoveMessageInsideBlock [
 				messageSend: #printString
 				inMethod: #caller1
 				inClass: #RBClassDataForRefactoringTest).
-	trans transform.
+	trans primitiveExecute.
 
 	self assert: ((trans model classNamed: #RBClassDataForRefactoringTest) parseTreeForSelector: #caller1) equals: (self parseMethod: 'caller1
 	| anObject |
@@ -78,7 +78,7 @@ RBRemoveAllMessageSendsTransformationTest >> testRemoveSenderIntoCascaded2Messag
 				messageSend: #inlineMethod
 				inMethod: #inlineMethod
 				inClass: #RBClassDataForRefactoringTest).
-	trans transform.
+	trans primitiveExecute.
 	transformedMethod := ((trans model classNamed: #RBClassDataForRefactoringTest) parseTreeForSelector: #inlineMethod).
 	self assert: (transformedMethod = afterRefactoring1 or: [ transformedMethod = afterRefactoring2])
 ]
@@ -120,7 +120,7 @@ RBRemoveAllMessageSendsTransformationTest >> testRemoveSenderIntoCascaded3Messag
 				messageSend: #errorBlock:
 				inMethod: #referencesConditionFor:
 				inClass: #RBClassDataForRefactoringTest).
-	trans transform.
+	trans primitiveExecute.
 	transformedMethod := ((trans model classNamed: #RBClassDataForRefactoringTest) parseTreeForSelector: #referencesConditionFor:).
 	self assert: (transformedMethod = afterRefactoring1 or: [ transformedMethod = afterRefactoring2])
 ]
@@ -133,7 +133,7 @@ RBRemoveAllMessageSendsTransformationTest >> testRemoveSenderIntoCascadedMessage
 				messageSend: #cr
 				inMethod: (#called:, #on:) asSymbol
 				inClass: #RBClassDataForRefactoringTest).
-	trans transform.
+	trans primitiveExecute.
 
 	self assert: ((trans model classNamed: #RBClassDataForRefactoringTest) parseTreeForSelector: (#called:, #on:) asSymbol)
 		equals: (self parseMethod: 'called: anObject on: aBlock
@@ -157,7 +157,7 @@ RBRemoveAllMessageSendsTransformationTest >> testRemoveSimpleSenderOfMessage [
 				messageSend: #called:on1:
 				inMethod: #caller1
 				inClass: #RBClassDataForRefactoringTest).
-	trans transform.
+	trans primitiveExecute.
 	transformedMethod := ((trans model classNamed: #RBClassDataForRefactoringTest) parseTreeForSelector: #caller1).
 	self assert: (transformedMethod = afterRefactoring1 or: [ transformedMethod = afterRefactoring2])
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveAllMessageSendsTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveAllMessageSendsTransformationTest.class.st
@@ -12,8 +12,7 @@ RBRemoveAllMessageSendsTransformationTest >> testClassDoesNotExist [
 				messageSend: #foo:
 				inMethod: #badMessage1
 				inClass: #ADoesNotExistClass).
-	self should: [ trans checkPreconditions ] raise: trans refactoringErrorClass.
-	self should: [ trans privateTransform ] raise: trans refactoringErrorClass.
+	self should: [ trans primitiveExecute ] raise: trans refactoringErrorClass.
 ]
 
 { #category : #'failure tests' }
@@ -24,8 +23,7 @@ RBRemoveAllMessageSendsTransformationTest >> testFailureNonExistantSelector [
 				messageSend: #foo:
 				inMethod: #checkClass1:
 				inClass: #RBClassDataForRefactoringTest).
-	self should: [ trans checkPreconditions ] raise: trans refactoringErrorClass.
-	self should: [ trans privateTransform ] raise: trans refactoringErrorClass.
+	self should: [ trans primitiveExecute ] raise: trans refactoringErrorClass.
 ]
 
 { #category : #'failure tests' }
@@ -36,8 +34,7 @@ RBRemoveAllMessageSendsTransformationTest >> testMethodDoesNotExist [
 				messageSend: #foo:
 				inMethod: #badMessage1
 				inClass: #RBClassDataForRefactoringTest).
-	self should: [ trans checkPreconditions ] raise: trans refactoringErrorClass.
-	self should: [ trans privateTransform ] raise: trans refactoringErrorClass.
+	self should: [ trans primitiveExecute ] raise: trans refactoringErrorClass.
 ]
 
 { #category : #tests }

--- a/src/Refactoring2-Transformations-Tests/RBRemoveAssignmentTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveAssignmentTransformationTest.class.st
@@ -27,36 +27,34 @@ RBRemoveAssignmentTransformationTest >> testAssignmentDoesNotExist [
 		                variable: 'variable2'
 		                inMethod: #methodBefore
 		                inClass: #RBRemoveAssignmentTransformationTest)
-		               asRefactoring primitiveExecute.
+		               primitiveExecute.
 
 	self shouldFail: (RBRemoveAssignmentTransformation
 			 model: refactoring model
 			 variable: 'variable2'
 			 value: '1 asString'
 			 inMethod: #methodBefore
-			 inClass: #RBRemoveAssignmentTransformationTest) asRefactoring
+			 inClass: #RBRemoveAssignmentTransformationTest)
 ]
 
 { #category : #tests }
 RBRemoveAssignmentTransformationTest >> testClassDoesNotExist [
 
 	self shouldFail: (RBRemoveAssignmentTransformation
-							variable: 'variable'
-							value: '1 asString'
-							inMethod: #methodBefore
-							inClass: #RBAssignmentTransformationTest)
-							asRefactoring
+			 variable: 'variable'
+			 value: '1 asString'
+			 inMethod: #methodBefore
+			 inClass: #RBAssignmentTransformationTest)
 ]
 
 { #category : #tests }
 RBRemoveAssignmentTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBRemoveAssignmentTransformation
-							variable: 'variable'
-							value: '1 asString'
-							inMethod: #method
-							inClass: #RBRemoveAssignmentTransformationTest)
-							asRefactoring
+			 variable: 'variable'
+			 value: '1 asString'
+			 inMethod: #method
+			 inClass: #RBRemoveAssignmentTransformationTest)
 ]
 
 { #category : #tests }
@@ -68,7 +66,7 @@ RBRemoveAssignmentTransformationTest >> testRefactoring [
 		                value: '1 asString'
 		                inMethod: #methodBefore
 		                inClass: #RBRemoveAssignmentTransformationTest)
-		               asRefactoring primitiveExecute.
+		               primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 1.
 
@@ -101,9 +99,8 @@ RBRemoveAssignmentTransformationTest >> testTransform [
 RBRemoveAssignmentTransformationTest >> testVariableDoesNotExist [
 
 	self shouldFail: (RBRemoveAssignmentTransformation
-							variable: 'variable1'
-							value: '1 asString'
-							inMethod: #methodBefore
-							inClass: #RBRemoveAssignmentTransformationTest)
-							asRefactoring
+			 variable: 'variable1'
+			 value: '1 asString'
+			 inMethod: #methodBefore
+			 inClass: #RBRemoveAssignmentTransformationTest)
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveAssignmentTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveAssignmentTransformationTest.class.st
@@ -24,18 +24,17 @@ RBRemoveAssignmentTransformationTest >> testAssignmentDoesNotExist [
 
 	| refactoring |
 	refactoring := (RBAddTemporaryVariableTransformation
-						variable: 'variable2'
-						inMethod: #methodBefore
-						inClass: #RBRemoveAssignmentTransformationTest)
-						asRefactoring transform.
+		                variable: 'variable2'
+		                inMethod: #methodBefore
+		                inClass: #RBRemoveAssignmentTransformationTest)
+		               asRefactoring primitiveExecute.
 
 	self shouldFail: (RBRemoveAssignmentTransformation
-							model: refactoring model
-							variable: 'variable2'
-							value: '1 asString'
-							inMethod: #methodBefore
-							inClass: #RBRemoveAssignmentTransformationTest)
-							asRefactoring
+			 model: refactoring model
+			 variable: 'variable2'
+			 value: '1 asString'
+			 inMethod: #methodBefore
+			 inClass: #RBRemoveAssignmentTransformationTest) asRefactoring
 ]
 
 { #category : #tests }
@@ -65,17 +64,19 @@ RBRemoveAssignmentTransformationTest >> testRefactoring [
 
 	| refactoring class |
 	refactoring := (RBRemoveAssignmentTransformation
-						variable: 'variable'
-						value: '1 asString'
-						inMethod: #methodBefore
-						inClass: #RBRemoveAssignmentTransformationTest)
-						asRefactoring transform.
+		                variable: 'variable'
+		                value: '1 asString'
+		                inMethod: #methodBefore
+		                inClass: #RBRemoveAssignmentTransformationTest)
+		               asRefactoring primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 1.
 
-	class := refactoring model classNamed: #RBRemoveAssignmentTransformationTest.
-	self assert: (class parseTreeForSelector: #methodBefore) body
-			equals: (class parseTreeForSelector: #methodAfter) body
+	class := refactoring model classNamed:
+		         #RBRemoveAssignmentTransformationTest.
+	self
+		assert: (class parseTreeForSelector: #methodBefore) body
+		equals: (class parseTreeForSelector: #methodAfter) body
 ]
 
 { #category : #tests }
@@ -83,17 +84,17 @@ RBRemoveAssignmentTransformationTest >> testTransform [
 
 	| transformation class |
 	transformation := (RBRemoveAssignmentTransformation new
-		variable: 'variable'
-		value: '1 asString'
-		inMethod: #methodBefore
-		inClass: self class name)
-		transform.
+		                   variable: 'variable'
+		                   value: '1 asString'
+		                   inMethod: #methodBefore
+		                   inClass: self class name) primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 
 	class := transformation model classNamed: self class name.
-	self assert: (class parseTreeForSelector: #methodBefore) body
-			equals: (class parseTreeForSelector: #methodAfter) body
+	self
+		assert: (class parseTreeForSelector: #methodBefore) body
+		equals: (class parseTreeForSelector: #methodAfter) body
 ]
 
 { #category : #tests }

--- a/src/Refactoring2-Transformations-Tests/RBRemoveClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveClassTransformationTest.class.st
@@ -13,8 +13,8 @@ RBRemoveClassTransformationTest class >> defaultTimeLimit [
 RBRemoveClassTransformationTest >> testRefactoring [
 
 	| refactoring |
-	refactoring := (RBRemoveClassTransformation className:
-		                #RBFooDummyLintRuleTest1) asRefactoring.
+	refactoring := RBRemoveClassTransformation className:
+		               #RBFooDummyLintRuleTest1.
 
 	self
 		should: [ refactoring primitiveExecute ]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveClassTransformationTest.class.st
@@ -11,14 +11,15 @@ RBRemoveClassTransformationTest class >> defaultTimeLimit [
 
 { #category : #tests }
 RBRemoveClassTransformationTest >> testRefactoring [
-	| refactoring |
-	refactoring := (RBRemoveClassTransformation className: #RBFooDummyLintRuleTest1)
-	asRefactoring.
 
-	self should:
-	[ refactoring transform ]
+	| refactoring |
+	refactoring := (RBRemoveClassTransformation className:
+		                #RBFooDummyLintRuleTest1) asRefactoring.
+
+	self
+		should: [ refactoring primitiveExecute ]
 		raise: RBRefactoringError.
 
-	self assert: (refactoring model classNamed: #RBFooDummyLintRuleTest1) isNotNil.
-
+	self assert:
+		(refactoring model classNamed: #RBFooDummyLintRuleTest1) isNotNil
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
@@ -16,17 +16,21 @@ RBRemoveDirectAccessToVariableTransformationTest >> testClassVariable [
 
 	| refactoring class |
 	refactoring := (RBRemoveDirectAccessToVariableTransformation
-						classVariable: 'UndoSize'
-						class: #RBRefactoryChangeManager)
-						asRefactoring transform.
+		                classVariable: 'UndoSize'
+		                class: #RBRefactoryChangeManager) asRefactoring
+		               primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 2.
 
-	class := (refactoring model classNamed: #RBRefactoryChangeManager) classSide.
-	self assert: (class parseTreeForSelector: #initialize)
-			equals: (self parseMethod: 'initialize self nuke. self undoSize: 20').
-	self assert: (class instanceSide parseTreeForSelector: #addUndo:)
-			equals: (self parseMethod: 'addUndo: aRefactoringChange
+	class := (refactoring model classNamed: #RBRefactoryChangeManager)
+		         classSide.
+	self
+		assert: (class parseTreeForSelector: #initialize)
+		equals:
+		(self parseMethod: 'initialize self nuke. self undoSize: 20').
+	self
+		assert: (class instanceSide parseTreeForSelector: #addUndo:)
+		equals: (self parseMethod: 'addUndo: aRefactoringChange
 				undo push: aRefactoringChange.
 				undo size > self class undoSize
 					ifTrue: [ undo removeFirst ].
@@ -68,14 +72,14 @@ RBRemoveDirectAccessToVariableTransformationTest >> testInstanceVariable [
 
 	| class |
 	(RBRemoveDirectAccessToVariableTransformation
-		model: model
-		instanceVariable: 'instVarName2'
-		class: #Foo)
-		asRefactoring transform.
+		 model: model
+		 instanceVariable: 'instVarName2'
+		 class: #Foo) asRefactoring primitiveExecute.
 
 	class := model classNamed: #Foo.
-	self assert: (class parseTreeForSelector: #foo)
-			equals: (self parseMethod: 'foo ^ self instVarName2: 3')
+	self
+		assert: (class parseTreeForSelector: #foo)
+		equals: (self parseMethod: 'foo ^ self instVarName2: 3')
 ]
 
 { #category : #tests }
@@ -83,20 +87,21 @@ RBRemoveDirectAccessToVariableTransformationTest >> testRefactoring [
 
 	| refactoring class |
 	refactoring := (RBRemoveDirectAccessToVariableTransformation
-						instanceVariable: 'environment'
-						class: #RBNamespace)
-						asRefactoring transform.
+		                instanceVariable: 'environment'
+		                class: #RBNamespace) asRefactoring primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 4.
 
 	class := refactoring model classNamed: #RBNamespace.
-	self assert: (class parseTreeForSelector: #includesGlobal:)
+	self
+		assert: (class parseTreeForSelector: #includesGlobal:)
 		equals: (self parseMethod: 'includesGlobal: aSymbol
 			(self hasRemoved: aSymbol) ifTrue: [^false].
 			(self includesClassNamed: aSymbol) ifTrue: [^true].
 			self environment at: aSymbol ifAbsent: [^false].
 			^ true').
-	self assert: (class parseTreeForSelector: #initialize)
+	self
+		assert: (class parseTreeForSelector: #initialize)
 		equals: (self parseMethod: 'initialize
 	super initialize.
 	changes := changeFactory compositeRefactoryChange onSystemDictionary: self environment.
@@ -115,14 +120,15 @@ RBRemoveDirectAccessToVariableTransformationTest >> testTransform [
 
 	| transformation class |
 	transformation := (RBRemoveDirectAccessToVariableTransformation
-							instanceVariable: 'class'
-							class: #RBTransformationRuleTestData)
-							transform.
+		                   instanceVariable: 'class'
+		                   class: #RBTransformationRuleTestData)
+		                  primitiveExecute.
 
-	class := transformation model classNamed: #RBTransformationRuleTestData.
-	self assert: (class parseTreeForSelector: #superSends)
-		  equals: (self parseMethod:
-	'superSends
+	class := transformation model classNamed:
+		         #RBTransformationRuleTestData.
+	self
+		assert: (class parseTreeForSelector: #superSends)
+		equals: (self parseMethod: 'superSends
 		| rule |
 		rule := RBParseTreeRewriter new.
 		rule addSearch: ''super `@message: ``@args''
@@ -134,9 +140,9 @@ RBRemoveDirectAccessToVariableTransformationTest >> testTransform [
 						-> ''self `@message: ``@args'').
 		self rewriteUsing: rule').
 
-	self assert: (class parseTreeForSelector: #checkMethod:)
-		  equals: (self parseMethod:
-	'checkMethod: aSmalllintContext
+	self
+		assert: (class parseTreeForSelector: #checkMethod:)
+		equals: (self parseMethod: 'checkMethod: aSmalllintContext
 		self class: aSmalllintContext selectedClass.
 		(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue:
 			[(RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false) ifFalse:

--- a/src/Refactoring2-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
@@ -17,8 +17,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testClassVariable [
 	| refactoring class |
 	refactoring := (RBRemoveDirectAccessToVariableTransformation
 		                classVariable: 'UndoSize'
-		                class: #RBRefactoryChangeManager) asRefactoring
-		               primitiveExecute.
+		                class: #RBRefactoryChangeManager) primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 2.
 
@@ -42,14 +41,12 @@ RBRemoveDirectAccessToVariableTransformationTest >> testDoesNotDefineVariable [
 
 	self
 		shouldFail: (RBRemoveDirectAccessToVariableTransformation
-						model: model
-						instanceVariable: 'instVarName1'
-						class: #Bar)
-						asRefactoring;
+				 model: model
+				 instanceVariable: 'instVarName1'
+				 class: #Bar);
 		shouldFail: (RBRemoveDirectAccessToVariableTransformation
-						classVariable: 'Foo1'
-						class: #RBFooLintRuleTestData)
-						asRefactoring
+				 classVariable: 'Foo1'
+				 class: #RBFooLintRuleTestData)
 ]
 
 { #category : #tests }
@@ -57,14 +54,12 @@ RBRemoveDirectAccessToVariableTransformationTest >> testDoesNotUnderstandAccesso
 
 	self
 		shouldFail: (RBRemoveDirectAccessToVariableTransformation
-						model: model
-						instanceVariable: 'instVarName1'
-						class: #Foo)
-						asRefactoring;
+				 model: model
+				 instanceVariable: 'instVarName1'
+				 class: #Foo);
 		shouldFail: (RBRemoveDirectAccessToVariableTransformation
-						classVariable: 'RecursiveSelfRule'
-						class: #RBTransformationRuleTestData)
-						asRefactoring
+				 classVariable: 'RecursiveSelfRule'
+				 class: #RBTransformationRuleTestData)
 ]
 
 { #category : #tests }
@@ -74,7 +69,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testInstanceVariable [
 	(RBRemoveDirectAccessToVariableTransformation
 		 model: model
 		 instanceVariable: 'instVarName2'
-		 class: #Foo) asRefactoring primitiveExecute.
+		 class: #Foo) primitiveExecute.
 
 	class := model classNamed: #Foo.
 	self
@@ -88,7 +83,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testRefactoring [
 	| refactoring class |
 	refactoring := (RBRemoveDirectAccessToVariableTransformation
 		                instanceVariable: 'environment'
-		                class: #RBNamespace) asRefactoring primitiveExecute.
+		                class: #RBNamespace) primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 4.
 

--- a/src/Refactoring2-Transformations-Tests/RBRemoveMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveMethodParametrizedTest.class.st
@@ -18,9 +18,10 @@ RBRemoveMethodParametrizedTest class >> testParameters [
 
 { #category : #builder }
 RBRemoveMethodParametrizedTest >> createRefactoringWithModel: rbNamespace andArguments: aParameterCollection [
-	^ (rbClass
-		perform: #model: , constructor
-		withArguments: {rbNamespace}, aParameterCollection) asRefactoring
+
+	^ rbClass
+		  perform: #model: , constructor
+		  withArguments: { rbNamespace } , aParameterCollection
 ]
 
 { #category : #builder }

--- a/src/Refactoring2-Transformations-Tests/RBRemovePragmaTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemovePragmaTransformationTest.class.st
@@ -25,30 +25,27 @@ RBRemovePragmaTransformationTest >> methodBefore [
 RBRemovePragmaTransformationTest >> testClassDoesNotExist [
 
 	self shouldFail: (RBRemovePragmaTransformation
-							pragma: '<pragmaForTesting: 34>'
-							inMethod: #methodBefore
-							inClass: #RBPragmaTransformationTest)
-							asRefactoring
+			 pragma: '<pragmaForTesting: 34>'
+			 inMethod: #methodBefore
+			 inClass: #RBPragmaTransformationTest)
 ]
 
 { #category : #tests }
 RBRemovePragmaTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBRemovePragmaTransformation
-							pragma: '<pragmaForTesting: 34>'
-							inMethod: #method
-							inClass: #RBRemovePragmaTransformationTest)
-							asRefactoring
+			 pragma: '<pragmaForTesting: 34>'
+			 inMethod: #method
+			 inClass: #RBRemovePragmaTransformationTest)
 ]
 
 { #category : #tests }
 RBRemovePragmaTransformationTest >> testPragmaDoesNotExist [
 
 	self shouldFail: (RBRemovePragmaTransformation
-							pragma: '<gtPresentationOrder: 34>'
-							inMethod: #methodBefore
-							inClass: #RBRemovePragmaTransformationTest)
-							asRefactoring
+			 pragma: '<gtPresentationOrder: 34>'
+			 inMethod: #methodBefore
+			 inClass: #RBRemovePragmaTransformationTest)
 ]
 
 { #category : #tests }
@@ -59,7 +56,7 @@ RBRemovePragmaTransformationTest >> testRefactoring [
 		                pragma: '<pragmaForTesting: 34>'
 		                inMethod: #methodBefore
 		                inClass: #RBRemovePragmaTransformationTest)
-		               asRefactoring primitiveExecute.
+		               primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 1.
 

--- a/src/Refactoring2-Transformations-Tests/RBRemovePragmaTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemovePragmaTransformationTest.class.st
@@ -56,16 +56,18 @@ RBRemovePragmaTransformationTest >> testRefactoring [
 
 	| refactoring class |
 	refactoring := (RBRemovePragmaTransformation
-						pragma: '<pragmaForTesting: 34>'
-						inMethod: #methodBefore
-						inClass: #RBRemovePragmaTransformationTest)
-						asRefactoring transform.
+		                pragma: '<pragmaForTesting: 34>'
+		                inMethod: #methodBefore
+		                inClass: #RBRemovePragmaTransformationTest)
+		               asRefactoring primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 1.
 
-	class := refactoring model classNamed: #RBRemovePragmaTransformationTest.
-	self assert: (class parseTreeForSelector: #methodBefore) body
-			equals: (class parseTreeForSelector: #methodAfter) body
+	class := refactoring model classNamed:
+		         #RBRemovePragmaTransformationTest.
+	self
+		assert: (class parseTreeForSelector: #methodBefore) body
+		equals: (class parseTreeForSelector: #methodAfter) body
 ]
 
 { #category : #tests }
@@ -73,14 +75,14 @@ RBRemovePragmaTransformationTest >> testTransform [
 
 	| transformation class |
 	transformation := (RBRemovePragmaTransformation new
-		pragma: '<pragmaForTesting: 34>'
-		inMethod: #methodBefore
-		inClass: self class name)
-		transform.
+		                   pragma: '<pragmaForTesting: 34>'
+		                   inMethod: #methodBefore
+		                   inClass: self class name) primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 
 	class := transformation model classNamed: self class name.
-	self assert: (class parseTreeForSelector: #methodBefore) body
-			equals: (class parseTreeForSelector: #methodAfter) body
+	self
+		assert: (class parseTreeForSelector: #methodBefore) body
+		equals: (class parseTreeForSelector: #methodAfter) body
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveProtocolTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveProtocolTransformationTest.class.st
@@ -15,8 +15,7 @@ RBRemoveProtocolTransformationTest >> testRefactoring [
 
 	refactoring := (RBRemoveProtocolTransformation
 		                protocol: 'transforming'
-		                inClass: #RBDummyEmptyClass) asRefactoring
-		               primitiveExecute.
+		                inClass: #RBDummyEmptyClass) primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 1
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveProtocolTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveProtocolTransformationTest.class.st
@@ -9,15 +9,14 @@ RBRemoveProtocolTransformationTest >> testRefactoring [
 
 	| refactoring |
 	refactoring := (RBAddProtocolTransformation
-						protocol: 'transforming'
-						inClass: #RBDummyEmptyClass)
-						transform.
+		                protocol: 'transforming'
+		                inClass: #RBDummyEmptyClass) primitiveExecute.
 	RBRefactoryChangeManager instance performChange: refactoring changes.
 
 	refactoring := (RBRemoveProtocolTransformation
-						protocol: 'transforming'
-						inClass: #RBDummyEmptyClass)
-						asRefactoring transform.
+		                protocol: 'transforming'
+		                inClass: #RBDummyEmptyClass) asRefactoring
+		               primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 1
 ]
@@ -27,15 +26,13 @@ RBRemoveProtocolTransformationTest >> testTransform [
 
 	| transformation |
 	transformation := (RBAddProtocolTransformation
-							protocol: 'transforming'
-							inClass: #RBDummyEmptyClass)
-							transform.
+		                   protocol: 'transforming'
+		                   inClass: #RBDummyEmptyClass) primitiveExecute.
 
 	transformation := (RBRemoveProtocolTransformation
-							model: transformation model
-							protocol: 'transforming'
-							inClass: #RBDummyEmptyClass)
-							transform.
+		                   model: transformation model
+		                   protocol: 'transforming'
+		                   inClass: #RBDummyEmptyClass) primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 2
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveReturnStatementTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveReturnStatementTransformationTest.class.st
@@ -23,20 +23,18 @@ RBRemoveReturnStatementTransformationTest >> methodBefore [
 RBRemoveReturnStatementTransformationTest >> testClassDoesNotExist [
 
 	self shouldFail: (RBRemoveReturnStatementTransformation
-							return: '^ variable'
-							inMethod: #methodBefore
-							inClass: #RBReturnStatementTransformationTest)
-							asRefactoring
+			 return: '^ variable'
+			 inMethod: #methodBefore
+			 inClass: #RBReturnStatementTransformationTest)
 ]
 
 { #category : #tests }
 RBRemoveReturnStatementTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBRemoveReturnStatementTransformation
-							return: '^ variable'
-							inMethod: #method
-							inClass: #RBRemoveReturnStatementTransformationTest)
-							asRefactoring
+			 return: '^ variable'
+			 inMethod: #method
+			 inClass: #RBRemoveReturnStatementTransformationTest)
 ]
 
 { #category : #tests }
@@ -47,7 +45,7 @@ RBRemoveReturnStatementTransformationTest >> testRefactoring [
 		                return: '^ variable'
 		                inMethod: #methodBefore
 		                inClass: #RBRemoveReturnStatementTransformationTest)
-		               asRefactoring primitiveExecute.
+		               primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 1.
 
@@ -62,10 +60,9 @@ RBRemoveReturnStatementTransformationTest >> testRefactoring [
 RBRemoveReturnStatementTransformationTest >> testReturnDoesNotExist [
 
 	self shouldFail: (RBRemoveReturnStatementTransformation
-							return: '^ variable'
-							inMethod: #methodAfter
-							inClass: #RBRemoveReturnStatementTransformationTest)
-							asRefactoring
+			 return: '^ variable'
+			 inMethod: #methodAfter
+			 inClass: #RBRemoveReturnStatementTransformationTest)
 ]
 
 { #category : #tests }

--- a/src/Refactoring2-Transformations-Tests/RBRemoveReturnStatementTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveReturnStatementTransformationTest.class.st
@@ -44,16 +44,18 @@ RBRemoveReturnStatementTransformationTest >> testRefactoring [
 
 	| refactoring class |
 	refactoring := (RBRemoveReturnStatementTransformation
-						return: '^ variable'
-						inMethod: #methodBefore
-						inClass: #RBRemoveReturnStatementTransformationTest)
-						asRefactoring transform.
+		                return: '^ variable'
+		                inMethod: #methodBefore
+		                inClass: #RBRemoveReturnStatementTransformationTest)
+		               asRefactoring primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 1.
 
-	class := refactoring model classNamed: #RBRemoveReturnStatementTransformationTest.
-	self assert: (class parseTreeForSelector: #methodBefore) body
-			equals: (class parseTreeForSelector: #methodAfter) body
+	class := refactoring model classNamed:
+		         #RBRemoveReturnStatementTransformationTest.
+	self
+		assert: (class parseTreeForSelector: #methodBefore) body
+		equals: (class parseTreeForSelector: #methodAfter) body
 ]
 
 { #category : #tests }
@@ -71,14 +73,14 @@ RBRemoveReturnStatementTransformationTest >> testTransform [
 
 	| transformation class |
 	transformation := (RBRemoveReturnStatementTransformation new
-		return: '^ variable'
-		inMethod: #methodBefore
-		inClass: self class name)
-		transform.
+		                   return: '^ variable'
+		                   inMethod: #methodBefore
+		                   inClass: self class name) primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 
 	class := transformation model classNamed: self class name.
-	self assert: (class parseTreeForSelector: #methodBefore) body
-			equals: (class parseTreeForSelector: #methodAfter) body
+	self
+		assert: (class parseTreeForSelector: #methodBefore) body
+		equals: (class parseTreeForSelector: #methodAfter) body
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveSubtreeTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveSubtreeTransformationTest.class.st
@@ -33,43 +33,60 @@ RBRemoveSubtreeTransformationTest >> testRefactoring [
 
 	| transformation class |
 	transformation := (RBRemoveSubtreeTransformation
-							code: 'selector := aSelector'
-							from: #selector:from:
-							in: #RBRemoveMethodTransformation)
-							asRefactoring transform.
+		                   code: 'selector := aSelector'
+		                   from: #selector:from:
+		                   in: #RBRemoveMethodTransformation) asRefactoring
+		                  primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 
-	class := transformation model classNamed: #RBRemoveMethodTransformation.
+	class := transformation model classNamed:
+		         #RBRemoveMethodTransformation.
 	self assert: (class directlyDefinesMethod: #selector:from:).
-	self assert: (class parseTreeForSelector: #selector:from:) body statements size equals: 1
+	self
+		assert:
+		(class parseTreeForSelector: #selector:from:) body statements size
+		equals: 1
 ]
 
 { #category : #tests }
 RBRemoveSubtreeTransformationTest >> testTransform [
+
 	| transformation class |
-	transformation := (RBRemoveSubtreeTransformation code: '^ 1' from: #one in: self changeMockClass name) transform.
+	transformation := (RBRemoveSubtreeTransformation
+		                   code: '^ 1'
+		                   from: #one
+		                   in: self changeMockClass name) primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 
-	class := transformation model classNamed: self changeMockClass name asSymbol.
+	class := transformation model classNamed:
+		         self changeMockClass name asSymbol.
 	self assert: (class directlyDefinesMethod: #one).
 	self assertEmpty: (class parseTreeForSelector: #one) body statements
 ]
 
 { #category : #tests }
 RBRemoveSubtreeTransformationTest >> testTransformNotSequenceNode [
+
 	| transformation class |
-	transformation := RBCompositeTransformation new
-		transformations:
-			(OrderedCollection
-				with: (RBAddMethodTransformation sourceCode: 'printString1 super printString' in: self changeMockClass name withProtocols: {#accessing})
-				with: (RBRemoveSubtreeTransformation code: 'super printString' from: #printString1 in: self changeMockClass name)).
-	transformation transform.
+	transformation := RBCompositeTransformation new transformations:
+		                  (OrderedCollection
+			                   with: (RBAddMethodTransformation
+					                    sourceCode: 'printString1 super printString'
+					                    in: self changeMockClass name
+					                    withProtocols: { #accessing })
+			                   with: (RBRemoveSubtreeTransformation
+					                    code: 'super printString'
+					                    from: #printString1
+					                    in: self changeMockClass name)).
+	transformation primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 2.
 
-	class := transformation model classNamed: self changeMockClass name asSymbol.
+	class := transformation model classNamed:
+		         self changeMockClass name asSymbol.
 	self assert: (class directlyDefinesMethod: #printString1).
-	self assertEmpty: (class parseTreeForSelector: #printString1) body statements
+	self assertEmpty:
+		(class parseTreeForSelector: #printString1) body statements
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveSubtreeTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveSubtreeTransformationTest.class.st
@@ -6,26 +6,44 @@ Class {
 
 { #category : #tests }
 RBRemoveSubtreeTransformationTest >> testEmptyCode [
-	
-	self shouldFail: (RBRemoveSubtreeTransformation code: '' from: #one in: self changeMockClass name).
 
-	self shouldFail: (RBRemoveSubtreeTransformation code: '' from: #selector:from: in: #RBRemoveMethodTransformation) asRefactoring
+	self shouldFail: (RBRemoveSubtreeTransformation
+			 code: ''
+			 from: #one
+			 in: self changeMockClass name).
+
+	self shouldFail: (RBRemoveSubtreeTransformation
+			 code: ''
+			 from: #selector:from:
+			 in: #RBRemoveMethodTransformation)
 ]
 
 { #category : #tests }
 RBRemoveSubtreeTransformationTest >> testFailureExtract [
-	
-	self shouldFail: (RBRemoveSubtreeTransformation code: ':= anInterval' from: #one in: self changeMockClass name).
 
-	self shouldFail: (RBRemoveSubtreeTransformation code: ':= aSelector' from: #selector:from: in: #RBRemoveMethodTransformation) asRefactoring
+	self shouldFail: (RBRemoveSubtreeTransformation
+			 code: ':= anInterval'
+			 from: #one
+			 in: self changeMockClass name).
+
+	self shouldFail: (RBRemoveSubtreeTransformation
+			 code: ':= aSelector'
+			 from: #selector:from:
+			 in: #RBRemoveMethodTransformation)
 ]
 
 { #category : #tests }
 RBRemoveSubtreeTransformationTest >> testMethodDoesNotExist [
-	
-	self shouldFail: (RBRemoveSubtreeTransformation code: 'selector := aSelector' from: #two in: self changeMockClass name).
 
-	self shouldFail: (RBRemoveSubtreeTransformation code: 'selector := aSelector' from: #selector:for: in: #RBRemoveMethodTransformation) asRefactoring
+	self shouldFail: (RBRemoveSubtreeTransformation
+			 code: 'selector := aSelector'
+			 from: #two
+			 in: self changeMockClass name).
+
+	self shouldFail: (RBRemoveSubtreeTransformation
+			 code: 'selector := aSelector'
+			 from: #selector:for:
+			 in: #RBRemoveMethodTransformation)
 ]
 
 { #category : #tests }
@@ -35,7 +53,7 @@ RBRemoveSubtreeTransformationTest >> testRefactoring [
 	transformation := (RBRemoveSubtreeTransformation
 		                   code: 'selector := aSelector'
 		                   from: #selector:from:
-		                   in: #RBRemoveMethodTransformation) asRefactoring
+		                   in: #RBRemoveMethodTransformation)
 		                  primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.

--- a/src/Refactoring2-Transformations-Tests/RBRemoveTemporaryVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveTemporaryVariableTransformationTest.class.st
@@ -29,28 +29,32 @@ RBRemoveTemporaryVariableTransformationTest >> testRefactoring [
 
 	| refactoring class |
 	refactoring := (RBAddMethodTransformation
-						sourceCode: 'foo
+		                sourceCode: 'foo
 										| temp bar |
 										bar := 5.
 										temp := bar * bar.
 										Transcript show: temp printString; cr.
 										^temp * temp'
-						in: #RBRemoveTemporaryVariableTransformationTest
-						withProtocols: {#accessing})
-						asRefactoring transform.
+		                in: #RBRemoveTemporaryVariableTransformationTest
+		                withProtocols: { #accessing }) asRefactoring
+		               primitiveExecute.
 
 	refactoring := (RBRemoveTemporaryVariableTransformation
-						model: refactoring model
-						variable: 'temp'
-						inMethod: #foo
-						inClass: #RBRemoveTemporaryVariableTransformationTest)
-						asRefactoring transform.
+		                model: refactoring model
+		                variable: 'temp'
+		                inMethod: #foo
+		                inClass:
+		                #RBRemoveTemporaryVariableTransformationTest)
+		               asRefactoring primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 2.
 
-	class := refactoring model classNamed: #RBRemoveTemporaryVariableTransformationTest.
+	class := refactoring model classNamed:
+		         #RBRemoveTemporaryVariableTransformationTest.
 	self assert: (class directlyDefinesMethod: #foo).
-	self assert: (class parseTreeForSelector: #foo) temporaries size equals: 1
+	self
+		assert: (class parseTreeForSelector: #foo) temporaries size
+		equals: 1
 ]
 
 { #category : #tests }
@@ -58,28 +62,29 @@ RBRemoveTemporaryVariableTransformationTest >> testTransform [
 
 	| transformation class |
 	transformation := (RBAddMethodTransformation
-					sourceCode: 'foo
+		                   sourceCode: 'foo
 									| temp bar |
 									bar := 5.
 									temp := bar * bar.
 									Transcript show: temp printString; cr.
 									^temp * temp'
-					in: self changeMockClass name
-					withProtocols: {#accessing})
-					transform.
+		                   in: self changeMockClass name
+		                   withProtocols: { #accessing }) primitiveExecute.
 
 	transformation := (RBRemoveTemporaryVariableTransformation
-				model: transformation model
-				variable: 'temp'
-				inMethod: #foo
-				inClass: self changeMockClass name)
-				transform.
+		                   model: transformation model
+		                   variable: 'temp'
+		                   inMethod: #foo
+		                   inClass: self changeMockClass name)
+		                  primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 2.
 
 	class := transformation model classNamed: self changeMockClass name.
 	self assert: (class directlyDefinesMethod: #one).
-	self assert: (class parseTreeForSelector: #foo) temporaries size equals: 1
+	self
+		assert: (class parseTreeForSelector: #foo) temporaries size
+		equals: 1
 ]
 
 { #category : #tests }

--- a/src/Refactoring2-Transformations-Tests/RBRemoveTemporaryVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveTemporaryVariableTransformationTest.class.st
@@ -8,20 +8,18 @@ Class {
 RBRemoveTemporaryVariableTransformationTest >> testClassDoesNotExist [
 
 	self shouldFail: (RBRemoveTemporaryVariableTransformation
-							variable: 'temp'
-							inMethod: #foo
-							inClass: #RBTemporaryVariableTransformationTest)
-							asRefactoring
+			 variable: 'temp'
+			 inMethod: #foo
+			 inClass: #RBTemporaryVariableTransformationTest)
 ]
 
 { #category : #tests }
 RBRemoveTemporaryVariableTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBRemoveTemporaryVariableTransformation
-							variable: 'temp'
-							inMethod: #foofoo
-							inClass: #RBRemoveTemporaryVariableTransformationTest)
-							asRefactoring
+			 variable: 'temp'
+			 inMethod: #foofoo
+			 inClass: #RBRemoveTemporaryVariableTransformationTest)
 ]
 
 { #category : #tests }
@@ -36,8 +34,7 @@ RBRemoveTemporaryVariableTransformationTest >> testRefactoring [
 										Transcript show: temp printString; cr.
 										^temp * temp'
 		                in: #RBRemoveTemporaryVariableTransformationTest
-		                withProtocols: { #accessing }) asRefactoring
-		               primitiveExecute.
+		                withProtocols: { #accessing }) primitiveExecute.
 
 	refactoring := (RBRemoveTemporaryVariableTransformation
 		                model: refactoring model
@@ -45,7 +42,7 @@ RBRemoveTemporaryVariableTransformationTest >> testRefactoring [
 		                inMethod: #foo
 		                inClass:
 		                #RBRemoveTemporaryVariableTransformationTest)
-		               asRefactoring primitiveExecute.
+		               primitiveExecute.
 
 	self assert: refactoring model changes changes size equals: 2.
 
@@ -91,8 +88,7 @@ RBRemoveTemporaryVariableTransformationTest >> testTransform [
 RBRemoveTemporaryVariableTransformationTest >> testVariableDoesNotExist [
 
 	self shouldFail: (RBRemoveTemporaryVariableTransformation
-							variable: 'temp123'
-							inMethod: #foo
-							inClass: #RBRemoveTemporaryVariableTransformationTest)
-							asRefactoring
+			 variable: 'temp123'
+			 inMethod: #foo
+			 inClass: #RBRemoveTemporaryVariableTransformationTest)
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRenameAndDeprecateClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameAndDeprecateClassTransformationTest.class.st
@@ -6,13 +6,17 @@ Class {
 
 { #category : #tests }
 RBRenameAndDeprecateClassTransformationTest >> testTransform [
+
 	| transformation class |
-	transformation := (RBRenameAndDeprecateClassTransformation rename: self changeMockClass name to: #RBRefactoringChangeMock2) transform.
+	transformation := (RBRenameAndDeprecateClassTransformation
+		                   rename: self changeMockClass name
+		                   to: #RBRefactoringChangeMock2) primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 10.
 
 	"old class"
-	class := transformation model classNamed: self changeMockClass name asSymbol.
+	class := transformation model classNamed:
+		         self changeMockClass name asSymbol.
 	self deny: class isNil.
 	self assertEmpty: class selectors.
 	self assert: class superclass name equals: #RBRefactoringChangeMock2.
@@ -23,6 +27,7 @@ RBRenameAndDeprecateClassTransformationTest >> testTransform [
 	self denyEmpty: class selectors.
 
 	"temporary class, should not exist"
-	class := transformation model classNamed: #TmpSubclass , self changeMockClass name asSymbol.
+	class := transformation model classNamed:
+		         #TmpSubclass , self changeMockClass name asSymbol.
 	self assert: class isNil
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRenameClassParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameClassParametrizedTest.class.st
@@ -142,24 +142,31 @@ rename class B to A
 -> class A is not marked as removed (model includesClassNamed:#A -> true"
 
 	| addClass renameClass classA classB classC |
-
 	classA := ('RBClass' , 'ToRename') asSymbol.
 	classB := 'TestUnmarkClassRenameSource' asSymbol.
 	classC := 'TestUnmarkClassRenameTarget' asSymbol.
 	addClass := RBInsertNewClassTransformation
-		model: model
-		addClass: classB
-		superclass: #Object
-		subclasses: {}
-		category: self class package name.
+		            model: model
+		            addClass: classB
+		            superclass: #Object
+		            subclasses: {  }
+		            category: self class package name.
 	self executeRefactoring: addClass asRefactoring.
 	self assert: (model includesClassNamed: classA).
-	renameClass := self createRefactoringWithModel: model andArguments: { classA . classC }.
-	self executeRefactoring: renameClass asRefactoring.
+	renameClass := self
+		               createRefactoringWithModel: model
+		               andArguments: {
+				               classA.
+				               classC }.
+	self executeRefactoring: renameClass.
 	self deny: (model includesClassNamed: classA).
 	self assert: (model includesClassNamed: classC).
-	renameClass :=self createRefactoringWithModel: model andArguments: { classB . classA }.
-	self executeRefactoring: renameClass asRefactoring.
+	renameClass := self
+		               createRefactoringWithModel: model
+		               andArguments: {
+				               classB.
+				               classA }.
+	self executeRefactoring: renameClass.
 	self deny: (model includesClassNamed: classB).
 	self assert: (model includesClassNamed: classC).
 	self assert: (model includesClassNamed: classA)

--- a/src/Refactoring2-Transformations-Tests/RBRenameClassParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameClassParametrizedTest.class.st
@@ -151,7 +151,7 @@ rename class B to A
 		            superclass: #Object
 		            subclasses: {  }
 		            category: self class package name.
-	self executeRefactoring: addClass asRefactoring.
+	self executeRefactoring: addClass.
 	self assert: (model includesClassNamed: classA).
 	renameClass := self
 		               createRefactoringWithModel: model

--- a/src/Refactoring2-Transformations-Tests/RBRenameTemporaryParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameTemporaryParametrizedTest.class.st
@@ -113,7 +113,7 @@ RBRenameTemporaryParametrizedTest >> testFailureModelExistingVariable [
 									Transcript show: temp printString; cr.
 									^temp * temp'
 		                   in: self class name
-		                   withProtocols: { #accessing }) transform.
+		                   withProtocols: { #accessing }) primitiveExecute.
 
 	self shouldFail: (self
 			 createRefactoringWithModel: transformation model

--- a/src/Refactoring2-Transformations-Tests/RBRenameVariableParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameVariableParametrizedTest.class.st
@@ -9,9 +9,10 @@ Class {
 
 { #category : #builder }
 RBRenameVariableParametrizedTest >> createRefactoringWithArguments: aParameterCollection [
-	^ (self renameVariableClass
-		perform: constructor
-		withArguments: aParameterCollection , extraArgument) asRefactoring
+
+	^ self renameVariableClass
+		  perform: constructor
+		  withArguments: aParameterCollection , extraArgument
 ]
 
 { #category : #parameterization }

--- a/src/Refactoring2-Transformations-Tests/RBReplaceSubtreeTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBReplaceSubtreeTransformationTest.class.st
@@ -53,18 +53,24 @@ RBReplaceSubtreeTransformationTest >> testRefactoring [
 
 	| transformation class |
 	transformation := (RBReplaceSubtreeTransformation
-							replace: 'selector := aSelector'
-							to: '^ selector'
-							inMethod: #selector:from:
-							inClass: #RBRemoveMethodTransformation)
-							asRefactoring transform.
+		                   replace: 'selector := aSelector'
+		                   to: '^ selector'
+		                   inMethod: #selector:from:
+		                   inClass: #RBRemoveMethodTransformation)
+		                  asRefactoring primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 
-	class := transformation model classNamed: #RBRemoveMethodTransformation.
+	class := transformation model classNamed:
+		         #RBRemoveMethodTransformation.
 	self assert: (class directlyDefinesMethod: #selector:from:).
-	self assert: (class parseTreeForSelector: #selector:from:) body statements size equals: 2.
-	self assert: (class parseTreeForSelector: #selector:from:) body statements last isReturn
+	self
+		assert:
+		(class parseTreeForSelector: #selector:from:) body statements size
+		equals: 2.
+	self assert:
+		(class parseTreeForSelector: #selector:from:) body statements last
+			isReturn
 ]
 
 { #category : #tests }
@@ -72,19 +78,26 @@ RBReplaceSubtreeTransformationTest >> testTransform [
 
 	| transformation class |
 	transformation := (RBReplaceSubtreeTransformation
-							replace: '^ 1'
-							to: '^ 123'
-							inMethod: #one
-							inClass: self changeMockClass name)
-							transform.
+		                   replace: '^ 1'
+		                   to: '^ 123'
+		                   inMethod: #one
+		                   inClass: self changeMockClass name)
+		                  primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 
-	class := transformation model classNamed: self changeMockClass name asSymbol.
+	class := transformation model classNamed:
+		         self changeMockClass name asSymbol.
 	self assert: (class directlyDefinesMethod: #one).
-	self assert: (class parseTreeForSelector: #one) body statements size equals: 1.
-	self assert: (class parseTreeForSelector: #one) body statements first isReturn.
-	self assert: (class parseTreeForSelector: #one) body statements first value value equals: 123
+	self
+		assert: (class parseTreeForSelector: #one) body statements size
+		equals: 1.
+	self assert:
+		(class parseTreeForSelector: #one) body statements first isReturn.
+	self
+		assert:
+		(class parseTreeForSelector: #one) body statements first value value
+		equals: 123
 ]
 
 { #category : #tests }
@@ -92,17 +105,27 @@ RBReplaceSubtreeTransformationTest >> testTransformOneOfManyStatements [
 
 	| transformation class |
 	transformation := (RBReplaceSubtreeTransformation
-		replace: 'self assert: (class parseTreeForSelector:  #selector:from:) body statements size equals: 2'
-		to: 'self assert: (class parseTreeForSelector:  #selector:from:) body statements size = 2'
-		inMethod: #testRefactoring
-		inClass: #RBReplaceSubtreeTransformationTest)
-		asRefactoring transform.
+		                   replace:
+		                   'self assert: (class parseTreeForSelector:  #selector:from:) body statements size equals: 2'
+		                   to:
+		                   'self assert: (class parseTreeForSelector:  #selector:from:) body statements size = 2'
+		                   inMethod: #testRefactoring
+		                   inClass: #RBReplaceSubtreeTransformationTest)
+		                  asRefactoring primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 
-	class := transformation model classNamed: #RBReplaceSubtreeTransformationTest.
+	class := transformation model classNamed:
+		         #RBReplaceSubtreeTransformationTest.
 	self assert: (class directlyDefinesMethod: #testRefactoring).
-	self assert: (class parseTreeForSelector: #testRefactoring) body statements size equals: 6.
-	self assert: ((((class parseTreeForSelector: #testRefactoring) body statements at: 5) sourceCode withBlanksCondensed copyReplaceAll: String cr with: ' ')
-		includesSubstring: 'assert: (class parseTreeForSelector: #selector:from:) body statements size = 2')
+	self
+		assert:
+		(class parseTreeForSelector: #testRefactoring) body statements size
+		equals: 6.
+	self assert:
+		((((class parseTreeForSelector: #testRefactoring) body statements
+			   at: 5) sourceCode withBlanksCondensed
+			  copyReplaceAll: String cr
+			  with: ' ') includesSubstring:
+			 'assert: (class parseTreeForSelector: #selector:from:) body statements size = 2')
 ]

--- a/src/Refactoring2-Transformations-Tests/RBReplaceSubtreeTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBReplaceSubtreeTransformationTest.class.st
@@ -8,44 +8,40 @@ Class {
 RBReplaceSubtreeTransformationTest >> testEmptyCode [
 
 	self shouldFail: (RBReplaceSubtreeTransformation
-							replace: ''
-							to: '^ selector'
-							inMethod: #selector:from:
-							inClass: #RBRemoveMethodTransformation)
-							asRefactoring
+			 replace: ''
+			 to: '^ selector'
+			 inMethod: #selector:from:
+			 inClass: #RBRemoveMethodTransformation)
 ]
 
 { #category : #tests }
 RBReplaceSubtreeTransformationTest >> testFailureExtract [
 
 	self shouldFail: (RBReplaceSubtreeTransformation
-							replace: ':= aSelector'
-							to: '^ selector'
-							inMethod: #selector:from:
-							inClass: #RBRemoveMethodTransformation)
-							asRefactoring
+			 replace: ':= aSelector'
+			 to: '^ selector'
+			 inMethod: #selector:from:
+			 inClass: #RBRemoveMethodTransformation)
 ]
 
 { #category : #tests }
 RBReplaceSubtreeTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBReplaceSubtreeTransformation
-							replace: 'selector := aSelector'
-							to: '^ selector'
-							inMethod: #selector:for:
-							inClass: #RBRemoveMethodTransformation)
-							asRefactoring
+			 replace: 'selector := aSelector'
+			 to: '^ selector'
+			 inMethod: #selector:for:
+			 inClass: #RBRemoveMethodTransformation)
 ]
 
 { #category : #tests }
 RBReplaceSubtreeTransformationTest >> testParseFailure [
 
 	self shouldFail: (RBReplaceSubtreeTransformation
-							replace: 'selector := aSelector'
-							to: ':= 123'
-							inMethod: #selector:from:
-							inClass: #RBRemoveMethodTransformation)
-							asRefactoring
+			 replace: 'selector := aSelector'
+			 to: ':= 123'
+			 inMethod: #selector:from:
+			 inClass: #RBRemoveMethodTransformation)
 ]
 
 { #category : #tests }
@@ -57,7 +53,7 @@ RBReplaceSubtreeTransformationTest >> testRefactoring [
 		                   to: '^ selector'
 		                   inMethod: #selector:from:
 		                   inClass: #RBRemoveMethodTransformation)
-		                  asRefactoring primitiveExecute.
+		                  primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 
@@ -111,7 +107,7 @@ RBReplaceSubtreeTransformationTest >> testTransformOneOfManyStatements [
 		                   'self assert: (class parseTreeForSelector:  #selector:from:) body statements size = 2'
 		                   inMethod: #testRefactoring
 		                   inClass: #RBReplaceSubtreeTransformationTest)
-		                  asRefactoring primitiveExecute.
+		                  primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 

--- a/src/Refactoring2-Transformations-Tests/RBSplitClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBSplitClassTransformationTest.class.st
@@ -31,29 +31,33 @@ RBSplitClassTransformationTest >> testTransform [
 
 	| transformation class |
 	transformation := (RBSplitClassTransformation
-							class: #RBRemoveDirectAccessToVariableTransformation
-							instanceVariables: #(receiver)
-							newClassName: #RBRemoveDirectAccessWithReceiverTransformation
-							referenceVariableName: #newReceiver)
-							transform.
+		                   class:
+		                   #RBRemoveDirectAccessToVariableTransformation
+		                   instanceVariables: #( receiver )
+		                   newClassName:
+		                   #RBRemoveDirectAccessWithReceiverTransformation
+		                   referenceVariableName: #newReceiver)
+		                  primitiveExecute.
 
-	class := transformation model classNamed: #RBRemoveDirectAccessToVariableTransformation.
+	class := transformation model classNamed:
+		         #RBRemoveDirectAccessToVariableTransformation.
 	self deny: (class instanceVariableNames includes: #receiver).
 	self assert: (class instanceVariableNames includes: #newReceiver).
 
-	self assert: (class parseTreeForSelector: #receiver:)
-		  equals: (self parseMethod:
-				'receiver: aString
+	self
+		assert: (class parseTreeForSelector: #receiver:)
+		equals: (self parseMethod: 'receiver: aString
 					newReceiver receiver: aString').
 
-	self assert: (class parseTreeForSelector: #receiver)
-		  equals: (self parseMethod:
-				'receiver
+	self
+		assert: (class parseTreeForSelector: #receiver)
+		equals: (self parseMethod: 'receiver
 					^ newReceiver receiver
-						ifNil: [ self receiver: ', 'self' surroundedBySingleQuotes,
-						'. newReceiver receiver ]').
+						ifNil: [ self receiver: ' , 'self' surroundedBySingleQuotes
+				 , '. newReceiver receiver ]').
 
-	class := transformation model classNamed: #RBRemoveDirectAccessWithReceiverTransformation.
+	class := transformation model classNamed:
+		         #RBRemoveDirectAccessWithReceiverTransformation.
 	self deny: class isNil.
 	self assert: (class instanceVariableNames includes: #receiver).
 	self assert: (class directlyDefinesLocalMethod: #receiver).

--- a/src/Refactoring2-Transformations-Tests/RBSplitClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBSplitClassTransformationTest.class.st
@@ -8,22 +8,20 @@ Class {
 RBSplitClassTransformationTest >> testClassVariable [
 
 	self shouldFail: (RBSplitClassTransformation
-							class:  #RBDummyLintRuleTest
-							instanceVariables: #(Foo1)
-							newClassName: #RBDummyLintRuleTest123
-							referenceVariableName: #receiver)
-							asRefactoring
+			 class: #RBDummyLintRuleTest
+			 instanceVariables: #( Foo1 )
+			 newClassName: #RBDummyLintRuleTest123
+			 referenceVariableName: #receiver)
 ]
 
 { #category : #tests }
 RBSplitClassTransformationTest >> testNonExistantName [
 
 	self shouldFail: (RBSplitClassTransformation
-							class: #RBDummyLintRuleTest
-							instanceVariables: #(name1)
-							newClassName: #RBDummyLintRuleTest123
-							referenceVariableName: #newName)
-							asRefactoring
+			 class: #RBDummyLintRuleTest
+			 instanceVariables: #( name1 )
+			 newClassName: #RBDummyLintRuleTest123
+			 referenceVariableName: #newName)
 ]
 
 { #category : #tests }

--- a/src/Refactoring2-Transformations-Tests/RBTransformationsTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBTransformationsTest.class.st
@@ -308,7 +308,7 @@ RBTransformationsTest >> testRemoveMessageSendTransform [
 		messageSend: #cr
 		inMethod: (#called:, #on:) asSymbol
 		inClass: #RBClassDataForRefactoringTest)
-		transform.
+		primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 

--- a/src/Refactoring2-Transformations-Tests/RBTransformationsTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBTransformationsTest.class.st
@@ -16,9 +16,8 @@ RBTransformationsTest >> testAddClassTransform [
 
 	| transformation class |
 	transformation := (RBAddClassCommentTransformation
-		comment: 'New comment for class'
-		in: self changeMockClass name)
-		transform.
+		                   comment: 'New comment for class'
+		                   in: self changeMockClass name) primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 
@@ -31,15 +30,18 @@ RBTransformationsTest >> testAddMethodCommentTransform [
 
 	| transformation method |
 	transformation := (RBAddMethodCommentTransformation
-		comment: 'New comment for method'
-		inMethod: #one
-		inClass: self changeMockClass name)
-		transform.
+		                   comment: 'New comment for method'
+		                   inMethod: #one
+		                   inClass: self changeMockClass name)
+		                  primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 
-	method := (transformation model classNamed: self changeMockClass name) methodFor: #one.
-	self assert: method ast comments first contents equals: 'New comment for method'
+	method := (transformation model classNamed: self changeMockClass name)
+		          methodFor: #one.
+	self
+		assert: method ast comments first contents
+		equals: 'New comment for method'
 ]
 
 { #category : #tests }
@@ -47,14 +49,14 @@ RBTransformationsTest >> testAddMethodTransform [
 
 	| transformation class |
 	transformation := (RBAddMethodTransformation
-		sourceCode: 'printString1 ^super printString'
-		in: self changeMockClass name
-		withProtocols: {#accessing})
-		transform.
+		                   sourceCode: 'printString1 ^super printString'
+		                   in: self changeMockClass name
+		                   withProtocols: { #accessing }) primitiveExecute.
 
 	class := transformation model classNamed: self changeMockClass name.
-	self assert: (class parseTreeForSelector: #printString1)
-		  equals: (self parseMethod: 'printString1 ^super printString')
+	self
+		assert: (class parseTreeForSelector: #printString1)
+		equals: (self parseMethod: 'printString1 ^super printString')
 ]
 
 { #category : #tests }
@@ -62,9 +64,8 @@ RBTransformationsTest >> testAddProtocolTransform [
 
 	| transformation |
 	transformation := (RBAddProtocolTransformation new
-		protocol: 'transforming'
-		inClass: #RBDummyEmptyClass)
-		transform.
+		                   protocol: 'transforming'
+		                   inClass: #RBDummyEmptyClass) primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1
 ]
@@ -74,32 +75,39 @@ RBTransformationsTest >> testAddTemporaryVariableTransform [
 
 	| transformation class |
 	transformation := (RBAddTemporaryVariableTransformation
-							variable: 'variable'
-							inMethod: #one
-							inClass: self changeMockClass name)
-							transform.
+		                   variable: 'variable'
+		                   inMethod: #one
+		                   inClass: self changeMockClass name)
+		                  primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 
-	class := transformation model classNamed: self changeMockClass name asSymbol.
+	class := transformation model classNamed:
+		         self changeMockClass name asSymbol.
 	self assert: (class directlyDefinesMethod: #one).
-	self assert: (class parseTreeForSelector: #one) temporaries size equals: 1
+	self
+		assert: (class parseTreeForSelector: #one) temporaries size
+		equals: 1
 ]
 
 { #category : #tests }
 RBTransformationsTest >> testAddVariableAccessorTransform [
+
 	| transformation class |
 	transformation := (RBAddVariableAccessorTransformation
-		instanceVariable: 'instVar'
-		class: self changeMockClass name)
-		transform.
+		                   instanceVariable: 'instVar'
+		                   class: self changeMockClass name)
+		                  primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 2.
 
-	class := transformation model classNamed: self changeMockClass name asSymbol.
-	self assert: (class parseTreeForSelector: #instVar)
+	class := transformation model classNamed:
+		         self changeMockClass name asSymbol.
+	self
+		assert: (class parseTreeForSelector: #instVar)
 		equals: (self parseMethod: 'instVar ^instVar').
-	self assert: (class parseTreeForSelector: #instVar:)
+	self
+		assert: (class parseTreeForSelector: #instVar:)
 		equals: (self parseMethod: 'instVar: anObject instVar := anObject')
 ]
 
@@ -108,13 +116,14 @@ RBTransformationsTest >> testAddVariableTransform [
 
 	| transformation class |
 	transformation := (RBAddVariableTransformation
-							instanceVariable: 'asdf'
-							class: self changeMockClass name)
-							transform.
+		                   instanceVariable: 'asdf'
+		                   class: self changeMockClass name)
+		                  primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 
-	class := transformation model classNamed: self changeMockClass name asSymbol.
+	class := transformation model classNamed:
+		         self changeMockClass name asSymbol.
 	self assert: (class directlyDefinesInstanceVariable: 'asdf')
 ]
 
@@ -122,55 +131,58 @@ RBTransformationsTest >> testAddVariableTransform [
 RBTransformationsTest >> testCompositeTransform [
 
 	| transformation newClassName class |
-	newClassName := (self changeMockClass name, 'Temporary') asSymbol.
-	transformation := RBCompositeTransformation new
-		transformations: (OrderedCollection new
-			add: (RBInsertNewClassTransformation
-					addClass: newClassName
-					superclass: #Object
-					subclasses: #()
-					category: self class category);
-			add: (RBAddVariableTransformation
-					instanceVariable: 'asdf'
-					class: newClassName);
-			add: (RBAddMethodTransformation
-					sourceCode: 'printString1 ^super printString'
-					in: newClassName
-					withProtocols: {#accessing});
-			yourself).
-	transformation transform.
+	newClassName := (self changeMockClass name , 'Temporary') asSymbol.
+	transformation := RBCompositeTransformation new transformations:
+		                  (OrderedCollection new
+			                   add: (RBInsertNewClassTransformation
+					                    addClass: newClassName
+					                    superclass: #Object
+					                    subclasses: #(  )
+					                    category: self class category);
+			                   add: (RBAddVariableTransformation
+					                    instanceVariable: 'asdf'
+					                    class: newClassName);
+			                   add: (RBAddMethodTransformation
+					                    sourceCode: 'printString1 ^super printString'
+					                    in: newClassName
+					                    withProtocols: { #accessing });
+			                   yourself).
+	transformation primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 3.
 
-	class := transformation model classNamed: (self changeMockClass name, 'Temporary') asSymbol.
+	class := transformation model classNamed:
+		         (self changeMockClass name , 'Temporary') asSymbol.
 	self assert: (class directlyDefinesInstanceVariable: 'asdf').
-	self assert: (class parseTreeForSelector: #printString1)
-		  equals: (self parseMethod: 'printString1 ^super printString')
+	self
+		assert: (class parseTreeForSelector: #printString1)
+		equals: (self parseMethod: 'printString1 ^super printString')
 ]
 
 { #category : #tests }
 RBTransformationsTest >> testCustomTransform [
 
 	| transformation newClassName class |
-	newClassName := (self changeMockClass name, 'Temporary') asSymbol.
-	transformation := RBCustomTransformation with: [ :aModel |
-		"add class"
-		aModel
-			defineClass: ('<1p> %<%< #<2s>
+	newClassName := (self changeMockClass name , 'Temporary') asSymbol.
+	transformation := RBCustomTransformation with: [ :aModel | "add class"
+		                  aModel defineClass: ('<1p> %<%< #<2s>
 				package: <3p>'
-			expandMacrosWith: 'Object'
-			with: newClassName
-			with: self class category).
+				                   expandMacrosWith: 'Object'
+				                   with: newClassName
+				                   with: self class category).
 
-		"add a comment in the class description"
-		(aModel classNamed: newClassName) comment: 'Deprecated!!! Use super class'.
-		"add an instance variable"
-		(aModel classNamed: newClassName) addInstanceVariable: 'asdf' ].
+		                  "add a comment in the class description"
+		                  (aModel classNamed: newClassName) comment:
+			                  'Deprecated!!! Use super class'.
+		                  "add an instance variable"
+		                  (aModel classNamed: newClassName)
+			                  addInstanceVariable: 'asdf' ].
 
-	transformation transform.
+	transformation primitiveExecute.
 	self assert: transformation model changes changes size equals: 3.
 
-	class := transformation model classNamed: (self changeMockClass name, 'Temporary') asSymbol.
+	class := transformation model classNamed:
+		         (self changeMockClass name , 'Temporary') asSymbol.
 	self assert: (class directlyDefinesInstanceVariable: 'asdf')
 ]
 
@@ -178,24 +190,28 @@ RBTransformationsTest >> testCustomTransform [
 RBTransformationsTest >> testDeprecateClassTransform [
 
 	| transformation class |
-	transformation := (RBDeprecateClassTransformation
-							class: self changeMockClass name)
-							transform.
+	transformation := (RBDeprecateClassTransformation class:
+		                   self changeMockClass name) primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 4.
 
-	class := transformation model classNamed: self changeMockClass name asSymbol.
+	class := transformation model classNamed:
+		         self changeMockClass name asSymbol.
 	self assert: class comment equals: 'Deprecated!!! Use superclass'.
 
-	class := transformation model metaclassNamed: self changeMockClass name.
+	class := transformation model metaclassNamed:
+		         self changeMockClass name.
 
-	self assert: (class parseTreeForSelector: #new)
+	self
+		assert: (class parseTreeForSelector: #new)
 		equals: (self parseMethod: 'new
 				self deprecated: ''Use superclass '' on: ''4 May 2016''  in: #Pharo60.
 				^ super new').
-	self assert: (class parseTreeForSelector: #deprecated)
+	self
+		assert: (class parseTreeForSelector: #deprecated)
 		equals: (self parseMethod: 'deprecated ^ true').
-	self assert: (class parseTreeForSelector: #systemIcon)
+	self
+		assert: (class parseTreeForSelector: #systemIcon)
 		equals: (self parseMethod: 'systemIcon
 				^ Smalltalk ui icons iconNamed: #packageDelete')
 ]
@@ -210,21 +226,23 @@ RBTransformationsTest >> testMoveInstanceVariableToClassTransform [
 				package: #''Refactory-Test data'''.
 
 	transformation := RBMoveInstanceVariableToClassTransformation
-							model: model
-							variable: 'asdf'
-							fromClass: #FOOBAR
-							toClass: self changeMockClass name.
+		                  model: model
+		                  variable: 'asdf'
+		                  fromClass: #FOOBAR
+		                  toClass: self changeMockClass name.
 
 	oldClass := transformation model classNamed: #FOOBAR.
-	newClass := transformation model classNamed: self changeMockClass name asSymbol.
+	newClass := transformation model classNamed:
+		            self changeMockClass name asSymbol.
 	self assert: (oldClass directlyDefinesInstanceVariable: 'asdf').
 	self deny: (newClass directlyDefinesInstanceVariable: 'asdf').
 
-	transformation transform.
+	transformation primitiveExecute.
 	self assert: transformation model changes changes size equals: 3.
 
 	oldClass := transformation model classNamed: #FOOBAR.
-	newClass := transformation model classNamed: self changeMockClass name asSymbol.
+	newClass := transformation model classNamed:
+		            self changeMockClass name asSymbol.
 	self deny: (oldClass directlyDefinesInstanceVariable: 'asdf').
 	self assert: (newClass directlyDefinesInstanceVariable: 'asdf')
 ]
@@ -234,17 +252,19 @@ RBTransformationsTest >> testPullUpVariableTransform [
 
 	| transformation |
 	transformation := (RBPullUpVariableTransformation
-							instanceVariable: 'result'
-							class: #RBDummyLintRuleTest)
-							transform.
+		                   instanceVariable: 'result'
+		                   class: #RBDummyLintRuleTest) primitiveExecute.
 
-	self assert: ((transformation model classNamed: #RBDummyLintRuleTest)
-			directlyDefinesInstanceVariable: 'result').
+	self assert:
+		((transformation model classNamed: #RBDummyLintRuleTest)
+			 directlyDefinesInstanceVariable: 'result').
 
-	self deny: ((transformation model classNamed: #RBBasicDummyLintRuleTest)
-			directlyDefinesInstanceVariable: 'result').
-	self deny: ((transformation model classNamed: #RBFooDummyLintRuleTest)
-			directlyDefinesInstanceVariable: 'result')
+	self deny:
+		((transformation model classNamed: #RBBasicDummyLintRuleTest)
+			 directlyDefinesInstanceVariable: 'result').
+	self deny:
+		((transformation model classNamed: #RBFooDummyLintRuleTest)
+			 directlyDefinesInstanceVariable: 'result')
 ]
 
 { #category : #tests }
@@ -252,28 +272,32 @@ RBTransformationsTest >> testPushDownVariableTransform [
 
 	| transformation |
 	transformation := (RBPushDownVariableTransformation
-							instanceVariable: 'foo1'
-							class: #RBDummyLintRuleTest)
-							transform.
+		                   instanceVariable: 'foo1'
+		                   class: #RBDummyLintRuleTest) primitiveExecute.
 
-	(transformation model classNamed: #RBDummyLintRuleTest)
-	subclasses do: [ :each | self assert: (each directlyDefinesInstanceVariable: 'foo1') ]
+	(transformation model classNamed: #RBDummyLintRuleTest) subclasses
+		do: [ :each |
+		self assert: (each directlyDefinesInstanceVariable: 'foo1') ]
 ]
 
 { #category : #tests }
 RBTransformationsTest >> testRemoveClassTransform [
 
 	| transformation newClass superclass |
-	transformation := (RBRemoveClassTransformation
-							className: self changeMockClass name)
-							transform.
+	transformation := (RBRemoveClassTransformation className:
+		                   self changeMockClass name) primitiveExecute.
 	self assert: transformation model changes changes size equals: 1.
-	newClass := transformation model classNamed: self changeMockClass name asSymbol.
+	newClass := transformation model classNamed:
+		            self changeMockClass name asSymbol.
 	superclass := transformation model classNamed: #Object.
 	self assert: newClass isNil.
 	newClass := self changeMockClass name.
-	self assert: ((superclass subclasses collect: [:each | each name]) includes: newClass) not.
-	self assert: ((superclass classSide subclasses collect: [:each | each name]) includes: newClass) not
+	self assert:
+		((superclass subclasses collect: [ :each | each name ]) includes:
+			 newClass) not.
+	self assert:
+		((superclass classSide subclasses collect: [ :each | each name ])
+			 includes: newClass) not
 ]
 
 { #category : #tests }
@@ -300,13 +324,13 @@ RBTransformationsTest >> testRemoveMethodTransform [
 
 	| transformation class |
 	transformation := (RBRemoveMethodTransformation
-		selector: #one
-		from: self changeMockClass name)
-		transform.
+		                   selector: #one
+		                   from: self changeMockClass name) primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 
-	class := transformation model classNamed: self changeMockClass name asSymbol.
+	class := transformation model classNamed:
+		         self changeMockClass name asSymbol.
 	self deny: (class directlyDefinesMethod: #one)
 ]
 
@@ -315,13 +339,14 @@ RBTransformationsTest >> testRemoveVariableTransform [
 
 	| transformation class |
 	transformation := (RBRemoveVariableTransformation
-							instanceVariable: 'instVar'
-							class: self changeMockClass name)
-							transform.
+		                   instanceVariable: 'instVar'
+		                   class: self changeMockClass name)
+		                  primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 1.
 
-	class := transformation model classNamed: self changeMockClass name asSymbol.
+	class := transformation model classNamed:
+		         self changeMockClass name asSymbol.
 	self deny: (class directlyDefinesInstanceVariable: 'instVar')
 ]
 
@@ -332,27 +357,32 @@ RBTransformationsTest >> testRenameClassTransform [
 	newClassName := #RBNewDummyClassName.
 	oldClassName := RBClassToRename name asSymbol.
 	transformation := (RBRenameClassTransformation
-							rename: oldClassName
-							to: newClassName)
-							transform.
+		                   rename: oldClassName
+		                   to: newClassName) primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 6.
 
 	class := transformation model classNamed: newClassName.
-	self assert: (class parseTreeForSelector: #method1)
-		  equals: (self parseMethod: 'method1 ^ self method2').
-		
+	self
+		assert: (class parseTreeForSelector: #method1)
+		equals: (self parseMethod: 'method1 ^ self method2').
+
 	self deny: (transformation model includesClassNamed: oldClassName).
 
-	class := transformation model classNamed: RBSubclassOfClassToRename name asSymbol.
-	
-	self assert: class superclass
-		  equals: (transformation model classNamed: 'RBNewDummyClassName' asSymbol).
-		
-	self assert: (class parseTreeForSelector: #symbolReference)
-		  equals: (self parseMethod: 'symbolReference ^ #RBNewDummyClassName').
-	self assert: (class parseTreeForSelector: #reference)
-		  equals: (self parseMethod: 'reference ^ RBNewDummyClassName new')
+	class := transformation model classNamed:
+		         RBSubclassOfClassToRename name asSymbol.
+
+	self
+		assert: class superclass
+		equals:
+		(transformation model classNamed: 'RBNewDummyClassName' asSymbol).
+
+	self
+		assert: (class parseTreeForSelector: #symbolReference)
+		equals: (self parseMethod: 'symbolReference ^ #RBNewDummyClassName').
+	self
+		assert: (class parseTreeForSelector: #reference)
+		equals: (self parseMethod: 'reference ^ RBNewDummyClassName new')
 ]
 
 { #category : #tests }
@@ -360,29 +390,32 @@ RBTransformationsTest >> testRenameTemporaryTransform [
 
 	| transformation class |
 	transformation := (RBAddMethodTransformation
-							sourceCode: 'foo
+		                   sourceCode: 'foo
 									| temp bar |
 									bar := 5.
 									temp := bar * bar.
 									Transcript show: temp printString; cr.
 									^temp * temp'
-							in: self changeMockClass name
-							withProtocols: {#accessing})
-							transform.
+		                   in: self changeMockClass name
+		                   withProtocols: { #accessing }) primitiveExecute.
 
 	transformation := (RBRenameTemporaryVariableTransformation
-							model: transformation model
-							rename: #temp to: #temp2
-							in: self changeMockClass name
-							selector: #foo)
-							transform.
+		                   model: transformation model
+		                   rename: #temp
+		                   to: #temp2
+		                   in: self changeMockClass name
+		                   selector: #foo) primitiveExecute.
 
 	self assert: transformation model changes changes size equals: 2.
 
 	class := transformation model classNamed: self changeMockClass name.
 	self assert: (class directlyDefinesMethod: #foo).
-	self assert: (class parseTreeForSelector: #foo) temporaries size equals: 2.
-	self assert: ((class parseTreeForSelector: #foo) temporaries anySatisfy: [ :e | e name = #temp2 ])
+	self
+		assert: (class parseTreeForSelector: #foo) temporaries size
+		equals: 2.
+	self assert:
+		((class parseTreeForSelector: #foo) temporaries anySatisfy: [ :e |
+			 e name = #temp2 ])
 ]
 
 { #category : #tests }
@@ -390,21 +423,21 @@ RBTransformationsTest >> testRenameVariableTransform [
 
 	| transformation class |
 	transformation := (RBRenameVariableTransformation
-							rename: 'classBlock' to: 'asdf'
-							in: #RBBasicLintRuleTestData
-							classVariable: false)
-							transform.
+		                   rename: 'classBlock'
+		                   to: 'asdf'
+		                   in: #RBBasicLintRuleTestData
+		                   classVariable: false) primitiveExecute.
 
 	class := transformation model classNamed: #RBBasicLintRuleTestData.
 	self assert: (class directlyDefinesInstanceVariable: 'asdf').
 	self deny: (class directlyDefinesInstanceVariable: 'classBlock').
-	self assert: (class parseTreeForSelector: #checkClass:)
-		  equals: (self parseMethod:
-				'checkClass: aSmalllintContext
+	self
+		assert: (class parseTreeForSelector: #checkClass:)
+		equals: (self parseMethod: 'checkClass: aSmalllintContext
 					^asdf value: aSmalllintContext value: result').
-	self assert: (class parseTreeForSelector: #initialize)
-		  equals: (self parseMethod:
-				'initialize
+	self
+		assert: (class parseTreeForSelector: #initialize)
+		equals: (self parseMethod: 'initialize
 					super initialize.
 					self anInstVar: 1.
 					asdf := [:context :aResult | ].

--- a/src/Refactoring2-Transformations-Tests/RBWithDifferentConstructorsParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBWithDifferentConstructorsParametrizedTest.class.st
@@ -15,14 +15,14 @@ RBWithDifferentConstructorsParametrizedTest >> constructor: anObject [
 
 { #category : #builder }
 RBWithDifferentConstructorsParametrizedTest >> createRefactoringWithArguments: aParameterCollection [
-	^ (rbClass
-		perform: constructor
-		withArguments: aParameterCollection) asRefactoring
+
+	^ rbClass perform: constructor withArguments: aParameterCollection
 ]
 
 { #category : #builder }
 RBWithDifferentConstructorsParametrizedTest >> createRefactoringWithModel: rbNamespace andArguments: aParameterCollection [
-	^ (rbClass
-		perform: #model: , constructor
-		withArguments: {rbNamespace}, aParameterCollection) asRefactoring
+
+	^ rbClass
+		  perform: #model: , constructor
+		  withArguments: { rbNamespace } , aParameterCollection
 ]

--- a/src/Refactoring2-Transformations-Tests/RBWithDifferentsArgumentsParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBWithDifferentsArgumentsParametrizedTest.class.st
@@ -9,17 +9,20 @@ Class {
 
 { #category : #builder }
 RBWithDifferentsArgumentsParametrizedTest >> createRefactoringWithArguments: aParameterCollection [
-	^ (rbClass
-		perform: constructor
-		withArguments: (self selectIndex: index of: aParameterCollection)) asRefactoring
+
+	^ rbClass
+		  perform: constructor
+		  withArguments: (self selectIndex: index of: aParameterCollection)
 ]
 
 { #category : #builder }
 RBWithDifferentsArgumentsParametrizedTest >> createRefactoringWithModel: rbNamespace andArguments: aParameterCollection [
-	^ (rbClass
-		perform: #model: , constructor
-		withArguments: {rbNamespace},
-			(self selectIndex: index of: aParameterCollection)) asRefactoring
+
+	^ rbClass
+		  perform: #model: , constructor
+		  withArguments:
+		  { rbNamespace }
+		  , (self selectIndex: index of: aParameterCollection)
 ]
 
 { #category : #accessing }

--- a/src/Refactoring2-Transformations/RBAbstractVariablesTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBAbstractVariablesTransformation.class.st
@@ -40,28 +40,30 @@ RBAbstractVariablesTransformation class >> model: aRBSmalltalk abstractVariables
 
 { #category : #executing }
 RBAbstractVariablesTransformation >> abstractClassVariable: aString [
+
 	| transformation rewriter nonMetaClass |
 	nonMetaClass := fromClass instanceSide.
 	transformation := (RBAddVariableAccessorTransformation
-		model: self model
-		variable: aString
-		class: nonMetaClass
-		classVariable: true)
-		transform.
+		                   model: self model
+		                   variable: aString
+		                   class: nonMetaClass
+		                   classVariable: true) primitiveExecute.
 	rewriter := self parseTreeRewriter.
 	fromClass isMeta
-		ifTrue:
-			[ rewriter
+		ifTrue: [
+			rewriter
 				replace: aString , ' := ``@object'
-					with: ('self <1s> ``@object' expandMacrosWith: transformation setterMethod);
-				replace: aString
-					with: 'self ' , transformation getterMethod ]
-		ifFalse:
-			[ rewriter
+				with:
+					('self <1s> ``@object' expandMacrosWith:
+							 transformation setterMethod);
+				replace: aString with: 'self ' , transformation getterMethod ]
+		ifFalse: [
+			rewriter
 				replace: aString , ' := ``@object'
-					with: ('self class <1s> ``@object' expandMacrosWith: transformation setterMethod);
+				with: ('self class <1s> ``@object' expandMacrosWith:
+							 transformation setterMethod);
 				replace: aString
-					with: 'self class ' , transformation getterMethod ].
+				with: 'self class ' , transformation getterMethod ].
 	(rewriter executeTree: tree) ifTrue: [ tree := rewriter tree ]
 ]
 
@@ -79,19 +81,21 @@ RBAbstractVariablesTransformation >> abstractClassVariables [
 
 { #category : #executing }
 RBAbstractVariablesTransformation >> abstractInstanceVariable: aString [
+
 	| transformation rewriter |
 	transformation := (RBAddVariableAccessorTransformation
-		model: self model
-		variable: aString
-		class: fromClass
-		classVariable: false)
-		transform.
+		                   model: self model
+		                   variable: aString
+		                   class: fromClass
+		                   classVariable: false) primitiveExecute.
 	rewriter := self parseTreeRewriter.
 	rewriter
 		replace: aString , ' := ``@object'
-			with: ('self <1s> ``@object' expandMacrosWith: transformation setterMethod);
+		with:
+			('self <1s> ``@object' expandMacrosWith:
+					 transformation setterMethod);
 		replace: aString with: 'self ' , transformation getterMethod.
-	(rewriter executeTree: tree) ifTrue: [tree := rewriter tree]
+	(rewriter executeTree: tree) ifTrue: [ tree := rewriter tree ]
 ]
 
 { #category : #executing }
@@ -112,14 +116,14 @@ RBAbstractVariablesTransformation >> abstractVariablesIn: aBRProgramNode from: f
 	| poolTransformation |
 	tree := aBRProgramNode.
 	fromClass := self model classObjectFor: fromBehavior.
-	toClasses := behaviorCollection collect: [ :each | self model classObjectFor: each ].
+	toClasses := behaviorCollection collect: [ :each |
+		             self model classObjectFor: each ].
 	ignore := aVariableName.
 	poolTransformation := (RBExpandReferencedPoolsTransformation
-				model: self model
-				forMethod: tree
-				fromClass: fromClass
-				toClasses: toClasses)
-				transform.
+		                       model: self model
+		                       forMethod: tree
+		                       fromClass: fromClass
+		                       toClasses: toClasses) primitiveExecute.
 	self computeVariablesToAbstract
 ]
 

--- a/src/Refactoring2-Transformations/RBCompositeTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBCompositeTransformation.class.st
@@ -53,12 +53,13 @@ RBCompositeTransformation >> privateTransform [
 
 	"previousTransformations can be a transformation resulting from a given configuration,
 	for example do we push up instance variable when we push up a method that uses such instance variable"
-	
-	(self previousTransformations, self transformations) do: [ :transformation |
+
+	self previousTransformations , self transformations do: [
+		:transformation |
 		transformation
 			copyOptionsFrom: self options;
 			model: self model;
-			transform ]
+			primitiveExecute ]
 ]
 
 { #category : #accessing }

--- a/src/Refactoring2-Transformations/RBMoveMethodToClassSideTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBMoveMethodToClassSideTransformation.class.st
@@ -115,17 +115,20 @@ RBMoveMethodToClassSideTransformation >> privateTransform [
 
 { #category : #refactoring }
 RBMoveMethodToClassSideTransformation >> removeInstVariableReferences [
+
 	| rbMethod references |
-	rbMethod := (class methodFor: method selector).
-	references := class instanceVariableNames select: [:e | rbMethod refersToVariable: e].
-	references do: [ :e | |replacer accessorsRefactoring|
+	rbMethod := class methodFor: method selector.
+	references := class instanceVariableNames select: [ :e |
+		              rbMethod refersToVariable: e ].
+	references do: [ :e |
+		| replacer accessorsRefactoring |
 		accessorsRefactoring := self accessorsFor: e.
-		accessorsRefactoring transform.
+		accessorsRefactoring primitiveExecute.
 		replacer := self parseTreeRewriterClass
-				variable: e
-				getter: accessorsRefactoring getterMethod
-				setter: accessorsRefactoring setterMethod.
-	   self convertMethod: method selector for: class using: replacer ]
+			            variable: e
+			            getter: accessorsRefactoring getterMethod
+			            setter: accessorsRefactoring setterMethod.
+		self convertMethod: method selector for: class using: replacer ]
 ]
 
 { #category : #refactoring }

--- a/src/Refactoring2-Transformations/RBMoveMethodTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBMoveMethodTransformation.class.st
@@ -67,7 +67,8 @@ RBMoveMethodTransformation class >> selector: aSymbol class: aClass variable: aV
 
 { #category : #transforming }
 RBMoveMethodTransformation >> abstractVariables [
-	self abstractVariablesRefactoring transform.
+
+	self abstractVariablesRefactoring primitiveExecute.
 	parseTree := self abstractVariablesRefactoring parseTree
 ]
 

--- a/src/Refactoring2-Transformations/RBPullUpMethodTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBPullUpMethodTransformation.class.st
@@ -308,7 +308,7 @@ RBPullUpMethodTransformation >> removeDuplicatesOf: aSelector [
 						(RBRemoveMethodTransformation
 							model: self model
 							selector: aClass
-							from: aSelector) transform ]]]]
+							from: aSelector) primitiveExecute ]]]]
 ]
 
 { #category : #executing }

--- a/src/Refactoring2-Transformations/RBRemoveAllMessageSendsTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBRemoveAllMessageSendsTransformation.class.st
@@ -117,10 +117,3 @@ RBRemoveAllMessageSendsTransformation >> storeOn: aStream [
 	class storeOn: aStream.
 	aStream nextPut: $)
 ]
-
-{ #category : #executing }
-RBRemoveAllMessageSendsTransformation >> transform [
-
-	self checkPreconditions.
-	self privateTransform
-]

--- a/src/Refactoring2-Transformations/RBTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBTransformation.class.st
@@ -89,17 +89,6 @@ RBTransformation >> buildSelectorString: aSelector withPermuteMap: anIntegerColl
 	^stream contents
 ]
 
-{ #category : #preconditions }
-RBTransformation >> checkPreconditions [
-
-	| conditions result |
-	conditions := self preconditions.
-
-	result := conditions check.
-	result ifFalse: [ self refactoringError: conditions errorString ].
-	^ result
-]
-
 { #category : #accessing }
 RBTransformation >> copyOptionsFrom: aDictionary [
 	| dict |
@@ -123,23 +112,6 @@ RBTransformation >> model [
 RBTransformation >> preconditions [
 
 	^ self applicabilityConditions 
-]
-
-{ #category : #executing }
-RBTransformation >> primitiveExecute [
-	"compatibility method RBRefactoring"
-
-	self checkPreconditions.
-	self privateTransform
-	
-	"below executes the refactoring without prompt"
-	"RBRefactoringManager instance addRefactoring: self"
-]
-
-{ #category : #executing }
-RBTransformation >> privateTransform [
-
-	self subclassResponsibility
 ]
 
 { #category : #accessing }

--- a/src/Refactoring2-Transformations/RBTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBTransformation.class.st
@@ -127,7 +127,12 @@ RBTransformation >> preconditions [
 { #category : #executing }
 RBTransformation >> primitiveExecute [
 	"compatibility method RBRefactoring"
-	self transform
+
+	self checkPreconditions.
+	self privateTransform
+	
+	"below executes the refactoring without prompt"
+	"RBRefactoringManager instance addRefactoring: self"
 ]
 
 { #category : #executing }
@@ -144,6 +149,9 @@ RBTransformation >> setOption: aSymbol toUse: aBlock [
 
 { #category : #transforming }
 RBTransformation >> transform [
+
+	self deprecated: 'Use primitiveExecute instead' transformWith: '`@rec transform' -> '`@rec primitiveExecute'.
+	
 	"Performs this transformation in a model,
 	 then it adds the refactoring to the manager"
 

--- a/src/Refactoring2-Transformations/RBTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBTransformation.class.st
@@ -61,6 +61,7 @@ RBTransformation >> applicabilityConditions [
 { #category : #converting }
 RBTransformation >> asRefactoring [
 
+	self deprecated: 'This method is a no-op and can be removed' transformWith: '`@rec asRefactoring' -> '`@rec'.
 	^ self yourself
 ]
 

--- a/src/Renraku/ReClassSideResetMethodProtocolRule.class.st
+++ b/src/Renraku/ReClassSideResetMethodProtocolRule.class.st
@@ -28,7 +28,7 @@ ReClassSideResetMethodProtocolRule >> critiqueFor: aMethod [
 		   by: self) refactoring: (RBMethodProtocolTransformation
 			   protocol: 'class initialization'
 			   inMethod: methodSymbol
-			   inClass: classSymbol) asRefactoring
+			   inClass: classSymbol)
 ]
 
 { #category : #accessing }

--- a/src/Renraku/ReProperMethodProtocolNameRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolNameRule.class.st
@@ -72,7 +72,7 @@ ReProperMethodProtocolNameRule >> critiqueFor: aMethod [
 		   by: self) refactoring: (RBMethodProtocolTransformation
 			   protocol: { proposedProtocol }
 			   inMethod: aMethod selector
-			   inClass: aMethod methodClass name) asRefactoring
+			   inClass: aMethod methodClass name)
 ]
 
 { #category : #accessing }

--- a/src/SystemCommands-ClassCommands/SycCmAddSubclassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycCmAddSubclassCommand.class.st
@@ -16,7 +16,7 @@ SycCmAddSubclassCommand >> executeRefactoring [
 		superclass: targetClass asString
 		subclasses:  #()
 		category: targetClass category.
-	refactoring asRefactoring execute.
+	refactoring execute.
 ]
 
 { #category : #accessing }

--- a/src/SystemCommands-ClassCommands/SycCmInsertSubclassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycCmInsertSubclassCommand.class.st
@@ -17,7 +17,7 @@ SycCmInsertSubclassCommand >> executeRefactoring [
 		superclass: targetClass asString
 		subclasses: targetClass subclasses
 		category: targetClass category.
-	refactoring asRefactoring execute
+	refactoring execute
 ]
 
 { #category : #accessing }

--- a/src/SystemCommands-ClassCommands/SycCmInsertSuperclassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycCmInsertSuperclassCommand.class.st
@@ -17,7 +17,7 @@ SycCmInsertSuperclassCommand >> executeRefactoring [
 		superclass: targetClass superclass asString
 		subclasses: {targetClass}
 		category: targetClass category.
-	refactoring asRefactoring execute
+	refactoring execute
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This PR continues refactoring execution API of refactoring and transformation:

* push up all execution logic to `RBAbstractTransformation`
* rename and deprecate `transform` to `privateTransform`
* deprecate `asRefactoring` since it's no-op and returns self