### PR TITLE
Change the #baseFont of the FixedFaceFont set in #fallbackFont in StrikeFont to the StrikeFont itself

### DIFF
--- a/src/Graphics-Fonts/StrikeFont.class.st
+++ b/src/Graphics-Fonts/StrikeFont.class.st
@@ -1008,7 +1008,7 @@ StrikeFont >> extendMaxAsciiTo: newMax [
 
 { #category : #accessing }
 StrikeFont >> fallbackFont [
-	^ fallbackFont ifNil: [ fallbackFont := FixedFaceFont new errorFont fontSize: self height ]
+	^ fallbackFont ifNil: [ fallbackFont := FixedFaceFont new errorFont baseFont: self ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This pull request changes the `#baseFont` of the FixedFaceFont set in `StrikeFont>>#fallbackFont` to the StrikeFont itself. Before this change, the snippet given below draws:

![1](https://github.com/pharo-project/pharo/assets/1611248/bc1b23c1-37a3-4ed6-8721-85e45375c04f)

With this change, the snippet draws:

![2](https://github.com/pharo-project/pharo/assets/1611248/920dfaec-2fd0-40ca-aba9-9b09b54b06c2)

Note that multiple executions of the snippet use the same StrikeFont instance, it can be sent `#reset` to reset its fallback font.

The send of `#fallbackFont` in the snippet avoids a MessageNotUnderstood in `StrikeFont>>#displayMultiString:on:from:to:at:kern:baselineY:` due to `fallbackFont` being nil. I’m not sure whether that method should use the accessor or whether it should take into account that the variable can be nil in another way: compare with `#widthOf:` which uses the accessor, while `#glyphOf:` and `#glyphInfoOf:into:` use the variable directly with an `#ifNotNil:` test.

A larger question is whether using an instance of StrikeFont still needs to be possible, there don’t seem to be many uses anymore, though there are not none either, the `#realFont` of the `#monthNameFont` and `#weekdayFont` of a CalendarMorph is a StrikeFont.

```smalltalk
strikeFont := (LogicalFont familyName: 'Bitmap DejaVu Sans' pointSize: 9) realFont.
strikeFont fallbackFont.
(form := Form extent: 260@14 depth: Display depth)
	fillColor: Color white.
form getCanvas drawString: (String loremIpsum copyReplaceAll: 'u' with: 'ū') from: 1 to: 40 at: 5@0
	font: strikeFont color: Color black.
form
```
