### PR TITLE
Change #destinationPath in ThemeIcons to use the local directory instead of the working directory

### DIFF
--- a/src/Polymorph-Widgets/ThemeIcons.class.st
+++ b/src/Polymorph-Widgets/ThemeIcons.class.st
@@ -111,7 +111,7 @@ ThemeIcons class >> current: aPack [
 
 { #category : #accessing }
 ThemeIcons class >> destinationPath [
-	^ 'icon-packs' asFileReference
+	^ FileLocator localDirectory / 'icon-packs'
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This pull request changes `#destinationPath` in ThemeIcons to use the local directory instead of the working directory. That avoids a problem on macOS: when Pharo is opened through Finder, the working directory is ‘/’ which is only writable by the ‘root’ user.

This could perhaps be changed, for compatibility with the previous version, to return the old destination if it already exists, but I’m not sure whether that’s necessary.