### PR TITLE
RPackage: Fix failing tests

### DIFF
--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -130,7 +130,6 @@ RPackageIncrementalTest >> testClassAddition [
 
 	| p a1 |
 	p := self createNewPackageNamed: self p1Name.
-	p register.
 	a1 := self createNewClassNamed: #A1InPAckageP1.
 	self assertEmpty: p definedClasses.
 	p importClass: a1.
@@ -144,7 +143,6 @@ RPackageIncrementalTest >> testClassDefinitionRemoval [
 
 	| p a1 b1 |
 	p := self createNewPackageNamed: self p1Name.
-	p register.
 	a1 := self createNewClassNamed: #A1InPAckageP1.
 	b1 := self createNewClassNamed: #B1InPAckageP1.
 	self assertEmpty: p definedClasses.
@@ -170,7 +168,6 @@ RPackageIncrementalTest >> testClassDefinitionWithTagsRemoval [
 
 	| p a1 b1 |
 	p := self createNewPackageNamed: self p1Name.
-	p register.
 
 	a1 := self createNewClassNamed: #A1InPAckageP1 inPackage: p.
 	b1 := self createNewClassNamed: #B1InPAckageP1 inPackage: p.
@@ -339,7 +336,6 @@ RPackageIncrementalTest >> testImportClassNoDuplicate [
 
 	| p a1 b1 |
 	p := self createNewPackageNamed: self p1Name.
-	p register.
 	a1 := self createNewClassNamed: #A1InPackageP1.
 	self assertEmpty: p definedClasses.
 	p importClass: a1.
@@ -358,8 +354,7 @@ RPackageIncrementalTest >> testIncludeClass [
 	| p1 p2 a2 |
 	p1 := self createNewPackageNamed: self p1Name.
 	p2 := self createNewPackageNamed: self p2Name.
-	p1 register.
-	p2 register.
+
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	a2 compileSilently: 'methodPackagedInP1 ^ #methodPackagedInP1'.
 
@@ -626,7 +621,6 @@ RPackageIncrementalTest >> testUniqueClassInDefinedClassesUsingAddClassDefinitio
 
 	| p a1 |
 	p := self createNewPackageNamed: self p1Name.
-	p register.
 	a1 := self createNewClassNamed: #A1InPAckageP1.
 	self assertEmpty: p definedClasses.
 	p importClass: a1.


### PR DESCRIPTION
This change fixes the failing tests of RPackage

The problem comes from the fact that two PR with conflicting changes got integrated, but the conflict was not arising on the same lines so git was able to merge without conflict.

One change was changing some tests and the tests needed to register packages.
The second change was to move the package registration directly in the method that creates packages. Thus, the registration done in the first change was creating a double registration after the second change got integrated