### PR TITLE
Remove some unused methods from StrikeFont, FixedFaceFont, GrafPort and BitBlt

### DIFF
--- a/src/Graphics-Fonts/BitBlt.extension.st
+++ b/src/Graphics-Fonts/BitBlt.extension.st
@@ -86,12 +86,6 @@ BitBlt >> installFont: aFont foregroundColor: foregroundColor backgroundColor: b
 ]
 
 { #category : #'*Graphics-Fonts' }
-BitBlt >> installStrikeFont: aStrikeFont foregroundColor: foregroundColor backgroundColor: backgroundColor [
-
-	^ self installStrikeFont: aStrikeFont foregroundColor: foregroundColor backgroundColor: backgroundColor scale: 1
-]
-
-{ #category : #'*Graphics-Fonts' }
 BitBlt >> installStrikeFont: aStrikeFont foregroundColor: foregroundColor backgroundColor: backgroundColor scale: scale [
 	| lastSourceDepth targetColor |
 	sourceForm ifNotNil:[lastSourceDepth := sourceForm depth].

--- a/src/Graphics-Fonts/FixedFaceFont.class.st
+++ b/src/Graphics-Fonts/FixedFaceFont.class.st
@@ -62,33 +62,6 @@ FixedFaceFont >> displayString: aString on: aDisplayContext from: startIndex to:
 		scale: scale
 ]
 
-{ #category : #displaying }
-FixedFaceFont >> displayString: aString on: aBitBlt from: startIndex to: stopIndex at: aPoint kern: kernDelta from: fromFont [
-	| destPoint |
-	destPoint := self
-				displayString: aString
-				on: aBitBlt
-				from: startIndex
-				to: stopIndex
-				at: aPoint
-				kern: kernDelta.
-	^ Array with: stopIndex + 1 with: destPoint
-]
-
-{ #category : #displaying }
-FixedFaceFont >> displayString: aString on: aBitBlt from: startIndex to: stopIndex at: aPoint kern: kernDelta from: fromFont baselineY: baselineY [
-	| destPoint |
-	destPoint := self
-				displayString: aString
-				on: aBitBlt
-				from: startIndex
-				to: stopIndex
-				at: aPoint
-				kern: kernDelta
-				baselineY: baselineY.
-	^ Array with: stopIndex + 1 with: destPoint
-]
-
 { #category : #accessing }
 FixedFaceFont >> emphasized: emph [
 	^self class new baseFont: (baseFont emphasized: emph)

--- a/src/Graphics-Fonts/GrafPort.extension.st
+++ b/src/Graphics-Fonts/GrafPort.extension.st
@@ -1,12 +1,6 @@
 Extension { #name : #GrafPort }
 
 { #category : #'*Graphics-Fonts' }
-GrafPort >> installStrikeFont: aStrikeFont [
-
-	^ self installStrikeFont: aStrikeFont foregroundColor: (lastFontForegroundColor ifNil: [Color black]) backgroundColor: (lastFontBackgroundColor ifNil: [Color transparent])
-]
-
-{ #category : #'*Graphics-Fonts' }
 GrafPort >> installStrikeFont: aStrikeFont foregroundColor: foregroundColor backgroundColor: backgroundColor scale: scale [
 	super installStrikeFont: aStrikeFont foregroundColor: foregroundColor backgroundColor: backgroundColor scale: scale.
 	aStrikeFont glyphs depth = 1 ifTrue: [

--- a/src/Graphics-Fonts/StrikeFont.class.st
+++ b/src/Graphics-Fonts/StrikeFont.class.st
@@ -1170,12 +1170,6 @@ StrikeFont >> heightOf: aCharacter [
 ]
 
 { #category : #displaying }
-StrikeFont >> installOn: aDisplayContext [
-
-	^aDisplayContext installStrikeFont: self
-]
-
-{ #category : #displaying }
 StrikeFont >> installOn: aDisplayContext foregroundColor: foregroundColor backgroundColor: backgroundColor scale: scale [
 	^aDisplayContext
 		installStrikeFont: self

--- a/src/Graphics-Fonts/StrikeFont.class.st
+++ b/src/Graphics-Fonts/StrikeFont.class.st
@@ -706,30 +706,6 @@ StrikeFont >> characterToGlyphMap: anArray [
 	characterToGlyphMap := anArray
 ]
 
-{ #category : #displaying }
-StrikeFont >> characters: anInterval in: sourceString displayAt: aPoint clippedBy: clippingRectangle rule: ruleInteger fillColor: aForm kernDelta: kernDelta on: aBitBlt [
-	"Simple, slow, primitive method for displaying a line of characters.
-	No wrap-around is provided."
-	| destPoint |
-	destPoint := aPoint.
-	anInterval do:
-		[ :i | | rightX sourceRect leftX ascii |
-		self flag: #yoDisplay.
-		"if the char is not supported, fall back to the specified fontset."
-		ascii := (sourceString at: i) charCode.
-		(ascii < minAscii or: [ ascii > maxAscii ]) ifTrue: [ ascii := maxAscii ].
-		leftX := xTable at: ascii + 1.
-		rightX := xTable at: ascii + 2.
-		sourceRect := leftX @ 0 extent: (rightX - leftX) @ self height.
-		aBitBlt
-			copyFrom: sourceRect
-			in: glyphs
-			to: destPoint.
-		destPoint := destPoint + ((rightX - leftX + kernDelta) @ 0)
-		"destPoint printString displayAt: 0@(i*20)" ].
-	^ destPoint
-]
-
 { #category : #testing }
 StrikeFont >> checkCharacter: character [
 	"Answer a Character that is within the ascii range of the receiver--either
@@ -818,20 +794,6 @@ StrikeFont >> displayChar: ascii form: charForm [
 	bigForm displayAt: 50 @ 2.
 	Display fillBlack:
 		(50 @ 2 + (m * charForm width @ 0) extent: 1 @ (m * self height))
-]
-
-{ #category : #displaying }
-StrikeFont >> displayLine: aString at: aPoint [
-	"Display the characters in aString, starting at position aPoint."
-
-	self characters: (1 to: aString size)
-		in: aString
-		displayAt: aPoint
-		clippedBy: Display boundingBox
-		rule: Form over
-		fillColor: nil
-		kernDelta: 0
-		on: (BitBlt toForm: Display)
 ]
 
 { #category : #displaying }


### PR DESCRIPTION
This pull request removes some unused methods from StrikeFont, FixedFaceFont, GrafPort and BitBlt.