### PR TITLE
Add ‘scale’ parameter for displaying strings using a StrikeFont, FixedFaceFont or LogicalFont

### DIFF
--- a/src/Fonts-Abstract/AbstractFont.class.st
+++ b/src/Fonts-Abstract/AbstractFont.class.st
@@ -142,6 +142,13 @@ AbstractFont >> displayString: aString on: aDisplayContext from: startIndex to: 
 
 { #category : #displaying }
 AbstractFont >> displayString: aString on: aDisplayContext from: startIndex to: stopIndex at: aPoint kern: kernDelta baselineY: baselineY [
+
+	^ self displayString: aString on: aDisplayContext from: startIndex to: stopIndex
+		at: aPoint kern: kernDelta baselineY: baselineY scale: 1
+]
+
+{ #category : #displaying }
+AbstractFont >> displayString: aString on: aDisplayContext from: startIndex to: stopIndex at: aPoint kern: kernDelta baselineY: baselineY scale: scale [
 	"Draw the given string from startIndex to stopIndex at aPoint on the (already prepared) display context."
 
 	^self subclassResponsibility
@@ -170,6 +177,12 @@ AbstractFont >> height [
 
 { #category : #displaying }
 AbstractFont >> installOn: aDisplayContext foregroundColor: foregroundColor backgroundColor: backgroundColor [
+
+	^ self installOn: aDisplayContext foregroundColor: foregroundColor backgroundColor: backgroundColor scale: 1
+]
+
+{ #category : #displaying }
+AbstractFont >> installOn: aDisplayContext foregroundColor: foregroundColor backgroundColor: backgroundColor scale: scale [
 	"Install the receiver on the given DisplayContext (either BitBlt or Canvas) for further drawing operations."
 
 	^ self subclassResponsibility

--- a/src/Fonts-Abstract/AbstractFont.class.st
+++ b/src/Fonts-Abstract/AbstractFont.class.st
@@ -135,7 +135,9 @@ AbstractFont >> descentOf: aCharacter [
 AbstractFont >> displayString: aString on: aDisplayContext from: startIndex to: stopIndex at: aPoint kern: kernDelta [
 	"Draw the given string from startIndex to stopIndex
 	at aPoint on the (already prepared) display context."
-	^self subclassResponsibility
+
+	^ self displayString: aString on: aDisplayContext from: startIndex to: stopIndex
+		at: aPoint kern: kernDelta baselineY: aPoint y + self ascent
 ]
 
 { #category : #displaying }

--- a/src/Fonts-Infrastructure/LogicalFont.class.st
+++ b/src/Fonts-Infrastructure/LogicalFont.class.st
@@ -515,11 +515,6 @@ LogicalFont >> displayStrikeoutOn: aGrafPort from: aPoint to: aPoint3 [
 ]
 
 { #category : #'forwarded to realFont' }
-LogicalFont >> displayString: aString on: aDisplayContext from: startIndex to: stopIndex at: aPoint kern: kernDelta [
-	^self realFont displayString: aString on: aDisplayContext from: startIndex to: stopIndex at: aPoint kern: kernDelta
-]
-
-{ #category : #'forwarded to realFont' }
 LogicalFont >> displayString: aWideString on: aGrafPort from: aSmallInteger to: aSmallInteger4 at: aPoint kern: aSmallInteger6 baselineY: aSmallInteger7 [
 	^self realFont displayString: aWideString on: aGrafPort from: aSmallInteger to: aSmallInteger4 at: aPoint kern: aSmallInteger6 baselineY: aSmallInteger7
 ]

--- a/src/Fonts-Infrastructure/LogicalFont.class.st
+++ b/src/Fonts-Infrastructure/LogicalFont.class.st
@@ -515,8 +515,10 @@ LogicalFont >> displayStrikeoutOn: aGrafPort from: aPoint to: aPoint3 [
 ]
 
 { #category : #'forwarded to realFont' }
-LogicalFont >> displayString: aWideString on: aGrafPort from: aSmallInteger to: aSmallInteger4 at: aPoint kern: aSmallInteger6 baselineY: aSmallInteger7 [
-	^self realFont displayString: aWideString on: aGrafPort from: aSmallInteger to: aSmallInteger4 at: aPoint kern: aSmallInteger6 baselineY: aSmallInteger7
+LogicalFont >> displayString: aString on: aDisplayContext from: startIndex to: stopIndex at: aPoint kern: kernDelta baselineY: baselineY scale: scale [
+
+	^ self realFont displayString: aString on: aDisplayContext from: startIndex to: stopIndex
+		at: aPoint kern: kernDelta baselineY: baselineY scale: scale
 ]
 
 { #category : #'forwarded to realFont' }
@@ -692,8 +694,9 @@ LogicalFont >> initialize: aFont [
 ]
 
 { #category : #'forwarded to realFont' }
-LogicalFont >> installOn: a foregroundColor: b backgroundColor: c [
-	^self realFont installOn: a foregroundColor: b backgroundColor: c
+LogicalFont >> installOn: aDisplayContext foregroundColor: foregroundColor backgroundColor: backgroundColor scale: scale [
+
+	^ self realFont installOn: aDisplayContext foregroundColor: foregroundColor backgroundColor: backgroundColor scale: scale
 ]
 
 { #category : #testing }

--- a/src/FreeType-Graphics/BitBlt.extension.st
+++ b/src/FreeType-Graphics/BitBlt.extension.st
@@ -29,7 +29,7 @@ BitBlt >> copyBitsColor: argbColorSmallInteger alpha: argbAlphaSmallInteger gamm
 ]
 
 { #category : #'*FreeType-Graphics' }
-BitBlt >> installFreeTypeFont: aFreeTypeFont foregroundColor: foregroundColor backgroundColor: backgroundColor [
+BitBlt >> installFreeTypeFont: aFreeTypeFont foregroundColor: foregroundColor backgroundColor: backgroundColor scale: scale [
 	"Set up the parameters.  Since the glyphs in a TTCFont is 32bit depth form, it tries to use rule=34 to get better AA result if possible."
 
 	(FreeTypeSettings current useSubPixelAntiAliasing and: [destForm depth >= 8])
@@ -50,7 +50,7 @@ BitBlt >> installFreeTypeFont: aFreeTypeFont foregroundColor: foregroundColor ba
 					self combinationRule: 34]].
 	halftoneForm := nil.
 	sourceX := sourceY := 0.
-	height := aFreeTypeFont height
+	height := aFreeTypeFont height * scale
 ]
 
 { #category : #'*FreeType-Graphics' }

--- a/src/FreeType-Graphics/GrafPort.extension.st
+++ b/src/FreeType-Graphics/GrafPort.extension.st
@@ -1,9 +1,9 @@
 Extension { #name : #GrafPort }
 
 { #category : #'*FreeType-Graphics' }
-GrafPort >> installFreeTypeFont: aFreeTypeFont foregroundColor: foregroundColor backgroundColor: backgroundColor [
+GrafPort >> installFreeTypeFont: aFreeTypeFont foregroundColor: foregroundColor backgroundColor: backgroundColor scale: scale [
 
-	super installFreeTypeFont: aFreeTypeFont foregroundColor: foregroundColor backgroundColor: backgroundColor.
+	super installFreeTypeFont: aFreeTypeFont foregroundColor: foregroundColor backgroundColor: backgroundColor scale: scale.
 	lastFont := aFreeTypeFont.
 	lastFontForegroundColor := foregroundColor.
 	lastFontBackgroundColor := backgroundColor

--- a/src/FreeType/FreeTypeFont.class.st
+++ b/src/FreeType/FreeTypeFont.class.st
@@ -159,18 +159,6 @@ FreeTypeFont >> displayStrikeoutOn: aDisplayContext from: baselineStartPoint to:
 ]
 
 { #category : #displaying }
-FreeTypeFont >> displayString: aString on: aDisplayContext from: startIndex to: stopIndex at: aPoint kern: kernDelta [
-
-	^self displayString: aString
-		on: aDisplayContext
-		from: startIndex
-		to: stopIndex
-		at: aPoint
-		kern: kernDelta
-		baselineY: aPoint y  + self ascent
-]
-
-{ #category : #displaying }
 FreeTypeFont >> displayString: aString on: aBitBlt from: startIndex to: stopIndex at: aPoint kern: kernDelta baselineY: baselineY [
 
 	^ self displayString: aString on: aBitBlt from: startIndex to: stopIndex

--- a/src/FreeType/FreeTypeFont.class.st
+++ b/src/FreeType/FreeTypeFont.class.st
@@ -159,13 +159,6 @@ FreeTypeFont >> displayStrikeoutOn: aDisplayContext from: baselineStartPoint to:
 ]
 
 { #category : #displaying }
-FreeTypeFont >> displayString: aString on: aBitBlt from: startIndex to: stopIndex at: aPoint kern: kernDelta baselineY: baselineY [
-
-	^ self displayString: aString on: aBitBlt from: startIndex to: stopIndex
-		at: aPoint kern: kernDelta baselineY: baselineY scale: 1
-]
-
-{ #category : #displaying }
 FreeTypeFont >> displayString: aString on: aBitBlt from: startIndex to: stopIndex at: aPoint kern: kernDelta baselineY: baselineY scale: scale [
 	| glyph  depth foreColorVal foreColorAlpha originalColorMap clr subPixelPosition widthAndKernedWidth char nextChar floatDestX  destX destY offset gammaTable gammaInverseTable useRule41 |
 
@@ -476,11 +469,9 @@ FreeTypeFont >> initialize: aFont [
 ]
 
 { #category : #displaying }
-FreeTypeFont >> installOn: aBitBlt foregroundColor: foreColor backgroundColor: backColor [
+FreeTypeFont >> installOn: aBitBlt foregroundColor: foreColor backgroundColor: backColor scale: scale [
 
-	| |
-	"fcolor := foreColor pixelValueForDepth: 32."
-	aBitBlt installFreeTypeFont: self foregroundColor: foreColor backgroundColor: backColor
+	aBitBlt installFreeTypeFont: self foregroundColor: foreColor backgroundColor: backColor scale: scale
 ]
 
 { #category : #testing }

--- a/src/Graphics-Fonts/BitBlt.extension.st
+++ b/src/Graphics-Fonts/BitBlt.extension.st
@@ -1,7 +1,9 @@
 Extension { #name : #BitBlt }
 
 { #category : #'*Graphics-Fonts' }
-BitBlt >> basicDisplayString: aString from: startIndex to: stopIndex at: aPoint strikeFont: font kern: kernDelta [
+BitBlt >> basicDisplayString: aString from: startIndex to: stopIndex at: aPoint strikeFont: font kern: kernDelta scale: scale [
+
+	| xTable |
 
 	destY := aPoint y.
 	destX := aPoint x.
@@ -9,9 +11,12 @@ BitBlt >> basicDisplayString: aString from: startIndex to: stopIndex at: aPoint 
 	"the following are not really needed, but theBitBlt primitive will fail if not set"
 	sourceX ifNil: [sourceX := 100].
 	width ifNil: [width := 100].
+	xTable := font xTable.
+	scale = 1 ifFalse: [
+		xTable := xTable collect: [ :x | x * scale ] ].
 
 	self primDisplayString: aString from: startIndex to: stopIndex
-			map: font characterToGlyphMap xTable: font xTable
+			map: font characterToGlyphMap xTable: xTable
 			kern: kernDelta.
 	^ destX@destY
 ]
@@ -46,7 +51,7 @@ BitBlt >> displayString: aString from: startIndex to: stopIndex at: aPoint kern:
 ]
 
 { #category : #'*Graphics-Fonts' }
-BitBlt >> displayString: aString from: startIndex to: stopIndex at: aPoint strikeFont: font kern: kernDelta [
+BitBlt >> displayString: aString from: startIndex to: stopIndex at: aPoint strikeFont: font kern: kernDelta scale: scale [
 	"If required, do a second pass with new rule and colorMap.
 	This happens when #installStrikeFont:foregroundColor:backgroundColor: sets rule 37 (rgbMul).
 	the desired effect is to do two bitblt calls. The first one is with rule 37 and special colormap.
@@ -58,18 +63,18 @@ BitBlt >> displayString: aString from: startIndex to: stopIndex at: aPoint strik
 	"If combinationRule is rgbMul, we might need the special two-pass technique for component alpha blending.
 	If not, do it simply"
 	combinationRule = 37 "rgbMul" ifFalse: [
-		^self basicDisplayString: aString from: startIndex to: stopIndex at: aPoint strikeFont: font kern: kernDelta ].
+		^self basicDisplayString: aString from: startIndex to: stopIndex at: aPoint strikeFont: font kern: kernDelta scale: scale ].
 
 	"We need to do a second pass. The colormap set is for use in the second pass."
 	secondPassMap := colorMap.
 	colorMap := sourceForm depth ~= destForm depth
 		ifTrue: [ self cachedFontColormapFrom: sourceForm depth to: destForm depth ].
-	answer := self basicDisplayString: aString from: startIndex to: stopIndex at: aPoint strikeFont: font kern: kernDelta.
+	answer := self basicDisplayString: aString from: startIndex to: stopIndex at: aPoint strikeFont: font kern: kernDelta scale: scale.
 	colorMap := secondPassMap.
 	secondPassMap ifNotNil: [
 		prevRule := combinationRule.
 		combinationRule := 20. "rgbAdd"
-		self basicDisplayString: aString from: startIndex to: stopIndex at: aPoint strikeFont: font kern: kernDelta.
+		self basicDisplayString: aString from: startIndex to: stopIndex at: aPoint strikeFont: font kern: kernDelta scale: scale.
 		combinationRule := prevRule ].
 	^answer
 ]
@@ -82,14 +87,22 @@ BitBlt >> installFont: aFont foregroundColor: foregroundColor backgroundColor: b
 
 { #category : #'*Graphics-Fonts' }
 BitBlt >> installStrikeFont: aStrikeFont foregroundColor: foregroundColor backgroundColor: backgroundColor [
+
+	^ self installStrikeFont: aStrikeFont foregroundColor: foregroundColor backgroundColor: backgroundColor scale: 1
+]
+
+{ #category : #'*Graphics-Fonts' }
+BitBlt >> installStrikeFont: aStrikeFont foregroundColor: foregroundColor backgroundColor: backgroundColor scale: scale [
 	| lastSourceDepth targetColor |
 	sourceForm ifNotNil:[lastSourceDepth := sourceForm depth].
 	sourceForm := aStrikeFont glyphs.
+	scale = 1 ifFalse: [
+		sourceForm := sourceForm scaledToSize: sourceForm extent * scale ].
 
 	"Ignore any halftone pattern since we use a color map approach here"
 	halftoneForm := nil.
 	sourceY := 0.
-	height := aStrikeFont height.
+	height := aStrikeFont height * scale.
 
 	sourceForm depth = 1 ifTrue: [
 		self combinationRule: Form paint.

--- a/src/Graphics-Fonts/FixedFaceFont.class.st
+++ b/src/Graphics-Fonts/FixedFaceFont.class.st
@@ -48,7 +48,7 @@ FixedFaceFont >> descentKern [
 ]
 
 { #category : #displaying }
-FixedFaceFont >> displayString: aString on: aDisplayContext from: startIndex to: stopIndex at: aPoint kern: kernDelta baselineY: baselineY [
+FixedFaceFont >> displayString: aString on: aDisplayContext from: startIndex to: stopIndex at: aPoint kern: kernDelta baselineY: baselineY scale: scale [
 	| size |
 	size := stopIndex - startIndex + 1.
 	^ baseFont
@@ -59,6 +59,7 @@ FixedFaceFont >> displayString: aString on: aDisplayContext from: startIndex to:
 		at: aPoint
 		kern: kernDelta
 		baselineY: baselineY
+		scale: scale
 ]
 
 { #category : #displaying }
@@ -127,8 +128,8 @@ FixedFaceFont >> initialize [
 ]
 
 { #category : #displaying }
-FixedFaceFont >> installOn: aDisplayContext foregroundColor: foregroundColor backgroundColor: backgroundColor [
-	^baseFont installOn: aDisplayContext foregroundColor: foregroundColor backgroundColor: backgroundColor
+FixedFaceFont >> installOn: aDisplayContext foregroundColor: foregroundColor backgroundColor: backgroundColor scale: scale [
+	^baseFont installOn: aDisplayContext foregroundColor: foregroundColor backgroundColor: backgroundColor scale: scale
 ]
 
 { #category : #accessing }

--- a/src/Graphics-Fonts/FixedFaceFont.class.st
+++ b/src/Graphics-Fonts/FixedFaceFont.class.st
@@ -48,13 +48,6 @@ FixedFaceFont >> descentKern [
 ]
 
 { #category : #displaying }
-FixedFaceFont >> displayString: aString on: aDisplayContext from: startIndex to: stopIndex at: aPoint kern: kernDelta [
-
-	^ self displayString: aString on: aDisplayContext from: startIndex to: stopIndex at: aPoint
-		kern: kernDelta baselineY: aPoint y + self ascent
-]
-
-{ #category : #displaying }
 FixedFaceFont >> displayString: aString on: aDisplayContext from: startIndex to: stopIndex at: aPoint kern: kernDelta baselineY: baselineY [
 	| size |
 	size := stopIndex - startIndex + 1.

--- a/src/Graphics-Fonts/GrafPort.extension.st
+++ b/src/Graphics-Fonts/GrafPort.extension.st
@@ -7,8 +7,8 @@ GrafPort >> installStrikeFont: aStrikeFont [
 ]
 
 { #category : #'*Graphics-Fonts' }
-GrafPort >> installStrikeFont: aStrikeFont foregroundColor: foregroundColor backgroundColor: backgroundColor [
-	super installStrikeFont: aStrikeFont foregroundColor: foregroundColor backgroundColor: backgroundColor.
+GrafPort >> installStrikeFont: aStrikeFont foregroundColor: foregroundColor backgroundColor: backgroundColor scale: scale [
+	super installStrikeFont: aStrikeFont foregroundColor: foregroundColor backgroundColor: backgroundColor scale: scale.
 	aStrikeFont glyphs depth = 1 ifTrue: [
 		alpha := foregroundColor privateAlpha.
 		"dynamically switch between blend modes to support translucent text"

--- a/src/Graphics-Fonts/StrikeFont.class.st
+++ b/src/Graphics-Fonts/StrikeFont.class.st
@@ -861,13 +861,6 @@ StrikeFont >> displayMultiString: aString on: aBitBlt from: startIndex to: stopI
 ]
 
 { #category : #displaying }
-StrikeFont >> displayString: aString on: aBitBlt from: startIndex to: stopIndex at: aPoint kern: kernDelta [
-
-	^ self displayString: aString on: aBitBlt from: startIndex to: stopIndex at: aPoint
-		kern: kernDelta baselineY: aPoint y + self ascent
-]
-
-{ #category : #displaying }
 StrikeFont >> displayString: aString on: aBitBlt from: startIndex to: stopIndex at: aPoint kern: kernDelta baselineY: baselineY [
 	"Draw the given string from startIndex to stopIndex
 	at aPoint on the (already prepared) BitBlt."

--- a/src/Graphics-Fonts/StrikeFont.class.st
+++ b/src/Graphics-Fonts/StrikeFont.class.st
@@ -862,19 +862,9 @@ StrikeFont >> displayMultiString: aString on: aBitBlt from: startIndex to: stopI
 
 { #category : #displaying }
 StrikeFont >> displayString: aString on: aBitBlt from: startIndex to: stopIndex at: aPoint kern: kernDelta [
-	"Draw the given string from startIndex to stopIndex
-	at aPoint on the (already prepared) BitBlt."
 
-		"Somewhat of a hack:
-	The scanner seem to only pass in runs of either all ASCII or all non-ASCII characters. If all characters are ascii, then it's safe to use basic rendering-method."
-	(aString hasWideCharacterFrom: startIndex to: stopIndex) ifTrue:  [^ self displayMultiString: aString on: aBitBlt from: startIndex to: stopIndex at: aPoint kern: kernDelta baselineY: aPoint y + self ascent.].
-
-	^ aBitBlt displayString: aString
-			from: startIndex
-			to: stopIndex
-			at: aPoint
-			strikeFont: self
-			kern: kernDelta
+	^ self displayString: aString on: aBitBlt from: startIndex to: stopIndex at: aPoint
+		kern: kernDelta baselineY: aPoint y + self ascent
 ]
 
 { #category : #displaying }

--- a/src/Graphics-Fonts/StrikeFont.class.st
+++ b/src/Graphics-Fonts/StrikeFont.class.st
@@ -835,7 +835,7 @@ StrikeFont >> displayLine: aString at: aPoint [
 ]
 
 { #category : #displaying }
-StrikeFont >> displayMultiString: aString on: aBitBlt from: startIndex to: stopIndex at: aPoint kern: kernDelta baselineY: baselineY [
+StrikeFont >> displayMultiString: aString on: aBitBlt from: startIndex to: stopIndex at: aPoint kern: kernDelta baselineY: baselineY scale: scale [
 	| nextWide destX glyphInfo char charIndex |
 	destX := aPoint x.
 	charIndex := startIndex.
@@ -848,12 +848,13 @@ StrikeFont >> displayMultiString: aString on: aBitBlt from: startIndex to: stopI
 			to: nextWide -1
 			at: destX @ aPoint y
 			strikeFont: self
-			kern: kernDelta) x.
+			kern: kernDelta
+			scale: scale) x.
 			charIndex := nextWide].
 		nextWide > stopIndex ifFalse: [
 			char := aString at: charIndex.
-			fallbackFont displayString: aString on: aBitBlt from: charIndex to: charIndex at: destX @ aPoint y kern: kernDelta baselineY: baselineY.
-			destX := destX + (fallbackFont widthOf: char) + kernDelta.
+			fallbackFont displayString: aString on: aBitBlt from: charIndex to: charIndex at: destX @ aPoint y kern: kernDelta baselineY: baselineY scale: scale.
+			destX := destX + (((fallbackFont widthOf: char) + kernDelta) * scale).
 			charIndex := charIndex + 1]].
 	^ Array
 		with: charIndex
@@ -861,7 +862,7 @@ StrikeFont >> displayMultiString: aString on: aBitBlt from: startIndex to: stopI
 ]
 
 { #category : #displaying }
-StrikeFont >> displayString: aString on: aBitBlt from: startIndex to: stopIndex at: aPoint kern: kernDelta baselineY: baselineY [
+StrikeFont >> displayString: aString on: aBitBlt from: startIndex to: stopIndex at: aPoint kern: kernDelta baselineY: baselineY scale: scale [
 	"Draw the given string from startIndex to stopIndex
 	at aPoint on the (already prepared) BitBlt."
 
@@ -873,7 +874,8 @@ StrikeFont >> displayString: aString on: aBitBlt from: startIndex to: stopIndex 
 						to: stopIndex
 						at: aPoint
 						kern: kernDelta
-						baselineY: baselineY.].
+						baselineY: baselineY
+						scale: scale].
 
 	^ aBitBlt displayString: aString
 			from: startIndex
@@ -881,6 +883,7 @@ StrikeFont >> displayString: aString on: aBitBlt from: startIndex to: stopIndex 
 			at: aPoint
 			strikeFont: self
 			kern: kernDelta
+			scale: scale
 ]
 
 { #category : #emphasis }
@@ -1173,11 +1176,12 @@ StrikeFont >> installOn: aDisplayContext [
 ]
 
 { #category : #displaying }
-StrikeFont >> installOn: aDisplayContext foregroundColor: foregroundColor backgroundColor: backgroundColor [
+StrikeFont >> installOn: aDisplayContext foregroundColor: foregroundColor backgroundColor: backgroundColor scale: scale [
 	^aDisplayContext
 		installStrikeFont: self
 		foregroundColor: foregroundColor
 		backgroundColor: backgroundColor
+		scale: scale
 ]
 
 { #category : #emphasis }


### PR DESCRIPTION
In pull request #14503, a parameter ‘scale’ was added for displaying strings using a FreeTypeFont. This pull request extends that to the other classes in the AbstractFont hierarchy. For StrikeFont, the parameter is just provided for compatibility, displaying at any scale is equivalent to displaying at scale 1 and then scaling the form, it does not use more detailed character glyphs as is the case with FreeTypeFont. An example is given by the snippet below.

```smalltalk
string := (String loremIpsum copyReplaceAll: 'u' with: 'ū') copyFrom: 1 to: 40.
position := 5@5.
fillColor := Color white.
color := Color black.
scale := 2.

font1 := LogicalFont familyName: 'Source Sans Pro' pointSize: 10.
font2 := LogicalFont familyName: 'Bitmap DejaVu Sans' pointSize: 9.
font2 realFont fallbackFont.

{ { font1. 230@25 }. { font2. 260@25 } } collect: [ :arguments |
    arguments bind: [ :font :extent |
        (baseForm := Form extent: extent depth: Display depth) fillColor: fillColor.
        baseForm getCanvas drawString: string from: 1 to: string size at: position
            font: font color: Color black.
        form1 := baseForm scaledToSize: extent * scale.

        (form2 := Form extent: extent * scale depth: Display depth) fillColor: fillColor.
        (port := form2 getCanvas privatePort) colorMap: nil; combinationRule: Form paint.
        font installOn: port foregroundColor: color 
            backgroundColor: Color transparent scale: scale.
        font displayString: string on: port from: 1 to: string size
            at: position * scale kern: 0 baselineY: (position y + font ascent) * scale scale: scale.
        { form1. form2 } ] ]
```