### PR TITLE
RPackage: Clean package demotion and tag promotion

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -382,18 +382,23 @@ RPackage >> definesOrExtendsClass: aClass [
 { #category : #converting }
 RPackage >> demoteToTagInPackageNamed: aString [
 
-	| newPackage |
+	| newPackage tag |
 	aString = self name ifTrue: [ ^ self ].
 
 	(self name beginsWith: aString , '-') ifFalse: [
 		self error: 'To demote a package to a package with a tag, the new package name needs to be a prefix of the old package name' ].
 
+	self flag: #package. "We need to unregister because we cannot have a package X-Y and a package X with a tag Y at the same time because of the system organizer. Once the system organizer is not here anymore, we should just do a #removeFromSystem at the end to avoid to have a removal system AND an unregistering system."
+	self unregister.
 
 	newPackage := self organizer ensurePackage: aString.
-	newPackage importPackage: self inTag: (self name withoutPrefix: aString , '-').
 
-	self unregister.
-	newPackage classes do: [ :each | SystemAnnouncer uniqueInstance classRepackaged: each from: self to: newPackage ].
+	"We keep the suffix that was removed as the tag name to create."
+	tag := newPackage addClassTag: (self name withoutPrefix: aString , '-').
+
+	self definedClasses do: [ :class | newPackage moveClass: class toTag: tag ].
+	self extensionMethods do: [ :method | newPackage addMethod: method ].
+
 	^ newPackage
 ]
 
@@ -529,15 +534,6 @@ RPackage >> importDefinedMethodsOf: aClass [
 	aClass protocols
 		reject: [ :protocol | protocol isExtensionProtocol ]
 		thenDo: [ :protocol | self importProtocol: protocol forClass: aClass ]
-]
-
-{ #category : #private }
-RPackage >> importPackage: aPackage inTag: aTag [
-
-	aPackage definedClasses do: [ :className | self moveClass: className toTag: aTag ].
-
-	"new rpackage inherits the extentions"
-	extensionSelectors := extensionSelectors , aPackage privateExtensionSelectors
 ]
 
 { #category : #private }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -385,10 +385,14 @@ RPackage >> demoteToTagInPackageNamed: aString [
 	| newPackage |
 	aString = self name ifTrue: [ ^ self ].
 
-	self unregister.
-	newPackage := self organizer ensurePackage: aString.
-	newPackage importPackage: self.
+	(self name beginsWith: aString , '-') ifFalse: [
+		self error: 'To demote a package to a package with a tag, the new package name needs to be a prefix of the old package name' ].
 
+
+	newPackage := self organizer ensurePackage: aString.
+	newPackage importPackage: self inTag: (self name withoutPrefix: aString , '-').
+
+	self unregister.
 	newPackage classes do: [ :each | SystemAnnouncer uniqueInstance classRepackaged: each from: self to: newPackage ].
 	^ newPackage
 ]
@@ -528,9 +532,9 @@ RPackage >> importDefinedMethodsOf: aClass [
 ]
 
 { #category : #private }
-RPackage >> importPackage: aPackage [
+RPackage >> importPackage: aPackage inTag: aTag [
 
-	aPackage definedClasses do: [ :className | self importClass: className ].
+	aPackage definedClasses do: [ :className | self moveClass: className toTag: aTag ].
 
 	"new rpackage inherits the extentions"
 	extensionSelectors := extensionSelectors , aPackage privateExtensionSelectors
@@ -714,12 +718,8 @@ RPackage >> moveClass: aClass fromPackage: oldPackage toTag: aTag [
 
 { #category : #private }
 RPackage >> moveClass: aClass toTag: aTag [
-	"TODO: deprecate system categories / replace this with a direct call to moveClass:fromPackage:toTag:"
 
-	"This change the class category as appropriate.
-		(and by cascade, ensure systemClassRecategorizedAction: is called)."
-
-	aClass category: aTag categoryName
+	^ self moveClass: aClass fromPackage: aClass package toTag: aTag
 ]
 
 { #category : #accessing }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -380,21 +380,18 @@ RPackage >> definesOrExtendsClass: aClass [
 ]
 
 { #category : #converting }
-RPackage >> demoteToTagInPackageNamed: aString [
+RPackage >> demoteToTagInPackage [
 
 	| newPackage tag |
-	aString = self name ifTrue: [ ^ self ].
-
-	(self name beginsWith: aString , '-') ifFalse: [
-		self error: 'To demote a package to a package with a tag, the new package name needs to be a prefix of the old package name' ].
+	(self name includes: $-) ifFalse: [ self error: 'To demote a package, it name needs to contain at least one dash `-`.' ].
 
 	self flag: #package. "We need to unregister because we cannot have a package X-Y and a package X with a tag Y at the same time because of the system organizer. Once the system organizer is not here anymore, we should just do a #removeFromSystem at the end to avoid to have a removal system AND an unregistering system."
 	self unregister.
 
-	newPackage := self organizer ensurePackage: aString.
+	newPackage := self organizer ensurePackage: (self name copyUpToLast: $-).
 
 	"We keep the suffix that was removed as the tag name to create."
-	tag := newPackage addClassTag: (self name withoutPrefix: aString , '-').
+	tag := newPackage addClassTag: (self name withoutPrefix: newPackage name , '-').
 
 	self definedClasses do: [ :class | newPackage moveClass: class toTag: tag ].
 	self extensionMethods do: [ :method | newPackage addMethod: method ].

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -472,12 +472,6 @@ RPackage >> extensionSelectorsForClass: aClass [
 	^ extensionSelectors at: aClass ifAbsent: [ #(  ) ]
 ]
 
-{ #category : #'class tags' }
-RPackage >> extensionsForTag: aRPackageTag [
-
-	^ self extensionMethods select: [ :extensionMethod | extensionMethod protocolName allButFirst isCategoryOf: aRPackageTag categoryName ]
-]
-
 { #category : #properties }
 RPackage >> hasProperty: aKey [
 	self propertyAt: aKey ifAbsent: [ ^ false ].
@@ -1027,6 +1021,12 @@ RPackage >> renameTo: aSymbol [
 RPackage >> reportBogusBehaviorOf: aSelector [
 
 	self traceCr: 'RPackage log: Something wrong around ', aSelector asString , 'since the removeKey: is called on not present information.'
+]
+
+{ #category : #'class tags' }
+RPackage >> rootTag [
+
+	^ self addClassTag: self rootTagName
 ]
 
 { #category : #accessing }

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -33,18 +33,6 @@ RPackageTag >> addClass: aClass [
 ]
 
 { #category : #private }
-RPackageTag >> asRPackage [
-	"Create a new RPackage with the same contents as this rpackage tag"
-
-	| newRPackage |
-	newRPackage := RPackage named: self categoryName organizer: self organizer.
-	self classes do: [ :className | newRPackage importClass: className ].
-	(self package extensionsForTag: self) do: [ :extensionMethod | newRPackage addMethod: extensionMethod ].
-
-	^ newRPackage
-]
-
-{ #category : #private }
 RPackageTag >> basicRenameTo: aString [
 	name := aString
 ]
@@ -186,19 +174,16 @@ RPackageTag >> printOn: aStream [
 ]
 
 { #category : #converting }
-RPackageTag >> promoteAsRPackage [
-	"This method converts this rpackage tag into an rpackage, removes the tag from the parent package with all classes included and registers the new package in the system.
-	The tag has to be removed before registering to avoid conflicts.
-	Smells like we could have an error and lose package tags! registerPackage should not fail because names Package-Tag are unique in the system."
+RPackageTag >> promoteAsPackage [
+	"This method converts this package tag into a package"
 
-	| newRPackage |
-	newRPackage := self asRPackage.
-	self classes do: [ :each | self package removeClass: each ].
-	self package removeClassTag: self name.
-	self package removeMethods: newRPackage extensionMethods.
-	self organizer registerPackage: newRPackage.
+	| newPackage |
+	self flag: #package. "We need to create and register in two steps because we cannot have a package X-Y and a package X with a tag Y at the same time because of the system organizer. Once the system organizer is not here anymore, we should just do a `self organizer ensurePackage: self package name , '-' , self name` to avoid to have a manual package creation AND a registration."
+	newPackage := RPackage named: self categoryName organizer: self organizer.
 
-	newRPackage classes do: [ :each | SystemAnnouncer uniqueInstance classRepackaged: each from: self package to: newRPackage ]
+	self classes do: [ :class | newPackage moveClass: class toTag: newPackage rootTag ].
+
+	self organizer registerPackage: newPackage
 ]
 
 { #category : #accessing }

--- a/src/RPackage-Tests/RPackageTagTest.class.st
+++ b/src/RPackage-Tests/RPackageTagTest.class.st
@@ -55,41 +55,7 @@ RPackageTagTest >> testAddClassFromTag [
 ]
 
 { #category : #tests }
-RPackageTagTest >> testAsRPackage [
-
-	| package1 tag convertedTag class |
-	package1 := (self createNewPackageNamed: #Test1) register.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
-	class compile: 'foo ^42' classified: 'accessing'.
-
-	tag := package1 classTagNamed: #TAG1.
-
-	convertedTag := tag asRPackage.
-
-	self assert: (convertedTag includesClass: class).
-	self assert: (convertedTag includesSelector: 'foo' ofClass: class)
-]
-
-{ #category : #tests }
-RPackageTagTest >> testAsRPackageWithExtensionMethods [
-
-	| package1 convertedTag class |
-	package1 := (self createNewPackageNamed: #Test1) register.
-	package1 addClassTag: #TAG1.
-
-	(self createNewPackageNamed: #Test2) register.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test2'.
-
-	class compile: 'foo ^42' classified: '*Test1-TAG1'.
-
-	convertedTag := (package1 classTagNamed: #TAG1) asRPackage.
-
-	self assertEmpty: convertedTag definedClasses.
-	self assert: (convertedTag includesExtensionSelector: 'foo' ofClass: class)
-]
-
-{ #category : #tests }
-RPackageTagTest >> testPromoteAsRPackage [
+RPackageTagTest >> testPromoteAsPackage [
 
 	| package1 package2 class tag1 |
 	package1 := (self createNewPackageNamed: #Test1) register.
@@ -98,33 +64,10 @@ RPackageTagTest >> testPromoteAsRPackage [
 
 	tag1 := package1 classTagNamed: 'TAG1'.
 
-	tag1 promoteAsRPackage.
+	tag1 promoteAsPackage.
 
 	package2 := self organizer packageNamed: 'Test1-TAG1'.
 	self assert: package2 notNil.
 	self assert: (package2 classes includes: class).
 	self deny: (package1 classes includes: class)
-]
-
-{ #category : #tests }
-RPackageTagTest >> testPromoteAsRPackageWithExtension [
-
-	| packageOriginal packagePromoted class classOther tag |
-	packageOriginal := (self createNewPackageNamed: #Test1) register.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
-	class compile: 'foo ^42' classified: #accessing.
-
-	classOther := self createNewClassNamed: 'TestClassOther' inCategory: 'XXXX'.
-	classOther compile: 'bar ^42' classified: #'*Test1-TAG1'.
-
-	tag := packageOriginal classTagNamed: 'TAG1'.
-	tag promoteAsRPackage.
-
-	packagePromoted := self organizer packageNamed: 'Test1-TAG1'.
-	self assert: packagePromoted notNil.
-	self assert: (packagePromoted classes includes: class).
-	self assert: (packagePromoted extensionMethods includes: classOther >> #bar).
-	self assert: (classOther >> #bar) protocolName equals: '*Test1-TAG1'.
-	self deny: (packageOriginal classes includes: class).
-	self deny: (packageOriginal extensionMethods includes: classOther >> #bar)
 ]

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -113,7 +113,7 @@ RPackageTest >> testAnonymousClassAndSelector [
 	ghost classify: #rpackagetest under: '*rpackagetest'
 ]
 
-{ #category : #tests }
+{ #category : #'tests - demotion' }
 RPackageTest >> testDemoteToRPackageNamed [
 
 	| package1 package2 class |
@@ -121,7 +121,7 @@ RPackageTest >> testDemoteToRPackageNamed [
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
 	class compile: 'foo ^42' classified: 'accessing'.
 
-	package1 demoteToTagInPackageNamed: 'Test1'.
+	package1 demoteToTagInPackage.
 
 	self deny: (self organizer hasPackage: package1).
 	package2 := self organizer packageNamed: 'Test1'.
@@ -130,7 +130,7 @@ RPackageTest >> testDemoteToRPackageNamed [
 	self assert: ((package2 classTagNamed: 'TAG1') classes includes: class)
 ]
 
-{ #category : #tests }
+{ #category : #'tests - demotion' }
 RPackageTest >> testDemoteToRPackageNamedExistingPackage [
 
 	| package1 package2 packageExisting class |
@@ -139,7 +139,7 @@ RPackageTest >> testDemoteToRPackageNamedExistingPackage [
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
 	class compile: 'foo ^42' classified: 'accessing'.
 
-	package1 demoteToTagInPackageNamed: 'Test1'.
+	package1 demoteToTagInPackage.
 
 	self deny: (self organizer hasPackage: package1).
 	package2 := self organizer packageNamed: 'Test1'.
@@ -149,7 +149,7 @@ RPackageTest >> testDemoteToRPackageNamedExistingPackage [
 	self assert: ((package2 classTagNamed: 'TAG1') classes includes: class)
 ]
 
-{ #category : #tests }
+{ #category : #'tests - demotion' }
 RPackageTest >> testDemoteToRPackageNamedKeepOrganizer [
 
 	| newOrganizer package renamedPackage |
@@ -157,37 +157,20 @@ RPackageTest >> testDemoteToRPackageNamedKeepOrganizer [
 
 	package := (RPackage named: #'Test1-TAG1' organizer: newOrganizer) register.
 
-	renamedPackage := package demoteToTagInPackageNamed: 'Test1'.
+	renamedPackage := package demoteToTagInPackage.
 
 	self assert: renamedPackage organizer identicalTo: newOrganizer
 ]
 
-{ #category : #tests }
-RPackageTest >> testDemoteToRPackageNamedMultilevelPackage1 [
+{ #category : #'tests - demotion' }
+RPackageTest >> testDemoteToRPackageNamedMultilevelPackage [
 
 	| package1 package2 class |
 	package1 := (self createNewPackageNamed: #'Test1-TAG1-X1') register.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1-X1'.
 	class compile: 'foo ^42' classified: 'accessing'.
 
-	package1 demoteToTagInPackageNamed: 'Test1'.
-
-	self deny: (self organizer hasPackage: package1).
-	package2 := self organizer packageNamed: 'Test1'.
-	self assert: package2 notNil.
-	self assert: (package2 classes includes: class).
-	self assert: ((package2 classTagNamed: 'TAG1-X1') classes includes: class)
-]
-
-{ #category : #tests }
-RPackageTest >> testDemoteToRPackageNamedMultilevelPackage2 [
-
-	| package1 package2 class |
-	package1 := (self createNewPackageNamed: #'Test1-TAG1-X1') register.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1-X1'.
-	class compile: 'foo ^42' classified: 'accessing'.
-
-	package1 demoteToTagInPackageNamed: 'Test1-TAG1'.
+	package1 demoteToTagInPackage.
 
 	self deny: (self organizer hasPackage: package1).
 	package2 := self organizer packageNamed: 'Test1-TAG1'.
@@ -196,7 +179,7 @@ RPackageTest >> testDemoteToRPackageNamedMultilevelPackage2 [
 	self assert: ((package2 classTagNamed: 'X1') classes includes: class)
 ]
 
-{ #category : #tests }
+{ #category : #'tests - demotion' }
 RPackageTest >> testDemoteToRPackageNamedWithExtension [
 
 	| packageOriginal packageDemoted class classOther |
@@ -207,7 +190,7 @@ RPackageTest >> testDemoteToRPackageNamedWithExtension [
 	classOther := self createNewClassNamed: 'TestClassOther' inCategory: 'XXXX'.
 	classOther compile: 'bar ^42' classified: #'*Test1-TAG1'.
 
-	packageOriginal demoteToTagInPackageNamed: 'Test1'.
+	packageOriginal demoteToTagInPackage.
 
 	self deny: (self organizer hasPackage: packageOriginal).
 	packageDemoted := self organizer packageNamed: 'Test1'.

--- a/src/SystemCommands-PackageCommands/SycDemoteToPackageWithTagCommand.class.st
+++ b/src/SystemCommands-PackageCommands/SycDemoteToPackageWithTagCommand.class.st
@@ -27,6 +27,6 @@ SycDemoteToPackageWithTagCommand >> defaultMenuItemName [
 SycDemoteToPackageWithTagCommand >> execute [
 
 	packages
-		select: [ :each | each name includes: $- ]
-		thenDo: [ :each | each demoteToTagInPackageNamed: (each name copyUpToLast: $-) ]
+		select: [ :package | package name includes: $- ]
+		thenDo: [ :package | package demoteToTagInPackage ]
 ]

--- a/src/SystemCommands-PackageCommands/SycPromotePackageFromTagCommand.class.st
+++ b/src/SystemCommands-PackageCommands/SycPromotePackageFromTagCommand.class.st
@@ -39,9 +39,7 @@ SycPromotePackageFromTagCommand >> defaultMenuItemName [
 { #category : #execution }
 SycPromotePackageFromTagCommand >> execute [
 
-	| packageTag |
-	packageTag := package classTagNamed: classTag.
-	packageTag promoteAsRPackage
+	(package classTagNamed: classTag) promoteAsPackage
 ]
 
 { #category : #execution }


### PR DESCRIPTION
This change cleans the package demotion and the tag promotion in RPackage.

My original goal was to factorize the code to move classes from a package to another because we had this logic in three different places with slight differences. I plan to update this moving logic (my mid term goal is to replace ClassRecategorized event by ClassRapackaged event, and to do that I need to add information about the tags containing the classes).

I also cleaned further those methods to simplify them because they were too complex for what they did. 

There are still two things I do not like in those methods but it cannot be fixed before the system organizer is dead. I left two comment in the code to explain the problem and what to do once the system organizer is out.