### PR TITLE
Add ‘scale’ for display of a Paragraph using a BitBltDisplayScanner

### DIFF
--- a/src/Athens-Morphic/AthensDisplayScanner.class.st
+++ b/src/Athens-Morphic/AthensDisplayScanner.class.st
@@ -29,6 +29,12 @@ AthensDisplayScanner >> initWithParagraph: aParagraph andCanvas: anAthensCanvas 
 	canvas := anAthensCanvas
 ]
 
+{ #category : #accessing }
+AthensDisplayScanner >> scale [
+
+	^ 1
+]
+
 { #category : #displaying }
 AthensDisplayScanner >> setFont [
 	super setFont.

--- a/src/Graphics-Fonts/BitBlt.extension.st
+++ b/src/Graphics-Fonts/BitBlt.extension.st
@@ -17,7 +17,7 @@ BitBlt >> basicDisplayString: aString from: startIndex to: stopIndex at: aPoint 
 
 	self primDisplayString: aString from: startIndex to: stopIndex
 			map: font characterToGlyphMap xTable: xTable
-			kern: kernDelta.
+			kern: kernDelta * scale.
 	^ destX@destY
 ]
 

--- a/src/Morphic-Base/Paragraph.class.st
+++ b/src/Morphic-Base/Paragraph.class.st
@@ -386,12 +386,12 @@ Paragraph >> displayOn: aCanvas using: displayScanner at: somePosition [
 	"Send all visible lines to the displayScanner for display"
 	| visibleRectangle offset leftInRun line |
 	visibleRectangle := aCanvas clipRect.
-	offset := (somePosition - positionWhenComposed) truncated.
+	offset := (somePosition - (positionWhenComposed * displayScanner scale)) truncated.
 	leftInRun := 0.
-	(self lineIndexForPoint: visibleRectangle topLeft)
-		to: (self lineIndexForPoint: visibleRectangle bottomRight)
+	(self lineIndexForPoint: visibleRectangle topLeft scale: displayScanner scale)
+		to: (self lineIndexForPoint: visibleRectangle bottomRight scale: displayScanner scale)
 		do: [:i | line := lines at: i.
-			self displaySelectionInLine: line on: aCanvas.
+			self displaySelectionInLine: line on: aCanvas scale: displayScanner scale.
 			line first <= line last ifTrue:
 				[leftInRun := displayScanner displayLine: line offset: offset leftInRun: leftInRun]]
 ]
@@ -427,6 +427,12 @@ Paragraph >> displaySelectionBlock: aSelBlock inLine: line on: aCanvas [
 
 { #category : #display }
 Paragraph >> displaySelectionInLine: line on: aCanvas [
+
+	^ self displaySelectionInLine: line on: aCanvas scale: 1
+]
+
+{ #category : #display }
+Paragraph >> displaySelectionInLine: line on: aCanvas scale: scale [
 	| leftX rightX w caretColor |
 	selectionStart ifNil: [^self].	"No selection"
 	aCanvas isShadowDrawing ifTrue: [ ^self ].	"don't draw selection with shadow"
@@ -464,17 +470,17 @@ Paragraph >> displaySelectionInLine: line on: aCanvas [
 					[:i |
 					"Draw caret triangles at top and bottom"
 
-					aCanvas fillRectangle: ((leftX - w + i - 1) @ (line top + i - 1)
-								extent: ((w - i) * 2 + 3) @ 1)
+					aCanvas fillRectangle: (((leftX - w + i - 1) @ (line top + i - 1)
+								extent: ((w - i) * 2 + 3) @ 1) scaleBy: scale)
 						color: caretColor.
-					aCanvas fillRectangle: ((leftX - w + i - 1) @ (line bottom - i)
-								extent: ((w - i) * 2 + 3) @ 1)
+					aCanvas fillRectangle: (((leftX - w + i - 1) @ (line bottom - i)
+								extent: ((w - i) * 2 + 3) @ 1) scaleBy: scale)
 						color: caretColor].
-			aCanvas fillRectangle: (leftX @ line top corner: rightX @ line bottom)
+			aCanvas fillRectangle: ((leftX @ line top corner: rightX @ line bottom) scaleBy: scale)
 				color: caretColor]
 		ifFalse:
 			[caretRect := nil.
-			aCanvas fillRectangle: (leftX @ line top corner: rightX @ line bottom)
+			aCanvas fillRectangle: ((leftX @ line top corner: rightX @ line bottom) scaleBy: scale)
 				color: self selectionColor]
 ]
 
@@ -601,16 +607,22 @@ Paragraph >> lineIndexForCharacter: index [
 
 { #category : #private }
 Paragraph >> lineIndexForPoint: aPoint [
+
+	^ self lineIndexForPoint: aPoint scale: 1
+]
+
+{ #category : #private }
+Paragraph >> lineIndexForPoint: aPoint scale: scale [
 	"Answer the index of the line in which to select the character nearest to aPoint."
 	| i py |
 	py := aPoint y truncated.
 
 	"Find the first line at this y-value"
-	i := (self fastFindFirstLineSuchThat: [:line | line bottom > py]) min: lines size.
+	i := (self fastFindFirstLineSuchThat: [:line | (line bottom * scale) > py]) min: lines size.
 
 	"Now find the first line at this x-value"
-	[i < lines size and: [(lines at: i+1) top = (lines at: i) top
-				and: [aPoint x >= (lines at: i+1) left]]]
+	[i < lines size and: [((lines at: i+1) top * scale) = ((lines at: i) top * scale)
+				and: [aPoint x >= ((lines at: i+1) left * scale)]]]
 		whileTrue: [i := i + 1].
 	^ i
 ]

--- a/src/Text-Core/TextStyle.class.st
+++ b/src/Text-Core/TextStyle.class.st
@@ -599,6 +599,12 @@ TextStyle allInstancesDo: [:ts | ts newFontArray: TextStyle default fontArray].
 
 { #category : #'tabs and margins' }
 TextStyle >> nextTabXFrom: anX leftMargin: leftMargin rightMargin: rightMargin [
+
+	^ self nextTabXFrom: anX leftMargin: leftMargin rightMargin: rightMargin scale: 1
+]
+
+{ #category : #'tabs and margins' }
+TextStyle >> nextTabXFrom: anX leftMargin: leftMargin rightMargin: rightMargin scale: scale [
 	"Tab stops are distances from the left margin. Set the distance into the
 	argument, anX, normalized for the paragraph's left margin."
 	| normalizedX tabX |
@@ -607,7 +613,7 @@ TextStyle >> nextTabXFrom: anX leftMargin: leftMargin rightMargin: rightMargin [
 		to: tabsArray size
 		do:
 			[ :i |
-			(tabX := tabsArray at: i) > normalizedX ifTrue: [ ^ leftMargin + tabX min: rightMargin ] ].
+			(tabX := (tabsArray at: i) * scale) > normalizedX ifTrue: [ ^ leftMargin + tabX min: rightMargin ] ].
 	^ rightMargin
 ]
 

--- a/src/Text-Scanning/BitBltDisplayScanner.class.st
+++ b/src/Text-Scanning/BitBltDisplayScanner.class.st
@@ -17,7 +17,8 @@ Class {
 	#name : #BitBltDisplayScanner,
 	#superclass : #DisplayScanner,
 	#instVars : [
-		'bitBlt'
+		'bitBlt',
+		'scale'
 	],
 	#category : #'Text-Scanning-Base'
 }
@@ -25,9 +26,12 @@ Class {
 { #category : #displaying }
 BitBltDisplayScanner >> displayEmbeddedForm: aForm [
 
-	aForm
+	| scaledForm |
+
+	scaledForm := self scale = 1 ifTrue: [ aForm ] ifFalse: [ aForm scaledToSize: aForm extent * self scale ].
+	scaledForm
 		displayOn: bitBlt destForm
-		at: destX @ (lineY + line baseline - aForm height)
+		at: destX @ (lineY + (line baseline * self scale) - scaledForm height)
 		clippingBox: bitBlt clipRect
 		rule: Form blend
 		fillColor: Color white
@@ -36,22 +40,43 @@ BitBltDisplayScanner >> displayEmbeddedForm: aForm [
 { #category : #displaying }
 BitBltDisplayScanner >> displayString: string from: startIndex to: stopIndex at: aPoint [
     | endPoint top |
-   top := aPoint translateBy: 0@ font ascent.
+   top := aPoint translateBy: 0@ (font ascent * self scale).
 	endPoint := font displayString: string on: bitBlt
 		from: startIndex
 		to: stopIndex
-		at: aPoint kern: kern.
+		at: aPoint kern: kern
+		baselineY: aPoint y + (font ascent * self scale)
+		scale: self scale.
 
     (emphasisCode allMask: 4)
-        ifTrue: [ font displayUnderlineOn: bitBlt from: top to: endPoint ].
+        ifTrue: [ font displayUnderlineOn: bitBlt from: top to: endPoint scale: self scale ].
     (emphasisCode allMask: 16)
-        ifTrue: [ font displayStrikeoutOn: bitBlt from: top to: endPoint ]
+        ifTrue: [ font displayStrikeoutOn: bitBlt from: top to: endPoint scale: self scale ]
+]
+
+{ #category : #initialization }
+BitBltDisplayScanner >> initialize [
+
+	super initialize.
+	scale := 1
+]
+
+{ #category : #accessing }
+BitBltDisplayScanner >> scale [
+
+	^ scale
+]
+
+{ #category : #accessing }
+BitBltDisplayScanner >> scale: newScale [
+
+	scale := newScale
 ]
 
 { #category : #private }
 BitBltDisplayScanner >> setFont [
 	super setFont.  "Sets font and emphasis bits, and maybe foregroundColor"
-	font installOn: bitBlt foregroundColor: foregroundColor backgroundColor: Color transparent
+	font installOn: bitBlt foregroundColor: foregroundColor backgroundColor: Color transparent scale: self scale
 ]
 
 { #category : #private }

--- a/src/Text-Scanning/CharacterBlockScanner.class.st
+++ b/src/Text-Scanning/CharacterBlockScanner.class.st
@@ -249,6 +249,12 @@ CharacterBlockScanner >> retrieveLastCharacterWidth [
 	^lastCharacterWidth
 ]
 
+{ #category : #accessing }
+CharacterBlockScanner >> scale [
+
+	^ 1
+]
+
 { #category : #'stop conditions' }
 CharacterBlockScanner >> setFont [
 	specialWidth := nil.

--- a/src/Text-Scanning/CharacterScanner.class.st
+++ b/src/Text-Scanning/CharacterScanner.class.st
@@ -181,7 +181,7 @@ CharacterScanner >> addKern: kernDelta [
 CharacterScanner >> advanceIfFirstCharOfLine [
 	lastIndex = line first
 		ifTrue:
-			[destX := destX + pendingKernX + (font widthOf: (text at: line first)).
+			[destX := destX + pendingKernX + ((font widthOf: (text at: line first)) * self scale).
 			lastIndex := lastIndex + 1.
 			pendingKernX := 0]
 ]
@@ -202,12 +202,12 @@ a font that does not do character-pair kerning"
 			(stopConditions at: ascii)
 				ifNotNil: [^ stopConditions at: ascii].
 			"bump nextDestX by the width of the current character"
-			nextDestX := destX + (font widthOf: char).
+			nextDestX := destX + ((font widthOf: char) * self scale).
 			"if the next x is past the right edge, return crossedX"
 			nextDestX > rightX
 				ifTrue: [^#crossedX].
 			"update destX and incorporate thr kernDelta"
-			destX := nextDestX + kern.
+			destX := nextDestX + (kern * self scale).
 			lastIndex := lastIndex + 1].
 	^self handleEndOfRunAt: stopIndex
 ]
@@ -283,11 +283,18 @@ CharacterScanner >> plainTab [
 	pendingKernX := 0.
 	^(alignment = Justified and: [self leadingTab not])
 		ifTrue:		"embedded tabs in justified text are weird"
-			[destX + (textStyle tabWidth - (line justifiedTabDeltaFor: spaceCount)) max: destX]
+			[destX + ((textStyle tabWidth * self scale) - ((line justifiedTabDeltaFor: spaceCount) * self scale)) max: destX]
 		ifFalse:
 			[textStyle nextTabXFrom: destX
 				leftMargin: leftMargin
-				rightMargin: rightMargin]
+				rightMargin: rightMargin
+				scale: self scale]
+]
+
+{ #category : #accessing }
+CharacterScanner >> scale [
+
+	self subclassResponsibility
 ]
 
 { #category : #scanning }
@@ -337,22 +344,22 @@ a font that does do character-pair kerning via widthAndKernedWidthOfLeft:right:i
 				into: widthAndKernedWidth.
 			"bump nextDestX by the width of the current character"
 			nextDestX := floatDestX
-						+ (widthAndKernedWidth at: 1).
+						+ ((widthAndKernedWidth at: 1) * self scale).
 			"if the next x is past the right edge, return crossedX"
 			nextDestX > rightX
 				ifTrue: [^ #crossedX].
 			"bump floatDestX by the *kerned* width of the current
 			character, which is where the *next* char will go"
-			floatDestX := floatDestX + kern
-						+ (widthAndKernedWidth at: 2).
+			floatDestX := floatDestX + (kern * self scale)
+						+ ((widthAndKernedWidth at: 2) * self scale).
 			"if we are at the end of this run we keep track of the
 			character-kern-delta for possible later use and then rather
 			insanely remove that character-kern-delta from floatDestX,
 			making it equivalent to (old floatDestX) + kernDelta +
 			width-of-character - no idea why"
 			atEndOfRun
-				ifTrue: [pendingKernX := (widthAndKernedWidth at: 2)
-								- (widthAndKernedWidth at: 1).
+				ifTrue: [pendingKernX := ((widthAndKernedWidth at: 2) * self scale)
+								- ((widthAndKernedWidth at: 1) * self scale).
 					floatDestX := floatDestX - pendingKernX].
 			"save the next x for next time around the loop"
 			destX := floatDestX.
@@ -390,12 +397,12 @@ a font that does do character-pair kerning via widthAndKernedWidthOfLeft:right:i
 			widthAndKernedWidthOfLeft: char
 			right: nextChar
 			into: widthAndKernedWidth.
-		nextDestX := floatDestX + (widthAndKernedWidth at: 1).
+		nextDestX := floatDestX + ((widthAndKernedWidth at: 1) * self scale).
 		nextDestX > rightX ifTrue: [^#crossedX].
-		floatDestX := floatDestX + kern + (widthAndKernedWidth at: 2).
+		floatDestX := floatDestX + (kern * self scale) + ((widthAndKernedWidth at: 2) * self scale).
 		atEndOfRun
 			ifTrue:[
-				pendingKernX := (widthAndKernedWidth at: 2) - (widthAndKernedWidth at: 1).
+				pendingKernX := ((widthAndKernedWidth at: 2) * self scale) - ((widthAndKernedWidth at: 1) * self scale).
 				floatDestX := floatDestX - pendingKernX].
 		destX := floatDestX .
 		lastIndex := lastIndex + 1.
@@ -416,9 +423,9 @@ a font that does not do character-pair kerning"
 		(ascii < 256 and: [(stopConditions at: ascii + 1) ~~ nil])
 			ifTrue: [^ stopConditions at: ascii + 1].
 		"bump nextDestX by the width of the current character"
-		nextDestX := destX + (font widthOf: char).
+		nextDestX := destX + ((font widthOf: char) * self scale).
 		nextDestX > rightX ifTrue: [^#crossedX].
-		destX := nextDestX + kern .
+		destX := nextDestX + (kern * self scale).
 		lastIndex := lastIndex + 1.
 	].
 	^self handleEndOfRunAt: stopIndex
@@ -459,9 +466,9 @@ CharacterScanner >> setFont [
 					We still want kerning between chars of the same
 					font, but of different color. So add any pending kern to destX"
 					destX := destX + (pendingKernX ifNil:[0])].
-			destX := destX + priorFont descentKern].
+			destX := destX + (priorFont descentKern * self scale)].
 	pendingKernX := 0. "clear any pending kern so there is no danger of it being added twice"
-	destX := destX - font descentKern.
+	destX := destX - (font descentKern * self scale).
 	"NOTE: next statement should be removed when clipping works"
 	leftMargin ifNotNil: [destX := destX max: leftMargin].
 	kern := kern - font baseKern.

--- a/src/Text-Scanning/CompositionScanner.class.st
+++ b/src/Text-Scanning/CompositionScanner.class.st
@@ -202,6 +202,12 @@ CompositionScanner >> rightX [
 	^spaceX
 ]
 
+{ #category : #accessing }
+CompositionScanner >> scale [
+
+	^ 1
+]
+
 { #category : #'text attributes' }
 CompositionScanner >> setActualFont: aFont [
 

--- a/src/Text-Scanning/DisplayScanner.class.st
+++ b/src/Text-Scanning/DisplayScanner.class.st
@@ -123,18 +123,18 @@ DisplayScanner >> displayLine: textLine offset: offset leftInRun: leftInRun [
 	| stopCondition nowLeftInRun startIndex string lastPos lineHeight stop |
 	line := textLine.
 	morphicOffset := offset.
-	lineY := line top + offset y.
-	lineHeight := line lineHeight.
-	rightMargin := line rightMargin + offset x.
+	lineY := line top * self scale + offset y.
+	lineHeight := line lineHeight * self scale.
+	rightMargin := line rightMargin * self scale + offset x.
 	lastIndex := line first.
 	leftInRun <= 0 ifTrue: [ self setStopConditions ].
-	leftMargin := (line leftMarginForAlignment: alignment) + offset x.
+	leftMargin := (line leftMarginForAlignment: alignment) * self scale + offset x.
 	destX := leftMargin.
 	lastDisplayableIndex := lastIndex := line first.
 	nowLeftInRun := leftInRun <= 0
 		ifTrue: [ text runLengthFor: lastIndex ]
 		ifFalse: [ leftInRun ].
-	destY := lineY + line baseline - font ascent.
+	destY := lineY + (line baseline * self scale) - (font ascent * self scale).
 	runStopIndex := lastIndex + (nowLeftInRun - 1) min: line last.
 	spaceCount := 0.
 	string := text string.
@@ -196,7 +196,7 @@ DisplayScanner >> paddedSpace [
 
 	lastDisplayableIndex := lastIndex - 1.
 	spaceCount := spaceCount + 1.
-	destX := destX + spaceWidth + kern + (line justifiedPadFor: spaceCount font: font).
+	destX := destX + (spaceWidth * self scale) + (kern * self scale) + ((line justifiedPadFor: spaceCount font: font) * self scale).
 	lastIndex := lastIndex + 1.
 	pendingKernX := 0.
 	^ false
@@ -208,15 +208,15 @@ DisplayScanner >> placeEmbeddedObject: anchoredMorphOrForm [
 	anchoredMorphOrForm relativeTextAnchorPosition ifNotNil:[:relativeTextAnchorPosition |
 		anchoredMorphOrForm position:
 			relativeTextAnchorPosition +
-			(anchoredMorphOrForm owner textBounds origin x @ (lineY - morphicOffset y)).
+			(anchoredMorphOrForm owner textBounds origin x @ ((lineY - morphicOffset y) / self scale)).
 		^true
 	].
 	anchoredMorphOrForm isMorph ifTrue: [
-		anchoredMorphOrForm position: (destX@(lineY + line baseline - anchoredMorphOrForm height)) - morphicOffset
+		anchoredMorphOrForm position: ((destX@(lineY + (line baseline * self scale) - (anchoredMorphOrForm height * self scale))) - morphicOffset) / self scale
 	] ifFalse: [
 		self displayEmbeddedForm: anchoredMorphOrForm
 	].
-	destX := destX + anchoredMorphOrForm width + kern.
+	destX := destX + (anchoredMorphOrForm width * self scale) + (kern * self scale).
 	^ true
 ]
 
@@ -224,7 +224,7 @@ DisplayScanner >> placeEmbeddedObject: anchoredMorphOrForm [
 DisplayScanner >> setFont [
 	foregroundColor := self defaultTextColor.
 	super setFont.  "Sets font and emphasis bits, and maybe foregroundColor"
-	text ifNotNil:[destY := lineY + line baseline - font ascent]
+	text ifNotNil:[destY := lineY + (line baseline * self scale) - (font ascent * self scale)]
 ]
 
 { #category : #private }


### PR DESCRIPTION
Pull requests #14563 and #14574 added a ‘scale’ parameter for displaying strings, strikeouts and underlines, this pull request extends that to displaying paragraphs. An example is given by the snippet below. For comparison, for ‘form1’, the example paragraph is displayed normally and then the form is scaled by a factor of two:

<p align="center"><img src="https://github.com/pharo-project/pharo/assets/1611248/1ca870e0-380c-4400-bb74-da07599b407c"></p>

For ‘form2’, the paragraph is displayed directly on the larger form so that the character glyphs have better detail:

<p align="center"><img src="https://github.com/pharo-project/pharo/assets/1611248/4dee8849-b2e6-45d6-93bb-31ccc38ebe68"></p>

```smalltalk
text := Text streamContents: [ :stream |
	stream
		nextPutAll: (Microdown asRichText: '# Lorem Ipsum'); cr;
		nextPutAll: (Microdown asRichText: 'Dolor **sit** amet, _consectetur adipiscing_ elit,');
		nextPutAll: ' ';
		nextPutAll: (Microdown asRichText: 'sed do eiusmod tempor ![](pharo:///Object/iconNamed:/home) incididunt ut');
		nextPutAll: '  ';
		withAttribute: (TextAnchor new anchoredMorph: (CircleMorph new extent: 10@10; yourself); yourself) do: [
			stream nextPut: Character home ];
		nextPutAll: '  ';
		nextPutAll: (Microdown asRichText: '  labore et ~dolore magna~ aliqua.') ].
(paragraph := Paragraph new)
	compose: text
	style: TextStyle default copy
	from: 1
	in: (0@0 extent: 300@999999999).
bounds := 0@0 corner: paragraph extent.
scale := 2.

(baseForm := Form extent: paragraph extent depth: Display depth) fillColor: Color white.
baseForm getCanvas
	paragraph: paragraph bounds: bounds color: Color black;
	translateBy: bounds topLeft during: [ :translatedCanvas |
		paragraph text embeddedMorphs do: [ :morph |
			translatedCanvas fullDrawMorph: morph ] ].
form1 := baseForm scaledToSize: baseForm extent * scale.

(form2 := Form extent: form1 extent depth: Display depth) fillColor: Color white.
canvas := form2 getCanvas.
canvas setPaintColor: Color black.
port := canvas privatePort.
origin := canvas origin.
scanner := (port clippedBy: ((bounds translateBy: origin) scaleBy: scale)) displayScannerFor: paragraph
	foreground: Color black.
scanner scale: scale.
paragraph displayOn: (canvas copyClipRect: (bounds scaleBy: scale)) using: scanner at: (origin + bounds topLeft) * scale.
canvas transformBy: (MatrixTransform2x3 withScale: scale) clippingTo: canvas clipRect during: [ :scaledCanvas |
	scaledCanvas translateBy: bounds topLeft during: [ :translatedCanvas |
		paragraph text embeddedMorphs do: [ :morph |
			translatedCanvas fullDrawMorph: morph ] ] ].

{ form1. form2 } keysAndValuesDo: [ :index :form |
	PNGReadWriter putForm: form onFileNamed: FileLocator imageDirectory / (index asString , '.png') ]
```