### PR TITLE
RPackage: Deprecate RPackageOrganizer>>#globalPackageOf:

### DIFF
--- a/src/Deprecated12/RPackageOrganizer.extension.st
+++ b/src/Deprecated12/RPackageOrganizer.extension.st
@@ -15,6 +15,21 @@ RPackageOrganizer >> ensureExistAndRegisterPackageNamed: aSymbol [
 ]
 
 { #category : #'*Deprecated12' }
+RPackageOrganizer >> globalPackageOf: aClass [
+	"this method should return the 'global' parent package of aClass, that means the package holding the (possible) subcategory in which aClass is concretely defined. For example, 'Object package' returns Kernel-Object, whereas 'PackageOrganizer packageOf: Object' returns Kernel. So I guess that all use of 'packageOf' should be replaced by this method  "
+
+	"RPackageOrganizer default globalPackageOf: Object"
+
+	| classPackage |
+	self deprecated:
+		'This method will be removed in the future version of Pharo because the implementation does not seems to match the method comment and the usecases needing this method are too few.'.
+	classPackage := self packageOf: aClass.
+	^ self packages
+		  detect: [ :aRPackage | aRPackage ~= classPackage and: [ aRPackage systemCategories includes: classPackage name ] ]
+		  ifNone: [ classPackage ]
+]
+
+{ #category : #'*Deprecated12' }
 RPackageOrganizer >> includesPackage: aPackage [
 
 	self deprecated: 'Use #hasPackage: instead.' transformWith: '`@rcv includesPackage: `@arg' -> '`@rcv hasPackage: `@arg'.

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -362,19 +362,6 @@ RPackageOrganizer >> extendingPackagesOf: aClass [
 	^ classExtendingPackagesMapping at: aClass instanceSide ifAbsent: [ #(  ) ]
 ]
 
-{ #category : #'package - access from class' }
-RPackageOrganizer >> globalPackageOf: aClass [
-	"this method should return the 'global' parent package of aClass, that means the package holding the (possible) subcategory in which aClass is concretely defined. For example, 'Object package' returns Kernel-Object, whereas 'PackageOrganizer packageOf: Object' returns Kernel. So I guess that all use of 'packageOf' should be replaced by this method  "
-
-	"RPackageOrganizer default globalPackageOf: Object"
-
-	| classPackage |
-	classPackage := self packageOf: aClass.
-	^ self packages
-		detect: [ :aRPackage | aRPackage ~= classPackage and: [ aRPackage systemCategories includes: classPackage name ] ]
-		ifNone: [ classPackage ]
-]
-
 { #category : #testing }
 RPackageOrganizer >> hasPackage: aPackage [
 	"Takes a package or a package name as parameter and return true if I include this package."


### PR DESCRIPTION
This method does not do what it says it does and is not used nor useful. I propose to deprecate it