### PR TITLE
RPackage: Clean package management in RPackageOrganizer

### DIFF
--- a/src/Monticello/MCWorkingCopy.class.st
+++ b/src/Monticello/MCWorkingCopy.class.st
@@ -277,12 +277,7 @@ MCWorkingCopy class >> unregisterForNotifications [
 { #category : #'system changes' }
 MCWorkingCopy class >> workingCopiesForClass: aClass do: aBlock [
 
-	| package |
-	package := aClass package.
-
-	self registry
-		select: [ :workingCopy | workingCopy systemPackage = package ]
-		thenDo: aBlock
+	^ self workingCopiesForPackage: aClass package do: aBlock
 ]
 
 { #category : #'system changes' }
@@ -314,11 +309,11 @@ MCWorkingCopy class >> workingCopiesForExtensionProtocol: extensionName do: aBlo
 { #category : #'system changes' }
 MCWorkingCopy class >> workingCopiesForPackage: aPackage do: aBlock [
 
+	| packageName |
+	packageName := aPackage name.
+
 	self registry
-		select: [ :workingCopy |
-			workingCopy systemPackage
-				ifNil: [ false ]
-				ifNotNil: [ :package | package = aPackage ] ]
+		select: [ :workingCopy | workingCopy packageName = packageName ]
 		thenDo: aBlock
 ]
 

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -842,7 +842,6 @@ RPackage >> renameTo: aSymbol [
 	oldCategoryNames := (self classTags collect: [ :each | each categoryName ] as: Set)
 		                    add: self name;
 		                    difference: { newName }.
-	self organizer basicUnregisterPackage: self.
 	self name: aSymbol.
 	SystemAnnouncer uniqueInstance suspendAllWhile: [
 		self definedClasses do: [ :each | each category: newName , (each category allButFirst: oldName size) ].
@@ -850,7 +849,6 @@ RPackage >> renameTo: aSymbol [
 	self flag: #package. "For now, the root tag has the name of the package, thus, renaming the package means that we need to rename the root tag. In the future I want to update the root tag name to be fix and not depend on the name of the package. When that happens, we'll be able to remove the next line."
 	self classTagNamed: oldName ifPresent: [ :tag | tag renameTo: newName ].
 	self renameExtensionsPrefixedWith: oldName to: newName.
-	self organizer basicRegisterPackage: self.
 	SystemAnnouncer uniqueInstance announce: (PackageRenamed to: self oldName: oldName newName: newName)
 ]
 

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -218,14 +218,17 @@ RPackageOrganizer >> basicInitializeFromPackagesList: aPackagesList [
 RPackageOrganizer >> basicRegisterPackage: aPackage [
 	"A new package is now available and declared in the receiver. Note that it is a low level implementation method since it does not deal with package contained information and does not update the related mapping tables."
 
-	^ packages add: aPackage
+	(self hasPackage: aPackage) ifTrue: [ ^ aPackage ].
+
+	packages := packages copyWith: aPackage.
+	^ aPackage
 ]
 
 { #category : #'private - registration' }
 RPackageOrganizer >> basicUnregisterPackage: aPackage [
 	"Unregister the specified package from the list of registered packages. Raise the PackageRemoved announcement. This is a low level action. It does not unregister the back pointer from classes to packages or any other information managed by the organizer"
 
-	^ packages remove: aPackage ifAbsent: [  ]
+	^ packages copyWithout: aPackage
 ]
 
 { #category : #'deprecated - SystemOrganizer leftovers' }
@@ -394,7 +397,7 @@ RPackageOrganizer >> includesCategory: aString [
 RPackageOrganizer >> initialize [
 
 	super initialize.
-	packages := Set new.
+	packages := Array new.
 	classPackageMapping := IdentityDictionary new.
 	classExtendingPackagesMapping := IdentityDictionary new.
 	debuggingName := ''.

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -105,11 +105,11 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'classPackageMapping',
-		'packages',
 		'classExtendingPackagesMapping',
 		'debuggingName',
 		'environment',
-		'categoryMap'
+		'categoryMap',
+		'packages'
 	],
 	#category : #'RPackage-Core-Base'
 }
@@ -218,14 +218,14 @@ RPackageOrganizer >> basicInitializeFromPackagesList: aPackagesList [
 RPackageOrganizer >> basicRegisterPackage: aPackage [
 	"A new package is now available and declared in the receiver. Note that it is a low level implementation method since it does not deal with package contained information and does not update the related mapping tables."
 
-	^ packages at: aPackage name asSymbol put: aPackage
+	^ packages add: aPackage
 ]
 
 { #category : #'private - registration' }
 RPackageOrganizer >> basicUnregisterPackage: aPackage [
 	"Unregister the specified package from the list of registered packages. Raise the PackageRemoved announcement. This is a low level action. It does not unregister the back pointer from classes to packages or any other information managed by the organizer"
 
-	^ packages removeKey: aPackage name ifAbsent: [  ]
+	^ packages remove: aPackage ifAbsent: [  ]
 ]
 
 { #category : #'deprecated - SystemOrganizer leftovers' }
@@ -366,7 +366,10 @@ RPackageOrganizer >> hasPackage: aPackage [
 	"Takes a package or a package name as parameter and return true if I include this package."
 
 	^ aPackage isString
-		  ifTrue: [ packages includesKey: aPackage asSymbol ]
+		  ifTrue: [
+			  | packageSymbol |
+			  packageSymbol := aPackage asSymbol.
+			  self packages anySatisfy: [ :package | package name = packageSymbol ] ]
 		  ifFalse: [ self packages includes: aPackage ]
 ]
 
@@ -391,8 +394,7 @@ RPackageOrganizer >> includesCategory: aString [
 RPackageOrganizer >> initialize [
 
 	super initialize.
-
-	packages := IdentityDictionary new.
+	packages := Set new.
 	classPackageMapping := IdentityDictionary new.
 	classExtendingPackagesMapping := IdentityDictionary new.
 	debuggingName := ''.
@@ -474,23 +476,27 @@ RPackageOrganizer >> packageNamed: aSymbol [
 { #category : #accessing }
 RPackageOrganizer >> packageNamed: aSymbol ifAbsent: errorBlock [
 
-	^ packages at: aSymbol asSymbol ifAbsent: errorBlock
+	| packageSymbol |
+	packageSymbol := aSymbol asSymbol.
+	^ self packages
+		  detect: [ :package | package name = packageSymbol ]
+		  ifNone: errorBlock
 ]
 
-{ #category : #private }
-RPackageOrganizer >> packageNamedIgnoreCase: aSymbol ifAbsent: aBlock [
-	"In case of extensions, I can need to take a package ignoring name"
-	self packagesDo: [  :each |
-		(each name sameAs: aSymbol)
-			ifTrue: [  ^ each  ]  ].
+{ #category : #accessing }
+RPackageOrganizer >> packageNamedIgnoreCase: aSymbol ifAbsent: errorBlock [
 
-	^ aBlock value
+	| packageSymbol |
+	packageSymbol := aSymbol asSymbol.
+	^ self packages
+		  detect: [ :package | package name sameAs: packageSymbol ]
+		  ifNone: errorBlock
 ]
 
 { #category : #'package - names-cache' }
 RPackageOrganizer >> packageNames [
 
-	^ packages keys
+	^ self packages collect: [ :package | package name ]
 ]
 
 { #category : #'package - names-cache' }
@@ -517,7 +523,7 @@ RPackageOrganizer >> packageOfClassNamed: aName [
 { #category : #accessing }
 RPackageOrganizer >> packages [
 
-	^ packages values
+	^ packages
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Here is a cleaning of the package management in RPackage organizer.

We now save an array of packages instead of a dictionary of package names and packages. I also cleaned some methods to rely less on the implementation details.

I did also some speed up