### PR TITLE
Fix: make class abstract

### DIFF
--- a/src/Refactoring-Core/RBAbstractTransformation.class.st
+++ b/src/Refactoring-Core/RBAbstractTransformation.class.st
@@ -160,7 +160,7 @@ RBAbstractTransformation >> model [
 
 	^ model
 		ifNil: [ model := ( RBClassModelFactory rbNamespace onEnvironment: self defaultEnvironment )
-				name: self printString;
+				name: 'Changes for ', self class name asString;
 				yourself
 			]
 		ifNotNil: [ model ]

--- a/src/Refactoring-Core/RBAbstractTransformation.class.st
+++ b/src/Refactoring-Core/RBAbstractTransformation.class.st
@@ -156,19 +156,20 @@ RBAbstractTransformation >> execute [
 ]
 
 { #category : #accessing }
+RBAbstractTransformation >> model [
+
+	^ model
+		ifNil: [ model := ( RBClassModelFactory rbNamespace onEnvironment: self defaultEnvironment )
+				name: self printString;
+				yourself
+			]
+		ifNotNil: [ model ]
+]
+
+{ #category : #accessing }
 RBAbstractTransformation >> model: aRBNamespace [
 
 	model := aRBNamespace
-]
-
-{ #category : #initialize }
-RBAbstractTransformation >> newModel [
-
-	model := (RBNamespace
-			onEnvironment: self defaultEnvironment)
-			name: self printString;
-			yourself.
-	^ model
 ]
 
 { #category : #'To be removed' }

--- a/src/Refactoring-Core/RBAbstractTransformation.class.st
+++ b/src/Refactoring-Core/RBAbstractTransformation.class.st
@@ -89,7 +89,7 @@ RBAbstractTransformation class >> refactoringOptions [
 { #category : #accessing }
 RBAbstractTransformation >> changes [
 
-	^ model changes
+	^ self model changes
 ]
 
 { #category : #'condition definitions' }
@@ -238,7 +238,7 @@ RBAbstractTransformation >> poolVariableNamesFor: aClass [
 
 { #category : #accessing }
 RBAbstractTransformation >> poolVariableNamesIn: poolName [
-	^(model classNamed: poolName) classPool keys
+	^(self model classNamed: poolName) classPool keys
 ]
 
 { #category : #preconditions }

--- a/src/Refactoring-Core/RBRefactoring.class.st
+++ b/src/Refactoring-Core/RBRefactoring.class.st
@@ -129,17 +129,6 @@ RBRefactoring >> generateChangesFor: aRefactoring [
 	aRefactoring primitiveExecute
 ]
 
-{ #category : #transforming }
-RBRefactoring >> model [
-
-	^ model
-		ifNil: [ model := ( RBClassModelFactory rbNamespace onEnvironment: self defaultEnvironment )
-				name: self printString;
-				yourself
-			]
-		ifNotNil: [ model ]
-]
-
 { #category : #private }
 RBRefactoring >> onError: aBlock do: errorBlock [
 	^aBlock on: self class preconditionSignal

--- a/src/Refactoring2-Transformations-Tests/RBMakeClassAbstractParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMakeClassAbstractParametrizedTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'testClass'
 	],
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
 }
 
 { #category : #tests }
@@ -36,6 +36,22 @@ RBMakeClassAbstractParametrizedTest >> testMakeClassAbstractAddsIsAbstractMethod
 	refactoring := rbClass class: testClass.
 
 	self executeRefactoring: refactoring.
+	self assert: ((refactoring model classNamed: testClass name) classSide
+			parseTreeForSelector: #isAbstract)
+		equals: (self parseMethod: 'isAbstract ^self == ', testClass name)
+]
+
+{ #category : #tests }
+RBMakeClassAbstractParametrizedTest >> testMakeClassAbstractPerformChanges [
+	"This test checks if actually performing refactoring applies the changes
+	since model needs to be set correctly. There was a regression when model
+	was nil. This test case covers that. In future we should create tests
+	that check `performChanges` logic."
+
+	| refactoring |
+	refactoring := rbClass class: testClass.
+
+	refactoring execute.
 	self assert: ((refactoring model classNamed: testClass name) classSide
 			parseTreeForSelector: #isAbstract)
 		equals: (self parseMethod: 'isAbstract ^self == ', testClass name)

--- a/src/Refactoring2-Transformations/RBTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBTransformation.class.st
@@ -102,12 +102,6 @@ RBTransformation >> copyOptionsFrom: aDictionary [
 	self options: dict
 ]
 
-{ #category : #accessing }
-RBTransformation >> model [
-
-	^ model ifNil: [ model := self newModel ]
-]
-
 { #category : #preconditions }
 RBTransformation >> preconditions [
 


### PR DESCRIPTION
Make class abstract was failing because `model` was `nil`. It's fixed by using model accessor instead of using it directly, since model is lazily initialised.

Besides, I've pushed-up `model` accessor to superclass, since it's the same for refactoring and transformation.