### PR TITLE
RPackage: Reduce logic in Class>>category

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -257,7 +257,7 @@ Class >> category [
 	(latter is much more expensive)"
 
 	| result |
-	self basicCategory ifNotNil: [ :symbol | ((self packageOrganizer listAtCategoryNamed: symbol) includes: self name) ifTrue: [ ^ symbol ] ].
+	self basicCategory ifNotNil: [ :symbol | ^ symbol ].
 	result := (self environment organization categoryOfBehavior: self)
 		          ifNil: [ #Unclassified ]
 		          ifNotNil: [ :value | value ].


### PR DESCRIPTION
Class>>#category should be removed in the future but it will not be an easy change. This change aim to simplify it and see if it is possible to remove the part checking the system organizer classes