### PR TITLE
[Enh]: Missing Evaluation API & Tests

### DIFF
--- a/src/Collections-Strings-Tests/SymbolTest.class.st
+++ b/src/Collections-Strings-Tests/SymbolTest.class.st
@@ -338,6 +338,14 @@ SymbolTest >> testCopyNotSame [
 ]
 
 { #category : #tests }
+SymbolTest >> testCullCull [
+
+	self assert: (#asNumber cull: '1' cull: 2) equals: 1.
+	self assert: (#at: cull: #(2) cull: 1) equals: 2.
+	self assert: (#correctAgainst:continuedFrom: cull: 'test' cull: #('nest')) size equals: 1.
+]
+
+{ #category : #tests }
 SymbolTest >> testDisplayString [
 
 	| actual |
@@ -524,6 +532,14 @@ SymbolTest >> testUncapitalized [
 	lc := #mElViN.
 	self assert: uc uncapitalized equals: lc.
 	self assert: lc uncapitalized equals: lc
+]
+
+{ #category : #tests }
+SymbolTest >> testValueWithArguments [
+
+	self assert: (#asNumber valueWithArguments: #('1')) equals: 1.
+	self assert: (#at: valueWithArguments: #(#(2) 1)) equals: 2.
+	self assert: (#beginsWith:caseSensitive: valueWithArguments: #('Test' 'te' true)) equals: false
 ]
 
 { #category : #requirements }

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -410,6 +410,11 @@ Symbol >> cull: anObject [
 	^anObject perform: self
 ]
 
+{ #category : #evaluating }
+Symbol >> cull: receiverObject cull: argumentObject [
+	^ receiverObject perform: self withEnoughArguments: { argumentObject }
+]
+
 { #category : #private }
 Symbol >> errorNoModification [
 
@@ -614,6 +619,11 @@ Symbol >> uncapitalized [
 { #category : #evaluating }
 Symbol >> value: anObject [
 	^anObject perform: self
+]
+
+{ #category : #evaluating }
+Symbol >> valueWithArguments: aCollection [ 
+	^ aCollection first perform: self withArguments: aCollection allButFirst.
 ]
 
 { #category : #copying }


### PR DESCRIPTION
I know adding value and cull API can be a controversial rabbit hole (e.g. `#value:value:value:value:value:value:value:value:value:`), but of the two methods I'm proposing, the first will greatly simplify Magritte packaging and the second makes Symbol polymorphic with all the other similar receivers. I hope that you will consider them. I even wrote tests, lol!

- `Symbol>>#cull:cull` - used in Magritte and will make packaging much easier
- `Symbol>>#valueWithEnoughArguments` - already implemented by Object, Block, and MessageSend; make polymorphic with those