### PR TITLE
RPackage: Clean bootstrap initialization

### DIFF
--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -199,18 +199,15 @@ RPackageOrganizer >> basicInitializeFromPackagesList: aPackagesList [
 		do: [ :packageName | packages at: packageName asSymbol put: (RPackage named: packageName organizer: self) ]
 		displayingProgress: 'Importing monticello packages'.
 
-	Smalltalk allClassesAndTraits do: [ :behavior | self initializeFor: behavior ] displayingProgress: 'Importing behaviors'.
+	Smalltalk allClassesAndTraits
+		do: [ :behavior | (self ensurePackageMatching: behavior category) importClass: behavior ]
+		displayingProgress: 'Importing behaviors'.
 
 	Smalltalk allClassesAndTraits
 		do: [ :behavior |
-			behavior package
-				importDefinedMethodsOf: behavior;
-				importDefinedMethodsOf: behavior classSide ]
-		displayingProgress: 'Importing defined methods'.
-
-	Smalltalk allClassesAndTraits
-		do: [ :behavior |
-			{ behavior . behavior classSide } do: [ :aBehavior |
+			{
+				behavior.
+				behavior classSide } do: [ :aBehavior |
 				aBehavior extensionProtocols do: [ :protocol |
 					(self ensurePackageMatching: protocol name allButFirst trimBoth) importProtocol: protocol forClass: aBehavior ] ] ]
 		displayingProgress: 'Importing extensions'
@@ -455,16 +452,6 @@ RPackageOrganizer >> initialize [
 	categoryMap := Dictionary new.
 
 	self defineUnpackagedClassesPackage
-]
-
-{ #category : #'initialization - data' }
-RPackageOrganizer >> initializeFor: aBehavior [
-
-	| package |
-	package := self ensurePackageMatching: aBehavior category.
-	package addClassDefinition: aBehavior.
-	package addClassDefinition: aBehavior toClassTag: aBehavior category asSymbol.
-	self registerPackage: package forClass: aBehavior
 ]
 
 { #category : #'deprecated - SystemOrganizer leftovers' }


### PR DESCRIPTION
There is an initialization of packages in the bootstrap that is redoing some code in it own way instead of using the RPackage classic API. This make it harder to clean the API. 

In the past weeks I tried to unify some of the behavior. Now let's see if the class import can be unified.