### PR TITLE
Kernel: Introduce environment announcer

### DIFF
--- a/src/Deprecated12/BlockClosure.extension.st
+++ b/src/Deprecated12/BlockClosure.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #BlockClosure }
+
+{ #category : #'*Deprecated12' }
+BlockClosure >> valueWithoutNotifications [
+
+	self deprecated: 'This method will be removed from future version of Pharo since the meta model will not rely on the singleton anymore.'.
+	^ SystemAnnouncer uniqueInstance suspendAllWhile: self
+]

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -619,6 +619,12 @@ Behavior >> environment [
 	^Smalltalk globals
 ]
 
+{ #category : #accessing }
+Behavior >> environmentAnnouncer [
+
+	^ self environment announcer
+]
+
 { #category : #testing }
 Behavior >> findOriginClassOf: aMethod [
 
@@ -1369,7 +1375,7 @@ Behavior >> removeSelector: aSelector [
 Behavior >> removeSelectorSilently: selector [
 	"Remove selector without sending system change notifications"
 
-	^ SystemAnnouncer uniqueInstance suspendAllWhile: [self removeSelector: selector]
+	^ self environmentAnnouncer suspendAllWhile: [ self removeSelector: selector ]
 ]
 
 { #category : #cleanup }

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -103,7 +103,7 @@ Class >> addClassVariable: aClassVariable [
 				, ' is already used as a variable name in class '
 				, subclass name]].
 	self basicDeclareClassVariable: aClassVariable.
-	SystemAnnouncer uniqueInstance
+	self environmentAnnouncer
 			classDefinitionChangedFrom: oldState to: self;
 			classModificationAppliedTo: self
 ]
@@ -278,7 +278,7 @@ Class >> category: aString [
 			self basicCategory: aString asSymbol.
 			self packageOrganizer classify: self name under: self basicCategory ]
 		ifFalse: [self errorCategoryName].
-	SystemAnnouncer uniqueInstance
+	self environmentAnnouncer
 		class: self recategorizedFrom: oldCategory to: self basicCategory
 ]
 
@@ -454,7 +454,7 @@ Class >> comment: aString stamp: aStamp [
 			self commentSourcePointer: newSourcePointer]
 		onFail: [ "ignore" ].
 
-	SystemAnnouncer uniqueInstance
+	self environmentAnnouncer
 		class: self
 		oldComment: oldComment
 		newComment: aString
@@ -956,7 +956,7 @@ Class >> removeClassVarNamed: aString interactive: interactive [
 
 	self classPool ifEmpty: [ self classPool: nil ].
 
-	SystemAnnouncer uniqueInstance classModificationAppliedTo: self
+	self environmentAnnouncer classModificationAppliedTo: self
 ]
 
 { #category : #'class variables' }
@@ -995,7 +995,7 @@ Class >> removeFromSystem: logged [
 	We deal also with a special case that is the case a class of the same name than the alias is installed in the image after the alias. In that case we do not remove it. It's the reason we check if the global of the alias is the same as self."
 	self deprecatedAliases do: [ :alias | self environment at: alias ifPresent: [ :class | class = self ifTrue: [ self environment removeKey: alias ] ] ].
 	self obsolete.
-	logged ifTrue: [ SystemAnnouncer announce: (ClassRemoved class: self package: package category: myCategory) ]
+	logged ifTrue: [ self environmentAnnouncer announce: (ClassRemoved class: self package: package category: myCategory) ]
 ]
 
 { #category : #initialization }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -34,7 +34,7 @@ ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod 
 		priorOrigin := method origin ].
 
 	oldProtocol := self protocolOfSelector: selector.
-	SystemAnnouncer uniqueInstance prevent: MethodRecategorized during: [ self classify: selector under: protocol ].
+	self environmentAnnouncer prevent: MethodRecategorized during: [ self classify: selector under: protocol ].
 	newProtocol := self protocolOfSelector: selector.
 
 	self addSelectorSilently: selector withMethod: compiledMethod.
@@ -42,11 +42,11 @@ ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod 
 	self isAnonymous ifTrue: [ ^ self ].
 
 	(priorMethod isNil or: [ priorOrigin ~= compiledMethod origin ])
-		ifTrue: [ SystemAnnouncer uniqueInstance methodAdded: compiledMethod ]
+		ifTrue: [ self environmentAnnouncer methodAdded: compiledMethod ]
 		ifFalse: [
 			"If protocol changed and someone is from different package, I need to throw a method recategorized"
-			newProtocol = oldProtocol ifFalse: [ SystemAnnouncer uniqueInstance methodRecategorized: compiledMethod oldProtocol: oldProtocol ].
-			SystemAnnouncer uniqueInstance methodChangedFrom: priorMethod to: compiledMethod oldProtocol: oldProtocol ]
+			newProtocol = oldProtocol ifFalse: [ self environmentAnnouncer methodRecategorized: compiledMethod oldProtocol: oldProtocol ].
+			self environmentAnnouncer methodChangedFrom: priorMethod to: compiledMethod oldProtocol: oldProtocol ]
 ]
 
 { #category : #'instance variables' }
@@ -70,7 +70,7 @@ ClassDescription >> addProtocol: aProtocol [
 
 	protocols := protocols copyWith: protocol.
 
-	SystemAnnouncer announce: (ProtocolAdded in: self protocol: protocol).
+	self environmentAnnouncer announce: (ProtocolAdded in: self protocol: protocol).
 	^ protocol
 ]
 
@@ -341,7 +341,7 @@ ClassDescription >> compileSilently: sourceCode classified: protocolName [
 ClassDescription >> compileSilently: sourceCode classified: protocolName notifying: requestor [
 	"Compile the code and classify the resulting method in the given protocol, leaving no trail in the system log, nor in any change set, nor in the 'recent submissions' list."
 
-	^ SystemAnnouncer uniqueInstance suspendAllWhile: [ self compile: sourceCode classified: protocolName notifying: requestor ]
+	^ self environmentAnnouncer suspendAllWhile: [ self compile: sourceCode classified: protocolName notifying: requestor ]
 ]
 
 { #category : #copying }
@@ -765,7 +765,7 @@ ClassDescription >> notifyOfRecategorizedSelector: selector from: oldProtocol to
 	"If compiled method is not there, it meens it has been removed, not recategorized... so I skip
 	 the method recategorized announce"
 
-	self compiledMethodAt: selector ifPresent: [ :method | SystemAnnouncer uniqueInstance methodRecategorized: method oldProtocol: oldProtocol ]
+	self compiledMethodAt: selector ifPresent: [ :method | self environmentAnnouncer methodRecategorized: method oldProtocol: oldProtocol ]
 ]
 
 { #category : #private }
@@ -924,7 +924,7 @@ ClassDescription >> removeProtocolIfEmpty: aProtocol [
 
 	oldProtocolNames := self protocolNames.
 	protocols := protocols copyWithout: protocol.
-	SystemAnnouncer announce: (ProtocolRemoved in: self protocol: protocol)
+	self environmentAnnouncer announce: (ProtocolRemoved in: self protocol: protocol)
 ]
 
 { #category : #'accessing - method dictionary' }
@@ -941,7 +941,7 @@ ClassDescription >> removeSelector: selector [
 	self removeFromProtocols: selector.
 	super removeSelector: selector.
 
-	SystemAnnouncer uniqueInstance methodRemoved: priorMethod protocol: priorProtocol origin: origin
+	self environmentAnnouncer methodRemoved: priorMethod protocol: priorProtocol origin: origin
 ]
 
 { #category : #'instance variables' }

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -831,6 +831,12 @@ Object >> enclosedElement [
 	Only SetElement instance or its subclasses allowed to answer something different than receiver itself"
 ]
 
+{ #category : #accessing }
+Object >> environmentAnnouncer [
+
+	^ self class environmentAnnouncer
+]
+
 { #category : #'error handling' }
 Object >> error [
 	"Throw a generic Error exception."

--- a/src/Monticello/MethodAddition.class.st
+++ b/src/Monticello/MethodAddition.class.st
@@ -55,28 +55,21 @@ MethodAddition >> createCompiledMethod [
 
 { #category : #operations }
 MethodAddition >> installMethod [
-	SystemAnnouncer uniqueInstance
-		suspendAllWhile: [ myClass addSelector: selector withMethod: compiledMethod ]
+
+	myClass environmentAnnouncer suspendAllWhile: [ myClass addSelector: selector withMethod: compiledMethod ]
 ]
 
 { #category : #notifying }
 MethodAddition >> notifyObservers [
-	SystemAnnouncer uniqueInstance 
-		suspendAllWhile: [myClass classify: selector under: protocolName].
-	priorMethod 
-		ifNil: [ SystemAnnouncer uniqueInstance
-				methodAdded: compiledMethod
-				configuredWith: [ :event | 
-					event
-						propertyAt: #eventSource
-						put: #Monticello ] ]
-		ifNotNil: [
-			SystemAnnouncer uniqueInstance methodChangedFrom: priorMethod to: compiledMethod oldProtocol: priorProtocol.
-			priorProtocol name = protocolName ifFalse: [
-       			SystemAnnouncer uniqueInstance methodRecategorized: compiledMethod oldProtocol: priorProtocol ] ].
-	"The following code doesn't seem to do anything."
-	myClass instanceSide noteCompilationOf: compiledMethod meta: myClass isClassSide.
 
+	myClass environmentAnnouncer suspendAllWhile: [ myClass classify: selector under: protocolName ].
+	priorMethod
+		ifNil: [ myClass environmentAnnouncer methodAdded: compiledMethod configuredWith: [ :event | event propertyAt: #eventSource put: #Monticello ] ]
+		ifNotNil: [
+			myClass environmentAnnouncer methodChangedFrom: priorMethod to: compiledMethod oldProtocol: priorProtocol.
+			priorProtocol name = protocolName ifFalse: [ myClass environmentAnnouncer methodRecategorized: compiledMethod oldProtocol: priorProtocol ] ].
+	"The following code doesn't seem to do anything."
+	myClass instanceSide noteCompilationOf: compiledMethod meta: myClass isClassSide
 ]
 
 { #category : #accessing }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -323,7 +323,7 @@ RPackage >> ensureTag: aTag [
 	self flag: #package. "Next line should go with the system organizer"
 	self organizer addCategory: newTag categoryName.
 
-	SystemAnnouncer announce: (PackageTagAdded to: newTag).
+	self environmentAnnouncer announce: (PackageTagAdded to: newTag).
 	^ newTag
 ]
 
@@ -620,7 +620,7 @@ RPackage >> moveClass: aClass toTag: aTag [
 	oldPackage removeClass: aClass.
 	self importClass: aClass inTag: aTag.
 
-	SystemAnnouncer uniqueInstance classRepackaged: aClass from: oldPackage to: self
+	self environmentAnnouncer classRepackaged: aClass from: oldPackage to: self
 ]
 
 { #category : #accessing }
@@ -848,7 +848,7 @@ RPackage >> removeTag: aTag [
 
 	classTags remove: tag ifAbsent: [ ^ self ].
 
-	SystemAnnouncer announce: (PackageTagRemoved to: tag)
+	self environmentAnnouncer announce: (PackageTagRemoved to: tag)
 ]
 
 { #category : #private }
@@ -902,7 +902,7 @@ RPackage >> renameTo: aSymbol [
 		                    add: self name;
 		                    difference: { newName }.
 	self name: aSymbol.
-	SystemAnnouncer uniqueInstance suspendAllWhile: [
+	self environmentAnnouncer suspendAllWhile: [
 		self definedClasses do: [ :each | each category: newName , (each category allButFirst: oldName size) ].
 		oldCategoryNames do: [ :each | self organizer removeCategory: each ] ].
 	self renameTagsPrefixedWith: oldName to: newName.
@@ -910,7 +910,7 @@ RPackage >> renameTo: aSymbol [
 	self organizer
 		basicUnregisterPackageNamed: oldName;
 		basicRegisterPackage: self.
-	SystemAnnouncer uniqueInstance announce: (PackageRenamed to: self oldName: oldName newName: newName)
+	self environmentAnnouncer announce: (PackageRenamed to: self oldName: oldName newName: newName)
 ]
 
 { #category : #'class tags' }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -168,7 +168,7 @@ RPackageOrganizer >> addCategory: catString [
 
 	categoryMap at: catString asSymbol ifPresent: [ ^ self ] ifAbsentPut: [ OrderedCollection new ].
 
-	SystemAnnouncer uniqueInstance classCategoryAdded: catString
+	self environmentAnnouncer classCategoryAdded: catString
 ]
 
 { #category : #private }
@@ -190,7 +190,8 @@ RPackageOrganizer >> addMethod: method [
 
 { #category : #'system integration' }
 RPackageOrganizer >> announcer [
-	^SystemAnnouncer uniqueInstance private
+
+	^ self environment announcer private
 ]
 
 { #category : #'initialization - data' }
@@ -359,6 +360,12 @@ RPackageOrganizer >> environment [
 { #category : #'deprecated - SystemOrganizer leftovers' }
 RPackageOrganizer >> environment: aSystemDictionary [
 	 environment := aSystemDictionary
+]
+
+{ #category : #accessing }
+RPackageOrganizer >> environmentAnnouncer [
+
+	^ self environment announcer
 ]
 
 { #category : #'package - access from class' }
@@ -586,7 +593,7 @@ RPackageOrganizer >> registerPackage: aPackage [
 	aPackage extendedClasses do: [ :extendedClass | self registerExtendingPackage: aPackage forClass: extendedClass ].
 	aPackage definedClasses do: [ :definedClass | self registerPackage: aPackage forClass: definedClass ].
 
-	SystemAnnouncer announce: (PackageAdded to: aPackage).
+	self environmentAnnouncer announce: (PackageAdded to: aPackage).
 
 	^ aPackage
 ]
@@ -669,7 +676,7 @@ RPackageOrganizer >> removePackage: aPackage [
 	self basicUnregisterPackageNamed: package name.
 	package extendedClasses do: [ :extendedClass | self unregisterExtendingPackage: package forClass: extendedClass ].
 	package definedClasses do: [ :definedClass | self unregisterPackage: package forClass: definedClass ].
-	SystemAnnouncer announce: (PackageRemoved to: package).
+	self environmentAnnouncer announce: (PackageRemoved to: package).
 
 	^ package
 ]
@@ -753,7 +760,7 @@ RPackageOrganizer >> stopNotification [
 
 	"pay attention that we can break the system using this method"
 
-	SystemAnnouncer uniqueInstance unsubscribe: self.
+	self environmentAnnouncer unsubscribe: self.
 
 	self class environment at: #MCWorkingCopy ifPresent: [:wc |
 		wc removeDependent: self]
@@ -843,7 +850,7 @@ RPackageOrganizer >> systemMethodRecategorizedActionFrom: ann [
 		oldPackage removeMethod: method.
 		newPackage addMethod: method.
 
-		SystemAnnouncer uniqueInstance methodRepackaged: method from: oldPackage to: newPackage ]
+		self environmentAnnouncer methodRepackaged: method from: oldPackage to: newPackage ]
 ]
 
 { #category : #accessing }
@@ -860,7 +867,7 @@ RPackageOrganizer >> testPackages [
 
 { #category : #initialization }
 RPackageOrganizer >> unregister [
-	SystemAnnouncer uniqueInstance unsubscribe: self
+	self environmentAnnouncer unsubscribe: self
 ]
 
 { #category : #'private - registration' }
@@ -873,7 +880,7 @@ RPackageOrganizer >> unregisterExtendingPackage: aPackage forClass: aClass [
 RPackageOrganizer >> unregisterInterestToSystemAnnouncement [
 	"self unregisterInterestToSystemAnnouncement"
 
-	SystemAnnouncer uniqueInstance unsubscribe: self
+	self environmentAnnouncer unsubscribe: self
 ]
 
 { #category : #'private - registration' }

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -170,10 +170,10 @@ RPackageTag >> renameTo: newTagName [
 	oldName = categoryName ifTrue: [ ^ self ].
 
 	self basicRenameTo: newTagName.
-	SystemAnnouncer uniqueInstance suspendAllWhile: [
+	self environmentAnnouncer suspendAllWhile: [
 		self classes do: [ :each | each category: categoryName ].
 		self organizer renameCategory: oldName toBe: categoryName ].
-	SystemAnnouncer announce: (PackageTagRenamed to: self oldName: tagName newName: newTagName)
+	self environmentAnnouncer announce: (PackageTagRenamed to: self oldName: tagName newName: newTagName)
 ]
 
 { #category : #accessing }
@@ -184,7 +184,7 @@ RPackageTag >> renameTo: aString category: categoryName [
 	oldName = categoryName ifTrue: [ ^ self ].
 
 	self basicRenameTo: aString.
-	SystemAnnouncer uniqueInstance suspendAllWhile: [
+	self environmentAnnouncer suspendAllWhile: [
 		self classes do: [ :each | each category: categoryName ].
 		self organizer renameCategory: oldName toBe: categoryName ]
 ]

--- a/src/Refactoring-Changes/RBCommentChange.class.st
+++ b/src/Refactoring-Changes/RBCommentChange.class.st
@@ -58,7 +58,7 @@ RBCommentChange >> comment: aString [
 RBCommentChange >> generateChanges [
 
 	self changeClass comment: comment stamp: self changeStamp.
-	SystemAnnouncer uniqueInstance classCommented: self changeClass
+	self environmentAnnouncer classCommented: self changeClass
 ]
 
 { #category : #printing }

--- a/src/SUnit-Core/ClassFactoryForTestCase.class.st
+++ b/src/SUnit-Core/ClassFactoryForTestCase.class.st
@@ -277,7 +277,7 @@ ClassFactoryForTestCase >> silentlyCompile: aString in: aBehavior storingSource:
 
 { #category : #private }
 ClassFactoryForTestCase >> silentlyDo: aBlock [
-	^ SystemAnnouncer uniqueInstance suspendAllWhile: aBlock
+	^ self environment announcer suspendAllWhile: aBlock
 ]
 
 { #category : #creating }

--- a/src/Shift-Changes/ShClassChanged.class.st
+++ b/src/Shift-Changes/ShClassChanged.class.st
@@ -10,8 +10,8 @@ Class {
 
 { #category : #announcing }
 ShClassChanged >> announceChanges [
-	SystemAnnouncer uniqueInstance classDefinitionChangedFrom: oldClass to: builder newClass.
-	SystemAnnouncer uniqueInstance classModificationAppliedTo: builder newClass
+	self environmentAnnouncer classDefinitionChangedFrom: oldClass to: builder newClass.
+	self environmentAnnouncer classModificationAppliedTo: builder newClass
 ]
 
 { #category : #announcing }

--- a/src/Shift-Changes/ShMetaclassChanged.class.st
+++ b/src/Shift-Changes/ShMetaclassChanged.class.st
@@ -10,8 +10,8 @@ Class {
 
 { #category : #announcing }
 ShMetaclassChanged >> announceChanges [
-	SystemAnnouncer uniqueInstance classDefinitionChangedFrom: oldClass class to: builder newMetaclass.
-	SystemAnnouncer uniqueInstance classModificationAppliedTo: builder newMetaclass
+	self environmentAnnouncer classDefinitionChangedFrom: oldClass class to: builder newMetaclass.
+	self environmentAnnouncer classModificationAppliedTo: builder newMetaclass
 ]
 
 { #category : #accessing }

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -301,8 +301,8 @@ ShiftClassInstaller >> recategorize: aClass to: newCategory [
 		ifNotNil: [ :systemOrganizer | systemOrganizer classify: aClass name under: newCategory ].
 
 	(oldCategory isNil or:[ oldCategory = #Unclassified])
-		ifTrue: [ SystemAnnouncer uniqueInstance classAdded: aClass inCategory: newCategory ]
-		ifFalse: [ SystemAnnouncer uniqueInstance class: aClass recategorizedFrom: oldCategory to: newCategory ]
+		ifTrue: [ self environmentAnnouncer classAdded: aClass inCategory: newCategory ]
+		ifFalse: [ self environmentAnnouncer class: aClass recategorizedFrom: oldCategory to: newCategory ]
 ]
 
 { #category : #building }

--- a/src/System-Announcements/BlockClosure.extension.st
+++ b/src/System-Announcements/BlockClosure.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #BlockClosure }
-
-{ #category : #'*System-Announcements' }
-BlockClosure >> valueWithoutNotifications [
-	^SystemAnnouncer uniqueInstance suspendAllWhile: self
-]

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -26,7 +26,8 @@ Class {
 		'cachedClassNames',
 		'cachedNonClassNames',
 		'cachedBehaviors',
-		'pseudoVariables'
+		'pseudoVariables',
+		'announcer'
 	],
 	#category : #'System-Support-Utilities'
 }
@@ -92,6 +93,19 @@ SystemDictionary >> allTraitsDo: aBlock [
 	"Evaluate the argument, aBlock, for each trait in the system."
 
 	^ self traitNames do: [ :name | aBlock value: (self at: name) ]
+]
+
+{ #category : #accessing }
+SystemDictionary >> announcer [
+
+	self flag: #announcer. "When the MM will use this instance for all announcements related to code changes, we should have a new instead of using the unique instance."
+	^ announcer ifNil: [ announcer := SystemAnnouncer uniqueInstance ]
+]
+
+{ #category : #accessing }
+SystemDictionary >> announcer: anObject [
+
+	announcer := anObject
 ]
 
 { #category : #'accessing - dictionary access' }
@@ -398,12 +412,12 @@ SystemDictionary >> renameClass: aClass from: oldName to: newName [
 	self add: oldref. "Old association preserves old refs"
 	SessionManager default renamedClass: aClass from: oldName to: newName.
 	self flushClassNameCache.
-	SystemAnnouncer uniqueInstance
+	self environmentAnnouncer
 		classRenamed: aClass
 		from: oldName
 		to: newName
 		inCategory: category.
-	aClass subclassesDo: [ :subclass | SystemAnnouncer uniqueInstance classParentOf: subclass renamedFrom: oldName to: newName ]
+	aClass subclassesDo: [ :subclass | self environmentAnnouncer classParentOf: subclass renamedFrom: oldName to: newName ]
 ]
 
 { #category : #renaming }

--- a/src/TraitsV2/TraitChange.class.st
+++ b/src/TraitsV2/TraitChange.class.st
@@ -129,7 +129,7 @@ TraitChange >> remove: aSelector into: aClass changes: results [
 		aClass removeFromProtocols: aSelector.
 		aClass methodDict removeKey: aSelector.
 
-		SystemAnnouncer uniqueInstance methodRemoved: priorMethod protocol: priorProtocol origin: aClass
+		self environmentAnnouncer methodRemoved: priorMethod protocol: priorProtocol origin: aClass
 	].
 
 	"The change is propagated as a removal"


### PR DESCRIPTION
SystemAnnouncer is a class used by the system to anounce anything related to the system. It currently uses a singleton.

This prevents to have separated environments that are standalone. And this change is a first step to push in the direction of having standalone environments. I introduced an #announcer variable in SystemDictionary that is currentl the class we use to create an environment. This announcer can be accesed by any object by calling #environmentAnnouncer. For now, this variable points to the unique instance of SystemAnnouncer because the impact of this change is big and I want to do it step by step.

I updated the code announcing anything related to announcing pharo meta model changes. 

The only listener of SystemAnnouncer I changed was RPackage because it is been merged in the meta model. But I didn't update anything else because it will be a big change to know how we will manage all Pharo projects with multiple environments. So for now, the system will only work with the default system announcer. This will still be useful because we will be able to have new environments to do some tests generating code.

I also deprecated BlockClosure>>valueWithoutNotifications since it was not used and the method can easily be inlined and the code stay pretty simple