### PR TITLE
Fix: enable push down method for concrete classes

### DIFF
--- a/src/Refactoring-Core/RBPushDownMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBPushDownMethodRefactoring.class.st
@@ -49,6 +49,31 @@ RBPushDownMethodRefactoring >> allClasses [
 	^ classes ifNil: [ class subclasses ]
 ]
 
+{ #category : #preconditions }
+RBPushDownMethodRefactoring >> applicabilityPreconditions [
+	"Check that all selectors are defined in `class`"
+
+	^ selectors
+		  inject: self trueCondition
+		  into: [ :cond :each |
+		  	cond & (RBCondition definesSelector: each in: class) ]
+]
+
+{ #category : #preconditions }
+RBPushDownMethodRefactoring >> breakingChangePreconditions [
+	"Check that that none of the subclasses of `class` refer to any of the selectors
+	that will be pushed down.
+	Also, to ensure this is in fact refactoring we should only push down methods from abstract class."
+
+	| condition |
+	condition := selectors
+		             inject: self trueCondition
+		             into: [ :cond :each |
+			             cond & (RBCondition subclassesOf: class referToSelector: each)
+				             not ].
+	^ condition & (RBCondition isAbstractClass: class)
+]
+
 { #category : #transforming }
 RBPushDownMethodRefactoring >> classes: aCollection [
 	classes := aCollection collect: [ :cls |
@@ -66,19 +91,8 @@ RBPushDownMethodRefactoring >> generateChanges [
 
 { #category : #preconditions }
 RBPushDownMethodRefactoring >> preconditions [
-	"Check that all selectors are defined in `class` and that none of the subclasses of `class`
-	refer to any of the selectors that will be pushed down.
-	Also, to ensure this is in fact refactoring we should only push down methods from abstract class."
 
-	| condition |
-	condition := selectors
-		             inject: self trueCondition
-		             into: [ :cond :each |
-			             cond & (RBCondition definesSelector: each in: class)
-			             &
-			             (RBCondition subclassesOf: class referToSelector: each)
-				             not ].
-	^ condition & (RBCondition isAbstractClass: class)
+	^ self applicabilityPreconditions & self breakingChangePreconditions 
 ]
 
 { #category : #transforming }

--- a/src/Refactoring-Core/RBPushDownMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBPushDownMethodRefactoring.class.st
@@ -84,7 +84,15 @@ RBPushDownMethodRefactoring >> classes: aCollection [
 { #category : #actions }
 RBPushDownMethodRefactoring >> generateChanges [
 
-	self primitiveExecute.
+	self applicabilityPreconditions check ifFalse: [
+		RBApplicabilityChecksFailedError signal:
+			self applicabilityPreconditions errorString ].
+
+	self breakingChangePreconditions check ifFalse: [
+		RBBreakingChangeChecksFailedWarning signal:
+			self breakingChangePreconditions errorString ].
+
+	self privateTransform.
 
 	^ self changes
 ]

--- a/src/Refactoring2-Transformations-Tests/RBPushDownMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBPushDownMethodParametrizedTest.class.st
@@ -18,40 +18,6 @@ RBPushDownMethodParametrizedTest >> constructor [
 ]
 
 { #category : #'failure tests' }
-RBPushDownMethodParametrizedTest >> testFailurePushDownMethodOnNonAbstractClass [
-
-	| refactoring |
-	refactoring := self createRefactoringWithArguments: {
-			               #( #isArray ).
-			               Array }.
-	self shouldFail: refactoring
-]
-
-{ #category : #'failure tests' }
-RBPushDownMethodParametrizedTest >> testFailurePushDownMethodSubclassesReferToSelector [
-
-	| refactoring |
-	model defineClass:
-		'Object << #Superclass package: #''Refactory-Test data'''.
-	model defineClass:
-		'Superclass << #Foo1 package: #''Refactory-Test data'''.
-	model defineClass:
-		'Superclass << #Foo2 package: #''Refactory-Test data'''.
-	(model classNamed: #Superclass)
-		compile: 'yourself ^1'
-		classified: #( #accessing ).
-	(model classNamed: #Foo1)
-		compile: 'method1 ^super yourself'
-		classified: #( #accessing ).
-
-	refactoring := rbClass
-		               model: model
-		               pushDown: #( #yourself )
-		               from: (model classNamed: #Superclass).
-	self shouldFail: refactoring
-]
-
-{ #category : #'failure tests' }
 RBPushDownMethodParametrizedTest >> testFailurePushDownNonExistantMenu [
 
 	| refactoring |
@@ -68,7 +34,7 @@ RBPushDownMethodParametrizedTest >> testPushDownMethod [
 	refactoring := self createRefactoringWithArguments: {
 			               #( #name: ).
 			               RBLintRuleTestData }.
-	self executeRefactoring: refactoring.
+	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBLintRuleTestData.
 	self deny: (class directlyDefinesMethod: #name:).
 	class subclasses do: [ :each |
@@ -85,7 +51,7 @@ RBPushDownMethodParametrizedTest >> testPushDownMethodThatReferencesPoolDictiona
 	refactoring := self createRefactoringWithArguments: {
 			               #( #junk ).
 			               RBLintRuleTestData }.
-	self executeRefactoring: refactoring.
+	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBLintRuleTestData.
 	self deny: (class directlyDefinesMethod: #junk).
 	class subclasses do: [ :each |

--- a/src/Refactoring2-Transformations-Tests/RBPushDownMethodRefactoringTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBPushDownMethodRefactoringTest.class.st
@@ -1,0 +1,55 @@
+Class {
+	#name : #RBPushDownMethodRefactoringTest,
+	#superclass : #RBAbstractTransformationTest,
+	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+}
+
+{ #category : #'failure tests' }
+RBPushDownMethodRefactoringTest >> testFailurePushDownMethodOnNonAbstractClass [
+
+	| refactoring |
+	refactoring := RBPushDownMethodRefactoring
+		               pushDown: #( #isArray )
+		               from: Array.
+	"Scripting API"
+	self shouldFail: refactoring.
+	
+	"Driver API"
+	self proceedThroughWarning: [
+		self
+			should: [ refactoring generateChanges ]
+			raise: RBBreakingChangeChecksFailedWarning
+	]
+]
+
+{ #category : #'failure tests' }
+RBPushDownMethodRefactoringTest >> testFailurePushDownMethodSubclassesReferToSelector [
+
+	| refactoring |
+	model defineClass:
+		'Object << #Superclass package: #''Refactory-Test data'''.
+	model defineClass:
+		'Superclass << #Foo1 package: #''Refactory-Test data'''.
+	model defineClass:
+		'Superclass << #Foo2 package: #''Refactory-Test data'''.
+	(model classNamed: #Superclass)
+		compile: 'yourself ^1'
+		classified: #( #accessing ).
+	(model classNamed: #Foo1)
+		compile: 'method1 ^super yourself'
+		classified: #( #accessing ).
+
+	refactoring := RBPushDownMethodRefactoring
+		               model: model
+		               pushDown: #( #yourself )
+		               from: (model classNamed: #Superclass).
+	"Scripting API"
+	self shouldFail: refactoring.
+	
+	"Driver API"
+	self proceedThroughWarning: [
+		self
+			should: [ refactoring generateChanges ]
+			raise: RBBreakingChangeChecksFailedWarning
+	]
+]

--- a/src/Refactoring2-Transformations/RBPushDownMethodTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBPushDownMethodTransformation.class.st
@@ -45,10 +45,20 @@ RBPushDownMethodTransformation >> applicabilityPreconditions [
 
 	| condition |
 	condition := selectors
+		             inject: (RBCondition true)
+		             into: [ :cond :each |
+			             cond & (RBCondition definesSelector: each in: class)].
+	^ condition 
+]
+
+{ #category : #preconditions }
+RBPushDownMethodTransformation >> breakingChangePreconditions [
+
+	| condition |
+	condition := selectors
 		             inject: (RBCondition isAbstractClass: class)
 		             into: [ :cond :each |
-			             cond & (RBCondition definesSelector: each in: class) 
-							&  (RBCondition subclassesOf: class referToSelector: each) not ].
+			             cond & (RBCondition subclassesOf: class referToSelector: each) not ].
 	^ condition 
 ]
 


### PR DESCRIPTION
Push down method refactoring wasn't working on concrete classes. It would just say "Cannot push down method from non-abstract class".

This PR fixes the issue by splitting refactoring preconditions on applicability and breaking changes and also by changing the `generateChanges` so that it raises breaking-change-warning.

Because of this refactoring specific tests are extracted from transformation tests and I've added additional assertions for Driver API (`generateChanges`).