### PR TITLE
Make unwind more flexible

### DIFF
--- a/src/Instrumentation/BlockClosure.extension.st
+++ b/src/Instrumentation/BlockClosure.extension.st
@@ -7,9 +7,11 @@ BlockClosure >> insEnsure: aBlock [
 	instrumenting I need to use the BlockClosure>>#ensure: method but if one instruments the
 	method BlockClosure>>#ensure: I will enter to an endless loop."
 
+	| handler complete returnValue |
 	<noInstrumentation>
 	<primitive: 198>
-	| complete returnValue |
+	"The handler should be in the first temporary to find it easily and support more complex unwind methods"
+	handler := aBlock.
 	returnValue := self valueNoContextSwitch.
 	complete ifNil: [
 		complete := true.

--- a/src/Kernel/BlockClosure.class.st
+++ b/src/Kernel/BlockClosure.class.st
@@ -227,8 +227,10 @@ BlockClosure >> ensure: aBlock [
 	 implemented as a primitive.  Primitive 198 always fails.  The VM uses prim
 	 198 in a context's method as the mark for an ensure:/ifCurtailed: activation."
 
-	| complete returnValue |
+	| handler complete returnValue |
 	<primitive: 198>
+	"The handler should be in the first temporary to find it easily and support more complex unwind methods"
+	handler := aBlock.
 	returnValue := self valueNoContextSwitch.
 	complete ifNil:[
 		complete := true.
@@ -321,8 +323,10 @@ BlockClosure >> ifCurtailed: aBlock [
 	 not evaluate aBlock.  N.B.  This method is *not* implemented as a
 	 primitive.  Primitive 198 always fails.  The VM uses prim 198 in a
 	 context's method as the mark for an ensure:/ifCurtailed: activation."
-	| complete result |
+	| handler complete result |
 	<primitive: 198>
+	"The handler should be in the first temporary to find it easily and support more complex unwind methods"
+	handler := aBlock.
 	result := self valueNoContextSwitch.
 	complete := true.
 	^result

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -2257,19 +2257,25 @@ Context >> tryPrimitiveFor: aMethod receiver: aReceiver args: arguments [
 { #category : #'special context access' }
 Context >> unwindBlock [
 	"unwindContext only. access temporaries from BlockClosure>>#ensure: and BlockClosure>>#ifCurtailed:"
-	^self tempAt: 1
+
+	"The handler is in the first temporary"
+	^ self tempAt: self numArgs + 1
 ]
 
 { #category : #'special context access' }
 Context >> unwindComplete [
 	"unwindContext only. access temporaries from BlockClosure>>#ensure: and BlockClosure>>#ifCurtailed:"
-	^self tempAt: 2
+
+	"The complete flag is in the antepenultimate temporary"
+	^ self tempAt: self numTemps - 1
 ]
 
 { #category : #'special context access' }
 Context >> unwindComplete: aBoolean [
 	"unwindContext only. access temporaries from BlockClosure>>#ensure: and BlockClosure>>#ifCurtailed:"
-	self tempAt: 2 put: aBoolean
+
+	"The complete flag is in the antepenultimate temporary"
+	self tempAt: self numTemps - 1 put: aBoolean
 ]
 
 { #category : #'private - exceptions' }

--- a/src/Reflectivity/BlockClosure.extension.st
+++ b/src/Reflectivity/BlockClosure.extension.st
@@ -6,7 +6,9 @@ BlockClosure >> rfEnsure: aBlock [
 
 	<primitive: 198>
 	<metaLinkOptions: #( + optionDisabledLink)>
-	| returnValue complete |
+	| handler complete returnValue |
+	"The handler should be in the first temporary to find it easily and support more complex unwind methods"
+	handler := aBlock.
 	returnValue := self rfvalueNoContextSwitch.
 	complete ifNil:[
 		complete := true.


### PR DESCRIPTION
Stack unwind (correct management of exceptions and non-local returns) management requires the creation of many blocks, which makes it very slow.
This PR introduces a slight change in how unwind is managed that is backwards compatible and allows for custom unwind methods. See for example the code of ensure:

```smalltalk
BlockClosure >> ensure: aBlock
	| complete returnValue |
	<primitive: 198>
	returnValue := self valueNoContextSwitch.
	complete ifNil:[
		complete := true.
		aBlock value.
	].
	^ returnValue
```

The key of the previous method is that when unwind is done, the methods with the marker 198 are found in the stack and then:

-    if the antepenultimate temp (complete) is not nil
       - the first argument is taken (the handler block) and executed via the value message
       - and the antepenultimate temp (complete) is set to true

This PR makes that the handler block is instead put in the first temp, allowing the method to have as many parameters as possible. This simplifies proxy implementations among others. The only impact in the existing code base is as follows:

```smalltalk
ensure: aBlock
	| handler complete returnValue |
	<primitive: 198>
        >> handler := aBlock. <<
	returnValue := self valueNoContextSwitch.
	complete ifNil:[
		complete := true.
		aBlock value.
	].
	^ returnValue
```

This way, trap methods can be written as:

```smalltalk
Proxy >> trapWith: arg1 with: arg2
  | handler |
  handler := "some object that understands value".
  ...
```

This allows

- unwind without extra blocks and fewer contexts
- having a very fast execution path without unwinding in the middle