### PR TITLE
RPackage: Cleanings in tag

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -274,9 +274,10 @@ RPackage >> classTagCategoryNames [
 
 { #category : #'class tags' }
 RPackage >> classTagForClass: aClass [
-	^ self
-		classTagNamed: (self toTagName: aClass category)
-		ifAbsent: [ nil ]
+
+	^ self classTags
+		  detect: [ :tag | tag hasClass: aClass ]
+		  ifNone: [ nil ]
 ]
 
 { #category : #'class tags' }
@@ -1039,6 +1040,13 @@ RPackage >> reportBogusBehaviorOf: aSelector [
 ]
 
 { #category : #accessing }
+RPackage >> rootTagName [
+
+	self flag: #package. "In the future we should not use the name of the package because it causes bugs."
+	^ self name
+]
+
+{ #category : #accessing }
 RPackage >> roots [
 	"Returns all the root classes of a package. A root class is a class whose superclass is not defined in the package.
 	Root classes are potentially root of inheritance trees defined in a package."
@@ -1090,7 +1098,10 @@ RPackage >> toTagName: aSymbol [
 
 	^ (aSymbol beginsWith: self name asString , '-')
 		  ifTrue: [ (aSymbol allButFirst: self name size + 1) asSymbol ]
-		  ifFalse: [ aSymbol ]
+		  ifFalse: [
+			  (aSymbol sameAs: self name)
+				  ifTrue: [ self rootTagName ]
+				  ifFalse: [ aSymbol ] ]
 ]
 
 { #category : #register }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -315,13 +315,10 @@ RPackage >> classes [
 ]
 
 { #category : #'class tags' }
-RPackage >> classesForClassTag: aSymbol [
+RPackage >> classesForClassTag: aTagName [
 	"Returns the classes tagged using aSymbol"
 
-	^ (self
-		classTagNamed: (self toTagName: aSymbol)
-		ifAbsent: [ ^ #() ])
-		classes
+	^ (self classTagNamed: aTagName ifAbsent: [ ^ #(  ) ]) classes
 ]
 
 { #category : #queries }
@@ -872,7 +869,7 @@ RPackage >> removeClass: aClass [
 RPackage >> removeClassDefinition: aClass fromClassTag: aSymbol [
 
 	| tag |
-	tag := self classTagNamed: (self toTagName: aSymbol) ifAbsent: [ ^ self ].
+	tag := self classTagNamed: aSymbol ifAbsent: [ ^ self ].
 	tag removeClass: aClass.
 	tag isEmpty ifTrue: [ self basicRemoveTag: tag ]
 ]

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -246,6 +246,12 @@ RPackageTag >> renameTo: aString category: categoryName [
 		self organizer renameCategory: oldName toBe: categoryName ]
 ]
 
+{ #category : #accessing }
+RPackageTag >> rootTagName [
+
+	^ self package rootTagName
+]
+
 { #category : #private }
 RPackageTag >> toCategoryName: aString [
 	^ aString = self packageName


### PR DESCRIPTION
This change mostly clean the concept of Root tag and push back some categories management in RPackage.

A root tag is the tag containing the unclassified classes and its name if the name of the package containing it. But this logic is spread in the system. Also, this logic is bad because it creates inconsistances in the system. Instead of using the name of the package, I want to have a default name such as 'Root' or 'Unclassified'.

This change start to introduce and use a #rootTagName method. Once it is used everywhere using this, it should be easy to change the name. 

The second change is to push back the system of categories. Some methods are rewritten to not be based on categories but on tags and some other are trying to remove the use of the method #toTagName: that takes as parameter a tag name or a category name and return a tag name. I want the RPackage API to deal with tag name only in my quest to kill categories.