### PR TITLE
Add ‘scale’ for display of a RubParagraph using a RubDisplayScanner

### DIFF
--- a/src/Graphics-Fonts/BitBlt.extension.st
+++ b/src/Graphics-Fonts/BitBlt.extension.st
@@ -39,12 +39,6 @@ BitBlt >> cachedFontColormapFrom: sourceDepth to: destDepth [
 ]
 
 { #category : #'*Graphics-Fonts' }
-BitBlt >> displayString: aString from: startIndex to: stopIndex at: aPoint kern: kernDelta baselineY: baselineY font: aFont [
-	"Double dispatch into the font. This method is present so that other-than-bitblt entities can be used by CharacterScanner and friends to display text."
-	^ aFont displayString: aString on: self from: startIndex to: stopIndex at: aPoint kern: kernDelta baselineY: baselineY
-]
-
-{ #category : #'*Graphics-Fonts' }
 BitBlt >> displayString: aString from: startIndex to: stopIndex at: aPoint kern: kernDelta font: aFont [
 	"Double dispatch into the font. This method is present so that other-than-bitblt entities can be used by CharacterScanner and friends to display text."
 	^ aFont displayString: aString on: self from: startIndex to: stopIndex at: aPoint kern: kernDelta

--- a/src/Rubric/RubCharacterBlockScanner.class.st
+++ b/src/Rubric/RubCharacterBlockScanner.class.st
@@ -252,6 +252,12 @@ RubCharacterBlockScanner >> placeEmbeddedObject: anchoredMorph [
 	^ true
 ]
 
+{ #category : #accessing }
+RubCharacterBlockScanner >> scale [
+
+	^ 1
+]
+
 { #category : #'stop conditions' }
 RubCharacterBlockScanner >> setFont [
 	specialWidth := nil.

--- a/src/Rubric/RubCharacterScanner.class.st
+++ b/src/Rubric/RubCharacterScanner.class.st
@@ -85,7 +85,6 @@ RubCharacterScanner >> basicScanCharactersFrom: startIndex to: stopIndex in: sou
 	reached, then return stops at: 257. Optional.
 	See Object documentation whatIsAPrimitive."
 	| ascii nextDestX char floatDestX widthAndKernedWidth nextChar atEndOfRun |
-	<primitive: 103>
 	lastIndex := startIndex.
 	floatDestX := destX.
 	widthAndKernedWidth := Array new: 2.

--- a/src/Rubric/RubCharacterScanner.class.st
+++ b/src/Rubric/RubCharacterScanner.class.st
@@ -115,14 +115,14 @@ RubCharacterScanner >> basicScanCharactersFrom: startIndex to: stopIndex in: sou
 				widthAndKernedWidthOfLeft: char
 				right: nextChar
 				into: widthAndKernedWidth.
-			nextDestX := floatDestX + (widthAndKernedWidth at: 1).
+			nextDestX := floatDestX + ((widthAndKernedWidth at: 1) * self scale).
 			"note crossing of right component side, unless we would end up on the first position
 			again (endless loop, if line is to narrow to hold this current character)"
 			nextDestX > rightX ifTrue: [firstDestX ~= destX ifTrue:[ ^stops crossedX]].
-			floatDestX := floatDestX + kernDelta + (widthAndKernedWidth at: 2).
+			floatDestX := floatDestX + (kernDelta * self scale) + ((widthAndKernedWidth at: 2) * self scale).
 			atEndOfRun
 				ifTrue:[
-					pendingKernX := (widthAndKernedWidth at: 2) - (widthAndKernedWidth at: 1).
+					pendingKernX := ((widthAndKernedWidth at: 2) * self scale) - ((widthAndKernedWidth at: 1) * self scale).
 					floatDestX := floatDestX - pendingKernX].
 			destX := floatDestX.
 			lastIndex := lastIndex + 1].
@@ -209,8 +209,8 @@ RubCharacterScanner >> nextTabXFrom: anX [
 	| normalizedX tabX mx |
 	mx := 9999.
 	normalizedX := anX - leftMargin.
-	tabX := self tabWidth.
-	[ tabX <= normalizedX and: [ tabX < mx ] ] whileTrue: [ tabX := tabX + self tabWidth ].
+	tabX := self tabWidth * self scale.
+	[ tabX <= normalizedX and: [ tabX < mx ] ] whileTrue: [ tabX := tabX + (self tabWidth * self scale) ].
 	^ tabX < mx
 		ifTrue: [ leftMargin + tabX min: rightMargin ]
 		ifFalse: [ rightMargin ]
@@ -223,7 +223,7 @@ RubCharacterScanner >> placeEmbeddedObject: anchoredMorph [
 	| w |
 	"Workaround: The following should really use #textAnchorType"
 	anchoredMorph relativeTextAnchorPosition ifNotNil:[^true].
-	destX := destX + (w := anchoredMorph width).
+	destX := destX + (w := anchoredMorph width * self scale).
 	(destX > rightMargin and: [(leftMargin + w) <= rightMargin])
 		ifTrue: ["Won't fit, but would on next line"
 				^ false].
@@ -238,7 +238,7 @@ RubCharacterScanner >> plainTab [
 	"This is the basic method of adjusting destX for a tab."
 	destX := (alignment = self justified and: [self leadingTab not])
 		ifTrue:		"embedded tabs in justified text are weird"
-			[destX + (self tabWidth - (line justifiedTabDeltaFor: spaceCount)) max: destX]
+			[destX + ((self tabWidth * self scale) - ((line justifiedTabDeltaFor: spaceCount) * self scale)) max: destX]
 		ifFalse:
 			[self nextTabXFrom: destX].
 	pendingKernX := 0.
@@ -252,6 +252,12 @@ RubCharacterScanner >> registerBreakableIndex [
 	The default implementation here does nothing."
 
 	^ false
+]
+
+{ #category : #accessing }
+RubCharacterScanner >> scale [
+
+	self subclassResponsibility
 ]
 
 { #category : #scanning }
@@ -315,12 +321,12 @@ RubCharacterScanner >> scanMultiCharactersFrom: startIndex to: stopIndex in: sou
 			widthAndKernedWidthOfLeft: (sourceString at: lastIndex)
 			right: nextChar
 			into: widthAndKernedWidth.
-		nextDestX := floatDestX + (widthAndKernedWidth at: 1).
+		nextDestX := floatDestX + ((widthAndKernedWidth at: 1) * self scale).
 		nextDestX > rightX ifTrue: [destX ~= firstDestX ifTrue: [^stops crossedX]].
-		floatDestX := floatDestX + kernDelta + (widthAndKernedWidth at: 2).
+		floatDestX := floatDestX + (kernDelta * self scale) + ((widthAndKernedWidth at: 2) * self scale).
 		atEndOfRun
 			ifTrue:[
-				pendingKernX := (widthAndKernedWidth at: 2) - (widthAndKernedWidth at: 1).
+				pendingKernX := ((widthAndKernedWidth at: 2) * self scale) - ((widthAndKernedWidth at: 1) * self scale).
 				floatDestX := floatDestX - pendingKernX].
 		destX := floatDestX .
 		lastIndex := lastIndex + 1.
@@ -374,9 +380,9 @@ RubCharacterScanner >> setFont [
 					We still want kerning between chars of the same
 					font, but of different color. So add any pending kern to destX"
 					destX := destX + (pendingKernX ifNil: [ 0 ]) ].
-			destX := destX + priorFont descentKern ].
+			destX := destX + (priorFont descentKern * self scale) ].
 	pendingKernX := 0.	"clear any pending kern so there is no danger of it being added twice"
-	destX := destX - font descentKern.	"NOTE: next statement should be removed when clipping works"
+	destX := destX - (font descentKern * self scale). "NOTE: next statement should be removed when clipping works"
 	leftMargin ifNotNil: [ destX := destX max: leftMargin ].
 	kern := kern - font baseKern.	"Install various parameters from the font."
 	spaceWidth := font widthOf: Character space.	"	map := font characterToGlyphMap."

--- a/src/Rubric/RubCompositionScanner.class.st
+++ b/src/Rubric/RubCompositionScanner.class.st
@@ -194,6 +194,12 @@ RubCompositionScanner >> rightX [
 	^ destX
 ]
 
+{ #category : #accessing }
+RubCompositionScanner >> scale [
+
+	^ 1
+]
+
 { #category : #scanning }
 RubCompositionScanner >> setActualFont: aFont [
 	"Keep track of max height and ascent for auto lineheight"

--- a/src/Rubric/RubDisplayScanner.class.st
+++ b/src/Rubric/RubDisplayScanner.class.st
@@ -48,17 +48,6 @@ RubDisplayScanner >> defaultTextColor [
 	^ defaultTextColor
 ]
 
-{ #category : #displaying }
-RubDisplayScanner >> displayEmbeddedForm: aForm [
-
-	aForm
-		displayOn: bitBlt destForm
-		at: destX @ (lineY + line baseline - aForm height)
-		clippingBox: bitBlt clipRect
-		rule: Form blend
-		fillColor: Color white
-]
-
 { #category : #scanning }
 RubDisplayScanner >> displayLine: textLine offset: offset leftInRun: leftInRun [
 	"The call on the primitive (scanCharactersFrom:to:in:rightX:) will be interrupted according to an array of stop conditions passed to the scanner at which time the code to handle the stop condition is run and the call on the primitive continued until a stop condition returns true (which means the line has terminated).  leftInRun is the # of characters left to scan in the current run; when 0, it is time to call setStopConditions."
@@ -109,14 +98,6 @@ RubDisplayScanner >> displayLine: textLine offset: offset leftInRun: leftInRun [
 		"or: [lastIndex > runStopIndex]."
 	] whileFalse.
 	^ runStopIndex - lastIndex   "Number of characters remaining in the current run"
-]
-
-{ #category : #displaying }
-RubDisplayScanner >> displayString: string from: startIndex to: stopIndex at: aPoint [
-	font displayString: string on: bitBlt
-		from: startIndex
-		to: stopIndex
-		at: aPoint kern: kern
 ]
 
 { #category : #'stop conditions' }

--- a/src/Rubric/RubDisplayScanner.class.st
+++ b/src/Rubric/RubDisplayScanner.class.st
@@ -8,7 +8,8 @@ Class {
 		'foregroundColor',
 		'lineHeight',
 		'morphicOffset',
-		'defaultTextColor'
+		'defaultTextColor',
+		'scale'
 	],
 	#category : #'Rubric-TextScanning'
 }
@@ -54,19 +55,19 @@ RubDisplayScanner >> displayLine: textLine offset: offset leftInRun: leftInRun [
 	| stopCondition nowLeftInRun startIndex string lastPos |
 	line := textLine.
 	morphicOffset := offset.
-	lineY := line top + offset y.
-	lineHeight := line lineHeight.
-	rightMargin := line rightMargin + offset x.
+	lineY := line top * self scale + offset y.
+	lineHeight := line lineHeight * self scale.
+	rightMargin := line rightMargin * self scale + offset x.
 	lastIndex := line first.
 	leftInRun <= 0 ifTrue: [self setStopConditions].
-	leftMargin := (line leftMarginForAlignment: alignment) + offset x.
+	leftMargin := (line leftMarginForAlignment: alignment) * self scale + offset x.
 	destX := runX := leftMargin.
 	lastIndex := line first.
 	leftInRun <= 0
 		ifTrue: [nowLeftInRun := text runLengthFor: lastIndex]
 		ifFalse: [nowLeftInRun := leftInRun].
-	baselineY := lineY + line baseline.
-	destY := baselineY - font ascent.
+	baselineY := lineY + (line baseline * self scale).
+	destY := baselineY - (font ascent * self scale).
 	runStopIndex := lastIndex + (nowLeftInRun - 1) min: line last.
 	spaceCount := 0.
 	string := text string.
@@ -77,7 +78,7 @@ RubDisplayScanner >> displayLine: textLine offset: offset leftInRun: leftInRun [
 						in: string rightX: rightMargin stopConditions: stopConditions
 						kern: kern.
 		lastIndex >= startIndex ifTrue:[
-			bitBlt displayString: string
+			font displayString: string on: bitBlt
 				from: startIndex
 	"XXXX: The following is an interesting bug. All stopConditions exept #endOfRun
 		have lastIndex past the last character displayed. #endOfRun sets it *on* the character.
@@ -86,12 +87,12 @@ RubDisplayScanner >> displayLine: textLine offset: offset leftInRun: leftInRun [
 		consistently) but I don't want to deal with the fallout right now so we keep the
 		fix minimally invasive."
 				to: (stopCondition == #endOfRun ifTrue:[lastIndex] ifFalse:[lastIndex-1])
-				at: lastPos kern: kern baselineY: baselineY font: font].
+				at: lastPos kern: kern baselineY: baselineY scale: self scale].
 		(emphasisCode allMask: 4) ifTrue:[
-			font displayUnderlineOn: bitBlt from: lastPos x@baselineY to: destX@baselineY.
+			font displayUnderlineOn: bitBlt from: lastPos x@baselineY to: destX@baselineY scale: self scale.
 		].
 		(emphasisCode allMask: 16) ifTrue:[
-			font displayStrikeoutOn: bitBlt from: lastPos x@baselineY to: destX@baselineY.
+			font displayStrikeoutOn: bitBlt from: lastPos x@baselineY to: destX@baselineY scale: self scale.
 		].
 		"see setStopConditions for stopping conditions for displaying."
 		self perform: stopCondition.
@@ -114,6 +115,13 @@ RubDisplayScanner >> endOfRun [
 	^ false
 ]
 
+{ #category : #initialization }
+RubDisplayScanner >> initialize [
+
+	super initialize.
+	scale := 1
+]
+
 { #category : #'multilingual scanning' }
 RubDisplayScanner >> isBreakableAt: index in: sourceString [
 
@@ -128,7 +136,7 @@ RubDisplayScanner >> paddedSpace [
 	space that remained at the end of the line when it was composed."
 
 	spaceCount := spaceCount + 1.
-	destX := destX + spaceWidth + (line justifiedPadFor: spaceCount  font: font).
+	destX := destX + (spaceWidth * self scale) + ((line justifiedPadFor: spaceCount font: font) * scale).
 	lastIndex := lastIndex + 1.
 	pendingKernX := 0.
 	^ false
@@ -140,20 +148,20 @@ RubDisplayScanner >> placeEmbeddedObject: anchoredMorph [
 		anchoredMorph position:
 			anchoredMorph relativeTextAnchorPosition +
 			(anchoredMorph owner bounds origin x @ 0)
-			- (0@morphicOffset y) + (0@lineY).
+			+ (0@((lineY - morphicOffset y) / self scale)).
 		^true
 	].
 	(super placeEmbeddedObject: anchoredMorph) ifFalse: [^ false].
 	anchoredMorph isMorph ifTrue: [
-		anchoredMorph position: ((destX - anchoredMorph width)@lineY) - morphicOffset.
+		anchoredMorph position: (((destX - (anchoredMorph width * self scale))@lineY) - morphicOffset) / self scale.
 		anchoredMorph setProperty: #hasBeenPositioned toValue: true
 	] ifFalse: [
 		destY := lineY.
-		baselineY := lineY + anchoredMorph height..
+		baselineY := lineY + (anchoredMorph height * self scale).
 		runX := destX.
-		anchoredMorph
+		(self scale = 1 ifTrue: [ anchoredMorph ] ifFalse: [ anchoredMorph scaledToSize: anchoredMorph extent * self scale ])
 			displayOn: bitBlt destForm
-			at: destX - anchoredMorph width @ destY
+			at: destX - (anchoredMorph width * self scale) @ destY
 			clippingBox: bitBlt clipRect
 			rule: Form blend
 			fillColor: Color white
@@ -161,14 +169,26 @@ RubDisplayScanner >> placeEmbeddedObject: anchoredMorph [
 	^ true
 ]
 
+{ #category : #accessing }
+RubDisplayScanner >> scale [
+
+	^ scale
+]
+
+{ #category : #accessing }
+RubDisplayScanner >> scale: newScale [
+
+	scale := newScale
+]
+
 { #category : #'stop conditions' }
 RubDisplayScanner >> setFont [
 	foregroundColor := self defaultTextColor.
 	super setFont.  "Sets font and emphasis bits, and maybe foregroundColor"
-	font installOn: bitBlt foregroundColor: foregroundColor backgroundColor: Color transparent.
+	font installOn: bitBlt foregroundColor: foregroundColor backgroundColor: Color transparent scale: self scale.
 	text ifNotNil:[
-		baselineY := lineY + line baseline.
-		destY := baselineY - font ascent]
+		baselineY := lineY + (line baseline * self scale).
+		destY := baselineY - (font ascent * self scale)]
 ]
 
 { #category : #'stop conditions' }

--- a/src/Rubric/RubParagraph.class.st
+++ b/src/Rubric/RubParagraph.class.st
@@ -237,9 +237,9 @@ RubParagraph >> drawOn: aCanvas using: aDisplayScanner at: aPosition [
 	self drawingEnabled
 		ifFalse: [ ^ self ].
 	visibleRectangle := aCanvas clipRect.
-	offset := (aPosition - self position) truncated.
+	offset := (aPosition - (self position * aDisplayScanner scale)) truncated.
 	leftInRun := 0.
-	(self lineIndexForPoint: visibleRectangle topLeft) to: (self lineIndexForPoint: visibleRectangle bottomRight) do: [ :i |
+	(self lineIndexForPoint: visibleRectangle topLeft scale: aDisplayScanner scale) to: (self lineIndexForPoint: visibleRectangle bottomRight scale: aDisplayScanner scale) do: [ :i |
 		line := self lines at: i.
 		line first <= line last
 			ifTrue: [ leftInRun := aDisplayScanner displayLine: line offset: offset leftInRun: leftInRun ] ]
@@ -380,8 +380,14 @@ RubParagraph >> lastNonBlankCharacterBlockInLine: aLine [
 
 { #category : #querying }
 RubParagraph >> lineIndexForPoint: aPoint [
+
+	^ self lineIndexForPoint: aPoint scale: 1
+]
+
+{ #category : #querying }
+RubParagraph >> lineIndexForPoint: aPoint scale: scale [
 	"Answer the index of the line in which to select the character nearest to aPoint."
-	^ self composer lineIndexForPoint: aPoint
+	^ self composer lineIndexForPoint: aPoint scale: scale
 ]
 
 { #category : #querying }

--- a/src/Rubric/RubTextComposer.class.st
+++ b/src/Rubric/RubTextComposer.class.st
@@ -307,16 +307,22 @@ RubTextComposer >> indentationOfLineIndex: lineIndex ifBlank: aBlock [
 
 { #category : #querying }
 RubTextComposer >> lineIndexForPoint: aPoint [
+
+	^ self lineIndexForPoint: aPoint scale: 1
+]
+
+{ #category : #querying }
+RubTextComposer >> lineIndexForPoint: aPoint scale: scale [
 	"Answer the index of the line in which to select the character nearest to aPoint."
 	| i py |
 	py := aPoint y truncated.
 
 	"Find the first line at this y-value"
-	i := (self fastFindFirstLineSuchThat: [:line | line bottom > py]) min: self lines size.
+	i := (self fastFindFirstLineSuchThat: [:line | (line bottom * scale) > py]) min: self lines size.
 
 	"Now find the first line at this x-value"
-	[i < self lines size and: [(self lines at: i+1) top = (self lines at: i) top
-				and: [aPoint x >= (self lines at: i+1) left]]]
+	[i < self lines size and: [((self lines at: i+1) top * scale) = ((self lines at: i) top * scale)
+				and: [aPoint x >= ((self lines at: i+1) left * scale)]]]
 		whileTrue: [i := i + 1].
 	^ i
 ]


### PR DESCRIPTION
Pull request #14630 added ‘scale’ for display of a Paragraph using a BitBltDisplayScanner, this pull request extends that to the display of a RubParagraph using a RubDisplayScanner. An example is given by the snippet below. For comparison, for ‘form1’, the example Rubric paragraph is displayed normally and then the form is scaled by a factor of two:

<p align="center"><img src="https://github.com/pharo-project/pharo/assets/1611248/8e781d30-a7a3-4035-ad3b-dfda8e0e260e"></p>

For ‘form2’, the paragraph is again displayed directly on the larger form so that the character glyphs have better detail:

<p align="center"><img src="https://github.com/pharo-project/pharo/assets/1611248/05cf40fc-115b-4b01-9ccb-fbe94f9b75e3"></p>

```smalltalk
text := Text streamContents: [ :stream |
	stream
		nextPutAll: (Microdown asRichText: '# Lorem Ipsum'); cr;
		nextPutAll: (Microdown asRichText: 'Dolor **sit** amet, _consectetur adipiscing_ elit,');
		nextPutAll: ' ';
		nextPutAll: (Microdown asRichText: 'sed do eiusmod tempor ![](pharo:///Object/iconNamed:/home) incididunt ut');
		nextPutAll: '  ';
		withAttribute: (TextAnchor new anchoredMorph: (CircleMorph new extent: 10@10; yourself); yourself) do: [
			stream nextPut: Character home ];
		nextPutAll: '  ';
		nextPutAll: (Microdown asRichText: '  labore ~et dolore magna~ aliqua.') ].
(editingArea := RubEditingArea new)
	extent: 300@0;
	beWrapped;
	setTextWith: text.
paragraph := editingArea paragraph next next next.
bounds := 0@0 corner: paragraph extent.
scale := 2.

(baseForm := Form extent: paragraph extent depth: Display depth) fillColor: Color white.
baseForm getCanvas
	rubParagraph: paragraph bounds: bounds color: Color black;
	translateBy: bounds topLeft during: [ :translatedCanvas |
		paragraph text embeddedMorphs do: [ :morph |
			translatedCanvas fullDrawMorph: morph ] ].
form1 := baseForm scaledToSize: baseForm extent * scale.

(form2 := Form extent: form1 extent depth: Display depth) fillColor: Color white.
canvas := form2 getCanvas.
canvas setPaintColor: Color black.
port := canvas privatePort.
origin := canvas origin.
scanner := (port clippedBy: ((bounds translateBy: origin) scaleBy: scale)) rubDisplayScannerFor: paragraph
	foreground: Color black.
scanner scale: scale.
paragraph drawOn: (canvas copyClipRect: (bounds scaleBy: scale)) using: scanner at: (origin + bounds topLeft) * scale.
canvas transformBy: (MatrixTransform2x3 withScale: scale) clippingTo: canvas clipRect during: [ :scaledCanvas |
	scaledCanvas translateBy: bounds topLeft during: [ :translatedCanvas |
		paragraph text embeddedMorphs do: [ :morph |
			translatedCanvas fullDrawMorph: morph ] ] ].

{ form1. form2 } keysAndValuesDo: [ :index :form |
	PNGReadWriter putForm: form onFileNamed: FileLocator imageDirectory / (index asString , '.png') ]
```