### PR TITLE
Kernel: Remove category at class removal

### DIFF
--- a/src/ClassParser-Tests/ASTClassBuilderTest.class.st
+++ b/src/ClassParser-Tests/ASTClassBuilderTest.class.st
@@ -159,7 +159,7 @@ ASTClassBuilderTest >> testCreateNormalClassWithPackage [
 		         buildEnvironment: self environment;
 		         buildFromAST: ast;
 		         build.
-	self assert: class category equals: #Unclassified
+	self assert: class category equals: Class unclassifiedCategory
 ]
 
 { #category : #tests }

--- a/src/Kernel-Tests-Extended/ClassTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassTest.class.st
@@ -606,5 +606,6 @@ ClassTest >> testclassVariables [
 
 { #category : #'tests - class creation' }
 ClassTest >> unclassifiedCategory [
-	^#Unclassified
+
+	^ Class unclassifiedCategory
 ]

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -93,6 +93,12 @@ Class class >> superclassOrder: classes [
     ^all
 ]
 
+{ #category : #accessing }
+Class class >> unclassifiedCategory [
+
+	^ #Unclassified
+]
+
 { #category : #'class variables' }
 Class >> addClassVarNamed: aString [
 	"Add the argument, aString, as a class variable of the receiver.

--- a/src/Refactoring-Changes/RBAddClassChange.class.st
+++ b/src/Refactoring-Changes/RBAddClassChange.class.st
@@ -167,7 +167,7 @@ RBAddClassChange >> fillOutDefinition: aDictionary [
 
 	category := (aDictionary
 		at: '`#category'
-		ifAbsent: [ #Unclassified ])
+		ifAbsent: [ Class unclassifiedCategory ])
 			asSymbol
 ]
 

--- a/src/Refactoring-Changes/RBAddTraitChange.class.st
+++ b/src/Refactoring-Changes/RBAddTraitChange.class.st
@@ -59,5 +59,5 @@ RBAddTraitChange >> fillOutDefinition: aDictionary [
 	in the expressions defined in the definitionPatterns method!"
 
 	className := (aDictionary at: '`#traitName') asSymbol.
-	category := (aDictionary at: '`#package' ifAbsent: [ #Unclassified ]) asSymbol
+	category := (aDictionary at: '`#package' ifAbsent: [ Class unclassifiedCategory ]) asSymbol
 ]

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -300,7 +300,7 @@ ShiftClassInstaller >> recategorize: aClass to: newCategory [
 	self installingEnvironment organization
 		ifNotNil: [ :systemOrganizer | systemOrganizer classify: aClass name under: newCategory ].
 
-	(oldCategory isNil or:[ oldCategory = #Unclassified])
+	(oldCategory isNil or:[ oldCategory = Class unclassifiedCategory])
 		ifTrue: [ SystemAnnouncer uniqueInstance classAdded: aClass inCategory: newCategory ]
 		ifFalse: [ SystemAnnouncer uniqueInstance class: aClass recategorizedFrom: oldCategory to: newCategory ]
 ]

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -211,6 +211,7 @@ SystemDictionary >> forgetClass: aClass [
 	self flag: #package. "Unify categories and packages to have only one removal to do and not two."
 	self organization removeBehavior: aClass.
 	self organization removeClass: aClass.
+	aClass basicCategory: Class unclassifiedCategory.
 	SessionManager default unregisterClassNamed: aClass name.
 	self removeKey: aClass name ifAbsent: [  ]
 ]


### PR DESCRIPTION
Currently when we remove a class from the system, the class is removed from the package and the category, but the variable #category is kept in the class. I propose to set it at the unclassified value (In the future I'd like also to remove this unclassified value to use nil because if we create a package name "Unclassified" then I guess that the system will really not like it..

I also factorized the name of this category under Class class>>unclassifiedCategory