### PR TITLE
RPackage: Simplify method additions in tests

### DIFF
--- a/src/RPackage-Tests/RPackageCompleteSetupButForModificationTest.class.st
+++ b/src/RPackage-Tests/RPackageCompleteSetupButForModificationTest.class.st
@@ -19,33 +19,26 @@ Class {
 
 { #category : #running }
 RPackageCompleteSetupButForModificationTest >> setUp [
+
 	super setUp.
 	p1 := self createNewPackageNamed: self p1Name.
 	p2 := self createNewPackageNamed: self p2Name.
 	p3 := self createNewPackageNamed: self p3Name.
 
-	a1 :=  self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
+	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
 	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.
 	a2 := self createNewClassNamed: #A2DefinedInP2 inPackage: p2.
 	b2 := self createNewClassNamed: #B2DefinedInP2 inPackage: p2.
 	a3 := self createNewClassNamed: #A3DefinedInP3 inPackage: p3.
 
-	a1 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addMethod: (a1>>#methodDefinedInP1).
-	a1 compileSilently: 'anotherMethodDefinedInP1 ^ #anotherMethodDefinedInP1'.
-	p1 addMethod: (a1>>#anotherMethodDefinedInP1).
+	a1 compile: 'methodDefinedInP1 ^ #methodDefinedInP1'.
+	a1 compile: 'anotherMethodDefinedInP1 ^ #anotherMethodDefinedInP1'.
 
-	a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addMethod: (a2>>#methodDefinedInP1).
+	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
+	a2 compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
 
-	a2 compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2'.
-	p2 addMethod: (a2>>#methodDefinedInP2).
-
-	a2 compileSilently: 'methodDefinedInP3 ^ #methodDefinedInP3'.
-	p3 addMethod: (a2>>#methodDefinedInP3).
-
-	a2 class compileSilently: 'classSideMethodDefinedInP3 ^ #classSideMethodDefinedInP3'.
-	p3 addMethod: (a2 class>>#classSideMethodDefinedInP3)
+	a2 compile: 'methodDefinedInP3 ^ #methodDefinedInP3' classified: '*' , p3 name.
+	a2 class compile: 'classSideMethodDefinedInP3 ^ #classSideMethodDefinedInP3' classified: '*' , p3 name
 ]
 
 { #category : #'test - addition' }

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -218,21 +218,21 @@ RPackageIncrementalTest >> testExtensionClassNames [
 	self assert: (p2 includesClass: b2).
 	self assert: (p2 includesClass: a2).
 
-	p1 addMethod: a2 >> (a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1').
+	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
 
 	self assert: p1 extensionSelectors size equals: 1.
 	self assert: p1 extensionMethods size equals: 1.
 	self assert: (p1 extendedClassNames includes: #A2InPackageP2).
 	self deny: (p1 includesClass: a2). "method extension class are not included in packages"
 
-	p1 addMethod: b2 >> (b2 compile: 'firstMethodInB2PackagedInP1 ^ 1').
+	b2 compile: 'firstMethodInB2PackagedInP1 ^ 1' classified: '*' , p1 name.
 
 	self assert: p1 extensionSelectors size equals: 2.
 	self assert: p1 extensionMethods size equals: 2.
 	self assert: (p1 extendedClassNames includes: #B2InPackageP2).
 	self deny: (p1 includesClass: b2).
 
-	p1 addMethod: b2 >> (b2 compileSilently: 'secondMethodInB2PackagedInP1 ^ 2').
+	b2 compile: 'secondMethodInB2PackagedInP1 ^ 2' classified: '*' , p1 name.
 
 	self assert: p1 extensionSelectors size equals: 3.
 	self assert: p1 extensionMethods size equals: 3.
@@ -253,16 +253,14 @@ RPackageIncrementalTest >> testExtensionClasses [
 	self deny: (p1 includesClass: a2).
 	self assert: (p2 includesClass: a2).
 
-	a2 compileSilently: 'methodPackagedInP1 ^ #methodPackagedInP1'.
-	p1 addMethod: a2 >> #methodPackagedInP1.
+	a2 compile: 'methodPackagedInP1 ^ #methodPackagedInP1' classified: '*' , p1 name.
 
 	self assert: p1 extendedClasses size equals: 1.
 	self assert: (p1 extendedClasses includes: a2).
 	self assert: p1 extendedClassNames size equals: 1.
 	self assert: (p1 extendedClassNames includes: a2 name).
 
-	b2 class compileSilently: 'methodPackagedInP1 ^ #methodPackagedInP1'.
-	p1 addMethod: b2 class >> #methodPackagedInP1.
+	b2 class compile: 'methodPackagedInP1 ^ #methodPackagedInP1' classified: '*' , p1 name.
 
 	self assert: p1 extendedClasses size equals: 2.
 	self assert: (p1 extendedClasses includes: b2 class).
@@ -284,8 +282,7 @@ RPackageIncrementalTest >> testExtensionClassesWithCompiledMethod [
 	self assert: (p2 includesClass: b2).
 	self assert: (p2 includesClass: b2).
 
-	a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addMethod: a2 >> #methodDefinedInP1.
+	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
 
 	self assert: p1 extensionMethods size equals: 1.
 	self assert: p1 extensionSelectors size equals: 1.
@@ -293,16 +290,14 @@ RPackageIncrementalTest >> testExtensionClassesWithCompiledMethod [
 	self deny: (p1 includesClass: a2).
 	"method extension class are not included in packages"
 
-	b2 compile: 'firstMethodInB2PackagedInP1 ^ 1'.
-	p1 addMethod: b2 >> #firstMethodInB2PackagedInP1.
+	b2 compile: 'firstMethodInB2PackagedInP1 ^ 1' classified: '*' , p1 name.
 
 	self assert: p1 extensionSelectors size equals: 2.
 	self assert: p1 extensionMethods size equals: 2.
 	self assert: p1 extendedClasses size equals: 2.
 	self deny: (p1 includesClass: b2).
 
-	b2 compileSilently: 'secondMethodInB2PackagedInP1 ^ 2'.
-	p1 addMethod: b2 >> #secondMethodInB2PackagedInP1.
+	b2 compile: 'secondMethodInB2PackagedInP1 ^ 2' classified: '*' , p1 name.
 
 	self assert: p1 extensionSelectors size equals: 3.
 	self assert: p1 extensionMethods size equals: 3.
@@ -319,15 +314,13 @@ RPackageIncrementalTest >> testExtensionMethods [
 
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	b2 := self createNewClassNamed: #B2InPackageP2 inPackage: p2.
-	a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addMethod: a2 >> #methodDefinedInP1.
+	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
 
 	self assert: p1 extensionSelectors size equals: 1.
 	self deny: (p1 includesClass: a2).
 	"method extension class are not included in packages"
 
-	b2 compileSilently: 'firstMethodInB2PackagedInP1 ^ 1'.
-	p1 addMethod: b2 >> #firstMethodInB2PackagedInP1.
+	b2 compile: 'firstMethodInB2PackagedInP1 ^ 1' classified: '*' , p1 name.
 	self assert: p1 extensionSelectors size equals: 2
 ]
 
@@ -356,7 +349,7 @@ RPackageIncrementalTest >> testIncludeClass [
 	p2 := self createNewPackageNamed: self p2Name.
 
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
-	a2 compileSilently: 'methodPackagedInP1 ^ #methodPackagedInP1'.
+	a2 compile: 'methodPackagedInP1 ^ #methodPackagedInP1' classified: '*' , p1 name.
 
 	self deny: (p1 includesClass: a2).
 	p1 addMethod: a2 >> #methodPackagedInP1.
@@ -378,12 +371,9 @@ RPackageIncrementalTest >> testIncludeClassMore [
 	p2 := self createNewPackageNamed: self p2Name.
 	p3 := self createNewPackageNamed: self p3Name.
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
-	a2 compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2'.
-	p2 addMethod: a2 >> #methodDefinedInP2.
-	a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addMethod: a2 >> #methodDefinedInP1.
-	a2 compileSilently: 'methodDefinedInP3 ^ #methodDefinedInP3'.
-	p3 addMethod: a2 >> #methodDefinedInP3.
+	a2 compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
+	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
+	a2 compile: 'methodDefinedInP3 ^ #methodDefinedInP3' classified: '*' , p3 name.
 
 	self assert: (p2 includesClass: a2).
 	self deny: (p1 includesClass: a2).
@@ -398,12 +388,9 @@ RPackageIncrementalTest >> testIncludeSelectorOfClass [
 	p2 := self createNewPackageNamed: self p2Name.
 	p3 := self createNewPackageNamed: self p3Name.
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
-	a2 compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2'.
-	p2 addMethod: a2 >> #methodDefinedInP2.
-	a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addMethod: a2 >> #methodDefinedInP1.
-	a2 compileSilently: 'methodDefinedInP3 ^ #methodDefinedInP3'.
-	p3 addMethod: a2 >> #methodDefinedInP3.
+	a2 compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
+	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
+	a2 compile: 'methodDefinedInP3 ^ #methodDefinedInP3' classified: '*' , p3 name.
 
 	"includesSelector checks both in defined and extension so we test both"
 	self assert: (p2 includesSelector: #methodDefinedInP2 ofClass: a2).
@@ -422,23 +409,18 @@ RPackageIncrementalTest >> testIncludeSelectorOfClass [
 { #category : #'tests - extension' }
 RPackageIncrementalTest >> testIncludeSelectorOfMetaClass [
 
-	| p1 p2 p3 a2 a2class |
+	| p1 p2 p3 a2 |
 	p1 := self createNewPackageNamed: self p1Name.
 	p2 := self createNewPackageNamed: self p2Name.
 	p3 := self createNewPackageNamed: self p3Name.
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
-	a2class := a2 class.
-	a2class compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2'.
-	p2 addMethod: a2class >> #methodDefinedInP2.
-	a2class compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addMethod: a2class >> #methodDefinedInP1.
-	a2class compileSilently: 'methodDefinedInP3 ^ #methodDefinedInP3'.
-	p3 addMethod: a2class >> #methodDefinedInP3.
+	a2 class compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
+	a2 class compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
+	a2 class compile: 'methodDefinedInP3 ^ #methodDefinedInP3' classified: '*' , p3 name.
 
 	"includesSelector checks both in defined and extension so we test both"
-	self assert: (p2 includesSelector: #methodDefinedInP2 ofClass: a2class).
+	self assert: (p2 includesSelector: #methodDefinedInP2 ofClass: a2 class).
 	self assert: (p2 includesDefinedSelector: #methodDefinedInP2 ofClass: a2 class).
-	self assert: (p2 includesDefinedSelector: #methodDefinedInP2 ofClass: a2class).
 	self deny: (p2 includesExtensionSelector: #methodDefinedInP2 ofClass: a2 class).
 
 	self deny: (p2 includesSelector: #methodDefinedInP3 ofClass: a2).
@@ -460,16 +442,13 @@ RPackageIncrementalTest >> testIncludesMethodOfClassInPresenceOfOtherPackageExte
 	p3 := self createNewPackageNamed: self p3Name.
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 
-	a2 compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2'.
-	p2 addMethod: a2 >> #methodDefinedInP2.
+	a2 compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
 	self assert: (p2 includesDefinedSelector: #methodDefinedInP2 ofClass: a2).
 
-	a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addMethod: a2 >> #methodDefinedInP1.
+	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
 	self assert: (p1 includesExtensionSelector: #methodDefinedInP1 ofClass: a2).
 
-	a2 compileSilently: 'methodDefinedInP3 ^ #methodDefinedInP3'.
-	p3 addMethod: a2 >> #methodDefinedInP3.
+	a2 compile: 'methodDefinedInP3 ^ #methodDefinedInP3' classified: '*' , p3 name.
 	self assert: (p3 includesExtensionSelector: #methodDefinedInP3 ofClass: a2).
 
 	self assert: (p2 includesDefinedSelector: #methodDefinedInP2 ofClass: a2).
@@ -490,8 +469,7 @@ RPackageIncrementalTest >> testIncludesOrTouches [
 	self deny: (p1 includesClass: a2).
 	self assert: (p2 includesClass: a2).
 
-	a2 compileSilently: 'methodPackagedInP1 ^ #methodPackagedInP1'.
-	p1 addMethod: a2 >> #methodPackagedInP1.
+	a2 compile: 'methodPackagedInP1 ^ #methodPackagedInP1' classified: '*' , p1 name.
 
 	self assert: p1 extensionMethods size equals: 1.
 	self assert: p1 extensionSelectors size equals: 1.
@@ -517,11 +495,8 @@ RPackageIncrementalTest >> testMethodPackageResolution [
 	| p1 a1 |
 	p1 := self createNewPackageNamed: self p1Name.
 	a1 := self createNewClassNamed: #A2InPackageP1 inPackage: p1.
-	a1 compileSilently: 'method ^ #methodDefinedInP1'.
-	a1 class compileSilently: 'method ^ #methodDefinedInP1'.
-
-	p1 addMethod: a1 >> #method.
-	p1 addMethod: a1 class >> #method.
+	a1 compile: 'method ^ #methodDefinedInP1'.
+	a1 class compile: 'method ^ #methodDefinedInP1'.
 
 	self assert: (a1 >> #method) package identicalTo: p1.
 	self assert: (a1 class >> #method) package identicalTo: p1
@@ -535,8 +510,7 @@ RPackageIncrementalTest >> testPackageOfClassForClassesNotDefinedInPackageButJus
 	p2 := self createNewPackageNamed: self p2Name.
 
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
-	a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addMethod: a2 >> #methodDefinedInP1.
+	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
 
 	self assert: a2 package equals: p2.
 	p1 extensionMethods do: [ :each | "the package of a class which is extended inside a package p, is not p
@@ -558,44 +532,44 @@ RPackageIncrementalTest >> testPackageOfClassForDefinedClasses [
 
 { #category : #'tests - class addition removal' }
 RPackageIncrementalTest >> testRemoveClassRemovesExtensions [
+
 	| p1 p2 a1 |
 	p1 := self createNewPackageNamed: self p1Name.
 	p2 := self createNewPackageNamed: self p2Name.
 	"the class is created but not added to the package for now"
 	a1 := self createNewClassNamed: #A1InPackageP1 inPackage: p1.
 	self assert: p1 definedClasses size equals: 1.
-	a1 compileSilently: 'newlyAddedToA1 ^ #methodDefinedInP1'.
-	p2 addMethod: (a1>>#newlyAddedToA1).
+	a1 compile: 'methodDefinedInP2 ^ #methodDefinedInP2' classified: '*' , p2 name.
 
-	self assert: (p2 includesSelector: #newlyAddedToA1 ofClass: a1).
-	self assert: (p2 includesExtensionSelector: #newlyAddedToA1 ofClass: a1).
+	self assert: (p2 includesSelector: #methodDefinedInP2 ofClass: a1).
+	self assert: (p2 includesExtensionSelector: #methodDefinedInP2 ofClass: a1).
 
 	a1 removeFromSystem.
 
-	self deny: (p2 includesSelector: #newlyAddedToA1 ofClass: a1).
-	self deny: (p2 includesExtensionSelector: #newlyAddedToA1 ofClass: a1).
-	self deny: (p2 includesDefinedSelector: #newlyAddedToA1 ofClass: a1)
+	self deny: (p2 includesSelector: #methodDefinedInP2 ofClass: a1).
+	self deny: (p2 includesExtensionSelector: #methodDefinedInP2 ofClass: a1).
+	self deny: (p2 includesDefinedSelector: #methodDefinedInP2 ofClass: a1)
 ]
 
 { #category : #'tests - class addition removal' }
-RPackageIncrementalTest >> testRemoveExtensionMethodRemovesExtensionsFromRPackage [
+RPackageIncrementalTest >> testRemoveExtensionMethodRemovesExtensionsFromPackage [
+
 	| p1 p2 a1 |
 	p1 := self createNewPackageNamed: self p1Name.
 	p2 := self createNewPackageNamed: self p2Name.
 	"the class is created but not added to the package for now"
 	a1 := self createNewClassNamed: #A1InPackageP1 inPackage: p1.
 	self assert: p1 definedClasses size equals: 1.
-	a1 compileSilently: 'newlyAddedToA1 ^ #methodDefinedInP1'.
-	p2 addMethod: (a1>>#newlyAddedToA1).
+	a1 compile: 'methodDefinedInP2 ^ #methodDefinedInP2' classified: '*' , p2 name.
 
-	self assert: (p2 includesSelector: #newlyAddedToA1 ofClass: a1).
-	self assert: (p2 includesExtensionSelector: #newlyAddedToA1 ofClass: a1).
+	self assert: (p2 includesSelector: #methodDefinedInP2 ofClass: a1).
+	self assert: (p2 includesExtensionSelector: #methodDefinedInP2 ofClass: a1).
 
-	a1 removeSelector: #newlyAddedToA1.
+	a1 removeSelector: #methodDefinedInP2.
 
-	self deny: (p2 includesSelector: #newlyAddedToA1 ofClass: a1).
-	self deny: (p2 includesExtensionSelector: #newlyAddedToA1 ofClass: a1).
-	self deny: (p2 includesDefinedSelector: #newlyAddedToA1 ofClass: a1)
+	self deny: (p2 includesSelector: #methodDefinedInP2 ofClass: a1).
+	self deny: (p2 includesExtensionSelector: #methodDefinedInP2 ofClass: a1).
+	self deny: (p2 includesDefinedSelector: #methodDefinedInP2 ofClass: a1)
 ]
 
 { #category : #'tests - extension' }
@@ -607,10 +581,8 @@ RPackageIncrementalTest >> testTwoClassesWithExtensions [
 
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	b2 := self createNewClassNamed: #B2InPackageP2 inPackage: p2.
-	a2 compileSilently: 'methodPackagedInP1 ^ #methodPackagedInP1'.
-	p1 addMethod: a2 >> #methodPackagedInP1.
-	b2 class compileSilently: 'methodPackagedInP1 ^ #methodPackagedInP1'.
-	p1 addMethod: b2 class >> #methodPackagedInP1.
+	a2 compile: 'methodPackagedInP1 ^ #methodPackagedInP1' classified: '*' , p1 name.
+	b2 class compile: 'methodPackagedInP1 ^ #methodPackagedInP1' classified: '*' , p1 name.
 
 	self assert: p1 classes size equals: 2.
 	self assert: p2 classes size equals: 2

--- a/src/RPackage-Tests/RPackageObsoleteTest.class.st
+++ b/src/RPackage-Tests/RPackageObsoleteTest.class.st
@@ -52,8 +52,8 @@ RPackageObsoleteTest >> testMethodPackageOfRemovedClass [
 	| pack method foo |
 	pack := self createNewPackageNamed: 'P1'.
 	foo := self createNewClassNamed: #FooForTest2 inPackage: pack.
-	foo compileSilently: 'bar ^42'.
-	method := foo>>#bar.
+	foo compile: 'bar ^42'.
+	method := foo >> #bar.
 	foo removeFromSystem.
-	self deny: (pack includesClassNamed: #FooForTest2 )
+	self deny: (pack includesClassNamed: #FooForTest2)
 ]

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -105,33 +105,23 @@ RPackageOrganizerTest >> testFullRegistration [
 
 	| p1 p2 p3 a1 a2 b1 b2 a3 |
 	"taken from setup of RPackageReadOnlyCompleteSetup"
-
 	p1 := self createNewPackageNamed: self p1Name.
 	p2 := self createNewPackageNamed: self p2Name.
 	p3 := self createNewPackageNamed: self p3Name.
 
-	a1 :=  self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
+	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
 	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.
 	a2 := self createNewClassNamed: #A2DefinedInP2 inPackage: p2.
 	b2 := self createNewClassNamed: #B2DefinedInP2 inPackage: p2.
 	a3 := self createNewClassNamed: #A3DefinedInP3 inPackage: p3.
 
-	a1 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addMethod: (a1>>#methodDefinedInP1).
-	a1 compileSilently: 'anotherMethodDefinedInP1 ^ #anotherMethodDefinedInP1'.
-	p1 addMethod: (a1>>#anotherMethodDefinedInP1).
+	a1 compile: 'methodDefinedInP1 ^ #methodDefinedInP1'.
+	a1 compile: 'anotherMethodDefinedInP1 ^ #anotherMethodDefinedInP1'.
 
-	a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addMethod: (a2>>#methodDefinedInP1).
-
-	a2 compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2'.
-	p2 addMethod: (a2>>#methodDefinedInP2).
-
-	a2 compileSilently: 'methodDefinedInP3 ^ #methodDefinedInP3'.
-	p3 addMethod: (a2>>#methodDefinedInP3).
-
-	a2 class compileSilently: 'classSideMethodDefinedInP3 ^ #classSideMethodDefinedInP3'.
-	p3 addMethod: (a2 class>>#classSideMethodDefinedInP3).
+	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
+	a2 compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
+	a2 compile: 'methodDefinedInP3 ^ #methodDefinedInP3' classified: '*' , p3 name.
+	a2 class compile: 'classSideMethodDefinedInP3 ^ #classSideMethodDefinedInP3' classified: '*' , p3 name.
 
 	self deny: (p2 includesClass: b1).
 	self assert: (p2 includesClass: b2).
@@ -225,7 +215,6 @@ RPackageOrganizerTest >> testRegistrationExtendingPackages [
 
 	| p |
 	self createNewClassNamed: 'QuadrangleForTesting' inCategory: self class category.
-	self quadrangleClass compileSilently: 'intersect:aPoint ^ false'.
 	self assertEmpty: (self organizer extendingPackagesOf: self quadrangleClass).
 	p := self createNewPackageNamed: 'P1'.
 	self organizer registerExtendingPackage: p forClass: self quadrangleClass.
@@ -295,22 +284,13 @@ RPackageOrganizerTest >> testRemovePackage [
 	b2 := self createNewClassNamed: #B2DefinedInP2 inPackage: p2.
 	a3 := self createNewClassNamed: #A3DefinedInP3 inPackage: p3.
 
-	a1 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addMethod: a1 >> #methodDefinedInP1.
-	a1 compileSilently: 'anotherMethodDefinedInP1 ^ #anotherMethodDefinedInP1'.
-	p1 addMethod: a1 >> #anotherMethodDefinedInP1.
+	a1 compile: 'methodDefinedInP1 ^ #methodDefinedInP1'.
+	a1 compile: 'anotherMethodDefinedInP1 ^ #anotherMethodDefinedInP1'.
 
-	a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addMethod: a2 >> #methodDefinedInP1.
-
-	a2 compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2'.
-	p2 addMethod: a2 >> #methodDefinedInP2.
-
-	a2 compileSilently: 'methodDefinedInP3 ^ #methodDefinedInP3'.
-	p3 addMethod: a2 >> #methodDefinedInP3.
-
-	a2 class compileSilently: 'classSideMethodDefinedInP3 ^ #classSideMethodDefinedInP3'.
-	p3 addMethod: a2 class >> #classSideMethodDefinedInP3.
+	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
+	a2 compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
+	a2 compile: 'methodDefinedInP3 ^ #methodDefinedInP3' classified: '*' , p3 name.
+	a2 class compile: 'classSideMethodDefinedInP3 ^ #classSideMethodDefinedInP3' classified: '*' , p3 name.
 
 	self organizer removePackage: p1.
 	self organizer removePackage: p2.
@@ -371,7 +351,6 @@ RPackageOrganizerTest >> testUnregistrationExtendingPackages [
 
 	| p |
 	self createNewClassNamed: 'QuadrangleForTesting' inCategory: self class category.
-	self quadrangleClass compileSilently: 'intersect:aPoint ^ false'.
 	p := self createNewPackageNamed: 'P1'.
 	self organizer registerExtendingPackage: p forClass: self quadrangleClass.
 	self denyEmpty: (self organizer extendingPackagesOf: self quadrangleClass).

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -47,22 +47,15 @@ RPackageReadOnlyCompleteSetupTest >> setUp [
 	b2 := self createNewClassNamed: #B2DefinedInP2 inPackage: p2.
 	a3 := self createNewClassNamed: #A3DefinedInP3 inPackage: p3.
 
-	a1 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addMethod: (a1>>#methodDefinedInP1).
-	a1 compileSilently: 'anotherMethodDefinedInP1 ^ #anotherMethodDefinedInP1'.
-	p1 addMethod: (a1>>#anotherMethodDefinedInP1).
+	a1 compile: 'methodDefinedInP1 ^ #methodDefinedInP1'.
+	a1 compile: 'anotherMethodDefinedInP1 ^ #anotherMethodDefinedInP1'.
 
-	a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addMethod: (a2>>#methodDefinedInP1).
+	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
+	a2 compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
 
-	a2 compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2'.
-	p2 addMethod: (a2>>#methodDefinedInP2).
+	a2 compile: 'methodDefinedInP3 ^ #methodDefinedInP3' classified: '*' , p3 name.
 
-	a2 compileSilently: 'methodDefinedInP3 ^ #methodDefinedInP3'.
-	p3 addMethod: (a2>>#methodDefinedInP3).
-
-	a2 class compileSilently: 'classSideMethodDefinedInP3 ^ #classSideMethodDefinedInP3'.
-	p3 addMethod: (a2 class>>#classSideMethodDefinedInP3)
+	a2 class compile: 'classSideMethodDefinedInP3 ^ #classSideMethodDefinedInP3' classified: '*' , p3 name
 ]
 
 { #category : #'tests - tag class' }

--- a/src/RPackage-Tests/RPackageTraitTest.class.st
+++ b/src/RPackage-Tests/RPackageTraitTest.class.st
@@ -27,27 +27,20 @@ RPackageTraitTest >> setUp [
 	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
 
 	"a1 defines two normal = local methods"
-	a1 compileSilently: 'localMethodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addMethod: a1 >> #localMethodDefinedInP1.
-	a1 compileSilently: 'anotherLocalMethodDefinedInP1 ^ #anotherMethodDefinedInP1'.
-	p1 addMethod: a1 >> #anotherLocalMethodDefinedInP1.
+	a1 compile: 'localMethodDefinedInP1 ^ #methodDefinedInP1'.
+	a1 compile: 'anotherLocalMethodDefinedInP1 ^ #anotherMethodDefinedInP1'.
 
 	t1 := self createNewTraitNamed: #TraitInPackageP1 inPackage: p1.
-	t1 compileSilently: 'traitMethodDefinedInP1 ^ #traitMethodDefinedInP1'.
-	p1 addMethod: t1 >> #traitMethodDefinedInP1.
+	t1 compile: 'traitMethodDefinedInP1 ^ #traitMethodDefinedInP1'.
 
-	"P6 defines a new method extension on T1 (packaged in p4)"
-	t1 compileSilently: 'traitMethodExtendedFromP3 ^ #traitMethodExtendedFromP3' classified: '*' , self p3Name.
-	p3 addMethod: t1 >> #traitMethodExtendedFromP3.
+	"P3 defines a new method extension on T1 (packaged in p1)"
+	t1 compile: 'traitMethodExtendedFromP3 ^ #traitMethodExtendedFromP3' classified: '*' , self p3Name.
 
 	t2 := self createNewTraitNamed: #TraitInPackageP2 inPackage: p2.
-	t2 compileSilently: 'traitMethodDefinedInP2 ^ #traitMethodDefinedInP2'.
+	t2 compile: 'traitMethodDefinedInP2 ^ #traitMethodDefinedInP2'.
 
-	p2 addMethod: t2 >> #traitMethodDefinedInP2.
-
-	"Here P4 extends T2 from P5 with a new method"
-	t2 compileSilently: 'traitMethodExtendedFromP1 ^ #traitMethodExtendedFromP1' classified: '*' , self p1Name.
-	p1 addMethod: t2 >> #traitMethodExtendedFromP1.
+	"Here P1 extends T2 from P2 with a new method"
+	t2 compile: 'traitMethodExtendedFromP1 ^ #traitMethodExtendedFromP1' classified: '*' , self p1Name.
 
 	a1 setTraitComposition: (t1 + t2) asTraitComposition
 ]


### PR DESCRIPTION
The tests of RPackage are too complex for what they are doing. I already started to simplify them and here is another step

If you want to add a method to a package currently we are silently compiling methods and since packages add the methods through announcements and the method was silently compiled, it has to add the method by hand in the package.

I replaced this by compiling normally the methods in the tests except for the tests that were explicitly adding method to a package