### PR TITLE
RPackage: Iteration on tag API in RPackage

### DIFF
--- a/src/Calypso-SystemQueries/ClyTaggedClassGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyTaggedClassGroup.class.st
@@ -55,8 +55,7 @@ ClyTaggedClassGroup >> importClass: aClass [
 ClyTaggedClassGroup >> removeWithClasses [
 
 	super removeWithClasses.
-	classQuery scope packagesDo: [ :each |
-		each removeClassTag: self tag]
+	classQuery scope packagesDo: [ :each | each removeTag: self tag ]
 ]
 
 { #category : #operations }
@@ -66,7 +65,7 @@ ClyTaggedClassGroup >> renameClassTagTo: newTag [
 
 	classQuery scope packagesDo: [ :package |
 		(package tagsForClasses includes: newTag) ifFalse: [ package addClassTag: newTag ].
-		package removeClassTag: self tag ]
+		package removeTag: self tag ]
 ]
 
 { #category : #accessing }

--- a/src/Calypso-SystemQueries/ClyTaggedClassGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyTaggedClassGroup.class.st
@@ -64,7 +64,7 @@ ClyTaggedClassGroup >> renameClassTagTo: newTag [
 	self classes do: [ :class | class packageTag: newTag ].
 
 	classQuery scope packagesDo: [ :package |
-		(package tagsForClasses includes: newTag) ifFalse: [ package addClassTag: newTag ].
+		package ensureTag: newTag.
 		package removeTag: self tag ]
 ]
 

--- a/src/Deprecated12/RPackage.extension.st
+++ b/src/Deprecated12/RPackage.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : #RPackage }
 
 { #category : #'*Deprecated12' }
+RPackage >> basicRemoveTag: tag [
+
+	self deprecated: 'Use #removeTag: instead.' transformWith: '`@rcv removeClassTag: `@arg' -> '`@rcv removeTag: `@arg'.
+	self removeTag: tag
+]
+
+{ #category : #'*Deprecated12' }
 RPackage >> classDefinedSlicesDo: aBlock [
 
 	self deprecated:
@@ -138,4 +145,11 @@ RPackage >> removeClassNamed: aClassName [
 
 	self deprecated: 'Use #removeClass: with a real class instead.'.
 	^ self removeClass: (self organizer environment at: aClassName)
+]
+
+{ #category : #'*Deprecated12' }
+RPackage >> removeClassTag: aSymbol [
+
+	self deprecated: 'Use #removeTag: instead.' transformWith: '`@rcv removeClassTag: `@arg' -> '`@rcv removeTag: `@arg'.
+	self removeTag: aSymbol
 ]

--- a/src/Deprecated12/RPackage.extension.st
+++ b/src/Deprecated12/RPackage.extension.st
@@ -49,6 +49,15 @@ RPackage >> classNamesAndExtensionSelectorsDo: aBlock [
 ]
 
 { #category : #'*Deprecated12' }
+RPackage >> classNamesForClassTag: aSymbol [
+	"Returns the classes tagged using aSymbol"
+
+	self deprecated: 'This method is too specific and will be remove in future versions of Pharo. If you are using it you can inline the method'.
+
+	^ (self classTagNamed: aSymbol ifAbsent: [ ^ #(  ) ]) classNames
+]
+
+{ #category : #'*Deprecated12' }
 RPackage >> definedClassesDo: aBlock [
 
 	self deprecated:

--- a/src/Deprecated12/RPackage.extension.st
+++ b/src/Deprecated12/RPackage.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : #RPackage }
 
 { #category : #'*Deprecated12' }
+RPackage >> addClassTag: tagName [
+
+	self deprecated: 'Use #ensureTag: instead' transformWith: '`@rcv addClassTag: `@arg' -> '`@rcv ensureTag: `@arg'.
+	^ self ensureTag: tagName
+]
+
+{ #category : #'*Deprecated12' }
 RPackage >> basicRemoveTag: tag [
 
 	self deprecated: 'Use #removeTag: instead.' transformWith: '`@rcv removeClassTag: `@arg' -> '`@rcv removeTag: `@arg'.

--- a/src/RPackage-Core/ClassDescription.extension.st
+++ b/src/RPackage-Core/ClassDescription.extension.st
@@ -68,7 +68,7 @@ ClassDescription >> packageTag [
 ClassDescription >> packageTag: aSymbol [
 
 	self flag: #package. "In the future this method should work with a real package tag also."
-	(self package addClassTag: aSymbol) addClass: self
+	(self package ensureTag: aSymbol) addClass: self
 ]
 
 { #category : #'*RPackage-Core' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -177,17 +177,6 @@ RPackage >> addMethod: aCompiledMethod [
 	^ aCompiledMethod
 ]
 
-{ #category : #private }
-RPackage >> basicAddClassTag: tagName [
-
-	| packageTag |
-	packageTag := RPackageTag package: self name: tagName.
-	classTags add: packageTag.
-	self organizer addCategory: packageTag categoryName.
-
-	^ packageTag
-]
-
 { #category : #'class tags' }
 RPackage >> classNamesForClassTag: aSymbol [
 	"Returns the classes tagged using aSymbol"
@@ -335,14 +324,22 @@ RPackage >> ensureProperties [
 RPackage >> ensureTag: aTag [
 
 	| tagName newTag |
-	tagName := aTag isString ifTrue: [ aTag ] ifFalse: [ aTag name ].
+	tagName := aTag isString
+		           ifTrue: [ aTag ]
+		           ifFalse: [ aTag name ].
 
 	(self hasTag: aTag) ifTrue: [ ^ self classTagNamed: tagName ].
 
-	self name = tagName ifFalse: [
-		self flag: #package. "We are giving nil as first tag name because currently there is a bug that we cannot have a package that has the same name as a package and tag. So we first want to ensure we do not have a package of the same name. When this limitation will be removed in the future we should directly give the package name and the tag name without going through the nil."
-		self organizer validateCanBeAddedPackageName: self name , '-' , tagName tagName: nil ].
-	newTag := self basicAddClassTag: tagName.
+
+	self flag: #package. "We are checking because currently there is a bug that we cannot have a package that has the same name as a package and tag. So we first want to ensure we do not have a package of the same name. When this limitation will be removed in the future we should remove the next check."
+	self name = tagName ifFalse: [ self organizer validateCanBeAddedPackageName: self name , '-' , tagName tagName: nil ].
+
+	newTag := RPackageTag package: self name: tagName.
+	classTags add: newTag.
+
+	self flag: #package. "Next line should go with the system organizer"
+	self organizer addCategory: newTag categoryName.
+
 	SystemAnnouncer announce: (PackageTagAdded to: newTag).
 	^ newTag
 ]

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -178,15 +178,6 @@ RPackage >> addMethod: aCompiledMethod [
 ]
 
 { #category : #'class tags' }
-RPackage >> classNamesForClassTag: aSymbol [
-	"Returns the classes tagged using aSymbol"
-
-	^ (self
-		classTagNamed: aSymbol
-		ifAbsent: [ ^ #() ]) classNames
-]
-
-{ #category : #'class tags' }
 RPackage >> classTagCategoryNames [
 	^ (Set with: self packageName), (self classTags collect: [:each | each categoryName])
 ]

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -162,14 +162,11 @@ RPackage >> addClass: aClass [
 ]
 
 { #category : #'class tags' }
-RPackage >> addClassTag: aSymbol [
+RPackage >> addClassTag: tagName [
 	"Add the class tag from the receiver, if already added do nothing."
 
-	| tagName newTag |
-	"strip package name if needed"
-	tagName := self toTagName: aSymbol.
-
 	^ self classTagNamed: tagName ifAbsent: [
+		  | newTag |
 		  self name = tagName ifFalse: [
 			  self flag: #package. "We are giving nil as first tag name because currently there is a bug that we cannot have a package that has the same name as a package and tag. So we first want to ensure we do not have a package of the same name. When this limitation will be removed in the future we should directly give the package name and the tag name without going through the nil."
 			  self organizer validateCanBeAddedPackageName: self name , '-' , tagName tagName: nil ].
@@ -445,7 +442,8 @@ RPackage >> importClass: aClass [
 	Handle also *- convention. Methods defined in *category are not added to the package.
 	Pay attention that it will not import anything from the metaClass side"
 
-	self importClass: aClass inTag: aClass category
+	self flag: #package. "Do not rely on the category here in the future"
+	self importClass: aClass inTag: (self toTagName: aClass category)
 ]
 
 { #category : #private }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -158,21 +158,7 @@ RPackage >> addClass: aClass [
 		- change the class category as appropriate.
 			(and by cascade, ensure systemClassRecategorizedAction: is called)."
 
-	aClass category: (self addClassTag: self name) categoryName
-]
-
-{ #category : #'class tags' }
-RPackage >> addClassTag: tagName [
-	"Add the class tag from the receiver, if already added do nothing."
-
-	^ self classTagNamed: tagName ifAbsent: [
-		  | newTag |
-		  self name = tagName ifFalse: [
-			  self flag: #package. "We are giving nil as first tag name because currently there is a bug that we cannot have a package that has the same name as a package and tag. So we first want to ensure we do not have a package of the same name. When this limitation will be removed in the future we should directly give the package name and the tag name without going through the nil."
-			  self organizer validateCanBeAddedPackageName: self name , '-' , tagName tagName: nil ].
-		  newTag := self basicAddClassTag: tagName.
-		  SystemAnnouncer announce: (PackageTagAdded to: newTag).
-		  ^ newTag ]
+	aClass category: self rootTag categoryName
 ]
 
 { #category : #'add method - compiled method' }
@@ -332,7 +318,7 @@ RPackage >> demoteToTagInPackage [
 	newPackage := self organizer ensurePackage: (self name copyUpToLast: $-).
 
 	"We keep the suffix that was removed as the tag name to create."
-	tag := newPackage addClassTag: (self name withoutPrefix: newPackage name , '-').
+	tag := newPackage ensureTag: (self name withoutPrefix: newPackage name , '-').
 
 	self definedClasses do: [ :class | newPackage moveClass: class toTag: tag ].
 	self extensionMethods do: [ :method | newPackage addMethod: method ].
@@ -343,6 +329,22 @@ RPackage >> demoteToTagInPackage [
 { #category : #properties }
 RPackage >> ensureProperties [
 	^ Properties at: self ifAbsentPut: WeakKeyDictionary new
+]
+
+{ #category : #'class tags' }
+RPackage >> ensureTag: aTag [
+
+	| tagName newTag |
+	tagName := aTag isString ifTrue: [ aTag ] ifFalse: [ aTag name ].
+
+	(self hasTag: aTag) ifTrue: [ ^ self classTagNamed: tagName ].
+
+	self name = tagName ifFalse: [
+		self flag: #package. "We are giving nil as first tag name because currently there is a bug that we cannot have a package that has the same name as a package and tag. So we first want to ensure we do not have a package of the same name. When this limitation will be removed in the future we should directly give the package name and the tag name without going through the nil."
+		self organizer validateCanBeAddedPackageName: self name , '-' , tagName tagName: nil ].
+	newTag := self basicAddClassTag: tagName.
+	SystemAnnouncer announce: (PackageTagAdded to: newTag).
+	^ newTag
 ]
 
 { #category : #accessing }
@@ -423,9 +425,9 @@ RPackage >> hasProperty: aKey [
 RPackage >> hasTag: aTag [
 	"Takes a package tag or a package tag name as parameter and return true if I include this package tag."
 
-	^ aTag isString
-		  ifTrue: [ self classTags anySatisfy: [ :tag | tag name = aTag ] ]
-		  ifFalse: [ self classTags includes: aTag ]
+	^ self tagNames includes: (aTag isString
+			   ifTrue: [ aTag ]
+			   ifFalse: [ aTag name ])
 ]
 
 { #category : #accessing }
@@ -458,7 +460,7 @@ RPackage >> importClass: aClass inTag: aTag [
 
 	self removeAllMethodsFromClass: aClass.
 	
-	(self addClassTag: (aTag isString ifTrue: [ aTag ] ifFalse: [ aTag name ])) addClass: aClass instanceSide.
+	(self ensureTag: aTag) addClass: aClass instanceSide.
 
 	"Maybe this should go in the PackageTag during the addition of the class"
 	self registerClass: aClass.
@@ -940,7 +942,7 @@ RPackage >> renameTo: aSymbol [
 { #category : #'class tags' }
 RPackage >> rootTag [
 
-	^ self addClassTag: self rootTagName
+	^ self ensureTag: self rootTagName
 ]
 
 { #category : #accessing }
@@ -981,6 +983,11 @@ RPackage >> selectorsForClass: aClass [
 { #category : #'system compatibility' }
 RPackage >> systemCategoryPrefix [
 	^ self name
+]
+
+{ #category : #'class tags' }
+RPackage >> tagNames [
+	^ self classTags collect: [ :tag | tag name ]
 ]
 
 { #category : #queries }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -206,14 +206,6 @@ RPackage >> basicAddClassTag: tagName [
 ]
 
 { #category : #'class tags' }
-RPackage >> basicRemoveTag: tag [
-
-	classTags remove: tag ifAbsent: [  ].
-
-	SystemAnnouncer announce: (PackageTagRemoved to: tag)
-]
-
-{ #category : #'class tags' }
 RPackage >> classNamesForClassTag: aSymbol [
 	"Returns the classes tagged using aSymbol"
 
@@ -794,22 +786,13 @@ RPackage >> removeClassDefinition: aClass fromClassTag: aSymbol [
 	| tag |
 	tag := self classTagNamed: aSymbol ifAbsent: [ ^ self ].
 	tag removeClass: aClass.
-	tag isEmpty ifTrue: [ self basicRemoveTag: tag ]
-]
-
-{ #category : #'class tags' }
-RPackage >> removeClassTag: aSymbol [
-	"Remove the class tag from the receiver."
-
-	self basicRemoveTag: (self
-		classTagNamed:  (self toTagName: aSymbol)
-		ifAbsent: [ ^ self ])
+	tag isEmpty ifTrue: [ self removeTag: tag ]
 ]
 
 { #category : #'class tags' }
 RPackage >> removeEmptyTags [
 
-	(self classTags select: [ :tag | tag isEmpty ]) do: [ :emptyTag | self removeClassTag: emptyTag name ]
+	(self classTags select: [ :tag | tag isEmpty ]) do: [ :emptyTag | self removeTag: emptyTag ]
 ]
 
 { #category : #removing }
@@ -884,11 +867,14 @@ RPackage >> removeProperty: propName ifAbsent: aBlock [
 { #category : #'class tags' }
 RPackage >> removeTag: aTag [
 
-	| tagName |
-	tagName := aTag isString
-		           ifTrue: [ aTag ]
-		           ifFalse: [ aTag name ].
-	self removeClassTag: tagName
+	| tag |
+	tag := aTag isString
+		       ifTrue: [ self classTagNamed: aTag ifAbsent: [ ^ self ] ]
+		       ifFalse: [ aTag ].
+
+	classTags remove: tag ifAbsent: [ ^ self ].
+
+	SystemAnnouncer announce: (PackageTagRemoved to: tag)
 ]
 
 { #category : #private }
@@ -951,12 +937,6 @@ RPackage >> renameTo: aSymbol [
 		basicUnregisterPackageNamed: oldName;
 		basicRegisterPackage: self.
 	SystemAnnouncer uniqueInstance announce: (PackageRenamed to: self oldName: oldName newName: newName)
-]
-
-{ #category : #private }
-RPackage >> reportBogusBehaviorOf: aSelector [
-
-	self traceCr: 'RPackage log: Something wrong around ', aSelector asString , 'since the removeKey: is called on not present information.'
 ]
 
 { #category : #'class tags' }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -348,7 +348,7 @@ RPackageOrganizer >> ensurePackageOfExtensionProtocol: aProtocol [
 { #category : #registration }
 RPackageOrganizer >> ensureTagNamed: aTagName inPackageNamed: aPackageName [
 
-	^ (self ensurePackage: aPackageName) addClassTag: aTagName
+	^ (self ensurePackage: aPackageName) ensureTag: aTagName
 ]
 
 { #category : #'deprecated - SystemOrganizer leftovers' }
@@ -778,7 +778,7 @@ RPackageOrganizer >> systemCategoryAddedActionFrom: ann [
 	package := self ensurePackageMatching: ann categoryName.
 
 	"We extract the tag name from the category"
-	package addClassTag: (package toTagName: ann categoryName)
+	package ensureTag: (package toTagName: ann categoryName)
 ]
 
 { #category : #'system integration' }
@@ -798,7 +798,7 @@ RPackageOrganizer >> systemClassRecategorizedActionFrom: announcement [
 	newCategoryName = announcement oldCategory ifTrue: [ ^ self ].
 	newPackage := self ensurePackageMatching: newCategoryName.
 
-	newPackage moveClass: class toTag: (newPackage addClassTag: (newPackage toTagName: newCategoryName))
+	newPackage moveClass: class toTag: (newPackage ensureTag: (newPackage toTagName: newCategoryName))
 ]
 
 { #category : #'system integration' }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -774,7 +774,11 @@ RPackageOrganizer >> superclassOrder: category [
 { #category : #'system integration' }
 RPackageOrganizer >> systemCategoryAddedActionFrom: ann [
 
-	(self ensurePackageMatching: ann categoryName) addClassTag: ann categoryName asSymbol
+	| package |
+	package := self ensurePackageMatching: ann categoryName.
+
+	"We extract the tag name from the category"
+	package addClassTag: (package toTagName: ann categoryName)
 ]
 
 { #category : #'system integration' }
@@ -786,15 +790,15 @@ RPackageOrganizer >> systemClassAddedActionFrom: ann [
 { #category : #'system integration' }
 RPackageOrganizer >> systemClassRecategorizedActionFrom: announcement [
 
-	| class newPackage newPackageName |
+	| class newPackage newCategoryName |
 	class := announcement classAffected.
 
-	newPackageName := announcement newCategory.
+	newCategoryName := announcement newCategory.
 
-	newPackageName = announcement oldCategory ifTrue: [ ^ self ].
-	newPackage := self ensurePackageMatching: newPackageName.
+	newCategoryName = announcement oldCategory ifTrue: [ ^ self ].
+	newPackage := self ensurePackageMatching: newCategoryName.
 
-	newPackage moveClass: class toTag: (newPackage addClassTag: newPackageName)
+	newPackage moveClass: class toTag: (newPackage addClassTag: (newPackage toTagName: newCategoryName))
 ]
 
 { #category : #'system integration' }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -636,7 +636,7 @@ RPackageOrganizer >> removeCategory: aCategory [
 	(self packageMatchingExtensionName: category) ifNotNil: [ :package |
 		package name = category
 			ifTrue: [ self removePackage: package ]
-			ifFalse: [ package classTagNamed: (category withoutPrefix: package name , '-') ifPresent: [ :tag | package removeClassTag: tag name ] ] ]
+			ifFalse: [ package classTagNamed: (category withoutPrefix: package name , '-') ifPresent: [ :tag | package removeTag: tag ] ] ]
 ]
 
 { #category : #'system integration' }

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -100,7 +100,7 @@ RPackageTag >> name [
 { #category : #accessing }
 RPackageTag >> name: aSymbol [
 
-	name := aSymbol
+	name := aSymbol asSymbol
 ]
 
 { #category : #accessing }

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -153,11 +153,10 @@ RPackageTag >> removeClass: aClass [
 
 { #category : #accessing }
 RPackageTag >> removeFromPackage [
-	self
-		assert: self isEmpty
-		description: 'Package tag is not empty'.
 
-	self package basicRemoveTag: self
+	self assert: self isEmpty description: 'Package tag is not empty'.
+
+	self package removeTag: self
 ]
 
 { #category : #accessing }

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -175,7 +175,7 @@ RPackageOrganizerTest >> testRegisterPackageConflictWithPackageTag [
 	| package1 |
 	self flag: #package. "This is a limitiation of the system organizer. I hope to kill this limitiation before p12 release."
 	package1 := self createNewPackageNamed: 'P1'.
-	package1 addClassTag: #T1.
+	package1 ensureTag: #T1.
 
 	self should: [ self createNewPackageNamed: 'P1-T1' ] raise: Error
 ]
@@ -188,7 +188,7 @@ RPackageOrganizerTest >> testRegisterPackageTagConflictWithPackage [
 	package1 := self createNewPackageNamed: 'P1-T1'.
 
 	package2 := self createNewPackageNamed: 'P1'.
-	self should: [ package2 addClassTag: #T1 ] raise: Error
+	self should: [ package2 ensureTag: #T1 ] raise: Error
 ]
 
 { #category : #tests }
@@ -246,8 +246,8 @@ RPackageOrganizerTest >> testRemoveEmptyPackagesAndTags [
 	"This one will be empty"
 	package4 := (self createNewPackageNamed: #Test4).
 
-	tag1 := package3 addClassTag: #Tag1.
-	tag2 := package3 addClassTag: #Tag2.
+	tag1 := package3 ensureTag: #Tag1.
+	tag2 := package3 ensureTag: #Tag2.
 
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1'.
 	class compile: 'extension ^ 1' classified: '*Test2'.

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -307,11 +307,11 @@ RPackageReadOnlyCompleteSetupTest >> testRemoveTag [
 	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
 	self assert: (p1 classesForClassTag: #foo) size equals: 2.
 
-	p1 removeClassTag: #bar.
+	p1 removeTag: #bar.
 	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
 	self assert: (p1 classesForClassTag: #foo) size equals: 2.
 
-	p1 removeClassTag: #foo.
+	p1 removeTag: #foo.
 	self deny: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
 	self assert: (p1 classesForClassTag: #foo) size equals: 0
 ]

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -101,16 +101,16 @@ RPackageReadOnlyCompleteSetupTest >> testAddTagNames [
 	p1 importClass: b1 inTag: #foo.
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #foo ]).
 	self assert: p1 classTags size equals: 2. "foo and baz. The root tag got automatically removed since it was empty."
-	self assert: ((p1 classNamesForClassTag: #foo) includes: #A1DefinedInP1).
-	self assert: ((p1 classNamesForClassTag: #foo) includes: #B1DefinedInP1).
-	self assert: (p1 classNamesForClassTag: #foo) size equals: 2.
+	self assert: ((p1 classTagNamed: #foo) classNames includes: #A1DefinedInP1).
+	self assert: ((p1 classTagNamed: #foo) classNames includes: #B1DefinedInP1).
+	self assert: (p1 classTagNamed: #foo) classNames size equals: 2.
 
 	p1 ensureTag: #foo.
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #baz ]).
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #foo ]).
-	self assert: ((p1 classNamesForClassTag: #foo) includes: #A1DefinedInP1).
-	self assert: ((p1 classNamesForClassTag: #foo) includes: #B1DefinedInP1).
-	self assert: (p1 classNamesForClassTag: #foo) size equals: 2
+	self assert: ((p1 classTagNamed: #foo) classNames includes: #A1DefinedInP1).
+	self assert: ((p1 classTagNamed: #foo) classNames includes: #B1DefinedInP1).
+	self assert: (p1 classTagNamed: #foo) classNames size equals: 2
 ]
 
 { #category : #'tests - tag class' }

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -69,7 +69,7 @@ RPackageReadOnlyCompleteSetupTest >> setUp [
 RPackageReadOnlyCompleteSetupTest >> testAddTag [
 
 	self assert: p1 classTags size equals: 1. "We start with the root tag"
-	p1 addClassTag: #baz.
+	p1 ensureTag: #baz.
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #baz ]).
 	self assert: p1 classTags size equals: 2.
 
@@ -81,7 +81,7 @@ RPackageReadOnlyCompleteSetupTest >> testAddTag [
 	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
 	self assert: (p1 classesForClassTag: #foo) size equals: 2.
 
-	p1 addClassTag: #foo.
+	p1 ensureTag: #foo.
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #baz ]).
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #foo ]).
 	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
@@ -93,7 +93,7 @@ RPackageReadOnlyCompleteSetupTest >> testAddTag [
 RPackageReadOnlyCompleteSetupTest >> testAddTagNames [
 
 	self assert: p1 classTags size equals: 1. "We start with the root tag"
-	p1 addClassTag: #baz.
+	p1 ensureTag: #baz.
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #baz ]).
 	self assert: p1 classTags size equals: 2.
 
@@ -105,7 +105,7 @@ RPackageReadOnlyCompleteSetupTest >> testAddTagNames [
 	self assert: ((p1 classNamesForClassTag: #foo) includes: #B1DefinedInP1).
 	self assert: (p1 classNamesForClassTag: #foo) size equals: 2.
 
-	p1 addClassTag: #foo.
+	p1 ensureTag: #foo.
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #baz ]).
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #foo ]).
 	self assert: ((p1 classNamesForClassTag: #foo) includes: #A1DefinedInP1).

--- a/src/RPackage-Tests/RPackageTagTest.class.st
+++ b/src/RPackage-Tests/RPackageTagTest.class.st
@@ -25,7 +25,7 @@ RPackageTagTest >> testAddClass [
 
 	package2 := self createNewPackageNamed: #Test2.
 
-	(package2 addClassTag: #TAG) addClass: class.
+	(package2 ensureTag: #TAG) addClass: class.
 
 	self deny: (package1 includesClass: class).
 	self assert: (package2 includesClass: class).
@@ -46,7 +46,7 @@ RPackageTagTest >> testAddClassFromTag [
 
 	package2 := self createNewPackageNamed: #Test2.
 
-	(package2 addClassTag: #TAG2) addClass: class.
+	(package2 ensureTag: #TAG2) addClass: class.
 
 	self deny: (package1 includesClass: class).
 	self assert: (package2 includesClass: class).

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -286,8 +286,8 @@ RPackageTest >> testRemoveEmptyTags [
 	| package class tag1 tag2 |
 	package := self createNewPackageNamed: #Test1.
 
-	tag1 := package addClassTag: #Tag1.
-	tag2 := package addClassTag: #Tag2.
+	tag1 := package ensureTag: #Tag1.
+	tag2 := package ensureTag: #Tag2.
 
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-Tag1'.
 

--- a/src/SystemCommands-PackageCommands/SycAddNewClassTagCommand.class.st
+++ b/src/SystemCommands-PackageCommands/SycAddNewClassTagCommand.class.st
@@ -42,7 +42,7 @@ SycAddNewClassTagCommand >> defaultMenuItemName [
 { #category : #execution }
 SycAddNewClassTagCommand >> execute [
 
-	package addClassTag: tagName
+	package ensureTag: tagName
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This change goal is to simplify the tag API of RPackage and make it more explicit.

* #addClassTag: was a bad name because it does not necessary add a tag. If the tag already exists, it will return the existing one. I propose to rename it #ensureTag: 
* #basicAddClassTag: is inlined in #ensureTag: 
* #classNamesForClassTag is deprecated since it has few utilities
* #basicRemoveTag: and #removeClassTag: were removed to keep only #removeTag: