### PR TITLE
Make unwind complete the second temporary

### DIFF
--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -2266,16 +2266,16 @@ Context >> unwindBlock [
 Context >> unwindComplete [
 	"unwindContext only. access temporaries from BlockClosure>>#ensure: and BlockClosure>>#ifCurtailed:"
 
-	"The complete flag is in the antepenultimate temporary"
-	^ self tempAt: self numTemps - 1
+	"The complete flag is in the second temporary"
+	^ self tempAt: self numArgs + 2
 ]
 
 { #category : #'special context access' }
 Context >> unwindComplete: aBoolean [
 	"unwindContext only. access temporaries from BlockClosure>>#ensure: and BlockClosure>>#ifCurtailed:"
 
-	"The complete flag is in the antepenultimate temporary"
-	self tempAt: self numTemps - 1 put: aBoolean
+	"The complete flag is in the second temporary"
+	self tempAt: self numArgs + 2 put: aBoolean
 ]
 
 { #category : #'private - exceptions' }


### PR DESCRIPTION
As proposed by @dionisiydk in https://github.com/pharo-project/pharo/pull/14610

This makes it simpler to read and understand.
Nothing really changes behind the scenes, this change is backwards compatible.
All unwind methods in the system have 3 temps, and the second one is the unwind flag.
Being the second of three, it was also the antepenultimate.