### PR TITLE
RPackage: Improve creation of package during demotion to tag

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -388,7 +388,7 @@ RPackage >> demoteToTagInPackageNamed: aString [
 	aString = self name ifTrue: [ ^ self ].
 
 	self unregister.
-	newPackage := self class organizer packageNamed: aString ifAbsent: [ (self class named: aString organizer: self organizer) register ].
+	newPackage := self organizer ensurePackage: aString.
 	newPackage importPackage: self.
 
 	newPackage classes do: [ :each | SystemAnnouncer uniqueInstance classRepackaged: each from: self to: newPackage ].


### PR DESCRIPTION
While demoting a package to a tag, the lookup of the new package was not using the organizer of the old package and the behavior can be simplified using #ensurePackage: