### PR TITLE
Make methods in classes in the category ‘Calypso-Browser-UI’ take the display scale factor into account

### DIFF
--- a/src/Calypso-Browser/ClyActivityAnimationIconMorph.class.st
+++ b/src/Calypso-Browser/ClyActivityAnimationIconMorph.class.st
@@ -49,7 +49,7 @@ ClyActivityAnimationIconMorph >> initialize [
 		hResizing: #shrinkWrap;
 		vResizing: #shrinkWrap;
 		listDirection: #leftToRight;
-		cellInset: 2.
+		cellInset: 2 scaledByDisplayScaleFactor.
 	progress := 1.
 	progressIconMorph := self currentIcon asMorph.
 	self addMorphBack: progressIconMorph.

--- a/src/Calypso-Browser/ClyBrowserMorph.class.st
+++ b/src/Calypso-Browser/ClyBrowserMorph.class.st
@@ -507,7 +507,7 @@ ClyBrowserMorph >> open [
 	window := self openInWindow.
 	window model: self.
 	self updateWindowTitle.
-	window minimumExtent: 650@500.0
+	window minimumExtent: (650@500.0) scaledByDisplayScaleFactor
 ]
 
 { #category : #'opening/closing' }

--- a/src/Calypso-Browser/ClyBrowserSearchDialogWindow.class.st
+++ b/src/Calypso-Browser/ClyBrowserSearchDialogWindow.class.st
@@ -87,7 +87,7 @@ ClyBrowserSearchDialogWindow >> itemsChanged [
 { #category : #initialization }
 ClyBrowserSearchDialogWindow >> newContentMorph [
 	itemsView := ClyQueryViewMorph for: self.
-	itemsView width: 250.
+	itemsView width: 250 scaledByDisplayScaleFactor.
 
 	itemsView whenDoubleClickDo: [:ann | self ok ].
 	itemsView whenEnterKeyPressedDo: [:ann | self ok ].

--- a/src/Calypso-Browser/ClyStatusBarMorph.class.st
+++ b/src/Calypso-Browser/ClyStatusBarMorph.class.st
@@ -44,7 +44,7 @@ ClyStatusBarMorph >> buildCommandBar [
 		listDirection: #rightToLeft;
 		hResizing: #shrinkWrap;
 		vResizing: #shrinkWrap;
-		cellInset: 4@0;
+		cellInset: (4@0) scaledByDisplayScaleFactor;
 		color: Color transparent;
 		height: 0;
 		minHeight: 0.
@@ -59,7 +59,7 @@ ClyStatusBarMorph >> buildContextBar [
 		listDirection: #leftToRight;
 		hResizing: #spaceFill;
 		vResizing: #shrinkWrap;
-		cellInset: 4@0;
+		cellInset: (4@0) scaledByDisplayScaleFactor;
 		color: Color transparent;
 		height: 0;
 		minHeight: 0.
@@ -83,7 +83,7 @@ ClyStatusBarMorph >> initialize [
 		vResizing: #shrinkWrap;
 		height: 0;
 		minHeight: 0;
-		layoutInset: 10@2.
+		layoutInset: (10@2) scaledByDisplayScaleFactor.
 	self buildContextBar.
 	self buildCommandBar
 ]


### PR DESCRIPTION
This pull request makes the methods in classes in the category ‘Calypso-Browser-UI’ take the display scale factor into account.