### PR TITLE
RPackage: Simplify actions of method modifications

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -1096,31 +1096,3 @@ RPackage >> unregisterClass: aClass [
 
 	self organizer unregisterPackage: self forClass: aClass
 ]
-
-{ #category : #updating }
-RPackage >> updateDefinedSelector: oldSelector inClass: aClass withNewSelector: newSelector [
-
-	(definedSelectors at: aClass)
-		remove: oldSelector;
-		add: newSelector
-]
-
-{ #category : #updating }
-RPackage >> updateExtensionSelector: oldSelector inClass: aClass withNewSelector: newSelector [
-
-	(extensionSelectors at: aClass)
-		remove: oldSelector;
-		add: newSelector
-]
-
-{ #category : #updating }
-RPackage >> updateSelector: oldSelector inClass: aClass withNewSelector: newSelector [
-
-	"here we check if the old seletor is defined in the package or if it is an extension. Then we dispatch the work to the corresponding method.
-	For one specific class, a selector is either a defined selector or an extension selector, there is no way to have a couple of class->selector present in both dictionary"
-
-	(self includesDefinedSelector: oldSelector ofClass: aClass)
-		ifTrue: [^ self updateDefinedSelector: oldSelector inClass: aClass  withNewSelector: newSelector].
-	(self includesExtensionSelector: oldSelector ofClass: aClass)
-		ifTrue: [^ self updateExtensionSelector: oldSelector inClass: aClass  withNewSelector: newSelector]
-]

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -150,6 +150,7 @@ RPackageOrganizer class >> methodAdded: anEvent [
 { #category : #'class initialization' }
 RPackageOrganizer class >> registerInterestToSystemAnnouncement [
 
+	<script>
 	self packageOrganizer unregisterInterestToSystemAnnouncement.
 	"To make sure that we do not have it twice registered"
 	self packageOrganizer registerInterestToSystemAnnouncement
@@ -603,7 +604,6 @@ RPackageOrganizer >> registerInterestToAnnouncer: anAnnouncer [
 		when: ClassRecategorized send: #systemClassRecategorizedActionFrom: to: self;
 		when: ProtocolAnnouncement send: #systemClassReorganizedActionFrom: to: self;
 		when: MethodAdded send: #systemMethodAddedActionFrom: to: self;
-		when: MethodModified send: #systemMethodModifiedActionFrom: to: self;
 		when: MethodRecategorized send: #systemMethodRecategorizedActionFrom: to: self
 ]
 
@@ -852,39 +852,6 @@ RPackageOrganizer >> systemMethodAddedActionFrom: ann [
 	method origin = ann methodClass ifFalse: [ ^ self ].
 
 	self addMethod: method
-]
-
-{ #category : #'system integration' }
-RPackageOrganizer >> systemMethodModifiedActionFrom: ann [
-	"this announcement can correspond to several kind of modifications:
-		=> a method has been renamed
-		=> a method has been move to another category // SHOULD BE TREATED WITH SystemMethodRecategorizedEvent
-		(
-			-maybe from the classic category to an extending package
-			-maybe from an extending package to another extending package
-			-maybe from an extending package to a classic category
-			- maybe from a classic category to another classic category
-			)
-	"
-
-	| oldMethod newMethod methodPackage |
-	newMethod := ann newMethod.
-	oldMethod := ann oldMethod.
-	self flag: #cyrille.
-	"This is not clear that we need to do soemthing here since the method is removed and added so the other events should be handled correctly
-	We should remove this method to see if this is working."
-
-	"If the method origin is not the one of the event, we do not care about that method"
-	newMethod origin = ann methodClass ifFalse: [ ^ self ].
-
-
-	"Special case for trait methods added an override"
-	newMethod origin = oldMethod origin ifFalse: [ ^ self addMethod: newMethod ].
-
-	methodPackage := newMethod package.
-	"maybe the name of the method has changed"
-	oldMethod selector = newMethod selector ifFalse: [
-		methodPackage updateSelector: oldMethod selector inClass: oldMethod methodClass withNewSelector: newMethod selector ]
 ]
 
 { #category : #'system integration' }


### PR DESCRIPTION
RPackage is acting on the modification of methods, but each actions requiering an update about methods already has another way to deal with it.

I propose to just remove all the code about it to simplify further RPackage.