### PR TITLE
Make finalization registry entry removal O(1) -- backport P11

### DIFF
--- a/src/Announcements-Core-Tests/WeakAnnouncerTest.class.st
+++ b/src/Announcements-Core-Tests/WeakAnnouncerTest.class.st
@@ -29,32 +29,11 @@ WeakAnnouncerTest >> benchManyWeakGuys [
 	^ time
 ]
 
-{ #category : #benchmarks }
-WeakAnnouncerTest >> benchWeakSubscriptionDynamic [
-	"Run me to see how expensive #becomeForward: is (compared to #benchWeakSubscriptionStatic )"
 
-	| object ann |
+{ #category : #utilities }
+WeakAnnouncerTest >> longTestCase [
 
-	object := Object new.
-	ann := Announcer new.
-
-	^[
-		1000 timesRepeat: [ (ann when: Announcement send: #value to: object) makeWeak ].
-	] timeToRun
-]
-
-{ #category : #benchmarks }
-WeakAnnouncerTest >> benchWeakSubscriptionStatic [
-	"Run me to see how cheap object creation is (compared to #benchWeakSubscriptionDynamic ) "
-
-	| object ann |
-
-	object := Object new.
-	ann := Announcer new.
-
-	^[
-		1000 timesRepeat: [ (ann weak when: Announcement send: #value to: object)  ].
-	] timeToRun
+	self timeLimit: 60 seconds
 ]
 
 { #category : #tests }
@@ -164,11 +143,4 @@ WeakAnnouncerTest >> testWeakSubscription [
 	subscription := (announcer when: AnnouncementMockA send: #value to: obj) makeWeak.
 
 	self assert: obj identicalTo: subscription subscriber
-]
-
-{ #category : #tests }
-WeakAnnouncerTest >> testWeakSubscriptionRelease [
-	"This test shows the a problem with weak registrations not garbage collected in Spur.
-	 See https://pharo.manuscript.com/f/cases/17537 for more details."
-	self benchManyWeakGuys
 ]

--- a/src/System-Finalization-Tests/FinalizationRegistryEntryTest.class.st
+++ b/src/System-Finalization-Tests/FinalizationRegistryEntryTest.class.st
@@ -1,0 +1,86 @@
+Class {
+	#name : #FinalizationRegistryEntryTest,
+	#superclass : #TestCase,
+	#category : #'System-Finalization-Tests'
+}
+
+{ #category : #tests }
+FinalizationRegistryEntryTest >> testAdd [
+
+	| entry1 entry2 |
+	entry1 := FinalizationRegistryEntry new.
+	entry2 := FinalizationRegistryEntry new.
+	
+	entry1 chainNext: entry2.
+	
+	self assert: entry1 next equals: entry2.
+	self assert: entry2 previous equals: entry1
+]
+
+{ #category : #tests }
+FinalizationRegistryEntryTest >> testAddFirstTwice [
+
+	| entry1 entry2 entry3 |
+	entry1 := FinalizationRegistryEntry new.
+	entry2 := FinalizationRegistryEntry new.
+	entry3 := FinalizationRegistryEntry new.
+	
+	entry1 chainNext: entry2.
+	entry1 chainNext: entry3.
+	
+	self assert: entry1 next equals: entry3.
+	self assert: entry3 next equals: entry2.
+	
+	self assert: entry1 previous equals: nil.
+	self assert: entry3 previous equals: entry1.
+	self assert: entry2 previous equals: entry3.
+]
+
+{ #category : #tests }
+FinalizationRegistryEntryTest >> testAddMiddle [
+
+	| head tail middle |
+	head := FinalizationRegistryEntry new.
+	tail := FinalizationRegistryEntry new.
+	head chainNext: tail.
+	
+	middle := FinalizationRegistryEntry new.
+	head chainNext: middle.
+	
+	self assert: head next equals: middle.
+	self assert: middle next equals: tail.
+	
+	self assert: middle previous equals: head.
+	self assert: tail previous equals: middle.
+]
+
+{ #category : #tests }
+FinalizationRegistryEntryTest >> testRemoveFromMiddle [
+
+	| head middle tail |
+	head := FinalizationRegistryEntry new.
+	middle := FinalizationRegistryEntry new.
+	tail := FinalizationRegistryEntry new.
+	
+	head chainNext: middle.
+	middle chainNext: tail.
+	
+	middle removeFromChain.
+	self assert: head next equals: tail.
+	self assert: tail previous equals: head.
+]
+
+{ #category : #tests }
+FinalizationRegistryEntryTest >> testRemoveFromTail [
+
+	| head middle tail |
+	head := FinalizationRegistryEntry new.
+	middle := FinalizationRegistryEntry new.
+	tail := FinalizationRegistryEntry new.
+	
+	head chainNext: middle.
+	middle chainNext: tail.
+
+	tail removeFromChain.
+	self assert: middle next equals: nil
+]

--- a/src/System-Finalization/FinalizationRegistry.class.st
+++ b/src/System-Finalization/FinalizationRegistry.class.st
@@ -121,7 +121,7 @@ FinalizationRegistry >> handleErrorsDuring: aBlock [
 { #category : #testing }
 FinalizationRegistry >> includes: anObject [
 
-    ^ false
+    ^ ephemeronListHead includes: anObject
 ]
 
 { #category : #initialization }
@@ -138,7 +138,7 @@ FinalizationRegistry >> initialize [
 
 { #category : #testing }
 FinalizationRegistry >> isEmpty [
-	
+		
 	^ ephemeronListHead next isNil
 ]
 
@@ -183,5 +183,5 @@ FinalizationRegistry >> removeEphemeron: anEphemeron [
 { #category : #accessing }
 FinalizationRegistry >> size [
 
-	^ 0
+	^ ephemeronListHead size - 1 "The head does not count"
 ]

--- a/src/System-Finalization/FinalizationRegistry.class.st
+++ b/src/System-Finalization/FinalizationRegistry.class.st
@@ -89,6 +89,19 @@ FinalizationRegistry >> add: anObject finalizer: finalizer [
 	^ anObject
 ]
 
+{ #category : #adding }
+FinalizationRegistry >> ephemeronAtKey: aKey [
+	| current |
+	current := ephemeronListHead.
+	[ current notNil ] whileTrue: [
+		current key == aKey
+			ifTrue: [ ^ current ].
+		current := current next
+	].
+	"Not found"
+	^ nil
+]
+
 { #category : #finalization }
 FinalizationRegistry >> errorHandler [
 	
@@ -141,17 +154,10 @@ FinalizationRegistry >> isEmpty [
 	^ ephemeronListHead next isNil
 ]
 
-{ #category : #adding }
-FinalizationRegistry >> ephemeronAtKey: aKey [
-	| current |
-	current := ephemeronListHead.
-	[ current notNil ] whileTrue: [
-		current key == aKey
-			ifTrue: [ ^ current ].
-		current := current next
-	].
-	"Not found"
-	^ nil
+{ #category : #accessing }
+FinalizationRegistry >> keys [
+
+	^ ephemeronListHead keys
 ]
 
 { #category : #copying }
@@ -191,4 +197,16 @@ FinalizationRegistry >> removeEphemeron: anEphemeron [
 FinalizationRegistry >> size [
 
 	^ ephemeronListHead size - 1 "The head does not count"
+]
+
+{ #category : #accessing }
+FinalizationRegistry >> values [
+
+	^ ephemeronListHead values
+]
+
+{ #category : #enumerating }
+FinalizationRegistry >> valuesDo: aBlock [
+
+	^ self values do: aBlock
 ]

--- a/src/System-Finalization/FinalizationRegistry.class.st
+++ b/src/System-Finalization/FinalizationRegistry.class.st
@@ -47,9 +47,9 @@ Class {
 	#name : #FinalizationRegistry,
 	#superclass : #Object,
 	#instVars : [
-		'ephemeronCollection',
 		'semaphore',
-		'errorHandler'
+		'errorHandler',
+		'ephemeronListHead'
 	],
 	#classVars : [
 		'Default'
@@ -82,9 +82,11 @@ FinalizationRegistry >> add: anObject executor: finalizer [
 { #category : #adding }
 FinalizationRegistry >> add: anObject finalizer: finalizer [
 
-	self protected: [ 
-		ephemeronCollection add:
-			(FinalizationRegistryEntry key: anObject value: finalizer container: self) ].
+	self protected: [ | newEntry |
+		newEntry := FinalizationRegistryEntry key: anObject value: finalizer container: self.
+		ephemeronListHead ifNotNil: [
+			ephemeronListHead chainNext: newEntry].
+	].
 	^ anObject
 ]
 
@@ -119,14 +121,17 @@ FinalizationRegistry >> handleErrorsDuring: aBlock [
 { #category : #testing }
 FinalizationRegistry >> includes: anObject [
 
-    ^ ephemeronCollection anySatisfy: [ :entry | entry key == anObject ]
+    ^ false
 ]
 
 { #category : #initialization }
 FinalizationRegistry >> initialize [
 
 	super initialize.
-	ephemeronCollection := IdentitySet new.
+
+	"We have a head with an empty entry, this is to keep the linked list only"
+	ephemeronListHead := FinalizationRegistryEntry new.
+
 	semaphore := Semaphore forMutualExclusion.
 	errorHandler := self.
 ]
@@ -134,13 +139,13 @@ FinalizationRegistry >> initialize [
 { #category : #testing }
 FinalizationRegistry >> isEmpty [
 	
-	^ ephemeronCollection isEmpty
+	^ ephemeronListHead next isNil
 ]
 
 { #category : #adding }
 FinalizationRegistry >> keys [
 
-	^ ephemeronCollection collect: [ :e | e key ]
+	^ #()
 ]
 
 { #category : #copying }
@@ -148,7 +153,7 @@ FinalizationRegistry >> postCopy [
 	"should we prohibit any attempts to copy receiver?"
 	self protected: [
 		semaphore := Semaphore forMutualExclusion.
-		ephemeronCollection := ephemeronCollection copy
+		ephemeronListHead := ephemeronListHead copy
 	]
 ]
 
@@ -164,17 +169,19 @@ FinalizationRegistry >> protected: aBlock [
 { #category : #adding }
 FinalizationRegistry >> remove: anEphemeron ifAbsent: aBlock [
 
-	^ self protected: [ ephemeronCollection remove: anEphemeron ifAbsent: aBlock ]
+	(anEphemeron isKindOf: FinalizationRegistryEntry) ifFalse: [ ^ aBlock value ].
+	^ self removeEphemeron: anEphemeron
 ]
 
 { #category : #adding }
 FinalizationRegistry >> removeEphemeron: anEphemeron [
 
-	self protected: [ ephemeronCollection remove: anEphemeron ]
+	self protected: [ 
+		anEphemeron removeFromChain ]
 ]
 
 { #category : #accessing }
 FinalizationRegistry >> size [
 
-	^ ephemeronCollection size
+	^ 0
 ]

--- a/src/System-Finalization/FinalizationRegistry.class.st
+++ b/src/System-Finalization/FinalizationRegistry.class.st
@@ -84,8 +84,7 @@ FinalizationRegistry >> add: anObject finalizer: finalizer [
 
 	self protected: [ | newEntry |
 		newEntry := FinalizationRegistryEntry key: anObject value: finalizer container: self.
-		ephemeronListHead ifNotNil: [
-			ephemeronListHead chainNext: newEntry].
+		ephemeronListHead chainNext: newEntry.
 	].
 	^ anObject
 ]
@@ -115,7 +114,7 @@ FinalizationRegistry >> finalizeEphemeron: anEphemeron [
 { #category : #'private - synchronization' }
 FinalizationRegistry >> handleErrorsDuring: aBlock [
 
-	aBlock	 on: Error fork: [ :e | e pass ]
+	aBlock on: Error fork: [ :e | e pass ]
 ]
 
 { #category : #testing }
@@ -143,14 +142,21 @@ FinalizationRegistry >> isEmpty [
 ]
 
 { #category : #adding }
-FinalizationRegistry >> keys [
-
-	^ #()
+FinalizationRegistry >> ephemeronAtKey: aKey [
+	| current |
+	current := ephemeronListHead.
+	[ current notNil ] whileTrue: [
+		current key == aKey
+			ifTrue: [ ^ current ].
+		current := current next
+	].
+	"Not found"
+	^ nil
 ]
 
 { #category : #copying }
 FinalizationRegistry >> postCopy [
-	"should we prohibit any attempts to copy receiver?"
+	"should we prohibit any attempts to copy the receiver?"
 	self protected: [
 		semaphore := Semaphore forMutualExclusion.
 		ephemeronListHead := ephemeronListHead copy
@@ -167,10 +173,11 @@ FinalizationRegistry >> protected: aBlock [
 ]
 
 { #category : #adding }
-FinalizationRegistry >> remove: anEphemeron ifAbsent: aBlock [
-
-	(anEphemeron isKindOf: FinalizationRegistryEntry) ifFalse: [ ^ aBlock value ].
-	^ self removeEphemeron: anEphemeron
+FinalizationRegistry >> remove: aKey ifAbsent: aBlock [
+	| ephemeron |
+	ephemeron := self ephemeronAtKey: aKey.
+	ephemeron ifNil: [ ^ aBlock value ].
+	^ self removeEphemeron: ephemeron
 ]
 
 { #category : #adding }

--- a/src/System-Finalization/FinalizationRegistryEntry.class.st
+++ b/src/System-Finalization/FinalizationRegistryEntry.class.st
@@ -56,16 +56,14 @@ FinalizationRegistryEntry class >> key: key value: value container: aContainer [
 { #category : #accessing }
 FinalizationRegistryEntry >> chainNext: aNode [
 	"Insert a node in the middle of myself and my next node.
-	Assume the argument has no next or previous"
-	| currentNext |
-	currentNext := next.
+	Assume the argument is a valid node with has no next or previous."
+	| previousNext |
+	previousNext := next.
 	next := aNode.
-	aNode ifNil: [ ^ self ].
-
-	aNode next: currentNext.
-	currentNext ifNotNil: [
-		currentNext previous: aNode ].
-
+	previousNext ifNotNil: [
+		previousNext previous: aNode ].
+	
+	aNode next: previousNext.
 	aNode previous: self
 ]
 
@@ -93,6 +91,13 @@ FinalizationRegistryEntry >> includes: anObject [
 	key = anObject ifTrue: [ ^ true ].
 	next ifNil: [ ^ false ].
 	^ next includes: anObject
+]
+
+{ #category : #enumerating }
+FinalizationRegistryEntry >> keys [
+
+	next ifNil: [ ^ { key } ].
+	^ { key }, next keys
 ]
 
 { #category : #mourning }
@@ -132,8 +137,14 @@ FinalizationRegistryEntry >> previous: anObject [
 { #category : #accessing }
 FinalizationRegistryEntry >> removeFromChain [
 
+	| previousNext |
 	previous ifNil: [ ^ self ].
-	previous chainNext: next
+
+	previousNext := next.
+	previous next: previousNext.
+
+	previousNext ifNil: [ ^ self ].
+	previousNext previous: previous.
 ]
 
 { #category : #accessing }

--- a/src/System-Finalization/FinalizationRegistryEntry.class.st
+++ b/src/System-Finalization/FinalizationRegistryEntry.class.st
@@ -21,6 +21,10 @@ When an ephemeron's key is hold strongly just by the ephemeron itself, the Ephem
 
 On the image side, the finalization process will send the message #mourn to an Ephemeron.  #mourn will #finalize the Ephemeron's key, and remove the Ephemeron from it's container to allow its collection during a subsequent garbage collection.
 
+# Implementation details
+
+I am implemented as a double linked list, to make removals O(1)
+
 !! More Documentation
 
 You can read the associated paper to understand better the semantics of ephemerons:
@@ -66,6 +70,12 @@ FinalizationRegistryEntry >> chainNext: aNode [
 ]
 
 { #category : #accessing }
+FinalizationRegistryEntry >> check [
+
+	^ self next previous == self and: [ self previous next == self ]
+]
+
+{ #category : #accessing }
 FinalizationRegistryEntry >> container [
 
 	^ container
@@ -75,6 +85,14 @@ FinalizationRegistryEntry >> container [
 FinalizationRegistryEntry >> container: anEphemeronContainer [
 
 	container := anEphemeronContainer
+]
+
+{ #category : #testing }
+FinalizationRegistryEntry >> includes: anObject [
+
+	key = anObject ifTrue: [ ^ true ].
+	next ifNil: [ ^ false ].
+	^ next includes: anObject
 ]
 
 { #category : #mourning }
@@ -116,4 +134,11 @@ FinalizationRegistryEntry >> removeFromChain [
 
 	previous ifNil: [ ^ self ].
 	previous chainNext: next
+]
+
+{ #category : #accessing }
+FinalizationRegistryEntry >> size [
+
+	next ifNil: [ ^ 1 ].
+	^ 1 + next size
 ]

--- a/src/System-Finalization/FinalizationRegistryEntry.class.st
+++ b/src/System-Finalization/FinalizationRegistryEntry.class.st
@@ -96,7 +96,13 @@ FinalizationRegistryEntry >> includes: anObject [
 { #category : #enumerating }
 FinalizationRegistryEntry >> keys [
 
+	"Base case, last entry in the list"
 	next ifNil: [ ^ { key } ].
+
+	"The head is empty, so check that"
+	key ifNil: [ ^ next keys ].
+	
+	"Otherwise, this is the recursive case"
 	^ { key }, next keys
 ]
 
@@ -152,4 +158,17 @@ FinalizationRegistryEntry >> size [
 
 	next ifNil: [ ^ 1 ].
 	^ 1 + next size
+]
+
+{ #category : #enumerating }
+FinalizationRegistryEntry >> values [
+
+	"Base case, last entry in the list"
+	next ifNil: [ ^ { value } ].
+
+	"The head is empty, so check that"
+	key ifNil: [ ^ next values ].
+
+	"Otherwise, this is the recursive case"
+	^ { value }, next values
 ]

--- a/src/System-Finalization/FinalizationRegistryEntry.class.st
+++ b/src/System-Finalization/FinalizationRegistryEntry.class.st
@@ -32,7 +32,9 @@ Class {
 	#superclass : #Association,
 	#type : #ephemeron,
 	#instVars : [
-		'container'
+		'container',
+		'next',
+		'previous'
 	],
 	#category : #'System-Finalization-Registry'
 }
@@ -45,6 +47,28 @@ FinalizationRegistryEntry class >> key: key value: value container: aContainer [
 		value: value;
 		container: aContainer;
 		yourself
+]
+
+{ #category : #accessing }
+FinalizationRegistryEntry >> chainNext: aNode [
+	"Insert a node in the middle of myself and my next node.
+	Assume the argument has no next or previous"
+	| currentNext |
+	currentNext := next.
+	next := aNode.
+	aNode ifNil: [ ^ self ].
+
+	aNode next: currentNext.
+	currentNext ifNotNil: [
+		currentNext previous: aNode ].
+
+	aNode previous: self
+]
+
+{ #category : #accessing }
+FinalizationRegistryEntry >> container [
+
+	^ container
 ]
 
 { #category : #accessing }
@@ -61,4 +85,35 @@ FinalizationRegistryEntry >> mourn [
 	Ask the container to finalize myself"
 
 	container finalizeEphemeron: self
+]
+
+{ #category : #accessing }
+FinalizationRegistryEntry >> next [
+
+	^ next
+]
+
+{ #category : #accessing }
+FinalizationRegistryEntry >> next: anObject [
+
+	next := anObject
+]
+
+{ #category : #accessing }
+FinalizationRegistryEntry >> previous [
+
+	^ previous
+]
+
+{ #category : #accessing }
+FinalizationRegistryEntry >> previous: anObject [
+
+	previous := anObject
+]
+
+{ #category : #accessing }
+FinalizationRegistryEntry >> removeFromChain [
+
+	previous ifNil: [ ^ self ].
+	previous chainNext: next
 ]

--- a/src/Tests/ObjectFinalizerTest.class.st
+++ b/src/Tests/ObjectFinalizerTest.class.st
@@ -25,6 +25,11 @@ ObjectFinalizerTest >> testFinalizationOfMultipleResources [
 	self deny: resource2 first.
 	"Trigger finalization"
 	objToFinalize := nil.
+
+	"Many finalizers on the same object are triggered one at a time.
+	When the GC triggers one finalizer, the reference becomes strong and it cannot trigger the second one.
+	=> Run two GCs to trigger both finalizers."
+	Smalltalk garbageCollect.
 	Smalltalk garbageCollect.
 	self assert: resource1 first.
 	self assert: resource2 first


### PR DESCRIPTION
Turn the finalization registry into a double-linked list.
This turns removal into an O(1) operation while making ephemeron objects a bit bigger (2 inst vars for previous and next).

Backport https://github.com/pharo-project/pharo/pull/14068 for Pharo11