### PR TITLE
RPackage: Do not use categories API in trait tests

### DIFF
--- a/src/TraitsV2-Tests/TraitFileOutTest.class.st
+++ b/src/TraitsV2-Tests/TraitFileOutTest.class.st
@@ -19,14 +19,15 @@ TraitFileOutTest class >> defaultTimeLimit [
 ]
 
 { #category : #running }
-TraitFileOutTest >> categoryName [
-	^'Traits-Tests-FileOut'
+TraitFileOutTest >> packageName [
+
+	^ 'Traits-Tests-FileOut'
 ]
 
 { #category : #running }
 TraitFileOutTest >> setUp [
 	super setUp.
-	self packageOrganizer addCategory: self categoryName.
+	self packageOrganizer ensurePackage: self packageName.
 
 	td := self createTraitNamed: #TD uses: {}.
 	td compile: 'd' classified: #cat1.
@@ -52,8 +53,8 @@ TraitFileOutTest >> tearDown [
 	dir := FileSystem workingDirectory.
 	self createdClassesAndTraits, self resourceClassesAndTraits  do: [:each |
 		(dir / each asString,'st') ensureDelete ] .
-	(dir / self categoryName,'st') ensureDelete.
-	self packageOrganizer removeSystemCategory: self categoryName.
+	(dir / self packageName,'st') ensureDelete.
+	self packageOrganizer removeSystemCategory: self packageName.
 	"Ensure cleaning of obsoletes refs"
 	ca := cb := ta := tb := tc := td := nil.
 	super tearDown
@@ -65,11 +66,11 @@ TraitFileOutTest >> testFileOutCategory [
 	file them in again."
 
 	self timeLimit: 30 seconds.
-	self packageOrganizer fileOutCategory: self categoryName.
-	self packageOrganizer removeSystemCategory: self categoryName.
+	self packageOrganizer fileOutCategory: self packageName.
+	self packageOrganizer removeSystemCategory: self packageName.
 	self deny: (testingEnvironment keys asSet includesAnyOf: #(#CA #CB #TA #TB #TC #TD)).
 
-	CodeImporter evaluateFileNamed: (self categoryName , '.st').
+	CodeImporter evaluateFileNamed: (self packageName , '.st').
 	self assertCollection: testingEnvironment keys asSet includesAll: #(#CA #CB #TA #TB #TC #TD).
 	ta := testingEnvironment at: #TA.
 	self assert: ta traitComposition asString equals:  '((TB + TC) @ {#cc->#c}) - {#c}'.

--- a/src/TraitsV2-Tests/TraitFileOutTest.class.st
+++ b/src/TraitsV2-Tests/TraitFileOutTest.class.st
@@ -49,12 +49,12 @@ TraitFileOutTest >> setUp [
 
 { #category : #running }
 TraitFileOutTest >> tearDown [
+
 	| dir |
 	dir := FileSystem workingDirectory.
-	self createdClassesAndTraits, self resourceClassesAndTraits  do: [:each |
-		(dir / each asString,'st') ensureDelete ] .
-	(dir / self packageName,'st') ensureDelete.
-	self packageOrganizer removeSystemCategory: self packageName.
+	self createdClassesAndTraits , self resourceClassesAndTraits do: [ :each | (dir / each asString , 'st') ensureDelete ].
+	(dir / self packageName , 'st') ensureDelete.
+	(self packageOrganizer packageNamed: self packageName ifAbsent: [ nil ]) ifNotNil: [ :package | package removeFromSystem ].
 	"Ensure cleaning of obsoletes refs"
 	ca := cb := ta := tb := tc := td := nil.
 	super tearDown
@@ -67,7 +67,7 @@ TraitFileOutTest >> testFileOutCategory [
 
 	self timeLimit: 30 seconds.
 	self packageOrganizer fileOutCategory: self packageName.
-	self packageOrganizer removeSystemCategory: self packageName.
+	(self packageOrganizer packageNamed: self packageName ifAbsent: [ nil ]) ifNotNil: [ :package | package removeFromSystem ].
 	self deny: (testingEnvironment keys asSet includesAnyOf: #(#CA #CB #TA #TB #TC #TD)).
 
 	CodeImporter evaluateFileNamed: (self packageName , '.st').

--- a/src/TraitsV2-Tests/TraitsResource.class.st
+++ b/src/TraitsV2-Tests/TraitsResource.class.st
@@ -145,38 +145,34 @@ TraitsResource >> c9: anObject [
 	^c9 := anObject
 ]
 
-{ #category : #accessing }
-TraitsResource >> categoryName [
-	^self class category
-]
-
 { #category : #utilities }
 TraitsResource >> createClassNamed: aSymbol superclass: aClass uses: aTraitComposition [
-	| class |
 
+	| class |
 	class := self class classInstaller make: [ :aBuilder |
-		aBuilder name: aSymbol;
-			superclass: aClass;
-			traitComposition: aTraitComposition;
-			package: self categoryName ].
+		         aBuilder
+			         name: aSymbol;
+			         superclass: aClass;
+			         traitComposition: aTraitComposition;
+			         package: self packageName ].
 
 	self createdClassesAndTraits add: class.
-	^class
+	^ class
 ]
 
 { #category : #utilities }
 TraitsResource >> createTraitNamed: aSymbol uses: aTraitComposition [
+
 	| trait |
-	
 	trait := self class classInstaller make: [ :aBuilder |
-		aBuilder
-			name: aSymbol;
-			traitComposition: aTraitComposition;
-			package: self categoryName;
-			beTrait ].
+		         aBuilder
+			         name: aSymbol;
+			         traitComposition: aTraitComposition;
+			         package: self packageName;
+			         beTrait ].
 
 	self createdClassesAndTraits add: trait.
-	^trait
+	^ trait
 ]
 
 { #category : #accessing }
@@ -184,6 +180,12 @@ TraitsResource >> createdClassesAndTraits [
 	createdClassesAndTraits ifNil: [
 		createdClassesAndTraits := OrderedCollection new].
 	^createdClassesAndTraits
+]
+
+{ #category : #accessing }
+TraitsResource >> packageName [
+
+	^ self class packageName
 ]
 
 { #category : #running }

--- a/src/TraitsV2-Tests/TraitsTestCase.class.st
+++ b/src/TraitsV2-Tests/TraitsTestCase.class.st
@@ -78,23 +78,19 @@ TraitsTestCase >> c9 [
 	^TraitsResource current c9
 ]
 
-{ #category : #running }
-TraitsTestCase >> categoryName [
-	^self class category
-]
-
 { #category : #utilities }
 TraitsTestCase >> createClassNamed: aSymbol superclass: aClass uses: aTraitComposition [
-	| class |
 
+	| class |
 	class := self class classInstaller make: [ :aBuilder |
-		aBuilder name: aSymbol;
-			superclass: aClass;
-			traitComposition: aTraitComposition;
-			package: self categoryName ].
+		         aBuilder
+			         name: aSymbol;
+			         superclass: aClass;
+			         traitComposition: aTraitComposition;
+			         package: self packageName ].
 
 	self createdClassesAndTraits add: class.
-	^class
+	^ class
 ]
 
 { #category : #utilities }
@@ -105,7 +101,7 @@ TraitsTestCase >> createTraitNamed: aSymbol uses: aTraitComposition [
 		aBuilder
 			name: aSymbol;
 			traitComposition: aTraitComposition;
-			package: self categoryName;
+			package: self packageName;
 			beTrait ].
 
 	self createdClassesAndTraits add: trait.
@@ -117,6 +113,12 @@ TraitsTestCase >> createdClassesAndTraits [
 	createdClassesAndTraits ifNil: [
 		createdClassesAndTraits := OrderedCollection new].
 	^createdClassesAndTraits
+]
+
+{ #category : #running }
+TraitsTestCase >> packageName [
+
+	^ self class packageName
 ]
 
 { #category : #utilities }

--- a/src/TraitsV2-Tests/TraitsTestCase.class.st
+++ b/src/TraitsV2-Tests/TraitsTestCase.class.st
@@ -2,8 +2,7 @@ Class {
 	#name : #TraitsTestCase,
 	#superclass : #AbstractEnvironmentTestCase,
 	#instVars : [
-		'createdClassesAndTraits',
-		'oldAnnouncer'
+		'createdClassesAndTraits'
 	],
 	#category : #'TraitsV2-Tests'
 }
@@ -126,14 +125,6 @@ TraitsTestCase >> resourceClassesAndTraits [
 	^TraitsResource current createdClassesAndTraits
 ]
 
-{ #category : #running }
-TraitsTestCase >> setUp [
-
-	super setUp.
-	oldAnnouncer := SystemAnnouncer uniqueInstance.
-	SystemAnnouncer announcer: nil
-]
-
 { #category : #accessing }
 TraitsTestCase >> t1 [
 	^TraitsResource current t1
@@ -191,12 +182,12 @@ TraitsTestCase >> t9 [
 
 { #category : #running }
 TraitsTestCase >> tearDown [
+
 	TraitsResource reset.
-	self createdClassesAndTraits
-		do: [ :aClassOrTrait || behaviorName |
-			behaviorName := aClassOrTrait name.
-			testingEnvironment at: behaviorName ifPresent: [ :classOrTrait | classOrTrait removeFromSystem: false ]].
+	self createdClassesAndTraits do: [ :aClassOrTrait |
+		| behaviorName |
+		behaviorName := aClassOrTrait name.
+		testingEnvironment at: behaviorName ifPresent: [ :classOrTrait | classOrTrait removeFromSystem: false ] ].
 	createdClassesAndTraits := nil.
-	SystemAnnouncer announcer: oldAnnouncer.
 	super tearDown
 ]


### PR DESCRIPTION
This PR updates the Trait tests to not use the category API but the package API.