### PR TITLE
Remove unused instance variables and methods from CharacterScanner and RubCharacterScanner hierarchies

### DIFF
--- a/src/Athens-Morphic/AthensDisplayScanner.class.st
+++ b/src/Athens-Morphic/AthensDisplayScanner.class.st
@@ -28,11 +28,6 @@ AthensDisplayScanner >> displayString: string from: startIndex to: stopIndex at:
 			canvas drawString: string from: startIndex to: stopIndex ]
 ]
 
-{ #category : #displaying }
-AthensDisplayScanner >> fillTextBackground [
-
-]
-
 { #category : #initialization }
 AthensDisplayScanner >> initWithParagraph: aParagraph andCanvas: anAthensCanvas [
 	self text: aParagraph text textStyle: aParagraph textStyle.

--- a/src/Athens-Morphic/AthensDisplayScanner.class.st
+++ b/src/Athens-Morphic/AthensDisplayScanner.class.st
@@ -15,11 +15,6 @@ AthensDisplayScanner class >> for: aParagraph on: anAthensCanvas [
 	^ self new initWithParagraph: aParagraph andCanvas: anAthensCanvas; yourself
 ]
 
-{ #category : #'instance creation' }
-AthensDisplayScanner class >> on: anAthensCanvas [
-	^ self new initWith: anAthensCanvas; yourself
-]
-
 { #category : #displaying }
 AthensDisplayScanner >> displayString: string from: startIndex to: stopIndex at: aPoint [
 	canvas pathTransform

--- a/src/Athens-Morphic/AthensDisplayScanner.class.st
+++ b/src/Athens-Morphic/AthensDisplayScanner.class.st
@@ -30,7 +30,7 @@ AthensDisplayScanner >> displayString: string from: startIndex to: stopIndex at:
 
 { #category : #displaying }
 AthensDisplayScanner >> fillTextBackground [
-	backgroundColor ifNotNil: [ canvas drawShape: (line left @ lineY extent: line width @ line lineHeight) ]
+
 ]
 
 { #category : #initialization }

--- a/src/Athens-Morphic/AthensDisplayScanner.class.st
+++ b/src/Athens-Morphic/AthensDisplayScanner.class.st
@@ -34,11 +34,6 @@ AthensDisplayScanner >> initWithParagraph: aParagraph andCanvas: anAthensCanvas 
 	canvas := anAthensCanvas
 ]
 
-{ #category : #initialization }
-AthensDisplayScanner >> initialize [
-	super initialize
-]
-
 { #category : #displaying }
 AthensDisplayScanner >> setFont [
 	super setFont.

--- a/src/FormCanvas-Core/FormCanvas.class.st
+++ b/src/FormCanvas-Core/FormCanvas.class.st
@@ -480,8 +480,7 @@ FormCanvas >> paragraph: para bounds: bounds color: c [
 	| scanner |
 	self setPaintColor: c.
 	scanner := (port clippedBy: (bounds translateBy: origin)) displayScannerFor: para
-		foreground: c background: Color transparent
-		ignoreColorChanges: false.
+		foreground: c.
 	para displayOn: (self copyClipRect: bounds) using: scanner at: origin+ bounds topLeft
 ]
 

--- a/src/Morphic-Base/GrafPort.extension.st
+++ b/src/Morphic-Base/GrafPort.extension.st
@@ -1,9 +1,8 @@
 Extension { #name : #GrafPort }
 
 { #category : #'*Morphic-Base' }
-GrafPort >> displayScannerFor: para foreground: foreColor background: backColor ignoreColorChanges: shadowMode [
+GrafPort >> displayScannerFor: para foreground: foreColor [
 	^ (BitBltDisplayScanner new text: para text textStyle: para textStyle
-			foreground: foreColor background: backColor fillBlt: self
-			ignoreColorChanges: shadowMode)
+			foreground: foreColor)
 		setPort: self shallowCopy
 ]

--- a/src/Rubric/FormCanvas.extension.st
+++ b/src/Rubric/FormCanvas.extension.st
@@ -6,7 +6,6 @@ FormCanvas >> rubParagraph: para bounds: bounds color: c [
 	| scanner |
 	self setPaintColor: c.
 	scanner := (port clippedBy: (bounds translateBy: origin)) rubDisplayScannerFor: para
-		foreground: c background: Color transparent
-		ignoreColorChanges: false.
+		foreground: c.
 	para drawOn: (self copyClipRect: bounds) using: scanner at: origin + bounds topLeft
 ]

--- a/src/Rubric/GrafPort.extension.st
+++ b/src/Rubric/GrafPort.extension.st
@@ -1,9 +1,8 @@
 Extension { #name : #GrafPort }
 
 { #category : #'*Rubric-Editing-Core' }
-GrafPort >> rubDisplayScannerFor: para foreground: foreColor background: backColor ignoreColorChanges: shadowMode [
+GrafPort >> rubDisplayScannerFor: para foreground: foreColor [
 	^ (RubDisplayScanner new text: para text textStyle: para textStyle
-			foreground: foreColor background: backColor fillBlt: self
-			ignoreColorChanges: shadowMode)
+			foreground: foreColor)
 		setPort: self shallowCopy
 ]

--- a/src/Rubric/RubCharacterScanner.class.st
+++ b/src/Rubric/RubCharacterScanner.class.st
@@ -72,11 +72,6 @@ RubCharacterScanner >> addKern: kernDelta [
 	kern := kern + kernDelta
 ]
 
-{ #category : #private }
-RubCharacterScanner >> backgroundColor: ignored [
-	"Overridden in DisplayScanner"
-]
-
 { #category : #scanning }
 RubCharacterScanner >> basicScanCharactersFrom: startIndex to: stopIndex in: sourceString rightX: rightX stopConditions: stops kern: kernDelta [
 	"Primitive. This is the inner loop of text display--but see

--- a/src/Rubric/RubCharacterScanner.class.st
+++ b/src/Rubric/RubCharacterScanner.class.st
@@ -406,9 +406,3 @@ RubCharacterScanner >> text: t textStyle: ts [
 RubCharacterScanner >> textColor: ignored [
 	"Overridden in DisplayScanner"
 ]
-
-{ #category : #'multilingual scanning' }
-RubCharacterScanner >> widthOf: char inFont: aFont [
-
-	^ aFont widthOf: char
-]

--- a/src/Rubric/RubCharacterScanner.class.st
+++ b/src/Rubric/RubCharacterScanner.class.st
@@ -203,17 +203,6 @@ RubCharacterScanner >> leadingTab [
 ]
 
 { #category : #scanning }
-RubCharacterScanner >> measureString: aString inFont: aFont from: startIndex to: stopIndex [
-	"WARNING: In order to use this method the receiver has to be set up using #initializeStringMeasurer"
-	destX := destY := lastIndex := 0.
-	baselineY := aFont ascent.
-	font := aFont.  " added Dec 03, 2004 "
-"	map := aFont characterToGlyphMap."
-	self scanCharactersFrom: startIndex to: stopIndex in: aString rightX: 999999 stopConditions: stopConditions kern: 0.
-	^destX
-]
-
-{ #category : #scanning }
 RubCharacterScanner >> nextTabXFrom: anX [
 	"Tab stops are distances from the left margin. Set the distance into the
 	argument, anX, normalized for the paragraph's left margin."

--- a/src/Rubric/RubDisplayScanner.class.st
+++ b/src/Rubric/RubDisplayScanner.class.st
@@ -133,11 +133,6 @@ RubDisplayScanner >> endOfRun [
 	^ false
 ]
 
-{ #category : #displaying }
-RubDisplayScanner >> fillTextBackground [
-
-]
-
 { #category : #'multilingual scanning' }
 RubDisplayScanner >> isBreakableAt: index in: sourceString [
 

--- a/src/Rubric/RubDisplayScanner.class.st
+++ b/src/Rubric/RubDisplayScanner.class.st
@@ -6,7 +6,6 @@ Class {
 		'lineY',
 		'runX',
 		'foregroundColor',
-		'backgroundColor',
 		'lineHeight',
 		'morphicOffset',
 		'defaultTextColor'
@@ -241,8 +240,7 @@ RubDisplayScanner >> tab [
 RubDisplayScanner >> text: t textStyle: ts foreground: foreColor [
 	text := t.
 	textStyle := ts.
-	foregroundColor := foreColor.
-	backgroundColor := Color transparent
+	foregroundColor := foreColor
 ]
 
 { #category : #private }

--- a/src/Rubric/RubDisplayScanner.class.st
+++ b/src/Rubric/RubDisplayScanner.class.st
@@ -262,14 +262,12 @@ RubDisplayScanner >> tab [
 ]
 
 { #category : #private }
-RubDisplayScanner >> text: t textStyle: ts foreground: foreColor background: backColor fillBlt: blt ignoreColorChanges: shadowMode [
+RubDisplayScanner >> text: t textStyle: ts foreground: foreColor [
 	text := t.
 	textStyle := ts.
 	foregroundColor := foreColor.
-	(backgroundColor := backColor) isTransparent ifFalse:
-		[fillBlt := blt.
-		fillBlt fillColor: backgroundColor].
-	ignoreColorChanges := shadowMode
+	backgroundColor := Color transparent.
+	ignoreColorChanges := false
 ]
 
 { #category : #private }

--- a/src/Rubric/RubDisplayScanner.class.st
+++ b/src/Rubric/RubDisplayScanner.class.st
@@ -180,12 +180,6 @@ RubDisplayScanner >> placeEmbeddedObject: anchoredMorph [
 	^ true
 ]
 
-{ #category : #private }
-RubDisplayScanner >> presentationText: t [
-
-	text := t
-]
-
 { #category : #'stop conditions' }
 RubDisplayScanner >> setFont [
 	foregroundColor := self defaultTextColor.

--- a/src/Rubric/RubDisplayScanner.class.st
+++ b/src/Rubric/RubDisplayScanner.class.st
@@ -7,7 +7,6 @@ Class {
 		'runX',
 		'foregroundColor',
 		'backgroundColor',
-		'fillBlt',
 		'lineHeight',
 		'morphicOffset',
 		'defaultTextColor'
@@ -79,10 +78,6 @@ RubDisplayScanner >> displayLine: textLine offset: offset leftInRun: leftInRun [
 	leftInRun <= 0 ifTrue: [self setStopConditions].
 	leftMargin := (line leftMarginForAlignment: alignment) + offset x.
 	destX := runX := leftMargin.
-	fillBlt == nil ifFalse:
-		["Not right"
-		fillBlt destX: line left destY: lineY
-			width: line width height: lineHeight; copyBits].
 	lastIndex := line first.
 	leftInRun <= 0
 		ifTrue: [nowLeftInRun := text runLengthFor: lastIndex]
@@ -146,10 +141,7 @@ RubDisplayScanner >> endOfRun [
 
 { #category : #displaying }
 RubDisplayScanner >> fillTextBackground [
-	fillBlt == nil ifFalse:
-		["Not right"
-		fillBlt destX: line left destY: lineY
-			width: line width left height: line lineHeight; copyBits]
+
 ]
 
 { #category : #'multilingual scanning' }
@@ -197,15 +189,6 @@ RubDisplayScanner >> placeEmbeddedObject: anchoredMorph [
 			fillColor: Color white
 	].
 	^ true
-]
-
-{ #category : #'stop conditions' }
-RubDisplayScanner >> plainTab [
-	| nextDestX |
- 	nextDestX := super plainTab.
-	fillBlt == nil ifFalse:
-		[fillBlt destX: destX destY: destY width: nextDestX - destX height: font height; copyBits].
-	^nextDestX
 ]
 
 { #category : #private }

--- a/src/Rubric/RubDisplayScanner.class.st
+++ b/src/Rubric/RubDisplayScanner.class.st
@@ -19,11 +19,6 @@ RubDisplayScanner class >> defaultFont [
 	^ TextStyle defaultFont
 ]
 
-{ #category : #private }
-RubDisplayScanner >> backgroundColor: aColor [
-	backgroundColor := aColor
-]
-
 { #category : #'stop conditions' }
 RubDisplayScanner >> cr [
 	"When a carriage return is encountered, simply increment the pointer

--- a/src/Rubric/RubDisplayScanner.class.st
+++ b/src/Rubric/RubDisplayScanner.class.st
@@ -187,11 +187,6 @@ RubDisplayScanner >> presentationText: t [
 ]
 
 { #category : #'stop conditions' }
-RubDisplayScanner >> setDestForm: df [
-	bitBlt setDestForm: df
-]
-
-{ #category : #'stop conditions' }
 RubDisplayScanner >> setFont [
 	foregroundColor := self defaultTextColor.
 	super setFont.  "Sets font and emphasis bits, and maybe foregroundColor"

--- a/src/Rubric/RubDisplayScanner.class.st
+++ b/src/Rubric/RubDisplayScanner.class.st
@@ -10,7 +10,6 @@ Class {
 		'fillBlt',
 		'lineHeight',
 		'morphicOffset',
-		'ignoreColorChanges',
 		'defaultTextColor'
 	],
 	#category : #'Rubric-TextScanning'
@@ -23,7 +22,6 @@ RubDisplayScanner class >> defaultFont [
 
 { #category : #private }
 RubDisplayScanner >> backgroundColor: aColor [
-	ignoreColorChanges ifTrue: [^ self].
 	backgroundColor := aColor
 ]
 
@@ -266,12 +264,10 @@ RubDisplayScanner >> text: t textStyle: ts foreground: foreColor [
 	text := t.
 	textStyle := ts.
 	foregroundColor := foreColor.
-	backgroundColor := Color transparent.
-	ignoreColorChanges := false
+	backgroundColor := Color transparent
 ]
 
 { #category : #private }
 RubDisplayScanner >> textColor: textColor [
-	ignoreColorChanges ifTrue: [^ self].
 	foregroundColor := textColor
 ]

--- a/src/Rubric/RubEncryptedDisplayScanner.class.st
+++ b/src/Rubric/RubEncryptedDisplayScanner.class.st
@@ -17,10 +17,6 @@ RubEncryptedDisplayScanner >> displayLine: textLine offset: offset leftInRun: le
 	leftInRun <= 0 ifTrue: [self setStopConditions].
 	leftMargin := (line leftMarginForAlignment: alignment) + offset x.
 	destX := runX := leftMargin.
-	fillBlt == nil ifFalse:
-		["Not right"
-		fillBlt destX: line left destY: lineY
-			width: line width left height: lineHeight; copyBits].
 	lastIndex := line first.
 	leftInRun <= 0
 		ifTrue: [nowLeftInRun := text runLengthFor: lastIndex]

--- a/src/Text-Scanning/BitBltDisplayScanner.class.st
+++ b/src/Text-Scanning/BitBltDisplayScanner.class.st
@@ -49,11 +49,6 @@ BitBltDisplayScanner >> displayString: string from: startIndex to: stopIndex at:
 ]
 
 { #category : #private }
-BitBltDisplayScanner >> setDestForm: df [
-	bitBlt setDestForm: df
-]
-
-{ #category : #private }
 BitBltDisplayScanner >> setFont [
 	super setFont.  "Sets font and emphasis bits, and maybe foregroundColor"
 	font installOn: bitBlt foregroundColor: foregroundColor backgroundColor: Color transparent

--- a/src/Text-Scanning/BitBltDisplayScanner.class.st
+++ b/src/Text-Scanning/BitBltDisplayScanner.class.st
@@ -17,8 +17,7 @@ Class {
 	#name : #BitBltDisplayScanner,
 	#superclass : #DisplayScanner,
 	#instVars : [
-		'bitBlt',
-		'fillBlt'
+		'bitBlt'
 	],
 	#category : #'Text-Scanning-Base'
 }
@@ -51,19 +50,7 @@ BitBltDisplayScanner >> displayString: string from: startIndex to: stopIndex at:
 
 { #category : #displaying }
 BitBltDisplayScanner >> fillTextBackground [
-	fillBlt ifNotNil:
-		["Not right"
-		fillBlt destX: line left destY: lineY
-			width: line width left height: line lineHeight; copyBits]
-]
 
-{ #category : #'stop conditions' }
-BitBltDisplayScanner >> plainTab [
-	| nextDestX |
- 	nextDestX := super plainTab.
-	fillBlt ifNotNil:
-		[fillBlt destX: destX destY: destY width: nextDestX - destX height: font height; copyBits].
-	^nextDestX
 ]
 
 { #category : #private }

--- a/src/Text-Scanning/BitBltDisplayScanner.class.st
+++ b/src/Text-Scanning/BitBltDisplayScanner.class.st
@@ -84,14 +84,3 @@ BitBltDisplayScanner >> setPort: aBitBlt [
 	bitBlt sourceX: 0; width: 0.	"Init BitBlt so that the first call to a primitive will not fail"
 	bitBlt sourceForm: nil. "Make sure font installation won't be confused"
 ]
-
-{ #category : #private }
-BitBltDisplayScanner >> text: t textStyle: ts foreground: foreColor background: backColor fillBlt: blt ignoreColorChanges: shadowMode [
-	text := t.
-	textStyle := ts.
-	foregroundColor := defaultTextColor := foreColor.
-	(backgroundColor := backColor) isTransparent ifFalse:
-		[fillBlt := blt.
-		fillBlt fillColor: backgroundColor].
-	ignoreColorChanges := shadowMode
-]

--- a/src/Text-Scanning/BitBltDisplayScanner.class.st
+++ b/src/Text-Scanning/BitBltDisplayScanner.class.st
@@ -48,11 +48,6 @@ BitBltDisplayScanner >> displayString: string from: startIndex to: stopIndex at:
         ifTrue: [ font displayStrikeoutOn: bitBlt from: top to: endPoint ]
 ]
 
-{ #category : #displaying }
-BitBltDisplayScanner >> fillTextBackground [
-
-]
-
 { #category : #private }
 BitBltDisplayScanner >> setDestForm: df [
 	bitBlt setDestForm: df

--- a/src/Text-Scanning/CharacterScanner.class.st
+++ b/src/Text-Scanning/CharacterScanner.class.st
@@ -305,11 +305,6 @@ CharacterScanner >> scanCharactersFrom: startIndex to: stopIndex in: sourceStrin
 ]
 
 { #category : #scanning }
-CharacterScanner >> scanCharactersFrom: startIndex to: stopIndex in: sourceString rightX: rightX stopConditions: stops kern: kernDelta [
-	^sourceString scanCharactersFrom: startIndex to: stopIndex with: self rightX: rightX font: font
-]
-
-{ #category : #scanning }
 CharacterScanner >> scanKernableByteCharactersFrom: startIndex to: stopIndex in: sourceString rightX: rightX [
 "this is a scanning method for
 single byte characters in a ByteString

--- a/src/Text-Scanning/CharacterScanner.class.st
+++ b/src/Text-Scanning/CharacterScanner.class.st
@@ -270,20 +270,6 @@ CharacterScanner >> leadingTab [
 	^ true
 ]
 
-{ #category : #scanning }
-CharacterScanner >> measureString: aString inFont: aFont from: startIndex to: stopIndex [
-	"Measure aString width in given font aFont.
-	The string shall not include line breaking, tab or other control character."
-	destX := destY := lastIndex := 0.
-	pendingKernX := 0.
-	font := aFont.
-	kern := 0 - font baseKern.
-	spaceWidth := font widthOf: Space.
-	stopConditions := MeasuringStopConditions.
-	self scanCharactersFrom: startIndex to: stopIndex in: aString rightX: 999999.
-	^destX
-]
-
 { #category : #private }
 CharacterScanner >> placeEmbeddedObject: anchoredMorph [
 	"Place the anchoredMorph or return false if it cannot be placed"

--- a/src/Text-Scanning/CharacterScanner.class.st
+++ b/src/Text-Scanning/CharacterScanner.class.st
@@ -104,8 +104,6 @@ Class {
 	#instVars : [
 		'destX',
 		'lastIndex',
-		'xTable',
-		'map',
 		'destY',
 		'stopConditions',
 		'text',
@@ -449,8 +447,6 @@ a font that does not do character-pair kerning"
 CharacterScanner >> setActualFont: aFont [
 	"Set the basal font to an isolated font reference."
 
-	xTable := aFont xTable.
-	map := aFont characterToGlyphMap.
 	font := aFont
 ]
 

--- a/src/Text-Scanning/CompositionScanner.class.st
+++ b/src/Text-Scanning/CompositionScanner.class.st
@@ -63,11 +63,6 @@ Class {
 	#category : #'Text-Scanning'
 }
 
-{ #category : #testing }
-CompositionScanner >> canComputeDefaultLineHeight [
-	^ rightMargin notNil
-]
-
 { #category : #'stop conditions' }
 CompositionScanner >> columnBreak [
 
@@ -119,17 +114,6 @@ CompositionScanner >> composeFrom: startIndex inRectangle: lineRectangle
 		baseline: baseline + textStyle leading
 ]
 
-{ #category : #scanning }
-CompositionScanner >> computeDefaultLineHeight [
-	"Compute the default line height for a potentially empty text"
-
-	^ rightMargin notNil
-		ifTrue: [ lastIndex := 1.
-			self setFont.
-			lineHeight + textStyle leading ]
-		ifFalse: [ textStyle lineGrid ]
-]
-
 { #category : #'stop conditions' }
 CompositionScanner >> cr [
 	"Answer true. Set up values for the text line interval currently being
@@ -165,11 +149,6 @@ CompositionScanner >> crossedX [
 	"Neither internal nor trailing spaces -- almost never happens."
 	self advanceIfFirstCharOfLine.
 	^self wrapHere
-]
-
-{ #category : #accessing }
-CompositionScanner >> doesTheLineBreaksAfterLastChar [
-	^nextIndexAfterLineBreak > text size
 ]
 
 { #category : #'stop conditions' }

--- a/src/Text-Scanning/DisplayScanner.class.st
+++ b/src/Text-Scanning/DisplayScanner.class.st
@@ -130,7 +130,6 @@ DisplayScanner >> displayLine: textLine offset: offset leftInRun: leftInRun [
 	leftInRun <= 0 ifTrue: [ self setStopConditions ].
 	leftMargin := (line leftMarginForAlignment: alignment) + offset x.
 	destX := leftMargin.
-	self fillTextBackground.
 	lastDisplayableIndex := lastIndex := line first.
 	nowLeftInRun := leftInRun <= 0
 		ifTrue: [ text runLengthFor: lastIndex ]
@@ -186,11 +185,6 @@ DisplayScanner >> endOfRun [
 	"differ reset of stopConditions and font AFTER the dispaly of last scanned string"
 	stopConditionsMustBeReset := true.
 	^ false
-]
-
-{ #category : #displaying }
-DisplayScanner >> fillTextBackground [
-	self subclassResponsibility
 ]
 
 { #category : #'stop conditions' }

--- a/src/Text-Scanning/DisplayScanner.class.st
+++ b/src/Text-Scanning/DisplayScanner.class.st
@@ -53,7 +53,6 @@ Class {
 	#instVars : [
 		'lineY',
 		'foregroundColor',
-		'backgroundColor',
 		'defaultTextColor',
 		'morphicOffset',
 		'lastDisplayableIndex',
@@ -252,8 +251,7 @@ DisplayScanner >> tab [
 DisplayScanner >> text: t textStyle: ts foreground: foreColor [
 	text := t.
 	textStyle := ts.
-	foregroundColor := defaultTextColor := foreColor.
-	backgroundColor := Color transparent
+	foregroundColor := defaultTextColor := foreColor
 ]
 
 { #category : #'text attributes' }

--- a/src/Text-Scanning/DisplayScanner.class.st
+++ b/src/Text-Scanning/DisplayScanner.class.st
@@ -56,7 +56,6 @@ Class {
 		'backgroundColor',
 		'defaultTextColor',
 		'morphicOffset',
-		'ignoreColorChanges',
 		'lastDisplayableIndex',
 		'stopConditionsMustBeReset'
 	],
@@ -195,12 +194,6 @@ DisplayScanner >> fillTextBackground [
 	self subclassResponsibility
 ]
 
-{ #category : #initialization }
-DisplayScanner >> initialize [
-	super initialize.
-	ignoreColorChanges := false
-]
-
 { #category : #'stop conditions' }
 DisplayScanner >> paddedSpace [
 	"Each space is a stop condition when the alignment is right justified.
@@ -260,12 +253,10 @@ DisplayScanner >> text: t textStyle: ts foreground: foreColor [
 	text := t.
 	textStyle := ts.
 	foregroundColor := defaultTextColor := foreColor.
-	backgroundColor := Color transparent.
-	ignoreColorChanges := false
+	backgroundColor := Color transparent
 ]
 
 { #category : #'text attributes' }
 DisplayScanner >> textColor: textColor [
-	ignoreColorChanges ifTrue: [^ self].
 	foregroundColor := textColor
 ]

--- a/src/Text-Scanning/DisplayScanner.class.st
+++ b/src/Text-Scanning/DisplayScanner.class.st
@@ -256,12 +256,12 @@ DisplayScanner >> tab [
 ]
 
 { #category : #private }
-DisplayScanner >> text: t textStyle: ts foreground: foreColor background: backColor fillBlt: blt ignoreColorChanges: shadowMode [
+DisplayScanner >> text: t textStyle: ts foreground: foreColor [
 	text := t.
 	textStyle := ts.
 	foregroundColor := defaultTextColor := foreColor.
-	backgroundColor := backColor.
-	ignoreColorChanges := shadowMode
+	backgroundColor := Color transparent.
+	ignoreColorChanges := false
 ]
 
 { #category : #'text attributes' }


### PR DESCRIPTION
This pull request removes unused instance variables and methods from the CharacterScanner and RubCharacterScanner hierarchies.