### PR TITLE
Calypso: Prevent the recategorization of removed methods

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
@@ -86,7 +86,7 @@ ClyMethodEditorToolMorph >> currentEditedAST [
 { #category : #operations }
 ClyMethodEditorToolMorph >> editProtocolOf: aMethod [
 
-	self applyChangesBy: [ aMethod protocol: methodProtocol ]
+	self applyChangesBy: [ methodProtocol ifNotNil: [ :protocolName | aMethod protocol: protocolName ] ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Calypso is listening to method changes to update the method pane. But doing this it forces the recategorization of methods in case the method has no protocol. This is happening when we explicitly remove a method from a protocol during a method removal. 

This change make sure we do not update the protocol of a method if its protocol is nil

Fixes #14553