### PR TITLE
SortedCollection should not implement #addLast: (fixes #9286)

### DIFF
--- a/src/Collections-Abstract-Tests/SplitJoinTest.class.st
+++ b/src/Collections-Abstract-Tests/SplitJoinTest.class.st
@@ -151,7 +151,7 @@ SplitJoinTest >> testJoinArrayUsingOrderedCollection [
 { #category : 'running' }
 SplitJoinTest >> testJoinArrayUsingSortedCollection [
 	self assert: ((1 to: 4) joinUsing: #(8 9) asSortedCollection)
-		equals: #(1 8 9 2 8 9 3 8 9 4) asSortedCollection
+		equals: #(1 8 9 2 8 9 3 8 9 4) asOrderedCollection
 ]
 
 { #category : 'running' }

--- a/src/Collections-Sequenceable-Tests/SortedCollectionTest.class.st
+++ b/src/Collections-Sequenceable-Tests/SortedCollectionTest.class.st
@@ -503,6 +503,14 @@ SortedCollectionTest >> testAddAll2 [
 ]
 
 { #category : 'tests - basic' }
+SortedCollectionTest >> testAddLast [
+
+	self
+		should: [ #( 10 9 8 ) asSortedCollection addLast: 11 ]
+		raise: ShouldNotImplement
+]
+
+{ #category : 'tests - basic' }
 SortedCollectionTest >> testCollect [
 
 	|result aSortedCollection|
@@ -804,6 +812,11 @@ SortedCollectionTest >> testRemoveAll [
 
 	c1 add: 13; add: 14.
 	self assert: (c1 first = 14 and: [c1 second = 13]) description: 'the sortBlock has been preserved'
+]
+
+{ #category : 'tests - basic' }
+SortedCollectionTest >> testReversedIsOrdered [
+	self assert: self nonEmpty reversed class equals: OrderedCollection
 ]
 
 { #category : 'tests - basic' }

--- a/src/Collections-Sequenceable/OrderedCollection.class.st
+++ b/src/Collections-Sequenceable/OrderedCollection.class.st
@@ -269,6 +269,13 @@ OrderedCollection >> addLast: newObject [
 	^array at: lastIndex put: newObject
 ]
 
+{ #category : 'private' }
+OrderedCollection >> addNoSort: newObject [
+	"Add newObject to the end of the receiver. If the receiver is sorted, assume that this is the correct position--do not check sort order. Answer newObject."
+
+	^ self addLast: newObject
+]
+
 { #category : 'converting' }
 OrderedCollection >> asArray [
 	"Convert an OrderedCollection into an Array."
@@ -352,7 +359,7 @@ OrderedCollection >> collect: aBlock [
 	"(#(1 2 3) asOrderedCollection collect: [ :v | 10 ]) asArray >>> #(10 10 10)"
 
 	| newCollection |
-	newCollection := self species new: self size.
+	newCollection := self copyForTransform: self size.
 	firstIndex to: lastIndex do:
 		[:index |
 		newCollection addLast: (aBlock value: (array at: index))].
@@ -364,7 +371,7 @@ OrderedCollection >> collect: aBlock from: fromIndex to: toIndex [
 	"Override superclass in order to use addLast:, not at:put:."
 	| result |
 	self ensureBoundsFrom: fromIndex to: toIndex.
-	result := self species new: toIndex - fromIndex + 1.
+	result := self copyForTransform: toIndex - fromIndex + 1.
 	firstIndex + fromIndex - 1 to: firstIndex + toIndex - 1 do:
 		[:index | result addLast: (aBlock value: (array at: index))].
 	^ result
@@ -376,7 +383,7 @@ OrderedCollection >> collect: collectBlock thenSelect: selectBlock [
 
     | newCollection newElement |
 
-    newCollection := self copyEmpty.
+    newCollection := self copyForTransform.
     firstIndex to: lastIndex do: [ :index |
 		newElement := collectBlock value: (array at: index).
 		(selectBlock value: newElement)
@@ -411,6 +418,21 @@ OrderedCollection >> copyEmpty [
 ]
 
 { #category : 'copying' }
+OrderedCollection >> copyForTransform [
+	"As #copyForTransform, but using the default size for a new collection."
+
+	^self species new
+]
+
+{ #category : #copying }
+OrderedCollection >> copyForTransform: copySize [
+	"Answer a 'copy' of the receiver suitable for holding the output of a #collect: or similar, with sufficient capacity for <copySize> elements, but which contains no elements.
+	When transforming the elements of a SortedCollection, the result may no longer be sorted, or indeed sortable, so we provide a hook for it to override and return an OrderedCollection."
+
+	^self species new: copySize
+]
+
+{ #category : #copying }
 OrderedCollection >> copyFrom: startIndex to: endIndex [
 	"Answer a copy of the receiver that contains elements from position
 	startIndex to endIndex."
@@ -475,12 +497,6 @@ OrderedCollection >> ensureBoundsFrom: fromIndex to: toIndex [
 		ifTrue: [^self errorSubscriptBounds: fromIndex].
 	(toIndex + firstIndex - 1 > lastIndex)
 		ifTrue: [^self errorSubscriptBounds: toIndex]
-]
-
-{ #category : 'private' }
-OrderedCollection >> errorConditionNotSatisfied [
-
-	self error: 'no element satisfies condition'
 ]
 
 { #category : 'private' }
@@ -653,7 +669,7 @@ OrderedCollection >> reject: rejectBlock [
 
 	firstIndex to: lastIndex do: [ :index |
 		(rejectBlock value: (element := array at: index))
-			ifFalse: [ newCollection addLast: element ]].
+			ifFalse: [ newCollection addNoSort: element ]].
 
 	^ newCollection
 ]
@@ -664,7 +680,7 @@ OrderedCollection >> reject: rejectBlock thenCollect: collectBlock [
 
 	| newCollection |
 
-    newCollection := self copyEmpty.
+    newCollection := self copyForTransform.
 
     firstIndex to: lastIndex do: [ :index |
 		| element |
@@ -836,7 +852,7 @@ OrderedCollection >> reversed [
 	"Answer a copy of the receiver with element order reversed.  "
 	"#(2 3 4 'fred') asOrderedCollection reversed >>> #('fred' 4 3 2) asOrderedCollection"
 	| newCol |
-	newCol := self copyEmpty.
+	newCol := self copyForTransform: self size.
 	self reverseDo:
 		[:elem | newCol addLast: elem].
 	^ newCol
@@ -852,7 +868,7 @@ OrderedCollection >> select: selectBlock [
 
 	firstIndex to: lastIndex do: [ :index |
 		(selectBlock value: (element := array at: index))
-			ifTrue: [ newCollection addLast: element ]].
+			ifTrue: [ newCollection addNoSort: element ]].
 
 	^ newCollection
 ]
@@ -863,7 +879,7 @@ OrderedCollection >> select: selectBlock thenCollect: collectBlock [
 
 	| newCollection element |
 
-    newCollection := self copyEmpty.
+    newCollection := self copyForTransform.
 
     firstIndex to: lastIndex do: [ :index |
 		element := array at: index.
@@ -913,7 +929,7 @@ OrderedCollection >> with: otherCollection collect: twoArgBlock [
 	corresponding elements from this collection and otherCollection."
 	| result |
 	otherCollection size = self size ifFalse: [self error: 'otherCollection must be the same size'].
-	result := self species new: self size.
+	result := self copyForTransform: self size.
 	1 to: self size do:
 		[:index | result addLast: (twoArgBlock value: (self at: index)
 									value: (otherCollection at: index))].
@@ -925,7 +941,7 @@ OrderedCollection >> withIndexCollect: elementAndIndexBlock [
 	"Just like with:collect: except that the iteration index supplies the second argument to the block. Override superclass in order to use addLast:, not at:put:."
 
 	| newCollection |
-	newCollection := self species new: self size.
+	newCollection := self copyForTransform: self size.
 	firstIndex to: lastIndex do:
 		[:index |
 		newCollection addLast: (elementAndIndexBlock
@@ -935,7 +951,7 @@ OrderedCollection >> withIndexCollect: elementAndIndexBlock [
 ]
 
 { #category : 'enumerating' }
-OrderedCollection >> withIndexSelect: elementAndIndexBlock select: selectBlock [
+OrderedCollection >> withIndexSelect: elementAndIndexBlock [
 	"Optimized version of SequenceableCollection>>#withIndexSelect: "
 
 	"(#('We' 'love' 'pharo!') asOrderedCollection withIndexSelect: [:value :index | value size - 1 <= index]) >>> (OrderedCollection with: 'We')"
@@ -943,7 +959,7 @@ OrderedCollection >> withIndexSelect: elementAndIndexBlock select: selectBlock [
 	| newCollection element |
 	newCollection := self copyEmpty.
 	firstIndex to: lastIndex do: [ :index |
-		(selectBlock value: (element := array at: index) value: index)
-			ifTrue: [ newCollection addLast: element ] ].
+		(elementAndIndexBlock value: (element := array at: index) value: index)
+			ifTrue: [ newCollection addNoSort: element ] ].
 	^ newCollection
 ]

--- a/src/Collections-Sequenceable/OrderedCollection.class.st
+++ b/src/Collections-Sequenceable/OrderedCollection.class.st
@@ -572,13 +572,18 @@ OrderedCollection >> insert: anObject before: spot [
 
 { #category : 'splitjoin' }
 OrderedCollection >> join: aCollection [
-	"Append the elements of the argument, aSequenceableCollection, separating them by the receiver."
+	"Append the elements of the argument, aSequenceableCollection, separating them by the receiver.
+	Note that we always return an OrderedCollection, not a SortedCollection--the interleaved order
+	of the result is the whole point, here."
 
 	| result |
-	result := self class new.
+	"Lower-bound guess at the size of the result, assuming aCollection is 'flat'--
+	no nested collections."
+	result := self speciesForTransform new:
+		          aCollection size + (self size * (aCollection size - 1)).
 	aCollection
-		do: [:each | each appendTo: result]
-		separatedBy: [self appendTo: result].
+		do: [ :each | each appendTo: result ]
+		separatedBy: [ self appendTo: result ].
 	^ result
 ]
 

--- a/src/Collections-Sequenceable/OrderedCollection.class.st
+++ b/src/Collections-Sequenceable/OrderedCollection.class.st
@@ -356,39 +356,39 @@ OrderedCollection >> collect: aBlock [
 	collection. Override superclass in order to use addLast:, not at:put:."
 
 	"(#(1 2 3) asOrderedCollection collect: [ :v | v * 10 ]) asArray >>> #(10 20 30)"
+
 	"(#(1 2 3) asOrderedCollection collect: [ :v | 10 ]) asArray >>> #(10 10 10)"
 
 	| newCollection |
-	newCollection := self copyForTransform: self size.
-	firstIndex to: lastIndex do:
-		[:index |
-		newCollection addLast: (aBlock value: (array at: index))].
+	newCollection := self speciesForTransform new: self size.
+	firstIndex to: lastIndex do: [ :index |
+	newCollection addLast: (aBlock value: (array at: index)) ].
 	^ newCollection
 ]
 
 { #category : 'enumerating' }
 OrderedCollection >> collect: aBlock from: fromIndex to: toIndex [
 	"Override superclass in order to use addLast:, not at:put:."
+
 	| result |
 	self ensureBoundsFrom: fromIndex to: toIndex.
-	result := self copyForTransform: toIndex - fromIndex + 1.
-	firstIndex + fromIndex - 1 to: firstIndex + toIndex - 1 do:
-		[:index | result addLast: (aBlock value: (array at: index))].
+	result := self speciesForTransform new: toIndex - fromIndex + 1.
+	firstIndex + fromIndex - 1 to: firstIndex + toIndex - 1 do: [ :index |
+	result addLast: (aBlock value: (array at: index)) ].
 	^ result
 ]
 
 { #category : 'enumerating' }
 OrderedCollection >> collect: collectBlock thenSelect: selectBlock [
-    "Optimized version Collection>>#collect:thenSelect:"
+	"Optimized version Collection>>#collect:thenSelect:"
 
-    | newCollection newElement |
-
-    newCollection := self copyForTransform.
-    firstIndex to: lastIndex do: [ :index |
+	| newCollection newElement |
+	newCollection := self speciesForTransform new.
+	firstIndex to: lastIndex do: [ :index |
 		newElement := collectBlock value: (array at: index).
-		(selectBlock value: newElement)
-			ifTrue: [ newCollection addLast: newElement ]].
-    ^ newCollection
+		(selectBlock value: newElement) ifTrue: [
+			newCollection addLast: newElement ] ].
+	^ newCollection
 ]
 
 { #category : 'private' }
@@ -418,21 +418,6 @@ OrderedCollection >> copyEmpty [
 ]
 
 { #category : 'copying' }
-OrderedCollection >> copyForTransform [
-	"As #copyForTransform, but using the default size for a new collection."
-
-	^self species new
-]
-
-{ #category : #copying }
-OrderedCollection >> copyForTransform: copySize [
-	"Answer a 'copy' of the receiver suitable for holding the output of a #collect: or similar, with sufficient capacity for <copySize> elements, but which contains no elements.
-	When transforming the elements of a SortedCollection, the result may no longer be sorted, or indeed sortable, so we provide a hook for it to override and return an OrderedCollection."
-
-	^self species new: copySize
-]
-
-{ #category : #copying }
 OrderedCollection >> copyFrom: startIndex to: endIndex [
 	"Answer a copy of the receiver that contains elements from position
 	startIndex to endIndex."
@@ -676,19 +661,18 @@ OrderedCollection >> reject: rejectBlock [
 
 { #category : 'enumerating' }
 OrderedCollection >> reject: rejectBlock thenCollect: collectBlock [
-    " Optimized version of Collection>>#reject:thenCollect: "
+	" Optimized version of Collection>>#reject:thenCollect: "
 
 	| newCollection |
+	newCollection := self speciesForTransform new.
 
-    newCollection := self copyForTransform.
-
-    firstIndex to: lastIndex do: [ :index |
+	firstIndex to: lastIndex do: [ :index |
 		| element |
 		element := array at: index.
-		(rejectBlock value: element)
-			ifFalse: [ newCollection addLast: (collectBlock value: element) ]].
+		(rejectBlock value: element) ifFalse: [
+			newCollection addLast: (collectBlock value: element) ] ].
 
-    ^ newCollection
+	^ newCollection
 ]
 
 { #category : 'removing' }
@@ -850,11 +834,12 @@ OrderedCollection >> reverseDo: aBlock [
 { #category : 'converting' }
 OrderedCollection >> reversed [
 	"Answer a copy of the receiver with element order reversed.  "
+
 	"#(2 3 4 'fred') asOrderedCollection reversed >>> #('fred' 4 3 2) asOrderedCollection"
+
 	| newCol |
-	newCol := self copyForTransform: self size.
-	self reverseDo:
-		[:elem | newCol addLast: elem].
+	newCol := self speciesForTransform new: self size.
+	self reverseDo: [ :elem | newCol addLast: elem ].
 	^ newCol
 ]
 
@@ -875,18 +860,17 @@ OrderedCollection >> select: selectBlock [
 
 { #category : 'enumerating' }
 OrderedCollection >> select: selectBlock thenCollect: collectBlock [
-    " Optimized version Collection>>#select:thenCollect: "
+	" Optimized version Collection>>#select:thenCollect: "
 
 	| newCollection element |
+	newCollection := self speciesForTransform new.
 
-    newCollection := self copyForTransform.
-
-    firstIndex to: lastIndex do: [ :index |
+	firstIndex to: lastIndex do: [ :index |
 		element := array at: index.
-		(selectBlock value: element)
-			ifTrue: [ newCollection addLast: (collectBlock value: element) ]].
+		(selectBlock value: element) ifTrue: [
+			newCollection addLast: (collectBlock value: element) ] ].
 
-    ^ newCollection
+	^ newCollection
 ]
 
 { #category : 'private' }
@@ -923,16 +907,26 @@ OrderedCollection >> sort: aSortBlock [
 		by: aSortBlock
 ]
 
+{ #category : 'private' }
+OrderedCollection >> speciesForTransform [
+	"Answer the preferred class for a transformation of the receiver (the output of a #collect: or similar). This may differ from the regular #species, as the transformed elements may no longer be compatible with the receiver in some way. For example, when transforming the elements of a SortedCollection, the result may no longer be sorted, or indeed sortable."
+
+	^ self species
+]
+
 { #category : 'enumerating' }
 OrderedCollection >> with: otherCollection collect: twoArgBlock [
 	"Collect and return the result of evaluating twoArgBlock with
 	corresponding elements from this collection and otherCollection."
+
 	| result |
-	otherCollection size = self size ifFalse: [self error: 'otherCollection must be the same size'].
-	result := self copyForTransform: self size.
-	1 to: self size do:
-		[:index | result addLast: (twoArgBlock value: (self at: index)
-									value: (otherCollection at: index))].
+	otherCollection size = self size ifFalse: [
+		self error: 'otherCollection must be the same size' ].
+	result := self speciesForTransform new: self size.
+	1 to: self size do: [ :index |
+		result addLast: (twoArgBlock
+				 value: (self at: index)
+				 value: (otherCollection at: index)) ].
 	^ result
 ]
 
@@ -941,12 +935,11 @@ OrderedCollection >> withIndexCollect: elementAndIndexBlock [
 	"Just like with:collect: except that the iteration index supplies the second argument to the block. Override superclass in order to use addLast:, not at:put:."
 
 	| newCollection |
-	newCollection := self copyForTransform: self size.
-	firstIndex to: lastIndex do:
-		[:index |
+	newCollection := self speciesForTransform new: self size.
+	firstIndex to: lastIndex do: [ :index |
 		newCollection addLast: (elementAndIndexBlock
-			value: (array at: index)
-			value: index - firstIndex + 1)].
+				 value: (array at: index)
+				 value: index - firstIndex + 1) ].
 	^ newCollection
 ]
 

--- a/src/Collections-Sequenceable/SortedCollection.class.st
+++ b/src/Collections-Sequenceable/SortedCollection.class.st
@@ -270,13 +270,6 @@ SortedCollection >> intersection: aCollection [
 		yourself
 ]
 
-{ #category : 'splitjoin' }
-SortedCollection >> join: aCollection [
-	"Append the elements of the argument, aSequenceableCollection, separating them by the receiver."
-	"Curiously addAllLast: does not trigger a reSort, so we must do it here."
-	^ (super join: aCollection) reSort; yourself
-]
-
 { #category : 'math functions' }
 SortedCollection >> median [
 	"Return the middle element, or as close as we can get."

--- a/src/Collections-Sequenceable/SortedCollection.class.st
+++ b/src/Collections-Sequenceable/SortedCollection.class.st
@@ -167,18 +167,6 @@ SortedCollection >> copyEmpty [
 	^self species sortBlock: sortBlock
 ]
 
-{ #category : #copying }
-SortedCollection >> copyForTransform [
-
-	^ OrderedCollection new
-]
-
-{ #category : #copying }
-SortedCollection >> copyForTransform: copySize [
-
-	^ OrderedCollection new: copySize
-]
-
 { #category : 'private' }
 SortedCollection >> defaultSort: i to: j [
 	"Sort elements i through j of self to be nondescending according to
@@ -382,4 +370,10 @@ SortedCollection >> sortBlock: aBlock [
 	sortBlock := aBlock.
 	"sortBlocks with side effects may not work right"
 	self size > 0 ifTrue: [self reSort]
+]
+
+{ #category : 'private' }
+SortedCollection >> speciesForTransform [
+
+	^ OrderedCollection
 ]

--- a/src/Collections-Sequenceable/SortedCollection.class.st
+++ b/src/Collections-Sequenceable/SortedCollection.class.st
@@ -118,7 +118,7 @@ SortedCollection >> add: newObject [
 SortedCollection >> addAll: aCollection [
 	aCollection size > (self size // 3)
 		ifTrue:
-			[aCollection do: [:each | self addLast: each].
+			[aCollection do: [:each | self addNoSort: each].
 			self reSort]
 		ifFalse: [aCollection do: [:each | self add: each]].
 	^ aCollection
@@ -127,6 +127,18 @@ SortedCollection >> addAll: aCollection [
 { #category : 'adding' }
 SortedCollection >> addFirst: newObject [
 	self shouldNotImplement
+]
+
+{ #category : 'adding' }
+SortedCollection >> addLast: newObject [
+	self shouldNotImplement
+]
+
+{ #category : 'private' }
+SortedCollection >> addNoSort: anObject [
+	"Add newObject to the end of the receiver. Assume that this is the correct position--do not check sort order. Answer newObject."
+
+	^ super addLast: anObject
 ]
 
 { #category : 'accessing' }
@@ -153,6 +165,18 @@ SortedCollection >> copyEmpty [
 	"Answer a copy of the receiver without any of the receiver's elements."
 
 	^self species sortBlock: sortBlock
+]
+
+{ #category : #copying }
+SortedCollection >> copyForTransform [
+
+	^ OrderedCollection new
+]
+
+{ #category : #copying }
+SortedCollection >> copyForTransform: copySize [
+
+	^ OrderedCollection new: copySize
 ]
 
 { #category : 'private' }

--- a/src/Collections-Unordered/SmallDictionary.class.st
+++ b/src/Collections-Unordered/SmallDictionary.class.st
@@ -658,7 +658,7 @@ SmallDictionary >> keysSortedSafely [
 			ifFalse: [x class == y class
 				ifTrue: [x printString < y printString]
 				ifFalse: [x class name < y class name]]].
-	self keysDo: [:each | sortedKeys addLast: each].
+	self keysDo: [:each | sortedKeys addNoSort: each].
 	^ sortedKeys reSort
 ]
 


### PR DESCRIPTION
#addLast: was used internally by the #select: and #collect: families, but it is also part of the public API of OrderedCollection, and in that role, it is not appropriate for a SortedCollection as it may leave the elements out of order.

Avoid near-exact duplication of 10 OrderedCollection methods by dispatching through two new ones:
* #addNoSort: which is explicitly private and expects the caller to maintain sort order (used in #select:, #reject: et al and SortedCollection>>addAll:).
* #copyForTransform[:], which answers a suitable collection for the output of a #collect: (used in, unsurprisingly, anything with 'collect' in the name, plus #reversed).

Also replace (typo'd?) #withIndexSelect:select: with correct implementation of #withIndexSelect:, and remove unreferenced #errorConditionNotSatisfied.