### PR TITLE
Fix FormCanvas string drawing to use the strikethrough color for displaying the strikeout

### DIFF
--- a/src/FormCanvas-Core/FormCanvas.class.st
+++ b/src/FormCanvas-Core/FormCanvas.class.st
@@ -252,7 +252,7 @@ FormCanvas >> drawString: aString from: firstIndex to: lastIndex in: bounds font
 		].
 	strikethrough ifTrue: [
 		font installOn: port
-			foregroundColor: uc
+			foregroundColor: sc
 			backgroundColor: Color transparent;
 			displayStrikeoutOn: port from: (bounds topLeft + origin + (0@font ascent)) to: endPoint.
 	].


### PR DESCRIPTION
This pull request fixes a bug in FormCanvas: `#drawString:from:to:in:font:color:underline:underlineColor:strikethrough:strikethroughColor:` displays the strikeout using the underline color instead of the strikethrough color. Snippet that gives an example:

```smalltalk
(form := Form extent: 330@60 depth: Display depth)
	fillColor: Color white.
string := 'Lorem ipsum dolor'.
font := LogicalFont familyName: 'Source Sans Pro' pointSize: 30.
form getCanvas drawString: string from: 1 to: string size
	at: 5@5 font: font color: Color black
	underline: true underlineColor: Color blue
	strikethrough: true strikethroughColor: Color red.
form
```