### PR TITLE
Monticello: avoid double loading of class definition

### DIFF
--- a/src/Monticello/MCPackageLoader.class.st
+++ b/src/Monticello/MCPackageLoader.class.st
@@ -217,7 +217,13 @@ MCPackageLoader >> sorterForItems: aCollection [
 
 { #category : #private }
 MCPackageLoader >> tryToLoad: aDefinition [
-	[aDefinition addMethodAdditionTo: methodAdditions] on: Error do: [errorDefinitions add: aDefinition].
+	"Here we are only interested by method definition. We want to avoid recompilating classes or traits for example."
+
+	aDefinition isMethodDefinition ifFalse: [ ^ self ].
+
+	[ aDefinition addMethodAdditionTo: methodAdditions ]
+		on: Error
+		do: [ errorDefinitions add: aDefinition ]
 ]
 
 { #category : #public }


### PR DESCRIPTION
This is a redo of https://github.com/pharo-project/pharo/pull/8282

I tried a more agressive approach to see if this work. If it does not work, I'll try a less agressive one.