### PR TITLE
Remove events for the existing ChangesLog when installing NoChangesLog

### DIFF
--- a/src/System-Sources/NoChangesLog.class.st
+++ b/src/System-Sources/NoChangesLog.class.st
@@ -21,6 +21,8 @@ Class {
 
 { #category : #singleton }
 NoChangesLog class >> install [
+
+	self reset.
 	DefaultInstance := self new
 ]
 


### PR DESCRIPTION
Otherwise changes may be logged anyway as events are still dispatched to an instance that is no longer the DefaultInstance.