### PR TITLE
RPackage: Remove categories from class removal announcement

### DIFF
--- a/src/Calypso-SystemQueries/ClyRestUntaggedClassesQuery.class.st
+++ b/src/Calypso-SystemQueries/ClyRestUntaggedClassesQuery.class.st
@@ -42,5 +42,5 @@ ClyRestUntaggedClassesQuery >> description [
 { #category : #testing }
 ClyRestUntaggedClassesQuery >> selectsClass: aClass [
 
-	^ aClass packageTag isNil
+	^ aClass packageTag isRoot
 ]

--- a/src/Calypso-SystemQueries/ClyUntaggedClassesQuery.class.st
+++ b/src/Calypso-SystemQueries/ClyUntaggedClassesQuery.class.st
@@ -16,5 +16,5 @@ ClyUntaggedClassesQuery >> description [
 { #category : #testing }
 ClyUntaggedClassesQuery >> selectsClass: aClass [
 
-	^ aClass packageTag isNil
+	^ aClass packageTag isRoot
 ]

--- a/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserMorph.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserMorph.class.st
@@ -590,25 +590,24 @@ ClyFullBrowserMorph >> restrictMethodVisibilityBy: aClassScope [
 
 { #category : #navigation }
 ClyFullBrowserMorph >> selectClass: aClass [
+
 	| foundItems classDefinition |
 	self changeStateBy: [
 		self switchToMetaLevelScope: aClass metaLevelScope.
 		foundItems := classView findItemsWith: { aClass instanceSide }.
-		foundItems ifNotEmpty: [
-			"we want ensure that selected package is the package of found class.
+		foundItems ifNotEmpty: [ "we want ensure that selected package is the package of found class.
 			If it is not then we will select required package"
 			classDefinition := foundItems anyOne systemDefinition.
-			(self isPackageSelected: classDefinition definingPackage)
-				ifTrue: [ ^self classSelection selectItems: foundItems ]].
+			(self isPackageSelected: classDefinition definingPackage) ifTrue: [ ^ self classSelection selectItems: foundItems ] ].
 
-		aClass packageTagName
-			ifNil: [ self selectPackage: aClass package]
-			ifNotNil: [ :tag | self selectPackage: aClass package atClassTag: tag ].
-		self packageSelection isEmpty ifTrue: [ ^self ].
+		aClass packageTag isRoot
+			ifTrue: [ self selectPackage: aClass package ]
+			ifFalse: [ self selectPackage: aClass package atClassTag: aClass packageTagName ].
+
+		self packageSelection isEmpty ifTrue: [ ^ self ].
 
 		self showsFullClassHierarchy ifTrue: [ self switchToFullClassHierarchyOf: aClass ].
-		self classSelection selectItemsWith: { aClass instanceSide }
-	]
+		self classSelection selectItemsWith: { aClass instanceSide } ]
 ]
 
 { #category : #navigation }
@@ -723,15 +722,14 @@ ClyFullBrowserMorph >> showsFullClassHierarchy [
 ClyFullBrowserMorph >> silentlySelectPackageOfSelectedClass [
 
 	| selectedClass |
-
-	self classSelection isEmpty ifTrue: [ ^self ].
+	self classSelection isEmpty ifTrue: [ ^ self ].
 
 	selectedClass := self classSelection lastSelectedItem actualObject.
 
 	packageView ignoreNavigationDuring: [
-		selectedClass packageTagName
-			ifNil: [ self selectPackage: selectedClass package]
-			ifNotNil: [ :tag | self selectPackage: selectedClass package atClassTag: tag ] ]
+		selectedClass packageTag isRoot
+			ifTrue: [ self selectPackage: selectedClass package ]
+			ifFalse: [ self selectPackage: selectedClass package atClassTag: selectedClass packageTagName ] ]
 ]
 
 { #category : #navigation }

--- a/src/Deprecated12/ClassAnnouncement.extension.st
+++ b/src/Deprecated12/ClassAnnouncement.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #ClassAnnouncement }
+
+{ #category : #'*Deprecated12' }
+ClassAnnouncement >> classTagAffected [
+
+	self deprecated: 'Use #packageTagAffected that returns a real package tag instance instead.'.
+	^ self packageTagAffected name
+]

--- a/src/Deprecated12/ClassRemoved.extension.st
+++ b/src/Deprecated12/ClassRemoved.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #ClassRemoved }
+
+{ #category : #'*Deprecated12' }
+ClassRemoved >> categoryName [
+
+	self deprecated: 'Use package and tag instead of the category.'.
+	^ self packageTagAffected categoryName
+]

--- a/src/Epicea/EpMonitor.class.st
+++ b/src/Epicea/EpMonitor.class.st
@@ -198,10 +198,11 @@ EpMonitor >> behaviorRemoved: aClassRemovedAnnouncement [
 		             ifTrue: [ 'package: ' , '_UnpackagedPackage' printString ]
 		             ifFalse: [ 'package: ' , 'Unclassified' printString ].
 
-	classRemoved definitionSource: (classRemoved definitionSource copyReplaceAll: toReplace with: 'package: ' , aClassRemovedAnnouncement categoryName printString).
+	classRemoved definitionSource: (classRemoved definitionSource copyReplaceAll: toReplace with: 'package: ' , aClassRemovedAnnouncement packageTag categoryName printString).
 
 	classRemoved name: aClassRemovedAnnouncement classRemoved originalName.
-	classRemoved category: aClassRemovedAnnouncement categoryName.
+	classRemoved category: aClassRemovedAnnouncement packageTag categoryName.
+	classRemoved packageTag: aClassRemovedAnnouncement packageTag name.
 	classRemoved package: aClassRemovedAnnouncement packageAffected name.
 
 	aClassRemovedAnnouncement classRemoved methods , aClassRemovedAnnouncement classRemoved classSide methods do: [ :each |

--- a/src/GeneralRules/ReClassNotCategorizedRule.class.st
+++ b/src/GeneralRules/ReClassNotCategorizedRule.class.st
@@ -27,7 +27,7 @@ ReClassNotCategorizedRule >> basicCheck: aClass [
 
 	aClass isMeta ifTrue: [ ^ false ].
 
-	^ aClass packageTag isNil and: [ aClass package classTags size > 1 ]
+	^ aClass packageTag isRoot and: [ aClass package classTags size > 1 ]
 ]
 
 { #category : #accessing }

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -978,7 +978,7 @@ Class >> removeFromSystem: logged [
 	Keep the class name and category for triggering the system change message. If we wait to long, then we get obsolete information which is not what we want.
 	Tell class to deactivate and unload itself-- two separate events in the module system"
 
-	| myCategory package |
+	| myCategory packageTag |
 	self release.
 	self unload.
 
@@ -988,14 +988,14 @@ Class >> removeFromSystem: logged [
 	if this class is loaded again. We do not check if references exist as it is too slow"
 	Undeclared declare: self name asSymbol from: Smalltalk globals.
 	myCategory := self category.
-	package := self package.
+	packageTag := self packageTag.
 	self environment forgetClass: self.
 
 	"In case the class has deprecated aliases we need to remove them from the system dictionary.
 	We deal also with a special case that is the case a class of the same name than the alias is installed in the image after the alias. In that case we do not remove it. It's the reason we check if the global of the alias is the same as self."
 	self deprecatedAliases do: [ :alias | self environment at: alias ifPresent: [ :class | class = self ifTrue: [ self environment removeKey: alias ] ] ].
 	self obsolete.
-	logged ifTrue: [ SystemAnnouncer announce: (ClassRemoved class: self package: package category: myCategory) ]
+	logged ifTrue: [ SystemAnnouncer announce: (ClassRemoved class: self packageTag: packageTag) ]
 ]
 
 { #category : #initialization }

--- a/src/Monticello/MCWorkingCopy.class.st
+++ b/src/Monticello/MCWorkingCopy.class.st
@@ -93,8 +93,7 @@ MCWorkingCopy class >> classMoved: anEvent [
 MCWorkingCopy class >> classRemoved: anEvent [
 	"Informs the registry who use to keep this class that its changed. Unlike #classModified:, class is not anymore in RPackages so it will not be found, that's why we look for system category instead if class is included or not"
 
-	(self packageOrganizer packageMatchingExtensionName: anEvent categoryName) ifNotNil: [ :package |
-		package mcWorkingCopy ifNotNil: [ :workingCopy | workingCopy modified: true ] ].
+	anEvent packageAffected ifNotNil: [ :package | package mcWorkingCopy ifNotNil: [ :workingCopy | workingCopy modified: true ] ].
 
 	anEvent classAffected protocolNames , anEvent classAffected classSide protocolNames do: [ :aProtocolName |
 		(aProtocolName beginsWith: '*') ifTrue: [

--- a/src/RPackage-Core/ClassDescription.extension.st
+++ b/src/RPackage-Core/ClassDescription.extension.st
@@ -56,7 +56,7 @@ ClassDescription >> packageName [
 
 { #category : #'*RPackage-Core' }
 ClassDescription >> packageTag [
-	"Package tags are sub categories of packages to have a better organization of the packages. I return my package tag or nil if the class is uncategorized."
+	"Package tags are sub categories of packages to have a better organization of the packages."
 
 	^ self package classTagForClass: self
 ]

--- a/src/RPackage-Core/ClassDescription.extension.st
+++ b/src/RPackage-Core/ClassDescription.extension.st
@@ -58,10 +58,7 @@ ClassDescription >> packageName [
 ClassDescription >> packageTag [
 	"Package tags are sub categories of packages to have a better organization of the packages. I return my package tag or nil if the class is uncategorized."
 
-	| packageTag |
-	packageTag := (self package classTagForClass: self) ifNil: [ ^ nil ].
-	packageTag isRoot ifTrue: [ ^ nil ].
-	^ packageTag
+	^ self package classTagForClass: self
 ]
 
 { #category : #'*RPackage-Core' }
@@ -88,7 +85,8 @@ ClassDescription >> packages [
 { #category : #'*RPackage-Core' }
 ClassDescription >> removePackageTag [
 
-	self packageTag ifNotNil: [ :tag |
-		tag removeClass: self.
-		self package addClass: self ]
+	self packageTag isRoot ifTrue: [ "Cannot remove root tag" ^ self ].
+
+	self packageTag removeClass: self.
+	self package addClass: self
 ]

--- a/src/Ring-Core/RGEnvironmentAnnouncer.class.st
+++ b/src/Ring-Core/RGEnvironmentAnnouncer.class.st
@@ -78,8 +78,7 @@ RGEnvironmentAnnouncer >> behaviorRecategorized: anRGBehavior [
 { #category : #triggering }
 RGEnvironmentAnnouncer >> behaviorRemoved: anRGBehavior [
 
-	self announce: (ClassRemoved
-		class: anRGBehavior category: anRGBehavior category)
+	self announce: (ClassRemoved class: anRGBehavior)
 ]
 
 { #category : #triggering }

--- a/src/Ring-Core/RGReadOnlyImageBackend.class.st
+++ b/src/Ring-Core/RGReadOnlyImageBackend.class.st
@@ -298,7 +298,7 @@ RGReadOnlyImageBackend >> superclassFor: anRGBehavior [
 { #category : #behavior }
 RGReadOnlyImageBackend >> tagsForClass: anRGBehavior do: aBlock [
 
-	(self realBehaviorFor: anRGBehavior) packageTagName ifNotNil: [ :tag | aBlock value: tag ]
+	(self realBehaviorFor: anRGBehavior) packageTag isRoot ifFalse: [ aBlock value: (self realBehaviorFor: anRGBehavior) packageTagName ]
 ]
 
 { #category : #method }

--- a/src/Ring-Definitions-Core/RGClassDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGClassDefinition.class.st
@@ -10,6 +10,7 @@ Class {
 		'classVariables',
 		'category',
 		'package',
+		'packageTag',
 		'sharedPools'
 	],
 	#category : #'Ring-Definitions-Core-Base'
@@ -113,7 +114,13 @@ RGClassDefinition >> allSharedPools [
 RGClassDefinition >> category [
 	"retrieves a tag for its package"
 
-	^category
+	^ category ifNil: [
+		  (self packageTag isNotNil and: [ self package isNotNil ])
+			  ifFalse: [ nil ]
+			  ifTrue: [
+				  self packageTag = self package
+					  ifTrue: [ self package ]
+					  ifFalse: [ self package , '-' , self packageTag ] ] ]
 ]
 
 { #category : #accessing }
@@ -264,6 +271,18 @@ RGClassDefinition >> package: aRGPackage [
 	"Sets the package in which this class is contained"
 
 	package:= aRGPackage
+]
+
+{ #category : #accessing }
+RGClassDefinition >> packageTag [
+
+	^ packageTag
+]
+
+{ #category : #accessing }
+RGClassDefinition >> packageTag: anObject [
+
+	packageTag := anObject
 ]
 
 { #category : #'class variables' }

--- a/src/Ring-Definitions-Core/RGTraitDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGTraitDefinition.class.st
@@ -8,16 +8,23 @@ Class {
 		'metaClass',
 		'comment',
 		'category',
-		'package'
+		'package',
+		'packageTag'
 	],
 	#category : #'Ring-Definitions-Core-Base'
 }
 
 { #category : #accessing }
 RGTraitDefinition >> category [
-	"Retrieves the tag-package associated to the receiver"
+	"retrieves a tag for its package"
 
-	^category
+	^ category ifNil: [
+		  (self packageTag isNotNil and: [ self package isNotNil ])
+			  ifFalse: [ nil ]
+			  ifTrue: [
+				  self packageTag = self package
+					  ifTrue: [ self package ]
+					  ifFalse: [ self package , '-' , self packageTag ] ] ]
 ]
 
 { #category : #accessing }
@@ -117,6 +124,18 @@ RGTraitDefinition >> package: aRGPackage [
 	"Sets the package in which this trait is contained"
 
 	package:= aRGPackage
+]
+
+{ #category : #accessing }
+RGTraitDefinition >> packageTag [
+
+	^ packageTag
+]
+
+{ #category : #accessing }
+RGTraitDefinition >> packageTag: anObject [
+
+	packageTag := anObject
 ]
 
 { #category : #accessing }

--- a/src/System-Announcements/ClassAnnouncement.class.st
+++ b/src/System-Announcements/ClassAnnouncement.class.st
@@ -48,6 +48,12 @@ ClassAnnouncement >> packageAffected [
 ]
 
 { #category : #accessing }
+ClassAnnouncement >> packageTagAffected [
+
+	^ self classAffected packageTag
+]
+
+{ #category : #accessing }
 ClassAnnouncement >> packagesAffected [
 	^{self packageAffected}
 ]

--- a/src/System-Announcements/ClassAnnouncement.class.st
+++ b/src/System-Announcements/ClassAnnouncement.class.st
@@ -38,11 +38,6 @@ ClassAnnouncement >> classAffected [
 ]
 
 { #category : #accessing }
-ClassAnnouncement >> classTagAffected [
-	^self packageAffected toTagName: self classAffected category
-]
-
-{ #category : #accessing }
 ClassAnnouncement >> packageAffected [
 	^self classAffected package
 ]

--- a/src/System-Announcements/ClassRemoved.class.st
+++ b/src/System-Announcements/ClassRemoved.class.st
@@ -81,12 +81,6 @@ ClassRemoved >> classRemoved: aClass [
 ]
 
 { #category : #accessing }
-ClassRemoved >> classTagAffected [
-
-	^ self packageAffected toTagName: self categoryName
-]
-
-{ #category : #accessing }
 ClassRemoved >> packageAffected [
 
 	^ self packageTag package

--- a/src/System-Announcements/ClassRemoved.class.st
+++ b/src/System-Announcements/ClassRemoved.class.st
@@ -57,12 +57,6 @@ ClassRemoved >> affectsMethodsInProtocol: protocol [
 ]
 
 { #category : #accessing }
-ClassRemoved >> categoryName [
-
-	^ self packageTagAffected categoryName
-]
-
-{ #category : #accessing }
 ClassRemoved >> classAffected [
 	^self classRemoved
 ]
@@ -84,4 +78,16 @@ ClassRemoved >> classRemoved: aClass [
 ClassRemoved >> packageAffected [
 
 	^ self packageTag package
+]
+
+{ #category : #accessing }
+ClassRemoved >> packageTag [
+
+	^ packageTag
+]
+
+{ #category : #accessing }
+ClassRemoved >> packageTag: anObject [
+
+	packageTag := anObject
 ]

--- a/src/System-Announcements/ClassRemoved.class.st
+++ b/src/System-Announcements/ClassRemoved.class.st
@@ -6,32 +6,25 @@ Class {
 	#name : #ClassRemoved,
 	#superclass : #ClassAnnouncement,
 	#instVars : [
-		'categoryName',
 		'classRemoved',
-		'affectedPackage'
+		'packageTag'
 	],
 	#category : #'System-Announcements-System-Classes'
 }
 
 { #category : #'instance creation' }
-ClassRemoved class >> class: aClass category: aCategoryName [
+ClassRemoved class >> class: aClass [
 	^self new
 			classRemoved: aClass;
-			categoryName: aCategoryName;
 			yourself
 ]
 
 { #category : #'instance creation' }
-ClassRemoved class >> class: aClass package: aPackage category: aCategoryName [
+ClassRemoved class >> class: aClass packageTag: aPackageTag [
 
-	^ (self class: aClass category: aCategoryName)
-		  affectedPackage: aPackage;
+	^ (self class: aClass)
+		  packageTag: aPackageTag;
 		  yourself
-]
-
-{ #category : #accessing }
-ClassRemoved >> affectedPackage: aPackage [
-	affectedPackage := aPackage
 ]
 
 { #category : #testing }
@@ -54,7 +47,7 @@ ClassRemoved >> affectsMethodsDefinedInClass: aClass [
 { #category : #testing }
 ClassRemoved >> affectsMethodsDefinedInPackage: aPackage [
 
-	^affectedPackage == aPackage
+	^ self packageAffected == aPackage
 ]
 
 { #category : #testing }
@@ -66,13 +59,7 @@ ClassRemoved >> affectsMethodsInProtocol: protocol [
 { #category : #accessing }
 ClassRemoved >> categoryName [
 
-	^ categoryName
-]
-
-{ #category : #accessing }
-ClassRemoved >> categoryName: anObject [
-
-	categoryName := anObject
+	^ self packageTagAffected categoryName
 ]
 
 { #category : #accessing }
@@ -90,21 +77,17 @@ ClassRemoved >> classRemoved [
 ClassRemoved >> classRemoved: aClass [
 
 	classRemoved := aClass.
-	affectedPackage := aClass package
+	packageTag := aClass packageTag
 ]
 
 { #category : #accessing }
 ClassRemoved >> classTagAffected [
-	^affectedPackage toTagName: categoryName
+
+	^ self packageAffected toTagName: self categoryName
 ]
 
 { #category : #accessing }
 ClassRemoved >> packageAffected [
-	^affectedPackage
-]
 
-{ #category : #accessing }
-ClassRemoved >> packageAffected: aPackage [
-
-	affectedPackage := aPackage
+	^ self packageTag package
 ]


### PR DESCRIPTION
This changes bring an update of ClassAnnouncement and especially ClassRemoved to reduce the usage of categories. 

Instead we are basing things on package tags. 

Depends on https://github.com/pharo-project/pharo/pull/14556