### PR TITLE
RPackage: Remove in image users of MCOrganizationDefinition categories

### DIFF
--- a/src/Gofer-Tests/GoferResource.class.st
+++ b/src/Gofer-Tests/GoferResource.class.st
@@ -47,7 +47,7 @@ GoferResource >> setUpMonticelloRepository [
 				author: reference author
 				ancestors: #())
 			snapshot: (MCSnapshot fromDefinitions: (Array
-				with: (MCOrganizationDefinition categories: (Array with: reference packageName asSymbol))
+				with: (MCOrganizationDefinition packageName: reference packageName)
 				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol instVarNames: #() comment: '')))
 			dependencies: #()) ]
 ]

--- a/src/Monticello-Tests/MCOrganizationTest.class.st
+++ b/src/Monticello-Tests/MCOrganizationTest.class.st
@@ -9,34 +9,7 @@ MCOrganizationTest >> testLoadAndUnload [
 
 	| packageName |
 	packageName := 'TestPackageToUnload'.
-	self packageOrganizer addCategory: packageName.
+	self packageOrganizer ensurePackage: packageName.
 	(MCOrganizationDefinition packageName: packageName) unload.
 	self deny: (self packageOrganizer includesCategory: packageName)
-]
-
-{ #category : #tests }
-MCOrganizationTest >> testReordering [
-	| dec cats newCats |
-	dec := MCOrganizationDefinition categories: #(A B C) copy.
-	cats := #(X Y B Z C A Q).
-	newCats := dec reorderCategories: cats original: #(B C A).
-	self assert: newCats asArray equals: #(X Y A B C Z Q)
-]
-
-{ #category : #tests }
-MCOrganizationTest >> testReorderingWithNoCategoriesInVersion [
-	| dec cats newCats |
-	dec := MCOrganizationDefinition categories: #().
-	cats := #(X Y B Z C A Q).
-	newCats := dec reorderCategories: cats original: #().
-	self assert: newCats asArray equals: cats
-]
-
-{ #category : #tests }
-MCOrganizationTest >> testReorderingWithRemovals [
-	| dec cats newCats |
-	dec := MCOrganizationDefinition categories: #(A B C) copy.
-	cats := #(X Y B Z C A Q).
-	newCats := dec reorderCategories: cats original: #(Y B C A Q).
-	self assert: newCats asArray equals: #(X A B C Z)
 ]

--- a/src/Monticello-Tests/MCRepositoryTest.class.st
+++ b/src/Monticello-Tests/MCRepositoryTest.class.st
@@ -64,12 +64,14 @@ MCRepositoryTest >> saveSnapshot: aSnapshot named: aString [
 
 { #category : #building }
 MCRepositoryTest >> snapshot1 [
-	^ (MCSnapshot fromDefinitions: (Array with: (MCOrganizationDefinition categories: #('y'))))
+
+	^ MCSnapshot fromDefinitions: (Array with: (MCOrganizationDefinition packageName: 'y'))
 ]
 
 { #category : #building }
 MCRepositoryTest >> snapshot2 [
-	^ (MCSnapshot fromDefinitions: (Array with: (MCOrganizationDefinition categories: #('x'))))
+
+	^ MCSnapshot fromDefinitions: (Array with: (MCOrganizationDefinition packageName: 'x'))
 ]
 
 { #category : #accessing }

--- a/src/Monticello-Tests/RPackageMonticelloSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMonticelloSynchronisationTest.class.st
@@ -20,7 +20,7 @@ RPackageMonticelloSynchronisationTest >> testAddMCPackageForCategoryAlreadyExist
 	"test that when we create a MCPackage and that a category of this name already exists, no package is created"
 
 	| tmpPackage |
-	testingEnvironment organization addCategory: 'Zork'.
+	self organizer ensurePackage: 'Zork'.
 	tmpPackage := self organizer packageNamed: #Zork.
 	MCWorkingCopy ensureForPackageNamed: #Zork packageOrganizer: self organizer.
 	self assert: tmpPackage identicalTo: (self organizer packageNamed: #Zork)

--- a/src/Monticello/MCOrganizationDefinition.class.st
+++ b/src/Monticello/MCOrganizationDefinition.class.st
@@ -66,9 +66,12 @@ MCOrganizationDefinition >> basicCommonPrefix [
 MCOrganizationDefinition >> categories [
 
 	^ categories ifNil: [
-		  { self packageName } , (self tagNames
-			   reject: [ :tagName | tagName = self packageName ]
-			   thenCollect: [ :tagName | self packageName , '-' , tagName ]) ]
+		  self packageName
+			  ifNil: [ {  } ]
+			  ifNotNil: [ :package |
+				  { package } , (self tagNames
+					   reject: [ :tagName | tagName = package ]
+					   thenCollect: [ :tagName | package , '-' , tagName ]) ] ]
 ]
 
 { #category : #deprecated }
@@ -146,17 +149,6 @@ MCOrganizationDefinition >> packageName: anObject [
 { #category : #installing }
 MCOrganizationDefinition >> postloadOver: oldDefinition [
 	"Nothing to do"
-]
-
-{ #category : #private }
-MCOrganizationDefinition >> reorderCategories: allCategories original: oldCategories [
-
-	^ allCategories
-		  detect: [ :ea | self categories includes: ea ]
-		  ifFound: [ :first |
-			  ((allCategories copyUpTo: first) copyWithoutAll: oldCategories , self categories) , self categories
-			  , ((allCategories copyAfter: first) copyWithoutAll: oldCategories , self categories) ]
-		  ifNone: [ allCategories ]
 ]
 
 { #category : #accessing }

--- a/src/Monticello/MCStReader.class.st
+++ b/src/Monticello/MCStReader.class.st
@@ -125,16 +125,6 @@ MCStReader >> readStream [
 ]
 
 { #category : #reading }
-MCStReader >> systemOrganizationFromRecords: changeRecords [
-
-	| categories |
-	categories := changeRecords
-		              select: [ :ea | 'SystemOrganization*' match: ea string ]
-		              thenCollect: [ :ea | self categoryFromDoIt: ea string ].
-	^ categories ifNotEmpty: [ MCOrganizationDefinition categories: categories asArray ]
-]
-
-{ #category : #reading }
 MCStReader >> typeOfSubclass: aSymbol [
 	| layoutClass |
 	layoutClass := ObjectLayout layoutForSubclassDefiningSymbol: aSymbol.

--- a/src/Monticello/MCSystemCategoryParser.class.st
+++ b/src/Monticello/MCSystemCategoryParser.class.st
@@ -25,7 +25,7 @@ MCSystemCategoryParser >> addDefinitionsTo: aCollection [
 		ifNotNil: [
 			| category |
 			category := self category.
-			definition tagNames: (definition tagName copyWith: ((category beginsWith: definition packageName , '-')
+			definition tagNames: (definition tagNames copyWith: ((category beginsWith: definition packageName , '-')
 						  ifTrue: [ category withoutPrefix: definition packageName , '-' ]
 						  ifFalse: [ category ])) ]
 ]

--- a/src/Monticello/MCSystemCategoryParser.class.st
+++ b/src/Monticello/MCSystemCategoryParser.class.st
@@ -14,17 +14,27 @@ MCSystemCategoryParser class >> pattern [
 
 { #category : #actions }
 MCSystemCategoryParser >> addDefinitionsTo: aCollection [
+
 	| definition |
-	definition := aCollection 
-					detect: [:ea | ea isOrganizationDefinition ] 
-					ifNone: [aCollection add: (MCOrganizationDefinition categories: #())].
-	definition categories: (definition categories copyWith: self category).
+	definition := aCollection
+		              detect: [ :ea | ea isOrganizationDefinition ]
+		              ifNone: [ aCollection add: MCOrganizationDefinition new ].
+	"The next part is a hack because the backup monticello format is using a mix of packages and tags as one string for the organization. We are trying to guess what is the package and what is the tag even if the way to do so is not nice and is brittle. But we should not end up here anyway."
+	definition packageName
+		ifNil: [ definition packageName: self category ]
+		ifNotNil: [
+			| category |
+			category := self category.
+			definition tagNames: (definition tagName copyWith: ((category beginsWith: definition packageName , '-')
+						  ifTrue: [ category withoutPrefix: definition packageName , '-' ]
+						  ifFalse: [ category ])) ]
 ]
 
 { #category : #accessing }
 MCSystemCategoryParser >> category [
-	| tokens  |
+
+	| tokens |
 	tokens := source parseLiterals.
-	tokens size = 3 ifFalse: [self error: 'Unrecognized category definition'].
+	tokens size = 3 ifFalse: [ self error: 'Unrecognized category definition' ].
 	^ tokens at: 3
 ]

--- a/src/Ring-Definitions-Tests-Monticello/RGMonticelloTest.class.st
+++ b/src/Ring-Definitions-Tests-Monticello/RGMonticelloTest.class.st
@@ -47,13 +47,13 @@ RGMonticelloTest >> testConvertingMCMethodDefinition [
 
 { #category : #testing }
 RGMonticelloTest >> testConvertingMCOrganizationDefinition [
-	| mcOrganization ringOrganization mcOrganization2 |
 
-	mcOrganization := MCOrganizationDefinition categories: {#'Ring-Definitions-Core' . #'Ring-Definitions-Core-Definitions'}.
-	mcOrganization2 := MCOrganizationDefinition categories: {#'Ring-Definitions-Core' . #'Ring-Definitions-Core-Definitions' . #'Ring-Definitions-Core-Variables'}.
+	| mcOrganization ringOrganization mcOrganization2 |
+	mcOrganization := MCOrganizationDefinition packageName: #'Ring-Definitions-Core' tagNames: { #Definitions }.
+	mcOrganization2 := MCOrganizationDefinition packageName: #'Ring-Definitions-Core' tagNames: { #Definitions. #Variables }.
 	ringOrganization := mcOrganization asRingDefinition.
 
-	self assert: (ringOrganization isOrganization).
+	self assert: ringOrganization isOrganization.
 	self deny: (ringOrganization isSameRevisionAs: mcOrganization2 asRingDefinition)
 ]
 


### PR DESCRIPTION
I am updating MCOrganizationDefinition to not use categories but packages and tag names instead. This change finish to update the users in the image. There are still users in Iceberg and Tonel but this will have to be done there.

-reorderCategories:original: was removed because dead code
- systemOrganizationFromRecords: is dead code
- MCSystemCategoryParser has been updated to use an ugly hack but this is a backup for monticello and we should not get there often. And if we do, our goal is to load borken code, not to have everything perfect