### PR TITLE
RPackage: clean API of RPackage

### DIFF
--- a/src/Calypso-SystemQueries-Tests/ClyAllClassGroupsQueryTest.class.st
+++ b/src/Calypso-SystemQueries-Tests/ClyAllClassGroupsQueryTest.class.st
@@ -33,8 +33,13 @@ ClyAllClassGroupsQueryTest >> testFromSinglePackage [
 
 	self queryFromScope: ClyPackageScope of: ClyClass7WithTag1FromP5Mock package.
 
-	self assert: (resultItems collect: #class as: Set) equals: { ClyNoTagClassGroup. ClyTaggedClassGroup. ClyClassGroup} asSet.
+	self assertCollection: (resultItems collect: #class) hasSameElements: {
+			ClyNoTagClassGroup.
+			ClyTaggedClassGroup.
+			ClyClassGroup }.
 	self
-		assert: (resultItems select:[:each | each class = ClyTaggedClassGroup] thenCollect: [:group | group tag]) asSet
-		equals: ClyClass7WithTag1FromP5Mock package tagsForClasses asSet
+		assertCollection: (resultItems
+				 select: [ :each | each class = ClyTaggedClassGroup ]
+				 thenCollect: [ :group | group tag ])
+		hasSameElements: ClyClass7WithTag1FromP5Mock package tagsForClasses
 ]

--- a/src/Calypso-SystemQueries/RPackage.extension.st
+++ b/src/Calypso-SystemQueries/RPackage.extension.st
@@ -67,3 +67,11 @@ RPackage class >> prepareClassQueriesFrom: packages in: aNavigationEnvironment [
 		ClyAllClassesQuery from: ClyPackageExtensionScope ofAll: packages in: aNavigationEnvironment
 	}
 ]
+
+{ #category : #'*Calypso-SystemQueries' }
+RPackage >> tagsForClasses [
+	"Any class could be tagged for user purpose.
+	Now we implement it on top of RPackageTag"
+
+	^self classTags reject: [:each | each isRoot] thenCollect: [:each | each name]
+]

--- a/src/Deprecated12/RPackage.extension.st
+++ b/src/Deprecated12/RPackage.extension.st
@@ -65,6 +65,13 @@ RPackage >> classTagForClass: aClass [
 ]
 
 { #category : #'*Deprecated12' }
+RPackage >> classesForClassTag: aTagName [
+
+	self deprecated: 'Use #classesTaggedWith: instead.' transformWith: '`@rcv classesForClassTag: `@arg' -> '`@rcv classesTaggedWith: `@arg'.
+	^ self classesTaggedWith: aTagName
+]
+
+{ #category : #'*Deprecated12' }
 RPackage >> definedClassesDo: aBlock [
 
 	self deprecated:

--- a/src/Monticello-Tests/RPackageExtensionMethodsSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageExtensionMethodsSynchronisationTest.class.st
@@ -151,7 +151,7 @@ RPackageExtensionMethodsSynchronisationTest >> testMoveClassInPackageWithExtensi
 	self addXYCategory.
 	secondPackage := self organizer packageNamed: #YYYYY.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	self createMethodNamed: 'stubMethod' inClass: class inCategory: secondPackage methodCategoryPrefix.
+	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*' , secondPackage name.
 
 	secondPackage addClass: class.
 
@@ -171,7 +171,7 @@ RPackageExtensionMethodsSynchronisationTest >> testMoveClassInPackageWithExtensi
 	firstPackage := self organizer packageNamed: #XXXXX.
 	secondPackage := self organizer packageNamed: #YYYYY.
 	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	self createMethodNamed: 'stubMethod' inClass: class inCategory: secondPackage methodCategoryPrefix.
+	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*', secondPackage name.
 
 	secondPackage addClass: class.
 

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -217,18 +217,10 @@ RPackage >> classes [
 ]
 
 { #category : #'class tags' }
-RPackage >> classesForClassTag: aTagName [
+RPackage >> classesTaggedWith: aSymbol [
 	"Returns the classes tagged using aSymbol"
 
-	^ (self classTagNamed: aTagName ifAbsent: [ ^ #(  ) ]) classes
-]
-
-{ #category : #queries }
-RPackage >> classesTaggedWith: aSymbol [
-	"Any class could be tagged for user purpose.
-	This method select all classes which are tagged by given symbol"
-
-	^(self classTagNamed: aSymbol) classes
+	^ (self classTagNamed: aSymbol ifAbsent: [ ^ #(  ) ]) classes
 ]
 
 { #category : #accessing }
@@ -452,14 +444,6 @@ RPackage >> importClass: aClass inTag: aTag [
 ]
 
 { #category : #private }
-RPackage >> importDefinedMethodsOf: aClass [
-
-	aClass protocols
-		reject: [ :protocol | protocol isExtensionProtocol ]
-		thenDo: [ :protocol | self importProtocol: protocol forClass: aClass ]
-]
-
-{ #category : #private }
 RPackage >> importProtocol: aProtocol forClass: aClass [
 	"import all the local methods of a protocol as defined in the receiver."
 
@@ -517,7 +501,10 @@ RPackage >> includesMethodsAffectedBy: aSystemAnnouncement [
 { #category : #'system compatibility' }
 RPackage >> includesProtocol: protocol ofClass: aClass [
 
-	^ (protocol isExtensionProtocolMatching: self) or: [ (self includesClass: aClass) and: [ (self isForeignClassExtension: protocol) not ] ]
+	(protocol isExtensionProtocolMatching: self) ifTrue: [ ^ true ].
+
+
+	^ (self includesClass: aClass) and: [ protocol isExtensionProtocol not ]
 ]
 
 { #category : #testing }
@@ -556,14 +543,6 @@ RPackage >> isEmpty [
 	^ self classes isEmpty and: [ self extensionSelectors isEmpty ]
 ]
 
-{ #category : #'system compatibility' }
-RPackage >> isForeignClassExtension: protocol [
-
-	protocol ifNil: [ ^ false ].
-
-	^ protocol isExtensionProtocol and: [ (protocol isExtensionProtocolMatching: self) not ]
-]
-
 { #category : #testing }
 RPackage >> isTestPackage [
 	"1. Test package ends with suffix -Tests. Suffix is case sensitive.
@@ -577,16 +556,11 @@ RPackage >> isTestPackage [
 	^ (self name endsWith: '-Tests') or: [self name includesSubstring: '-Tests-']
 ]
 
-{ #category : #queries }
+{ #category : #accessing }
 RPackage >> linesOfCode [
 	"An approximate measure of lines of code.
 	Includes comments, but excludes blank lines."
 	^self methods inject: 0 into: [:sum :each | sum + each linesOfCode]
-]
-
-{ #category : #'system compatibility' }
-RPackage >> methodCategoryPrefix [
-	^ '*', self name asLowercase
 ]
 
 { #category : #accessing }
@@ -674,12 +648,6 @@ RPackage >> printOn: aStream [
 	aStream nextPut: $(.
 	aStream nextPutAll: self name.
 	aStream nextPut: $)
-]
-
-{ #category : #private }
-RPackage >> privateExtensionSelectors [
-
-	^ extensionSelectors
 ]
 
 { #category : #properties }
@@ -954,11 +922,6 @@ RPackage >> selectorsForClass: aClass [
 		ifTrue: [self definedSelectorsForClass: aClass]
 ]
 
-{ #category : #'system compatibility' }
-RPackage >> systemCategoryPrefix [
-	^ self name
-]
-
 { #category : #'class tags' }
 RPackage >> tagNames [
 	^ self classTags collect: [ :tag | tag name ]
@@ -970,14 +933,6 @@ RPackage >> tagOf: aClass [
 	^ self classTags
 		  detect: [ :tag | tag hasClass: aClass ]
 		  ifNone: [ nil ]
-]
-
-{ #category : #queries }
-RPackage >> tagsForClasses [
-	"Any class could be tagged for user purpose.
-	Now we implement it on top of RPackageTag"
-
-	^self classTags reject: [:each | each isRoot] thenCollect: [:each | each name]
 ]
 
 { #category : #private }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -223,9 +223,9 @@ RPackageOrganizer >> basicRegisterPackage: aPackage [
 
 { #category : #'private - registration' }
 RPackageOrganizer >> basicUnregisterPackageNamed: aPackageName [
-	"Unregister the specified package from the list of registered packages. Raise the RPackageUnregistered announcement. This is a low level action. It does not unregister the back pointer from classes to packages or any other information managed by the organizer"
+	"Unregister the specified package from the list of registered packages. Raise the PackageRemoved announcement. This is a low level action. It does not unregister the back pointer from classes to packages or any other information managed by the organizer"
 
-	^ packages removeKey: aPackageName ifAbsent: [ self reportExtraRemovalOf: aPackageName ]
+	^ packages removeKey: aPackageName ifAbsent: [  ]
 ]
 
 { #category : #'deprecated - SystemOrganizer leftovers' }
@@ -720,18 +720,6 @@ RPackageOrganizer >> renameTag: aTag to: newName inPackage: aPackage [
 	(self hasPackage: aPackage) ifFalse: [ ^ self ].
 
 	(self ensurePackage: aPackage) renameTag: aTag to: newName
-]
-
-{ #category : #private }
-RPackageOrganizer >> reportBogusBehaviorOf: aSelector [
-
-	self traceCr: 'RPackage log: Something wrong around ', aSelector asString , 'since the removeKey: is called on not present information.'
-]
-
-{ #category : #private }
-RPackageOrganizer >> reportExtraRemovalOf: aPackageOrClass [
-
-	self traceCr: 'The class ' , aPackageOrClass printString , ' is removed twice'
 ]
 
 { #category : #registration }

--- a/src/RPackage-Core/RPackageSet.class.st
+++ b/src/RPackage-Core/RPackageSet.class.st
@@ -136,11 +136,6 @@ RPackageSet >> initialize: aString [
 		            ifNil: [ {  } ]
 ]
 
-{ #category : #'system compatibility' }
-RPackageSet >> methodCategoryPrefix [
-	^ '*', self packageName asLowercase
-]
-
 { #category : #accessing }
 RPackageSet >> methods [
 	^ methods ifNil: [ methods := (self packages flatCollect: [ :p | p methods ]) ]

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -70,16 +70,16 @@ RPackageReadOnlyCompleteSetupTest >> testAddTag [
 	p1 importClass: b1 inTag: #foo.
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #foo ]).
 	self assert: p1 classTags size equals: 2. "foo and baz. The root tag got automatically removed since it was empty."
-	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
-	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
-	self assert: (p1 classesForClassTag: #foo) size equals: 2.
+	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
+	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+	self assert: (p1 classesTaggedWith: #foo) size equals: 2.
 
 	p1 ensureTag: #foo.
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #baz ]).
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #foo ]).
-	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
-	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
-	self assert: (p1 classesForClassTag: #foo) size equals: 2
+	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
+	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+	self assert: (p1 classesTaggedWith: #foo) size equals: 2
 ]
 
 { #category : #'tests - tag class' }
@@ -112,17 +112,17 @@ RPackageReadOnlyCompleteSetupTest >> testAddTagsToAClass [
 	self assert: p1 classTags size equals: 1. "We start with the root tag"
 
 	p1 importClass: a1 inTag: #foo.
-	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
-	self assert: (p1 classesForClassTag: #foo) size equals: 1.
+	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
+	self assert: (p1 classesTaggedWith: #foo) size equals: 1.
 
 	p1 importClass: b1 inTag: #foo.
-	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
-	self assert: (p1 classesForClassTag: #foo) size equals: 2.
+	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+	self assert: (p1 classesTaggedWith: #foo) size equals: 2.
 
 	p1 importClass: b1 inTag: #zork.
-	self assert: (((p1 classesForClassTag: #zork) collect: [ :each | each name ]) includes: #B1DefinedInP1).
-	self assert: (p1 classesForClassTag: #foo) size equals: 1.
-	self assert: (p1 classesForClassTag: #zork) size equals: 1
+	self assert: (((p1 classesTaggedWith: #zork) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+	self assert: (p1 classesTaggedWith: #foo) size equals: 1.
+	self assert: (p1 classesTaggedWith: #zork) size equals: 1
 ]
 
 { #category : #'tests - compiled method' }
@@ -293,20 +293,20 @@ RPackageReadOnlyCompleteSetupTest >> testRemoveTag [
 	self assert: p1 classTags size equals: 1. "We start with the root tag"
 
 	p1 importClass: a1 inTag: #foo.
-	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
-	self assert: (p1 classesForClassTag: #foo) size equals: 1.
+	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
+	self assert: (p1 classesTaggedWith: #foo) size equals: 1.
 
 	p1 importClass: b1 inTag: #foo.
-	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
-	self assert: (p1 classesForClassTag: #foo) size equals: 2.
+	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+	self assert: (p1 classesTaggedWith: #foo) size equals: 2.
 
 	p1 removeTag: #bar.
-	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
-	self assert: (p1 classesForClassTag: #foo) size equals: 2.
+	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+	self assert: (p1 classesTaggedWith: #foo) size equals: 2.
 
 	p1 removeTag: #foo.
-	self deny: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
-	self assert: (p1 classesForClassTag: #foo) size equals: 0
+	self deny: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+	self assert: (p1 classesTaggedWith: #foo) size equals: 0
 ]
 
 { #category : #'tests - tag class' }
@@ -315,28 +315,28 @@ RPackageReadOnlyCompleteSetupTest >> testRemoveTaggedClasses [
 	p1 importClass: a1 inTag: #foo.
 	p1 importClass: b1 inTag: #foo.
 	p1 importClass: b1 inTag: #zork.
-	self assert: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
-	self deny: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
-	self assert: (p1 classesForClassTag: #foo) size equals: 1.
-	self deny: (((p1 classesForClassTag: #zork) collect: [ :each | each name ]) includes: #A1DefinedInP1).
-	self assert: (((p1 classesForClassTag: #zork) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
+	self deny: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+	self assert: (p1 classesTaggedWith: #foo) size equals: 1.
+	self deny: (((p1 classesTaggedWith: #zork) collect: [ :each | each name ]) includes: #A1DefinedInP1).
+	self assert: (((p1 classesTaggedWith: #zork) collect: [ :each | each name ]) includes: #B1DefinedInP1).
 
 	"now when we remove a class" "from an existing tags list"
 	p1 removeClassDefinition: a1 fromClassTag: #foo.
-	self deny: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
-	self deny: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
-	self assertEmpty: (p1 classesForClassTag: #foo).
+	self deny: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
+	self deny: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+	self assertEmpty: (p1 classesTaggedWith: #foo).
 
 	"from a nonexisting tag list"
 	p1 removeClassDefinition: b1 fromClassTag: #taz.
-	self deny: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
-	self assert: (((p1 classesForClassTag: #zork) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+	self deny: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+	self assert: (((p1 classesTaggedWith: #zork) collect: [ :each | each name ]) includes: #B1DefinedInP1).
 
 	"with a class not registered to a tag list"
 	p1 removeClassDefinition: self class fromClassTag: #foo.
-	self deny: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
-	self deny: (((p1 classesForClassTag: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
-	self assertEmpty: (p1 classesForClassTag: #foo)
+	self deny: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
+	self deny: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+	self assertEmpty: (p1 classesTaggedWith: #foo)
 ]
 
 { #category : #'tests - situation' }

--- a/src/ReleaseTests/ProperPackagesTest.class.st
+++ b/src/ReleaseTests/ProperPackagesTest.class.st
@@ -39,7 +39,7 @@ ProperPackagesTest >> testProperManifestCategorization [
 	|violations|
 	violations := OrderedCollection new.
 	PackageManifest allSubclassesDo: [:each |
- 	   ((each package classesForClassTag: 'Manifest') includes: each)
+ 	   ((each package classesTaggedWith: 'Manifest') includes: each)
   	      ifFalse: [ violations add: each ]
 	].
 

--- a/src/Renraku/RePackageManifestShouldBePackagedInManifestTagRule.class.st
+++ b/src/Renraku/RePackageManifestShouldBePackagedInManifestTagRule.class.st
@@ -13,8 +13,7 @@ RePackageManifestShouldBePackagedInManifestTagRule class >> checksClass [
 { #category : #running }
 RePackageManifestShouldBePackagedInManifestTagRule >> basicCheck: aClass [
 
-	^ (aClass inheritsFrom: PackageManifest) and: [
-		((aClass package classesForClassTag: 'Manifest') includes: aClass) not ]
+	^ (aClass inheritsFrom: PackageManifest) and: [ ((aClass package classesTaggedWith: 'Manifest') includes: aClass) not ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
The goal of this change is to clean the API of RPackage

- Deprecate classesForClassTag: in favor of classesTaggedWith: that does the same already
- Remove dead #importDefinedMethodsOf: that was previously used by one of the way to import classes that got removed
- Simplify #includesProtocol:ofClass: 
- Remove the dead #isForeignClassExtension: that was previously used by #includesProtocol:ofClass: 
- Remove #methodCategoryPrefix and #systemCategoryPrefix that now have no users \0/
- Remove privateExtensionSelectors that was used by the class import in the past but now the code was simplified
- Move #tagsForClasses to Calypso since it is only used by it and it not a really nice method (it manipulates strings and reject the root tag)
- Remove dead #reportBogusBehaviorOf: and #reportExtraRemovalOf: