### PR TITLE
RPackageTag should store real classes

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -189,7 +189,7 @@ RPackage >> addClassDefinition: aClass [
 RPackage >> addClassDefinition: aClass toClassTag: aSymbol [
 	"Tags the class aClass with the tag aSymbol"
 
-	(self addClassTag: aSymbol) addClassNamed: aClass name
+	(self addClassTag: aSymbol) addClass: aClass
 ]
 
 { #category : #'class tags' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -1099,10 +1099,7 @@ RPackage >> updateDefinedClassNamed: oldString withNewName: newString [
 	(oldString substrings size > 1 or: [ newString substrings size > 1 ]) ifTrue: [ Error signal: 'You should not use metaclass names' ].
 
 	classes remove: oldString asSymbol.
-	classes add: newString asSymbol.
-
-	"Don't forget that class tags also register the classes names."
-	self classTags do: [ :aTag | aTag updateDefinedClassNamed: oldString withNewName: newString ]
+	classes add: newString asSymbol
 ]
 
 { #category : #updating }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -1100,8 +1100,8 @@ RPackageOrganizer >> unregisterPackage: aPackage forClass: aClass [
 	className := (aClass isString
 		              ifTrue: [ aClass ]
 		              ifFalse: [ aClass instanceSide originalName ]) asSymbol.
-
-	^ classPackageMapping removeKey: className ifAbsent: [ self error: aPackage name , ' still includes the class ' , className ]
+	self flag: #package. "When RPackage will be simplified we should not have to check the package but it is required for now"
+	^ (classPackageMapping at: className ifAbsent: [ ^ self ]) = aPackage ifTrue: [ classPackageMapping removeKey: className ]
 ]
 
 { #category : #private }

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -8,7 +8,7 @@ Class {
 	#instVars : [
 		'package',
 		'name',
-		'classNames'
+		'classes'
 	],
 	#category : #'RPackage-Core-Base'
 }
@@ -29,13 +29,7 @@ RPackageTag class >> package: aPackage name: aString [
 RPackageTag >> addClass: aClass [
 
 	aClass category = self categoryName ifFalse: [ aClass category: self categoryName ].
-	classNames add: aClass name
-]
-
-{ #category : #accessing }
-RPackageTag >> addClassNamed: aSymbol [
-
-	^ classNames add: aSymbol
+	classes add: aClass
 ]
 
 { #category : #private }
@@ -64,13 +58,14 @@ RPackageTag >> categoryName [
 
 { #category : #accessing }
 RPackageTag >> classNames [
-	^ classNames
+
+	^ self classes collect: [ :class | class name ]
 ]
 
 { #category : #accessing }
 RPackageTag >> classes [
 
-	^ self classNames collect: [ :each | self environment at: each ]
+	^ classes
 ]
 
 { #category : #accessing }
@@ -135,8 +130,9 @@ RPackageTag >> includesSelector: aSelector ofClass: aClass [
 
 { #category : #initialization }
 RPackageTag >> initialize [
+
 	super initialize.
-	classNames := Set new
+	classes := IdentitySet new
 ]
 
 { #category : #initialization }
@@ -207,12 +203,8 @@ RPackageTag >> promoteAsRPackage [
 
 { #category : #accessing }
 RPackageTag >> removeClass: aClass [
-	^ self removeClassNamed: aClass name
-]
 
-{ #category : #accessing }
-RPackageTag >> removeClassNamed: aSymbol [
-	^ classNames remove: aSymbol ifAbsent: []
+	^ classes remove: aClass ifAbsent: [  ]
 ]
 
 { #category : #accessing }
@@ -259,12 +251,4 @@ RPackageTag >> toCategoryName: aString [
 	^ aString = self packageName
 		ifTrue: [ aString ]
 		ifFalse: [ self packageName, '-', aString ]
-]
-
-{ #category : #updating }
-RPackageTag >> updateDefinedClassNamed: oldString withNewName: newString [
-	(self hasClassNamed: oldString)
-		ifFalse: [ ^ self ].
-	self removeClassNamed: oldString.
-	self addClassNamed: newString
 ]

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -27,12 +27,14 @@ RPackageTag class >> package: aPackage name: aString [
 
 { #category : #accessing }
 RPackageTag >> addClass: aClass [
-	aClass category: self categoryName
+
+	aClass category = self categoryName ifFalse: [ aClass category: self categoryName ].
+	classNames add: aClass name
 ]
 
 { #category : #accessing }
 RPackageTag >> addClassNamed: aSymbol [
-	(classNames includes: aSymbol) ifTrue: [ ^ self ].
+
 	^ classNames add: aSymbol
 ]
 

--- a/src/Renraku-Tests/RenrakuBaseTestCase.class.st
+++ b/src/Renraku-Tests/RenrakuBaseTestCase.class.st
@@ -21,8 +21,9 @@ RenrakuBaseTestCase class >> isAbstract [
 
 { #category : #running }
 RenrakuBaseTestCase >> setUp [
+
 	super setUp.
-	testPackage := (RPackage named: #'RenrakuCreatedForTests') register.
+	testPackage := self packageOrganizer ensurePackage: #RenrakuCreatedForTests.
 	self setupScreamerRule
 ]
 
@@ -53,8 +54,7 @@ RenrakuBaseTestCase >> setupScreamerRule [
 RenrakuBaseTestCase >> tearDown [
 
 	self tearDownscreamerRule.
-	testPackage unregister.
-	testPackage := nil.
+	testPackage removeFromSystem.
 	super tearDown
 ]
 

--- a/src/SUnit-Rules-Tests/ReTestBasedTestCase.class.st
+++ b/src/SUnit-Rules-Tests/ReTestBasedTestCase.class.st
@@ -15,24 +15,21 @@ ReTestBasedTestCase class >> isAbstract [
 
 { #category : #running }
 ReTestBasedTestCase >> setUp [
+
 	super setUp.
-	validTestPackage := (RPackage
-		named: #'Renraku-Programmatically-Created-Class-Tests') register.
+	validTestPackage := self packageOrganizer ensurePackage: #'Renraku-Programmatically-Created-Class-Tests'.
 
 	"create tests in wrong package"
 	testClass := self class classInstaller make: [ :builder |
-			builder
-				superclass: TestCase;
-				name: #RenrakuProgrammaticallyCreatedClassTest;
-				package: testPackage name ]
+		             builder
+			             superclass: TestCase;
+			             name: #RenrakuProgrammaticallyCreatedClassTest;
+			             package: testPackage name ]
 ]
 
 { #category : #running }
 ReTestBasedTestCase >> tearDown [
 
-	validTestPackage methods do: #removeFromSystem.
-	validTestPackage definedClasses do: #removeFromSystem.
-	validTestPackage unregister.
-	validTestPackage := nil.	
+	validTestPackage removeFromSystem.
 	super tearDown
 ]


### PR DESCRIPTION
This change updates RPackageTag to store real classes instead of class names.

A next step could be to remove the #classes variable of RPackage and to just flat collect this variable in the tags. I ran some benches and it is pretty fast to do and could simplify the code quite a lot and remove some sync problems