### PR TITLE
RPackage: #packageTag should work on class side

### DIFF
--- a/src/Calypso-SystemPlugins-SUnit-Browser/TClyGenerateTestClass.trait.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/TClyGenerateTestClass.trait.st
@@ -35,17 +35,17 @@ TClyGenerateTestClass >> isValidClass: inputClass [
 
 { #category : #action }
 TClyGenerateTestClass >> newTestClassCategoryFor: aClass [
+
 	| tag |
-	tag := aClass package classTagForClass: aClass.
-	^ String
-		streamContents: [ :s |
-			s
-				nextPutAll: aClass package name;
-				nextPutAll: '-Tests'.
-			tag isRoot
-				ifFalse: [ s
-						nextPut: $-;
-						nextPutAll: tag name ] ]
+	tag := aClass packageTag.
+	^ String streamContents: [ :s |
+		  s
+			  nextPutAll: aClass package name;
+			  nextPutAll: '-Tests'.
+		  tag isRoot ifFalse: [
+			  s
+				  nextPut: $-;
+				  nextPutAll: tag name ] ]
 ]
 
 { #category : #accessing }

--- a/src/Deprecated12/ClassDescription.extension.st
+++ b/src/Deprecated12/ClassDescription.extension.st
@@ -300,7 +300,7 @@ ClassDescription >> untagFrom: aSymbol [
 	"Any class or trait could be tagged by multiple symbols for user purpose.
 	For now we could only model single tag with RPackageTag"
 	package := self package.
-	packageTag := package classTagForClass: self.
+	packageTag := package tagOf: self.
 	packageTag ifNil: [ ^ #(  ) ].
 	packageTag isRoot ifTrue: [ ^ #(  ) ].
 	packageTag name = aSymbol ifFalse: [ ^ self ].

--- a/src/Deprecated12/RPackage.extension.st
+++ b/src/Deprecated12/RPackage.extension.st
@@ -58,6 +58,13 @@ RPackage >> classNamesForClassTag: aSymbol [
 ]
 
 { #category : #'*Deprecated12' }
+RPackage >> classTagForClass: aClass [
+
+	self deprecated: 'Use #tagOf: instead' transformWith: '`@rcv classTagForClass: `@arg' -> '`@rcv tagOf: `@arg'.
+	^ self tagOf: aClass
+]
+
+{ #category : #'*Deprecated12' }
 RPackage >> definedClassesDo: aBlock [
 
 	self deprecated:

--- a/src/FluidClassBuilder/FluidBuilder.class.st
+++ b/src/FluidClassBuilder/FluidBuilder.class.st
@@ -92,15 +92,11 @@ FluidBuilder >> fillClassSideFromEnvironment: anEnvironment [
 { #category : #copying }
 FluidBuilder >> fillInstanceSideFromClass: aClass [
 
-	| tag |
-
 	slotsToBuild := aClass slots.
 	uses := aClass traitComposition.
 	self package: aClass package name.
 
-	tag := (aClass package classTagForClass: aClass).
-	tag ifNotNil: [ :s |
-		s isRoot ifFalse: [self tag: (aClass package classTagForClass: aClass) name ]]
+	aClass packageTag ifNotNil: [ :tag | tag isRoot ifFalse: [ self tag: tag name ] ]
 ]
 
 { #category : #building }

--- a/src/Kernel/FluidClassDefinitionPrinter.class.st
+++ b/src/Kernel/FluidClassDefinitionPrinter.class.st
@@ -140,7 +140,7 @@ FluidClassDefinitionPrinter >> expandedDefinitionString [
 		  self sharedVariablesOn: s.
 		  self sharedPoolsOn: s.
 
-		  (forClass package classTagForClass: forClass) ifNotNil: [ :t |
+		  forClass packageTag ifNotNil: [ :t |
 			  | tag |
 			  tag := t name.
 			  tag = forClass package name
@@ -215,7 +215,7 @@ FluidClassDefinitionPrinter >> expandedTraitDefinitionString [
 		self slotsOn: s.
 		s crtab.
 
-		(forClass package classTagForClass: forClass) ifNotNil: [:t |
+		forClass packageTag ifNotNil: [:t |
 							tag := t name.
 							tag = forClass package name
 								ifFalse:  [
@@ -401,7 +401,7 @@ FluidClassDefinitionPrinter >> slotsOn: s [
 FluidClassDefinitionPrinter >> tagOn: s [
 
 	| tag |
-	(forClass package classTagForClass: forClass) ifNotNil: [ :t |
+	forClass packageTag ifNotNil: [ :t |
 		tag := t name.
 		tag = forClass package name ifFalse: [
 			s crtab.

--- a/src/RPackage-Core/ClassDescription.extension.st
+++ b/src/RPackage-Core/ClassDescription.extension.st
@@ -58,7 +58,7 @@ ClassDescription >> packageName [
 ClassDescription >> packageTag [
 	"Package tags are sub categories of packages to have a better organization of the packages."
 
-	^ self package classTagForClass: self
+	^ self package tagOf: self
 ]
 
 { #category : #'*RPackage-Core' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -183,14 +183,6 @@ RPackage >> classTagCategoryNames [
 ]
 
 { #category : #'class tags' }
-RPackage >> classTagForClass: aClass [
-
-	^ self classTags
-		  detect: [ :tag | tag hasClass: aClass ]
-		  ifNone: [ nil ]
-]
-
-{ #category : #'class tags' }
 RPackage >> classTagNamed: aSymbol [
 
 	^ classTags detect: [ :each | each name = aSymbol ]
@@ -970,6 +962,14 @@ RPackage >> systemCategoryPrefix [
 { #category : #'class tags' }
 RPackage >> tagNames [
 	^ self classTags collect: [ :tag | tag name ]
+]
+
+{ #category : #'class tags' }
+RPackage >> tagOf: aClass [
+
+	^ self classTags
+		  detect: [ :tag | tag hasClass: aClass ]
+		  ifNone: [ nil ]
 ]
 
 { #category : #queries }

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -62,7 +62,7 @@ RPackageTag >> environment [
 { #category : #testing }
 RPackageTag >> hasClass: aClass [
 
-	^ self hasClassNamed: aClass name
+	^ self classes includes: aClass instanceSide
 ]
 
 { #category : #testing }

--- a/src/RPackage-Tests/RPackageRenameTest.class.st
+++ b/src/RPackage-Tests/RPackageRenameTest.class.st
@@ -111,13 +111,13 @@ RPackageRenameTest >> testRenamePackageToOwnTagNameWithClassesInRoot [
 
 	self assert: (package classTagNamed: #Core ifAbsent: [ nil ]) notNil.
 	self assert: (package classTagNamed: #Util ifAbsent: [ nil ]) notNil.
-	self assert: (package classTagForClass: class1) name equals: #Core.
-	self assert: (package classTagForClass: class2) name equals: #Util.
-	self assert: (package classTagForClass: class3) name equals: #Test1.
+	self assert: (package tagOf: class1) name equals: #Core.
+	self assert: (package tagOf: class2) name equals: #Util.
+	self assert: (package tagOf: class3) name equals: #Test1.
 	package renameTo: 'Test1-Core'.
-	self assert: (package classTagForClass: class1) name equals: #Core.
-	self assert: (package classTagForClass: class2) name equals: #Util.
-	self assert: (package classTagForClass: class3) name equals: #'Test1-Core'.
+	self assert: (package tagOf: class1) name equals: #Core.
+	self assert: (package tagOf: class2) name equals: #Util.
+	self assert: (package tagOf: class3) name equals: #'Test1-Core'.
 
 	workingCopy := MCWorkingCopy forPackageNamed: 'Test1-Core'.
 	self assert: workingCopy modified

--- a/src/RPackage-Tests/RPackageTagTest.class.st
+++ b/src/RPackage-Tests/RPackageTagTest.class.st
@@ -55,6 +55,23 @@ RPackageTagTest >> testAddClassFromTag [
 ]
 
 { #category : #tests }
+RPackageTagTest >> testHasClass [
+
+	| package class tag |
+	package := self createNewPackageNamed: #Test1.
+	class := self createNewClassNamed: 'TestClass' inCategory: package name , '-TAG'.
+	tag := class packageTag.
+
+	self assert: (package includesClass: class).
+	self assert: (package hasTag: tag).
+	self assert: tag name equals: 'TAG'.
+
+	self assert: (tag hasClass: class).
+	self assert: (tag hasClass: class class). "We want it to work with class side too"
+	self deny: (tag hasClass: self class)
+]
+
+{ #category : #tests }
 RPackageTagTest >> testPromoteAsPackage [
 
 	| package1 package2 class tag1 |


### PR DESCRIPTION
#packageTag currently only works on instance side which is not coherent with #package that works on instance and class side. This change fixes this problems. 

The way I fixed the problem was to make RPackageTag>>#hasClass: work with class side. 

I also renamed #classTagForClass: into #tagOf: to have a better API. We have methods using 'classTag' and methods using 'tag' in RPackage and I want to align them to use 'tag'

Thank @pavel-krivanek for the bug report!