### PR TITLE
Simplify FixedFaceFont by removing ‘displaySelector’

### DIFF
--- a/src/Graphics-Fonts/FixedFaceFont.class.st
+++ b/src/Graphics-Fonts/FixedFaceFont.class.st
@@ -1,9 +1,6 @@
 "
 I am a font for special purpose like password or fallback.
 I can show same form whenever someone requests any character.
-
-Variable displaySelector is future use to show a form dynamically.
-(Although it would be unnecessary...)
 "
 Class {
 	#name : #FixedFaceFont,

--- a/src/Graphics-Fonts/FixedFaceFont.class.st
+++ b/src/Graphics-Fonts/FixedFaceFont.class.st
@@ -10,8 +10,7 @@ Class {
 	#superclass : #AbstractFont,
 	#instVars : [
 		'baseFont',
-		'substitutionCharacter',
-		'displaySelector'
+		'substitutionCharacter'
 	],
 	#category : #'Graphics-Fonts'
 }
@@ -52,75 +51,24 @@ FixedFaceFont >> descentKern [
 ]
 
 { #category : #displaying }
-FixedFaceFont >> displayErrorOn: aCanvas length: length at: aPoint kern: kernDelta [
-	| maskedString |
-	maskedString := String new: length.
-	maskedString atAllPut: substitutionCharacter.
-	^ baseFont
-		displayString: maskedString
-		on: aCanvas
-		from: 1
-		to: length
-		at: aPoint
-		kern: kernDelta
-]
-
-{ #category : #displaying }
-FixedFaceFont >> displayErrorOn: aCanvas length: length at: aPoint kern: kernDelta baselineY: baselineY [
-	| maskedString |
-	maskedString := String new: length.
-	maskedString atAllPut: substitutionCharacter.
-	^ baseFont
-		displayString: maskedString
-		on: aCanvas
-		from: 1
-		to: length
-		at: aPoint
-		kern: kernDelta
-		baselineY: baselineY
-]
-
-{ #category : #displaying }
-FixedFaceFont >> displayPasswordOn: aCanvas length: length at: aPoint kern: kernDelta [
-	| maskedString |
-	maskedString := String new: length.
-	maskedString atAllPut: substitutionCharacter.
-	^ baseFont
-		displayString: maskedString
-		on: aCanvas
-		from: 1
-		to: length
-		at: aPoint
-		kern: kernDelta
-]
-
-{ #category : #displaying }
-FixedFaceFont >> displayPasswordOn: aCanvas length: length at: aPoint kern: kernDelta baselineY: baselineY [
-	| maskedString |
-	maskedString := String new: length.
-	maskedString atAllPut: substitutionCharacter.
-	^ baseFont
-		displayString: maskedString
-		on: aCanvas
-		from: 1
-		to: length
-		at: aPoint
-		kern: kernDelta
-		baselineY: baselineY
-]
-
-{ #category : #displaying }
 FixedFaceFont >> displayString: aString on: aDisplayContext from: startIndex to: stopIndex at: aPoint kern: kernDelta [
-	| size |
-	size := stopIndex - startIndex + 1.
-	^ self perform: displaySelector withArguments: (Array with: aDisplayContext with: size with: aPoint with: kernDelta with: aPoint y + self ascent)
+
+	^ self displayString: aString on: aDisplayContext from: startIndex to: stopIndex at: aPoint
+		kern: kernDelta baselineY: aPoint y + self ascent
 ]
 
 { #category : #displaying }
 FixedFaceFont >> displayString: aString on: aDisplayContext from: startIndex to: stopIndex at: aPoint kern: kernDelta baselineY: baselineY [
 	| size |
 	size := stopIndex - startIndex + 1.
-	^ self perform: displaySelector withArguments: (Array with: aDisplayContext with: size with: aPoint with: kernDelta with: baselineY)
+	^ baseFont
+		displayString: (String new: size withAll: substitutionCharacter)
+		on: aDisplayContext
+		from: 1
+		to: size
+		at: aPoint
+		kern: kernDelta
+		baselineY: baselineY
 ]
 
 { #category : #displaying }
@@ -157,7 +105,6 @@ FixedFaceFont >> emphasized: emph [
 
 { #category : #initialization }
 FixedFaceFont >> errorFont [
-	displaySelector := #displayErrorOn:length:at:kern:baselineY:.
 	substitutionCharacter := $?
 ]
 
@@ -211,7 +158,6 @@ FixedFaceFont >> passwordCharacter [
 
 { #category : #initialization }
 FixedFaceFont >> passwordFont [
-	displaySelector := #displayPasswordOn:length:at:kern:baselineY:.
 	substitutionCharacter := $*
 ]
 


### PR DESCRIPTION
This pull request simplifies FixedFaceFont by removing ‘displaySelector’. The two selectors that were used both just displayed a string of the given ‘length’ filled with the ‘substitutionCharacter’.