### PR TITLE
RPackage: Try to fix CI failure

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -485,12 +485,21 @@ RPackage >> importClass: aClass inTag: aTag [
 	classes add: aClass instanceSide.
 	self registerClass: aClass.
 
-	{ aClass . aClass classSide } do: [ :class |
-		(class protocols select: [ :protocol | self isYourClassExtension: protocol ]) do: [ :protocol | class renameProtocol: protocol as: Protocol unclassified ].
+	{
+		aClass.
+		aClass classSide } do: [ :class |
+		(class protocols select: [ :protocol |
+			 self flag: #package. "The next line should be factorize and other senders or #isYourClassExtension: should be updated because they are wrong."
+			 (self organizer hasPackageForProtocol: protocol name) and: [ (self organizer packageMatchingExtensionName: protocol name) = self ] ]) do: [ :protocol |
+			class renameProtocol: protocol as: Protocol unclassified ].
 
-		class protocols reject: [ :protocol | protocol isExtensionProtocol ] thenDo: [ :protocol | self importProtocol: protocol forClass: class ] ].
-	
-	(self addClassTag: (aTag isString ifTrue: [ aTag ] ifFalse: [ aTag name ])) addClass: aClass
+		class protocols
+			reject: [ :protocol | protocol isExtensionProtocol ]
+			thenDo: [ :protocol | self importProtocol: protocol forClass: class ] ].
+
+	(self addClassTag: (aTag isString
+			  ifTrue: [ aTag ]
+			  ifFalse: [ aTag name ])) addClass: aClass
 ]
 
 { #category : #private }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -490,7 +490,7 @@ RPackage >> importClass: aClass inTag: aTag [
 		aClass classSide } do: [ :class |
 		(class protocols select: [ :protocol |
 			 self flag: #package. "The next line should be factorize and other senders or #isYourClassExtension: should be updated because they are wrong."
-			 (self organizer hasPackageForProtocol: protocol name) and: [ (self organizer packageMatchingExtensionName: protocol name) = self ] ]) do: [ :protocol |
+			 (self organizer hasPackageForProtocol: protocol name) and: [ (self organizer packageMatchingExtensionName: protocol name allButFirst) = self ] ]) do: [ :protocol |
 			class renameProtocol: protocol as: Protocol unclassified ].
 
 		class protocols


### PR DESCRIPTION
We recently had some CI failure during the bootstrap about an extension method missing and I think I found the origin (but I am not sure).

Here is what I think is happening:

During the bootstrap, there is a step where we tell RPackage to reimport everything to be sure the state is good. I recently updated this part of the system to use the right API of RPackage and not duplicate everything with slight changes.

If I am right, we import at some point Kernel package with the tag Kernel-Chronology.  During this import, we:
- Import the classes contained by the package
- Remove all the caches about mehtods
- Check the protocols of the imported classes and if a protocol matched the packages, the protocol is renamed into 'as yet unclassified' since it is not an extension anymore
- We reimport all the methods

My guess is that during phase 3, the way to match the protocol and the package is wrong because it is based on a simple string manipulation of the category. And then it thinks that Kernel-Chronology-Extra is an extension of Kernel, but no! There is a Kernel-Chronology-Extra package. And because of that, the protocol is transformed from an extension protocol to a classic protocol. And then when the next package is loaded and the step "remove all the methods from the caches", those methods are lost.

I am not sure this is exaclty what happens but it is worth to fix the problem with the matching of the protocols. 

This problem happens in multiple other places and if this fix works, I'll have to clean those to.

Fixes #14527 (I hope.. Not too sure)