### PR TITLE
RPackage: Update class category in class builder

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -276,7 +276,10 @@ Class >> category [
 	(latter is much more expensive)"
 
 	| result |
-	self basicCategory ifNotNil: [ :symbol | ((self packageOrganizer listAtCategoryNamed: symbol) includes: self name) ifTrue: [ ^ symbol ] ].
+	self basicCategory ifNotNil: [ :symbol |
+		symbol = Class unclassifiedCategory ifTrue: [ ^ symbol ].
+
+		((self packageOrganizer listAtCategoryNamed: symbol) includes: self name) ifFalse: [ 1halt ] ifTrue: [ ^ symbol ] ].
 	result := (self environment organization categoryOfBehavior: self)
 		          ifNil: [ #Unclassified ]
 		          ifNotNil: [ :value | value ].

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -279,7 +279,7 @@ Class >> category [
 	self basicCategory ifNotNil: [ :symbol |
 		symbol = Class unclassifiedCategory ifTrue: [ ^ symbol ].
 
-		((self packageOrganizer listAtCategoryNamed: symbol) includes: self name) ifFalse: [ 1halt ] ifTrue: [ ^ symbol ] ].
+		((self packageOrganizer listAtCategoryNamed: symbol) includes: self name) ifTrue: [ ^ symbol ] ].
 	result := (self environment organization categoryOfBehavior: self)
 		          ifNil: [ #Unclassified ]
 		          ifNotNil: [ :value | value ].

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -292,15 +292,16 @@ ShiftClassInstaller >> oldClass: anObject [
 
 { #category : #notifications }
 ShiftClassInstaller >> recategorize: aClass to: newCategory [
+
 	| oldCategory |
-	oldCategory := oldClass ifNotNil:[oldClass basicCategory].
-	oldCategory == newCategory asSymbol
-		ifTrue: [ ^ self ].
+	oldCategory := oldClass ifNotNil: [ oldClass basicCategory ].
+	oldCategory == newCategory asSymbol ifTrue: [ ^ self ].
 
-	self installingEnvironment organization
-		ifNotNil: [ :systemOrganizer | systemOrganizer classify: aClass name under: newCategory ].
+	self installingEnvironment organization ifNotNil: [ :systemOrganizer |
+		systemOrganizer classify: aClass name under: newCategory.
+		aClass basicCategory: newCategory ].
 
-	(oldCategory isNil or:[ oldCategory = Class unclassifiedCategory])
+	(oldCategory isNil or: [ oldCategory = Class unclassifiedCategory ])
 		ifTrue: [ SystemAnnouncer uniqueInstance classAdded: aClass inCategory: newCategory ]
 		ifFalse: [ SystemAnnouncer uniqueInstance class: aClass recategorizedFrom: oldCategory to: newCategory ]
 ]

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -196,7 +196,7 @@ ShiftClassInstaller >> make [
 	self fixSlotScope: newClass.
 	self fixSlotScope: newClass class.
 
-	self recategorize: newClass to: builder category.
+	self recategorize: newClass to: builder category asSymbol.
 	self comment: newClass.
 
 	self notifyChanges.
@@ -295,7 +295,7 @@ ShiftClassInstaller >> recategorize: aClass to: newCategory [
 
 	| oldCategory |
 	oldCategory := oldClass ifNotNil: [ oldClass basicCategory ].
-	oldCategory == newCategory asSymbol ifTrue: [ ^ self ].
+	oldCategory == newCategory ifTrue: [ ^ self ].
 
 	self installingEnvironment organization ifNotNil: [ :systemOrganizer |
 		systemOrganizer classify: aClass name under: newCategory.


### PR DESCRIPTION
When classifying a class in the class installer, the category is not updated. This is done later by RPAckage while listening to the announcements. But this creates a ping pong: Installer classify with the category -> RPackage listen and try to update the tag -> The tag notices a missmatch of categories -> the tag update the category -> the category is updated and an announcement rasied -> rpackage listen to it to update the tag -> since the category matches, the categorixation happens

I would like to simplify this by setting the category between the categorization and the raise of the announcement. 

Also, this will ensure the category of the class and the system organizer are in sync during the class installation which can simplify the state of the system

As a bonus I added an escape in Class>>category to manage in a better way the unclassified classes. Since a recent change I made, classes with unclassified category cannot be in a category of the system organizer. So we do not need to scan it which should speed things up in that case