### PR TITLE
Make methods in classes in the category ‘Calypso-Browser-Table’ take the display scale factor into account

### DIFF
--- a/src/Calypso-Browser/ClyMainItemCellMorph.class.st
+++ b/src/Calypso-Browser/ClyMainItemCellMorph.class.st
@@ -123,13 +123,13 @@ ClyMainItemCellMorph >> buildWithFullIndentation [
 		expansionButton := self currentExpansionButton.
 		self addMorphBack: expansionButton].
 	definitionMorph ifNotNil: [
-		definitionMorph width: 16.
+		definitionMorph width: 16 scaledByDisplayScaleFactor.
 		 self addMorphBack: definitionMorph].
 
 
 	self addMorphBack: label.
 	extraToolMorphs ifNotNil: [ extraToolMorphs do: [:each |
-			each width: 16.
+			each width: 16 scaledByDisplayScaleFactor.
 			 self addMorphBack: each  ] ]
 ]
 
@@ -185,7 +185,7 @@ ClyMainItemCellMorph >> definitionIcon: iconName [
 ClyMainItemCellMorph >> definitionMorph: aMorph [
 
 	definitionMorph := aMorph.
-	definitionMorph width: 16.
+	definitionMorph width: 16 scaledByDisplayScaleFactor.
 	^definitionMorph
 ]
 
@@ -220,7 +220,7 @@ ClyMainItemCellMorph >> expandedButton [
 ClyMainItemCellMorph >> initialize [
 	super initialize.
 	fullIndentation := false.
-	self cellInset: 2@0
+	self cellInset: (2@0) scaledByDisplayScaleFactor
 ]
 
 { #category : #accessing }

--- a/src/Calypso-Browser/ClyQueryViewMorph.class.st
+++ b/src/Calypso-Browser/ClyQueryViewMorph.class.st
@@ -176,8 +176,8 @@ ClyQueryViewMorph >> addColumn: columnId [
 { #category : #controlling }
 ClyQueryViewMorph >> adoptForDialog [
 	(self areItemsLoaded and: [self itemCount < 10])
-		ifTrue: [ self height: 100 ]
-		ifFalse: [ self height: 300; enableFilterUsing: ClyRegexPattern new]
+		ifTrue: [ self height: 100 scaledByDisplayScaleFactor ]
+		ifFalse: [ self height: 300 scaledByDisplayScaleFactor; enableFilterUsing: ClyRegexPattern new]
 ]
 
 { #category : #controlling }


### PR DESCRIPTION
This pull request makes the methods in classes in the category ‘Calypso-Browser-Table’ take the display scale factor into account.