### PR TITLE
Fix Rename class Bug

### DIFF
--- a/src/SystemCommands-ClassCommands/SycRenameClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycRenameClassCommand.class.st
@@ -29,7 +29,7 @@ SycRenameClassCommand >> defaultMenuItemName [
 SycRenameClassCommand >> execute [
 
 	| refactoring |
-	refactoring := RBRenameClassTransformation
+	refactoring := RBRenameClassRefactoring
 		rename: targetClass name
 		to: newName.
 	refactoring execute


### PR DESCRIPTION
Transformation contains side effects in applicability preconditions checking logic that refacortirngs don't. These side effects caused the bug to pop up.
The main issue is that transformation did rewriting of class references __during__ precondition checking. This is not needed since `privateTransform` already invokes `renameReferences`. This double removal caused us to have undeclared variable in the method before we actually renamed the class.
In the next PR I'll clean the Rename class refactoring and transformation.

Co-authored with @gocko