### PR TITLE
Add ‘scale’ parameter for displaying strings using a FreeTypeFont

### DIFF
--- a/src/FreeType-Graphics/FreeTypeGlyphRenderer.class.st
+++ b/src/FreeType-Graphics/FreeTypeGlyphRenderer.class.st
@@ -116,14 +116,15 @@ FreeTypeGlyphRenderer >> fixBytesForMono: aGlyphForm [
 ]
 
 { #category : #public }
-FreeTypeGlyphRenderer >> glyphOf: aCharacter colorValue: aColorValue mono: monoBoolean subpixelPosition: sub font: aFreeTypeFont [
+FreeTypeGlyphRenderer >> glyphOf: aCharacter colorValue: aColorValue mono: monoBoolean subpixelPosition: sub font: aFreeTypeFont scale: scale [
 
 	| form |
 	form := self
 		renderGlyph: aCharacter
 		depth: (monoBoolean ifTrue:[1] ifFalse:[8])
 		subpixelPosition: sub
-		font: aFreeTypeFont.
+		font: aFreeTypeFont
+		scale: scale.
 	monoBoolean
 		ifTrue:[
 			form := self fixBytesForMono: form.
@@ -133,14 +134,15 @@ FreeTypeGlyphRenderer >> glyphOf: aCharacter colorValue: aColorValue mono: monoB
 ]
 
 { #category : #public }
-FreeTypeGlyphRenderer >> mode41GlyphOf: aCharacter colorValue: aColorValue mono: monoBoolean subpixelPosition: sub font: aFreeTypeFont [
+FreeTypeGlyphRenderer >> mode41GlyphOf: aCharacter colorValue: aColorValue mono: monoBoolean subpixelPosition: sub font: aFreeTypeFont scale: scale [
 
 	| form |
 	form := self
 		renderGlyph: aCharacter
 		depth: (monoBoolean ifTrue:[1] ifFalse:[8])
 		subpixelPosition: sub
-		font: aFreeTypeFont.
+		font: aFreeTypeFont
+		scale: scale.
 	monoBoolean
 		ifTrue:[
 			form := self fixBytesForMono: form.
@@ -151,7 +153,7 @@ FreeTypeGlyphRenderer >> mode41GlyphOf: aCharacter colorValue: aColorValue mono:
 ]
 
 { #category : #private }
-FreeTypeGlyphRenderer >> renderGlyph: aCharacter depth: depth subpixelPosition: sub font: aFreeTypeFont [
+FreeTypeGlyphRenderer >> renderGlyph: aCharacter depth: depth subpixelPosition: sub font: aFreeTypeFont scale: scale [
 	"Glyphs are either 1 or 8 bit deep. For 32 bpp we use 8 bits, otherwise 1"
 	| em form glyph charCode slant extraWidth extraHeight boldExtra offsetX offsetY s synthBoldStrength face |
 
@@ -192,32 +194,32 @@ FreeTypeGlyphRenderer >> renderGlyph: aCharacter depth: depth subpixelPosition: 
 	extraWidth := extraWidth + boldExtra.
 	sub > 0 ifTrue:[ extraWidth := extraWidth + 1].
 	extraHeight := boldExtra.
-	form := GlyphForm extent: (glyph width + extraWidth + 1)@(glyph height + extraHeight+ 1) depth: depth.
+	form := GlyphForm extent: ((glyph width + extraWidth + 1)@(glyph height + extraHeight+ 1)) * scale depth: depth.
 	s := (glyph height-glyph hBearingY)  * slant.
 	s := s sign * (s abs ceiling).
 	offsetX := glyph hBearingX negated + s + (boldExtra // 2) .
 	offsetY := glyph height - glyph hBearingY + (boldExtra//2).
 	synthBoldStrength ~= 0
 		ifTrue:[face emboldenOutline: synthBoldStrength].
-	face transformOutlineAngle: 0 scalePoint: 1@1  slant: slant.
-	face translateOutlineBy: (offsetX+(sub/64))@offsetY.
+	face transformOutlineAngle: 0 scalePoint: (1@1) * scale slant: slant.
+	face translateOutlineBy: ((offsetX+(sub/64))@offsetY) * scale.
 	face renderGlyphIntoForm: form.
-	form offset: (glyph hBearingX - s - (boldExtra // 2) ) @ (glyph hBearingY + 1 + (boldExtra / 2) ceiling  ) negated.
+	form offset: ((glyph hBearingX - s - (boldExtra // 2) ) @ (glyph hBearingY + 1 + (boldExtra / 2) ceiling  ) negated) * scale.
 	"When not hinting FreeType sets the advance to the truncated linearAdvance.
 	The characters appear squashed together. Rounding is probably better, so we fix the advance here"
 	aFreeTypeFont subPixelPositioned
-		ifTrue:[ form advance: glyph roundedPixelLinearAdvance]
-		ifFalse:[ form advance: glyph advance].
-	form linearAdvance: glyph linearAdvance.
+		ifTrue:[ form advance: glyph roundedPixelLinearAdvance * scale]
+		ifFalse:[ form advance: glyph advance * scale].
+	form linearAdvance: glyph linearAdvance * scale.
 	^ form
 ]
 
 { #category : #public }
-FreeTypeGlyphRenderer >> subGlyphOf: aCharacter colorValue: aColorValue mono: monoBoolean subpixelPosition: sub font: aFreeTypeFont [
+FreeTypeGlyphRenderer >> subGlyphOf: aCharacter colorValue: aColorValue mono: monoBoolean subpixelPosition: sub font: aFreeTypeFont scale: scale [
 	"The default renderer does not support sub-pixel anti-aliasing,
 	so answer an ordinary glyph"
 
-	^self mode41GlyphOf: aCharacter colorValue: aColorValue mono: monoBoolean subpixelPosition: sub font: aFreeTypeFont
+	^self mode41GlyphOf: aCharacter colorValue: aColorValue mono: monoBoolean subpixelPosition: sub font: aFreeTypeFont scale: scale
 ]
 
 { #category : #private }

--- a/src/FreeType-Graphics/FreeTypeSubPixelAntiAliasedGlyphRenderer.class.st
+++ b/src/FreeType-Graphics/FreeTypeSubPixelAntiAliasedGlyphRenderer.class.st
@@ -17,7 +17,7 @@ FreeTypeSubPixelAntiAliasedGlyphRenderer class >> initialize [
 ]
 
 { #category : #rendering }
-FreeTypeSubPixelAntiAliasedGlyphRenderer >> filter: aGlyphForm [
+FreeTypeSubPixelAntiAliasedGlyphRenderer >> filter: aGlyphForm baseExtent: baseExtent baseOffset: baseOffset baseAdvance: baseAdvance baseLinearAdvance: baseLinearAdvance scale: scale [
 	"aGlyphForm should be 3x stretched 8 bit GlyphForm"
 	| w h s answer rowstart bytes word littleEndian shift v a colorVal i
 	  prevG prevB r g b nextR nextG  filters rfilter gfilter bfilter
@@ -31,11 +31,11 @@ FreeTypeSubPixelAntiAliasedGlyphRenderer >> filter: aGlyphForm [
 	bytes := aGlyphForm bits.
 	w := aGlyphForm width.
 	h := aGlyphForm height.
-	answer := aGlyphForm class extent: ((aGlyphForm width / 3) ceiling + 2)@h depth: 32.
+	answer := aGlyphForm class extent: (((baseExtent x / 3) ceiling + 2) @ baseExtent y) * scale depth: 32.
 	answer
-		offset: (aGlyphForm offset x / 3) rounded@(aGlyphForm offset y);
-		advance: (aGlyphForm advance / 3) rounded;
-		linearAdvance: aGlyphForm linearAdvance.
+		offset: ((baseOffset x / 3) rounded@(baseOffset y)) * scale;
+		advance: (baseAdvance / 3) rounded * scale;
+		linearAdvance: baseLinearAdvance * scale.
 	s := w + 3 >> 2.
 	littleEndian := aGlyphForm isLittleEndian.
 	0 to: h - 1 do: [:y |
@@ -98,9 +98,9 @@ FreeTypeSubPixelAntiAliasedGlyphRenderer >> filter: aGlyphForm [
 ]
 
 { #category : #rendering }
-FreeTypeSubPixelAntiAliasedGlyphRenderer >> renderStretchedGlyph: aCharacter depth: depth subpixelPosition: sub font: aFreeTypeFont [
+FreeTypeSubPixelAntiAliasedGlyphRenderer >> renderAndFilterStretchedGlyph: aCharacter depth: depth subpixelPosition: sub font: aFreeTypeFont scale: scale [
 	"Glyphs are either 1 or 8 bit deep. For 32 bpp we use 8 bits, otherwise 1"
-	| em form glyph scaleX charCode slant extraWidth s offsetX offsetY synthBoldStrength boldExtra extraHeight face |
+	| em form glyph scaleX charCode slant extraWidth s offsetX offsetY synthBoldStrength boldExtra extraHeight face baseExtent baseOffset baseAdvance baseLinearAdvance |
 
 	charCode := aCharacter asUnicode asInteger.
 	(aFreeTypeFont face charmaps includes:'unic')
@@ -137,48 +137,50 @@ FreeTypeSubPixelAntiAliasedGlyphRenderer >> renderStretchedGlyph: aCharacter dep
 	synthBoldStrength ~= 0
 		ifTrue:[face emboldenOutline: synthBoldStrength].
 	boldExtra := 4 * synthBoldStrength abs ceiling.
-	face transformOutlineAngle: 0 scalePoint: scaleX@1  slant: slant.
+	face transformOutlineAngle: 0 scalePoint: (scaleX@1) * scale slant: slant.
 	extraWidth := (glyph height * slant) abs ceiling.
 	extraWidth := extraWidth + boldExtra.
 	sub > 0 ifTrue:[ extraWidth := extraWidth + 3].
 	extraHeight := boldExtra.
+	baseExtent := ((glyph width + extraWidth "+ 6" + 1 + 2)*scaleX)@(glyph height +extraHeight + 1).
 	form := GlyphForm
-		extent: ((glyph width + extraWidth "+ 6" + 1 + 2)*scaleX)@(glyph height +extraHeight + 1)
+		extent: baseExtent * scale
 		depth: depth.
 	s := (glyph height-glyph hBearingY)  * slant.
 	s := s sign * (s abs ceiling).
 	offsetX := (glyph hBearingX negated + s + (boldExtra // 2) + 1) * scaleX .
 	offsetY := glyph height - glyph hBearingY + (boldExtra//2).
-	face translateOutlineBy: (offsetX+(sub*scaleX/64))@offsetY.
+	face translateOutlineBy: ((offsetX+(sub*scaleX/64))@offsetY) * scale.
 	face renderGlyphIntoForm: form.
-	form offset: ((glyph hBearingX - s - 1 - (boldExtra // 2)) * scaleX)@ (glyph hBearingY + 1 + (boldExtra / 2) ceiling) negated.
+	baseOffset := ((glyph hBearingX - s - 1 - (boldExtra // 2)) * scaleX)@ (glyph hBearingY + 1 + (boldExtra / 2) ceiling) negated.
 	"When not hinting FreeType sets the advance to the truncated linearAdvance.
 	The characters appear squashed together. Rounding is probably better, so we fix the advance here"
-	aFreeTypeFont subPixelPositioned
-		ifTrue:[ form advance: glyph roundedPixelLinearAdvance * (scaleX@1)]
-		ifFalse:[ form advance: glyph advance x * scaleX@glyph advance y].
-	form linearAdvance: glyph linearAdvance.
-	^form
+	baseAdvance := aFreeTypeFont subPixelPositioned
+		ifTrue:[ glyph roundedPixelLinearAdvance * (scaleX@1)]
+		ifFalse:[ glyph advance x * scaleX@glyph advance y].
+	baseLinearAdvance := glyph linearAdvance.
+	^ self filter: form baseExtent: baseExtent baseOffset: baseOffset baseAdvance: baseAdvance baseLinearAdvance: baseLinearAdvance scale: scale
 ]
 
 { #category : #rendering }
-FreeTypeSubPixelAntiAliasedGlyphRenderer >> subGlyphOf: aCharacter colorValue: aColorValue mono: monoBoolean subpixelPosition: sub font: aFreeTypeFont [
+FreeTypeSubPixelAntiAliasedGlyphRenderer >> subGlyphOf: aCharacter colorValue: aColorValue mono: monoBoolean subpixelPosition: sub font: aFreeTypeFont scale: scale [
 
 	| form |
 	monoBoolean
 		ifFalse:[
 			form := self
-				renderStretchedGlyph: aCharacter
+				renderAndFilterStretchedGlyph: aCharacter
 				depth: 8
 				subpixelPosition: sub
-				font: aFreeTypeFont.
-			form := self filter: form]
+				font: aFreeTypeFont
+				scale: scale]
 		ifTrue:[
 			form := self
 				renderGlyph: aCharacter
 				depth: 1
 				subpixelPosition: sub
-				font: aFreeTypeFont.
+				font: aFreeTypeFont
+				scale: scale.
 			form := self fixBytesForMono: form.
 			form := form asFormOfDepth: 32].
 	^form

--- a/src/FreeType/FreeTypeFont.class.st
+++ b/src/FreeType/FreeTypeFont.class.st
@@ -172,6 +172,13 @@ FreeTypeFont >> displayString: aString on: aDisplayContext from: startIndex to: 
 
 { #category : #displaying }
 FreeTypeFont >> displayString: aString on: aBitBlt from: startIndex to: stopIndex at: aPoint kern: kernDelta baselineY: baselineY [
+
+	^ self displayString: aString on: aBitBlt from: startIndex to: stopIndex
+		at: aPoint kern: kernDelta baselineY: baselineY scale: 1
+]
+
+{ #category : #displaying }
+FreeTypeFont >> displayString: aString on: aBitBlt from: startIndex to: stopIndex at: aPoint kern: kernDelta baselineY: baselineY scale: scale [
 	| glyph  depth foreColorVal foreColorAlpha originalColorMap clr subPixelPosition widthAndKernedWidth char nextChar floatDestX  destX destY offset gammaTable gammaInverseTable useRule41 |
 
 	useRule41 := FreeTypeSettings current useSubPixelAntiAliasing and: [aBitBlt destForm depth >= 8].
@@ -207,7 +214,8 @@ FreeTypeFont >> displayString: aString on: aBitBlt from: startIndex to: stopInde
 			glyphOf: char
 			destDepth: depth
 			colorValue: foreColorVal
-			subpixelPosition: subPixelPosition.
+			subpixelPosition: subPixelPosition
+			scale: scale.
 		aBitBlt sourceForm: glyph.
 		offset := glyph offset.
 		aBitBlt destX: destX + offset x.
@@ -230,7 +238,7 @@ FreeTypeFont >> displayString: aString on: aBitBlt from: startIndex to: stopInde
 			widthAndKernedWidthOfLeft: char
 			right: nextChar
 			into: widthAndKernedWidth.
-		floatDestX := floatDestX + (widthAndKernedWidth at: 2) + kernDelta.
+		floatDestX := floatDestX + (((widthAndKernedWidth at: 2) + kernDelta) * scale).
 		destX := floatDestX ].
 	aBitBlt colorMap: originalColorMap.
 	^ destX @ destY
@@ -345,21 +353,40 @@ FreeTypeFont >> getWidthOf: aCharacter [
 { #category : #'glyph lookup' }
 FreeTypeFont >> glyphOf: aCharacter colorValue: aColorValue mono: monoBoolean subpixelPosition: sub [
 
-	^FreeTypeCache current
-		atFont: self
-		charCode: aCharacter asUnicode asInteger
-		type: ((1+sub) << 32) + aColorValue
-		ifAbsentPut: [
-			FreeTypeGlyphRenderer current
-				glyphOf: aCharacter
-				colorValue: aColorValue
-				mono: monoBoolean
-				subpixelPosition: sub
-				font: self]
+	^ self glyphOf: aCharacter colorValue: aColorValue mono: monoBoolean subpixelPosition: sub scale: 1
+]
+
+{ #category : #'glyph lookup' }
+FreeTypeFont >> glyphOf: aCharacter colorValue: aColorValue mono: monoBoolean subpixelPosition: sub scale: scale [
+
+	| glyphBlock |
+
+	glyphBlock := [
+		FreeTypeGlyphRenderer current
+			glyphOf: aCharacter
+			colorValue: aColorValue
+			mono: monoBoolean
+			subpixelPosition: sub
+			font: self
+			scale: scale ].
+	^ scale = 1
+		ifTrue: [
+			FreeTypeCache current
+				atFont: self
+				charCode: aCharacter asUnicode asInteger
+				type: ((1+sub) << 32) + aColorValue
+				ifAbsentPut: glyphBlock ]
+		ifFalse: [ glyphBlock value ]
 ]
 
 { #category : #'glyph lookup' }
 FreeTypeFont >> glyphOf: aCharacter destDepth: destDepth colorValue: aColorValue subpixelPosition: sub [
+
+	^ self glyphOf: aCharacter destDepth: destDepth colorValue: aColorValue subpixelPosition: sub scale: 1
+]
+
+{ #category : #'glyph lookup' }
+FreeTypeFont >> glyphOf: aCharacter destDepth: destDepth colorValue: aColorValue subpixelPosition: sub scale: scale [
 	"sub can be between 0 and 63 and denotes the sub-pixel position of the glyph"
 	| validSub |
 	validSub := self isSubPixelPositioned
@@ -371,7 +398,8 @@ FreeTypeFont >> glyphOf: aCharacter destDepth: destDepth colorValue: aColorValue
 				subGlyphOf: aCharacter
 				colorValue: aColorValue
 				mono: FreeTypeSettings current monoHinting
-				subpixelPosition: validSub]
+				subpixelPosition: validSub
+				scale: scale]
 		ifFalse:[
 			(destDepth >= 8 and:[FreeTypeSettings current useSubPixelAntiAliasing])
 				ifTrue:[
@@ -379,13 +407,15 @@ FreeTypeFont >> glyphOf: aCharacter destDepth: destDepth colorValue: aColorValue
 						mode41GlyphOf: aCharacter
 						colorValue: aColorValue
 						mono: FreeTypeSettings current monoHinting
-						subpixelPosition: validSub]
+						subpixelPosition: validSub
+						scale: scale]
 				ifFalse:[
 					self
 						glyphOf: aCharacter
 						colorValue: aColorValue
 						mono: FreeTypeSettings current monoHinting
-						subpixelPosition: validSub]]
+						subpixelPosition: validSub
+						scale: scale]]
 ]
 
 { #category : #testing }
@@ -607,20 +637,26 @@ FreeTypeFont >> minAscii [
 ]
 
 { #category : #'glyph lookup' }
-FreeTypeFont >> mode41GlyphOf: aCharacter colorValue: aColorValue mono: monoBoolean subpixelPosition: sub [
+FreeTypeFont >> mode41GlyphOf: aCharacter colorValue: aColorValue mono: monoBoolean subpixelPosition: sub scale: scale [
 
-	| |
-	^FreeTypeCache current
-		atFont: self
-		charCode: aCharacter asUnicode asInteger
-		type: (FreeTypeCacheGlyph + sub)
-		ifAbsentPut: [
-			FreeTypeGlyphRenderer current
-				mode41GlyphOf: aCharacter
-				colorValue: aColorValue
-				mono: monoBoolean
-				subpixelPosition: sub
-				font: self]
+	| glyphBlock |
+
+	glyphBlock := [
+		FreeTypeGlyphRenderer current
+			mode41GlyphOf: aCharacter
+			colorValue: aColorValue
+			mono: monoBoolean
+			subpixelPosition: sub
+			font: self
+			scale: scale ].
+	^ scale = 1
+		ifTrue: [
+			FreeTypeCache current
+				atFont: self
+				charCode: aCharacter asUnicode asInteger
+				type: (FreeTypeCacheGlyph + sub)
+				ifAbsentPut: glyphBlock ]
+		ifFalse: [ glyphBlock value ]
 ]
 
 { #category : #accessing }
@@ -747,19 +783,26 @@ FreeTypeFont >> strikeoutTop [
 ]
 
 { #category : #'glyph lookup' }
-FreeTypeFont >> subGlyphOf: aCharacter colorValue: aColorValue mono: monoBoolean subpixelPosition: sub [
+FreeTypeFont >> subGlyphOf: aCharacter colorValue: aColorValue mono: monoBoolean subpixelPosition: sub scale: scale [
 
-	^FreeTypeCache current
-		atFont: self
-		charCode: aCharacter asUnicode asInteger
-		type: FreeTypeCacheGlyphLCD + sub
-		ifAbsentPut: [
-			FreeTypeGlyphRenderer current
-				subGlyphOf: aCharacter
-				colorValue: aColorValue
-				mono: monoBoolean
-				subpixelPosition: sub
-				font: self]
+	| glyphBlock |
+
+	glyphBlock := [
+		FreeTypeGlyphRenderer current
+			subGlyphOf: aCharacter
+			colorValue: aColorValue
+			mono: monoBoolean
+			subpixelPosition: sub
+			font: self
+			scale: scale ].
+	^ scale = 1
+		ifTrue: [
+			FreeTypeCache current
+				atFont: self
+				charCode: aCharacter asUnicode asInteger
+				type: FreeTypeCacheGlyphLCD + sub
+				ifAbsentPut: glyphBlock ]
+		ifFalse: [ glyphBlock value ]
 ]
 
 { #category : #testing }


### PR DESCRIPTION
This pull request adds a parameter ‘scale’ for displaying strings using a FreeTypeFont. An example is given by the snippet below. For comparison, for ‘form1’, the example string is displayed normally and then the form is scaled by a factor of two:

![1](https://github.com/pharo-project/pharo/assets/1611248/dc1f64a5-e355-466a-8c56-cbb50bfe239c)

For ‘form2’, the string is displayed directly on the larger form with the point size of the font doubled, this provides better detail in the character glyphs, but also changes the width:

![2](https://github.com/pharo-project/pharo/assets/1611248/5df565d5-e259-4fcd-bac0-6ad21613cda8)

For ‘form3’, the string is displayed directly on the larger form using the new ‘scale’ parameter, which provides better detail in the character glyphs while keeping the width:

![3](https://github.com/pharo-project/pharo/assets/1611248/1a50edce-416e-4355-a23f-20073da464ee)

Before this can be merged: how should loading this into an existing image be handled? I tried it and while it did load, it required closing a debugger and resetting the draw error of some morphs afterwards (so `Morph allSubInstancesDo: #resumeAfterDrawError`).

Some other things to note:
* Only integer scales are supported.
* The FreeTypeCache is not used yet when the scale is not 1.
* The parameter is only available on FreeTypeFont, extending it to the other font classes and the string drawing methods on the canvas classes is left to ‘future work’.

```smalltalk
(baseForm := Form extent: 230@18 depth: Display depth)
	fillColor: Color white.
baseForm getCanvas drawString: String loremIpsum from: 1 to: 40 at: 5@0
	font: (LogicalFont familyName: 'Source Sans Pro' pointSize: 10) color: Color black.
form1 := baseForm scaledToSize: 230@18 * 2.

(form2 := Form extent: 230@18 * 2 depth: Display depth)
	fillColor: Color white.
form2 getCanvas drawString: String loremIpsum from: 1 to: 40 at: 5@0 * 2
	font: (LogicalFont familyName: 'Source Sans Pro' pointSize: 10 * 2) color: Color black.

(form3 := Form extent: 230@18 * 2 depth: Display depth)
	fillColor: Color white.
(port := form3 getCanvas privatePort)
	colorMap: nil;
	combinationRule: Form paint.
(freeTypeFont := (LogicalFont familyName: 'Source Sans Pro' pointSize: 10) realFont)
	installOn: port foregroundColor: Color black
	backgroundColor: Color transparent.
freeTypeFont displayString: String loremIpsum on: port from: 1 to: 40
	at: (5@0) * 2 kern: 0 baselineY: ((5@0) y + freeTypeFont ascent) * 2 scale: 2.

{ form1. form2. form3 } keysAndValuesDo: [ :index :form |
	form getCanvas drawPolygon: { 0@0. 459@0. 459@35. 0@35 } color: Color transparent
		borderWidth: 1 borderColor: Color black.
	PNGReadWriter putForm: form onFileNamed: FileLocator imageDirectory / (index asString , '.png') ]
```