### PR TITLE
Monticello: Do not use constructors with dizaines of paramaters in MCClassDescription

### DIFF
--- a/src/Gofer-Tests/GoferResource.class.st
+++ b/src/Gofer-Tests/GoferResource.class.st
@@ -48,7 +48,7 @@ GoferResource >> setUpMonticelloRepository [
 				ancestors: #())
 			snapshot: (MCSnapshot fromDefinitions: (Array
 				with: (MCOrganizationDefinition packageName: reference packageName)
-				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol instVarNames: #())))
+				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol)))
 			dependencies: #()) ]
 ]
 

--- a/src/Gofer-Tests/GoferResource.class.st
+++ b/src/Gofer-Tests/GoferResource.class.st
@@ -48,7 +48,7 @@ GoferResource >> setUpMonticelloRepository [
 				ancestors: #())
 			snapshot: (MCSnapshot fromDefinitions: (Array
 				with: (MCOrganizationDefinition packageName: reference packageName)
-				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol instVarNames: #() comment: '')))
+				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol instVarNames: #())))
 			dependencies: #()) ]
 ]
 

--- a/src/Gofer-Tests/GoferResource.class.st
+++ b/src/Gofer-Tests/GoferResource.class.st
@@ -48,7 +48,7 @@ GoferResource >> setUpMonticelloRepository [
 				ancestors: #())
 			snapshot: (MCSnapshot fromDefinitions: (Array
 				with: (MCOrganizationDefinition packageName: reference packageName)
-				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol)))
+				with: (MCClassDefinition named: (reference packageName copyWithout: $-) asSymbol category: reference packageName asSymbol)))
 			dependencies: #()) ]
 ]
 

--- a/src/Metacello-TestsMCResources/MetacelloAlternateResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloAlternateResource.class.st
@@ -39,7 +39,7 @@ MetacelloAlternateResource >> setUpMonticelloRepository [
 				ancestors: #())
 			snapshot: (MCSnapshot fromDefinitions: (Array
 				with: (MCOrganizationDefinition packageName: reference packageName)
-				with: (MCClassDefinition name: reference packageName asSymbol superclassName: #Object category: reference packageName asSymbol)))
+				with: (MCClassDefinition named: reference packageName asSymbol category: reference packageName asSymbol)))
 			dependencies: #()) ]
 ]
 

--- a/src/Metacello-TestsMCResources/MetacelloAlternateResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloAlternateResource.class.st
@@ -39,7 +39,7 @@ MetacelloAlternateResource >> setUpMonticelloRepository [
 				ancestors: #())
 			snapshot: (MCSnapshot fromDefinitions: (Array
 				with: (MCOrganizationDefinition packageName: reference packageName)
-				with: (MCClassDefinition name: reference packageName asSymbol superclassName: #Object category: reference packageName asSymbol instVarNames: #() comment: '')))
+				with: (MCClassDefinition name: reference packageName asSymbol superclassName: #Object category: reference packageName asSymbol instVarNames: #())))
 			dependencies: #()) ]
 ]
 

--- a/src/Metacello-TestsMCResources/MetacelloAlternateResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloAlternateResource.class.st
@@ -39,7 +39,7 @@ MetacelloAlternateResource >> setUpMonticelloRepository [
 				ancestors: #())
 			snapshot: (MCSnapshot fromDefinitions: (Array
 				with: (MCOrganizationDefinition packageName: reference packageName)
-				with: (MCClassDefinition name: reference packageName asSymbol superclassName: #Object category: reference packageName asSymbol instVarNames: #())))
+				with: (MCClassDefinition name: reference packageName asSymbol superclassName: #Object category: reference packageName asSymbol)))
 			dependencies: #()) ]
 ]
 

--- a/src/Metacello-TestsMCResources/MetacelloAtomicConfigurationResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloAtomicConfigurationResource.class.st
@@ -352,10 +352,7 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfAtomicFan [
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfAtomicFan-dkh.1'.
     packageName := reference packageName asSymbol.
     definitionArray := {(MCOrganizationDefinition packageName: packageName).
-    (MCClassDefinition
-        name: packageName
-        superclassName: #'Object'
-        category: packageName).
+    (MCClassDefinition named: packageName category: packageName).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true
@@ -412,10 +409,7 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfAtomicFoo [
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfAtomicFoo-dkh.1'.
     packageName := reference packageName asSymbol.
     definitionArray := {(MCOrganizationDefinition packageName: packageName).
-    (MCClassDefinition
-        name: packageName
-        superclassName: #'Object'
-        category: packageName).
+    (MCClassDefinition named: packageName category: packageName).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true
@@ -472,10 +466,7 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfLinearFoo [
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfLinearFoo-dkh.1'.
     packageName := reference packageName asSymbol.
     definitionArray := {(MCOrganizationDefinition packageName: packageName).
-    (MCClassDefinition
-        name: packageName
-        superclassName: #'Object'
-        category: packageName).
+    (MCClassDefinition named: packageName category: packageName).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true
@@ -556,10 +547,7 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfProjectIssue86 [
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue86-dkh.1'.
     packageName := reference packageName asSymbol.
     definitionArray := {(MCOrganizationDefinition packageName: packageName).
-    (MCClassDefinition
-        name: packageName
-        superclassName: #'Object'
-        category: packageName).
+    (MCClassDefinition named: packageName category: packageName).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true
@@ -616,10 +604,7 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfUmbrellaA [
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfUmbrellaA-dkh.1'.
     packageName := reference packageName asSymbol.
     definitionArray := {(MCOrganizationDefinition packageName: packageName).
-    (MCClassDefinition
-        name: packageName
-        superclassName: #'Object'
-        category: packageName).
+    (MCClassDefinition named: packageName category: packageName).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true
@@ -664,10 +649,7 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfUmbrellaB [
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfUmbrellaB-dkh.1'.
     packageName := reference packageName asSymbol.
     definitionArray := {(MCOrganizationDefinition packageName: packageName).
-    (MCClassDefinition
-        name: packageName
-        superclassName: #'Object'
-        category: packageName).
+    (MCClassDefinition named: packageName category: packageName).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true

--- a/src/Metacello-TestsMCResources/MetacelloAtomicConfigurationResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloAtomicConfigurationResource.class.st
@@ -356,8 +356,7 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfAtomicFan [
         name: packageName
         superclassName: #'Object'
         category: packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true
@@ -418,8 +417,7 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfAtomicFoo [
         name: packageName
         superclassName: #'Object'
         category: packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true
@@ -480,8 +478,7 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfLinearFoo [
         name: packageName
         superclassName: #'Object'
         category: packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true
@@ -566,8 +563,7 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfProjectIssue86 [
         name: packageName
         superclassName: #'Object'
         category: packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true
@@ -628,8 +624,7 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfUmbrellaA [
         name: packageName
         superclassName: #'Object'
         category: packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true
@@ -678,8 +673,7 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfUmbrellaB [
         name: packageName
         superclassName: #'Object'
         category: packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true

--- a/src/Metacello-TestsMCResources/MetacelloAtomicConfigurationResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloAtomicConfigurationResource.class.st
@@ -355,8 +355,7 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfAtomicFan [
     (MCClassDefinition
         name: packageName
         superclassName: #'Object'
-        category: packageName
-        instVarNames: #()).
+        category: packageName).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true
@@ -416,8 +415,7 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfAtomicFoo [
     (MCClassDefinition
         name: packageName
         superclassName: #'Object'
-        category: packageName
-        instVarNames: #()).
+        category: packageName).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true
@@ -477,8 +475,7 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfLinearFoo [
     (MCClassDefinition
         name: packageName
         superclassName: #'Object'
-        category: packageName
-        instVarNames: #()).
+        category: packageName).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true
@@ -562,8 +559,7 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfProjectIssue86 [
     (MCClassDefinition
         name: packageName
         superclassName: #'Object'
-        category: packageName
-        instVarNames: #()).
+        category: packageName).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true
@@ -623,8 +619,7 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfUmbrellaA [
     (MCClassDefinition
         name: packageName
         superclassName: #'Object'
-        category: packageName
-        instVarNames: #()).
+        category: packageName).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true
@@ -672,8 +667,7 @@ MetacelloAtomicConfigurationResource >> setUpConfigurationOfUmbrellaB [
     (MCClassDefinition
         name: packageName
         superclassName: #'Object'
-        category: packageName
-        instVarNames: #()).
+        category: packageName).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true

--- a/src/Metacello-TestsMCResources/MetacelloAtomicMonticelloResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloAtomicMonticelloResource.class.st
@@ -41,7 +41,7 @@ MetacelloAtomicMonticelloResource >> setUpDependency [
 				ancestors: #())
 		snapshot: (MCSnapshot fromDefinitions: (Array
 				with: (MCOrganizationDefinition packageName: reference packageName)
-				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol instVarNames: #() comment: '')))
+				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol instVarNames: #())))
 		dependencies: (Array 
 				with: (MCVersionDependency 
 						package: (MCPackage new name: 'GoferBarDependency') 
@@ -71,7 +71,7 @@ MetacelloAtomicMonticelloResource >> setUpMonticelloRepository [
 				ancestors: #())
 			snapshot: (MCSnapshot fromDefinitions: (Array
 				with: (MCOrganizationDefinition packageName: reference packageName)
-				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: superclassName category: reference packageName asSymbol instVarNames: #() comment: '')))
+				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: superclassName category: reference packageName asSymbol instVarNames: #())))
 			dependencies: #()) ]
 ]
 
@@ -93,7 +93,7 @@ MetacelloAtomicMonticelloResource >> setUpNewerDependency [
 				ancestors: #())
 		snapshot: (MCSnapshot fromDefinitions: (Array
 				with: (MCOrganizationDefinition packageName: reference packageName)
-				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol instVarNames: #() comment: '')))
+				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol instVarNames: #())))
 		dependencies: (Array 
 				with: (MCVersionDependency 
 						package: (MCPackage new name: 'GoferBarDependency') 

--- a/src/Metacello-TestsMCResources/MetacelloAtomicMonticelloResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloAtomicMonticelloResource.class.st
@@ -41,7 +41,7 @@ MetacelloAtomicMonticelloResource >> setUpDependency [
 				ancestors: #())
 		snapshot: (MCSnapshot fromDefinitions: (Array
 				with: (MCOrganizationDefinition packageName: reference packageName)
-				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol instVarNames: #())))
+				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol)))
 		dependencies: (Array 
 				with: (MCVersionDependency 
 						package: (MCPackage new name: 'GoferBarDependency') 
@@ -71,7 +71,7 @@ MetacelloAtomicMonticelloResource >> setUpMonticelloRepository [
 				ancestors: #())
 			snapshot: (MCSnapshot fromDefinitions: (Array
 				with: (MCOrganizationDefinition packageName: reference packageName)
-				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: superclassName category: reference packageName asSymbol instVarNames: #())))
+				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: superclassName category: reference packageName asSymbol)))
 			dependencies: #()) ]
 ]
 
@@ -93,7 +93,7 @@ MetacelloAtomicMonticelloResource >> setUpNewerDependency [
 				ancestors: #())
 		snapshot: (MCSnapshot fromDefinitions: (Array
 				with: (MCOrganizationDefinition packageName: reference packageName)
-				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol instVarNames: #())))
+				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol)))
 		dependencies: (Array 
 				with: (MCVersionDependency 
 						package: (MCPackage new name: 'GoferBarDependency') 

--- a/src/Metacello-TestsMCResources/MetacelloAtomicMonticelloResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloAtomicMonticelloResource.class.st
@@ -41,7 +41,7 @@ MetacelloAtomicMonticelloResource >> setUpDependency [
 				ancestors: #())
 		snapshot: (MCSnapshot fromDefinitions: (Array
 				with: (MCOrganizationDefinition packageName: reference packageName)
-				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol)))
+				with: (MCClassDefinition named: (reference packageName copyWithout: $-) category: reference packageName asSymbol)))
 		dependencies: (Array 
 				with: (MCVersionDependency 
 						package: (MCPackage new name: 'GoferBarDependency') 
@@ -56,23 +56,26 @@ MetacelloAtomicMonticelloResource >> setUpMonticelloRepository [
 	"This method builds a fake repository with the version references from #buildReferences."
 
 	monticelloRepository := MCDictionaryRepository new.
-	versionReferences do: [ :assoc | | reference superclassName |
+	versionReferences do: [ :assoc |
+		| reference superclassName |
 		reference := assoc key.
 		superclassName := assoc value.
 		monticelloRepository basicStoreVersion: (MCVersion new
-			setPackage:  (MCPackage new name: reference packageName)
-			info: (MCVersionInfo
-				name: reference name
-				id: UUID new
-				message: 'This is a mock version'
-				date: Date today
-				time: Time now
-				author: reference author
-				ancestors: #())
-			snapshot: (MCSnapshot fromDefinitions: (Array
-				with: (MCOrganizationDefinition packageName: reference packageName)
-				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: superclassName category: reference packageName asSymbol)))
-			dependencies: #()) ]
+				 setPackage: (MCPackage new name: reference packageName)
+				 info: (MCVersionInfo
+						  name: reference name
+						  id: UUID new
+						  message: 'This is a mock version'
+						  date: Date today
+						  time: Time now
+						  author: reference author
+						  ancestors: #(  ))
+				 snapshot: (MCSnapshot fromDefinitions: {
+							  (MCOrganizationDefinition packageName: reference packageName).
+							  ((MCClassDefinition named: (reference packageName copyWithout: $-) asSymbol category: reference packageName asSymbol)
+								   superclassName: superclassName;
+								   yourself) })
+				 dependencies: #(  )) ]
 ]
 
 { #category : #running }
@@ -93,7 +96,7 @@ MetacelloAtomicMonticelloResource >> setUpNewerDependency [
 				ancestors: #())
 		snapshot: (MCSnapshot fromDefinitions: (Array
 				with: (MCOrganizationDefinition packageName: reference packageName)
-				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol)))
+				with: (MCClassDefinition named: (reference packageName copyWithout: $-) asSymbol category: reference packageName asSymbol)))
 		dependencies: (Array 
 				with: (MCVersionDependency 
 						package: (MCPackage new name: 'GoferBarDependency') 

--- a/src/Metacello-TestsMCResources/MetacelloConfigurationResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloConfigurationResource.class.st
@@ -1245,7 +1245,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfFan [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -1313,7 +1313,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfFeaux [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -1357,7 +1357,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfFix [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -1410,8 +1410,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfFoo [
         name: packageName
         superclassName: #'Object'
         category: packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: false
@@ -1494,7 +1493,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfFum [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -1540,8 +1539,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfMetacelloExampledkh1 [
         name: className
         superclassName: #'Object'
         category: className
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -1597,8 +1595,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectConfigIssue283dkh1 
     name: className
     superclassName: #'Object'
     category: className
-    instVarNames: #()
-    comment: '').
+    instVarNames: #()).
   (MCMethodDefinition
     className: className asString
     classIsMeta: true
@@ -1651,7 +1648,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectFee [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -1698,8 +1695,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectFie [
         name: packageName
         superclassName: #'Object'
         category: packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true
@@ -1763,7 +1759,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectFoe [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -1810,8 +1806,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectFum [
         name: packageName
         superclassName: #'Object'
         category: packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true
@@ -1857,7 +1852,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectInfinite [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -1910,7 +1905,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue115dkh1 [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -1961,7 +1956,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue115dkh2: ances
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -2036,8 +2031,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue119dkh1 [
         name: className
         superclassName: #'Object'
         category: className
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2094,8 +2088,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue119dkh2: ances
         name: className
         superclassName: #'Object'
         category: className
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2152,8 +2145,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue119dkh3: ances
         name: className
         superclassName: #'Object'
         category: className
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2210,8 +2202,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue119dkh4: ances
         name: className
         superclassName: #'Object'
         category: className
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2268,8 +2259,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue119dkh5: ances
         name: className
         superclassName: #'Object'
         category: className
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2350,8 +2340,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue119dkh6: ances
         name: className
         superclassName: #'Object'
         category: className
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2468,8 +2457,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue119dkh7: ances
         name: className
         superclassName: #'Object'
         category: className
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2525,8 +2513,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue125 [
         name: packageName
         superclassName: #'Object'
         category: packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true
@@ -2594,7 +2581,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue136dkh1 [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -2645,7 +2632,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue136dkh2: ances
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -2713,8 +2700,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue154dkh1 [
         name: className
         superclassName: #'Object'
         category: className
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2813,8 +2799,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue171dkh1 [
         name: className
         superclassName: #'Object'
         category: className
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2869,8 +2854,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue171dkh2: ances
         name: className
         superclassName: #'Object'
         category: className
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2936,8 +2920,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue283dkh1 [
     name: className
     superclassName: #'Object'
     category: className
-    instVarNames: #()
-    comment: '').
+    instVarNames: #()).
   (MCMethodDefinition
     className: className asString
     classIsMeta: true
@@ -2999,8 +2982,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue283dkh2: ances
     name: className
     superclassName: #'Object'
     category: className
-    instVarNames: #()
-    comment: '').
+    instVarNames: #()).
   (MCMethodDefinition
     className: className asString
     classIsMeta: true
@@ -3065,7 +3047,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue95 [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -3109,7 +3091,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectLoop [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -3155,8 +3137,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectToolBox [
         name: className
         superclassName: #'Object'
         category: className
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -3442,7 +3423,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfSymbolic [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -3515,8 +3496,7 @@ MetacelloConfigurationResource >> setUpIssue156BaselineOfGoo [
     name: packageName
     superclassName: #'BaselineOf'
     category: packageName
-    instVarNames: #()
-    comment: '').
+    instVarNames: #()).
   (MCMethodDefinition
     className: packageName asString
     selector: 'baselineGooIssue156Baseline:'
@@ -3554,8 +3534,7 @@ MetacelloConfigurationResource >> setUpIssue156ConfigurationOfGoo [
     name: packageName
     superclassName: #'ConfigurationOf'
     category: packageName
-    instVarNames: #()
-    comment: '').
+    instVarNames: #()).
   (MCMethodDefinition
     className: packageName asString
     selector: 'baselineGoo300Issue156Configuration:'
@@ -3608,8 +3587,7 @@ MetacelloConfigurationResource >> setUpIssue156ConfigurationOfProjectGoo [
     name: packageName
     superclassName: #'ConfigurationOf'
     category: packageName
-    instVarNames: #()
-    comment: '').
+    instVarNames: #()).
   (MCMethodDefinition
     className: packageName asString
     selector: 'version10Issue156:'
@@ -3663,8 +3641,7 @@ MetacelloConfigurationResource >> setUpIssue156ConfigurationOfProjectSoo [
     name: packageName
     superclassName: #'ConfigurationOf'
     category: packageName
-    instVarNames: #()
-    comment: '').
+    instVarNames: #()).
   (MCMethodDefinition
     className: packageName asString
     selector: 'version10Issue156:'
@@ -3725,7 +3702,7 @@ MetacelloConfigurationResource >> setUpIssue77B [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -3769,7 +3746,7 @@ MetacelloConfigurationResource >> setUpIssue77C [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -3819,7 +3796,7 @@ MetacelloConfigurationResource >> setUpIssue77D [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #() comment: ''.
+					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true

--- a/src/Metacello-TestsMCResources/MetacelloConfigurationResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloConfigurationResource.class.st
@@ -1245,7 +1245,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfFan [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName.
+					MCClassDefinition named: packageName category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -1313,7 +1313,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfFeaux [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName.
+					MCClassDefinition named: packageName category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -1357,7 +1357,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfFix [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName.
+					MCClassDefinition named: packageName category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -1406,10 +1406,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfFoo [
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfFoo-dkh.1'.
     packageName := reference packageName asSymbol.
     definitionArray := {(MCOrganizationDefinition packageName: packageName).
-    (MCClassDefinition
-        name: packageName
-        superclassName: #'Object'
-        category: packageName).
+    (MCClassDefinition named: packageName category: packageName).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: false
@@ -1492,7 +1489,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfFum [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName.
+					MCClassDefinition named: packageName category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -1534,10 +1531,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfMetacelloExampledkh1 [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'ConfigurationOfMetacelloExample-dkh.1'.
     className := reference packageName asSymbol.
-    definitionArray := {(MCClassDefinition
-        name: className
-        superclassName: #'Object'
-        category: className).
+    definitionArray := {(MCClassDefinition named: className category: className).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -1589,10 +1583,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectConfigIssue283dkh1 
   reference := GoferVersionReference
     name: 'ConfigurationOfProjectConfigIssue283-dkh.1'.
   className := reference packageName asSymbol.
-  definitionArray := {(MCClassDefinition
-    name: className
-    superclassName: #'Object'
-    category: className).
+  definitionArray := {(MCClassDefinition named: className category: className).
   (MCMethodDefinition
     className: className asString
     classIsMeta: true
@@ -1645,7 +1636,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectFee [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName.
+					MCClassDefinition named: packageName category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -1688,10 +1679,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectFie [
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectFie-dkh.1'.
     packageName := reference packageName asSymbol.
     definitionArray := {(MCOrganizationDefinition packageName: packageName).
-    (MCClassDefinition
-        name: packageName
-        superclassName: #'Object'
-        category: packageName).
+    (MCClassDefinition named: packageName category: packageName).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true
@@ -1755,7 +1743,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectFoe [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName.
+					MCClassDefinition named: packageName category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -1798,10 +1786,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectFum [
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectFum-dkh.1'.
     packageName := reference packageName asSymbol.
     definitionArray := {(MCOrganizationDefinition packageName: packageName).
-    (MCClassDefinition
-        name: packageName
-        superclassName: #'Object'
-        category: packageName).
+    (MCClassDefinition named: packageName category: packageName).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true
@@ -1847,7 +1832,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectInfinite [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName.
+					MCClassDefinition named: packageName category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -1900,7 +1885,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue115dkh1 [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName.
+					MCClassDefinition named: packageName category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -1951,7 +1936,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue115dkh2: ances
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName.
+					MCClassDefinition named: packageName category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -2022,10 +2007,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue119dkh1 [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue119-dkh.1'.
     className := reference packageName asSymbol.
-    definitionArray := {(MCClassDefinition
-        name: className
-        superclassName: #'Object'
-        category: className).
+    definitionArray := {(MCClassDefinition named: className category: className).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2078,10 +2060,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue119dkh2: ances
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue119-dkh.2'.
     className := reference packageName asSymbol.
-    definitionArray := {(MCClassDefinition
-        name: className
-        superclassName: #'Object'
-        category: className).
+    definitionArray := {(MCClassDefinition named: className category: className).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2134,10 +2113,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue119dkh3: ances
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue119-dkh.3'.
     className := reference packageName asSymbol.
-    definitionArray := {(MCClassDefinition
-        name: className
-        superclassName: #'Object'
-        category: className).
+    definitionArray := {(MCClassDefinition named: className category: className).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2190,10 +2166,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue119dkh4: ances
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue119-dkh.4'.
     className := reference packageName asSymbol.
-    definitionArray := {(MCClassDefinition
-        name: className
-        superclassName: #'Object'
-        category: className).
+    definitionArray := {(MCClassDefinition named: className category: className).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2246,10 +2219,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue119dkh5: ances
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue119-dkh.5'.
     className := reference packageName asSymbol.
-    definitionArray := {(MCClassDefinition
-        name: className
-        superclassName: #'Object'
-        category: className).
+    definitionArray := {(MCClassDefinition named: className category: className).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2326,10 +2296,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue119dkh6: ances
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue119-dkh.6'.
     className := reference packageName asSymbol.
-    definitionArray := {(MCClassDefinition
-        name: className
-        superclassName: #'Object'
-        category: className).
+    definitionArray := {(MCClassDefinition named: className category: className).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2442,10 +2409,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue119dkh7: ances
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue119-dkh.7'.
     className := reference packageName asSymbol.
-    definitionArray := {(MCClassDefinition
-        name: className
-        superclassName: #'Object'
-        category: className).
+    definitionArray := {(MCClassDefinition named: className category: className).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2497,10 +2461,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue125 [
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue125-dkh.1'.
     packageName := reference packageName asSymbol.
     definitionArray := {(MCOrganizationDefinition packageName: packageName).
-    (MCClassDefinition
-        name: packageName
-        superclassName: #'Object'
-        category: packageName).
+    (MCClassDefinition named: packageName category: packageName).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true
@@ -2568,7 +2529,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue136dkh1 [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName.
+					MCClassDefinition named: packageName category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -2619,7 +2580,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue136dkh2: ances
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName.
+					MCClassDefinition named: packageName category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -2683,10 +2644,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue154dkh1 [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'ConfigurationOfMetacelloProjectIssue154-dkh.1'.
     className := reference packageName asSymbol.
-    definitionArray := {(MCClassDefinition
-        name: className
-        superclassName: #'Object'
-        category: className).
+    definitionArray := {(MCClassDefinition named: className category: className).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2781,10 +2739,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue171dkh1 [
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue171-dkh.1'.
     className := reference packageName asSymbol.
-    definitionArray := {(MCClassDefinition
-        name: className
-        superclassName: #'Object'
-        category: className).
+    definitionArray := {(MCClassDefinition named: className category: className).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2835,10 +2790,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue171dkh2: ances
     | reference className definitionArray versionInfo |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectIssue171-dkh.2'.
     className := reference packageName asSymbol.
-    definitionArray := {(MCClassDefinition
-        name: className
-        superclassName: #'Object'
-        category: className).
+    definitionArray := {(MCClassDefinition named: className category: className).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2900,10 +2852,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue283dkh1 [
   reference := GoferVersionReference
     name: 'ConfigurationOfProjectIssue283-dkh.1'.
   className := reference packageName asSymbol.
-  definitionArray := {(MCClassDefinition
-    name: className
-    superclassName: #'Object'
-    category: className).
+  definitionArray := {(MCClassDefinition named: className  category: className).
   (MCMethodDefinition
     className: className asString
     classIsMeta: true
@@ -2961,10 +2910,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue283dkh2: ances
   reference := GoferVersionReference
     name: 'ConfigurationOfProjectIssue283-dkh.2'.
   className := reference packageName asSymbol.
-  definitionArray := {(MCClassDefinition
-    name: className
-    superclassName: #'Object'
-    category: className).
+  definitionArray := {(MCClassDefinition named: className category: className).
   (MCMethodDefinition
     className: className asString
     classIsMeta: true
@@ -3029,7 +2975,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue95 [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName.
+					MCClassDefinition named: packageName category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -3073,7 +3019,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectLoop [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName.
+					MCClassDefinition named: packageName category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -3115,10 +3061,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectToolBox [
     | reference className definitionArray |
     reference := GoferVersionReference name: 'MetacelloTestConfigurationOfProjectToolBox-dkh.1'.
     className := reference packageName asSymbol.
-    definitionArray := {(MCClassDefinition
-        name: className
-        superclassName: #'Object'
-        category: className).
+    definitionArray := {(MCClassDefinition named: className category: className).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -3404,7 +3347,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfSymbolic [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName.
+					MCClassDefinition named: packageName category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -3465,199 +3408,184 @@ MetacelloConfigurationResource >> setUpConfigurationOfSymbolic [
 
 { #category : #ConfigurationOfFoo }
 MetacelloConfigurationResource >> setUpIssue156BaselineOfGoo [
-  "https://github.com/dalehenrich/metacello-work/issues/156"
+	"https://github.com/dalehenrich/metacello-work/issues/156"
 
-  "self reset"
+	"self reset"
 
-  | reference packageName definitionArray |
-  reference := GoferVersionReference name: 'BaselineOfGoo-dkh.1'.
-  packageName := reference packageName asSymbol.
-  definitionArray := {(MCOrganizationDefinition packageName: packageName).
-  (MCClassDefinition
-    name: packageName
-    superclassName: #'BaselineOf'
-    category: packageName).
-  (MCMethodDefinition
-    className: packageName asString
-    selector: 'baselineGooIssue156Baseline:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'baselineGooIssue156Baseline:') asString)}.
-  monticelloRepository
-    basicStoreVersion:
-      (MCVersion new
-        setPackage: (MCPackage new name: reference packageName)
-        info:
-          (MCVersionInfo
-            name: reference name
-            id: UUID new
-            message: 'This is a mock version'
-            date: Date today
-            time: Time now
-            author: reference author
-            ancestors: #())
-        snapshot: (MCSnapshot fromDefinitions: definitionArray)
-        dependencies: #())
+	| reference packageName definitionArray |
+	reference := GoferVersionReference name: 'BaselineOfGoo-dkh.1'.
+	packageName := reference packageName asSymbol.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: packageName).
+		                   ((MCClassDefinition named: packageName category: packageName)
+			                    superclassName: #BaselineOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: packageName asString
+			                    selector: 'baselineGooIssue156Baseline:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #baselineGooIssue156Baseline:) asString) }.
+	monticelloRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (MCVersionInfo
+					  name: reference name
+					  id: UUID new
+					  message: 'This is a mock version'
+					  date: Date today
+					  time: Time now
+					  author: reference author
+					  ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  ))
 ]
 
 { #category : #ConfigurationOfFoo }
 MetacelloConfigurationResource >> setUpIssue156ConfigurationOfGoo [
-  "https://github.com/dalehenrich/metacello-work/issues/156"
+	"https://github.com/dalehenrich/metacello-work/issues/156"
 
-  "self reset"
+	"self reset"
 
-  | reference packageName definitionArray |
-  reference := GoferVersionReference name: 'ConfigurationOfGoo-dkh.1'.
-  packageName := reference packageName asSymbol.
-  definitionArray := {(MCOrganizationDefinition packageName: packageName).
-  (MCClassDefinition
-    name: packageName
-    superclassName: #'ConfigurationOf'
-    category: packageName).
-  (MCMethodDefinition
-    className: packageName asString
-    selector: 'baselineGoo300Issue156Configuration:'
-    category: 'cat'
-    timeStamp: ''
-    source:
-      (self class sourceCodeAt: #'baselineGoo300Issue156Configuration:') asString).
-  (MCMethodDefinition
-    className: packageName asString
-    selector: 'baselineGoo400Issue156Configuration:'
-    category: 'cat'
-    timeStamp: ''
-    source:
-      (self class sourceCodeAt: #'baselineGoo400Issue156Configuration:') asString).
-  (MCMethodDefinition
-    className: packageName asString
-    selector: 'baselineGoo500Issue156Configuration:'
-    category: 'cat'
-    timeStamp: ''
-    source:
-      (self class sourceCodeAt: #'baselineGoo500Issue156Configuration:') asString)}.
-  monticelloRepository
-    basicStoreVersion:
-      (MCVersion new
-        setPackage: (MCPackage new name: reference packageName)
-        info:
-          (MCVersionInfo
-            name: reference name
-            id: UUID new
-            message: 'This is a mock version'
-            date: Date today
-            time: Time now
-            author: reference author
-            ancestors: #())
-        snapshot: (MCSnapshot fromDefinitions: definitionArray)
-        dependencies: #())
+	| reference packageName definitionArray |
+	reference := GoferVersionReference name: 'ConfigurationOfGoo-dkh.1'.
+	packageName := reference packageName asSymbol.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: packageName).
+		                   ((MCClassDefinition named: packageName category: packageName)
+			                    superclassName: #ConfigurationOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: packageName asString
+			                    selector: 'baselineGoo300Issue156Configuration:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #baselineGoo300Issue156Configuration:) asString).
+		                   (MCMethodDefinition
+			                    className: packageName asString
+			                    selector: 'baselineGoo400Issue156Configuration:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #baselineGoo400Issue156Configuration:) asString).
+		                   (MCMethodDefinition
+			                    className: packageName asString
+			                    selector: 'baselineGoo500Issue156Configuration:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #baselineGoo500Issue156Configuration:) asString) }.
+	monticelloRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (MCVersionInfo
+					  name: reference name
+					  id: UUID new
+					  message: 'This is a mock version'
+					  date: Date today
+					  time: Time now
+					  author: reference author
+					  ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  ))
 ]
 
 { #category : #ConfigurationOfFoo }
 MetacelloConfigurationResource >> setUpIssue156ConfigurationOfProjectGoo [
-  "https://github.com/dalehenrich/metacello-work/issues/156"
+	"https://github.com/dalehenrich/metacello-work/issues/156"
 
-  "self reset"
+	"self reset"
 
-  | reference packageName definitionArray |
-  reference := GoferVersionReference name: 'ConfigurationOfProjectGoo-dkh.1'.
-  packageName := reference packageName asSymbol.
-  definitionArray := {(MCOrganizationDefinition packageName: packageName).
-  (MCClassDefinition
-    name: packageName
-    superclassName: #'ConfigurationOf'
-    category: packageName).
-  (MCMethodDefinition
-    className: packageName asString
-    selector: 'version10Issue156:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'version10Issue156:') asString).
-  (MCMethodDefinition
-    className: packageName asString
-    selector: 'version11Issue156:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'version11Issue156:') asString).
-  (MCMethodDefinition
-    className: packageName asString
-    selector: 'version20Issue156:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'version20Issue156:') asString).
-  (MCMethodDefinition
-    className: packageName asString
-    selector: 'version30Issue156:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'version30Issue156:') asString)}.
-  monticelloRepository
-    basicStoreVersion:
-      (MCVersion new
-        setPackage: (MCPackage new name: reference packageName)
-        info:
-          (MCVersionInfo
-            name: reference name
-            id: UUID new
-            message: 'This is a mock version'
-            date: Date today
-            time: Time now
-            author: reference author
-            ancestors: #())
-        snapshot: (MCSnapshot fromDefinitions: definitionArray)
-        dependencies: #())
+	| reference packageName definitionArray |
+	reference := GoferVersionReference name: 'ConfigurationOfProjectGoo-dkh.1'.
+	packageName := reference packageName asSymbol.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: packageName).
+		                   ((MCClassDefinition named: packageName category: packageName)
+			                    superclassName: #ConfigurationOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: packageName asString
+			                    selector: 'version10Issue156:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #version10Issue156:) asString).
+		                   (MCMethodDefinition
+			                    className: packageName asString
+			                    selector: 'version11Issue156:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #version11Issue156:) asString).
+		                   (MCMethodDefinition
+			                    className: packageName asString
+			                    selector: 'version20Issue156:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #version20Issue156:) asString).
+		                   (MCMethodDefinition
+			                    className: packageName asString
+			                    selector: 'version30Issue156:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #version30Issue156:) asString) }.
+	monticelloRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (MCVersionInfo
+					  name: reference name
+					  id: UUID new
+					  message: 'This is a mock version'
+					  date: Date today
+					  time: Time now
+					  author: reference author
+					  ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  ))
 ]
 
 { #category : #ConfigurationOfFoo }
 MetacelloConfigurationResource >> setUpIssue156ConfigurationOfProjectSoo [
-  "self reset"
+	"self reset"
 
-  | reference packageName definitionArray |
-  reference := GoferVersionReference name: 'ConfigurationOfProjectSoo-dkh.1'.
-  packageName := reference packageName asSymbol.
-  definitionArray := {(MCOrganizationDefinition packageName: packageName).
-  (MCClassDefinition
-    name: packageName
-    superclassName: #'ConfigurationOf'
-    category: packageName).
-  (MCMethodDefinition
-    className: packageName asString
-    selector: 'version10Issue156:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'version10Issue156:') asString).
-  (MCMethodDefinition
-    className: packageName asString
-    selector: 'version11Issue156:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'version11Issue156:') asString).
-  (MCMethodDefinition
-    className: packageName asString
-    selector: 'version20Issue156:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'version20Issue156:') asString).
-  (MCMethodDefinition
-    className: packageName asString
-    selector: 'version30Issue156:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'version30Issue156:') asString)}.
-  monticelloRepository
-    basicStoreVersion:
-      (MCVersion new
-        setPackage: (MCPackage new name: reference packageName)
-        info:
-          (MCVersionInfo
-            name: reference name
-            id: UUID new
-            message: 'This is a mock version'
-            date: Date today
-            time: Time now
-            author: reference author
-            ancestors: #())
-        snapshot: (MCSnapshot fromDefinitions: definitionArray)
-        dependencies: #())
+	| reference packageName definitionArray |
+	reference := GoferVersionReference name: 'ConfigurationOfProjectSoo-dkh.1'.
+	packageName := reference packageName asSymbol.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: packageName).
+		                   ((MCClassDefinition named: packageName category: packageName)
+			                    superclassName: #ConfigurationOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: packageName asString
+			                    selector: 'version10Issue156:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #version10Issue156:) asString).
+		                   (MCMethodDefinition
+			                    className: packageName asString
+			                    selector: 'version11Issue156:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #version11Issue156:) asString).
+		                   (MCMethodDefinition
+			                    className: packageName asString
+			                    selector: 'version20Issue156:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #version20Issue156:) asString).
+		                   (MCMethodDefinition
+			                    className: packageName asString
+			                    selector: 'version30Issue156:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #version30Issue156:) asString) }.
+	monticelloRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (MCVersionInfo
+					  name: reference name
+					  id: UUID new
+					  message: 'This is a mock version'
+					  date: Date today
+					  time: Time now
+					  author: reference author
+					  ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  ))
 ]
 
 { #category : #'Issue 77' }
@@ -3679,7 +3607,7 @@ MetacelloConfigurationResource >> setUpIssue77B [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName.
+					MCClassDefinition named: packageName category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -3723,7 +3651,7 @@ MetacelloConfigurationResource >> setUpIssue77C [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName.
+					MCClassDefinition named: packageName category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -3773,7 +3701,7 @@ MetacelloConfigurationResource >> setUpIssue77D [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName.
+					MCClassDefinition named: packageName category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true

--- a/src/Metacello-TestsMCResources/MetacelloConfigurationResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloConfigurationResource.class.st
@@ -1245,7 +1245,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfFan [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
+					MCClassDefinition name: packageName superclassName: #Object category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -1313,7 +1313,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfFeaux [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
+					MCClassDefinition name: packageName superclassName: #Object category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -1357,7 +1357,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfFix [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
+					MCClassDefinition name: packageName superclassName: #Object category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -1409,8 +1409,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfFoo [
     (MCClassDefinition
         name: packageName
         superclassName: #'Object'
-        category: packageName
-        instVarNames: #()).
+        category: packageName).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: false
@@ -1493,7 +1492,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfFum [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
+					MCClassDefinition name: packageName superclassName: #Object category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -1538,8 +1537,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfMetacelloExampledkh1 [
     definitionArray := {(MCClassDefinition
         name: className
         superclassName: #'Object'
-        category: className
-        instVarNames: #()).
+        category: className).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -1594,8 +1592,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectConfigIssue283dkh1 
   definitionArray := {(MCClassDefinition
     name: className
     superclassName: #'Object'
-    category: className
-    instVarNames: #()).
+    category: className).
   (MCMethodDefinition
     className: className asString
     classIsMeta: true
@@ -1648,7 +1645,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectFee [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
+					MCClassDefinition name: packageName superclassName: #Object category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -1694,8 +1691,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectFie [
     (MCClassDefinition
         name: packageName
         superclassName: #'Object'
-        category: packageName
-        instVarNames: #()).
+        category: packageName).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true
@@ -1759,7 +1755,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectFoe [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
+					MCClassDefinition name: packageName superclassName: #Object category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -1805,8 +1801,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectFum [
     (MCClassDefinition
         name: packageName
         superclassName: #'Object'
-        category: packageName
-        instVarNames: #()).
+        category: packageName).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true
@@ -1852,7 +1847,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectInfinite [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
+					MCClassDefinition name: packageName superclassName: #Object category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -1905,7 +1900,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue115dkh1 [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
+					MCClassDefinition name: packageName superclassName: #Object category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -1956,7 +1951,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue115dkh2: ances
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
+					MCClassDefinition name: packageName superclassName: #Object category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -2030,8 +2025,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue119dkh1 [
     definitionArray := {(MCClassDefinition
         name: className
         superclassName: #'Object'
-        category: className
-        instVarNames: #()).
+        category: className).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2087,8 +2081,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue119dkh2: ances
     definitionArray := {(MCClassDefinition
         name: className
         superclassName: #'Object'
-        category: className
-        instVarNames: #()).
+        category: className).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2144,8 +2137,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue119dkh3: ances
     definitionArray := {(MCClassDefinition
         name: className
         superclassName: #'Object'
-        category: className
-        instVarNames: #()).
+        category: className).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2201,8 +2193,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue119dkh4: ances
     definitionArray := {(MCClassDefinition
         name: className
         superclassName: #'Object'
-        category: className
-        instVarNames: #()).
+        category: className).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2258,8 +2249,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue119dkh5: ances
     definitionArray := {(MCClassDefinition
         name: className
         superclassName: #'Object'
-        category: className
-        instVarNames: #()).
+        category: className).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2339,8 +2329,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue119dkh6: ances
     definitionArray := {(MCClassDefinition
         name: className
         superclassName: #'Object'
-        category: className
-        instVarNames: #()).
+        category: className).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2456,8 +2445,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue119dkh7: ances
     definitionArray := {(MCClassDefinition
         name: className
         superclassName: #'Object'
-        category: className
-        instVarNames: #()).
+        category: className).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2512,8 +2500,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue125 [
     (MCClassDefinition
         name: packageName
         superclassName: #'Object'
-        category: packageName
-        instVarNames: #()).
+        category: packageName).
     (MCMethodDefinition
         className: packageName asString
         classIsMeta: true
@@ -2581,7 +2568,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue136dkh1 [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
+					MCClassDefinition name: packageName superclassName: #Object category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -2632,7 +2619,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue136dkh2: ances
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
+					MCClassDefinition name: packageName superclassName: #Object category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -2699,8 +2686,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue154dkh1 [
     definitionArray := {(MCClassDefinition
         name: className
         superclassName: #'Object'
-        category: className
-        instVarNames: #()).
+        category: className).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2798,8 +2784,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue171dkh1 [
     definitionArray := {(MCClassDefinition
         name: className
         superclassName: #'Object'
-        category: className
-        instVarNames: #()).
+        category: className).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2853,8 +2838,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue171dkh2: ances
     definitionArray := {(MCClassDefinition
         name: className
         superclassName: #'Object'
-        category: className
-        instVarNames: #()).
+        category: className).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -2919,8 +2903,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue283dkh1 [
   definitionArray := {(MCClassDefinition
     name: className
     superclassName: #'Object'
-    category: className
-    instVarNames: #()).
+    category: className).
   (MCMethodDefinition
     className: className asString
     classIsMeta: true
@@ -2981,8 +2964,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue283dkh2: ances
   definitionArray := {(MCClassDefinition
     name: className
     superclassName: #'Object'
-    category: className
-    instVarNames: #()).
+    category: className).
   (MCMethodDefinition
     className: className asString
     classIsMeta: true
@@ -3047,7 +3029,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectIssue95 [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
+					MCClassDefinition name: packageName superclassName: #Object category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -3091,7 +3073,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectLoop [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
+					MCClassDefinition name: packageName superclassName: #Object category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -3136,8 +3118,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfProjectToolBox [
     definitionArray := {(MCClassDefinition
         name: className
         superclassName: #'Object'
-        category: className
-        instVarNames: #()).
+        category: className).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -3423,7 +3404,7 @@ MetacelloConfigurationResource >> setUpConfigurationOfSymbolic [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
+					MCClassDefinition name: packageName superclassName: #Object category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -3495,8 +3476,7 @@ MetacelloConfigurationResource >> setUpIssue156BaselineOfGoo [
   (MCClassDefinition
     name: packageName
     superclassName: #'BaselineOf'
-    category: packageName
-    instVarNames: #()).
+    category: packageName).
   (MCMethodDefinition
     className: packageName asString
     selector: 'baselineGooIssue156Baseline:'
@@ -3533,8 +3513,7 @@ MetacelloConfigurationResource >> setUpIssue156ConfigurationOfGoo [
   (MCClassDefinition
     name: packageName
     superclassName: #'ConfigurationOf'
-    category: packageName
-    instVarNames: #()).
+    category: packageName).
   (MCMethodDefinition
     className: packageName asString
     selector: 'baselineGoo300Issue156Configuration:'
@@ -3586,8 +3565,7 @@ MetacelloConfigurationResource >> setUpIssue156ConfigurationOfProjectGoo [
   (MCClassDefinition
     name: packageName
     superclassName: #'ConfigurationOf'
-    category: packageName
-    instVarNames: #()).
+    category: packageName).
   (MCMethodDefinition
     className: packageName asString
     selector: 'version10Issue156:'
@@ -3640,8 +3618,7 @@ MetacelloConfigurationResource >> setUpIssue156ConfigurationOfProjectSoo [
   (MCClassDefinition
     name: packageName
     superclassName: #'ConfigurationOf'
-    category: packageName
-    instVarNames: #()).
+    category: packageName).
   (MCMethodDefinition
     className: packageName asString
     selector: 'version10Issue156:'
@@ -3702,7 +3679,7 @@ MetacelloConfigurationResource >> setUpIssue77B [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
+					MCClassDefinition name: packageName superclassName: #Object category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -3746,7 +3723,7 @@ MetacelloConfigurationResource >> setUpIssue77C [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
+					MCClassDefinition name: packageName superclassName: #Object category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true
@@ -3796,7 +3773,7 @@ MetacelloConfigurationResource >> setUpIssue77D [
 	packageName := reference packageName asSymbol.
 	definitionArray := {
 					MCOrganizationDefinition packageName: packageName.
-					MCClassDefinition name: packageName superclassName: #Object category: packageName instVarNames: #().
+					MCClassDefinition name: packageName superclassName: #Object category: packageName.
 					MCMethodDefinition 
 						className: packageName asString
 						classIsMeta: true

--- a/src/Metacello-TestsMCResources/MetacelloIssue108Resource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloIssue108Resource.class.st
@@ -41,7 +41,7 @@ MetacelloIssue108Resource >> setUpMonticelloRepository [
 				ancestors: #())
 			snapshot: (MCSnapshot fromDefinitions: (Array
 				with: (MCOrganizationDefinition packageName: reference packageName)
-				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol instVarNames: #())))
+				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol)))
 			dependencies: #()) ]
 ]
 

--- a/src/Metacello-TestsMCResources/MetacelloIssue108Resource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloIssue108Resource.class.st
@@ -41,7 +41,7 @@ MetacelloIssue108Resource >> setUpMonticelloRepository [
 				ancestors: #())
 			snapshot: (MCSnapshot fromDefinitions: (Array
 				with: (MCOrganizationDefinition packageName: reference packageName)
-				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol)))
+				with: (MCClassDefinition named: (reference packageName copyWithout: $-) asSymbol category: reference packageName asSymbol)))
 			dependencies: #()) ]
 ]
 

--- a/src/Metacello-TestsMCResources/MetacelloIssue108Resource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloIssue108Resource.class.st
@@ -41,7 +41,7 @@ MetacelloIssue108Resource >> setUpMonticelloRepository [
 				ancestors: #())
 			snapshot: (MCSnapshot fromDefinitions: (Array
 				with: (MCOrganizationDefinition packageName: reference packageName)
-				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol instVarNames: #() comment: '')))
+				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol instVarNames: #())))
 			dependencies: #()) ]
 ]
 

--- a/src/Metacello-TestsMCResources/MetacelloMonticelloResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloMonticelloResource.class.st
@@ -39,7 +39,7 @@ MetacelloMonticelloResource >> setUpMonticelloRepository [
 				ancestors: #())
 			snapshot: (MCSnapshot fromDefinitions: (Array
 				with: (MCOrganizationDefinition packageName: reference packageName)
-				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol instVarNames: #())))
+				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol)))
 			dependencies: #()) ]
 ]
 

--- a/src/Metacello-TestsMCResources/MetacelloMonticelloResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloMonticelloResource.class.st
@@ -39,7 +39,7 @@ MetacelloMonticelloResource >> setUpMonticelloRepository [
 				ancestors: #())
 			snapshot: (MCSnapshot fromDefinitions: (Array
 				with: (MCOrganizationDefinition packageName: reference packageName)
-				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol instVarNames: #() comment: '')))
+				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol instVarNames: #())))
 			dependencies: #()) ]
 ]
 

--- a/src/Metacello-TestsMCResources/MetacelloMonticelloResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloMonticelloResource.class.st
@@ -39,7 +39,7 @@ MetacelloMonticelloResource >> setUpMonticelloRepository [
 				ancestors: #())
 			snapshot: (MCSnapshot fromDefinitions: (Array
 				with: (MCOrganizationDefinition packageName: reference packageName)
-				with: (MCClassDefinition name: (reference packageName copyWithout: $-) asSymbol superclassName: #Object category: reference packageName asSymbol)))
+				with: (MCClassDefinition named: (reference packageName copyWithout: $-) asSymbol category: reference packageName asSymbol)))
 			dependencies: #()) ]
 ]
 

--- a/src/Metacello-TestsMCResources/MetacelloScriptingResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloScriptingResource.class.st
@@ -1000,8 +1000,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceIV [
         name: className
         superclassName: #'BaselineOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1039,8 +1038,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceIX [
         name: className
         superclassName: #'BaselineOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1078,8 +1076,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceV [
         name: className
         superclassName: #'BaselineOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1117,8 +1114,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceVI [
         name: className
         superclassName: #'BaselineOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1156,8 +1152,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceVII [
         name: className
         superclassName: #'BaselineOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1195,8 +1190,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceVIII [
         name: className
         superclassName: #'BaselineOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1234,8 +1228,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceXI [
         name: className
         superclassName: #'BaselineOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1273,8 +1266,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceXII [
         name: className
         superclassName: #'BaselineOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1312,8 +1304,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceXIII [
         name: className
         superclassName: #'BaselineOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1351,8 +1342,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceXX [
         name: className
         superclassName: #'BaselineOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1390,8 +1380,7 @@ MetacelloScriptingResource >> setUpBaselineIssue215 [
     name: className
     superclassName: #'BaselineOf'
     category: reference packageName
-    instVarNames: #()
-    comment: '').
+    instVarNames: #()).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -1450,8 +1439,7 @@ MetacelloScriptingResource >> setUpBaselineIssue32 [
         name: className
         superclassName: #'BaselineOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1510,8 +1498,7 @@ MetacelloScriptingResource >> setUpBaselineIssue399 [
     name: className
     superclassName: #'BaselineOf'
     category: reference packageName
-    instVarNames: #()
-    comment: '').
+    instVarNames: #()).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -1549,8 +1536,7 @@ MetacelloScriptingResource >> setUpBaselineIssue399Cypress [
     name: className
     superclassName: #'BaselineOf'
     category: reference packageName
-    instVarNames: #()
-    comment: '').
+    instVarNames: #()).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -1595,8 +1581,7 @@ MetacelloScriptingResource >> setUpBaselineOfExternalX [
         name: className
         superclassName: #'BaselineOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1634,8 +1619,7 @@ MetacelloScriptingResource >> setUpBaselineOfExternalXX [
         name: className
         superclassName: #'BaselineOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1673,8 +1657,7 @@ MetacelloScriptingResource >> setUpBaselineOfExternalXXX [
         name: className
         superclassName: #'BaselineOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1719,8 +1702,7 @@ MetacelloScriptingResource >> setUpConfiguration181 [
     name: className
     superclassName: #'ConfigurationOf'
     category: reference packageName
-    instVarNames: #()
-    comment: '').
+    instVarNames: #()).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -1807,8 +1789,7 @@ MetacelloScriptingResource >> setUpConfiguration63 [
         name: className
         superclassName: #'ConfigurationOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1862,8 +1843,7 @@ MetacelloScriptingResource >> setUpConfigurationExternalRefdkh1 [
     name: className
     superclassName: #'ConfigurationOf'
     category: reference packageName
-    instVarNames: #()
-    comment: '').
+    instVarNames: #()).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -1908,8 +1888,7 @@ MetacelloScriptingResource >> setUpConfigurationExternalRefdkh2: ancestors [
     name: className
     superclassName: #'ConfigurationOf'
     category: reference packageName
-    instVarNames: #()
-    comment: '').
+    instVarNames: #()).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -1963,8 +1942,7 @@ MetacelloScriptingResource >> setUpConfigurationIssue32 [
         name: className
         superclassName: #'ConfigurationOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -2018,8 +1996,7 @@ MetacelloScriptingResource >> setUpConfigurationIssue339 [
     name: className
     superclassName: #'ConfigurationOf'
     category: reference packageName
-    instVarNames: #()
-    comment: '').
+    instVarNames: #()).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -2061,8 +2038,7 @@ MetacelloScriptingResource >> setUpConfigurationIssue59 [
         name: className
         superclassName: #'ConfigurationOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -2116,8 +2092,7 @@ MetacelloScriptingResource >> setUpConfigurationIssue84 [
         name: className
         superclassName: #'ConfigurationOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -2175,8 +2150,7 @@ MetacelloScriptingResource >> setUpConfigurationNextedIssue84dkh1 [
         name: className
         superclassName: #'ConfigurationOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -2230,8 +2204,7 @@ MetacelloScriptingResource >> setUpConfigurationNextedIssue84dkh2: ancestors [
         name: className
         superclassName: #'ConfigurationOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -2283,8 +2256,7 @@ MetacelloScriptingResource >> setUpConfigurationOfConflict [
     name: className
     superclassName: #'ConfigurationOf'
     category: reference packageName
-    instVarNames: #()
-    comment: '').
+    instVarNames: #()).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -2359,8 +2331,7 @@ MetacelloScriptingResource >> setUpConfigurationOfExternalIV [
         name: className
         superclassName: #'ConfigurationOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -2414,8 +2385,7 @@ MetacelloScriptingResource >> setUpConfigurationOfExternalXX [
         name: className
         superclassName: #'ConfigurationOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -2460,8 +2430,7 @@ MetacelloScriptingResource >> setUpConfigurationOfExternalXXX [
         name: className
         superclassName: #'ConfigurationOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -2499,8 +2468,7 @@ MetacelloScriptingResource >> setUpConfigurationOfExternalXdkh1 [
     name: className
     superclassName: #'ConfigurationOf'
     category: reference packageName
-    instVarNames: #()
-    comment: '').
+    instVarNames: #()).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -2552,8 +2520,7 @@ MetacelloScriptingResource >> setUpConfigurationOfExternalXdkh2: ancestors [
     name: className
     superclassName: #'ConfigurationOf'
     category: reference packageName
-    instVarNames: #()
-    comment: '').
+    instVarNames: #()).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -2619,8 +2586,7 @@ MetacelloScriptingResource >> setUpConfigurationOfExternaldkh1 [
     name: className
     superclassName: #'ConfigurationOf'
     category: reference packageName
-    instVarNames: #()
-    comment: '').
+    instVarNames: #()).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -2658,8 +2624,7 @@ MetacelloScriptingResource >> setUpConfigurationOfExternaldkh2 [
     name: className
     superclassName: #'ConfigurationOf'
     category: reference packageName
-    instVarNames: #()
-    comment: '').
+    instVarNames: #()).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -2704,8 +2669,7 @@ MetacelloScriptingResource >> setUpExternalCore [
     name: className
     superclassName: #'Object'
     category: reference packageName
-    instVarNames: #()
-    comment: '').
+    instVarNames: #()).
   (MCMethodDefinition
     className: className asString
     classIsMeta: true
@@ -2750,8 +2714,7 @@ MetacelloScriptingResource >> setUpExternalCoreX [
     name: className
     superclassName: #'Object'
     category: reference packageName
-    instVarNames: #()
-    comment: '').
+    instVarNames: #()).
   (MCMethodDefinition
     className: className asString
     classIsMeta: true
@@ -2796,8 +2759,7 @@ MetacelloScriptingResource >> setUpInvalidConfigurations [
         name: className
         superclassName: #'ConfigurationOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -2874,8 +2836,7 @@ MetacelloScriptingResource >> setUpIssue399CoreExternaldkh1 [
     name: className
     superclassName: #'Object'
     category: reference packageName
-    instVarNames: #()
-    comment: '')}.
+    instVarNames: #())}.
   externalRepository
     basicStoreVersion:
       (MCVersion new
@@ -2912,8 +2873,7 @@ MetacelloScriptingResource >> setUpIssue399CoreSampledkh1 [
     name: className
     superclassName: #'Object'
     category: reference packageName
-    instVarNames: #()
-    comment: '')}.
+    instVarNames: #())}.
   sampleRepository
     basicStoreVersion:
       (MCVersion new
@@ -2950,8 +2910,7 @@ MetacelloScriptingResource >> setUpIssue399CoreSampledkh2: ancestors [
     name: className
     superclassName: #'Object'
     category: reference packageName
-    instVarNames: #()
-    comment: '')}.
+    instVarNames: #())}.
   sampleRepository
     basicStoreVersion:
       (MCVersion new
@@ -2983,8 +2942,7 @@ MetacelloScriptingResource >> setUpLockConfigurations [
     name: className
     superclassName: #'ConfigurationOf'
     category: reference packageName
-    instVarNames: #()
-    comment: '').
+    instVarNames: #()).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -3067,8 +3025,7 @@ MetacelloScriptingResource >> setUpMarianosImage [
         name: className
         superclassName: #'ConfigurationOf'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -3122,8 +3079,7 @@ MetacelloScriptingResource >> setUpSampleCore [
         name: className
         superclassName: #'Object'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -3135,8 +3091,7 @@ MetacelloScriptingResource >> setUpSampleCore [
         name: #'Object'
         superclassName: #'ProtoObject'
         category: reference packageName
-        instVarNames: #()
-        comment: '').
+        instVarNames: #()).
     (MCMethodDefinition
         className: 'Object'
         classIsMeta: true

--- a/src/Metacello-TestsMCResources/MetacelloScriptingResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloScriptingResource.class.st
@@ -990,817 +990,760 @@ MetacelloScriptingResource >> setUp [
 
 { #category : #'baseline pragma - github reference' }
 MetacelloScriptingResource >> setUpBaselineGithubReferenceIV [
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'BaselineOfGithubRefIV-dkh.1'.
-    className := #'BaselineOfGithubRefIV'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'BaselineOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'configurationGithubReferenceX:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'configurationGithubReferenceX:') asString)}.
-    externalRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'BaselineOfGithubRefIV-dkh.1'.
+	className := #BaselineOfGithubRefIV.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #BaselineOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'configurationGithubReferenceX:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #configurationGithubReferenceX:) asString) }.
+	externalRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'baseline pragma - github reference' }
 MetacelloScriptingResource >> setUpBaselineGithubReferenceIX [
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'BaselineOfGithubRefIX-dkh.1'.
-    className := #'BaselineOfGithubRefIX'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'BaselineOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'configurationGithubReferenceIV:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'configurationGithubReferenceIV:') asString)}.
-    externalRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'BaselineOfGithubRefIX-dkh.1'.
+	className := #BaselineOfGithubRefIX.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #BaselineOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'configurationGithubReferenceIV:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #configurationGithubReferenceIV:) asString) }.
+	externalRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'baseline pragma - github reference' }
 MetacelloScriptingResource >> setUpBaselineGithubReferenceV [
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'BaselineOfGithubRefV-dkh.1'.
-    className := #'BaselineOfGithubRefV'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'BaselineOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'configurationGithubReferenceXX:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'configurationGithubReferenceXX:') asString)}.
-    externalRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'BaselineOfGithubRefV-dkh.1'.
+	className := #BaselineOfGithubRefV.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #BaselineOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'configurationGithubReferenceXX:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #configurationGithubReferenceXX:) asString) }.
+	externalRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'baseline pragma - github reference' }
 MetacelloScriptingResource >> setUpBaselineGithubReferenceVI [
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'BaselineOfGithubRefVI-dkh.1'.
-    className := #'BaselineOfGithubRefVI'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'BaselineOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'configurationGithubReferenceXXX:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'configurationGithubReferenceXXX:') asString)}.
-    externalRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'BaselineOfGithubRefVI-dkh.1'.
+	className := #BaselineOfGithubRefVI.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #BaselineOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'configurationGithubReferenceXXX:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #configurationGithubReferenceXXX:) asString) }.
+	externalRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'baseline pragma - github reference' }
 MetacelloScriptingResource >> setUpBaselineGithubReferenceVII [
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'BaselineOfGithubRefVII-dkh.1'.
-    className := #'BaselineOfGithubRefVII'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'BaselineOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'baselineGithubReferenceIV:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'baselineGithubReferenceIV:') asString)}.
-    externalRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'BaselineOfGithubRefVII-dkh.1'.
+	className := #BaselineOfGithubRefVII.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #BaselineOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'baselineGithubReferenceIV:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #baselineGithubReferenceIV:) asString) }.
+	externalRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'baseline pragma - github reference' }
 MetacelloScriptingResource >> setUpBaselineGithubReferenceVIII [
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'BaselineOfGithubRefVIII-dkh.1'.
-    className := #'BaselineOfGithubRefVIII'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'BaselineOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'baselineGithubReferenceV:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'baselineGithubReferenceV:') asString)}.
-    externalRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'BaselineOfGithubRefVIII-dkh.1'.
+	className := #BaselineOfGithubRefVIII.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #BaselineOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'baselineGithubReferenceV:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #baselineGithubReferenceV:) asString) }.
+	externalRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'baseline pragma - github reference' }
 MetacelloScriptingResource >> setUpBaselineGithubReferenceXI [
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'BaselineOfGithubRefXI-dkh.1'.
-    className := #'BaselineOfGithubRefXI'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'BaselineOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'configurationGithubReferenceV:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'configurationGithubReferenceV:') asString)}.
-    externalRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'BaselineOfGithubRefXI-dkh.1'.
+	className := #BaselineOfGithubRefXI.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #BaselineOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'configurationGithubReferenceV:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #configurationGithubReferenceV:) asString) }.
+	externalRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'baseline pragma - github reference' }
 MetacelloScriptingResource >> setUpBaselineGithubReferenceXII [
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'BaselineOfGithubRefXII-dkh.1'.
-    className := #'BaselineOfGithubRefXII'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'BaselineOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'baselineGithubReferenceVI:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'baselineGithubReferenceVI:') asString)}.
-    externalRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'BaselineOfGithubRefXII-dkh.1'.
+	className := #BaselineOfGithubRefXII.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #BaselineOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'baselineGithubReferenceVI:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #baselineGithubReferenceVI:) asString) }.
+	externalRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'baseline pragma - github reference' }
 MetacelloScriptingResource >> setUpBaselineGithubReferenceXIII [
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'BaselineOfGithubRefXIII-dkh.1'.
-    className := #'BaselineOfGithubRefXIII'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'BaselineOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'baselineGithubReferenceVII:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'baselineGithubReferenceVII:') asString)}.
-    externalRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'BaselineOfGithubRefXIII-dkh.1'.
+	className := #BaselineOfGithubRefXIII.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #BaselineOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'baselineGithubReferenceVII:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #baselineGithubReferenceVII:) asString) }.
+	externalRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'baseline pragma - github reference' }
 MetacelloScriptingResource >> setUpBaselineGithubReferenceXX [
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'BaselineOfGithubRefXX-dkh.1'.
-    className := #'BaselineOfGithubRefXX'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'BaselineOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'baselineGithubReferenceXX:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'baselineGithubReferenceXX:') asString)}.
-    externalRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'BaselineOfGithubRefXX-dkh.1'.
+	className := #BaselineOfGithubRefXX.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #BaselineOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'baselineGithubReferenceXX:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #baselineGithubReferenceXX:) asString) }.
+	externalRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'issue 215' }
 MetacelloScriptingResource >> setUpBaselineIssue215 [
-  "self reset"
+	"self reset"
 
-  | reference className definitionArray versionInfo |
-  reference := GoferVersionReference name: 'BaselineOfIssue215-dkh.1'.
-  className := #'BaselineOfIssue215'.
-  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-  (MCClassDefinition
-    name: className
-    superclassName: #'BaselineOf'
-    category: reference packageName).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'postloadDoIt'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'postloadDoIt') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'preloadDoIt'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'preloadDoIt') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'baselineIssue215:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'baselineIssue215:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'customProjectAttributes'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'customProjectAttributes') asString)}.
-  configurationRepository
-    basicStoreVersion:
-      (MCVersion new
-        setPackage: (MCPackage new name: reference packageName)
-        info:
-          (versionInfo := MCVersionInfo
-            name: reference name
-            id: UUID new
-            message: 'This is a mock version'
-            date: Date today
-            time: Time now
-            author: reference author
-            ancestors: #())
-        snapshot: (MCSnapshot fromDefinitions: definitionArray)
-        dependencies: #()).
-  ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'BaselineOfIssue215-dkh.1'.
+	className := #BaselineOfIssue215.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #BaselineOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'postloadDoIt'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #postloadDoIt) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'preloadDoIt'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #preloadDoIt) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'baselineIssue215:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #baselineIssue215:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'customProjectAttributes'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #customProjectAttributes) asString) }.
+	configurationRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'issue 32' }
 MetacelloScriptingResource >> setUpBaselineIssue32 [
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'BaselineOfIssue32-dkh.1'.
-    className := #'BaselineOfIssue32'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'BaselineOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'postloadDoIt'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'postloadDoIt') asString).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'preloadDoIt'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'preloadDoIt') asString).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'baselineIssue32:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'baselineIssue32:') asString).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'customProjectAttributes'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'customProjectAttributes') asString)}.
-    externalRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'BaselineOfIssue32-dkh.1'.
+	className := #BaselineOfIssue32.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #BaselineOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'postloadDoIt'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #postloadDoIt) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'preloadDoIt'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #preloadDoIt) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'baselineIssue32:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #baselineIssue32:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'customProjectAttributes'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #customProjectAttributes) asString) }.
+	externalRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'issue 399' }
 MetacelloScriptingResource >> setUpBaselineIssue399 [
-  "self reset"
+	"self reset"
 
-  | reference className definitionArray versionInfo |
-  reference := GoferVersionReference name: 'BaselineOfIssue399-dkh.1'.
-  className := #'BaselineOfIssue399'.
-  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-  (MCClassDefinition
-    name: className
-    superclassName: #'BaselineOf'
-    category: reference packageName).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'baselineIssue399:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'baselineIssue399:') asString)}.
-  externalRepository
-    basicStoreVersion:
-      (MCVersion new
-        setPackage: (MCPackage new name: reference packageName)
-        info:
-          (versionInfo := MCVersionInfo
-            name: reference name
-            id: UUID new
-            message: 'This is a mock version'
-            date: Date today
-            time: Time now
-            author: reference author
-            ancestors: #())
-        snapshot: (MCSnapshot fromDefinitions: definitionArray)
-        dependencies: #()).
-  ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'BaselineOfIssue399-dkh.1'.
+	className := #BaselineOfIssue399.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #BaselineOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'baselineIssue399:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #baselineIssue399:) asString) }.
+	externalRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'issue 399' }
 MetacelloScriptingResource >> setUpBaselineIssue399Cypress [
-  "self reset"
+	"self reset"
 
-  | reference className definitionArray versionInfo |
-  reference := GoferVersionReference name: 'BaselineOfIssue399Cypress-dkh.1'.
-  className := #'BaselineOfIssue399Cypress'.
-  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-  (MCClassDefinition
-    name: className
-    superclassName: #'BaselineOf'
-    category: reference packageName).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'baselineIssue399:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'baselineIssue399:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'projectClass'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'projectClass') asString)}.
-  externalRepository
-    basicStoreVersion:
-      (MCVersion new
-        setPackage: (MCPackage new name: reference packageName)
-        info:
-          (versionInfo := MCVersionInfo
-            name: reference name
-            id: UUID new
-            message: 'This is a mock version'
-            date: Date today
-            time: Time now
-            author: reference author
-            ancestors: #())
-        snapshot: (MCSnapshot fromDefinitions: definitionArray)
-        dependencies: #()).
-  ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'BaselineOfIssue399Cypress-dkh.1'.
+	className := #BaselineOfIssue399Cypress.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #BaselineOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'baselineIssue399:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #baselineIssue399:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'projectClass'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #projectClass) asString) }.
+	externalRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'baseline pragma - external' }
 MetacelloScriptingResource >> setUpBaselineOfExternalX [
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'BaselineOfExternalX-dkh.1'.
-    className := #'BaselineOfExternalX'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'BaselineOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'externalBaselineX:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'externalBaselineX:') asString)}.
-    externalRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'BaselineOfExternalX-dkh.1'.
+	className := #BaselineOfExternalX.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #BaselineOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'externalBaselineX:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #externalBaselineX:) asString) }.
+	externalRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'baseline pragma - external' }
 MetacelloScriptingResource >> setUpBaselineOfExternalXX [
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'BaselineOfExternalXX-dkh.1'.
-    className := #'BaselineOfExternalXX'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'BaselineOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'externalBaselineXX:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'externalBaselineXX:') asString)}.
-    externalRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'BaselineOfExternalXX-dkh.1'.
+	className := #BaselineOfExternalXX.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #BaselineOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'externalBaselineXX:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #externalBaselineXX:) asString) }.
+	externalRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'baseline pragma - external' }
 MetacelloScriptingResource >> setUpBaselineOfExternalXXX [
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'BaselineOfExternalXXX-dkh.1'.
-    className := #'BaselineOfExternalXXX'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'BaselineOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'externalBaselineXXX:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'externalBaselineXXX:') asString).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'customProjectAttributes'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'customProjectAttributes') asString)}.
-    externalRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'BaselineOfExternalXXX-dkh.1'.
+	className := #BaselineOfExternalXXX.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #BaselineOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'externalBaselineXXX:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #externalBaselineXXX:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'customProjectAttributes'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #customProjectAttributes) asString) }.
+	externalRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'issue 63' }
 MetacelloScriptingResource >> setUpConfiguration181 [
-  "self reset"
+	"self reset"
 
-  | reference className definitionArray versionInfo |
-  reference := GoferVersionReference name: 'ConfigurationOfIssue181-dkh.1'.
-  className := #'ConfigurationOfIssue181'.
-  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-  (MCClassDefinition
-    name: className
-    superclassName: #'ConfigurationOf'
-    category: reference packageName).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'configuration091Issue181:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'configuration091Issue181:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'configuration092Issue181:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'configuration092Issue181:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'configuration093Issue185:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'configuration093Issue185:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'configuration094Issue185:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'configuration094Issue185:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'configuration095Issue185:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'configuration095Issue185:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'configuration096Issue185:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'configuration096Issue185:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'configuration097Issue185:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'configuration097Issue185:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'configuration098Issue215:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'configuration098Issue215:') asString)}.
-  configurationRepository
-    basicStoreVersion:
-      (MCVersion new
-        setPackage: (MCPackage new name: reference packageName)
-        info:
-          (versionInfo := MCVersionInfo
-            name: reference name
-            id: UUID new
-            message: 'This is a mock version'
-            date: Date today
-            time: Time now
-            author: reference author
-            ancestors: #())
-        snapshot: (MCSnapshot fromDefinitions: definitionArray)
-        dependencies: #()).
-  ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'ConfigurationOfIssue181-dkh.1'.
+	className := #ConfigurationOfIssue181.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #ConfigurationOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'configuration091Issue181:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #configuration091Issue181:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'configuration092Issue181:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #configuration092Issue181:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'configuration093Issue185:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #configuration093Issue185:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'configuration094Issue185:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #configuration094Issue185:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'configuration095Issue185:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #configuration095Issue185:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'configuration096Issue185:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #configuration096Issue185:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'configuration097Issue185:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #configuration097Issue185:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'configuration098Issue215:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #configuration098Issue215:) asString) }.
+	configurationRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'issue 63' }
 MetacelloScriptingResource >> setUpConfiguration63 [
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'ConfigurationOfIssue63-dkh.1'.
-    className := #'ConfigurationOfIssue63'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'ConfigurationOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'configuration091Issue63:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'configuration091Issue63:') asString).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'configuration092Issue63:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'configuration092Issue63:') asString)}.
-    configurationRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'ConfigurationOfIssue63-dkh.1'.
+	className := #ConfigurationOfIssue63.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #ConfigurationOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'configuration091Issue63:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #configuration091Issue63:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'configuration092Issue63:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #configuration092Issue63:) asString) }.
+	configurationRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'baseline pragma - github reference' }
@@ -1814,290 +1757,272 @@ MetacelloScriptingResource >> setUpConfigurationExternalRef [
 
 { #category : #'baseline pragma - github reference' }
 MetacelloScriptingResource >> setUpConfigurationExternalRefdkh1 [
-  "self reset"
+	"self reset"
 
-  | reference className definitionArray versionInfo |
-  reference := GoferVersionReference name: 'ConfigurationOfExternalRef-dkh.1'.
-  className := #'ConfigurationOfExternalRef'.
-  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-  (MCClassDefinition
-    name: className
-    superclassName: #'ConfigurationOf'
-    category: reference packageName).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'configurationExternalRef090:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'configurationExternalRef090:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'configurationExternalRef091:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'configurationExternalRef091:') asString)}.
-  externalRepository
-    basicStoreVersion:
-      (MCVersion new
-        setPackage: (MCPackage new name: reference packageName)
-        info:
-          (versionInfo := MCVersionInfo
-            name: reference name
-            id: UUID new
-            message: 'This is a mock version'
-            date: Date today
-            time: Time now
-            author: reference author
-            ancestors: #())
-        snapshot: (MCSnapshot fromDefinitions: definitionArray)
-        dependencies: #()).
-  ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'ConfigurationOfExternalRef-dkh.1'.
+	className := #ConfigurationOfExternalRef.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #ConfigurationOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'configurationExternalRef090:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #configurationExternalRef090:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'configurationExternalRef091:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #configurationExternalRef091:) asString) }.
+	externalRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'baseline pragma - github reference' }
 MetacelloScriptingResource >> setUpConfigurationExternalRefdkh2: ancestors [
-  "self reset"
+	"self reset"
 
-  | reference className definitionArray versionInfo |
-  reference := GoferVersionReference name: 'ConfigurationOfExternalRef-dkh.2'.
-  className := #'ConfigurationOfExternalRef'.
-  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-  (MCClassDefinition
-    name: className
-    superclassName: #'ConfigurationOf'
-    category: reference packageName).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'configurationExternalRef090:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'configurationExternalRef090:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'configurationExternalRef091:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'configurationExternalRef091:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'configurationExternalRef092:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'configurationExternalRef092:') asString)}.
-  externalRepository
-    basicStoreVersion:
-      (MCVersion new
-        setPackage: (MCPackage new name: reference packageName)
-        info:
-          (versionInfo := MCVersionInfo
-            name: reference name
-            id: UUID new
-            message: 'This is a mock version'
-            date: Date today
-            time: Time now
-            author: reference author
-            ancestors: ancestors)
-        snapshot: (MCSnapshot fromDefinitions: definitionArray)
-        dependencies: #()).
-  ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'ConfigurationOfExternalRef-dkh.2'.
+	className := #ConfigurationOfExternalRef.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #ConfigurationOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'configurationExternalRef090:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #configurationExternalRef090:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'configurationExternalRef091:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #configurationExternalRef091:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'configurationExternalRef092:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #configurationExternalRef092:) asString) }.
+	externalRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: ancestors)
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'issue 32' }
 MetacelloScriptingResource >> setUpConfigurationIssue32 [
-    "see https://github.com/dalehenrich/metacello-work/issues/32"
+	"see https://github.com/dalehenrich/metacello-work/issues/32"
 
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'ConfigurationOfIssue32-dkh.1'.
-    className := #'ConfigurationOfIssue32'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'ConfigurationOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'version10Issue47:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'version10Issue47:') asString).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'version09Issue32:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'version09Issue32:') asString).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'customProjectAttributes'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'customProjectAttributes') asString)}.
-    configurationRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'ConfigurationOfIssue32-dkh.1'.
+	className := #ConfigurationOfIssue32.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #ConfigurationOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'version10Issue47:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #version10Issue47:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'version09Issue32:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #version09Issue32:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'customProjectAttributes'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #customProjectAttributes) asString) }.
+	configurationRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'issue 339' }
 MetacelloScriptingResource >> setUpConfigurationIssue339 [
-  "see https://github.com/dalehenrich/metacello-work/issues/339"
+	"see https://github.com/dalehenrich/metacello-work/issues/339"
 
-  "self reset"
+	"self reset"
 
-  | reference className definitionArray versionInfo |
-  reference := GoferVersionReference name: 'ConfigurationOfIssue339-dkh.1'.
-  className := #'ConfigurationOfIssue339'.
-  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-  (MCClassDefinition
-    name: className
-    superclassName: #'ConfigurationOf'
-    category: reference packageName).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'version100Issue339:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'version100Issue339:') asString)}.
-  configurationRepository
-    basicStoreVersion:
-      (MCVersion new
-        setPackage: (MCPackage new name: reference packageName)
-        info:
-          (versionInfo := MCVersionInfo
-            name: reference name
-            id: UUID new
-            message: 'This is a mock version'
-            date: Date today
-            time: Time now
-            author: reference author
-            ancestors: #())
-        snapshot: (MCSnapshot fromDefinitions: definitionArray)
-        dependencies: #()).
-  ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'ConfigurationOfIssue339-dkh.1'.
+	className := #ConfigurationOfIssue339.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #ConfigurationOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'version100Issue339:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #version100Issue339:) asString) }.
+	configurationRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'issue 59' }
 MetacelloScriptingResource >> setUpConfigurationIssue59 [
-    "see https://github.com/dalehenrich/metacello-work/issues/59"
+	"see https://github.com/dalehenrich/metacello-work/issues/59"
 
-    "Use MetacelloVersionNumber instead of MetacelloSematicVersionNumber"
+	"Use MetacelloVersionNumber instead of MetacelloSematicVersionNumber"
 
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'ConfigurationOfIssue59-dkh.1'.
-    className := #'ConfigurationOfIssue59'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'ConfigurationOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'version10Issue59:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'version10Issue59:') asString).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'versionNumberClass'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'versionNumberClass') asString).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'customProjectAttributes'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'customProjectAttributes') asString)}.
-    configurationRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'ConfigurationOfIssue59-dkh.1'.
+	className := #ConfigurationOfIssue59.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #ConfigurationOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'version10Issue59:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #version10Issue59:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'versionNumberClass'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #versionNumberClass) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'customProjectAttributes'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #customProjectAttributes) asString) }.
+	configurationRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'issue 84' }
 MetacelloScriptingResource >> setUpConfigurationIssue84 [
-    "see https://github.com/dalehenrich/metacello-work/issues/84"
+	"see https://github.com/dalehenrich/metacello-work/issues/84"
 
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'ConfigurationOfIssue84-dkh.1'.
-    className := #'ConfigurationOfIssue84'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'ConfigurationOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'version10Issue84:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'version10Issue84:') asString).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'customProjectAttributes'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'customProjectAttributes') asString)}.
-    configurationRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'ConfigurationOfIssue84-dkh.1'.
+	className := #ConfigurationOfIssue84.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #ConfigurationOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'version10Issue84:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #version10Issue84:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'customProjectAttributes'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #customProjectAttributes) asString) }.
+	configurationRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'issue 84' }
@@ -2113,226 +2038,214 @@ MetacelloScriptingResource >> setUpConfigurationNextedIssue84 [
 
 { #category : #'issue 84' }
 MetacelloScriptingResource >> setUpConfigurationNextedIssue84dkh1 [
-    "see https://github.com/dalehenrich/metacello-work/issues/84"
+	"see https://github.com/dalehenrich/metacello-work/issues/84"
 
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'ConfigurationOfNestedIssue84-dkh.1'.
-    className := #'ConfigurationOfNestedIssue84'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'ConfigurationOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'version10NestedIssue84:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'version10NestedIssue84:') asString).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'versionNumberClass'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'versionNumberClass') asString).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'customProjectAttributes'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'customProjectAttributes') asString)}.
-    configurationRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'ConfigurationOfNestedIssue84-dkh.1'.
+	className := #ConfigurationOfNestedIssue84.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #ConfigurationOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'version10NestedIssue84:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #version10NestedIssue84:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'versionNumberClass'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #versionNumberClass) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'customProjectAttributes'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #customProjectAttributes) asString) }.
+	configurationRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'issue 84' }
 MetacelloScriptingResource >> setUpConfigurationNextedIssue84dkh2: ancestors [
-    "see https://github.com/dalehenrich/metacello-work/issues/84"
+	"see https://github.com/dalehenrich/metacello-work/issues/84"
 
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'ConfigurationOfNestedIssue84-dkh.2'.
-    className := #'ConfigurationOfNestedIssue84'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'ConfigurationOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'version10NestedIssue84:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'version10NestedIssue84:') asString).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'versionNumberClass'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'versionNumberClass') asString).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'customProjectAttributes'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'customProjectAttributes') asString)}.
-    configurationRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: ancestors)
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'ConfigurationOfNestedIssue84-dkh.2'.
+	className := #ConfigurationOfNestedIssue84.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #ConfigurationOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'version10NestedIssue84:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #version10NestedIssue84:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'versionNumberClass'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #versionNumberClass) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'customProjectAttributes'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #customProjectAttributes) asString) }.
+	configurationRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: ancestors)
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'baseline:with:' }
 MetacelloScriptingResource >> setUpConfigurationOfConflict [
-  "self reset"
+	"self reset"
 
-  | reference className definitionArray versionInfo |
-  reference := GoferVersionReference name: 'ConfigurationOfConflict-dkh.1'.
-  className := #'ConfigurationOfConflict'.
-  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-  (MCClassDefinition
-    name: className
-    superclassName: #'ConfigurationOf'
-    category: reference packageName).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'conflictOf20:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'conflictOf20:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'conflictOf21:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'conflictOf21:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'conflictOf10:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'conflictOf10:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'conflictOf11:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'conflictOf11:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'conflictOf12:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'conflictOf12:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'customProjectAttributes'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'customProjectAttributes') asString)}.
-  configurationRepository
-    basicStoreVersion:
-      (MCVersion new
-        setPackage: (MCPackage new name: reference packageName)
-        info:
-          (versionInfo := MCVersionInfo
-            name: reference name
-            id: UUID new
-            message: 'This is a mock version'
-            date: Date today
-            time: Time now
-            author: reference author
-            ancestors: #())
-        snapshot: (MCSnapshot fromDefinitions: definitionArray)
-        dependencies: #()).
-  ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'ConfigurationOfConflict-dkh.1'.
+	className := #ConfigurationOfConflict.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #ConfigurationOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'conflictOf20:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #conflictOf20:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'conflictOf21:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #conflictOf21:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'conflictOf10:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #conflictOf10:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'conflictOf11:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #conflictOf11:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'conflictOf12:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #conflictOf12:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'customProjectAttributes'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #customProjectAttributes) asString) }.
+	configurationRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'external configurations' }
 MetacelloScriptingResource >> setUpConfigurationOfExternalIV [
-    "see https://github.com/dalehenrich/metacello-work/issues/6"
+	"see https://github.com/dalehenrich/metacello-work/issues/6"
 
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'ConfigurationOfExternalIV-dkh.1'.
-    className := #'ConfigurationOfExternalIV'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'ConfigurationOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'versionOfIV:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'versionOfIV:') asString).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'customProjectAttributes'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'customProjectAttributes') asString)}.
-    configurationRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'ConfigurationOfExternalIV-dkh.1'.
+	className := #ConfigurationOfExternalIV.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #ConfigurationOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'versionOfIV:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #versionOfIV:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'customProjectAttributes'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #customProjectAttributes) asString) }.
+	configurationRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'external configurations' }
@@ -2346,280 +2259,262 @@ MetacelloScriptingResource >> setUpConfigurationOfExternalX [
 
 { #category : #'baseline:with:' }
 MetacelloScriptingResource >> setUpConfigurationOfExternalXX [
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'ConfigurationOfExternalXX-dkh.1'.
-    className := #'ConfigurationOfExternalXX'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'ConfigurationOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'versionOfXX:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'versionOfXX:') asString).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'customProjectAttributes'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'customProjectAttributes') asString)}.
-    configurationRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'ConfigurationOfExternalXX-dkh.1'.
+	className := #ConfigurationOfExternalXX.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #ConfigurationOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'versionOfXX:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #versionOfXX:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'customProjectAttributes'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #customProjectAttributes) asString) }.
+	configurationRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'external configurations' }
 MetacelloScriptingResource >> setUpConfigurationOfExternalXXX [
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'ConfigurationOfExternalXXX-dkh.1'.
-    className := #'ConfigurationOfExternalXXX'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'ConfigurationOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'versionOfXXX:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'versionOfXXX:') asString)}.
-    configurationRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'ConfigurationOfExternalXXX-dkh.1'.
+	className := #ConfigurationOfExternalXXX.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #ConfigurationOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'versionOfXXX:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #versionOfXXX:) asString) }.
+	configurationRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'external configurations' }
 MetacelloScriptingResource >> setUpConfigurationOfExternalXdkh1 [
-  "self reset"
+	"self reset"
 
-  | reference className definitionArray versionInfo |
-  reference := GoferVersionReference name: 'ConfigurationOfExternalX-dkh.1'.
-  className := #'ConfigurationOfExternalX'.
-  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-  (MCClassDefinition
-    name: className
-    superclassName: #'ConfigurationOf'
-    category: reference packageName).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'stableVersionOfX:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'stableVersionOfX:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'versionOfX090:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'versionOfX090:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'customProjectAttributes'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'customProjectAttributes') asString)}.
-  configurationRepository
-    basicStoreVersion:
-      (MCVersion new
-        setPackage: (MCPackage new name: reference packageName)
-        info:
-          (versionInfo := MCVersionInfo
-            name: reference name
-            id: UUID new
-            message: 'This is a mock version'
-            date: Date today
-            time: Time now
-            author: reference author
-            ancestors: #())
-        snapshot: (MCSnapshot fromDefinitions: definitionArray)
-        dependencies: #()).
-  ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'ConfigurationOfExternalX-dkh.1'.
+	className := #ConfigurationOfExternalX.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #ConfigurationOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'stableVersionOfX:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #stableVersionOfX:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'versionOfX090:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #versionOfX090:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'customProjectAttributes'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #customProjectAttributes) asString) }.
+	configurationRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'external configurations' }
 MetacelloScriptingResource >> setUpConfigurationOfExternalXdkh2: ancestors [
-  "self reset"
+	"self reset"
 
-  | reference className definitionArray versionInfo |
-  reference := GoferVersionReference name: 'ConfigurationOfExternalX-dkh.2'.
-  className := #'ConfigurationOfExternalX'.
-  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-  (MCClassDefinition
-    name: className
-    superclassName: #'ConfigurationOf'
-    category: reference packageName).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'stableVersionOfX:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'stableVersionOfX:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'unstableVersionOfX:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'unstableVersionOfX:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'versionOfX090:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'versionOfX090:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'versionOfX091:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'versionOfX091:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'customProjectAttributes'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'customProjectAttributes') asString)}.
-  configurationRepository
-    basicStoreVersion:
-      (MCVersion new
-        setPackage: (MCPackage new name: reference packageName)
-        info:
-          (versionInfo := MCVersionInfo
-            name: reference name
-            id: UUID new
-            message: 'This is a mock version'
-            date: Date today
-            time: Time now
-            author: reference author
-            ancestors: ancestors)
-        snapshot: (MCSnapshot fromDefinitions: definitionArray)
-        dependencies: #()).
-  ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'ConfigurationOfExternalX-dkh.2'.
+	className := #ConfigurationOfExternalX.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #ConfigurationOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'stableVersionOfX:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #stableVersionOfX:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'unstableVersionOfX:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #unstableVersionOfX:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'versionOfX090:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #versionOfX090:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'versionOfX091:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #versionOfX091:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'customProjectAttributes'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #customProjectAttributes) asString) }.
+	configurationRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: ancestors)
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'external configurations' }
 MetacelloScriptingResource >> setUpConfigurationOfExternaldkh1 [
-  "self reset"
+	"self reset"
 
-  | reference className definitionArray versionInfo |
-  reference := GoferVersionReference name: 'ConfigurationOfExternal-dkh.1'.
-  className := #'ConfigurationOfExternal'.
-  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-  (MCClassDefinition
-    name: className
-    superclassName: #'ConfigurationOf'
-    category: reference packageName).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'versionOfExternal090:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'versionOfExternal090:') asString)}.
-  externalRepository
-    basicStoreVersion:
-      (MCVersion new
-        setPackage: (MCPackage new name: reference packageName)
-        info:
-          (versionInfo := MCVersionInfo
-            name: reference name
-            id: UUID new
-            message: 'This is a mock version'
-            date: Date today
-            time: Time now
-            author: reference author
-            ancestors: #())
-        snapshot: (MCSnapshot fromDefinitions: definitionArray)
-        dependencies: #()).
-  ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'ConfigurationOfExternal-dkh.1'.
+	className := #ConfigurationOfExternal.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #ConfigurationOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'versionOfExternal090:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #versionOfExternal090:) asString) }.
+	externalRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'external configurations' }
 MetacelloScriptingResource >> setUpConfigurationOfExternaldkh2 [
-  "self reset"
+	"self reset"
 
-  | reference className definitionArray versionInfo |
-  reference := GoferVersionReference name: 'ConfigurationOfExternal-dkh.2'.
-  className := #'ConfigurationOfExternal'.
-  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-  (MCClassDefinition
-    name: className
-    superclassName: #'ConfigurationOf'
-    category: reference packageName).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'versionOfExternal090:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'versionOfExternal090:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'versionOfExternal091:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'versionOfExternal091:') asString)}.
-  externalRepository
-    basicStoreVersion:
-      (MCVersion new
-        setPackage: (MCPackage new name: reference packageName)
-        info:
-          (versionInfo := MCVersionInfo
-            name: reference name
-            id: UUID new
-            message: 'This is a mock version'
-            date: Date today
-            time: Time now
-            author: reference author
-            ancestors: #())
-        snapshot: (MCSnapshot fromDefinitions: definitionArray)
-        dependencies: #()).
-  ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'ConfigurationOfExternal-dkh.2'.
+	className := #ConfigurationOfExternal.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #ConfigurationOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'versionOfExternal090:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #versionOfExternal090:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'versionOfExternal091:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #versionOfExternal091:) asString) }.
+	externalRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'external core' }
@@ -2630,10 +2525,7 @@ MetacelloScriptingResource >> setUpExternalCore [
   reference := GoferVersionReference name: 'External-Core-dkh.1'.
   className := #'ExternalCore'.
   definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-  (MCClassDefinition
-    name: className
-    superclassName: #'Object'
-    category: reference packageName).
+  (MCClassDefinition named: className category: reference packageName).
   (MCMethodDefinition
     className: className asString
     classIsMeta: true
@@ -2674,10 +2566,7 @@ MetacelloScriptingResource >> setUpExternalCoreX [
   reference := GoferVersionReference name: 'External-CoreX-dkh.1'.
   className := #'ExternalCoreX'.
   definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-  (MCClassDefinition
-    name: className
-    superclassName: #'Object'
-    category: reference packageName).
+  (MCClassDefinition named: className category: reference packageName).
   (MCMethodDefinition
     className: className asString
     classIsMeta: true
@@ -2712,60 +2601,57 @@ MetacelloScriptingResource >> setUpExternalCoreX [
 
 { #category : #'invalid configurations' }
 MetacelloScriptingResource >> setUpInvalidConfigurations [
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'ConfigurationOfInvalidConfigurations-dkh.1'.
-    className := #'ConfigurationOfInvalidConfigurations'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'ConfigurationOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'invalidConfiguration10:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'invalidConfiguration10:') asString).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'invalidConfiguration20:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'invalidConfiguration20:') asString).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'invalidConfiguration30:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'invalidConfiguration30:') asString).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'customProjectAttributes'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'customProjectAttributes') asString)}.
-    configurationRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'ConfigurationOfInvalidConfigurations-dkh.1'.
+	className := #ConfigurationOfInvalidConfigurations.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #ConfigurationOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'invalidConfiguration10:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #invalidConfiguration10:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'invalidConfiguration20:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #invalidConfiguration20:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'invalidConfiguration30:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #invalidConfiguration30:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'customProjectAttributes'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #customProjectAttributes) asString) }.
+	configurationRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'issue 399' }
@@ -2794,10 +2680,7 @@ MetacelloScriptingResource >> setUpIssue399CoreExternaldkh1 [
   reference := GoferVersionReference name: 'Issue399-Core-dkh.1'.
   className := #'Issue399External'.
   definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-  (MCClassDefinition
-    name: className
-    superclassName: #'Object'
-    category: reference packageName)}.
+  (MCClassDefinition named: className category: reference packageName)}.
   externalRepository
     basicStoreVersion:
       (MCVersion new
@@ -2818,201 +2701,184 @@ MetacelloScriptingResource >> setUpIssue399CoreExternaldkh1 [
 
 { #category : #'issue 399' }
 MetacelloScriptingResource >> setUpIssue399CoreSampledkh1 [
-  "two packages with same name and version number, but a different class created."
+	"two packages with same name and version number, but a different class created."
 
-  "this on goes into the sample repository"
+	"this on goes into the sample repository"
 
-  "add first package to the package cache, then load a baseline in repo with other package"
+	"add first package to the package cache, then load a baseline in repo with other package"
 
-  "self reset"
+	"self reset"
 
-  | reference className definitionArray versionInfo |
-  reference := GoferVersionReference name: 'Issue399-Core-dkh.1'.
-  className := #'Issue399Sample'.
-  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-  (MCClassDefinition
-    name: className
-    superclassName: #'Object'
-    category: reference packageName)}.
-  sampleRepository
-    basicStoreVersion:
-      (MCVersion new
-        setPackage: (MCPackage new name: reference packageName)
-        info:
-          (versionInfo := MCVersionInfo
-            name: reference name
-            id: UUID new
-            message: 'This is a mock version'
-            date: Date today
-            time: Time now
-            author: reference author
-            ancestors: #())
-        snapshot: (MCSnapshot fromDefinitions: definitionArray)
-        dependencies: #()).
-  ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'Issue399-Core-dkh.1'.
+	className := #Issue399Sample.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   (MCClassDefinition named: className category: reference packageName) }.
+	sampleRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'issue 399' }
 MetacelloScriptingResource >> setUpIssue399CoreSampledkh2: ancestors [
-  "two packages with same name and version number, but a different class created."
+	"two packages with same name and version number, but a different class created."
 
-  "this on goes into the sample repository"
+	"this on goes into the sample repository"
 
-  "add first package to the package cache, then load a baseline in repo with other package"
+	"add first package to the package cache, then load a baseline in repo with other package"
 
-  "self reset"
+	"self reset"
 
-  | reference className definitionArray versionInfo |
-  reference := GoferVersionReference name: 'Issue399-Core-dkh.2'.
-  className := #'Issue399Sample'.
-  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-  (MCClassDefinition
-    name: className
-    superclassName: #'Object'
-    category: reference packageName)}.
-  sampleRepository
-    basicStoreVersion:
-      (MCVersion new
-        setPackage: (MCPackage new name: reference packageName)
-        info:
-          (versionInfo := MCVersionInfo
-            name: reference name
-            id: UUID new
-            message: 'This is a mock version'
-            date: Date today
-            time: Time now
-            author: reference author
-            ancestors: ancestors)
-        snapshot: (MCSnapshot fromDefinitions: definitionArray)
-        dependencies: #()).
-  ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'Issue399-Core-dkh.2'.
+	className := #Issue399Sample.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   (MCClassDefinition named: className category: reference packageName) }.
+	sampleRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: ancestors)
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #locking }
 MetacelloScriptingResource >> setUpLockConfigurations [
-  "self reset"
+	"self reset"
 
-  | reference className definitionArray versionInfo |
-  reference := GoferVersionReference
-    name: 'ConfigurationOfLockConfigurations-dkh.1'.
-  className := #'ConfigurationOfLockConfigurations'.
-  definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-  (MCClassDefinition
-    name: className
-    superclassName: #'ConfigurationOf'
-    category: reference packageName).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'lockConfiguration10:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'lockConfiguration10:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'lockConfiguration11:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'lockConfiguration11:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'lockConfiguration12:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'lockConfiguration12:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'lockConfiguration13:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'lockConfiguration13:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'lockConfiguration14:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'lockConfiguration14:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'lockConfiguration15:'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'lockConfiguration15:') asString).
-  (MCMethodDefinition
-    className: className asString
-    classIsMeta: false
-    selector: 'customProjectAttributes'
-    category: 'cat'
-    timeStamp: ''
-    source: (self class sourceCodeAt: #'customProjectAttributes') asString)}.
-  configurationRepository
-    basicStoreVersion:
-      (MCVersion new
-        setPackage: (MCPackage new name: reference packageName)
-        info:
-          (versionInfo := MCVersionInfo
-            name: reference name
-            id: UUID new
-            message: 'This is a mock version'
-            date: Date today
-            time: Time now
-            author: reference author
-            ancestors: #())
-        snapshot: (MCSnapshot fromDefinitions: definitionArray)
-        dependencies: #()).
-  ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'ConfigurationOfLockConfigurations-dkh.1'.
+	className := #ConfigurationOfLockConfigurations.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #ConfigurationOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'lockConfiguration10:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #lockConfiguration10:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'lockConfiguration11:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #lockConfiguration11:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'lockConfiguration12:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #lockConfiguration12:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'lockConfiguration13:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #lockConfiguration13:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'lockConfiguration14:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #lockConfiguration14:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'lockConfiguration15:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #lockConfiguration15:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'customProjectAttributes'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #customProjectAttributes) asString) }.
+	configurationRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'baseline:with:' }
 MetacelloScriptingResource >> setUpMarianosImage [
-    "className: test case
+	"className: test case
 	seehttps://github.com/dalehenrich/metacello-work/issues/24"
 
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'MarianosImage-dkh.1'.
-    className := #'MarianosImage'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'ConfigurationOf'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'versionOfMariano:'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'versionOfMariano:') asString).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: false
-        selector: 'customProjectAttributes'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'customProjectAttributes') asString)}.
-    configurationRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'MarianosImage-dkh.1'.
+	className := #MarianosImage.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   ((MCClassDefinition named: className category: reference packageName)
+			                    superclassName: #ConfigurationOf;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'versionOfMariano:'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #versionOfMariano:) asString).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: false
+			                    selector: 'customProjectAttributes'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #customProjectAttributes) asString) }.
+	configurationRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #running }
@@ -3026,50 +2892,44 @@ MetacelloScriptingResource >> setUpRepositories [
 
 { #category : #'sample repository' }
 MetacelloScriptingResource >> setUpSampleCore [
-    "self reset"
+	"self reset"
 
-    | reference className definitionArray versionInfo |
-    reference := GoferVersionReference name: 'Sample-CoreX-dkh.1'.
-    className := #'SampleCoreX'.
-    definitionArray := {(MCOrganizationDefinition packageName: reference packageName).
-    (MCClassDefinition
-        name: className
-        superclassName: #'Object'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: className asString
-        classIsMeta: true
-        selector: 'sampleAuthorName'
-        category: 'cat'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'sampleAuthorName') asString).
-    (MCClassDefinition
-        name: #'Object'
-        superclassName: #'ProtoObject'
-        category: reference packageName).
-    (MCMethodDefinition
-        className: 'Object'
-        classIsMeta: true
-        selector: 'isSample'
-        category: '*sample-core'
-        timeStamp: ''
-        source: (self class sourceCodeAt: #'isSample') asString)}.
-    sampleRepository
-        basicStoreVersion:
-            (MCVersion new
-                setPackage: (MCPackage new name: reference packageName)
-                info:
-                    (versionInfo := MCVersionInfo
-                        name: reference name
-                        id: UUID new
-                        message: 'This is a mock version'
-                        date: Date today
-                        time: Time now
-                        author: reference author
-                        ancestors: #())
-                snapshot: (MCSnapshot fromDefinitions: definitionArray)
-                dependencies: #()).
-    ^ versionInfo
+	| reference className definitionArray versionInfo |
+	reference := GoferVersionReference name: 'Sample-CoreX-dkh.1'.
+	className := #SampleCoreX.
+	definitionArray := {
+		                   (MCOrganizationDefinition packageName: reference packageName).
+		                   (MCClassDefinition named: className category: reference packageName).
+		                   (MCMethodDefinition
+			                    className: className asString
+			                    classIsMeta: true
+			                    selector: 'sampleAuthorName'
+			                    category: 'cat'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #sampleAuthorName) asString).
+		                   ((MCClassDefinition named: #Object category: reference packageName)
+			                    superclassName: #ProtoObject;
+			                    yourself).
+		                   (MCMethodDefinition
+			                    className: 'Object'
+			                    classIsMeta: true
+			                    selector: 'isSample'
+			                    category: '*sample-core'
+			                    timeStamp: ''
+			                    source: (self class sourceCodeAt: #isSample) asString) }.
+	sampleRepository basicStoreVersion: (MCVersion new
+			 setPackage: (MCPackage new name: reference packageName)
+			 info: (versionInfo := MCVersionInfo
+					                 name: reference name
+					                 id: UUID new
+					                 message: 'This is a mock version'
+					                 date: Date today
+					                 time: Time now
+					                 author: reference author
+					                 ancestors: #(  ))
+			 snapshot: (MCSnapshot fromDefinitions: definitionArray)
+			 dependencies: #(  )).
+	^ versionInfo
 ]
 
 { #category : #'external configurations' }

--- a/src/Metacello-TestsMCResources/MetacelloScriptingResource.class.st
+++ b/src/Metacello-TestsMCResources/MetacelloScriptingResource.class.st
@@ -999,8 +999,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceIV [
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1037,8 +1036,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceIX [
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1075,8 +1073,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceV [
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1113,8 +1110,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceVI [
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1151,8 +1147,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceVII [
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1189,8 +1184,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceVIII [
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1227,8 +1221,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceXI [
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1265,8 +1258,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceXII [
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1303,8 +1295,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceXIII [
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1341,8 +1332,7 @@ MetacelloScriptingResource >> setUpBaselineGithubReferenceXX [
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1379,8 +1369,7 @@ MetacelloScriptingResource >> setUpBaselineIssue215 [
   (MCClassDefinition
     name: className
     superclassName: #'BaselineOf'
-    category: reference packageName
-    instVarNames: #()).
+    category: reference packageName).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -1438,8 +1427,7 @@ MetacelloScriptingResource >> setUpBaselineIssue32 [
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1497,8 +1485,7 @@ MetacelloScriptingResource >> setUpBaselineIssue399 [
   (MCClassDefinition
     name: className
     superclassName: #'BaselineOf'
-    category: reference packageName
-    instVarNames: #()).
+    category: reference packageName).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -1535,8 +1522,7 @@ MetacelloScriptingResource >> setUpBaselineIssue399Cypress [
   (MCClassDefinition
     name: className
     superclassName: #'BaselineOf'
-    category: reference packageName
-    instVarNames: #()).
+    category: reference packageName).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -1580,8 +1566,7 @@ MetacelloScriptingResource >> setUpBaselineOfExternalX [
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1618,8 +1603,7 @@ MetacelloScriptingResource >> setUpBaselineOfExternalXX [
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1656,8 +1640,7 @@ MetacelloScriptingResource >> setUpBaselineOfExternalXXX [
     (MCClassDefinition
         name: className
         superclassName: #'BaselineOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1701,8 +1684,7 @@ MetacelloScriptingResource >> setUpConfiguration181 [
   (MCClassDefinition
     name: className
     superclassName: #'ConfigurationOf'
-    category: reference packageName
-    instVarNames: #()).
+    category: reference packageName).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -1788,8 +1770,7 @@ MetacelloScriptingResource >> setUpConfiguration63 [
     (MCClassDefinition
         name: className
         superclassName: #'ConfigurationOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1842,8 +1823,7 @@ MetacelloScriptingResource >> setUpConfigurationExternalRefdkh1 [
   (MCClassDefinition
     name: className
     superclassName: #'ConfigurationOf'
-    category: reference packageName
-    instVarNames: #()).
+    category: reference packageName).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -1887,8 +1867,7 @@ MetacelloScriptingResource >> setUpConfigurationExternalRefdkh2: ancestors [
   (MCClassDefinition
     name: className
     superclassName: #'ConfigurationOf'
-    category: reference packageName
-    instVarNames: #()).
+    category: reference packageName).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -1941,8 +1920,7 @@ MetacelloScriptingResource >> setUpConfigurationIssue32 [
     (MCClassDefinition
         name: className
         superclassName: #'ConfigurationOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -1995,8 +1973,7 @@ MetacelloScriptingResource >> setUpConfigurationIssue339 [
   (MCClassDefinition
     name: className
     superclassName: #'ConfigurationOf'
-    category: reference packageName
-    instVarNames: #()).
+    category: reference packageName).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -2037,8 +2014,7 @@ MetacelloScriptingResource >> setUpConfigurationIssue59 [
     (MCClassDefinition
         name: className
         superclassName: #'ConfigurationOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -2091,8 +2067,7 @@ MetacelloScriptingResource >> setUpConfigurationIssue84 [
     (MCClassDefinition
         name: className
         superclassName: #'ConfigurationOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -2149,8 +2124,7 @@ MetacelloScriptingResource >> setUpConfigurationNextedIssue84dkh1 [
     (MCClassDefinition
         name: className
         superclassName: #'ConfigurationOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -2203,8 +2177,7 @@ MetacelloScriptingResource >> setUpConfigurationNextedIssue84dkh2: ancestors [
     (MCClassDefinition
         name: className
         superclassName: #'ConfigurationOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -2255,8 +2228,7 @@ MetacelloScriptingResource >> setUpConfigurationOfConflict [
   (MCClassDefinition
     name: className
     superclassName: #'ConfigurationOf'
-    category: reference packageName
-    instVarNames: #()).
+    category: reference packageName).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -2330,8 +2302,7 @@ MetacelloScriptingResource >> setUpConfigurationOfExternalIV [
     (MCClassDefinition
         name: className
         superclassName: #'ConfigurationOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -2384,8 +2355,7 @@ MetacelloScriptingResource >> setUpConfigurationOfExternalXX [
     (MCClassDefinition
         name: className
         superclassName: #'ConfigurationOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -2429,8 +2399,7 @@ MetacelloScriptingResource >> setUpConfigurationOfExternalXXX [
     (MCClassDefinition
         name: className
         superclassName: #'ConfigurationOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -2467,8 +2436,7 @@ MetacelloScriptingResource >> setUpConfigurationOfExternalXdkh1 [
   (MCClassDefinition
     name: className
     superclassName: #'ConfigurationOf'
-    category: reference packageName
-    instVarNames: #()).
+    category: reference packageName).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -2519,8 +2487,7 @@ MetacelloScriptingResource >> setUpConfigurationOfExternalXdkh2: ancestors [
   (MCClassDefinition
     name: className
     superclassName: #'ConfigurationOf'
-    category: reference packageName
-    instVarNames: #()).
+    category: reference packageName).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -2585,8 +2552,7 @@ MetacelloScriptingResource >> setUpConfigurationOfExternaldkh1 [
   (MCClassDefinition
     name: className
     superclassName: #'ConfigurationOf'
-    category: reference packageName
-    instVarNames: #()).
+    category: reference packageName).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -2623,8 +2589,7 @@ MetacelloScriptingResource >> setUpConfigurationOfExternaldkh2 [
   (MCClassDefinition
     name: className
     superclassName: #'ConfigurationOf'
-    category: reference packageName
-    instVarNames: #()).
+    category: reference packageName).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -2668,8 +2633,7 @@ MetacelloScriptingResource >> setUpExternalCore [
   (MCClassDefinition
     name: className
     superclassName: #'Object'
-    category: reference packageName
-    instVarNames: #()).
+    category: reference packageName).
   (MCMethodDefinition
     className: className asString
     classIsMeta: true
@@ -2713,8 +2677,7 @@ MetacelloScriptingResource >> setUpExternalCoreX [
   (MCClassDefinition
     name: className
     superclassName: #'Object'
-    category: reference packageName
-    instVarNames: #()).
+    category: reference packageName).
   (MCMethodDefinition
     className: className asString
     classIsMeta: true
@@ -2758,8 +2721,7 @@ MetacelloScriptingResource >> setUpInvalidConfigurations [
     (MCClassDefinition
         name: className
         superclassName: #'ConfigurationOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -2835,8 +2797,7 @@ MetacelloScriptingResource >> setUpIssue399CoreExternaldkh1 [
   (MCClassDefinition
     name: className
     superclassName: #'Object'
-    category: reference packageName
-    instVarNames: #())}.
+    category: reference packageName)}.
   externalRepository
     basicStoreVersion:
       (MCVersion new
@@ -2872,8 +2833,7 @@ MetacelloScriptingResource >> setUpIssue399CoreSampledkh1 [
   (MCClassDefinition
     name: className
     superclassName: #'Object'
-    category: reference packageName
-    instVarNames: #())}.
+    category: reference packageName)}.
   sampleRepository
     basicStoreVersion:
       (MCVersion new
@@ -2909,8 +2869,7 @@ MetacelloScriptingResource >> setUpIssue399CoreSampledkh2: ancestors [
   (MCClassDefinition
     name: className
     superclassName: #'Object'
-    category: reference packageName
-    instVarNames: #())}.
+    category: reference packageName)}.
   sampleRepository
     basicStoreVersion:
       (MCVersion new
@@ -2941,8 +2900,7 @@ MetacelloScriptingResource >> setUpLockConfigurations [
   (MCClassDefinition
     name: className
     superclassName: #'ConfigurationOf'
-    category: reference packageName
-    instVarNames: #()).
+    category: reference packageName).
   (MCMethodDefinition
     className: className asString
     classIsMeta: false
@@ -3024,8 +2982,7 @@ MetacelloScriptingResource >> setUpMarianosImage [
     (MCClassDefinition
         name: className
         superclassName: #'ConfigurationOf'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: false
@@ -3078,8 +3035,7 @@ MetacelloScriptingResource >> setUpSampleCore [
     (MCClassDefinition
         name: className
         superclassName: #'Object'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: className asString
         classIsMeta: true
@@ -3090,8 +3046,7 @@ MetacelloScriptingResource >> setUpSampleCore [
     (MCClassDefinition
         name: #'Object'
         superclassName: #'ProtoObject'
-        category: reference packageName
-        instVarNames: #()).
+        category: reference packageName).
     (MCMethodDefinition
         className: 'Object'
         classIsMeta: true

--- a/src/Monticello-Tests/MCClassDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCClassDefinitionTest.class.st
@@ -108,8 +108,8 @@ MCClassDefinitionTest >> testEqualsSensitivity [
 		         superclassName: 'SuperA'
 		         traitComposition: '{}'
 		         classTraitComposition: '{}'
-		         category: 'CategoryA'
-		         instVarNames: #( iVarA ))
+		         category: 'CategoryA')
+		        instVarNames: #( iVarA );
 		        classVarNames: #( cVarB );
 		        poolDictionaryNames: #( PoolA );
 		        classInstVarNames: #( ciVarA );
@@ -184,8 +184,7 @@ MCClassDefinitionTest >> testValidTraitComposition [
 		      superclassName: 'Object'
 		      traitComposition: '{MCTraitMock1}'
 		      classTraitComposition: '{}'
-		      category: self mockCategoryName
-		      instVarNames: #(  ))
+		      category: self mockCategoryName)
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
@@ -207,8 +206,7 @@ MCClassDefinitionTest >> testValidTraitComposition2 [
 		      superclassName: 'Object'
 		      traitComposition: 'MCTraitMock1'
 		      classTraitComposition: '{}'
-		      category: self mockCategoryName
-		      instVarNames: #(  ))
+		      category: self mockCategoryName)
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
@@ -230,8 +228,7 @@ MCClassDefinitionTest >> testValidTraitComposition3 [
 		      superclassName: 'Object'
 		      traitComposition: 'MCTraitMock1 + MCTraitMock2'
 		      classTraitComposition: '{}'
-		      category: self mockCategoryName
-		      instVarNames: #(  ))
+		      category: self mockCategoryName)
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
@@ -255,8 +252,7 @@ MCClassDefinitionTest >> testValidTraitComposition4 [
 		      superclassName: 'Object'
 		      traitComposition: 'MCTraitMock1 - {#c1}'
 		      classTraitComposition: '{}'
-		      category: self mockCategoryName
-		      instVarNames: #(  ))
+		      category: self mockCategoryName)
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.

--- a/src/Monticello-Tests/MCClassDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCClassDefinitionTest.class.st
@@ -112,8 +112,8 @@ MCClassDefinitionTest >> testEqualsSensitivity [
 		         instVarNames: #( iVarA )
 		         classVarNames: #( cVarB )
 		         poolDictionaryNames: #( PoolA )
-		         classInstVarNames: #( ciVarA )
-		         type: #typeA)
+		         classInstVarNames: #( ciVarA ))
+		        type: #typeA;
 		        comment: 'A comment';
 		        commentStamp: 'A';
 		        yourself.
@@ -188,8 +188,7 @@ MCClassDefinitionTest >> testValidTraitComposition [
 		      instVarNames: #(  )
 		      classVarNames: #(  )
 		      poolDictionaryNames: #(  )
-		      classInstVarNames: #(  )
-		      type: #normal)
+		      classInstVarNames: #(  ))
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
@@ -215,8 +214,7 @@ MCClassDefinitionTest >> testValidTraitComposition2 [
 		      instVarNames: #(  )
 		      classVarNames: #(  )
 		      poolDictionaryNames: #(  )
-		      classInstVarNames: #(  )
-		      type: #normal)
+		      classInstVarNames: #(  ))
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
@@ -242,8 +240,7 @@ MCClassDefinitionTest >> testValidTraitComposition3 [
 		      instVarNames: #(  )
 		      classVarNames: #(  )
 		      poolDictionaryNames: #(  )
-		      classInstVarNames: #(  )
-		      type: #normal)
+		      classInstVarNames: #(  ))
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
@@ -271,8 +268,7 @@ MCClassDefinitionTest >> testValidTraitComposition4 [
 		      instVarNames: #(  )
 		      classVarNames: #(  )
 		      poolDictionaryNames: #(  )
-		      classInstVarNames: #(  )
-		      type: #normal)
+		      classInstVarNames: #(  ))
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.

--- a/src/Monticello-Tests/MCClassDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCClassDefinitionTest.class.st
@@ -101,21 +101,47 @@ MCClassDefinitionTest >> testEquals [
 
 { #category : #tests }
 MCClassDefinitionTest >> testEqualsSensitivity [
-	| message a b defA args defB |
-	
-	message := MessageSend 
-		receiver: MCClassDefinition 
-		selector:#name:superclassName:traitComposition:classTraitComposition:category:instVarNames:classVarNames:poolDictionaryNames:classInstVarNames:type:comment:commentStamp:.
-	
-	a := #(ClassA SuperA '{}' '{}' CategoryA #(iVarA) #(CVarA) #(PoolA) #(ciVarA) typeA 'A comment' 'A').
-	b := #(ClassB SuperB 'T' 'T classTrait' CategoryB #(iVarB) #(CVarB) #(PoolB) #(ciVarB) typeB 'B comment' 'B').
 
-	defA := message valueWithArguments: a.
-	1 to: 8 do: [ :index | 
-		args := a copy.
-		args at: index put: (b at: index).
-		defB := message valueWithArguments: args.
-		self deny: defA equals: defB ]
+	| defA defB |
+	defA := (MCClassDefinition
+		         name: 'ClassA'
+		         superclassName: 'SuperA'
+		         traitComposition: '{}'
+		         classTraitComposition: '{}'
+		         category: 'CategoryA'
+		         instVarNames: #( iVarA )
+		         classVarNames: #( cVarB )
+		         poolDictionaryNames: #( PoolA )
+		         classInstVarNames: #( ciVarA )
+		         type: #typeA
+		         comment: 'A comment')
+		        commentStamp: 'A';
+		        yourself.
+
+	defB := defA copy name: 'ClassB'.
+	self deny: defA equals: defB.
+	defB := defA copy superclassName: 'SuperB'.
+	self deny: defA equals: defB.
+	defB := defA copy traitComposition: 'T'.
+	self deny: defA equals: defB.
+	defB := defA copy classTraitComposition: 'T'.
+	self deny: defA equals: defB.
+	defB := defA copy category: 'CategoryB'.
+	self deny: defA equals: defB.
+	defB := defA copy instVarNames: #( iVarB ).
+	self deny: defA equals: defB.
+	defB := defA copy classVarNames: #( cVarB ).
+	self deny: defA equals: defB.
+	defB := defA copy poolDictionaryNames: #( PoolB ).
+	self deny: defA equals: defB.
+	defB := defA copy classInstVarNames: #( ciVarB ).
+	self deny: defA equals: defB.
+	defB := defA copy type: 'typeB'.
+	self deny: defA equals: defB.
+	defB := defA copy comment: 'B comment'.
+	self deny: defA equals: defB.
+	defB := defA copy commentStamp: 'B'.
+	self deny: defA equals: defB
 ]
 
 { #category : #tests }
@@ -153,19 +179,20 @@ MCClassDefinitionTest >> testValidTraitComposition [
 
 	| d className cls |
 	className := 'MCMockClassC'.
-	d := MCClassDefinition
-		name: className
-		superclassName: 'Object'
-		traitComposition: '{MCTraitMock1}'
-		classTraitComposition: '{}'
-		category: self mockCategoryName
-		instVarNames: #()
-		classVarNames: #()
-		poolDictionaryNames: #()
-		classInstVarNames: #()
-		type: #normal
-		comment: (self commentForClass: className)
-		commentStamp: (self commentStampForClass: className).
+	d := (MCClassDefinition
+		      name: className
+		      superclassName: 'Object'
+		      traitComposition: '{MCTraitMock1}'
+		      classTraitComposition: '{}'
+		      category: self mockCategoryName
+		      instVarNames: #(  )
+		      classVarNames: #(  )
+		      poolDictionaryNames: #(  )
+		      classInstVarNames: #(  )
+		      type: #normal
+		      comment: (self commentForClass: className))
+		     commentStamp: (self commentStampForClass: className);
+		     yourself.
 	d load.
 	self assert: (testingEnvironment hasClassNamed: 'MCMockClassC').
 	cls := testingEnvironment at: #MCMockClassC.
@@ -179,19 +206,20 @@ MCClassDefinitionTest >> testValidTraitComposition2 [
 
 	| d className cls |
 	className := 'MCMockClassC'.
-	d := MCClassDefinition
-		name: className
-		superclassName: 'Object'
-		traitComposition: 'MCTraitMock1'
-		classTraitComposition: '{}'
-		category: self mockCategoryName
-		instVarNames: #()
-		classVarNames: #()
-		poolDictionaryNames: #()
-		classInstVarNames: #()
-		type: #normal
-		comment: (self commentForClass: className)
-		commentStamp: (self commentStampForClass: className).
+	d := (MCClassDefinition
+		      name: className
+		      superclassName: 'Object'
+		      traitComposition: 'MCTraitMock1'
+		      classTraitComposition: '{}'
+		      category: self mockCategoryName
+		      instVarNames: #(  )
+		      classVarNames: #(  )
+		      poolDictionaryNames: #(  )
+		      classInstVarNames: #(  )
+		      type: #normal
+		      comment: (self commentForClass: className))
+		     commentStamp: (self commentStampForClass: className);
+		     yourself.
 	d load.
 	self assert: (testingEnvironment hasClassNamed: 'MCMockClassC').
 	cls := testingEnvironment at: #MCMockClassC.
@@ -205,19 +233,20 @@ MCClassDefinitionTest >> testValidTraitComposition3 [
 
 	| d className cls |
 	className := 'MCMockClassC'.
-	d := MCClassDefinition
-		name: className
-		superclassName: 'Object'
-		traitComposition: 'MCTraitMock1 + MCTraitMock2'
-		classTraitComposition: '{}'
-		category: self mockCategoryName
-		instVarNames: #()
-		classVarNames: #()
-		poolDictionaryNames: #()
-		classInstVarNames: #()
-		type: #normal
-		comment: (self commentForClass: className)
-		commentStamp: (self commentStampForClass: className).
+	d := (MCClassDefinition
+		      name: className
+		      superclassName: 'Object'
+		      traitComposition: 'MCTraitMock1 + MCTraitMock2'
+		      classTraitComposition: '{}'
+		      category: self mockCategoryName
+		      instVarNames: #(  )
+		      classVarNames: #(  )
+		      poolDictionaryNames: #(  )
+		      classInstVarNames: #(  )
+		      type: #normal
+		      comment: (self commentForClass: className))
+		     commentStamp: (self commentStampForClass: className);
+		     yourself.
 	d load.
 	self assert: (testingEnvironment hasClassNamed: 'MCMockClassC').
 	cls := testingEnvironment at: #MCMockClassC.
@@ -233,22 +262,23 @@ MCClassDefinitionTest >> testValidTraitComposition4 [
 
 	| d className cls |
 	className := 'MCMockClassC'.
-	d := MCClassDefinition
-		name: className
-		superclassName: 'Object'
-		traitComposition: 'MCTraitMock1 - {#c1}'
-		classTraitComposition: '{}'
-		category: self mockCategoryName
-		instVarNames: #()
-		classVarNames: #()
-		poolDictionaryNames: #()
-		classInstVarNames: #()
-		type: #normal
-		comment: (self commentForClass: className)
-		commentStamp: (self commentStampForClass: className).
+	d := (MCClassDefinition
+		      name: className
+		      superclassName: 'Object'
+		      traitComposition: 'MCTraitMock1 - {#c1}'
+		      classTraitComposition: '{}'
+		      category: self mockCategoryName
+		      instVarNames: #(  )
+		      classVarNames: #(  )
+		      poolDictionaryNames: #(  )
+		      classInstVarNames: #(  )
+		      type: #normal
+		      comment: (self commentForClass: className))
+		     commentStamp: (self commentStampForClass: className);
+		     yourself.
 	d load.
 	self assert: (testingEnvironment hasClassNamed: 'MCMockClassC').
 	cls := testingEnvironment at: #MCMockClassC.
-	self assert: (cls selectors includesAll: {#c}).
-	self deny: (cls selectors includesAnyOf: {#c1})
+	self assert: (cls selectors includesAll: { #c }).
+	self deny: (cls selectors includesAnyOf: { #c1 })
 ]

--- a/src/Monticello-Tests/MCClassDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCClassDefinitionTest.class.st
@@ -107,8 +107,8 @@ MCClassDefinitionTest >> testEqualsSensitivity [
 		         name: 'ClassA'
 		         superclassName: 'SuperA'
 		         traitComposition: '{}'
-		         classTraitComposition: '{}'
-		         category: 'CategoryA')
+		         classTraitComposition: '{}')
+		        category: 'CategoryA';
 		        instVarNames: #( iVarA );
 		        classVarNames: #( cVarB );
 		        poolDictionaryNames: #( PoolA );
@@ -183,8 +183,8 @@ MCClassDefinitionTest >> testValidTraitComposition [
 		      name: className
 		      superclassName: 'Object'
 		      traitComposition: '{MCTraitMock1}'
-		      classTraitComposition: '{}'
-		      category: self mockCategoryName)
+		      classTraitComposition: '{}')
+		     category: self mockCategoryName;
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
@@ -205,8 +205,8 @@ MCClassDefinitionTest >> testValidTraitComposition2 [
 		      name: className
 		      superclassName: 'Object'
 		      traitComposition: 'MCTraitMock1'
-		      classTraitComposition: '{}'
-		      category: self mockCategoryName)
+		      classTraitComposition: '{}')
+		     category: self mockCategoryName;
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
@@ -227,8 +227,8 @@ MCClassDefinitionTest >> testValidTraitComposition3 [
 		      name: className
 		      superclassName: 'Object'
 		      traitComposition: 'MCTraitMock1 + MCTraitMock2'
-		      classTraitComposition: '{}'
-		      category: self mockCategoryName)
+		      classTraitComposition: '{}')
+		     category: self mockCategoryName;
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
@@ -251,8 +251,8 @@ MCClassDefinitionTest >> testValidTraitComposition4 [
 		      name: className
 		      superclassName: 'Object'
 		      traitComposition: 'MCTraitMock1 - {#c1}'
-		      classTraitComposition: '{}'
-		      category: self mockCategoryName)
+		      classTraitComposition: '{}')
+		     category: self mockCategoryName;
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.

--- a/src/Monticello-Tests/MCClassDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCClassDefinitionTest.class.st
@@ -103,11 +103,8 @@ MCClassDefinitionTest >> testEquals [
 MCClassDefinitionTest >> testEqualsSensitivity [
 
 	| defA defB |
-	defA := (MCClassDefinition
-		         name: 'ClassA'
-		         superclassName: 'SuperA'
-		         traitComposition: '{}'
-		         classTraitComposition: '{}')
+	defA := (MCClassDefinition named: 'ClassA')
+		        superclassName: 'SuperA';
 		        category: 'CategoryA';
 		        instVarNames: #( iVarA );
 		        classVarNames: #( cVarB );
@@ -115,7 +112,6 @@ MCClassDefinitionTest >> testEqualsSensitivity [
 		        classInstVarNames: #( ciVarA );
 		        type: #typeA;
 		        comment: 'A comment';
-		        commentStamp: 'A';
 		        yourself.
 
 	defB := defA copy name: 'ClassB'.
@@ -139,8 +135,6 @@ MCClassDefinitionTest >> testEqualsSensitivity [
 	defB := defA copy type: 'typeB'.
 	self deny: defA equals: defB.
 	defB := defA copy comment: 'B comment'.
-	self deny: defA equals: defB.
-	defB := defA copy commentStamp: 'B'.
 	self deny: defA equals: defB
 ]
 
@@ -179,11 +173,8 @@ MCClassDefinitionTest >> testValidTraitComposition [
 
 	| d className cls |
 	className := 'MCMockClassC'.
-	d := (MCClassDefinition
-		      name: className
-		      superclassName: 'Object'
-		      traitComposition: '{MCTraitMock1}'
-		      classTraitComposition: '{}')
+	d := (MCClassDefinition named: className)
+		     traitComposition: '{MCTraitMock1}';
 		     category: self mockCategoryName;
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
@@ -201,11 +192,8 @@ MCClassDefinitionTest >> testValidTraitComposition2 [
 
 	| d className cls |
 	className := 'MCMockClassC'.
-	d := (MCClassDefinition
-		      name: className
-		      superclassName: 'Object'
-		      traitComposition: 'MCTraitMock1'
-		      classTraitComposition: '{}')
+	d := (MCClassDefinition named: className)
+		     traitComposition: 'MCTraitMock1';
 		     category: self mockCategoryName;
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
@@ -223,11 +211,8 @@ MCClassDefinitionTest >> testValidTraitComposition3 [
 
 	| d className cls |
 	className := 'MCMockClassC'.
-	d := (MCClassDefinition
-		      name: className
-		      superclassName: 'Object'
-		      traitComposition: 'MCTraitMock1 + MCTraitMock2'
-		      classTraitComposition: '{}')
+	d := (MCClassDefinition named: className)
+		     traitComposition: 'MCTraitMock1 + MCTraitMock2';
 		     category: self mockCategoryName;
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
@@ -247,11 +232,8 @@ MCClassDefinitionTest >> testValidTraitComposition4 [
 
 	| d className cls |
 	className := 'MCMockClassC'.
-	d := (MCClassDefinition
-		      name: className
-		      superclassName: 'Object'
-		      traitComposition: 'MCTraitMock1 - {#c1}'
-		      classTraitComposition: '{}')
+	d := (MCClassDefinition named: className)
+		     traitComposition: 'MCTraitMock1 - {#c1}';
 		     category: self mockCategoryName;
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);

--- a/src/Monticello-Tests/MCClassDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCClassDefinitionTest.class.st
@@ -110,8 +110,8 @@ MCClassDefinitionTest >> testEqualsSensitivity [
 		         classTraitComposition: '{}'
 		         category: 'CategoryA'
 		         instVarNames: #( iVarA )
-		         classVarNames: #( cVarB )
-		         poolDictionaryNames: #( PoolA ))
+		         classVarNames: #( cVarB ))
+		        poolDictionaryNames: #( PoolA );
 		        classInstVarNames: #( ciVarA );
 		        type: #typeA;
 		        comment: 'A comment';
@@ -186,8 +186,7 @@ MCClassDefinitionTest >> testValidTraitComposition [
 		      classTraitComposition: '{}'
 		      category: self mockCategoryName
 		      instVarNames: #(  )
-		      classVarNames: #(  )
-		      poolDictionaryNames: #(  ))
+		      classVarNames: #(  ))
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
@@ -211,8 +210,7 @@ MCClassDefinitionTest >> testValidTraitComposition2 [
 		      classTraitComposition: '{}'
 		      category: self mockCategoryName
 		      instVarNames: #(  )
-		      classVarNames: #(  )
-		      poolDictionaryNames: #(  ))
+		      classVarNames: #(  ))
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
@@ -236,8 +234,7 @@ MCClassDefinitionTest >> testValidTraitComposition3 [
 		      classTraitComposition: '{}'
 		      category: self mockCategoryName
 		      instVarNames: #(  )
-		      classVarNames: #(  )
-		      poolDictionaryNames: #(  ))
+		      classVarNames: #(  ))
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
@@ -263,8 +260,7 @@ MCClassDefinitionTest >> testValidTraitComposition4 [
 		      classTraitComposition: '{}'
 		      category: self mockCategoryName
 		      instVarNames: #(  )
-		      classVarNames: #(  )
-		      poolDictionaryNames: #(  ))
+		      classVarNames: #(  ))
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.

--- a/src/Monticello-Tests/MCClassDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCClassDefinitionTest.class.st
@@ -113,8 +113,8 @@ MCClassDefinitionTest >> testEqualsSensitivity [
 		         classVarNames: #( cVarB )
 		         poolDictionaryNames: #( PoolA )
 		         classInstVarNames: #( ciVarA )
-		         type: #typeA
-		         comment: 'A comment')
+		         type: #typeA)
+		        comment: 'A comment';
 		        commentStamp: 'A';
 		        yourself.
 
@@ -189,8 +189,8 @@ MCClassDefinitionTest >> testValidTraitComposition [
 		      classVarNames: #(  )
 		      poolDictionaryNames: #(  )
 		      classInstVarNames: #(  )
-		      type: #normal
-		      comment: (self commentForClass: className))
+		      type: #normal)
+		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
 	d load.
@@ -216,8 +216,8 @@ MCClassDefinitionTest >> testValidTraitComposition2 [
 		      classVarNames: #(  )
 		      poolDictionaryNames: #(  )
 		      classInstVarNames: #(  )
-		      type: #normal
-		      comment: (self commentForClass: className))
+		      type: #normal)
+		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
 	d load.
@@ -243,8 +243,8 @@ MCClassDefinitionTest >> testValidTraitComposition3 [
 		      classVarNames: #(  )
 		      poolDictionaryNames: #(  )
 		      classInstVarNames: #(  )
-		      type: #normal
-		      comment: (self commentForClass: className))
+		      type: #normal)
+		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
 	d load.
@@ -272,8 +272,8 @@ MCClassDefinitionTest >> testValidTraitComposition4 [
 		      classVarNames: #(  )
 		      poolDictionaryNames: #(  )
 		      classInstVarNames: #(  )
-		      type: #normal
-		      comment: (self commentForClass: className))
+		      type: #normal)
+		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
 	d load.

--- a/src/Monticello-Tests/MCClassDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCClassDefinitionTest.class.st
@@ -109,8 +109,8 @@ MCClassDefinitionTest >> testEqualsSensitivity [
 		         traitComposition: '{}'
 		         classTraitComposition: '{}'
 		         category: 'CategoryA'
-		         instVarNames: #( iVarA )
-		         classVarNames: #( cVarB ))
+		         instVarNames: #( iVarA ))
+		        classVarNames: #( cVarB );
 		        poolDictionaryNames: #( PoolA );
 		        classInstVarNames: #( ciVarA );
 		        type: #typeA;
@@ -185,8 +185,7 @@ MCClassDefinitionTest >> testValidTraitComposition [
 		      traitComposition: '{MCTraitMock1}'
 		      classTraitComposition: '{}'
 		      category: self mockCategoryName
-		      instVarNames: #(  )
-		      classVarNames: #(  ))
+		      instVarNames: #(  ))
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
@@ -209,8 +208,7 @@ MCClassDefinitionTest >> testValidTraitComposition2 [
 		      traitComposition: 'MCTraitMock1'
 		      classTraitComposition: '{}'
 		      category: self mockCategoryName
-		      instVarNames: #(  )
-		      classVarNames: #(  ))
+		      instVarNames: #(  ))
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
@@ -233,8 +231,7 @@ MCClassDefinitionTest >> testValidTraitComposition3 [
 		      traitComposition: 'MCTraitMock1 + MCTraitMock2'
 		      classTraitComposition: '{}'
 		      category: self mockCategoryName
-		      instVarNames: #(  )
-		      classVarNames: #(  ))
+		      instVarNames: #(  ))
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
@@ -259,8 +256,7 @@ MCClassDefinitionTest >> testValidTraitComposition4 [
 		      traitComposition: 'MCTraitMock1 - {#c1}'
 		      classTraitComposition: '{}'
 		      category: self mockCategoryName
-		      instVarNames: #(  )
-		      classVarNames: #(  ))
+		      instVarNames: #(  ))
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.

--- a/src/Monticello-Tests/MCClassDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCClassDefinitionTest.class.st
@@ -111,8 +111,8 @@ MCClassDefinitionTest >> testEqualsSensitivity [
 		         category: 'CategoryA'
 		         instVarNames: #( iVarA )
 		         classVarNames: #( cVarB )
-		         poolDictionaryNames: #( PoolA )
-		         classInstVarNames: #( ciVarA ))
+		         poolDictionaryNames: #( PoolA ))
+		        classInstVarNames: #( ciVarA );
 		        type: #typeA;
 		        comment: 'A comment';
 		        commentStamp: 'A';
@@ -187,8 +187,7 @@ MCClassDefinitionTest >> testValidTraitComposition [
 		      category: self mockCategoryName
 		      instVarNames: #(  )
 		      classVarNames: #(  )
-		      poolDictionaryNames: #(  )
-		      classInstVarNames: #(  ))
+		      poolDictionaryNames: #(  ))
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
@@ -213,8 +212,7 @@ MCClassDefinitionTest >> testValidTraitComposition2 [
 		      category: self mockCategoryName
 		      instVarNames: #(  )
 		      classVarNames: #(  )
-		      poolDictionaryNames: #(  )
-		      classInstVarNames: #(  ))
+		      poolDictionaryNames: #(  ))
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
@@ -239,8 +237,7 @@ MCClassDefinitionTest >> testValidTraitComposition3 [
 		      category: self mockCategoryName
 		      instVarNames: #(  )
 		      classVarNames: #(  )
-		      poolDictionaryNames: #(  )
-		      classInstVarNames: #(  ))
+		      poolDictionaryNames: #(  ))
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
@@ -267,8 +264,7 @@ MCClassDefinitionTest >> testValidTraitComposition4 [
 		      category: self mockCategoryName
 		      instVarNames: #(  )
 		      classVarNames: #(  )
-		      poolDictionaryNames: #(  )
-		      classInstVarNames: #(  ))
+		      poolDictionaryNames: #(  ))
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.

--- a/src/Monticello-Tests/MCSortingTest.class.st
+++ b/src/Monticello-Tests/MCSortingTest.class.st
@@ -11,11 +11,8 @@ MCSortingTest class >> isUnitTest [
 
 { #category : #building }
 MCSortingTest >> classNamed: aSymbol [
-	^ MCClassDefinition
-		name: aSymbol
-		superclassName: #Object
-		category: ''
-		instVarNames: #()
+
+	^ MCClassDefinition name: aSymbol superclassName: #Object category: ''
 ]
 
 { #category : #building }

--- a/src/Monticello-Tests/MCSortingTest.class.st
+++ b/src/Monticello-Tests/MCSortingTest.class.st
@@ -12,7 +12,7 @@ MCSortingTest class >> isUnitTest [
 { #category : #building }
 MCSortingTest >> classNamed: aSymbol [
 
-	^ MCClassDefinition name: aSymbol superclassName: #Object category: ''
+	^ MCClassDefinition named: aSymbol
 ]
 
 { #category : #building }

--- a/src/Monticello-Tests/MCSortingTest.class.st
+++ b/src/Monticello-Tests/MCSortingTest.class.st
@@ -16,7 +16,6 @@ MCSortingTest >> classNamed: aSymbol [
 		superclassName: #Object
 		category: ''
 		instVarNames: #()
-		comment: ''
 ]
 
 { #category : #building }

--- a/src/Monticello-Tests/MCTestCase.class.st
+++ b/src/Monticello-Tests/MCTestCase.class.st
@@ -81,8 +81,7 @@ MCTestCase >> mockClass: className super: superclassName [
 		   classTraitComposition: '{}'
 		   category: self mockCategoryName
 		   instVarNames: #(  )
-		   classVarNames: #(  )
-		   poolDictionaryNames: #(  ))
+		   classVarNames: #(  ))
 		  comment: (self commentForClass: className);
 		  commentStamp: (self commentStampForClass: className);
 		  yourself

--- a/src/Monticello-Tests/MCTestCase.class.st
+++ b/src/Monticello-Tests/MCTestCase.class.st
@@ -78,8 +78,8 @@ MCTestCase >> mockClass: className super: superclassName [
 		   name: className
 		   superclassName: superclassName
 		   traitComposition: '{}'
-		   classTraitComposition: '{}'
-		   category: self mockCategoryName)
+		   classTraitComposition: '{}')
+		  category: self mockCategoryName;
 		  comment: (self commentForClass: className);
 		  commentStamp: (self commentStampForClass: className);
 		  yourself

--- a/src/Monticello-Tests/MCTestCase.class.st
+++ b/src/Monticello-Tests/MCTestCase.class.st
@@ -80,8 +80,7 @@ MCTestCase >> mockClass: className super: superclassName [
 		   traitComposition: '{}'
 		   classTraitComposition: '{}'
 		   category: self mockCategoryName
-		   instVarNames: #(  )
-		   classVarNames: #(  ))
+		   instVarNames: #(  ))
 		  comment: (self commentForClass: className);
 		  commentStamp: (self commentStampForClass: className);
 		  yourself

--- a/src/Monticello-Tests/MCTestCase.class.st
+++ b/src/Monticello-Tests/MCTestCase.class.st
@@ -82,8 +82,7 @@ MCTestCase >> mockClass: className super: superclassName [
 		   category: self mockCategoryName
 		   instVarNames: #(  )
 		   classVarNames: #(  )
-		   poolDictionaryNames: #(  )
-		   classInstVarNames: #(  ))
+		   poolDictionaryNames: #(  ))
 		  comment: (self commentForClass: className);
 		  commentStamp: (self commentStampForClass: className);
 		  yourself

--- a/src/Monticello-Tests/MCTestCase.class.st
+++ b/src/Monticello-Tests/MCTestCase.class.st
@@ -79,8 +79,7 @@ MCTestCase >> mockClass: className super: superclassName [
 		   superclassName: superclassName
 		   traitComposition: '{}'
 		   classTraitComposition: '{}'
-		   category: self mockCategoryName
-		   instVarNames: #(  ))
+		   category: self mockCategoryName)
 		  comment: (self commentForClass: className);
 		  commentStamp: (self commentStampForClass: className);
 		  yourself

--- a/src/Monticello-Tests/MCTestCase.class.st
+++ b/src/Monticello-Tests/MCTestCase.class.st
@@ -83,8 +83,7 @@ MCTestCase >> mockClass: className super: superclassName [
 		   instVarNames: #(  )
 		   classVarNames: #(  )
 		   poolDictionaryNames: #(  )
-		   classInstVarNames: #(  )
-		   type: #normal)
+		   classInstVarNames: #(  ))
 		  comment: (self commentForClass: className);
 		  commentStamp: (self commentStampForClass: className);
 		  yourself

--- a/src/Monticello-Tests/MCTestCase.class.st
+++ b/src/Monticello-Tests/MCTestCase.class.st
@@ -84,8 +84,8 @@ MCTestCase >> mockClass: className super: superclassName [
 		   classVarNames: #(  )
 		   poolDictionaryNames: #(  )
 		   classInstVarNames: #(  )
-		   type: #normal
-		   comment: (self commentForClass: className))
+		   type: #normal)
+		  comment: (self commentForClass: className);
 		  commentStamp: (self commentStampForClass: className);
 		  yourself
 ]

--- a/src/Monticello-Tests/MCTestCase.class.st
+++ b/src/Monticello-Tests/MCTestCase.class.st
@@ -74,11 +74,8 @@ MCTestCase >> mockCategoryName [
 { #category : #mocks }
 MCTestCase >> mockClass: className super: superclassName [
 
-	^ (MCClassDefinition
-		   name: className
-		   superclassName: superclassName
-		   traitComposition: '{}'
-		   classTraitComposition: '{}')
+	^ (MCClassDefinition named: className)
+		  superclassName: superclassName;
 		  category: self mockCategoryName;
 		  comment: (self commentForClass: className);
 		  commentStamp: (self commentStampForClass: className);

--- a/src/Monticello-Tests/MCTestCase.class.st
+++ b/src/Monticello-Tests/MCTestCase.class.st
@@ -73,19 +73,21 @@ MCTestCase >> mockCategoryName [
 
 { #category : #mocks }
 MCTestCase >> mockClass: className super: superclassName [
-	^ MCClassDefinition
-		name:  className
-		superclassName:  superclassName
-		traitComposition: '{}'
-		classTraitComposition: '{}'
-		category: self mockCategoryName
-		instVarNames: #()
-		classVarNames: #()
-		poolDictionaryNames: #()
-		classInstVarNames: #()
-		type: #normal
-		comment: (self commentForClass: className)
-		commentStamp: (self commentStampForClass: className)
+
+	^ (MCClassDefinition
+		   name: className
+		   superclassName: superclassName
+		   traitComposition: '{}'
+		   classTraitComposition: '{}'
+		   category: self mockCategoryName
+		   instVarNames: #(  )
+		   classVarNames: #(  )
+		   poolDictionaryNames: #(  )
+		   classInstVarNames: #(  )
+		   type: #normal
+		   comment: (self commentForClass: className))
+		  commentStamp: (self commentStampForClass: className);
+		  yourself
 ]
 
 { #category : #mocks }

--- a/src/Monticello/Class.extension.st
+++ b/src/Monticello/Class.extension.st
@@ -19,8 +19,7 @@ Class >> asClassDefinition [
 						     ifNil: [ nil asString ]
 						     ifNotNil: [ self superclass name ])
 				    traitComposition: self traitCompositionString
-				    classTraitComposition: self class traitCompositionString
-				    category: self category)
+				    classTraitComposition: self class traitCompositionString)
 				   instVarNames: (self localSlots collect: [ :each | each definitionString ]);
 				   classVarNames: (self classVariables collect: [ :each | each definitionString ]);
 				   classInstVarNames: (self class localSlots collect: [ :each | each definitionString ]);
@@ -32,12 +31,12 @@ Class >> asClassDefinition [
 						     ifNil: [ nil asString ]
 						     ifNotNil: [ self superclass name ])
 				    traitComposition: self traitCompositionString
-				    classTraitComposition: self class traitCompositionString
-				    category: self category)
+				    classTraitComposition: self class traitCompositionString)
 				   instVarNames: (self localSlots collect: [ :each | each name ]);
 				   classVarNames: self classVarNames;
 				   classInstVarNames: (self class localSlots collect: [ :each | each name ]);
 				   yourself ])
+		  category: self category;
 		  poolDictionaryNames: self sharedPoolNames;
 		  type: self mcType;
 		  comment: self comment;

--- a/src/Monticello/Class.extension.st
+++ b/src/Monticello/Class.extension.st
@@ -21,8 +21,8 @@ Class >> asClassDefinition [
 				    traitComposition: self traitCompositionString
 				    classTraitComposition: self class traitCompositionString
 				    category: self category
-				    instVarNames: (self localSlots collect: [ :each | each definitionString ])
-				    classVarNames: (self classVariables collect: [ :each | each definitionString ]))
+				    instVarNames: (self localSlots collect: [ :each | each definitionString ]))
+				   classVarNames: (self classVariables collect: [ :each | each definitionString ]);
 				   classInstVarNames: (self class localSlots collect: [ :each | each definitionString ]);
 				   yourself ]
 		   ifFalse: [
@@ -34,8 +34,8 @@ Class >> asClassDefinition [
 				    traitComposition: self traitCompositionString
 				    classTraitComposition: self class traitCompositionString
 				    category: self category
-				    instVarNames: (self localSlots collect: [ :each | each name ])
-				    classVarNames: self classVarNames)
+				    instVarNames: (self localSlots collect: [ :each | each name ]))
+				   classVarNames: self classVarNames;
 				   classInstVarNames: (self class localSlots collect: [ :each | each name ]);
 				   yourself ])
 		  poolDictionaryNames: self sharedPoolNames;

--- a/src/Monticello/Class.extension.st
+++ b/src/Monticello/Class.extension.st
@@ -11,37 +11,30 @@ Class >> asClassDefinition [
 	This is produces by definitionString on slot while x is produced simnply by invoking name.
 	"
 
-	^ (self needsSlotClassDefinition
-		   ifTrue: [
-			   (MCClassDefinition
-				    name: self name
-				    superclassName: (self superclass
-						     ifNil: [ nil asString ]
-						     ifNotNil: [ self superclass name ])
-				    traitComposition: self traitCompositionString
-				    classTraitComposition: self class traitCompositionString)
-				   instVarNames: (self localSlots collect: [ :each | each definitionString ]);
-				   classVarNames: (self classVariables collect: [ :each | each definitionString ]);
-				   classInstVarNames: (self class localSlots collect: [ :each | each definitionString ]);
-				   yourself ]
-		   ifFalse: [
-			   (MCClassDefinition
-				    name: self name
-				    superclassName: (self superclass
-						     ifNil: [ nil asString ]
-						     ifNotNil: [ self superclass name ])
-				    traitComposition: self traitCompositionString
-				    classTraitComposition: self class traitCompositionString)
-				   instVarNames: (self localSlots collect: [ :each | each name ]);
-				   classVarNames: self classVarNames;
-				   classInstVarNames: (self class localSlots collect: [ :each | each name ]);
-				   yourself ])
-		  category: self category;
-		  poolDictionaryNames: self sharedPoolNames;
-		  type: self mcType;
-		  comment: self comment;
-		  commentStamp: self commentStamp;
-		  yourself
+	| definition |
+	definition := (MCClassDefinition named: self name)
+		              superclassName: (self superclass ifNotNil: [ self superclass name ]);
+		              traitComposition: self traitCompositionString;
+		              classTraitComposition: self class traitCompositionString;
+		              category: self category;
+		              poolDictionaryNames: self sharedPoolNames;
+		              type: self mcType;
+		              comment: self comment;
+		              commentStamp: self commentStamp;
+		              yourself.
+	self needsSlotClassDefinition
+		ifTrue: [
+			definition
+				instVarNames: (self localSlots collect: [ :each | each definitionString ]);
+				classVarNames: (self classVariables collect: [ :each | each definitionString ]);
+				classInstVarNames: (self class localSlots collect: [ :each | each definitionString ]) ]
+		ifFalse: [
+			definition
+				instVarNames: (self localSlots collect: [ :each | each name ]);
+				classVarNames: self classVarNames;
+				classInstVarNames: (self class localSlots collect: [ :each | each name ]) ].
+
+	^ definition
 ]
 
 { #category : #'*Monticello' }

--- a/src/Monticello/Class.extension.st
+++ b/src/Monticello/Class.extension.st
@@ -13,31 +13,33 @@ Class >> asClassDefinition [
 
 	^ (self needsSlotClassDefinition
 		   ifTrue: [
-			   MCClassDefinition
-				   name: self name
-				   superclassName: (self superclass
-						    ifNil: [ nil asString ]
-						    ifNotNil: [ self superclass name ])
-				   traitComposition: self traitCompositionString
-				   classTraitComposition: self class traitCompositionString
-				   category: self category
-				   instVarNames: (self localSlots collect: [ :each | each definitionString ])
-				   classVarNames: (self classVariables collect: [ :each | each definitionString ])
-				   poolDictionaryNames: self sharedPoolNames
-				   classInstVarNames: (self class localSlots collect: [ :each | each definitionString ]) ]
+			   (MCClassDefinition
+				    name: self name
+				    superclassName: (self superclass
+						     ifNil: [ nil asString ]
+						     ifNotNil: [ self superclass name ])
+				    traitComposition: self traitCompositionString
+				    classTraitComposition: self class traitCompositionString
+				    category: self category
+				    instVarNames: (self localSlots collect: [ :each | each definitionString ])
+				    classVarNames: (self classVariables collect: [ :each | each definitionString ])
+				    poolDictionaryNames: self sharedPoolNames)
+				   classInstVarNames: (self class localSlots collect: [ :each | each definitionString ]);
+				   yourself ]
 		   ifFalse: [
-			   MCClassDefinition
-				   name: self name
-				   superclassName: (self superclass
-						    ifNil: [ nil asString ]
-						    ifNotNil: [ self superclass name ])
-				   traitComposition: self traitCompositionString
-				   classTraitComposition: self class traitCompositionString
-				   category: self category
-				   instVarNames: (self localSlots collect: [ :each | each name ])
-				   classVarNames: self classVarNames
-				   poolDictionaryNames: self sharedPoolNames
-				   classInstVarNames: (self class localSlots collect: [ :each | each name ]) ])
+			   (MCClassDefinition
+				    name: self name
+				    superclassName: (self superclass
+						     ifNil: [ nil asString ]
+						     ifNotNil: [ self superclass name ])
+				    traitComposition: self traitCompositionString
+				    classTraitComposition: self class traitCompositionString
+				    category: self category
+				    instVarNames: (self localSlots collect: [ :each | each name ])
+				    classVarNames: self classVarNames
+				    poolDictionaryNames: self sharedPoolNames)
+				   classInstVarNames: (self class localSlots collect: [ :each | each name ]);
+				   yourself ])
 		  type: self mcType;
 		  comment: self comment;
 		  commentStamp: self commentStamp;

--- a/src/Monticello/Class.extension.st
+++ b/src/Monticello/Class.extension.st
@@ -22,8 +22,7 @@ Class >> asClassDefinition [
 				    classTraitComposition: self class traitCompositionString
 				    category: self category
 				    instVarNames: (self localSlots collect: [ :each | each definitionString ])
-				    classVarNames: (self classVariables collect: [ :each | each definitionString ])
-				    poolDictionaryNames: self sharedPoolNames)
+				    classVarNames: (self classVariables collect: [ :each | each definitionString ]))
 				   classInstVarNames: (self class localSlots collect: [ :each | each definitionString ]);
 				   yourself ]
 		   ifFalse: [
@@ -36,10 +35,10 @@ Class >> asClassDefinition [
 				    classTraitComposition: self class traitCompositionString
 				    category: self category
 				    instVarNames: (self localSlots collect: [ :each | each name ])
-				    classVarNames: self classVarNames
-				    poolDictionaryNames: self sharedPoolNames)
+				    classVarNames: self classVarNames)
 				   classInstVarNames: (self class localSlots collect: [ :each | each name ]);
 				   yourself ])
+		  poolDictionaryNames: self sharedPoolNames;
 		  type: self mcType;
 		  comment: self comment;
 		  commentStamp: self commentStamp;

--- a/src/Monticello/Class.extension.st
+++ b/src/Monticello/Class.extension.st
@@ -20,8 +20,8 @@ Class >> asClassDefinition [
 						     ifNotNil: [ self superclass name ])
 				    traitComposition: self traitCompositionString
 				    classTraitComposition: self class traitCompositionString
-				    category: self category
-				    instVarNames: (self localSlots collect: [ :each | each definitionString ]))
+				    category: self category)
+				   instVarNames: (self localSlots collect: [ :each | each definitionString ]);
 				   classVarNames: (self classVariables collect: [ :each | each definitionString ]);
 				   classInstVarNames: (self class localSlots collect: [ :each | each definitionString ]);
 				   yourself ]
@@ -33,8 +33,8 @@ Class >> asClassDefinition [
 						     ifNotNil: [ self superclass name ])
 				    traitComposition: self traitCompositionString
 				    classTraitComposition: self class traitCompositionString
-				    category: self category
-				    instVarNames: (self localSlots collect: [ :each | each name ]))
+				    category: self category)
+				   instVarNames: (self localSlots collect: [ :each | each name ]);
 				   classVarNames: self classVarNames;
 				   classInstVarNames: (self class localSlots collect: [ :each | each name ]);
 				   yourself ])

--- a/src/Monticello/Class.extension.st
+++ b/src/Monticello/Class.extension.st
@@ -24,8 +24,7 @@ Class >> asClassDefinition [
 				   instVarNames: (self localSlots collect: [ :each | each definitionString ])
 				   classVarNames: (self classVariables collect: [ :each | each definitionString ])
 				   poolDictionaryNames: self sharedPoolNames
-				   classInstVarNames: (self class localSlots collect: [ :each | each definitionString ])
-				   type: self mcType ]
+				   classInstVarNames: (self class localSlots collect: [ :each | each definitionString ]) ]
 		   ifFalse: [
 			   MCClassDefinition
 				   name: self name
@@ -38,8 +37,8 @@ Class >> asClassDefinition [
 				   instVarNames: (self localSlots collect: [ :each | each name ])
 				   classVarNames: self classVarNames
 				   poolDictionaryNames: self sharedPoolNames
-				   classInstVarNames: (self class localSlots collect: [ :each | each name ])
-				   type: self mcType ])
+				   classInstVarNames: (self class localSlots collect: [ :each | each name ]) ])
+		  type: self mcType;
 		  comment: self comment;
 		  commentStamp: self commentStamp;
 		  yourself

--- a/src/Monticello/Class.extension.st
+++ b/src/Monticello/Class.extension.st
@@ -3,47 +3,47 @@ Extension { #name : #Class }
 { #category : #'*Monticello' }
 Class >> asClassDefinition [
 	"we use a very ugly hack to encode complex slots as string with MC... later MC should model Slots directly"
+
 	"We do not dispatch on the printer because in fact MC only support the oldPharo syntax. 
 	This syntax is hijacked to store the full definition of a slot in case of complex slots: 
 				#x => PropertySlot 
 				
 	This is produces by definitionString on slot while x is produced simnply by invoking name.
 	"
-	^ self needsSlotClassDefinition 
-		ifTrue: [ MCClassDefinition
-						name: self name
-						superclassName: (self superclass ifNil: [ nil asString ] ifNotNil: [ self superclass name ])
-						traitComposition: self traitCompositionString
-						classTraitComposition: self class traitCompositionString
-						category: self category 
-						instVarNames: (self localSlots collect: [:each | each definitionString])
-						classVarNames: (self classVariables collect: [:each | each definitionString])
-						poolDictionaryNames: self sharedPoolNames
-						classInstVarNames: (self class localSlots collect: [:each | each definitionString])
-						type: self mcType
-						comment: self comment
-						commentStamp: self commentStamp ]
-	
-		ifFalse: [  
-				 MCClassDefinition
-						name: self name
-						superclassName: (self superclass ifNil: [ nil asString ] ifNotNil: [ self superclass name ])
-						traitComposition: self traitCompositionString
-						classTraitComposition: self class traitCompositionString
-						category: self category 
-						instVarNames:  (self localSlots collect: [ :each | each name ])
-						classVarNames: self classVarNames
-						poolDictionaryNames: self sharedPoolNames
-						classInstVarNames: (self class localSlots collect: [ :each | each name ])
-						type: self mcType
-						comment: self comment
-						commentStamp: self commentStamp ]
-	
 
-
-
-
-
+	^ (self needsSlotClassDefinition
+		   ifTrue: [
+			   MCClassDefinition
+				   name: self name
+				   superclassName: (self superclass
+						    ifNil: [ nil asString ]
+						    ifNotNil: [ self superclass name ])
+				   traitComposition: self traitCompositionString
+				   classTraitComposition: self class traitCompositionString
+				   category: self category
+				   instVarNames: (self localSlots collect: [ :each | each definitionString ])
+				   classVarNames: (self classVariables collect: [ :each | each definitionString ])
+				   poolDictionaryNames: self sharedPoolNames
+				   classInstVarNames: (self class localSlots collect: [ :each | each definitionString ])
+				   type: self mcType
+				   comment: self comment ]
+		   ifFalse: [
+			   MCClassDefinition
+				   name: self name
+				   superclassName: (self superclass
+						    ifNil: [ nil asString ]
+						    ifNotNil: [ self superclass name ])
+				   traitComposition: self traitCompositionString
+				   classTraitComposition: self class traitCompositionString
+				   category: self category
+				   instVarNames: (self localSlots collect: [ :each | each name ])
+				   classVarNames: self classVarNames
+				   poolDictionaryNames: self sharedPoolNames
+				   classInstVarNames: (self class localSlots collect: [ :each | each name ])
+				   type: self mcType
+				   comment: self comment ])
+		  commentStamp: self commentStamp;
+		  yourself
 ]
 
 { #category : #'*Monticello' }

--- a/src/Monticello/Class.extension.st
+++ b/src/Monticello/Class.extension.st
@@ -25,8 +25,7 @@ Class >> asClassDefinition [
 				   classVarNames: (self classVariables collect: [ :each | each definitionString ])
 				   poolDictionaryNames: self sharedPoolNames
 				   classInstVarNames: (self class localSlots collect: [ :each | each definitionString ])
-				   type: self mcType
-				   comment: self comment ]
+				   type: self mcType ]
 		   ifFalse: [
 			   MCClassDefinition
 				   name: self name
@@ -40,8 +39,8 @@ Class >> asClassDefinition [
 				   classVarNames: self classVarNames
 				   poolDictionaryNames: self sharedPoolNames
 				   classInstVarNames: (self class localSlots collect: [ :each | each name ])
-				   type: self mcType
-				   comment: self comment ])
+				   type: self mcType ])
+		  comment: self comment;
 		  commentStamp: self commentStamp;
 		  yourself
 ]

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -19,7 +19,7 @@ Class {
 }
 
 { #category : #obsolete }
-MCClassDefinition class >> name: nameString superclassName: superclassString category: categoryString instVarNames: ivarArray [
+MCClassDefinition class >> name: nameString superclassName: superclassString category: categoryString [
 
 	^ self
 		  name: nameString
@@ -27,11 +27,10 @@ MCClassDefinition class >> name: nameString superclassName: superclassString cat
 		  traitComposition: '{}'
 		  classTraitComposition: '{}'
 		  category: categoryString
-		  instVarNames: ivarArray
 ]
 
 { #category : #'instance creation' }
-MCClassDefinition class >> name: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray [
+MCClassDefinition class >> name: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString [
 
 	^ self new
 		  initializeWithName: nameString
@@ -39,7 +38,6 @@ MCClassDefinition class >> name: nameString superclassName: superclassString tra
 		  traitComposition: traitCompositionString
 		  classTraitComposition: classTraitCompositionString
 		  category: categoryString
-		  instVarNames: ivarArray
 ]
 
 { #category : #'instance creation' }
@@ -50,8 +48,8 @@ MCClassDefinition class >> name: nameString superclassName: superclassString tra
 		   superclassName: superclassString
 		   traitComposition: traitCompositionString
 		   classTraitComposition: classTraitCompositionString
-		   category: categoryString
-		   instVarNames: ivarArray)
+		   category: categoryString)
+		  instVarNames: ivarArray;
 		  classVarNames: cvarArray;
 		  poolDictionaryNames: poolArray;
 		  classInstVarNames: civarArray;
@@ -316,7 +314,7 @@ MCClassDefinition >> initialize [
 ]
 
 { #category : #initialization }
-MCClassDefinition >> initializeWithName: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray [
+MCClassDefinition >> initializeWithName: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString [
 
 	name := nameString asSymbol.
 	superclassName := superclassString
@@ -324,14 +322,18 @@ MCClassDefinition >> initializeWithName: nameString superclassName: superclassSt
 		                  ifNotNil: [ superclassString asSymbol ].
 	traitComposition := traitCompositionString.
 	classTraitComposition := classTraitCompositionString.
-	category := categoryString.
-
-	self addVariables: ivarArray ofType: MCInstanceVariableDefinition
+	category := categoryString
 ]
 
 { #category : #accessing }
 MCClassDefinition >> instVarNames [
 	^ self selectVariables: #isInstanceVariable
+]
+
+{ #category : #accessing }
+MCClassDefinition >> instVarNames: ivarArray [
+
+	self addVariables: ivarArray ofType: MCInstanceVariableDefinition
 ]
 
 { #category : #printing }

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -30,11 +30,10 @@ MCClassDefinition class >> name: nameString superclassName: superclassString cat
 		  instVarNames: ivarArray
 		  classVarNames: ''
 		  poolDictionaryNames: ''
-		  classInstVarNames: ''
 ]
 
 { #category : #'instance creation' }
-MCClassDefinition class >> name: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray classInstVarNames: civarArray [
+MCClassDefinition class >> name: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray [
 
 	^ self new
 		  initializeWithName: nameString
@@ -45,7 +44,6 @@ MCClassDefinition class >> name: nameString superclassName: superclassString tra
 		  instVarNames: ivarArray
 		  classVarNames: cvarArray
 		  poolDictionaryNames: poolArray
-		  classInstVarNames: civarArray
 ]
 
 { #category : #'instance creation' }
@@ -59,8 +57,8 @@ MCClassDefinition class >> name: nameString superclassName: superclassString tra
 		   category: categoryString
 		   instVarNames: ivarArray
 		   classVarNames: cvarArray
-		   poolDictionaryNames: poolArray
-		   classInstVarNames: civarArray)
+		   poolDictionaryNames: poolArray)
+		  classInstVarNames: civarArray;
 		  type: typeSymbol;
 		  comment: commentString;
 		  commentStamp: stampString;
@@ -115,6 +113,12 @@ MCClassDefinition >> classDefinitionString [
 { #category : #accessing }
 MCClassDefinition >> classInstVarNames [
 	^ self selectVariables: #isClassInstanceVariable
+]
+
+{ #category : #accessing }
+MCClassDefinition >> classInstVarNames: civarArray [
+
+	self addVariables: civarArray ofType: MCClassInstanceVariableDefinition
 ]
 
 { #category : #printing }
@@ -310,7 +314,7 @@ MCClassDefinition >> initialize [
 ]
 
 { #category : #initialization }
-MCClassDefinition >> initializeWithName: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray classInstVarNames: civarArray [
+MCClassDefinition >> initializeWithName: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray [
 
 	name := nameString asSymbol.
 	superclassName := superclassString
@@ -322,28 +326,7 @@ MCClassDefinition >> initializeWithName: nameString superclassName: superclassSt
 
 	self addVariables: ivarArray ofType: MCInstanceVariableDefinition.
 	self addVariables: cvarArray asSortedCollection ofType: MCClassVariableDefinition.
-	self addVariables: poolArray asSortedCollection ofType: MCPoolImportDefinition.
-	self addVariables: civarArray ofType: MCClassInstanceVariableDefinition
-]
-
-{ #category : #initialization }
-MCClassDefinition >> initializeWithName: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray classInstVarNames: civarArray type: typeSymbol [
-
-	name := nameString asSymbol.
-	superclassName := superclassString
-		                  ifNil: [ #nil ]
-		                  ifNotNil: [ superclassString asSymbol ].
-	traitComposition := traitCompositionString.
-	classTraitComposition := classTraitCompositionString.
-	category := categoryString.
-	type := (#( #CompiledMethod #CompiledBlock #CompiledCode ) includes: name)
-		        ifTrue: [ #compiledMethod ]
-		        ifFalse: [ typeSymbol ].
-
-	self addVariables: ivarArray ofType: MCInstanceVariableDefinition.
-	self addVariables: cvarArray asSortedCollection ofType: MCClassVariableDefinition.
-	self addVariables: poolArray asSortedCollection ofType: MCPoolImportDefinition.
-	self addVariables: civarArray ofType: MCClassInstanceVariableDefinition
+	self addVariables: poolArray asSortedCollection ofType: MCPoolImportDefinition
 ]
 
 { #category : #accessing }

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -29,11 +29,10 @@ MCClassDefinition class >> name: nameString superclassName: superclassString cat
 		  category: categoryString
 		  instVarNames: ivarArray
 		  classVarNames: ''
-		  poolDictionaryNames: ''
 ]
 
 { #category : #'instance creation' }
-MCClassDefinition class >> name: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray [
+MCClassDefinition class >> name: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray [
 
 	^ self new
 		  initializeWithName: nameString
@@ -43,7 +42,6 @@ MCClassDefinition class >> name: nameString superclassName: superclassString tra
 		  category: categoryString
 		  instVarNames: ivarArray
 		  classVarNames: cvarArray
-		  poolDictionaryNames: poolArray
 ]
 
 { #category : #'instance creation' }
@@ -56,8 +54,8 @@ MCClassDefinition class >> name: nameString superclassName: superclassString tra
 		   classTraitComposition: classTraitCompositionString
 		   category: categoryString
 		   instVarNames: ivarArray
-		   classVarNames: cvarArray
-		   poolDictionaryNames: poolArray)
+		   classVarNames: cvarArray)
+		  poolDictionaryNames: poolArray;
 		  classInstVarNames: civarArray;
 		  type: typeSymbol;
 		  comment: commentString;
@@ -314,7 +312,7 @@ MCClassDefinition >> initialize [
 ]
 
 { #category : #initialization }
-MCClassDefinition >> initializeWithName: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray [
+MCClassDefinition >> initializeWithName: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray [
 
 	name := nameString asSymbol.
 	superclassName := superclassString
@@ -325,8 +323,7 @@ MCClassDefinition >> initializeWithName: nameString superclassName: superclassSt
 	category := categoryString.
 
 	self addVariables: ivarArray ofType: MCInstanceVariableDefinition.
-	self addVariables: cvarArray asSortedCollection ofType: MCClassVariableDefinition.
-	self addVariables: poolArray asSortedCollection ofType: MCPoolImportDefinition
+	self addVariables: cvarArray asSortedCollection ofType: MCClassVariableDefinition
 ]
 
 { #category : #accessing }
@@ -395,6 +392,12 @@ MCClassDefinition >> needsSlotClassDefinition [
 { #category : #accessing }
 MCClassDefinition >> poolDictionaries [
 	^ self selectVariables: #isPoolImport
+]
+
+{ #category : #accessing }
+MCClassDefinition >> poolDictionaryNames: poolArray [
+
+	self addVariables: poolArray asSortedCollection ofType: MCPoolImportDefinition
 ]
 
 { #category : #annotations }

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -18,37 +18,14 @@ Class {
 	#category : #'Monticello-Modeling'
 }
 
-{ #category : #obsolete }
-MCClassDefinition class >> name: nameString superclassName: superclassString category: categoryString [
-
-	^ (self
-		   name: nameString
-		   superclassName: superclassString
-		   traitComposition: '{}'
-		   classTraitComposition: '{}')
-		  category: categoryString;
-		  yourself
-]
-
-{ #category : #'instance creation' }
-MCClassDefinition class >> name: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString [
-
-	^ self new
-		  initializeWithName: nameString
-		  superclassName: superclassString
-		  traitComposition: traitCompositionString
-		  classTraitComposition: classTraitCompositionString
-]
-
-{ #category : #'instance creation' }
+{ #category : #deprecated }
 MCClassDefinition class >> name: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray classInstVarNames: civarArray type: typeSymbol comment: commentString commentStamp: stampString [
+	"Do not use this method! This method will be deprecated one Tonel will not use it anymore."
 
-	^ (self
-		   name: nameString
-		   superclassName: superclassString
-		   traitComposition: traitCompositionString
-		   classTraitComposition: classTraitCompositionString)
-		  category: categoryString;
+	^ (self named: nameString category: categoryString)
+		  superclassName: superclassString;
+		  traitComposition: traitCompositionString;
+		  classTraitComposition: classTraitCompositionString;
 		  instVarNames: ivarArray;
 		  classVarNames: cvarArray;
 		  poolDictionaryNames: poolArray;
@@ -56,6 +33,22 @@ MCClassDefinition class >> name: nameString superclassName: superclassString tra
 		  type: typeSymbol;
 		  comment: commentString;
 		  commentStamp: stampString;
+		  yourself
+]
+
+{ #category : #'instance creation' }
+MCClassDefinition class >> named: nameString [
+
+	^ self new
+		  name: nameString;
+		  yourself
+]
+
+{ #category : #obsolete }
+MCClassDefinition class >> named: nameString category: categoryString [
+
+	^ (self named: nameString)
+		  category: categoryString;
 		  yourself
 ]
 
@@ -143,8 +136,9 @@ MCClassDefinition >> classTraitComposition [
 ]
 
 { #category : #accessing }
-MCClassDefinition >> classTraitComposition: anObject [
-	classTraitComposition := anObject
+MCClassDefinition >> classTraitComposition: classTraitCompositionString [
+
+	classTraitComposition := classTraitCompositionString
 ]
 
 { #category : #accessing }
@@ -308,21 +302,14 @@ MCClassDefinition >> hash [
 MCClassDefinition >> initialize [
 
 	super initialize.
+	category := ''.
+	superclassName := #Object.
+	traitComposition := '{}'.
+	classTraitComposition := '{}'.
 	type := #normal.
 	comment := ''.
 	commentStamp := self defaultCommentStamp.
 	variables := OrderedCollection new
-]
-
-{ #category : #initialization }
-MCClassDefinition >> initializeWithName: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString [
-
-	name := nameString asSymbol.
-	superclassName := superclassString
-		                  ifNil: [ #nil ]
-		                  ifNotNil: [ superclassString asSymbol ].
-	traitComposition := traitCompositionString.
-	classTraitComposition := classTraitCompositionString
 ]
 
 { #category : #accessing }
@@ -382,7 +369,7 @@ MCClassDefinition >> load [
 { #category : #accessing }
 MCClassDefinition >> name: anObject [
 
-	name := anObject.
+	name := anObject asSymbol.
 	self type: type
 ]
 
@@ -403,6 +390,13 @@ MCClassDefinition >> poolDictionaries [
 MCClassDefinition >> poolDictionaryNames: poolArray [
 
 	self addVariables: poolArray asSortedCollection ofType: MCPoolImportDefinition
+]
+
+{ #category : #copying }
+MCClassDefinition >> postCopy [
+
+	super postCopy.
+	variables := variables copy
 ]
 
 { #category : #annotations }
@@ -575,8 +569,11 @@ MCClassDefinition >> superclassName [
 ]
 
 { #category : #accessing }
-MCClassDefinition >> superclassName: anObject [
-	superclassName := anObject
+MCClassDefinition >> superclassName: superclassString [
+
+	superclassName := superclassString
+		                  ifNil: [ #nil ]
+		                  ifNotNil: [ superclassString asSymbol ]
 ]
 
 { #category : #accessing }
@@ -585,8 +582,9 @@ MCClassDefinition >> traitComposition [
 ]
 
 { #category : #accessing }
-MCClassDefinition >> traitComposition: anObject [
-	traitComposition := anObject
+MCClassDefinition >> traitComposition: traitCompositionString [
+
+	traitComposition := traitCompositionString
 ]
 
 { #category : #accessing }

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -31,11 +31,10 @@ MCClassDefinition class >> name: nameString superclassName: superclassString cat
 		  classVarNames: ''
 		  poolDictionaryNames: ''
 		  classInstVarNames: ''
-		  type: #normal
 ]
 
 { #category : #'instance creation' }
-MCClassDefinition class >> name: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray classInstVarNames: civarArray type: typeSymbol [
+MCClassDefinition class >> name: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray classInstVarNames: civarArray [
 
 	^ self new
 		  initializeWithName: nameString
@@ -47,14 +46,13 @@ MCClassDefinition class >> name: nameString superclassName: superclassString tra
 		  classVarNames: cvarArray
 		  poolDictionaryNames: poolArray
 		  classInstVarNames: civarArray
-		  type: typeSymbol
 ]
 
 { #category : #'instance creation' }
 MCClassDefinition class >> name: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray classInstVarNames: civarArray type: typeSymbol comment: commentString commentStamp: stampString [
 
-	^ (self new
-		   initializeWithName: nameString
+	^ (self
+		   name: nameString
 		   superclassName: superclassString
 		   traitComposition: traitCompositionString
 		   classTraitComposition: classTraitCompositionString
@@ -62,8 +60,8 @@ MCClassDefinition class >> name: nameString superclassName: superclassString tra
 		   instVarNames: ivarArray
 		   classVarNames: cvarArray
 		   poolDictionaryNames: poolArray
-		   classInstVarNames: civarArray
-		   type: typeSymbol)
+		   classInstVarNames: civarArray)
+		  type: typeSymbol;
 		  comment: commentString;
 		  commentStamp: stampString;
 		  yourself
@@ -305,9 +303,27 @@ MCClassDefinition >> hash [
 MCClassDefinition >> initialize [
 
 	super initialize.
+	type := #normal.
 	comment := ''.
 	commentStamp := self defaultCommentStamp.
 	variables := OrderedCollection new
+]
+
+{ #category : #initialization }
+MCClassDefinition >> initializeWithName: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray classInstVarNames: civarArray [
+
+	name := nameString asSymbol.
+	superclassName := superclassString
+		                  ifNil: [ #nil ]
+		                  ifNotNil: [ superclassString asSymbol ].
+	traitComposition := traitCompositionString.
+	classTraitComposition := classTraitCompositionString.
+	category := categoryString.
+
+	self addVariables: ivarArray ofType: MCInstanceVariableDefinition.
+	self addVariables: cvarArray asSortedCollection ofType: MCClassVariableDefinition.
+	self addVariables: poolArray asSortedCollection ofType: MCPoolImportDefinition.
+	self addVariables: civarArray ofType: MCClassInstanceVariableDefinition
 ]
 
 { #category : #initialization }
@@ -380,7 +396,9 @@ MCClassDefinition >> load [
 
 { #category : #accessing }
 MCClassDefinition >> name: anObject [
-	name := anObject
+
+	name := anObject.
+	self type: type
 ]
 
 { #category : #installing }
@@ -593,6 +611,14 @@ MCClassDefinition >> traitCompositionString [
 { #category : #accessing }
 MCClassDefinition >> type [
 	^ type
+]
+
+{ #category : #accessing }
+MCClassDefinition >> type: aSymbol [
+
+	type := (#( #CompiledMethod #CompiledBlock #CompiledCode ) includes: name)
+		        ifTrue: [ #compiledMethod ]
+		        ifFalse: [ aSymbol ]
 ]
 
 { #category : #installing }

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -28,11 +28,10 @@ MCClassDefinition class >> name: nameString superclassName: superclassString cat
 		  classTraitComposition: '{}'
 		  category: categoryString
 		  instVarNames: ivarArray
-		  classVarNames: ''
 ]
 
 { #category : #'instance creation' }
-MCClassDefinition class >> name: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray [
+MCClassDefinition class >> name: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray [
 
 	^ self new
 		  initializeWithName: nameString
@@ -41,7 +40,6 @@ MCClassDefinition class >> name: nameString superclassName: superclassString tra
 		  classTraitComposition: classTraitCompositionString
 		  category: categoryString
 		  instVarNames: ivarArray
-		  classVarNames: cvarArray
 ]
 
 { #category : #'instance creation' }
@@ -53,8 +51,8 @@ MCClassDefinition class >> name: nameString superclassName: superclassString tra
 		   traitComposition: traitCompositionString
 		   classTraitComposition: classTraitCompositionString
 		   category: categoryString
-		   instVarNames: ivarArray
-		   classVarNames: cvarArray)
+		   instVarNames: ivarArray)
+		  classVarNames: cvarArray;
 		  poolDictionaryNames: poolArray;
 		  classInstVarNames: civarArray;
 		  type: typeSymbol;
@@ -163,6 +161,12 @@ MCClassDefinition >> classTraitCompositionString [
 { #category : #accessing }
 MCClassDefinition >> classVarNames [
 	^(self selectVariables: #isClassVariable) asArray sort
+]
+
+{ #category : #accessing }
+MCClassDefinition >> classVarNames: cvarArray [
+
+	self addVariables: cvarArray asSortedCollection ofType: MCClassVariableDefinition
 ]
 
 { #category : #printing }
@@ -312,7 +316,7 @@ MCClassDefinition >> initialize [
 ]
 
 { #category : #initialization }
-MCClassDefinition >> initializeWithName: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray [
+MCClassDefinition >> initializeWithName: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray [
 
 	name := nameString asSymbol.
 	superclassName := superclassString
@@ -322,8 +326,7 @@ MCClassDefinition >> initializeWithName: nameString superclassName: superclassSt
 	classTraitComposition := classTraitCompositionString.
 	category := categoryString.
 
-	self addVariables: ivarArray ofType: MCInstanceVariableDefinition.
-	self addVariables: cvarArray asSortedCollection ofType: MCClassVariableDefinition
+	self addVariables: ivarArray ofType: MCInstanceVariableDefinition
 ]
 
 { #category : #accessing }

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -21,23 +21,23 @@ Class {
 { #category : #obsolete }
 MCClassDefinition class >> name: nameString superclassName: superclassString category: categoryString [
 
-	^ self
-		  name: nameString
-		  superclassName: superclassString
-		  traitComposition: '{}'
-		  classTraitComposition: '{}'
-		  category: categoryString
+	^ (self
+		   name: nameString
+		   superclassName: superclassString
+		   traitComposition: '{}'
+		   classTraitComposition: '{}')
+		  category: categoryString;
+		  yourself
 ]
 
 { #category : #'instance creation' }
-MCClassDefinition class >> name: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString [
+MCClassDefinition class >> name: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString [
 
 	^ self new
 		  initializeWithName: nameString
 		  superclassName: superclassString
 		  traitComposition: traitCompositionString
 		  classTraitComposition: classTraitCompositionString
-		  category: categoryString
 ]
 
 { #category : #'instance creation' }
@@ -47,8 +47,8 @@ MCClassDefinition class >> name: nameString superclassName: superclassString tra
 		   name: nameString
 		   superclassName: superclassString
 		   traitComposition: traitCompositionString
-		   classTraitComposition: classTraitCompositionString
-		   category: categoryString)
+		   classTraitComposition: classTraitCompositionString)
+		  category: categoryString;
 		  instVarNames: ivarArray;
 		  classVarNames: cvarArray;
 		  poolDictionaryNames: poolArray;
@@ -93,8 +93,9 @@ MCClassDefinition >> category [
 ]
 
 { #category : #accessing }
-MCClassDefinition >> category: anObject [
-	category := anObject
+MCClassDefinition >> category: categoryString [
+
+	category := categoryString
 ]
 
 { #category : #accessing }
@@ -314,15 +315,14 @@ MCClassDefinition >> initialize [
 ]
 
 { #category : #initialization }
-MCClassDefinition >> initializeWithName: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString [
+MCClassDefinition >> initializeWithName: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString [
 
 	name := nameString asSymbol.
 	superclassName := superclassString
 		                  ifNil: [ #nil ]
 		                  ifNotNil: [ superclassString asSymbol ].
 	traitComposition := traitCompositionString.
-	classTraitComposition := classTraitCompositionString.
-	category := categoryString
+	classTraitComposition := classTraitCompositionString
 ]
 
 { #category : #accessing }

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -19,7 +19,7 @@ Class {
 }
 
 { #category : #obsolete }
-MCClassDefinition class >> name: nameString superclassName: superclassString category: categoryString instVarNames: ivarArray comment: commentString [
+MCClassDefinition class >> name: nameString superclassName: superclassString category: categoryString instVarNames: ivarArray [
 
 	^ self
 		  name: nameString
@@ -32,24 +32,22 @@ MCClassDefinition class >> name: nameString superclassName: superclassString cat
 		  poolDictionaryNames: ''
 		  classInstVarNames: ''
 		  type: #normal
-		  comment: commentString
 ]
 
 { #category : #'instance creation' }
-MCClassDefinition class >> name: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray classInstVarNames: civarArray type: typeSymbol comment: commentString [
+MCClassDefinition class >> name: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray classInstVarNames: civarArray type: typeSymbol [
 
 	^ self new
-		initializeWithName: nameString
-		superclassName: superclassString
-		traitComposition: traitCompositionString
-		classTraitComposition: classTraitCompositionString
-		category: categoryString
-		instVarNames: ivarArray
-		classVarNames: cvarArray
-		poolDictionaryNames: poolArray
-		classInstVarNames: civarArray
-		type: typeSymbol
-		comment: commentString
+		  initializeWithName: nameString
+		  superclassName: superclassString
+		  traitComposition: traitCompositionString
+		  classTraitComposition: classTraitCompositionString
+		  category: categoryString
+		  instVarNames: ivarArray
+		  classVarNames: cvarArray
+		  poolDictionaryNames: poolArray
+		  classInstVarNames: civarArray
+		  type: typeSymbol
 ]
 
 { #category : #'instance creation' }
@@ -65,8 +63,8 @@ MCClassDefinition class >> name: nameString superclassName: superclassString tra
 		   classVarNames: cvarArray
 		   poolDictionaryNames: poolArray
 		   classInstVarNames: civarArray
-		   type: typeSymbol
-		   comment: commentString)
+		   type: typeSymbol)
+		  comment: commentString;
 		  commentStamp: stampString;
 		  yourself
 ]
@@ -94,7 +92,7 @@ MCClassDefinition >> actualClass [
 	^ Smalltalk globals classNamed: self className
 ]
 
-{ #category : #initializing }
+{ #category : #initialization }
 MCClassDefinition >> addVariables: aCollection ofType: aClass [
 	variables addAll: (aCollection collect: [:var | aClass name: var asString]).
 ]
@@ -186,6 +184,12 @@ MCClassDefinition >> comment [
 ]
 
 { #category : #accessing }
+MCClassDefinition >> comment: aString [
+
+	comment := aString withInternalLineEndings
+]
+
+{ #category : #accessing }
 MCClassDefinition >> commentStamp [
 	^ commentStamp
 ]
@@ -238,7 +242,7 @@ MCClassDefinition >> createVariableFromString: aString [
 			UndefinedSlot named: slotName ast: ast  ]
 ]
 
-{ #category : #initializing }
+{ #category : #accessing }
 MCClassDefinition >> defaultCommentStamp [
 	^ String new
 
@@ -301,11 +305,13 @@ MCClassDefinition >> hash [
 MCClassDefinition >> initialize [
 
 	super initialize.
-	commentStamp := self defaultCommentStamp
+	comment := ''.
+	commentStamp := self defaultCommentStamp.
+	variables := OrderedCollection new
 ]
 
-{ #category : #initializing }
-MCClassDefinition >> initializeWithName: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray classInstVarNames: civarArray type: typeSymbol comment: commentString [
+{ #category : #initialization }
+MCClassDefinition >> initializeWithName: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray classInstVarNames: civarArray type: typeSymbol [
 
 	name := nameString asSymbol.
 	superclassName := superclassString
@@ -314,11 +320,10 @@ MCClassDefinition >> initializeWithName: nameString superclassName: superclassSt
 	traitComposition := traitCompositionString.
 	classTraitComposition := classTraitCompositionString.
 	category := categoryString.
-	 type := (#(#CompiledMethod #CompiledBlock #CompiledCode) includes: name)
-		ifTrue: [ #compiledMethod ]
-		ifFalse: [ typeSymbol ].
-	comment := commentString withInternalLineEndings.
-	variables := OrderedCollection new.
+	type := (#( #CompiledMethod #CompiledBlock #CompiledCode ) includes: name)
+		        ifTrue: [ #compiledMethod ]
+		        ifFalse: [ typeSymbol ].
+
 	self addVariables: ivarArray ofType: MCInstanceVariableDefinition.
 	self addVariables: cvarArray asSortedCollection ofType: MCClassVariableDefinition.
 	self addVariables: poolArray asSortedCollection ofType: MCPoolImportDefinition.

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -22,22 +22,21 @@ Class {
 MCClassDefinition class >> name: nameString superclassName: superclassString category: categoryString instVarNames: ivarArray comment: commentString [
 
 	^ self
-		name: nameString
-		superclassName: superclassString
-		traitComposition: '{}'
-		classTraitComposition: '{}'
-		category: categoryString
-		instVarNames: ivarArray
-		classVarNames: ''
-		poolDictionaryNames: ''
-		classInstVarNames: ''
-		type: #normal
-		comment: commentString
-		commentStamp: nil
+		  name: nameString
+		  superclassName: superclassString
+		  traitComposition: '{}'
+		  classTraitComposition: '{}'
+		  category: categoryString
+		  instVarNames: ivarArray
+		  classVarNames: ''
+		  poolDictionaryNames: ''
+		  classInstVarNames: ''
+		  type: #normal
+		  comment: commentString
 ]
 
 { #category : #'instance creation' }
-MCClassDefinition class >> name: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray classInstVarNames: civarArray type: typeSymbol comment: commentString commentStamp: stampString [
+MCClassDefinition class >> name: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray classInstVarNames: civarArray type: typeSymbol comment: commentString [
 
 	^ self new
 		initializeWithName: nameString
@@ -51,7 +50,25 @@ MCClassDefinition class >> name: nameString superclassName: superclassString tra
 		classInstVarNames: civarArray
 		type: typeSymbol
 		comment: commentString
-		commentStamp: stampString
+]
+
+{ #category : #'instance creation' }
+MCClassDefinition class >> name: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray classInstVarNames: civarArray type: typeSymbol comment: commentString commentStamp: stampString [
+
+	^ (self new
+		   initializeWithName: nameString
+		   superclassName: superclassString
+		   traitComposition: traitCompositionString
+		   classTraitComposition: classTraitCompositionString
+		   category: categoryString
+		   instVarNames: ivarArray
+		   classVarNames: cvarArray
+		   poolDictionaryNames: poolArray
+		   classInstVarNames: civarArray
+		   type: typeSymbol
+		   comment: commentString)
+		  commentStamp: stampString;
+		  yourself
 ]
 
 { #category : #comparing }
@@ -85,6 +102,11 @@ MCClassDefinition >> addVariables: aCollection ofType: aClass [
 { #category : #accessing }
 MCClassDefinition >> category [
 	^ category
+]
+
+{ #category : #accessing }
+MCClassDefinition >> category: anObject [
+	category := anObject
 ]
 
 { #category : #accessing }
@@ -126,6 +148,11 @@ MCClassDefinition >> classTraitComposition [
 ]
 
 { #category : #accessing }
+MCClassDefinition >> classTraitComposition: anObject [
+	classTraitComposition := anObject
+]
+
+{ #category : #accessing }
 MCClassDefinition >> classTraitCompositionCompiled [
 		^(Smalltalk compiler evaluate: self classTraitCompositionString) asTraitComposition 
 ]
@@ -163,13 +190,18 @@ MCClassDefinition >> commentStamp [
 	^ commentStamp
 ]
 
+{ #category : #accessing }
+MCClassDefinition >> commentStamp: anObject [
+	commentStamp := anObject
+]
+
 { #category : #installing }
 MCClassDefinition >> createClass [
 	| superClass |
 	"Ignore Context definition because of troubles with class migration on bootstrapped image. Temporary solution."
 	name = #Context
 		ifTrue: [ Context comment = comment 
-						ifFalse: [ Context comment: comment stamp: commentStamp ].
+						ifFalse: [ Context comment: comment stamp: self commentStamp ].
 					^ self ].
 
 	superClass := superclassName = #nil
@@ -186,7 +218,7 @@ MCClassDefinition >> createClass [
 				classSlots: self classInstanceVariables;
 				traitComposition: self traitCompositionCompiled;
 				classTraitComposition: self classTraitCompositionCompiled;
-				comment: comment stamp: commentStamp;
+				comment: comment stamp: self commentStamp;
 				category: category;
 				environment: superClass environment ] ]
 		on: Warning , DuplicatedVariableError
@@ -265,8 +297,15 @@ MCClassDefinition >> hash [
 	^ hash
 ]
 
+{ #category : #initialization }
+MCClassDefinition >> initialize [
+
+	super initialize.
+	commentStamp := self defaultCommentStamp
+]
+
 { #category : #initializing }
-MCClassDefinition >> initializeWithName: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray classInstVarNames: civarArray type: typeSymbol comment: commentString commentStamp: stampStringOrNil [
+MCClassDefinition >> initializeWithName: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray classInstVarNames: civarArray type: typeSymbol comment: commentString [
 
 	name := nameString asSymbol.
 	superclassName := superclassString
@@ -279,7 +318,6 @@ MCClassDefinition >> initializeWithName: nameString superclassName: superclassSt
 		ifTrue: [ #compiledMethod ]
 		ifFalse: [ typeSymbol ].
 	comment := commentString withInternalLineEndings.
-	commentStamp := stampStringOrNil ifNil: [ self defaultCommentStamp ].
 	variables := OrderedCollection new.
 	self addVariables: ivarArray ofType: MCInstanceVariableDefinition.
 	self addVariables: cvarArray asSortedCollection ofType: MCClassVariableDefinition.
@@ -333,6 +371,11 @@ MCClassDefinition >> kindOfSubclass [
 { #category : #installing }
 MCClassDefinition >> load [
 	self createClass
+]
+
+{ #category : #accessing }
+MCClassDefinition >> name: anObject [
+	name := anObject
 ]
 
 { #category : #installing }
@@ -518,8 +561,18 @@ MCClassDefinition >> superclassName [
 ]
 
 { #category : #accessing }
+MCClassDefinition >> superclassName: anObject [
+	superclassName := anObject
+]
+
+{ #category : #accessing }
 MCClassDefinition >> traitComposition [
 	^traitComposition
+]
+
+{ #category : #accessing }
+MCClassDefinition >> traitComposition: anObject [
+	traitComposition := anObject
 ]
 
 { #category : #accessing }

--- a/src/Monticello/MCStReader.class.st
+++ b/src/Monticello/MCStReader.class.st
@@ -57,8 +57,8 @@ MCStReader >> classDefinitionFrom: aRingClass [
 		   name: (tokens at: 3)
 		   superclassName: (tokens at: 1)
 		   traitComposition: traitCompositionString
-		   classTraitComposition: classTraitCompositionString
-		   category: (tokens at: lastIndex))
+		   classTraitComposition: classTraitCompositionString)
+		  category: (tokens at: lastIndex);
 		  instVarNames: ((tokens at: lastIndex - 6) findTokens: ' ');
 		  classVarNames: ((tokens at: lastIndex - 4) findTokens: ' ');
 		  poolDictionaryNames: ((tokens at: lastIndex - 2) findTokens: ' ');

--- a/src/Monticello/MCStReader.class.st
+++ b/src/Monticello/MCStReader.class.st
@@ -41,30 +41,32 @@ MCStReader >> categoryFromDoIt: aString [
 
 { #category : #reading }
 MCStReader >> classDefinitionFrom: aRingClass [
+
 	| tokens traitCompositionString lastIndex classTraitCompositionString |
 	tokens := aRingClass definitionSource parseLiterals.
 	traitCompositionString := (aRingClass definitionSource readStream
-		match: 'uses:';
-		upToAll: 'instanceVariableNames:') trimBoth.
+		                           match: 'uses:';
+		                           upToAll: 'instanceVariableNames:') trimBoth.
 	classTraitCompositionString := (aRingClass classSide definitionSource asString readStream
-		match: 'uses:';
-		upToAll: 'instanceVariableNames:') trimBoth.
-	traitCompositionString isEmpty ifTrue: [traitCompositionString := '{}'].
-	classTraitCompositionString isEmpty ifTrue: [classTraitCompositionString := '{}'].
+		                                match: 'uses:';
+		                                upToAll: 'instanceVariableNames:') trimBoth.
+	traitCompositionString isEmpty ifTrue: [ traitCompositionString := '{}' ].
+	classTraitCompositionString isEmpty ifTrue: [ classTraitCompositionString := '{}' ].
 	lastIndex := tokens size.
-	^ MCClassDefinition
-		name: (tokens at: 3)
-		superclassName: (tokens at: 1)
-		traitComposition: traitCompositionString
-		classTraitComposition: classTraitCompositionString
-		category: (tokens at: lastIndex)
-		instVarNames: ((tokens at: lastIndex - 6) findTokens: ' ')
-		classVarNames: ((tokens at: lastIndex - 4) findTokens: ' ')
-		poolDictionaryNames: ((tokens at: lastIndex - 2) findTokens: ' ')
-		classInstVarNames: (self classInstVarNamesFor: aRingClass)
-		type: (self typeOfSubclass: (tokens at: 2))
-		comment: (self commentFor: aRingClass)
-		commentStamp: (self commentStampFor: aRingClass)
+	^ (MCClassDefinition
+		   name: (tokens at: 3)
+		   superclassName: (tokens at: 1)
+		   traitComposition: traitCompositionString
+		   classTraitComposition: classTraitCompositionString
+		   category: (tokens at: lastIndex)
+		   instVarNames: ((tokens at: lastIndex - 6) findTokens: ' ')
+		   classVarNames: ((tokens at: lastIndex - 4) findTokens: ' ')
+		   poolDictionaryNames: ((tokens at: lastIndex - 2) findTokens: ' ')
+		   classInstVarNames: (self classInstVarNamesFor: aRingClass)
+		   type: (self typeOfSubclass: (tokens at: 2))
+		   comment: (self commentFor: aRingClass))
+		  commentStamp: (self commentStampFor: aRingClass);
+		  yourself
 ]
 
 { #category : #reading }

--- a/src/Monticello/MCStReader.class.st
+++ b/src/Monticello/MCStReader.class.st
@@ -59,8 +59,8 @@ MCStReader >> classDefinitionFrom: aRingClass [
 		   traitComposition: traitCompositionString
 		   classTraitComposition: classTraitCompositionString
 		   category: (tokens at: lastIndex)
-		   instVarNames: ((tokens at: lastIndex - 6) findTokens: ' ')
-		   classVarNames: ((tokens at: lastIndex - 4) findTokens: ' '))
+		   instVarNames: ((tokens at: lastIndex - 6) findTokens: ' '))
+		  classVarNames: ((tokens at: lastIndex - 4) findTokens: ' ');
 		  poolDictionaryNames: ((tokens at: lastIndex - 2) findTokens: ' ');
 		  classInstVarNames: (self classInstVarNamesFor: aRingClass);
 		  type: (self typeOfSubclass: (tokens at: 2));

--- a/src/Monticello/MCStReader.class.st
+++ b/src/Monticello/MCStReader.class.st
@@ -60,8 +60,8 @@ MCStReader >> classDefinitionFrom: aRingClass [
 		   classTraitComposition: classTraitCompositionString
 		   category: (tokens at: lastIndex)
 		   instVarNames: ((tokens at: lastIndex - 6) findTokens: ' ')
-		   classVarNames: ((tokens at: lastIndex - 4) findTokens: ' ')
-		   poolDictionaryNames: ((tokens at: lastIndex - 2) findTokens: ' '))
+		   classVarNames: ((tokens at: lastIndex - 4) findTokens: ' '))
+		  poolDictionaryNames: ((tokens at: lastIndex - 2) findTokens: ' ');
 		  classInstVarNames: (self classInstVarNamesFor: aRingClass);
 		  type: (self typeOfSubclass: (tokens at: 2));
 		  comment: (self commentFor: aRingClass);

--- a/src/Monticello/MCStReader.class.st
+++ b/src/Monticello/MCStReader.class.st
@@ -63,8 +63,8 @@ MCStReader >> classDefinitionFrom: aRingClass [
 		   classVarNames: ((tokens at: lastIndex - 4) findTokens: ' ')
 		   poolDictionaryNames: ((tokens at: lastIndex - 2) findTokens: ' ')
 		   classInstVarNames: (self classInstVarNamesFor: aRingClass)
-		   type: (self typeOfSubclass: (tokens at: 2))
-		   comment: (self commentFor: aRingClass))
+		   type: (self typeOfSubclass: (tokens at: 2)))
+		  comment: (self commentFor: aRingClass);
 		  commentStamp: (self commentStampFor: aRingClass);
 		  yourself
 ]

--- a/src/Monticello/MCStReader.class.st
+++ b/src/Monticello/MCStReader.class.st
@@ -61,8 +61,8 @@ MCStReader >> classDefinitionFrom: aRingClass [
 		   category: (tokens at: lastIndex)
 		   instVarNames: ((tokens at: lastIndex - 6) findTokens: ' ')
 		   classVarNames: ((tokens at: lastIndex - 4) findTokens: ' ')
-		   poolDictionaryNames: ((tokens at: lastIndex - 2) findTokens: ' ')
-		   classInstVarNames: (self classInstVarNamesFor: aRingClass))
+		   poolDictionaryNames: ((tokens at: lastIndex - 2) findTokens: ' '))
+		  classInstVarNames: (self classInstVarNamesFor: aRingClass);
 		  type: (self typeOfSubclass: (tokens at: 2));
 		  comment: (self commentFor: aRingClass);
 		  commentStamp: (self commentStampFor: aRingClass);

--- a/src/Monticello/MCStReader.class.st
+++ b/src/Monticello/MCStReader.class.st
@@ -53,11 +53,10 @@ MCStReader >> classDefinitionFrom: aRingClass [
 	traitCompositionString isEmpty ifTrue: [ traitCompositionString := '{}' ].
 	classTraitCompositionString isEmpty ifTrue: [ classTraitCompositionString := '{}' ].
 	lastIndex := tokens size.
-	^ (MCClassDefinition
-		   name: (tokens at: 3)
-		   superclassName: (tokens at: 1)
-		   traitComposition: traitCompositionString
-		   classTraitComposition: classTraitCompositionString)
+	^ (MCClassDefinition named: (tokens at: 3))
+		  superclassName: (tokens at: 1);
+		  traitComposition: traitCompositionString;
+		  classTraitComposition: classTraitCompositionString;
 		  category: (tokens at: lastIndex);
 		  instVarNames: ((tokens at: lastIndex - 6) findTokens: ' ');
 		  classVarNames: ((tokens at: lastIndex - 4) findTokens: ' ');

--- a/src/Monticello/MCStReader.class.st
+++ b/src/Monticello/MCStReader.class.st
@@ -58,8 +58,8 @@ MCStReader >> classDefinitionFrom: aRingClass [
 		   superclassName: (tokens at: 1)
 		   traitComposition: traitCompositionString
 		   classTraitComposition: classTraitCompositionString
-		   category: (tokens at: lastIndex)
-		   instVarNames: ((tokens at: lastIndex - 6) findTokens: ' '))
+		   category: (tokens at: lastIndex))
+		  instVarNames: ((tokens at: lastIndex - 6) findTokens: ' ');
 		  classVarNames: ((tokens at: lastIndex - 4) findTokens: ' ');
 		  poolDictionaryNames: ((tokens at: lastIndex - 2) findTokens: ' ');
 		  classInstVarNames: (self classInstVarNamesFor: aRingClass);

--- a/src/Monticello/MCStReader.class.st
+++ b/src/Monticello/MCStReader.class.st
@@ -62,8 +62,8 @@ MCStReader >> classDefinitionFrom: aRingClass [
 		   instVarNames: ((tokens at: lastIndex - 6) findTokens: ' ')
 		   classVarNames: ((tokens at: lastIndex - 4) findTokens: ' ')
 		   poolDictionaryNames: ((tokens at: lastIndex - 2) findTokens: ' ')
-		   classInstVarNames: (self classInstVarNamesFor: aRingClass)
-		   type: (self typeOfSubclass: (tokens at: 2)))
+		   classInstVarNames: (self classInstVarNamesFor: aRingClass))
+		  type: (self typeOfSubclass: (tokens at: 2));
 		  comment: (self commentFor: aRingClass);
 		  commentStamp: (self commentStampFor: aRingClass);
 		  yourself

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
@@ -74,8 +74,8 @@ MCFileTreeStCypressReader >> addClassDefinitionFrom: classPropertiesDict comment
 			  superclassName: (classPropertiesDict at: 'super')
 			  traitComposition: (classPropertiesDict at: 'traitcomposition' ifAbsent: [ '{}' ])
 			  classTraitComposition: (classPropertiesDict at: 'classtraitcomposition' ifAbsent: [ '{}' ])
-			  category: categoryName
-			  instVarNames: (classPropertiesDict at: 'instvars' ifAbsent: [ #(  ) ]))
+			  category: categoryName)
+			 instVarNames: (classPropertiesDict at: 'instvars' ifAbsent: [ #(  ) ]);
 			 classVarNames: (classPropertiesDict at: 'classvars' ifAbsent: [ #(  ) ]);
 			 poolDictionaryNames: (classPropertiesDict at: 'pools' ifAbsent: [ #(  ) ]);
 			 classInstVarNames: (classPropertiesDict at: 'classinstvars' ifAbsent: [ #(  ) ]);

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
@@ -65,24 +65,28 @@ MCFileTreeStCypressReader >> addClassAndMethodDefinitionsFromEntry: classEntry [
 { #category : #utilities }
 MCFileTreeStCypressReader >> addClassDefinitionFrom: classPropertiesDict comment: classComment [
 
-	| categoryName className |
+	| categoryName className definition |
 	className := classPropertiesDict at: 'name'.
 	categoryName := classPropertiesDict at: 'category' ifAbsent: [ self packageNameFromPackageDirectory ].
 	self validateClassCategory: categoryName for: className.
-	definitions add: ((MCClassDefinition
-			  name: className
-			  superclassName: (classPropertiesDict at: 'super')
-			  traitComposition: (classPropertiesDict at: 'traitcomposition' ifAbsent: [ '{}' ])
-			  classTraitComposition: (classPropertiesDict at: 'classtraitcomposition' ifAbsent: [ '{}' ]))
-			 category: categoryName;
-			 instVarNames: (classPropertiesDict at: 'instvars' ifAbsent: [ #(  ) ]);
-			 classVarNames: (classPropertiesDict at: 'classvars' ifAbsent: [ #(  ) ]);
-			 poolDictionaryNames: (classPropertiesDict at: 'pools' ifAbsent: [ #(  ) ]);
-			 classInstVarNames: (classPropertiesDict at: 'classinstvars' ifAbsent: [ #(  ) ]);
-			 type: (classPropertiesDict at: 'type' ifAbsent: [ #normal ]) asSymbol;
-			 comment: classComment;
-			 commentStamp: (classPropertiesDict at: 'commentStamp' ifAbsent: [ '' ]);
-			 yourself)
+
+	definition := (MCClassDefinition named: className)
+		              superclassName: (classPropertiesDict at: 'super');
+		              category: categoryName;
+		              comment: classComment;
+		              yourself.
+
+	classPropertiesDict
+		at: 'traitcomposition' ifPresent: [ :composition | definition traitComposition: composition ];
+		at: 'classtraitcomposition' ifPresent: [ :composition | definition classTraitComposition: composition ];
+		at: 'instvars' ifPresent: [ :instVars | definition instVarNames: instVars ];
+		at: 'classvars' ifPresent: [ :classVars | definition classVarNames: classVars ];
+		at: 'pools' ifPresent: [ :pools | definition poolDictionaryNames: pools ];
+		at: 'classinstvars' ifPresent: [ :classInstVars | definition classInstVarNames: classInstVars ];
+		at: 'type' ifPresent: [ :type | definition type: type ];
+		at: 'commentStamp' ifPresent: [ :stamp | definition commentStamp: stamp ].
+
+	definitions add: definition
 ]
 
 { #category : #utilities }

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
@@ -73,8 +73,8 @@ MCFileTreeStCypressReader >> addClassDefinitionFrom: classPropertiesDict comment
 			  name: className
 			  superclassName: (classPropertiesDict at: 'super')
 			  traitComposition: (classPropertiesDict at: 'traitcomposition' ifAbsent: [ '{}' ])
-			  classTraitComposition: (classPropertiesDict at: 'classtraitcomposition' ifAbsent: [ '{}' ])
-			  category: categoryName)
+			  classTraitComposition: (classPropertiesDict at: 'classtraitcomposition' ifAbsent: [ '{}' ]))
+			 category: categoryName;
 			 instVarNames: (classPropertiesDict at: 'instvars' ifAbsent: [ #(  ) ]);
 			 classVarNames: (classPropertiesDict at: 'classvars' ifAbsent: [ #(  ) ]);
 			 poolDictionaryNames: (classPropertiesDict at: 'pools' ifAbsent: [ #(  ) ]);

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
@@ -79,8 +79,8 @@ MCFileTreeStCypressReader >> addClassDefinitionFrom: classPropertiesDict comment
 			  classVarNames: (classPropertiesDict at: 'classvars' ifAbsent: [ #(  ) ])
 			  poolDictionaryNames: (classPropertiesDict at: 'pools' ifAbsent: [ #(  ) ])
 			  classInstVarNames: (classPropertiesDict at: 'classinstvars' ifAbsent: [ #(  ) ])
-			  type: (classPropertiesDict at: 'type' ifAbsent: [ 'normal' ]) asSymbol
-			  comment: classComment)
+			  type: (classPropertiesDict at: 'type' ifAbsent: [ 'normal' ]) asSymbol)
+			 comment: classComment;
 			 commentStamp: (classPropertiesDict at: 'commentStamp' ifAbsent: [ '' ]);
 			 yourself)
 ]

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
@@ -78,8 +78,8 @@ MCFileTreeStCypressReader >> addClassDefinitionFrom: classPropertiesDict comment
 			  instVarNames: (classPropertiesDict at: 'instvars' ifAbsent: [ #(  ) ])
 			  classVarNames: (classPropertiesDict at: 'classvars' ifAbsent: [ #(  ) ])
 			  poolDictionaryNames: (classPropertiesDict at: 'pools' ifAbsent: [ #(  ) ])
-			  classInstVarNames: (classPropertiesDict at: 'classinstvars' ifAbsent: [ #(  ) ])
-			  type: (classPropertiesDict at: 'type' ifAbsent: [ 'normal' ]) asSymbol)
+			  classInstVarNames: (classPropertiesDict at: 'classinstvars' ifAbsent: [ #(  ) ]))
+			 type: (classPropertiesDict at: 'type' ifAbsent: [ #normal ]) asSymbol;
 			 comment: classComment;
 			 commentStamp: (classPropertiesDict at: 'commentStamp' ifAbsent: [ '' ]);
 			 yourself)

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
@@ -77,8 +77,8 @@ MCFileTreeStCypressReader >> addClassDefinitionFrom: classPropertiesDict comment
 			  category: categoryName
 			  instVarNames: (classPropertiesDict at: 'instvars' ifAbsent: [ #(  ) ])
 			  classVarNames: (classPropertiesDict at: 'classvars' ifAbsent: [ #(  ) ])
-			  poolDictionaryNames: (classPropertiesDict at: 'pools' ifAbsent: [ #(  ) ])
-			  classInstVarNames: (classPropertiesDict at: 'classinstvars' ifAbsent: [ #(  ) ]))
+			  poolDictionaryNames: (classPropertiesDict at: 'pools' ifAbsent: [ #(  ) ]))
+			 classInstVarNames: (classPropertiesDict at: 'classinstvars' ifAbsent: [ #(  ) ]);
 			 type: (classPropertiesDict at: 'type' ifAbsent: [ #normal ]) asSymbol;
 			 comment: classComment;
 			 commentStamp: (classPropertiesDict at: 'commentStamp' ifAbsent: [ '' ]);

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
@@ -64,30 +64,25 @@ MCFileTreeStCypressReader >> addClassAndMethodDefinitionsFromEntry: classEntry [
 
 { #category : #utilities }
 MCFileTreeStCypressReader >> addClassDefinitionFrom: classPropertiesDict comment: classComment [
-  | categoryName className |
-  className := classPropertiesDict at: 'name'.
-  categoryName := classPropertiesDict
-    at: 'category'
-    ifAbsent: [ self packageNameFromPackageDirectory ].
-  self validateClassCategory: categoryName for: className.
-  definitions
-    add:
-      (MCClassDefinition
-        name: className
-        superclassName: (classPropertiesDict at: 'super')
-        traitComposition: (classPropertiesDict at: 'traitcomposition' ifAbsent: [ '{}' ])
-        classTraitComposition: (classPropertiesDict at: 'classtraitcomposition' ifAbsent: [ '{}' ])
-        category: categoryName
-        instVarNames: (classPropertiesDict at: 'instvars' ifAbsent: [ #() ])
-        classVarNames: (classPropertiesDict at: 'classvars' ifAbsent: [ #() ])
-        poolDictionaryNames: (classPropertiesDict at: 'pools' ifAbsent: [ #() ])
-        classInstVarNames:
-          (classPropertiesDict at: 'classinstvars' ifAbsent: [ #() ])
-        type: (classPropertiesDict at: 'type' ifAbsent: [ 'normal' ]) asSymbol
-        comment: classComment
-        commentStamp: (classPropertiesDict at: 'commentStamp' ifAbsent: [ '' ]))
 
-
+	| categoryName className |
+	className := classPropertiesDict at: 'name'.
+	categoryName := classPropertiesDict at: 'category' ifAbsent: [ self packageNameFromPackageDirectory ].
+	self validateClassCategory: categoryName for: className.
+	definitions add: ((MCClassDefinition
+			  name: className
+			  superclassName: (classPropertiesDict at: 'super')
+			  traitComposition: (classPropertiesDict at: 'traitcomposition' ifAbsent: [ '{}' ])
+			  classTraitComposition: (classPropertiesDict at: 'classtraitcomposition' ifAbsent: [ '{}' ])
+			  category: categoryName
+			  instVarNames: (classPropertiesDict at: 'instvars' ifAbsent: [ #(  ) ])
+			  classVarNames: (classPropertiesDict at: 'classvars' ifAbsent: [ #(  ) ])
+			  poolDictionaryNames: (classPropertiesDict at: 'pools' ifAbsent: [ #(  ) ])
+			  classInstVarNames: (classPropertiesDict at: 'classinstvars' ifAbsent: [ #(  ) ])
+			  type: (classPropertiesDict at: 'type' ifAbsent: [ 'normal' ]) asSymbol
+			  comment: classComment)
+			 commentStamp: (classPropertiesDict at: 'commentStamp' ifAbsent: [ '' ]);
+			 yourself)
 ]
 
 { #category : #utilities }

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
@@ -76,8 +76,8 @@ MCFileTreeStCypressReader >> addClassDefinitionFrom: classPropertiesDict comment
 			  classTraitComposition: (classPropertiesDict at: 'classtraitcomposition' ifAbsent: [ '{}' ])
 			  category: categoryName
 			  instVarNames: (classPropertiesDict at: 'instvars' ifAbsent: [ #(  ) ])
-			  classVarNames: (classPropertiesDict at: 'classvars' ifAbsent: [ #(  ) ])
-			  poolDictionaryNames: (classPropertiesDict at: 'pools' ifAbsent: [ #(  ) ]))
+			  classVarNames: (classPropertiesDict at: 'classvars' ifAbsent: [ #(  ) ]))
+			 poolDictionaryNames: (classPropertiesDict at: 'pools' ifAbsent: [ #(  ) ]);
 			 classInstVarNames: (classPropertiesDict at: 'classinstvars' ifAbsent: [ #(  ) ]);
 			 type: (classPropertiesDict at: 'type' ifAbsent: [ #normal ]) asSymbol;
 			 comment: classComment;

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
@@ -75,8 +75,8 @@ MCFileTreeStCypressReader >> addClassDefinitionFrom: classPropertiesDict comment
 			  traitComposition: (classPropertiesDict at: 'traitcomposition' ifAbsent: [ '{}' ])
 			  classTraitComposition: (classPropertiesDict at: 'classtraitcomposition' ifAbsent: [ '{}' ])
 			  category: categoryName
-			  instVarNames: (classPropertiesDict at: 'instvars' ifAbsent: [ #(  ) ])
-			  classVarNames: (classPropertiesDict at: 'classvars' ifAbsent: [ #(  ) ]))
+			  instVarNames: (classPropertiesDict at: 'instvars' ifAbsent: [ #(  ) ]))
+			 classVarNames: (classPropertiesDict at: 'classvars' ifAbsent: [ #(  ) ]);
 			 poolDictionaryNames: (classPropertiesDict at: 'pools' ifAbsent: [ #(  ) ]);
 			 classInstVarNames: (classPropertiesDict at: 'classinstvars' ifAbsent: [ #(  ) ]);
 			 type: (classPropertiesDict at: 'type' ifAbsent: [ #normal ]) asSymbol;

--- a/src/Ring-Monticello/RGClassStrategy.extension.st
+++ b/src/Ring-Monticello/RGClassStrategy.extension.st
@@ -12,8 +12,8 @@ RGClassStrategy >> asMCDefinition [
 		   classTraitComposition: self owner metaclass traitCompositionString
 		   category: self owner category
 		   instVarNames: self instVarNames
-		   classVarNames: self owner classVarNames
-		   poolDictionaryNames: self owner sharedPoolNames)
+		   classVarNames: self owner classVarNames)
+		  poolDictionaryNames: self owner sharedPoolNames;
 		  classInstVarNames: self owner metaclass instVarNames;
 		  type: self mcType;
 		  comment: self owner comment content;

--- a/src/Ring-Monticello/RGClassStrategy.extension.st
+++ b/src/Ring-Monticello/RGClassStrategy.extension.st
@@ -13,8 +13,8 @@ RGClassStrategy >> asMCDefinition [
 		   category: self owner category
 		   instVarNames: self instVarNames
 		   classVarNames: self owner classVarNames
-		   poolDictionaryNames: self owner sharedPoolNames
-		   classInstVarNames: self owner metaclass instVarNames)
+		   poolDictionaryNames: self owner sharedPoolNames)
+		  classInstVarNames: self owner metaclass instVarNames;
 		  type: self mcType;
 		  comment: self owner comment content;
 		  commentStamp: self owner comment stamp;

--- a/src/Ring-Monticello/RGClassStrategy.extension.st
+++ b/src/Ring-Monticello/RGClassStrategy.extension.st
@@ -15,8 +15,8 @@ RGClassStrategy >> asMCDefinition [
 		   classVarNames: self owner classVarNames
 		   poolDictionaryNames: self owner sharedPoolNames
 		   classInstVarNames: self owner metaclass instVarNames
-		   type: self mcType
-		   comment: self owner comment content)
+		   type: self mcType)
+		  comment: self owner comment content;
 		  commentStamp: self owner comment stamp;
 		  yourself
 ]

--- a/src/Ring-Monticello/RGClassStrategy.extension.st
+++ b/src/Ring-Monticello/RGClassStrategy.extension.st
@@ -14,8 +14,8 @@ RGClassStrategy >> asMCDefinition [
 		   instVarNames: self instVarNames
 		   classVarNames: self owner classVarNames
 		   poolDictionaryNames: self owner sharedPoolNames
-		   classInstVarNames: self owner metaclass instVarNames
-		   type: self mcType)
+		   classInstVarNames: self owner metaclass instVarNames)
+		  type: self mcType;
 		  comment: self owner comment content;
 		  commentStamp: self owner comment stamp;
 		  yourself

--- a/src/Ring-Monticello/RGClassStrategy.extension.st
+++ b/src/Ring-Monticello/RGClassStrategy.extension.st
@@ -11,8 +11,8 @@ RGClassStrategy >> asMCDefinition [
 		   traitComposition: self owner traitCompositionString
 		   classTraitComposition: self owner metaclass traitCompositionString
 		   category: self owner category
-		   instVarNames: self instVarNames
-		   classVarNames: self owner classVarNames)
+		   instVarNames: self instVarNames)
+		  classVarNames: self owner classVarNames;
 		  poolDictionaryNames: self owner sharedPoolNames;
 		  classInstVarNames: self owner metaclass instVarNames;
 		  type: self mcType;

--- a/src/Ring-Monticello/RGClassStrategy.extension.st
+++ b/src/Ring-Monticello/RGClassStrategy.extension.st
@@ -10,8 +10,8 @@ RGClassStrategy >> asMCDefinition [
 				    ifNotNil: [ :aSuperclass | aSuperclass name ])
 		   traitComposition: self owner traitCompositionString
 		   classTraitComposition: self owner metaclass traitCompositionString
-		   category: self owner category
-		   instVarNames: self instVarNames)
+		   category: self owner category)
+		  instVarNames: self instVarNames;
 		  classVarNames: self owner classVarNames;
 		  poolDictionaryNames: self owner sharedPoolNames;
 		  classInstVarNames: self owner metaclass instVarNames;

--- a/src/Ring-Monticello/RGClassStrategy.extension.st
+++ b/src/Ring-Monticello/RGClassStrategy.extension.st
@@ -9,8 +9,8 @@ RGClassStrategy >> asMCDefinition [
 				    ifNil: [ 'nil' ]
 				    ifNotNil: [ :aSuperclass | aSuperclass name ])
 		   traitComposition: self owner traitCompositionString
-		   classTraitComposition: self owner metaclass traitCompositionString
-		   category: self owner category)
+		   classTraitComposition: self owner metaclass traitCompositionString)
+		  category: self owner category;
 		  instVarNames: self instVarNames;
 		  classVarNames: self owner classVarNames;
 		  poolDictionaryNames: self owner sharedPoolNames;

--- a/src/Ring-Monticello/RGClassStrategy.extension.st
+++ b/src/Ring-Monticello/RGClassStrategy.extension.st
@@ -3,19 +3,22 @@ Extension { #name : #RGClassStrategy }
 { #category : #'*Ring-Monticello' }
 RGClassStrategy >> asMCDefinition [
 
-	^ MCClassDefinition
-		name: self owner name
-		superclassName: (self owner superclass ifNil: [ 'nil' ] ifNotNil: [ :aSuperclass | aSuperclass name ])
-		traitComposition: self owner traitCompositionString
-		classTraitComposition: self owner metaclass traitCompositionString
-		category: self owner category
-		instVarNames: self instVarNames
-		classVarNames: self owner classVarNames
-		poolDictionaryNames: self owner sharedPoolNames
-		classInstVarNames: self owner metaclass instVarNames
-		type: self mcType
-		comment: self owner comment content
-		commentStamp: self owner comment stamp
+	^ (MCClassDefinition
+		   name: self owner name
+		   superclassName: (self owner superclass
+				    ifNil: [ 'nil' ]
+				    ifNotNil: [ :aSuperclass | aSuperclass name ])
+		   traitComposition: self owner traitCompositionString
+		   classTraitComposition: self owner metaclass traitCompositionString
+		   category: self owner category
+		   instVarNames: self instVarNames
+		   classVarNames: self owner classVarNames
+		   poolDictionaryNames: self owner sharedPoolNames
+		   classInstVarNames: self owner metaclass instVarNames
+		   type: self mcType
+		   comment: self owner comment content)
+		  commentStamp: self owner comment stamp;
+		  yourself
 ]
 
 { #category : #'*Ring-Monticello' }

--- a/src/Ring-Monticello/RGClassStrategy.extension.st
+++ b/src/Ring-Monticello/RGClassStrategy.extension.st
@@ -3,13 +3,10 @@ Extension { #name : #RGClassStrategy }
 { #category : #'*Ring-Monticello' }
 RGClassStrategy >> asMCDefinition [
 
-	^ (MCClassDefinition
-		   name: self owner name
-		   superclassName: (self owner superclass
-				    ifNil: [ 'nil' ]
-				    ifNotNil: [ :aSuperclass | aSuperclass name ])
-		   traitComposition: self owner traitCompositionString
-		   classTraitComposition: self owner metaclass traitCompositionString)
+	^ (MCClassDefinition named: self owner name)
+		  superclassName: (self owner superclass ifNotNil: [ :aSuperclass | aSuperclass name ]);
+		  traitComposition: self owner traitCompositionString;
+		  classTraitComposition: self owner metaclass traitCompositionString;
 		  category: self owner category;
 		  instVarNames: self instVarNames;
 		  classVarNames: self owner classVarNames;

--- a/src/Ring-Monticello/RGTraitV2Strategy.extension.st
+++ b/src/Ring-Monticello/RGTraitV2Strategy.extension.st
@@ -12,8 +12,8 @@ RGTraitV2Strategy >> asMCDefinition [
 		   classTraitComposition: self owner metaclass traitCompositionString
 		   category: self category
 		   instVarNames: self instVarNames
-		   classVarNames: self classVarNames
-		   poolDictionaryNames: self sharedPoolNames)
+		   classVarNames: self classVarNames)
+		  poolDictionaryNames: self sharedPoolNames;
 		  classInstVarNames: self metaclass instVarNames;
 		  type: self mcType;
 		  comment: self comment content;

--- a/src/Ring-Monticello/RGTraitV2Strategy.extension.st
+++ b/src/Ring-Monticello/RGTraitV2Strategy.extension.st
@@ -15,8 +15,8 @@ RGTraitV2Strategy >> asMCDefinition [
 		   classVarNames: self classVarNames
 		   poolDictionaryNames: self sharedPoolNames
 		   classInstVarNames: self metaclass instVarNames
-		   type: self mcType
-		   comment: self comment content)
+		   type: self mcType)
+		  comment: self comment content;
 		  commentStamp: self comment stamp;
 		  yourself
 ]

--- a/src/Ring-Monticello/RGTraitV2Strategy.extension.st
+++ b/src/Ring-Monticello/RGTraitV2Strategy.extension.st
@@ -11,8 +11,8 @@ RGTraitV2Strategy >> asMCDefinition [
 		   traitComposition: self owner traitCompositionString
 		   classTraitComposition: self owner metaclass traitCompositionString
 		   category: self category
-		   instVarNames: self instVarNames
-		   classVarNames: self classVarNames)
+		   instVarNames: self instVarNames)
+		  classVarNames: self classVarNames;
 		  poolDictionaryNames: self sharedPoolNames;
 		  classInstVarNames: self metaclass instVarNames;
 		  type: self mcType;

--- a/src/Ring-Monticello/RGTraitV2Strategy.extension.st
+++ b/src/Ring-Monticello/RGTraitV2Strategy.extension.st
@@ -14,8 +14,8 @@ RGTraitV2Strategy >> asMCDefinition [
 		   instVarNames: self instVarNames
 		   classVarNames: self classVarNames
 		   poolDictionaryNames: self sharedPoolNames
-		   classInstVarNames: self metaclass instVarNames
-		   type: self mcType)
+		   classInstVarNames: self metaclass instVarNames)
+		  type: self mcType;
 		  comment: self comment content;
 		  commentStamp: self comment stamp;
 		  yourself

--- a/src/Ring-Monticello/RGTraitV2Strategy.extension.st
+++ b/src/Ring-Monticello/RGTraitV2Strategy.extension.st
@@ -3,19 +3,22 @@ Extension { #name : #RGTraitV2Strategy }
 { #category : #'*Ring-Monticello' }
 RGTraitV2Strategy >> asMCDefinition [
 
-	^ MCClassDefinition
-		name: self name
-		superclassName: (self superclass ifNil: [ 'nil' ] ifNotNil: [ :aSuperclass | aSuperclass name ])
-		traitComposition: self owner traitCompositionString
-		classTraitComposition: self owner metaclass traitCompositionString
-		category: self category
-		instVarNames: self instVarNames
-		classVarNames: self classVarNames
-		poolDictionaryNames: self sharedPoolNames
-		classInstVarNames: self metaclass instVarNames
-		type: self mcType
-		comment: self comment content
-		commentStamp: self comment stamp
+	^ (MCClassDefinition
+		   name: self name
+		   superclassName: (self superclass
+				    ifNil: [ 'nil' ]
+				    ifNotNil: [ :aSuperclass | aSuperclass name ])
+		   traitComposition: self owner traitCompositionString
+		   classTraitComposition: self owner metaclass traitCompositionString
+		   category: self category
+		   instVarNames: self instVarNames
+		   classVarNames: self classVarNames
+		   poolDictionaryNames: self sharedPoolNames
+		   classInstVarNames: self metaclass instVarNames
+		   type: self mcType
+		   comment: self comment content)
+		  commentStamp: self comment stamp;
+		  yourself
 ]
 
 { #category : #'*Ring-Monticello' }

--- a/src/Ring-Monticello/RGTraitV2Strategy.extension.st
+++ b/src/Ring-Monticello/RGTraitV2Strategy.extension.st
@@ -3,13 +3,10 @@ Extension { #name : #RGTraitV2Strategy }
 { #category : #'*Ring-Monticello' }
 RGTraitV2Strategy >> asMCDefinition [
 
-	^ (MCClassDefinition
-		   name: self name
-		   superclassName: (self superclass
-				    ifNil: [ 'nil' ]
-				    ifNotNil: [ :aSuperclass | aSuperclass name ])
-		   traitComposition: self owner traitCompositionString
-		   classTraitComposition: self owner metaclass traitCompositionString)
+	^ (MCClassDefinition named: self name)
+		  superclassName: (self superclass ifNotNil: [ :aSuperclass | aSuperclass name ]);
+		  traitComposition: self owner traitCompositionString;
+		  classTraitComposition: self owner metaclass traitCompositionString;
 		  category: self category;
 		  instVarNames: self instVarNames;
 		  classVarNames: self classVarNames;

--- a/src/Ring-Monticello/RGTraitV2Strategy.extension.st
+++ b/src/Ring-Monticello/RGTraitV2Strategy.extension.st
@@ -13,8 +13,8 @@ RGTraitV2Strategy >> asMCDefinition [
 		   category: self category
 		   instVarNames: self instVarNames
 		   classVarNames: self classVarNames
-		   poolDictionaryNames: self sharedPoolNames
-		   classInstVarNames: self metaclass instVarNames)
+		   poolDictionaryNames: self sharedPoolNames)
+		  classInstVarNames: self metaclass instVarNames;
 		  type: self mcType;
 		  comment: self comment content;
 		  commentStamp: self comment stamp;

--- a/src/Ring-Monticello/RGTraitV2Strategy.extension.st
+++ b/src/Ring-Monticello/RGTraitV2Strategy.extension.st
@@ -9,8 +9,8 @@ RGTraitV2Strategy >> asMCDefinition [
 				    ifNil: [ 'nil' ]
 				    ifNotNil: [ :aSuperclass | aSuperclass name ])
 		   traitComposition: self owner traitCompositionString
-		   classTraitComposition: self owner metaclass traitCompositionString
-		   category: self category)
+		   classTraitComposition: self owner metaclass traitCompositionString)
+		  category: self category;
 		  instVarNames: self instVarNames;
 		  classVarNames: self classVarNames;
 		  poolDictionaryNames: self sharedPoolNames;

--- a/src/Ring-Monticello/RGTraitV2Strategy.extension.st
+++ b/src/Ring-Monticello/RGTraitV2Strategy.extension.st
@@ -10,8 +10,8 @@ RGTraitV2Strategy >> asMCDefinition [
 				    ifNotNil: [ :aSuperclass | aSuperclass name ])
 		   traitComposition: self owner traitCompositionString
 		   classTraitComposition: self owner metaclass traitCompositionString
-		   category: self category
-		   instVarNames: self instVarNames)
+		   category: self category)
+		  instVarNames: self instVarNames;
 		  classVarNames: self classVarNames;
 		  poolDictionaryNames: self sharedPoolNames;
 		  classInstVarNames: self metaclass instVarNames;


### PR DESCRIPTION
MCClassDescription has a lot of parameters and to create a new instance there is a huge constructor.

Most of the parameters end up been default values. I'll have to update the state of this method to split the packages and tags from the category and before doing this change I would like to change the way we create the class description by configuring the instance instead.