### PR TITLE
Monticello: Announce MethodAdded when compiling a method whose prior method is from a different origin

### DIFF
--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -43,8 +43,7 @@ ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod 
 
 	(priorMethod isNil or: [ priorOrigin ~= compiledMethod origin ])
 		ifTrue: [ SystemAnnouncer uniqueInstance methodAdded: compiledMethod ]
-		ifFalse: [
-			"If protocol changed and someone is from different package, I need to throw a method recategorized"
+		ifFalse: [ "If protocol changed and someone is from different package, I need to throw a method recategorized"
 			newProtocol = oldProtocol ifFalse: [ SystemAnnouncer uniqueInstance methodRecategorized: compiledMethod oldProtocol: oldProtocol ].
 			SystemAnnouncer uniqueInstance methodChangedFrom: priorMethod to: compiledMethod oldProtocol: oldProtocol ]
 ]

--- a/src/Monticello/MethodAddition.class.st
+++ b/src/Monticello/MethodAddition.class.st
@@ -13,7 +13,8 @@ Class {
 		'compiledMethod',
 		'priorMethod',
 		'protocolName',
-		'priorProtocol'
+		'priorProtocol',
+		'priorOrigin'
 	],
 	#category : #'Monticello-Loading'
 }
@@ -50,6 +51,7 @@ MethodAddition >> createCompiledMethod [
 	selector := compiledMethod selector.
 	self writeSourceToLog.
 	priorMethod := myClass compiledMethodAt: selector ifAbsent: [ nil ].
+	priorOrigin := compiledMethod origin.
 	priorProtocol := myClass protocolOfSelector: selector
 ]
 
@@ -61,22 +63,15 @@ MethodAddition >> installMethod [
 
 { #category : #notifying }
 MethodAddition >> notifyObservers [
-	SystemAnnouncer uniqueInstance 
-		suspendAllWhile: [myClass classify: selector under: protocolName].
-	priorMethod 
-		ifNil: [ SystemAnnouncer uniqueInstance
-				methodAdded: compiledMethod
-				configuredWith: [ :event | 
-					event
-						propertyAt: #eventSource
-						put: #Monticello ] ]
-		ifNotNil: [
-			SystemAnnouncer uniqueInstance methodChangedFrom: priorMethod to: compiledMethod oldProtocol: priorProtocol.
-			priorProtocol name = protocolName ifFalse: [
-       			SystemAnnouncer uniqueInstance methodRecategorized: compiledMethod oldProtocol: priorProtocol ] ].
-	"The following code doesn't seem to do anything."
-	myClass instanceSide noteCompilationOf: compiledMethod meta: myClass isClassSide.
 
+	SystemAnnouncer uniqueInstance suspendAllWhile: [ myClass classify: selector under: protocolName ].
+	(priorMethod isNil or: [ priorOrigin ~= compiledMethod origin ])
+		ifTrue: [ SystemAnnouncer uniqueInstance methodAdded: compiledMethod configuredWith: [ :event | event propertyAt: #eventSource put: #Monticello ] ]
+		ifFalse: [
+			SystemAnnouncer uniqueInstance methodChangedFrom: priorMethod to: compiledMethod oldProtocol: priorProtocol.
+			priorProtocol name = protocolName ifFalse: [ SystemAnnouncer uniqueInstance methodRecategorized: compiledMethod oldProtocol: priorProtocol ] ].
+	"The following code doesn't seem to do anything."
+	myClass instanceSide noteCompilationOf: compiledMethod meta: myClass isClassSide
 ]
 
 { #category : #accessing }

--- a/src/RPackage-Tests/RPackageTraitTest.class.st
+++ b/src/RPackage-Tests/RPackageTraitTest.class.st
@@ -53,6 +53,24 @@ RPackageTraitTest >> setUp [
 ]
 
 { #category : #tests }
+RPackageTraitTest >> testMethodOverridingTraitMethodIsKnowByPackage [
+	"Regression test for a bug where adding a method to a class that overrides a method from a trait was not know by the package of the class"
+
+	| a2 |
+	a2 := self createNewClassNamed: #A2DefinedInP1 inPackage: p1.
+
+	a2 setTraitComposition: t1 asTraitComposition.
+
+	self deny: (p1 includesDefinedSelector: #traitMethodDefinedInP1 ofClass: a2).
+	self assert: (a2 >> #traitMethodDefinedInP1) isFromTrait.
+
+	a2 compile: 'traitMethodDefinedInP1 "Override in the class"'.
+
+	self assert: (p1 includesDefinedSelector: #traitMethodDefinedInP1 ofClass: a2).
+	self deny: (a2 >> #traitMethodDefinedInP1) isFromTrait
+]
+
+{ #category : #tests }
 RPackageTraitTest >> testPackageOfClassMethodFromTraitExtensionIsExtendingPackage [
 	"The package of a method defined in atrait but package in another package than the extended trait is the
 	package containing the extension."


### PR DESCRIPTION


Monticello has a duplication of the kernel code to install methods in the image. I tired to remove it but this is not so trivial.

In this duplication there is one part that is not synchronized: it does not manages traits. The problem arise if you compile a method in a class that already have this method but from a trait. Since there is a prior method we currently raise a MethodModified but in the case that the origin of the method is not the origin of the prior method, we should raise a MethodAdded instead.

This fix a bug in RPackage were all methods are not added to the packages.