### PR TITLE
Refactorings: Remove categories from environments and clean the code

### DIFF
--- a/src/Monticello/MCWorkingCopy.class.st
+++ b/src/Monticello/MCWorkingCopy.class.st
@@ -318,7 +318,7 @@ MCWorkingCopy class >> workingCopiesForPackage: aPackage do: aBlock [
 		select: [ :workingCopy |
 			workingCopy systemPackage
 				ifNil: [ false ]
-				ifNotNil: [ :package | package includesSystemCategory: aPackage name ] ]
+				ifNotNil: [ :package | package = aPackage ] ]
 		thenDo: aBlock
 ]
 

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -555,12 +555,6 @@ RPackage >> includesSelector: aSelector ofClass: aClass [
 	^ (self includesDefinedSelector: aSelector ofClass: aClass) or: [ self includesExtensionSelector: aSelector ofClass: aClass ]
 ]
 
-{ #category : #'system compatibility' }
-RPackage >> includesSystemCategory: categoryName [
-
-	^ categoryName isCategoryOf: self systemCategoryPrefix
-]
-
 { #category : #initialization }
 RPackage >> initialize [
 

--- a/src/RPackage-Core/RPackageSet.class.st
+++ b/src/RPackage-Core/RPackageSet.class.st
@@ -126,12 +126,6 @@ RPackageSet >> includesClass: aClass [
 	^self packages anySatisfy: [ :each | each includesClass: aClass ]
 ]
 
-{ #category : #'system compatibility' }
-RPackageSet >> includesSystemCategory: categoryName [
-	^self packages anySatisfy: [ :each |
-		each includesSystemCategory: categoryName ]
-]
-
 { #category : #initialization }
 RPackageSet >> initialize: aString [
 

--- a/src/Refactoring-Critics/RBMultiEnvironment.class.st
+++ b/src/Refactoring-Critics/RBMultiEnvironment.class.st
@@ -37,11 +37,6 @@ RBMultiEnvironment >> environments [
 ]
 
 { #category : #testing }
-RBMultiEnvironment >> includesCategory: aCategory [
-	^ (super includesCategory: aCategory) and: [ environmentDictionaries anySatisfy: [ :env | env includesCategory: aCategory ] ]
-]
-
-{ #category : #testing }
 RBMultiEnvironment >> includesClass: aClass [
 	^ (super includesClass: aClass) and: [ environmentDictionaries anySatisfy: [ :env | env includesClass: aClass ] ]
 ]

--- a/src/Refactoring-Environment/RBAndEnvironment.class.st
+++ b/src/Refactoring-Environment/RBAndEnvironment.class.st
@@ -60,12 +60,6 @@ RBAndEnvironment >> includesClass: aClass [
 ]
 
 { #category : #testing }
-RBAndEnvironment >> includesPackage: aPackage [
-
-	^ (environment includesPackage: aPackage) and: [ self andedEnvironment includesPackage: aPackage ]
-]
-
-{ #category : #testing }
 RBAndEnvironment >> includesProtocol: aProtocol in: aClass [
 
 	^ (environment includesProtocol: aProtocol in: aClass) and: [ self andedEnvironment includesProtocol: aProtocol in: aClass ]

--- a/src/Refactoring-Environment/RBAndEnvironment.class.st
+++ b/src/Refactoring-Environment/RBAndEnvironment.class.st
@@ -46,11 +46,6 @@ RBAndEnvironment >> definesClass: aClass [
 ]
 
 { #category : #testing }
-RBAndEnvironment >> includesCategory: aCategory [
-	^(self classNamesFor: aCategory) isNotEmpty
-]
-
-{ #category : #testing }
 RBAndEnvironment >> includesClass: aClass [
 	| doesntHaveSelectors |
 	(environment includesClass: aClass) ifFalse: [^false].

--- a/src/Refactoring-Environment/RBAndEnvironment.class.st
+++ b/src/Refactoring-Environment/RBAndEnvironment.class.st
@@ -65,6 +65,12 @@ RBAndEnvironment >> includesClass: aClass [
 ]
 
 { #category : #testing }
+RBAndEnvironment >> includesPackage: aPackage [
+
+	^ (environment includesPackage: aPackage) and: [ self andedEnvironment includesPackage: aPackage ]
+]
+
+{ #category : #testing }
 RBAndEnvironment >> includesProtocol: aProtocol in: aClass [
 
 	^ (environment includesProtocol: aProtocol in: aClass) and: [ self andedEnvironment includesProtocol: aProtocol in: aClass ]
@@ -85,11 +91,6 @@ RBAndEnvironment >> methodsForClass: aClass do: aBlock [
 { #category : #printing }
 RBAndEnvironment >> operator [
 	^ ' & '
-]
-
-{ #category : #accessing }
-RBAndEnvironment >> packages [
-	^ environment packages & self andedEnvironment packages
 ]
 
 { #category : #printing }

--- a/src/Refactoring-Environment/RBBrowserEnvironment.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironment.class.st
@@ -393,11 +393,6 @@ RBBrowserEnvironment >> implementorsOf: aSelector [
 ]
 
 { #category : #testing }
-RBBrowserEnvironment >> includesCategory: aCategory [
-	^ true
-]
-
-{ #category : #testing }
 RBBrowserEnvironment >> includesClass: aClass [
 	^ true
 ]

--- a/src/Refactoring-Environment/RBBrowserEnvironment.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironment.class.st
@@ -191,11 +191,6 @@ RBBrowserEnvironment >> cachedResultOf: aQuery [
 	^self queryCache at: aQuery ifAbsent: [ nil ]
 ]
 
-{ #category : #accessing }
-RBBrowserEnvironment >> categories [
-	^ self systemDictionary organization categories select: [ :each | self includesCategory: each ]
-]
-
 { #category : #'accessing - classes' }
 RBBrowserEnvironment >> classNames [
 	| names |
@@ -588,13 +583,10 @@ RBBrowserEnvironment >> packageAt: aName [
 
 { #category : #'accessing - packages' }
 RBBrowserEnvironment >> packageAt: aName ifAbsent: absentBlock [
-	| package |
-	package := self packageOrganizer
-		packageNamed: aName ifAbsent: absentBlock.
 
-	^ (self includesCategory: aName)
-		ifTrue: [ package ]
-		ifFalse: absentBlock
+	^ self packages
+		  detect: [ :package | package name sameAs: aName ]
+		  ifNone: absentBlock
 ]
 
 { #category : #'accessing - packages' }

--- a/src/Refactoring-Environment/RBBrowserEnvironment.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironment.class.st
@@ -199,16 +199,6 @@ RBBrowserEnvironment >> classNames [
 	^ names
 ]
 
-{ #category : #accessing }
-RBBrowserEnvironment >> classNamesFor: aCategoryName [
-	^ (self systemDictionary organization listAtCategoryNamed: aCategoryName) select: [ :each |
-		| class |
-		class := self systemDictionary at: each ifAbsent: [ nil ].
-		class notNil
-			and: [ (self includesClass: class)
-			or: [ self includesClass: class class ] ] ]
-]
-
 { #category : #environments }
 RBBrowserEnvironment >> classVarRefsTo: instVarName in: aClass [
 	^ RBVariableEnvironment

--- a/src/Refactoring-Environment/RBBrowserEnvironment.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironment.class.st
@@ -266,6 +266,12 @@ RBBrowserEnvironment >> classesDo: aBlock [
 			ifTrue: [aBlock value: each ] ]
 ]
 
+{ #category : #accessing }
+RBBrowserEnvironment >> classesInPackage: aPackage [
+
+	^ aPackage definedClasses select: [ :class | (self includesClass: class) or: [ self includesClass: class class ] ]
+]
+
 { #category : #cleaning }
 RBBrowserEnvironment >> cleanGarbageInCache [
 
@@ -594,9 +600,7 @@ RBBrowserEnvironment >> packageAt: aName ifAbsent: absentBlock [
 { #category : #'accessing - packages' }
 RBBrowserEnvironment >> packages [
 
-	^ self packageOrganizer packages
-		select: [ :package |
-			self includesCategory: package name ]
+	^ self packageOrganizer packages select: [ :package | self includesPackage: package ]
 ]
 
 { #category : #'accessing - packages' }

--- a/src/Refactoring-Environment/RBBrowserEnvironmentWrapper.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironmentWrapper.class.st
@@ -70,7 +70,8 @@ RBBrowserEnvironmentWrapper >> environment [
 
 { #category : #testing }
 RBBrowserEnvironmentWrapper >> includesCategory: aCategory [
-	^environment includesCategory: aCategory
+
+	^ environment includesCategory: aCategory
 ]
 
 { #category : #testing }
@@ -79,8 +80,10 @@ RBBrowserEnvironmentWrapper >> includesClass: aClass [
 ]
 
 { #category : #testing }
-RBBrowserEnvironmentWrapper >> includesPackage: aRPackage [
-	^ self packages includes: aRPackage
+RBBrowserEnvironmentWrapper >> includesPackage: aPackage [
+
+	^ (super includesPackage: aPackage) and: [
+		  (environment classesInPackage: aPackage) anySatisfy: [ :class | (self includesClass: class) or: [ self includesClass: class class ] ] ]
 ]
 
 { #category : #testing }
@@ -120,12 +123,6 @@ RBBrowserEnvironmentWrapper >> onEnvironment: anEnvironment [
 { #category : #private }
 RBBrowserEnvironmentWrapper >> packageNames [
 	^ self packages collect: [ :each | each packageName ]
-]
-
-{ #category : #accessing }
-RBBrowserEnvironmentWrapper >> packages [
-
-	^ self subclassResponsibility
 ]
 
 { #category : #printing }

--- a/src/Refactoring-Environment/RBBrowserEnvironmentWrapper.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironmentWrapper.class.st
@@ -69,12 +69,6 @@ RBBrowserEnvironmentWrapper >> environment [
 ]
 
 { #category : #testing }
-RBBrowserEnvironmentWrapper >> includesCategory: aCategory [
-
-	^ environment includesCategory: aCategory
-]
-
-{ #category : #testing }
 RBBrowserEnvironmentWrapper >> includesClass: aClass [
 	^environment includesClass: aClass
 ]

--- a/src/Refactoring-Environment/RBBrowserEnvironmentWrapper.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironmentWrapper.class.st
@@ -76,8 +76,7 @@ RBBrowserEnvironmentWrapper >> includesClass: aClass [
 { #category : #testing }
 RBBrowserEnvironmentWrapper >> includesPackage: aPackage [
 
-	^ (super includesPackage: aPackage) and: [
-		  (environment classesInPackage: aPackage) anySatisfy: [ :class | (self includesClass: class) or: [ self includesClass: class class ] ] ]
+	^ (super includesPackage: aPackage) and: [ (self classesInPackage: aPackage) isNotEmpty ]
 ]
 
 { #category : #testing }

--- a/src/Refactoring-Environment/RBClassEnvironment.class.st
+++ b/src/Refactoring-Environment/RBClassEnvironment.class.st
@@ -180,11 +180,6 @@ RBClassEnvironment >> metaClassSelectorDictionary [
 				yourself ]
 ]
 
-{ #category : #accessing }
-RBClassEnvironment >> packages [
-	^ self classes collect: [:each | each package]
-]
-
 { #category : #copying }
 RBClassEnvironment >> postCopy [
 	super postCopy.

--- a/src/Refactoring-Environment/RBClassEnvironment.class.st
+++ b/src/Refactoring-Environment/RBClassEnvironment.class.st
@@ -132,20 +132,6 @@ RBClassEnvironment >> definesClass: aClass [
 ]
 
 { #category : #testing }
-RBClassEnvironment >> includesCategory: aCategory [
-	^ (super includesCategory: aCategory) and: [
-		(environment classNamesFor: aCategory)
-			inject: false
-			into: [ :bool :each |
-				bool or: [
-					| class |
-					class := self systemDictionary at: each ifAbsent: [ nil ].
-					class notNil
-						and: [ (self includesClass: class)
-						or: [ self includesClass: class class ]]]]]
-]
-
-{ #category : #testing }
 RBClassEnvironment >> includesClass: aClass [
 	^(aClass isMeta
 		ifTrue: [metaClasses includes: aClass soleInstance name]

--- a/src/Refactoring-Environment/RBClassHierarchyEnvironment.class.st
+++ b/src/Refactoring-Environment/RBClassHierarchyEnvironment.class.st
@@ -67,8 +67,3 @@ RBClassHierarchyEnvironment >> includesClass: aClass [
 		[ (class inheritsFrom: aClass) or:
 			[ aClass inheritsFrom: class ] ]) and: [super includesClass: aClass]
 ]
-
-{ #category : #accessing }
-RBClassHierarchyEnvironment >> packages [
-	^ self classes collect: [:each | each package]
-]

--- a/src/Refactoring-Environment/RBClassHierarchyEnvironment.class.st
+++ b/src/Refactoring-Environment/RBClassHierarchyEnvironment.class.st
@@ -51,17 +51,6 @@ RBClassHierarchyEnvironment >> definesClass: aClass [
 ]
 
 { #category : #testing }
-RBClassHierarchyEnvironment >> includesCategory: aCategory [
-	^ (super includesCategory: aCategory) and: [
-		(environment classNamesFor: aCategory)
-			inject: false into: [ :bool :each |
-				bool or: [
-					| aClass |
-					aClass := self systemDictionary at: each ifAbsent: [ nil ].
-					aClass == class or: [ aClass class == class ] ] ] ]
-]
-
-{ #category : #testing }
 RBClassHierarchyEnvironment >> includesClass: aClass [
 	^ (aClass == class or:
 		[ (class inheritsFrom: aClass) or:

--- a/src/Refactoring-Environment/RBNotEnvironment.class.st
+++ b/src/Refactoring-Environment/RBNotEnvironment.class.st
@@ -22,11 +22,6 @@ RBNotEnvironment >> description [
 ]
 
 { #category : #testing }
-RBNotEnvironment >> includesCategory: aCategory [
-	^(self classNamesFor: aCategory) isNotEmpty
-]
-
-{ #category : #testing }
 RBNotEnvironment >> includesClass: aClass [
 	(environment includesClass: aClass) ifFalse: [^true].
 	^false

--- a/src/Refactoring-Environment/RBNotEnvironment.class.st
+++ b/src/Refactoring-Environment/RBNotEnvironment.class.st
@@ -55,12 +55,6 @@ RBNotEnvironment >> not [
 	^environment
 ]
 
-{ #category : #accessing }
-RBNotEnvironment >> packages [
-	^ self rootEnvironment packages
-		select: [ :package | self includesPackage: package ]
-]
-
 { #category : #printing }
 RBNotEnvironment >> storeOn: aStream [
 	environment storeOn: aStream.

--- a/src/Refactoring-Environment/RBNotEnvironment.class.st
+++ b/src/Refactoring-Environment/RBNotEnvironment.class.st
@@ -28,11 +28,6 @@ RBNotEnvironment >> includesClass: aClass [
 ]
 
 { #category : #testing }
-RBNotEnvironment >> includesPackage: aRPackage [
-	^ (environment includesPackage: aRPackage) not
-]
-
-{ #category : #testing }
 RBNotEnvironment >> includesProtocol: aProtocol in: aClass [
 
 	(aClass hasProtocol: aProtocol) ifFalse: [ ^ false ].

--- a/src/Refactoring-Environment/RBOrEnvironment.class.st
+++ b/src/Refactoring-Environment/RBOrEnvironment.class.st
@@ -37,12 +37,6 @@ RBOrEnvironment >> definesClass: aClass [
 ]
 
 { #category : #testing }
-RBOrEnvironment >> includesCategory: aCategory [
-	^ (environment includesCategory: aCategory)
-		or: [ self orEnvironment includesCategory: aCategory ]
-]
-
-{ #category : #testing }
 RBOrEnvironment >> includesClass: aClass [
 	(environment includesClass: aClass) ifTrue: [ ^ true ].
 	(self orEnvironment includesClass: aClass) ifTrue: [ ^ true ].

--- a/src/Refactoring-Environment/RBOrEnvironment.class.st
+++ b/src/Refactoring-Environment/RBOrEnvironment.class.st
@@ -46,12 +46,6 @@ RBOrEnvironment >> includesClass: aClass [
 ]
 
 { #category : #testing }
-RBOrEnvironment >> includesPackage: aPackage [
-
-	^ (environment includesPackage: aPackage) or: [ self orEnvironment includesPackage: aPackage ]
-]
-
-{ #category : #testing }
 RBOrEnvironment >> includesProtocol: aProtocol in: aClass [
 
 	^ (environment includesProtocol: aProtocol in: aClass) or: [ self orEnvironment includesProtocol: aProtocol in: aClass ]

--- a/src/Refactoring-Environment/RBOrEnvironment.class.st
+++ b/src/Refactoring-Environment/RBOrEnvironment.class.st
@@ -52,6 +52,12 @@ RBOrEnvironment >> includesClass: aClass [
 ]
 
 { #category : #testing }
+RBOrEnvironment >> includesPackage: aPackage [
+
+	^ (environment includesPackage: aPackage) or: [ self orEnvironment includesPackage: aPackage ]
+]
+
+{ #category : #testing }
 RBOrEnvironment >> includesProtocol: aProtocol in: aClass [
 
 	^ (environment includesProtocol: aProtocol in: aClass) or: [ self orEnvironment includesProtocol: aProtocol in: aClass ]
@@ -87,11 +93,6 @@ RBOrEnvironment >> orEnvironment [
 { #category : #accessing }
 RBOrEnvironment >> orEnvironment: aBrowserEnvironment [
 	 otherEnvironment := aBrowserEnvironment
-]
-
-{ #category : #accessing }
-RBOrEnvironment >> packages [
-	^ environment packages | self orEnvironment packages
 ]
 
 { #category : #accessing }

--- a/src/Refactoring-Environment/RBPackageEnvironment.class.st
+++ b/src/Refactoring-Environment/RBPackageEnvironment.class.st
@@ -112,13 +112,6 @@ RBPackageEnvironment >> definesClass: aClass [
 ]
 
 { #category : #testing }
-RBPackageEnvironment >> includesCategory: aCategory [
-	^ (super includesCategory: aCategory) and: [
-		self packages anySatisfy: [ :package |
-			package includesSystemCategory: aCategory ] ]
-]
-
-{ #category : #testing }
 RBPackageEnvironment >> includesClass: aClass [
 
 	^ (super includesClass: aClass) and: [

--- a/src/Refactoring-Environment/RBPackageEnvironment.class.st
+++ b/src/Refactoring-Environment/RBPackageEnvironment.class.st
@@ -126,6 +126,12 @@ RBPackageEnvironment >> includesClass: aClass [
 ]
 
 { #category : #testing }
+RBPackageEnvironment >> includesPackage: aPackage [
+
+	^ (super includesPackage: aPackage) and: [ self packages anySatisfy: [ :package | package = aPackage ] ]
+]
+
+{ #category : #testing }
 RBPackageEnvironment >> includesProtocol: aProtocol in: aClass [
 	^ (environment includesProtocol: aProtocol in: aClass) and: [ self packages anySatisfy: [ :package | package includesProtocol: aProtocol ofClass: aClass ] ]
 ]

--- a/src/Refactoring-Environment/RBPragmaEnvironment.class.st
+++ b/src/Refactoring-Environment/RBPragmaEnvironment.class.st
@@ -62,12 +62,6 @@ RBPragmaEnvironment >> includesClass: aClass [
 ]
 
 { #category : #testing }
-RBPragmaEnvironment >> includesPackage: aPackage [
-
-	^ (environment includesPackage: aPackage) and: [ (self classesInPackage: aPackage) isNotEmpty ]
-]
-
-{ #category : #testing }
 RBPragmaEnvironment >> includesPragma: aPragma [
 	^ (keywords includes: aPragma selector) and: [ condition value: aPragma ]
 ]

--- a/src/Refactoring-Environment/RBPragmaEnvironment.class.st
+++ b/src/Refactoring-Environment/RBPragmaEnvironment.class.st
@@ -67,6 +67,12 @@ RBPragmaEnvironment >> includesClass: aClass [
 ]
 
 { #category : #testing }
+RBPragmaEnvironment >> includesPackage: aPackage [
+
+	^ (environment includesPackage: aPackage) and: [ (self classesInPackage: aPackage) isNotEmpty ]
+]
+
+{ #category : #testing }
 RBPragmaEnvironment >> includesPragma: aPragma [
 	^ (keywords includes: aPragma selector) and: [ condition value: aPragma ]
 ]
@@ -94,11 +100,6 @@ RBPragmaEnvironment >> initialize [
 { #category : #initialization }
 RBPragmaEnvironment >> keywords: aCollection [
 	keywords addAll: aCollection
-]
-
-{ #category : #testing }
-RBPragmaEnvironment >> packages [
-	^ (self methods collect: [:each | each package]) asSet
 ]
 
 { #category : #copying }

--- a/src/Refactoring-Environment/RBPragmaEnvironment.class.st
+++ b/src/Refactoring-Environment/RBPragmaEnvironment.class.st
@@ -57,11 +57,6 @@ RBPragmaEnvironment >> defaultLabel [
 ]
 
 { #category : #testing }
-RBPragmaEnvironment >> includesCategory: aCategory [
-	^ (environment includesCategory: aCategory) and: [ (self classNamesFor: aCategory) notEmpty ]
-]
-
-{ #category : #testing }
 RBPragmaEnvironment >> includesClass: aClass [
 	^ (environment includesClass: aClass) and: [ aClass selectors anySatisfy: [ :each | self includesSelector: each in: aClass ] ]
 ]

--- a/src/Refactoring-Environment/RBProtocolEnvironment.class.st
+++ b/src/Refactoring-Environment/RBProtocolEnvironment.class.st
@@ -89,13 +89,6 @@ RBProtocolEnvironment >> includesClass: aClass [
 ]
 
 { #category : #testing }
-RBProtocolEnvironment >> includesPackage: aPackage [
-
-	^ (super includesPackage: aPackage) and: [
-		  (environment classesInPackage: aPackage) anySatisfy: [ :aClass | (self includesClass: aClass) or: [ self includesClass: aClass class ] ] ]
-]
-
-{ #category : #testing }
 RBProtocolEnvironment >> includesProtocol: aProtocol in: aClass [
 
 	^ aClass == class and: [ (super includesProtocol: aProtocol in: aClass) and: [ protocols includes: aProtocol name ] ]

--- a/src/Refactoring-Environment/RBProtocolEnvironment.class.st
+++ b/src/Refactoring-Environment/RBProtocolEnvironment.class.st
@@ -84,17 +84,6 @@ RBProtocolEnvironment >> description [
 ]
 
 { #category : #testing }
-RBProtocolEnvironment >> includesCategory: aCategory [
-	^ (super includesCategory: aCategory) and: [
-		(environment classNamesFor: aCategory)
-			inject: false into: [ :bool :each |
-				bool or: [
-					| aClass |
-					aClass := self systemDictionary at: each ifAbsent: [ nil ].
-					aClass == class or: [ aClass class == class ] ] ] ]
-]
-
-{ #category : #testing }
 RBProtocolEnvironment >> includesClass: aClass [
 	^ aClass == class and: [super includesClass: aClass]
 ]

--- a/src/Refactoring-Environment/RBProtocolEnvironment.class.st
+++ b/src/Refactoring-Environment/RBProtocolEnvironment.class.st
@@ -100,6 +100,13 @@ RBProtocolEnvironment >> includesClass: aClass [
 ]
 
 { #category : #testing }
+RBProtocolEnvironment >> includesPackage: aPackage [
+
+	^ (super includesPackage: aPackage) and: [
+		  (environment classesInPackage: aPackage) anySatisfy: [ :aClass | (self includesClass: aClass) or: [ self includesClass: aClass class ] ] ]
+]
+
+{ #category : #testing }
 RBProtocolEnvironment >> includesProtocol: aProtocol in: aClass [
 
 	^ aClass == class and: [ (super includesProtocol: aProtocol in: aClass) and: [ protocols includes: aProtocol name ] ]
@@ -115,11 +122,6 @@ RBProtocolEnvironment >> includesSelector: aSelector in: aClass [
 { #category : #testing }
 RBProtocolEnvironment >> isEmpty [
 	^protocols isEmpty
-]
-
-{ #category : #testing }
-RBProtocolEnvironment >> packages [
-	^ self methods collect: [ :m | m package ]
 ]
 
 { #category : #copying }

--- a/src/Refactoring-Environment/RBSelectorEnvironment.class.st
+++ b/src/Refactoring-Environment/RBSelectorEnvironment.class.st
@@ -214,15 +214,6 @@ RBSelectorEnvironment >> defaultLabel [
 ]
 
 { #category : #testing }
-RBSelectorEnvironment >> includesCategory: aCategory [
-	^(super includesCategory: aCategory) and:
-			[(self classNamesFor: aCategory) anySatisfy:
-					[:className |
-					(classSelectors includesKey: className)
-						or: [metaClassSelectors includesKey: className]]]
-]
-
-{ #category : #testing }
 RBSelectorEnvironment >> includesClass: aClass [
 	^(self privateSelectorsForClass: aClass) isNotEmpty
 		and: [super includesClass: aClass]

--- a/src/Refactoring-Environment/RBSelectorEnvironment.class.st
+++ b/src/Refactoring-Environment/RBSelectorEnvironment.class.st
@@ -229,6 +229,13 @@ RBSelectorEnvironment >> includesClass: aClass [
 ]
 
 { #category : #testing }
+RBSelectorEnvironment >> includesPackage: aPackage [
+
+	^ (super includesPackage: aPackage) and: [
+		  (self classesInPackage: aPackage) anySatisfy: [ :class | (self includesClass: class) or: [ self includesClass: class class ] ] ]
+]
+
+{ #category : #testing }
 RBSelectorEnvironment >> includesProtocol: aProtocol in: aClass [
 
 	^ (super includesProtocol: aProtocol in: aClass) and: [
@@ -264,24 +271,6 @@ RBSelectorEnvironment >> on: aDictionary [
 		class isMeta
 			ifTrue: [ metaClassSelectors at: class soleInstance name put: selectors asIdentitySet ]
 			ifFalse: [ classSelectors at: class name put: selectors asIdentitySet ] ]
-]
-
-{ #category : #accessing }
-RBSelectorEnvironment >> packages [
-	"Check that packages have really class and selector included."
-
-	| pSet |
-	pSet := Set new.
-	self classes
-		do: [ :each |
-			each packages
-				do: [ :p |
-					self
-						selectorsForClass: each
-						do: [ :s |
-							(p includesSelector: s ofClass: each)
-								ifTrue: [ pSet add: p ] ] ] ].
-	^ pSet
 ]
 
 { #category : #copying }

--- a/src/Refactoring-Environment/RBSelectorEnvironment.class.st
+++ b/src/Refactoring-Environment/RBSelectorEnvironment.class.st
@@ -220,13 +220,6 @@ RBSelectorEnvironment >> includesClass: aClass [
 ]
 
 { #category : #testing }
-RBSelectorEnvironment >> includesPackage: aPackage [
-
-	^ (super includesPackage: aPackage) and: [
-		  (self classesInPackage: aPackage) anySatisfy: [ :class | (self includesClass: class) or: [ self includesClass: class class ] ] ]
-]
-
-{ #category : #testing }
 RBSelectorEnvironment >> includesProtocol: aProtocol in: aClass [
 
 	^ (super includesProtocol: aProtocol in: aClass) and: [

--- a/src/Refactoring-Environment/RBVariableEnvironment.class.st
+++ b/src/Refactoring-Environment/RBVariableEnvironment.class.st
@@ -315,12 +315,6 @@ RBVariableEnvironment >> includesClass: aClass [
 ]
 
 { #category : #testing }
-RBVariableEnvironment >> includesPackage: aPackage [
-
-	^ (self classesInPackage: aPackage) isNotEmpty
-]
-
-{ #category : #testing }
 RBVariableEnvironment >> includesProtocol: aProtocol in: aClass [
 
 	^ (self selectorsFor: aProtocol in: aClass) isNotEmpty

--- a/src/Refactoring-Environment/RBVariableEnvironment.class.st
+++ b/src/Refactoring-Environment/RBVariableEnvironment.class.st
@@ -320,6 +320,12 @@ RBVariableEnvironment >> includesClass: aClass [
 ]
 
 { #category : #testing }
+RBVariableEnvironment >> includesPackage: aPackage [
+
+	^ (self classesInPackage: aPackage) isNotEmpty
+]
+
+{ #category : #testing }
 RBVariableEnvironment >> includesProtocol: aProtocol in: aClass [
 
 	^ (self selectorsFor: aProtocol in: aClass) isNotEmpty
@@ -415,11 +421,6 @@ RBVariableEnvironment >> isVariableEnvironment [
 RBVariableEnvironment >> numberVariables [
 	^self accessorMethods inject: 0
 		into: [:sum :each | sum + ((self perform: each) inject: 0 into: [:s :e | s + e size])]
-]
-
-{ #category : #accessing }
-RBVariableEnvironment >> packages [
-	^ self classes collect: [:each | each package]
 ]
 
 { #category : #copying }

--- a/src/Refactoring-Environment/RBVariableEnvironment.class.st
+++ b/src/Refactoring-Environment/RBVariableEnvironment.class.st
@@ -306,11 +306,6 @@ RBVariableEnvironment >> flushCachesFor: aClass [
 ]
 
 { #category : #testing }
-RBVariableEnvironment >> includesCategory: aCategory [
-	^(self classNamesFor: aCategory) isNotEmpty
-]
-
-{ #category : #testing }
 RBVariableEnvironment >> includesClass: aClass [
 	(super includesClass: aClass) ifFalse: [^false].
 	(instanceVariables includesKey: aClass name) ifTrue: [^true].

--- a/src/Refactoring-Tests-Environment/RBBrowserEnvironmentTest.class.st
+++ b/src/Refactoring-Tests-Environment/RBBrowserEnvironmentTest.class.st
@@ -32,15 +32,6 @@ RBBrowserEnvironmentTest class >> packageNamesUnderTest [
 ]
 
 { #category : #private }
-RBBrowserEnvironmentTest >> categoriesFor: anEnvironment [
-	| allCategories |
-	allCategories := IdentitySet withAll: universalEnvironment categories.
-	allCategories removeAll: anEnvironment categories.
-	anEnvironment not categories do: [ :each | allCategories remove: each ifAbsent: [  ] ].
-	allCategories do: [ :each | self assertEmpty: (universalEnvironment classNamesFor: each) ]
-]
-
-{ #category : #private }
 RBBrowserEnvironmentTest >> classNamesFor: anEnvironment [
 	| classNames allClassNames |
 	classNames := IdentitySet new
@@ -106,6 +97,16 @@ RBBrowserEnvironmentTest >> numberSelectorsFor: aBrowserEnvironment [
 	self assert: (aBrowserEnvironment & aBrowserEnvironment not) numberSelectors equals: 0.
 	self assert: (universalEnvironment & aBrowserEnvironment) numberSelectors equals: numberSelectors.
 	self assert: (aBrowserEnvironment & universalEnvironment) numberSelectors equals: numberSelectors
+]
+
+{ #category : #private }
+RBBrowserEnvironmentTest >> packagesFor: anEnvironment [
+
+	| allPackages |
+	allPackages := IdentitySet withAll: universalEnvironment packages.
+	allPackages removeAll: anEnvironment packages.
+	anEnvironment not packages do: [ :package | allPackages remove: package ifAbsent: [  ] ].
+	allPackages do: [ :package | self assertEmpty: (universalEnvironment classesInPackage: package) ]
 ]
 
 { #category : #private }
@@ -522,7 +523,7 @@ RBBrowserEnvironmentTest >> universalTestFor: aBrowserEnvironment [
 	self storeStringFor: aBrowserEnvironment.
 	self classNamesFor: aBrowserEnvironment.
 	self copyFor: aBrowserEnvironment.
-	self categoriesFor: aBrowserEnvironment.
+	self packagesFor: aBrowserEnvironment.
 	self protocolsFor: aBrowserEnvironment.
 	self classesFor: aBrowserEnvironment.
 	self keysFor: aBrowserEnvironment.


### PR DESCRIPTION
The main goal of this change is to remove the concept of "Categories" from RBBrowserEnvironment and subclasses and use real packages instead. 

A second thing I did in this PR was to speed up the package management of RBBrowserEnvironment and also simplify the code that was too complex for what it does. (the #packages methods is 10 times fast than before and now as fast as #categories was)

A last change is that I remove the last user of #includesSystemCategory: in Monticello and removed this method since it is not useful anymore and is related to categories that we are trying to remove.