### PR TITLE
RPackahe: Clean usage of packages instance variable

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -842,6 +842,7 @@ RPackage >> renameTo: aSymbol [
 	oldCategoryNames := (self classTags collect: [ :each | each categoryName ] as: Set)
 		                    add: self name;
 		                    difference: { newName }.
+	self organizer basicUnregisterPackage: self.
 	self name: aSymbol.
 	SystemAnnouncer uniqueInstance suspendAllWhile: [
 		self definedClasses do: [ :each | each category: newName , (each category allButFirst: oldName size) ].
@@ -849,9 +850,7 @@ RPackage >> renameTo: aSymbol [
 	self flag: #package. "For now, the root tag has the name of the package, thus, renaming the package means that we need to rename the root tag. In the future I want to update the root tag name to be fix and not depend on the name of the package. When that happens, we'll be able to remove the next line."
 	self classTagNamed: oldName ifPresent: [ :tag | tag renameTo: newName ].
 	self renameExtensionsPrefixedWith: oldName to: newName.
-	self organizer
-		basicUnregisterPackageNamed: oldName;
-		basicRegisterPackage: self.
+	self organizer basicRegisterPackage: self.
 	SystemAnnouncer uniqueInstance announce: (PackageRenamed to: self oldName: oldName newName: newName)
 ]
 

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -197,7 +197,7 @@ RPackageOrganizer >> announcer [
 RPackageOrganizer >> basicInitializeFromPackagesList: aPackagesList [
 
 	aPackagesList
-		do: [ :packageName | packages at: packageName asSymbol put: (RPackage named: packageName organizer: self) ]
+		do: [ :packageName | self basicRegisterPackage: (RPackage named: packageName organizer: self) ]
 		displayingProgress: 'Importing monticello packages'.
 
 	Smalltalk allClassesAndTraits
@@ -222,10 +222,10 @@ RPackageOrganizer >> basicRegisterPackage: aPackage [
 ]
 
 { #category : #'private - registration' }
-RPackageOrganizer >> basicUnregisterPackageNamed: aPackageName [
+RPackageOrganizer >> basicUnregisterPackage: aPackage [
 	"Unregister the specified package from the list of registered packages. Raise the PackageRemoved announcement. This is a low level action. It does not unregister the back pointer from classes to packages or any other information managed by the organizer"
 
-	^ packages removeKey: aPackageName ifAbsent: [  ]
+	^ packages removeKey: aPackage name ifAbsent: [  ]
 ]
 
 { #category : #'deprecated - SystemOrganizer leftovers' }
@@ -455,7 +455,7 @@ RPackageOrganizer >> packageMatchingExtensionName: anExtensionName [
 
 	"if no package was found, we try to find one matching the begining of the name specified"
 	tmpPackageName := ''.
-	packages keysDo: [ :aSymbol |
+	self packageNames do: [ :aSymbol |
 		(anExtensionName beginsWith: aSymbol asString , '-' caseSensitive: false) ifTrue: [ "we keep the longest package name found"
 			aSymbol size > tmpPackageName size ifTrue: [ tmpPackageName := aSymbol ] ] ].
 
@@ -523,7 +523,7 @@ RPackageOrganizer >> packages [
 { #category : #accessing }
 RPackageOrganizer >> packagesDo: aBlock [
 
-	packages valuesDo: aBlock
+	self packages do: aBlock
 ]
 
 { #category : #printing }
@@ -659,7 +659,7 @@ RPackageOrganizer >> removePackage: aPackage [
 		           ifTrue: [ self packageNamed: aPackage ]
 		           ifFalse: [ aPackage ].
 
-	self basicUnregisterPackageNamed: package name.
+	self basicUnregisterPackage: package.
 	package extendedClasses do: [ :extendedClass | self unregisterExtendingPackage: package forClass: extendedClass ].
 	package definedClasses do: [ :definedClass | self unregisterPackage: package forClass: definedClass ].
 	SystemAnnouncer announce: (PackageRemoved to: package).
@@ -830,13 +830,13 @@ RPackageOrganizer >> systemMethodRecategorizedActionFrom: ann [
 { #category : #accessing }
 RPackageOrganizer >> testPackageNames [
 
-	^ packages keys select: [:nameSymbol | (self packageNamed: nameSymbol) isTestPackage]
+	^ self testPackages collect: [ :package | package name ]
 ]
 
 { #category : #accessing }
 RPackageOrganizer >> testPackages [
 
-	^ packages values select: #isTestPackage
+	^ self packages select: [ :package | package isTestPackage ]
 ]
 
 { #category : #initialization }

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -51,7 +51,7 @@ RPackageIncrementalTest >> setUp [
 { #category : #running }
 RPackageIncrementalTest >> tearDown [
 
-	createdPackages do: [ :each | self removePackage: each name ].
+	createdPackages do: [ :package | self removePackage: package ].
 	"just remove package from package organizer dictionary"
 
 	createdPackages do: [ :each |

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -17,12 +17,6 @@ RPackageOrganizerTest class >> removeClassNamedIfExists: aClassNameSymbol [
 	self environment at: aClassNameSymbol asSymbol ifPresent: [ :c | c removeFromSystem ]
 ]
 
-{ #category : #utilities }
-RPackageOrganizerTest class >> removePackageIfExist: aName [
-
-	self packageOrganizer basicUnregisterPackageNamed: aName asSymbol
-]
-
 { #category : #tests }
 RPackageOrganizerTest >> p1Name [
 	^ 'RPackageTestP1'
@@ -192,7 +186,7 @@ RPackageOrganizerTest >> testRegisteredNumberOfPackageIsOk [
 	self organizer basicRegisterPackage: p2.
 	self organizer basicRegisterPackage: p3.
 	self assert: self organizer packageNames size equals: 4.
-	self organizer basicUnregisterPackageNamed: p3 name.
+	self organizer basicUnregisterPackage: p3.
 	self assert: self organizer packageNames size equals: 3
 ]
 
@@ -330,7 +324,7 @@ RPackageOrganizerTest >> testTestPackages [
 ]
 
 { #category : #tests }
-RPackageOrganizerTest >> testUnregisterBasedOnNames [
+RPackageOrganizerTest >> testUnregister [
 
 	| p1 p2 p3 |
 	p1 := self createNewPackageNamed: 'P1'.
@@ -339,9 +333,9 @@ RPackageOrganizerTest >> testUnregisterBasedOnNames [
 
 	self assert: self organizer packageNames size equals: 4.
 
-	{p1 . p2 . p3} do: [:each |
-		(self organizer basicUnregisterPackageNamed: each name).
-		self deny: (self organizer packageNames includes: each name) ].
+	{p1 . p2 . p3} do: [:package |
+		(self organizer basicUnregisterPackage: package).
+		self deny: (self organizer packageNames includes: package name) ].
 
 	self assert: self organizer packageNames size equals: 1
 ]

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -105,9 +105,9 @@ RPackageTestCase >> organizer [
 ]
 
 { #category : #utilities }
-RPackageTestCase >> removePackage: aName [
+RPackageTestCase >> removePackage: aPackage [
 
-	self organizer basicUnregisterPackageNamed: aName
+	self organizer basicUnregisterPackage: aPackage
 ]
 
 { #category : #running }


### PR DESCRIPTION
This change clean a little the usage of the #packages instance variable to push the usage of real packages and reduce the references to the variable and rely less on the implementation.

Subpart of #14637 to find what is the origin of the problem