### PR TITLE
Gofer: Remove update of categories

### DIFF
--- a/src/Gofer-Core/GoferLoad.class.st
+++ b/src/Gofer-Core/GoferLoad.class.st
@@ -26,10 +26,9 @@ GoferLoad >> defaultModel [
 
 { #category : #running }
 GoferLoad >> execute [
-	self model hasVersions
-		ifTrue: [ self model load ].
-	self updateRepositories.
-	self updateCategories
+
+	self model hasVersions ifTrue: [ self model load ].
+	self updateRepositories
 ]
 
 { #category : #initialization }
@@ -38,22 +37,6 @@ GoferLoad >> initializeOn: aGofer [
 	aGofer resolved
 		do: [ :each | self addResolved: each ]
 		displayingProgress: 'Loading Versions'
-]
-
-{ #category : #private }
-GoferLoad >> updateCategories [
-	"This method makes sure that the categories are ordered in load-order and as specified in the packages."
-
-	| categories |
-	categories := OrderedCollection new.
-	self versions do: [ :version |
-		version snapshot definitions do: [ :definition |
-			definition isOrganizationDefinition ifTrue: [
-				definition categories do: [ :category |
-					(categories includes: category)
-						ifFalse: [ categories addLast: category ] ] ] ] ].
-	(MCOrganizationDefinition categories: categories)
-		postloadOver: nil
 ]
 
 { #category : #private }

--- a/src/Metacello-Core/MetacelloPlatform.class.st
+++ b/src/Metacello-Core/MetacelloPlatform.class.st
@@ -2,8 +2,7 @@ Class {
 	#name : #MetacelloPlatform,
 	#superclass : #Object,
 	#instVars : [
-		'bypassProgressBars',
-		'bypassGoferLoadUpdateCategories'
+		'bypassProgressBars'
 	],
 	#classVars : [
 		'Current'
@@ -46,18 +45,6 @@ MetacelloPlatform >> authorName: aString [
 	"Used by SmalltalkCI"
 
 	self subclassResponsibility
-]
-
-{ #category : #accessing }
-MetacelloPlatform >> bypassGoferLoadUpdateCategories [
-
-	bypassGoferLoadUpdateCategories == nil ifTrue: [ bypassGoferLoadUpdateCategories := false ].
-	^ bypassGoferLoadUpdateCategories
-]
-
-{ #category : #accessing }
-MetacelloPlatform >> bypassGoferLoadUpdateCategories: anObject [
-	bypassGoferLoadUpdateCategories := anObject
 ]
 
 { #category : #accessing }

--- a/src/Metacello-MC/MetacelloGoferLoad.class.st
+++ b/src/Metacello-MC/MetacelloGoferLoad.class.st
@@ -5,12 +5,6 @@ Class {
 }
 
 { #category : #private }
-MetacelloGoferLoad >> updateCategories [
-	MetacelloPlatform current bypassGoferLoadUpdateCategories
-		ifFalse: [ super updateCategories ]
-]
-
-{ #category : #private }
 MetacelloGoferLoad >> updateRepositories [
 	"Noop for Metacello...done by loader itself"
 ]

--- a/src/Metacello-TestsMC/MetacelloDictionaryRepositoryTest.class.st
+++ b/src/Metacello-TestsMC/MetacelloDictionaryRepositoryTest.class.st
@@ -80,13 +80,10 @@ MetacelloDictionaryRepositoryTest >> projectWith: projectAttributes [
 
 { #category : #running }
 MetacelloDictionaryRepositoryTest >> runCase [
-	| original |
-	(self doSilently) ifFalse: [ ^super runCase ].
-	original := MetacelloPlatform current bypassGoferLoadUpdateCategories.
-	[ 
-	MetacelloPlatform current bypassGoferLoadUpdateCategories: true.
-	^ MetacelloPlatform current suspendSystemUpdateEventsDuring: [ super runCase ] ]
-		ensure: [ MetacelloPlatform current bypassGoferLoadUpdateCategories: original ]
+
+	self doSilently ifFalse: [ ^ super runCase ].
+
+	^ MetacelloPlatform current suspendSystemUpdateEventsDuring: [ super runCase ]
 ]
 
 { #category : #running }

--- a/src/Metacello-TestsMC/MetacelloIssueTestCase.class.st
+++ b/src/Metacello-TestsMC/MetacelloIssueTestCase.class.st
@@ -61,12 +61,8 @@ MetacelloIssueTestCase >> projectWith: projectAttributes [
 
 { #category : #running }
 MetacelloIssueTestCase >> runCase [
-	| original |
-	original := MetacelloPlatform current bypassGoferLoadUpdateCategories.
-	[ 
-	MetacelloPlatform current bypassGoferLoadUpdateCategories: true.
-	^ MetacelloPlatform current suspendSystemUpdateEventsDuring: [ super runCase ] ]
-		ensure: [ MetacelloPlatform current bypassGoferLoadUpdateCategories: original ]
+
+	^ MetacelloPlatform current suspendSystemUpdateEventsDuring: [ super runCase ]
 ]
 
 { #category : #running }

--- a/src/Metacello-TestsMC/MetacelloScriptingStdTstHarnessTestCase.class.st
+++ b/src/Metacello-TestsMC/MetacelloScriptingStdTstHarnessTestCase.class.st
@@ -29,14 +29,10 @@ MetacelloScriptingStdTstHarnessTestCase >> hasPackage: aString [
 
 { #category : #running }
 MetacelloScriptingStdTstHarnessTestCase >> runCase [
-    | original |
-    self doSilently
-        ifFalse: [ ^ super runCase ].
-    original := MetacelloPlatform current bypassGoferLoadUpdateCategories.
-    [ 
-    MetacelloPlatform current bypassGoferLoadUpdateCategories: true.
-    ^ MetacelloPlatform current suspendSystemUpdateEventsDuring: [ super runCase ] ]
-        ensure: [ MetacelloPlatform current bypassGoferLoadUpdateCategories: original ]
+
+	self doSilently ifFalse: [ ^ super runCase ].
+
+	^ MetacelloPlatform current suspendSystemUpdateEventsDuring: [ super runCase ]
 ]
 
 { #category : #running }


### PR DESCRIPTION
Gofer>>updateCategories seems to do nothing in the end.  It create a new organization definition but does not use it. It just call the post load on it with a nil parameter but the post load does nothing of this class. 

So let's see if we can remove it and have one less place dealing with categories.

I also removed some related Metacello code dealing with this method