### PR TITLE
Save real classes in RPackage

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -180,7 +180,7 @@ RPackage >> addClassDefinition: aClass [
 	"Please do not use me, I will be removed in the future. Use #importClass: instead."
 
 	(self includesClass: aClass) ifTrue: [ ^ self ].
-	classes add: aClass instanceSide name asSymbol.
+	classes add: aClass instanceSide.
 	self registerClass: aClass
 ]
 
@@ -332,16 +332,13 @@ RPackage >> classesTaggedWith: aSymbol [
 RPackage >> definedClassNames [
 	"Return the class names having methods defined in the receiver."
 
-	^ classes
+	^ classes collect: [ :class | class name ]
 ]
 
 { #category : #accessing }
 RPackage >> definedClasses [
 
-	| definedClasses |
-	definedClasses := Set new: classes size.
-	classes do: [ :each | self environment at: each ifPresent: [ :aClass | definedClasses add: aClass ] ].
-	^ definedClasses
+	^ classes
 ]
 
 { #category : #accessing }
@@ -539,14 +536,14 @@ RPackage >> importProtocol: aProtocol forClass: aClass [
 RPackage >> includesClass: aClass [
 	"Returns true if the receiver includes aClass in the classes that are defined within it: only class definition are considered - not class extensions"
 
-	^ self includesClassNamed: aClass instanceSide name
+	^ classes includes: aClass instanceSide
 ]
 
 { #category : #testing }
 RPackage >> includesClassNamed: aSymbol [
 	"Returns true if the receiver includes class named aSymbol in the classes that are defined within it: only class definition are considered - not class extensions"
 
-	^ classes includes: aSymbol asSymbol
+	^ classes anySatisfy: [ :class | class name = aSymbol ]
 ]
 
 { #category : #testing }
@@ -839,7 +836,7 @@ RPackage >> removeClass: aClass [
 	self removeAllMethodsFromClass: aClass.
 
 	"Then I remove the class from myself."
-	(classes remove: aClass originalName asSymbol ifAbsent: [ nil ]) ifNotNil: [ self unregisterClass: aClass ].
+	(classes remove: aClass ifAbsent: [ nil ]) ifNotNil: [ self unregisterClass: aClass ].
 
 	"Lastly I unregister it from the tags"
 	(self classTags select: [ :eachTag | eachTag includesClass: aClass ]) do: [ :eachTag | self removeClassDefinition: aClass fromClassTag: eachTag name ]
@@ -1098,16 +1095,6 @@ RPackage >> unregisterClass: aClass [
 	"Private method that declares the mapping between a class and its package."
 
 	self organizer unregisterPackage: self forClass: aClass
-]
-
-{ #category : #updating }
-RPackage >> updateDefinedClassNamed: oldString withNewName: newString [
-	"this method should only be used with class names , and not metaclass names"
-
-	(oldString substrings size > 1 or: [ newString substrings size > 1 ]) ifTrue: [ Error signal: 'You should not use metaclass names' ].
-
-	classes remove: oldString asSymbol.
-	classes add: newString asSymbol
 ]
 
 { #category : #updating }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -766,12 +766,6 @@ RPackageOrganizer >> renameCategory: oldCatString toBe: newCatString [
 ]
 
 { #category : #'system integration' }
-RPackageOrganizer >> renameClass: class from: oldName to: newName [
-
-	(self packageOf: class) updateDefinedClassNamed: oldName withNewName: newName
-]
-
-{ #category : #'system integration' }
 RPackageOrganizer >> renamePackage: aPackage to: newName [
 
 	(self hasPackage: aPackage) ifFalse: [ ^ self ].

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -388,11 +388,10 @@ SystemDictionary >> renameClass: aClass from: oldName to: newName [
 	"Rename the class, aClass, to have the title newName."
 
 	| oldref category |
-	self flag: #package. "When the category thing will be removed, we should have only one line updating the organization"
+	self flag: #package. "When the category thing will be removed, we should remove the category update"
 	category := self organization categoryOfBehavior: oldName.
 	self organization classify: newName under: category.
 	self organization removeBehavior: oldName.
-	self organization renameClass: aClass from: oldName to: newName.
 	oldref := self associationAt: oldName.
 	self removeKey: oldName.
 	oldref key: newName.


### PR DESCRIPTION
RPackage is currently keeping a list of class names to know the classes it contains. This means that we often need to lookup in the system dictionary to know the real classes.

I propose to save the real classes instead since it is easier to ask to a class its name than to lookup the class in the system.

I also make the collection containing the classes a IdentitySet since instance of classes should stay the same and it is faster.

Lastly I removed a test that was really not useful since it tests a behavior that should never happen in the system (and if someone does that, then it's his problem, not RPackage problem)

Redo of #14369