### PR TITLE
Search strings without symbols using RB pattern matcher

### DIFF
--- a/src/AST-Core-Tests/RBPatternParserTest.class.st
+++ b/src/AST-Core-Tests/RBPatternParserTest.class.st
@@ -49,6 +49,28 @@ RBPatternParserTest >> testParseFaultyPatternBlock [
 ]
 
 { #category : #'tests - parsing' }
+RBPatternParserTest >> testPatternNotStringExpression [
+	| searchPattern tree |
+	searchPattern := RBPatternParser parseExpression: '`{ :node | node isString }'.
+
+	tree := self parseExpression: 'a = a1'.
+
+	self deny: (searchPattern match: tree inContext: Dictionary new).
+
+]
+
+{ #category : #'tests - parsing' }
+RBPatternParserTest >> testPatternStringExpression [
+	| searchPattern tree |
+	searchPattern := RBPatternParser parseExpression: '`{ :node | node isString }'.
+
+	tree := self parseExpression: '''justAString'''.
+
+	self assert: (searchPattern match: tree inContext: Dictionary new).
+
+]
+
+{ #category : #'tests - parsing' }
 RBPatternParserTest >> testPatternVariable [
 	| searchPattern |
 	searchPattern := RBPatternParser parseExpression: '`a'.

--- a/src/AST-Core/RBLiteralValueNode.class.st
+++ b/src/AST-Core/RBLiteralValueNode.class.st
@@ -67,6 +67,12 @@ RBLiteralValueNode >> evaluateForReceiver: aReceicer [
 	^ value
 ]
 
+{ #category : #testing }
+RBLiteralValueNode >> isString [
+
+	^ value isString and: [ value isSymbol not ]
+]
+
 { #category : #accessing }
 RBLiteralValueNode >> sourceText [
 


### PR DESCRIPTION
Add #isString method to RBLiteralValueNode, to enable matching method with strings** but not symbols.
Add tests.

One use of this feature is for instance to browse all the strings in a class which are not symbols.
