### PR TITLE
Remove category ivar from MCClass(Trait)Definition

### DIFF
--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -299,6 +299,17 @@ MCClassDefinition >> initialize [
 	variables := OrderedCollection new
 ]
 
+{ #category : #introspection }
+MCClassDefinition >> instVarNamed: aString put: aValue [
+
+	self flag: #package. "temporary hack until Tonel is fixed"
+	super
+		instVarNamed: (aString = 'category'
+				 ifTrue: [ 'packageName' ]
+				 ifFalse: [ aString ])
+		put: aValue
+]
+
 { #category : #accessing }
 MCClassDefinition >> instVarNames [
 	^ self selectVariables: #isInstanceVariable

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -196,32 +196,34 @@ MCClassDefinition >> commentStamp: anObject [
 
 { #category : #installing }
 MCClassDefinition >> createClass [
+
 	| superClass |
 	"Ignore Context definition because of troubles with class migration on bootstrapped image. Temporary solution."
-	name = #Context
-		ifTrue: [ Context comment = comment 
-						ifFalse: [ Context comment: comment stamp: self commentStamp ].
-					^ self ].
+	name = #Context ifTrue: [
+		Context comment = comment ifFalse: [ Context comment: comment stamp: self commentStamp ].
+		^ self ].
 
-	superClass := superclassName = #nil
-		ifFalse: [ Smalltalk globals at: superclassName ].
-	^ [ Smalltalk classInstaller
-		make: [ :builder | 
-			builder
-				superclass: superClass;
-				name: name;
-				layoutClass: (ObjectLayout layoutForType: type);
-				slots: self instanceVariables;
-				sharedVariables: self classVariables;
-				sharedPools: self sharedPoolsString;
-				classSlots: self classInstanceVariables;
-				traitComposition: self traitCompositionCompiled;
-				classTraitComposition: self classTraitCompositionCompiled;
-				comment: comment stamp: self commentStamp;
-				category: self category;
-				environment: superClass environment ] ]
-		on: Warning , DuplicatedVariableError
-		do: [ :ex | ex resume ]
+	superClass := superclassName = #nil ifFalse: [ Smalltalk globals at: superclassName ].
+	^ [
+	  Smalltalk classInstaller make: [ :builder |
+		  Stdio stdout
+			  nextPutAll: 'Type of ' , name asString , ' is ' , type asString;
+			  lf.
+		  builder
+			  superclass: superClass;
+			  name: name;
+			  layoutClass: (ObjectLayout layoutForType: type);
+			  slots: self instanceVariables;
+			  sharedVariables: self classVariables;
+			  sharedPools: self sharedPoolsString;
+			  classSlots: self classInstanceVariables;
+			  traitComposition: self traitCompositionCompiled;
+			  classTraitComposition: self classTraitCompositionCompiled;
+			  comment: comment stamp: self commentStamp;
+			  category: self category;
+			  environment: superClass environment ] ]
+		  on: Warning , DuplicatedVariableError
+		  do: [ :ex | ex resume ]
 ]
 
 { #category : #installing }
@@ -619,7 +621,10 @@ MCClassDefinition >> type: aSymbol [
 
 	type := (#( #CompiledMethod #CompiledBlock #CompiledCode ) includes: name)
 		        ifTrue: [ #compiledMethod ]
-		        ifFalse: [ aSymbol ]
+		        ifFalse: [ aSymbol ].
+	Stdio stdout
+		nextPutAll: 'Type of ' , (name ifNil: [ 'nil' ]) asString , ' is ' , type asString;
+		lf
 ]
 
 { #category : #installing }

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -8,10 +8,10 @@ Class {
 		'name',
 		'superclassName',
 		'variables',
+		'packageName',
 		'type',
 		'comment',
 		'commentStamp',
-		'packageName',
 		'tagName',
 		'traitComposition',
 		'classTraitComposition'
@@ -206,9 +206,6 @@ MCClassDefinition >> createClass [
 	superClass := superclassName = #nil ifFalse: [ Smalltalk globals at: superclassName ].
 	^ [
 	  Smalltalk classInstaller make: [ :builder |
-		  Stdio stdout
-			  nextPutAll: 'Type of ' , name asString , ' is ' , type asString;
-			  lf.
 		  builder
 			  superclass: superClass;
 			  name: name;
@@ -621,10 +618,7 @@ MCClassDefinition >> type: aSymbol [
 
 	type := (#( #CompiledMethod #CompiledBlock #CompiledCode ) includes: name)
 		        ifTrue: [ #compiledMethod ]
-		        ifFalse: [ aSymbol ].
-	Stdio stdout
-		nextPutAll: 'Type of ' , (name ifNil: [ 'nil' ]) asString , ' is ' , type asString;
-		lf
+		        ifFalse: [ aSymbol ]
 ]
 
 { #category : #installing }

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -8,7 +8,6 @@ Class {
 		'name',
 		'superclassName',
 		'variables',
-		'category',
 		'type',
 		'comment',
 		'commentStamp',
@@ -78,17 +77,16 @@ MCClassDefinition >> addVariables: aCollection ofType: aClass [
 { #category : #accessing }
 MCClassDefinition >> category [
 
-	^ category ifNil: [
-		  self packageName ifNotNil: [ :package |
-			  (self tagName isNil or: [ self tagName = package ])
-				  ifTrue: [ package ]
-				  ifFalse: [ package , '-' , self tagName ] ] ]
+	^ self packageName ifNotNil: [ :package |
+		  (self tagName isNil or: [ self tagName = package ])
+			  ifTrue: [ package ]
+			  ifFalse: [ package , '-' , self tagName ] ]
 ]
 
 { #category : #accessing }
 MCClassDefinition >> category: categoryString [
 
-	category := categoryString
+	self packageName: categoryString
 ]
 
 { #category : #accessing }

--- a/src/Monticello/MCClassTraitDefinition.class.st
+++ b/src/Monticello/MCClassTraitDefinition.class.st
@@ -7,7 +7,6 @@ Class {
 	#instVars : [
 		'baseTrait',
 		'classTraitComposition',
-		'category',
 		'packageName',
 		'tagName'
 	],
@@ -60,22 +59,21 @@ MCClassTraitDefinition >> baseTraitName: aTraitName [
 { #category : #accessing }
 MCClassTraitDefinition >> category [
 
-	^ category ifNil: [
-		  self packageName
-			  ifNil: [
-				  (Smalltalk classOrTraitNamed: self baseTrait)
-					  ifNotNil: [ :bTrait | bTrait category ]
-					  ifNil: [ self error: 'Can''t detect the category' ] ]
-			  ifNotNil: [ :package |
-				  (self tagName isNil or: [ self tagName = package ])
-					  ifTrue: [ package ]
-					  ifFalse: [ package , '-' , self tagName ] ] ]
+	^ self packageName
+		  ifNil: [
+			  (Smalltalk classOrTraitNamed: self baseTrait)
+				  ifNotNil: [ :bTrait | bTrait category ]
+				  ifNil: [ self error: 'Can''t detect the category' ] ]
+		  ifNotNil: [ :package |
+			  (self tagName isNil or: [ self tagName = package ])
+				  ifTrue: [ package ]
+				  ifFalse: [ package , '-' , self tagName ] ]
 ]
 
 { #category : #initialization }
 MCClassTraitDefinition >> category: aCategoryString [
 
-	category := aCategoryString
+	self packageName: aCategoryString
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
I started to push the usage of #packageName in MCClass(Trait)Definition and now most users are using #packageName and #tagName instead. The last users have a PR waiting to fix them. It is not time to remove the category instance variable. For now I'm keeping the `category:` method for backward compatibility purpose (I'll deprecate it later). And we still have too many users of #category to remove this one yet.