### PR TITLE
RPackage:  Remove #systemCategories

### DIFF
--- a/src/Deprecated12/RPackageOrganizer.extension.st
+++ b/src/Deprecated12/RPackageOrganizer.extension.st
@@ -15,6 +15,14 @@ RPackageOrganizer >> ensureExistAndRegisterPackageNamed: aSymbol [
 ]
 
 { #category : #'*Deprecated12' }
+RPackageOrganizer >> globalPackageOf: aClass [
+
+	self deprecated:
+		'This method will be removed in the future version of Pharo because the implementation does not seems to match the old method comment and the usecases needing this method are too few.'.
+	^ self packageOf: aClass
+]
+
+{ #category : #'*Deprecated12' }
 RPackageOrganizer >> includesPackage: aPackage [
 
 	self deprecated: 'Use #hasPackage: instead.' transformWith: '`@rcv includesPackage: `@arg' -> '`@rcv hasPackage: `@arg'.

--- a/src/Monticello-Tests/MCStWriterTest.class.st
+++ b/src/Monticello-Tests/MCStWriterTest.class.st
@@ -264,7 +264,7 @@ MCStWriterTest >> testNotLoadedClassMethod [
 MCStWriterTest >> testOrganizationDefinition [
 
 	| definition |
-	definition := MCOrganizationDefinition categories: self mockPackage packageSet systemCategories.
+	definition := MCOrganizationDefinition categories: { self mockPackage name asSymbol }.
 	writer visitOrganizationDefinition: definition.
 	self assertContentsOf: stream match: self expectedOrganizationDefinition.
 	self assertAllChunksAreWellFormed

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -1033,12 +1033,6 @@ RPackage >> selectorsForClass: aClass [
 ]
 
 { #category : #'system compatibility' }
-RPackage >> systemCategories [
-
-	^ self organizer categories select: [:cat | self includesSystemCategory: cat]
-]
-
-{ #category : #'system compatibility' }
 RPackage >> systemCategoryPrefix [
 	^ self name
 ]

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -368,11 +368,7 @@ RPackageOrganizer >> globalPackageOf: aClass [
 
 	"RPackageOrganizer default globalPackageOf: Object"
 
-	| classPackage |
-	classPackage := self packageOf: aClass.
-	^ self packages
-		detect: [ :aRPackage | aRPackage ~= classPackage and: [ aRPackage systemCategories includes: classPackage name ] ]
-		ifNone: [ classPackage ]
+	^ self packageOf: aClass
 ]
 
 { #category : #testing }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -362,15 +362,6 @@ RPackageOrganizer >> extendingPackagesOf: aClass [
 	^ classExtendingPackagesMapping at: aClass instanceSide ifAbsent: [ #(  ) ]
 ]
 
-{ #category : #'package - access from class' }
-RPackageOrganizer >> globalPackageOf: aClass [
-	"this method should return the 'global' parent package of aClass, that means the package holding the (possible) subcategory in which aClass is concretely defined. For example, 'Object package' returns Kernel-Object, whereas 'PackageOrganizer packageOf: Object' returns Kernel. So I guess that all use of 'packageOf' should be replaced by this method  "
-
-	"RPackageOrganizer default globalPackageOf: Object"
-
-	^ self packageOf: aClass
-]
-
 { #category : #testing }
 RPackageOrganizer >> hasPackage: aPackage [
 	"Takes a package or a package name as parameter and return true if I include this package."

--- a/src/RPackage-Core/RPackageSet.class.st
+++ b/src/RPackage-Core/RPackageSet.class.st
@@ -12,8 +12,7 @@ Class {
 		'classes',
 		'definedClasses',
 		'extensionMethods',
-		'methods',
-		'systemCategories'
+		'methods'
 	],
 	#classInstVars : [
 		'cacheActive',
@@ -197,11 +196,6 @@ RPackageSet >> packageName [
 { #category : #accessing }
 RPackageSet >> packages [
 	^packages
-]
-
-{ #category : #'system compatibility' }
-RPackageSet >> systemCategories [
-	^ systemCategories ifNil: [ systemCategories := (self packages flatCollect: #systemCategories as: Set) asArray ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This change removes the last users of #systemCategories and the two methods (RPackage and RPackageSet)

Also deprecate RPackageOrganizer>>#globalPackageOf:. This method does not do what it says it does and is not used nor useful. I propose to deprecate it