### PR TITLE
RPackage: Remove empty tag while removing its last class

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -718,9 +718,7 @@ RPackage >> removeClass: aClass [
 	"Then I unregister it from the tags"
 	self classTags
 		detect: [ :tag | tag includesClass: aClass ]
-		ifFound: [ :tag |
-			tag removeClass: aClass.
-			tag isEmpty ifTrue: [ self removeTag: tag ] ].
+		ifFound: [ :tag | tag removeClass: aClass ].
 
 	"Lastly I remove the class from the organizer. Maybe this should go in the PackageTag during the removal."
 	self unregisterClass: aClass

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -148,7 +148,10 @@ RPackageTag >> promoteAsPackage [
 { #category : #accessing }
 RPackageTag >> removeClass: aClass [
 
-	^ classes remove: aClass ifAbsent: [  ]
+	| oldObject |
+	oldObject := classes remove: aClass ifAbsent: [  ].
+	self isEmpty ifTrue: [ self removeFromPackage ].
+	^ oldObject
 ]
 
 { #category : #accessing }

--- a/src/RPackage-Tests/RPackageTagTest.class.st
+++ b/src/RPackage-Tests/RPackageTagTest.class.st
@@ -88,3 +88,20 @@ RPackageTagTest >> testPromoteAsPackage [
 	self assert: (package2 classes includes: class).
 	self deny: (package1 classes includes: class)
 ]
+
+{ #category : #tests }
+RPackageTagTest >> testRemoveClassRemoveTagIfEmpty [
+
+	| package tag class |
+	package := self createNewPackageNamed: #Test1.
+	tag := package ensureTag: #TAG.
+	class := self createNewClassNamed: 'TestClass' inCategory: package name , '-TAG'.
+
+	self assert: (tag includesClass: class).
+	self assert: (package hasTag: tag).
+
+	tag removeClass: class.
+
+	self deny: (tag includesClass: class).
+	self deny: (package hasTag: tag)
+]


### PR DESCRIPTION
This change move the removal of empty tags on class remove from RPackage to RPackageTag to avoid having another part of the system using RPackageTag>>#removeClass: instead of RPackage>>#removeClass: