### PR TITLE
Fix bug in #rubParagraph:bounds:color: in PluggableCanvas

### DIFF
--- a/src/Rubric/PluggableCanvas.extension.st
+++ b/src/Rubric/PluggableCanvas.extension.st
@@ -3,5 +3,5 @@ Extension { #name : #PluggableCanvas }
 { #category : #'*Rubric-Editing-Core' }
 PluggableCanvas >> rubParagraph: paragraph bounds: bounds color: color [
 	self apply: [ :c |
-		c paragraph: paragraph bounds: bounds color: color ]
+		c rubParagraph: paragraph bounds: bounds color: color ]
 ]


### PR DESCRIPTION
This pull request fixes a bug in `PluggableCanvas>>#rubParagraph:bounds:color:` so that the morph in the following example no longer draws an error:

```smalltalk
(editingArea := RubEditingArea new)
	beWrapped;
	setTextWith: String loremIpsum;
	width: 500.
form := Form extent: editingArea bounds bottomRight depth: Display depth.
clippingCanvas := ClippingCanvas canvas: form getCanvas
	clipRect: (editingArea bounds withWidth: 250).
editingArea fullDrawOn: clippingCanvas.
form
```