### PR TITLE
Allow formatting the contents of a Playground

### DIFF
--- a/src/AST-Core/ClassDescription.extension.st
+++ b/src/AST-Core/ClassDescription.extension.st
@@ -3,7 +3,5 @@ Extension { #name : #ClassDescription }
 { #category : #'*AST-Core' }
 ClassDescription >> formatter [
 
-	^ self package packageManifestOrNil
-		ifNotNil: [ :manifest | manifest formatter ]
-		ifNil: [ RBProgramNode formatterClass new ]
+	^ self package packageManifestOrNil formatter
 ]

--- a/src/AST-Core/UndefinedObject.extension.st
+++ b/src/AST-Core/UndefinedObject.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #UndefinedObject }
+
+{ #category : #'*AST-Core' }
+UndefinedObject >> formatter [
+
+	^ RBProgramNode formatterClass new
+]

--- a/src/Rubric/RubSmalltalkCodeMode.class.st
+++ b/src/Rubric/RubSmalltalkCodeMode.class.st
@@ -165,7 +165,8 @@ RubSmalltalkCodeMode >> classOrMetaClass: aBehavior [
 RubSmalltalkCodeMode >> formatMethodCode [
 	| source tree formatted |
 	source := self textArea text asString.
-	tree := RBParser parseMethod: source onError: [ :msg :pos | ^ self ].
+	tree := self parseSource: source.
+	tree checkFaulty: [ :msg :pos | ^self ].
 	formatted := tree formattedCodeIn: classOrMetaclass.
 	formatted = source
 		ifTrue: [ ^ self ].


### PR DESCRIPTION
Move the fallback formatter for packages without a manifest to exist on UndefinedObject so it is available when even the class is unknown. Delegate parsing for the purpose of formatting to existing RubEditingMode>>parseSource:.