### PR TITLE
RPackage: Clean package tag API

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -210,11 +210,11 @@ RPackage >> addMethod: aCompiledMethod [
 
 { #category : #private }
 RPackage >> basicAddClassTag: tagName [
-	| packageTag |
 
+	| packageTag |
 	packageTag := RPackageTag package: self name: tagName.
 	classTags add: packageTag.
-	packageTag ensureSystemCategory.
+	self organizer addCategory: packageTag categoryName.
 
 	^ packageTag
 ]
@@ -700,15 +700,6 @@ RPackage >> name: aSymbol [
 	"Set the name of a package. This method is private and should not be used.
 	If you wish to rename a package, use #renameTo: instead"
 	name := aSymbol asSymbol
-]
-
-{ #category : #accessing }
-RPackage >> orderedClasses [
-
-	| tmp |
-	tmp := self definedClasses asArray sort: [:a :b | a name <= b name].
-	tmp := tmp, (self extendedClasses asArray sort: [:a :b | a name <= b name]).
-	^tmp collect: [:e | e instanceSide ]
 ]
 
 { #category : #private }

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -14,15 +14,12 @@ Class {
 }
 
 { #category : #'instance creation' }
-RPackageTag class >> new [
-	self error: 'Use #package:name:'
-]
-
-{ #category : #'instance creation' }
 RPackageTag class >> package: aPackage name: aString [
-	^ self basicNew
-		initializePackage: aPackage name: aString;
-		yourself
+
+	^ self new
+		  package: aPackage;
+		  name: aString;
+		  yourself
 ]
 
 { #category : #accessing }
@@ -57,41 +54,15 @@ RPackageTag >> classes [
 ]
 
 { #category : #accessing }
-RPackageTag >> ensureSystemCategory [
-	"We should not hardcode the global variable but ask the package organizer for the organization."
-
-	self organizer addCategory: self categoryName
-]
-
-{ #category : #accessing }
 RPackageTag >> environment [
 
 	^ self package environment
 ]
 
-{ #category : #accessing }
-RPackageTag >> extendedClasses [
-	^ #()
-]
-
-{ #category : #accessing }
-RPackageTag >> extensionCategoriesForClass: aClass [
-
-	self
-		deprecated: 'Use #extensionProtocolsForClass: instead.'
-		transformWith: '`@rcv extensionCategoriesForClass: `@arg' -> '`@rcv extensionProtocolsForClass: `@arg'.
-	^ self extensionProtocolsForClass: aClass
-]
-
-{ #category : #accessing }
-RPackageTag >> extensionProtocolsForClass: aClass [
-
-	^ self package extensionProtocolsForClass: aClass
-]
-
 { #category : #testing }
 RPackageTag >> hasClass: aClass [
-	^  self hasClassNamed: aClass name
+
+	^ self hasClassNamed: aClass name
 ]
 
 { #category : #testing }
@@ -104,30 +75,11 @@ RPackageTag >> includesClass: aClass [
 	^ self hasClassNamed: aClass name
 ]
 
-{ #category : #testing }
-RPackageTag >> includesProtocol: protocol ofClass: aClass [
-
-	^ self package includesProtocol: protocol ofClass: aClass
-]
-
-{ #category : #testing }
-RPackageTag >> includesSelector: aSelector ofClass: aClass [
-
-	^ self package includesSelector: aSelector ofClass: aClass
-]
-
 { #category : #initialization }
 RPackageTag >> initialize [
 
 	super initialize.
 	classes := IdentitySet new
-]
-
-{ #category : #initialization }
-RPackageTag >> initializePackage: aPackage name: aString [
-	package := aPackage.
-	name := aString.
-	self initialize
 ]
 
 { #category : #testing }
@@ -146,8 +98,9 @@ RPackageTag >> name [
 ]
 
 { #category : #accessing }
-RPackageTag >> orderedClasses [
-	^ self package orderedClasses select:[:c | c category = self categoryName]
+RPackageTag >> name: aSymbol [
+
+	name := aSymbol
 ]
 
 { #category : #accessing }
@@ -158,6 +111,12 @@ RPackageTag >> organizer [
 { #category : #accessing }
 RPackageTag >> package [
 	^ package
+]
+
+{ #category : #accessing }
+RPackageTag >> package: anObject [
+
+	package := anObject
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This change cleans a little the Package tag API and mostly remove methods with no sender and that do not make sense. For example mulitple methods are about extension methods or protocols while those are managed at the level of the package and not at the level of the tag.