### PR TITLE
Confirmation dialog for "Jump to test class"

### DIFF
--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyJumpToTestClassCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyJumpToTestClassCommand.class.st
@@ -59,7 +59,7 @@ ClyJumpToTestClassCommand >> execute [
 
 	[ browser selectClass: (self testClassFor: targetClass) ]
 		on: ClyInvalidClassForTestClassGeneration
-		do: [ : ex | self inform: 'Cannot generate test class for ' , ex baseClass printString , '.' ]
+		do: [ :ex | self inform: 'Cannot generate test class for ' , ex baseClass printString , '.' ]
 ]
 
 { #category : #execution }

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyJumpToTestClassCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyJumpToTestClassCommand.class.st
@@ -50,9 +50,16 @@ ClyJumpToTestClassCommand >> defaultMenuItemName [
 
 { #category : #execution }
 ClyJumpToTestClassCommand >> execute [
+
+	self systemEnvironment 
+		classNamed: (self testClassNameFor: targetClass)
+		ifAbsent: [
+			(self confirm: 'Do you want to create a test class for: ' , targetClass asString )
+				ifFalse: [ ^ self ] ].
+
 	[ browser selectClass: (self testClassFor: targetClass) ]
 		on: ClyInvalidClassForTestClassGeneration
-		do: [ :ex | self inform: 'Cannot generate test class for ' , ex baseClass printString , '.' ]
+		do: [ : ex | self inform: 'Cannot generate test class for ' , ex baseClass printString , '.' ]
 ]
 
 { #category : #execution }

--- a/src/Calypso-SystemPlugins-SUnit-Browser/TClyGenerateTestClass.trait.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/TClyGenerateTestClass.trait.st
@@ -55,19 +55,22 @@ TClyGenerateTestClass >> systemEnvironment [
 
 { #category : #accessing }
 TClyGenerateTestClass >> testClassFor: inputClass [
+
 	| className resultClass |
 	className := self testClassNameFor: inputClass.
 	self systemEnvironment
 		classNamed: className
 		ifPresent: [ :class | resultClass := class ]
 		ifAbsent: [
-			(self isValidClass: inputClass) ifFalse: [ ClyInvalidClassForTestClassGeneration signalFor: inputClass ].
+			(self isValidClass: inputClass) 
+				ifFalse: [ ClyInvalidClassForTestClassGeneration signalFor: inputClass ].
 			self systemEnvironment ensurePackage: inputClass package name asString , '-Tests'.
 
 			resultClass := self class classInstaller make: [ :aBuilder |
-				aBuilder name: className;
-					superclass: TestCase;
-					package: (self newTestClassCategoryFor: inputClass) ].
+				               aBuilder
+					               name: className;
+					               superclass: TestCase;
+					               package: (self newTestClassCategoryFor: inputClass) ].
 
 			self addNewCommentForTestClass: resultClass basedOn: inputClass ].
 	^ resultClass


### PR DESCRIPTION
This PR add a confirmation dialog to avoid command "Jump to test class" in the Calypso Browser to create automatically a class if there is none, as reported in #14533 