### PR TITLE
RPackage: Use real classes for extension caches

### DIFF
--- a/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
@@ -394,18 +394,17 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateMetaclassExtensionSel
 { #category : #'tests - operations on classes' }
 RPackageClassesSynchronisationTest >> testRenameClassUpdateOrganizerClassExtendingPackagesMapping [
 	"test that when we rename a class, the classExtendingPackages dictionary of the organizer is updated with the new name, so that we can access the packages when specifying the new name"
-	
-	| XPackage YPackage class |
+
+	| xPackage yPackage class |
 	self addXYCategory.
-	XPackage := self organizer packageNamed: #XXXXX.
-	YPackage := self organizer packageNamed: #YYYYY.
+	xPackage := self organizer packageNamed: #XXXXX.
+	yPackage := self organizer packageNamed: #YYYYY.
 	class := self createNewClassNamed: 'RPackageOldStubClass' inCategory: 'XXXXX'.
-	self createMethodNamed: #stubMethod inClass: class inCategory: '*yyyyy'. 
-	
+	self createMethodNamed: #stubMethod inClass: class inCategory: '*yyyyy'.
+
 	class rename: 'RPackageNewStubClass'.
-	
-	self assert: ((self organizer extendingPackagesOfClassNamed: 'RPackageNewStubClass' asSymbol) includes: YPackage). 
-	self deny: ((self organizer extendingPackagesOfClassNamed: 'RPackageOldStubClass' asSymbol) includes: YPackage).
+
+	self assert: ((self organizer extendingPackagesOf: class) includes: yPackage)
 ]
 
 { #category : #'tests - operations on classes' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -842,15 +842,12 @@ RPackage >> registerClass: aClass [
 RPackage >> removeAllMethodsFromClass: aClass [
 	"Remove all the methods (defined and extensions) that are related to the class as parameter. The class should always be instance side."
 
-	| aClassNameSymbol |
-	aClassNameSymbol := aClass originalName asSymbol.
-
 	definedSelectors removeKey: aClass ifAbsent: [  ].
 	definedSelectors removeKey: aClass classSide ifAbsent: [  ].
 	extensionSelectors removeKey: aClass ifAbsent: [  ].
 	extensionSelectors removeKey: aClass classSide ifAbsent: [  ].
 
-	self organizer unregisterExtendingPackage: self forClassName: aClassNameSymbol
+	self organizer unregisterExtendingPackage: self forClass: aClass
 ]
 
 { #category : #removing }
@@ -917,7 +914,7 @@ RPackage >> removeMethod: aCompiledMethod [
 	(self includesClass: methodClass)
 		ifTrue: [
 			definedSelectors at: methodClass ifPresent: [ :selectors |
-				selectors remove: aCompiledMethod selector ifAbsent: [ ].
+				selectors remove: aCompiledMethod selector ifAbsent: [  ].
 				selectors ifEmpty: [ definedSelectors removeKey: methodClass ] ] ]
 		ifFalse: [
 			extensionSelectors at: methodClass ifPresent: [ :selectors |
@@ -926,7 +923,7 @@ RPackage >> removeMethod: aCompiledMethod [
 
 	((extensionSelectors at: methodClass instanceSide ifAbsent: [ #(  ) ]) isEmpty and: [
 		 (extensionSelectors at: methodClass classSide ifAbsent: [ #(  ) ]) isEmpty ]) ifTrue: [
-		self organizer unregisterExtendingPackage: self forClassName: methodClass instanceSide originalName ].
+		self organizer unregisterExtendingPackage: self forClass: methodClass ].
 
 	^ aCompiledMethod
 ]

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -361,13 +361,7 @@ RPackageOrganizer >> environment: aSystemDictionary [
 RPackageOrganizer >> extendingPackagesOf: aClass [
 	"Returns the packages extending the class aClass"
 
-	^ self extendingPackagesOfClassNamed: aClass instanceSide originalName
-]
-
-{ #category : #'package - access from class' }
-RPackageOrganizer >> extendingPackagesOfClassNamed: aName [
-	"Returns the packages extending the class named a Symbol"
-	^ classExtendingPackagesMapping at: aName asSymbol ifAbsent: [#()]
+	^ classExtendingPackagesMapping at: aClass instanceSide ifAbsent: [ #(  ) ]
 ]
 
 { #category : #'package - access from class' }
@@ -624,23 +618,7 @@ RPackageOrganizer >> register [
 { #category : #'private - registration' }
 RPackageOrganizer >> registerExtendingPackage: aPackage forClass: aClass [
 
-	| cur |
-
-	cur := classExtendingPackagesMapping at: aClass instanceSide name ifAbsent: [ nil ].
-	cur
-		ifNil: [ classExtendingPackagesMapping at: aClass instanceSide name put: ( Set with: aPackage ) ]
-		ifNotNil: [ cur add: aPackage ]
-]
-
-{ #category : #'private - registration' }
-RPackageOrganizer >> registerExtendingPackage: aPackage forClassName: aClassName [
-
-	| cur |
-
-	cur := classExtendingPackagesMapping at: aClassName asSymbol ifAbsent: [ nil ].
-	cur
-		ifNil: [ classExtendingPackagesMapping at: aClassName asSymbol put: ( Set with: aPackage ) ]
-		ifNotNil: [ cur add: aPackage ]
+	(classExtendingPackagesMapping at: aClass instanceSide ifAbsentPut: [ IdentitySet new ]) add: aPackage
 ]
 
 { #category : #'system integration' }
@@ -807,16 +785,7 @@ RPackageOrganizer >> renameCategory: oldCatString toBe: newCatString [
 { #category : #'system integration' }
 RPackageOrganizer >> renameClass: class from: oldName to: newName [
 
-	| package extendingPackages |
-	package := self packageOf: class.
-	extendingPackages := self extendingPackagesOfClassNamed: oldName.
-
-	package updateDefinedClassNamed: oldName withNewName: newName.
-
-	"update the 'classExtendingPackagesMapping' to replace the key with the new class name"
-	extendingPackages do: [ :extendingPackage |
-		self unregisterExtendingPackage: extendingPackage forClassName: oldName.
-		self registerExtendingPackage: extendingPackage forClassName: newName ]
+	(self packageOf: class) updateDefinedClassNamed: oldName withNewName: newName
 ]
 
 { #category : #'system integration' }
@@ -1026,21 +995,8 @@ RPackageOrganizer >> unregister [
 
 { #category : #'private - registration' }
 RPackageOrganizer >> unregisterExtendingPackage: aPackage forClass: aClass [
-	| extendingPackageForClass |
 
-	extendingPackageForClass := classExtendingPackagesMapping
-		at: aClass instanceSide name
-		ifAbsent: [ nil ].
-	extendingPackageForClass ifNotNil: [
-		extendingPackageForClass
-			remove: aPackage
-			ifAbsent: [] "not happy with this one" ]
-]
-
-{ #category : #'private - registration' }
-RPackageOrganizer >> unregisterExtendingPackage: aPackage forClassName: aClassName [
-
-	classExtendingPackagesMapping at: aClassName asSymbol ifPresent: [ :listOfPackages | listOfPackages remove: aPackage ifAbsent: [  ] ]
+	classExtendingPackagesMapping at: aClass instanceSide ifPresent: [ :extendingPackages | extendingPackages remove: aPackage ifAbsent: [  ] ]
 ]
 
 { #category : #'system integration' }


### PR DESCRIPTION
In RPackageOrganizer we have a cache of the classes and the packages extending those classes to speed up the search of packages of the extension methods.

This cache was using a class name and a set of packages. This change updates it to store and identity set of the packages under the real classes and not the names. 

The update code happening on class renaming is starting to be much smaller and easier with all the recent changes