### PR TITLE
Treat a second click within the double-click window but in a different location as a separate click (fixes #14474)

### DIFF
--- a/src/Morphic-Base/MouseClickState.class.st
+++ b/src/Morphic-Base/MouseClickState.class.st
@@ -316,9 +316,11 @@ MouseClickState >> handleEvent: evt from: aHand [
 		^false].
 
 	clickState == #firstClickUp ifTrue:[
-		(timedOut or: [localEvt isMouseDown and: [isDrag]]) ifTrue:[
-			"timed out after mouseUp, or second click down far away from first click
-			either way breaks the possibility of a double-click - signal timeout and pass the event"
+		(timedOut or: [localEvt isMouseDown and: [
+				isDrag or: [localEvt buttons ~= firstClickDown buttons]]]) 
+		ifTrue:[
+			"timed out after mouseUp, or the mouse has moved, or this click is of a different button.
+			Can no longer have a double-click - signal timeout and pass the event"
 			aHand resetClickState.
 			self doubleClickTimeout. "***"
 			^true].

--- a/src/Morphic-Base/MouseClickState.class.st
+++ b/src/Morphic-Base/MouseClickState.class.st
@@ -279,6 +279,7 @@ MouseClickState >> handleEvent: evt from: aHand [
 			^true].
 		localEvt isMouseUp ifTrue:[
 
+			"If timedOut or the client's not interested in dbl clicks get outta here"
 			(timedOut or:[doubleClickSelector isNil]) ifTrue:[
 				self click.
 				aHand resetClickState.
@@ -289,7 +290,6 @@ MouseClickState >> handleEvent: evt from: aHand [
 			We will handle a click now."
 			clickState := #firstClickUp.
 			firstClickUp := evt copy.
-			"If timedOut or the client's not interested in dbl clicks get outta here"
 			aHand queuePendingEvent: firstClickUp.
 
 			self click.
@@ -316,8 +316,9 @@ MouseClickState >> handleEvent: evt from: aHand [
 		^false].
 
 	clickState == #firstClickUp ifTrue:[
-		(timedOut) ifTrue:[
-			"timed out after mouseUp - signal timeout and pass the event"
+		(timedOut or: [localEvt isMouseDown and: [isDrag]]) ifTrue:[
+			"timed out after mouseUp, or second click down far away from first click
+			either way breaks the possibility of a double-click - signal timeout and pass the event"
 			aHand resetClickState.
 			self doubleClickTimeout. "***"
 			^true].

--- a/src/Morphic-Base/Object.extension.st
+++ b/src/Morphic-Base/Object.extension.st
@@ -103,18 +103,18 @@ Object >> taskbarIcon [
 ]
 
 { #category : #'*Morphic-Base' }
-Object class >> taskbarIconName [
-	"Answer the icon for an instance of the receiver in a task bar"
-
-	^#smallWindow
-]
-
-{ #category : #'*Morphic-Base' }
 Object >> taskbarIconName [
 	"Answer the icon for the receiver in a task bar
 	or nil for the default."
 
 	^self class taskbarIconName
+]
+
+{ #category : #'*Morphic-Base' }
+Object class >> taskbarIconName [
+	"Answer the icon for an instance of the receiver in a task bar"
+
+	^#smallWindow
 ]
 
 { #category : #'*Morphic-Base' }


### PR DESCRIPTION
I chose to bail only on mouse _down_ outside the drag threshold, such that with a very long double-click time, you could click, move away, move back, and click again and this would still count as a double-click. My thinking is that for most of us it doesn't matter, because this is more-or-less impossible to do within 350ms. However someone with e.g. a hand tremor, who might need to set their double-click time much higher, might do this as part of normal usage. This matches the native Windows behavior, while macOS stops watching for a double-click on any movement even if you move back afterwards. I'd be fine with changing the condition to just `timedOut or: [isDrag]` if you think that's better though—like I said, it doesn't affect me either way.

One related question: Why is a double-click-and-drag detected with zero threshold? Why not use the same threshold as for a normal drag? In other words, why have `isDrag` and `isDragSecond` rather than just using `isDrag` all the time? Seems like a nice simplification that could be made...