### PR TITLE
Packages: Introduce new API in MCOrganizationDefinition

### DIFF
--- a/src/Metacello-TestsMCResources/MetacelloAlternateResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloAlternateResource.class.st
@@ -38,7 +38,7 @@ MetacelloAlternateResource >> setUpMonticelloRepository [
 				author: reference author
 				ancestors: #())
 			snapshot: (MCSnapshot fromDefinitions: (Array
-				with: (MCOrganizationDefinition categories: (Array with: reference packageName asSymbol))
+				with: (MCOrganizationDefinition packageName: reference packageName)
 				with: (MCClassDefinition name: reference packageName asSymbol superclassName: #Object category: reference packageName asSymbol instVarNames: #() comment: '')))
 			dependencies: #()) ]
 ]

--- a/src/Metacello-TestsMCResources/MetacelloAtomicConfigurationResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloAtomicConfigurationResource.class.st
@@ -351,7 +351,7 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfAtomicFan [
     | reference packageName definitionArray |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfAtomicFan-dkh.1'.
     packageName := reference packageName asSymbol.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: packageName)).
+    definitionArray := {(MCOrganizationDefinition packageName: packageName).
     (MCClassDefinition
         name: packageName
         superclassName: #'Object'
@@ -413,7 +413,7 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfAtomicFoo [
     | reference packageName definitionArray |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfAtomicFoo-dkh.1'.
     packageName := reference packageName asSymbol.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: packageName)).
+    definitionArray := {(MCOrganizationDefinition packageName: packageName).
     (MCClassDefinition
         name: packageName
         superclassName: #'Object'
@@ -475,7 +475,7 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfLinearFoo [
     | reference packageName definitionArray |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfLinearFoo-dkh.1'.
     packageName := reference packageName asSymbol.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: packageName)).
+    definitionArray := {(MCOrganizationDefinition packageName: packageName).
     (MCClassDefinition
         name: packageName
         superclassName: #'Object'
@@ -561,7 +561,7 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfProjectIssue86 [
     | reference packageName definitionArray |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue86-dkh.1'.
     packageName := reference packageName asSymbol.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: packageName)).
+    definitionArray := {(MCOrganizationDefinition packageName: packageName).
     (MCClassDefinition
         name: packageName
         superclassName: #'Object'
@@ -623,7 +623,7 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfUmbrellaA [
     | reference packageName definitionArray |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfUmbrellaA-dkh.1'.
     packageName := reference packageName asSymbol.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: packageName)).
+    definitionArray := {(MCOrganizationDefinition packageName: packageName).
     (MCClassDefinition
         name: packageName
         superclassName: #'Object'
@@ -673,7 +673,7 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfUmbrellaB [
     | reference packageName definitionArray |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfUmbrellaB-dkh.1'.
     packageName := reference packageName asSymbol.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: packageName)).
+    definitionArray := {(MCOrganizationDefinition packageName: packageName).
     (MCClassDefinition
         name: packageName
         superclassName: #'Object'

--- a/src/Metacello-TestsMCResources/MetacelloAtomicConfigurationResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloAtomicConfigurationResource.class.st
@@ -348,43 +348,43 @@ MetacelloAtomicConfigurationResource >> setUp [
 MetacelloAtomicConfigurationResource >> setUpConfigurationOfAtomicFan [
     "self reset"
 
-    | reference className definitionArray |
+    | reference packageName definitionArray |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfAtomicFan-dkh.1'.
-    className := reference packageName asSymbol.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: className)).
+    packageName := reference packageName asSymbol.
+    definitionArray := {(MCOrganizationDefinition categories: (Array with: packageName)).
     (MCClassDefinition
-        name: className
+        name: packageName
         superclassName: #'Object'
-        category: className
+        category: packageName
         instVarNames: #()
         comment: '').
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         classIsMeta: true
         selector: 'project'
         category: 'cat'
         timeStamp: ''
         source: self projectClassMethodSource).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'project'
         category: 'cat'
         timeStamp: ''
         source: self projectMethodSource).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'baseline20Fan:'
         category: 'cat'
         timeStamp: ''
         source: self baseline20MethodSourceFan).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'baseline31Fan:'
         category: 'cat'
         timeStamp: ''
         source: self baseline31MethodSourceFan).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'postLoad31baseline'
         category: 'cat'
         timeStamp: ''
@@ -410,43 +410,43 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfAtomicFan [
 MetacelloAtomicConfigurationResource >> setUpConfigurationOfAtomicFoo [
     "self reset"
 
-    | reference className definitionArray |
+    | reference packageName definitionArray |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfAtomicFoo-dkh.1'.
-    className := reference packageName asSymbol.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: className)).
+    packageName := reference packageName asSymbol.
+    definitionArray := {(MCOrganizationDefinition categories: (Array with: packageName)).
     (MCClassDefinition
-        name: className
+        name: packageName
         superclassName: #'Object'
-        category: className
+        category: packageName
         instVarNames: #()
         comment: '').
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         classIsMeta: true
         selector: 'project'
         category: 'cat'
         timeStamp: ''
         source: self projectClassMethodSource).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'project'
         category: 'cat'
         timeStamp: ''
         source: self projectMethodSource).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'baseline20Foo:'
         category: 'cat'
         timeStamp: ''
         source: self baseline20MethodSourceFoo).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'baseline25Foo:'
         category: 'cat'
         timeStamp: ''
         source: self baseline25MethodSourceFoo).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'version20Foo:'
         category: 'cat'
         timeStamp: ''
@@ -472,67 +472,67 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfAtomicFoo [
 MetacelloAtomicConfigurationResource >> setUpConfigurationOfLinearFoo [
     "self reset"
 
-    | reference className definitionArray |
+    | reference packageName definitionArray |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfLinearFoo-dkh.1'.
-    className := reference packageName asSymbol.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: className)).
+    packageName := reference packageName asSymbol.
+    definitionArray := {(MCOrganizationDefinition categories: (Array with: packageName)).
     (MCClassDefinition
-        name: className
+        name: packageName
         superclassName: #'Object'
-        category: className
+        category: packageName
         instVarNames: #()
         comment: '').
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         classIsMeta: true
         selector: 'project'
         category: 'cat'
         timeStamp: ''
         source: self projectClassMethodSource).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'project'
         category: 'cat'
         timeStamp: ''
         source: self linearProjectMethodSource).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'baseline20Foo:'
         category: 'cat'
         timeStamp: ''
         source: self baseline20MethodSourceFoo).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'version20Foo:'
         category: 'cat'
         timeStamp: ''
         source: self version20MethodSourceFoo).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'version50Foo:'
         category: 'cat'
         timeStamp: ''
         source: self version50MethodSourceFoo).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'version51Foo:'
         category: 'cat'
         timeStamp: ''
         source: self version51MethodSourceFoo).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'baseline60Foo:'
         category: 'cat'
         timeStamp: ''
         source: self baseline60MethodSourceFoo).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'baseline61Foo:'
         category: 'cat'
         timeStamp: ''
         source: self baseline61MethodSourceFoo).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'baseline62Foo:'
         category: 'cat'
         timeStamp: ''
@@ -558,43 +558,43 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfLinearFoo [
 MetacelloAtomicConfigurationResource >> setUpConfigurationOfProjectIssue86 [
     "self reset"
 
-    | reference className definitionArray |
+    | reference packageName definitionArray |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue86-dkh.1'.
-    className := reference packageName asSymbol.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: className)).
+    packageName := reference packageName asSymbol.
+    definitionArray := {(MCOrganizationDefinition categories: (Array with: packageName)).
     (MCClassDefinition
-        name: className
+        name: packageName
         superclassName: #'Object'
-        category: className
+        category: packageName
         instVarNames: #()
         comment: '').
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         classIsMeta: true
         selector: 'project'
         category: 'cat'
         timeStamp: ''
         source: self projectClassMethodSource).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'project'
         category: 'cat'
         timeStamp: ''
         source: self linearProjectMethodSource).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'baseline60ProjectIssue86:'
         category: 'cat'
         timeStamp: ''
         source: self baseline60MethodSourceProjectIssue86).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'baseline61ProjectIssue86:'
         category: 'cat'
         timeStamp: ''
         source: self baseline61MethodSourceProjectIssue86).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'baseline62ProjectIssue86:'
         category: 'cat'
         timeStamp: ''
@@ -620,31 +620,31 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfProjectIssue86 [
 MetacelloAtomicConfigurationResource >> setUpConfigurationOfUmbrellaA [
     "self reset"
 
-    | reference className definitionArray |
+    | reference packageName definitionArray |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfUmbrellaA-dkh.1'.
-    className := reference packageName asSymbol.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: className)).
+    packageName := reference packageName asSymbol.
+    definitionArray := {(MCOrganizationDefinition categories: (Array with: packageName)).
     (MCClassDefinition
-        name: className
+        name: packageName
         superclassName: #'Object'
-        category: className
+        category: packageName
         instVarNames: #()
         comment: '').
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         classIsMeta: true
         selector: 'project'
         category: 'cat'
         timeStamp: ''
         source: self projectClassMethodSource).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'project'
         category: 'cat'
         timeStamp: ''
         source: self projectMethodSource).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'version50Umbrella:'
         category: 'cat'
         timeStamp: ''
@@ -670,31 +670,31 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfUmbrellaA [
 MetacelloAtomicConfigurationResource >> setUpConfigurationOfUmbrellaB [
     "self reset"
 
-    | reference className definitionArray |
+    | reference packageName definitionArray |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfUmbrellaB-dkh.1'.
-    className := reference packageName asSymbol.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: className)).
+    packageName := reference packageName asSymbol.
+    definitionArray := {(MCOrganizationDefinition categories: (Array with: packageName)).
     (MCClassDefinition
-        name: className
+        name: packageName
         superclassName: #'Object'
-        category: className
+        category: packageName
         instVarNames: #()
         comment: '').
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         classIsMeta: true
         selector: 'project'
         category: 'cat'
         timeStamp: ''
         source: self projectClassMethodSource).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'project'
         category: 'cat'
         timeStamp: ''
         source: self projectMethodSource).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'version51Umbrella:'
         category: 'cat'
         timeStamp: ''

--- a/src/Metacello-TestsMCResources/MetacelloAtomicMonticelloResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloAtomicMonticelloResource.class.st
@@ -40,7 +40,7 @@ MetacelloAtomicMonticelloResource >> setUpDependency [
 				author: reference author
 				ancestors: #())
 		snapshot: (MCSnapshot fromDefinitions: (Array
-				with: (MCOrganizationDefinition categories: (Array with: reference packageName asSymbol))
+				with: (MCOrganizationDefinition packageName: reference packageName)
 				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol instVarNames: #() comment: '')))
 		dependencies: (Array 
 				with: (MCVersionDependency 
@@ -70,7 +70,7 @@ MetacelloAtomicMonticelloResource >> setUpMonticelloRepository [
 				author: reference author
 				ancestors: #())
 			snapshot: (MCSnapshot fromDefinitions: (Array
-				with: (MCOrganizationDefinition categories: (Array with: reference packageName asSymbol))
+				with: (MCOrganizationDefinition packageName: reference packageName)
 				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: superclassName category: reference packageName asSymbol instVarNames: #() comment: '')))
 			dependencies: #()) ]
 ]
@@ -92,7 +92,7 @@ MetacelloAtomicMonticelloResource >> setUpNewerDependency [
 				author: reference author
 				ancestors: #())
 		snapshot: (MCSnapshot fromDefinitions: (Array
-				with: (MCOrganizationDefinition categories: (Array with: reference packageName asSymbol))
+				with: (MCOrganizationDefinition packageName: reference packageName)
 				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol instVarNames: #() comment: '')))
 		dependencies: (Array 
 				with: (MCVersionDependency 

--- a/src/Metacello-TestsMCResources/MetacelloConfigurationResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloConfigurationResource.class.st
@@ -1244,7 +1244,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfFan [
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfFan-dkh.1'.
 	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: packageName).
+					MCOrganizationDefinition packageName: packageName.
 					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
 						className: packageName asString
@@ -1312,7 +1312,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfFeaux [
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfFeaux-dkh.1'.
 	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: packageName).
+					MCOrganizationDefinition packageName: packageName.
 					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
 						className: packageName asString
@@ -1356,7 +1356,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfFix [
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfFix-dkh.1'.
 	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: packageName).
+					MCOrganizationDefinition packageName: packageName.
 					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
 						className: packageName asString
@@ -1405,7 +1405,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfFoo [
     | reference packageName definitionArray |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfFoo-dkh.1'.
     packageName := reference packageName asSymbol.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: packageName)).
+    definitionArray := {(MCOrganizationDefinition packageName: packageName).
     (MCClassDefinition
         name: packageName
         superclassName: #'Object'
@@ -1493,7 +1493,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfFum [
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfFum-dkh.1'.
 	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: packageName).
+					MCOrganizationDefinition packageName: packageName.
 					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
 						className: packageName asString
@@ -1650,7 +1650,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectFee [
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectFee-dkh.1'.
 	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: packageName).
+					MCOrganizationDefinition packageName: packageName.
 					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
 						className: packageName asString
@@ -1693,7 +1693,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectFie [
     | reference packageName definitionArray |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectFie-dkh.1'.
     packageName := reference packageName asSymbol.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: packageName)).
+    definitionArray := {(MCOrganizationDefinition packageName: packageName).
     (MCClassDefinition
         name: packageName
         superclassName: #'Object'
@@ -1762,7 +1762,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectFoe [
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectFoe-dkh.1'.
 	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: packageName).
+					MCOrganizationDefinition packageName: packageName.
 					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
 						className: packageName asString
@@ -1805,7 +1805,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectFum [
     | reference packageName definitionArray |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectFum-dkh.1'.
     packageName := reference packageName asSymbol.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: packageName)).
+    definitionArray := {(MCOrganizationDefinition packageName: packageName).
     (MCClassDefinition
         name: packageName
         superclassName: #'Object'
@@ -1856,7 +1856,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectInfinite [
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectInfinite-dkh.1'.
 	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: packageName).
+					MCOrganizationDefinition packageName: packageName.
 					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
 						className: packageName asString
@@ -1909,7 +1909,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue115dkh1 [
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue115-dkh.1'.
 	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: packageName).
+					MCOrganizationDefinition packageName: packageName.
 					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
 						className: packageName asString
@@ -1960,7 +1960,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue115dkh2: ances
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue115-dkh.2'.
 	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: packageName).
+					MCOrganizationDefinition packageName: packageName.
 					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
 						className: packageName asString
@@ -2520,7 +2520,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue125 [
     | reference packageName definitionArray versionInfo |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue125-dkh.1'.
     packageName := reference packageName asSymbol.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: packageName)).
+    definitionArray := {(MCOrganizationDefinition packageName: packageName).
     (MCClassDefinition
         name: packageName
         superclassName: #'Object'
@@ -2593,7 +2593,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue136dkh1 [
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue136-dkh.1'.
 	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: packageName).
+					MCOrganizationDefinition packageName: packageName.
 					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
 						className: packageName asString
@@ -2644,7 +2644,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue136dkh2: ances
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue136-dkh.2'.
 	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: packageName).
+					MCOrganizationDefinition packageName: packageName.
 					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
 						className: packageName asString
@@ -3064,7 +3064,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue95 [
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue95-dkh.1'.
 	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: packageName).
+					MCOrganizationDefinition packageName: packageName.
 					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
 						className: packageName asString
@@ -3108,7 +3108,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectLoop [
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectLoop-dkh.1'.
 	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: packageName).
+					MCOrganizationDefinition packageName: packageName.
 					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
 						className: packageName asString
@@ -3441,7 +3441,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfSymbolic [
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfSymbolic-dkh.1'.
 	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: packageName).
+					MCOrganizationDefinition packageName: packageName.
 					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
 						className: packageName asString
@@ -3510,8 +3510,7 @@ MetacelloConfigurationResource >> setUpIssue156BaselineOfGoo [
   | reference packageName definitionArray |
   reference := GoferVersionReference name: 'BaselineOfGoo-dkh.1'.
   packageName := reference packageName asSymbol.
-  definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: packageName)).
+  definitionArray := {(MCOrganizationDefinition packageName: packageName).
   (MCClassDefinition
     name: packageName
     superclassName: #'BaselineOf'
@@ -3550,8 +3549,7 @@ MetacelloConfigurationResource >> setUpIssue156ConfigurationOfGoo [
   | reference packageName definitionArray |
   reference := GoferVersionReference name: 'ConfigurationOfGoo-dkh.1'.
   packageName := reference packageName asSymbol.
-  definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: packageName)).
+  definitionArray := {(MCOrganizationDefinition packageName: packageName).
   (MCClassDefinition
     name: packageName
     superclassName: #'ConfigurationOf'
@@ -3605,8 +3603,7 @@ MetacelloConfigurationResource >> setUpIssue156ConfigurationOfProjectGoo [
   | reference packageName definitionArray |
   reference := GoferVersionReference name: 'ConfigurationOfProjectGoo-dkh.1'.
   packageName := reference packageName asSymbol.
-  definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: packageName)).
+  definitionArray := {(MCOrganizationDefinition packageName: packageName).
   (MCClassDefinition
     name: packageName
     superclassName: #'ConfigurationOf'
@@ -3661,8 +3658,7 @@ MetacelloConfigurationResource >> setUpIssue156ConfigurationOfProjectSoo [
   | reference packageName definitionArray |
   reference := GoferVersionReference name: 'ConfigurationOfProjectSoo-dkh.1'.
   packageName := reference packageName asSymbol.
-  definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: packageName)).
+  definitionArray := {(MCOrganizationDefinition packageName: packageName).
   (MCClassDefinition
     name: packageName
     superclassName: #'ConfigurationOf'
@@ -3728,7 +3724,7 @@ MetacelloConfigurationResource >> setUpIssue77B [
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfIssue77B-dkh.1'.
 	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: packageName).
+					MCOrganizationDefinition packageName: packageName.
 					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
 						className: packageName asString
@@ -3772,7 +3768,7 @@ MetacelloConfigurationResource >> setUpIssue77C [
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfIssue77C-dkh.1'.
 	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: packageName).
+					MCOrganizationDefinition packageName: packageName.
 					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
 						className: packageName asString
@@ -3822,7 +3818,7 @@ MetacelloConfigurationResource >> setUpIssue77D [
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfIssue77D-dkh.1'.
 	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: packageName).
+					MCOrganizationDefinition packageName: packageName.
 					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
 						className: packageName asString

--- a/src/Metacello-TestsMCResources/MetacelloConfigurationResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloConfigurationResource.class.st
@@ -1240,51 +1240,51 @@ MetacelloConfigurationResource >> setUp [
 MetacelloConfigurationResource >> setUpConfigurationOfFan [
 	"self reset"
 	
-	| reference className definitionArray |
+	| reference packageName definitionArray |
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfFan-dkh.1'.
-	className := reference packageName asSymbol.
+	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: className).
-					MCClassDefinition name: className superclassName: #Object category: className instVarNames: #() comment: ''.
+					MCOrganizationDefinition categories: (Array with: packageName).
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						classIsMeta: true
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectClassMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'baseline20Fan:'
 						category: 'cat'
 						timeStamp: ''
 						source: self baseline20MethodSourceFan.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'baseline30Fan:'
 						category: 'cat'
 						timeStamp: ''
 						source: self baseline30MethodSourceFan.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'baseline35Fan:'
 						category: 'cat'
 						timeStamp: ''
 						source: self baseline35MethodSourceFan.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'baseline40Fan:'
 						category: 'cat'
 						timeStamp: ''
 						source: self baseline40MethodSourceFan.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'baseline50Fan:'
 						category: 'cat'
 						timeStamp: ''
@@ -1308,27 +1308,27 @@ MetacelloConfigurationResource >> setUpConfigurationOfFan [
 MetacelloConfigurationResource >> setUpConfigurationOfFeaux [
 	"self reset"
 	
-	| reference className definitionArray |
+	| reference packageName definitionArray |
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfFeaux-dkh.1'.
-	className := reference packageName asSymbol.
+	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: className).
-					MCClassDefinition name: className superclassName: #Object category: className instVarNames: #() comment: ''.
+					MCOrganizationDefinition categories: (Array with: packageName).
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						classIsMeta: true
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectClassMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'baseline40Feaux:'
 						category: 'cat'
 						timeStamp: ''
@@ -1352,33 +1352,33 @@ MetacelloConfigurationResource >> setUpConfigurationOfFeaux [
 MetacelloConfigurationResource >> setUpConfigurationOfFix [
 	"self reset"
 	
-	| reference className definitionArray |
+	| reference packageName definitionArray |
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfFix-dkh.1'.
-	className := reference packageName asSymbol.
+	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: className).
-					MCClassDefinition name: className superclassName: #Object category: className instVarNames: #() comment: ''.
+					MCOrganizationDefinition categories: (Array with: packageName).
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						classIsMeta: true
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectClassMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'baseline60Fix:'
 						category: 'cat'
 						timeStamp: ''
 						source: self baseline60MethodSourceFix.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'baseline61Fix:'
 						category: 'cat'
 						timeStamp: ''
@@ -1402,68 +1402,68 @@ MetacelloConfigurationResource >> setUpConfigurationOfFix [
 MetacelloConfigurationResource >> setUpConfigurationOfFoo [
     "self reset"
 
-    | reference className definitionArray |
+    | reference packageName definitionArray |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfFoo-dkh.1'.
-    className := reference packageName asSymbol.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: className)).
+    packageName := reference packageName asSymbol.
+    definitionArray := {(MCOrganizationDefinition categories: (Array with: packageName)).
     (MCClassDefinition
-        name: className
+        name: packageName
         superclassName: #'Object'
-        category: className
+        category: packageName
         instVarNames: #()
         comment: '').
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         classIsMeta: false
         selector: 'bleedingEdgeVersion:'
         category: 'cat'
         timeStamp: ''
         source: (self class sourceCodeAt: #'bleedingEdgeVersion:') asString).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'project'
         category: 'cat'
         timeStamp: ''
         source: self projectMethodSource).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         classIsMeta: true
         selector: 'project'
         category: 'cat'
         timeStamp: ''
         source: self projectClassMethodSource).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'baseline20Foo:'
         category: 'cat'
         timeStamp: ''
         source: self baseline20MethodSourceFoo).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'baseline30Foo:'
         category: 'cat'
         timeStamp: ''
         source: self baseline30MethodSourceFoo).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'baseline35Foo:'
         category: 'cat'
         timeStamp: ''
         source: self baseline35MethodSourceFoo).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'baseline40Foo:'
         category: 'cat'
         timeStamp: ''
         source: self baseline40MethodSourceFoo).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'baseline50Foo:'
         category: 'cat'
         timeStamp: ''
         source: self baseline50MethodSourceFoo).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'preloadDoIt'
         category: 'cat'
         timeStamp: ''
@@ -1489,27 +1489,27 @@ MetacelloConfigurationResource >> setUpConfigurationOfFoo [
 MetacelloConfigurationResource >> setUpConfigurationOfFum [
 	"self reset"
 	
-	| reference className definitionArray |
+	| reference packageName definitionArray |
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfFum-dkh.1'.
-	className := reference packageName asSymbol.
+	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: className).
-					MCClassDefinition name: className superclassName: #Object category: className instVarNames: #() comment: ''.
+					MCOrganizationDefinition categories: (Array with: packageName).
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						classIsMeta: true
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectClassMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'baseline40ProjectFum:'
 						category: 'cat'
 						timeStamp: ''
@@ -1646,27 +1646,27 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectConfigIssue283dkh1 
 MetacelloConfigurationResource >> setUpConfigurationOfProjectFee [
 	"self reset"
 	
-	| reference className definitionArray |
+	| reference packageName definitionArray |
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectFee-dkh.1'.
-	className := reference packageName asSymbol.
+	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: className).
-					MCClassDefinition name: className superclassName: #Object category: className instVarNames: #() comment: ''.
+					MCOrganizationDefinition categories: (Array with: packageName).
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						classIsMeta: true
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectClassMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'baseline40ProjectFee:'
 						category: 'cat'
 						timeStamp: ''
@@ -1690,49 +1690,49 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectFee [
 MetacelloConfigurationResource >> setUpConfigurationOfProjectFie [
     "self reset"
 
-    | reference className definitionArray |
+    | reference packageName definitionArray |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectFie-dkh.1'.
-    className := reference packageName asSymbol.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: className)).
+    packageName := reference packageName asSymbol.
+    definitionArray := {(MCOrganizationDefinition categories: (Array with: packageName)).
     (MCClassDefinition
-        name: className
+        name: packageName
         superclassName: #'Object'
-        category: className
+        category: packageName
         instVarNames: #()
         comment: '').
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         classIsMeta: true
         selector: 'project'
         category: 'cat'
         timeStamp: ''
         source: self projectClassMethodSource).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'project'
         category: 'cat'
         timeStamp: ''
         source: self projectMethodSource).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'baseline15ProjectFie:'
         category: 'cat'
         timeStamp: ''
         source: (self class sourceCodeAt: #'baseline15ProjectFie:') asString).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'baseline25ProjectFie:'
         category: 'cat'
         timeStamp: ''
         source: (self class sourceCodeAt: #'baseline25ProjectFie:') asString).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'baseline35ProjectFie:'
         category: 'cat'
         timeStamp: ''
         source: (self class sourceCodeAt: #'baseline35ProjectFie:') asString).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'baseline40ProjectFie:'
         category: 'cat'
         timeStamp: ''
@@ -1758,27 +1758,27 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectFie [
 MetacelloConfigurationResource >> setUpConfigurationOfProjectFoe [
 	"self reset"
 	
-	| reference className definitionArray |
+	| reference packageName definitionArray |
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectFoe-dkh.1'.
-	className := reference packageName asSymbol.
+	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: className).
-					MCClassDefinition name: className superclassName: #Object category: className instVarNames: #() comment: ''.
+					MCOrganizationDefinition categories: (Array with: packageName).
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						classIsMeta: true
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectClassMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'baseline40ProjectFoe:'
 						category: 'cat'
 						timeStamp: ''
@@ -1802,31 +1802,31 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectFoe [
 MetacelloConfigurationResource >> setUpConfigurationOfProjectFum [
     "self reset"
 
-    | reference className definitionArray |
+    | reference packageName definitionArray |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectFum-dkh.1'.
-    className := reference packageName asSymbol.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: className)).
+    packageName := reference packageName asSymbol.
+    definitionArray := {(MCOrganizationDefinition categories: (Array with: packageName)).
     (MCClassDefinition
-        name: className
+        name: packageName
         superclassName: #'Object'
-        category: className
+        category: packageName
         instVarNames: #()
         comment: '').
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         classIsMeta: true
         selector: 'project'
         category: 'cat'
         timeStamp: ''
         source: self projectClassMethodSource).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'project'
         category: 'cat'
         timeStamp: ''
         source: self projectMethodSource).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'baseline10ProjectFum:'
         category: 'cat'
         timeStamp: ''
@@ -1852,27 +1852,27 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectFum [
 MetacelloConfigurationResource >> setUpConfigurationOfProjectInfinite [
 	"self reset"
 	
-	| reference className definitionArray |
+	| reference packageName definitionArray |
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectInfinite-dkh.1'.
-	className := reference packageName asSymbol.
+	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: className).
-					MCClassDefinition name: className superclassName: #Object category: className instVarNames: #() comment: ''.
+					MCOrganizationDefinition categories: (Array with: packageName).
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						classIsMeta: true
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectClassMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'baseline40ProjectInfinite:'
 						category: 'cat'
 						timeStamp: ''
@@ -1905,33 +1905,33 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue115 [
 MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue115dkh1 [
 	"self reset"
 	
-	| reference className definitionArray versionInfo |
+	| reference packageName definitionArray versionInfo |
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue115-dkh.1'.
-	className := reference packageName asSymbol.
+	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: className).
-					MCClassDefinition name: className superclassName: #Object category: className instVarNames: #() comment: ''.
+					MCOrganizationDefinition categories: (Array with: packageName).
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						classIsMeta: true
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectClassMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'baselineVersion10Issue115:'
 						category: 'cat'
 						timeStamp: ''
 						source: (self class sourceCodeAt: #baselineVersion10Issue115:) asString.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'version10Issue115:'
 						category: 'cat'
 						timeStamp: ''
@@ -1956,39 +1956,39 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue115dkh1 [
 MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue115dkh2: ancestors [
 	"self reset"
 	
-	| reference className definitionArray versionInfo |
+	| reference packageName definitionArray versionInfo |
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue115-dkh.2'.
-	className := reference packageName asSymbol.
+	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: className).
-					MCClassDefinition name: className superclassName: #Object category: className instVarNames: #() comment: ''.
+					MCOrganizationDefinition categories: (Array with: packageName).
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						classIsMeta: true
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectClassMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'baselineVersion10Issue115:'
 						category: 'cat'
 						timeStamp: ''
 						source: (self class sourceCodeAt: #baselineVersion10Issue115:) asString.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'version10Issue115:'
 						category: 'cat'
 						timeStamp: ''
 						source: (self class sourceCodeAt: #version10Issue115:) asString.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'version11Issue115:'
 						category: 'cat'
 						timeStamp: ''
@@ -2517,43 +2517,43 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue119dkh7: ances
 MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue125 [
     "self reset"
 
-    | reference className definitionArray versionInfo |
+    | reference packageName definitionArray versionInfo |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue125-dkh.1'.
-    className := reference packageName asSymbol.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: className)).
+    packageName := reference packageName asSymbol.
+    definitionArray := {(MCOrganizationDefinition categories: (Array with: packageName)).
     (MCClassDefinition
-        name: className
+        name: packageName
         superclassName: #'Object'
-        category: className
+        category: packageName
         instVarNames: #()
         comment: '').
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         classIsMeta: true
         selector: 'project'
         category: 'cat'
         timeStamp: ''
         source: self projectClassMethodSource).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'project'
         category: 'cat'
         timeStamp: ''
         source: self projectMethodSource).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'version30Issue125:'
         category: 'cat'
         timeStamp: ''
         source: (self class sourceCodeAt: #'version30Issue125:') asString).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'baselineVersion20Issue125:'
         category: 'cat'
         timeStamp: ''
         source: (self class sourceCodeAt: #'baselineVersion20Issue125:') asString).
     (MCMethodDefinition
-        className: className asString
+        className: packageName asString
         selector: 'baselineVersion30Issue125:'
         category: 'cat'
         timeStamp: ''
@@ -2589,33 +2589,33 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue136 [
 MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue136dkh1 [
 	"self reset"
 	
-	| reference className definitionArray versionInfo |
+	| reference packageName definitionArray versionInfo |
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue136-dkh.1'.
-	className := reference packageName asSymbol.
+	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: className).
-					MCClassDefinition name: className superclassName: #Object category: className instVarNames: #() comment: ''.
+					MCOrganizationDefinition categories: (Array with: packageName).
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						classIsMeta: true
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectClassMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'baselineVersion10Issue136:'
 						category: 'cat'
 						timeStamp: ''
 						source: (self class sourceCodeAt: #baselineVersion10Issue136:) asString.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'version10Issue136:'
 						category: 'cat'
 						timeStamp: ''
@@ -2640,39 +2640,39 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue136dkh1 [
 MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue136dkh2: ancestors [
 	"self reset"
 	
-	| reference className definitionArray versionInfo |
+	| reference packageName definitionArray versionInfo |
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue136-dkh.2'.
-	className := reference packageName asSymbol.
+	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: className).
-					MCClassDefinition name: className superclassName: #Object category: className instVarNames: #() comment: ''.
+					MCOrganizationDefinition categories: (Array with: packageName).
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						classIsMeta: true
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectClassMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'baselineVersion10Issue136:'
 						category: 'cat'
 						timeStamp: ''
 						source: (self class sourceCodeAt: #baselineVersion10Issue136:) asString.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'version10Issue136:'
 						category: 'cat'
 						timeStamp: ''
 						source: (self class sourceCodeAt: #version10Issue136:) asString.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'version11Issue136:'
 						category: 'cat'
 						timeStamp: ''
@@ -3060,27 +3060,27 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue283dkh2: ances
 MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue95 [
 	"self reset"
 	
-	| reference className definitionArray |
+	| reference packageName definitionArray |
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue95-dkh.1'.
-	className := reference packageName asSymbol.
+	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: className).
-					MCClassDefinition name: className superclassName: #Object category: className instVarNames: #() comment: ''.
+					MCOrganizationDefinition categories: (Array with: packageName).
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						classIsMeta: true
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectClassMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'baseline40ProjectIssue95:'
 						category: 'cat'
 						timeStamp: ''
@@ -3104,27 +3104,27 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue95 [
 MetacelloConfigurationResource >> setUpConfigurationOfProjectLoop [
 	"self reset"
 	
-	| reference className definitionArray |
+	| reference packageName definitionArray |
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectLoop-dkh.1'.
-	className := reference packageName asSymbol.
+	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: className).
-					MCClassDefinition name: className superclassName: #Object category: className instVarNames: #() comment: ''.
+					MCOrganizationDefinition categories: (Array with: packageName).
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						classIsMeta: true
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectClassMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'baseline40ProjectLoop:'
 						category: 'cat'
 						timeStamp: ''
@@ -3437,51 +3437,51 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectToolBox [
 MetacelloConfigurationResource >> setUpConfigurationOfSymbolic [
 	"self reset"
 	
-	| reference className definitionArray |
+	| reference packageName definitionArray |
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfSymbolic-dkh.1'.
-	className := reference packageName asSymbol.
+	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: className).
-					MCClassDefinition name: className superclassName: #Object category: className instVarNames: #() comment: ''.
+					MCOrganizationDefinition categories: (Array with: packageName).
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						classIsMeta: true
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectClassMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'stableVersionD:'
 						category: 'cat'
 						timeStamp: ''
 						source: self stableVersionDMethodSourceSymbolic.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'version40Symbolic:'
 						category: 'cat'
 						timeStamp: ''
 						source: self version40SymbolicMethodSourceSymbolic.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'version41Symbolic:'
 						category: 'cat'
 						timeStamp: ''
 						source: self version41SymbolicMethodSourceSymbolic.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'version42Symbolic:'
 						category: 'cat'
 						timeStamp: ''
 						source: self version42SymbolicMethodSourceSymbolic.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'version43Symbolic:'
 						category: 'cat'
 						timeStamp: ''
@@ -3507,19 +3507,19 @@ MetacelloConfigurationResource >> setUpIssue156BaselineOfGoo [
 
   "self reset"
 
-  | reference className definitionArray |
+  | reference packageName definitionArray |
   reference := GoferVersionReference name: 'BaselineOfGoo-dkh.1'.
-  className := reference packageName asSymbol.
+  packageName := reference packageName asSymbol.
   definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: className)).
+    categories: (Array with: packageName)).
   (MCClassDefinition
-    name: className
+    name: packageName
     superclassName: #'BaselineOf'
-    category: className
+    category: packageName
     instVarNames: #()
     comment: '').
   (MCMethodDefinition
-    className: className asString
+    className: packageName asString
     selector: 'baselineGooIssue156Baseline:'
     category: 'cat'
     timeStamp: ''
@@ -3547,33 +3547,33 @@ MetacelloConfigurationResource >> setUpIssue156ConfigurationOfGoo [
 
   "self reset"
 
-  | reference className definitionArray |
+  | reference packageName definitionArray |
   reference := GoferVersionReference name: 'ConfigurationOfGoo-dkh.1'.
-  className := reference packageName asSymbol.
+  packageName := reference packageName asSymbol.
   definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: className)).
+    categories: (Array with: packageName)).
   (MCClassDefinition
-    name: className
+    name: packageName
     superclassName: #'ConfigurationOf'
-    category: className
+    category: packageName
     instVarNames: #()
     comment: '').
   (MCMethodDefinition
-    className: className asString
+    className: packageName asString
     selector: 'baselineGoo300Issue156Configuration:'
     category: 'cat'
     timeStamp: ''
     source:
       (self class sourceCodeAt: #'baselineGoo300Issue156Configuration:') asString).
   (MCMethodDefinition
-    className: className asString
+    className: packageName asString
     selector: 'baselineGoo400Issue156Configuration:'
     category: 'cat'
     timeStamp: ''
     source:
       (self class sourceCodeAt: #'baselineGoo400Issue156Configuration:') asString).
   (MCMethodDefinition
-    className: className asString
+    className: packageName asString
     selector: 'baselineGoo500Issue156Configuration:'
     category: 'cat'
     timeStamp: ''
@@ -3602,37 +3602,37 @@ MetacelloConfigurationResource >> setUpIssue156ConfigurationOfProjectGoo [
 
   "self reset"
 
-  | reference className definitionArray |
+  | reference packageName definitionArray |
   reference := GoferVersionReference name: 'ConfigurationOfProjectGoo-dkh.1'.
-  className := reference packageName asSymbol.
+  packageName := reference packageName asSymbol.
   definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: className)).
+    categories: (Array with: packageName)).
   (MCClassDefinition
-    name: className
+    name: packageName
     superclassName: #'ConfigurationOf'
-    category: className
+    category: packageName
     instVarNames: #()
     comment: '').
   (MCMethodDefinition
-    className: className asString
+    className: packageName asString
     selector: 'version10Issue156:'
     category: 'cat'
     timeStamp: ''
     source: (self class sourceCodeAt: #'version10Issue156:') asString).
   (MCMethodDefinition
-    className: className asString
+    className: packageName asString
     selector: 'version11Issue156:'
     category: 'cat'
     timeStamp: ''
     source: (self class sourceCodeAt: #'version11Issue156:') asString).
   (MCMethodDefinition
-    className: className asString
+    className: packageName asString
     selector: 'version20Issue156:'
     category: 'cat'
     timeStamp: ''
     source: (self class sourceCodeAt: #'version20Issue156:') asString).
   (MCMethodDefinition
-    className: className asString
+    className: packageName asString
     selector: 'version30Issue156:'
     category: 'cat'
     timeStamp: ''
@@ -3658,37 +3658,37 @@ MetacelloConfigurationResource >> setUpIssue156ConfigurationOfProjectGoo [
 MetacelloConfigurationResource >> setUpIssue156ConfigurationOfProjectSoo [
   "self reset"
 
-  | reference className definitionArray |
+  | reference packageName definitionArray |
   reference := GoferVersionReference name: 'ConfigurationOfProjectSoo-dkh.1'.
-  className := reference packageName asSymbol.
+  packageName := reference packageName asSymbol.
   definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: className)).
+    categories: (Array with: packageName)).
   (MCClassDefinition
-    name: className
+    name: packageName
     superclassName: #'ConfigurationOf'
-    category: className
+    category: packageName
     instVarNames: #()
     comment: '').
   (MCMethodDefinition
-    className: className asString
+    className: packageName asString
     selector: 'version10Issue156:'
     category: 'cat'
     timeStamp: ''
     source: (self class sourceCodeAt: #'version10Issue156:') asString).
   (MCMethodDefinition
-    className: className asString
+    className: packageName asString
     selector: 'version11Issue156:'
     category: 'cat'
     timeStamp: ''
     source: (self class sourceCodeAt: #'version11Issue156:') asString).
   (MCMethodDefinition
-    className: className asString
+    className: packageName asString
     selector: 'version20Issue156:'
     category: 'cat'
     timeStamp: ''
     source: (self class sourceCodeAt: #'version20Issue156:') asString).
   (MCMethodDefinition
-    className: className asString
+    className: packageName asString
     selector: 'version30Issue156:'
     category: 'cat'
     timeStamp: ''
@@ -3724,27 +3724,27 @@ MetacelloConfigurationResource >> setUpIssue77 [
 MetacelloConfigurationResource >> setUpIssue77B [
 	"self reset"
 	
-	| reference className definitionArray |
+	| reference packageName definitionArray |
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfIssue77B-dkh.1'.
-	className := reference packageName asSymbol.
+	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: className).
-					MCClassDefinition name: className superclassName: #Object category: className instVarNames: #() comment: ''.
+					MCOrganizationDefinition categories: (Array with: packageName).
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						classIsMeta: true
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectClassMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'baseline10B:'
 						category: 'cat'
 						timeStamp: ''
@@ -3768,33 +3768,33 @@ MetacelloConfigurationResource >> setUpIssue77B [
 MetacelloConfigurationResource >> setUpIssue77C [
 	"self reset"
 	
-	| reference className definitionArray |
+	| reference packageName definitionArray |
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfIssue77C-dkh.1'.
-	className := reference packageName asSymbol.
+	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: className).
-					MCClassDefinition name: className superclassName: #Object category: className instVarNames: #() comment: ''.
+					MCOrganizationDefinition categories: (Array with: packageName).
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						classIsMeta: true
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectClassMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'baseline12C:'
 						category: 'cat'
 						timeStamp: ''
 						source: self baseline12MethodSourceC.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'baseline13C:'
 						category: 'cat'
 						timeStamp: ''
@@ -3818,27 +3818,27 @@ MetacelloConfigurationResource >> setUpIssue77C [
 MetacelloConfigurationResource >> setUpIssue77D [
 	"self reset"
 	
-	| reference className definitionArray |
+	| reference packageName definitionArray |
 	reference := GoferVersionReference name: 'MetacelloTestConfigurationOfIssue77D-dkh.1'.
-	className := reference packageName asSymbol.
+	packageName := reference packageName asSymbol.
 	definitionArray := {
-					MCOrganizationDefinition categories: (Array with: className).
-					MCClassDefinition name: className superclassName: #Object category: className instVarNames: #() comment: ''.
+					MCOrganizationDefinition categories: (Array with: packageName).
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						classIsMeta: true
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectClassMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'project'
 						category: 'cat'
 						timeStamp: ''
 						source: self projectMethodSource.
 					MCMethodDefinition 
-						className: className asString
+						className: packageName asString
 						selector: 'baseline10D:'
 						category: 'cat'
 						timeStamp: ''

--- a/src/Metacello-TestsMCResources/MetacelloIssue108Resource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloIssue108Resource.class.st
@@ -40,7 +40,7 @@ MetacelloIssue108Resource >> setUpMonticelloRepository [
 				author: reference author
 				ancestors: #())
 			snapshot: (MCSnapshot fromDefinitions: (Array
-				with: (MCOrganizationDefinition categories: (Array with: reference packageName asSymbol))
+				with: (MCOrganizationDefinition packageName: reference packageName)
 				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol instVarNames: #() comment: '')))
 			dependencies: #()) ]
 ]

--- a/src/Metacello-TestsMCResources/MetacelloMonticelloResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloMonticelloResource.class.st
@@ -38,7 +38,7 @@ MetacelloMonticelloResource >> setUpMonticelloRepository [
 				author: reference author
 				ancestors: #())
 			snapshot: (MCSnapshot fromDefinitions: (Array
-				with: (MCOrganizationDefinition categories: (Array with: reference packageName asSymbol))
+				with: (MCOrganizationDefinition packageName: reference packageName)
 				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol instVarNames: #() comment: '')))
 			dependencies: #()) ]
 ]

--- a/src/Metacello-TestsMCResources/MetacelloScriptingResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloScriptingResource.class.st
@@ -995,7 +995,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceIV [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'BaselineOfGithubRefIV-dkh.1'.
     className := #'BaselineOfGithubRefIV'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
@@ -1034,7 +1034,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceIX [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'BaselineOfGithubRefIX-dkh.1'.
     className := #'BaselineOfGithubRefIX'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
@@ -1073,7 +1073,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceV [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'BaselineOfGithubRefV-dkh.1'.
     className := #'BaselineOfGithubRefV'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
@@ -1112,7 +1112,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceVI [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'BaselineOfGithubRefVI-dkh.1'.
     className := #'BaselineOfGithubRefVI'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
@@ -1151,7 +1151,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceVII [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'BaselineOfGithubRefVII-dkh.1'.
     className := #'BaselineOfGithubRefVII'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
@@ -1190,7 +1190,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceVIII [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'BaselineOfGithubRefVIII-dkh.1'.
     className := #'BaselineOfGithubRefVIII'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
@@ -1229,7 +1229,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceXI [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'BaselineOfGithubRefXI-dkh.1'.
     className := #'BaselineOfGithubRefXI'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
@@ -1268,7 +1268,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceXII [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'BaselineOfGithubRefXII-dkh.1'.
     className := #'BaselineOfGithubRefXII'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
@@ -1307,7 +1307,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceXIII [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'BaselineOfGithubRefXIII-dkh.1'.
     className := #'BaselineOfGithubRefXIII'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
@@ -1346,7 +1346,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceXX [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'BaselineOfGithubRefXX-dkh.1'.
     className := #'BaselineOfGithubRefXX'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
@@ -1385,8 +1385,7 @@ MetacelloScriptingResource >> setUpBaselineIssue215 [
   | reference className definitionArray versionInfo |
   reference := GoferVersionReference name: 'BaselineOfIssue215-dkh.1'.
   className := #'BaselineOfIssue215'.
-  definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: reference packageName asSymbol)).
+  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
   (MCClassDefinition
     name: className
     superclassName: #'BaselineOf'
@@ -1446,7 +1445,7 @@ MetacelloScriptingResource >> setUpBaselineIssue32 [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'BaselineOfIssue32-dkh.1'.
     className := #'BaselineOfIssue32'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
@@ -1506,8 +1505,7 @@ MetacelloScriptingResource >> setUpBaselineIssue399 [
   | reference className definitionArray versionInfo |
   reference := GoferVersionReference name: 'BaselineOfIssue399-dkh.1'.
   className := #'BaselineOfIssue399'.
-  definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: reference packageName asSymbol)).
+  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
   (MCClassDefinition
     name: className
     superclassName: #'BaselineOf'
@@ -1546,8 +1544,7 @@ MetacelloScriptingResource >> setUpBaselineIssue399Cypress [
   | reference className definitionArray versionInfo |
   reference := GoferVersionReference name: 'BaselineOfIssue399Cypress-dkh.1'.
   className := #'BaselineOfIssue399Cypress'.
-  definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: reference packageName asSymbol)).
+  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
   (MCClassDefinition
     name: className
     superclassName: #'BaselineOf'
@@ -1593,7 +1590,7 @@ MetacelloScriptingResource >> setUpBaselineOfExternalX [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'BaselineOfExternalX-dkh.1'.
     className := #'BaselineOfExternalX'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
@@ -1632,7 +1629,7 @@ MetacelloScriptingResource >> setUpBaselineOfExternalXX [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'BaselineOfExternalXX-dkh.1'.
     className := #'BaselineOfExternalXX'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
@@ -1671,7 +1668,7 @@ MetacelloScriptingResource >> setUpBaselineOfExternalXXX [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'BaselineOfExternalXXX-dkh.1'.
     className := #'BaselineOfExternalXXX'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
@@ -1717,8 +1714,7 @@ MetacelloScriptingResource >> setUpConfiguration181 [
   | reference className definitionArray versionInfo |
   reference := GoferVersionReference name: 'ConfigurationOfIssue181-dkh.1'.
   className := #'ConfigurationOfIssue181'.
-  definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: reference packageName asSymbol)).
+  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
   (MCClassDefinition
     name: className
     superclassName: #'ConfigurationOf'
@@ -1806,7 +1802,7 @@ MetacelloScriptingResource >> setUpConfiguration63 [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'ConfigurationOfIssue63-dkh.1'.
     className := #'ConfigurationOfIssue63'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'ConfigurationOf'
@@ -1861,8 +1857,7 @@ MetacelloScriptingResource >> setUpConfigurationExternalRefdkh1 [
   | reference className definitionArray versionInfo |
   reference := GoferVersionReference name: 'ConfigurationOfExternalRef-dkh.1'.
   className := #'ConfigurationOfExternalRef'.
-  definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: reference packageName asSymbol)).
+  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
   (MCClassDefinition
     name: className
     superclassName: #'ConfigurationOf'
@@ -1908,8 +1903,7 @@ MetacelloScriptingResource >> setUpConfigurationExternalRefdkh2: ancestors [
   | reference className definitionArray versionInfo |
   reference := GoferVersionReference name: 'ConfigurationOfExternalRef-dkh.2'.
   className := #'ConfigurationOfExternalRef'.
-  definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: reference packageName asSymbol)).
+  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
   (MCClassDefinition
     name: className
     superclassName: #'ConfigurationOf'
@@ -1964,7 +1958,7 @@ MetacelloScriptingResource >> setUpConfigurationIssue32 [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'ConfigurationOfIssue32-dkh.1'.
     className := #'ConfigurationOfIssue32'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'ConfigurationOf'
@@ -2019,8 +2013,7 @@ MetacelloScriptingResource >> setUpConfigurationIssue339 [
   | reference className definitionArray versionInfo |
   reference := GoferVersionReference name: 'ConfigurationOfIssue339-dkh.1'.
   className := #'ConfigurationOfIssue339'.
-  definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: reference packageName asSymbol)).
+  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
   (MCClassDefinition
     name: className
     superclassName: #'ConfigurationOf'
@@ -2063,7 +2056,7 @@ MetacelloScriptingResource >> setUpConfigurationIssue59 [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'ConfigurationOfIssue59-dkh.1'.
     className := #'ConfigurationOfIssue59'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'ConfigurationOf'
@@ -2118,7 +2111,7 @@ MetacelloScriptingResource >> setUpConfigurationIssue84 [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'ConfigurationOfIssue84-dkh.1'.
     className := #'ConfigurationOfIssue84'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'ConfigurationOf'
@@ -2177,7 +2170,7 @@ MetacelloScriptingResource >> setUpConfigurationNextedIssue84dkh1 [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'ConfigurationOfNestedIssue84-dkh.1'.
     className := #'ConfigurationOfNestedIssue84'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'ConfigurationOf'
@@ -2232,7 +2225,7 @@ MetacelloScriptingResource >> setUpConfigurationNextedIssue84dkh2: ancestors [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'ConfigurationOfNestedIssue84-dkh.2'.
     className := #'ConfigurationOfNestedIssue84'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'ConfigurationOf'
@@ -2285,8 +2278,7 @@ MetacelloScriptingResource >> setUpConfigurationOfConflict [
   | reference className definitionArray versionInfo |
   reference := GoferVersionReference name: 'ConfigurationOfConflict-dkh.1'.
   className := #'ConfigurationOfConflict'.
-  definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: reference packageName asSymbol)).
+  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
   (MCClassDefinition
     name: className
     superclassName: #'ConfigurationOf'
@@ -2362,7 +2354,7 @@ MetacelloScriptingResource >> setUpConfigurationOfExternalIV [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'ConfigurationOfExternalIV-dkh.1'.
     className := #'ConfigurationOfExternalIV'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'ConfigurationOf'
@@ -2417,7 +2409,7 @@ MetacelloScriptingResource >> setUpConfigurationOfExternalXX [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'ConfigurationOfExternalXX-dkh.1'.
     className := #'ConfigurationOfExternalXX'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'ConfigurationOf'
@@ -2463,7 +2455,7 @@ MetacelloScriptingResource >> setUpConfigurationOfExternalXXX [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'ConfigurationOfExternalXXX-dkh.1'.
     className := #'ConfigurationOfExternalXXX'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'ConfigurationOf'
@@ -2502,8 +2494,7 @@ MetacelloScriptingResource >> setUpConfigurationOfExternalXdkh1 [
   | reference className definitionArray versionInfo |
   reference := GoferVersionReference name: 'ConfigurationOfExternalX-dkh.1'.
   className := #'ConfigurationOfExternalX'.
-  definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: reference packageName asSymbol)).
+  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
   (MCClassDefinition
     name: className
     superclassName: #'ConfigurationOf'
@@ -2556,8 +2547,7 @@ MetacelloScriptingResource >> setUpConfigurationOfExternalXdkh2: ancestors [
   | reference className definitionArray versionInfo |
   reference := GoferVersionReference name: 'ConfigurationOfExternalX-dkh.2'.
   className := #'ConfigurationOfExternalX'.
-  definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: reference packageName asSymbol)).
+  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
   (MCClassDefinition
     name: className
     superclassName: #'ConfigurationOf'
@@ -2624,8 +2614,7 @@ MetacelloScriptingResource >> setUpConfigurationOfExternaldkh1 [
   | reference className definitionArray versionInfo |
   reference := GoferVersionReference name: 'ConfigurationOfExternal-dkh.1'.
   className := #'ConfigurationOfExternal'.
-  definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: reference packageName asSymbol)).
+  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
   (MCClassDefinition
     name: className
     superclassName: #'ConfigurationOf'
@@ -2664,8 +2653,7 @@ MetacelloScriptingResource >> setUpConfigurationOfExternaldkh2 [
   | reference className definitionArray versionInfo |
   reference := GoferVersionReference name: 'ConfigurationOfExternal-dkh.2'.
   className := #'ConfigurationOfExternal'.
-  definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: reference packageName asSymbol)).
+  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
   (MCClassDefinition
     name: className
     superclassName: #'ConfigurationOf'
@@ -2711,8 +2699,7 @@ MetacelloScriptingResource >> setUpExternalCore [
   | reference className definitionArray versionInfo |
   reference := GoferVersionReference name: 'External-Core-dkh.1'.
   className := #'ExternalCore'.
-  definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: reference packageName asSymbol)).
+  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
   (MCClassDefinition
     name: className
     superclassName: #'Object'
@@ -2758,8 +2745,7 @@ MetacelloScriptingResource >> setUpExternalCoreX [
   | reference className definitionArray versionInfo |
   reference := GoferVersionReference name: 'External-CoreX-dkh.1'.
   className := #'ExternalCoreX'.
-  definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: reference packageName asSymbol)).
+  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
   (MCClassDefinition
     name: className
     superclassName: #'Object'
@@ -2805,7 +2791,7 @@ MetacelloScriptingResource >> setUpInvalidConfigurations [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'ConfigurationOfInvalidConfigurations-dkh.1'.
     className := #'ConfigurationOfInvalidConfigurations'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'ConfigurationOf'
@@ -2883,8 +2869,7 @@ MetacelloScriptingResource >> setUpIssue399CoreExternaldkh1 [
   | reference className definitionArray versionInfo |
   reference := GoferVersionReference name: 'Issue399-Core-dkh.1'.
   className := #'Issue399External'.
-  definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: reference packageName asSymbol)).
+  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
   (MCClassDefinition
     name: className
     superclassName: #'Object'
@@ -2922,8 +2907,7 @@ MetacelloScriptingResource >> setUpIssue399CoreSampledkh1 [
   | reference className definitionArray versionInfo |
   reference := GoferVersionReference name: 'Issue399-Core-dkh.1'.
   className := #'Issue399Sample'.
-  definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: reference packageName asSymbol)).
+  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
   (MCClassDefinition
     name: className
     superclassName: #'Object'
@@ -2961,8 +2945,7 @@ MetacelloScriptingResource >> setUpIssue399CoreSampledkh2: ancestors [
   | reference className definitionArray versionInfo |
   reference := GoferVersionReference name: 'Issue399-Core-dkh.2'.
   className := #'Issue399Sample'.
-  definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: reference packageName asSymbol)).
+  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
   (MCClassDefinition
     name: className
     superclassName: #'Object'
@@ -2995,8 +2978,7 @@ MetacelloScriptingResource >> setUpLockConfigurations [
   reference := GoferVersionReference
     name: 'ConfigurationOfLockConfigurations-dkh.1'.
   className := #'ConfigurationOfLockConfigurations'.
-  definitionArray := {(MCOrganizationDefinition
-    categories: (Array with: reference packageName asSymbol)).
+  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
   (MCClassDefinition
     name: className
     superclassName: #'ConfigurationOf'
@@ -3080,7 +3062,7 @@ MetacelloScriptingResource >> setUpMarianosImage [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'MarianosImage-dkh.1'.
     className := #'MarianosImage'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'ConfigurationOf'
@@ -3135,7 +3117,7 @@ MetacelloScriptingResource >> setUpSampleCore [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'Sample-CoreX-dkh.1'.
     className := #'SampleCoreX'.
-    definitionArray := {(MCOrganizationDefinition categories: (Array with: reference packageName asSymbol)).
+    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
     (MCClassDefinition
         name: className
         superclassName: #'Object'

--- a/src/Monticello-Tests/MCOrganizationTest.class.st
+++ b/src/Monticello-Tests/MCOrganizationTest.class.st
@@ -7,11 +7,11 @@ Class {
 { #category : #tests }
 MCOrganizationTest >> testLoadAndUnload [
 
-	| category |
-	category := 'TestPackageToUnload'.
-	self packageOrganizer addCategory: category.
-	(MCOrganizationDefinition categories: { category }) unload.
-	self deny: (self packageOrganizer includesCategory: category)
+	| packageName |
+	packageName := 'TestPackageToUnload'.
+	self packageOrganizer addCategory: packageName.
+	(MCOrganizationDefinition packageName: packageName) unload.
+	self deny: (self packageOrganizer includesCategory: packageName)
 ]
 
 { #category : #tests }

--- a/src/Monticello-Tests/MCStWriterTest.class.st
+++ b/src/Monticello-Tests/MCStWriterTest.class.st
@@ -262,10 +262,10 @@ MCStWriterTest >> testNotLoadedClassMethod [
 
 { #category : #testing }
 MCStWriterTest >> testOrganizationDefinition [
+
 	| definition |
-	definition := MCOrganizationDefinition categories: 
-					(self mockPackage packageSet systemCategories).
+	definition := MCOrganizationDefinition categories: self mockPackage packageSet systemCategories.
 	writer visitOrganizationDefinition: definition.
 	self assertContentsOf: stream match: self expectedOrganizationDefinition.
-	self assertAllChunksAreWellFormed.
+	self assertAllChunksAreWellFormed
 ]

--- a/src/Monticello/MCOrganizationDefinition.class.st
+++ b/src/Monticello/MCOrganizationDefinition.class.st
@@ -5,7 +5,9 @@ Class {
 	#name : #MCOrganizationDefinition,
 	#superclass : #MCDefinition,
 	#instVars : [
-		'categories'
+		'categories',
+		'packageName',
+		'tagNames'
 	],
 	#category : #'Monticello-Modeling'
 }
@@ -13,6 +15,23 @@ Class {
 { #category : #'instance creation' }
 MCOrganizationDefinition class >> categories: aCollection [
 	^ self new categories: aCollection
+]
+
+{ #category : #'instance creation' }
+MCOrganizationDefinition class >> packageName: aPackageName [
+
+	^ self new
+		  packageName: aPackageName;
+		  yourself
+]
+
+{ #category : #'instance creation' }
+MCOrganizationDefinition class >> packageName: aPackageName tagNames: aCollection [
+
+	^ self new
+		  packageName: aPackageName;
+		  tagNames: aCollection;
+		  yourself
 ]
 
 { #category : #comparing }
@@ -46,12 +65,14 @@ MCOrganizationDefinition >> basicCommonPrefix [
 
 { #category : #accessing }
 MCOrganizationDefinition >> categories [
-	^ categories
+
+	^ categories ifNil: [ { self packageName } , self tagNames collect: [ :tagName | self packageName , '-' , tagName ] ]
 ]
 
-{ #category : #accessing }
+{ #category : #deprecated }
 MCOrganizationDefinition >> categories: aCollection [
-	"ensure the categories are sorted alphabetically, so the merge don't take it as a conflict"
+	"Do not use. This methods should be replaced by #packageName and #tagNames"
+
 	categories := aCollection sorted asArray
 ]
 
@@ -102,6 +123,18 @@ MCOrganizationDefinition >> isOrganizationDefinition [
 	^ true
 ]
 
+{ #category : #accessing }
+MCOrganizationDefinition >> packageName [
+
+	^ packageName
+]
+
+{ #category : #accessing }
+MCOrganizationDefinition >> packageName: anObject [
+
+	packageName := anObject
+]
+
 { #category : #installing }
 MCOrganizationDefinition >> postloadOver: oldDefinition [
 	"Nothing to do"
@@ -139,6 +172,19 @@ MCOrganizationDefinition >> source [
 MCOrganizationDefinition >> summary [
 
 	^ self categories asArray printString
+]
+
+{ #category : #accessing }
+MCOrganizationDefinition >> tagNames [
+
+	^ tagNames
+]
+
+{ #category : #accessing }
+MCOrganizationDefinition >> tagNames: aCollection [
+	"ensure the tags are sorted alphabetically, so the merge don't take it as a conflict"
+
+	tagNames := aCollection sorted asArray
 ]
 
 { #category : #unloading }

--- a/src/Monticello/MCOrganizationDefinition.class.st
+++ b/src/Monticello/MCOrganizationDefinition.class.st
@@ -65,7 +65,7 @@ MCOrganizationDefinition >> basicCommonPrefix [
 { #category : #accessing }
 MCOrganizationDefinition >> categories [
 
-	^ categories ifNil: [ { self packageName } , self tagNames collect: [ :tagName | self packageName , '-' , tagName ] ]
+	^ categories ifNil: [ { self packageName } , (self tagNames collect: [ :tagName | self packageName , '-' , tagName ]) ]
 ]
 
 { #category : #deprecated }

--- a/src/Monticello/MCOrganizationDefinition.class.st
+++ b/src/Monticello/MCOrganizationDefinition.class.st
@@ -21,15 +21,14 @@ MCOrganizationDefinition class >> categories: aCollection [
 MCOrganizationDefinition class >> packageName: aPackageName [
 
 	^ self new
-		  packageName: aPackageName;
+		  packageName: aPackageName asSymbol;
 		  yourself
 ]
 
 { #category : #'instance creation' }
 MCOrganizationDefinition class >> packageName: aPackageName tagNames: aCollection [
 
-	^ self new
-		  packageName: aPackageName;
+	^ (self packageName: aPackageName)
 		  tagNames: aCollection;
 		  yourself
 ]
@@ -116,6 +115,12 @@ MCOrganizationDefinition >> hash [
 	^ (self species hash 
 		bitXor: super hash)
 		bitXor: self categories hash
+]
+
+{ #category : #initialization }
+MCOrganizationDefinition >> initialize [
+	super initialize.
+	tagNames := #()
 ]
 
 { #category : #testing }

--- a/src/Monticello/MCOrganizationDefinition.class.st
+++ b/src/Monticello/MCOrganizationDefinition.class.st
@@ -32,11 +32,11 @@ MCOrganizationDefinition >> basicCommonPrefix [
 	"Answers the minimum common denominator on package names contained in the monticello package. 
 	 It can answer a package in the form X-Y-, with a minus at end..."
 	| stream  |
-	categories isEmpty ifTrue: [ ^ '' ].
+	self categories ifEmpty: [ ^ '' ].
 	
 	stream := String new writeStream.
-	categories first withIndexDo: [:c :index |
-		categories do: [:each |
+	self categories first withIndexDo: [:c :index |
+		self categories do: [:each |
 			(each at: index ifAbsent: []) = c 
 				ifFalse: [ ^ stream contents ] ].
 		stream nextPut: c ].
@@ -111,14 +111,11 @@ MCOrganizationDefinition >> postloadOver: oldDefinition [
 MCOrganizationDefinition >> reorderCategories: allCategories original: oldCategories [
 
 	^ allCategories
-		detect: [ :ea | categories includes: ea ]
-		ifFound: [ :first | 
-			((allCategories copyUpTo: first)
-				copyWithoutAll: oldCategories , categories) , categories
-				,
-					((allCategories copyAfter: first)
-						copyWithoutAll: oldCategories , categories) ]
-		ifNone: [ allCategories ]
+		  detect: [ :ea | self categories includes: ea ]
+		  ifFound: [ :first |
+			  ((allCategories copyUpTo: first) copyWithoutAll: oldCategories , self categories) , self categories
+			  , ((allCategories copyAfter: first) copyWithoutAll: oldCategories , self categories) ]
+		  ifNone: [ allCategories ]
 ]
 
 { #category : #accessing }
@@ -134,18 +131,18 @@ MCOrganizationDefinition >> sortKey [
 
 { #category : #accessing }
 MCOrganizationDefinition >> source [
-	^ String streamContents:
-		[:s |
-		categories do: [:ea | s nextPutAll: ea] separatedBy: [s cr]]
+
+	^ String streamContents: [ :s | self categories do: [ :ea | s nextPutAll: ea ] separatedBy: [ s cr ] ]
 ]
 
 { #category : #accessing }
 MCOrganizationDefinition >> summary [
-	^ categories asArray printString
+
+	^ self categories asArray printString
 ]
 
 { #category : #unloading }
 MCOrganizationDefinition >> unload [
 
-	categories do: [ :category | (self packageOrganizer isEmptyCategoryNamed: category) ifTrue: [ self packageOrganizer removeCategory: category ] ]
+	self categories do: [ :category | (self packageOrganizer isEmptyCategoryNamed: category) ifTrue: [ self packageOrganizer removeCategory: category ] ]
 ]

--- a/src/Monticello/MCPackage.class.st
+++ b/src/Monticello/MCPackage.class.st
@@ -93,23 +93,17 @@ MCPackage >> printOn: aStream [
 
 { #category : #accessing }
 MCPackage >> snapshot [
-	| rPackageSet definitions categories |
+
+	| rPackageSet definitions |
 	rPackageSet := self packageSet.
 	definitions := OrderedCollection new.
-	categories := rPackageSet categoryNames asArray.
-	categories isEmpty 
-		ifFalse: [ definitions add: (MCOrganizationDefinition categories: categories) ].
-		
-	rPackageSet methods 
-		do: [:ea | definitions add: ea asMCMethodDefinition] 
-		displayingProgress: [ :ea| 'Snapshotting methods...' ].
-				
-	rPackageSet definedClasses 
-		do: [:ea | definitions addAll: ea classDefinitions] 
-		displayingProgress: [ :ea| 'Snapshotting class ', ea asString ].
-		
-	^ MCSnapshot fromDefinitions: definitions
+	rPackageSet categoryNames asArray ifNotEmpty: [ :categories | definitions add: (MCOrganizationDefinition categories: categories) ].
 
+	rPackageSet methods do: [ :ea | definitions add: ea asMCMethodDefinition ] displayingProgress: [ :ea | 'Snapshotting methods...' ].
+
+	rPackageSet definedClasses do: [ :ea | definitions addAll: ea classDefinitions ] displayingProgress: [ :ea | 'Snapshotting class ' , ea asString ].
+
+	^ MCSnapshot fromDefinitions: definitions
 ]
 
 { #category : #printing }

--- a/src/Monticello/MCStReader.class.st
+++ b/src/Monticello/MCStReader.class.st
@@ -126,11 +126,12 @@ MCStReader >> readStream [
 
 { #category : #reading }
 MCStReader >> systemOrganizationFromRecords: changeRecords [
+
 	| categories |
 	categories := changeRecords
-					select: [:ea | 'SystemOrganization*' match: ea string]
-					thenCollect: [:ea | (self categoryFromDoIt: ea string)].
-	^ categories isEmpty ifFalse: [MCOrganizationDefinition categories: categories asArray]
+		              select: [ :ea | 'SystemOrganization*' match: ea string ]
+		              thenCollect: [ :ea | self categoryFromDoIt: ea string ].
+	^ categories ifNotEmpty: [ MCOrganizationDefinition categories: categories asArray ]
 ]
 
 { #category : #reading }

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
@@ -230,22 +230,26 @@ MCFileTreeStCypressReader >> isPropertyFile: entry [
 
 { #category : #utilities }
 MCFileTreeStCypressReader >> loadDefinitions [
-    | entries directory |
-    definitions := OrderedCollection new.
-    directory := self fileUtils directoryFromPath: self monticelloMetaDirName relativeTo: packageDirectory.
-    (self fileUtils directoryExists: directory)
-        ifTrue: [ 
-            		entries := directory entries.
-            		self
-                			addDefinitionFromFile: (entries detect: [ :entry | entry name beginsWith: 'categories' ] ifNone: [  ])
-                			inDirectory: directory ]
-	ifFalse: [definitions add: (MCOrganizationDefinition categories: {self packageNameFromPackageDirectory }) ].
-    self addClassAndMethodDefinitionsFromDirectory: packageDirectory.
-    (self fileUtils directoryExists: directory)
-        ifTrue: [ 
-            self
-                addDefinitionFromFile: (entries detect: [ :entry | entry name beginsWith: 'initializers' ] ifNone: [  ])
-                inDirectory: directory ]
+
+	| entries directory |
+	definitions := OrderedCollection new.
+	directory := self fileUtils directoryFromPath: self monticelloMetaDirName relativeTo: packageDirectory.
+	(self fileUtils directoryExists: directory)
+		ifTrue: [
+			entries := directory entries.
+			self
+				addDefinitionFromFile: (entries
+						 detect: [ :entry | entry name beginsWith: 'categories' ]
+						 ifNone: [  ])
+				inDirectory: directory ]
+		ifFalse: [ definitions add: (MCOrganizationDefinition packageName: self packageNameFromPackageDirectory) ].
+	self addClassAndMethodDefinitionsFromDirectory: packageDirectory.
+	(self fileUtils directoryExists: directory) ifTrue: [
+		self
+			addDefinitionFromFile: (entries
+					 detect: [ :entry | entry name beginsWith: 'initializers' ]
+					 ifNone: [  ])
+			inDirectory: directory ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
MCOrganizationDefinition is the Monticello class used to describe packages and tags. 

Currently this class is based on 'categories'. This change adds an alternative that is to give a package name and tags.

Those are used to return the categories afterward so there should be no change in behavior, but it is a first step to use packages and tags instead. 

I started to replace some places using the categories to use the packages names and tag names. In future PR I'll use even more this new API but this will also need to update Tonel and Iceberg.