### PR TITLE
Introducing useful event when a debug session has been cleared, so that all subscribers can unsubscribe from any cleared session automatically

### DIFF
--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -80,7 +80,9 @@ DebugSession >> clear [
 	the same process, it should call this method."
 	exception := nil.
 	interruptedProcess := nil.
-	self updateContextTo: nil
+	self updateContextTo: nil.
+	
+	self triggerEvent: #clear
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
When a debug session is cleared, its process becomes `nil` so we can't get information from this process anymore.
Also, it means any subscribed debugger shouldn't be able to perform any action on the debug session anymore. That's why, a debugger that has a cleared debug session should unsubscribe from the debug session and from the SystemAnnouncer (it is subscribed to the SystemAnnouncer to get notified when a method has been compiled/recompiled).

For now, we don't have a mechanism that does that automatically. All debuggers should call their method `#clear`, which is annoying, especially in tests. Because if someone instanciates a debugger in a test but doesn't know that they should ensure the method `#clear` is called, then some errors (like this one: https://github.com/pharo-spec/NewTools/issues/579) might happen because the debugger executes code due to subscriptions that should have been cancelled, causing some messages to be sent to a `nil` process.

This PR introduces an event triggered when a session is cleared so that all subscribers can unsubscribe from whatever they should unsubscribe from