### PR TITLE
Cleanup: rename primitive execute

### DIFF
--- a/src/Epicea/EpRBPropagateRefactoring.class.st
+++ b/src/Epicea/EpRBPropagateRefactoring.class.st
@@ -24,15 +24,15 @@ EpRBPropagateRefactoring >> asEpiceaEvent [
 	^ EpPropagateRefactoring target: targetRefactoring asEpiceaEvent
 ]
 
+{ #category : #executing }
+EpRBPropagateRefactoring >> generateChanges [
+	targetRefactoring propagateTransformation
+]
+
 { #category : #initialization }
 EpRBPropagateRefactoring >> initializeWith: aRefactoring [
 	self initialize.
 	targetRefactoring := aRefactoring
-]
-
-{ #category : #private }
-EpRBPropagateRefactoring >> primitiveExecute [
-	targetRefactoring propagateTransformation
 ]
 
 { #category : #accessing }

--- a/src/Epicea/TestCase.extension.st
+++ b/src/Epicea/TestCase.extension.st
@@ -1,14 +1,14 @@
 Extension { #name : #TestCase }
 
 { #category : #'*Epicea' }
-TestCase >> shouldLogWithEpicea [
-
-	^ self class shouldLogWithEpicea
-]
-
-{ #category : #'*Epicea' }
 TestCase class >> shouldLogWithEpicea [
 	"When running a test, we disable the loggings of Epicea to run the tests silently. In case a TestCase explicitly wants to Epicea logs, then I can be overriden to return true and enable the logs."
 
 	^ false
+]
+
+{ #category : #'*Epicea' }
+TestCase >> shouldLogWithEpicea [
+
+	^ self class shouldLogWithEpicea
 ]

--- a/src/Refactoring-Changes/RBAddMethodChange.class.st
+++ b/src/Refactoring-Changes/RBAddMethodChange.class.st
@@ -144,6 +144,15 @@ RBAddMethodChange >> definedSelector [
 	^ definedSelector
 ]
 
+{ #category : #private }
+RBAddMethodChange >> generateChanges [
+
+	definedSelector := self changeClass
+		                   compile: self source
+		                   classified: self protocol
+		                   notifying: self controller
+]
+
 { #category : #comparing }
 RBAddMethodChange >> hash [
 
@@ -174,15 +183,6 @@ RBAddMethodChange >> parseTree [
 		  onError: [ :str :pos | ^ nil ].
 	tree ifNotNil: [ tree doSemanticAnalysis ].
 	^ tree
-]
-
-{ #category : #private }
-RBAddMethodChange >> primitiveExecute [
-
-	definedSelector := self changeClass
-		                   compile: self source
-		                   classified: self protocol
-		                   notifying: self controller
 ]
 
 { #category : #printing }

--- a/src/Refactoring-Changes/RBAddPackageChange.class.st
+++ b/src/Refactoring-Changes/RBAddPackageChange.class.st
@@ -27,7 +27,7 @@ RBAddPackageChange >> asUndoOperation [
 ]
 
 { #category : #private }
-RBAddPackageChange >> primitiveExecute [
+RBAddPackageChange >> generateChanges [
 
 	self packageOrganizer ensurePackage: packageName
 ]

--- a/src/Refactoring-Changes/RBAddProtocolChange.class.st
+++ b/src/Refactoring-Changes/RBAddProtocolChange.class.st
@@ -29,7 +29,7 @@ RBAddProtocolChange >> changeString [
 ]
 
 { #category : #private }
-RBAddProtocolChange >> primitiveExecute [
+RBAddProtocolChange >> generateChanges [
 
 	self changeClass addProtocol: protocol
 ]

--- a/src/Refactoring-Changes/RBClassCategoryChange.class.st
+++ b/src/Refactoring-Changes/RBClassCategoryChange.class.st
@@ -52,7 +52,7 @@ RBClassCategoryChange >> displayCategoryName [
 ]
 
 { #category : #private }
-RBClassCategoryChange >> primitiveExecute [
+RBClassCategoryChange >> generateChanges [
 
 	self changeClass category: category
 ]

--- a/src/Refactoring-Changes/RBCommentChange.class.st
+++ b/src/Refactoring-Changes/RBCommentChange.class.st
@@ -55,7 +55,7 @@ RBCommentChange >> comment: aString [
 ]
 
 { #category : #private }
-RBCommentChange >> primitiveExecute [
+RBCommentChange >> generateChanges [
 
 	self changeClass comment: comment stamp: self changeStamp.
 	SystemAnnouncer uniqueInstance classCommented: self changeClass

--- a/src/Refactoring-Changes/RBRefactoryClassChange.class.st
+++ b/src/Refactoring-Changes/RBRefactoryClassChange.class.st
@@ -86,9 +86,15 @@ RBRefactoryClassChange >> executeNotifying: aBlock [
 	| undo |
 	undo := self asUndoOperation.
 	undo name: self name.
-	self primitiveExecute.
+	self generateChanges.
 	aBlock value.
 	^ undo
+]
+
+{ #category : #private }
+RBRefactoryClassChange >> generateChanges [
+
+	^ self subclassResponsibility
 ]
 
 { #category : #comparing }
@@ -114,12 +120,6 @@ RBRefactoryClassChange >> methodSourceFor: aSymbol [
 RBRefactoryClassChange >> parserClass [
 
 	^ RBParser
-]
-
-{ #category : #private }
-RBRefactoryClassChange >> primitiveExecute [
-
-	^ self subclassResponsibility
 ]
 
 { #category : #printing }

--- a/src/Refactoring-Changes/RBRefactoryDefinitionChange.class.st
+++ b/src/Refactoring-Changes/RBRefactoryDefinitionChange.class.st
@@ -115,6 +115,14 @@ RBRefactoryDefinitionChange >> fillOutDefinition: aDictionary [
 	self subclassResponsibility
 ]
 
+{ #category : #private }
+RBRefactoryDefinitionChange >> generateChanges [
+
+	definedClass := self definitionClass environment
+		                defineClass: self definition
+		                withController: self controller
+]
+
 { #category : #comparing }
 RBRefactoryDefinitionChange >> hash [
 
@@ -131,14 +139,6 @@ RBRefactoryDefinitionChange >> namesIn: aString [
 		token := scanner next.
 		token isIdentifier ifTrue: [ names add: token value ] ].
 	^ names asArray
-]
-
-{ #category : #private }
-RBRefactoryDefinitionChange >> primitiveExecute [
-
-	definedClass := self definitionClass environment
-		                defineClass: self definition
-		                withController: self controller
 ]
 
 { #category : #printing }

--- a/src/Refactoring-Changes/RBRefactoryPackageChange.class.st
+++ b/src/Refactoring-Changes/RBRefactoryPackageChange.class.st
@@ -20,18 +20,18 @@ RBRefactoryPackageChange >> executeNotifying: aBlock [
 	| undo |
 	undo := self asUndoOperation.
 	undo name: self name.
-	self primitiveExecute.
+	self generateChanges.
 	aBlock value.
 	^ undo
+]
+
+{ #category : #private }
+RBRefactoryPackageChange >> generateChanges [
+	self subclassResponsibility
 ]
 
 { #category : #initialization }
 RBRefactoryPackageChange >> initialize [
 	super initialize.
 	browserEnvironment := RBBrowserEnvironment default
-]
-
-{ #category : #private }
-RBRefactoryPackageChange >> primitiveExecute [
-	self subclassResponsibility
 ]

--- a/src/Refactoring-Changes/RBRefactoryVariableChange.class.st
+++ b/src/Refactoring-Changes/RBRefactoryVariableChange.class.st
@@ -52,16 +52,16 @@ RBRefactoryVariableChange >> class: aBehavior variable: aString [
 	variable := aString
 ]
 
+{ #category : #private }
+RBRefactoryVariableChange >> generateChanges [
+
+	self changeClass perform: self changeSymbol with: self changeObject
+]
+
 { #category : #comparing }
 RBRefactoryVariableChange >> hash [
 
 	^ self changeClassName hash bitXor: self variable hash
-]
-
-{ #category : #private }
-RBRefactoryVariableChange >> primitiveExecute [
-
-	self changeClass perform: self changeSymbol with: self changeObject
 ]
 
 { #category : #printing }

--- a/src/Refactoring-Changes/RBRemoveClassChange.class.st
+++ b/src/Refactoring-Changes/RBRemoveClassChange.class.st
@@ -51,17 +51,17 @@ RBRemoveClassChange >> changeString [
 	^ 'Remove ' , self displayClassName
 ]
 
+{ #category : #private }
+RBRemoveClassChange >> generateChanges [
+
+	self changeClass removeFromSystem
+]
+
 { #category : #initialization }
 RBRemoveClassChange >> initialize [
 
 	super initialize.
 	changeFactory := RBRefactoryChangeManager changeFactory
-]
-
-{ #category : #private }
-RBRemoveClassChange >> primitiveExecute [
-
-	self changeClass removeFromSystem
 ]
 
 { #category : #printing }

--- a/src/Refactoring-Changes/RBRemoveMethodChange.class.st
+++ b/src/Refactoring-Changes/RBRemoveMethodChange.class.st
@@ -44,16 +44,16 @@ RBRemoveMethodChange >> changeString [
 		with: selector
 ]
 
+{ #category : #private }
+RBRemoveMethodChange >> generateChanges [
+
+	^ self changeClass removeSelector: selector
+]
+
 { #category : #comparing }
 RBRemoveMethodChange >> hash [
 
 	^ selector hash
-]
-
-{ #category : #private }
-RBRemoveMethodChange >> primitiveExecute [
-
-	^ self changeClass removeSelector: selector
 ]
 
 { #category : #printing }

--- a/src/Refactoring-Changes/RBRemovePackageChange.class.st
+++ b/src/Refactoring-Changes/RBRemovePackageChange.class.st
@@ -22,18 +22,18 @@ RBRemovePackageChange >> asUndoOperation [
 	^ changeFactory addPackageNamed: packageName
 ]
 
-{ #category : #accessing }
-RBRemovePackageChange >> package [
-
-	^ (browserEnvironment packageAt: packageName ifAbsent: [nil])
-]
-
 { #category : #private }
-RBRemovePackageChange >> primitiveExecute [
+RBRemovePackageChange >> generateChanges [
 
 	| pkg |
 	pkg := self package.
 	pkg ifNotNil: [ pkg removeFromSystem ]
+]
+
+{ #category : #accessing }
+RBRemovePackageChange >> package [
+
+	^ (browserEnvironment packageAt: packageName ifAbsent: [nil])
 ]
 
 { #category : #removing }

--- a/src/Refactoring-Changes/RBRemoveProtocolChange.class.st
+++ b/src/Refactoring-Changes/RBRemoveProtocolChange.class.st
@@ -29,7 +29,7 @@ RBRemoveProtocolChange >> changeString [
 ]
 
 { #category : #private }
-RBRemoveProtocolChange >> primitiveExecute [
+RBRemoveProtocolChange >> generateChanges [
 
 	self changeClass removeProtocolIfEmpty: protocol
 ]

--- a/src/Refactoring-Changes/RBRenamePackageChange.class.st
+++ b/src/Refactoring-Changes/RBRenamePackageChange.class.st
@@ -33,7 +33,7 @@ RBRenamePackageChange >> changePackage [
 ]
 
 { #category : #private }
-RBRenamePackageChange >> primitiveExecute [
+RBRenamePackageChange >> generateChanges [
 
 	self changePackage renameTo: newName
 ]

--- a/src/Refactoring-Core/RBAbstractTransformation.class.st
+++ b/src/Refactoring-Core/RBAbstractTransformation.class.st
@@ -151,8 +151,19 @@ RBAbstractTransformation >> emptyCondition [
 { #category : #transforming }
 RBAbstractTransformation >> execute [
 	"Check precondition, execute the transformation that produces changes and finally execute the changes"
-	self primitiveExecute.
+	self generateChanges.
 	self performChanges
+]
+
+{ #category : #executing }
+RBAbstractTransformation >> generateChanges [
+	"compatibility method RBRefactoring"
+
+	self checkPreconditions.
+	self privateTransform
+	
+	"below executes the refactoring without prompt"
+	"RBRefactoringManager instance addRefactoring: self"
 ]
 
 { #category : #accessing }
@@ -254,17 +265,6 @@ RBAbstractTransformation >> preconditions [
 	self subclassResponsibility
 ]
 
-{ #category : #executing }
-RBAbstractTransformation >> primitiveExecute [
-	"compatibility method RBRefactoring"
-
-	self checkPreconditions.
-	self privateTransform
-	
-	"below executes the refactoring without prompt"
-	"RBRefactoringManager instance addRefactoring: self"
-]
-
 { #category : #transforming }
 RBAbstractTransformation >> privateTransform [ 
 
@@ -359,7 +359,7 @@ RBAbstractTransformation >> shouldUseExistingMethod: aSelector [
 { #category : #transforming }
 RBAbstractTransformation >> transform [
 	"Do the actual operations."
-	self deprecated: 'Use primitiveExecute or privateTransform instead. Check subclasses for more details.'. 
+	self deprecated: 'Use generateChanges or privateTransform instead. Check subclasses for more details.'. 
 	
 	self subclassResponsibility
 ]

--- a/src/Refactoring-Core/RBApplicabilityChecksFailedError.class.st
+++ b/src/Refactoring-Core/RBApplicabilityChecksFailedError.class.st
@@ -3,6 +3,6 @@ I represent an Error that is signaled when applicability checks are not met.
 "
 Class {
 	#name : #RBApplicabilityChecksFailedError,
-	#superclass : #Error,
+	#superclass : #RBRefactoringError,
 	#category : #'Refactoring-Core-Support'
 }

--- a/src/Refactoring-Core/RBBreakingChangeChecksFailedWarning.class.st
+++ b/src/Refactoring-Core/RBBreakingChangeChecksFailedWarning.class.st
@@ -3,6 +3,6 @@ I represent a Warning that is signaled when breaking change checks are not met.
 "
 Class {
 	#name : #RBBreakingChangeChecksFailedWarning,
-	#superclass : #Warning,
+	#superclass : #RBRefactoringWarning,
 	#category : #'Refactoring-Core-Support'
 }

--- a/src/Refactoring-Core/RBCompositeContinuingRefactoring.class.st
+++ b/src/Refactoring-Core/RBCompositeContinuingRefactoring.class.st
@@ -10,5 +10,5 @@ Class {
 { #category : #preconditions }
 RBCompositeContinuingRefactoring >> privateTransform [
 
-	refactorings do: [ :each | [ each primitiveExecute] on: RBRefactoringError do: [ :ex | ] ]
+	refactorings do: [ :each | [ each generateChanges] on: RBRefactoringError do: [ :ex | ] ]
 ]

--- a/src/Refactoring-Core/RBCompositeRefactoring.class.st
+++ b/src/Refactoring-Core/RBCompositeRefactoring.class.st
@@ -43,10 +43,10 @@ RBCompositeRefactoring >> preconditions [
 	^ self applicabilityPreconditions & self breakingChangePreconditions 
 ]
 
-{ #category : #preconditions }
+{ #category : #transforming }
 RBCompositeRefactoring >> privateTransform [
 
-	refactorings do: [ :each | each primitiveExecute ]
+	refactorings do: [ :each | each generateChanges ]
 ]
 
 { #category : #accessing }

--- a/src/Refactoring-Core/RBPullUpMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBPullUpMethodRefactoring.class.st
@@ -249,7 +249,7 @@ RBPullUpMethodRefactoring >> copyDownMethods [
 { #category : #actions }
 RBPullUpMethodRefactoring >> generateChanges [
 
-	self primitiveExecute.
+	super generateChanges.
 
 	^ self changes
 ]

--- a/src/Refactoring-Core/RBRefactoring.class.st
+++ b/src/Refactoring-Core/RBRefactoring.class.st
@@ -127,7 +127,7 @@ RBRefactoring >> generateChangesFor: aRefactoring [
 	"Execute the argument but passing the receiver options to that refactoring"
 	aRefactoring copyOptionsFrom: self options.
 	aRefactoring model: self model.
-	aRefactoring primitiveExecute
+	aRefactoring generateChanges
 ]
 
 { #category : #private }

--- a/src/Refactoring-Core/RBRemoveClassKeepingSubclassesRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveClassKeepingSubclassesRefactoring.class.st
@@ -52,10 +52,10 @@ RBRemoveClassKeepingSubclassesRefactoring >> preconditions [
 		  "& ( self preconditionEmptyOrHasNoSubclasses: aClassOrTrait )" ]
 ]
 
-{ #category : #preconditions }
+{ #category : #transforming }
 RBRemoveClassKeepingSubclassesRefactoring >> privateTransform [
 	self initalizeRefactorings.
-	refactorings do: [ :ref | ref primitiveExecute ].
+	refactorings do: [ :ref | ref generateChanges ].
 	self reparentSubclasses.
 	self removeClasses
 ]

--- a/src/Refactoring-Core/RBRenameMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenameMethodRefactoring.class.st
@@ -125,7 +125,7 @@ RBRenameMethodRefactoring >> newNameDoesNotRequireRefactoringPreconditions [
 		   'The selector name has <1?not:> changed <1?:to #' , newSelector
 		   , '>') & (RBCondition
 		   withBlock: [
-		   permutation asArray ~= (1 to: oldSelector numArgs) asArray ]
+		   permutation asArray = (1 to: oldSelector numArgs) asArray ]
 		   errorString: 'The arguments are <1?:not >permuted')
 ]
 

--- a/src/Refactoring-Tests-Core/RBRefactoringBrowserTest.class.st
+++ b/src/Refactoring-Tests-Core/RBRefactoringBrowserTest.class.st
@@ -11,7 +11,7 @@ RBRefactoringBrowserTest class >> isAbstract [
 
 { #category : #private }
 RBRefactoringBrowserTest >> executeRefactoring: aRefactoring [
-	aRefactoring primitiveExecute.
+	aRefactoring generateChanges.
 	self parserClass parseExpression: aRefactoring storeString
 ]
 

--- a/src/Refactoring2-Transformations-Tests/RBAbstractRefactoringTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAbstractRefactoringTest.class.st
@@ -29,12 +29,12 @@ RBAbstractRefactoringTest >> createRefactoringWithModel: aRBNamespace andArgumen
 
 { #category : #parsing }
 RBAbstractRefactoringTest >> executeRefactoring: aRefactoring [
-	aRefactoring primitiveExecute
+	aRefactoring generateChanges
 ]
 
 { #category : #parsing }
 RBAbstractRefactoringTest >> executeRefactorings: aRefactoringColl [
-	aRefactoringColl do: [ :ref | ref primitiveExecute]
+	aRefactoringColl do: [ :ref | ref generateChanges]
 ]
 
 { #category : #tests }
@@ -192,7 +192,7 @@ RBAbstractRefactoringTest >> shouldFail: aRefactoring [
 
 	self proceedThroughWarning: [
 		self
-			should: [ aRefactoring primitiveExecute ]
+			should: [ aRefactoring generateChanges ]
 			raise: RBRefactoringError
 	]
 ]

--- a/src/Refactoring2-Transformations-Tests/RBAbstractTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAbstractTransformationTest.class.st
@@ -56,7 +56,7 @@ RBAbstractTransformationTest >> shouldFail: aRefactoring [
 
 	self proceedThroughWarning: [
 		self
-			should: [ aRefactoring primitiveExecute ]
+			should: [ aRefactoring generateChanges ]
 			raise: RBRefactoringError ]
 ]
 

--- a/src/Refactoring2-Transformations-Tests/RBAddAccessorsForClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddAccessorsForClassTransformationTest.class.st
@@ -9,7 +9,7 @@ RBAddAccessorsForClassTransformationTest >> testRefactoring [
 
 	| refactoring class |
 	refactoring := (RBAddAccessorsForClassTransformation className:
-		                #RBVariableTransformation) primitiveExecute.
+		                #RBVariableTransformation) generateChanges.
 
 	self assert: refactoring model changes changes size equals: 4.
 
@@ -28,7 +28,7 @@ RBAddAccessorsForClassTransformationTest >> testTransform [
 
 	| transformation class |
 	transformation := (RBAddAccessorsForClassTransformation className:
-		                   self changeMockClass name) primitiveExecute.
+		                   self changeMockClass name) generateChanges.
 
 	self assert: transformation model changes changes size equals: 2.
 

--- a/src/Refactoring2-Transformations-Tests/RBAddAssignmentTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddAssignmentTransformationTest.class.st
@@ -48,7 +48,7 @@ RBAddAssignmentTransformationTest >> testRefactoring [
 		                value: '1 asString'
 		                inMethod: #methodBefore
 		                inClass: #RBAddAssignmentTransformationTest)
-		               primitiveExecute.
+		               generateChanges.
 
 	self assert: refactoring model changes changes size equals: 1.
 
@@ -74,7 +74,7 @@ RBAddAssignmentTransformationTest >> testTransform [
 		                   variable: 'variable'
 		                   value: '1 asString'
 		                   inMethod: #methodBefore
-		                   inClass: self class name) primitiveExecute.
+		                   inClass: self class name) generateChanges.
 
 	self assert: transformation model changes changes size equals: 1.
 

--- a/src/Refactoring2-Transformations-Tests/RBAddMessageSendTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddMessageSendTransformationTest.class.st
@@ -54,7 +54,7 @@ RBAddMessageSendTransformationTest >> testRefactoring [
 		                messageSend: 'variable byteAt: 1'
 		                inMethod: #methodBefore
 		                inClass: #RBAddMessageSendTransformationTest)
-		               primitiveExecute.
+		               generateChanges.
 
 	self assert: refactoring model changes changes size equals: 1.
 
@@ -72,7 +72,7 @@ RBAddMessageSendTransformationTest >> testTransform [
 	transformation := (RBAddMessageSendTransformation new
 		                   messageSend: 'variable byteAt: 1'
 		                   inMethod: #methodBefore
-		                   inClass: self class name) primitiveExecute.
+		                   inClass: self class name) generateChanges.
 
 	self assert: transformation model changes changes size equals: 1.
 

--- a/src/Refactoring2-Transformations-Tests/RBAddPragmaTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddPragmaTransformationTest.class.st
@@ -54,7 +54,7 @@ RBAddPragmaTransformationTest >> testRefactoring [
 		                pragma: '<pragmaForTesting: 56>'
 		                inMethod: #methodBefore
 		                inClass: #RBAddPragmaTransformationTest)
-		               primitiveExecute.
+		               generateChanges.
 
 	self assert: refactoring model changes changes size equals: 1.
 
@@ -71,7 +71,7 @@ RBAddPragmaTransformationTest >> testTransform [
 	transformation := (RBAddPragmaTransformation new
 		                   pragma: '<pragmaForTesting: 56>'
 		                   inMethod: #methodBefore
-		                   inClass: self class name) primitiveExecute.
+		                   inClass: self class name) generateChanges.
 
 	self assert: transformation model changes changes size equals: 1.
 

--- a/src/Refactoring2-Transformations-Tests/RBAddReturnStatementTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddReturnStatementTransformationTest.class.st
@@ -63,7 +63,7 @@ RBAddReturnStatementTransformationTest >> testRefactoring [
 		                return: '^ variable'
 		                inMethod: #methodBefore
 		                inClass: #RBAddReturnStatementTransformationTest)
-		               primitiveExecute.
+		               generateChanges.
 
 	self assert: refactoring model changes changes size equals: 1.
 
@@ -81,7 +81,7 @@ RBAddReturnStatementTransformationTest >> testTransform [
 	transformation := (RBAddReturnStatementTransformation new
 		                   return: '^ variable'
 		                   inMethod: #methodBefore
-		                   inClass: self class name) primitiveExecute.
+		                   inClass: self class name) generateChanges.
 
 	self assert: transformation model changes changes size equals: 1.
 

--- a/src/Refactoring2-Transformations-Tests/RBAddSubtreeTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddSubtreeTransformationTest.class.st
@@ -48,7 +48,7 @@ RBAddSubtreeTransformationTest >> testTransform [
 		                   interval: (0 to: 1)
 		                   with: 'self printString'
 		                   from: #one
-		                   in: self changeMockClass name) primitiveExecute.
+		                   in: self changeMockClass name) generateChanges.
 
 	self assert: transformation model changes changes size equals: 1.
 

--- a/src/Refactoring2-Transformations-Tests/RBComposeParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBComposeParametrizedTest.class.st
@@ -36,7 +36,7 @@ RBComposeParametrizedTest >> shouldFail: refactoringColl [
 
 	self proceedThroughWarning: [
 		self should: [ refactoringColl do: [ :ref |
-				ref primitiveExecute ] ] raise: RBRefactoringError ]
+				ref generateChanges ] ] raise: RBRefactoringError ]
 ]
 
 { #category : #asserting }

--- a/src/Refactoring2-Transformations-Tests/RBDeprecateMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBDeprecateMethodParametrizedTest.class.st
@@ -52,39 +52,3 @@ RBDeprecateMethodParametrizedTest >> testDeprecateMethodUsingMethodWithoutArgs [
 		assert: ((class parseTreeForSelector: oldSelector ) statements anySatisfy:
 			[ :e | e isMessage and: [ e selector = #deprecated:on:in: ] ])
 ]
-
-{ #category : #'failure tests' }
-RBDeprecateMethodParametrizedTest >> testFailureInvalidNewSelector [
-	"please note that this strange way to create symbol is because some tests are counting symbol
-	and rewriting the code in a bad way so for now do not change them."
-
-	| refactoring oldSelector newSelector |
-	oldSelector := ('called:' , 'on1:') asSymbol.
-	newSelector := 'inlineFoo1:' asSymbol.
-	refactoring := self
-		               createRefactoringWithModel: model
-		               andArguments: {
-				               oldSelector.
-				               RBClassDataForRefactoringTest.
-				               newSelector }.
-
-	self shouldFail: refactoring
-]
-
-{ #category : #'failure tests' }
-RBDeprecateMethodParametrizedTest >> testFailureInvalidNumArgsOfSelector [
-	"please note that this strange way to create symbol is because some tests are counting symbol
-	and rewriting the code in a bad way so for now do not change them."
-
-	| refactoring oldSelector newSelector |
-	oldSelector := ('called:' , 'on1:') asSymbol.
-	newSelector := 'inlineFoo:' asSymbol.
-	refactoring := self
-		               createRefactoringWithModel: model
-		               andArguments: {
-				               oldSelector.
-				               RBClassDataForRefactoringTest.
-				               newSelector }.
-
-	self shouldFail: refactoring
-]

--- a/src/Refactoring2-Transformations-Tests/RBDeprecateMethodRefactoringTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBDeprecateMethodRefactoringTest.class.st
@@ -1,0 +1,43 @@
+Class {
+	#name : #RBDeprecateMethodRefactoringTest,
+	#superclass : #RBAbstractTransformationTest,
+	#category : #'Refactoring2-Transformations-Tests-Test'
+}
+
+{ #category : #'failure tests' }
+RBDeprecateMethodRefactoringTest >> testShouldWarnWhenNewSelectorHasInvalidNumArgs [
+	"please note that this strange way to create symbol is because some tests are counting symbol
+	and rewriting the code in a bad way so for now do not change them."
+
+	| refactoring oldSelector newSelector |
+	oldSelector := ('called:' , 'on1:') asSymbol.
+	newSelector := 'inlineFoo:' asSymbol.
+	refactoring := RBDeprecateMethodRefactoring
+		               model: model
+		               deprecateMethod: oldSelector
+		               in: RBClassDataForRefactoringTest
+		               using: newSelector.
+
+	self
+		should: [ refactoring generateChanges ]
+		raise: RBRefactoringWarning 
+]
+
+{ #category : #'failure tests' }
+RBDeprecateMethodRefactoringTest >> testShouldWarnWhenNewSelectorIsNotDefinedInClass [
+	"please note that this strange way to create symbol is because some tests are counting symbol
+	and rewriting the code in a bad way so for now do not change them."
+
+	| refactoring oldSelector newSelector |
+	oldSelector := ('called:' , 'on1:') asSymbol.
+	newSelector := 'inlineFoo1:' asSymbol.
+	refactoring := RBDeprecateMethodRefactoring
+		               model: model
+		               deprecateMethod: oldSelector
+		               in: RBClassDataForRefactoringTest
+		               using: newSelector.
+
+	self
+		should: [ refactoring generateChanges ]
+		raise: RBRefactoringWarning 
+]

--- a/src/Refactoring2-Transformations-Tests/RBExtractMethodTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBExtractMethodTransformationTest.class.st
@@ -20,7 +20,7 @@ RBExtractMethodTransformationTest >> testExtractUsingExistingMethodRefactoring [
 		                  from: #checkMethod:
 		                  to: #bar
 		                  in: #RBTransformationRuleTestData.
-	transformation primitiveExecute.
+	transformation generateChanges.
 	self assert: transformation model changes changes size equals: 1.
 
 	class := transformation model classNamed:
@@ -106,7 +106,7 @@ RBExtractMethodTransformationTest >> testNeedsReturn [
 						rules size == 1 ifTrue: [^rules first viewResults]'
 		                from: #openEditor
 		                to: #foo:
-		                in: #RBDummyLintRuleTest) primitiveExecute.
+		                in: #RBDummyLintRuleTest) generateChanges.
 
 	self assert: refactoring model changes changes size equals: 2.
 
@@ -138,7 +138,7 @@ RBExtractMethodTransformationTest >> testRefactoring [
 		                   from: #checkMethod:
 		                   to: #foo:
 		                   in: #RBTransformationRuleTestData)
-		                  primitiveExecute.
+		                  generateChanges.
 
 	self assert: transformation model changes changes size equals: 2.
 
@@ -172,7 +172,7 @@ RBExtractMethodTransformationTest >> testTransform [
 									Transcript show: temp printString; cr.
 									^temp * temp'
 		                   in: self changeMockClass name
-		                   withProtocol: #accessing ) primitiveExecute.
+		                   withProtocol: #accessing ) generateChanges.
 
 	transformation := (RBExtractMethodTransformation
 		                   model: transformation model
@@ -181,7 +181,7 @@ RBExtractMethodTransformationTest >> testTransform [
 							Transcript show: temp printString; cr'
 		                   from: #foo
 		                   to: #foobar
-		                   in: self changeMockClass name) primitiveExecute.
+		                   in: self changeMockClass name) generateChanges.
 
 	self assert: transformation model changes changes size equals: 4.
 
@@ -213,7 +213,7 @@ RBExtractMethodTransformationTest >> testWithArgument [
 				                 in: RBTransformationRuleTestData)
 		                from: #checkMethod:
 		                to: #foo:
-		                in: #RBTransformationRuleTestData) primitiveExecute.
+		                in: #RBTransformationRuleTestData) generateChanges.
 
 	self assert: refactoring model changes changes size equals: 2.
 
@@ -249,7 +249,7 @@ RBExtractMethodTransformationTest >> testWithTemporariesSelected [
 		                extract: '| temp | temp := 5. temp * temp'
 		                from: #foo
 		                to: #foobar
-		                in: class) primitiveExecute.
+		                in: class) generateChanges.
 
 	self assert: refactoring model changes changes size equals: 4.
 	self
@@ -279,7 +279,7 @@ RBExtractMethodTransformationTest >> testWithTemporaryAssigned [
 		                extract: (method copyFrom: 24 to: 98)
 		                from: #foo
 		                to: #foobar
-		                in: class) primitiveExecute.
+		                in: class) generateChanges.
 
 	self assert: refactoring model changes changes size equals: 4.
 	self
@@ -303,7 +303,7 @@ RBExtractMethodTransformationTest >> testWithTemporaryVariable [
 				                 in: RBTransformationRuleTestData)
 		                from: #superSends
 		                to: #foo1
-		                in: #RBTransformationRuleTestData) primitiveExecute.
+		                in: #RBTransformationRuleTestData) generateChanges.
 
 	self assert: refactoring model changes changes size equals: 2.
 
@@ -338,7 +338,7 @@ RBExtractMethodTransformationTest >> testWithTemporaryVariable2 [
 				                 in: RBDummyLintRuleTest)
 		                from: #displayName
 		                to: #foo:
-		                in: #RBDummyLintRuleTest) primitiveExecute.
+		                in: #RBDummyLintRuleTest) generateChanges.
 
 	self assert: refactoring model changes changes size equals: 2.
 

--- a/src/Refactoring2-Transformations-Tests/RBMethodProtocolTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMethodProtocolTransformationTest.class.st
@@ -31,7 +31,7 @@ RBMethodProtocolTransformationTest >> testRefactoring [
 	refactoring := (RBMethodProtocolTransformation
 		                protocol: 'empty protocol 2'
 		                inMethod: #someMethod
-		                inClass: #RBDummyEmptyClass) primitiveExecute.
+		                inClass: #RBDummyEmptyClass) generateChanges.
 	RBRefactoryChangeManager instance performChange: refactoring changes.
 
 	self deny:
@@ -40,7 +40,7 @@ RBMethodProtocolTransformationTest >> testRefactoring [
 	refactoring := (RBMethodProtocolTransformation
 		                protocol: 'empty protocol 1'
 		                inMethod: #someMethod
-		                inClass: #RBDummyEmptyClass) primitiveExecute.
+		                inClass: #RBDummyEmptyClass) generateChanges.
 	RBRefactoryChangeManager instance performChange: refactoring changes.
 
 	self deny: (RBDummyEmptyClass hasProtocol: 'empty protocol 2')
@@ -55,7 +55,7 @@ RBMethodProtocolTransformationTest >> testTransform [
 	transformation := (RBMethodProtocolTransformation new
 		                   protocol: 'empty protocol 2'
 		                   inMethod: #someMethod
-		                   inClass: #RBDummyEmptyClass) primitiveExecute.
+		                   inClass: #RBDummyEmptyClass) generateChanges.
 	RBRefactoryChangeManager instance performChange:
 		transformation changes.
 
@@ -65,7 +65,7 @@ RBMethodProtocolTransformationTest >> testTransform [
 	transformation := (RBMethodProtocolTransformation new
 		                   protocol: 'empty protocol 1'
 		                   inMethod: #someMethod
-		                   inClass: #RBDummyEmptyClass) primitiveExecute.
+		                   inClass: #RBDummyEmptyClass) generateChanges.
 	RBRefactoryChangeManager instance performChange:
 		transformation changes.
 	self deny: (RBDummyEmptyClass hasProtocol: 'empty protocol 2')

--- a/src/Refactoring2-Transformations-Tests/RBMoveClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveClassTransformationTest.class.st
@@ -16,7 +16,7 @@ RBMoveClassTransformationTest >> testRefactoring [
 	| transformation class |
 	self assert: self class category equals: #'Refactoring2-Transformations-Tests-Test'.
 
-	transformation := (RBMoveClassTransformation move: self class name toPackage: #'Refactoring2-Transformations' inTag: #Utilities) primitiveExecute.
+	transformation := (RBMoveClassTransformation move: self class name toPackage: #'Refactoring2-Transformations' inTag: #Utilities) generateChanges.
 
 	self assert: transformation model changes changes size equals: 1.
 
@@ -30,7 +30,7 @@ RBMoveClassTransformationTest >> testTransform [
 	| transformation class |
 	self assert: self changeMockClass category equals: #'Refactoring-Tests-Changes'.
 
-	transformation := (RBMoveClassTransformation move: self changeMockClass name toPackage: #'Refactoring2-Transformations-Tests' inTag: 'Test') primitiveExecute.
+	transformation := (RBMoveClassTransformation move: self changeMockClass name toPackage: #'Refactoring2-Transformations-Tests' inTag: 'Test') generateChanges.
 
 	self assert: transformation model changes changes size equals: 1.
 

--- a/src/Refactoring2-Transformations-Tests/RBMoveInstanceVariableToClassParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveInstanceVariableToClassParametrizedTest.class.st
@@ -49,7 +49,7 @@ RBMoveInstanceVariableToClassParametrizedTest >> testRefactoring [
 		(oldClass directlyDefinesInstanceVariable: 'methodBlock').
 	self deny: (newClass directlyDefinesInstanceVariable: 'methodBlock').
 
-	refactoring primitiveExecute.
+	refactoring generateChanges.
 	self assert: refactoring model changes changes size equals: 2.
 	oldClass := refactoring model classNamed: #RBBasicLintRuleTestData.
 	newClass := refactoring model classNamed: #RBFooLintRuleTestData.

--- a/src/Refactoring2-Transformations-Tests/RBMoveMethodToClassSideParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveMethodToClassSideParametrizedTest.class.st
@@ -35,23 +35,6 @@ RBMoveMethodToClassSideParametrizedTest >> testFailureClassIsNotMeta [
 	self shouldFail: refactoring
 ]
 
-{ #category : #'failure tests' }
-RBMoveMethodToClassSideParametrizedTest >> testFailureExistsMethodInClassSide [
-
-	| method someClass className refactoring |
-	className := RBClassDataForRefactoringTest.
-	method := className >> ('threeElement' , 'Point') asSymbol.
-	refactoring := self createRefactoringWithArguments: {
-			               method.
-			               className }.
-	model := refactoring model.
-	someClass := model classNamed: className name , ' class'.
-	someClass
-		compile: 'threeElementPoint ^ self new'
-		classified: { #example }.
-	self shouldFail: refactoring
-]
-
 { #category : #tests }
 RBMoveMethodToClassSideParametrizedTest >> testMoveMethodToClassSide [
 	| method someClass className refactoring |

--- a/src/Refactoring2-Transformations-Tests/RBMoveMethodToClassSideRefactoringTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveMethodToClassSideRefactoringTest.class.st
@@ -1,0 +1,24 @@
+Class {
+	#name : #RBMoveMethodToClassSideRefactoringTest,
+	#superclass : #RBAbstractTransformationTest,
+	#category : #'Refactoring2-Transformations-Tests-Test'
+}
+
+{ #category : #'failure tests' }
+RBMoveMethodToClassSideRefactoringTest >> testFailureExistsMethodInClassSide [
+
+	| method someClass className refactoring |
+	className := RBClassDataForRefactoringTest.
+	method := className >> ('threeElement' , 'Point') asSymbol.
+	refactoring := RBMoveMethodToClassSideRefactoring
+		               method: method
+		               class: className.
+	model := refactoring model.
+	someClass := model classNamed: className name , ' class'.
+	someClass
+		compile: 'threeElementPoint ^ self new'
+		classified: { #example }.
+	self
+		should: [ refactoring generateChanges ]
+		raise: RBBreakingChangeChecksFailedWarning
+]

--- a/src/Refactoring2-Transformations-Tests/RBMoveTemporaryVariableDefinitionTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveTemporaryVariableDefinitionTransformationTest.class.st
@@ -21,7 +21,7 @@ RBMoveTemporaryVariableDefinitionTransformationTest >> testMoveDefinition [
 		                   variable: #temp
 		                   inMethod: #moveDefinition
 		                   inClass: #RBClassDataForRefactoringTest)
-		                  primitiveExecute.
+		                  generateChanges.
 
 	class := transformation model classNamed:
 		         #RBClassDataForRefactoringTest.
@@ -48,7 +48,7 @@ RBMoveTemporaryVariableDefinitionTransformationTest >> testMoveDefinitionIntoBlo
 		                   variable: #association
 		                   inMethod: #referencesConditionFor:
 		                   inClass: #RBClassDataForRefactoringTest)
-		                  primitiveExecute.
+		                  generateChanges.
 
 	class := transformation model classNamed:
 		         #RBClassDataForRefactoringTest.

--- a/src/Refactoring2-Transformations-Tests/RBProtectVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBProtectVariableTransformationTest.class.st
@@ -18,7 +18,7 @@ RBProtectVariableTransformationTest >> testAccessorsAlreadyExist [
 	(RBProtectVariableTransformation
 		 model: model
 		 instanceVariable: 'instVarName1'
-		 class: #Foo) primitiveExecute.
+		 class: #Foo) generateChanges.
 
 	class := model classNamed: #Foo.
 	self
@@ -47,7 +47,7 @@ RBProtectVariableTransformationTest >> testClassVariable [
 	refactoring := (RBProtectVariableTransformation
 		                classVariable: 'RecursiveSelfRule'
 		                class: #RBTransformationRuleTestData)
-		               primitiveExecute.
+		               generateChanges.
 
 	class := (refactoring model classNamed: #RBTransformationRuleTestData)
 		         classSide.
@@ -90,7 +90,7 @@ RBProtectVariableTransformationTest >> testClassVariableInModel [
 	(RBProtectVariableTransformation
 		 model: model
 		 classVariable: 'ClassVarName1'
-		 class: #Foo) primitiveExecute.
+		 class: #Foo) generateChanges.
 
 	class := (model classNamed: #Foo) classSide.
 	self
@@ -138,7 +138,7 @@ RBProtectVariableTransformationTest >> testMetaclass [
 	(RBProtectVariableTransformation
 		 model: model
 		 instanceVariable: 'foo'
-		 class: class) primitiveExecute.
+		 class: class) generateChanges.
 
 	self
 		assert: (class parseTreeForSelector: #foo1)
@@ -168,7 +168,7 @@ RBProtectVariableTransformationTest >> testRefactoring [
 	refactoring := (RBProtectVariableTransformation
 		                instanceVariable: 'builder'
 		                class: #RBTransformationRuleTestData)
-		               primitiveExecute.
+		               generateChanges.
 
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
 	self
@@ -204,7 +204,7 @@ RBProtectVariableTransformationTest >> testTransform [
 	transformation := (RBProtectVariableTransformation
 		                   instanceVariable: 'class'
 		                   class: #RBTransformationRuleTestData)
-		                  primitiveExecute.
+		                  generateChanges.
 
 	class := transformation model classNamed:
 		         #RBTransformationRuleTestData.
@@ -262,7 +262,7 @@ RBProtectVariableTransformationTest >> testVariableIsNotAccessed [
 	self deny: (class directlyDefinesLocalMethod: #instVar).
 	self deny: (class directlyDefinesLocalMethod: #instVar:).
 
-	transformation primitiveExecute.
+	transformation generateChanges.
 	self assert: transformation model changes changes size equals: 3.
 	"the accessors and the method using the variables"
 	self assert: (class directlyDefinesLocalMethod: #instVar).
@@ -292,7 +292,7 @@ RBProtectVariableTransformationTest >> testWithAssignment [
 	refactoring := (RBProtectVariableTransformation
 		                model: model
 		                instanceVariable: 'instVarName2'
-		                class: #Foo) primitiveExecute.
+		                class: #Foo) generateChanges.
 
 	class := model classNamed: #Foo.
 	self

--- a/src/Refactoring2-Transformations-Tests/RBPushDownMethodRefactoringTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBPushDownMethodRefactoringTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #RBPushDownMethodRefactoringTest,
 	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#category : #'Refactoring2-Transformations-Tests-Test'
 }
 
 { #category : #'failure tests' }
@@ -11,15 +11,10 @@ RBPushDownMethodRefactoringTest >> testFailurePushDownMethodOnNonAbstractClass [
 	refactoring := RBPushDownMethodRefactoring
 		               pushDown: #( #isArray )
 		               from: Array.
-	"Scripting API"
-	self shouldFail: refactoring.
-	
-	"Driver API"
-	self proceedThroughWarning: [
-		self
-			should: [ refactoring generateChanges ]
-			raise: RBBreakingChangeChecksFailedWarning
-	]
+
+	self
+		should: [ refactoring generateChanges ]
+		raise: RBRefactoringWarning
 ]
 
 { #category : #'failure tests' }
@@ -43,13 +38,9 @@ RBPushDownMethodRefactoringTest >> testFailurePushDownMethodSubclassesReferToSel
 		               model: model
 		               pushDown: #( #yourself )
 		               from: (model classNamed: #Superclass).
-	"Scripting API"
-	self shouldFail: refactoring.
-	
-	"Driver API"
-	self proceedThroughWarning: [
-		self
-			should: [ refactoring generateChanges ]
-			raise: RBBreakingChangeChecksFailedWarning
-	]
+
+
+	self
+		should: [ refactoring generateChanges ]
+		raise: RBRefactoringWarning 
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveAllMessageSendsTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveAllMessageSendsTransformationTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #RBRemoveAllMessageSendsTransformationTest,
 	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#category : #'Refactoring2-Transformations-Tests-Test'
 }
 
 { #category : #'failure tests' }
@@ -12,7 +12,7 @@ RBRemoveAllMessageSendsTransformationTest >> testClassDoesNotExist [
 				messageSend: #foo:
 				inMethod: #badMessage1
 				inClass: #ADoesNotExistClass).
-	self should: [ trans primitiveExecute ] raise: trans refactoringErrorClass.
+	self should: [ trans generateChanges ] raise: trans refactoringErrorClass.
 ]
 
 { #category : #'failure tests' }
@@ -23,7 +23,7 @@ RBRemoveAllMessageSendsTransformationTest >> testFailureNonExistantSelector [
 				messageSend: #foo:
 				inMethod: #checkClass1:
 				inClass: #RBClassDataForRefactoringTest).
-	self should: [ trans primitiveExecute ] raise: trans refactoringErrorClass.
+	self should: [ trans generateChanges ] raise: trans refactoringErrorClass.
 ]
 
 { #category : #'failure tests' }
@@ -34,7 +34,7 @@ RBRemoveAllMessageSendsTransformationTest >> testMethodDoesNotExist [
 				messageSend: #foo:
 				inMethod: #badMessage1
 				inClass: #RBClassDataForRefactoringTest).
-	self should: [ trans primitiveExecute ] raise: trans refactoringErrorClass.
+	self should: [ trans generateChanges ] raise: trans refactoringErrorClass.
 ]
 
 { #category : #tests }
@@ -45,7 +45,7 @@ RBRemoveAllMessageSendsTransformationTest >> testRemoveMessageInsideBlock [
 				messageSend: #printString
 				inMethod: #caller1
 				inClass: #RBClassDataForRefactoringTest).
-	trans primitiveExecute.
+	trans generateChanges.
 
 	self assert: ((trans model classNamed: #RBClassDataForRefactoringTest) parseTreeForSelector: #caller1) equals: (self parseMethod: 'caller1
 	| anObject |
@@ -75,7 +75,7 @@ RBRemoveAllMessageSendsTransformationTest >> testRemoveSenderIntoCascaded2Messag
 				messageSend: #inlineMethod
 				inMethod: #inlineMethod
 				inClass: #RBClassDataForRefactoringTest).
-	trans primitiveExecute.
+	trans generateChanges.
 	transformedMethod := ((trans model classNamed: #RBClassDataForRefactoringTest) parseTreeForSelector: #inlineMethod).
 	self assert: (transformedMethod = afterRefactoring1 or: [ transformedMethod = afterRefactoring2])
 ]
@@ -117,7 +117,7 @@ RBRemoveAllMessageSendsTransformationTest >> testRemoveSenderIntoCascaded3Messag
 				messageSend: #errorBlock:
 				inMethod: #referencesConditionFor:
 				inClass: #RBClassDataForRefactoringTest).
-	trans primitiveExecute.
+	trans generateChanges.
 	transformedMethod := ((trans model classNamed: #RBClassDataForRefactoringTest) parseTreeForSelector: #referencesConditionFor:).
 	self assert: (transformedMethod = afterRefactoring1 or: [ transformedMethod = afterRefactoring2])
 ]
@@ -130,7 +130,7 @@ RBRemoveAllMessageSendsTransformationTest >> testRemoveSenderIntoCascadedMessage
 				messageSend: #cr
 				inMethod: (#called:, #on:) asSymbol
 				inClass: #RBClassDataForRefactoringTest).
-	trans primitiveExecute.
+	trans generateChanges.
 
 	self assert: ((trans model classNamed: #RBClassDataForRefactoringTest) parseTreeForSelector: (#called:, #on:) asSymbol)
 		equals: (self parseMethod: 'called: anObject on: aBlock
@@ -154,7 +154,7 @@ RBRemoveAllMessageSendsTransformationTest >> testRemoveSimpleSenderOfMessage [
 				messageSend: #called:on1:
 				inMethod: #caller1
 				inClass: #RBClassDataForRefactoringTest).
-	trans primitiveExecute.
+	trans generateChanges.
 	transformedMethod := ((trans model classNamed: #RBClassDataForRefactoringTest) parseTreeForSelector: #caller1).
 	self assert: (transformedMethod = afterRefactoring1 or: [ transformedMethod = afterRefactoring2])
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveAssignmentTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveAssignmentTransformationTest.class.st
@@ -27,7 +27,7 @@ RBRemoveAssignmentTransformationTest >> testAssignmentDoesNotExist [
 		                variable: 'variable2'
 		                inMethod: #methodBefore
 		                inClass: #RBRemoveAssignmentTransformationTest)
-		               primitiveExecute.
+		               generateChanges.
 
 	self shouldFail: (RBRemoveAssignmentTransformation
 			 model: refactoring model
@@ -66,7 +66,7 @@ RBRemoveAssignmentTransformationTest >> testRefactoring [
 		                value: '1 asString'
 		                inMethod: #methodBefore
 		                inClass: #RBRemoveAssignmentTransformationTest)
-		               primitiveExecute.
+		               generateChanges.
 
 	self assert: refactoring model changes changes size equals: 1.
 
@@ -85,7 +85,7 @@ RBRemoveAssignmentTransformationTest >> testTransform [
 		                   variable: 'variable'
 		                   value: '1 asString'
 		                   inMethod: #methodBefore
-		                   inClass: self class name) primitiveExecute.
+		                   inClass: self class name) generateChanges.
 
 	self assert: transformation model changes changes size equals: 1.
 

--- a/src/Refactoring2-Transformations-Tests/RBRemoveClassKeepingSubclassesParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveClassKeepingSubclassesParametrizedTest.class.st
@@ -16,13 +16,6 @@ RBRemoveClassKeepingSubclassesParametrizedTest >> constructor [
 	^ #classNames:
 ]
 
-{ #category : #'failure tests' }
-RBRemoveClassKeepingSubclassesParametrizedTest >> testFailureRemoveClassWithReferencesRaisesRBRefactoringError [
-
-	self shouldFail: (self createRefactoringWithArguments:
-			 { #( #RBBasicLintRuleTestData ) })
-]
-
 { #category : #tests }
 RBRemoveClassKeepingSubclassesParametrizedTest >> testRemoveNotEmptySuperclass [
 
@@ -40,4 +33,11 @@ RBRemoveClassKeepingSubclassesParametrizedTest >> testRemoveNotEmptySuperclass [
 	self assert: class superclass
 		equals: (refactoring model classNamed: #RBFooLintRuleTestData1).
 	self assert: (class directlyDefinesMethod: #foo)
+]
+
+{ #category : #'failure tests' }
+RBRemoveClassKeepingSubclassesParametrizedTest >> testShouldWarnWhenRemovingClassWithReferences [
+
+	self shouldWarn: (self createRefactoringWithArguments:
+			 { #( #RBBasicLintRuleTestData ) })
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveClassParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveClassParametrizedTest.class.st
@@ -35,14 +35,6 @@ RBRemoveClassParametrizedTest >> testFailureRemoveClassWithBadNameRaisesRBRefact
 ]
 
 { #category : #'failure tests' }
-RBRemoveClassParametrizedTest >> testFailureRemoveClassWithReferencesRaisesRBRefactoringError [
-
-	self shouldWarn: (self
-			 createRefactoringWithModel: model
-			 andArguments: #( #RBBasicLintRuleTestData ))
-]
-
-{ #category : #'failure tests' }
 RBRemoveClassParametrizedTest >> testFailureRemoveClassWithSubclasses [
 
 	self shouldFail:
@@ -88,4 +80,12 @@ RBRemoveClassParametrizedTest >> testRemoveEmptySuperclass [
 
 	self assert: (model classNamed: classA) isNil.
 	self assert: (model classNamed: classB) superclass equals: (model classNamed: classC)
+]
+
+{ #category : #'failure tests' }
+RBRemoveClassParametrizedTest >> testShouldWarnWhenRemovingClassWithReferences [
+
+	self shouldWarn: (self
+			 createRefactoringWithModel: model
+			 andArguments: #( #RBBasicLintRuleTestData ))
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveClassTransformationTest.class.st
@@ -17,7 +17,7 @@ RBRemoveClassTransformationTest >> testRefactoring [
 		               #RBFooDummyLintRuleTest1.
 
 	self
-		should: [ refactoring primitiveExecute ]
+		should: [ refactoring generateChanges ]
 		raise: RBRefactoringError.
 
 	self assert:

--- a/src/Refactoring2-Transformations-Tests/RBRemoveClassVariableRefactoringTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveClassVariableRefactoringTest.class.st
@@ -5,7 +5,7 @@ Class {
 }
 
 { #category : #'failure tests' }
-RBRemoveClassVariableRefactoringTest >> testFailureReferencedVariable [
+RBRemoveClassVariableRefactoringTest >> testShouldWarnWhenVariableReferenced [
 
 	self shouldWarn: (RBRemoveClassVariableRefactoring
 			 variable: #RecursiveSelfRule

--- a/src/Refactoring2-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
@@ -17,7 +17,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testClassVariable [
 	| refactoring class |
 	refactoring := (RBRemoveDirectAccessToVariableTransformation
 		                classVariable: 'UndoSize'
-		                class: #RBRefactoryChangeManager) primitiveExecute.
+		                class: #RBRefactoryChangeManager) generateChanges.
 
 	self assert: refactoring model changes changes size equals: 2.
 
@@ -69,7 +69,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testInstanceVariable [
 	(RBRemoveDirectAccessToVariableTransformation
 		 model: model
 		 instanceVariable: 'instVarName2'
-		 class: #Foo) primitiveExecute.
+		 class: #Foo) generateChanges.
 
 	class := model classNamed: #Foo.
 	self
@@ -83,7 +83,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testRefactoring [
 	| refactoring class |
 	refactoring := (RBRemoveDirectAccessToVariableTransformation
 		                instanceVariable: 'environment'
-		                class: #RBNamespace) primitiveExecute.
+		                class: #RBNamespace) generateChanges.
 
 	self assert: refactoring model changes changes size equals: 4.
 
@@ -117,7 +117,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testTransform [
 	transformation := (RBRemoveDirectAccessToVariableTransformation
 		                   instanceVariable: 'class'
 		                   class: #RBTransformationRuleTestData)
-		                  primitiveExecute.
+		                  generateChanges.
 
 	class := transformation model classNamed:
 		         #RBTransformationRuleTestData.

--- a/src/Refactoring2-Transformations-Tests/RBRemoveInstanceVariable2ParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveInstanceVariable2ParametrizedTest.class.st
@@ -20,12 +20,6 @@ RBRemoveInstanceVariable2ParametrizedTest >> testFailureNonExistantName [
 			 { 'name1'. #RBLintRuleTestData })
 ]
 
-{ #category : #'failure tests' }
-RBRemoveInstanceVariable2ParametrizedTest >> testFailureReferencedVariable [
-
-	self shouldFail: (self createRefactoringWithArguments:  { 'name'. #RBLintRuleTestData })
-]
-
 { #category : #tests }
 RBRemoveInstanceVariable2ParametrizedTest >> testRemoveLocallyDefinedInstanceVariable [
 
@@ -69,6 +63,12 @@ RBRemoveInstanceVariable2ParametrizedTest >> testRemoveNonLocalInstanceVariableP
 	self deny: (subsubclass directlyDefinesInstanceVariable: #foo1).
 	self assert: (subsubclass definesInstanceVariable: #foo1).
 	self assert: (subclass definesInstanceVariable: #foo1)
+]
+
+{ #category : #'failure tests' }
+RBRemoveInstanceVariable2ParametrizedTest >> testShouldWarnWhenVariableReferenced [
+
+	self shouldWarn: (self createRefactoringWithArguments:  { 'name'. #RBLintRuleTestData })
 ]
 
 { #category : #tests }

--- a/src/Refactoring2-Transformations-Tests/RBRemovePragmaTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemovePragmaTransformationTest.class.st
@@ -56,7 +56,7 @@ RBRemovePragmaTransformationTest >> testRefactoring [
 		                pragma: '<pragmaForTesting: 34>'
 		                inMethod: #methodBefore
 		                inClass: #RBRemovePragmaTransformationTest)
-		               primitiveExecute.
+		               generateChanges.
 
 	self assert: refactoring model changes changes size equals: 1.
 
@@ -74,7 +74,7 @@ RBRemovePragmaTransformationTest >> testTransform [
 	transformation := (RBRemovePragmaTransformation new
 		                   pragma: '<pragmaForTesting: 34>'
 		                   inMethod: #methodBefore
-		                   inClass: self class name) primitiveExecute.
+		                   inClass: self class name) generateChanges.
 
 	self assert: transformation model changes changes size equals: 1.
 

--- a/src/Refactoring2-Transformations-Tests/RBRemoveProtocolTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveProtocolTransformationTest.class.st
@@ -10,12 +10,12 @@ RBRemoveProtocolTransformationTest >> testRefactoring [
 	| refactoring |
 	refactoring := (RBAddProtocolTransformation
 		                protocol: 'transforming'
-		                inClass: #RBDummyEmptyClass) primitiveExecute.
+		                inClass: #RBDummyEmptyClass) generateChanges.
 	RBRefactoryChangeManager instance performChange: refactoring changes.
 
 	refactoring := (RBRemoveProtocolTransformation
 		                protocol: 'transforming'
-		                inClass: #RBDummyEmptyClass) primitiveExecute.
+		                inClass: #RBDummyEmptyClass) generateChanges.
 
 	self assert: refactoring model changes changes size equals: 1
 ]
@@ -26,12 +26,12 @@ RBRemoveProtocolTransformationTest >> testTransform [
 	| transformation |
 	transformation := (RBAddProtocolTransformation
 		                   protocol: 'transforming'
-		                   inClass: #RBDummyEmptyClass) primitiveExecute.
+		                   inClass: #RBDummyEmptyClass) generateChanges.
 
 	transformation := (RBRemoveProtocolTransformation
 		                   model: transformation model
 		                   protocol: 'transforming'
-		                   inClass: #RBDummyEmptyClass) primitiveExecute.
+		                   inClass: #RBDummyEmptyClass) generateChanges.
 
 	self assert: transformation model changes changes size equals: 2
 ]

--- a/src/Refactoring2-Transformations-Tests/RBRemoveReturnStatementTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveReturnStatementTransformationTest.class.st
@@ -45,7 +45,7 @@ RBRemoveReturnStatementTransformationTest >> testRefactoring [
 		                return: '^ variable'
 		                inMethod: #methodBefore
 		                inClass: #RBRemoveReturnStatementTransformationTest)
-		               primitiveExecute.
+		               generateChanges.
 
 	self assert: refactoring model changes changes size equals: 1.
 
@@ -72,7 +72,7 @@ RBRemoveReturnStatementTransformationTest >> testTransform [
 	transformation := (RBRemoveReturnStatementTransformation new
 		                   return: '^ variable'
 		                   inMethod: #methodBefore
-		                   inClass: self class name) primitiveExecute.
+		                   inClass: self class name) generateChanges.
 
 	self assert: transformation model changes changes size equals: 1.
 

--- a/src/Refactoring2-Transformations-Tests/RBRemoveSubtreeTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveSubtreeTransformationTest.class.st
@@ -54,7 +54,7 @@ RBRemoveSubtreeTransformationTest >> testRefactoring [
 		                   code: 'selector := aSelector'
 		                   from: #selector:from:
 		                   in: #RBRemoveMethodTransformation)
-		                  primitiveExecute.
+		                  generateChanges.
 
 	self assert: transformation model changes changes size equals: 1.
 
@@ -74,7 +74,7 @@ RBRemoveSubtreeTransformationTest >> testTransform [
 	transformation := (RBRemoveSubtreeTransformation
 		                   code: '^ 1'
 		                   from: #one
-		                   in: self changeMockClass name) primitiveExecute.
+		                   in: self changeMockClass name) generateChanges.
 
 	self assert: transformation model changes changes size equals: 1.
 
@@ -98,7 +98,7 @@ RBRemoveSubtreeTransformationTest >> testTransformNotSequenceNode [
 					                    code: 'super printString'
 					                    from: #printString1
 					                    in: self changeMockClass name)).
-	transformation primitiveExecute.
+	transformation generateChanges.
 
 	self assert: transformation model changes changes size equals: 2.
 

--- a/src/Refactoring2-Transformations-Tests/RBRemoveTemporaryVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveTemporaryVariableTransformationTest.class.st
@@ -34,7 +34,7 @@ RBRemoveTemporaryVariableTransformationTest >> testRefactoring [
 										Transcript show: temp printString; cr.
 										^temp * temp'
 		                in: #RBRemoveTemporaryVariableTransformationTest
-		                withProtocol: #accessing ) primitiveExecute.
+		                withProtocol: #accessing ) generateChanges.
 
 	refactoring := (RBRemoveTemporaryVariableTransformation
 		                model: refactoring model
@@ -42,7 +42,7 @@ RBRemoveTemporaryVariableTransformationTest >> testRefactoring [
 		                inMethod: #foo
 		                inClass:
 		                #RBRemoveTemporaryVariableTransformationTest)
-		               primitiveExecute.
+		               generateChanges.
 
 	self assert: refactoring model changes changes size equals: 2.
 
@@ -66,14 +66,14 @@ RBRemoveTemporaryVariableTransformationTest >> testTransform [
 									Transcript show: temp printString; cr.
 									^temp * temp'
 		                   in: self changeMockClass name
-		                   withProtocol: #accessing ) primitiveExecute.
+		                   withProtocol: #accessing ) generateChanges.
 
 	transformation := (RBRemoveTemporaryVariableTransformation
 		                   model: transformation model
 		                   variable: 'temp'
 		                   inMethod: #foo
 		                   inClass: self changeMockClass name)
-		                  primitiveExecute.
+		                  generateChanges.
 
 	self assert: transformation model changes changes size equals: 2.
 

--- a/src/Refactoring2-Transformations-Tests/RBRenameAndDeprecateClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameAndDeprecateClassTransformationTest.class.st
@@ -10,7 +10,7 @@ RBRenameAndDeprecateClassTransformationTest >> testTransform [
 	| transformation class |
 	transformation := (RBRenameAndDeprecateClassTransformation
 		                   rename: self changeMockClass name
-		                   to: #RBRefactoringChangeMock2) primitiveExecute.
+		                   to: #RBRefactoringChangeMock2) generateChanges.
 
 	self assert: transformation model changes changes size equals: 10.
 

--- a/src/Refactoring2-Transformations-Tests/RBRenameMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameMethodParametrizedTest.class.st
@@ -18,12 +18,6 @@ RBRenameMethodParametrizedTest >> constructor [
 ]
 
 { #category : #'failure tests' }
-RBRenameMethodParametrizedTest >> testFailureExistingSelector [
-	self shouldFail: (self createRefactoringWithArguments:
-		{ #checkClass: . RBBasicLintRuleTestData . #runOnEnvironment: . (1 to: 1) })
-]
-
-{ #category : #'failure tests' }
 RBRenameMethodParametrizedTest >> testFailureWithNonCorrectNumberOfArgs [
 	self shouldFail: (self createRefactoringWithArguments:
 		{ #checkClass: . RBBasicLintRuleTestData . #checkClass . (1 to: 1) })
@@ -75,7 +69,7 @@ RBRenameMethodParametrizedTest >> testRenameMethodPermuteArgs [
 	refactoring := self createRefactoringWithArguments:
 		{ ('demoRenameMethod:' , 'PermuteArgs:') asSymbol . RBClassDataForRefactoringTest .
 		('demoRenameMethod:' , 'PermuteArgs:') asSymbol . #(2 1) }.
-	self executeRefactoring: refactoring.
+	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBClassDataForRefactoringTest.
 	self
 		assert:
@@ -99,7 +93,7 @@ RBRenameMethodParametrizedTest >> testRenamePermuteArgs [
 	refactoring := self createRefactoringWithArguments:
 		{ ('rename:' , 'two:') asSymbol . RBClassDataForRefactoringTest .
 		('rename:' , 'two:') asSymbol . #(2 1 ) }.
-	self executeRefactoring: refactoring.
+	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBClassDataForRefactoringTest.
 	
 	self 

--- a/src/Refactoring2-Transformations-Tests/RBRenameMethodRefactoringTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameMethodRefactoringTest.class.st
@@ -1,0 +1,16 @@
+Class {
+	#name : #RBRenameMethodRefactoringTest,
+	#superclass : #RBAbstractTransformationTest,
+	#category : #'Refactoring2-Transformations-Tests-Test'
+}
+
+{ #category : #'failure tests' }
+RBRenameMethodRefactoringTest >> testFailureExistingSelector [
+		
+	| refactoring |
+	refactoring := RBRenameMethodRefactoring renameMethod: #checkClass: in: RBBasicLintRuleTestData to: #runOnEnvironment: permutation: (1 to: 1).
+	
+	self
+		should: [ refactoring generateChanges ]
+		raise: RBBreakingChangeChecksFailedWarning 
+]

--- a/src/Refactoring2-Transformations-Tests/RBRenameTemporaryParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameTemporaryParametrizedTest.class.st
@@ -113,7 +113,7 @@ RBRenameTemporaryParametrizedTest >> testFailureModelExistingVariable [
 									Transcript show: temp printString; cr.
 									^temp * temp'
 		                   in: self class name
-		                   withProtocol: #accessing ) primitiveExecute.
+		                   withProtocol: #accessing ) generateChanges.
 
 	self shouldFail: (self
 			 createRefactoringWithModel: transformation model

--- a/src/Refactoring2-Transformations-Tests/RBReplaceSendersMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBReplaceSendersMethodParametrizedTest.class.st
@@ -58,7 +58,7 @@ RBReplaceSendersMethodParametrizedTest >> testModelReplaceMethodOnlyInClass [
 				to: newSelector
 				permutation: (1 to: 1)
 				inAllClasses: false.
-	self proceedThroughWarning: [ refactoring primitiveExecute ].
+	self proceedThroughWarning: [ refactoring generateChanges ].
 	self assert: sendersNewSelector + sendersLastSelector
 		equals: (model allReferencesTo: newSelector) size
 ]
@@ -79,7 +79,7 @@ RBReplaceSendersMethodParametrizedTest >> testModelReplaceMethodWithLessArgs [
 				to: newSelector
 				permutation: #(2)
 				inAllClasses: true.
-	self proceedThroughWarning: [ refactoring primitiveExecute ].
+	self proceedThroughWarning: [ refactoring generateChanges ].
 	self assert: sendersNewSelector + sendersLastSelector
 		equals: (model allReferencesTo: newSelector) size
 ]
@@ -101,7 +101,7 @@ RBReplaceSendersMethodParametrizedTest >> testModelReplaceMethodWithMoreArgs [
 				permutation: #(-1 2 1)
 				inAllClasses: true.
 	refactoring initializers: #('OrderedCollection new: 5').
-	self proceedThroughWarning: [ refactoring primitiveExecute ].
+	self proceedThroughWarning: [ refactoring generateChanges ].
 	self assert: sendersNewSelector + sendersLastSelector
 		equals: (model allReferencesTo: newSelector) size
 ]
@@ -122,7 +122,7 @@ RBReplaceSendersMethodParametrizedTest >> testModelReplaceMethodWithSameArgs [
 				to: newSelector
 				permutation: #(2 1)
 				inAllClasses: true.
-	self proceedThroughWarning: [ refactoring primitiveExecute ].
+	self proceedThroughWarning: [ refactoring generateChanges ].
 	self assert: sendersNewSelector + sendersLastSelector
 		equals: (model allReferencesTo: newSelector) size
 ]
@@ -140,7 +140,7 @@ RBReplaceSendersMethodParametrizedTest >> testReplaceMethodInAllClasses [
 				inAllClasses: true.
 	sendersNewSelector := (refactoring model allReferencesTo: newSelector) size.
 	sendersLastSelector := (refactoring model allReferencesTo: selector) size.
-	self proceedThroughWarning: [ refactoring primitiveExecute ].
+	self proceedThroughWarning: [ refactoring generateChanges ].
 	self assert: sendersNewSelector + sendersLastSelector
 		equals: (refactoring model allReferencesTo: newSelector) size
 ]
@@ -158,7 +158,7 @@ RBReplaceSendersMethodParametrizedTest >> testReplaceMethodOnlyInClass [
 				inAllClasses: false.
 	sendersNewSelector := (refactoring model allReferencesTo: newSelector) size.
 	sendersLastSelector := ((refactoring model allReferencesTo: selector) select: [ :e | e modelClass name = 'RBBasicLintRuleTestData' ]) size.
-	self proceedThroughWarning: [ refactoring primitiveExecute ].
+	self proceedThroughWarning: [ refactoring generateChanges ].
 	self assert: sendersNewSelector + sendersLastSelector
 		equals: (refactoring model allReferencesTo: newSelector) size
 ]

--- a/src/Refactoring2-Transformations-Tests/RBReplaceSubtreeTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBReplaceSubtreeTransformationTest.class.st
@@ -53,7 +53,7 @@ RBReplaceSubtreeTransformationTest >> testRefactoring [
 		                   to: '^ selector'
 		                   inMethod: #selector:from:
 		                   inClass: #RBRemoveMethodTransformation)
-		                  primitiveExecute.
+		                  generateChanges.
 
 	self assert: transformation model changes changes size equals: 1.
 
@@ -78,7 +78,7 @@ RBReplaceSubtreeTransformationTest >> testTransform [
 		                   to: '^ 123'
 		                   inMethod: #one
 		                   inClass: self changeMockClass name)
-		                  primitiveExecute.
+		                  generateChanges.
 
 	self assert: transformation model changes changes size equals: 1.
 
@@ -107,7 +107,7 @@ RBReplaceSubtreeTransformationTest >> testTransformOneOfManyStatements [
 		                   'self assert: (class parseTreeForSelector:  #selector:from:) body statements size = 2'
 		                   inMethod: #testRefactoring
 		                   inClass: #RBReplaceSubtreeTransformationTest)
-		                  primitiveExecute.
+		                  generateChanges.
 
 	self assert: transformation model changes changes size equals: 1.
 

--- a/src/Refactoring2-Transformations-Tests/RBSplitClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBSplitClassTransformationTest.class.st
@@ -35,7 +35,7 @@ RBSplitClassTransformationTest >> testTransform [
 		                   newClassName:
 		                   #RBRemoveDirectAccessWithReceiverTransformation
 		                   referenceVariableName: #newReceiver)
-		                  primitiveExecute.
+		                  generateChanges.
 
 	class := transformation model classNamed:
 		         #RBRemoveDirectAccessToVariableTransformation.

--- a/src/Refactoring2-Transformations-Tests/RBTransformationsTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBTransformationsTest.class.st
@@ -17,7 +17,7 @@ RBTransformationsTest >> testAddClassTransform [
 	| transformation class |
 	transformation := (RBAddClassCommentTransformation
 		                   comment: 'New comment for class'
-		                   in: self changeMockClass name) primitiveExecute.
+		                   in: self changeMockClass name) generateChanges.
 
 	self assert: transformation model changes changes size equals: 1.
 
@@ -33,7 +33,7 @@ RBTransformationsTest >> testAddMethodCommentTransform [
 		                   comment: 'New comment for method'
 		                   inMethod: #one
 		                   inClass: self changeMockClass name)
-		                  primitiveExecute.
+		                  generateChanges.
 
 	self assert: transformation model changes changes size equals: 1.
 
@@ -51,7 +51,7 @@ RBTransformationsTest >> testAddMethodTransform [
 	transformation := (RBAddMethodTransformation
 		                   sourceCode: 'printString1 ^super printString'
 		                   in: self changeMockClass name
-		                   withProtocol: #accessing ) primitiveExecute.
+		                   withProtocol: #accessing ) generateChanges.
 
 	class := transformation model classNamed: self changeMockClass name.
 	self
@@ -65,7 +65,7 @@ RBTransformationsTest >> testAddProtocolTransform [
 	| transformation |
 	transformation := (RBAddProtocolTransformation new
 		                   protocol: 'transforming'
-		                   inClass: #RBDummyEmptyClass) primitiveExecute.
+		                   inClass: #RBDummyEmptyClass) generateChanges.
 
 	self assert: transformation model changes changes size equals: 1
 ]
@@ -78,7 +78,7 @@ RBTransformationsTest >> testAddTemporaryVariableTransform [
 		                   variable: 'variable'
 		                   inMethod: #one
 		                   inClass: self changeMockClass name)
-		                  primitiveExecute.
+		                  generateChanges.
 
 	self assert: transformation model changes changes size equals: 1.
 
@@ -97,7 +97,7 @@ RBTransformationsTest >> testAddVariableAccessorTransform [
 	transformation := (RBAddVariableAccessorTransformation
 		                   instanceVariable: 'instVar'
 		                   class: self changeMockClass name)
-		                  primitiveExecute.
+		                  generateChanges.
 
 	self assert: transformation model changes changes size equals: 2.
 
@@ -118,7 +118,7 @@ RBTransformationsTest >> testAddVariableTransform [
 	transformation := (RBAddVariableTransformation
 		                   instanceVariable: 'asdf'
 		                   class: self changeMockClass name)
-		                  primitiveExecute.
+		                  generateChanges.
 
 	self assert: transformation model changes changes size equals: 1.
 
@@ -147,7 +147,7 @@ RBTransformationsTest >> testCompositeTransform [
 					                    in: newClassName
 					                    withProtocol: #accessing );
 			                   yourself).
-	transformation primitiveExecute.
+	transformation generateChanges.
 
 	self assert: transformation model changes changes size equals: 3.
 
@@ -178,7 +178,7 @@ RBTransformationsTest >> testCustomTransform [
 		                  (aModel classNamed: newClassName)
 			                  addInstanceVariable: 'asdf' ].
 
-	transformation primitiveExecute.
+	transformation generateChanges.
 	self assert: transformation model changes changes size equals: 3.
 
 	class := transformation model classNamed:
@@ -191,7 +191,7 @@ RBTransformationsTest >> testDeprecateClassTransform [
 
 	| transformation class |
 	transformation := (RBDeprecateClassTransformation class:
-		                   self changeMockClass name) primitiveExecute.
+		                   self changeMockClass name) generateChanges.
 
 	self assert: transformation model changes changes size equals: 4.
 
@@ -237,7 +237,7 @@ RBTransformationsTest >> testMoveInstanceVariableToClassTransform [
 	self assert: (oldClass directlyDefinesInstanceVariable: 'asdf').
 	self deny: (newClass directlyDefinesInstanceVariable: 'asdf').
 
-	transformation primitiveExecute.
+	transformation generateChanges.
 	self assert: transformation model changes changes size equals: 3.
 
 	oldClass := transformation model classNamed: #FOOBAR.
@@ -253,7 +253,7 @@ RBTransformationsTest >> testPullUpVariableTransform [
 	| transformation |
 	transformation := (RBPullUpVariableTransformation
 		                   instanceVariable: 'result'
-		                   class: #RBDummyLintRuleTest) primitiveExecute.
+		                   class: #RBDummyLintRuleTest) generateChanges.
 
 	self assert:
 		((transformation model classNamed: #RBDummyLintRuleTest)
@@ -273,7 +273,7 @@ RBTransformationsTest >> testPushDownVariableTransform [
 	| transformation |
 	transformation := (RBPushDownVariableTransformation
 		                   instanceVariable: 'foo1'
-		                   class: #RBDummyLintRuleTest) primitiveExecute.
+		                   class: #RBDummyLintRuleTest) generateChanges.
 
 	(transformation model classNamed: #RBDummyLintRuleTest) subclasses
 		do: [ :each |
@@ -285,7 +285,7 @@ RBTransformationsTest >> testRemoveClassTransform [
 
 	| transformation newClass superclass |
 	transformation := (RBRemoveClassTransformation className:
-		                   self changeMockClass name) primitiveExecute.
+		                   self changeMockClass name) generateChanges.
 	self assert: transformation model changes changes size equals: 1.
 	newClass := transformation model classNamed:
 		            self changeMockClass name asSymbol.
@@ -308,7 +308,7 @@ RBTransformationsTest >> testRemoveMessageSendTransform [
 		messageSend: #cr
 		inMethod: (#called:, #on:) asSymbol
 		inClass: #RBClassDataForRefactoringTest)
-		primitiveExecute.
+		generateChanges.
 
 	self assert: transformation model changes changes size equals: 1.
 
@@ -325,7 +325,7 @@ RBTransformationsTest >> testRemoveMethodTransform [
 	| transformation class |
 	transformation := (RBRemoveMethodTransformation
 		                   selector: #one
-		                   from: self changeMockClass name) primitiveExecute.
+		                   from: self changeMockClass name) generateChanges.
 
 	self assert: transformation model changes changes size equals: 1.
 
@@ -341,7 +341,7 @@ RBTransformationsTest >> testRemoveVariableTransform [
 	transformation := (RBRemoveVariableTransformation
 		                   instanceVariable: 'instVar'
 		                   class: self changeMockClass name)
-		                  primitiveExecute.
+		                  generateChanges.
 
 	self assert: transformation model changes changes size equals: 1.
 
@@ -358,7 +358,7 @@ RBTransformationsTest >> testRenameClassTransform [
 	oldClassName := RBClassToRename name asSymbol.
 	transformation := (RBRenameClassTransformation
 		                   rename: oldClassName
-		                   to: newClassName) primitiveExecute.
+		                   to: newClassName) generateChanges.
 
 	self assert: transformation model changes changes size equals: 10.
 
@@ -397,14 +397,14 @@ RBTransformationsTest >> testRenameTemporaryTransform [
 									Transcript show: temp printString; cr.
 									^temp * temp'
 		                   in: self changeMockClass name
-		                   withProtocol: #accessing ) primitiveExecute.
+		                   withProtocol: #accessing ) generateChanges.
 
 	transformation := (RBRenameTemporaryVariableTransformation
 		                   model: transformation model
 		                   rename: #temp
 		                   to: #temp2
 		                   in: self changeMockClass name
-		                   selector: #foo) primitiveExecute.
+		                   selector: #foo) generateChanges.
 
 	self assert: transformation model changes changes size equals: 2.
 
@@ -426,7 +426,7 @@ RBTransformationsTest >> testRenameVariableTransform [
 		                   rename: 'classBlock'
 		                   to: 'asdf'
 		                   in: #RBBasicLintRuleTestData
-		                   classVariable: false) primitiveExecute.
+		                   classVariable: false) generateChanges.
 
 	class := transformation model classNamed: #RBBasicLintRuleTestData.
 	self assert: (class directlyDefinesInstanceVariable: 'asdf').

--- a/src/Refactoring2-Transformations/RBAbstractVariablesTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBAbstractVariablesTransformation.class.st
@@ -47,7 +47,7 @@ RBAbstractVariablesTransformation >> abstractClassVariable: aString [
 		                   model: self model
 		                   variable: aString
 		                   class: nonMetaClass
-		                   classVariable: true) primitiveExecute.
+		                   classVariable: true) generateChanges.
 	rewriter := self parseTreeRewriter.
 	fromClass isMeta
 		ifTrue: [
@@ -87,7 +87,7 @@ RBAbstractVariablesTransformation >> abstractInstanceVariable: aString [
 		                   model: self model
 		                   variable: aString
 		                   class: fromClass
-		                   classVariable: false) primitiveExecute.
+		                   classVariable: false) generateChanges.
 	rewriter := self parseTreeRewriter.
 	rewriter
 		replace: aString , ' := ``@object'
@@ -123,7 +123,7 @@ RBAbstractVariablesTransformation >> abstractVariablesIn: aBRProgramNode from: f
 		                       model: self model
 		                       forMethod: tree
 		                       fromClass: fromClass
-		                       toClasses: toClasses) primitiveExecute.
+		                       toClasses: toClasses) generateChanges.
 	self computeVariablesToAbstract
 ]
 

--- a/src/Refactoring2-Transformations/RBCompositeTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBCompositeTransformation.class.st
@@ -46,7 +46,7 @@ RBCompositeTransformation >> previousTransformations [
 	^ previousTransformations ifNil: [ previousTransformations := OrderedCollection new ]
 ]
 
-{ #category : #executing }
+{ #category : #transforming }
 RBCompositeTransformation >> privateTransform [
 	"in refactoring mode, the transformation can do its own precondition checking,
 	 therefore not needing checking from its containing transformations"
@@ -59,7 +59,7 @@ RBCompositeTransformation >> privateTransform [
 		transformation
 			copyOptionsFrom: self options;
 			model: self model;
-			primitiveExecute ]
+			generateChanges ]
 ]
 
 { #category : #accessing }

--- a/src/Refactoring2-Transformations/RBMoveMethodToClassSideTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBMoveMethodToClassSideTransformation.class.st
@@ -123,7 +123,7 @@ RBMoveMethodToClassSideTransformation >> removeInstVariableReferences [
 	references do: [ :e |
 		| replacer accessorsRefactoring |
 		accessorsRefactoring := self accessorsFor: e.
-		accessorsRefactoring primitiveExecute.
+		accessorsRefactoring generateChanges.
 		replacer := self parseTreeRewriterClass
 			            variable: e
 			            getter: accessorsRefactoring getterMethod

--- a/src/Refactoring2-Transformations/RBMoveMethodTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBMoveMethodTransformation.class.st
@@ -68,7 +68,7 @@ RBMoveMethodTransformation class >> selector: aSymbol class: aClass variable: aV
 { #category : #transforming }
 RBMoveMethodTransformation >> abstractVariables [
 
-	self abstractVariablesRefactoring primitiveExecute.
+	self abstractVariablesRefactoring generateChanges.
 	parseTree := self abstractVariablesRefactoring parseTree
 ]
 

--- a/src/Refactoring2-Transformations/RBPullUpMethodTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBPullUpMethodTransformation.class.st
@@ -308,7 +308,7 @@ RBPullUpMethodTransformation >> removeDuplicatesOf: aSelector [
 						(RBRemoveMethodTransformation
 							model: self model
 							selector: aClass
-							from: aSelector) primitiveExecute ]]]]
+							from: aSelector) generateChanges ]]]]
 ]
 
 { #category : #executing }

--- a/src/Refactoring2-Transformations/RBTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBTransformation.class.st
@@ -117,7 +117,7 @@ RBTransformation >> setOption: aSymbol toUse: aBlock [
 { #category : #transforming }
 RBTransformation >> transform [
 
-	self deprecated: 'Use primitiveExecute instead' transformWith: '`@rec transform' -> '`@rec primitiveExecute'.
+	self deprecated: 'Use generateChanges instead' transformWith: '`@rec transform' -> '`@rec generateChanges'.
 	
 	"Performs this transformation in a model,
 	 then it adds the refactoring to the manager"

--- a/src/Renraku/ReRefactoringCritique.class.st
+++ b/src/Renraku/ReRefactoringCritique.class.st
@@ -16,7 +16,7 @@ ReRefactoringCritique >> change [
 	"return changes provided by the refactoring"
 
 	alreadyExecuted ifFalse: [
-		refactoring primitiveExecute.
+		refactoring generateChanges.
 		alreadyExecuted := true ].
 
 	^ refactoring changes

--- a/src/SystemCommands-RefactoringSupport-Tests/SycMockRBRefactoring.class.st
+++ b/src/SystemCommands-RefactoringSupport-Tests/SycMockRBRefactoring.class.st
@@ -22,6 +22,11 @@ SycMockRBRefactoring >> environment: anEnvironement [
 ]
 
 { #category : #accessing }
+SycMockRBRefactoring >> generateChanges [
+	^self
+]
+
+{ #category : #accessing }
 SycMockRBRefactoring >> model [
 	^ self
 ]
@@ -29,11 +34,6 @@ SycMockRBRefactoring >> model [
 { #category : #accessing }
 SycMockRBRefactoring >> model: aRBNamespace [
 	^ self
-]
-
-{ #category : #accessing }
-SycMockRBRefactoring >> primitiveExecute [
-	^self
 ]
 
 { #category : #accessing }

--- a/src/SystemCommands-RefactoringSupport/SycRefactoringPreviewPresenter.class.st
+++ b/src/SystemCommands-RefactoringSupport/SycRefactoringPreviewPresenter.class.st
@@ -164,7 +164,7 @@ SycRefactoringPreviewPresenter >> generateChanges [
 	rbEnvironment := self activeRBEnvironment.
 	changes do: [ :each |
 		each model environment: rbEnvironment.
-		each primitiveExecute ]
+		each generateChanges ]
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
This PR renames `primitiveExecute` to `generateChanges` and fixes failing tests along the way. With this work we're moving towards unifying scripting API and UI interaction API.