### PR TITLE
Small refactoring: use #whichMethodsReferTo, not #whichSelectorsReferTo

### DIFF
--- a/src/GeneralRules/ReAddRemoveDependentsRule.class.st
+++ b/src/GeneralRules/ReAddRemoveDependentsRule.class.st
@@ -2,24 +2,26 @@
 Check that the number of addDependent: message sends in a class is less than or equal to the number of removeDependent: messages. If there are more addDependent: messages that may signify that some dependents are not being released, which may lead to memory leaks.
 "
 Class {
-	#name : #ReAddRemoveDependentsRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReAddRemoveDependentsRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReAddRemoveDependentsRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAddRemoveDependentsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'AddRemoveDependentsRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReAddRemoveDependentsRule >> basicCheck: aClass [
 	| methods addSends removeSends |
 	addSends := 0.
@@ -33,12 +35,12 @@ ReAddRemoveDependentsRule >> basicCheck: aClass [
 	^ addSends > removeSends
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAddRemoveDependentsRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAddRemoveDependentsRule >> name [
 	^ 'Number of addDependent: messages > removeDependent:'
 ]

--- a/src/GeneralRules/ReAllAnyNoneSatisfyRule.class.st
+++ b/src/GeneralRules/ReAllAnyNoneSatisfyRule.class.st
@@ -16,24 +16,26 @@ collection allSatisfy: [ :each | condition ]
 ]]]
 "
 Class {
-	#name : #ReAllAnyNoneSatisfyRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReAllAnyNoneSatisfyRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAllAnyNoneSatisfyRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'AllAnyNoneSatisfyRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAllAnyNoneSatisfyRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReAllAnyNoneSatisfyRule >> initialize [
 	super initialize.
 	self
@@ -93,12 +95,12 @@ ReAllAnyNoneSatisfyRule >> initialize [
 				`@condition ]'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAllAnyNoneSatisfyRule >> name [
 	^ 'Replace with #allSatisfy:, #anySatisfy: or #noneSatisfy:'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAllAnyNoneSatisfyRule >> rationale [
 	^ 'Replace ad-hoc implementations (using explicit logic based on do:) of allSatisfy:, anySatisfy: and noneSatisfy: by the adequate calls to #allSatisfy:, #anySatisfy: or #noneSatisfy:. '
 ]

--- a/src/GeneralRules/ReAsClassRule.class.st
+++ b/src/GeneralRules/ReAsClassRule.class.st
@@ -8,18 +8,20 @@ Do not use methods such as
 because they do not take into account an environment. Instead use `self class environment at: #ClassName`
 "
 Class {
-	#name : #ReAsClassRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReAsClassRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAsClassRule >> group [
 
 	^ 'Design Flaws'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReAsClassRule >> initialize [
 	super initialize.
 	self
@@ -33,13 +35,13 @@ ReAsClassRule >> initialize [
 		with: 'self class environment at: `@expr ifPresent: `@block'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAsClassRule >> name [
 
 	^ 'Do not use #asClass & similar'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAsClassRule >> severity [
 
 	^ #error

--- a/src/GeneralRules/ReAsOrderedCollectionNotNeededRule.class.st
+++ b/src/GeneralRules/ReAsOrderedCollectionNotNeededRule.class.st
@@ -3,24 +3,26 @@ A prior conversion to an Array or OrderedCollection is not necessary when adding
 
 "
 Class {
-	#name : #ReAsOrderedCollectionNotNeededRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReAsOrderedCollectionNotNeededRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAsOrderedCollectionNotNeededRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'AsOrderedCollectionNotNeededRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAsOrderedCollectionNotNeededRule >> group [
 	^ 'Optimization'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReAsOrderedCollectionNotNeededRule >> initialize [
 	super initialize.
 	#('addAll:' 'removeAll:' 'includesAll:' 'copyWithoutAll:')
@@ -32,7 +34,7 @@ ReAsOrderedCollectionNotNeededRule >> initialize [
 					self replace: baseString , conversionMessage with: baseString ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAsOrderedCollectionNotNeededRule >> name [
 	^ '#asOrderedCollection/#asArray not needed'
 ]

--- a/src/GeneralRules/ReAssignmentInBlockRule.class.st
+++ b/src/GeneralRules/ReAssignmentInBlockRule.class.st
@@ -2,24 +2,26 @@
 Checks ensure:, ifCurtailed:, and showWhile: blocks for assignments or returns that are the last statement in the block. These assignments or returns can be moved outside the block since these messages return the value of the block.
 "
 Class {
-	#name : #ReAssignmentInBlockRule,
-	#superclass : #ReNodeMatchRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReAssignmentInBlockRule',
+	#superclass : 'ReNodeMatchRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAssignmentInBlockRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'AssignmentInBlockRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAssignmentInBlockRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReAssignmentInBlockRule >> initialize [
 	super initialize.
 	self  matchesAny: #(
@@ -31,7 +33,7 @@ ReAssignmentInBlockRule >> initialize [
 			'[| `@temps | `@.Statements. ^`@object] ifCurtailed: `@block' )
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAssignmentInBlockRule >> name [
 	^ 'Unnecessary assignment or return in block'
 ]

--- a/src/GeneralRules/ReAssignmentInIfTrueRule.class.st
+++ b/src/GeneralRules/ReAssignmentInIfTrueRule.class.st
@@ -10,24 +10,26 @@ var :=  test
 	ifFalse: [2]
 "
 Class {
-	#name : #ReAssignmentInIfTrueRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReAssignmentInIfTrueRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAssignmentInIfTrueRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'AssignmentInIfTrueRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAssignmentInIfTrueRule >> group [
 	^ 'Optimization'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReAssignmentInIfTrueRule >> initialize [
 	super initialize.
 	self
@@ -37,12 +39,12 @@ ReAssignmentInIfTrueRule >> initialize [
 		with: '`variable := ``@Boolean ifFalse: [``@true] ifTrue: [``@false]'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAssignmentInIfTrueRule >> name [
 	^ 'Move variable assignment outside of single statement ifTrue:ifFalse: blocks'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAssignmentInIfTrueRule >> rationale [
 	^ 'Moving assignments outside blocks leads to shorter and more efficient code.'
 ]

--- a/src/GeneralRules/ReAssignmentWithoutEffectRule.class.st
+++ b/src/GeneralRules/ReAssignmentWithoutEffectRule.class.st
@@ -2,35 +2,37 @@
 This smell arises when a statement such as x := x is found. This statement has not effect, it can be removed.
 "
 Class {
-	#name : #ReAssignmentWithoutEffectRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReAssignmentWithoutEffectRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAssignmentWithoutEffectRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'AssignmentWithoutEffectRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAssignmentWithoutEffectRule >> group [
 	^ 'Optimization'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReAssignmentWithoutEffectRule >> initialize [
 	super initialize.
 	self  replace: 	'`var := `var' with: ''
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAssignmentWithoutEffectRule >> name [
 	^ 'Assignment has no effect'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAssignmentWithoutEffectRule >> severity [
 	^ #information
 ]

--- a/src/GeneralRules/ReAtIfAbsentRule.class.st
+++ b/src/GeneralRules/ReAtIfAbsentRule.class.st
@@ -4,24 +4,26 @@ Replaces at:ifAbsent: by at:ifAbsentPut:. Its leads to shorter and more readable
 
 "
 Class {
-	#name : #ReAtIfAbsentRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReAtIfAbsentRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAtIfAbsentRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'AtIfAbsentRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAtIfAbsentRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReAtIfAbsentRule >> initialize [
 	super initialize.
 	self
@@ -46,7 +48,7 @@ ReAtIfAbsentRule >> initialize [
 							``@object]'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReAtIfAbsentRule >> name [
 	^ 'at:ifAbsent: -> at:ifAbsentPut:'
 ]

--- a/src/GeneralRules/ReBadMessageRule.class.st
+++ b/src/GeneralRules/ReBadMessageRule.class.st
@@ -4,24 +4,26 @@ This smell arises when methods send messages that perform low level things. You 
 This rule is not active for methods in test classes.
 "
 Class {
-	#name : #ReBadMessageRule,
-	#superclass : #ReNodeBasedRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReBadMessageRule',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReBadMessageRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'BadMessageRule2'
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ReBadMessageRule >> badSelectors [
 	^ #( #become: #isKindOf: #respondsTo: #isMemberOf: #perform: #perform:arguments: #perform:with: #perform:with:with: #perform:with:with:with: #allOwners #instVarAt: #instVarAt:put: #nextInstance instVarsInclude: #nextObject caseOf: caseOf:otherwise: caseError isThisEverCalled isThisEverCalled: becomeForward: instVarNamed: instVarNamed:put: someObject primitiveChangeClassTo:)
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReBadMessageRule >> basicCheck: aNode [
 	aNode isMessage ifFalse: [ ^false ].
 	"In tests using these messages (like isKindOf:) is no problem"
@@ -29,17 +31,17 @@ ReBadMessageRule >> basicCheck: aNode [
 	^ self badSelectors includes: aNode selector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReBadMessageRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReBadMessageRule >> name [
 	^ 'Sends "questionable" message'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReBadMessageRule >> rationale [
 	^ 'Check methods that send messages that perform low level things.'
 ]

--- a/src/GeneralRules/ReBetweenAndRule.class.st
+++ b/src/GeneralRules/ReBetweenAndRule.class.st
@@ -2,24 +2,26 @@
 Replaces ""a >= b and: [a <= c]"" by ""a between: b and: c.
 "
 Class {
-	#name : #ReBetweenAndRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReBetweenAndRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReBetweenAndRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'BetweenAndRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReBetweenAndRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReBetweenAndRule >> initialize [
 	super initialize.
 	self
@@ -41,7 +43,7 @@ ReBetweenAndRule >> initialize [
 		replace: '``@c >= ``@a & (``@b <= ``@a)' with: '``@a between: ``@b and: ``@c'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReBetweenAndRule >> name [
 	^ '"a >= b and: [a <= c]" -> "a between: b and: c"'
 ]

--- a/src/GeneralRules/ReBooleanPrecedenceRule.class.st
+++ b/src/GeneralRules/ReBooleanPrecedenceRule.class.st
@@ -2,24 +2,26 @@
 Checks precedence ordering of & and | with equality operators. Since | and & have the same precedence as =, there are common mistakes where parenthesis are missing around the equality operators.
 "
 Class {
-	#name : #ReBooleanPrecedenceRule,
-	#superclass : #ReNodeMatchRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReBooleanPrecedenceRule',
+	#superclass : 'ReNodeMatchRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReBooleanPrecedenceRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'BooleanPrecedenceRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReBooleanPrecedenceRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReBooleanPrecedenceRule >> initialize [
 	super initialize.
 	self  matchesAny: #(
@@ -33,12 +35,12 @@ ReBooleanPrecedenceRule >> initialize [
 			'`@object1 & `@object2 ~~ `@object3' )
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReBooleanPrecedenceRule >> name [
 	^ 'Uses A | B = C instead of A | (B = C)'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReBooleanPrecedenceRule >> severity [
 	^ #error
 ]

--- a/src/GeneralRules/ReCascadedNextPutAllsRule.class.st
+++ b/src/GeneralRules/ReCascadedNextPutAllsRule.class.st
@@ -11,24 +11,26 @@ String streamContents: [ :s|
 		s nextPutAll: '---' ].
 "
 Class {
-	#name : #ReCascadedNextPutAllsRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReCascadedNextPutAllsRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReCascadedNextPutAllsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'CascadedNextPutAllsRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReCascadedNextPutAllsRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReCascadedNextPutAllsRule >> initialize [
 	super initialize.
 	self
@@ -36,12 +38,12 @@ ReCascadedNextPutAllsRule >> initialize [
 		replace: '``@rcvr show: ``@object1 , ``@object2' with: '``@rcvr show: ``@object1; show: ``@object2'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReCascadedNextPutAllsRule >> name [
 	^ 'Use cascaded nextPutAll:''s instead of #, in #nextPutAll:'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReCascadedNextPutAllsRule >> rationale [
 	^ 'Use cascaded nextPutAll:''s instead of #, in #nextPutAll:.'
 ]

--- a/src/GeneralRules/ReClassNameInSelectorRule.class.st
+++ b/src/GeneralRules/ReClassNameInSelectorRule.class.st
@@ -4,24 +4,26 @@ This smell arises when the class name is found in a selector. This is redundant 
 For example, #openHierarchyBrowserFrom: is a redundant name for HierarchyBrowser.
 "
 Class {
-	#name : #ReClassNameInSelectorRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReClassNameInSelectorRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReClassNameInSelectorRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReClassNameInSelectorRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ClassNameInSelectorRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReClassNameInSelectorRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	| className classNameIndex |
 	(aMethod methodClass isMeta) ifFalse: [ ^ self ].
@@ -38,7 +40,7 @@ ReClassNameInSelectorRule >> check: aMethod forCritiquesDo: aCriticBlock [
 			yourself) ]
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReClassNameInSelectorRule >> critiqueFor: aMethod withInterval: anInterval [
 
 	^ ReTrivialCritique
@@ -48,17 +50,17 @@ ReClassNameInSelectorRule >> critiqueFor: aMethod withInterval: anInterval [
 		by: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReClassNameInSelectorRule >> group [
 	^ 'Style'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReClassNameInSelectorRule >> name [
 	^ 'Redundant class name in selector'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReClassNameInSelectorRule >> rationale [
 	^ 'Checks for the class name in a selector. This is redundant since to call the you must already refer to the class name. For example, openHierarchyBrowserFrom: is a redundant name for HierarchyBrowser. Avoiding selector including class name gives a chance to have more polymorphic methods.'
 ]

--- a/src/GeneralRules/ReClassNotCategorizedRule.class.st
+++ b/src/GeneralRules/ReClassNotCategorizedRule.class.st
@@ -4,25 +4,27 @@ If a package contains classes that are not tagged then this is OK. But when a ta
 The goal is to have no classes that are shown as ""Uncategorized"" in the system browser.
 "
 Class {
-	#name : #ReClassNotCategorizedRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReClassNotCategorizedRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReClassNotCategorizedRule class >> checksClass [
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReClassNotCategorizedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ReClassNotCategorizedRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReClassNotCategorizedRule >> basicCheck: aClass [
 
 	aClass isMeta ifTrue: [ ^ false ].
@@ -30,23 +32,23 @@ ReClassNotCategorizedRule >> basicCheck: aClass [
 	^ aClass packageTag isRoot and: [ aClass package classTags size > 1 ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReClassNotCategorizedRule >> group [
 	^ 'Design Flaws'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReClassNotCategorizedRule >> name [
 
 	^ 'Uncategorized class - missing class tag'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReClassNotCategorizedRule >> rationale [
 	^ 'Classes should be categorized with a tag if other class tags exist in the package. Use "Base" as default if you can not provide a better name.'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReClassNotCategorizedRule >> severity [
 
 	^ #information

--- a/src/GeneralRules/ReClassNotReferencedRule.class.st
+++ b/src/GeneralRules/ReClassNotReferencedRule.class.st
@@ -2,44 +2,46 @@
 This smell arises when a class is not referenced either directly or indirectly by a symbol. If a class is not referenced, it can be removed.
 "
 Class {
-	#name : #ReClassNotReferencedRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReClassNotReferencedRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReClassNotReferencedRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReClassNotReferencedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ClassNotReferencedRule'
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ReClassNotReferencedRule >> basicCheck: aClass [
 	^ aClass isUsed not
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReClassNotReferencedRule >> group [
 	^ 'Design Flaws'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReClassNotReferencedRule >> name [
 	^ 'Class not referenced'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReClassNotReferencedRule >> rationale [
 	^ 'Check if a class is referenced either directly or indirectly by a symbol. If a class is not referenced, it can be removed.'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReClassNotReferencedRule >> severity [
 	^ #information
 ]

--- a/src/GeneralRules/ReClassVariableCapitalizationRule.class.st
+++ b/src/GeneralRules/ReClassVariableCapitalizationRule.class.st
@@ -2,17 +2,19 @@
 Class and pool variable names should start with an uppercase letter.
 "
 Class {
-	#name : #ReClassVariableCapitalizationRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReClassVariableCapitalizationRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #'testing-interest' }
+{ #category : 'testing-interest' }
 ReClassVariableCapitalizationRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReClassVariableCapitalizationRule >> check: aClass forCritiquesDo: aCriticBlock [
 	aClass isMeta ifTrue: [ ^ self ].
 	aClass classVarNames, aClass sharedPoolNames
@@ -22,7 +24,7 @@ ReClassVariableCapitalizationRule >> check: aClass forCritiquesDo: aCriticBlock 
 				(self critiqueFor: aClass about: each) ]
 ]
 
-{ #category : #'running - helpers' }
+{ #category : 'running - helpers' }
 ReClassVariableCapitalizationRule >> critiqueFor: aClass about: aVarName [
 
 	| crit |
@@ -43,12 +45,12 @@ ReClassVariableCapitalizationRule >> critiqueFor: aClass about: aVarName [
 	^ crit
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReClassVariableCapitalizationRule >> group [
 	^ 'Style'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReClassVariableCapitalizationRule >> name [
 	^ 'Class (or pool) variable not capitalized'
 ]

--- a/src/GeneralRules/ReClassVariableNeitherReadNorWrittenRule.class.st
+++ b/src/GeneralRules/ReClassVariableNeitherReadNorWrittenRule.class.st
@@ -2,35 +2,37 @@
 This smell arises when a class variable is not both read and written. If a class variable is only read, the reads can be replaced by nil, since it could not have been assigned a value. If the variable is only written, then it does not need to store the result since it is never used.
 "
 Class {
-	#name : #ReClassVariableNeitherReadNorWrittenRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReClassVariableNeitherReadNorWrittenRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #'testing-interest' }
+{ #category : 'testing-interest' }
 ReClassVariableNeitherReadNorWrittenRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReClassVariableNeitherReadNorWrittenRule >> check: aClass forCritiquesDo: aCriticBlock [
 	aClass classVariables
 		select: [ :variable | variable isReferenced not ]
 		thenDo: [ :variable | aCriticBlock cull: (self critiqueFor: aClass about: variable name) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReClassVariableNeitherReadNorWrittenRule >> group [
 	^ 'Clean Code'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReClassVariableNeitherReadNorWrittenRule >> name [
 
 	^ 'Class variable not read or not written'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReClassVariableNeitherReadNorWrittenRule >> severity [
 	^ #information
 ]

--- a/src/GeneralRules/ReClassVariablesShadowingRule.class.st
+++ b/src/GeneralRules/ReClassVariablesShadowingRule.class.st
@@ -2,18 +2,20 @@
 This rule checks if a instance or class variable shadows a global
 "
 Class {
-	#name : #ReClassVariablesShadowingRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReClassVariablesShadowingRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #'testing-interest' }
+{ #category : 'testing-interest' }
 ReClassVariablesShadowingRule class >> checksClass [
 
 	^ true
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReClassVariablesShadowingRule >> check: aClass forCritiquesDo: aCriticBlock [
 
 	aClass definedVariables
@@ -21,12 +23,12 @@ ReClassVariablesShadowingRule >> check: aClass forCritiquesDo: aCriticBlock [
 		thenDo: [ :variable | aCriticBlock cull: (self critiqueFor: aClass about: variable name) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReClassVariablesShadowingRule >> group [
 	^ 'Design Flaws'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReClassVariablesShadowingRule >> name [
 	^ 'Variable shadows a global variable'
 ]

--- a/src/GeneralRules/ReCodeCruftLeftInMethodsRule.class.st
+++ b/src/GeneralRules/ReCodeCruftLeftInMethodsRule.class.st
@@ -2,19 +2,21 @@
 This smell arises when a breakpoint,  logging statement,  etc is found in a method. This debugging code should not be left in production code.  Here are messages currently checked: clearHaltOnce,  doOnlyOnce: ,  halt, halt:   onCount:  object2, haltOnCount: , haltOnce, hatIf: , inspectOnCount: , inspectOnce, inspectUntilCount: , rearmOneShot, setHaltOnce, flag: , isThisEverCalled, isThisEverCalled: , logEntry, logExecution, logExit, needsWork and Transcript  messages.
 "
 Class {
-	#name : #ReCodeCruftLeftInMethodsRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReCodeCruftLeftInMethodsRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReCodeCruftLeftInMethodsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'CodeCruftLeftInMethodsRule'
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ReCodeCruftLeftInMethodsRule >> addRuleRemoving: patternString [
 	"When you are completely removing statement(s), you can not just match the relevant node. You must match the whole method and then replace it minus the part to be removed"
 
@@ -28,7 +30,7 @@ ReCodeCruftLeftInMethodsRule >> addRuleRemoving: patternString [
 	self replace: findString with: replaceString
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 ReCodeCruftLeftInMethodsRule >> anchorFor: aNode [
 	"we do not use the method of the superclass as it hightlights far too much"
     ^ ReIntervalSourceAnchor
@@ -36,32 +38,32 @@ ReCodeCruftLeftInMethodsRule >> anchorFor: aNode [
             interval: (1 to: aNode methodNode selector size)
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ReCodeCruftLeftInMethodsRule >> debuggingPatterns [
 	| result |
 	result := self debuggingSelectors collect: [ :e | self patternFor: e ].
 	^ result, { 'Transcript `@message: `@arg' }
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ReCodeCruftLeftInMethodsRule >> debuggingSelectors [
 
 	^ (Object allSelectorsInProtocol: 'flagging') , (Object allSelectorsInProtocol: 'debugging')
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReCodeCruftLeftInMethodsRule >> group [
 	^ 'Bugs'
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ReCodeCruftLeftInMethodsRule >> haltPatterns [
 	| result |
 	result := self haltSelectors collect: [ :e | self patternFor: e ].
 	^ result, { 'Halt `@message: `@arg' }
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ReCodeCruftLeftInMethodsRule >> haltSelectors [
 	| objectConvenience miscellaneous |
 	objectConvenience := Object allSelectorsInProtocol: #halting.
@@ -69,25 +71,25 @@ ReCodeCruftLeftInMethodsRule >> haltSelectors [
 	^ objectConvenience, miscellaneous
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReCodeCruftLeftInMethodsRule >> initialize [
 	super initialize.
 	self patterns do: [ :halt | self addRuleRemoving: halt ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReCodeCruftLeftInMethodsRule >> name [
 	^ 'Debugging code left in methods'
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ReCodeCruftLeftInMethodsRule >> patternFor: selector [
 	selector isUnary ifTrue: [ ^ '`@object ', selector ].
 	selector isBinary ifTrue: [ ^ '`@object ', selector, ' `@arg' ].
 	^ self patternForKeywordSelector: selector
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ReCodeCruftLeftInMethodsRule >> patternForKeywordSelector: selector [
 	|  index |
 	^ String streamContents: [ :str |
@@ -104,17 +106,17 @@ ReCodeCruftLeftInMethodsRule >> patternForKeywordSelector: selector [
 				str space ] ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ReCodeCruftLeftInMethodsRule >> patterns [
 	^ self debuggingPatterns, self haltPatterns
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReCodeCruftLeftInMethodsRule >> rationale [
 	^ 'Breakpoints, logging statements, etc. should not be left in production code.'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReCodeCruftLeftInMethodsRule >> severity [
 	^ #error
 ]

--- a/src/GeneralRules/ReCollectSelectNotUsedRule.class.st
+++ b/src/GeneralRules/ReCollectSelectNotUsedRule.class.st
@@ -4,31 +4,33 @@ Checks for senders of typical collection enumeration methods that return an unus
 For example, check that the result of a select: or detect: is used.
 "
 Class {
-	#name : #ReCollectSelectNotUsedRule,
-	#superclass : #ReNodeBasedRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReCollectSelectNotUsedRule',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReCollectSelectNotUsedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'CollectSelectNotUsedRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReCollectSelectNotUsedRule >> basicCheck: aNode [
 	aNode isMessage ifFalse: [ ^ false ].
 	(#(#select: #collect: #reject:) includes: aNode selector) ifFalse: [ ^ false ].
 	^ aNode isUsed not
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReCollectSelectNotUsedRule >> group [
 	^ 'Optimization'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReCollectSelectNotUsedRule >> name [
 	^ 'Doesn''t use the result of a collect:/select:'
 ]

--- a/src/GeneralRules/ReCollectionAtCollectionSizeRule.class.st
+++ b/src/GeneralRules/ReCollectionAtCollectionSizeRule.class.st
@@ -2,30 +2,32 @@
 Checks for code using  ""collection at: collection size"" instead of ""collection last"".
 "
 Class {
-	#name : #ReCollectionAtCollectionSizeRule,
-	#superclass : #ReNodeMatchRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReCollectionAtCollectionSizeRule',
+	#superclass : 'ReNodeMatchRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReCollectionAtCollectionSizeRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ReCollectionAtCollectionSizeRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReCollectionAtCollectionSizeRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReCollectionAtCollectionSizeRule >> initialize [
 	super initialize.
 	self  matchesAny: #('`@collection at: `@collection size')
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReCollectionAtCollectionSizeRule >> name [
 	^ 'Uses "collection at: collection size" instead of "collection last"'
 ]

--- a/src/GeneralRules/ReCollectionCopyEmptyRule.class.st
+++ b/src/GeneralRules/ReCollectionCopyEmptyRule.class.st
@@ -2,34 +2,36 @@
 Checks that all subclasses of the Collection classes that add an instance variable also redefine the copyEmpty method. This method is used when the collection grows. It copies over the necessary instance variables to the new larger collection.
 "
 Class {
-	#name : #ReCollectionCopyEmptyRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReCollectionCopyEmptyRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReCollectionCopyEmptyRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReCollectionCopyEmptyRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'CollectionCopyEmptyRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReCollectionCopyEmptyRule >> basicCheck: aClass [
 	^ (aClass inheritsFrom: Collection) and: [ aClass isVariable and: [ (aClass includesSelector: #copyEmpty) not and: [ aClass instVarNames isNotEmpty ] ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReCollectionCopyEmptyRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReCollectionCopyEmptyRule >> name [
 	^ 'Subclass of collection that has instance variable but doesn''t define copyEmpty'
 ]

--- a/src/GeneralRules/ReCollectionMessagesToExternalObjectRule.class.st
+++ b/src/GeneralRules/ReCollectionMessagesToExternalObjectRule.class.st
@@ -2,19 +2,21 @@
 Checks for methods that appear to be modifying a collection that is owned by another object. Such modifications can cause problems especially if other variables are modified when the collection is modified. For example, CompositePart must set the containers of all its parts when adding a new component.
 "
 Class {
-	#name : #ReCollectionMessagesToExternalObjectRule,
-	#superclass : #ReNodeMatchRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReCollectionMessagesToExternalObjectRule',
+	#superclass : 'ReNodeMatchRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReCollectionMessagesToExternalObjectRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'CollectionMessagesToExternalObjectRule'
 ]
 
-{ #category : #hooks }
+{ #category : 'hooks' }
 ReCollectionMessagesToExternalObjectRule >> afterCheck: aNode mappings: mappingDict [
 	| collectionGetter collectionOwner |
 	collectionGetter := mappingDict at: '`@collectionGetter:'.
@@ -27,12 +29,12 @@ ReCollectionMessagesToExternalObjectRule >> afterCheck: aNode mappings: mappingD
 	^ (aNode scope lookupVar: collectionOwner name) scope ~= Smalltalk globals
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReCollectionMessagesToExternalObjectRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReCollectionMessagesToExternalObjectRule >> initialize [
 	super initialize.
 	self matchesAny: #(
@@ -43,7 +45,7 @@ ReCollectionMessagesToExternalObjectRule >> initialize [
 		)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReCollectionMessagesToExternalObjectRule >> name [
 	^ 'Sends add:/remove: to external collection'
 ]

--- a/src/GeneralRules/ReCollectionProtocolRule.class.st
+++ b/src/GeneralRules/ReCollectionProtocolRule.class.st
@@ -2,24 +2,26 @@
 Checks code using the do: method instead of using the collect: or select: methods. This often occurs with new people writing code. The collect: and select: variants express the source code''s intentions better.
 "
 Class {
-	#name : #ReCollectionProtocolRule,
-	#superclass : #ReNodeMatchRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReCollectionProtocolRule',
+	#superclass : 'ReNodeMatchRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReCollectionProtocolRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'CollectionProtocolRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReCollectionProtocolRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReCollectionProtocolRule >> initialize [
 	super initialize.
 	self matchesAny: #(
@@ -42,7 +44,7 @@ ReCollectionProtocolRule >> initialize [
 			`@.Statements2]' )
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReCollectionProtocolRule >> name [
 	^ 'Uses do: instead of collect: or select:''s'
 ]

--- a/src/GeneralRules/ReDeadBlockRule.class.st
+++ b/src/GeneralRules/ReDeadBlockRule.class.st
@@ -3,40 +3,42 @@ Dead Block. The block is not assigned, not returned and no message is send to it
 Often this is a left over from using blocks to comment out code.
 "
 Class {
-	#name : #ReDeadBlockRule,
-	#superclass : #ReNodeBasedRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReDeadBlockRule',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDeadBlockRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'DeadBlockRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReDeadBlockRule >> basicCheck: node [
 	^ node isBlock and: [ node isUsed not ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDeadBlockRule >> group [
 	^ 'Optimization'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDeadBlockRule >> name [
 	^ 'Dead Block'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDeadBlockRule >> rationale [
 	^ 'Dead Block. The block is not assigned, not returned and no message is send to it.
 Often this is a left over from using blocks to comment out code.'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDeadBlockRule >> severity [
 	^ #information
 ]

--- a/src/GeneralRules/ReDefineBasicCheckRule.class.st
+++ b/src/GeneralRules/ReDefineBasicCheckRule.class.st
@@ -6,22 +6,24 @@ If the entity violates the rule, method should ruturn ""true"", otherwise - ""fa
 It is recommended to reuse #basicCheck: functionality in #checkClass: and #checkMethod:
 "
 Class {
-	#name : #ReDefineBasicCheckRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReDefineBasicCheckRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReDefineBasicCheckRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReDefineBasicCheckRule >> basicCheck: aClass [
 	^ (aClass inheritsFrom: RBLintRule) and: [ aClass isVisible and: [ (aClass lookupSelector: #basicCheck:) isSubclassResponsibility ] ]
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 ReDefineBasicCheckRule >> critiqueFor: aClass [
 	^ (ReMissingMethodCritique
 		for: aClass
@@ -30,12 +32,12 @@ ReDefineBasicCheckRule >> critiqueFor: aClass [
 		selector: #basicCheck:) beShouldBeImplemented
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDefineBasicCheckRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDefineBasicCheckRule >> name [
 	^ 'Rule does not define #basicCheck:'
 ]

--- a/src/GeneralRules/ReDefineEntityComplianceCheckRule.class.st
+++ b/src/GeneralRules/ReDefineEntityComplianceCheckRule.class.st
@@ -2,38 +2,40 @@
 The rule checks if the class rule in question specifies which entities it can check
 "
 Class {
-	#name : #ReDefineEntityComplianceCheckRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReDefineEntityComplianceCheckRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReDefineEntityComplianceCheckRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReDefineEntityComplianceCheckRule >> basicCheck: aClass [
 	^ (aClass inheritsFrom: RBLintRule) and: [ aClass isVisible and: [ self complianceMethods noneSatisfy: [ :method | aClass perform: method ] ] ]
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 ReDefineEntityComplianceCheckRule >> complianceMethods [
 
 	^ #(checksMethod checksClass checksPackage)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDefineEntityComplianceCheckRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDefineEntityComplianceCheckRule >> name [
 	^ 'Rule does not define entity compliance'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDefineEntityComplianceCheckRule >> rationale [
 
 	^ 'You should override on the CLASS SIDE at least one of #',

--- a/src/GeneralRules/ReDefinesEqualNotHashRule.class.st
+++ b/src/GeneralRules/ReDefinesEqualNotHashRule.class.st
@@ -12,34 +12,36 @@ One pattern proposed by Kent Beck in Best Smalltalk Practices is to define hash 
 		^ (self title hash bitXor: self title hash		
 "
 Class {
-	#name : #ReDefinesEqualNotHashRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReDefinesEqualNotHashRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReDefinesEqualNotHashRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDefinesEqualNotHashRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'DefinesEqualNotHashRule'
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ReDefinesEqualNotHashRule >> basicCheck: aClass [
 	^ (aClass includesSelector: #=) and: [ (aClass includesSelector: #hash) not ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDefinesEqualNotHashRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDefinesEqualNotHashRule >> name [
 	^ 'Defines = but not hash'
 ]

--- a/src/GeneralRules/ReDeprecateWithFirstCharacterDownshiftedRule.class.st
+++ b/src/GeneralRules/ReDeprecateWithFirstCharacterDownshiftedRule.class.st
@@ -2,31 +2,33 @@
 Use uncapitalized instead of withFirstCharacterDownshifted since withFirstCharacterDownshifted is ugly and is deprecated now.
 "
 Class {
-	#name : #ReDeprecateWithFirstCharacterDownshiftedRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReDeprecateWithFirstCharacterDownshiftedRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDeprecateWithFirstCharacterDownshiftedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'FirstCharacterDownShifted'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDeprecateWithFirstCharacterDownshiftedRule >> group [
 	^ 'Style'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReDeprecateWithFirstCharacterDownshiftedRule >> initialize [
 	super initialize.
 	self
 		replace: '``@object withFirstCharacterDownshifted' with: '``@object uncapitalized'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDeprecateWithFirstCharacterDownshiftedRule >> name [
 	^ 'Use uncapitalized instead of withFirstCharacterDownshifted'
 ]

--- a/src/GeneralRules/ReDetectContainsRule.class.st
+++ b/src/GeneralRules/ReDetectContainsRule.class.st
@@ -2,24 +2,26 @@
 Checks for bytecodePrimEqual  using the do: method instead of using the contains: or detect: methods.
 "
 Class {
-	#name : #ReDetectContainsRule,
-	#superclass : #ReNodeMatchRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReDetectContainsRule',
+	#superclass : 'ReNodeMatchRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDetectContainsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'DetectContainsRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDetectContainsRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReDetectContainsRule >> initialize [
 	super initialize.
 	self matchesAny: #(
@@ -49,7 +51,7 @@ ReDetectContainsRule >> initialize [
 				`@.Statements2]' )
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDetectContainsRule >> name [
 	^ 'Uses do: instead of contains: or detect:''s'
 ]

--- a/src/GeneralRules/ReDetectIfNoneRule.class.st
+++ b/src/GeneralRules/ReDetectIfNoneRule.class.st
@@ -13,24 +13,26 @@ collection anySatisfy: [ :each | .... ])
 ]]]
 "
 Class {
-	#name : #ReDetectIfNoneRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReDetectIfNoneRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDetectIfNoneRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'DetectIfNoneRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDetectIfNoneRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReDetectIfNoneRule >> initialize [
 	super initialize.
 	self
@@ -56,12 +58,12 @@ ReDetectIfNoneRule >> initialize [
 		with: '``@collection anySatisfy: [:`each | | `@temps | ``@.Statements]'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDetectIfNoneRule >> name [
 	^ '#detect:ifNone: or #contains: -> #anySatisfy:'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDetectIfNoneRule >> rationale [
 	^ 'Replaces detect:ifNone: and contains: by anySatisfy:'
 ]

--- a/src/GeneralRules/ReDoNotSendSuperInitializeInClassSideRule.class.st
+++ b/src/GeneralRules/ReDoNotSendSuperInitializeInClassSideRule.class.st
@@ -12,19 +12,21 @@ ZnServer class>>initialize
 ]]]
 "
 Class {
-	#name : #ReDoNotSendSuperInitializeInClassSideRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReDoNotSendSuperInitializeInClassSideRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDoNotSendSuperInitializeInClassSideRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'DoNotSendSuperInitializeInClassSideRule'
 ]
 
-{ #category : #hooks }
+{ #category : 'hooks' }
 ReDoNotSendSuperInitializeInClassSideRule >> afterCheck: aNode mappings: mappingDict [
 
 	aNode methodNode ifNotNil: [ :methNode |
@@ -36,12 +38,12 @@ ReDoNotSendSuperInitializeInClassSideRule >> afterCheck: aNode mappings: mapping
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDoNotSendSuperInitializeInClassSideRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReDoNotSendSuperInitializeInClassSideRule >> initialize [
 	super initialize.
 	self
@@ -49,7 +51,7 @@ ReDoNotSendSuperInitializeInClassSideRule >> initialize [
 		with: ''
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReDoNotSendSuperInitializeInClassSideRule >> name [
 	^ 'Class-side #initialize should not send "super initialize".'
 ]

--- a/src/GeneralRules/ReEmptyExceptionHandlerRule.class.st
+++ b/src/GeneralRules/ReEmptyExceptionHandlerRule.class.st
@@ -8,19 +8,21 @@ Empty exception handler blocks hide potential bugs. The situation should be hand
 having an empty block is a bad idea because the program silently fails.
 "
 Class {
-	#name : #ReEmptyExceptionHandlerRule,
-	#superclass : #ReNodeMatchRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReEmptyExceptionHandlerRule',
+	#superclass : 'ReNodeMatchRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReEmptyExceptionHandlerRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'EmptyExceptionHandlerRule'
 ]
 
-{ #category : #hooks }
+{ #category : 'hooks' }
 ReEmptyExceptionHandlerRule >> afterCheck: aNode mappings: mappingDict [
 	| exception class |
 	exception := mappingDict at: '`exception'.
@@ -33,12 +35,12 @@ ReEmptyExceptionHandlerRule >> afterCheck: aNode mappings: mappingDict [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReEmptyExceptionHandlerRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReEmptyExceptionHandlerRule >> initialize [
 	super initialize.
 	self matches:
@@ -47,7 +49,7 @@ ReEmptyExceptionHandlerRule >> initialize [
 			do: [ :`@err | | `@temps | ]'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReEmptyExceptionHandlerRule >> name [
 	^ 'Empty exception handler'
 ]

--- a/src/GeneralRules/ReEqualNilRule.class.st
+++ b/src/GeneralRules/ReEqualNilRule.class.st
@@ -2,24 +2,26 @@
 Replaces = nil and == nil by isNil, ~= nil and ~~ nil by notNil to make the code more readable.  
 "
 Class {
-	#name : #ReEqualNilRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReEqualNilRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReEqualNilRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'EqualNilRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReEqualNilRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReEqualNilRule >> initialize [
 	super initialize.
 	self
@@ -29,7 +31,7 @@ ReEqualNilRule >> initialize [
 		replace: '``@object ~~ nil' with: '``@object notNil'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReEqualNilRule >> name [
 	^ '= nil -> isNil AND ~= nil -> notNil'
 ]

--- a/src/GeneralRules/ReEqualNotUsedRule.class.st
+++ b/src/GeneralRules/ReEqualNotUsedRule.class.st
@@ -2,29 +2,31 @@
 Checks for senders of comparator messages that do not use the result of the comparison.
 "
 Class {
-	#name : #ReEqualNotUsedRule,
-	#superclass : #ReNodeBasedRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReEqualNotUsedRule',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReEqualNotUsedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'EqualNotUsedRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReEqualNotUsedRule >> basicCheck: node [
 	^ node isMessage and: [ node isUsed not and: [ #(#= #== #~= #~~ #< #> #<= #>=) includes: node selector ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReEqualNotUsedRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReEqualNotUsedRule >> name [
 	^ 'Doesn''t use the result of a =, ~=, etc.'
 ]

--- a/src/GeneralRules/ReEqualsTrueRule.class.st
+++ b/src/GeneralRules/ReEqualsTrueRule.class.st
@@ -2,19 +2,21 @@
 Check for a =, ==, ~=, or ~~ message being sent to true/false or with true/false as the argument. Many times these can be eliminated since their receivers are already booleans. For example, ""anObject isFoo == false"" could be replaced with ""anObject isFoo not"" if isFoo always returns a boolean. Sometimes variables might refer to true, false, and something else, but this is considered bad style since the variable has multiple types.
 "
 Class {
-	#name : #ReEqualsTrueRule,
-	#superclass : #ReNodeBasedRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReEqualsTrueRule',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReEqualsTrueRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'EqualsTrueRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReEqualsTrueRule >> basicCheck: aNode [
 	| parent |
 	aNode isLiteralNode ifFalse: [ ^ false ].
@@ -24,17 +26,17 @@ ReEqualsTrueRule >> basicCheck: aNode [
 	^ #(#= #== #~= #~~) includes: parent selector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReEqualsTrueRule >> group [
 	^ 'Optimization'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReEqualsTrueRule >> name [
 	^ 'Unnecessary "= true"'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReEqualsTrueRule >> severity [
 	^ #information
 ]

--- a/src/GeneralRules/ReEquivalentSuperclassMethodsRule.class.st
+++ b/src/GeneralRules/ReEquivalentSuperclassMethodsRule.class.st
@@ -4,24 +4,26 @@ This smell arises when a method is equivalent to its superclass method. The meth
 Furthermore, the methods #new and #initialize are ignored once they are often overridden for compatilbity with other platforms. The ignored methods can be edited in RBEquivalentSuperclassMethodsRule>>ignoredSelectors
 "
 Class {
-	#name : #ReEquivalentSuperclassMethodsRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReEquivalentSuperclassMethodsRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReEquivalentSuperclassMethodsRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReEquivalentSuperclassMethodsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'EquivalentSuperclassMethodsRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReEquivalentSuperclassMethodsRule >> basicCheck: aMethod [
 	(self ignoredSelectors includes: aMethod selector) ifTrue: [ ^ false ].
 
@@ -32,24 +34,24 @@ ReEquivalentSuperclassMethodsRule >> basicCheck: aMethod [
 		ifNil: [ false ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReEquivalentSuperclassMethodsRule >> group [
 	^ 'Design Flaws'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReEquivalentSuperclassMethodsRule >> ignoredSelectors [
 	"These methods are often overridden for compatilbity with other platforms."
 
 	^ #(new initialize)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReEquivalentSuperclassMethodsRule >> name [
 	^ 'Methods equivalently defined in superclass'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReEquivalentSuperclassMethodsRule >> rationale [
 	^ 'Check for methods that are equivalent to their superclass methods.'
 ]

--- a/src/GeneralRules/ReExcessiveArgumentsRule.class.st
+++ b/src/GeneralRules/ReExcessiveArgumentsRule.class.st
@@ -6,29 +6,31 @@ If the arguments are used in multiple methods this is a clear indication for the
 The defined number of arguments can be edited in #argumentsCount.
 "
 Class {
-	#name : #ReExcessiveArgumentsRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReExcessiveArgumentsRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReExcessiveArgumentsRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReExcessiveArgumentsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ExcessiveArgumentsRule'
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ReExcessiveArgumentsRule >> argumentsCount [
 	^ 5
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReExcessiveArgumentsRule >> basicCheck: aMethod [
 
 	"If method includes UFFI calls then it is OK to have high number of arguments"
@@ -37,17 +39,17 @@ ReExcessiveArgumentsRule >> basicCheck: aMethod [
 	^ aMethod numArgs >= self argumentsCount
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReExcessiveArgumentsRule >> group [
 	^ 'Design Flaws'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReExcessiveArgumentsRule >> name [
 	^ 'Excessive number of arguments'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReExcessiveArgumentsRule >> rationale [
 	^ 'Long argument lists (five or more) can indicate that a new object should be created to wrap the numerous parameters.'
 ]

--- a/src/GeneralRules/ReExcessiveInheritanceRule.class.st
+++ b/src/GeneralRules/ReExcessiveInheritanceRule.class.st
@@ -10,46 +10,48 @@ Note that often a framework may already define a certain level of inheritance, w
 The defined inheritance depth can be edited in #inheritanceDepth.
 "
 Class {
-	#name : #ReExcessiveInheritanceRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReExcessiveInheritanceRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReExcessiveInheritanceRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReExcessiveInheritanceRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ExcessiveInheritanceRule'
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ReExcessiveInheritanceRule >> basicCheck: aClass [
 	aClass isMeta ifTrue: [ ^ false ].
 
 	^ aClass allSuperclasses size >= self inheritanceDepth
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReExcessiveInheritanceRule >> group [
 	^ 'Design Flaws'
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ReExcessiveInheritanceRule >> inheritanceDepth [
 	^ 10
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReExcessiveInheritanceRule >> name [
 	^ 'Excessive inheritance depth'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReExcessiveInheritanceRule >> rationale [
 	^ 'Deep inheritance (10+ depth) is usually a sign of a design flaw.'
 ]

--- a/src/GeneralRules/ReExcessiveMethodsRule.class.st
+++ b/src/GeneralRules/ReExcessiveMethodsRule.class.st
@@ -8,44 +8,46 @@ An indication that a class may have too many responsibilities is when different 
 The defined number of methods can be edited in #methodsCount.
 "
 Class {
-	#name : #ReExcessiveMethodsRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReExcessiveMethodsRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReExcessiveMethodsRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReExcessiveMethodsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ExcessiveMethodsRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReExcessiveMethodsRule >> basicCheck: aClass [
 	^ aClass selectors size >= self methodsCount
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReExcessiveMethodsRule >> group [
 	^ 'Design Flaws'
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ReExcessiveMethodsRule >> methodsCount [
 	^ 60
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReExcessiveMethodsRule >> name [
 	^ 'Excessive number of methods'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReExcessiveMethodsRule >> rationale [
 	^ 'Large classes are indications that the class may be trying to do too much.'
 ]

--- a/src/GeneralRules/ReExcessiveVariablesRule.class.st
+++ b/src/GeneralRules/ReExcessiveVariablesRule.class.st
@@ -4,46 +4,48 @@ Sometimes instance variables are used instead of method arguments or temporaries
 The defined number of instance variables can be edited in #variablesCount.
 "
 Class {
-	#name : #ReExcessiveVariablesRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReExcessiveVariablesRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReExcessiveVariablesRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReExcessiveVariablesRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ExcessiveVariablesRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReExcessiveVariablesRule >> basicCheck: aClass [
 	^ aClass instVarNames size >= self variablesCount or: [
 		"Shared pools are just there to define vars, so it is ok for them to have a lot"
 		(aClass instanceSide isPool not) and: [aClass classVarNames size >= self variablesCount ]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReExcessiveVariablesRule >> group [
 	^ 'Design Flaws'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReExcessiveVariablesRule >> name [
 	^ 'Excessive number of variables'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReExcessiveVariablesRule >> rationale [
 	^ 'Classes that have too many instance variables (10+) could be redesigned to have fewer fields, possibly through some nested object grouping.'
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ReExcessiveVariablesRule >> variablesCount [
 	^ 10
 ]

--- a/src/GeneralRules/ReExplicitRequirementMethodsRule.class.st
+++ b/src/GeneralRules/ReExplicitRequirementMethodsRule.class.st
@@ -2,23 +2,25 @@
 Classes that use traits with explicit requirement methods should either implement the method or inherit it.
 "
 Class {
-	#name : #ReExplicitRequirementMethodsRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReExplicitRequirementMethodsRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReExplicitRequirementMethodsRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReExplicitRequirementMethodsRule class >> uniqueIdentifierName [
 
 	^ 'ExplicitRequirementMethodsRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReExplicitRequirementMethodsRule >> check: aClass forCritiquesDo: aCritiqueBlock [
 	| explicitRequirementMethods |
 	aClass isTrait ifTrue: [ ^ self ].
@@ -40,12 +42,12 @@ ReExplicitRequirementMethodsRule >> check: aClass forCritiquesDo: aCritiqueBlock
 						yourself) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReExplicitRequirementMethodsRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReExplicitRequirementMethodsRule >> name [
 	^ 'Explicit requirement methods'
 ]

--- a/src/GeneralRules/ReExtraBlockRule.class.st
+++ b/src/GeneralRules/ReExtraBlockRule.class.st
@@ -3,19 +3,21 @@ Check for blocks that are immediately evaluated. Since the block is immediately 
 For example, [:x | 1 + x] value: 4 is equivalent to 1 + 4
 "
 Class {
-	#name : #ReExtraBlockRule,
-	#superclass : #ReNodeBasedRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReExtraBlockRule',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReExtraBlockRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ExtraBlockRule'
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ReExtraBlockRule >> basicCheck: node [
 	node isMessage ifFalse: [ ^ false ].
 	node receiver isBlock ifFalse: [ ^ false ].
@@ -23,7 +25,7 @@ ReExtraBlockRule >> basicCheck: node [
 	^ self blockEvaluatingMessages includes: node selector
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ReExtraBlockRule >> blockEvaluatingMessages [
 	^ #(value
 	value: value:value: value:value:value: value:value:value:value:
@@ -31,17 +33,17 @@ ReExtraBlockRule >> blockEvaluatingMessages [
 	#valueWithArguments: valueWithPossibleArgs: valueWithPossibleArgument)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReExtraBlockRule >> group [
 	^ 'Optimization'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReExtraBlockRule >> name [
 	^ 'Block immediately evaluated'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReExtraBlockRule >> severity [
 	^ #information
 ]

--- a/src/GeneralRules/ReFileBlocksRule.class.st
+++ b/src/GeneralRules/ReFileBlocksRule.class.st
@@ -18,24 +18,26 @@ This code can be changed to
     ] ensure: [ inputStream close ].
 "
 Class {
-	#name : #ReFileBlocksRule,
-	#superclass : #ReNodeMatchRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReFileBlocksRule',
+	#superclass : 'ReNodeMatchRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReFileBlocksRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'FileBlocksRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReFileBlocksRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReFileBlocksRule >> initialize [
 	super initialize.
 	self matchesAny: #(
@@ -51,12 +53,12 @@ ReFileBlocksRule >> initialize [
 							[`var `@messages: `@args]' )
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReFileBlocksRule >> name [
 	^ 'Assignment inside unwind blocks should be outside.'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReFileBlocksRule >> rationale [
 	^ 'Checks assignment to a variable that is the first statement inside the value block that is also used in the unwind block.'
 ]

--- a/src/GeneralRules/ReFloatEqualityComparisonRule.class.st
+++ b/src/GeneralRules/ReFloatEqualityComparisonRule.class.st
@@ -2,29 +2,31 @@
 Floating point types are imprecise. Using the operators = or ~= might not yield the expected result due to internal rounding differences.
 "
 Class {
-	#name : #ReFloatEqualityComparisonRule,
-	#superclass : #ReNodeMatchRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReFloatEqualityComparisonRule',
+	#superclass : 'ReNodeMatchRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReFloatEqualityComparisonRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'FloatEqualityComparisonRule'
 ]
 
-{ #category : #hooks }
+{ #category : 'hooks' }
 ReFloatEqualityComparisonRule >> afterCheck: aNode mappings: mappingDict [
 	^ (mappingDict at: '`#floatLiteral') value isFloat
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReFloatEqualityComparisonRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReFloatEqualityComparisonRule >> initialize [
 	super initialize.
 	self matchesAny: #(
@@ -34,7 +36,7 @@ ReFloatEqualityComparisonRule >> initialize [
 			'`@expr ~= `#floatLiteral' )
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReFloatEqualityComparisonRule >> name [
 	^ 'Float equality comparison'
 ]

--- a/src/GeneralRules/ReGlobalVariablesUsageRule.class.st
+++ b/src/GeneralRules/ReGlobalVariablesUsageRule.class.st
@@ -4,17 +4,19 @@ Global Variables are a known design smell.
 Specially in Pharo, we do not want to keep global bindings because their usage can a will produce undesirable implicit coupling, avoiding out language to evolve into the usage of powerful modules. 
 "
 Class {
-	#name : #ReGlobalVariablesUsageRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReGlobalVariablesUsageRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #'testing-interest' }
+{ #category : 'testing-interest' }
 ReGlobalVariablesUsageRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReGlobalVariablesUsageRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	aMethod ast allChildren
 		select: [ :node |
@@ -28,12 +30,12 @@ ReGlobalVariablesUsageRule >> check: aMethod forCritiquesDo: aCriticBlock [
 				hint: node name) ]
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReGlobalVariablesUsageRule >> group [
 	^ 'Design Flaws'
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReGlobalVariablesUsageRule >> isKnownGlobal: aString [
 	^ #(
 			ActiveEvent
@@ -49,12 +51,12 @@ ReGlobalVariablesUsageRule >> isKnownGlobal: aString [
 		) includes: aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReGlobalVariablesUsageRule >> name [
 	^ 'Global variable usage'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReGlobalVariablesUsageRule >> rationale [
 	^ 'http://wiki.c2.com/?GlobalVariablesAreBad
 

--- a/src/GeneralRules/ReGuardClauseRule.class.st
+++ b/src/GeneralRules/ReGuardClauseRule.class.st
@@ -19,17 +19,19 @@ foo
 ]]]
 "
 Class {
-	#name : #ReGuardClauseRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReGuardClauseRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReGuardClauseRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReGuardClauseRule >> initialize [
 	super initialize.
 	self
@@ -57,7 +59,7 @@ ReGuardClauseRule >> initialize [
 					`@.Statements1'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReGuardClauseRule >> name [
 	^ 'Replace single branch conditional with guard clause'
 ]

--- a/src/GeneralRules/ReIfNotNilDoRule.class.st
+++ b/src/GeneralRules/ReIfNotNilDoRule.class.st
@@ -2,23 +2,25 @@
 ifNotNilDo: should not be used as ifNotNil: works for blocks with arguments, too.
 "
 Class {
-	#name : #ReIfNotNilDoRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReIfNotNilDoRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReIfNotNilDoRule class >> uniqueIdentifierName [
 
 	^ 'RuleIfNotNilDo'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReIfNotNilDoRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReIfNotNilDoRule >> initialize [
 	super initialize.
 	self
@@ -30,7 +32,7 @@ ReIfNotNilDoRule >> initialize [
 			with: '`@receiver ifNil: `@statements1 ifNotNil: `@statements2'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReIfNotNilDoRule >> name [
 	^ 'Use "ifNotNil:" not "ifNotNilDo:"'
 ]

--- a/src/GeneralRules/ReImplementedNotSentRule.class.st
+++ b/src/GeneralRules/ReImplementedNotSentRule.class.st
@@ -13,15 +13,17 @@ It can be forced to update by executing:
 	ReImplementedNotSentRule reset
 "
 Class {
-	#name : #ReImplementedNotSentRule,
-	#superclass : #ReAbstractRule,
+	#name : 'ReImplementedNotSentRule',
+	#superclass : 'ReAbstractRule',
 	#classInstVars : [
 		'allMessages'
 	],
-	#category : #'GeneralRules-Migrated'
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReImplementedNotSentRule class >> allMessages [
 	"return all 'message sends' in the system and cache them"
 
@@ -31,22 +33,22 @@ ReImplementedNotSentRule class >> allMessages [
 		  allMessages ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReImplementedNotSentRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #cleanup }
+{ #category : 'cleanup' }
 ReImplementedNotSentRule class >> cleanUp [
 	self reset
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReImplementedNotSentRule class >> enabled [
 	^ enabled ifNil: [ enabled := false ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReImplementedNotSentRule class >> enabled: aBoolean [
 	super enabled: aBoolean.
 	self reset.
@@ -55,7 +57,7 @@ ReImplementedNotSentRule class >> enabled: aBoolean [
 		ifFalse: [ self unsubscribe ]
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 ReImplementedNotSentRule class >> initialize [
 	"we do not want to register if the rule is disabled"
 	self enabled ifFalse: [ ^self ].
@@ -65,30 +67,30 @@ ReImplementedNotSentRule class >> initialize [
 		registerToolClassNamed: self name
 ]
 
-{ #category : #'system announcements' }
+{ #category : 'system announcements' }
 ReImplementedNotSentRule class >> methodAdded: anAnnouncement [
 
 	self allMessages addAll: anAnnouncement methodAdded messages
 ]
 
-{ #category : #'system announcements' }
+{ #category : 'system announcements' }
 ReImplementedNotSentRule class >> methodModified: anAnnouncement [
 
 	self allMessages addAll: anAnnouncement newMethod messages
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 ReImplementedNotSentRule class >> reset [
 	<script>
 	allMessages := nil
 ]
 
-{ #category : #cleanup }
+{ #category : 'cleanup' }
 ReImplementedNotSentRule class >> shutDown [
 	self reset
 ]
 
-{ #category : #announcement }
+{ #category : 'announcement' }
 ReImplementedNotSentRule class >> subscribe [
 	<systemEventRegistration>
 	self unsubscribe.
@@ -98,20 +100,20 @@ ReImplementedNotSentRule class >> subscribe [
 		when: MethodModified send: #methodModified: to: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReImplementedNotSentRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ImplementedNotSentRule'
 ]
 
-{ #category : #announcement }
+{ #category : 'announcement' }
 ReImplementedNotSentRule class >> unsubscribe [
 
 	SystemAnnouncer uniqueInstance unsubscribe: self
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReImplementedNotSentRule >> basicCheck: aMethod [
 	"Check if there are any senders. Furthermore methods with pragmas are likely to be sent through reflection, thus do not report those."
 
@@ -134,17 +136,17 @@ ReImplementedNotSentRule >> basicCheck: aMethod [
 			  ifFalse: [ false ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReImplementedNotSentRule >> group [
 	^ 'Design Flaws'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReImplementedNotSentRule >> name [
 	^ 'Methods implemented but not sent'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReImplementedNotSentRule >> severity [
 	^ #information
 ]

--- a/src/GeneralRules/ReInconsistentMethodClassificationRule.class.st
+++ b/src/GeneralRules/ReInconsistentMethodClassificationRule.class.st
@@ -4,24 +4,26 @@ This smell arises when a method protocol is not equivalent to the one defined in
 
 "
 Class {
-	#name : #ReInconsistentMethodClassificationRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReInconsistentMethodClassificationRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReInconsistentMethodClassificationRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReInconsistentMethodClassificationRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'InconsistentMethodClassificationRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReInconsistentMethodClassificationRule >> check: aMethod forCritiquesDo: aCritiqueBlock [
 
 	| ownerProtocol |
@@ -38,7 +40,7 @@ ReInconsistentMethodClassificationRule >> check: aMethod forCritiquesDo: aCritiq
 				aCritiqueBlock cull: ((self critiqueFor: aMethod) tinyHint: 'superclass categorizes as: ' , superProtocol name) ] ] ]
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 ReInconsistentMethodClassificationRule >> critiqueFor: aMethod [
 
 	| protocolInSuperclass |
@@ -54,17 +56,17 @@ ReInconsistentMethodClassificationRule >> critiqueFor: aMethod [
 			   inClass: aMethod methodClass name)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReInconsistentMethodClassificationRule >> group [
 	^ 'Design Flaws'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReInconsistentMethodClassificationRule >> name [
 	^ 'Inconsistent method classification'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReInconsistentMethodClassificationRule >> severity [
 	^ #information
 ]

--- a/src/GeneralRules/ReInstVarInSubclassesRule.class.st
+++ b/src/GeneralRules/ReInstVarInSubclassesRule.class.st
@@ -4,24 +4,26 @@ This smell arises when instance variables are defined in all subclasses. Many ti
 
 "
 Class {
-	#name : #ReInstVarInSubclassesRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReInstVarInSubclassesRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReInstVarInSubclassesRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReInstVarInSubclassesRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'InstVarInSubclassesRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReInstVarInSubclassesRule >> check: aClass forCritiquesDo: aCritiqueBlock [
 
 	| subs sels |
@@ -43,29 +45,29 @@ ReInstVarInSubclassesRule >> check: aClass forCritiquesDo: aCritiqueBlock [
 				yourself) ]
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReInstVarInSubclassesRule >> critiqueFor: aClass [
 	^ ReRefactoringCritique
 			withAnchor: (self anchorFor: aClass)
 			by: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReInstVarInSubclassesRule >> group [
 	^ 'Design Flaws'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReInstVarInSubclassesRule >> name [
 	^ 'Same instance variable defined in ALL subclasses'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReInstVarInSubclassesRule >> rationale [
 	^ 'All subclasses of this class define the same variable. Most likely this variable should be pulled up to the superclass.'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReInstVarInSubclassesRule >> severity [
 	^ #information
 ]

--- a/src/GeneralRules/ReInstanceVariableCapitalizationRule.class.st
+++ b/src/GeneralRules/ReInstanceVariableCapitalizationRule.class.st
@@ -2,17 +2,19 @@
 Instance variable names on the instance- and class-side should start with a lowercase letter.
 "
 Class {
-	#name : #ReInstanceVariableCapitalizationRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReInstanceVariableCapitalizationRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #'testing-interest' }
+{ #category : 'testing-interest' }
 ReInstanceVariableCapitalizationRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReInstanceVariableCapitalizationRule >> check: aClass forCritiquesDo: aCriticBlock [
 
 	aClass instVarNames
@@ -20,7 +22,7 @@ ReInstanceVariableCapitalizationRule >> check: aClass forCritiquesDo: aCriticBlo
 		thenDo: [ :each | aCriticBlock cull: (self critiqueFor: aClass about: each) ]
 ]
 
-{ #category : #'running - helpers' }
+{ #category : 'running - helpers' }
 ReInstanceVariableCapitalizationRule >> critiqueFor: aClass about: aVarName [
 
 	| crit |
@@ -41,12 +43,12 @@ ReInstanceVariableCapitalizationRule >> critiqueFor: aClass about: aVarName [
 	^ crit
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReInstanceVariableCapitalizationRule >> group [
 	^ 'Style'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReInstanceVariableCapitalizationRule >> name [
 	^ 'Instance variable capitalized'
 ]

--- a/src/GeneralRules/ReIsNilAndConditionalRule.class.st
+++ b/src/GeneralRules/ReIsNilAndConditionalRule.class.st
@@ -2,18 +2,20 @@
 Replaces isNil ifTrue , isNil ifFalse and isNil ifTrue:ifFalse by ifNil: , ifNotNil and ifNil:ifNotNil: to make the code more readable. Helps to avoid unnecesary temporal variables.
 "
 Class {
-	#name : #ReIsNilAndConditionalRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReIsNilAndConditionalRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReIsNilAndConditionalRule >> group [
 
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReIsNilAndConditionalRule >> initialize [
 
 	super initialize.
@@ -26,13 +28,13 @@ ReIsNilAndConditionalRule >> initialize [
 			with: '``@receiver ifNil: ``@nilBlock ifNotNil: ``@notNilBlock'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReIsNilAndConditionalRule >> name [
 
 	^ 'Sends isNil and a conditional check instead of using #ifNil: #ifNotNil: or #ifNil:ifNotNil:'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReIsNilAndConditionalRule >> rationale [
 
 	^ 'Using specific conditional methods leads to shorter code and helps in avoiding unneeded temporary variables.<n><n>Replaces<n><t>isNil ifTrue: ~~> ifNil:<n><t>isNil ifFalse: ~~> ifNotNil:<n><t>isNil ifTrue:ifFalse ~~> ifNil:ifNotNil:'

--- a/src/GeneralRules/ReIsNotNilAndConditionalRule.class.st
+++ b/src/GeneralRules/ReIsNotNilAndConditionalRule.class.st
@@ -3,18 +3,20 @@ Replaces isNotNil ifTrue , isNotNil ifFalse and isNotNil ifTrue:ifFalse by ifNot
 Works also with notNil.
 "
 Class {
-	#name : #ReIsNotNilAndConditionalRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReIsNotNilAndConditionalRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReIsNotNilAndConditionalRule >> group [
 
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReIsNotNilAndConditionalRule >> initialize [
 
 	super initialize.
@@ -34,13 +36,13 @@ ReIsNotNilAndConditionalRule >> initialize [
 			with: '``@receiver ifNotNil: ``@nilBlock ifNil: ``@notNilBlock'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReIsNotNilAndConditionalRule >> name [
 
 	^ 'Sends isNotNil / notNil and a conditional check instead of using #ifNil: #ifNotNil: or #ifNil:ifNotNil:'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReIsNotNilAndConditionalRule >> rationale [
 
 	^ 'Using specific conditional methods leads to shorter code and helps in avoiding unneeded temporary variables.<n><n>Replaces<n><t>isNotNil ifTrue: ~~> ifNotNil:<n><t>isNotNil ifFalse: ~~> ifNil:<n><t>isNotNil ifTrue:ifFalse ~~> ifNotNil:ifNil:'

--- a/src/GeneralRules/ReIvarNeitherReadNorWrittenRule.class.st
+++ b/src/GeneralRules/ReIvarNeitherReadNorWrittenRule.class.st
@@ -2,35 +2,37 @@
 This smell arises when an instance variable is not both read and written. If an instance variable is only read, the reads can be replaced by nil, since it could not have been assigned a value. If the variable is only written, then it does not need to store the result since it is never used.
 "
 Class {
-	#name : #ReIvarNeitherReadNorWrittenRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReIvarNeitherReadNorWrittenRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #'testing-interest' }
+{ #category : 'testing-interest' }
 ReIvarNeitherReadNorWrittenRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReIvarNeitherReadNorWrittenRule >> check: aClass forCritiquesDo: aCriticBlock [
 	aClass slots
 		select: [ :slot | slot isReferenced not ]
 		thenDo: [ :slot | aCriticBlock cull: (self critiqueFor: aClass about: slot name) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReIvarNeitherReadNorWrittenRule >> group [
 	^ 'Clean Code'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReIvarNeitherReadNorWrittenRule >> name [
 
 	^ 'Instance variable not read or not written'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReIvarNeitherReadNorWrittenRule >> severity [
 	^ #information
 ]

--- a/src/GeneralRules/ReJustSendsSuperRule.class.st
+++ b/src/GeneralRules/ReJustSendsSuperRule.class.st
@@ -2,53 +2,55 @@
 This smell arises when a method just forwards the message to its superclass. This often happens due to code changes or when you simply forget that you wanted to extend the behavior of a superclass method. These methods can be removed.
 "
 Class {
-	#name : #ReJustSendsSuperRule,
-	#superclass : #ReAbstractRule,
+	#name : 'ReJustSendsSuperRule',
+	#superclass : 'ReAbstractRule',
 	#instVars : [
 		'matcher'
 	],
-	#category : #'GeneralRules-Migrated'
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReJustSendsSuperRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReJustSendsSuperRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'JustSendsSuperRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReJustSendsSuperRule >> basicCheck: aMethod [
 	^ aMethod ast isPrimitive not and: [ matcher executeMethod: aMethod ast initialAnswer: false ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReJustSendsSuperRule >> group [
 	^ 'Optimization'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReJustSendsSuperRule >> initialize [
 	super initialize.
 	matcher := RBParseTreeSearcher justSendsSuper
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReJustSendsSuperRule >> name [
 	^ 'Method just sends super message'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReJustSendsSuperRule >> rationale [
 	^ 'Check for methods that just forward the message to its superclass.'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReJustSendsSuperRule >> severity [
 	^ #information
 ]

--- a/src/GeneralRules/ReKeysDoRule.class.st
+++ b/src/GeneralRules/ReKeysDoRule.class.st
@@ -9,24 +9,26 @@ Dictionary>>keys
 This array can be quite large and using the keysDo: does not create such intermediate collection.
 "
 Class {
-	#name : #ReKeysDoRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReKeysDoRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReKeysDoRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'keysDoRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReKeysDoRule >> group [
 	^ 'Optimization'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReKeysDoRule >> initialize [
 	super initialize.
 	self
@@ -34,12 +36,12 @@ ReKeysDoRule >> initialize [
 		replace: '``@object values do: ``@block' with: '``@object valuesDo: ``@block'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReKeysDoRule >> name [
 	^ 'keys do: -> keysDo: and valuesDo:'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReKeysDoRule >> rationale [
 	^ 'The use of keysDo:/valuesDo: means one intermediate collection created less'
 ]

--- a/src/GeneralRules/ReLiteralArrayCharactersRule.class.st
+++ b/src/GeneralRules/ReLiteralArrayCharactersRule.class.st
@@ -2,31 +2,33 @@
 Literal arrays containing only characters can more efficiently represented as strings.
 "
 Class {
-	#name : #ReLiteralArrayCharactersRule,
-	#superclass : #ReNodeBasedRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReLiteralArrayCharactersRule',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReLiteralArrayCharactersRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'LiteralArrayCharactersRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReLiteralArrayCharactersRule >> basicCheck: aNode [
 	aNode isLiteralArray ifFalse: [ ^ false ].
 	aNode value ifEmpty: [ ^ false ].
 	^ aNode value allSatisfy: #isCharacter
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReLiteralArrayCharactersRule >> group [
 	^ 'Optimization'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReLiteralArrayCharactersRule >> name [
 	^ 'Literal array contains only characters'
 ]

--- a/src/GeneralRules/ReLiteralArrayContainsCommaRule.class.st
+++ b/src/GeneralRules/ReLiteralArrayContainsCommaRule.class.st
@@ -2,19 +2,21 @@
 Checks for literal arrays that contain the #, symbol. The user may have thought that it was a separator.
 "
 Class {
-	#name : #ReLiteralArrayContainsCommaRule,
-	#superclass : #ReNodeBasedRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReLiteralArrayContainsCommaRule',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReLiteralArrayContainsCommaRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'LiteralArrayContainsCommaRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReLiteralArrayContainsCommaRule >> basicCheck: aNode [
 
 	aNode isLiteralArray ifFalse: [ ^ false ].
@@ -26,12 +28,12 @@ ReLiteralArrayContainsCommaRule >> basicCheck: aNode [
 	^ aNode value includes: #,
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReLiteralArrayContainsCommaRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReLiteralArrayContainsCommaRule >> name [
 	^ 'Literal array contains a #,'
 ]

--- a/src/GeneralRules/ReLocalMethodsSameThanTraitRule.class.st
+++ b/src/GeneralRules/ReLocalMethodsSameThanTraitRule.class.st
@@ -2,24 +2,26 @@
 If a class has a method in its trait composition, the method should not be implemented in the class.
 "
 Class {
-	#name : #ReLocalMethodsSameThanTraitRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReLocalMethodsSameThanTraitRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReLocalMethodsSameThanTraitRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReLocalMethodsSameThanTraitRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'MethodInClassVsTrait'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReLocalMethodsSameThanTraitRule >> check: aClass forCritiquesDo: aCriticBlock [
 	"The comparison between methods is made using the ast, this is better than comparing source code only since it does not take into account identations, extra parenthesis, etc"
 
@@ -35,12 +37,12 @@ ReLocalMethodsSameThanTraitRule >> check: aClass forCritiquesDo: aCriticBlock [
 				(ReRemoveMethodCritique for: aClass selector: duplicatedMethod selector by: self) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReLocalMethodsSameThanTraitRule >> group [
 	^ 'Optimization'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReLocalMethodsSameThanTraitRule >> name [
 	^ 'Repeated methods in the trait composition'
 ]

--- a/src/GeneralRules/ReLongMethodsRule.class.st
+++ b/src/GeneralRules/ReLongMethodsRule.class.st
@@ -10,24 +10,26 @@ Use the extract method refactoring, which even checks whether the method you are
 The defined number of statements can be edited in #longMethodSize. In the future such rule should hold state and not be based on method redefinition for its customization. 
 "
 Class {
-	#name : #ReLongMethodsRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReLongMethodsRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReLongMethodsRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReLongMethodsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'LongMethodsRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReLongMethodsRule >> basicCheck: aMethod [
 	| numberOfStatements |
 	"long methods are no problem for tests"
@@ -42,22 +44,22 @@ ReLongMethodsRule >> basicCheck: aMethod [
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReLongMethodsRule >> group [
 	^ 'Design Flaws'
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ReLongMethodsRule >> longMethodSize [
 	^ 20
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReLongMethodsRule >> name [
 	^ 'Long methods'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReLongMethodsRule >> rationale [
 	^ 'This smell arises when a long method is found (with {1} or more statements). Note that, it counts statements, not lines. Long methods should often be split into several smaller ones.
 

--- a/src/GeneralRules/ReMethodHasSyntaxErrorRule.class.st
+++ b/src/GeneralRules/ReMethodHasSyntaxErrorRule.class.st
@@ -2,39 +2,41 @@
 Methods can be compiled with syntax errors, fix the code and recompile the method
 "
 Class {
-	#name : #ReMethodHasSyntaxErrorRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReMethodHasSyntaxErrorRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReMethodHasSyntaxErrorRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReMethodHasSyntaxErrorRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'MethodSyntaxError'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReMethodHasSyntaxErrorRule >> basicCheck: aMethod [
 	^aMethod isFaulty
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReMethodHasSyntaxErrorRule >> group [
 	^ 'Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReMethodHasSyntaxErrorRule >> name [
 	^ 'Method source has syntax errors'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReMethodHasSyntaxErrorRule >> severity [
 	^ #error
 ]

--- a/src/GeneralRules/ReMethodSignaturePeriodRule.class.st
+++ b/src/GeneralRules/ReMethodSignaturePeriodRule.class.st
@@ -2,17 +2,19 @@
 A rule to check for a period terminating the method signature, which is unnecessary, probably unintentional, and can cause problems when portin to other platforms like GemStone.
 "
 Class {
-	#name : #ReMethodSignaturePeriodRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReMethodSignaturePeriodRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReMethodSignaturePeriodRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReMethodSignaturePeriodRule >> check: aMethod forCritiquesDo: aCriticBlock [
 
 	| firstLine hasDot |
@@ -26,12 +28,12 @@ ReMethodSignaturePeriodRule >> check: aMethod forCritiquesDo: aCriticBlock [
 				 by: self) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReMethodSignaturePeriodRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReMethodSignaturePeriodRule >> name [
 	^ 'Method signature has terminating period'
 ]

--- a/src/GeneralRules/ReMethodSourceContainsLinefeedsRule.class.st
+++ b/src/GeneralRules/ReMethodSourceContainsLinefeedsRule.class.st
@@ -2,24 +2,26 @@
 Pharo code should not contain linefeed characters.
 "
 Class {
-	#name : #ReMethodSourceContainsLinefeedsRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReMethodSourceContainsLinefeedsRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReMethodSourceContainsLinefeedsRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReMethodSourceContainsLinefeedsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'MethodSourceContainsLinefeedsRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReMethodSourceContainsLinefeedsRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	| linefeeds |
 	linefeeds := aMethod sourceCode allRangesOfSubstring: String lf.
@@ -33,17 +35,17 @@ ReMethodSourceContainsLinefeedsRule >> check: aMethod forCritiquesDo: aCriticBlo
 			hint: 'lf') ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReMethodSourceContainsLinefeedsRule >> group [
 	^ 'Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReMethodSourceContainsLinefeedsRule >> name [
 	^ 'Method source contains linefeeds'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReMethodSourceContainsLinefeedsRule >> severity [
 	^ #error
 ]

--- a/src/GeneralRules/ReMinMaxRule.class.st
+++ b/src/GeneralRules/ReMinMaxRule.class.st
@@ -16,24 +16,26 @@ a min: b
 		
 "
 Class {
-	#name : #ReMinMaxRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReMinMaxRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReMinMaxRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'MinMaxRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReMinMaxRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReMinMaxRule >> initialize [
 	super initialize.
 	self
@@ -63,12 +65,12 @@ ReMinMaxRule >> initialize [
 		replace: '``@b >= `a ifFalse: [`a := ``@b]' with: '`a := `a min: ``@b'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReMinMaxRule >> name [
 	^ 'Rewrite ifTrue:ifFalse: using min:/max:'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReMinMaxRule >> rationale [
 	^ 'The use of the messages #min: and #max: improves code readability and avoids heavily nested conditionals.'
 ]

--- a/src/GeneralRules/ReMissingSubclassResponsibilityRule.class.st
+++ b/src/GeneralRules/ReMissingSubclassResponsibilityRule.class.st
@@ -2,24 +2,26 @@
 This smell arises when a class defines a method in all subclasses, but not in itself as an abstract method. Such methods should most likely be defined as subclassResponsibility methods. Furthermore, this check helps to find similar code that might be occurring in all the subclasses that should be pulled up into the superclass.
 "
 Class {
-	#name : #ReMissingSubclassResponsibilityRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReMissingSubclassResponsibilityRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReMissingSubclassResponsibilityRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReMissingSubclassResponsibilityRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'MissingSubclassResponsibilityRule'
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ReMissingSubclassResponsibilityRule >> check: aClass forCritiquesDo: aCritiqueBlock [
 
 	| subs |
@@ -45,12 +47,12 @@ ReMissingSubclassResponsibilityRule >> check: aClass forCritiquesDo: aCritiqueBl
 				^ self ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReMissingSubclassResponsibilityRule >> group [
 	^ 'Design Flaws'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReMissingSubclassResponsibilityRule >> name [
 	^ 'Method defined in all subclasses, but not in superclass'
 ]

--- a/src/GeneralRules/ReMissingSuperSendsRule.class.st
+++ b/src/GeneralRules/ReMissingSuperSendsRule.class.st
@@ -4,24 +4,26 @@ Checks that methods who should always contain a super message send, actually con
 The list of methods that should contain super message sends is in #superMessages.
 "
 Class {
-	#name : #ReMissingSuperSendsRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReMissingSuperSendsRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReMissingSuperSendsRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReMissingSuperSendsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'MissingSuperSendsRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReMissingSuperSendsRule >> basicCheck: aMethod [
 
 	| definer superMethod |
@@ -41,20 +43,20 @@ ReMissingSuperSendsRule >> basicCheck: aMethod [
 	^ (superMethod sendsSelector: #subclassResponsibility) not
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReMissingSuperSendsRule >> group [
 
 	^ 'Potential Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReMissingSuperSendsRule >> methodsRequiringSuper [
 
 	^ #( #release #postCopy #postBuildWith: #preBuildWith: #postOpenWith:
 	     #noticeOfWindowClose: #initialize )
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReMissingSuperSendsRule >> name [
 
 	^ 'Missing super sends in selected methods.'

--- a/src/GeneralRules/ReModifiesCollectionRule.class.st
+++ b/src/GeneralRules/ReModifiesCollectionRule.class.st
@@ -10,31 +10,33 @@ into
 aCol copy do: [ :each |  ... aCol remove:... ]
 "
 Class {
-	#name : #ReModifiesCollectionRule,
-	#superclass : #ReNodeMatchRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReModifiesCollectionRule',
+	#superclass : 'ReNodeMatchRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReModifiesCollectionRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ModifiesCollectionRule'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReModifiesCollectionRule >> afterCheck: aNode mappings: mappingDict [
 	^ self
 		modifiesCollection: (mappingDict at: '`@collection')
 		inAnyStatement: (mappingDict at: '`@.Statements')
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReModifiesCollectionRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReModifiesCollectionRule >> initialize [
 	super initialize.
 	self
@@ -46,7 +48,7 @@ ReModifiesCollectionRule >> initialize [
 			'`@collection inject: `@value into: [:`sum :`each | | `@temps | `@.Statements]')
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ReModifiesCollectionRule >> modifiesCollection: aCollectionNode inAnyStatement: aStatementCollection [
 	aStatementCollection do: [ :statement |
 		statement nodesDo: [ :node |
@@ -55,12 +57,12 @@ ReModifiesCollectionRule >> modifiesCollection: aCollectionNode inAnyStatement: 
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReModifiesCollectionRule >> name [
 	^ 'Modifies collection while iterating over it'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReModifiesCollectionRule >> rationale [
 
 	^ 'Checks for remove:''s of elements inside of collection iteration methods such as do:. '

--- a/src/GeneralRules/ReMultiplePeriodsTerminatingStatementRule.class.st
+++ b/src/GeneralRules/ReMultiplePeriodsTerminatingStatementRule.class.st
@@ -2,23 +2,25 @@
 A rule to check for multiple periods terminating the same statement, which is unnecessary, probably unintentional, and can cause problems when porting to other platforms like GemStone.
 "
 Class {
-	#name : #ReMultiplePeriodsTerminatingStatementRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReMultiplePeriodsTerminatingStatementRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReMultiplePeriodsTerminatingStatementRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReMultiplePeriodsTerminatingStatementRule class >> uniqueIdentifierName [
 
 	^ 'MultiplePeriodsTerminatingStatementRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReMultiplePeriodsTerminatingStatementRule >> check: aMethod forCritiquesDo: aCriticBlock [
 
 	aMethod ast
@@ -29,17 +31,17 @@ ReMultiplePeriodsTerminatingStatementRule >> check: aMethod forCritiquesDo: aCri
 					self periodPairs: node critiqueBlock: aCriticBlock in: aMethod ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReMultiplePeriodsTerminatingStatementRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReMultiplePeriodsTerminatingStatementRule >> name [
 	^ 'Multiple periods terminating the same statement'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReMultiplePeriodsTerminatingStatementRule >> periodPairs: node critiqueBlock: aCriticBlock in: aMethod [
 	| periods |
 	periods := node periods.

--- a/src/GeneralRules/ReNoClassCommentRule.class.st
+++ b/src/GeneralRules/ReNoClassCommentRule.class.st
@@ -2,40 +2,42 @@
 This smell arises when a class has no comment. Classes should have comments to explain their purpose, collaborations with other classes, and optionally provide examples of use.
 "
 Class {
-	#name : #ReNoClassCommentRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReNoClassCommentRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReNoClassCommentRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReNoClassCommentRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'NoClassCommentRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReNoClassCommentRule >> basicCheck: aClass [
 	(aClass isMeta or: [ aClass isTestCase ]) ifTrue: [ ^ false ].
 	^ aClass hasComment not
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReNoClassCommentRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReNoClassCommentRule >> name [
 	^ 'No class comment'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReNoClassCommentRule >> rationale [
 	^ 'Classes should have comments to explain their purpose, collaborations with other classes, and optionally provide examples of use.'
 ]

--- a/src/GeneralRules/ReNoSpaceAroundProtocolRule.class.st
+++ b/src/GeneralRules/ReNoSpaceAroundProtocolRule.class.st
@@ -2,34 +2,36 @@
 Provide rule to have no leading or trailing space in method category name
 "
 Class {
-	#name : #ReNoSpaceAroundProtocolRule,
-	#superclass : #ReAbstractRule,
+	#name : 'ReNoSpaceAroundProtocolRule',
+	#superclass : 'ReAbstractRule',
 	#instVars : [
 		'protocolName'
 	],
-	#category : #'GeneralRules-Migrated'
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReNoSpaceAroundProtocolRule class >> checksMethod [
 
 	^ true
 ]
 
-{ #category : #manifest }
+{ #category : 'manifest' }
 ReNoSpaceAroundProtocolRule class >> uniqueIdentifierName [
 
 	^ 'ReNoSpaceAroundMethodCategoryNameRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReNoSpaceAroundProtocolRule >> basicCheck: aMethod [
 
 	protocolName := aMethod protocolName.
 	^ (protocolName endsWith: ' ') or: [ protocolName beginsWith: ' ' ]
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReNoSpaceAroundProtocolRule >> critiqueFor: aMethod [
 
 	| proposedProtocol |
@@ -43,13 +45,13 @@ ReNoSpaceAroundProtocolRule >> critiqueFor: aMethod [
 			   inClass: aMethod methodClass name asSymbol)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReNoSpaceAroundProtocolRule >> group [
 
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReNoSpaceAroundProtocolRule >> name [
 
 	^ 'Protocol named "{1}" should be trimmed (includes space at start or end)' format: { protocolName }

--- a/src/GeneralRules/ReNoUnusedInstanceVariableRule.class.st
+++ b/src/GeneralRules/ReNoUnusedInstanceVariableRule.class.st
@@ -1,30 +1,32 @@
 Class {
-	#name : #ReNoUnusedInstanceVariableRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReNoUnusedInstanceVariableRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReNoUnusedInstanceVariableRule class >> checksClass [
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReNoUnusedInstanceVariableRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'NoUnusedInstanceVariableRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReNoUnusedInstanceVariableRule >> check: aClass forCritiquesDo: aCriticBlock [
 	aClass slots
 		select: [ :slot | slot isReferenced not ]
 		thenDo: [ :slot | aCriticBlock cull: (self critiqueFor: aClass about: slot name) ]
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReNoUnusedInstanceVariableRule >> critiqueFor: aClass about: aVarName [
 
 	| crit |
@@ -39,19 +41,19 @@ ReNoUnusedInstanceVariableRule >> critiqueFor: aClass about: aVarName [
 	^ crit
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReNoUnusedInstanceVariableRule >> group [
 
 	^ 'Optimization'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReNoUnusedInstanceVariableRule >> name [
 
 	^ 'Unused instance variable'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReNoUnusedInstanceVariableRule >> rationale [
 	^ 'Classes should have instance variables that are actually used - instance variables without a reference should be removed.'
 ]

--- a/src/GeneralRules/ReNotEliminationRule.class.st
+++ b/src/GeneralRules/ReNotEliminationRule.class.st
@@ -23,24 +23,26 @@ aCollection reject: [ :each | ... anObject ]
 ]]]
 "
 Class {
-	#name : #ReNotEliminationRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReNotEliminationRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReNotEliminationRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'NotEliminationRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReNotEliminationRule >> group [
 	^ 'Optimization'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReNotEliminationRule >> initialize [
 	super initialize.
 	self
@@ -70,12 +72,12 @@ ReNotEliminationRule >> initialize [
 		replace: '(``@a > ``@b) not' with: '``@a <= ``@b'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReNotEliminationRule >> name [
 	^ 'Eliminate unnecessary not''s'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReNotEliminationRule >> rationale [
 	^ 'Eliminate unnecessary not''s in relation of conditionals'
 ]

--- a/src/GeneralRules/ReNotEqualityOperatorsRule.class.st
+++ b/src/GeneralRules/ReNotEqualityOperatorsRule.class.st
@@ -2,17 +2,19 @@
 In pharo, the inequality operators are `~=` (for the negation of `=`) and `~~` (for the negation of `==`).
 "
 Class {
-	#name : #ReNotEqualityOperatorsRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReNotEqualityOperatorsRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReNotEqualityOperatorsRule >> group [
 	^ 'Bugs'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReNotEqualityOperatorsRule >> initialize [
 	super initialize.
 	self
@@ -21,12 +23,12 @@ ReNotEqualityOperatorsRule >> initialize [
 		replace: '``@a !== ``@b' with: '``@a ~~ ``@b'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReNotEqualityOperatorsRule >> name [
 	^ 'Use the correct non-equality operators'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReNotEqualityOperatorsRule >> severity [
 	^#error
 ]

--- a/src/GeneralRules/ReNotOptimizedIfNilRule.class.st
+++ b/src/GeneralRules/ReNotOptimizedIfNilRule.class.st
@@ -8,12 +8,14 @@ See the method RBMessageNode>>#isInlineIfNil for the exact implementation of the
 
 "
 Class {
-	#name : #ReNotOptimizedIfNilRule,
-	#superclass : #ReNodeBasedRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReNotOptimizedIfNilRule',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 ReNotOptimizedIfNilRule >> check: aNode forCritiquesDo: aBlock [
 	aNode isMessage ifFalse: [  ^ self ].
 	(#(ifNil: ifNotNil: ifNil:ifNotNil: ifNotNil:ifNil:) includes: aNode selector) ifFalse: [^ self].
@@ -21,12 +23,12 @@ ReNotOptimizedIfNilRule >> check: aNode forCritiquesDo: aBlock [
 		aBlock cull: (self critiqueFor: aNode) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReNotOptimizedIfNilRule >> group [
 	^ 'Optimization'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReNotOptimizedIfNilRule >> name [
 	^ 'ifNil: ifNotNil: ifNil:ifNotNil: ifNotNil:ifNil: is used in a way that it can not be optimized'
 ]

--- a/src/GeneralRules/ReNotOptimizedIfRule.class.st
+++ b/src/GeneralRules/ReNotOptimizedIfRule.class.st
@@ -6,12 +6,14 @@ This can be fixed by making sure that all arguments are static blocks.
 See the method RBMessageNode>>#isInlineIf for the exact implementation of the check that the compiler uses
 "
 Class {
-	#name : #ReNotOptimizedIfRule,
-	#superclass : #ReNodeBasedRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReNotOptimizedIfRule',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 ReNotOptimizedIfRule >> check: aNode forCritiquesDo: aBlock [
 	aNode isMessage ifFalse: [  ^ self ].
 	(#(ifTrue: ifFalse: ifTrue:ifFalse: ifFalse:ifTrue:) includes: aNode selector) ifFalse: [^ self].
@@ -19,12 +21,12 @@ ReNotOptimizedIfRule >> check: aNode forCritiquesDo: aBlock [
 		aBlock cull: (self critiqueFor: aNode) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReNotOptimizedIfRule >> group [
 	^ 'Optimization'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReNotOptimizedIfRule >> name [
 	^ 'ifTrue: ifFalse: ifTrue:ifFalse: ifFalse:ifTrue: is used in a way that it can not be optimized'
 ]

--- a/src/GeneralRules/ReOverridesSpecialMessageRule.class.st
+++ b/src/GeneralRules/ReOverridesSpecialMessageRule.class.st
@@ -2,24 +2,26 @@
 Checks that a class does not override a message that is essential to the base system. For example, if you override the #class method from object, you are likely to crash your image. #classShouldNotOverride returns the list of messages which should not be overriden.
 "
 Class {
-	#name : #ReOverridesSpecialMessageRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReOverridesSpecialMessageRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReOverridesSpecialMessageRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReOverridesSpecialMessageRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'OverridesSpecialMessageRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReOverridesSpecialMessageRule >> check: aClass forCritiquesDo: aCriticBlock [
 	| selectors |
 	selectors := aClass isMeta
@@ -32,27 +34,27 @@ ReOverridesSpecialMessageRule >> check: aClass forCritiquesDo: aCriticBlock [
 		aCriticBlock cull: (self critiqueFor: aClass) ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ReOverridesSpecialMessageRule >> classShouldNotOverride [
 	^ #( #== #~~ #class #basicAt: #basicAt:put: #basicSize #identityHash )
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReOverridesSpecialMessageRule >> group [
 	^ 'Bugs'
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ReOverridesSpecialMessageRule >> metaclassShouldNotOverride [
 	^ #( #basicNew #basicNew #class #comment #name )
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReOverridesSpecialMessageRule >> name [
 	^ 'Overrides a "special" message'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReOverridesSpecialMessageRule >> rationale [
 
 	^ 'Checks that a class does not override a message that is essential to the base system. For example, if you override the #class method from object, you are likely to crash your image.
@@ -60,7 +62,7 @@ In the class the messages we should not override are: ',  (', ' join: (self clas
 In the class side the messages we should not override are: ',  (', ' join: (self metaclassShouldNotOverride) ),'.'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReOverridesSpecialMessageRule >> severity [
 	^ #error
 ]

--- a/src/GeneralRules/RePlatformDependentUserInteractionRule.class.st
+++ b/src/GeneralRules/RePlatformDependentUserInteractionRule.class.st
@@ -4,24 +4,26 @@ Check the methods that  use platform dependent user interactions.
 This rule should be updated.
 "
 Class {
-	#name : #RePlatformDependentUserInteractionRule,
-	#superclass : #ReNodeMatchRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'RePlatformDependentUserInteractionRule',
+	#superclass : 'ReNodeMatchRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RePlatformDependentUserInteractionRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'PlatformDependentUserInteractionRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RePlatformDependentUserInteractionRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RePlatformDependentUserInteractionRule >> initialize [
 	super initialize.
 	 self matchesAny: #(
@@ -38,17 +40,17 @@ RePlatformDependentUserInteractionRule >> initialize [
 			 )
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RePlatformDependentUserInteractionRule >> name [
 	^ 'Platform dependent user interaction'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RePlatformDependentUserInteractionRule >> rationale [
 	^ 'Check the methods that  use platform dependent user interactions.'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RePlatformDependentUserInteractionRule >> severity [
 	^ #error
 ]

--- a/src/GeneralRules/RePrecedenceRule.class.st
+++ b/src/GeneralRules/RePrecedenceRule.class.st
@@ -2,19 +2,21 @@
 Checks for mathematical expressions that might be evaluated different (from left-to-right) than the developer thinks.
 "
 Class {
-	#name : #RePrecedenceRule,
-	#superclass : #ReNodeBasedRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'RePrecedenceRule',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RePrecedenceRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'PrecedenceRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RePrecedenceRule >> basicCheck: aNode [
 	| leftOperand |
 	aNode isMessage ifFalse: [ ^ false ].
@@ -25,12 +27,12 @@ RePrecedenceRule >> basicCheck: aNode [
 	^ #(#+ #-) includes: leftOperand selector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RePrecedenceRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RePrecedenceRule >> name [
 	^ 'Inspect instances of "A + B * C" might be "A + (B * C)"'
 ]

--- a/src/GeneralRules/ReReferencesObsoleteClassRule.class.st
+++ b/src/GeneralRules/ReReferencesObsoleteClassRule.class.st
@@ -3,36 +3,38 @@ You are referencing a class that is obsolete, that is, it has been removed
 
 "
 Class {
-	#name : #ReReferencesObsoleteClassRule,
-	#superclass : #ReNodeBasedRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReReferencesObsoleteClassRule',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 ReReferencesObsoleteClassRule >> basicCheck: aNode [
  	^ aNode isGlobalVariable
  			and: [ aNode variable isGlobalClassNameBinding
  				and: [ aNode variable value isObsolete ] ]
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 ReReferencesObsoleteClassRule >> critiqueFor: aNode [
 	^ (super critiqueFor: aNode)
 		  tinyHint: aNode name;
 		  yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReReferencesObsoleteClassRule >> group [
 	^ 'Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReReferencesObsoleteClassRule >> name [
 	^ 'References an obsolete class'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReReferencesObsoleteClassRule >> severity [
 	^ #error
 ]

--- a/src/GeneralRules/ReRefersToClassRule.class.st
+++ b/src/GeneralRules/ReRefersToClassRule.class.st
@@ -3,24 +3,26 @@ This smell arises when a class has its class name directly in the source instead
 However we cannot systematically replace Class reference by self class or self because a Class reference is static and a self expression is dynamic. So the programmer may want to send messages to root of an hierarchy and not to the leaf classes. Therefore this rule generates false positives, please double check when fixing!
 "
 Class {
-	#name : #ReRefersToClassRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReRefersToClassRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReRefersToClassRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReRefersToClassRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'RefersToClassRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReRefersToClassRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	| class problemLiterals |
 
@@ -37,17 +39,17 @@ ReRefersToClassRule >> check: aMethod forCritiquesDo: aCriticBlock [
 			aCriticBlock cull: (self createTrivialCritiqueOn: aMethod intervalOf: literal hint:literal name )]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReRefersToClassRule >> group [
 	^ 'Design Flaws'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReRefersToClassRule >> name [
 	^ 'Refers to class name instead of "self class"'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReRefersToClassRule >> rationale [
 	^ 'Checks for direct reference to classes themselves.'
 ]

--- a/src/GeneralRules/ReReturnInEnsureRule.class.st
+++ b/src/GeneralRules/ReReturnInEnsureRule.class.st
@@ -2,30 +2,32 @@
 Checks for return statements within ensure: blocks that can have unintended side-effects.
 "
 Class {
-	#name : #ReReturnInEnsureRule,
-	#superclass : #ReNodeMatchRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReReturnInEnsureRule',
+	#superclass : 'ReNodeMatchRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReReturnInEnsureRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ReturnInEnsureRule'
 ]
 
-{ #category : #hooks }
+{ #category : 'hooks' }
 ReReturnInEnsureRule >> afterCheck: aNode mappings: mappingDict [
 	^ (mappingDict at: '`@.Stmts')
 		anySatisfy: #containsReturn
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReReturnInEnsureRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReReturnInEnsureRule >> initialize [
 	super initialize.
 	self matchesAny: #(
@@ -33,7 +35,7 @@ ReReturnInEnsureRule >> initialize [
 		'`@rcv ifCurtailed: [| `@temps | `@.Stmts]')
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReReturnInEnsureRule >> name [
 	^ 'Contains a return in an ensure: block'
 ]

--- a/src/GeneralRules/ReReturnsBooleanAndOtherRule.class.st
+++ b/src/GeneralRules/ReReturnsBooleanAndOtherRule.class.st
@@ -2,24 +2,26 @@
 This smell arises when a method return a boolean value (true or false) and return some other value such as (nil or self). If the method is suppose to return a boolean, then this signifies that there is one path through the method that might return a non-boolean. If the method doesn''t need to return a boolean, it should be probably rewriten to return some non-boolean value since other programmers reading the method might assume that it returns a boolean.
 "
 Class {
-	#name : #ReReturnsBooleanAndOtherRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReReturnsBooleanAndOtherRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReReturnsBooleanAndOtherRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReReturnsBooleanAndOtherRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ReturnsBooleanAndOtherRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReReturnsBooleanAndOtherRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	| returnsBool returnsNonBool |
 	returnsBool := false.
@@ -42,24 +44,24 @@ ReReturnsBooleanAndOtherRule >> check: aMethod forCritiquesDo: aCriticBlock [
 				^ aCriticBlock cull: (self critiqueFor: aMethod) ] ] ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ReReturnsBooleanAndOtherRule >> checkIfNodeIsBool: node [
 	^ (node isLiteralNode and: [ #(true false) includes: node value ])
 		or: [ node isMessage and: [ #(and: or:) includes: node selector ] ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ReReturnsBooleanAndOtherRule >> checkIfNodeIsNotBool: node [
 	^ node isSelfVariable or:
 		[ node isLiteralNode and: [ (#(true false) includes: node value) not ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReReturnsBooleanAndOtherRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReReturnsBooleanAndOtherRule >> name [
 	^ 'Returns a boolean and non boolean'
 ]

--- a/src/GeneralRules/ReReturnsIfTrueRule.class.st
+++ b/src/GeneralRules/ReReturnsIfTrueRule.class.st
@@ -2,24 +2,26 @@
 Check for methods that return the value of an ifTrue: or ifFalse: message. These statements return nil when the block is not executed.
 "
 Class {
-	#name : #ReReturnsIfTrueRule,
-	#superclass : #ReNodeMatchRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReReturnsIfTrueRule',
+	#superclass : 'ReNodeMatchRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReReturnsIfTrueRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ReturnsIfTrueRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReReturnsIfTrueRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReReturnsIfTrueRule >> initialize [
 	super initialize.
 	self matchesAny: #(
@@ -27,7 +29,7 @@ ReReturnsIfTrueRule >> initialize [
 			'^`@condition ifFalse: [| `@temps | `@.statements]' )
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReReturnsIfTrueRule >> name [
 	^ 'Returns value of ifTrue:/ifFalse: without ifFalse:/ifTrue: block'
 ]

--- a/src/GeneralRules/ReSearchingLiteralRule.class.st
+++ b/src/GeneralRules/ReSearchingLiteralRule.class.st
@@ -2,31 +2,33 @@
 Checks for repeated literal equality tests that should rather be implemented as a search in a literal collection.
 "
 Class {
-	#name : #ReSearchingLiteralRule,
-	#superclass : #ReNodeMatchRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReSearchingLiteralRule',
+	#superclass : 'ReNodeMatchRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSearchingLiteralRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'SearchingLiteralRule'
 ]
 
-{ #category : #hooks }
+{ #category : 'hooks' }
 ReSearchingLiteralRule >> afterCheck: aNode mappings: mappingDict [
 	^ self
 		isSearchingLiteralExpression: aNode
 		for: (mappingDict at: '``@object')
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSearchingLiteralRule >> group [
 	^ 'Optimization'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReSearchingLiteralRule >> initialize [
 	super initialize.
 	self matchesAny: #(
@@ -40,7 +42,7 @@ ReSearchingLiteralRule >> initialize [
 			'``@expression | (`#literal == ``@object)')
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ReSearchingLiteralRule >> isSearchingLiteralExpression: aSearchingNode for: anObjectNode [
 	| argument arguments |
 	aSearchingNode isMessage ifFalse: [^false].
@@ -67,7 +69,7 @@ ReSearchingLiteralRule >> isSearchingLiteralExpression: aSearchingNode for: anOb
 					for: anObjectNode]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSearchingLiteralRule >> name [
 	^ 'Uses or instead of a searching literal'
 ]

--- a/src/GeneralRules/ReSelfSentNotImplementedRule.class.st
+++ b/src/GeneralRules/ReSelfSentNotImplementedRule.class.st
@@ -2,24 +2,26 @@
 This smell arises when a message is sent to self by a method,  but no class in the superclass chain implements such a message. This method sent will certainly cause a doesNotUnderstand: message when they are executed.
 "
 Class {
-	#name : #ReSelfSentNotImplementedRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReSelfSentNotImplementedRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReSelfSentNotImplementedRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSelfSentNotImplementedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'SelfSentNotImplementedRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReSelfSentNotImplementedRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	| problemSends ignored |
 	aMethod methodClass isTrait ifTrue: [ ^ self ].
@@ -35,22 +37,22 @@ ReSelfSentNotImplementedRule >> check: aMethod forCritiquesDo: aCriticBlock [
 			aCriticBlock cull: (self createTrivialCritiqueOn: aMethod intervalOf: msgSend hint: msgSend selector asString)]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSelfSentNotImplementedRule >> group [
 	^ 'Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSelfSentNotImplementedRule >> name [
 	^ 'Super and Self Messages sent but not implemented'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSelfSentNotImplementedRule >> rationale [
 	^ 'Checks if messages sent to self or super exist in the hierarchy, since these can be statically typed. Reported methods will certainly cause a doesNotUnderstand: message when they are executed.'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSelfSentNotImplementedRule >> severity [
 	^ #error
 ]

--- a/src/GeneralRules/ReSendsDifferentSuperRule.class.st
+++ b/src/GeneralRules/ReSendsDifferentSuperRule.class.st
@@ -9,39 +9,41 @@ A common example of this is in creation methods. You might define a method such 
 If the new method is not defined in the class, you should probably rewrite this to use self instead. Also, if the new method is defined, you might question why you need to send new to the superclass instead of to the class.
 "
 Class {
-	#name : #ReSendsDifferentSuperRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReSendsDifferentSuperRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReSendsDifferentSuperRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSendsDifferentSuperRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'SendsDifferentSuperRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReSendsDifferentSuperRule >> basicCheck: aMethod [
 	^ aMethod superMessages anySatisfy: [ :message | message ~= aMethod selector ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSendsDifferentSuperRule >> group [
 	^ 'Design Flaws'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSendsDifferentSuperRule >> name [
 	^ 'Sends different super message'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSendsDifferentSuperRule >> rationale [
 	^ 'Checks for methods whose source sends a different super message.'
 ]

--- a/src/GeneralRules/ReSendsMethodDictRule.class.st
+++ b/src/GeneralRules/ReSendsMethodDictRule.class.st
@@ -2,24 +2,26 @@
 Nobody should directly access the method dictionary. It is purely an implementation artefact that we use one dictionary and it might change in the future.
 "
 Class {
-	#name : #ReSendsMethodDictRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReSendsMethodDictRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReSendsMethodDictRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSendsMethodDictRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'NobodyShouldSendMethodDict'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReSendsMethodDictRule >> basicCheck: aMethod [
 	"in the Behavior classes we want to use the accessor (see comment #methodDict)"
 	({Behavior . ClassDescription . Class. Metaclass. TraitedMetaclass. MetaclassForTraits} includes: aMethod methodClass)
@@ -27,22 +29,22 @@ ReSendsMethodDictRule >> basicCheck: aMethod [
 	^(aMethod refersToLiteral: #methodDict) and: [aMethod messages includes: #methodDict]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSendsMethodDictRule >> group [
 	^ 'Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSendsMethodDictRule >> name [
 	^ 'No direct access of methodDict'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSendsMethodDictRule >> rationale [
 	^ 'Nobody should directly access the method dictionary. It is purely an implementation artefact that we use one dictionary and it might change in the future'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSendsMethodDictRule >> severity [
 	^ #error
 ]

--- a/src/GeneralRules/ReSendsUnknownMessageToGlobalRule.class.st
+++ b/src/GeneralRules/ReSendsUnknownMessageToGlobalRule.class.st
@@ -2,19 +2,21 @@
 Checks for messages that are sent but not implemented by a global. Reported methods will certainly cause a doesNotUnderstand: message when they are executed.
 "
 Class {
-	#name : #ReSendsUnknownMessageToGlobalRule,
-	#superclass : #ReNodeBasedRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReSendsUnknownMessageToGlobalRule',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSendsUnknownMessageToGlobalRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'SendsUnknownMessageToGlobalRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReSendsUnknownMessageToGlobalRule >> basicCheck: aNode [
 	aNode isMessage ifFalse: [ ^ false ].
 
@@ -27,17 +29,17 @@ ReSendsUnknownMessageToGlobalRule >> basicCheck: aNode [
 	^ (aNode receiver variable value respondsTo: aNode selector) not
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSendsUnknownMessageToGlobalRule >> group [
 	^ 'Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSendsUnknownMessageToGlobalRule >> name [
 	^ 'Sends unknown message to global'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSendsUnknownMessageToGlobalRule >> severity [
 	^ #error
 ]

--- a/src/GeneralRules/ReSentNotImplementedRule.class.st
+++ b/src/GeneralRules/ReSentNotImplementedRule.class.st
@@ -2,24 +2,26 @@
 This smell arises when a message is sent by a method,  but no class in the system implements such a message. This method sent will certainly cause a doesNotUnderstand: message when they are executed.
 "
 Class {
-	#name : #ReSentNotImplementedRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReSentNotImplementedRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReSentNotImplementedRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSentNotImplementedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'SentNotImplementedRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReSentNotImplementedRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	| ignored problemSends |
 
@@ -37,22 +39,22 @@ ReSentNotImplementedRule >> check: aMethod forCritiquesDo: aCriticBlock [
 				 hint: msgSend selector asString) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSentNotImplementedRule >> group [
 	^ 'Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSentNotImplementedRule >> name [
 	^ 'Messages sent but not implemented'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSentNotImplementedRule >> rationale [
 	^ 'Checks for messages that are sent by a method, but no class in the system implements such a message. Reported methods will certainly cause a doesNotUnderstand: message when they are executed.'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSentNotImplementedRule >> severity [
 	^ #error
 ]

--- a/src/GeneralRules/ReShouldntRaiseErrorRule.class.st
+++ b/src/GeneralRules/ReShouldntRaiseErrorRule.class.st
@@ -33,24 +33,26 @@ internal error message that shadows the real error. Using Error as argument for
 be avoided.
 "
 Class {
-	#name : #ReShouldntRaiseErrorRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReShouldntRaiseErrorRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReShouldntRaiseErrorRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ShouldntRaiseErrorRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReShouldntRaiseErrorRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReShouldntRaiseErrorRule >> initialize [
 	super initialize.
 	self
@@ -58,12 +60,12 @@ ReShouldntRaiseErrorRule >> initialize [
 		replace: 'self shouldnt: [ `@statements ] raise: Exception' with: '`@statements'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReShouldntRaiseErrorRule >> name [
 	^ 'Do not use  `shouldnt: [ ... ] raise: Error` '
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReShouldntRaiseErrorRule >> rationale [
 	^ 'Replaces `shouldnt: [ ... ] raise: Error` with  `[ ... ]`'
 ]

--- a/src/GeneralRules/ReSizeCheckRule.class.st
+++ b/src/GeneralRules/ReSizeCheckRule.class.st
@@ -2,19 +2,21 @@
 Check for code that checks that a collection is non-empty before sending it an iteration message (e.g., do:, collect:, etc.). Since the collection iteration messages work for empty collections, we do not need to clutter up our method with the extra size check.
 "
 Class {
-	#name : #ReSizeCheckRule,
-	#superclass : #ReNodeMatchRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReSizeCheckRule',
+	#superclass : 'ReNodeMatchRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSizeCheckRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'SizeCheckRule'
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ReSizeCheckRule >> genericPatternForSelector: aSymbol [
 	^ String streamContents: [ :stream |
 		aSymbol keywords keysAndValuesDo: [ :index :value |
@@ -23,12 +25,12 @@ ReSizeCheckRule >> genericPatternForSelector: aSymbol [
 				ifTrue: [ stream space; nextPutAll: '`@object'; print: index ] ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSizeCheckRule >> group [
 	^ 'Optimization'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReSizeCheckRule >> initialize [
 	| patterns |
 	super initialize.
@@ -44,12 +46,12 @@ ReSizeCheckRule >> initialize [
 	self matchesAny: patterns
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSizeCheckRule >> name [
 	^ 'Unnecessary size check'
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ReSizeCheckRule >> selectors [
 	^ #( collect: do: reject: select: )
 ]

--- a/src/GeneralRules/ReSmalltalkGlobalsRule.class.st
+++ b/src/GeneralRules/ReSmalltalkGlobalsRule.class.st
@@ -2,24 +2,26 @@
 Do not send requests to ""Smalltalk"" (which models the whole image)  that are related to the envionment of defines classes and globals
 "
 Class {
-	#name : #ReSmalltalkGlobalsRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReSmalltalkGlobalsRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSmalltalkGlobalsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^ 'SmalltalkGlobalsRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSmalltalkGlobalsRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReSmalltalkGlobalsRule >> initialize [
 	super initialize.
 	self
@@ -37,7 +39,7 @@ ReSmalltalkGlobalsRule >> initialize [
 			with: 'Smalltalk globals includesKey: `@statements'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSmalltalkGlobalsRule >> name [
 	^ 'Use "Smalltalk globals" instead of "Smalltalk"'
 ]

--- a/src/GeneralRules/ReStringConcatenationRule.class.st
+++ b/src/GeneralRules/ReStringConcatenationRule.class.st
@@ -18,19 +18,21 @@ or more concisely...
 
 "
 Class {
-	#name : #ReStringConcatenationRule,
-	#superclass : #ReNodeMatchRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReStringConcatenationRule',
+	#superclass : 'ReNodeMatchRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReStringConcatenationRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'StringConcatenationRule'
 ]
 
-{ #category : #hooks }
+{ #category : 'hooks' }
 ReStringConcatenationRule >> afterCheck: aNode mappings: mappingDict [
 	(self performsConcatenation: (mappingDict at: '``@argument'))
 		ifTrue: [ ^ true ].
@@ -43,12 +45,12 @@ ReStringConcatenationRule >> afterCheck: aNode mappings: mappingDict [
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReStringConcatenationRule >> group [
 	^ 'Optimization'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReStringConcatenationRule >> initialize [
 	super initialize.
 	self  matchesAny: #(
@@ -65,12 +67,12 @@ ReStringConcatenationRule >> initialize [
 		'``@collection noneSatisfy: ``@argument' )
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReStringConcatenationRule >> name [
 	^ 'String concatenation instead of streams'
 ]
 
-{ #category : #hooks }
+{ #category : 'hooks' }
 ReStringConcatenationRule >> performsConcatenation: aNode [
 
 	aNode isBlock ifFalse: [ ^ false ].

--- a/src/GeneralRules/ReSubclassResponsibilityNotDefinedRule.class.st
+++ b/src/GeneralRules/ReSubclassResponsibilityNotDefinedRule.class.st
@@ -2,56 +2,58 @@
 This rule checks if all subclassResponsibility methods are defined in all leaf classes. if such a method is not overridden, a subclassResponsibility message can be occur when this method is called.
 "
 Class {
-	#name : #ReSubclassResponsibilityNotDefinedRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReSubclassResponsibilityNotDefinedRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReSubclassResponsibilityNotDefinedRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSubclassResponsibilityNotDefinedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'SubclassResponsibilityNotDefinedRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReSubclassResponsibilityNotDefinedRule >> check: aClass forCritiquesDo: aCriticBlock [
 
-	(aClass whichSelectorsReferTo: #subclassResponsibility) do:
-		[ :selector |
+	(aClass whichMethodsReferTo: #subclassResponsibility) do:
+		[ :method |
 		(aClass subclasses do: [ :class |
 				(class subclasses isEmpty and:
-				[ (class whichClassIncludesSelector: selector) == aClass ]) ifTrue: [
+				[ (class whichClassIncludesSelector: method selector) == aClass ]) ifTrue: [
 					aCriticBlock cull: (ReMissingMethodCritique
 						for: aClass
 						by: self
 						class: class
-						selector: selector)
+						selector: method selector)
 						beShouldBeImplemented;
 						yourself ] ]) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSubclassResponsibilityNotDefinedRule >> group [
 	^ 'Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSubclassResponsibilityNotDefinedRule >> name [
 	^ '#subclassResponsibility not defined'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSubclassResponsibilityNotDefinedRule >> rationale [
 	^ 'Checks that all methods which send #subclassResponsibility, which indicates that they are abstract, are defined in all leaf classes.'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSubclassResponsibilityNotDefinedRule >> severity [
 	^ #error
 ]

--- a/src/GeneralRules/ReSuperSendsNewRule.class.st
+++ b/src/GeneralRules/ReSuperSendsNewRule.class.st
@@ -3,29 +3,31 @@ This rule checks for method that wrongly initialize an object twice. Contrary to
 A warning is raised when the statement self new initialize is found in a method.
 "
 Class {
-	#name : #ReSuperSendsNewRule,
-	#superclass : #ReNodeMatchRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReSuperSendsNewRule',
+	#superclass : 'ReNodeMatchRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSuperSendsNewRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'SuperSendsNewRule'
 ]
 
-{ #category : #hooks }
+{ #category : 'hooks' }
 ReSuperSendsNewRule >> afterCheck: aNode mappings: mappingDict [
 	^ aNode methodNode methodClass isMeta
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSuperSendsNewRule >> group [
 	^ 'Bugs'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReSuperSendsNewRule >> initialize [
 	super initialize.
 	self matchesAny: #(
@@ -35,7 +37,7 @@ ReSuperSendsNewRule >> initialize [
 			'(self new: `@expr) initialize' )
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSuperSendsNewRule >> name [
 	^ 'Sends super new initialize or self new initialize'
 ]

--- a/src/GeneralRules/ReSuperSendsRule.class.st
+++ b/src/GeneralRules/ReSuperSendsRule.class.st
@@ -2,31 +2,33 @@
 Rewrite super messages to self messages when both refer to same method
 "
 Class {
-	#name : #ReSuperSendsRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReSuperSendsRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSuperSendsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'SuperSendsRule'
 ]
 
-{ #category : #hooks }
+{ #category : 'hooks' }
 ReSuperSendsRule >> afterCheck: aNode mappings: mappingDict [
 
 	^aNode methodNode methodClass withAllSubclasses noneSatisfy: [: class |
 		class includesSelector: aNode selector ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSuperSendsRule >> group [
 	^ 'Design Flaws'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReSuperSendsRule >> initialize [
 	super initialize.
 	self
@@ -34,7 +36,7 @@ ReSuperSendsRule >> initialize [
 		with: 'self `@message: ``@args'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSuperSendsRule >> name [
 	^ 'Rewrite super messages to self messages'
 ]

--- a/src/GeneralRules/ReSuperWithoutSend.class.st
+++ b/src/GeneralRules/ReSuperWithoutSend.class.st
@@ -7,12 +7,14 @@ For every other use, it is just the same as ""self"".
 
 "
 Class {
-	#name : #ReSuperWithoutSend,
-	#superclass : #ReNodeBasedRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReSuperWithoutSend',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 ReSuperWithoutSend >> basicCheck: aNode [
 	aNode isVariable ifFalse: [ ^ false ].
 	aNode isSuperVariable ifFalse: [ ^ false ].
@@ -23,12 +25,12 @@ ReSuperWithoutSend >> basicCheck: aNode [
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSuperWithoutSend >> group [
 	^ 'Design Flaws'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReSuperWithoutSend >> name [
 	^ 'super makes only sense as the receiver of a message'
 ]

--- a/src/GeneralRules/ReTempVarOverridesInstVarRule.class.st
+++ b/src/GeneralRules/ReTempVarOverridesInstVarRule.class.st
@@ -2,24 +2,26 @@
 Finds methods whose arguments or temporary variables ooverride an instance variable. This causes problems if you want to use the instance variable inside the method.
 "
 Class {
-	#name : #ReTempVarOverridesInstVarRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReTempVarOverridesInstVarRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #'testing-interest' }
+{ #category : 'testing-interest' }
 ReTempVarOverridesInstVarRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReTempVarOverridesInstVarRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'TempVarOverridesInstVarRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReTempVarOverridesInstVarRule >> check: aMethod forCritiquesDo: aCriticBlock [
 
 	| problemTemps |
@@ -31,7 +33,7 @@ ReTempVarOverridesInstVarRule >> check: aMethod forCritiquesDo: aCriticBlock [
 			(self critiqueFor: aMethod about: var definingNode) ]
 ]
 
-{ #category : #'running - helpers' }
+{ #category : 'running - helpers' }
 ReTempVarOverridesInstVarRule >> critiqueFor: aMethod about: aVarNode [
 	^ (ReTrivialCritique
 		withAnchor: (ReIntervalSourceAnchor
@@ -42,12 +44,12 @@ ReTempVarOverridesInstVarRule >> critiqueFor: aMethod about: aVarNode [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReTempVarOverridesInstVarRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReTempVarOverridesInstVarRule >> name [
 	^ 'Outer variable shadowed by temporary variable or argument'
 ]

--- a/src/GeneralRules/ReTemporaryNeitherReadNorWrittenRule.class.st
+++ b/src/GeneralRules/ReTemporaryNeitherReadNorWrittenRule.class.st
@@ -2,12 +2,14 @@
 There is something wrong in the method as you have variables that are either nor read or not written (or both).
 "
 Class {
-	#name : #ReTemporaryNeitherReadNorWrittenRule,
-	#superclass : #ReNodeBasedRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReTemporaryNeitherReadNorWrittenRule',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 ReTemporaryNeitherReadNorWrittenRule >> check: aNode forCritiquesDo: aBlock [
 	aNode isTempVariable ifFalse: [ ^ self ].
 	aNode isDefinition ifFalse: [ ^ self ].
@@ -15,12 +17,12 @@ ReTemporaryNeitherReadNorWrittenRule >> check: aNode forCritiquesDo: aBlock [
 		aBlock cull: (self critiqueFor: aNode) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReTemporaryNeitherReadNorWrittenRule >> group [
 	^ 'Optimization'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReTemporaryNeitherReadNorWrittenRule >> name [
 	^ 'Temporary variables not read or not written'
 ]

--- a/src/GeneralRules/ReTemporaryVariableCapitalizationRule.class.st
+++ b/src/GeneralRules/ReTemporaryVariableCapitalizationRule.class.st
@@ -2,19 +2,21 @@
 Temporary and argument variable names should start with a lowercase letter.
 "
 Class {
-	#name : #ReTemporaryVariableCapitalizationRule,
-	#superclass : #ReNodeBasedRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReTemporaryVariableCapitalizationRule',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 ReTemporaryVariableCapitalizationRule >> basicCheck: aNode [
 	aNode isLocalVariable ifFalse: [ ^false ].
 	aNode isDefinition ifFalse: [ ^false ].
 	^aNode name first isUppercase
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 ReTemporaryVariableCapitalizationRule >> critiqueFor: aNode [
 	| crit |
 
@@ -34,12 +36,12 @@ ReTemporaryVariableCapitalizationRule >> critiqueFor: aNode [
 	^ crit
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReTemporaryVariableCapitalizationRule >> group [
 	^ 'Style'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReTemporaryVariableCapitalizationRule >> name [
 	^ 'Temporary variable (or parameter) capitalized'
 ]

--- a/src/GeneralRules/ReTempsReadBeforeWrittenRule.class.st
+++ b/src/GeneralRules/ReTempsReadBeforeWrittenRule.class.st
@@ -14,24 +14,26 @@ be exected.
 NOTE: This rule detects *many* false positives.
 "
 Class {
-	#name : #ReTempsReadBeforeWrittenRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReTempsReadBeforeWrittenRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReTempsReadBeforeWrittenRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReTempsReadBeforeWrittenRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'TempsReadBeforeWrittenRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReTempsReadBeforeWrittenRule >> check: aMethod forCritiquesDo: aCriticBlock [
 
 	(self findReadsBeforeWrittenTemporariesIn: aMethod) ifNotEmpty: [
@@ -44,19 +46,19 @@ ReTempsReadBeforeWrittenRule >> check: aMethod forCritiquesDo: aCriticBlock [
 				 yourself) ]
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReTempsReadBeforeWrittenRule >> findReadsBeforeWrittenTemporariesIn: aMethod [
 
 	^ (RBReadBeforeWrittenTester variablesReadBeforeWrittenIn:
 		   aMethod ast) array select: #isNotNil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReTempsReadBeforeWrittenRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReTempsReadBeforeWrittenRule >> name [
 
 	^ 'Temporaries may be read before written'

--- a/src/GeneralRules/ReTestCaseShouldNotUseInitializeRule.class.st
+++ b/src/GeneralRules/ReTestCaseShouldNotUseInitializeRule.class.st
@@ -5,18 +5,20 @@ It means that you can get a test breaking and when you rerun your test you get t
 Initialize should only use variables defined in #instanceVariablesToKeep.
 "
 Class {
-	#name : #ReTestCaseShouldNotUseInitializeRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReTestCaseShouldNotUseInitializeRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #'testing-interest' }
+{ #category : 'testing-interest' }
 ReTestCaseShouldNotUseInitializeRule class >> checksClass [
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReTestCaseShouldNotUseInitializeRule >> basicCheck: aClass [
 
 	| alteredVariables expectedVariables |
@@ -36,12 +38,12 @@ ReTestCaseShouldNotUseInitializeRule >> basicCheck: aClass [
 	^ alteredVariables anySatisfy: [ :e | (expectedVariables includes: e name) not ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReTestCaseShouldNotUseInitializeRule >> group [
 	^ 'Clean Code'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReTestCaseShouldNotUseInitializeRule >> name [
 
 	^ 'Tests should not use initialize'

--- a/src/GeneralRules/ReThemeAPIUpdateRule.class.st
+++ b/src/GeneralRules/ReThemeAPIUpdateRule.class.st
@@ -3,24 +3,26 @@ Do not explicitly refer to UITheme current but use Smalltalk ui theme. Similarly
 
 "
 Class {
-	#name : #ReThemeAPIUpdateRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReThemeAPIUpdateRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReThemeAPIUpdateRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ThemeAPIUpdateRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReThemeAPIUpdateRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReThemeAPIUpdateRule >> initialize [
 	super initialize.
 	self
@@ -30,7 +32,7 @@ ReThemeAPIUpdateRule >> initialize [
 			with: 'Smalltalk ui icons'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReThemeAPIUpdateRule >> name [
 	^ 'Use "Smalltalk ui theme" and "Smalltalk ui icons"'
 ]

--- a/src/GeneralRules/ReThreeElementPointRule.class.st
+++ b/src/GeneralRules/ReThreeElementPointRule.class.st
@@ -2,19 +2,21 @@
 Checks arithmetic statements for possible three element points (i.e., a point that has another point in its x or y part).
 "
 Class {
-	#name : #ReThreeElementPointRule,
-	#superclass : #ReNodeBasedRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReThreeElementPointRule',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReThreeElementPointRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ThreeElementPointRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReThreeElementPointRule >> check: aNode forCritiquesDo: aCriticBlock [
 	| parentPoint |
 
@@ -29,7 +31,7 @@ ReThreeElementPointRule >> check: aNode forCritiquesDo: aCriticBlock [
 		self critiqueFor: parentPoint)
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReThreeElementPointRule >> findSuspiciousParentFor: aNode ifNone: alternativeBlock [
 	| tentativeNode |
 
@@ -47,12 +49,12 @@ ReThreeElementPointRule >> findSuspiciousParentFor: aNode ifNone: alternativeBlo
 		ifNone: alternativeBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReThreeElementPointRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReThreeElementPointRule >> name [
 	^ 'Possible three element point (e.g., x @ y + q @ r)'
 ]

--- a/src/GeneralRules/ReToDoCollectRule.class.st
+++ b/src/GeneralRules/ReToDoCollectRule.class.st
@@ -2,24 +2,26 @@
 Checks for users of to:do: when the shorter collect: would work.
 "
 Class {
-	#name : #ReToDoCollectRule,
-	#superclass : #ReNodeMatchRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReToDoCollectRule',
+	#superclass : 'ReNodeMatchRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReToDoCollectRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ToDoCollectRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReToDoCollectRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReToDoCollectRule >> initialize [
 	super initialize.
 	self matchesAny: #(
@@ -47,7 +49,7 @@ ReToDoCollectRule >> initialize [
 			`@.Stmts3' )
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReToDoCollectRule >> name [
 	^ 'to:do: used instead of collect:'
 ]

--- a/src/GeneralRules/ReToDoWithIncrementRule.class.st
+++ b/src/GeneralRules/ReToDoWithIncrementRule.class.st
@@ -5,24 +5,26 @@ In Pharo you do not increment or decrement counter but should use the message to
 1 to: 100 by: 3 do: [ :each | ... ]
 "
 Class {
-	#name : #ReToDoWithIncrementRule,
-	#superclass : #ReNodeMatchRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReToDoWithIncrementRule',
+	#superclass : 'ReNodeMatchRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReToDoWithIncrementRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ToDoWithIncrementRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReToDoWithIncrementRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReToDoWithIncrementRule >> initialize [
 	super initialize.
 	self matchesAny: #(
@@ -32,12 +34,12 @@ ReToDoWithIncrementRule >> initialize [
 			'`@i to: `@j by: `@k do: [:`e | | `@temps | `@.Stmts. `x := `x - `@k. `@.Stmts2]')
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReToDoWithIncrementRule >> name [
 	^ 'to:do: loop also increments a counter'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReToDoWithIncrementRule >> rationale [
 	^ 'Checks for users of to:do: that also increment or decrement a counter.'
 ]

--- a/src/GeneralRules/ReTrueFalseDuplicationRule.class.st
+++ b/src/GeneralRules/ReTrueFalseDuplicationRule.class.st
@@ -13,19 +13,21 @@ test
 	ifFalse: [ self baz ]
 "
 Class {
-	#name : #ReTrueFalseDuplicationRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReTrueFalseDuplicationRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReTrueFalseDuplicationRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'EndTrueFalseRule'
 ]
 
-{ #category : #hooks }
+{ #category : 'hooks' }
 ReTrueFalseDuplicationRule >> afterCheck: aNode mappings: mappingDict [
 
 	mappingDict
@@ -37,12 +39,12 @@ ReTrueFalseDuplicationRule >> afterCheck: aNode mappings: mappingDict [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReTrueFalseDuplicationRule >> group [
 	^ 'Optimization'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReTrueFalseDuplicationRule >> initialize [
 	super initialize.
 	self
@@ -107,17 +109,17 @@ ReTrueFalseDuplicationRule >> initialize [
 		`.@PostStatements.'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReTrueFalseDuplicationRule >> name [
 	^ 'Check for same statements at end of ifTrue:ifFalse: blocks'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReTrueFalseDuplicationRule >> rationale [
 	^ 'Checks for ifTrue:ifFalse: blocks that have the same code at the beginning or end.'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReTrueFalseDuplicationRule >> severity [
 	^ #information
 ]

--- a/src/GeneralRules/ReUnaryAccessingMethodWithoutReturnRule.class.st
+++ b/src/GeneralRules/ReUnaryAccessingMethodWithoutReturnRule.class.st
@@ -2,23 +2,25 @@
 Checks for any unary ""accessing"" methods without explicit return statements.
 "
 Class {
-	#name : #ReUnaryAccessingMethodWithoutReturnRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReUnaryAccessingMethodWithoutReturnRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReUnaryAccessingMethodWithoutReturnRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnaryAccessingMethodWithoutReturnRule class >> uniqueIdentifierName [
 
 	^ 'UnaryAccessingMethodWithoutReturnRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReUnaryAccessingMethodWithoutReturnRule >> basicCheck: aMethod [
 
 	(aMethod numArgs > 0 or: [ aMethod isAbstract ]) ifTrue: [ ^ false ].
@@ -26,12 +28,12 @@ ReUnaryAccessingMethodWithoutReturnRule >> basicCheck: aMethod [
 	^ aMethod ast allChildren noneSatisfy: [ :each | each isReturn ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnaryAccessingMethodWithoutReturnRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnaryAccessingMethodWithoutReturnRule >> name [
 	^ 'Unary "accessing" method without explicit return'
 ]

--- a/src/GeneralRules/ReUnclassifiedMethodsRule.class.st
+++ b/src/GeneralRules/ReUnclassifiedMethodsRule.class.st
@@ -2,35 +2,37 @@
 All methods should be put into a protocol (method category) for better readability.
 "
 Class {
-	#name : #ReUnclassifiedMethodsRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReUnclassifiedMethodsRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReUnclassifiedMethodsRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnclassifiedMethodsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'UnclassifiedMethodsRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReUnclassifiedMethodsRule >> basicCheck: aMethod [
 
 	^ aMethod isClassified not
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnclassifiedMethodsRule >> group [
 	^ 'Style'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnclassifiedMethodsRule >> name [
 	^ 'Unclassified methods'
 ]

--- a/src/GeneralRules/ReUncommonMessageSendRule.class.st
+++ b/src/GeneralRules/ReUncommonMessageSendRule.class.st
@@ -4,24 +4,26 @@ Sending messages with a common literal (e.g. ""Object self"") or an uppercase se
 Notice, problems of this kind will most likely also cause RBSentNotImplementedRule to be invoked, because one should not use such method names in the first place.
 "
 Class {
-	#name : #ReUncommonMessageSendRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReUncommonMessageSendRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReUncommonMessageSendRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUncommonMessageSendRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'UncommonMessageSendRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReUncommonMessageSendRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	| problemSelectors |
 	problemSelectors :=
@@ -32,18 +34,18 @@ ReUncommonMessageSendRule >> check: aMethod forCritiquesDo: aCriticBlock [
 			aCriticBlock cull: (self createTrivialCritiqueOn: aMethod intervalOf: msgSend hint: msgSend selector asString) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUncommonMessageSendRule >> commonLiterals [
 
 	^ #(#self #super #thisContext #true #false #nil)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUncommonMessageSendRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUncommonMessageSendRule >> name [
 	^ 'Uncommon message send'
 ]

--- a/src/GeneralRules/ReUnconditionalRecursionRule.class.st
+++ b/src/GeneralRules/ReUnconditionalRecursionRule.class.st
@@ -2,35 +2,37 @@
 Checks for unconditional recursion that might cause the image to hang when executed.
 "
 Class {
-	#name : #ReUnconditionalRecursionRule,
-	#superclass : #ReNodeMatchRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReUnconditionalRecursionRule',
+	#superclass : 'ReNodeMatchRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReUnconditionalRecursionRule class >> checksMethod [
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnconditionalRecursionRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'UnconditionalRecursionRule'
 ]
 
-{ #category : #hooks }
+{ #category : 'hooks' }
 ReUnconditionalRecursionRule >> afterCheck: aNode mappings: mappingDict [
 	^ (mappingDict at: '`@.before') noneSatisfy: #containsReturn
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnconditionalRecursionRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReUnconditionalRecursionRule >> initialize [
 	super initialize.
 	self addMatchingMethod:
@@ -41,12 +43,12 @@ ReUnconditionalRecursionRule >> initialize [
 			`@.after'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnconditionalRecursionRule >> name [
 	^ 'Unconditional recursion'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnconditionalRecursionRule >> severity [
 	^ #error
 ]

--- a/src/GeneralRules/ReUndeclaredVariableRule.class.st
+++ b/src/GeneralRules/ReUndeclaredVariableRule.class.st
@@ -2,34 +2,36 @@
 You are referencing a variable that is not declared anywhere. There is no temp, instance var, class var, or a global variable that can be bound to by this reference. Most likely you got into this state by writing an entirely correct code, but then the variable was removed.
 "
 Class {
-	#name : #ReUndeclaredVariableRule,
-	#superclass : #ReNodeBasedRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReUndeclaredVariableRule',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 ReUndeclaredVariableRule >> basicCheck: aNode [
 	^ aNode isVariable and: [ aNode isUndeclaredVariable ]
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 ReUndeclaredVariableRule >> critiqueFor: aNode [
 	^ (super critiqueFor: aNode)
 		tinyHint: aNode name;
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUndeclaredVariableRule >> group [
 	^ 'Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUndeclaredVariableRule >> name [
 	^ 'References an undeclared variable'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUndeclaredVariableRule >> severity [
 	^ #error
 ]

--- a/src/GeneralRules/ReUnnecessaryAssignmentRule.class.st
+++ b/src/GeneralRules/ReUnnecessaryAssignmentRule.class.st
@@ -2,36 +2,38 @@
 Checks for assignements to temporaries that are not used afterwards.
 "
 Class {
-	#name : #ReUnnecessaryAssignmentRule,
-	#superclass : #ReNodeBasedRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReUnnecessaryAssignmentRule',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnnecessaryAssignmentRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'UnnecessaryAssignmentRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReUnnecessaryAssignmentRule >> basicCheck: aNode [
 	aNode isReturn ifFalse: [ ^ false ].
 	aNode isAssignment ifFalse: [ ^ false ].
 	^ (aNode whoDefines: aNode variable name) isNotNil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnnecessaryAssignmentRule >> group [
 	^ 'Optimization'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnnecessaryAssignmentRule >> name [
 	^ 'Unnecessary assignment to a temporary variable'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnnecessaryAssignmentRule >> severity [
 	^ #information
 ]

--- a/src/GeneralRules/ReUnoptimizedAndOrRule.class.st
+++ b/src/GeneralRules/ReUnoptimizedAndOrRule.class.st
@@ -2,24 +2,26 @@
 Checks for inefficient nesting of logical conditions.
 "
 Class {
-	#name : #ReUnoptimizedAndOrRule,
-	#superclass : #ReNodeMatchRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReUnoptimizedAndOrRule',
+	#superclass : 'ReNodeMatchRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnoptimizedAndOrRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'UnoptimizedAndOrRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnoptimizedAndOrRule >> group [
 	^ 'Optimization'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReUnoptimizedAndOrRule >> initialize [
 	super initialize.
 	self matchesAny: #(
@@ -27,7 +29,7 @@ ReUnoptimizedAndOrRule >> initialize [
 			'(`@a or: `@b) or: `@c' )
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnoptimizedAndOrRule >> name [
 	^ 'Uses "(a and: [b]) and: [c]" instead of "a and: [b and: [c]]"'
 ]

--- a/src/GeneralRules/ReUnoptimizedToDoRule.class.st
+++ b/src/GeneralRules/ReUnoptimizedToDoRule.class.st
@@ -8,30 +8,32 @@ can be more efficiently expressed as
 1 to: 10 do: aBlock
 "
 Class {
-	#name : #ReUnoptimizedToDoRule,
-	#superclass : #ReNodeMatchRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReUnoptimizedToDoRule',
+	#superclass : 'ReNodeMatchRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnoptimizedToDoRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'UnoptimizedToDoRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnoptimizedToDoRule >> group [
 	^ 'Optimization'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReUnoptimizedToDoRule >> initialize [
 	super initialize.
 	self matches: '(`@a to: `@b) do: `@c'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnoptimizedToDoRule >> name [
 	^ 'Uses (to:)do: instead of to:do:'
 ]

--- a/src/GeneralRules/ReUnpackagedCodeRule.class.st
+++ b/src/GeneralRules/ReUnpackagedCodeRule.class.st
@@ -2,39 +2,41 @@
 Code that is not contained in a Monticello package is not versioned and cannot be brought into a different image.
 "
 Class {
-	#name : #ReUnpackagedCodeRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReUnpackagedCodeRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReUnpackagedCodeRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReUnpackagedCodeRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnpackagedCodeRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'UnpackagedCodeRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReUnpackagedCodeRule >> basicCheck: anEntity [
 	^ anEntity package isNotNil and: [ anEntity package isDefault ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnpackagedCodeRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnpackagedCodeRule >> name [
 	^ 'Unpackaged code'
 ]

--- a/src/GeneralRules/ReUnwindBlocksRule.class.st
+++ b/src/GeneralRules/ReUnwindBlocksRule.class.st
@@ -15,24 +15,26 @@ var := [ statements.
 ]]]
 "
 Class {
-	#name : #ReUnwindBlocksRule,
-	#superclass : #ReNodeRewriteRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReUnwindBlocksRule',
+	#superclass : 'ReNodeRewriteRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnwindBlocksRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'UnwindBlocksRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnwindBlocksRule >> group [
 	^ 'Optimization'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReUnwindBlocksRule >> initialize [
 	super initialize.
 	self
@@ -46,7 +48,7 @@ ReUnwindBlocksRule >> initialize [
 			with: '^[| `@temps | ``@.Statements. ``@object] ifCurtailed: ``@block'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUnwindBlocksRule >> name [
 	^ 'Move assignment out of unwind blocks'
 ]

--- a/src/GeneralRules/ReUseIsEmptyNotSizeRule.class.st
+++ b/src/GeneralRules/ReUseIsEmptyNotSizeRule.class.st
@@ -2,24 +2,26 @@
 Checks for code using equality tests instead of the message sends. Since the code ""aCollection size = 0"" works for all objects, it is more difficult for someone reading such code to determine that ""aCollection"" is a collection. Whereas, if you say ""aCollection isEmpty"" then aCollection must be a collection since isEmpty is only defined for collections.
 "
 Class {
-	#name : #ReUseIsEmptyNotSizeRule,
-	#superclass : #ReNodeMatchRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReUseIsEmptyNotSizeRule',
+	#superclass : 'ReNodeMatchRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUseIsEmptyNotSizeRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ConsistencyCheckRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUseIsEmptyNotSizeRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReUseIsEmptyNotSizeRule >> initialize [
 	super initialize.
 	self  matchesAny: #(
@@ -29,7 +31,7 @@ ReUseIsEmptyNotSizeRule >> initialize [
 		'`@object size >= 1')
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUseIsEmptyNotSizeRule >> name [
 	^ 'Checks for empty collection using #size instead of #isEmpty" or #isNotEmpty'
 ]

--- a/src/GeneralRules/ReUsesAddRule.class.st
+++ b/src/GeneralRules/ReUsesAddRule.class.st
@@ -2,29 +2,31 @@
 Check for possible uses of the result returned by an add: or addAll: messages. These messages return their arguments not the receiver. As a result, may uses of the results are wrong.
 "
 Class {
-	#name : #ReUsesAddRule,
-	#superclass : #ReNodeBasedRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReUsesAddRule',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUsesAddRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'UsesAddRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReUsesAddRule >> basicCheck: node [
 	^ node isMessage and: [ (#(#add: #addAll:) includes: node selector) and: [ node isDirectlyUsed ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUsesAddRule >> group [
 	^ 'Potential Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUsesAddRule >> name [
 	^ 'Uses the result of an add: message'
 ]

--- a/src/GeneralRules/ReUsesTrueRule.class.st
+++ b/src/GeneralRules/ReUsesTrueRule.class.st
@@ -4,24 +4,26 @@ Checks for uses of the classes True and False instead of the objects true and fa
 true is the object true, while True is the class whose true is the sole instance.
 "
 Class {
-	#name : #ReUsesTrueRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReUsesTrueRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReUsesTrueRule class >> checksMethod [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUsesTrueRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'UsesTrueRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReUsesTrueRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	| problemUsages |
 	problemUsages := aMethod ast variableNodes select: [ :aNode |
@@ -30,17 +32,17 @@ ReUsesTrueRule >> check: aMethod forCritiquesDo: aCriticBlock [
 		aCriticBlock cull: (self createTrivialCritiqueOn: aMethod intervalOf: ref hint: ref name asString)]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUsesTrueRule >> group [
 	^ 'Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUsesTrueRule >> name [
 	^ 'Uses True/False instead of true/false'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUsesTrueRule >> severity [
 	^ #error
 ]

--- a/src/GeneralRules/ReUsesWorldGlobalRule.class.st
+++ b/src/GeneralRules/ReUsesWorldGlobalRule.class.st
@@ -3,29 +3,31 @@ The direct use of the global variables World and ActiveWorld is incorrect.
 Use ""self currentWorld"" instead.
 "
 Class {
-	#name : #ReUsesWorldGlobalRule,
-	#superclass : #ReNodeBasedRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReUsesWorldGlobalRule',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUsesWorldGlobalRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'UsesWorldGlobalRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReUsesWorldGlobalRule >> basicCheck: aNode [
 	^ aNode isGlobalVariable and: [ #(#World #ActiveWorld) includes: aNode name ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUsesWorldGlobalRule >> group [
 	^ 'Bugs'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReUsesWorldGlobalRule >> name [
 	^ 'Uses World or ActiveWorld directly'
 ]

--- a/src/GeneralRules/ReVariableAssignedLiteralRule.class.st
+++ b/src/GeneralRules/ReVariableAssignedLiteralRule.class.st
@@ -2,18 +2,20 @@
 If a variable is only assigned a single literal value then that variable is either nil or that literal value. If the variable is always initialized with that literal value, then you could replace each variable reference with a message send to get the value. If the variable can also be nil, then you might want to replace that variable with another that stores true or false depending on whether the old variable had been assigned.
 "
 Class {
-	#name : #ReVariableAssignedLiteralRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReVariableAssignedLiteralRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #'testing-interest' }
+{ #category : 'testing-interest' }
 ReVariableAssignedLiteralRule class >> checksClass [
 
 	^ true
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReVariableAssignedLiteralRule >> check: aClass forCritiquesDo: aCriticBlock [
 
 	aClass definedVariables do: [ :variable |
@@ -26,12 +28,12 @@ ReVariableAssignedLiteralRule >> check: aClass forCritiquesDo: aCriticBlock [
 			aCriticBlock cull: (self critiqueFor: aClass about: variable name) ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReVariableAssignedLiteralRule >> group [
 	^ 'Design Flaws'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReVariableAssignedLiteralRule >> name [
 	^ 'Variable is only assigned a single literal value'
 ]

--- a/src/GeneralRules/ReVariableReferencedOnceRule.class.st
+++ b/src/GeneralRules/ReVariableReferencedOnceRule.class.st
@@ -2,24 +2,26 @@
 Checks for instance variables that might better be defined as temporary variables. If an instance variable is only used in one method and it is always assigned before it is used, then that method could define that variable as a temporary variable of the method instead (assuming that the method is not recursive).
 "
 Class {
-	#name : #ReVariableReferencedOnceRule,
-	#superclass : #ReAbstractRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReVariableReferencedOnceRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ReVariableReferencedOnceRule class >> checksClass [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReVariableReferencedOnceRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'VariableReferencedOnceRule'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ReVariableReferencedOnceRule >> check: aClass forCritiquesDo: aCriticBlock [
 		aClass slots do: [ :slot |
 		  | usingMethods |
@@ -30,17 +32,17 @@ ReVariableReferencedOnceRule >> check: aClass forCritiquesDo: aCriticBlock [
 				  writtenBeforeReadIn: usingMethods first ast) ifTrue: [aCriticBlock cull: (self critiqueFor: aClass about: slot  name)   ]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReVariableReferencedOnceRule >> group [
 	^ 'Design Flaws'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReVariableReferencedOnceRule >> name [
 	^ 'Variable referenced in only one method and always assigned first'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReVariableReferencedOnceRule >> severity [
 	^ #information
 ]

--- a/src/GeneralRules/ReWhileTrueRule.class.st
+++ b/src/GeneralRules/ReWhileTrueRule.class.st
@@ -12,24 +12,26 @@ statements1.
 statements2
 "
 Class {
-	#name : #ReWhileTrueRule,
-	#superclass : #ReNodeMatchRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReWhileTrueRule',
+	#superclass : 'ReNodeMatchRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReWhileTrueRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'WhileTrueRule'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReWhileTrueRule >> group [
 	^ 'Coding Idiom Violation'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ReWhileTrueRule >> initialize [
 	super initialize.
 	self matchesAny: #(
@@ -67,12 +69,12 @@ ReWhileTrueRule >> initialize [
 			`@.Statements2' )
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReWhileTrueRule >> name [
 	^ 'Uses whileTrue: instead of to:do:'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReWhileTrueRule >> rationale [
 	^ 'Checks for users of whileTrue: when the shorter to:do: would work.'
 ]

--- a/src/GeneralRules/ReYourselfNotUsedRule.class.st
+++ b/src/GeneralRules/ReYourselfNotUsedRule.class.st
@@ -2,31 +2,33 @@
 Check for methods sending the yourself message when it is not necessary.
 "
 Class {
-	#name : #ReYourselfNotUsedRule,
-	#superclass : #ReNodeBasedRule,
-	#category : #'GeneralRules-Migrated'
+	#name : 'ReYourselfNotUsedRule',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'GeneralRules-Migrated',
+	#package : 'GeneralRules',
+	#tag : 'Migrated'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReYourselfNotUsedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^ 'YourselfNotUsedRule'
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ReYourselfNotUsedRule >> basicCheck: aNode [
 	aNode isMessage ifFalse: [ ^ false ].
 	aNode selector = #yourself ifFalse: [ ^ false ].
 	^ aNode isUsed not
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReYourselfNotUsedRule >> group [
 	^ 'Optimization'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ReYourselfNotUsedRule >> name [
 	^ 'Doesn''t use the result of a yourself message'
 ]

--- a/src/GeneralRules/package.st
+++ b/src/GeneralRules/package.st
@@ -1,1 +1,1 @@
-Package { #name : #GeneralRules }
+Package { #name : 'GeneralRules' }

--- a/src/Kernel-Tests-Extended/AdditionalMethodStateTest.class.st
+++ b/src/Kernel-Tests-Extended/AdditionalMethodStateTest.class.st
@@ -2,15 +2,17 @@
 SUnit tests for AdditionalMethodState
 "
 Class {
-	#name : #AdditionalMethodStateTest,
-	#superclass : #TestCase,
+	#name : 'AdditionalMethodStateTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'amState'
 	],
-	#category : #'Kernel-Tests-Extended-Methods'
+	#category : 'Kernel-Tests-Extended-Methods',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Methods'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 AdditionalMethodStateTest >> setUp [
 
 	| pragma |
@@ -20,7 +22,7 @@ AdditionalMethodStateTest >> setUp [
 	amState := AdditionalMethodState selector: #at: with: pragma copy
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AdditionalMethodStateTest >> testAnalogousCodeTo [
 	"create a fake traitSource association property"
 	| state |
@@ -34,7 +36,7 @@ AdditionalMethodStateTest >> testAnalogousCodeTo [
 		raise: MessageNotUnderstood
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AdditionalMethodStateTest >> testCopy [
 	| copy |
 	copy := amState copy.

--- a/src/Kernel-Tests-Extended/AsciiCharsetTest.class.st
+++ b/src/Kernel-Tests-Extended/AsciiCharsetTest.class.st
@@ -3,17 +3,19 @@ Tests for the AsciiCharSet class.  The invariant is that AsciiCharSet is  a subs
 have behaviour consisetent with Unicode.
 "
 Class {
-	#name : #AsciiCharsetTest,
-	#superclass : #TestCase,
-	#category : #'Kernel-Tests-Extended-Charset'
+	#name : 'AsciiCharsetTest',
+	#superclass : 'TestCase',
+	#category : 'Kernel-Tests-Extended-Charset',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Charset'
 }
 
-{ #category : #helper }
+{ #category : 'helper' }
 AsciiCharsetTest >> classUnderTest [
 	^ AsciiCharset
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsCasedLetter [
 	"Exhaustively check that the charset under test behaves like Unicode"
 
@@ -25,7 +27,7 @@ AsciiCharsetTest >> testIsCasedLetter [
 		self assert: (Unicode isCasedLetter: ch) equals: (charset isCasedLetter: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsClosePunctuation [
 	"Exhaustively check that the charset under test behaves like Unicode"
 
@@ -39,7 +41,7 @@ AsciiCharsetTest >> testIsClosePunctuation [
 			equals: (charset isClosePunctuation: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsConnectorPunctuation [
 
 	"Exhaustively check that the charset under test behaves like Unicode"
@@ -52,7 +54,7 @@ AsciiCharsetTest >> testIsConnectorPunctuation [
 		self assert: (Unicode isConnectorPunctuation: ch) equals: (charset isConnectorPunctuation: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsControlOther [
 
 	"Exhaustively check that the charset under test behaves like Unicode"
@@ -65,7 +67,7 @@ AsciiCharsetTest >> testIsControlOther [
 		self assert: (Unicode isControlOther: ch) equals: (charset isControlOther: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsCurrencySymbol [
 
 	"Exhaustively check that the charset under test behaves like Unicode"
@@ -78,7 +80,7 @@ AsciiCharsetTest >> testIsCurrencySymbol [
 		self assert: (Unicode isCurrencySymbol: ch) equals: (charset isCurrencySymbol: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsDashPunctuation [
 
 	"Exhaustively check that the charset under test behaves like Unicode"
@@ -91,7 +93,7 @@ AsciiCharsetTest >> testIsDashPunctuation [
 		self assert: (Unicode isDashPunctuation: ch) equals: (charset isDashPunctuation: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsDecimalDigit [
 
 	"Exhaustively check that the charset under test behaves like Unicode"
@@ -104,7 +106,7 @@ AsciiCharsetTest >> testIsDecimalDigit [
 		self assert: (Unicode isDecimalDigit: ch) equals: (charset isDecimalDigit: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsDigit [
 
 	"Exhaustively check that the charset under test behaves like Unicode"
@@ -117,7 +119,7 @@ AsciiCharsetTest >> testIsDigit [
 		self assert: (Unicode isDigit: ch) equals: (charset isDigit: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsEnclosingMark [
 
 	"Exhaustively check that the charset under test behaves like Unicode"
@@ -130,7 +132,7 @@ AsciiCharsetTest >> testIsEnclosingMark [
 		self assert: (Unicode isEnclosingMark: ch) equals: (charset isEnclosingMark: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsFinalQuote [
 
 	"Exhaustively check that the charset under test behaves like Unicode"
@@ -143,7 +145,7 @@ AsciiCharsetTest >> testIsFinalQuote [
 		self assert: (Unicode isFinalQuote: ch) equals: (charset isFinalQuote: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsFormatOther [
 
 	"Exhaustively check that the charset under test behaves like Unicode"
@@ -156,7 +158,7 @@ AsciiCharsetTest >> testIsFormatOther [
 		self assert: (Unicode isFormatOther: ch) equals: (charset isFormatOther: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsInitialQuote [
 
 	"Exhaustively check that the charset under test behaves like Unicode"
@@ -169,7 +171,7 @@ AsciiCharsetTest >> testIsInitialQuote [
 		self assert: (Unicode isInitialQuote: ch) equals: (charset isInitialQuote: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsLetter [
 
 	"Exhaustively check that the charset under test behaves like Unicode"
@@ -182,7 +184,7 @@ AsciiCharsetTest >> testIsLetter [
 		self assert: (Unicode isLetter: ch) equals: (charset isLetter: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsLetterModifier [
 
 	"Exhaustively check that the charset under test behaves like Unicode"
@@ -195,7 +197,7 @@ AsciiCharsetTest >> testIsLetterModifier [
 		self assert: (Unicode isLetterModifier: ch) equals: (charset isLetterModifier: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsLetterNumber [
 
 	"Exhaustively check that the charset under test behaves like Unicode"
@@ -208,7 +210,7 @@ AsciiCharsetTest >> testIsLetterNumber [
 		self assert: (Unicode isLetterNumber: ch) equals: (charset isLetterNumber: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsLineSeparator [
 
 	"Exhaustively check that the charset under test behaves like Unicode"
@@ -221,7 +223,7 @@ AsciiCharsetTest >> testIsLineSeparator [
 		self assert: (Unicode isLineSeparator: ch) equals: (charset isLineSeparator: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsLowercase [
 
 	"Exhaustively check that the charset under test behaves like Unicode"
@@ -234,7 +236,7 @@ AsciiCharsetTest >> testIsLowercase [
 		self assert: (Unicode isLowercase: ch) equals: (charset isLowercase: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsMathSymbol [
 
 	"Exhaustively check that the charset under test behaves like Unicode"
@@ -247,7 +249,7 @@ AsciiCharsetTest >> testIsMathSymbol [
 		self assert: (Unicode isMathSymbol: ch) equals: (charset isMathSymbol: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsModifierSymbol [
 
 	"Exhaustively check that the charset under test behaves like Unicode"
@@ -260,7 +262,7 @@ AsciiCharsetTest >> testIsModifierSymbol [
 		self assert: (Unicode isModifierSymbol: ch) equals: (charset isModifierSymbol: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsNonspacingMark [
 	"Exhaustively check that the charset under test behaves like Unicode"
 
@@ -274,7 +276,7 @@ AsciiCharsetTest >> testIsNonspacingMark [
 			equals: (charset isNonspacingMark: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsOpenPunctuation [
 	"Exhaustively check that the charset under test behaves like Unicode"
 
@@ -288,7 +290,7 @@ AsciiCharsetTest >> testIsOpenPunctuation [
 			equals: (charset isOpenPunctuation: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsOtherLetter [
 	"Exhaustively check that the charset under test behaves like Unicode"
 
@@ -302,7 +304,7 @@ AsciiCharsetTest >> testIsOtherLetter [
 			equals: (charset isOtherLetter: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsOtherNumber [
 	"Exhaustively check that the charset under test behaves like Unicode"
 
@@ -316,7 +318,7 @@ AsciiCharsetTest >> testIsOtherNumber [
 			equals: (charset isOtherNumber: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsOtherPunctuation [
 	"Exhaustively check that the charset under test behaves like Unicode"
 
@@ -330,7 +332,7 @@ AsciiCharsetTest >> testIsOtherPunctuation [
 			equals: (charset isOtherPunctuation: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsOtherSymbol [
 	"Exhaustively check that the charset under test behaves like Unicode"
 
@@ -344,7 +346,7 @@ AsciiCharsetTest >> testIsOtherSymbol [
 			equals: (charset isOtherSymbol: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsParagraphSeparator [
 	"Exhaustively check that the charset under test behaves like Unicode"
 
@@ -358,7 +360,7 @@ AsciiCharsetTest >> testIsParagraphSeparator [
 			equals: (charset isParagraphSeparator: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsPrivateOther [
 	"Exhaustively check that the charset under test behaves like Unicode"
 
@@ -372,7 +374,7 @@ AsciiCharsetTest >> testIsPrivateOther [
 			equals: (charset isPrivateOther: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsSpaceSeparator [
 	"Exhaustively check that the charset under test behaves like Unicode"
 
@@ -386,7 +388,7 @@ AsciiCharsetTest >> testIsSpaceSeparator [
 			equals: (charset isSpaceSeparator: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsSpacingCombiningMark [
 	"Exhaustively check that the charset under test behaves like Unicode"
 
@@ -400,7 +402,7 @@ AsciiCharsetTest >> testIsSpacingCombiningMark [
 			equals: (charset isSpacingCombiningMark: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsSurrogateOther [
 	"Exhaustively check that the charset under test behaves like Unicode"
 
@@ -414,7 +416,7 @@ AsciiCharsetTest >> testIsSurrogateOther [
 			equals: (charset isSurrogateOther: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsTitlecaseLetter [
 	"Exhaustively check that the charset under test behaves like Unicode"
 
@@ -428,7 +430,7 @@ AsciiCharsetTest >> testIsTitlecaseLetter [
 			equals: (charset isTitlecaseLetter: ch) ]
 ]
 
-{ #category : #'generated tests' }
+{ #category : 'generated tests' }
 AsciiCharsetTest >> testIsUppercase [
 	"Exhaustively check that the charset under test behaves like Unicode"
 

--- a/src/Kernel-Tests-Extended/BehaviorTest.extension.st
+++ b/src/Kernel-Tests-Extended/BehaviorTest.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #BehaviorTest }
+Extension { #name : 'BehaviorTest' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 BehaviorTest >> testAllReferencesTo [
 	| result |
 	result := SystemNavigation new allReferencesTo: Point binding.

--- a/src/Kernel-Tests-Extended/BenchmarkResultTest.class.st
+++ b/src/Kernel-Tests-Extended/BenchmarkResultTest.class.st
@@ -2,12 +2,14 @@
 Unit test for BenchmarkResult
 "
 Class {
-	#name : #BenchmarkResultTest,
-	#superclass : #TestCase,
-	#category : #'Kernel-Tests-Extended-Chronology'
+	#name : 'BenchmarkResultTest',
+	#superclass : 'TestCase',
+	#category : 'Kernel-Tests-Extended-Chronology',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Chronology'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 BenchmarkResultTest >> testEmpty [
 	| benchmarkResult |
 	benchmarkResult := BenchmarkResult new.
@@ -19,7 +21,7 @@ BenchmarkResultTest >> testEmpty [
 	self deny: benchmarkResult printString isEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 BenchmarkResultTest >> testOne [
 	| benchmarkResult |
 	benchmarkResult := BenchmarkResult new.
@@ -37,7 +39,7 @@ BenchmarkResultTest >> testOne [
 	self deny: benchmarkResult printString isEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 BenchmarkResultTest >> testOneOverTwo [
 	| benchmarkResult |
 	benchmarkResult := BenchmarkResult new.
@@ -55,7 +57,7 @@ BenchmarkResultTest >> testOneOverTwo [
 	self deny: benchmarkResult printString isEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 BenchmarkResultTest >> testSimple [
 	| benchmarkResult |
 	benchmarkResult := BenchmarkResult new.

--- a/src/Kernel-Tests-Extended/BlockClosureTest.extension.st
+++ b/src/Kernel-Tests-Extended/BlockClosureTest.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #BlockClosureTest }
+Extension { #name : 'BlockClosureTest' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 BlockClosureTest >> testBenchFor [
 	| benchmarkResult duration minimumIterations |
 	duration := 500 milliSeconds.
@@ -13,7 +13,7 @@ BlockClosureTest >> testBenchFor [
 	self assert: benchmarkResult period < (duration / minimumIterations)
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 BlockClosureTest >> testBenchForException [
 
 	"benchFor: expects a duration. Check that the bencher does not go in an infinite loop if the wakeup thread fails."
@@ -21,7 +21,7 @@ BlockClosureTest >> testBenchForException [
 	self should: [ [ 100 factorial ] benchFor: 1 ] raise: Error
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 BlockClosureTest >> testCannotReturn [
 
 	| block p |
@@ -33,19 +33,19 @@ BlockClosureTest >> testCannotReturn [
 		self assert: err home equals: block home ]
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 BlockClosureTest >> testRunSimulated [
 	self assert: (Context runSimulated: aBlock) class equals: Rectangle
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 BlockClosureTest >> testSourceNodeOptimized [
 	| block |
 	block := [ :ctx | [ ctx atEnd ] whileTrue: [ 1 + 2 ] ].
 	self assert: block sourceNode printString equals: 'RBBlockNode([ :ctx | [ ctx atEnd ] whileTrue: [ 1 + 2 ] ])'
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 BlockClosureTest >> testTallyInstructions [
 
 	| expected |
@@ -58,7 +58,7 @@ BlockClosureTest >> testTallyInstructions [
 		equals: expected
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 BlockClosureTest >> testTallyMethods [
 	self assert: (Context tallyMethods: aBlock) size equals: 7
 ]

--- a/src/Kernel-Tests-Extended/BlockClosuresTestCase.extension.st
+++ b/src/Kernel-Tests-Extended/BlockClosuresTestCase.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #BlockClosuresTestCase }
+Extension { #name : 'BlockClosuresTestCase' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 BlockClosuresTestCase >> testExample1 [
 	self assert: (self example1: 5) equals: 5 factorial
 ]

--- a/src/Kernel-Tests-Extended/ClassDescriptionTest.extension.st
+++ b/src/Kernel-Tests-Extended/ClassDescriptionTest.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #ClassDescriptionTest }
+Extension { #name : 'ClassDescriptionTest' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 ClassDescriptionTest >> testAllLocalCallsOn [
 
 	self assert: (( Point allLocalCallsOn: #asPoint )  notEmpty).

--- a/src/Kernel-Tests-Extended/ClassTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassTest.class.st
@@ -2,29 +2,31 @@
 SUnit tests for classes
 "
 Class {
-	#name : #ClassTest,
-	#superclass : #ClassTestCase,
+	#name : 'ClassTest',
+	#superclass : 'ClassTestCase',
 	#instVars : [
 		'className',
 		'testEnvironment'
 	],
-	#category : #'Kernel-Tests-Extended-Classes'
+	#category : 'Kernel-Tests-Extended-Classes',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Classes'
 }
 
-{ #category : #setup }
+{ #category : 'setup' }
 ClassTest >> categoryNameForTemporaryClasses [
 	"Answer the category where to classify temporarily created classes"
 
 	^'Dummy-Tests-Class'
 ]
 
-{ #category : #coverage }
+{ #category : 'coverage' }
 ClassTest >> classToBeTested [
 
 	^ Class
 ]
 
-{ #category : #setup }
+{ #category : 'setup' }
 ClassTest >> deleteClass [
 	| cl |
 	cl := testEnvironment at: className ifAbsent: [ ^ self ].
@@ -35,26 +37,26 @@ ClassTest >> deleteClass [
 	cl removeFromSystemUnlogged
 ]
 
-{ #category : #'referencing methods' }
+{ #category : 'referencing methods' }
 ClassTest >> referencingMethod1 [
 
 	^ ExampleForTest1
 ]
 
-{ #category : #'referencing methods' }
+{ #category : 'referencing methods' }
 ClassTest >> referencingMethod2 [
 
 	^ {ExampleForTest12. ExampleForTest1}
 ]
 
-{ #category : #'referencing methods' }
+{ #category : 'referencing methods' }
 ClassTest >> referencingMethod3 [
 	"no reference"
 
 	^ self
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ClassTest >> setUp [
 	super setUp.
 	className := #TUTU.
@@ -67,7 +69,7 @@ ClassTest >> setUp [
 			package: self categoryNameForTemporaryClasses]
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ClassTest >> tearDown [
 
 	self deleteClass.
@@ -77,7 +79,7 @@ ClassTest >> tearDown [
 	super tearDown
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ClassTest >> testAddClassSlot [
 	| tutu slot1 slot2 |
 	tutu := testEnvironment at: #TUTU.
@@ -89,7 +91,7 @@ ClassTest >> testAddClassSlot [
 	self assert: tutu class instVarNames equals: #(#X #Y)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ClassTest >> testAddInstVarName [
 
 	| tutu |
@@ -100,7 +102,7 @@ ClassTest >> testAddInstVarName [
 	self assert: tutu instVarNames equals: #('x' 'y')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ClassTest >> testAddSlot [
 
 	| tutu |
@@ -112,7 +114,7 @@ ClassTest >> testAddSlot [
 	self assert: tutu instVarNames equals: #('x' 'y')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ClassTest >> testAddSlotAnonymous [
 
 	| tutu |
@@ -126,7 +128,7 @@ ClassTest >> testAddSlotAnonymous [
 	self assert: tutu instVarNames equals: #('x' 'y')
 ]
 
-{ #category : #'tests - access' }
+{ #category : 'tests - access' }
 ClassTest >> testAllSharedPools [
 	self assert: Point allSharedPools equals: OrderedCollection new.
 	self assert: Date sharedPools first equals: ChronologyConstants.
@@ -137,7 +139,12 @@ ClassTest >> testAllSharedPools [
 	self assertEmpty: SubclassPoolUser sharedPools
 ]
 
-{ #category : #tests }
+{ #category : 'tests - class variables' }
+ClassTest >> testAnyUserOfClassVarNamed [
+	self assert: ((Object anyUserOfClassVarNamed: #DependentsFields) isKindOf: Object)
+]
+
+{ #category : 'tests' }
 ClassTest >> testChangingShapeDoesNotPutNilInMethodsLastLiteralKey [
 	"Test that when the shape of a class changes, the key of the last literal of the methods is not nil"
 	| tutu |
@@ -148,14 +155,14 @@ ClassTest >> testChangingShapeDoesNotPutNilInMethodsLastLiteralKey [
 	self deny: (tutu >> #foo) allLiterals last key isNil
 ]
 
-{ #category : #'test - accessing parallel hierarchy' }
+{ #category : 'test - accessing parallel hierarchy' }
 ClassTest >> testClassSide [
 
 	self assert: Point classSide equals: Point class.
 	self assert: Point class classSide equals: Point class
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ClassTest >> testClassVariableEntanglement [
 	| firstClassName firstClass secondClassName secondClass thirdClassName thirdClass |
 	<ignoreNotImplementedSelectors: #(myVar myVar:)>
@@ -226,13 +233,13 @@ ClassTest >> testClassVariableEntanglement [
 			removeFromSystemUnlogged ]
 ]
 
-{ #category : #'tests - accessing - comments' }
+{ #category : 'tests - accessing - comments' }
 ClassTest >> testComment [
 	self assert: Object comment isNotNil.
 	self assert: Object class comment equals: Object comment
 ]
 
-{ #category : #'tests - accessing - comments' }
+{ #category : 'tests - accessing - comments' }
 ClassTest >> testCommentSourcePointer [
 
 	self
@@ -240,13 +247,13 @@ ClassTest >> testCommentSourcePointer [
 		identicalTo: Object commentSourcePointer
 ]
 
-{ #category : #'tests - accessing - comments' }
+{ #category : 'tests - accessing - comments' }
 ClassTest >> testCommentStamp [
 	self assert: Object commentStamp equals: ''.
 	self assert: Object class commentStamp equals: ''.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ClassTest >> testCommonSuperclassWith [
 	self assert: (OrderedCollection commonSuperclassWith: Array) equals: SequenceableCollection.
 	self assert: (OrderedCollection commonSuperclassWith: OrderedCollection) equals: SequenceableCollection.
@@ -258,28 +265,28 @@ ClassTest >> testCommonSuperclassWith [
 	self assert: (nil commonSuperclassWith: ProtoObject) equals: nil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ClassTest >> testCompileAll [
 	ClassTest compileAll
 ]
 
-{ #category : #'tests - dependencies' }
+{ #category : 'tests - dependencies' }
 ClassTest >> testDependencies [
 	self assert: (self class dependentClasses includes: self class superclass).
 	self assert: (self class dependentClasses includes: Date)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClassTest >> testEnvironment [
 	^ testEnvironment
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClassTest >> testEnvironment: anObject [
 	testEnvironment := anObject
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ClassTest >> testHasBindingThatBeginsWith [
 	self assert: (SmalltalkImage hasBindingThatBeginsWith: 'Compiler').
 	self assert: (SmalltalkImage hasBindingThatBeginsWith: 'Object').
@@ -291,20 +298,20 @@ ClassTest >> testHasBindingThatBeginsWith [
 	self deny: (CompiledMethod hasBindingThatBeginsWith: 'Compiler')
 ]
 
-{ #category : #'tests - class variables' }
+{ #category : 'tests - class variables' }
 ClassTest >> testHasClassVarNamed [
 
 	self assert: (Object hasClassVarNamed: #DependentsFields).
 	self deny: (Object hasClassVarNamed: #CompilerClass)
 ]
 
-{ #category : #'tests - accessing - comments' }
+{ #category : 'tests - accessing - comments' }
 ClassTest >> testHasComments [
 	self assert: Object hasComment.
 	self assert: Object class hasComment
 ]
 
-{ #category : #'tests - access' }
+{ #category : 'tests - access' }
 ClassTest >> testHasPoolVarNamed [
 
 	self assert: (Date usesLocalPoolVarNamed: 'DayNames').
@@ -316,7 +323,7 @@ ClassTest >> testHasPoolVarNamed [
 	self deny: (SubclassPoolUser usesLocalPoolVarNamed: 'AnAuthor')
 ]
 
-{ #category : #'tests - access' }
+{ #category : 'tests - access' }
 ClassTest >> testHasSharedPools [
 
 	self deny: Point hasSharedPools.
@@ -331,28 +338,28 @@ ClassTest >> testHasSharedPools [
 	self deny: SubclassPoolUser hasSharedPools
 ]
 
-{ #category : #'test - accessing parallel hierarchy' }
+{ #category : 'test - accessing parallel hierarchy' }
 ClassTest >> testInstanceSide [
 
 	self assert: Point instanceSide equals: Point.
 	self assert: Point class instanceSide equals: Point
 ]
 
-{ #category : #'test - accessing parallel hierarchy' }
+{ #category : 'test - accessing parallel hierarchy' }
 ClassTest >> testIsClassSide [
 
 	self deny: Point isClassSide.
 	self assert: Point class isClassSide
 ]
 
-{ #category : #'test - accessing parallel hierarchy' }
+{ #category : 'test - accessing parallel hierarchy' }
 ClassTest >> testIsInstanceSide [
 
 	self assert: Point isInstanceSide.
 	self deny: Point class isInstanceSide
 ]
 
-{ #category : #'tests - navigation' }
+{ #category : 'tests - navigation' }
 ClassTest >> testMethodsReferencingClass [
 	self assert: (ClassTest methodsReferencingClass: (Smalltalk classNamed: #ExampleForTest111)) equals: {(ClassTest >> #testOrdersACollectionOfClassesBySuperclass)}.
 	self
@@ -361,7 +368,7 @@ ClassTest >> testMethodsReferencingClass [
 	self assertEmpty: (ClassTest methodsReferencingClass: (Smalltalk classNamed: #BehaviorTest))
 ]
 
-{ #category : #'tests - navigation' }
+{ #category : 'tests - navigation' }
 ClassTest >> testMethodsReferencingClasses [
 
 	| collectionOfMethods collectionOfMethodsShouldBe |
@@ -376,7 +383,7 @@ ClassTest >> testMethodsReferencingClasses [
 	self assert: collectionOfMethods asSet equals: collectionOfMethodsShouldBe asSet
 ]
 
-{ #category : #'tests - class creation' }
+{ #category : 'tests - class creation' }
 ClassTest >> testNewSubclass [
 	| cls |
 	cls := Point newSubclass.
@@ -390,7 +397,7 @@ ClassTest >> testNewSubclass [
 	cls removeFromSystem
 ]
 
-{ #category : #'tests - file in/out' }
+{ #category : 'tests - file in/out' }
 ClassTest >> testOrdersACollectionOfClassesBySuperclass [
 	| ordered |
 	ordered := (Class superclassOrder:
@@ -408,7 +415,7 @@ ClassTest >> testOrdersACollectionOfClassesBySuperclass [
 	self assert: (ordered indexOf: ExampleForTest1 class) < (ordered indexOf: ExampleForTest12 class)
 ]
 
-{ #category : #'tests - file in/out' }
+{ #category : 'tests - file in/out' }
 ClassTest >> testOrdersMetaClassAfterItsClassInstance [
 	| ordered |
 	ordered := (Class superclassOrder:
@@ -424,7 +431,7 @@ ClassTest >> testOrdersMetaClassAfterItsClassInstance [
 	self assert: (ordered indexOf: Boolean) < (ordered indexOf: True)
 ]
 
-{ #category : #'tests - pools' }
+{ #category : 'tests - pools' }
 ClassTest >> testPoolVariableAccessibleInClassUser [
 	"This test shows that a Pool Variable is accessible from the class that declare the Pool usage: here the superclass"
 
@@ -435,7 +442,7 @@ ClassTest >> testPoolVariableAccessibleInClassUser [
 	self assert: RootClassPoolUser author equals: 'Ducasse'
 ]
 
-{ #category : #'tests - pools' }
+{ #category : 'tests - pools' }
 ClassTest >> testPoolVariableAccessibleInSubclassOfClassUser [
 	"This test shows that a Pool Variable is not accessible from a subclass that declare the Pool usage: here SubFlop subclass of Flop and this is a bug. "
 
@@ -446,7 +453,7 @@ ClassTest >> testPoolVariableAccessibleInSubclassOfClassUser [
 	self assert: SubclassPoolUser author equals: 'Ducasse'
 ]
 
-{ #category : #'tests - navigation' }
+{ #category : 'tests - navigation' }
 ClassTest >> testReferencedClasses [
 	{(ExceptionTester -> { MyTestNotification. Warning. String. MyResumableTestError. OrderedCollection. MyTestError}).
 	 (CollectionCombinator -> {Array}).
@@ -461,7 +468,7 @@ ClassTest >> testReferencedClasses [
 	self assert: (SmalltalkImage class>>#compilerClass ) referencedClasses isEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ClassTest >> testRemoveClassSlot [
 	| tutu slot1 slot2 |
 	tutu := testEnvironment at: #TUTU.
@@ -477,7 +484,7 @@ ClassTest >> testRemoveClassSlot [
 	self assert: tutu class instVarNames equals: #()
 ]
 
-{ #category : #'tests - access' }
+{ #category : 'tests - access' }
 ClassTest >> testSharedPoolOfVarNamed [
 
 	self assert: (Date sharedPoolOfVarNamed: 'DayNames') equals: ChronologyConstants.
@@ -493,7 +500,7 @@ ClassTest >> testSharedPoolOfVarNamed [
 	self assert: (ClassMultiplePoolUser sharedPoolOfVarNamed: 'Gloups') equals: PoolDefiner
 ]
 
-{ #category : #'tests - access' }
+{ #category : 'tests - access' }
 ClassTest >> testSharedPools [
 	self assert: Point sharedPools equals: OrderedCollection new.
 	self assert: Date sharedPools first equals: ChronologyConstants.
@@ -504,7 +511,7 @@ ClassTest >> testSharedPools [
 	self assertEmpty: SubclassPoolUser sharedPools
 ]
 
-{ #category : #'tests - class creation' }
+{ #category : 'tests - class creation' }
 ClassTest >> testSubclass [
 	| cls |
 	(testEnvironment includesKey: #SubclassExample) ifTrue: [ (testEnvironment at: #SubclassExample) removeFromSystem ].
@@ -521,7 +528,7 @@ ClassTest >> testSubclass [
 	cls removeFromSystem
 ]
 
-{ #category : #'tests - class creation' }
+{ #category : 'tests - class creation' }
 ClassTest >> testSubclassInstanceVariableNames [
 	| cls |
 	(testEnvironment includesKey: #SubclassExample) ifTrue: [ (testEnvironment at: #SubclassExample) removeFromSystem ].
@@ -542,7 +549,7 @@ ClassTest >> testSubclassInstanceVariableNames [
 	cls removeFromSystem
 ]
 
-{ #category : #'tests - file in/out' }
+{ #category : 'tests - file in/out' }
 ClassTest >> testSuperclassOrder [
 	|  ordered orderedSuperclasses shuffledSuperclasses |
 	orderedSuperclasses := {ProtoObject. Object. Collection. SequenceableCollection}.
@@ -556,7 +563,7 @@ ClassTest >> testSuperclassOrder [
 	self assert: ordered equals: orderedSuperclasses asOrderedCollection
 ]
 
-{ #category : #'tests - file in/out' }
+{ #category : 'tests - file in/out' }
 ClassTest >> testSuperclassOrderPreservingOrder [
 	| noHierarchicalRelationship ordered |
 	"a shuffled collection of direct subclasses of Collection"
@@ -568,7 +575,7 @@ ClassTest >> testSuperclassOrderPreservingOrder [
 	self assert: ordered equals: noHierarchicalRelationship asOrderedCollection
 ]
 
-{ #category : #'tests - access' }
+{ #category : 'tests - access' }
 ClassTest >> testUsesPoolVarNamed [
 
 	self assert: (Date usesPoolVarNamed: 'DayNames').
@@ -580,13 +587,13 @@ ClassTest >> testUsesPoolVarNamed [
 	self assert: (SubclassPoolUser usesPoolVarNamed: 'AnAuthor')
 ]
 
-{ #category : #'tests - class variables' }
+{ #category : 'tests - class variables' }
 ClassTest >> testallClassVariables [
 
 	self assert: SmalltalkImage allClassVariables last name equals: #DependentsFields
 ]
 
-{ #category : #'tests - class variables' }
+{ #category : 'tests - class variables' }
 ClassTest >> testclassVarNames [
 
 	self assert: (Object classVarNames includes: #DependentsFields).
@@ -595,7 +602,7 @@ ClassTest >> testclassVarNames [
 	self assert: Object classVarNames equals: Object class classVarNames
 ]
 
-{ #category : #'tests - class variables' }
+{ #category : 'tests - class variables' }
 ClassTest >> testclassVariables [
 
 	self assert: Object classVariables first name equals: #DependentsFields.
@@ -604,7 +611,7 @@ ClassTest >> testclassVariables [
 	self assert: Object classVariables equals: Object class classVariables
 ]
 
-{ #category : #'tests - class creation' }
+{ #category : 'tests - class creation' }
 ClassTest >> unclassifiedCategory [
 
 	^ Class unclassifiedCategory

--- a/src/Kernel-Tests-Extended/ClassUsedInInstructionStreamTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassUsedInInstructionStreamTest.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #ClassUsedInInstructionStreamTest,
-	#superclass : #SuperClassUsedInInstructionStreamTest,
+	#name : 'ClassUsedInInstructionStreamTest',
+	#superclass : 'SuperClassUsedInInstructionStreamTest',
 	#instVars : [
 		'expectedValue',
 		'aProcess'
 	],
-	#category : #'Kernel-Tests-Extended-Methods'
+	#category : 'Kernel-Tests-Extended-Methods',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Methods'
 }
 
-{ #category : #examples }
+{ #category : 'examples' }
 ClassUsedInInstructionStreamTest >> aMethodSuspendedBeforeTheTerminateOfAnotherProcess [
 
 	Processor activeProcess suspend.
@@ -18,7 +20,7 @@ ClassUsedInInstructionStreamTest >> aMethodSuspendedBeforeTheTerminateOfAnotherP
 	expectedValue := 42
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 ClassUsedInInstructionStreamTest >> aMethodWithHalt [
 
 	<haltOrBreakpointForTesting>
@@ -27,14 +29,14 @@ ClassUsedInInstructionStreamTest >> aMethodWithHalt [
 	self halt
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 ClassUsedInInstructionStreamTest >> aMethodWithMNU [
 	<ignoreNotImplementedSelectors: #(iAmAnMNUMessage)>
 	thisProcess suspend.
 	self iAmAnMNUMessage
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 ClassUsedInInstructionStreamTest >> aMethodWithMustBeBooleanMNU [
 
 	Processor activeProcess suspend.
@@ -42,68 +44,68 @@ ClassUsedInInstructionStreamTest >> aMethodWithMustBeBooleanMNU [
 	^ 2 ifTrue: [ 5 ] ifFalse: [ 7 ]
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 ClassUsedInInstructionStreamTest >> aMethodWithSuspendAndReturnANumber [
 
 	Processor activeProcess suspend.
 	^ 42
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 ClassUsedInInstructionStreamTest >> aSuperMethod: anInteger with: anotherInteger [
 
 	^ self error
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 ClassUsedInInstructionStreamTest >> callingAMethodSuspendedBeforeTheTerminateOfAnotherProcess [
 
 	self aMethodSuspendedBeforeTheTerminateOfAnotherProcess
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 ClassUsedInInstructionStreamTest >> callingAMethodWithHalt [
 
 	self aMethodWithHalt
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 ClassUsedInInstructionStreamTest >> callingAMethodWithMNU [
 
 	self aMethodWithMNU
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 ClassUsedInInstructionStreamTest >> callingAMethodWithMustBeBooleanMNU [
 
 	self aMethodWithMustBeBooleanMNU
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 ClassUsedInInstructionStreamTest >> callingAMethodWithSuspendAndReturnANumber [
 
 	^ self aMethodWithSuspendAndReturnANumber
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 ClassUsedInInstructionStreamTest >> expectedValue [
 
 	^ expectedValue
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 ClassUsedInInstructionStreamTest >> methodWithASuperBlock [
 
 	^ [ super aSuperMethod: 1 with: 2 ]
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 ClassUsedInInstructionStreamTest >> methodWithASuperBlockWithoutArguments [
 
 	^ [ super yourself ]
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ClassUsedInInstructionStreamTest >> newMethodWithALotOfLiteralsToTestExtensions [
 
 	| anArray |
@@ -127,13 +129,13 @@ ClassUsedInInstructionStreamTest >> newMethodWithALotOfLiteralsToTestExtensions 
 		with: ' literals'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClassUsedInInstructionStreamTest >> process: aValue [
 
 	aProcess := aValue
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 ClassUsedInInstructionStreamTest >> valueOfBlockWithSupersend [
 
 	expectedValue := self methodWithASuperBlock value

--- a/src/Kernel-Tests-Extended/CodeSimulationTest.class.st
+++ b/src/Kernel-Tests-Extended/CodeSimulationTest.class.st
@@ -2,44 +2,46 @@
 SUnit tests for code simulation
 "
 Class {
-	#name : #CodeSimulationTest,
-	#superclass : #TestCase,
-	#category : #'Kernel-Tests-Extended-Methods'
+	#name : 'CodeSimulationTest',
+	#superclass : 'TestCase',
+	#category : 'Kernel-Tests-Extended-Methods',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Methods'
 }
 
-{ #category : #private }
+{ #category : 'private' }
 CodeSimulationTest >> indexedBasicAt: index [
 	<primitive: 60 error: code >
 	^ code
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CodeSimulationTest >> methodWithError [
 	self error: 'my error'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CodeSimulationTest >> methodWithTranscript [
 	self trace: 'something'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CodeSimulationTest >> runSimulated: aBlock [
 	thisContext runSimulated: aBlock contextAtEachStep: [ :current |  ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CodeSimulationTest >> testDNU [
 	<ignoreNotImplementedSelectors: #(absentMethod)>
 	self should: [ self runSimulated: [ self absentMethod ] ] raise: MessageNotUnderstood
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CodeSimulationTest >> testError [
 	self should: [ self runSimulated: [self methodWithError] ] raise: Error
 ]
 
-{ #category : #'tests - primitives' }
+{ #category : 'tests - primitives' }
 CodeSimulationTest >> testErrorCodeNotFound [
 	| ctx result resultSimu |
 	self skip.
@@ -67,7 +69,7 @@ CodeSimulationTest >> testErrorCodeNotFound [
 	self assert: result equals: resultSimu second
 ]
 
-{ #category : #'tests - primitives' }
+{ #category : 'tests - primitives' }
 CodeSimulationTest >> testErrorCodeNotFoundIndexed [
 	| ctx result resultSimu |
 	Smalltalk vm isRunningCog ifFalse: [ ^ self ].
@@ -94,7 +96,7 @@ CodeSimulationTest >> testErrorCodeNotFoundIndexed [
 	self assert: result equals: resultSimu second
 ]
 
-{ #category : #'tests - primitives' }
+{ #category : 'tests - primitives' }
 CodeSimulationTest >> testErrorToken [
 	| token1 token2 |
 	token1 := Context primitiveFailToken.
@@ -105,7 +107,7 @@ CodeSimulationTest >> testErrorToken [
 	self assert: token2 second equals: 100
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CodeSimulationTest >> testErrorWithErrorHandler [
 	self
 		runSimulated: [ [ self methodWithError ]
@@ -113,22 +115,22 @@ CodeSimulationTest >> testErrorWithErrorHandler [
 				do: [ :err |  ] ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CodeSimulationTest >> testGoodSimulation [
 	self runSimulated: [ 1 + 2 ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CodeSimulationTest >> testTranscriptPrinting [
 	self runSimulated: [ self methodWithTranscript ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CodeSimulationTest >> testTranscriptPrintingWithOpenedTranscriptExists [
 	self runSimulated: [ self methodWithTranscript ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 CodeSimulationTest >> veryBasicAt: index [
 	<primitive: 'dooo' module: 'bar' error: code>
 	^ code

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -5,44 +5,46 @@ This is the unit test for the class CompiledMethod. Unit tests are a good way to
 	- the sunit class category
 "
 Class {
-	#name : #CompiledMethodTest,
-	#superclass : #ClassTestCase,
+	#name : 'CompiledMethodTest',
+	#superclass : 'ClassTestCase',
 	#instVars : [
 		'x',
 		'y',
 		'class'
 	],
-	#category : #'Kernel-Tests-Extended-Methods'
+	#category : 'Kernel-Tests-Extended-Methods',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Methods'
 }
 
-{ #category : #'tests - performing' }
+{ #category : 'tests - performing' }
 CompiledMethodTest >> a1: a1 a2: a2 a3: a3 a4: a4 a5: a5 a6: a6 a7: a7 a8: a8 a9: a9 a10: a10 a11: a11 a12: a12 a13: a13 a14: a14 a15: a15 [
 	"I'm a method with the maximum size of arguments that can be executed via normal send but crash on perform :)"
 
 	^ a1 + a2 - a2
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 CompiledMethodTest >> abstractMethod [
 	"I am an abstract method"
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #'private - accessing' }
+{ #category : 'private - accessing' }
 CompiledMethodTest >> categoryNameForTemporaryClasses [
 	"Answer the category where to classify temporarily created classes"
 
 	^'Dummy-Tests-Class'
 ]
 
-{ #category : #coverage }
+{ #category : 'coverage' }
 CompiledMethodTest >> classToBeTested [
 
 	^ CompiledMethod
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 CompiledMethodTest >> deprecatedMethod [
 	"Used to test sends of deprecation messages;
 	do not recategorize in one of the 'deprecated' categories."
@@ -50,7 +52,7 @@ CompiledMethodTest >> deprecatedMethod [
 	self deprecated: 'example of a deprecated method'
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 CompiledMethodTest >> deprecatedMethod2 [
 	"Used to test sends of deprecation messages;
 	do not recategorize in one of the 'deprecated' categories."
@@ -58,7 +60,7 @@ CompiledMethodTest >> deprecatedMethod2 [
 	self deprecated: 'example of a deprecated method' on: 'date' in: 'someversion'
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 CompiledMethodTest >> deprecatedMethod3 [
 	"Used to test sends of deprecation messages;
 	do not recategorize in one of the 'deprecated' categories."
@@ -69,7 +71,7 @@ CompiledMethodTest >> deprecatedMethod3 [
 						-> '`@receiver deprecatedMethod3'
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 CompiledMethodTest >> deprecatedMethod4 [
 	"Used to test sends of deprecation messages;
 	do not recategorize in one of the 'deprecated' categories."
@@ -83,7 +85,7 @@ CompiledMethodTest >> deprecatedMethod4 [
 						-> '`@receiver deprecatedMethod4'
 ]
 
-{ #category : #'examples - linesofcode' }
+{ #category : 'examples - linesofcode' }
 CompiledMethodTest >> locComplex [
 
 	"A multiline
@@ -104,14 +106,14 @@ CompiledMethodTest >> locComplex [
 			c "Comment at the end of a line" ] ]
 ]
 
-{ #category : #'examples - linesofcode' }
+{ #category : 'examples - linesofcode' }
 CompiledMethodTest >> locEmptyLineInTheEnd [
 	| a |
 	a := 1.
 	^ a
 ]
 
-{ #category : #'examples - linesofcode' }
+{ #category : 'examples - linesofcode' }
 CompiledMethodTest >> locEmptyLineInTheMiddle [
 	| a |
 	a := 1.
@@ -119,14 +121,14 @@ CompiledMethodTest >> locEmptyLineInTheMiddle [
 	^ a
 ]
 
-{ #category : #'examples - linesofcode' }
+{ #category : 'examples - linesofcode' }
 CompiledMethodTest >> locEmptyLineWithTabInTheEnd [
 	| a |
 	a := 1.
 	^ a
 ]
 
-{ #category : #'examples - linesofcode' }
+{ #category : 'examples - linesofcode' }
 CompiledMethodTest >> locEmptyLineWithTabInTheMiddle [
 	| a |
 	a := 1.
@@ -134,26 +136,26 @@ CompiledMethodTest >> locEmptyLineWithTabInTheMiddle [
 	^ a
 ]
 
-{ #category : #'examples - linesofcode' }
+{ #category : 'examples - linesofcode' }
 CompiledMethodTest >> locEmptyMethod [
 ]
 
-{ #category : #'examples - linesofcode' }
+{ #category : 'examples - linesofcode' }
 CompiledMethodTest >> locEmptyMethodWithNewline [
 ]
 
-{ #category : #'examples - linesofcode' }
+{ #category : 'examples - linesofcode' }
 CompiledMethodTest >> locEmptyMethodWithNewlineAndTab [
 ]
 
-{ #category : #'examples - linesofcode' }
+{ #category : 'examples - linesofcode' }
 CompiledMethodTest >> locMultilineComment [
 	^ 1
 	"Multiline
 	comment"
 ]
 
-{ #category : #'examples - linesofcode' }
+{ #category : 'examples - linesofcode' }
 CompiledMethodTest >> locMultilineCommentWithoutWhitespace [
 	^ 1
 "Multiline
@@ -162,20 +164,20 @@ without
 whitespaces"
 ]
 
-{ #category : #'examples - linesofcode' }
+{ #category : 'examples - linesofcode' }
 CompiledMethodTest >> locMultilineMethodComment [
 	"Multiline
 	comments"
 	^ 1
 ]
 
-{ #category : #'examples - linesofcode' }
+{ #category : 'examples - linesofcode' }
 CompiledMethodTest >> locMultilineMethodCommentWithoutWhitespace [
 "Comment"
 	^ 1
 ]
 
-{ #category : #'examples - linesofcode' }
+{ #category : 'examples - linesofcode' }
 CompiledMethodTest >> locSimple [
 	| a b c |
 	a := 1.
@@ -184,68 +186,68 @@ CompiledMethodTest >> locSimple [
 	^ 1 / c
 ]
 
-{ #category : #'examples - linesofcode' }
+{ #category : 'examples - linesofcode' }
 CompiledMethodTest >> locSingleLineComment [
 	^ 1
 	"Comment"
 ]
 
-{ #category : #'examples - linesofcode' }
+{ #category : 'examples - linesofcode' }
 CompiledMethodTest >> locSingleLineCommentWithoutWhitespace [
 	^ 1
 "Comment"
 ]
 
-{ #category : #'examples - linesofcode' }
+{ #category : 'examples - linesofcode' }
 CompiledMethodTest >> locSingleLineMethodComment [
 	"Comment"
 	^ 1
 ]
 
-{ #category : #'examples - linesofcode' }
+{ #category : 'examples - linesofcode' }
 CompiledMethodTest >> locSingleLineMethodCommentWithoutWhitespace [
 "Comment"
 	^ 1
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 CompiledMethodTest >> nonAbstractMethod [
 	"I am not an abstract method"
 
 	^ 4 + 5
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 CompiledMethodTest >> readX [
 	| tmp |
 	tmp := x.
 	^ tmp
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 CompiledMethodTest >> readXandY [
 
 	^ x + y
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 CompiledMethodTest >> returnPlusOne: anInteger [
 	^anInteger + 1
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 CompiledMethodTest >> returnTrue [
 	^true
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 CompiledMethodTest >> shouldNotImplementMethod [
 	"I am not an abstract method"
 
 	^ self shouldNotImplement
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 CompiledMethodTest >> tearDown [
 
 	self packageOrganizer removePackage: self categoryNameForTemporaryClasses.
@@ -253,7 +255,7 @@ CompiledMethodTest >> tearDown [
 	super tearDown
 ]
 
-{ #category : #'tests - instance variable' }
+{ #category : 'tests - instance variable' }
 CompiledMethodTest >> testAccessesField [
 	| method |
 	method := self class compiledMethodAt: #readX.
@@ -274,7 +276,7 @@ CompiledMethodTest >> testAccessesField [
 	self assert: (method accessesField: 5)
 ]
 
-{ #category : #'tests - slots' }
+{ #category : 'tests - slots' }
 CompiledMethodTest >> testAccessesSlot [
 
 	"Check the source code availability to do not fail on images without sources"
@@ -286,13 +288,13 @@ CompiledMethodTest >> testAccessesSlot [
 	self assert: ((Point>>#setX:setY:) accessesSlot: (Point slotNamed: #y))
 ]
 
-{ #category : #'tests - converting' }
+{ #category : 'tests - converting' }
 CompiledMethodTest >> testAsString [
 
 	self assert: thisContext method asString isString
 ]
 
-{ #category : #'tests - accessing' }
+{ #category : 'tests - accessing' }
 CompiledMethodTest >> testBytecode [
 	"The result of this test depends on the used bytecode set.
 
@@ -305,7 +307,7 @@ CompiledMethodTest >> testBytecode [
 	self assertCollection: (Object>>#halt) bytecodes equals: expectedResult
 ]
 
-{ #category : #'tests - accessing' }
+{ #category : 'tests - accessing' }
 CompiledMethodTest >> testComments [
 	"I am the first comment to be found in this test"
 	self
@@ -319,7 +321,7 @@ CompiledMethodTest >> testComments [
 	self assert: (CompiledMethod >> #compiledMethod) comments isEmpty
 ]
 
-{ #category : #'tests - accessing' }
+{ #category : 'tests - accessing' }
 CompiledMethodTest >> testComparison [
 	| method1 method2 |
 	method1 := Float class >> #nan.
@@ -338,7 +340,7 @@ CompiledMethodTest >> testComparison [
 			self deny: each equals: method2 ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CompiledMethodTest >> testCopy [
 	<pragma: #pragma>
 	| method copy |
@@ -355,7 +357,7 @@ CompiledMethodTest >> testCopy [
 	copy pragmas do: [ :p | self assert: p method identicalTo: copy ]
 ]
 
-{ #category : #'tests - comparing' }
+{ #category : 'tests - comparing' }
 CompiledMethodTest >> testEqualityClassSideMethod [
    	| method1 method2 |
 
@@ -368,7 +370,7 @@ CompiledMethodTest >> testEqualityClassSideMethod [
  	self assert: method1 equals: method2
 ]
 
-{ #category : #'tests - comparing' }
+{ #category : 'tests - comparing' }
 CompiledMethodTest >> testEqualityInstanceSideMethod [
 	| method1 method2 |
 	method1 := TestCase compiler compile: 'aMethod'.
@@ -378,12 +380,12 @@ CompiledMethodTest >> testEqualityInstanceSideMethod [
 	self assert: method1 equals: method2
 ]
 
-{ #category : #'tests - testing' }
+{ #category : 'tests - testing' }
 CompiledMethodTest >> testHasComment [
 	self assert: (CompiledMethod>>#hasComment) hasComment
 ]
 
-{ #category : #'tests - instance variable' }
+{ #category : 'tests - instance variable' }
 CompiledMethodTest >> testHasInstVarRef [
 
 	| method  |
@@ -400,7 +402,7 @@ CompiledMethodTest >> testHasInstVarRef [
 	self assert: (method hasInstVarRef)
 ]
 
-{ #category : #'tests - literals' }
+{ #category : 'tests - literals' }
 CompiledMethodTest >> testHasLiteralSuchThat [
 	"#literals should not expose implementation hack that the last two literals are
 	used for name of method and class"
@@ -409,7 +411,7 @@ CompiledMethodTest >> testHasLiteralSuchThat [
 	self assert: (Object >> #halt hasLiteralSuchThat: [ :lit | lit == #now ])
 ]
 
-{ #category : #'tests - testing' }
+{ #category : 'tests - testing' }
 CompiledMethodTest >> testHasNonLocalReturn [
 	| method |
 	method := self class compiler compile: 'm ^1'.
@@ -422,7 +424,7 @@ CompiledMethodTest >> testHasNonLocalReturn [
 	self assert: [method hasNonLocalReturn ]
 ]
 
-{ #category : #'tests - testing' }
+{ #category : 'tests - testing' }
 CompiledMethodTest >> testHasPragma [
 
 	| methodWithPragma methodWithOutPragma |
@@ -433,7 +435,7 @@ CompiledMethodTest >> testHasPragma [
 	self deny: methodWithOutPragma hasPragma
 ]
 
-{ #category : #'tests - abstract' }
+{ #category : 'tests - abstract' }
 CompiledMethodTest >> testIsAbstract [
 
 	self assert: (self class >> #abstractMethod) isAbstract.
@@ -441,13 +443,13 @@ CompiledMethodTest >> testIsAbstract [
 	self deny: (self class >> #shouldNotImplementMethod) isAbstract
 ]
 
-{ #category : #'tests - testing' }
+{ #category : 'tests - testing' }
 CompiledMethodTest >> testIsClassSide [
 	self deny: (Object>>#yourself) isClassSide.
 	self assert: (Object class>>#initialize) isClassSide
 ]
 
-{ #category : #'tests - testing' }
+{ #category : 'tests - testing' }
 CompiledMethodTest >> testIsDeprecated [
 	| deprecatedSelectors |
 	deprecatedSelectors := #(deprecatedMethod deprecatedMethod2 deprecatedMethod3 deprecatedMethod4).
@@ -457,7 +459,7 @@ CompiledMethodTest >> testIsDeprecated [
 			ifFalse: [ self deny: (self class >> each) isDeprecated ] ]
 ]
 
-{ #category : #'tests - abstract' }
+{ #category : 'tests - abstract' }
 CompiledMethodTest >> testIsExtension [
 
 	[
@@ -475,7 +477,7 @@ CompiledMethodTest >> testIsExtension [
 		self class compiledMethodAt: #isExtensionTestMethod ifPresent: [ :method | method removeFromSystem ] ]
 ]
 
-{ #category : #'tests - testing' }
+{ #category : 'tests - testing' }
 CompiledMethodTest >> testIsFaulty [
 	|  cm |
 	cm := OpalCompiler new
@@ -486,7 +488,7 @@ CompiledMethodTest >> testIsFaulty [
 	self deny: (OCASTTranslator>>#visitParseErrorNode:) isFaulty
 ]
 
-{ #category : #'tests - testing' }
+{ #category : 'tests - testing' }
 CompiledMethodTest >> testIsInstalled [
 |  method cls |
 
@@ -512,7 +514,7 @@ CompiledMethodTest >> testIsInstalled [
 	Smalltalk removeClassNamed: #TUTU
 ]
 
-{ #category : #'tests - testing' }
+{ #category : 'tests - testing' }
 CompiledMethodTest >> testIsQuick [
 	| method  |
 
@@ -523,126 +525,126 @@ CompiledMethodTest >> testIsQuick [
 	self deny: (method isQuick)
 ]
 
-{ #category : #'tests - linesofcode' }
+{ #category : 'tests - linesofcode' }
 CompiledMethodTest >> testLinesOfCodeAllInOne [
 	| method |
 	method := self class >> #locComplex.
 	self assert: method linesOfCode equals: 14
 ]
 
-{ #category : #'tests - linesofcode' }
+{ #category : 'tests - linesofcode' }
 CompiledMethodTest >> testLinesOfCodeEmptyLineInTheEnd [
 	| method |
 	method := self class >> #locEmptyLineInTheEnd.
 	self assert: method linesOfCode equals: 4
 ]
 
-{ #category : #'tests - linesofcode' }
+{ #category : 'tests - linesofcode' }
 CompiledMethodTest >> testLinesOfCodeEmptyLineInTheMiddle [
 	| method |
 	method := self class >> #locEmptyLineInTheMiddle.
 	self assert: method linesOfCode equals: 4
 ]
 
-{ #category : #'tests - linesofcode' }
+{ #category : 'tests - linesofcode' }
 CompiledMethodTest >> testLinesOfCodeEmptyLineWithTabInTheEnd [
 	| method |
 	method := self class >> #locEmptyLineWithTabInTheEnd.
 	self assert: method linesOfCode equals: 4
 ]
 
-{ #category : #'tests - linesofcode' }
+{ #category : 'tests - linesofcode' }
 CompiledMethodTest >> testLinesOfCodeEmptyLineWithTabInTheMiddle [
 	| method |
 	method := self class >> #locEmptyLineWithTabInTheMiddle.
 	self assert: method linesOfCode equals: 4
 ]
 
-{ #category : #'tests - linesofcode' }
+{ #category : 'tests - linesofcode' }
 CompiledMethodTest >> testLinesOfCodeEmptyMethod [
 	| method |
 	method := self class >> #locEmptyMethod.
 	self assert: method linesOfCode equals: 1
 ]
 
-{ #category : #'tests - linesofcode' }
+{ #category : 'tests - linesofcode' }
 CompiledMethodTest >> testLinesOfCodeEmptyMethodWithNewline [
 	| method |
 	method := self class >> #locEmptyMethodWithNewline.
 	self assert: method linesOfCode equals: 1
 ]
 
-{ #category : #'tests - linesofcode' }
+{ #category : 'tests - linesofcode' }
 CompiledMethodTest >> testLinesOfCodeEmptyMethodWithNewlineAndTab [
 	| method |
 	method := self class >> #locEmptyMethodWithNewlineAndTab.
 	self assert: method linesOfCode equals: 1
 ]
 
-{ #category : #'tests - linesofcode' }
+{ #category : 'tests - linesofcode' }
 CompiledMethodTest >> testLinesOfCodeMultilineComment [
 	| method |
 	method := self class >> #locMultilineComment.
 	self assert: method linesOfCode equals: 4
 ]
 
-{ #category : #'tests - linesofcode' }
+{ #category : 'tests - linesofcode' }
 CompiledMethodTest >> testLinesOfCodeMultilineCommentWithoutWhitespace [
 	| method |
 	method := self class >> #locMultilineCommentWithoutWhitespace.
 	self assert: method linesOfCode equals: 6
 ]
 
-{ #category : #'tests - linesofcode' }
+{ #category : 'tests - linesofcode' }
 CompiledMethodTest >> testLinesOfCodeMultilineMethodComment [
 	| method |
 	method := self class >> #locMultilineMethodComment.
 	self assert: method linesOfCode equals: 4
 ]
 
-{ #category : #'tests - linesofcode' }
+{ #category : 'tests - linesofcode' }
 CompiledMethodTest >> testLinesOfCodeMultilineMethodCommentWithoutWhitespace [
 	| method |
 	method := self class >> #locMultilineMethodCommentWithoutWhitespace.
 	self assert: method linesOfCode equals: 3
 ]
 
-{ #category : #'tests - linesofcode' }
+{ #category : 'tests - linesofcode' }
 CompiledMethodTest >> testLinesOfCodeSimpleCase [
 	| method |
 	method := self class >> #locSimple.
 	self assert: method linesOfCode equals: 6
 ]
 
-{ #category : #'tests - linesofcode' }
+{ #category : 'tests - linesofcode' }
 CompiledMethodTest >> testLinesOfCodeSingleLineComment [
 	| method |
 	method := self class >> #locSingleLineComment.
 	self assert: method linesOfCode equals: 3
 ]
 
-{ #category : #'tests - linesofcode' }
+{ #category : 'tests - linesofcode' }
 CompiledMethodTest >> testLinesOfCodeSingleLineCommentWithoutWhitespace [
 	| method |
 	method := self class >> #locSingleLineCommentWithoutWhitespace.
 	self assert: method linesOfCode equals: 3
 ]
 
-{ #category : #'tests - linesofcode' }
+{ #category : 'tests - linesofcode' }
 CompiledMethodTest >> testLinesOfCodeSingleLineMethodComment [
 	| method |
 	method := self class >> #locSingleLineMethodComment .
 	self assert: method linesOfCode equals: 3
 ]
 
-{ #category : #'tests - linesofcode' }
+{ #category : 'tests - linesofcode' }
 CompiledMethodTest >> testLinesOfCodeSingleLineMethodCommentWithoutWhitespace [
 	| method |
 	method := self class >> #locSingleLineMethodCommentWithoutWhitespace.
 	self assert: method linesOfCode equals: 3
 ]
 
-{ #category : #'tests - literals' }
+{ #category : 'tests - literals' }
 CompiledMethodTest >> testLiterals [
 	"#literals should not expose implementation hack that the last two literals are
 	used for name of method and class"
@@ -652,7 +654,7 @@ CompiledMethodTest >> testLiterals [
 	self deny: (Object >> #yourself hasLiteral: #yourself)
 ]
 
-{ #category : #'tests - accessing' }
+{ #category : 'tests - accessing' }
 CompiledMethodTest >> testMethodClass [
 	| method cls |
 	method := self class >> #returnTrue.
@@ -673,7 +675,7 @@ CompiledMethodTest >> testMethodClass [
 	self assert: method methodClass equals: cls
 ]
 
-{ #category : #'tests - comparing' }
+{ #category : 'tests - comparing' }
 CompiledMethodTest >> testMethodsThatHaveOnlyDifferentSelectorsShouldBeDifferent [
 	| method1 method2 |
 	method1 := TestCase compiler compile: 'aMethod'.
@@ -683,7 +685,7 @@ CompiledMethodTest >> testMethodsThatHaveOnlyDifferentSelectorsShouldBeDifferent
 	self deny: method1 equals: method2
 ]
 
-{ #category : #'tests - accessing' }
+{ #category : 'tests - accessing' }
 CompiledMethodTest >> testOrigin [
 	| regularMethod methodFromTrait |
 	"Regular method"
@@ -696,7 +698,7 @@ CompiledMethodTest >> testOrigin [
 	self assert: methodFromTrait origin identicalTo: methodFromTrait originMethod methodClass
 ]
 
-{ #category : #'tests - performing' }
+{ #category : 'tests - performing' }
 CompiledMethodTest >> testPerformCanExecutelongMethodWithTemps [
 	"the perform: primitive reuses the context of the method calling it. The primitive adds performed selector arguments to the context variables list. So this means that you can execute some methods but not performed them if the calling methods defined too many temps "
 
@@ -709,7 +711,7 @@ CompiledMethodTest >> testPerformCanExecutelongMethodWithTemps [
 	self assert: (self class>>#a1:a2:a3:a4:a5:a6:a7:a8:a9:a10:a11:a12:a13:a14:a15:) frameSize equals: CompiledMethod fullFrameSize
 ]
 
-{ #category : #'tests - performing' }
+{ #category : 'tests - performing' }
 CompiledMethodTest >> testPerformInSuperclassCanExecutelongMethodWithTemps [
 	"the perform: primitive reuses the context of the method calling it. The primitive adds performed selector arguments to the context variables list. So this means that you can execute some methods but not performed them if the calling methods defined too many temps "
 
@@ -720,7 +722,7 @@ CompiledMethodTest >> testPerformInSuperclassCanExecutelongMethodWithTemps [
 	self assert: (self perform: #a1:a2:a3:a4:a5:a6:a7:a8:a9:a10:a11:a12:a13:a14:a15: withArguments: #(1 2 3 4 5 6 7 8 9 10 11 12 13 14 15) inSuperclass: self class) equals: 1
 ]
 
-{ #category : #'tests - pragmas' }
+{ #category : 'tests - pragmas' }
 CompiledMethodTest >> testPragmaAt [
 
 	| method |
@@ -734,7 +736,7 @@ CompiledMethodTest >> testPragmaAt [
 	self assert: (method pragmaAt: #hello) equals: nil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CompiledMethodTest >> testProperties [
 
 	| method tmp |
@@ -781,7 +783,7 @@ CompiledMethodTest >> testProperties [
 	self deny: method hasProperties
 ]
 
-{ #category : #'tests - instance variable' }
+{ #category : 'tests - instance variable' }
 CompiledMethodTest >> testReadsField [
 	| method |
 	method := self class compiledMethodAt: #readX.
@@ -802,7 +804,7 @@ CompiledMethodTest >> testReadsField [
 	self deny: (method readsField: 5)
 ]
 
-{ #category : #'tests - slots' }
+{ #category : 'tests - slots' }
 CompiledMethodTest >> testReadsSlot [
 
 	"Check the source code availability to do not fail on images without sources"
@@ -814,7 +816,7 @@ CompiledMethodTest >> testReadsSlot [
 	self deny: ((Point>>#setX:setY:) readsSlot: (Point slotNamed: #y))
 ]
 
-{ #category : #'tests - accessing' }
+{ #category : 'tests - accessing' }
 CompiledMethodTest >> testSelector [
 	Author
 		useAuthor: 'TUTU_TEST'
@@ -839,13 +841,13 @@ CompiledMethodTest >> testSelector [
 			self assert: method selector equals: #foo ]
 ]
 
-{ #category : #'tests - testing' }
+{ #category : 'tests - testing' }
 CompiledMethodTest >> testSendsSelector [
 	self assert: ((CompiledCode >> #sendsSelector:) sendsSelector: #includes:).
 	self deny: ((CompiledCode >> #sendsSelector:) sendsSelector: #doBreakfastForMe)
 ]
 
-{ #category : #'tests - literals' }
+{ #category : 'tests - literals' }
 CompiledMethodTest >> testUndeclaredReparationWithClass [
 
 	| method c c2 |
@@ -877,7 +879,7 @@ CompiledMethodTest >> testUndeclaredReparationWithClass [
 	Smalltalk globals removeKey: #TestUndeclaredVariable
 ]
 
-{ #category : #'tests - literals' }
+{ #category : 'tests - literals' }
 CompiledMethodTest >> testUndeclaredReparationWithGlobal [
 
 	| method |
@@ -907,7 +909,7 @@ CompiledMethodTest >> testUndeclaredReparationWithGlobal [
 	Smalltalk globals removeKey: #TestUndeclaredVariable
 ]
 
-{ #category : #'tests - literals' }
+{ #category : 'tests - literals' }
 CompiledMethodTest >> testUndeclaredReparationWithInstanceVariable [
 
 	| method method2 method3 method4 receiver |
@@ -950,7 +952,7 @@ CompiledMethodTest >> testUndeclaredReparationWithInstanceVariable [
 
 ]
 
-{ #category : #'tests - literals' }
+{ #category : 'tests - literals' }
 CompiledMethodTest >> testUndeclaredReparationWithShared [
 
 	| method |
@@ -971,7 +973,7 @@ CompiledMethodTest >> testUndeclaredReparationWithShared [
 	nil executeMethod: method
 ]
 
-{ #category : #'tests - literals' }
+{ #category : 'tests - literals' }
 CompiledMethodTest >> testUndeclaredReparationWithSharedWasCrashingOnOldVM1001 [
 
 	| method |
@@ -992,7 +994,7 @@ CompiledMethodTest >> testUndeclaredReparationWithSharedWasCrashingOnOldVM1001 [
 	nil executeMethod: method
 ]
 
-{ #category : #'tests - testing' }
+{ #category : 'tests - testing' }
 CompiledMethodTest >> testUsesUndeclareds [
 	| method |
 	method := self class compiler compile: 'x ^x'.
@@ -1003,7 +1005,7 @@ CompiledMethodTest >> testUsesUndeclareds [
 	self assert: method usesUndeclareds
 ]
 
-{ #category : #'tests - evaluating' }
+{ #category : 'tests - evaluating' }
 CompiledMethodTest >> testValueWithReceiver [
 
 	| method value |
@@ -1014,7 +1016,7 @@ CompiledMethodTest >> testValueWithReceiver [
 	self assert: value equals: true.
 ]
 
-{ #category : #'tests - evaluating' }
+{ #category : 'tests - evaluating' }
 CompiledMethodTest >> testValueWithReceiverArguments [
 
 	| method value |
@@ -1029,7 +1031,7 @@ CompiledMethodTest >> testValueWithReceiverArguments [
 	self assert: value equals: 2
 ]
 
-{ #category : #'tests - instance variable' }
+{ #category : 'tests - instance variable' }
 CompiledMethodTest >> testWritesField [
 	| method |
 	method := self class compiledMethodAt: #writeX.
@@ -1053,7 +1055,7 @@ CompiledMethodTest >> testWritesField [
 	self deny: (method writesField: 5)
 ]
 
-{ #category : #'tests - slots' }
+{ #category : 'tests - slots' }
 CompiledMethodTest >> testWritesSlot [
 
 	"Check the source code availability to do not fail on images without sources"
@@ -1067,7 +1069,7 @@ CompiledMethodTest >> testWritesSlot [
 	self assert: ((Point>>#setX:setY:) writesSlot: (Point slotNamed: #x))
 ]
 
-{ #category : #'tests - testing' }
+{ #category : 'tests - testing' }
 CompiledMethodTest >> testWritesUndeclared [
 	| method |
 	
@@ -1099,13 +1101,13 @@ CompiledMethodTest >> testWritesUndeclared [
 		equals: 2
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 CompiledMethodTest >> writeX [
 
 	x := 33
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 CompiledMethodTest >> writeXandY [
 
 	x := 33.

--- a/src/Kernel-Tests-Extended/ContextTest.extension.st
+++ b/src/Kernel-Tests-Extended/ContextTest.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #ContextTest }
+Extension { #name : 'ContextTest' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 ContextTest >> testCannotReturn [
 	| context p |
 	p := [context := thisContext] fork.
@@ -13,7 +13,7 @@ ContextTest >> testCannotReturn [
 			self assert: err target equals: context]
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 ContextTest >> testClosureRestart [
 	"Test that various combinations of closures are restarted with the expected values"
 	"no args, no remote temps blocks are not tested, as I don't know how to do that programatically without ending up looping endlessly"
@@ -22,13 +22,13 @@ ContextTest >> testClosureRestart [
 	"self should: [self privRestartBlockArgsNoRemoteTempsTest] notTakeMoreThan: 0.1 second" "FAILING!"
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 ContextTest >> testJump [
 	#(exampleClosure exampleSend exampleStore) do: [ :selector |
 		self verifyJumpWithSelector: selector ]
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 ContextTest >> testReadVariableNamed [
 	|localVar|
 	localVar := 2.
@@ -40,14 +40,14 @@ ContextTest >> testReadVariableNamed [
 	self assert: (thisContext readVariableNamed: #Smalltalk) equals: Smalltalk
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 ContextTest >> testSourceNodeExecuted [
 	| sourceNode |
 	sourceNode := thisContext sender sender sourceNodeExecuted.
 	self assert: sourceNode selector equals: #performTest
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 ContextTest >> testSourceNodeExecutedWhenContextIsJustAtStartpc [
 	| sourceNode context |
 
@@ -56,7 +56,7 @@ ContextTest >> testSourceNodeExecutedWhenContextIsJustAtStartpc [
 	self assert: sourceNode equals: (self class >> testSelector) ast sendNodes first receiver
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 ContextTest >> testWriteVariableNamedValue [
 	|localVar|
 	localVar := 2.

--- a/src/Kernel-Tests-Extended/DateAndTimeDosEpochTest.extension.st
+++ b/src/Kernel-Tests-Extended/DateAndTimeDosEpochTest.extension.st
@@ -1,18 +1,18 @@
-Extension { #name : #DateAndTimeDosEpochTest }
+Extension { #name : 'DateAndTimeDosEpochTest' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 DateAndTimeDosEpochTest >> testAsMonth [
 	self
 		assert: aDateAndTime asMonth
 		equals: (Month year: 1980 month: 'January')
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 DateAndTimeDosEpochTest >> testAsWeek [
 	self assert: aDateAndTime asWeek equals: (Week starting: '12-31-1979' asDate)
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 DateAndTimeDosEpochTest >> testAsYear [
 	self assert: aDateAndTime asYear equals: (Year starting: '01-01-1980' asDate)
 ]

--- a/src/Kernel-Tests-Extended/DateAndTimeEpochTest.extension.st
+++ b/src/Kernel-Tests-Extended/DateAndTimeEpochTest.extension.st
@@ -1,18 +1,18 @@
-Extension { #name : #DateAndTimeEpochTest }
+Extension { #name : 'DateAndTimeEpochTest' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 DateAndTimeEpochTest >> testAsMonth [
 	self
 		assert: aDateAndTime asMonth
 		equals: (Month year: 1901 month: 'January')
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 DateAndTimeEpochTest >> testAsWeek [
 	self assert: aDateAndTime asWeek equals: (Week starting: '12-31-1900' asDate)
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 DateAndTimeEpochTest >> testAsYear [
 	self assert: aDateAndTime asYear equals: (Year starting: '01-01-1901' asDate)
 ]

--- a/src/Kernel-Tests-Extended/DateAndTimeLeapTest.extension.st
+++ b/src/Kernel-Tests-Extended/DateAndTimeLeapTest.extension.st
@@ -1,18 +1,18 @@
-Extension { #name : #DateAndTimeLeapTest }
+Extension { #name : 'DateAndTimeLeapTest' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 DateAndTimeLeapTest >> testAsMonth [
 	self
 		assert: aDateAndTime asMonth
 		equals: ((Month year: 2004 month: 'February') translateTo: 2 hours)
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 DateAndTimeLeapTest >> testAsWeek [
 	self assert: aDateAndTime asWeek equals: ((Week starting: '02-29-2004' asDate) translateTo: 2 hours)
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 DateAndTimeLeapTest >> testAsYear [
 	"A year always starts at January 1"
 	self

--- a/src/Kernel-Tests-Extended/DateAndTimeTest.extension.st
+++ b/src/Kernel-Tests-Extended/DateAndTimeTest.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #DateAndTimeTest }
+Extension { #name : 'DateAndTimeTest' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 DateAndTimeTest >> testAsDateAndTime [
 	| localOffset localOffsetSuffix |
 	#('-1199-01-05T20:33:14.321-05:00'

--- a/src/Kernel-Tests-Extended/DateAndTimeUnixEpochTest.extension.st
+++ b/src/Kernel-Tests-Extended/DateAndTimeUnixEpochTest.extension.st
@@ -1,18 +1,18 @@
-Extension { #name : #DateAndTimeUnixEpochTest }
+Extension { #name : 'DateAndTimeUnixEpochTest' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 DateAndTimeUnixEpochTest >> testAsMonth [
 	self
 		assert: aDateAndTime asMonth
 		equals: (Month year: 1970 month: 'January')
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 DateAndTimeUnixEpochTest >> testAsWeek [
 	self assert: aDateAndTime asWeek equals: (Week starting: '12-31-1969' asDate)
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 DateAndTimeUnixEpochTest >> testAsYear [
 	self assert: aDateAndTime asYear equals: (Year starting: '01-01-1970' asDate)
 ]

--- a/src/Kernel-Tests-Extended/DateParsingTest.class.st
+++ b/src/Kernel-Tests-Extended/DateParsingTest.class.st
@@ -2,17 +2,19 @@
 SUnit tests for date parsing
 "
 Class {
-	#name : #DateParsingTest,
-	#superclass : #TestCase,
-	#category : #'Kernel-Tests-Extended-Chronology'
+	#name : 'DateParsingTest',
+	#superclass : 'TestCase',
+	#category : 'Kernel-Tests-Extended-Chronology',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Chronology'
 }
 
-{ #category : #asserting }
+{ #category : 'asserting' }
 DateParsingTest >> assertReading: aString as: aPattern equals: aDate [
 	self assert: (self reading: aPattern pattern: aString) equals: aDate
 ]
 
-{ #category : #asserting }
+{ #category : 'asserting' }
 DateParsingTest >> assertReading: aString as: aPattern raise: anErrorClass [
 
 	self
@@ -20,23 +22,23 @@ DateParsingTest >> assertReading: aString as: aPattern raise: anErrorClass [
 		raise: anErrorClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DateParsingTest >> dateParserClass [
 	^ DateParser
 ]
 
-{ #category : #asserting }
+{ #category : 'asserting' }
 DateParsingTest >> reading: aPattern pattern: aString [
 	^ (self dateParserClass readingFrom: aString readStream pattern: aPattern) parse
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 DateParsingTest >> testCanEscapeSpecialCharacters [
 	"Checks that reserved pattern characters $d $m and $y can be escaped in patterns"
 	self assertReading: '4d\2m\2345y' as: 'd\d\\m\m\\y\y' equals: (Date year: 2345 month: 2 day: 4)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 DateParsingTest >> testDefaultParsingSucceeds [
 	| date |
 	date := Date year: 2013 month: 11 day: 29.
@@ -45,51 +47,51 @@ DateParsingTest >> testDefaultParsingSucceeds [
 	self assertReading: '29.11.13' as: 'd.m.y' equals: date
 ]
 
-{ #category : #'tests - dd pattern' }
+{ #category : 'tests - dd pattern' }
 DateParsingTest >> testParsingDDPatternWithIncorrectDaysFails [
 	self assertReading: '02.00.2013' as: 'dd.mm.yyyy' raise: DateError.
 	self assertReading: '02.13.2013' as: 'dd.mm.yyyy' raise: DateError
 ]
 
-{ #category : #'tests - dd pattern' }
+{ #category : 'tests - dd pattern' }
 DateParsingTest >> testParsingDDPatternWithSingleDigitFails [
 	self assertReading: '4.02.2345' as: 'dd.mm.yyyy' raise: DateError
 ]
 
-{ #category : #'tests - d pattern' }
+{ #category : 'tests - d pattern' }
 DateParsingTest >> testParsingDPatternWithIncorrectDayFails [
 	self assertReading: '0.11.2013' as: 'd.mm.yyyy' raise: DateError.
 	self assertReading: '32.2013.29' as: 'd.mm.yyyy' raise: DateError
 ]
 
-{ #category : #'tests - d pattern' }
+{ #category : 'tests - d pattern' }
 DateParsingTest >> testParsingDPatternWithSingleDigitSucceeds [
 	self assertReading: '2.11.2013' as: 'd.mm.yyyy' equals: (Date year: 2013 month: 11 day: 2)
 ]
 
-{ #category : #'tests - d pattern' }
+{ #category : 'tests - d pattern' }
 DateParsingTest >> testParsingDPatternWithTwoDigitSucceeds [
 	self assertReading: '29.11.2013' as: 'd.mm.yyyy' equals: (Date year: 2013 month: 11 day: 29)
 ]
 
-{ #category : #'tests - mm pattern' }
+{ #category : 'tests - mm pattern' }
 DateParsingTest >> testParsingMMPatternWithIncorrectMonthFails [
 	self assertReading: '02.00.2013' as: 'dd.mm.yyyy' raise: DateError.
 	self assertReading: '02.13.2013' as: 'dd.mm.yyyy' raise: DateError
 ]
 
-{ #category : #'tests - mm pattern' }
+{ #category : 'tests - mm pattern' }
 DateParsingTest >> testParsingMMPatternWithSingleDigitFails [
 	self assertReading: '04.2.2345' as: 'dd.mm.yyyy' raise: DateError
 ]
 
-{ #category : #'tests - m pattern' }
+{ #category : 'tests - m pattern' }
 DateParsingTest >> testParsingMPatternWithIncorrectMonthFails [
 	self assertReading: '1.0.2013' as: 'dd.m.yyyy' raise: DateError.
 	self assertReading: '22.13.2013' as: 'dd.m.yyyy' raise: DateError
 ]
 
-{ #category : #'tests - m pattern' }
+{ #category : 'tests - m pattern' }
 DateParsingTest >> testParsingMPatternWithSingleDigitSucceeds [
 	| date |
 	date := Date year: 2013 month: 2 day: 11.
@@ -98,7 +100,7 @@ DateParsingTest >> testParsingMPatternWithSingleDigitSucceeds [
 	self assertReading: '11.2013.2' as: 'dd.yyyy.m' equals: date
 ]
 
-{ #category : #'tests - m pattern' }
+{ #category : 'tests - m pattern' }
 DateParsingTest >> testParsingMPatternWithTwoDigitSucceeds [
 	| date |
 	date := Date year: 2013 month: 11 day: 29.
@@ -107,7 +109,7 @@ DateParsingTest >> testParsingMPatternWithTwoDigitSucceeds [
 	self assertReading: '29.2013.11' as: 'dd.yyyy.m' equals: date
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 DateParsingTest >> testParsingPatternWithExtraCharacter [
 
 	self assertReading: 'a4.2.2345' as: 'ad.m.y' equals: (Date year: 2345 month: 2 day: 4).
@@ -115,39 +117,39 @@ DateParsingTest >> testParsingPatternWithExtraCharacter [
 	self assertReading: 'a4.2.2345' as: 'd.m.y' raise: DateError
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 DateParsingTest >> testParsingPatternWithTrailingCharacterFails [
 
 	self assertReading: '04.02.2013trailing' as: 'd.m.y' raise: DateError
 ]
 
-{ #category : #'tests - y pattern' }
+{ #category : 'tests - y pattern' }
 DateParsingTest >> testParsingYPatternWithFiveDigits [
 	self assertReading: '2.11.10000' as: 'd.mm.y' equals: (Date year: 10000 month: 11 day: 2)
 ]
 
-{ #category : #'tests - y pattern' }
+{ #category : 'tests - y pattern' }
 DateParsingTest >> testParsingYPatternWithSingleDigitReturnsASecondMillenaryYear [
 	self assertReading: '2.11.3' as: 'd.mm.y' equals: (Date year: 2003 month: 11 day: 2)
 ]
 
-{ #category : #'tests - y pattern' }
+{ #category : 'tests - y pattern' }
 DateParsingTest >> testParsingYPatternWithTwoDigitsReturnsASecondMillenaryYear [
 	self assertReading: '2.11.13' as: 'd.mm.y' equals: (Date year: 2013 month: 11 day: 2)
 ]
 
-{ #category : #'tests - yy pattern' }
+{ #category : 'tests - yy pattern' }
 DateParsingTest >> testParsingYYPatternReturnsASecondMillenaryYear [
 	self assertReading: '2.11.13' as: 'd.mm.yy' equals: (Date year: 2013 month: 11 day: 2)
 ]
 
-{ #category : #'tests - yy pattern' }
+{ #category : 'tests - yy pattern' }
 DateParsingTest >> testParsingYYPatternWithWrongNumberOrDigitsShouldFails [
 	self assertReading: '02.11.3' as: 'dd.mm.yy' raise: DateError.
 	self assertReading: '02.11.113' as: 'dd.mm.yy' raise: DateError
 ]
 
-{ #category : #'tests - yyyy pattern' }
+{ #category : 'tests - yyyy pattern' }
 DateParsingTest >> testParsingYYYYPatternWithWrongNumberOrDigitsShouldFails [
 	self assertReading: '02.11.3' as: 'dd.mm.yyyy' raise: DateError.
 	self assertReading: '02.11.13' as: 'dd.mm.yyyy' raise: DateError.

--- a/src/Kernel-Tests-Extended/DelayTest.extension.st
+++ b/src/Kernel-Tests-Extended/DelayTest.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #DelayTest }
+Extension { #name : 'DelayTest' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 DelayTest >> testSemaphoreNoTimeout [
 	| sem process |
 	sem := Semaphore new.
@@ -14,7 +14,7 @@ DelayTest >> testSemaphoreNoTimeout [
 	self assert: process isTerminated
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 DelayTest >> testSemaphoreTimeout [
 	"When we provide our own semaphore for a Delay, it should be used"
 

--- a/src/Kernel-Tests-Extended/DosTimestampTest.class.st
+++ b/src/Kernel-Tests-Extended/DosTimestampTest.class.st
@@ -2,12 +2,14 @@
 SUnit tests for class  DosTimeStamp
 "
 Class {
-	#name : #DosTimestampTest,
-	#superclass : #TestCase,
-	#category : #'Kernel-Tests-Extended-Chronology'
+	#name : 'DosTimestampTest',
+	#superclass : 'TestCase',
+	#category : 'Kernel-Tests-Extended-Chronology',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Chronology'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 DosTimestampTest >> testAsDateAndTime [
 
 	| timestamp |
@@ -15,7 +17,7 @@ DosTimestampTest >> testAsDateAndTime [
 	self assert: timestamp asDateAndTime equals: '21 May 2012 3:02:44 pm' asDateAndTime
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 DosTimestampTest >> testFromDateAndTime [
 
 	| timestamp |
@@ -24,7 +26,7 @@ DosTimestampTest >> testFromDateAndTime [
 	self assert: timestamp value equals: 16r40B57856
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 DosTimestampTest >> testTimesAreLocal [
 
 	| remoteDateAndTime remoteTimestamp localTimestamp |

--- a/src/Kernel-Tests-Extended/DurationTest.extension.st
+++ b/src/Kernel-Tests-Extended/DurationTest.extension.st
@@ -1,13 +1,13 @@
-Extension { #name : #DurationTest }
+Extension { #name : 'DurationTest' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 DurationTest >> testAsDays [
 	self assert: (Duration days: 2) asDays equals: 2.
 	self assert: (Duration weeks: 1) asDays equals: 7.
 	self assert: (aDuration asDays closeTo: 1.08546)
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 DurationTest >> testAsHour [
 	| full half quarter |
 	full := Duration minutes: 60.
@@ -21,14 +21,14 @@ DurationTest >> testAsHour [
 		assert: (1 / 4) hour equals: quarter
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 DurationTest >> testAsHours [
 	self assert: (Duration hours: 2) asHours equals: 2.
 	self assert: (Duration days: 1) asHours equals: 24.
 	self assert: (aDuration asHours closeTo: 26.0511)
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 DurationTest >> testAsMinutes [
 	self assert: (Duration seconds: 60) asMinutes equals: 1.
 	self assert: (Duration hours: 1) asMinutes equals: 60.
@@ -36,7 +36,7 @@ DurationTest >> testAsMinutes [
 	self assert: ((Duration milliSeconds: 100) asMinutes closeTo: 1 / 600)
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 DurationTest >> testMonthDurations [
 	| jan feb dec |
 	jan := Duration month: #January.

--- a/src/Kernel-Tests-Extended/ExceptionTest.extension.st
+++ b/src/Kernel-Tests-Extended/ExceptionTest.extension.st
@@ -1,11 +1,11 @@
-Extension { #name : #ExceptionTest }
+Extension { #name : 'ExceptionTest' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 ExceptionTest >> testSimpleRetry [
 	self assertSuccess: (ExceptionTester new runTest: #simpleRetryTest)
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 ExceptionTest >> testSimpleRetryUsing [
 	self assertSuccess: (ExceptionTester new runTest: #simpleRetryUsingTest)
 ]

--- a/src/Kernel-Tests-Extended/FloatTest.extension.st
+++ b/src/Kernel-Tests-Extended/FloatTest.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FloatTest }
+Extension { #name : 'FloatTest' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FloatTest >> test32bitConversion [
 	"Except for NaN, we can convert a 32bits float to a 64bits float exactly.
 	Thus we can convert the 64bits float to the original 32bits float pattern."
@@ -21,7 +21,7 @@ FloatTest >> test32bitConversion [
 	  do: [:originalWord | self assert: (Float fromIEEE32Bit: originalWord) asIEEE32BitWord equals: originalWord ]
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FloatTest >> test32bitGradualUnderflow [
 	"method asIEEE32BitWord did not respect IEEE gradual underflow"
 
@@ -61,7 +61,7 @@ FloatTest >> test32bitGradualUnderflow [
 	self assert: expected equals: conv
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FloatTest >> test32bitRoundingMode [
 	"method asIEEE32BitWord did not respect IEEE default rounding mode"
 
@@ -97,7 +97,7 @@ FloatTest >> test32bitRoundingMode [
 	self assert: expected equals: conv
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FloatTest >> testArcTan [
 
 	self assert: ((100 arcTan: 100) closeTo: Float pi / 4).
@@ -118,7 +118,7 @@ FloatTest >> testArcTan [
 	self assert: ((Float negativeZero arcTan: Float negativeZero) closeTo: Float pi negated)
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FloatTest >> testBinaryLiteralString [
 
 	self assert: 0.0 binaryLiteralString equals: '0.0'.
@@ -278,7 +278,7 @@ FloatTest >> testBinaryLiteralString [
 		equals: 'Float nan'
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FloatTest >> testCharacterization [
 	"Test the largest finite representable floating point value"
 
@@ -350,7 +350,7 @@ FloatTest >> testCharacterization [
 	self assert: Float infinity negated hex equals: 'FFF0000000000000'
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FloatTest >> testComparison [
 	"test equality when Float conversion loose bits"
 
@@ -397,7 +397,7 @@ FloatTest >> testComparison [
 		((Set new: 4) add: 3; add: 3.0; size)
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FloatTest >> testDegreeCos [
 
 	45.0 degreeCos. "Following tests use approximate equality, because cosine are generally evaluated using inexact Floating point arithmetic"
@@ -414,7 +414,7 @@ FloatTest >> testDegreeCos [
 		self assert: (k * 360) degreeCos - 1 equals: 0 ]
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FloatTest >> testDegreeCosForExceptionalValues [
 
 	self assert: Float nan degreeCos isNaN.
@@ -422,7 +422,7 @@ FloatTest >> testDegreeCosForExceptionalValues [
 	self assert: Float infinity negated degreeCos isNaN
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FloatTest >> testDegreeSin [
 
 	45.0 degreeSin. "Following tests use approximate equality, because sine are generally evaluated using inexact Floating point arithmetic"
@@ -439,7 +439,7 @@ FloatTest >> testDegreeSin [
 		self assert: (k * 360) degreeSin equals: 0 ]
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FloatTest >> testDegreeSinForExceptionalValues [
 
 	self assert: Float nan degreeSin isNaN.
@@ -447,7 +447,7 @@ FloatTest >> testDegreeSinForExceptionalValues [
 	self assert: Float infinity negated degreeSin isNaN
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FloatTest >> testFloatPrinting [
 	"This test shows that floats are printed exactly. The idea is too make sure that users understand that "
 
@@ -457,7 +457,7 @@ FloatTest >> testFloatPrinting [
   	self assert: 240 degreesToRadians cos abs equals: 0.5000000000000004
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FloatTest >> testFloatRounded [
 	"5000000000000001 asFloat has an exact representation (no round off error).
 	It should round to nearest integer without loosing bits.
@@ -485,7 +485,7 @@ FloatTest >> testFloatRounded [
 		self assert: x negated rounded equals: x negated asTrueFraction rounded ]
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FloatTest >> testFloorLog2 [
 	"Float internal representation of Float being in base 2, we expect (aFloat floorLog: 2) to be exact."
 
@@ -502,7 +502,7 @@ FloatTest >> testFloorLog2 [
 			equals: exp - 1 ]
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FloatTest >> testFractionAsFloat [
 	"use a random test"
 
@@ -522,7 +522,7 @@ FloatTest >> testFractionAsFloat [
 			self assert: err <= (1/2)]]
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FloatTest >> testFractionAsFloat2 [
 	"test rounding to nearest even"
 
@@ -534,7 +534,7 @@ FloatTest >> testFractionAsFloat2 [
 	self assert: ((1<<52)+1+(3/4)) asFloat asTrueFraction equals: ((1<<52)+2)
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FloatTest >> testHugeIntegerCloseTo [
 	"This is a test for bug http://bugs.squeak.org/view.php?id=7368"
 
@@ -543,7 +543,7 @@ FloatTest >> testHugeIntegerCloseTo [
 	self assert: (Float infinity closeTo: 200 factorial) equals: (200 factorial closeTo: Float infinity)
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FloatTest >> testInfinityCloseTo [
 	"This is a test for bug http://bugs.squeak.org/view.php?id=6729"
 
@@ -551,7 +551,7 @@ FloatTest >> testInfinityCloseTo [
 	self deny: (Float infinity negated closeTo: Float infinity)
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FloatTest >> testNaN5 [
 
 	self assert: ((Float nan asIEEE32BitWord printPaddedWith: $0 to: 32 base: 2) copyFrom: 2 to: 9)
@@ -560,7 +560,7 @@ FloatTest >> testNaN5 [
 		(Integer readFrom: '01111111110000000000000000000000' readStream base: 2)) isNaN
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FloatTest >> testRounding [
 
 	self assert: (10.1234 round: 2) equals: 10.12.

--- a/src/Kernel-Tests-Extended/FractionTest.extension.st
+++ b/src/Kernel-Tests-Extended/FractionTest.extension.st
@@ -1,20 +1,20 @@
-Extension { #name : #FractionTest }
+Extension { #name : 'FractionTest' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FractionTest >> testDegreeCos [
 
 	(4 / 3) degreeCos.
 	-361 / 3 to: 359 / 3 do: [ :i | self assert: (i degreeCos closeTo: i degreesToRadians cos) ]
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FractionTest >> testDegreeSin [
 
 	(4 / 3) degreeSin.
 	-361 / 3 to: 359 / 3 do: [ :i | self assert: (i degreeSin closeTo: i degreesToRadians sin) ]
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FractionTest >> testExactRaisedTo [
 	"
 	FractionTest new testExactRaisedTo
@@ -87,7 +87,7 @@ FractionTest >> testExactRaisedTo [
 		self assert: ((f negated raisedTo: 3) -1 raisedTo: 5/3) isFloat ]
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FractionTest >> testExactSqrt [
 	"
 	FractionTest new testExactSqrt
@@ -101,7 +101,7 @@ FractionTest >> testExactSqrt [
 		self assert: f squared sqrt classAndValueEquals: f ]
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FractionTest >> testFloorLog [
 	self assert: (1 / 100 floorLog: 10) equals: -2.
 	self assert: ((2 raisedTo: Float emax + 11) / 3 floorLog: 10) = ((Float emax + 11) * 2 log - 3 log) floor description: 'Fraction>>log should not overflow'.
@@ -110,7 +110,7 @@ FractionTest >> testFloorLog [
 		description: 'Fraction>>log should not underflow'
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FractionTest >> testInexactRaisedTo [
 	"
 	FractionTest new testInexactRaisedTo
@@ -120,7 +120,7 @@ FractionTest >> testInexactRaisedTo [
 	self assert: ((((1 << 1024) + 1) / ((1 << 1024) + 3)) negated raisedTo: 1 / 3) equals: -1.0
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FractionTest >> testInexactSqrt [
 	"
 	FractionTest new testInexactSqrt
@@ -129,27 +129,27 @@ FractionTest >> testInexactSqrt [
 	self assert: (((1 << 1024) + 1) / ((1 << 1024) + 3)) sqrt equals: 1.0
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FractionTest >> testLn [
 	self assert: ((1/100) ln closeTo: -2 * 10 ln).
 	self assert: (((2 raisedTo: Float emax + 11)/3) ln closeTo: (Float emax + 11)*2 ln - 3 ln) description: 'Fraction>>ln should not overflow'.
 	self assert: ((3/(2 raisedTo: Float precision - Float emin)) ln closeTo: (Float emin - Float precision)*2 ln + 3 ln) description: 'Fraction>>ln should not underflow'
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FractionTest >> testLog [
 	self assert: ((1/100) log closeTo: -2).
 	self assert: (((2 raisedTo: Float emax + 11)/3) log closeTo: (Float emax + 11)*2 log - 3 log) description: 'Fraction>>log should not overflow'.
 	self assert: ((3/(2 raisedTo: Float precision - Float emin)) log closeTo: (Float emin - Float precision)*2 log + 3 log) description: 'Fraction>>log should not underflow'
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FractionTest >> testNthRoot [
 	self assert: ((-2 raisedTo: 35) / (3 raisedTo: 20) raisedTo: 1/5) equals: (-2 raisedTo: 7) / (3 raisedTo: 4).
 	self assert: (1 / (1 << 2000) raisedTo: 1/100) equals: 1 / (1 << 20)
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 FractionTest >> testSqrtErrorConditions [
 	"
 	FractionTest new testSqrtErrorConditions

--- a/src/Kernel-Tests-Extended/InstVarRefLocatorTest.class.st
+++ b/src/Kernel-Tests-Extended/InstVarRefLocatorTest.class.st
@@ -5,15 +5,17 @@ This is the unit test for the class InstVarRefLocator. Unit tests are a good way
 	- the sunit class category
 "
 Class {
-	#name : #InstVarRefLocatorTest,
-	#superclass : #TestCase,
+	#name : 'InstVarRefLocatorTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'tt'
 	],
-	#category : #'Kernel-Tests-Extended-Methods'
+	#category : 'Kernel-Tests-Extended-Methods',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Methods'
 }
 
-{ #category : #examples }
+{ #category : 'examples' }
 InstVarRefLocatorTest >> example1 [
 	<sampleInstance>
 	| ff |
@@ -21,7 +23,7 @@ InstVarRefLocatorTest >> example1 [
 	^ ff
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 InstVarRefLocatorTest >> example2 [
 	<sampleInstance>
 	| ff |
@@ -30,7 +32,7 @@ InstVarRefLocatorTest >> example2 [
 	^ ff
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 InstVarRefLocatorTest >> hasInstVarRef: aMethod [
 	"Answer whether the receiver references an instance variable."
 
@@ -46,7 +48,7 @@ InstVarRefLocatorTest >> hasInstVarRef: aMethod [
 	^false
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 InstVarRefLocatorTest >> testExample1 [
 	| method |
 
@@ -54,7 +56,7 @@ InstVarRefLocatorTest >> testExample1 [
 	self assert: (self hasInstVarRef: method)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 InstVarRefLocatorTest >> testExample2 [
 	| method |
 
@@ -62,7 +64,7 @@ InstVarRefLocatorTest >> testExample2 [
 	self deny: (self hasInstVarRef: method)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 InstVarRefLocatorTest >> testInstructions [
 	Object methods
 		do: [ :method |

--- a/src/Kernel-Tests-Extended/InstructionClientTest.class.st
+++ b/src/Kernel-Tests-Extended/InstructionClientTest.class.st
@@ -5,12 +5,14 @@ This is the unit test for the class InstructionClient. Unit tests are a good way
 	- the sunit class category
 "
 Class {
-	#name : #InstructionClientTest,
-	#superclass : #TestCase,
-	#category : #'Kernel-Tests-Extended-Methods'
+	#name : 'InstructionClientTest',
+	#superclass : 'TestCase',
+	#category : 'Kernel-Tests-Extended-Methods',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Methods'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 InstructionClientTest >> testInstructions [
 	"just interpret all of methods of Object"
 

--- a/src/Kernel-Tests-Extended/InstructionStreamTest.class.st
+++ b/src/Kernel-Tests-Extended/InstructionStreamTest.class.st
@@ -1,68 +1,70 @@
 Class {
-	#name : #InstructionStreamTest,
-	#superclass : #TestCase,
+	#name : 'InstructionStreamTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'operations'
 	],
-	#category : #'Kernel-Tests-Extended-Methods'
+	#category : 'Kernel-Tests-Extended-Methods',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Methods'
 }
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 InstructionStreamTest >> blockReturnTop [
 
 		operations add: { #blockReturnTop }
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 InstructionStreamTest >> classUnderTest [
 
 	^ ClassUsedInInstructionStreamTest
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 InstructionStreamTest >> directedSuperSend: aString numArgs: anInteger [
 
 	operations add: { #directSuperSend:numArgs:. aString. anInteger }
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 InstructionStreamTest >> pc: anInteger [
 
 	"Ignore the PC"
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 InstructionStreamTest >> pushConstant: anInteger [
 
 	operations add: { #pushConstant. anInteger }
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 InstructionStreamTest >> pushLiteralVariable: aLiteralVariable [
 
 	operations add: { #pushConstant. aLiteralVariable }
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 InstructionStreamTest >> pushReceiver [
 
 	operations add: {#pushReceiver}
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 InstructionStreamTest >> send: aString super: aBoolean numArgs: anInteger [
 
 	operations add: { #send:super:numArgs:. aString. aBoolean. anInteger }
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 InstructionStreamTest >> setUp [
 
 	super setUp.
 	operations := OrderedCollection new
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 InstructionStreamTest >> testBlockWithASuperSendHasCorrectNumberOfArguments [
 
 	| aMethod aCompiledBlock aStream |
@@ -78,7 +80,7 @@ InstructionStreamTest >> testBlockWithASuperSendHasCorrectNumberOfArguments [
 	self assert: operations fifth equals: { #directSuperSend:numArgs:. #aSuperMethod:with:. 2 }
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 InstructionStreamTest >> testBlockWithASuperWithoutArgumentsSendHasCorrectNumberOfArguments [
 
 	| aMethod aCompiledBlock aStream |
@@ -94,7 +96,7 @@ InstructionStreamTest >> testBlockWithASuperWithoutArgumentsSendHasCorrectNumber
 	self assert: operations third equals: { #directSuperSend:numArgs:. #yourself. 0 }
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 InstructionStreamTest >> testNextPcAnswerNextBytecodePcInCaseOfExtension [
 
 	| stream methodToTest ir startingPc |
@@ -114,7 +116,7 @@ InstructionStreamTest >> testNextPcAnswerNextBytecodePcInCaseOfExtension [
 	self assert: (stream nextPc: 16rE0) equals: startingPc + 4
 ]
 
-{ #category : #'tests - example' }
+{ #category : 'tests - example' }
 InstructionStreamTest >> testSimulatedTerminationOfProcessDoNotCorruptTheContext [
 
 	| initialContext aContext receiver semaphore process suspendedProcess return errorThatHappen |
@@ -136,7 +138,7 @@ InstructionStreamTest >> testSimulatedTerminationOfProcessDoNotCorruptTheContext
 	self assert: receiver expectedValue equals: 42
 ]
 
-{ #category : #'tests - example' }
+{ #category : 'tests - example' }
 InstructionStreamTest >> testSimulatingAMethodWithHaltHasCorrectContext [
 
 	| initialContext aContext receiver suspendedProcess return |
@@ -155,7 +157,7 @@ InstructionStreamTest >> testSimulatingAMethodWithHaltHasCorrectContext [
 	self assert: return size equals: 1
 ]
 
-{ #category : #'tests - example' }
+{ #category : 'tests - example' }
 InstructionStreamTest >> testStepContextNonTakenConditionalJumpBytecodes [
 
 	| context |
@@ -169,7 +171,7 @@ InstructionStreamTest >> testStepContextNonTakenConditionalJumpBytecodes [
 	self assert: context top equals: 8
 ]
 
-{ #category : #'tests - example' }
+{ #category : 'tests - example' }
 InstructionStreamTest >> testStepContextTakenConditionalJumpBytecodes [
 
 	| context |
@@ -183,7 +185,7 @@ InstructionStreamTest >> testStepContextTakenConditionalJumpBytecodes [
 	self assert: context top equals: 2
 ]
 
-{ #category : #'tests - example' }
+{ #category : 'tests - example' }
 InstructionStreamTest >> testStepNonTakenConditionalJumpBytecodes [
 
 	| context stream |
@@ -198,7 +200,7 @@ InstructionStreamTest >> testStepNonTakenConditionalJumpBytecodes [
 	self assert: context top equals: 8
 ]
 
-{ #category : #'tests - example' }
+{ #category : 'tests - example' }
 InstructionStreamTest >> testStepSendPopsArgumentsAndPushesResultBytecodes [
 
 	| context stream |
@@ -212,7 +214,7 @@ InstructionStreamTest >> testStepSendPopsArgumentsAndPushesResultBytecodes [
 	self assert: context top equals: 3
 ]
 
-{ #category : #'tests - example' }
+{ #category : 'tests - example' }
 InstructionStreamTest >> testStepSingleBytecode [
 
 	| context stream |
@@ -224,7 +226,7 @@ InstructionStreamTest >> testStepSingleBytecode [
 	self assert: context top equals: 1
 ]
 
-{ #category : #'tests - example' }
+{ #category : 'tests - example' }
 InstructionStreamTest >> testStepTakenConditionalJumpBytecodes [
 
 	| context stream |
@@ -239,7 +241,7 @@ InstructionStreamTest >> testStepTakenConditionalJumpBytecodes [
 	self assert: context top equals: 2
 ]
 
-{ #category : #'tests - example' }
+{ #category : 'tests - example' }
 InstructionStreamTest >> testStepThroughInAMethodWithMNU [
 
 	| initialContext aContext receiver suspendedProcess return |
@@ -257,7 +259,7 @@ InstructionStreamTest >> testStepThroughInAMethodWithMNU [
 	self assert: return method equals: (self classUnderTest lookupSelector: #doesNotUnderstand:)
 ]
 
-{ #category : #'tests - example' }
+{ #category : 'tests - example' }
 InstructionStreamTest >> testStepThroughInAMethodWithoutError [
 
 	| initialContext aContext receiver suspendedProcess return |
@@ -276,7 +278,7 @@ InstructionStreamTest >> testStepThroughInAMethodWithoutError [
 	self assert: return top equals: 42
 ]
 
-{ #category : #'tests - example' }
+{ #category : 'tests - example' }
 InstructionStreamTest >> testStepTwoBytecodes [
 
 	| context stream |
@@ -289,7 +291,7 @@ InstructionStreamTest >> testStepTwoBytecodes [
 	self assert: context top equals: 2
 ]
 
-{ #category : #'tests - example' }
+{ #category : 'tests - example' }
 InstructionStreamTest >> testSteppingSendsDirectSend [
 
 	| initialContext aContext receiver |

--- a/src/Kernel-Tests-Extended/IntegerTest.extension.st
+++ b/src/Kernel-Tests-Extended/IntegerTest.extension.st
@@ -1,13 +1,13 @@
-Extension { #name : #IntegerTest }
+Extension { #name : 'IntegerTest' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testBenchFib [
 	self assert: 0 benchFib equals: 1.
 	self assert: 1 benchFib equals: 1.
 	self assert: 2 benchFib equals: 3
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testBigReceiverInexactNthRoot [
 	"
 	IntegerTest new testBigReceiverInexactNthRoot
@@ -26,7 +26,7 @@ IntegerTest >> testBigReceiverInexactNthRoot [
 	self assert: 100 factorial asFloat equals: (100 factorial + 1) asFloat
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testBigReceiverInexactSqrt [
 	"
 	IntegerTest new testBigReceiverInexactSqrt
@@ -46,14 +46,14 @@ IntegerTest >> testBigReceiverInexactSqrt [
 	self assert: (result predecessor asFraction squared - bigNum) abs >= (result asFraction squared - bigNum) abs
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testBitOr [
 
 	self assert: (2r0101 | 2r1010) equals: 2r1111.
 	self assert: (2r0101 bitOr: 2r1010) equals: 2r1111
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testDegreeCos [
 
 	45 degreeCos. "Following tests use approximate equality, because cosine are generally evaluated using inexact Floating point arithmetic"
@@ -70,7 +70,7 @@ IntegerTest >> testDegreeCos [
 		self assert: (k * 360) degreeCos - 1 equals: 0 ]
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testDegreeSin [
 
 	45 degreeSin. "Following tests use approximate equality, because sine are generally evaluated using inexact Floating point arithmetic"
@@ -87,7 +87,7 @@ IntegerTest >> testDegreeSin [
 		self assert: (k * 360) degreeSin equals: 0 ]
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testDigitsAccess [
 
 	self assert: (42 digitAt: 2 base: 10) equals: 4.
@@ -109,7 +109,7 @@ IntegerTest >> testDigitsAccess [
 	self assert: ((256*256) lastDigit) equals: 1
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testExactRaisedTo [
 	"
 	IntegerTest new testExactRaisedTo
@@ -160,7 +160,7 @@ IntegerTest >> testExactRaisedTo [
 		self assert: ((i negated raisedTo: 3) -1 raisedTo: 5/3) isFloat ]
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testExactSqrt [
 	"
 	IntegerTest new testExactSqrt
@@ -173,13 +173,13 @@ IntegerTest >> testExactSqrt [
 		self assert: i squared sqrt classAndValueEquals: i ]
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testFloorLog [
 	self assert: (100 floorLog: 10) equals: 2.
 	self assert: ((2 raisedTo: Float emax + 3) floorLog: 10) = (2 log * (Float emax + 3)) floor description: 'Integer>>floorLog: should not overflow'
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testIsPrime [
 
 	self assert: 2 isPrime.
@@ -210,7 +210,7 @@ IntegerTest >> testIsPrime [
 	self deny: 29996224275831 isPrime
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testIsPrime2 [
 
 	"Not primes:"
@@ -226,14 +226,14 @@ IntegerTest >> testIsPrime2 [
 		self deny: each isPrime ]
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testIsPrime3 [
 
 	self assert:
 		((Integer primesUpTo: 10000) allSatisfy: [ :each | each isPrime ])
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testIsProbablyPrime [
 
 	"Not primes:"
@@ -249,7 +249,7 @@ IntegerTest >> testIsProbablyPrime [
 		self deny: each isProbablyPrime ]
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testLargePrimesUpTo [
 	| nn |
 	nn := (2 raisedTo: 17) - 1.
@@ -257,7 +257,7 @@ IntegerTest >> testLargePrimesUpTo [
 	self assert: (Integer primesUpTo: nn + 1) last equals: nn
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testLargePrimesUpTo2 [
 
 	| primesLessThan10000 |
@@ -416,25 +416,25 @@ IntegerTest >> testLargePrimesUpTo2 [
 	self assert: (Integer primesUpTo: 10000) equals: primesLessThan10000
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testLn [
 	self assert: (100 ln closeTo: 10 ln*2).
 	self assert: ((2 raisedTo: Float emax + 3) ln closeTo: 2 ln*(Float emax + 3)) description: 'Integer>>ln should not overflow'
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testLog [
 	self assert: (100 log closeTo: 2).
 	self assert: ((2 raisedTo: Float emax + 3) log closeTo: 2 log*(Float emax + 3)) description: 'Integer>>log should not overflow'
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testNthRoot [
 	1 << 2000 nthRoot: 100.
 	self assert: (1 << 2000 nthRoot: 100) equals: 1 << 20
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testNthRootErrorConditions [
 	"
 	IntegerTest new testExactRaisedToErrorConditions
@@ -444,7 +444,7 @@ IntegerTest >> testNthRootErrorConditions [
 	self should: [ -2 nthRoot: 1.24 ] raise: ArithmeticError
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testNthRootExactness [
 	| inexactRoots largeExactPowersOf6 |
 	largeExactPowersOf6 := (2 to: 100) collect: [:k | k raisedTo: 66].
@@ -452,7 +452,7 @@ IntegerTest >> testNthRootExactness [
 	self assert: inexactRoots isEmpty description: 'Failed to find the exact 6th root of these numbers'
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testNthRootTruncated [
 	<timeout:  5 "seconds">
 	| tooBigToBeAFloat large |
@@ -474,7 +474,7 @@ IntegerTest >> testNthRootTruncated [
 			self assert: (theTruncatedRoot + 1 raisedTo: thePower) > n]]
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testPrimesUpTo [
 	| primes nn |
 	primes := Integer primesUpTo: 100.
@@ -490,7 +490,7 @@ IntegerTest >> testPrimesUpTo [
 	self assert: (Integer primesUpTo: nn + 1) last equals: nn
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testRomanPrinting [
 	self assert: 0 printStringRoman equals: ''.	"No symbol for zero"
 	self assert: 1 printStringRoman equals: 'I'.
@@ -583,7 +583,7 @@ IntegerTest >> testRomanPrinting [
 	self assert: -10 printStringRoman equals: '-X'
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testSqrtErrorConditions [
 	"
 	IntegerTest new testSqrtErrorConditions
@@ -592,7 +592,7 @@ IntegerTest >> testSqrtErrorConditions [
 	self should: [ -1 sqrt ] raise: ArithmeticError
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 IntegerTest >> testSqrtFloor [
 	#(-1234567890123 -10 -5 -1) do: [ :each | self should: [ each sqrtFloor ] raise: Error ].
 	#(0 1 2 3 4 5 10 16 30 160479924 386234481 501619156 524723498 580855366 766098594 834165249 1020363860 1042083924 1049218924 1459774772895569 3050005981408238 4856589481837079 5650488387708463 7831037396100244)

--- a/src/Kernel-Tests-Extended/LargePositiveIntegerTest.extension.st
+++ b/src/Kernel-Tests-Extended/LargePositiveIntegerTest.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #LargePositiveIntegerTest }
+Extension { #name : 'LargePositiveIntegerTest' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 LargePositiveIntegerTest >> testLargeSqrtFloor [
 	"This test fails if a careless implementation naivly factors out the power of two (remove the trailing zeroes up to lowBit).
 	This was the case in a previous implementation, so this is a non regression test."
@@ -12,7 +12,7 @@ LargePositiveIntegerTest >> testLargeSqrtFloor [
 	self assert: (root + 1) squared > large
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 LargePositiveIntegerTest >> testMultDicAddSub [
 	| n f f1 |
 	n := 100.

--- a/src/Kernel-Tests-Extended/ManifestKernelTestsExtended.class.st
+++ b/src/Kernel-Tests-Extended/ManifestKernelTestsExtended.class.st
@@ -2,7 +2,9 @@
 I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
 "
 Class {
-	#name : #ManifestKernelTestsExtended,
-	#superclass : #PackageManifest,
-	#category : #'Kernel-Tests-Extended-Manifest'
+	#name : 'ManifestKernelTestsExtended',
+	#superclass : 'PackageManifest',
+	#category : 'Kernel-Tests-Extended-Manifest',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Manifest'
 }

--- a/src/Kernel-Tests-Extended/MonthTest.class.st
+++ b/src/Kernel-Tests-Extended/MonthTest.class.st
@@ -3,21 +3,23 @@ This is the unit test for the class Month.
 
 "
 Class {
-	#name : #MonthTest,
-	#superclass : #ClassTestCase,
+	#name : 'MonthTest',
+	#superclass : 'ClassTestCase',
 	#instVars : [
 		'month'
 	],
-	#category : #'Kernel-Tests-Extended-Chronology'
+	#category : 'Kernel-Tests-Extended-Chronology',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Chronology'
 }
 
-{ #category : #coverage }
+{ #category : 'coverage' }
 MonthTest >> classToBeTested [
 
 	^ Month
 ]
 
-{ #category : #coverage }
+{ #category : 'coverage' }
 MonthTest >> selectorsToBeIgnored [
 
 	| deprecated private special |
@@ -28,26 +30,26 @@ MonthTest >> selectorsToBeIgnored [
 	^ super selectorsToBeIgnored, deprecated, private, special
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 MonthTest >> setUp [
 
 	super setUp.
 	month := Month year: 1998 month: 7
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 MonthTest >> tearDown [
 
 	month := nil.
 	super tearDown
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MonthTest >> testConverting [
 	self assert: month asDate equals: '1 July 1998' asDate
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MonthTest >> testEnumerating [
 	| weeks |
 	weeks := OrderedCollection new.
@@ -56,7 +58,7 @@ MonthTest >> testEnumerating [
 	self assertEmpty: weeks
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MonthTest >> testIndexOfMonth [
 	| m |
 	m := #(#January #February #March #April #May #June #July #August #September #October #November #December).
@@ -69,7 +71,7 @@ MonthTest >> testIndexOfMonth [
 	self should: [ Month indexOfMonth: #UnexistingMonth ] raise: self defaultTestError
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MonthTest >> testIndexOfMonthCaseInsensitive [
 	self assert: (Month indexOfMonth: 'january') equals: 1.
 	self assert: (Month indexOfMonth: #january) equals: 1.
@@ -77,7 +79,7 @@ MonthTest >> testIndexOfMonthCaseInsensitive [
 	self assert: (Month indexOfMonth: #jAnUaRy) equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MonthTest >> testIndexOfMonthIncompleteMonths [
 	| m |
 	m := #(Jan Feb Mar Apr May Jun Jul Aug Sept Oct Nov Dec).
@@ -85,7 +87,7 @@ MonthTest >> testIndexOfMonthIncompleteMonths [
 	m withIndexDo: [ :item :index | self assert: (Month indexOfMonth: item) equals: index ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MonthTest >> testIndexOfMonthWithStrings [
 	| m |
 	m := #(#January #February #March #April #May #June #July #August #September #October #November #December)
@@ -95,7 +97,7 @@ MonthTest >> testIndexOfMonthWithStrings [
 		self assert: (Month indexOfMonth: item) equals: index ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MonthTest >> testInquiries [
 	self
 		assert: month index equals: 7;
@@ -103,7 +105,7 @@ MonthTest >> testInquiries [
 		assert: month duration equals: 31 days
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MonthTest >> testInstanceCreation [
 	| m1 m2 |
 	m1 := Month starting: '4 July 1998' asDate.
@@ -113,7 +115,7 @@ MonthTest >> testInstanceCreation [
 		assert: month equals: m2
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MonthTest >> testNameOfMonth [
 	| m |
 	m := #(#January #February #March #April #May #June #July #August #September #October #November #December).
@@ -125,7 +127,7 @@ MonthTest >> testNameOfMonth [
 	self should: [ Month nameOfMonth: #January ] raise: self defaultTestError
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MonthTest >> testOffset [
 	"Check that the offset is maintained when creating a new instance of Month from a DateAndTime"
 
@@ -136,7 +138,7 @@ MonthTest >> testOffset [
 	self assert: newMonth asDateAndTime offset equals: dt offset
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MonthTest >> testPreviousNext [
 	| n p |
 	n := month next.
@@ -149,12 +151,12 @@ MonthTest >> testPreviousNext [
 		assert: p index equals: 6
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MonthTest >> testPrinting [
 	self assert: month printString equals: 'July 1998'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MonthTest >> testReadFrom [
 	| m |
 	m := Month readFrom: 'July 1998' readStream.

--- a/src/Kernel-Tests-Extended/MutexTest.class.st
+++ b/src/Kernel-Tests-Extended/MutexTest.class.st
@@ -2,16 +2,18 @@
 SUnit tests for class  Mutex
 "
 Class {
-	#name : #MutexTest,
-	#superclass : #TestCase,
+	#name : 'MutexTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'mutex',
 		'forkedProcesses'
 	],
-	#category : #'Kernel-Tests-Extended-Processes'
+	#category : 'Kernel-Tests-Extended-Processes',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Processes'
 }
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 MutexTest >> fork: aBlock [
 
 	| newProcess |
@@ -20,7 +22,7 @@ MutexTest >> fork: aBlock [
 	^newProcess
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 MutexTest >> fork: aBlock at: priority [
 
 	| newProcess |
@@ -29,7 +31,7 @@ MutexTest >> fork: aBlock at: priority [
 	^newProcess
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 MutexTest >> setUp [
 	super setUp.
 
@@ -37,14 +39,14 @@ MutexTest >> setUp [
 	mutex := Mutex new
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 MutexTest >> tearDown [
 	forkedProcesses do: #terminate.
 
 	super tearDown
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MutexTest >> testExecutionCriticalSection [
 
 	| actual |
@@ -53,7 +55,7 @@ MutexTest >> testExecutionCriticalSection [
 	self assert: actual equals: #result
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MutexTest >> testFailedCriticalSectionShouldUnblockWaitingOne [
 	| lastCriticalExecuted semaphoreToHoldMutex |
 	lastCriticalExecuted := false.
@@ -73,7 +75,7 @@ MutexTest >> testFailedCriticalSectionShouldUnblockWaitingOne [
 	self assert: lastCriticalExecuted
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MutexTest >> testTerminatedCriticalSectionShouldUnblockWaitingOne [
 	| lastCriticalExecuted semaphoreToHoldMutex processHoldingMutex |
 	lastCriticalExecuted := false.
@@ -92,7 +94,7 @@ MutexTest >> testTerminatedCriticalSectionShouldUnblockWaitingOne [
 	self assert: lastCriticalExecuted
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MutexTest >> testTerminatingBlockedCriticalSectionShouldNotUnblockAnotherWaitingSection [
 	| semaphoreToHoldMutex holdingCriticalExecutedFirst firstWaitingProcess lastCriticalExecuted |
 	holdingCriticalExecutedFirst := false.
@@ -117,7 +119,7 @@ MutexTest >> testTerminatingBlockedCriticalSectionShouldNotUnblockAnotherWaiting
 	self assert: lastCriticalExecuted
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MutexTest >> testTerminatingBlockedCriticalWhichWasSignalledButNotResumedYet [
 	| processWaitingForMutex firstCriticalExecuted lastCriticalExecuted semaphoreToHoldMutex |
 	firstCriticalExecuted := false.
@@ -141,7 +143,7 @@ MutexTest >> testTerminatingBlockedCriticalWhichWasSignalledButNotResumedYet [
 	self assert: lastCriticalExecuted description: 'consequent last critical should be executed'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MutexTest >> testTwoCriticalsShouldWaitEachOther [
 
 	| lastCriticalExecuted firstCriticalExecutedFirst semaphoreToHoldMutex |
@@ -163,7 +165,7 @@ MutexTest >> testTwoCriticalsShouldWaitEachOther [
 	self assert: firstCriticalExecutedFirst
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MutexTest >> testTwoRecursiveCriticalsShouldNotWaitEachOther [
 
 	| executed |
@@ -175,43 +177,43 @@ MutexTest >> testTwoRecursiveCriticalsShouldNotWaitEachOther [
 	self assert: executed
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 MutexTest >> waitFor: aBlock [
 
 	[ 10 milliSeconds wait. aBlock value ] whileFalse
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 MutexTest >> waitLastProcessLock [
 
 	self waitProcessLock: forkedProcesses last
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 MutexTest >> waitLastProcessSuspend [
 
 	self waitProcessSuspend: forkedProcesses last
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 MutexTest >> waitLastProcessTerminate [
 
 	self waitProcessTermination: forkedProcesses last
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 MutexTest >> waitProcessLock: aProcess [
 
 	self waitFor: [ aProcess suspendingList isEmptyOrNil not ]
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 MutexTest >> waitProcessSuspend: aProcess [
 
 	self waitFor: [ aProcess isSuspended ]
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 MutexTest >> waitProcessTermination: aProcess [
 
 	self waitFor: [ aProcess isTerminated ]

--- a/src/Kernel-Tests-Extended/NumberTest.extension.st
+++ b/src/Kernel-Tests-Extended/NumberTest.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #NumberTest }
+Extension { #name : 'NumberTest' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 NumberTest >> testPercent [
 	self assert: 20 / 40 equals: 50 percent
 ]

--- a/src/Kernel-Tests-Extended/ProcessTest.class.st
+++ b/src/Kernel-Tests-Extended/ProcessTest.class.st
@@ -2,12 +2,14 @@
 A ProcessTest holds test cases for generic Process-related behaviour.
 "
 Class {
-	#name : #ProcessTest,
-	#superclass : #TestCase,
-	#category : #'Kernel-Tests-Extended-Processes'
+	#name : 'ProcessTest',
+	#superclass : 'TestCase',
+	#category : 'Kernel-Tests-Extended-Processes',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Processes'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> expectedFailures [
 	^#("these two tests fail after fixing the root cause of an unwind error in Process>>terminate"
 		#testIsTerminatingForcedTermination
@@ -15,14 +17,14 @@ ProcessTest >> expectedFailures [
 	)
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ProcessTest >> setUp [
 	super setUp.
 
 	self executionProcessMonitor disable
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testActiveProcessFromProcesor [
 
 	| processFromProcessor activeProcess |
@@ -31,7 +33,7 @@ ProcessTest >> testActiveProcessFromProcesor [
 	self assert: processFromProcessor identicalTo: activeProcess
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testActiveProcessFromProcesorShouldUseInstalledEffectiveProcess [
 
 	| processFromProcessor activeProcess effectiveProcess |
@@ -45,7 +47,7 @@ ProcessTest >> testActiveProcessFromProcesorShouldUseInstalledEffectiveProcess [
 	self assert: processFromProcessor identicalTo: effectiveProcess
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testChangingPriorityRespectsTheProcessPreemptionSettings [
 	"test whether #priority: preempts active process to allow higher priority processes run;
 	#priority behavior reflects the processPreemptionYields setting - for false the active
@@ -64,7 +66,7 @@ ProcessTest >> testChangingPriorityRespectsTheProcessPreemptionSettings [
 	self assert: val equals: Smalltalk vm processPreemptionYields
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testChangingPriorityYieldsCurrentProcess [
 
 	| val highPriority |
@@ -81,7 +83,7 @@ ProcessTest >> testChangingPriorityYieldsCurrentProcess [
 	self assert: val equals: 2
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testFork [
 
 	| hasBlockRun block return checkAssert |
@@ -101,7 +103,7 @@ ProcessTest >> testFork [
 	self assert: hasBlockRun
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testForkAtHigherPriority [
 	| hasBlockRun |
 	hasBlockRun := false.
@@ -111,7 +113,7 @@ ProcessTest >> testForkAtHigherPriority [
 	self assert: hasBlockRun
 ]
 
-{ #category : #'tests - exception handlers' }
+{ #category : 'tests - exception handlers' }
 ProcessTest >> testInjectingExceptionHandlerFromProcessItself [
 	| error interceptedError process interrupted |
 	DefaultExecutionEnvironment beActive.
@@ -129,7 +131,7 @@ ProcessTest >> testInjectingExceptionHandlerFromProcessItself [
 	self assert: interrupted
 ]
 
-{ #category : #'tests - exception handlers' }
+{ #category : 'tests - exception handlers' }
 ProcessTest >> testInjectingExceptionHandlerIntoNotRunningProcess [
 	| error interceptedError process interrupted |
 	DefaultExecutionEnvironment beActive.
@@ -147,7 +149,7 @@ ProcessTest >> testInjectingExceptionHandlerIntoNotRunningProcess [
 	self assert: interrupted
 ]
 
-{ #category : #'tests - exception handlers' }
+{ #category : 'tests - exception handlers' }
 ProcessTest >> testInjectingExceptionHandlerIntoProcessWithArg [
 	| error interceptedError process interrupted processArg |
 	DefaultExecutionEnvironment beActive.
@@ -168,7 +170,7 @@ ProcessTest >> testInjectingExceptionHandlerIntoProcessWithArg [
 	self assert: processArg equals: #arg
 ]
 
-{ #category : #'tests - exception handlers' }
+{ #category : 'tests - exception handlers' }
 ProcessTest >> testInjectingExceptionHandlerIntoRunningProcess [
 	| error interceptedError process sema started interrupted |
 	DefaultExecutionEnvironment beActive.
@@ -194,7 +196,7 @@ ProcessTest >> testInjectingExceptionHandlerIntoRunningProcess [
 	self assert: interrupted
 ]
 
-{ #category : #'tests - exception handlers' }
+{ #category : 'tests - exception handlers' }
 ProcessTest >> testInjectingMultipleExceptionHandlersIntoNotRunningProcess [
 
 	| error process lastHandler firstHandler |
@@ -222,7 +224,7 @@ ProcessTest >> testInjectingMultipleExceptionHandlersIntoNotRunningProcess [
 	self assert: lastHandler
 ]
 
-{ #category : #'tests - exception handlers' }
+{ #category : 'tests - exception handlers' }
 ProcessTest >> testInjectingMultipleExceptionHandlersIntoRunningProcess [
 
 	| error process lastHandler firstHandler sema started |
@@ -254,7 +256,7 @@ ProcessTest >> testInjectingMultipleExceptionHandlersIntoRunningProcess [
 	self assert: lastHandler
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testIsNotSuspendedWhenItIsActiveProcess [
 
 	| semaphore suspended |
@@ -264,7 +266,7 @@ ProcessTest >> testIsNotSuspendedWhenItIsActiveProcess [
 	self deny: suspended
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testIsNotSuspendedWhenItIsRunningButNotActiveProcess [
 
 	| semaphore process |
@@ -275,7 +277,7 @@ ProcessTest >> testIsNotSuspendedWhenItIsRunningButNotActiveProcess [
 	self deny: process isSuspended
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testIsNotSuspendedWhenItIsTerminated [
 
 	| semaphore process |
@@ -286,7 +288,7 @@ ProcessTest >> testIsNotSuspendedWhenItIsTerminated [
 	self deny: process isSuspended
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testIsNotTerminatedWhenItIsInsideLastTerminationMethod [
 
 	| process processBody |
@@ -310,7 +312,7 @@ ProcessTest >> testIsNotTerminatedWhenItIsInsideLastTerminationMethod [
 	self deny: process isTerminated
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testIsNotTerminatedWhenItIsJustStartedByEnteringMainBlock [
 
 	| process processBody |
@@ -326,7 +328,7 @@ ProcessTest >> testIsNotTerminatedWhenItIsJustStartedByEnteringMainBlock [
 	self deny: process isTerminated
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testIsNotTerminatedWhenItIsNotStarted [
 
 	| process |
@@ -335,12 +337,12 @@ ProcessTest >> testIsNotTerminatedWhenItIsNotStarted [
 	self deny: process isTerminated
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testIsSelfEvaluating [
 	self assert: Processor printString equals: 'Processor'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testIsSuspendedWhenItIsNotStartedYet [
 
 	| process |
@@ -348,7 +350,7 @@ ProcessTest >> testIsSuspendedWhenItIsNotStartedYet [
 	self assert: process isSuspended
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testIsTerminatedAfterManualTermination [
 
 	| process |
@@ -359,7 +361,7 @@ ProcessTest >> testIsTerminatedAfterManualTermination [
 	self assert: process isTerminated
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testIsTerminatedAfterSelfTermination [
 
 	| process |
@@ -368,7 +370,7 @@ ProcessTest >> testIsTerminatedAfterSelfTermination [
 	self assert: process isTerminated
 ]
 
-{ #category : #'tests - termination' }
+{ #category : 'tests - termination' }
 ProcessTest >> testIsTerminatingForcedTermination [
 	| process unwound started terminator unwindChecks terminationSemaphore |
 	unwound := false.
@@ -422,7 +424,7 @@ ProcessTest >> testIsTerminatingForcedTermination [
 	self assert: terminator identicalTo: process
 ]
 
-{ #category : #'tests - termination' }
+{ #category : 'tests - termination' }
 ProcessTest >> testIsTerminatingForcedTerminationWithoutRunning [
 	| process unwound started terminator |
 	unwound := false.
@@ -458,7 +460,7 @@ ProcessTest >> testIsTerminatingForcedTerminationWithoutRunning [
 	self deny: terminator identicalTo: process
 ]
 
-{ #category : #'tests - termination' }
+{ #category : 'tests - termination' }
 ProcessTest >> testIsTerminatingNormalTermination [
 	| sem process unwound started terminator |
 	sem := Semaphore new.
@@ -487,7 +489,7 @@ ProcessTest >> testIsTerminatingNormalTermination [
 	self assert: terminator identicalTo: process
 ]
 
-{ #category : #'tests - creation' }
+{ #category : 'tests - creation' }
 ProcessTest >> testNewProcess [
 
 	| hasBlockRun block return |
@@ -505,7 +507,7 @@ ProcessTest >> testNewProcess [
 	self assert: return isSuspended
 ]
 
-{ #category : #'tests - creation' }
+{ #category : 'tests - creation' }
 ProcessTest >> testNewProcessWith [
 
 	| hasBlockRun block process passedArguments receivedArgument1 receivedArgument2 |
@@ -532,7 +534,7 @@ ProcessTest >> testNewProcessWith [
 	self assert: { receivedArgument1. receivedArgument2 } equals: passedArguments
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testNormalProcessCompletionWithLeftEffectiveProcess [
 
 	| effectiveProcess activeProcess |
@@ -547,7 +549,7 @@ ProcessTest >> testNormalProcessCompletionWithLeftEffectiveProcess [
 	effectiveProcess terminate
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testNormalProcessWithArgsCompletionWithLeftEffectiveProcess [
 
 	| effectiveProcess activeProcess |
@@ -565,7 +567,7 @@ ProcessTest >> testNormalProcessWithArgsCompletionWithLeftEffectiveProcess [
 	effectiveProcess terminate
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testRealActiveProcessFromProcesor [
 
 	| processFromProcessor activeProcess |
@@ -574,7 +576,7 @@ ProcessTest >> testRealActiveProcessFromProcesor [
 	self assert: processFromProcessor identicalTo: activeProcess
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testRealActiveProcessFromProcesorShouldIgnoreInstalledEffectiveProcess [
 
 	| processFromProcessor activeProcess effectiveProcess |
@@ -588,7 +590,7 @@ ProcessTest >> testRealActiveProcessFromProcesorShouldIgnoreInstalledEffectivePr
 	self assert: processFromProcessor identicalTo: activeProcess
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testSchedulingHigherPriorityServedFirst [
     "The first process to run will pass straight through the gate
     while the other waits for the assert to whichRan."
@@ -611,7 +613,7 @@ ProcessTest >> testSchedulingHigherPriorityServedFirst [
 	self assert: whichRan=11 description: 'First scheduled but lower priority should run after'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testSchedulingSamePriorityFirstComeFirstServed [
     "The first process to run will pass straight through the gate
     while the other waits for the assert to whichRan."
@@ -633,7 +635,7 @@ ProcessTest >> testSchedulingSamePriorityFirstComeFirstServed [
 	self assert: whichRan=2 description: 'Second scheduled process should run after'
 ]
 
-{ #category : #'tests - termination' }
+{ #category : 'tests - termination' }
 ProcessTest >> testTerminateActive [
 
 	| lastStatementEvaluated block1HasRun block2HasRun p1 p2 |
@@ -656,7 +658,7 @@ ProcessTest >> testTerminateActive [
 	self deny: lastStatementEvaluated
 ]
 
-{ #category : #'tests - creation' }
+{ #category : 'tests - creation' }
 ProcessTest >> testTerminateAnswersSelf [
 
 	| process |
@@ -672,7 +674,7 @@ ProcessTest >> testTerminateAnswersSelf [
 	self assert: process isTerminated
 ]
 
-{ #category : #'tests - termination' }
+{ #category : 'tests - termination' }
 ProcessTest >> testTerminationShouldProceedAllEnsureBlocksIfSomeWasFailed [
 
 	| ensureCalled process ensureFailure started unwindError |
@@ -695,7 +697,7 @@ ProcessTest >> testTerminationShouldProceedAllEnsureBlocksIfSomeWasFailed [
 	self assert: unwindError signalerContext sender exception equals: ensureFailure
 ]
 
-{ #category : #'tests - termination' }
+{ #category : 'tests - termination' }
 ProcessTest >> testTerminationShouldProceedEnsureBlocks [
 
 	| ensureCalled process semaphore |
@@ -710,7 +712,7 @@ ProcessTest >> testTerminationShouldProceedEnsureBlocks [
 	self assert: ensureCalled
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testYield [
 
 	| lowerHasRun lowerPriority same1HasRun same2HasRun |
@@ -728,7 +730,7 @@ ProcessTest >> testYield [
 	self deny: lowerHasRun
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 ProcessTest >> waitForProcessTermination: aProcess [
 	aProcess priority: Processor activePriority + 1.
 	[ aProcess isTerminated ] whileFalse: [ Processor yield ]

--- a/src/Kernel-Tests-Extended/ProtoObjectTest.extension.st
+++ b/src/Kernel-Tests-Extended/ProtoObjectTest.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #ProtoObjectTest }
+Extension { #name : 'ProtoObjectTest' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 ProtoObjectTest >> testPointersToCycle [
 
 	| myObject myArray myArray2 pointingObjects |

--- a/src/Kernel-Tests-Extended/RecursionStopperTest.extension.st
+++ b/src/Kernel-Tests-Extended/RecursionStopperTest.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #RecursionStopperTest }
+Extension { #name : 'RecursionStopperTest' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 RecursionStopperTest >> testThreadSafe [
 
 	self should: [ self threadSafe ] notTakeMoreThanMilliseconds: 10.

--- a/src/Kernel-Tests-Extended/ReferencedClassesTestClass.class.st
+++ b/src/Kernel-Tests-Extended/ReferencedClassesTestClass.class.st
@@ -1,20 +1,22 @@
 Class {
-	#name : #ReferencedClassesTestClass,
-	#superclass : #Object,
-	#category : #'Kernel-Tests-Extended-Classes'
+	#name : 'ReferencedClassesTestClass',
+	#superclass : 'Object',
+	#category : 'Kernel-Tests-Extended-Classes',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Classes'
 }
 
-{ #category : #methods }
+{ #category : 'methods' }
 ReferencedClassesTestClass >> methodReferencingDirectly [
 	^ Object
 ]
 
-{ #category : #methods }
+{ #category : 'methods' }
 ReferencedClassesTestClass >> methodReferencingInBlock [
 	^ [ OrderedCollection ]
 ]
 
-{ #category : #methods }
+{ #category : 'methods' }
 ReferencedClassesTestClass >> methodReferencingInNestedBlock [
 	^ [[[ Array ]]]
 ]

--- a/src/Kernel-Tests-Extended/ScaledDecimalTest.extension.st
+++ b/src/Kernel-Tests-Extended/ScaledDecimalTest.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #ScaledDecimalTest }
+Extension { #name : 'ScaledDecimalTest' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 ScaledDecimalTest >> testExactNthRoot [
 	| eight thousandth tenth two |
 	eight := 8.0s1.
@@ -13,7 +13,7 @@ ScaledDecimalTest >> testExactNthRoot [
 	self assert: (tenth class = thousandth class and: [ tenth scale = thousandth scale ])
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 ScaledDecimalTest >> testExactSqrt [
 	| four hundredth tenth two |
 	four := 4.0s1.
@@ -26,7 +26,7 @@ ScaledDecimalTest >> testExactSqrt [
 	self assert: (tenth class = hundredth class and: [ tenth scale = hundredth scale ])
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 ScaledDecimalTest >> testInexactNthRoot [
 	| tenth cubicRoot3 fifthRootTenth three |
 	three := 3.0s1.
@@ -39,7 +39,7 @@ ScaledDecimalTest >> testInexactNthRoot [
 	self deny: fifthRootTenth squared equals: tenth
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 ScaledDecimalTest >> testInexactSqrt [
 	| tenth sqrt3 sqrtTenth three |
 	three := 3.0s1.

--- a/src/Kernel-Tests-Extended/ScheduleTest.class.st
+++ b/src/Kernel-Tests-Extended/ScheduleTest.class.st
@@ -2,23 +2,25 @@
 SUnit tests for recurring schedules (class Schedule).
 "
 Class {
-	#name : #ScheduleTest,
-	#superclass : #ClassTestCase,
+	#name : 'ScheduleTest',
+	#superclass : 'ClassTestCase',
 	#instVars : [
 		'firstEvent',
 		'aSchedule',
 		'restoredTimeZone'
 	],
-	#category : #'Kernel-Tests-Extended-Chronology'
+	#category : 'Kernel-Tests-Extended-Chronology',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Chronology'
 }
 
-{ #category : #coverage }
+{ #category : 'coverage' }
 ScheduleTest >> classToBeTested [
 
 	^ Schedule
 ]
 
-{ #category : #coverage }
+{ #category : 'coverage' }
 ScheduleTest >> selectorsToBeIgnored [
 
 	| private |
@@ -27,7 +29,7 @@ ScheduleTest >> selectorsToBeIgnored [
 	^ super selectorsToBeIgnored, private
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ScheduleTest >> setUp [
  	 "Schedule is a type of Timespan representing repeated occurrences of the same event.
 	The beginning of the schedule is the first occurrence of the event.
@@ -53,14 +55,14 @@ ScheduleTest >> setUp [
 	aSchedule schedule: { Duration days: 1. Duration days: 6 }
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 ScheduleTest >> tearDown [
 
 	DateAndTime localTimeZone: restoredTimeZone.
 	super tearDown
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ScheduleTest >> testBetweenAndDoDisjointWithSchedule [
 	| count |
 	count := 0.
@@ -68,7 +70,7 @@ ScheduleTest >> testBetweenAndDoDisjointWithSchedule [
 	self assert: count equals: 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ScheduleTest >> testBetweenAndDoIncludedInSchedule [
 	| count |
 	count := 0.
@@ -76,7 +78,7 @@ ScheduleTest >> testBetweenAndDoIncludedInSchedule [
 	self assert: count equals: 8
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ScheduleTest >> testBetweenAndDoOverlappingSchedule [
 	| count |
 	count := 0.
@@ -84,7 +86,7 @@ ScheduleTest >> testBetweenAndDoOverlappingSchedule [
 	self assert: count equals: 8
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ScheduleTest >> testDateAndTimes [
 	| answer |
 	self assert: aSchedule dateAndTimes size equals: 104.
@@ -94,7 +96,7 @@ ScheduleTest >> testDateAndTimes [
 	self assert: answer
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ScheduleTest >> testDaysOfWeekAreConsistent [
 	| originalDayOfWeekSet modifiedDayOfWeekSet start end |
 	originalDayOfWeekSet := (aSchedule dateAndTimes collect: [ :each | each dayOfWeek ]) asSet.
@@ -115,7 +117,7 @@ ScheduleTest >> testDaysOfWeekAreConsistent [
 	self assert: originalDayOfWeekSet equals: modifiedDayOfWeekSet asSet
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ScheduleTest >> testExampleFromSwikiPage [
 	"It is often neccessary to schedule repeated events, like airline flight schedules, TV programmes, and file backups.
 	 Schedule is a Timespan which maintains an array of Durations.
@@ -133,7 +135,7 @@ ScheduleTest >> testExampleFromSwikiPage [
 	shows dateAndTimes collect: [ :dt | dt dayOfWeekName ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ScheduleTest >> testFromDateAndTime [
 	| oc1 oc2 |
 	oc1 := OrderedCollection new.
@@ -144,12 +146,12 @@ ScheduleTest >> testFromDateAndTime [
 	self assert: oc1 asArray equals: oc2
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ScheduleTest >> testIncludes [
 	self assert: (aSchedule includes: (DateAndTime year: 2003 month: 6 day: 15 hour: 20 minute: 30 second: 0 offset: 0 hours))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ScheduleTest >> testMonotonicity [
 
 	| t1 t2 t3 t4 |
@@ -164,7 +166,7 @@ ScheduleTest >> testMonotonicity [
 		assert: (	t3 <= t4)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ScheduleTest >> testSchedule [
 	self assert: aSchedule schedule size equals: 2.
 	self assert: aSchedule schedule first equals: 1 days.

--- a/src/Kernel-Tests-Extended/SemaphoreTest.extension.st
+++ b/src/Kernel-Tests-Extended/SemaphoreTest.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #SemaphoreTest }
+Extension { #name : 'SemaphoreTest' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 SemaphoreTest >> testWaitAndWaitTimeoutTogether [
 	| semaphore value waitProcess waitTimeoutProcess |
 	semaphore := Semaphore new.

--- a/src/Kernel-Tests-Extended/SharedPoolTest.extension.st
+++ b/src/Kernel-Tests-Extended/SharedPoolTest.extension.st
@@ -1,13 +1,13 @@
-Extension { #name : #SharedPoolTest }
+Extension { #name : 'SharedPoolTest' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 SharedPoolTest >> testPoolUsers [
 	| result |
 	result := ChronologyConstants poolUsers.
 	self assert: result asSet equals: {Date. DateAndTime. Duration. Month. Time. TimeZone. Week. LocalTimeZone . AbstractTimeZone. ExampleForTestWithSharedPool } asSet
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 SharedPoolTest >> testmethodsAccessingPoolVariables [
 	| result |
 	result := ChronologyConstants methodsAccessingPoolVariables.
@@ -17,7 +17,7 @@ SharedPoolTest >> testmethodsAccessingPoolVariables [
 	self deny: (result includes: ClassTest>>#testSharedPoolOfVarNamed)
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 SharedPoolTest >> testusingMethods [
 	| result |
 	result := ChronologyConstants usingMethods.

--- a/src/Kernel-Tests-Extended/SizeInMemoryTest.class.st
+++ b/src/Kernel-Tests-Extended/SizeInMemoryTest.class.st
@@ -2,12 +2,14 @@
 SUnit tests for the size of objects in memory
 "
 Class {
-	#name : #SizeInMemoryTest,
-	#superclass : #TestCase,
-	#category : #'Kernel-Tests-Extended-Objects'
+	#name : 'SizeInMemoryTest',
+	#superclass : 'TestCase',
+	#category : 'Kernel-Tests-Extended-Objects',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Objects'
 }
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 SizeInMemoryTest >> align64Bits: size [
 
 	^ size % 8 = 0
@@ -15,13 +17,13 @@ SizeInMemoryTest >> align64Bits: size [
 		  ifFalse: [ size + 8 - (size % 8) ]
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 SizeInMemoryTest >> headerSize [
 	" The header is 64 bits"
 	^ 8
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 SizeInMemoryTest >> paddedByteStringSize: numberOfChars [
 	"64 bits for the header"
 	| originalSize  |
@@ -30,7 +32,7 @@ SizeInMemoryTest >> paddedByteStringSize: numberOfChars [
 	^ self align64Bits: originalSize
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SizeInMemoryTest >> testSizeInMemoryCompactClasses [
 	self skip.
 	"One word for the header + one word per instance variable"
@@ -40,7 +42,7 @@ SizeInMemoryTest >> testSizeInMemoryCompactClasses [
 	self assert: Rectangle new sizeInMemory equals: 12
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SizeInMemoryTest >> testSizeInMemoryLargeInstances [
 	"64 bits for the object header + a world per instance variable"
 
@@ -50,7 +52,7 @@ SizeInMemoryTest >> testSizeInMemoryLargeInstances [
 			equals: (self align64Bits: self headerSize + (Smalltalk allClasses asArray size * Smalltalk wordSize) + self headerSize)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SizeInMemoryTest >> testSizeInMemoryNormalClasses [
 	"Two word for the header + one word per instance variable"
 
@@ -60,7 +62,7 @@ SizeInMemoryTest >> testSizeInMemoryNormalClasses [
 	self assert: TestCase new sizeInMemory equals: (self align64Bits: 2 * Smalltalk wordSize + self headerSize)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SizeInMemoryTest >> testSizeInMemoryOfByteObjects [
 	"Byte objects should be padded to words"
 	self assert: 'a' sizeInMemory equals: (self paddedByteStringSize: 1).
@@ -70,7 +72,7 @@ SizeInMemoryTest >> testSizeInMemoryOfByteObjects [
 	self assert: 'abcdefghi' sizeInMemory equals: (self paddedByteStringSize: 9)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SizeInMemoryTest >> testSizeInMemoryOfCharacters [
 	self assert: 0 asCharacter sizeInMemory isZero.
 	self assert: 255 asCharacter sizeInMemory isZero.
@@ -78,7 +80,7 @@ SizeInMemoryTest >> testSizeInMemoryOfCharacters [
 	self assert: 16r10FFFF asCharacter sizeInMemory isZero
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SizeInMemoryTest >> testSizeInMemorySmallIntegers [
 	self assert: SmallInteger minVal sizeInMemory isZero.
 	self assert: 0 sizeInMemory isZero.

--- a/src/Kernel-Tests-Extended/StopwatchTest.class.st
+++ b/src/Kernel-Tests-Extended/StopwatchTest.class.st
@@ -2,27 +2,29 @@
 SUnit tests for the stopwatch 
 "
 Class {
-	#name : #StopwatchTest,
-	#superclass : #ClassTestCase,
+	#name : 'StopwatchTest',
+	#superclass : 'ClassTestCase',
 	#instVars : [
 		'aStopwatch',
 		'aDelay'
 	],
-	#category : #'Kernel-Tests-Extended-Chronology'
+	#category : 'Kernel-Tests-Extended-Chronology',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Chronology'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 StopwatchTest class >> isUnitTest [
 	^false
 ]
 
-{ #category : #coverage }
+{ #category : 'coverage' }
 StopwatchTest >> classToBeTested [
 
 	^ Stopwatch
 ]
 
-{ #category : #coverage }
+{ #category : 'coverage' }
 StopwatchTest >> selectorsToBeIgnored [
 
 	| private |
@@ -31,14 +33,14 @@ StopwatchTest >> selectorsToBeIgnored [
 	^ super selectorsToBeIgnored, private
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 StopwatchTest >> setUp [
 	super setUp.
 	aStopwatch := Stopwatch new.
 	aDelay := Delay forMilliseconds: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 StopwatchTest >> testChangingStatus [
 	aStopwatch activate.
 	self assert: aStopwatch isActive.
@@ -55,14 +57,14 @@ StopwatchTest >> testChangingStatus [
 	self assert: aStopwatch timespans size equals: 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 StopwatchTest >> testInitialStatus [
 	self assert: aStopwatch isSuspended.
 	self deny: aStopwatch isActive.
 	self assert: aStopwatch duration equals: 0 seconds
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 StopwatchTest >> testMultipleTimings [
 	aStopwatch activate.
 	aDelay wait.
@@ -74,7 +76,7 @@ StopwatchTest >> testMultipleTimings [
 	self assert: aStopwatch timespans first asDateAndTime <= aStopwatch timespans last asDateAndTime
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 StopwatchTest >> testNew [
 	| sw |
 	sw := Stopwatch new.
@@ -86,12 +88,12 @@ StopwatchTest >> testNew [
 		assertEmpty: sw timespans
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 StopwatchTest >> testPrintOn [
 	self assert: (String streamContents: [ :str | aStopwatch printOn: str ]) equals: 'a Stopwatch(suspended:0:00:00:00)'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 StopwatchTest >> testReActivate [
 
 	| sw |
@@ -105,7 +107,7 @@ StopwatchTest >> testReActivate [
 		assert: (sw isActive)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 StopwatchTest >> testReset [
 	| sw |
 	sw := Stopwatch new.
@@ -117,7 +119,7 @@ StopwatchTest >> testReset [
 		assertEmpty: sw timespans
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 StopwatchTest >> testSingleTiming [
 	| timeBefore |
 	timeBefore := DateAndTime now.
@@ -129,7 +131,7 @@ StopwatchTest >> testSingleTiming [
 	self assert: aStopwatch timespans first asDateAndTime <= aStopwatch end
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 StopwatchTest >> testStartStop [
 	| sw t1 t2 t3 t4 |
 	sw := Stopwatch new.

--- a/src/Kernel-Tests-Extended/SuperClassUsedInInstructionStreamTest.class.st
+++ b/src/Kernel-Tests-Extended/SuperClassUsedInInstructionStreamTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SuperClassUsedInInstructionStreamTest,
-	#superclass : #Object,
-	#category : #'Kernel-Tests-Extended-Methods'
+	#name : 'SuperClassUsedInInstructionStreamTest',
+	#superclass : 'Object',
+	#category : 'Kernel-Tests-Extended-Methods',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Methods'
 }
 
-{ #category : #examples }
+{ #category : 'examples' }
 SuperClassUsedInInstructionStreamTest >> aSuperMethod: anInteger with: anotherInteger [
 
 	^ 42

--- a/src/Kernel-Tests-Extended/TimeTest.extension.st
+++ b/src/Kernel-Tests-Extended/TimeTest.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #TimeTest }
+Extension { #name : 'TimeTest' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 TimeTest >> testNanoConstructor [
 	| timeFromString timeFromNano timeFromNanoSecond |
 	timeFromString := Time fromString: '01:23:45.67809'.

--- a/src/Kernel-Tests-Extended/TimespanDoSpanAYearTest.class.st
+++ b/src/Kernel-Tests-Extended/TimespanDoSpanAYearTest.class.st
@@ -6,17 +6,19 @@ aDuration = 91 days
 aTimeSpan= 91 days, starting December 25, 2004, midnight
 "
 Class {
-	#name : #TimespanDoSpanAYearTest,
-	#superclass : #TestCase,
+	#name : 'TimespanDoSpanAYearTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'aTimespan',
 		'aDuration',
 		'aDate'
 	],
-	#category : #'Kernel-Tests-Extended-Chronology'
+	#category : 'Kernel-Tests-Extended-Chronology',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Chronology'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 TimespanDoSpanAYearTest >> setUp [
 	super setUp.
 	aDate := DateAndTime year: 2004 month: 12 day: 25 hour: 0 minute: 0 second: 0.
@@ -25,7 +27,7 @@ TimespanDoSpanAYearTest >> setUp [
 	aTimespan := Timespan starting: aDate duration: aDuration
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 TimespanDoSpanAYearTest >> testMonthsDo [
 	| monthArray |
 	monthArray := Array
@@ -37,7 +39,7 @@ TimespanDoSpanAYearTest >> testMonthsDo [
 	self assert: aTimespan months equals: monthArray
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 TimespanDoSpanAYearTest >> testNext [
 	self
 		assert: aTimespan next
@@ -54,7 +56,7 @@ TimespanDoSpanAYearTest >> testNext [
 				duration: aDuration)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 TimespanDoSpanAYearTest >> testWeeksDo [
 	| weeks weekArray |
 	weeks := aTimespan weeks.
@@ -71,7 +73,7 @@ TimespanDoSpanAYearTest >> testWeeksDo [
 	self assert: aTimespan weeks equals: weekArray
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 TimespanDoSpanAYearTest >> testYearsDo [
 	| yearArray |
 	yearArray := Array

--- a/src/Kernel-Tests-Extended/TimespanDoTest.extension.st
+++ b/src/Kernel-Tests-Extended/TimespanDoTest.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #TimespanDoTest }
+Extension { #name : 'TimespanDoTest' }
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 TimespanDoTest >> testMonthsDo [
 	| monthArray |
 	monthArray := Array
@@ -11,7 +11,7 @@ TimespanDoTest >> testMonthsDo [
 	self assert: aTimespan months equals: monthArray
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 TimespanDoTest >> testWeeksDo [
 	| weekArray |
 	weekArray := OrderedCollection new.
@@ -20,7 +20,7 @@ TimespanDoTest >> testWeeksDo [
 	self assert: aTimespan weeks equals: weekArray
 ]
 
-{ #category : #'*Kernel-Tests-Extended' }
+{ #category : '*Kernel-Tests-Extended' }
 TimespanDoTest >> testYearsDo [
 	| yearArray |
 	yearArray := Array with: (Year starting: (DateAndTime year: 2003 day: 7) duration: 365 days).

--- a/src/Kernel-Tests-Extended/UnicodeTest.class.st
+++ b/src/Kernel-Tests-Extended/UnicodeTest.class.st
@@ -5,20 +5,22 @@ Note that the correctness of the table is not checked.
 It probebably should be, but that is another task. 
 "
 Class {
-	#name : #UnicodeTest,
-	#superclass : #TestCase,
+	#name : 'UnicodeTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'unicodeGenerator'
 	],
-	#category : #'Kernel-Tests-Extended-Charset'
+	#category : 'Kernel-Tests-Extended-Charset',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Charset'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicodeTest class >> resources [
 	^ { UnicodeTestRNG }
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 UnicodeTest class >> unicodeCategoryTableLookup: codePoint [
 	| index table |
 	index := codePoint + 1.
@@ -28,18 +30,18 @@ UnicodeTest class >> unicodeCategoryTableLookup: codePoint [
 		ifFalse: [ table at: index ]
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 UnicodeTest >> aRandomSelectionOfCharactersDo: aBlock [
 	self aRandomSelectionOfCodePointsDo: [ :cp | aBlock value: (Character codePoint: cp) ]
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 UnicodeTest >> aRandomSelectionOfCodePointsDo: aBlock [
 	0 to: 255 do: [ :cp | aBlock value: cp].
 	500 timesRepeat: [ aBlock value: (unicodeGenerator randomCodePointAtOrAbove: 256) ]
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 UnicodeTest >> checkCorrespondanceOf: aSelector and: aCategoryTag [
 	| cat methodAnswer catFromTable |
 	cat := Unicode classPool at: aCategoryTag.
@@ -57,75 +59,75 @@ UnicodeTest >> checkCorrespondanceOf: aSelector and: aCategoryTag [
 								, 'disagree at U+' , cp asHexString ] ]
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 UnicodeTest >> setUp [
 	super setUp.
 	unicodeGenerator := UnicodeTestRNG current
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsCasedLetter [
 	"The Cased letter category, LC, is empty"
 	self aRandomSelectionOfCharactersDo: [ :ch |
 		self deny: (Unicode isCasedLetter: ch) ]
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsClosePunctuation [
 	self checkCorrespondanceOf: #isClosePunctuation: and: #Pe
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsConnectorPunctuation [
 	self checkCorrespondanceOf: #isConnectorPunctuation: and: #Pc
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsControlOther [
 	self checkCorrespondanceOf: #isControlOther: and: #Cc
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsCurrencySymbol [
 	self checkCorrespondanceOf: #isCurrencySymbol: and: #Sc
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsDashPunctuation [
 	self checkCorrespondanceOf: #isDashPunctuation: and: #Pd
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsDecimalDigit [
 	self checkCorrespondanceOf: #isDecimalDigit: and: #Nd
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsDigit [
 	self checkCorrespondanceOf: #isDigit: and: #Nd
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsEnclosingMark [
 	self checkCorrespondanceOf: #isEnclosingMark: and: #Me
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsFinalQuote [
 	self checkCorrespondanceOf: #isFinalQuote: and: #Pf
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsFormatOther [
 	self checkCorrespondanceOf: #isFormatOther: and: #Cf
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsInitialQuote [
 	self checkCorrespondanceOf: #isInitialQuote: and: #Pi
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsLetter [
 	| letterCategories methodAnswer catFromTable |
 	letterCategories := #(Ll Lm Lo Lt Lu) collect: [ :c | Unicode classPool at: c ].
@@ -135,109 +137,109 @@ UnicodeTest >> testIsLetter [
 			self assert: methodAnswer equals: (letterCategories includes: catFromTable) ]
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsLetterModifier [
 	self checkCorrespondanceOf: #isLetterModifier: and: #Lm
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsLetterNumber [
 	self checkCorrespondanceOf: #isLetterNumber: and: #Nl
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsLineSeparator [
 	self checkCorrespondanceOf: #isLineSeparator: and: #Zl
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsLowercase [
 	self checkCorrespondanceOf: #isLowercase: and: #Ll
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsMathSymbol [
 	self checkCorrespondanceOf: #isMathSymbol: and: #Sm
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsModifierSymbol [
 	self checkCorrespondanceOf: #isModifierSymbol: and: #Sk
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsNonspacingMark [
 	self checkCorrespondanceOf: #isNonspacingMark: and: #Mn
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsOpenPunctuation [
 	self checkCorrespondanceOf: #isOpenPunctuation: and: #Ps
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsOtherLetter [
 	self checkCorrespondanceOf: #isOtherLetter: and: #Lo
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsOtherNumber [
 	self checkCorrespondanceOf: #isOtherNumber: and: #No
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsOtherPunctuation [
 	self checkCorrespondanceOf: #isOtherPunctuation: and: #Po
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsOtherSymbol [
 	self checkCorrespondanceOf: #isOtherSymbol: and: #So
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsParagraphSeparator [
 	self checkCorrespondanceOf: #isParagraphSeparator: and: #Zp
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsPrivateOther [
 	self checkCorrespondanceOf: #isPrivateOther: and: #Co
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsSpaceSeparator [
 	self checkCorrespondanceOf: #isSpaceSeparator: and: #Zs
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsSpacingCombiningMark [
 	self checkCorrespondanceOf: #isSpacingCombiningMark: and: #Mc
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsSurrogateOther [
 	self checkCorrespondanceOf: #isSurrogateOther: and: #Cs
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsTitlecaseLetter [
 	self checkCorrespondanceOf: #isTitlecaseLetter: and: #Lt
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testIsUppercase [
 	self checkCorrespondanceOf: #isUppercase: and: #Lu
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testNonCharacterNegative [
 	self aRandomSelectionOfCharactersDo: [  :ch |
 		self deny: (Unicode isNonCharacter: ch)
 	]
 ]
 
-{ #category : #'tests - categorization' }
+{ #category : 'tests - categorization' }
 UnicodeTest >> testNonCharacterPositive [
 	| nonCps |
 	nonCps := (16rFDD0 to: 16rFDEF) asSet.
@@ -247,7 +249,7 @@ UnicodeTest >> testNonCharacterPositive [
 	nonCps do: [ :each | self assert: (Unicode isNonCharacter: (Character codePoint: each)) ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 UnicodeTest >> testRNG [
 	| chars uniqueCount |
 	chars := (1 to: 100)
@@ -256,7 +258,7 @@ UnicodeTest >> testRNG [
 	self assert: uniqueCount = 100 description: (100 - uniqueCount) asString , ' duplicates'
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 UnicodeTest >> unicodeCategoryTableLookup: codePoint [
 
 	^self class unicodeCategoryTableLookup: codePoint

--- a/src/Kernel-Tests-Extended/UnicodeTestRNG.class.st
+++ b/src/Kernel-Tests-Extended/UnicodeTestRNG.class.st
@@ -2,50 +2,52 @@
 The random number generator used by the UnicodeTest
 "
 Class {
-	#name : #UnicodeTestRNG,
-	#superclass : #TestResource,
+	#name : 'UnicodeTestRNG',
+	#superclass : 'TestResource',
 	#instVars : [
 		'generator'
 	],
-	#category : #'Kernel-Tests-Extended-Charset'
+	#category : 'Kernel-Tests-Extended-Charset',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Charset'
 }
 
-{ #category : #private }
+{ #category : 'private' }
 UnicodeTestRNG >> generator [
 	^ generator
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 UnicodeTestRNG >> next [
 	^ generator next
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 UnicodeTestRNG >> randomCharacter [
 	^ self randomCharacterBetween: 0 and: Unicode maxValue
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 UnicodeTestRNG >> randomCharacterAtOrAbove: lower [
 	^ self randomCharacterBetween: lower and: Unicode maxValue
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 UnicodeTestRNG >> randomCharacterBetween: lower and: upper [
 	^ Character codePoint: (self randomCodePointBetween: lower and: upper)
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 UnicodeTestRNG >> randomCodePoint [
 	^ self randomCodePointBetween: 0 and: Unicode maxValue
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 UnicodeTestRNG >> randomCodePointAtOrAbove: lower [
 	^ self randomCodePointBetween: lower and: Unicode maxValue
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 UnicodeTestRNG >> randomCodePointBetween: lower and: upper [
 	| max span codePoint |
 	max := upper min: 16rE01EF.
@@ -57,7 +59,7 @@ UnicodeTestRNG >> randomCodePointBetween: lower and: upper [
 	^ codePoint
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 UnicodeTestRNG >> setUp [
 	super setUp.
 	generator := Random seed: 14159265

--- a/src/Kernel-Tests-Extended/ValueWithinFixTest.class.st
+++ b/src/Kernel-Tests-Extended/ValueWithinFixTest.class.st
@@ -2,12 +2,14 @@
 SUnit tests for a fix on #valueWithin:
 "
 Class {
-	#name : #ValueWithinFixTest,
-	#superclass : #TestCase,
-	#category : #'Kernel-Tests-Extended-Processes'
+	#name : 'ValueWithinFixTest',
+	#superclass : 'TestCase',
+	#category : 'Kernel-Tests-Extended-Processes',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Processes'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 ValueWithinFixTest >> testValueWithinNonLocalReturnFixReal [
 	"The real test for the fix is just as obscure as the original problem"
 
@@ -23,7 +25,7 @@ ValueWithinFixTest >> testValueWithinNonLocalReturnFixReal [
 	]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ValueWithinFixTest >> testValueWithinNonLocalReturnFixSimply [
 	"The simple version to test the fix"
 
@@ -31,7 +33,7 @@ ValueWithinFixTest >> testValueWithinNonLocalReturnFixSimply [
 	(Delay forMilliseconds: 50) wait
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ValueWithinFixTest >> testValueWithinTimingBasic [
 	"Test timing of valueWithin:onTimeout:"
 	| time |
@@ -42,7 +44,7 @@ ValueWithinFixTest >> testValueWithinTimingBasic [
 	self assert: time < 1000 milliSeconds
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ValueWithinFixTest >> testValueWithinTimingNestedInner [
 	"Test nested timing of valueWithin:onTimeout:"
 	| time |
@@ -55,7 +57,7 @@ ValueWithinFixTest >> testValueWithinTimingNestedInner [
 	self assert: time < 500 milliSeconds
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ValueWithinFixTest >> testValueWithinTimingNestedOuter [
 	"Test nested timing of valueWithin:onTimeout:"
 	| time |
@@ -70,7 +72,7 @@ ValueWithinFixTest >> testValueWithinTimingNestedOuter [
 	self assert: time < 5000 milliSeconds
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ValueWithinFixTest >> testValueWithinTimingRepeat [
 	"Test timing of valueWithin:onTimeout:"
 	| time |
@@ -82,7 +84,7 @@ ValueWithinFixTest >> testValueWithinTimingRepeat [
 	self assert: time < 500 milliSeconds
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ValueWithinFixTest >> valueWithinNonLocalReturn [
 	"Do a non-local return from a valueWithin: block"
 	[^self] valueWithin: 20 milliSeconds onTimeout:[]

--- a/src/Kernel-Tests-Extended/WeekTest.class.st
+++ b/src/Kernel-Tests-Extended/WeekTest.class.st
@@ -2,22 +2,24 @@
 SUnit tests for weeks
 "
 Class {
-	#name : #WeekTest,
-	#superclass : #ClassTestCase,
+	#name : 'WeekTest',
+	#superclass : 'ClassTestCase',
 	#instVars : [
 		'week',
 		'restoredStartDay'
 	],
-	#category : #'Kernel-Tests-Extended-Chronology'
+	#category : 'Kernel-Tests-Extended-Chronology',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Chronology'
 }
 
-{ #category : #coverage }
+{ #category : 'coverage' }
 WeekTest >> classToBeTested [
 
 	^ Week
 ]
 
-{ #category : #coverage }
+{ #category : 'coverage' }
 WeekTest >> selectorsToBeIgnored [
 
 	| deprecated private special |
@@ -29,7 +31,7 @@ WeekTest >> selectorsToBeIgnored [
 	^ super selectorsToBeIgnored, deprecated, private, special
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 WeekTest >> setUp [
 	"June 1998, 5th week"
 
@@ -39,7 +41,7 @@ WeekTest >> setUp [
 	week := Week starting: '4 July 1998' asDate
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 WeekTest >> tearDown [
 
 	Week startDay: restoredStartDay.
@@ -47,7 +49,7 @@ WeekTest >> tearDown [
 	super tearDown
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 WeekTest >> testByWeekNumber [
 	"Check some week dates, and check that the week starts on Monday
 	 even though Week >> startDay is set to Sunday in setUp."
@@ -68,18 +70,18 @@ WeekTest >> testByWeekNumber [
 	self assert: week start dayOfWeek equals: 2
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 WeekTest >> testByWeekNumberInCurrentYear [
 	week := Week week: 2.
 	self assert: week year asYear equals: Year current
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 WeekTest >> testDayNames [
 	self assert: Week dayNames equals: #(#Sunday #Monday #Tuesday #Wednesday #Thursday #Friday #Saturday)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 WeekTest >> testEnumerating [
 	| days |
 	days := OrderedCollection new.
@@ -90,7 +92,7 @@ WeekTest >> testEnumerating [
 	self assertEmpty: days
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 WeekTest >> testIndexOfDay [
 	| days |
 	days := #(#Sunday #Monday #Tuesday #Wednesday #Thursday #Friday #Saturday).
@@ -105,7 +107,7 @@ WeekTest >> testIndexOfDay [
 	self assert: (Week indexOfDay: #Sunnyday) equals: 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 WeekTest >> testInquiries [
 	self
 		assert: week start asDate equals: '28 June 1998' asDate;
@@ -114,7 +116,7 @@ WeekTest >> testInquiries [
 		assert: week duration equals: 7 days
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 WeekTest >> testNameOfDay [
 	| days |
 	days := #(#Sunday #Monday #Tuesday #Wednesday #Thursday #Friday #Saturday).
@@ -126,7 +128,7 @@ WeekTest >> testNameOfDay [
 	self should: [ Week nameOfDay: #Sunday ] raise: self defaultTestError
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 WeekTest >> testOffset [
 	"Check that the offset is maintained when creating a new instance of Month from a DateAndTime"
 
@@ -137,7 +139,7 @@ WeekTest >> testOffset [
 	self assert: newWeek asDateAndTime offset equals: dt offset
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 WeekTest >> testPreviousNext [
 	self
 		assert: week next equals: (Week starting: '6 July 1998' asDate);

--- a/src/Kernel-Tests-Extended/WriteBarrierAnotherStub.class.st
+++ b/src/Kernel-Tests-Extended/WriteBarrierAnotherStub.class.st
@@ -2,8 +2,8 @@
 Another stub for WriteBarrier to be used by tests
 "
 Class {
-	#name : #WriteBarrierAnotherStub,
-	#superclass : #Object,
+	#name : 'WriteBarrierAnotherStub',
+	#superclass : 'Object',
 	#instVars : [
 		'var1',
 		'var2',
@@ -16,72 +16,74 @@ Class {
 		'var9',
 		'var10'
 	],
-	#category : #'Kernel-Tests-Extended-WriteBarrier'
+	#category : 'Kernel-Tests-Extended-WriteBarrier',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'WriteBarrier'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WriteBarrierAnotherStub >> var1 [
 	^ var1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WriteBarrierAnotherStub >> var10 [
 	^ var10
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WriteBarrierAnotherStub >> var10: anObject [
 	var10 := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WriteBarrierAnotherStub >> var1: anObject [
 	var1 := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WriteBarrierAnotherStub >> var2 [
 
 	^ var2
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WriteBarrierAnotherStub >> var3 [
 
 	^ var3
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WriteBarrierAnotherStub >> var4 [
 
 	^ var4
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WriteBarrierAnotherStub >> var5 [
 
 	^ var5
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WriteBarrierAnotherStub >> var6 [
 
 	^ var6
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WriteBarrierAnotherStub >> var7 [
 
 	^ var7
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WriteBarrierAnotherStub >> var8 [
 
 	^ var8
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WriteBarrierAnotherStub >> var9 [
 
 	^ var9

--- a/src/Kernel-Tests-Extended/WriteBarrierStub.class.st
+++ b/src/Kernel-Tests-Extended/WriteBarrierStub.class.st
@@ -2,8 +2,8 @@
 A stub for WriteBarrier to be used by tests
 "
 Class {
-	#name : #WriteBarrierStub,
-	#superclass : #Object,
+	#name : 'WriteBarrierStub',
+	#superclass : 'Object',
 	#instVars : [
 		'var1',
 		'var2',
@@ -16,72 +16,74 @@ Class {
 		'var9',
 		'var10'
 	],
-	#category : #'Kernel-Tests-Extended-WriteBarrier'
+	#category : 'Kernel-Tests-Extended-WriteBarrier',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'WriteBarrier'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WriteBarrierStub >> var1 [
 	^ var1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WriteBarrierStub >> var10 [
 	^ var10
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WriteBarrierStub >> var10: anObject [
 	var10 := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WriteBarrierStub >> var1: anObject [
 	var1 := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WriteBarrierStub >> var2 [
 
 	^ var2
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WriteBarrierStub >> var3 [
 
 	^ var3
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WriteBarrierStub >> var4 [
 
 	^ var4
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WriteBarrierStub >> var5 [
 
 	^ var5
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WriteBarrierStub >> var6 [
 
 	^ var6
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WriteBarrierStub >> var7 [
 
 	^ var7
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WriteBarrierStub >> var8 [
 
 	^ var8
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WriteBarrierStub >> var9 [
 
 	^ var9

--- a/src/Kernel-Tests-Extended/WriteBarrierTest.class.st
+++ b/src/Kernel-Tests-Extended/WriteBarrierTest.class.st
@@ -6,32 +6,34 @@ My tests ensure the ReadOnly property of objects work properly.
 The VM needs to be compiled with -DIMMUTABILTY= true for those tests to work.
 "
 Class {
-	#name : #WriteBarrierTest,
-	#superclass : #TestCase,
+	#name : 'WriteBarrierTest',
+	#superclass : 'TestCase',
 	#classVars : [
 		'ContextInstance'
 	],
-	#category : #'Kernel-Tests-Extended-WriteBarrier'
+	#category : 'Kernel-Tests-Extended-WriteBarrier',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'WriteBarrier'
 }
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 WriteBarrierTest class >> initialize [
 
 	ContextInstance := Context sender: nil receiver: self new method: self >> #alwaysWritableObjects arguments: #()
 ]
 
-{ #category : #cleanup }
+{ #category : 'cleanup' }
 WriteBarrierTest class >> restartMethods [
    self initialize
 ]
 
-{ #category : #'guinea pigs' }
+{ #category : 'guinea pigs' }
 WriteBarrierTest >> alwaysReadOnlyObjects [
 	"Immediates are always immutable"
 	^ { 1 }
 ]
 
-{ #category : #'guinea pigs' }
+{ #category : 'guinea pigs' }
 WriteBarrierTest >> alwaysWritableObjects [
 	"Objects that currently can't be immutable"
 	^ { ContextInstance .
@@ -39,37 +41,37 @@ WriteBarrierTest >> alwaysWritableObjects [
 		Processor activeProcess }
 ]
 
-{ #category : #'guinea pigs' }
+{ #category : 'guinea pigs' }
 WriteBarrierTest >> maybeReadOnlyObjects [
 	"ByteObject, Variable object, fixed sized object"
 	^ { { 1 . 2 . 3 } asByteArray . { 1 . 2 . 3 } . (MessageSend receiver: 1 selector: #+ argument: 2) }
 ]
 
-{ #category : #'tests - proxy' }
+{ #category : 'tests - proxy' }
 WriteBarrierTest >> testBasicProxyReadOnly [
 	self alwaysReadOnlyObjects do: [ :each |
 		self assert: (MirrorPrimitives isObjectReadOnly: each) equals: true ]
 ]
 
-{ #category : #'tests - proxy' }
+{ #category : 'tests - proxy' }
 WriteBarrierTest >> testBasicProxyWritable [
 	self alwaysWritableObjects , self maybeReadOnlyObjects do: [ :each |
 		self assert: (MirrorPrimitives isObjectReadOnly: each) equals: false ]
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testBasicReadOnly [
 	self alwaysReadOnlyObjects do: [ :each |
 		self assert: each isReadOnlyObject equals: true ]
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testBasicWritable [
 	self alwaysWritableObjects , self maybeReadOnlyObjects do: [ :each |
 		self assert: each isReadOnlyObject equals: false ]
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testMutateByteArrayUsingByteAtPut [
 	| guineaPig |
 	guineaPig := ByteArray new: 5.
@@ -89,7 +91,7 @@ WriteBarrierTest >> testMutateByteArrayUsingByteAtPut [
 	self assert: guineaPig first equals: 12
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testMutateByteArrayUsingDoubleAtPut [
 	| guineaPig |
 	<expectedFailure>
@@ -110,7 +112,7 @@ WriteBarrierTest >> testMutateByteArrayUsingDoubleAtPut [
 	self assert: guineaPig first equals: (2 raisedTo: 65) asFloat
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testMutateByteArrayUsingFloatAtPut [
 	<expectedFailure>
 	| guineaPig |
@@ -131,7 +133,7 @@ WriteBarrierTest >> testMutateByteArrayUsingFloatAtPut [
 	self assert: guineaPig first equals: 1.0
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testMutateByteStringyUsingAtPut [
 	| guineaPig |
 	guineaPig := ByteString new: 5.
@@ -151,7 +153,7 @@ WriteBarrierTest >> testMutateByteStringyUsingAtPut [
 	self assert: guineaPig first equals: $h
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testMutateByteStringyUsingByteAtPut [
 	| guineaPig |
 	guineaPig := ByteString new: 5.
@@ -171,7 +173,7 @@ WriteBarrierTest >> testMutateByteStringyUsingByteAtPut [
 	self assert: guineaPig first asciiValue equals: 100
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testMutateByteSymbolUsingPrivateAtPut [
 	| guineaPig |
 	guineaPig := #hello.
@@ -183,7 +185,7 @@ WriteBarrierTest >> testMutateByteSymbolUsingPrivateAtPut [
 	self assert: guineaPig first equals: $h
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testMutateIVObject [
 	| guineaPig |
 	guineaPig := MessageSend new.
@@ -203,7 +205,7 @@ WriteBarrierTest >> testMutateIVObject [
 	self assert: guineaPig selector identicalTo: #+
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testMutateObjectClass [
 	| guineaPig |
 	guineaPig := WriteBarrierStub new.
@@ -222,7 +224,7 @@ WriteBarrierTest >> testMutateObjectClass [
 	self assert: guineaPig class equals: WriteBarrierAnotherStub
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testMutateObjectFirstInstVarWithManyVars [
 	| guineaPig failure |
 	guineaPig := WriteBarrierStub new.
@@ -232,7 +234,7 @@ WriteBarrierTest >> testMutateObjectFirstInstVarWithManyVars [
 	self assert: failure fieldIndex equals: 1
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testMutateObjectInstVarShouldCatchRightFailure [
 	| guineaPig failure |
 	guineaPig := MessageSend new.
@@ -246,7 +248,7 @@ WriteBarrierTest >> testMutateObjectInstVarShouldCatchRightFailure [
 	self assert: failure fieldIndex equals: 1
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testMutateObjectInstVarUsingAtPut [
 	| guineaPig |
 	guineaPig := Array new: 5.
@@ -266,7 +268,7 @@ WriteBarrierTest >> testMutateObjectInstVarUsingAtPut [
 	self assert: guineaPig first equals: #test
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testMutateObjectInstVarUsingBasicAtPut [
 	| guineaPig |
 	guineaPig := Array new: 5.
@@ -286,7 +288,7 @@ WriteBarrierTest >> testMutateObjectInstVarUsingBasicAtPut [
 	self assert: guineaPig first equals: #test
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testMutateObjectInstVarUsingInstVarAtPut [
 	| guineaPig |
 	guineaPig := WriteBarrierStub new.
@@ -306,7 +308,7 @@ WriteBarrierTest >> testMutateObjectInstVarUsingInstVarAtPut [
 	self assert: guineaPig var1 equals: #test
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testMutateObjectLastInstVarWithManyVars [
 	| guineaPig failure |
 	guineaPig := WriteBarrierStub new.
@@ -316,7 +318,7 @@ WriteBarrierTest >> testMutateObjectLastInstVarWithManyVars [
 	self assert: failure fieldIndex equals: 10
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testMutateVariableObject [
 	| guineaPigs |
 	guineaPigs := {#[1 2 3] copy . #(1 2 3) copy}.
@@ -338,7 +340,7 @@ WriteBarrierTest >> testMutateVariableObject [
 			self assert: guineaPig third equals: 3 ]
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testMutateWideStringUsingAtPut [
 	| guineaPig |
 	guineaPig := 'hello' asWideString.
@@ -358,7 +360,7 @@ WriteBarrierTest >> testMutateWideStringUsingAtPut [
 	self assert: guineaPig first equals: $q
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testMutateWideStringUsingWordAtPut [
 	| guineaPig |
 	guineaPig := 'hello' asWideString.
@@ -378,7 +380,7 @@ WriteBarrierTest >> testMutateWideStringUsingWordAtPut [
 	self assert: guineaPig first asciiValue equals: 65536
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testMutateWideSymbolUsingPrivateAtPut [
 	| guineaPig |
 	[ guineaPig := ('hello', (Character codePoint: 8002) asString) asSymbol.
@@ -392,7 +394,7 @@ WriteBarrierTest >> testMutateWideSymbolUsingPrivateAtPut [
 	self assert: guineaPig first  equals: $h
 ]
 
-{ #category : #'tests - helper' }
+{ #category : 'tests - helper' }
 WriteBarrierTest >> testObject: object initialState: initialState tuples: tuples [
 	self
 		testObject: object
@@ -401,7 +403,7 @@ WriteBarrierTest >> testObject: object initialState: initialState tuples: tuples
 		setReadOnlyBlock: [ :value | object setIsReadOnlyObject: value ]
 ]
 
-{ #category : #'tests - helper' }
+{ #category : 'tests - helper' }
 WriteBarrierTest >> testObject: object initialState: initialState tuples: tuples setReadOnlyBlock: setImmutabilityBlock [
 	self assert: object isReadOnlyObject equals: initialState.
 	tuples do: [ :tuple |
@@ -415,7 +417,7 @@ WriteBarrierTest >> testObject: object initialState: initialState tuples: tuples
 		self assert: object isReadOnlyObject equals: expectedNewState ]
 ]
 
-{ #category : #'tests - helper' }
+{ #category : 'tests - helper' }
 WriteBarrierTest >> testProxyObject: object initialState: initialState tuples: tuples [
 	self
 		testObject: object
@@ -425,7 +427,7 @@ WriteBarrierTest >> testProxyObject: object initialState: initialState tuples: t
 			MirrorPrimitives makeObject: object readOnly: value ]
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testReadOnlyImmediate [
 	"immediate objects like SmallIntegers are read only"
 	self assert: 1 isReadOnlyObject.
@@ -433,7 +435,7 @@ WriteBarrierTest >> testReadOnlyImmediate [
 	self assert: 1 beReadOnlyObject
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testRetryingInstVarModification [
 	| guineaPig |
 	guineaPig := MessageSend new.
@@ -446,7 +448,7 @@ WriteBarrierTest >> testRetryingInstVarModification [
 	self assert: guineaPig receiver equals: 1
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testSetIsReadOnlyFailure [
 	self alwaysWritableObjects do: [ :each |
 		self
@@ -455,7 +457,7 @@ WriteBarrierTest >> testSetIsReadOnlyFailure [
 			tuples: #( (true false false) (false false false) ) ]
 ]
 
-{ #category : #'tests - proxy' }
+{ #category : 'tests - proxy' }
 WriteBarrierTest >> testSetIsReadOnlyFailureProxy [
 	self alwaysWritableObjects do: [ :each |
 		self
@@ -464,7 +466,7 @@ WriteBarrierTest >> testSetIsReadOnlyFailureProxy [
 			tuples: #( (true false false) (false false false) ) ]
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testSetIsReadOnlyImmediate [
 	self alwaysReadOnlyObjects do: [ :each |
 		self
@@ -473,7 +475,7 @@ WriteBarrierTest >> testSetIsReadOnlyImmediate [
 			tuples: #( (true true true) (false true true) ) ]
 ]
 
-{ #category : #'tests - proxy' }
+{ #category : 'tests - proxy' }
 WriteBarrierTest >> testSetIsReadOnlyImmediateProxy [
 	self alwaysReadOnlyObjects do: [ :each |
 		self
@@ -482,7 +484,7 @@ WriteBarrierTest >> testSetIsReadOnlyImmediateProxy [
 			tuples: #( (true true true) (false true true) ) ]
 ]
 
-{ #category : #'tests - object' }
+{ #category : 'tests - object' }
 WriteBarrierTest >> testSetIsReadOnlySuccess [
 	self maybeReadOnlyObjects do: [ :each |
 		self
@@ -491,7 +493,7 @@ WriteBarrierTest >> testSetIsReadOnlySuccess [
 			tuples: #( (true false true) (false true false) ) ]
 ]
 
-{ #category : #'tests - proxy' }
+{ #category : 'tests - proxy' }
 WriteBarrierTest >> testSetIsReadOnlySuccessProxy [
 	self maybeReadOnlyObjects do: [ :each |
 		self

--- a/src/Kernel-Tests-Extended/YearMonthWeekTest.class.st
+++ b/src/Kernel-Tests-Extended/YearMonthWeekTest.class.st
@@ -3,16 +3,18 @@ I am one of several Sunit test Cases intentended to provide complete coverage fo
 I have no fixtures but do make sure to restore anything I change.
 "
 Class {
-	#name : #YearMonthWeekTest,
-	#superclass : #TestCase,
+	#name : 'YearMonthWeekTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'restoredStartDay',
 		'restoredTimeZone'
 	],
-	#category : #'Kernel-Tests-Extended-Chronology'
+	#category : 'Kernel-Tests-Extended-Chronology',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Chronology'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 YearMonthWeekTest >> setUp [
 	super setUp.
 	restoredStartDay := Week startDay.
@@ -22,14 +24,14 @@ YearMonthWeekTest >> setUp [
 	DateAndTime localTimeZone: (TimeZone timeZones detect: [:tz | tz abbreviation = 'GMT'])
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 YearMonthWeekTest >> tearDown [
 	Week startDay: restoredStartDay.
 	DateAndTime localTimeZone: restoredTimeZone.
 	super tearDown
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 YearMonthWeekTest >> testDaysInMonth [
 	self assert: (Month daysInMonth: 2 forYear: 2000) equals: 29.
 	self assert: (Month daysInMonth: 2 forYear: 2001) equals: 28.
@@ -50,7 +52,7 @@ YearMonthWeekTest >> testDaysInMonth [
 	self assert: (Month daysInMonth: 'December' forYear: 2003) equals: 31
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 YearMonthWeekTest >> testDaysInYear [
 	self assert: (Year daysInYear: 2000) equals: 366.
 	self assert: (Year daysInYear: 2001) equals: 365.
@@ -59,12 +61,12 @@ YearMonthWeekTest >> testDaysInYear [
 	self assert: (Year daysInYear: 2003) equals: 365
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 YearMonthWeekTest >> testIndexOfDay [
 	self assert: (Week indexOfDay: 'Friday') equals: 6
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 YearMonthWeekTest >> testIsLeapYear [
 	self assert: (Year isLeapYear: 2000).
 	self deny: (Year isLeapYear: 2001).
@@ -73,14 +75,14 @@ YearMonthWeekTest >> testIsLeapYear [
 	self deny: (Year isLeapYear: 2002)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 YearMonthWeekTest >> testMonthPrintOn [
 	| aMonth |
 	aMonth := Month starting: DateAndTime new duration: 31 days.
 	self assert: (String streamContents: [ :str | aMonth printOn: str ]) equals: 'January 1901'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 YearMonthWeekTest >> testStartDay [
 	Week startDay: 'Wednesday'.
 	self assert: Week startDay equals: 'Wednesday'.
@@ -88,7 +90,7 @@ YearMonthWeekTest >> testStartDay [
 	self assert: Week startDay equals: 'Thursday'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 YearMonthWeekTest >> testWeekPrintOn [
 	| aWeek cs rw |
 	aWeek := Week starting: (DateAndTime year: 1900 month: 12 day: 31).
@@ -98,7 +100,7 @@ YearMonthWeekTest >> testWeekPrintOn [
 	self assert: rw contents equals: cs
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 YearMonthWeekTest >> testYearPrintOn [
 	| aYear |
 	aYear := Year starting: DateAndTime new duration: 365 days.

--- a/src/Kernel-Tests-Extended/YearTest.class.st
+++ b/src/Kernel-Tests-Extended/YearTest.class.st
@@ -2,18 +2,20 @@
 SUnit tests for year handling
 "
 Class {
-	#name : #YearTest,
-	#superclass : #ClassTestCase,
-	#category : #'Kernel-Tests-Extended-Chronology'
+	#name : 'YearTest',
+	#superclass : 'ClassTestCase',
+	#category : 'Kernel-Tests-Extended-Chronology',
+	#package : 'Kernel-Tests-Extended',
+	#tag : 'Chronology'
 }
 
-{ #category : #coverage }
+{ #category : 'coverage' }
 YearTest >> classToBeTested [
 
 	^ Year
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 YearTest >> testFirstThursday [
 
 	1800 to: 2000 do:
@@ -25,7 +27,7 @@ YearTest >> testFirstThursday [
 			self assert: (firstThursday - 1 week) year equals: y - 1 ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 YearTest >> testOffset [
 	"Check that the offset is maintained when creating a new instance of Month from a DateAndTime"
 
@@ -36,7 +38,7 @@ YearTest >> testOffset [
 	self assert: newYear asDateAndTime offset equals: dt offset
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 YearTest >> testPreviousInLeapYear [
 	| leap |
 	leap := Year year: 2008.
@@ -44,14 +46,14 @@ YearTest >> testPreviousInLeapYear [
 	self assert: (Year year: leap year - 1) equals: leap previous
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 YearTest >> testStart [
 	| yyyy |
 	yyyy := DateAndTime now year.
 	self assert: Year current start equals: (DateAndTime year: yyyy month: 1 day: 1)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 YearTest >> testcurrentYear [
 
 	| yyyy |
@@ -59,7 +61,7 @@ YearTest >> testcurrentYear [
 	self assert: Date today asYear equals: yyyy
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 YearTest >> testcurrentYearNumber [
 
 	| yyyy |
@@ -67,7 +69,7 @@ YearTest >> testcurrentYearNumber [
 	self assert: Date today year equals: yyyy
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 YearTest >> testdaysInMonth [
 
 	self assert: ((Year year: 2018) daysInMonth:1) equals: 31. "January"

--- a/src/Kernel-Tests-Extended/package.st
+++ b/src/Kernel-Tests-Extended/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Kernel-Tests-Extended' }
+Package { #name : 'Kernel-Tests-Extended' }

--- a/src/Kernel/Abort.class.st
+++ b/src/Kernel/Abort.class.st
@@ -2,7 +2,9 @@
 Notify to abort a task
 "
 Class {
-	#name : #Abort,
-	#superclass : #Exception,
-	#category : #'Kernel-Exceptions'
+	#name : 'Abort',
+	#superclass : 'Exception',
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }

--- a/src/Kernel/AbstractDelayTicker.class.st
+++ b/src/Kernel/AbstractDelayTicker.class.st
@@ -6,28 +6,30 @@ I supply /nextTick/ to the VM and wait for /timingSemaphore/ to be signalled.
 I read time-base specific ticks from the VM, and scale ticks around snapshot pauses.
 "
 Class {
-	#name : #AbstractDelayTicker,
-	#superclass : #Object,
-	#category : #'Kernel-Delays'
+	#name : 'AbstractDelayTicker',
+	#superclass : 'Object',
+	#category : 'Kernel-Delays',
+	#package : 'Kernel',
+	#tag : 'Delays'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 AbstractDelayTicker class >> isAbstract [
 
 	^ self == AbstractDelayTicker
 ]
 
-{ #category : #'api-system' }
+{ #category : 'api-system' }
 AbstractDelayTicker >> millisecondsUntilTick: delay [
 	self subclassResponsibility
 ]
 
-{ #category : #'api-system' }
+{ #category : 'api-system' }
 AbstractDelayTicker >> nowTick [
 	self subclassResponsibility
 ]
 
-{ #category : #'api-system' }
+{ #category : 'api-system' }
 AbstractDelayTicker >> restoreResumptionTimes: delaysOrNils [
 	"Private! Called only from the timing-priority process.
     Not performance critical."
@@ -40,7 +42,7 @@ AbstractDelayTicker >> restoreResumptionTimes: delaysOrNils [
 		delay ifNotNil: [delay resumptionTickAdjustFrom: 0 to: newBaseTick ]]
 ]
 
-{ #category : #'api-system' }
+{ #category : 'api-system' }
 AbstractDelayTicker >> saveResumptionTimes: delaysOrNils [
 	"Private! Called only from the timing-priority process.
     Not performance critical."
@@ -53,12 +55,12 @@ AbstractDelayTicker >> saveResumptionTimes: delaysOrNils [
 		delay ifNotNil: [delay resumptionTickAdjustFrom: oldBaseTick to: 0 ]]
 ]
 
-{ #category : #'api-system' }
+{ #category : 'api-system' }
 AbstractDelayTicker >> tickAfterMilliseconds: milliseconds [
 	self subclassResponsibility
 ]
 
-{ #category : #'api-system' }
+{ #category : 'api-system' }
 AbstractDelayTicker >> waitForUserSignalled: timingSemaphore orExpired: activeDelay [
 	self subclassResponsibility
 ]

--- a/src/Kernel/AbstractLayout.class.st
+++ b/src/Kernel/AbstractLayout.class.st
@@ -3,183 +3,185 @@ I'm a container for slots.
 
 "
 Class {
-	#name : #AbstractLayout,
-	#superclass : #Object,
+	#name : 'AbstractLayout',
+	#superclass : 'Object',
 	#instVars : [
 		'host'
 	],
-	#category : #'Kernel-Layout'
+	#category : 'Kernel-Layout',
+	#package : 'Kernel',
+	#tag : 'Layout'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 AbstractLayout class >> isAbstract [
 	^self == AbstractLayout
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 AbstractLayout >> = other [
 	^ self class = other class
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayout >> allSlots [
 	^ {}
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 AbstractLayout >> allSlotsDo: aBlock [
 	self slotScope allSlotsDo: aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayout >> allVisibleSlots [
 	^ {}
 ]
 
-{ #category : #validation }
+{ #category : 'validation' }
 AbstractLayout >> checkIntegrity [
 	self checkSanity
 ]
 
-{ #category : #validation }
+{ #category : 'validation' }
 AbstractLayout >> checkSanity [
 	host ifNil: [ self error: 'Host should not be nil' ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 AbstractLayout >> definesSlot: aSlot [
 	^self slots identityIncludes: aSlot
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayout >> extend: arg1 [
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayout >> extendByte [
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayout >> extendDoubleByte [
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayout >> extendDoubleWord [
 	^ self subclassResponsibility
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 AbstractLayout >> extendImmediate [
 	^ ImmediateLayout new
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayout >> extendVariable: arg1 [
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayout >> extendWord [
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayout >> fieldSize [
 	^ 0
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 AbstractLayout >> hasBindingThatBeginsWith: aString [
 	"Answer true if there is a Slot that begins with aString, false otherwise"
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 AbstractLayout >> hasFields [
 	^ false
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 AbstractLayout >> hasSlot: aSlot [
 	^ self allSlots identityIncludes: aSlot
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 AbstractLayout >> hasSlotNamed: aString [
 	"Return true whether the receiver defines an instance variable named aString.
 	this includs non-visible slots"
 	^self allSlots anySatisfy: [:slot | slot name = aString  ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 AbstractLayout >> hasSlots [
 	^ false
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 AbstractLayout >> hash [
 	^ self class hash
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayout >> host [
 	^ host
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayout >> host: aClass [
 	host := aClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayout >> instVarNames [
 	^ {}
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 AbstractLayout >> isBits [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 AbstractLayout >> isFixedLayout [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 AbstractLayout >> isVariable [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 AbstractLayout >> isWeak [
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayout >> resolveSlot: aName [
 	^SlotNotFound signalForName: aName
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 AbstractLayout >> resolveSlot: aName ifFound: foundBlock ifNone: exceptionBlock [
 	^exceptionBlock value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayout >> slotScope [
 	^ LayoutEmptyScope instance
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayout >> slots [
 	^ {}
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayout >> visibleSlots [
 	^self slots select: [:slot | slot isVisible]
 ]

--- a/src/Kernel/AbstractLayoutScope.class.st
+++ b/src/Kernel/AbstractLayoutScope.class.st
@@ -2,43 +2,45 @@
 Layout scopes reify how classes extend the layout of their superclass.
 "
 Class {
-	#name : #AbstractLayoutScope,
-	#superclass : #Object,
-	#category : #'Kernel-Layout'
+	#name : 'AbstractLayoutScope',
+	#superclass : 'Object',
+	#category : 'Kernel-Layout',
+	#package : 'Kernel',
+	#tag : 'Layout'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 AbstractLayoutScope class >> isAbstract [
 
 	^ self == AbstractLayoutScope
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 AbstractLayoutScope >> = other [
 	^ self class = other class
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 AbstractLayoutScope >> allSlotsDo: aBlock [
 	self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayoutScope >> allVisibleSlots [
 	^ self subclassResponsibility
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 AbstractLayoutScope >> extend [
 	^ self extend: { }
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 AbstractLayoutScope >> extend: someSlots [
 	^ self extend: someSlots as: LayoutClassScope
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 AbstractLayoutScope >> extend: someSlots as: type [
 	| scope fieldIndex  |
 	scope := type new: someSlots size.
@@ -54,53 +56,53 @@ AbstractLayoutScope >> extend: someSlots as: type [
 	^ scope
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayoutScope >> fieldSize [
 	self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayoutScope >> firstFieldIndex [
 	^ self fieldSize + 1
 ]
 
-{ #category : #flattening }
+{ #category : 'flattening' }
 AbstractLayoutScope >> flatten [
 
 	^ self flattenIn: OrderedCollection new
 ]
 
-{ #category : #flattening }
+{ #category : 'flattening' }
 AbstractLayoutScope >> flattenIn: aCollection [
 	self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayoutScope >> hasBindingThatBeginsWith: arg1 [
 	^ self subclassResponsibility
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 AbstractLayoutScope >> hasFields [
 	self subclassResponsibility
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 AbstractLayoutScope >> hasSlots [
 	self subclassResponsibility
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 AbstractLayoutScope >> hash [
 	^ self class hash
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 AbstractLayoutScope >> ifNotEmpty: aBlock [
 	self subclassResponsibility
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 AbstractLayoutScope >> indexOf: anElement [
 	"Answer the index of the first occurrence of anElement within the
 	receiver. If the receiver does not contain anElement, answer 0."
@@ -108,7 +110,7 @@ AbstractLayoutScope >> indexOf: anElement [
 	^ self indexOf: anElement ifAbsent: 0
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 AbstractLayoutScope >> indexOf: anElement ifAbsent: exceptionBlock [
 	"Answer the index of the first occurrence of anElement within the
 	receiver. If the receiver does not contain anElement, answer the
@@ -120,12 +122,12 @@ AbstractLayoutScope >> indexOf: anElement ifAbsent: exceptionBlock [
 	^ exceptionBlock value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayoutScope >> ownFieldSize [
 	self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayoutScope >> resolveSlot: aName [
 	^ self
 		resolveSlot: aName
@@ -133,19 +135,19 @@ AbstractLayoutScope >> resolveSlot: aName [
 		ifNone: [ SlotNotFound signalForName: aName ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayoutScope >> resolveSlot: aName ifFound: foundBlock ifNone: exceptionBlock [
 	self allSlotsDo: [ :slot |
 		slot name = aName ifTrue: [ ^ foundBlock cull: slot ]].
 	^ exceptionBlock value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayoutScope >> visibleSlotNames [
 	^self visibleSlots collect: [:each | each name ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractLayoutScope >> visibleSlots [
 	self subclassResponsibility
 ]

--- a/src/Kernel/AbstractTimeZone.class.st
+++ b/src/Kernel/AbstractTimeZone.class.st
@@ -5,31 +5,33 @@ See my subclasses for specific implementations.
 Timezones are used to encapsulate the offset from the Coordinated Univeral Time (UTC) used for proper Date and Time display and manipulations.
 "
 Class {
-	#name : #AbstractTimeZone,
-	#superclass : #Object,
+	#name : 'AbstractTimeZone',
+	#superclass : 'Object',
 	#pools : [
 		'ChronologyConstants'
 	],
-	#category : #'Kernel-Chronology'
+	#category : 'Kernel-Chronology',
+	#package : 'Kernel',
+	#tag : 'Chronology'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractTimeZone >> abbreviation [
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractTimeZone >> name [
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AbstractTimeZone >> offset [
 	"Return a duration representing the offset from UTC for this timezone"
 	self subclassResponsibility
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 AbstractTimeZone >> printOn: aStream [
 
  	super printOn: aStream.

--- a/src/Kernel/AdditionalBinding.class.st
+++ b/src/Kernel/AdditionalBinding.class.st
@@ -10,24 +10,26 @@ all associations are changed to be AdditionaBinding.
 AddionalBinding is used, too, by both Slots and Reflectivity to reference directly objects from generated code.
 "
 Class {
-	#name : #AdditionalBinding,
-	#superclass : #LiteralVariable,
-	#category : #'Kernel-Variables'
+	#name : 'AdditionalBinding',
+	#superclass : 'LiteralVariable',
+	#category : 'Kernel-Variables',
+	#package : 'Kernel',
+	#tag : 'Variables'
 }
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 AdditionalBinding >> emitStore: methodBuilder [
 
 	methodBuilder storeIntoLiteralVariable: self
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 AdditionalBinding >> emitValue: methodBuilder [
 
 	methodBuilder pushLiteralVariable: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 AdditionalBinding >> isReferenced [
 	^ false
 ]

--- a/src/Kernel/AdditionalMethodState.class.st
+++ b/src/Kernel/AdditionalMethodState.class.st
@@ -3,17 +3,19 @@ I am class holding state for compiled methods. All my instance variables should 
 I am a reimplementation of much of MethodProperties, but eliminating the explicit properties and pragmas dictionaries.  Hence I answer true to isMethodProperties.
 "
 Class {
-	#name : #AdditionalMethodState,
-	#superclass : #Object,
-	#type : #variable,
+	#name : 'AdditionalMethodState',
+	#superclass : 'Object',
+	#type : 'variable',
 	#instVars : [
 		'method',
 		'selector'
 	],
-	#category : #'Kernel-Methods'
+	#category : 'Kernel-Methods',
+	#package : 'Kernel',
+	#tag : 'Methods'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 AdditionalMethodState class >> forMethod: aMethod selector: aSelector [
 	^(self new: 0)
 		selector: aSelector;
@@ -21,19 +23,19 @@ AdditionalMethodState class >> forMethod: aMethod selector: aSelector [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 AdditionalMethodState class >> forSelector: aSelector [
 	^(self new: 0)
 		selector: aSelector;
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 AdditionalMethodState class >> new [
 	^ self new: 0
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 AdditionalMethodState class >> selector: aSelector with: aPropertyOrPragma [
 	^(self new: 1)
 		selector: aSelector;
@@ -41,7 +43,7 @@ AdditionalMethodState class >> selector: aSelector with: aPropertyOrPragma [
 		yourself
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 AdditionalMethodState >> analogousCodeTo: aMethodProperties [
 	| bs |
 	self class == aMethodProperties class ifFalse:
@@ -55,14 +57,14 @@ AdditionalMethodState >> analogousCodeTo: aMethodProperties [
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AdditionalMethodState >> at: aKey [
 	"Answer the property value or pragma associated with aKey."
 
 	^self at: aKey ifAbsent: [self error: 'not found']
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AdditionalMethodState >> at: aKey ifAbsent: aBlock [
 	"Answer the property value or pragma associated with aKey or,
 	 if aKey isn't found, answer the result of evaluating aBlock."
@@ -77,7 +79,7 @@ AdditionalMethodState >> at: aKey ifAbsent: aBlock [
 	^aBlock value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AdditionalMethodState >> at: aKey ifAbsentPut: aBlock [
 	"Answer the property value or pragma associated with aKey or,
 	 if aKey isn't found, answer the result of evaluating aBlock."
@@ -92,13 +94,13 @@ AdditionalMethodState >> at: aKey ifAbsentPut: aBlock [
 	^method propertyAt: aKey put: aBlock value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AdditionalMethodState >> at: aKey ifPresent: aBlock [
 	"Lookup the given key in the receiver. If it is present, answer the value of evaluating the given block with the value associated with the key. Otherwise, answer self."
 	^ aBlock value: (self at: aKey ifAbsent: [ ^ self ])
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AdditionalMethodState >> at: aKey put: aValue [
        "Replace the property value or pragma associated with aKey."
        | keyAlreadyExists |
@@ -119,7 +121,7 @@ AdditionalMethodState >> at: aKey put: aValue [
        ^ aValue
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 AdditionalMethodState >> copyWith: aPropertyOrPragma [ "<Association|Pragma>"
 	"Answer a copy of the receiver which includes aPropertyOrPragma"
 	| bs copy |
@@ -137,7 +139,7 @@ AdditionalMethodState >> copyWith: aPropertyOrPragma [ "<Association|Pragma>"
 	^copy
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 AdditionalMethodState >> copyWithout: aPropertyOrPragma [ "<Association|Pragma>"
 	"Answer a copy of the receiver which no longer includes aPropertyOrPragma"
 	| bs copy offset |
@@ -156,7 +158,7 @@ AdditionalMethodState >> copyWithout: aPropertyOrPragma [ "<Association|Pragma>"
 	^copy
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 AdditionalMethodState >> includes: aPropertyOrPragma [ "<Association|Pragma>"
 	"Test if the property or pragma is present."
 
@@ -167,7 +169,7 @@ AdditionalMethodState >> includes: aPropertyOrPragma [ "<Association|Pragma>"
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 AdditionalMethodState >> includesKey: aKey [
 	"Test if the property aKey or pragma with selector aKey is present."
 
@@ -178,7 +180,7 @@ AdditionalMethodState >> includesKey: aKey [
 	^false
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 AdditionalMethodState >> includesProperty: aKey [
 	"Test if the property aKey is present."
 
@@ -191,17 +193,17 @@ AdditionalMethodState >> includesProperty: aKey [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 AdditionalMethodState >> isEmpty [
 	^self basicSize = 0
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 AdditionalMethodState >> isMethodProperties [
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AdditionalMethodState >> keysAndValuesDo: aBlock [
 	"Enumerate the receiver with all the keys and values."
 
@@ -212,31 +214,31 @@ AdditionalMethodState >> keysAndValuesDo: aBlock [
 			ifFalse: [aBlock value: propertyOrPragma selector value: propertyOrPragma]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AdditionalMethodState >> method [
 
 	^method
 ]
 
-{ #category : #decompiling }
+{ #category : 'decompiling' }
 AdditionalMethodState >> method: aMethodNodeOrNil [
 	"For decompilation"
 	method := aMethodNodeOrNil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 AdditionalMethodState >> notEmpty [
 	^self basicSize > 0
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 AdditionalMethodState >> postCopy [
 	"After copying we must duplicate any associations and pragmas so they don't end up being shared."
 	1 to: self basicSize do:
 		[:i| self basicAt: i put: (self basicAt: i) shallowCopy]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AdditionalMethodState >> pragmas [
 	"Return the Pragma objects. Properties are stored as Associations"
 	^ Array new: self basicSize streamContents: [ :pragmaStream |
@@ -246,7 +248,7 @@ AdditionalMethodState >> pragmas [
 				  pragmaStream nextPut: propertyOrPragma ] ] ]
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 AdditionalMethodState >> pragmasDo: aBlock [
 
 	1 to: self basicSize do: [ :i |
@@ -256,13 +258,13 @@ AdditionalMethodState >> pragmasDo: aBlock [
 			ifFalse: [ aBlock value: propertyOrPragma ] ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 AdditionalMethodState >> printOn: aStream [
 	super printOn: aStream.
 	aStream space; nextPut: $(; print: self identityHash; nextPut: $)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AdditionalMethodState >> properties [
 
 	| propertyStream |
@@ -274,14 +276,14 @@ AdditionalMethodState >> properties [
 	^IdentityDictionary newFromPairs: propertyStream contents
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 AdditionalMethodState >> propertyAt: aKey [
 	"Answer the property value associated with aKey."
 
 	^ self propertyAt: aKey ifAbsent: [ self error: 'Property not found' ]
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 AdditionalMethodState >> propertyAt: aKey ifAbsent: aBlock [
 	"Answer the property value associated with aKey or, if aKey isn't found, answer the result of evaluating aBlock."
 
@@ -294,7 +296,7 @@ AdditionalMethodState >> propertyAt: aKey ifAbsent: aBlock [
 	^aBlock value
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 AdditionalMethodState >> propertyKeysAndValuesDo: aBlock [
 	"Enumerate the receiver with all the keys and values."
 
@@ -304,27 +306,27 @@ AdditionalMethodState >> propertyKeysAndValuesDo: aBlock [
 			[aBlock value: propertyOrPragma key value: propertyOrPragma value]]
 ]
 
-{ #category : #'properties-compatibility' }
+{ #category : 'properties-compatibility' }
 AdditionalMethodState >> propertyValueAt: aKey [
 	"use the version without ..Value, this methid is retained for compatibility"
 
 	^ self propertyAt: aKey
 ]
 
-{ #category : #'properties-compatibility' }
+{ #category : 'properties-compatibility' }
 AdditionalMethodState >> propertyValueAt: aKey ifAbsent: aBlock [
 	"use the version without ..Value, this methid is retained for compatibility"
 	^self propertyAt: aKey ifAbsent: aBlock
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 AdditionalMethodState >> removeKey: aKey [
 	"Remove the property with aKey. Answer the property or raise an error if aKey isn't found."
 
 	^ self removeKey: aKey ifAbsent: [ self error: 'Property not found' ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AdditionalMethodState >> removeKey: aKey ifAbsent: aBlock [
 	"Remove the property with aKey. Answer the value or, if aKey isn't found, answer the result of evaluating aBlock."
 
@@ -339,17 +341,17 @@ AdditionalMethodState >> removeKey: aKey ifAbsent: aBlock [
 	^aBlock value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AdditionalMethodState >> selector [
 	^selector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AdditionalMethodState >> selector: aSymbol [
 	selector := aSymbol
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AdditionalMethodState >> setMethod: aMethod [
 	method := aMethod.
 	1 to: self basicSize do: [ :i |

--- a/src/Kernel/ArgumentsCountMismatch.class.st
+++ b/src/Kernel/ArgumentsCountMismatch.class.st
@@ -3,16 +3,18 @@ I am an error that is signalled in a case when a block is invoked with arguments
 
 "
 Class {
-	#name : #ArgumentsCountMismatch,
-	#superclass : #Error,
+	#name : 'ArgumentsCountMismatch',
+	#superclass : 'Error',
 	#instVars : [
 		'expectedArgumentsCount',
 		'calledArgumentsCount'
 	],
-	#category : #'Kernel-Exceptions'
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #signalling }
+{ #category : 'signalling' }
 ArgumentsCountMismatch class >> signalExpectedArgumentsCount: expected calledArgumentsCount: called [
 
 	self new
@@ -21,34 +23,34 @@ ArgumentsCountMismatch class >> signalExpectedArgumentsCount: expected calledArg
 		signal
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ArgumentsCountMismatch >> calledArgumentsCount [
 	^ calledArgumentsCount
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ArgumentsCountMismatch >> calledArgumentsCount: anObject [
 	calledArgumentsCount := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ArgumentsCountMismatch >> expectedArgumentsCount [
 	^ expectedArgumentsCount
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ArgumentsCountMismatch >> expectedArgumentsCount: anObject [
 	expectedArgumentsCount := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ArgumentsCountMismatch >> messageText [
 
 	^ 'This block accepts ', (self printArgumentsCount: expectedArgumentsCount),
 			', but was called with ', (self printArgumentsCount: calledArgumentsCount), '.'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ArgumentsCountMismatch >> printArgumentsCount: aNumber [
 
 	^ aNumber printString, ' argument', (aNumber = 1 ifTrue: [''] ifFalse:['s'])

--- a/src/Kernel/ArithmeticError.class.st
+++ b/src/Kernel/ArithmeticError.class.st
@@ -2,7 +2,9 @@
 I am ArithmeticError, the superclass of all exceptions related to arithmetic.
 "
 Class {
-	#name : #ArithmeticError,
-	#superclass : #Error,
-	#category : #'Kernel-Exceptions'
+	#name : 'ArithmeticError',
+	#superclass : 'Error',
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }

--- a/src/Kernel/AsciiCharset.class.st
+++ b/src/Kernel/AsciiCharset.class.st
@@ -4,182 +4,184 @@ This class defines the attributes of the ASCII character set. It's here to be us
 Character objects delegate behaviour to one of the  character sets AsciiCharSet or Unicode. 
 "
 Class {
-	#name : #AsciiCharset,
-	#superclass : #Object,
-	#category : #'Kernel-BasicObjects'
+	#name : 'AsciiCharset',
+	#superclass : 'Object',
+	#category : 'Kernel-BasicObjects',
+	#package : 'Kernel',
+	#tag : 'BasicObjects'
 }
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isCasedLetter: char [
 	"There are no ASCII Characters in this Category"
 	^ false
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isClosePunctuation: char [
 	^ ')]}' includes: char
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isConnectorPunctuation: char [
 	^ char = $_
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isControlOther: char [
 	char charCode <= 16r1F ifTrue: [ ^ true ].
 	^ char = Character delete
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isCurrencySymbol: char [
 	^ char = $$
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isDashPunctuation: char [
 	^ char = $-
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isDecimalDigit: char [
 	^ self isDigit: char
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isDigit: aCharacter [
 	^ aCharacter between: $0 and: $9
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isEnclosingMark: char [
 	^ false
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isFinalQuote: char [
 	^ false
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isFormatOther: char [
 	^ false
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isInitialQuote: char [
 	^ false
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isLetter: aCharacter [
 	^ (aCharacter between: $a and: $z)
 		or: [ aCharacter between: $A and: $Z ]
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isLetterModifier: char [
 	^ false
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isLetterNumber: char [
 	^ false
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isLineSeparator: char [
 	^ false
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isLowercase: aCharacter [
 	^ aCharacter between: $a and: $z
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isMathSymbol: char [
 	^ '+<=>|~' includes: char
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isModifierSymbol: char [
 	^ '^`' includes: char
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isNonspacingMark: char [
 	^ false
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isOpenPunctuation: char [
 	^ '([{' includes: char
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isOtherLetter: char [
 	^ false
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isOtherNumber: char [
 	^ false
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isOtherPunctuation: char [
 	^ '!"#%&''*,./:;?@\' includes: char
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isOtherSymbol: char [
 	^ false
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isParagraphSeparator: char [
 	^ false
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isPrivateOther: char [
 	^ false
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isSpaceSeparator: char [
 	^ char = Character space
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isSpacingCombiningMark: char [
 	^ false
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isSurrogateOther: char [
 	^ false
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isTitlecaseLetter: char [
 	^ false
 ]
 
-{ #category : #'character classification' }
+{ #category : 'character classification' }
 AsciiCharset class >> isUppercase: aCharacter [
 	^ aCharacter between: $A and: $Z
 ]
 
-{ #category : #sizing }
+{ #category : 'sizing' }
 AsciiCharset class >> maxValue [
 	"The maximum value of a character in this character set"
 
 	^ 127
 ]
 
-{ #category : #casing }
+{ #category : 'casing' }
 AsciiCharset class >> toLowercase: aCharacter [
 	"(AsciiCharset toLowercase: $A) >>> $a."
 	"(AsciiCharset  toLowercase: $a) >>> $a."
@@ -191,7 +193,7 @@ AsciiCharset class >> toLowercase: aCharacter [
 		value: aCharacter asciiValue + $a asInteger - $A asInteger
 ]
 
-{ #category : #casing }
+{ #category : 'casing' }
 AsciiCharset class >> toUppercase: aCharacter [
 	"(AsciiCharset toUppercase: $a) >>> $A."
 	"(AsciiCharset toUppercase: $A) >>> $A."

--- a/src/Kernel/AssertionFailure.class.st
+++ b/src/Kernel/AssertionFailure.class.st
@@ -2,7 +2,9 @@
 AsssertionFailure is the exception signaled from Object>>assert: when the assertion block evaluates to false.
 "
 Class {
-	#name : #AssertionFailure,
-	#superclass : #Error,
-	#category : #'Kernel-Exceptions'
+	#name : 'AssertionFailure',
+	#superclass : 'Error',
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }

--- a/src/Kernel/BasicDatePrinter.class.st
+++ b/src/Kernel/BasicDatePrinter.class.st
@@ -9,12 +9,14 @@ I use ISO 8601 for formatting Date, Time and DateTime
 https://en.wikipedia.org/wiki/ISO_8601
 "
 Class {
-	#name : #BasicDatePrinter,
-	#superclass : #Object,
-	#category : #'Kernel-Chronology'
+	#name : 'BasicDatePrinter',
+	#superclass : 'Object',
+	#category : 'Kernel-Chronology',
+	#package : 'Kernel',
+	#tag : 'Chronology'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BasicDatePrinter class >> default [
 	" I prefer to use any of my subclasses than myself.
 	I am a really basic implementation."
@@ -22,14 +24,14 @@ BasicDatePrinter class >> default [
 	^ self new
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 BasicDatePrinter >> printDate: aDate format: formatArray on: aStream [
 	"I print a basic representation of the date in ISO 8601 ex: 	2018-03-08"
 
 	self printYMD: aDate withLeadingSpace: false on: aStream
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 BasicDatePrinter >> printDateAndTime: aDateTime withLeadingSpace: printLeadingSpaceToo on: aStream [
 	"Print as per ISO 8601 sections 5.3.3 and 5.4.1.
 	If printLeadingSpaceToo is false, prints either:
@@ -78,7 +80,7 @@ BasicDatePrinter >> printDateAndTime: aDateTime withLeadingSpace: printLeadingSp
 				print: aDateTime offset seconds abs truncated ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 BasicDatePrinter >> printHMS: aTime separatedBy: aSeparator on: aStream [
 	"Print just hh<aSep>mm<aSep>ss"
 
@@ -89,7 +91,7 @@ BasicDatePrinter >> printHMS: aTime separatedBy: aSeparator on: aStream [
 	aTime second printOn: aStream base: 10 length: 2 padded: true
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 BasicDatePrinter >> printYMD: aDateTime withLeadingSpace: printLeadingSpaceToo on: aStream [
 	"Print just the year, month, and day on aStream.
 

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -2,8 +2,8 @@
 My instances describe the behavior of other objects. I provide the minimum state necessary for compiling methods, and creating and running instances. Most objects are created as instances of the more fully supported subclass, Class, but I am a good starting point for providing instance-specific behavior (as in Metaclass).
 "
 Class {
-	#name : #Behavior,
-	#superclass : #Object,
+	#name : 'Behavior',
+	#superclass : 'Object',
 	#instVars : [
 		'superclass',
 		'methodDict',
@@ -14,10 +14,12 @@ Class {
 		'ClassProperties',
 		'ObsoleteSubclasses'
 	],
-	#category : #'Kernel-Classes'
+	#category : 'Kernel-Classes',
+	#package : 'Kernel',
+	#tag : 'Classes'
 }
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 Behavior class >> initialize [
 	"Behavior initialize"
 	"Never called for real"
@@ -34,17 +36,17 @@ Behavior class >> initialize [
 			ClassProperties := newDict ]
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 Behavior class >> initializeClassProperties [
 	ClassProperties := WeakIdentityKeyDictionary new
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 Behavior class >> initializeObsoleteSubclasses [
 	ObsoleteSubclasses := WeakIdentityKeyDictionary new
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> >> selector [
 	"Answer the compiled method associated with the argument, selector (a
 	Symbol), a message selector in the receiver's method dictionary. If the
@@ -53,7 +55,7 @@ Behavior >> >> selector [
 	^self compiledMethodAt: selector
 ]
 
-{ #category : #'obsolete subclasses' }
+{ #category : 'obsolete subclasses' }
 Behavior >> addObsoleteSubclass: aClass [
 	"Weakly remember that aClass was a subclass of the receiver and is now obsolete"
 
@@ -64,17 +66,17 @@ Behavior >> addObsoleteSubclass: aClass [
 	obsoleteSubclasses add: aClass
 ]
 
-{ #category : #'adding-removing methods' }
+{ #category : 'adding-removing methods' }
 Behavior >> addSelector: selector withMethod: compiledMethod [
 	^ self addSelectorSilently: selector withMethod: compiledMethod
 ]
 
-{ #category : #'adding-removing methods' }
+{ #category : 'adding-removing methods' }
 Behavior >> addSelector: selector withRecompiledMethod: compiledMethod [
 	^ self addSelectorSilently: selector withMethod: compiledMethod
 ]
 
-{ #category : #'adding-removing methods' }
+{ #category : 'adding-removing methods' }
 Behavior >> addSelectorSilently: selector withMethod: compiledMethod [
 	"Add the message selector with the corresponding compiled method to the
 	receiver's method dictionary.
@@ -87,7 +89,7 @@ Behavior >> addSelectorSilently: selector withMethod: compiledMethod [
 	Symbol recordSelector: selector
 ]
 
-{ #category : #'adding-removing methods' }
+{ #category : 'adding-removing methods' }
 Behavior >> adoptInstance: anInstance [
 	"Change the class of anInstance to me.
 	Primitive (found in Cog and new VMs)  follows the same rules as primitiveChangeClassTo:, but returns the 	class rather than the modified instance"
@@ -96,7 +98,7 @@ Behavior >> adoptInstance: anInstance [
 	^self
 ]
 
-{ #category : #'accessing - instances and variables' }
+{ #category : 'accessing - instances and variables' }
 Behavior >> allClassVarNames [
 	"Answer the names of the receiver's and the receiver's ancestor's class variables."
 
@@ -105,7 +107,7 @@ Behavior >> allClassVarNames [
 		ifNotNil: [ :sup | sup allClassVarNames , self classVarNames ]
 ]
 
-{ #category : #'accessing - instances and variables' }
+{ #category : 'accessing - instances and variables' }
 Behavior >> allInstVarNames [
 	"Answer an Array of the names of the receiver's instance variables. The
 	Array ordering is the order in which the variables are stored and
@@ -116,7 +118,7 @@ Behavior >> allInstVarNames [
 		ifNotNil: [ :sup | sup allInstVarNames , self instVarNames ]
 ]
 
-{ #category : #'accessing - instances and variables' }
+{ #category : 'accessing - instances and variables' }
 Behavior >> allInstances [
 	"Answer all instances of the receiver."
 	<primitive: 177>
@@ -134,7 +136,7 @@ Behavior >> allInstances [
 	^insts contents
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 Behavior >> allInstancesDo: aBlock [
 	"Evaluate aBlock with each of the current instances of the receiver."
 	| instances inst next |
@@ -152,7 +154,7 @@ Behavior >> allInstancesDo: aBlock [
 		 inst := next]
 ]
 
-{ #category : #'accessing - instances and variables' }
+{ #category : 'accessing - instances and variables' }
 Behavior >> allInstancesOrNil [
 	"Answer all instances of the receiver, or nil if the primitive
 	 fails, which it may be due to being out of memory."
@@ -160,7 +162,7 @@ Behavior >> allInstancesOrNil [
 	^nil
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> allMethods [
 	"Return the collection of compiled method I and my superclasses are defining"
 	"asArray is used to not bump into a bug when comparing compiled methods."
@@ -168,38 +170,38 @@ Behavior >> allMethods [
 	^ self allSelectors asArray collect: [ :s | self lookupSelector: s ]
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 Behavior >> allMethodsAccessingSlot: aSlot [
 	"return all methods that access aSlot in this class and subclasses"
 	^self withAllSubclasses flatCollect: [ :class | class methodsAccessingSlot: aSlot ]
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 Behavior >> allMethodsReadingSlot: aSlot [
 	"return all methods that access aSlot in this class and subclasses"
 	^self withAllSubclasses flatCollect: [ :class | class methodsReadingSlot: aSlot]
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 Behavior >> allMethodsWritingSlot: aSlot [
 	"return all methods that access aSlot in this class and subclasses"
 	^self withAllSubclasses flatCollect: [ :class | class methodsWritingSlot: aSlot ]
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> allSelectors [
 	"Answer all selectors understood by instances of the receiver"
 
 	^ self allSelectorsBelow: nil
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> allSelectorsAbove [
 
 	^ self allSelectorsAboveUntil: ProtoObject
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> allSelectorsAboveUntil: aRootClass [
 
 	| coll |
@@ -210,7 +212,7 @@ Behavior >> allSelectorsAboveUntil: aRootClass [
 	^ coll
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> allSelectorsBelow: topClass [
 	| coll |
 	coll := IdentitySet new.
@@ -222,7 +224,7 @@ Behavior >> allSelectorsBelow: topClass [
 	^ coll
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> allSelectorsWithout: behaviors [
 	"Returns all the selectors of the receiver and its superclasses, except the ones define in behaviors"
 
@@ -234,19 +236,19 @@ Behavior >> allSelectorsWithout: behaviors [
 	^ selectors
 ]
 
-{ #category : #'accessing - instances and variables' }
+{ #category : 'accessing - instances and variables' }
 Behavior >> allSharedPools [
 	"Answer an ordered collection of the shared pools that the receiver and the receiver's ancestors share."
 
 	^self superclass allSharedPools
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Behavior >> allSlots [
 	^#()
 ]
 
-{ #category : #'accessing - instances and variables' }
+{ #category : 'accessing - instances and variables' }
 Behavior >> allSubInstances [
 	"Answer a list of all current instances of the receiver and all of its subclasses."
 	| aCollection |
@@ -256,7 +258,7 @@ Behavior >> allSubInstances [
 	^ aCollection
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 Behavior >> allSubInstancesDo: aBlock [
 	"Evaluate the argument, aBlock, for each of the current instances of the
 	receiver and all its subclasses."
@@ -265,7 +267,7 @@ Behavior >> allSubInstancesDo: aBlock [
 	self allSubclassesDo: [:sub | sub allInstancesDo: aBlock]
 ]
 
-{ #category : #'accessing - class hierarchy' }
+{ #category : 'accessing - class hierarchy' }
 Behavior >> allSubclasses [
 	"Answer an orderedCollection of the receiver's and the receiver's descendent's subclasses. "
 
@@ -278,7 +280,7 @@ Behavior >> allSubclasses [
 	^ scan
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 Behavior >> allSubclassesDo: aBlock [
 	"Evaluate the argument, aBlock, for each of the receiver's subclasses."
 
@@ -288,7 +290,7 @@ Behavior >> allSubclassesDo: aBlock [
 		cl allSubclassesDo: aBlock]
 ]
 
-{ #category : #'accessing - class hierarchy' }
+{ #category : 'accessing - class hierarchy' }
 Behavior >> allSubclassesWithLevelDo: classAndLevelBlock startingLevel: level [
 	"Walk the tree of subclasses, giving the class and its level"
 	| subclassNames |
@@ -303,7 +305,7 @@ Behavior >> allSubclassesWithLevelDo: classAndLevelBlock startingLevel: level [
 			startingLevel: level+1]
 ]
 
-{ #category : #'accessing - class hierarchy' }
+{ #category : 'accessing - class hierarchy' }
 Behavior >> allSuperclasses [
 	"Answer an OrderedCollection of the receiver's and the receiver's
 	ancestor's superclasses. The first element is the receiver's immediate
@@ -316,7 +318,7 @@ Behavior >> allSuperclasses [
 			temp]
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 Behavior >> allSuperclassesDo: aBlock [
 	"Evaluate the argument, aBlock, for each of the receiver's superclasses."
 
@@ -325,7 +327,7 @@ Behavior >> allSuperclassesDo: aBlock [
 				self superclass allSuperclassesDo: aBlock]
 ]
 
-{ #category : #'accessing - class hierarchy' }
+{ #category : 'accessing - class hierarchy' }
 Behavior >> allSuperclassesIncluding: aClass [
 	"Answer an OrderedCollection of the receiver's and the receiver's  ancestor's superclasses
 	up to aClass included. If aClass is not part of the receiver's superclass, returns up to the root."
@@ -338,7 +340,7 @@ Behavior >> allSuperclassesIncluding: aClass [
 			temp]
 ]
 
-{ #category : #'reflective operations' }
+{ #category : 'reflective operations' }
 Behavior >> basicIdentityHash [
 	"Answer a 22 bits unsigned SmallInteger, whose value is related to the receiver's identity
 	 and unique among the behaviors (i.e. 2 different Behaviors cannot have the same identityHash).
@@ -358,7 +360,7 @@ Behavior >> basicIdentityHash [
 	self primitiveFailed
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Behavior >> basicNew [
 	"Primitive. Answer an instance of the receiver (which is a class) with no
 	 indexable variables. Fail if the class is indexable. Essential. See Object
@@ -375,7 +377,7 @@ Behavior >> basicNew [
 	self primitiveFailed
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Behavior >> basicNew: sizeRequested [
 	"Primitive. Answer an instance of this class with the number of indexable
 	 variables specified by the argument, sizeRequested.  Fail if this class is not
@@ -393,34 +395,34 @@ Behavior >> basicNew: sizeRequested [
 	self primitiveFailed
 ]
 
-{ #category : #'obsolete subclasses' }
+{ #category : 'obsolete subclasses' }
 Behavior >> basicObsoleteSubclasses [
 	^ObsoleteSubclasses
 ]
 
-{ #category : #'accessing - class hierarchy' }
+{ #category : 'accessing - class hierarchy' }
 Behavior >> basicSuperclass: aClass [
 	superclass := aClass
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Behavior >> becomeUncompact [
 	"Backward compatibility with the Squeak V3 object format.
 	 Spur does not have a distinction between compact and non-compact classes."
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Behavior >> binding [
 	^ LiteralVariable key: nil value: self
 ]
 
-{ #category : #'accessing - instances and variables' }
+{ #category : 'accessing - instances and variables' }
 Behavior >> bindingOf: varName [
 	"Answer the binding of some variable resolved in the scope of the receiver"
 	^self superclass bindingOf: varName
 ]
 
-{ #category : #'accessing - instances and variables' }
+{ #category : 'accessing - instances and variables' }
 Behavior >> byteSizeOfInstance [
 	"Answer the total memory size of an instance of the receiver."
 
@@ -430,7 +432,7 @@ Behavior >> byteSizeOfInstance [
 	self primitiveFailed
 ]
 
-{ #category : #'accessing - instances and variables' }
+{ #category : 'accessing - instances and variables' }
 Behavior >> byteSizeOfInstanceOfSize: basicSize [
 	"Answer the total memory size of an instance of the receiver
 	 with the given number of indexable instance variables."
@@ -448,7 +450,7 @@ Behavior >> byteSizeOfInstanceOfSize: basicSize [
 	self primitiveFailed
 ]
 
-{ #category : #'testing - method dictionary' }
+{ #category : 'testing - method dictionary' }
 Behavior >> canPerform: selector [
 	"Answer whether the receiver's instances can safely perform to the message whose selector
 	is the argument: it is not an abstract or cancelled method"
@@ -456,7 +458,7 @@ Behavior >> canPerform: selector [
 	^ self classAndMethodFor: selector do: [:c :m | m isProvided] ifAbsent: [false]
 ]
 
-{ #category : #'testing - method dictionary' }
+{ #category : 'testing - method dictionary' }
 Behavior >> canUnderstand: selector [
 	"Answer whether the receiver's instances can respond to the message whose selector
 	is the argument."
@@ -467,7 +469,7 @@ Behavior >> canUnderstand: selector [
 		ifAbsent: [ false ]
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> classAndMethodFor: aSymbol do: binaryBlock ifAbsent: absentBlock [
 	"Looks up the selector aSymbol in the class chain. If it is found, binaryBlock is evaluated
 	with the class that defines the selector and the associated method. Otherwise
@@ -477,20 +479,20 @@ Behavior >> classAndMethodFor: aSymbol do: binaryBlock ifAbsent: absentBlock [
 	^ absentBlock value
 ]
 
-{ #category : #'testing - method dictionary' }
+{ #category : 'testing - method dictionary' }
 Behavior >> classBindingOf: varName [
 	"Answer the binding of some variable resolved in the scope of the receiver's class"
 	^self bindingOf: varName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Behavior >> classDepth [
 
 	self superclass ifNil: [^ 1].
 	^ self superclass classDepth + 1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Behavior >> classLayout [
 	^ layout
 		ifNil: [
@@ -502,31 +504,31 @@ Behavior >> classLayout [
 			layout := superLayout class extending: superLayout scope: scope host: self ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Behavior >> classLayout: aClassLayout [
 	layout := aClassLayout
 ]
 
-{ #category : #'accessing - instances and variables' }
+{ #category : 'accessing - instances and variables' }
 Behavior >> classVarNames [
 	"Answer a collection of the receiver's class variable names."
 
 	^#()
 ]
 
-{ #category : #cleanup }
+{ #category : 'cleanup' }
 Behavior >> cleanUp [
 	"Clean out any caches and other state that should be flushed when trying to get an image into a pristine state. Subclasses may override #cleanUp: to provide different levels of cleanliness"
 ]
 
-{ #category : #cleanup }
+{ #category : 'cleanup' }
 Behavior >> cleanUp: aggressive [
 	"Clean out any caches and other state that should be flushed when trying to get an image into a pristine state. The argument should be used to indicate how aggressive the cleanup should be. Some subclasses may act differently depending on its value - for example, ChangeSet will only delete all unused and reinitialize the current change set if we're asking it to be aggressive."
 
 	^self cleanUp
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> compiledMethodAt: selector [
 	"Answer the compiled method associated with the argument, selector (a
 	Symbol), a message selector in the receiver's method dictionary. If the
@@ -535,14 +537,14 @@ Behavior >> compiledMethodAt: selector [
 	^ self methodDict at: selector
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> compiledMethodAt: selector ifAbsent: aBlock [
 	"Answer the compiled method associated with the argument, selector (a Symbol), a message selector in the receiver's method dictionary. If the selector is not in the dictionary, return the value of aBlock"
 
 	^ self methodDict at: selector ifAbsent: aBlock
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> compiledMethodAt: selector ifPresent: aBlock [
 	"Answer the compiled method associated with the argument, selector (a Symbol),
 	 a message selector in the receiver's method dictionary.
@@ -552,7 +554,7 @@ Behavior >> compiledMethodAt: selector ifPresent: aBlock [
 	^ self methodDict at: selector ifPresent: aBlock
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> compiledMethodAt: selector ifPresent: aBlock ifAbsent: anotherBlock [
 	"Answer the compiled method associated with the argument, selector (a Symbol),
 	 a message selector in the receiver's method dictionary.
@@ -563,20 +565,20 @@ Behavior >> compiledMethodAt: selector ifPresent: aBlock ifAbsent: anotherBlock 
 	^ self methodDict at: selector ifPresent: aBlock ifAbsent: anotherBlock
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Behavior >> deepCopy [
 	"Classes should only be shallowCopied or made anew."
 
 	^ self shallowCopy
 ]
 
-{ #category : #'accessing - instances and variables' }
+{ #category : 'accessing - instances and variables' }
 Behavior >> definedVariables [
 	"return all the Variables defined"
 	^ self slots
 ]
 
-{ #category : #'accessing - instances and variables' }
+{ #category : 'accessing - instances and variables' }
 Behavior >> elementSize [
 	"Answer the size in bytes of an element in the receiver.  The formats are
 			0	= 0 sized objects (UndefinedObject True False et al)
@@ -602,24 +604,24 @@ Behavior >> elementSize [
 	^8
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Behavior >> emptyMethodDictionary [
 
 	^ MethodDictionary new
 ]
 
-{ #category : #'accessing - properties' }
+{ #category : 'accessing - properties' }
 Behavior >> ensureProperties [
 	^ ClassProperties at: self ifAbsentPut: WeakKeyDictionary new
 ]
 
-{ #category : #naming }
+{ #category : 'naming' }
 Behavior >> environment [
 	"Return the environment in which the receiver is visible"
 	^Smalltalk globals
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> findOriginClassOf: aMethod [
 
 	"I return the origin of my given method. In a basic class is always self.
@@ -627,7 +629,7 @@ Behavior >> findOriginClassOf: aMethod [
 	^ self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> findOriginMethodOf: aMethod [
 	"I return the original method for a aMethod.
 	When in a normal class it is the same. Enhanced classes (eg. TraitedClasses)
@@ -636,7 +638,7 @@ Behavior >> findOriginMethodOf: aMethod [
 	^ aMethod
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Behavior >> flushCache [
 	"Tell the virtual machine to remove the contents of its method lookup caches, if it has any.  This must be done when the system 	modifies the class hierarchy so that message lookups reflect the revised organization.  c.f. Symbol>>flushCache & 	CompiledMethod>>flushCache.  Essential. See MethodDictionary class comment."
 
@@ -644,7 +646,7 @@ Behavior >> flushCache [
 	self primitiveFailed
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Behavior >> format [
 	"Answer an Integer that encodes the kinds and numbers of variables of
 	instances of the receiver."
@@ -652,7 +654,7 @@ Behavior >> format [
 	^format
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Behavior >> handleFailingBasicNew [
 	"handleFailingBasicNew gets sent after basicNew has failed and allowed
 	 a scavenging garbage collection to occur.  The scavenging collection
@@ -672,7 +674,7 @@ Behavior >> handleFailingBasicNew [
 	^self handleFailingFailingBasicNew "retry after global garbage collect"
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Behavior >> handleFailingBasicNew: sizeRequested [
 	"handleFailingBasicNew: gets sent after basicNew: has failed and allowed
 	 a scavenging garbage collection to occur.  The scavenging collection
@@ -696,7 +698,7 @@ Behavior >> handleFailingBasicNew: sizeRequested [
 		[ self handleFailingBasicNewWithGC: sizeRequested ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Behavior >> handleFailingBasicNewWithGC: sizeRequested [
 	"handleFailingBasicNewWithGC: gets sent after basicNew: has failed, a GC has been	performed and the allocation still fails even though enough memory was reported 	as available. Given that this has happened when there is plenty of virtual memory available, assume that the GC has reported incorrectly and try one more time anyway.	 Primitive. Answer an instance of this class with the number of indexable	 variables specified by the argument, sizeRequested.  Fail if this class is not	 indexable or if the argument is not a positive Integer, or if there is not	 enough memory available. Essential. See Object documentation whatIsAPrimitive."
 
@@ -707,7 +709,7 @@ Behavior >> handleFailingBasicNewWithGC: sizeRequested [
 	^ self handleFailingFailingBasicNew: sizeRequested
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Behavior >> handleFailingFailingBasicNew [
 	"This basicNew gets sent after handleFailingBasicNew: has done a full
 	 garbage collection and possibly grown memory.  If this basicNew fails
@@ -724,7 +726,7 @@ Behavior >> handleFailingFailingBasicNew [
 	^self basicNew  "retry if user proceeds"
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Behavior >> handleFailingFailingBasicNew: sizeRequested [
 	"This basicNew: gets sent after handleFailingBasicNew: has done a full
 	 garbage collection and possibly grown memory.  If this basicNew: fails
@@ -741,7 +743,7 @@ Behavior >> handleFailingFailingBasicNew: sizeRequested [
 	^self basicNew: sizeRequested  "retry if user proceeds"
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> hasAbstractMethods [
 	"Tells whether the receiver locally defines an abstract method, i.e., a method sending subclassResponsibility"
 	"we do not use #anySatisfy: for speed"
@@ -750,51 +752,51 @@ Behavior >> hasAbstractMethods [
 	^false
 ]
 
-{ #category : #binding }
+{ #category : 'binding' }
 Behavior >> hasBindingOf: aString [
 	^ (self bindingOf: aString) notNil
 ]
 
-{ #category : #'testing - method dictionary' }
+{ #category : 'testing - method dictionary' }
 Behavior >> hasMethodAccessingVariable: aVariable [
 	"Answer true if any of my methods access the variable"
 
 	^self methods anySatisfy: [ :method | aVariable isAccessedIn: method ]
 ]
 
-{ #category : #'testing - method dictionary' }
+{ #category : 'testing - method dictionary' }
 Behavior >> hasMethods [
 	"Answer whether the receiver has any methods in its method dictionary."
 
 	^ self methodDict notEmpty
 ]
 
-{ #category : #'accessing - properties' }
+{ #category : 'accessing - properties' }
 Behavior >> hasProperty: aKey [
 	self propertyAt: aKey ifAbsent: [ ^ false ].
 	^ true
 ]
 
-{ #category : #'testing - method dictionary' }
+{ #category : 'testing - method dictionary' }
 Behavior >> hasSelectorReferringTo: literal [
 	"Answer true if any of my methods access the argument as a literal"
 
 	^self methods anySatisfy: [ :method | method hasLiteral: literal ]
 ]
 
-{ #category : #'testing - class hierarchy' }
+{ #category : 'testing - class hierarchy' }
 Behavior >> includesBehavior: aClass [
 
 	self isTrait ifTrue: [ ^false ].
 	^self == aClass or:[self inheritsFrom: aClass]
 ]
 
-{ #category : #'testing - method dictionary' }
+{ #category : 'testing - method dictionary' }
 Behavior >> includesLocalSelector: aSymbol [
 	^ self includesSelector: aSymbol
 ]
 
-{ #category : #'testing - method dictionary' }
+{ #category : 'testing - method dictionary' }
 Behavior >> includesMethod: aMethod [
 	"Answer whether aMethod is in the method dictionary. Use identityIncludes
 	as = of CompiledMethod is too weak (ignores the selector)"
@@ -802,7 +804,7 @@ Behavior >> includesMethod: aMethod [
 	^ self methodDict identityIncludes: aMethod
 ]
 
-{ #category : #'testing - method dictionary' }
+{ #category : 'testing - method dictionary' }
 Behavior >> includesSelector: aSymbol [
 	"Answer whether the message whose selector is the argument is in the
 	method dictionary of the receiver's class."
@@ -810,7 +812,7 @@ Behavior >> includesSelector: aSymbol [
 	^ self methodDict includesKey: aSymbol
 ]
 
-{ #category : #'testing - class hierarchy' }
+{ #category : 'testing - class hierarchy' }
 Behavior >> inheritsFrom: aClass [
 	"Answer whether the argument, aClass, is on the receiver's superclass
 	chain."
@@ -824,7 +826,7 @@ Behavior >> inheritsFrom: aClass [
 	^false
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Behavior >> initialize [
 	"moved here from the class side's #new"
 	super initialize.
@@ -834,12 +836,12 @@ Behavior >> initialize [
 	self setFormat: Object format
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Behavior >> initializeSlots: anObject [
 	self classLayout initializeInstance: anObject
 ]
 
-{ #category : #'accessing - instances and variables' }
+{ #category : 'accessing - instances and variables' }
 Behavior >> instSize [
 	"Answer the number of named instance variables
 	(as opposed to indexed variables) of the receiver.
@@ -848,7 +850,7 @@ Behavior >> instSize [
 	^format bitAnd: 16rFFFF
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> instSpec [
 	"Answer the instance specification part of the format that defines what kind of object
 	 an instance of the receiver is.  The formats are
@@ -869,7 +871,7 @@ Behavior >> instSpec [
 	^(self format bitShift: -16) bitAnd: 16r1F
 ]
 
-{ #category : #'accessing - instances and variables' }
+{ #category : 'accessing - instances and variables' }
 Behavior >> instVarNames [
 	"Answer an Array of the instance variable names. Behaviors must make
 	up fake local instance variable names because Behaviors have instance
@@ -885,7 +887,7 @@ Behavior >> instVarNames [
 	^(superSize + 1 to: mySize) collect: [:i | 'inst' , i printString]
 ]
 
-{ #category : #'accessing - instances and variables' }
+{ #category : 'accessing - instances and variables' }
 Behavior >> instanceCount [
 	"Answer the number of instances of the receiver that are currently in use.
 	Note: we do not use #allInstances as allInstancesDo: has a fallback for low memory"
@@ -896,13 +898,13 @@ Behavior >> instanceCount [
 	^count
 ]
 
-{ #category : #'accessing - instances and variables' }
+{ #category : 'accessing - instances and variables' }
 Behavior >> instanceVariables [
 	"in older version, this method was returning names, not objects"
 	^self slots
 ]
 
-{ #category : #'memory usage' }
+{ #category : 'memory usage' }
 Behavior >> instancesSizeInMemory [
 	"Answers the number of bytes consumed by all its instances including their object header.
 	Note: we do not use #allInstances as allInstancesDo: has a fallback for low memory"
@@ -913,7 +915,7 @@ Behavior >> instancesSizeInMemory [
 	^ bytes
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> isAbstract [
 	"By default a class is not abstract.
 	Hook to mark your own subclasses as abstract."
@@ -921,18 +923,18 @@ Behavior >> isAbstract [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> isAnonymous [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> isBehavior [
 	"Return true if the receiver is a behavior"
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> isBits [
 	"Answer whether the receiver contains just bits (not pointers).
 	 Above Cog Spur the class format is
@@ -955,7 +957,7 @@ Behavior >> isBits [
 	^self instSpec >= 7
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> isBytes [
 	"Answer whether the receiver has 8-bit instance variables.
 	 Above Cog Spur the class format is
@@ -978,25 +980,25 @@ Behavior >> isBytes [
 	^self instSpec >= 16
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> isCompact [
 	"Backward compatibility with the Squeak V3 object format.
 	Spur does not have a distinction between compact and non-compact classes."
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> isCompiledMethodClass [
 	"Answer whether the receiver has compiled method instances that mix pointers and bytes."
 	^self instSpec >= 24
 ]
 
-{ #category : #'testing - method dictionary' }
+{ #category : 'testing - method dictionary' }
 Behavior >> isDisabledSelector: selector [
 	^ self classAndMethodFor: selector do: [:c :m | m isDisabled] ifAbsent: [false]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> isEphemeronClass [
 	"Answer whether the receiver has ephemeral instance variables.  The garbage collector will
 	 fire (queue for finalization) any ephemeron whose first instance variable is not referenced
@@ -1011,14 +1013,14 @@ Behavior >> isEphemeronClass [
 	^self instSpec = 5
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> isFixed [
 	"Answer whether the receiver does not have a variable (indexable) part."
 
 	^self isVariable not
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> isImmediateClass [
 	"Answer whether the receiver has immediate instances.  Immediate instances
 	 store their value in their object pointer, not in an object body.  Hence immediates
@@ -1029,53 +1031,53 @@ Behavior >> isImmediateClass [
 	^self instSpec = 7
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> isManifest [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> isMeta [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> isObsolete [
 	"Return true if the receiver is obsolete."
 	^self instanceCount = 0
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> isPointers [
 	"Answer whether the receiver contains just pointers (not bits)."
 
 	^self isBits not
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> isPool [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> isReferenced [
 	"Returns true if the class is referenced from a method."
 	^ self binding isReferenced
 ]
 
-{ #category : #'testing - class hierarchy' }
+{ #category : 'testing - class hierarchy' }
 Behavior >> isRootInEnvironment [
 	^self superclass isNil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> isUsed [
 	"the class is used somehow. This is client specific, subclasses can override"
 
 	^ self isReferenced
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> isVariable [
 	"Answer whether the receiver has indexable variables.
 	 Above Cog Spur the class format is
@@ -1100,34 +1102,34 @@ Behavior >> isVariable [
 	^instSpec >= 2 and: [instSpec <= 4 or: [instSpec >= 9]]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> isWeak [
 	"Answer whether the receiver has contains weak references."
 	^ self instSpec = 4
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> isWords [
 	"Answer true if the receiver is made of 32-bit instance variables."
 
 	^self isBytes not
 ]
 
-{ #category : #'testing - class hierarchy' }
+{ #category : 'testing - class hierarchy' }
 Behavior >> kindOfSubclass [
 	"Answer a String that is the keyword that describes the receiver's kind of subclass
 	Note: this is for printing the ST80 style class definiton, see #subclassDefiningSymbol"
 	^ self classLayout kindOfSubclass
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Behavior >> longPrintOn: aStream [
 	"Append to the argument, aStream, the names and values of all of the receiver's instance variables.  But, not useful for a class with a method dictionary."
 
 	aStream nextPutAll: '<<too complex to show>>'; cr
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> lookupSelector: selector [
 	"Look up the given selector in my methodDictionary.
 	Return the corresponding method if found.
@@ -1144,7 +1146,7 @@ Behavior >> lookupSelector: selector [
 	^ nil
 ]
 
-{ #category : #lookup }
+{ #category : 'lookup' }
 Behavior >> lookupVar: aName [
 	^ self classLayout
 		resolveSlot: aName asSymbol
@@ -1152,7 +1154,7 @@ Behavior >> lookupVar: aName [
 		ifNone: [self bindingOf: aName]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Behavior >> methodDict [
        "The method dictionary of a class can be nil when we want to use the #cannotInterpret: hook. Indeed when a class dictionary is nil, the VM sends the message cannotInterpret: to the receiver but starting the look up in the superclass of the class whose method dictionary was nil.
 	 Now the system relies that when the message methodDict is sent to a class a method dictionary is returned. In order to prevent the complaints of tools and IDE unaware of this feature, we fool them by providing an empty MethodDictionary. This will hopefully work in most cases, but the tools will loose the ability to modify the behaviour of this behavior. The user of #cannotInterpret: should be aware of this."
@@ -1160,74 +1162,74 @@ Behavior >> methodDict [
        ^ methodDict ifNil: [ MethodDictionary new ]
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> methodDict: aDictionary [
 	methodDict := aDictionary
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> methodDictionary [
 	^self methodDict
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> methodDictionary: aDictionary [
 	self methodDict: aDictionary
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> methods [
 
 	^ self methodDict values
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 Behavior >> methodsAccessingSlot: aSlot [
 	^self methods select: [ :method | method accessesSlot: aSlot ]
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> methodsDo: aBlock [
 	"Evaluate aBlock for all the compiled methods in my method dictionary."
 
 	^ self methodDict valuesDo: aBlock
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 Behavior >> methodsReadingSlot: aSlot [
 	^self methods select: [ :method | method readsSlot: aSlot ]
 ]
 
-{ #category : #navigation }
+{ #category : 'navigation' }
 Behavior >> methodsReferencingClass: aClass [
 
 	^self methodsReferencingClasses: { aClass }
 ]
 
-{ #category : #navigation }
+{ #category : 'navigation' }
 Behavior >> methodsReferencingClasses: aCollectionOfClasses [
 	^ self methods select: [ :meth | meth referencedClasses includesAny: aCollectionOfClasses ]
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 Behavior >> methodsWritingSlot: aSlot [
 	^self methods select: [ :method | method writesSlot: aSlot ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Behavior >> name [
 	"Answer a String that is the name of the receiver."
 	^'a subclass of ', self superclass name
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Behavior >> new [
 	"Answer a new initialized instance of the receiver (which is a class) with no indexable variables. Fail if the class is indexable."
 
 	^ self basicNew initialize
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Behavior >> new: sizeRequested [
 	"Answer an initialized instance of this class with the number of indexable
 	variables specified by the argument, sizeRequested."
@@ -1235,26 +1237,26 @@ Behavior >> new: sizeRequested [
 	^ (self basicNew: sizeRequested) initialize
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Behavior >> nonObsoleteClass [
 	"Attempt to find and return the current version of this obsolete class"
 
 	^ self environment at: self originalName
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Behavior >> obsolete [
 	"nothing to be done"
 ]
 
-{ #category : #'obsolete subclasses' }
+{ #category : 'obsolete subclasses' }
 Behavior >> obsoleteSubclasses [
 	"Return all the weakly remembered obsolete subclasses of the receiver"
 
 	^ self basicObsoleteSubclasses at: self ifAbsent: [ #(  ) ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Behavior >> originalName [
 	| obsName |
 	obsName := self name.
@@ -1264,29 +1266,29 @@ Behavior >> originalName [
 	^obsName asSymbol
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Behavior >> packageOrganizer [
 
 	^ self environment organization
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Behavior >> postCopy [
 	super postCopy.
 	self methodDict: self methodDict copy
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 Behavior >> pragmas [
 	^ self methods flatCollect: [ :method | method pragmas ]
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 Behavior >> pragmasDo: aBlock [
 	self methodsDo: [ :method | method pragmasDo: aBlock ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Behavior >> printOn: aStream [
 	"Refer to the comment in Object|printOn:."
 
@@ -1294,19 +1296,19 @@ Behavior >> printOn: aStream [
 	self superclass printOn: aStream
 ]
 
-{ #category : #'accessing - properties' }
+{ #category : 'accessing - properties' }
 Behavior >> properties [
 	^ ClassProperties at: self ifAbsent: nil
 ]
 
-{ #category : #'accessing - properties' }
+{ #category : 'accessing - properties' }
 Behavior >> propertyAt: propName [
 	^ self
 		propertyAt: propName
 		ifAbsent: [ nil ]
 ]
 
-{ #category : #'accessing - properties' }
+{ #category : 'accessing - properties' }
 Behavior >> propertyAt: propName ifAbsent: aBlock [
 	self properties ifNil: [^aBlock value].
 	^ self properties
@@ -1314,40 +1316,40 @@ Behavior >> propertyAt: propName ifAbsent: aBlock [
 		ifAbsent: aBlock
 ]
 
-{ #category : #'accessing - properties' }
+{ #category : 'accessing - properties' }
 Behavior >> propertyAt: propName put: propValue [
 	^ self ensureProperties
 		at: propName
 		ifAbsentPut: propValue
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Behavior >> realClass [
 
 	^ self
 ]
 
-{ #category : #'obsolete subclasses' }
+{ #category : 'obsolete subclasses' }
 Behavior >> removeAllObsoleteSubclasses [
 	"Remove all the obsolete subclasses of the receiver"
 
 	self basicObsoleteSubclasses removeKey: self ifAbsent: [  ]
 ]
 
-{ #category : #'accessing - properties' }
+{ #category : 'accessing - properties' }
 Behavior >> removePropertiesIfEmpty [
 	^ ClassProperties at: self ifPresent: [ :dict |
 		dict ifEmpty: [ ClassProperties removeKey: self ] ]
 ]
 
-{ #category : #'accessing - properties' }
+{ #category : 'accessing - properties' }
 Behavior >> removeProperty: propName [
 	^ self
 		removeProperty: propName
 		ifAbsent: [ nil ]
 ]
 
-{ #category : #'accessing - properties' }
+{ #category : 'accessing - properties' }
 Behavior >> removeProperty: propName ifAbsent: aBlock [
 	| property |
 	self properties ifNil: [^aBlock value].
@@ -1358,26 +1360,26 @@ Behavior >> removeProperty: propName ifAbsent: aBlock [
 	^ property
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> removeSelector: aSelector [
 	"Assuming that the argument, selector (a Symbol), is a message selector in my method dictionary, remove it and its method."
 
 	self methodDict removeKey: aSelector ifAbsent: []
 ]
 
-{ #category : #'adding-removing methods' }
+{ #category : 'adding-removing methods' }
 Behavior >> removeSelectorSilently: selector [
 	"Remove selector without sending system change notifications"
 
 	^ SystemAnnouncer uniqueInstance suspendAllWhile: [self removeSelector: selector]
 ]
 
-{ #category : #cleanup }
+{ #category : 'cleanup' }
 Behavior >> restartMethods [
 	"Clean up. Long running loops or stored closures can lead to methods that are out if sync with the recompiled code. Subclasses should override this method if they need to restart methods"
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 Behavior >> selectSubclasses: aBlock [
 	"Evaluate the argument, aBlock, with each of the receiver's (next level)
 	subclasses as its argument. Collect into a Set only those subclasses for
@@ -1393,7 +1395,7 @@ Behavior >> selectSubclasses: aBlock [
 	^aSet
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 Behavior >> selectSuperclasses: aBlock [
 	"Evaluate the argument, aBlock, with the receiver's superclasses as the
 	argument. Collect into an OrderedCollection only those superclasses for
@@ -1410,7 +1412,7 @@ Behavior >> selectSuperclasses: aBlock [
 	^aSet
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> selectors [
 	"Answer a Set of all the message selectors specified in the receiver's
 	method dictionary."
@@ -1418,28 +1420,28 @@ Behavior >> selectors [
 	^ self methodDict keys
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> selectorsAndMethodsDo: selectorAndMethodBlock [
 	"Evaluate selectorAndMethodBlock with two arguments for each selector/method pair in my method dictionary."
 
 	^ self methodDict keysAndValuesDo: selectorAndMethodBlock
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> selectorsDo: selectorBlock [
 	"Evaluate selectorBlock for all the message selectors in my method dictionary."
 
 	^ self methodDict keysDo: selectorBlock
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> selectorsWithArgs: numberOfArgs [
 	"Return all selectors defined in this class that take this number of arguments"
 
 	^ self selectors select: [:selector | selector numArgs = numberOfArgs]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Behavior >> setFormat: aFormatInstanceDescription [
 	"only use this method with extreme care since it modifies the format of the class
      ie a description of the number of instance variables and whether the class is
@@ -1448,7 +1450,7 @@ Behavior >> setFormat: aFormatInstanceDescription [
 	format := aFormatInstanceDescription
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Behavior >> shouldNotBeRedefined [
 	"Answer if the receiver should not be redefined.
 	 The assumption is that classes in Smalltalk specialObjects and
@@ -1459,23 +1461,23 @@ Behavior >> shouldNotBeRedefined [
 		ifAbsent: [(self isKindOf: self) ifTrue: [1] ifFalse: [0]]) ~= 0
 ]
 
-{ #category : #'system startup' }
+{ #category : 'system startup' }
 Behavior >> shutDown [
 	"This message is sent on system shutdown to registered classes"
 ]
 
-{ #category : #'system startup' }
+{ #category : 'system startup' }
 Behavior >> shutDown: quitting [
 	"This message is sent on system shutdown to registered classes"
 	^self shutDown
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Behavior >> slots [
 	^#()
 ]
 
-{ #category : #'accessing - instances and variables' }
+{ #category : 'accessing - instances and variables' }
 Behavior >> someInstance [
 	"Primitive. Answer the first instance in the enumeration of all instances
 	of the receiver. Fails if there are none. Essential. See Object
@@ -1485,19 +1487,19 @@ Behavior >> someInstance [
 	^nil
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> sourceCodeAt: selector [
 
 	^ (self compiledMethodAt: selector) sourceCode
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Behavior >> sourceCodeAt: selector ifAbsent: aBlock [
 
 	^ (self compiledMethodAt: selector ifAbsent: [^ aBlock value]) sourceCode
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 Behavior >> sourceCodeTemplate [
 	"Answer an expression to be edited and evaluated in order to define
 	methods in this class or trait."
@@ -1510,7 +1512,7 @@ Behavior >> sourceCodeTemplate [
 	statements'
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Behavior >> spaceUsed [
 	"Answer a rough estimate of number of bytes used by this class and its metaclass. Does not include space used by class variables."
 
@@ -1528,18 +1530,18 @@ Behavior >> spaceUsed [
 		^ space
 ]
 
-{ #category : #'system startup' }
+{ #category : 'system startup' }
 Behavior >> startUp [
 	"This message is sent to registered classes when the system is coming up."
 ]
 
-{ #category : #'system startup' }
+{ #category : 'system startup' }
 Behavior >> startUp: resuming [
 	"This message is sent to registered classes when the system is coming up."
 	^self startUp
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Behavior >> subclassDefinerClass [
 	"Answer an evaluator class appropriate for evaluating definitions of new
 	subclasses of this class."
@@ -1547,20 +1549,20 @@ Behavior >> subclassDefinerClass [
 	^Smalltalk compilerClass
 ]
 
-{ #category : #'accessing - instances and variables' }
+{ #category : 'accessing - instances and variables' }
 Behavior >> subclassInstVarNames [
 	"Answer a Set of the names of the receiver's subclasses' instance variables."
 	^self allSubclasses flatCollectAsSet: [:aSubclass | aSubclass instVarNames]
 ]
 
-{ #category : #'accessing - class hierarchy' }
+{ #category : 'accessing - class hierarchy' }
 Behavior >> superclass [
 	"Answer the receiver's superclass, a Class."
 
 	^superclass
 ]
 
-{ #category : #'accessing - class hierarchy' }
+{ #category : 'accessing - class hierarchy' }
 Behavior >> superclass: aClass [
 
 	"Change the receiver's superclass to be aClass."
@@ -1578,7 +1580,7 @@ Behavior >> superclass: aClass [
 		to: [ :builder | builder superclass: aClass ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Behavior >> superclass: aClass methodDictionary: mDict format: fmt [
 	"Basic initialization of the receiver.
 	Must only be sent to a new instance; else we would need Object flushCache."
@@ -1587,7 +1589,7 @@ Behavior >> superclass: aClass methodDictionary: mDict format: fmt [
 	self methodDict: mDict
 ]
 
-{ #category : #'testing - method dictionary' }
+{ #category : 'testing - method dictionary' }
 Behavior >> thoroughHasSelectorReferringTo: literal [
 	"Answer true if any of my methods access the argument as a
 	literal. Dives into the compact literal notation, making it slow but
@@ -1600,7 +1602,7 @@ Behavior >> thoroughHasSelectorReferringTo: literal [
 		method hasSelector: literal specialSelectorIndex: specialIndex]
 ]
 
-{ #category : #'testing - method dictionary' }
+{ #category : 'testing - method dictionary' }
 Behavior >> thoroughWhichMethodsReferTo: literal [
 	"Answer methods whose methods referes to the argument as a literal.
 	 Dives into the compact literal notation and embedded literal arrays,
@@ -1612,7 +1614,7 @@ Behavior >> thoroughWhichMethodsReferTo: literal [
 	^ self methods select: [ :method | method hasSelector: literal specialSelectorIndex: specialIndex ]
 ]
 
-{ #category : #'testing - method dictionary' }
+{ #category : 'testing - method dictionary' }
 Behavior >> thoroughWhichMethodsReferTo: literal specialIndex: specialIndex [
 	"Answer methods whose methods referes to the argument as a literal.
 	 Dives into the compact literal notation and embedded literal arrays,
@@ -1621,26 +1623,26 @@ Behavior >> thoroughWhichMethodsReferTo: literal specialIndex: specialIndex [
 	^ self methods select: [ :method | method hasSelector: literal specialSelectorIndex: specialIndex ]
 ]
 
-{ #category : #'testing - method dictionary' }
+{ #category : 'testing - method dictionary' }
 Behavior >> thoroughWhichSelectorsReferTo: literal [
 	^ (self thoroughWhichMethodsReferTo: literal) collect: [ :method | method selector ]
 ]
 
-{ #category : #'user interface' }
+{ #category : 'user interface' }
 Behavior >> unreferencedInstanceVariables [
 	"Return a list of the instance variables defined in the receiver which are not referenced in the receiver or any of its subclasses."
 
 	^ self slots reject: [:slot | slot isReferenced]
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 Behavior >> usingMethods [
 	"all methods that reference me"
 	self isAnonymous ifTrue: [ ^#() ].
 	^self binding usingMethods
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 Behavior >> whichClassDefinesClassVar: aString [
 	Symbol hasInterned: aString ifTrue: [ :aSymbol |
 		^self whichSuperclassSatisfies:
@@ -1649,13 +1651,13 @@ Behavior >> whichClassDefinesClassVar: aString [
 	^#()
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 Behavior >> whichClassDefinesInstVar: aString [
 	^self
 		whichSuperclassSatisfies: [:aClass | aClass instVarNames includes: aString]
 ]
 
-{ #category : #'testing - method dictionary' }
+{ #category : 'testing - method dictionary' }
 Behavior >> whichClassIncludesSelector: aSymbol [
 	"Answer the class on the receiver's superclass chain where the
 	argument, aSymbol (a message selector), will be found. Answer nil if none found."
@@ -1667,32 +1669,32 @@ Behavior >> whichClassIncludesSelector: aSymbol [
 	^ self superclass whichClassIncludesSelector: aSymbol
 ]
 
-{ #category : #'testing - method dictionary' }
+{ #category : 'testing - method dictionary' }
 Behavior >> whichMethodsReferTo: aLiteral [
 	"Answer methods whose methods directly refers to the argument as a literal"
 
 	^ self methods select: [ :method | method hasLiteral: aLiteral ]
 ]
 
-{ #category : #'testing - method dictionary' }
+{ #category : 'testing - method dictionary' }
 Behavior >> whichSelectorsReferTo: literal [
 	^ (self whichMethodsReferTo: literal) collect: [ :method | method selector ]
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 Behavior >> whichSuperclassSatisfies: aBlock [
 	(aBlock value: self) ifTrue: [^self].
 	^self superclass ifNotNil: [self superclass whichSuperclassSatisfies: aBlock]
 ]
 
-{ #category : #'user interface' }
+{ #category : 'user interface' }
 Behavior >> withAllSubAndSuperclassesDo: aBlock [
 
 	self withAllSubclassesDo: aBlock.
 	self allSuperclassesDo: aBlock
 ]
 
-{ #category : #'accessing - class hierarchy' }
+{ #category : 'accessing - class hierarchy' }
 Behavior >> withAllSubclasses [
 	"Answer a Set of the receiver, the receiver's descendent's, and the
 	receiver's descendent's subclasses."
@@ -1701,28 +1703,28 @@ Behavior >> withAllSubclasses [
 		 yourself
 ]
 
-{ #category : #'accessing - class hierarchy' }
+{ #category : 'accessing - class hierarchy' }
 Behavior >> withAllSubclassesDo: aBlock [
 	"Evaluate the argument, aBlock, for the receiver and each of its subclasses."
 
 	self withAllSubclasses do: aBlock
 ]
 
-{ #category : #'accessing - class hierarchy' }
+{ #category : 'accessing - class hierarchy' }
 Behavior >> withAllSuperAndSubclasses [
 	"Answer the receiver's class hierarchy"
 
 	^self allSuperclasses, self withAllSubclasses
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 Behavior >> withAllSuperAndSubclassesDo: aBlock [
 	self allSuperclassesDo: aBlock.
 	aBlock value: self.
 	self allSubclassesDo: aBlock
 ]
 
-{ #category : #'accessing - class hierarchy' }
+{ #category : 'accessing - class hierarchy' }
 Behavior >> withAllSuperclasses [
 	"Answer an OrderedCollection of the receiver and the receiver's superclasses.
 	The first element is the receiver, followed by its superclass;
@@ -1733,7 +1735,7 @@ Behavior >> withAllSuperclasses [
 		yourself
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 Behavior >> withAllSuperclassesDo: aBlock [
 	"Evaluate the argument, aBlock, for each of the receiver's superclasses."
 	aBlock value: self.

--- a/src/Kernel/BitsLayout.class.st
+++ b/src/Kernel/BitsLayout.class.st
@@ -2,30 +2,32 @@
 I am a specialized layout which does not hold slots but only raw data (bytes or words).
 "
 Class {
-	#name : #BitsLayout,
-	#superclass : #ObjectLayout,
-	#category : #'Kernel-Layout'
+	#name : 'BitsLayout',
+	#superclass : 'ObjectLayout',
+	#category : 'Kernel-Layout',
+	#package : 'Kernel',
+	#tag : 'Layout'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 BitsLayout class >> isAbstract [
 	^self == BitsLayout
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BitsLayout >> bytesPerSlot [
 
 	^ 8
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 BitsLayout >> extend [
 	"Answer a default extension of me."
 
 	^ self species new
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 BitsLayout >> extendByte [
 	IncompatibleLayoutConflict new
 		layout: self;
@@ -33,7 +35,7 @@ BitsLayout >> extendByte [
 		signal
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 BitsLayout >> extendDoubleByte [
 	IncompatibleLayoutConflict new
 		layout: self;
@@ -41,7 +43,7 @@ BitsLayout >> extendDoubleByte [
 		signal
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 BitsLayout >> extendDoubleWord [
 	IncompatibleLayoutConflict new
 		layout: self;
@@ -49,7 +51,7 @@ BitsLayout >> extendDoubleWord [
 		signal
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 BitsLayout >> extendWeak: aLayoutClassScope [
 	IncompatibleLayoutConflict new
 		layout: self;
@@ -57,7 +59,7 @@ BitsLayout >> extendWeak: aLayoutClassScope [
 		signal
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 BitsLayout >> extendWord [
 	IncompatibleLayoutConflict new
 		layout: self;
@@ -65,32 +67,32 @@ BitsLayout >> extendWord [
 		signal
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 BitsLayout >> isBits [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 BitsLayout >> isBytes [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 BitsLayout >> isDoubleBytes [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 BitsLayout >> isDoubleWords [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 BitsLayout >> isVariable [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 BitsLayout >> isWords [
 	^ false
 ]

--- a/src/Kernel/BlockCannotReturn.class.st
+++ b/src/Kernel/BlockCannotReturn.class.st
@@ -2,15 +2,17 @@
 This exception is thrown when a block tries to return but there is no home context.
 "
 Class {
-	#name : #BlockCannotReturn,
-	#superclass : #CannotReturn,
+	#name : 'BlockCannotReturn',
+	#superclass : 'CannotReturn',
 	#instVars : [
 		'home'
 	],
-	#category : #'Kernel-Exceptions'
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #signalling }
+{ #category : 'signalling' }
 BlockCannotReturn class >> result: anObject from: homeContext [
 
 	^self new
@@ -19,12 +21,12 @@ BlockCannotReturn class >> result: anObject from: homeContext [
 		signal
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BlockCannotReturn >> home [
 	^ home
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BlockCannotReturn >> home: anObject [
 	home := anObject
 ]

--- a/src/Kernel/BlockClosure.class.st
+++ b/src/Kernel/BlockClosure.class.st
@@ -33,43 +33,45 @@ Common blocks (2/3 of the blocks) are optimized directly in the compiler and hav
 
 "
 Class {
-	#name : #BlockClosure,
-	#superclass : #Object,
-	#type : #variable,
+	#name : 'BlockClosure',
+	#superclass : 'Object',
+	#type : 'variable',
 	#instVars : [
 		'outerContext',
 		'compiledBlock',
 		'numArgs'
 	],
-	#category : #'Kernel-Methods'
+	#category : 'Kernel-Methods',
+	#package : 'Kernel',
+	#tag : 'Methods'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 BlockClosure class >> isAbstract [
 
 	^ self == BlockClosure
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BlockClosure >> argumentCount [
 	"Answer the number of arguments that must be used to evaluate this block"
 
 	^numArgs
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BlockClosure >> argumentNames [
 	^ self sourceNode argumentNames
 ]
 
-{ #category : #scheduling }
+{ #category : 'scheduling' }
 BlockClosure >> asContext [
 	"Create a MethodContext that is ready to execute self.  Assumes self takes no args (if it does the args will be nil)"
 
 	^self asContextWithSender: nil
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 BlockClosure >> asContextWithSender: aContext [
 	"Inner private support method for evaluation.  Do not use unless you know what you're doing."
 
@@ -82,20 +84,20 @@ BlockClosure >> asContextWithSender: aContext [
 		privRefresh
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 BlockClosure >> asMinimalRepresentation [
 	"Answer the receiver."
 
 	^self
 ]
 
-{ #category : #exceptions }
+{ #category : 'exceptions' }
 BlockClosure >> assert [
 
 	self value ifFalse: [AssertionFailure signal: 'Assertion failed']
 ]
 
-{ #category : #exceptions }
+{ #category : 'exceptions' }
 BlockClosure >> assertWithDescription: aStringOrABlock [
 	| value |
 	self value
@@ -104,30 +106,30 @@ BlockClosure >> assertWithDescription: aStringOrABlock [
 	AssertionFailure signal: value
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 BlockClosure >> clearTemporariesOn: aContext [
 
 	(self numArgs + self numCopiedValues + 1) to: self numTemps do: [ :anIndex |
 		aContext tempAt: anIndex put: nil ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BlockClosure >> compiledBlock [
 	^ compiledBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BlockClosure >> compiledBlock: aCompiledMethod [
 	compiledBlock := aCompiledMethod
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BlockClosure >> copiedValueAt: i [
 	<primitive: 60>
 	^self basicAt: i
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 BlockClosure >> copyForSaving [
 	"Answer a copy of the receiver suitable for serialization.
 	 Notionally, if the receiver's outerContext has been returned from then nothing
@@ -137,7 +139,7 @@ BlockClosure >> copyForSaving [
 	^self shallowCopy postCopy
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> cull: anArg [
 	"Execute the receiver with one or zero arguments depending on the receiver"
 	"([ 12 ] cull: 13)>>> 12 "
@@ -147,7 +149,7 @@ BlockClosure >> cull: anArg [
 		ifFalse: [self value: anArg]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> cull: firstArg cull: secondArg [
 	"Execute the receiver with one or two arguments depending on the receiver"
 	"([:x | x + 1] cull: 13 cull: 12) >>> 14
@@ -159,14 +161,14 @@ BlockClosure >> cull: firstArg cull: secondArg [
 		ifFalse: [self value: firstArg value: secondArg]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> cull: firstArg cull: secondArg cull: thirdArg [
 	^numArgs < 3
 		ifTrue: [self cull: firstArg cull: secondArg]
 		ifFalse: [self value: firstArg value: secondArg value: thirdArg]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> cull: firstArg cull: secondArg cull: thirdArg cull: fourthArg [
 	"Execute the receiver with four or less arguments. Check cull:cull: for examples"
 
@@ -175,7 +177,7 @@ BlockClosure >> cull: firstArg cull: secondArg cull: thirdArg cull: fourthArg [
 		ifFalse: [self value: firstArg value: secondArg value: thirdArg value: fourthArg]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 BlockClosure >> doPrintOn: aStream [
 
 	| code |
@@ -186,7 +188,7 @@ BlockClosure >> doPrintOn: aStream [
 	aStream nextPutAll: code
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 BlockClosure >> doWhileFalse: conditionBlock [
 	"Evaluate the receiver once, then again as long the value of conditionBlock is false."
 
@@ -197,7 +199,7 @@ BlockClosure >> doWhileFalse: conditionBlock [
 	^ result
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 BlockClosure >> doWhileTrue: conditionBlock [
 	"Evaluate the receiver once, then again as long the value of conditionBlock is true."
 
@@ -208,19 +210,19 @@ BlockClosure >> doWhileTrue: conditionBlock [
 	^ result
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> durationToRun [
 	"Answer the duration taken to execute this block."
 
 	^ self timeToRun
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BlockClosure >> endPC [
 	^ self compiledBlock endPC
 ]
 
-{ #category : #exceptions }
+{ #category : 'exceptions' }
 BlockClosure >> ensure: aBlock [
 	"Evaluate a termination block after evaluating the receiver, regardless of
 	 whether the receiver's evaluation completes.  N.B.  This method is *not*
@@ -239,14 +241,14 @@ BlockClosure >> ensure: aBlock [
 	^ returnValue
 ]
 
-{ #category : #scheduling }
+{ #category : 'scheduling' }
 BlockClosure >> fork [
 	"Create and schedule a Process running the code in the receiver."
 
 	^ self newProcess resume
 ]
 
-{ #category : #scheduling }
+{ #category : 'scheduling' }
 BlockClosure >> forkAndWait [
 	"Suspend current process and execute self in new process, when it completes resume current process"
 
@@ -256,7 +258,7 @@ BlockClosure >> forkAndWait [
 	semaphore wait
 ]
 
-{ #category : #scheduling }
+{ #category : 'scheduling' }
 BlockClosure >> forkAt: priority [
 	"Create and schedule a Process running the code in the receiver at the given priority. Answer the newly created process."
 
@@ -265,7 +267,7 @@ BlockClosure >> forkAt: priority [
 		resume
 ]
 
-{ #category : #scheduling }
+{ #category : 'scheduling' }
 BlockClosure >> forkAt: priority named: name [
 
 	"Create and schedule a Process running the code in the receiver at the
@@ -279,7 +281,7 @@ BlockClosure >> forkAt: priority named: name [
 	^ forkedProcess resume
 ]
 
-{ #category : #scheduling }
+{ #category : 'scheduling' }
 BlockClosure >> forkNamed: aString [
 
 	"Create and schedule a Process running the code in the receiver and having the given name."
@@ -287,7 +289,7 @@ BlockClosure >> forkNamed: aString [
 	^ self newProcess name: aString; resume
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 BlockClosure >> hasMethodReturn [
 	self
 		deprecated: 'use #hasNonLocalReturn'
@@ -295,19 +297,19 @@ BlockClosure >> hasMethodReturn [
 	^self hasNonLocalReturn
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 BlockClosure >> hasNonLocalReturn [
 	"Answer whether the receiver has a method-return ('^') in its code."
 	self withAllBlocksDo: [ :each | each hasMethodReturn ifTrue: [ ^true ] ].
 	^false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BlockClosure >> home [
 	^ outerContext ifNotNil: [ outerContext home ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BlockClosure >> homeMethod [
 	"return the home method. If no #home is available due to no outerContext, use the compiledBlock"
 	^ (self home
@@ -315,7 +317,7 @@ BlockClosure >> homeMethod [
 		   ifNil: [ self compiledBlock ]) method
 ]
 
-{ #category : #exceptions }
+{ #category : 'exceptions' }
 BlockClosure >> ifCurtailed: aBlock [
 	"Evaluate the receiver with an abnormal termination action.
 	 Evaluate aBlock only if execution is unwound during execution
@@ -332,54 +334,54 @@ BlockClosure >> ifCurtailed: aBlock [
 	^result
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 BlockClosure >> initialStackPointer [
 
 	^ self numTemps
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 BlockClosure >> isBlock [
 
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 BlockClosure >> isClean [
 	"for now we forward to the AST. When clean blocks are enabled, we can just return false
 	as CleanBlockClosure returns true"
 	^self sourceNode isClean
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 BlockClosure >> isClosure [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 BlockClosure >> isDead [
 	"Has self finished"
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 BlockClosure >> isFullBlock [
 	^ true
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 BlockClosure >> isValid [
 	"Answer the receiver."
 
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BlockClosure >> method [
 	^ self compiledBlock
 ]
 
-{ #category : #scheduling }
+{ #category : 'scheduling' }
 BlockClosure >> newProcess [
 	"Answer a Process running the code in the receiver. The process is not
 	scheduled.
@@ -394,7 +396,7 @@ BlockClosure >> newProcess [
 		priority: Processor activePriority
 ]
 
-{ #category : #scheduling }
+{ #category : 'scheduling' }
 BlockClosure >> newProcessWith: anArray [
 	"Answer a Process running the code in the receiver. The receiver's block
 	arguments are bound to the contents of the argument, anArray. The
@@ -408,25 +410,25 @@ BlockClosure >> newProcessWith: anArray [
 		priority: Processor activePriority
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BlockClosure >> numArgs [
 	"Answer the number of arguments that must be used to evaluate this block"
 
 	^numArgs
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BlockClosure >> numArgs: n [
 	numArgs := n
 ]
 
-{ #category : #'error handling' }
+{ #category : 'error handling' }
 BlockClosure >> numArgsError: numArgsForInvocation [
 
 	ArgumentsCountMismatch signalExpectedArgumentsCount: numArgs calledArgumentsCount: numArgsForInvocation
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BlockClosure >> numCopiedValues [
 	"Answer the number of copied values of the receiver.  Since these are
 	 stored in the receiver's indexable fields this is the receiver's basic size.
@@ -437,12 +439,12 @@ BlockClosure >> numCopiedValues [
 	^self basicSize
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BlockClosure >> numTemps [
 	^ self compiledBlock numTemps
 ]
 
-{ #category : #exceptions }
+{ #category : 'exceptions' }
 BlockClosure >> on: exception do: handlerAction [
 	"Evaluate the receiver in the scope of an exception handler.
 	The following primitive is just a marker used to find the error handling context.
@@ -451,7 +453,7 @@ BlockClosure >> on: exception do: handlerAction [
 	^ self value
 ]
 
-{ #category : #exceptions }
+{ #category : 'exceptions' }
 BlockClosure >> on: exception fork: handlerAction [
 	"Activate the receiver. In case of exception, fork a new process, which will handle an error.
 	An original process will continue running as if receiver evaluation finished and answered nil,
@@ -494,7 +496,7 @@ BlockClosure >> on: exception fork: handlerAction [
 			  nil ]
 ]
 
-{ #category : #exceptions }
+{ #category : 'exceptions' }
 BlockClosure >> on: exception fork: handlerAction return: answerAction [
 	"This is the same as #on:fork: but instead just fork and letting the flow continues, in
 	 case of an error it also evaluates answerAction and returns its result."
@@ -527,7 +529,7 @@ BlockClosure >> on: exception fork: handlerAction return: answerAction [
 		answerAction cull: exception ]
 ]
 
-{ #category : #exceptions }
+{ #category : 'exceptions' }
 BlockClosure >> onDNU: selector do: handleBlock [
 	"Catch MessageNotUnderstood exceptions but only those of the given selector (DNU stands for doesNotUnderstand:)"
 
@@ -538,7 +540,7 @@ BlockClosure >> onDNU: selector do: handleBlock [
 	  ]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> onErrorDo: errorHandlerBlock [
 	"Evaluate the block represented by the receiver, and normally return it's value.  If an error occurs, the errorHandlerBlock is evaluated, and it's value is instead returned.  The errorHandlerBlock must accept zero or one parameter (the error object)."
 	"Examples:
@@ -552,17 +554,17 @@ BlockClosure >> onErrorDo: errorHandlerBlock [
 	^ self on: Error do: [:ex | errorHandlerBlock cull: ex]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BlockClosure >> outerContext [
 	^outerContext
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BlockClosure >> outerContext: ctxt [
 	outerContext := ctxt
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 BlockClosure >> printOn: aStream [
 
 	[self doPrintOn: aStream]
@@ -572,26 +574,26 @@ BlockClosure >> printOn: aStream [
 				nextPutAll: ' >' ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BlockClosure >> receiver [
 	^ self subclassResponsibility
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 BlockClosure >> reentrant [
 	"Answer a version of the recever that can be reentered.
 	 Closures are reentrant (unlike BlockContect) so simply answer self."
 	^self
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 BlockClosure >> repeat [
 	"Evaluate the receiver repeatedly, ending only if the block explicitly returns."
 
 	[self value. true] whileTrue
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 BlockClosure >> repeatWithGCIf: testBlock [
 	| ans |
 	"run the receiver, and if testBlock returns true, garbage collect and run the receiver again"
@@ -600,12 +602,12 @@ BlockClosure >> repeatWithGCIf: testBlock [
 	^ans
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BlockClosure >> sender [
 	^ self subclassResponsibility
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> simulateValueWithArguments: anArray caller: aContext [
 	"Simulate the valueWithArguments: primitive. Fail if anArray is not an array of the right arity."
 	| newContext |
@@ -626,22 +628,22 @@ BlockClosure >> simulateValueWithArguments: anArray caller: aContext [
 	^newContext
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BlockClosure >> startpc [
 	^ self compiledBlock initialPC
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BlockClosure >> startpcOrOuterCode [
 	^ compiledBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BlockClosure >> tempNames [
 	^ self sourceNode temporaryNames
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> value [
 	"Activate the receiver, creating a closure activation (MethodContext)
 	 whose closure is the receiver and whose caller is the sender of this
@@ -653,7 +655,7 @@ BlockClosure >> value [
 	^self primitiveFailed
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> value: firstArg [
 	"Activate the receiver, creating a closure activation (MethodContext)
 	 whose closure is the receiver and whose caller is the sender of this
@@ -671,7 +673,7 @@ BlockClosure >> value: firstArg [
 		ifFalse: [self primitiveFailed]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> value: firstArg value: secondArg [
 	"Activate the receiver, creating a closure activation (MethodContext)
 	 whose closure is the receiver and whose caller is the sender of this
@@ -690,7 +692,7 @@ BlockClosure >> value: firstArg value: secondArg [
 		ifFalse: [self primitiveFailed]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> value: firstArg value: secondArg value: thirdArg [
 	"Activate the receiver, creating a closure activation (MethodContext)
 	 whose closure is the receiver and whose caller is the sender of this
@@ -710,7 +712,7 @@ BlockClosure >> value: firstArg value: secondArg value: thirdArg [
 		ifFalse: [self primitiveFailed]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> value: firstArg value: secondArg value: thirdArg value: fourthArg [
 	"Activate the receiver, creating a closure activation (MethodContext)
 	 whose closure is the receiver and whose caller is the sender of this
@@ -731,7 +733,7 @@ BlockClosure >> value: firstArg value: secondArg value: thirdArg value: fourthAr
 		ifFalse: [self primitiveFailed]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> valueAfterWaiting: aDelay [
 	"Waits for a delay, then executes the block. Answers the process so you can terminate it"
 
@@ -745,7 +747,7 @@ BlockClosure >> valueAfterWaiting: aDelay [
 					print: self ] )
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> valueNoContextSwitch [
 	"An exact copy of BlockClosure>>value except that this version will not preempt
 	 the current process on block activation if a higher-priority process is runnable.
@@ -756,7 +758,7 @@ BlockClosure >> valueNoContextSwitch [
 	self primitiveFailed
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> valueNoContextSwitch: anArg [
 	"An exact copy of BlockClosure>>value: except that this version will not preempt
 	 the current process on block activation if a higher-priority process is runnable.
@@ -767,14 +769,14 @@ BlockClosure >> valueNoContextSwitch: anArg [
 	self primitiveFailed
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> valueSupplyingAnswer: anObject [
 	^ (anObject isCollection and: [anObject isString not])
 		ifTrue: [self valueSupplyingAnswers: {anObject}]
 		ifFalse: [self valueSupplyingAnswers: {{'*'. anObject}}]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> valueSupplyingAnswers: aListOfPairs [
 	"evaluate the block using a list of questions / answers that might be called upon to
 	automatically respond to Object>>confirm: or FillInTheBlank requests"
@@ -802,13 +804,13 @@ BlockClosure >> valueSupplyingAnswers: aListOfPairs [
 						ifNotNil: [ notify resume: outerAnswer ] ] ]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> valueSuppressingAllMessages [
 
 	^ self valueSuppressingMessages: #('*')
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> valueSuppressingMessages: aListOfStrings [
 
 	^ self
@@ -816,20 +818,20 @@ BlockClosure >> valueSuppressingMessages: aListOfStrings [
 		supplyingAnswers: #()
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> valueSuppressingMessages: aListOfStrings supplyingAnswers: aListOfPairs [
 
 	^ self valueSupplyingAnswers: aListOfPairs, (aListOfStrings collect: [:each | {each . true}])
 ]
 
-{ #category : #exceptions }
+{ #category : 'exceptions' }
 BlockClosure >> valueUninterruptably [
 	"Prevent remote returns from escaping the sender.  Even attempts to terminate (unwind) this process will be halted and the process will resume here.  A terminate message is needed for every one of these in the sender chain to get the entire process unwound."
 
 	^ self ifCurtailed: [^ self]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 BlockClosure >> valueUnpreemptively [
 	"Evaluate the receiver (block), without the possibility of preemption by higher priority processes. Use this facility VERY sparingly!"
 	"Think about using Block>>valueUninterruptably first, and think about using Semaphore>>critical: before that, and think about redesigning your application even before that!
@@ -849,7 +851,7 @@ BlockClosure >> valueUnpreemptively [
 	^result
 ]
 
-{ #category : #scheduling }
+{ #category : 'scheduling' }
 BlockClosure >> valueUnwindInContext: ctxt [ 
 	"Create a context for the unwind block and execute it on the unwind block's stack.
 	Note: using #value instead of #runUntilErrorOrReturnFrom: would lead to executing
@@ -861,7 +863,7 @@ BlockClosure >> valueUnwindInContext: ctxt [
 
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> valueWithArguments: anArray [
 	"Activate the receiver, creating a closure activation (MethodContext)
 	 whose closure is the receiver and whose caller is the sender of this
@@ -878,7 +880,7 @@ BlockClosure >> valueWithArguments: anArray [
 			^ self valueWithArguments: anArray asArray ]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> valueWithEnoughArguments: anArray [
 	"call me with enough arguments from anArray"
 	| args |
@@ -894,13 +896,13 @@ BlockClosure >> valueWithEnoughArguments: anArray [
 	^ self valueWithArguments: args
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> valueWithExit [
 
 	^ self value: [ ^ nil ]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> valueWithInterval: aDelay [
 	"Executes the block every x milliseconds specified in arguments. Answers the process, so you can terminate it"
 
@@ -914,7 +916,7 @@ BlockClosure >> valueWithInterval: aDelay [
 					print: self ] )
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> valueWithPossibleArgs: anArray [
 	"Execute the receiver with the correct number of arguments taken from the argument."
 	"([:x | x + 1] valueWithPossibleArgs: #( 13 12 15)) >>> 14
@@ -937,7 +939,7 @@ BlockClosure >> valueWithPossibleArgs: anArray [
 							ifFalse: [anArray copyFrom: 1 to: numArgs]])]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> valueWithPossibleArgument: anArg [
 	"Evaluate the block represented by the receiver.
 	 If the block requires one argument, use anArg, if it requires more than one,
@@ -951,7 +953,7 @@ BlockClosure >> valueWithPossibleArgument: anArg [
 	^self valueWithArguments: a
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 BlockClosure >> valueWithin: aDuration onTimeout: timeoutBlock [
 	"Evaluate the receiver.
 	If the evaluation does not complete in less than aDuration evaluate the timeoutBlock instead"
@@ -985,7 +987,7 @@ BlockClosure >> valueWithin: aDuration onTimeout: timeoutBlock [
 				ifFalse:[ e pass]]
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 BlockClosure >> whileFalse [
 	"Ordinarily compiled in-line, and therefore not overridable.
 	This is in case the message is sent to other than a literal block.
@@ -994,7 +996,7 @@ BlockClosure >> whileFalse [
 	self value ifFalse: [ self whileFalse ]
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 BlockClosure >> whileFalse: aBlock [
 	"Ordinarily compiled in-line, and therefore not overridable.
 	This is in case the message is sent to other than a literal block.
@@ -1004,19 +1006,19 @@ BlockClosure >> whileFalse: aBlock [
 	^ nil
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 BlockClosure >> whileNil: aBlock [
 	"Unlike #whileTrue/False: this is not compiled inline."
 	^ [self value isNil] whileTrue: [aBlock value]
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 BlockClosure >> whileNotNil: aBlock [
 	"Unlike #whileTrue/False: this is not compiled inline."
 	^ [self value notNil] whileTrue: [aBlock value]
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 BlockClosure >> whileTrue [
 	"Ordinarily compiled in-line, and therefore not overridable.
 	This is in case the message is sent to other than a literal block.
@@ -1025,7 +1027,7 @@ BlockClosure >> whileTrue [
 	self value ifTrue: [ self whileTrue ]
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 BlockClosure >> whileTrue: aBlock [
 	"Ordinarily compiled in-line, and therefore not overridable.
 	This is in case the message is sent to other than a literal block.
@@ -1035,7 +1037,7 @@ BlockClosure >> whileTrue: aBlock [
 	^ nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BlockClosure >> withAllBlocksDo: aBlock [
 	self compiledBlock withAllBlocksDo: aBlock
 ]

--- a/src/Kernel/Boolean.class.st
+++ b/src/Kernel/Boolean.class.st
@@ -4,17 +4,19 @@ Boolean is an abstract class defining the protocol for logic testing operations 
 Boolean redefines #new so no instances of Boolean can be created. It also redefines several messages in the 'copying' protocol to ensure that only one instance of each of its subclasses True (the global true, logical assertion) and False (the global false, logical negation) ever exist in the system.
 "
 Class {
-	#name : #Boolean,
-	#superclass : #Object,
-	#category : #'Kernel-Objects'
+	#name : 'Boolean',
+	#superclass : 'Object',
+	#category : 'Kernel-Objects',
+	#package : 'Kernel',
+	#tag : 'Objects'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Boolean class >> new [
 	self error: 'You may not create any more Booleans - this is two-valued logic'
 ]
 
-{ #category : #'logical operations' }
+{ #category : 'logical operations' }
 Boolean >> & aBoolean [
 	"Evaluating conjunction. Evaluate the argument. Then answer true if
 	both the receiver and the argument are true."
@@ -26,7 +28,7 @@ Boolean >> & aBoolean [
 	self subclassResponsibility
 ]
 
-{ #category : #'logical operations' }
+{ #category : 'logical operations' }
 Boolean >> ==> aBlock [
 	"The material conditional, also known as the material implication or truth functional conditional.
 	Correspond to not ... or ... and does not correspond to the English if...then... construction.
@@ -55,7 +57,7 @@ Boolean >> ==> aBlock [
 	^ self not or: [ aBlock value ]
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Boolean >> and: alternativeBlock [
 	"Nonevaluating conjunction. If the receiver is true, answer the value of
 	the argument, alternativeBlock; otherwise answer false without
@@ -69,7 +71,7 @@ Boolean >> and: alternativeBlock [
 	self subclassResponsibility
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Boolean >> asBit [
 	"convert myself to an Integer representing 1 for true and 0 for false"
 
@@ -80,18 +82,18 @@ Boolean >> asBit [
 	self subclassResponsibility
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Boolean >> asInteger [
 	^ self subclassResponsibility
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Boolean >> deepCopy [
 	"Receiver has two concrete subclasses, True and False.
 	Only one instance of each should be made, so return self."
 ]
 
-{ #category : #'logical operations' }
+{ #category : 'logical operations' }
 Boolean >> eqv: aBoolean [
 	"Answer true if the receiver is equivalent to aBoolean."
 
@@ -102,7 +104,7 @@ Boolean >> eqv: aBoolean [
 	^ self == aBoolean
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Boolean >> ifFalse: alternativeBlock [
 	"If the receiver is true (i.e., the condition is true), then the value is the
 	true alternative, which is nil. Otherwise answer the result of evaluating
@@ -116,7 +118,7 @@ Boolean >> ifFalse: alternativeBlock [
 	self subclassResponsibility
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Boolean >> ifFalse: falseAlternativeBlock ifTrue: trueAlternativeBlock [
 	"Same as ifTrue:ifFalse:."
 
@@ -126,7 +128,7 @@ Boolean >> ifFalse: falseAlternativeBlock ifTrue: trueAlternativeBlock [
 	self subclassResponsibility
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Boolean >> ifTrue: alternativeBlock [
 	"If the receiver is false (i.e., the condition is false), then the value is the
 	false alternative, which is nil. Otherwise answer the result of evaluating
@@ -140,7 +142,7 @@ Boolean >> ifTrue: alternativeBlock [
 	self subclassResponsibility
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Boolean >> ifTrue: trueAlternativeBlock ifFalse: falseAlternativeBlock [
 	"If the receiver is true (i.e., the condition is true), then answer the value
 	of the argument trueAlternativeBlock. If the receiver is false, answer the
@@ -154,17 +156,17 @@ Boolean >> ifTrue: trueAlternativeBlock ifFalse: falseAlternativeBlock [
 	self subclassResponsibility
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Boolean >> isLiteral [
 	^ true
 ]
 
-{ #category : #'self evaluating' }
+{ #category : 'self evaluating' }
 Boolean >> isSelfEvaluating [
 	^ true
 ]
 
-{ #category : #'logical operations' }
+{ #category : 'logical operations' }
 Boolean >> not [
 	"Negation. Answer true if the receiver is false, answer false if the
 	receiver is true."
@@ -174,7 +176,7 @@ Boolean >> not [
 	self subclassResponsibility
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Boolean >> or: alternativeBlock [
 	"Nonevaluating disjunction. If the receiver is false, answer the value of
 	the argument, alternativeBlock; otherwise answer true without
@@ -188,31 +190,31 @@ Boolean >> or: alternativeBlock [
 	self subclassResponsibility
 ]
 
-{ #category : #pinning }
+{ #category : 'pinning' }
 Boolean >> setPinnedInMemory: aBoolean [
 
 	self error: self printString , ' cannot be pinned.'
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Boolean >> shallowCopy [
 	"Receiver has two concrete subclasses, True and False.
 	Only one instance of each should be made, so return self."
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Boolean >> storeOn: aStream [
 	"Refer to the comment in Object|storeOn:."
 
 	self printOn: aStream
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Boolean >> veryDeepCopyWith: deepCopier [
 	"Return self.  I can't be copied.  Do not record me."
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Boolean >> xor: alternativeBlock [
 	"Nonevaluating conjunction. If the receiver is true, answer the opposite of the
 	the argument, alternativeBlock; otherwise answer the value of the alternativeBlock."
@@ -225,7 +227,7 @@ Boolean >> xor: alternativeBlock [
 	self subclassResponsibility
 ]
 
-{ #category : #'logical operations' }
+{ #category : 'logical operations' }
 Boolean >> | aBoolean [
 	"Evaluating disjunction (OR). Evaluate the argument. Then answer true
 	if either the receiver or the argument is true."

--- a/src/Kernel/BoxedFloat64.class.st
+++ b/src/Kernel/BoxedFloat64.class.st
@@ -2,18 +2,20 @@
 My instances hold 64-bit Floats in heap objects.  This is the only representation on 32-bit systems.  But on 64-bit systems SmallFloat64 holds a subset of the full 64-bit double-precision range in immediate objects.
 "
 Class {
-	#name : #BoxedFloat64,
-	#superclass : #Float,
-	#type : #words,
-	#category : #'Kernel-Numbers'
+	#name : 'BoxedFloat64',
+	#superclass : 'Float',
+	#type : 'words',
+	#category : 'Kernel-Numbers',
+	#package : 'Kernel',
+	#tag : 'Numbers'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 BoxedFloat64 class >> basicNew [
 	^self basicNew: 2
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 BoxedFloat64 class >> basicNew: sizeRequested [
 	"Primitive. Answer an instance of this class with the number
 	 of indexable variables specified by the argument, sizeRequested.
@@ -32,7 +34,7 @@ BoxedFloat64 class >> basicNew: sizeRequested [
 	self primitiveFailed
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 BoxedFloat64 >> * aNumber [
 	"Primitive. Answer the result of multiplying the receiver by aNumber.
 	Fail if the argument is not a Float. Essential. See Object documentation
@@ -42,7 +44,7 @@ BoxedFloat64 >> * aNumber [
 	^ aNumber adaptToFloat: self andSend: #*
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 BoxedFloat64 >> + aNumber [
 	"Primitive. Answer the sum of the receiver and aNumber. Essential.
 	Fail if the argument is not a Float. See Object documentation
@@ -52,7 +54,7 @@ BoxedFloat64 >> + aNumber [
 	^ aNumber adaptToFloat: self andSend: #+
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 BoxedFloat64 >> - aNumber [
 	"Primitive. Answer the difference between the receiver and aNumber.
 	Fail if the argument is not a Float. Essential. See Object documentation
@@ -62,7 +64,7 @@ BoxedFloat64 >> - aNumber [
 	^ aNumber adaptToFloat: self andSend: #-
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 BoxedFloat64 >> / aNumber [
 	"Primitive. Answer the result of dividing receiver by aNumber.
 	Fail if the argument is not a Float. Essential. See Object documentation
@@ -73,7 +75,7 @@ BoxedFloat64 >> / aNumber [
 	^aNumber adaptToFloat: self andSend: #/
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 BoxedFloat64 >> < aNumber [
 	"Primitive. Compare the receiver with the argument and return true
 	if the receiver is less than the argument. Otherwise return false.
@@ -84,7 +86,7 @@ BoxedFloat64 >> < aNumber [
 	^ aNumber adaptToFloat: self andCompare: #<
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 BoxedFloat64 >> <= aNumber [
 	"Primitive. Compare the receiver with the argument and return true
 	if the receiver is less than or equal to the argument. Otherwise return
@@ -95,7 +97,7 @@ BoxedFloat64 >> <= aNumber [
 	^ aNumber adaptToFloat: self andCompare: #<=
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 BoxedFloat64 >> = aNumber [
 	"Primitive. Compare the receiver with the argument and return true
 	if the receiver is equal to the argument. Otherwise return false.
@@ -107,7 +109,7 @@ BoxedFloat64 >> = aNumber [
 	^ aNumber adaptToFloat: self andCompare: #=
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 BoxedFloat64 >> > aNumber [
 	"Primitive. Compare the receiver with the argument and return true
 	if the receiver is greater than the argument. Otherwise return false.
@@ -118,7 +120,7 @@ BoxedFloat64 >> > aNumber [
 	^ aNumber adaptToFloat: self andCompare: #>
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 BoxedFloat64 >> >= aNumber [
 	"Primitive. Compare the receiver with the argument and return true
 	if the receiver is greater than or equal to the argument. Otherwise return
@@ -129,7 +131,7 @@ BoxedFloat64 >> >= aNumber [
 	^ aNumber adaptToFloat: self andCompare: #>=
 ]
 
-{ #category : #'math functions' }
+{ #category : 'math functions' }
 BoxedFloat64 >> exp [
 	"Answer E raised to the receiver power.
 	 Optional. See Object documentation whatIsAPrimitive."
@@ -163,7 +165,7 @@ BoxedFloat64 >> exp [
 	^ base * correction
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 BoxedFloat64 >> exponent [
 	"Primitive. Consider the receiver to be represented as a power of two
 	multiplied by a mantissa (between one and two). Answer with the
@@ -183,7 +185,7 @@ BoxedFloat64 >> exponent [
 	^self negated exponent
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 BoxedFloat64 >> fractionPart [
 	"Primitive. Answer a Float whose value is the difference between the
 	receiver and the receiver's asInteger value. Optional. See Object
@@ -193,7 +195,7 @@ BoxedFloat64 >> fractionPart [
 	^self - self truncated asFloat
 ]
 
-{ #category : #'math functions' }
+{ #category : 'math functions' }
 BoxedFloat64 >> ln [
 	"Answer the natural logarithm of the receiver.
 	 Optional. See Object documentation whatIsAPrimitive."
@@ -234,7 +236,7 @@ BoxedFloat64 >> ln [
 	"2.718284 ln 1.0"
 ]
 
-{ #category : #'math functions' }
+{ #category : 'math functions' }
 BoxedFloat64 >> timesTwoPower: anInteger [
 	"Primitive. Answer with the receiver multiplied by 2.0 raised
 	to the power of the argument.
@@ -248,7 +250,7 @@ BoxedFloat64 >> timesTwoPower: anInteger [
 	^ self * (2.0 raisedToInteger: anInteger)
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 BoxedFloat64 >> truncated [
 	"Answer with a SmallInteger equal to the value of the receiver without
 	its fractional part. The primitive fails if the truncated value cannot be
@@ -271,7 +273,7 @@ BoxedFloat64 >> truncated [
 		ifFalse: [^ self asTrueFraction.  "Extract all bits of the mantissa and shift if necess"]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 BoxedFloat64 >> ~= aNumber [
 	"Primitive. Compare the receiver with the argument and return true
 	if the receiver is not equal to the argument. Otherwise return false.

--- a/src/Kernel/ByteLayout.class.st
+++ b/src/Kernel/ByteLayout.class.st
@@ -2,19 +2,21 @@
 I am a raw data layout that holds bytes (8 bits).
 "
 Class {
-	#name : #ByteLayout,
-	#superclass : #BitsLayout,
-	#category : #'Kernel-Layout'
+	#name : 'ByteLayout',
+	#superclass : 'BitsLayout',
+	#category : 'Kernel-Layout',
+	#package : 'Kernel',
+	#tag : 'Layout'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ByteLayout class >> extending: superLayout scope: aScope host: aClass [
 	^ superLayout extendByte
 		host: aClass;
 		yourself
 ]
 
-{ #category : #description }
+{ #category : 'description' }
 ByteLayout class >> subclassDefiningSymbol [
 	"Answer a keyword that describes the receiver's kind of subclass
 	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
@@ -22,23 +24,23 @@ ByteLayout class >> subclassDefiningSymbol [
 	^#variableByteSubclass:
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ByteLayout >> bytesPerSlot [
 
 	^ 1
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 ByteLayout >> extendByte [
 	^ ByteLayout new
 ]
 
-{ #category : #format }
+{ #category : 'format' }
 ByteLayout >> instanceSpecification [
 	^ 16
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ByteLayout >> isBytes [
 	^ true
 ]

--- a/src/Kernel/BytecodeMappedInlinePrimitiveConfiguration.class.st
+++ b/src/Kernel/BytecodeMappedInlinePrimitiveConfiguration.class.st
@@ -4,12 +4,14 @@ My subclasses configure `InstructionClient`s to handle bytecode extensions.
 They send clients the `addMappedInlinePrimitiveHandler:at:` message to add bytecode handlers.
 "
 Class {
-	#name : #BytecodeMappedInlinePrimitiveConfiguration,
-	#superclass : #Object,
-	#category : #'Kernel-Methods'
+	#name : 'BytecodeMappedInlinePrimitiveConfiguration',
+	#superclass : 'Object',
+	#category : 'Kernel-Methods',
+	#package : 'Kernel',
+	#tag : 'Methods'
 }
 
-{ #category : #configuring }
+{ #category : 'configuring' }
 BytecodeMappedInlinePrimitiveConfiguration class >> configure: instructionClient [
 	"Send the `addMappedInlinePrimitiveHandler:at:` message to the instructionClient in order to add bytecode handlers"
 

--- a/src/Kernel/CannotReturn.class.st
+++ b/src/Kernel/CannotReturn.class.st
@@ -3,27 +3,29 @@ Block and Context cases for CannotReturn need to signal a dedicated exception.
 (see subclasses and the related testcases)
 "
 Class {
-	#name : #CannotReturn,
-	#superclass : #Error,
+	#name : 'CannotReturn',
+	#superclass : 'Error',
 	#instVars : [
 		'result'
 	],
-	#category : #'Kernel-Exceptions'
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 CannotReturn >> isResumable [
 
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CannotReturn >> result [
 
 	^result
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CannotReturn >> result: r [
 
 	result := r

--- a/src/Kernel/Character.class.st
+++ b/src/Kernel/Character.class.st
@@ -8,25 +8,27 @@ The other languages can have the language tag if you like.  This will help to br
 I represent a character by storing its associated ASCII code (extended to 256 codes). My instances are created uniquely, so that all instances of a character ($R, for example) are identical.
 "
 Class {
-	#name : #Character,
-	#superclass : #Magnitude,
-	#type : #immediate,
+	#name : 'Character',
+	#superclass : 'Magnitude',
+	#type : 'immediate',
 	#classVars : [
 		'CharSet',
 		'CharacterTable',
 		'DigitValues'
 	],
-	#category : #'Kernel-BasicObjects'
+	#category : 'Kernel-BasicObjects',
+	#package : 'Kernel',
+	#tag : 'BasicObjects'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Character class >> allByteCharacters [
 	"Answer all the characters that can be encoded in a byte"
 
 	^ (0 to: 255) collect: [:v | Character value: v] as: String
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Character class >> allCharacters [
 
 	"This name is obsolete since only the characters that will fit in a byte can be queried"
@@ -39,70 +41,70 @@ Character class >> allCharacters [
 	^ self allByteCharacters
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 Character class >> alphabet [
 	"($a to: $z) as: String"
 
 	^ 'abcdefghijklmnopqrstuvwxyz' copy
 ]
 
-{ #category : #'accessing untypeable characters' }
+{ #category : 'accessing untypeable characters' }
 Character class >> arrowDown [
 	^ self value: 31
 ]
 
-{ #category : #'accessing untypeable characters' }
+{ #category : 'accessing untypeable characters' }
 Character class >> arrowLeft [
 	^ self value: 28
 ]
 
-{ #category : #'accessing untypeable characters' }
+{ #category : 'accessing untypeable characters' }
 Character class >> arrowRight [
 	^ self value: 29
 ]
 
-{ #category : #'accessing untypeable characters' }
+{ #category : 'accessing untypeable characters' }
 Character class >> arrowUp [
 	^ self value: 30
 ]
 
-{ #category : #'accessing untypeable characters' }
+{ #category : 'accessing untypeable characters' }
 Character class >> backspace [
 	"Answer the Character representing a backspace."
 
 	^self value: 8
 ]
 
-{ #category : #'special characters' }
+{ #category : 'special characters' }
 Character class >> centeredDot [
 	^self codePoint: 183
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Character class >> characterSet [
 	^ CharSet ifNil: [ AsciiCharset ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Character class >> characterSet: aCharSet [
 	^ CharSet := aCharSet
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Character class >> codePoint: anInteger [
 	"Just for ANSI Compliance"
 
 	^self value: anInteger
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Character class >> constantNameFor: aCharacter [
 	^ self constantNames
 		detect: [ :each | (self perform: each) = aCharacter ]
 		ifNone: [ nil ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Character class >> constantNames [
 	"Added the rest of them!"
 
@@ -111,19 +113,19 @@ Character class >> constantNames [
 		enter end home insert nbsp pageDown pageUp null)
 ]
 
-{ #category : #'accessing untypeable characters' }
+{ #category : 'accessing untypeable characters' }
 Character class >> cr [
 	"Answer the Character representing a carriage return."
 
 	^self value: 13
 ]
 
-{ #category : #'accessing untypeable characters' }
+{ #category : 'accessing untypeable characters' }
 Character class >> delete [
 	^ self value: 127
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Character class >> digitValue: x [
 	"Answer the Character whose digit value is x. For example,
 	 answer $9 for x=9, $0 for x=0, $A for x=10, $Z for x=35."
@@ -133,43 +135,43 @@ Character class >> digitValue: x [
 	^self value: (n < 10 ifTrue: [n + 48] ifFalse: [n + 55])
 ]
 
-{ #category : #'special characters' }
+{ #category : 'special characters' }
 Character class >> divide [
 	^self codePoint: 247
 ]
 
-{ #category : #'accessing untypeable characters' }
+{ #category : 'accessing untypeable characters' }
 Character class >> end [
 	^ self value: 4
 ]
 
-{ #category : #'accessing untypeable characters' }
+{ #category : 'accessing untypeable characters' }
 Character class >> enter [
 	"Answer the Character representing enter."
 
 	^self value: 3
 ]
 
-{ #category : #'accessing untypeable characters' }
+{ #category : 'accessing untypeable characters' }
 Character class >> escape [
 	"Answer the ASCII ESC character"
 
 	^self value: 27
 ]
 
-{ #category : #'accessing untypeable characters' }
+{ #category : 'accessing untypeable characters' }
 Character class >> home [
 	^ self value: 1
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 Character class >> initialize [
 	"Create the DigitsValues table."
 
 	self initializeDigitValues
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Character class >> initializeDigitValues [
 	"Initialize the well known digit value of ascii characters.
 	Note that the DigitValues table is 1-based while ascii values are 0-based, thus the offset+1."
@@ -182,74 +184,74 @@ Character class >> initializeDigitValues [
 	10 to: 35 do: [:i | DigitValues at: 87 + i + 1 put: i]
 ]
 
-{ #category : #'accessing untypeable characters' }
+{ #category : 'accessing untypeable characters' }
 Character class >> insert [
 	^ self value: 5
 ]
 
-{ #category : #'accessing untypeable characters' }
+{ #category : 'accessing untypeable characters' }
 Character class >> lf [
 	"Answer the Character representing a linefeed."
 
 	^self value: 10
 ]
 
-{ #category : #'accessing untypeable characters' }
+{ #category : 'accessing untypeable characters' }
 Character class >> linefeed [
 	"Answer the Character representing a linefeed."
 
 	^self value: 10
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 Character class >> maxVal [
 	"Answer the maximum value (code point) for a Character."
 
 	^ (2 ** 30) - 1
 ]
 
-{ #category : #'accessing untypeable characters' }
+{ #category : 'accessing untypeable characters' }
 Character class >> nbsp [
 	"non-breakable space. Latin1 encoding common usage."
 
 	^ Character value: 160
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Character class >> new [
 	"Creating new characters is not allowed."
 
 	self error: 'cannot create new characters'
 ]
 
-{ #category : #'accessing untypeable characters' }
+{ #category : 'accessing untypeable characters' }
 Character class >> newPage [
 	"Answer the Character representing a form feed."
 
 	^self value: 12
 ]
 
-{ #category : #'accessing untypeable characters' }
+{ #category : 'accessing untypeable characters' }
 Character class >> null [
 	^ self value: 0
 ]
 
-{ #category : #'accessing untypeable characters' }
+{ #category : 'accessing untypeable characters' }
 Character class >> pageDown [
 	^ self value: 12
 ]
 
-{ #category : #'accessing untypeable characters' }
+{ #category : 'accessing untypeable characters' }
 Character class >> pageUp [
 	^ self value: 11
 ]
 
-{ #category : #'special characters' }
+{ #category : 'special characters' }
 Character class >> plusOrMinus [
 	^self codePoint: 177
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Character class >> separators [
 	"Answer a collection of the standard ASCII separator characters as string."
 
@@ -261,14 +263,14 @@ Character class >> separators [
 		collect: [:v | Character value: v] as: String
 ]
 
-{ #category : #'accessing untypeable characters' }
+{ #category : 'accessing untypeable characters' }
 Character class >> space [
 	"Answer the Character representing a space."
 
 	^self value: 32
 ]
 
-{ #category : #'special characters' }
+{ #category : 'special characters' }
 Character class >> specialCharacters [
 	^ '+-/\*~<>=@,%|&?!' , (String
 		   with: self centeredDot
@@ -277,40 +279,40 @@ Character class >> specialCharacters [
 		   with: self times)
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 Character class >> supportsNonASCII [
 
 	^ (self environment includesKey: #Unicode) and: [
 		((self environment  at: #EncodedCharSet) charsetAt: 255) name = #Unicode ]
 ]
 
-{ #category : #'accessing untypeable characters' }
+{ #category : 'accessing untypeable characters' }
 Character class >> tab [
 	"Answer the Character representing a tab."
 
 	^self value: 9
 ]
 
-{ #category : #'special characters' }
+{ #category : 'special characters' }
 Character class >> times [
 	^self codePoint: 215
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Character class >> value: anInteger [
 	"Answer the Character whose value is anInteger."
 	<primitive: 170>
 	^self primitiveFailed
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Character >> < aCharacter [
 	"Answer true if the receiver's value < aCharacter's value."
 
 	^self asciiValue < aCharacter asciiValue
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Character >> = aCharacter [
 	"Primitive. Answer if the receiver and the argument are the
 	 same object (have the same object pointer). Optional. See
@@ -319,21 +321,21 @@ Character >> = aCharacter [
 	^self == aCharacter
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Character >> > aCharacter [
 	"Answer true if the receiver's value > aCharacter's value."
 
 	^self asciiValue > aCharacter asciiValue
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Character >> asCharacter [
 	"Answer the receiver itself."
 
 	^ self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Character >> asHTMLString [
 	"substitute the < & > into HTML compliant elements"
 
@@ -342,43 +344,43 @@ Character >> asHTMLString [
 	^ String with: self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Character >> asInteger [
 	"Answer the receiver's character code."
 	<primitive: 171>
 	^self primitiveFailed
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Character >> asLowercase [
 	"If the receiver is uppercase, answer its matching lowercase Character."
 	^ self characterSet toLowercase: self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Character >> asString [
 	^ String with: self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Character >> asSymbol [
 	"Answer a Symbol consisting of the receiver as the only element."
 	^ self asString asSymbol
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Character >> asUnicode [
 
 	^ self asInteger
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Character >> asUppercase [
 	"If the receiver is lowercase, answer its matching uppercase Character."
 	^ self characterSet toUppercase: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Character >> asciiValue [
 	"Answer the receiver's character code.
 	 This will be ascii for characters with value <= 127,
@@ -387,7 +389,7 @@ Character >> asciiValue [
 	^self primitiveFailed
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Character >> basicIdentityHash [
 	"Answer the receiver's character code.
 	 The value answered is unsigned. It can in theory be in the full
@@ -397,7 +399,7 @@ Character >> basicIdentityHash [
 	^self primitiveFailed
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Character >> basicPharoToIso [
 	| tmp1 |
 	self asInteger < 128
@@ -409,42 +411,42 @@ Character >> basicPharoToIso [
 	^ Character value: tmp1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Character >> charCode [
 	^ self asInteger bitAnd: 4194303
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Character >> characterSet [
 	^ self class characterSet
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Character >> codePoint [
 	"Just for ANSI Compliance"
 	^self asciiValue
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Character >> copy [
 	"Answer the receiver, because Characters are unique."
 	^self
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Character >> deepCopy [
 	"Answer the receiver, because Characters are unique."
 	^self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Character >> digitValue [
 	self asInteger > 255
 		ifTrue: [ ^ self characterSet digitValueOf: self ].
 	^ DigitValues at: 1 + self asInteger
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Character >> hash [
 	"Hash is reimplemented because = is implemented.
 	 Answer the receiver's character code."
@@ -452,7 +454,7 @@ Character >> hash [
 	^self primitiveFailed
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Character >> hex [
 	"Returns a string representation of the receiver as hex, prefixed with 16r.
 	DO NOT CHANGE THIS!  The Cog VMMaker depends on this."
@@ -461,7 +463,7 @@ Character >> hex [
 	^ self asInteger hex
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Character >> hexDigitValue [
 	"Return the case independent hexadecimal digit value of the receiver.
 	$0 to: $9 will return 0 to 9, while $a to $f and $A to $F both will return 10 to 15.
@@ -474,7 +476,7 @@ Character >> hexDigitValue [
 		ifFalse: [ nil ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isAlphaNumeric [
 	"Answer whether the receiver is a letter or a digit."
 	"$a isAlphaNumeric >>> true"
@@ -486,13 +488,13 @@ Character >> isAlphaNumeric [
 	^ self isLetter or: [ self isDigit ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isArrow [
 
 	^ { Character arrowUp. Character arrowDown. Character arrowLeft. Character arrowRight } includes: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isCasedLetter [
 	"We are sorry but this method is unclear and will probably be removed.
 	This method only returning false."
@@ -502,13 +504,13 @@ Character >> isCasedLetter [
 	^ self characterSet isCasedLetter: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isCharacter [
 
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isClosePunctuation [
 	"Return whether the receiver is one of these characters:  )]}"
 	"$a isClosePunctuation >>> false"
@@ -520,7 +522,7 @@ Character >> isClosePunctuation [
 	^ self characterSet isClosePunctuation: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isConnectorPunctuation [
 	"Return whether the receiver is one of these characters:   _"
 	"$_ isConnectorPunctuation >>> true"
@@ -532,7 +534,7 @@ Character >> isConnectorPunctuation [
 	^ self characterSet isConnectorPunctuation: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isControlOther [
 	"Return whether the receiver is one of these characters: backspace, delete, escape, arrowUp, arrowLeft, arrowDown, arrowRight, pageUp, pageDown, end, home, nbsp, insert"
 	"Character delete isControlOther >>> true"
@@ -550,7 +552,7 @@ Character >> isControlOther [
 	^ self characterSet isControlOther: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isCurrencySymbol [
 	"Return whether the receiver is one of these characters:   $ and euro"
 	"$$ isCurrencySymbol >>> true"
@@ -560,7 +562,7 @@ Character >> isCurrencySymbol [
 	^ self characterSet isCurrencySymbol: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isDashPunctuation [
 	"Return whether the receiver is one of these characters:   $-"
 	"$- isDashPunctuation >>> true"
@@ -569,7 +571,7 @@ Character >> isDashPunctuation [
 	^ self characterSet isDashPunctuation: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isDecimalDigit [
 	"Return whether the receiver is a digit."
 	"$1 isDecimalDigit >>> true"
@@ -578,7 +580,7 @@ Character >> isDecimalDigit [
 	^ self characterSet isDecimalDigit: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isDigit [
 	"Return whether the receiver is a digit."
 	"$1 isDigit >>> true"
@@ -587,14 +589,14 @@ Character >> isDigit [
 	^ self characterSet isDigit: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isDoubleQuote [
 	"Returns whether the receiver is a Double Quote"
 
 	^ self = $"
 ]
 
-{ #category : #'testing - unicode' }
+{ #category : 'testing - unicode' }
 Character >> isEnclosingMark [
 	"Return whether the receiver is ... one of these https://www.compart.com/en/unicode/category/Me"
 	"$' isEnclosingMark >>> false"
@@ -603,7 +605,7 @@ Character >> isEnclosingMark [
 	^ self characterSet isEnclosingMark: self
 ]
 
-{ #category : #'testing - unicode' }
+{ #category : 'testing - unicode' }
 Character >> isFinalQuote [
 	"Return whether the receiver is https://www.compart.com/en/unicode/category/Pf"
 	"$' isFinalQuote >>> false"
@@ -611,19 +613,19 @@ Character >> isFinalQuote [
 	^ self characterSet isFinalQuote: self
 ]
 
-{ #category : #'testing - unicode' }
+{ #category : 'testing - unicode' }
 Character >> isFormatOther [
 	"Return whether the receiver in this category: https://www.compart.com/en/unicode/category/Cf"
 	^ self characterSet isFormatOther: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isImmediateObject [
 	"This is needed for the bootstrap"
 	^ true
 ]
 
-{ #category : #'testing - unicode' }
+{ #category : 'testing - unicode' }
 Character >> isInitialQuote [
 	"Return whether the receiver is https://www.compart.com/en/unicode/category/Pi"
 	"$' isInitialQuote >>> false"
@@ -631,7 +633,7 @@ Character >> isInitialQuote [
 	^ self characterSet isInitialQuote: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isLetter [
 	"Return whether the receiver is a letter."
 	"$a isLetter >>> true"
@@ -641,108 +643,108 @@ Character >> isLetter [
 	^ self characterSet isLetter: self
 ]
 
-{ #category : #'testing - unicode' }
+{ #category : 'testing - unicode' }
 Character >> isLetterModifier [
 	"Return whether the receiver is https://www.compart.com/en/unicode/category/Lm"
 
 	^ self characterSet isLetterModifier: self
 ]
 
-{ #category : #'testing - unicode' }
+{ #category : 'testing - unicode' }
 Character >> isLetterNumber [
 	"Return whether the receiver is part of https://www.compart.com/en/unicode/category/Nl"
 	^ self characterSet isLetterNumber: self
 ]
 
-{ #category : #'testing - unicode' }
+{ #category : 'testing - unicode' }
 Character >> isLineSeparator [
 	"Return whether the receiver is https://www.compart.com/en/unicode/category/Zl"
 
 	^ self characterSet isLineSeparator: self
 ]
 
-{ #category : #'testing - kind' }
+{ #category : 'testing - kind' }
 Character >> isLiteral [
 
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isLowercase [
 
 	^ self characterSet isLowercase: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isMathSymbol [
 	^ self characterSet isMathSymbol: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isModifierSymbol [
 
 	^ self characterSet isModifierSymbol: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isNonspacingMark [
 ^ self characterSet isNonspacingMark: self
 ]
 
-{ #category : #'testing - kind' }
+{ #category : 'testing - kind' }
 Character >> isOctetCharacter [
 	^ self asInteger < 256
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isOpenPunctuation [
 ^ self characterSet isOpenPunctuation: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isOtherLetter [
 ^ self characterSet isOtherLetter: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isOtherNumber [
 	^ self characterSet isOtherNumber: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isOtherPunctuation [
 ^ self characterSet isOtherPunctuation: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isOtherSymbol [
 ^ self characterSet isOtherSymbol: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isParagraphSeparator [
 ^ self characterSet isParagraphSeparator: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isPinnedInMemory [
 	"Immediate instances can't be pinned"
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isPrivateOther [
 ^ self characterSet isPrivateOther: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isPunctuation [
 
 	^ self isOpenPunctuation or: [ self isClosePunctuation ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isSafeForHTTP [
 	"Return whether a character is 'safe', or needs to be escaped when used, eg, in a URL"
 	"See http://www.faqs.org/rfcs/rfc1738.html. ~ is unsafe and has been removed"
@@ -752,7 +754,7 @@ Character >> isSafeForHTTP [
 				or: ['.-_' includes: (Character value: self charCode)]]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isSeparator [
 	"Returns whether the receiver is a separator i.e., a space, tab, lf, cr, and newPage"
 	"Character space isSeparator >>> true"
@@ -766,40 +768,40 @@ Character >> isSeparator [
 	^ (in := self asInteger) == 32 or: [ in == 13 or: [ in == 9 or: [ in == 10 or: [ in == 12 ] ] ] ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isSpaceSeparator [
 ^ self characterSet isSpaceSeparator: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isSpacingCombiningMark [
 ^ self characterSet isSpacingCombiningMark: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isSpecial [
 	"Answer whether the receiver is one of the special characters: i.e., +-/\*~<>=@,%|&?! and a couple of others."
 
 	^ self class specialCharacters includes: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isSurrogateOther [
 ^ self characterSet isSurrogateOther: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isTitlecaseLetter [
 ^ self characterSet isTitlecaseLetter: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isUppercase [
 
 	^ self characterSet isUppercase: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> isVowel [
 	"Answer whether the receiver is one of the vowels, AEIOU, in upper or
 	lower case."
@@ -807,19 +809,19 @@ Character >> isVowel [
 	^'AEIOU' includes: self asUppercase
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Character >> lowercase [
 	^ self asLowercase
 ]
 
-{ #category : #'memory scanning' }
+{ #category : 'memory scanning' }
 Character >> nextObject [
 	"Characters are immediate objects, and, as such, do not have successors in object memory."
 
 	self shouldNotImplement
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Character >> printOn: aStream [
 	| name |
 	(self asInteger > 32 and: [ self asInteger ~= 127])
@@ -832,43 +834,43 @@ Character >> printOn: aStream [
 				ifFalse: [ aStream nextPutAll: ' value: '; print: self asInteger ] ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Character >> printStringHex [
 	"$A printStringHex >>> '41'"
 
 	^ self asInteger printStringBase: 16
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Character >> sameAs: aCharacter [
 	"Answer whether the receiver is equal to aCharacter, ignoring case"
 	^ (self asLowercase = aCharacter asLowercase)
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Character >> setValue: newValue [
 	self error: 'Characters are immutable'
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Character >> shallowCopy [
 	"Answer the receiver, because Characters are unique."
 	^self
 ]
 
-{ #category : #'testing - kind' }
+{ #category : 'testing - kind' }
 Character >> shouldBePrintedAsLiteral [
 	^ self asInteger between: 33 and: 255
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Character >> storeBinaryOn: aStream [
 	self asInteger < 256
 		ifTrue: [ aStream basicNextPut: self asInteger ]
 		ifFalse: [ aStream nextInt32Put: self asInteger ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Character >> storeOn: aStream [
 	"Common character literals are preceded by '$', however special need to be encoded differently: for some this might be done by using one of the shortcut constructor methods for the rest we have to create them by ascii-value."
 
@@ -885,14 +887,14 @@ Character >> storeOn: aStream [
 						nextPutAll: ' value: '; print: self asInteger; nextPut: $) ] ]
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Character >> to: other [
 	"Answer with a collection in ascii order -- $a to: $z"
 	^ (self asciiValue to: other asciiValue) collect:
 				[:ascii | Character value: ascii]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Character >> tokenish [
 	"Answer whether the receiver is a valid token-character -- letter, digit, underscore, or colon."
 	"$' tokenish >>> false"
@@ -903,12 +905,12 @@ Character >> tokenish [
 	^ self isLetter or: [ self isDigit or: [ self = $_ or: [ self = $: ] ] ]
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Character >> uppercase [
 	^ self asUppercase
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Character >> veryDeepCopyWith: deepCopier [
 	"Answer the receiver, because Characters are unique."
 	^self

--- a/src/Kernel/ChronologyConstants.class.st
+++ b/src/Kernel/ChronologyConstants.class.st
@@ -2,8 +2,8 @@
 ChronologyConstants is a SharedPool for the constants used by the Kernel-Chronology classes.
 "
 Class {
-	#name : #ChronologyConstants,
-	#superclass : #SharedPool,
+	#name : 'ChronologyConstants',
+	#superclass : 'SharedPool',
 	#classVars : [
 		'DayNames',
 		'DaysInMonth',
@@ -19,10 +19,12 @@ Class {
 		'SecondsInMinute',
 		'SqueakEpoch'
 	],
-	#category : #'Kernel-Chronology'
+	#category : 'Kernel-Chronology',
+	#package : 'Kernel',
+	#tag : 'Chronology'
 }
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 ChronologyConstants class >> initialize [
 	"ChronologyConstants initialize"
 	SqueakEpoch := 2415386. 		"Julian day number of 1 Jan 1901"

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -14,8 +14,8 @@ In order to know if a class is obsolete or not, we save the instances in a weak 
 Note: In the past we saved this information in the properties of the class but this is slower than the current solution. Maybe we could speed up the properties management.
 "
 Class {
-	#name : #Class,
-	#superclass : #ClassDescription,
+	#name : 'Class',
+	#superclass : 'ClassDescription',
 	#instVars : [
 		'subclasses',
 		'name',
@@ -28,15 +28,17 @@ Class {
 	#classVars : [
 		'ObsoleteClasses'
 	],
-	#category : #'Kernel-Classes'
+	#category : 'Kernel-Classes',
+	#package : 'Kernel',
+	#tag : 'Classes'
 }
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 Class class >> allSuperclassesFor: aClass cache: cache [
 	^ cache at: aClass ifAbsentPut: [aClass allSuperclasses asArray]
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 Class class >> doesNotIncludeInstanceOrSuperclassesFor: aClass in: unprocessedClasses cache: cache [
 	| soleInstance |
 	soleInstance := aClass soleInstance.
@@ -44,14 +46,14 @@ Class class >> doesNotIncludeInstanceOrSuperclassesFor: aClass in: unprocessedCl
 				self hasNoSuperclassesOf: soleInstance in: unprocessedClasses cache: cache]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Class class >> hasNoDependenciesFor: aClass in: unprocessedClasses cache: cache [
 	^ (self hasNoSuperclassesOf: aClass in: unprocessedClasses cache: cache) and: [
 		aClass isMeta not or: [
 			self hasNoDependenciesForMetaclass: aClass in: unprocessedClasses cache: cache]]
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 Class class >> hasNoDependenciesForMetaclass: aClass in: unprocessedClasses cache: cache [
 	| soleInstance |
 	soleInstance := aClass soleInstance.
@@ -59,18 +61,18 @@ Class class >> hasNoDependenciesForMetaclass: aClass in: unprocessedClasses cach
 				self hasNoSuperclassesOf: soleInstance in: unprocessedClasses cache: cache]
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 Class class >> hasNoSuperclassesOf: aClass in: unprocessedClasses cache: cache [
 	^ (unprocessedClasses includesAnyOf: (self allSuperclassesFor: aClass cache: cache)) not
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 Class class >> initialize [
 
 	ObsoleteClasses := WeakIdentitySet new
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 Class class >> superclassOrder: classes [
     "Arrange the classes in the collection, classes, in superclass order so the
     classes can be properly filed in. Do it in sets instead of ordered collections.
@@ -93,13 +95,13 @@ Class class >> superclassOrder: classes [
     ^all
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Class class >> unclassifiedCategory [
 
 	^ #Unclassified
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 Class >> addClassVarNamed: aString [
 	"Add the argument, aString, as a class variable of the receiver.
 	Signal an error if the first character of aString is not capitalized,
@@ -108,7 +110,7 @@ Class >> addClassVarNamed: aString [
 	self addClassVariable: (aString asSymbol => ClassVariable)
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 Class >> addClassVariable: aClassVariable [
 	"Add the argument, aString, as a class variable of the receiver.
 	Signal an error if the first character of aString is not capitalized,
@@ -127,7 +129,7 @@ Class >> addClassVariable: aClassVariable [
 			classModificationAppliedTo: self
 ]
 
-{ #category : #'instance variables' }
+{ #category : 'instance variables' }
 Class >> addInstVarNamed: aString [
 	"Add the argument, aString, as one of the receiver's instance variables."
 
@@ -135,7 +137,7 @@ Class >> addInstVarNamed: aString [
 		self addSlot: (InstanceVariableSlot named: each asSymbol) ]
 ]
 
-{ #category : #'pool variables' }
+{ #category : 'pool variables' }
 Class >> addSharedPool: aSharedPool [
 
 	"Add the argument, aSharedPool, as one of the receiver's shared pools.
@@ -149,7 +151,7 @@ Class >> addSharedPool: aSharedPool [
 		ifNotNil: [ self sharedPools add: aSharedPool ]
 ]
 
-{ #category : #'pool variables' }
+{ #category : 'pool variables' }
 Class >> addSharedPoolNamed: aSharedPoolName [
 
 	|poolClass|
@@ -159,7 +161,7 @@ Class >> addSharedPoolNamed: aSharedPoolName [
 		ifFalse: [ self error: 'The specified class is not pool.' ]
 ]
 
-{ #category : #'accessing - class hierarchy' }
+{ #category : 'accessing - class hierarchy' }
 Class >> addSubclass: aSubclass [
 	"Make the argument, aSubclass, be one of the subclasses of the receiver.
 	Create an error notification if the argument's superclass is not the receiver."
@@ -172,14 +174,14 @@ Class >> addSubclass: aSubclass [
 	self subclasses: (subclasses copyWith: aSubclass)
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 Class >> allClassVariables [
 	"Answer the meta objects of all class variables of the class and its superclass"
 
 	^self withAllSuperclasses flatCollect:  [ :each | each classVariables ]
 ]
 
-{ #category : #'pool variables' }
+{ #category : 'pool variables' }
 Class >> allSharedPools [
 	"Answer an ordered collection of the pools the receiver shares, including those defined  in the superclasses of the receiver."
 
@@ -190,33 +192,32 @@ Class >> allSharedPools [
 			aSet addAll: self sharedPools; yourself]
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 Class >> anyUserOfClassVarNamed: aSymbol [
 	self withAllSubclasses do: [ :subclass |
  		{subclass . subclass class} do: [ :classOrMeta |
-			(classOrMeta whichSelectorsReferTo: (self classPool associationAt: aSymbol))
+			(classOrMeta whichMethodsReferTo: (self classPool associationAt: aSymbol))
 				ifNotEmpty: [ ^classOrMeta ]]].
-
 	^nil
 ]
 
-{ #category : #deprecation }
+{ #category : 'deprecation' }
 Class >> applyDeprecation [
 
 	self deprecationRefactorings do: #execute
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Class >> basicCategory [
 	^category
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Class >> basicCategory: aSymbol [
 	category := aSymbol
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 Class >> basicDeclareClassVariable: aClassVariable [
 	"Add aClassVariable to the receiver. Two cases are handled here:
 	- When there is exiting variable in class pool and it is an instance of different class
@@ -242,7 +243,7 @@ Class >> basicDeclareClassVariable: aClassVariable [
 	self classPool add: aClassVariable
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 Class >> binding [
    "Answer a binding for the receiver, sharing if possible"
    | binding |
@@ -250,7 +251,7 @@ Class >> binding [
    ^binding value == self ifTrue: [binding] ifFalse: [LiteralVariable key: nil value: self]
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 Class >> bindingOf: varName [
 	"Answer the binding of some variable resolved in the scope of the receiver, or nil
 	if variable with such name is not defined"
@@ -269,7 +270,7 @@ Class >> bindingOf: varName [
 	]
 ]
 
-{ #category : #organization }
+{ #category : 'organization' }
 Class >> category [
 	"Answer the system organization category for the receiver. First check whether the
 	category name stored in the ivar is still correct and only if this fails look it up
@@ -288,7 +289,7 @@ Class >> category [
 	^ result
 ]
 
-{ #category : #organization }
+{ #category : 'organization' }
 Class >> category: aString [
 	"Categorize the receiver under the system category, aString, removing it from
 	any previous categorization."
@@ -304,7 +305,7 @@ Class >> category: aString [
 	SystemAnnouncer uniqueInstance class: self recategorizedFrom: oldCategory to: self basicCategory
 ]
 
-{ #category : #'subclass creation - variableByte' }
+{ #category : 'subclass creation - variableByte' }
 Class >> checkForCompiledMethodLayout: className [ 
 	"There is no class definiton message for CompiledMethodLayout, it just uses the one for bytelayout for CompiledCode, CompiledMethod and CompiledBlock"
 
@@ -317,14 +318,14 @@ Class >> checkForCompiledMethodLayout: className [
 
 ]
 
-{ #category : #'subclass creation' }
+{ #category : 'subclass creation' }
 Class >> classBuilder [
 		"Answer the object responsible of creating subclasses of myself in the system."
 
 		^ self classInstaller new builder
 ]
 
-{ #category : #'accessing - comment' }
+{ #category : 'accessing - comment' }
 Class >> classComment: aString [
 	self
 		deprecated: 'use comment:'
@@ -332,7 +333,7 @@ Class >> classComment: aString [
 	self comment: aString
 ]
 
-{ #category : #'accessing - comment' }
+{ #category : 'accessing - comment' }
 Class >> classComment: aString stamp: aStamp [
 		self
 		deprecated: 'Use #comment:stamp: instead.'
@@ -340,7 +341,7 @@ Class >> classComment: aString stamp: aStamp [
 	^self comment: aString stamp: aStamp
 ]
 
-{ #category : #'subclass creation' }
+{ #category : 'subclass creation' }
 Class >> classInstaller [
 	"Answer the class responsible of creating subclasses of myself in the system."
 	^self isAnonymous
@@ -348,7 +349,7 @@ Class >> classInstaller [
 		ifFalse: [Smalltalk classInstaller]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Class >> classPool [
 	"Answer the dictionary of class variables.
 	We initialize in basicDeclareClassVariable: to not allocate unused empty dictionaries"
@@ -356,12 +357,12 @@ Class >> classPool [
 	^classPool ifNil: [ Dictionary new ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Class >> classPool: aDictionary [
 	classPool := aDictionary
 ]
 
-{ #category : #'accessing - parallel hierarchy' }
+{ #category : 'accessing - parallel hierarchy' }
 Class >> classSide [
 	"Return the metaclass of the couple class/metaclass. Useful to avoid explicit test."
 	"Point classSide >>> Point class"
@@ -370,28 +371,28 @@ Class >> classSide [
 	^ self class
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 Class >> classVarNamed: aString [
 	"for compatibility"
 
 	^self readClassVariableNamed: aString
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 Class >> classVarNamed: aString put: anObject [
 	"for compatibility"
 
 	self writeClassVariableNamed: aString value: anObject
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 Class >> classVarNames [
 	"Answer a collection of the receiver's class variable names."
 
 	^self classPool keys sort
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 Class >> classVariableDefinitionString [
 	"Answer a string that evaluates to the definition of the class Variables"
 
@@ -406,47 +407,47 @@ Class >> classVariableDefinitionString [
 		str nextPutAll: ' }'. ]
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 Class >> classVariableNamed: aString [
 	"Answer the Class Variable"
 
 	^self classVariableNamed: aString ifAbsent: [self error: 'no such class var']
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 Class >> classVariableNamed: aString ifAbsent: absentBlock [
 	"Answer the Class Variable"
 
 	^self classPool associationAt: aString asSymbol ifAbsent: absentBlock
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 Class >> classVariables [
 	"Answer the meta objects of all class variables"
 
 	^self classPool associations
 ]
 
-{ #category : #slots }
+{ #category : 'slots' }
 Class >> classVariablesNeedFullDefinition [
 
 	^ self classVariables anySatisfy: [ :each | each needsFullDefinition ]
 ]
 
-{ #category : #'accessing - comment' }
+{ #category : 'accessing - comment' }
 Class >> comment [
     ^ self commentSourcePointer
 		  ifNil: [ '' ]
 		  ifNotNil: [ :ptr | SourceFiles sourceCodeAt: ptr ]
 ]
 
-{ #category : #'accessing - comment' }
+{ #category : 'accessing - comment' }
 Class >> comment: aString [
 	"Set the receiver's comment to be the argument, aStringOrText."
 	^ self comment: aString stamp: '<historical>'
 ]
 
-{ #category : #'accessing - comment' }
+{ #category : 'accessing - comment' }
 Class >> comment: aString stamp: aStamp [
 	"Store the comment, aString or Text or RemoteString, associated with the class we are organizing.  Empty string gets stored only if had a non-empty one before."
 
@@ -484,17 +485,17 @@ Class >> comment: aString stamp: aStamp [
 		newStamp: aStamp
 ]
 
-{ #category : #'accessing - comment' }
+{ #category : 'accessing - comment' }
 Class >> commentSourcePointer [
 	^ commentSourcePointer
 ]
 
-{ #category : #'accessing - comment' }
+{ #category : 'accessing - comment' }
 Class >> commentSourcePointer: anObject [
 	commentSourcePointer := anObject
 ]
 
-{ #category : #'accessing - comment' }
+{ #category : 'accessing - comment' }
 Class >> commentStamp [
 
 	^ self commentSourcePointer
@@ -502,19 +503,19 @@ Class >> commentStamp [
 		  ifNotNil: [:sourcePointer | SourceFiles commentTimeStampAt: sourcePointer ]
 ]
 
-{ #category : #'accessing - comment' }
+{ #category : 'accessing - comment' }
 Class >> commentStamp: changeStamp [
 	"update the changeStamp"
 	self comment: self comment stamp: changeStamp
 ]
 
-{ #category : #'accessing - class hierarchy' }
+{ #category : 'accessing - class hierarchy' }
 Class >> commonSuperclassWith: aClass [
 	"return the next common superclass between me and aClass. If I am the superclass of aClass, that is me"
 	^ self withAllSuperclasses detect: [ :class | (aClass allSuperclasses includes: class) ] ifNone: nil
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 Class >> compileAllFrom: oldClass [
 	"Recompile all the methods in the receiver's method dictionary (not the
 	subclasses). Also recompile the methods in the metaclass."
@@ -523,7 +524,7 @@ Class >> compileAllFrom: oldClass [
 	self classSide compileAllFrom: oldClass classSide
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Class >> copyForAnnouncement [
 	"Answer a copy of the receiver to be used in the announcement of changes.
 	You should not use this class for anything else, it is invalid."
@@ -541,7 +542,7 @@ Class >> copyForAnnouncement [
 	^ newClass
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Class >> declareClassVariables: newVars [
 	"Declare class variables common to all instances. Answer whether
 	recompilation is advisable."
@@ -561,33 +562,33 @@ Class >> declareClassVariables: newVars [
 	^conflicts
 ]
 
-{ #category : #'pool variables' }
+{ #category : 'pool variables' }
 Class >> definedVariables [
 	"return all the Variables defined by this class"
 	^self slots, self classVariables
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 Class >> definesClassVariable: aGlobal [
 	"Return whether the receiver has a class variables (shared variables among its class and subclasses) named: aString"
 
 	^ self classVariables includes: aGlobal
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 Class >> definesClassVariableNamed: aString [
 	"Return whether the receiver has a class variables (shared variables among its class and subclasses) named: aString"
 
 	^ self classVarNames includes: aString
 ]
 
-{ #category : #fileout }
+{ #category : 'fileout' }
 Class >> definitionStringFor: aConfiguredPrinter [
 
 	^ aConfiguredPrinter classDefinitionString
 ]
 
-{ #category : #deprecation }
+{ #category : 'deprecation' }
 Class >> deprecationRefactorings [
 
 	"Return a list of refactorings that will apply class deprecation in the system. E.g. to
@@ -598,7 +599,7 @@ Class >> deprecationRefactorings [
 	^ #()
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Class >> duplicateClassWithNewName: aSymbol [
 	| copysName class |
 	copysName := aSymbol asSymbol.
@@ -616,19 +617,19 @@ Class >> duplicateClassWithNewName: aSymbol [
 	^ class
 ]
 
-{ #category : #organization }
+{ #category : 'organization' }
 Class >> environment [
 
 	^environment ifNil: [super environment]
 ]
 
-{ #category : #organization }
+{ #category : 'organization' }
 Class >> environment: anEnvironment [
 
 	environment := anEnvironment
 ]
 
-{ #category : #'subclass creation - weak' }
+{ #category : 'subclass creation - weak' }
 Class >> ephemeronSubclass: className instanceVariableNames: instVarNameList classVariableNames: classVarNames package: cat [
 	"Added to allow for a simplified subclass creation experience. "
 
@@ -644,7 +645,7 @@ Class >> ephemeronSubclass: className instanceVariableNames: instVarNameList cla
 					environment: self environment ]
 ]
 
-{ #category : #'subclass creation - deprecated' }
+{ #category : 'subclass creation - deprecated' }
 Class >> ephemeronSubclass: t instanceVariableNames: f classVariableNames: d poolDictionaries: s category: cat [
 
 	^ self classInstaller make: [ :builder |
@@ -659,7 +660,7 @@ Class >> ephemeronSubclass: t instanceVariableNames: f classVariableNames: d poo
 			  environment: self environment ]
 ]
 
-{ #category : #'subclass creation - weak' }
+{ #category : 'subclass creation - weak' }
 Class >> ephemeronSubclass: t instanceVariableNames: f classVariableNames: d poolDictionaries: s package: cat [
 	"This is the standard initialization message for creating a new class as a subclass of an existing class (the receiver) in which the subclass is to have weak indexable pointer variables."
 
@@ -676,26 +677,26 @@ Class >> ephemeronSubclass: t instanceVariableNames: f classVariableNames: d poo
 				environment: self environment ]
 ]
 
-{ #category : #fileout }
+{ #category : 'fileout' }
 Class >> expandedDefinitionStringFor: aPrinter [
 
 	^ aPrinter expandedDefinitionString
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Class >> getName [
 
 	^ name
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Class >> hasAbstractMethods [
 	"Tells whether the receiver locally defines an abstract method, i.e., a method sending subclassResponsibility"
 
 	^ super hasAbstractMethods or: [ self classSide hasAbstractMethods ]
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 Class >> hasBindingThatBeginsWith: aString [
 	"Answer true if the receiver has a binding that begins with aString, false otherwise"
 
@@ -712,32 +713,32 @@ Class >> hasBindingThatBeginsWith: aString [
 	^ self environment hasBindingThatBeginsWith: aString
 ]
 
-{ #category : #'accessing - parallel hierarchy' }
+{ #category : 'accessing - parallel hierarchy' }
 Class >> hasClassSide [
 	^self classSide notNil
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 Class >> hasClassVarNamed: aString [
 	"Return whether the receiver has a class variables (shared variables among its class and subclasses) named: aString"
 
 	^ self classPool includesKey: aString
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 Class >> hasClassVariable: aGlobal [
 	"Return whether the receiver has a class variables (shared variables among its class and subclasses) named: aString"
 
 	^ self classVariables identityIncludes: aGlobal
 ]
 
-{ #category : #'accessing - comment' }
+{ #category : 'accessing - comment' }
 Class >> hasComment [
 	"Return whether this class truly has a comment other than the default"
 	^ self commentSourcePointer isNotNil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Class >> hasMethods [
 	"Answer a Boolean according to whether any methods are defined for the
 	receiver (includes whether there are methods defined in the receiver's
@@ -746,18 +747,18 @@ Class >> hasMethods [
 	^super hasMethods or: [ self classSide hasMethods ]
 ]
 
-{ #category : #'pool variables' }
+{ #category : 'pool variables' }
 Class >> hasSharedPools [
 	"Returns whether the receiver uses shared pools directly (Does not take into account that it may inherit shared pool uses."
 	^ self sharedPools notEmpty
 ]
 
-{ #category : #'accessing - class hierarchy' }
+{ #category : 'accessing - class hierarchy' }
 Class >> hasSubclasses [
 	^ self subclasses isNotEmpty
 ]
 
-{ #category : #'subclass creation - immediate' }
+{ #category : 'subclass creation - immediate' }
 Class >> immediateSubclass: className instanceVariableNames: instVarNameList classVariableNames: classVarNames package: cat [
 	"
 	An immediate subclass define a class for which its value is coded within the OOP itself (like SmallInteger in 32 bits). It is not meant to be used by non-experimented users.
@@ -775,7 +776,7 @@ Class >> immediateSubclass: className instanceVariableNames: instVarNameList cla
 			environment: self environment ]
 ]
 
-{ #category : #'subclass creation - deprecated' }
+{ #category : 'subclass creation - deprecated' }
 Class >> immediateSubclass: t instanceVariableNames: f classVariableNames: d poolDictionaries: s category: cat [
 	^ self classInstaller make: [ :builder |
 		builder
@@ -789,7 +790,7 @@ Class >> immediateSubclass: t instanceVariableNames: f classVariableNames: d poo
 			environment: self environment ]
 ]
 
-{ #category : #'subclass creation - immediate' }
+{ #category : 'subclass creation - immediate' }
 Class >> immediateSubclass: t instanceVariableNames: f classVariableNames: d poolDictionaries: s package: cat [
 	"This is the standard initialization message for creating a new class as a
 	subclass of an existing class (the receiver) in which the subclass is to
@@ -807,7 +808,7 @@ Class >> immediateSubclass: t instanceVariableNames: f classVariableNames: d poo
 			environment: self environment ]
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 Class >> innerBindingOf: aSymbol [
 	"Answer the binding of some variable resolved in the scope of the receiver, or one of its superclass
 	but do not look up binding in receiver's environment.
@@ -821,7 +822,7 @@ Class >> innerBindingOf: aSymbol [
 	^ nil
 ]
 
-{ #category : #'accessing - parallel hierarchy' }
+{ #category : 'accessing - parallel hierarchy' }
 Class >> instanceSide [
 	"Return the class of the couple class/metaclass. Useful to avoid explicit test."
 	"Point instanceSide >>> Point"
@@ -830,35 +831,35 @@ Class >> instanceSide [
 	^ self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Class >> isAnonymous [
 	^self getName isNil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Class >> isClass [
 
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Class >> isClassOrTrait [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Class >> isObsolete [
 	"Return true if the receiver is obsolete."
 
 	^ ObsoleteClasses includes: self
 ]
 
-{ #category : #'self evaluating' }
+{ #category : 'self evaluating' }
 Class >> isSelfEvaluating [
 	^self isObsolete not
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Class >> isUsed [
 
 	^ self hasSubclasses
@@ -866,21 +867,21 @@ Class >> isUsed [
 		ifTrue: [ true ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Class >> name [
 	"Answer the name of the receiver."
 
 	^ name ifNil: [ super name ]
 ]
 
-{ #category : #slots }
+{ #category : 'slots' }
 Class >> needsSlotClassDefinition [
     "return true if we define something else than InstanceVariableSlots or normal class variables"
 
     ^ super needsSlotClassDefinition or: [ self classVariablesNeedFullDefinition ]
 ]
 
-{ #category : #'subclass creation' }
+{ #category : 'subclass creation' }
 Class >> newAnonymousSubclass [
 
 	^ Smalltalk anonymousClassInstaller make: [ :builder |
@@ -889,7 +890,7 @@ Class >> newAnonymousSubclass [
 			layoutClass: self classLayout class ]
 ]
 
-{ #category : #'subclass creation' }
+{ #category : 'subclass creation' }
 Class >> newSubclass [
 	| i className |
 	i := 1.
@@ -903,7 +904,7 @@ Class >> newSubclass [
 				environment: self environment ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Class >> obsolete [
 	"Change the receiver and all of its subclasses to an obsolete class."
 	self == Object
@@ -918,7 +919,7 @@ Class >> obsolete [
 	super obsolete
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 Class >> possibleVariablesFor: misspelled continuedFrom: oldResults [
 
 	| results |
@@ -930,14 +931,14 @@ Class >> possibleVariablesFor: misspelled continuedFrom: oldResults [
 		ifNotNil: [ self superclass possibleVariablesFor: misspelled continuedFrom: results ]
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 Class >> readClassVariableNamed: aString [
 	"Answer the content of the Class Variable"
 
 	^(self classVariableNamed: aString) read
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 Class >> reformatAll [
 	"Reformat all methods in this class.
 	Leaves old code accessible to version browsing"
@@ -946,7 +947,7 @@ Class >> reformatAll [
 	self classSide reformatAll.	"...and my metaclass"
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 Class >> removeClassVarNamed: aString [
 	"Remove the class variable whose name is the argument, aString, from
     the names defined in the receiver, a class. Create an error notification if
@@ -956,7 +957,7 @@ Class >> removeClassVarNamed: aString [
 	self removeClassVarNamed: aString interactive: false
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 Class >> removeClassVarNamed: aString interactive: interactive [
 	"Remove the class variable whose name is the argument, aString, from
     the names defined in the receiver, a class. Create an error notification if
@@ -981,20 +982,20 @@ Class >> removeClassVarNamed: aString interactive: interactive [
 	SystemAnnouncer uniqueInstance classModificationAppliedTo: self
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 Class >> removeClassVariable: aGlobal [
 	"Remove the class variable"
 	self removeClassVarNamed: aGlobal name
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Class >> removeFromSystem [
 	"Forget the receiver from the Smalltalk global dictionary. Any existing
 	instances will refer to an obsolete version of the receiver."
 	self removeFromSystem: true
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Class >> removeFromSystem: logged [
 	"Forget the receiver from the Smalltalk global dictionary. Any existing  instances will refer to an obsolete version of the receiver.
 	Keep the class name and category for triggering the system change message. If we wait to long, then we get obsolete information which is not what we want.
@@ -1020,13 +1021,13 @@ Class >> removeFromSystem: logged [
 	logged ifTrue: [ SystemAnnouncer announce: (ClassRemoved class: self package: package category: myCategory) ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Class >> removeFromSystemUnlogged [
 	"Forget the receiver from the Smalltalk global dictionary. Any existing instances will refer to an obsolete version of the receiver.  Do not log the removal either to the current change set nor to the system changes log"
 	^self removeFromSystem: false
 ]
 
-{ #category : #'pool variables' }
+{ #category : 'pool variables' }
 Class >> removeSharedPool: aDictionary [
 	"Remove the pool dictionary, aDictionary, as one of the receiver's pool
 	dictionaries. Create an error notification if the dictionary is not one of
@@ -1058,12 +1059,12 @@ Class >> removeSharedPool: aDictionary [
 	satisfiedSet add: self.
 	satisfiedSet do: [ :sub |
 		aDictionary associationsDo: [ :aGlobal |
-			(sub whichSelectorsReferTo: aGlobal) ifNotEmpty: [ ^ self error: aGlobal key , ' is still used in code of class ' , sub name ] ] ].
+			(sub whichMethodsReferTo: aGlobal) ifNotEmpty: [ ^ self error: aGlobal key , ' is still used in code of class ' , sub name ] ] ].
 	self sharedPools remove: aDictionary.
 	self sharedPools ifEmpty: [ self sharedPools: nil ]
 ]
 
-{ #category : #'accessing - class hierarchy' }
+{ #category : 'accessing - class hierarchy' }
 Class >> removeSubclass: aSubclass [
 	"If the argument, aSubclass, is one of the receiver's subclasses, remove it."
 
@@ -1072,7 +1073,7 @@ Class >> removeSubclass: aSubclass [
 		self subclasses ifEmpty: [ self subclasses: nil ] ]
 ]
 
-{ #category : #'class name' }
+{ #category : 'class name' }
 Class >> rename: aString [
 	"The new name of the receiver is the argument, aString."
 
@@ -1088,13 +1089,13 @@ Class >> rename: aString [
 from Undeclared. Check them after this change.']
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Class >> setName: aSymbol [
 
 	name := aSymbol
 ]
 
-{ #category : #'pool variables' }
+{ #category : 'pool variables' }
 Class >> sharedPoolNames [
 	^ self sharedPools collect: [:ea |
 		ea isObsolete
@@ -1102,7 +1103,7 @@ Class >> sharedPoolNames [
 			ifFalse: [ self environment keyAtIdentityValue: ea ] ]
 ]
 
-{ #category : #'pool variables' }
+{ #category : 'pool variables' }
 Class >> sharedPoolOfVarNamed: aString [
 	"Returns the SharedPool or nil from which the pool variable named aString is coming from."
 
@@ -1111,7 +1112,7 @@ Class >> sharedPoolOfVarNamed: aString [
 		ifNone: [ self superclass ifNotNil: [ self superclass sharedPoolOfVarNamed: aString ] ]
 ]
 
-{ #category : #'pool variables' }
+{ #category : 'pool variables' }
 Class >> sharedPools [
 	"Answer an orderedCollection of the shared pools declared in the receiver.
 	Note: To save memory, the variable is initialized by #addSharedPool:"
@@ -1119,12 +1120,12 @@ Class >> sharedPools [
 	^ sharedPools ifNil: [ sharedPools := super sharedPools ]
 ]
 
-{ #category : #'pool variables' }
+{ #category : 'pool variables' }
 Class >> sharedPools: aCollection [
 	sharedPools := aCollection
 ]
 
-{ #category : #'pool variables' }
+{ #category : 'pool variables' }
 Class >> sharedPoolsDo: aBlockClosure [
 	"Iterate shared pools.
 	The shared pool collection is lazily created on access.
@@ -1133,7 +1134,7 @@ Class >> sharedPoolsDo: aBlockClosure [
 	self sharedPools do: aBlockClosure
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Class >> sharing: poolString [
 	"Set up sharedPools. Answer whether recompilation is advisable."
 
@@ -1158,7 +1159,7 @@ Class >> sharing: poolString [
 	^ false
 ]
 
-{ #category : #'subclass creation' }
+{ #category : 'subclass creation' }
 Class >> subclass: t [
 	^ self classInstaller
 		make: [ :builder |
@@ -1170,7 +1171,7 @@ Class >> subclass: t [
 	
 ]
 
-{ #category : #'subclass creation' }
+{ #category : 'subclass creation' }
 Class >> subclass: t instanceVariableNames: ins [
 	^ self classInstaller
 		make: [ :builder |
@@ -1181,7 +1182,7 @@ Class >> subclass: t instanceVariableNames: ins [
 				environment: self environment ]
 ]
 
-{ #category : #'subclass creation - deprecated' }
+{ #category : 'subclass creation - deprecated' }
 Class >> subclass: aSubclassSymbol instanceVariableNames: instVarNameList classVariableNames: classVarNames category: aCategorySymbol [
 	"Added to allow for a simplified subclass creation experience. "
 
@@ -1195,7 +1196,7 @@ Class >> subclass: aSubclassSymbol instanceVariableNames: instVarNameList classV
 				environment: self environment ]
 ]
 
-{ #category : #'subclass creation' }
+{ #category : 'subclass creation' }
 Class >> subclass: aSubclassSymbol instanceVariableNames: instVarNameList classVariableNames: classVarNames package: aPackageSymbol [
 	"Added to allow for a simplified subclass creation experience. "
 
@@ -1210,7 +1211,7 @@ Class >> subclass: aSubclassSymbol instanceVariableNames: instVarNameList classV
 				environment: self environment ]
 ]
 
-{ #category : #'subclass creation - deprecated' }
+{ #category : 'subclass creation - deprecated' }
 Class >> subclass: t instanceVariableNames: f classVariableNames: d poolDictionaries: s category: cat [
 	^ self classInstaller
 		make: [ :builder |
@@ -1224,7 +1225,7 @@ Class >> subclass: t instanceVariableNames: f classVariableNames: d poolDictiona
 				environment: self environment ]
 ]
 
-{ #category : #'subclass creation' }
+{ #category : 'subclass creation' }
 Class >> subclass: t instanceVariableNames: f classVariableNames: d poolDictionaries: s package: cat [
 
 	^ self classInstaller
@@ -1240,7 +1241,7 @@ Class >> subclass: t instanceVariableNames: f classVariableNames: d poolDictiona
 				environment: self environment ]
 ]
 
-{ #category : #'subclass creation - slots' }
+{ #category : 'subclass creation - slots' }
 Class >> subclass: aSubclassSymbol layout: layoutClass slots: slotDefinition classVariables: classVarDefinition package: aCategorySymbol [
 
 	^ self classInstaller make: [ :builder |
@@ -1253,7 +1254,7 @@ Class >> subclass: aSubclassSymbol layout: layoutClass slots: slotDefinition cla
 			  category: aCategorySymbol ]
 ]
 
-{ #category : #'subclass creation - slots' }
+{ #category : 'subclass creation - slots' }
 Class >> subclass: aSubclassSymbol layout: layoutClass slots: slotDefinition classVariables: classVarDefinition poolDictionaries: someSharedPoolNames package: aCategorySymbol [
 
 	^ self classInstaller make: [ :builder |
@@ -1267,7 +1268,7 @@ Class >> subclass: aSubclassSymbol layout: layoutClass slots: slotDefinition cla
 			  category: aCategorySymbol ]
 ]
 
-{ #category : #'subclass creation - slots' }
+{ #category : 'subclass creation - slots' }
 Class >> subclass: aSubclassSymbol slots: slotDefinition classVariables: classVarDefinition package: aCategorySymbol [
 
 	^ self classInstaller make: [ :builder |
@@ -1279,7 +1280,7 @@ Class >> subclass: aSubclassSymbol slots: slotDefinition classVariables: classVa
 			  category: aCategorySymbol ]
 ]
 
-{ #category : #'subclass creation - slots' }
+{ #category : 'subclass creation - slots' }
 Class >> subclass: aSubclassSymbol slots: slotDefinition classVariables: classVarDefinition poolDictionaries: someSharedPoolNames package: aCategorySymbol [
 
 	^ self classInstaller make: [ :builder |
@@ -1292,7 +1293,7 @@ Class >> subclass: aSubclassSymbol slots: slotDefinition classVariables: classVa
 			  category: aCategorySymbol ]
 ]
 
-{ #category : #'accessing - class hierarchy' }
+{ #category : 'accessing - class hierarchy' }
 Class >> subclasses [
 	"Answer a Set containing the receiver's subclasses."
 
@@ -1301,52 +1302,52 @@ Class >> subclasses [
 		ifNotNil: [ subclasses copy ]
 ]
 
-{ #category : #'accessing - class hierarchy' }
+{ #category : 'accessing - class hierarchy' }
 Class >> subclasses: aCollection [
 	subclasses := aCollection
 ]
 
-{ #category : #'accessing - class hierarchy' }
+{ #category : 'accessing - class hierarchy' }
 Class >> subclassesDo: aBlock [
 	"Evaluate the argument, aBlock, for each of the receiver's immediate subclasses."
 
 	self subclasses do: aBlock
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Class >> superclass: aClass methodDictionary: mDict format: fmt [
 	"Basic initialization of the receiver"
 	super superclass: aClass methodDictionary: mDict format: fmt.
 	self subclasses: nil
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Class >> unload [
 	"Sent when a the class is removed.  Does nothing, but may be overridden by (class-side) subclasses."
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 Class >> usesClassVarNamed: aString [
 	"Return whether the receiver or its superclasses have a class variable named: aString"
 
 	^ self allClassVarNames includes: aString
 ]
 
-{ #category : #'pool variables' }
+{ #category : 'pool variables' }
 Class >> usesLocalPoolVarNamed: aString [
 	"Return whether the receiver uses a pool variable named: aString which is defined locally"
 
 	^ self sharedPools anySatisfy: [ :each | each usesClassVarNamed: aString ]
 ]
 
-{ #category : #'pool variables' }
+{ #category : 'pool variables' }
 Class >> usesPoolVarNamed: aString [
 	"Return whether the receiver has a pool variable named: aString, taking into account superclasses too"
 
 	^self allSharedPools anySatisfy: [:each | each usesClassVarNamed: aString]
 ]
 
-{ #category : #'subclass creation - deprecated' }
+{ #category : 'subclass creation - deprecated' }
 Class >> variableByteSubclass: className instanceVariableNames: instVarNameList  classVariableNames: classVarNames category: cat [
 
 	^ self classInstaller
@@ -1361,7 +1362,7 @@ Class >> variableByteSubclass: className instanceVariableNames: instVarNameList 
 				environment: self environment ]
 ]
 
-{ #category : #'subclass creation - variableByte' }
+{ #category : 'subclass creation - variableByte' }
 Class >> variableByteSubclass: className instanceVariableNames: instVarNameList classVariableNames: classVarNames package: cat [
 	"Added to allow for a simplified subclass creation experience. "
 
@@ -1377,7 +1378,7 @@ Class >> variableByteSubclass: className instanceVariableNames: instVarNameList 
 				environment: self environment ]
 ]
 
-{ #category : #'subclass creation - deprecated' }
+{ #category : 'subclass creation - deprecated' }
 Class >> variableByteSubclass: className instanceVariableNames: f classVariableNames: d poolDictionaries: s category: cat [
 
 	^ self classInstaller
@@ -1393,7 +1394,7 @@ Class >> variableByteSubclass: className instanceVariableNames: f classVariableN
 				environment: self environment ]
 ]
 
-{ #category : #'subclass creation - variableByte' }
+{ #category : 'subclass creation - variableByte' }
 Class >> variableByteSubclass: className instanceVariableNames: f classVariableNames: d poolDictionaries: s package: cat [
 	"This is the standard initialization message for creating a new class as a
 	subclass of an existing class (the receiver) in which the subclass is to
@@ -1412,7 +1413,7 @@ Class >> variableByteSubclass: className instanceVariableNames: f classVariableN
 				environment: self environment ]
 ]
 
-{ #category : #'subclass creation - variableByte' }
+{ #category : 'subclass creation - variableByte' }
 Class >> variableDoubleByteSubclass: className instanceVariableNames: instVarNameList  classVariableNames: classVarNames package: cat [
 
 	^ self classInstaller
@@ -1427,7 +1428,7 @@ Class >> variableDoubleByteSubclass: className instanceVariableNames: instVarNam
 				environment: self environment ]
 ]
 
-{ #category : #'subclass creation - variableByte' }
+{ #category : 'subclass creation - variableByte' }
 Class >> variableDoubleWordSubclass: className instanceVariableNames: instVarNameList  classVariableNames: classVarNames package: cat [
 
 	^ self classInstaller
@@ -1442,7 +1443,7 @@ Class >> variableDoubleWordSubclass: className instanceVariableNames: instVarNam
 				environment: self environment ]
 ]
 
-{ #category : #'subclass creation - deprecated' }
+{ #category : 'subclass creation - deprecated' }
 Class >> variableSubclass: className instanceVariableNames: instVarNameList classVariableNames: classVarNames category: cat [
 
 	^ self classInstaller make: [ :builder |
@@ -1456,7 +1457,7 @@ Class >> variableSubclass: className instanceVariableNames: instVarNameList clas
 			  environment: self environment ]
 ]
 
-{ #category : #'subclass creation - variable' }
+{ #category : 'subclass creation - variable' }
 Class >> variableSubclass: className instanceVariableNames: instVarNameList classVariableNames: classVarNames package: cat [
 
 	^ self classInstaller make: [ :builder |
@@ -1470,7 +1471,7 @@ Class >> variableSubclass: className instanceVariableNames: instVarNameList clas
 			  environment: self environment ]
 ]
 
-{ #category : #'subclass creation - deprecated' }
+{ #category : 'subclass creation - deprecated' }
 Class >> variableSubclass: className instanceVariableNames: instVarNameList classVariableNames: classVarNames poolDictionaries: s category: cat [
 
 	^ self classInstaller make: [ :builder |
@@ -1485,7 +1486,7 @@ Class >> variableSubclass: className instanceVariableNames: instVarNameList clas
 			  environment: self environment ]
 ]
 
-{ #category : #'subclass creation - variable' }
+{ #category : 'subclass creation - variable' }
 Class >> variableSubclass: t instanceVariableNames: f classVariableNames: d poolDictionaries: s package: cat [
 	"This is the standard initialization message for creating a new class as a
 	subclass of an existing class (the receiver) in which the subclass is to
@@ -1504,7 +1505,7 @@ Class >> variableSubclass: t instanceVariableNames: f classVariableNames: d pool
 				environment: self environment ]
 ]
 
-{ #category : #'subclass creation - deprecated' }
+{ #category : 'subclass creation - deprecated' }
 Class >> variableWordSubclass: className instanceVariableNames: instVarNameList classVariableNames: classVarNames category: cat [
 	"Added to allow for a simplified subclass creation experience. "
 
@@ -1519,7 +1520,7 @@ Class >> variableWordSubclass: className instanceVariableNames: instVarNameList 
 			  environment: self environment ]
 ]
 
-{ #category : #'subclass creation - variableWord' }
+{ #category : 'subclass creation - variableWord' }
 Class >> variableWordSubclass: className instanceVariableNames: instVarNameList classVariableNames: classVarNames package: cat [
 	"Variable word is like variable byte (ByteArray), variable size, with indices instead of named instance variables, but each index points to a full word (32 bits).
 
@@ -1536,7 +1537,7 @@ Class >> variableWordSubclass: className instanceVariableNames: instVarNameList 
 			  environment: self environment ]
 ]
 
-{ #category : #'subclass creation - deprecated' }
+{ #category : 'subclass creation - deprecated' }
 Class >> variableWordSubclass: t instanceVariableNames: f classVariableNames: d poolDictionaries: s category: cat [
 
 	^ self classInstaller make: [ :builder |
@@ -1551,7 +1552,7 @@ Class >> variableWordSubclass: t instanceVariableNames: f classVariableNames: d 
 			  environment: self environment ]
 ]
 
-{ #category : #'subclass creation - variableWord' }
+{ #category : 'subclass creation - variableWord' }
 Class >> variableWordSubclass: t instanceVariableNames: f classVariableNames: d poolDictionaries: s package: cat [
 	"This is the standard initialization message for creating a new class as a subclass of an existing class (the receiver) in which the subclass is to have indexable word-sized nonpointer variables."
 
@@ -1568,7 +1569,7 @@ Class >> variableWordSubclass: t instanceVariableNames: f classVariableNames: d 
 				environment: self environment ]
 ]
 
-{ #category : #'subclass creation - deprecated' }
+{ #category : 'subclass creation - deprecated' }
 Class >> weakSubclass: className instanceVariableNames: instVarNameList classVariableNames: classVarNames category: cat [
 	"Added to allow for a simplified subclass creation experience. "
 
@@ -1583,7 +1584,7 @@ Class >> weakSubclass: className instanceVariableNames: instVarNameList classVar
 			  environment: self environment ]
 ]
 
-{ #category : #'subclass creation - weak' }
+{ #category : 'subclass creation - weak' }
 Class >> weakSubclass: className instanceVariableNames: instVarNameList classVariableNames: classVarNames package: cat [
 	"Added to allow for a simplified subclass creation experience. "
 
@@ -1598,7 +1599,7 @@ Class >> weakSubclass: className instanceVariableNames: instVarNameList classVar
 			  environment: self environment ]
 ]
 
-{ #category : #'subclass creation - deprecated' }
+{ #category : 'subclass creation - deprecated' }
 Class >> weakSubclass: t instanceVariableNames: f classVariableNames: d poolDictionaries: s category: cat [
 
 	^ self classInstaller make: [ :builder |
@@ -1613,7 +1614,7 @@ Class >> weakSubclass: t instanceVariableNames: f classVariableNames: d poolDict
 			  environment: self environment ]
 ]
 
-{ #category : #'subclass creation - weak' }
+{ #category : 'subclass creation - weak' }
 Class >> weakSubclass: t instanceVariableNames: f classVariableNames: d poolDictionaries: s package: cat [
 	"This is the standard initialization message for creating a new class as a subclass of an existing class (the receiver) in which the subclass is to have weak indexable pointer variables."
 
@@ -1630,7 +1631,7 @@ Class >> weakSubclass: t instanceVariableNames: f classVariableNames: d poolDict
 				environment: self environment ]
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 Class >> writeClassVariableNamed: aString value: anObject [
 	"Store anObject in the class variable."
 

--- a/src/Kernel/ClassDefinitionPrinter.class.st
+++ b/src/Kernel/ClassDefinitionPrinter.class.st
@@ -53,8 +53,8 @@ In addition the printer should support
 
 "
 Class {
-	#name : #ClassDefinitionPrinter,
-	#superclass : #Object,
+	#name : 'ClassDefinitionPrinter',
+	#superclass : 'Object',
 	#instVars : [
 		'forClass'
 	],
@@ -62,27 +62,29 @@ Class {
 		'DisplayEmptySlots',
 		'ShowFluidClassDefinition'
 	],
-	#category : #'Kernel-ClassDefinitionPrinter'
+	#category : 'Kernel-ClassDefinitionPrinter',
+	#package : 'Kernel',
+	#tag : 'ClassDefinitionPrinter'
 }
 
-{ #category : #configure }
+{ #category : 'configure' }
 ClassDefinitionPrinter class >> displayEmptySlots [
 
 	^ DisplayEmptySlots ifNil: [ DisplayEmptySlots := true ]
 ]
 
-{ #category : #configure }
+{ #category : 'configure' }
 ClassDefinitionPrinter class >> displayEmptySlots: aBoolean [
 
 	DisplayEmptySlots := aBoolean
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ClassDefinitionPrinter class >> fluid [
 	^  FluidClassDefinitionPrinter basicNew initialize
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ClassDefinitionPrinter class >> for: aClass [
 	"Given the current class definition syntax and the need for the class,
 	return the correct printer.
@@ -99,18 +101,18 @@ ClassDefinitionPrinter class >> for: aClass [
 		yourself
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClassDefinitionPrinter class >> isAbstract [
 
 	^ self == ClassDefinitionPrinter
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ClassDefinitionPrinter class >> legacy [
 	^ LegacyClassDefinitionPrinter basicNew initialize
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ClassDefinitionPrinter class >> new [
 
 	^ self showFluidClassDefinition
@@ -118,12 +120,12 @@ ClassDefinitionPrinter class >> new [
 			ifFalse: [ self oldPharo ]
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ClassDefinitionPrinter class >> oldPharo [
 	^ OldPharoClassDefinitionPrinter basicNew initialize
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 ClassDefinitionPrinter class >> settingsOn: aBuilder [
 	"This method could be packaged in a setting kernel related package.
 	For now when the Settings system is not available it will just be deadcode."
@@ -158,40 +160,40 @@ Object << #Faked
 		target: self
 ]
 
-{ #category : #configure }
+{ #category : 'configure' }
 ClassDefinitionPrinter class >> showFluidClassDefinition [
 
 	^ ShowFluidClassDefinition ifNil: [ ShowFluidClassDefinition := true ]
 ]
 
-{ #category : #configure }
+{ #category : 'configure' }
 ClassDefinitionPrinter class >> showFluidClassDefinition: aBoolean [
 
 	ShowFluidClassDefinition := aBoolean
 ]
 
-{ #category : #configure }
+{ #category : 'configure' }
 ClassDefinitionPrinter class >> toggleShowFluidClassDefinition [
 
 	self showFluidClassDefinition: self showFluidClassDefinition not
 ]
 
-{ #category : #'public api' }
+{ #category : 'public api' }
 ClassDefinitionPrinter >> classDefinitionString [
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClassDefinitionPrinter >> classDefinitionTemplateInPackage: aPackageName [
 	^ self classDefinitionTemplateInPackage: aPackageName named: #MyClass
 ]
 
-{ #category : #template }
+{ #category : 'template' }
 ClassDefinitionPrinter >> classDefinitionTemplateInPackage: aPackageName named: aClassName [
 	^ self subclassResponsibility
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ClassDefinitionPrinter >> definitionString [
 	"The method is part of the double dispatch. It is an extra starting point.
 	Each entity will select the right definition and call me back.
@@ -200,7 +202,7 @@ ClassDefinitionPrinter >> definitionString [
 	^ forClass definitionStringFor: self
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ClassDefinitionPrinter >> expandedDefinitionString [
 	"The method is part of the double dispatch. It is an extra starting point.
 	Each entity will select the right definition and call me back.
@@ -209,37 +211,37 @@ ClassDefinitionPrinter >> expandedDefinitionString [
 	^ forClass expandedDefinitionStringFor: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClassDefinitionPrinter >> for: aClass [
 	forClass := aClass
 ]
 
-{ #category : #'public api' }
+{ #category : 'public api' }
 ClassDefinitionPrinter >> metaclassDefinitionString [
 	^ self subclassResponsibility
 ]
 
-{ #category : #template }
+{ #category : 'template' }
 ClassDefinitionPrinter >> testClassDefinitionTemplateInPackage: aString [
 	^ self subclassResponsibility
 ]
 
-{ #category : #'public api' }
+{ #category : 'public api' }
 ClassDefinitionPrinter >> traitDefinitionString [
 	^ self subclassResponsibility
 ]
 
-{ #category : #template }
+{ #category : 'template' }
 ClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aString [
 	^ self traitDefinitionTemplateInPackage: aString named: #TMyTrait
 ]
 
-{ #category : #template }
+{ #category : 'template' }
 ClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aPackageName named: aTraitName [ 
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClassDefinitionPrinter >> traitedMetaclassDefinitionString [
 	^ self subclassResponsibility
 ]

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -9,15 +9,17 @@ I add a number of facilities to basic Behaviors:
 I am an abstract class, in particular, my facilities are intended for inheritance by two subclasses, Class and Metaclass.
 "
 Class {
-	#name : #ClassDescription,
-	#superclass : #Behavior,
+	#name : 'ClassDescription',
+	#superclass : 'Behavior',
 	#instVars : [
 		'protocols'
 	],
-	#category : #'Kernel-Classes'
+	#category : 'Kernel-Classes',
+	#package : 'Kernel',
+	#tag : 'Classes'
 }
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 ClassDescription >> acceptsLoggingOfCompilation [
 	"Answer whether the receiver's method submisions and class defintions should be logged to the changes file and to the current change set.  The metaclass follows the rule of the class itself
 	Weird name is so that it will come lexically before #compile, so that a clean build can make it through."
@@ -25,7 +27,7 @@ ClassDescription >> acceptsLoggingOfCompilation [
 	^ true
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod inProtocol: protocol [
 
 	| priorMethod priorOrigin oldProtocol newProtocol |
@@ -48,14 +50,14 @@ ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod 
 			SystemAnnouncer uniqueInstance methodChangedFrom: priorMethod to: compiledMethod oldProtocol: oldProtocol ]
 ]
 
-{ #category : #'instance variables' }
+{ #category : 'instance variables' }
 ClassDescription >> addInstVarNamed: aString [
 	"Add the argument, aString, as one of the receiver's instance variables."
 
 	self subclassResponsibility
 ]
 
-{ #category : #protocols }
+{ #category : 'protocols' }
 ClassDescription >> addProtocol: aProtocol [
 
 	| oldProtocols protocol protocolName |
@@ -73,39 +75,39 @@ ClassDescription >> addProtocol: aProtocol [
 	^ protocol
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 ClassDescription >> addSelector: selector withMethod: compiledMethod [
 
 	self addAndClassifySelector: selector withMethod: compiledMethod inProtocol: nil
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 ClassDescription >> addSelectorSilently: selector withMethod: compiledMethod [
 	super addSelectorSilently: selector withMethod: compiledMethod.
 	self instanceSide noteAddedSelector: selector meta: self isMeta
 ]
 
-{ #category : #'instance variables' }
+{ #category : 'instance variables' }
 ClassDescription >> addSlot: aSlot [
 
 	^self subclassResponsibility
 ]
 
-{ #category : #'accessing - instances and variables' }
+{ #category : 'accessing - instances and variables' }
 ClassDescription >> allInstVarNames [
 	"Answer an Array of the receiver's instance variable names."
 
 	^self allSlots collect: [ :each | each name ] as: Array
 ]
 
-{ #category : #'instance variables' }
+{ #category : 'instance variables' }
 ClassDescription >> allInstVarNamesEverywhere [
 	"Answer the set of inst var names used by the receiver, all superclasses, and all subclasses"
 
 	^ self withAllSuperAndSubclasses flatCollectAsSet: [ :cls | cls instVarNames ]
 ]
 
-{ #category : #'obsolete subclasses' }
+{ #category : 'obsolete subclasses' }
 ClassDescription >> allLocalCallsOn: aSymbol [
 	"Answer all the methods that call on aSymbol, anywhere in my class hierarchy."
 
@@ -113,40 +115,40 @@ ClassDescription >> allLocalCallsOn: aSymbol [
 			(class thoroughWhichMethodsReferTo: aSymbol), (class class thoroughWhichMethodsReferTo: aSymbol)]
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 ClassDescription >> allSelectorsInProtocol: protocol [
 	"Answer a list of all the method selectors of the receiver and all its superclasses that are in the protocol as parameter."
 
 	^ self withAllSuperclasses flatCollectAsSet: [ :class | class selectorsInProtocol: protocol ]
 ]
 
-{ #category : #'pool variable' }
+{ #category : 'pool variable' }
 ClassDescription >> allSharedPools [
 	"Answer an ordered collection of the shared pools the receiver shares, including those defined  in the superclasses of the receiver."
 
 	^ OrderedCollection new
 ]
 
-{ #category : #slots }
+{ #category : 'slots' }
 ClassDescription >> allSlots [
 	^self classLayout allVisibleSlots
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ClassDescription >> allUnreferencedInstanceVariables [
 	"Return a list of the instance variables known to the receiver which are not referenced"
 
 	^ self allSlots reject: [:slot | slot isReferenced]
 ]
 
-{ #category : #authors }
+{ #category : 'authors' }
 ClassDescription >> authors [
 	"Returns a bag representing the author frequency based on the latest version of the methods of the receiver."
 
 	^(self methods, self classSide methods) collect: [ :each | each author ] as: Bag
 ]
 
-{ #category : #'accessing - deprecated parallel hierarchy' }
+{ #category : 'accessing - deprecated parallel hierarchy' }
 ClassDescription >> baseClass [
 	"This method is deprecated so consider to migrate."
 	self deprecated:  'Please use #instanceSide instead' transformWith:  '`@receiver baseClass'
@@ -154,7 +156,7 @@ ClassDescription >> baseClass [
 	^ self instanceSide
 ]
 
-{ #category : #'accessing - comment' }
+{ #category : 'accessing - comment' }
 ClassDescription >> classCommentBlank [
 	"Classes can override this method to show another template."
 
@@ -204,7 +206,7 @@ Internal Representation and Key Implementation Points.'.
 	^ stream contents
 ]
 
-{ #category : #'accessing - parallel hierarchy' }
+{ #category : 'accessing - parallel hierarchy' }
 ClassDescription >> classSide [
 	"Return the metaclass of the couple class/metaclass. Useful to avoid explicit test."
 	"Point classSide >>> Point class"
@@ -213,7 +215,7 @@ ClassDescription >> classSide [
 	^ self subclassResponsibility
 ]
 
-{ #category : #'instance variables' }
+{ #category : 'instance variables' }
 ClassDescription >> classThatDefinesClassVariable: classVarName [
 	"Answer the class that defines the given class variable"
 
@@ -221,7 +223,7 @@ ClassDescription >> classThatDefinesClassVariable: classVarName [
 	^self superclass ifNotNil: [self superclass classThatDefinesClassVariable: classVarName]
 ]
 
-{ #category : #'instance variables' }
+{ #category : 'instance variables' }
 ClassDescription >> classThatDefinesInstVarNamed: instVarName [
 	^self
 		slotNamed: instVarName
@@ -229,7 +231,7 @@ ClassDescription >> classThatDefinesInstVarNamed: instVarName [
 		 ifNone: nil
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ClassDescription >> classVariablesOn: aStream [
 	"Write my class variable names separated by spaces on the argument."
 
@@ -238,14 +240,14 @@ ClassDescription >> classVariablesOn: aStream [
 		separatedBy: [ aStream space ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ClassDescription >> classVariablesString [
 	"Answer a string of my class variable names separated by spaces."
 
 	^ String streamContents: [ :stream | self classVariablesOn: stream ]
 ]
 
-{ #category : #protocols }
+{ #category : 'protocols' }
 ClassDescription >> classify: selector under: aProtocol [
 
 	| oldProtocol newProtocol |
@@ -271,7 +273,7 @@ ClassDescription >> classify: selector under: aProtocol [
 	oldProtocol ifNotNil: [ self notifyOfRecategorizedSelector: selector from: oldProtocol to: newProtocol ]
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 ClassDescription >> compile: sourceCode classified: protocol [
 	"Compile the source code in the context of the receiver and install the result in the receiver's method dictionary under the given protocol (this can be a protocol or a protocol name).
 	
@@ -280,13 +282,13 @@ ClassDescription >> compile: sourceCode classified: protocol [
 	^ self compile: sourceCode classified: protocol notifying: nil
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 ClassDescription >> compile: sourceCode classified: protcol notifying: requestor [
 
 	^ self compile: sourceCode classified: protcol withStamp: Author changeStamp notifying: requestor
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 ClassDescription >> compile: sourceCode classified: protocol withStamp: changeStamp notifying: requestor [
 
 	^ self
@@ -297,7 +299,7 @@ ClassDescription >> compile: sourceCode classified: protocol withStamp: changeSt
 		  logSource: self acceptsLoggingOfCompilation
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 ClassDescription >> compile: sourceCode classified: protocol withStamp: changeStamp notifying: requestor logSource: logSource [
 
 	| method |
@@ -315,35 +317,35 @@ ClassDescription >> compile: sourceCode classified: protocol withStamp: changeSt
 	^ method selector
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 ClassDescription >> compile: sourceCode notifying: requestor [
 	"Refer to the comment in Behavior|compile:notifying:."
 
 	^ self compile: sourceCode classified: nil notifying: requestor
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 ClassDescription >> compileSilently: sourceCode [
 	"Compile the code and classify the resulting method in the given protocol, leaving no trail in the system log, nor in any change set, nor in the 'recent submissions' list. This should only be used when you know for sure that the compilation will succeed."
 
 	^ self compileSilently: sourceCode classified: 'not defined protocol' notifying: nil
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 ClassDescription >> compileSilently: sourceCode classified: protocolName [
 	"Compile the code and classify the resulting method in the given protocol, leaving no trail in the system log, nor in any change set, nor in the 'recent submissions' list. This should only be used when you know for sure that the compilation will succeed."
 
 	^ self compileSilently: sourceCode classified: protocolName notifying: nil
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 ClassDescription >> compileSilently: sourceCode classified: protocolName notifying: requestor [
 	"Compile the code and classify the resulting method in the given protocol, leaving no trail in the system log, nor in any change set, nor in the 'recent submissions' list."
 
 	^ SystemAnnouncer uniqueInstance suspendAllWhile: [ self compile: sourceCode classified: protocolName notifying: requestor ]
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 ClassDescription >> copyAllMethodsFrom: originClass [
 	"Install a copy of each methods of originClass in myself under the same protocol."
 
@@ -357,21 +359,21 @@ ClassDescription >> copyAllMethodsFrom: originClass [
 		self compile: aMethod sourceCode classified: aMethod protocol ]
 ]
 
-{ #category : #slots }
+{ #category : 'slots' }
 ClassDescription >> definesSlot: aSlot [
 	"Return true whether the receiver defines an instance variable named aString"
 
 	^ self slots identityIncludes: aSlot
 ]
 
-{ #category : #slots }
+{ #category : 'slots' }
 ClassDescription >> definesSlotNamed: aString [
 	"Return true whether the receiver defines an instance variable named aString."
 
 	^ self slotNames includes: aString
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ClassDescription >> definition [
 	"Answer a String that defines the receiver."
 	self
@@ -380,27 +382,27 @@ ClassDescription >> definition [
 	^ self definitionString
 ]
 
-{ #category : #fileout }
+{ #category : 'fileout' }
 ClassDescription >> definitionPrinter [
 	"Return a configurated printer associated with the current class definition format."
 
 	^ ClassDefinitionPrinter for: self
 ]
 
-{ #category : #fileout }
+{ #category : 'fileout' }
 ClassDescription >> definitionString [
 	"Return the string of the class definition, each of my subclass may tell the printer how to printer it. A kind of double dispatch since we have multiple printers and multiple entities to be printed."
 
 	^ self definitionPrinter definitionString
 ]
 
-{ #category : #fileout }
+{ #category : 'fileout' }
 ClassDescription >> definitionStringFor: aConfiguredPrinter [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #dependencies }
+{ #category : 'dependencies' }
 ClassDescription >> dependentClasses [
 	"Return the list of classes used myself"
 
@@ -418,14 +420,14 @@ ClassDescription >> dependentClasses [
 	^ classes asArray
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClassDescription >> deprecatedAliases [
 	"I return a potential list of alias names for myself that are deprecated."
 
 	^ self propertyAt: #deprecatedAliases ifAbsent: [ {  } ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClassDescription >> deprecatedAliases: aCollection [
 	"I allow one to declare deperecated names for myself. Typically, in case I get renamed, I can be used to declare the old name as a deprecated name.
 	Compared to the use of #isDeprecated, I have some advantages such as:
@@ -453,7 +455,7 @@ ClassDescription >> deprecatedAliases: aCollection [
 		(environment lookupVar: deprecatedName) isDeprecated: true ]
 ]
 
-{ #category : #'queries - protocols' }
+{ #category : 'queries - protocols' }
 ClassDescription >> ensureProtocol: aProtocol [
 	"I can take a Protocol or a protocol name as paramater.
 	
@@ -465,31 +467,31 @@ ClassDescription >> ensureProtocol: aProtocol [
 	^ self addProtocol: aProtocol
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ClassDescription >> errorCategoryName [
 	self error: 'Category name must be a String'
 ]
 
-{ #category : #fileout }
+{ #category : 'fileout' }
 ClassDescription >> expandedDefinitionString [
 	"Return the string of the class definition, each of my subclass may tell the printer how to printer it. A kind of double dispatch since we have multiple printers and multiple entities to be printed."
 
 	^ self expandedDefinitionStringFor: (self definitionPrinter for: self)
 ]
 
-{ #category : #fileout }
+{ #category : 'fileout' }
 ClassDescription >> expandedDefinitionStringFor: aPrinter [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #protocols }
+{ #category : 'protocols' }
 ClassDescription >> extensionProtocols [
 
 	^ self protocols select: [ :protocol | protocol isExtensionProtocol ]
 ]
 
-{ #category : #'instance variables' }
+{ #category : 'instance variables' }
 ClassDescription >> forceNewFrom: anArray [
     "Create a new instance of the class and fill
     its instance variables up with the array."
@@ -503,38 +505,38 @@ ClassDescription >> forceNewFrom: anArray [
     ^ object
 ]
 
-{ #category : #'accessing - parallel hierarchy' }
+{ #category : 'accessing - parallel hierarchy' }
 ClassDescription >> hasClassSide [
 	^self subclassResponsibility
 ]
 
-{ #category : #'instance variables' }
+{ #category : 'instance variables' }
 ClassDescription >> hasInstVarNamed: aString [
 	"Return true whether the receiver defines an instance variable named aString."
 
 	^ self instVarNames includes: aString
 ]
 
-{ #category : #protocols }
+{ #category : 'protocols' }
 ClassDescription >> hasProtocol: aProtocol [
 
 	^ self protocolNames includes: (aProtocol isString ifTrue: [ aProtocol ] ifFalse: [ aProtocol name ])
 ]
 
-{ #category : #'pool variable' }
+{ #category : 'pool variable' }
 ClassDescription >> hasSharedPools [
 	"Only a class may have shared pools"
 	^ false
 ]
 
-{ #category : #slots }
+{ #category : 'slots' }
 ClassDescription >> hasSlot: aSlot [
 	"Return true whether the receivers hierarchy defines an instance variable named aString."
 
 	^ self allSlots identityIncludes: aSlot
 ]
 
-{ #category : #slots }
+{ #category : 'slots' }
 ClassDescription >> hasSlotNamed: aString [
 	"Return true whether the receiver defines an instance variable named aString.
 	this includes non-visible slots"
@@ -542,28 +544,28 @@ ClassDescription >> hasSlotNamed: aString [
 	^ self classLayout hasSlotNamed: aString
 ]
 
-{ #category : #'pool variable' }
+{ #category : 'pool variable' }
 ClassDescription >> includesSharedPoolNamed:  aSharedPoolString [
 	"Answer whether the receiver uses the shared pool named aSharedPoolString"
 
 	^ self sharedPools anySatisfy: [:each | each name = aSharedPoolString]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ClassDescription >> initialize [
 
 	super initialize.
 	self resetProtocols
 ]
 
-{ #category : #'instance variables' }
+{ #category : 'instance variables' }
 ClassDescription >> instVarIndexFor: instVarName [
 	"Answer the index of the named instance variable."
 
 	^self instVarIndexFor: instVarName ifAbsent: 0
 ]
 
-{ #category : #'instance variables' }
+{ #category : 'instance variables' }
 ClassDescription >> instVarIndexFor: instVarName ifAbsent: aBlock [
 	"Answer the index of the named instance variable."
 
@@ -573,7 +575,7 @@ ClassDescription >> instVarIndexFor: instVarName ifAbsent: aBlock [
 		ifNone: aBlock
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ClassDescription >> instVarMappingFrom: oldClass [
 	"Return the mapping from instVars of oldClass to new class that is used for converting old instances of oldClass."
 	| oldInstVarNames |
@@ -582,14 +584,14 @@ ClassDescription >> instVarMappingFrom: oldClass [
 			collect: [:instVarName | oldInstVarNames indexOf: instVarName]
 ]
 
-{ #category : #'instance variables' }
+{ #category : 'instance variables' }
 ClassDescription >> instVarNames [
 	"Answer an Array of the receiver's instance variable names."
 
 	^self slots collect: [ :each | each name ]
 ]
 
-{ #category : #'accessing - parallel hierarchy' }
+{ #category : 'accessing - parallel hierarchy' }
 ClassDescription >> instanceSide [
 	"Return the class of the couple class/metaclass. Useful to avoid explicit test."
 	"Point instanceSide >>> Point"
@@ -598,7 +600,7 @@ ClassDescription >> instanceSide [
 	^ self subclassResponsibility
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ClassDescription >> instanceVariablesOn: aStream [
 	"Write my instance variable names separated by spaces on the argument."
 
@@ -607,14 +609,14 @@ ClassDescription >> instanceVariablesOn: aStream [
 		separatedBy: [ aStream space ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ClassDescription >> instanceVariablesString [
 	"Answer a string of my instance variable names separated by spaces."
 
 	^ String streamContents: [ :stream | self instanceVariablesOn: stream ]
 ]
 
-{ #category : #'accessing - parallel hierarchy' }
+{ #category : 'accessing - parallel hierarchy' }
 ClassDescription >> isClassSide [
 	"Return true whether the receiver is a metaclass (in a couple class/metaclass sense)."
 	"Point isClassSide >>> false"
@@ -623,12 +625,12 @@ ClassDescription >> isClassSide [
 	^self == self classSide
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClassDescription >> isDeprecated [
 	^ self package isDeprecated
 ]
 
-{ #category : #'accessing - parallel hierarchy' }
+{ #category : 'accessing - parallel hierarchy' }
 ClassDescription >> isInstanceSide [
 	"Return true whether the receiver is a class (in a couple class/metaclass sense)."
 	"Point isInstanceSide >>> true"
@@ -637,18 +639,18 @@ ClassDescription >> isInstanceSide [
 	^ self isClassSide not
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClassDescription >> isLocalSelector: aSelector [
 
 	^ self methodDict includesKey: aSelector
 ]
 
-{ #category : #'accessing - deprecated parallel hierarchy' }
+{ #category : 'accessing - deprecated parallel hierarchy' }
 ClassDescription >> isMeta [
 	^self isClassSide
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ClassDescription >> isProtocolExtensionFromTheSamePackage: aProtocol [
 	"I return true if the protocol as parameter is an extension protocol and the concerned package is my origin package."
 
@@ -665,7 +667,7 @@ ClassDescription >> isProtocolExtensionFromTheSamePackage: aProtocol [
 	^ (self packageOrganizer packageMatchingExtensionName: protocolName allButFirst) = self package
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClassDescription >> isTaggedWith: aSymbol [
 
 	^ self packageTagName
@@ -673,7 +675,7 @@ ClassDescription >> isTaggedWith: aSymbol [
 		  ifNotNil: [ :tag | tag = aSymbol ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ClassDescription >> linesOfCode [
 	"An approximate measure of lines of code.
 	Includes comments, but excludes blank lines."
@@ -685,26 +687,26 @@ ClassDescription >> linesOfCode [
 		ifFalse: [ lines + self classSide linesOfCode ]
 ]
 
-{ #category : #slots }
+{ #category : 'slots' }
 ClassDescription >> localSlots [
 
 	^ self slots select: [ :aSlot | aSlot isDefinedByOwningClass ]
 ]
 
-{ #category : #protocols }
+{ #category : 'protocols' }
 ClassDescription >> methodsInProtocol: protocol [
 
 	^ (self selectorsInProtocol: protocol) collect: [ :selector | self compiledMethodAt: selector ]
 ]
 
-{ #category : #slots }
+{ #category : 'slots' }
 ClassDescription >> needsSlotClassDefinition [
     "return true if we define something else than InstanceVariableSlots or normal class variables"
 
     ^ self slotsNeedFullDefinition or: [ self class slotsNeedFullDefinition ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ClassDescription >> newInstanceFrom: oldInstance variable: variable size: instSize [
 	"Create a new instance of the receiver based on the given old instance.
 	The supplied map contains a mapping of the old instVar names into
@@ -729,7 +731,7 @@ ClassDescription >> newInstanceFrom: oldInstance variable: variable size: instSi
 	^ new
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ClassDescription >> newInstanceFrom: oldInstance variable: variable size: instSize map: map [
 	"Create a new instance of the receiver based on the given old instance.
 	The supplied map contains a mapping of the old instVar names into
@@ -749,17 +751,17 @@ ClassDescription >> newInstanceFrom: oldInstance variable: variable size: instSi
 	^new
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 ClassDescription >> noteAddedSelector: aSelector meta: isMeta [
 	"A hook allowing some classes to react to adding of certain selectors"
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 ClassDescription >> noteCompilationOf: aSelector meta: isMeta [
 	"A hook allowing some classes to react to recompilation of certain selectors"
 ]
 
-{ #category : #'organization updating' }
+{ #category : 'organization updating' }
 ClassDescription >> notifyOfRecategorizedSelector: selector from: oldProtocol to: newProtocol [
 	"If compiled method is not there, it meens it has been removed, not recategorized... so I skip
 	 the method recategorized announce"
@@ -767,7 +769,7 @@ ClassDescription >> notifyOfRecategorizedSelector: selector from: oldProtocol to
 	self compiledMethodAt: selector ifPresent: [ :method | SystemAnnouncer uniqueInstance methodRecategorized: method oldProtocol: oldProtocol ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ClassDescription >> numberOfMethods [
 	"count all methods that are local (not comming from a trait)"
 	| num |
@@ -777,14 +779,14 @@ ClassDescription >> numberOfMethods [
 		ifFalse: [ num + self classSide numberOfMethods ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ClassDescription >> obsolete [
 	"Make the receiver obsolete."
 	self superclass removeSubclass: self.
 	super obsolete
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ClassDescription >> oldDefinition [
 
 	^ ClassDefinitionPrinter legacy
@@ -792,7 +794,7 @@ ClassDescription >> oldDefinition [
 		definitionString
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ClassDescription >> oldPharoDefinition [
 
 	^ ClassDefinitionPrinter oldPharo
@@ -800,12 +802,12 @@ ClassDescription >> oldPharoDefinition [
 		definitionString
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ClassDescription >> printOn: aStream [
 	aStream nextPutAll: self name
 ]
 
-{ #category : #protocols }
+{ #category : 'protocols' }
 ClassDescription >> protocolNameOfSelector: aSelector [
 	"Return the protocol name including the method of the same name as the selector.
 	If the class does not includes a method of this name, returns nil. Maybe this should be changed for an error in the future."
@@ -813,13 +815,13 @@ ClassDescription >> protocolNameOfSelector: aSelector [
 	^ (self protocolOfSelector: aSelector) ifNotNil: [ :protocol | protocol name ]
 ]
 
-{ #category : #protocols }
+{ #category : 'protocols' }
 ClassDescription >> protocolNamed: aString [
 
 	^ self protocolNamed: aString ifAbsent: [ NotFound signalFor: aString ]
 ]
 
-{ #category : #protocols }
+{ #category : 'protocols' }
 ClassDescription >> protocolNamed: aString ifAbsent: aBlock [
 
 	^ self protocols
@@ -827,14 +829,14 @@ ClassDescription >> protocolNamed: aString ifAbsent: aBlock [
 		  ifNone: aBlock
 ]
 
-{ #category : #protocols }
+{ #category : 'protocols' }
 ClassDescription >> protocolNames [
 	"Return the list of all the protocol names included in this class."
 
 	^ self protocols collect: [ :protocol | protocol name ]
 ]
 
-{ #category : #protocols }
+{ #category : 'protocols' }
 ClassDescription >> protocolOfSelector: aSelector [
 	"Return the protocol including the method of the same name as the selector.
 	If the class does not includes a method of this name, returns nil. Maybe this should be changed for an error in the future."
@@ -844,7 +846,7 @@ ClassDescription >> protocolOfSelector: aSelector [
 		  ifNone: [ nil ]
 ]
 
-{ #category : #protocols }
+{ #category : 'protocols' }
 ClassDescription >> protocols [
 	"I return all the protocols contained in me.
 	In the past I was returning the protocol names but now I am returning the instances directly. If you want to deal with the names you can use #protocolNames."
@@ -852,27 +854,27 @@ ClassDescription >> protocols [
 	^ protocols
 ]
 
-{ #category : #protocols }
+{ #category : 'protocols' }
 ClassDescription >> protocols: aCollection [
 	
 	protocols := aCollection
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 ClassDescription >> reformatAll [
 	"Reformat all methods in this class"
 
 	self methods do: [ :method | method reformat ]
 ]
 
-{ #category : #protocols }
+{ #category : 'protocols' }
 ClassDescription >> removeEmptyProtocols [
 	"We copy protocols because it is usually bad to remove elements of a collection while iterating on it"
 
 	self protocols copy do: [ :protocol | self removeProtocolIfEmpty: protocol ]
 ]
 
-{ #category : #protocols }
+{ #category : 'protocols' }
 ClassDescription >> removeFromProtocols: aSelector [
 
 	(self protocolOfSelector: aSelector) ifNotNil: [ :protocol |
@@ -881,14 +883,14 @@ ClassDescription >> removeFromProtocols: aSelector [
 		self notifyOfRecategorizedSelector: aSelector from: protocol to: nil ]
 ]
 
-{ #category : #'instance variables' }
+{ #category : 'instance variables' }
 ClassDescription >> removeInstVarNamed: aString [
 	"Remove the argument, aString, as one of the receiver's instance variables."
 
 	^self removeSlot: (self slotNamed: aString)
 ]
 
-{ #category : #protocols }
+{ #category : 'protocols' }
 ClassDescription >> removeNonexistentSelectorsFromProtocols [
 	"For each protocol, remove the selectors that are not present in the class."
 
@@ -898,7 +900,7 @@ ClassDescription >> removeNonexistentSelectorsFromProtocols [
 			thenDo: [ :selector | self removeFromProtocols: selector ] ]
 ]
 
-{ #category : #protocols }
+{ #category : 'protocols' }
 ClassDescription >> removeProtocol: aProtocol [
 	"Remove all methods present in the given protocol (or protocol name) and remove the protocol.
 	Does nothing if the protocol does not exists."
@@ -910,7 +912,7 @@ ClassDescription >> removeProtocol: aProtocol [
 	self removeProtocolIfEmpty: protocol 
 ]
 
-{ #category : #protocols }
+{ #category : 'protocols' }
 ClassDescription >> removeProtocolIfEmpty: aProtocol [
 	"I take a protocol or a protocol name and remvoe it if it is empty."
 
@@ -926,7 +928,7 @@ ClassDescription >> removeProtocolIfEmpty: aProtocol [
 	SystemAnnouncer announce: (ProtocolRemoved in: self protocol: protocol)
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 ClassDescription >> removeSelector: selector [
 	"Remove the message whose selector is given from the method
 	dictionary of the receiver, if it is there. Answer nil otherwise."
@@ -943,13 +945,13 @@ ClassDescription >> removeSelector: selector [
 	SystemAnnouncer uniqueInstance methodRemoved: priorMethod protocol: priorProtocol origin: origin
 ]
 
-{ #category : #'instance variables' }
+{ #category : 'instance variables' }
 ClassDescription >> removeSlot: aSlot [
 
 	^self subclassResponsibility
 ]
 
-{ #category : #protocols }
+{ #category : 'protocols' }
 ClassDescription >> renameProtocol: anOldProtocol as: aNewProtocol [
 
 	| oldProtocol newProtocol |
@@ -975,20 +977,20 @@ ClassDescription >> renameProtocol: anOldProtocol as: aNewProtocol [
 	newProtocol methodSelectors do: [ :each | self notifyOfRecategorizedSelector: each from: oldProtocol to: newProtocol ]
 ]
 
-{ #category : #organization }
+{ #category : 'organization' }
 ClassDescription >> reorganize [
 	"During fileIn, !Rectangle reorganize! allows Rectangle to seize control and treat the next chunk as its organization.  See the transfer of control where ReadWriteStream fileIn calls scanFrom:"
 
 	^ self
 ]
 
-{ #category : #protocols }
+{ #category : 'protocols' }
 ClassDescription >> resetProtocols [
 
 	protocols := Array new
 ]
 
-{ #category : #protocols }
+{ #category : 'protocols' }
 ClassDescription >> selectorsInProtocol: aProtocol [
 	"Answer a list of the selectors of the receiver that are in specific protocol (or protocol name)"
 
@@ -997,14 +999,14 @@ ClassDescription >> selectorsInProtocol: aProtocol [
 	^ (self ensureProtocol: aProtocol) methodSelectors
 ]
 
-{ #category : #'pool variable' }
+{ #category : 'pool variable' }
 ClassDescription >> sharedPoolOfVarNamed: aString [
 	"Only classes may have shared pools"
 
 	^ nil
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ClassDescription >> sharedPoolString [
 	"Answer a string of my shared pools separated by spaces."
 
@@ -1012,19 +1014,19 @@ ClassDescription >> sharedPoolString [
 		self sharedPoolStringOn: stream ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ClassDescription >> sharedPoolStringOn: aStream [
 	"Write my shared pools separated by dots on argument, aStream."
 
 	self sharedPools do:  [ :p | aStream nextPutAll: p name ] separatedBy: [ aStream nextPutAll: ' . ' ]
 ]
 
-{ #category : #'pool variable' }
+{ #category : 'pool variable' }
 ClassDescription >> sharedPools [
 	^ OrderedCollection new
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ClassDescription >> sharedPoolsOn: aStream [
 	"Answer a string of my shared pool names separated by spaces."
 
@@ -1039,7 +1041,7 @@ ClassDescription >> sharedPoolsOn: aStream [
 			separatedBy: [ aStream space ]
 ]
 
-{ #category : #'pool variable' }
+{ #category : 'pool variable' }
 ClassDescription >> sharedPoolsString [
 	"Answer a string of my shared pool names separated by spaces."
 
@@ -1055,52 +1057,52 @@ ClassDescription >> sharedPoolsString [
 			separatedBy: [ stream space ] ]
 ]
 
-{ #category : #slots }
+{ #category : 'slots' }
 ClassDescription >> slotNamed: aName [
 	^self classLayout resolveSlot: aName asSymbol
 ]
 
-{ #category : #slots }
+{ #category : 'slots' }
 ClassDescription >> slotNamed: aName ifFound: foundBlock [
 	^self slotNamed: aName ifFound: foundBlock ifNone: [ "do nothing" ]
 ]
 
-{ #category : #slots }
+{ #category : 'slots' }
 ClassDescription >> slotNamed: aName ifFound: foundBlock ifNone: exceptionBlock [
 	^self classLayout resolveSlot: aName ifFound: foundBlock ifNone: exceptionBlock
 ]
 
-{ #category : #slots }
+{ #category : 'slots' }
 ClassDescription >> slotNames [
 	^self slots collect: [ :each | each name ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClassDescription >> slots [
 	^self classLayout visibleSlots
 ]
 
-{ #category : #slots }
+{ #category : 'slots' }
 ClassDescription >> slotsNeedFullDefinition [
 	"return true if we define something else than InstanceVariableSlots"
 	^self slots anySatisfy: [ :each | each needsFullDefinition ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ClassDescription >> spaceUsed [
 	^super spaceUsed + (self hasClassSide
 		ifTrue: [self classSide spaceUsed]
 		ifFalse: [0])
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ClassDescription >> storeOn: aStream [
 	"Classes and Metaclasses have global names."
 
 	aStream nextPutAll: self name
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ClassDescription >> superclass: aSuperclass layout: aLayout [
 	layout := aLayout.
 
@@ -1110,7 +1112,7 @@ ClassDescription >> superclass: aSuperclass layout: aLayout [
 		format: aLayout format
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ClassDescription >> superclass: aClass methodDictionary: mDict format: fmt [
 	"Basic initialization of the receiver"
 
@@ -1118,7 +1120,7 @@ ClassDescription >> superclass: aClass methodDictionary: mDict format: fmt [
 	self resetProtocols
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ClassDescription >> superclass: aSuperclass withLayoutType: layoutType slots: slotArray [
 	| superLayout newScope newLayout |
 	superLayout := aSuperclass
@@ -1132,7 +1134,7 @@ ClassDescription >> superclass: aSuperclass withLayoutType: layoutType slots: sl
 		layout: newLayout
 ]
 
-{ #category : #'accessing - deprecated parallel hierarchy' }
+{ #category : 'accessing - deprecated parallel hierarchy' }
 ClassDescription >> theMetaClass [
 	"This method is deprecated so consider to migrate."
 	self deprecated:  'Please use #classSide instead' transformWith:  '`@receiver theMetaClass'
@@ -1140,7 +1142,7 @@ ClassDescription >> theMetaClass [
 	^ self classSide
 ]
 
-{ #category : #'accessing - deprecated parallel hierarchy' }
+{ #category : 'accessing - deprecated parallel hierarchy' }
 ClassDescription >> theNonMetaClass [
 	"This method is deprecated so consider to migrate."
 	self deprecated:  'Please use #instanceSide instead' transformWith:  '`@receiver theNonMetaClass'
@@ -1148,32 +1150,32 @@ ClassDescription >> theNonMetaClass [
 	^ self instanceSide
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 ClassDescription >> uncategorizedSelectors [
 
 	^ self selectorsInProtocol: Protocol unclassified
 ]
 
-{ #category : #'pool variable' }
+{ #category : 'pool variable' }
 ClassDescription >> usesLocalPoolVarNamed: aString [
 	^false
 ]
 
-{ #category : #'pool variable' }
+{ #category : 'pool variable' }
 ClassDescription >> usesPoolVarNamed: aString [
 	"Only classes may use a pool variable named: aString"
 
 	^ false
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 ClassDescription >> wantsChangeSetLogging [
 	"Answer whether code submitted for the receiver should be remembered by the changeSet mechanism."
 
 	^ true
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 ClassDescription >> whichSelectorsAccess: instVarName [
 	"Answer the selectors whose methods access the argument, instVarName, as a named instance variable."
 
@@ -1183,7 +1185,7 @@ ClassDescription >> whichSelectorsAccess: instVarName [
 		ifNone: [ #() ]
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 ClassDescription >> whichSelectorsRead: instVarName [
 	"Answer the selectors whose methods read the argument, instVarName, as a named instance variable."
 
@@ -1193,7 +1195,7 @@ ClassDescription >> whichSelectorsRead: instVarName [
 		ifNone: [ #() ]
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 ClassDescription >> whichSelectorsWrite: instVarName [
 	"Answer the selectors whose methods write the argument, instVarName, as a named instance variable"
 

--- a/src/Kernel/ClassVariable.class.st
+++ b/src/Kernel/ClassVariable.class.st
@@ -9,32 +9,34 @@ Note: PoolVariable is not modeled as it's own subclass to allow all special kind
 as pool variables.
 "
 Class {
-	#name : #ClassVariable,
-	#superclass : #LiteralVariable,
+	#name : 'ClassVariable',
+	#superclass : 'LiteralVariable',
 	#instVars : [
 		'owningClass',
 		'definingClass'
 	],
-	#category : #'Kernel-Variables'
+	#category : 'Kernel-Variables',
+	#package : 'Kernel',
+	#tag : 'Variables'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 ClassVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 	^ aProgramNodeVisitor visitClassVariableNode: aNode
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClassVariable >> definingClass [
 	"if a Variable is from a Trait is installed in a class, we store the orginal class of the trait here"
 	^ definingClass ifNil: [ self owningClass ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClassVariable >> definingClass: anObject [
 	definingClass := anObject
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ClassVariable >> definitionOn: aStream [
 	"non special globals are defined by the symbol"
 	^self needsFullDefinition
@@ -42,47 +44,47 @@ ClassVariable >> definitionOn: aStream [
 		ifFalse: [ self name printOn: aStream ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ClassVariable >> definitionString [
 	"Every subclass that adds state must redefine either this method or #printOn:"
 	^ String streamContents: [:s | self definitionOn: s]
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 ClassVariable >> emitStore: methodBuilder [
 
 	methodBuilder storeIntoLiteralVariable: self
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 ClassVariable >> emitValue: methodBuilder [
 
 	methodBuilder pushLiteralVariable: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClassVariable >> isAccessedBy: aBehavior [
 
 	^ (aBehavior hasMethodAccessingVariable: self) or: [ aBehavior class hasMethodAccessingVariable: self ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClassVariable >> isClassVariable [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClassVariable >> isDefinedByOwningClass [
 
 	^ self owningClass = self definingClass
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClassVariable >> isPoolVariable [
 	^ self definingClass isPool
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClassVariable >> isReferenced [
 
 	(self definingClass withAllSubclasses anySatisfy: [ :behavior | self isAccessedBy: behavior ]) ifTrue: [ ^ true ].
@@ -94,24 +96,24 @@ ClassVariable >> isReferenced [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClassVariable >> needsFullDefinition [
 	"only ClassVariable can use a simplified definition"
 
 	^ self class ~= ClassVariable
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClassVariable >> owningClass [
 	^ owningClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClassVariable >> owningClass: anObject [
 	owningClass := anObject
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 ClassVariable >> possiblyUsingClasses [
 
 	| classes |
@@ -127,7 +129,7 @@ ClassVariable >> possiblyUsingClasses [
 	^ classes
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ClassVariable >> printOn: aStream [
 	"Every subclass that adds state must redefine either this method or #definitionString"
 	aStream
@@ -136,7 +138,7 @@ ClassVariable >> printOn: aStream [
 		nextPutAll: self class name
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 ClassVariable >> usingMethods [
 	^self possiblyUsingClasses flatCollect: [ :class | class whichMethodsReferTo: self ]
 ]

--- a/src/Kernel/CleanBlockClosure.class.st
+++ b/src/Kernel/CleanBlockClosure.class.st
@@ -19,59 +19,61 @@ pushed on the stack.
 For debugging, it does implement all needed machinary to read temps (via tempNamed:) just like a FullBlockClosure
 "
 Class {
-	#name : #CleanBlockClosure,
-	#superclass : #BlockClosure,
-	#type : #variable,
+	#name : 'CleanBlockClosure',
+	#superclass : 'BlockClosure',
+	#type : 'variable',
 	#instVars : [
 		'literal'
 	],
-	#category : #'Kernel-Methods'
+	#category : 'Kernel-Methods',
+	#package : 'Kernel',
+	#tag : 'Methods'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CleanBlockClosure class >> compiledBlock: aCompiledBlock [
 	^self new
 		numArgs: aCompiledBlock numArgs;
 		compiledBlock: aCompiledBlock
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 CleanBlockClosure >> doPrintOn: aStream [
 
 	aStream nextPutAll: self sourceNode value sourceCode
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CleanBlockClosure >> hasLiteral: aLiteral [
 	^self compiledBlock hasLiteral: aLiteral
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CleanBlockClosure >> hasLiteralSuchThat: aLiteral [
 	^self compiledBlock hasLiteralSuchThat: aLiteral
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CleanBlockClosure >> innerCompiledBlocksAnySatisfy: aBlock [
 	^self compiledBlock innerCompiledBlocksAnySatisfy: aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CleanBlockClosure >> innerCompiledBlocksDo: aBlock [
 	^self compiledBlock innerCompiledBlocksDo: aBlock
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CleanBlockClosure >> isClean [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CleanBlockClosure >> isEmbeddedBlock [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CleanBlockClosure >> literal [
 	"The variable and accessor should be in the subclass ConstantBlockClosure.
 	It seems that the VM expects closures to have 4 ivars
@@ -79,73 +81,73 @@ CleanBlockClosure >> literal [
 	^literal
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CleanBlockClosure >> literalsEvenTheOnesInTheInnerBlocks [
 	^self compiledBlock literalsEvenTheOnesInTheInnerBlocks
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CleanBlockClosure >> messages [
 	^self compiledBlock messages
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CleanBlockClosure >> outerCode [
 	^self compiledBlock outerCode
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CleanBlockClosure >> outerCode: aCompiledCode [
 	self compiledBlock outerCode: aCompiledCode
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CleanBlockClosure >> readsField: varIndex [
 	"Clean blocks by definition do not read fields"
 	^false
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CleanBlockClosure >> readsSelf [
 	"Clean blocks by definition do not access self"
 	^false
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CleanBlockClosure >> readsThisContext [
 	"Clean blocks can access thisContext, we have to forward to the compiled block to check"
 	^self compiledBlock readsThisContext
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CleanBlockClosure >> receiver [
 	"Clean blocks do not know the receiver"
 	^ nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CleanBlockClosure >> refersToLiteral: aLiteral [
 	^self compiledBlock refersToLiteral: aLiteral
 ]
 
-{ #category : #'debugger access' }
+{ #category : 'debugger access' }
 CleanBlockClosure >> sender [
 	" clean blocks do not know the sender"
 	^nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CleanBlockClosure >> sendsAnySelectorOf: aCollection [
 	^self compiledBlock sendsAnySelectorOf: aCollection
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CleanBlockClosure >> sendsToSuper [
 	"Clean blocks by definition do not access super"
 	^false
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CleanBlockClosure >> writesField: varIndex [
 	"Clean blocks by definition do not read fields"
 	^false

--- a/src/Kernel/CompiledBlock.class.st
+++ b/src/Kernel/CompiledBlock.class.st
@@ -7,52 +7,54 @@ In addition the execution mechanics, a compiled block has an extra literal: the 
 
 "
 Class {
-	#name : #CompiledBlock,
-	#superclass : #CompiledCode,
-	#type : #compiledMethod,
-	#category : #'Kernel-Methods'
+	#name : 'CompiledBlock',
+	#superclass : 'CompiledCode',
+	#type : 'compiledMethod',
+	#category : 'Kernel-Methods',
+	#package : 'Kernel',
+	#tag : 'Methods'
 }
 
-{ #category : #printing }
+{ #category : 'printing' }
 CompiledBlock >> displayStringOn: stream [
 	self printOn: stream
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledBlock >> endPC [
 	"Answer the index of the last bytecode"
 	^ self size
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CompiledBlock >> hasMethodReturn [
 	"Answer whether the receiver has a method-return ('^') in its code."
 	^ (InstructionStream on: self) scanFor: [:byte |
 		 self encoderClass methodReturnBytecodes includes: byte]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledBlock >> hasPragmaNamed: aSymbol [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledBlock >> hasProperties [
 	^false
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 CompiledBlock >> hasProperty: aString [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledBlock >> hasSourceCode [
 	^ self method hasSourceCode
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CompiledBlock >> hash [
 	"CompiledMethod>>#= compares code, i.e. same literals and same bytecode.
 	 So we look at the header, methodClass and some bytes between initialPC and endPC,
@@ -72,68 +74,68 @@ CompiledBlock >> hash [
 	"(CompiledMethod>>#hash) hash"
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledBlock >> isCompiledBlock [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledBlock >> isEmbeddedBlock [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledBlock >> isInstalled [
 
 	^ self method isInstalled
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledBlock >> isTestMethod [
 	^ false
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CompiledBlock >> literalEqual: other [
 	"when there are two blocks with the same code, we want to still have both in the literal array"
 	^self == other
 ]
 
-{ #category : #literals }
+{ #category : 'literals' }
 CompiledBlock >> literalsToSkip [
 
 	^ 1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledBlock >> method [
 	"answer the compiled method that I am installed in, or nil if none."
 	^self outerCode method
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledBlock >> methodClass [
 	"answer the compiled method that I am installed in, or nil if none."
 	^self outerCode methodClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledBlock >> methodNode [
 	^ self outerCode methodNode
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledBlock >> outerCode [
 	"answer the compiled code that I am installed in, or nil if none."
 	^self literalAt: self numLiterals
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledBlock >> outerCode: aCompiledCode [
 	^self literalAt: self numLiterals put: aCompiledCode
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CompiledBlock >> pcInOuter [
 	| outer end instructionStream |
 	outer := self outerCode.
@@ -157,18 +159,18 @@ CompiledBlock >> pcInOuter [
 	self error: 'block not installed in outer code'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledBlock >> pragmas [
 	^ #()
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledBlock >> primitive [
 	"for now we do not compile Quick CompiedBlocks, see IRBytecodeGenerator>>#compiledBlockWith:"
 	^0
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 CompiledBlock >> printOn: anStream [
 
 	anStream
@@ -176,18 +178,18 @@ CompiledBlock >> printOn: anStream [
 		nextPutAll: self sourceNode sourceCode
 ]
 
-{ #category : #compatibility }
+{ #category : 'compatibility' }
 CompiledBlock >> properties [
 	^ nil->nil
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 CompiledBlock >> propertyAt: aString [
 
 	^ nil
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CompiledBlock >> sameLiteralsAs: method [
 	"Compare my literals to those of method. This is needed to compare compiled methods."
 
@@ -204,27 +206,27 @@ CompiledBlock >> sameLiteralsAs: method [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledBlock >> selector [
 	^ self outerCode selector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledBlock >> sourceCode [
 	^ self outerCode sourceCode
 ]
 
-{ #category : #'source code management' }
+{ #category : 'source code management' }
 CompiledBlock >> sourcePointer [
 	^self outerCode sourcePointer
 ]
 
-{ #category : #'debugger support' }
+{ #category : 'debugger support' }
 CompiledBlock >> stepIntoQuickMethods [
 	^self method stepIntoQuickMethods
 ]
 
-{ #category : #'debugger support' }
+{ #category : 'debugger support' }
 CompiledBlock >> stepIntoQuickMethods: aBoolean [
 	^self method stepIntoQuickMethods: aBoolean
 ]

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -25,31 +25,33 @@ For the user flag bit, use #clearFlag, #flag, #setFlag. Take care: do not change
 The trailer encodes a sourcePointer to fetch the method's sources.
 "
 Class {
-	#name : #CompiledCode,
-	#superclass : #ByteArray,
-	#type : #compiledMethod,
+	#name : 'CompiledCode',
+	#superclass : 'ByteArray',
+	#type : 'compiledMethod',
 	#classVars : [
 		'LargeFrame',
 		'PrimaryBytecodeSetEncoderClass',
 		'SecondaryBytecodeSetEncoderClass',
 		'SmallFrame'
 	],
-	#category : #'Kernel-Methods'
+	#category : 'Kernel-Methods',
+	#package : 'Kernel',
+	#tag : 'Methods'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CompiledCode class >> basicNew [
 
 	self error: 'CompiledMethods and CompiledBlocks may only be created with newMethod:header:'
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CompiledCode class >> basicNew: size [
 
 	self error: 'CompiledMethods and CompiledBlocks may only be created with newMethod:header:'
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CompiledCode class >> newMethod: numberOfBytes header: headerWord [
 	"Primitive. Answer an instance of me. The number of literals (and other
 	 information) is specified by the headerWord (see my class comment).
@@ -65,7 +67,7 @@ CompiledCode class >> newMethod: numberOfBytes header: headerWord [
 	^self primitiveFailed
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CompiledCode >> = aCompiledMethod [
 	"Answer whether the receiver implements the same code as aCompiledMethod."
 
@@ -85,14 +87,14 @@ CompiledCode >> = aCompiledMethod [
 	^ true
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CompiledCode >> accessesField: varIndex [
 	"Answer whether the receiver accesses the instance variable indexed by the argument."
 
 	^ (self readsField: varIndex) or: [ self writesField: varIndex ]
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CompiledCode >> accessesRef: literalVariable [
 	"Answer whether this method accesses the LiteralVariable"
 	"we do not need to call readsRef: or #writesRef:, as if the variable
@@ -101,12 +103,12 @@ CompiledCode >> accessesRef: literalVariable [
 	^ self hasLiteral: literalVariable
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CompiledCode >> accessesSlot: aSlot [
 	^aSlot isAccessedIn: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> allBlocks [
 	| all |
 	all := IdentitySet new.
@@ -114,7 +116,7 @@ CompiledCode >> allBlocks [
 	^all
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> allBlocksDo: aBlock [
 
 	self literals
@@ -122,7 +124,7 @@ CompiledCode >> allBlocksDo: aBlock [
 		thenDo: [ :aLiteral | aLiteral withAllBlocksDo: aBlock  ]
 ]
 
-{ #category : #literals }
+{ #category : 'literals' }
 CompiledCode >> allLiterals [
 	"Answer an Array of the literals referenced by the receiver.
 	 including superclass + selector/properties"
@@ -133,12 +135,12 @@ CompiledCode >> allLiterals [
 	^literals
 ]
 
-{ #category : #'source code management' }
+{ #category : 'source code management' }
 CompiledCode >> argumentNames [
 	^ self propertyAt: #argumentNames ifAbsent: [ self ast argumentNames ]
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 CompiledCode >> asOrderedCollection [
 	"We should override it because most of collection methods are not working for CompiledMethod. And it can't be normally converted into OrderedCollection.
 	It is special class which needs to be ByteArray by VM. But it is not behaves like ByteArray from user perspective"
@@ -146,13 +148,13 @@ CompiledCode >> asOrderedCollection [
 	^OrderedCollection with: self
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 CompiledCode >> asString [
 
 	  ^self sourceCode
 ]
 
-{ #category : #'source code management' }
+{ #category : 'source code management' }
 CompiledCode >> author [
 	"Answer the author of the current version of the receiver. retrieved from the sources or changes file. Answer the empty string if no time stamp is available."
 
@@ -165,7 +167,7 @@ CompiledCode >> author [
 	^''
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> bytecode [
 	self
 		deprecated: 'Changed selector for coherency'
@@ -174,7 +176,7 @@ CompiledCode >> bytecode [
 	^ self bytecodes
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> bytecodes [
 	"Answer an ByteArray of the btyecode of the method."
 
@@ -189,14 +191,14 @@ CompiledCode >> bytecodes [
 	^bytecode
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> clearFlag [
 	"Clear the user-level flag bit"
 
 	self objectAt: 1 put: (self header bitAt: 29 put: 0)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> clearSignFlag [
 	"Clear the sign flag bit.  The sign flag bit may be
 	 used by the VM to select an alternate bytecode set."
@@ -205,7 +207,7 @@ CompiledCode >> clearSignFlag [
 		[self objectAt: 1 put: self header - SmallInteger minVal]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> comment [
 	"Return the first comment of the receiver"
 	"(self>>#comment) comment"
@@ -213,7 +215,7 @@ CompiledCode >> comment [
 	^ self ast firstPrecodeComment
 ]
 
-{ #category : #'source code management' }
+{ #category : 'source code management' }
 CompiledCode >> definitionString [
 
 	"Polymorphic to class definitionString"
@@ -221,19 +223,19 @@ CompiledCode >> definitionString [
 	^ self sourceCode
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> encoderClass [
 	^ self signFlag
 		ifTrue: [ SecondaryBytecodeSetEncoderClass ]
 		ifFalse: [ PrimaryBytecodeSetEncoderClass ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> endPC [
 	^ self subclassResponsibility
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CompiledCode >> equivalentTo: aCompiledMethod [
 	^self = aCompiledMethod
 	or: [self class == aCompiledMethod class
@@ -242,20 +244,20 @@ CompiledCode >> equivalentTo: aCompiledMethod [
 		and: [self methodNode = aCompiledMethod methodNode ]]]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> flag [
 	"Answer the user-level flag bit"
 
 	^(self header bitAt: 29) = 1
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 CompiledCode >> flattenOn: aStream [
 	"We do not flatten code into bytecode/literals but add the whole object"
 	aStream nextPut: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> frameSize [
 	"Answer the size of temporary frame needed to run the receiver."
 	"NOTE:  Versions 2.7 and later use two sizes of contexts."
@@ -265,7 +267,7 @@ CompiledCode >> frameSize [
 		ifFalse: [LargeFrame]
 ]
 
-{ #category : #literals }
+{ #category : 'literals' }
 CompiledCode >> hasLiteral: literal [
 	"Answer whether the receiver references the argument, literal."
 	1 to: self numLiterals - self literalsToSkip do: "exclude superclass + selector/properties"
@@ -276,7 +278,7 @@ CompiledCode >> hasLiteral: literal [
 	^false
 ]
 
-{ #category : #literals }
+{ #category : 'literals' }
 CompiledCode >> hasLiteralSuchThat: litBlock [
 	"Answer true if litBlock returns true for any literal in this method, even if embedded in array structure."
 	1 to: self numLiterals - self literalsToSkip do: "exclude header and methodClass or outerCode"
@@ -289,18 +291,18 @@ CompiledCode >> hasLiteralSuchThat: litBlock [
 	^false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> hasPragmaNamed: arg1 [
 	^ self subclassResponsibility
 ]
 
-{ #category : #literals }
+{ #category : 'literals' }
 CompiledCode >> hasSelector: selector [
 	"Answers true if the method refers to the selector"
 	^ self hasSelector: selector specialSelectorIndex: (Smalltalk specialSelectorIndexOrNil: selector)
 ]
 
-{ #category : #literals }
+{ #category : 'literals' }
 CompiledCode >> hasSelector: selector specialSelectorIndex: specialOrNil [
 	"Answers true if the method refers to the selector.
 	 If you don't know what's a special selector, use #hasSelector:.
@@ -317,18 +319,18 @@ CompiledCode >> hasSelector: selector specialSelectorIndex: specialOrNil [
 	^false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> hasSourceCode [
 	^ self subclassResponsibility
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledCode >> hasTemporaries [
 	"Fast check that does not scan the bytecode, nor reifies the AST"
 	^ (self numTemps - self numArgs) > 0
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CompiledCode >> hash [
 	"CompiledMethod>>#= compares code, i.e. same literals and same bytecode.
 	 So we look at the header, methodClass and some bytes between initialPC and endPC,
@@ -348,7 +350,7 @@ CompiledCode >> hash [
 	"(CompiledMethod>>#hash) hash"
 ]
 
-{ #category : #literals }
+{ #category : 'literals' }
 CompiledCode >> header [
 	"Answer the word containing the information about the form of the
 	receiver and the form of the context needed to run the receiver."
@@ -356,7 +358,7 @@ CompiledCode >> header [
 	^self objectAt: 1
 ]
 
-{ #category : #literals }
+{ #category : 'literals' }
 CompiledCode >> headerDescription [
 	"Answer a description containing the information about the form of the
 	receiver and the form of the context needed to run the receiver."
@@ -383,7 +385,7 @@ CompiledCode >> headerDescription [
 	^ s contents
 ]
 
-{ #category : #literals }
+{ #category : 'literals' }
 CompiledCode >> indexOfLiteral: literal [
 	"Answer the literal index of the argument, literal, or zero if none."
 	1 to: self numLiterals - self literalsToSkip "exclude superclass + selector/properties"
@@ -393,20 +395,20 @@ CompiledCode >> indexOfLiteral: literal [
 	^0
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> initialPC [
 	"Answer the program counter for the receiver's first bytecode."
 
 	^ (self numLiterals + 1) * Smalltalk wordSize + 1
 ]
 
-{ #category : #literals }
+{ #category : 'literals' }
 CompiledCode >> innerCompiledBlocksAnySatisfy: aBlock [
 	self innerCompiledBlocksDo: [ :cb | (aBlock value: cb) ifTrue: [ ^ true ] ].
 	^ false
 ]
 
-{ #category : #literals }
+{ #category : 'literals' }
 CompiledCode >> innerCompiledBlocksDo: aBlock [
 	"We ignore the enclosing compiled code in compiled block by ignoring the last literal"
 	1 to: self numLiterals - self literalsToSkip do:
@@ -415,77 +417,77 @@ CompiledCode >> innerCompiledBlocksDo: aBlock [
 		lit isEmbeddedBlock ifTrue: [ aBlock value: lit ] ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledCode >> isCollection [
 	"We should override it because most of collection methods are not working for CompiledMethod. It is special class which needs to be ByteArray by VM. But it is not behaves like ByteArray from user perspective.
 	And some tools uses isCollection check for specific behaviour which will fail for CompiledMethod"
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledCode >> isDoIt [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledCode >> isExternalCallPrimitive [
 	^self primitive = 120
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> isInstalled [
 	^ self subclassResponsibility
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledCode >> isNamedPrimitive [
 	^self primitive = 117
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledCode >> isPrimitive [
 	^self primitive > 0
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledCode >> isQuick [
 	"Answer whether the receiver is a quick return (of self or of an instance
 	variable)."
 	^ self primitive between: 256 and: 519
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledCode >> isRealPrimitive [
 	^self isPrimitive and: [ self isQuick not ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledCode >> isReturnSelf [
 	"Answer whether the receiver is a quick return of self."
 
 	^ self primitive = 256
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledCode >> isReturnSpecial [
 	"Answer whether the receiver is a quick return of self or constant."
 
 	^ self primitive between: 256 and: 263
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> isTestMethod [
 	^ self subclassResponsibility
 ]
 
-{ #category : #literals }
+{ #category : 'literals' }
 CompiledCode >> literalAt: index [
 	"Answer the literal indexed by the argument."
 
 	^self objectAt: index + 1
 ]
 
-{ #category : #literals }
+{ #category : 'literals' }
 CompiledCode >> literalAt: index put: value [
 	"Replace the literal indexed by the first argument with the second
 	argument. Answer the second argument."
@@ -493,7 +495,7 @@ CompiledCode >> literalAt: index put: value [
 	^self objectAt: index + 1 put: value
 ]
 
-{ #category : #literals }
+{ #category : 'literals' }
 CompiledCode >> literals [
 
 	"Answer an Array of the literals referenced by the receiver.
@@ -508,20 +510,20 @@ CompiledCode >> literals [
 	^ literals
 ]
 
-{ #category : #literals }
+{ #category : 'literals' }
 CompiledCode >> literalsAt: anIndex [
 	"All literals are shifted of one slot. First slot is the method header"
 	^ self objectAt: anIndex + 1
 ]
 
-{ #category : #literals }
+{ #category : 'literals' }
 CompiledCode >> literalsDo: aBlock [
 	"Evaluate aBlock for each of the literals referenced by the receiver."
 	1 to: self numLiterals - self literalsToSkip do:
 		[:index | aBlock value: (self literalAt: index)]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> literalsEvenTheOnesInTheInnerBlocks [
 
 	| literals numberLiterals |
@@ -537,13 +539,13 @@ CompiledCode >> literalsEvenTheOnesInTheInnerBlocks [
 	^ literals asArray
 ]
 
-{ #category : #literals }
+{ #category : 'literals' }
 CompiledCode >> literalsToSkip [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CompiledCode >> localMessages [
 	"Answer a Set of all the message selectors sent by this method."
 
@@ -556,7 +558,7 @@ CompiledCode >> localMessages [
 	^aSet
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CompiledCode >> localReadsRef: literalAssociation [
 	"Answer whether the receiver loads the argument."
 	| litIndex scanner |
@@ -566,17 +568,17 @@ CompiledCode >> localReadsRef: literalAssociation [
 	^(scanner := InstructionStream on: self) scanFor: (self encoderClass bindingReadScanBlockFor: litIndex using: scanner)
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CompiledCode >> localReadsSelf [
 	^ self encoderClass readsSelfFor: self
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CompiledCode >> localReadsThisContext [
 	^ self encoderClass readsThisContextFor: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledCode >> localSendsAnySelectorOf: aCollection [
 
 	self literalsDo: [ :lit |
@@ -587,12 +589,12 @@ CompiledCode >> localSendsAnySelectorOf: aCollection [
 	^ false
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CompiledCode >> localSendsToSuper [
 	^ self encoderClass sendsToSuperFor: self
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CompiledCode >> localWritesRef: literalAssociation [
 	"Answer whether the receiver stores into the argument."
 	| litIndex scanner |
@@ -602,7 +604,7 @@ CompiledCode >> localWritesRef: literalAssociation [
 	^(scanner := InstructionStream on: self) scanFor: (self encoderClass bindingWriteScanBlockFor: litIndex using: scanner)
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 CompiledCode >> longPrintOn: aStream [
 	"List of all the byte codes in a method with a short description of each"
 
@@ -618,7 +620,7 @@ CompiledCode >> longPrintOn: aStream [
 	self symbolicBytecodes do: [ :each | each printOn: aStream ] separatedBy: [ aStream cr ]
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CompiledCode >> messages [
 	"Answer a Set of all the message selectors sent by this method."
 	| aSet |
@@ -627,22 +629,22 @@ CompiledCode >> messages [
 	^ aSet
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> method [
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> methodClass [
 	self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> methodNode [
 	^ self subclassResponsibility
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 CompiledCode >> needsFrameSize: newFrameSize [
 	"Set the largeFrameBit to accomodate the newFrameSize"
 	(self numTemps + newFrameSize) > LargeFrame ifTrue:
@@ -651,27 +653,27 @@ CompiledCode >> needsFrameSize: newFrameSize [
 		or: [ self primitive = 84 "perform:withArguments:"])
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> numArgs [
 	"Answer the number of arguments the receiver takes."
 
 	^ (self header bitShift: -24) bitAnd: 16r0F
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> numLiterals [
 	"Answer the number of literals used by the receiver."
 	^self header bitAnd: 16r7FFF
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> numTemps [
 	"Answer the number of temporary variables used by the receiver."
 
 	^ (self header bitShift: -18) bitAnd: 16r3F
 ]
 
-{ #category : #literals }
+{ #category : 'literals' }
 CompiledCode >> objectAt: index [
 	"Primitive. Answer the method header (if index=1) or a literal (if index
 	>1) from the receiver. Essential. See Object documentation
@@ -681,7 +683,7 @@ CompiledCode >> objectAt: index [
 	self primitiveFailed
 ]
 
-{ #category : #literals }
+{ #category : 'literals' }
 CompiledCode >> objectAt: index put: value [
 	"Primitive. Store the value argument into a literal in the receiver. An
 	index of 2 corresponds to the first literal. Fails if the index is less than 2
@@ -694,22 +696,22 @@ CompiledCode >> objectAt: index put: value [
 	self primitiveFailed
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> origin [
 	^ self methodClass findOriginClassOf: self method
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> originMethod [
 	^ self methodClass findOriginMethodOf: self method
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> pragmas [
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> primitive [
 	"Answer the primitive index associated with the receiver.
 	 Zero indicates that this is not a primitive method."
@@ -719,7 +721,7 @@ CompiledCode >> primitive [
 		ifFalse: [0]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 CompiledCode >> primitiveErrorVariableName [
 	"Answer the primitive error code temp name, or nil if none."
 	self isPrimitive ifTrue:
@@ -731,17 +733,17 @@ CompiledCode >> primitiveErrorVariableName [
 	^nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> properties [
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> propertyAt: aString ifAbsent: aFullBlockClosure [
 	^ aFullBlockClosure value
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CompiledCode >> readsField: varIndex [
 	"Answer whether the receiver loads the instance variable indexed by the argument."
 	| varIndexCode scanner |
@@ -750,14 +752,14 @@ CompiledCode >> readsField: varIndex [
 	^ self innerCompiledBlocksAnySatisfy: [ :cb | cb readsField: varIndex ]
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CompiledCode >> readsRef: literalAssociation [
 	"Answer whether the receiver loads the argument."
 	(self localReadsRef: literalAssociation) ifTrue: [ ^ true ].
 	^ self innerCompiledBlocksAnySatisfy: [ :cb | cb readsRef: literalAssociation ]
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CompiledCode >> readsSelf [
 	"Answer whether compiledMethod reads self, look into embedded blocks, too"
 	self isReturnSelf ifTrue: [ ^ true ].
@@ -765,19 +767,19 @@ CompiledCode >> readsSelf [
 	^ self innerCompiledBlocksAnySatisfy: [ :cb | cb readsSelf]
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CompiledCode >> readsSlot: aSlot [
 	^aSlot isReadIn: self
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CompiledCode >> readsThisContext [
 	"Answer whether compiledMethod reads thisContext, look into embedded blocks, too"
 	self localReadsThisContext ifTrue: [ ^ true ].
 	^ self innerCompiledBlocksAnySatisfy: [ :cb | cb readsThisContext]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledCode >> refersToLiteral: aLiteral [
 	"Answer true if any literal in this method is literal,
 	even if embedded in array structure."
@@ -791,7 +793,7 @@ CompiledCode >> refersToLiteral: aLiteral [
 	^ false
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CompiledCode >> sameLiteralsAs: method [
 	"Compare my literals to those of method. This is needed to compare compiled methods."
 
@@ -833,7 +835,7 @@ CompiledCode >> sameLiteralsAs: method [
 	                ifFalse: [literal1 = literal2]]
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CompiledCode >> scanFor: byte [
 	"Answer whether the receiver contains the argument as a bytecode."
 
@@ -843,44 +845,44 @@ Smalltalk browseAllSelect: [:m | m scanFor: 134]
 "
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> scanner [
 
 	^ InstructionStream on: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> selector [
 	^ self subclassResponsibility
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledCode >> sendsAnySelectorOf: aCollection [
 
 	(self localSendsAnySelectorOf: aCollection) ifTrue: [ ^ true ].
 	^ self innerCompiledBlocksAnySatisfy: [ :cb | cb sendsAnySelectorOf: aCollection ]
 ]
 
-{ #category : #literals }
+{ #category : 'literals' }
 CompiledCode >> sendsSelector: aSymbol [
 	"Answer whether the method sends a particular selector"
 	^ self messages includes: aSymbol
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CompiledCode >> sendsToSuper [
 	self localSendsToSuper ifTrue: [ ^ true ].
 	^ self innerCompiledBlocksAnySatisfy: [ :cb | cb sendsToSuper ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> setFlag [
 	"set the user-level flag bit"
 
 	self objectAt: 1 put: (self header bitAt: 29 put: 1)
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 CompiledCode >> setFrameBit: boolean [
 	"true for large frame, else false"
 	| largeFrameBit newHeader |
@@ -890,7 +892,7 @@ CompiledCode >> setFrameBit: boolean [
 	self objectAt: 1 put: newHeader
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> setSignFlag [
 	"Set the sign flag bit.  The sign flag bit may be
 	 used by the VM to select an alternate bytecode set."
@@ -899,7 +901,7 @@ CompiledCode >> setSignFlag [
 		[self objectAt: 1 put: self header + SmallInteger minVal]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> signFlag [
 	"Answer the sign flag bit.  The sign flag bit may be
 	 used by the VM to select an alternate bytecode set."
@@ -907,45 +909,45 @@ CompiledCode >> signFlag [
 	^ self header < 0
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> sourceCode [
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> sourceNode [
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> sourceNodeForPC: arg1 [
 	^ self subclassResponsibility
 ]
 
-{ #category : #'source code management' }
+{ #category : 'source code management' }
 CompiledCode >> sourcePointer [
 	^ self subclassResponsibility
 ]
 
-{ #category : #'source code management' }
+{ #category : 'source code management' }
 CompiledCode >> stamp [
 
 	^ self timeStamp
 ]
 
-{ #category : #'debugger support' }
+{ #category : 'debugger support' }
 CompiledCode >> stepIntoQuickMethods [
 	^self propertyAt: #stepIntoQuickMethod ifAbsent: [ false ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 CompiledCode >> symbolic [
 	"Answer a String that contains a list of all the byte codes in a method with a short description of each."
 
 	^self longPrintString
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 CompiledCode >> timeStamp [
 	"Answer the authoring time-stamp for the given method, retrieved from the sources or changes file. Answer the empty string if no time stamp is available."
 	"(CompiledMethod compiledMethodAt: #timeStamp) timeStamp"
@@ -953,17 +955,17 @@ CompiledCode >> timeStamp [
 	^ SourceFiles timeStampAt: self sourcePointer
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledCode >> usesPrimaryBytecodeSet [
 	^ self header >= 0
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledCode >> usesSecondaryBytecodeSet [
 	^ self header < 0
 ]
 
-{ #category : #cleaning }
+{ #category : 'cleaning' }
 CompiledCode >> voidCogVMState [
 	"Tell the VM to remove all references to any machine code form of the method.
 	 This primitive must be called whenever a method is in use and modified.  This is
@@ -976,7 +978,7 @@ CompiledCode >> voidCogVMState [
 	^self flushCache
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> withAllBlocks [
 	| all |
 	all := IdentitySet new.
@@ -984,14 +986,14 @@ CompiledCode >> withAllBlocks [
 	^all
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> withAllBlocksDo: aBlock [
 
 	aBlock value: self.
 	self allBlocksDo: aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledCode >> withAllNestedLiteralsDo: aBlockClosure [
 	"This method traverses all the nested literals.
 	As a Block or Method can have literals in the nested blocks.
@@ -1001,7 +1003,7 @@ CompiledCode >> withAllNestedLiteralsDo: aBlockClosure [
 		aCompiledCode literals do: aBlockClosure ]
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CompiledCode >> writesField: varIndex [
 	"Answer whether the receiver stores into the instance variable indexed by the argument."
 
@@ -1011,14 +1013,14 @@ CompiledCode >> writesField: varIndex [
 	^ self innerCompiledBlocksAnySatisfy: [ :cb | cb writesField: varIndex ]
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CompiledCode >> writesRef: literalAssociation [
 	"Answer whether the receiver stores into the argument."
 	(self localWritesRef: literalAssociation) ifTrue: [ ^ true ].
 	^ self innerCompiledBlocksAnySatisfy: [ :cb | cb writesRef: literalAssociation ]
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CompiledCode >> writesSlot: aSlot [
 	^aSlot isWrittenIn: self
 ]

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -8,18 +8,20 @@ Thus endPC of a compiled method is not the size of the bytecode, but the size mi
 
 "
 Class {
-	#name : #CompiledMethod,
-	#superclass : #CompiledCode,
-	#type : #compiledMethod,
-	#category : #'Kernel-Methods'
+	#name : 'CompiledMethod',
+	#superclass : 'CompiledCode',
+	#type : 'compiledMethod',
+	#category : 'Kernel-Methods',
+	#package : 'Kernel',
+	#tag : 'Methods'
 }
 
-{ #category : #constants }
+{ #category : 'constants' }
 CompiledMethod class >> abstractMarker [
 	^ #subclassResponsibility
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 CompiledMethod class >> checkBytecodeSetConflictsInMethodsWith: aBlock [
 
 	self allSubInstances
@@ -27,33 +29,33 @@ CompiledMethod class >> checkBytecodeSetConflictsInMethodsWith: aBlock [
 		ifFound: [ Warning signal: 'There are existing CompiledMethods with a different encoderClass.' ]
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 CompiledMethod class >> checkIsValidBytecodeEncoder: aBytecodeEncoderSubclass [
 	(aBytecodeEncoderSubclass inheritsFrom: BytecodeEncoder) ifFalse:
 		[self error: 'A bytecode set encoder is expected to be a subclass of BytecodeEncoder']
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 CompiledMethod class >> conflictMarker [
 	^ #traitConflict
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 CompiledMethod class >> disabledMarker [
 	^ #shouldNotImplement
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 CompiledMethod class >> explicitRequirementMarker [
 	^ #explicitRequirement
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 CompiledMethod class >> fullFrameSize [  "CompiledMethod fullFrameSize"
 	^ LargeFrame
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 CompiledMethod class >> handleFailingFailingNewMethod: numberOfBytes header: headerWord [
 	"This newMethod:header: gets sent after handleFailingBasicNew: has done a full
 	 garbage collection and possibly grown memory.  If this basicNew: fails then the
@@ -72,7 +74,7 @@ CompiledMethod class >> handleFailingFailingNewMethod: numberOfBytes header: hea
 	^self newMethod: numberOfBytes header: headerWord
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 CompiledMethod class >> handleFailingNewMethod: numberOfBytes header: headerWord [
 	"This newMethod:header: gets sent after newMethod:header: has failed
 	 and allowed a scavenging garbage collection to occur.  The scavenging
@@ -96,14 +98,14 @@ CompiledMethod class >> handleFailingNewMethod: numberOfBytes header: headerWord
 	^self handleFailingFailingNewMethod: numberOfBytes header: headerWord
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CompiledMethod class >> headerFlagForEncoder: anEncoderClass [
 	anEncoderClass == PrimaryBytecodeSetEncoderClass ifTrue: [ ^ 0 ].
 	anEncoderClass == SecondaryBytecodeSetEncoderClass ifTrue: [ ^ SmallInteger minVal ].
 	self error: 'The encoder is not one of the two installed bytecode sets'
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 CompiledMethod class >> initialize [    "CompiledMethod initialize"
 	"Initialize class variables specifying the size of the temporary frame
 	needed to run instances of me."
@@ -114,7 +116,7 @@ CompiledMethod class >> initialize [    "CompiledMethod initialize"
 	SecondaryBytecodeSetEncoderClass := EncoderForSistaV1
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 CompiledMethod class >> installPrimaryBytecodeSet: aBytecodeEncoderSubclass [
 	PrimaryBytecodeSetEncoderClass == aBytecodeEncoderSubclass ifTrue:
 		[ ^self ].
@@ -124,7 +126,7 @@ CompiledMethod class >> installPrimaryBytecodeSet: aBytecodeEncoderSubclass [
 	PrimaryBytecodeSetEncoderClass := aBytecodeEncoderSubclass
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 CompiledMethod class >> installSecondaryBytecodeSet: aBytecodeEncoderSubclass [
 	PrimaryBytecodeSetEncoderClass == aBytecodeEncoderSubclass ifTrue:
 		[ ^ self ].
@@ -134,7 +136,7 @@ CompiledMethod class >> installSecondaryBytecodeSet: aBytecodeEncoderSubclass [
 	SecondaryBytecodeSetEncoderClass := aBytecodeEncoderSubclass
 ]
 
-{ #category : #'accessing - class hierarchy' }
+{ #category : 'accessing - class hierarchy' }
 CompiledMethod class >> methodPropertiesClass [
 	"Answer the class to use to create a method's properties, which can be a poor man's way
 	 to add instance variables to subclassses of CompiledMethod.  Subclasses of CompiledMethod
@@ -143,14 +145,14 @@ CompiledMethod class >> methodPropertiesClass [
 	^AdditionalMethodState
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CompiledMethod class >> new [
 	"This will not make a meaningful method, but it could be used
 	to invoke some otherwise useful method in this class."
 	^self newMethod: 2 header: 1024
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CompiledMethod class >> newFrom: aCompiledMethod [
 	| inst |
 	inst := super basicNew: aCompiledMethod size.
@@ -159,7 +161,7 @@ CompiledMethod class >> newFrom: aCompiledMethod [
 	^ inst
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CompiledMethod class >> newInstanceFrom: oldInstance variable: variable size: instSize map: map [
 	"Create a new instance of the receiver based on the given old instance.
 	The supplied map contains a mapping of the old instVar names into
@@ -173,24 +175,24 @@ CompiledMethod class >> newInstanceFrom: oldInstance variable: variable size: in
 	^new
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 CompiledMethod class >> smallFrameSize [
 
 	^ SmallFrame
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 CompiledMethod class >> subclassResponsibilityMarker [
 	^ #subclassResponsibility
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 CompiledMethod class >> trailerSize [
 	"we use the last 5 byte to store the source pointer"
 	^ 5
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 CompiledMethod >> allIgnoredNotImplementedSelectors [
 
 	^ (self pragmaAt: #ignoreNotImplementedSelectors:)
@@ -198,43 +200,43 @@ CompiledMethod >> allIgnoredNotImplementedSelectors [
 		  ifNil: [ #(  ) ]
 ]
 
-{ #category : #'source code management' }
+{ #category : 'source code management' }
 CompiledMethod >> argumentNames [
 	^ self propertyAt: #argumentNames ifAbsent: [ super argumentNames ]
 ]
 
-{ #category : #'accessing - pragmas & properties' }
+{ #category : 'accessing - pragmas & properties' }
 CompiledMethod >> cachePragmas [
 
 	self pragmas do: [ :pragma | pragma class addToCache: pragma ]
 ]
 
-{ #category : #deprecated }
+{ #category : 'deprecated' }
 CompiledMethod >> category [
 
 	self deprecated: 'Use #protocolName instead.' transformWith: '`@rcv category' -> '`@rcv protocolName'.
 	^ self protocolName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledMethod >> classBinding [
 	"answer the association to the class that I am installed in, or nil if none."
 	^self literalAt: self numLiterals
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledMethod >> classBinding: aBinding [
        "sets the association to the class that I am installed in"
        ^self literalAt: self numLiterals put: aBinding
 ]
 
-{ #category : #'source code management' }
+{ #category : 'source code management' }
 CompiledMethod >> clearSourcePointer [
 	"we use #setSourcePointer: to not clear the property #source"
 	self setSourcePointer: 0
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledMethod >> codeForNoSource [
 	"if everything fails, decompile the bytecode"
 	"If there is no compiler, we cannot decompile it"
@@ -243,13 +245,13 @@ CompiledMethod >> codeForNoSource [
 	 ^(self compiler decompileMethod: self) formattedCode
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> containsHalt [
 
 	^ self hasProperty: #containsHalt
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledMethod >> defaultSelector [
 	"Invent and answer an appropriate message selector (a Symbol) for me,
 	that is, one that will parse with the correct number of arguments."
@@ -257,30 +259,30 @@ CompiledMethod >> defaultSelector [
 	^ #DoIt numArgs: self numArgs
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 CompiledMethod >> displayStringOn: aStream [
 	aStream print: self methodClass; nextPutAll: '>>'; store: self selector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledMethod >> endPC [
 	"Answer the index of the last bytecode"
 	^ self size - self class trailerSize
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledMethod >> flushCache [
 	"Tell the virtual machine to remove all references to this method from its method lookup caches, and to discard any optimized version 	of the method, if it has any of these.  This must be done whenever a method is modified in place, such as modifying its literals or 	machine code, to reflect the revised code.  c.f. Behavior>>flushCache & Symbol>>flushCache.  Essential.	 See MethodDictionary class 	comment."
 
 	<primitive: 116>
 ]
 
-{ #category : #'source code management' }
+{ #category : 'source code management' }
 CompiledMethod >> getPreambleFrom: aFileStream at: position [
 	^ SourceFiles getPreambleFrom: aFileStream at: position
 ]
 
-{ #category : #'source code management' }
+{ #category : 'source code management' }
 CompiledMethod >> getSourceFromFile [
 	"PLEASE Note: clients should always call #sourceCode"
 	"Read the source code from file, determining source file index and
@@ -289,7 +291,7 @@ CompiledMethod >> getSourceFromFile [
 	^ [ SourceFiles sourceCodeAt: self sourcePointer ] on: Error do: [ nil ]
 ]
 
-{ #category : #'source code management' }
+{ #category : 'source code management' }
 CompiledMethod >> getSourceReplacingSelectorWith: newSelector [
 	| oldKeywords newKeywords source newSource oldSelector start |
 	source := self sourceCode.
@@ -313,35 +315,35 @@ CompiledMethod >> getSourceReplacingSelectorWith: newSelector [
 	^newSource
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> hasComment [
 	"check if this method has a method comment"
 	^self comment isEmptyOrNil not
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> hasNonLocalReturn [
 	"Answer whether any block has a method-return ('^') in its code."
 	self allBlocksDo: [ :each | each hasMethodReturn ifTrue: [ ^true ] ].
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> hasPragma [
 	^ self hasProperties and: [self pragmas isNotEmpty]
 ]
 
-{ #category : #'accessing - pragmas & properties' }
+{ #category : 'accessing - pragmas & properties' }
 CompiledMethod >> hasPragmaNamed: aSymbol [
 	^ self pragmas anySatisfy: [ :pragma | pragma selector = aSymbol ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> hasProperties [
 	^ self penultimateLiteral isMethodProperties
 ]
 
-{ #category : #'accessing - pragmas & properties' }
+{ #category : 'accessing - pragmas & properties' }
 CompiledMethod >> hasProperty: aKey [
 
 	| extendedMethodState |
@@ -349,18 +351,18 @@ CompiledMethod >> hasProperty: aKey [
 		  and: [  extendedMethodState includesProperty: aKey ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledMethod >> hasSourceCode [
 
 	^ self sourceCodeOrNil isNotNil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> hasSourcePointer [
 	^ self sourcePointer ~= 0
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> isAbstract [
 	"Answer true if I am abstract"
 
@@ -371,35 +373,35 @@ CompiledMethod >> isAbstract [
 		or: [ marker == self class explicitRequirementMarker ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> isBinarySelector [
 	^self selector
 		allSatisfy: [:each | each isSpecial]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> isClassSide [
 	^self methodClass isClassSide
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> isClassified [
 
 	^ self protocol isUnclassifiedProtocol not
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> isCompiledMethod [
 
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> isConflict [
 	^ self markerOrNil == self class conflictMarker
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> isDeprecated [
 
 	^ self sendsAnySelectorOf: #(
@@ -411,32 +413,32 @@ CompiledMethod >> isDeprecated [
 			#deprecated:on:in:transformWith:when:)
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> isDisabled [
 	^ self isDisabled: self markerOrNil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> isDisabled: marker [
 	^ marker == self class disabledMarker
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> isDoIt [
 	^self selector isDoIt
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> isExplicitlyRequired [
 	^ self isExplicitlyRequired: self markerOrNil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> isExplicitlyRequired: marker [
 	^ marker == self class explicitRequirementMarker
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> isFaulty [
  	"check if this method was compiled from syntactically wrong code"
 	| ast |
@@ -454,7 +456,7 @@ CompiledMethod >> isFaulty [
 	^ ast isFaulty
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> isFromTrait [
 	"Return true for methods that have been included from Traits"
 
@@ -463,7 +465,7 @@ CompiledMethod >> isFromTrait [
 	^ origin isTrait and: [ origin ~= self methodClass ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> isInstalled [
 	self methodClass ifNotNil:
 		[:class|
@@ -473,7 +475,7 @@ CompiledMethod >> isInstalled [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> isOverridden [
 	| selector|
 	selector := self selector.
@@ -483,25 +485,25 @@ CompiledMethod >> isOverridden [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> isProvided [
 	^ self isProvided: self markerOrNil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> isProvided: marker [
 	marker ifNil: [^ true].
 	^ (self isRequired: marker) not and: [(self isDisabled: marker) not]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> isRequired [
 	"A method is required if it is a method declaring a subclass responsibility or an explicit requirement. This mean the method needs to be overriden (in case of subclass reponsibility) or implemented (in case of explicit requirement)."
 
 	^ self isRequired: self markerOrNil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> isRequired: marker [
 	marker ifNil: [^ false].
 	(self isExplicitlyRequired: marker) ifTrue: [^ true].
@@ -509,29 +511,29 @@ CompiledMethod >> isRequired: marker [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> isReturnField [
 	"Answer whether the receiver is a quick return of an instance variable."
 	^ self primitive between: 264 and: 519
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 CompiledMethod >> isSelfEvaluating [
 
 	^self methodClass notNil and: [self isDoIt not]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> isSubclassResponsibility [
 	^ self isSubclassResponsibility: self markerOrNil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> isSubclassResponsibility: marker [
 	^ marker == self class subclassResponsibilityMarker
 ]
 
-{ #category : #'source code management' }
+{ #category : 'source code management' }
 CompiledMethod >> linesOfCode [
 	"An approximate measure of lines of code.
 	Includes method's name and comments, but excludes empty lines."
@@ -542,43 +544,43 @@ CompiledMethod >> linesOfCode [
 	^lines
 ]
 
-{ #category : #literals }
+{ #category : 'literals' }
 CompiledMethod >> literalsToSkip [
 
 	^ 2
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 CompiledMethod >> markerOrNil [
 	^ self encoderClass markerOrNilFor: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledMethod >> method [
 	"polymorphic with closure"
 
 	^ self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledMethod >> methodClass [
 	"answer the class that I am installed in"
 	^self classBinding value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledMethod >> methodClass: aClass [
 	"set the class binding in the last literal to aClass"
 	^self numLiterals > 0
 		ifTrue: [ self literalAt: self numLiterals put: aClass binding ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledMethod >> name [
 	^ self printString
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 CompiledMethod >> penultimateLiteral [
 	"Answer the penultimate literal of the receiver, which holds either
 	 the receiver's selector or its properties (which will hold the selector)."
@@ -588,7 +590,7 @@ CompiledMethod >> penultimateLiteral [
 		ifFalse: [nil]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 CompiledMethod >> penultimateLiteral: anObject [
 	"Answer the penultimate literal of the receiver, which holds either
 	 the receiver's selector or its properties (which will hold the selector)."
@@ -598,7 +600,7 @@ CompiledMethod >> penultimateLiteral: anObject [
 		ifFalse: [self error: 'insufficient literals']
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 CompiledMethod >> postCopy [
 	| penultimateLiteral |
 	(penultimateLiteral := self penultimateLiteral) isMethodProperties ifTrue:
@@ -609,20 +611,20 @@ CompiledMethod >> postCopy [
 			[:p| p method: self]]
 ]
 
-{ #category : #'accessing - pragmas & properties' }
+{ #category : 'accessing - pragmas & properties' }
 CompiledMethod >> pragmaAt: aKey [
 	"Answer the first pragma with selector aKey, or nil if none."
 	^ self pragmas detect: [ :pragma | pragma selector == aKey ] ifNone: nil
 ]
 
-{ #category : #literals }
+{ #category : 'literals' }
 CompiledMethod >> pragmaRefersToLiteral: literal [
 
 	^ self penultimateLiteral isMethodProperties and: [
 		  self pragmas anySatisfy: [ :pragma | pragma refersToLiteral: literal ] ]
 ]
 
-{ #category : #'accessing - pragmas & properties' }
+{ #category : 'accessing - pragmas & properties' }
 CompiledMethod >> pragmas [
 	| selectorOrProperties |
 	^(selectorOrProperties := self penultimateLiteral) isMethodProperties
@@ -630,14 +632,14 @@ CompiledMethod >> pragmas [
 		ifFalse: [#()]
 ]
 
-{ #category : #'accessing - pragmas & properties' }
+{ #category : 'accessing - pragmas & properties' }
 CompiledMethod >> pragmasDo: aBlock [
 	| selectorOrProperties |
 	(selectorOrProperties := self penultimateLiteral) isMethodProperties
 		ifTrue: [selectorOrProperties pragmasDo: aBlock]
 ]
 
-{ #category : #'debugger support' }
+{ #category : 'debugger support' }
 CompiledMethod >> prepareForSimulationWith: numArgs [
 	"This method changes the argument count of a CompiledMethod header to numArgs, its temporary count to numArgs + 1 and change the code handling primitive error to store the error code in the unique temporary of the method"
 
@@ -651,14 +653,14 @@ CompiledMethod >> prepareForSimulationWith: numArgs [
 	self encoderClass prepareMethod: self forSimulationWith: numArgs
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 CompiledMethod >> printOn: aStream [
 	"Overrides method inherited from the byte arrayed collection."
 
 	aStream print: self methodClass; nextPutAll: '>>'; print: self selector
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 CompiledMethod >> printPrimitiveOn: aStream [
 	"Print the primitive on aStream"
 	| primDecl |
@@ -683,7 +685,7 @@ CompiledMethod >> printPrimitiveOn: aStream [
 	aStream nextPut: $>; cr
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledMethod >> properties [
 	"Answer the method properties of the receiver."
 	| propertiesOrSelector |
@@ -692,7 +694,7 @@ CompiledMethod >> properties [
 		ifFalse: [self class methodPropertiesClass forMethod: self selector: propertiesOrSelector]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledMethod >> properties: aMethodProperties [
 	"Set the method-properties of the receiver to aMethodProperties."
 
@@ -707,7 +709,7 @@ CompiledMethod >> properties: aMethodProperties [
 				 		yourself ])
 ]
 
-{ #category : #'accessing - pragmas & properties' }
+{ #category : 'accessing - pragmas & properties' }
 CompiledMethod >> propertyAt: propName [
 	| propertiesOrSelector |
 	^(propertiesOrSelector := self penultimateLiteral) isMethodProperties
@@ -715,7 +717,7 @@ CompiledMethod >> propertyAt: propName [
 		ifFalse: [nil]
 ]
 
-{ #category : #'accessing - pragmas & properties' }
+{ #category : 'accessing - pragmas & properties' }
 CompiledMethod >> propertyAt: propName ifAbsent: aBlock [
 	| propertiesOrSelector |
 	^(propertiesOrSelector := self penultimateLiteral) isMethodProperties
@@ -723,14 +725,14 @@ CompiledMethod >> propertyAt: propName ifAbsent: aBlock [
 		ifFalse: [aBlock value]
 ]
 
-{ #category : #'accessing - pragmas & properties' }
+{ #category : 'accessing - pragmas & properties' }
 CompiledMethod >> propertyAt: aKey ifAbsentPut: aBlock [
 	"Answer the property associated with aKey or, if aKey isn't found store the result of evaluating aBlock as new value."
 
 	^ self propertyAt: aKey ifAbsent: [ self propertyAt: aKey put: aBlock value ]
 ]
 
-{ #category : #'accessing - pragmas & properties' }
+{ #category : 'accessing - pragmas & properties' }
 CompiledMethod >> propertyAt: propName ifPresent: aBlock [
 	| propertiesOrSelector |
 	^(propertiesOrSelector := self penultimateLiteral) isMethodProperties
@@ -738,7 +740,7 @@ CompiledMethod >> propertyAt: propName ifPresent: aBlock [
 		ifFalse: [nil]
 ]
 
-{ #category : #'accessing - pragmas & properties' }
+{ #category : 'accessing - pragmas & properties' }
 CompiledMethod >> propertyAt: propName put: propValue [
 	"Set or add the property with key propName and value propValue.
 	 If the receiver does not yet have a method properties create one and replace
@@ -763,7 +765,7 @@ CompiledMethod >> propertyAt: propName put: propValue [
 	^propValue
 ]
 
-{ #category : #'accessing - pragmas & properties' }
+{ #category : 'accessing - pragmas & properties' }
 CompiledMethod >> propertyKeysAndValuesDo: aBlock [
 	"Enumerate the receiver with all the keys and values."
 
@@ -772,33 +774,33 @@ CompiledMethod >> propertyKeysAndValuesDo: aBlock [
 		[propertiesOrSelector propertyKeysAndValuesDo: aBlock]
 ]
 
-{ #category : #protocols }
+{ #category : 'protocols' }
 CompiledMethod >> protocol [
 	"Return in which protocol (conceptual groups of methods) the receiver is grouped into."
 
 	^ self methodClass protocolOfSelector: self selector
 ]
 
-{ #category : #protocols }
+{ #category : 'protocols' }
 CompiledMethod >> protocol: aProtocol [
 	^ self methodClass classify: self selector under: aProtocol
 ]
 
-{ #category : #protocols }
+{ #category : 'protocols' }
 CompiledMethod >> protocolName [
 	"Return the name of the protocol (conceptual groups of methods) in which the receiver is grouped into."
 
 	^ self methodClass protocolNameOfSelector: self selector
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CompiledMethod >> readsField: varIndex [
 	"Answer whether the receiver loads the instance variable indexed by the argument."
 	self isReturnField ifTrue: [^self returnField = (varIndex - 1)].
 	^ super readsField: varIndex
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 CompiledMethod >> receiver: aReceiver withArguments: anArray executeMethod: aMethod [
 	"execute aMethod.
 	This method takes aMethod as an argument so we can call primitive 188.
@@ -810,19 +812,19 @@ CompiledMethod >> receiver: aReceiver withArguments: anArray executeMethod: aMet
 	self primitiveFailed
 ]
 
-{ #category : #literals }
+{ #category : 'literals' }
 CompiledMethod >> refersToLiteral: aLiteral [
 	"Answer true if any literal in this method is literal, even if embedded in array structure."
 
 	^(self pragmaRefersToLiteral: aLiteral) or: [ super refersToLiteral: aLiteral]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 CompiledMethod >> removeFromSystem [
 	^ self methodClass removeSelector: self selector
 ]
 
-{ #category : #'accessing - pragmas & properties' }
+{ #category : 'accessing - pragmas & properties' }
 CompiledMethod >> removeProperty: propName [
 	"Remove the property propName if it exists.
 	 Do _not_ raise an error if the property is missing."
@@ -838,7 +840,7 @@ CompiledMethod >> removeProperty: propName [
 	^value
 ]
 
-{ #category : #'accessing - pragmas & properties' }
+{ #category : 'accessing - pragmas & properties' }
 CompiledMethod >> removeProperty: propName ifAbsent: aBlock [
 	"Remove the property propName if it exists.
 	 Answer the evaluation of aBlock if the property is missing."
@@ -851,7 +853,7 @@ CompiledMethod >> removeProperty: propName ifAbsent: aBlock [
 	^value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledMethod >> returnField [
 	"Answer the index of the instance variable returned by a quick return
 	method."
@@ -862,7 +864,7 @@ CompiledMethod >> returnField [
 		ifFalse: [^ prim - 264]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledMethod >> selector [
 	"Answer a method's selector.  This is either the penultimate literal,
 	 or, if the method has any properties or pragmas, the selector of
@@ -873,7 +875,7 @@ CompiledMethod >> selector [
 		ifFalse: [penultimateLiteral]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledMethod >> selector: aSelector [
 	"Set a method's selector.  This is either the penultimate literal,
 	 or, if the method has any properties or pragmas, the selector of
@@ -886,7 +888,7 @@ CompiledMethod >> selector: aSelector [
 				self literalAt: nl - 1 put: aSelector]
 ]
 
-{ #category : #'source code management' }
+{ #category : 'source code management' }
 CompiledMethod >> setSourcePointer: srcPointer [
 
 	| trailerBytes trailerSize start |
@@ -898,7 +900,7 @@ CompiledMethod >> setSourcePointer: srcPointer [
 	start + 1 to: self size do: [:n | self at: n put: (trailerBytes at: n - start) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledMethod >> sourceCode [
 	"Retrieve or reconstruct the source code for this method."
 
@@ -907,7 +909,7 @@ CompiledMethod >> sourceCode [
 		  ifNil: [ self codeForNoSource ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledMethod >> sourceCodeOrNil [
 	"Retrieve the source code for this method, or return nil."
 
@@ -916,7 +918,7 @@ CompiledMethod >> sourceCodeOrNil [
 	^ self getSourceFromFile
 ]
 
-{ #category : #'source code management' }
+{ #category : 'source code management' }
 CompiledMethod >> sourcePointer [
 	"Answer the integer which can be used to find the source file and position for this method.
 	The actual interpretation of this number is up to the SourceFileArray stored in the global variable SourceFiles."
@@ -928,7 +930,7 @@ CompiledMethod >> sourcePointer [
 	^ trailerBytes asInteger
 ]
 
-{ #category : #'source code management' }
+{ #category : 'source code management' }
 CompiledMethod >> sourcePointer: srcPointer [
 
 	"Drop the #source property if any"
@@ -936,12 +938,12 @@ CompiledMethod >> sourcePointer: srcPointer [
 	self setSourcePointer: srcPointer
 ]
 
-{ #category : #'debugger support' }
+{ #category : 'debugger support' }
 CompiledMethod >> stepIntoQuickMethods: aBoolean [
 	^self propertyAt: #stepIntoQuickMethod put: aBoolean
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 CompiledMethod >> storeOn: aStream [
 	| noneYet |
 	aStream nextPutAll: '(('.
@@ -965,24 +967,24 @@ CompiledMethod >> storeOn: aStream [
 	aStream nextPut: $)
 ]
 
-{ #category : #'source code management' }
+{ #category : 'source code management' }
 CompiledMethod >> tempNames [
 	"on the level of the compiled method, tempNames includes argument names"
 	^self ast argumentNames, self ast temporaryNames
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompiledMethod >> trailer [
 	^self deprecated: 'CompiledMethodTrailer has been removed in Pharo12. Just use sourcePointer / sourcePointer to read and set. See class comment of CompiledMethodTrailer for more information'
 ]
 
-{ #category : #protocols }
+{ #category : 'protocols' }
 CompiledMethod >> unclassify [
 
 	self protocol: Protocol unclassified
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethod >> usesUndeclareds [
 	"this is mixing Undeclareds and Obsoletes, maybe we should have two methods"
 	self withAllNestedLiteralsDo: [ :literal |
@@ -993,22 +995,22 @@ CompiledMethod >> usesUndeclareds [
 	^ false
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 CompiledMethod >> valueWithReceiver: aReceiver [
 	^self receiver: aReceiver withArguments: #() executeMethod: self
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 CompiledMethod >> valueWithReceiver: aReceiver arguments: anArray [
 	^self receiver: aReceiver withArguments: anArray executeMethod: self
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 CompiledMethod >> veryDeepCopyWith: deepCopier [
 	"Return self.  I am always shared.  Do not record me.  Only use this for blocks.  Normally methodDictionaries should not be copied this way."
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 CompiledMethod >> writesField: varIndex [
 	"Answer whether the receiver stores into the instance variable indexed by the argument."
 	self isQuick ifTrue: [^false].

--- a/src/Kernel/CompiledMethodLayout.class.st
+++ b/src/Kernel/CompiledMethodLayout.class.st
@@ -5,19 +5,21 @@ Unlike default Object layouts, CompiledMethods define a custom format integer si
 See CompiledMethod for more details.
 "
 Class {
-	#name : #CompiledMethodLayout,
-	#superclass : #ObjectLayout,
-	#category : #'Kernel-Layout'
+	#name : 'CompiledMethodLayout',
+	#superclass : 'ObjectLayout',
+	#category : 'Kernel-Layout',
+	#package : 'Kernel',
+	#tag : 'Layout'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CompiledMethodLayout class >> extending: superLayout scope: aScope host: aClass [
 	^ superLayout extendCompiledMethod
 		host: aClass;
 		yourself
 ]
 
-{ #category : #description }
+{ #category : 'description' }
 CompiledMethodLayout class >> subclassDefiningSymbol [
 	"Answer a keyword that describes the receiver's kind of subclass
 	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
@@ -26,12 +28,12 @@ CompiledMethodLayout class >> subclassDefiningSymbol [
 	^#variableByteSubclass:
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 CompiledMethodLayout >> extend [
 	self error: 'CompiledMethodLayout can not be extendend'
 ]
 
-{ #category : #format }
+{ #category : 'format' }
 CompiledMethodLayout >> instanceSpecification [
 	 ^ 24
 ]

--- a/src/Kernel/CompiledMethodTrailer.class.st
+++ b/src/Kernel/CompiledMethodTrailer.class.st
@@ -27,17 +27,19 @@ If you use the compiler, you need to do nothing special anymore! All methods com
 
 "
 Class {
-	#name : #CompiledMethodTrailer,
-	#superclass : #Object,
-	#category : #'Kernel-Methods'
+	#name : 'CompiledMethodTrailer',
+	#superclass : 'Object',
+	#category : 'Kernel-Methods',
+	#package : 'Kernel',
+	#tag : 'Methods'
 }
 
-{ #category : #kinds }
+{ #category : 'kinds' }
 CompiledMethodTrailer class >> empty [
 	^self deprecated: 'CompiledMethodTrailer has been removed in Pharo12. Just use sourcePointer / sourcePointer to read and set. See class comment of CompiledMethodTrailer for more information'
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CompiledMethodTrailer class >> isDeprecated [
 	^ true
 ]

--- a/src/Kernel/ConstantBlockClosure.class.st
+++ b/src/Kernel/ConstantBlockClosure.class.st
@@ -17,13 +17,15 @@ This class implements 0-arg blocks, with correct error handling for args >0. Sub
 	
 "
 Class {
-	#name : #ConstantBlockClosure,
-	#superclass : #CleanBlockClosure,
-	#type : #variable,
-	#category : #'Kernel-Methods'
+	#name : 'ConstantBlockClosure',
+	#superclass : 'CleanBlockClosure',
+	#type : 'variable',
+	#category : 'Kernel-Methods',
+	#package : 'Kernel',
+	#tag : 'Methods'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ConstantBlockClosure class >> numArgs: numArgs literal: aLiteral [
 	| classToUse |
 	classToUse := numArgs caseOf:
@@ -38,37 +40,37 @@ ConstantBlockClosure class >> numArgs: numArgs literal: aLiteral [
 		literal: aLiteral
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ConstantBlockClosure >> literal: anObject [
 	 literal := anObject
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 ConstantBlockClosure >> value [
 	^literal
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 ConstantBlockClosure >> value: anObject [
 	self numArgsError: 1
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 ConstantBlockClosure >> value: firstArg value: secondArg [
 	self numArgsError: 2
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 ConstantBlockClosure >> value: firstArg value: secondArg value: thirdArg [
 	self numArgsError: 3
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 ConstantBlockClosure >> value: firstArg value: secondArg value: thirdArg value: fourthArg [
 	self numArgsError: 4
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 ConstantBlockClosure >> valueWithArguments: anArray [
 	(anArray size ~= 0) ifTrue: [self numArgsError: anArray size].
 	^literal

--- a/src/Kernel/ConstantBlockClosure1Arg.class.st
+++ b/src/Kernel/ConstantBlockClosure1Arg.class.st
@@ -2,23 +2,25 @@
 one-arg block
 "
 Class {
-	#name : #ConstantBlockClosure1Arg,
-	#superclass : #ConstantBlockClosure,
-	#type : #variable,
-	#category : #'Kernel-Methods'
+	#name : 'ConstantBlockClosure1Arg',
+	#superclass : 'ConstantBlockClosure',
+	#type : 'variable',
+	#category : 'Kernel-Methods',
+	#package : 'Kernel',
+	#tag : 'Methods'
 }
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 ConstantBlockClosure1Arg >> value [
 	self numArgsError: 0
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 ConstantBlockClosure1Arg >> value: anObject [
 	^literal
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 ConstantBlockClosure1Arg >> valueWithArguments: anArray [
 	(anArray size ~= 1) ifTrue: [self numArgsError: anArray size].
 	^literal

--- a/src/Kernel/ConstantBlockClosure2Arg.class.st
+++ b/src/Kernel/ConstantBlockClosure2Arg.class.st
@@ -3,23 +3,25 @@
 
 "
 Class {
-	#name : #ConstantBlockClosure2Arg,
-	#superclass : #ConstantBlockClosure,
-	#type : #variable,
-	#category : #'Kernel-Methods'
+	#name : 'ConstantBlockClosure2Arg',
+	#superclass : 'ConstantBlockClosure',
+	#type : 'variable',
+	#category : 'Kernel-Methods',
+	#package : 'Kernel',
+	#tag : 'Methods'
 }
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 ConstantBlockClosure2Arg >> value [
 	self numArgsError: 0
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 ConstantBlockClosure2Arg >> value: firstArg value: secondArg [
 	^literal
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 ConstantBlockClosure2Arg >> valueWithArguments: anArray [
 	(anArray size ~= 2) ifTrue: [self numArgsError: anArray size].
 	^literal

--- a/src/Kernel/ConstantBlockClosure3Arg.class.st
+++ b/src/Kernel/ConstantBlockClosure3Arg.class.st
@@ -2,23 +2,25 @@
 3-arg block
 "
 Class {
-	#name : #ConstantBlockClosure3Arg,
-	#superclass : #ConstantBlockClosure,
-	#type : #variable,
-	#category : #'Kernel-Methods'
+	#name : 'ConstantBlockClosure3Arg',
+	#superclass : 'ConstantBlockClosure',
+	#type : 'variable',
+	#category : 'Kernel-Methods',
+	#package : 'Kernel',
+	#tag : 'Methods'
 }
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 ConstantBlockClosure3Arg >> value [
 	self numArgsError: 0
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 ConstantBlockClosure3Arg >> value: firstArg value: secondArg value: thirdArg [
 	^literal
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 ConstantBlockClosure3Arg >> valueWithArguments: anArray [
 	(anArray size ~= 3) ifTrue: [self numArgsError: anArray size].
 	^literal

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -16,9 +16,9 @@ MethodContexts, though normal in their variable size, are actually only used in 
 MethodContexts must only be created using the method newForMethod:.  Note that it is impossible to determine the real object size of a MethodContext except by asking for the frameSize of its method.  Any fields above the stack pointer (stackp) are truly invisible -- even (and especially!) to the garbage collector.  Any store into stackp other than by the primitive method stackp: is potentially fatal.
 "
 Class {
-	#name : #Context,
-	#superclass : #Object,
-	#type : #variable,
+	#name : 'Context',
+	#superclass : 'Object',
+	#type : 'variable',
 	#instVars : [
 		'sender',
 		'pc',
@@ -32,10 +32,12 @@ Class {
 		'SpecialPrimitiveSimulators',
 		'TryNamedPrimitiveTemplateMethod'
 	],
-	#category : #'Kernel-Methods'
+	#category : 'Kernel-Methods',
+	#package : 'Kernel',
+	#tag : 'Methods'
 }
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 Context class >> allInstances [
 	"Answer all instances of the receiver."
 	<primitive: 177>
@@ -55,7 +57,7 @@ Context class >> allInstances [
 	^insts contents
 ]
 
-{ #category : #hacks }
+{ #category : 'hacks' }
 Context class >> allInstancesDo: aBlock [
 	"Evaluate aBlock with each of the current instances of the receiver."
 	| instances inst next |
@@ -74,25 +76,25 @@ Context class >> allInstancesDo: aBlock [
 		 inst := next]
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Context class >> basicNew: size [
 	self error: 'Contexts must only be created with newForMethod:'
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Context class >> carefullyPrint: anObject on: aStream [
 	aStream nextPutAll: ([anObject printString]
 		on: Error
 		do: ['unprintable ' , anObject class name])
 ]
 
-{ #category : #compiler }
+{ #category : 'compiler' }
 Context class >> compiler [
 	"The JIT compiler needs to trap all reads to instance variables of contexts. As this check is costly, it is only done in the long form of the bytecodes, which are not used often. In this hierarchy we force the compiler to alwasy generate long bytecodes"
 	^super compiler options: #(+ optionLongIvarAccessBytecodes)
 ]
 
-{ #category : #'special context creation' }
+{ #category : 'special context creation' }
 Context class >> contextEnsure: block [
 	"Create an #ensure: context that is ready to return from executing its receiver"
 
@@ -111,7 +113,7 @@ Context class >> contextEnsure: block [
 	^ chain
 ]
 
-{ #category : #'special context creation' }
+{ #category : 'special context creation' }
 Context class >> contextOn: exceptionClass do: block [
 	"Create an #on:do: context that is ready to return from executing its receiver"
 
@@ -130,7 +132,7 @@ Context class >> contextOn: exceptionClass do: block [
 	^ chain
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 Context class >> initialize [
 
 	"A unique object to be returned when a primitive fails during simulation"
@@ -139,7 +141,7 @@ Context class >> initialize [
 	SpecialPrimitiveSimulators := nil
 ]
 
-{ #category : #simulation }
+{ #category : 'simulation' }
 Context class >> initializePrimitiveSimulators [
 	"extra primitive simulators can be registered by implementing
 	#registerPrimitiveSimulators method in class side of your class."
@@ -154,7 +156,7 @@ Context class >> initializePrimitiveSimulators [
 		]
 ]
 
-{ #category : #simulation }
+{ #category : 'simulation' }
 Context class >> initializeTryNamedPrimitiveTemplateMethod [
 	| source |
 	source := 'tryNamedPrimitive
@@ -165,19 +167,19 @@ Context class >> initializeTryNamedPrimitiveTemplateMethod [
 	TryNamedPrimitiveTemplateMethod := Smalltalk compiler compile: source
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Context class >> new [
 
 	self error: 'Contexts must only be created with newForMethod:'
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Context class >> new: size [
 
 	self error: 'Contexts must only be created with newForMethod:'
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Context class >> newForMethod: aMethod [
 	"This is the only method for creating new contexts, other than primitive cloning.
 	Any other attempts, such as inherited methods like shallowCopy, should be
@@ -189,32 +191,32 @@ Context class >> newForMethod: aMethod [
 	^ super basicNew: aMethod frameSize
 ]
 
-{ #category : #simulation }
+{ #category : 'simulation' }
 Context class >> primitiveFailToken [
 
 	^ self primitiveFailTokenFor: nil
 ]
 
-{ #category : #simulation }
+{ #category : 'simulation' }
 Context class >> primitiveFailTokenFor: errorCode [
 
 	^ { PrimitiveFailToken. errorCode }
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Context class >> sender: s receiver: r method: m arguments: args [
 	"Answer an instance of me with attributes set to the arguments."
 
 	^(self newForMethod: m) setSender: s receiver: r method: m arguments: args
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context class >> specialPrimitiveSimulators [
 	SpecialPrimitiveSimulators ifNil: [ self initializePrimitiveSimulators ].
 	^ SpecialPrimitiveSimulators
 ]
 
-{ #category : #'special context creation' }
+{ #category : 'special context creation' }
 Context class >> theReturnMethod [
 
 	| meth |
@@ -223,12 +225,12 @@ Context class >> theReturnMethod [
 	^ meth
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context class >> tryNamedPrimitiveTemplateMethod [
 	^ TryNamedPrimitiveTemplateMethod
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Context >> aboutToReturn: result through: firstUnwindContext [
 
 	"Called from VM when an unwindBlock is found between self and its home.
@@ -237,7 +239,7 @@ Context >> aboutToReturn: result through: firstUnwindContext [
 	self home return: result through: firstUnwindContext
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Context >> activateMethod: newMethod withArgs: args receiver: rcvr class: class [
 	"Answer a Context initialized with the arguments."
 
@@ -248,7 +250,7 @@ Context >> activateMethod: newMethod withArgs: args receiver: rcvr class: class 
 		arguments: args
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Context >> activateReturn: aContext value: value [
 	"Activate 'aContext return: value' in place of self, so execution will return to aContext's sender"
 
@@ -259,7 +261,7 @@ Context >> activateReturn: aContext value: value [
 		class: aContext class
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> activeHome [
 	"If executing closure, search senders for the activation of the original
 	 (outermost) method that (indirectly) created my closure (the closureHome).
@@ -272,7 +274,7 @@ Context >> activeHome [
 	^self findMethodContextSuchThat: [:ctxt | ctxt method == homeMethod]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> activeOuterContext [
 	"If executing closure, search senders for the activation in which the receiver's
 	 closure was created (the receiver's outerContext).  If the outerContext is not
@@ -285,20 +287,20 @@ Context >> activeOuterContext [
 	^self sender findContextSuchThat: [:ctxt | ctxt = outerContext]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> arguments [
 	"returns the arguments of a message invocation"
 
 	^(1 to: self numArgs) collect: [:i | self tempAt: i]
 ]
 
-{ #category : #'closure support' }
+{ #category : 'closure support' }
 Context >> asContext [
 
 	^ self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> at: index [
 	"Primitive. Assumes receiver is indexable. Answer the value of an
 	 indexable element in the receiver. Fail if the argument index is not an
@@ -314,7 +316,7 @@ Context >> at: index [
 		ifFalse: [self errorNonIntegerIndex]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> at: index put: value [
 	"Primitive. Assumes receiver is indexable. Answer the value of an
 	 indexable element in the receiver. Fail if the argument index is not
@@ -330,7 +332,7 @@ Context >> at: index put: value [
 		ifFalse: [self errorNonIntegerIndex]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> basicAt: index [
 	"Primitive. Assumes receiver is indexable. Answer the value of an
 	 indexable element in the receiver. Fail if the argument index is not an
@@ -344,7 +346,7 @@ Context >> basicAt: index [
 	self errorNonIntegerIndex
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> basicAt: index put: value [
 	"Primitive. Assumes receiver is indexable. Answer the value of an
 	 indexable element in the receiver. Fail if the argument index is not
@@ -358,7 +360,7 @@ Context >> basicAt: index put: value [
 	self errorNonIntegerIndex
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> basicSize [
 	"Primitive. Answer the number of indexable variables in the receiver.
 	This value is the same as the largest legal subscript. Essential. Do not
@@ -370,12 +372,12 @@ Context >> basicSize [
 	^self primitiveFail
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Context >> belongsToDoIt [
 	^self homeMethod isDoIt
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> blockReturnConstant: value [
 	"Simulate the interpreter's action when a ReturnConstantToCaller
 	bytecode is
@@ -385,7 +387,7 @@ Context >> blockReturnConstant: value [
 	^ self return: value from: self
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> blockReturnTop [
 	"Simulate the interpreter's action when a ReturnTopOfStackToCaller bytecode is
 	 encountered in the receiver.  This should only happen in a closure activation."
@@ -393,14 +395,14 @@ Context >> blockReturnTop [
 	^self return: self pop from: self
 ]
 
-{ #category : #query }
+{ #category : 'query' }
 Context >> bottomContext [
 	"Return the last context (the first context invoked) in my sender chain"
 
 	^ self findContextSuchThat: [ :context | context sender isNil]
 ]
 
-{ #category : #'private - exceptions' }
+{ #category : 'private - exceptions' }
 Context >> canHandleSignal: exception [
 	"Sent to handler (on:do:) contexts only.  If my exception class (first arg) handles exception then return true, otherwise forward this message to the next handler context.  If none left, return false (see nil>>canHandleSignal:)"
 
@@ -408,7 +410,7 @@ Context >> canHandleSignal: exception [
 		or: [ self nextHandlerContext canHandleSignal: exception ]
 ]
 
-{ #category : #'private - exceptions' }
+{ #category : 'private - exceptions' }
 Context >> cannotReturn: result [
 
 	closureOrNil ifNotNil: [
@@ -418,58 +420,58 @@ Context >> cannotReturn: result [
 		inContext: thisContext
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Context >> cannotReturn: result to: aContext [
 	"The receiver tried to return result to homeContext that no longer exists."
 
 	^ ContextCannotReturn result: result to: aContext
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> client [
 	"Answer the client, that is, the object that sent the message that created this context."
 
 	^sender receiver
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> closure [
 	^closureOrNil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> compiledCode [
 
 	^method
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> contextClass [
 "The context class of a message send should be the one of the method to be evaluated, because if that method has some super sends, the method lookup won't work as expected'"
 
 	^self compiledCode methodClass
 ]
 
-{ #category : #'debugger access' }
+{ #category : 'debugger access' }
 Context >> contextStack [
 	"Answer an Array of the contexts on the receiver's sender chain."
 
 	^self stackOfSize: 100000
 ]
 
-{ #category : #'closure support' }
+{ #category : 'closure support' }
 Context >> contextTag [
 	"Context tags may be used for referring to contexts instead of contexts themselves as they can be copied and will continue to work in other processes (continuations). By default, we use the context itself to as its tag."
 	^self
 ]
 
-{ #category : #query }
+{ #category : 'query' }
 Context >> copyStack [
 
 	^ self copyTo: nil
 ]
 
-{ #category : #query }
+{ #category : 'query' }
 Context >> copyTo: aContext [
 	"Copy self and my sender chain down to, but not including, aContext.  End of copied chain will have nil sender."
 
@@ -481,7 +483,7 @@ Context >> copyTo: aContext [
 	^ copy
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Context >> cut: aContext [
 	"Cut aContext and its senders from my sender chain"
 
@@ -496,7 +498,7 @@ Context >> cut: aContext [
 	callee privSender: nil
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Context >> debugStack: stackSize on: aStream [
 	"print a condensed version of the stack up to stackSize on aStream"
 
@@ -506,13 +508,13 @@ Context >> debugStack: stackSize on: aStream [
 			aStream cr ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Context >> debugStackOn: aStream [
 	"print the top ten contexts on my sender chain."
 	^ self debugStack: 100 on: aStream
 ]
 
-{ #category : #'debugger access' }
+{ #category : 'debugger access' }
 Context >> depthBelow: aContext [
 	"Answer how many calls there are between this and aContext."
 
@@ -526,7 +528,7 @@ Context >> depthBelow: aContext [
 	^ depth
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> directedSuperSend: selector numArgs: numArgs [
 
 	| lookupClass arguments currentReceiver |
@@ -542,27 +544,27 @@ Context >> directedSuperSend: selector numArgs: numArgs [
 	^ self send: selector to: currentReceiver with: arguments lookupIn: lookupClass
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> doDup [
 	"Simulate the action of a 'duplicate top of stack' bytecode."
 
 	self push: self top
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> doNop [
 
 	"do nothing"
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> doPop [
 	"Simulate the action of a 'remove top of stack' bytecode."
 
 	self pop
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Context >> doPrimitive: primitiveIndex method: meth receiver: aReceiver args: arguments [
 	"Simulate a primitive method whose index is primitiveIndex.  The simulated receiver and
 	 arguments are given as arguments to this message. If successful, push result and return
@@ -664,12 +666,12 @@ Context >> doPrimitive: primitiveIndex method: meth receiver: aReceiver args: ar
 		ifFalse: [self push: value]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Context >> endPC [
 	^ self compiledCode endPC
 ]
 
-{ #category : #'debugger access' }
+{ #category : 'debugger access' }
 Context >> errorReportOn: stream [
 	"Write a detailed error report on the stack (above me) on a
 	stream.  For both the error file, and emailing a bug report.
@@ -718,7 +720,7 @@ Context >> errorReportOn: stream [
 		aContext := aContext sender ]
 ]
 
-{ #category : #'private - exceptions' }
+{ #category : 'private - exceptions' }
 Context >> evaluateSignal: exception [
 	"The following primitive is just a marker used to find the evaluation context.
 	See MethodContext>>#isHandlerOrSignalingContext. "
@@ -732,25 +734,25 @@ Context >> evaluateSignal: exception [
 	self return: value
 ]
 
-{ #category : #'special context access' }
+{ #category : 'special context access' }
 Context >> exception [
 	"signaling context (Context>>evaluateSignal:) only. Access the exception argument."
 	^self tempAt: 1
 ]
 
-{ #category : #'special context access' }
+{ #category : 'special context access' }
 Context >> exceptionClass [
 	"handlercontext only. access temporaries from BlockClosure>>#on:do:"
 	^self tempAt: 1
 ]
 
-{ #category : #'special context access' }
+{ #category : 'special context access' }
 Context >> exceptionHandlerBlock [
 	"handlercontext only. access temporaries from BlockClosure>>#on:do:"
 	^self tempAt: 2
 ]
 
-{ #category : #'private - exceptions' }
+{ #category : 'private - exceptions' }
 Context >> exceptionsToCaptureWhenStepping [
 
 	| exceptionsToCapture exceptionsSet |
@@ -761,7 +763,7 @@ Context >> exceptionsToCaptureWhenStepping [
 	^ exceptionsSet
 ]
 
-{ #category : #'system simulation' }
+{ #category : 'system simulation' }
 Context >> failPrimitiveWith: maybePrimFailToken [
 	"The receiver is a freshly-created context on a primitive method.  Skip the callPrimitive:
 	 bytecode and store the primitive fail code if there is one and the method consumes it."
@@ -771,7 +773,7 @@ Context >> failPrimitiveWith: maybePrimFailToken [
 		[self at: stackp put: maybePrimFailToken last]
 ]
 
-{ #category : #'debugger access' }
+{ #category : 'debugger access' }
 Context >> filterDebuggerStack [
 	"Answer self or the first sender that do not have the pragma `debuggerCompleteToSender` or belong to the `Exception` class hierarchy"
 
@@ -781,7 +783,7 @@ Context >> filterDebuggerStack [
 		  ifFalse: [ self ]
 ]
 
-{ #category : #query }
+{ #category : 'query' }
 Context >> findContextSuchThat: testBlock [
 	"Search self and my sender chain for first one that satisfies testBlock.  Return nil if none satisfy"
 
@@ -794,7 +796,7 @@ Context >> findContextSuchThat: testBlock [
 	^ nil
 ]
 
-{ #category : #query }
+{ #category : 'query' }
 Context >> findMethodContextSuchThat: testBlock [
 	"Search self and my sender chain for first one that satisfies testBlock. Ignore block contexts. Return nil if none satisfy"
 
@@ -807,7 +809,7 @@ Context >> findMethodContextSuchThat: testBlock [
 	^ nil
 ]
 
-{ #category : #'private - exceptions' }
+{ #category : 'private - exceptions' }
 Context >> findNextHandlerContext [
 	"Return the next handler marked context, returning nil if there is none.
 	Search starts with self and proceeds up to nil."
@@ -822,7 +824,7 @@ Context >> findNextHandlerContext [
 	^searchStartContext nextHandlerContext
 ]
 
-{ #category : #'private - exceptions' }
+{ #category : 'private - exceptions' }
 Context >> findNextHandlerOrSignalingContext [
 	"Return the next handler/signaling marked context, answering nil if there is none.
 	Search starts with self and proceeds up to nil."
@@ -837,7 +839,7 @@ Context >> findNextHandlerOrSignalingContext [
 	^ nil
 ]
 
-{ #category : #'private - exceptions' }
+{ #category : 'private - exceptions' }
 Context >> findNextUnwindContextUpTo: aContext [
 	"Return the next unwind marked above the receiver, returning nil if there is none.  Search proceeds up to but not including aContext."
 
@@ -853,7 +855,7 @@ Context >> findNextUnwindContextUpTo: aContext [
 	^nil
 ]
 
-{ #category : #'private - exceptions' }
+{ #category : 'private - exceptions' }
 Context >> handleSignal: exception [
 	"Sent to handler (on:do:) contexts only.  If my exception class (first arg) handles exception then execute my handle block (second arg), otherwise forward this message to the next handler context.  If none left, execute exception's defaultAction (see nil>>handleSignal:)."
 	<debuggerCompleteToSender>
@@ -862,21 +864,21 @@ Context >> handleSignal: exception [
 	self evaluateSignal: exception
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Context >> hasContext: aContext [
 	"Answer whether aContext is me or one of my senders"
 
 	^ (self findContextSuchThat: [ :context | context == aContext ]) notNil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> hasInstVarRef [
 	"Answer whether the receiver references an instance variable."
 
 	^self compiledCode hasInstVarRef
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Context >> hasMethodReturn [
 	self
 		deprecated: 'use #hasNonLocalReturn'
@@ -884,7 +886,7 @@ Context >> hasMethodReturn [
 	^self hasNonLocalReturn
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Context >> hasNonLocalReturn [
 	"check if this context does a non-local return, do not recurse into nested blocks as they will have anohter context"
 	^ closureOrNil
@@ -892,7 +894,7 @@ Context >> hasNonLocalReturn [
 		  ifNotNil: [ :closure | closure compiledBlock hasMethodReturn ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Context >> hasSender: context [
 	"Answer whether the receiver is strictly above context on the stack."
 
@@ -908,12 +910,12 @@ Context >> hasSender: context [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Context >> hasTemporaryVariableNamed: aName [
 	^ self tempNames includes: aName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> home [
 	"Answer the context in which the receiver was defined, i.e. the context from which an ^-return ] should return from."
 
@@ -924,14 +926,14 @@ Context >> home [
 		ifNotNil: [:outer | outer home ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> homeMethod [
 	"Answer the method in which the receiver was defined, i.e. the context from which an ^-return ] should return from. Note: implemented to not need #home"
 
 	^ closureOrNil ifNil: [ self method ] ifNotNil: [ :closure | closure homeMethod ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Context >> insertSender: aContext [
 	"Insert aContext and its sender chain between me and my sender.  Return new callee of my original sender."
 
@@ -942,7 +944,7 @@ Context >> insertSender: aContext [
 	^ context
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Context >> instVarAt: index put: value [
 	index = 3
 		ifTrue: [
@@ -951,7 +953,7 @@ Context >> instVarAt: index put: value [
 	^ super instVarAt: index put: value
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Context >> isBlockContext [
 	"Is this executing a block versus a method?  In the new closure
 	 implemetation this is true if closureOrNil is not nil, in which case
@@ -960,19 +962,19 @@ Context >> isBlockContext [
 	^closureOrNil isClosure
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Context >> isBottomContext [
 	"Answer if this is the last context (the first context invoked) in my sender chain"
 
 	^sender isNil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Context >> isContext [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Context >> isDead [
 	"Context is dead when
 	- it is self finished (returned to sender)
@@ -981,7 +983,7 @@ Context >> isDead [
 	^ pc isNil or: [  self isEndOfProcessTermination ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Context >> isEndOfProcessTermination [
 	"The normal completion of any process always ends at Process>>doTerminationFromYourself method
 	(see #newProcess and #terminateRealActive).
@@ -993,45 +995,45 @@ Context >> isEndOfProcessTermination [
 	^pc = (self endPC - 1)
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Context >> isExecutingBlock [
 	"for compatibility"
 	^self isBlockContext
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Context >> isFailToken: anObject [
 	^ (self objectClass: anObject) == Array
 			and: [ anObject size = 2 and: [(anObject at: 1) == PrimitiveFailToken]]
 ]
 
-{ #category : #'private - exceptions' }
+{ #category : 'private - exceptions' }
 Context >> isHandlerContext [
 	"is this context for #on:do:?"
 	^self isHandlerOrSignalingContext and: [ self selector == #on:do: ]
 ]
 
-{ #category : #'private - exceptions' }
+{ #category : 'private - exceptions' }
 Context >> isHandlerOrSignalingContext [
 	"Both BlockClosure>>on:do: (handler) and Context>>evaluateSignal: (signaling)
 	are marked with primitive 199."
 	^method primitive = 199
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Context >> isPrimFailToken: anObject [
 	^ (self objectClass: anObject) == Array
 		  and: [anObject size = 2
 		  and: [anObject first == PrimitiveFailToken]]
 ]
 
-{ #category : #'private - exceptions' }
+{ #category : 'private - exceptions' }
 Context >> isUnwindContext [
 	"is this context for  method that is marked?"
 	^method primitive = 198
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Context >> jump [
 	"Abandon thisContext and resume self instead (using the same current process).  You may want to save thisContext's sender before calling this so you can jump back to it.
 	Self MUST BE a top context (ie. a suspended context or an abandoned context that was jumped out of).  A top context already has its return value on its stack (see Interpreter>>primitiveSuspend and other suspending primitives).
@@ -1051,7 +1053,7 @@ Context >> jump [
 	^ top
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> jump: distance if: condition withInterpreter: anInterpreter [
 	"Simulate the action of a 'conditional jump' bytecode whose offset is the
 	argument, distance, and whose condition is the argument, condition."
@@ -1067,7 +1069,7 @@ Context >> jump: distance if: condition withInterpreter: anInterpreter [
 	(bool eqv: condition) ifTrue: [self jump: distance withInterpreter: anInterpreter]
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> jump: distance withInterpreter: anInterpreter [
 	"Simulate the action of a 'unconditional jump' bytecode whose offset is
 	the argument, distance."
@@ -1076,7 +1078,7 @@ Context >> jump: distance withInterpreter: anInterpreter [
 	anInterpreter pc: pc
 ]
 
-{ #category : #'debugger access' }
+{ #category : 'debugger access' }
 Context >> longStack [
 	"Answer a String showing the top 100 contexts on my sender chain."
 
@@ -1085,7 +1087,7 @@ Context >> longStack [
 			stream print: item; cr ]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> method [
 	"self
 		deprecated: 'Should use compiledCode since it can be CompiledMethod or a CompiledBlock'
@@ -1095,19 +1097,19 @@ Context >> method [
 	^method
 ]
 
-{ #category : #'debugger access' }
+{ #category : 'debugger access' }
 Context >> methodClass [
 	"Answer the class in which the receiver's method was found."
 
 	^self compiledCode methodClass ifNil:[self receiver class]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> methodNode [
 	^ self homeMethod methodNode
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> methodReturnContext [
 	self
 		deprecated: 'Use #home instead'
@@ -1115,7 +1117,7 @@ Context >> methodReturnContext [
 	^ self home
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> methodReturnReceiver [
 	"Simulate the action of a 'return receiver' bytecode. This corresponds to
 	 the source expression '^self'."
@@ -1123,7 +1125,7 @@ Context >> methodReturnReceiver [
 	^self return: self receiver from: self home
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> methodReturnTop [
 
 	"Simulate the action of a 'return top of stack' bytecode. This corresponds
@@ -1132,7 +1134,7 @@ Context >> methodReturnTop [
 	^ self return: self pop from: self home
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> methodSelector [
 	self
 		deprecated: 'use #selector'
@@ -1140,13 +1142,13 @@ Context >> methodSelector [
 	^ self selector
 ]
 
-{ #category : #'private - exceptions' }
+{ #category : 'private - exceptions' }
 Context >> nextHandlerContext [
 
 	^ self sender findNextHandlerContext
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> numArgs [
 	"Answer the number of arguments for this activation."
 	^closureOrNil
@@ -1154,7 +1156,7 @@ Context >> numArgs [
 		ifNotNil: [closureOrNil numArgs]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> numTemps [
 	"Answer the number of temporaries for this activation; this includes
 	 the number of arguments, and for blocks, the number of copied values."
@@ -1163,7 +1165,7 @@ Context >> numTemps [
 		ifNotNil: [closureOrNil numTemps]
 ]
 
-{ #category : #'mirror primitives' }
+{ #category : 'mirror primitives' }
 Context >> object: anObject basicAt: index [
 	"Answer the value of an indexable element in the argument anObject without sending
 	 it a message. Fail if the argument index is not an Integer or is out of bounds, or if
@@ -1178,7 +1180,7 @@ Context >> object: anObject basicAt: index [
 		ifFalse: [self errorNonIntegerIndex]
 ]
 
-{ #category : #'mirror primitives' }
+{ #category : 'mirror primitives' }
 Context >> object: anObject basicAt: index put: value [
 	"Store the last argument
 	 value in the indexable element of the argument anObject indicated by index without sending
@@ -1204,7 +1206,7 @@ Context >> object: anObject basicAt: index put: value [
 	self errorImproperStore
 ]
 
-{ #category : #'mirror primitives' }
+{ #category : 'mirror primitives' }
 Context >> object: anObject eqeq: anOtherObject [
 	"Answer whether the first and second arguments are the same object (have the
 	 same object pointer) without sending a message to the first argument.  This
@@ -1216,7 +1218,7 @@ Context >> object: anObject eqeq: anOtherObject [
 	self primitiveFailed
 ]
 
-{ #category : #'mirror primitives' }
+{ #category : 'mirror primitives' }
 Context >> object: anObject instVarAt: anIndex [
 	"Primitive. Answer a fixed variable in an object. The numbering of the
 	 variables corresponds to the named instance variables. Fail if the index
@@ -1228,7 +1230,7 @@ Context >> object: anObject instVarAt: anIndex [
 	^self object: anObject basicAt: anIndex - (self objectClass: anObject) instSize
 ]
 
-{ #category : #'mirror primitives' }
+{ #category : 'mirror primitives' }
 Context >> object: anObject instVarAt: anIndex put: aValue [
 	"Primitive. Store a value into a fixed variable in the argument anObject.
 	 The numbering of the variables corresponds to the named instance
@@ -1243,7 +1245,7 @@ Context >> object: anObject instVarAt: anIndex put: aValue [
 	^self object: anObject basicAt: anIndex - (self objectClass: anObject) instSize put: aValue
 ]
 
-{ #category : #'mirror primitives' }
+{ #category : 'mirror primitives' }
 Context >> object: anObject perform: selector withArguments: argArray inClass: lookupClass [
 	"Send the selector, aSymbol, to anObject with arguments in argArray.
 	 Fail if the number of arguments expected by the selector
@@ -1263,13 +1265,13 @@ Context >> object: anObject perform: selector withArguments: argArray inClass: l
 	self primitiveFailed
 ]
 
-{ #category : #'mirror primitives' }
+{ #category : 'mirror primitives' }
 Context >> objectClass: aReceiver [
 	<primitive: 111>
 	self primitiveFailed
 ]
 
-{ #category : #'mirror primitives' }
+{ #category : 'mirror primitives' }
 Context >> objectSize: anObject [
 	"Answer the number of indexable variables in the argument anObject without sending
 	 it a message. This mimics the action of the VM when it fetches an object's variable size.
@@ -1281,7 +1283,7 @@ Context >> objectSize: anObject [
 	^0
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> outerContext [
 	"Answer the context within which the receiver is nested."
 
@@ -1289,24 +1291,24 @@ Context >> outerContext [
 		[closureOrNil outerContext ifNil: ["if the outer is nil, this is a CleanBlock" self sender]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> outerMostContext [
 	^ self outerContext
 		ifNil: [ self ]
 		ifNotNil: [ self outerContext ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> pc [
 	^ pc
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> pc: anInteger [
 	pc := anInteger
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Context >> pop [
 	"Answer the top of the receiver's stack and remove the top of the stack."
 	| value |
@@ -1315,7 +1317,7 @@ Context >> pop [
 	^ value
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> popIntoLiteralVariable: value [
 	"Simulate the action of bytecode that removes the top of the stack and
 	stores it into a literal variable of my method."
@@ -1323,7 +1325,7 @@ Context >> popIntoLiteralVariable: value [
 	value value: self pop
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> popIntoReceiverVariable: offset [
 	"Simulate the action of bytecode that removes the top of the stack and
 	stores it into an instance variable of my receiver."
@@ -1331,7 +1333,7 @@ Context >> popIntoReceiverVariable: offset [
 	self object: self receiver instVarAt: offset + 1 put: self pop
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> popIntoRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex [
 	"Simulate the action of bytecode that removes the top of the stack and  stores
 	 it into an offset in one of my local variables being used as a remote temp vector."
@@ -1339,7 +1341,7 @@ Context >> popIntoRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex [
 	(self at: tempVectorIndex + 1) at: remoteTempIndex + 1 put: self pop
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> popIntoTemporaryVariable: offset [
 	"Simulate the action of bytecode that removes the top of the stack and
 	stores it into one of my temporary variables."
@@ -1347,7 +1349,7 @@ Context >> popIntoTemporaryVariable: offset [
 	self at: offset + 1 put: self pop
 ]
 
-{ #category : #'debugger access' }
+{ #category : 'debugger access' }
 Context >> print: anObject on: aStream [
 	"Safely print anObject in the face of direct ProtoObject subclasses"
 	| title |
@@ -1359,7 +1361,7 @@ Context >> print: anObject on: aStream [
 		nextPutAll: title
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Context >> printDebugOn: aStream [
 	"print a condensed for of the stack.
 		For methods simply print Class >> selector
@@ -1381,7 +1383,7 @@ Context >> printDebugOn: aStream [
 		ifTrue: [ aStream nextPutAll: '...' ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Context >> printDebugStackOn: aStream [
 
 	"Print the debug stack from the context on my sender chain.
@@ -1390,7 +1392,7 @@ Context >> printDebugStackOn: aStream [
 	^ self debugStack: SmallInteger maxVal on: aStream
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Context >> printDetails: stream [
 	"Put my class>>selector and instance variables and arguments and temporaries on the stream.  Protect against errors during printing."
 
@@ -1432,7 +1434,7 @@ Context >> printDetails: stream [
 	stream cr
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Context >> printOn: aStream [
 	(closureOrNil isNotNil and: [closureOrNil isKindOf: CleanBlockClosure]) ifTrue:
 		[ | selector |
@@ -1472,7 +1474,7 @@ Context >> printOn: aStream [
 			outerContext printOn: aStream ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Context >> privRefresh [
 	"Reinitialize the receiver so that it is in the state it was at its creation."
 	 closureOrNil
@@ -1489,7 +1491,7 @@ Context >> privRefresh [
 				[:i | self tempAt: i put: nil]]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Context >> privRefreshWith: aCompiledMethod [
 	"Reinitialize the receiver as though it had been for a different method.
 	 Used by a Debugger when one of the methods to which it refers is
@@ -1503,13 +1505,13 @@ Context >> privRefreshWith: aCompiledMethod [
 	self privRefresh
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Context >> privSender: aContext [
 
 	sender := aContext
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Context >> push: value [
 	"Push value on the receiver's stack."
 
@@ -1517,7 +1519,7 @@ Context >> push: value [
 	self at: stackp put: value
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> pushActiveContext [
 	"Simulate the action of bytecode that pushes the the active context on the
 	top of its own stack."
@@ -1525,7 +1527,7 @@ Context >> pushActiveContext [
 	self push: self
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> pushActiveProcess [
 	"Simulate the action of bytecode that pushes the the active Process on the
 	top of its own stack."
@@ -1533,7 +1535,7 @@ Context >> pushActiveProcess [
 	self push: Processor activeProcess
 ]
 
-{ #category : #'system simulation' }
+{ #category : 'system simulation' }
 Context >> pushArgs: arguments from: senderContext [
 	"Helps simulate action of the value primitive for closures.
 	 This is used by Context>>runSimulated:contextAtEachStep:"
@@ -1550,12 +1552,12 @@ Context >> pushArgs: arguments from: senderContext [
 	sender := senderContext
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> pushClosureTemps: numTemps [
 	numTemps timesRepeat: [ self push: nil ]
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> pushConsArrayWithElements: numElements [
 	| array |
 	array := Array new: numElements.
@@ -1564,7 +1566,7 @@ Context >> pushConsArrayWithElements: numElements [
 	self push: array
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> pushConstant: value [
 	"Simulate the action of bytecode that pushes the constant, value, on the
 	top of the stack."
@@ -1572,7 +1574,7 @@ Context >> pushConstant: value [
 	self push: value
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> pushFullClosure: compiledBlock numCopied: numCopied receiverOnStack: onStack ignoreOuterContext: ignore [
 	| copiedValues cls |
 	copiedValues := (1 to: numCopied) collect: [ :i | self pop ].
@@ -1586,7 +1588,7 @@ Context >> pushFullClosure: compiledBlock numCopied: numCopied receiverOnStack: 
 		 cls at: copiedValues size - i + 1 put: (copiedValues at: i) ]
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> pushLiteralVariable: value [
 	"Simulate the action of bytecode that pushes the contents of the literal
 	variable whose index is the argument, index, on the top of the stack."
@@ -1594,12 +1596,12 @@ Context >> pushLiteralVariable: value [
 	self push: value value
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> pushNewArrayOfSize: arraySize [
 	self push: (Array new: arraySize)
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> pushReceiver [
 	"Simulate the action of bytecode that pushes the active context's receiver
 	on the top of the stack."
@@ -1607,7 +1609,7 @@ Context >> pushReceiver [
 	self push: self receiver
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> pushReceiverVariable: offset [
 	"Simulate the action of bytecode that pushes the contents of the receiver's
 	instance variable whose index is the argument, index, on the top of the
@@ -1616,14 +1618,14 @@ Context >> pushReceiverVariable: offset [
 	self push: (self object: self receiver instVarAt: offset + 1)
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> pushRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex [
 	"Simulate the action of bytecode that pushes the value at remoteTempIndex
 	 in one of my local variables being used as a remote temp vector."
 	self push: ((self at: tempVectorIndex + 1) at: remoteTempIndex + 1)
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> pushTemporaryVariable: offset [
 	"Simulate the action of bytecode that pushes the contents of the
 	temporary variable whose index is the argument, index, on the top of
@@ -1632,7 +1634,7 @@ Context >> pushTemporaryVariable: offset [
 	self push: (self at: offset + 1)
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Context >> quickMethodPrimitiveBytecodeSize [
 
 	"A quick method starts with a 3 bytecodes primitive (264 or 256)"
@@ -1640,19 +1642,19 @@ Context >> quickMethodPrimitiveBytecodeSize [
 	^ 3
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> receiver [
 
 	^receiver
 ]
 
-{ #category : #'private - exceptions' }
+{ #category : 'private - exceptions' }
 Context >> receiver: anObject [
 
 	receiver := anObject
 ]
 
-{ #category : #'debugger access' }
+{ #category : 'debugger access' }
 Context >> release [
 	"Remove information from the receiver and all of the contexts on its
 	sender chain in order to break circularities."
@@ -1660,7 +1662,7 @@ Context >> release [
 	self releaseTo: nil
 ]
 
-{ #category : #'debugger access' }
+{ #category : 'debugger access' }
 Context >> releaseTo: caller [
 	"Remove information from the receiver and the contexts on its sender
 	chain up to caller in order to break circularities."
@@ -1674,7 +1676,7 @@ Context >> releaseTo: caller [
 			contex := senderContext ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> removeSelf [
 	"Nil the receiver pointer and answer its former value."
 
@@ -1684,21 +1686,21 @@ Context >> removeSelf [
 	^tempSelf
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Context >> resume [
 	"Roll back thisContext to self and resume.  Execute unwind blocks when rolling back.  ASSUMES self is a sender of thisContext"
 
 	self resume: nil
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Context >> resume: value [
 	"Unwind thisContext to self and resume with value as result of last send.  Execute unwind blocks when unwinding.  ASSUMES self is a sender of thisContext"
 
 	self resume: value through: (thisContext findNextUnwindContextUpTo: self)
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Context >> resume: value through: firstUnwindContext [
 	"Unwind thisContext to self and resume with value as result of last send.
 	 Execute any unwind blocks while unwinding.
@@ -1720,7 +1722,7 @@ Context >> resume: value through: firstUnwindContext [
 	^value
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Context >> resumeEvaluating: aBlock [
 	"Unwind thisContext to self and resume with aBlock value as result of last send.
 	Execute unwind blocks when unwinding.
@@ -1742,14 +1744,14 @@ Context >> resumeEvaluating: aBlock [
 	^aBlock value
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Context >> return [
 	"Unwind until my sender is on top"
 
 	self return: self receiver
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Context >> return: value [
 	"Unwind thisContext to self and return value to self's sender.  Execute any unwind blocks while unwinding.  ASSUMES self is a sender of thisContext"
 
@@ -1757,7 +1759,7 @@ Context >> return: value [
 	sender resume: value
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Context >> return: value from: aSender [
 	"For simulation.  Roll back self to aSender and return value from it.  Execute any unwind blocks on the way.  ASSUMES aSender is a sender of self"
 	| newTop context |
@@ -1780,7 +1782,7 @@ Context >> return: value from: aSender [
 	^ newTop
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Context >> return: value through: firstUnwindContext [
 	"Unwind thisContext to self and return value to self's sender.
 	 Execute any unwind blocks while unwinding.
@@ -1790,7 +1792,7 @@ Context >> return: value through: firstUnwindContext [
 	sender resume: value through: firstUnwindContext
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Context >> runUntilErrorOrReturnFrom: aSender [
 	"ASSUMES aSender is a sender of self.  Execute self's stack until aSender returns or an unhandled exception is raised.  Return a pair containing the new top context and a possibly nil exception.  The exception is not nil if it was raised before aSender returned and it was not handled.  The exception is returned rather than openning the debugger, giving the caller the choice of how to handle it."
 	"Self is run by jumping directly to it (the active process abandons thisContext and executes self).  However, before jumping to self we insert an ensure block under aSender that jumps back to thisContext when evaluated.  We also insert an exception handler under aSender that jumps back to thisContext when an unhandled exception is raised.  In either case, the inserted ensure and exception handler are removed once control jumps back to thisContext."
@@ -1827,14 +1829,14 @@ Context >> runUntilErrorOrReturnFrom: aSender [
 	]
 ]
 
-{ #category : #'debugger access' }
+{ #category : 'debugger access' }
 Context >> selector [
 	"Answer the selector of the method that created the receiver."
 
 	^self compiledCode selector ifNil: [self compiledCode defaultSelector]
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Context >> send: selector to: rcvr with: arguments lookupIn: lookupClass [
 	"Simulate the action of sending a message with selector and arguments
 	 to rcvr. The argument, lookupClass, is the class in which to lookup the
@@ -1859,7 +1861,7 @@ Context >> send: selector to: rcvr with: arguments lookupIn: lookupClass [
 	^ctxt
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Context >> send: selector to: aReceiver with: arguments super: superFlag [
 
 	"Simulate the action of sending a message with selector, selector, and
@@ -1934,14 +1936,14 @@ Context >> send: selector to: aReceiver with: arguments super: superFlag [
 	^ context
 ]
 
-{ #category : #'debugger access' }
+{ #category : 'debugger access' }
 Context >> sender [
 	"Answer the context that sent the message that created the receiver."
 
 	^sender
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Context >> setNamedPrimitiveInformationFrom: fromMethod toMethod: toMethod [
 	"For named primitives, the first literal contains a special object that has information of the primitive. In this method we cope such information from one to another one."
 	| spec |
@@ -1949,7 +1951,7 @@ Context >> setNamedPrimitiveInformationFrom: fromMethod toMethod: toMethod [
 	spec replaceFrom: 1 to: spec size with: (fromMethod literalAt: 1) startingAt: 1
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Context >> setSender: newSender receiver: newReceiver method: newMethod arguments: arguments [
 	"Create the receiver's initial state."
 
@@ -1963,7 +1965,7 @@ Context >> setSender: newSender receiver: newReceiver method: newMethod argument
 		self at: i put: (arguments at: i)]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Context >> setSender: newSender receiver: newReceiver method: newMethod closure: newClosure startpc: startpc [
 	"Create the receiver's initial state."
 
@@ -1975,21 +1977,21 @@ Context >> setSender: newSender receiver: newReceiver method: newMethod closure:
 	stackp := 0
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Context >> shortDebugStack [
 	"Answer a String showing the top ten contexts on my sender chain."
 
 	^ String streamContents: [ :stream | self debugStack: 10 on: stream ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Context >> shortDebugStackOn: aStream [
 	"print the top 30 contexts on my sender chain."
 
 	^ self debugStack: 30 on: aStream
 ]
 
-{ #category : #'debugger access' }
+{ #category : 'debugger access' }
 Context >> shortStack [
 	"Answer a String showing the top ten contexts on my sender chain."
 
@@ -1998,7 +2000,7 @@ Context >> shortStack [
 			stream print: item; cr]]
 ]
 
-{ #category : #'debugger access' }
+{ #category : 'debugger access' }
 Context >> singleRelease [
 	"Remove information from the receiver in order to break circularities."
 
@@ -2009,7 +2011,7 @@ Context >> singleRelease [
 	pc := nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> size [
 	"Primitive. Answer the number of indexable variables in the receiver.
 	This value is the same as the largest legal subscript. Essential. See Object
@@ -2021,19 +2023,19 @@ Context >> size [
 	^self primitiveFail
 ]
 
-{ #category : #'debugger access' }
+{ #category : 'debugger access' }
 Context >> sourceCode [
 	^self compiledCode sourceCode
 ]
 
-{ #category : #'debugger access' }
+{ #category : 'debugger access' }
 Context >> stack [
 	"Answer an Array of the contexts on the receiver's sender chain."
 
 	^self stackOfSize: 9999
 ]
 
-{ #category : #'debugger access' }
+{ #category : 'debugger access' }
 Context >> stackOfSize: limit [
 	"Answer an OrderedCollection of the top 'limit' contexts
 	 on the receiver's sender chain."
@@ -2047,13 +2049,13 @@ Context >> stackOfSize: limit [
 	^ stack
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Context >> stackPtr [
 	"For use only by the SystemTracer and the Debugger, Inspectors etc"
 	^ stackp
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Context >> stackp: newStackp [
 	"Storing into the stack pointer is a potentially dangerous thing.
 	This primitive stores nil into any cells that become accessible as a result,
@@ -2073,14 +2075,14 @@ Context >> stackp: newStackp [
 "
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Context >> startpc [
 	^closureOrNil
 		ifNil:	[self compiledCode initialPC]
 		ifNotNil: [closureOrNil startpc]
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Context >> step [
 	"Simulate the execution of the receiver's next bytecode. Answer the
 	context that would be the active context after this bytecode."
@@ -2090,7 +2092,7 @@ Context >> step [
 	^ result
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Context >> stepToCallee [
 	"Step to callee or sender"
 
@@ -2100,7 +2102,7 @@ Context >> stepToCallee [
 	^ context
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Context >> stepUntilSomethingOnStack [
 	"Simulate the execution of bytecodes until either sending a message or
 	returning a value to the receiver (that is, until switching contexts)."
@@ -2115,7 +2117,7 @@ Context >> stepUntilSomethingOnStack [
 				^context ]]
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> storeIntoLiteralVariable: value [
 	"Simulate the action of bytecode that stores the top of the stack into a
 	literal variable of my method."
@@ -2123,7 +2125,7 @@ Context >> storeIntoLiteralVariable: value [
 	value value: self top
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> storeIntoReceiverVariable: offset [
 	"Simulate the action of bytecode that stores the top of the stack into an
 	instance variable of my receiver."
@@ -2131,7 +2133,7 @@ Context >> storeIntoReceiverVariable: offset [
 	self object: self receiver instVarAt: offset + 1 put: self top
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> storeIntoRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex [
 	"Simulate the action of bytecode that stores the top of the stack at
 	 an offset in one of my local variables being used as a remote temp vector."
@@ -2139,7 +2141,7 @@ Context >> storeIntoRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex [
 	(self at: tempVectorIndex + 1) at: remoteTempIndex + 1 put: self top
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 Context >> storeIntoTemporaryVariable: offset [
 	"Simulate the action of bytecode that stores the top of the stack into one
 	of my temporary variables."
@@ -2147,13 +2149,13 @@ Context >> storeIntoTemporaryVariable: offset [
 	self at: offset + 1 put: self top
 ]
 
-{ #category : #'private - exceptions' }
+{ #category : 'private - exceptions' }
 Context >> swapReceiver: newReceiver [
 
 	receiver := newReceiver
 ]
 
-{ #category : #'debugger access' }
+{ #category : 'debugger access' }
 Context >> swapSender: coroutine [
 	"Replace the receiver's sender with coroutine and answer the receiver's
 	previous sender. For use in coroutining."
@@ -2164,7 +2166,7 @@ Context >> swapSender: coroutine [
 	^oldSender
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> tempAt: index [
 	"Answer the value of the temporary variable whose index is the
 	 argument, index.  Primitive. Assumes receiver is indexable. Answer the
@@ -2177,7 +2179,7 @@ Context >> tempAt: index [
 	^self at: index
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Context >> tempAt: index put: value [
 	"Store the argument, value, as the temporary variable whose index is the
 	 argument, index.  Primitive. Assumes receiver is indexable. Answer the
@@ -2190,7 +2192,7 @@ Context >> tempAt: index put: value [
 	^self at: index put: value
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Context >> terminate [
 	"Make myself unresumable."
 
@@ -2198,7 +2200,7 @@ Context >> terminate [
 	pc := nil
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Context >> terminateTo: previousContext [
 	"Terminate all the Contexts between me and previousContext, if previousContext is on my Context stack. Make previousContext my sender."
 
@@ -2213,14 +2215,14 @@ Context >> terminateTo: previousContext [
 	sender := previousContext
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 Context >> top [
 	"Answer the top of the receiver's stack."
 
 	^self at: stackp
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Context >> tryNamedPrimitiveIn: aCompiledMethod for: aReceiver withArgs: arguments [
 	<primitive: 218 error: errorCode>
 	errorCode ifNotNil: [
@@ -2243,7 +2245,7 @@ Context >> tryNamedPrimitiveIn: aCompiledMethod for: aReceiver withArgs: argumen
 		withArgs: arguments
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Context >> tryPrimitiveFor: aMethod receiver: aReceiver args: arguments [
 	"If this method has a primitive index, then run the primitive and return its result.
 	Otherwise (and also if the primitive fails) return PrimitiveFailToken,
@@ -2254,7 +2256,7 @@ Context >> tryPrimitiveFor: aMethod receiver: aReceiver args: arguments [
 	^ self doPrimitive: primIndex method: aMethod receiver: aReceiver args: arguments
 ]
 
-{ #category : #'special context access' }
+{ #category : 'special context access' }
 Context >> unwindBlock [
 	"unwindContext only. access temporaries from BlockClosure>>#ensure: and BlockClosure>>#ifCurtailed:"
 
@@ -2262,7 +2264,7 @@ Context >> unwindBlock [
 	^ self tempAt: self numArgs + 1
 ]
 
-{ #category : #'special context access' }
+{ #category : 'special context access' }
 Context >> unwindComplete [
 	"unwindContext only. access temporaries from BlockClosure>>#ensure: and BlockClosure>>#ifCurtailed:"
 
@@ -2270,7 +2272,7 @@ Context >> unwindComplete [
 	^ self tempAt: self numArgs + 2
 ]
 
-{ #category : #'special context access' }
+{ #category : 'special context access' }
 Context >> unwindComplete: aBoolean [
 	"unwindContext only. access temporaries from BlockClosure>>#ensure: and BlockClosure>>#ifCurtailed:"
 
@@ -2278,7 +2280,7 @@ Context >> unwindComplete: aBoolean [
 	self tempAt: self numArgs + 2 put: aBoolean
 ]
 
-{ #category : #'private - exceptions' }
+{ #category : 'private - exceptions' }
 Context >> unwindForTermination [
 	"Unwind to execute pending ensure:/ifCurtailed: blocks before terminating active process.
 	It assumes that self belongs to the active process. "
@@ -2294,7 +2296,7 @@ Context >> unwindForTermination [
 	self terminateTo: nil
 ]
 
-{ #category : #'private - exceptions' }
+{ #category : 'private - exceptions' }
 Context >> unwindTo: aContext [
 
 	| context unwindBlock |
@@ -2306,7 +2308,7 @@ Context >> unwindTo: aContext [
 			unwindBlock value ]]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Context >> withoutPrimitiveTryNamedPrimitiveIn: aCompiledMethod for: aReceiver withArgs: arguments [
 "When using the debugger we want to run a method step by step. What what happens when we do a step into a CompiledMethod which has a primitive? If such a method is executed from outside the Debugger (normal scenario) the VM knows that such CompiledMethod has a primitive declaration and hence executes it. If it fails then it continues executing all the bytecodes of the method. Otherwise, it just returns.
 

--- a/src/Kernel/ContextCannotReturn.class.st
+++ b/src/Kernel/ContextCannotReturn.class.st
@@ -2,15 +2,17 @@
 This exception is thrown when a value is returned from a context, but the context is dead and the return can not be done.
 "
 Class {
-	#name : #ContextCannotReturn,
-	#superclass : #CannotReturn,
+	#name : 'ContextCannotReturn',
+	#superclass : 'CannotReturn',
 	#instVars : [
 		'target'
 	],
-	#category : #'Kernel-Exceptions'
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #signalling }
+{ #category : 'signalling' }
 ContextCannotReturn class >> result: anObject to: aContext [
 
 	^self new
@@ -19,12 +21,12 @@ ContextCannotReturn class >> result: anObject to: aContext [
 		signal
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ContextCannotReturn >> target [
 	^ target
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ContextCannotReturn >> target: anObject [
 	target := anObject
 ]

--- a/src/Kernel/Continuation.class.st
+++ b/src/Kernel/Continuation.class.st
@@ -15,30 +15,32 @@ executionFlow value: true
 
 "
 Class {
-	#name : #Continuation,
-	#superclass : #Object,
+	#name : 'Continuation',
+	#superclass : 'Object',
 	#instVars : [
 		'values'
 	],
-	#category : #'Kernel-Methods'
+	#category : 'Kernel-Methods',
+	#package : 'Kernel',
+	#tag : 'Methods'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Continuation class >> current [
 	^ self fromContext: thisContext sender
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Continuation class >> currentDo: aBlock [
 	^ aBlock value: (self fromContext: thisContext sender)
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Continuation class >> fromContext: aStack [
 	^self new initializeFromContext: aStack
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Continuation class >> try: tryBlock or: orBlock or: orrBlock otherwise: elseBlock [
 	^ self
 		try: tryBlock
@@ -49,7 +51,7 @@ Continuation class >> try: tryBlock or: orBlock or: orrBlock otherwise: elseBloc
 				otherwise: [ :rr :r | elseBlock cull: rr cull: r cull: res ] ]
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Continuation class >> try: tryBlock or: orBlock otherwise: elseBlock [
 	"	^ self
 		currentDo: [ :success |
@@ -68,7 +70,7 @@ Continuation class >> try: tryBlock or: orBlock otherwise: elseBlock [
 				otherwise: [ :lastRes | elseBlock cull: lastRes cull: res ] ]
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Continuation class >> try: tryBlock otherwise: elseBlock [
 	^ self
 		currentDo: [ :success |
@@ -78,7 +80,7 @@ Continuation class >> try: tryBlock otherwise: elseBlock [
 			elseBlock cull: localResult ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Continuation >> initializeFromContext: aContext [
 	| valueStream context |
 	valueStream := WriteStream on: (Array new: 20).
@@ -91,12 +93,12 @@ Continuation >> initializeFromContext: aContext [
 	values := valueStream contents
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Continuation >> numArgs [
 	^ 1
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Continuation >> restoreValues [
 	| valueStream context |
 	valueStream := values readStream.
@@ -106,19 +108,19 @@ Continuation >> restoreValues [
 		1 to: context size do: [:i | context at: i put: valueStream next]]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Continuation >> terminate: aContext [
 	| context |
 	context := aContext.
 	[context notNil] whileTrue: [context := context swapSender: nil]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 Continuation >> value [
 	self value: nil
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 Continuation >> value: anObject [
 	"Invoke the continuation and answer anObject as return value."
 
@@ -128,7 +130,7 @@ Continuation >> value: anObject [
 	^ anObject
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 Continuation >> valueWithArguments: anArray [
 	anArray size = 1
 		ifFalse: [ ^ self error: 'continuations can only be resumed with one argument' ].

--- a/src/Kernel/CurrentExecutionEnvironment.class.st
+++ b/src/Kernel/CurrentExecutionEnvironment.class.st
@@ -4,12 +4,14 @@ I am container for special meta object ExecutionEnvironment which represent curr
 Look at ExecutionEnvironment for details
 "
 Class {
-	#name : #CurrentExecutionEnvironment,
-	#superclass : #ProcessLocalVariable,
-	#category : #'Kernel-Processes'
+	#name : 'CurrentExecutionEnvironment',
+	#superclass : 'ProcessLocalVariable',
+	#category : 'Kernel-Processes',
+	#package : 'Kernel',
+	#tag : 'Processes'
 }
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 CurrentExecutionEnvironment class >> activate: anExecutionEnvironment for: aBlock [
 
 	| current |
@@ -23,12 +25,12 @@ CurrentExecutionEnvironment class >> activate: anExecutionEnvironment for: aBloc
 		anExecutionEnvironment deactivated]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CurrentExecutionEnvironment class >> isInheritable [
 	^true
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 CurrentExecutionEnvironment class >> restoreDefault [
 
 	| current |
@@ -37,12 +39,12 @@ CurrentExecutionEnvironment class >> restoreDefault [
 	self value: nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CurrentExecutionEnvironment >> default [
 	^DefaultExecutionEnvironment instance
 ]
 
-{ #category : #inheriting }
+{ #category : 'inheriting' }
 CurrentExecutionEnvironment >> installValue: anExecutionEnvironment intoForked: newProcess from: ownerProcess [
 	super installValue: anExecutionEnvironment intoForked: newProcess from: ownerProcess.
 

--- a/src/Kernel/Date.class.st
+++ b/src/Kernel/Date.class.st
@@ -41,55 +41,57 @@ birthday1 isOnOrBefore: birthday2.  ""true""
 
 "
 Class {
-	#name : #Date,
-	#superclass : #Timespan,
+	#name : 'Date',
+	#superclass : 'Timespan',
 	#pools : [
 		'ChronologyConstants'
 	],
-	#category : #'Kernel-Chronology'
+	#category : 'Kernel-Chronology',
+	#package : 'Kernel',
+	#tag : 'Chronology'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Date class >> fromDays: dayCount [
 	"Days since 1 January 1901"
 
 	^ self julianDayNumber: SqueakEpoch + dayCount
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Date class >> fromSeconds: seconds [
 	"Answer an instance of me which is 'seconds' seconds after January 1, 1901."
 
 	^ self starting: (DateAndTime fromSeconds: seconds)
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Date class >> starting: aDateAndTime [
 
 	^ super starting: (aDateAndTime midnight) duration: (Duration days: 1)
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Date class >> today [
 
 	^ self current
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Date >> asDate [
 	"(Date year: 2018 month: 9 day: 28) asDate printString >>> '28 September 2018'"
 
 	^ self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Date >> dayMonthYearDo: aBlock [
 	"Supply integers for day, month and year to aBlock and return the result"
 
 	^ start dayMonthYearDo: aBlock
 ]
 
-{ #category : #'comparing - ignore timezone' }
+{ #category : 'comparing - ignore timezone' }
 Date >> equals: aDate [
 	"Perform a time zone independent comparison of the dates, i.e. only compare day, month and year.
 	To compare with time zones, use #="
@@ -100,7 +102,7 @@ Date >> equals: aDate [
         [ self dayOfMonth = aDate dayOfMonth ] ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Date >> printFormat: formatArray [
 	"Answer a String describing the receiver using the argument formatArray."
 
@@ -108,19 +110,19 @@ Date >> printFormat: formatArray [
 		self printOn: aStream format: formatArray ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Date >> printOn: aStream [
 
  	self printOn: aStream format: #(1 2 3 $  3 1 )
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Date >> printOn: aStream format: formatArray [
 
 	BasicDatePrinter default printDate: self format: formatArray on: aStream
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Date >> species [
 
 	^Timespan

--- a/src/Kernel/DateAndTime.class.st
+++ b/src/Kernel/DateAndTime.class.st
@@ -22,8 +22,8 @@ The nanosecond attribute is often zero but it defined for full ISO compliance an
 
 "
 Class {
-	#name : #DateAndTime,
-	#superclass : #Magnitude,
+	#name : 'DateAndTime',
+	#superclass : 'Magnitude',
 	#instVars : [
 		'seconds',
 		'offset',
@@ -37,10 +37,12 @@ Class {
 	#pools : [
 		'ChronologyConstants'
 	],
-	#category : #'Kernel-Chronology'
+	#category : 'Kernel-Chronology',
+	#package : 'Kernel',
+	#tag : 'Chronology'
 }
 
-{ #category : #private }
+{ #category : 'private' }
 DateAndTime class >> basicYear: year month: month day: day hour: hour minute: minute second: second nanoSecond: nanoCount offset: utcOffset [
 	"Return a DateAndTime with the values in the given TimeZone (UTCOffset)"
 
@@ -68,56 +70,56 @@ DateAndTime class >> basicYear: year month: month day: day hour: hour minute: mi
 		yourself
 ]
 
-{ #category : #'clock provider' }
+{ #category : 'clock provider' }
 DateAndTime class >> clock [
 	 "the provider of real time seconds/milliseconds."
 
 	^ ClockProvider
 ]
 
-{ #category : #'system queries' }
+{ #category : 'system queries' }
 DateAndTime class >> clockPrecision [
 	"One nanosecond precision"
 
 	^ Duration seconds: 0 nanoSeconds: 1
 ]
 
-{ #category : #'instance creation queries' }
+{ #category : 'instance creation queries' }
 DateAndTime class >> current [
 
 	^ self now
 ]
 
-{ #category : #'instance creation queries' }
+{ #category : 'instance creation queries' }
 DateAndTime class >> epoch [
   "Answer a DateAndTime representing the epoch: 1 January 1901"
 
   ^ (self julianDayNumber: SqueakEpoch) offset: 0
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 DateAndTime class >> fromInternalTime: anInteger [
 	"Answer an instance of the receiver with the time represented by anInteger. Pharo internal time is an integer representing time in the local timezone with an epoch of 1 Jan. 1901"
 
 	^(self fromSeconds: anInteger offset: 0) translateTo: self localOffset
 ]
 
-{ #category : #input }
+{ #category : 'input' }
 DateAndTime class >> fromString: aString [
 	^ self readFrom: aString readStream
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 DateAndTime class >> fromUnixTime: anInteger [
 	^ self fromSeconds: anInteger + 2177452800 "unix epoch constant"
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 DateAndTime class >> initialize [
 	ClockProvider := Time
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 DateAndTime class >> julianDayNumber: aJulianDayNumber [
 
 	^ self basicNew
@@ -125,7 +127,7 @@ DateAndTime class >> julianDayNumber: aJulianDayNumber [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 DateAndTime class >> julianDayNumber: aJulianDayNumber offset: aTimeZoneOffset [
 	"Return a DateAndTime at midnight local time at the given julian day"
 	| ticks |
@@ -138,21 +140,21 @@ DateAndTime class >> julianDayNumber: aJulianDayNumber offset: aTimeZoneOffset [
 		yourself
 ]
 
-{ #category : #'system queries' }
+{ #category : 'system queries' }
 DateAndTime class >> localOffset [
 	"Answer the duration we are offset from UTC"
 
 	^ self localTimeZone offset
 ]
 
-{ #category : #'time zones' }
+{ #category : 'time zones' }
 DateAndTime class >> localTimeZone [
 	"Answer the local time zone"
 
 	^ LocalTimeZoneCache ifNil: [ LocalTimeZoneCache := TimeZone default ]
 ]
 
-{ #category : #'time zones' }
+{ #category : 'time zones' }
 DateAndTime class >> localTimeZone: aTimeZone [
 	"Set the local time zone"
 
@@ -164,26 +166,26 @@ DateAndTime class >> localTimeZone: aTimeZone [
 	LocalTimeZoneCache := aTimeZone
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 DateAndTime class >> midnight [
 
 	^ self now midnight
 ]
 
-{ #category : #primitives }
+{ #category : 'primitives' }
 DateAndTime class >> millisecondClockValue [
 
 	^ self clock millisecondClockValue
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 DateAndTime class >> new [
 	"Answer a DateAndTime representing the epoch: 1 January 1901"
 
 	^ self epoch offset: self localOffset
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 DateAndTime class >> now [
 	"Answer the current date and time expressed in local time.
 	[ 10000 timesRepeat: [ self now. ] ] timeToRun / 10000.0 . "
@@ -197,7 +199,7 @@ DateAndTime class >> now [
 		offset: self localOffset
 ]
 
-{ #category : #'instance creation queries' }
+{ #category : 'instance creation queries' }
 DateAndTime class >> unixEpoch [
 	"Answer a DateAndTime representing the Unix epoch (1 January 1970, midnight UTC)"
 	^ self basicNew
@@ -205,7 +207,7 @@ DateAndTime class >> unixEpoch [
 		yourself
 ]
 
-{ #category : #'clock provider' }
+{ #category : 'clock provider' }
 DateAndTime class >> year: aYearInteger month: aMonthNumber [
     "Return a date starting the first day of the month"
 
@@ -217,7 +219,7 @@ DateAndTime class >> year: aYearInteger month: aMonthNumber [
         minute: 0
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 DateAndTime >> + operand [
 	"operand conforms to protocol Duration"
 
@@ -231,7 +233,7 @@ DateAndTime >> + operand [
 		yourself
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 DateAndTime >> - operand [
 	"operand conforms to protocol DateAndTime or protocol Duration"
 
@@ -246,7 +248,7 @@ DateAndTime >> - operand [
 		ifFalse: [ self + operand negated ]
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 DateAndTime >> < comparand [
 	"comparand conforms to protocol DateAndTime,
 	or can be converted into something that conforms."
@@ -261,46 +263,46 @@ DateAndTime >> < comparand [
 		ifFalse: [ julianDayNumber < other julianDayNumberUTC ]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 DateAndTime >> = other [
 	self == other ifTrue: [ ^ true ].
 	(self species = other species) ifFalse: [ ^ false ].
 	^ self hasEqualTicks: other
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 DateAndTime >> asDate [
     "Convert the receiver in a date object."
     "(DateAndTime fromString: ' 2019-08-17T13:33:00+02:00') asDate printString >>> (Date newDay: 17 month: 8 year: 2019) printString"
     ^ Date starting: self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 DateAndTime >> asDateAndTime [
 
 	^ self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 DateAndTime >> asDuration [
 	"Answer the duration since midnight."
 
 	^ Duration seconds: self secondsSinceMidnightLocalTime nanoSeconds: nanos
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 DateAndTime >> asTime [
 
 	^ Time seconds: self secondsSinceMidnightLocalTime nanoSeconds: nanos
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 DateAndTime >> asTimeUTC [
 
 	^ Time seconds: self secondsSinceMidnightUTC nanoSeconds: nanos
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 DateAndTime >> asUTC [
 
 	^ offset isZero
@@ -308,13 +310,13 @@ DateAndTime >> asUTC [
 		ifFalse: [ self offset: 0 ]
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 DateAndTime >> asUnixTime [
 	"answer number of seconds since unix epoch (midnight Jan 1, 1970, UTC)"
 	^((self offset: Duration zero) - self class unixEpoch) asSeconds
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DateAndTime >> dayMonthYearDo: aBlock [
 	"Return the value of executing block with the Gregorian Calender day, month and year as arguments,
 	as computed from my Julian Day Number, julianDayNumber.
@@ -345,7 +347,7 @@ DateAndTime >> dayMonthYearDo: aBlock [
 		value: fullYear
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 DateAndTime >> hasEqualTicks: aDateAndTime [
 
 	^ (self julianDayNumberUTC = aDateAndTime julianDayNumberUTC)
@@ -353,37 +355,37 @@ DateAndTime >> hasEqualTicks: aDateAndTime [
 			and: [ nanos = aDateAndTime nanoSecond ] ]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 DateAndTime >> hash [
 	^ (julianDayNumber hashMultiply bitXor: seconds) bitXor: nanos
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DateAndTime >> julianDayNumber [
 
 	^ julianDayNumber + self julianDayOffset
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DateAndTime >> julianDayNumberUTC [
 
 	^ julianDayNumber
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DateAndTime >> julianDayOffset [
 	"Return the offset in julian days possibly introduced by the timezone offset"
 
 	^ ((seconds + self offset asSeconds) / SecondsInDay) floor
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DateAndTime >> localSeconds [
 	" Return the seconds since the epoch in local time."
 	^ seconds + self offset asSeconds
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DateAndTime >> midnight [
 	"Answer a DateAndTime starting at midnight (towards the end of the day) local time"
 
@@ -399,7 +401,7 @@ DateAndTime >> midnight [
 				offset: offset ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DateAndTime >> minute [
 	"Answer a number that represents the number of complete minutes in the receiver' time part,
 	after the number of complete hours has been removed."
@@ -408,13 +410,13 @@ DateAndTime >> minute [
  	^ self localSeconds // SecondsInMinute \\ 60
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DateAndTime >> nanoSecond [
 
 	^ nanos
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 DateAndTime >> normalizeSecondsAndNanos [
 	(NanosInSecond <= nanos or: [ nanos < 0 ])
 		ifTrue: [
@@ -426,13 +428,13 @@ DateAndTime >> normalizeSecondsAndNanos [
 			seconds := seconds \\ SecondsInDay]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DateAndTime >> offset [
 
 	^ offset
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DateAndTime >> offset: anOffset [
 	"Answer a <DateAndTime> equivalent to the receiver but with its local time
 	being offset from UTC by offset.
@@ -443,7 +445,7 @@ DateAndTime >> offset: anOffset [
 		yourself
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 DateAndTime >> printOn: aStream [
 	"Print as per ISO 8601 sections 5.3.3 and 5.4.1.
 	Prints either:
@@ -452,13 +454,13 @@ DateAndTime >> printOn: aStream [
 	^self printOn: aStream withLeadingSpace: false
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 DateAndTime >> printOn: aStream withLeadingSpace: printLeadingSpaceToo [
 
 	BasicDatePrinter default printDateAndTime: self withLeadingSpace: printLeadingSpaceToo on: aStream
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DateAndTime >> second [
 	"Answer a number that represents the number of complete seconds in the receiver's time part,
 	after the number of complete minutes has been removed."
@@ -467,7 +469,7 @@ DateAndTime >> second [
  	^ self localSeconds \\ 60
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 DateAndTime >> setJdn: julDays seconds: secs nano: nanoSecs offset: anOffset [
 	julianDayNumber := julDays.
 	seconds := secs.
@@ -476,14 +478,14 @@ DateAndTime >> setJdn: julDays seconds: secs nano: nanoSecs offset: anOffset [
 	self normalizeSecondsAndNanos
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 DateAndTime >> ticks [
 	"Private - answer an array with our instance variables. Assumed to be UTC "
 
 	^ Array with: julianDayNumber with: seconds with: nanos
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 DateAndTime >> ticks: ticks offset: utcOffset [
 	"ticks is {julianDayNumber. secondCount. nanoSeconds}"
 

--- a/src/Kernel/DateError.class.st
+++ b/src/Kernel/DateError.class.st
@@ -2,7 +2,9 @@
 A generic error raised when try to instantiate dates.
 "
 Class {
-	#name : #DateError,
-	#superclass : #Error,
-	#category : #'Kernel-Chronology'
+	#name : 'DateError',
+	#superclass : 'Error',
+	#category : 'Kernel-Chronology',
+	#package : 'Kernel',
+	#tag : 'Chronology'
 }

--- a/src/Kernel/DeepCopier.class.st
+++ b/src/Kernel/DeepCopier.class.st
@@ -29,15 +29,17 @@ Dependents are now fixed up.  Suppose a model has a dependent view.  In the Depe
 
 "
 Class {
-	#name : #DeepCopier,
-	#superclass : #Object,
+	#name : 'DeepCopier',
+	#superclass : 'Object',
 	#instVars : [
 		'references'
 	],
-	#category : #'Kernel-Copying'
+	#category : 'Kernel-Copying',
+	#package : 'Kernel',
+	#tag : 'Copying'
 }
 
-{ #category : #checking }
+{ #category : 'checking' }
 DeepCopier >> basicCheckClass: aClass [
 	"Every class that implements veryDeepInner: or veryDeepCopyWith: must copy all its inst vars.
 	The danger is that a user will add a new instance variable and forget to copy it.
@@ -65,7 +67,7 @@ DeepCopier >> basicCheckClass: aClass [
 	^ warnings
 ]
 
-{ #category : #checking }
+{ #category : 'checking' }
 DeepCopier >> checkAllClasses [
 
 	| warnings |
@@ -76,7 +78,7 @@ DeepCopier >> checkAllClasses [
 	self raiseWarningsIfAny: warnings
 ]
 
-{ #category : #checking }
+{ #category : 'checking' }
 DeepCopier >> checkClass: aClass [
 	(self basicCheckClass: aClass)
 		ifNotEmpty: [ :warnings |
@@ -87,7 +89,7 @@ DeepCopier >> checkClass: aClass [
 				signal ]
 ]
 
-{ #category : #'like fullCopy' }
+{ #category : 'like fullCopy' }
 DeepCopier >> checkDeep [
 	"Write exceptions in the Transcript.  Every class that implements veryDeepInner: must copy all its inst vars.  Danger is that a user will add a new instance variable and forget to copy it.  This check is only run by hand once in a while to make sure nothing was forgotten.
 (Please do not remove this method.)
@@ -111,7 +113,7 @@ DeepCopier >> checkDeep [
 												(aClass allInstVarNames at: index) printOn: stream ] ] ] ] ])
 ]
 
-{ #category : #checking }
+{ #category : 'checking' }
 DeepCopier >> doesMethod: aSelector writeAllInstanceVariablesOfClass: aClass [
 
 	"This method returns true if the method of the given selector writes all instance variables of the given class.
@@ -125,7 +127,7 @@ DeepCopier >> doesMethod: aSelector writeAllInstanceVariablesOfClass: aClass [
 	^ hasNoInstanceVariables or: [ method writesField: lastFieldIndex ]
 ]
 
-{ #category : #'like fullCopy' }
+{ #category : 'like fullCopy' }
 DeepCopier >> fixDependents [
 	"They are not used much, but need to be right"
 
@@ -139,20 +141,20 @@ DeepCopier >> fixDependents [
 				newModel addDependent: newDep]]]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 DeepCopier >> initialize [
 
 	super initialize.
 	self initialize: 4096
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 DeepCopier >> initialize: size [
 
 	references := IdentityDictionary new: size
 ]
 
-{ #category : #checking }
+{ #category : 'checking' }
 DeepCopier >> raiseWarningsIfAny: warnings [
 
 	warnings ifNotEmpty: [
@@ -162,7 +164,7 @@ DeepCopier >> raiseWarningsIfAny: warnings [
 			signal ]
 ]
 
-{ #category : #'like fullCopy' }
+{ #category : 'like fullCopy' }
 DeepCopier >> references [
 	^ references
 ]

--- a/src/Kernel/DefaultExecutionEnvironment.class.st
+++ b/src/Kernel/DefaultExecutionEnvironment.class.st
@@ -7,31 +7,33 @@ I am singleton:
 Tools which define specific environments could add polymorphic behaviour to me
 "
 Class {
-	#name : #DefaultExecutionEnvironment,
-	#superclass : #ExecutionEnvironment,
+	#name : 'DefaultExecutionEnvironment',
+	#superclass : 'ExecutionEnvironment',
 	#classInstVars : [
 		'instance'
 	],
-	#category : #'Kernel-Processes'
+	#category : 'Kernel-Processes',
+	#package : 'Kernel',
+	#tag : 'Processes'
 }
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 DefaultExecutionEnvironment class >> beActive [
 
 	CurrentExecutionEnvironment restoreDefault
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 DefaultExecutionEnvironment class >> beActiveDuring: aBlock [
 
 	^self instance beActiveDuring: aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DefaultExecutionEnvironment class >> instance [
 	^instance ifNil: [ instance := self new ]
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 DefaultExecutionEnvironment >> prepareForNewProcess: aProcess [
 ]

--- a/src/Kernel/Delay.class.st
+++ b/src/Kernel/Delay.class.st
@@ -16,8 +16,8 @@ i.e. from the image perspective of timing, the image snapshot never happened.
 
 "
 Class {
-	#name : #Delay,
-	#superclass : #Object,
+	#name : 'Delay',
+	#superclass : 'Object',
 	#instVars : [
 		'delaySemaphore',
 		'beingWaitedOn',
@@ -28,21 +28,23 @@ Class {
 	#classVars : [
 		'Scheduler'
 	],
-	#category : #'Kernel-Delays'
+	#category : 'Kernel-Delays',
+	#package : 'Kernel',
+	#tag : 'Delays'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 Delay class >> anyActive [
 	"Return true if there is any delay currently active"
 		^self scheduler anyActive
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 Delay class >> delaySchedulerClass [
 	^self scheduler class
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 Delay class >> delaySchedulerClass: aSchedulerClass [
 	| newScheduler oldScheduler |
 	self delaySchedulerClass = aSchedulerClass ifTrue:[ ^self ].
@@ -58,13 +60,13 @@ Delay class >> delaySchedulerClass: aSchedulerClass [
 	self inform: 'Delay scheduler set to ' , aSchedulerClass printString
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Delay class >> forDuration: aDuration [
  	"Return a new Delay for the given duration."
  	^ self forMilliseconds: aDuration asMilliSeconds
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Delay class >> forMilliseconds: aNumber [
 	"Return a new Delay for the given number of milliseconds. Sending 'wait' to this Delay will cause the sender's process to be suspended for approximately that length of time.
 
@@ -73,13 +75,13 @@ Delay class >> forMilliseconds: aNumber [
 	^ self new setDelay: aNumber forSemaphore: Semaphore new
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Delay class >> forSeconds: aNumber [
 	"Return a new Delay for the given number of Seconds"
 	^ self forMilliseconds: aNumber * 1000
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 Delay class >> initialize [
 
 	self scheduler ifNotNil: [ self scheduler stopTimerEventLoop ].
@@ -90,62 +92,62 @@ Delay class >> initialize [
 		atPriority: 20
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Delay class >> nextWakeUpTime [
 
 	^ self scheduler nextWakeUpTime
 ]
 
-{ #category : #'timer process' }
+{ #category : 'timer process' }
 Delay class >> restartTimerEventLoop [
 	self stopTimerEventLoop.
 	self startTimerEventLoop
 ]
 
-{ #category : #scheduler }
+{ #category : 'scheduler' }
 Delay class >> scheduler [
 
 	^ Scheduler
 ]
 
-{ #category : #scheduler }
+{ #category : 'scheduler' }
 Delay class >> scheduler: anObject [
 
 	Scheduler := anObject
 ]
 
-{ #category : #'timer process' }
+{ #category : 'timer process' }
 Delay class >> schedulingProcess [
 
 	^ self scheduler schedulingProcess
 ]
 
-{ #category : #snapshotting }
+{ #category : 'snapshotting' }
 Delay class >> shutDown [
 
 	self scheduler shutDown
 ]
 
-{ #category : #'timer process' }
+{ #category : 'timer process' }
 Delay class >> startTimerEventLoop [
 
 	self scheduler startTimerEventLoop
 ]
 
-{ #category : #snapshotting }
+{ #category : 'snapshotting' }
 Delay class >> startUp [
 	"Restart active delay, if any, when resuming a snapshot."
 
 	self scheduler startUp
 ]
 
-{ #category : #'timer process' }
+{ #category : 'timer process' }
 Delay class >> stopTimerEventLoop [
 
 	^ self scheduler stopTimerEventLoop
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 Delay class >> systemSettingOn: aBuilder [
 	<systemsettings>
 
@@ -159,7 +161,7 @@ Delay class >> systemSettingOn: aBuilder [
 			String crlf, 'You can observe which is running from Tools > Process Browser.'
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Delay class >> timeoutSemaphore: aSemaphore afterMSecs: anInteger [
 	"Create and schedule a Delay to signal the given semaphore when the given number of milliseconds has elapsed. Return the scheduled Delay. The timeout can be cancelled by sending 'unschedule' to this Delay."
 	"Details: This mechanism is used to provide a timeout when waiting for an external event, such as arrival of data over a network connection, to signal a semaphore. The timeout ensures that the semaphore will be signalled within a reasonable period of time even if the event fails to occur. Typically, the waiting process cancels the timeout request when awoken, then determines if the awaited event has actually occurred."
@@ -167,35 +169,35 @@ Delay class >> timeoutSemaphore: aSemaphore afterMSecs: anInteger [
 	^ (self new setDelay: anInteger forSemaphore: aSemaphore) schedule; yourself
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 Delay >> beingWaitedOn [
 	"Answer whether this delay is currently scheduled, e.g., being waited on"
 	^beingWaitedOn
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 Delay >> delaySemaphore [
 
 	^ delaySemaphore
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Delay >> isExpired [
 
 	^ delaySemaphore isSignaled
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 Delay >> millisecondDelayDuration [
 	^millisecondDelayDuration
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 Delay >> millisecondsToGo [
 	^ ticker millisecondsUntilTick: resumptionTick
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Delay >> printOn: aStream [
 	super printOn: aStream.
 	aStream
@@ -211,33 +213,33 @@ Delay >> printOn: aStream [
 	aStream nextPutAll: ')'
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 Delay >> resumptionTick [
 	"The tick semantics (e.g. millisecond/microsecond) depends on the ticker its derived from."
 
 	^resumptionTick
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 Delay >> resumptionTickAdjustFrom: oldBaseTick to: newBaseTick [
 	resumptionTick := resumptionTick - oldBaseTick + newBaseTick
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Delay >> schedule [
 	"Schedule this delay."
 
 	self class scheduler schedule: self
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Delay >> setDelay: milliseconds [
 	"Private! Initialize this delay to signal the given semaphore after the given number of milliseconds."
 
 	millisecondDelayDuration := milliseconds asInteger
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Delay >> setDelay: milliseconds forSemaphore: aSemaphore [
 	"Private! Initialize this delay to signal the given semaphore after the given number of milliseconds."
 
@@ -247,7 +249,7 @@ Delay >> setDelay: milliseconds forSemaphore: aSemaphore [
 	beingWaitedOn := false
 ]
 
-{ #category : #'private - timing priority process' }
+{ #category : 'private - timing priority process' }
 Delay >> timingPriorityScheduleTicker: aDelayTicker [
 	beingWaitedOn ifTrue: [ ^false ]. "Already scheduled"
 	beingWaitedOn := true.
@@ -256,7 +258,7 @@ Delay >> timingPriorityScheduleTicker: aDelayTicker [
 	^true
 ]
 
-{ #category : #'private - timing priority process' }
+{ #category : 'private - timing priority process' }
 Delay >> timingPrioritySignalExpired [
 	"The delay time has elapsed; signal the waiting process."
 
@@ -267,7 +269,7 @@ Delay >> timingPrioritySignalExpired [
 		DelayScheduler>>handleEventTimer."
 ]
 
-{ #category : #'private - timing priority process' }
+{ #category : 'private - timing priority process' }
 Delay >> timingPriorityUnschedule [
 	""
 
@@ -277,12 +279,12 @@ Delay >> timingPriorityUnschedule [
 		DelayScheduler>>handleEventTimer."
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Delay >> unschedule [
 	self class scheduler unschedule: self
 ]
 
-{ #category : #delaying }
+{ #category : 'delaying' }
 Delay >> wait [
 	"Schedule this Delay, then wait on its semaphore. The current process will be suspended for the amount of time specified when this Delay was created."
 

--- a/src/Kernel/DelayBasicScheduler.class.st
+++ b/src/Kernel/DelayBasicScheduler.class.st
@@ -60,8 +60,8 @@ but is fragile wrt changing process scheduling semantics.  Subclasses add specif
 protection.
 "
 Class {
-	#name : #DelayBasicScheduler,
-	#superclass : #DelayNullScheduler,
+	#name : 'DelayBasicScheduler',
+	#superclass : 'DelayNullScheduler',
 	#instVars : [
 		'ticker',
 		'runTimerEventLoop',
@@ -73,29 +73,31 @@ Class {
 		'delayToStart',
 		'delayToStop'
 	],
-	#category : #'Kernel-Delays'
+	#category : 'Kernel-Delays',
+	#package : 'Kernel',
+	#tag : 'Delays'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DelayBasicScheduler class >> defaultSuspendedDelaysHeap [
 	 ^ Heap
 			sortBlock: [ :delay1 :delay2 |
 				delay1 resumptionTick <= delay2 resumptionTick ]
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 DelayBasicScheduler class >> onTicker: aDelayTicker suspendedDelaysHeap: aHeap [
 	"Facilitates unit tests examining the otherwise hidden suspendedDelays variable"
 	^self basicNew initializeTicker: aDelayTicker suspendedDelaysHeap: aHeap
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 DelayBasicScheduler >> anyActive [
 	"Return true if there is any delay currently active"
 	^activeDelay notNil
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 DelayBasicScheduler >> initialize [
 	"Default configuration."
 
@@ -103,21 +105,21 @@ DelayBasicScheduler >> initialize [
 		  suspendedDelaysHeap: DelayBasicScheduler defaultSuspendedDelaysHeap
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 DelayBasicScheduler >> initializeTicker: aDelayTicker suspendedDelaysHeap: aHeap [
 	ticker := aDelayTicker.
 	suspendedDelays := aHeap.
 	timingSemaphore := Semaphore new
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 DelayBasicScheduler >> nextWakeUpTime [
 	^ activeDelay
 			ifNil: [ 0 ]
 			ifNotNil: [ :delay | delay resumptionTick ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 DelayBasicScheduler >> printOn: aStream [
 	super printOn: aStream.
 	aStream
@@ -127,7 +129,7 @@ DelayBasicScheduler >> printOn: aStream [
 		nextPutAll: ticker className
 ]
 
-{ #category : #'system-api' }
+{ #category : 'system-api' }
 DelayBasicScheduler >> restartTimerEventLoop [
 	"Start the timer event loop"
 	"Delay restartTimerEventLoop"
@@ -135,7 +137,7 @@ DelayBasicScheduler >> restartTimerEventLoop [
 	self startTimerEventLoop
 ]
 
-{ #category : #'user-api' }
+{ #category : 'user-api' }
 DelayBasicScheduler >> resume [
 	"Unsuspend the timing-priority delay scheduling loop when resuming a snapshot."
 
@@ -146,7 +148,7 @@ DelayBasicScheduler >> resume [
 	 which does... suspendSemaphore := nil."
 ]
 
-{ #category : #'private - timing priority process' }
+{ #category : 'private - timing priority process' }
 DelayBasicScheduler >> runBackendLoopAtTimingPriority [
 	"Private! Outer loop for the timing priority timer event loop.
 	 Invoked by api-system #startTimerEventLoop"
@@ -175,7 +177,7 @@ DelayBasicScheduler >> runBackendLoopAtTimingPriority [
 				activeDelay := suspendedDelays removeFirstOrNil ]]
 ]
 
-{ #category : #'user-api' }
+{ #category : 'user-api' }
 DelayBasicScheduler >> schedule: aDelay [
 	"This is the front-half of scheduling a delay. Invoked from user processes.
 	 For back-half see #scheduleAtTimingPriority"
@@ -192,7 +194,7 @@ DelayBasicScheduler >> schedule: aDelay [
 	timingSemaphore signal. "Transfer execution to back-end #scheduleAtTimingPriority"
 ]
 
-{ #category : #'private - timing priority process' }
+{ #category : 'private - timing priority process' }
 DelayBasicScheduler >> scheduleAtTimingPriority [
 	"Private! Invoke only from the timing-priority process.
 	 This is the back-half of scheduling a delay. For front-half see #schedule:"
@@ -210,24 +212,24 @@ DelayBasicScheduler >> scheduleAtTimingPriority [
 	delayToStart := nil
 ]
 
-{ #category : #'system-api' }
+{ #category : 'system-api' }
 DelayBasicScheduler >> schedulingProcess [
 	^ timerEventLoop
 ]
 
-{ #category : #'system-api' }
+{ #category : 'system-api' }
 DelayBasicScheduler >> shutDown [
 	self suspend
 ]
 
-{ #category : #'support - test cases' }
+{ #category : 'support - test cases' }
 DelayBasicScheduler >> simulate_vmMilliseconds: milliseconds [
 	"This method is only called from tests which make use of the 'simulation' tickers
 	which implement the next method."
 	ticker simulate_vmMilliseconds: milliseconds
 ]
 
-{ #category : #'system-api' }
+{ #category : 'system-api' }
 DelayBasicScheduler >> startTimerEventLoop [
 	"Start the timer event loop"
 	"Delay restartTimerEventLoop"
@@ -235,7 +237,7 @@ DelayBasicScheduler >> startTimerEventLoop [
 	self startTimerEventLoopPriority: Processor timingPriority
 ]
 
-{ #category : #'system-api' }
+{ #category : 'system-api' }
 DelayBasicScheduler >> startTimerEventLoopPriority: processorPriority [
 	"Start the timer event loop"
 	"Delay restartTimerEventLoop"
@@ -251,12 +253,12 @@ DelayBasicScheduler >> startTimerEventLoopPriority: processorPriority [
 	timerEventLoop resume
 ]
 
-{ #category : #'system-api' }
+{ #category : 'system-api' }
 DelayBasicScheduler >> startUp [
 	self resume
 ]
 
-{ #category : #'system-api' }
+{ #category : 'system-api' }
 DelayBasicScheduler >> stopTimerEventLoop [
 	"Stop the timingpriority event loop"
 
@@ -273,7 +275,7 @@ DelayBasicScheduler >> stopTimerEventLoop [
 	timerEventLoop := nil
 ]
 
-{ #category : #'user-api' }
+{ #category : 'user-api' }
 DelayBasicScheduler >> suspend [
 	"This is the front-half for suspending the delay scheduler to prevent
 	 wake-up of delayed threads in the middle of snapshotting.
@@ -286,7 +288,7 @@ DelayBasicScheduler >> suspend [
 	 which then waits for suspendSemaphore to be signalled from #startup"
 ]
 
-{ #category : #'private - timing priority process' }
+{ #category : 'private - timing priority process' }
 DelayBasicScheduler >> suspendAtTimingPriority [
 	"Private! This is the front-half for suspending the delay scheduler to prevent
 	 wake-up of delayed threads in the middle of snapshotting. For front-half see #suspend"
@@ -299,12 +301,12 @@ DelayBasicScheduler >> suspendAtTimingPriority [
 	suspendSemaphore := nil
 ]
 
-{ #category : #'system-api' }
+{ #category : 'system-api' }
 DelayBasicScheduler >> ticker [
 	^ticker
 ]
 
-{ #category : #'user-api' }
+{ #category : 'user-api' }
 DelayBasicScheduler >> unschedule: aDelay [
 	"This is the front-half of unscheduling a delay. Invoked from user processes.
 	 For back-half see #unscheduleAtTimingPriority"
@@ -318,7 +320,7 @@ DelayBasicScheduler >> unschedule: aDelay [
 	timingSemaphore signal. "Transfer execution to #unscheduleAtTimingPriority"
 ]
 
-{ #category : #'private - timing priority process' }
+{ #category : 'private - timing priority process' }
 DelayBasicScheduler >> unscheduleAtTimingPriority [
 	"Private! Invoke only from the timing-priority process.
 	 This is the back-half of unscheduling a delay. For front-half see #unschedule:"

--- a/src/Kernel/DelayMicrosecondTicker.class.st
+++ b/src/Kernel/DelayMicrosecondTicker.class.st
@@ -2,17 +2,19 @@
 I interface to the microsecond based VM primitives.
 "
 Class {
-	#name : #DelayMicrosecondTicker,
-	#superclass : #AbstractDelayTicker,
-	#category : #'Kernel-Delays'
+	#name : 'DelayMicrosecondTicker',
+	#superclass : 'AbstractDelayTicker',
+	#category : 'Kernel-Delays',
+	#package : 'Kernel',
+	#tag : 'Delays'
 }
 
-{ #category : #'api-system' }
+{ #category : 'api-system' }
 DelayMicrosecondTicker >> millisecondsUntilTick: microsecondsTick [
 	^((microsecondsTick - self nowTick) max: 0) / 1000
 ]
 
-{ #category : #'api-system' }
+{ #category : 'api-system' }
 DelayMicrosecondTicker >> nowTick [
 	 "Copied from Time class >> primUTCMicrosecondsClock.
 	 Answer the number of micro-seconds ellapsed since epoch.
@@ -24,7 +26,7 @@ DelayMicrosecondTicker >> nowTick [
 	self primitiveFailed
 ]
 
-{ #category : #'private - primitives' }
+{ #category : 'private - primitives' }
 DelayMicrosecondTicker >> primSignal: aSemaphore atUTCMicroseconds: aLargePositiveInteger [
 	"Signal the semaphore when the microsecond clock reaches the value of the second argument. Fail if the first argument is neither a Semaphore nor nil. Essential. See Object documentation whatIsAPrimitive."
 	<primitive: 242>
@@ -54,12 +56,12 @@ DelayMicrosecondTicker >> primSignal: aSemaphore atUTCMicroseconds: aLargePositi
 	self primitiveFailFor: PrimErrBadArgument"
 ]
 
-{ #category : #'api-system' }
+{ #category : 'api-system' }
 DelayMicrosecondTicker >> tickAfterMilliseconds: milliseconds [
 	^self nowTick "microseconds" + (1000 * milliseconds)
 ]
 
-{ #category : #'api-system' }
+{ #category : 'api-system' }
 DelayMicrosecondTicker >> waitForUserSignalled: timingSemaphore orExpired: activeDelay [
 	|nextTick|
 	"Sleep until the active delay is due, or timingSemaphore signalled by DelayScheduler user-api."

--- a/src/Kernel/DelayMicrosecondTickerSimulation.class.st
+++ b/src/Kernel/DelayMicrosecondTickerSimulation.class.st
@@ -3,29 +3,31 @@ To facilitate unit tests without interferring with the live VM interface,
 I simulate the VM code for the microsecond primitives.
 "
 Class {
-	#name : #DelayMicrosecondTickerSimulation,
-	#superclass : #DelayMicrosecondTicker,
+	#name : 'DelayMicrosecondTickerSimulation',
+	#superclass : 'DelayMicrosecondTicker',
 	#instVars : [
 		'vmSimNow',
 		'vmSimTheTimerSemaphore',
 		'vmSimNextWakeupTick'
 	],
-	#category : #'Kernel-Delays'
+	#category : 'Kernel-Delays',
+	#package : 'Kernel',
+	#tag : 'Delays'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 DelayMicrosecondTickerSimulation >> initialize [
 	super initialize.
 	vmSimTheTimerSemaphore := Semaphore new.
 	vmSimNow := 0
 ]
 
-{ #category : #'api-system' }
+{ #category : 'api-system' }
 DelayMicrosecondTickerSimulation >> nowTick [
 	^vmSimNow
 ]
 
-{ #category : #'private - primitives' }
+{ #category : 'private - primitives' }
 DelayMicrosecondTickerSimulation >> primSignal: sempahore atUTCMicroseconds: nextTick [
 	"This is a simulation of the primitive, working hand-in-hand with #simulate_vmMilliseconds:"
 	(sempahore isKindOf: Semaphore) ifTrue: [
@@ -61,7 +63,7 @@ StackInterpreterPrimitives >> primitiveSignalAtUTCMicroseconds
 "
 ]
 
-{ #category : #'api-system' }
+{ #category : 'api-system' }
 DelayMicrosecondTickerSimulation >> simulate_vmMilliseconds: milliseconds [
 
 	vmSimNextWakeupTick ~= 0 ifTrue: [
@@ -85,7 +87,7 @@ StackInterpreter>>checkForEventsMayContextSwitch:
 "
 ]
 
-{ #category : #'api-system' }
+{ #category : 'api-system' }
 DelayMicrosecondTickerSimulation >> vmSimNextWakeupMilliseconds [
 	^vmSimNextWakeupTick / 1000
 ]

--- a/src/Kernel/DelayMicrosecondUncappedTicker.class.st
+++ b/src/Kernel/DelayMicrosecondUncappedTicker.class.st
@@ -5,12 +5,14 @@ When there is no scheduled delay, the VM will sleep indefinitely until woken
 by another mechanism (which is what?)
 "
 Class {
-	#name : #DelayMicrosecondUncappedTicker,
-	#superclass : #DelayMicrosecondTicker,
-	#category : #'Kernel-Delays'
+	#name : 'DelayMicrosecondUncappedTicker',
+	#superclass : 'DelayMicrosecondTicker',
+	#category : 'Kernel-Delays',
+	#package : 'Kernel',
+	#tag : 'Delays'
 }
 
-{ #category : #'api-system' }
+{ #category : 'api-system' }
 DelayMicrosecondUncappedTicker >> waitForUserSignalled: timingSemaphore orExpired: activeDelay [
 	|nextTick|
 	"Sleep until the active delay is due, or timingSemaphore signalled by DelayScheduler user-api."

--- a/src/Kernel/DelayMillisecondTicker.class.st
+++ b/src/Kernel/DelayMillisecondTicker.class.st
@@ -2,17 +2,19 @@
 I interface to the millisecond based VM primitives.
 "
 Class {
-	#name : #DelayMillisecondTicker,
-	#superclass : #AbstractDelayTicker,
-	#category : #'Kernel-Delays'
+	#name : 'DelayMillisecondTicker',
+	#superclass : 'AbstractDelayTicker',
+	#category : 'Kernel-Delays',
+	#package : 'Kernel',
+	#tag : 'Delays'
 }
 
-{ #category : #'api-system' }
+{ #category : 'api-system' }
 DelayMillisecondTicker >> millisecondsUntilTick: microsecondsTick [
 	^((microsecondsTick - self nowTick) max: 0)
 ]
 
-{ #category : #'api-system' }
+{ #category : 'api-system' }
 DelayMillisecondTicker >> nowTick [
 	"Copied from Time class >> primMillisecondClock."
 	"Primitive. Answer the number of milliseconds since the millisecond clock
@@ -22,19 +24,19 @@ DelayMillisecondTicker >> nowTick [
 	^ 0
 ]
 
-{ #category : #'private - primitives' }
+{ #category : 'private - primitives' }
 DelayMillisecondTicker >> primSignal: aSemaphore atMilliseconds: aSmallInteger [
 	"Signal the semaphore when the millisecond clock reaches the value of the second argument. Fail if the first argument is neither a Semaphore nor nil. Essential. See Object documentation whatIsAPrimitive."
 	<primitive: 136>
 	^self primitiveFailed
 ]
 
-{ #category : #'api-system' }
+{ #category : 'api-system' }
 DelayMillisecondTicker >> tickAfterMilliseconds: milliseconds [
 	^self nowTick "milliseconds" + milliseconds
 ]
 
-{ #category : #'api-system' }
+{ #category : 'api-system' }
 DelayMillisecondTicker >> waitForUserSignalled: timingSemaphore orExpired: activeDelay [
 	|nextTick|
 	"Sleep until the active delay is due, or timingSemaphore signalled by DelayScheduler user-api."

--- a/src/Kernel/DelayMillisecondTickerSimulation.class.st
+++ b/src/Kernel/DelayMillisecondTickerSimulation.class.st
@@ -3,29 +3,31 @@ To facilitate unit tests without interferring with the live VM interface,
 I simulate the VM code for the millisecond primitives.
 "
 Class {
-	#name : #DelayMillisecondTickerSimulation,
-	#superclass : #DelayMillisecondTicker,
+	#name : 'DelayMillisecondTickerSimulation',
+	#superclass : 'DelayMillisecondTicker',
 	#instVars : [
 		'vmSimNow',
 		'vmSimTheTimerSemaphore',
 		'vmSimNextWakeupTick'
 	],
-	#category : #'Kernel-Delays'
+	#category : 'Kernel-Delays',
+	#package : 'Kernel',
+	#tag : 'Delays'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 DelayMillisecondTickerSimulation >> initialize [
 	super initialize.
 	vmSimTheTimerSemaphore := Semaphore new.
 	vmSimNow := 0
 ]
 
-{ #category : #'api-system' }
+{ #category : 'api-system' }
 DelayMillisecondTickerSimulation >> nowTick [
 	^vmSimNow
 ]
 
-{ #category : #'private - primitives' }
+{ #category : 'private - primitives' }
 DelayMillisecondTickerSimulation >> primSignal: sempahore atMilliseconds: nextTick [
 	"This is a simulation of the primitive, working hand-in-hand with #simulate_vmMilliseconds:"
 	(sempahore isKindOf: Semaphore) ifTrue: [
@@ -36,7 +38,7 @@ DelayMillisecondTickerSimulation >> primSignal: sempahore atMilliseconds: nextTi
 		vmSimNextWakeupTick := 0]
 ]
 
-{ #category : #'api-system' }
+{ #category : 'api-system' }
 DelayMillisecondTickerSimulation >> simulate_vmMilliseconds: milliseconds [
 
 	vmSimNextWakeupTick ~= 0 ifTrue: [
@@ -48,7 +50,7 @@ DelayMillisecondTickerSimulation >> simulate_vmMilliseconds: milliseconds [
  		]
 ]
 
-{ #category : #'api-system' }
+{ #category : 'api-system' }
 DelayMillisecondTickerSimulation >> vmSimNextWakeupMilliseconds [
 	^vmSimNextWakeupTick
 ]

--- a/src/Kernel/DelayMutexScheduler.class.st
+++ b/src/Kernel/DelayMutexScheduler.class.st
@@ -2,26 +2,28 @@
 I add shared-resource based synchronization to the basic scheduler.
 "
 Class {
-	#name : #DelayMutexScheduler,
-	#superclass : #DelayBasicScheduler,
+	#name : 'DelayMutexScheduler',
+	#superclass : 'DelayBasicScheduler',
 	#instVars : [
 		'accessProtect'
 	],
-	#category : #'Kernel-Delays'
+	#category : 'Kernel-Delays',
+	#package : 'Kernel',
+	#tag : 'Delays'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 DelayMutexScheduler >> initializeTicker: aDelayTicker suspendedDelaysHeap: aHeap [
 	super initializeTicker: aDelayTicker suspendedDelaysHeap: aHeap.
 	accessProtect := Semaphore forMutualExclusion
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 DelayMutexScheduler >> schedule: aDelay [
 	accessProtect critical: [ super schedule: aDelay]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 DelayMutexScheduler >> unschedule: aDelay [
 	accessProtect critical: [ super unschedule: aDelay]
 ]

--- a/src/Kernel/DelayNullScheduler.class.st
+++ b/src/Kernel/DelayNullScheduler.class.st
@@ -45,12 +45,14 @@ SYSTEM-API
 	Required by Delay-class>>#shutdown
 "
 Class {
-	#name : #DelayNullScheduler,
-	#superclass : #Object,
-	#category : #'Kernel-Delays'
+	#name : 'DelayNullScheduler',
+	#superclass : 'Object',
+	#category : 'Kernel-Delays',
+	#package : 'Kernel',
+	#tag : 'Delays'
 }
 
-{ #category : #'user-api' }
+{ #category : 'user-api' }
 DelayNullScheduler >> schedule: aDelay [
 	"Invoked from user code Delay>>schedule:
 	 DelayNullScheduler does not schedule delays, but need to avoid user code blocking.
@@ -60,29 +62,29 @@ DelayNullScheduler >> schedule: aDelay [
 	aDelay delaySemaphore signal
 ]
 
-{ #category : #'system-api' }
+{ #category : 'system-api' }
 DelayNullScheduler >> shutDown [
 	"Nothing to do for DelayNullScheduler"
 ]
 
-{ #category : #'system-api' }
+{ #category : 'system-api' }
 DelayNullScheduler >> startTimerEventLoop [
 	"Nothing to do for DelayNullScheduler"
 ]
 
-{ #category : #'system-api' }
+{ #category : 'system-api' }
 DelayNullScheduler >> startUp [
 	Warning signal: 'Delay scheduler is NOT RUNNING!'.
 
 	"To get delays working again, go to System > Settings > System > Delay scheduler. "
 ]
 
-{ #category : #'system-api' }
+{ #category : 'system-api' }
 DelayNullScheduler >> stopTimerEventLoop [
 	"Nothing to do for DelayNullScheduler"
 ]
 
-{ #category : #'user-api' }
+{ #category : 'user-api' }
 DelayNullScheduler >> unschedule: aDelay [
 	"Nothing to do for DelayNullScheduler"
 ]

--- a/src/Kernel/DelaySemaphoreScheduler.class.st
+++ b/src/Kernel/DelaySemaphoreScheduler.class.st
@@ -2,23 +2,25 @@
 I add multi-producer/single-consumer semaphore based syncronization to the basic scheduler.
 "
 Class {
-	#name : #DelaySemaphoreScheduler,
-	#superclass : #DelayBasicScheduler,
+	#name : 'DelaySemaphoreScheduler',
+	#superclass : 'DelayBasicScheduler',
 	#instVars : [
 		'readyToSchedule',
 		'readyToUnschedule'
 	],
-	#category : #'Kernel-Delays'
+	#category : 'Kernel-Delays',
+	#package : 'Kernel',
+	#tag : 'Delays'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 DelaySemaphoreScheduler >> initializeTicker: aDelayTicker suspendedDelaysHeap: aHeap [
 	super initializeTicker: aDelayTicker suspendedDelaysHeap: aHeap.
 	readyToSchedule := Semaphore new signal.
 	readyToUnschedule := Semaphore new signal
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 DelaySemaphoreScheduler >> schedule: aDelay [
 	"This is the front-half of scheduling a delay. For back-half see #timingPrioritySchedule:"
 
@@ -30,7 +32,7 @@ DelaySemaphoreScheduler >> schedule: aDelay [
 	timingSemaphore signal. "Transfer execution to back-end #scheduleAtTimingPriority"
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 DelaySemaphoreScheduler >> scheduleAtTimingPriority [
 	"Private! Invoke only from the timing-priority process.
 	 This is the back-half of scheduling a delay. For front-half see #schedule:"
@@ -39,14 +41,14 @@ DelaySemaphoreScheduler >> scheduleAtTimingPriority [
 	super 	scheduleAtTimingPriority
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 DelaySemaphoreScheduler >> unschedule: aDelay [
 	readyToUnschedule  wait.  "Starts signalled. Resignalled from back-end #unscheduleAtTimingPriority"
 	delayToStop := aDelay.
 	timingSemaphore signal. "Transfer execution to back-end #unscheduleAtTimingPriority"
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 DelaySemaphoreScheduler >> unscheduleAtTimingPriority [
 	"Private! Invoke only from the timing-priority process.
 	 This is the back-half of scheduling a delay. For front-half see #schedule:"

--- a/src/Kernel/DelayWaitTimeout.class.st
+++ b/src/Kernel/DelayWaitTimeout.class.st
@@ -2,29 +2,31 @@
 DelayWaitTimeout is a special kind of Delay used in waitTimeoutMSecs: to avoid signaling the underlying semaphore when the wait times out.
 "
 Class {
-	#name : #DelayWaitTimeout,
-	#superclass : #Delay,
+	#name : 'DelayWaitTimeout',
+	#superclass : 'Delay',
 	#instVars : [
 		'process',
 		'expired'
 	],
-	#category : #'Kernel-Delays'
+	#category : 'Kernel-Delays',
+	#package : 'Kernel',
+	#tag : 'Delays'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 DelayWaitTimeout >> isExpired [
 	"Did this timeout fire before the associated semaphore was signaled?"
 	^expired
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 DelayWaitTimeout >> setDelay: anInteger forSemaphore: aSemaphore [
 	super setDelay: anInteger forSemaphore: aSemaphore.
 	process := Processor activeProcess.
 	expired := false
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 DelayWaitTimeout >> timingPrioritySignalExpired [
 	"Release the given process from the semaphore it is waiting on.
 	This method relies on running at highest priority so that it cannot be preempted
@@ -37,7 +39,7 @@ DelayWaitTimeout >> timingPrioritySignalExpired [
 		]
 ]
 
-{ #category : #waiting }
+{ #category : 'waiting' }
 DelayWaitTimeout >> wait [
 	"Wait until either the semaphore is signaled or the delay times out"
 	[self schedule.
@@ -51,7 +53,7 @@ DelayWaitTimeout >> wait [
 	^self isExpired
 ]
 
-{ #category : #waiting }
+{ #category : 'waiting' }
 DelayWaitTimeout >> waitOnCompletion: completionBlock onTimeout: timeoutBlock [
 	"Wait until either the semaphore is signaled or the delay times out.
 	If the delay times out execute timeoutBlock, otherwise if the semaphore is signaled execute completionBlock.

--- a/src/Kernel/DependentsArray.class.st
+++ b/src/Kernel/DependentsArray.class.st
@@ -8,18 +8,20 @@ This is because #size and #at: both require scanning for nils.
 For this reason, DependentsArray though sequenceable, is not a subclass of SequenceableCollection.
 "
 Class {
-	#name : #DependentsArray,
-	#superclass : #Collection,
-	#type : #weak,
-	#category : #'Kernel-Models'
+	#name : 'DependentsArray',
+	#superclass : 'Collection',
+	#type : 'weak',
+	#category : 'Kernel-Models',
+	#package : 'Kernel',
+	#tag : 'Models'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 DependentsArray class >> with: anObject [
 	^(self basicNew: 1) basicAt: 1 put: anObject; yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 DependentsArray class >> with: firstObject with: secondObject [
 	^(self basicNew: 2)
 		basicAt: 1 put: firstObject;
@@ -27,7 +29,7 @@ DependentsArray class >> with: firstObject with: secondObject [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 DependentsArray class >> with: firstObject with: secondObject with: thirdObject [
 	^(self basicNew: 3)
 		basicAt: 1 put: firstObject;
@@ -36,7 +38,7 @@ DependentsArray class >> with: firstObject with: secondObject with: thirdObject 
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 DependentsArray class >> with: firstObject with: secondObject with: thirdObject with: fourthObject [
 	^(self basicNew: 4)
 		basicAt: 1 put: firstObject;
@@ -46,7 +48,7 @@ DependentsArray class >> with: firstObject with: secondObject with: thirdObject 
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 DependentsArray class >> with: firstObject with: secondObject with: thirdObject with: fourthObject with: fifthObject [
 	^(self basicNew: 5)
 		basicAt: 1 put: firstObject;
@@ -57,7 +59,7 @@ DependentsArray class >> with: firstObject with: secondObject with: thirdObject 
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 DependentsArray class >> with: firstObject with: secondObject with: thirdObject with: fourthObject with: fifthObject with: sixthObject [
 	^(self basicNew: 6)
 		basicAt: 1 put: firstObject;
@@ -69,7 +71,7 @@ DependentsArray class >> with: firstObject with: secondObject with: thirdObject 
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 DependentsArray class >> withAll: aCollection [
 	| newInstance |
 	newInstance := self basicNew: aCollection size.
@@ -78,7 +80,7 @@ DependentsArray class >> withAll: aCollection [
 	^newInstance
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DependentsArray >> at: anIndex [
 	| basicSize counter dep |
 	anIndex > 0 ifTrue: [
@@ -91,7 +93,7 @@ DependentsArray >> at: anIndex [
 	self error: 'access with an index out of bounds'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DependentsArray >> at: anIndex put: anObject [
 	| basicSize counter |
 	anIndex > 0 ifTrue: [
@@ -104,7 +106,7 @@ DependentsArray >> at: anIndex put: anObject [
 	self error: 'access with an index out of bounds'
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 DependentsArray >> basicReplaceFrom: start to: stop with: replacement startingAt: repStart [
 	"Primitive. This destructively replaces elements from start to stop in the receiver starting at index, repStart, in the collection, replacement. Answer the receiver. Range checks are performed in the primitive only. Optional. See Object documentation whatIsAPrimitive."
 	<primitive: 105>
@@ -112,7 +114,7 @@ DependentsArray >> basicReplaceFrom: start to: stop with: replacement startingAt
 		self basicAt: i put: (replacement basicAt: repStart - start + i)]
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 DependentsArray >> collect: aBlock [
 	"Refer to the comment in Collection|select:."
 	| basicSize newSelf size dep selection |
@@ -126,7 +128,7 @@ DependentsArray >> collect: aBlock [
 	^selection
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 DependentsArray >> copyWith: newElement [
 	"Re-implemented to not copy any niled out dependents."
 	| copy i |
@@ -137,7 +139,7 @@ DependentsArray >> copyWith: newElement [
 	^copy
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 DependentsArray >> do: aBlock [
 	"Evaluate a Block on non nil elements of the receiver"
 	| dep |
@@ -145,19 +147,19 @@ DependentsArray >> do: aBlock [
 		(dep := self basicAt: i) ifNotNil:[aBlock value: dep]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DependentsArray >> first [
 	self do: [:dep | ^dep].
 	self error: 'this collection is empty'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DependentsArray >> last [
 	self reverseDo: [:dep | ^dep].
 	self error: 'this collection is empty'
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 DependentsArray >> reverseDo: aBlock [
 	"Refer to the comment in Collection|do:."
 	| dep |
@@ -165,7 +167,7 @@ DependentsArray >> reverseDo: aBlock [
 		(dep := self basicAt: i) ifNotNil: [aBlock value: dep]]
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 DependentsArray >> select: aBlock [
 	"Refer to the comment in Collection|select:."
 	| basicSize newSelf size selection |
@@ -181,7 +183,7 @@ DependentsArray >> select: aBlock [
 	^selection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DependentsArray >> size [
 	"count each non nil elements in self.
 	Note: count: will use do: which will already have filtered out nil elements"
@@ -189,7 +191,7 @@ DependentsArray >> size [
 	^self count: [:each | true]
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 DependentsArray >> writeStream [
 	^ WriteStream on: self
 ]

--- a/src/Kernel/Deprecation.class.st
+++ b/src/Kernel/Deprecation.class.st
@@ -23,8 +23,8 @@ If the transformation is defined, the Warning will not signalled.
 
 "
 Class {
-	#name : #Deprecation,
-	#superclass : #Warning,
+	#name : 'Deprecation',
+	#superclass : 'Warning',
 	#instVars : [
 		'context',
 		'explanationString',
@@ -39,22 +39,24 @@ Class {
 		'RaiseWarning',
 		'ShowWarning'
 	],
-	#category : #'Kernel-Exceptions'
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #logging }
+{ #category : 'logging' }
 Deprecation class >> activateTransformations [
 
 	^ Active ifNil: [ Active := true ]
 ]
 
-{ #category : #logging }
+{ #category : 'logging' }
 Deprecation class >> activateTransformations: aBoolean [
 
 	Active := aBoolean
 ]
 
-{ #category : #logging }
+{ #category : 'logging' }
 Deprecation class >> deprecationsWhile: aBlock [
 	"returns a log of all deprecated methods seen while executing aBlock"
 	| oldLog result |
@@ -67,34 +69,34 @@ Deprecation class >> deprecationsWhile: aBlock [
 	^result
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 Deprecation class >> initialize [
 	Log := nil "#deprecationsWhile: logs all deprecations here"
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 Deprecation class >> raiseWarning [
 	"If true, then a dialog is popup for each deprecated method invocation"
 	^ RaiseWarning ifNil: [RaiseWarning := true]
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 Deprecation class >> raiseWarning: aBoolean [
 	RaiseWarning := aBoolean
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 Deprecation class >> showWarning [
 	"If true, then a message is send to the Transcript for each deprecated method invocation"
 	^ ShowWarning ifNil: [ShowWarning := true]
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 Deprecation class >> showWarning: aBoolean [
 	ShowWarning := aBoolean
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Deprecation >> = anObject [
 	^self class == anObject class
 	  and: [context = anObject context
@@ -103,32 +105,32 @@ Deprecation >> = anObject [
 			ifNotNil: [true]]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Deprecation >> condition: aBlock [
 	condition := aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Deprecation >> context: aContext [
 	context := aContext
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Deprecation >> contextOfDeprecatedMethod [
 	^context
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Deprecation >> contextOfSender [
 	^context sender
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Deprecation >> date: aDate [
 	deprecationDate := aDate
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 Deprecation >> defaultAction [
 	Log
 		ifNotNil: [:log | log add: self].
@@ -137,40 +139,40 @@ Deprecation >> defaultAction [
 		ifTrue: [super defaultAction]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Deprecation >> deprecatedMethodName [
 	^self contextOfDeprecatedMethod homeMethod printString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Deprecation >> deprecationDate [
 
 	^ deprecationDate ifNil: [ 'unknown' ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Deprecation >> explanation: aString [
 	explanationString := aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Deprecation >> explanationString [
 
 	^ explanationString
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Deprecation >> hash [
 	^(context ifNil: [explanationString]) hash
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Deprecation >> logTranscript [
 	self showWarning
 		ifTrue: [ DeprecationPerformedNotification signal: self messageText ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Deprecation >> messageText [
 	^String streamContents: [ :str |
 		self shouldTransform ifTrue: [
@@ -184,39 +186,39 @@ Deprecation >> messageText [
 		 	nextPutAll: explanationString]
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 Deprecation >> raiseWarning [
 	^ self class raiseWarning
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Deprecation >> rewriterClass [
 	^ self class environment at: #RBParseTreeRewriter ifAbsent: [ nil ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Deprecation >> rule: aRule [
 	rule := aRule
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Deprecation >> sendingMethodName [
 	^self contextOfSender homeMethod printString
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 Deprecation >> shouldTransform [
 	self class activateTransformations ifFalse: [ ^false  ].
 	(condition isNil or: [ condition cull: self ]) ifFalse: [ ^false ].
 	^rule isNotNil
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 Deprecation >> showWarning [
 	^ self class showWarning
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 Deprecation >> signal [
 	| pragma homeMethod |
 	homeMethod := context homeMethod.
@@ -227,7 +229,7 @@ Deprecation >> signal [
 	self transform
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 Deprecation >> transform [
 	| node rewriteRule aMethod |
 	self shouldTransform ifFalse: [ ^ self signal].
@@ -248,12 +250,12 @@ Deprecation >> transform [
 		self logTranscript]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Deprecation >> version: aString [
 	versionString := aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Deprecation >> versionString [
 
 	^ versionString ifNil: [ 'unknown' ]

--- a/src/Kernel/DeprecationPerformedNotification.class.st
+++ b/src/Kernel/DeprecationPerformedNotification.class.st
@@ -2,7 +2,9 @@
 I am a notificaton about an operation that was performed as reaction of a Deprecation warning. I inform user about a method rewrite and so on. Usual reaction is to write related description to Transcript.
 "
 Class {
-	#name : #DeprecationPerformedNotification,
-	#superclass : #SystemNotification,
-	#category : #'Kernel-Exceptions'
+	#name : 'DeprecationPerformedNotification',
+	#superclass : 'SystemNotification',
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }

--- a/src/Kernel/DoItVariable.class.st
+++ b/src/Kernel/DoItVariable.class.st
@@ -33,16 +33,18 @@ Internal Representation and Key Implementation Points.
 	doItContext:		<Context>
 "
 Class {
-	#name : #DoItVariable,
-	#superclass : #Variable,
+	#name : 'DoItVariable',
+	#superclass : 'Variable',
 	#instVars : [
 		'actualVariable',
 		'doItContext'
 	],
-	#category : #'Kernel-Variables'
+	#category : 'Kernel-Variables',
+	#package : 'Kernel',
+	#tag : 'Variables'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 DoItVariable class >> fromContext: aContext variable: aVariable [
 
 	^self new
@@ -50,40 +52,40 @@ DoItVariable class >> fromContext: aContext variable: aVariable [
 		actualVariable: aVariable
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 DoItVariable class >> named: aString fromContext: aContext [
 	^self
 		fromContext: aContext
 		variable: (aContext lookupVar: aString)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DoItVariable >> actualVariable [
 	^ actualVariable
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DoItVariable >> actualVariable: aVariable [
 	actualVariable := aVariable.
 	name := actualVariable name
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 DoItVariable >> allowsShadowing [
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DoItVariable >> doItContext [
 	^ doItContext
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DoItVariable >> doItContext: anObject [
 	doItContext := anObject
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 DoItVariable >> emitStore: aMethodBuilder [
 	"generate bytecode to call the reflective write method of the Slot"
 	| tempName |
@@ -97,94 +99,94 @@ DoItVariable >> emitStore: aMethodBuilder [
 		send: #write:
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 DoItVariable >> emitValue: aMethodBuilder [
 	aMethodBuilder
 		pushLiteral: self;
 		send: #read
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 DoItVariable >> isArgumentVariable [
 	^actualVariable isArgumentVariable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 DoItVariable >> isClassVariable [
 	^actualVariable isClassVariable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 DoItVariable >> isGlobalVariable [
 	^actualVariable isGlobalVariable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 DoItVariable >> isInstanceVariable [
 	^actualVariable isInstanceVariable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 DoItVariable >> isLiteralVariable [
 	^actualVariable isLiteralVariable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 DoItVariable >> isLocalVariable [
 	^actualVariable isLocalVariable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 DoItVariable >> isPseudoVariable [
 	^actualVariable isPseudoVariable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 DoItVariable >> isSelfVariable [
 	^actualVariable isSelfVariable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 DoItVariable >> isSuperVariable [
 	^actualVariable isSuperVariable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 DoItVariable >> isTempVariable [
 	^actualVariable isTempVariable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 DoItVariable >> isThisContextVariable [
 	^actualVariable isThisContextVariable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 DoItVariable >> isThisProcessVariable [
 	^actualVariable isThisProcessVariable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 DoItVariable >> isUndeclaredVariable [
 	^actualVariable isUndeclaredVariable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 DoItVariable >> isUninitialized [
 	^actualVariable isUninitialized
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 DoItVariable >> isWorkspaceVariable [
 	^actualVariable isWorkspaceVariable
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DoItVariable >> key [
 	^self name
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 DoItVariable >> printOn: aStream [
 	super printOn: aStream.
 
@@ -193,32 +195,32 @@ DoItVariable >> printOn: aStream [
 	aStream nextPut: $)
 ]
 
-{ #category : #'meta-object-protocol' }
+{ #category : 'meta-object-protocol' }
 DoItVariable >> read [
 	^actualVariable readInContext: doItContext
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 DoItVariable >> readInContext: aContext [
 	^self read
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DoItVariable >> scope [
 	^ actualVariable scope
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 DoItVariable >> usingMethods [
 	^actualVariable usingMethods
 ]
 
-{ #category : #'meta-object-protocol' }
+{ #category : 'meta-object-protocol' }
 DoItVariable >> write: aValue [
 	^actualVariable write: aValue inContext: doItContext
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 DoItVariable >> write: aValue inContext: aContext [
 	self write: aValue
 ]

--- a/src/Kernel/DomainError.class.st
+++ b/src/Kernel/DomainError.class.st
@@ -4,21 +4,23 @@ I am DomainError, an ArithmeticException indicating that some argument falls out
 When my valid interval is left- or right-open, use signal: creation protocol to provide a custom messageText rather than the default [from, to] notation.
 "
 Class {
-	#name : #DomainError,
-	#superclass : #ArithmeticError,
+	#name : 'DomainError',
+	#superclass : 'ArithmeticError',
 	#instVars : [
 		'from',
 		'to'
 	],
-	#category : #'Kernel-Exceptions'
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #signaling }
+{ #category : 'signaling' }
 DomainError class >> signal: signallerText from: start [
 	^ self signal: signallerText from: start to: Float infinity
 ]
 
-{ #category : #signaling }
+{ #category : 'signaling' }
 DomainError class >> signal: signallerText from: start to: end [
 	^ self new
 		from: start;
@@ -26,17 +28,17 @@ DomainError class >> signal: signallerText from: start to: end [
 		signal: signallerText
 ]
 
-{ #category : #signaling }
+{ #category : 'signaling' }
 DomainError class >> signal: signallerText to: end [
 	^ self signal: signallerText from: Float infinity negated to: end
 ]
 
-{ #category : #signaling }
+{ #category : 'signaling' }
 DomainError class >> signalFrom: start [
 	^ self signalFrom: start to: Float infinity
 ]
 
-{ #category : #signaling }
+{ #category : 'signaling' }
 DomainError class >> signalFrom: start to: end [
 	| msgStart msgEnd |
 	msgStart := (start isFloat and: [start isFinite not]) ifTrue: ['(-infinity'] ifFalse: ['[', start printString].
@@ -46,27 +48,27 @@ DomainError class >> signalFrom: start to: end [
 		to: end
 ]
 
-{ #category : #signaling }
+{ #category : 'signaling' }
 DomainError class >> signalTo: end [
 	^ self signalFrom: Float infinity negated to: end
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DomainError >> from [
 	^ from
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DomainError >> from: start [
 	from := start
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DomainError >> to [
 	^ to
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DomainError >> to: end [
 	to := end
 ]

--- a/src/Kernel/DoubleByteLayout.class.st
+++ b/src/Kernel/DoubleByteLayout.class.st
@@ -2,19 +2,21 @@
 I am a raw data layout that holds double bytes (16 bits).
 "
 Class {
-	#name : #DoubleByteLayout,
-	#superclass : #BitsLayout,
-	#category : #'Kernel-Layout'
+	#name : 'DoubleByteLayout',
+	#superclass : 'BitsLayout',
+	#category : 'Kernel-Layout',
+	#package : 'Kernel',
+	#tag : 'Layout'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 DoubleByteLayout class >> extending: superLayout scope: aScope host: aClass [
 	^ superLayout extendDoubleByte
 		host: aClass;
 		yourself
 ]
 
-{ #category : #description }
+{ #category : 'description' }
 DoubleByteLayout class >> subclassDefiningSymbol [
 	"Answer a keyword that describes the receiver's kind of subclass
 	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
@@ -22,23 +24,23 @@ DoubleByteLayout class >> subclassDefiningSymbol [
 	^#variableDoubleByteSubclass:
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DoubleByteLayout >> bytesPerSlot [
 
 	^ 2
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 DoubleByteLayout >> extendDoubleByte [
 	^ DoubleByteLayout new
 ]
 
-{ #category : #format }
+{ #category : 'format' }
 DoubleByteLayout >> instanceSpecification [
 	^ 12
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 DoubleByteLayout >> isDoubleBytes [
 	^ true
 ]

--- a/src/Kernel/DoubleWordLayout.class.st
+++ b/src/Kernel/DoubleWordLayout.class.st
@@ -2,19 +2,21 @@
 I am a raw data layout that holds double words (64 bit).
 "
 Class {
-	#name : #DoubleWordLayout,
-	#superclass : #BitsLayout,
-	#category : #'Kernel-Layout'
+	#name : 'DoubleWordLayout',
+	#superclass : 'BitsLayout',
+	#category : 'Kernel-Layout',
+	#package : 'Kernel',
+	#tag : 'Layout'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 DoubleWordLayout class >> extending: superLayout scope: aScope host: aClass [
 	^ superLayout extendDoubleWord
 		host: aClass;
 		yourself
 ]
 
-{ #category : #description }
+{ #category : 'description' }
 DoubleWordLayout class >> subclassDefiningSymbol [
 	"Answer a keyword that describes the receiver's kind of subclass
 	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
@@ -22,17 +24,17 @@ DoubleWordLayout class >> subclassDefiningSymbol [
 	^#variableDoubleWordSubclass:
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 DoubleWordLayout >> extendDoubleWord [
 	^ DoubleWordLayout new
 ]
 
-{ #category : #format }
+{ #category : 'format' }
 DoubleWordLayout >> instanceSpecification [
 	^ 9
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 DoubleWordLayout >> isDoubleWords [
 	^ true
 ]

--- a/src/Kernel/DuplicatedVariableError.class.st
+++ b/src/Kernel/DuplicatedVariableError.class.st
@@ -2,47 +2,49 @@
 I am an error signalled when a variable is redeclared. For instance when a method is created wich has a temporary or argument with the same name as an instance variable.
 "
 Class {
-	#name : #DuplicatedVariableError,
-	#superclass : #Error,
+	#name : 'DuplicatedVariableError',
+	#superclass : 'Error',
 	#instVars : [
 		'superclass',
 		'variable'
 	],
-	#category : #'Kernel-Exceptions'
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #signalling }
+{ #category : 'signalling' }
 DuplicatedVariableError class >> signalWith: existingVariable [
 	^self new
 		variable: existingVariable;
 		signal: existingVariable name , ' is defined in ', existingVariable definingClass printString
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 DuplicatedVariableError >> isResumable [
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DuplicatedVariableError >> superclass [
         "The superclass in which the variable is defined"
         ^superclass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DuplicatedVariableError >> superclass: aSuperclass [
         "The superclass in which the variable is defined"
         superclass := aSuperclass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DuplicatedVariableError >> variable [
         "Name of the duplicate variable"
         ^variable
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DuplicatedVariableError >> variable: aVariable [
         "Name of the duplicate variable"
         variable := aVariable

--- a/src/Kernel/Duration.class.st
+++ b/src/Kernel/Duration.class.st
@@ -2,8 +2,8 @@
 I represent a duration of time. I have nanosecond precision
 "
 Class {
-	#name : #Duration,
-	#superclass : #Magnitude,
+	#name : 'Duration',
+	#superclass : 'Magnitude',
 	#instVars : [
 		'nanos',
 		'seconds'
@@ -11,22 +11,24 @@ Class {
 	#pools : [
 		'ChronologyConstants'
 	],
-	#category : #'Kernel-Chronology'
+	#category : 'Kernel-Chronology',
+	#package : 'Kernel',
+	#tag : 'Chronology'
 }
 
-{ #category : #'instance creation simple' }
+{ #category : 'instance creation simple' }
 Duration class >> days: aNumber [
 
 	^ self seconds: aNumber * SecondsInDay nanoSeconds: 0
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Duration class >> days: days hours: hours minutes: minutes seconds: seconds [
 
 	^ self days: days hours: hours minutes: minutes seconds: seconds nanoSeconds: 0
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Duration class >> days: days hours: hours minutes: minutes seconds: seconds nanoSeconds: nanos [
 
  	^ self seconds: ((days * SecondsInDay)
@@ -36,32 +38,32 @@ Duration class >> days: days hours: hours minutes: minutes seconds: seconds nano
 		nanoSeconds: nanos
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Duration class >> days: days seconds: seconds [
 
 	^ self basicNew seconds: days * SecondsInDay + seconds nanoSeconds: 0
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Duration class >> fromString: aString [
 
 	^ self readFrom: aString readStream
 ]
 
-{ #category : #'instance creation simple' }
+{ #category : 'instance creation simple' }
 Duration class >> hours: aNumber [
 
 	^ self seconds: aNumber * SecondsInHour nanoSeconds: 0
 ]
 
-{ #category : #'instance creation simple' }
+{ #category : 'instance creation simple' }
 Duration class >> microSeconds: microCount [
 	^ self
 		seconds: (microCount quo: 1000000)
 		nanoSeconds: (microCount rem: 1000000) * NanosInMicroSecond
 ]
 
-{ #category : #'instance creation simple' }
+{ #category : 'instance creation simple' }
 Duration class >> milliSeconds: milliCount [
 
 	^ self
@@ -69,13 +71,13 @@ Duration class >> milliSeconds: milliCount [
 		nanoSeconds: (milliCount rem: 1000) * NanosInMillisecond
 ]
 
-{ #category : #'instance creation simple' }
+{ #category : 'instance creation simple' }
 Duration class >> minutes: aNumber [
 
 	^ self seconds: aNumber * SecondsInMinute nanoSeconds: 0
 ]
 
-{ #category : #'instance creation simple' }
+{ #category : 'instance creation simple' }
 Duration class >> nanoSeconds: nanos [
 	"This method is slow. If you have nanos less than 10^6 you should use #seconds:nanoSeconds: instead."
 
@@ -86,7 +88,7 @@ Duration class >> nanoSeconds: nanos [
 		nanoSeconds: nanos - (quo * NanosInSecond)
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Duration class >> readFrom: aStream [
 	"Formatted as per ANSI 5.8.2.16: [-]D:HH:MM:SS[.S]"
 
@@ -109,56 +111,56 @@ Duration class >> readFrom: aStream [
 		nanoSeconds: (nanosBuffer asInteger sign: sign)
 ]
 
-{ #category : #'instance creation simple' }
+{ #category : 'instance creation simple' }
 Duration class >> seconds: seconds [
 
 	^ self seconds: seconds nanoSeconds: 0
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Duration class >> seconds: seconds nanoSeconds: nanos [
 	^ self basicNew
 		seconds: seconds truncated
 		nanoSeconds: seconds fractionPart * NanosInSecond + nanos
 ]
 
-{ #category : #'instance creation simple' }
+{ #category : 'instance creation simple' }
 Duration class >> weeks: aNumber [
 
 	^ self days: (aNumber * 7) seconds: 0
 ]
 
-{ #category : #'instance creation simple' }
+{ #category : 'instance creation simple' }
 Duration class >> years: aNumber [
 
 	^ self days: (aNumber * 365) seconds: 0
 ]
 
-{ #category : #'instance creation simple' }
+{ #category : 'instance creation simple' }
 Duration class >> zero [
 
 	^ self basicNew seconds: 0 nanoSeconds: 0
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Duration >> * operand [
 	"operand is a Number"
 	^ self class nanoSeconds: ( (self asNanoSeconds * operand) asInteger)
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Duration >> + operand [
   	"operand is a Duration"
 	^ self class nanoSeconds: (self asNanoSeconds + operand asNanoSeconds)
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Duration >> - operand [
 	"operand is a Duration"
 	^ self + operand negated
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Duration >> / operand [
  	"operand is a Duration or a Number"
 
@@ -167,7 +169,7 @@ Duration >> / operand [
  		ifFalse: [ self asNanoSeconds / operand asDuration asNanoSeconds ]
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 Duration >> // operand [
 
  	"operand is a Duration or a Number (count of nanoseconds)"
@@ -177,13 +179,13 @@ Duration >> // operand [
  		ifFalse: [ self asNanoSeconds // operand asDuration asNanoSeconds ]
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Duration >> < comparand [
 
  	^ self asNanoSeconds < comparand asNanoSeconds
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Duration >> = comparand [
  	"Answer whether the argument is a <Duration> representing the same
  	period of time as the receiver."
@@ -195,7 +197,7 @@ Duration >> = comparand [
  				and: [self asNanoSeconds = comparand asNanoSeconds]]
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 Duration >> \\ operand [
 
  	"modulo. Remainder defined in terms of //. Answer a Duration with the
@@ -206,87 +208,87 @@ Duration >> \\ operand [
  		ifFalse: [ self - (operand * (self // operand)) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Duration >> abs [
 
  	^ self class seconds: seconds abs nanoSeconds: nanos abs
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Duration >> asDays [
  	"Answer the number of days in the receiver."
  	^ self asHours / 24
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Duration >> asDelay [
 
  	^ Delay forDuration: self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Duration >> asDuration [
 
  	^ self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Duration >> asHours [
  	"Answer the number of hours in the receiver."
  	^ self asMinutes / 60.0
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Duration >> asMicroseconds [
 
 
  	^ ((seconds * NanosInSecond) + nanos) // (10 raisedToInteger: 3)
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Duration >> asMilliSeconds [
 
 
  	^ ((seconds * NanosInSecond) + nanos) // (10 raisedToInteger: 6)
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Duration >> asMinutes [
  	"Answer the number of minutes in the receiver."
  	^ self asNanoSeconds  / 60000000000.0
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Duration >> asNanoSeconds [
 
  	^ (seconds * NanosInSecond) + nanos
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Duration >> asSeconds [
  	"Answer the number of seconds in the receiver."
  	^ seconds
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Duration >> days [
  	"Answer a number that represents the number of complete days in the receiver"
 	^ seconds quo: SecondsInDay
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Duration >> hash [
 	^seconds bitXor: nanos
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Duration >> hours [
  	"Answer a number that represents the number of complete hours in the receiver, after the number of complete days has been removed."
 
  	^ (seconds rem: SecondsInDay) quo: SecondsInHour
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Duration >> humanReadablePrintString [
 	"Return a String with a human readable representation of me"
 
@@ -298,52 +300,52 @@ Duration >> humanReadablePrintString [
 		self printHumanReadableOn: out ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Duration >> initialize [
 	super initialize.
 	self seconds: 0 nanoSeconds: 0
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Duration >> isZero [
 
 	^ seconds = 0 and: [ nanos = 0 ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Duration >> minutes [
   	"Answer a number that represents the number of complete minutes in the receiver, after the number of complete hours has been removed."
  	^ (seconds rem: SecondsInHour) quo: SecondsInMinute
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Duration >> nanoSeconds [
 
 
  	^ nanos
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Duration >> negated [
 
  	^ self class seconds: seconds negated nanoSeconds: nanos negated
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Duration >> negative [
 
 
  	^ self positive not
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Duration >> positive [
 
 
  	^ seconds = 0 ifTrue: [ nanos positive ] ifFalse: [ seconds positive ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Duration >> printHumanReadableOn: stream [
 	| outputWritten count |
 	outputWritten := false.
@@ -368,7 +370,7 @@ Duration >> printHumanReadableOn: stream [
 	outputWritten ifFalse: [ stream << '0 seconds' ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Duration >> printOn: aStream [
 	"Format as per ANSI 5.8.2.16: [-]D:HH:MM:SS[.S]" 	| d h m s n |
 	d := self days abs.
@@ -392,14 +394,14 @@ Duration >> printOn: aStream [
 		ps from: 1 to: z do: [ :c | aStream nextPut: c ] ]
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 Duration >> roundTo: aDuration [
  	"e.g. if the receiver is 5 minutes, 37 seconds, and aDuration is 2 minutes, answer 6 minutes."
 
  	^ self class nanoSeconds: (self asNanoSeconds roundTo: aDuration asNanoSeconds)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Duration >> seconds [
  	"Answer a number that represents the number of complete seconds in the receiver, after the number of complete minutes has been removed."
 
@@ -408,7 +410,7 @@ Duration >> seconds [
  	^ (seconds rem: SecondsInMinute)
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Duration >> seconds: secondCount nanoSeconds: nanoCount [
 	"Private - only used by Duration class"
 
@@ -423,7 +425,7 @@ Duration >> seconds: secondCount nanoSeconds: nanoCount [
 			nanos := nanos - NanosInSecond ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Duration >> storeOn: aStream [
 
  	aStream
@@ -436,7 +438,7 @@ Duration >> storeOn: aStream [
  		nextPut: $)
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Duration >> ticks [
 	"Answer an array {days. seconds. nanoSeconds}. Used by DateAndTime and Time."
 
@@ -448,7 +450,7 @@ Duration >> ticks [
 		with: nanos
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Duration >> totalSeconds [
 	"Return the total number of seconds in me.
 	If I have zero nano seconds, the result is equivalent to #seconds.
@@ -461,7 +463,7 @@ Duration >> totalSeconds [
 		ifFalse: [ self asNanoSeconds / 1e9 ]
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 Duration >> truncateTo: aDuration [
  	"e.g. if the receiver is 5 minutes, 37 seconds, and aDuration is 2 minutes, answer 4 minutes."
 
@@ -469,13 +471,13 @@ Duration >> truncateTo: aDuration [
  		nanoSeconds: (self asNanoSeconds truncateTo: aDuration asNanoSeconds)
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 Duration >> wait [
 
 	self asDelay wait
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Duration >> wholeMicroseconds [
 	"Answer the number of whole microseconds in me after whole seconds and milliseconds are removed"
 
@@ -484,7 +486,7 @@ Duration >> wholeMicroseconds [
 	^ (nanos rem: 1e6) quo: 1e3
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Duration >> wholeMilliseconds [
 	"Answer the number of whole milliseconds in me after whole seconds are removed"
 
@@ -493,7 +495,7 @@ Duration >> wholeMilliseconds [
 	^ nanos quo: 1e6
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Duration >> wholeNanoseconds [
 	"Answer the number of whole nanoseconds in me after whole seconds, milli & microseconds are removed"
 

--- a/src/Kernel/DynamicVariable.class.st
+++ b/src/Kernel/DynamicVariable.class.st
@@ -5,18 +5,20 @@ no way to change the value inside such a block, but it is possible to
 temporarirly rebind it in a nested manner.
 "
 Class {
-	#name : #DynamicVariable,
-	#superclass : #ProcessSpecificVariable,
-	#category : #'Kernel-Processes'
+	#name : 'DynamicVariable',
+	#superclass : 'ProcessSpecificVariable',
+	#category : 'Kernel-Processes',
+	#package : 'Kernel',
+	#tag : 'Processes'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DynamicVariable class >> value: anObject during: aBlock [
 
 	^ self soleInstance value: anObject during: aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DynamicVariable >> value: anObject during: aBlock [
 	| activeProcess oldValue |
 	activeProcess := Processor activeProcess.

--- a/src/Kernel/EmptyLayout.class.st
+++ b/src/Kernel/EmptyLayout.class.st
@@ -2,52 +2,54 @@
 Empty top-level layout used to delimit the layout chains.
 "
 Class {
-	#name : #EmptyLayout,
-	#superclass : #AbstractLayout,
+	#name : 'EmptyLayout',
+	#superclass : 'AbstractLayout',
 	#classInstVars : [
 		'instance'
 	],
-	#category : #'Kernel-Layout'
+	#category : 'Kernel-Layout',
+	#package : 'Kernel',
+	#tag : 'Layout'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 EmptyLayout class >> instance [
 	^ instance ifNil: [ instance := self new ]
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 EmptyLayout >> extend: someSlots [
 	^ FixedLayout new
 		slotScope: (LayoutEmptyScope instance extend: someSlots)
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 EmptyLayout >> extendByte [
 	^ ByteLayout new
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 EmptyLayout >> extendDoubleByte [
 	^ DoubleByteLayout new
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 EmptyLayout >> extendDoubleWord [
 	^ DoubleWordLayout new
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 EmptyLayout >> extendVariable: someSlots [
 	^ VariableLayout new
 		slotScope: (LayoutEmptyScope extend: someSlots)
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 EmptyLayout >> extendWeak [
 	^ WeakLayout new
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 EmptyLayout >> extendWord [
 	^ WordLayout new
 ]

--- a/src/Kernel/EphemeronLayout.class.st
+++ b/src/Kernel/EphemeronLayout.class.st
@@ -2,12 +2,14 @@
 A layout for ephemeron objects
 "
 Class {
-	#name : #EphemeronLayout,
-	#superclass : #PointerLayout,
-	#category : #'Kernel-Layout'
+	#name : 'EphemeronLayout',
+	#superclass : 'PointerLayout',
+	#category : 'Kernel-Layout',
+	#package : 'Kernel',
+	#tag : 'Layout'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 EphemeronLayout class >> extending: superLayout scope: aScope host: aClass [
 
 	^ (superLayout extendEphemeron: aScope)
@@ -15,7 +17,7 @@ EphemeronLayout class >> extending: superLayout scope: aScope host: aClass [
 		yourself
 ]
 
-{ #category : #description }
+{ #category : 'description' }
 EphemeronLayout class >> subclassDefiningSymbol [
 	"Answer a keyword that describes the receiver's kind of subclass
 	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
@@ -23,7 +25,7 @@ EphemeronLayout class >> subclassDefiningSymbol [
 	^#ephemeronSubclass:
 ]
 
-{ #category : #format }
+{ #category : 'format' }
 EphemeronLayout >> instanceSpecification [
 	^ 5
 ]

--- a/src/Kernel/Error.class.st
+++ b/src/Kernel/Error.class.st
@@ -7,17 +7,19 @@ Additional notes:
 Error>defaultAction uses an explicit test for the presence of the Debugger class to decide whether or not it is in development mode.  In the future, TFEI hopes to enhance the semantics of #defaultAction to improve support for pluggable default handlers.
 "
 Class {
-	#name : #Error,
-	#superclass : #Exception,
-	#category : #'Kernel-Exceptions'
+	#name : 'Error',
+	#superclass : 'Exception',
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 Error class >> captureIfSignalledWhenStepping [
 	^self == Error
 ]
 
-{ #category : #'private - testing' }
+{ #category : 'private - testing' }
 Error >> isResumable [
 	"Determine whether an exception is resumable."
 

--- a/src/Kernel/ExactFloatPrintPolicy.class.st
+++ b/src/Kernel/ExactFloatPrintPolicy.class.st
@@ -4,12 +4,14 @@ I am ExactFloatPrintPolicy.
 Through FloatPrintPolicy and double dispatch I force Float>>#printOn:base: to dynamically use the slower but accurate way to print Floats using Float>>#absPrintExactlyOn:base:
 "
 Class {
-	#name : #ExactFloatPrintPolicy,
-	#superclass : #Object,
-	#category : #'Kernel-Numbers'
+	#name : 'ExactFloatPrintPolicy',
+	#superclass : 'Object',
+	#category : 'Kernel-Numbers',
+	#package : 'Kernel',
+	#tag : 'Numbers'
 }
 
-{ #category : #printing }
+{ #category : 'printing' }
 ExactFloatPrintPolicy >> absPrint: float on: stream base: base [
 	"Doube dispatch to the slower but accurate way to print"
 

--- a/src/Kernel/Exception.class.st
+++ b/src/Kernel/Exception.class.st
@@ -17,8 +17,8 @@ Context>>answer:
 Thanks, Craig!
 "
 Class {
-	#name : #Exception,
-	#superclass : #Object,
+	#name : 'Exception',
+	#superclass : 'Object',
 	#instVars : [
 		'messageText',
 		'tag',
@@ -27,10 +27,12 @@ Class {
 		'handlerContext',
 		'outerContext'
 	],
-	#category : #'Kernel-Exceptions'
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #exceptionselector }
+{ #category : 'exceptionselector' }
 Exception class >> , anotherException [
 	"Create an exception set containing the receiver and anotherException"
 
@@ -40,7 +42,7 @@ Exception class >> , anotherException [
 		yourself
 ]
 
-{ #category : #exceptionselector }
+{ #category : 'exceptionselector' }
 Exception class >> - anotherException [
 	"Create an exception set containing the receiver and anotherException as exclusion."
 
@@ -50,33 +52,33 @@ Exception class >> - anotherException [
 		yourself
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Exception class >> captureIfSignalledWhenStepping [
 	^false
 ]
 
-{ #category : #exceptionselector }
+{ #category : 'exceptionselector' }
 Exception class >> handles: exception [
 	"Determine whether an exception handler will accept a signaled exception."
 
 	^ exception isKindOf: self
 ]
 
-{ #category : #exceptioninstantiator }
+{ #category : 'exceptioninstantiator' }
 Exception class >> signal [
 	"Signal the occurrence of an exceptional condition."
 
 	^ self new signal
 ]
 
-{ #category : #exceptioninstantiator }
+{ #category : 'exceptioninstantiator' }
 Exception class >> signal: message [
 	"Signal the occurrence of an exceptional condition with a specified textual description."
 
 	^ self new signal: message
 ]
 
-{ #category : #exceptioninstantiator }
+{ #category : 'exceptioninstantiator' }
 Exception class >> signal: message in: context [
 	"Signal the occurrence of an exceptional condition with a specified textual description in the given context."
 
@@ -85,7 +87,7 @@ Exception class >> signal: message in: context [
 		signalIn: context
 ]
 
-{ #category : #exceptioninstantiator }
+{ #category : 'exceptioninstantiator' }
 Exception class >> signal: message withTag: aTag [
 	"Signal the occurrence of an exceptional condition with a specified textual description including a tag for the exception."
 
@@ -95,14 +97,14 @@ Exception class >> signal: message withTag: aTag [
 		signal
 ]
 
-{ #category : #exceptioninstantiator }
+{ #category : 'exceptioninstantiator' }
 Exception class >> signalIn: context [
 	"Signal the occurrence of an exceptional condition in the given context."
 
 	^ self new signalIn: context
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Exception >> completeProcess: aProcess with: aContext [
 	"I am a hook during process completion in case one of my subclass wants to plug a special behavior.
 
@@ -111,7 +113,7 @@ Exception >> completeProcess: aProcess with: aContext [
 	^ self signalContext
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 Exception >> debug [
 
 	"requests a debugger on myself"
@@ -120,7 +122,7 @@ Exception >> debug [
 	UIManager default requestDebuggerOpeningFor: self
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 Exception >> defaultAction [
 	"No one has handled this error, but now give them a chance to decide how to debug it.
 	If none handles this either then open debugger (see UnhandedError-defaultAction).
@@ -131,7 +133,7 @@ Exception >> defaultAction [
 	^ self raiseUnhandledError
 ]
 
-{ #category : #default }
+{ #category : 'default' }
 Exception >> defaultDescription [
 	"Return a textual description of the exception."
 
@@ -141,21 +143,21 @@ Exception >> defaultDescription [
 			ifFalse: [ stream << ': ' << mt ] ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Exception >> defaultResumeValue [
 	"Answer the value that by default should be returned if the exception is resumed"
 
 	^ nil
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Exception >> defaultReturnValue [
 	"Answer the value that by default should be returned if the exception is returned"
 
 	^ nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Exception >> description [
 
 	"Returns a textual description of the exception."
@@ -165,64 +167,64 @@ Exception >> description [
 	^ self defaultDescription
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 Exception >> freeze [
 	"Freeze the context stack to keep the exception usable outside the catch blocks"
 
 	self freezeUpTo: thisContext
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 Exception >> freezeUpTo:  aContext [
 	"Freeze the signal context up to the given context so the exception is usable outside the catch block"
 
 	signalContext := signalContext copyTo: aContext
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Exception >> isDebuggerFailure [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Exception >> isHandleableBy: aDebugger [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Exception >> isNested [
 	"Determine whether the current exception handler is within the scope of another handler for the same exception."
 
 	^ handlerContext nextHandlerContext canHandleSignal: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Exception >> isResumable [
 	"Determine whether an exception is resumable."
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Exception >> messageText [
 	"Return an exception's message text."
 
 	^ messageText ifNil: [ String empty ]
 ]
 
-{ #category : #signaling }
+{ #category : 'signaling' }
 Exception >> messageText: signalerText [
 	"Set an exception's message text."
 
 	messageText := signalerText
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Exception >> originException [
 	^ self
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 Exception >> outer [
 	"Evaluate the enclosing exception action and return to here instead of signal if it resumes (see #resumeUnchecked:)."
 	| prevOuterContext currentHandler |
@@ -234,7 +236,7 @@ Exception >> outer [
 	[self pass] ensure: [handlerContext := currentHandler]
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 Exception >> pass [
 	"Yield control to the enclosing exception action for the receiver."
 
@@ -244,50 +246,50 @@ Exception >> pass [
 	nextHandler handleSignal: self
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Exception >> printOn: stream [
 
 	stream nextPutAll: self description
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Exception >> privHandlerContext [
 
 	^handlerContext
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Exception >> privHandlerContext: aContextTag [
 
 	handlerContext := aContextTag
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 Exception >> raiseUnhandledError [
 	"No one has handled this error, but now give them a chance to decide how to debug it.  If none handle this either then open debugger (see UnhandedError>>#defaultAction)"
 
 	^ UnhandledError signalForException: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Exception >> receiver [
 	^ self signalerContext receiver
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 Exception >> resignalAs: replacementException [
 	"Signal an alternative exception in place of the receiver."
 	signalContext resumeEvaluating: [replacementException signal]
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 Exception >> resume [
 	"Return from the message that signaled the receiver."
 
 	self resume: self defaultResumeValue
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 Exception >> resume: resumptionValue [
 	"Return resumptionValue as the value of the signal message."
 
@@ -295,7 +297,7 @@ Exception >> resume: resumptionValue [
 	self resumeUnchecked: resumptionValue
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 Exception >> resumeUnchecked: resumptionValue [
 	"Return resumptionValue as the value of #signal, unless this was called after an #outer message, then return resumptionValue as the value of #outer."
 
@@ -309,28 +311,28 @@ Exception >> resumeUnchecked: resumptionValue [
 			ctxt return: resumptionValue ]
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 Exception >> return [
 	"Return nil as the value of the block protected by the active exception handler."
 
 	self return: self defaultReturnValue
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 Exception >> return: returnValue [
 	"Return the argument as the value of the block protected by the active exception handler."
 
 	handlerContext return: returnValue
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 Exception >> searchFrom: aContext [
 	"Set the context where the handler search will start. "
 
 	signalContext := aContext contextTag
 ]
 
-{ #category : #signaling }
+{ #category : 'signaling' }
 Exception >> signal [
 	"Ask ContextHandlers in the sender chain to handle this signal.  The default is to execute and return my defaultAction."
 	<debuggerCompleteToSender>
@@ -339,7 +341,7 @@ Exception >> signal [
 	^ signalContext nextHandlerContext handleSignal: self
 ]
 
-{ #category : #signaling }
+{ #category : 'signaling' }
 Exception >> signal: signalerText [
 	"Signal the occurrence of an exceptional condition with a specified textual description."
 
@@ -347,7 +349,7 @@ Exception >> signal: signalerText [
 	^ self signal
 ]
 
-{ #category : #signaling }
+{ #category : 'signaling' }
 Exception >> signalIn: context [
 	"Ask ContextHandlers in the sender chain starting at the given context to handle this signal.
 	The default is to execute and return my defaultAction."
@@ -357,7 +359,7 @@ Exception >> signalIn: context [
 	^ signalContext nextHandlerContext handleSignal: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Exception >> signaler [
 	"Return the object that is the subject involving me.
 	This is set automatically to my #receiver during #signal
@@ -366,7 +368,7 @@ Exception >> signaler [
 	^ signaler
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Exception >> signaler: anObject [
 	"Set the object that is the subject involving me.
 	This is set automatically to my #receiver during #signal
@@ -375,7 +377,7 @@ Exception >> signaler: anObject [
 	signaler := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Exception >> signalerContext [
 	"Find the first sender of signal(:), the first context which is neither for an instance method nor for a class side method of Exception (or subclass).
 	This will make sure that the same context is found for both, `Error signal` and `Error new signal`"
@@ -385,7 +387,7 @@ Exception >> signalerContext [
 		or: [ context receiver == self class ]) not ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Exception >> tag [
 	"Return an exception's tag value."
 
@@ -394,14 +396,14 @@ Exception >> tag [
 		ifNotNil: [ tag ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Exception >> tag: t [
 	"This message is not specified in the ANSI protocol, but that looks like an oversight because #tag is specified, and the spec states that the signaler may store the tag value."
 
 	tag := t
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 Exception >> unhandledErrorAction [
 	"No one has handled this error, then I gave them a chance to decide how to debug it and I raise an UnhandledError. But it was not handled by anybody so that we are here (see nhandedError-defaultAction).
 	It is the final action an exception can do which is normally a debugger in interactive image"

--- a/src/Kernel/ExceptionSet.class.st
+++ b/src/Kernel/ExceptionSet.class.st
@@ -2,22 +2,24 @@
 An ExceptionSet is a grouping of exception handlers which acts as a single handler.  Within the group, the most recently added handler will be the last handler found during a handler search (in the case where more than one handler in the group is capable of handling a given exception). 
 "
 Class {
-	#name : #ExceptionSet,
-	#superclass : #Object,
+	#name : 'ExceptionSet',
+	#superclass : 'Object',
 	#instVars : [
 		'exceptions'
 	],
-	#category : #'Kernel-Exceptions'
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #exceptionselector }
+{ #category : 'exceptionselector' }
 ExceptionSet >> , anException [
 	"Return an exception set that contains the receiver and the argument exception. This is commonly used to specify a set of exception selectors for an exception handler."
 
 	self add: anException
 ]
 
-{ #category : #exceptionselector }
+{ #category : 'exceptionselector' }
 ExceptionSet >> - anotherException [
 	"Create an exception set containnig the receiver
 	and anotherException as an exclusion."
@@ -28,21 +30,21 @@ ExceptionSet >> - anotherException [
 		yourself
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ExceptionSet >> add: anException [
 	"Add anException to the exceptions that I handle"
 
 	^ exceptions add: anException
 ]
 
-{ #category : #exceptionselector }
+{ #category : 'exceptionselector' }
 ExceptionSet >> handles: anException [
 	"Determine whether an exception handler will accept a signaled exception."
 
 	^ exceptions anySatisfy: [ :exception | exception handles: anException ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ExceptionSet >> initialize [
 
 	super initialize.

--- a/src/Kernel/ExceptionSetWithExclusions.class.st
+++ b/src/Kernel/ExceptionSetWithExclusions.class.st
@@ -2,15 +2,17 @@
 I am ExceptionSetWithExclusions, an ExceptionSet that explicitely does not handle a number of exclusion Exceptions.
 "
 Class {
-	#name : #ExceptionSetWithExclusions,
-	#superclass : #ExceptionSet,
+	#name : 'ExceptionSetWithExclusions',
+	#superclass : 'ExceptionSet',
 	#instVars : [
 		'exclusions'
 	],
-	#category : #'Kernel-Exceptions'
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #exceptionselector }
+{ #category : 'exceptionselector' }
 ExceptionSetWithExclusions >> - exception [
 	"Add exception as an exclusion to me.
 	I will explicitly not handle my exclusion exceptions."
@@ -18,7 +20,7 @@ ExceptionSetWithExclusions >> - exception [
 	self addExclusion: exception
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ExceptionSetWithExclusions >> addExclusion: exception [
 	"Add exception as an exclusion to me.
 	I will explicitly not handle my exclusion exceptions."
@@ -26,7 +28,7 @@ ExceptionSetWithExclusions >> addExclusion: exception [
 	^ exclusions add: exception
 ]
 
-{ #category : #exceptionselector }
+{ #category : 'exceptionselector' }
 ExceptionSetWithExclusions >> handles: exception [
 	"Return true when I will handled exception.
 	I extend my superclass behavior by explicitly
@@ -36,7 +38,7 @@ ExceptionSetWithExclusions >> handles: exception [
 			and: [ exclusions noneSatisfy: [ :each | each handles: exception ] ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ExceptionSetWithExclusions >> initialize [
 
 	super initialize.

--- a/src/Kernel/ExecutionEnvironment.class.st
+++ b/src/Kernel/ExecutionEnvironment.class.st
@@ -10,35 +10,37 @@ Tools could define specific environment to provide specific hooks for code execu
 For example SUnit installs special TestExecutionEnvironment to manage all forked processes during test
 "
 Class {
-	#name : #ExecutionEnvironment,
-	#superclass : #Object,
-	#category : #'Kernel-Processes'
+	#name : 'ExecutionEnvironment',
+	#superclass : 'Object',
+	#category : 'Kernel-Processes',
+	#package : 'Kernel',
+	#tag : 'Processes'
 }
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 ExecutionEnvironment >> activated [
 	"Method is called just after installation as current environment.
 	Any preparation logic could be here"
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 ExecutionEnvironment >> beActiveDuring: aBlock [
 
 	CurrentExecutionEnvironment activate: self for: aBlock
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 ExecutionEnvironment >> deactivated [
 	"Method is called just after uninstallation when current environment become different.
 	Any cleanup logic could be here"
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ExecutionEnvironment >> isTest [
 	^false
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 ExecutionEnvironment >> prepareForNewProcess: aProcess [
 	self subclassResponsibility
 ]

--- a/src/Kernel/ExtensionPointsOwningPackageNotification.class.st
+++ b/src/Kernel/ExtensionPointsOwningPackageNotification.class.st
@@ -2,15 +2,17 @@
 I am a warning that is raised in the case the user try to make a method an extension method contained in the package containing the class. This should not happen because it would cause some incoherences in the system.
 "
 Class {
-	#name : #ExtensionPointsOwningPackageNotification,
-	#superclass : #SystemNotification,
+	#name : 'ExtensionPointsOwningPackageNotification',
+	#superclass : 'SystemNotification',
 	#instVars : [
 		'packageName'
 	],
-	#category : #'Kernel-Exceptions'
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #signalling }
+{ #category : 'signalling' }
 ExtensionPointsOwningPackageNotification class >> signalFor: aPackageName [
 
 	^ self new
@@ -18,7 +20,7 @@ ExtensionPointsOwningPackageNotification class >> signalFor: aPackageName [
 		  signal
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ExtensionPointsOwningPackageNotification >> messageText [
 
 	^ messageText ifNil: [
@@ -26,13 +28,13 @@ ExtensionPointsOwningPackageNotification >> messageText [
 		  , '" while the class containing the method is already in this package. The creation of this protocol will be aborted.' ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ExtensionPointsOwningPackageNotification >> packageName [
 
 	^ packageName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ExtensionPointsOwningPackageNotification >> packageName: anObject [
 
 	packageName := anObject

--- a/src/Kernel/False.class.st
+++ b/src/Kernel/False.class.st
@@ -4,12 +4,14 @@ False defines the behavior of its single instance, false -- logical negation. No
 Be aware however that most of these methods are not sent as real messages in normal use. Most are inline coded by the compiler as test and jump bytecodes - avoiding the overhead of the full message sends. So simply redefining these methods here will have no effect.
 "
 Class {
-	#name : #False,
-	#superclass : #Boolean,
-	#category : #'Kernel-Objects'
+	#name : 'False',
+	#superclass : 'Boolean',
+	#category : 'Kernel-Objects',
+	#package : 'Kernel',
+	#tag : 'Objects'
 }
 
-{ #category : #'logical operations' }
+{ #category : 'logical operations' }
 False >> & aBoolean [
 	"Evaluating conjunction -- answer false since receiver is false."
 	"false & true >>> false"
@@ -18,7 +20,7 @@ False >> & aBoolean [
 	^self
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 False >> and: alternativeBlock [
 	"Nonevaluating conjunction -- answer with false since the receiver is false."
 	"(false and: [true]) >>> false"
@@ -27,7 +29,7 @@ False >> and: alternativeBlock [
 	^self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 False >> asBit [
 	"Answer 0 since the receiver is false."
 	"false asBit >>> 0"
@@ -35,7 +37,7 @@ False >> asBit [
 	^ 0
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 False >> ifFalse: alternativeBlock [
 	"Answer the value of alternativeBlock. Execution does not actually
 	reach here because the expression is compiled in-line."
@@ -44,7 +46,7 @@ False >> ifFalse: alternativeBlock [
 	^alternativeBlock value
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 False >> ifFalse: falseAlternativeBlock ifTrue: trueAlternativeBlock [
 	"Answer the value of falseAlternativeBlock. Execution does not
 	actually reach here because the expression is compiled in-line."
@@ -53,7 +55,7 @@ False >> ifFalse: falseAlternativeBlock ifTrue: trueAlternativeBlock [
 	^falseAlternativeBlock value
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 False >> ifTrue: alternativeBlock [
 	"Since the condition is false, answer the value of the false alternative,
 	which is nil. Execution does not actually reach here because the
@@ -63,7 +65,7 @@ False >> ifTrue: alternativeBlock [
 	^nil
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 False >> ifTrue: trueAlternativeBlock ifFalse: falseAlternativeBlock [
 	"Answer the value of falseAlternativeBlock. Execution does not
 	actually reach here because the expression is compiled in-line."
@@ -72,7 +74,7 @@ False >> ifTrue: trueAlternativeBlock ifFalse: falseAlternativeBlock [
 	^falseAlternativeBlock value
 ]
 
-{ #category : #'logical operations' }
+{ #category : 'logical operations' }
 False >> not [
 	"Negation -- answer true since the receiver is false."
 	"false not >>> true"
@@ -80,7 +82,7 @@ False >> not [
 	^true
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 False >> or: alternativeBlock [
 	"Nonevaluating disjunction -- answer value of alternativeBlock."
 	"(false or: [true]) >>> true"
@@ -89,13 +91,13 @@ False >> or: alternativeBlock [
 	^alternativeBlock value
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 False >> printOn: aStream [
 
 	aStream nextPutAll: 'false'
 ]
 
-{ #category : #'logical operations' }
+{ #category : 'logical operations' }
 False >> xor: alternativeBlock [
 	"Answer the value of the alternativeBlock since the receiver is false."
 	"(false xor: [true]) >>> true"
@@ -104,7 +106,7 @@ False >> xor: alternativeBlock [
 	^ alternativeBlock value
 ]
 
-{ #category : #'logical operations' }
+{ #category : 'logical operations' }
 False >> | aBoolean [
 	"Evaluating disjunction (OR) -- answer with the argument, aBoolean, since the receiver is false."
 	"false | true >>> true"

--- a/src/Kernel/FixedLayout.class.st
+++ b/src/Kernel/FixedLayout.class.st
@@ -5,26 +5,28 @@ I contain a fixed number of Slots.
 Instances of classes using this kind of layout have always the same size.
 "
 Class {
-	#name : #FixedLayout,
-	#superclass : #PointerLayout,
-	#category : #'Kernel-Layout'
+	#name : 'FixedLayout',
+	#superclass : 'PointerLayout',
+	#category : 'Kernel-Layout',
+	#package : 'Kernel',
+	#tag : 'Layout'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 FixedLayout class >> extending: superLayout scope: aScope host: aClass [
 	^ (superLayout extend: aScope)
 		host: aClass;
 		yourself
 ]
 
-{ #category : #format }
+{ #category : 'format' }
 FixedLayout >> instanceSpecification [
 	^ self hasFields
 		ifTrue: [ 1 ]
 		ifFalse: [ 0 ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 FixedLayout >> isFixedLayout [
 	^true
 ]

--- a/src/Kernel/Float.class.st
+++ b/src/Kernel/Float.class.st
@@ -31,8 +31,8 @@ This format is used in FloatArray (qv), and much can be learned from the convers
 Thanks to Rich Harmon for asking many questions and to Tim Olson, Bruce Cohen, Rick Zaccone and others for the answers that I have collected here.
 "
 Class {
-	#name : #Float,
-	#superclass : #Number,
+	#name : 'Float',
+	#superclass : 'Number',
 	#classVars : [
 		'DefaultComparisonPrecision',
 		'E',
@@ -53,54 +53,56 @@ Class {
 		'ThreePi',
 		'Twopi'
 	],
-	#category : #'Kernel-Numbers'
+	#category : 'Kernel-Numbers',
+	#package : 'Kernel',
+	#tag : 'Numbers'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Float class >> basicNew [
 	^BoxedFloat64 basicNew: 2
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Float class >> basicNew: anInteger [
 	^BoxedFloat64 basicNew: 2
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 Float class >> defaultComparisonPrecision [
 
 	^ DefaultComparisonPrecision
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 Float class >> denormalized [
 	"Answer whether implementation supports denormalized numbers (also known as gradual underflow)."
 
 	^true
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 Float class >> e [
 	"Answer the constant, E."
 
 	^E
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 Float class >> emax [
 	"Answer exponent of maximal representable value"
 
 	^1023
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 Float class >> emin [
 	"Answer exponent of minimal normalized representable value"
 
 	^-1022
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Float class >> fromIEEE32Bit: word [
 	"Convert the given 32 bit word (which is supposed to be a positive 32-bit value) from
 	 a 32 bit IEEE floating point representation into an actual float object (being
@@ -140,13 +142,13 @@ Float class >> fromIEEE32Bit: word [
 		* 1.0 "reduce to SmallFloat64 if possible"
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Float class >> fromIEEE64Bit: doubleWord [
 
     ^ (self new: 2) basicAt: 1 put: (doubleWord bitShift: -32); basicAt: 2 put: (doubleWord bitAnd: 16rFFFFFFFF); yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Float class >> fromIEEE64BitWord: anInteger [
 	"Convert the given 64 bit word from a 64 bit IEEE floating point representation
 	into an actual float object.
@@ -162,19 +164,19 @@ Float class >> fromIEEE64BitWord: anInteger [
 		ifFalse: [value]
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 Float class >> halfPi [
 	^ Halfpi
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 Float class >> infinity [
 	"Answer the value used to represent an infinite magnitude"
 
 	^ Infinity
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 Float class >> initialize [
 	"Float initialize"
 	"Constants from Computer Approximations, pp. 182-183:
@@ -213,7 +215,7 @@ Float class >> initialize [
 	NegativeZero := 1.0 / Infinity negated
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 Float class >> machineEpsilon [
 	"Answer the machine epsilon or macheps, defined by wikipedia (https://en.wikipedia.org/wiki/Machine_epsilon) as:
 
@@ -224,46 +226,46 @@ Float class >> machineEpsilon [
 	^1.0 timesTwoPower: 1 - self precision
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 Float class >> maxExactInteger [
 	"Answer the biggest integer such that it is exactly represented in a float, and all smaller integers also are"
 	^1 bitShift: self precision
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 Float class >> nan [
 	"Answer the canonical value used to represent Not-A-Number"
 
 	^ NaN
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 Float class >> negativeInfinity [
 	"Answer the value used to represent a negative infinite magnitude"
 
 	^ NegativeInfinity
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 Float class >> negativeZero [
 
 	^ NegativeZero
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 Float class >> one [
 
 	^1.0
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 Float class >> pi [
 	"Answer the constant, Pi."
 
 	^Pi
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 Float class >> precision [
 	"Answer the apparent precision of the floating point representation.
 	That is the maximum number of radix-based digits (bits if radix=2) representable in floating point without round off error.
@@ -274,45 +276,45 @@ Float class >> precision [
 	^53
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 Float class >> radix [
 	"Answer the radix used for internal floating point representation."
 
 	^2
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Float class >> readFrom: aStream [
 	"Answer a new Float as described on the stream, aStream."
 
 	^(super readFrom: aStream) asFloat
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Float class >> readFrom: aStream ifFail: aBlock [
 	"Answer a new Float as described on the stream, aStream."
 
 	^(super readFrom: aStream ifFail: [^aBlock value]) asFloat
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 Float class >> threePi [
 
 	^ ThreePi
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 Float class >> twoPi [
 
 	^ Twopi
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 Float class >> zero [
 	^ 0.0
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Float >> abs [
 	"This is faster than using Number abs and works for negativeZero."
 	^ self <= 0.0
@@ -320,7 +322,7 @@ Float >> abs [
 		ifFalse: [self]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Float >> absPrintExactlyOn: aStream base: base [
 	"Print my value on a stream in the given base.  Assumes that my value is strictly
 	positive; negative numbers, zero, NaNs and infinite numbers have already been handled elsewhere.
@@ -405,7 +407,7 @@ Float >> absPrintExactlyOn: aStream base: base [
 		aStream nextPutAll: (baseExpEstimate - 1) printString]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Float >> absPrintInexactlyOn: aStream base: base [
 	"Print my value on a stream in the given base.  Assumes that my value is strictly
 	positive; negative numbers, zero, NaNs and infinite numbers have already been handled elsewhere.
@@ -489,7 +491,7 @@ Float >> absPrintInexactlyOn: aStream base: base [
 		aStream nextPutAll: (baseExpEstimate - 1) printString]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Float >> absPrintOn: aStream base: base digitCount: digitCount [
 	"Print me in the given base, using digitCount significant figures."
 
@@ -543,7 +545,7 @@ at: i)]]]
 			q printOn: aStream]
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Float >> adaptToFraction: rcvr andCompare: selector [
 	"If I am involved in comparison with a Fraction, convert myself to a
 	Fraction. This way, no bit is lost and comparison is exact."
@@ -568,13 +570,13 @@ Float >> adaptToFraction: rcvr andCompare: selector [
 	^ rcvr perform: selector with: self asTrueFraction
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Float >> adaptToFraction: rcvr andSend: selector [
 	"If I am involved in arithmetic with a Fraction, convert it to a Float."
 	^ rcvr asFloat perform: selector with: self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Float >> adaptToInteger: rcvr andCompare: selector [
 	"If I am involved in comparison with an Integer, convert myself to a
 	Fraction. This way, no bit is lost and comparison is exact."
@@ -599,13 +601,13 @@ Float >> adaptToInteger: rcvr andCompare: selector [
 	^ rcvr perform: selector with: self asTrueFraction
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Float >> adaptToInteger: rcvr andSend: selector [
 	"If I am involved in arithmetic with an Integer, convert it to a Float."
 	^ rcvr asFloat perform: selector with: self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Float >> asApproximateFraction [
 	"Answer a Fraction approximating the receiver. This conversion uses the
 	continued fraction method to approximate a floating point number."
@@ -613,7 +615,7 @@ Float >> asApproximateFraction [
 	^ self asApproximateFractionAtOrder: 0
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Float >> asApproximateFractionAtOrder: maxOrder [
 	"Answer a Fraction approximating the receiver. This conversion uses the
 	continued fraction method to approximate a floating point number. If maxOrder
@@ -656,19 +658,19 @@ Float >> asApproximateFractionAtOrder: maxOrder [
 				Fraction numerator: num1 denominator: denom1]
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Float >> asFloat [
 	"Answer the receiver itself."
 
 	^self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Float >> asFraction [
 	^ self asTrueFraction
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Float >> asMinimalDecimalFraction [
 	"Answer the shortest decimal Fraction that will equal self when converted back asFloat.
 	A decimal Fraction has only powers of 2 and 5 as decnominator.
@@ -754,7 +756,7 @@ Float >> asMinimalDecimalFraction [
 	^numerator / denominator
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Float >> asScaledDecimal [
 
 	"Answer a scaled decimal number approximating the receiver.
@@ -768,7 +770,7 @@ Float >> asScaledDecimal [
 	^ self asScaledDecimal: 14
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Float >> asTrueFraction [
 	" Answer a fraction that EXACTLY represents self,
 	  a double precision IEEE floating point number.
@@ -828,17 +830,17 @@ exp) ] ].
 	^ result
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Float >> at: index [
 	^self basicAt: index
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Float >> at: index put: value [
 	^self basicAt: index put: value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Float >> basicAt: index [
 	"Primitive. Assumes receiver is indexable. Answer the value of an
 	indexable element in the receiver. Fail if the argument index is not an
@@ -854,7 +856,7 @@ Float >> basicAt: index [
 	^super basicAt: index
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Float >> basicAt: index put: value [
 	"Primitive. Assumes receiver is indexable. Store the second argument
 	value in the indexable element of the receiver indicated by index. Fail
@@ -872,24 +874,24 @@ Float >> basicAt: index put: value [
 	^super basicAt: index put: value
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Float >> binaryLiteralString [
 
 	^ String streamContents: [ :stream | self printBinaryLiteralOn: stream ]
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Float >> deepCopy [
 
 	^self copy
 ]
 
-{ #category : #'mathematical functions' }
+{ #category : 'mathematical functions' }
 Float >> exponent [
 	^ self subclassResponsibility
 ]
 
-{ #category : #'mathematical functions' }
+{ #category : 'mathematical functions' }
 Float >> floorLog: radix [
 	"Answer the floor of the log base radix of the receiver.
 	The result may be off by one due to rounding errors, except in base 2."
@@ -898,7 +900,7 @@ Float >> floorLog: radix [
 	^ (self log: radix) floor
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Float >> hash [
 	"Hash is reimplemented because = is implemented. Both words of the float are used; 8 bits are removed from each end to clear most of the exponent regardless of the byte ordering. (The bitAnd:'s ensure that the intermediate results do not become a large integer.) Slower than the original version in the ratios 12:5 to 2:1 depending on values. (DNS, 11 May, 1997)"
 
@@ -907,7 +909,7 @@ Float >> hash [
 	   ((self basicAt: 2) bitAnd: 16r00FFFF00)) bitShift: -8
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Float >> hex [
 
 	^ String streamContents:
@@ -922,26 +924,26 @@ Float >> hex [
 "
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Float >> isFinite [
 	"simple, byte-order independent test for rejecting Not-a-Number and (Negative)Infinity"
 
 	^(self - self) = 0.0
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Float >> isFloat [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Float >> isInfinite [
 	"Return true if the receiver is positive or negative infinity."
 
 	^ self = Infinity or: [self = NegativeInfinity]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Float >> isLiteral [
 	"There is no literal representation of NaN.
 	However, there are literal representations of Infinity, like 1.0e1000.
@@ -950,37 +952,37 @@ Float >> isLiteral [
 	^self isFinite
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Float >> isNaN [
 	"simple, byte-order independent test for Not-a-Number"
 
 	^ self ~= self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Float >> isPowerOfTwo [
 	"Return true if the receiver is an integral power of two.
 	Floats never return true here."
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Float >> isSelfEvaluating [
     ^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Float >> isZero [
 	^self = 0.0
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Float >> literalEqual: other [
 
 	^ (super literalEqual: other) and: [ self isZero not or: [ self signBit = other signBit ] ]
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Float >> negated [
 	"Answer a Number that is the negation of the receiver.
 	Implementation note: this version cares of negativeZero."
@@ -988,7 +990,7 @@ Float >> negated [
 	^-1.0 * self
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Float >> printBinaryLiteralOn: stream [
 
 	"Floats represent those numbers that can be written in Pharo notation as literals of the form {sign}2r1.{fraction}e{exponent} -- where {sign} is the minus
@@ -1032,7 +1034,7 @@ Float >> printBinaryLiteralOn: stream [
 	(exponentBits - 1023) printOn: stream base: 10
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Float >> printOn: stream base: base [
 	"Handle sign, zero, and NaNs; all other values passed to FloatPrintPolicy"
 
@@ -1050,7 +1052,7 @@ Float >> printOn: stream base: base [
 				ifFalse: [ FloatPrintPolicy absPrint: self negated on: stream base: base ] ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Float >> printPaddedWith: aCharacter to: aNumber [
 	"Answer the string containing the ASCII representation of the receiver
 	padded on the left with aCharacter to be at least on aNumber
@@ -1082,14 +1084,14 @@ Float >> printPaddedWith: aCharacter to: aNumber [
 	^ iPadding , digits , fPadding
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Float >> printShowingDecimalPlaces: placesDesired [
 	"This implementation avoids any rounding error caused by rounded or roundTo:"
 
 	^self asTrueFraction printShowingDecimalPlaces: placesDesired
 ]
 
-{ #category : #'mathematical functions' }
+{ #category : 'mathematical functions' }
 Float >> reciprocalFloorLog: radix [
 	"Quick computation of (self log: radix) floor, when self < 1.0.
 	Avoids infinite recursion problems with denormalized numbers"
@@ -1104,7 +1106,7 @@ Float >> reciprocalFloorLog: radix [
 	^ ((n floorLog: radix) + adjust) negated
 ]
 
-{ #category : #'mathematical functions' }
+{ #category : 'mathematical functions' }
 Float >> reciprocalLogBase2 [
 	"optimized for self = 10, for use in conversion for printing"
 
@@ -1113,13 +1115,13 @@ Float >> reciprocalLogBase2 [
 		ifFalse: [Ln2 / self ln]
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Float >> shallowCopy [
 
 	^self - 0.0
 ]
 
-{ #category : #'mathematical functions' }
+{ #category : 'mathematical functions' }
 Float >> signBit [
 	"Answer 1 if the receiver has sign bit set (including case of IEEE-754 negative-zero).
 	Answer 0 otherwise"
@@ -1127,13 +1129,13 @@ Float >> signBit [
 	^((self at: 1) bitShift: -31)
 ]
 
-{ #category : #'mathematical functions' }
+{ #category : 'mathematical functions' }
 Float >> significand [
 
 	^ self timesTwoPower: (self exponent negated)
 ]
 
-{ #category : #'mathematical functions' }
+{ #category : 'mathematical functions' }
 Float >> significandAsInteger [
 	"Answer the mantissa of a Float shifted so as to have the ulp equal to 1.
 	For exceptional values, infinity and nan, just answer the bit pattern."
@@ -1143,14 +1145,14 @@ Float >> significandAsInteger [
 	^(((self basicAt: 1) bitAnd: 16r000FFFFF) bitShift: 32) bitOr: (self basicAt: 2)
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Float >> storeOn: aStream [
 	"Print the Number exactly so it can be interpreted back unchanged"
 
 	self storeOn: aStream base: 10
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Float >> storeOn: aStream base: base [
 	"Print the Number exactly so it can be interpreted back unchanged"
 	self isFinite
@@ -1166,12 +1168,12 @@ Float >> storeOn: aStream base: base [
 						ifFalse: [aStream nextPutAll: 'Float infinity negated']]]
 ]
 
-{ #category : #'mathematical functions' }
+{ #category : 'mathematical functions' }
 Float >> timesTwoPower: anInteger [
 	^ self subclassResponsibility
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Float >> veryDeepCopyWith: deepCopier [
 	"Return self.  Do not record me."
 

--- a/src/Kernel/FloatPrintPolicy.class.st
+++ b/src/Kernel/FloatPrintPolicy.class.st
@@ -11,27 +11,29 @@ FloatPrintPolicy
 	during: [ Float pi printString ]
 "
 Class {
-	#name : #FloatPrintPolicy,
-	#superclass : #DynamicVariable,
+	#name : 'FloatPrintPolicy',
+	#superclass : 'DynamicVariable',
 	#instVars : [
 		'default'
 	],
-	#category : #'Kernel-Numbers'
+	#category : 'Kernel-Numbers',
+	#package : 'Kernel',
+	#tag : 'Numbers'
 }
 
-{ #category : #printing }
+{ #category : 'printing' }
 FloatPrintPolicy class >> absPrint: float on: stream base: base [
 	"I delegate Float printing to the current dynamic value of myself"
 
 	self value absPrint: float on: stream base: base
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FloatPrintPolicy >> default [
 	^ default
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 FloatPrintPolicy >> initialize [
 	default := ExactFloatPrintPolicy new
 ]

--- a/src/Kernel/FluidClassDefinitionPrinter.class.st
+++ b/src/Kernel/FluidClassDefinitionPrinter.class.st
@@ -30,12 +30,14 @@ ClassDefinitionPrinter displayEmptySlots: true
 
 "
 Class {
-	#name : #FluidClassDefinitionPrinter,
-	#superclass : #ClassDefinitionPrinter,
-	#category : #'Kernel-ClassDefinitionPrinter'
+	#name : 'FluidClassDefinitionPrinter',
+	#superclass : 'ClassDefinitionPrinter',
+	#category : 'Kernel-ClassDefinitionPrinter',
+	#package : 'Kernel',
+	#tag : 'ClassDefinitionPrinter'
 }
 
-{ #category : #'definition double dispatch API' }
+{ #category : 'definition double dispatch API' }
 FluidClassDefinitionPrinter >> classDefinitionString [
 
 	"Next step
@@ -62,7 +64,7 @@ FluidClassDefinitionPrinter >> classDefinitionString [
 		  self packageOn: s ]
 ]
 
-{ #category : #template }
+{ #category : 'template' }
 FluidClassDefinitionPrinter >> classDefinitionTemplateInPackage: aPackageName named: aClassName [
 
 		^ String streamContents: [ :s |
@@ -76,7 +78,7 @@ FluidClassDefinitionPrinter >> classDefinitionTemplateInPackage: aPackageName na
 						s nextPutAll: 'package: '''; nextPutAll: aPackageName; nextPutAll: '''' ]
 ]
 
-{ #category : #'elementary operations' }
+{ #category : 'elementary operations' }
 FluidClassDefinitionPrinter >> classVariableDefinitionsOn: aStream [
 	"Answer a string that evaluates to the definition of the class Variables"
 
@@ -96,7 +98,7 @@ FluidClassDefinitionPrinter >> classVariableDefinitionsOn: aStream [
 		aStream nextPutAll: '}'. ]
 ]
 
-{ #category : #template }
+{ #category : 'template' }
 FluidClassDefinitionPrinter >> compactClassDefinitionTemplateInPackage: aPackageName [
 	^ String streamContents: [ :s |
 			s nextPutAll: 'Object << #MyClass'; crtab.
@@ -105,7 +107,7 @@ FluidClassDefinitionPrinter >> compactClassDefinitionTemplateInPackage: aPackage
 			s nextPutAll: 'package: ''', aPackageName, '''' ]
 ]
 
-{ #category : #template }
+{ #category : 'template' }
 FluidClassDefinitionPrinter >> compactTraitDefinitionTemplateInPackage: aPackageName [
 
 	^ String streamContents: [ :s |
@@ -118,7 +120,7 @@ FluidClassDefinitionPrinter >> compactTraitDefinitionTemplateInPackage: aPackage
 			  nextPutAll: '''' ]
 ]
 
-{ #category : #'expanded double dispatch API' }
+{ #category : 'expanded double dispatch API' }
 FluidClassDefinitionPrinter >> expandedDefinitionString [
 
 	^ String streamContents: [ :s | "in case of ProtoObject"
@@ -152,7 +154,7 @@ FluidClassDefinitionPrinter >> expandedDefinitionString [
 		  self packageOn: s ]
 ]
 
-{ #category : #'expanded double dispatch API' }
+{ #category : 'expanded double dispatch API' }
 FluidClassDefinitionPrinter >> expandedMetaclassDefinitionString [
 
 	^ String streamContents: [ :s |
@@ -178,7 +180,7 @@ FluidClassDefinitionPrinter >> expandedMetaclassDefinitionString [
 		  self slotDefinitionsOn: s ]
 ]
 
-{ #category : #'expanded double dispatch API' }
+{ #category : 'expanded double dispatch API' }
 FluidClassDefinitionPrinter >> expandedTraitClassDefinitionString [
 
 	^ String streamContents: [ :s |
@@ -199,7 +201,7 @@ FluidClassDefinitionPrinter >> expandedTraitClassDefinitionString [
 		  self slotDefinitionsOn: s ]
 ]
 
-{ #category : #'expanded double dispatch API' }
+{ #category : 'expanded double dispatch API' }
 FluidClassDefinitionPrinter >> expandedTraitDefinitionString [
 
 	^ String streamContents: [ :s |
@@ -232,7 +234,7 @@ FluidClassDefinitionPrinter >> expandedTraitDefinitionString [
 					nextPutAll: '''' ]
 ]
 
-{ #category : #'definition double dispatch API' }
+{ #category : 'definition double dispatch API' }
 FluidClassDefinitionPrinter >> expandedTraitedMetaclassDefinitionString [
 
 	^ String streamContents:
@@ -245,7 +247,7 @@ FluidClassDefinitionPrinter >> expandedTraitedMetaclassDefinitionString [
 		self lastSlotsOn: strm]
 ]
 
-{ #category : #'elementary operations' }
+{ #category : 'elementary operations' }
 FluidClassDefinitionPrinter >> lastSlotsOn: s [
 
 	s crtab.
@@ -253,7 +255,7 @@ FluidClassDefinitionPrinter >> lastSlotsOn: s [
 	self slotDefinitionsOn: s
 ]
 
-{ #category : #'elementary operations' }
+{ #category : 'elementary operations' }
 FluidClassDefinitionPrinter >> lastTraitsOn: strm [
 	"uses: can the last part of a definition so watch out for terminating ;"
 
@@ -266,7 +268,7 @@ FluidClassDefinitionPrinter >> lastTraitsOn: strm [
 	forClass slots	ifNotEmpty: [ strm nextPutAll: ';' ] ]
 ]
 
-{ #category : #'elementary operations' }
+{ #category : 'elementary operations' }
 FluidClassDefinitionPrinter >> layoutOn: s [
 	"Layout is always followed by other message ultimately package: so it terminates with ;"
 	s
@@ -276,7 +278,7 @@ FluidClassDefinitionPrinter >> layoutOn: s [
 		nextPutAll: ';'
 ]
 
-{ #category : #'definition double dispatch API' }
+{ #category : 'definition double dispatch API' }
 FluidClassDefinitionPrinter >> metaclassDefinitionString [
 
 	^ String streamContents: [ :strm |
@@ -297,7 +299,7 @@ FluidClassDefinitionPrinter >> metaclassDefinitionString [
 		  		ifFalse: [forClass slots ifNotEmpty: [ self lastSlotsOn: strm ]]]
 ]
 
-{ #category : #'elementary operations' }
+{ #category : 'elementary operations' }
 FluidClassDefinitionPrinter >> msgAndClassNameOn: s [
 
 	s
@@ -305,7 +307,7 @@ FluidClassDefinitionPrinter >> msgAndClassNameOn: s [
 		nextPutAll: forClass name
 ]
 
-{ #category : #'elementary operations' }
+{ #category : 'elementary operations' }
 FluidClassDefinitionPrinter >> packageOn: s [
 	"The code to get the package name is not nice but it is possible we are asking the definition to a class that was uninstalled from the system and in that case it does not know its package anymore. And some code in the image expect to have the package of the class with the same name instead."
 
@@ -319,7 +321,7 @@ FluidClassDefinitionPrinter >> packageOn: s [
 		nextPut: $'
 ]
 
-{ #category : #'elementary operations' }
+{ #category : 'elementary operations' }
 FluidClassDefinitionPrinter >> sharedPoolsOn: s [
 	"shared pool message is always followed by other message ultimately package: so it terminates with ;"
 	s
@@ -335,7 +337,7 @@ FluidClassDefinitionPrinter >> sharedPoolsOn: s [
 		nextPutAll: '};'
 ]
 
-{ #category : #'elementary operations' }
+{ #category : 'elementary operations' }
 FluidClassDefinitionPrinter >> sharedVariablesOn: s [
 	"shared variable is always followed by other message ultimately package: so it terminates with ;"
 	s
@@ -346,14 +348,14 @@ FluidClassDefinitionPrinter >> sharedVariablesOn: s [
 		nextPutAll: ';'
 ]
 
-{ #category : #'elementary operations' }
+{ #category : 'elementary operations' }
 FluidClassDefinitionPrinter >> slotDefinitionString [
 	"Answer a string that represents an executable description of my Slots"
 
 	^String streamContents: [ :str | self slotDefinitionsOn: str]
 ]
 
-{ #category : #'elementary operations' }
+{ #category : 'elementary operations' }
 FluidClassDefinitionPrinter >> slotDefinitionsOn: aStream [
 	"If the class has many instance variable print one slot per line, do the same for complex slots."
 
@@ -379,7 +381,7 @@ FluidClassDefinitionPrinter >> slotDefinitionsOn: aStream [
 	aStream nextPutAll: '}'
 ]
 
-{ #category : #'elementary operations' }
+{ #category : 'elementary operations' }
 FluidClassDefinitionPrinter >> slotShiftOn: aStream [
 
 	aStream
@@ -389,7 +391,7 @@ FluidClassDefinitionPrinter >> slotShiftOn: aStream [
 		tab
 ]
 
-{ #category : #'elementary operations' }
+{ #category : 'elementary operations' }
 FluidClassDefinitionPrinter >> slotsOn: s [
 	"uses: can the last part of a definition so watch out for terminating ;"
 
@@ -397,7 +399,7 @@ FluidClassDefinitionPrinter >> slotsOn: s [
 	s nextPutAll: ';'
 ]
 
-{ #category : #'expanded double dispatch API' }
+{ #category : 'expanded double dispatch API' }
 FluidClassDefinitionPrinter >> tagOn: s [
 
 	| tag |
@@ -412,7 +414,7 @@ FluidClassDefinitionPrinter >> tagOn: s [
 				nextPutAll: ''';' ] ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 FluidClassDefinitionPrinter >> testClassDefinitionTemplateInPackage: aPackageName [
 
 		^ String streamContents: [ :s |
@@ -422,7 +424,7 @@ FluidClassDefinitionPrinter >> testClassDefinitionTemplateInPackage: aPackageNam
 						s nextPutAll: 'package: ''', aPackageName, '''' ]
 ]
 
-{ #category : #'definition double dispatch API' }
+{ #category : 'definition double dispatch API' }
 FluidClassDefinitionPrinter >> traitDefinitionString [
 
 	^ String streamContents: [ :strm |
@@ -435,7 +437,7 @@ FluidClassDefinitionPrinter >> traitDefinitionString [
 			self packageOn: strm ]
 ]
 
-{ #category : #template }
+{ #category : 'template' }
 FluidClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aPackageName named: aTraitName [
 
 	^ String streamContents: [ :s |
@@ -458,7 +460,7 @@ FluidClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aPackageName na
 			  nextPutAll: '''' ]
 ]
 
-{ #category : #'definition double dispatch API' }
+{ #category : 'definition double dispatch API' }
 FluidClassDefinitionPrinter >> traitedMetaclassDefinitionString [
 
 	^ String streamContents:
@@ -471,7 +473,7 @@ FluidClassDefinitionPrinter >> traitedMetaclassDefinitionString [
 		forClass slots ifNotEmpty: [ self lastSlotsOn: strm ]]
 ]
 
-{ #category : #'elementary operations' }
+{ #category : 'elementary operations' }
 FluidClassDefinitionPrinter >> traitsOn: strm [
 	"uses: can the last part of a definition so watch out for terminating ;"
 

--- a/src/Kernel/Fraction.class.st
+++ b/src/Kernel/Fraction.class.st
@@ -11,16 +11,18 @@ Examples: (note the parentheses required to get the right answers in Smalltalk a
 
 "
 Class {
-	#name : #Fraction,
-	#superclass : #Number,
+	#name : 'Fraction',
+	#superclass : 'Number',
 	#instVars : [
 		'numerator',
 		'denominator'
 	],
-	#category : #'Kernel-Numbers'
+	#category : 'Kernel-Numbers',
+	#package : 'Kernel',
+	#tag : 'Numbers'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Fraction class >> numerator: numInteger denominator: denInteger [
 	"Answer an instance of me (numInteger/denInteger).
 	NOTE: This primitive initialization method will not reduce improper fractions,
@@ -32,7 +34,7 @@ Fraction class >> numerator: numInteger denominator: denInteger [
 	^self new setNumerator: numInteger denominator: denInteger
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Fraction >> * aNumber [
 	"Answer the result of multiplying the receiver by aNumber."
 	| d1 d2 |
@@ -46,7 +48,7 @@ Fraction >> * aNumber [
 	^ aNumber adaptToFraction: self andSend: #*
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Fraction >> + aNumber [
 	"Answer the sum of the receiver and aNumber."
 	| n d d1 d2 |
@@ -62,7 +64,7 @@ Fraction >> + aNumber [
 	^ aNumber adaptToFraction: self andSend: #+
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Fraction >> - aNumber [
 	"Answer the difference between the receiver and aNumber."
 	aNumber isInteger ifTrue:
@@ -72,7 +74,7 @@ Fraction >> - aNumber [
 	^ aNumber adaptToFraction: self andSend: #-
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Fraction >> / aNumber [
 	"Answer the result of dividing the receiver by aNumber."
 	aNumber isFraction
@@ -80,21 +82,21 @@ Fraction >> / aNumber [
 	^ aNumber adaptToFraction: self andSend: #/
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Fraction >> < aNumber [
 	aNumber isFraction ifTrue:
 		[^ numerator * aNumber denominator < (aNumber numerator * denominator)].
 	^ aNumber adaptToFraction: self andCompare: #<
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Fraction >> <= aNumber [
 	aNumber isFraction ifTrue:
 		[^ numerator * aNumber denominator <= (aNumber numerator * denominator)].
 	^ aNumber adaptToFraction: self andCompare: #<=
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Fraction >> = aNumber [
 	aNumber isNumber ifFalse: [^ false].
 	aNumber isFraction
@@ -106,27 +108,27 @@ Fraction >> = aNumber [
 	^ aNumber adaptToFraction: self andCompare: #=
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Fraction >> > aNumber [
 	aNumber isFraction ifTrue:
 		[^ numerator * aNumber denominator > (aNumber numerator * denominator)].
 	^ aNumber adaptToFraction: self andCompare: #>
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Fraction >> >= aNumber [
 	aNumber isFraction ifTrue:
 		[^ numerator * aNumber denominator >= (aNumber numerator * denominator)].
 	^ aNumber adaptToFraction: self andCompare: #>=
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Fraction >> adaptToInteger: rcvr andSend: selector [
 	"If I am involved in arithmetic with an Integer, convert it to a Fraction."
 	^ (Fraction numerator: rcvr denominator: 1) perform: selector with: self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Fraction >> asFloat [
 	"Answer a Float that closely approximates the value of the receiver.
 	This implementation will answer the closest floating point number to the receiver.
@@ -180,14 +182,14 @@ Fraction >> asFloat [
 		timesTwoPower: exponent
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Fraction >> asFraction [
 	"Answer the receiver itself."
 
 	^self
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Fraction >> asLargerPowerOfTwo [
 	"Convert the receiver into a power of two which is not less than the receiver"
 	| quotient |
@@ -202,7 +204,7 @@ Fraction >> asLargerPowerOfTwo [
 					ifFalse: [1 bitShift: (quotient highBit )]]
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Fraction >> asScaledDecimal [
 	"Convert the receiver to a ScaledDecimal.
 	If there is a finite decimal representation of the receiver, then use the exact number of decimal places required.
@@ -221,7 +223,7 @@ Fraction >> asScaledDecimal [
 	^self asScaledDecimal: (pow2 max: pow5)
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Fraction >> asSmallerPowerOfTwo [
 	"Convert the receiver into a power of two which is not larger than the receiver"
 	| quotient |
@@ -236,13 +238,13 @@ Fraction >> asSmallerPowerOfTwo [
 		ifFalse: [1 bitShift: ((numerator // denominator) highBit -1)]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Fraction >> denominator [
 
 	^denominator
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Fraction >> hash [
 	"Hash is reimplemented because = is implemented.
 	Care is taken that a Fraction equal to a Float also have an equal hash"
@@ -258,22 +260,22 @@ Fraction >> hash [
 	^numerator hash bitXor: denominator hash
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Fraction >> isFraction [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Fraction >> isPowerOfTwo [
 	^ numerator = 1 and: [ denominator isPowerOfTwo ]
 ]
 
-{ #category : #'self evaluating' }
+{ #category : 'self evaluating' }
 Fraction >> isSelfEvaluating [
 	^ true
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Fraction >> negated [
 	"Refer to the comment in Number|negated."
 
@@ -282,19 +284,19 @@ Fraction >> negated [
 		denominator: denominator
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Fraction >> negative [
 
 	^numerator negative
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Fraction >> numerator [
 
 	^numerator
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Fraction >> printOn: aStream [
 
 	aStream nextPut: $(.
@@ -304,7 +306,7 @@ Fraction >> printOn: aStream [
 	aStream nextPut: $)
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Fraction >> printOn: aStream base: base [
 
 	aStream nextPut: $(.
@@ -314,7 +316,7 @@ Fraction >> printOn: aStream base: base [
 	aStream nextPut: $)
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Fraction >> printOn: aStream showingDecimalPlaces: placesDesired [
 	"Same as super, but provides a faster implementation by inlining some Fraction protocol thus avoiding intermediate Fraction creation."
 
@@ -336,14 +338,14 @@ Fraction >> printOn: aStream showingDecimalPlaces: placesDesired [
 			roundedFractionPart printOn: aStream base: 10 length: placesDesired padded: true]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Fraction >> reciprocal [
 
 	numerator abs = 1 ifTrue: [^denominator * numerator].
 	^self class numerator: denominator denominator: numerator
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Fraction >> reduced [
 
 	| gcd numer denom |
@@ -355,7 +357,7 @@ Fraction >> reduced [
 	^Fraction numerator: numer denominator: denom
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Fraction >> round: numberOfWishedDecimal [
 	"Round the decimal part of the receiver to be limited to the number of wished decimal. Only leave a fixed amount of decimal"
    "(1/3 round: 2) >>> (33/100) "
@@ -364,7 +366,7 @@ Fraction >> round: numberOfWishedDecimal [
 	^self roundTo: (10 raisedTo: numberOfWishedDecimal negated)
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Fraction >> setNumerator: n denominator: d [
 
 	d = 0
@@ -375,7 +377,7 @@ Fraction >> setNumerator: n denominator: d [
 			d < 0 ifTrue: [numerator := numerator negated]]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Fraction >> storeOn: aStream base: base [
 
 	aStream nextPut: $(.
@@ -385,7 +387,7 @@ Fraction >> storeOn: aStream base: base [
 	aStream nextPut: $)
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Fraction >> truncated [
 	"Refer to the comment in Number|truncated."
 

--- a/src/Kernel/FullBlockClosure.class.st
+++ b/src/Kernel/FullBlockClosure.class.st
@@ -8,26 +8,28 @@ Instance Variables
 	receiver:		<Object>
 "
 Class {
-	#name : #FullBlockClosure,
-	#superclass : #BlockClosure,
-	#type : #variable,
+	#name : 'FullBlockClosure',
+	#superclass : 'BlockClosure',
+	#type : 'variable',
 	#instVars : [
 		'receiver'
 	],
-	#category : #'Kernel-Methods'
+	#category : 'Kernel-Methods',
+	#package : 'Kernel',
+	#tag : 'Methods'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FullBlockClosure >> receiver [
 	^ receiver
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FullBlockClosure >> receiver: anObject [
 	receiver := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FullBlockClosure >> sender [
 	"Answer the context that sent the message that created the receiver."
 

--- a/src/Kernel/GlobalVariable.class.st
+++ b/src/Kernel/GlobalVariable.class.st
@@ -4,52 +4,54 @@ I model Globals. I am stored as a binding in the Smalltalk globals.
 The compiler forwards bytecode generation to me for accessing the variable.
 "
 Class {
-	#name : #GlobalVariable,
-	#superclass : #LiteralVariable,
-	#category : #'Kernel-Variables'
+	#name : 'GlobalVariable',
+	#superclass : 'LiteralVariable',
+	#category : 'Kernel-Variables',
+	#package : 'Kernel',
+	#tag : 'Variables'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 GlobalVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 	^ aProgramNodeVisitor visitGlobalVariableNode: aNode
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 GlobalVariable >> definingClass [
 	"The class defining the variable. For Globals, return nil"
 	^nil
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 GlobalVariable >> emitStore: methodBuilder [
 
 	methodBuilder storeIntoLiteralVariable: self
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 GlobalVariable >> emitValue: methodBuilder [
 	methodBuilder pushLiteralVariable: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 GlobalVariable >> isDeprecated [
 
 	^ (self propertyAt: #isDeprecated ifAbsent: [ false ]) or: [ self value isClass and: [ self value isDeprecated ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 GlobalVariable >> isDeprecated: aBoolean [
 
 	self propertyAt: #isDeprecated put: aBoolean
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 GlobalVariable >> isGlobalVariable [
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 GlobalVariable >> scope [
 	"The scope of Globals is Smalltalk globals"
 	^ Smalltalk globals

--- a/src/Kernel/Halt.class.st
+++ b/src/Kernel/Halt.class.st
@@ -70,17 +70,19 @@ In past Halt was a normal exception (not a kind of UnhandledException) and it wa
 But it such design did not allow to debug the unhandled logic itself. For example halt in UnhandledError>>#defaultAction leaded to infinite recursion
 "
 Class {
-	#name : #Halt,
-	#superclass : #UnhandledException,
-	#category : #'Kernel-Exceptions'
+	#name : 'Halt',
+	#superclass : 'UnhandledException',
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 Halt class >> captureIfSignalledWhenStepping [
 	^self == Halt
 ]
 
-{ #category : #halting }
+{ #category : 'halting' }
 Halt class >> fromCount: anInteger [
 	"Always halt after a count has been reached"
 
@@ -89,7 +91,7 @@ Halt class >> fromCount: anInteger [
 		onCountWithBehavior: [ :node | (node propertyAt: #haltCount) >= anInteger ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Halt class >> haltIfBlock: aBlock withCallingObjectFrom: haltSenderContext [
 
 	(aBlock cull: haltSenderContext receiver)
@@ -97,7 +99,7 @@ Halt class >> haltIfBlock: aBlock withCallingObjectFrom: haltSenderContext [
 		ifFalse: [^ self]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Halt class >> haltIfCallChain: haltSenderContext contains: aSelector [
 	| cntxt |
 	cntxt := haltSenderContext.
@@ -106,7 +108,7 @@ Halt class >> haltIfCallChain: haltSenderContext contains: aSelector [
 		cntxt := cntxt sender ]
 ]
 
-{ #category : #halting }
+{ #category : 'halting' }
 Halt class >> if: condition [
 	<debuggerCompleteToSender>
 	"This is the typical message to use for inserting breakpoints during
@@ -125,34 +127,34 @@ Halt class >> if: condition [
 	]
 ]
 
-{ #category : #halting }
+{ #category : 'halting' }
 Halt class >> ifNotTest [
 	<debuggerCompleteToSender>
 	"Halt if execution was not started by a test"
 	CurrentExecutionEnvironment value isTest ifFalse: [self signalIn: thisContext home sender ]
 ]
 
-{ #category : #halting }
+{ #category : 'halting' }
 Halt class >> ifTest [
 	<debuggerCompleteToSender>
 	"Halt if execution was started by a test"
 	CurrentExecutionEnvironment value isTest ifTrue: [self signalIn: thisContext home sender ]
 ]
 
-{ #category : #halting }
+{ #category : 'halting' }
 Halt class >> now [
 	<debuggerCompleteToSender>
 	self signal
 ]
 
-{ #category : #halting }
+{ #category : 'halting' }
 Halt class >> now: aString [
 	"set a breakpoint with some explanation"
 	<debuggerCompleteToSender>
 	self signal: aString
 ]
 
-{ #category : #halting }
+{ #category : 'halting' }
 Halt class >> onCount: anInteger [
 	"Halts once when a count is reached"
 
@@ -161,7 +163,7 @@ Halt class >> onCount: anInteger [
 		onCountWithBehavior: [ :node | (node propertyAt: #haltCount) = anInteger ]
 ]
 
-{ #category : #halting }
+{ #category : 'halting' }
 Halt class >> onCountWithBehavior: behaviorBlock [
 	"Halt on the anInteger-th time through, as defined in the behavior block passed as parameter.
 	First parameter of the behaviorBlock is the AST node corresponding to the halt call."
@@ -179,7 +181,7 @@ Halt class >> onCountWithBehavior: behaviorBlock [
 		ifTrue: [ ^ self signal ]
 ]
 
-{ #category : #halting }
+{ #category : 'halting' }
 Halt class >> once [
 	"Stop once and only once the execution of the method containing the expression Halt once. If you need to get it stops another time after the first stop, use Halt resetOnce."
 
@@ -206,12 +208,12 @@ Halt class >> once [
 	]
 ]
 
-{ #category : #'once-reset' }
+{ #category : 'once-reset' }
 Halt class >> resetHaltOnCount [
 	 #haltOnCount: senders do: [ :method | method ast removeProperty: #haltCount ifAbsent: [  ] ]
 ]
 
-{ #category : #'once-reset' }
+{ #category : 'once-reset' }
 Halt class >> resetOnce [
 	"Once stops an expression once and only once. Halt resetOnce will rearm and make sure that the execution of a method containing Halt once will stop another time."
 	 (#haltOnce senders, #inspectOnce senders) do: [ :method |
@@ -219,7 +221,7 @@ Halt class >> resetOnce [
 			sendNode removeProperty: #Once ifAbsent: [  ]]]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Halt >> completeProcess: aProcess with: aContext [
 	^ aContext methodNode
 		pragmaNamed: #debuggerCompleteToSender
@@ -227,7 +229,7 @@ Halt >> completeProcess: aProcess with: aContext [
 		ifAbsent: [ super completeProcess: aProcess with: aContext ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Halt >> exception [
 	"In the context management, it might happen that we get an Halt instead of an UnhandledError. The context will ask the exception. In case we have an halt, we should return self."
 

--- a/src/Kernel/Heap.extension.st
+++ b/src/Kernel/Heap.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Heap }
+Extension { #name : 'Heap' }
 
-{ #category : #'*Kernel-Processes' }
+{ #category : '*Kernel-Processes' }
 Heap >> removeFirstOrNil [
 	"Remove the first element from the receiver"
 	self isEmpty ifTrue:  [ ^nil ].

--- a/src/Kernel/IllegalResumeAttempt.class.st
+++ b/src/Kernel/IllegalResumeAttempt.class.st
@@ -2,18 +2,20 @@
 This class is private to the EHS implementation.  An instance of it is signaled whenever an attempt is made to resume from an exception which answers false to #isResumable.
 "
 Class {
-	#name : #IllegalResumeAttempt,
-	#superclass : #Exception,
-	#category : #'Kernel-Exceptions'
+	#name : 'IllegalResumeAttempt',
+	#superclass : 'Exception',
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 IllegalResumeAttempt >> isResumable [
 
 	^ false
 ]
 
-{ #category : #comment }
+{ #category : 'comment' }
 IllegalResumeAttempt >> readMe [
 
 	"Never handle this exception!"

--- a/src/Kernel/ImmediateLayout.class.st
+++ b/src/Kernel/ImmediateLayout.class.st
@@ -4,19 +4,21 @@ I am the special layout for SmallIntegers.
 SmallIntegers are typically implemented as tagged pointers and thus require a special format.
 "
 Class {
-	#name : #ImmediateLayout,
-	#superclass : #ObjectLayout,
-	#category : #'Kernel-Layout'
+	#name : 'ImmediateLayout',
+	#superclass : 'ObjectLayout',
+	#category : 'Kernel-Layout',
+	#package : 'Kernel',
+	#tag : 'Layout'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ImmediateLayout class >> extending: superLayout scope: aScope host: aClass [
 	^ superLayout extendImmediate
 		host: aClass;
 		yourself
 ]
 
-{ #category : #description }
+{ #category : 'description' }
 ImmediateLayout class >> subclassDefiningSymbol [
 	"Answer a keyword that describes the receiver's kind of subclass
 	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
@@ -24,23 +26,23 @@ ImmediateLayout class >> subclassDefiningSymbol [
 	^#immediateSubclass:
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 ImmediateLayout >> extend [
 	self error: 'ImmediateLayout can not be extendend'
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 ImmediateLayout >> extend: newScope [
 	^ FixedLayout new slotScope: newScope
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ImmediateLayout >> initialize [
 	super initialize.
 	self host: SmallInteger
 ]
 
-{ #category : #format }
+{ #category : 'format' }
 ImmediateLayout >> instanceSpecification [
 	^ 7
 ]

--- a/src/Kernel/IndexedSlot.class.st
+++ b/src/Kernel/IndexedSlot.class.st
@@ -4,15 +4,17 @@ By default each Slot corresponds to an instance variable and vice versa. Hence t
 
 "
 Class {
-	#name : #IndexedSlot,
-	#superclass : #Slot,
+	#name : 'IndexedSlot',
+	#superclass : 'Slot',
 	#instVars : [
 		'index'
 	],
-	#category : #'Kernel-Variables'
+	#category : 'Kernel-Variables',
+	#package : 'Kernel',
+	#tag : 'Variables'
 }
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 IndexedSlot >> = other [
 	self == other
 		ifTrue: [ ^ true ].
@@ -21,34 +23,34 @@ IndexedSlot >> = other [
 			and: [ name = other name ]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 IndexedSlot >> hasSameDefinitionAs: other [
 	"Definiton does not contain index"
 	^super = other
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 IndexedSlot >> hash [
 	^ (self species hash bitXor: self name hash) bitXor: (self index ifNil: [ 0 ])
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IndexedSlot >> index [
 	^ index
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IndexedSlot >> index: anIndex [
 	index := anIndex
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IndexedSlot >> isVirtual [
 	"indexed slots are the only not virtual slots for now"
 	^false
 ]
 
-{ #category : #'meta-object-protocol' }
+{ #category : 'meta-object-protocol' }
 IndexedSlot >> object: anObject instVarAt: anIndex [
 	"Primitive. Answer a fixed variable in an object. The numbering of the
 	 variables corresponds to the named instance variables. Fail if the index
@@ -60,7 +62,7 @@ IndexedSlot >> object: anObject instVarAt: anIndex [
 	^thisContext object: anObject instVarAt: anIndex
 ]
 
-{ #category : #'meta-object-protocol' }
+{ #category : 'meta-object-protocol' }
 IndexedSlot >> object: anObject instVarAt: anIndex put: aValue [
 	"Primitive. Store a value into a fixed variable in the argument anObject.
 	 The numbering of the variables corresponds to the named instance
@@ -75,12 +77,12 @@ IndexedSlot >> object: anObject instVarAt: anIndex put: aValue [
 	^thisContext object: anObject instVarAt: anIndex put: aValue
 ]
 
-{ #category : #'meta-object-protocol' }
+{ #category : 'meta-object-protocol' }
 IndexedSlot >> read: anObject [
 	^ self object: anObject instVarAt: index
 ]
 
-{ #category : #'meta-object-protocol' }
+{ #category : 'meta-object-protocol' }
 IndexedSlot >> write: aValue to: anObject [
 	^ self object: anObject instVarAt: index put: aValue
 ]

--- a/src/Kernel/InexactFloatPrintPolicy.class.st
+++ b/src/Kernel/InexactFloatPrintPolicy.class.st
@@ -4,12 +4,14 @@ I am InexactFloatPrintPolicy.
 Through FloatPrintPolicy and double dispatch I force Float>>#printOn:base: to dynamically use the faster but potentially less accurate way to print Floats using Float>>#absPrintOn:base:
 "
 Class {
-	#name : #InexactFloatPrintPolicy,
-	#superclass : #Object,
-	#category : #'Kernel-Numbers'
+	#name : 'InexactFloatPrintPolicy',
+	#superclass : 'Object',
+	#category : 'Kernel-Numbers',
+	#package : 'Kernel',
+	#tag : 'Numbers'
 }
 
-{ #category : #printing }
+{ #category : 'printing' }
 InexactFloatPrintPolicy >> absPrint: float on: stream base: base [
 	"Doube dispatch to the faster but potentially less accurate way to print"
 

--- a/src/Kernel/InstanceVariableNotFound.class.st
+++ b/src/Kernel/InstanceVariableNotFound.class.st
@@ -20,15 +20,17 @@ Internal Representation and Key Implementation Points.
 	instVarName:		<aString>	Name of the instance variable we tried to access.
 "
 Class {
-	#name : #InstanceVariableNotFound,
-	#superclass : #Error,
+	#name : 'InstanceVariableNotFound',
+	#superclass : 'Error',
 	#instVars : [
 		'instVarName'
 	],
-	#category : #'Kernel-Exceptions'
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #signalling }
+{ #category : 'signalling' }
 InstanceVariableNotFound class >> signalFor: aString [
 	"Create and signal a NoInstanceVariableNAmed exception for aString in the default receiver."
 
@@ -37,24 +39,24 @@ InstanceVariableNotFound class >> signalFor: aString [
 		signal
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 InstanceVariableNotFound >> instVarName [
 	^ instVarName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 InstanceVariableNotFound >> instVarName: anObject [
 	instVarName := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 InstanceVariableNotFound >> messageText [
 	"Overwritten to initialiaze the message text to a standard text if it has not yet been set"
 
 	^ messageText ifNil: [ messageText := self standardMessageText ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 InstanceVariableNotFound >> standardMessageText [
 	"Generate a standard textual description"
 

--- a/src/Kernel/InstanceVariableSlot.class.st
+++ b/src/Kernel/InstanceVariableSlot.class.st
@@ -8,12 +8,14 @@ If you subclass this class, take note that as it overrides both #emitStore: and 
 
 "
 Class {
-	#name : #InstanceVariableSlot,
-	#superclass : #IndexedSlot,
-	#category : #'Kernel-Variables'
+	#name : 'InstanceVariableSlot',
+	#superclass : 'IndexedSlot',
+	#category : 'Kernel-Variables',
+	#package : 'Kernel',
+	#tag : 'Variables'
 }
 
-{ #category : #cleanup }
+{ #category : 'cleanup' }
 InstanceVariableSlot class >> resetIvarSlots [
 	"when the Ivar slots need to be re-created (e.g. due to changes in the layout of the class),
 	 this method re-creates for every ivar a ivar slot"
@@ -35,7 +37,7 @@ InstanceVariableSlot class >> resetIvarSlots [
 			block value: class classSide ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 InstanceVariableSlot >> definitionOn: aStream [
 	"non special globals are defined by the symbol"
 	^self needsFullDefinition
@@ -43,34 +45,34 @@ InstanceVariableSlot >> definitionOn: aStream [
 		ifFalse: [ self name printOn: aStream ]
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 InstanceVariableSlot >> emitStore: methodBuilder [
 	"generate store bytecode"
 	methodBuilder storeInstVar: index
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 InstanceVariableSlot >> emitValue: methodBuilder [
 	"emit the bytecode to push ivar"
 	methodBuilder pushInstVar: index
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 InstanceVariableSlot >> isAccessedIn: aCompiledCode [
 	^ aCompiledCode accessesField: index
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 InstanceVariableSlot >> isReadIn: aCompiledCode [
 	^aCompiledCode readsField: index
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 InstanceVariableSlot >> isWrittenIn: aCompiledCode [
 	^aCompiledCode writesField: index
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 InstanceVariableSlot >> needsFullDefinition [
 	"I am just a backward compatible ivar slot and can use simple definitions.
 	 Note: my subclasses need full definitions"

--- a/src/Kernel/InstructionClient.class.st
+++ b/src/Kernel/InstructionClient.class.st
@@ -3,31 +3,33 @@ My job is to make it easier to implement clients for InstructionStream. See Inst
 as an example. 
 "
 Class {
-	#name : #InstructionClient,
-	#superclass : #Object,
+	#name : 'InstructionClient',
+	#superclass : 'Object',
 	#instVars : [
 		'mappedInlinePrimitiveHandlers'
 	],
-	#category : #'Kernel-Methods'
+	#category : 'Kernel-Methods',
+	#package : 'Kernel',
+	#tag : 'Methods'
 }
 
-{ #category : #'extended instruction decoding' }
+{ #category : 'extended instruction decoding' }
 InstructionClient >> addMappedInlinePrimitiveHandler: handler at: bytecodeNumber [
 
 	mappedInlinePrimitiveHandlers at: bytecodeNumber put: handler
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> blockReturnConstant: value [
 	"Return Constant From Block bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> blockReturnTop [
 	"Return Top Of Stack bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> callPrimitive: pimIndex [
 	"V3PlusClosures:	139 10001011	iiiiiiii   jjjjjjjj  Call Primitive #iiiiiiii + (jjjjjjjj * 256)
 	 NewsqueakV4:		249 11111001	iiiiiiii   jjjjjjjj  Call Primitive #iiiiiiii + (jjjjjjjj * 256)
@@ -35,7 +37,7 @@ InstructionClient >> callPrimitive: pimIndex [
 							m=1 means inlined primitive, no hard return after execution."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> directedSuperSend: selector numArgs: numArgs [
 	"Send Message Above Specific Class With Selector, selector, bytecode.
 	 Start the lookup above the class that is the value of the association on
@@ -43,51 +45,51 @@ InstructionClient >> directedSuperSend: selector numArgs: numArgs [
 	 stack locations beneath the association, and the receiver just below them."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> doDup [
 	"Duplicate Top Of Stack bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> doNop [
 	"Do nothing (nop = no operation)"
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> doPop [
 	"Remove Top Of Stack bytecode."
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 InstructionClient >> initialize [
 	mappedInlinePrimitiveHandlers := Dictionary new.
 	"Configuration classes are expected to send the `addMappedInlinePrimitiveHandler:at:` message to add bytecode handlers to this instance"
 	BytecodeMappedInlinePrimitiveConfiguration subclasses do: [ :each | each configure: self ]
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> jump: offset [
 	"Unconditional Jump bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> jump: offset if: condition [
 	"Conditional Jump bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> jump: offset if: condition withInterpreter: anInterpreter [
 
 	^ self jump: offset if: condition
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> jump: offset withInterpreter: anInterpreter [
 
 	^ self jump: offset
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> mappedInlinePrimitive: extensionBytecodeNumber [
 
 	| extensionHandler |
@@ -97,110 +99,110 @@ InstructionClient >> mappedInlinePrimitive: extensionBytecodeNumber [
 	self perform: extensionHandler
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> methodReturnConstant: value [
 	"Return Constant bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> methodReturnReceiver [
 	"Return Self bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> methodReturnTop [
 	"Return Top Of Stack bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> pc: aPC [
 
 	"Set the pc to the given PC"
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> popIntoLiteralVariable: anAssociation [
 	"Remove Top Of Stack And Store Into Literal Variable bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> popIntoReceiverVariable: offset [
 	"Remove Top Of Stack And Store Into Instance Variable bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> popIntoRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex [
 	"Remove Top Of Stack And Store Into Offset of Temp Vector bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> popIntoTemporaryVariable: offset [
 	"Remove Top Of Stack And Store Into Temporary Variable bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> pushActiveContext [
 	"Push Active Context On Top Of Its Own Stack bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> pushActiveProcess [
 	"Push Active Process On Top Of Its Own Stack bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> pushClosureTemps: numTemps [
 	"push on stack nil numTemps times for the closure temps"
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> pushConsArrayWithElements: numElements [
 	"Push Cons Array of size numElements popping numElements items from the stack into the array bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> pushConstant: value [
 	"Push Constant, value, on Top Of Stack bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> pushFullClosure: aCollection numCopied: anInteger receiverOnStack: aFalse ignoreOuterContext: aFalse4 [
 	"Push Full Closure bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> pushLiteralVariable: anAssociation [
 	"Push Contents Of anAssociation On Top Of Stack bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> pushNewArrayOfSize: numElements [
 	"Push New Array of size numElements bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> pushReceiver [
 	"Push Active Context's Receiver on Top Of Stack bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> pushReceiverVariable: offset [
 	"Push Contents Of the Receiver's Instance Variable Whose Index
 	is the argument, offset, On Top Of Stack bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> pushRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex [
 	"Push Contents at Offset in Temp Vector bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> pushTemporaryVariable: offset [
 	"Push Contents Of Temporary Variable Whose Index Is the
 	argument, offset, On Top Of Stack bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> send: selector super: supered numArgs: numberArguments [
 	"Send Message With Selector, selector, bytecode. The argument,
 	supered, indicates whether the receiver of the message is specified with
@@ -209,32 +211,32 @@ InstructionClient >> send: selector super: supered numArgs: numberArguments [
 	below them."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> storeIntoLiteralVariable: anAssociation [
 	"Store Top Of Stack Into Literal Variable Of Method bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> storeIntoReceiverVariable: offset [
 	"Store Top Of Stack Into Instance Variable Of Method bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> storeIntoRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex [
 	"Store Top Of Stack And Store Into Offset of Temp Vector bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> storeIntoTemporaryVariable: offset [
 	"Store Top Of Stack Into Temporary Variable Of Method bytecode."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> trap [
 	"send the class trap message to the current context."
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 InstructionClient >> unusedBytecode [
 		"an unused bytecode is encountered"
 ]

--- a/src/Kernel/InstructionStream.class.st
+++ b/src/Kernel/InstructionStream.class.st
@@ -6,8 +6,8 @@ Instance variables:
 My instances can interpret the byte-encoded Smalltalk instruction set. They maintain a program counter (pc) for streaming through CompiledMethods. My subclasses are Contexts, which inherit this capability. They store the return pointer in the instance variable sender, and the current position in their method in the instance variable pc. For other users, sender can hold a method to be similarly interpreted. The unclean re-use of sender to hold the method was to avoid a trivial subclass for the stand-alone scanning function.
 "
 Class {
-	#name : #InstructionStream,
-	#superclass : #Object,
+	#name : 'InstructionStream',
+	#superclass : 'Object',
 	#instVars : [
 		'sender',
 		'pc'
@@ -15,10 +15,12 @@ Class {
 	#classVars : [
 		'SpecialConstants'
 	],
-	#category : #'Kernel-Methods'
+	#category : 'Kernel-Methods',
+	#package : 'Kernel',
+	#tag : 'Methods'
 }
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 InstructionStream class >> initialize [
 	"Initialize an array of special constants returned by single-bytecode returns."
 
@@ -28,26 +30,26 @@ InstructionStream class >> initialize [
 	"InstructionStream initialize."
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 InstructionStream class >> on: method [
 	"Answer an instance of me on the argument, method."
 
 	^self on: method pc: method initialPC
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 InstructionStream class >> on: method pc: aPC [
 	"Answer an instance of me on the argument, method."
 
 	^self new method: method pc: aPC
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 InstructionStream >> compiledCode [
 	^self method
 ]
 
-{ #category : #interpreting }
+{ #category : 'interpreting' }
 InstructionStream >> interpretNext2ByteSistaV1Instruction: bytecode for: client extA: extA extB: extB startPC: startPC [
 	"Send to the argument, client, a message that specifies the next instruction.
 	 This method handles the two-byte codes.
@@ -115,7 +117,7 @@ InstructionStream >> interpretNext2ByteSistaV1Instruction: bytecode for: client 
 	^self interpretUnusedBytecode: client at: startPC
 ]
 
-{ #category : #interpreting }
+{ #category : 'interpreting' }
 InstructionStream >> interpretNext3ByteSistaV1Instruction: bytecode for: client extA: extA extB: extB startPC: startPC [
 	"Send to the argument, client, a message that specifies the next instruction.
 	 This method handles the three-byte codes.
@@ -152,14 +154,14 @@ InstructionStream >> interpretNext3ByteSistaV1Instruction: bytecode for: client 
 	^self interpretUnusedBytecode: client at: startPC
 ]
 
-{ #category : #interpreting }
+{ #category : 'interpreting' }
 InstructionStream >> interpretNextInstructionFor: client [
 	"Send to the argument, client, a message that specifies the type of the
 	next instruction."
 	^ self compiledCode encoderClass interpretNextInstructionFor: client  in: self
 ]
 
-{ #category : #interpreting }
+{ #category : 'interpreting' }
 InstructionStream >> interpretNextSistaV1InstructionFor: client [
 	"Send to the argument, client, a message that specifies the next instruction."
 
@@ -268,7 +270,7 @@ InstructionStream >> interpretNextSistaV1InstructionFor: client [
 	^self interpretNext3ByteSistaV1Instruction: byte for: client extA: extA extB: extB startPC: savedPC
 ]
 
-{ #category : #interpreting }
+{ #category : 'interpreting' }
 InstructionStream >> interpretSistaV1ExtendedPush: extB for: client [
 	"Implement the extended push for non-zero extensions."
 	"*	82			01010010			Push thisContext, (then Extend B = 1 => push
@@ -280,19 +282,19 @@ InstructionStream >> interpretSistaV1ExtendedPush: extB for: client [
 	self error: 'undefined extended push'
 ]
 
-{ #category : #interpreting }
+{ #category : 'interpreting' }
 InstructionStream >> interpretUnusedBytecode: client at: startPC [
 	^ client unusedBytecode
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 InstructionStream >> method [
 	"Answer the compiled method that supplies the receiver's bytecodes."
 
 	^sender		"method access when used alone (not as part of a context)"
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 InstructionStream >> method: method pc: startpc [
 
 	sender := method.
@@ -300,14 +302,14 @@ InstructionStream >> method: method pc: startpc [
 	pc := startpc
 ]
 
-{ #category : #scanning }
+{ #category : 'scanning' }
 InstructionStream >> pc [
 	"Answer the index of the next bytecode."
 
 	^pc
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 InstructionStream >> pc: anInteger [
 
 	pc := anInteger

--- a/src/Kernel/Integer.class.st
+++ b/src/Kernel/Integer.class.st
@@ -8,12 +8,14 @@ Integer division consists of:
 	quo: truncated division, rounded towards zero
 "
 Class {
-	#name : #Integer,
-	#superclass : #Number,
-	#category : #'Kernel-Numbers'
+	#name : 'Integer',
+	#superclass : 'Number',
+	#category : 'Kernel-Numbers',
+	#package : 'Kernel',
+	#tag : 'Numbers'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Integer class >> basicNew [
 
 	self == Integer ifTrue: [
@@ -21,7 +23,7 @@ Integer class >> basicNew [
 	^ super basicNew
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Integer class >> byte1: byte1 byte2: byte2 byte3: byte3 byte4: byte4 [
 	"Depending on high-order byte copy directly into a LargeInteger,
 	or build up a SmallInteger by shifting"
@@ -39,13 +41,13 @@ Integer class >> byte1: byte1 byte2: byte2 byte3: byte3 byte4: byte4 [
 	^ value
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Integer class >> isAbstract [
 
 	^self name = #Integer
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Integer class >> new [
 
 	self == Integer ifTrue: [
@@ -53,7 +55,7 @@ Integer class >> new [
 	^ super new
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Integer class >> new: length neg: neg [
 	"Answer an instance of a large integer whose size is length. neg is a flag
 	determining whether the integer is negative or not."
@@ -63,7 +65,7 @@ Integer class >> new: length neg: neg [
 		  ifFalse: [ LargePositiveInteger new: length ]
 ]
 
-{ #category : #reading }
+{ #category : 'reading' }
 Integer class >> readHexByteFrom: characterReadStream [
 	| highNibble lowNibble |
 	highNibble := characterReadStream next
@@ -75,12 +77,12 @@ Integer class >> readHexByteFrom: characterReadStream [
 	^ (highNibble bitShift: 4) + lowNibble
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 Integer >> & aNumber [
 	^ self bitAnd: aNumber
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Integer >> * aNumber [
 	"Refer to the comment in Number * "
 	aNumber isInteger ifTrue:
@@ -89,7 +91,7 @@ Integer >> * aNumber [
 	^ aNumber adaptToInteger: self andSend: #*
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Integer >> + aNumber [
 	"Refer to the comment in Number + "
 	aNumber isInteger ifTrue:
@@ -101,7 +103,7 @@ Integer >> + aNumber [
 	^ aNumber adaptToInteger: self andSend: #+
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Integer >> - aNumber [
 	"Refer to the comment in Number - "
 	aNumber isInteger ifTrue:
@@ -113,7 +115,7 @@ Integer >> - aNumber [
 	^ aNumber adaptToInteger: self andSend: #-
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Integer >> / aNumber [
 	"Refer to the comment in Number / "
 	| quoRem |
@@ -125,7 +127,7 @@ Integer >> / aNumber [
 	^ aNumber adaptToInteger: self andSend: #/
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Integer >> // aNumber [
 	| q |
 	aNumber = 0 ifTrue: [^ (ZeroDivide dividend: self) signal"<- Chg"].
@@ -139,7 +141,7 @@ Integer >> // aNumber [
 		ifFalse: [ q]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Integer >> < aNumber [
 	aNumber isInteger ifTrue:
 		[^ self negative == aNumber negative
@@ -150,14 +152,14 @@ Integer >> < aNumber [
 	^ aNumber adaptToInteger: self andCompare: #<
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 Integer >> << shiftAmount [
 	"left shift"
 
 	^ self bitShift: shiftAmount
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Integer >> <= aNumber [
 	aNumber isInteger ifTrue:
 		[^ self negative == aNumber negative
@@ -168,7 +170,7 @@ Integer >> <= aNumber [
 	^ aNumber adaptToInteger: self andCompare: #<=
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Integer >> = aNumber [
 	aNumber isNumber ifFalse: [^ false].
 	aNumber isInteger ifTrue:
@@ -177,7 +179,7 @@ Integer >> = aNumber [
 	^ aNumber adaptToInteger: self andCompare: #=
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Integer >> > aNumber [
 	aNumber isInteger ifTrue:
 		[^ self negative == aNumber negative
@@ -188,7 +190,7 @@ Integer >> > aNumber [
 	^ aNumber adaptToInteger: self andCompare: #>
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Integer >> >= aNumber [
 	aNumber isInteger ifTrue:
 		[^ self negative == aNumber negative
@@ -199,27 +201,27 @@ Integer >> >= aNumber [
 	^ aNumber adaptToInteger: self andCompare: #>=
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 Integer >> >> shiftAmount [
 	"right shift"
 
 	^ self bitShift: 0 - shiftAmount
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Integer >> \\\ anInteger [
 	"a modulo method for use in DSA. Be careful if you try to use this elsewhere."
 
 	^self \\ anInteger
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Integer >> adaptToFraction: rcvr andSend: selector [
 	"If I am involved in arithmetic with a Fraction, convert me to a Fraction."
 	^ rcvr perform: selector with: (Fraction numerator: self denominator: 1)
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Integer >> alignedTo: anInteger [
 	"Answer the smallest number not less than receiver that is a multiple of anInteger."
 
@@ -229,7 +231,7 @@ Integer >> alignedTo: anInteger [
 "12 alignedTo: 3"
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 Integer >> allMask: mask [
 	"Treat the argument as a bit mask. Answer whether all of the bits that
 	are 1 in the argument are 1 in the receiver."
@@ -237,7 +239,7 @@ Integer >> allMask: mask [
 	^mask = (self bitAnd: mask)
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 Integer >> anyBitOfMagnitudeFrom: start to: stopArg [
 	"Tests for any magnitude bits in the interval from start to stopArg."
 	"Primitive fixed in LargeIntegers v1.2. If you have an earlier version
@@ -278,7 +280,7 @@ Integer >> anyBitOfMagnitudeFrom: start to: stopArg [
 	^ false
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 Integer >> anyMask: mask [
 	"Treat the argument as a bit mask. Answer whether any of the bits that
 	are 1 in the argument are 1 in the receiver."
@@ -286,7 +288,7 @@ Integer >> anyMask: mask [
 	^0 ~= (self bitAnd: mask)
 ]
 
-{ #category : #'converting - arrays' }
+{ #category : 'converting - arrays' }
 Integer >> asByteArray [
 
 	| stream |
@@ -296,7 +298,7 @@ Integer >> asByteArray [
 	^ stream contents
 ]
 
-{ #category : #'converting - arrays' }
+{ #category : 'converting - arrays' }
 Integer >> asByteArrayOfSize: aSize [
 	"Answer a ByteArray of aSize with my value, most-significant byte first."
 	| answer digitPos |
@@ -315,19 +317,19 @@ Integer >> asByteArrayOfSize: aSize [
 	^ answer
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Integer >> asCharacter [
 	"Answer the Character whose value is the receiver."
 	^Character value: self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Integer >> asCharacterDigit [
 	"Answer the Character whose string representation is the receiver."
 	^Character digitValue: self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Integer >> asFraction [
 	"Answer a Fraction that represents the value of the receiver.
 	Since an Integer already behaves as a special kind of Fraction, no conversion is required, see #isFraction."
@@ -335,19 +337,19 @@ Integer >> asFraction [
 	^self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Integer >> asHexDigit [
 	^'0123456789ABCDEF' at: self+1
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Integer >> asInteger [
 	"Answer with the receiver itself."
 
 	^self
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Integer >> asLargerPowerOfTwo [
 	"Convert the receiver into a power of two which is not less than the receiver"
 	^self isPowerOfTwo
@@ -356,24 +358,24 @@ Integer >> asLargerPowerOfTwo [
 						ifFalse: [DomainError signal: 'Value outside (0 , infinity)' from: 0]]
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Integer >> asPowerOfTwo [
 	"Convert the receiver into a power of two"
 	^self asSmallerPowerOfTwo
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Integer >> asScaledDecimal [
 	"The number of significant digits of the answer is the same as the number of decimal digits in the receiver."
 	^ ScaledDecimal newFromNumber: self scale: 0
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Integer >> asSeconds [
 	^ Duration seconds: self
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Integer >> asSmallerPowerOfTwo [
 	"Convert the receiver into a power of two which is not larger than the receiver"
 	^self isPowerOfTwo
@@ -382,7 +384,7 @@ Integer >> asSmallerPowerOfTwo [
 						ifFalse: [DomainError signal: 'Value outside (0 , infinity)' from: 0]]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Integer >> asStringWithCommas [
 	"123456789 asStringWithCommas"
 	"-123456789 asStringWithCommas"
@@ -390,7 +392,7 @@ Integer >> asStringWithCommas [
 		self printWithCommasOn: stream ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Integer >> asStringWithCommasSigned [
 	"123456789 asStringWithCommasSigned"
 	"-123456789 asStringWithCommasSigned"
@@ -398,7 +400,7 @@ Integer >> asStringWithCommasSigned [
 		self printWithCommasSignedOn: stream ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Integer >> asTwoCharacterString [
 	"Answer a two-character string representing the receiver, with leading zero if required.  Intended for use with integers in the range 0 to 99, but plausible replies given for other values too
 	Examples:
@@ -414,7 +416,7 @@ Integer >> asTwoCharacterString [
 		ifFalse:	[self printString copyFrom: 1 to: 2]
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 Integer >> bitAnd: n [
 	"Answer an Integer whose bits are the logical AND of the receiver's bits
 	and those of the argument, n."
@@ -427,7 +429,7 @@ Integer >> bitAnd: n [
 		length: (self bytesCount max: norm bytesCount)
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 Integer >> bitAt: anInteger [
 	"Answer 1 if the bit at position anInteger is set to 1, 0 otherwise.
 	self is considered an infinite sequence of bits, so anInteger can be any strictly positive integer.
@@ -439,7 +441,7 @@ Integer >> bitAt: anInteger [
 	^(self bitShift: 1 - anInteger) bitAnd: 1
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 Integer >> bitAt: anInteger put: value [
 	"Answer a new Integer that has the bit of rank anInteger set to value.
 	The bit value should be 0 or 1, otherwise raise an Error.
@@ -454,14 +456,14 @@ Integer >> bitAt: anInteger put: value [
 	self error: 'bit value should be 0 or 1'
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 Integer >> bitClear: aMask [
 	"Answer an Integer equal to the receiver, except with all bits cleared that are set in aMask."
 
 	^ (self bitOr: aMask) - aMask
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 Integer >> bitInvert [
 	"Answer an Integer whose bits are the logical negation of the receiver's bits.
 	Numbers are interpreted as having 2's-complement representation."
@@ -469,14 +471,14 @@ Integer >> bitInvert [
 	^ -1 - self
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 Integer >> bitInvert32 [
 	"Answer the 32-bit complement of the receiver."
 
 	^ self bitXor: 16rFFFFFFFF
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 Integer >> bitOr: n [
 	"Answer an Integer whose bits are the logical OR of the receiver's bits
 	and those of the argument, n."
@@ -489,7 +491,7 @@ Integer >> bitOr: n [
 		length: (self bytesCount max: norm bytesCount)
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 Integer >> bitShift: shiftCount [
 	"Answer an Integer whose value (in twos-complement representation) is
 	the receiver's value (in twos-complement representation) shifted left by
@@ -503,7 +505,7 @@ Integer >> bitShift: shiftCount [
 		ifFalse: [magnitudeShift]
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 Integer >> bitShiftMagnitude: shiftCount [
 	"Answer an Integer whose value (in magnitude representation) is
 	the receiver's value (in magnitude representation) shifted left by
@@ -519,7 +521,7 @@ Integer >> bitShiftMagnitude: shiftCount [
 		lookfirst: self bytesCount) normalize
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 Integer >> bitString [
 	"Returns a string representing the receiver in binary form"
 	"2 bitString
@@ -536,7 +538,7 @@ Integer >> bitString [
 		collect: [:i | Character value: $0 charCode + (self bitAt: i)] as: String
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 Integer >> bitStringLength [
 
       ^self bytesCount * 8
@@ -544,7 +546,7 @@ Integer >> bitStringLength [
            + (self positive ifTrue: [1] ifFalse: [0])
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 Integer >> bitXor: n [
 	"Answer an Integer whose bits are the logical XOR of the receiver's bits
 	and those of the argument, n."
@@ -557,17 +559,17 @@ Integer >> bitXor: n [
 		length: (self bytesCount max: norm bytesCount)
 ]
 
-{ #category : #'system primitives' }
+{ #category : 'system primitives' }
 Integer >> byteAt: index [
 	self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Integer >> byteAt: index put: value [
 	^ self subclassResponsibility
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Integer >> bytesCompare: arg [
 	"Compare the magnitude of self with that of arg.
 	Return a code of 1, 0, -1 for self >, = , < arg"
@@ -588,24 +590,24 @@ Integer >> bytesCompare: arg [
 	^ 0
 ]
 
-{ #category : #'system primitives' }
+{ #category : 'system primitives' }
 Integer >> bytesCount [
 	self subclassResponsibility
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Integer >> ceiling [
 	"Refer to the comment in Number|ceiling."
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Integer >> copyto: x [
 	| stop |
 	stop := self bytesCount min: x bytesCount.
 	^ x replaceFrom: 1 to: stop with: self startingAt: 1
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Integer >> crossSumBase: aBase [
 	|aResult|
 	"Precondition"
@@ -621,7 +623,7 @@ Integer >> crossSumBase: aBase [
 	^aResult
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Integer >> decimalDigitLength [
 
 	"Return how many digits are necessary to print this number in base 10.
@@ -631,13 +633,13 @@ Integer >> decimalDigitLength [
 	^ self numberOfDigitsInBase: 10
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Integer >> denominator [
 	"Let an Integer be polymorphic to a Fraction. See #isFraction."
 	^1
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Integer >> digitAdd: arg [
 	| len arglen accum sum |
 	<primitive: 'primDigitAdd' module:'LargeIntegers'>
@@ -657,7 +659,7 @@ Integer >> digitAdd: arg [
 	^ sum
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Integer >> digitAt: anExponent base: base [
 
 	"Return number that represents digit at given position.
@@ -671,7 +673,7 @@ Integer >> digitAt: anExponent base: base [
 	^ self // (base raisedToInteger: anExponent - 1) \\ base
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Integer >> digitDiv: arg neg: ng [
 	"Answer with an array of (quotient, remainder)."
 	| quo rem ql d div dh dnh dl qhi qlo j l hi lo r3 a t |
@@ -786,7 +788,7 @@ Integer >> digitDiv: arg neg: ng [
 	^ Array with: quo with: rem
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Integer >> digitLogic: arg op: op length: len [
 	| i result neg1 neg2 rneg z1 z2 rz b1 b2 b |
 	neg1 := self negative.
@@ -837,7 +839,7 @@ Integer >> digitLogic: arg op: op length: len [
 	^ result normalize
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Integer >> digitLshift: shiftCount [
 	| carry rShift mask len result digit byteShift bitShift highBit |
 	(highBit := self highBitOfMagnitude) = 0 ifTrue: [^ 0].
@@ -865,7 +867,7 @@ Integer >> digitLshift: shiftCount [
 	^ result
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Integer >> digitMultiply: arg neg: ng [
 	| prod prodLen carry digit k ab |
 	<primitive: 'primDigitMultiplyNegative' module:'LargeIntegers'>
@@ -894,7 +896,7 @@ Integer >> digitMultiply: arg neg: ng [
 	^ prod normalize
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Integer >> digitRshift: anInteger bytes: b lookfirst: a [
 	 "Shift right 8*b+anInteger bits, 0<=n<8.
 	Discard all digits beyond a, and all zeroes at or below a."
@@ -921,7 +923,7 @@ Integer >> digitRshift: anInteger bytes: b lookfirst: a [
 	^r
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Integer >> digitSubtract: arg [
 	| smaller larger z sum sl al ng |
 	<primitive: 'primDigitSubtract' module:'LargeIntegers'>
@@ -957,26 +959,26 @@ Integer >> digitSubtract: arg [
 	^ sum normalize
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Integer >> digitSum [
     "Returns the digit sum of the receiver"
 
     ^self abs asString inject: 0 into: [:value :new| value + new digitValue]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Integer >> even [
 	"Refer to the comment in Number|even."
 
 	^((self byteAt: 1) bitAnd: 1) = 0
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Integer >> floor [
 	"Refer to the comment in Number|floor."
 ]
 
-{ #category : #'mathematical functions' }
+{ #category : 'mathematical functions' }
 Integer >> gcd: anInteger [
 	"See Knuth, Vol 2, 4.5.2, Algorithm L"
 	"Initialize"
@@ -1014,24 +1016,24 @@ Integer >> gcd: anInteger [
 	^ v gcd: u
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Integer >> growby: n [
 
 	^self growto: self bytesCount + n
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Integer >> growto: n [
 
 	^self copyto: (self species new: n)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Integer >> hashMultiply [
 	^ self subclassResponsibility
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Integer >> hex [
 	"Returns a string representation of the receiver as hex, prefixed with 16r.
 	DO NOT CHANGE THIS!  The Cog VMMaker depends on this."
@@ -1051,7 +1053,7 @@ Integer >> hex [
 	^ self storeStringBase: 16
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Integer >> hexString [
 	"Returns a string representation of the receiver as hexadecimal, prefixed with 16r."
 
@@ -1070,7 +1072,7 @@ Integer >> hexString [
 	^ self storeStringBase: 16
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 Integer >> highBit [
 	"Answer the index of the high order bit of the receiver, or zero if the
 	receiver is zero. Raise an error if the receiver is negative, since
@@ -1081,14 +1083,14 @@ Integer >> highBit [
 	^ self subclassResponsibility
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 Integer >> highBitOfMagnitude [
 	"Answer the index of the high order bit of the magnitude of the
 	receiver, or zero if the receiver is zero."
 	^ self subclassResponsibility
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Integer >> humanReadableSISizeOn: aStream [
 	"Print a SI representation of myself on the argument. See humanReadableSIByteSize for better comment."
 
@@ -1104,7 +1106,7 @@ Integer >> humanReadableSISizeOn: aStream [
 		nextPut: $B
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Integer >> humanReadableSISizeString [
 	"Return the receiver as a string with SI binary (International System of Units) file size, e.g. '50 KB'. It means that it takes 1000 and not 1024 as unit as humanReadableByteSizeString does."
 
@@ -1117,7 +1119,7 @@ Integer >> humanReadableSISizeString [
 		self humanReadableSISizeOn: s ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Integer >> isFraction [
 	"Each Integer is considered as a special kind of Fraction with self as numerator and a unit denominator.
 	Rationale: A Fraction with a unit denominator will be automatically reduced to an Integer.
@@ -1125,38 +1127,38 @@ Integer >> isFraction [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Integer >> isInteger [
 	"True for all subclasses of Integer."
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Integer >> isLarge [
 	^ self subclassResponsibility
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Integer >> isLiteral [
 
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Integer >> isPowerOfTwo [
 	"Return true if the receiver is an integral power of two."
 	^ self ~= 0 and: [(self bitAnd: self-1) = 0]
 ]
 
-{ #category : #'system primitives' }
+{ #category : 'system primitives' }
 Integer >> lastDigit [
 	"Answer the last digit of the integer base 256.  LargePositiveInteger uses bytes of base two number, and each is a 'digit'."
 
 	^self byteAt: self bytesCount
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 Integer >> lowBit [
 	"Answer the index of the low order bit of this number."
 	| index |
@@ -1168,7 +1170,7 @@ Integer >> lowBit [
 	^ (self byteAt: index) lowBit + (8 * (index - 1))
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 Integer >> noMask: mask [
 	"Treat the argument as a bit mask. Answer whether none of the bits that
 	are 1 in the argument are 1 in the receiver."
@@ -1176,13 +1178,13 @@ Integer >> noMask: mask [
 	^0 = (self bitAnd: mask)
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Integer >> normalize [
 	"SmallInts OK; LgInts override"
 	^ self
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Integer >> numberOfDigits [
 	"Return how many digits are necessary to print this number in base 10.
 	This does not count any place for minus sign, radix prefix or whatever."
@@ -1190,7 +1192,7 @@ Integer >> numberOfDigits [
 	^ self numberOfDigitsInBase: 10
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Integer >> numberOfDigitsInBase: b [
 	"Return how many digits are necessary to print this number in base b.
 	This does not count any place for minus sign, radix prefix or whatever.
@@ -1222,13 +1224,13 @@ Integer >> numberOfDigitsInBase: b [
 		ifFalse: [total + 1]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Integer >> numerator [
 	"Let an Integer be polymorphic to a Fraction. See #isFraction."
 	^self
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Integer >> print: positiveNumberString on: aStream prefix: prefix length: minimum padded: zeroFlag [
 	"Return a String based on concatenation of positiveNumberString with prefix then padded by 0 is zeroFlag is set for a minimum length."
 
@@ -1245,7 +1247,7 @@ Integer >> print: positiveNumberString on: aStream prefix: prefix length: minimu
 	aStream nextPutAll: positiveNumberString
 ]
 
-{ #category : #'printing - numerative' }
+{ #category : 'printing - numerative' }
 Integer >> printHexByteOn: characterWriteStream [
 	"Assuming the receiver is a byte value [0, 255],
 	print a 2 character hexadecimal representation on characterWriteStream
@@ -1264,7 +1266,7 @@ Integer >> printHexByteOn: characterWriteStream [
 			self error: 'byte value between 0 and 255 expected' ]
 ]
 
-{ #category : #'printing - numerative' }
+{ #category : 'printing - numerative' }
 Integer >> printLowercaseHexByteOn: characterWriteStream [
 	"Assuming the receiver is a byte value [0, 255],
 	print a 2 character hexadecimal representation on characterWriteStream
@@ -1283,7 +1285,7 @@ Integer >> printLowercaseHexByteOn: characterWriteStream [
 			self error: 'byte value between 0 and 255 expected' ]
 ]
 
-{ #category : #'printing - numerative' }
+{ #category : 'printing - numerative' }
 Integer >> printOn: aStream base: base length: minimum padded: zeroFlag [
 	"Return a String representation of this number in base b with a minimum length and padded by 0 if zeroFlag is set"
 
@@ -1301,7 +1303,7 @@ Integer >> printOn: aStream base: base length: minimum padded: zeroFlag [
 		padded: zeroFlag
 ]
 
-{ #category : #'printing - numerative' }
+{ #category : 'printing - numerative' }
 Integer >> printOn: aStream base: b nDigits: n [
 	"Append a representation of this number in base b on aStream using nDigits.
 	self must be positive."
@@ -1309,7 +1311,7 @@ Integer >> printOn: aStream base: b nDigits: n [
 	self subclassResponsibility
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Integer >> printOn: outputStream base: baseInteger showRadix: flagBoolean [
 	"Write a sequence of characters that describes the receiver in radix
 	baseInteger with optional radix specifier.
@@ -1326,7 +1328,7 @@ Integer >> printOn: outputStream base: baseInteger showRadix: flagBoolean [
 	outputStream nextPutAll: (tempString copyFrom: startPos to: tempString size)
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Integer >> printOn: aStream showingDecimalPlaces: placesDesired [
 	"Same as super, but provides a faster implementation because fraction part and rounding are trivial."
 
@@ -1338,7 +1340,7 @@ Integer >> printOn: aStream showingDecimalPlaces: placesDesired [
 	placesDesired timesRepeat: [ aStream nextPut: $0 ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Integer >> printPaddedWith: aCharacter to: anInteger [
 	"Answer the string containing the ASCII representation of the receiver
 	padded on the left with aCharacter to be at least anInteger characters."
@@ -1349,7 +1351,7 @@ Integer >> printPaddedWith: aCharacter to: anInteger [
 		base: 10
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Integer >> printPaddedWith: aCharacter to: anInteger base: aRadix [
 	"Answer the string containing the ASCII representation of the receiver
 	padded on the left with aCharacter to be at least anInteger characters."
@@ -1367,7 +1369,7 @@ Integer >> printPaddedWith: aCharacter to: anInteger base: aRadix [
 	 yourself) , digits
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Integer >> printSeparatedBy: aDelimiter every: offset signed: printSigned base: base on: aStream [
 	| digits |
 	digits := self abs printStringBase: base.
@@ -1382,25 +1384,25 @@ Integer >> printSeparatedBy: aDelimiter every: offset signed: printSigned base: 
 			ifTrue: [ aStream nextPut: aDelimiter ] ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Integer >> printSeparatedBy: aDelimiter every: offset signed: printSigned on: aStream [
 	^ self printSeparatedBy: aDelimiter every: offset signed: printSigned base: 10 on: aStream
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Integer >> printString [
 	"For Integer, prefer the stream version to the string version for efficiency"
 
 	^String streamContents: [:str | self printOn: str base: 10]
 ]
 
-{ #category : #'printing - numerative' }
+{ #category : 'printing - numerative' }
 Integer >> printStringBase: base length: minimum padded: zeroFlag [
 
 	^ String streamContents: [:s| self printOn: s base: base length: minimum padded: zeroFlag]
 ]
 
-{ #category : #'printing - numerative' }
+{ #category : 'printing - numerative' }
 Integer >> printStringHex [
 	"Returns the hex digit part of the integer when printed in hexadecimal format."
 	"30 printStringHex >>> '1E'"
@@ -1409,22 +1411,22 @@ Integer >> printStringHex [
 	^ self printStringBase: 16
 ]
 
-{ #category : #'printing - numerative' }
+{ #category : 'printing - numerative' }
 Integer >> printStringLength: minimal [
 	^self printStringLength: minimal padded: false
 ]
 
-{ #category : #'printing - numerative' }
+{ #category : 'printing - numerative' }
 Integer >> printStringLength: minimal padded: zeroFlag [
 	^self printStringBase: 10 length: minimal padded: zeroFlag
 ]
 
-{ #category : #'printing - numerative' }
+{ #category : 'printing - numerative' }
 Integer >> printStringPadded: minimal [
 	^self printStringLength: minimal padded: true
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Integer >> printStringRadix: baseInteger [
 	"Return a string containing a sequence of characters that represents the
 	numeric value of the receiver in the radix specified by the argument.
@@ -1444,21 +1446,21 @@ Integer >> printStringRadix: baseInteger [
 	^ self storeStringBase: baseInteger
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Integer >> printWithCommasOn: aStream [
 	"123456789 asStringWithCommas"
 	"-123456789 asStringWithCommas"
 	^ self printSeparatedBy: $, every: 3 signed: false on: aStream
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Integer >> printWithCommasSignedOn: aStream [
 	"123456789 asStringWithCommasSigned"
 	"-123456789 asStringWithCommasSigned"
 	^ self printSeparatedBy: $, every: 3 signed: true on: aStream
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Integer >> quo: aNumber [
 	"Refer to the comment in Number quo: "
 	| ng quo |
@@ -1469,12 +1471,12 @@ Integer >> quo: aNumber [
 	^ aNumber adaptToInteger: self andSend: #quo:
 ]
 
-{ #category : #'printing - numerative' }
+{ #category : 'printing - numerative' }
 Integer >> radix: base [
 	^ self printStringBase: base
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Integer >> reciprocalModulo: n [
 	"Answer an integer x such that (self * x) \\ n = 1, x > 0, x < n.
 	Raise an error if there is no such integer.
@@ -1502,7 +1504,7 @@ Integer >> reciprocalModulo: n [
 		ifFalse: [result2]
 ]
 
-{ #category : #'system primitives' }
+{ #category : 'system primitives' }
 Integer >> replaceFrom: start to: stop with: replacement startingAt: repStart [
 	| j |  "Catches failure if LgInt replace primitive fails"
 	j := repStart.
@@ -1512,19 +1514,19 @@ Integer >> replaceFrom: start to: stop with: replacement startingAt: repStart [
 		j := j+1]
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Integer >> round: numberOfWishedDecimal [
 	"Round the decimal part of the receiver to be limited to the number of wished decimal. Only leave a fixed amount of decimal. Integers there are already rounded."
 
 	^self
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Integer >> rounded [
 	"Refer to the comment in Number|rounded."
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Integer >> storeOn: aStream [
 	self < 0
 		ifTrue: [ aStream space ].
@@ -1532,7 +1534,7 @@ Integer >> storeOn: aStream [
 	super storeOn: aStream
 ]
 
-{ #category : #'printing - numerative' }
+{ #category : 'printing - numerative' }
 Integer >> storeOn: aStream base: base [
 	"Print a representation of the receiver on the stream
 	<aStream> in base <base> where
@@ -1548,7 +1550,7 @@ Integer >> storeOn: aStream base: base [
 	aStream nextPutAll: (integer printStringBase: base)
 ]
 
-{ #category : #'printing - numerative' }
+{ #category : 'printing - numerative' }
 Integer >> storeOn: aStream base: base length: minimum padded: zeroFlag [
 	| prefix |
 	prefix := self negative ifTrue: ['-'] ifFalse: [String new].
@@ -1556,7 +1558,7 @@ Integer >> storeOn: aStream base: base length: minimum padded: zeroFlag [
 	self print: (self abs printStringBase: base) on: aStream prefix: prefix length: minimum padded: zeroFlag
 ]
 
-{ #category : #'printing - numerative' }
+{ #category : 'printing - numerative' }
 Integer >> storeStringBase: base length: minimum padded: zeroFlag [
 	"(10 storeStringBase: 16 length: 6 padded: true) >>> '16r00A'"
 
@@ -1564,7 +1566,7 @@ Integer >> storeStringBase: base length: minimum padded: zeroFlag [
 			self storeOn: s base: base length: minimum padded: zeroFlag ]
 ]
 
-{ #category : #'printing - numerative' }
+{ #category : 'printing - numerative' }
 Integer >> storeStringHex [
 	"Returns a string representation of the receiver in base 16 in a way that executing it will return the receiver."
 	"10 storeStringHex >>> '16rA'"
@@ -1572,7 +1574,7 @@ Integer >> storeStringHex [
 	^ self storeStringBase: 16
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 Integer >> timesRepeat: aBlock [
 	"Evaluate the argument, aBlock, the number of times represented by the
 	receiver."
@@ -1585,12 +1587,12 @@ Integer >> timesRepeat: aBlock [
 			count := count + 1]
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Integer >> truncated [
 	"Refer to the comment in Number|truncated."
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 Integer >> | anInteger [
 	^self bitOr: anInteger
 ]

--- a/src/Kernel/LargeInteger.class.st
+++ b/src/Kernel/LargeInteger.class.st
@@ -2,19 +2,21 @@
 I represent integers of more than 30 bits.  These values are beyond the range of SmallInteger, and are encoded here as an array of 8-bit digits. 
 "
 Class {
-	#name : #LargeInteger,
-	#superclass : #Integer,
-	#type : #bytes,
-	#category : #'Kernel-Numbers'
+	#name : 'LargeInteger',
+	#superclass : 'Integer',
+	#type : 'bytes',
+	#category : 'Kernel-Numbers',
+	#package : 'Kernel',
+	#tag : 'Numbers'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 LargeInteger class >> isAbstract [
 
 	^ self == LargeInteger
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 LargeInteger >> * anInteger [
 	"Primitive. Multiply the receiver by the argument and answer with an
 	Integer result. Fail if either the argument or the result is not a
@@ -25,7 +27,7 @@ LargeInteger >> * anInteger [
 	^super * anInteger
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 LargeInteger >> + anInteger [
 	"Primitive. Add the receiver to the argument and answer with an
 	Integer result. Fail if either the argument or the result is not a
@@ -36,7 +38,7 @@ LargeInteger >> + anInteger [
 	^super + anInteger
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 LargeInteger >> - anInteger [
 	"Primitive. Subtract the argument from the receiver and answer with an
 	Integer result. Fail if either the argument or the result is not a
@@ -47,7 +49,7 @@ LargeInteger >> - anInteger [
 	^super - anInteger
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 LargeInteger >> / anInteger [
 	"Primitive. Divide the receiver by the argument and answer with the
 	result if the division is exact. Fail if the result is not a whole integer.
@@ -59,7 +61,7 @@ LargeInteger >> / anInteger [
 	^super / anInteger
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 LargeInteger >> // anInteger [
 	"Primitive. Divide the receiver by the argument and return the result.
 	Round the result down towards negative infinity to make it a whole
@@ -71,7 +73,7 @@ LargeInteger >> // anInteger [
 	^super // anInteger
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 LargeInteger >> < anInteger [
 	"Primitive. Compare the receiver with the argument and answer true if
 	the receiver is less than the argument. Otherwise answer false. Fail if the
@@ -82,7 +84,7 @@ LargeInteger >> < anInteger [
 	^super < anInteger
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 LargeInteger >> <= anInteger [
 	"Primitive. Compare the receiver with the argument and answer true if
 	the receiver is less than or equal to the argument. Otherwise answer false.
@@ -93,7 +95,7 @@ LargeInteger >> <= anInteger [
 	^super <= anInteger
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 LargeInteger >> > anInteger [
 	"Primitive. Compare the receiver with the argument and answer true if
 	the receiver is greater than the argument. Otherwise answer false. Fail if
@@ -104,7 +106,7 @@ LargeInteger >> > anInteger [
 	^super > anInteger
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 LargeInteger >> >= anInteger [
 	"Primitive. Compare the receiver with the argument and answer true if
 	the receiver is greater than or equal to the argument. Otherwise answer
@@ -115,7 +117,7 @@ LargeInteger >> >= anInteger [
 	^super >= anInteger
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 LargeInteger >> \\ aNumber [
 	"Primitive. Take the receiver modulo the argument. The result is the
 	remainder rounded towards negative infinity, of the receiver divided
@@ -139,14 +141,14 @@ LargeInteger >> \\ aNumber [
 	^super \\ aNumber
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 LargeInteger >> \\\ anInteger [
 	"a faster modulo method for use in DSA. Be careful if you try to use this elsewhere"
 
 	^(self digitDiv: anInteger neg: false) second
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 LargeInteger >> asFloat [
 	"Answer a Float that best approximates the value of the receiver.
 	This algorithm is optimized to process only the significant digits of a LargeInteger.
@@ -200,7 +202,7 @@ LargeInteger >> asFloat [
 	^result timesTwoPower: shift
 ]
 
-{ #category : #'system primitives' }
+{ #category : 'system primitives' }
 LargeInteger >> byteAt: index [
 	"Primitive. Answer the value of an indexable field in the receiver.   LargePositiveInteger uses bytes of base two number, and each is a 'digit' base 256.  Fail if the argument (the index) is not an Integer or is out of bounds. Essential.  See Object documentation whatIsAPrimitive."
 
@@ -210,7 +212,7 @@ LargeInteger >> byteAt: index [
 		ifFalse: [^super at: index]
 ]
 
-{ #category : #'system primitives' }
+{ #category : 'system primitives' }
 LargeInteger >> byteAt: index put: value [
 	"Primitive. Store the second argument (value) in the indexable field of
 	the receiver indicated by index. Fail if the value is negative or is larger
@@ -222,7 +224,7 @@ LargeInteger >> byteAt: index put: value [
 	^super at: index put: value
 ]
 
-{ #category : #'system primitives' }
+{ #category : 'system primitives' }
 LargeInteger >> bytesCount [
 	"Primitive. Answer the number of indexable fields in the receiver. This
 	value is the same as the largest legal subscript. Essential. See Object
@@ -232,21 +234,21 @@ LargeInteger >> bytesCount [
 	self primitiveFailed
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 LargeInteger >> hash [
 	^ self bytesCount <= 8
 		ifTrue: [ self ]
 		ifFalse: [ ByteArray hashBytes: self startingWith: self species hash ]
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 LargeInteger >> hashMultiply [
 	"Truncate to 28 bits and try again"
 
 	^(self bitAnd: 16rFFFFFFF) hashMultiply
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 LargeInteger >> highBitOfMagnitude [
 	"Answer the index of the high order bit of the magnitude of the
 	receiver, or zero if the receiver is zero.
@@ -259,17 +261,17 @@ LargeInteger >> highBitOfMagnitude [
 	^ lastDigit highBitOfPositiveReceiver + (8 * (realLength - 1))
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LargeInteger >> isLarge [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LargeInteger >> mightBeASquare [
 	self subclassResponsibility
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 LargeInteger >> printOn: aStream base: b nDigits: n [
 	"Append a representation of this number in base b on aStream using n digits.
 	In order to reduce cost of LargePositiveInteger ops, split the number of digts approximatily in two
@@ -291,7 +293,7 @@ LargeInteger >> printOn: aStream base: b nDigits: n [
 	tail printOn: aStream base: b nDigits: halfPower
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 LargeInteger >> quo: anInteger [
 	"Primitive. Divide the receiver by the argument and return the result.
 	Round the result down towards zero to make it a whole integer. Fail if
@@ -303,7 +305,7 @@ LargeInteger >> quo: anInteger [
 	^super quo: anInteger
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 LargeInteger >> rem: aNumber [
 	"Remainder defined in terms of quo:. See super rem:.
 	This is defined only to speed up case of large integers."
@@ -318,14 +320,14 @@ LargeInteger >> rem: aNumber [
 	^super rem: aNumber
 ]
 
-{ #category : #'system primitives' }
+{ #category : 'system primitives' }
 LargeInteger >> replaceFrom: start to: stop with: replacement startingAt: repStart [
 	"Primitive. This destructively replaces elements from start to stop in the receiver starting at index, repStart, in the collection, replacement. Answer the receiver. Range checks are performed in the primitive only. Optional. See Object documentation whatIsAPrimitive."
 	<primitive: 105>
 	^ super replaceFrom: start to: stop with: replacement startingAt: repStart
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 LargeInteger >> withAtLeastNDigits: desiredLength [
 
 	| new |

--- a/src/Kernel/LargeNegativeInteger.class.st
+++ b/src/Kernel/LargeNegativeInteger.class.st
@@ -2,23 +2,25 @@
 Just like LargePositiveInteger, but represents a negative number.
 "
 Class {
-	#name : #LargeNegativeInteger,
-	#superclass : #LargeInteger,
-	#type : #bytes,
-	#category : #'Kernel-Numbers'
+	#name : 'LargeNegativeInteger',
+	#superclass : 'LargeInteger',
+	#type : 'bytes',
+	#category : 'Kernel-Numbers',
+	#package : 'Kernel',
+	#tag : 'Numbers'
 }
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 LargeNegativeInteger >> abs [
 	^ self negated
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 LargeNegativeInteger >> asFloat [
 	^super asFloat negated
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 LargeNegativeInteger >> bitAt: anInteger [
 	"super would not work because we have to pretend we are in two-complement.
 	this has to be tricky..."
@@ -47,7 +49,7 @@ LargeNegativeInteger >> bitAt: anInteger [
 	^1 - ((self byteAt: digitIndex) bitAt: bitIndex)
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 LargeNegativeInteger >> highBit [
 	"Answer the index of the high order bit of the receiver, or zero if the
 	receiver is zero. Raise an error if the receiver is negative, since
@@ -58,24 +60,24 @@ LargeNegativeInteger >> highBit [
 	^ self shouldNotImplement
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LargeNegativeInteger >> mightBeASquare [
 	^false
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 LargeNegativeInteger >> negated [
 	^ self copyto: (LargePositiveInteger new: self bytesCount)
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LargeNegativeInteger >> negative [
 	"Answer whether the receiver is mathematically negative."
 
 	^ true
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 LargeNegativeInteger >> normalize [
 	"Check for leading zeroes and return shortened copy if so"
 	| sLen val len oldLen minVal |
@@ -114,7 +116,7 @@ LargeNegativeInteger >> normalize [
 		ifFalse: [^ self]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LargeNegativeInteger >> positive [
 	"Answer whether the receiver is positive or equal to 0. (ST-80 protocol).
 	See also strictlyPositive"
@@ -122,7 +124,7 @@ LargeNegativeInteger >> positive [
 	^ false
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 LargeNegativeInteger >> printOn: aStream base: b [
 	"Append a representation of this number in base b on aStream."
 
@@ -130,21 +132,21 @@ LargeNegativeInteger >> printOn: aStream base: b [
 	self abs printOn: aStream base: b
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LargeNegativeInteger >> sign [
 	"Optimization. Answer -1 since receiver is less than 0."
 
 	^ -1
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LargeNegativeInteger >> signBit [
 	"Optimization."
 
 	^1
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LargeNegativeInteger >> strictlyPositive [
 	"Answer whether the receiver is mathematically positive."
 

--- a/src/Kernel/LargePositiveInteger.class.st
+++ b/src/Kernel/LargePositiveInteger.class.st
@@ -4,17 +4,19 @@ I represent positive integers of more than 30 bits (ie, >= 1073741824).  These v
 Note that the bit manipulation primitives, bitAnd:, bitShift:, etc., = and ~= run without failure (and therefore fast) if the value fits in 32 bits.  This is a great help to the simulator.
 "
 Class {
-	#name : #LargePositiveInteger,
-	#superclass : #LargeInteger,
-	#type : #bytes,
-	#category : #'Kernel-Numbers'
+	#name : 'LargePositiveInteger',
+	#superclass : 'LargeInteger',
+	#type : 'bytes',
+	#category : 'Kernel-Numbers',
+	#package : 'Kernel',
+	#tag : 'Numbers'
 }
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 LargePositiveInteger >> abs [
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 LargePositiveInteger >> bitAt: anInteger [
 	"Optimize super algorithm to avoid long bit operations.
 	Instead work on digits which are known to be SmallInteger and fast.
@@ -27,7 +29,7 @@ LargePositiveInteger >> bitAt: anInteger [
 	^(self byteAt: digitIndex) bitAt: bitIndex
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 LargePositiveInteger >> hashMultiply [
 	"This is a multiplication of hashes by 1664525 mod 2^28 written to avoid overflowing into large integers.
 	 The primitive is able to perform the operation with modulo arihmetic.
@@ -42,7 +44,7 @@ LargePositiveInteger >> hashMultiply [
 	^(self bitAnd: 16rFFFFFFF) hashMultiply
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 LargePositiveInteger >> highBit [
 	"Answer the index of the high order bit of the receiver, or zero if the
 	receiver is zero. Raise an error if the receiver is negative, since
@@ -52,7 +54,7 @@ LargePositiveInteger >> highBit [
 	^ self highBitOfMagnitude
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LargePositiveInteger >> mightBeASquare [
 	"In base 16, a square number can end only with 0,1,4 or 9 and
 	- in case 0, only 0,1,4,9 can precede it,
@@ -77,20 +79,20 @@ LargePositiveInteger >> mightBeASquare [
 		or: [ (lsb bitAnd: 16r7F) = 16 ]]]]	"10 or 90"
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 LargePositiveInteger >> negated [
 	^ (self copyto: (LargeNegativeInteger new: self bytesCount))
 		normalize  "Need to normalize to catch SmallInteger minVal"
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LargePositiveInteger >> negative [
 	"Answer whether the receiver is mathematically negative."
 
 	^ false
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 LargePositiveInteger >> normalize [
 	"Check for leading zeroes and return shortened copy if so"
 	| sLen val len oldLen |
@@ -119,7 +121,7 @@ LargePositiveInteger >> normalize [
 		ifFalse: [^ self]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LargePositiveInteger >> positive [
 	"Answer whether the receiver is positive or equal to 0. (ST-80 protocol).
 	See also strictlyPositive"
@@ -127,7 +129,7 @@ LargePositiveInteger >> positive [
 	^ true
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 LargePositiveInteger >> printOn: aStream base: b [
 	"Append a representation of this number in base b on aStream.
 	In order to reduce cost of LargePositiveInteger ops, split the number in approximately two equal parts in number of digits."
@@ -160,21 +162,21 @@ LargePositiveInteger >> printOn: aStream base: b [
 	tail printOn: aStream base: b nDigits: halfDigits
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LargePositiveInteger >> sign [
 	"Optimization. Answer 1 since receiver is greater than 0."
 
 	^ 1
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LargePositiveInteger >> signBit [
 	"Optimization."
 
 	^0
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LargePositiveInteger >> strictlyPositive [
 	"Answer whether the receiver is mathematically positive."
 

--- a/src/Kernel/LayoutClassScope.class.st
+++ b/src/Kernel/LayoutClassScope.class.st
@@ -2,16 +2,18 @@
 I am layout scope for classes.
 "
 Class {
-	#name : #LayoutClassScope,
-	#superclass : #AbstractLayoutScope,
-	#type : #variable,
+	#name : 'LayoutClassScope',
+	#superclass : 'AbstractLayoutScope',
+	#type : 'variable',
 	#instVars : [
 		'parentScope'
 	],
-	#category : #'Kernel-Layout'
+	#category : 'Kernel-Layout',
+	#package : 'Kernel',
+	#tag : 'Layout'
 }
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 LayoutClassScope >> = other [
 	super = other
 		ifFalse: [ ^ false ].
@@ -26,13 +28,13 @@ LayoutClassScope >> = other [
 	^ self parentScope = other parentScope
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 LayoutClassScope >> allSlotsDo: aBlock [
 	parentScope allSlotsDo: aBlock.
 	self do: aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LayoutClassScope >> allVisibleSlots [
 	| result |
 	result := parentScope allVisibleSlots.
@@ -42,18 +44,18 @@ LayoutClassScope >> allVisibleSlots [
 	^ result
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 LayoutClassScope >> do: aBlock [
 	1 to: self size do: [ :index |
 		aBlock value: (self at: index) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LayoutClassScope >> fieldSize [
 	^ parentScope fieldSize + self ownFieldSize
 ]
 
-{ #category : #flattening }
+{ #category : 'flattening' }
 LayoutClassScope >> flattenIn: aCollection [
 
 	parentScope flattenIn: aCollection.
@@ -61,7 +63,7 @@ LayoutClassScope >> flattenIn: aCollection [
 	^ aCollection
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 LayoutClassScope >> hasBindingThatBeginsWith: aString [
 	"Answer true if there is a Slot name that begins with aString, false otherwise"
 
@@ -71,7 +73,7 @@ LayoutClassScope >> hasBindingThatBeginsWith: aString [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LayoutClassScope >> hasFields [
 	self do: [ :slot |
 		slot size > 0
@@ -79,14 +81,14 @@ LayoutClassScope >> hasFields [
 	^ parentScope hasFields
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LayoutClassScope >> hasSlots [
 	self size > 0
 		ifTrue: [ ^ true ].
 	^ parentScope hasSlots
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 LayoutClassScope >> hash [
 	| hash |
 	hash := super hash.
@@ -95,13 +97,13 @@ LayoutClassScope >> hash [
 	^ hash + self parentScope hash hashMultiply
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LayoutClassScope >> ifNotEmpty: aBlock [
 	"This scope is not empty so we evaluate the block"
 	aBlock value: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LayoutClassScope >> ownFieldSize [
 	|result|
 	result := 0.
@@ -109,31 +111,31 @@ LayoutClassScope >> ownFieldSize [
 	^ result
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LayoutClassScope >> parentScope [
 	^ parentScope
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LayoutClassScope >> parentScope: aLayoutScope [
 	parentScope := aLayoutScope
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 LayoutClassScope >> postCopy [
 	parentScope := parentScope copy.
 	1 to: self size do: [ :index |
 		self at: index put: (self at: index) copy ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 LayoutClassScope >> printOn: aStream [
 
 	super printOn: aStream.
 	self allVisibleSlots printElementsOn: aStream
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 LayoutClassScope >> reverseDo: aBlock [
 	|size|
 	size := self size.
@@ -141,7 +143,7 @@ LayoutClassScope >> reverseDo: aBlock [
 		aBlock value: (self at: (1 + size - index)) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LayoutClassScope >> slots [
 	| result |
 	result := OrderedCollection new.
@@ -149,7 +151,7 @@ LayoutClassScope >> slots [
 	^ result asArray
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LayoutClassScope >> visibleSlots [
 	| result |
 	result := OrderedCollection new.
@@ -159,7 +161,7 @@ LayoutClassScope >> visibleSlots [
 	^ result asArray
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 LayoutClassScope >> withIndexDo: elementAndIndexBlock [
 	"Just like do: except that the iteration index supplies the second argument to the block"
 	1 to: self size do:

--- a/src/Kernel/LayoutEmptyScope.class.st
+++ b/src/Kernel/LayoutEmptyScope.class.st
@@ -2,66 +2,68 @@
 I am the last layout scope in a scope chain.
 "
 Class {
-	#name : #LayoutEmptyScope,
-	#superclass : #AbstractLayoutScope,
+	#name : 'LayoutEmptyScope',
+	#superclass : 'AbstractLayoutScope',
 	#classInstVars : [
 		'instance'
 	],
-	#category : #'Kernel-Layout'
+	#category : 'Kernel-Layout',
+	#package : 'Kernel',
+	#tag : 'Layout'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LayoutEmptyScope class >> instance [
 	^ instance ifNil: [ instance := self new ]
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 LayoutEmptyScope >> allSlotsDo: aBlock [
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LayoutEmptyScope >> allVisibleSlots [
 	^ OrderedCollection new
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LayoutEmptyScope >> fieldSize [
 	^ 0
 ]
 
-{ #category : #flattening }
+{ #category : 'flattening' }
 LayoutEmptyScope >> flattenIn: aCollection [
 	"Nothing to add"
 
 	^ aCollection
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LayoutEmptyScope >> hasBindingThatBeginsWith: aString [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LayoutEmptyScope >> hasFields [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LayoutEmptyScope >> hasSlots [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LayoutEmptyScope >> ifNotEmpty: aBlock [
 	"This scope is empty so we do nothing"
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LayoutEmptyScope >> ownFieldSize [
 	^ 0
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LayoutEmptyScope >> visibleSlots [
 	^ #()
 ]

--- a/src/Kernel/LegacyClassDefinitionPrinter.class.st
+++ b/src/Kernel/LegacyClassDefinitionPrinter.class.st
@@ -6,12 +6,14 @@ The reason we still need this is that there are still parts of the system that u
 When the last users have been fixed, we can remove this class
 "
 Class {
-	#name : #LegacyClassDefinitionPrinter,
-	#superclass : #ClassDefinitionPrinter,
-	#category : #'Kernel-ClassDefinitionPrinter'
+	#name : 'LegacyClassDefinitionPrinter',
+	#superclass : 'ClassDefinitionPrinter',
+	#category : 'Kernel-ClassDefinitionPrinter',
+	#package : 'Kernel',
+	#tag : 'ClassDefinitionPrinter'
 }
 
-{ #category : #'public API' }
+{ #category : 'public API' }
 LegacyClassDefinitionPrinter >> classDefinitionString [
 
 	"Answer a String that defines the receiver in the old format using poolDictionaries and category.
@@ -50,7 +52,7 @@ LegacyClassDefinitionPrinter >> classDefinitionString [
 	^ aStream contents
 ]
 
-{ #category : #template }
+{ #category : 'template' }
 LegacyClassDefinitionPrinter >> classDefinitionTemplateInPackage: aString named: aClassName [
 
 	^ String streamContents: [ :s |
@@ -73,13 +75,13 @@ LegacyClassDefinitionPrinter >> classDefinitionTemplateInPackage: aString named:
 			  nextPutAll: '''' ]
 ]
 
-{ #category : #delegating }
+{ #category : 'delegating' }
 LegacyClassDefinitionPrinter >> expandedDefinitionString [
 	"We do not support expansion on legacy syntax so we shortcut the double dispatch call."
 	^ self definitionString
 ]
 
-{ #category : #'public API' }
+{ #category : 'public API' }
 LegacyClassDefinitionPrinter >> metaclassDefinitionString [
 
 	^ String streamContents: [:stream |
@@ -90,7 +92,7 @@ LegacyClassDefinitionPrinter >> metaclassDefinitionString [
 			store: forClass instanceVariablesString ]
 ]
 
-{ #category : #template }
+{ #category : 'template' }
 LegacyClassDefinitionPrinter >> testClassDefinitionTemplateInPackage: aString [
 
 	^ String streamContents: [ :s |
@@ -101,7 +103,7 @@ LegacyClassDefinitionPrinter >> testClassDefinitionTemplateInPackage: aString [
 			s nextPutAll: 'category ''', aString, '''' ]
 ]
 
-{ #category : #'public API' }
+{ #category : 'public API' }
 LegacyClassDefinitionPrinter >> traitDefinitionString [
 
 	^ String streamContents: [ :s |
@@ -118,7 +120,7 @@ LegacyClassDefinitionPrinter >> traitDefinitionString [
 	]
 ]
 
-{ #category : #template }
+{ #category : 'template' }
 LegacyClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aString named: aTraitName [
 
 	^ String streamContents: [ :s |
@@ -132,7 +134,7 @@ LegacyClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aString named:
 			  nextPut: $' ]
 ]
 
-{ #category : #'public API' }
+{ #category : 'public API' }
 LegacyClassDefinitionPrinter >> traitedMetaclassDefinitionString [
 
 	^ self metaclassDefinitionString

--- a/src/Kernel/LiteralVariable.class.st
+++ b/src/Kernel/LiteralVariable.class.st
@@ -13,22 +13,24 @@ When moving binding from Undeclared, we change the class of that binding to eith
 ==> when we use Global subclasses, we will either need to restrict adding variables or add a slow path where we create a new binding and update all users. But this can be done later.
 "
 Class {
-	#name : #LiteralVariable,
-	#superclass : #Variable,
+	#name : 'LiteralVariable',
+	#superclass : 'Variable',
 	#instVars : [
 		'value'
 	],
-	#category : #'Kernel-Variables'
+	#category : 'Kernel-Variables',
+	#package : 'Kernel',
+	#tag : 'Variables'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 LiteralVariable class >> key: aKey [
 	"Answer an instance of me with the argument as the lookup up."
 
 	^self basicNew key: aKey
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 LiteralVariable class >> key: newKey value: newValue [
 	"Answer an instance of me with the arguments as the key and value of
 	the association."
@@ -36,40 +38,40 @@ LiteralVariable class >> key: newKey value: newValue [
 	^self basicNew key: newKey value: newValue
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 LiteralVariable >> = anAssociation [
 
 	^ super = anAssociation and: [value = anAssociation value]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 LiteralVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 	^ aProgramNodeVisitor visitLiteralVariableNode: aNode
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LiteralVariable >> analogousCodeTo: anAssociation [
 	^ self = anAssociation
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 LiteralVariable >> asClassVariable [
 	^self
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 LiteralVariable >> definingClass [
 	"The class defining the variable. For Globals, return nil"
 	^Smalltalk globals allClasses detect: [ :class | class hasClassVariable: self ] ifNone: [ nil ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 LiteralVariable >> definitionString [
 	"Every subclass that adds state must redefine either this method or #printOn:"
 	^ self printString
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 LiteralVariable >> emitStore: aMethodBuilder [
 	| tempName |
 	tempName := '0TempForStackManipulation'.
@@ -82,48 +84,48 @@ LiteralVariable >> emitStore: aMethodBuilder [
 		send: #write:
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 LiteralVariable >> emitValue: aMethodBuilder [
 	aMethodBuilder
 		pushLiteral: self;
 		send: #read
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 LiteralVariable >> hash [
 	"Hash is reimplemented because = is implemented."
 
 	^name hash
 ]
 
-{ #category : #'class building' }
+{ #category : 'class building' }
 LiteralVariable >> installingIn: aClass [
 	"I am called by the class builder. This way a class variable can change the class it is installed in"
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LiteralVariable >> isAccessedIn: aMethod [
 
 	^aMethod accessesRef: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LiteralVariable >> isGlobalClassNameBinding [
 	^ self value isClassOrTrait
 		and: [ (name == self value name) or: [ self value isObsolete ] ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LiteralVariable >> isLiteralVariable [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LiteralVariable >> isReadIn: aCompiledCode [
 	^aCompiledCode readsRef: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LiteralVariable >> isReferenced [
 	"my subclasses override this if they know better"
 
@@ -131,18 +133,18 @@ LiteralVariable >> isReferenced [
 		  behavior hasMethodAccessingVariable: self ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LiteralVariable >> isSelfEvaluating [
 	^ self key isSelfEvaluating and: [self value isSelfEvaluating]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LiteralVariable >> isVariableBinding [
 	"Maybe we should deprecate this and use isLiteralVariable instead"
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LiteralVariable >> isWritable [
 	"Literal variables are writable, if they aren't global bindings for class names, like
  #Object -> Object "
@@ -150,22 +152,22 @@ LiteralVariable >> isWritable [
 	^ (self isGlobalVariable and: [ self isGlobalClassNameBinding ]) not
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LiteralVariable >> isWrittenIn: aCompiledCode [
 	^aCompiledCode writesRef: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LiteralVariable >> key [
 	^name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LiteralVariable >> key: anObject [
 	name := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LiteralVariable >> key: aKey value: anObject [
 	"Store the arguments as the variables of the receiver."
 
@@ -173,7 +175,7 @@ LiteralVariable >> key: aKey value: anObject [
 	value := anObject
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 LiteralVariable >> literalEqual: otherLiteral [
 	"Answer true if the receiver and otherLiteral represent the same literal.
 	Variable bindings are literally equals only if identical.
@@ -181,12 +183,12 @@ LiteralVariable >> literalEqual: otherLiteral [
 	^self == otherLiteral
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LiteralVariable >> name: aString [
 	self key: aString asSymbol
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 LiteralVariable >> printOn: aStream [
 
 	name printOn: aStream.
@@ -194,17 +196,17 @@ LiteralVariable >> printOn: aStream [
 	value printOn: aStream
 ]
 
-{ #category : #'meta-object-protocol' }
+{ #category : 'meta-object-protocol' }
 LiteralVariable >> read [
 	^self value
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 LiteralVariable >> readInContext: aContext [
 	^self value
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 LiteralVariable >> runtimeUndeclaredRead [
 	"This method is used internally to compile polymorphic read on undeclared variables.
 	Do not call it youself to not polute senders."
@@ -212,7 +214,7 @@ LiteralVariable >> runtimeUndeclaredRead [
 	^ self read
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 LiteralVariable >> runtimeUndeclaredWrite: anObject [
 	"This method is used internally to compile polymorphic write on undeclared variables.
 	Do not call it youself to not polute senders."
@@ -220,12 +222,12 @@ LiteralVariable >> runtimeUndeclaredWrite: anObject [
 	^ self write: anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LiteralVariable >> scope [
 	^self definingClass
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 LiteralVariable >> storeOn: aStream [
 	"Store in the format (key->value)"
 	aStream nextPut: $(.
@@ -235,28 +237,28 @@ LiteralVariable >> storeOn: aStream [
 	aStream nextPut: $)
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 LiteralVariable >> usingMethods [
 	^SystemNavigation new allReferencesToBinding: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LiteralVariable >> value [
 	^ value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LiteralVariable >> value: anObject [
 	value := anObject
 ]
 
-{ #category : #'meta-object-protocol' }
+{ #category : 'meta-object-protocol' }
 LiteralVariable >> write: anObject [
 	self value: anObject.
 	^anObject
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 LiteralVariable >> write: aValue inContext: aContext [
 	self isWritable ifFalse: [
 		^self error: 'Variable ' , name, ' is read only'].

--- a/src/Kernel/LocalRecursionStopper.class.st
+++ b/src/Kernel/LocalRecursionStopper.class.st
@@ -8,23 +8,25 @@ executes a block just once in a recursion in current process. If aBlock fork new
 A LocalRecursionStopper value is a collection of active methods which are currently called from within LocalRecrusionStopper>>#during: this means that recursion stopper can be used multiple places without one blocking the other
 "
 Class {
-	#name : #LocalRecursionStopper,
-	#superclass : #ProcessLocalVariable,
-	#category : #'Kernel-Processes'
+	#name : 'LocalRecursionStopper',
+	#superclass : 'ProcessLocalVariable',
+	#category : 'Kernel-Processes',
+	#package : 'Kernel',
+	#tag : 'Processes'
 }
 
-{ #category : #private }
+{ #category : 'private' }
 LocalRecursionStopper class >> activeMethods [
 	^self value ifNil: [ self value: IdentitySet new. self value ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 LocalRecursionStopper class >> during: aBlock [
 	<debuggerCompleteToSender>
 	self stopMethod: thisContext sender homeMethod during: aBlock
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 LocalRecursionStopper class >> stopMethod: aMethod during: aBlock [
 
 	| activeMethods |

--- a/src/Kernel/LocalTimeZone.class.st
+++ b/src/Kernel/LocalTimeZone.class.st
@@ -4,22 +4,24 @@ I am the local time zone which will use the system's current time offset dynamic
 This is the default timezone.
 "
 Class {
-	#name : #LocalTimeZone,
-	#superclass : #AbstractTimeZone,
+	#name : 'LocalTimeZone',
+	#superclass : 'AbstractTimeZone',
 	#pools : [
 		'ChronologyConstants'
 	],
-	#category : #'Kernel-Chronology'
+	#category : 'Kernel-Chronology',
+	#package : 'Kernel',
+	#tag : 'Chronology'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LocalTimeZone >> abbreviation [
 	^ String streamContents: [ :s |
 		s nextPutAll: 'LT'; print: self offset hours; nextPut: $:.
 		s nextPutAll: (self offset minutes printPaddedWith: $0 to: 2) ]
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 LocalTimeZone >> asFixedTimeZone [
 	"Convert this dynamic timezone to one with a fixed offset."
 	^ TimeZone
@@ -28,17 +30,17 @@ LocalTimeZone >> asFixedTimeZone [
 		abbreviation: self abbreviation
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LocalTimeZone >> name [
 	^ 'Local Time'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LocalTimeZone >> offset [
 	^ self primOffset minutes
 ]
 
-{ #category : #primitives }
+{ #category : 'primitives' }
 LocalTimeZone >> primOffset [
 	"The offset from UTC in minutes, with positive offsets being towards the east.
 	(San Francisco is in UTC -07*60 and Paris is in UTC +02*60 (daylight savings is not in effect)."

--- a/src/Kernel/Magnitude.class.st
+++ b/src/Kernel/Magnitude.class.st
@@ -18,26 +18,28 @@ Here are some example of my protocol:
 
 "
 Class {
-	#name : #Magnitude,
-	#superclass : #Object,
-	#category : #'Kernel-Numbers'
+	#name : 'Magnitude',
+	#superclass : 'Object',
+	#category : 'Kernel-Numbers',
+	#package : 'Kernel',
+	#tag : 'Numbers'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 Magnitude >> < aMagnitude [
 	"Answer whether the receiver is less than the argument."
 
 	^self subclassResponsibility
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Magnitude >> <= aMagnitude [
 	"Answer whether the receiver is less than or equal to the argument."
 
 	^(self > aMagnitude) not
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Magnitude >> = aMagnitude [
 	"Compare the receiver with the argument and answer with true if the
 	receiver is equal to the argument. Otherwise answer false."
@@ -45,21 +47,21 @@ Magnitude >> = aMagnitude [
 	^self subclassResponsibility
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Magnitude >> > aMagnitude [
 	"Answer whether the receiver is greater than the argument."
 
 	^aMagnitude < self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Magnitude >> >= aMagnitude [
 	"Answer whether the receiver is greater than or equal to the argument."
 
 	^aMagnitude <= self
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Magnitude >> beBetween: minValue and: maxValue [
 	"Answer my value constrained to the interval [minValue ; maxValue]
 	I take care of the situation where minValue > maxValue"
@@ -74,7 +76,7 @@ Magnitude >> beBetween: minValue and: maxValue [
 		ifFalse: [ (self min: minValue) max: maxValue ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Magnitude >> between: min and: max [
 	"Answer whether the receiver is less than or equal to the argument, max,
 	and greater than or equal to the argument, min."
@@ -82,14 +84,14 @@ Magnitude >> between: min and: max [
 	^self >= min and: [self <= max]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Magnitude >> hash [
 	"Hash must be redefined whenever = is redefined."
 
 	^self subclassResponsibility
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Magnitude >> max: aMagnitude [
 	"Answer the receiver or the argument, whichever has the greater
 	magnitude."
@@ -99,7 +101,7 @@ Magnitude >> max: aMagnitude [
 		ifFalse: [aMagnitude]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Magnitude >> min: aMagnitude [
 	"Answer the receiver or the argument, whichever has the lesser
 	magnitude."
@@ -109,7 +111,7 @@ Magnitude >> min: aMagnitude [
 		ifFalse: [aMagnitude]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Magnitude >> min: maxValue max: minValue [
 	"Take the minimum between self and maxValue, then the maximum with minValue"
 	"(10 min: 20 max: 5) >>> 10"

--- a/src/Kernel/ManifestKernel.class.st
+++ b/src/Kernel/ManifestKernel.class.st
@@ -2,47 +2,49 @@
 Core classes of Pharo Smalltalk including basic objects, types, exceptions, process, etc.
 "
 Class {
-	#name : #ManifestKernel,
-	#superclass : #PackageManifest,
-	#category : #'Kernel-Manifest'
+	#name : 'ManifestKernel',
+	#superclass : 'PackageManifest',
+	#category : 'Kernel-Manifest',
+	#package : 'Kernel',
+	#tag : 'Manifest'
 }
 
-{ #category : #'meta-data' }
+{ #category : 'meta-data' }
 ManifestKernel class >> dependencies [
 	^ #(#'System-Announcements' #'System-CommandLine' #'Collections-Strings' #'Slot-Core' #'Collections-Unordered' #'Collections-Streams' #Files #'System-Object Events' #'Collections-Abstract' #'Collections-Native' #'Collections-Support' #'System-Support' #'Multilingual-Encodings' #'Collections-Sequenceable' #'NewValueHolder-Core' #'System-Sources' #Compiler #'OpalCompiler-Core' #'System-Finalization' #Traits #'Collections-Weak' #UIManager)
 ]
 
-{ #category : #'meta-data - dependency analyser' }
+{ #category : 'meta-data - dependency analyser' }
 ManifestKernel class >> ignoredDependencies [
 	^ #('Reflectivity' 'Regex-Core' 'System-Settings-Core' 'FFI-Kernel')
 ]
 
-{ #category : #'meta-data - dependency analyser' }
+{ #category : 'meta-data - dependency analyser' }
 ManifestKernel class >> manuallyResolvedDependencies [
 	^ #(#'System-Settings-Core' #'System-Sources' #'System-Platforms' #'Shift-ClassBuilder' #'Regex-Core' #'RPackage-Core' #Reflectivity #'Shift-ClassInstaller')
 ]
 
-{ #category : #'meta-data' }
+{ #category : 'meta-data' }
 ManifestKernel class >> packageName [
 	^ #Kernel
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestKernel class >> ruleRBBadMessageRuleV1FalsePositive [
 	^ #(#(#(#RGMethodDefinition #(#'Delay class' #delaySchedulerClass: #true)) #'2016-12-07T10:58:09.403079+08:00') #(#(#RGMethodDefinition #(#'Character class' #constantNameFor: #true)) #'2019-01-28T20:56:52.112604+01:00') )
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestKernel class >> ruleRBClassNameInSelectorRuleV1FalsePositive [
 	^ #(#(#(#RGMethodDefinition #(#'Character class' #allCharacters #true)) #'2019-01-28T20:55:17.784869+01:00') #(#(#RGMethodDefinition #(#'Character class' #allByteCharacters #true)) #'2019-01-28T20:55:32.378368+01:00') )
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestKernel class >> ruleRBRefersToClassRuleV1FalsePositive [
 	^ #(#(#(#RGMethodDefinition #(#'Character class' #allByteCharacters #true)) #'2019-01-28T20:55:28.683846+01:00') )
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestKernel class >> ruleReDeadMethodV1FalsePositive [
 	^ #(#(#(#RGMethodDefinition #(#'Character class' #characterSet: #true)) #'2019-01-28T20:56:23.286894+01:00') )
 ]

--- a/src/Kernel/Message.class.st
+++ b/src/Kernel/Message.class.st
@@ -4,24 +4,26 @@ I represent a selector and its argument values.
 Generally, the system does not use instances of Message for efficiency reasons. However, when a message is not understood by its receiver, the interpreter will make up an instance of me in order to capture the information involved in an actual message transmission. This instance is sent it as an argument with the message doesNotUnderstand: to the receiver.
 "
 Class {
-	#name : #Message,
-	#superclass : #Object,
+	#name : 'Message',
+	#superclass : 'Object',
 	#instVars : [
 		'selector',
 		'arguments',
 		'lookupClass'
 	],
-	#category : #'Kernel-Methods'
+	#category : 'Kernel-Methods',
+	#package : 'Kernel',
+	#tag : 'Methods'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Message class >> selector: aSymbol [
 	"Answer an instance of me with unary selector, aSymbol."
 
 	^self new setSelector: aSymbol arguments: (Array new: 0)
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Message class >> selector: aSymbol argument: anObject [
 	"Answer an instance of me whose selector is aSymbol and single
 	argument is anObject."
@@ -29,7 +31,7 @@ Message class >> selector: aSymbol argument: anObject [
 	^self new setSelector: aSymbol arguments: { anObject }
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Message class >> selector: aSymbol arguments: anArray [
 	"Answer an instance of me with selector, aSymbol, and arguments,
 	anArray."
@@ -37,7 +39,7 @@ Message class >> selector: aSymbol arguments: anArray [
 	^self new setSelector: aSymbol arguments: anArray
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Message >> analogousCodeTo: anObject [
 	"For MethodPropertires comparison."
 	^self class == anObject class
@@ -46,57 +48,57 @@ Message >> analogousCodeTo: anObject [
 	  and: [lookupClass == anObject lookupClass]]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Message >> argument [
 	"Answer the first (presumably sole) argument"
 
 	^arguments at: 1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Message >> argument: newValue [
 	"Change the first argument to newValue and answer self"
 
 	arguments at: 1 put: newValue
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Message >> arguments [
 	"Answer the arguments of the receiver."
 
 	^arguments
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Message >> asSendTo: anObject [
 	^MessageSend message: self to: anObject
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Message >> hasArguments [
 	^arguments notEmpty
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Message >> lookupClass [
 
 	^ lookupClass
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Message >> lookupClass: aClass [
 
 	lookupClass := aClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Message >> numArgs [
 	"Answer the number of arguments in this message"
 
 	^arguments size
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Message >> printOn: stream [
 
 	arguments ifEmpty: [ ^ stream nextPutAll: selector ].
@@ -108,28 +110,28 @@ Message >> printOn: stream [
 	stream skip: -1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Message >> selector [
 	"Answer the selector of the receiver."
 
 	^selector
 ]
 
-{ #category : #sending }
+{ #category : 'sending' }
 Message >> sendTo: receiver [
 	"answer the result of sending this message to receiver"
 
 	^ receiver perform: selector withArguments: arguments
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Message >> sends: aSelector [
 	"answer whether this message's selector is aSelector"
 
 	^selector == aSelector
 ]
 
-{ #category : #sending }
+{ #category : 'sending' }
 Message >> sentTo: receiver [
 	"answer the result of sending this message to receiver"
 
@@ -138,20 +140,20 @@ Message >> sentTo: receiver [
 		ifNotNil: [ receiver perform: selector withArguments: arguments inSuperclass: lookupClass]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Message >> setSelector: aSymbol [
 
 	selector := aSymbol
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Message >> setSelector: aSymbol arguments: anArray [
 
 	selector := aSymbol.
 	arguments := anArray
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Message >> storeOn: aStream [
 	"Refer to the comment in Object|storeOn:."
 

--- a/src/Kernel/MessageNotUnderstood.class.st
+++ b/src/Kernel/MessageNotUnderstood.class.st
@@ -2,30 +2,32 @@
 This exception is provided to support Object>>doesNotUnderstand:.
 "
 Class {
-	#name : #MessageNotUnderstood,
-	#superclass : #Error,
+	#name : 'MessageNotUnderstood',
+	#superclass : 'Error',
 	#instVars : [
 		'message',
 		'receiver',
 		'reachedDefaultHandler'
 	],
-	#category : #'Kernel-Exceptions'
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 MessageNotUnderstood class >> initialize [
 
 	self deprecatedAliases: { #VariableNotDeclared }
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MessageNotUnderstood >> defaultAction [
 
 	reachedDefaultHandler := true.
 	super defaultAction
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MessageNotUnderstood >> description [
 
 	"Returns a textual description of the exception (based on the message instance variable). If message is nil, it returns the defaultDescription instead."
@@ -38,34 +40,34 @@ MessageNotUnderstood >> description [
 	  , ' did not understand ' , message selector printString
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MessageNotUnderstood >> initialize [
 
 	super initialize.
 	reachedDefaultHandler := false
 ]
 
-{ #category : #'private - testing' }
+{ #category : 'private - testing' }
 MessageNotUnderstood >> isResumable [
 	"Determine whether an exception is resumable."
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MessageNotUnderstood >> message [
 	"Answer the selector and arguments of the message that failed."
 
 	^message
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MessageNotUnderstood >> message: aMessage [
 
 	message := aMessage
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MessageNotUnderstood >> messageText [
 	"Return an exception's message text."
 
@@ -79,19 +81,19 @@ MessageNotUnderstood >> messageText [
 							ifFalse: ['Message not understood: ', message lookupClass printString, ' >> #', message selector asString]]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MessageNotUnderstood >> reachedDefaultHandler [
 	^reachedDefaultHandler
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MessageNotUnderstood >> receiver [
 	"Answer the receiver that did not understand the message"
 
 	^ receiver
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MessageNotUnderstood >> receiver: obj [
 
 	receiver := obj

--- a/src/Kernel/MessageSend.class.st
+++ b/src/Kernel/MessageSend.class.st
@@ -9,32 +9,34 @@ Structure:
  arguments		Array -- bound arguments
 "
 Class {
-	#name : #MessageSend,
-	#superclass : #Object,
+	#name : 'MessageSend',
+	#superclass : 'Object',
 	#instVars : [
 		'receiver',
 		'selector',
 		'arguments'
 	],
-	#category : #'Kernel-Messaging'
+	#category : 'Kernel-Messaging',
+	#package : 'Kernel',
+	#tag : 'Messaging'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MessageSend class >> message: aMessage to: anObject [
 	^ self receiver: anObject selector: aMessage selector arguments: aMessage arguments
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MessageSend class >> receiver: anObject selector: aSymbol [
 	^ self receiver: anObject selector: aSymbol arguments: #()
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MessageSend class >> receiver: anObject selector: aSymbol argument: aParameter [
 	^ self receiver: anObject selector: aSymbol arguments: (Array with: aParameter)
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MessageSend class >> receiver: anObject selector: aSymbol arguments: anArray [
 	^ self new
 		receiver: anObject;
@@ -42,7 +44,7 @@ MessageSend class >> receiver: anObject selector: aSymbol arguments: anArray [
 		arguments: anArray
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MessageSend >> = anObject [
 	^ anObject species == self species
 		and: [receiver == anObject receiver
@@ -50,22 +52,22 @@ MessageSend >> = anObject [
 		and: [arguments = anObject arguments]]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MessageSend >> arguments [
 	^ arguments
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MessageSend >> arguments: anArray [
 	arguments := anArray
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 MessageSend >> asMinimalRepresentation [
 	^self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 MessageSend >> asWeakMessageSend [
 
 	^ WeakMessageSend
@@ -74,7 +76,7 @@ MessageSend >> asWeakMessageSend [
 		arguments: arguments copy
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MessageSend >> collectArguments: anArgArray [
 	"Private"
 
@@ -90,55 +92,55 @@ MessageSend >> collectArguments: anArgArray [
 				  startingAt: 1 ]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 MessageSend >> cull: arg [
 	^ selector numArgs = 0
 		ifTrue: [ self value ]
 		ifFalse: [ self value: arg ]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 MessageSend >> cull: arg1 cull: arg2 [
 	^ selector numArgs < 2
 		ifTrue: [ self cull: arg1]
 		ifFalse: [ self value: arg1 value: arg2 ]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 MessageSend >> cull: arg1 cull: arg2 cull: arg3 [
 	^ selector numArgs < 3
 		ifTrue: [ self cull: arg1 cull: arg2 ]
 		ifFalse: [ self value: arg1 value: arg2 value: arg3 ]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MessageSend >> hash [
 	^ receiver hash bitXor: selector hash
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MessageSend >> isMessageSend [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MessageSend >> isValid [
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MessageSend >> message [
 	^Message selector: selector arguments: arguments
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MessageSend >> numArgs [
 	"Answer the number of arguments in this message"
 
 	^arguments size
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MessageSend >> printOn: aStream [
 
         aStream
@@ -150,27 +152,27 @@ MessageSend >> printOn: aStream [
         aStream nextPut: $)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MessageSend >> receiver [
 	^ receiver
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MessageSend >> receiver: anObject [
 	receiver := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MessageSend >> selector [
 	^ selector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MessageSend >> selector: aSymbol [
 	selector := aSymbol
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 MessageSend >> value [
   "Send the message and answer the return value"
 
@@ -181,7 +183,7 @@ MessageSend >> value [
     withArguments: (self collectArguments: arguments)
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 MessageSend >> value: anObject [
 
   ^ receiver
@@ -189,7 +191,7 @@ MessageSend >> value: anObject [
     with: anObject
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 MessageSend >> value: anObject1 value: anObject2 [
 
 	^ receiver
@@ -198,7 +200,7 @@ MessageSend >> value: anObject1 value: anObject2 [
 		with: anObject2
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 MessageSend >> value: anObject1 value: anObject2 value: anObject3 [
 
 	^ receiver
@@ -208,7 +210,7 @@ MessageSend >> value: anObject1 value: anObject2 value: anObject3 [
 		with: anObject3
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 MessageSend >> valueWithArguments: anArray [
 
 	^ receiver
@@ -216,7 +218,7 @@ MessageSend >> valueWithArguments: anArray [
 		withArguments: (self collectArguments: anArray)
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 MessageSend >> valueWithEnoughArguments: anArray [
 	"call the selector with enough arguments from arguments and anArray"
 	| args |

--- a/src/Kernel/Metaclass.class.st
+++ b/src/Kernel/Metaclass.class.st
@@ -9,22 +9,24 @@ However there is a singularity at Object. Here the class hierarchy terminates, b
 	Object class superclass == Class.
 "
 Class {
-	#name : #Metaclass,
-	#superclass : #ClassDescription,
+	#name : 'Metaclass',
+	#superclass : 'ClassDescription',
 	#instVars : [
 		'thisClass'
 	],
-	#category : #'Kernel-Classes'
+	#category : 'Kernel-Classes',
+	#package : 'Kernel',
+	#tag : 'Classes'
 }
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 Metaclass >> acceptsLoggingOfCompilation [
 	"Answer whether the receiver's method submisions and class defintions should be logged to the changes file and to the current change set.  The metaclass follows the rule of the class itself."
 
 	^ self instanceSide acceptsLoggingOfCompilation
 ]
 
-{ #category : #'instance variables' }
+{ #category : 'instance variables' }
 Metaclass >> addInstVarNamed: aString [
 	"Add the argument, aString, as one of the receiver's instance variables."
 
@@ -35,23 +37,23 @@ Metaclass >> addInstVarNamed: aString [
 	self instanceVariableNames: fullString
 ]
 
-{ #category : #'class hierarchy' }
+{ #category : 'class hierarchy' }
 Metaclass >> addObsoleteSubclass: aClass [
 	"Do nothing."
 ]
 
-{ #category : #'instance variables' }
+{ #category : 'instance variables' }
 Metaclass >> addSlot: aClassSlot [
 
 	^self instanceSide addClassSlot: aClassSlot
 ]
 
-{ #category : #'class hierarchy' }
+{ #category : 'class hierarchy' }
 Metaclass >> addSubclass: aClass [
 	"Do nothing."
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 Metaclass >> adoptInstance: oldInstance from: oldMetaClass [
 	"Recreate any existing instances of the argument, oldClass, as instances of
 	the receiver, which is a newly changed class. Permute variables as
@@ -66,7 +68,7 @@ Metaclass >> adoptInstance: oldInstance from: oldMetaClass [
 		map: (self instVarMappingFrom: oldMetaClass)
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 Metaclass >> binding [
 	"return an association that can be used as the binding
 	 To share it between methods, reuse an existing one if possible"
@@ -75,25 +77,25 @@ Metaclass >> binding [
 		ifNotEmpty: [:dict | dict anyOne classBinding]
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 Metaclass >> bindingOf: varName [
 
 	^self instanceSide classBindingOf: varName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Metaclass >> category [
 	^ self instanceSide category
 ]
 
-{ #category : #'pool variables' }
+{ #category : 'pool variables' }
 Metaclass >> classPool [
 	"Answer the dictionary of class variables."
 
 	^self instanceSide classPool
 ]
 
-{ #category : #'accessing - parallel hierarchy' }
+{ #category : 'accessing - parallel hierarchy' }
 Metaclass >> classSide [
 	"Return the metaclass of the couple class/metaclass. Useful to avoid explicit test."
 	"Point classSide >>> Point class"
@@ -102,7 +104,7 @@ Metaclass >> classSide [
 	^ self
 ]
 
-{ #category : #'accessing - instances and variables' }
+{ #category : 'accessing - instances and variables' }
 Metaclass >> classVarNames [
 	"Answer the names of the class variables defined in the receiver's instance."
 
@@ -111,7 +113,7 @@ Metaclass >> classVarNames [
 		ifNotNil: [ :class | class classVarNames ]
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 Metaclass >> classVariables [
 	"Answer the class variables defined in the receiver's instance."
 
@@ -120,76 +122,76 @@ Metaclass >> classVariables [
 		ifNotNil: [ :class | class classVariables ]
 ]
 
-{ #category : #'accessing - comment' }
+{ #category : 'accessing - comment' }
 Metaclass >> comment [
     ^ self instanceSide comment
 ]
 
-{ #category : #'accessing - comment' }
+{ #category : 'accessing - comment' }
 Metaclass >> comment: aStringOrText [
 	"Set the receiver's comment to be the argument, aStringOrText."
 
 	self instanceSide comment: aStringOrText
 ]
 
-{ #category : #'accessing - comment' }
+{ #category : 'accessing - comment' }
 Metaclass >> comment: aStringOrText stamp: aStamp [
 	"Set the receiver's comment to be the argument, aStringOrText."
 
 	self instanceSide comment: aStringOrText stamp: aStamp
 ]
 
-{ #category : #'accessing - comment' }
+{ #category : 'accessing - comment' }
 Metaclass >> commentSourcePointer [
 	^ self instanceSide commentSourcePointer
 ]
 
-{ #category : #'accessing - comment' }
+{ #category : 'accessing - comment' }
 Metaclass >> commentSourcePointer: anObject [
 	^ self instanceSide commentSourcePointer: anObject
 ]
 
-{ #category : #'accessing - comment' }
+{ #category : 'accessing - comment' }
 Metaclass >> commentStamp [
 
 	^ self instanceSide commentStamp
 ]
 
-{ #category : #'accessing - comment' }
+{ #category : 'accessing - comment' }
 Metaclass >> commentStamp: changeStamp [
 	self instanceSide commentStamp: changeStamp
 ]
 
-{ #category : #fileout }
+{ #category : 'fileout' }
 Metaclass >> definitionStringFor: aConfiguredPrinter [
 
 	^ aConfiguredPrinter metaclassDefinitionString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Metaclass >> environment [
 
 	^thisClass environment
 ]
 
-{ #category : #fileout }
+{ #category : 'fileout' }
 Metaclass >> expandedDefinitionStringFor: aPrinter [
 
 	^ aPrinter expandedMetaclassDefinitionString
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Metaclass >> hasBindingThatBeginsWith: aString [
 	"class and pool vars are accessible from the class side the same as the instance side"
 	^self instanceSide hasBindingThatBeginsWith: aString
 ]
 
-{ #category : #'accessing - parallel hierarchy - deprecated' }
+{ #category : 'accessing - parallel hierarchy - deprecated' }
 Metaclass >> hasClassSide [
 	^ false
 ]
 
-{ #category : #'accessing - instances and variables' }
+{ #category : 'accessing - instances and variables' }
 Metaclass >> hasClassVarNamed: aString [
 
 	^self instanceSide
@@ -197,19 +199,19 @@ Metaclass >> hasClassVarNamed: aString [
 		ifNotNil: [ :class | class hasClassVarNamed: aString ]
 ]
 
-{ #category : #'accessing - comment' }
+{ #category : 'accessing - comment' }
 Metaclass >> hasComment [
 	"Return whether this class truly has a comment other than the default"
 	^ self instanceSide hasComment
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 Metaclass >> innerBindingOf: varName [
 
 	^self instanceSide innerBindingOf: varName
 ]
 
-{ #category : #'accessing - parallel hierarchy' }
+{ #category : 'accessing - parallel hierarchy' }
 Metaclass >> instanceSide [
 	"Return the class of the couple class/metaclass. Useful to avoid explicit test."
 	"Point instanceSide >>> Point"
@@ -218,23 +220,23 @@ Metaclass >> instanceSide [
 	^ self soleInstance
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Metaclass >> isAnonymous [
 	^self soleInstance isAnonymous
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Metaclass >> isClass [
 
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Metaclass >> isMeta [
 	^ true
 ]
 
-{ #category : #'class hierarchy' }
+{ #category : 'class hierarchy' }
 Metaclass >> isMetaclassOfClassOrNil [
 
 	^ self instanceSide
@@ -242,7 +244,7 @@ Metaclass >> isMetaclassOfClassOrNil [
 		ifNotNil: [ :nonMetaClass | nonMetaClass == Class ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Metaclass >> isObsolete [
 	"Return true if the receiver is obsolete"
 	^self soleInstance isNil "Either no thisClass"
@@ -250,24 +252,24 @@ Metaclass >> isObsolete [
 			or:[self soleInstance isObsolete]] "or my instance is obsolete"
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Metaclass >> isReferenced [
 	"Metaclasses are never directly referenced in code"
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Metaclass >> isSelfEvaluating [
 	^self isObsolete not
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Metaclass >> isUsed [
 	"Metaclasses are used by default"
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Metaclass >> name [
 
 	"Answer a String that is the name of the receiver, either 'Metaclass' or
@@ -276,7 +278,7 @@ Metaclass >> name [
 	^ thisClass ifNil: [ 'a Metaclass' ] ifNotNil: [ thisClass name asString , ' class' ]
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Metaclass >> new [
 	"The receiver can only have one instance. Create it or complain that
 	one already exists."
@@ -286,13 +288,13 @@ Metaclass >> new [
 		ifFalse: [self error: 'A Metaclass should only have one instance!']
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Metaclass >> newAnonymousSubclass [
 
 	^self instanceSide newAnonymousSubclass class
 ]
 
-{ #category : #'class hierarchy' }
+{ #category : 'class hierarchy' }
 Metaclass >> obsoleteSubclasses [
 	"Answer the receiver's subclasses."
 
@@ -300,13 +302,13 @@ Metaclass >> obsoleteSubclasses [
 	^ self instanceSide obsoleteSubclasses collect: [ :aSubclass | aSubclass classSide ]
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 Metaclass >> possibleVariablesFor: misspelled continuedFrom: oldResults [
 
 	^ self instanceSide possibleVariablesFor: misspelled continuedFrom: oldResults
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Metaclass >> postCopy [
 	"Don't share the reference to the sole instance."
 
@@ -315,23 +317,23 @@ Metaclass >> postCopy [
 	thisClass := nil
 ]
 
-{ #category : #'instance variables' }
+{ #category : 'instance variables' }
 Metaclass >> removeSlot: aClassSlot [
 
 	^self instanceSide removeClassSlot: aClassSlot
 ]
 
-{ #category : #'class hierarchy' }
+{ #category : 'class hierarchy' }
 Metaclass >> removeSubclass: aClass [
 	"Do nothing."
 ]
 
-{ #category : #'pool variables' }
+{ #category : 'pool variables' }
 Metaclass >> sharedPoolNames [
 	^#()
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Metaclass >> slots: slotCollection [
 
 	| theClass |
@@ -342,14 +344,14 @@ Metaclass >> slots: slotCollection [
 	^ theClass classSide
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Metaclass >> soleInstance [
 	"The receiver has only one instance. Answer it."
 
 	^thisClass
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 Metaclass >> sourceCodeTemplate [
 	"Answer an expression to be edited and evaluated in order to define
 	methods in this class or trait."
@@ -362,7 +364,7 @@ Metaclass >> sourceCodeTemplate [
 	statements'
 ]
 
-{ #category : #'class hierarchy' }
+{ #category : 'class hierarchy' }
 Metaclass >> subclasses [
 	"Answer the receiver's subclasses."
 
@@ -370,7 +372,7 @@ Metaclass >> subclasses [
 	^ self instanceSide subclasses collect: [ :aSubclass | aSubclass classSide ]
 ]
 
-{ #category : #'class hierarchy' }
+{ #category : 'class hierarchy' }
 Metaclass >> subclassesDo: aBlock [
 	"Evaluate aBlock for each of the receiver's immediate subclasses."
 
@@ -378,13 +380,13 @@ Metaclass >> subclassesDo: aBlock [
 	self instanceSide subclasses do: [ :each | aBlock value: each classSide ]
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Metaclass >> veryDeepCopyWith: deepCopier [
 
 	"Return self.  Must be created, not copied.  Do not record me."
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 Metaclass >> wantsChangeSetLogging [
 	"Answer whether code submitted for the receiver should be remembered by the changeSet mechanism.The metaclass follows the rule of the class itself."
 

--- a/src/Kernel/MethodDictionary.class.st
+++ b/src/Kernel/MethodDictionary.class.st
@@ -25,13 +25,15 @@ There used to be confusion in Squeak, which Pharo inherited, that using Compiled
 The VM must be told to flush the cached state for a compiled method via CompiledMethod>>flushCache and will /try/ and void the state for that method.  But it can't always deal with existing activations of that method, because if there are activations running the machine code, that machine code can't merely be thrown away, and can't be replaced because its length may change, depending on literals or byte codes.  So this kind of byte coded method manipulation needs to be done with case and some understanding of the total system state.
 "
 Class {
-	#name : #MethodDictionary,
-	#superclass : #Dictionary,
-	#type : #variable,
-	#category : #'Kernel-Methods'
+	#name : 'MethodDictionary',
+	#superclass : 'Dictionary',
+	#type : 'variable',
+	#category : 'Kernel-Methods',
+	#package : 'Kernel',
+	#tag : 'Methods'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MethodDictionary class >> compactAllInstances [
 
 	| instancesToExchange newInstances |
@@ -48,41 +50,41 @@ MethodDictionary class >> compactAllInstances [
 	instancesToExchange elementsForwardIdentityTo: newInstances
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MethodDictionary class >> new [
 	"Create a new instance with 32 slots, which can hold at most 24 methods before growing is necessary."
 
 	^self newForCapacity: 32
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MethodDictionary class >> new: numberOfElements [
 	"Create an instance large enough to hold numberOfElements methods without growing."
 
 	^self newForCapacity: (self sizeFor: numberOfElements)
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MethodDictionary class >> newForCapacity: capacity [
 	"Create an instance with the given capacity which must be a power of two."
 
 	^(self basicNew: capacity) initialize: capacity
 ]
 
-{ #category : #sizing }
+{ #category : 'sizing' }
 MethodDictionary class >> sizeFor: numberOfElements [
     "Return the minimum capacity of a dictionary that can hold numberOfElements elements. At least 25% of the array must be empty and the return value must be a nonnegative power of 2. Notice that the max: 1 is because a MethodDictionaries can never be entirely empty, as the #grow method requires it not to be (since it does self basicSize * 2)"
 
 	^(numberOfElements * 4 // 3 max: 1) asLargerPowerOfTwo
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MethodDictionary >> add: anAssociation [
 
 	^ self at: anAssociation key put: anAssociation value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MethodDictionary >> associationAt: key ifAbsent: aBlock [
       "Answer the association with the given key.
        If key is not found, return the result of evaluating aBlock."
@@ -92,7 +94,7 @@ MethodDictionary >> associationAt: key ifAbsent: aBlock [
                ifNotNil: [ :value | key -> value ]
 ]
 
-{ #category : #enumeration }
+{ #category : 'enumeration' }
 MethodDictionary >> associationsDo: aBlock [
 
 	tally = 0 ifTrue: [^ self].
@@ -101,7 +103,7 @@ MethodDictionary >> associationsDo: aBlock [
 			[ :key | aBlock value: (Association key: key value: (array at: i))]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MethodDictionary >> at: key ifAbsent: aBlock [
 
 	| index |
@@ -110,14 +112,14 @@ MethodDictionary >> at: key ifAbsent: aBlock [
 	^ array at: index
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MethodDictionary >> at: key ifPresent: aBlock [
 
 	^(array at: (self findElementOrNil: key))
 		ifNotNil: [ :value | aBlock cull: value ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MethodDictionary >> at: key put: value [
 	"Set the value at key to be value."
 	| index |
@@ -133,7 +135,7 @@ MethodDictionary >> at: key put: value [
 	^ value
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MethodDictionary >> compact [
 	"Make sure that I have the highest possible load factor (between 37.5% and 75%)."
 
@@ -144,7 +146,7 @@ MethodDictionary >> compact [
 		ifFalse: [ self becomeForward: newInstance ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MethodDictionary >> compactWithoutBecome [
 	"Return a copy of self which has the highest possible load factor (between 37.5% and 75%)."
 
@@ -156,7 +158,7 @@ MethodDictionary >> compactWithoutBecome [
 	^newInstance
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MethodDictionary >> fixCollisionsFrom: start [
 	"The element at start has been removed and replaced by nil.
 	This method moves forward from there, relocating any entries
@@ -170,7 +172,7 @@ MethodDictionary >> fixCollisionsFrom: start [
 			self swap: index with: newIndex ] ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MethodDictionary >> grow [
 	| newSelf |
 	newSelf := self species newForCapacity: self basicSize * 2.
@@ -179,7 +181,7 @@ MethodDictionary >> grow [
 	self becomeForward: newSelf
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MethodDictionary >> isHealthy [
 	"Test that selector hashes match their positions stored in dictionary,
 	answer true if everything ok, false otherwise
@@ -195,7 +197,7 @@ MethodDictionary >> isHealthy [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MethodDictionary >> keyAtIdentityValue: value ifAbsent: exceptionBlock [
 	"Answer the key whose value equals the argument, value. If there is
 	none, answer the result of evaluating exceptionBlock."
@@ -207,7 +209,7 @@ MethodDictionary >> keyAtIdentityValue: value ifAbsent: exceptionBlock [
 	^ exceptionBlock value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MethodDictionary >> keyAtValue: value ifAbsent: exceptionBlock [
 	"Answer the key whose value equals the argument, value. If there is
 	none, answer the result of evaluating exceptionBlock."
@@ -219,7 +221,7 @@ MethodDictionary >> keyAtValue: value ifAbsent: exceptionBlock [
 	^ exceptionBlock value
 ]
 
-{ #category : #enumeration }
+{ #category : 'enumeration' }
 MethodDictionary >> keysAndValuesDo: aBlock [
 	"Enumerate the receiver with all the keys and values passed to the block"
 	tally = 0 ifTrue: [^ self].
@@ -229,19 +231,19 @@ MethodDictionary >> keysAndValuesDo: aBlock [
 		]
 ]
 
-{ #category : #enumeration }
+{ #category : 'enumeration' }
 MethodDictionary >> keysDo: aBlock [
 	tally = 0 ifTrue: [^ self].
 	1 to: self basicSize do:
 		[:i | (self basicAt: i) ifNotNil: [ :key | aBlock value: key]]
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 MethodDictionary >> postCopy [
 	array := array copy
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MethodDictionary >> rehash [
 
 	| newInstance |
@@ -252,7 +254,7 @@ MethodDictionary >> rehash [
 	self copyFrom: newInstance
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 MethodDictionary >> removeAll [
 	"Remove all elements from this collection. Preserve the capacity"
 
@@ -262,7 +264,7 @@ MethodDictionary >> removeAll [
 	self copyFrom: newSelf
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MethodDictionary >> removeDangerouslyKey: key ifAbsent: aBlock [
 	"This is not really dangerous.  But if normal removal
 	were done WHILE a MethodDict were being used, the
@@ -281,7 +283,7 @@ MethodDictionary >> removeDangerouslyKey: key ifAbsent: aBlock [
 	^ element
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 MethodDictionary >> removeKey: key ifAbsent: errorBlock [
 	"The interpreter might be using this MethodDictionary while
 	this method is running! Therefore we perform the removal
@@ -295,7 +297,7 @@ MethodDictionary >> removeKey: key ifAbsent: errorBlock [
 	^ removedValue
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MethodDictionary >> scanFor: anObject [
 	"Scan the key array for the first slot containing either a nil (indicating an empty slot) or an element that matches anObject. Answer the index of that slot or zero if no slot is found. This method will be overridden in various subclasses that have different interpretations for matching elements."
 	| element start finish |
@@ -315,7 +317,7 @@ MethodDictionary >> scanFor: anObject [
 	^ 0  "No match AND no empty slot"
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MethodDictionary >> swap: oneIndex with: otherIndex [
 
 	| element |
@@ -325,7 +327,7 @@ MethodDictionary >> swap: oneIndex with: otherIndex [
 	array swap: oneIndex with: otherIndex
 ]
 
-{ #category : #enumeration }
+{ #category : 'enumeration' }
 MethodDictionary >> valuesDo: aBlock [
 	tally = 0 ifTrue: [^ self].
 	1 to: self basicSize do:

--- a/src/Kernel/ModificationForbidden.class.st
+++ b/src/Kernel/ModificationForbidden.class.st
@@ -9,18 +9,20 @@ value <Object> value that was attempted to be stored into the read-only object
 selector <Symbol> selector that can be used to reproduce the mutation (typically, #at:put:, #instVarAt:put:, etc.)
 "
 Class {
-	#name : #ModificationForbidden,
-	#superclass : #Error,
+	#name : 'ModificationForbidden',
+	#superclass : 'Error',
 	#instVars : [
 		'object',
 		'fieldIndex',
 		'newValue',
 		'retrySelector'
 	],
-	#category : #'Kernel-Exceptions'
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ModificationForbidden class >> for: anObject at: fieldIndex with: newValue retrySelector: selector [
 
 	^self new
@@ -30,17 +32,17 @@ ModificationForbidden class >> for: anObject at: fieldIndex with: newValue retry
 		retrySelector: selector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ModificationForbidden >> fieldIndex [
 	^ fieldIndex
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ModificationForbidden >> fieldIndex: anObject [
 	fieldIndex := anObject
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ModificationForbidden >> indexedMessageText [
 	^ String streamContents: [ :s |
 		s << ' '.
@@ -51,24 +53,24 @@ ModificationForbidden >> indexedMessageText [
 		self printObject: newValue on: s]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ModificationForbidden >> messageText [
 	"Overwritten to initialiaze the message text to a standard text if it has not yet been set"
 
 	^ messageText ifNil: [ messageText := self standardMessageText ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ModificationForbidden >> newValue [
 	^ newValue
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ModificationForbidden >> newValue: anObject [
 	newValue := anObject
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ModificationForbidden >> nonIndexedMessageText [
 	^ String streamContents: [ :s |
 		s << ' '.
@@ -79,22 +81,22 @@ ModificationForbidden >> nonIndexedMessageText [
 		self printObject: newValue on: s]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ModificationForbidden >> object [
 	^ object
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ModificationForbidden >> object: anObject [
 	object := anObject
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ModificationForbidden >> printObject: obj on: s [
 	[obj printOn: s] on: Exception do: [ :ex | s << '<cannot print object>' ]
 ]
 
-{ #category : #retrying }
+{ #category : 'retrying' }
 ModificationForbidden >> retryModification [
 	fieldIndex notNil
 		ifTrue: [ object perform: retrySelector with: fieldIndex with: newValue ]
@@ -102,17 +104,17 @@ ModificationForbidden >> retryModification [
 	self resumeUnchecked: newValue
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ModificationForbidden >> retrySelector [
 	^ retrySelector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ModificationForbidden >> retrySelector: anObject [
 	retrySelector := anObject
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ModificationForbidden >> standardMessageText [
 
 	^ fieldIndex ifNil: [ self nonIndexedMessageText ] ifNotNil: [ self indexedMessageText ]

--- a/src/Kernel/Monitor.class.st
+++ b/src/Kernel/Monitor.class.st
@@ -73,8 +73,8 @@ Monitor>>waitUntil: aBlock for: aSymbol maxMilliseconds: anInteger
 Same as Monitor>>waitUntil: (resp. Monitor>>waitUntil:for:), but the process gets automatically woken up when the specified time has passed.
 "
 Class {
-	#name : #Monitor,
-	#superclass : #Object,
+	#name : 'Monitor',
+	#superclass : 'Object',
 	#instVars : [
 		'mutex',
 		'ownerProcess',
@@ -83,22 +83,24 @@ Class {
 		'queueDict',
 		'queuesMutex'
 	],
-	#category : #'Kernel-Processes'
+	#category : 'Kernel-Processes',
+	#package : 'Kernel',
+	#tag : 'Processes'
 }
 
-{ #category : #private }
+{ #category : 'private' }
 Monitor >> checkOwnerProcess [
 	self isOwnerProcess
 		ifFalse: [self error: 'Monitor access violation']
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Monitor >> cleanup [
 	self checkOwnerProcess.
 	self critical: [self privateCleanup]
 ]
 
-{ #category : #synchronization }
+{ #category : 'synchronization' }
 Monitor >> critical: aBlock [
 	"Critical section.
 	Executes aBlock as a critical section. At any time, only one process can be executing code
@@ -112,13 +114,13 @@ Monitor >> critical: aBlock [
 		ensure: [self exit]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Monitor >> defaultQueue [
 	defaultQueue ifNil: [defaultQueue := OrderedCollection new].
 	^ defaultQueue
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Monitor >> enter [
 	self isOwnerProcess ifTrue: [
 		nestingLevel := nestingLevel + 1.
@@ -129,7 +131,7 @@ Monitor >> enter [
 	]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Monitor >> exit [
 	nestingLevel := nestingLevel - 1.
 	nestingLevel < 1 ifTrue: [
@@ -138,7 +140,7 @@ Monitor >> exit [
 	]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Monitor >> exitAndWaitInQueue: anOrderedCollection maxMilliseconds: anIntegerOrNil [
 	| lock delay |
 	lock := queuesMutex
@@ -154,7 +156,7 @@ Monitor >> exitAndWaitInQueue: anOrderedCollection maxMilliseconds: anIntegerOrN
 	self enter
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Monitor >> initialize [
 	super initialize.
 	mutex := Semaphore forMutualExclusion.
@@ -162,12 +164,12 @@ Monitor >> initialize [
 	nestingLevel := 0
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Monitor >> isOwnerProcess [
 	^ Processor activeProcess == ownerProcess
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Monitor >> privateCleanup [
 
 	queuesMutex critical: [
@@ -177,25 +179,25 @@ Monitor >> privateCleanup [
 			queueDict ifEmpty: [ queueDict := nil ] ] ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Monitor >> queueDict [
 	^ queueDict ifNil: [queueDict := IdentityDictionary new]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Monitor >> queueFor: aSymbol [
 	aSymbol ifNil: [^self defaultQueue].
 	^self queueDict at: aSymbol ifAbsentPut: [OrderedCollection new]
 ]
 
-{ #category : #'signaling-default' }
+{ #category : 'signaling-default' }
 Monitor >> signal [
 	"One process waiting for the default event is woken up."
 
 	^ self signal: nil
 ]
 
-{ #category : #'signaling-specific' }
+{ #category : 'signaling-specific' }
 Monitor >> signal: aSymbolOrNil [
 	"One process waiting for the given event is woken up. If there is no process waiting
 	for this specific event, a process waiting for the default event gets resumed."
@@ -207,14 +209,14 @@ Monitor >> signal: aSymbolOrNil [
 	self signalQueue: queue
 ]
 
-{ #category : #'signaling-default' }
+{ #category : 'signaling-default' }
 Monitor >> signalAll [
 	"All processes waiting for the default event are woken up."
 
 	^ self signalAll: nil
 ]
 
-{ #category : #'signaling-specific' }
+{ #category : 'signaling-specific' }
 Monitor >> signalAll: aSymbolOrNil [
 	"All process waiting for the given event or the default event are woken up."
 
@@ -225,7 +227,7 @@ Monitor >> signalAll: aSymbolOrNil [
 	queue ~~ self defaultQueue ifTrue: [self signalAllInQueue: queue]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Monitor >> signalAllInQueue: anOrderedCollection [
 	 queuesMutex critical: [
 		anOrderedCollection removeAllSuchThat: [ :each |
@@ -233,7 +235,7 @@ Monitor >> signalAllInQueue: anOrderedCollection [
 				true ] ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Monitor >> signalLock: aSemaphore inQueue: anOrderedCollection [
 	queuesMutex critical: [
 		aSemaphore signal.
@@ -241,13 +243,13 @@ Monitor >> signalLock: aSemaphore inQueue: anOrderedCollection [
 	]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Monitor >> signalQueue: anOrderedCollection [
 
 	queuesMutex critical: [ anOrderedCollection ifNotEmpty: [ anOrderedCollection removeFirst signal ] ]
 ]
 
-{ #category : #'signaling-specific' }
+{ #category : 'signaling-specific' }
 Monitor >> signalReallyAll [
 	"All processes waiting for any events (default or specific) are woken up."
 
@@ -257,7 +259,7 @@ Monitor >> signalReallyAll [
 		self signalAllInQueue: queue]
 ]
 
-{ #category : #'waiting - basic' }
+{ #category : 'waiting - basic' }
 Monitor >> wait [
 	"Unconditional waiting for the default event.
 	The current process gets blocked and leaves the monitor, which means that the monitor
@@ -267,7 +269,7 @@ Monitor >> wait [
 	^ self waitMaxMilliseconds: nil
 ]
 
-{ #category : #'waiting - specific' }
+{ #category : 'waiting - specific' }
 Monitor >> waitFor: aSymbolOrNil [
 	"Unconditional waiting for the non-default event represented by the argument symbol.
 	Same as Monitor>>wait, but the process gets only reactivated by the specific event and
@@ -276,7 +278,7 @@ Monitor >> waitFor: aSymbolOrNil [
 	^ self waitFor: aSymbolOrNil maxMilliseconds: nil
 ]
 
-{ #category : #'waiting - timeout' }
+{ #category : 'waiting - timeout' }
 Monitor >> waitFor: aSymbolOrNil maxMilliseconds: anIntegerOrNil [
 	"Same as Monitor>>waitFor:, but the process gets automatically woken up when the
 	specified time has passed."
@@ -285,7 +287,7 @@ Monitor >> waitFor: aSymbolOrNil maxMilliseconds: anIntegerOrNil [
 	self waitInQueue: (self queueFor: aSymbolOrNil) maxMilliseconds: anIntegerOrNil
 ]
 
-{ #category : #'waiting - timeout' }
+{ #category : 'waiting - timeout' }
 Monitor >> waitFor: aSymbolOrNil maxSeconds: aNumber [
 	"Same as Monitor>>waitFor:, but the process gets automatically woken up when the
 	specified time has passed."
@@ -293,12 +295,12 @@ Monitor >> waitFor: aSymbolOrNil maxSeconds: aNumber [
 	^ self waitFor: aSymbolOrNil maxMilliseconds: (aNumber * 1000) asInteger
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Monitor >> waitInQueue: anOrderedCollection maxMilliseconds: anIntegerOrNil [
 	self exitAndWaitInQueue: anOrderedCollection maxMilliseconds: anIntegerOrNil
 ]
 
-{ #category : #'waiting - timeout' }
+{ #category : 'waiting - timeout' }
 Monitor >> waitMaxMilliseconds: anIntegerOrNil [
 	"Same as Monitor>>wait, but the process gets automatically woken up when the
 	specified time has passed."
@@ -306,7 +308,7 @@ Monitor >> waitMaxMilliseconds: anIntegerOrNil [
 	^ self waitFor: nil maxMilliseconds: anIntegerOrNil
 ]
 
-{ #category : #'waiting - timeout' }
+{ #category : 'waiting - timeout' }
 Monitor >> waitMaxSeconds: aNumber [
 	"Same as Monitor>>wait, but the process gets automatically woken up when the
 	specified time has passed."
@@ -314,7 +316,7 @@ Monitor >> waitMaxSeconds: aNumber [
 	^ self waitMaxMilliseconds: (aNumber * 1000) asInteger
 ]
 
-{ #category : #'waiting - basic' }
+{ #category : 'waiting - basic' }
 Monitor >> waitUntil: aBlock [
 	"Conditional waiting for the default event.
 	See Monitor>>waitWhile: aBlock."
@@ -322,7 +324,7 @@ Monitor >> waitUntil: aBlock [
 	^ self waitUntil: aBlock for: nil
 ]
 
-{ #category : #'waiting - specific' }
+{ #category : 'waiting - specific' }
 Monitor >> waitUntil: aBlock for: aSymbolOrNil [
 	"Confitional waiting for the non-default event represented by the argument symbol.
 	See Monitor>>waitWhile:for: aBlock."
@@ -330,7 +332,7 @@ Monitor >> waitUntil: aBlock for: aSymbolOrNil [
 	^ self waitUntil: aBlock for: aSymbolOrNil maxMilliseconds: nil
 ]
 
-{ #category : #'waiting - timeout' }
+{ #category : 'waiting - timeout' }
 Monitor >> waitUntil: aBlock for: aSymbolOrNil maxMilliseconds: anIntegerOrNil [
 	"Same as Monitor>>waitUntil:for:, but the process gets automatically woken up when the
 	specified time has passed."
@@ -338,7 +340,7 @@ Monitor >> waitUntil: aBlock for: aSymbolOrNil maxMilliseconds: anIntegerOrNil [
 	^ self waitWhile: [aBlock value not] for: aSymbolOrNil maxMilliseconds: anIntegerOrNil
 ]
 
-{ #category : #'waiting - timeout' }
+{ #category : 'waiting - timeout' }
 Monitor >> waitUntil: aBlock for: aSymbolOrNil maxSeconds: aNumber [
 	"Same as Monitor>>waitUntil:for:, but the process gets automatically woken up when the
 	specified time has passed."
@@ -346,7 +348,7 @@ Monitor >> waitUntil: aBlock for: aSymbolOrNil maxSeconds: aNumber [
 	^ self waitUntil: aBlock for: aSymbolOrNil maxMilliseconds: (aNumber * 1000) asInteger
 ]
 
-{ #category : #'waiting - timeout' }
+{ #category : 'waiting - timeout' }
 Monitor >> waitUntil: aBlock maxMilliseconds: anIntegerOrNil [
 	"Same as Monitor>>waitUntil:, but the process gets automatically woken up when the
 	specified time has passed."
@@ -354,7 +356,7 @@ Monitor >> waitUntil: aBlock maxMilliseconds: anIntegerOrNil [
 	^ self waitUntil: aBlock for: nil maxMilliseconds: anIntegerOrNil
 ]
 
-{ #category : #'waiting - timeout' }
+{ #category : 'waiting - timeout' }
 Monitor >> waitUntil: aBlock maxSeconds: aNumber [
 	"Same as Monitor>>waitUntil:, but the process gets automatically woken up when the
 	specified time has passed."
@@ -362,7 +364,7 @@ Monitor >> waitUntil: aBlock maxSeconds: aNumber [
 	^ self waitUntil: aBlock maxMilliseconds: (aNumber * 1000) asInteger
 ]
 
-{ #category : #'waiting - basic' }
+{ #category : 'waiting - basic' }
 Monitor >> waitWhile: aBlock [
 	"Conditional waiting for the default event.
 	The current process gets blocked and leaves the monitor only if the argument block
@@ -374,7 +376,7 @@ Monitor >> waitWhile: aBlock [
 	^ self waitWhile: aBlock for: nil
 ]
 
-{ #category : #'waiting - specific' }
+{ #category : 'waiting - specific' }
 Monitor >> waitWhile: aBlock for: aSymbolOrNil [
 	"Confitional waiting for the non-default event represented by the argument symbol.
 	Same as Monitor>>waitWhile:for:, but the process gets only reactivated by the specific
@@ -383,7 +385,7 @@ Monitor >> waitWhile: aBlock for: aSymbolOrNil [
 	^ self waitWhile: aBlock for: aSymbolOrNil maxMilliseconds: nil
 ]
 
-{ #category : #'waiting - timeout' }
+{ #category : 'waiting - timeout' }
 Monitor >> waitWhile: aBlock for: aSymbolOrNil maxMilliseconds: anIntegerOrNil [
 	"Same as Monitor>>waitWhile:for:, but the process gets automatically woken up when the
 	specified time has passed."
@@ -392,7 +394,7 @@ Monitor >> waitWhile: aBlock for: aSymbolOrNil maxMilliseconds: anIntegerOrNil [
 	self waitWhile: aBlock inQueue: (self queueFor: aSymbolOrNil) maxMilliseconds: anIntegerOrNil
 ]
 
-{ #category : #'waiting - timeout' }
+{ #category : 'waiting - timeout' }
 Monitor >> waitWhile: aBlock for: aSymbolOrNil maxSeconds: aNumber [
 	"Same as Monitor>>waitWhile:for:, but the process gets automatically woken up when the
 	specified time has passed."
@@ -400,12 +402,12 @@ Monitor >> waitWhile: aBlock for: aSymbolOrNil maxSeconds: aNumber [
 	^ self waitWhile: aBlock for: aSymbolOrNil maxMilliseconds: (aNumber * 1000) asInteger
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Monitor >> waitWhile: aBlock inQueue: anOrderedCollection maxMilliseconds: anIntegerOrNil [
 	[aBlock value] whileTrue: [self exitAndWaitInQueue: anOrderedCollection maxMilliseconds: anIntegerOrNil]
 ]
 
-{ #category : #'waiting - timeout' }
+{ #category : 'waiting - timeout' }
 Monitor >> waitWhile: aBlock maxMilliseconds: anIntegerOrNil [
 	"Same as Monitor>>waitWhile:, but the process gets automatically woken up when the
 	specified time has passed."
@@ -413,7 +415,7 @@ Monitor >> waitWhile: aBlock maxMilliseconds: anIntegerOrNil [
 	^ self waitWhile: aBlock for: nil maxMilliseconds: anIntegerOrNil
 ]
 
-{ #category : #'waiting - timeout' }
+{ #category : 'waiting - timeout' }
 Monitor >> waitWhile: aBlock maxSeconds: aNumber [
 	"Same as Monitor>>waitWhile:, but the process gets automatically woken up when the
 	specified time has passed."

--- a/src/Kernel/MonitorDelay.class.st
+++ b/src/Kernel/MonitorDelay.class.st
@@ -2,29 +2,31 @@
 This is a specialization of the class Delay that is used for the implementation of the class Monitor.
 "
 Class {
-	#name : #MonitorDelay,
-	#superclass : #Delay,
+	#name : 'MonitorDelay',
+	#superclass : 'Delay',
 	#instVars : [
 		'monitor',
 		'queue'
 	],
-	#category : #'Kernel-Delays'
+	#category : 'Kernel-Delays',
+	#package : 'Kernel',
+	#tag : 'Delays'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MonitorDelay class >> signalLock: aSemaphore afterMSecs: anInteger inMonitor: aMonitor queue: anOrderedCollection [
 	anInteger < 0 ifTrue: [self error: 'delay times cannot be negative'].
 	^ (self new setDelay: anInteger forSemaphore: aSemaphore monitor: aMonitor queue: anOrderedCollection) schedule; yourself
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MonitorDelay >> setDelay: anInteger forSemaphore: aSemaphore monitor: aMonitor queue: anOrderedCollection [
 	monitor := aMonitor.
 	queue := anOrderedCollection.
 	self setDelay: anInteger forSemaphore: aSemaphore
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MonitorDelay >> timingPrioritySignalExpired [
 	"The delay time has elapsed; signal the waiting process."
 

--- a/src/Kernel/Mutex.class.st
+++ b/src/Kernel/Mutex.class.st
@@ -13,16 +13,18 @@ Instance variables:
 	owner		<Process>		The process owning the mutex.
 "
 Class {
-	#name : #Mutex,
-	#superclass : #Object,
+	#name : 'Mutex',
+	#superclass : 'Object',
 	#instVars : [
 		'semaphore',
 		'owner'
 	],
-	#category : #'Kernel-Processes'
+	#category : 'Kernel-Processes',
+	#package : 'Kernel',
+	#tag : 'Processes'
 }
 
-{ #category : #'mutual exclusion' }
+{ #category : 'mutual exclusion' }
 Mutex >> critical: aBlock [
 	"Execute aBlock only if the receiver is not already used by another process.
 	If it is, wait until the resource is available.
@@ -37,7 +39,7 @@ Mutex >> critical: aBlock [
 			aBlock ensure: [ owner := nil ] ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Mutex >> initialize [
 	super initialize.
 	semaphore := Semaphore forMutualExclusion

--- a/src/Kernel/MutexSet.class.st
+++ b/src/Kernel/MutexSet.class.st
@@ -2,26 +2,28 @@
 A MutexSet helps with aquiring a set of mutexes.
 "
 Class {
-	#name : #MutexSet,
-	#superclass : #Object,
+	#name : 'MutexSet',
+	#superclass : 'Object',
 	#instVars : [
 		'array'
 	],
-	#category : #'Kernel-Processes'
+	#category : 'Kernel-Processes',
+	#package : 'Kernel',
+	#tag : 'Processes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MutexSet class >> withAll: mutexList [
 	^self new withAll: mutexList
 ]
 
-{ #category : #'mutual exclusion' }
+{ #category : 'mutual exclusion' }
 MutexSet >> critical: aBlock [
 	"Evaluate aBlock aquiring all mutexes"
 	^self pvtCritical: aBlock startingAt: 1
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MutexSet >> pvtCritical: aBlock startingAt: index [
 	| mutex |
 	index > array size ifTrue:[^aBlock value].
@@ -29,7 +31,7 @@ MutexSet >> pvtCritical: aBlock startingAt: index [
 	^mutex critical:[self pvtCritical: aBlock startingAt: index+1]
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 MutexSet >> withAll: mutexList [
 	array := mutexList
 ]

--- a/src/Kernel/NewUndeclaredWarning.class.st
+++ b/src/Kernel/NewUndeclaredWarning.class.st
@@ -2,16 +2,18 @@
 I am a warning about the definition of a new Undeclared variable. I may be quite common during loading of packages that do not have (or cannot have) clean dependencies structure or are loaded in wrong order.
 "
 Class {
-	#name : #NewUndeclaredWarning,
-	#superclass : #SystemNotification,
+	#name : 'NewUndeclaredWarning',
+	#superclass : 'SystemNotification',
 	#instVars : [
 		'undeclaredName',
 		'originName'
 	],
-	#category : #'Kernel-Exceptions'
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #exceptioninstantiator }
+{ #category : 'exceptioninstantiator' }
 NewUndeclaredWarning class >> signal: undeclaredName in: originName [
 
 	^ self new
@@ -20,7 +22,7 @@ NewUndeclaredWarning class >> signal: undeclaredName in: originName [
 		signal
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NewUndeclaredWarning >> messageText [
 	^String streamContents: [ :str |
 		originName putOn: str.
@@ -29,22 +31,22 @@ NewUndeclaredWarning >> messageText [
 		str nextPutAll: ' is Undeclared)' ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NewUndeclaredWarning >> originName [
 	^ originName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NewUndeclaredWarning >> originName: anObject [
 	originName := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NewUndeclaredWarning >> undeclaredName [
 	^ undeclaredName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NewUndeclaredWarning >> undeclaredName: anObject [
 	undeclaredName := anObject
 ]

--- a/src/Kernel/NonBooleanReceiver.class.st
+++ b/src/Kernel/NonBooleanReceiver.class.st
@@ -15,41 +15,43 @@ If you really need to use optimized constructs, you can enable Opal compiler and
 		- call from this method by Object>>#mustBeBooleanInMagic:""
 "
 Class {
-	#name : #NonBooleanReceiver,
-	#superclass : #Error,
+	#name : 'NonBooleanReceiver',
+	#superclass : 'Error',
 	#instVars : [
 		'object'
 	],
 	#classVars : [
 		'MustBeBooleanHandler'
 	],
-	#category : #'Kernel-Exceptions'
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #'must-be-boolean-mop' }
+{ #category : 'must-be-boolean-mop' }
 NonBooleanReceiver class >> mustBeBooleanHandler [
 
 	^ MustBeBooleanHandler
 ]
 
-{ #category : #'must-be-boolean-mop' }
+{ #category : 'must-be-boolean-mop' }
 NonBooleanReceiver class >> mustBeBooleanHandler: aHandler [
 
 	MustBeBooleanHandler := aHandler
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 NonBooleanReceiver >> isResumable [
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NonBooleanReceiver >> object [
 	^object
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 NonBooleanReceiver >> object: anObject [
 	object := anObject
 ]

--- a/src/Kernel/NotYetImplemented.class.st
+++ b/src/Kernel/NotYetImplemented.class.st
@@ -5,12 +5,14 @@ This is used in incremental development, for example when doing Test First devel
 It is similar to ShouldBeImplemented, with a slightly different meaning.
 "
 Class {
-	#name : #NotYetImplemented,
-	#superclass : #SelectorException,
-	#category : #'Kernel-Exceptions'
+	#name : 'NotYetImplemented',
+	#superclass : 'SelectorException',
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #printing }
+{ #category : 'printing' }
 NotYetImplemented >> standardMessageText [
 	"Generate a standard textual description"
 

--- a/src/Kernel/Notification.class.st
+++ b/src/Kernel/Notification.class.st
@@ -2,12 +2,14 @@
 A Notification is an indication that something interesting has occurred.  If it is not handled, it will pass by without effect.
 "
 Class {
-	#name : #Notification,
-	#superclass : #Exception,
-	#category : #'Kernel-Exceptions'
+	#name : 'Notification',
+	#superclass : 'Exception',
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #handling }
+{ #category : 'handling' }
 Notification >> defaultAction [
 	"No action is taken. The value nil is returned as the value of the message that signaled the exception."
 

--- a/src/Kernel/Number.class.st
+++ b/src/Kernel/Number.class.st
@@ -33,12 +33,14 @@ A possible implementation would be:
 We prefer evaluating cosd(90-x) thus providing a branch free implementation.
 "
 Class {
-	#name : #Number,
-	#superclass : #Magnitude,
-	#category : #'Kernel-Numbers'
+	#name : 'Number',
+	#superclass : 'Magnitude',
+	#category : 'Kernel-Numbers',
+	#package : 'Kernel',
+	#tag : 'Numbers'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Number class >> new [
 
 	self == Number ifTrue: [
@@ -46,41 +48,41 @@ Number class >> new [
 	^ super new
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 Number class >> one [
 
 	^1
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Number >> * aNumber [
 	"Answer the result of multiplying the receiver by aNumber."
 
 	self subclassResponsibility
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Number >> + aNumber [
 	"Answer the sum of the receiver and aNumber."
 
 	self subclassResponsibility
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Number >> - aNumber [
 	"Answer the difference between the receiver and aNumber."
 
 	self subclassResponsibility
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Number >> / aNumber [
 	"Answer the result of dividing the receiver by aNumber."
 
 	self subclassResponsibility
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Number >> // aNumber [
 	"Integer quotient defined by division with truncation toward negative
 	infinity. \\ answers the remainder from this division."
@@ -92,7 +94,7 @@ Number >> // aNumber [
 	^(self / aNumber) floor
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Number >> @ y [
 	"Primitive. Answer a Point whose x value is the receiver and whose y
 	value is the argument. Optional. No Lookup. See Object documentation
@@ -102,7 +104,7 @@ Number >> @ y [
 	^Point x: self y: y
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Number >> \\ aNumber [
 	"modulo. Remainder defined in terms of //. Answer a Number with the
 	same sign as aNumber."
@@ -114,7 +116,7 @@ Number >> \\ aNumber [
 	^self - (self // aNumber * aNumber)
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Number >> abs [
 	"Answer a Number that is the absolute value (positive magnitude) of the
 	receiver."
@@ -124,7 +126,7 @@ Number >> abs [
 		ifFalse: [self]
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Number >> adaptToFloat: rcvr andCompare: selector [
 	"If I am involved in comparison with a Float, convert rcvr to a
 	Fraction. This way, no bit is lost and comparison is exact."
@@ -143,48 +145,48 @@ Number >> adaptToFloat: rcvr andCompare: selector [
 	^ rcvr asTrueFraction perform: selector with: self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Number >> adaptToFloat: rcvr andSend: selector [
 	"If I am involved in arithmetic with a Float, convert me to a Float."
 	^ rcvr perform: selector with: self asFloat
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Number >> adaptToFraction: rcvr andSend: selector [
 	"If I am involved in arithmetic with a Fraction, convert us and evaluate exprBlock."
 	^ self subclassResponsibility
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Number >> adaptToInteger: rcvr andSend: selector [
 	"If I am involved in arithmetic with a Integer, convert us and evaluate exprBlock."
 	^ self subclassResponsibility
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 Number >> addAssignToFloatArray: aFloatArray [
 	^ aFloatArray primAddScalar: self asFloat
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Number >> asDuration [
 
  	^ Duration seconds: self asInteger
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Number >> asFloat [
 	"Answer a floating-point number approximating the receiver."
 
 	self subclassResponsibility
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Number >> asFraction [
 	^ self subclassResponsibility
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Number >> asInteger [
 	"Round me towards nearest integer closer to zero."
 	"This violates the ANSI standard, but the system depends on this"
@@ -192,12 +194,12 @@ Number >> asInteger [
 	^self truncated
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Number >> asNumber [
 	^ self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Number >> asPoint [
 	"Answer a Point with the receiver as both coordinates; often used to
 	supply the same value in two dimensions, as with symmetrical gridding
@@ -206,26 +208,26 @@ Number >> asPoint [
 	^self @ self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Number >> asScaledDecimal [
 	"Answer a scaled decimal number approximating the receiver."
 
 	^ self asScaledDecimal: 8
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Number >> asScaledDecimal: scale [
 	"Answer the receiver converted to a ScaledDecimal."
 
 	^ ScaledDecimal newFromNumber: self scale: scale
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Number >> asSeconds [
 	^ Duration milliSeconds: self * 1000
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Number >> asSmallAngleDegrees [
 	"Return the receiver normalized to lie within the range (-180, 180)"
 
@@ -237,14 +239,14 @@ Number >> asSmallAngleDegrees [
 "#(-500 -300 -150 -5 0 5 150 300 500 1200) collect: [:n | n asSmallAngleDegrees]"
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Number >> asSmallPositiveDegrees [
 	"Return the receiver normalized to lie within the range (0, 360)"
 
 	^self \\ 360
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Number >> ceiling [
        "Answer the integer nearest the receiver toward  infinity."
 
@@ -256,7 +258,7 @@ Number >> ceiling [
                ifFalse: [ truncation + 1 ]
 ]
 
-{ #category : #calculating }
+{ #category : 'calculating' }
 Number >> clampBetween: min and: max [
 
 	 (self between: min and: max ) ifTrue: [ ^ self  ]
@@ -264,7 +266,7 @@ Number >> clampBetween: min and: max [
 	^ max
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Number >> copySignTo: aNumber [
 	"Return a number with same magnitude as aNumber and same sign as self."
 
@@ -273,19 +275,19 @@ Number >> copySignTo: aNumber [
 		ifFalse: [aNumber abs negated]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Number >> day [
 
  	^ self days
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Number >> days [
 
  	^ Duration days: self
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Number >> detentBy: detent atMultiplesOf: grid snap: snap [
 	"Map all values that are within detent/2 of any multiple of grid to that multiple.  Otherwise, if snap is true, return self, meaning that the values in the dead zone will never be returned.  If snap is false, then expand the range between dead zones so that it covers the range between multiples of the grid, and scale the value by that factor."
 	| r1 r2 |
@@ -304,14 +306,14 @@ Number >> detentBy: detent atMultiplesOf: grid snap: snap [
 "
 ]
 
-{ #category : #'mathematical functions' }
+{ #category : 'mathematical functions' }
 Number >> exp [
 	"Answer the exponential of the receiver as a floating point number."
 
 	^self asFloat exp
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Number >> floor [
 	"Answer the integer nearest the receiver toward negative infinity."
 
@@ -323,57 +325,57 @@ Number >> floor [
 		  ifFalse: [ truncation - 1 ]
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Number >> fractionPart [
 	"Added for ANSI compatibility"
 	^self - self integerPart
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Number >> hour [
 
  	^ self hours
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Number >> hours [
 
  	^ Duration hours: self
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Number >> integerPart [
 	"Added for ANSI compatibility"
 	^self truncated
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Number >> isInfinite [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Number >> isNaN [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Number >> isNumber [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Number >> isPowerOfTwo [
 	^ self subclassResponsibility
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Number >> isZero [
 	^self = 0
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Number >> milliSecond [
 	"1 milliSecond printString >>> '0:00:00:00.001'"
 	"(1 second + 1 milliSecond) printString >>> '0:00:00:01.001'"
@@ -381,7 +383,7 @@ Number >> milliSecond [
  	^ self milliSeconds
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Number >> milliSeconds [
 
 	"2 milliSeconds printString >>> '0:00:00:00.002'"
@@ -390,7 +392,7 @@ Number >> milliSeconds [
  	^ Duration milliSeconds: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Number >> minute [
 	"1 minute printString >>> '0:00:01:00'"
 	"(1 hour + 1 minute) printString >>> '0:01:01:00'"
@@ -398,7 +400,7 @@ Number >> minute [
  	^ self minutes
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Number >> minutes [
 	"2 minutes printString >>> '0:00:02:00'"
 	"(1 hour + 2 minutes) printString >>> '0:01:02:00'"
@@ -406,7 +408,7 @@ Number >> minutes [
  	^ Duration minutes: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Number >> nanoSecond [
 	"1 nanoSecond printString >>> '0:00:00:00.000000001'"
 	"(1 milliSecond + 1 nanoSecond) printString >>> '0:00:00:00.001000001'"
@@ -414,7 +416,7 @@ Number >> nanoSecond [
  	^ self nanoSeconds
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Number >> nanoSeconds [
 	"2 nanoSeconds printString >>> '0:00:00:00.000000002'"
 	"(1 milliSecond + 2 nanoSeconds) printString >>> '0:00:00:00.001000002'"
@@ -422,21 +424,21 @@ Number >> nanoSeconds [
  	^ Duration nanoSeconds: self
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Number >> negated [
 	"Answer a Number that is the negation of the receiver."
 
 	^0 - self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Number >> negative [
 	"Answer whether the receiver is mathematically negative."
 
 	^ self < 0
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Number >> positive [
 	"Answer whether the receiver is positive or equal to 0. (ST-80 protocol).
 	See also strictlyPositive"
@@ -444,12 +446,12 @@ Number >> positive [
 	^ self >= 0
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Number >> printOn: aStream [
 	self printOn: aStream base: 10
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Number >> printOn: aStream base: base [
 	"This method should print a representation of the number for the given base,
 	excluding the base prefix (and the letter r for radix)"
@@ -457,7 +459,7 @@ Number >> printOn: aStream base: base [
 	self subclassResponsibility
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Number >> printOn: aStream showingDecimalPlaces: placesDesired [
 	"Print a representation of the receiver on aStream in decimal notation with prescribed number of places after decimal separator."
 
@@ -473,7 +475,7 @@ Number >> printOn: aStream showingDecimalPlaces: placesDesired [
 	roundedFractionPart printOn: aStream base: 10 length: placesDesired padded: true
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Number >> printShowingDecimalPlaces: placesDesired [
 	"Print the receiver showing precisely the given number of places desired.  If placesDesired is positive, a decimal point and that many digits after the decimal point will always be shown.  If placesDesired is zero, a whole number will be shown, without a decimal point. Here are some examples:"
 
@@ -493,12 +495,12 @@ Number >> printShowingDecimalPlaces: placesDesired [
 		self printOn: aStream showingDecimalPlaces: placesDesired]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Number >> printString [
 	^self printStringBase: 10
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Number >> printStringBase: base [
 	"Return a String representation of this number in base b."
 	"(10 printStringBase: 10) >>> '10'"
@@ -509,7 +511,7 @@ Number >> printStringBase: base [
 	^ String streamContents: [:strm | self printOn: strm base: base]
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Number >> quo: aNumber [
 	"Integer quotient defined by division with truncation toward zero.
 
@@ -521,7 +523,7 @@ Number >> quo: aNumber [
 	^(self / aNumber) truncated
 ]
 
-{ #category : #'mathematical functions' }
+{ #category : 'mathematical functions' }
 Number >> raisedTo: aNumber [
 	"Answer the receiver raised to aNumber."
 
@@ -547,7 +549,7 @@ Number >> raisedTo: aNumber [
 	^ (aNumber * self ln) exp		"Otherwise use logarithms"
 ]
 
-{ #category : #'mathematical functions' }
+{ #category : 'mathematical functions' }
 Number >> raisedToFraction: aFraction [
 	self isZero
 		ifTrue:
@@ -559,7 +561,7 @@ Number >> raisedToFraction: aFraction [
 	^(self negated ln * aFraction) exp negated
 ]
 
-{ #category : #'mathematical functions' }
+{ #category : 'mathematical functions' }
 Number >> raisedToInteger: anInteger [
 
 	"The 0 raisedToInteger: 0 is an special case. In some contexts must be 1 and in others must
@@ -581,7 +583,7 @@ Number >> raisedToInteger: anInteger [
 	^result
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Number >> reciprocal [
 	"Returns the reciprocal of self.
 	In case self is 0 the / signals ZeroDivide"
@@ -594,13 +596,13 @@ Number >> reciprocal [
 	^1 / self
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Number >> reduce [
     "If self is close to an integer, return that integer"
     ^ self
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Number >> rem: aNumber [
 	"Remainder defined in terms of quo:. Answer a Number with the same
 	sign as self. e.g. 9 rem: 4 = 1, -9 rem: 4 = -1. 0.9 rem: 0.4 = 0.1."
@@ -608,7 +610,7 @@ Number >> rem: aNumber [
 	^self - ((self quo: aNumber) * aNumber)
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Number >> round: numberOfWishedDecimal [
 	"Round the decimal part of the receiver to be limited to the number of wished decimal. Only leave a fixed amount of decimal"
    "(10.12345 round: 2) >>> 10.12"
@@ -617,7 +619,7 @@ Number >> round: numberOfWishedDecimal [
 	^ self subclassResponsibility
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Number >> roundDownTo: aNumber [
 	"Answer the next multiple of aNumber toward negative infinity that is nearest the receiver.
 	Examples:"
@@ -630,14 +632,14 @@ Number >> roundDownTo: aNumber [
 	^(self / aNumber) floor * aNumber
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Number >> roundTo: quantum [
 	"Answer the nearest number that is a multiple of quantum."
 
 	^(self / quantum) rounded * quantum
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Number >> roundUpTo: aNumber [
 	"Answer the next multiple of aNumber toward infinity that is nearest the receiver."
 	"(3.1479 roundUpTo: 0.01) >>> 3.15"
@@ -649,7 +651,7 @@ Number >> roundUpTo: aNumber [
 	^(self / aNumber) ceiling * aNumber
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Number >> rounded [
 	"Answer the integer nearest the receiver."
 
@@ -661,7 +663,7 @@ Number >> rounded [
 	^(self + (self sign / 2)) truncated
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Number >> second [
 	"1 second printString >>> '0:00:00:01'"
 	"(1 minute + 1 second) printString >>> '0:00:01:01'"
@@ -669,7 +671,7 @@ Number >> second [
  	^ self seconds
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Number >> seconds [
 
 	"2 seconds printString >>> '0:00:00:02'"
@@ -678,7 +680,7 @@ Number >> seconds [
  	^ Duration seconds: self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Number >> sign [
 	"Answer 1 if the receiver is greater than 0, -1 if less than 0, else 0."
 
@@ -687,14 +689,14 @@ Number >> sign [
 	^0
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Number >> sign: aNumber [
  	"Return a Number with the same sign as aNumber"
 
  	^ aNumber copySignTo: self
 ]
 
-{ #category : #'mathematical functions' }
+{ #category : 'mathematical functions' }
 Number >> signBit [
 	"Answer 1 if the receiver is negative, zero otherwise."
 
@@ -702,12 +704,12 @@ Number >> signBit [
 	^0
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Number >> storeOn: aStream [
 	self printOn: aStream
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Number >> storeOn: aStream base: base [
 	"This method should print a representation of the number for the given base,
 	including the base prefix (with letter r for radix)"
@@ -715,7 +717,7 @@ Number >> storeOn: aStream base: base [
 	^self subclassResponsibility
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Number >> storeStringBase: base [
 	"Returns a string representation of the receiver in base 16 in a way that executing it will return the receiver."
 	"(10 storeStringBase: 16) >>> '16rA'"
@@ -724,12 +726,12 @@ Number >> storeStringBase: base [
 	^ String streamContents: [:strm | self storeOn: strm base: base]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Number >> stringForReadout [
 	^ self rounded printString
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Number >> truncateTo: aNumber [
 	"Answer the next multiple of aNumber toward zero that is nearest the receiver."
 	"(3.1479 truncateTo: 0.01) >>>  3.14"
@@ -743,32 +745,32 @@ Number >> truncateTo: aNumber [
 	^(self quo: aNumber) * aNumber
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Number >> truncated [
 	"Answer an integer nearest the receiver toward zero."
 
 	^self quo: 1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Number >> week [
 
  	^ self weeks
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Number >> weeks [
 
  	^ Duration weeks: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Number >> year [
 
  	^self years
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Number >> years [
 
  	^ Duration years: self

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -51,22 +51,24 @@ rid of it risks breaking code.  If it is there but does not harm then why get ri
 best Eliot Miranda 
 "
 Class {
-	#name : #Object,
-	#superclass : #ProtoObject,
+	#name : 'Object',
+	#superclass : 'ProtoObject',
 	#classVars : [
 		'DependentsFields'
 	],
-	#category : #'Kernel-Objects'
+	#category : 'Kernel-Objects',
+	#package : 'Kernel',
+	#tag : 'Objects'
 }
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 Object class >> flushDependents [
 	DependentsFields keysAndValuesDo:[:key :dep|
 		key ifNotNil:[key removeDependent: nil].
 	].
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 Object class >> howToModifyPrimitives [
 	"You are allowed to write methods which specify primitives, but please use
 	caution.  If you make a subclass of a class which contains a primitive method,
@@ -117,21 +119,21 @@ Object class >> howToModifyPrimitives [
 	self error: 'comment only'
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 Object class >> initialize [
 	"Upon loading a class, this selector is not looked up.
 	If you want a class to be initialized upon loading, this class should define the selector #intialize explicitly"
 	DependentsFields ifNil:[ self initializeDependentsFields ]
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 Object class >> initializeDependentsFields [
 	<script: 'Object initialize'>
 
 	DependentsFields := WeakIdentityKeyDictionary new
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Object class >> newFrom: aSimilarObject [
 	"Create an object that has similar contents to aSimilarObject. If the classes have any instance variables with the same names, copy them across. If this is bad for a class, override this method."
 
@@ -140,7 +142,7 @@ Object class >> newFrom: aSimilarObject [
 		ifFalse: [self basicNew]) copySameFrom: aSimilarObject
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Object class >> newFromArray: anArray [
 
 	"Fast initialization from an Array.
@@ -151,7 +153,7 @@ Object class >> newFromArray: anArray [
 	^ self newFrom: anArray
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 Object class >> reInitializeDependentsFields [
 	<script>
 
@@ -162,7 +164,7 @@ Object class >> reInitializeDependentsFields [
 		keysAndValuesDo: [ :obj :deps | deps do: [ :d | obj addDependent: d ] ]
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Object class >> readFrom: textStringOrStream [
 	"Create an object based on the contents of textStringOrStream."
 
@@ -172,7 +174,7 @@ Object class >> readFrom: textStringOrStream [
 	^object
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 Object class >> whatIsAPrimitive [
 	"Some messages in the system are responded to primitively. A primitive
 	response is performed directly by the interpreter rather than by evaluating
@@ -241,7 +243,7 @@ Object class >> whatIsAPrimitive [
 	self error: 'comment only'
 ]
 
-{ #category : #associating }
+{ #category : 'associating' }
 Object >> -> anObject [
 	"Answer an Association between self and anObject"
 	"The following example creates an association whose key is number 1 and value string 'one'."
@@ -254,7 +256,7 @@ Object >> -> anObject [
 	^ Association key: self value: anObject
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Object >> = anObject [
 	"Answer whether the receiver and the argument represent the same
 	object. If = is redefined in any subclass, consider also redefining the
@@ -263,14 +265,14 @@ Object >> = anObject [
 	^ self == anObject
 ]
 
-{ #category : #finalization }
+{ #category : 'finalization' }
 Object >> actAsExecutor [
 	"Prepare the receiver to act as executor for any resources associated with it"
 
 	self breakDependents
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Object >> adaptToFloat: rcvr andCompare: selector [
 	"If I am involved in comparison with a Float.
 	Default behaviour is to process comparison as any other selectors."
@@ -278,7 +280,7 @@ Object >> adaptToFloat: rcvr andCompare: selector [
 	^ self adaptToFloat: rcvr andSend: selector
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Object >> adaptToFloat: rcvr andSend: selector [
 	"If no method has been provided for adapting an object to a Float,
 	then it may be adequate to simply adapt it to a number."
@@ -286,7 +288,7 @@ Object >> adaptToFloat: rcvr andSend: selector [
 	^ self adaptToNumber: rcvr andSend: selector
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Object >> adaptToFraction: rcvr andCompare: selector [
 	"If I am involved in comparison with a Fraction.
 	Default behaviour is to process comparison as any other selectors."
@@ -294,7 +296,7 @@ Object >> adaptToFraction: rcvr andCompare: selector [
 	^ self adaptToFraction: rcvr andSend: selector
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Object >> adaptToFraction: rcvr andSend: selector [
 	"If no method has been provided for adapting an object to a Fraction,
 	then it may be adequate to simply adapt it to a number."
@@ -302,7 +304,7 @@ Object >> adaptToFraction: rcvr andSend: selector [
 	^ self adaptToNumber: rcvr andSend: selector
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Object >> adaptToInteger: rcvr andCompare: selector [
 	"If I am involved in comparison with an Integer.
 	Default behaviour is to process comparison as any other selectors."
@@ -310,7 +312,7 @@ Object >> adaptToInteger: rcvr andCompare: selector [
 	^ self adaptToInteger: rcvr andSend: selector
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Object >> adaptToInteger: rcvr andSend: selector [
 	"If no method has been provided for adapting an object to a Integer,
 	then it may be adequate to simply adapt it to a number."
@@ -318,7 +320,7 @@ Object >> adaptToInteger: rcvr andSend: selector [
 	^ self adaptToNumber: rcvr andSend: selector
 ]
 
-{ #category : #dependencies }
+{ #category : 'dependencies' }
 Object >> addDependent: anObject [
 	"Make the given object one of the receiver's dependents."
 
@@ -329,7 +331,7 @@ Object >> addDependent: anObject [
 	^ anObject
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Object >> as: aSimilarClass [
 	"Create an object of class aSimilarClass that has similar contents to the receiver if the object is not already an instance of this class."
 
@@ -338,34 +340,34 @@ Object >> as: aSimilarClass [
 	^ aSimilarClass newFrom: self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Object >> asCollectionElement [
 	"Answer an object, which can be put into a Set as element , wrapped
 	by one of SetElement instance, if necessary.
 	Default implementation is to answer self"
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Object >> asLink [
 	"Answer a string that represents the receiver."
 
 	^ ValueLink value: self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Object >> asLinkPrepend: anObject [
 
 	^ self asLink asLinkPrepend: anObject
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Object >> asString [
 	"Answer a string that represents the receiver."
 
 	^ self printString
 ]
 
-{ #category : #asserting }
+{ #category : 'asserting' }
 Object >> assert: aBlock [
 	"Throw an assertion error if aBlock does not evaluates to true.
 	We check for true explicitly to make the assertion fail for non booleans"
@@ -374,7 +376,7 @@ Object >> assert: aBlock [
 	self assert: aBlock description: 'Assertion failed'
 ]
 
-{ #category : #asserting }
+{ #category : 'asserting' }
 Object >> assert: aBlock description: aStringOrBlock [
 	"Throw an assertion error if aBlock does not evaluates to true."
 
@@ -384,7 +386,7 @@ Object >> assert: aBlock description: aStringOrBlock [
 		AssertionFailure signal: aStringOrBlock value ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Object >> at: index [
 	"Primitive. Assumes receiver is indexable. Answer the value of an
 	indexable element in the receiver. Fail if the argument index is not an
@@ -400,7 +402,7 @@ Object >> at: index [
 	self errorNonIntegerIndex
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Object >> at: index put: value [
 	"Primitive. Assumes receiver is indexable. Store the argument value in
 	the indexable element of the receiver indicated by index. Fail if the
@@ -420,7 +422,7 @@ Object >> at: index put: value [
 	self errorImproperStore
 ]
 
-{ #category : #'write barrier' }
+{ #category : 'write barrier' }
 Object >> attemptToAssign: value withIndex: index [
 	"Called by the VM when assigning an instance variable of an immutable object.
 	Upon return, executing will resume *after* the inst var assignment. If the inst var mutation has to be
@@ -433,7 +435,7 @@ Object >> attemptToAssign: value withIndex: index [
 	"CAN'T REACH"
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Object >> basicAt: index [
 	"Primitive. Assumes receiver is indexable. Answer the value of an
 	indexable element in the receiver. Fail if the argument index is not an
@@ -450,7 +452,7 @@ Object >> basicAt: index [
 	self errorNonIntegerIndex
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Object >> basicAt: index put: value [
 	"Primitive. Assumes receiver is indexable. Store the second argument
 	value in the indexable element of the receiver indicated by index. Fail
@@ -471,7 +473,7 @@ Object >> basicAt: index put: value [
 	self errorImproperStore
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Object >> basicSize [
 	"Primitive. Answer the number of indexable variables in the receiver.
 	This value is the same as the largest legal subscript. Essential. Do not
@@ -482,14 +484,14 @@ Object >> basicSize [
 	^0
 ]
 
-{ #category : #'write barrier' }
+{ #category : 'write barrier' }
 Object >> beReadOnlyLiteral [
 	"This is used by the compiler, it recurses into Arrays (see the override there)"
 	self isLiteral ifFalse: [ ^ self ].
 	self beReadOnlyObject
 ]
 
-{ #category : #'write barrier' }
+{ #category : 'write barrier' }
 Object >> beReadOnlyObject [
 	"If the VM supports read-only objects it will not write to read-only objects.
 	 An attempt to write to an instance variable of a read-only object will
@@ -500,18 +502,18 @@ Object >> beReadOnlyObject [
 	^self setIsReadOnlyObject: true
 ]
 
-{ #category : #'write barrier' }
+{ #category : 'write barrier' }
 Object >> beRecursivelyReadOnlyObject [
 	^self recursivelySetIsReadOnlyObject: true
 ]
 
-{ #category : #'write barrier' }
+{ #category : 'write barrier' }
 Object >> beRecursivelyWritableObject [
 
 	^ self recursivelySetIsReadOnlyObject: false
 ]
 
-{ #category : #'write barrier' }
+{ #category : 'write barrier' }
 Object >> beWritableObject [
 	"If the VM supports read-only objects it will not write to read-only objects.
 	 An attempt to write to an instance variable of a read-only object will
@@ -523,14 +525,14 @@ Object >> beWritableObject [
 	^ self setIsReadOnlyObject: false
 ]
 
-{ #category : #dependencies }
+{ #category : 'dependencies' }
 Object >> breakDependents [
 	"Remove all of the receiver's dependents."
 
 	self myDependents: nil
 ]
 
-{ #category : #dependencies }
+{ #category : 'dependencies' }
 Object >> canDiscardEdits [
 	"Answer true if none of the views on this model has unaccepted edits that matter."
 
@@ -540,7 +542,7 @@ Object >> canDiscardEdits [
 	^ true
 ]
 
-{ #category : #'casing-To be deprecated' }
+{ #category : 'casing-To be deprecated' }
 Object >> caseError [
 	"DO NOT USE THIS METHOD! It will be removed from Pharo."
 	"Report an error from an in-line or explicit case statement."
@@ -548,7 +550,7 @@ Object >> caseError [
 	self error: 'Case not found (', self printString, '), and no otherwise clause'
 ]
 
-{ #category : #'casing-To be deprecated' }
+{ #category : 'casing-To be deprecated' }
 Object >> caseOf: aBlockAssociationCollection [
 	"DO NOT USE THIS METHOD! It will be removed from Pharo."
 
@@ -565,7 +567,7 @@ Object >> caseOf: aBlockAssociationCollection [
 "#b caseOf: {[#a]->[1+1]. ['d' asSymbol]->[2+2]. [#c]->[3+3]}"
 ]
 
-{ #category : #'casing-To be deprecated' }
+{ #category : 'casing-To be deprecated' }
 Object >> caseOf: aBlockAssociationCollection otherwise: aBlock [
 	"DO NOT USE THIS METHOD! It will be removed from Pharo."
 
@@ -585,7 +587,7 @@ Object >> caseOf: aBlockAssociationCollection otherwise: aBlock [
 "#b caseOf: {[#a]->[1+1]. ['d' asSymbol]->[2+2]. [#c]->[3+3]} otherwise: [0]"
 ]
 
-{ #category : #updating }
+{ #category : 'updating' }
 Object >> changed [
 	"Receiver changed in a general way; inform all the dependents by
 	sending each dependent an update: message."
@@ -593,7 +595,7 @@ Object >> changed [
 	self changed: self
 ]
 
-{ #category : #updating }
+{ #category : 'updating' }
 Object >> changed: aParameter [
 	"Receiver changed. The change is denoted by the argument aParameter.
 	Usually the argument is a Symbol that is part of the dependent's change
@@ -602,7 +604,7 @@ Object >> changed: aParameter [
 	self dependents do: [:aDependent | aDependent update: aParameter]
 ]
 
-{ #category : #updating }
+{ #category : 'updating' }
 Object >> changed: anAspect with: anObject [
 	"Receiver changed. The change is denoted by the argument anAspect.
 	Usually the argument is a Symbol that is part of the dependent's change
@@ -611,14 +613,14 @@ Object >> changed: anAspect with: anObject [
 	self dependents do: [:aDependent | aDependent update: anAspect with: anObject]
 ]
 
-{ #category : #introspection }
+{ #category : 'introspection' }
 Object >> className [
 	"Answer a string characterizing the receiver's class, for use in list views for example"
 
 	^ self class name asString
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Object >> clone [
 	"Answer a shallow copy of the receiver."
 	<primitive: 148 error: ec>
@@ -639,14 +641,14 @@ Object >> clone [
 	^newObject copyFrom: self
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Object >> copy [
 	"Answer another instance just like the receiver. Subclasses typically override postCopy; they typically do not override shallowCopy. Copy is a template method in the sense of Design Patterns. So do not override it. Override postCopy instead. Pay attention that normally you should call postCopy of your superclass too."
 
 	^ self shallowCopy postCopy
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Object >> copyFrom: anotherObject [
 	"Copy to myself all instance variables I have in common with anotherObject.  This is dangerous because it ignores an object's control over its own inst vars.  "
 
@@ -662,7 +664,7 @@ Object >> copyFrom: anotherObject [
 			self basicAt: ind put: (anotherObject basicAt: ind)]]
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Object >> copySameFrom: otherObject [
 	"Copy to myself all instance variables named the same in otherObject.
 	This ignores otherObject's control over its own inst vars."
@@ -677,7 +679,7 @@ Object >> copySameFrom: otherObject [
 		self basicAt: i put: (otherObject basicAt: i)]
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Object >> deepCopy [
 	"Answer a copy of the receiver with its own copy of each instance variable. deepCopy does a deep copy. It should never be overridden and only be used if you want to get these very specific semantics.
 It doesn't handle cycles, #veryDeepCopy does. In the future we will make it handle cycles and deprecate veryDeepCopy"
@@ -703,7 +705,7 @@ It doesn't handle cycles, #veryDeepCopy does. In the future we will make it hand
 	^newObject
 ]
 
-{ #category : #dependencies }
+{ #category : 'dependencies' }
 Object >> dependents [
 	"Answer a collection of objects that are 'dependent' on the receiver;
 	 that is, all objects that should be notified if the receiver changes."
@@ -711,7 +713,7 @@ Object >> dependents [
 	^ self myDependents ifNil: [#()]
 ]
 
-{ #category : #deprecation }
+{ #category : 'deprecation' }
 Object >> deprecated: anExplanationString [
 	"Warn that the sending method has been deprecated"
 
@@ -721,7 +723,7 @@ Object >> deprecated: anExplanationString [
 		signal
 ]
 
-{ #category : #deprecation }
+{ #category : 'deprecation' }
 Object >> deprecated: anExplanationString on: date in: version [
 	"Warn that the sending method has been deprecated"
 
@@ -733,7 +735,7 @@ Object >> deprecated: anExplanationString on: date in: version [
 		signal
 ]
 
-{ #category : #deprecation }
+{ #category : 'deprecation' }
 Object >> deprecated: anExplanationString on: date in: version transformWith: aRule [
 	"Automatically tranform the deprecated call"
 
@@ -746,7 +748,7 @@ Object >> deprecated: anExplanationString on: date in: version transformWith: aR
 		transform
 ]
 
-{ #category : #deprecation }
+{ #category : 'deprecation' }
 Object >> deprecated: anExplanationString on: date in: version transformWith: aRule when: conditionBlock [
 	"Automatically tranform the deprecated call if it matches the condition"
 
@@ -760,7 +762,7 @@ Object >> deprecated: anExplanationString on: date in: version transformWith: aR
 		transform
 ]
 
-{ #category : #deprecation }
+{ #category : 'deprecation' }
 Object >> deprecated: anExplanationString transformWith: aRule [
 	"Automatically tranform the deprecated call"
 
@@ -771,7 +773,7 @@ Object >> deprecated: anExplanationString transformWith: aRule [
 		transform
 ]
 
-{ #category : #deprecation }
+{ #category : 'deprecation' }
 Object >> deprecated: anExplanationString transformWith: aRule when: conditionBlock [
 	"Automatically tranform the deprecated call if it matches the condition"
 
@@ -783,14 +785,14 @@ Object >> deprecated: anExplanationString transformWith: aRule when: conditionBl
 		transform
 ]
 
-{ #category : #displaying }
+{ #category : 'displaying' }
 Object >> displayString [
 	"While printString is about to give a detailled information about an object, displayString is a message that should return a short string-based representation to be used by list and related UI frameworks. By default, simply return printString. Subclasses should not override this method but instead stream based method #displayStringOn:"
 
 	^ self displayStringLimitedTo: 1000
 ]
 
-{ #category : #displaying }
+{ #category : 'displaying' }
 Object >> displayStringLimitedTo: limit [
 	"Answer a String whose characters are a description of the receiver.
 	If you want to print without a character limit, use fullDisplayString."
@@ -798,7 +800,7 @@ Object >> displayStringLimitedTo: limit [
 	^ self printStringLimitedTo: limit using: [:s | self displayStringOn: s]
 ]
 
-{ #category : #displaying }
+{ #category : 'displaying' }
 Object >> displayStringOn: aStream [
 	"While #printOn: is about to give a detailled information about an object, #displayStringOn: is a message that should return a string-based representation to be used by list and related UI frameworks. By default, simply use printOn: method.
 	Subclasses should override this method instead of #displayString"
@@ -806,7 +808,7 @@ Object >> displayStringOn: aStream [
 	self printOn: aStream
 ]
 
-{ #category : #'reflective operations' }
+{ #category : 'reflective operations' }
 Object >> doesNotUnderstand: aMessage [
 	<debuggerCompleteToSender>
 	 "Handle the fact that there was an attempt to send the given message to the receiver but the receiver does not understand this message (typically sent from the machine when a message is sent to the receiver and no method is defined for that selector)."
@@ -822,7 +824,7 @@ Object >> doesNotUnderstand: aMessage [
 		ifFalse: [resumeValue]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Object >> enclosedElement [
 	"The receiver is included into a set as an element.
 	Since some objects require wrappers (see SetElement) to be able to be included into a Set,
@@ -831,49 +833,49 @@ Object >> enclosedElement [
 	Only SetElement instance or its subclasses allowed to answer something different than receiver itself"
 ]
 
-{ #category : #'error handling' }
+{ #category : 'error handling' }
 Object >> error [
 	"Throw a generic Error exception."
 	<debuggerCompleteToSender>
 	^ self error: 'Error!'
 ]
 
-{ #category : #'error handling' }
+{ #category : 'error handling' }
 Object >> error: aString [
 	"Throw a generic Error exception."
 	<debuggerCompleteToSender>
 	^ Error new signal: aString
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Object >> errorImproperStore [
 	"Create an error notification that an improper store was attempted."
 
 	self error: 'Improper store into indexable object'
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Object >> errorNonIntegerIndex [
 	"Create an error notification that an improper object was used as an index."
 
 	self error: 'only integers should be used as indices'
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Object >> errorNotIndexable [
 	"Create an error notification that the receiver is not indexable."
 
 	self error: ('Instances of {1} are not indexable' format: {self class name})
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Object >> errorSubscriptBounds: index [
 	"Create an error notification that an improper integer was used as an index."
 
 	SubscriptOutOfBounds signalFor: index
 ]
 
-{ #category : #finalization }
+{ #category : 'finalization' }
 Object >> executor [
 	"Return an object which can act as executor for finalization of the receiver"
 
@@ -884,7 +886,7 @@ Object >> executor [
 	^ self finalizer
 ]
 
-{ #category : #'error handling' }
+{ #category : 'error handling' }
 Object >> explicitRequirement [
 	"If one of the superclasses can perform the selector, we execute the method of that class, otherwise, the explicit requirement error is thrown"
 	<debuggerCompleteToSender>
@@ -911,46 +913,46 @@ Object >> explicitRequirement [
 	errorBlock value
 ]
 
-{ #category : #finalization }
+{ #category : 'finalization' }
 Object >> finalizationRegistry [
 	"Answer the finalization registry associated with the receiver."
 	
 	^ FinalizationRegistry default
 ]
 
-{ #category : #finalization }
+{ #category : 'finalization' }
 Object >> finalize [
 	"Finalize the resource associated with the receiver. This message should only be sent during the finalization process. There is NO garantuee that the resource associated with the receiver hasn't been free'd before so take care that you don't run into trouble - this all may happen with interrupt priority."
 ]
 
-{ #category : #finalization }
+{ #category : 'finalization' }
 Object >> finalizer [
 	"Return an object which can act as finalizer of the receiver"
 
 	^ self
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 Object >> flattenOn: aStream [
 
 	aStream nextPut: self
 ]
 
-{ #category : #displaying }
+{ #category : 'displaying' }
 Object >> fullDisplayString [
 	"Answer a String whose characters are a description of the receiver suitable for UI"
 
 	^ String streamContents: [:s | self displayStringOn: s]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Object >> fullPrintString [
 	"Answer a String whose characters are a description of the receiver."
 
 	^ String streamContents: [:s | self printOn: s]
 ]
 
-{ #category : #halting }
+{ #category : 'halting' }
 Object >> halt [
 	"This is the typical message to use for inserting breakpoints during debugging."
 
@@ -958,13 +960,13 @@ Object >> halt [
 	Halt now
 ]
 
-{ #category : #halting }
+{ #category : 'halting' }
 Object >> halt: aString [
 	<debuggerCompleteToSender>
 	Halt now: aString
 ]
 
-{ #category : #halting }
+{ #category : 'halting' }
 Object >> haltFromCount: anInteger [
 	"Always halt after a count has been reached"
 
@@ -972,32 +974,32 @@ Object >> haltFromCount: anInteger [
 	Halt fromCount: anInteger
 ]
 
-{ #category : #halting }
+{ #category : 'halting' }
 Object >> haltIf: condition [
 	<debuggerCompleteToSender>
 
 	Halt if: condition
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> haltIfNil [
 ]
 
-{ #category : #halting }
+{ #category : 'halting' }
 Object >> haltIfNotTest [
 	"Halt if execution was not started by a test. This is useful as this means one can just run tests undisturbed, while a execution for example from the Playground would be halted"
 	<debuggerCompleteToSender>
 	Halt ifNotTest
 ]
 
-{ #category : #halting }
+{ #category : 'halting' }
 Object >> haltIfTest [
 	"Halt if execution was started by a test. These #halts are just active in the tests, useful when you want to add a halt in methods that are executed a lot (e.g. collections)"
 	<debuggerCompleteToSender>
 	Halt ifTest
 ]
 
-{ #category : #halting }
+{ #category : 'halting' }
 Object >> haltOnCount: anInteger [
 	"Halts once when a count is reached"
 
@@ -1005,40 +1007,40 @@ Object >> haltOnCount: anInteger [
 	Halt onCount: anInteger
 ]
 
-{ #category : #halting }
+{ #category : 'halting' }
 Object >> haltOnce [
 	<debuggerCompleteToSender>
 	Halt once
 ]
 
-{ #category : #'process termination handling' }
+{ #category : 'process termination handling' }
 Object >> handleProcessTerminationOfWaitingContext: suspendedContext [
 
 	^ suspendedContext
 ]
 
-{ #category : #'error handling' }
+{ #category : 'error handling' }
 Object >> handles: exception [
 	"This method exists in case a non exception class is the first arg in an on:do: (for instance using a exception class that is not loaded). We prefer this to raising an error during error handling itself. Also, semantically it makes sense that the exception handler is not active if its exception class is not loaded"
 
 	^ false
 ]
 
-{ #category : #'literal testing' }
+{ #category : 'literal testing' }
 Object >> hasLiteralSuchThat: testBlock [
 	"This is the end of the embedded structure path so return false."
 
 	^ false
 ]
 
-{ #category : #finalization }
+{ #category : 'finalization' }
 Object >> hasMultipleExecutors [
 	"All objects, except ObjectFinalizerCollection instances should answer false to this message"
 
 	^ false
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Object >> hash [
 	"Answer a SmallInteger whose value is related to the receiver's identity.
 	May be overridden, and should be overridden in any classes that define = "
@@ -1046,14 +1048,14 @@ Object >> hash [
 	^ self identityHash
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 Object >> in: aBlock [
 	"Evaluate the given block with the receiver as its argument."
 
 	^ aBlock value: self
 ]
 
-{ #category : #introspection }
+{ #category : 'introspection' }
 Object >> instVarAt: index [
 	"Primitive. Answer a fixed variable in an object. The numbering of the variables
 	 corresponds to the named instance variables, followed by the indexed instance
@@ -1064,7 +1066,7 @@ Object >> instVarAt: index [
 	self primitiveFailed
 ]
 
-{ #category : #introspection }
+{ #category : 'introspection' }
 Object >> instVarAt: index put: anObject [
 	"Primitive. Store a value into a fixed variable in an object. The numbering of the
 	 variables corresponds to the named instance variables, followed by the indexed
@@ -1079,7 +1081,7 @@ Object >> instVarAt: index put: anObject [
 		ifTrue: [ ^ self modificationForbiddenFor: #instVarAt:put: index: index value: anObject ]
 ]
 
-{ #category : #introspection }
+{ #category : 'introspection' }
 Object >> instVarNamed: aStringOrSymbol [
 	"Return the value of the instance variable in me with that name.  Slow, but very useful.
 	We support here all slots (even non indexed) but raise a backward compatible exception"
@@ -1090,7 +1092,7 @@ Object >> instVarNamed: aStringOrSymbol [
 		ifNone: [ InstanceVariableNotFound signalFor: aStringOrSymbol asString ]
 ]
 
-{ #category : #introspection }
+{ #category : 'introspection' }
 Object >> instVarNamed: aString put: aValue [
 	"Store into the value of the instance variable in me of that name. Slow, but very useful.
 	We support here all slots (even non indexed) but raise a backward compatible exception"
@@ -1101,19 +1103,19 @@ Object >> instVarNamed: aString put: aValue [
 		ifNone: [ InstanceVariableNotFound signalFor: aString asString ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isArray [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isAssociation [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isBehavior [
 	"Return true if the receiver is a behavior.
 	Note: Do not override in any class except behavior."
@@ -1121,87 +1123,87 @@ Object >> isBehavior [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isBlock [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isCharacter [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isClass [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isClassOrTrait [
 
 	^ self isClass or: [ self isTrait ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isClosure [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isCollection [
 	"Return true if the receiver is some sort of Collection and responds to basic collection messages such as #size and #do:"
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isColor [
 	"Answer true if receiver is a Color. False by default."
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isColorForm [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isCompiledBlock [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isCompiledMethod [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isContext [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isDictionary [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isEmbeddedBlock [
 	"Returns true for CleanBlockBlockClosure and CompiledBlock"
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isFloat [
 	"Overridden to return true in Float, natch"
 
@@ -1209,39 +1211,39 @@ Object >> isFloat [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isForm [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isFraction [
 	"Answer true if the receiver is a Fraction."
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isHeap [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isInteger [
 	"Overridden to return true in Integer."
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isInterval [
 
 	^ false
 ]
 
-{ #category : #'class membership' }
+{ #category : 'class membership' }
 Object >> isKindOf: aClass [
 	"Answer whether the class, aClass, is a superclass or class of the receiver.
 	The current implemementation allows for a Trait to be used as argument"
@@ -1249,7 +1251,7 @@ Object >> isKindOf: aClass [
 	^ self class == aClass or: [ self class inheritsFrom: aClass ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isLiteral [
 
 	"Answer whether the receiver has a literal text form recognized by the compiler.
@@ -1260,57 +1262,57 @@ Object >> isLiteral [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isLiteral: alreadyVisited [
 
 	^ self isLiteral
 ]
 
-{ #category : #'class membership' }
+{ #category : 'class membership' }
 Object >> isMemberOf: aClass [
 	"Answer whether the receiver is an instance of the class, aClass."
 
 	^ self class == aClass
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isMessageSend [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isMethodProperties [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isMorph [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isMorphicEvent [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isNotNil [
 	"Coerces nil to false and everything else to true."
 
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isNumber [
 	"Overridden to return true in Number, natch"
 	^ false
 ]
 
-{ #category : #pinning }
+{ #category : 'pinning' }
 Object >> isPinned [
 	"self
 		deprecated: 'Please use #isPinnedInMemory instead'
@@ -1319,7 +1321,7 @@ Object >> isPinned [
 	^self isPinnedInMemory
 ]
 
-{ #category : #pinning }
+{ #category : 'pinning' }
 Object >> isPinnedInMemory [
 	"Answer if the receiver is pinned.  The VM's garbage collector routinely moves
 	 objects as it reclaims and compacts memory.  But it can also pin an object so
@@ -1329,14 +1331,14 @@ Object >> isPinnedInMemory [
 	^self primitiveFailed
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isPoint [
 	"Overridden to return true in Point."
 
 	^ false
 ]
 
-{ #category : #'write barrier' }
+{ #category : 'write barrier' }
 Object >> isReadOnlyObject [
 	"Answer if the receiver is read-only.
 	 If the VM supports read-only objects it will not write to read-only objects.
@@ -1348,13 +1350,13 @@ Object >> isReadOnlyObject [
 	^self isImmediateObject
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isRectangle [
 
 	^ false
 ]
 
-{ #category : #'self evaluating' }
+{ #category : 'self evaluating' }
 Object >> isSelfEvaluating [
 
 	"A self evaluating object means that the string representation can be evaluated and give an identical object"
@@ -1362,76 +1364,76 @@ Object >> isSelfEvaluating [
 	^ self isLiteral
 ]
 
-{ #category : #'self evaluating' }
+{ #category : 'self evaluating' }
 Object >> isSelfEvaluating: alreadyVisited [
 
 	^ self isSelfEvaluating
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isStream [
 	"Return true if the receiver responds to the stream protocol"
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isString [
 	"Overridden to return true in String, natch"
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isSymbol [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isSystemWindow [
 	"Answer whether the receiver is a SystemWindow"
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isText [
 
 	^ false
 ]
 
-{ #category : #flagging }
+{ #category : 'flagging' }
 Object >> isThisEverCalled [
 
 	^ self isThisEverCalled: thisContext sender printString
 ]
 
-{ #category : #flagging }
+{ #category : 'flagging' }
 Object >> isThisEverCalled: msg [
 	"Send this message, with some useful printable argument, from methods or branches of methods which you believe are never reached."
 
 	self error: 'This is indeed called: ' , msg printString
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isTrait [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> isVariableBinding [
 	"Return true if I represent a literal variable binding"
 	^false
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Object >> literalEqual: other [
 
 	^ self class == other class and: [self = other]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Object >> longPrintOn: aStream [
 	"Append to the argument, aStream, the names and values of all
 	of the receiver's instance variables."
@@ -1446,7 +1448,7 @@ Object >> longPrintOn: aStream [
 		 cr]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Object >> longPrintOn: aStream limitedTo: sizeLimit indent: indent [
 	"Append to the argument, aStream, the names and values of all of the receiver's instance variables.  Limit is the length limit for each inst var."
 
@@ -1462,7 +1464,7 @@ Object >> longPrintOn: aStream limitedTo: sizeLimit indent: indent [
 		 cr]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Object >> longPrintString [
 	"Answer a String whose characters are a description of the receiver."
 
@@ -1473,7 +1475,7 @@ Object >> longPrintString [
 	^ str ifEmpty: [ self printString , String cr ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Object >> longPrintStringLimitedTo: aLimitValue [
 	"Answer a String whose characters are a description of the receiver."
 
@@ -1484,14 +1486,14 @@ Object >> longPrintStringLimitedTo: aLimitValue [
 	^ str ifEmpty: [ self printString , String cr ]
 ]
 
-{ #category : #dependencies }
+{ #category : 'dependencies' }
 Object >> myDependents [
 	"Private. Answer a list of all the receiver's dependents."
 
 	^ DependentsFields at: self ifAbsent: []
 ]
 
-{ #category : #dependencies }
+{ #category : 'dependencies' }
 Object >> myDependents: aCollectionOrNil [
 	"Private. Set (or remove) the receiver's dependents list."
 
@@ -1500,7 +1502,7 @@ Object >> myDependents: aCollectionOrNil [
 		ifNotNil: [DependentsFields at: self put: aCollectionOrNil]
 ]
 
-{ #category : #flagging }
+{ #category : 'flagging' }
 Object >> nominallyUnsent: aSelectorSymbol [
 	"From within the body of a method which is not formally sent within the system, but which you intend to have remain in the system (for potential manual invocation, or for documentation, or perhaps because it's sent by commented-out-code that you anticipate uncommenting out someday, send this message, with the selector itself as the argument.
 
@@ -1512,21 +1514,21 @@ This will serve two purposes:
 	false ifTrue: [self flag: #nominallyUnsent:]    "So that this method itself will appear to be sent"
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> notNil [
 	"Coerces nil to false and everything else to true."
 
 	^true
 ]
 
-{ #category : #'error handling' }
+{ #category : 'error handling' }
 Object >> notYetImplemented [
 	"Announce that this message is not yet implemented"
 	<debuggerCompleteToSender>
 	NotYetImplemented signalFor: thisContext sender selector
 ]
 
-{ #category : #'error handling' }
+{ #category : 'error handling' }
 Object >> notify: aString [
 	"Create and schedule a Notifier with the argument as the message in
 	order to request confirmation before a process can proceed."
@@ -1534,19 +1536,19 @@ Object >> notify: aString [
 	Warning signal: aString
 ]
 
-{ #category : #'model - updating' }
+{ #category : 'model - updating' }
 Object >> okToChange [
 	"Allows a controller to ask this of any model"
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Object >> packageOrganizer [
 
 	^ self class packageOrganizer
 ]
 
-{ #category : #'message performing' }
+{ #category : 'message performing' }
 Object >> perform: aSymbol [
 	"Send the unary selector, aSymbol, to the receiver.
 	Fail if the number of arguments expected by the selector is not zero.
@@ -1556,13 +1558,13 @@ Object >> perform: aSymbol [
 	^ self perform: aSymbol withArguments: #()
 ]
 
-{ #category : #'message performing' }
+{ #category : 'message performing' }
 Object >> perform: selector orSendTo: otherTarget [
 	"If I wish to intercept and handle selector myself, do it; else send it to otherTarget"
 	^ (self respondsTo: selector) ifTrue: [self perform: selector] ifFalse: [otherTarget perform: selector]
 ]
 
-{ #category : #'message performing' }
+{ #category : 'message performing' }
 Object >> perform: aSymbol with: anObject [
 	"Send the selector, aSymbol, to the receiver with anObject as its argument.
 	Fail if the number of arguments expected by the selector is not one.
@@ -1572,7 +1574,7 @@ Object >> perform: aSymbol with: anObject [
 	^ self perform: aSymbol withArguments: {anObject}
 ]
 
-{ #category : #'message performing' }
+{ #category : 'message performing' }
 Object >> perform: aSymbol with: firstObject with: secondObject [
 	"Send the selector, aSymbol, to the receiver with the given arguments.
 	Fail if the number of arguments expected by the selector is not two.
@@ -1582,7 +1584,7 @@ Object >> perform: aSymbol with: firstObject with: secondObject [
 	^ self perform: aSymbol withArguments: {firstObject . secondObject}
 ]
 
-{ #category : #'message performing' }
+{ #category : 'message performing' }
 Object >> perform: aSymbol with: firstObject with: secondObject with: thirdObject [
 	"Send the selector, aSymbol, to the receiver with the given arguments.
 	Fail if the number of arguments expected by the selector is not three.
@@ -1593,7 +1595,7 @@ Object >> perform: aSymbol with: firstObject with: secondObject with: thirdObjec
 		withArguments: {firstObject . secondObject . thirdObject}
 ]
 
-{ #category : #'message performing' }
+{ #category : 'message performing' }
 Object >> perform: aSymbol with: firstObject with: secondObject with: thirdObject with: fourthObject [
 	"Send the selector, aSymbol, to the receiver with the given arguments.
 	Fail if the number of arguments expected by the selector is not four.
@@ -1604,7 +1606,7 @@ Object >> perform: aSymbol with: firstObject with: secondObject with: thirdObjec
 		withArguments: {firstObject . secondObject . thirdObject . fourthObject}
 ]
 
-{ #category : #'message performing' }
+{ #category : 'message performing' }
 Object >> perform: selector withArguments: argArray [
 	"Send the selector, aSymbol, to the receiver with arguments in argArray.
 	Fail if the number of arguments expected by the selector
@@ -1615,7 +1617,7 @@ Object >> perform: selector withArguments: argArray [
 	^ self perform: selector withArguments: argArray inSuperclass: self class
 ]
 
-{ #category : #'message performing' }
+{ #category : 'message performing' }
 Object >> perform: selector withArguments: argArray inSuperclass: lookupClass [
 	"NOTE:  This is just like perform:withArguments:, except that
 	the message lookup process begins, not with the receivers's class,
@@ -1633,7 +1635,7 @@ Object >> perform: selector withArguments: argArray inSuperclass: lookupClass [
 	self primitiveFailed
 ]
 
-{ #category : #'message performing' }
+{ #category : 'message performing' }
 Object >> perform: selector withEnoughArguments: anArray [
 	"Send the selector, aSymbol, to the receiver with arguments in argArray.
 	Only use enough arguments for the arity of the selector; supply nils for missing ones."
@@ -1651,7 +1653,7 @@ Object >> perform: selector withEnoughArguments: anArray [
 	^ self perform: selector withArguments: args
 ]
 
-{ #category : #pinning }
+{ #category : 'pinning' }
 Object >> pin [
 	"self
 		deprecated: 'Please use #pinInMemory instead'
@@ -1660,7 +1662,7 @@ Object >> pin [
 	self pinInMemory
 ]
 
-{ #category : #pinning }
+{ #category : 'pinning' }
 Object >> pinInMemory [
 	"The VM's garbage collector routinely moves objects as it reclaims and compacts
 	 memory. But it can also pin an object so that it will not be moved, which can make
@@ -1669,7 +1671,7 @@ Object >> pinInMemory [
 	^self setPinnedInMemory: true
 ]
 
-{ #category : #'pointing to' }
+{ #category : 'pointing to' }
 Object >> pointsOnlyWeaklyTo: anObject [
 	"Assume, we already know that receiver points to an object,
 	answer true if receiver points only weakly to it "
@@ -1680,14 +1682,14 @@ Object >> pointsOnlyWeaklyTo: anObject [
 	^ true
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Object >> postCopy [
 	"I'm a hook method in the sense of Design Patterns TemplateHook/Methods. I'm called by copy. self is a shallow copy, subclasses should copy fields as necessary to complete the full copy"
 
 	^ self
 ]
 
-{ #category : #'reflective operations' }
+{ #category : 'reflective operations' }
 Object >> primitiveChangeClassTo: anObject [
 	"Primitive. Change the class of the receiver into the class of the argument given that the format of the receiver matches the format of the argument's class. Fail if receiver or argument are SmallIntegers, or when the format of the receiver is different from the format of the argument's class, or when the arguments class is fixed and the receiver's size differs from the size that an instance of the argument's class should have.
 	Note: The primitive will fail in most cases that you think might work. This is mostly because of differences in the format. As an example, '(Array new: 3) primitiveChangeClassTo: Morph basicNew' would fail for two of the reasons mentioned above. Array is variable and Morph is fixed (different format - failure #1). Morph is a fixed-field-only object and the array is too short (failure #2)."
@@ -1698,7 +1700,7 @@ Object >> primitiveChangeClassTo: anObject [
 	self primitiveFailed
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Object >> printOn: aStream [
 	"Append to the argument, aStream, a sequence of characters that
 	identifies the receiver."
@@ -1710,7 +1712,7 @@ Object >> printOn: aStream [
 		nextPutAll: title
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Object >> printString [
 	"Answer a String whose characters are a description of the receiver.
 	If you want to print without a character limit, use fullPrintString."
@@ -1718,14 +1720,14 @@ Object >> printString [
 	^ self printStringLimitedTo: 50000
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Object >> printStringLimitedTo: limit [
 	"Answer a String whose characters are a description of the receiver.
 	If you want to print without a character limit, use fullPrintString."
 	^self printStringLimitedTo: limit using: [:s | self printOn: s]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Object >> printStringLimitedTo: limit using: printBlock [
 	"Answer a String whose characters are a description of the receiver
 	produced by given printBlock. It ensures the result will be not bigger than given limit.
@@ -1736,7 +1738,7 @@ Object >> printStringLimitedTo: limit using: printBlock [
 	^ (limitedString truncateTo: limit - 4), '[..]'
 ]
 
-{ #category : #streaming }
+{ #category : 'streaming' }
 Object >> putOn: aStream [
 	"Write the receiver onto aStream.
 	In general we assume aStream accepts the receiver as element type.
@@ -1745,28 +1747,28 @@ Object >> putOn: aStream [
 	aStream nextPut: self
 ]
 
-{ #category : #reading }
+{ #category : 'reading' }
 Object >> readFromString: aString [
 	"Create an object based on the contents of aString."
 	^ self readFrom: aString readStream
 ]
 
-{ #category : #introspection }
+{ #category : 'introspection' }
 Object >> readSlot: aSlot [
 	^aSlot read: self
 ]
 
-{ #category : #introspection }
+{ #category : 'introspection' }
 Object >> readSlotNamed: aName [
 	^(self class slotNamed: aName) read: self
 ]
 
-{ #category : #'write barrier' }
+{ #category : 'write barrier' }
 Object >> recursivelySetIsReadOnlyObject: aBoolean [
 	^self recursivelySetIsReadOnlyObject: aBoolean exceptObjectsIn: IdentitySet new
 ]
 
-{ #category : #'write barrier' }
+{ #category : 'write barrier' }
 Object >> recursivelySetIsReadOnlyObject: aBoolean exceptObjectsIn: alreadyDone [
 
 	"Handle self if not already done, and note it as done."
@@ -1788,19 +1790,19 @@ Object >> recursivelySetIsReadOnlyObject: aBoolean exceptObjectsIn: alreadyDone 
 			exceptObjectsIn: alreadyDone ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Object >> refersToLiteral: aLitteral [
 	^ self literalEqual: aLitteral
 ]
 
-{ #category : #dependencies }
+{ #category : 'dependencies' }
 Object >> release [
 	"Remove references to objects that may refer to the receiver. This message
 	should be overridden by subclasses with any cycles, in which case the
 	subclass should also include the expression super release."
 ]
 
-{ #category : #dependencies }
+{ #category : 'dependencies' }
 Object >> removeDependent: anObject [
 	"Remove the given object as one of the receiver's dependents."
 
@@ -1810,7 +1812,7 @@ Object >> removeDependent: anObject [
 	^ anObject
 ]
 
-{ #category : #'class membership' }
+{ #category : 'class membership' }
 Object >> respondsTo: aSymbol [
 	"Answer whether the receiver can understand the specified message selector
 	aSymbol (ie. will respond meaningfully when such a message is sent to the
@@ -1819,7 +1821,7 @@ Object >> respondsTo: aSymbol [
 	^self class canUnderstand: aSymbol
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Object >> retrySetPinnedInMemory: aBoolean [
 	"Never use me directly use #setPinnedInMemory: instead"
 
@@ -1828,7 +1830,7 @@ Object >> retrySetPinnedInMemory: aBoolean [
 	^ self primitiveFailed
 ]
 
-{ #category : #finalization }
+{ #category : 'finalization' }
 Object >> retryWithGC: execBlock until: testBlock [
 	"Retry execBlock as long as testBlock returns false. Do an incremental GC after the first try, a full GC after the second try."
 	| blockValue |
@@ -1841,7 +1843,7 @@ Object >> retryWithGC: execBlock until: testBlock [
 	^execBlock value
 ]
 
-{ #category : #'write barrier' }
+{ #category : 'write barrier' }
 Object >> setIsReadOnlyObject: aBoolean [
 	"If the VM supports read-only objects it will not write to read-only objects.
 	 An attempt to write to an instance variable of a read-only object will
@@ -1857,7 +1859,7 @@ Object >> setIsReadOnlyObject: aBoolean [
 	^self primitiveFailed
 ]
 
-{ #category : #pinning }
+{ #category : 'pinning' }
 Object >> setPinned: aBoolean [
 	"self
 		deprecated: 'Please use #setPinnedInMemory: instead'
@@ -1866,7 +1868,7 @@ Object >> setPinned: aBoolean [
 	self setPinnedInMemory: aBoolean
 ]
 
-{ #category : #pinning }
+{ #category : 'pinning' }
 Object >> setPinnedInMemory: aBoolean [
 	"The VM's garbage collector routinely moves objects as it reclaims and compacts
 	 memory. But it can also pin an object so that it will not be moved around in memory,
@@ -1891,7 +1893,7 @@ Object >> setPinnedInMemory: aBoolean [
 	^ self retrySetPinnedInMemory: aBoolean
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Object >> shallowCopy [
 	"Answer a copy of the receiver which shares the receiver's instance variables. It should never be overridden. I'm invoked from the copy template method. Subclasses that need to specialize the copy should specialize the postCopy hook method."
 
@@ -1915,14 +1917,14 @@ Object >> shallowCopy [
 	^ newObject
 ]
 
-{ #category : #'error handling' }
+{ #category : 'error handling' }
 Object >> shouldBeImplemented [
 	"Announce that this message should be implemented"
 	<debuggerCompleteToSender>
 	ShouldBeImplemented signalFor: thisContext sender selector
 ]
 
-{ #category : #'literal testing' }
+{ #category : 'literal testing' }
 Object >> shouldBePrintedAsLiteral [
 
 	"Only literals should be printed as literals"
@@ -1930,13 +1932,13 @@ Object >> shouldBePrintedAsLiteral [
 	^ self isLiteral
 ]
 
-{ #category : #'literal testing' }
+{ #category : 'literal testing' }
 Object >> shouldBePrintedAsLiteral: alreadyVisited [
 
 	^ self shouldBePrintedAsLiteral
 ]
 
-{ #category : #'error handling' }
+{ #category : 'error handling' }
 Object >> shouldNotImplement [
 	"Announce that, although the receiver inherits this message,
 	it should not implement it."
@@ -1944,7 +1946,7 @@ Object >> shouldNotImplement [
 	ShouldNotImplement signalFor: thisContext sender selector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Object >> size [
 	"Primitive. Answer the number of indexable variables in the receiver.
 	This value is the same as the largest legal subscript. Essential. See Object
@@ -1955,7 +1957,7 @@ Object >> size [
 	^ 0
 ]
 
-{ #category : #'memory usage' }
+{ #category : 'memory usage' }
 Object >> sizeInMemory [
 	self class isImmediateClass
 		ifTrue: [ ^ 0 ].
@@ -1964,7 +1966,7 @@ Object >> sizeInMemory [
 		ifFalse: [ self class byteSizeOfInstance ]
 ]
 
-{ #category : #'reflective operations' }
+{ #category : 'reflective operations' }
 Object >> someObject [
 	"Primitive. Answer the first object in the enumeration of all
 	 objects."
@@ -1973,7 +1975,7 @@ Object >> someObject [
 	self primitiveFailed
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Object >> species [
 	"Answer the preferred class for reconstructing the receiver.  For example,
 	collections create new collections whenever enumeration messages such as
@@ -1984,7 +1986,7 @@ Object >> species [
 	^self class
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Object >> storeAt: offset inTempFrame: aContext [
 	"This message had to get sent to an expression already on the stack
 	as a Block argument being accessed by the debugger.
@@ -1992,7 +1994,7 @@ Object >> storeAt: offset inTempFrame: aContext [
 	^ aContext tempAt: offset put: self
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Object >> storeOn: aStream [
 	"Append to the argument aStream a sequence of characters that is an
 	expression whose evaluation creates an object similar to the receiver."
@@ -2020,7 +2022,7 @@ Object >> storeOn: aStream [
 	aStream nextPutAll: ' yourself)'
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Object >> storeString [
 	"Answer a String representation of the receiver from which the receiver
 	can be reconstructed."
@@ -2028,7 +2030,7 @@ Object >> storeString [
 	^ String streamContents: [:s | self storeOn: s]
 ]
 
-{ #category : #'error handling' }
+{ #category : 'error handling' }
 Object >> subclassResponsibility [
 	"This message sets up a framework for the behavior of the class' subclasses.
 	Announce that the subclass should have implemented this message."
@@ -2036,7 +2038,7 @@ Object >> subclassResponsibility [
 	SubclassResponsibility signalFor: thisContext sender selector
 ]
 
-{ #category : #finalization }
+{ #category : 'finalization' }
 Object >> toFinalizeSend: aSelector to: aFinalizer with: aResourceHandle [
 	"When I am finalized (e.g., garbage collected) close the associated resource handle by sending aSelector to the appropriate finalizer (the guy who knows how to get rid of the resource).
 	WARNING: Neither the finalizer nor the resource handle are allowed to reference me. If they do, then I will NEVER be garbage collected. Since this cannot be validated here, it is up to the client to make sure this invariant is not broken."
@@ -2052,12 +2054,12 @@ Object >> toFinalizeSend: aSelector to: aFinalizer with: aResourceHandle [
 				   argument: aResourceHandle)
 ]
 
-{ #category : #'error handling' }
+{ #category : 'error handling' }
 Object >> traitConflict [
 	self error: 'A class or trait does not properly resolve a conflict between multiple traits it uses.'
 ]
 
-{ #category : #pinning }
+{ #category : 'pinning' }
 Object >> unpin [
 	"self
 		deprecated: 'Please use #unpinInMemory instead'
@@ -2066,7 +2068,7 @@ Object >> unpin [
 	self unpinInMemory
 ]
 
-{ #category : #pinning }
+{ #category : 'pinning' }
 Object >> unpinInMemory [
 	"The VM's garbage collector routinely moves objects as it reclaims and compacts
 	 memory. But it can also pin an object so that it will not be moved, which can make
@@ -2075,7 +2077,7 @@ Object >> unpinInMemory [
 	^self setPinnedInMemory: false
 ]
 
-{ #category : #updating }
+{ #category : 'updating' }
 Object >> update: aParameter [
 	"Receive a change notice from an object of whom the receiver is a
 	dependent. The default behavior is to do nothing; a subclass might want
@@ -2084,7 +2086,7 @@ Object >> update: aParameter [
 	^ self
 ]
 
-{ #category : #updating }
+{ #category : 'updating' }
 Object >> update: anAspect with: anObject [
 	"Receive a change notice from an object of whom the receiver is a
 	dependent. The default behavior is to call update:,
@@ -2094,19 +2096,19 @@ Object >> update: anAspect with: anObject [
 	^ self update: anAspect
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 Object >> value [
 
 	^self
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 Object >> valueWithArguments: aSequenceOfArguments [
 
 	^self
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Object >> veryDeepCopy [
 	"Do a complete tree copy using a dictionary.  An object in the tree twice is only copied once.  All references to the object in the copy of the tree will point to the new copy."
 
@@ -2119,7 +2121,7 @@ Object >> veryDeepCopy [
 	^ new
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Object >> veryDeepCopyWith: deepCopier [
 	"Copy me and the entire tree of objects I point to.  An object in the tree twice is copied once, and both references point to him.  deepCopier holds a dictionary of objects we have seen.  Some classes refuse to be copied.  Some classes are picky about which fields get deep copied."
 
@@ -2167,36 +2169,36 @@ Object >> veryDeepCopyWith: deepCopier [
 	^ copyOfSelf
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Object >> veryDeepFixupWith: deepCopier [
 	"I have no fields and no superclass.  Catch the super call."
 
 	"avoid to use me we will deprecate it in the future"
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Object >> veryDeepInner: deepCopier [
 	"No special treatment for inst vars of my superclasses.  Override when some need to be weakly copied.  Object>>veryDeepCopyWith: will veryDeepCopy any inst var whose class does not actually define veryDeepInner:"
 
 	"avoid to use me we will deprecate it in the future"
 ]
 
-{ #category : #'model - updating' }
+{ #category : 'model - updating' }
 Object >> windowIsClosing [
 	"This message is used to inform a models that its window is closing. Most models do nothing, but some, such as the Debugger, must do some cleanup. Note that this mechanism must be used with care by models that support multiple views, since one view may be closed while others left open."
 ]
 
-{ #category : #introspection }
+{ #category : 'introspection' }
 Object >> writeSlot: aSlot value: anObject [
 	^aSlot write: anObject to: self
 ]
 
-{ #category : #introspection }
+{ #category : 'introspection' }
 Object >> writeSlotNamed: aName value: anObject [
 	^(self class slotNamed: aName) write: anObject to: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Object >> yourself [
 	"Answer self. The message yourself deserves a bit of explanation.
 	Sending yourself is handy to get the receiver of a message. It is especially useful when using a cascade since all the cascaded messages are send to the receiver. Let us look at an example.
@@ -2221,7 +2223,7 @@ Object >> yourself [
 	^self
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Object >> ~= anObject [
 	"Answer whether the receiver and the argument do not represent the
 	same object."
@@ -2229,7 +2231,7 @@ Object >> ~= anObject [
 	^ self = anObject == false
 ]
 
-{ #category : #associating }
+{ #category : 'associating' }
 Object >> ~~> aValueLinkOrNil [
 
 	"Answer a link of the same class of `aValueLinkOrNil`; if that argument is nil,

--- a/src/Kernel/ObjectLayout.class.st
+++ b/src/Kernel/ObjectLayout.class.st
@@ -2,27 +2,29 @@
 I am the superclass of standard layouts for Objects.
 "
 Class {
-	#name : #ObjectLayout,
-	#superclass : #AbstractLayout,
-	#category : #'Kernel-Layout'
+	#name : 'ObjectLayout',
+	#superclass : 'AbstractLayout',
+	#category : 'Kernel-Layout',
+	#package : 'Kernel',
+	#tag : 'Layout'
 }
 
-{ #category : #description }
+{ #category : 'description' }
 ObjectLayout class >> allSubclassDefiningSymbols [
 	^self allSubclasses collect: [ :class | class subclassDefiningSymbol ] as: Set
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ObjectLayout class >> extending: superLayout scope: aScope host: aClass [
 	self subclassResponsibility
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ObjectLayout class >> isAbstract [
 	^self == ObjectLayout
 ]
 
-{ #category : #monticello }
+{ #category : 'monticello' }
 ObjectLayout class >> layoutForSubclassDefiningSymbol: aSymbol [
 	"used to get the layout for a subclass definition symbol"
 	^self allSubclasses
@@ -30,7 +32,7 @@ ObjectLayout class >> layoutForSubclassDefiningSymbol: aSymbol [
 		ifNone: [ FixedLayout ]
 ]
 
-{ #category : #description }
+{ #category : 'description' }
 ObjectLayout class >> subclassDefiningSymbol [
 	"Answer a keyword that describes the receiver's kind of subclass
 	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
@@ -40,14 +42,14 @@ ObjectLayout class >> subclassDefiningSymbol [
 	^#subclass:
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 ObjectLayout >> extend [
 	"Answer a default extension of me."
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 ObjectLayout >> extend: aScope [
 	IncompatibleLayoutConflict new
 		layout: self;
@@ -55,7 +57,7 @@ ObjectLayout >> extend: aScope [
 		signal
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 ObjectLayout >> extendByte [
 	self hasFields ifTrue: [
 		IncompatibleLayoutConflict new
@@ -65,7 +67,7 @@ ObjectLayout >> extendByte [
 	^ ByteLayout new
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 ObjectLayout >> extendCompiledMethod [
 	self hasFields ifTrue: [
 		IncompatibleLayoutConflict new
@@ -75,7 +77,7 @@ ObjectLayout >> extendCompiledMethod [
 	^ CompiledMethodLayout new
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 ObjectLayout >> extendDoubleByte [
 	self hasFields ifTrue: [
 		IncompatibleLayoutConflict new
@@ -85,7 +87,7 @@ ObjectLayout >> extendDoubleByte [
 	^ DoubleByteLayout new
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 ObjectLayout >> extendDoubleWord [
 	self hasFields ifTrue: [
 		IncompatibleLayoutConflict new
@@ -95,7 +97,7 @@ ObjectLayout >> extendDoubleWord [
 	^ DoubleWordLayout new
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 ObjectLayout >> extendSmallInteger [
 	self hasFields ifTrue: [
 		IncompatibleLayoutConflict new
@@ -105,7 +107,7 @@ ObjectLayout >> extendSmallInteger [
 	^ ImmediateLayout new
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 ObjectLayout >> extendVariable: aScope [
 	IncompatibleLayoutConflict new
 		layout: self;
@@ -113,7 +115,7 @@ ObjectLayout >> extendVariable: aScope [
 		signal
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 ObjectLayout >> extendWord [
 	self hasFields ifTrue: [
 		IncompatibleLayoutConflict new
@@ -123,7 +125,7 @@ ObjectLayout >> extendWord [
 	^ WordLayout new
 ]
 
-{ #category : #format }
+{ #category : 'format' }
 ObjectLayout >> format [
 	"Answer an Integer that encodes this layout in the way that VM expects it."
 
@@ -134,24 +136,24 @@ ObjectLayout >> format [
 	^ format
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ObjectLayout >> initializeInstance: anInstance [
 	"do nothing by default, overriden by PointerLayout"
 ]
 
-{ #category : #format }
+{ #category : 'format' }
 ObjectLayout >> instanceSpecification [
 	self subclassResponsibility
 ]
 
-{ #category : #'testing - class hierarchy' }
+{ #category : 'testing - class hierarchy' }
 ObjectLayout >> kindOfSubclass [
 	"Answer a String that is the keyword that describes the receiver's kind of subclass
 	Note: this is for printing the ST80 style class definiton, see #subclassDefiningSymbol"
 	^' ',self class subclassDefiningSymbol, ' '
 ]
 
-{ #category : #'testing - class hierarchy' }
+{ #category : 'testing - class hierarchy' }
 ObjectLayout >> subclassDefiningSymbol [
 	"Answer a keyword that describes the receiver's kind of subclass
 	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything

--- a/src/Kernel/OldPharoClassDefinitionPrinter.class.st
+++ b/src/Kernel/OldPharoClassDefinitionPrinter.class.st
@@ -5,12 +5,14 @@ This prints the class definition as it was till Pharo9: ST80 style, but with ext
 - support for traits
 "
 Class {
-	#name : #OldPharoClassDefinitionPrinter,
-	#superclass : #ClassDefinitionPrinter,
-	#category : #'Kernel-ClassDefinitionPrinter'
+	#name : 'OldPharoClassDefinitionPrinter',
+	#superclass : 'ClassDefinitionPrinter',
+	#category : 'Kernel-ClassDefinitionPrinter',
+	#package : 'Kernel',
+	#tag : 'ClassDefinitionPrinter'
 }
 
-{ #category : #internal }
+{ #category : 'internal' }
 OldPharoClassDefinitionPrinter >> basicClassDefinitionString [
 
 	"Pay attention this definition is fragile in presence of complex slots. Use the public API i.e., classDefinitionString"
@@ -39,7 +41,7 @@ OldPharoClassDefinitionPrinter >> basicClassDefinitionString [
 	^ stream contents
 ]
 
-{ #category : #internal }
+{ #category : 'internal' }
 OldPharoClassDefinitionPrinter >> basicMetaclassDefinitionString [
 
 	"Pay attention this definition is fragile in presence of complex slots. Use the public API i.e., classDefinitionString"
@@ -49,7 +51,7 @@ OldPharoClassDefinitionPrinter >> basicMetaclassDefinitionString [
 		  self instanceVariablesOn: stream ]
 ]
 
-{ #category : #internal }
+{ #category : 'internal' }
 OldPharoClassDefinitionPrinter >> basicTraitDefinitionString [
 
 	"Pay attention this definition is fragile in presence of complex slots. Use the public API i.e., classDefinitionString"
@@ -66,7 +68,7 @@ OldPharoClassDefinitionPrinter >> basicTraitDefinitionString [
 		  self packageOn: s ]
 ]
 
-{ #category : #internal }
+{ #category : 'internal' }
 OldPharoClassDefinitionPrinter >> basicTraitedMetaclassDefinitionString [
 
 	^ String streamContents: [:strm |
@@ -75,7 +77,7 @@ OldPharoClassDefinitionPrinter >> basicTraitedMetaclassDefinitionString [
 			self instanceVariablesOn: strm ]
 ]
 
-{ #category : #'public API' }
+{ #category : 'public API' }
 OldPharoClassDefinitionPrinter >> classDefinitionString [
 
 	^ forClass needsSlotClassDefinition
@@ -83,7 +85,7 @@ OldPharoClassDefinitionPrinter >> classDefinitionString [
 		ifFalse: [ self basicClassDefinitionString ]
 ]
 
-{ #category : #template }
+{ #category : 'template' }
 OldPharoClassDefinitionPrinter >> classDefinitionTemplateInPackage: aString named: aClassName [
 
 	^ String streamContents: [ :s |
@@ -103,7 +105,7 @@ OldPharoClassDefinitionPrinter >> classDefinitionTemplateInPackage: aString name
 			  nextPutAll: '''' ]
 ]
 
-{ #category : #'low-level elements' }
+{ #category : 'low-level elements' }
 OldPharoClassDefinitionPrinter >> classVariablesOn: stream [
 
 	stream
@@ -113,27 +115,27 @@ OldPharoClassDefinitionPrinter >> classVariablesOn: stream [
 	stream nextPut: $'
 ]
 
-{ #category : #template }
+{ #category : 'template' }
 OldPharoClassDefinitionPrinter >> compactClassDefinitionTemplateInPackage: aString [
 	"there is not compact version..."
 
 	^ self classDefinitionTemplateInPackage: aString
 ]
 
-{ #category : #template }
+{ #category : 'template' }
 OldPharoClassDefinitionPrinter >> compactTraitDefinitionTemplateInPackage: aString [
 
 	^ self traitDefinitionTemplateInPackage: aString
 ]
 
-{ #category : #'expanded double dispatch API' }
+{ #category : 'expanded double dispatch API' }
 OldPharoClassDefinitionPrinter >> expandedDefinitionString [
 	"We do not support expanded on old Pharo syntax so we shortcut the double dispatch call."
 
 	^ self definitionString
 ]
 
-{ #category : #'low-level elements' }
+{ #category : 'low-level elements' }
 OldPharoClassDefinitionPrinter >> instanceVariablesOn: stream [
 
 	stream
@@ -143,7 +145,7 @@ OldPharoClassDefinitionPrinter >> instanceVariablesOn: stream [
 	stream nextPut: $'
 ]
 
-{ #category : #'public API' }
+{ #category : 'public API' }
 OldPharoClassDefinitionPrinter >> metaclassDefinitionString [
 
 	^ forClass needsSlotClassDefinition
@@ -151,7 +153,7 @@ OldPharoClassDefinitionPrinter >> metaclassDefinitionString [
 		ifFalse: [ self basicMetaclassDefinitionString ]
 ]
 
-{ #category : #'low-level elements' }
+{ #category : 'low-level elements' }
 OldPharoClassDefinitionPrinter >> packageOn: stream [
 
 	stream
@@ -160,7 +162,7 @@ OldPharoClassDefinitionPrinter >> packageOn: stream [
 		store: forClass category asString
 ]
 
-{ #category : #'low-level elements' }
+{ #category : 'low-level elements' }
 OldPharoClassDefinitionPrinter >> poolOn: stream [
 
 	| poolString |
@@ -172,7 +174,7 @@ OldPharoClassDefinitionPrinter >> poolOn: stream [
 			store: poolString ]
 ]
 
-{ #category : #template }
+{ #category : 'template' }
 OldPharoClassDefinitionPrinter >> testClassDefinitionTemplateInPackage: aString [
 
 	^ String streamContents: [ :s |
@@ -182,7 +184,7 @@ OldPharoClassDefinitionPrinter >> testClassDefinitionTemplateInPackage: aString 
 			s nextPutAll: 'package: ''', aString, '''' ]
 ]
 
-{ #category : #'low-level elements' }
+{ #category : 'low-level elements' }
 OldPharoClassDefinitionPrinter >> traitCompositionOn: stream [
 
 	forClass hasTraitComposition ifTrue: [
@@ -192,7 +194,7 @@ OldPharoClassDefinitionPrinter >> traitCompositionOn: stream [
 			nextPutAll: forClass traitCompositionString ]
 ]
 
-{ #category : #'public API' }
+{ #category : 'public API' }
 OldPharoClassDefinitionPrinter >> traitDefinitionString [
 
 	^ forClass needsSlotClassDefinition
@@ -200,7 +202,7 @@ OldPharoClassDefinitionPrinter >> traitDefinitionString [
 		ifFalse: [ self basicTraitDefinitionString ]
 ]
 
-{ #category : #template }
+{ #category : 'template' }
 OldPharoClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aString named: aTraitName [
 
 	^ String streamContents: [ :s |
@@ -214,7 +216,7 @@ OldPharoClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aString name
 			  nextPut: $' ]
 ]
 
-{ #category : #'public API' }
+{ #category : 'public API' }
 OldPharoClassDefinitionPrinter >> traitedMetaclassDefinitionString [
 
 	^ forClass needsSlotClassDefinition

--- a/src/Kernel/OutOfMemory.class.st
+++ b/src/Kernel/OutOfMemory.class.st
@@ -3,12 +3,14 @@ OutOfMemory is signaled when an allocation fails due to not having enough memory
 Originally suggested by A. Raab.
 "
 Class {
-	#name : #OutOfMemory,
-	#superclass : #Error,
-	#category : #'Kernel-Exceptions'
+	#name : 'OutOfMemory',
+	#superclass : 'Error',
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 OutOfMemory >> isResumable [
 
 	^ true

--- a/src/Kernel/PackageManifest.class.st
+++ b/src/Kernel/PackageManifest.class.st
@@ -2,49 +2,51 @@
 I store meta-data for a package. I'm the common superclass of all package Manifest.
 "
 Class {
-	#name : #PackageManifest,
-	#superclass : #Object,
-	#category : #'Kernel-Manifest'
+	#name : 'PackageManifest',
+	#superclass : 'Object',
+	#category : 'Kernel-Manifest',
+	#package : 'Kernel',
+	#tag : 'Manifest'
 }
 
-{ #category : #'accessing - comment' }
+{ #category : 'accessing - comment' }
 PackageManifest class >> classCommentBlank [
 
 	^'No description for this package available. Please add a description for this package here'
 ]
 
-{ #category : #'meta-data' }
+{ #category : 'meta-data' }
 PackageManifest class >> description [
 	^ 'No description for this package manifest available. Please add a description for this package here.'
 ]
 
-{ #category : #'meta-data - dependency analyser' }
+{ #category : 'meta-data - dependency analyser' }
 PackageManifest class >> ignoredDependencies [
 	^ #(#'System-Settings-Core')
 ]
 
-{ #category : #deprecation }
+{ #category : 'deprecation' }
 PackageManifest class >> isDeprecated [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 PackageManifest class >> isManifest [
 
 	^ self ~= PackageManifest
 ]
 
-{ #category : #'System-Support' }
+{ #category : 'System-Support' }
 PackageManifest class >> isUsed [
 	^ true
 ]
 
-{ #category : #'meta-data - dependency analyser' }
+{ #category : 'meta-data - dependency analyser' }
 PackageManifest class >> manuallyResolvedDependencies [
 	^ #()
 ]
 
-{ #category : #unloading }
+{ #category : 'unloading' }
 PackageManifest class >> postUnloadAction [
 
 	"override to return block that will be executed after the package unloading. Keep in mind that all package classes are already removed from the system including the manifest class"
@@ -52,18 +54,18 @@ PackageManifest class >> postUnloadAction [
 	^ [ "do nothing" ]
 ]
 
-{ #category : #unloading }
+{ #category : 'unloading' }
 PackageManifest class >> preUnload [
 
 	"override this method to specify clean-up actions that should be done before package unloading."
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 PackageManifest class >> rejectClasses [
 	^ #()
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 PackageManifest class >> rejectRules [
 	^ #()
 ]

--- a/src/Kernel/Point.class.st
+++ b/src/Kernel/Point.class.st
@@ -33,23 +33,25 @@ I define many nice messages that deal with point such as:
 
 "
 Class {
-	#name : #Point,
-	#superclass : #Object,
+	#name : 'Point',
+	#superclass : 'Object',
 	#instVars : [
 		'x',
 		'y'
 	],
-	#category : #'Kernel-BasicObjects'
+	#category : 'Kernel-BasicObjects',
+	#package : 'Kernel',
+	#tag : 'BasicObjects'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Point class >> x: xInteger y: yInteger [
 	"Answer an instance of me with coordinates xInteger and yInteger."
 
 	^ self basicNew setX: xInteger setY: yInteger
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Point >> * arg [
 	"Answer a Point that is the product of the receiver and arg."
 	"((2@2) * (100@200)) >>> (200@400)"
@@ -59,7 +61,7 @@ Point >> * arg [
 	^ arg adaptToPoint: self andSend: #*
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Point >> + arg [
 	"Answer a Point that is the sum of the receiver and arg."
 	"((2@2) + (100@200)) >>> (102@202)"
@@ -69,7 +71,7 @@ Point >> + arg [
 	^ arg adaptToPoint: self andSend: #+
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Point >> - arg [
 	"Answer a Point that is the difference of the receiver and arg."
 	"((2@2) - (100@200)) >>> (-98@ -198)"
@@ -79,7 +81,7 @@ Point >> - arg [
 	^ arg adaptToPoint: self andSend: #-
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Point >> / arg [
 	"Answer a Point that is the quotient of the receiver and arg."
 
@@ -87,7 +89,7 @@ Point >> / arg [
 	^ arg adaptToPoint: self andSend: #/
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Point >> // arg [
 	"Answer a Point that is the quotient of the receiver and arg."
 
@@ -95,7 +97,7 @@ Point >> // arg [
 	^ arg adaptToPoint: self andSend: #//
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Point >> < aPoint [
 	"Answer whether the receiver is above and to the left of aPoint."
 	"((100@200) < (330@400)) >>> true"
@@ -104,35 +106,35 @@ Point >> < aPoint [
 	^ x < aPoint x and: [y < aPoint y]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Point >> <= aPoint [
 	"Answer whether the receiver is neither below nor to the right of aPoint."
 
 	^ x <= aPoint x and: [y <= aPoint y]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Point >> = aPoint [
 
 	^ self species = aPoint species
 		and: [ x = aPoint x and: [ y = aPoint y ]]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Point >> > aPoint [
 	"Answer whether the receiver is below and to the right of aPoint."
 
 	^ x > aPoint x and: [ y > aPoint y ]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Point >> >= aPoint [
 	"Answer whether the receiver is neither above nor to the left of aPoint."
 
 	^ x >= aPoint x and: [ y >= aPoint y ]
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Point >> \\ arg [
 	"Answer a Point that is the mod of the receiver and arg."
 
@@ -140,27 +142,27 @@ Point >> \\ arg [
 	^ arg adaptToPoint: self andSend: #\\
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Point >> abs [
 	"Answer a Point whose x and y are the absolute values of the receiver's x and y."
 	"(100 @ -200) abs >>> (100@200)"
 	^ x abs @ y abs
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Point >> adaptToCollection: rcvr andSend: selector [
 	"If I am involved in arithmetic with a Collection, return a Collection of the results of each element combined with me in that expression."
 
 	^ rcvr collect: [ :element | element perform: selector with: self ]
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Point >> adaptToNumber: rcvr andSend: selector [
 	"If I am involved in arithmetic with an Integer, convert it to a Point."
 	^ rcvr@rcvr perform: selector with: self
 ]
 
-{ #category : #transforming }
+{ #category : 'transforming' }
 Point >> adhereTo: aRectangle [
 	"If the receiver lies outside aRectangle, return the nearest point on the boundary of the rectangle, otherwise return self."
 
@@ -169,7 +171,7 @@ Point >> adhereTo: aRectangle [
 		@ ((y max: aRectangle top) min: aRectangle bottom)
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Point >> asFloatPoint [
 	"Convert me to a float point transforming both of my coordinates
 	to floats using #asFloat. If x and y are already represented
@@ -181,7 +183,7 @@ Point >> asFloatPoint [
 	^ x asFloat @ y asFloat
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Point >> asIntegerPoint [
 	"Convert me to an integer point transforming both of my coordinates
 	to integers using #asInteger. If x and y are already represented
@@ -192,7 +194,7 @@ Point >> asIntegerPoint [
 	^ x asInteger @ y asInteger
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Point >> asNonFractionalPoint [
 	"Convert a point to a float point if necessary i.e., if one of its constituents are fractions."
 
@@ -200,19 +202,19 @@ Point >> asNonFractionalPoint [
 		ifTrue: [ ^ x asFloat @ y asFloat ]
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Point >> asPoint [
 	"Answer the receiver itself."
 	^self
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Point >> bitShiftPoint: bits [
 	x := x bitShift: bits.
 	y := y bitShift: bits
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Point >> ceiling [
 	"Answer a Point that is the receiver's x and y ceiling. Answer the receiver if its coordinates are already integral."
 	"(100@200) ceiling >>> (100@200)"
@@ -222,7 +224,7 @@ Point >> ceiling [
 	^ x ceiling @ y ceiling
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Point >> closeTo: aPoint [
 	"Return whether the receiver is close to the argument aPoint. The precision for point holding floats is defined by Float >> #closeTo:precision:. For points holding integer, closeTo: corresponds to equalsTo:"
 
@@ -232,12 +234,12 @@ Point >> closeTo: aPoint [
  	^ (x closeTo: aPoint x) and: [ y closeTo: aPoint y ]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Point >> closeTo: aPoint precision: aPrecision [
  	^ (x closeTo: aPoint x precision: aPrecision) and: [ y closeTo: aPoint y precision: aPrecision ]
 ]
 
-{ #category : #'rectangle creation' }
+{ #category : 'rectangle creation' }
 Point >> corner: aPoint [
 	"Answer a Rectangle whose origin is the receiver and whose corner is aPoint. This is one of the infix ways of expressing the creation of a rectangle."
 	"(10@10 corner: 100@100) >>> (10@10 corner: 100@100)"
@@ -245,21 +247,21 @@ Point >> corner: aPoint [
 	^ Rectangle origin: self corner: aPoint
 ]
 
-{ #category : #'point functions' }
+{ #category : 'point functions' }
 Point >> crossProduct: aPoint [
 	"Answer a number that is the cross product of the receiver and the argument, aPoint."
 
 	^ (x * aPoint y) - (y * aPoint x)
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Point >> deepCopy [
 	"Implemented here for better performance."
 
 	^ x deepCopy @ y deepCopy
 ]
 
-{ #category : #'point functions' }
+{ #category : 'point functions' }
 Point >> directionToLineFrom: p1 to: p2 [
 	"Answer the direction of the line from the receiver position.
 	< 0 => left (receiver to right)
@@ -269,27 +271,27 @@ Point >> directionToLineFrom: p1 to: p2 [
 	^((p2 x - p1 x) * (self y - p1 y)) - ((self x - p1 x) * (p2 y - p1 y))
 ]
 
-{ #category : #'point functions' }
+{ #category : 'point functions' }
 Point >> dotProduct: aPoint [
 	"Answer a number that is the dot product of the receiver and the argument, aPoint. That is, the two points are multipled and the coordinates of the result summed."
 
 	^ (x * aPoint x) + (y * aPoint y)
 ]
 
-{ #category : #'point functions' }
+{ #category : 'point functions' }
 Point >> eightNeighbors [
 	^ { self + (1 @ 0) . self + (1 @ 1) .  self + (0 @ 1) . self + (-1 @ 1) . self + (-1 @ 0) .
 		 self + (-1 @ -1) . self + (0 @ -1) . self + (1 @ -1)}
 ]
 
-{ #category : #'rectangle creation' }
+{ #category : 'rectangle creation' }
 Point >> extent: aPoint [
 	"Answer a Rectangle whose origin is the receiver and whose extent is aPoint. This is one of the infix ways of expressing the creation of a rectangle."
 
 	^ Rectangle origin: self extent: aPoint
 ]
 
-{ #category : #'point functions' }
+{ #category : 'point functions' }
 Point >> flipBy: direction centerAt: c [
 	"Answer a Point which is flipped according to the direction about the point c. Direction must be #vertical or #horizontal."
 	direction == #vertical ifTrue: [ ^ x @ (c y * 2 - y) ].
@@ -297,7 +299,7 @@ Point >> flipBy: direction centerAt: c [
 	self error: 'unrecognizable direction'
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Point >> floor [
 	"Answer a Point that is the receiver's x and y floor. Answer the receiver if its coordinates are already integral."
 	"(100@200) floor >>> (100@200)"
@@ -307,7 +309,7 @@ Point >> floor [
 	^ x floor @ y floor
 ]
 
-{ #category : #'point functions' }
+{ #category : 'point functions' }
 Point >> fourDirections [
 	"Return vertices for a square centered at 0 asPoint with the receiver as first corner.
 	Returns the four rotation of the reciever in counter clockwise order with the receiver appearing last."
@@ -318,7 +320,7 @@ Point >> fourDirections [
 			with: self
 ]
 
-{ #category : #'point functions' }
+{ #category : 'point functions' }
 Point >> fourNeighbors [
 	^ Array with: self + (1 @ 0)
 		with: self + (0 @ 1)
@@ -326,7 +328,7 @@ Point >> fourNeighbors [
 		with: self + (0 @ -1)
 ]
 
-{ #category : #'point functions' }
+{ #category : 'point functions' }
 Point >> grid: aPoint [
 	"Answer a Point to the nearest rounded grid modules specified by aPoint."
 	| newX newY |
@@ -335,7 +337,7 @@ Point >> grid: aPoint [
 	^ newX @ newY
 ]
 
-{ #category : #'extent functions' }
+{ #category : 'extent functions' }
 Point >> guarded [
 	"Return a positive nonzero extent."
 	"(100@200) guarded >>> (100@200)"
@@ -344,14 +346,14 @@ Point >> guarded [
 	^self max: 1@1
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Point >> hash [
 	"Hash is reimplemented because = is reimplemented."
 
 	^ ( x hash hashMultiply + y hash) hashMultiply
 ]
 
-{ #category : #'point functions' }
+{ #category : 'point functions' }
 Point >> insideTriangle: p1 with: p2 with: p3 [
 	"Return true if the receiver is within the triangle defined by the three coordinates.
 	Note: This method computes the barycentric coordinates for the receiver and tests those coordinates."
@@ -370,14 +372,14 @@ Point >> insideTriangle: p1 with: p2 with: p3 [
 	^ true
 ]
 
-{ #category : #interpolating }
+{ #category : 'interpolating' }
 Point >> interpolateTo: end at: amountDone [
 	"Interpolate between the instance and end after the specified amount has been done (0 - 1)."
 
 	^ self * (1 - amountDone) + (end * amountDone)
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Point >> isFloatPoint [
 	"Return true if both of my x and y coordinates
 	are represented by float values, otherwise false"
@@ -389,7 +391,7 @@ Point >> isFloatPoint [
 	^ x isFloat and: [ y isFloat ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Point >> isInsideCircle: a with: b with: c [
 	"Returns true if self is inside the circle defined by the points a, b, c. See Guibas and Stolfi (1985) p.107"
 	^ (a dotProduct: a)
@@ -399,7 +401,7 @@ Point >> isInsideCircle: a with: b with: c [
 			* (a triangleArea: b with: c)) > 0.0
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Point >> isInsideRectangle: aRectangle [
 	"Answer true whether the receiver is inside the argument (following Rectangle>>#containsPoint: semantics"
 
@@ -412,35 +414,35 @@ Point >> isInsideRectangle: aRectangle [
 	^ aRectangle containsPoint: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Point >> isIntegerPoint [
 	"Return true if both of my x and y coordinates
 	are represented by integer values, otherwise false"
 	^ x isInteger and: [ y isInteger ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Point >> isPoint [
 	^ true
 ]
 
-{ #category : #'self evaluating' }
+{ #category : 'self evaluating' }
 Point >> isSelfEvaluating [
 	^ self class == Point
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Point >> isZero [
 	^ x isZero and: [ y isZero ]
 ]
 
-{ #category : #'point functions' }
+{ #category : 'point functions' }
 Point >> leftRotated [
 	"Return the receiver rotated 90 degrees. i.e., self rotateBy: #left centerAt: 0 asPoint. Compare to transposed and normal."
 	^ y  @x negated
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Point >> max [
 	"Answer a number that is the maximum of the x and y of the receiver."
 	"(100@200) max >>> 200"
@@ -448,7 +450,7 @@ Point >> max [
 	^ self x max: self y
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Point >> max: aPoint [
 	"Answer the lower right corner of the rectangle uniquely defined by the receiver and the argument, aPoint."
 	"((100@200) max: (330@400)) >>> (330@400)"
@@ -456,7 +458,7 @@ Point >> max: aPoint [
 	^ (x max: aPoint x) @ (y max: aPoint y)
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Point >> min [
 	"Answer a number that is the minimum of the x and y of the receiver."
 	"(100@200) min >>> 100"
@@ -464,7 +466,7 @@ Point >> min [
 	^ self x min: self y
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Point >> min: aPoint [
 	"Answer the upper left corner of the rectangle uniquely defined by the receiver and the argument, aPoint."
 	"((100@200) min: (330@400)) >>> (100@200)"
@@ -473,13 +475,13 @@ Point >> min: aPoint [
 	^ (x min: aPoint x) @ (y min: aPoint y)
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Point >> min: aMin max: aMax [
 
 	^ (self min: aMin) max: aMax
 ]
 
-{ #category : #'point functions' }
+{ #category : 'point functions' }
 Point >> nearestPointAlongLineFrom: p1 to: p2 [
 	"Note this will give points beyond the endpoints."
 
@@ -494,20 +496,20 @@ Point >> nearestPointAlongLineFrom: p1 to: p2 [
 	^ (x1 + (t * x21)) @ (y1 + (t * y21))
 ]
 
-{ #category : #'point functions' }
+{ #category : 'point functions' }
 Point >> nearestPointOnLineFrom: p1 to: p2 [
 	"This will not give points beyond the endpoints"
 	^ (self nearestPointAlongLineFrom: p1 to: p2)
 		adhereTo: (p1 rectangle: p2)
 ]
 
-{ #category : #transforming }
+{ #category : 'transforming' }
 Point >> negated [
 	"Answer a point whose x and y coordinates are the negatives of those of the receiver."
 	^ (0 - x) @ (0 - y)
 ]
 
-{ #category : #'point functions' }
+{ #category : 'point functions' }
 Point >> octantOf: otherPoint [
 	"Return 1..8 indicating relative direction to otherPoint.
 	1=ESE, 2=SSE, ... etc. clockwise to 8=ENE"
@@ -523,7 +525,7 @@ Point >> octantOf: otherPoint [
 		ifFalse: [ quad * 2 - 1 ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Point >> printOn: aStream [
 	"The receiver prints on aStream in terms of infix notation."
 
@@ -538,7 +540,7 @@ Point >> printOn: aStream [
 	aStream nextPut: $)
 ]
 
-{ #category : #'point functions' }
+{ #category : 'point functions' }
 Point >> quadrantOf: otherPoint [
 	"Return 1..4 indicating relative direction to otherPoint.
 	1 is downRight, 2=downLeft, 3=upLeft, 4=upRight"
@@ -547,7 +549,7 @@ Point >> quadrantOf: otherPoint [
 		ifFalse: [ y <= otherPoint y ifTrue: [2] ifFalse: [3] ]
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Point >> reciprocal [
 	"Answer a Point with coordinates that are the reciprocals of mine."
 	"(100@200) reciprocal >>> ((1/100)@(1/200))"
@@ -555,7 +557,7 @@ Point >> reciprocal [
 	^ x reciprocal @ y reciprocal
 ]
 
-{ #category : #'rectangle creation' }
+{ #category : 'rectangle creation' }
 Point >> rectangle: aPoint [
 	"Answer a Rectangle that encompasses the receiver and aPoint. This is the most general infix way to create a rectangle."
 
@@ -564,20 +566,20 @@ Point >> rectangle: aPoint [
 		point: aPoint
 ]
 
-{ #category : #'point functions' }
+{ #category : 'point functions' }
 Point >> reflectedAbout: aPoint [
 	"Answer a new point that is the reflection of the receiver about the given point."
 
 	^ (self - aPoint) negated + aPoint
 ]
 
-{ #category : #'point functions' }
+{ #category : 'point functions' }
 Point >> rightRotated [
 	"Return the receiver rotated 90 degrees, i.e. self rotateBy: #right centerAt: 0 asPoint. Compare to transposed and normal."
 	^ y negated @ x
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Point >> roundDownTo: grid [
 	"Answer a Point that is the receiver's x and y rounded to grid x and
 	grid y by lower value (toward negative infinity)."
@@ -587,7 +589,7 @@ Point >> roundDownTo: grid [
 	^ (x roundDownTo: gridPoint x) @ (y roundDownTo: gridPoint y)
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Point >> roundTo: grid [
 	"Answer a Point that is the receiver's x and y rounded to grid x and
 	grid y."
@@ -597,7 +599,7 @@ Point >> roundTo: grid [
 	^ (x roundTo: gridPoint x) @ (y roundTo: gridPoint y)
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Point >> roundUpTo: grid [
 	"Answer a Point that is the receiver's x and y rounded to grid x and
 	grid y by upper value (toward infinity)."
@@ -607,7 +609,7 @@ Point >> roundUpTo: grid [
 	^ (x roundUpTo: gridPoint x) @ (y roundUpTo: gridPoint y)
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Point >> rounded [
 	"Answer a Point that is the receiver's x and y rounded. Answer the receiver if its coordinates are already integral."
 
@@ -615,14 +617,14 @@ Point >> rounded [
 	^ x rounded @ y rounded
 ]
 
-{ #category : #transforming }
+{ #category : 'transforming' }
 Point >> scaleBy: factorPoint [
 	"Answer a Point scaled by factor (an instance of Point)."
 	 "(200@200 scaleBy: 2@3) >>> (400@600)"
 	^(factorPoint x * x) @ (factorPoint y * y)
 ]
 
-{ #category : #transforming }
+{ #category : 'transforming' }
 Point >> scaleFrom: rect1 to: rect2 [
 	"Produce a point stretched according to the stretch from rect1 to rect2"
 
@@ -631,7 +633,7 @@ Point >> scaleFrom: rect1 to: rect2 [
 				@ ((y-rect1 top) * rect2 height // rect1 height))
 ]
 
-{ #category : #transforming }
+{ #category : 'transforming' }
 Point >> scaleTo: anExtent [
 	"Return a Point scalefactor for shrinking a thumbnail of the receiver's extent to fit within anExtent. self and anExtent are expected to have positive nonZero x and y."
     "(200@200 scaleTo: 400@400) >>> (2.0@2.0)"
@@ -647,13 +649,13 @@ Point >> scaleTo: anExtent [
         ifFalse: [ (sY max: sX * factor ) @ sY  ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Point >> setX: xValue setY: yValue [
 	x := xValue.
 	y := yValue
 ]
 
-{ #category : #geometry }
+{ #category : 'geometry' }
 Point >> sideOf: otherPoint [
 	"Returns #left, #right or #center if the otherPoint lies to the left, right or on the line given by the vector from 0@0 to self"
 	"((0@0) sideOf: (100@100)) >>> #center"
@@ -663,12 +665,12 @@ Point >> sideOf: otherPoint [
 	^ { #right . #center . #left } at: side + 2
 ]
 
-{ #category : #'point functions' }
+{ #category : 'point functions' }
 Point >> sign [
 	^ (x sign @ y sign)
 ]
 
-{ #category : #'point functions' }
+{ #category : 'point functions' }
 Point >> sortsBefore: otherPoint [
 	"Return true if the receiver sorts before the other point"
 	^ y = otherPoint y
@@ -676,7 +678,7 @@ Point >> sortsBefore: otherPoint [
 		ifFalse: [ y <= otherPoint y ]
 ]
 
-{ #category : #'point functions' }
+{ #category : 'point functions' }
 Point >> squaredDistanceTo: aPoint [
 	"Answer the distance between aPoint and the receiver."
 	| delta |
@@ -684,7 +686,7 @@ Point >> squaredDistanceTo: aPoint [
 	^ delta dotProduct: delta
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Point >> storeOn: aStream [
 	"x@y printed form is good for storing too"
 	aStream nextPut: $(.
@@ -692,7 +694,7 @@ Point >> storeOn: aStream [
 	aStream nextPut: $)
 ]
 
-{ #category : #geometry }
+{ #category : 'geometry' }
 Point >> to: end1 intersects: start2 to: end2 [
 	"Returns true if the linesegment from start1 (=self) to end1 intersects with the segment from start2 to end2, otherwise false."
 
@@ -716,13 +718,13 @@ Point >> to: end1 intersects: start2 to: end2 [
 	^ true
 ]
 
-{ #category : #geometry }
+{ #category : 'geometry' }
 Point >> to: end sideOf: otherPoint [
 	"Returns #left, #right, #center if the otherPoint lies to the left, right or on the line given by the vector from self to end"
 	^ end - self sideOf: otherPoint - self
 ]
 
-{ #category : #transforming }
+{ #category : 'transforming' }
 Point >> translateBy: delta [
 	"Answer a Point translated by delta (an instance of Point)."
 	"((100@200) translateBy: 5@10) >>> (105@210)"
@@ -730,18 +732,18 @@ Point >> translateBy: delta [
 	^ (delta x + x) @ (delta y + y)
 ]
 
-{ #category : #'point functions' }
+{ #category : 'point functions' }
 Point >> transposed [
 	^ y @ x
 ]
 
-{ #category : #geometry }
+{ #category : 'geometry' }
 Point >> triangleArea: b with: c [
 	"Returns twice the area of the oriented triangle (a, b, c), i.e., the area is positive if the triangle is oriented counterclockwise"
 	^ b x - self x * (c y - self y) - (b y - self y * (c x - self x))
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Point >> truncateTo: grid [
 	"Answer a Point that is the receiver's x and y truncated to grid x and grid y."
 	| gridPoint |
@@ -749,7 +751,7 @@ Point >> truncateTo: grid [
 	^ (x truncateTo: gridPoint x) @ (y truncateTo: gridPoint y)
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Point >> truncated [
 	"Answer a Point whose x and y coordinates are integers. Answer the receiver if its coordinates are already integral."
 
@@ -757,13 +759,13 @@ Point >> truncated [
 	^ x truncated @ y truncated
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 Point >> veryDeepCopyWith: deepCopier [
 	"Return self.  I am immutable in the Morphic world.  Do not record me."
 	^ self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Point >> x [
 	"Answer the x coordinate."
 	"(100@200) x >>> 100"
@@ -771,7 +773,7 @@ Point >> x [
 	^ x
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Point >> y [
 	"Answer the y coordinate."
 	"(100@200) y >>> 200"

--- a/src/Kernel/PointerLayout.class.st
+++ b/src/Kernel/PointerLayout.class.st
@@ -2,37 +2,39 @@
 I am the superclass for all layouts with Slots.
 "
 Class {
-	#name : #PointerLayout,
-	#superclass : #ObjectLayout,
+	#name : 'PointerLayout',
+	#superclass : 'ObjectLayout',
 	#instVars : [
 		'slotScope'
 	],
-	#category : #'Kernel-Layout'
+	#category : 'Kernel-Layout',
+	#package : 'Kernel',
+	#tag : 'Layout'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 PointerLayout class >> isAbstract [
 	^self == PointerLayout
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 PointerLayout >> = other [
 	^ super = other
 		ifFalse: [  false ]
 		ifTrue: [ self slotScope = other slotScope ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 PointerLayout >> allSlots [
 	^ slotScope flatten
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 PointerLayout >> allVisibleSlots [
 	^ slotScope allVisibleSlots
 ]
 
-{ #category : #validation }
+{ #category : 'validation' }
 PointerLayout >> checkInheritedSlots [
 
 	self host superclass
@@ -53,7 +55,7 @@ PointerLayout >> checkInheritedSlots [
 			description: [ 'Slot "', localSlot name, '" index at position ', index asString, ' conflicts with slot "', slot name, '" in ', self host superclass asString ]]
 ]
 
-{ #category : #validation }
+{ #category : 'validation' }
 PointerLayout >> checkIntegrity [
 	self
 		checkSanity;
@@ -61,7 +63,7 @@ PointerLayout >> checkIntegrity [
 		checkInheritedSlots
 ]
 
-{ #category : #validation }
+{ #category : 'validation' }
 PointerLayout >> checkParentScopes [
 	| parentScope superclassScope |
 	parentScope := self slotScope parentScope.
@@ -72,7 +74,7 @@ PointerLayout >> checkParentScopes [
 		description: 'Parent slot scope is out of sync'
 ]
 
-{ #category : #validation }
+{ #category : 'validation' }
 PointerLayout >> checkSanity [
 	super checkSanity.
 	self
@@ -80,7 +82,7 @@ PointerLayout >> checkSanity [
 		checkSlotIndices
 ]
 
-{ #category : #validation }
+{ #category : 'validation' }
 PointerLayout >> checkSlotIndices [
 	| slots current |
 	slots := slotScope flatten select: [:each | each size > 0]. "skip slots that have no index"
@@ -89,7 +91,7 @@ PointerLayout >> checkSlotIndices [
 			self assert: slots first index = (current index + current size) ]
 ]
 
-{ #category : #validation }
+{ #category : 'validation' }
 PointerLayout >> checkSlotNames [
 	| slots current |
 	slots := slotScope allVisibleSlots.
@@ -105,119 +107,119 @@ PointerLayout >> checkSlotNames [
 						signal ]]]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 PointerLayout >> definesSlotNamed: aString [
 	^self resolveSlot: aString ifFound: [ true ] ifNone: [ false ]
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 PointerLayout >> extend [
 	"Answer a default layout extending me."
 
 	^ self extend: self slotScope extend
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 PointerLayout >> extend: aScope [
 	^ self species new slotScope: aScope
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 PointerLayout >> extendEphemeron: newScope [
 
 	^ EphemeronLayout new slotScope: newScope
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 PointerLayout >> extendVariable: newScope [
 	^ VariableLayout new slotScope: newScope
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 PointerLayout >> extendWeak: newScope [
 	^ WeakLayout new slotScope: newScope
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 PointerLayout >> fieldSize [
 	^ slotScope fieldSize
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 PointerLayout >> hasBindingThatBeginsWith: aString [
 	"Answer true if there is a Slot that begins with aString, false otherwise"
 
 	^ self slotScope hasBindingThatBeginsWith: aString
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 PointerLayout >> hasFields [
 	^ slotScope hasFields
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 PointerLayout >> hasSlots [
 	^ slotScope hasSlots
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 PointerLayout >> hash [
 	^ self class hash bitXor: self slotScope hash
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 PointerLayout >> host: aClass [
 
 	super host: aClass.
 	self slots do: [ :aSlot | aSlot owningClass: aClass ]
 ]
 
-{ #category : #'instance initialization' }
+{ #category : 'instance initialization' }
 PointerLayout >> initializeInstance: anInstance [
 	self allSlotsDo: [ :slot | slot initialize: anInstance ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 PointerLayout >> instVarNames [
 	^ slotScope visibleSlotNames
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 PointerLayout >> postCopy [
 	slotScope := slotScope copy
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 PointerLayout >> resolveSlot: aName [
 	^ slotScope resolveSlot: aName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 PointerLayout >> resolveSlot: aName ifFound: foundBlock ifNone: noneBlock [
 	^ slotScope resolveSlot: aName ifFound: foundBlock ifNone: noneBlock
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 PointerLayout >> size [
 	^ slotScope fieldSize
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 PointerLayout >> slotNamed: aName [
 	^self resolveSlot: aName asSymbol
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 PointerLayout >> slotScope [
 	^ slotScope
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 PointerLayout >> slotScope: anObject [
 	slotScope := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 PointerLayout >> slots [
 	^ slotScope slots
 ]

--- a/src/Kernel/Pragma.class.st
+++ b/src/Kernel/Pragma.class.st
@@ -13,8 +13,8 @@ and to browse all nonprimitive methods with pragmas evaluate
 	SystemNavigation new browseAllSelect: [:m| m primitive isZero and: [m pragmas notEmpty]]
 "
 Class {
-	#name : #Pragma,
-	#superclass : #Object,
+	#name : 'Pragma',
+	#superclass : 'Object',
 	#instVars : [
 		'method',
 		'arguments',
@@ -23,10 +23,12 @@ Class {
 	#classInstVars : [
 		'pragmaCache'
 	],
-	#category : #'Kernel-Pragmas'
+	#category : 'Kernel-Pragmas',
+	#package : 'Kernel',
+	#tag : 'Pragmas'
 }
 
-{ #category : #cache }
+{ #category : 'cache' }
 Pragma class >> addToCache: aPragma [
 	"when a method is added to a class, the Pragma is added to the cache"
 	self pragmaCache
@@ -35,14 +37,14 @@ Pragma class >> addToCache: aPragma [
 	(self pragmaCache at: aPragma selector) add: aPragma
 ]
 
-{ #category : #cache }
+{ #category : 'cache' }
 Pragma class >> all [
 	"all pragmas whose methods are currently installed in the system"
 	^ self pragmaCache values flattened select: [ :each |
 		  each method isInstalled ]
 ]
 
-{ #category : #finding }
+{ #category : 'finding' }
 Pragma class >> allNamed: aSymbol [
 
 	"Answer a collection of all pragmas whose selector is aSymbol."
@@ -56,7 +58,7 @@ Pragma class >> allNamed: aSymbol [
 	^ (pragmas select: [ :each | each method isInstalled ]) asArray
 ]
 
-{ #category : #finding }
+{ #category : 'finding' }
 Pragma class >> allNamed: aSymbol from: aSubClass to: aSuperClass [
 	"Answer a collection of all pragmas found in methods of all classes between aSubClass and aSuperClass (inclusive) whose keyword is aSymbol."
 
@@ -71,21 +73,21 @@ Pragma class >> allNamed: aSymbol from: aSubClass to: aSuperClass [
 						ifTrue: [ ^ stream contents ] ] ]
 ]
 
-{ #category : #finding }
+{ #category : 'finding' }
 Pragma class >> allNamed: aSymbol from: aSubClass to: aSuperClass sortedByArgument: anInteger [
 	"Answer a collection of all pragmas found in methods of all classes between aSubClass and aSuperClass (inclusive) whose keyword is aSymbol, sorted according to argument anInteger."
 
 	^ self allNamed: aSymbol from: aSubClass to: aSuperClass sortedUsing: [ :a :b | (a argumentAt: anInteger) < (b argumentAt: anInteger) ]
 ]
 
-{ #category : #finding }
+{ #category : 'finding' }
 Pragma class >> allNamed: aSymbol from: aSubClass to: aSuperClass sortedUsing: aSortBlock [
 	"Answer a collection of all pragmas found in methods of all classes between aSubClass and aSuperClass (inclusive) whose keyword is aSymbol, sorted according to aSortBlock."
 
 	^ (self allNamed: aSymbol from: aSubClass to: aSuperClass) sort: aSortBlock
 ]
 
-{ #category : #finding }
+{ #category : 'finding' }
 Pragma class >> allNamed: aSymbol in: aClass [
 	"Answer a collection of all pragmas found in methods of aClass whose selector is aSymbol."
 
@@ -95,21 +97,21 @@ Pragma class >> allNamed: aSymbol in: aClass [
 				ifTrue: [ stream nextPut: pragma ] ] ]
 ]
 
-{ #category : #finding }
+{ #category : 'finding' }
 Pragma class >> allNamed: aSymbol in: aClass sortedByArgument: anInteger [
 	"Answer a collection of all pragmas found in methods of aClass whose keyword is aSymbol, sorted according to argument anInteger."
 
 	^ self allNamed: aSymbol in: aClass sortedUsing: [ :a :b | (a argumentAt: anInteger) < (b argumentAt: anInteger) ]
 ]
 
-{ #category : #finding }
+{ #category : 'finding' }
 Pragma class >> allNamed: aSymbol in: aClass sortedUsing: aSortBlock [
 	"Answer a collection of all pragmas found in methods of aClass whose keyword is aSymbol, sorted according to aSortBlock."
 
 	^ (self allNamed: aSymbol in: aClass) sort: aSortBlock
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Pragma class >> for: aMethod selector: aSelector arguments: anArray [
 	^self new
 		method: aMethod;
@@ -118,13 +120,13 @@ Pragma class >> for: aMethod selector: aSelector arguments: anArray [
 		yourself
 ]
 
-{ #category : #cache }
+{ #category : 'cache' }
 Pragma class >> pragmaCache [
 
 	^ pragmaCache ifNil: [ pragmaCache := Dictionary new ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Pragma class >> selector: aSymbol arguments: anArray [
 	^ self new
 		selector: aSymbol;
@@ -132,7 +134,7 @@ Pragma class >> selector: aSymbol arguments: anArray [
 		yourself
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Pragma >> = aPragma [
 
 	self == aPragma ifTrue: [^true].
@@ -146,21 +148,21 @@ Pragma >> = aPragma [
 	^true
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Pragma >> analogousCodeTo: anObject [
 	^self class == anObject class
 	  and: [self selector == anObject selector
 	  and: [arguments = anObject arguments]]
 ]
 
-{ #category : #'accessing - pragma' }
+{ #category : 'accessing - pragma' }
 Pragma >> argumentAt: anInteger [
 	"Answer one of the arguments of the pragma."
 
 	^ self arguments at: anInteger
 ]
 
-{ #category : #'accessing - pragma' }
+{ #category : 'accessing - pragma' }
 Pragma >> argumentNamed: aSymbol [
 	"Answer the argument of the pragma after the keyword given as parameter.
 	If none, raise an error."
@@ -168,7 +170,7 @@ Pragma >> argumentNamed: aSymbol [
 	^ self argumentNamed: aSymbol ifNone: [ self error: 'No argument of this name.' ]
 ]
 
-{ #category : #'accessing - pragma' }
+{ #category : 'accessing - pragma' }
 Pragma >> argumentNamed: aSymbol ifNone: aBlockClosure [
 	"Answer the argument of the pragma after the keyword given as parameter.
 	If none, return the result of the block given as parameter.
@@ -181,32 +183,32 @@ Pragma >> argumentNamed: aSymbol ifNone: aBlockClosure [
 			ifAbsent: [ ^ aBlockClosure value])
 ]
 
-{ #category : #'accessing - pragma' }
+{ #category : 'accessing - pragma' }
 Pragma >> arguments [
 	"Answer the arguments of the receiving pragma. For a pragma defined as <key1: val1 key2: val2> this will answer #(val1 val2)."
 
 	^ arguments
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Pragma >> arguments: anArray [
 	arguments := anArray
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Pragma >> displayStringOn: stream [
 	self method displayStringOn: stream.
 	stream space.
 	self printOn: stream
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Pragma >> hasLiteral: aLiteral [
 	^self selector == aLiteral
 	   or: [arguments hasLiteral: aLiteral]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Pragma >> hash [
 
 	| hash |
@@ -217,40 +219,40 @@ Pragma >> hash [
 	^hash
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 Pragma >> key [
 	"Answer the keyword of the pragma (the selector of its message pattern).
 	 This accessor provides polymorphism with Associations used for properties."
 	^self selector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Pragma >> message [
 	"Answer the message of the receiving pragma."
 
 	^ Message selector: self selector arguments: self arguments
 ]
 
-{ #category : #'accessing - method' }
+{ #category : 'accessing - method' }
 Pragma >> method [
 	"Answer the compiled-method containing the pragma."
 
 	^ method
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Pragma >> method: aCompiledMethod [
 	method := aCompiledMethod
 ]
 
-{ #category : #'accessing - method' }
+{ #category : 'accessing - method' }
 Pragma >> methodClass [
 	"Answer the class of the method containing the pragma."
 
 	^ method methodClass
 ]
 
-{ #category : #view }
+{ #category : 'view' }
 Pragma >> methodSelector [
 	"Answer the selector of the method containing the pragma.
 	 Do not confuse this with the selector of the pragma's message pattern."
@@ -258,14 +260,14 @@ Pragma >> methodSelector [
 	^method selector
 ]
 
-{ #category : #'accessing - pragma' }
+{ #category : 'accessing - pragma' }
 Pragma >> numArgs [
 	"Answer the number of arguments in the pragma."
 
 	^ self arguments size
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Pragma >> printOn: aStream [
 	aStream nextPut: $<.
 	self selector precedence = 1
@@ -277,13 +279,13 @@ Pragma >> printOn: aStream [
 	aStream nextPut: $>
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Pragma >> refersToLiteral: aLiteral [
 	^self selector == aLiteral
 	   or: [arguments hasLiteral: aLiteral]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Pragma >> selector [
 	"Answer the selector of the pragma.
 	 For a pragma defined as <key1: val1 key2: val2> this will answer #key1:key2:."
@@ -291,19 +293,19 @@ Pragma >> selector [
 	^ selector
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Pragma >> selector: aSymbol [
 	selector := aSymbol
 ]
 
-{ #category : #sending }
+{ #category : 'sending' }
 Pragma >> sendTo: anObject [
 	"Send the pragma keyword together with its arguments to anObject and answer the result."
 
 	^ anObject perform: self selector withArguments: self arguments
 ]
 
-{ #category : #processing }
+{ #category : 'processing' }
 Pragma >> withArgumentsDo: aBlock [
 	"Pass the arguments of the receiving pragma into aBlock and answer the result."
 

--- a/src/Kernel/PrimitiveFailed.class.st
+++ b/src/Kernel/PrimitiveFailed.class.st
@@ -2,12 +2,14 @@
 I am PrimitiveFailed, an exception signaled when a primitive fails.
 "
 Class {
-	#name : #PrimitiveFailed,
-	#superclass : #SelectorException,
-	#category : #'Kernel-Exceptions'
+	#name : 'PrimitiveFailed',
+	#superclass : 'SelectorException',
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #printing }
+{ #category : 'printing' }
 PrimitiveFailed >> standardMessageText [
 	"Generate a standard textual description"
 

--- a/src/Kernel/Process.class.st
+++ b/src/Kernel/Process.class.st
@@ -19,8 +19,8 @@ Another important aspect of new implementation is that all values in PSS are hel
 as well as no need to manually unregistering a process-specific keys , once they are no longer in use.
 "
 Class {
-	#name : #Process,
-	#superclass : #Link,
+	#name : 'Process',
+	#superclass : 'Link',
 	#instVars : [
 		'suspendedContext',
 		'priority',
@@ -36,10 +36,12 @@ Class {
 		'PSKeys',
 		'PSKeysSema'
 	],
-	#category : #'Kernel-Processes'
+	#category : 'Kernel-Processes',
+	#package : 'Kernel',
+	#tag : 'Processes'
 }
 
-{ #category : #'process specific' }
+{ #category : 'process specific' }
 Process class >> allocatePSKey: aPSVariable [
 
 	"Add a new process-specific key.
@@ -79,7 +81,7 @@ Process class >> allocatePSKey: aPSVariable [
 	^ index
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Process class >> forContext: aContext priority: anInteger [
 	"Answer an instance of me that has suspended aContext at priority
 	anInteger."
@@ -92,14 +94,14 @@ Process class >> forContext: aContext priority: anInteger [
 	^newProcess
 ]
 
-{ #category : #'process specific' }
+{ #category : 'process specific' }
 Process class >> psKeysSema [
 	"Isolate handling of class variable"
 
 	^PSKeysSema ifNil: [ PSKeysSema := Semaphore forMutualExclusion ]
 ]
 
-{ #category : #'process specific' }
+{ #category : 'process specific' }
 Process class >> updateInheritableKeys [
 "
 	self updateInheritableKeys
@@ -111,7 +113,7 @@ Process class >> updateInheritableKeys [
 	InheritablePSKeys := keys asArray ifEmpty: [ nil ]
 ]
 
-{ #category : #'changing suspended state' }
+{ #category : 'changing suspended state' }
 Process >> activateReturn: aContext value: value [
 	"Activate 'aContext return: value', so execution will return to aContext's sender"
 
@@ -120,12 +122,12 @@ Process >> activateReturn: aContext value: value [
 		onBehalfOf: self
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Process >> browserPrintString [
 	^self browserPrintStringWith: suspendedContext
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Process >> browserPrintStringWith: anObject [
 	| stream |
 	stream := (String new: 100) writeStream.
@@ -141,7 +143,7 @@ Process >> browserPrintStringWith: anObject [
 	^ stream contents
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Process >> calleeOf: aContext [
 	"Return the context whose sender is aContext.  Return nil if aContext is on top.  Raise error if aContext is not in process chain."
 
@@ -150,7 +152,7 @@ Process >> calleeOf: aContext [
 		ifNil: [self error: 'aContext not in process chain']
 ]
 
-{ #category : #'changing suspended state' }
+{ #category : 'changing suspended state' }
 Process >> complete: aContext [
 	"Run self until aContext is popped or an unhandled error is raised.  Return self's new top context, unless an unhandled error was raised then return the signal context (rather than open a debugger)."
 
@@ -166,7 +168,7 @@ Process >> complete: aContext [
 		ifNotNil: [ :error | error completeProcess: self with: aContext ]
 ]
 
-{ #category : #'changing suspended state' }
+{ #category : 'changing suspended state' }
 Process >> completeStep: aContext [
 	"Resume self until aContext is on top, or if already on top, complete next step"
 
@@ -179,7 +181,7 @@ Process >> completeStep: aContext [
 	^ self complete: callee  "finish send"
 ]
 
-{ #category : #'changing suspended state' }
+{ #category : 'changing suspended state' }
 Process >> completeTo: aContext [
 	"Resume self until aContext is on top"
 
@@ -187,18 +189,18 @@ Process >> completeTo: aContext [
 	^ self complete: (self calleeOf: aContext)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Process >> copyStack [
 
 	^ self copy install: suspendedContext copyStack
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 Process >> debug [
 	^ self debugWithTitle: 'Debug'
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 Process >> debugWithTitle: title [
 
 	| context |
@@ -211,7 +213,7 @@ Process >> debugWithTitle: title [
 		inContext: context
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Process >> doTerminationFromAnotherProcess [
 
   "Stop this process forever from another process.
@@ -268,7 +270,7 @@ Process >> doTerminationFromAnotherProcess [
 	suspendedContext setSender: nil receiver: self method: (Process>>#endProcess) arguments: {}
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Process >> doTerminationFromYourself [
 	"Stop this process forever from the process itself.
 	Unwind to execute pending ensure:/ifCurtailed: blocks before terminating.
@@ -278,7 +280,7 @@ Process >> doTerminationFromYourself [
 	^self endProcess
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Process >> effectiveProcess [
 	"effectiveProcess is a mechanism to allow process-faithful debugging.  The debugger executes code
 	 on behalf of processes, so unless some effort is made the identity of Processor activeProcess is not
@@ -288,12 +290,12 @@ Process >> effectiveProcess [
 	^effectiveProcess ifNil: [self]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Process >> effectiveProcess: aProcess [
 	effectiveProcess := aProcess
 ]
 
-{ #category : #'changing process state' }
+{ #category : 'changing process state' }
 Process >> endProcess [
 	"When I reach this method, I'm terminated. Suspending or terminating me is harmless."
 
@@ -306,7 +308,7 @@ Process >> endProcess [
 	"^thisContext restart"
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Process >> evaluate: aBlock onBehalfOf: aProcess [
 	"Evaluate aBlock setting effectiveProcess to aProcess.  Used
 	 in the execution simulation machinery to ensure that
@@ -317,14 +319,14 @@ Process >> evaluate: aBlock onBehalfOf: aProcess [
 	^aBlock ensure: [effectiveProcess := oldEffectiveProcess]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Process >> initialize [
 	super initialize.
 
 	terminating := false
 ]
 
-{ #category : #'changing suspended state' }
+{ #category : 'changing suspended state' }
 Process >> install: aContext [
 	"Replace the suspendedContext with aContext."
 
@@ -333,7 +335,7 @@ Process >> install: aContext [
 	suspendedContext := aContext
 ]
 
-{ #category : #'process specific' }
+{ #category : 'process specific' }
 Process >> installEnvIntoForked: newProcess [
 	env ifNil: [ ^ self ].
 	InheritablePSKeys ifNil: [ ^self ].
@@ -347,13 +349,13 @@ Process >> installEnvIntoForked: newProcess [
 				varValue ifNotNil: [ (PSKeys at: varIndex) installValue: varValue intoForked: newProcess from: self ] ]]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Process >> isActiveProcess [
 
 	^ self == Processor activeProcess
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Process >> isSuspended [
 	"Answer true if I was never scheduled yet (new process, never been sent #resume) or paused (was sent #suspend)"
 	self isActiveProcess ifTrue: [ ^false ].
@@ -361,7 +363,7 @@ Process >> isSuspended [
 	^myList isNil or: [ myList isEmpty ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Process >> isTerminated [
 
 	"Answer if the receiver is terminated, i.e. if the receiver is not active and
@@ -377,13 +379,13 @@ Process >> isTerminated [
 			(suspendedContext method == (self class >> #endProcess))]]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Process >> isTerminating [
 	"lazy initialization is a fallback only for processes that existed before this addition"
 	^ terminating ifNil: [ false ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Process >> longPrintOn: stream [
 	| ctxt |
 	super printOn: stream.
@@ -397,19 +399,19 @@ Process >> longPrintOn: stream [
 			ctxt := ctxt sender ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Process >> name [
 
  	^name ifNil: [ self hash asString forceTo: 10 paddingStartWith: $ ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Process >> name: aString [
 
 	name := aString
 ]
 
-{ #category : #signaling }
+{ #category : 'signaling' }
 Process >> on: exception do: handlerAction [
 	"This method inject new bottom context into process with exception handler.
 	It uses context jump tricks to achieve it"
@@ -426,7 +428,7 @@ Process >> on: exception do: handlerAction [
 		ifFalse: [ self install: newRoot ]
 ]
 
-{ #category : #'changing suspended state' }
+{ #category : 'changing suspended state' }
 Process >> popTo: aContext [
 	"Pop self down to aContext by remote returning from aContext's callee.  Unwind blocks will be executed on the way.
 	This is done by pushing a new context on top which executes 'aContext callee return' then resuming self until aContext is reached.  This way any errors raised in an unwind block will get handled by senders in self and not by senders in the activeProcess.
@@ -443,7 +445,7 @@ Process >> popTo: aContext [
 				onBehalfOf: self]
 ]
 
-{ #category : #'changing suspended state' }
+{ #category : 'changing suspended state' }
 Process >> popTo: aContext value: aValue [
 	"Replace the suspendedContext with aContext, releasing all contexts
 	 between the currently suspendedContext and it."
@@ -459,7 +461,7 @@ Process >> popTo: aContext value: aValue [
 				onBehalfOf: self]
 ]
 
-{ #category : #'changing process state' }
+{ #category : 'changing process state' }
 Process >> primitiveResume [
 	"Primitive. Allow the process that the receiver represents to continue. Put
 	the receiver in line to become the activeProcess. Fail if the receiver is
@@ -470,7 +472,7 @@ Process >> primitiveResume [
 	self primitiveFailed
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Process >> printOn: aStream [
 
 	super printOn: aStream.
@@ -478,14 +480,14 @@ Process >> printOn: aStream [
 	suspendedContext printOn: aStream
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Process >> priority [
 	"Answer the priority of the receiver."
 
 	^priority
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Process >> priority: anInteger [
 	"Set the receiver's priority to anInteger.
 	When changing the process priority we need to yield to make it reschedule the processor"
@@ -495,7 +497,7 @@ Process >> priority: anInteger [
 		ifFalse: [ self error: 'Invalid priority: ' , anInteger printString ]
 ]
 
-{ #category : #'process specific' }
+{ #category : 'process specific' }
 Process >> psValueAt: index [
 	"Answer a process-specific value at given index, or nil if value at given index is not defined"
 
@@ -504,7 +506,7 @@ Process >> psValueAt: index [
 	^ env at: index ifAbsent: nil
 ]
 
-{ #category : #'process specific' }
+{ #category : 'process specific' }
 Process >> psValueAt: index put: value [
 	"Set a value for given index in process-specific storage"
 
@@ -515,7 +517,7 @@ Process >> psValueAt: index put: value [
 	^ env at: index put: value
 ]
 
-{ #category : #signaling }
+{ #category : 'signaling' }
 Process >> pvtSignal: anException list: aList [
 	"Private. This method is used to signal an exception from another
 	process...the receiver must be the active process.  If the receiver
@@ -547,7 +549,7 @@ Process >> pvtSignal: anException list: aList [
 	blocker wait
 ]
 
-{ #category : #'process specific' }
+{ #category : 'process specific' }
 Process >> resetPSValueAt: index [
 
 	"NOTE: this method are PRIVATE. "
@@ -558,21 +560,21 @@ Process >> resetPSValueAt: index [
 	env at: index put: nil
 ]
 
-{ #category : #'changing suspended state' }
+{ #category : 'changing suspended state' }
 Process >> restartTop [
 	"Rollback top context and replace with new method.  Assumes self is suspended"
 
 	suspendedContext privRefresh
 ]
 
-{ #category : #'changing suspended state' }
+{ #category : 'changing suspended state' }
 Process >> restartTopWith: method [
 	"Rollback top context and replace with new method.  Assumes self is suspended"
 
 	suspendedContext privRefreshWith: method
 ]
 
-{ #category : #'changing process state' }
+{ #category : 'changing process state' }
 Process >> resume [
 	"Allow the process that the receiver represents to continue. Put
 	the receiver in line to become the activeProcess. Check for a nil
@@ -583,7 +585,7 @@ Process >> resume [
 	^ self primitiveResume
 ]
 
-{ #category : #'changing suspended state' }
+{ #category : 'changing suspended state' }
 Process >> return: aContext value: value [
 	"Pop thread down to aContext's sender.  Execute any unwind blocks on the way.  See #popTo: comment and #runUntilErrorOrReturnFrom: for more details."
 
@@ -595,7 +597,7 @@ Process >> return: aContext value: value [
 	^self complete: aContext
 ]
 
-{ #category : #'changing process state' }
+{ #category : 'changing process state' }
 Process >> run [
 	"Suspend current process and execute self instead"
 
@@ -606,7 +608,7 @@ Process >> run [
 	] forkAt: Processor highestPriority
 ]
 
-{ #category : #signaling }
+{ #category : 'signaling' }
 Process >> signalException: anException [
 	"Signal an exception in the receiver process...if the receiver is currently
 	suspended, the exception will get signaled when the receiver is resumed.  If
@@ -636,7 +638,7 @@ Process >> signalException: anException [
 	oldList ifNotNil: [self resume]
 ]
 
-{ #category : #'changing suspended state' }
+{ #category : 'changing suspended state' }
 Process >> step [
 
 	^Processor activeProcess
@@ -644,7 +646,7 @@ Process >> step [
 		onBehalfOf: self
 ]
 
-{ #category : #'changing suspended state' }
+{ #category : 'changing suspended state' }
 Process >> step: aContext [
 	"Resume self until aContext is on top, or if already on top, do next step"
 
@@ -656,7 +658,7 @@ Process >> step: aContext [
 		onBehalfOf: self
 ]
 
-{ #category : #'changing suspended state' }
+{ #category : 'changing suspended state' }
 Process >> stepToCallee [
 	"Step until top context changes"
 
@@ -670,7 +672,7 @@ Process >> stepToCallee [
 	^suspendedContext
 ]
 
-{ #category : #'changing suspended state' }
+{ #category : 'changing suspended state' }
 Process >> stepToHome: aContext [
 	| ctxt pair error |
 	ctxt := suspendedContext.
@@ -697,7 +699,7 @@ Process >> stepToHome: aContext [
 	^ suspendedContext
 ]
 
-{ #category : #'changing process state' }
+{ #category : 'changing process state' }
 Process >> suspend [
 	"Primitive. Stop the process that the receiver represents in such a way
 	that it can be restarted at a later time (by sending the receiver the
@@ -715,27 +717,27 @@ Process >> suspend [
 	^oldList
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Process >> suspendedContext [
 	"Answer the context the receiver has suspended."
 
 	^suspendedContext
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Process >> suspendedContext: aContext [
 
 	suspendedContext := aContext
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Process >> suspendingList [
 	"Answer the list on which the receiver has been suspended."
 
 	^myList
 ]
 
-{ #category : #'changing process state' }
+{ #category : 'changing process state' }
 Process >> terminate [
 	"Stop the process that the receiver represents forever.  Unwind to execute pending ensure:/ifCurtailed: blocks before terminating."
 

--- a/src/Kernel/ProcessAlreadyTerminating.class.st
+++ b/src/Kernel/ProcessAlreadyTerminating.class.st
@@ -4,7 +4,9 @@ I notify the sender of #terminate that the receiving process has already receive
 Use Process>>isTerminating to check for this.
 "
 Class {
-	#name : #ProcessAlreadyTerminating,
-	#superclass : #Notification,
-	#category : #'Kernel-Processes'
+	#name : 'ProcessAlreadyTerminating',
+	#superclass : 'Notification',
+	#category : 'Kernel-Processes',
+	#package : 'Kernel',
+	#tag : 'Processes'
 }

--- a/src/Kernel/ProcessList.class.st
+++ b/src/Kernel/ProcessList.class.st
@@ -7,27 +7,29 @@ I am a linked list that contains processes as Nodes. My implementation is tied t
 My main user is ProcessScheduler, which contains an array with instances of myself. Each entry in that array a priority for processes. Processes are queues in each process list by the VM automatically.
 "
 Class {
-	#name : #ProcessList,
-	#superclass : #SequenceableCollection,
+	#name : 'ProcessList',
+	#superclass : 'SequenceableCollection',
 	#instVars : [
 		'firstLink',
 		'lastLink'
 	],
-	#category : #'Kernel-Processes'
+	#category : 'Kernel-Processes',
+	#package : 'Kernel',
+	#tag : 'Processes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ProcessList class >> new: anInt [
 	"LinkedList don't need capacity"
 	^self new
 ]
 
-{ #category : #'stream creation' }
+{ #category : 'stream creation' }
 ProcessList class >> new: size streamContents: aBlock [
 	^ self withAll: (super new: size streamContents: aBlock)
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ProcessList class >> newFrom: aCollection [
 	"Answer an instance with same elements as aCollection."
 	^self new
@@ -35,19 +37,19 @@ ProcessList class >> newFrom: aCollection [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessList class >> streamSpecies [
 	^ Array
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 ProcessList >> add: aLinkOrObject [
 	"Add aLink to the end of the receiver's list. Answer aLink."
 
 	^self addLast: aLinkOrObject
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 ProcessList >> add: link after: otherLinkOrObject [
 	"Add otherLink  after link in the list. Answer aLink."
 
@@ -56,7 +58,7 @@ ProcessList >> add: link after: otherLinkOrObject [
 	^ self add: link afterLink: otherLink
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 ProcessList >> add: aLinkOrObject afterLink: otherLink [
 
 	"Add otherLink  after link in the list. Answer aLink."
@@ -70,7 +72,7 @@ ProcessList >> add: aLinkOrObject afterLink: otherLink [
 	^aLink
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 ProcessList >> add: link before: otherLinkOrObject [
 	"Add otherLink  after link in the list. Answer aLink."
 
@@ -79,7 +81,7 @@ ProcessList >> add: link before: otherLinkOrObject [
 	^ self add: link beforeLink: otherLink
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 ProcessList >> add: aLinkOrObject beforeLink: otherLink [
 
 	| currentLink|
@@ -100,7 +102,7 @@ ProcessList >> add: aLinkOrObject beforeLink: otherLink [
 	^ self errorNotFound: otherLink
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 ProcessList >> addFirst: aLinkOrObject [
 	"Add aLink to the beginning of the receiver's list. Answer aLink."
 
@@ -112,7 +114,7 @@ ProcessList >> addFirst: aLinkOrObject [
 	^ aLink
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 ProcessList >> addLast: aLinkOrObject [
 	"Add aLink to the end of the receiver's list. Answer aLink."
 
@@ -125,19 +127,19 @@ ProcessList >> addLast: aLinkOrObject [
 	^ aLink
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessList >> at: index [
 
 	^(self linkAt: index) value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessList >> at: index put: anObject [
 
 	^self at: index putLink: (self linkOf: anObject ifAbsent: [anObject asLink])
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessList >> at: index putLink: aLink [
 	| previousLink nextLink |
 	"Please don't put a link which is already in the list, or you will create an infinite loop"
@@ -167,7 +169,7 @@ ProcessList >> at: index putLink: aLink [
 	^ aLink
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ProcessList >> collect: aBlock [
 	"Evaluate aBlock with each of the receiver's elements as the argument.
 	Collect the resulting values into a collection like the receiver. Answer
@@ -182,7 +184,7 @@ ProcessList >> collect: aBlock [
 	^ newCollection
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ProcessList >> collect: collectBlock thenSelect: selectBlock [
 	"Optimized version of SequenceableCollection>>#collect:#thenSelect:"
 
@@ -196,12 +198,12 @@ ProcessList >> collect: collectBlock thenSelect: selectBlock [
 	^ newCollection
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 ProcessList >> copyWith: newElement [
 	^self copy add: newElement; yourself
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 ProcessList >> copyWithout: oldElement [
 	|newInst|
 	newInst := self class new.
@@ -209,7 +211,7 @@ ProcessList >> copyWithout: oldElement [
 	^newInst
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ProcessList >> do: aBlock [
 
 	| aLink |
@@ -219,14 +221,14 @@ ProcessList >> do: aBlock [
 		 aLink := aLink nextLink]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessList >> first [
 	"Answer the first link. Create an error notification if the receiver is
 	empty."
 ^self firstLink value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessList >> firstLink [
 	"Answer the first link. Create an error notification if the receiver is
 	empty."
@@ -235,7 +237,7 @@ ProcessList >> firstLink [
 	^firstLink
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ProcessList >> indexOf: anElement startingAt: start ifAbsent: exceptionBlock [
 	"Answer the index of the first occurrence of anElement after start
 	within the receiver. If the receiver does not contain anElement,
@@ -251,13 +253,13 @@ ProcessList >> indexOf: anElement startingAt: start ifAbsent: exceptionBlock [
 	^exceptionBlock value
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ProcessList >> isEmpty [
 
 	^firstLink isNil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessList >> last [
 	"Answer the last link. Create an error notification if the receiver is
 	empty."
@@ -266,7 +268,7 @@ ProcessList >> last [
 	^self lastLink value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessList >> lastLink [
 	"Answer the last link. Create an error notification if the receiver is
 	empty."
@@ -275,13 +277,13 @@ ProcessList >> lastLink [
 	^lastLink
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ProcessList >> linkAt: index [
 
 	^self linkAt: index ifAbsent: [ self errorSubscriptBounds: index]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ProcessList >> linkAt: index ifAbsent: errorBlock [
 
 	| i |
@@ -291,14 +293,14 @@ ProcessList >> linkAt: index ifAbsent: errorBlock [
 	^ errorBlock value
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ProcessList >> linkOf: anObject [
 	^ self
 		linkOf: anObject
 		ifAbsent: [self error: 'No such element']
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ProcessList >> linkOf: anObject ifAbsent: errorBlock [
 
 	self
@@ -307,7 +309,7 @@ ProcessList >> linkOf: anObject ifAbsent: errorBlock [
 	^ errorBlock value
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ProcessList >> linksDo: aBlock [
 
 	| aLink |
@@ -318,7 +320,7 @@ ProcessList >> linksDo: aBlock [
 		aLink := aLink nextLink]
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 ProcessList >> postCopy [
 	| aLink |
 	super postCopy.
@@ -328,7 +330,7 @@ ProcessList >> postCopy [
 		lastLink := aLink]
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 ProcessList >> remove: aLinkOrObject ifAbsent: aBlock [
 	"Remove aLink from the receiver. If it is not there, answer the result of evaluating aBlock."
 
@@ -338,14 +340,14 @@ ProcessList >> remove: aLinkOrObject ifAbsent: aBlock [
 	^aLinkOrObject
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 ProcessList >> removeAll [
 	"Implementation note: this has to be fast"
 
 	firstLink := lastLink := nil
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 ProcessList >> removeAllSuchThat: aBlock [
 	"Evaluate aBlock for each element and remove all that elements from
 	the receiver for that aBlock evaluates to true.  For LinkedLists, it's safe to use do:."
@@ -353,7 +355,7 @@ ProcessList >> removeAllSuchThat: aBlock [
 	self do: [:each | (aBlock value: each) ifTrue: [self remove: each]]
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 ProcessList >> removeFirst [
 	"Remove the first element and answer it. If the receiver is empty, create
 	an error notification."
@@ -368,7 +370,7 @@ ProcessList >> removeFirst [
 	^oldLink value
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 ProcessList >> removeLast [
 	"Remove the receiver's last element and answer it. If the receiver is
 	empty, create an error notification."
@@ -387,12 +389,12 @@ ProcessList >> removeLast [
 	^oldLink value
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 ProcessList >> removeLink: aLink [
 	^self removeLink: aLink ifAbsent: [self error: 'no such method!']
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 ProcessList >> removeLink: aLink ifAbsent: aBlock [
 	"Remove aLink from the receiver. If it is not there, answer the result of
 	evaluating aBlock."
@@ -414,7 +416,7 @@ ProcessList >> removeLink: aLink ifAbsent: aBlock [
 	^aLink
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ProcessList >> select: aBlock [
 	"Reimplemennt #select: for speedup on linked lists.
 	The super implemention accesses the linkes by index, thus causing an O(n^2)"
@@ -427,7 +429,7 @@ ProcessList >> select: aBlock [
 	^newCollection
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ProcessList >> select: selectBlock thenCollect: collectBlock [
 	"Optimized version of SequenceableCollection>>#select:thenCollect:"
 
@@ -440,7 +442,7 @@ ProcessList >> select: selectBlock thenCollect: collectBlock [
 	^ newCollection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessList >> size [
 	"Answer how many elements the receiver contains."
 
@@ -450,13 +452,13 @@ ProcessList >> size [
 	^ tally
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ProcessList >> species [
 
 	^ Array
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessList >> swap: ix1 with: ix2 [
 	"Reimplemented, super would create an infinite loop"
 	| minIx maxIx link1Prev link2Prev link1 link2 link1Next link2Next newLink2Next |
@@ -488,7 +490,7 @@ ProcessList >> swap: ix1 with: ix2 [
 	link2 nextLink: newLink2Next
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ProcessList >> validIndex: index [
 	 ^index > 0
 			and: [index <= self size]

--- a/src/Kernel/ProcessLocalVariable.class.st
+++ b/src/Kernel/ProcessLocalVariable.class.st
@@ -2,17 +2,19 @@
 My subclasses have values specific to the active process. They can be read with #value and set with #value:
 "
 Class {
-	#name : #ProcessLocalVariable,
-	#superclass : #ProcessSpecificVariable,
-	#category : #'Kernel-Processes'
+	#name : 'ProcessLocalVariable',
+	#superclass : 'ProcessSpecificVariable',
+	#category : 'Kernel-Processes',
+	#package : 'Kernel',
+	#tag : 'Processes'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessLocalVariable class >> value: anObject [
 	^ self soleInstance value: anObject
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 ProcessLocalVariable >> value: anObject [
 	Processor activeProcess psValueAt: index put: anObject
 ]

--- a/src/Kernel/ProcessSpecificVariable.class.st
+++ b/src/Kernel/ProcessSpecificVariable.class.st
@@ -10,28 +10,30 @@ Also subclasses could provide specific logic for installing variables into new p
 
 "
 Class {
-	#name : #ProcessSpecificVariable,
-	#superclass : #Object,
+	#name : 'ProcessSpecificVariable',
+	#superclass : 'Object',
 	#instVars : [
 		'index'
 	],
 	#classInstVars : [
 		'soleInstance'
 	],
-	#category : #'Kernel-Processes'
+	#category : 'Kernel-Processes',
+	#package : 'Kernel',
+	#tag : 'Processes'
 }
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 ProcessSpecificVariable class >> initialize [
 	self resetSoleInstance
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ProcessSpecificVariable class >> isInheritable [
 	^false
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ProcessSpecificVariable class >> new [
 	| instance |
 	instance := super new.
@@ -39,39 +41,39 @@ ProcessSpecificVariable class >> new [
 	^ instance
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 ProcessSpecificVariable class >> resetSoleInstance [
 	soleInstance := nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessSpecificVariable class >> soleInstance [
 	^ soleInstance ifNil: [ soleInstance := self new ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessSpecificVariable class >> value [
 	"Answer the current value for this variable in the current context."
 	^ self soleInstance value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessSpecificVariable >> default [
 	"Answer the default value for the variable. The default for the default value is nil."
 	^nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessSpecificVariable >> index [
 	^ index
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessSpecificVariable >> index: anInteger [
 	index := anInteger
 ]
 
-{ #category : #inheriting }
+{ #category : 'inheriting' }
 ProcessSpecificVariable >> installValue: anObject intoForked: newProcess from: ownerProcess [
 "
 	In subclasses you can override this method to implement specific variable inheritance logic
@@ -79,18 +81,18 @@ ProcessSpecificVariable >> installValue: anObject intoForked: newProcess from: o
 	newProcess psValueAt: index put: anObject
 ]
 
-{ #category : #inheriting }
+{ #category : 'inheriting' }
 ProcessSpecificVariable >> isInheritable [
 	^self class isInheritable
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessSpecificVariable >> value [
 
 	^ (Processor activeProcess psValueAt: index) ifNil: [ self default ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessSpecificVariable >> valueOrNil [
 	"a faster version, which doesn't using ifAbsent: to avoid using block closure"
 	^ Processor activeProcess psValueAt: index

--- a/src/Kernel/ProcessorScheduler.class.st
+++ b/src/Kernel/ProcessorScheduler.class.st
@@ -7,8 +7,8 @@ NB: DelayBasicScheduler is THE HIGHEST priority code which is run in Pharo. See 
 
 "
 Class {
-	#name : #ProcessorScheduler,
-	#superclass : #Object,
+	#name : 'ProcessorScheduler',
+	#superclass : 'Object',
 	#instVars : [
 		'quiescentProcessLists',
 		'activeProcess'
@@ -25,10 +25,12 @@ Class {
 		'UserInterruptPriority',
 		'UserSchedulingPriority'
 	],
-	#category : #'Kernel-Processes'
+	#category : 'Kernel-Processes',
+	#package : 'Kernel',
+	#tag : 'Processes'
 }
 
-{ #category : #'background process' }
+{ #category : 'background process' }
 ProcessorScheduler class >> idleProcess [
 	"A default background process which is invisible. During the idle time, the delays may not wake up."
 
@@ -36,7 +38,7 @@ ProcessorScheduler class >> idleProcess [
 		[self relinquishProcessorForMicroseconds: IdleTime]
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 ProcessorScheduler class >> idleTime [
 
 	"The default idle time for the Pharo process in case of inactivity. In idle mode, the system can be awakened by a signal. This value can limit the minimal delay time."
@@ -44,13 +46,13 @@ ProcessorScheduler class >> idleTime [
 	^ IdleTime
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 ProcessorScheduler class >> idleTime: microsecondsCount [
 
 	IdleTime := microsecondsCount
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 ProcessorScheduler class >> idleTimeSettingOn: aBuilder [
 	<systemsettings>
 
@@ -62,7 +64,7 @@ ProcessorScheduler class >> idleTimeSettingOn: aBuilder [
 		description: 'Detault idle time for the Pharo process in case of inactivity. In idle mode, the system can be awakened by a signal. This value can limit the minimal delay time.'
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 ProcessorScheduler class >> initialize [
 	"ProcessorScheduler initialize."
 
@@ -81,7 +83,7 @@ ProcessorScheduler class >> initialize [
 		atPriority: 30
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ProcessorScheduler class >> new [
 	"New instances of ProcessorScheduler should not be created."
 
@@ -90,7 +92,7 @@ ProcessorScheduler class >> new [
 the integrity of the system depends on a unique scheduler'
 ]
 
-{ #category : #'background process' }
+{ #category : 'background process' }
 ProcessorScheduler class >> relinquishProcessorForMicroseconds: anInteger [
 	"Platform specific. This primitive is used to return processor cycles to the host operating system when Pharo's idle process is running (i.e., when no other Pharo process is runnable). On some platforms, this primitive causes the entire Pharo application to sleep for approximately the given number of microseconds. No Pharo process can run while the Pharo application is sleeping, even if some external event makes it runnable. On the Macintosh, this primitive simply calls GetNextEvent() to give other applications a chance to run. On platforms without a host operating system, it does nothing. This primitive should not be used to add pauses to a Pharo process; use a Delay instead."
 
@@ -98,7 +100,7 @@ ProcessorScheduler class >> relinquishProcessorForMicroseconds: anInteger [
 	"don't fail if primitive is not implemented, just do nothing"
 ]
 
-{ #category : #'background process' }
+{ #category : 'background process' }
 ProcessorScheduler class >> startUp [
 	"Install a background process of the lowest possible priority that is always runnable."
 	"Details: The virtual machine requires that there is always some runnable process that can be scheduled; this background process ensures that this is the case."
@@ -111,14 +113,14 @@ ProcessorScheduler class >> startUp [
 	BackgroundProcess resume
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessorScheduler >> activePriority [
 	"Answer the priority level of the currently running Process."
 
 	^self activeProcess priority
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessorScheduler >> activeProcess [
 	"Answers the currently running Process.
 	It can be just pretending to be the active process
@@ -127,7 +129,7 @@ ProcessorScheduler >> activeProcess [
 	^activeProcess effectiveProcess
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ProcessorScheduler >> anyProcessesAbove: highestPriority [
 	"Do any instances of Process exist with higher priorities?"
 
@@ -136,13 +138,13 @@ ProcessorScheduler >> anyProcessesAbove: highestPriority [
 		"If anyone ever makes a subclass of Process, be sure to use allSubInstances."
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessorScheduler >> backgroundProcess [
 	"Answer the background process"
 	^ BackgroundProcess
 ]
 
-{ #category : #'priority names' }
+{ #category : 'priority names' }
 ProcessorScheduler >> highIOPriority [
 	"Answer the priority at which the most time critical input/output
 	processes should run. An example is the process handling input from a
@@ -151,7 +153,7 @@ ProcessorScheduler >> highIOPriority [
 	^HighIOPriority
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessorScheduler >> highestPriority [
 	"Answer the number of priority levels currently available for use."
 	"NB: If you are looking to set a priority when forking a process, please use the methods in 'priority names' protocol"
@@ -159,7 +161,7 @@ ProcessorScheduler >> highestPriority [
 	^quiescentProcessLists size
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessorScheduler >> highestPriority: newHighestPriority [
 	"Change the number of priority levels currently available for use."
 
@@ -176,7 +178,7 @@ ProcessorScheduler >> highestPriority: newHighestPriority [
 	quiescentProcessLists := newProcessLists
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ProcessorScheduler >> interpriorityYield: modifiedProcess [
 
 	"The original yield only works within processes of the same priority.
@@ -193,12 +195,12 @@ ProcessorScheduler >> interpriorityYield: modifiedProcess [
 	modifiedProcess suspend
 ]
 
-{ #category : #'self evaluating' }
+{ #category : 'self evaluating' }
 ProcessorScheduler >> isSelfEvaluating [
 	^self == Processor
 ]
 
-{ #category : #'priority names' }
+{ #category : 'priority names' }
 ProcessorScheduler >> lowIOPriority [
 	"Answer the priority at which most input/output processes should run.
 	Examples are the process handling input from the user (keyboard,
@@ -207,13 +209,13 @@ ProcessorScheduler >> lowIOPriority [
 	^LowIOPriority
 ]
 
-{ #category : #'priority names' }
+{ #category : 'priority names' }
 ProcessorScheduler >> lowestPriority [
 	"Return the lowest priority that is allowed with the scheduler"
 	^SystemRockBottomPriority
 ]
 
-{ #category : #'CPU usage tally' }
+{ #category : 'CPU usage tally' }
 ProcessorScheduler >> nextReadyProcess [
 
 	quiescentProcessLists reverseDo: [ :list |
@@ -222,7 +224,7 @@ ProcessorScheduler >> nextReadyProcess [
 	^ nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessorScheduler >> preemptedProcess [
 	"Return the process that the currently active process just preempted."
 
@@ -235,13 +237,13 @@ ProcessorScheduler >> preemptedProcess [
 	"Processor preemptedProcess"
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ProcessorScheduler >> printOn: aStream [
 	self isSelfEvaluating ifFalse: [^super printOn: aStream].
 	aStream nextPutAll: #Processor
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessorScheduler >> realActiveProcess [
 	"Answers the real currently running Process (ignoring any effective process installed).
 	Method should be used carefully only in specific low level parts of the system.
@@ -253,7 +255,7 @@ ProcessorScheduler >> realActiveProcess [
 	^activeProcess
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 ProcessorScheduler >> remove: aProcess ifAbsent: aBlock [
 	"Remove aProcess from the list on which it is waiting for the processor
 	and answer aProcess. If it is not waiting, evaluate aBlock."
@@ -263,7 +265,7 @@ ProcessorScheduler >> remove: aProcess ifAbsent: aBlock [
 	^aProcess
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessorScheduler >> scanSchedule: aBlock startingAt: topPriority [
 	"Iterate over scheduled processes  list, starting from topPriority down to lowest one. "
 
@@ -275,7 +277,7 @@ ProcessorScheduler >> scanSchedule: aBlock startingAt: topPriority [
 	]
 ]
 
-{ #category : #'process state change' }
+{ #category : 'process state change' }
 ProcessorScheduler >> suspendFirstAt: aPriority [
 	"Suspend the first Process that is waiting to run with priority aPriority."
 
@@ -283,7 +285,7 @@ ProcessorScheduler >> suspendFirstAt: aPriority [
 		  ifNone: [self error: 'No Process to suspend']
 ]
 
-{ #category : #'process state change' }
+{ #category : 'process state change' }
 ProcessorScheduler >> suspendFirstAt: aPriority ifNone: noneBlock [
 	"Suspend the first Process that is waiting to run with priority aPriority. If
 	no Process is waiting, evaluate the argument, noneBlock."
@@ -293,7 +295,7 @@ ProcessorScheduler >> suspendFirstAt: aPriority ifNone: noneBlock [
 			ifNotEmpty: [ :aList | aList first suspend ]
 ]
 
-{ #category : #'priority names' }
+{ #category : 'priority names' }
 ProcessorScheduler >> systemBackgroundPriority [
 	"Answer the priority at which system background processes should run.
 	Examples are an incremental garbage collector or status checker."
@@ -301,7 +303,7 @@ ProcessorScheduler >> systemBackgroundPriority [
 	^SystemBackgroundPriority
 ]
 
-{ #category : #'CPU usage tally' }
+{ #category : 'CPU usage tally' }
 ProcessorScheduler >> tallyCPUUsageFor: seconds [
 	"Start a high-priority process that will tally the next ready process for the given
 	number of seconds. Answer a Block that will return the tally (a Bag) after the task
@@ -309,7 +311,7 @@ ProcessorScheduler >> tallyCPUUsageFor: seconds [
 	^self tallyCPUUsageFor: seconds every: 10
 ]
 
-{ #category : #'CPU usage tally' }
+{ #category : 'CPU usage tally' }
 ProcessorScheduler >> tallyCPUUsageFor: seconds every: msec [
 	"Start a high-priority process that will tally the next ready process for the given
 	number of seconds. Answer a Block that will return the tally (a Bag) after the task
@@ -331,14 +333,14 @@ ProcessorScheduler >> tallyCPUUsageFor: seconds every: msec [
 	^[ sem wait. tally ]
 ]
 
-{ #category : #'process state change' }
+{ #category : 'process state change' }
 ProcessorScheduler >> terminateActive [
 	"Terminate the process that is currently running."
 
 	self activeProcess doTerminationFromYourself
 ]
 
-{ #category : #'process state change' }
+{ #category : 'process state change' }
 ProcessorScheduler >> terminateRealActive [
 	"IMPORTANT: Do not step over this method in the debugger (normally you will never do it) because it will terminate the UIProcess of the debugger instead of the process under the debugger.
 	Method should not be used by users. It is only for specific low level places of the system like a normal process termination.
@@ -370,7 +372,7 @@ ProcessorScheduler >> terminateRealActive [
 	activeProcess doTerminationFromYourself
 ]
 
-{ #category : #'priority names' }
+{ #category : 'priority names' }
 ProcessorScheduler >> timingPriority [
 	"Answer the priority at which the system processes keeping track of real
 	time should run."
@@ -380,14 +382,14 @@ ProcessorScheduler >> timingPriority [
 	^TimingPriority
 ]
 
-{ #category : #'priority names' }
+{ #category : 'priority names' }
 ProcessorScheduler >> userBackgroundPriority [
 	"Answer the priority at which user background processes should run."
 
 	^UserBackgroundPriority
 ]
 
-{ #category : #'priority names' }
+{ #category : 'priority names' }
 ProcessorScheduler >> userInterruptPriority [
 	"Answer the priority at which user processes desiring immediate service
 	should run. Processes run at this level will preempt the window
@@ -396,20 +398,20 @@ ProcessorScheduler >> userInterruptPriority [
 	^UserInterruptPriority
 ]
 
-{ #category : #'priority names' }
+{ #category : 'priority names' }
 ProcessorScheduler >> userSchedulingPriority [
 	"Answer the priority at which the window scheduler should run."
 
 	^UserSchedulingPriority
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessorScheduler >> waitingProcessesAt: aPriority [
 	"Return the list of processes at the given priority level."
 	^quiescentProcessLists at: aPriority
 ]
 
-{ #category : #'process state change' }
+{ #category : 'process state change' }
 ProcessorScheduler >> yield [
 	"Give other Processes at the current priority a chance to run."
 

--- a/src/Kernel/ProtoObject.class.st
+++ b/src/Kernel/ProtoObject.class.st
@@ -6,12 +6,14 @@ Generally these are proxy objects designed to read themselves in from the disk, 
 ProtoObject has no instance variables, nor should any be added.
 "
 Class {
-	#name : #ProtoObject,
-	#superclass : #nil,
-	#category : #'Kernel-Objects'
+	#name : 'ProtoObject',
+	#superclass : 'nil',
+	#category : 'Kernel-Objects',
+	#package : 'Kernel',
+	#tag : 'Objects'
 }
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 ProtoObject >> == anObject [
 	"Primitive. Answer whether the receiver and the argument are the same
 	object (have the same object pointer). Do not redefine the message == in
@@ -22,7 +24,7 @@ ProtoObject >> == anObject [
 	self primitiveFailed
 ]
 
-{ #category : #'reflective operations' }
+{ #category : 'reflective operations' }
 ProtoObject >> basicIdentityHash [
 	"Answer a 22 bits unsigned SmallInteger whose value is related to the receiver's identity.
 
@@ -35,7 +37,7 @@ ProtoObject >> basicIdentityHash [
 	self primitiveFailed
 ]
 
-{ #category : #'reflective operations' }
+{ #category : 'reflective operations' }
 ProtoObject >> become: otherObject [
 	"Primitive. Swap the object pointers of the receiver and the argument.
 	All variables in the entire system that used to point to the
@@ -45,7 +47,7 @@ ProtoObject >> become: otherObject [
 	{self} elementsExchangeIdentityWith: {otherObject}
 ]
 
-{ #category : #'reflective operations' }
+{ #category : 'reflective operations' }
 ProtoObject >> becomeForward: otherObject [
 	"Primitive. All variables in the entire system that used to point
 	to the receiver now point to the argument.
@@ -54,7 +56,7 @@ ProtoObject >> becomeForward: otherObject [
 	{self} elementsForwardIdentityTo: {otherObject}
 ]
 
-{ #category : #'reflective operations' }
+{ #category : 'reflective operations' }
 ProtoObject >> becomeForward: otherObject copyHash: copyHash [
 	"Primitive. All variables in the entire system that used to point to the receiver now point to the argument.
 	If copyHash is true, the argument's identity hash bits will be set to those of the receiver.
@@ -63,7 +65,7 @@ ProtoObject >> becomeForward: otherObject copyHash: copyHash [
 	{self} elementsForwardIdentityTo: {otherObject} copyHash: copyHash
 ]
 
-{ #category : #'reflective operations' }
+{ #category : 'reflective operations' }
 ProtoObject >> cannotInterpret: aMessage [
 	 "Handle the fact that there was an attempt to send the given message to the receiver but a null methodDictionary was encountered while looking up the message selector.  Hopefully this is the result of encountering a stub for a swapped out class which induces this exception on purpose."
 
@@ -80,7 +82,7 @@ ProtoObject >> cannotInterpret: aMessage [
 	^ aMessage sentTo: self
 ]
 
-{ #category : #'class membership' }
+{ #category : 'class membership' }
 ProtoObject >> class [
 	"Primitive. Answer the object which is the receiver's class. Essential. See
 	Object documentation whatIsAPrimitive."
@@ -89,7 +91,7 @@ ProtoObject >> class [
 	self primitiveFailed
 ]
 
-{ #category : #'reflective operations' }
+{ #category : 'reflective operations' }
 ProtoObject >> doesNotUnderstand: aMessage [
 
 	<debuggerCompleteToSender>
@@ -100,12 +102,12 @@ ProtoObject >> doesNotUnderstand: aMessage [
 		signal
 ]
 
-{ #category : #executing }
+{ #category : 'executing' }
 ProtoObject >> executeMethod: compiledMethod [
 	^ self withArgs: #( ) executeMethod: compiledMethod
 ]
 
-{ #category : #flagging }
+{ #category : 'flagging' }
 ProtoObject >> flag: aSymbol [
 
 	"Send this message, with a relevant symbol as argument, to flag a message for subsequent retrieval.  For example, you might put the following line in a number of messages:
@@ -113,7 +115,7 @@ ProtoObject >> flag: aSymbol [
 	Then, to retrieve all such messages, browse all senders of #returnHereUrgently."
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 ProtoObject >> identityHash [
 	"Answer a SmallInteger whose value is related to the receiver's identity.
 	 This method must not be overridden, except by SmallInteger.  As of
@@ -125,14 +127,14 @@ ProtoObject >> identityHash [
 	^self basicIdentityHash bitShift: 8
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ProtoObject >> ifNil: nilBlock [
 	"Return self, or evaluate the block if I'm == nil (q.v.)"
 	"Might be compiled inline for speed, see RBMessageNode>>#isInlineIfNil"
 	^ self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ProtoObject >> ifNil: nilBlock ifNotNil: ifNotNilBlock [
 	"If the receiver is not nil, pass it as argument to the ifNotNilBlock block. else execute the nilBlock block"
 	"Might be compiled inline for speed, see RBMessageNode>>#isInlineIfNil"
@@ -143,7 +145,7 @@ ProtoObject >> ifNil: nilBlock ifNotNil: ifNotNilBlock [
 	^ ifNotNilBlock cull: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ProtoObject >> ifNotNil: ifNotNilBlock [
 	"Evaluate the block, unless I'm == nil (q.v.). If the receiver is not nil, pass it as argument to the block."
 	"Might be compiled inline for speed, see RBMessageNode>>#isInlineIfNil"
@@ -154,7 +156,7 @@ ProtoObject >> ifNotNil: ifNotNilBlock [
 	^ ifNotNilBlock cull: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ProtoObject >> ifNotNil: ifNotNilBlock ifNil: nilBlock [
 	"If the receiver is not nil, pass it as argument to the ifNotNilBlock block. else execute the nilBlock block"
 	"Might be compiled inline for speed, see RBMessageNode>>#isInlineIfNil"
@@ -165,12 +167,12 @@ ProtoObject >> ifNotNil: ifNotNilBlock ifNil: nilBlock [
 	^ ifNotNilBlock cull: self
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ProtoObject >> initialize [
 	"Subclasses should redefine this method to perform initializations on instance creation"
 ]
 
-{ #category : #introspection }
+{ #category : 'introspection' }
 ProtoObject >> instVarsInclude: anObject [
 "Answers true if anObject is among my named or indexed instance variables, and false otherwise"
 
@@ -182,19 +184,19 @@ ProtoObject >> instVarsInclude: anObject [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ProtoObject >> isImmediateObject [
 	^ self class isImmediateClass
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ProtoObject >> isNil [
 	"Coerces nil to true and everything else to false."
 
 	^false
 ]
 
-{ #category : #'write barrier' }
+{ #category : 'write barrier' }
 ProtoObject >> modificationForbiddenFor: selector index: index value: value [
 	^ (ModificationForbidden
 		for: self
@@ -203,25 +205,25 @@ ProtoObject >> modificationForbiddenFor: selector index: index value: value [
 		retrySelector: selector) signal
 ]
 
-{ #category : #'write barrier' }
+{ #category : 'write barrier' }
 ProtoObject >> modificationForbiddenFor: selector value: value [
 	^ self modificationForbiddenFor: selector index: nil value: value
 ]
 
-{ #category : #'block support' }
+{ #category : 'block support' }
 ProtoObject >> mustBeBoolean [
 	"Catches attempts to test truth of non-Booleans.  This message is sent from the VM.  The sending context is rewound to just before the jump causing this exception."
 
 	^ self mustBeBooleanHandler mustBeBooleanIn: thisContext sender
 ]
 
-{ #category : #'block support' }
+{ #category : 'block support' }
 ProtoObject >> mustBeBooleanHandler [
 
 	^ NonBooleanReceiver mustBeBooleanHandler ifNil: [ self ]
 ]
 
-{ #category : #'block support' }
+{ #category : 'block support' }
 ProtoObject >> mustBeBooleanIn: context [
 	"context is the where the non-boolean error occurred. Rewind context to before jump then raise error."
 
@@ -250,7 +252,7 @@ ProtoObject >> mustBeBooleanIn: context [
 	^ proceedValue ~~ false
 ]
 
-{ #category : #'memory scanning' }
+{ #category : 'memory scanning' }
 ProtoObject >> nextInstance [
 	"Primitive. Answer the next instance after the receiver in the
 	enumeration of all instances of this class. Fails if all instances have been
@@ -260,7 +262,7 @@ ProtoObject >> nextInstance [
 	^nil
 ]
 
-{ #category : #'memory scanning' }
+{ #category : 'memory scanning' }
 ProtoObject >> nextObject [
 	"Primitive. Answer the next object after the receiver in the
 	enumeration of all objects. Return 0 when all objects have been
@@ -270,12 +272,12 @@ ProtoObject >> nextObject [
 	self primitiveFailed
 ]
 
-{ #category : #'pointing to' }
+{ #category : 'pointing to' }
 ProtoObject >> pointersTo [
 	^self pointersToExcept: #()
 ]
 
-{ #category : #'pointing to' }
+{ #category : 'pointing to' }
 ProtoObject >> pointersToAmong: aCollectionOfObjects [
 	"Meant to be used as:
 	Smalltalk garbageCollect.
@@ -289,7 +291,7 @@ ProtoObject >> pointersToAmong: aCollectionOfObjects [
 	^ self pointersToExcept: #() among: aCollectionOfObjects
 ]
 
-{ #category : #'pointing to' }
+{ #category : 'pointing to' }
 ProtoObject >> pointersToExcept: objectsToExclude [
 	"Find all objects in the system that hold a pointer to me, excluding those listed"
 	| c pointers objectsToAlwaysExclude closure|
@@ -312,7 +314,7 @@ ProtoObject >> pointersToExcept: objectsToExclude [
 				or: [objectsToExclude identityIncludes: ea ]] ]) asArray
 ]
 
-{ #category : #'pointing to' }
+{ #category : 'pointing to' }
 ProtoObject >> pointersToExcept: objectsToExclude among: aCollectionOfObjects [
 	"Find all objects in the system that hold a pointer to me, excluding those listed.
 	This method is meant to be a faster solution if used several times on several objects rather than calling the GC multiples times.
@@ -335,7 +337,7 @@ ProtoObject >> pointersToExcept: objectsToExclude among: aCollectionOfObjects [
 						or: [ objectsToExclude identityIncludes: ea ] ] ]) asArray
 ]
 
-{ #category : #'pointing to' }
+{ #category : 'pointing to' }
 ProtoObject >> pointsTo: anObject [
 	"Answers true if I hold a reference to anObject, or false otherwise.
 	Note: an object points to the class via the header"
@@ -343,7 +345,7 @@ ProtoObject >> pointsTo: anObject [
 	^ (self instVarsInclude: anObject) or: [ ^self class == anObject]
 ]
 
-{ #category : #'primitive failure' }
+{ #category : 'primitive failure' }
 ProtoObject >> primitiveFail [
 	"primitiveFail may be invoked by certain methods whose code is translated in C. In such a case primitiveFail and not primitiveFailed
 	 should be invoked. The reason is that this code is translated to C by VMMaker. #primitiveFail is
@@ -352,21 +354,21 @@ ProtoObject >> primitiveFail [
 	^ self primitiveFailed
 ]
 
-{ #category : #'primitive failure' }
+{ #category : 'primitive failure' }
 ProtoObject >> primitiveFailed [
 	"Announce that a primitive has failed and there is no appropriate Smalltalk code to run."
 
 	self primitiveFailed: thisContext sender selector
 ]
 
-{ #category : #'primitive failure' }
+{ #category : 'primitive failure' }
 ProtoObject >> primitiveFailed: selector [
 	"Announce that a primitive has failed and there is no appropriate Smalltalk code to run."
 
 	PrimitiveFailed signalFor: selector
 ]
 
-{ #category : #'apply primitives' }
+{ #category : 'apply primitives' }
 ProtoObject >> tryPrimitive: primIndex withArgs: argumentArray [
 	"This method is a template that the Smalltalk simulator uses to
 	execute primitives. See Object documentation whatIsAPrimitive."
@@ -375,7 +377,7 @@ ProtoObject >> tryPrimitive: primIndex withArgs: argumentArray [
 	^ Context primitiveFailTokenFor: code
 ]
 
-{ #category : #executing }
+{ #category : 'executing' }
 ProtoObject >> withArgs: argArray executeMethod: compiledMethod [
 	"Execute compiledMethod against the receiver and args in argArray"
 
@@ -383,7 +385,7 @@ ProtoObject >> withArgs: argArray executeMethod: compiledMethod [
 	self primitiveFailed
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 ProtoObject >> ~~ anObject [
 	"Primitive. Answer whether the receiver and the argument are different objects
 	(do not have the same object pointer). Do not redefine the message ~~ in

--- a/src/Kernel/Protocol.class.st
+++ b/src/Kernel/Protocol.class.st
@@ -5,23 +5,25 @@ A class holds my instances (for now through ClassOrganization but we want to rem
 I have a name that is used in browsers to display the different protocols.
 "
 Class {
-	#name : #Protocol,
-	#superclass : #Object,
+	#name : 'Protocol',
+	#superclass : 'Object',
 	#instVars : [
 		'name',
 		'methodSelectors'
 	],
-	#category : #'Kernel-Classes'
+	#category : 'Kernel-Classes',
+	#package : 'Kernel',
+	#tag : 'Classes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Protocol class >> name: aString [
 
 	self deprecated: 'Use #named: instead' transformWith: '`@rcv name: `@arg' -> '`@rcv named: `@arg'.
 	^ self named: aString
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Protocol class >> name: aString methodSelectors: methods [
 
 	^ (self named: aString)
@@ -29,7 +31,7 @@ Protocol class >> name: aString methodSelectors: methods [
 		  yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Protocol class >> named: aStrings [
 
 	^ self new
@@ -37,30 +39,30 @@ Protocol class >> named: aStrings [
 		  yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Protocol class >> unclassified [
 	^ #'as yet unclassified'
 ]
 
-{ #category : #'adding-removing' }
+{ #category : 'adding-removing' }
 Protocol >> addAllMethodsFrom: aProtocol [
 	aProtocol methodSelectors do: [ :each | self addMethodSelector: each ]
 ]
 
-{ #category : #'adding-removing' }
+{ #category : 'adding-removing' }
 Protocol >> addMethodSelector: aSymbol [
 	(methodSelectors includes: aSymbol) ifTrue: [ ^ self ].
 	
 	methodSelectors := methodSelectors copyWith: aSymbol
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Protocol >> includesSelector: selector [
 
 	^ self methodSelectors includes: selector
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Protocol >> initialize [
 
 	super initialize.
@@ -69,12 +71,12 @@ Protocol >> initialize [
 	name := self class unclassified
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Protocol >> isEmpty [
 	^ self methodSelectors isEmpty
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Protocol >> isExtensionProtocol [
 	"For now, extension methods are managed via protocols. 
 	
@@ -83,41 +85,41 @@ Protocol >> isExtensionProtocol [
 	^ self name first = $*
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Protocol >> isExtensionProtocolMatching: aPackage [
 	"Return true if I am an extension protocol linked to the package as parameter"
 
 	^ (aPackage organizer packageForProtocol: self) = aPackage
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Protocol >> isUnclassifiedProtocol [
 
 	^ self name = self class unclassified
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Protocol >> methodSelectors [
 	^ methodSelectors
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Protocol >> methodSelectors: anObject [
 	methodSelectors := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Protocol >> name [
 
 	^ name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Protocol >> name: anObject [
 	name := anObject asSymbol
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Protocol >> printOn: aStream [
 	aStream
 		nextPutAll: self class name;
@@ -128,18 +130,18 @@ Protocol >> printOn: aStream [
 		nextPutAll: ' selector(s)'
 ]
 
-{ #category : #'adding-removing' }
+{ #category : 'adding-removing' }
 Protocol >> removeMethodSelector: aSymbol [
 	methodSelectors := methodSelectors copyWithout: aSymbol
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Protocol >> rename: newName [
 
 	self name: newName
 ]
 
-{ #category : #'adding-removing' }
+{ #category : 'adding-removing' }
 Protocol >> resetMethodSelectors [
 	methodSelectors := Array empty
 ]

--- a/src/Kernel/PseudoVariable.class.st
+++ b/src/Kernel/PseudoVariable.class.st
@@ -2,32 +2,34 @@
 I model self, super, thisContext, and thisProcess
 "
 Class {
-	#name : #PseudoVariable,
-	#superclass : #Variable,
+	#name : 'PseudoVariable',
+	#superclass : 'Variable',
 	#instVars : [
 		'environment'
 	],
-	#category : #'Kernel-Variables'
+	#category : 'Kernel-Variables',
+	#package : 'Kernel',
+	#tag : 'Variables'
 }
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 PseudoVariable class >> initialize [
 
 	self deprecatedAliases: { #ReservedVariable }
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 PseudoVariable class >> instance [
 	self deprecated: 'use new to get a new instance or #lookupVar: for the shared instance'.
 	^self new.
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 PseudoVariable class >> isAbstract [
 	^self = PseudoVariable
 ]
 
-{ #category : #compiler }
+{ #category : 'compiler' }
 PseudoVariable class >> lookupDictionary [
 	"create a loopup table name -> instance for Semantic Analysis"
 
@@ -37,69 +39,69 @@ PseudoVariable class >> lookupDictionary [
 		   instance name -> instance ]) asDictionary
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 PseudoVariable class >> variableName [
 	^self subclassResponsibility
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 PseudoVariable >> asDoItVariableFrom: aContext [
 	^ DoItVariable fromContext: aContext variable: self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 PseudoVariable >> asString [
 
 	^ self name
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 PseudoVariable >> emitStore: methodBuilder [
 
 	self shouldNotImplement
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 PseudoVariable >> initialize [
 	environment := Smalltalk globals.
 	name := self class variableName
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 PseudoVariable >> isPseudoVariable [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 PseudoVariable >> isWritable [
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 PseudoVariable >> name: aSymbol [
 	"names of ReservedVariables are fixed and can not be changed"
 	self shouldNotImplement
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 PseudoVariable >> printOn: stream [
 
 	stream nextPutAll: self name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 PseudoVariable >> scope [
 	^ environment
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 PseudoVariable >> usingMethods [
 	"first call is very slow as it creates all ASTs"
 	^environment allMethods select: [ : method |
 		method ast variableNodes anySatisfy: [ :varNode | varNode variable == self]]
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 PseudoVariable >> write: aValue inContext: aContext [
 
 	self error: name, ' is a read-only variable and cant be modified'

--- a/src/Kernel/Rectangle.class.st
+++ b/src/Kernel/Rectangle.class.st
@@ -21,23 +21,25 @@ Instance variables:
 
 "
 Class {
-	#name : #Rectangle,
-	#superclass : #Object,
+	#name : 'Rectangle',
+	#superclass : 'Object',
 	#instVars : [
 		'origin',
 		'corner'
 	],
-	#category : #'Kernel-BasicObjects'
+	#category : 'Kernel-BasicObjects',
+	#package : 'Kernel',
+	#tag : 'BasicObjects'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Rectangle class >> center: centerPoint extent: extentPoint [
 	"Answer an instance of me whose center is centerPoint asInteger  "
 
 	^self origin: centerPoint - (extentPoint//2) extent: extentPoint
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Rectangle class >> encompassing: listOfPoints [
 	"A number of callers of encompass: should use this method."
 	| topLeft bottomRight |
@@ -48,14 +50,14 @@ Rectangle class >> encompassing: listOfPoints [
 	^ topLeft corner: bottomRight
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Rectangle class >> floatCenter: centerPoint extent: extentPoint [
 	"Answer an instance of me whose center is centerPoint and width
 	by height is extentPoint."
 	^self origin: centerPoint - (extentPoint/2.0) extent: extentPoint
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Rectangle class >> left: left right: right top: top bottom: bottom [
 	"Answer an instance of me whose left, right, top, and bottom coordinates
 	are determined by the arguments."
@@ -63,7 +65,7 @@ Rectangle class >> left: left right: right top: top bottom: bottom [
 	^ self basicNew setLeft: left right: right top: top bottom: bottom
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Rectangle class >> merging: listOfRects [
 	"A number of callers of merge: should use this method."
 	| minX minY maxX maxY |
@@ -83,7 +85,7 @@ Rectangle class >> merging: listOfRects [
 	^ minX @ minY corner: maxX @ maxY
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Rectangle class >> origin: originPoint corner: cornerPoint [
 	"Answer an instance of me whose corners (top left and bottom right) are
 	determined by the arguments."
@@ -91,7 +93,7 @@ Rectangle class >> origin: originPoint corner: cornerPoint [
 	^self basicNew setPoint: originPoint point: cornerPoint
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Rectangle class >> origin: originPoint extent: extentPoint [
 	"Answer an instance of me whose top left corner is originPoint and width by height is extentPoint. Note that extentPoint should be non negative since it represents the size of the rectangle"
 
@@ -101,14 +103,14 @@ Rectangle class >> origin: originPoint extent: extentPoint [
 		point: (originPoint x+ (extentPoint x max: 0)) @ (originPoint y + (extentPoint y max: 0))
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Rectangle class >> point: pt1 point: pt2 [
 	"Answer an instance of me constructed from two points."
 
 	^self basicNew setPoint: pt1 point: pt2
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Rectangle >> = aRectangle [
 	"Answer true if the receiver's species, origin and corner match aRectangle's."
 
@@ -116,14 +118,14 @@ Rectangle >> = aRectangle [
 		  origin = aRectangle origin and: [ corner = aRectangle corner ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> aboveCenter [
 	"Answer the point slightly above the center of the receiver."
 
 	^self topLeft + self bottomRight // (2@3)
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> adjustTo: newRect along: side [
 	"Return a copy adjusted to fit a neighbor that has changed size."
 	side = #left ifTrue: [^ self withRight: newRect left].
@@ -132,21 +134,21 @@ Rectangle >> adjustTo: newRect along: side [
 	side = #bottom ifTrue: [^ self withTop: newRect bottom]
 ]
 
-{ #category : #transforming }
+{ #category : 'transforming' }
 Rectangle >> align: aPoint1 with: aPoint2 [
 	"Answer a Rectangle that is a translated by aPoint2 - aPoint1."
 
 	^self translateBy: aPoint2 - aPoint1
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> allAreasOutsideList: aCollection do: aBlock [
 	"Enumerate aBlock with all areas of the receiver not overlapping
 	any rectangle in the given collection"
 	^self allAreasOutsideList: aCollection startingAt: 1 do: aBlock
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> allAreasOutsideList: aCollection startingAt: startIndex do: aBlock [
 	"Enumerate aBlock with all areas of the receiver not overlapping
 	any rectangle in the given collection"
@@ -190,7 +192,7 @@ Rectangle >> allAreasOutsideList: aCollection startingAt: startIndex do: aBlock 
 			do: aBlock ]
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> amountToTranslateWithin: aRectangle [
 	"Answer a Point, delta, such that self + delta is forced within aRectangle.
 	Keep self topLeft inside when all of self cannot be made to fit"
@@ -204,7 +206,7 @@ Rectangle >> amountToTranslateWithin: aRectangle [
 	^ dx @ dy
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> area [
 	"Answer the receiver's area, the product of width and height."
 	| w |
@@ -212,7 +214,7 @@ Rectangle >> area [
 	^ w * self height max: 0
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> areasOutside: aRectangle [
 	"Answer an Array of Rectangles comprising the parts of the receiver not
 	intersecting aRectangle."
@@ -235,7 +237,7 @@ Rectangle >> areasOutside: aRectangle [
 			[ aStream nextPut: (aRectangle corner x @ yOrigin corner: corner x @ yCorner) ] ]
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> bordersOn: her along: herSide [
 	((herSide = #right and: [self left = her right])
 	or: [herSide = #left and: [self right = her left]])
@@ -248,19 +250,19 @@ Rectangle >> bordersOn: her along: herSide [
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> bottom [
 	"Answer the position of the receiver's bottom horizontal line."
 
 	^corner y
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> bottom: aNumber [
 	^origin corner: corner x @ aNumber
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> bottomCenter [
 	"Answer the point at the center of the bottom horizontal line of the
 	receiver."
@@ -268,7 +270,7 @@ Rectangle >> bottomCenter [
 	^self center x @ self bottom
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> bottomLeft [
 	"Answer the point at the left edge of the bottom horizontal line of the
 	receiver."
@@ -276,7 +278,7 @@ Rectangle >> bottomLeft [
 	^origin x @ corner y
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> bottomRight [
 	"Answer the point at the right edge of the bottom horizontal line of the
 	receiver."
@@ -284,12 +286,12 @@ Rectangle >> bottomRight [
 	^corner
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> boundingBox [
 	^ self
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Rectangle >> ceiling [
 	"Answer the integer rectangle to the bottom right of receiver.
 	Return receiver if it is already an integerRectangle."
@@ -298,32 +300,32 @@ Rectangle >> ceiling [
 	^origin ceiling corner: corner ceiling
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> center [
 	"Answer the point at the center of the receiver."
 
 	^self topLeft + self bottomRight // 2
 ]
 
-{ #category : #transforming }
+{ #category : 'transforming' }
 Rectangle >> centeredBeneath: aRectangle [
 	 "Move the receiver so that its top center point coincides with the bottom center point of aRectangle."
 
 	^ self align: self topCenter with: aRectangle bottomCenter
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Rectangle >> closeTo: aRectangle [
  	^ (origin closeTo: aRectangle origin) and: [ corner closeTo: aRectangle corner ]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Rectangle >> closeTo: aRectangle precision: aPrecision [
  	^ (origin closeTo: aRectangle origin precision: aPrecision) and: [
 		corner closeTo: aRectangle corner precision: aPrecision ]
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Rectangle >> compressTo: grid [
 	"Answer a Rectangle whose origin and corner are rounded to grid x and grid y.
 	Rounding is done by upper value on origin and lower value on corner so that
@@ -333,7 +335,7 @@ Rectangle >> compressTo: grid [
 				corner: (corner roundDownTo: grid)
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Rectangle >> compressed [
 	"Answer a Rectangle whose origin and corner are rounded to integers.
 	Rounding is done by upper value on origin and lower value on corner so that
@@ -342,7 +344,7 @@ Rectangle >> compressed [
 	^Rectangle origin: origin ceiling corner: corner floor
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Rectangle >> containsPoint: aPoint [
 	"Answer whether aPoint is within the receiver. Pay attention the self origin is considered less than but the corner is strict"
 
@@ -354,21 +356,21 @@ Rectangle >> containsPoint: aPoint [
 	^origin <= aPoint and: [aPoint < corner]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Rectangle >> containsRect: aRect [
 	"Answer whether aRect is within the receiver (OK to coincide)."
 
 	^ aRect origin >= origin and: [aRect corner <= corner]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> corner [
 	"Answer the point at the bottom right corner of the receiver."
 
 	^corner
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> corners [
 	"Return an array of corner points in the order of a quadrilateral spec for WarpBlt."
 
@@ -379,7 +381,7 @@ Rectangle >> corners [
 		with: self topRight
 ]
 
-{ #category : #fmp }
+{ #category : 'fmp' }
 Rectangle >> deltaToEnsureInOrCentered: r extra: aNumber [
 	| dX dY halfXDiff halfYDiff |
 	dX := dY := 0.
@@ -396,7 +398,7 @@ Rectangle >> deltaToEnsureInOrCentered: r extra: aNumber [
 	^ dX @ dY
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> encompass: aPoint [
 	"Answer a Rectangle that contains both the receiver and aPoint."
 
@@ -405,7 +407,7 @@ Rectangle >> encompass: aPoint [
 		corner: (corner max:  aPoint)
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> expandBy: delta [
 	"Answer a Rectangle that is outset from the receiver by delta. delta is a
 	Rectangle, Point, or scalar."
@@ -413,7 +415,7 @@ Rectangle >> expandBy: delta [
 	^ delta asMargin expandRectangle: self
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Rectangle >> expandTo: grid [
 	"Answer a Rectangle whose origin and corner are rounded to grid x and grid y.
 	Rounding is done by upper value on origin and lower value on corner so that
@@ -423,7 +425,7 @@ Rectangle >> expandTo: grid [
 				corner: (corner roundUpTo: grid)
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Rectangle >> expanded [
 	"Answer a Rectangle whose origin and corner are rounded to integers.
 	Rounding is done by upper value on origin and lower value on corner so that
@@ -432,34 +434,34 @@ Rectangle >> expanded [
 	^Rectangle origin: origin floor corner: corner ceiling
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> extendBy: deltaMargin [
 	"Answer a Rectangle with the same origin as the receiver, but whose corner is offset by deltaMargin."
 
 	^ deltaMargin asMargin extendRectangle: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> extent [
 	"Answer a point with the receiver's width @ the receiver's height."
 
 	^corner - origin
 ]
 
-{ #category : #transforming }
+{ #category : 'transforming' }
 Rectangle >> flipBy: direction centerAt: aPoint [
 	"Return a copy flipped #vertical or #horizontal, about aPoint."
 	^ (origin flipBy: direction centerAt: aPoint)
 		rectangle: (corner flipBy: direction centerAt: aPoint)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> floatCenter [
 	"Answer the float point at the center of the receiver."
 	^ self topLeft + self bottomRight / 2.0
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Rectangle >> floor [
 	"Answer the integer rectangle to the topLeft of receiver.
 	Return receiver if it is already an integerRectangle."
@@ -469,7 +471,7 @@ Rectangle >> floor [
 	^ origin floor corner: corner floor
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> forPoint: aPoint closestSideDistLen: sideDistLenBlock [
 	"Evaluate the block with my side (symbol) closest to aPoint,
 		the approx distance of aPoint from that side, and
@@ -514,26 +516,26 @@ Rectangle >> forPoint: aPoint closestSideDistLen: sideDistLenBlock [
 					ifFalse: [ 0 ]) ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Rectangle >> hasPositiveExtent [
 	^ (corner x > origin x) and: [corner y > origin y]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Rectangle >> hash [
 	"Hash is reimplemented because = is implemented."
 
 	^origin hash bitXor: corner hash
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> height [
 	"Answer the height of the receiver."
 
 	^corner y - origin y
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> innerCorners [
 	"Return an array of inner corner points,
 	ie, the most extreme pixels included,
@@ -547,7 +549,7 @@ Rectangle >> innerCorners [
 		with: r1 topRight
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> insetBy: delta [
 	"Answer a Rectangle that is inset from the receiver by delta. delta is a
 	Rectangle, Point, or scalar."
@@ -555,7 +557,7 @@ Rectangle >> insetBy: delta [
 	^ delta asMargin insetRectangle: self
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> insetOriginBy: originDeltaPoint cornerBy: cornerDeltaPoint [
 	"Answer a Rectangle that is inset from the receiver by a given amount in
 	the origin and corner."
@@ -565,7 +567,7 @@ Rectangle >> insetOriginBy: originDeltaPoint cornerBy: cornerDeltaPoint [
 		corner: corner - cornerDeltaPoint
 ]
 
-{ #category : #transforming }
+{ #category : 'transforming' }
 Rectangle >> interpolateTo: end at: amountDone [
 	"Interpolate between the instance and end after the specified amount has been done (0 - 1)."
 
@@ -573,14 +575,14 @@ Rectangle >> interpolateTo: end at: amountDone [
 		corner: (self corner interpolateTo: end corner at: amountDone)
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> intersect: aRectangle [
 	"Answer a Rectangle that is the area in which the receiver overlaps with
 	aRectangle."
 	^ self intersect: aRectangle ifNone:[0@0 extent:0@0]
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> intersect: aRectangle ifNone: aBlock [
 	"Answer a Rectangle that is the area in which the receiver overlaps with
 	aRectangle.
@@ -599,7 +601,7 @@ Rectangle >> intersect: aRectangle ifNone: aBlock [
 	^ Rectangle origin: left @ top corner: right @ bottom
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Rectangle >> intersects: aRectangle [
 	"Answer whether aRectangle intersects the receiver anywhere."
 	"Optimized; old code answered:
@@ -614,58 +616,58 @@ Rectangle >> intersects: aRectangle [
 	^ true
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Rectangle >> isIntegerRectangle [
 	"Answer true if all component of receiver are integral."
 
 	^ origin isIntegerPoint and: [ corner isIntegerPoint ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Rectangle >> isRectangle [
 	^true
 ]
 
-{ #category : #'self evaluating' }
+{ #category : 'self evaluating' }
 Rectangle >> isSelfEvaluating [
 	^ self class == Rectangle
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Rectangle >> isTall [
 	^ self height > self width
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Rectangle >> isWide [
 	^ self width > self height
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Rectangle >> isZero [
 	^origin isZero and:[corner isZero]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> left [
 	"Answer the position of the receiver's left vertical line."
 
 	^origin x
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> left: aNumber [
 	^aNumber @ origin y corner: corner
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> leftCenter [
 	"Answer the point at the center of the receiver's left vertical line."
 
 	^self left @ self center y
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> merge: aRectangle [
 	"Answer a Rectangle that contains both the receiver and aRectangle."
 
@@ -674,14 +676,14 @@ Rectangle >> merge: aRectangle [
 		corner: (corner max: aRectangle corner)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> origin [
 	"Answer the point at the top left corner of the receiver."
 
 	^origin
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> pointAtSideOrCorner: loc [
 	"Answer the point represented by the given location."
 
@@ -692,7 +694,7 @@ Rectangle >> pointAtSideOrCorner: loc [
 					bottomRight bottom bottomLeft left) indexOf: loc))
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> pointNearestTo: aPoint [
 	"Return the point on my border closest to aPoint"
 	| side |
@@ -706,7 +708,7 @@ Rectangle >> pointNearestTo: aPoint [
 		ifFalse: [ ^ aPoint adhereTo: self ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Rectangle >> printOn: aStream [
 	"Refer to the comment in Object|printOn:."
 
@@ -715,7 +717,7 @@ Rectangle >> printOn: aStream [
 	corner printOn: aStream
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> quickMerge: aRectangle [
 	"Answer the receiver if it encloses the given rectangle or the merge of the two rectangles if it doesn't. This method is an optimization to reduce extra rectangle creations."
 	| useRcvr rOrigin rCorner minX maxX minY maxY |
@@ -753,7 +755,7 @@ Rectangle >> quickMerge: aRectangle [
 				corner: maxX @ maxY ]
 ]
 
-{ #category : #transforming }
+{ #category : 'transforming' }
 Rectangle >> quickMergePoint: aPoint [
 	"Answer the receiver if it encloses the given point or the expansion of the
 	receiver to do so if it doesn't. "
@@ -769,7 +771,7 @@ Rectangle >> quickMergePoint: aPoint [
 		ifFalse: [minX@minY corner: maxX@maxY]
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> rectanglesAt: y height: ht [
 
 	^ y + ht > self bottom
@@ -777,33 +779,33 @@ Rectangle >> rectanglesAt: y height: ht [
 		  ifFalse: [ { (origin x @ y corner: corner x @ (y + ht)) } ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> right [
 	"Answer the position of the receiver's right vertical line."
 
 	^corner x
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> right: aNumber [
 	^origin corner: aNumber @ corner y
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> rightCenter [
 	"Answer the point at the center of the receiver's right vertical line."
 
 	^self right @ self center y
 ]
 
-{ #category : #transforming }
+{ #category : 'transforming' }
 Rectangle >> rotateBy: direction centerAt: aPoint [
 	"Return a copy rotated #right, #left, or #pi about aPoint"
 	^ (origin rotateBy: direction centerAt: aPoint)
 		rectangle: (corner rotateBy: direction centerAt: aPoint)
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Rectangle >> roundTo: grid [
 	"Answer a Rectangle whose origin and corner are rounded to grid x and grid y."
 
@@ -811,28 +813,28 @@ Rectangle >> roundTo: grid [
 				corner: (corner roundTo: grid)
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Rectangle >> rounded [
 	"Answer a Rectangle whose origin and corner are rounded."
 
 	^Rectangle origin: origin rounded corner: corner rounded
 ]
 
-{ #category : #transforming }
+{ #category : 'transforming' }
 Rectangle >> scaleBy: scale [
 	"Answer a Rectangle scaled by scale, a Point or a scalar."
 
 	^Rectangle origin: origin * scale corner: corner * scale
 ]
 
-{ #category : #transforming }
+{ #category : 'transforming' }
 Rectangle >> scaleFrom: rect1 to: rect2 [
 	"Produce a rectangle stretched according to the stretch from rect1 to rect2"
 	^ (origin scaleFrom: rect1 to: rect2)
 		corner: (corner scaleFrom: rect1 to: rect2)
 ]
 
-{ #category : #transforming }
+{ #category : 'transforming' }
 Rectangle >> scaledAndCenteredIn: aRect [
 	"Answer a new rectangle that fits into aRectangle and is centered
 	but with the same aspect ratio as the receiver."
@@ -844,21 +846,21 @@ Rectangle >> scaledAndCenteredIn: aRect [
 					corner: (aRect topCenter x + (self width * (aRect height / self height) / 2)) @ aRect bottom]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Rectangle >> setLeft: left right: right top: top bottom: bottom [
 
 	origin := (left min: right) @ (top min: bottom).
 	corner := (left max: right) @ (top max: bottom)
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Rectangle >> setPoint: pt1 point: pt2 [
 
 	origin := (pt1 x min: pt2 x)@(pt1 y min: pt2 y).
 	corner := (pt1 x max: pt2 x)@(pt1 y max: pt2 y)
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> sideNearestTo: aPoint [
 	| distToLeft distToRight distToTop distToBottom closest side |
 	distToLeft := aPoint x - self left.
@@ -885,7 +887,7 @@ Display border: r width: 1.
 "
 ]
 
-{ #category : #transforming }
+{ #category : 'transforming' }
 Rectangle >> squishedWithin: aRectangle [
 	"Return an adjustment of the receiver that fits within aRectangle by reducing its size, not by changing its origin.  "
 
@@ -894,7 +896,7 @@ Rectangle >> squishedWithin: aRectangle [
 "(50 @ 50 corner: 160 @ 100) squishedWithin:  (20 @ 10 corner: 90 @ 85)"
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Rectangle >> storeOn: aStream [
 	"printed form is good for storing too"
 
@@ -903,33 +905,33 @@ Rectangle >> storeOn: aStream [
 	aStream nextPut: $)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> top [
 	"Answer the position of the receiver's top horizontal line."
 
 	^origin y
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> top: aNumber [
 	^origin x @ aNumber corner: corner
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> topCenter [
 	"Answer the point at the center of the receiver's top horizontal line."
 
 	^self center x @ self top
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> topLeft [
 	"Answer the point at the top left corner of the receiver's top horizontal line."
 
 	^origin
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> topRight [
 	"Answer the point at the top right corner of the receiver's top horizontal
 	line."
@@ -937,14 +939,14 @@ Rectangle >> topRight [
 	^corner x @ origin y
 ]
 
-{ #category : #transforming }
+{ #category : 'transforming' }
 Rectangle >> translateBy: factor [
 	"Answer a Rectangle translated by factor, a Point or a scalar."
 
 	^Rectangle origin: origin + factor corner: corner + factor
 ]
 
-{ #category : #transforming }
+{ #category : 'transforming' }
 Rectangle >> translatedAndSquishedToBeWithin: aRectangle [
 	"Return an adjustment of the receiver that fits within aRectangle by
 		- translating it to be within aRectangle if necessary, then
@@ -953,14 +955,14 @@ Rectangle >> translatedAndSquishedToBeWithin: aRectangle [
 	^ (self translatedToBeWithin: aRectangle) squishedWithin: aRectangle
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> translatedToBeWithin: aRectangle [
 	"Answer a copy of the receiver that does not extend beyond aRectangle."
 
 	^ self translateBy: (self amountToTranslateWithin: aRectangle)
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Rectangle >> truncateTo: grid [
 	"Answer a Rectangle whose origin and corner are truncated to grid x and grid y."
 
@@ -968,7 +970,7 @@ Rectangle >> truncateTo: grid [
 				corner: (corner truncateTo: grid)
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 Rectangle >> truncated [
 	"Answer a Rectangle whose origin and corner have any fractional parts removed. Answer the receiver if its coordinates are already integral."
 
@@ -981,59 +983,59 @@ Rectangle >> truncated [
 	^ Rectangle origin: origin truncated corner: corner truncated
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Rectangle >> width [
 	"Answer the width of the receiver."
 
 	^corner x - origin x
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> withBottom: y [
 	"Return a copy of me with a different bottom y"
 	^ origin x @ origin y corner: corner x @ (y max: origin y)
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> withHeight: height [
 	"Return a copy of me with a different height"
 	^ origin corner: corner x @ (origin y + height)
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> withLeft: x [
 	"Return a copy of me with a different left x (but not going over right side)"
 	^ (x min: corner x) @ origin y corner: corner x @ corner y
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> withRight: x [
 	"Return a copy of me with a different right x"
 	^ origin x @ origin y corner: (x max: origin x) @ corner y
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> withSide: side setTo: value [  "return a copy with side set to value"
 	^ self perform: (#(withLeft: withRight: withTop: withBottom: )
 							at: (#(left right top bottom) indexOf: side))
 		with: value
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> withSideOrCorner: side setToPoint: newPoint [
 	"Return a copy with side set to newPoint"
 
 	^ self withSideOrCorner: side setToPoint: newPoint minExtent: 0@0
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> withSideOrCorner: side setToPoint: newPoint minExtent: minExtent [
 	"Return a copy with side set to newPoint"
 	^self withSideOrCorner: side setToPoint: newPoint minExtent: minExtent
 		limit: ((#(left top) includes: side) ifTrue: [SmallInteger minVal] ifFalse: [SmallInteger maxVal])
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> withSideOrCorner: side setToPoint: newPoint minExtent: minExtent limit: limit [
 	"Return a copy with side set to newPoint"
 	side = #top ifTrue: [^ self withTop: (newPoint y min: corner y - minExtent y max: limit + minExtent y)].
@@ -1046,13 +1048,13 @@ Rectangle >> withSideOrCorner: side setToPoint: newPoint minExtent: minExtent li
 	side = #topRight ifTrue: [^ self bottomLeft rectangle: ((newPoint x max: origin x + minExtent x) @ (newPoint y min: corner y - minExtent y))]
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> withTop: y [
 	"Return a copy of me with a different top y"
 	^ origin x @ (y min: corner y) corner: corner x @ corner y
 ]
 
-{ #category : #'rectangle functions' }
+{ #category : 'rectangle functions' }
 Rectangle >> withWidth: width [
 	"Return a copy of me with a different width"
 	^ origin corner: (origin x + width) @ corner y

--- a/src/Kernel/RecursionStopper.class.st
+++ b/src/Kernel/RecursionStopper.class.st
@@ -8,24 +8,26 @@ executes a block just once in a recursion.
 A RecursionStopper object contains a collection of active methods which are currently called from within RecrusionStopper>>#during: this means that Recursion stopper can be used multiple places without one blocking the other, but multiple stoppers cannot be nested in the same method.
 "
 Class {
-	#name : #RecursionStopper,
-	#superclass : #Object,
+	#name : 'RecursionStopper',
+	#superclass : 'Object',
 	#instVars : [
 		'activeMethods'
 	],
 	#classVars : [
 		'Default'
 	],
-	#category : #'Kernel-Processes'
+	#category : 'Kernel-Processes',
+	#package : 'Kernel',
+	#tag : 'Processes'
 }
 
-{ #category : #api }
+{ #category : 'api' }
 RecursionStopper class >> default [
 
 	^ Default ifNil: [ Default := self new ]
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 RecursionStopper class >> during: aBlock [
 	<debuggerCompleteToSender>
 	self default
@@ -33,7 +35,7 @@ RecursionStopper class >> during: aBlock [
 		during: aBlock
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RecursionStopper >> initialize [
 
 	super initialize.
@@ -41,7 +43,7 @@ RecursionStopper >> initialize [
 	activeMethods := OrderedCollection new
 ]
 
-{ #category : #operating }
+{ #category : 'operating' }
 RecursionStopper >> stopMethod: aMethod during: aBlock [
 
 	(activeMethods includes: aMethod) ifTrue: [ ^ self ].

--- a/src/Kernel/RuntimeSyntaxError.class.st
+++ b/src/Kernel/RuntimeSyntaxError.class.st
@@ -4,12 +4,14 @@ When compiling syntactically incorrect code, we compile raising this exception.
 This way the debugger opens and the programmer can easily fix the faulty method
 "
 Class {
-	#name : #RuntimeSyntaxError,
-	#superclass : #Error,
-	#category : #'Kernel-Exceptions'
+	#name : 'RuntimeSyntaxError',
+	#superclass : 'Error',
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #signalling }
+{ #category : 'signalling' }
 RuntimeSyntaxError class >> signalSyntaxError: aString [
 	"we use signalSyntaxError: instead of signal: so we can quickly check
 	compiledMethods for syntax errors by checking the literals"

--- a/src/Kernel/ScaledDecimal.class.st
+++ b/src/Kernel/ScaledDecimal.class.st
@@ -6,15 +6,17 @@ Note that a ScaledDecimal does not printOn: exactly, however it will storeOn: ex
 This is mostly usefull with denominators being powers of 10.
 "
 Class {
-	#name : #ScaledDecimal,
-	#superclass : #Fraction,
+	#name : 'ScaledDecimal',
+	#superclass : 'Fraction',
 	#instVars : [
 		'scale'
 	],
-	#category : #'Kernel-Numbers'
+	#category : 'Kernel-Numbers',
+	#package : 'Kernel',
+	#tag : 'Numbers'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ScaledDecimal class >> newFromNumber: aNumber scale: anInteger [
 	| aFraction |
 	aFraction := aNumber asFraction.
@@ -23,7 +25,7 @@ ScaledDecimal class >> newFromNumber: aNumber scale: anInteger [
 		ifFalse: [self new setNumerator: aFraction denominator: 1 scale: anInteger]
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 ScaledDecimal >> * aNumber [
 
 	aNumber class = self class ifTrue: [
@@ -32,69 +34,69 @@ ScaledDecimal >> * aNumber [
 	^ self coerce: self asFraction * aNumber
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 ScaledDecimal >> + aNumber [
 	aNumber class = self class ifTrue: [^self asFraction + aNumber asFraction asScaledDecimal: (scale max: aNumber scale)].
 	^self coerce: self asFraction + aNumber
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 ScaledDecimal >> - aNumber [
 	aNumber class = self class ifTrue: [^self asFraction - aNumber asFraction asScaledDecimal: (scale max: aNumber scale)].
 	^self coerce: self asFraction - aNumber
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 ScaledDecimal >> / aNumber [
 	aNumber class = self class ifTrue: [^self asFraction / aNumber asFraction asScaledDecimal: (scale max: aNumber scale)].
 	^self coerce: self asFraction / aNumber
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 ScaledDecimal >> < aNumber [
 	aNumber class = self class ifTrue: [^self asFraction < aNumber asFraction].
 	^self asFraction < aNumber
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 ScaledDecimal >> <= aNumber [
 	aNumber class = self class ifTrue: [^self asFraction <= aNumber asFraction].
 	^self asFraction <= aNumber
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 ScaledDecimal >> = aNumber [
 	aNumber class = self class ifTrue: [^self asFraction = aNumber asFraction].
 	^self asFraction = aNumber
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 ScaledDecimal >> > aNumber [
 	aNumber class = self class ifTrue: [^self asFraction > aNumber asFraction].
 	^self asFraction > aNumber
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 ScaledDecimal >> >= aNumber [
 	aNumber class = self class ifTrue: [^self asFraction >= aNumber asFraction].
 	^self asFraction >= aNumber
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ScaledDecimal >> adaptToFraction: rcvr andSend: selector [
 	"If I am involved in arithmetic with a Fraction, convert it to a ScaledDecimal."
 
 	^(rcvr asScaledDecimal: 0) perform: selector with: self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ScaledDecimal >> adaptToInteger: rcvr andSend: selector [
 	"If I am involved in arithmetic with an Integer, convert it to a ScaledDecimal."
 
 	^(rcvr asScaledDecimal: 0) perform: selector with: self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 ScaledDecimal >> asFraction [
 	"Convert the receiver to a Fraction.
 	Avoid using numerator / denominator to save a useless and costly gcd: computation"
@@ -104,7 +106,7 @@ ScaledDecimal >> asFraction [
 		ifFalse: [Fraction numerator: numerator denominator: denominator]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ScaledDecimal >> coerce: aNumber [
 	"Note: this quick hack could be replaced by double dispatching"
 
@@ -113,14 +115,14 @@ ScaledDecimal >> coerce: aNumber [
 	^aNumber
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ScaledDecimal >> isFraction [
 	"Though kind of Fraction, pretend we are not a Fraction to let coercion works correctly"
 
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ScaledDecimal >> isLiteral [
 	"Answer if this number could be a well behaved literal.
 	Well, it would only if evaluating back to self.
@@ -135,13 +137,13 @@ ScaledDecimal >> isLiteral [
 			(10 raisedTo: scale) \\ denominator = 0]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ScaledDecimal >> isSelfEvaluating [
     "Not all scaled decimal are self evaluating, because they print rounded digits."
     ^self isLiteral
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 ScaledDecimal >> literalEqual: other [
 	"Testing equality is not enough.
 	It is also necessary to test number of decimal places (scale).
@@ -150,12 +152,12 @@ ScaledDecimal >> literalEqual: other [
 	^(super literalEqual: other) and: [self scale = other scale]
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 ScaledDecimal >> negated [
 	^self class newFromNumber: super negated scale: scale
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ScaledDecimal >> printOn: aStream [
 	"Append an approximated representation of the receiver on aStream.
 	Use prescribed number of digits after decimal point (the scale) using a rounding operation if not exact"
@@ -166,18 +168,18 @@ ScaledDecimal >> printOn: aStream [
 	aStream nextPut: $s; print: scale
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ScaledDecimal >> printOn: aStream base: base [
 	base = 10 ifFalse: [self error: 'ScaledDecimals should be printed only in base 10'].
 	self printOn: aStream
 ]
 
-{ #category : #'mathematical functions' }
+{ #category : 'mathematical functions' }
 ScaledDecimal >> raisedTo: aNumber [
 	^self coerce: (super raisedTo: aNumber)
 ]
 
-{ #category : #'mathematical functions' }
+{ #category : 'mathematical functions' }
 ScaledDecimal >> raisedToFraction: aFraction [
 	| result |
 	result := self asFraction raisedToFraction: aFraction.
@@ -186,34 +188,34 @@ ScaledDecimal >> raisedToFraction: aFraction [
 		ifFalse: [result asScaledDecimal: scale]
 ]
 
-{ #category : #'mathematical functions' }
+{ #category : 'mathematical functions' }
 ScaledDecimal >> raisedToInteger: aNumber [
 	^self class newFromNumber: (super raisedToInteger: aNumber) scale: scale
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 ScaledDecimal >> reciprocal [
 	^self class newFromNumber: super reciprocal scale: scale
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ScaledDecimal >> scale [
 	^scale
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ScaledDecimal >> setNumerator: n denominator: d scale: s [
 
 	self setNumerator: n denominator: d.
 	scale := s
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 ScaledDecimal >> squared [
 	^self class newFromNumber: super squared scale: scale
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ScaledDecimal >> storeOn: aStream [
 	"ScaledDecimal sometimes have more digits than they print (potentially an infinity).
 	In this case, do not use printOn: because it would loose some extra digits"

--- a/src/Kernel/SelectorException.class.st
+++ b/src/Kernel/SelectorException.class.st
@@ -2,15 +2,17 @@
 I am SelectorException, an abstract superclass for exceptions related to a selector.
 "
 Class {
-	#name : #SelectorException,
-	#superclass : #Error,
+	#name : 'SelectorException',
+	#superclass : 'Error',
 	#instVars : [
 		'selector'
 	],
-	#category : #'Kernel-Exceptions'
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #signaling }
+{ #category : 'signaling' }
 SelectorException class >> signalFor: aSelector [
 	"Create and signal an exception for aSelector in the default receiver."
 
@@ -19,7 +21,7 @@ SelectorException class >> signalFor: aSelector [
 		signal
 ]
 
-{ #category : #signaling }
+{ #category : 'signaling' }
 SelectorException class >> signalFor: aSelector in: aReceiver [
 	"Create and signal an exception for aSelector in aReceiver."
 
@@ -29,24 +31,24 @@ SelectorException class >> signalFor: aSelector in: aReceiver [
 		signal
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SelectorException >> messageText [
 	"Overwritten to initialiaze the message text to a standard text if it has not yet been set"
 
 	^ messageText ifNil: [ messageText := self standardMessageText ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SelectorException >> selector [
 	^ selector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SelectorException >> selector: aSelector [
 	selector := aSelector
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SelectorException >> standardMessageText [
 	"Generate a standard textual description"
 

--- a/src/Kernel/SelfVariable.class.st
+++ b/src/Kernel/SelfVariable.class.st
@@ -2,41 +2,43 @@
 I model ""self""
 "
 Class {
-	#name : #SelfVariable,
-	#superclass : #PseudoVariable,
-	#category : #'Kernel-Variables'
+	#name : 'SelfVariable',
+	#superclass : 'PseudoVariable',
+	#category : 'Kernel-Variables',
+	#package : 'Kernel',
+	#tag : 'Variables'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SelfVariable class >> variableName [
 	^#self
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 SelfVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 
 	^ aProgramNodeVisitor visitSelfNode: aNode
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 SelfVariable >> emitValue: methodBuilder [
 
 	methodBuilder pushReceiver
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SelfVariable >> isSelfVariable [
 	^true
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 SelfVariable >> readInContext: aContext [
 	"self in a block is the receiver of the home context
 	For clean blocks it might not be known (nil)"
 	^aContext home ifNotNil: [:home | home receiver ]
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 SelfVariable >> usingMethods [
 	"Super sends are doing a pushSelf, too, we need to still check the AST level sometimes.
 	FFI methods after a first call do not have a self send in the bytecode, but one in the code"

--- a/src/Kernel/Semaphore.class.st
+++ b/src/Kernel/Semaphore.class.st
@@ -13,15 +13,17 @@ While conceptually a semaphore has a list and a counter of excess signals. At th
 This is a design simplification for the virtual machine.
 "
 Class {
-	#name : #Semaphore,
-	#superclass : #LinkedList,
+	#name : 'Semaphore',
+	#superclass : 'LinkedList',
 	#instVars : [
 		'excessSignals'
 	],
-	#category : #'Kernel-Processes'
+	#category : 'Kernel-Processes',
+	#package : 'Kernel',
+	#tag : 'Processes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Semaphore class >> forMutualExclusion [
 	"Answer an instance of me that contains a single signal. This new
 	instance can now be used for mutual exclusion (see the critical: message
@@ -30,26 +32,26 @@ Semaphore class >> forMutualExclusion [
 	^self new signal
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Semaphore class >> new [
 	"Answer a new instance of Semaphore that contains no signals."
 
 	^self basicNew initSignals
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Semaphore >> = anObject [
 	^ self == anObject
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Semaphore >> consumeAllSignals [
 	"Consume any excess signals the receiver may have accumulated."
 
 	excessSignals := 0
 ]
 
-{ #category : #'mutual exclusion' }
+{ #category : 'mutual exclusion' }
 Semaphore >> critical: mutuallyExcludedBlock [
 	"Evaluate mutuallyExcludedBlock only if the receiver is not currently in
 	the process of running the critical: message. If the receiver is, evaluate
@@ -80,7 +82,7 @@ Semaphore >> critical: mutuallyExcludedBlock [
 	^blockValue
 ]
 
-{ #category : #'mutual exclusion' }
+{ #category : 'mutual exclusion' }
 Semaphore >> critical: mutuallyExcludedBlock ifCurtailed: terminationBlock [
 	"Evaluate mutuallyExcludedBlock only if the receiver is not currently in
 	the process of running the critical: message. If the receiver is, evaluate
@@ -88,7 +90,7 @@ Semaphore >> critical: mutuallyExcludedBlock ifCurtailed: terminationBlock [
 	^self critical:[mutuallyExcludedBlock ifCurtailed: terminationBlock]
 ]
 
-{ #category : #'mutual exclusion' }
+{ #category : 'mutual exclusion' }
 Semaphore >> critical: mutuallyExcludedBlock ifError: errorBlock [
 	"Evaluate mutuallyExcludedBlock only if the receiver is not currently in
 	the process of running the critical: message. If the receiver is, evaluate
@@ -105,7 +107,7 @@ Semaphore >> critical: mutuallyExcludedBlock ifError: errorBlock [
 	^blockValue
 ]
 
-{ #category : #'mutual exclusion' }
+{ #category : 'mutual exclusion' }
 Semaphore >> critical: mutuallyExcludedBlock ifLocked: alternativeBlock [
 	"Evaluate mutuallyExcludedBlock only if the receiver is not currently in
 	the process of running the critical: message. If the receiver is, evaluate
@@ -123,7 +125,7 @@ test is written carefully so that it will result in bytecodes only."
 	^self critical: mutuallyExcludedBlock
 ]
 
-{ #category : #'mutual exclusion' }
+{ #category : 'mutual exclusion' }
 Semaphore >> criticalReleasingOnError: mutuallyExcludedBlock [
 	"This is like #critical: but releasing the lock if there is an exception in the block"
 	| blockValue caught |
@@ -142,7 +144,7 @@ Semaphore >> criticalReleasingOnError: mutuallyExcludedBlock [
 	^blockValue
 ]
 
-{ #category : #'process termination handling' }
+{ #category : 'process termination handling' }
 Semaphore >> handleProcessTerminationOfWaitingContext: suspendedContext [
 
 	^suspendedContext homeMethod == (Semaphore compiledMethodAt: #critical:)
@@ -150,25 +152,25 @@ Semaphore >> handleProcessTerminationOfWaitingContext: suspendedContext [
 		ifFalse: [ suspendedContext]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Semaphore >> hash [
 	^ self identityHash
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Semaphore >> initSignals [
 	"Consume any excess signals the receiver may have accumulated."
 
 	excessSignals := 0
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Semaphore >> isSignaled [
 	"Return true if this semaphore is currently signaled"
 	^excessSignals > 0
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Semaphore >> resumeProcess: aProcess [
 	"Remove the given process from the list of waiting processes (if it's there) and resume it.  This is used when a process asked for its wait to be timed out."
 
@@ -177,7 +179,7 @@ Semaphore >> resumeProcess: aProcess [
 	process ifNotNil: [process resume]
 ]
 
-{ #category : #communication }
+{ #category : 'communication' }
 Semaphore >> signal [
 	"Primitive. Send a signal through the receiver. If one or more processes
 	have been suspended trying to receive a signal, allow the first one to
@@ -192,14 +194,14 @@ Semaphore >> signal [
 		ifFalse: [Processor resume: self removeFirstLink]"
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 Semaphore >> terminateProcess [
 	"Terminate the process waiting on this semaphore, if any."
 
 	self ifNotEmpty: [ self removeFirst terminate ]
 ]
 
-{ #category : #communication }
+{ #category : 'communication' }
 Semaphore >> wait [
 	"Primitive. The active Process must receive a signal through the receiver
 	before proceeding. If no signal has been sent, the active Process will be
@@ -214,7 +216,7 @@ Semaphore >> wait [
 		ifFalse: [self addLastLink: Processor activeProcess suspend]"
 ]
 
-{ #category : #communication }
+{ #category : 'communication' }
 Semaphore >> wait: aDuration [
 	"Wait on this semaphore for up to the given time duration, then timeout.
 	Return true if the deadline expired, false otherwise."
@@ -223,7 +225,7 @@ Semaphore >> wait: aDuration [
 	^d wait
 ]
 
-{ #category : #communication }
+{ #category : 'communication' }
 Semaphore >> wait: aDuration onCompletion: completionBlock onTimeout: timeoutBlock [
 	"Wait on this semaphore for up to the given time duration, then timeout.
 	If the deadline expired execute timeoutBlock, otherwise execute completionBlock.
@@ -233,7 +235,7 @@ Semaphore >> wait: aDuration onCompletion: completionBlock onTimeout: timeoutBlo
 	^d waitOnCompletion: completionBlock onTimeout: timeoutBlock
 ]
 
-{ #category : #communication }
+{ #category : 'communication' }
 Semaphore >> waitTimeoutMSecs: anInteger [
 	"Wait on this semaphore for up to the given number of milliseconds, then timeout.
 	Return true if the deadline expired, false otherwise."
@@ -242,14 +244,14 @@ Semaphore >> waitTimeoutMSecs: anInteger [
 	^d wait
 ]
 
-{ #category : #communication }
+{ #category : 'communication' }
 Semaphore >> waitTimeoutSeconds: anInteger [
 	"Wait on this semaphore for up to the given number of seconds, then timeout.
 	Return true if the deadline expired, false otherwise."
 	^self waitTimeoutMSecs: anInteger * 1000
 ]
 
-{ #category : #communication }
+{ #category : 'communication' }
 Semaphore >> waitTimeoutSeconds: anInteger onCompletion: completionBlock onTimeout: timeoutBlock [
 	"Wait on this semaphore for up to the given number of seconds, then timeout.
 	If the deadline expired execute timeoutBlock, otherwise execute completionBlock.

--- a/src/Kernel/SharedPool.class.st
+++ b/src/Kernel/SharedPool.class.st
@@ -2,46 +2,48 @@
 A shared pool represents a set of bindings which are accessible to all classes which import the pool in its 'pool dictionaries'. SharedPool is NOT a dictionary but rather a name space. Bindings are represented by 'class variables' - as long as we have no better way to represent them at least.
 "
 Class {
-	#name : #SharedPool,
-	#superclass : #Object,
-	#category : #'Kernel-Classes'
+	#name : 'SharedPool',
+	#superclass : 'Object',
+	#category : 'Kernel-Classes',
+	#package : 'Kernel',
+	#tag : 'Classes'
 }
 
-{ #category : #'name lookup' }
+{ #category : 'name lookup' }
 SharedPool class >> bindingOf: varName [
 	"Answer the binding of some variable resolved in the scope of the receiver"
 
 	^ (self localBindingOf: varName) ifNil: [ self superclass bindingOf: varName ]
 ]
 
-{ #category : #'name lookup' }
+{ #category : 'name lookup' }
 SharedPool class >> bindingsDo: aBlock [
 	^self classPool bindingsDo: aBlock
 ]
 
-{ #category : #'name lookup' }
+{ #category : 'name lookup' }
 SharedPool class >> classBindingOf: varName [
 	"For initialization messages grant the regular scope"
 	^super bindingOf: varName
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SharedPool class >> includesKey: aName [
 	"does this pool include aName"
 	^(self localBindingOf: aName) notNil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SharedPool class >> isPool [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SharedPool class >> isUsed [
 	^super isUsed or: [self poolUsers isNotEmpty]
 ]
 
-{ #category : #'name lookup' }
+{ #category : 'name lookup' }
 SharedPool class >> localBindingOf: varName [
 	"Answer the binding of some variable resolved in the scope of the receiver without accessing the superclass"
 	| aSymbol binding |
@@ -61,20 +63,20 @@ SharedPool class >> localBindingOf: varName [
 	^nil
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 SharedPool class >> methodsAccessingPoolVariables [
 	"Answer all methods that use one of the variables defined by the shared pool"
 	^ self classVariables flatCollect: [ :variable | variable usingMethods ]
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 SharedPool class >> poolUsers [
 	"Answer all classes that uses the shared pool"
 
 	^ self environment allClasses select: [ :class | class includesSharedPoolNamed: self name ]
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 SharedPool class >> usingMethods [
 	"Answer all methods that reference the Pool the variables defined by the shared pool"
 	^super usingMethods, self methodsAccessingPoolVariables

--- a/src/Kernel/ShouldBeImplemented.class.st
+++ b/src/Kernel/ShouldBeImplemented.class.st
@@ -4,12 +4,14 @@ I am ShouldBeImplemented, an exception signaled when some method should have bee
 This is more like a placeholder during development.
 "
 Class {
-	#name : #ShouldBeImplemented,
-	#superclass : #SelectorException,
-	#category : #'Kernel-Exceptions'
+	#name : 'ShouldBeImplemented',
+	#superclass : 'SelectorException',
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #printing }
+{ #category : 'printing' }
 ShouldBeImplemented >> standardMessageText [
 	"Generate a standard textual description"
 

--- a/src/Kernel/ShouldNotImplement.class.st
+++ b/src/Kernel/ShouldNotImplement.class.st
@@ -4,12 +4,14 @@ I am ShouldNotImplement, an exception signaled when a method was implemented but
 This can happen when an implementation is inherited.
 "
 Class {
-	#name : #ShouldNotImplement,
-	#superclass : #SelectorException,
-	#category : #'Kernel-Exceptions'
+	#name : 'ShouldNotImplement',
+	#superclass : 'SelectorException',
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #printing }
+{ #category : 'printing' }
 ShouldNotImplement >> standardMessageText [
 	"Generate a standard textual description"
 

--- a/src/Kernel/SimulationExceptionWrapper.class.st
+++ b/src/Kernel/SimulationExceptionWrapper.class.st
@@ -2,28 +2,30 @@
 Notify about an exception while simulating an execution
 "
 Class {
-	#name : #SimulationExceptionWrapper,
-	#superclass : #Exception,
+	#name : 'SimulationExceptionWrapper',
+	#superclass : 'Exception',
 	#instVars : [
 		'exception'
 	],
-	#category : #'Kernel-Exceptions'
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #signalling }
+{ #category : 'signalling' }
 SimulationExceptionWrapper class >> signalForException: anError [
 
 	^ self new
 		exception: anError
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SimulationExceptionWrapper >> exception [
 
 	^ exception
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SimulationExceptionWrapper >> exception: anObject [
 
 	exception := anObject

--- a/src/Kernel/Slot.class.st
+++ b/src/Kernel/Slot.class.st
@@ -23,21 +23,23 @@ the Trait I am coming from (that defined me) is stored here.
 
 "
 Class {
-	#name : #Slot,
-	#superclass : #Variable,
+	#name : 'Slot',
+	#superclass : 'Variable',
 	#instVars : [
 		'owningClass',
 		'definingClass'
 	],
-	#category : #'Kernel-Variables'
+	#category : 'Kernel-Variables',
+	#package : 'Kernel',
+	#tag : 'Variables'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Slot class >> asSlot [
 	^ self new
 ]
 
-{ #category : #validating }
+{ #category : 'validating' }
 Slot class >> checkValidName: aSymbol [
 
 	aSymbol startsWithDigit ifTrue: [
@@ -47,58 +49,58 @@ Slot class >> checkValidName: aSymbol [
 		^ InvalidSlotName signalFor: aSymbol ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Slot class >> isUsed [
 	^super isUsed or: [self slotUsers isNotEmpty ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Slot class >> slotUsers [
 	"all classes or traits that have slots of this kind"
 	^self environment allBehaviors
 		select:  [ :class | class slots anySatisfy: [ :slot | slot class == self ] ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 Slot >> acceptVisitor: aProgramNodeVisitor node: aNode [
 	^ aProgramNodeVisitor visitInstanceVariableNode: aNode
 ]
 
-{ #category : #'class building' }
+{ #category : 'class building' }
 Slot >> asClassVariable [
 	self
 		error:
 			'Slots can not be used to define Class Variables, you need to create a LiteralVariable subclass instead'
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Slot >> asSlot [
 	^ self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Slot >> baseSlot [
 	^self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Slot >> definingClass [
 	"if a Slot from a Trait is installed in a class, we store the orginal class of the trait here"
 	^ definingClass ifNil: [ self owningClass ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Slot >> definingClass: aClass [
 	definingClass := aClass
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Slot >> definitionString [
 	"Every subclass that adds state must redefine either this method or #printOn:"
 	^ String streamContents: [:s | self definitionOn: s]
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 Slot >> emitStore: aMethodBuilder [
 	"generate bytecode to call the reflective write method of the Slot"
 	| tempName |
@@ -113,7 +115,7 @@ Slot >> emitStore: aMethodBuilder [
 		send: #writeSlot:value:
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 Slot >> emitValue: aMethodBuilder [
 	aMethodBuilder
 		pushLiteral: self;
@@ -121,7 +123,7 @@ Slot >> emitValue: aMethodBuilder [
 		send: #read:
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Slot >> ensureInitalizeMethodExists: aClass [
 	(aClass includesSelector: #initialize) ifTrue: [ ^ self ].
 
@@ -134,7 +136,7 @@ Slot >> ensureInitalizeMethodExists: aClass [
 				classified: 'initialization' ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Slot >> ensureSlotInitializationFor: aClass [
 	| source |
 	(self sendsInitializeSlots: aClass) ifTrue: [ ^ self ].
@@ -149,7 +151,7 @@ Slot >> ensureSlotInitializationFor: aClass [
 	Author useAuthor: 'Generated' during: [ aClass compile: source classified: 'initialization' ]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Slot >> hasSameDefinitionAs: otherSlot [
 
 	"equal definition. Slots an have additional state that is not part of the definitoon
@@ -158,41 +160,41 @@ Slot >> hasSameDefinitionAs: otherSlot [
 	^self = otherSlot
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Slot >> initialize: instance [
 	"nothing to do for the default slot"
 ]
 
-{ #category : #'class building' }
+{ #category : 'class building' }
 Slot >> installingIn: aClass [
 	"I am called by the class builder. This way a Slot can change the class it is installed in"
 	self wantsInitialization ifTrue: [ self ensureSlotInitializationFor: aClass ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Slot >> isAccessedIn: aCompiledCode [
 	^aCompiledCode ast instanceVariableNodes
 		anySatisfy: [ :node | node binding == self ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Slot >> isDefinedByOwningClass [
 
 	^ self owningClass = self definingClass
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Slot >> isInstanceVariable [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Slot >> isReadIn: aCompiledCode [
 	^aCompiledCode ast instanceVariableReadNodes
 		 anySatisfy: [ :node | node binding == self ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Slot >> isReferenced [
 	^ self owningClass
 		ifNil: [ false ]
@@ -200,46 +202,46 @@ Slot >> isReferenced [
 		  class withAllSubclasses anySatisfy: [ :subclass | subclass hasMethodAccessingVariable: self ] ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Slot >> isSelfEvaluating [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Slot >> isVirtual [
 	"virtual slots do not take up space in the object and have size = 0"
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Slot >> isVisible [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Slot >> isWrittenIn: aCompiledCode [
 	^aCompiledCode ast instanceVariableWriteNodes
 		anySatisfy: [ :node | node binding == self ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Slot >> named: aSymbol [
 	"to be polymorhic with slot class"
 	self name: aSymbol
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Slot >> owningClass [
 	"the class that the slot is installed in"
 	^owningClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Slot >> owningClass: aClass [
 	owningClass := aClass
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Slot >> printOn: aStream [
 	"Every subclass that adds state must redefine either this method or #definitionString"
 	aStream
@@ -248,27 +250,27 @@ Slot >> printOn: aStream [
 		nextPutAll: self class name
 ]
 
-{ #category : #'meta-object-protocol' }
+{ #category : 'meta-object-protocol' }
 Slot >> read: anObject [
 	^ self subclassResponsibility
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 Slot >> readInContext: aContext [
 	^self read: aContext receiver
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Slot >> scope [
 	^ self owningClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Slot >> scope: aScope [
 	"ignored, subclasses can override to analyze the scope they are to be installed in"
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Slot >> sendsInitializeSlots: aClass [
 	(aClass isTrait or: [ aClass includesSelector: #initialize ])
 		ifFalse: [ ^ self sendsInitializeSlots: aClass superclass ].
@@ -286,19 +288,19 @@ Slot >> sendsInitializeSlots: aClass [
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Slot >> size [
 	"normally a slot takes one ivar. Virtual slots do not take space.
 	 We could even have Slots that map to multiple ivars"
 	^self isVirtual ifTrue: [0] ifFalse: [1]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Slot >> storeOn: aStream [
 	^self printOn: aStream
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 Slot >> usingMethods [
 	"All methods that read or write the slot"
 	^self owningClass
@@ -306,18 +308,18 @@ Slot >> usingMethods [
 		ifNotNil: [:class | class allMethodsAccessingSlot: self]
 ]
 
-{ #category : #'meta-object-protocol' }
+{ #category : 'meta-object-protocol' }
 Slot >> wantsInitialization [
 	"if a slot wants to enable instance initalization, return true here"
 	^false
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 Slot >> write: aValue inContext: aContext [
 	^self write: aValue to: aContext receiver
 ]
 
-{ #category : #'meta-object-protocol' }
+{ #category : 'meta-object-protocol' }
 Slot >> write: aValue to: anObject [
 	^self subclassResponsibility
 ]

--- a/src/Kernel/SmallFloat64.class.st
+++ b/src/Kernel/SmallFloat64.class.st
@@ -2,23 +2,25 @@
 My instances represent 64-bit Floats whose exponent fits in 8 bits as immediate objects.  This representation is only available on 64-bit systems, not 32-bit systems.
 "
 Class {
-	#name : #SmallFloat64,
-	#superclass : #Float,
-	#type : #immediate,
-	#category : #'Kernel-Numbers'
+	#name : 'SmallFloat64',
+	#superclass : 'Float',
+	#type : 'immediate',
+	#category : 'Kernel-Numbers',
+	#package : 'Kernel',
+	#tag : 'Numbers'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SmallFloat64 class >> basicNew [
 	self error: 'SmallFloat64s can only be created by performing arithmetic'
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SmallFloat64 class >> basicNew: anInteger [
 	^self basicNew
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 SmallFloat64 >> * aNumber [
 	"Primitive. Answer the result of multiplying the receiver by aNumber.
 	Fail if the argument is not a Float. Essential. See Object documentation
@@ -28,7 +30,7 @@ SmallFloat64 >> * aNumber [
 	^ aNumber adaptToFloat: self andSend: #*
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 SmallFloat64 >> + aNumber [
 	"Primitive. Answer the sum of the receiver and aNumber. Essential.
 	Fail if the argument is not a Float. See Object documentation
@@ -38,7 +40,7 @@ SmallFloat64 >> + aNumber [
 	^ aNumber adaptToFloat: self andSend: #+
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 SmallFloat64 >> - aNumber [
 	"Primitive. Answer the difference between the receiver and aNumber.
 	Fail if the argument is not a Float. Essential. See Object documentation
@@ -48,7 +50,7 @@ SmallFloat64 >> - aNumber [
 	^ aNumber adaptToFloat: self andSend: #-
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 SmallFloat64 >> / aNumber [
 	"Primitive. Answer the result of dividing receiver by aNumber.
 	Fail if the argument is not a Float. Essential. See Object documentation
@@ -59,7 +61,7 @@ SmallFloat64 >> / aNumber [
 	^aNumber adaptToFloat: self andSend: #/
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 SmallFloat64 >> < aNumber [
 	"Primitive. Compare the receiver with the argument and return true
 	if the receiver is less than the argument. Otherwise return false.
@@ -70,7 +72,7 @@ SmallFloat64 >> < aNumber [
 	^ aNumber adaptToFloat: self andCompare: #<
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 SmallFloat64 >> <= aNumber [
 	"Primitive. Compare the receiver with the argument and return true
 	if the receiver is less than or equal to the argument. Otherwise return
@@ -81,7 +83,7 @@ SmallFloat64 >> <= aNumber [
 	^ aNumber adaptToFloat: self andCompare: #<=
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 SmallFloat64 >> = aNumber [
 	"Primitive. Compare the receiver with the argument and return true
 	if the receiver is equal to the argument. Otherwise return false.
@@ -93,7 +95,7 @@ SmallFloat64 >> = aNumber [
 	^ aNumber adaptToFloat: self andCompare: #=
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 SmallFloat64 >> > aNumber [
 	"Primitive. Compare the receiver with the argument and return true
 	if the receiver is greater than the argument. Otherwise return false.
@@ -104,7 +106,7 @@ SmallFloat64 >> > aNumber [
 	^ aNumber adaptToFloat: self andCompare: #>
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 SmallFloat64 >> >= aNumber [
 	"Primitive. Compare the receiver with the argument and return true
 	if the receiver is greater than or equal to the argument. Otherwise return
@@ -115,7 +117,7 @@ SmallFloat64 >> >= aNumber [
 	^ aNumber adaptToFloat: self andCompare: #>=
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 SmallFloat64 >> basicIdentityHash [
 	"Answer an integer unique to the receiver."
 	"primitive 171 is the primitiveImmediateAsInteger primitive that converts SmallIntegers to themselves, Characters to their integer codes, and SmallFloat64 to an integer representing their bits.  e.g.
@@ -130,25 +132,25 @@ SmallFloat64 >> basicIdentityHash [
 	^self primitiveFailed
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 SmallFloat64 >> clone [
 	"Answer the receiver, because SmallFloat64s are unique."
 	^self
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 SmallFloat64 >> copy [
 	"Answer the receiver, because SmallFloat64s are unique."
 	^self
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 SmallFloat64 >> deepCopy [
 	"Answer the receiver, because SmallFloat64s are unique."
 	^self
 ]
 
-{ #category : #'mathematical functions' }
+{ #category : 'mathematical functions' }
 SmallFloat64 >> exp [
 	"Answer E raised to the receiver power.
 	 Optional. See Object documentation whatIsAPrimitive."
@@ -182,7 +184,7 @@ SmallFloat64 >> exp [
 	^ base * correction
 ]
 
-{ #category : #'mathematical functions' }
+{ #category : 'mathematical functions' }
 SmallFloat64 >> exponent [
 	"Primitive. Consider the receiver to be represented as a power of two
 	multiplied by a mantissa (between one and two). Answer with the
@@ -202,7 +204,7 @@ SmallFloat64 >> exponent [
 	^self negated exponent
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 SmallFloat64 >> fractionPart [
 	"Primitive. Answer a Float whose value is the difference between the
 	receiver and the receiver's asInteger value. Optional. See Object
@@ -212,27 +214,27 @@ SmallFloat64 >> fractionPart [
 	^self - self truncated asFloat
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 SmallFloat64 >> identityHash [
 	"We need the override since basicIdentityHash is already in SmallInteger range,
 	 the bitShift: 8 of the super implementation would lead to a LargeInteger"
 	^ self basicIdentityHash
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SmallFloat64 >> isImmediateObject [
 	"This is needed for the bootstrap"
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SmallFloat64 >> isPinnedInMemory [
 	"Immediate instances can't be pinned"
 
 	^ false
 ]
 
-{ #category : #'mathematical functions' }
+{ #category : 'mathematical functions' }
 SmallFloat64 >> ln [
 	"Answer the natural logarithm of the receiver.
 	 Optional. See Object documentation whatIsAPrimitive."
@@ -273,20 +275,20 @@ SmallFloat64 >> ln [
 	"2.718284 ln 1.0"
 ]
 
-{ #category : #'memory scanning' }
+{ #category : 'memory scanning' }
 SmallFloat64 >> nextObject [
 	"SmallFloat64 are immediate objects, and, as such, do not have successors in object memory."
 
 	self shouldNotImplement
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 SmallFloat64 >> shallowCopy [
 	"Answer the receiver, because SmallFloat64s are unique."
 	^self
 ]
 
-{ #category : #'mathematical functions' }
+{ #category : 'mathematical functions' }
 SmallFloat64 >> timesTwoPower: anInteger [
 	"Primitive. Answer with the receiver multiplied by 2.0 raised
 	to the power of the argument.
@@ -300,7 +302,7 @@ SmallFloat64 >> timesTwoPower: anInteger [
 	^ self * (2.0 raisedToInteger: anInteger)
 ]
 
-{ #category : #'truncation and round off' }
+{ #category : 'truncation and round off' }
 SmallFloat64 >> truncated [
 	"Answer with a SmallInteger equal to the value of the receiver without
 	its fractional part. The primitive fails if the truncated value cannot be
@@ -323,13 +325,13 @@ SmallFloat64 >> truncated [
 		ifFalse: [^ self asTrueFraction.  "Extract all bits of the mantissa and shift if necess"]
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 SmallFloat64 >> veryDeepCopyWith: deepCopier [
 	"Answer the receiver, because SmallFloat64s are unique."
 	^self
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 SmallFloat64 >> ~= aNumber [
 	"Primitive. Compare the receiver with the argument and return true
 	if the receiver is not equal to the argument. Otherwise return false.

--- a/src/Kernel/SmallInteger.class.st
+++ b/src/Kernel/SmallInteger.class.st
@@ -8,47 +8,49 @@ Handy guide to the kinds of Integer division:
 - quo:  truncated division, rounded towards zero.
 "
 Class {
-	#name : #SmallInteger,
-	#superclass : #Integer,
-	#type : #immediate,
+	#name : 'SmallInteger',
+	#superclass : 'Integer',
+	#type : 'immediate',
 	#classInstVars : [
 		'minVal',
 		'maxVal'
 	],
-	#category : #'Kernel-Numbers'
+	#category : 'Kernel-Numbers',
+	#package : 'Kernel',
+	#tag : 'Numbers'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SmallInteger class >> basicNew [
 
 	self error: 'SmallIntegers can only be created by performing arithmetic'
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 SmallInteger class >> initialize [
 
 	self startUp: true
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 SmallInteger class >> maxVal [
 	"Answer the maximum value for a SmallInteger."
 	^ maxVal
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 SmallInteger class >> minVal [
 	"Answer the minimum value for a SmallInteger."
 	^ minVal
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SmallInteger class >> new [
 
 	self basicNew	"generates an error"
 ]
 
-{ #category : #'system startup' }
+{ #category : 'system startup' }
 SmallInteger class >> startUp: isImageStarting [
 	"The image is either being newly started (isImageStarting is true), or it's just been snapshotted.
 	 If this has just been a snapshot, skip all the startup stuff."
@@ -62,7 +64,7 @@ SmallInteger class >> startUp: isImageStarting [
 	maxVal := -1 - val
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 SmallInteger >> * aNumber [
 	"Primitive. Multiply the receiver by the argument and answer with the
 	result if it is a SmallInteger. Fail if the argument or the result is not a
@@ -72,7 +74,7 @@ SmallInteger >> * aNumber [
 	^ super * aNumber
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 SmallInteger >> + aNumber [
 	"Primitive. Add the receiver to the argument and answer with the result
 	if it is a SmallInteger. Fail if the argument or the result is not a
@@ -82,7 +84,7 @@ SmallInteger >> + aNumber [
 	^ super + aNumber
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 SmallInteger >> - aNumber [
 	"Primitive. Subtract the argument from the receiver and answer with the
 	result if it is a SmallInteger. Fail if the argument or the result is not a
@@ -93,7 +95,7 @@ SmallInteger >> - aNumber [
 	^super - aNumber
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 SmallInteger >> / aNumber [
 	"Primitive. This primitive (for /) divides the receiver by the argument
 	and returns the result if the division is exact. Fail if the result is not a
@@ -114,7 +116,7 @@ SmallInteger >> / aNumber [
 		ifFalse: [super / aNumber]
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 SmallInteger >> // aNumber [
 	"Primitive. Divide the receiver by the argument and answer with the
 	result. Round the result down towards negative infinity to make it a
@@ -125,7 +127,7 @@ SmallInteger >> // aNumber [
 	^ super // aNumber 	"Do with quo: if primitive fails"
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 SmallInteger >> < aNumber [
 	"Primitive. Compare the receiver with the argument and answer with
 	true if the receiver is less than the argument. Otherwise answer false.
@@ -136,7 +138,7 @@ SmallInteger >> < aNumber [
 	^super < aNumber
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 SmallInteger >> <= aNumber [
 	"Primitive. Compare the receiver with the argument and answer true if
 	the receiver is less than or equal to the argument. Otherwise answer
@@ -147,7 +149,7 @@ SmallInteger >> <= aNumber [
 	^super <= aNumber
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 SmallInteger >> = aNumber [
 	"Primitive. Compare the receiver with the argument and answer true if
 	the receiver is equal to the argument. Otherwise answer false. Fail if the
@@ -158,7 +160,7 @@ SmallInteger >> = aNumber [
 	^super = aNumber
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 SmallInteger >> > aNumber [
 	"Primitive. Compare the receiver with the argument and answer true if
 	the receiver is greater than the argument. Otherwise answer false. Fail if
@@ -169,7 +171,7 @@ SmallInteger >> > aNumber [
 	^super > aNumber
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 SmallInteger >> >= aNumber [
 	"Primitive. Compare the receiver with the argument and answer true if
 	the receiver is greater than or equal to the argument. Otherwise answer
@@ -180,7 +182,7 @@ SmallInteger >> >= aNumber [
 	^super >= aNumber
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 SmallInteger >> \\ aNumber [
 	"Primitive. Take the receiver modulo the argument. The result is the
 	remainder rounded towards negative infinity, of the receiver divided by
@@ -191,13 +193,13 @@ SmallInteger >> \\ aNumber [
 	^ super \\ aNumber 	"will use // to compute it if primitive fails"
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 SmallInteger >> asCharacter [
 	<primitive: 170>
 	^self primitiveFailed
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 SmallInteger >> asFloat [
 	"Primitive. Answer a Float that represents the value of the receiver.
 	Essential. See Object documentation whatIsAPrimitive."
@@ -206,14 +208,14 @@ SmallInteger >> asFloat [
 	self primitiveFailed
 ]
 
-{ #category : #'system primitives' }
+{ #category : 'system primitives' }
 SmallInteger >> basicIdentityHash [
 	"The value answered is signed, within the full
 	 SmallInteger range, on the contrary to normal objects."
 	^self
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 SmallInteger >> bitAnd: arg [
 	"Primitive. Answer an Integer whose bits are the logical AND of the
 	receiver's bits and those of the argument, arg.
@@ -225,7 +227,7 @@ SmallInteger >> bitAnd: arg [
 	^ (self bitInvert bitOr: arg bitInvert) bitInvert
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 SmallInteger >> bitOr: arg [
 	"Primitive. Answer an Integer whose bits are the logical OR of the
 	receiver's bits and those of the argument, arg.
@@ -239,7 +241,7 @@ SmallInteger >> bitOr: arg [
 		ifFalse: [(self bitInvert bitClear: arg) bitInvert]
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 SmallInteger >> bitShift: arg [
 	"Primitive. Answer an Integer whose value is the receiver's value shifted
 	left by the number of bits indicated by the argument. Negative arguments
@@ -253,14 +255,14 @@ SmallInteger >> bitShift: arg [
 		ifFalse: [(self bitInvert bitShift: arg) bitInvert]
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 SmallInteger >> bitStringLength [
       "Always use as many bits as the native format to represent a SmallInteger"
 
       ^self class maxVal highBit + 1
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 SmallInteger >> bitXor: arg [
 	"Primitive. Answer an Integer whose bits are the logical XOR of the
 	receiver's bits and those of the argument, arg.
@@ -274,7 +276,7 @@ SmallInteger >> bitXor: arg [
 		ifFalse: [(self bitInvert bitXor: arg) bitInvert]
 ]
 
-{ #category : #'system primitives' }
+{ #category : 'system primitives' }
 SmallInteger >> byteAt: n [
 	"Answer the value of an apparent byte-indexable field in the receiver,
 	 analogous to the large integers, which are organized as bytes."
@@ -290,14 +292,14 @@ SmallInteger >> byteAt: n [
 		ifFalse: [ (self bitShift: 8 - (n bitShift: 3)) bitAnd: 255 ]
 ]
 
-{ #category : #'system primitives' }
+{ #category : 'system primitives' }
 SmallInteger >> byteAt: n put: value [
 	"Fails. The digits of a small integer can not be modified."
 
 	self error: 'You can''t store in a SmallInteger'
 ]
 
-{ #category : #'system primitives' }
+{ #category : 'system primitives' }
 SmallInteger >> bytesCount [
 	"Answer the number of indexable fields in the receiver. This value is the
 	 same as the largest legal subscript. Included so that a SmallInteger can
@@ -324,7 +326,7 @@ SmallInteger >> bytesCount [
 	^length
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SmallInteger >> decimalDigitLength [
 	"Answer the number of digits printed out in base 10.
 	 Note that this only works for positive SmallIntegers up to 64-bits."
@@ -363,11 +365,11 @@ SmallInteger >> decimalDigitLength [
 										ifFalse: [self < 10000000000000000000 ifTrue: [19] ifFalse: [20]]]]]]
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 SmallInteger >> deepCopy [
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SmallInteger >> even [
 	" 0 even >>> true"
 	" 2 even >>> true"
@@ -378,7 +380,7 @@ SmallInteger >> even [
 	^(self bitAnd: 1) = 0
 ]
 
-{ #category : #'mathematical functions' }
+{ #category : 'mathematical functions' }
 SmallInteger >> gcd: anInteger [
 	"See SmallInteger (Integer) | gcd:"
 	| n m |
@@ -390,7 +392,7 @@ SmallInteger >> gcd: anInteger [
 	^ m abs
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 SmallInteger >> hash [
 
     "Spread consecutive integers or integers related by some other pattern
@@ -399,7 +401,7 @@ SmallInteger >> hash [
     ^ self hashMultiply
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 SmallInteger >> hashMultiply [
 	"This is a multiplication of hashes by 1664525 mod 2^28 written to avoid overflowing into large integers.
 	 The primitive is able to perform the operation with modulo arihmetic.
@@ -417,7 +419,7 @@ SmallInteger >> hashMultiply [
 			bitAnd: 16r0FFFFFFF
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 SmallInteger >> highBit [
 	"Answer the index of the high order bit of the receiver, or zero if the
 	receiver is zero. Raise an error if the receiver is negative, since
@@ -431,7 +433,7 @@ SmallInteger >> highBit [
 	^ self highBitOfPositiveReceiver
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 SmallInteger >> highBitOfMagnitude [
 	"Answer the index of the high order bit of the receiver, or zero if the
 	receiver is zero. This method is used for negative SmallIntegers as well,
@@ -447,7 +449,7 @@ SmallInteger >> highBitOfMagnitude [
 	^self highBitOfPositiveReceiver
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SmallInteger >> highBitOfPositiveReceiver [
 	| shifted bitNo |
 	"Answer the index of the high order bit of the receiver, or zero if the
@@ -468,32 +470,32 @@ SmallInteger >> highBitOfPositiveReceiver [
 	^bitNo + ( #[0 1 2 2 3 3 3 3 4 4 4 4 4 4 4 4 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 6 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8] at: shifted + 1)
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 SmallInteger >> identityHash [
 	"Answer a SmallInteger whose value is related to the receiver's identity.
 	 Specific override here to decrease the number of conflicts"
 	^ self hashMultiply
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SmallInteger >> isImmediateObject [
 	"This is needed for the bootstrap"
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SmallInteger >> isLarge [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SmallInteger >> isPinnedInMemory [
 	"Immediate instances can't be pinned"
 
 	^ false
 ]
 
-{ #category : #'bit manipulation' }
+{ #category : 'bit manipulation' }
 SmallInteger >> lowBit [
 	" Answer the index of the low order one bit.
 	  First we skip bits in groups of 8, then do a lookup in a table.
@@ -515,7 +517,7 @@ SmallInteger >> lowBit [
 	^result + ( #[1 2 1 3 1 2 1 4 1 2 1 3 1 2 1 5 1 2 1 3 1 2 1 4 1 2 1 3 1 2 1 6 1 2 1 3 1 2 1 4 1 2 1 3 1 2 1 5 1 2 1 3 1 2 1 4 1 2 1 3 1 2 1 7 1 2 1 3 1 2 1 4 1 2 1 3 1 2 1 5 1 2 1 3 1 2 1 4 1 2 1 3 1 2 1 6 1 2 1 3 1 2 1 4 1 2 1 3 1 2 1 5 1 2 1 3 1 2 1 4 1 2 1 3 1 2 1 8 1 2 1 3 1 2 1 4 1 2 1 3 1 2 1 5 1 2 1 3 1 2 1 4 1 2 1 3 1 2 1 6 1 2 1 3 1 2 1 4 1 2 1 3 1 2 1 5 1 2 1 3 1 2 1 4 1 2 1 3 1 2 1 7 1 2 1 3 1 2 1 4 1 2 1 3 1 2 1 5 1 2 1 3 1 2 1 4 1 2 1 3 1 2 1 6 1 2 1 3 1 2 1 4 1 2 1 3 1 2 1 5 1 2 1 3 1 2 1 4 1 2 1 3 1 2 1] at: lastByte)
 ]
 
-{ #category : #'system primitives' }
+{ #category : 'system primitives' }
 SmallInteger >> nextInstance [
 	"SmallIntegers can't be enumerated this way.  There are a finite number of them from from (SmallInteger minVal) to (SmallInteger maxVal), but you'll have to enumerate them yourself with:
 	(SmallInteger minVal) to: (SmallInteger maxVal) do: [:integer | <your code here>].
@@ -524,14 +526,14 @@ SmallInteger >> nextInstance [
 	self shouldNotImplement
 ]
 
-{ #category : #'system primitives' }
+{ #category : 'system primitives' }
 SmallInteger >> nextObject [
 	"SmallIntegers are immediate objects, and, as such, do not have successors in object memory."
 
 	self shouldNotImplement
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SmallInteger >> numberOfDigitsInBase: b [
 	"Return how many digits are necessary to print this number in base b.
 	Mostly same as super but an optimized version for base 10 case"
@@ -541,7 +543,7 @@ SmallInteger >> numberOfDigitsInBase: b [
 	^self decimalDigitLength
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SmallInteger >> odd [
 	" 0 odd >>> false"
 	" 2 odd >>> false"
@@ -551,20 +553,20 @@ SmallInteger >> odd [
 	^(self bitAnd: 1) = 1
 ]
 
-{ #category : #pointers }
+{ #category : 'pointers' }
 SmallInteger >> pointsTo: anObject [
 	"Answers true if I hold a reference to anObject, or false otherwise. But since SmallIntegers do not have pointers, it always answers false"
 	^false
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SmallInteger >> printOn: stream base: base [
 	"Append a representation of this number in base b on aStream."
 
 	self printOn: stream base: base length: 0 padded: false
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SmallInteger >> printOn: stream base: base length: minimumLength padded: padWithZeroes [
 	"Return a String representation of this number in base b with a minimum length and padded by 0 if zeroFlag is set"
 
@@ -599,7 +601,7 @@ SmallInteger >> printOn: stream base: base length: minimumLength padded: padWith
 		divisor := divisor // base ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SmallInteger >> printOn: aStream base: b nDigits: n [
 	"Append a representation of this number in base b on aStream using nDigits.
 	self must be positive."
@@ -607,7 +609,7 @@ SmallInteger >> printOn: aStream base: b nDigits: n [
 	self printOn: aStream base: b length: n padded: true
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SmallInteger >> printString [
 	"Highly optimized version for base 10
 	and that we know it is a SmallInteger.
@@ -627,7 +629,7 @@ SmallInteger >> printString [
 	^result
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SmallInteger >> printStringBase: b [
 	"Return a String representation of this number in base b.
 	For SmallIntegers, it is more efficient to print directly in a String,
@@ -647,7 +649,7 @@ SmallInteger >> printStringBase: b [
 	^ self printStringBase: b nDigits: (self numberOfDigitsInBase: b)
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SmallInteger >> printStringBase: b nDigits: n [
 	"Return a string representation of this number in base b with n digits (left padded with 0).
 	Should be invoked with: 0 <= self < (b raisedToInteger: n)."
@@ -662,7 +664,7 @@ SmallInteger >> printStringBase: b nDigits: n [
 	^result
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 SmallInteger >> quo: aNumber [
 	"Primitive. Divide the receiver by the argument and answer with the
 	result. Round the result down towards zero to make it a whole integer.
@@ -678,16 +680,16 @@ SmallInteger >> quo: aNumber [
 	self primitiveFailed
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 SmallInteger >> shallowCopy [
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 SmallInteger >> veryDeepCopyWith: deepCopier [
 	"Return self.  I can't be copied.  Do not record me."
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 SmallInteger >> ~= aNumber [
 	"Primitive. Compare the receiver with the argument and answer true if
 	the receiver is not equal to the argument. Otherwise answer false. Fail if

--- a/src/Kernel/SubclassResponsibility.class.st
+++ b/src/Kernel/SubclassResponsibility.class.st
@@ -2,12 +2,14 @@
 I am SubclassResponsibility, an exception signaled when an inherited method should have been implemented in a subclass but was not.
 "
 Class {
-	#name : #SubclassResponsibility,
-	#superclass : #SelectorException,
-	#category : #'Kernel-Exceptions'
+	#name : 'SubclassResponsibility',
+	#superclass : 'SelectorException',
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #printing }
+{ #category : 'printing' }
 SubclassResponsibility >> standardMessageText [
 	"Generate a standard textual description"
 

--- a/src/Kernel/SubscriptOutOfBounds.class.st
+++ b/src/Kernel/SubscriptOutOfBounds.class.st
@@ -10,17 +10,19 @@ SubscriptOutOfBounds
 	in: (Array new: 5)
 "
 Class {
-	#name : #SubscriptOutOfBounds,
-	#superclass : #Error,
+	#name : 'SubscriptOutOfBounds',
+	#superclass : 'Error',
 	#instVars : [
 		'subscript',
 		'lowerBound',
 		'upperBound'
 	],
-	#category : #'Kernel-Exceptions'
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #signaling }
+{ #category : 'signaling' }
 SubscriptOutOfBounds class >> signalFor: subscript [
 	^ self
 		signalFor: subscript
@@ -28,7 +30,7 @@ SubscriptOutOfBounds class >> signalFor: subscript [
 		upperBound: nil
 ]
 
-{ #category : #signaling }
+{ #category : 'signaling' }
 SubscriptOutOfBounds class >> signalFor: subscript lowerBound: lowerBound upperBound: upperBound [
 	^ self
 		signalFor: subscript
@@ -37,7 +39,7 @@ SubscriptOutOfBounds class >> signalFor: subscript lowerBound: lowerBound upperB
 		in: nil
 ]
 
-{ #category : #signaling }
+{ #category : 'signaling' }
 SubscriptOutOfBounds class >> signalFor: subscript lowerBound: lowerBound upperBound: upperBound in: object [
 	^ self new
 		signaler: object;
@@ -47,24 +49,24 @@ SubscriptOutOfBounds class >> signalFor: subscript lowerBound: lowerBound upperB
 		signal
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SubscriptOutOfBounds >> lowerBound [
 	^ lowerBound
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SubscriptOutOfBounds >> lowerBound: anObject [
 	lowerBound := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SubscriptOutOfBounds >> messageText [
 	"Overwritten to initialiaze the message text to a standard text if it has not yet been set"
 
 	^ messageText ifNil: [ messageText := self standardMessageText ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SubscriptOutOfBounds >> standardMessageText [
 	"Generate a standard textual description"
 
@@ -84,22 +86,22 @@ SubscriptOutOfBounds >> standardMessageText [
 				  print: self signaler ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SubscriptOutOfBounds >> subscript [
 	^ subscript
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SubscriptOutOfBounds >> subscript: anObject [
 	subscript := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SubscriptOutOfBounds >> upperBound [
 	^ upperBound
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SubscriptOutOfBounds >> upperBound: anObject [
 	upperBound := anObject
 ]

--- a/src/Kernel/SuperVariable.class.st
+++ b/src/Kernel/SuperVariable.class.st
@@ -2,40 +2,42 @@
 I model ""super""
 "
 Class {
-	#name : #SuperVariable,
-	#superclass : #PseudoVariable,
-	#category : #'Kernel-Variables'
+	#name : 'SuperVariable',
+	#superclass : 'PseudoVariable',
+	#category : 'Kernel-Variables',
+	#package : 'Kernel',
+	#tag : 'Variables'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SuperVariable class >> variableName [
 	^#super
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 SuperVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 	^ aProgramNodeVisitor visitSuperNode: aNode
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 SuperVariable >> emitValue: methodBuilder [
 	"super references the receiver, send that follows is a super send (the message lookup starts in the superclass, see OCASTTranslator>>#emitMessageNode:)"
 	methodBuilder pushReceiver
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SuperVariable >> isSuperVariable [
 	^true
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 SuperVariable >> readInContext: aContext [
 	"super in a block is the receiver of the home context
 	For clean blocks it might not be known (nil)"
 	^aContext home ifNotNil: [:home | home receiver ]
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 SuperVariable >> usingMethods [
 	"As super is just a push Self, this detects real super sends, not accesses to super which should never happen"
 	^ environment allMethods select: [ :method |

--- a/src/Kernel/SystemNotification.class.st
+++ b/src/Kernel/SystemNotification.class.st
@@ -2,12 +2,14 @@
 I am a notification that informs user aboout some important operation that the system did. 
 "
 Class {
-	#name : #SystemNotification,
-	#superclass : #Notification,
-	#category : #'Kernel-Exceptions'
+	#name : 'SystemNotification',
+	#superclass : 'Notification',
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #exceptiondescription }
+{ #category : 'exceptiondescription' }
 SystemNotification >> defaultAction [
 
 	UIManager default systemNotificationDefaultAction: self

--- a/src/Kernel/ThisContextVariable.class.st
+++ b/src/Kernel/ThisContextVariable.class.st
@@ -2,38 +2,40 @@
 I model thisContext
 "
 Class {
-	#name : #ThisContextVariable,
-	#superclass : #PseudoVariable,
-	#category : #'Kernel-Variables'
+	#name : 'ThisContextVariable',
+	#superclass : 'PseudoVariable',
+	#category : 'Kernel-Variables',
+	#package : 'Kernel',
+	#tag : 'Variables'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ThisContextVariable class >> variableName [
 	^#thisContext
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 ThisContextVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 	^ aProgramNodeVisitor visitThisContextNode: aNode
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 ThisContextVariable >> emitValue: methodBuilder [
 
 	methodBuilder pushThisContext
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ThisContextVariable >> isThisContextVariable [
 	^true
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 ThisContextVariable >> readInContext: aContext [
 	^aContext
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 ThisContextVariable >> usingMethods [
 	^ environment allMethods select: [ :method |
 		  method readsThisContext ]

--- a/src/Kernel/ThisProcessVariable.class.st
+++ b/src/Kernel/ThisProcessVariable.class.st
@@ -2,28 +2,30 @@
 I model thisProcess
 "
 Class {
-	#name : #ThisProcessVariable,
-	#superclass : #PseudoVariable,
-	#category : #'Kernel-Variables'
+	#name : 'ThisProcessVariable',
+	#superclass : 'PseudoVariable',
+	#category : 'Kernel-Variables',
+	#package : 'Kernel',
+	#tag : 'Variables'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ThisProcessVariable class >> variableName [
 	^#thisProcess
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 ThisProcessVariable >> emitValue: methodBuilder [
 
 	methodBuilder pushThisProcess 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ThisProcessVariable >> isThisProcessVariable [
 	^true
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 ThisProcessVariable >> readInContext: aContext [
 	"We expect this method to be called either from the same process or by debugger process that will read the correct process. Otherwise we cannot guarantee to read the correct process"
 	^ Processor activeProcess

--- a/src/Kernel/Time.class.st
+++ b/src/Kernel/Time.class.st
@@ -5,8 +5,8 @@ If you need a point in time on a particular day, use DateAndTime.  If you need a
 
 "
 Class {
-	#name : #Time,
-	#superclass : #Magnitude,
+	#name : 'Time',
+	#superclass : 'Magnitude',
 	#instVars : [
 		'seconds',
 		'nanos'
@@ -14,16 +14,18 @@ Class {
 	#pools : [
 		'ChronologyConstants'
 	],
-	#category : #'Kernel-Chronology'
+	#category : 'Kernel-Chronology',
+	#package : 'Kernel',
+	#tag : 'Chronology'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Time class >> current [
 
 	^ self now
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Time class >> fromSeconds: secondCount [
 	"Answer an instance of me that is secondCount number of seconds since midnight."
 
@@ -35,21 +37,21 @@ Time class >> fromSeconds: secondCount [
 	^ self seconds: integerSeconds nanoSeconds: nanos
 ]
 
-{ #category : #primitives }
+{ #category : 'primitives' }
 Time class >> microsecondClockValue [
 	"Answer the number of microseconds since Epoch"
 
 	^self primUTCMicrosecondsClock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Time class >> microsecondsSince: lastTimeInMicroSeconds [
  	"Answer the elapsed time since last recorded in microseconds"
 
  	^self microsecondClockValue - lastTimeInMicroSeconds
 ]
 
-{ #category : #'general inquiries' }
+{ #category : 'general inquiries' }
 Time class >> microsecondsToRun: timedBlock [
 	"Answer the number of milliseconds timedBlock takes to return its value."
 
@@ -59,7 +61,7 @@ Time class >> microsecondsToRun: timedBlock [
 	^self microsecondClockValue - initialMicroseconds
 ]
 
-{ #category : #primitives }
+{ #category : 'primitives' }
 Time class >> millisecondClockValue [
 	"Answer the number of milliseconds since the millisecond clock was last reset or rolled over.
 	Answer 0 if the primitive fails."
@@ -68,21 +70,21 @@ Time class >> millisecondClockValue [
 	^ 0
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Time class >> new [
 	"Answer a Time representing midnight"
 
 	^ self midnight
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Time class >> now [
 	"Answer a Time representing the time right now - this is a 24 hour clock."
 
 	^ self nowLocal
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Time class >> nowLocal [
 	"Answer the time since midnight in local timezone"
 
@@ -93,7 +95,7 @@ Time class >> nowLocal [
 		nanoSeconds: microSecondsToday \\ 1000000 * 1000
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Time class >> nowUTC [
 	"Answer the time since midnight in UTC timezone"
 
@@ -104,7 +106,7 @@ Time class >> nowUTC [
 		nanoSeconds: microSecondsToday \\ 1000000 * 1000
 ]
 
-{ #category : #primitives }
+{ #category : 'primitives' }
 Time class >> primMillisecondClock [
 	"Primitive. Answer the number of milliseconds since the millisecond clock
 	 was last reset or rolled over. Answer zero if the primitive fails.
@@ -114,7 +116,7 @@ Time class >> primMillisecondClock [
 	^ 0
 ]
 
-{ #category : #primitives }
+{ #category : 'primitives' }
 Time class >> primUTCMicrosecondsClock [
 	"Answer the number of micro-seconds ellapsed since epoch.
 	That is since 00:00 on the morning of January 1, 1901 UTC.
@@ -125,7 +127,7 @@ Time class >> primUTCMicrosecondsClock [
 	self primitiveFailed
 ]
 
-{ #category : #primitives }
+{ #category : 'primitives' }
 Time class >> primUTCMillisecondsClock [
 	"Answer the number of whole milliseconds ellapsed since epoch.
 	That is since 00:00 on the morning of January 1, 1901 UTC"
@@ -133,7 +135,7 @@ Time class >> primUTCMillisecondsClock [
 	^self primUTCMicrosecondsClock // 1e3
 ]
 
-{ #category : #primitives }
+{ #category : 'primitives' }
 Time class >> primUTCSecondsClock [
 	"Answer the number of whole seconds ellapsed since epoch.
 	That is since 00:00 on the morning of January 1, 1901 UTC"
@@ -141,14 +143,14 @@ Time class >> primUTCSecondsClock [
 	^self primUTCMicrosecondsClock // 1e6
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Time class >> seconds: seconds [
 	"Answer a Time from midnight."
 	TimeError validateSeconds: seconds andNanos: 0.
 	^ self basicNew ticks: (Duration seconds: seconds) ticks
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Time class >> seconds: seconds nanoSeconds: nanoCount [
 	"Answer a Time from midnight."
 	TimeError validateSeconds: seconds andNanos: nanoCount.
@@ -156,7 +158,7 @@ Time class >> seconds: seconds nanoSeconds: nanoCount [
 		ticks: (Duration seconds: seconds nanoSeconds: nanoCount) ticks
 ]
 
-{ #category : #clock }
+{ #category : 'clock' }
 Time class >> secondsWhenClockTicks [
 
 	"waits for the moment when a new second begins"
@@ -169,34 +171,34 @@ Time class >> secondsWhenClockTicks [
 	^ lastSecond + 1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Time class >> totalSeconds [
 	"Answer the total seconds ellapsed since the epoch: 1 January 1901 00:00 UTC"
 
 	^ self primUTCSecondsClock
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Time >> < aTime [
 
 	^ self asDuration < aTime asDuration
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Time >> = aTime [
 
 	^ [ self ticks = aTime ticks ]
 		on: MessageNotUnderstood do: [false]
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 Time >> addSeconds: nSeconds [
 	"Answer a Time that is nSeconds after the receiver."
 
 	^ self class seconds: self asSeconds + nSeconds
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 Time >> addTime: timeAmount [
  	"Answer a Time that is timeInterval after the receiver. timeInterval is an
  	instance of Date or Time."
@@ -204,83 +206,83 @@ Time >> addTime: timeAmount [
  	^ self class seconds: self asSeconds + timeAmount asSeconds
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Time >> asDate [
 
 	^ Date today
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Time >> asDateAndTime [
 
 	^ DateAndTime today + self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Time >> asDuration [
 	"Answer the duration since midnight"
 
 	^ Duration seconds: seconds nanoSeconds: nanos
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Time >> asMilliSeconds [
 	"Answer the number of milliseconds since midnight"
 
 	^ self asDuration asMilliSeconds
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Time >> asMonth [
 
 	^ self asDateAndTime asMonth
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Time >> asNanoSeconds [
 	"Answer the number of nanoseconds since midnight"
 
 	^ self asDuration asNanoSeconds
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Time >> asSeconds [
  	"Answer the number of seconds since midnight of the receiver."
 
  	^ seconds
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Time >> asTime [
 
 	^ self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Time >> asWeek [
 
 	^ self asDateAndTime asWeek
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Time >> asYear [
 
 	^ self asDateAndTime asYear
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Time >> duration [
 
 	^ Duration zero
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Time >> hash [
 
 	^ self ticks hash
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Time >> hhmm24 [
  	"Return a string of the form 1123 (for 11:23 am), 2154 (for 9:54 pm), of exactly 4 digits"
 
@@ -289,20 +291,20 @@ Time >> hhmm24 [
 		self minute printOn: aStream base: 10 length: 2 padded: true ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Time >> hour [
 
 	^ self hour24
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Time >> hour12 [
  	"Answer an <integer> between 1 and 12, inclusive, representing the hour
  	of the day in the 12-hour clock of the local time of the receiver."
 	^ self hour24 - 1 \\ 12 + 1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Time >> hour24 [
 	"Answer a number that represents the number of complete hours in the receiver,
 	after the number of complete days has been removed."
@@ -310,13 +312,13 @@ Time >> hour24 [
  	^ (seconds rem: SecondsInDay) quo: SecondsInHour
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Time >> hours [
 
 	^ self hour
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Time >> intervalString [
 	"Treat the time as a difference.  Give it in hours and minutes with two digits of accuracy."
 
@@ -328,13 +330,13 @@ Time >> intervalString [
 		d seconds > 0 ifTrue: [s space; print: d seconds; nextPutAll: ' seconds'] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Time >> meridianAbbreviation [
 
 	^ self hour < 12 ifTrue: ['AM'] ifFalse: ['PM']
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Time >> minute [
 	"Answer a number that represents the number of complete minutes in the receiver,
 	after the number of complete hours has been removed."
@@ -342,19 +344,19 @@ Time >> minute [
 	^ (seconds rem: SecondsInHour) quo: SecondsInMinute
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Time >> minutes [
 
 	^ self asDuration minutes
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Time >> nanoSecond [
 
 	^ nanos
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Time >> print24 [
  	"Return as 8-digit string 'hh:mm:ss', with leading zeros if needed"
 
@@ -362,7 +364,7 @@ Time >> print24 [
 		self print24: true on: aStream ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Time >> print24: hr24 on: aStream [
  	"Format is 'hh:mm:ss' or 'h:mm:ss am' "
 
@@ -386,7 +388,7 @@ Time >> print24: hr24 on: aStream [
 	hr24 ifFalse: [ aStream nextPutAll: (h < 12 ifTrue: [ ' am' ] ifFalse: [ ' pm' ]) ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Time >> print24: hr24 showSeconds: showSeconds on: aStream [
 	"Format is 'hh:mm:ss.nnnnnnnnn' or 'h:mm:ss.nnnnnnnnn am'  or, if showSeconds is false, 'hh:mm' or 'h:mm am'"
 
@@ -418,7 +420,7 @@ Time >> print24: hr24 showSeconds: showSeconds on: aStream [
 	hr24 ifFalse: [ aStream nextPutAll: (h < 12 ifTrue: [ ' am' ] ifFalse: [ ' pm' ]) ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Time >> printMinutes [
  	"Return as string 'hh:mm pm'  "
 
@@ -426,7 +428,7 @@ Time >> printMinutes [
 		self print24: false showSeconds: false on: aStream ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Time >> printOn: aStream [
 
 	self
@@ -435,7 +437,7 @@ Time >> printOn: aStream [
 		on: aStream
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Time >> second [
 	"Answer a number that represents the number of complete seconds in the receiver,
 	after the number of complete minutes has been removed."
@@ -443,13 +445,13 @@ Time >> second [
  	^ (seconds rem: SecondsInMinute)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Time >> seconds [
 
 	^ self second
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Time >> seconds: secondCount [
 	"Private - only used by Time class."
 	TimeError validateSeconds: secondCount andNanos: 0.
@@ -457,7 +459,7 @@ Time >> seconds: secondCount [
 	nanos := 0
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Time >> seconds: secondCount nanoSeconds: nanoCount [
 	"Private - only used by Time class."
 	TimeError validateSeconds: secondCount andNanos: nanoCount.
@@ -465,13 +467,13 @@ Time >> seconds: secondCount nanoSeconds: nanoCount [
 	nanos := nanoCount
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Time >> storeOn: aStream [
 
  	aStream print: self printString; nextPutAll: ' asTime'
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 Time >> subtractTime: timeAmount [
 	"Answer a Time that is timeInterval before the receiver. timeInterval is
 	an instance of Date or Time."
@@ -479,14 +481,14 @@ Time >> subtractTime: timeAmount [
 	^ self class seconds: self asSeconds - timeAmount asSeconds
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Time >> ticks [
 	"Answer an Array: { seconds. nanoSeconds }"
 
 	^ Array with: 0 with: seconds with: nanos
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Time >> ticks: anArray [
 	"ticks is an Array: { days. seconds. nanoSeconds }"
 	TimeError validateSeconds: (anArray at: 2) andNanos: (anArray at: 3).

--- a/src/Kernel/TimeError.class.st
+++ b/src/Kernel/TimeError.class.st
@@ -2,12 +2,14 @@
 I am an error thrown if Time expands outside a 24 hour range.
 "
 Class {
-	#name : #TimeError,
-	#superclass : #Error,
-	#category : #'Kernel-Chronology'
+	#name : 'TimeError',
+	#superclass : 'Error',
+	#category : 'Kernel-Chronology',
+	#package : 'Kernel',
+	#tag : 'Chronology'
 }
 
-{ #category : #validation }
+{ #category : 'validation' }
 TimeError class >> validateSeconds: seconds andNanos: nano [
 	"Signal an error if seconds are outside 24 hours, or nano is larger than a second"
 	(seconds between: 0 and: "24*60*60-1" 86399)

--- a/src/Kernel/TimeZone.class.st
+++ b/src/Kernel/TimeZone.class.st
@@ -9,8 +9,8 @@ TimeZone class >> #timeZones returns an array of the known time zones
 TimeZone class >> #default returns the default time zone (Grenwich Mean Time)
 "
 Class {
-	#name : #TimeZone,
-	#superclass : #AbstractTimeZone,
+	#name : 'TimeZone',
+	#superclass : 'AbstractTimeZone',
 	#instVars : [
 		'offset',
 		'abbreviation',
@@ -19,17 +19,19 @@ Class {
 	#pools : [
 		'ChronologyConstants'
 	],
-	#category : #'Kernel-Chronology'
+	#category : 'Kernel-Chronology',
+	#package : 'Kernel',
+	#tag : 'Chronology'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TimeZone class >> abbreviated: aString [
  	"Return the timezone whose abbreviation is aString."
  	^ self timeZones detect: [ :timeZone |
 		timeZone abbreviation = aString ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TimeZone class >> default [
  	"Answer the default time zone - GMT"
 
@@ -37,12 +39,12 @@ TimeZone class >> default [
 		timeZone offset = Duration zero ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TimeZone class >> local [
 	^ LocalTimeZone new
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TimeZone class >> offset: aDuration [
  	"Return the timezone with the given offset
 
@@ -53,7 +55,7 @@ TimeZone class >> offset: aDuration [
 		ifNone: [ self new offset: aDuration ]
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 TimeZone class >> offset: aDuration name: aName abbreviation: anAbbreviation [
 
  	^ self new
@@ -63,7 +65,7 @@ TimeZone class >> offset: aDuration name: aName abbreviation: anAbbreviation [
  		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TimeZone class >> timeZones [
 
 	^ {
@@ -82,37 +84,37 @@ TimeZone class >> timeZones [
 	}
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TimeZone >> abbreviation [
 
  	^ abbreviation
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TimeZone >> abbreviation: aString [
 
 	abbreviation := aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TimeZone >> name [
 
  	^ name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TimeZone >> name: aString [
 
 	name := aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TimeZone >> offset [
 
  	^ offset
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TimeZone >> offset: aDuration [
 
 	offset := aDuration

--- a/src/Kernel/TimedOut.class.st
+++ b/src/Kernel/TimedOut.class.st
@@ -6,7 +6,9 @@ I am signalled by a watchdog process spawned by #duration:timeoutDo: and caught 
 I am not intended to be used elsewhere.
 "
 Class {
-	#name : #TimedOut,
-	#superclass : #Notification,
-	#category : #'Kernel-Exceptions'
+	#name : 'TimedOut',
+	#superclass : 'Notification',
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }

--- a/src/Kernel/Timespan.class.st
+++ b/src/Kernel/Timespan.class.st
@@ -3,35 +3,37 @@ I represent a duration starting on a specific DateAndTime.
 
 "
 Class {
-	#name : #Timespan,
-	#superclass : #Magnitude,
+	#name : 'Timespan',
+	#superclass : 'Magnitude',
 	#instVars : [
 		'start',
 		'duration'
 	],
-	#category : #'Kernel-Chronology'
+	#category : 'Kernel-Chronology',
+	#package : 'Kernel',
+	#tag : 'Chronology'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Timespan class >> current [
 
 	^ self starting: DateAndTime now
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Timespan class >> new [
 	"Answer a Timespan starting on the epoch: 1 January 1901"
 
 	^ self starting: DateAndTime new
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Timespan class >> starting: aDateAndTime [
 
 	^ self starting: aDateAndTime duration: Duration zero
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Timespan class >> starting: aDateAndTime duration: aDuration [
 
 	^ self basicNew
@@ -40,7 +42,7 @@ Timespan class >> starting: aDateAndTime duration: aDuration [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Timespan class >> starting: startDateAndTime ending: endDateAndTime [
 
 	^ self
@@ -48,14 +50,14 @@ Timespan class >> starting: startDateAndTime ending: endDateAndTime [
 		duration: (endDateAndTime asDateAndTime - startDateAndTime)
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Timespan >> + operand [
 	"operand conforms to protocol Duration"
 
 	^ self species starting: (self start + operand) duration: self duration
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Timespan >> - operand [
 	"operand conforms to protocol DateAndTime or protocol Duration"
 
@@ -64,112 +66,112 @@ Timespan >> - operand [
 	 	ifFalse: [ self + (operand negated) ]
 ]
 
-{ #category : #arithmetic }
+{ #category : 'arithmetic' }
 Timespan >> < comparand [
 
 	^ self start < comparand
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Timespan >> = comparand [
 	^ self species = comparand species
 		and: [ self start = comparand start
 				and: [ self duration = comparand duration ]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Timespan >> asDate [
 
 	^ start asDate
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Timespan >> asDateAndTime [
 
 	^ start
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Timespan >> asDuration [
 
 	^ self duration
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Timespan >> asSeconds [
  	"Answer the seconds since the epoch: 1 January 1901"
 
  	^ start asSeconds
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Timespan >> asTime [
 
 	^ start asTime
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Timespan >> dayOfMonth [
 	"Answer the day of the month represented by the receiver."
 
 	^ start dayOfMonth
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Timespan >> duration [
  	"Answer the Duration of this timespan"
 
 	^ duration
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Timespan >> duration: aDuration [
 	"Set the Duration of this timespan"
 
 	duration := aDuration
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Timespan >> hash [
 
 	^ start hash + duration hash
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Timespan >> julianDayNumber [
 
 	^ start julianDayNumber
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Timespan >> julianDayNumberUTC [
 	^ start julianDayNumberUTC
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Timespan >> month [
 
 	^ start month
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Timespan >> monthIndex [
 
 	^ self month
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Timespan >> next [
 
 	^ self class starting: (start + duration) duration: duration
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Timespan >> offset [
 	^ start offset
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Timespan >> offset: anOffset [
 	"Answer a <Timespan> equivalent to the receiver but with its local time
 	being offset from UTC by offset.
@@ -180,13 +182,13 @@ Timespan >> offset: anOffset [
 		duration: self duration
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Timespan >> previous [
 
 	^ self class starting: (start - duration) duration: duration
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Timespan >> printOn: aStream [
 
 	super printOn: aStream.
@@ -198,21 +200,21 @@ Timespan >> printOn: aStream [
 		nextPut: $)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Timespan >> start [
  	"Answer the start DateAndTime of this timespan"
 
 	^ start
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Timespan >> start: aDateAndTime [
 	"Store the start DateAndTime of this timespan"
 
 	start := aDateAndTime asDateAndTime
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Timespan >> year [
 
 	^ start year

--- a/src/Kernel/True.class.st
+++ b/src/Kernel/True.class.st
@@ -4,12 +4,14 @@ True defines the behavior of its single instance, true -- logical assertion. Not
 Be aware however that most of these methods are not sent as real messages in normal use. Most are inline coded by the compiler as test and jump bytecodes - avoiding the overhead of the full message sends. So simply redefining these methods here will have no effect.
 "
 Class {
-	#name : #True,
-	#superclass : #Boolean,
-	#category : #'Kernel-Objects'
+	#name : 'True',
+	#superclass : 'Boolean',
+	#category : 'Kernel-Objects',
+	#package : 'Kernel',
+	#tag : 'Objects'
 }
 
-{ #category : #'logical operations' }
+{ #category : 'logical operations' }
 True >> & aBoolean [
 	"Evaluating conjunction -- answer aBoolean since receiver is true."
 	"true & true >>> true"
@@ -18,7 +20,7 @@ True >> & aBoolean [
 	^aBoolean
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 True >> and: alternativeBlock [
 	"Nonevaluating conjunction -- answer the value of alternativeBlock since
 	the receiver is true."
@@ -28,7 +30,7 @@ True >> and: alternativeBlock [
 	^ alternativeBlock value
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 True >> asBit [
 	"Answer 1 since receiver is true."
 	"true asBit >>> 1"
@@ -36,7 +38,7 @@ True >> asBit [
 	^ 1
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 True >> ifFalse: alternativeBlock [
 	"Since the condition is true, the value is the true alternative, which is nil.
 	Execution does not actually reach here because the expression is compiled
@@ -46,7 +48,7 @@ True >> ifFalse: alternativeBlock [
 	^nil
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 True >> ifFalse: falseAlternativeBlock ifTrue: trueAlternativeBlock [
 	"Answer the value of trueAlternativeBlock. Execution does not
 	actually reach here because the expression is compiled in-line."
@@ -55,7 +57,7 @@ True >> ifFalse: falseAlternativeBlock ifTrue: trueAlternativeBlock [
 	^trueAlternativeBlock value
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 True >> ifTrue: alternativeBlock [
 	"Answer the value of alternativeBlock. Execution does not actually
 	reach here because the expression is compiled in-line."
@@ -64,7 +66,7 @@ True >> ifTrue: alternativeBlock [
 	^alternativeBlock value
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 True >> ifTrue: trueAlternativeBlock ifFalse: falseAlternativeBlock [
 	"Answer with the value of trueAlternativeBlock. Execution does not
 	actually reach here because the expression is compiled in-line."
@@ -73,7 +75,7 @@ True >> ifTrue: trueAlternativeBlock ifFalse: falseAlternativeBlock [
 	^trueAlternativeBlock value
 ]
 
-{ #category : #'logical operations' }
+{ #category : 'logical operations' }
 True >> not [
 	"Negation--answer false since the receiver is true."
 	"true not >>> false"
@@ -81,7 +83,7 @@ True >> not [
 	^false
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 True >> or: alternativeBlock [
 	"Nonevaluating disjunction -- answer true since the receiver is true."
 	"(true or: [Error signal]) >>> true"
@@ -90,13 +92,13 @@ True >> or: alternativeBlock [
 	^ self
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 True >> printOn: aStream [
 
 	aStream nextPutAll: 'true'
 ]
 
-{ #category : #'logical operations' }
+{ #category : 'logical operations' }
 True >> xor: alternativeBlock [
 	"Nonevaluating conjunction. Answer the opposite of the
 	the argument, alternativeBlock; since the receiver is true."
@@ -106,7 +108,7 @@ True >> xor: alternativeBlock [
 	^ alternativeBlock value not
 ]
 
-{ #category : #'logical operations' }
+{ #category : 'logical operations' }
 True >> | aBoolean [
 	"Evaluating disjunction (OR) -- answer true since the receiver is true."
 	"true | true >>> true"

--- a/src/Kernel/UndeclaredVariable.class.st
+++ b/src/Kernel/UndeclaredVariable.class.st
@@ -6,12 +6,14 @@ The compiler forwards bytecode generation to me for accessing the variable.
 In future I can profice logging and user warning when evaluated code accesses undeclared variables
 "
 Class {
-	#name : #UndeclaredVariable,
-	#superclass : #LiteralVariable,
-	#category : #'Kernel-Variables'
+	#name : 'UndeclaredVariable',
+	#superclass : 'LiteralVariable',
+	#category : 'Kernel-Variables',
+	#package : 'Kernel',
+	#tag : 'Variables'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 UndeclaredVariable class >> possiblyRegisteredWithName: aString [
 
 	"Get a registered undeclared variable if any, or a new unregistered undeclared variable"
@@ -29,7 +31,7 @@ UndeclaredVariable class >> possiblyRegisteredWithName: aString [
 	^self named: varName
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 UndeclaredVariable class >> registeredWithName: aString [
 
 	| var |
@@ -38,13 +40,13 @@ UndeclaredVariable class >> registeredWithName: aString [
 	^ var
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 UndeclaredVariable >> definingClass [
 	"Nobody defines undeclared variable"
 	^nil
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 UndeclaredVariable >> emitStore: aMethodBuilder [
 	| tempName |
 	"Swap implementation comes from the superclass"
@@ -58,30 +60,30 @@ UndeclaredVariable >> emitStore: aMethodBuilder [
 		send: #runtimeUndeclaredWrite:
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 UndeclaredVariable >> emitValue: aMethodBuilder [
 	aMethodBuilder
 		pushLiteral: self;
 		send: #runtimeUndeclaredRead
 ]
 
-{ #category : #registry }
+{ #category : 'registry' }
 UndeclaredVariable >> isRegistered [
 	^Undeclared includesKey: name
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 UndeclaredVariable >> isUndeclaredVariable [
 
 	^ true
 ]
 
-{ #category : #registry }
+{ #category : 'registry' }
 UndeclaredVariable >> register [
 	Undeclared add: self
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 UndeclaredVariable >> runtimeUndeclaredRead [
 
 	<debuggerCompleteToSender>
@@ -91,7 +93,7 @@ UndeclaredVariable >> runtimeUndeclaredRead [
 		signal
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 UndeclaredVariable >> runtimeUndeclaredWrite: anObject [
 
 	<debuggerCompleteToSender>
@@ -102,7 +104,7 @@ UndeclaredVariable >> runtimeUndeclaredWrite: anObject [
 		signal
 ]
 
-{ #category : #registry }
+{ #category : 'registry' }
 UndeclaredVariable >> unregister [
 	Undeclared removeKey: name ifAbsent: [ ]
 ]

--- a/src/Kernel/UndeclaredVariableError.class.st
+++ b/src/Kernel/UndeclaredVariableError.class.st
@@ -2,34 +2,36 @@
 I am an abstract superclass for exceptions related to a read and write access on undeclared variable.
 "
 Class {
-	#name : #UndeclaredVariableError,
-	#superclass : #Error,
+	#name : 'UndeclaredVariableError',
+	#superclass : 'Error',
 	#instVars : [
 		'variable'
 	],
-	#category : #'Kernel-Exceptions'
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 UndeclaredVariableError >> isResumable [
 	"The undeclared variable write become a no-op"
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UndeclaredVariableError >> variable [
 
 	^ variable
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UndeclaredVariableError >> variable: anObject [
 
 	variable := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UndeclaredVariableError >> variableNode [
 	"Return the possible AST node doing the variable access (for reparation)"
 

--- a/src/Kernel/UndeclaredVariableRead.class.st
+++ b/src/Kernel/UndeclaredVariableRead.class.st
@@ -2,7 +2,9 @@
 This error is signaled on read attempt of undeclared variables
 "
 Class {
-	#name : #UndeclaredVariableRead,
-	#superclass : #UndeclaredVariableError,
-	#category : #'Kernel-Exceptions'
+	#name : 'UndeclaredVariableRead',
+	#superclass : 'UndeclaredVariableError',
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }

--- a/src/Kernel/UndeclaredVariableWrite.class.st
+++ b/src/Kernel/UndeclaredVariableWrite.class.st
@@ -2,27 +2,29 @@
 This error is signaled on write attempt to undeclared variables
 "
 Class {
-	#name : #UndeclaredVariableWrite,
-	#superclass : #UndeclaredVariableError,
+	#name : 'UndeclaredVariableWrite',
+	#superclass : 'UndeclaredVariableError',
 	#instVars : [
 		'value'
 	],
-	#category : #'Kernel-Exceptions'
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 UndeclaredVariableWrite >> defaultResumeValue [
 
 	^ value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UndeclaredVariableWrite >> value [
 
 	^ value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UndeclaredVariableWrite >> value: anObject [
 
 	value := anObject

--- a/src/Kernel/UndefinedObject.class.st
+++ b/src/Kernel/UndefinedObject.class.st
@@ -2,125 +2,127 @@
 I describe the behavior of my sole instance, nil. nil represents a prior value for variables that have not been initialized, or for results which are meaningless.
 "
 Class {
-	#name : #UndefinedObject,
-	#superclass : #Object,
-	#category : #'Kernel-Objects'
+	#name : 'UndefinedObject',
+	#superclass : 'Object',
+	#category : 'Kernel-Objects',
+	#package : 'Kernel',
+	#tag : 'Objects'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UndefinedObject class >> allInstances [
 	"It is well known there is a single instance"
 
 	^Array with: nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UndefinedObject class >> allInstancesDo: aBlock [
 	"It is well known there is a single instance"
 
 	aBlock value: nil
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 UndefinedObject class >> new [
 	self error: 'You may not create any more undefined objects--use nil'
 ]
 
-{ #category : #'dependents access' }
+{ #category : 'dependents access' }
 UndefinedObject >> addDependent: ignored [
 	"Refer to the comment in Object|dependents."
 
 	self error: 'Nil should not have dependents'
 ]
 
-{ #category : #'class hierarchy' }
+{ #category : 'class hierarchy' }
 UndefinedObject >> addSubclass: aClass [
 	"Ignored -- necessary to support disjoint class hierarchies"
 ]
 
-{ #category : #'class hierarchy' }
+{ #category : 'class hierarchy' }
 UndefinedObject >> allSuperclassesDo: aBlockContext [
 	"Ignored -- necessary to support disjoint class hierarchies"
 ]
 
-{ #category : #'sets support' }
+{ #category : 'sets support' }
 UndefinedObject >> asCollectionElement [
 	"Since nil is a singleton, we need only a single wrapper instance to represent it in set,
 	created in advance"
 	^ CollectionElement withNil
 ]
 
-{ #category : #dispatched }
+{ #category : 'dispatched' }
 UndefinedObject >> asLinkPrepend: anObject [
 
 	^ ValueLink value: anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UndefinedObject >> at: index put: anObject [
 	self shouldNotImplement
 ]
 
-{ #category : #'bottom context' }
+{ #category : 'bottom context' }
 UndefinedObject >> canHandleSignal: exception [
 	"When no more handler (on:do:) context left in sender chain this gets called"
 
 	^ false
 ]
 
-{ #category : #'class hierarchy' }
+{ #category : 'class hierarchy' }
 UndefinedObject >> classBuilder [
 	"Answer the object responsible of creating subclasses of myself in the system."
 
 		^ self classInstaller new builder
 ]
 
-{ #category : #'class hierarchy' }
+{ #category : 'class hierarchy' }
 UndefinedObject >> classInstaller [
 	"Answer the class responsible of creating classes in the system."
 
 	^ Smalltalk classInstaller
 ]
 
-{ #category : #'class hierarchy' }
+{ #category : 'class hierarchy' }
 UndefinedObject >> commonSuperclassWith: aClass [
 	^ self
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 UndefinedObject >> deepCopy [
 	"Only one instance of UndefinedObject should ever be made, so answer
 	with self."
 ]
 
-{ #category : #'class hierarchy' }
+{ #category : 'class hierarchy' }
 UndefinedObject >> environment [
 	"Necessary to support disjoint class hierarchies."
 
 	^self class environment
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 UndefinedObject >> haltIfNil [
 	<debuggerCompleteToSender>
 	Halt now
 ]
 
-{ #category : #'bottom context' }
+{ #category : 'bottom context' }
 UndefinedObject >> handleSignal: exception [
 	"When no more handler (on:do:) context left in sender chain this gets called.  Return from signal with default action."
 
 	^ exception resumeUnchecked: exception defaultAction
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 UndefinedObject >> ifNil: aBlock [
 	"A convenient test, in conjunction with Object ifNil:"
 	"Might be compiled inline for speed, see RBMessageNode>>#isInlineIfNil"
 	^ aBlock value
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 UndefinedObject >> ifNil: nilBlock ifNotNil: ifNotNilBlock [
 	"If the receiver is not nil, pass it as argument to the ifNotNilBlock block. else execute the nilBlock block"
 	"Might be compiled inline for speed, see RBMessageNode>>#isInlineIfNil"
@@ -131,7 +133,7 @@ UndefinedObject >> ifNil: nilBlock ifNotNil: ifNotNilBlock [
 	^ nilBlock value
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 UndefinedObject >> ifNotNil: aBlock [
 	"If the receiver is not nil, pass it as argument to the block."
 	"Might be compiled inline for speed, see RBMessageNode>>#isInlineIfNil"
@@ -142,7 +144,7 @@ UndefinedObject >> ifNotNil: aBlock [
 	^ self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 UndefinedObject >> ifNotNil: ifNotNilBlock ifNil: nilBlock [
 	"If the receiver is not nil, pass it as argument to the ifNotNilBlock block. else execute the nilBlock block"
 	"Might be compiled inline for speed, see RBMessageNode>>#isInlineIfNil"
@@ -153,70 +155,70 @@ UndefinedObject >> ifNotNil: ifNotNilBlock ifNil: nilBlock [
 	^ nilBlock value
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 UndefinedObject >> isEmptyOrNil [
 	"Answer whether the receiver contains any elements, or is nil.  Useful in numerous situations where one wishes the same reaction to an empty collection or to nil"
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 UndefinedObject >> isLiteral [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 UndefinedObject >> isNil [
 	"Refer to the comment in Object|isNil."
 
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 UndefinedObject >> isNotNil [
 	"Refer to the comment in Object|isNotNil."
 
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 UndefinedObject >> notNil [
 	"Refer to the comment in Object|notNil."
 
 	^false
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 UndefinedObject >> printOn: aStream [
 	"Refer to the comment in Object|printOn:."
 
 	aStream nextPutAll: 'nil'
 ]
 
-{ #category : #'class hierarchy' }
+{ #category : 'class hierarchy' }
 UndefinedObject >> removeSubclass: aClass [
 	"Ignored -- necessary to support disjoint class hierarchies"
 ]
 
-{ #category : #pinning }
+{ #category : 'pinning' }
 UndefinedObject >> setPinnedInMemory: aBoolean [
 
 	self error: 'nil cannot be pinned.'
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 UndefinedObject >> shallowCopy [
 	"Only one instance of UndefinedObject should ever be made, so answer
 	with self."
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 UndefinedObject >> storeOn: aStream [
 	"Refer to the comment in Object|storeOn:."
 
 	aStream nextPutAll: 'nil'
 ]
 
-{ #category : #'class hierarchy' }
+{ #category : 'class hierarchy' }
 UndefinedObject >> subclass: nameOfClass instanceVariableNames: instVarNameList classVariableNames: classVarNames poolDictionaries: poolDictnames category: category [
 	"Calling this method is now considered an accident.  If you really want to create a class with a nil superclass, then create the class and then set the superclass using #superclass:"
 
@@ -233,13 +235,13 @@ UndefinedObject >> subclass: nameOfClass instanceVariableNames: instVarNameList 
 			  environment: self environment ]
 ]
 
-{ #category : #'class hierarchy' }
+{ #category : 'class hierarchy' }
 UndefinedObject >> subclassDefinerClass [
 	"For disjunct class hierarchies -- how should subclasses of nil be evaluated"
 	^self class subclassDefinerClass
 ]
 
-{ #category : #'class hierarchy' }
+{ #category : 'class hierarchy' }
 UndefinedObject >> subclasses [
 	"Return all the subclasses of nil"
 	| classList |
@@ -248,7 +250,7 @@ UndefinedObject >> subclasses [
 	^classList contents
 ]
 
-{ #category : #'class hierarchy' }
+{ #category : 'class hierarchy' }
 UndefinedObject >> subclassesDo: aBlock [
 	"Evaluate aBlock with all subclasses of nil.  Others are not direct subclasses of Class."
 
@@ -256,7 +258,7 @@ UndefinedObject >> subclassesDo: aBlock [
 			cl isMeta ifTrue: [aBlock value: cl soleInstance]]
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 UndefinedObject >> veryDeepCopyWith: deepCopier [
 	"Return self.  I can't be copied.  Do not record me."
 ]

--- a/src/Kernel/UndefinedSlot.class.st
+++ b/src/Kernel/UndefinedSlot.class.st
@@ -6,27 +6,29 @@ The UndefinedSlot ingores reads and write (it returns nil like undeclared variab
 access, it checks if the Slot has been loaded and if yes, it rebuilds the class definition.
 "
 Class {
-	#name : #UndefinedSlot,
-	#superclass : #Slot,
+	#name : 'UndefinedSlot',
+	#superclass : 'Slot',
 	#instVars : [
 		'ast',
 		'classIsRebuild'
 	],
-	#category : #'Kernel-Variables'
+	#category : 'Kernel-Variables',
+	#package : 'Kernel',
+	#tag : 'Variables'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 UndefinedSlot class >> named: aName ast: aSlotClassName [
 	^ (self named: aName) ast: aSlotClassName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UndefinedSlot >> ast: aMessageNode [
 	classIsRebuild := false.
 	ast := aMessageNode
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 UndefinedSlot >> checkClassRebuild [
 	"break the recursion while rebuilding"
 	classIsRebuild ifTrue: [ ^ self].
@@ -38,25 +40,25 @@ UndefinedSlot >> checkClassRebuild [
 	self usingMethods do: [:each | each recompile]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 UndefinedSlot >> printOn: aStream [
 	"we print as the definition that could not be loaded"
 	aStream nextPutAll: ast formattedCode
 ]
 
-{ #category : #'meta-object-protocol' }
+{ #category : 'meta-object-protocol' }
 UndefinedSlot >> read: anObject [
 	"Undeclared slots read nil always, but check if they can repair the class"
 	 self checkClassRebuild.
 	^ nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UndefinedSlot >> slotClassName [
 	^ast arguments first variable name
 ]
 
-{ #category : #'meta-object-protocol' }
+{ #category : 'meta-object-protocol' }
 UndefinedSlot >> write: aValue to: anObject [
 	"Undeclared slots ignore writes, but check if they can repair the class"
 	 self checkClassRebuild.

--- a/src/Kernel/UnhandledError.class.st
+++ b/src/Kernel/UnhandledError.class.st
@@ -19,15 +19,17 @@ The logic behind my class name and methods:
 Not all exceptions are errors. But by default the absence of any handler for signaled exception is considered as an error. Therefore #defaultAction for Exception raises an error, an UnhandledError. And because exception should be able to specify default action for UnhandledError it implements #unhandledErrorAction
 "
 Class {
-	#name : #UnhandledError,
-	#superclass : #UnhandledException,
+	#name : 'UnhandledError',
+	#superclass : 'UnhandledException',
 	#instVars : [
 		'exception'
 	],
-	#category : #'Kernel-Exceptions'
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #signalling }
+{ #category : 'signalling' }
 UnhandledError class >> signalForException: anError [
 
 	^ self new
@@ -35,24 +37,24 @@ UnhandledError class >> signalForException: anError [
 		signal
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 UnhandledError >> defaultAction [
 	^ exception unhandledErrorAction
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnhandledError >> exception [
 
 	^ exception
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnhandledError >> exception: anError [
 
 	exception := anError
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 UnhandledError >> isResumable [
 
 	"UnhandledError can be signaled for more than non-resumable Errors.

--- a/src/Kernel/UnhandledException.class.st
+++ b/src/Kernel/UnhandledException.class.st
@@ -10,12 +10,14 @@ There are two main subclasses:
 See comments for details
 "
 Class {
-	#name : #UnhandledException,
-	#superclass : #Exception,
-	#category : #'Kernel-Exceptions'
+	#name : 'UnhandledException',
+	#superclass : 'Exception',
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #handling }
+{ #category : 'handling' }
 UnhandledException >> defaultAction [
 	"If none handles this either then open debugger.
 

--- a/src/Kernel/UnwindError.class.st
+++ b/src/Kernel/UnwindError.class.st
@@ -1,5 +1,7 @@
 Class {
-	#name : #UnwindError,
-	#superclass : #Error,
-	#category : #'Kernel-Processes'
+	#name : 'UnwindError',
+	#superclass : 'Error',
+	#category : 'Kernel-Processes',
+	#package : 'Kernel',
+	#tag : 'Processes'
 }

--- a/src/Kernel/Variable.class.st
+++ b/src/Kernel/Variable.class.st
@@ -22,34 +22,36 @@ Instance Variables
 	name:		<Symbol>
 "
 Class {
-	#name : #Variable,
-	#superclass : #Object,
+	#name : 'Variable',
+	#superclass : 'Object',
 	#instVars : [
 		'name'
 	],
 	#classVars : [
 		'Properties'
 	],
-	#category : #'Kernel-Variables'
+	#category : 'Kernel-Variables',
+	#package : 'Kernel',
+	#tag : 'Variables'
 }
 
-{ #category : #validating }
+{ #category : 'validating' }
 Variable class >> checkValidName: aString [
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 Variable class >> initialize [
 	Properties := Properties
 		ifNil: [ WeakIdentityKeyDictionary new. ]
 		ifNotNil: [ (WeakIdentityKeyDictionary newFrom: Properties) rehash]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable class >> isAbstract [
 	^self = Variable
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Variable class >> named: aSymbol [
 	self checkValidName: aSymbol.
 	^ self new
@@ -57,7 +59,7 @@ Variable class >> named: aSymbol [
 		yourself
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Variable >> = other [
 	"Every subclass that adds state must redefine this method"
 	self == other
@@ -66,17 +68,17 @@ Variable >> = other [
 			and: [ name = other name ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 Variable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 	^ aProgramNodeVisitor visitVariableNode: aNode
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> allowsShadowing [
 	^false
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 Variable >> asDoItVariableFrom: aContext [
 	"Specific kind of variables may require special logic to be visible in DoIt expressions.
 	For example local variables can't be accessed directly in DoIt expressions in the debugger:
@@ -86,35 +88,35 @@ Variable >> asDoItVariableFrom: aContext [
 	^ self
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 Variable >> definingNode [
 	^ nil
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 Variable >> definitionOn: aStream [
 	"Every subclass that adds state must redefine either this method or #printOn:"
 	^ self printOn: aStream
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 Variable >> emitStore: methodBuilder [
 
 	self subclassResponsibility
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 Variable >> emitValue: methodBuilder [
 
 	self subclassResponsibility
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 Variable >> ensureProperties [
 	^ Properties at: self ifAbsentPut: WeakKeyDictionary new
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 Variable >> hasProperty: aKey [
 	"Test if the property aKey is present."
 	^self properties
@@ -122,85 +124,85 @@ Variable >> hasProperty: aKey [
 		ifNotNil: [:prop | prop includesKey: aKey]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 Variable >> hash [
 	"Every subclass that adds state must redefine this method"
 	^ self species hash bitXor: self name hash
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isAccessedIn: aMethod [
 	^self usingMethods includes: aMethod
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isArgumentVariable [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isClassVariable [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isDefinedByBlock [
 	"true if a variable node is defined by a block"
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isGlobalVariable [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isInstanceVariable [
 	"check if the var is an instance variable (a Slot)"
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isInvalidVariable [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isLiteralVariable [
 	"returns true for Global Variables, Class Variables and some others
 	(e.g. Workspace bindings and Undeclared variables, see subclasses)"
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isLocalVariable [
 	"temporary variables and arguments are local variables"
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isPoolVariable [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isPseudoVariable [
 	"thisContext, super, self, thisProcess are reserved variables (true, false and nil are literals)"
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isReadIn: aCompiledCode [
 	^aCompiledCode ast readNodes
 		 anySatisfy: [ :node | node binding == self ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isReferenced [
 	^ self usingMethods isNotEmpty
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isReservedVariable [
 	self
 		deprecated: 'Please use #isPseudoVariable instead'
@@ -209,92 +211,92 @@ Variable >> isReservedVariable [
 	^ self isPseudoVariable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isSelfOrSuperVariable [
 	^ self isSelfVariable or: [ self isSuperVariable ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isSelfVariable [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isShadowing [
 	"I shadow a variable if looking up my name in the outer scope returns a variable"
 	^(self scope outerScope ifNotNil: [:outer | outer lookupVar: self name]) notNil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isSuperVariable [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isTempVariable [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isThisContextVariable [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isThisProcessVariable [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isUndeclaredVariable [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isUninitialized [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isUsed [
 	^ self isReferenced
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isWorkspaceVariable [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isWritable [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> isWrittenIn: aCompiledCode [
 	^aCompiledCode ast variableWriteNodes
 		anySatisfy: [ :node | node binding == self ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Variable >> name [
 	^ name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Variable >> name: aSymbol [
 	name := aSymbol
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Variable >> needsFullDefinition [
 	"all but InstanceVariableSlot and ClassVariable need to print the full definition"
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Variable >> originalVar [
 	"Because some AST analysis optimize temps representatipn, specific implementation-dependant variables cas apears in AST. This method return the original temp.
 	On other varialbes, it's just self."
@@ -302,19 +304,19 @@ Variable >> originalVar [
 	^ self
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 Variable >> properties [
 	^ Properties at: self ifAbsent: nil
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 Variable >> propertyAt: propName [
 	^ self
 		propertyAt: propName
 		ifAbsent: [ nil ]
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 Variable >> propertyAt: propName ifAbsent: aBlock [
 	self properties ifNil: [^aBlock value].
 	^ self properties
@@ -322,39 +324,39 @@ Variable >> propertyAt: propName ifAbsent: aBlock [
 		ifAbsent: aBlock
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 Variable >> propertyAt: aKey ifAbsentPut: aBlock [
 	"Answer the property associated with aKey or, if aKey isn't found store the result of evaluating aBlock as new value."
 
 	^ self propertyAt: aKey ifAbsent: [ self propertyAt: aKey put: aBlock value ]
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 Variable >> propertyAt: propName put: propValue [
 	^ self ensureProperties
 		at: propName
 		put: propValue
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 Variable >> readInContext: aContext [
 	self subclassResponsibility
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 Variable >> removePropertiesIfEmpty [
 	^ Properties at: self ifPresent: [ :dict |
 		dict ifEmpty: [ Properties removeKey: self ] ]
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 Variable >> removeProperty: propName [
 	^ self
 		removeProperty: propName
 		ifAbsent: [ nil ]
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 Variable >> removeProperty: propName ifAbsent: aBlock [
 	| property |
 	self properties ifNil: [^aBlock value].
@@ -365,17 +367,17 @@ Variable >> removeProperty: propName ifAbsent: aBlock [
 	^ property
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Variable >> scope [
 	^self subclassResponsibility
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 Variable >> usingMethods [
 	self subclassResponsibility
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 Variable >> write: aValue inContext: aContext [
 	"write the value in aContext. All #write:inContext: methods need to return the assigned value,
 	as this is the reflective version of assignment which has the assigned value as a value"

--- a/src/Kernel/VariableLayout.class.st
+++ b/src/Kernel/VariableLayout.class.st
@@ -5,19 +5,21 @@ I contain a fixed number of Slots plus.
 Instances of classes using this kind of layout have only a minimum given size. Instances have a custom number of additional fields which can be accessed with an index.
 "
 Class {
-	#name : #VariableLayout,
-	#superclass : #PointerLayout,
-	#category : #'Kernel-Layout'
+	#name : 'VariableLayout',
+	#superclass : 'PointerLayout',
+	#category : 'Kernel-Layout',
+	#package : 'Kernel',
+	#tag : 'Layout'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 VariableLayout class >> extending: superLayout scope: aScope host: aClass [
 	^ (superLayout extendVariable: aScope)
 		host: aClass;
 		yourself
 ]
 
-{ #category : #description }
+{ #category : 'description' }
 VariableLayout class >> subclassDefiningSymbol [
 	"Answer a keyword that describes the receiver's kind of subclass
 	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
@@ -25,14 +27,14 @@ VariableLayout class >> subclassDefiningSymbol [
 	^#variableSubclass:
 ]
 
-{ #category : #format }
+{ #category : 'format' }
 VariableLayout >> instanceSpecification [
 	^ self hasFields
 		ifTrue: [ 3 ]
 		ifFalse: [ 2 ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 VariableLayout >> isVariable [
 	^ true
 ]

--- a/src/Kernel/Warning.class.st
+++ b/src/Kernel/Warning.class.st
@@ -2,12 +2,14 @@
 A Warning is a Notification which by default should be brought to the attention of the user.
 "
 Class {
-	#name : #Warning,
-	#superclass : #Notification,
-	#category : #'Kernel-Exceptions'
+	#name : 'Warning',
+	#superclass : 'Notification',
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #handling }
+{ #category : 'handling' }
 Warning >> defaultAction [
 	"No one has handled this warning, but now give them a chance to decide how to debug it.
 	If none handles this either then open debugger (see UnhandedError-defaultAction).
@@ -19,7 +21,7 @@ Warning >> defaultAction [
 	self raiseUnhandledError
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 Warning >> unhandledErrorAction [
 
 	"No one has handled this warning, then I gave them a chance to decide how to debug it and I raise an UnhandledError. But it was not handled by anybody so that we are here (see UnhandedError-defaultAction).

--- a/src/Kernel/WeakLayout.class.st
+++ b/src/Kernel/WeakLayout.class.st
@@ -7,19 +7,21 @@ Instances of classes using this kind of layout have only a minimum given size. I
 References held in the variable part are held weakly and might be nilled out by the garbage collector at any time. References in the named section are held strongly as in the default layout.
 "
 Class {
-	#name : #WeakLayout,
-	#superclass : #PointerLayout,
-	#category : #'Kernel-Layout'
+	#name : 'WeakLayout',
+	#superclass : 'PointerLayout',
+	#category : 'Kernel-Layout',
+	#package : 'Kernel',
+	#tag : 'Layout'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 WeakLayout class >> extending: superLayout scope: aScope host: aClass [
 	^ (superLayout extendWeak: aScope)
 		host: aClass;
 		yourself
 ]
 
-{ #category : #description }
+{ #category : 'description' }
 WeakLayout class >> subclassDefiningSymbol [
 	"Answer a keyword that describes the receiver's kind of subclass
 	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
@@ -27,17 +29,17 @@ WeakLayout class >> subclassDefiningSymbol [
 	^#weakSubclass:
 ]
 
-{ #category : #format }
+{ #category : 'format' }
 WeakLayout >> instanceSpecification [
 	^ 4
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 WeakLayout >> isVariable [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 WeakLayout >> isWeak [
 	^ true
 ]

--- a/src/Kernel/WeakMessageSend.class.st
+++ b/src/Kernel/WeakMessageSend.class.st
@@ -11,33 +11,35 @@ and it also has
  shouldBeNil		Boolean --  used to ensure array of arguments is not all nils
 "
 Class {
-	#name : #WeakMessageSend,
-	#superclass : #Object,
-	#type : #weak,
+	#name : 'WeakMessageSend',
+	#superclass : 'Object',
+	#type : 'weak',
 	#instVars : [
 		'selector',
 		'shouldBeNil',
 		'arguments'
 	],
-	#category : #'Kernel-Messaging'
+	#category : 'Kernel-Messaging',
+	#package : 'Kernel',
+	#tag : 'Messaging'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 WeakMessageSend class >> new [
 	^self new: 1
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 WeakMessageSend class >> receiver: anObject selector: aSymbol [
 	^ self receiver: anObject selector: aSymbol arguments: #()
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 WeakMessageSend class >> receiver: anObject selector: aSymbol argument: aParameter [
 	^ self receiver: anObject selector: aSymbol arguments: (Array with: aParameter)
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 WeakMessageSend class >> receiver: anObject selector: aSymbol arguments: anArray [
 	^ self new
 		receiver: anObject;
@@ -45,7 +47,7 @@ WeakMessageSend class >> receiver: anObject selector: aSymbol arguments: anArray
 		arguments: anArray
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 WeakMessageSend >> = anObject [
 	"Compare equal to equivalent MessageSend"
 	^ anObject isMessageSend
@@ -54,24 +56,24 @@ WeakMessageSend >> = anObject [
 		and: [(Array withAll: arguments) = (Array withAll: anObject arguments)]]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WeakMessageSend >> arguments [
 	^arguments ifNil: [ Array new ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WeakMessageSend >> arguments: anArray [
 	arguments := WeakArray withAll: anArray.
 	"no reason this should be a WeakArray"
 	shouldBeNil := Array withAll: (anArray collect: [ :ea | ea isNil ])
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 WeakMessageSend >> asMessageSend [
 	^MessageSend receiver: self receiver selector: selector arguments: (Array withAll: self arguments)
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 WeakMessageSend >> asMinimalRepresentation [
 
 	^ self isReceiverOrAnyArgumentGarbage
@@ -79,7 +81,7 @@ WeakMessageSend >> asMinimalRepresentation [
 		  ifFalse: [ self ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 WeakMessageSend >> collectArguments: anArgArray [
 	"Private"
 
@@ -95,28 +97,28 @@ WeakMessageSend >> collectArguments: anArgArray [
 				  startingAt: 1 ]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 WeakMessageSend >> cull: arg [
 	^ selector numArgs = 0
 		ifTrue: [ self value ]
 		ifFalse: [ self value: arg ]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 WeakMessageSend >> cull: arg1 cull: arg2 [
 	^ selector numArgs < 2
 		ifTrue: [ self cull: arg1]
 		ifFalse: [ self value: arg1 value: arg2 ]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 WeakMessageSend >> cull: arg1 cull: arg2 cull: arg3 [
 	^ selector numArgs < 3
 		ifTrue: [ self cull: arg1 cull: arg2 ]
 		ifFalse: [ self value: arg1 value: arg2 value: arg3 ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 WeakMessageSend >> ensureArguments [
 	"Return true if my arguments haven't gone away"
 	arguments ifNotNil: [
@@ -127,7 +129,7 @@ WeakMessageSend >> ensureArguments [
 	^true
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 WeakMessageSend >> ensureReceiver [
   "Return true if my receiver hasn't gone away"
   self receiver ifNil: [^ false].
@@ -136,7 +138,7 @@ WeakMessageSend >> ensureReceiver [
   ^ true
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 WeakMessageSend >> ensureReceiver: anObject [
   "Return true if my receiver hasn't gone away"
   anObject ifNil: [^ false].
@@ -145,7 +147,7 @@ WeakMessageSend >> ensureReceiver: anObject [
   ^ true
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 WeakMessageSend >> ensureReceiverAndArguments [
 
   "Return true if my receiver hasn't gone away"
@@ -163,7 +165,7 @@ WeakMessageSend >> ensureReceiverAndArguments [
   ^true
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 WeakMessageSend >> ensureReceiverAndArguments: aReceiver [
 
   "Return true if my receiver hasn't gone away"
@@ -181,13 +183,13 @@ WeakMessageSend >> ensureReceiverAndArguments: aReceiver [
   ^true
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 WeakMessageSend >> hash [
 	"work like MessageSend>>hash"
 	^self receiver hash bitXor: selector hash
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 WeakMessageSend >> isAnyArgumentGarbage [
 	"Make sure that my arguments haven't gone away"
 	arguments ifNotNil: [
@@ -199,30 +201,30 @@ WeakMessageSend >> isAnyArgumentGarbage [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 WeakMessageSend >> isMessageSend [
 	^true
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 WeakMessageSend >> isReceiverGarbage [
 	"Make sure that my receiver hasn't gone away"
 	^self receiver isNil
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 WeakMessageSend >> isReceiverOrAnyArgumentGarbage [
 	"Make sure that my receiver hasn't gone away"
 	^self isReceiverGarbage
 		or: [self isAnyArgumentGarbage]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 WeakMessageSend >> isValid [
 	^self isReceiverOrAnyArgumentGarbage not
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 WeakMessageSend >> printOn: aStream [
 
 	super printOn: aStream.
@@ -235,27 +237,27 @@ WeakMessageSend >> printOn: aStream [
 		nextPut: $)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WeakMessageSend >> receiver [
 	^self at: 1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WeakMessageSend >> receiver: anObject [
 	self at: 1 put: anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WeakMessageSend >> selector [
 	^selector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WeakMessageSend >> selector: aSymbol [
 	selector := aSymbol
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 WeakMessageSend >> value [
 
 	| strongReceiver |
@@ -273,7 +275,7 @@ WeakMessageSend >> value [
 			]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 WeakMessageSend >> value: anObject [
 
 	| strongReceiver |
@@ -287,7 +289,7 @@ WeakMessageSend >> value: anObject [
 		with: anObject
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 WeakMessageSend >> value: anObject1 value: anObject2 [
 
 	| strongReceiver |
@@ -302,7 +304,7 @@ WeakMessageSend >> value: anObject1 value: anObject2 [
 		with: anObject2
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 WeakMessageSend >> value: anObject1 value: anObject2 value: anObject3 [
 
 	| strongReceiver |
@@ -318,7 +320,7 @@ WeakMessageSend >> value: anObject1 value: anObject2 value: anObject3 [
 		with: anObject3
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 WeakMessageSend >> valueWithArguments: anArray [
 
 	| strongReceiver |
@@ -331,7 +333,7 @@ WeakMessageSend >> valueWithArguments: anArray [
 		withArguments: (self collectArguments: anArray)
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 WeakMessageSend >> valueWithEnoughArguments: anArray [
 	"call the selector with enough arguments from arguments and anArray"
 	| args strongReceiver |

--- a/src/Kernel/WordLayout.class.st
+++ b/src/Kernel/WordLayout.class.st
@@ -2,19 +2,21 @@
 I am a raw data layout that holds words (32 bits ).
 "
 Class {
-	#name : #WordLayout,
-	#superclass : #BitsLayout,
-	#category : #'Kernel-Layout'
+	#name : 'WordLayout',
+	#superclass : 'BitsLayout',
+	#category : 'Kernel-Layout',
+	#package : 'Kernel',
+	#tag : 'Layout'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 WordLayout class >> extending: superLayout scope: aScope host: aClass [
 	^ superLayout extendWord
 		host: aClass;
 		yourself
 ]
 
-{ #category : #description }
+{ #category : 'description' }
 WordLayout class >> subclassDefiningSymbol [
 	"Answer a keyword that describes the receiver's kind of subclass
 	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
@@ -22,23 +24,23 @@ WordLayout class >> subclassDefiningSymbol [
 	^#variableWordSubclass:
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 WordLayout >> bytesPerSlot [
 
 	^ 4
 ]
 
-{ #category : #extending }
+{ #category : 'extending' }
 WordLayout >> extendWord [
 	^ WordLayout new
 ]
 
-{ #category : #format }
+{ #category : 'format' }
 WordLayout >> instanceSpecification [
 	^ 10
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 WordLayout >> isWords [
 	^ true
 ]

--- a/src/Kernel/WorkspaceVariable.class.st
+++ b/src/Kernel/WorkspaceVariable.class.st
@@ -2,34 +2,36 @@
 I am a binding in a Workspace. Used for non-defined temps
 "
 Class {
-	#name : #WorkspaceVariable,
-	#superclass : #LiteralVariable,
-	#category : #'Kernel-Variables'
+	#name : 'WorkspaceVariable',
+	#superclass : 'LiteralVariable',
+	#category : 'Kernel-Variables',
+	#package : 'Kernel',
+	#tag : 'Variables'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 WorkspaceVariable >> allowsShadowing [
 	^true
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 WorkspaceVariable >> emitStore: methodBuilder [
 
 	methodBuilder storeIntoLiteralVariable: self
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 WorkspaceVariable >> emitValue: methodBuilder [
 
 	methodBuilder pushLiteralVariable: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 WorkspaceVariable >> isReferenced [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 WorkspaceVariable >> isWorkspaceVariable [
 	^ true
 ]

--- a/src/Kernel/ZeroDivide.class.st
+++ b/src/Kernel/ZeroDivide.class.st
@@ -2,40 +2,42 @@
 I am ZeroDivide, an ArithmeticError that may be signaled when a mathematical division by 0 is attempted.
 "
 Class {
-	#name : #ZeroDivide,
-	#superclass : #ArithmeticError,
+	#name : 'ZeroDivide',
+	#superclass : 'ArithmeticError',
 	#instVars : [
 		'dividend'
 	],
-	#category : #'Kernel-Exceptions'
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
 }
 
-{ #category : #exceptioninstantiator }
+{ #category : 'exceptioninstantiator' }
 ZeroDivide class >> dividend: argument [
 	^self new dividend: argument; yourself
 ]
 
-{ #category : #signaling }
+{ #category : 'signaling' }
 ZeroDivide class >> signalWithDividend: aDividend [
 
 	^(self dividend: aDividend) signal
 ]
 
-{ #category : #exceptiondescription }
+{ #category : 'exceptiondescription' }
 ZeroDivide >> dividend [
 	"Answer the number that was being divided by zero."
 
 	^dividend
 ]
 
-{ #category : #exceptionbuilder }
+{ #category : 'exceptionbuilder' }
 ZeroDivide >> dividend: argument [
 	"Specify the number that was being divided by zero."
 
 	dividend := argument
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ZeroDivide >> isResumable [
 	"Determine whether an exception is resumable."
 

--- a/src/Kernel/package.st
+++ b/src/Kernel/package.st
@@ -1,1 +1,1 @@
-Package { #name : #Kernel }
+Package { #name : 'Kernel' }

--- a/src/Slot-Tests/AccessorInstanceVariableSlotTest.class.st
+++ b/src/Slot-Tests/AccessorInstanceVariableSlotTest.class.st
@@ -3,12 +3,14 @@ This class is the place for tests related to the Slot examples.
 (some examples have their own test class, the rest is here)
 "
 Class {
-	#name : #AccessorInstanceVariableSlotTest,
-	#superclass : #SlotSilentTest,
-	#category : #'Slot-Tests-Examples'
+	#name : 'AccessorInstanceVariableSlotTest',
+	#superclass : 'SlotSilentTest',
+	#category : 'Slot-Tests-Examples',
+	#package : 'Slot-Tests',
+	#tag : 'Examples'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 AccessorInstanceVariableSlotTest >> testAccessorInstanceVariableSlot [
 	| slot object |
 	<ignoreNotImplementedSelectors: #(slot1 slot1:)>

--- a/src/Slot-Tests/ArgumentVariableTest.class.st
+++ b/src/Slot-Tests/ArgumentVariableTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #ArgumentVariableTest,
-	#superclass : #TestCase,
-	#category : #'Slot-Tests-VariablesAndSlots'
+	#name : 'ArgumentVariableTest',
+	#superclass : 'TestCase',
+	#category : 'Slot-Tests-VariablesAndSlots',
+	#package : 'Slot-Tests',
+	#tag : 'VariablesAndSlots'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 ArgumentVariableTest >> testDefiningNode [
 	| method declaringNode declaringNodeViaVariable|
 
@@ -19,7 +21,7 @@ ArgumentVariableTest >> testDefiningNode [
 	self assert: declaringNodeViaVariable equals: declaringNode
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ArgumentVariableTest >> testUsingMethods [
 
 	| method |

--- a/src/Slot-Tests/BooleanSlotTest.class.st
+++ b/src/Slot-Tests/BooleanSlotTest.class.st
@@ -2,12 +2,14 @@
 Tests for BooleanSlot
 "
 Class {
-	#name : #BooleanSlotTest,
-	#superclass : #SlotSilentTest,
-	#category : #'Slot-Tests-Examples'
+	#name : 'BooleanSlotTest',
+	#superclass : 'SlotSilentTest',
+	#category : 'Slot-Tests-Examples',
+	#package : 'Slot-Tests',
+	#tag : 'Examples'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 BooleanSlotTest >> testExampleBooleanSlot [
 	| object slot |
 	<ignoreNotImplementedSelectors: #(slot1: slot1)>
@@ -29,7 +31,7 @@ BooleanSlotTest >> testExampleBooleanSlot [
 	self assert: object slot1 identicalTo: false
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 BooleanSlotTest >> testExampleTwoBooleanSlots [
 	| object slot1 slot2 |
 	slot1 := #slot1 => BooleanSlot.
@@ -55,7 +57,7 @@ BooleanSlotTest >> testExampleTwoBooleanSlots [
 	self assert: (slot2 read: object) equals: false
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 BooleanSlotTest >> testExampleTwoBooleanSlotsRemoveOne [
 	| object slot1 slot2 |
 	slot1 := #slot1 => BooleanSlot.

--- a/src/Slot-Tests/ClassVariableTest.class.st
+++ b/src/Slot-Tests/ClassVariableTest.class.st
@@ -2,18 +2,20 @@
 Tests for ClassVariable
 "
 Class {
-	#name : #ClassVariableTest,
-	#superclass : #TestCase,
+	#name : 'ClassVariableTest',
+	#superclass : 'TestCase',
 	#classVars : [
 		'TestVariable'
 	],
 	#pools : [
 		'TestSharedPool'
 	],
-	#category : #'Slot-Tests-VariablesAndSlots'
+	#category : 'Slot-Tests-VariablesAndSlots',
+	#package : 'Slot-Tests',
+	#tag : 'VariablesAndSlots'
 }
 
-{ #category : #'tests - properties' }
+{ #category : 'tests - properties' }
 ClassVariableTest >> testIsReadInMethod [
 
 	DefaultTimeLimit printString. "reading class variable".
@@ -21,7 +23,7 @@ ClassVariableTest >> testIsReadInMethod [
 	self assert: ((TestCase classVariableNamed: #DefaultTimeLimit) isReadIn: self class >> testSelector)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ClassVariableTest >> testIsReferenced [
 	self assert: (SmalltalkImage classVariableNamed: #CompilerClass) isReferenced.
 	TestVariable.
@@ -32,14 +34,14 @@ ClassVariableTest >> testIsReferenced [
 	self assert: (TestSharedPool classVariableNamed: #ReferencedInTest) isReferenced
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ClassVariableTest >> testIsShadowing [
 	| variable |
 	variable := SmalltalkImage classVariableNamed: #CompilerClass.
 	self deny: variable isShadowing
 ]
 
-{ #category : #'tests - properties' }
+{ #category : 'tests - properties' }
 ClassVariableTest >> testIsWrittenInMethod [
 
 	DefaultTimeLimit := DefaultTimeLimit. "writing class variable".
@@ -47,13 +49,13 @@ ClassVariableTest >> testIsWrittenInMethod [
 	self assert: ((TestCase classVariableNamed: #DefaultTimeLimit) isWrittenIn: self class >> testSelector)
 ]
 
-{ #category : #'tests - properties' }
+{ #category : 'tests - properties' }
 ClassVariableTest >> testNotReadInMethod [
 
 	self deny: ((TestCase classVariableNamed: #DefaultTimeLimit) isReadIn: self class >> testSelector)
 ]
 
-{ #category : #'tests - properties' }
+{ #category : 'tests - properties' }
 ClassVariableTest >> testNotWrittenInMethodWhenItIsOnlyRead [
 
 	DefaultTimeLimit printString. "reading class variable".
@@ -61,7 +63,7 @@ ClassVariableTest >> testNotWrittenInMethodWhenItIsOnlyRead [
 	self deny: ((TestCase classVariableNamed: #DefaultTimeLimit) isWrittenIn: self class >> testSelector)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ClassVariableTest >> testPossiblyUsingClasses [
 	| variable |
 
@@ -89,7 +91,7 @@ ClassVariableTest >> testPossiblyUsingClasses [
 	self assert: (variable possiblyUsingClasses includes: CompositionScanner class)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ClassVariableTest >> testPrintOn [
 	| variable |
 	variable := SmalltalkImage classVariableNamed: #CompilerClass.
@@ -98,7 +100,7 @@ ClassVariableTest >> testPrintOn [
 	self assert: variable printString equals: '#CompilerClass => ClassVariable'
 ]
 
-{ #category : #'tests - properties' }
+{ #category : 'tests - properties' }
 ClassVariableTest >> testPropertyAtPut [
 
 	| testValue classVariable |
@@ -121,7 +123,7 @@ ClassVariableTest >> testPropertyAtPut [
 	self assert: classVariable properties isNil
 ]
 
-{ #category : #'tests - properties' }
+{ #category : 'tests - properties' }
 ClassVariableTest >> testReadingFromContext [
 
 	| classVariable |
@@ -133,7 +135,7 @@ ClassVariableTest >> testReadingFromContext [
 		equals: #testValue
 ]
 
-{ #category : #'tests - properties' }
+{ #category : 'tests - properties' }
 ClassVariableTest >> testRemoveProperty [
 	| classVariable |
 	classVariable := self class classVariableNamed: #TestVariable.
@@ -146,7 +148,7 @@ ClassVariableTest >> testRemoveProperty [
 	self assert: classVariable properties isNil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ClassVariableTest >> testScope [
 	| variable |
 	variable := SmalltalkImage classVariableNamed: #CompilerClass.
@@ -154,7 +156,7 @@ ClassVariableTest >> testScope [
 	self assert: (variable scope lookupVar: variable name) equals: variable
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ClassVariableTest >> testUsingMethods [
 	| variable |
 	"The semantics of where to search is tested as part of #testPossiblyUsingClasses"
@@ -168,7 +170,7 @@ ClassVariableTest >> testUsingMethods [
 	self assert: (variable usingMethods includes: TextStyle>>#newFontArray:)
 ]
 
-{ #category : #'tests - properties' }
+{ #category : 'tests - properties' }
 ClassVariableTest >> testWritingToContext [
 
 	| classVariable |
@@ -178,7 +180,7 @@ ClassVariableTest >> testWritingToContext [
 	self assert: TestVariable equals: #testValue
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ClassVariableTest >> testisPoolVariable [
 	| variable |
 	variable := SmalltalkImage classVariableNamed: #CompilerClass.

--- a/src/Slot-Tests/DoItVariableTest.class.st
+++ b/src/Slot-Tests/DoItVariableTest.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #DoItVariableTest,
-	#superclass : #TestCase,
+	#name : 'DoItVariableTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'instVarForTest'
 	],
-	#category : #'Slot-Tests-VariablesAndSlots'
+	#category : 'Slot-Tests-VariablesAndSlots',
+	#package : 'Slot-Tests',
+	#tag : 'VariablesAndSlots'
 }
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 DoItVariableTest >> readVarInDifferentContext: aVar [
 	| temp |
 	self assert: aVar name equals: #temp.
@@ -16,7 +18,7 @@ DoItVariableTest >> readVarInDifferentContext: aVar [
 	^aVar readInContext: thisContext
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 DoItVariableTest >> testConvertingToDoItVariable [
 
 	| temp var |
@@ -26,7 +28,7 @@ DoItVariableTest >> testConvertingToDoItVariable [
 	self assert: (var asDoItVariableFrom: #anyContext) identicalTo: var
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 DoItVariableTest >> testCreationFromAnotherVariable [
 	| temp var targetTemp |
 	temp := 100.
@@ -38,7 +40,7 @@ DoItVariableTest >> testCreationFromAnotherVariable [
 	self assert: var actualVariable identicalTo: targetTemp
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 DoItVariableTest >> testDoItCompilation [
 	| temp var doIt |
 	temp := 100.
@@ -51,7 +53,7 @@ DoItVariableTest >> testDoItCompilation [
 	self assert: (doIt valueWithReceiver: self arguments: #()) equals: 102
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 DoItVariableTest >> testFromInstVarVariable [
 
 	| var |
@@ -65,7 +67,7 @@ DoItVariableTest >> testFromInstVarVariable [
 	self assert: instVarForTest equals: 200
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 DoItVariableTest >> testFromTempVariable [
 
 	| temp var |
@@ -79,7 +81,7 @@ DoItVariableTest >> testFromTempVariable [
 	self assert: temp equals: 200
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 DoItVariableTest >> testReadCompilation [
 	| temp var ast doIt |
 	temp := 100.
@@ -91,7 +93,7 @@ DoItVariableTest >> testReadCompilation [
 	self assert: (doIt valueWithReceiver: self arguments: #()) equals: 102
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 DoItVariableTest >> testReadInGivenContextShouldIgnoreIt [
 	| temp var actual |
 	temp := 100.
@@ -101,7 +103,7 @@ DoItVariableTest >> testReadInGivenContextShouldIgnoreIt [
 	self assert: actual equals: 100
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 DoItVariableTest >> testUsingMethods [
 
 	| temp var |
@@ -111,7 +113,7 @@ DoItVariableTest >> testUsingMethods [
 	self assert: var usingMethods equals: { thisContext method }
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 DoItVariableTest >> testWriteCompilation [
 	| temp var ast doIt |
 	temp := 100.
@@ -124,7 +126,7 @@ DoItVariableTest >> testWriteCompilation [
 	self assert: temp equals: 500
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 DoItVariableTest >> testWriteInGivenContextShouldIgnoreIt [
 	| temp var |
 	temp := 100.
@@ -134,7 +136,7 @@ DoItVariableTest >> testWriteInGivenContextShouldIgnoreIt [
 	self assert: temp equals: 200
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 DoItVariableTest >> writeVarInDifferentContext: aVar value: aValue [
 	| temp |
 	self assert: aVar name equals: #temp.

--- a/src/Slot-Tests/ExampleClassVariableTest.class.st
+++ b/src/Slot-Tests/ExampleClassVariableTest.class.st
@@ -2,12 +2,14 @@
 Test for class variables
 "
 Class {
-	#name : #ExampleClassVariableTest,
-	#superclass : #SlotSilentTest,
-	#category : #'Slot-Tests-Examples'
+	#name : 'ExampleClassVariableTest',
+	#superclass : 'SlotSilentTest',
+	#category : 'Slot-Tests-Examples',
+	#package : 'Slot-Tests',
+	#tag : 'Examples'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 ExampleClassVariableTest >> testCreateClassWithClassVariable [
 	"Add class variable using the builder interface"
 
@@ -23,7 +25,7 @@ ExampleClassVariableTest >> testCreateClassWithClassVariable [
 	self assert: (aClass hasClassVarNamed: 'ClassVar')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ExampleClassVariableTest >> testCreateClassWithTwoClassVariable [
 	"Add class variable using the builder interface"
 
@@ -41,7 +43,7 @@ ExampleClassVariableTest >> testCreateClassWithTwoClassVariable [
 	self assert: (aClass hasClassVarNamed: 'ClassVar2')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ExampleClassVariableTest >> testMigrateClassVar [
 	"Add class variable using the builder interface and change it to another kind"
 

--- a/src/Slot-Tests/ExampleSlotWithFluidAPITest.class.st
+++ b/src/Slot-Tests/ExampleSlotWithFluidAPITest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #ExampleSlotWithFluidAPITest,
-	#superclass : #SlotSilentTest,
-	#category : #'Slot-Tests-Examples'
+	#name : 'ExampleSlotWithFluidAPITest',
+	#superclass : 'SlotSilentTest',
+	#category : 'Slot-Tests-Examples',
+	#package : 'Slot-Tests',
+	#tag : 'Examples'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 ExampleSlotWithFluidAPITest >> testExampleSlotWithFluidAPI [
 
 	"Shows that we can use cascade (fluid api) to set meta data on slots. As the #=> has precedense, the cascade

--- a/src/Slot-Tests/ExampleSlotWithStateTest.class.st
+++ b/src/Slot-Tests/ExampleSlotWithStateTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #ExampleSlotWithStateTest,
-	#superclass : #SlotSilentTest,
-	#category : #'Slot-Tests-Examples'
+	#name : 'ExampleSlotWithStateTest',
+	#superclass : 'SlotSilentTest',
+	#category : 'Slot-Tests-Examples',
+	#package : 'Slot-Tests',
+	#tag : 'Examples'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 ExampleSlotWithStateTest >> testExampleClassSide [
 	" can we install a slot on the class side?"
 	| slot |
@@ -14,7 +16,7 @@ ExampleSlotWithStateTest >> testExampleClassSide [
 	self assert: slot class equals: ExampleSlotWithState
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ExampleSlotWithStateTest >> testExampleSlotWithState [
 	| slot |
 	<ignoreNotImplementedSelectors: #(slot1: slot1)>
@@ -31,7 +33,7 @@ ExampleSlotWithStateTest >> testExampleSlotWithState [
 	self assert: aClass new slot1 equals: 10
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ExampleSlotWithStateTest >> testExampleTwoSlotWithState [
 	" add two, remove one"
 	aClass := self make: [ :builder | builder

--- a/src/Slot-Tests/GlobalVariableTest.class.st
+++ b/src/Slot-Tests/GlobalVariableTest.class.st
@@ -2,12 +2,14 @@
 Tests for GlobalVariable
 "
 Class {
-	#name : #GlobalVariableTest,
-	#superclass : #TestCase,
-	#category : #'Slot-Tests-VariablesAndSlots'
+	#name : 'GlobalVariableTest',
+	#superclass : 'TestCase',
+	#category : 'Slot-Tests-VariablesAndSlots',
+	#package : 'Slot-Tests',
+	#tag : 'VariablesAndSlots'
 }
 
-{ #category : #'tests - properties' }
+{ #category : 'tests - properties' }
 GlobalVariableTest >> testIsReadInMethod [
 
 	self assert: (Object binding isReadIn: self class >> testSelector).
@@ -15,18 +17,18 @@ GlobalVariableTest >> testIsReadInMethod [
 							isReadIn: self class >> testSelector)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 GlobalVariableTest >> testIsShadowing [
 	self deny: Object binding isShadowing
 ]
 
-{ #category : #'tests - properties' }
+{ #category : 'tests - properties' }
 GlobalVariableTest >> testNotWrittenInMethod [
 
 	self deny: (Object binding isWrittenIn: self class >> testSelector)
 ]
 
-{ #category : #'tests - properties' }
+{ #category : 'tests - properties' }
 GlobalVariableTest >> testPropertyAtPut [
 
 	| testValue |
@@ -40,7 +42,7 @@ GlobalVariableTest >> testPropertyAtPut [
 	self assert: self class binding properties isNil
 ]
 
-{ #category : #'tests - properties' }
+{ #category : 'tests - properties' }
 GlobalVariableTest >> testRemoveProperty [
 
 	self class binding propertyAt: #testKeySelector put: 1.
@@ -53,7 +55,7 @@ GlobalVariableTest >> testRemoveProperty [
 	self assert: self class binding properties isNil
 ]
 
-{ #category : #'tests - properties' }
+{ #category : 'tests - properties' }
 GlobalVariableTest >> testScope [
 
 	self assert: Object binding scope equals: Object environment.

--- a/src/Slot-Tests/LiteralVariableTest.class.st
+++ b/src/Slot-Tests/LiteralVariableTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #LiteralVariableTest,
-	#superclass : #TestCase,
-	#category : #'Slot-Tests-VariablesAndSlots'
+	#name : 'LiteralVariableTest',
+	#superclass : 'TestCase',
+	#category : 'Slot-Tests-VariablesAndSlots',
+	#package : 'Slot-Tests',
+	#tag : 'VariablesAndSlots'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 LiteralVariableTest >> testComparison [
 
 	| var1 var2 |
@@ -18,7 +20,7 @@ LiteralVariableTest >> testComparison [
 	self deny: var1 equals: #var1 -> var1 value
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 LiteralVariableTest >> testIsVariableBinding [
 
 	| var1 |
@@ -27,7 +29,7 @@ LiteralVariableTest >> testIsVariableBinding [
 	self assert: var1 isVariableBinding
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 LiteralVariableTest >> testLiteralEquality [
 
 	| var1 var2 |

--- a/src/Slot-Tests/PropertySlotTest.class.st
+++ b/src/Slot-Tests/PropertySlotTest.class.st
@@ -2,12 +2,14 @@
 Test for PropertySlot
 "
 Class {
-	#name : #PropertySlotTest,
-	#superclass : #SlotSilentTest,
-	#category : #'Slot-Tests-Examples'
+	#name : 'PropertySlotTest',
+	#superclass : 'SlotSilentTest',
+	#category : 'Slot-Tests-Examples',
+	#package : 'Slot-Tests',
+	#tag : 'Examples'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 PropertySlotTest >> testCreateClassWithPropertySlot [
 	"Add instance variables using the builder interface"
 
@@ -24,7 +26,7 @@ PropertySlotTest >> testCreateClassWithPropertySlot [
 	self assert: (aClass classLayout hasSlot: (propertySlot instVarNamed: 'baseSlot'))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 PropertySlotTest >> testCreateClassWithPropertySlotAddSecond [
 	"Add instance variables using the builder interface"
 
@@ -48,7 +50,7 @@ PropertySlotTest >> testCreateClassWithPropertySlotAddSecond [
 	self assert: (aClass classLayout hasSlot: (propertySlot2 instVarNamed: 'baseSlot'))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 PropertySlotTest >> testCreateClassWithTwoPropertySlots [
 	"Add instance variables using the builder interface"
 
@@ -69,7 +71,7 @@ PropertySlotTest >> testCreateClassWithTwoPropertySlots [
 	self assert: (aClass classLayout  hasSlot: (propertySlot2 instVarNamed: 'baseSlot'))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 PropertySlotTest >> testRemovePropertySlot [
 
 	| propertySlot |
@@ -87,7 +89,7 @@ PropertySlotTest >> testRemovePropertySlot [
 	self deny: (aClass classLayout hasSlotNamed: #'_propertyBaseSlot')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 PropertySlotTest >> testRemovePropertySlot2 [
 	"add two property slots, remove one"
 
@@ -126,7 +128,7 @@ PropertySlotTest >> testRemovePropertySlot2 [
 	self deny:	(aClass classLayout hasSlotNamed:  #'_propertyBaseSlot')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 PropertySlotTest >> testRemovePropertySlotWithInstance [
 	"add two property slots, remove one"
 
@@ -154,7 +156,7 @@ PropertySlotTest >> testRemovePropertySlotWithInstance [
 	self deny: 	(aClass hasSlot: propertySlot1)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 PropertySlotTest >> testRemovePropertySlotWithTwoInstances [
 	"add two property slots, remove one"
 
@@ -182,7 +184,7 @@ PropertySlotTest >> testRemovePropertySlotWithTwoInstances [
 	self assert: (propertySlot1 read: instance2) equals: 5
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 PropertySlotTest >> testWhichSelectorsAccessFindSlots [
 	| cls |
 	cls := Object newAnonymousSubclass.

--- a/src/Slot-Tests/RelationSetTest.class.st
+++ b/src/Slot-Tests/RelationSetTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RelationSetTest,
-	#superclass : #TestCase,
-	#category : #'Slot-Tests-Examples - Associations'
+	#name : 'RelationSetTest',
+	#superclass : 'TestCase',
+	#category : 'Slot-Tests-Examples - Associations',
+	#package : 'Slot-Tests',
+	#tag : 'Examples - Associations'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RelationSetTest >> testCopy [
 	"A copy of an RelationSet should give us a regular Set."
 
@@ -15,7 +17,7 @@ RelationSetTest >> testCopy [
 	self deny: movie actors copy class equals: RelationSet
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RelationSetTest >> testSelect [
 
 	| movie result |

--- a/src/Slot-Tests/RelationSlotTest.class.st
+++ b/src/Slot-Tests/RelationSlotTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RelationSlotTest,
-	#superclass : #TestCase,
-	#category : #'Slot-Tests-Examples - Associations'
+	#name : 'RelationSlotTest',
+	#superclass : 'TestCase',
+	#category : 'Slot-Tests-Examples - Associations',
+	#package : 'Slot-Tests',
+	#tag : 'Examples - Associations'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RelationSlotTest >> testDefinition [
 
 	| s1 s2 |
@@ -16,7 +18,7 @@ RelationSlotTest >> testDefinition [
 	self assert: s1 hasInverse
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RelationSlotTest >> testDefinitionWithClass [
 
 	| s1 s2 |
@@ -28,7 +30,7 @@ RelationSlotTest >> testDefinitionWithClass [
 	self assert: s1 hasInverse
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RelationSlotTest >> testDefinitionWithoutInverse [
 
 	| slot |
@@ -37,7 +39,7 @@ RelationSlotTest >> testDefinitionWithoutInverse [
 	self deny: slot hasInverse
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RelationSlotTest >> testEquals [
 
 	| s1 s2 |
@@ -49,7 +51,7 @@ RelationSlotTest >> testEquals [
 	self assert: s1 hash equals: s2 hash
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RelationSlotTest >> testNotEquals [
 	| s1 s2 |
 	s1 := ToManyRelationSlot named: #slot inverse: #x inClass: #SlotExamplePerson.

--- a/src/Slot-Tests/SelfVariableTest.class.st
+++ b/src/Slot-Tests/SelfVariableTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SelfVariableTest,
-	#superclass : #TestCase,
-	#category : #'Slot-Tests-VariablesAndSlots'
+	#name : 'SelfVariableTest',
+	#superclass : 'TestCase',
+	#category : 'Slot-Tests-VariablesAndSlots',
+	#package : 'Slot-Tests',
+	#tag : 'VariablesAndSlots'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 SelfVariableTest >> testReadInContext [
 
 	| var |
@@ -14,7 +16,7 @@ SelfVariableTest >> testReadInContext [
 	self assert: [(var readInContext: thisContext)] value identicalTo: self
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SelfVariableTest >> testReadInContextClean [
 	<compilerOptions: #( +optionCleanBlockClosure)>
 	| var block |
@@ -27,7 +29,7 @@ SelfVariableTest >> testReadInContextClean [
 	self assert: (var readInContext: block value ) equals: nil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SelfVariableTest >> testUsingMethods [
 
 	|  var |
@@ -35,7 +37,7 @@ SelfVariableTest >> testUsingMethods [
 	self assert: (var usingMethods includes: thisContext method)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SelfVariableTest >> testUsingMethodsFFI [
 
 	|  var |
@@ -45,7 +47,7 @@ SelfVariableTest >> testUsingMethodsFFI [
 	self assert: (var usingMethods anySatisfy: [:method | method isFFIMethod and: [ method readsSelf not ]])
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SelfVariableTest >> testUsingMethodsSuper [
 
 	|  var |

--- a/src/Slot-Tests/SlotAnnouncementsTest.class.st
+++ b/src/Slot-Tests/SlotAnnouncementsTest.class.st
@@ -1,36 +1,38 @@
 Class {
-	#name : #SlotAnnouncementsTest,
-	#superclass : #SlotClassBuilderTest,
+	#name : 'SlotAnnouncementsTest',
+	#superclass : 'SlotClassBuilderTest',
 	#instVars : [
 		'announcement',
 		'collectedAnnouncements'
 	],
-	#category : #'Slot-Tests-ClassBuilder'
+	#category : 'Slot-Tests-ClassBuilder',
+	#package : 'Slot-Tests',
+	#tag : 'ClassBuilder'
 }
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 SlotAnnouncementsTest >> collectedAnnouncementClasses [
 	^ collectedAnnouncements collect: [:each | each class]
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 SlotAnnouncementsTest >> collectedAnnouncements [
 	^ collectedAnnouncements
 ]
 
-{ #category : #'tests - integration' }
+{ #category : 'tests - integration' }
 SlotAnnouncementsTest >> createClass [
 
 	^ self createClassWithLayout: FixedLayout
 ]
 
-{ #category : #'tests - integration' }
+{ #category : 'tests - integration' }
 SlotAnnouncementsTest >> createClassWithLayout: aLayoutClass [
 
 	^ self createClassWithLayout: aLayoutClass traitComposition: #()
 ]
 
-{ #category : #'tests - integration' }
+{ #category : 'tests - integration' }
 SlotAnnouncementsTest >> createClassWithLayout: aLayoutClass traitComposition: aTraitComposition [
 
 	^ self class classInstaller make: [ :aClassBuilder |
@@ -41,20 +43,20 @@ SlotAnnouncementsTest >> createClassWithLayout: aLayoutClass traitComposition: a
 			package: self slotTestPackageName ]
 ]
 
-{ #category : #'tests - integration' }
+{ #category : 'tests - integration' }
 SlotAnnouncementsTest >> createClassWithTraitComposition: aTraitComposition [
 
 	^ self createClassWithLayout: FixedLayout traitComposition: aTraitComposition
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SlotAnnouncementsTest >> setUp [
 	super setUp.
 
 	collectedAnnouncements := OrderedCollection new
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 SlotAnnouncementsTest >> subscribeOn: anAnnouncement [
 
 	SystemAnnouncer uniqueInstance weak
@@ -63,14 +65,14 @@ SlotAnnouncementsTest >> subscribeOn: anAnnouncement [
 		to: collectedAnnouncements
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SlotAnnouncementsTest >> tearDown [
 
 	SystemAnnouncer uniqueInstance unsubscribe: collectedAnnouncements.
 	super tearDown
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotAnnouncementsTest >> testChangeInSharedPoolShouldAnnounceClassModified [
 
 	self subscribeOn: ClassModifiedClassDefinition.
@@ -92,7 +94,7 @@ SlotAnnouncementsTest >> testChangeInSharedPoolShouldAnnounceClassModified [
 	self assert: self collectedAnnouncements first newClassDefinition equals: aClass
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotAnnouncementsTest >> testChangeInSharedVariablesAndSharedPoolsShouldAnnounceClassModified [
 
 	self subscribeOn: ClassModifiedClassDefinition.
@@ -115,7 +117,7 @@ SlotAnnouncementsTest >> testChangeInSharedVariablesAndSharedPoolsShouldAnnounce
 	self assert: self collectedAnnouncements first newClassDefinition equals: aClass
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotAnnouncementsTest >> testChangeInSharedVariablesShouldAnnounceClassModified [
 
 	self subscribeOn: ClassModifiedClassDefinition.
@@ -137,7 +139,7 @@ SlotAnnouncementsTest >> testChangeInSharedVariablesShouldAnnounceClassModified 
 	self assert: self collectedAnnouncements first newClassDefinition equals: aClass
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotAnnouncementsTest >> testChangeInSuperclassShouldNotAnnounceSubclassModified [
 
 	self subscribeOn: ClassModifiedClassDefinition.
@@ -166,7 +168,7 @@ SlotAnnouncementsTest >> testChangeInSuperclassShouldNotAnnounceSubclassModified
 	self assert: self collectedAnnouncements first newClassDefinition equals: anotherClass
 ]
 
-{ #category : #'tests - integration' }
+{ #category : 'tests - integration' }
 SlotAnnouncementsTest >> testClassAddedToNewPackageShouldAnnouncePackageAdded [
 
 	self subscribeOn: PackageAdded.
@@ -180,7 +182,7 @@ SlotAnnouncementsTest >> testClassAddedToNewPackageShouldAnnouncePackageAdded [
 	self assert: self collectedAnnouncements size equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotAnnouncementsTest >> testClassCreationShouldAnnounceClassAdded [
 
 	self subscribeOn: ClassAdded.
@@ -192,7 +194,7 @@ SlotAnnouncementsTest >> testClassCreationShouldAnnounceClassAdded [
 	self assert: self collectedAnnouncements first classAdded equals: aClass
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotAnnouncementsTest >> testClassRecategorizationShouldAnnounceClassModified [
 
 	self subscribeOn: ClassRecategorized.
@@ -207,7 +209,7 @@ SlotAnnouncementsTest >> testClassRecategorizationShouldAnnounceClassModified [
 	self assert: announcement classRecategorized identicalTo: anotherClass
 ]
 
-{ #category : #'tests - comments' }
+{ #category : 'tests - comments' }
 SlotAnnouncementsTest >> testCreateAndChangeWithCommentDoesAnnounceBoth [
 
 	| classCommented |
@@ -240,7 +242,7 @@ SlotAnnouncementsTest >> testCreateAndChangeWithCommentDoesAnnounceBoth [
 	self assert: classCommented newStamp equals: nil "why nil?"
 ]
 
-{ #category : #'tests - comments' }
+{ #category : 'tests - comments' }
 SlotAnnouncementsTest >> testCreateAndChangeWithoutCommentDoesNotAnnounce [
 	self subscribeOn: ClassCommented.
 
@@ -255,7 +257,7 @@ SlotAnnouncementsTest >> testCreateAndChangeWithoutCommentDoesNotAnnounce [
 	self assertEmpty: self collectedAnnouncements
 ]
 
-{ #category : #'tests - comments' }
+{ #category : 'tests - comments' }
 SlotAnnouncementsTest >> testCreateWithCommentDoesAnnounce [
 
 	| classCommented |
@@ -277,7 +279,7 @@ SlotAnnouncementsTest >> testCreateWithCommentDoesAnnounce [
 	self assert: classCommented newStamp equals: nil  "why nil?"
 ]
 
-{ #category : #'tests - comments' }
+{ #category : 'tests - comments' }
 SlotAnnouncementsTest >> testEmptyCommentDoesNotAnnounce [
 	self subscribeOn: ClassCommented.
 
@@ -297,7 +299,7 @@ SlotAnnouncementsTest >> testEmptyCommentDoesNotAnnounce [
 	self assertEmpty: self collectedAnnouncements
 ]
 
-{ #category : #'tests - integration' }
+{ #category : 'tests - integration' }
 SlotAnnouncementsTest >> testFixedClassWhenTraitCompositionChangedShouldAnnounceClassModified [
 
 	self subscribeOn: ClassModifiedClassDefinition.
@@ -314,7 +316,7 @@ SlotAnnouncementsTest >> testFixedClassWhenTraitCompositionChangedShouldAnnounce
 	self assert: (announcement newClassDefinition traitComposition syntacticallyEquals: TOne asTraitComposition)
 ]
 
-{ #category : #'tests - integration' }
+{ #category : 'tests - integration' }
 SlotAnnouncementsTest >> testFixedClassWithTraitCreatedShouldntAnnounceClassModified [
 
 	self subscribeOn: ClassModifiedClassDefinition.
@@ -327,7 +329,7 @@ SlotAnnouncementsTest >> testFixedClassWithTraitCreatedShouldntAnnounceClassModi
 	self assert: (aClass traitComposition syntacticallyEquals: TOne asTraitComposition)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotAnnouncementsTest >> testLayoutChangeShouldAnnounceClassModified [
 
 	| classAdded classModified addedFormat |
@@ -347,7 +349,7 @@ SlotAnnouncementsTest >> testLayoutChangeShouldAnnounceClassModified [
 	self assert: announcement newClassDefinition format equals: classModified format
 ]
 
-{ #category : #'tests - comments' }
+{ #category : 'tests - comments' }
 SlotAnnouncementsTest >> testSameCommentDoesNotAnnounce [
 
 	self subscribeOn: ClassCommented.
@@ -365,7 +367,7 @@ SlotAnnouncementsTest >> testSameCommentDoesNotAnnounce [
 	self assert: self collectedAnnouncements size equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotAnnouncementsTest >> testSlotAdditionShouldAnnounceClassModified [
 
 	| classAdded classModified addedInstanceNames |
@@ -384,7 +386,7 @@ SlotAnnouncementsTest >> testSlotAdditionShouldAnnounceClassModified [
 	self assert: announcement oldClassDefinition allInstVarNames equals: addedInstanceNames
 ]
 
-{ #category : #'tests - integration' }
+{ #category : 'tests - integration' }
 SlotAnnouncementsTest >> testVariableByteClassWhenTraitCompositionChangedShouldAnnounceClassModified [
 
 	self subscribeOn: ClassModifiedClassDefinition.
@@ -401,7 +403,7 @@ SlotAnnouncementsTest >> testVariableByteClassWhenTraitCompositionChangedShouldA
 	self assert: (announcement newClassDefinition traitComposition syntacticallyEquals: TOne asTraitComposition)
 ]
 
-{ #category : #'tests - integration' }
+{ #category : 'tests - integration' }
 SlotAnnouncementsTest >> testVariableByteClassWithTraitCreatedShouldntAnnounceClassModified [
 
 	self subscribeOn: ClassModifiedClassDefinition.
@@ -416,7 +418,7 @@ SlotAnnouncementsTest >> testVariableByteClassWithTraitCreatedShouldntAnnounceCl
 	self assert: (aClass traitComposition syntacticallyEquals: TOne asTraitComposition)
 ]
 
-{ #category : #'tests - integration' }
+{ #category : 'tests - integration' }
 SlotAnnouncementsTest >> testVariableClassWhenTraitCompositionChangedShouldAnnounceClassModified [
 
 	self subscribeOn: ClassModifiedClassDefinition.
@@ -435,7 +437,7 @@ SlotAnnouncementsTest >> testVariableClassWhenTraitCompositionChangedShouldAnnou
 	self assert: (announcement newClassDefinition traitComposition syntacticallyEquals: TOne asTraitComposition)
 ]
 
-{ #category : #'tests - integration' }
+{ #category : 'tests - integration' }
 SlotAnnouncementsTest >> testVariableClassWithTraitCreatedShouldntAnnounceClassModified [
 
 	self subscribeOn: ClassModifiedClassDefinition.
@@ -449,7 +451,7 @@ SlotAnnouncementsTest >> testVariableClassWithTraitCreatedShouldntAnnounceClassM
 	self assert: (aClass traitComposition syntacticallyEquals: TOne asTraitComposition)
 ]
 
-{ #category : #'tests - integration' }
+{ #category : 'tests - integration' }
 SlotAnnouncementsTest >> testVariableWordClassWhenTraitCompositionChangedShouldAnnounceClassModified [
 
 	self subscribeOn: ClassModifiedClassDefinition.
@@ -468,7 +470,7 @@ SlotAnnouncementsTest >> testVariableWordClassWhenTraitCompositionChangedShouldA
 	self assert: (announcement newClassDefinition traitComposition syntacticallyEquals: TOne asTraitComposition)
 ]
 
-{ #category : #'tests - integration' }
+{ #category : 'tests - integration' }
 SlotAnnouncementsTest >> testVariableWordClassWithTraitCreatedShouldntAnnounceClassModified [
 
 	self subscribeOn: ClassModifiedClassDefinition.
@@ -483,7 +485,7 @@ SlotAnnouncementsTest >> testVariableWordClassWithTraitCreatedShouldntAnnounceCl
 	self assert: (aClass traitComposition syntacticallyEquals: TOne asTraitComposition)
 ]
 
-{ #category : #'tests - integration' }
+{ #category : 'tests - integration' }
 SlotAnnouncementsTest >> testWeakClassWhenTraitCompositionChangedShouldAnnounceClassModified [
 
 	self subscribeOn: ClassModifiedClassDefinition.
@@ -501,7 +503,7 @@ SlotAnnouncementsTest >> testWeakClassWhenTraitCompositionChangedShouldAnnounceC
 	self assert: (announcement newClassDefinition traitComposition syntacticallyEquals: TOne asTraitComposition)
 ]
 
-{ #category : #'tests - integration' }
+{ #category : 'tests - integration' }
 SlotAnnouncementsTest >> testWeakClassWithTraitCreatedShouldntAnnounceClassModified [
 
 	self subscribeOn: ClassModifiedClassDefinition.

--- a/src/Slot-Tests/SlotBasicTest.class.st
+++ b/src/Slot-Tests/SlotBasicTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SlotBasicTest,
-	#superclass : #SlotSilentTest,
-	#category : #'Slot-Tests-ClassBuilder'
+	#name : 'SlotBasicTest',
+	#superclass : 'SlotSilentTest',
+	#category : 'Slot-Tests-ClassBuilder',
+	#package : 'Slot-Tests',
+	#tag : 'ClassBuilder'
 }
 
-{ #category : #'tests - class slots' }
+{ #category : 'tests - class slots' }
 SlotBasicTest >> testAddClassSlotAndMigrate [
 
 	| classAdded classModified |
@@ -22,7 +24,7 @@ SlotBasicTest >> testAddClassSlotAndMigrate [
 	self assert: (classModified instVarNamed: #b) isNil
 ]
 
-{ #category : #'tests - shared pools' }
+{ #category : 'tests - shared pools' }
 SlotBasicTest >> testAddSharedPool [
 
 	self make: [ :builder |
@@ -34,7 +36,7 @@ SlotBasicTest >> testAddSharedPool [
 	self assert: (aClass sharedPools includes: TestSharedPool)
 ]
 
-{ #category : #'tests - shared variables' }
+{ #category : 'tests - shared variables' }
 SlotBasicTest >> testAddSharedVariable [
 
 	self make: [ :builder |
@@ -46,7 +48,7 @@ SlotBasicTest >> testAddSharedVariable [
 	self assert: aClass classVarNames equals: #(Var)
 ]
 
-{ #category : #'tests - basic' }
+{ #category : 'tests - basic' }
 SlotBasicTest >> testBasicClassBuilding [
 	aClass := self make: [ :builder | builder name: self aClassName ].
 
@@ -55,7 +57,7 @@ SlotBasicTest >> testBasicClassBuilding [
 	self assert: (self class environment at: self aClassName) identicalTo: aClass
 ]
 
-{ #category : #'tests - comments' }
+{ #category : 'tests - comments' }
 SlotBasicTest >> testClassWithComment [
 
 	aClass := self make: [ :builder |
@@ -67,7 +69,7 @@ SlotBasicTest >> testClassWithComment [
 	self assert: aClass comment equals: 'A class Comment'
 ]
 
-{ #category : #'tests - comments' }
+{ #category : 'tests - comments' }
 SlotBasicTest >> testClassWithCommentAndStamp [
 
 	aClass := self make: [ :builder |
@@ -80,7 +82,7 @@ SlotBasicTest >> testClassWithCommentAndStamp [
 	self assert: aClass commentStamp equals: (Object>>#halt) stamp
 ]
 
-{ #category : #'tests - basic' }
+{ #category : 'tests - basic' }
 SlotBasicTest >> testNewCompiledMethodClass [
 
 	aClass := self makeWithLayout: CompiledMethodLayout.
@@ -90,7 +92,7 @@ SlotBasicTest >> testNewCompiledMethodClass [
 	self deny: aClass isWeak
 ]
 
-{ #category : #'tests - basic' }
+{ #category : 'tests - basic' }
 SlotBasicTest >> testNewPointerClass [
 	aClass := self makeWithLayout: FixedLayout.
 	self assert: aClass isPointers.
@@ -98,7 +100,7 @@ SlotBasicTest >> testNewPointerClass [
 	self assertEmpty: aClass instVarNames
 ]
 
-{ #category : #'tests - basic' }
+{ #category : 'tests - basic' }
 SlotBasicTest >> testNewPointerClassWithSlots [
 
 	aClass := self
@@ -109,7 +111,7 @@ SlotBasicTest >> testNewPointerClassWithSlots [
 	self assert: (aClass instVarNames includes: 'name')
 ]
 
-{ #category : #'tests - basic' }
+{ #category : 'tests - basic' }
 SlotBasicTest >> testNewVariableByteClass [
 
 	aClass := self makeWithLayout: ByteLayout.
@@ -119,7 +121,7 @@ SlotBasicTest >> testNewVariableByteClass [
 	self assert: aClass isVariable
 ]
 
-{ #category : #'tests - basic' }
+{ #category : 'tests - basic' }
 SlotBasicTest >> testNewVariableWordClass [
 
 	aClass := self makeWithLayout: WordLayout.
@@ -129,7 +131,7 @@ SlotBasicTest >> testNewVariableWordClass [
 	self assert: aClass isVariable
 ]
 
-{ #category : #'tests - basic' }
+{ #category : 'tests - basic' }
 SlotBasicTest >> testNewWeakClass [
 
 	aClass := self makeWithLayout: WeakLayout.
@@ -139,7 +141,7 @@ SlotBasicTest >> testNewWeakClass [
 	self assert: aClass isWeak
 ]
 
-{ #category : #'tests - class slots' }
+{ #category : 'tests - class slots' }
 SlotBasicTest >> testRemoveClassSlotAndMigrate [
 
 	| classAdded classModified |
@@ -157,7 +159,7 @@ SlotBasicTest >> testRemoveClassSlotAndMigrate [
 	self should: [ classModified instVarNamed: #b ] raise: Error
 ]
 
-{ #category : #'tests - shared pools' }
+{ #category : 'tests - shared pools' }
 SlotBasicTest >> testRemoveSharedPool [
 	self make: [ :builder | builder sharedPools: 'TestSharedPool' ].
 
@@ -166,7 +168,7 @@ SlotBasicTest >> testRemoveSharedPool [
 	self assertEmpty: aClass sharedPools
 ]
 
-{ #category : #'tests - shared variables' }
+{ #category : 'tests - shared variables' }
 SlotBasicTest >> testRemoveSharedVariable [
 	self make: [ :builder | builder sharedVariablesFromString: 'Var' ].
 
@@ -175,7 +177,7 @@ SlotBasicTest >> testRemoveSharedVariable [
 	self assertEmpty: aClass classVarNames
 ]
 
-{ #category : #'tests - class slots' }
+{ #category : 'tests - class slots' }
 SlotBasicTest >> testSwitchClassSlotAndMigrate [
 
 	| classAdded classModified |
@@ -206,7 +208,7 @@ SlotBasicTest >> testSwitchClassSlotAndMigrate [
 	self assert: classModified b equals: $B
 ]
 
-{ #category : #'tests - class slots' }
+{ #category : 'tests - class slots' }
 SlotBasicTest >> testWithClassSlots [
 
 	aClass := self make: [ :builder |
@@ -217,7 +219,7 @@ SlotBasicTest >> testWithClassSlots [
 	self assert: (aClass instVarNamed: #a) equals: $A
 ]
 
-{ #category : #'tests - shared pools' }
+{ #category : 'tests - shared pools' }
 SlotBasicTest >> testWithSharedPool [
 
 	aClass := self make: [ :builder |
@@ -228,7 +230,7 @@ SlotBasicTest >> testWithSharedPool [
 	self assert: aClass one equals: 1
 ]
 
-{ #category : #'tests - shared variables' }
+{ #category : 'tests - shared variables' }
 SlotBasicTest >> testWithSharedVariable [
 	<ignoreNotImplementedSelectors: #(var:)>
 	aClass := self make: [ :builder |
@@ -243,21 +245,21 @@ SlotBasicTest >> testWithSharedVariable [
 	self assert: aClass var
 ]
 
-{ #category : #'tests - class slots' }
+{ #category : 'tests - class slots' }
 SlotBasicTest >> testWithoutClassSlots [
 	aClass := self make: [ :builder | builder classSlots: #() ].
 
 	self assertEmpty: aClass classVarNames
 ]
 
-{ #category : #'tests - shared pools' }
+{ #category : 'tests - shared pools' }
 SlotBasicTest >> testWithoutSharedPools [
 	aClass := self make: [ :builder | builder sharedPools: '' ].
 
 	self assertEmpty: aClass sharedPools
 ]
 
-{ #category : #'tests - shared variables' }
+{ #category : 'tests - shared variables' }
 SlotBasicTest >> testWithoutSharedVariables [
 	aClass := self make: [ :builder | builder sharedVariablesFromString: '' ].
 

--- a/src/Slot-Tests/SlotClassBuilderTest.class.st
+++ b/src/Slot-Tests/SlotClassBuilderTest.class.st
@@ -1,25 +1,27 @@
 Class {
-	#name : #SlotClassBuilderTest,
-	#superclass : #AbstractEnvironmentTestCase,
+	#name : 'SlotClassBuilderTest',
+	#superclass : 'AbstractEnvironmentTestCase',
 	#instVars : [
 		'aClass',
 		'anotherClass',
 		'yetAnotherClass'
 	],
-	#category : #'Slot-Tests-ClassBuilder'
+	#category : 'Slot-Tests-ClassBuilder',
+	#package : 'Slot-Tests',
+	#tag : 'ClassBuilder'
 }
 
-{ #category : #'helpers-names' }
+{ #category : 'helpers-names' }
 SlotClassBuilderTest >> aClassName [
 	^ #SlotTestsClassA
 ]
 
-{ #category : #'helpers-names' }
+{ #category : 'helpers-names' }
 SlotClassBuilderTest >> anotherClassName [
 	^ #SlotTestsClassB
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SlotClassBuilderTest >> assertTraitIntegrity [
 	self assert: TOne traitUsers isHealthy.
 	self assert: TOne classTrait traitUsers isHealthy.
@@ -27,7 +29,7 @@ SlotClassBuilderTest >> assertTraitIntegrity [
 	self assert: TTwo classTrait traitUsers isHealthy
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SlotClassBuilderTest >> cleanUpTrait: trait [
 	"During development some tests might invalidate the trait internal state.
 	To avoid follow-up failures we reset the trait state here as good as possible."
@@ -36,17 +38,17 @@ SlotClassBuilderTest >> cleanUpTrait: trait [
 	trait classTrait traitUsers removeAll
 ]
 
-{ #category : #'helpers-names' }
+{ #category : 'helpers-names' }
 SlotClassBuilderTest >> layoutClasses [
 	^ { ByteLayout. WordLayout. FixedLayout. VariableLayout. WeakLayout }
 ]
 
-{ #category : #'helpers-names' }
+{ #category : 'helpers-names' }
 SlotClassBuilderTest >> layoutClassesWithSlots [
 	^ { FixedLayout. VariableLayout. WeakLayout }
 ]
 
-{ #category : #'helpers-building' }
+{ #category : 'helpers-building' }
 SlotClassBuilderTest >> make: anUnaryBlock [
 	"I build a class for testing, providing basic default values, but eventually customized by the received unary block."
 
@@ -59,12 +61,12 @@ SlotClassBuilderTest >> make: anUnaryBlock [
 		  anUnaryBlock value: builder ]
 ]
 
-{ #category : #'helpers-building' }
+{ #category : 'helpers-building' }
 SlotClassBuilderTest >> makeWithLayout: aClassLayout [
 	^self makeWithLayout: aClassLayout andSlots: {}
 ]
 
-{ #category : #'helpers-building' }
+{ #category : 'helpers-building' }
 SlotClassBuilderTest >> makeWithLayout: aClassLayout andSlots: someSlots [
 	"
 	I create a class using the Slot class builder given a class layout and a collection of slots.
@@ -77,12 +79,12 @@ SlotClassBuilderTest >> makeWithLayout: aClassLayout andSlots: someSlots [
 		]
 ]
 
-{ #category : #'helpers-names' }
+{ #category : 'helpers-names' }
 SlotClassBuilderTest >> slotTestPackageName [
 	^ 'SlotTestsTmp'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SlotClassBuilderTest >> tearDown [
 	"We remove the classes that could have been created during test run"
 
@@ -104,12 +106,12 @@ SlotClassBuilderTest >> tearDown [
 	super tearDown
 ]
 
-{ #category : #'helpers-names' }
+{ #category : 'helpers-names' }
 SlotClassBuilderTest >> yetAnotherClassName [
 	^ #SlotTestsClassC
 ]
 
-{ #category : #'helpers-names' }
+{ #category : 'helpers-names' }
 SlotClassBuilderTest >> yetYetAnotherClassName [
 	^ #SlotTestsClassD
 ]

--- a/src/Slot-Tests/SlotClassVariableTest.class.st
+++ b/src/Slot-Tests/SlotClassVariableTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SlotClassVariableTest,
-	#superclass : #SlotClassBuilderTest,
-	#category : #'Slot-Tests-ClassBuilder'
+	#name : 'SlotClassVariableTest',
+	#superclass : 'SlotClassBuilderTest',
+	#category : 'Slot-Tests-ClassBuilder',
+	#package : 'Slot-Tests',
+	#tag : 'ClassBuilder'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotClassVariableTest >> testAccessorInstanceVariableSlotGeneratesAccessors [
 	| class1 |
 
@@ -19,7 +21,7 @@ SlotClassVariableTest >> testAccessorInstanceVariableSlotGeneratesAccessors [
 	self assert: (class1 class canUnderstand: #foo:)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotClassVariableTest >> testClassVariableDoesNotDuplicatesSubclassesOfSuperclass [
 	"Issue: 13028"
 	| class1 class2 |
@@ -43,7 +45,7 @@ SlotClassVariableTest >> testClassVariableDoesNotDuplicatesSubclassesOfSuperclas
 	self assert: class1 subclasses equals: { class2 }
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotClassVariableTest >> testSlotIsPersistedAfterRebuildOfClass [
 	| class1 |
 
@@ -68,7 +70,7 @@ SlotClassVariableTest >> testSlotIsPersistedAfterRebuildOfClass [
 	self assert: (class1 class slots at:1) class equals: AccessorInstanceVariableSlot
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotClassVariableTest >> testWantsInitializationAddsInitializeSlot [
 
 	| class1 |
@@ -87,7 +89,7 @@ SlotClassVariableTest >> testWantsInitializationAddsInitializeSlot [
 	self assert: (class1 >> #initialize) literals second equals: #initializeSlots:
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotClassVariableTest >> testWantsInitializationSkipInitializeSlotIfAlreadyInHierarchy [
 	| class1 class2 |
 

--- a/src/Slot-Tests/SlotEnvironmentTest.class.st
+++ b/src/Slot-Tests/SlotEnvironmentTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SlotEnvironmentTest,
-	#superclass : #SlotSilentTest,
-	#category : #'Slot-Tests-ClassBuilder'
+	#name : 'SlotEnvironmentTest',
+	#superclass : 'SlotSilentTest',
+	#category : 'Slot-Tests-ClassBuilder',
+	#package : 'Slot-Tests',
+	#tag : 'ClassBuilder'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotEnvironmentTest >> testBasicEnvironment [
 	| environment |
 	environment := SystemDictionary new.

--- a/src/Slot-Tests/SlotErrorsTest.class.st
+++ b/src/Slot-Tests/SlotErrorsTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SlotErrorsTest,
-	#superclass : #SlotSilentTest,
-	#category : #'Slot-Tests-ClassBuilder'
+	#name : 'SlotErrorsTest',
+	#superclass : 'SlotSilentTest',
+	#category : 'Slot-Tests-ClassBuilder',
+	#package : 'Slot-Tests',
+	#tag : 'ClassBuilder'
 }
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 SlotErrorsTest >> assertInvalidClassName: aName [
 
 	self should: [
@@ -19,7 +21,7 @@ SlotErrorsTest >> assertInvalidClassName: aName [
 		raise: InvalidGlobalName
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotErrorsTest >> testCannotBeRecompiled [
 	| superclass |
 	<expectedFailure>
@@ -43,25 +45,25 @@ SlotErrorsTest >> testCannotBeRecompiled [
 		description: 'Old class builder raises: X cannot be recompiled'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotErrorsTest >> testClassNameMustBeCapitalized [
 
 	self assertInvalidClassName: #aNotCapitalizedClassName
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotErrorsTest >> testClassNameMustBeSymbol [
 
 	self assertInvalidClassName: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotErrorsTest >> testClassNameWithInvalidCharacter [
 
 	self assertInvalidClassName: #'Invalid-ClassName'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotErrorsTest >> testClassSlotDuplicationConflict [
 
 	aClass := self make: [ :builder |
@@ -76,7 +78,7 @@ SlotErrorsTest >> testClassSlotDuplicationConflict [
 		raise: DuplicatedSlotName
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotErrorsTest >> testDangerousClassesConditions [
 
 	| specialObjectsArrayItem |
@@ -87,7 +89,7 @@ SlotErrorsTest >> testDangerousClassesConditions [
 	self assert: (DangerousClassNotifier shouldNotBeRedefined: specialObjectsArrayItem)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotErrorsTest >> testDangerousClassesEnabling [
 
 	| savedExistingSystemSetting myExpectedError |
@@ -119,7 +121,7 @@ SlotErrorsTest >> testDangerousClassesEnabling [
 	self assert: DangerousClassNotifier enabled equals: savedExistingSystemSetting
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotErrorsTest >> testDirectCircularHierarchyError [
 	"Tests an error is raised when trying to create a hierarchy A<-A"
 
@@ -137,7 +139,7 @@ SlotErrorsTest >> testDirectCircularHierarchyError [
 		raise: CircularHierarchyError
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotErrorsTest >> testIndirectCircularHierarchyError [
 	"Tests an error is raised when trying to create a hierarchy A<-B<-A"
 
@@ -160,7 +162,7 @@ SlotErrorsTest >> testIndirectCircularHierarchyError [
 		raise: CircularHierarchyError
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotErrorsTest >> testSlotDuplicationConflict [
 
 	aClass := self make: [ :builder |
@@ -175,7 +177,7 @@ SlotErrorsTest >> testSlotDuplicationConflict [
 		raise: DuplicatedSlotName
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotErrorsTest >> testUndeclareSlot [
 	| slot instance |
 
@@ -195,7 +197,7 @@ SlotErrorsTest >> testUndeclareSlot [
 	self assert: (slot read: instance) equals: nil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotErrorsTest >> testUndeclareSlotFixWhenSlotIsLoaded [
 	| slot instance mySlot |
 
@@ -231,7 +233,7 @@ SlotErrorsTest >> testUndeclareSlotFixWhenSlotIsLoaded [
 	self assert: (mySlot read: instance) equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotErrorsTest >> testValidateClassName [
 
 	Smalltalk classInstaller

--- a/src/Slot-Tests/SlotExampleMovie.class.st
+++ b/src/Slot-Tests/SlotExampleMovie.class.st
@@ -2,67 +2,69 @@
 A SlotExampleMovie is an example class to demonstrate the workings of relation slots.
 "
 Class {
-	#name : #SlotExampleMovie,
-	#superclass : #Object,
+	#name : 'SlotExampleMovie',
+	#superclass : 'Object',
 	#instVars : [
 		'#name',
 		'#director => ToOneRelationSlot inverse: #directedMovies inClass: #SlotExamplePerson',
 		'#actors => ToManyRelationSlot inverse: #actedInMovies inClass: #SlotExamplePerson'
 	],
-	#category : #'Slot-Tests-Examples - Associations'
+	#category : 'Slot-Tests-Examples - Associations',
+	#package : 'Slot-Tests',
+	#tag : 'Examples - Associations'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SlotExampleMovie class >> named: aString [
 	^ self new
 		name: aString;
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SlotExampleMovie >> actors [
 	^ actors
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SlotExampleMovie >> actors: anObject [
 	actors := anObject
 ]
 
-{ #category : #'adding-removing' }
+{ #category : 'adding-removing' }
 SlotExampleMovie >> addActor: aPerson [
 
 	^actors add: aPerson
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SlotExampleMovie >> director [
 	^ director
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SlotExampleMovie >> director: aPerson [
 
 	director := aPerson
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SlotExampleMovie >> initialize [
 	super initialize.
 	self class initializeSlots: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SlotExampleMovie >> name [
 	^ name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SlotExampleMovie >> name: anObject [
 	name := anObject
 ]
 
-{ #category : #'adding-removing' }
+{ #category : 'adding-removing' }
 SlotExampleMovie >> removeActor: aPerson [
 
 	^actors remove: aPerson

--- a/src/Slot-Tests/SlotExampleMovieAndPersonTest.class.st
+++ b/src/Slot-Tests/SlotExampleMovieAndPersonTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SlotExampleMovieAndPersonTest,
-	#superclass : #TestCase,
-	#category : #'Slot-Tests-Examples - Associations'
+	#name : 'SlotExampleMovieAndPersonTest',
+	#superclass : 'TestCase',
+	#category : 'Slot-Tests-Examples - Associations',
+	#package : 'Slot-Tests',
+	#tag : 'Examples - Associations'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotExampleMovieAndPersonTest >> testAddActors [
 
 	| m1 m2 p1 p2 |
@@ -24,7 +26,7 @@ SlotExampleMovieAndPersonTest >> testAddActors [
 	self assert: p2 actedInMovies size equals: 2
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotExampleMovieAndPersonTest >> testAddAndRemoveActors [
 	| m1 m2 p1 p2 |
 	m1 := SlotExampleMovie named: 'M1'.
@@ -45,7 +47,7 @@ SlotExampleMovieAndPersonTest >> testAddAndRemoveActors [
 	self should: [ m2 removeActor: p2 ] raise: Error
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotExampleMovieAndPersonTest >> testAddMovieDirector [
 
 	| movie person |
@@ -59,7 +61,7 @@ SlotExampleMovieAndPersonTest >> testAddMovieDirector [
 	self assert: person directedMovies anyOne equals: movie
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotExampleMovieAndPersonTest >> testAddMovieDirectorInvalid [
 
 	| person |
@@ -69,7 +71,7 @@ SlotExampleMovieAndPersonTest >> testAddMovieDirectorInvalid [
 	self should: [ person directedMovies add: 'not-a-movie' ] raise: Error
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotExampleMovieAndPersonTest >> testAddMovieDirectorTwice [
 
 	| movie person |
@@ -83,7 +85,7 @@ SlotExampleMovieAndPersonTest >> testAddMovieDirectorTwice [
 	self assert: person directedMovies anyOne equals: movie
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotExampleMovieAndPersonTest >> testChangeMovieDirector [
 	| movie p1 p2 |
 	movie := SlotExampleMovie named: 'Jaws'.
@@ -101,7 +103,7 @@ SlotExampleMovieAndPersonTest >> testChangeMovieDirector [
 	self assert: p2 directedMovies anyOne equals: movie
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotExampleMovieAndPersonTest >> testNewMovie [
 	| movie |
 	movie := SlotExampleMovie new.
@@ -111,7 +113,7 @@ SlotExampleMovieAndPersonTest >> testNewMovie [
 	self assertEmpty: movie actors
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotExampleMovieAndPersonTest >> testNewPerson [
 	| person |
 	person := SlotExamplePerson new.
@@ -120,7 +122,7 @@ SlotExampleMovieAndPersonTest >> testNewPerson [
 	self assertEmpty: person directedMovies
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotExampleMovieAndPersonTest >> testSetAndRemoveMovieDirector [
 	| movie person |
 	movie := SlotExampleMovie named: 'Jaws'.
@@ -135,7 +137,7 @@ SlotExampleMovieAndPersonTest >> testSetAndRemoveMovieDirector [
 	self assertEmpty: person directedMovies
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotExampleMovieAndPersonTest >> testSetAndUnsetMovieDirector [
 	| movie person |
 	movie := SlotExampleMovie named: 'Jaws'.
@@ -150,7 +152,7 @@ SlotExampleMovieAndPersonTest >> testSetAndUnsetMovieDirector [
 	self assertEmpty: person directedMovies
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotExampleMovieAndPersonTest >> testSetMovieDirector [
 
 	| movie person |
@@ -164,7 +166,7 @@ SlotExampleMovieAndPersonTest >> testSetMovieDirector [
 	self assert: person directedMovies anyOne equals: movie
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotExampleMovieAndPersonTest >> testSetMovieDirectorInvalid [
 
 	| movie |
@@ -175,7 +177,7 @@ SlotExampleMovieAndPersonTest >> testSetMovieDirectorInvalid [
 	self assert: movie director isNil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotExampleMovieAndPersonTest >> testSetMovieDirectorTwice [
 
 	| movie person |

--- a/src/Slot-Tests/SlotExamplePerson.class.st
+++ b/src/Slot-Tests/SlotExamplePerson.class.st
@@ -2,56 +2,58 @@
 A SlotExamplePerson is an example class to demonstrate the workings of relation slots.
 "
 Class {
-	#name : #SlotExamplePerson,
-	#superclass : #Object,
+	#name : 'SlotExamplePerson',
+	#superclass : 'Object',
 	#instVars : [
 		'#name',
 		'#directedMovies => ToManyRelationSlot inverse: #director inClass: #SlotExampleMovie',
 		'#actedInMovies => ToManyRelationSlot inverse: #actors inClass: #SlotExampleMovie'
 	],
-	#category : #'Slot-Tests-Examples - Associations'
+	#category : 'Slot-Tests-Examples - Associations',
+	#package : 'Slot-Tests',
+	#tag : 'Examples - Associations'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SlotExamplePerson class >> named: aString [
 	^ self new
 		name: aString;
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SlotExamplePerson >> actedInMovies [
 	^ actedInMovies
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SlotExamplePerson >> actedInMovies: anObject [
 	actedInMovies := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SlotExamplePerson >> directedMovies [
 	^ directedMovies
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SlotExamplePerson >> directedMovies: anObject [
 	directedMovies := anObject
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SlotExamplePerson >> initialize [
 	super initialize.
 	self class initializeSlots: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SlotExamplePerson >> name [
 
 	^name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SlotExamplePerson >> name: anObject [
 	name := anObject
 ]

--- a/src/Slot-Tests/SlotIntegrationTest.class.st
+++ b/src/Slot-Tests/SlotIntegrationTest.class.st
@@ -2,12 +2,14 @@
 I'm a test case of SlotClassBuilder integration in the system. Typically, my tests assert over Class API.
 "
 Class {
-	#name : #SlotIntegrationTest,
-	#superclass : #SlotSilentTest,
-	#category : #'Slot-Tests-ClassBuilder'
+	#name : 'SlotIntegrationTest',
+	#superclass : 'SlotSilentTest',
+	#category : 'Slot-Tests-ClassBuilder',
+	#package : 'Slot-Tests',
+	#tag : 'ClassBuilder'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotIntegrationTest >> testAddAndAddInstVarNamedWithTrait2 [
 	"Add instance variables using the builder interface"
 
@@ -38,7 +40,7 @@ SlotIntegrationTest >> testAddAndAddInstVarNamedWithTrait2 [
 	self assert: aClass new one equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotIntegrationTest >> testAddAndRemoveInstVarNamedWithTrait2 [
 	"Add instance variables using the builder interface"
 
@@ -69,7 +71,7 @@ SlotIntegrationTest >> testAddAndRemoveInstVarNamedWithTrait2 [
 	self assert: aClass new one equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotIntegrationTest >> testAddInstVarNamed [
 	"Add instance variables using the builder interface"
 
@@ -92,7 +94,7 @@ SlotIntegrationTest >> testAddInstVarNamed [
 	self assert: anotherClass instVarNames equals: #(y)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotIntegrationTest >> testAddInstVarNamedClassInterface [
 
 	"Add instance variables using the class interface"
@@ -115,7 +117,7 @@ SlotIntegrationTest >> testAddInstVarNamedClassInterface [
 	self assert: anotherClass instVarNames equals: #(y)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotIntegrationTest >> testAddInstVarNamedWithTrait [
 	"Add instance variables using the builder interface"
 
@@ -149,7 +151,7 @@ SlotIntegrationTest >> testAddInstVarNamedWithTrait [
 	self assert: aClass new one equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotIntegrationTest >> testAddInstVarNamedWithTrait2 [
 	"Add instance variables using the builder interface"
 
@@ -179,7 +181,7 @@ SlotIntegrationTest >> testAddInstVarNamedWithTrait2 [
 	self assert: aClass new one equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotIntegrationTest >> testAnonymousSubclass [
 	aClass := self
 		make: [ :builder |
@@ -195,12 +197,12 @@ SlotIntegrationTest >> testAnonymousSubclass [
 	self assert: anotherClass allInstVarNames equals: #(x)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotIntegrationTest >> testCompiledMethodLayout [
 	self assert: (CompiledMethod classLayout isKindOf: CompiledMethodLayout)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotIntegrationTest >> testRemoveInstVarNamed [
 
 	| answer |
@@ -226,7 +228,7 @@ SlotIntegrationTest >> testRemoveInstVarNamed [
 	self assert: answer equals: #none
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotIntegrationTest >> testRemoveInstVarNamedClassInterface [
 
 	aClass := self make: [ :builder |
@@ -239,7 +241,7 @@ SlotIntegrationTest >> testRemoveInstVarNamedClassInterface [
 	self assert: aClass instVarNames equals: #(x z)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotIntegrationTest >> testRemoveInstVarNamedWithTrait2 [
 	"Add instance variables using the builder interface"
 
@@ -267,7 +269,7 @@ SlotIntegrationTest >> testRemoveInstVarNamedWithTrait2 [
 	self assert: aClass new one equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotIntegrationTest >> testReshapeClassPropagatesToDeepHierarchyClassInterface [
 	"Test reshaping a class which is head of a hierarchy of 4 levels"
 
@@ -334,7 +336,7 @@ SlotIntegrationTest >> testReshapeClassPropagatesToDeepHierarchyClassInterface [
 	yetYetAnotherClass classLayout checkIntegrity
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotIntegrationTest >> testReshapeClassWithClassSlot [
 
 	aClass := self class classInstaller make: [ :aClassBuilder |
@@ -356,7 +358,7 @@ SlotIntegrationTest >> testReshapeClassWithClassSlot [
 	self assert: aClass class instVarNames equals: #(x)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotIntegrationTest >> testSlotNamedIfFoundIfNone [
 
 	aClass := self make: [ :builder |
@@ -374,7 +376,7 @@ SlotIntegrationTest >> testSlotNamedIfFoundIfNone [
 		equals: #none
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotIntegrationTest >> testSlotScopeParallelism [
 	"Proposed by Camille Teruel"
 
@@ -391,7 +393,7 @@ SlotIntegrationTest >> testSlotScopeParallelism [
 	self assert: classWithWrongSlotScope asArray equals: #()
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotIntegrationTest >> testSlotsAreInitializedWithDefiningAnonimousClass [
 	"All slots should include reference to defining class"
 	aClass := self make: [ :builder |
@@ -406,7 +408,7 @@ SlotIntegrationTest >> testSlotsAreInitializedWithDefiningAnonimousClass [
 	self assert: (aClass slots collect: #owningClass as: Set) equals: {aClass} asSet
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotIntegrationTest >> testSmallIntegerLayout [
 	self assert: (SmallInteger classLayout isKindOf: ImmediateLayout)
 ]

--- a/src/Slot-Tests/SlotLayoutEqualityTest.class.st
+++ b/src/Slot-Tests/SlotLayoutEqualityTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SlotLayoutEqualityTest,
-	#superclass : #SlotSilentTest,
-	#category : #'Slot-Tests-ClassBuilder'
+	#name : 'SlotLayoutEqualityTest',
+	#superclass : 'SlotSilentTest',
+	#category : 'Slot-Tests-ClassBuilder',
+	#package : 'Slot-Tests',
+	#tag : 'ClassBuilder'
 }
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 SlotLayoutEqualityTest >> assertClassBuiltWith: blockToBuildAClass isEqualToClassBuiltWith: blockToBuildAnotherClass [
 
 	aClass := self make: [ :builder |
@@ -22,7 +24,7 @@ SlotLayoutEqualityTest >> assertClassBuiltWith: blockToBuildAClass isEqualToClas
 	self assert: aClass classLayout hash equals: anotherClass classLayout hash
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 SlotLayoutEqualityTest >> assertClassBuiltWith: blockToBuildAClass isNotEqualToClassBuiltWith: blockToBuildAnotherClass [
 
 	aClass := self make: [ :builder |
@@ -39,7 +41,7 @@ SlotLayoutEqualityTest >> assertClassBuiltWith: blockToBuildAClass isNotEqualToC
 	self assert: aClass classLayout hash ~= anotherClass classLayout hash
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotLayoutEqualityTest >> testLayoutEquals [
 
 	self layoutClasses do: [:aLayoutClass |
@@ -48,7 +50,7 @@ SlotLayoutEqualityTest >> testLayoutEquals [
 			isEqualToClassBuiltWith: [:builder | builder layoutClass: aLayoutClass ] ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotLayoutEqualityTest >> testLayoutNotEquals [
 
 	self layoutClasses do: [:aLayoutClass |
@@ -58,7 +60,7 @@ SlotLayoutEqualityTest >> testLayoutNotEquals [
 				isNotEqualToClassBuiltWith: [:builder | builder layoutClass: anotherLayoutClass ]]]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotLayoutEqualityTest >> testLayoutWithSlotsEquals [
 
 	self layoutClassesWithSlots do: [:aLayoutClass |
@@ -73,7 +75,7 @@ SlotLayoutEqualityTest >> testLayoutWithSlotsEquals [
 					slots: { #field1}  ]]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotLayoutEqualityTest >> testLayoutWithSlotsNotEquals [
 
 	self layoutClassesWithSlots do: [:aLayoutClass |

--- a/src/Slot-Tests/SlotLayoutExtensionTest.class.st
+++ b/src/Slot-Tests/SlotLayoutExtensionTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SlotLayoutExtensionTest,
-	#superclass : #SlotSilentTest,
-	#category : #'Slot-Tests-ClassBuilder'
+	#name : 'SlotLayoutExtensionTest',
+	#superclass : 'SlotSilentTest',
+	#category : 'Slot-Tests-ClassBuilder',
+	#package : 'Slot-Tests',
+	#tag : 'ClassBuilder'
 }
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 SlotLayoutExtensionTest >> should: superclassBlock extendWith: subclassBlock [
 
 	| superclass |
@@ -17,7 +19,7 @@ SlotLayoutExtensionTest >> should: superclassBlock extendWith: subclassBlock [
 			in: subclassBlock ]
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 SlotLayoutExtensionTest >> shouldnt: superclassBlock extendWith: subclassBlock [
 
 	| superclass |
@@ -32,7 +34,7 @@ SlotLayoutExtensionTest >> shouldnt: superclassBlock extendWith: subclassBlock [
 		raise: IncompatibleLayoutConflict
 ]
 
-{ #category : #'tests - valid extensions' }
+{ #category : 'tests - valid extensions' }
 SlotLayoutExtensionTest >> testByteCanExtendByte [
 
 	self should: [ :builder |
@@ -41,7 +43,7 @@ SlotLayoutExtensionTest >> testByteCanExtendByte [
 			builder layoutClass: ByteLayout ]
 ]
 
-{ #category : #'tests - invalid extensions' }
+{ #category : 'tests - invalid extensions' }
 SlotLayoutExtensionTest >> testByteCannotExtendPointerWithFields [
 
 	self shouldnt: [ :builder |
@@ -52,7 +54,7 @@ SlotLayoutExtensionTest >> testByteCannotExtendPointerWithFields [
 			builder layoutClass: ByteLayout ]
 ]
 
-{ #category : #'tests - invalid extensions' }
+{ #category : 'tests - invalid extensions' }
 SlotLayoutExtensionTest >> testByteCannotExtendWord [
 
 	self shouldnt: [ :builder |
@@ -61,7 +63,7 @@ SlotLayoutExtensionTest >> testByteCannotExtendWord [
 			builder layoutClass: ByteLayout ]
 ]
 
-{ #category : #'tests - valid extensions' }
+{ #category : 'tests - valid extensions' }
 SlotLayoutExtensionTest >> testCompiledMethodCanBeExtended [
 
 	self should: [ :builder |
@@ -70,7 +72,7 @@ SlotLayoutExtensionTest >> testCompiledMethodCanBeExtended [
 			builder layoutClass: CompiledMethodLayout ]
 ]
 
-{ #category : #'tests - invalid extensions' }
+{ #category : 'tests - invalid extensions' }
 SlotLayoutExtensionTest >> testInstanceVariableNamesMetaclassInterface [
 	"Add instance variables using the Metaclass interface"
 
@@ -90,7 +92,7 @@ SlotLayoutExtensionTest >> testInstanceVariableNamesMetaclassInterface [
 	self assert: (anotherClass class allInstVarNames includesAll: #(x y))
 ]
 
-{ #category : #'tests - valid extensions' }
+{ #category : 'tests - valid extensions' }
 SlotLayoutExtensionTest >> testPointerCanExtendPointer [
 
 	self should: [ :builder |
@@ -99,7 +101,7 @@ SlotLayoutExtensionTest >> testPointerCanExtendPointer [
 			builder layoutClass: FixedLayout ]
 ]
 
-{ #category : #'tests - valid extensions' }
+{ #category : 'tests - valid extensions' }
 SlotLayoutExtensionTest >> testPointerCanExtendVariable [
 
 	self should: [ :builder |
@@ -108,7 +110,7 @@ SlotLayoutExtensionTest >> testPointerCanExtendVariable [
 			builder layoutClass: FixedLayout ]
 ]
 
-{ #category : #'tests - invalid extensions' }
+{ #category : 'tests - invalid extensions' }
 SlotLayoutExtensionTest >> testPointerCannotExtendByte [
 
 	self shouldnt: [ :builder |
@@ -117,7 +119,7 @@ SlotLayoutExtensionTest >> testPointerCannotExtendByte [
 			builder layoutClass: FixedLayout ]
 ]
 
-{ #category : #'tests - invalid extensions' }
+{ #category : 'tests - invalid extensions' }
 SlotLayoutExtensionTest >> testPointerCannotExtendWord [
 
 	self shouldnt: [ :builder |
@@ -126,7 +128,7 @@ SlotLayoutExtensionTest >> testPointerCannotExtendWord [
 			builder layoutClass: FixedLayout ]
 ]
 
-{ #category : #'tests - valid extensions' }
+{ #category : 'tests - valid extensions' }
 SlotLayoutExtensionTest >> testPointerWithVariableExtensionIsNowVariable [
 	"This test case reproduces a real bug."
 
@@ -149,7 +151,7 @@ SlotLayoutExtensionTest >> testPointerWithVariableExtensionIsNowVariable [
 	self assert: subclass isVariable
 ]
 
-{ #category : #'tests - valid extensions' }
+{ #category : 'tests - valid extensions' }
 SlotLayoutExtensionTest >> testVariableCanExtendPointer [
 
 	self should: [ :builder |
@@ -158,7 +160,7 @@ SlotLayoutExtensionTest >> testVariableCanExtendPointer [
 			builder layoutClass: VariableLayout ]
 ]
 
-{ #category : #'tests - valid extensions' }
+{ #category : 'tests - valid extensions' }
 SlotLayoutExtensionTest >> testVariableCanExtendVariable [
 
 	self should: [ :builder |
@@ -167,7 +169,7 @@ SlotLayoutExtensionTest >> testVariableCanExtendVariable [
 			builder layoutClass: VariableLayout ]
 ]
 
-{ #category : #'tests - invalid extensions' }
+{ #category : 'tests - invalid extensions' }
 SlotLayoutExtensionTest >> testVariableCannotExtendByte [
 
 	self shouldnt: [ :builder |
@@ -176,7 +178,7 @@ SlotLayoutExtensionTest >> testVariableCannotExtendByte [
 			builder layoutClass: VariableLayout ]
 ]
 
-{ #category : #'tests - invalid extensions' }
+{ #category : 'tests - invalid extensions' }
 SlotLayoutExtensionTest >> testVariableCannotExtendWord [
 
 	self shouldnt: [ :builder |
@@ -185,7 +187,7 @@ SlotLayoutExtensionTest >> testVariableCannotExtendWord [
 			builder layoutClass: VariableLayout ]
 ]
 
-{ #category : #'tests - valid extensions' }
+{ #category : 'tests - valid extensions' }
 SlotLayoutExtensionTest >> testWordCanExtendWord [
 
 	self should: [ :builder |
@@ -194,7 +196,7 @@ SlotLayoutExtensionTest >> testWordCanExtendWord [
 			builder layoutClass: WordLayout ]
 ]
 
-{ #category : #'tests - invalid extensions' }
+{ #category : 'tests - invalid extensions' }
 SlotLayoutExtensionTest >> testWordCannotExtendByte [
 
 	self shouldnt: [ :builder |
@@ -203,7 +205,7 @@ SlotLayoutExtensionTest >> testWordCannotExtendByte [
 			builder layoutClass: WordLayout ]
 ]
 
-{ #category : #'tests - invalid extensions' }
+{ #category : 'tests - invalid extensions' }
 SlotLayoutExtensionTest >> testWordCannotExtendPointerWithFields [
 
 	self shouldnt: [ :builder |

--- a/src/Slot-Tests/SlotMethodRecompilationTest.class.st
+++ b/src/Slot-Tests/SlotMethodRecompilationTest.class.st
@@ -1,23 +1,20 @@
 Class {
-	#name : #SlotMethodRecompilationTest,
-	#superclass : #SlotSilentTest,
+	#name : 'SlotMethodRecompilationTest',
+	#superclass : 'SlotSilentTest',
 	#instVars : [
 		'class'
 	],
-	#category : #'Slot-Tests-ClassBuilder'
+	#category : 'Slot-Tests-ClassBuilder',
+	#package : 'Slot-Tests',
+	#tag : 'ClassBuilder'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SlotMethodRecompilationTest >> method [
 	^ class >> #m1
 ]
 
-{ #category : #accessing }
-SlotMethodRecompilationTest >> methodBinding [
-	^ self method classBinding
-]
-
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMethodRecompilationTest >> reshapeClass [
 	^ class := self
 		make: [ :builder |
@@ -25,7 +22,7 @@ SlotMethodRecompilationTest >> reshapeClass [
 			builder slots: #(#iv) ]
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SlotMethodRecompilationTest >> setUp [
 	super setUp.
 	class := self make: [ :builder |
@@ -33,42 +30,37 @@ SlotMethodRecompilationTest >> setUp [
 	class compile: 'm1'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMethodRecompilationTest >> testClassReshapeShouldKeepClassBinding [
 	"Check that when a class is reshaped, the recompilation of the methods gives correct class bindings (in the literal array of the methods)"
 
 	self reshapeClass.
-	self assert: self methodBinding identicalTo: class binding
+	self assert: self method classBinding identicalTo: class binding
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMethodRecompilationTest >> testClassReshapeShouldKeepClassBindingForTraitMethods [
 	"A method should have the same binding than its class even if it come from a trait"
 
 	self reshapeClass.
-	self assert: self traitMethodBinding identicalTo: class binding
+	self assert: self traitMethod classBinding identicalTo: class binding
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMethodRecompilationTest >> testMethodClassBindingShouldBeClassBinding [
 	"A method should have the same binding than its class"
 
-	self assert: self methodBinding identicalTo: class binding
+	self assert:  self method classBinding identicalTo: class binding
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMethodRecompilationTest >> testTraitMethodClassBindingShouldBeClassBinding [
 	"A method should have the same binding than its class even if it come from a trait"
 
-	self assert: self traitMethodBinding identicalTo: class binding
+	self assert: self traitMethod classBinding identicalTo: class binding
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SlotMethodRecompilationTest >> traitMethod [
 	^ class >> #one
-]
-
-{ #category : #accessing }
-SlotMethodRecompilationTest >> traitMethodBinding [
-	^ self traitMethod classBinding
 ]

--- a/src/Slot-Tests/SlotMigrationTest.class.st
+++ b/src/Slot-Tests/SlotMigrationTest.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #SlotMigrationTest,
-	#superclass : #SlotSilentTest,
+	#name : 'SlotMigrationTest',
+	#superclass : 'SlotSilentTest',
 	#instVars : [
 		'instance'
 	],
-	#category : #'Slot-Tests-ClassBuilder'
+	#category : 'Slot-Tests-ClassBuilder',
+	#package : 'Slot-Tests',
+	#tag : 'ClassBuilder'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMigrationTest >> testAddSharedVariableKeepSubclasses [
 	"Reproduces fogbugz case 13028"
 
@@ -40,7 +42,7 @@ SlotMigrationTest >> testAddSharedVariableKeepSubclasses [
 	self assert: aClass subclasses anyOne identicalTo: anotherClass
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMigrationTest >> testAddSlotAndMigrate [
 	"We create a class without slots and create an instance; then we add a slot and check the instance can hold a value."
 	aClass := self makeWithLayout: FixedLayout.
@@ -55,7 +57,7 @@ SlotMigrationTest >> testAddSlotAndMigrate [
 	aClass classLayout checkIntegrity
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMigrationTest >> testAddSlotPropagateAndMigrate [
 	"We create a class without slots and a subclass, and create an instance of the latter; then we add a slot to superclass and check the instance can hold a value."
 
@@ -82,7 +84,7 @@ SlotMigrationTest >> testAddSlotPropagateAndMigrate [
 	subclass classLayout checkIntegrity
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMigrationTest >> testAddTestSlot [
 	"We create a class without slots and create an instance; then we add a slot and check the instance can hold a value."
 	aClass := self makeWithLayout: FixedLayout andSlots: { #aSlot }.
@@ -97,7 +99,7 @@ SlotMigrationTest >> testAddTestSlot [
 	aClass classLayout checkIntegrity
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMigrationTest >> testChangeLayoutTypeFromByte [
 
 	aClass := self makeWithLayout: ByteLayout.
@@ -112,7 +114,7 @@ SlotMigrationTest >> testChangeLayoutTypeFromByte [
 	self assert: aClass instVarNames equals: { #id. #name }
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMigrationTest >> testChangeLayoutTypeToByte [
 	aClass := self makeWithLayout: FixedLayout andSlots: {#id . #name}.
 	"Change the layout of the class from pointer to bytes"
@@ -124,7 +126,7 @@ SlotMigrationTest >> testChangeLayoutTypeToByte [
 	self assertEmpty: aClass instVarNames
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMigrationTest >> testChangeSuperclass [
 	"Define original hierarchy"
 
@@ -163,7 +165,7 @@ SlotMigrationTest >> testChangeSuperclass [
 	self assert: anotherClass superclass identicalTo: yetAnotherClass
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMigrationTest >> testChangingFormatKeepsMethod [
 
 	aClass := self make: [ :builder |
@@ -185,7 +187,7 @@ SlotMigrationTest >> testChangingFormatKeepsMethod [
 	anotherClass classLayout checkIntegrity
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMigrationTest >> testMigrateSlotWithInitialize [
 	"We create a class without slots, instantiate, then add a lot that wants to intialize the instance"
 	aClass := self makeWithLayout: FixedLayout andSlots: { }.
@@ -198,7 +200,7 @@ SlotMigrationTest >> testMigrateSlotWithInitialize [
 	aClass classLayout checkIntegrity
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMigrationTest >> testMigrateTestSlot [
 	"We create a class with a Test slot, so its  value is shared between instances"
 	| instance2 |
@@ -215,7 +217,7 @@ SlotMigrationTest >> testMigrateTestSlot [
 	aClass classLayout checkIntegrity
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMigrationTest >> testRedefineSuperclass [
 	"This case reproduces a MNU found loading Moose."
 
@@ -234,7 +236,7 @@ SlotMigrationTest >> testRedefineSuperclass [
 	class classLayout checkIntegrity
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMigrationTest >> testRemoveSlotAndMigrate [
 	"We create a class with a slot and create an instance; then we remove the slot and check the instance doesn't hold the value."
 	aClass := self makeWithLayout: FixedLayout andSlots: { #aSlot }.
@@ -250,7 +252,7 @@ SlotMigrationTest >> testRemoveSlotAndMigrate [
 	aClass classLayout checkIntegrity
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMigrationTest >> testRemoveTestSlot [
 	aClass := self makeWithLayout: FixedLayout andSlots: {#anotherSlot => ExampleSlotWithState. #aSlot }.
 
@@ -264,7 +266,7 @@ SlotMigrationTest >> testRemoveTestSlot [
 	aClass classLayout checkIntegrity
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMigrationTest >> testReshapeByteVariableToPointerPropagatesToDeepHierarchy [
 
 	"create the original hierarchy"
@@ -313,7 +315,7 @@ SlotMigrationTest >> testReshapeByteVariableToPointerPropagatesToDeepHierarchy [
 		self assert: each isPointers description: each name, ' was not reshaped.' ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMigrationTest >> testReshapeClassPropagatesToDeepHierarchy [
 	"Test reshaping a class which is head of a hierarchy of 4 levels"
 
@@ -380,7 +382,7 @@ SlotMigrationTest >> testReshapeClassPropagatesToDeepHierarchy [
 	yetYetAnotherClass classLayout checkIntegrity
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMigrationTest >> testReshapePointerToByteVariablePropagatesToDeepHierarchy [
 
 	"create the original hierarchy"
@@ -428,7 +430,7 @@ SlotMigrationTest >> testReshapePointerToByteVariablePropagatesToDeepHierarchy [
 		self assert: each isBytes description: each name, ' was not reshaped.' ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMigrationTest >> testReshapeSuperSuperClass [
 	| supersuperclass superclass subclass |
 	supersuperclass := self
@@ -482,7 +484,7 @@ SlotMigrationTest >> testReshapeSuperSuperClass [
 	supersuperclass classLayout checkIntegrity
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMigrationTest >> testShiftSlotAndMigrate [
 
 	aClass := self makeWithLayout: FixedLayout andSlots: { #a. #c }.
@@ -511,7 +513,7 @@ SlotMigrationTest >> testShiftSlotAndMigrate [
 	aClass classLayout checkIntegrity
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMigrationTest >> testSuperclassChangeLayoutType [
 	"This case reproduces a MNU found loading Moose."
 
@@ -533,7 +535,7 @@ SlotMigrationTest >> testSuperclassChangeLayoutType [
 	self assert: class classLayout isBits
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotMigrationTest >> testSwitchSlotsAndMigrate [
 
 	aClass := self makeWithLayout: FixedLayout andSlots: { #a. #b }.

--- a/src/Slot-Tests/SlotSilentTest.class.st
+++ b/src/Slot-Tests/SlotSilentTest.class.st
@@ -5,15 +5,17 @@ Currently this class silences the SystemAnnouncer and sets the Author to the cla
 
 "
 Class {
-	#name : #SlotSilentTest,
-	#superclass : #SlotClassBuilderTest,
+	#name : 'SlotSilentTest',
+	#superclass : 'SlotClassBuilderTest',
 	#instVars : [
 		'yetYetAnotherClass'
 	],
-	#category : #'Slot-Tests-ClassBuilder'
+	#category : 'Slot-Tests-ClassBuilder',
+	#package : 'Slot-Tests',
+	#tag : 'ClassBuilder'
 }
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 SlotSilentTest >> compileAccessorsFor: aSlot [
 	| readerString writerString |
 	readerString := String streamContents: [ :str |
@@ -35,7 +37,7 @@ SlotSilentTest >> compileAccessorsFor: aSlot [
 	aClass compile: writerString classified: 'accessing'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SlotSilentTest >> runCase [
 
 	SystemAnnouncer uniqueInstance suspendAllWhile: [

--- a/src/Slot-Tests/SlotTest.class.st
+++ b/src/Slot-Tests/SlotTest.class.st
@@ -2,15 +2,17 @@
 tests for Slots 
 "
 Class {
-	#name : #SlotTest,
-	#superclass : #TestCase,
+	#name : 'SlotTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'ivarForTesting'
 	],
-	#category : #'Slot-Tests-VariablesAndSlots'
+	#category : 'Slot-Tests-VariablesAndSlots',
+	#package : 'Slot-Tests',
+	#tag : 'VariablesAndSlots'
 }
 
-{ #category : #'tests - misc' }
+{ #category : 'tests - misc' }
 SlotTest >> testAsSlotCollection [
 
  	self assert: 'a b' asSlotCollection equals: {#a => InstanceVariableSlot. #b => InstanceVariableSlot}.
@@ -20,39 +22,39 @@ SlotTest >> testAsSlotCollection [
 	self should: ['iva|rG' asSlotCollection] raise: Error
 ]
 
-{ #category : #'tests - read/write' }
+{ #category : 'tests - read/write' }
 SlotTest >> testIsReadInMethod [
 
 	ivarForTesting printString.
 	self assert: ((self class slotNamed: #ivarForTesting) isReadIn: self class >> testSelector)
 ]
 
-{ #category : #'tests - testing' }
+{ #category : 'tests - testing' }
 SlotTest >> testIsReferenced [
 	self assert: (Point slotNamed: #x) isReferenced
 ]
 
-{ #category : #'tests - read/write' }
+{ #category : 'tests - read/write' }
 SlotTest >> testIsWrittenInMethod [
 
 	ivarForTesting := #test.
 	self assert: ((self class slotNamed: #ivarForTesting) isWrittenIn: self class >> testSelector)
 ]
 
-{ #category : #'tests - read/write' }
+{ #category : 'tests - read/write' }
 SlotTest >> testNotReadInMethod [
 
 	self deny: ((self class slotNamed: #ivarForTesting) isReadIn: self class >> testSelector)
 ]
 
-{ #category : #'tests - read/write' }
+{ #category : 'tests - read/write' }
 SlotTest >> testNotWrittenInMethodWhenItIsOnlyRead [
 
 	ivarForTesting printString.
 	self deny: ((self class slotNamed: #ivarForTesting) isWrittenIn: self class >> testSelector)
 ]
 
-{ #category : #'tests - properties' }
+{ #category : 'tests - properties' }
 SlotTest >> testPropertyAtPut [
 
 	| testValue ivar |
@@ -68,7 +70,7 @@ SlotTest >> testPropertyAtPut [
 	self assert: ivar properties isNil
 ]
 
-{ #category : #'tests - read/write' }
+{ #category : 'tests - read/write' }
 SlotTest >> testReadFromContext [
 
 	| slot |
@@ -78,7 +80,7 @@ SlotTest >> testReadFromContext [
 	self assert: (slot readInContext: thisContext) equals: #testValue
 ]
 
-{ #category : #'tests - properties' }
+{ #category : 'tests - properties' }
 SlotTest >> testRemoveProperty [
 	| ivar |
 	ivar := self class slotNamed: #ivarForTesting.
@@ -93,7 +95,7 @@ SlotTest >> testRemoveProperty [
 	self assert: ivar properties isNil
 ]
 
-{ #category : #'tests - misc' }
+{ #category : 'tests - misc' }
 SlotTest >> testScope [
 	| variable |
 	variable := self class slotNamed: #ivarForTesting.
@@ -102,13 +104,13 @@ SlotTest >> testScope [
 	self assert: (variable scope lookupVar: variable name) equals: variable
 ]
 
-{ #category : #'tests - misc' }
+{ #category : 'tests - misc' }
 SlotTest >> testSlotUsers [
 	self assert: (ToOneRelationSlot slotUsers includes: SlotExampleMovie).
 	self deny: (ToOneRelationSlot slotUsers includes: SlotExamplePerson)
 ]
 
-{ #category : #'tests - read/write' }
+{ #category : 'tests - read/write' }
 SlotTest >> testWriteToContext [
 
 	| slot |
@@ -118,7 +120,7 @@ SlotTest >> testWriteToContext [
 	self assert: ivarForTesting equals: #testValue
 ]
 
-{ #category : #'tests - misc' }
+{ #category : 'tests - misc' }
 SlotTest >> testisUsed [
 	self assert: InstanceVariableSlot isUsed.
 	self assert: IndexedSlot isUsed. "subclasses are users"

--- a/src/Slot-Tests/SlotTraitsTest.class.st
+++ b/src/Slot-Tests/SlotTraitsTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SlotTraitsTest,
-	#superclass : #SlotSilentTest,
-	#category : #'Slot-Tests-ClassBuilder'
+	#name : 'SlotTraitsTest',
+	#superclass : 'SlotSilentTest',
+	#category : 'Slot-Tests-ClassBuilder',
+	#package : 'Slot-Tests',
+	#tag : 'ClassBuilder'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotTraitsTest >> testClassWithClassTrait [
 	self assertEmpty: TOne traitUsers.
 	self assertEmpty: TOne classTrait traitUsers.
@@ -19,7 +21,7 @@ SlotTraitsTest >> testClassWithClassTrait [
 	self assert: aClass one equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotTraitsTest >> testClassWithTrait [
 	self assertEmpty: TOne traitUsers.
 	self assertEmpty: TOne classTrait traitUsers.
@@ -34,7 +36,7 @@ SlotTraitsTest >> testClassWithTrait [
 	self assert: aClass new one equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotTraitsTest >> testModifyClassTraitComposition [
 	"Tests that when modifying the trait composition on class-side, the old methods are removed from the method dictionary, and the new ones are added."
 
@@ -65,7 +67,7 @@ SlotTraitsTest >> testModifyClassTraitComposition [
 	self deny: (aClass canUnderstand: #two)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotTraitsTest >> testModifyTraitComposition [
 	"Tests that when modifying the trait composition, the old methods are removed from the method dictionary, and the new ones are added."
 
@@ -96,7 +98,7 @@ SlotTraitsTest >> testModifyTraitComposition [
 	self deny: (aClass canUnderstand: #two)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotTraitsTest >> testRemoveClassTrait [
 	"Tests that when removing a trait from class-side, its methods are removed from the method dictionary."
 
@@ -109,7 +111,7 @@ SlotTraitsTest >> testRemoveClassTrait [
 	self assertEmpty: TOne classTrait traitUsers
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotTraitsTest >> testRemoveTrait [
 	"Tests that when removing a trait from a class, its methods are removed from the method dictionary."
 
@@ -122,7 +124,7 @@ SlotTraitsTest >> testRemoveTrait [
 	self deny: (aClass canUnderstand: #one)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotTraitsTest >> testTraitUsersAfterClassReshape [
 
 	aClass := self make: [ :builder |
@@ -165,7 +167,7 @@ SlotTraitsTest >> testTraitUsersAfterClassReshape [
 	self assert: (anotherClass class canUnderstand: #two)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SlotTraitsTest >> testTraitUsersAfterMetaclassReshape [
 
 	aClass := self make: [ :builder |

--- a/src/Slot-Tests/SuperVariableTest.class.st
+++ b/src/Slot-Tests/SuperVariableTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SuperVariableTest,
-	#superclass : #TestCase,
-	#category : #'Slot-Tests-VariablesAndSlots'
+	#name : 'SuperVariableTest',
+	#superclass : 'TestCase',
+	#category : 'Slot-Tests-VariablesAndSlots',
+	#package : 'Slot-Tests',
+	#tag : 'VariablesAndSlots'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 SuperVariableTest >> testReadInContext [
 
 	| var |
@@ -14,7 +16,7 @@ SuperVariableTest >> testReadInContext [
 	self assert: [(var readInContext: thisContext)] value identicalTo: super
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SuperVariableTest >> testReadInContextClean [
 	<compilerOptions: #( +optionCleanBlockClosure)>
 	| var block |
@@ -27,7 +29,7 @@ SuperVariableTest >> testReadInContextClean [
 	self assert: (var readInContext: block value ) equals: nil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SuperVariableTest >> testUsingMethods [
 
 	|  var |

--- a/src/Slot-Tests/TOne.trait.st
+++ b/src/Slot-Tests/TOne.trait.st
@@ -2,16 +2,18 @@
 I am a trait used for testing.
 "
 Trait {
-	#name : #TOne,
-	#category : #'Slot-Tests-Data'
+	#name : 'TOne',
+	#category : 'Slot-Tests-Data',
+	#package : 'Slot-Tests',
+	#tag : 'Data'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 TOne classSide >> classOne [
 	^ 1
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TOne >> one [
 	^ 1
 ]

--- a/src/Slot-Tests/TTwo.trait.st
+++ b/src/Slot-Tests/TTwo.trait.st
@@ -2,11 +2,13 @@
 I am a trait used for testing.
 "
 Trait {
-	#name : #TTwo,
-	#category : #'Slot-Tests-Data'
+	#name : 'TTwo',
+	#category : 'Slot-Tests-Data',
+	#package : 'Slot-Tests',
+	#tag : 'Data'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 TTwo >> two [
 	^ 2
 ]

--- a/src/Slot-Tests/TemporaryVariableTest.class.st
+++ b/src/Slot-Tests/TemporaryVariableTest.class.st
@@ -2,12 +2,14 @@
 Tests for TemporaryVariable 
 "
 Class {
-	#name : #TemporaryVariableTest,
-	#superclass : #TestCase,
-	#category : #'Slot-Tests-VariablesAndSlots'
+	#name : 'TemporaryVariableTest',
+	#superclass : 'TestCase',
+	#category : 'Slot-Tests-VariablesAndSlots',
+	#package : 'Slot-Tests',
+	#tag : 'VariablesAndSlots'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 TemporaryVariableTest >> testDefiningNode [
 	"test for normal temps, copied and tempvector"
 	| ast tempsNodes tempDefintions  tempUses |
@@ -24,21 +26,21 @@ TemporaryVariableTest >> testDefiningNode [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 TemporaryVariableTest >> testHasTemporaryVariablesBlock [
 	| block |
 	block := [ | b | b := 2. b +2  ].
 	self assert: (block hasTemporaryVariableNamed: #b)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 TemporaryVariableTest >> testHasTemporaryVariablesMethod [
 	| method |
 	method := self class >> #testTemporaryVariablesMethod.
 	self assert: (method hasTemporaryVariableNamed: #method)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 TemporaryVariableTest >> testIsReferenced [
 	| method notReferenced |
 	"The temp notReferenced is not used as we test exactly that here"
@@ -47,7 +49,7 @@ TemporaryVariableTest >> testIsReferenced [
 	self deny: method temporaryVariables second isReferenced
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 TemporaryVariableTest >> testPropertyAtPut [
 
 	| testValue temp |
@@ -64,7 +66,7 @@ TemporaryVariableTest >> testPropertyAtPut [
 	self assert: temp properties isNil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 TemporaryVariableTest >> testReadNodes [
 	| method |
 	"On the level of CompiledMethod, args include temps. This needs to be fixed"
@@ -72,7 +74,7 @@ TemporaryVariableTest >> testReadNodes [
 	self assert: (method lookupVar: #aBlock) astNodes notEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 TemporaryVariableTest >> testReadTemporaryVariablesMethod [
 	| tempVar |
 	tempVar := thisContext lookupVar: #tempVar.
@@ -80,7 +82,7 @@ TemporaryVariableTest >> testReadTemporaryVariablesMethod [
 	self assert: (tempVar readInContext: thisContext) equals: tempVar
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 TemporaryVariableTest >> testScope [
 	| method variable |
 	method := self class >> #testTemporaryVariablesMethod.
@@ -90,14 +92,14 @@ TemporaryVariableTest >> testScope [
 	self assert: (variable scope lookupVar: variable name) equals: variable
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 TemporaryVariableTest >> testTemporaryVariablesBlock [
 	| block |
 	block := [ | b | b +2  ].
 	self assert: block temporaryVariables first name equals: #b
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 TemporaryVariableTest >> testTemporaryVariablesMethod [
 	| method |
 	method := self class >> #testTemporaryVariablesMethod.
@@ -110,7 +112,7 @@ TemporaryVariableTest >> testTemporaryVariablesMethod [
 	self assert: (method lookupVar: #aBlock) class equals: ArgumentVariable
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 TemporaryVariableTest >> testWriteTemporaryVariablesMethod [
 	| tempVar |
 	tempVar := thisContext lookupVar: #tempVar.

--- a/src/Slot-Tests/TestSharedPool.class.st
+++ b/src/Slot-Tests/TestSharedPool.class.st
@@ -2,16 +2,18 @@
 I am a shared pool used for testing.
 "
 Class {
-	#name : #TestSharedPool,
-	#superclass : #SharedPool,
+	#name : 'TestSharedPool',
+	#superclass : 'SharedPool',
 	#classVars : [
 		'One',
 		'ReferencedInTest'
 	],
-	#category : #'Slot-Tests-Data'
+	#category : 'Slot-Tests-Data',
+	#package : 'Slot-Tests',
+	#tag : 'Data'
 }
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 TestSharedPool class >> initialize [
 	One := 1
 ]

--- a/src/Slot-Tests/ThisContextVariableTest.class.st
+++ b/src/Slot-Tests/ThisContextVariableTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #ThisContextVariableTest,
-	#superclass : #TestCase,
-	#category : #'Slot-Tests-VariablesAndSlots'
+	#name : 'ThisContextVariableTest',
+	#superclass : 'TestCase',
+	#category : 'Slot-Tests-VariablesAndSlots',
+	#package : 'Slot-Tests',
+	#tag : 'VariablesAndSlots'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 ThisContextVariableTest >> testReadInContext [
 
 	| var |
@@ -12,7 +14,7 @@ ThisContextVariableTest >> testReadInContext [
 	self assert: (var readInContext: thisContext) identicalTo: thisContext
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ThisContextVariableTest >> testUsingMethods [
 
 	| var |

--- a/src/Slot-Tests/UnlimitedInstanceVariableSlotTest.class.st
+++ b/src/Slot-Tests/UnlimitedInstanceVariableSlotTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #UnlimitedInstanceVariableSlotTest,
-	#superclass : #SlotSilentTest,
-	#category : #'Slot-Tests-Examples'
+	#name : 'UnlimitedInstanceVariableSlotTest',
+	#superclass : 'SlotSilentTest',
+	#category : 'Slot-Tests-Examples',
+	#package : 'Slot-Tests',
+	#tag : 'Examples'
 }
 
-{ #category : #'test - unlimited ivars' }
+{ #category : 'test - unlimited ivars' }
 UnlimitedInstanceVariableSlotTest >> testExampleIvarSlot [
 	| object slot |
 	<ignoreNotImplementedSelectors: #(slot1: slot1)>
@@ -25,7 +27,7 @@ UnlimitedInstanceVariableSlotTest >> testExampleIvarSlot [
 	self deny: object slot1
 ]
 
-{ #category : #'test - unlimited ivars' }
+{ #category : 'test - unlimited ivars' }
 UnlimitedInstanceVariableSlotTest >> testExampleTwoIvarSlots [
 	| object slot1 slot2 |
 	slot1 := #slot1 => UnlimitedInstanceVariableSlot.

--- a/src/Slot-Tests/WriteOnceSlotTest.class.st
+++ b/src/Slot-Tests/WriteOnceSlotTest.class.st
@@ -2,12 +2,14 @@
 Automated tests for WriteOnceSlot
 "
 Class {
-	#name : #WriteOnceSlotTest,
-	#superclass : #SlotSilentTest,
-	#category : #'Slot-Tests-Examples'
+	#name : 'WriteOnceSlotTest',
+	#superclass : 'SlotSilentTest',
+	#category : 'Slot-Tests-Examples',
+	#package : 'Slot-Tests',
+	#tag : 'Examples'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 WriteOnceSlotTest >> testClassSide [
 	"test that we can change a normal slot into a WriteOnceSlot. Tests class side slot init"
 	| slot |
@@ -19,7 +21,7 @@ WriteOnceSlotTest >> testClassSide [
 	self assert: (aClass class hasSlotNamed: #slot1)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 WriteOnceSlotTest >> testRead [
 	| slot |
 	<ignoreNotImplementedSelectors: #(slot1)>
@@ -31,7 +33,7 @@ WriteOnceSlotTest >> testRead [
 	self assert: aClass new slot1 equals: nil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 WriteOnceSlotTest >> testWriteAndRead [
 	| slot object |
 	<ignoreNotImplementedSelectors: #(slot1: slot1)>
@@ -46,7 +48,7 @@ WriteOnceSlotTest >> testWriteAndRead [
 	self assert: object slot1 equals: 3
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 WriteOnceSlotTest >> testWriteTwice [
 	| slot object |
 	<ignoreNotImplementedSelectors: #(slot1: slot1)>

--- a/src/Slot-Tests/package.st
+++ b/src/Slot-Tests/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Slot-Tests' }
+Package { #name : 'Slot-Tests' }


### PR DESCRIPTION
Outside of RB:

- add #testAnyUserOfClassVarNamed
- rewrite #removeSharedPool: #anyUserOfClassVarNamed: and ReSubclassResponsibilityNotDefinedRule to use #whichMethodsReferTo: intead of #whichSelectorsReferTo:

Not related: 
- simplify SlotMethodRecompilationTest, the methods defined make the tests harder to understand