### PR TITLE
Add ‘scale’ parameter for displaying strikeouts and underlines through fonts

### DIFF
--- a/src/Fonts-Infrastructure/LogicalFont.class.st
+++ b/src/Fonts-Infrastructure/LogicalFont.class.st
@@ -510,8 +510,10 @@ LogicalFont >> descentKern [
 ]
 
 { #category : #'forwarded to realFont' }
-LogicalFont >> displayStrikeoutOn: aGrafPort from: aPoint to: aPoint3 [
-	^self realFont displayStrikeoutOn: aGrafPort from: aPoint to: aPoint3
+LogicalFont >> displayStrikeoutOn: aDisplayContext from: baselineStartPoint to: baselineEndPoint scale: scale [
+
+	^ self realFont displayStrikeoutOn: aDisplayContext from: baselineStartPoint
+		to: baselineEndPoint scale: scale
 ]
 
 { #category : #'forwarded to realFont' }
@@ -522,8 +524,10 @@ LogicalFont >> displayString: aString on: aDisplayContext from: startIndex to: s
 ]
 
 { #category : #'forwarded to realFont' }
-LogicalFont >> displayUnderlineOn: aGrafPort from: aPoint to: aPoint3 [
-	^self realFont displayUnderlineOn: aGrafPort from: aPoint to: aPoint3
+LogicalFont >> displayUnderlineOn: aDisplayContext from: baselineStartPoint to: baselineEndPoint scale: scale [
+
+	^ self realFont displayUnderlineOn: aDisplayContext from: baselineStartPoint
+		to: baselineEndPoint scale: scale
 ]
 
 { #category : #emphasis }

--- a/src/FreeType/AbstractFont.extension.st
+++ b/src/FreeType/AbstractFont.extension.st
@@ -2,11 +2,23 @@ Extension { #name : #AbstractFont }
 
 { #category : #'*FreeType-addition' }
 AbstractFont >> displayStrikeoutOn: aDisplayContext from: baselineStartPoint to: baselineEndPoint [
+
+	^ self displayStrikeoutOn: aDisplayContext from: baselineStartPoint to: baselineEndPoint scale: 1
+]
+
+{ #category : #'*FreeType-addition' }
+AbstractFont >> displayStrikeoutOn: aDisplayContext from: baselineStartPoint to: baselineEndPoint scale: scale [
 	"display the strikeout if appropriate for the receiver"
 ]
 
 { #category : #'*FreeType-addition' }
 AbstractFont >> displayUnderlineOn: aDisplayContext from: baselineStartPoint to: baselineEndPoint [
+
+	^ self displayUnderlineOn: aDisplayContext from: baselineStartPoint to: baselineEndPoint scale: 1
+]
+
+{ #category : #'*FreeType-addition' }
+AbstractFont >> displayUnderlineOn: aDisplayContext from: baselineStartPoint to: baselineEndPoint scale: scale [
 	"display the underline if appropriate for the receiver"
 ]
 

--- a/src/FreeType/FreeTypeFont.class.st
+++ b/src/FreeType/FreeTypeFont.class.st
@@ -143,7 +143,7 @@ FreeTypeFont >> descentKern [
 ]
 
 { #category : #displaying }
-FreeTypeFont >> displayStrikeoutOn: aDisplayContext from: baselineStartPoint to: baselineEndPoint [
+FreeTypeFont >> displayStrikeoutOn: aDisplayContext from: baselineStartPoint to: baselineEndPoint scale: scale [
 	| top bottom strikeoutThickness s e |
 
 	"the strikeout size/position for TrueType fonts should really come from the TT_OS2 table.
@@ -153,8 +153,8 @@ FreeTypeFont >> displayStrikeoutOn: aDisplayContext from: baselineStartPoint to:
 	top := ((self face ascender / 4) * self pixelSize / self face unitsPerEm) negated - (strikeoutThickness/2).
 	top := top rounded.
 	bottom := top + strikeoutThickness ceiling.
-	s := baselineStartPoint + (0@top).
-	e := baselineEndPoint + (0@bottom).
+	s := baselineStartPoint + (0@(top * scale)).
+	e := baselineEndPoint + (0@(bottom * scale)).
 	self displayLineGlyphOn: aDisplayContext from: s to: e
 ]
 
@@ -226,15 +226,15 @@ FreeTypeFont >> displayString: aString on: aBitBlt from: startIndex to: stopInde
 ]
 
 { #category : #displaying }
-FreeTypeFont >> displayUnderlineOn: aDisplayContext from: baselineStartPoint to: baselineEndPoint [
+FreeTypeFont >> displayUnderlineOn: aDisplayContext from: baselineStartPoint to: baselineEndPoint scale: scale [
 	| underlineTop underlineBottom underlineThickness s e |
 
 	underlineThickness := (self face underlineThickness * self pixelSize / self face unitsPerEm).
 	underlineTop := (self face underlinePosition * self pixelSize / self face unitsPerEm) negated - (underlineThickness/2).
 	underlineTop := underlineTop rounded + 1.  "needs the +1 , possibly because glyph origins are moved down by 1 so that their baselines line up with strike fonts"
 	underlineBottom := underlineTop + underlineThickness ceiling.
-	s := baselineStartPoint + (0@underlineTop).
-	e := baselineEndPoint + (0@(underlineBottom)).
+	s := baselineStartPoint + (0@(underlineTop * scale)).
+	e := baselineEndPoint + (0@(underlineBottom * scale)).
 	self displayLineGlyphOn: aDisplayContext from: s to: e
 ]
 


### PR DESCRIPTION
Pull requests #14503 and #14563 added a ‘scale’ parameter for displaying strings through fonts, this pull request extends that to displaying strikeouts and underlines. An example is given by the following snippet.

```smalltalk
string := String loremIpsum copyFrom: 1 to: 40.
position := 5@5.
fillColor := Color white.
color := Color black.
underlineColor := Color blue alpha: 0.5.
strikethroughColor := Color red alpha: 0.5.
scale := 2.
font := LogicalFont familyName: 'Source Sans Pro' pointSize: 10.
extent := 230@25.

(baseForm := Form extent: extent depth: Display depth) fillColor: fillColor.
baseForm getCanvas drawString: string from: 1 to: string size at: position
	font: font color: color
	underline: true underlineColor: underlineColor
	strikethrough: true strikethroughColor: strikethroughColor.
form1 := baseForm scaledToSize: extent * scale.

(form2 := Form extent: extent * scale depth: Display depth) fillColor: fillColor.
(port := form2 getCanvas privatePort) colorMap: nil; combinationRule: Form paint.
font installOn: port foregroundColor: color 
	backgroundColor: Color transparent scale: scale.
endPoint := font displayString: string on: port from: 1 to: string size
	at: position * scale kern: 0 baselineY: (position y + font ascent) * scale scale: scale.
font installOn: port foregroundColor: underlineColor
	backgroundColor: Color transparent scale: scale.
font displayUnderlineOn: port from: (position + (0@font ascent)) * scale to: endPoint scale: scale.
font installOn: port foregroundColor: strikethroughColor
	backgroundColor: Color transparent scale: scale.
font displayStrikeoutOn: port from: (position + (0@font ascent)) * scale to: endPoint scale: scale.

{ form1. form2 }
```
