### PR TITLE
RPackage: Clean tests and reduce categories usage

### DIFF
--- a/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
@@ -10,39 +10,39 @@ Class {
 { #category : #'tests - adding classes' }
 RPackageClassesSynchronisationTest >> testAddClassAddItIntoPackageBestMatchName [
 
-	| tmpPackage class |
-	tmpPackage := self ensureXPackage.
-	self ensureTagYinX.
+	| package tag class |
+	tag := self ensureTagYinX.
+	package := tag package.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX-YYYY'.
+	class := self newClassNamed: 'NewClass' inTag: tag.
 
-	self assert: (tmpPackage definesClass: class).
-	self assert: class package equals: tmpPackage
+	self assert: (package definesClass: class).
+	self assert: class package equals: package
 ]
 
 { #category : #'tests - adding classes' }
 RPackageClassesSynchronisationTest >> testAddClassAddItIntoPackageExactName [
 
-	| tmpPackage class |
-	tmpPackage := self ensureXPackage.
-	self ensureTagYinX.
+	| package tag class |
+	tag := self ensureTagYinX.
+	package := tag package.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' inTag: tag.
 
-	self assert: (tmpPackage definesClass: class).
-	self assert: class package equals: tmpPackage
+	self assert: (package definesClass: class).
+	self assert: class package equals: package
 ]
 
 { #category : #'tests - adding classes' }
 RPackageClassesSynchronisationTest >> testAddClassUpdateTheOrganizerMappings [
 	"test that when we add a class, the organizer 'classPackageMapping' dictionary is updated, so that the class is linked to its package and so that we can access its owning package"
 
-	| tmpPackage class |
-	tmpPackage := self ensureXPackage.
+	| package class |
+	package := self ensureXPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: package.
 
-	self assert: class package equals: tmpPackage
+	self assert: class package equals: package
 ]
 
 { #category : #'tests - recategorizing class' }
@@ -54,7 +54,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassRaisesClassRepackaged
 
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	class category: 'YYYYY'.
 
 	self assert: ann isNotNil.
@@ -72,7 +72,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassRegisterTheClassInThe
 	self ensureTagYinX.
 	yPackage := self ensureYPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'YYYYY'.
+	class := self newClassNamed: 'NewClass' in: yPackage.
 
 	class category: 'XXXXX-YYYY'.
 	self assert: (self organizer packageOf: class) equals: xPackage.
@@ -87,7 +87,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassRegisterTheClassInThe
 	xPackage := self ensureXPackage.
 	self ensureTagYinX.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'YYYYY'.
+	class := self newClassNamed: 'NewClass' in: yPackage.
 
 	class category: 'XXXXX'.
 
@@ -103,7 +103,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassRegisterTheClassInThe
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'YYYYY'.
+	class := self newClassNamed: 'NewClass' in: yPackage.
 
 	class category: 'XXXXX'.
 	self deny: (self organizer packageOf: class) equals: yPackage.
@@ -119,7 +119,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassRegisterTheClassMetho
 	yPackage := self ensureYPackage.
 	zPackage := self ensureZPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'method1' inClass: class inCategory: 'category'.
 	self createMethodNamed: 'method2' inClass: class inCategory: '*zzzzz'.
 	self createMethodNamed: 'method3' inClass: class inCategory: '*yyyyy'.
@@ -147,7 +147,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassUnregisterTheClassFro
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	class category: 'YYYYY'.
 	self deny: (xPackage includesClass: class)
@@ -162,7 +162,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassUnregisterTheClassMet
 	yPackage := self ensureYPackage.
 	zPackage := self ensureZPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'method1' inClass: class inCategory: 'category'.
 	self createMethodNamed: 'method2' inClass: class inCategory: '*zzzzz'.
 	self createMethodNamed: 'method3' inClass: class inCategory: '*yyyyy'.
@@ -180,7 +180,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassUpdateTheOrganizerMap
 	| yPackage class |
 	self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: 'XXXXX'.
 	class category: 'YYYYY'.
 	self assert: (self organizer packageOf: class) equals: yPackage
 ]
@@ -194,7 +194,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassWithMetaClassMethodsR
 	yPackage := self ensureYPackage.
 	zPackage := self ensureZPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self createMethodNamed: 'method1' inClass: class class inCategory: 'category'.
 	self createMethodNamed: 'method2' inClass: class class inCategory: '*yyyyy'.
@@ -215,7 +215,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassWithUnexistingPackage
 	| xPackage yYPackage class |
 	xPackage := self ensureXPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self assert: (self organizer packageOf: class) equals: xPackage.
 
 	class category: 'YYYYY'.
@@ -231,7 +231,7 @@ RPackageClassesSynchronisationTest >> testRemoveClassUnregisterTheClassDefinedMe
 
 	| xPackage class |
 	xPackage := self ensureXPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
 
 	self organizer environment removeClassNamed: 'NewClass'.
@@ -245,7 +245,7 @@ RPackageClassesSynchronisationTest >> testRemoveClassUnregisterTheClassExtension
 	| xPackage yPackage class |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 
 	self organizer environment removeClassNamed: 'NewClass'.
@@ -258,7 +258,7 @@ RPackageClassesSynchronisationTest >> testRemoveClassUnregisterTheClassFromItsPa
 
 	| xPackage class |
 	xPackage := self ensureXPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self organizer environment removeClassNamed: 'NewClass'.
 	self deny: (xPackage includesClass: class)
@@ -270,7 +270,7 @@ RPackageClassesSynchronisationTest >> testRemoveClassUpdateTheOrganizerMappings 
 
 	| xPackage class |
 	xPackage := self ensureXPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self organizer environment removeClassNamed: 'NewClass'.
 	self deny: (self organizer packageOf: class) isNil
@@ -283,7 +283,7 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateClassDefinedInThePare
 	| xPackage class |
 	xPackage := self ensureXPackage.
 
-	class := self createNewClassNamed: 'RPackageOldStubClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'RPackageOldStubClass' in: xPackage.
 	class rename: 'RPackageNewStubClass'.
 
 	self assert: (xPackage includesClassNamed: 'RPackageNewStubClass').
@@ -296,7 +296,7 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateClassDefinedSelectors
 
 	| xPackage class |
 	xPackage := self ensureXPackage.
-	class := self createNewClassNamed: 'RPackageOldStubClass' asSymbol inCategory: 'XXXXX'.
+	class := self newClassNamed: 'RPackageOldStubClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
 
 	class rename: 'RPackageNewStubClass'.
@@ -311,7 +311,7 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateClassExtensionSelecto
 	| xPackage yPackage class |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'RPackageOldStubClass' asSymbol inCategory: 'XXXXX'.
+	class := self newClassNamed: 'RPackageOldStubClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 
 	class rename: 'RPackageNewStubClass'.
@@ -325,7 +325,7 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateMetaclassDefinedSelec
 
 	| xPackage class |
 	xPackage := self ensureXPackage.
-	class := self createNewClassNamed: 'RPackageOldStubClass' asSymbol inCategory: 'XXXXX'.
+	class := self newClassNamed: 'RPackageOldStubClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClassSideOfClass: class inCategory: 'classic category'.
 
 	class rename: 'RPackageNewStubClass'.
@@ -340,7 +340,7 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateMetaclassExtensionSel
 	| xPackage yPackage class |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'RPackageOldStubClass' asSymbol inCategory: 'XXXXX'.
+	class := self newClassNamed: 'RPackageOldStubClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClassSideOfClass: class inCategory: '*yyyyy'.
 
 	class rename: 'RPackageNewStubClass'.
@@ -355,7 +355,7 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateOrganizerClassExtendi
 	| xPackage yPackage class |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'RPackageOldStubClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'RPackageOldStubClass' in: xPackage.
 	self createMethodNamed: #stubMethod inClass: class inCategory: '*yyyyy'.
 
 	class rename: 'RPackageNewStubClass'.
@@ -369,7 +369,7 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateOrganizerClassPackage
 
 	| xPackage class |
 	xPackage := self ensureXPackage.
-	class := self createNewClassNamed: 'RPackageOldStubClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'RPackageOldStubClass' in: xPackage.
 
 	class rename: 'RPackageNewStubClass'.
 
@@ -381,10 +381,10 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateOrganizerClassPackage
 RPackageClassesSynchronisationTest >> testReorganizeClassByAddingExtensionProtocol [
 	"test that when we reoganized a class by adding a category, nothing change from  RPackage point of vue."
 
-	| class |
-	self ensureXPackage.
+	| xPackage class |
+	xPackage := self ensureXPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'newMethod' inClass: class inCategory: 'xxxxx'.
 	class addProtocol: '*yyyyy'.
 
@@ -397,7 +397,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByAddingNewProtocolDoes
 
 	| xPackage class |
 	xPackage := self ensureXPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'newMethod' inClass: class inCategory: 'xxxxx'.
 	class addProtocol: 'accessing'.
 
@@ -412,7 +412,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRemovingClassicCatego
 
 	| xPackage class |
 	xPackage := self ensureXPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
 	class removeProtocol: 'classic category'.
 	self deny: (xPackage includesDefinedSelector: #stubMethod ofClass: class)
@@ -425,7 +425,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRemovingExtensionCate
 	| xPackage yPackage class |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 
@@ -442,7 +442,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingClassicCatego
 	| xPackage yPackage class |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
 	self createMethodNamed: 'stubMethod2' inClass: class inCategory: 'classic category'.
@@ -462,7 +462,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingClassicCatego
 	| xPackage yPackage class |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
 	class renameProtocol: 'classic category' as: '*yyyyy'.
 	self assert: (yPackage includesExtensionSelector: #stubMethod ofClass: class).
@@ -477,7 +477,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingExtensionCate
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
 	zPackage := self ensureZPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 	class renameProtocol: '*yyyyy' as: '*zzzzz'.
 	self assert: (zPackage includesExtensionSelector: #stubMethod ofClass: class).
@@ -492,7 +492,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingExtensionCate
 	| xPackage yPackage class |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 	self createMethodNamed: 'stubMethod2' inClass: class inCategory: '*yyyyy'.
@@ -512,7 +512,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingExtensionCate
 	| xPackage yPackage class |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 	class renameProtocol: '*yyyyy' as: 'classic category'.
 	self deny: (yPackage includesExtensionSelector: #stubMethod ofClass: class).

--- a/src/Monticello-Tests/RPackageExtensionMethodsSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageExtensionMethodsSynchronisationTest.class.st
@@ -11,13 +11,13 @@ Class {
 RPackageExtensionMethodsSynchronisationTest >> testAddMethodInExtensionCategoryBestMatchingNameAddMethodToTheExtendingPackage [
 	"test that when we add a method  in an extension category ( beginning with*) that enlarge a package name (for example *mondrian-accessing for Mondrian), this method is added to the corresponding extending package"
 
-	| class xPackage yPackage |
+	| class xPackage yPackage tag |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	self ensureTagYinX.
+	tag := self ensureTagYinX.
 
-	self createNewClassNamed: 'NewClass' inCategory: 'XXXXX-YYYY'.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'YYYYY'.
+	self newClassNamed: 'NewClass' inTag: tag.
+	class := self newClassNamed: 'NewClass' in: yPackage.
 
 	self createMethodNamed: #newMethod inClass: class inCategory: '*XXXXX-YYYY'.
 
@@ -34,7 +34,7 @@ RPackageExtensionMethodsSynchronisationTest >> testAddMethodInExtensionCategoryM
 	| class xPackage yPackage |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self createMethodNamed: #newMethod inClass: class inCategory: '*YYYYY-subcategory'.
 
@@ -48,10 +48,10 @@ RPackageExtensionMethodsSynchronisationTest >> testAddMethodInExtensionCategoryM
 RPackageExtensionMethodsSynchronisationTest >> testAddMethodInExtensionCategoryNotExistingCreateANewPackage [
 	"test that when we add a method  in an extension category ( beginning with *)that does not refer to an existing categorya new package with the name of this category is added, and that the method is added to this new package"
 
-	| class firstPackage |
-	firstPackage := self ensureXPackage.
+	| class xPackage |
+	xPackage := self ensureXPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self createMethodNamed: #newMethod inClass: class inCategory: '*SomethingDifferentNothingToDoWithWhatWeHave'.
 
@@ -64,10 +64,10 @@ RPackageExtensionMethodsSynchronisationTest >> testAddMethodInExtensionCategoryN
 RPackageExtensionMethodsSynchronisationTest >> testAddMethodInExtensionCategoryNotExistingCreateANewPackageAndInstallsMethodInIt [
 	"test that when we add a method  in an extension category ( beginning with *)that does not refer to an existing categorya new package with the name of this category is added, and that the method is added to this new package"
 
-	| class firstPackage |
-	firstPackage := self ensureXPackage.
+	| class xPackage |
+	xPackage := self ensureXPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self createMethodNamed: #newMethod inClass: class inCategory: '*SomethingDifferentNothingToDoWithWhatWeHave'.
 
@@ -81,101 +81,101 @@ RPackageExtensionMethodsSynchronisationTest >> testAddMethodInExtensionCategoryN
 RPackageExtensionMethodsSynchronisationTest >> testAddMethodInExtensionCategoryNotRespectingCaseAddMethodToTheExtendingPackage [
 	"test that when we add a method  in an extension category ( beginning with *)thae does not match the case of the corresponding package (for example *packagea for PackageA), this method is added to the corresponding extending package"
 
-	| class firstPackage secondPackage |
-	firstPackage := self ensureXPackage.
-	secondPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	| class xPackage yPackage |
+	xPackage := self ensureXPackage.
+	yPackage := self ensureYPackage.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyYyY'.
 
-	self assert: (secondPackage includesExtensionSelector: #stubMethod ofClass: class).
-	self deny: (firstPackage includesDefinedSelector: #stubMethod ofClass: class).
+	self assert: (yPackage includesExtensionSelector: #stubMethod ofClass: class).
+	self deny: (xPackage includesDefinedSelector: #stubMethod ofClass: class).
 
-	self assert: (class >> #stubMethod) package equals: secondPackage
+	self assert: (class >> #stubMethod) package equals: yPackage
 ]
 
 { #category : #'we are not sure' }
 RPackageExtensionMethodsSynchronisationTest >> testAddMethodInExtensionCategoryWithExactMatchAddMethodToTheExtendingPackage [
 	"test that when we add a method to a  class in an extension category ( beginning with *), this method is added to the corresponding extending package"
 
-	| class firstPackage secondPackage |
-	firstPackage := self ensureXPackage.
-	secondPackage := self ensureYPackage.
+	| class xPackage yPackage |
+	xPackage := self ensureXPackage.
+	yPackage := self ensureYPackage.
 	self ensureTagYinX.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*YYYYY'.
 
-	self assert: (secondPackage includesExtensionSelector: #stubMethod ofClass: class).
-	self deny: (firstPackage includesDefinedSelector: #stubMethod ofClass: class).
+	self assert: (yPackage includesExtensionSelector: #stubMethod ofClass: class).
+	self deny: (xPackage includesDefinedSelector: #stubMethod ofClass: class).
 
-	self assert: (class >> #stubMethod) package equals: secondPackage
+	self assert: (class >> #stubMethod) package equals: yPackage
 ]
 
 { #category : #'tests - operations on methods' }
 RPackageExtensionMethodsSynchronisationTest >> testModifyMethodByChangingCode [
 	"test that when we modify the code of a method, everything work well: NOTHING SHOULD HAPPEN REGARDING THE PACKAGING"
 
-	| class firstPackage |
-	firstPackage := self ensureXPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	| class xPackage |
+	xPackage := self ensureXPackage.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
 
 	class compile: 'stubMethod ^22222222222'.
 
 	"nothing should change"
 	self assert: (class >> #stubMethod) protocolName equals: 'classic category'.
-	self assert: (firstPackage includesDefinedSelector: #stubMethod ofClass: class).
-	self deny: (firstPackage includesExtensionSelector: #stubMethod ofClass: class).
-	self assert: (class >> #stubMethod) package equals: firstPackage
+	self assert: (xPackage includesDefinedSelector: #stubMethod ofClass: class).
+	self deny: (xPackage includesExtensionSelector: #stubMethod ofClass: class).
+	self assert: (class >> #stubMethod) package equals: xPackage
 ]
 
 { #category : #'tests - operations on methods' }
 RPackageExtensionMethodsSynchronisationTest >> testMoveClassInPackageWithExtensionsOnClass [
 	"Move a class in package XXXXX (with extensions from YYYY) to package YYYYY."
 
-	| class secondPackage |
-	self ensureXPackage.
-	secondPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*' , secondPackage name.
+	| class xPackage yPackage |
+	xPackage := self ensureXPackage.
+	yPackage := self ensureYPackage.
+	class := self newClassNamed: 'NewClass' in: xPackage.
+	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*' , yPackage name.
 
-	secondPackage addClass: class.
+	yPackage addClass: class.
 
 	"Everything should now be in second package (and not listed as an extension)."
 	self deny: (class >> #stubMethod) isClassified.
-	self assert: (secondPackage includesDefinedSelector: #stubMethod ofClass: class).
-	self deny: (secondPackage includesExtensionSelector: #stubMethod ofClass: class).
-	self assert: (class >> #stubMethod) package equals: secondPackage
+	self assert: (yPackage includesDefinedSelector: #stubMethod ofClass: class).
+	self deny: (yPackage includesExtensionSelector: #stubMethod ofClass: class).
+	self assert: (class >> #stubMethod) package equals: yPackage
 ]
 
 { #category : #'tests - operations on methods' }
 RPackageExtensionMethodsSynchronisationTest >> testMoveClassInPackageWithExtensionsOnClassAndBack [
 	"Move a class in package XXXXX (with extensions from YYYY) to package YYYYY."
 
-	| class firstPackage secondPackage |
-	firstPackage := self ensureXPackage.
-	secondPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*' , secondPackage name.
+	| class xPackage yPackage |
+	xPackage := self ensureXPackage.
+	yPackage := self ensureYPackage.
+	class := self newClassNamed: 'NewClass' in: xPackage.
+	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*' , yPackage name.
 
-	secondPackage addClass: class.
+	yPackage addClass: class.
 
 	"Everything should now be in second package (and not listed as an extension, but instead as 'as yet unclassified')."
 
 	self deny: (class >> #stubMethod) isClassified.
-	self assert: (secondPackage includesDefinedSelector: #stubMethod ofClass: class).
-	self deny: (secondPackage includesExtensionSelector: #stubMethod ofClass: class).
-	self assert: (class >> #stubMethod) package equals: secondPackage.
+	self assert: (yPackage includesDefinedSelector: #stubMethod ofClass: class).
+	self deny: (yPackage includesExtensionSelector: #stubMethod ofClass: class).
+	self assert: (class >> #stubMethod) package equals: yPackage.
 
 	"Moving back, we should not see the extension reappear."
 
-	firstPackage addClass: class.
+	xPackage addClass: class.
 
 	self deny: (class >> #stubMethod) isClassified.
-	self assert: (firstPackage includesDefinedSelector: #stubMethod ofClass: class).
-	self deny: (secondPackage includesExtensionSelector: #stubMethod ofClass: class)
+	self assert: (xPackage includesDefinedSelector: #stubMethod ofClass: class).
+	self deny: (yPackage includesExtensionSelector: #stubMethod ofClass: class)
 ]
 
 { #category : #'tests - operations on methods' }
@@ -186,7 +186,7 @@ RPackageExtensionMethodsSynchronisationTest >> testRemoveAllExtensionMethodsFrom
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 	self createMethodNamed: 'stubMethod2' inClass: class classSide inCategory: '*yyyyy'.
 
@@ -204,7 +204,7 @@ RPackageExtensionMethodsSynchronisationTest >> testRemoveAllExtensionMethodsRemo
 	| xPackage class yPackage |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 	self createMethodNamed: 'stubMethod2' inClass: class inCategory: '*yyyyy'.
 
@@ -224,7 +224,7 @@ RPackageExtensionMethodsSynchronisationTest >> testRemoveExtensionMethodDoesNotR
 	| xPackage class yPackage |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 	self createMethodNamed: 'stubMethod2' inClass: class inCategory: '*yyyyy'.
 
@@ -245,7 +245,7 @@ RPackageExtensionMethodsSynchronisationTest >> testRemoveExtensionMethodRemoveMe
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 
 	class removeSelector: #stubMethod.

--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -70,7 +70,7 @@ RPackageMCSynchronisationTest >> emptyOrganizer [
 { #category : #utilities }
 RPackageMCSynchronisationTest >> ensureTagYinX [
 
-	self organizer ensureTagNamed: #YYYY inPackageNamed: #XXXXX
+	^ self organizer ensureTagNamed: #YYYY inPackageNamed: #XXXXX
 ]
 
 { #category : #utilities }
@@ -140,7 +140,7 @@ RPackageMCSynchronisationTest >> testNotRepackagedAnnouncementWhenModifyMethodBy
 	| ann class |
 	SystemAnnouncer uniqueInstance when: MethodRepackaged do: [ :a | ann := a ] for: self.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: 'XXXXX'.
 
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 
@@ -157,7 +157,7 @@ RPackageMCSynchronisationTest >> testNotRepackagedAnnouncementWhenMovingClassicC
 	| ann class |
 	SystemAnnouncer uniqueInstance when: MethodRepackaged do: [ :a | ann := a ] for: self.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: 'XXXXX'.
 
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic'.
 
@@ -176,7 +176,7 @@ RPackageMCSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMov
 
 	firstPackage := self ensureXPackage.
 	secondPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
 
 	class classify: #stubMethod under: '*yyyyy'.
@@ -202,7 +202,7 @@ RPackageMCSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMov
 	secondPackage := self ensureYPackage.
 	thirdPackage := self ensureZPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 
 	class classify: #stubMethod under: '*zzzzz'.
@@ -221,7 +221,7 @@ RPackageMCSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMov
 
 	firstPackage := self ensureXPackage.
 	secondPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 
 	class classify: #stubMethod under: 'classic one'.

--- a/src/Monticello-Tests/RPackageMethodsSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMethodsSynchronisationTest.class.st
@@ -11,10 +11,10 @@ Class {
 RPackageMethodsSynchronisationTest >> testAddMethodInClassicCategoryAddMethodToTheParentPackageOfItsClass [
 	"test that when we add a method to a  class in a classic category (not beginning with *), this method is added to the parent package of the class"
 
-	| tmpPackage class |
-	tmpPackage := self ensureXPackage.
+	| xPackage class |
+	xPackage := self ensureXPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
 
@@ -26,10 +26,10 @@ RPackageMethodsSynchronisationTest >> testAddMethodInClassicCategoryAddMethodToT
 RPackageMethodsSynchronisationTest >> testAddMethodInClassicCategoryAddMethodToTheParentPackageOfItsTrait [
 	"test that when we add a method to a  trait in a classic category (*not beginning with *), this method is added to the parent package of the class"
 
-	| tmpPackage trait |
-	tmpPackage := self ensureXPackage.
+	| xPackage trait |
+	xPackage := self ensureXPackage.
 
-	trait := self createNewTraitNamed: 'NewClass' inCategory: 'XXXXX'.
+	trait := self newTraitNamed: 'NewClass' in: xPackage.
 
 	self createMethodNamed: 'stubMethod' inClass: trait inCategory: 'classic category'.
 
@@ -41,9 +41,9 @@ RPackageMethodsSynchronisationTest >> testAddMethodInClassicCategoryAddMethodToT
 RPackageMethodsSynchronisationTest >> testModifyMethodByMovingFromClassicCategoryToClassicCategoryDoesNothing [
 	"test that when we move a method from a classic category (not begining with *) to another classic category , the packaging keeps the same"
 
-	| class firstPackage |
-	firstPackage := self ensureXPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	| class xPackage |
+	xPackage := self ensureXPackage.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
 
 	"this we do"
@@ -51,46 +51,46 @@ RPackageMethodsSynchronisationTest >> testModifyMethodByMovingFromClassicCategor
 
 	"this we check"
 	self assert: (class >> #stubMethod) protocolName equals: 'new category'.
-	self assert: (firstPackage includesDefinedSelector: #stubMethod ofClass: class).
-	self deny: (firstPackage includesExtensionSelector: #stubMethod ofClass: class).
-	self assert: (class >> #stubMethod) package equals: firstPackage
+	self assert: (xPackage includesDefinedSelector: #stubMethod ofClass: class).
+	self deny: (xPackage includesExtensionSelector: #stubMethod ofClass: class).
+	self assert: (class >> #stubMethod) package equals: xPackage
 ]
 
 { #category : #'tests - operations on methods' }
 RPackageMethodsSynchronisationTest >> testModifyMethodByMovingFromClassicCategoryToExtensionCategoryMoveItFromClassPackageToExtendingPackage [
 	"test that when we move a method from a classic category (not begining with *) to an extension category , the method is moved from the parent package of the class to the extending package"
 
-	| class firstPackage secondPackage |
-	firstPackage := self ensureXPackage.
-	secondPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	| class xPackage yPackage |
+	xPackage := self ensureXPackage.
+	yPackage := self ensureYPackage.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
 
 	class classify: #stubMethod under: '*yyyyy'.
-	self deny: (firstPackage includesDefinedSelector: #stubMethod ofClass: class).
-	self assert: (secondPackage includesExtensionSelector: #stubMethod ofClass: class).
-	self assert: (class >> #stubMethod) package equals: secondPackage.
+	self deny: (xPackage includesDefinedSelector: #stubMethod ofClass: class).
+	self assert: (yPackage includesExtensionSelector: #stubMethod ofClass: class).
+	self assert: (class >> #stubMethod) package equals: yPackage.
 
 	class classify: #stubMethod under: '*yyyyy-subcategory'.
-	self deny: (firstPackage includesDefinedSelector: #stubMethod ofClass: class).
-	self assert: (secondPackage includesExtensionSelector: #stubMethod ofClass: class).
-	self assert: (class >> #stubMethod) package equals: secondPackage
+	self deny: (xPackage includesDefinedSelector: #stubMethod ofClass: class).
+	self assert: (yPackage includesExtensionSelector: #stubMethod ofClass: class).
+	self assert: (class >> #stubMethod) package equals: yPackage
 ]
 
 { #category : #'tests - operations on methods' }
 RPackageMethodsSynchronisationTest >> testModifyMethodByMovingFromExtensionCategoryToClassicCategoryMoveItFromExtendingPackageToClassPackage [
 	"test that when we move a method from an extension category ( begining with *) to a classic category , the method is moved from the extending package to the parent package of the class"
 
-	| class firstPackage secondPackage |
-	firstPackage := self ensureXPackage.
-	secondPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	| class xPackage yPackage |
+	xPackage := self ensureXPackage.
+	yPackage := self ensureYPackage.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 
 	class classify: #stubMethod under: 'classic category'.
-	self assert: (firstPackage includesDefinedSelector: #stubMethod ofClass: class).
-	self deny: (secondPackage includesExtensionSelector: #stubMethod ofClass: class).
-	self assert: (class >> #stubMethod) package equals: firstPackage
+	self assert: (xPackage includesDefinedSelector: #stubMethod ofClass: class).
+	self deny: (yPackage includesExtensionSelector: #stubMethod ofClass: class).
+	self assert: (class >> #stubMethod) package equals: xPackage
 ]
 
 { #category : #'tests - operations on methods' }
@@ -101,7 +101,7 @@ RPackageMethodsSynchronisationTest >> testModifyMethodByMovingFromExtensionCateg
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
 	zPackage := self ensureZPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: #newMethod inClass: class inCategory: '*yyyyy'.
 
 	class classify: #newMethod under: '*zzzzz'.
@@ -117,7 +117,7 @@ RPackageMethodsSynchronisationTest >> testRemoveMethodRemoveMethodFromItsPackage
 
 	| xPackage class |
 	xPackage := self ensureXPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
 
 	class removeSelector: #stubMethod.

--- a/src/Monticello-Tests/RPackageTraitSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageTraitSynchronisationTest.class.st
@@ -15,8 +15,8 @@ RPackageTraitSynchronisationTest >> testAddMethodByUsingATraitDoesNotAddTheMetho
 	| xPackage yPackage class trait |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	trait := self createNewTraitNamed: 'NewTrait' inCategory: 'YYYYY'.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	trait := self newTraitNamed: 'NewTrait' in: yPackage.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: trait inCategory: 'trait category'.
 
 	self assertEmpty: xPackage methods.
@@ -29,39 +29,39 @@ RPackageTraitSynchronisationTest >> testAddMethodByUsingATraitDoesNotAddTheMetho
 { #category : #'tests - operations on traits' }
 RPackageTraitSynchronisationTest >> testAddTraitAddItIntoPackageBestMatchName [
 
-	| tmpPackage class |
-	tmpPackage := self ensureXPackage.
-	self ensureTagYinX.
+	| xPackage tag class |
+	tag := self ensureTagYinX.
+	xPackage := tag package.
 
-	class := self createNewTraitNamed: 'NewClass' inCategory: 'XXXXX-YYYY'.
+	class := self newTraitNamed: 'NewClass' inTag: tag.
 
-	self assert: (tmpPackage definesClass: class).
-	self assert: tmpPackage equals: class package
+	self assert: (xPackage definesClass: class).
+	self assert: xPackage equals: class package
 ]
 
 { #category : #'tests - operations on traits' }
 RPackageTraitSynchronisationTest >> testAddTraitAddItIntoPackageExactName [
 
-	| tmpPackage class |
-	tmpPackage := self ensureXPackage.
+	| xPackage class |
+	xPackage := self ensureXPackage.
 	self ensureTagYinX.
 
-	class := self createNewTraitNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newTraitNamed: 'NewClass' in: xPackage.
 
-	self assert: (tmpPackage definesClass: class).
-	self assert: tmpPackage equals: class package
+	self assert: (xPackage definesClass: class).
+	self assert: xPackage equals: class package
 ]
 
 { #category : #'tests - operations on traits' }
 RPackageTraitSynchronisationTest >> testAddTraitUpdateTheOrganizerMappings [
 	"test that when we add a Trait, the organizer 'classPackageMapping' dictionary is updated, so that the trait is linked to its package and so that we can access its owning package"
 
-	| tmpPackage class |
-	tmpPackage := self ensureXPackage.
+	| xPackage class |
+	xPackage := self ensureXPackage.
 
-	class := self createNewTraitNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newTraitNamed: 'NewClass' in: xPackage.
 
-	self assert: class package equals: tmpPackage
+	self assert: class package equals: xPackage
 ]
 
 { #category : #'tests - operations on methods' }
@@ -72,8 +72,8 @@ RPackageTraitSynchronisationTest >> testRemoveMethodComingFromTraitDoesNotRemove
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	trait := self createNewTraitNamed: 'NewTrait' inCategory: 'YYYYY'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
+	trait := self newTraitNamed: 'NewTrait' in: yPackage.
 
 	self createMethodNamed: 'stubMethod' inClass: trait inCategory: 'classic protocol'.
 	class setTraitComposition: trait asTraitComposition.
@@ -90,8 +90,8 @@ RPackageTraitSynchronisationTest >> testRemoveTraitMethod [
 	| xPackage yPackage class trait |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	trait := self createNewTraitNamed: 'NewTrait' inCategory: 'YYYYY'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
+	trait := self newTraitNamed: 'NewTrait' in: yPackage.
 	self createMethodNamed: 'stubMethod' inClass: trait inCategory: 'classic protocol'.
 	class setTraitComposition: trait asTraitComposition.
 
@@ -108,8 +108,8 @@ RPackageTraitSynchronisationTest >> testRemoveTraitMethodOverridenByClassDoesRem
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	trait := self createNewTraitNamed: 'NewTrait' inCategory: 'YYYYY'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
+	trait := self newTraitNamed: 'NewTrait' in: yPackage.
 
 	self createMethodNamed: 'stubMethod' inClass: trait inCategory: 'classic protocol'.
 	class setTraitComposition: trait asTraitComposition.
@@ -127,8 +127,8 @@ RPackageTraitSynchronisationTest >> testTraitCompositionMethodsArePackagedWithTh
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	trait := self createNewTraitNamed: 'NewTrait' inCategory: 'YYYYY'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
+	trait := self newTraitNamed: 'NewTrait' in: yPackage.
 
 	self createMethodNamed: 'stubMethod' inClass: trait inCategory: 'classic protocol'.
 	class setTraitComposition: trait asTraitComposition.

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -502,7 +502,7 @@ RPackageOrganizer >> packageNamesDo: aBlock [
 { #category : #'package - access from class' }
 RPackageOrganizer >> packageOf: aClass [
 
-	^ classPackageMapping at: aClass instanceSide ifAbsent: [ self packageNamed: RPackage defaultPackageName ]
+	^ classPackageMapping at: aClass instanceSide ifAbsent: [ self defineUnpackagedClassesPackage ]
 ]
 
 { #category : #'package - access from class' }
@@ -597,7 +597,7 @@ RPackageOrganizer >> removeBehavior: behavior [
 
 	| behaviorName |
 	behaviorName := behavior isBehavior
-		                ifTrue: [ behavior name ]
+		                ifTrue: [ behavior originalName ]
 		                ifFalse: [ behavior ].
 
 	categoryMap keysAndValuesDo: [ :category :classes | (classes includes: behaviorName) ifTrue: [ classes remove: behaviorName ] ]

--- a/src/RPackage-Tests/RPackageCompleteSetupButForModificationTest.class.st
+++ b/src/RPackage-Tests/RPackageCompleteSetupButForModificationTest.class.st
@@ -25,11 +25,11 @@ RPackageCompleteSetupButForModificationTest >> setUp [
 	p2 := self organizer ensurePackage: self p2Name.
 	p3 := self organizer ensurePackage: self p3Name.
 
-	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
-	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.
-	a2 := self createNewClassNamed: #A2DefinedInP2 inPackage: p2.
-	b2 := self createNewClassNamed: #B2DefinedInP2 inPackage: p2.
-	a3 := self createNewClassNamed: #A3DefinedInP3 inPackage: p3.
+	a1 := self newClassNamed: #A1DefinedInP1 in: p1.
+	b1 := self newClassNamed: #B1DefinedInP1 in: p1.
+	a2 := self newClassNamed: #A2DefinedInP2 in: p2.
+	b2 := self newClassNamed: #B2DefinedInP2 in: p2.
+	a3 := self newClassNamed: #A3DefinedInP3 in: p3.
 
 	a1 compile: 'methodDefinedInP1 ^ #methodDefinedInP1'.
 	a1 compile: 'anotherMethodDefinedInP1 ^ #anotherMethodDefinedInP1'.

--- a/src/RPackage-Tests/RPackageCompleteSetupButForModificationTest.class.st
+++ b/src/RPackage-Tests/RPackageCompleteSetupButForModificationTest.class.st
@@ -21,9 +21,9 @@ Class {
 RPackageCompleteSetupButForModificationTest >> setUp [
 
 	super setUp.
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
-	p3 := self createNewPackageNamed: self p3Name.
+	p1 := self organizer ensurePackage: self p1Name.
+	p2 := self organizer ensurePackage: self p2Name.
+	p3 := self organizer ensurePackage: self p3Name.
 
 	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
 	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.

--- a/src/RPackage-Tests/RPackageCompleteSetupButForModificationTest.class.st
+++ b/src/RPackage-Tests/RPackageCompleteSetupButForModificationTest.class.st
@@ -57,19 +57,19 @@ RPackageCompleteSetupButForModificationTest >> testAddMethod [
 RPackageCompleteSetupButForModificationTest >> testBasicRemoveClass [
 	"we remove a class we check that it is not in the package anymore"
 
-	|  size |
+	| size |
 	size := p1 definedClasses size.
 	self assert: size equals: 2.
 	self assert: (p1 includesClass: a1).
 	self assert: (p1 includesClass: a1 class).
 	p1 removeClass: a1.
-	self assert: p1 definedClasses size equals: (size - 1).
+	self assert: p1 definedClasses size equals: size - 1.
 	self assert: (p1 includesClass: b1).
 	self assert: (p1 includesClass: b1 class).
 	self deny: (p1 includesClass: a1).
 	self deny: (p1 includesClass: a1 class).
 	p1 removeClass: b1.
-	self assert: p1 definedClasses size equals: (size - 2).
+	self assert: p1 definedClasses size equals: size - 2.
 	self deny: (p1 includesClass: b1).
 	self deny: (p1 includesClass: b1 class)
 ]

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -50,7 +50,7 @@ RPackageIncrementalTest >> testAddRemoveMethod [
 	p1 := self organizer ensurePackage: self p1Name.
 	p2 := self organizer ensurePackage: self p2Name.
 	p3 := self organizer ensurePackage: self p3Name.
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
 	a2 compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2'.
 
 	p2 addMethod: a2 >> #methodDefinedInP2.
@@ -83,7 +83,7 @@ RPackageIncrementalTest >> testAddRemoveSelector [
 	p1 := self organizer ensurePackage: self p1Name.
 	p2 := self organizer ensurePackage: self p2Name.
 	p3 := self organizer ensurePackage: self p3Name.
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
 
 	p2 addMethod: a2 >> (a2 compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2').
 	p1 addMethod: a2 >> (a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1').
@@ -110,7 +110,7 @@ RPackageIncrementalTest >> testClassAddition [
 
 	| p a1 |
 	p := self organizer ensurePackage: self p1Name.
-	a1 := self createNewClassNamed: #A1InPAckageP1 inCategory: self p2Name.
+	a1 := self newClassNamed: #A1InPAckageP1 in: self p2Name.
 	self assertEmpty: p definedClasses.
 	p importClass: a1.
 	self assert: p definedClasses size equals: 1.
@@ -123,8 +123,8 @@ RPackageIncrementalTest >> testClassDefinitionRemoval [
 
 	| p a1 b1 |
 	p := self organizer ensurePackage: self p1Name.
-	a1 := self createNewClassNamed: #A1InPAckageP1 inCategory: self p2Name.
-	b1 := self createNewClassNamed: #B1InPAckageP1 inCategory: self p2Name.
+	a1 := self newClassNamed: #A1InPAckageP1 in: self p2Name.
+	b1 := self newClassNamed: #B1InPAckageP1 in: self p2Name.
 	self assertEmpty: p definedClasses.
 
 	p importClass: a1.
@@ -149,8 +149,8 @@ RPackageIncrementalTest >> testClassDefinitionWithTagsRemoval [
 	| p a1 b1 |
 	p := self organizer ensurePackage: self p1Name.
 
-	a1 := self createNewClassNamed: #A1InPAckageP1 inPackage: p.
-	b1 := self createNewClassNamed: #B1InPAckageP1 inPackage: p.
+	a1 := self newClassNamed: #A1InPAckageP1 in: p.
+	b1 := self newClassNamed: #B1InPAckageP1 in: p.
 	self assert: p definedClasses size equals: 2.
 
 	p importClass: a1 inTag: 'a1-tag'.
@@ -175,12 +175,12 @@ RPackageIncrementalTest >> testDefinedClassesAndDefinedClassNames [
 
 	| p a1 b1 |
 	p := self organizer ensurePackage: self p1Name.
-	a1 := self createNewClassNamed: #A1InPackageP1 inPackage: p.
+	a1 := self newClassNamed: #A1InPackageP1 in: p.
 	self assert: p definedClasses size equals: 1.
 	self assert: (p definedClasses includes: a1).
 	self assert: (p definedClassNames includes: a1 name).
 
-	b1 := self createNewClassNamed: #B1InPackageP1 inPackage: p.
+	b1 := self newClassNamed: #B1InPackageP1 in: p.
 	self assert: p definedClasses size equals: 2.
 	self assert: (p definedClasses includes: b1).
 	self assert: (p definedClassNames includes: b1 name)
@@ -192,8 +192,8 @@ RPackageIncrementalTest >> testExtensionClassNames [
 	| p1 p2 a2 b2 |
 	p1 := self organizer ensurePackage: self p1Name.
 	p2 := self organizer ensurePackage: self p2Name.
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
-	b2 := self createNewClassNamed: #B2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
+	b2 := self newClassNamed: #B2InPackageP2 in: p2.
 	self deny: (p1 includesClass: a2).
 	self assert: (p2 includesClass: b2).
 	self assert: (p2 includesClass: a2).
@@ -228,8 +228,8 @@ RPackageIncrementalTest >> testExtensionClasses [
 	p1 := self organizer ensurePackage: self p1Name.
 	p2 := self organizer ensurePackage: self p2Name.
 
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
-	b2 := self createNewClassNamed: #B2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
+	b2 := self newClassNamed: #B2InPackageP2 in: p2.
 	self deny: (p1 includesClass: a2).
 	self assert: (p2 includesClass: a2).
 
@@ -256,8 +256,8 @@ RPackageIncrementalTest >> testExtensionClassesWithCompiledMethod [
 	| p1 p2 a2 b2 |
 	p1 := self organizer ensurePackage: self p1Name.
 	p2 := self organizer ensurePackage: self p2Name.
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
-	b2 := self createNewClassNamed: #B2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
+	b2 := self newClassNamed: #B2InPackageP2 in: p2.
 	self deny: (p1 includesClass: a2).
 	self assert: (p2 includesClass: b2).
 	self assert: (p2 includesClass: b2).
@@ -292,8 +292,8 @@ RPackageIncrementalTest >> testExtensionMethods [
 	p1 := self organizer ensurePackage: self p1Name.
 	p2 := self organizer ensurePackage: self p2Name.
 
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
-	b2 := self createNewClassNamed: #B2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
+	b2 := self newClassNamed: #B2InPackageP2 in: p2.
 	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
 
 	self assert: p1 extensionSelectors size equals: 1.
@@ -309,11 +309,11 @@ RPackageIncrementalTest >> testImportClassNoDuplicate [
 
 	| p a1 b1 |
 	p := self organizer ensurePackage: self p1Name.
-	a1 := self createNewClassNamed: #A1InPackageP1 inCategory: self p2Name.
+	a1 := self newClassNamed: #A1InPackageP1 in: self p2Name.
 	self assertEmpty: p definedClasses.
 	p importClass: a1.
 	self assert: p definedClasses size equals: 1.
-	b1 := self createNewClassNamed: #B1InPackageP1 inCategory: self p2Name.
+	b1 := self newClassNamed: #B1InPackageP1 in: self p2Name.
 	p importClass: a1.
 	"adding the same class does not do anything - luckily"
 	self assert: p definedClasses size equals: 1.
@@ -328,7 +328,7 @@ RPackageIncrementalTest >> testIncludeClass [
 	p1 := self organizer ensurePackage: self p1Name.
 	p2 := self organizer ensurePackage: self p2Name.
 
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
 	a2 compile: 'methodPackagedInP1 ^ #methodPackagedInP1' classified: '*' , p1 name.
 
 	self deny: (p1 includesClass: a2).
@@ -350,7 +350,7 @@ RPackageIncrementalTest >> testIncludeClassMore [
 	p1 := self organizer ensurePackage: self p1Name.
 	p2 := self organizer ensurePackage: self p2Name.
 	p3 := self organizer ensurePackage: self p3Name.
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
 	a2 compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
 	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
 	a2 compile: 'methodDefinedInP3 ^ #methodDefinedInP3' classified: '*' , p3 name.
@@ -367,7 +367,7 @@ RPackageIncrementalTest >> testIncludeSelectorOfClass [
 	p1 := self organizer ensurePackage: self p1Name.
 	p2 := self organizer ensurePackage: self p2Name.
 	p3 := self organizer ensurePackage: self p3Name.
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
 	a2 compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
 	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
 	a2 compile: 'methodDefinedInP3 ^ #methodDefinedInP3' classified: '*' , p3 name.
@@ -393,7 +393,7 @@ RPackageIncrementalTest >> testIncludeSelectorOfMetaClass [
 	p1 := self organizer ensurePackage: self p1Name.
 	p2 := self organizer ensurePackage: self p2Name.
 	p3 := self organizer ensurePackage: self p3Name.
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
 	a2 class compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
 	a2 class compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
 	a2 class compile: 'methodDefinedInP3 ^ #methodDefinedInP3' classified: '*' , p3 name.
@@ -420,7 +420,7 @@ RPackageIncrementalTest >> testIncludesMethodOfClassInPresenceOfOtherPackageExte
 	p1 := self organizer ensurePackage: self p1Name.
 	p2 := self organizer ensurePackage: self p2Name.
 	p3 := self organizer ensurePackage: self p3Name.
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
 
 	a2 compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
 	self assert: (p2 includesDefinedSelector: #methodDefinedInP2 ofClass: a2).
@@ -445,7 +445,7 @@ RPackageIncrementalTest >> testIncludesOrTouches [
 	p1 := self organizer ensurePackage: self p1Name.
 	p2 := self organizer ensurePackage: self p2Name.
 
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
 	self deny: (p1 includesClass: a2).
 	self assert: (p2 includesClass: a2).
 
@@ -463,7 +463,7 @@ RPackageIncrementalTest >> testMethodAddition [
 
 	| p1 a1 |
 	p1 := self organizer ensurePackage: self p1Name.
-	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
+	a1 := self newClassNamed: #A1DefinedInP1 in: p1.
 	a1 compileSilently: 'foo ^ 10'.
 	p1 addMethod: a1 >> #foo.
 	self assert: (p1 includesSelector: #foo ofClass: a1)
@@ -474,7 +474,7 @@ RPackageIncrementalTest >> testMethodPackageResolution [
 
 	| p1 a1 |
 	p1 := self organizer ensurePackage: self p1Name.
-	a1 := self createNewClassNamed: #A2InPackageP1 inPackage: p1.
+	a1 := self newClassNamed: #A2InPackageP1 in: p1.
 	a1 compile: 'method ^ #methodDefinedInP1'.
 	a1 class compile: 'method ^ #methodDefinedInP1'.
 
@@ -489,7 +489,7 @@ RPackageIncrementalTest >> testPackageOfClassForClassesNotDefinedInPackageButJus
 	p1 := self organizer ensurePackage: self p1Name.
 	p2 := self organizer ensurePackage: self p2Name.
 
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
 	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
 
 	self assert: a2 package equals: p2.
@@ -503,8 +503,8 @@ RPackageIncrementalTest >> testPackageOfClassForDefinedClasses [
 
 	| p a1 b1 |
 	p := self organizer ensurePackage: self p1Name.
-	a1 := self createNewClassNamed: #A1InPAckageP1 inPackage: p.
-	b1 := self createNewClassNamed: #B1InPAckageP1 inPackage: p.
+	a1 := self newClassNamed: #A1InPAckageP1 in: p.
+	b1 := self newClassNamed: #B1InPAckageP1 in: p.
 
 	self assert: a1 package equals: p.
 	self assert: b1 package equals: p
@@ -517,7 +517,7 @@ RPackageIncrementalTest >> testRemoveClassRemovesExtensions [
 	p1 := self organizer ensurePackage: self p1Name.
 	p2 := self organizer ensurePackage: self p2Name.
 	"the class is created but not added to the package for now"
-	a1 := self createNewClassNamed: #A1InPackageP1 inPackage: p1.
+	a1 := self newClassNamed: #A1InPackageP1 in: p1.
 	self assert: p1 definedClasses size equals: 1.
 	a1 compile: 'methodDefinedInP2 ^ #methodDefinedInP2' classified: '*' , p2 name.
 
@@ -538,7 +538,7 @@ RPackageIncrementalTest >> testRemoveExtensionMethodRemovesExtensionsFromPackage
 	p1 := self organizer ensurePackage: self p1Name.
 	p2 := self organizer ensurePackage: self p2Name.
 	"the class is created but not added to the package for now"
-	a1 := self createNewClassNamed: #A1InPackageP1 inPackage: p1.
+	a1 := self newClassNamed: #A1InPackageP1 in: p1.
 	self assert: p1 definedClasses size equals: 1.
 	a1 compile: 'methodDefinedInP2 ^ #methodDefinedInP2' classified: '*' , p2 name.
 
@@ -559,8 +559,8 @@ RPackageIncrementalTest >> testTwoClassesWithExtensions [
 	p1 := self organizer ensurePackage: self p1Name.
 	p2 := self organizer ensurePackage: self p2Name.
 
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
-	b2 := self createNewClassNamed: #B2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
+	b2 := self newClassNamed: #B2InPackageP2 in: p2.
 	a2 compile: 'methodPackagedInP1 ^ #methodPackagedInP1' classified: '*' , p1 name.
 	b2 class compile: 'methodPackagedInP1 ^ #methodPackagedInP1' classified: '*' , p1 name.
 
@@ -573,7 +573,7 @@ RPackageIncrementalTest >> testUniqueClassInDefinedClassesUsingAddClassDefinitio
 
 	| p a1 |
 	p := self organizer ensurePackage: self p1Name.
-	a1 := self createNewClassNamed: #A1InPAckageP1 inCategory: self p2Name.
+	a1 := self newClassNamed: #A1InPAckageP1 in: self p2Name.
 	self assertEmpty: p definedClasses.
 	p importClass: a1.
 	self assert: p definedClasses size equals: 1.

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -37,30 +37,10 @@ RPackageIncrementalTest >> p3Name [
 	^ 'RPackageTestP3'
 ]
 
-{ #category : #utilities }
-RPackageIncrementalTest >> removeClassNamedIfExists: aClassNameSymbol [
-	testingEnvironment at: aClassNameSymbol asSymbol ifPresent: [:c| c removeFromSystem]
-]
-
 { #category : #running }
 RPackageIncrementalTest >> setUp [
 	super setUp.
 	Author fullName ifNil: [Author fullName: 'RPackage']
-]
-
-{ #category : #running }
-RPackageIncrementalTest >> tearDown [
-
-	createdPackages do: [ :package | self removePackage: package ].
-	"just remove package from package organizer dictionary"
-
-	createdPackages do: [ :each |
-		self allWorkingCopies
-			detect: [ :mcPackage | mcPackage packageName = each packageName asString ]
-			ifFound: [ :mcPackage | mcPackage unregister ].
-		each extendedClasses do: [ :extendedClass | self organizer unregisterExtendingPackage: each forClass: extendedClass ] ].
-	"all ***extending*** classes the packages are also unregistered from PackageOrganizer"
-	super tearDown
 ]
 
 { #category : #'tests - method addition removal' }
@@ -130,7 +110,7 @@ RPackageIncrementalTest >> testClassAddition [
 
 	| p a1 |
 	p := self createNewPackageNamed: self p1Name.
-	a1 := self createNewClassNamed: #A1InPAckageP1.
+	a1 := self createNewClassNamed: #A1InPAckageP1 inCategory: self p2Name.
 	self assertEmpty: p definedClasses.
 	p importClass: a1.
 	self assert: p definedClasses size equals: 1.
@@ -143,8 +123,8 @@ RPackageIncrementalTest >> testClassDefinitionRemoval [
 
 	| p a1 b1 |
 	p := self createNewPackageNamed: self p1Name.
-	a1 := self createNewClassNamed: #A1InPAckageP1.
-	b1 := self createNewClassNamed: #B1InPAckageP1.
+	a1 := self createNewClassNamed: #A1InPAckageP1 inCategory: self p2Name.
+	b1 := self createNewClassNamed: #B1InPAckageP1 inCategory: self p2Name.
 	self assertEmpty: p definedClasses.
 
 	p importClass: a1.
@@ -329,11 +309,11 @@ RPackageIncrementalTest >> testImportClassNoDuplicate [
 
 	| p a1 b1 |
 	p := self createNewPackageNamed: self p1Name.
-	a1 := self createNewClassNamed: #A1InPackageP1.
+	a1 := self createNewClassNamed: #A1InPackageP1 inCategory: self p2Name.
 	self assertEmpty: p definedClasses.
 	p importClass: a1.
 	self assert: p definedClasses size equals: 1.
-	b1 := self createNewClassNamed: #B1InPackageP1.
+	b1 := self createNewClassNamed: #B1InPackageP1 inCategory: self p2Name.
 	p importClass: a1.
 	"adding the same class does not do anything - luckily"
 	self assert: p definedClasses size equals: 1.
@@ -593,7 +573,7 @@ RPackageIncrementalTest >> testUniqueClassInDefinedClassesUsingAddClassDefinitio
 
 	| p a1 |
 	p := self createNewPackageNamed: self p1Name.
-	a1 := self createNewClassNamed: #A1InPAckageP1.
+	a1 := self createNewClassNamed: #A1InPAckageP1 inCategory: self p2Name.
 	self assertEmpty: p definedClasses.
 	p importClass: a1.
 	self assert: p definedClasses size equals: 1.

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -47,9 +47,9 @@ RPackageIncrementalTest >> setUp [
 RPackageIncrementalTest >> testAddRemoveMethod [
 
 	| p1 p2 p3 a2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
-	p3 := self createNewPackageNamed: self p3Name.
+	p1 := self organizer ensurePackage: self p1Name.
+	p2 := self organizer ensurePackage: self p2Name.
+	p3 := self organizer ensurePackage: self p3Name.
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	a2 compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2'.
 
@@ -80,9 +80,9 @@ RPackageIncrementalTest >> testAddRemoveMethod [
 RPackageIncrementalTest >> testAddRemoveSelector [
 
 	| p1 p2 p3 a2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
-	p3 := self createNewPackageNamed: self p3Name.
+	p1 := self organizer ensurePackage: self p1Name.
+	p2 := self organizer ensurePackage: self p2Name.
+	p3 := self organizer ensurePackage: self p3Name.
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 
 	p2 addMethod: a2 >> (a2 compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2').
@@ -109,7 +109,7 @@ RPackageIncrementalTest >> testAddRemoveSelector [
 RPackageIncrementalTest >> testClassAddition [
 
 	| p a1 |
-	p := self createNewPackageNamed: self p1Name.
+	p := self organizer ensurePackage: self p1Name.
 	a1 := self createNewClassNamed: #A1InPAckageP1 inCategory: self p2Name.
 	self assertEmpty: p definedClasses.
 	p importClass: a1.
@@ -122,7 +122,7 @@ RPackageIncrementalTest >> testClassAddition [
 RPackageIncrementalTest >> testClassDefinitionRemoval [
 
 	| p a1 b1 |
-	p := self createNewPackageNamed: self p1Name.
+	p := self organizer ensurePackage: self p1Name.
 	a1 := self createNewClassNamed: #A1InPAckageP1 inCategory: self p2Name.
 	b1 := self createNewClassNamed: #B1InPAckageP1 inCategory: self p2Name.
 	self assertEmpty: p definedClasses.
@@ -147,7 +147,7 @@ RPackageIncrementalTest >> testClassDefinitionRemoval [
 RPackageIncrementalTest >> testClassDefinitionWithTagsRemoval [
 
 	| p a1 b1 |
-	p := self createNewPackageNamed: self p1Name.
+	p := self organizer ensurePackage: self p1Name.
 
 	a1 := self createNewClassNamed: #A1InPAckageP1 inPackage: p.
 	b1 := self createNewClassNamed: #B1InPAckageP1 inPackage: p.
@@ -174,7 +174,7 @@ RPackageIncrementalTest >> testClassDefinitionWithTagsRemoval [
 RPackageIncrementalTest >> testDefinedClassesAndDefinedClassNames [
 
 	| p a1 b1 |
-	p := self createNewPackageNamed: self p1Name.
+	p := self organizer ensurePackage: self p1Name.
 	a1 := self createNewClassNamed: #A1InPackageP1 inPackage: p.
 	self assert: p definedClasses size equals: 1.
 	self assert: (p definedClasses includes: a1).
@@ -190,8 +190,8 @@ RPackageIncrementalTest >> testDefinedClassesAndDefinedClassNames [
 RPackageIncrementalTest >> testExtensionClassNames [
 
 	| p1 p2 a2 b2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
+	p1 := self organizer ensurePackage: self p1Name.
+	p2 := self organizer ensurePackage: self p2Name.
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	b2 := self createNewClassNamed: #B2InPackageP2 inPackage: p2.
 	self deny: (p1 includesClass: a2).
@@ -225,8 +225,8 @@ RPackageIncrementalTest >> testExtensionClassNames [
 RPackageIncrementalTest >> testExtensionClasses [
 
 	| p1 p2 a2 b2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
+	p1 := self organizer ensurePackage: self p1Name.
+	p2 := self organizer ensurePackage: self p2Name.
 
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	b2 := self createNewClassNamed: #B2InPackageP2 inPackage: p2.
@@ -254,8 +254,8 @@ RPackageIncrementalTest >> testExtensionClasses [
 RPackageIncrementalTest >> testExtensionClassesWithCompiledMethod [
 
 	| p1 p2 a2 b2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
+	p1 := self organizer ensurePackage: self p1Name.
+	p2 := self organizer ensurePackage: self p2Name.
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	b2 := self createNewClassNamed: #B2InPackageP2 inPackage: p2.
 	self deny: (p1 includesClass: a2).
@@ -289,8 +289,8 @@ RPackageIncrementalTest >> testExtensionClassesWithCompiledMethod [
 RPackageIncrementalTest >> testExtensionMethods [
 
 	| p1 p2 a2 b2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
+	p1 := self organizer ensurePackage: self p1Name.
+	p2 := self organizer ensurePackage: self p2Name.
 
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	b2 := self createNewClassNamed: #B2InPackageP2 inPackage: p2.
@@ -308,7 +308,7 @@ RPackageIncrementalTest >> testExtensionMethods [
 RPackageIncrementalTest >> testImportClassNoDuplicate [
 
 	| p a1 b1 |
-	p := self createNewPackageNamed: self p1Name.
+	p := self organizer ensurePackage: self p1Name.
 	a1 := self createNewClassNamed: #A1InPackageP1 inCategory: self p2Name.
 	self assertEmpty: p definedClasses.
 	p importClass: a1.
@@ -325,8 +325,8 @@ RPackageIncrementalTest >> testImportClassNoDuplicate [
 RPackageIncrementalTest >> testIncludeClass [
 
 	| p1 p2 a2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
+	p1 := self organizer ensurePackage: self p1Name.
+	p2 := self organizer ensurePackage: self p2Name.
 
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	a2 compile: 'methodPackagedInP1 ^ #methodPackagedInP1' classified: '*' , p1 name.
@@ -347,9 +347,9 @@ RPackageIncrementalTest >> testIncludeClass [
 RPackageIncrementalTest >> testIncludeClassMore [
 
 	| p1 p2 p3 a2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
-	p3 := self createNewPackageNamed: self p3Name.
+	p1 := self organizer ensurePackage: self p1Name.
+	p2 := self organizer ensurePackage: self p2Name.
+	p3 := self organizer ensurePackage: self p3Name.
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	a2 compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
 	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
@@ -364,9 +364,9 @@ RPackageIncrementalTest >> testIncludeClassMore [
 RPackageIncrementalTest >> testIncludeSelectorOfClass [
 
 	| p1 p2 p3 a2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
-	p3 := self createNewPackageNamed: self p3Name.
+	p1 := self organizer ensurePackage: self p1Name.
+	p2 := self organizer ensurePackage: self p2Name.
+	p3 := self organizer ensurePackage: self p3Name.
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	a2 compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
 	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
@@ -390,9 +390,9 @@ RPackageIncrementalTest >> testIncludeSelectorOfClass [
 RPackageIncrementalTest >> testIncludeSelectorOfMetaClass [
 
 	| p1 p2 p3 a2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
-	p3 := self createNewPackageNamed: self p3Name.
+	p1 := self organizer ensurePackage: self p1Name.
+	p2 := self organizer ensurePackage: self p2Name.
+	p3 := self organizer ensurePackage: self p3Name.
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	a2 class compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
 	a2 class compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
@@ -417,9 +417,9 @@ RPackageIncrementalTest >> testIncludeSelectorOfMetaClass [
 RPackageIncrementalTest >> testIncludesMethodOfClassInPresenceOfOtherPackageExtensions [
 
 	| p1 p2 p3 a2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
-	p3 := self createNewPackageNamed: self p3Name.
+	p1 := self organizer ensurePackage: self p1Name.
+	p2 := self organizer ensurePackage: self p2Name.
+	p3 := self organizer ensurePackage: self p3Name.
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 
 	a2 compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
@@ -442,8 +442,8 @@ RPackageIncrementalTest >> testIncludesMethodOfClassInPresenceOfOtherPackageExte
 RPackageIncrementalTest >> testIncludesOrTouches [
 
 	| p1 p2 a2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
+	p1 := self organizer ensurePackage: self p1Name.
+	p2 := self organizer ensurePackage: self p2Name.
 
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	self deny: (p1 includesClass: a2).
@@ -462,7 +462,7 @@ RPackageIncrementalTest >> testIncludesOrTouches [
 RPackageIncrementalTest >> testMethodAddition [
 
 	| p1 a1 |
-	p1 := self createNewPackageNamed: self p1Name.
+	p1 := self organizer ensurePackage: self p1Name.
 	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
 	a1 compileSilently: 'foo ^ 10'.
 	p1 addMethod: a1 >> #foo.
@@ -473,7 +473,7 @@ RPackageIncrementalTest >> testMethodAddition [
 RPackageIncrementalTest >> testMethodPackageResolution [
 
 	| p1 a1 |
-	p1 := self createNewPackageNamed: self p1Name.
+	p1 := self organizer ensurePackage: self p1Name.
 	a1 := self createNewClassNamed: #A2InPackageP1 inPackage: p1.
 	a1 compile: 'method ^ #methodDefinedInP1'.
 	a1 class compile: 'method ^ #methodDefinedInP1'.
@@ -486,8 +486,8 @@ RPackageIncrementalTest >> testMethodPackageResolution [
 RPackageIncrementalTest >> testPackageOfClassForClassesNotDefinedInPackageButJustExtendingIt [
 
 	| p1 p2 a2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
+	p1 := self organizer ensurePackage: self p1Name.
+	p2 := self organizer ensurePackage: self p2Name.
 
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
@@ -502,7 +502,7 @@ RPackageIncrementalTest >> testPackageOfClassForClassesNotDefinedInPackageButJus
 RPackageIncrementalTest >> testPackageOfClassForDefinedClasses [
 
 	| p a1 b1 |
-	p := self createNewPackageNamed: self p1Name.
+	p := self organizer ensurePackage: self p1Name.
 	a1 := self createNewClassNamed: #A1InPAckageP1 inPackage: p.
 	b1 := self createNewClassNamed: #B1InPAckageP1 inPackage: p.
 
@@ -514,8 +514,8 @@ RPackageIncrementalTest >> testPackageOfClassForDefinedClasses [
 RPackageIncrementalTest >> testRemoveClassRemovesExtensions [
 
 	| p1 p2 a1 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
+	p1 := self organizer ensurePackage: self p1Name.
+	p2 := self organizer ensurePackage: self p2Name.
 	"the class is created but not added to the package for now"
 	a1 := self createNewClassNamed: #A1InPackageP1 inPackage: p1.
 	self assert: p1 definedClasses size equals: 1.
@@ -535,8 +535,8 @@ RPackageIncrementalTest >> testRemoveClassRemovesExtensions [
 RPackageIncrementalTest >> testRemoveExtensionMethodRemovesExtensionsFromPackage [
 
 	| p1 p2 a1 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
+	p1 := self organizer ensurePackage: self p1Name.
+	p2 := self organizer ensurePackage: self p2Name.
 	"the class is created but not added to the package for now"
 	a1 := self createNewClassNamed: #A1InPackageP1 inPackage: p1.
 	self assert: p1 definedClasses size equals: 1.
@@ -556,8 +556,8 @@ RPackageIncrementalTest >> testRemoveExtensionMethodRemovesExtensionsFromPackage
 RPackageIncrementalTest >> testTwoClassesWithExtensions [
 
 	| p1 p2 a2 b2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
+	p1 := self organizer ensurePackage: self p1Name.
+	p2 := self organizer ensurePackage: self p2Name.
 
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	b2 := self createNewClassNamed: #B2InPackageP2 inPackage: p2.
@@ -572,7 +572,7 @@ RPackageIncrementalTest >> testTwoClassesWithExtensions [
 RPackageIncrementalTest >> testUniqueClassInDefinedClassesUsingAddClassDefinition [
 
 	| p a1 |
-	p := self createNewPackageNamed: self p1Name.
+	p := self organizer ensurePackage: self p1Name.
 	a1 := self createNewClassNamed: #A1InPAckageP1 inCategory: self p2Name.
 	self assertEmpty: p definedClasses.
 	p importClass: a1.

--- a/src/RPackage-Tests/RPackageObsoleteTest.class.st
+++ b/src/RPackage-Tests/RPackageObsoleteTest.class.st
@@ -22,7 +22,7 @@ RPackageObsoleteTest >> testAnnouncementClassRemovedIsRaisedOnRemoveFromSystem [
 	[
 	notRun := false.
 	SystemAnnouncer uniqueInstance weak when: ClassRemoved send: #setNotRun to: self.
-	foo := self createNewClassNamed: #FooForTest2  inCategory: self p1Name.
+	foo := self newClassNamed: #FooForTest2 in: self p1Name.
 	self deny: notRun.
 	foo removeFromSystem.
 	self assert: notRun ] ensure: [ SystemAnnouncer uniqueInstance unsubscribe: self ]
@@ -33,7 +33,7 @@ RPackageObsoleteTest >> testMethodPackageFromObsoleteClass [
 
 	| pack method foo |
 	pack := self organizer ensurePackage: 'P1'.
-	foo := self createNewClassNamed: #FooForTest inPackage: pack.
+	foo := self newClassNamed: #FooForTest in: pack.
 	foo compile: 'bar ^42'.
 	method := foo >> #bar.
 
@@ -46,7 +46,7 @@ RPackageObsoleteTest >> testMethodPackageOfRemovedClass [
 
 	| pack method foo |
 	pack := self organizer ensurePackage: 'P1'.
-	foo := self createNewClassNamed: #FooForTest2 inPackage: pack.
+	foo := self newClassNamed: #FooForTest2 in: pack.
 	foo compile: 'bar ^42'.
 	method := foo >> #bar.
 	foo removeFromSystem.

--- a/src/RPackage-Tests/RPackageObsoleteTest.class.st
+++ b/src/RPackage-Tests/RPackageObsoleteTest.class.st
@@ -32,7 +32,7 @@ RPackageObsoleteTest >> testAnnouncementClassRemovedIsRaisedOnRemoveFromSystem [
 RPackageObsoleteTest >> testMethodPackageFromObsoleteClass [
 
 	| pack method foo |
-	pack := self createNewPackageNamed: 'P1'.
+	pack := self organizer ensurePackage: 'P1'.
 	foo := self createNewClassNamed: #FooForTest inPackage: pack.
 	foo compile: 'bar ^42'.
 	method := foo >> #bar.
@@ -45,7 +45,7 @@ RPackageObsoleteTest >> testMethodPackageFromObsoleteClass [
 RPackageObsoleteTest >> testMethodPackageOfRemovedClass [
 
 	| pack method foo |
-	pack := self createNewPackageNamed: 'P1'.
+	pack := self organizer ensurePackage: 'P1'.
 	foo := self createNewClassNamed: #FooForTest2 inPackage: pack.
 	foo compile: 'bar ^42'.
 	method := foo >> #bar.

--- a/src/RPackage-Tests/RPackageObsoleteTest.class.st
+++ b/src/RPackage-Tests/RPackageObsoleteTest.class.st
@@ -22,7 +22,7 @@ RPackageObsoleteTest >> testAnnouncementClassRemovedIsRaisedOnRemoveFromSystem [
 	[
 	notRun := false.
 	SystemAnnouncer uniqueInstance weak when: ClassRemoved send: #setNotRun to: self.
-	foo := self createNewClassNamed: #FooForTest2.
+	foo := self createNewClassNamed: #FooForTest2  inCategory: self p1Name.
 	self deny: notRun.
 	foo removeFromSystem.
 	self assert: notRun ] ensure: [ SystemAnnouncer uniqueInstance unsubscribe: self ]
@@ -32,18 +32,13 @@ RPackageObsoleteTest >> testAnnouncementClassRemovedIsRaisedOnRemoveFromSystem [
 RPackageObsoleteTest >> testMethodPackageFromObsoleteClass [
 
 	| pack method foo |
-	[
 	pack := self createNewPackageNamed: 'P1'.
 	foo := self createNewClassNamed: #FooForTest inPackage: pack.
 	foo compile: 'bar ^42'.
 	method := foo >> #bar.
 
 	foo obsolete.
-	self assert: method package equals: foo package ] ensure: [
-		foo ifNotNil: [
-			foo setName: foo originalName.
-			foo removeFromSystem ].
-		testingEnvironment removeKey: #FooForTest ifAbsent: [  ] ]
+	self assert: method package equals: foo package
 ]
 
 { #category : #tests }

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -17,6 +17,12 @@ RPackageOrganizerTest class >> removeClassNamedIfExists: aClassNameSymbol [
 	self environment at: aClassNameSymbol asSymbol ifPresent: [ :c | c removeFromSystem ]
 ]
 
+{ #category : #utilities }
+RPackageOrganizerTest >> createMockTestPackages [
+
+	^ #( 'MockPackage-Tests' 'MockPackage-tests' 'MockPackage' 'MockPackage-Tests-Package' ) collect: [ :pName | self organizer ensurePackage: pName ]
+]
+
 { #category : #tests }
 RPackageOrganizerTest >> p1Name [
 	^ 'RPackageTestP1'

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -71,7 +71,7 @@ RPackageOrganizerTest >> testDefinedClassesInstanceAndMetaSideAPI [
 
 	| p1 |
 	p1 := self organizer ensurePackage: self p1Name.
-	self createNewClassNamed: #MyPoint inPackage: p1.
+	self newClassNamed: #MyPoint in: p1.
 	self assert: self organizer packageNames size equals: 2.
 	self assert: self organizer packages size equals: 2.
 	self assert: (self organizer packageNamed: self p1Name) definedClasses size equals: 1
@@ -91,7 +91,7 @@ RPackageOrganizerTest >> testExtensionMethodNotExactlyTheName [
 	p1 := self organizer ensurePackage: 'P1'.
 	p2 := self organizer ensurePackage: 'P2'.
 
-	c1 := self createNewClassNamed: #C1 inPackage: p2.
+	c1 := self newClassNamed: #C1 in: p2.
 
 	c1 compileSilently: 'methodPackagedInP1 ^ #methodPackagedInP1' classified: '*p1-something'.
 	self organizer addMethod: c1 >> #methodPackagedInP1.
@@ -109,11 +109,11 @@ RPackageOrganizerTest >> testFullRegistration [
 	p2 := self organizer ensurePackage: self p2Name.
 	p3 := self organizer ensurePackage: self p3Name.
 
-	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
-	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.
-	a2 := self createNewClassNamed: #A2DefinedInP2 inPackage: p2.
-	b2 := self createNewClassNamed: #B2DefinedInP2 inPackage: p2.
-	a3 := self createNewClassNamed: #A3DefinedInP3 inPackage: p3.
+	a1 := self newClassNamed: #A1DefinedInP1 in: p1.
+	b1 := self newClassNamed: #B1DefinedInP1 in: p1.
+	a2 := self newClassNamed: #A2DefinedInP2 in: p2.
+	b2 := self newClassNamed: #B2DefinedInP2 in: p2.
+	a3 := self newClassNamed: #A3DefinedInP3 in: p3.
 
 	a1 compile: 'methodDefinedInP1 ^ #methodDefinedInP1'.
 	a1 compile: 'anotherMethodDefinedInP1 ^ #anotherMethodDefinedInP1'.
@@ -218,7 +218,7 @@ RPackageOrganizerTest >> testRegisteredPackages [
 RPackageOrganizerTest >> testRegistrationExtendingPackages [
 
 	| p |
-	self createNewClassNamed: 'QuadrangleForTesting' inCategory: self class category.
+	self newClassNamed: 'QuadrangleForTesting' in: self class package.
 	self assertEmpty: (self organizer extendingPackagesOf: self quadrangleClass).
 	p := self organizer ensurePackage: 'P1'.
 	self organizer registerExtendingPackage: p forClass: self quadrangleClass.
@@ -242,10 +242,10 @@ RPackageOrganizerTest >> testRemoveEmptyPackagesAndTags [
 	tag1 := package3 ensureTag: #Tag1.
 	tag2 := package3 ensureTag: #Tag2.
 
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1'.
+	class := self newClassNamed: 'TestClass' in: 'Test1'.
 	class compile: 'extension ^ 1' classified: '*Test2'.
 
-	class := self createNewClassNamed: 'TestClass2' inCategory: 'Test3-Tag1'.
+	class := self newClassNamed: 'TestClass2' inTag: tag1.
 
 	self flag: #package. "Use the organizer provided by the tests later."
 	organizer := package1 organizer.
@@ -282,11 +282,11 @@ RPackageOrganizerTest >> testRemovePackage [
 	p2 := self organizer ensurePackage: self p2Name.
 	p3 := self organizer ensurePackage: self p3Name.
 
-	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
-	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.
-	a2 := self createNewClassNamed: #A2DefinedInP2 inPackage: p2.
-	b2 := self createNewClassNamed: #B2DefinedInP2 inPackage: p2.
-	a3 := self createNewClassNamed: #A3DefinedInP3 inPackage: p3.
+	a1 := self newClassNamed: #A1DefinedInP1 in: p1.
+	b1 := self newClassNamed: #B1DefinedInP1 in: p1.
+	a2 := self newClassNamed: #A2DefinedInP2 in: p2.
+	b2 := self newClassNamed: #B2DefinedInP2 in: p2.
+	a3 := self newClassNamed: #A3DefinedInP3 in: p3.
 
 	a1 compile: 'methodDefinedInP1 ^ #methodDefinedInP1'.
 	a1 compile: 'anotherMethodDefinedInP1 ^ #anotherMethodDefinedInP1'.
@@ -370,7 +370,7 @@ RPackageOrganizerTest >> testUnregister [
 RPackageOrganizerTest >> testUnregistrationExtendingPackages [
 
 	| p |
-	self createNewClassNamed: 'QuadrangleForTesting' inCategory: self class category.
+	self newClassNamed: 'QuadrangleForTesting' in: self class package.
 	p := self organizer ensurePackage: 'P1'.
 	self organizer registerExtendingPackage: p forClass: self quadrangleClass.
 	self denyEmpty: (self organizer extendingPackagesOf: self quadrangleClass).

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -41,7 +41,7 @@ RPackageOrganizerTest >> quadrangleClass [
 RPackageOrganizerTest >> testAccessingPackage [
 
 	| p1 |
-	p1 := self createNewPackageNamed: 'P1'.
+	p1 := self organizer ensurePackage: 'P1'.
 	self assert: (self organizer packageNamed: #P1) equals: p1.
 	self should: [ self organizer packageNamed: #P22 ] raise: Error
 ]
@@ -64,7 +64,7 @@ RPackageOrganizerTest >> testCreateNewPackageWithoutConflictCreatesPackage [
 RPackageOrganizerTest >> testDefinedClassesInstanceAndMetaSideAPI [
 
 	| p1 |
-	p1 := self createNewPackageNamed: self p1Name.
+	p1 := self organizer ensurePackage: self p1Name.
 	self createNewClassNamed: #MyPoint inPackage: p1.
 	self assert: self organizer packageNames size equals: 2.
 	self assert: self organizer packages size equals: 2.
@@ -82,8 +82,8 @@ RPackageOrganizerTest >> testEmpty [
 RPackageOrganizerTest >> testExtensionMethodNotExactlyTheName [
 
 	| p1 p2 c1 |
-	p1 := self createNewPackageNamed: 'P1'.
-	p2 := self createNewPackageNamed: 'P2'.
+	p1 := self organizer ensurePackage: 'P1'.
+	p2 := self organizer ensurePackage: 'P2'.
 
 	c1 := self createNewClassNamed: #C1 inPackage: p2.
 
@@ -99,9 +99,9 @@ RPackageOrganizerTest >> testFullRegistration [
 
 	| p1 p2 p3 a1 a2 b1 b2 a3 |
 	"taken from setup of RPackageReadOnlyCompleteSetup"
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
-	p3 := self createNewPackageNamed: self p3Name.
+	p1 := self organizer ensurePackage: self p1Name.
+	p2 := self organizer ensurePackage: self p2Name.
+	p3 := self organizer ensurePackage: self p3Name.
 
 	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
 	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.
@@ -149,7 +149,7 @@ RPackageOrganizerTest >> testHasPackage [
 { #category : #tests }
 RPackageOrganizerTest >> testRegisterPackageConflictWithPackage [
 
-	self createNewPackageNamed: 'P1'.
+	self organizer ensurePackage: 'P1'.
 	self should: [ (RPackage named: 'P1') register ] raise: Error
 ]
 
@@ -158,10 +158,10 @@ RPackageOrganizerTest >> testRegisterPackageConflictWithPackageTag [
 
 	| package1 |
 	self flag: #package. "This is a limitiation of the system organizer. I hope to kill this limitiation before p12 release."
-	package1 := self createNewPackageNamed: 'P1'.
+	package1 := self organizer ensurePackage: 'P1'.
 	package1 ensureTag: #T1.
 
-	self should: [ self createNewPackageNamed: 'P1-T1' ] raise: Error
+	self should: [ self organizer ensurePackage: 'P1-T1' ] raise: Error
 ]
 
 { #category : #tests }
@@ -169,18 +169,19 @@ RPackageOrganizerTest >> testRegisterPackageTagConflictWithPackage [
 
 	| package1 package2 |
 	self flag: #package. "This is a limitiation of the system organizer. I hope to kill this limitiation before p12 release."
-	package1 := self createNewPackageNamed: 'P1-T1'.
+	package1 := self organizer ensurePackage: 'P1-T1'.
 
-	package2 := self createNewPackageNamed: 'P1'.
+	package2 := self organizer ensurePackage: 'P1'.
 	self should: [ package2 ensureTag: #T1 ] raise: Error
 ]
 
 { #category : #tests }
 RPackageOrganizerTest >> testRegisteredNumberOfPackageIsOk [
+
 	| p1 p2 p3 |
-	p1 := self createNewPackageNamed: 'P1'.
-	p2 := self createNewPackageNamed: 'P2'.
-	p3 := self createNewPackageNamed: 'P3'.
+	p1 := self organizer ensurePackage: 'P1'.
+	p2 := self organizer ensurePackage: 'P2'.
+	p3 := self organizer ensurePackage: 'P3'.
 
 	self organizer basicRegisterPackage: p1.
 	self organizer basicRegisterPackage: p2.
@@ -194,12 +195,15 @@ RPackageOrganizerTest >> testRegisteredNumberOfPackageIsOk [
 RPackageOrganizerTest >> testRegisteredPackages [
 
 	| p1 p2 p3 |
-	p1 := self createNewPackageNamed: 'P1'.
-	p2 := self createNewPackageNamed: 'P2'.
-	p3 := self createNewPackageNamed: 'P3'.
+	p1 := self organizer ensurePackage: 'P1'.
+	p2 := self organizer ensurePackage: 'P2'.
+	p3 := self organizer ensurePackage: 'P3'.
 
 	self assert: self organizer packageNames size equals: 4. "We also have the default package."
-	{ p1 . p2 . p3 } do: [ :package |
+	{
+		p1.
+		p2.
+		p3 } do: [ :package |
 		self assert: (self organizer packageNames includes: package name).
 		self assert: (self organizer packages includes: package) ]
 ]
@@ -210,7 +214,7 @@ RPackageOrganizerTest >> testRegistrationExtendingPackages [
 	| p |
 	self createNewClassNamed: 'QuadrangleForTesting' inCategory: self class category.
 	self assertEmpty: (self organizer extendingPackagesOf: self quadrangleClass).
-	p := self createNewPackageNamed: 'P1'.
+	p := self organizer ensurePackage: 'P1'.
 	self organizer registerExtendingPackage: p forClass: self quadrangleClass.
 	self denyEmpty: (self organizer extendingPackagesOf: self quadrangleClass).
 	self assert: (self organizer extendingPackagesOf: self quadrangleClass) anyOne name equals: #P1
@@ -221,20 +225,20 @@ RPackageOrganizerTest >> testRemoveEmptyPackagesAndTags [
 
 	| organizer package1 package2 package3 package4 class tag1 tag2 |
 	"This one will contain a class"
-	package1 := (self createNewPackageNamed: #Test1).
+	package1 := self organizer ensurePackage: #Test1.
 	"This one will contain an extension method"
-	package2 := (self createNewPackageNamed: #Test2).
+	package2 := self organizer ensurePackage: #Test2.
 	"This one will contain a tag with a class and an empty tag"
-	package3 := (self createNewPackageNamed: #Test3).
+	package3 := self organizer ensurePackage: #Test3.
 	"This one will be empty"
-	package4 := (self createNewPackageNamed: #Test4).
+	package4 := self organizer ensurePackage: #Test4.
 
 	tag1 := package3 ensureTag: #Tag1.
 	tag2 := package3 ensureTag: #Tag2.
 
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1'.
 	class compile: 'extension ^ 1' classified: '*Test2'.
-	
+
 	class := self createNewClassNamed: 'TestClass2' inCategory: 'Test3-Tag1'.
 
 	self flag: #package. "Use the organizer provided by the tests later."
@@ -268,9 +272,9 @@ RPackageOrganizerTest >> testRemovePackage [
 
 	| p1 p2 p3 a1 a2 b1 b2 a3 |
 	"taken from setup of RPackageReadOnlyCompleteSetup"
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
-	p3 := self createNewPackageNamed: self p3Name.
+	p1 := self organizer ensurePackage: self p1Name.
+	p2 := self organizer ensurePackage: self p2Name.
+	p3 := self organizer ensurePackage: self p3Name.
 
 	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
 	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.
@@ -302,7 +306,7 @@ RPackageOrganizerTest >> testRenameUpdateTheOrganizer [
 	"test that when we rename a category, the organizer dictionary is update with this new name, so that we can access the package with this new name as key"
 
 	| package |
-	package := self createNewPackageNamed: #Test1.
+	package := self organizer ensurePackage: #Test1.
 
 	self organizer renamePackage: package to: #Test2.
 	self assert: package name equals: #Test2.
@@ -340,14 +344,17 @@ RPackageOrganizerTest >> testTestPackages [
 RPackageOrganizerTest >> testUnregister [
 
 	| p1 p2 p3 |
-	p1 := self createNewPackageNamed: 'P1'.
-	p2 := self createNewPackageNamed: 'P2'.
-	p3 := self createNewPackageNamed: 'P3'.
+	p1 := self organizer ensurePackage: 'P1'.
+	p2 := self organizer ensurePackage: 'P2'.
+	p3 := self organizer ensurePackage: 'P3'.
 
 	self assert: self organizer packageNames size equals: 4.
 
-	{p1 . p2 . p3} do: [:package |
-		(self organizer basicUnregisterPackage: package).
+	{
+		p1.
+		p2.
+		p3 } do: [ :package |
+		self organizer basicUnregisterPackage: package.
 		self deny: (self organizer packageNames includes: package name) ].
 
 	self assert: self organizer packageNames size equals: 1
@@ -358,7 +365,7 @@ RPackageOrganizerTest >> testUnregistrationExtendingPackages [
 
 	| p |
 	self createNewClassNamed: 'QuadrangleForTesting' inCategory: self class category.
-	p := self createNewPackageNamed: 'P1'.
+	p := self organizer ensurePackage: 'P1'.
 	self organizer registerExtendingPackage: p forClass: self quadrangleClass.
 	self denyEmpty: (self organizer extendingPackagesOf: self quadrangleClass).
 	self assert: (self organizer extendingPackagesOf: self quadrangleClass) anyOne name equals: #P1.

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -37,9 +37,9 @@ Class {
 RPackageReadOnlyCompleteSetupTest >> setUp [
 
 	super setUp.
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
-	p3 := self createNewPackageNamed: self p3Name.
+	p1 := self organizer ensurePackage: self p1Name.
+	p2 := self organizer ensurePackage: self p2Name.
+	p3 := self organizer ensurePackage: self p3Name.
 
 	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
 	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -41,11 +41,11 @@ RPackageReadOnlyCompleteSetupTest >> setUp [
 	p2 := self organizer ensurePackage: self p2Name.
 	p3 := self organizer ensurePackage: self p3Name.
 
-	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
-	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.
-	a2 := self createNewClassNamed: #A2DefinedInP2 inPackage: p2.
-	b2 := self createNewClassNamed: #B2DefinedInP2 inPackage: p2.
-	a3 := self createNewClassNamed: #A3DefinedInP3 inPackage: p3.
+	a1 := self newClassNamed: #A1DefinedInP1 in: p1.
+	b1 := self newClassNamed: #B1DefinedInP1 in: p1.
+	a2 := self newClassNamed: #A2DefinedInP2 in: p2.
+	b2 := self newClassNamed: #B2DefinedInP2 in: p2.
+	a3 := self newClassNamed: #A3DefinedInP3 in: p3.
 
 	a1 compile: 'methodDefinedInP1 ^ #methodDefinedInP1'.
 	a1 compile: 'anotherMethodDefinedInP1 ^ #anotherMethodDefinedInP1'.

--- a/src/RPackage-Tests/RPackageTagTest.class.st
+++ b/src/RPackage-Tests/RPackageTagTest.class.st
@@ -19,7 +19,7 @@ RPackageTagTest >> testAddClass [
 
 	| package1 package2 class |
 	package1 := self organizer ensurePackage: #Test1.
-	class := self createNewClassNamed: 'TestClass' inPackage: package1.
+	class := self newClassNamed: 'TestClass' in: package1.
 
 	self assert: (package1 includesClass: class).
 
@@ -38,7 +38,7 @@ RPackageTagTest >> testAddClassFromTag [
 
 	| package1 package2 class |
 	package1 := self organizer ensurePackage: #Test1.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
+	class := self newClassNamed: 'TestClass' in: package1 tag: 'TAG1'.
 
 	self assert: (package1 includesClass: class).
 	self assert: (package1 hasTag: #TAG1).
@@ -59,7 +59,7 @@ RPackageTagTest >> testHasClass [
 
 	| package class tag |
 	package := self organizer ensurePackage: #Test1.
-	class := self createNewClassNamed: 'TestClass' inCategory: package name , '-TAG'.
+	class := self newClassNamed: 'TestClass' in: package tag: 'TAG'.
 	tag := class packageTag.
 
 	self assert: (package includesClass: class).
@@ -76,7 +76,7 @@ RPackageTagTest >> testPromoteAsPackage [
 
 	| package1 package2 class tag1 |
 	package1 := self organizer ensurePackage: #Test1.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
+	class := self newClassNamed: 'TestClass' in: package1 tag: 'TAG1'.
 	class compile: 'foo ^42' classified: 'accessing'.
 
 	tag1 := package1 classTagNamed: 'TAG1'.
@@ -95,7 +95,7 @@ RPackageTagTest >> testRemoveClassRemoveTagIfEmpty [
 	| package tag class |
 	package := self organizer ensurePackage: #Test1.
 	tag := package ensureTag: #TAG.
-	class := self createNewClassNamed: 'TestClass' inCategory: package name , '-TAG'.
+	class := self newClassNamed: 'TestClass' inTag: tag.
 
 	self assert: (tag includesClass: class).
 	self assert: (package hasTag: tag).

--- a/src/RPackage-Tests/RPackageTagTest.class.st
+++ b/src/RPackage-Tests/RPackageTagTest.class.st
@@ -18,12 +18,12 @@ RPackageTagTest >> tearDown [
 RPackageTagTest >> testAddClass [
 
 	| package1 package2 class |
-	package1 := self createNewPackageNamed: #Test1.
+	package1 := self organizer ensurePackage: #Test1.
 	class := self createNewClassNamed: 'TestClass' inPackage: package1.
 
 	self assert: (package1 includesClass: class).
 
-	package2 := self createNewPackageNamed: #Test2.
+	package2 := self organizer ensurePackage: #Test2.
 
 	(package2 ensureTag: #TAG) addClass: class.
 
@@ -37,14 +37,14 @@ RPackageTagTest >> testAddClass [
 RPackageTagTest >> testAddClassFromTag [
 
 	| package1 package2 class |
-	package1 := self createNewPackageNamed: #Test1.
+	package1 := self organizer ensurePackage: #Test1.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
 
 	self assert: (package1 includesClass: class).
 	self assert: (package1 hasTag: #TAG1).
 	self assert: ((package1 classTagNamed: #TAG1) includesClass: class).
 
-	package2 := self createNewPackageNamed: #Test2.
+	package2 := self organizer ensurePackage: #Test2.
 
 	(package2 ensureTag: #TAG2) addClass: class.
 
@@ -58,7 +58,7 @@ RPackageTagTest >> testAddClassFromTag [
 RPackageTagTest >> testHasClass [
 
 	| package class tag |
-	package := self createNewPackageNamed: #Test1.
+	package := self organizer ensurePackage: #Test1.
 	class := self createNewClassNamed: 'TestClass' inCategory: package name , '-TAG'.
 	tag := class packageTag.
 
@@ -75,7 +75,7 @@ RPackageTagTest >> testHasClass [
 RPackageTagTest >> testPromoteAsPackage [
 
 	| package1 package2 class tag1 |
-	package1 := self createNewPackageNamed: #Test1.
+	package1 := self organizer ensurePackage: #Test1.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
 	class compile: 'foo ^42' classified: 'accessing'.
 
@@ -93,7 +93,7 @@ RPackageTagTest >> testPromoteAsPackage [
 RPackageTagTest >> testRemoveClassRemoveTagIfEmpty [
 
 	| package tag class |
-	package := self createNewPackageNamed: #Test1.
+	package := self organizer ensurePackage: #Test1.
 	tag := package ensureTag: #TAG.
 	class := self createNewClassNamed: 'TestClass' inCategory: package name , '-TAG'.
 

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -230,21 +230,18 @@ RPackageTest >> testHierarchyRoots [
 { #category : #tests }
 RPackageTest >> testIsTestPackage [
 
-	|packages |
-	packages := self createMockTestPackages.
-	"Happy case: test package 'MockPackage-Tests' must contain -Tests suffix."
-	self assert: packages first isTestPackage equals: true.
+	| package |
+	package := self organizer ensurePackage: 'MockPackage-Tests'.
+	self assert: package isTestPackage. "Happy case: test package 'MockPackage-Tests' must contain -Tests suffix."
 
-	"Package 'MockPackage-tests' is not test package, since it has lowercase suffix."
-	self assert: packages second isTestPackage  equals: false.
+	package := self organizer ensurePackage: 'MockPackage-tests'.
+	self deny: package isTestPackage. "Package 'MockPackage-tests' is not test package, since it has lowercase suffix."
 
-	"Happy case: regular package 'MockPackage' without -Tests suffix is not a test package."
-	self assert: packages third isTestPackage  equals: false.
+	package := self organizer ensurePackage: 'MockPackage'.
+	self deny: package isTestPackage. "Happy case: regular package 'MockPackage' without -Tests suffix is not a test package."
 
-	"Package 'MockPackage-Tests-Package' containting -Tests- in middle, so it is test package."
-	self assert: packages fourth isTestPackage equals: true.
-
-	"cleanup of inst.vars should be done in tearDown"
+	package := self organizer ensurePackage: 'MockPackage-Tests-Package'.
+	self assert: package isTestPackage "Package 'MockPackage-Tests-Package' containting -Tests- in middle, so it is test package."
 ]
 
 { #category : #'tests - MC' }

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -32,7 +32,7 @@ RPackageTest >> testActualClassTags [
 RPackageTest >> testAddClass [
 
 	| package1 package2 class done |
-	package1 := self createNewPackageNamed: #Test1.
+	package1 := self organizer ensurePackage: #Test1.
 	done := 0.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG'.
 
@@ -41,7 +41,7 @@ RPackageTest >> testAddClass [
 	self assert: (package1 hasTag: #TAG).
 	self assert: ((package1 classTagNamed: #TAG) includesClass: class).
 
-	package2 := self createNewPackageNamed: #Test2.
+	package2 := self organizer ensurePackage: #Test2.
 	[
 	SystemAnnouncer uniqueInstance when: ClassRecategorized do: [ done := done + 1 ] for: self.
 	package2 addClass: class ] ensure: [ SystemAnnouncer uniqueInstance unsubscribe: self ].
@@ -57,12 +57,12 @@ RPackageTest >> testAddClass [
 RPackageTest >> testAddClassFromTag [
 
 	| package1 package2 class |
-	package1 := self createNewPackageNamed: #Test1.
+	package1 := self organizer ensurePackage: #Test1.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG'.
 
 	self assert: (package1 includesClass: class).
 
-	package2 := self createNewPackageNamed: #Test2.
+	package2 := self organizer ensurePackage: #Test2.
 
 	package2 addClass: class.
 
@@ -76,7 +76,7 @@ RPackageTest >> testAddClassFromTag [
 RPackageTest >> testAllUnsentMessages [
 
 	| package class1 class2 |
-	package := self createNewPackageNamed: #Test1.
+	package := self organizer ensurePackage: #Test1.
 
 	class1 := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG'.
 	class2 := self createNewClassNamed: 'TestClassOther' inCategory: 'Test1-TAG'.
@@ -117,7 +117,7 @@ RPackageTest >> testAnonymousClassAndSelector [
 RPackageTest >> testDemoteToRPackageNamed [
 
 	| package1 package2 class |
-	package1 := self createNewPackageNamed: #'Test1-TAG1'.
+	package1 := self organizer ensurePackage: #'Test1-TAG1'.
 	class := self createNewClassNamed: 'TestClass' inPackage: package1.
 	class compile: 'foo ^42' classified: 'accessing'.
 
@@ -134,8 +134,8 @@ RPackageTest >> testDemoteToRPackageNamed [
 RPackageTest >> testDemoteToRPackageNamedExistingPackage [
 
 	| package1 package2 packageExisting class |
-	package1 := self createNewPackageNamed: #'Test1-TAG1'.
-	packageExisting := self createNewPackageNamed: #Test1.
+	package1 := self organizer ensurePackage: #'Test1-TAG1'.
+	packageExisting := self organizer ensurePackage: #Test1.
 	class := self createNewClassNamed: 'TestClass' inPackage: package1.
 	class compile: 'foo ^42' classified: 'accessing'.
 
@@ -166,7 +166,7 @@ RPackageTest >> testDemoteToRPackageNamedKeepOrganizer [
 RPackageTest >> testDemoteToRPackageNamedMultilevelPackage [
 
 	| package1 package2 class |
-	package1 := self createNewPackageNamed: #'Test1-TAG1-X1'.
+	package1 := self organizer ensurePackage: #'Test1-TAG1-X1'.
 	class := self createNewClassNamed: 'TestClass' inPackage: package1.
 	class compile: 'foo ^42' classified: 'accessing'.
 
@@ -183,7 +183,7 @@ RPackageTest >> testDemoteToRPackageNamedMultilevelPackage [
 RPackageTest >> testDemoteToRPackageNamedWithExtension [
 
 	| packageOriginal packageDemoted class classOther |
-	packageOriginal := self createNewPackageNamed: #'Test1-TAG1'.
+	packageOriginal := self organizer ensurePackage: #'Test1-TAG1'.
 	class := self createNewClassNamed: 'TestClass' inPackage: packageOriginal.
 	class compile: 'foo ^42' classified: 'accessing'.
 
@@ -284,7 +284,7 @@ RPackageTest >> testPropertyAtPut [
 RPackageTest >> testRemoveEmptyTags [
 
 	| package class tag1 tag2 |
-	package := self createNewPackageNamed: #Test1.
+	package := self organizer ensurePackage: #Test1.
 
 	tag1 := package ensureTag: #Tag1.
 	tag2 := package ensureTag: #Tag2.
@@ -309,9 +309,9 @@ RPackageTest >> testRenamePackageAlsoRenameAllExtensionProtocols [
 	"test that when we rename a category, all corresponding extension protocols in the system are renamed"
 
 	| p1 p2 p3 classInY classInZ |
-	p1 := self createNewPackageNamed: #Test1.
-	p2 := self createNewPackageNamed: #Test2.
-	p3 := self createNewPackageNamed: #Test3.
+	p1 := self organizer ensurePackage: #Test1.
+	p2 := self organizer ensurePackage: #Test2.
+	p3 := self organizer ensurePackage: #Test3.
 
 	classInY := self createNewClassNamed: 'ClassInYPackage' inPackage: p2.
 	classInZ := self createNewClassNamed: 'ClassInZPackage' inPackage: p3.
@@ -333,7 +333,7 @@ RPackageTest >> testRenameUpdateTheOrganizer [
 	"test that when we rename a category, the organizer dictionary is update with this new name, so that we can access the package with this new name as key"
 
 	| package |
-	package := self createNewPackageNamed: #Test1.
+	package := self organizer ensurePackage: #Test1.
 
 	package renameTo: #Test2.
 	self assert: package name equals: #Test2.

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -34,7 +34,7 @@ RPackageTest >> testAddClass [
 	| package1 package2 class done |
 	package1 := self organizer ensurePackage: #Test1.
 	done := 0.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG'.
+	class := self newClassNamed: 'TestClass' in: package1 tag: 'TAG'.
 
 
 	self assert: (package1 includesClass: class).
@@ -58,7 +58,7 @@ RPackageTest >> testAddClassFromTag [
 
 	| package1 package2 class |
 	package1 := self organizer ensurePackage: #Test1.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG'.
+	class := self newClassNamed: 'TestClass' in: package1 tag: 'TAG'.
 
 	self assert: (package1 includesClass: class).
 
@@ -78,8 +78,8 @@ RPackageTest >> testAllUnsentMessages [
 	| package class1 class2 |
 	package := self organizer ensurePackage: #Test1.
 
-	class1 := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG'.
-	class2 := self createNewClassNamed: 'TestClassOther' inCategory: 'Test1-TAG'.
+	class1 := self newClassNamed: 'TestClass' in: package tag: 'TAG'.
+	class2 := self newClassNamed: 'TestClassOther' in: package tag: 'TAG'.
 
 	class1
 		compile: 'nonexistingMethodName1 42';
@@ -118,7 +118,7 @@ RPackageTest >> testDemoteToRPackageNamed [
 
 	| package1 package2 class |
 	package1 := self organizer ensurePackage: #'Test1-TAG1'.
-	class := self createNewClassNamed: 'TestClass' inPackage: package1.
+	class := self newClassNamed: 'TestClass' in: package1.
 	class compile: 'foo ^42' classified: 'accessing'.
 
 	package1 demoteToTagInPackage.
@@ -136,7 +136,7 @@ RPackageTest >> testDemoteToRPackageNamedExistingPackage [
 	| package1 package2 packageExisting class |
 	package1 := self organizer ensurePackage: #'Test1-TAG1'.
 	packageExisting := self organizer ensurePackage: #Test1.
-	class := self createNewClassNamed: 'TestClass' inPackage: package1.
+	class := self newClassNamed: 'TestClass' in: package1.
 	class compile: 'foo ^42' classified: 'accessing'.
 
 	package1 demoteToTagInPackage.
@@ -167,7 +167,7 @@ RPackageTest >> testDemoteToRPackageNamedMultilevelPackage [
 
 	| package1 package2 class |
 	package1 := self organizer ensurePackage: #'Test1-TAG1-X1'.
-	class := self createNewClassNamed: 'TestClass' inPackage: package1.
+	class := self newClassNamed: 'TestClass' in: package1.
 	class compile: 'foo ^42' classified: 'accessing'.
 
 	package1 demoteToTagInPackage.
@@ -184,10 +184,10 @@ RPackageTest >> testDemoteToRPackageNamedWithExtension [
 
 	| packageOriginal packageDemoted class classOther |
 	packageOriginal := self organizer ensurePackage: #'Test1-TAG1'.
-	class := self createNewClassNamed: 'TestClass' inPackage: packageOriginal.
+	class := self newClassNamed: 'TestClass' in: packageOriginal.
 	class compile: 'foo ^42' classified: 'accessing'.
 
-	classOther := self createNewClassNamed: 'TestClassOther' inCategory: 'XXXX'.
+	classOther := self newClassNamed: 'TestClassOther' in: 'XXXX'.
 	classOther compile: 'bar ^42' classified: #'*Test1-TAG1'.
 
 	packageOriginal demoteToTagInPackage.
@@ -286,7 +286,7 @@ RPackageTest >> testRemoveEmptyTags [
 	tag1 := package ensureTag: #Tag1.
 	tag2 := package ensureTag: #Tag2.
 
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-Tag1'.
+	class := self newClassNamed: 'TestClass' inTag: tag1.
 
 	self assert: (tag1 includesClass: class).
 	self deny: tag1 isEmpty.
@@ -310,8 +310,8 @@ RPackageTest >> testRenamePackageAlsoRenameAllExtensionProtocols [
 	p2 := self organizer ensurePackage: #Test2.
 	p3 := self organizer ensurePackage: #Test3.
 
-	classInY := self createNewClassNamed: 'ClassInYPackage' inPackage: p2.
-	classInZ := self createNewClassNamed: 'ClassInZPackage' inPackage: p3.
+	classInY := self newClassNamed: 'ClassInYPackage' in: p2.
+	classInZ := self newClassNamed: 'ClassInZPackage' in: p3.
 
 	classInY compile: #extensionFromXInClassInY classified: '*' , p1 name.
 	classInY compile: #longNameExtensionFromXInClassInY classified: '*' , p1 name , '-subcategory'.

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -3,10 +3,8 @@ Common superclass for RPackage related tests
 "
 Class {
 	#name : #RPackageTestCase,
-	#superclass : #AbstractEnvironmentTestCase,
+	#superclass : #TestCase,
 	#instVars : [
-		'createdClasses',
-		'createdPackages',
 		'testEnvironment'
 	],
 	#category : #'RPackage-Tests'
@@ -25,71 +23,42 @@ RPackageTestCase >> createMockTestPackages [
 ]
 
 { #category : #utilities }
-RPackageTestCase >> createNewClassNamed: aName [
-	^ self createNewClassNamed: aName inCategory: 'RPackageTest'
-]
-
-{ #category : #utilities }
 RPackageTestCase >> createNewClassNamed: aName inCategory: cat [
 
-	| cls |
-	cls := self class classInstaller make: [ :aClassBuilder |
-		       aClassBuilder
-			       name: aName;
-			       installingEnvironment: testEnvironment;
-			       package: cat ].
-
-	createdClasses add: cls.
-	createdPackages add: cls package.
-	^ cls
+	^ self class classInstaller make: [ :aClassBuilder |
+		  aClassBuilder
+			  name: aName;
+			  installingEnvironment: testEnvironment;
+			  package: cat ]
 ]
 
 { #category : #utilities }
 RPackageTestCase >> createNewClassNamed: aName inPackage: p [
 
-	| cls |
-	cls := self createNewClassNamed: aName inCategory: p name.
-	p importClass: cls.
-	^ cls
+	^ self createNewClassNamed: aName inCategory: p name
 ]
 
 { #category : #utilities }
 RPackageTestCase >> createNewPackageNamed: aName [
 
-	| pack |
-	pack := self organizer ensurePackage: aName.
-	createdPackages add: pack.
-	^ pack
-]
-
-{ #category : #utilities }
-RPackageTestCase >> createNewTraitNamed: aName [
-	^ self createNewTraitNamed: aName inCategory: 'RPackageTest'
+	^ self organizer ensurePackage: aName
 ]
 
 { #category : #utilities }
 RPackageTestCase >> createNewTraitNamed: aName inCategory: cat [
 
-	| cls |
-	cls := self class classInstaller make: [ :aBuilder |
-		       aBuilder
-			       name: aName;
-			       package: cat;
-			       installingEnvironment: testEnvironment;
-			       beTrait ].
-
-	createdClasses add: cls.
-	createdPackages add: cls package.
-	^ cls
+	^ self class classInstaller make: [ :aBuilder |
+		  aBuilder
+			  name: aName;
+			  package: cat;
+			  installingEnvironment: testEnvironment;
+			  beTrait ]
 ]
 
 { #category : #utilities }
 RPackageTestCase >> createNewTraitNamed: aName inPackage: p [
 
-	| cls |
-	cls := self createNewTraitNamed: aName.
-	p importClass: cls.
-	^ cls
+	^ self createNewTraitNamed: aName inCategory: p name
 ]
 
 { #category : #utilities }
@@ -124,17 +93,11 @@ RPackageTestCase >> runCase [
 ]
 
 { #category : #running }
-RPackageTestCase >> setUp [
-
-	super setUp.
-	createdClasses := Set new.
-	createdPackages := Set new
-]
-
-{ #category : #running }
 RPackageTestCase >> tearDown [
 
-	createdClasses do: [ :cls | cls removeFromSystem ].
-
+	self organizer packages do: [ :package |
+		self allWorkingCopies
+			detect: [ :mcPackage | mcPackage packageName = package packageName asString ]
+			ifFound: [ :mcPackage | mcPackage unregister ] ].
 	super tearDown
 ]

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -19,7 +19,7 @@ RPackageTestCase >> allWorkingCopies [
 { #category : #utilities }
 RPackageTestCase >> createMockTestPackages [
 
-	^ self namesOfMockTestPackages collect: [:pName | self createNewPackageNamed: pName]
+	^ #( 'MockPackage-Tests' 'MockPackage-tests' 'MockPackage' 'MockPackage-Tests-Package' ) collect: [ :pName | self organizer ensurePackage: pName ]
 ]
 
 { #category : #utilities }
@@ -36,12 +36,6 @@ RPackageTestCase >> createNewClassNamed: aName inCategory: cat [
 RPackageTestCase >> createNewClassNamed: aName inPackage: p [
 
 	^ self createNewClassNamed: aName inCategory: p name
-]
-
-{ #category : #utilities }
-RPackageTestCase >> createNewPackageNamed: aName [
-
-	^ self organizer ensurePackage: aName
 ]
 
 { #category : #utilities }

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -17,12 +17,6 @@ RPackageTestCase >> allWorkingCopies [
 ]
 
 { #category : #utilities }
-RPackageTestCase >> createMockTestPackages [
-
-	^ #( 'MockPackage-Tests' 'MockPackage-tests' 'MockPackage' 'MockPackage-Tests-Package' ) collect: [ :pName | self organizer ensurePackage: pName ]
-]
-
-{ #category : #utilities }
 RPackageTestCase >> createNewClassNamed: aName inCategory: cat [
 
 	^ self class classInstaller make: [ :aClassBuilder |
@@ -53,12 +47,6 @@ RPackageTestCase >> createNewTraitNamed: aName inCategory: cat [
 RPackageTestCase >> createNewTraitNamed: aName inPackage: p [
 
 	^ self createNewTraitNamed: aName inCategory: p name
-]
-
-{ #category : #utilities }
-RPackageTestCase >> namesOfMockTestPackages [
-
-	^ #( 'MockPackage-Tests' 'MockPackage-tests' 'MockPackage' 'MockPackage-Tests-Package')
 ]
 
 { #category : #accessing }

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -17,36 +17,66 @@ RPackageTestCase >> allWorkingCopies [
 ]
 
 { #category : #utilities }
-RPackageTestCase >> createNewClassNamed: aName inCategory: cat [
+RPackageTestCase >> newClassNamed: aName in: aPackage [
 
 	^ self class classInstaller make: [ :aClassBuilder |
 		  aClassBuilder
 			  name: aName;
 			  installingEnvironment: testEnvironment;
-			  package: cat ]
+			  package: (aPackage isString
+					   ifTrue: [ aPackage ]
+					   ifFalse: [ aPackage name ]) ]
 ]
 
 { #category : #utilities }
-RPackageTestCase >> createNewClassNamed: aName inPackage: p [
+RPackageTestCase >> newClassNamed: aName in: aPackage tag: aTag [
 
-	^ self createNewClassNamed: aName inCategory: p name
+	^ self class classInstaller make: [ :aClassBuilder |
+		  aClassBuilder
+			  name: aName;
+			  installingEnvironment: testEnvironment;
+			  package: (aPackage isString
+					   ifTrue: [ aPackage ]
+					   ifFalse: [ aPackage name ]);
+			  tag: (aTag isString
+					   ifTrue: [ aTag ]
+					   ifFalse: [ aTag name ]) ]
 ]
 
 { #category : #utilities }
-RPackageTestCase >> createNewTraitNamed: aName inCategory: cat [
+RPackageTestCase >> newClassNamed: aName inTag: aTag [
+
+	^ self class classInstaller make: [ :aClassBuilder |
+		  aClassBuilder
+			  name: aName;
+			  installingEnvironment: testEnvironment;
+			  package: aTag package name;
+			  tag: aTag name ]
+]
+
+{ #category : #utilities }
+RPackageTestCase >> newTraitNamed: aName in: aPackage [
 
 	^ self class classInstaller make: [ :aBuilder |
 		  aBuilder
 			  name: aName;
-			  package: cat;
+			  package: (aPackage isString
+					   ifTrue: [ aPackage ]
+					   ifFalse: [ aPackage name ]);
 			  installingEnvironment: testEnvironment;
 			  beTrait ]
 ]
 
 { #category : #utilities }
-RPackageTestCase >> createNewTraitNamed: aName inPackage: p [
+RPackageTestCase >> newTraitNamed: aName inTag: aTag [
 
-	^ self createNewTraitNamed: aName inCategory: p name
+	^ self class classInstaller make: [ :aBuilder |
+		  aBuilder
+			  name: aName;
+			  package: aTag package name;
+			  tag: aTag name;
+			  installingEnvironment: testEnvironment;
+			  beTrait ]
 ]
 
 { #category : #accessing }

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -107,9 +107,8 @@ RPackageTestCase >> runCase [
 { #category : #running }
 RPackageTestCase >> tearDown [
 
-	self organizer packages do: [ :package |
-		self allWorkingCopies
-			detect: [ :mcPackage | mcPackage packageName = package packageName asString ]
-			ifFound: [ :mcPackage | mcPackage unregister ] ].
+	self organizer packages do: [ :package | package removeFromSystem ].
+	"Most classes should be removed with the above line but some might be unpackaged"
+	self organizer environment allClasses do: [ :class | class removeFromSystem ].
 	super tearDown
 ]

--- a/src/RPackage-Tests/RPackageTraitTest.class.st
+++ b/src/RPackage-Tests/RPackageTraitTest.class.st
@@ -20,9 +20,9 @@ RPackageTraitTest >> setUp [
 
 	super setUp.
 
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
-	p3 := self createNewPackageNamed: self p3Name.
+	p1 := self organizer ensurePackage: self p1Name.
+	p2 := self organizer ensurePackage: self p2Name.
+	p3 := self organizer ensurePackage: self p3Name.
 
 	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
 

--- a/src/RPackage-Tests/RPackageTraitTest.class.st
+++ b/src/RPackage-Tests/RPackageTraitTest.class.st
@@ -24,19 +24,19 @@ RPackageTraitTest >> setUp [
 	p2 := self organizer ensurePackage: self p2Name.
 	p3 := self organizer ensurePackage: self p3Name.
 
-	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
+	a1 := self newClassNamed: #A1DefinedInP1 in: p1.
 
 	"a1 defines two normal = local methods"
 	a1 compile: 'localMethodDefinedInP1 ^ #methodDefinedInP1'.
 	a1 compile: 'anotherLocalMethodDefinedInP1 ^ #anotherMethodDefinedInP1'.
 
-	t1 := self createNewTraitNamed: #TraitInPackageP1 inPackage: p1.
+	t1 := self newTraitNamed: #TraitInPackageP1 in: p1.
 	t1 compile: 'traitMethodDefinedInP1 ^ #traitMethodDefinedInP1'.
 
 	"P3 defines a new method extension on T1 (packaged in p1)"
 	t1 compile: 'traitMethodExtendedFromP3 ^ #traitMethodExtendedFromP3' classified: '*' , self p3Name.
 
-	t2 := self createNewTraitNamed: #TraitInPackageP2 inPackage: p2.
+	t2 := self newTraitNamed: #TraitInPackageP2 in: p2.
 	t2 compile: 'traitMethodDefinedInP2 ^ #traitMethodDefinedInP2'.
 
 	"Here P1 extends T2 from P2 with a new method"
@@ -50,7 +50,7 @@ RPackageTraitTest >> testMethodOverridingTraitMethodIsKnowByPackage [
 	"Regression test for a bug where adding a method to a class that overrides a method from a trait was not know by the package of the class"
 
 	| a2 |
-	a2 := self createNewClassNamed: #A2DefinedInP1 inPackage: p1.
+	a2 := self newClassNamed: #A2DefinedInP1 in: p1.
 
 	a2 setTraitComposition: t1 asTraitComposition.
 


### PR DESCRIPTION
This change is cleaning some behaviors in tests and also reducing the number of category manipulations