### PR TITLE
Change `Object>>#printStringLimitedTo:using:` to use ellipsis

### DIFF
--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1727,13 +1727,13 @@ Object >> printStringLimitedTo: limit [
 
 { #category : #printing }
 Object >> printStringLimitedTo: limit using: printBlock [
-	"Answer a String whose characters are a description of the receiver
-	produced by given printBlock. It ensures the result will be not bigger than given limit.
-	Given that the '[..]' is itself four characters long, limit should be at least 5."
+	"Answer a String whose characters are a description of the receiver produced by
+	the given printBlock. It ensures the result is not longer than the given limit.
+	Since '[…]' is three characters long, the limit should be at least 4."
 	| limitedString |
 	limitedString := String streamContents: printBlock limitedTo: limit + 1.
 	limitedString size <= limit ifTrue: [^ limitedString].
-	^ (limitedString truncateTo: limit - 4), '[..]'
+	^ (limitedString truncateTo: limit - 3), '[…]'
 ]
 
 { #category : #streaming }


### PR DESCRIPTION
By using the [ellipsis unicode character `…`](https://www.compart.com/en/unicode/U+2026), we can display a regular ellipsis instead of two dots, using one less character.

As a side note, `(limitedString truncateTo: limit - 3), '[…]'` could be optimized a bit to `(limitedString first: limit) replaceFrom: limit - 2 to: limit with: '[…]'` which makes one less copy.
However, I don't think this is critical code, so it can stay pretty and more readable.