### PR TITLE
Update Calypso after removal of a new package.

### DIFF
--- a/src/Calypso-Browser-Tests/ClyBrowserToolValidityTest.class.st
+++ b/src/Calypso-Browser-Tests/ClyBrowserToolValidityTest.class.st
@@ -15,6 +15,20 @@ ClyBrowserToolValidityTest >> isValidInContextOtherThan: someContexts [
 		anySatisfy: [ :ctx | tool isValidInContext: ctx ]
 ]
 
+{ #category : #accessing }
+ClyBrowserToolValidityTest >> mockPackage [
+
+	^ [ RPackageOrganizer default createPackageNamed: self mockPackageName ]
+		on: RPackageConflictError 
+		do: [ : ex |  RPackageOrganizer default packageNamed: self mockPackageName ]
+]
+
+{ #category : #accessing }
+ClyBrowserToolValidityTest >> mockPackageName [
+
+	^ 'MockPackageForTestingCalypso'.
+]
+
 { #category : #tests }
 ClyBrowserToolValidityTest >> testClassCommentToolIsNotValidWhenNotAClassContext [
 
@@ -184,6 +198,19 @@ ClyBrowserToolValidityTest >> testPackageCommmentToolIsValidWhenPackageContext [
 ]
 
 { #category : #tests }
+ClyBrowserToolValidityTest >> testPackageSelectionAfterPackageCreation [
+
+	self deleteBrowser.
+	browser := ClyFullBrowserMorph openOnPackage: self mockPackage.
+	tool := self findBrowserTool: ClyClassCreationToolMorph.
+	
+	self 
+		assertCollection: (self packageContext selectedPackageItems collect: #name)
+		equals: (Array with: self mockPackageName).
+
+]
+
+{ #category : #tests }
 ClyBrowserToolValidityTest >> testSetUpToolIsNotValidWhenNotAClassContext [
 
 	tool := self findBrowserTool: ClyTestSetUpEditorToolMorph.
@@ -208,4 +235,44 @@ ClyBrowserToolValidityTest >> testSetUpToolIsValidWhenReferencingSameClass [
 	tool := self findBrowserTool: ClyTestSetUpEditorToolMorph.
 	
 	self assert: (tool isValidInContext: self classContext).
+]
+
+{ #category : #tests }
+ClyBrowserToolValidityTest >> testWindowLabelIsUpdatedAfterPackageRemoval [
+
+	| realPackage command activator cmdContext |
+	
+	self deleteBrowser.
+	browser := ClyFullBrowserMorph openOnPackage: self mockPackage.
+	tool := self findBrowserTool: ClyClassCreationToolMorph.
+	
+	realPackage := self packageContext selectedPackageItems anyOne actualObject.
+	
+	command := SycRemovePackageCommand new
+		packages: { realPackage };
+		yourself.
+	cmdContext := browser createCommandContext. 
+
+	activator := CmdCommandActivator new 
+		command: command;
+		context: cmdContext;
+		yourself.
+
+	cmdContext executeCommand: command by: activator.
+	activator applyCommandResult.
+	self 
+		assert: browser window label 
+		equals: 'Current image'
+]
+
+{ #category : #tests }
+ClyBrowserToolValidityTest >> testWindowLabelSetAfterPackageCreation [
+
+	self deleteBrowser.
+	browser := ClyFullBrowserMorph openOnPackage: self mockPackage.
+	tool := self findBrowserTool: ClyClassCreationToolMorph.
+	
+	self 
+		assert: browser window label 
+		equals: self mockPackageName
 ]

--- a/src/Calypso-SystemTools-Core/ClyClassCreationToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassCreationToolMorph.class.st
@@ -145,6 +145,17 @@ ClyClassCreationToolMorph >> printContext [
 ]
 
 { #category : #initialization }
+ClyClassCreationToolMorph >> resetStateForRemoval [
+	" A package was removed from the receiver's browser, update the receiver's text "
+
+	self package: nil.
+	textModel setInitialText: self classTemplate.
+	textMorph hasEditingConflicts: false.
+	textMorph changed.
+
+]
+
+{ #category : #initialization }
 ClyClassCreationToolMorph >> setUpModelFromContext [
 	super setUpModelFromContext.
 

--- a/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserMorph.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserMorph.class.st
@@ -871,3 +871,12 @@ ClyFullBrowserMorph >> updateDefaultPackageFilter [
 
 	DefaultPackageFilter := packageView filterField getText ifEmpty: [ nil ]
 ]
+
+{ #category : #updating }
+ClyFullBrowserMorph >> updateMethodEditorAfterPackageRemoval [
+	"A package was removed from the receiver, update the method editor accordingly"
+	
+	self tabManager tools
+		detect: [ :aTool | aTool class = ClyClassCreationToolMorph ]
+		ifFound: [ : methodEditor | methodEditor resetStateForRemoval ].
+]

--- a/src/SystemCommands-PackageCommands-Tests/SycRemoveNewPackageCommandTest.class.st
+++ b/src/SystemCommands-PackageCommands-Tests/SycRemoveNewPackageCommandTest.class.st
@@ -1,0 +1,48 @@
+Class {
+	#name : #SycRemoveNewPackageCommandTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'mockPackage'
+	],
+	#category : #'SystemCommands-PackageCommands-Tests'
+}
+
+{ #category : #accessing }
+SycRemoveNewPackageCommandTest >> mockPackage [
+
+	^ mockPackage
+]
+
+{ #category : #accessing }
+SycRemoveNewPackageCommandTest >> mockPackage: anObject [
+
+	mockPackage := anObject
+]
+
+{ #category : #running }
+SycRemoveNewPackageCommandTest >> packageNameForTesting [
+
+	^ 'Test-Package'
+]
+
+{ #category : #running }
+SycRemoveNewPackageCommandTest >> setUp [
+
+	super setUp.
+	mockPackage := MockObject new on: #removeFromSystem
+
+]
+
+{ #category : #tests }
+SycRemoveNewPackageCommandTest >> testExecute [
+
+	| command |
+
+	command := SycRemovePackageCommand new
+		packages: { mockPackage };
+		execute.
+
+	self assert: command packages isEmpty.
+	self verify: mockPackage
+
+]

--- a/src/SystemCommands-PackageCommands/SycRemovePackageCommand.class.st
+++ b/src/SystemCommands-PackageCommands/SycRemovePackageCommand.class.st
@@ -12,6 +12,22 @@ SycRemovePackageCommand class >> defaultMenuIconName [
 	^ #delete
 ]
 
+{ #category : #execution }
+SycRemovePackageCommand >> applyResultInContext: aToolContext [
+	"Update the browser's title and method editor  after removal of a package"
+
+	| browserTool |
+	
+	super applyResultInContext: aToolContext.
+
+	browserTool := aToolContext tool.
+	aToolContext tool navigationEnvironment: ClyNavigationEnvironment currentImage.
+	browserTool 
+		updateWindowTitle;
+		updateMethodEditorAfterPackageRemoval.
+	
+]
+
 { #category : #accessing }
 SycRemovePackageCommand >> defaultMenuIconName [
 	^#removeIcon
@@ -25,7 +41,8 @@ SycRemovePackageCommand >> defaultMenuItemName [
 { #category : #execution }
 SycRemovePackageCommand >> execute [
 
-	packages do: [ :each | each removeFromSystem ]
+	self packages do: [ :each | each removeFromSystem ].
+	self packages: OrderedCollection new.
 ]
 
 { #category : #execution }


### PR DESCRIPTION
It fixes issue #14526. This involves after a removal of a package:

- Updating the browser window label.
- Restore the class template definition to a clean state, where there is no reference to the removed package.

Add tests simulating the package removal behavior.