### PR TITLE
Kernel: Make sure category is never nil

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -276,14 +276,14 @@ Class >> category [
 	category name stored in the ivar is still correct and only if this fails look it up
 	(latter is much more expensive)"
 
-	| result |
-	self basicCategory ifNotNil: [ :symbol |
-		symbol = Class unclassifiedCategory ifTrue: [ ^ symbol ].
+	| result cat |
+	cat := self basicCategory.
 
-		((self packageOrganizer listAtCategoryNamed: symbol) includes: self name) ifTrue: [ ^ symbol ] ].
+	cat = Class unclassifiedCategory ifTrue: [ ^ cat ].
 
+	"The next lines are only useful anymore because of a problem in Fuel that should be resolved in not too long. Then we will be able to just return #basicCategory in this whole method"
+	((self packageOrganizer listAtCategoryNamed: cat) includes: self name) ifTrue: [ ^ cat ].
 	result := (self packageOrganizer categoryOfBehavior: self) ifNil: [ #Unclassified ].
-
 	self basicCategory: result.
 
 	^ result

--- a/src/Shift-ClassBuilder/ClassResolver.class.st
+++ b/src/Shift-ClassBuilder/ClassResolver.class.st
@@ -2,17 +2,18 @@
 I am in charge of resolving the existence of a class
 "
 Class {
-	#name : #ClassResolver,
-	#superclass : #Object,
-	#category : #'Shift-ClassBuilder'
+	#name : 'ClassResolver',
+	#superclass : 'Object',
+	#category : 'Shift-ClassBuilder',
+	#package : 'Shift-ClassBuilder'
 }
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 ClassResolver >> resolve: aCDClassDefinitionNode [
 	^self subclassResponsibility
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 ClassResolver >> resolve: aClassName inEnv: anEnvironment [
 	^ (anEnvironment classNamed: aClassName) ifNil: [ self resolve: aClassName ]
 ]

--- a/src/Shift-ClassBuilder/ClassResolverStrictResolve.class.st
+++ b/src/Shift-ClassBuilder/ClassResolverStrictResolve.class.st
@@ -2,12 +2,13 @@
 My strategy is to raise an error if the class doesn't exist
 "
 Class {
-	#name : #ClassResolverStrictResolve,
-	#superclass : #ClassResolver,
-	#category : #'Shift-ClassBuilder'
+	#name : 'ClassResolverStrictResolve',
+	#superclass : 'ClassResolver',
+	#category : 'Shift-ClassBuilder',
+	#package : 'Shift-ClassBuilder'
 }
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 ClassResolverStrictResolve >> resolve: aClassName [
 	"^Error new:'You''re superclass doesn''t exist'."
 	^ self error: 'Superclass ', aClassName,' doesn''t exist'

--- a/src/Shift-ClassBuilder/DangerousClassNotifier.class.st
+++ b/src/Shift-ClassBuilder/DangerousClassNotifier.class.st
@@ -21,15 +21,16 @@ restoreState
 
 "
 Class {
-	#name : #DangerousClassNotifier,
-	#superclass : #Object,
+	#name : 'DangerousClassNotifier',
+	#superclass : 'Object',
 	#classInstVars : [
 		'enabled'
 	],
-	#category : #'Shift-ClassBuilder'
+	#category : 'Shift-ClassBuilder',
+	#package : 'Shift-ClassBuilder'
 }
 
-{ #category : #validation }
+{ #category : 'validation' }
 DangerousClassNotifier class >> check: classSymbol [
 
 	self enabled ifFalse: [ ^false ].
@@ -38,12 +39,12 @@ DangerousClassNotifier class >> check: classSymbol [
 			ifTrue: [ self notify: '"' , classSymbol , '" should not be redefined as its structure is known to the VM. \Only proceed if you know what you are doing!' withCRs ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DangerousClassNotifier class >> disable [
 	enabled := false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DangerousClassNotifier class >> disableDuring: aBlock [
 	"execute a block with me disabled. Works even nested and restores the old state"
 	| oldState |
@@ -53,23 +54,23 @@ DangerousClassNotifier class >> disableDuring: aBlock [
 	enabled := oldState
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DangerousClassNotifier class >> enable [
 	enabled := true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DangerousClassNotifier class >> enabled [
 	^enabled ifNil: [  enabled := false ]
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 DangerousClassNotifier class >> initialize [
 
 	enabled := true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DangerousClassNotifier class >> shouldNotBeRedefined: classSymbol [
 	(self tooDangerousClasses includes: classSymbol) ifTrue: [ ^true ].
 	^Smalltalk globals
@@ -78,7 +79,7 @@ DangerousClassNotifier class >> shouldNotBeRedefined: classSymbol [
 		ifAbsent: false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DangerousClassNotifier class >> tooDangerousClasses [
 	"Return a list of class names which will not be modified in the public interface"
 	^#(

--- a/src/Shift-ClassBuilder/ShDefaultBuilderEnhancer.class.st
+++ b/src/Shift-ClassBuilder/ShDefaultBuilderEnhancer.class.st
@@ -5,63 +5,64 @@ I am the point of extension to add new features to it in a modular way.
 Also I can configure the builder to add more comparers or do additional things.
 "
 Class {
-	#name : #ShDefaultBuilderEnhancer,
-	#superclass : #Object,
-	#category : #'Shift-ClassBuilder'
+	#name : 'ShDefaultBuilderEnhancer',
+	#superclass : 'Object',
+	#category : 'Shift-ClassBuilder',
+	#package : 'Shift-ClassBuilder'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ShDefaultBuilderEnhancer class >> isApplicableFor: aBuilder [
 	^ false
 ]
 
-{ #category : #'class modifications' }
+{ #category : 'class modifications' }
 ShDefaultBuilderEnhancer >> afterMethodsCompiled: builder [
 ]
 
-{ #category : #migrating }
+{ #category : 'migrating' }
 ShDefaultBuilderEnhancer >> afterMigratingClass: aBuilder installer: anInstaller [
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShDefaultBuilderEnhancer >> allSlotsForBuilder: aBuilder [
 
 	^ aBuilder layoutDefinition allSlots
 ]
 
-{ #category : #migrating }
+{ #category : 'migrating' }
 ShDefaultBuilderEnhancer >> beforeMigratingClass: aBuilder installer: anInstaller [
 ]
 
-{ #category : #events }
+{ #category : 'events' }
 ShDefaultBuilderEnhancer >> classCreated: builder [
 ]
 
-{ #category : #'class modifications' }
+{ #category : 'class modifications' }
 ShDefaultBuilderEnhancer >> compileMethodsFor: aBuilder [
 	aBuilder compileMethods
 ]
 
-{ #category : #'class modifications' }
+{ #category : 'class modifications' }
 ShDefaultBuilderEnhancer >> configureClass: newClass superclass: superclass withLayoutType: layoutType slots: slots [
 	newClass superclass: superclass withLayoutType: layoutType slots: slots
 ]
 
-{ #category : #'class modifications' }
+{ #category : 'class modifications' }
 ShDefaultBuilderEnhancer >> configureMetaclass: newMetaclass superclass: superclass withLayoutType: aLayoutType slots: classSlots [
 	newMetaclass superclass: superclass withLayoutType: aLayoutType slots: classSlots
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ShDefaultBuilderEnhancer >> fillBuilder: aBuilder from: aClass [
 ]
 
-{ #category : #migrating }
+{ #category : 'migrating' }
 ShDefaultBuilderEnhancer >> hasToSkipSlot: aSlot [
 	^ Class hasSlotNamed: aSlot name
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ShDefaultBuilderEnhancer >> initializeBuilder: aBuilder [
 
 	aBuilder addChangeComparer: ShSharedPoolChangeDetector.
@@ -74,41 +75,41 @@ ShDefaultBuilderEnhancer >> initializeBuilder: aBuilder [
 	aBuilder addChangeComparer: ShMetaclassChangeDetector
 ]
 
-{ #category : #events }
+{ #category : 'events' }
 ShDefaultBuilderEnhancer >> metaclassCreated: builder [
 ]
 
-{ #category : #events }
+{ #category : 'events' }
 ShDefaultBuilderEnhancer >> migrateInstancesTo: aClass installer: aShiftClassInstaller [
 
 	aShiftClassInstaller migrateInstancesTo: aClass
 ]
 
-{ #category : #events }
+{ #category : 'events' }
 ShDefaultBuilderEnhancer >> migrateToClass: aClass installer: aShiftClassInstaller [
 
 	aShiftClassInstaller migrateClassTo: aClass
 ]
 
-{ #category : #'class modifications' }
+{ #category : 'class modifications' }
 ShDefaultBuilderEnhancer >> newMetaclass: builder [
 	^ builder metaclassClass new
 ]
 
-{ #category : #'class modifications' }
+{ #category : 'class modifications' }
 ShDefaultBuilderEnhancer >> on: newClass declareClassVariables: sharedVariables sharing: sharedPoolsString [
 	newClass
 		declareClassVariables: sharedVariables;
 		sharing: sharedPoolsString
 ]
 
-{ #category : #'class modifications' }
+{ #category : 'class modifications' }
 ShDefaultBuilderEnhancer >> propagateChangesToRelatedClasses: newClass installer: installer [
 
 	newClass subclasses do: [ :e | installer remake: e ]
 ]
 
-{ #category : #'class modifications' }
+{ #category : 'class modifications' }
 ShDefaultBuilderEnhancer >> validateRedefinition: anOldClass [
 	"Subclasses can validate that the new definition is coherent with the old class"
 ]

--- a/src/Shift-ClassBuilder/ShLayoutDefinition.class.st
+++ b/src/Shift-ClassBuilder/ShLayoutDefinition.class.st
@@ -2,8 +2,8 @@
 I am an internal object used by the ShiftClassBuilder to represent the layout of a class.
 "
 Class {
-	#name : #ShLayoutDefinition,
-	#superclass : #Object,
+	#name : 'ShLayoutDefinition',
+	#superclass : 'Object',
 	#instVars : [
 		'layoutClass',
 		'slots',
@@ -12,32 +12,33 @@ Class {
 		'sharedVariables',
 		'builder'
 	],
-	#category : #'Shift-ClassBuilder'
+	#category : 'Shift-ClassBuilder',
+	#package : 'Shift-ClassBuilder'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShLayoutDefinition >> allSlots [
 	| superclass |
 	superclass := builder superclass.
 	^ (superclass ifNil: [ #() ] ifNotNil: [ superclass allSlots ]) , slots
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShLayoutDefinition >> builder: anObject [
 	builder := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShLayoutDefinition >> classSlots [
 	^ classSlots ifNil: [ #() ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShLayoutDefinition >> classSlots: anObject [
 	classSlots := anObject collect: [ :e | e asSlot ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShLayoutDefinition >> copy: slotCollection ifUsedIn: aClass [
 	"I only copy the slot if it is not virtual and it is the same in the oldClass.
 	 They are copied as they have the index as instance variable, the index can change in the new class."
@@ -55,7 +56,7 @@ ShLayoutDefinition >> copy: slotCollection ifUsedIn: aClass [
 				ifNone: [ aSlot ] ]
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 ShLayoutDefinition >> copyClassSlotsIfNeeded: oldSlots [
 
 	classSlots ifNotNil: [ ^ self ].
@@ -65,7 +66,7 @@ ShLayoutDefinition >> copyClassSlotsIfNeeded: oldSlots [
 		thenCollect: [ :each | each copy index: nil; yourself ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShLayoutDefinition >> copySlotsIfUsedIn: oldClass [
 	"I copy the slots if they are used in oldClass. As the slots has state (usually the index) they cannot be shared between the old and the new class."
 
@@ -75,7 +76,7 @@ ShLayoutDefinition >> copySlotsIfUsedIn: oldClass [
 	classSlots := self copy: self classSlots ifUsedIn: oldClass class
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ShLayoutDefinition >> initialize [
 	super initialize.
 
@@ -84,62 +85,62 @@ ShLayoutDefinition >> initialize [
 	sharedVariables := #()
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ShLayoutDefinition >> isBits [
 	^ self layoutClass new isBits
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShLayoutDefinition >> layoutClass [
 	^ layoutClass ifNil: [ builder classNamed: #FixedLayout ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShLayoutDefinition >> layoutClass: anObject [
 	layoutClass := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShLayoutDefinition >> sharedPools [
 	^ sharedPools
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShLayoutDefinition >> sharedPools: anObject [
 	sharedPools := anObject
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ShLayoutDefinition >> sharedPoolsString [
 	^ self sharedPools joinUsing: Character space
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShLayoutDefinition >> sharedVariables [
 	^ sharedVariables
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShLayoutDefinition >> sharedVariables: anObject [
 	sharedVariables := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShLayoutDefinition >> sharedVariablesString [
 	^ (sharedVariables collect:[:e | e key]) joinUsing: ' '
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShLayoutDefinition >> slots [
 	^ slots
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShLayoutDefinition >> slots: anObject [
 	slots := anObject collect: [ :e | e asSlot ]
 ]
 
-{ #category : #validating }
+{ #category : 'validating' }
 ShLayoutDefinition >> validate [
 
 	| slotNames classSlotNames |

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -10,8 +10,8 @@ I can be used directly to create anonymous classes, but it is better if you use 
 I also can compare the old class with the configured new class to calculate the required changes.
 "
 Class {
-	#name : #ShiftClassBuilder,
-	#superclass : #Object,
+	#name : 'ShiftClassBuilder',
+	#superclass : 'Object',
 	#instVars : [
 		'buildEnvironment',
 		'installingEnvironment',
@@ -39,36 +39,37 @@ Class {
 	#classVars : [
 		'BuilderEnhancer'
 	],
-	#category : #'Shift-ClassBuilder'
+	#category : 'Shift-ClassBuilder',
+	#package : 'Shift-ClassBuilder'
 }
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 ShiftClassBuilder class >> defaultBuildEnhancer [
 	^ BuilderEnhancer ifNil: [ ShDefaultBuilderEnhancer ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder class >> setDefaultBuilderEnhancer: aClass [
 	BuilderEnhancer := aClass
 ]
 
-{ #category : #changes }
+{ #category : 'changes' }
 ShiftClassBuilder >> addChange: aChange [
 	changes add: aChange
 ]
 
-{ #category : #changes }
+{ #category : 'changes' }
 ShiftClassBuilder >> addChangeComparer: aChangeComparer [
 	changeComparers add: aChangeComparer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> allSlots [
 
 	^ self builderEnhancer allSlotsForBuilder: self
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 ShiftClassBuilder >> build [
 
 	self tryToFillOldClass.
@@ -104,29 +105,29 @@ ShiftClassBuilder >> build [
 	^ newClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> buildEnvironment [
 	^ buildEnvironment
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> buildEnvironment: anObject [
 	buildEnvironment := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> builderEnhancer [
 	^ builderEnhancer ifNil: [ self detectBuilderEnhancer ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> builderEnhancer: anObject [
 	builderEnhancer := anObject.
 
 	builderEnhancer initializeBuilder: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> category [
 
 	self flag: #package. "Category is an old concept mixing packages and tag. For now this is what is used by the system but in the future we should go away from it."
@@ -135,7 +136,7 @@ ShiftClassBuilder >> category [
 		  ifNil: [ self package ]
 ]
 
-{ #category : #deprecated }
+{ #category : 'deprecated' }
 ShiftClassBuilder >> category: aString [
 
 	self flag: #package. "Category is an old concept mixing packages and tag. For now this is what is used by the system but in the future we should go away from it."
@@ -147,64 +148,64 @@ ShiftClassBuilder >> category: aString [
 		ifFalse: [ self package: aString ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> changeComparers [
 	^ changeComparers
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> changes [
 	^ changes
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> classNamed: aName [
 
 	^ self buildEnvironment at: aName ifAbsent: [ nil ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> classSlots: aSlotCollection [
 	self layoutDefinition classSlots: aSlotCollection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> classTraitComposition [
 	^ extensibleProperties at: #classTraitComposition ifAbsent: {}
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> classTraitComposition: aValue [
 	^ extensibleProperties at: #classTraitComposition put: aValue
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> comment [
 	^ comment
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> comment: anObject [
 	comment := anObject
 ]
 
-{ #category : #'accessing - comment' }
+{ #category : 'accessing - comment' }
 ShiftClassBuilder >> comment:aComment stamp: anStamp [
 	self comment: aComment.
 	self commentStamp: anStamp
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> commentStamp [
 	^ commentStamp
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> commentStamp: anObject [
 	commentStamp := anObject
 ]
 
-{ #category : #changes }
+{ #category : 'changes' }
 ShiftClassBuilder >> compareWithOldClass [
 	oldClass ifNil: [ ^ self ].
 	changeComparers do: [ :e | e compareClass: oldClass with: self ].
@@ -212,7 +213,7 @@ ShiftClassBuilder >> compareWithOldClass [
 	changes ifEmpty: [ ShNoChangesInClass signal. ]
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 ShiftClassBuilder >> compileMethods [
 
 	newClass
@@ -220,18 +221,20 @@ ShiftClassBuilder >> compileMethods [
 		removeNonexistentSelectorsFromProtocols
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 ShiftClassBuilder >> copyProtocols [
 
 	newClass protocols: oldClass protocols copy.
 	newClass class protocols: oldClass class protocols copy
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 ShiftClassBuilder >> createClass [
 
 	newClass := newMetaclass new.
-	newClass setName: self name.
+	newClass
+		setName: self name;
+		basicCategory: Class unclassifiedCategory.
 
 	self builderEnhancer
 		configureClass: newClass
@@ -244,7 +247,7 @@ ShiftClassBuilder >> createClass [
 	self builderEnhancer classCreated: self
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 ShiftClassBuilder >> createMetaclass [
 	newMetaclass := self builderEnhancer newMetaclass: self.
 
@@ -257,7 +260,7 @@ ShiftClassBuilder >> createMetaclass [
 	self builderEnhancer metaclassCreated: self
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 ShiftClassBuilder >> createSharedVariables [
 	self builderEnhancer
 		on: newClass
@@ -265,7 +268,7 @@ ShiftClassBuilder >> createSharedVariables [
 		sharing: self layoutDefinition sharedPoolsString
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ShiftClassBuilder >> detectBuilderEnhancer [
 
 	| builderEnhancerClass |
@@ -277,7 +280,7 @@ ShiftClassBuilder >> detectBuilderEnhancer [
 	^ builderEnhancer
 ]
 
-{ #category : #'reflective operations' }
+{ #category : 'reflective operations' }
 ShiftClassBuilder >> doesNotUnderstand: aMessage [
 	| selector variable setter|
 
@@ -297,19 +300,19 @@ ShiftClassBuilder >> doesNotUnderstand: aMessage [
 		ifFalse:[ ^ extensibleProperties at: variable]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> environment [
 
 	^ self buildEnvironment
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> environment: anObject [
 
 	^ self buildEnvironment: anObject
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ShiftClassBuilder >> fillFor: aClass [
 
 	self
@@ -327,12 +330,12 @@ ShiftClassBuilder >> fillFor: aClass [
 	self builderEnhancer fillBuilder: self from: aClass
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ShiftClassBuilder >> hasToMigrateInstances [
 	^ self changes anySatisfy: [ :e | e hasToMigrateInstances ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ShiftClassBuilder >> initialize [
 
 	super initialize.
@@ -354,7 +357,7 @@ ShiftClassBuilder >> initialize [
 	buildEnvironment := self class environment
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 ShiftClassBuilder >> installSlotsAndVariables [
 	"notify all the variables so they can react to being installed in a class"
 	newClass classLayout slots do: [ :each | each installingIn: newClass ].
@@ -362,20 +365,20 @@ ShiftClassBuilder >> installSlotsAndVariables [
 	newClass classVariables do: [ :each | each installingIn: newClass ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> installingEnvironment [
 	"The build environment is used to find the classes used during the building of a class such as the layouts, and the installing environment is the environment in which the class should be installed."
 
 	^ installingEnvironment ifNil: [ self buildEnvironment ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> installingEnvironment: anObject [
 
 	installingEnvironment := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> isInRemake [
 
 	"If the builder is in remake (when propagating changes to subclasses)"
@@ -383,139 +386,139 @@ ShiftClassBuilder >> isInRemake [
 	^ inRemake
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> layoutClass: aLayoutClass [
 	self layoutDefinition layoutClass: aLayoutClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> layoutDefinition [
 	^ layoutDefinition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> markIsInRemake [
 
 	inRemake := true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> metaSuperclass [
 
 	^ metaSuperclass ifNil:[ (superclass ifNil: [ Class ] ifNotNil: [ superclass class ]) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> metaSuperclass: aClass [
 
 	metaSuperclass := aClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> metaclassClass [
 	^ metaclassClass ifNil: [ Metaclass ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> metaclassClass: anObject [
 	metaclassClass := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> name [
 	^ name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> name: anObject [
 	name := anObject.
 	self validateClassName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> newClass [
 	^ newClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> newMetaclass [
 	^ newMetaclass
 ]
 
-{ #category : #changes }
+{ #category : 'changes' }
 ShiftClassBuilder >> notifyChanges [
 	changes do: #announceChanges
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> oldClass [
 	^ oldClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> oldClass: anObject [
 	oldClass := anObject.
 	oldClass ifNotNil: [oldMetaclass := oldClass class]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> oldMetaclass [
 	^ oldMetaclass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> package [
 
 	^ package
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> package: aString [
 
 	package := aString
 ]
 
-{ #category : #changes }
+{ #category : 'changes' }
 ShiftClassBuilder >> propagateChangesTo: anotherBuilder [
 	changes do: [ :e | e propagateToSubclasses: anotherBuilder ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> propertyAt: aKey [
 	^ extensibleProperties at: aKey
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> propertyAt: aKey put: aValue [
 	extensibleProperties at: aKey put: aValue
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> sharedPools [
 	^ self layoutDefinition sharedPools
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> sharedPools: aString [
 	self layoutDefinition sharedPools: ((aString substrings: ' ') collect: [:e | e asSymbol])
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> sharedPoolsCollectionOfSymbols: aCol [
 	self layoutDefinition sharedPools: aCol
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> sharedVariables [
 	^ self layoutDefinition sharedVariables
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> sharedVariables: aCollection [
 	self layoutDefinition sharedVariables: (aCollection collect:[:e | e asClassVariable])
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> sharedVariablesFromString: aStringOrArray [
 	layoutDefinition sharedVariables: (aStringOrArray isString
         ifTrue: [ (aStringOrArray substrings: ' ') collect: [ :x | x asSymbol => ClassVariable ] ]
@@ -525,61 +528,61 @@ ShiftClassBuilder >> sharedVariablesFromString: aStringOrArray [
                     ifFalse: [ self error: 'Shared variables can only be String or an array of Symbols' ] ] ])
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> slots [
 	^ self layoutDefinition slots
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> slots: aCollection [
 	self layoutDefinition slots: aCollection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> slotsFromString: aString [
 	self slots: aString asSlotCollection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> superclass [
 
 	^ superclass ifNil: [ superclassName ifNotNil: [ self classNamed: self superclassName ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> superclass: aSuperclass [
 	aSuperclass ifNil: [ superclassName := nil ].
 	superclass := aSuperclass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> superclassName [
 	^ superclassName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> superclassName: anObject [
 	superclassName := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> superclassResolver: asuperclassResolver [
 	superclassResolver:= asuperclassResolver
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> tag [
 
 	^ tag
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassBuilder >> tag: anObject [
 
 	tag := anObject
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 ShiftClassBuilder >> tryToFillOldClass [
 
 	oldClass ifNotNil: [ ^ self ].
@@ -587,14 +590,14 @@ ShiftClassBuilder >> tryToFillOldClass [
 	self oldClass: (self classNamed: self name)
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 ShiftClassBuilder >> useStrictSuperclass [
 	"default behavior"
 	"If I am use, the superResolver will resolve unknown superclass by raising an error"
 	self superclassResolver: ClassResolverStrictResolve new
 ]
 
-{ #category : #'private - validating' }
+{ #category : 'private - validating' }
 ShiftClassBuilder >> validateClassName [
 	name ifNil: [ ^self ].
 
@@ -611,7 +614,7 @@ ShiftClassBuilder >> validateClassName [
 	DangerousClassNotifier check: name
 ]
 
-{ #category : #'private - validating' }
+{ #category : 'private - validating' }
 ShiftClassBuilder >> validateSuperclass [
 	self superclass ifNil: [ ^self ].
 	oldClass ifNil: [ ^ self ].

--- a/src/Shift-ClassBuilder/package.st
+++ b/src/Shift-ClassBuilder/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Shift-ClassBuilder' }
+Package { #name : 'Shift-ClassBuilder' }

--- a/src/Shift-ClassInstaller/Class.extension.st
+++ b/src/Shift-ClassInstaller/Class.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Class }
+Extension { #name : 'Class' }
 
-{ #category : #'*Shift-ClassInstaller' }
+{ #category : '*Shift-ClassInstaller' }
 Class >> addClassSlot: aSlot [
 
 	^ self classInstaller update: self to: [ :builder |
@@ -8,7 +8,7 @@ Class >> addClassSlot: aSlot [
 			classSlots: (self class classLayout slots copyWith: aSlot)]
 ]
 
-{ #category : #'*Shift-ClassInstaller' }
+{ #category : '*Shift-ClassInstaller' }
 Class >> addSlot: aSlot [
 
 	^ self classInstaller
@@ -16,7 +16,7 @@ Class >> addSlot: aSlot [
 		  to: [ :builder | builder slots: (self localSlots copyWith: aSlot) ]
 ]
 
-{ #category : #'*Shift-ClassInstaller' }
+{ #category : '*Shift-ClassInstaller' }
 Class >> removeClassSlot: aSlot [
 
 	^ self classInstaller update: self to: [ :builder |
@@ -24,7 +24,7 @@ Class >> removeClassSlot: aSlot [
 			classSlots: (self class classLayout slots copyWithout: aSlot)]
 ]
 
-{ #category : #'*Shift-ClassInstaller' }
+{ #category : '*Shift-ClassInstaller' }
 Class >> removeSlot: aSlot [
 
 	(self classLayout slots includes: aSlot) ifFalse: [

--- a/src/Shift-ClassInstaller/ManifestShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ManifestShiftClassInstaller.class.st
@@ -2,12 +2,14 @@
 ShiftClassInstaller (responsible of installing a class in the system) and related classes
 "
 Class {
-	#name : #ManifestShiftClassInstaller,
-	#superclass : #PackageManifest,
-	#category : #'Shift-ClassInstaller-Manifest'
+	#name : 'ManifestShiftClassInstaller',
+	#superclass : 'PackageManifest',
+	#category : 'Shift-ClassInstaller-Manifest',
+	#package : 'Shift-ClassInstaller',
+	#tag : 'Manifest'
 }
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestShiftClassInstaller class >> ruleRBBadMessageRuleV1FalsePositive [
 	^ #(#(#(#RGMethodDefinition #(#ShiftClassInstaller #fixSlotScope: #false)) #'2019-07-25T11:05:26.260339+02:00') )
 ]

--- a/src/Shift-ClassInstaller/Metaclass.extension.st
+++ b/src/Shift-ClassInstaller/Metaclass.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Metaclass }
+Extension { #name : 'Metaclass' }
 
-{ #category : #'*Shift-ClassInstaller' }
+{ #category : '*Shift-ClassInstaller' }
 Metaclass >> instanceVariableNames: instVarString [
 
 	^ self slots: instVarString asSlotCollection

--- a/src/Shift-ClassInstaller/ShiftAnonymousClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftAnonymousClassInstaller.class.st
@@ -5,33 +5,35 @@ I should not be accessed directly, but by the accessor in Smalltalk or in  the c
 I have exactly the same interface than the main class installer.
 "
 Class {
-	#name : #ShiftAnonymousClassInstaller,
-	#superclass : #ShiftClassInstaller,
-	#category : #'Shift-ClassInstaller-Base'
+	#name : 'ShiftAnonymousClassInstaller',
+	#superclass : 'ShiftClassInstaller',
+	#category : 'Shift-ClassInstaller-Base',
+	#package : 'Shift-ClassInstaller',
+	#tag : 'Base'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftAnonymousClassInstaller >> comment: newClass [
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 ShiftAnonymousClassInstaller >> installInEnvironment: newClass [
 	^ self
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 ShiftAnonymousClassInstaller >> installSubclassInSuperclass: newClass [
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 ShiftAnonymousClassInstaller >> lookupOldClass [
 	^ self
 ]
 
-{ #category : #notifications }
+{ #category : 'notifications' }
 ShiftAnonymousClassInstaller >> notifyChanges [
 ]
 
-{ #category : #notifications }
+{ #category : 'notifications' }
 ShiftAnonymousClassInstaller >> recategorize: newClass to: category [
 ]

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -303,7 +303,7 @@ ShiftClassInstaller >> recategorize: aClass to: newCategory [
 		systemOrganizer classify: aClass name under: newCategory.
 		aClass basicCategory: newCategory ].
 
-	oldCategory = Class unclassifiedCategory
+	(oldCategory isNil or: [ oldCategory = Class unclassifiedCategory ])
 		ifTrue: [ SystemAnnouncer uniqueInstance classAdded: aClass inCategory: newCategory ]
 		ifFalse: [ SystemAnnouncer uniqueInstance class: aClass recategorizedFrom: oldCategory to: newCategory ]
 ]

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -19,16 +19,18 @@ The block passed is used to configure the builder. Check ShiftClassBuilder to se
 I have a subclass to anonymous generate classes, without registering in the environment. 
 "
 Class {
-	#name : #ShiftClassInstaller,
-	#superclass : #Object,
+	#name : 'ShiftClassInstaller',
+	#superclass : 'Object',
 	#instVars : [
 		'oldClass',
 		'builder'
 	],
-	#category : #'Shift-ClassInstaller-Base'
+	#category : 'Shift-ClassInstaller-Base',
+	#package : 'Shift-ClassInstaller',
+	#tag : 'Base'
 }
 
-{ #category : #examples }
+{ #category : 'examples' }
 ShiftClassInstaller class >> example [
 	<sampleInstance>
 	^ Smalltalk classInstaller make: [ :aSlotClassBuilder |
@@ -39,12 +41,12 @@ ShiftClassInstaller class >> example [
 			category: 'My-Category' ]
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 ShiftClassInstaller class >> make: aBlock [
 	^ self new make:aBlock
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 ShiftClassInstaller class >> update: oldClass to: aBlock [
 	^ self new
 		fillFor: oldClass;
@@ -52,27 +54,27 @@ ShiftClassInstaller class >> update: oldClass to: aBlock [
 		make: aBlock
 ]
 
-{ #category : #validating }
+{ #category : 'validating' }
 ShiftClassInstaller class >> validateClassName: aString [
 	ShiftClassBuilder new name: aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassInstaller >> builder [
 	^ builder
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassInstaller >> comment: newClass [
 	builder comment ifNotNil: [ newClass comment: builder comment stamp: builder commentStamp ]
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 ShiftClassInstaller >> copyClassSlotsFromExistingClass [
 	self builder layoutDefinition copyClassSlotsIfNeeded: oldClass class slots
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 ShiftClassInstaller >> copyObject: oldObject to: newClass [
 
 	| newObject |
@@ -104,12 +106,12 @@ ShiftClassInstaller >> copyObject: oldObject to: newClass [
 	^ newObject
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ShiftClassInstaller >> fillFor: aClassOrTrait [
 	builder fillFor: aClassOrTrait
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 ShiftClassInstaller >> fixSlotScope: newClass [
 	newClass superclass ifNil: [ ^ self ].
 	(newClass classLayout slotScope isKindOf: LayoutEmptyScope) ifTrue: [ ^ self ].
@@ -120,14 +122,14 @@ ShiftClassInstaller >> fixSlotScope: newClass [
 	self assert: newClass superclass classLayout slotScope == newClass classLayout slotScope parentScope
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ShiftClassInstaller >> initialize [
 
 	super initialize.
 	builder := ShiftClassBuilder new
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 ShiftClassInstaller >> installInEnvironment: newClass [
 	"I only install if there is a name / non anonymous"
 
@@ -139,7 +141,7 @@ ShiftClassInstaller >> installInEnvironment: newClass [
 	self updateBindings: (self installingEnvironment bindingOf: builder name) of: newClass
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 ShiftClassInstaller >> installSubclassInSuperclass: newClass [
 
 	"I only install if there is a name / non anonymous"
@@ -148,25 +150,25 @@ ShiftClassInstaller >> installSubclassInSuperclass: newClass [
 	newClass superclass addSubclass: newClass
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 ShiftClassInstaller >> installingEnvironment [
 
 	^ builder installingEnvironment
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 ShiftClassInstaller >> installingEnvironment: anEnvironment [
 
 	builder installingEnvironment: anEnvironment
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 ShiftClassInstaller >> lookupOldClass [
 
 	oldClass ifNil: [ oldClass := self installingEnvironment at: builder name ifAbsent: [ nil ] ]
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 ShiftClassInstaller >> make [
 	| newClass |
 
@@ -204,7 +206,7 @@ ShiftClassInstaller >> make [
 	^ newClass
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 ShiftClassInstaller >> make: aBlock [
 
 	aBlock value: builder.
@@ -212,14 +214,14 @@ ShiftClassInstaller >> make: aBlock [
 	^self make
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ShiftClassInstaller >> makeWithBuilder: aBuilder [
 
 	builder := aBuilder.
 	^ self make
 ]
 
-{ #category : #migrating }
+{ #category : 'migrating' }
 ShiftClassInstaller >> migrateClassTo: newClass [
 	| slotsToMigrate oldClassVariables newClassVariables|
 
@@ -258,7 +260,7 @@ ShiftClassInstaller >> migrateClassTo: newClass [
 	] valueUninterruptably
 ]
 
-{ #category : #migrating }
+{ #category : 'migrating' }
 ShiftClassInstaller >> migrateInstancesTo: newClass [
 	| oldObjects newObjects readOnlyOldObjectsFlags |
 	oldObjects := oldClass allInstances.
@@ -275,22 +277,22 @@ ShiftClassInstaller >> migrateInstancesTo: newClass [
 	newObjects with: readOnlyOldObjectsFlags do: [ :anObject :aFlag | anObject setIsReadOnlyObject: aFlag ]
 ]
 
-{ #category : #notifications }
+{ #category : 'notifications' }
 ShiftClassInstaller >> notifyChanges [
 	builder notifyChanges
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassInstaller >> oldClass [
 	^ oldClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ShiftClassInstaller >> oldClass: anObject [
 	oldClass := anObject
 ]
 
-{ #category : #notifications }
+{ #category : 'notifications' }
 ShiftClassInstaller >> recategorize: aClass to: newCategory [
 
 	| oldCategory |
@@ -301,12 +303,12 @@ ShiftClassInstaller >> recategorize: aClass to: newCategory [
 		systemOrganizer classify: aClass name under: newCategory.
 		aClass basicCategory: newCategory ].
 
-	(oldCategory isNil or: [ oldCategory = Class unclassifiedCategory ])
+	oldCategory = Class unclassifiedCategory
 		ifTrue: [ SystemAnnouncer uniqueInstance classAdded: aClass inCategory: newCategory ]
 		ifFalse: [ SystemAnnouncer uniqueInstance class: aClass recategorizedFrom: oldCategory to: newCategory ]
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 ShiftClassInstaller >> remake: aClass [
 
 	self class new
@@ -319,7 +321,7 @@ ShiftClassInstaller >> remake: aClass [
 			builder propagateChangesTo: anotherBuilder ]
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 ShiftClassInstaller >> updateBindings: aBinding of: newClass [
 	newClass methods do: [ :e | e classBinding: aBinding ]
 ]

--- a/src/Shift-ClassInstaller/SmalltalkImage.extension.st
+++ b/src/Shift-ClassInstaller/SmalltalkImage.extension.st
@@ -1,20 +1,20 @@
-Extension { #name : #SmalltalkImage }
+Extension { #name : 'SmalltalkImage' }
 
-{ #category : #'*Shift-ClassInstaller' }
+{ #category : '*Shift-ClassInstaller' }
 SmalltalkImage >> anonymousClassInstaller [
 	"Answer the class responsible of creating classes in the system."
 
 	^ ShiftAnonymousClassInstaller
 ]
 
-{ #category : #'*Shift-ClassInstaller' }
+{ #category : '*Shift-ClassInstaller' }
 SmalltalkImage >> classBuilder [
 	"Answer the object responsible of creating subclasses of myself in the system."
 
 	^ self classInstaller new builder
 ]
 
-{ #category : #'*Shift-ClassInstaller' }
+{ #category : '*Shift-ClassInstaller' }
 SmalltalkImage >> classInstaller [
 	"Answer the class responsible of creating classes in the system."
 

--- a/src/Shift-ClassInstaller/package.st
+++ b/src/Shift-ClassInstaller/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Shift-ClassInstaller' }
+Package { #name : 'Shift-ClassInstaller' }


### PR DESCRIPTION
In Class>>category we have two hacks:
- One because a class can have a wrong category. I removed most code provoking this problem and the last one is in Fuel but there is a fix incoming
- One because a class might not have a category set but is already in a category

I fixed all the cases where the second case happened already. We just have a few cases were the category is nil instead of #Unclassified during the class installation. In order to be able to remove the nils there, I'm setting the Unclassified symbol at class creation.