### PR TITLE
RPackage: #packageTag should always return a tag

### DIFF
--- a/src/Calypso-SystemQueries/ClyRestUntaggedClassesQuery.class.st
+++ b/src/Calypso-SystemQueries/ClyRestUntaggedClassesQuery.class.st
@@ -42,5 +42,5 @@ ClyRestUntaggedClassesQuery >> description [
 { #category : #testing }
 ClyRestUntaggedClassesQuery >> selectsClass: aClass [
 
-	^ aClass packageTag isNil
+	^ aClass packageTag isRoot
 ]

--- a/src/Calypso-SystemQueries/ClyUntaggedClassesQuery.class.st
+++ b/src/Calypso-SystemQueries/ClyUntaggedClassesQuery.class.st
@@ -16,5 +16,5 @@ ClyUntaggedClassesQuery >> description [
 { #category : #testing }
 ClyUntaggedClassesQuery >> selectsClass: aClass [
 
-	^ aClass packageTag isNil
+	^ aClass packageTag isRoot
 ]

--- a/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserMorph.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserMorph.class.st
@@ -590,25 +590,24 @@ ClyFullBrowserMorph >> restrictMethodVisibilityBy: aClassScope [
 
 { #category : #navigation }
 ClyFullBrowserMorph >> selectClass: aClass [
+
 	| foundItems classDefinition |
 	self changeStateBy: [
 		self switchToMetaLevelScope: aClass metaLevelScope.
 		foundItems := classView findItemsWith: { aClass instanceSide }.
-		foundItems ifNotEmpty: [
-			"we want ensure that selected package is the package of found class.
+		foundItems ifNotEmpty: [ "we want ensure that selected package is the package of found class.
 			If it is not then we will select required package"
 			classDefinition := foundItems anyOne systemDefinition.
-			(self isPackageSelected: classDefinition definingPackage)
-				ifTrue: [ ^self classSelection selectItems: foundItems ]].
+			(self isPackageSelected: classDefinition definingPackage) ifTrue: [ ^ self classSelection selectItems: foundItems ] ].
 
-		aClass packageTagName
-			ifNil: [ self selectPackage: aClass package]
-			ifNotNil: [ :tag | self selectPackage: aClass package atClassTag: tag ].
-		self packageSelection isEmpty ifTrue: [ ^self ].
+		aClass packageTag isRoot
+			ifTrue: [ self selectPackage: aClass package ]
+			ifFalse: [ self selectPackage: aClass package atClassTag: aClass packageTagName ].
+
+		self packageSelection isEmpty ifTrue: [ ^ self ].
 
 		self showsFullClassHierarchy ifTrue: [ self switchToFullClassHierarchyOf: aClass ].
-		self classSelection selectItemsWith: { aClass instanceSide }
-	]
+		self classSelection selectItemsWith: { aClass instanceSide } ]
 ]
 
 { #category : #navigation }
@@ -723,15 +722,14 @@ ClyFullBrowserMorph >> showsFullClassHierarchy [
 ClyFullBrowserMorph >> silentlySelectPackageOfSelectedClass [
 
 	| selectedClass |
-
-	self classSelection isEmpty ifTrue: [ ^self ].
+	self classSelection isEmpty ifTrue: [ ^ self ].
 
 	selectedClass := self classSelection lastSelectedItem actualObject.
 
 	packageView ignoreNavigationDuring: [
-		selectedClass packageTagName
-			ifNil: [ self selectPackage: selectedClass package]
-			ifNotNil: [ :tag | self selectPackage: selectedClass package atClassTag: tag ] ]
+		selectedClass packageTag isRoot
+			ifTrue: [ self selectPackage: selectedClass package ]
+			ifFalse: [ self selectPackage: selectedClass package atClassTag: selectedClass packageTagName ] ]
 ]
 
 { #category : #navigation }

--- a/src/GeneralRules/ReClassNotCategorizedRule.class.st
+++ b/src/GeneralRules/ReClassNotCategorizedRule.class.st
@@ -27,7 +27,7 @@ ReClassNotCategorizedRule >> basicCheck: aClass [
 
 	aClass isMeta ifTrue: [ ^ false ].
 
-	^ aClass packageTag isNil and: [ aClass package classTags size > 1 ]
+	^ aClass packageTag isRoot and: [ aClass package classTags size > 1 ]
 ]
 
 { #category : #accessing }

--- a/src/RPackage-Core/ClassDescription.extension.st
+++ b/src/RPackage-Core/ClassDescription.extension.st
@@ -56,7 +56,7 @@ ClassDescription >> packageName [
 
 { #category : #'*RPackage-Core' }
 ClassDescription >> packageTag [
-	"Package tags are sub categories of packages to have a better organization of the packages. I return my package tag or nil if the class is uncategorized."
+	"Package tags are sub categories of packages to have a better organization of the packages."
 
 	^ self package classTagForClass: self
 ]

--- a/src/RPackage-Core/ClassDescription.extension.st
+++ b/src/RPackage-Core/ClassDescription.extension.st
@@ -58,10 +58,7 @@ ClassDescription >> packageName [
 ClassDescription >> packageTag [
 	"Package tags are sub categories of packages to have a better organization of the packages. I return my package tag or nil if the class is uncategorized."
 
-	| packageTag |
-	packageTag := (self package classTagForClass: self) ifNil: [ ^ nil ].
-	packageTag isRoot ifTrue: [ ^ nil ].
-	^ packageTag
+	^ self package classTagForClass: self
 ]
 
 { #category : #'*RPackage-Core' }
@@ -88,7 +85,8 @@ ClassDescription >> packages [
 { #category : #'*RPackage-Core' }
 ClassDescription >> removePackageTag [
 
-	self packageTag ifNotNil: [ :tag |
-		tag removeClass: self.
-		self package addClass: self ]
+	self packageTag isRoot ifTrue: [ "Cannot remove root tag" ^ self ].
+
+	self packageTag removeClass: self.
+	self package addClass: self
 ]

--- a/src/Ring-Core/RGReadOnlyImageBackend.class.st
+++ b/src/Ring-Core/RGReadOnlyImageBackend.class.st
@@ -298,7 +298,7 @@ RGReadOnlyImageBackend >> superclassFor: anRGBehavior [
 { #category : #behavior }
 RGReadOnlyImageBackend >> tagsForClass: anRGBehavior do: aBlock [
 
-	(self realBehaviorFor: anRGBehavior) packageTagName ifNotNil: [ :tag | aBlock value: tag ]
+	(self realBehaviorFor: anRGBehavior) packageTag isRoot ifFalse: [ aBlock value: (self realBehaviorFor: anRGBehavior) packageTagName ]
 ]
 
 { #category : #method }


### PR DESCRIPTION
ClassDescription>>#packageTag has a guard to return nil if the class is in the default tag. This can cause some problems and make the RPAckage code more complex. 

I propose to always return a tag and is #isRoot instead of #ifNil: to manage the root tag. This will simplify future changes