### PR TITLE
RPackage: Simplify class import

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -175,15 +175,6 @@ RPackage >> addClass: aClass [
 	aClass category: (self addClassTag: self name) categoryName
 ]
 
-{ #category : #deprecated }
-RPackage >> addClassDefinition: aClass [
-	"Please do not use me, I will be removed in the future. Use #importClass: instead."
-
-	(self includesClass: aClass) ifTrue: [ ^ self ].
-	classes add: aClass instanceSide.
-	self registerClass: aClass
-]
-
 { #category : #'class tags' }
 RPackage >> addClassDefinition: aClass toClassTag: aSymbol [
 	"Tags the class aClass with the tag aSymbol"
@@ -233,20 +224,6 @@ RPackage >> basicAddClassTag: tagName [
 	packageTag ensureSystemCategory.
 
 	^ packageTag
-]
-
-{ #category : #private }
-RPackage >> basicImportClass: aClass [
-	"Add the class definition and all the selectors which are not extensions of other packages. If the class had an extension to us, then all methods in that extension are moved to 'as yet unclassified' and the extension protocol is deleted (should I use silently or not?)."
-
-	"Question: should we check that for each extension, there is a real package behind or not?"
-
-	"We first remove the potention methods in case there are extensions registered then we add the class."
-
-	self removeAllMethodsFromClass: aClass.
-	self addClassDefinition: aClass.
-	(aClass protocols select: [ :protocol | self isYourClassExtension: protocol ]) do: [ :protocol | aClass renameProtocol: protocol as: Protocol unclassified ].
-	self importDefinedMethodsOf: aClass
 ]
 
 { #category : #'class tags' }
@@ -497,22 +474,32 @@ RPackage >> importClass: aClass [
 	Handle also *- convention. Methods defined in *category are not added to the package.
 	Pay attention that it will not import anything from the metaClass side"
 
-	self basicImportClass: aClass.
-	self basicImportClass: aClass classSide.
-	self addClassDefinition: aClass toClassTag: aClass category
+	self importClass: aClass inTag: aClass category
 ]
 
 { #category : #private }
 RPackage >> importClass: aClass inTag: aTag [
-	"import a class already created but not attached to a package to the receiver.
-	Handle also *- convention. Methods defined in *category are not added to the package.
-	Pay attention that it will not import anything from the metaClass side"
+	"Import a class already created but not attached to a package to the receiver. It will import the class and its methods.
 
-	self basicImportClass: aClass.
-	self basicImportClass: aClass classSide.
-	self
-		addClassDefinition:  aClass
-		toClassTag: aTag name
+	Handle also *- convention. Methods defined in *category are not added to the package.
+	
+	If the class had an extension to us, then all methods in that extension are moved to 'as yet unclassified' and the extension protocol is deleted"
+
+	"Question: should we check that for each extension, there is a real package behind or not?"
+
+	self removeAllMethodsFromClass: aClass.
+
+	classes add: aClass instanceSide.
+	self registerClass: aClass.
+
+	{ aClass . aClass classSide } do: [ :class |
+		(class protocols select: [ :protocol | self isYourClassExtension: protocol ]) do: [ :protocol | class renameProtocol: protocol as: Protocol unclassified ].
+
+		class protocols reject: [ :protocol | protocol isExtensionProtocol ] thenDo: [ :protocol | self importProtocol: protocol forClass: class ] ].
+	
+	self addClassDefinition: aClass toClassTag: (aTag isString
+			 ifTrue: [ aTag ]
+			 ifFalse: [ aTag name ])
 ]
 
 { #category : #private }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -176,13 +176,6 @@ RPackage >> addClass: aClass [
 ]
 
 { #category : #'class tags' }
-RPackage >> addClassDefinition: aClass toClassTag: aSymbol [
-	"Tags the class aClass with the tag aSymbol"
-
-	(self addClassTag: aSymbol) addClass: aClass
-]
-
-{ #category : #'class tags' }
 RPackage >> addClassTag: aSymbol [
 	"Add the class tag from the receiver, if already added do nothing."
 
@@ -497,9 +490,7 @@ RPackage >> importClass: aClass inTag: aTag [
 
 		class protocols reject: [ :protocol | protocol isExtensionProtocol ] thenDo: [ :protocol | self importProtocol: protocol forClass: class ] ].
 	
-	self addClassDefinition: aClass toClassTag: (aTag isString
-			 ifTrue: [ aTag ]
-			 ifFalse: [ aTag name ])
+	(self addClassTag: (aTag isString ifTrue: [ aTag ] ifFalse: [ aTag name ])) addClass: aClass
 ]
 
 { #category : #private }

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -173,8 +173,8 @@ RPackageIncrementalTest >> testClassDefinitionWithTagsRemoval [
 	b1 := self createNewClassNamed: #B1InPAckageP1 inPackage: p.
 	self assert: p definedClasses size equals: 2.
 
-	p addClassDefinition: a1 toClassTag: 'a1-tag'.
-	p addClassDefinition: b1 toClassTag: 'b1-tag'.
+	p importClass: a1 inTag: 'a1-tag'.
+	p importClass: b1 inTag: 'b1-tag'.
 	self assert: p classTags size equals: 2.
 
 	self assert: (p includesClass: a1).

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -38,18 +38,6 @@ RPackageOrganizerTest >> p3Name [
 	^ 'RPackageTestP3'
 ]
 
-{ #category : #'tests - extending' }
-RPackageOrganizerTest >> pointRectangleInGraphElement [
-
-	^ (RPackage named: #GraphElement)
-		  addClassDefinition: Point;
-		  addMethod: Point >> #x;
-		  addMethod: Point >> #rotateBy:about:;
-		  addClassDefinition: Rectangle;
-		  addMethod: self quadrangleClass >> #intersect:;
-		  yourself
-]
-
 { #category : #utilities }
 RPackageOrganizerTest >> quadrangleClass [
 	^ self organizer environment at: #QuadrangleForTesting
@@ -239,10 +227,10 @@ RPackageOrganizerTest >> testRegistrationExtendingPackages [
 	self createNewClassNamed: 'QuadrangleForTesting' inCategory: self class category.
 	self quadrangleClass compileSilently: 'intersect:aPoint ^ false'.
 	self assertEmpty: (self organizer extendingPackagesOf: self quadrangleClass).
-	p := self pointRectangleInGraphElement.
+	p := self createNewPackageNamed: 'P1'.
 	self organizer registerExtendingPackage: p forClass: self quadrangleClass.
 	self denyEmpty: (self organizer extendingPackagesOf: self quadrangleClass).
-	self assert: (self organizer extendingPackagesOf: self quadrangleClass) anyOne name equals: #GraphElement
+	self assert: (self organizer extendingPackagesOf: self quadrangleClass) anyOne name equals: #P1
 ]
 
 { #category : #tests }
@@ -384,10 +372,10 @@ RPackageOrganizerTest >> testUnregistrationExtendingPackages [
 	| p |
 	self createNewClassNamed: 'QuadrangleForTesting' inCategory: self class category.
 	self quadrangleClass compileSilently: 'intersect:aPoint ^ false'.
-	p := self pointRectangleInGraphElement.
+	p := self createNewPackageNamed: 'P1'.
 	self organizer registerExtendingPackage: p forClass: self quadrangleClass.
 	self denyEmpty: (self organizer extendingPackagesOf: self quadrangleClass).
-	self assert: (self organizer extendingPackagesOf: self quadrangleClass) anyOne name equals: #GraphElement.
+	self assert: (self organizer extendingPackagesOf: self quadrangleClass) anyOne name equals: #P1.
 	self organizer unregisterExtendingPackage: p forClass: self quadrangleClass.
 	self assertEmpty: (self organizer extendingPackagesOf: self quadrangleClass)
 ]

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -73,8 +73,8 @@ RPackageReadOnlyCompleteSetupTest >> testAddTag [
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #baz ]).
 	self assert: p1 classTags size equals: 2.
 
-	p1 addClassDefinition: a1 toClassTag: #foo.
-	p1 addClassDefinition: b1 toClassTag: #foo.
+	p1 importClass: a1 inTag: #foo.
+	p1 importClass: b1 inTag: #foo.
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #foo ]).
 	self assert: p1 classTags size equals: 2. "foo and baz. The root tag got automatically removed since it was empty."
 	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
@@ -97,8 +97,8 @@ RPackageReadOnlyCompleteSetupTest >> testAddTagNames [
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #baz ]).
 	self assert: p1 classTags size equals: 2.
 
-	p1 addClassDefinition: a1 toClassTag: #foo.
-	p1 addClassDefinition: b1 toClassTag: #foo.
+	p1 importClass: a1 inTag: #foo.
+	p1 importClass: b1 inTag: #foo.
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #foo ]).
 	self assert: p1 classTags size equals: 2. "foo and baz. The root tag got automatically removed since it was empty."
 	self assert: ((p1 classNamesForClassTag: #foo) includes: #A1DefinedInP1).
@@ -118,15 +118,15 @@ RPackageReadOnlyCompleteSetupTest >> testAddTagsToAClass [
 
 	self assert: p1 classTags size equals: 1. "We start with the root tag"
 
-	p1 addClassDefinition: a1 toClassTag: #foo.
+	p1 importClass: a1 inTag: #foo.
 	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
 	self assert: (p1 classesForClassTag: #foo) size equals: 1.
 
-	p1 addClassDefinition: b1 toClassTag: #foo.
+	p1 importClass: b1 inTag: #foo.
 	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
 	self assert: (p1 classesForClassTag: #foo) size equals: 2.
 
-	p1 addClassDefinition: b1 toClassTag: #zork.
+	p1 importClass: b1 inTag: #zork.
 	self assert: (((p1 classesForClassTag: #zork) collect: [ :each | each name ]) includes: #B1DefinedInP1).
 	self assert: (p1 classesForClassTag: #foo) size equals: 1.
 	self assert: (p1 classesForClassTag: #zork) size equals: 1
@@ -299,11 +299,11 @@ RPackageReadOnlyCompleteSetupTest >> testRemoveTag [
 
 	self assert: p1 classTags size equals: 1. "We start with the root tag"
 
-	p1 addClassDefinition: a1 toClassTag: #foo.
+	p1 importClass: a1 inTag: #foo.
 	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
 	self assert: (p1 classesForClassTag: #foo) size equals: 1.
 
-	p1 addClassDefinition: b1 toClassTag: #foo.
+	p1 importClass: b1 inTag: #foo.
 	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
 	self assert: (p1 classesForClassTag: #foo) size equals: 2.
 
@@ -319,9 +319,9 @@ RPackageReadOnlyCompleteSetupTest >> testRemoveTag [
 { #category : #'tests - tag class' }
 RPackageReadOnlyCompleteSetupTest >> testRemoveTaggedClasses [
 
-	p1 addClassDefinition: a1 toClassTag: #foo.
-	p1 addClassDefinition: b1 toClassTag: #foo.
-	p1 addClassDefinition: b1 toClassTag: #zork.
+	p1 importClass: a1 inTag: #foo.
+	p1 importClass: b1 inTag: #foo.
+	p1 importClass: b1 inTag: #zork.
 	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
 	self deny: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
 	self assert: (p1 classesForClassTag: #foo) size equals: 1.

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -49,7 +49,7 @@ RPackageTestCase >> createNewClassNamed: aName inPackage: p [
 
 	| cls |
 	cls := self createNewClassNamed: aName inCategory: p name.
-	p addClassDefinition: cls.
+	p importClass: cls.
 	^ cls
 ]
 
@@ -88,7 +88,7 @@ RPackageTestCase >> createNewTraitNamed: aName inPackage: p [
 
 	| cls |
 	cls := self createNewTraitNamed: aName.
-	p addClassDefinition: cls.
+	p importClass: cls.
 	^ cls
 ]
 


### PR DESCRIPTION
The class import in RPackage is split into multiple methods. In the past it made sense because it was complex to import a class, but the recent cleanings simplified a lot this. 

The problem of having all those methods is that users end up using the private methods that do not import a class totally and the system end up in a weird state.

Here I propose to change those places and simplify the API to keep only #importClass: and #importClass:inTag: