### PR TITLE
Monticello: Do not use constructors with dizaines of paramaters in MCTraitDescription

### DIFF
--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -20,7 +20,7 @@ Class {
 
 { #category : #deprecated }
 MCClassDefinition class >> name: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray classInstVarNames: civarArray type: typeSymbol comment: commentString commentStamp: stampString [
-	"Do not use this method! This method will be deprecated one Tonel will not use it anymore."
+	"Do not use this method! This method will be deprecated once Tonel will not use it anymore."
 
 	^ (self named: nameString)
 		  category: categoryString;

--- a/src/Monticello/MCTraitDefinition.class.st
+++ b/src/Monticello/MCTraitDefinition.class.st
@@ -8,14 +8,13 @@ Class {
 }
 
 { #category : #'instance creation api' }
-MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray classInstVarNames: civarArray [
+MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray [
 
 	^ self new
 		  initializeWithName: classNameString
 		  traitComposition: traitCompositionString
 		  category: categoryString
 		  instVarNames: ivarArray
-		  classInstVarNames: civarArray
 ]
 
 { #category : #deprecated }
@@ -26,8 +25,8 @@ MCTraitDefinition class >> name: classNameString traitComposition: traitComposit
 		   initializeWithName: classNameString
 		   traitComposition: traitCompositionString
 		   category: categoryString
-		   instVarNames: ivarArray
-		   classInstVarNames: civarArray)
+		   instVarNames: ivarArray)
+		  classInstVarNames: civarArray;
 		  comment: commentString;
 		  commentStamp: commentStamp;
 		  classTraitComposition: classTraitCompositionString;
@@ -106,7 +105,7 @@ MCTraitDefinition >> hash [
 ]
 
 { #category : #initializing }
-MCTraitDefinition >> initializeWithName: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray classInstVarNames: civarArray [
+MCTraitDefinition >> initializeWithName: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray [
 
 	name := classNameString asSymbol.
 	traitComposition := traitCompositionString.

--- a/src/Monticello/MCTraitDefinition.class.st
+++ b/src/Monticello/MCTraitDefinition.class.st
@@ -7,21 +7,9 @@ Class {
 	#category : #'Monticello-Modeling'
 }
 
-{ #category : #'instance creation' }
-MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString category: categoryString comment: commentString commentStamp: aString5 [
-
-	^ self new
-		  initializeWithName: classNameString
-		  traitComposition: traitCompositionString
-		  category: categoryString
-		  instVarNames: ''
-		  classInstVarNames: ''
-		  comment: commentString
-		  commentStamp: aString5
-]
-
-{ #category : #'instance creation api' }
+{ #category : #deprecated }
 MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray classInstVarNames: civarArray classTraitComposition: classTraitCompositionString comment: commentString commentStamp: commentStamp [
+	"Do not use this method! This method will be deprecated once Tonel will not use it anymore."
 
 	^ (self new
 		   initializeWithName: classNameString
@@ -29,10 +17,22 @@ MCTraitDefinition class >> name: classNameString traitComposition: traitComposit
 		   category: categoryString
 		   instVarNames: ivarArray
 		   classInstVarNames: civarArray
-		   comment: commentString
-		   commentStamp: commentStamp)
+		   comment: commentString)
+		  commentStamp: commentStamp;
 		  classTraitComposition: classTraitCompositionString;
 		  yourself
+]
+
+{ #category : #'instance creation api' }
+MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray classInstVarNames: civarArray comment: commentString [
+
+	^ self new
+		  initializeWithName: classNameString
+		  traitComposition: traitCompositionString
+		  category: categoryString
+		  instVarNames: ivarArray
+		  classInstVarNames: civarArray
+		  comment: commentString
 ]
 
 { #category : #comparing }
@@ -107,14 +107,13 @@ MCTraitDefinition >> hash [
 ]
 
 { #category : #initializing }
-MCTraitDefinition >> initializeWithName: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray classInstVarNames: civarArray comment: commentString commentStamp: commentStampString [
+MCTraitDefinition >> initializeWithName: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray classInstVarNames: civarArray comment: commentString [
 
 	name := classNameString asSymbol.
 	traitComposition := traitCompositionString.
 	category := categoryString.
 	comment := commentString withInternalLineEndings.
 	variables := OrderedCollection new.
-	commentStamp := commentStampString ifNil: [ self defaultCommentStamp ].
 	self addVariables: ivarArray ofType: MCInstanceVariableDefinition
 ]
 

--- a/src/Monticello/MCTraitDefinition.class.st
+++ b/src/Monticello/MCTraitDefinition.class.st
@@ -8,34 +8,31 @@ Class {
 }
 
 { #category : #'instance creation' }
-MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString category: categoryString comment: commentString commentStamp: aString5 [ 
+MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString category: categoryString comment: commentString commentStamp: aString5 [
 
 	^ self new
-		initializeWithName: classNameString
-		traitComposition: traitCompositionString
-		category: categoryString
-		instVarNames: ''
-		classTraitComposition: nil
-		classInstVarNames: ''
-		comment: commentString
-		commentStamp: aString5
-
+		  initializeWithName: classNameString
+		  traitComposition: traitCompositionString
+		  category: categoryString
+		  instVarNames: ''
+		  classInstVarNames: ''
+		  comment: commentString
+		  commentStamp: aString5
 ]
 
 { #category : #'instance creation api' }
 MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray classInstVarNames: civarArray classTraitComposition: classTraitCompositionString comment: commentString commentStamp: commentStamp [
 
-	^ self new
-		initializeWithName: classNameString
-		traitComposition: traitCompositionString
-		category: categoryString
-		instVarNames: ivarArray
-		classTraitComposition: classTraitCompositionString
-		classInstVarNames: civarArray
-		comment: commentString
-		commentStamp: commentStamp
-
-		
+	^ (self new
+		   initializeWithName: classNameString
+		   traitComposition: traitCompositionString
+		   category: categoryString
+		   instVarNames: ivarArray
+		   classInstVarNames: civarArray
+		   comment: commentString
+		   commentStamp: commentStamp)
+		  classTraitComposition: classTraitCompositionString;
+		  yourself
 ]
 
 { #category : #comparing }
@@ -110,90 +107,15 @@ MCTraitDefinition >> hash [
 ]
 
 { #category : #initializing }
-MCTraitDefinition >> initializeWithName: classNameString 
-	traitComposition:  traitCompositionString
-	category:  categoryString
-	comment:  commentString  
-	commentStamp:   commentStampString [
-					
-		name := classNameString asSymbol.
-		traitComposition := traitCompositionString.
-	     category := categoryString.
-		comment := commentString withInternalLineEndings.
-		variables := OrderedCollection  new.
-		commentStamp :=  commentStampString ifNil: [self defaultCommentStamp]
+MCTraitDefinition >> initializeWithName: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray classInstVarNames: civarArray comment: commentString commentStamp: commentStampString [
 
-]
-
-{ #category : #initializing }
-MCTraitDefinition >> initializeWithName: classNameString 
-	traitComposition:  traitCompositionString
-	category:  categoryString
-	instVarNames: ivarArray
-	classInstVarNames: civarArray
-	comment:  commentString  
-	commentStamp:   commentStampString [
-					
-		name := classNameString asSymbol.
-		traitComposition := traitCompositionString.
-	    category := categoryString.
-		comment := commentString withInternalLineEndings.
-		commentStamp :=  commentStampString ifNil: [self defaultCommentStamp].
-		variables := OrderedCollection  new.
-		self addVariables: ivarArray ofType: MCInstanceVariableDefinition.
-		self addVariables: civarArray ofType: MCClassInstanceVariableDefinition.
-]
-
-{ #category : #initialization }
-MCTraitDefinition >> initializeWithName: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray classTraitComposition: classTraitCompositionString classInstVarNames: civarArray comment: commentString commentStamp: commentStampString [
-	self
-		initializeWithName: classNameString
-		traitComposition: traitCompositionString
-		category: categoryString
-		instVarNames: ivarArray
-		classInstVarNames: civarArray
-		comment: commentString
-		commentStamp: commentStampString.
-
-		classTraitComposition := classTraitCompositionString
-]
-
-{ #category : #initializing }
-MCTraitDefinition >> initializeWithName: classNameString 
-	traitComposition:  traitCompositionString
-	category:  categoryString
-	instVarNames: ivarArray
-	comment:  commentString  
-	commentStamp:   commentStampString [
-					
-		name := classNameString asSymbol.
-		traitComposition := traitCompositionString.
-	    category := categoryString.
-		comment := commentString withInternalLineEndings.
-		commentStamp :=  commentStampString ifNil: [self defaultCommentStamp].
-		variables := OrderedCollection  new.
-		self addVariables: ivarArray ofType: MCInstanceVariableDefinition.
-
-]
-
-{ #category : #initializing }
-MCTraitDefinition >> initializeWithName: classNameString 
-	traitComposition:  traitCompositionString
-	classTraitComposition: aClassTraitComposition
-	category:  categoryString
-	instVarNames: ivarArray
-	comment:  commentString  
-	commentStamp:   commentStampString [
-					
-		name := classNameString asSymbol.
-		traitComposition := traitCompositionString.
-	    category := categoryString.
-		comment := commentString withInternalLineEndings.
-		commentStamp :=  commentStampString ifNil: [self defaultCommentStamp].
-		variables := OrderedCollection  new.
-		self addVariables: ivarArray ofType: MCInstanceVariableDefinition.
-		
-	classTraitComposition := aClassTraitComposition
+	name := classNameString asSymbol.
+	traitComposition := traitCompositionString.
+	category := categoryString.
+	comment := commentString withInternalLineEndings.
+	variables := OrderedCollection new.
+	commentStamp := commentStampString ifNil: [ self defaultCommentStamp ].
+	self addVariables: ivarArray ofType: MCInstanceVariableDefinition
 ]
 
 { #category : #printing }

--- a/src/Monticello/MCTraitDefinition.class.st
+++ b/src/Monticello/MCTraitDefinition.class.st
@@ -8,16 +8,17 @@ Class {
 }
 
 { #category : #'instance creation api' }
-MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString category: categoryString [
+MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString [
 
-	^ self new initializeWithName: classNameString traitComposition: traitCompositionString category: categoryString
+	^ self new initializeWithName: classNameString traitComposition: traitCompositionString
 ]
 
 { #category : #deprecated }
 MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray classInstVarNames: civarArray classTraitComposition: classTraitCompositionString comment: commentString commentStamp: commentStamp [
 	"Do not use this method! This method will be deprecated once Tonel will not use it anymore."
 
-	^ (self new initializeWithName: classNameString traitComposition: traitCompositionString category: categoryString)
+	^ (self new initializeWithName: classNameString traitComposition: traitCompositionString)
+		  category: categoryString;
 		  instVarNames: ivarArray;
 		  classInstVarNames: civarArray;
 		  comment: commentString;
@@ -98,12 +99,10 @@ MCTraitDefinition >> hash [
 ]
 
 { #category : #initializing }
-MCTraitDefinition >> initializeWithName: classNameString traitComposition: traitCompositionString category: categoryString [
+MCTraitDefinition >> initializeWithName: classNameString traitComposition: traitCompositionString [
 
 	name := classNameString asSymbol.
-	traitComposition := traitCompositionString.
-	category := categoryString.
-	variables := OrderedCollection new
+	traitComposition := traitCompositionString
 ]
 
 { #category : #printing }

--- a/src/Monticello/MCTraitDefinition.class.st
+++ b/src/Monticello/MCTraitDefinition.class.st
@@ -7,6 +7,17 @@ Class {
 	#category : #'Monticello-Modeling'
 }
 
+{ #category : #'instance creation api' }
+MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray classInstVarNames: civarArray [
+
+	^ self new
+		  initializeWithName: classNameString
+		  traitComposition: traitCompositionString
+		  category: categoryString
+		  instVarNames: ivarArray
+		  classInstVarNames: civarArray
+]
+
 { #category : #deprecated }
 MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray classInstVarNames: civarArray classTraitComposition: classTraitCompositionString comment: commentString commentStamp: commentStamp [
 	"Do not use this method! This method will be deprecated once Tonel will not use it anymore."
@@ -16,23 +27,11 @@ MCTraitDefinition class >> name: classNameString traitComposition: traitComposit
 		   traitComposition: traitCompositionString
 		   category: categoryString
 		   instVarNames: ivarArray
-		   classInstVarNames: civarArray
-		   comment: commentString)
+		   classInstVarNames: civarArray)
+		  comment: commentString;
 		  commentStamp: commentStamp;
 		  classTraitComposition: classTraitCompositionString;
 		  yourself
-]
-
-{ #category : #'instance creation api' }
-MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray classInstVarNames: civarArray comment: commentString [
-
-	^ self new
-		  initializeWithName: classNameString
-		  traitComposition: traitCompositionString
-		  category: categoryString
-		  instVarNames: ivarArray
-		  classInstVarNames: civarArray
-		  comment: commentString
 ]
 
 { #category : #comparing }
@@ -107,12 +106,11 @@ MCTraitDefinition >> hash [
 ]
 
 { #category : #initializing }
-MCTraitDefinition >> initializeWithName: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray classInstVarNames: civarArray comment: commentString [
+MCTraitDefinition >> initializeWithName: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray classInstVarNames: civarArray [
 
 	name := classNameString asSymbol.
 	traitComposition := traitCompositionString.
 	category := categoryString.
-	comment := commentString withInternalLineEndings.
 	variables := OrderedCollection new.
 	self addVariables: ivarArray ofType: MCInstanceVariableDefinition
 ]

--- a/src/Monticello/MCTraitDefinition.class.st
+++ b/src/Monticello/MCTraitDefinition.class.st
@@ -8,24 +8,17 @@ Class {
 }
 
 { #category : #'instance creation api' }
-MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray [
+MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString category: categoryString [
 
-	^ self new
-		  initializeWithName: classNameString
-		  traitComposition: traitCompositionString
-		  category: categoryString
-		  instVarNames: ivarArray
+	^ self new initializeWithName: classNameString traitComposition: traitCompositionString category: categoryString
 ]
 
 { #category : #deprecated }
 MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray classInstVarNames: civarArray classTraitComposition: classTraitCompositionString comment: commentString commentStamp: commentStamp [
 	"Do not use this method! This method will be deprecated once Tonel will not use it anymore."
 
-	^ (self new
-		   initializeWithName: classNameString
-		   traitComposition: traitCompositionString
-		   category: categoryString
-		   instVarNames: ivarArray)
+	^ (self new initializeWithName: classNameString traitComposition: traitCompositionString category: categoryString)
+		  instVarNames: ivarArray;
 		  classInstVarNames: civarArray;
 		  comment: commentString;
 		  commentStamp: commentStamp;
@@ -105,13 +98,12 @@ MCTraitDefinition >> hash [
 ]
 
 { #category : #initializing }
-MCTraitDefinition >> initializeWithName: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray [
+MCTraitDefinition >> initializeWithName: classNameString traitComposition: traitCompositionString category: categoryString [
 
 	name := classNameString asSymbol.
 	traitComposition := traitCompositionString.
 	category := categoryString.
-	variables := OrderedCollection new.
-	self addVariables: ivarArray ofType: MCInstanceVariableDefinition
+	variables := OrderedCollection new
 ]
 
 { #category : #printing }

--- a/src/Monticello/MCTraitDefinition.class.st
+++ b/src/Monticello/MCTraitDefinition.class.st
@@ -7,17 +7,12 @@ Class {
 	#category : #'Monticello-Modeling'
 }
 
-{ #category : #'instance creation api' }
-MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString [
-
-	^ self new initializeWithName: classNameString traitComposition: traitCompositionString
-]
-
 { #category : #deprecated }
 MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray classInstVarNames: civarArray classTraitComposition: classTraitCompositionString comment: commentString commentStamp: commentStamp [
 	"Do not use this method! This method will be deprecated once Tonel will not use it anymore."
 
-	^ (self new initializeWithName: classNameString traitComposition: traitCompositionString)
+	^ (self named: classNameString)
+		  traitComposition: traitCompositionString;
 		  category: categoryString;
 		  instVarNames: ivarArray;
 		  classInstVarNames: civarArray;
@@ -96,13 +91,6 @@ MCTraitDefinition >> hash [
 	hash := String stringHash: (category ifNil: ['']) initialHash: hash.
 	^ hash
 
-]
-
-{ #category : #initializing }
-MCTraitDefinition >> initializeWithName: classNameString traitComposition: traitCompositionString [
-
-	name := classNameString asSymbol.
-	traitComposition := traitCompositionString
 ]
 
 { #category : #printing }

--- a/src/Monticello/MCTraitParser.class.st
+++ b/src/Monticello/MCTraitParser.class.st
@@ -66,11 +66,9 @@ MCTraitParser >> addDefinitionsTo: aCollection [
 			                  argumentNode source copyFrom: argumentNode sourceInterval first to: argumentNode sourceInterval last ]
 		                  ifNil: [ 'Unclassified' ].
 
-	definition := MCTraitDefinition
-		              name: traitName
-		              traitComposition: traitCompositionString
-		              category: categoryString
-		              instVarNames: slotsArray.
+	definition := (MCTraitDefinition name: traitName traitComposition: traitCompositionString category: categoryString)
+		              instVarNames: slotsArray;
+		              yourself.
 
 	aCollection add: definition
 ]

--- a/src/Monticello/MCTraitParser.class.st
+++ b/src/Monticello/MCTraitParser.class.st
@@ -66,7 +66,8 @@ MCTraitParser >> addDefinitionsTo: aCollection [
 			                  argumentNode source copyFrom: argumentNode sourceInterval first to: argumentNode sourceInterval last ]
 		                  ifNil: [ 'Unclassified' ].
 
-	definition := (MCTraitDefinition name: traitName traitComposition: traitCompositionString category: categoryString)
+	definition := (MCTraitDefinition name: traitName traitComposition: traitCompositionString)
+		              category: categoryString;
 		              instVarNames: slotsArray;
 		              yourself.
 

--- a/src/Monticello/MCTraitParser.class.st
+++ b/src/Monticello/MCTraitParser.class.st
@@ -71,8 +71,7 @@ MCTraitParser >> addDefinitionsTo: aCollection [
 		              traitComposition: traitCompositionString
 		              category: categoryString
 		              instVarNames: slotsArray
-		              classInstVarNames: ''
-		              comment: ''.
+		              classInstVarNames: ''.
 
 	aCollection add: definition
 ]

--- a/src/Monticello/MCTraitParser.class.st
+++ b/src/Monticello/MCTraitParser.class.st
@@ -66,7 +66,8 @@ MCTraitParser >> addDefinitionsTo: aCollection [
 			                  argumentNode source copyFrom: argumentNode sourceInterval first to: argumentNode sourceInterval last ]
 		                  ifNil: [ 'Unclassified' ].
 
-	definition := (MCTraitDefinition name: traitName traitComposition: traitCompositionString)
+	definition := (MCTraitDefinition named: traitName)
+		              traitComposition: traitCompositionString;
 		              category: categoryString;
 		              instVarNames: slotsArray;
 		              yourself.

--- a/src/Monticello/MCTraitParser.class.st
+++ b/src/Monticello/MCTraitParser.class.st
@@ -14,55 +14,65 @@ MCTraitParser class >> pattern [
 
 { #category : #actions }
 MCTraitParser >> addDefinitionsTo: aCollection [
+
 	| node compositionIndex categoryIndex slotsIndex traitName traitCompositionString slotsArray argumentNode categoryString definition |
-	 
 	node := RBParser parseExpression: source.
-	
-	node selector caseOf: { 
-		[#named:] -> [ 
-			compositionIndex := nil. slotsIndex := nil. categoryIndex := nil ].
-		[#named:uses:] -> [ 
-			compositionIndex := 2. slotsIndex := nil. categoryIndex := nil ].
-		[#named:uses:category:] -> [ 
-			compositionIndex := 2. slotsIndex := nil. categoryIndex := 3 ].
-		[#named:uses:package:] -> [ 
-			compositionIndex := 2. slotsIndex := nil. categoryIndex := 3 ].
-		[#named:uses:slots:category:] -> [ 
-			compositionIndex := 2. slotsIndex := 3. categoryIndex := 4 ].
-		[#named:uses:slots:package:] -> [ 
-			compositionIndex := 2. slotsIndex := 3. categoryIndex := 4 ]
-	} otherwise: [ self error: 'Unknown trait building selector' ].
+
+	node selector
+		caseOf: {
+				([ #named: ] -> [
+				 compositionIndex := nil.
+				 slotsIndex := nil.
+				 categoryIndex := nil ]).
+				([ #named:uses: ] -> [
+				 compositionIndex := 2.
+				 slotsIndex := nil.
+				 categoryIndex := nil ]).
+				([ #named:uses:category: ] -> [
+				 compositionIndex := 2.
+				 slotsIndex := nil.
+				 categoryIndex := 3 ]).
+				([ #named:uses:package: ] -> [
+				 compositionIndex := 2.
+				 slotsIndex := nil.
+				 categoryIndex := 3 ]).
+				([ #named:uses:slots:category: ] -> [
+				 compositionIndex := 2.
+				 slotsIndex := 3.
+				 categoryIndex := 4 ]).
+				([ #named:uses:slots:package: ] -> [
+				 compositionIndex := 2.
+				 slotsIndex := 3.
+				 categoryIndex := 4 ]) }
+		otherwise: [ self error: 'Unknown trait building selector' ].
 
 	traitName := node arguments first value.
 
-	traitCompositionString := compositionIndex 
-		ifNotNil: [ 
-			argumentNode := node arguments at: compositionIndex.
-			argumentNode source copyFrom: argumentNode sourceInterval first to: argumentNode sourceInterval last ]
-		ifNil: [ '' ].
+	traitCompositionString := compositionIndex
+		                          ifNotNil: [
+			                          argumentNode := node arguments at: compositionIndex.
+			                          argumentNode source copyFrom: argumentNode sourceInterval first to: argumentNode sourceInterval last ]
+		                          ifNil: [ '' ].
 
-	slotsArray := slotsIndex 
-		ifNotNil: [ 
-			argumentNode := node arguments at: slotsIndex.
-			argumentNode statements collect: [ :each |
-				each source copyFrom: each sourceInterval first to: each sourceInterval last ] ]
-		ifNil: [ Array new ].
+	slotsArray := slotsIndex
+		              ifNotNil: [
+			              argumentNode := node arguments at: slotsIndex.
+			              argumentNode statements collect: [ :each | each source copyFrom: each sourceInterval first to: each sourceInterval last ] ]
+		              ifNil: [ Array new ].
 
-	categoryString := categoryIndex 
-		ifNotNil: [ 
-			argumentNode := node arguments at: categoryIndex.
-			argumentNode source copyFrom: argumentNode sourceInterval first to: argumentNode sourceInterval last ]
-		ifNil: [ 'Unclassified' ].
+	categoryString := categoryIndex
+		                  ifNotNil: [
+			                  argumentNode := node arguments at: categoryIndex.
+			                  argumentNode source copyFrom: argumentNode sourceInterval first to: argumentNode sourceInterval last ]
+		                  ifNil: [ 'Unclassified' ].
 
 	definition := MCTraitDefinition
-		name: traitName
-		traitComposition: traitCompositionString
-		category:  categoryString
-		instVarNames:  slotsArray
-		classInstVarNames: ''
-		classTraitComposition: nil
-		comment:  ''  
-		commentStamp: ''.
-		
-	aCollection add: definition.
+		              name: traitName
+		              traitComposition: traitCompositionString
+		              category: categoryString
+		              instVarNames: slotsArray
+		              classInstVarNames: ''
+		              comment: ''.
+
+	aCollection add: definition
 ]

--- a/src/Monticello/MCTraitParser.class.st
+++ b/src/Monticello/MCTraitParser.class.st
@@ -18,33 +18,20 @@ MCTraitParser >> addDefinitionsTo: aCollection [
 	| node compositionIndex categoryIndex slotsIndex traitName traitCompositionString slotsArray argumentNode categoryString definition |
 	node := RBParser parseExpression: source.
 
-	node selector
-		caseOf: {
-				([ #named: ] -> [
-				 compositionIndex := nil.
-				 slotsIndex := nil.
-				 categoryIndex := nil ]).
-				([ #named:uses: ] -> [
-				 compositionIndex := 2.
-				 slotsIndex := nil.
-				 categoryIndex := nil ]).
-				([ #named:uses:category: ] -> [
-				 compositionIndex := 2.
-				 slotsIndex := nil.
-				 categoryIndex := 3 ]).
-				([ #named:uses:package: ] -> [
-				 compositionIndex := 2.
-				 slotsIndex := nil.
-				 categoryIndex := 3 ]).
-				([ #named:uses:slots:category: ] -> [
-				 compositionIndex := 2.
-				 slotsIndex := 3.
-				 categoryIndex := 4 ]).
-				([ #named:uses:slots:package: ] -> [
-				 compositionIndex := 2.
-				 slotsIndex := 3.
-				 categoryIndex := 4 ]) }
-		otherwise: [ self error: 'Unknown trait building selector' ].
+	node selector caseOf: { 
+		[#named:] -> [ 
+			compositionIndex := nil. slotsIndex := nil. categoryIndex := nil ].
+		[#named:uses:] -> [ 
+			compositionIndex := 2. slotsIndex := nil. categoryIndex := nil ].
+		[#named:uses:category:] -> [ 
+			compositionIndex := 2. slotsIndex := nil. categoryIndex := 3 ].
+		[#named:uses:package:] -> [ 
+			compositionIndex := 2. slotsIndex := nil. categoryIndex := 3 ].
+		[#named:uses:slots:category:] -> [ 
+			compositionIndex := 2. slotsIndex := 3. categoryIndex := 4 ].
+		[#named:uses:slots:package:] -> [ 
+			compositionIndex := 2. slotsIndex := 3. categoryIndex := 4 ]
+	} otherwise: [ self error: 'Unknown trait building selector' ].
 
 	traitName := node arguments first value.
 

--- a/src/Monticello/MCTraitParser.class.st
+++ b/src/Monticello/MCTraitParser.class.st
@@ -70,8 +70,7 @@ MCTraitParser >> addDefinitionsTo: aCollection [
 		              name: traitName
 		              traitComposition: traitCompositionString
 		              category: categoryString
-		              instVarNames: slotsArray
-		              classInstVarNames: ''.
+		              instVarNames: slotsArray.
 
 	aCollection add: definition
 ]

--- a/src/Monticello/Trait.extension.st
+++ b/src/Monticello/Trait.extension.st
@@ -12,19 +12,21 @@ Trait >> asClassDefinition [
 	| definition |
 	definition := self needsSlotClassDefinition
 		              ifTrue: [
-			              MCTraitDefinition
-				              name: self name
-				              traitComposition: self traitCompositionString
-				              category: self category
-				              instVarNames: (self localSlots collect: [ :each | each definitionString ])
-				              classInstVarNames: (self classSide localSlots collect: [ :each | each definitionString ]) ]
+			              (MCTraitDefinition
+				               name: self name
+				               traitComposition: self traitCompositionString
+				               category: self category
+				               instVarNames: (self localSlots collect: [ :each | each definitionString ]))
+				              classInstVarNames: (self classSide localSlots collect: [ :each | each definitionString ]);
+				              yourself ]
 		              ifFalse: [
-			              MCTraitDefinition
-				              name: self name
-				              traitComposition: self traitCompositionString
-				              category: self category
-				              instVarNames: (self localSlots collect: [ :each | each name ])
-				              classInstVarNames: (self class localSlots collect: [ :each | each name ]) ].
+			              (MCTraitDefinition
+				               name: self name
+				               traitComposition: self traitCompositionString
+				               category: self category
+				               instVarNames: (self localSlots collect: [ :each | each name ]))
+				              classInstVarNames: (self class localSlots collect: [ :each | each name ]);
+				              yourself ].
 
 	definition
 		classTraitComposition: self class traitCompositionString;

--- a/src/Monticello/Trait.extension.st
+++ b/src/Monticello/Trait.extension.st
@@ -12,19 +12,13 @@ Trait >> asClassDefinition [
 	| definition |
 	definition := self needsSlotClassDefinition
 		              ifTrue: [
-			              (MCTraitDefinition
-				               name: self name
-				               traitComposition: self traitCompositionString
-				               category: self category
-				               instVarNames: (self localSlots collect: [ :each | each definitionString ]))
+			              (MCTraitDefinition name: self name traitComposition: self traitCompositionString category: self category)
+				              instVarNames: (self localSlots collect: [ :each | each definitionString ]);
 				              classInstVarNames: (self classSide localSlots collect: [ :each | each definitionString ]);
 				              yourself ]
 		              ifFalse: [
-			              (MCTraitDefinition
-				               name: self name
-				               traitComposition: self traitCompositionString
-				               category: self category
-				               instVarNames: (self localSlots collect: [ :each | each name ]))
+			              (MCTraitDefinition name: self name traitComposition: self traitCompositionString category: self category)
+				              instVarNames: (self localSlots collect: [ :each | each name ]);
 				              classInstVarNames: (self class localSlots collect: [ :each | each name ]);
 				              yourself ].
 

--- a/src/Monticello/Trait.extension.st
+++ b/src/Monticello/Trait.extension.st
@@ -12,17 +12,18 @@ Trait >> asClassDefinition [
 	| definition |
 	definition := self needsSlotClassDefinition
 		              ifTrue: [
-			              (MCTraitDefinition name: self name traitComposition: self traitCompositionString category: self category)
+			              (MCTraitDefinition name: self name traitComposition: self traitCompositionString)
 				              instVarNames: (self localSlots collect: [ :each | each definitionString ]);
 				              classInstVarNames: (self classSide localSlots collect: [ :each | each definitionString ]);
 				              yourself ]
 		              ifFalse: [
-			              (MCTraitDefinition name: self name traitComposition: self traitCompositionString category: self category)
+			              (MCTraitDefinition name: self name traitComposition: self traitCompositionString)
 				              instVarNames: (self localSlots collect: [ :each | each name ]);
 				              classInstVarNames: (self class localSlots collect: [ :each | each name ]);
 				              yourself ].
 
 	definition
+		category: self category;
 		classTraitComposition: self class traitCompositionString;
 		comment: self comment;
 		commentStamp: self commentStamp.

--- a/src/Monticello/Trait.extension.st
+++ b/src/Monticello/Trait.extension.st
@@ -10,23 +10,22 @@ Trait >> asClassDefinition [
 	"
 
 	| definition |
-	definition := self needsSlotClassDefinition
-		              ifTrue: [
-			              (MCTraitDefinition name: self name traitComposition: self traitCompositionString)
-				              instVarNames: (self localSlots collect: [ :each | each definitionString ]);
-				              classInstVarNames: (self classSide localSlots collect: [ :each | each definitionString ]);
-				              yourself ]
-		              ifFalse: [
-			              (MCTraitDefinition name: self name traitComposition: self traitCompositionString)
-				              instVarNames: (self localSlots collect: [ :each | each name ]);
-				              classInstVarNames: (self class localSlots collect: [ :each | each name ]);
-				              yourself ].
+	definition := (MCTraitDefinition named: self name)
+		              traitComposition: self traitCompositionString;
+		              category: self category;
+		              classTraitComposition: self class traitCompositionString;
+		              comment: self comment;
+		              commentStamp: self commentStamp.
 
-	definition
-		category: self category;
-		classTraitComposition: self class traitCompositionString;
-		comment: self comment;
-		commentStamp: self commentStamp.
+	self needsSlotClassDefinition
+		ifTrue: [
+			definition
+				instVarNames: (self localSlots collect: [ :each | each definitionString ]);
+				classInstVarNames: (self classSide localSlots collect: [ :each | each definitionString ]) ]
+		ifFalse: [
+			definition
+				instVarNames: (self localSlots collect: [ :each | each name ]);
+				classInstVarNames: (self class localSlots collect: [ :each | each name ]) ].
 
 	^ definition
 ]

--- a/src/Monticello/Trait.extension.st
+++ b/src/Monticello/Trait.extension.st
@@ -8,34 +8,31 @@ Trait >> asClassDefinition [
 				
 	This is produces by definitionString on slot while x is produced simnply by invoking name.
 	"
-	| classTraitCompositionToUse |
-	classTraitCompositionToUse := self class traitCompositionString.
 
-	^ self needsSlotClassDefinition
-		ifTrue: [ 
-			MCTraitDefinition
-				name: self name
-				traitComposition: self traitCompositionString
-				category: self category 
-				instVarNames: (self localSlots collect: [:each |each definitionString])
-				classInstVarNames: (self classSide localSlots collect: [:each |each definitionString])
-				classTraitComposition: classTraitCompositionToUse
-				comment: self comment
-				commentStamp: self commentStamp ]
-		 ifFalse: [  
-			MCTraitDefinition
-				name: self name
-				traitComposition: self traitCompositionString
-				category: self category 
-				instVarNames: (self localSlots collect: [ :each | each name ])
-				classInstVarNames: (self class localSlots collect: [ :each | each name ])
-				classTraitComposition: classTraitCompositionToUse
-				comment: self comment
-				commentStamp: self commentStamp
-				]
-		
-	
-		
+	| definition |
+	definition := self needsSlotClassDefinition
+		              ifTrue: [
+			              MCTraitDefinition
+				              name: self name
+				              traitComposition: self traitCompositionString
+				              category: self category
+				              instVarNames: (self localSlots collect: [ :each | each definitionString ])
+				              classInstVarNames: (self classSide localSlots collect: [ :each | each definitionString ])
+				              comment: self comment ]
+		              ifFalse: [
+			              MCTraitDefinition
+				              name: self name
+				              traitComposition: self traitCompositionString
+				              category: self category
+				              instVarNames: (self localSlots collect: [ :each | each name ])
+				              classInstVarNames: (self class localSlots collect: [ :each | each name ])
+				              comment: self comment ].
+
+	definition
+		classTraitComposition: self class traitCompositionString;
+		commentStamp: self commentStamp.
+
+	^ definition
 ]
 
 { #category : #'*Monticello' }

--- a/src/Monticello/Trait.extension.st
+++ b/src/Monticello/Trait.extension.st
@@ -17,19 +17,18 @@ Trait >> asClassDefinition [
 				              traitComposition: self traitCompositionString
 				              category: self category
 				              instVarNames: (self localSlots collect: [ :each | each definitionString ])
-				              classInstVarNames: (self classSide localSlots collect: [ :each | each definitionString ])
-				              comment: self comment ]
+				              classInstVarNames: (self classSide localSlots collect: [ :each | each definitionString ]) ]
 		              ifFalse: [
 			              MCTraitDefinition
 				              name: self name
 				              traitComposition: self traitCompositionString
 				              category: self category
 				              instVarNames: (self localSlots collect: [ :each | each name ])
-				              classInstVarNames: (self class localSlots collect: [ :each | each name ])
-				              comment: self comment ].
+				              classInstVarNames: (self class localSlots collect: [ :each | each name ]) ].
 
 	definition
 		classTraitComposition: self class traitCompositionString;
+		comment: self comment;
 		commentStamp: self commentStamp.
 
 	^ definition

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
@@ -188,13 +188,14 @@ MCFileTreeStCypressReader >> addTraitAndMethodDefinitionsFromEntry: classEntry [
 MCFileTreeStCypressReader >> addTraitDefinitionFrom: traitPropertiesDict comment: traitComment [
 
 	| definition |
-	definition := MCTraitDefinition
-		              name: (traitPropertiesDict at: 'name')
-		              traitComposition: (traitPropertiesDict at: 'traitcomposition' ifAbsent: [ '{}' ])
-		              category: (traitPropertiesDict at: 'category' ifAbsent: [ self packageNameFromPackageDirectory ])
-		              instVarNames: (traitPropertiesDict at: 'instvars' ifAbsent: [ #(  ) ])
-		              classInstVarNames: ''
-		              comment: traitComment.
+	definition := (MCTraitDefinition
+		               name: (traitPropertiesDict at: 'name')
+		               traitComposition: (traitPropertiesDict at: 'traitcomposition' ifAbsent: [ '{}' ])
+		               category: (traitPropertiesDict at: 'category' ifAbsent: [ self packageNameFromPackageDirectory ])
+		               instVarNames: (traitPropertiesDict at: 'instvars' ifAbsent: [ #(  ) ])
+		               classInstVarNames: '')
+		              comment: traitComment;
+		              yourself.
 
 	traitPropertiesDict at: 'commentStamp' ifPresent: [ :stamp | definition commentStamp: stamp ].
 

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
@@ -192,8 +192,7 @@ MCFileTreeStCypressReader >> addTraitDefinitionFrom: traitPropertiesDict comment
 		               name: (traitPropertiesDict at: 'name')
 		               traitComposition: (traitPropertiesDict at: 'traitcomposition' ifAbsent: [ '{}' ])
 		               category: (traitPropertiesDict at: 'category' ifAbsent: [ self packageNameFromPackageDirectory ])
-		               instVarNames: (traitPropertiesDict at: 'instvars' ifAbsent: [ #(  ) ])
-		               classInstVarNames: '')
+		               instVarNames: (traitPropertiesDict at: 'instvars' ifAbsent: [ #(  ) ]))
 		              comment: traitComment;
 		              yourself.
 

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
@@ -188,12 +188,13 @@ MCFileTreeStCypressReader >> addTraitAndMethodDefinitionsFromEntry: classEntry [
 MCFileTreeStCypressReader >> addTraitDefinitionFrom: traitPropertiesDict comment: traitComment [
 
 	| definition |
-	definition := (MCTraitDefinition name: (traitPropertiesDict at: 'name') traitComposition: (traitPropertiesDict at: 'traitcomposition' ifAbsent: [ '{}' ]))
+	definition := (MCTraitDefinition named: (traitPropertiesDict at: 'name'))
 		              category: (traitPropertiesDict at: 'category' ifAbsent: [ self packageNameFromPackageDirectory ]);
 		              comment: traitComment;
 		              yourself.
 
 	traitPropertiesDict
+		at: 'traitcomposition' ifPresent: [ :composition | definition traitComposition: composition ];
 		at: 'instvars' ifPresent: [ :ivars | definition instVarNames: ivars ];
 		at: 'commentStamp' ifPresent: [ :stamp | definition commentStamp: stamp ].
 

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
@@ -191,12 +191,13 @@ MCFileTreeStCypressReader >> addTraitDefinitionFrom: traitPropertiesDict comment
 	definition := (MCTraitDefinition
 		               name: (traitPropertiesDict at: 'name')
 		               traitComposition: (traitPropertiesDict at: 'traitcomposition' ifAbsent: [ '{}' ])
-		               category: (traitPropertiesDict at: 'category' ifAbsent: [ self packageNameFromPackageDirectory ])
-		               instVarNames: (traitPropertiesDict at: 'instvars' ifAbsent: [ #(  ) ]))
+		               category: (traitPropertiesDict at: 'category' ifAbsent: [ self packageNameFromPackageDirectory ]))
 		              comment: traitComment;
 		              yourself.
 
-	traitPropertiesDict at: 'commentStamp' ifPresent: [ :stamp | definition commentStamp: stamp ].
+	traitPropertiesDict
+		at: 'instvars' ifPresent: [ :ivars | definition instVarNames: ivars ];
+		at: 'commentStamp' ifPresent: [ :stamp | definition commentStamp: stamp ].
 
 	definitions add: definition.
 

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
@@ -186,23 +186,22 @@ MCFileTreeStCypressReader >> addTraitAndMethodDefinitionsFromEntry: classEntry [
 
 { #category : #utilities }
 MCFileTreeStCypressReader >> addTraitDefinitionFrom: traitPropertiesDict comment: traitComment [
-    definitions
-        add:
-            (MCTraitDefinition
-                name: (traitPropertiesDict at: 'name')
-                traitComposition: (traitPropertiesDict at: 'traitcomposition' ifAbsent: [ '{}' ])
-                category: (traitPropertiesDict at: 'category' ifAbsent: [ self packageNameFromPackageDirectory ])
-					instVarNames: (traitPropertiesDict at: 'instvars' ifAbsent: [ #() ])
-					classInstVarNames: ''
-					classTraitComposition: nil
-					comment: traitComment
-					commentStamp: (traitPropertiesDict at: 'commentStamp' ifAbsent: [ '' ])).
-    traitPropertiesDict at: 'classtraitcomposition' ifPresent: [:classTraitComposition |
-        definitions
-             add:
-                (MCClassTraitDefinition
-                    baseTraitName: (traitPropertiesDict at: 'name')
-                    classTraitComposition: classTraitComposition)].
+
+	| definition |
+	definition := MCTraitDefinition
+		              name: (traitPropertiesDict at: 'name')
+		              traitComposition: (traitPropertiesDict at: 'traitcomposition' ifAbsent: [ '{}' ])
+		              category: (traitPropertiesDict at: 'category' ifAbsent: [ self packageNameFromPackageDirectory ])
+		              instVarNames: (traitPropertiesDict at: 'instvars' ifAbsent: [ #(  ) ])
+		              classInstVarNames: ''
+		              comment: traitComment.
+
+	traitPropertiesDict at: 'commentStamp' ifPresent: [ :stamp | definition commentStamp: stamp ].
+
+	definitions add: definition.
+
+	traitPropertiesDict at: 'classtraitcomposition' ifPresent: [ :classTraitComposition |
+		definitions add: (MCClassTraitDefinition baseTraitName: (traitPropertiesDict at: 'name') classTraitComposition: classTraitComposition) ]
 ]
 
 { #category : #accessing }

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
@@ -188,10 +188,8 @@ MCFileTreeStCypressReader >> addTraitAndMethodDefinitionsFromEntry: classEntry [
 MCFileTreeStCypressReader >> addTraitDefinitionFrom: traitPropertiesDict comment: traitComment [
 
 	| definition |
-	definition := (MCTraitDefinition
-		               name: (traitPropertiesDict at: 'name')
-		               traitComposition: (traitPropertiesDict at: 'traitcomposition' ifAbsent: [ '{}' ])
-		               category: (traitPropertiesDict at: 'category' ifAbsent: [ self packageNameFromPackageDirectory ]))
+	definition := (MCTraitDefinition name: (traitPropertiesDict at: 'name') traitComposition: (traitPropertiesDict at: 'traitcomposition' ifAbsent: [ '{}' ]))
+		              category: (traitPropertiesDict at: 'category' ifAbsent: [ self packageNameFromPackageDirectory ]);
 		              comment: traitComment;
 		              yourself.
 


### PR DESCRIPTION
MCTraitDescription has a lot of parameters and to create a new instance there is a huge constructor.

Most of the parameters end up been default values. I'll have to update the state of this method to split the packages and tags from the category and before doing this change I would like to change the way we create the class description by configuring the instance instead.
