### PR TITLE
Speedup key combination for all items selection in Test Runner

### DIFF
--- a/src/SUnit-UI/TestRunner.class.st
+++ b/src/SUnit-UI/TestRunner.class.st
@@ -194,6 +194,7 @@ TestRunner >> buildClasses [
 		changeListSelection: #classAt:put:
 		menu: #classMenu:
 		keystroke: nil;
+		bindKeyCombination: PharoShortcuts current selectAllShortcut toAction: [ self selectAllUnitTests ];
 		yourself
 ]
 
@@ -254,6 +255,7 @@ TestRunner >> buildPackages [
 		changeListSelection: #packageAt:put:
 		menu: #packageMenu:
 		keystroke: nil;
+		bindKeyCombination: PharoShortcuts current selectAllShortcut toAction: [ self selectAllPackages ];
 		yourself
 ]
 


### PR DESCRIPTION
This PR fix the slow selection time in the Test Runner window, when pressing CMD+A key combination to select all test packages or test classes, as reported in #11236.

It add a key binding combination to the PluggableListMorph, which performs the same action as in the "Select all" menu option, for both packages and test unit classes.
