### PR TITLE
Monticello: Add package and tag in class definition and start to migrate to it

### DIFF
--- a/src/Gofer-Tests/GoferResource.class.st
+++ b/src/Gofer-Tests/GoferResource.class.st
@@ -45,11 +45,9 @@ GoferResource >> setUpMonticelloRepository [
 						  author: reference author
 						  ancestors: #(  ))
 				 snapshot: (MCSnapshot fromDefinitions:
-						  (Array
-							   with: (MCOrganizationDefinition packageName: reference packageName)
-							   with: ((MCClassDefinition named: (reference packageName copyWithout: $-) asSymbol)
-									    category: reference packageName asSymbol;
-									    yourself)))
+						  (Array with: (MCOrganizationDefinition packageName: reference packageName) with: ((MCClassDefinition named: (reference packageName copyWithout: $-))
+								    packageName: reference packageName;
+								    yourself)))
 				 dependencies: #(  )) ]
 ]
 

--- a/src/Monticello-Tests/MCClassDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCClassDefinitionTest.class.st
@@ -105,7 +105,7 @@ MCClassDefinitionTest >> testEqualsSensitivity [
 	| defA defB |
 	defA := (MCClassDefinition named: 'ClassA')
 		        superclassName: 'SuperA';
-		        category: 'CategoryA';
+		        packageName: 'PackageA';
 		        instVarNames: #( iVarA );
 		        classVarNames: #( cVarB );
 		        poolDictionaryNames: #( PoolA );
@@ -117,6 +117,8 @@ MCClassDefinitionTest >> testEqualsSensitivity [
 	defB := defA copy name: 'ClassB'.
 	self deny: defA equals: defB.
 	defB := defA copy superclassName: 'SuperB'.
+	self deny: defA equals: defB.
+	defB := defA copy packageName: 'PackageB'.
 	self deny: defA equals: defB.
 	defB := defA copy traitComposition: 'T'.
 	self deny: defA equals: defB.
@@ -175,7 +177,7 @@ MCClassDefinitionTest >> testValidTraitComposition [
 	className := 'MCMockClassC'.
 	d := (MCClassDefinition named: className)
 		     traitComposition: '{MCTraitMock1}';
-		     category: self mockCategoryName;
+		     packageName: self mockCategoryName;
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
@@ -194,7 +196,7 @@ MCClassDefinitionTest >> testValidTraitComposition2 [
 	className := 'MCMockClassC'.
 	d := (MCClassDefinition named: className)
 		     traitComposition: 'MCTraitMock1';
-		     category: self mockCategoryName;
+		     packageName: self mockCategoryName;
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
@@ -213,7 +215,7 @@ MCClassDefinitionTest >> testValidTraitComposition3 [
 	className := 'MCMockClassC'.
 	d := (MCClassDefinition named: className)
 		     traitComposition: 'MCTraitMock1 + MCTraitMock2';
-		     category: self mockCategoryName;
+		     packageName: self mockCategoryName;
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
@@ -234,7 +236,7 @@ MCClassDefinitionTest >> testValidTraitComposition4 [
 	className := 'MCMockClassC'.
 	d := (MCClassDefinition named: className)
 		     traitComposition: 'MCTraitMock1 - {#c1}';
-		     category: self mockCategoryName;
+		     packageName: self mockCategoryName;
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.

--- a/src/Monticello-Tests/MCTestCase.class.st
+++ b/src/Monticello-Tests/MCTestCase.class.st
@@ -76,7 +76,7 @@ MCTestCase >> mockClass: className super: superclassName [
 
 	^ (MCClassDefinition named: className)
 		  superclassName: superclassName;
-		  category: self mockCategoryName;
+		  packageName: self mockCategoryName;
 		  comment: (self commentForClass: className);
 		  commentStamp: (self commentStampForClass: className);
 		  yourself

--- a/src/Monticello/Class.extension.st
+++ b/src/Monticello/Class.extension.st
@@ -16,12 +16,17 @@ Class >> asClassDefinition [
 		              superclassName: (self superclass ifNotNil: [ self superclass name ]);
 		              traitComposition: self traitCompositionString;
 		              classTraitComposition: self class traitCompositionString;
-		              category: self category;
+		              packageName: self package name;
 		              poolDictionaryNames: self sharedPoolNames;
 		              type: self mcType;
 		              comment: self comment;
 		              commentStamp: self commentStamp;
 		              yourself.
+
+	"We do not export the tag if this is the root."
+	self packageTag ifNotNil: [ :tag | tag isRoot ifFalse: [ definition tagName: tag name ] ].
+
+
 	self needsSlotClassDefinition
 		ifTrue: [
 			definition

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -12,10 +12,10 @@ Class {
 		'type',
 		'comment',
 		'commentStamp',
-		'traitComposition',
-		'classTraitComposition',
 		'packageName',
-		'tagName'
+		'tagName',
+		'traitComposition',
+		'classTraitComposition'
 	],
 	#category : #'Monticello-Modeling'
 }

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -378,9 +378,9 @@ MCClassDefinition >> packageName [
 ]
 
 { #category : #accessing }
-MCClassDefinition >> packageName: anObject [
+MCClassDefinition >> packageName: aString [
 
-	packageName := anObject
+	packageName := aString ifNotNil: [ :package | package asSymbol ]
 ]
 
 { #category : #accessing }
@@ -585,9 +585,9 @@ MCClassDefinition >> tagName [
 ]
 
 { #category : #accessing }
-MCClassDefinition >> tagName: anObject [
+MCClassDefinition >> tagName: aString [
 
-	tagName := anObject
+	tagName := aString ifNotNil: [ :tag | tag asSymbol ]
 ]
 
 { #category : #accessing }

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -13,7 +13,9 @@ Class {
 		'comment',
 		'commentStamp',
 		'traitComposition',
-		'classTraitComposition'
+		'classTraitComposition',
+		'packageName',
+		'tagName'
 	],
 	#category : #'Monticello-Modeling'
 }
@@ -51,7 +53,7 @@ MCClassDefinition >> = aDefinition [
 		and: [ superclassName = aDefinition superclassName
 		and: [ self traitCompositionString = aDefinition traitCompositionString
 		and: [ self classTraitCompositionString = aDefinition classTraitCompositionString
-		and: [ category = aDefinition category
+		and: [ self category = aDefinition category
 		and: [ type = aDefinition type and: [ self sortedVariables = aDefinition sortedVariables and: [ comment = aDefinition comment ] ] ] ] ] ] ]
 ]
 
@@ -75,7 +77,12 @@ MCClassDefinition >> addVariables: aCollection ofType: aClass [
 
 { #category : #accessing }
 MCClassDefinition >> category [
-	^ category
+
+	^ category ifNil: [
+		  self packageName ifNotNil: [ :package |
+			  (self tagName isNil or: [ self tagName = package ])
+				  ifTrue: [ package ]
+				  ifFalse: [ package , '-' , self tagName ] ] ]
 ]
 
 { #category : #accessing }
@@ -213,7 +220,7 @@ MCClassDefinition >> createClass [
 				traitComposition: self traitCompositionCompiled;
 				classTraitComposition: self classTraitCompositionCompiled;
 				comment: comment stamp: self commentStamp;
-				category: category;
+				category: self category;
 				environment: superClass environment ] ]
 		on: Warning , DuplicatedVariableError
 		do: [ :ex | ex resume ]
@@ -277,25 +284,15 @@ MCClassDefinition >> hasTraitComposition [
 
 { #category : #comparing }
 MCClassDefinition >> hash [
-	| hash |
-	hash := String stringHash: name initialHash: 0.
-	hash := String stringHash: superclassName initialHash: hash.
-	hash := String stringHash: self traitCompositionString initialHash: hash.
-	hash := String stringHash: self classTraitComposition asString initialHash: hash.
-	hash := String stringHash: (category ifNil: ['']) initialHash: hash.
-	hash := String stringHash: type initialHash: hash.
-	variables do: [
-		:v |
-		hash := String stringHash: v name initialHash: hash.
-	].
-	^ hash
+
+	^ (((((name hash bitXor: superclassName hash) bitXor: traitComposition hash) bitXor: classTraitComposition hash) bitXor: self category hash) bitXor: type hash)
+		  bitXor: variables hash
 ]
 
 { #category : #initialization }
 MCClassDefinition >> initialize [
 
 	super initialize.
-	category := ''.
 	superclassName := #Object.
 	traitComposition := '{}'.
 	classTraitComposition := '{}'.
@@ -372,6 +369,18 @@ MCClassDefinition >> needsSlotClassDefinition [
 	Complex vars are encoded with a string that starts with a # or one that has a space"
 	
 	^self variables anySatisfy: [:var | (var name beginsWith:'#') or: [ var name includes: Character space ]]
+]
+
+{ #category : #accessing }
+MCClassDefinition >> packageName [
+
+	^ packageName
+]
+
+{ #category : #accessing }
+MCClassDefinition >> packageName: anObject [
+
+	packageName := anObject
 ]
 
 { #category : #accessing }
@@ -567,6 +576,18 @@ MCClassDefinition >> superclassName: superclassString [
 	superclassName := superclassString
 		                  ifNil: [ #nil ]
 		                  ifNotNil: [ superclassString asSymbol ]
+]
+
+{ #category : #accessing }
+MCClassDefinition >> tagName [
+
+	^ tagName
+]
+
+{ #category : #accessing }
+MCClassDefinition >> tagName: anObject [
+
+	tagName := anObject
 ]
 
 { #category : #accessing }

--- a/src/Monticello/MCDataStream.class.st
+++ b/src/Monticello/MCDataStream.class.st
@@ -411,10 +411,10 @@ MCDataStream >> nextPut: anObject [
 
 { #category : #'write and read' }
 MCDataStream >> nextPutAll: aCollection [
-    "Write each of the objects in aCollection to the
+	"Write each of the objects in aCollection to the
      receiver stream. Answer aCollection."
 
-    ^ aCollection do: [:each | self nextPut: each]
+	^ aCollection do: [ :each | self nextPut: each ]
 ]
 
 { #category : #'write and read' }

--- a/src/Monticello/MCMczWriter.class.st
+++ b/src/Monticello/MCMczWriter.class.st
@@ -110,7 +110,8 @@ MCMczWriter >> writePackage: aPackage [
 
 { #category : #visiting }
 MCMczWriter >> writeSnapshot: aSnapshot [
-	self addString: (self serializeDefinitions: aSnapshot definitions) at: 'snapshot/source.', self snapshotWriterClass extension encodedTo: 'utf8'.
+
+	self addString: (self serializeDefinitions: aSnapshot definitions) at: 'snapshot/source.' , self snapshotWriterClass extension encodedTo: 'utf8'.
 	self addString: (self serializeInBinary: aSnapshot) at: 'snapshot.bin'
 ]
 

--- a/src/Monticello/MCStReader.class.st
+++ b/src/Monticello/MCStReader.class.st
@@ -50,14 +50,14 @@ MCStReader >> classDefinitionFrom: aRingClass [
 	classTraitCompositionString := (aRingClass classSide definitionSource asString readStream
 		                                match: 'uses:';
 		                                upToAll: 'instanceVariableNames:') trimBoth.
-	traitCompositionString isEmpty ifTrue: [ traitCompositionString := '{}' ].
-	classTraitCompositionString isEmpty ifTrue: [ classTraitCompositionString := '{}' ].
+	traitCompositionString ifEmpty: [ traitCompositionString := '{}' ].
+	classTraitCompositionString ifEmpty: [ classTraitCompositionString := '{}' ].
 	lastIndex := tokens size.
 	^ (MCClassDefinition named: (tokens at: 3))
 		  superclassName: (tokens at: 1);
 		  traitComposition: traitCompositionString;
 		  classTraitComposition: classTraitCompositionString;
-		  category: (tokens at: lastIndex);
+		  packageName: (tokens at: lastIndex);
 		  instVarNames: ((tokens at: lastIndex - 6) findTokens: ' ');
 		  classVarNames: ((tokens at: lastIndex - 4) findTokens: ' ');
 		  poolDictionaryNames: ((tokens at: lastIndex - 2) findTokens: ' ');

--- a/src/Monticello/MCTraitDefinition.class.st
+++ b/src/Monticello/MCTraitDefinition.class.st
@@ -24,16 +24,16 @@ MCTraitDefinition class >> name: classNameString traitComposition: traitComposit
 
 { #category : #comparing }
 MCTraitDefinition >> = aDefinition [
+
 	self flag: #traits. "Ugly we harcoded the super superclass method.  We will have to refactor the definition hierarchy"
-	
-	^ (aDefinition isKindOf: MCDefinition)
-		and: [(self isRevisionOf: aDefinition)
-		and: [self traitCompositionString = aDefinition traitCompositionString
-		and: [self classTraitCompositionString = aDefinition classTraitCompositionString
-		and: [category = aDefinition category
-		and: [self slotDefinitionString = aDefinition slotDefinitionString
-		and: [self classInstVarNames  = aDefinition classInstVarNames  
-		and: [comment = aDefinition comment]]]]]]]
+
+	^ (aDefinition isKindOf: MCDefinition) and: [
+		  (self isRevisionOf: aDefinition) and: [
+			  self traitCompositionString = aDefinition traitCompositionString and: [
+				  self classTraitCompositionString = aDefinition classTraitCompositionString and: [
+					  self category = aDefinition category and: [
+						  self slotDefinitionString = aDefinition slotDefinitionString and: [
+							  self classInstVarNames = aDefinition classInstVarNames and: [ comment = aDefinition comment ] ] ] ] ] ] ]
 ]
 
 { #category : #visiting }
@@ -58,22 +58,21 @@ MCTraitDefinition >> classSlotDefinitionString [
 
 { #category : #installing }
 MCTraitDefinition >> createClass [
+
 	| trait |
-	
 	trait := self class classInstaller make: [ :aBuilder |
-		aBuilder 
-			name: name;
-			traitComposition: (Smalltalk compiler evaluate: self traitCompositionString);
-			slots: self instanceVariables;
-			package:  category;
-			beTrait ].					
+		         aBuilder
+			         name: name;
+			         traitComposition: (Smalltalk compiler evaluate: self traitCompositionString);
+			         slots: self instanceVariables;
+			         package: self category;
+			         beTrait ].
 
 
 	trait ifNotNil: [
 		trait comment: comment stamp: commentStamp.
-		self classInstanceVariables ifNotEmpty: [
-			trait classSide slots: self classInstanceVariables ]].
-	^trait
+		self classInstanceVariables ifNotEmpty: [ trait classSide slots: self classInstanceVariables ] ].
+	^ trait
 ]
 
 { #category : #testing }
@@ -85,12 +84,8 @@ MCTraitDefinition >> hasClassInstanceVariables [
 
 { #category : #comparing }
 MCTraitDefinition >> hash [
-	| hash |
-	hash := String stringHash: name initialHash: 0.
-	hash := String stringHash: self traitCompositionString initialHash: hash.
-	hash := String stringHash: (category ifNil: ['']) initialHash: hash.
-	^ hash
 
+	^ (name hash bitXor: traitComposition hash) bitXor: self category hash
 ]
 
 { #category : #printing }

--- a/src/Monticello/MCTraitDefinition.class.st
+++ b/src/Monticello/MCTraitDefinition.class.st
@@ -71,7 +71,7 @@ MCTraitDefinition >> createClass [
 
 	trait ifNotNil: [
 		trait comment: comment stamp: commentStamp.
-		self classInstanceVariables ifNotEmpty: [ trait classSide slots: self classInstanceVariables ] ].
+		self classInstanceVariables ifNotEmpty: [ :vars | trait classSide slots: vars ] ].
 	^ trait
 ]
 

--- a/src/Monticello/MCTraitParser.class.st
+++ b/src/Monticello/MCTraitParser.class.st
@@ -55,7 +55,7 @@ MCTraitParser >> addDefinitionsTo: aCollection [
 
 	definition := (MCTraitDefinition named: traitName)
 		              traitComposition: traitCompositionString;
-		              category: categoryString;
+		              packageName: categoryString;
 		              instVarNames: slotsArray;
 		              yourself.
 

--- a/src/Monticello/MCVersionReader.class.st
+++ b/src/Monticello/MCVersionReader.class.st
@@ -62,11 +62,12 @@ MCVersionReader class >> versionInfoFromStream: aStream [
 
 { #category : #accessing }
 MCVersionReader >> basicVersion [
+
 	^ MCVersion
-		package: self package
-		info: self info
-		snapshot: [ self snapshot ]
-		dependencies: self dependencies
+		  package: self package
+		  info: self info
+		  snapshot: [ self snapshot ]
+		  dependencies: self dependencies
 ]
 
 { #category : #accessing }

--- a/src/Monticello/Trait.extension.st
+++ b/src/Monticello/Trait.extension.st
@@ -12,10 +12,13 @@ Trait >> asClassDefinition [
 	| definition |
 	definition := (MCTraitDefinition named: self name)
 		              traitComposition: self traitCompositionString;
-		              category: self category;
+		              packageName: self package name;
 		              classTraitComposition: self class traitCompositionString;
 		              comment: self comment;
 		              commentStamp: self commentStamp.
+
+	"We do not export the tag if this is the root."
+	self packageTag ifNotNil: [ :tag | tag isRoot ifFalse: [ definition tagName: tag name ] ].
 
 	self needsSlotClassDefinition
 		ifTrue: [

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
@@ -65,18 +65,21 @@ MCFileTreeStCypressReader >> addClassAndMethodDefinitionsFromEntry: classEntry [
 { #category : #utilities }
 MCFileTreeStCypressReader >> addClassDefinitionFrom: classPropertiesDict comment: classComment [
 
-	| categoryName className definition |
-	className := classPropertiesDict at: 'name'.
-	categoryName := classPropertiesDict at: 'category' ifAbsent: [ self packageNameFromPackageDirectory ].
-	self validateClassCategory: categoryName for: className.
-
-	definition := (MCClassDefinition named: className)
+	| definition |
+	definition := (MCClassDefinition named: (classPropertiesDict at: 'name'))
 		              superclassName: (classPropertiesDict at: 'super');
-		              category: categoryName;
+		              packageName: self packageNameFromPackageDirectory;
 		              comment: classComment;
 		              yourself.
 
 	classPropertiesDict
+		at: 'category' ifPresent: [ :category |
+			| packageName |
+			packageName := definition packageName.
+			(self verifyCategory: category matches: packageName) ifFalse: [
+					self error: 'Class category name ' , category , ' for the class ' , definition name , ' is inconsistent with the package name ' , packageName ].
+			"If the category is the package name then it means that there is not tag"
+			category = packageName ifFalse: [ definition tagName: (category withoutPrefix: packageName , '-') ] ];
 		at: 'traitcomposition' ifPresent: [ :composition | definition traitComposition: composition ];
 		at: 'classtraitcomposition' ifPresent: [ :composition | definition classTraitComposition: composition ];
 		at: 'instvars' ifPresent: [ :instVars | definition instVarNames: instVars ];
@@ -284,23 +287,6 @@ MCFileTreeStCypressReader >> packageNameFromPackageDirectory [
     | filename2 |
     filename2 := self fileUtils directoryName: packageDirectory.
     ^ filename2 copyFrom: 1 to: (filename2 lastIndexOf: $.) - 1
-]
-
-{ #category : #validation }
-MCFileTreeStCypressReader >> validateClassCategory: categoryName for: className [
-  "https://github.com/dalehenrich/filetree/issues/136"
-
-  "class category must match the package name ... guard against manual editing mistakes"
-
-  | prefix |
-  prefix := self packageNameFromPackageDirectory.
-  (self verifyCategory: categoryName matches: prefix)
-    ifTrue: [ ^ self ].
-  self
-    error:
-      'Class category name ' , categoryName printString , ' for the class '
-        , className printString , ' is inconsistent with the package name '
-        , prefix printString
 ]
 
 { #category : #validation }

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
@@ -293,7 +293,7 @@ MCFileTreeStCypressReader >> setPackageTagIn: definition fromCategory: category 
 		self error: 'Class category name ' , category , ' for the class ' , definition name , ' is inconsistent with the package name ' , packageName ].
 
 	"If the category is the package name then it means that there is not tag"
-	^ category = packageName ifFalse: [ definition tagName: (category withoutPrefix: packageName , '-') ]
+	category = packageName ifFalse: [ definition tagName: (category withoutPrefix: packageName , '-') ]
 ]
 
 { #category : #validation }

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
@@ -73,13 +73,7 @@ MCFileTreeStCypressReader >> addClassDefinitionFrom: classPropertiesDict comment
 		              yourself.
 
 	classPropertiesDict
-		at: 'category' ifPresent: [ :category |
-			| packageName |
-			packageName := definition packageName.
-			(self verifyCategory: category matches: packageName) ifFalse: [
-					self error: 'Class category name ' , category , ' for the class ' , definition name , ' is inconsistent with the package name ' , packageName ].
-			"If the category is the package name then it means that there is not tag"
-			category = packageName ifFalse: [ definition tagName: (category withoutPrefix: packageName , '-') ] ];
+		at: 'category' ifPresent: [ :category | self setPackageTagIn: definition fromCategory: category ];
 		at: 'traitcomposition' ifPresent: [ :composition | definition traitComposition: composition ];
 		at: 'classtraitcomposition' ifPresent: [ :composition | definition classTraitComposition: composition ];
 		at: 'instvars' ifPresent: [ :instVars | definition instVarNames: instVars ];
@@ -192,11 +186,12 @@ MCFileTreeStCypressReader >> addTraitDefinitionFrom: traitPropertiesDict comment
 
 	| definition |
 	definition := (MCTraitDefinition named: (traitPropertiesDict at: 'name'))
-		              category: (traitPropertiesDict at: 'category' ifAbsent: [ self packageNameFromPackageDirectory ]);
+		              packageName: self packageNameFromPackageDirectory;
 		              comment: traitComment;
 		              yourself.
 
 	traitPropertiesDict
+		at: 'category' ifPresent: [ :category | self setPackageTagIn: definition fromCategory: category ];
 		at: 'traitcomposition' ifPresent: [ :composition | definition traitComposition: composition ];
 		at: 'instvars' ifPresent: [ :ivars | definition instVarNames: ivars ];
 		at: 'commentStamp' ifPresent: [ :stamp | definition commentStamp: stamp ].
@@ -287,6 +282,18 @@ MCFileTreeStCypressReader >> packageNameFromPackageDirectory [
     | filename2 |
     filename2 := self fileUtils directoryName: packageDirectory.
     ^ filename2 copyFrom: 1 to: (filename2 lastIndexOf: $.) - 1
+]
+
+{ #category : #utilities }
+MCFileTreeStCypressReader >> setPackageTagIn: definition fromCategory: category [
+
+	| packageName |
+	packageName := definition packageName.
+	(self verifyCategory: category matches: packageName) ifFalse: [
+		self error: 'Class category name ' , category , ' for the class ' , definition name , ' is inconsistent with the package name ' , packageName ].
+
+	"If the category is the package name then it means that there is not tag"
+	^ category = packageName ifFalse: [ definition tagName: (category withoutPrefix: packageName , '-') ]
 ]
 
 { #category : #validation }

--- a/src/Ring-Monticello/RGClassStrategy.extension.st
+++ b/src/Ring-Monticello/RGClassStrategy.extension.st
@@ -2,12 +2,13 @@ Extension { #name : #RGClassStrategy }
 
 { #category : #'*Ring-Monticello' }
 RGClassStrategy >> asMCDefinition [
+	"Here we should remove the use of the category and also add the package tag to the class definition"
 
 	^ (MCClassDefinition named: self owner name)
 		  superclassName: (self owner superclass ifNotNil: [ :aSuperclass | aSuperclass name ]);
 		  traitComposition: self owner traitCompositionString;
 		  classTraitComposition: self owner metaclass traitCompositionString;
-		  category: self owner category;
+		  packageName: self owner category;
 		  instVarNames: self instVarNames;
 		  classVarNames: self owner classVarNames;
 		  poolDictionaryNames: self owner sharedPoolNames;

--- a/src/Ring-Monticello/RGTraitV2Strategy.extension.st
+++ b/src/Ring-Monticello/RGTraitV2Strategy.extension.st
@@ -7,7 +7,7 @@ RGTraitV2Strategy >> asMCDefinition [
 		  superclassName: (self superclass ifNotNil: [ :aSuperclass | aSuperclass name ]);
 		  traitComposition: self owner traitCompositionString;
 		  classTraitComposition: self owner metaclass traitCompositionString;
-		  category: self category;
+		  packageName: self category;
 		  instVarNames: self instVarNames;
 		  classVarNames: self classVarNames;
 		  poolDictionaryNames: self sharedPoolNames;


### PR DESCRIPTION
Add Package and tag info in MCClassDefinition to push out the concept of categories. 

I might migrate more places later. I'd just like to see if the CI is happy with this for now because I found some wild bugs already in the image while doing that.

Here is a funny one: To stay compatible with other smalltalk when possible, if a class has no trait composition, the trait composition and class trait composition are not exported in MCZ format. But the way it is done is by exporting all instance variables except the last 2. Yes, the last 2. So if you add a instance variable or just change the order... You're f***ed :)

Next step is to update the FillTree reader in order to determine the package and the tag from the category depending on the name of the parent forlder (the format seems to always know the parent folder of the file so we can do it like this)