### PR TITLE
RPackage: Automatically register packages in tests

### DIFF
--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -60,21 +60,15 @@ RPackageOrganizerTest >> testAccessingPackage [
 
 	| p1 |
 	p1 := self createNewPackageNamed: 'P1'.
-	self organizer registerPackage: p1.
-	p1 addClassDefinition: Point.
-	p1 addMethod: Point>>#x.
-	p1 addMethod: Point class>>#x:y:.
 	self assert: (self organizer packageNamed: #P1) equals: p1.
-	self should: [(self organizer packageNamed: #P22)] raise: Error
+	self should: [ self organizer packageNamed: #P22 ] raise: Error
 ]
 
 { #category : #tests }
 RPackageOrganizerTest >> testCreateNewPackageWithConflictRaisesConflictException [
 
 	self organizer createPackageNamed: 'P1'.
-	self
-		should: [ self organizer createPackageNamed: 'P1' ]
-		raise: RPackageConflictError
+	self should: [ self organizer createPackageNamed: 'P1' ] raise: RPackageConflictError
 ]
 
 { #category : #tests }
@@ -88,12 +82,11 @@ RPackageOrganizerTest >> testCreateNewPackageWithoutConflictCreatesPackage [
 RPackageOrganizerTest >> testDefinedClassesInstanceAndMetaSideAPI [
 
 	| p1 |
-	p1 := self createNewPackageNamed: 'P1'.
-	self organizer registerPackage: p1.
+	p1 := self createNewPackageNamed: self p1Name.
 	self createNewClassNamed: #MyPoint inPackage: p1.
 	self assert: self organizer packageNames size equals: 2.
 	self assert: self organizer packages size equals: 2.
-	self assert: (self organizer packageNamed: #P1) definedClasses size equals: 1
+	self assert: (self organizer packageNamed: self p1Name) definedClasses size equals: 1
 ]
 
 { #category : #tests }
@@ -109,9 +102,6 @@ RPackageOrganizerTest >> testExtensionMethodNotExactlyTheName [
 	| p1 p2 c1 |
 	p1 := self createNewPackageNamed: 'P1'.
 	p2 := self createNewPackageNamed: 'P2'.
-
-	self organizer basicRegisterPackage: p1.
-	self organizer basicRegisterPackage: p2.
 
 	c1 := self createNewClassNamed: #C1 inPackage: p2.
 
@@ -131,10 +121,6 @@ RPackageOrganizerTest >> testFullRegistration [
 	p1 := self createNewPackageNamed: self p1Name.
 	p2 := self createNewPackageNamed: self p2Name.
 	p3 := self createNewPackageNamed: self p3Name.
-	
-	p1 register.
-	p2 register.
-	p3 register.
 
 	a1 :=  self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
 	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.
@@ -191,73 +177,30 @@ RPackageOrganizerTest >> testHasPackage [
 { #category : #tests }
 RPackageOrganizerTest >> testRegisterPackageConflictWithPackage [
 
-	| package1 package2 |
-	package1 := self createNewPackageNamed: 'P1'.
-	package1 register.
-
-	package2 := RPackage named: 'P1'.
-	self
-		should: [ package2 register ]
-		raise: Error
+	self createNewPackageNamed: 'P1'.
+	self should: [ (RPackage named: 'P1') register ] raise: Error
 ]
 
 { #category : #tests }
 RPackageOrganizerTest >> testRegisterPackageConflictWithPackageTag [
 
-	| package1 package2 |
-
+	| package1 |
+	self flag: #package. "This is a limitiation of the system organizer. I hope to kill this limitiation before p12 release."
 	package1 := self createNewPackageNamed: 'P1'.
-	package1 register.
 	package1 addClassTag: #T1.
 
-	package2 := self createNewPackageNamed: 'P1-T1'.
-	self
-		should: [ package2 register ]
-		raise: Error
+	self should: [ self createNewPackageNamed: 'P1-T1' ] raise: Error
 ]
 
 { #category : #tests }
 RPackageOrganizerTest >> testRegisterPackageTagConflictWithPackage [
-	| package1 package2 |
 
+	| package1 package2 |
+	self flag: #package. "This is a limitiation of the system organizer. I hope to kill this limitiation before p12 release."
 	package1 := self createNewPackageNamed: 'P1-T1'.
-	package1 register.
 
 	package2 := self createNewPackageNamed: 'P1'.
-	self
-		should: [ package2 addClassTag: #T1 ]
-		raise: Error
-]
-
-{ #category : #tests }
-RPackageOrganizerTest >> testRegisteredIsIncludedInPackageNames [
-
-	| p1 p2 p3 |
-	p1 := self createNewPackageNamed: 'P1'.
-	p2 := self createNewPackageNamed: 'P2'.
-	p3 := self createNewPackageNamed: 'P3'.
-
-	self organizer registerPackage: p1.
-	self organizer registerPackage: p2.
-	self organizer registerPackage: p3.
-	self assert: self organizer packageNames size equals: 4. "We also have the default package."
-	{ p1 . p2 . p3 } do: [ :package | self assert: (self organizer packageNames includes: package name) ]
-]
-
-{ #category : #tests }
-RPackageOrganizerTest >> testRegisteredIsThere [
-	| p1 p2 p3 |
-	p1 := self createNewPackageNamed: 'P1'.
-	p2 := self createNewPackageNamed: 'P2'.
-	p3 := self createNewPackageNamed: 'P3'.
-
-	self organizer basicRegisterPackage: p1.
-	self organizer basicRegisterPackage: p2.
-	self organizer basicRegisterPackage: p3.
-	self assert: self organizer packageNames size equals: 4.
-
-	{p1 . p2 . p3} do: [:each |
-		self assert:  (self organizer packageNames includes: each name)]
+	self should: [ package2 addClassTag: #T1 ] raise: Error
 ]
 
 { #category : #tests }
@@ -273,6 +216,20 @@ RPackageOrganizerTest >> testRegisteredNumberOfPackageIsOk [
 	self assert: self organizer packageNames size equals: 4.
 	self organizer basicUnregisterPackageNamed: p3 name.
 	self assert: self organizer packageNames size equals: 3
+]
+
+{ #category : #tests }
+RPackageOrganizerTest >> testRegisteredPackages [
+
+	| p1 p2 p3 |
+	p1 := self createNewPackageNamed: 'P1'.
+	p2 := self createNewPackageNamed: 'P2'.
+	p3 := self createNewPackageNamed: 'P3'.
+
+	self assert: self organizer packageNames size equals: 4. "We also have the default package."
+	{ p1 . p2 . p3 } do: [ :package |
+		self assert: (self organizer packageNames includes: package name).
+		self assert: (self organizer packages includes: package) ]
 ]
 
 { #category : #'tests - extending' }
@@ -293,13 +250,13 @@ RPackageOrganizerTest >> testRemoveEmptyPackagesAndTags [
 
 	| organizer package1 package2 package3 package4 class tag1 tag2 |
 	"This one will contain a class"
-	package1 := (self createNewPackageNamed: #Test1) register.
+	package1 := (self createNewPackageNamed: #Test1).
 	"This one will contain an extension method"
-	package2 := (self createNewPackageNamed: #Test2) register.
+	package2 := (self createNewPackageNamed: #Test2).
 	"This one will contain a tag with a class and an empty tag"
-	package3 := (self createNewPackageNamed: #Test3) register.
+	package3 := (self createNewPackageNamed: #Test3).
 	"This one will be empty"
-	package4 := (self createNewPackageNamed: #Test4) register.
+	package4 := (self createNewPackageNamed: #Test4).
 
 	tag1 := package3 addClassTag: #Tag1.
 	tag2 := package3 addClassTag: #Tag2.
@@ -344,10 +301,6 @@ RPackageOrganizerTest >> testRemovePackage [
 	p2 := self createNewPackageNamed: self p2Name.
 	p3 := self createNewPackageNamed: self p3Name.
 
-	p1 register.
-	p2 register.
-	p3 register.
-
 	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
 	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.
 	a2 := self createNewClassNamed: #A2DefinedInP2 inPackage: p2.
@@ -387,13 +340,12 @@ RPackageOrganizerTest >> testTestPackageNames [
 
 	| packages |
 	packages := self createMockTestPackages.
-	packages do: [:aPackage | self organizer registerPackage: aPackage].
 
 	"Only 2 mock package names are test packages:  'MockPackage-Tests' 'MockPackage-Tests-Package'"
 	self assert: self organizer testPackageNames size equals: 2.
 
 	"Names of test packages are symbols."
-	self assert: (self organizer testPackageNames allSatisfy: #isSymbol) equals: true
+	self assert: (self organizer testPackageNames allSatisfy: #isSymbol)
 ]
 
 { #category : #tests }
@@ -401,30 +353,29 @@ RPackageOrganizerTest >> testTestPackages [
 
 	| packages |
 	packages := self createMockTestPackages.
-	packages do: [:aPackage | self organizer registerPackage: aPackage].
 
 	"Only 2 mock packages are test packages:  'MockPackage-Tests' 'MockPackage-Tests-Package'."
 	self assert: self organizer testPackages size equals: 2.
 
 	"all items from resulting collection are test packages."
-	self assert: (self organizer testPackages allSatisfy: #isTestPackage) equals: true
+	self assert: (self organizer testPackages allSatisfy: #isTestPackage)
 ]
 
 { #category : #tests }
 RPackageOrganizerTest >> testUnregisterBasedOnNames [
+
 	| p1 p2 p3 |
 	p1 := self createNewPackageNamed: 'P1'.
 	p2 := self createNewPackageNamed: 'P2'.
 	p3 := self createNewPackageNamed: 'P3'.
 
-	self organizer basicRegisterPackage: p1.
-	self organizer basicRegisterPackage: p2.
-	self organizer basicRegisterPackage: p3.
 	self assert: self organizer packageNames size equals: 4.
 
 	{p1 . p2 . p3} do: [:each |
 		(self organizer basicUnregisterPackageNamed: each name).
-		self deny:  (self organizer packageNames includes: each name)]
+		self deny: (self organizer packageNames includes: each name) ].
+
+	self assert: self organizer packageNames size equals: 1
 ]
 
 { #category : #'tests - extending' }

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -67,24 +67,25 @@ RPackageReadOnlyCompleteSetupTest >> setUp [
 
 { #category : #'tests - tag class' }
 RPackageReadOnlyCompleteSetupTest >> testAddTag [
-	self assertEmpty: p1 classTags.
+
+	self assert: p1 classTags size equals: 1. "We start with the root tag"
 	p1 addClassTag: #baz.
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #baz ]).
-	self assert: p1 classTags size equals: 1.
+	self assert: p1 classTags size equals: 2.
 
 	p1 addClassDefinition: a1 toClassTag: #foo.
 	p1 addClassDefinition: b1 toClassTag: #foo.
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #foo ]).
 	self assert: p1 classTags size equals: 2.
-	self assert: (((p1 classesForClassTag: #foo) collect: [:each | each name]) includes: #A1DefinedInP1).
-	self assert: (((p1 classesForClassTag: #foo) collect: [:each | each name]) includes: #B1DefinedInP1).
+	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
+	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
 	self assert: (p1 classesForClassTag: #foo) size equals: 2.
 
 	p1 addClassTag: #foo.
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #baz ]).
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #foo ]).
-	self assert: (((p1 classesForClassTag: #foo) collect: [:each | each name]) includes: #A1DefinedInP1).
-	self assert: (((p1 classesForClassTag: #foo) collect: [:each | each name]) includes: #B1DefinedInP1).
+	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
+	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
 	self assert: (p1 classesForClassTag: #foo) size equals: 2
 ]
 

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -76,7 +76,7 @@ RPackageReadOnlyCompleteSetupTest >> testAddTag [
 	p1 addClassDefinition: a1 toClassTag: #foo.
 	p1 addClassDefinition: b1 toClassTag: #foo.
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #foo ]).
-	self assert: p1 classTags size equals: 2.
+	self assert: p1 classTags size equals: 2. "foo and baz. The root tag got automatically removed since it was empty."
 	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
 	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
 	self assert: (p1 classesForClassTag: #foo) size equals: 2.
@@ -91,15 +91,16 @@ RPackageReadOnlyCompleteSetupTest >> testAddTag [
 
 { #category : #'tests - tag class' }
 RPackageReadOnlyCompleteSetupTest >> testAddTagNames [
-	self assertEmpty: p1 classTags.
+
+	self assert: p1 classTags size equals: 1. "We start with the root tag"
 	p1 addClassTag: #baz.
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #baz ]).
-	self assert: p1 classTags size equals: 1.
+	self assert: p1 classTags size equals: 2.
 
 	p1 addClassDefinition: a1 toClassTag: #foo.
 	p1 addClassDefinition: b1 toClassTag: #foo.
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #foo ]).
-	self assert: p1 classTags size equals: 2.
+	self assert: p1 classTags size equals: 2. "foo and baz. The root tag got automatically removed since it was empty."
 	self assert: ((p1 classNamesForClassTag: #foo) includes: #A1DefinedInP1).
 	self assert: ((p1 classNamesForClassTag: #foo) includes: #B1DefinedInP1).
 	self assert: (p1 classNamesForClassTag: #foo) size equals: 2.
@@ -115,7 +116,7 @@ RPackageReadOnlyCompleteSetupTest >> testAddTagNames [
 { #category : #'tests - tag class' }
 RPackageReadOnlyCompleteSetupTest >> testAddTagsToAClass [
 
-	self assertEmpty: p1 classTags.
+	self assert: p1 classTags size equals: 1. "We start with the root tag"
 
 	p1 addClassDefinition: a1 toClassTag: #foo.
 	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
@@ -127,7 +128,7 @@ RPackageReadOnlyCompleteSetupTest >> testAddTagsToAClass [
 
 	p1 addClassDefinition: b1 toClassTag: #zork.
 	self assert: (((p1 classesForClassTag: #zork) collect: [ :each | each name ]) includes: #B1DefinedInP1).
-	self assert: (p1 classesForClassTag: #foo) size equals: 2.
+	self assert: (p1 classesForClassTag: #foo) size equals: 1.
 	self assert: (p1 classesForClassTag: #zork) size equals: 1
 ]
 
@@ -188,7 +189,8 @@ RPackageReadOnlyCompleteSetupTest >> testDefinedSelectorsForClass [
 
 { #category : #'tests - tag class' }
 RPackageReadOnlyCompleteSetupTest >> testEmpty [
-	self assertEmpty: p1 classTags
+
+	self assertEmpty: (RPackage named: 'new package') classTags
 ]
 
 { #category : #'tests - accessing' }
@@ -295,7 +297,7 @@ RPackageReadOnlyCompleteSetupTest >> testPackagesOfClass [
 { #category : #'tests - tag class' }
 RPackageReadOnlyCompleteSetupTest >> testRemoveTag [
 
-	self assertEmpty: p1 classTags.
+	self assert: p1 classTags size equals: 1. "We start with the root tag"
 
 	p1 addClassDefinition: a1 toClassTag: #foo.
 	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
@@ -321,21 +323,27 @@ RPackageReadOnlyCompleteSetupTest >> testRemoveTaggedClasses [
 	p1 addClassDefinition: b1 toClassTag: #foo.
 	p1 addClassDefinition: b1 toClassTag: #zork.
 	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
-	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
-	self assert: (p1 classesForClassTag: #foo) size equals: 2.
+	self deny: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+	self assert: (p1 classesForClassTag: #foo) size equals: 1.
 	self deny: (((p1 classesForClassTag: #zork) collect: [ :each | each name ]) includes: #A1DefinedInP1).
-	self assert: (((p1 classesForClassTag: #zork) collect: [ :each | each name ]) includes: #B1DefinedInP1). "now when we remove a class" "from an existing tags list"
+	self assert: (((p1 classesForClassTag: #zork) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+
+	"now when we remove a class" "from an existing tags list"
 	p1 removeClassDefinition: a1 fromClassTag: #foo.
 	self deny: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
-	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
-	self assert: (p1 classesForClassTag: #foo) size equals: 1. "from a nonexisting tag list"
+	self deny: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+	self assertEmpty: (p1 classesForClassTag: #foo).
+
+	"from a nonexisting tag list"
 	p1 removeClassDefinition: b1 fromClassTag: #taz.
-	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
-	self assert: (((p1 classesForClassTag: #zork) collect: [ :each | each name ]) includes: #B1DefinedInP1). "with a class not registered to a tag list"
+	self deny: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+	self assert: (((p1 classesForClassTag: #zork) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+
+	"with a class not registered to a tag list"
 	p1 removeClassDefinition: self class fromClassTag: #foo.
 	self deny: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
-	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
-	self assert: (p1 classesForClassTag: #foo) size equals: 1
+	self deny: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+	self assertEmpty: (p1 classesForClassTag: #foo)
 ]
 
 { #category : #'tests - situation' }

--- a/src/RPackage-Tests/RPackageTagTest.class.st
+++ b/src/RPackage-Tests/RPackageTagTest.class.st
@@ -18,47 +18,47 @@ RPackageTagTest >> tearDown [
 RPackageTagTest >> testAddClass [
 
 	| package1 package2 class |
-	package1 := (self createNewPackageNamed: #Test1) register.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1'.
+	package1 := self createNewPackageNamed: #Test1.
+	class := self createNewClassNamed: 'TestClass' inPackage: package1.
 
 	self assert: (package1 includesClass: class).
 
-	package2 := (self createNewPackageNamed: #Test2) register.
+	package2 := self createNewPackageNamed: #Test2.
 
 	(package2 addClassTag: #TAG) addClass: class.
 
 	self deny: (package1 includesClass: class).
 	self assert: (package2 includesClass: class).
-	self assert: (package2 classTagNamed: #TAG ifAbsent: [ nil ]) notNil.
-	self assert: ((package2 classTagNamed: #TAG ifAbsent: [ nil ]) includesClass: class)
+	self assert: (package2 hasTag: #TAG).
+	self assert: ((package2 classTagNamed: #TAG) includesClass: class)
 ]
 
 { #category : #tests }
 RPackageTagTest >> testAddClassFromTag [
-	| package1 package2 class |
 
-	package1 := (self createNewPackageNamed: #Test1) register.
+	| package1 package2 class |
+	package1 := self createNewPackageNamed: #Test1.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
 
 	self assert: (package1 includesClass: class).
-	self assert: (package1 classTagNamed: #TAG1 ifAbsent: [ nil ]) notNil.
-	self assert: ((package1 classTagNamed: #TAG1 ifAbsent: [ nil ]) includesClass: class).
+	self assert: (package1 hasTag: #TAG1).
+	self assert: ((package1 classTagNamed: #TAG1) includesClass: class).
 
-	package2 := (self createNewPackageNamed: #Test2) register.
+	package2 := self createNewPackageNamed: #Test2.
 
 	(package2 addClassTag: #TAG2) addClass: class.
 
 	self deny: (package1 includesClass: class).
 	self assert: (package2 includesClass: class).
-	self assert: (package2 classTagNamed: #TAG2 ifAbsent: [ nil ]) notNil.
-	self assert: ((package2 classTagNamed: #TAG2 ifAbsent: [ nil ]) includesClass: class)
+	self assert: (package2 hasTag: #TAG2).
+	self assert: ((package2 classTagNamed: #TAG2) includesClass: class)
 ]
 
 { #category : #tests }
 RPackageTagTest >> testPromoteAsPackage [
 
 	| package1 package2 class tag1 |
-	package1 := (self createNewPackageNamed: #Test1) register.
+	package1 := self createNewPackageNamed: #Test1.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
 	class compile: 'foo ^42' classified: 'accessing'.
 
@@ -67,7 +67,7 @@ RPackageTagTest >> testPromoteAsPackage [
 	tag1 promoteAsPackage.
 
 	package2 := self organizer packageNamed: 'Test1-TAG1'.
-	self assert: package2 notNil.
+	self assert: package2 isNotNil.
 	self assert: (package2 classes includes: class).
 	self deny: (package1 classes includes: class)
 ]

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -32,16 +32,16 @@ RPackageTest >> testActualClassTags [
 RPackageTest >> testAddClass [
 
 	| package1 package2 class done |
-	package1 := (self createNewPackageNamed: #Test1) register.
+	package1 := self createNewPackageNamed: #Test1.
 	done := 0.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG'.
 
 
 	self assert: (package1 includesClass: class).
-	self assert: (package1 classTagNamed: #TAG ifAbsent: [ nil ]) notNil.
-	self assert: ((package1 classTagNamed: #TAG ifAbsent: [ nil ]) includesClass: class).
+	self assert: (package1 hasTag: #TAG).
+	self assert: ((package1 classTagNamed: #TAG) includesClass: class).
 
-	package2 := (self createNewPackageNamed: #Test2) register.
+	package2 := self createNewPackageNamed: #Test2.
 	[
 	SystemAnnouncer uniqueInstance when: ClassRecategorized do: [ done := done + 1 ] for: self.
 	package2 addClass: class ] ensure: [ SystemAnnouncer uniqueInstance unsubscribe: self ].
@@ -49,34 +49,34 @@ RPackageTest >> testAddClass [
 	self assert: done equals: 1.
 	self deny: (package1 includesClass: class).
 	self assert: (package2 includesClass: class).
-	self assert: (package2 classTagNamed: #Test2 ifAbsent: [ nil ]) notNil.
-	self assert: ((package2 classTagNamed: #Test2 ifAbsent: [ nil ]) includesClass: class)
+	self assert: (package2 hasTag: #Test2).
+	self assert: ((package2 classTagNamed: #Test2) includesClass: class)
 ]
 
 { #category : #tests }
 RPackageTest >> testAddClassFromTag [
 
 	| package1 package2 class |
-	package1 := (self createNewPackageNamed: #Test1) register.
+	package1 := self createNewPackageNamed: #Test1.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG'.
 
 	self assert: (package1 includesClass: class).
 
-	package2 := (self createNewPackageNamed: #Test2) register.
+	package2 := self createNewPackageNamed: #Test2.
 
 	package2 addClass: class.
 
 	self deny: (package1 includesClass: class).
 	self assert: (package2 includesClass: class).
-	self assert: (package2 classTagNamed: #Test2 ifAbsent: [ nil ]) notNil.
-	self assert: ((package2 classTagNamed: #Test2 ifAbsent: [ nil ]) includesClass: class)
+	self assert: (package2 hasTag: #Test2).
+	self assert: ((package2 classTagNamed: #Test2) includesClass: class)
 ]
 
 { #category : #tests }
 RPackageTest >> testAllUnsentMessages [
 
 	| package class1 class2 |
-	package := (self createNewPackageNamed: #Test1) register.
+	package := self createNewPackageNamed: #Test1.
 
 	class1 := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG'.
 	class2 := self createNewClassNamed: 'TestClassOther' inCategory: 'Test1-TAG'.
@@ -117,8 +117,8 @@ RPackageTest >> testAnonymousClassAndSelector [
 RPackageTest >> testDemoteToRPackageNamed [
 
 	| package1 package2 class |
-	package1 := (self createNewPackageNamed: #'Test1-TAG1') register.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
+	package1 := self createNewPackageNamed: #'Test1-TAG1'.
+	class := self createNewClassNamed: 'TestClass' inPackage: package1.
 	class compile: 'foo ^42' classified: 'accessing'.
 
 	package1 demoteToTagInPackage.
@@ -134,16 +134,16 @@ RPackageTest >> testDemoteToRPackageNamed [
 RPackageTest >> testDemoteToRPackageNamedExistingPackage [
 
 	| package1 package2 packageExisting class |
-	package1 := (self createNewPackageNamed: #'Test1-TAG1') register.
-	packageExisting := (self createNewPackageNamed: #Test1) register.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
+	package1 := self createNewPackageNamed: #'Test1-TAG1'.
+	packageExisting := self createNewPackageNamed: #Test1.
+	class := self createNewClassNamed: 'TestClass' inPackage: package1.
 	class compile: 'foo ^42' classified: 'accessing'.
 
 	package1 demoteToTagInPackage.
 
 	self deny: (self organizer hasPackage: package1).
 	package2 := self organizer packageNamed: 'Test1'.
-	self assert: package2 notNil.
+	self assert: package2 isNotNil.
 	self assert: package2 equals: packageExisting.
 	self assert: (package2 classes includes: class).
 	self assert: ((package2 classTagNamed: 'TAG1') classes includes: class)
@@ -155,7 +155,7 @@ RPackageTest >> testDemoteToRPackageNamedKeepOrganizer [
 	| newOrganizer package renamedPackage |
 	newOrganizer := RPackageOrganizer new.
 
-	package := (RPackage named: #'Test1-TAG1' organizer: newOrganizer) register.
+	package := newOrganizer ensurePackage: #'Test1-TAG1'.
 
 	renamedPackage := package demoteToTagInPackage.
 
@@ -166,15 +166,15 @@ RPackageTest >> testDemoteToRPackageNamedKeepOrganizer [
 RPackageTest >> testDemoteToRPackageNamedMultilevelPackage [
 
 	| package1 package2 class |
-	package1 := (self createNewPackageNamed: #'Test1-TAG1-X1') register.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1-X1'.
+	package1 := self createNewPackageNamed: #'Test1-TAG1-X1'.
+	class := self createNewClassNamed: 'TestClass' inPackage: package1.
 	class compile: 'foo ^42' classified: 'accessing'.
 
 	package1 demoteToTagInPackage.
 
 	self deny: (self organizer hasPackage: package1).
 	package2 := self organizer packageNamed: 'Test1-TAG1'.
-	self assert: package2 notNil.
+	self assert: package2 isNotNil.
 	self assert: (package2 classes includes: class).
 	self assert: ((package2 classTagNamed: 'X1') classes includes: class)
 ]
@@ -183,8 +183,8 @@ RPackageTest >> testDemoteToRPackageNamedMultilevelPackage [
 RPackageTest >> testDemoteToRPackageNamedWithExtension [
 
 	| packageOriginal packageDemoted class classOther |
-	packageOriginal := (self createNewPackageNamed: #'Test1-TAG1') register.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
+	packageOriginal := self createNewPackageNamed: #'Test1-TAG1'.
+	class := self createNewClassNamed: 'TestClass' inPackage: packageOriginal.
 	class compile: 'foo ^42' classified: 'accessing'.
 
 	classOther := self createNewClassNamed: 'TestClassOther' inCategory: 'XXXX'.
@@ -194,7 +194,7 @@ RPackageTest >> testDemoteToRPackageNamedWithExtension [
 
 	self deny: (self organizer hasPackage: packageOriginal).
 	packageDemoted := self organizer packageNamed: 'Test1'.
-	self assert: packageDemoted notNil.
+	self assert: packageDemoted isNotNil.
 	self assert: (packageDemoted classes includes: class).
 	self assert: ((packageDemoted classTagNamed: 'TAG1') classes includes: class).
 	self assert: (packageDemoted extensionMethods includes: classOther >> #bar).
@@ -284,7 +284,7 @@ RPackageTest >> testPropertyAtPut [
 RPackageTest >> testRemoveEmptyTags [
 
 	| package class tag1 tag2 |
-	package := (self createNewPackageNamed: #Test1) register.
+	package := self createNewPackageNamed: #Test1.
 
 	tag1 := package addClassTag: #Tag1.
 	tag2 := package addClassTag: #Tag2.
@@ -302,23 +302,4 @@ RPackageTest >> testRemoveEmptyTags [
 
 	self assert: (package includesClassTagNamed: #Tag1).
 	self deny: (package includesClassTagNamed: #Tag2)
-]
-
-{ #category : #tests }
-RPackageTest >> testRenameToMakesMCDirty [
-
-	| package |
-	package := (self createNewPackageNamed: #Test1) register.
-	self createNewClassNamed: 'TestClass' inCategory: 'Test1'.
-
-	package renameTo: 'Test2'
-]
-
-{ #category : #'tests - queries' }
-RPackageTest >> testRoots [
-
-	| roots |
-	roots := (self packageOrganizer packageNamed: #'RPackage-Tests') roots.
-	roots := roots collect: [ :each | each name ].
-	#( RPackageStringExtensionTest RPackageRenameTest TestRPackagePrequisites RPackageTestCase RPackageWithDoTest ) do: [ :each | roots includes: each ]
 ]

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -57,8 +57,7 @@ RPackageTestCase >> createNewClassNamed: aName inPackage: p [
 RPackageTestCase >> createNewPackageNamed: aName [
 
 	| pack |
-	self removePackage: aName.
-	pack := RPackage named: aName organizer: self organizer.
+	pack := self organizer ensurePackage: aName.
 	createdPackages add: pack.
 	^ pack
 ]


### PR DESCRIPTION
RPackage tests have some helpers methods to help with the tests. One of them is here to create a new package. 

The problem is that it does not register the new package to the package organizer used for tests. So we have a lot of tests registering the packages by hand and other tests that do not register the package at all. But then the assertions can be wrong because some code is been executed in a state that does not represent the system.

Worst! In a lot of tests, we ended up with two packages of the same name. One registered in the organizer, and one orphan. This was caused by the creation of a class that ensured the requested package name was there and created a new package since the one we saved in a temporary variable was not in the organizer. This bit me a lot while manipulating the tests because I had two packages of the same name and this was hard to debug.

I found one test that really expect an unregistered package so I moved the package registration to the helper methods and adapted the tests. Either to remove the registrations or to fix the assertions that were wrong because of this. 

I also merged two tests and removed two others that had no assertion.