### PR TITLE
Make methods in classes in the category ‘Calypso-Browser-Toolbar’ take the display scale factor into account

### DIFF
--- a/src/Calypso-Browser/ClyBrowserButtonMorph.class.st
+++ b/src/Calypso-Browser/ClyBrowserButtonMorph.class.st
@@ -32,7 +32,7 @@ ClyBrowserButtonMorph >> handlesMouseOver: evt [
 ClyBrowserButtonMorph >> initialize [
 	super initialize.
 	self
-		layoutInset: 4@0
+		layoutInset: (4@0) scaledByDisplayScaleFactor
 ]
 
 { #category : #installing }

--- a/src/Calypso-Browser/ClyBrowserToolbarItemMorph.class.st
+++ b/src/Calypso-Browser/ClyBrowserToolbarItemMorph.class.st
@@ -69,7 +69,7 @@ ClyBrowserToolbarItemMorph >> initialize [
 		listDirection: #leftToRight;
 		hResizing: #shrinkWrap;
 		vResizing: #shrinkWrap;
-		cellInset: 4
+		cellInset: 4 scaledByDisplayScaleFactor
 ]
 
 { #category : #printing }

--- a/src/Calypso-Browser/ClyToolbarMorph.class.st
+++ b/src/Calypso-Browser/ClyToolbarMorph.class.st
@@ -41,7 +41,7 @@ ClyToolbarMorph >> addNewItem: aMorph [
 	offsetX := self submorphs
 		           inject: 0
 		           into: [ :sum :each | sum + each extent x ].
-	offsetY := 5.
+	offsetY := 5 scaledByDisplayScaleFactor.
 	self addMorphBack: aMorph.
 	self computeFullBounds.
 	self minHeight: self defaultHeight.

--- a/src/Calypso-Browser/ClyToolbarSeparatorMorph.class.st
+++ b/src/Calypso-Browser/ClyToolbarSeparatorMorph.class.st
@@ -24,7 +24,7 @@ ClyToolbarSeparatorMorph >> initialize [
 		changeTableLayout;
 		hResizing: #shrinkWrap;
 		vResizing: #shrinkWrap;
-		layoutInset: 4@0.
+		layoutInset: (4@0) scaledByDisplayScaleFactor.
 	separator := self theme newLabelIn: self label: '|'.
 
 	self addMorph: separator


### PR DESCRIPTION
This pull request makes the methods in classes in the category ‘Calypso-Browser-Toolbar’ take the display scale factor into account.