### PR TITLE
Fix check already-existing extension in Path>>withExtension: (fixes #14594)

### DIFF
--- a/src/FileSystem-Path/Path.class.st
+++ b/src/FileSystem-Path/Path.class.st
@@ -585,13 +585,12 @@ Path >> segments [
 
 { #category : #navigating }
 Path >> withExtension: extension [
-	| basename name |
-	basename := self basename.
-	^ (basename endsWith: extension)
-		ifTrue: [ self ]
-		ifFalse:
-			[name := basename copyUpToLast: self extensionDelimiter.
-			self withName: name extension: extension]
+
+	^ (self basename endsWith:
+		   (extension copyWithFirst: self extensionDelimiter))
+		  ifTrue: [ self ]
+		  ifFalse: [
+		  self withName: self basenameWithoutExtension extension: extension ]
 ]
 
 { #category : #private }

--- a/src/FileSystem-Tests-Core/FileReferenceTest.class.st
+++ b/src/FileSystem-Tests-Core/FileReferenceTest.class.st
@@ -1196,7 +1196,7 @@ FileReferenceTest >> testVersionNumberForExtension [
 ]
 
 { #category : #tests }
-FileReferenceTest >> testWithExtentionAddsExtension [
+FileReferenceTest >> testWithExtensionAddsExtension [
 	| ref result |
 	ref := filesystem * 'plonk'.
 	result := ref withExtension: 'griffle'.
@@ -1205,7 +1205,7 @@ FileReferenceTest >> testWithExtentionAddsExtension [
 ]
 
 { #category : #tests }
-FileReferenceTest >> testWithExtentionReplacesExtension [
+FileReferenceTest >> testWithExtensionReplacesExtension [
 	| ref result |
 	ref := filesystem * 'plonk.griffle'.
 	result := ref withExtension: 'nurp'.

--- a/src/FileSystem-Tests-Core/PathTest.class.st
+++ b/src/FileSystem-Tests-Core/PathTest.class.st
@@ -796,7 +796,7 @@ PathTest >> testWindowsAbsolutePathName [
 ]
 
 { #category : #tests }
-PathTest >> testWithExtentionAddsExtension [
+PathTest >> testWithExtensionAddsExtension [
 	| path result |
 	path := Path * 'plonk'.
 	result := path withExtension: 'griffle'.
@@ -804,7 +804,15 @@ PathTest >> testWithExtentionAddsExtension [
 ]
 
 { #category : #tests }
-PathTest >> testWithExtentionReplacesExtension [
+PathTest >> testWithExtensionAddsExtensionNameContainsExtension [
+	| path result |
+	path := Path * 'footxt'.
+	result := path withExtension: 'txt'.
+	self assert: result basename equals: 'footxt.txt'
+]
+
+{ #category : #tests }
+PathTest >> testWithExtensionReplacesExtension [
 	| path result |
 	path := Path * 'plonk.griffle'.
 	result := path withExtension: 'griffle'.


### PR DESCRIPTION
Check for delimiter followed by the requested extension to distinguish 'footxt' from 'foo.txt'--the former does not have an extension and so `(Path * 'footxt') withExtension: 'txt'` should become `'footxt.txt'` rather than being left with no extension at all.

Also rename some tests to correct "exten*t*ion" typo.