### PR TITLE
Fix bugs in display of wide characters through StrikeFont

### DIFF
--- a/src/Graphics-Fonts/BitBlt.extension.st
+++ b/src/Graphics-Fonts/BitBlt.extension.st
@@ -34,37 +34,6 @@ BitBlt >> cachedFontColormapFrom: sourceDepth to: destDepth [
 ]
 
 { #category : #'*Graphics-Fonts' }
-BitBlt >> displayGlyph: aForm at: aPoint left: leftX right: rightX font: aFont [
-	"Display a glyph in a multi-lingual font. Do 2 pass rendering if necessary.
-	This happens when #installStrikeFont:foregroundColor:backgroundColor: sets rule 37 (rgbMul).
-	the desired effect is to do two bitblt calls. The first one is with rule 37 and special colormap.
-	The second one is rule 34, with a colormap for applying the requested foreground color.
-	This two together do component alpha blending, i.e. alpha blend red, green and blue separatedly.
-	This is needed for arbitrary color over abitrary background text with subpixel AA."
-
-	| prevRule secondPassMap |
-	self sourceForm: aForm.
-	destX := aPoint x.
-	destY := aPoint y.
-	sourceX := leftX.
-	sourceY := 0.
-	width := rightX - leftX.
-	height := aFont height.
-	combinationRule = 37 ifTrue:[
-		"We need to do a second pass. The colormap set is for use in the second pass."
-		secondPassMap := colorMap.
-		colorMap := sourceForm depth = destForm depth
-			ifFalse: [ self cachedFontColormapFrom: sourceForm depth to: destForm depth ].
-		self copyBits.
-		prevRule := combinationRule.
-		combinationRule := 20. "rgbAdd"
-		colorMap := secondPassMap.
-		self copyBits.
-		combinationRule := prevRule.
-	] ifFalse:[self copyBits]
-]
-
-{ #category : #'*Graphics-Fonts' }
 BitBlt >> displayString: aString from: startIndex to: stopIndex at: aPoint kern: kernDelta baselineY: baselineY font: aFont [
 	"Double dispatch into the font. This method is present so that other-than-bitblt entities can be used by CharacterScanner and friends to display text."
 	^ aFont displayString: aString on: self from: startIndex to: stopIndex at: aPoint kern: kernDelta baselineY: baselineY

--- a/src/Graphics-Fonts/StrikeFont.class.st
+++ b/src/Graphics-Fonts/StrikeFont.class.st
@@ -837,7 +837,7 @@ StrikeFont >> displayLine: aString at: aPoint [
 
 { #category : #displaying }
 StrikeFont >> displayMultiString: aString on: aBitBlt from: startIndex to: stopIndex at: aPoint kern: kernDelta baselineY: baselineY [
-	| nextWide destX leftX rightX glyphInfo char destY gfont charIndex |
+	| nextWide destX glyphInfo char charIndex |
 	destX := aPoint x.
 	charIndex := startIndex.
 	glyphInfo := Array new: 5.
@@ -852,24 +852,10 @@ StrikeFont >> displayMultiString: aString on: aBitBlt from: startIndex to: stopI
 			kern: kernDelta) x.
 			charIndex := nextWide].
 		nextWide > stopIndex ifFalse: [
-		char := aString at: charIndex.
-		(self hasGlyphOf: char)
-			ifTrue:
-				[ self
-					glyphInfoOf: char
-					into: glyphInfo.
-				leftX := glyphInfo at: 2.
-				rightX := glyphInfo at: 3.
-				destY := glyphInfo at: 4.
-				gfont := glyphInfo at: 5.
-				(gfont == aBitBlt lastFont) ifFalse: [gfont installOn: aBitBlt].
-				aBitBlt displayGlyph: (glyphInfo at: 1) at: (destX @ (baselineY - destY)) left: leftX right: rightX font: self.
-				destX := destX + (rightX - leftX + kernDelta).
-				 ]
-			ifFalse:
-				[fallbackFont displayString: aString on: aBitBlt from: charIndex to: charIndex at: destX @ aPoint y kern: kernDelta baselineY: baselineY.
-				destX := destX + (fallbackFont widthOf: char) + kernDelta.
-				charIndex := charIndex + 1]]].
+			char := aString at: charIndex.
+			fallbackFont displayString: aString on: aBitBlt from: charIndex to: charIndex at: destX @ aPoint y kern: kernDelta baselineY: baselineY.
+			destX := destX + (fallbackFont widthOf: char) + kernDelta.
+			charIndex := charIndex + 1]].
 	^ Array
 		with: charIndex
 		with: aPoint + (destX @ 0)

--- a/src/Graphics-Fonts/StrikeFont.class.st
+++ b/src/Graphics-Fonts/StrikeFont.class.st
@@ -867,7 +867,7 @@ StrikeFont >> displayMultiString: aString on: aBitBlt from: startIndex to: stopI
 				destX := destX + (rightX - leftX + kernDelta).
 				 ]
 			ifFalse:
-				[fallbackFont displayString: aString on: aBitBlt from: charIndex to: charIndex at: destX@destY kern: kernDelta baselineY: baselineY.
+				[fallbackFont displayString: aString on: aBitBlt from: charIndex to: charIndex at: destX @ aPoint y kern: kernDelta baselineY: baselineY.
 				destX := destX + (fallbackFont widthOf: char) + kernDelta.
 				charIndex := charIndex + 1]]].
 	^ Array


### PR DESCRIPTION
This pull request fixes two problems in `#displayMultiString:on:from:to:at:kern:baselineY:` in StrikeFont: wide characters being put at the wrong vertical position, and a branch which is never executed as it would have caused an infinite loop otherwise. Note that there don’t seem to be many uses of instances of StrikeFont anymore, though there are still some, the `#realFont` of the `#monthNameFont` and `#weekdayFont` of a CalendarMorph is a StrikeFont.