### PR TITLE
RPackage: simplify class removal

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -748,19 +748,14 @@ RPackage >> removeClass: aClass [
 	self removeAllMethodsFromClass: aClass.
 
 	"Then I unregister it from the tags"
-	(self classTags select: [ :eachTag | eachTag includesClass: aClass ]) do: [ :eachTag | self removeClassDefinition: aClass fromClassTag: eachTag name ].
+	self classTags
+		detect: [ :tag | tag includesClass: aClass ]
+		ifFound: [ :tag |
+			tag removeClass: aClass.
+			tag isEmpty ifTrue: [ self removeTag: tag ] ].
 
 	"Lastly I remove the class from the organizer. Maybe this should go in the PackageTag during the removal."
 	self unregisterClass: aClass
-]
-
-{ #category : #'class tags' }
-RPackage >> removeClassDefinition: aClass fromClassTag: aSymbol [
-
-	| tag |
-	tag := self classTagNamed: aSymbol ifAbsent: [ ^ self ].
-	tag removeClass: aClass.
-	tag isEmpty ifTrue: [ self removeTag: tag ]
 ]
 
 { #category : #'class tags' }

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -322,18 +322,13 @@ RPackageReadOnlyCompleteSetupTest >> testRemoveTaggedClasses [
 	self assert: (((p1 classesForClassTag: #zork) collect: [ :each | each name ]) includes: #B1DefinedInP1).
 
 	"now when we remove a class" "from an existing tags list"
-	p1 removeClassDefinition: a1 fromClassTag: #foo.
+	p1 removeClass: a1.
 	self deny: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
 	self deny: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
 	self assertEmpty: (p1 classesForClassTag: #foo).
 
-	"from a nonexisting tag list"
-	p1 removeClassDefinition: b1 fromClassTag: #taz.
-	self deny: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
-	self assert: (((p1 classesForClassTag: #zork) collect: [ :each | each name ]) includes: #B1DefinedInP1).
-
 	"with a class not registered to a tag list"
-	p1 removeClassDefinition: self class fromClassTag: #foo.
+	p1 removeClass: self class.
 	self deny: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
 	self deny: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
 	self assertEmpty: (p1 classesForClassTag: #foo)


### PR DESCRIPTION
This is a little change to simplify the class removal. 

Next step would be to automatically remove the empty tags when we remove a method in RPackageTag>>removeClass: but since this has more impact I'll do it in another PR later