### PR TITLE
RPackage: Unify creation of packages from extension protocols

### DIFF
--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -256,13 +256,6 @@ RPackageOrganizer >> categoryOfBehavior: behavior [
 	^ nil
 ]
 
-{ #category : #'private - registration' }
-RPackageOrganizer >> checkPackageExistsOrRegister: packageName [
-
-	(self packages anySatisfy: [ :package | packageName isCategoryOf: package packageName ]) ifFalse: [
-		(RPackage named: packageName capitalized organizer: self) register ]
-]
-
 { #category : #'deprecated - SystemOrganizer leftovers' }
 RPackageOrganizer >> classesInCategory: category [
 
@@ -801,7 +794,7 @@ RPackageOrganizer >> systemClassRecategorizedActionFrom: announcement [
 RPackageOrganizer >> systemClassReorganizedActionFrom: ann [
 	"when a class is reorganized, we have to check if an extension has not been added"
 
-	ann classReorganized extensionProtocols do: [ :protocol | self checkPackageExistsOrRegister: protocol name allButFirst ]
+	ann classReorganized extensionProtocols do: [ :protocol | self ensurePackageOfExtensionProtocol: protocol ]
 ]
 
 { #category : #'system integration' }


### PR DESCRIPTION
This change is removing #checkPackageExistsOrRegister: because it is based on a brittle category management.

The last user was to ensure extension protocols have a packages associated and this usage was updated to use the same method than other places doing the same check