### PR TITLE
RPackage: simplify package renaming

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -295,13 +295,13 @@ Class >> category: aString [
 
 	| oldCategory |
 	oldCategory := self basicCategory.
+	oldCategory = aString ifTrue: [ ^ self ].
 	aString isString
 		ifTrue: [
 			self basicCategory: aString asSymbol.
 			self packageOrganizer classify: self name under: self basicCategory ]
-		ifFalse: [self errorCategoryName].
-	SystemAnnouncer uniqueInstance
-		class: self recategorizedFrom: oldCategory to: self basicCategory
+		ifFalse: [ self errorCategoryName ].
+	SystemAnnouncer uniqueInstance class: self recategorizedFrom: oldCategory to: self basicCategory
 ]
 
 { #category : #'subclass creation - variableByte' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -831,26 +831,6 @@ RPackage >> renameTag: aTag to: newName [
 		 ifFalse: [ aTag ]) renameTo: newName
 ]
 
-{ #category : #private }
-RPackage >> renameTagsPrefixedWith: oldName to: newName [
-	| oldPrefix newPrefix |
-
-	oldName ifNil: [ ^ self ].
-
-	self
-		classTagNamed: oldName
-		ifPresent: [ :tag | tag renameTo: newName category: newName ].
-
-	oldPrefix := oldName, '-'.
-	newPrefix := newName, '-'.
-	(self classTags
-		select: [ :each | each categoryName beginsWith: oldPrefix ])
-		do: [ :each |
-			each
-				renameTo: each name
-				category: newPrefix, (each name) ]
-]
-
 { #category : #register }
 RPackage >> renameTo: aSymbol [
 	"Rename a package with a different name, provided as a symbol"
@@ -866,7 +846,8 @@ RPackage >> renameTo: aSymbol [
 	SystemAnnouncer uniqueInstance suspendAllWhile: [
 		self definedClasses do: [ :each | each category: newName , (each category allButFirst: oldName size) ].
 		oldCategoryNames do: [ :each | self organizer removeCategory: each ] ].
-	self renameTagsPrefixedWith: oldName to: newName.
+	self flag: #package. "For now, the root tag has the name of the package, thus, renaming the package means that we need to rename the root tag. In the future I want to update the root tag name to be fix and not depend on the name of the package. When that happens, we'll be able to remove the next line."
+	self classTagNamed: oldName ifPresent: [ :tag | tag renameTo: newName ].
 	self renameExtensionsPrefixedWith: oldName to: newName.
 	self organizer
 		basicUnregisterPackageNamed: oldName;

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -167,31 +167,19 @@ RPackageTag >> removeFromPackage [
 { #category : #accessing }
 RPackageTag >> renameTo: newTagName [
 
-	| oldName categoryName tagName |
-	tagName := self name.
-	oldName := self toCategoryName: tagName.
-	categoryName := self toCategoryName: newTagName.
+	| oldCategoryName newCategoryName oldTagName |
+	oldTagName := self name.
+	oldCategoryName := self toCategoryName: oldTagName.
+	newCategoryName := self toCategoryName: newTagName.
 
-	oldName = categoryName ifTrue: [ ^ self ].
+	oldTagName = newTagName ifTrue: [ ^ self ].
 
 	self basicRenameTo: newTagName.
 	SystemAnnouncer uniqueInstance suspendAllWhile: [
-		self classes do: [ :each | each category: categoryName ].
-		self organizer renameCategory: oldName toBe: categoryName ].
-	SystemAnnouncer announce: (PackageTagRenamed to: self oldName: tagName newName: newTagName)
-]
-
-{ #category : #accessing }
-RPackageTag >> renameTo: aString category: categoryName [
-
-	| oldName |
-	oldName := self toCategoryName: self name.
-	oldName = categoryName ifTrue: [ ^ self ].
-
-	self basicRenameTo: aString.
-	SystemAnnouncer uniqueInstance suspendAllWhile: [
-		self classes do: [ :each | each category: categoryName ].
-		self organizer renameCategory: oldName toBe: categoryName ]
+		self flag: #package. "This should be removed with the system organizer."
+		self classes do: [ :each | each category: newCategoryName ].
+		self organizer renameCategory: oldCategoryName toBe: newCategoryName ].
+	SystemAnnouncer announce: (PackageTagRenamed to: self oldName: oldTagName newName: newTagName)
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Here is a simplification of the package renaming.

Before we were checking every tag that was starting with the package name to update the name. But a tag should not be prefixed by the package name.  The only case we have to manage is the root tag that is currently the name of the package. 

I introduced two changes with this cleaning:
- The renaming of the root tag is announced while it was silent in the past
- If we set the category to a class, but the class already has this category, we do not proceed (which will cut some update code before it happens since there is nothing to update)