### PR TITLE
Extend FreeTypeCache to support different scales

### DIFF
--- a/src/FreeType-Tests/FreeTypeCacheTest.class.st
+++ b/src/FreeType-Tests/FreeTypeCacheTest.class.st
@@ -43,7 +43,7 @@ FreeTypeCacheTest >> setUp [
 	fullCache
 		maximumSize: (10*(fullCache sizeOf: font1YGlyph)).
 	1 to: 10 do:[:i |
-		fullCache atFont: font1 charCode: i type: FreeTypeCacheGlyph put: font1YGlyph]
+		fullCache atFont: font1 charCode: i type: FreeTypeCacheGlyph scale: 1 put: font1YGlyph]
 ]
 
 { #category : #tests }
@@ -65,6 +65,7 @@ FreeTypeCacheTest >> testEntriesRemovedFIFO [
 			atFont: font1
 			charCode: (1000-i)
 			type: FreeTypeCacheGlyph
+			scale: 1
 			put: font1XGlyph].
 	self validateCollections: cache.
 	11 to: 1000 do:[:i |
@@ -72,6 +73,7 @@ FreeTypeCacheTest >> testEntriesRemovedFIFO [
 			atFont: font1
 			charCode: (1000-i)
 			type: FreeTypeCacheGlyph
+			scale: 1
 			put: font1XGlyph.
 		self validateSizes: cache.
 		self validateCollections: cache.
@@ -80,7 +82,7 @@ FreeTypeCacheTest >> testEntriesRemovedFIFO [
 				shouldnt: [cache atFont: font1 charCode: 1000-i2 type: FreeTypeCacheGlyph]
 				raise: Error]."
 		self
-			should: [cache atFont: font1 charCode: 1000-(i-10) type: FreeTypeCacheGlyph]
+			should: [cache atFont: font1 charCode: 1000-(i-10) type: FreeTypeCacheGlyph scale: 1]
 			raise: Error].
 	self validateSizes: cache
 ]
@@ -88,7 +90,7 @@ FreeTypeCacheTest >> testEntriesRemovedFIFO [
 { #category : #tests }
 FreeTypeCacheTest >> testFailedGet [
 
-	self should: [ cache atFont: font1 charCode: $X asInteger type: FreeTypeCacheGlyph ] raise: Error.
+	self should: [ cache atFont: font1 charCode: $X asInteger type: FreeTypeCacheGlyph scale: 1 ] raise: Error.
 	self assert: (cache instVarNamed: #used) equals: 0.
 	self validateSizes: cache
 ]
@@ -102,12 +104,14 @@ FreeTypeCacheTest >> testFreeTypeCacheEntry [
 		charCode: 1;
 		font: font1;
 		type: FreeTypeCacheGlyph;
+		scale: 1;
 		object: font1XGlyph.
 	f2 := FreeTypeCacheEntry new.
 	f2
 		charCode: 2;
 		font: font1;
 		type: FreeTypeCacheGlyphLCD;
+		scale: 1;
 		object: font1XGlyph.
 	f nextLink: f2.
 	self assert: f ~= f2.
@@ -220,6 +224,7 @@ FreeTypeCacheTest >> testMaximumSizeRespectedOnIfAbsentPut [
 		atFont: font1
 		charCode: $X asInteger
 		type: FreeTypeCacheGlyph
+		scale: 1
 		ifAbsentPut: [font1XGlyph].
 	self validateSizes: cache.
 	self validateCollections: cache.
@@ -227,12 +232,13 @@ FreeTypeCacheTest >> testMaximumSizeRespectedOnIfAbsentPut [
 		atFont: font1
 		charCode: $Y asInteger
 		type: FreeTypeCacheGlyph
+		scale: 1
 		ifAbsentPut: [font1XGlyph].
 	self assert: (cache instVarNamed: #used) equals: 0.	"cache has been cleared on reaching max size"
 	self validateSizes: cache.
 	self validateCollections: cache.
-	self should: [ cache atFont: font1 charCode: $X asInteger type: FreeTypeCacheGlyph ] raise: Error.
-	self should: [ cache atFont: font1 charCode: $Y asInteger type: FreeTypeCacheGlyph ] raise: Error
+	self should: [ cache atFont: font1 charCode: $X asInteger type: FreeTypeCacheGlyph scale: 1 ] raise: Error.
+	self should: [ cache atFont: font1 charCode: $Y asInteger type: FreeTypeCacheGlyph scale: 1 ] raise: Error
 ]
 
 { #category : #tests }
@@ -243,6 +249,7 @@ FreeTypeCacheTest >> testMaximumSizeRespectedOnPut [
 		atFont: font1
 		charCode: $X asInteger
 		type: FreeTypeCacheGlyph
+		scale: 1
 		put: font1XGlyph.
 	self validateSizes: cache.
 	self validateCollections: cache.
@@ -250,12 +257,13 @@ FreeTypeCacheTest >> testMaximumSizeRespectedOnPut [
 		atFont: font1
 		charCode: $Y asInteger
 		type: FreeTypeCacheGlyph
+		scale: 1
 		put: font1XGlyph.
 	self assert: (cache instVarNamed: #used) equals: 0.	"cache has been cleared on reaching max size"
 	self validateSizes: cache.
 	self validateCollections: cache.
-	self should: [ cache atFont: font1 charCode: $X asInteger type: FreeTypeCacheGlyph ] raise: Error.
-	self should: [ cache atFont: font1 charCode: $Y asInteger type: FreeTypeCacheGlyph ] raise: Error
+	self should: [ cache atFont: font1 charCode: $X asInteger type: FreeTypeCacheGlyph scale: 1 ] raise: Error.
+	self should: [ cache atFont: font1 charCode: $Y asInteger type: FreeTypeCacheGlyph scale: 1 ] raise: Error
 ]
 
 { #category : #tests }
@@ -268,11 +276,12 @@ FreeTypeCacheTest >> testNormalGetIfAbsentPut [
 		atFont: font1
 		charCode: $X asInteger
 		type: FreeTypeCacheGlyph
+		scale: 1
 		ifAbsentPut: [ font1XGlyph ].
 	self assert: (r isKindOf: GlyphForm).
 	self assert: (cache instVarNamed: #used) > u.	"grown"
 	self validateSizes: cache.
-	g := cache atFont: font1 charCode: $X asInteger type: FreeTypeCacheGlyph.
+	g := cache atFont: font1 charCode: $X asInteger type: FreeTypeCacheGlyph scale: 1.
 	self assert: g identicalTo: font1XGlyph.
 	self validateSizes: cache.
 	self validateCollections: cache
@@ -288,16 +297,18 @@ FreeTypeCacheTest >> testNormalGetIfAbsentPutTwice [
 		atFont: font1
 		charCode: $X asInteger
 		type: FreeTypeCacheGlyph
+		scale: 1
 		ifAbsentPut: [ font1XGlyph ].
 	r := cache
 		atFont: font1
 		charCode: $X asInteger
 		type: FreeTypeCacheGlyph
+		scale: 1
 		ifAbsentPut: [ font1XGlyph ].
 	self assert: (r isKindOf: GlyphForm).
 	self assert: (cache instVarNamed: #used) > u.	"grown"
 	self validateSizes: cache.
-	g := cache atFont: font1 charCode: $X asInteger type: FreeTypeCacheGlyph.
+	g := cache atFont: font1 charCode: $X asInteger type: FreeTypeCacheGlyph scale: 1.
 	self assert: g identicalTo: font1XGlyph.
 	self validateSizes: cache.
 	self validateCollections: cache
@@ -313,21 +324,24 @@ FreeTypeCacheTest >> testNormalGetIfAbsentPutTwiceIntoNonEmptyCache [
 		atFont: font1
 		charCode: $Z asInteger
 		type: FreeTypeCacheGlyph
+		scale: 1
 		ifAbsentPut: [ font1XGlyph ].
 	r := cache
 		atFont: font1
 		charCode: $X asInteger
 		type: FreeTypeCacheGlyph
+		scale: 1
 		ifAbsentPut: [ font1XGlyph ].
 	r := cache
 		atFont: font1
 		charCode: $X asInteger
 		type: FreeTypeCacheGlyph
+		scale: 1
 		ifAbsentPut: [ font1XGlyph ].
 	self assert: (r isKindOf: GlyphForm).
 	self assert: (cache instVarNamed: #used) > u.	"grown"
 	self validateSizes: cache.
-	g := cache atFont: font1 charCode: $X asInteger type: FreeTypeCacheGlyph.
+	g := cache atFont: font1 charCode: $X asInteger type: FreeTypeCacheGlyph scale: 1.
 	self assert: g identicalTo: font1XGlyph.
 	self validateSizes: cache.
 	self validateCollections: cache
@@ -343,10 +357,11 @@ FreeTypeCacheTest >> testNormalPutGet [
 		atFont: font1
 		charCode: $X asInteger
 		type: FreeTypeCacheGlyph
+		scale: 1
 		put: font1XGlyph.
 	self assert: (cache instVarNamed: #used) > u.	"grown"
 	self validateSizes: cache.
-	g := cache atFont: font1 charCode: $X asInteger type: FreeTypeCacheGlyph.
+	g := cache atFont: font1 charCode: $X asInteger type: FreeTypeCacheGlyph scale: 1.
 	self assert: g identicalTo: font1XGlyph.
 	self validateSizes: cache.
 	self validateCollections: cache
@@ -362,11 +377,12 @@ FreeTypeCacheTest >> testNormalPutGetTwice [
 		atFont: font1
 		charCode: $X asInteger
 		type: FreeTypeCacheGlyph
+		scale: 1
 		put: font1XGlyph.
 	self assert: (cache instVarNamed: #used) > u.	"grown"
 	self validateSizes: cache.
-	g := cache atFont: font1 charCode: $X asInteger type: FreeTypeCacheGlyph.
-	g := cache atFont: font1 charCode: $X asInteger type: FreeTypeCacheGlyph.
+	g := cache atFont: font1 charCode: $X asInteger type: FreeTypeCacheGlyph scale: 1.
+	g := cache atFont: font1 charCode: $X asInteger type: FreeTypeCacheGlyph scale: 1.
 	self assert: g identicalTo: font1XGlyph.
 	self validateSizes: cache.
 	self validateCollections: cache
@@ -382,10 +398,11 @@ FreeTypeCacheTest >> testNormalPutGetWidth [
 		atFont: font1
 		charCode: $X asInteger
 		type: FreeTypeCacheWidth
+		scale: 1
 		put: 100.
 	self assert: (cache instVarNamed: #used) > u.	"grown"
 	self validateSizes: cache.
-	g := cache atFont: font1 charCode: $X asInteger type: FreeTypeCacheWidth.
+	g := cache atFont: font1 charCode: $X asInteger type: FreeTypeCacheWidth scale: 1.
 	self assert: g equals: 100.
 	self validateSizes: cache.
 	self validateCollections: cache
@@ -399,6 +416,7 @@ FreeTypeCacheTest >> testPutSameElementTwice [
 		atFont: font1
 		charCode: $X asInteger
 		type: FreeTypeCacheGlyph
+		scale: 1
 		put: font1XGlyph.
 	self assert: (cache instVarNamed: #used) equals: (cache sizeOf: font1XGlyph).
 	self validateSizes: cache.
@@ -407,6 +425,7 @@ FreeTypeCacheTest >> testPutSameElementTwice [
 		atFont: font1
 		charCode: $X asInteger
 		type: FreeTypeCacheGlyph
+		scale: 1
 		put: font1XGlyph.
 	self assert: (cache instVarNamed: #used) equals: (cache sizeOf: font1XGlyph).
 	self validateSizes: cache.
@@ -435,11 +454,11 @@ FreeTypeCacheTest >> testRemoveAllForFont [
 	| fifo |
 	fullCache maximumSize: nil.
 	1 to: 100 do:[:i |
-		fullCache atFont: font1 charCode: i type: 1 put: font1XGlyph].
+		fullCache atFont: font1 charCode: i type: 1 scale: 1 put: font1XGlyph].
 	1 to: 100 do:[:i |
-		fullCache atFont: font2 charCode: i type: 2 put: font1YGlyph].
+		fullCache atFont: font2 charCode: i type: 2 scale: 1 put: font1YGlyph].
 	1 to: 100 do:[:i |
-		fullCache atFont: font3 charCode: i type: 3 put: font1ZGlyph].
+		fullCache atFont: font3 charCode: i type: 3 scale: 1 put: font1ZGlyph].
 	fifo := fullCache instVarNamed: #fifo.
 	self assert: (fifo detect:[:each | each font = font1] ifNone:[]) notNil.
 	self assert: (fifo detect:[:each | each font = font2] ifNone:[]) notNil.
@@ -459,11 +478,11 @@ FreeTypeCacheTest >> testRemoveAllForType [
 	| fifo |
 	fullCache maximumSize: nil.
 	1 to: 100 do:[:i |
-		fullCache atFont: font1 charCode: i type: 1 put: font1XGlyph].
+		fullCache atFont: font1 charCode: i type: 1 scale: 1 put: font1XGlyph].
 	1 to: 100 do:[:i |
-		fullCache atFont: font2 charCode: i type: 2 put: font1YGlyph].
+		fullCache atFont: font2 charCode: i type: 2 scale: 1 put: font1YGlyph].
 	1 to: 100 do:[:i |
-		fullCache atFont: font3 charCode: i type: 3 put: font1ZGlyph].
+		fullCache atFont: font3 charCode: i type: 3 scale: 1 put: font1ZGlyph].
 	fifo := fullCache instVarNamed: #fifo.
 	self assert: (fifo detect:[:each | each type = 1] ifNone:[]) notNil.
 	self assert: (fifo detect:[:each | each type = 2] ifNone:[]) notNil.
@@ -551,7 +570,8 @@ FreeTypeCacheTest >> validateCollections: aFreeTypeCache [
 	fifo := aFreeTypeCache instVarNamed: #fifo.
 	lastLink := fifo instVarNamed: #lastLink.
 	fontTableEntries := Set new.
-	fontTable keysAndValuesDo: [ :k1 :v1 | v1 keysAndValuesDo: [ :k2 :v2 | v2 keysAndValuesDo: [ :k3 :v3 | fontTableEntries add: v3 ] ] ].
+	fontTable keysAndValuesDo: [ :k1 :v1 | v1 keysAndValuesDo: [ :k2 :v2 | v2 keysAndValuesDo: [ :k3 :v3 | v3 keysAndValuesDo: [ :k4 :v4 |
+		fontTableEntries add: v4 ] ] ] ].
 	self assert: fifo size equals: fontTableEntries size.
 	self assert: fifo asSet equals: fontTableEntries.
 	self assert: (lastLink isNil or: [ lastLink nextLink isNil ])
@@ -566,7 +586,8 @@ FreeTypeCacheTest >> validateSizes: aFreeTypeCache [
 	used := aFreeTypeCache instVarNamed: #used.
 	max := aFreeTypeCache instVarNamed: #maximumSize.
 	calcSize := 0.
-	fontTable do: [ :charCodeTable | charCodeTable do: [ :typeTable | typeTable do: [ :entry | calcSize := calcSize + (aFreeTypeCache sizeOf: entry object) ] ] ].
+	fontTable do: [ :charCodeTable | charCodeTable do: [ :typeTable | typeTable do: [ :scaleTable | scaleTable do: [ :entry |
+		calcSize := calcSize + (aFreeTypeCache sizeOf: entry object) ] ] ] ].
 	self assert: calcSize equals: used.
 	self assert: (max isNil or: [ used <= max ])
 ]

--- a/src/FreeType/FreeTypeCache.class.st
+++ b/src/FreeType/FreeTypeCache.class.st
@@ -79,24 +79,26 @@ FreeTypeCache class >> startUp: isImageStarting [
 ]
 
 { #category : #'add-remove' }
-FreeTypeCache >> atFont: aFreeTypeFont charCode: charCodeInteger type: typeFlag [
+FreeTypeCache >> atFont: aFreeTypeFont charCode: charCodeInteger type: typeFlag scale: scale [
 
 	^ self
 		atFont: aFreeTypeFont
 		charCode: charCodeInteger
 		type: typeFlag
+		scale: scale
 		ifAbsentPut: [ self error: 'Not found' ]
 ]
 
 { #category : #'add-remove' }
-FreeTypeCache >> atFont: aFreeTypeFont charCode: charCodeInteger type: typeFlag ifAbsentPut: aBlock [
+FreeTypeCache >> atFont: aFreeTypeFont charCode: charCodeInteger type: typeFlag scale: scale ifAbsentPut: aBlock [
 
-	| charCodeTable typeTable entry v vSize |
+	| charCodeTable typeTable scaleTable entry v vSize |
 
 	aFreeTypeFont mutex criticalReleasingOnError: [
 		charCodeTable := fontTable at: aFreeTypeFont ifAbsentPut:[self dictionaryClass new: 60].
 		typeTable := charCodeTable at: charCodeInteger ifAbsentPut:[self dictionaryClass new: 10].
-		entry := typeTable at: typeFlag ifAbsent:[].
+		scaleTable := typeTable at: typeFlag ifAbsentPut:[self dictionaryClass new: 1].
+		entry := scaleTable at: scale ifAbsent:[].
 		entry
 			ifNotNil:[
 				fifo moveDown: entry.
@@ -110,18 +112,19 @@ FreeTypeCache >> atFont: aFreeTypeFont charCode: charCodeInteger type: typeFlag 
 			 font: aFreeTypeFont;
 			charCode: charCodeInteger;
 			type: typeFlag;
+			scale: scale;
 			object: v;
 			yourself).
-		typeTable at: typeFlag put: entry.
+		scaleTable at: scale put: entry.
 		fifo addLast: entry.
 		maximumSize ifNotNil:[self shrinkTo: maximumSize].
 		^ v ]
 ]
 
 { #category : #'add-remove' }
-FreeTypeCache >> atFont: aFreeTypeFont charCode: charCodeInteger type: typeFlag put: anObject [
+FreeTypeCache >> atFont: aFreeTypeFont charCode: charCodeInteger type: typeFlag scale: scale put: anObject [
 
-	| charCodeTable typeTable anObjectSize oldEntry oldEntrySize entry |
+	| charCodeTable typeTable scaleTable anObjectSize oldEntry oldEntrySize entry |
 
 	aFreeTypeFont mutex criticalReleasingOnError: [
 		anObjectSize := self sizeOf: anObject.
@@ -131,7 +134,8 @@ FreeTypeCache >> atFont: aFreeTypeFont charCode: charCodeInteger type: typeFlag 
 			ifNotNil:[
 				(typeTable := charCodeTable at: charCodeInteger ifAbsentPut:[self dictionaryClass new: 10])
 					ifNotNil:[
-						oldEntry := typeTable at: typeFlag ifAbsent:[].
+						scaleTable := typeTable at: typeFlag ifAbsentPut:[self dictionaryClass new: 1].
+						oldEntry := scaleTable at: scale ifAbsent:[].
 						oldEntrySize := (oldEntry
 							ifNil:[0]
 							ifNotNil:[self sizeOf: oldEntry object]).
@@ -139,9 +143,10 @@ FreeTypeCache >> atFont: aFreeTypeFont charCode: charCodeInteger type: typeFlag 
 							font: aFreeTypeFont;
 							charCode: charCodeInteger;
 							type: typeFlag;
+							scale: scale;
 							object: anObject;
 							yourself).
-						typeTable at: typeFlag put: entry]].
+						scaleTable at: scale put: entry]].
 		used := used + anObjectSize - oldEntrySize.
 		oldEntry ifNotNil: [fifo remove: oldEntry].
 		fifo addLast: entry.

--- a/src/FreeType/FreeTypeCacheEntry.class.st
+++ b/src/FreeType/FreeTypeCacheEntry.class.st
@@ -8,6 +8,7 @@ Class {
 		'font',
 		'charCode',
 		'type',
+		'scale',
 		'object',
 		'previousLink'
 	],
@@ -23,7 +24,8 @@ FreeTypeCacheEntry >> = aFreeTypeCacheEntry [
 	^font = aFreeTypeCacheEntry font and: [
 		charCode = aFreeTypeCacheEntry charCode
 			and: [type = aFreeTypeCacheEntry type
-				and:[object = aFreeTypeCacheEntry object]]]
+				and: [scale = aFreeTypeCacheEntry scale
+					and:[object = aFreeTypeCacheEntry object]]]]
 ]
 
 { #category : #accessing }
@@ -86,6 +88,18 @@ FreeTypeCacheEntry >> previousLink: anObject [
 	"Set the value of previousLink"
 
 	previousLink := anObject
+]
+
+{ #category : #accessing }
+FreeTypeCacheEntry >> scale [
+
+	^ scale
+]
+
+{ #category : #accessing }
+FreeTypeCacheEntry >> scale: anObject [
+
+	scale := anObject
 ]
 
 { #category : #accessing }

--- a/src/FreeType/FreeTypeFont.class.st
+++ b/src/FreeType/FreeTypeFont.class.st
@@ -359,24 +359,19 @@ FreeTypeFont >> glyphOf: aCharacter colorValue: aColorValue mono: monoBoolean su
 { #category : #'glyph lookup' }
 FreeTypeFont >> glyphOf: aCharacter colorValue: aColorValue mono: monoBoolean subpixelPosition: sub scale: scale [
 
-	| glyphBlock |
-
-	glyphBlock := [
-		FreeTypeGlyphRenderer current
-			glyphOf: aCharacter
-			colorValue: aColorValue
-			mono: monoBoolean
-			subpixelPosition: sub
-			font: self
-			scale: scale ].
-	^ scale = 1
-		ifTrue: [
-			FreeTypeCache current
-				atFont: self
-				charCode: aCharacter asUnicode asInteger
-				type: ((1+sub) << 32) + aColorValue
-				ifAbsentPut: glyphBlock ]
-		ifFalse: [ glyphBlock value ]
+	^ FreeTypeCache current
+		atFont: self
+		charCode: aCharacter asUnicode asInteger
+		type: ((1+sub) << 32) + aColorValue
+		scale: scale
+		ifAbsentPut: [
+			FreeTypeGlyphRenderer current
+				glyphOf: aCharacter
+				colorValue: aColorValue
+				mono: monoBoolean
+				subpixelPosition: sub
+				font: self
+				scale: scale ]
 ]
 
 { #category : #'glyph lookup' }
@@ -481,6 +476,7 @@ FreeTypeFont >> hintedWidthOf: aCharacter [
 		atFont: self
 		charCode: charCode
 		type: FreeTypeCacheWidth
+		scale: 1
 		ifAbsentPut: [self getWidthOf: aCharacter].
 	^answer
 ]
@@ -620,6 +616,7 @@ FreeTypeFont >> linearWidthOf: aCharacter [
 		atFont: self
 		charCode: charCode
 		type: FreeTypeCacheLinearWidth
+		scale: 1
 		ifAbsentPut: [self getLinearWidthOf: aCharacter].
 	^answer
 ]
@@ -639,24 +636,19 @@ FreeTypeFont >> minAscii [
 { #category : #'glyph lookup' }
 FreeTypeFont >> mode41GlyphOf: aCharacter colorValue: aColorValue mono: monoBoolean subpixelPosition: sub scale: scale [
 
-	| glyphBlock |
-
-	glyphBlock := [
-		FreeTypeGlyphRenderer current
-			mode41GlyphOf: aCharacter
-			colorValue: aColorValue
-			mono: monoBoolean
-			subpixelPosition: sub
-			font: self
-			scale: scale ].
-	^ scale = 1
-		ifTrue: [
-			FreeTypeCache current
-				atFont: self
-				charCode: aCharacter asUnicode asInteger
-				type: (FreeTypeCacheGlyph + sub)
-				ifAbsentPut: glyphBlock ]
-		ifFalse: [ glyphBlock value ]
+	^ FreeTypeCache current
+		atFont: self
+		charCode: aCharacter asUnicode asInteger
+		type: (FreeTypeCacheGlyph + sub)
+		scale: scale
+		ifAbsentPut: [
+			FreeTypeGlyphRenderer current
+				mode41GlyphOf: aCharacter
+				colorValue: aColorValue
+				mono: monoBoolean
+				subpixelPosition: sub
+				font: self
+				scale: scale ]
 ]
 
 { #category : #accessing }
@@ -785,24 +777,19 @@ FreeTypeFont >> strikeoutTop [
 { #category : #'glyph lookup' }
 FreeTypeFont >> subGlyphOf: aCharacter colorValue: aColorValue mono: monoBoolean subpixelPosition: sub scale: scale [
 
-	| glyphBlock |
-
-	glyphBlock := [
-		FreeTypeGlyphRenderer current
-			subGlyphOf: aCharacter
-			colorValue: aColorValue
-			mono: monoBoolean
-			subpixelPosition: sub
-			font: self
-			scale: scale ].
-	^ scale = 1
-		ifTrue: [
-			FreeTypeCache current
-				atFont: self
-				charCode: aCharacter asUnicode asInteger
-				type: FreeTypeCacheGlyphLCD + sub
-				ifAbsentPut: glyphBlock ]
-		ifFalse: [ glyphBlock value ]
+	^ FreeTypeCache current
+		atFont: self
+		charCode: aCharacter asUnicode asInteger
+		type: FreeTypeCacheGlyphLCD + sub
+		scale: scale
+		ifAbsentPut: [
+			FreeTypeGlyphRenderer current
+				subGlyphOf: aCharacter
+				colorValue: aColorValue
+				mono: monoBoolean
+				subpixelPosition: sub
+				font: self
+				scale: scale ]
 ]
 
 { #category : #testing }


### PR DESCRIPTION
This pull request extends FreeTypeCache to support different scales and makes the ‘glyph lookup’ methods of FreeTypeFont also use the cache when the scale is not 1 (see pull request #14503). Note that this does not take migration of existing Pharo images into account.