### PR TITLE
Kernel: Speedup #isObsolete

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -7,7 +7,11 @@ I add a number of facilities to those in ClassDescription:
 
 My instances describe the representation and behavior of objects. I add more comprehensive programming support facilities to the basic attributes of Behavior and the descriptive facilities of ClassDescription.
 
-The slot 'subclasses' is a redundant structure.  It is never used during execution, but is used by the development system to simplify or speed certain operations.  
+The slot 'subclasses' is a redundant structure.  It is never used during execution, but is used by the development system to simplify or speed certain operations.
+
+When a class is removed from the system, we keep the instance in case it is still referenced. In that case, we declare the class as Obsolete.
+In order to know if a class is obsolete or not, we save the instances in a weak identity set called ObsoleteClasses. When the class is not referenced anymore, the GC will collect the class and remove it totally from the system.
+Note: In the past we saved this information in the properties of the class but this is slower than the current solution. Maybe we could speed up the properties management.
 "
 Class {
 	#name : #Class,
@@ -20,6 +24,9 @@ Class {
 		'environment',
 		'category',
 		'commentSourcePointer'
+	],
+	#classVars : [
+		'ObsoleteClasses'
 	],
 	#category : #'Kernel-Classes'
 }
@@ -55,6 +62,12 @@ Class class >> hasNoDependenciesForMetaclass: aClass in: unprocessedClasses cach
 { #category : #'file in/out' }
 Class class >> hasNoSuperclassesOf: aClass in: unprocessedClasses cache: cache [
 	^ (unprocessedClasses includesAnyOf: (self allSuperclassesFor: aClass cache: cache)) not
+]
+
+{ #category : #'identifying obsoletes' }
+Class class >> initialize [
+
+	ObsoleteClasses := WeakIdentitySet new
 ]
 
 { #category : #'file in/out' }
@@ -828,7 +841,7 @@ Class >> isClassOrTrait [
 Class >> isObsolete [
 	"Return true if the receiver is obsolete."
 
-	^ self propertyAt: #obsolete ifAbsent: false
+	^ ObsoleteClasses includes: self
 ]
 
 { #category : #'self evaluating' }
@@ -892,7 +905,7 @@ Class >> obsolete [
 	self classPool: nil.
 	self sharedPools: nil.
 	self hasClassSide ifTrue: [ self classSide obsolete].
-	self propertyAt: #obsolete put: true.
+	ObsoleteClasses add: self.
 	super obsolete
 ]
 

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -64,7 +64,7 @@ Class class >> hasNoSuperclassesOf: aClass in: unprocessedClasses cache: cache [
 	^ (unprocessedClasses includesAnyOf: (self allSuperclassesFor: aClass cache: cache)) not
 ]
 
-{ #category : #'identifying obsoletes' }
+{ #category : #'class initialization' }
 Class class >> initialize [
 
 	ObsoleteClasses := WeakIdentitySet new

--- a/src/PharoBootstrap-Initialization/PharoBootstrapInitialization.class.st
+++ b/src/PharoBootstrap-Initialization/PharoBootstrapInitialization.class.st
@@ -60,6 +60,7 @@ PharoBootstrapInitialization class >> initializeCommandLineHandlerAndErrorHandli
 	Slot initialize.
 	RPackage initialize.
 	Behavior initialize.
+	Class initialize.
 
 	UIManager default: NonInteractiveUIManager new.
 

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -456,7 +456,7 @@ RPackage >> importProtocol: aProtocol forClass: aClass [
 RPackage >> includesClass: aClass [
 	"Returns true if the receiver includes aClass in the classes that are defined within it: only class definition are considered - not class extensions"
 
-	^ self definedClasses includes: aClass instanceSide
+	^ self classTags anySatisfy: [ :tag | tag includesClass: aClass ]
 ]
 
 { #category : #testing }

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -72,7 +72,9 @@ RPackageTag >> hasClassNamed: aSymbol [
 
 { #category : #testing }
 RPackageTag >> includesClass: aClass [
-	^ self hasClassNamed: aClass name
+	"To deprecate in favor of #hasClass:"
+
+	^ self hasClass: aClass
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
To know if a class is obsolete we are currently saving the info in class properties. But this is slow when we ask the information a lot, which happens in RPackage.

Here is an alternative where I store the obsolete classes in a weak identity set which is much faster. 

I also shipped a speed up of RPackage>>#includesClass: that should make class compilation faster.