### PR TITLE
Use basicCategory in Ring instead of category

### DIFF
--- a/src/Epicea/Class.extension.st
+++ b/src/Epicea/Class.extension.st
@@ -5,7 +5,7 @@ Class >> asEpiceaRingDefinition [
 
 	| ring |
 	ring := (RGClassDefinition named: self name)
-		        category: self category;
+		        category: self basicCategory;
 		        superclassName: self superclass asString;
 		        "Note it's nil for ProtoObject"traitCompositionSource:
 			        self traitCompositionString;

--- a/src/Epicea/TestCase.extension.st
+++ b/src/Epicea/TestCase.extension.st
@@ -1,14 +1,14 @@
 Extension { #name : #TestCase }
 
 { #category : #'*Epicea' }
+TestCase >> shouldLogWithEpicea [
+
+	^ self class shouldLogWithEpicea
+]
+
+{ #category : #'*Epicea' }
 TestCase class >> shouldLogWithEpicea [
 	"When running a test, we disable the loggings of Epicea to run the tests silently. In case a TestCase explicitly wants to Epicea logs, then I can be overriden to return true and enable the logs."
 
 	^ false
-]
-
-{ #category : #'*Epicea' }
-TestCase >> shouldLogWithEpicea [
-
-	^ self class shouldLogWithEpicea
 ]

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -280,9 +280,9 @@ Class >> category [
 		symbol = Class unclassifiedCategory ifTrue: [ ^ symbol ].
 
 		((self packageOrganizer listAtCategoryNamed: symbol) includes: self name) ifTrue: [ ^ symbol ] ].
-	result := (self environment organization categoryOfBehavior: self)
-		          ifNil: [ #Unclassified ]
-		          ifNotNil: [ :value | value ].
+
+	result := (self packageOrganizer categoryOfBehavior: self) ifNil: [ #Unclassified ].
+
 	self basicCategory: result.
 
 	^ result

--- a/src/Ring-Definitions-Core/Class.extension.st
+++ b/src/Ring-Definitions-Core/Class.extension.st
@@ -44,7 +44,7 @@ Class >> asRingDefinition [
 
 	| ring |
 	ring := (RGClassDefinition named: self name)
-		category: self category;
+		category: self basicCategory;
 		superclassName: (self superclass
 			ifNil: [ nil printString ]
 			ifNotNil: [ self superclass name ]);

--- a/src/Ring-Definitions-Core/Trait.extension.st
+++ b/src/Ring-Definitions-Core/Trait.extension.st
@@ -8,7 +8,7 @@ Trait >> asRingDefinition [
 
 	| ring |
 	ring := (RGTraitDefinition named: self name)
-		        category: self category;
+		        category: self basicCategory;
 		        superclassName: #Trait;
 		        traitCompositionSource: self traitCompositionString;
 		        comment: self comment;


### PR DESCRIPTION
While creating a Ring definition from a Class or a Trait we are using the method #category. But in the case of classes that got updated or removed from the image, the method #category contains a hack that will try to check the category of the class of the same name in the image. Thus if a class get updated and you ask the ring definition of the old class, it will have the category of the new class.

This change make Ring be based on #basicCategory that is the category of the class even if a newer version of the class is in the image.