### PR TITLE
RPackage: Rely less on categories in MCOrganizationDefinition

### DIFF
--- a/src/Monticello-Tests/MCStWriterTest.class.st
+++ b/src/Monticello-Tests/MCStWriterTest.class.st
@@ -124,7 +124,7 @@ MCMethodDeclaration className: #MCMockClassD selector: #one category: #''''as ye
 
 { #category : 'data' }
 MCStWriterTest >> expectedOrganizationDefinition [
-	^ 'SystemOrganization addCategory: #MonticelloMocks!
+	^ 'self packageOrganizer ensurePackage: #MonticelloMocks withTags: #()!
 '
 ]
 

--- a/src/Monticello/Behavior.extension.st
+++ b/src/Monticello/Behavior.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Behavior }
+Extension { #name : 'Behavior' }
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 Behavior >> mcType [
 	"Answer the symbol that Monticello uses internally to encode layouts"
 	^self classLayout class mcTypeSymbol

--- a/src/Monticello/ByteLayout.extension.st
+++ b/src/Monticello/ByteLayout.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #ByteLayout }
+Extension { #name : 'ByteLayout' }
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 ByteLayout class >> mcTypeSymbol [ 
 	^ #bytes
 ]

--- a/src/Monticello/ChangeRecord.extension.st
+++ b/src/Monticello/ChangeRecord.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #ChangeRecord }
+Extension { #name : 'ChangeRecord' }
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 ChangeRecord >> asMCMethodDefinition [
 	"Creates a MCMethodDefinition from the receiver when this was created for a method (type=#method)"
 	

--- a/src/Monticello/Class.extension.st
+++ b/src/Monticello/Class.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Class }
+Extension { #name : 'Class' }
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 Class >> asClassDefinition [
 	"we use a very ugly hack to encode complex slots as string with MC... later MC should model Slots directly"
 
@@ -42,7 +42,7 @@ Class >> asClassDefinition [
 	^ definition
 ]
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 Class >> classDefinitions [
 	^ { self asClassDefinition }
 ]

--- a/src/Monticello/CompiledMethod.extension.st
+++ b/src/Monticello/CompiledMethod.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #CompiledMethod }
+Extension { #name : 'CompiledMethod' }
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 CompiledMethod >> asMCMethodDefinition [
    "Creates a MCMethodDefinition from the receiver"
 	| cached |
@@ -19,7 +19,7 @@ CompiledMethod >> asMCMethodDefinition [
 	^ cached
 ]
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 CompiledMethod >> basicAsMCMethodDefinition [
 
 	"Creates a MCMethodDefinition from the receiver"
@@ -33,7 +33,7 @@ CompiledMethod >> basicAsMCMethodDefinition [
 		  source: self sourceCode
 ]
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 CompiledMethod >> sameAsMCDefinition: anMCMethodDefinition [
 
 	^ anMCMethodDefinition selector = self selector and: [ 

--- a/src/Monticello/CompiledMethodLayout.extension.st
+++ b/src/Monticello/CompiledMethodLayout.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #CompiledMethodLayout }
+Extension { #name : 'CompiledMethodLayout' }
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 CompiledMethodLayout class >> mcTypeSymbol [ 
 	^ #compiledMethod 
 ]

--- a/src/Monticello/EphemeronLayout.extension.st
+++ b/src/Monticello/EphemeronLayout.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #EphemeronLayout }
+Extension { #name : 'EphemeronLayout' }
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 EphemeronLayout class >> mcTypeSymbol [ 
 	^ #ephemeron
 ]

--- a/src/Monticello/FixedLayout.extension.st
+++ b/src/Monticello/FixedLayout.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FixedLayout }
+Extension { #name : 'FixedLayout' }
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 FixedLayout class >> mcTypeSymbol [ 
 	^ #normal
 ]

--- a/src/Monticello/HashedCollection.extension.st
+++ b/src/Monticello/HashedCollection.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #HashedCollection }
+Extension { #name : 'HashedCollection' }
 
-{ #category : #'*Monticello-Storing' }
+{ #category : '*Monticello-Storing' }
 HashedCollection >> comeFullyUpOnReload: smartRefStream [
 	"Symbols have new hashes in this image."
 

--- a/src/Monticello/ImmediateLayout.extension.st
+++ b/src/Monticello/ImmediateLayout.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #ImmediateLayout }
+Extension { #name : 'ImmediateLayout' }
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 ImmediateLayout class >> mcTypeSymbol [ 	
 	^ #immediate
 ]

--- a/src/Monticello/MCAddition.class.st
+++ b/src/Monticello/MCAddition.class.st
@@ -2,70 +2,72 @@
 A MCAddition represents the operation to add an entity to a snapshot. 
 "
 Class {
-	#name : #MCAddition,
-	#superclass : #MCPatchOperation,
+	#name : 'MCAddition',
+	#superclass : 'MCPatchOperation',
 	#instVars : [
 		'definition'
 	],
-	#category : #'Monticello-Patching'
+	#category : 'Monticello-Patching',
+	#package : 'Monticello',
+	#tag : 'Patching'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCAddition class >> of: aDefinition [
 	^ self new intializeWithDefinition: aDefinition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCAddition >> baseDefinition [
 	^ nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCAddition >> basicApplyTo: anObject [
 	anObject addDefinition: definition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCAddition >> definition [
 	^ definition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCAddition >> fromSource [
 	^ ''
 ]
 
-{ #category : #initializing }
+{ #category : 'initializing' }
 MCAddition >> intializeWithDefinition: aDefinition [
 	definition := aDefinition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCAddition >> inverse [
 	^ MCRemoval of: definition
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCAddition >> isAddition [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCAddition >> isClassPatch [
 	^definition isClassDefinition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCAddition >> targetClass [
 	^definition actualClass 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCAddition >> targetDefinition [
 	^ definition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCAddition >> toSource [
 	^ definition diffSource
 ]

--- a/src/Monticello/MCAncestry.class.st
+++ b/src/Monticello/MCAncestry.class.st
@@ -2,16 +2,18 @@
 Abstract superclass of records of ancestry.
 "
 Class {
-	#name : #MCAncestry,
-	#superclass : #Object,
+	#name : 'MCAncestry',
+	#superclass : 'Object',
 	#instVars : [
 		'ancestors',
 		'stepChildren'
 	],
-	#category : #'Monticello-Versioning'
+	#category : 'Monticello-Versioning',
+	#package : 'Monticello',
+	#tag : 'Versioning'
 }
 
-{ #category : #ancestry }
+{ #category : 'ancestry' }
 MCAncestry >> allAncestorsDo: aBlock [
 	self ancestors do:
 		[:ea |
@@ -19,7 +21,7 @@ MCAncestry >> allAncestorsDo: aBlock [
 		ea allAncestorsDo: aBlock]
 ]
 
-{ #category : #ancestry }
+{ #category : 'ancestry' }
 MCAncestry >> allAncestorsOnPathTo: aVersionInfo [
 	^ MCFilteredVersionSorter new
 		target: aVersionInfo;
@@ -27,24 +29,24 @@ MCAncestry >> allAncestorsOnPathTo: aVersionInfo [
 		sortedVersionInfos
 ]
 
-{ #category : #ancestry }
+{ #category : 'ancestry' }
 MCAncestry >> ancestorString [
 	^ String streamContents:
 		[:s | self ancestors do: [:ea | s nextPutAll: ea name] separatedBy: [s nextPutAll: ', ']]
 ]
 
-{ #category : #ancestry }
+{ #category : 'ancestry' }
 MCAncestry >> ancestorStringWithout: packageName [
 	^ String streamContents:
 		[:s | self ancestors do: [:ea | s nextPutAll: (ea nameWithout: packageName)] separatedBy: [s nextPutAll: ', ']]
 ]
 
-{ #category : #ancestry }
+{ #category : 'ancestry' }
 MCAncestry >> ancestors [
 	^ ancestors ifNil: [#()]
 ]
 
-{ #category : #ancestry }
+{ #category : 'ancestry' }
 MCAncestry >> ancestorsDoWhileTrue: aBlock [
 	self ancestors do:
 		[:ea |
@@ -52,12 +54,12 @@ MCAncestry >> ancestorsDoWhileTrue: aBlock [
 			[ea ancestorsDoWhileTrue: aBlock]]
 ]
 
-{ #category : #ancestry }
+{ #category : 'ancestry' }
 MCAncestry >> breadthFirstAncestors [
 	^ Array streamContents: [:s | self breadthFirstAncestorsDo: [:ea | s nextPut: ea]]
 ]
 
-{ #category : #ancestry }
+{ #category : 'ancestry' }
 MCAncestry >> breadthFirstAncestorsDo: aBlock [
 	| seen todo next |
 	seen := Set with: self.
@@ -72,14 +74,14 @@ MCAncestry >> breadthFirstAncestorsDo: aBlock [
 				todo add: ea]]]
 ]
 
-{ #category : #ancestry }
+{ #category : 'ancestry' }
 MCAncestry >> commonAncestorWith: aNode [
 	| commonAncestors |
 	commonAncestors := self commonAncestorsWith: aNode.
 	^ commonAncestors at: 1 ifAbsent: [nil]
 ]
 
-{ #category : #ancestry }
+{ #category : 'ancestry' }
 MCAncestry >> commonAncestorsWith: aVersionInfo [
 
 	| sharedAncestors mergedOrder sorter |
@@ -91,14 +93,14 @@ MCAncestry >> commonAncestorsWith: aVersionInfo [
 	^ mergedOrder select: [:ea | sharedAncestors includes: ea]
 ]
 
-{ #category : #ancestry }
+{ #category : 'ancestry' }
 MCAncestry >> hasAncestor: aVersionInfo [
 	^ self
 		hasAncestor: aVersionInfo
 		alreadySeen: OrderedCollection new
 ]
 
-{ #category : #ancestry }
+{ #category : 'ancestry' }
 MCAncestry >> hasAncestor: aVersionInfo alreadySeen: aList [
 	(aList includes: self) ifTrue: [^ false].
 	aList add: self.
@@ -107,32 +109,32 @@ MCAncestry >> hasAncestor: aVersionInfo alreadySeen: aList [
 
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCAncestry >> initialize [
 	super initialize.
 	ancestors := #().
 	stepChildren := #()
 ]
 
-{ #category : #ancestry }
+{ #category : 'ancestry' }
 MCAncestry >> isRelatedTo: aVersionInfo [
 	^ aVersionInfo timeStamp < self timeStamp
 		ifTrue: [self hasAncestor: aVersionInfo]
 		ifFalse: [aVersionInfo hasAncestor: self]
 ]
 
-{ #category : #ancestry }
+{ #category : 'ancestry' }
 MCAncestry >> stepChildren [
 	^ stepChildren ifNil: [#()]
 ]
 
-{ #category : #ancestry }
+{ #category : 'ancestry' }
 MCAncestry >> stepChildrenString [
 	^ String streamContents:
 		[:s | self stepChildren do: [:ea | s nextPutAll: ea name] separatedBy: [s nextPutAll: ', ']]
 ]
 
-{ #category : #ancestry }
+{ #category : 'ancestry' }
 MCAncestry >> topologicalAncestors [
 	
 	^ Array streamContents:
@@ -144,7 +146,7 @@ MCAncestry >> topologicalAncestors [
 		f isEmpty] whileFalse] 
 ]
 
-{ #category : #ancestry }
+{ #category : 'ancestry' }
 MCAncestry >> withBreadthFirstAncestors [
 	^ (Array with: self), self breadthFirstAncestors
 ]

--- a/src/Monticello/MCCacheRepository.class.st
+++ b/src/Monticello/MCCacheRepository.class.st
@@ -4,8 +4,8 @@ I am a special monticello directory-based repository that is used for the global
 Most other repositories will first query the default cache repository for existing files before handling the request by themselves. For instance an http repository will first check if the file is in the caceh before doing a ""slow"" download.
 "
 Class {
-	#name : #MCCacheRepository,
-	#superclass : #MCDirectoryRepository,
+	#name : 'MCCacheRepository',
+	#superclass : 'MCDirectoryRepository',
 	#instVars : [
 		'packageCaches',
 		'seenFiles',
@@ -14,30 +14,32 @@ Class {
 	#classInstVars : [
 		'default'
 	],
-	#category : #'Monticello-Repositories'
+	#category : 'Monticello-Repositories',
+	#package : 'Monticello',
+	#tag : 'Repositories'
 }
 
-{ #category : #'accessing settings' }
+{ #category : 'accessing settings' }
 MCCacheRepository class >> cacheDirectory [
 	^self uniqueInstance directory asAbsolute
 	
 ]
 
-{ #category : #'accessing settings' }
+{ #category : 'accessing settings' }
 MCCacheRepository class >> cacheDirectory: directory [
 	"directory - can be an absolutePathString (to interface with the settings framework), or aFileReference"
  
 	default := self new directory: directory asFileReference.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCCacheRepository class >> default [
 	"This should be deleted as soon as Metacello is fixed"
 	self flag: #toBeDeleted.			
 	^ self uniqueInstance 
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 MCCacheRepository class >> defaultDirectory [
 	| directories |
 	directories := {
@@ -51,39 +53,39 @@ MCCacheRepository class >> defaultDirectory [
 	Error signal: 'Can''t create a package-cache'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCCacheRepository class >> description [
 	^ nil
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCCacheRepository class >> disableCacheDuring: aBlock [
 	self uniqueInstance disableCacheDuring: aBlock
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 MCCacheRepository class >> initialize [
 	self resetIfInvalid
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 MCCacheRepository class >> reset [
 
 	default := nil.
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCCacheRepository class >> resetIfInvalid [
 	default notNil and: [ default directory ifAbsent: [ default := nil ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCCacheRepository class >> uniqueInstance [
 	self resetIfInvalid.
 	^ default ifNil: [default := self new directory: self defaultDirectory]
 ]
 
-{ #category : #storing }
+{ #category : 'storing' }
 MCCacheRepository >> basicStoreVersion: aVersion [
 	"we store a version if it is cacheable and we don't have the file already"
 	
@@ -92,46 +94,46 @@ MCCacheRepository >> basicStoreVersion: aVersion [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCCacheRepository >> cacheForPackage: aPackage [
 	packageCaches ifNil: [packageCaches := Dictionary new].
 	^ packageCaches at: aPackage ifAbsentPut: [MCPackageCache new]
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCCacheRepository >> disable [
 	cacheEnabled := false.
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCCacheRepository >> disableCacheDuring: aBlock [
 	self disable.
 	aBlock ensure: [ self enable ].
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCCacheRepository >> enable [
 	cacheEnabled := true
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCCacheRepository >> initialize [
 	cacheEnabled := true.
 	super initialize.
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCCacheRepository >> loadVersionFromFileNamed: aString [
 	
 	^ self versionReaderForFileNamed: aString do: [:r | r version]
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCCacheRepository >> newFileNames [ 
 	^ self allFileNames difference: self seenFileNames
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCCacheRepository >> rescan [
 	self newFileNames do:
 		[:ea |
@@ -144,18 +146,18 @@ MCCacheRepository >> rescan [
 		displayingProgress: 'Scanning cache...'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCCacheRepository >> seenFileNames [
 	^ seenFiles ifNil: [seenFiles := OrderedCollection new]
 ]
 
-{ #category : #storing }
+{ #category : 'storing' }
 MCCacheRepository >> storeVersion: aVersion [
 	cacheEnabled == true ifFalse: [ ^ self ].
 	^ super storeVersion: aVersion.
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCCacheRepository >> useDirectory: aFolder during: aBlock [
 
 	| oldDirectory |
@@ -165,14 +167,14 @@ MCCacheRepository >> useDirectory: aFolder during: aBlock [
 	aBlock value ] ensure: [ self directory: oldDirectory ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCCacheRepository >> versionInfoForFileNamed: aString [
 	^ self infoCache 
 		at: aString 
 		ifAbsentPut: [ self versionReaderForFileNamed: aString do: [:r | r info]]
 ]
 
-{ #category : #interface }
+{ #category : 'interface' }
 MCCacheRepository >> versionWithInfo: aVersionInfo ifAbsent: errorBlock [
 	(self allFileNamesForVersionNamed: aVersionInfo name) do: [:fileName | | version |
 			version := self versionFromFileNamed: fileName.

--- a/src/Monticello/MCChangeSelectionRequest.class.st
+++ b/src/Monticello/MCChangeSelectionRequest.class.st
@@ -2,31 +2,33 @@
 Notify about a change selection request
 "
 Class {
-	#name : #MCChangeSelectionRequest,
-	#superclass : #Notification,
+	#name : 'MCChangeSelectionRequest',
+	#superclass : 'Notification',
 	#instVars : [
 		'patch',
 		'label'
 	],
-	#category : #'Monticello-Versioning'
+	#category : 'Monticello-Versioning',
+	#package : 'Monticello',
+	#tag : 'Versioning'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCChangeSelectionRequest >> label [
 	^ label
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCChangeSelectionRequest >> label: aString [
 	label := aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCChangeSelectionRequest >> patch [
 	^ patch
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCChangeSelectionRequest >> patch: aPatch [
 	patch := aPatch
 ]

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -2,8 +2,8 @@
 A MCClassDefinition represents a class.
 "
 Class {
-	#name : #MCClassDefinition,
-	#superclass : #MCDefinition,
+	#name : 'MCClassDefinition',
+	#superclass : 'MCDefinition',
 	#instVars : [
 		'name',
 		'superclassName',
@@ -16,10 +16,12 @@ Class {
 		'traitComposition',
 		'classTraitComposition'
 	],
-	#category : #'Monticello-Modeling'
+	#category : 'Monticello-Modeling',
+	#package : 'Monticello',
+	#tag : 'Modeling'
 }
 
-{ #category : #deprecated }
+{ #category : 'deprecated' }
 MCClassDefinition class >> name: nameString superclassName: superclassString traitComposition: traitCompositionString classTraitComposition: classTraitCompositionString category: categoryString instVarNames: ivarArray classVarNames: cvarArray poolDictionaryNames: poolArray classInstVarNames: civarArray type: typeSymbol comment: commentString commentStamp: stampString [
 	"Do not use this method! This method will be deprecated once Tonel will not use it anymore."
 
@@ -38,7 +40,7 @@ MCClassDefinition class >> name: nameString superclassName: superclassString tra
 		  yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCClassDefinition class >> named: nameString [
 
 	^ self new
@@ -46,7 +48,7 @@ MCClassDefinition class >> named: nameString [
 		  yourself
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCClassDefinition >> = aDefinition [
 	^ super = aDefinition
 		and: [ superclassName = aDefinition superclassName
@@ -56,7 +58,7 @@ MCClassDefinition >> = aDefinition [
 		and: [ type = aDefinition type and: [ self sortedVariables = aDefinition sortedVariables and: [ comment = aDefinition comment ] ] ] ] ] ] ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCClassDefinition >> accept: aVisitor [
 	aVisitor visitClassDefinition: self.
 	(self hasClassInstanceVariables or: [self hasClassTraitComposition])
@@ -64,17 +66,17 @@ MCClassDefinition >> accept: aVisitor [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> actualClass [
 	^ Smalltalk globals classNamed: self className
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCClassDefinition >> addVariables: aCollection ofType: aClass [
 	variables addAll: (aCollection collect: [:var | aClass name: var asString]).
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> category [
 
 	^ self packageName ifNotNil: [ :package |
@@ -83,31 +85,31 @@ MCClassDefinition >> category [
 			  ifFalse: [ package , '-' , self tagName ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> category: categoryString [
 
 	self packageName: categoryString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> classDefinitionString [
 	"Answer a string describing the class-side definition."
 	
 	^String streamContents: [:stream | self printClassDefinitionOn: stream]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> classInstVarNames [
 	^ self selectVariables: #isClassInstanceVariable
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> classInstVarNames: civarArray [
 
 	self addVariables: civarArray ofType: MCClassInstanceVariableDefinition
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCClassDefinition >> classInstanceVariables [
 
 	variables ifNil: [ ^ #() ].
@@ -117,50 +119,50 @@ MCClassDefinition >> classInstanceVariables [
 		ifFalse: [self classInstanceVariablesString asSlotCollection]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCClassDefinition >> classInstanceVariablesString [
 
 	^ self stringForVariablesOfType: #isClassInstanceVariable
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> className [
 	^ name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> classTraitComposition [
 	^classTraitComposition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> classTraitComposition: classTraitCompositionString [
 
 	classTraitComposition := classTraitCompositionString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> classTraitCompositionCompiled [
 		^(Smalltalk compiler evaluate: self classTraitCompositionString) asTraitComposition 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> classTraitCompositionString [
 	^self classTraitComposition ifNil: ['{}'].
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> classVarNames [
 	^(self selectVariables: #isClassVariable) asArray sort
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> classVarNames: cvarArray [
 
 	self addVariables: cvarArray asSortedCollection ofType: MCClassVariableDefinition
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCClassDefinition >> classVariables [
 	^self needsSlotClassDefinition 
 		ifTrue: [self sortedVariablesOfType: #isClassVariable ]
@@ -168,33 +170,33 @@ MCClassDefinition >> classVariables [
 
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCClassDefinition >> classVariablesString [
 	^ self stringForSortedVariablesOfType: #isClassVariable
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> comment [
 	^ comment
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> comment: aString [
 
 	comment := aString withInternalLineEndings
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> commentStamp [
 	^ commentStamp
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> commentStamp: anObject [
 	commentStamp := anObject
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCClassDefinition >> createClass [
 
 	| superClass |
@@ -223,7 +225,7 @@ MCClassDefinition >> createClass [
 		  do: [ :ex | ex resume ]
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCClassDefinition >> createVariableFromString: aString [
 	^[ Smalltalk compiler evaluate: aString ] 
 		on: Error 
@@ -236,7 +238,7 @@ MCClassDefinition >> createVariableFromString: aString [
 			UndefinedSlot named: slotName ast: ast  ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> defaultCommentStamp [
 	^ String new
 
@@ -248,45 +250,45 @@ MCClassDefinition >> defaultCommentStamp [
 
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCClassDefinition >> definitionString [
 	^ String streamContents: [:stream | self printDefinitionOn: stream]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> description [
 	^ { name }
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCClassDefinition >> hasClassInstanceVariables [
 	^ (self selectVariables: #isClassInstanceVariable) isEmpty not
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCClassDefinition >> hasClassTraitComposition [
 	^self classTraitCompositionString ~= '{}'
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCClassDefinition >> hasComment [
 	^ comment isEmptyOrNil not
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCClassDefinition >> hasTraitComposition [
 	^self traitCompositionString ~= '{}'
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCClassDefinition >> hash [
 
 	^ (((((name hash bitXor: superclassName hash) bitXor: traitComposition hash) bitXor: classTraitComposition hash) bitXor: self category hash) bitXor: type hash)
 		  bitXor: variables hash
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCClassDefinition >> initialize [
 
 	super initialize.
@@ -299,7 +301,7 @@ MCClassDefinition >> initialize [
 	variables := OrderedCollection new
 ]
 
-{ #category : #introspection }
+{ #category : 'introspection' }
 MCClassDefinition >> instVarNamed: aString put: aValue [
 
 	self flag: #package. "temporary hack until Tonel is fixed"
@@ -310,40 +312,40 @@ MCClassDefinition >> instVarNamed: aString put: aValue [
 		put: aValue
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> instVarNames [
 	^ self selectVariables: #isInstanceVariable
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> instVarNames: ivarArray [
 
 	self addVariables: ivarArray ofType: MCInstanceVariableDefinition
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCClassDefinition >> instanceVariables [
 	^self needsSlotClassDefinition 
 		ifTrue: [self variablesOfType: #isInstanceVariable]
 		ifFalse: [self instanceVariablesString asSlotCollection]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCClassDefinition >> instanceVariablesString [
 	^ self stringForVariablesOfType: #isInstanceVariable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCClassDefinition >> isClassDefinition [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCClassDefinition >> isCodeDefinition [
 	^ true
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCClassDefinition >> kindOfSubclass [
 	type = #normal ifTrue: [^ ' subclass: '].
 	type = #words ifTrue: [^ ' variableWordSubclass: '].
@@ -359,19 +361,19 @@ MCClassDefinition >> kindOfSubclass [
 	^ ' subclass: '
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCClassDefinition >> load [
 	self createClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> name: anObject [
 
 	name := anObject asSymbol.
 	self type: type
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCClassDefinition >> needsSlotClassDefinition [
 	"this checks if any ivar or class var is using more than just standard definitions.
 	Complex vars are encoded with a string that starts with a # or one that has a space"
@@ -379,37 +381,37 @@ MCClassDefinition >> needsSlotClassDefinition [
 	^self variables anySatisfy: [:var | (var name beginsWith:'#') or: [ var name includes: Character space ]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> packageName [
 
 	^ packageName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> packageName: aString [
 
 	packageName := aString ifNotNil: [ :package | package asSymbol ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> poolDictionaries [
 	^ self selectVariables: #isPoolImport
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> poolDictionaryNames: poolArray [
 
 	self addVariables: poolArray asSortedCollection ofType: MCPoolImportDefinition
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 MCClassDefinition >> postCopy [
 
 	super postCopy.
 	variables := variables copy
 ]
 
-{ #category : #annotations }
+{ #category : 'annotations' }
 MCClassDefinition >> printAnnotations: requests on: aStream [
 	"Add a string for an annotation pane, trying to fulfill the browser annotationRequests"
 
@@ -419,7 +421,7 @@ MCClassDefinition >> printAnnotations: requests on: aStream [
 	] separatedBy: [ aStream space ].
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCClassDefinition >> printClassDefinitionOn: stream [
 	"Print a class-side definition of the receiver on the given stream.
 	Class instance variables and class traits."
@@ -438,7 +440,7 @@ MCClassDefinition >> printClassDefinitionOn: stream [
 			store: self classInstanceVariablesString
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCClassDefinition >> printDefinitionBodyOn: stream [
 
 	self hasClassTraitComposition ifTrue: [
@@ -451,7 +453,7 @@ MCClassDefinition >> printDefinitionBodyOn: stream [
 		store: self classInstanceVariablesString
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCClassDefinition >> printDefinitionOn: stream [
 		stream 
 			nextPutAll: self superclassName;
@@ -478,7 +480,7 @@ MCClassDefinition >> printDefinitionOn: stream [
 			store: self category asString
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCClassDefinition >> printMetaDefinitionOn: stream [
 	stream 
 		nextPutAll: self className;
@@ -486,12 +488,12 @@ MCClassDefinition >> printMetaDefinitionOn: stream [
 	self printDefinitionBodyOn: stream
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCClassDefinition >> provisions [
 	^ { name }
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCClassDefinition >> requirements [
 
 	^ (superclassName = #nil or: [ superclassName asString beginsWith: 'AnObsolete' ])
@@ -499,22 +501,22 @@ MCClassDefinition >> requirements [
 		  ifFalse: [ { superclassName } , self poolDictionaries ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> selectVariables: aSelector [
 	^ variables select: [:v | v perform: aSelector] thenCollect: [:v | v name]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCClassDefinition >> sharedPoolsString [
 	^ self stringForSortedVariablesOfType: #isPoolImport
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> sortKey [
 	^ self className
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> sortedVariables [
 	"sort variables for comparison purposes"
 
@@ -525,19 +527,19 @@ MCClassDefinition >> sortedVariables [
 	^sorted
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCClassDefinition >> sortedVariablesOfType: aSymbol [
 	"version for complex vars, { definition . definition }"
 	^(((self selectVariables: aSymbol) asSortedCollection collect: [:each | Smalltalk compiler evaluate: each])) asArray.
 		
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCClassDefinition >> source [
 	^ self definitionString
 ]
 
-{ #category : #storing }
+{ #category : 'storing' }
 MCClassDefinition >> storeDataOn: aDataStream [
 	| instVarSize |
 	instVarSize := (self hasTraitComposition or: [ self hasClassTraitComposition ])
@@ -550,7 +552,7 @@ MCClassDefinition >> storeDataOn: aDataStream [
 		aDataStream nextPut: (self instVarAt: index) ].
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCClassDefinition >> stringForSortedVariablesOfType: aSymbol [
 	^ String streamContents:
 		[:stream |
@@ -559,7 +561,7 @@ MCClassDefinition >> stringForSortedVariablesOfType: aSymbol [
 			separatedBy: [stream space]]
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCClassDefinition >> stringForVariablesOfType: aSymbol [
 	^ String streamContents:
 		[:stream |
@@ -568,17 +570,17 @@ MCClassDefinition >> stringForVariablesOfType: aSymbol [
 			separatedBy: [stream space]]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCClassDefinition >> summary [
 	^ name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> superclassName [
 	^ superclassName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> superclassName: superclassString [
 
 	superclassName := superclassString
@@ -586,45 +588,45 @@ MCClassDefinition >> superclassName: superclassString [
 		                  ifNotNil: [ superclassString asSymbol ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> tagName [
 
 	^ tagName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> tagName: aString [
 
 	tagName := aString ifNotNil: [ :tag | tag asSymbol ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> traitComposition [
 	^traitComposition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> traitComposition: traitCompositionString [
 
 	traitComposition := traitCompositionString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> traitCompositionCompiled [
 	^(Smalltalk compiler evaluate: self traitCompositionString) asTraitComposition 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> traitCompositionString [
 	^self traitComposition ifNil: ['{}'].
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> type [
 	^ type
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> type: aSymbol [
 
 	type := (#( #CompiledMethod #CompiledBlock #CompiledCode ) includes: name)
@@ -632,17 +634,17 @@ MCClassDefinition >> type: aSymbol [
 		        ifFalse: [ aSymbol ]
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCClassDefinition >> unload [
 	Smalltalk globals removeClassNamed: name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassDefinition >> variables [
 	^ variables ifNil: [ variables := OrderedCollection  new ]
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCClassDefinition >> variablesOfType: aSymbol [
 	"version for complex vars, { definition . definition }"
 	^(self selectVariables: aSymbol) 

--- a/src/Monticello/MCClassInstanceVariableDefinition.class.st
+++ b/src/Monticello/MCClassInstanceVariableDefinition.class.st
@@ -2,17 +2,19 @@
 A MCClassInstanceVariableDefinition represents a class instance variable.
 "
 Class {
-	#name : #MCClassInstanceVariableDefinition,
-	#superclass : #MCVariableDefinition,
-	#category : #'Monticello-Modeling'
+	#name : 'MCClassInstanceVariableDefinition',
+	#superclass : 'MCVariableDefinition',
+	#category : 'Monticello-Modeling',
+	#package : 'Monticello',
+	#tag : 'Modeling'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassInstanceVariableDefinition class >> type [
 	^ #classInstance
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCClassInstanceVariableDefinition >> isClassInstanceVariable [
 	^ true
 ]

--- a/src/Monticello/MCClassTraitDefinition.class.st
+++ b/src/Monticello/MCClassTraitDefinition.class.st
@@ -2,18 +2,20 @@
 A class trait definition
 "
 Class {
-	#name : #MCClassTraitDefinition,
-	#superclass : #MCDefinition,
+	#name : 'MCClassTraitDefinition',
+	#superclass : 'MCDefinition',
 	#instVars : [
 		'baseTrait',
 		'classTraitComposition',
 		'packageName',
 		'tagName'
 	],
-	#category : #'Monticello-Modeling'
+	#category : 'Monticello-Modeling',
+	#package : 'Monticello',
+	#tag : 'Modeling'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCClassTraitDefinition class >> baseTraitName: aString [
 
 	^ self new
@@ -21,7 +23,7 @@ MCClassTraitDefinition class >> baseTraitName: aString [
 		  yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCClassTraitDefinition class >> baseTraitName: aString classTraitComposition: classTraitCompositionString category: aCategoryString [
 
 	^ self new
@@ -31,7 +33,7 @@ MCClassTraitDefinition class >> baseTraitName: aString classTraitComposition: cl
 		  yourself
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCClassTraitDefinition >> = aDefinition [
 	^ super = aDefinition
 		and: [ baseTrait = aDefinition baseTrait
@@ -39,24 +41,24 @@ MCClassTraitDefinition >> = aDefinition [
 		and: [ self category = aDefinition category ] ] ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCClassTraitDefinition >> accept: aVisitor [
 	^ aVisitor visitClassTraitDefinition: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassTraitDefinition >> baseTrait [
 	^baseTrait
 
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCClassTraitDefinition >> baseTraitName: aTraitName [
 
 	baseTrait := aTraitName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassTraitDefinition >> category [
 
 	^ self packageName
@@ -70,48 +72,48 @@ MCClassTraitDefinition >> category [
 				  ifFalse: [ package , '-' , self tagName ] ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCClassTraitDefinition >> category: aCategoryString [
 
 	self packageName: aCategoryString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassTraitDefinition >> className [
 	^self baseTrait
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassTraitDefinition >> classTraitComposition [
 	^classTraitComposition
 
 
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCClassTraitDefinition >> classTraitComposition: aString [
 
 	classTraitComposition := aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassTraitDefinition >> classTraitCompositionString [
 	^ self classTraitComposition ifNil: [ '{}' ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassTraitDefinition >> definitionString [
 	^self baseTrait , ' classTrait
 	uses: ' , self classTraitCompositionString.
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassTraitDefinition >> description [
 	^ Array with: baseTrait with: classTraitComposition
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCClassTraitDefinition >> hash [
 	| hash |
 	hash := String stringHash: baseTrait initialHash: 0.
@@ -120,31 +122,31 @@ MCClassTraitDefinition >> hash [
 	^ hash
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCClassTraitDefinition >> isClassDefinition [
 	"Traits are treated the same like classes."
 	
 	^ true
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCClassTraitDefinition >> load [	
 	self class compiler evaluate: self definitionString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassTraitDefinition >> packageName [
 
 	^ packageName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassTraitDefinition >> packageName: anObject [
 
 	packageName := anObject
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCClassTraitDefinition >> printDefinitionOn: stream [
 	stream
 		nextPutAll: self baseTrait;
@@ -155,34 +157,34 @@ MCClassTraitDefinition >> printDefinitionOn: stream [
 		nextPutAll: self classTraitCompositionString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassTraitDefinition >> requirements [
 	^ { baseTrait }
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassTraitDefinition >> sortKey [
 	^ self baseTrait , '.classTrait'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassTraitDefinition >> source [
 	^self definitionString
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCClassTraitDefinition >> summary [
 	^self baseTrait , ' classTrait'
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassTraitDefinition >> tagName [
 
 	^ tagName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassTraitDefinition >> tagName: anObject [
 
 	tagName := anObject

--- a/src/Monticello/MCClassTraitParser.class.st
+++ b/src/Monticello/MCClassTraitParser.class.st
@@ -2,17 +2,19 @@
 MCClassTraitParser identifies classTrait. 
 "
 Class {
-	#name : #MCClassTraitParser,
-	#superclass : #MCDoItParser,
-	#category : #'Monticello-Chunk Format'
+	#name : 'MCClassTraitParser',
+	#superclass : 'MCDoItParser',
+	#category : 'Monticello-Chunk Format',
+	#package : 'Monticello',
+	#tag : 'Chunk Format'
 }
 
-{ #category : #'factory identification hook' }
+{ #category : 'factory identification hook' }
 MCClassTraitParser class >> pattern [
 	^ '*classTrait*uses:*'
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCClassTraitParser >> addDefinitionsTo: aCollection [
 
 	| tokens definition traitCompositionString |

--- a/src/Monticello/MCClassVariableDefinition.class.st
+++ b/src/Monticello/MCClassVariableDefinition.class.st
@@ -2,22 +2,24 @@
 A MCClassVariableDefinition represent a class variable.
 "
 Class {
-	#name : #MCClassVariableDefinition,
-	#superclass : #MCVariableDefinition,
-	#category : #'Monticello-Modeling'
+	#name : 'MCClassVariableDefinition',
+	#superclass : 'MCVariableDefinition',
+	#category : 'Monticello-Modeling',
+	#package : 'Monticello',
+	#tag : 'Modeling'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCClassVariableDefinition class >> type [
 	^ #class
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCClassVariableDefinition >> isClassVariable [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCClassVariableDefinition >> isOrderDependend [
 	^false
 ]

--- a/src/Monticello/MCDataStream.class.st
+++ b/src/Monticello/MCDataStream.class.st
@@ -21,8 +21,8 @@ NOTE: A DataStream should be treated as a write-stream for writing.  It is a rea
 
 "
 Class {
-	#name : #MCDataStream,
-	#superclass : #Stream,
+	#name : 'MCDataStream',
+	#superclass : 'Stream',
 	#instVars : [
 		'byteStream',
 		'topCall',
@@ -33,17 +33,19 @@ Class {
 		'TypeMap',
 		'WriteSelectors'
 	],
-	#category : #'Monticello-Storing'
+	#category : 'Monticello-Storing',
+	#package : 'Monticello',
+	#tag : 'Storing'
 }
 
-{ #category : #cleanup }
+{ #category : 'cleanup' }
 MCDataStream class >> cleanUp [
 	"Re-initialize DataStream to avoid hanging onto obsolete classes"
 
 	self initialize
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCDataStream class >> detectFile: aBlock do: anotherBlock [
 	^ aBlock value
 		ifNotNil: [ :file | 
@@ -51,7 +53,7 @@ MCDataStream class >> detectFile: aBlock do: anotherBlock [
 				ensure: [ file close ] ]
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCDataStream class >> fileNamed: aString [
 	"Here is the way to use DataStream and ReferenceStream:
 
@@ -64,19 +66,19 @@ rr close.
 	^ self on: aString asFileReference binaryWriteStream
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCDataStream class >> fileNamed: fileName do: aBlock [
 	"Returns the result of aBlock."
 	
 	^ self detectFile: [ self fileNamed: fileName ] do: aBlock
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 MCDataStream class >> initialize [
 	self initializeTypeMap 
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 MCDataStream class >> initializeTypeMap [
 	"TypeMap maps Smalltalk classes to type ID numbers which identify the data stream primitive formats.  nextPut: writes these IDs to the data stream.  NOTE: Changing these type ID numbers will invalidate all extant data stream files.  Adding new ones is OK.  
 	Classes named here have special formats in the file.  If such a class has a subclass, it will use type 9 and write correctly.  It will just be slow.  (Later write the class name in the special format, then subclasses can use the type also.)
@@ -136,12 +138,12 @@ MCDataStream class >> initializeTypeMap [
 		usingWriteSelector: #writeWordLike:
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCDataStream class >> new [
 	^ self basicNew
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCDataStream class >> newFileNamed: aString [
 	"Here is the way to use DataStream and ReferenceStream:
 	|rr|
@@ -155,7 +157,7 @@ MCDataStream class >> newFileNamed: aString [
 	^ self on: fileReference binaryWriteStream
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCDataStream class >> oldFileNamed: aString [
 	"Here is the way to use DataStream and ReferenceStream:
 
@@ -171,7 +173,7 @@ MCDataStream class >> oldFileNamed: aString [
 	^ strm
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCDataStream class >> on: aStream [
 	"Open a new DataStream onto a low-level I/O stream."
 
@@ -179,7 +181,7 @@ MCDataStream class >> on: aStream [
 
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCDataStream class >> readOnlyFileNamed:  aString [
 	"Here is the way to use DataStream and ReferenceStream:
 	
@@ -192,37 +194,37 @@ MCDataStream class >> readOnlyFileNamed:  aString [
 	^ self on: aString asFileReference binaryReadStream
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCDataStream class >> readOnlyFileNamed: fileName do: aBlock [
 	"Returns the result of aBlock."
 	
 	^ self detectFile: [ self readOnlyFileNamed: fileName ] do: aBlock
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 MCDataStream class >> readSelectors [
 	ReadSelectors ifNil: [ self initializeTypeMap ].
 	^ReadSelectors 
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 MCDataStream class >> registerClass: aClass atIndex: anIndex usingReadSelector: readSelector usingWriteSelector: writeSelector [
 	self typeMap at: aClass put: anIndex.
 	self readSelectors at: anIndex put: readSelector.
 	self writeSelectors at: anIndex put: writeSelector
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 MCDataStream class >> registerReaderSelector: aSelector atIndex: index [
 	self readSelectors at: index put: aSelector
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 MCDataStream class >> registerWriterSelector: aSelector atIndex: anIndex [
 	self writeSelectors at: anIndex put: aSelector
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCDataStream class >> streamedRepresentationOf: anObject [
 
 	| file |
@@ -231,26 +233,26 @@ MCDataStream class >> streamedRepresentationOf: anObject [
 	^file contents
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 MCDataStream class >> typeMap [
 	TypeMap ifNil: [ self initializeTypeMap ].
 	^ TypeMap
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 MCDataStream class >> writeSelectors [
 	WriteSelectors ifNil: [ self initializeTypeMap ].
 	^ WriteSelectors
 ]
 
-{ #category : #other }
+{ #category : 'other' }
 MCDataStream >> atEnd [
     "Answer true if the stream is at the end."
 
     ^ byteStream atEnd
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> beginInstance: aClass size: anInteger [
 	"This is for use by storeDataOn: methods.
 	 Cf. Object>>storeDataOn:."
@@ -268,7 +270,7 @@ MCDataStream >> beginInstance: aClass size: anInteger [
 	self nextPut: aClass name
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> beginReference: anObject [
     "We're starting to read anObject. Remember it and its reference
      position (if we care; ReferenceStream cares). Answer the
@@ -277,12 +279,12 @@ MCDataStream >> beginReference: anObject [
     ^ 0
 ]
 
-{ #category : #other }
+{ #category : 'other' }
 MCDataStream >> byteStream [
 	^ byteStream
 ]
 
-{ #category : #other }
+{ #category : 'other' }
 MCDataStream >> close [
 	"Close the stream."
 
@@ -295,12 +297,12 @@ MCDataStream >> close [
 	^ bytes
 ]
 
-{ #category : #other }
+{ #category : 'other' }
 MCDataStream >> contents [
 	^byteStream contents
 ]
 
-{ #category : #other }
+{ #category : 'other' }
 MCDataStream >> errorWriteReference: anInteger [
     "PRIVATE -- Raise an error because this case of nextPut:'s perform:
      shouldn't be called."
@@ -308,14 +310,14 @@ MCDataStream >> errorWriteReference: anInteger [
     self error: 'This should never be called'
 ]
 
-{ #category : #other }
+{ #category : 'other' }
 MCDataStream >> flush [
     "Guarantee that any writes to me are actually recorded on disk."
 
     ^ byteStream flush
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> getCurrentReference [
     "PRIVATE -- Return the currentReference posn.
      Overridden by ReferenceStream."
@@ -323,14 +325,14 @@ MCDataStream >> getCurrentReference [
     ^ 0
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> maybeBeginReference: internalObject [
 	"Do nothing.  See ReferenceStream|maybeBeginReference:"
 
 	^ internalObject
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> next [
 	"Answer the next object in the stream."
 	| type selector anObject  internalObject |
@@ -369,7 +371,7 @@ MCDataStream >> next [
 	^ self maybeBeginReference: internalObject
 ]
 
-{ #category : #other }
+{ #category : 'other' }
 MCDataStream >> next: anInteger [
     "Answer an Array of the next anInteger objects in the stream."
     | array |
@@ -380,7 +382,7 @@ MCDataStream >> next: anInteger [
     ^ array
 ]
 
-{ #category : #other }
+{ #category : 'other' }
 MCDataStream >> nextAndClose [
 	"Speedy way to grab one object.  Only use when we are inside an object binary file.  Do not use for the start of a SmartRefStream mixed code-and-object file."
 
@@ -390,7 +392,7 @@ MCDataStream >> nextAndClose [
 	^ obj
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> nextPut: anObject [
 	"Write anObject to the receiver stream. Answer anObject."
 	| typeID selector objectToStore |
@@ -409,7 +411,7 @@ MCDataStream >> nextPut: anObject [
 	^ anObject
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> nextPutAll: aCollection [
 	"Write each of the objects in aCollection to the
      receiver stream. Answer aCollection."
@@ -417,7 +419,7 @@ MCDataStream >> nextPutAll: aCollection [
 	^ aCollection do: [ :each | self nextPut: each ]
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> objectAt: anInteger [
 	"PRIVATE -- Read & return the object at a given stream position.  08:18 tk  anInteger is a relative file position. "
 	| savedPosn anObject refPosn |
@@ -433,14 +435,14 @@ MCDataStream >> objectAt: anInteger [
 	^ anObject
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> objectIfBlocked: anObject [
 	"We don't do any blocking"
 
 	^ anObject
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> outputReference: referencePosn [
 	"PRIVATE -- Output a reference to the object at integer stream position referencePosn (relative to basePos). To output a weak reference to an object not yet written, supply (self vacantRef) for referencePosn."
 
@@ -448,7 +450,7 @@ MCDataStream >> outputReference: referencePosn [
 	byteStream nextNumber: 4 put: referencePosn	"relative position"
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> readArray [
 	"PRIVATE -- Read the contents of an Array.
 	 We must do beginReference: here after instantiating the Array
@@ -467,14 +469,14 @@ MCDataStream >> readArray [
 	^ array
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> readFalse [
     "PRIVATE -- Read the contents of a False."
 
     ^ false
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> readInstance [
 	"PRIVATE -- Read the contents of an arbitrary instance.
 	 ASSUMES: readDataFrom:size: sends me beginReference: after it
@@ -497,21 +499,21 @@ MCDataStream >> readInstance [
 	^ anObject
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> readInteger [
     "PRIVATE -- Read the contents of a SmallInteger."
 
     ^ byteStream nextInt32	"signed!!!"
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> readNil [
     "PRIVATE -- Read the contents of an UndefinedObject."
 
     ^ nil
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> readString [
 
 	| length aByteArray |
@@ -526,47 +528,47 @@ MCDataStream >> readString [
 	^ aByteArray asString.
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> readSymbol [
     "PRIVATE -- Read the contents of a Symbol."
     ^ self readString asSymbol
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> readTrue [
     "PRIVATE -- Read the contents of a True."
 
     ^ true
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCDataStream >> reset [
     "Reset the stream."
 
     byteStream reset
 ]
 
-{ #category : #other }
+{ #category : 'other' }
 MCDataStream >> rootObject [
 	"Return the object at the root of the tree we are filing out.  "
 
 	^ topCall
 ]
 
-{ #category : #other }
+{ #category : 'other' }
 MCDataStream >> rootObject: anObject [
 	"Return the object at the root of the tree we are filing out.  "
 
 	topCall := anObject
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> setCurrentReference: refPosn [
     "PRIVATE -- Set currentReference to refPosn.
      Noop here. Cf. ReferenceStream."
 ]
 
-{ #category : #other }
+{ #category : 'other' }
 MCDataStream >> setStream: aStream [
 	"PRIVATE -- Initialization method."
 
@@ -574,7 +576,7 @@ MCDataStream >> setStream: aStream [
 	byteStream := aStream.
 ]
 
-{ #category : #other }
+{ #category : 'other' }
 MCDataStream >> setStream: aStream reading: isReading [
 	"PRIVATE -- Initialization method."
 
@@ -583,14 +585,14 @@ MCDataStream >> setStream: aStream reading: isReading [
 	byteStream := aStream.
 ]
 
-{ #category : #other }
+{ #category : 'other' }
 MCDataStream >> size [
     "Answer the stream's size."
 
     ^ byteStream size
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> tryToPutReference: anObject typeID: typeID [
     "PRIVATE -- If we support references for type typeID, and if
        anObject already appears in my output stream, then put a
@@ -605,7 +607,7 @@ MCDataStream >> tryToPutReference: anObject typeID: typeID [
     ^ false
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> typeIDFor: anObject [
 	"Return the typeID for anObject's class.  This is where the tangle of objects is clipped to stop everything from going out.  
 	Classes can control their instance variables by defining objectToStoreOnDataStream.
@@ -616,7 +618,7 @@ MCDataStream >> typeIDFor: anObject [
 "See DataStream initialize.  nil=1. true=2. false=3. a SmallInteger=4. (a String was 5). a Symbol=6.  a ByteArray=7. an Array=8. other = 9.  a Bitmap=11. a Metaclass=12. a Float=14.  a Rectangle=15. any instance that can have a short header=16.  a String=17 (new format). a WordArray=18."
 ]
 
-{ #category : #other }
+{ #category : 'other' }
 MCDataStream >> vacantRef [
 	"Answer the magic 32-bit constant we use ***ON DISK*** as a stream 'reference
 	 position' to identify a reference that's not yet filled in. This must be a
@@ -629,7 +631,7 @@ MCDataStream >> vacantRef [
 	^ SmallInteger maxVal
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> writeArray: anArray [
 	"PRIVATE -- Write the contents of an Array."
 
@@ -637,31 +639,31 @@ MCDataStream >> writeArray: anArray [
 	self nextPutAll: anArray.
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> writeFalse: aFalse [
     "PRIVATE -- Write the contents of a False."
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> writeInstance: anObject [
     "PRIVATE -- Write the contents of an arbitrary instance."
 
     ^ anObject storeDataOn: self
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> writeInteger: anInteger [
 	"PRIVATE -- Write the contents of a SmallInteger."
 
 	byteStream nextInt32Put: anInteger	"signed!!!!!"
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> writeNil: anUndefinedObject [
     "PRIVATE -- Write the contents of an UndefinedObject."
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> writeString: aString [
 	"PRIVATE -- Write the contents of a String."
 
@@ -676,14 +678,14 @@ MCDataStream >> writeString: aString [
 	byteStream nextPutAll: aString asByteArray.
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> writeSymbol: aSymbol [
     "PRIVATE -- Write the contents of a Symbol."
 
     self writeString: aSymbol
 ]
 
-{ #category : #'write and read' }
+{ #category : 'write and read' }
 MCDataStream >> writeTrue: aTrue [
     "PRIVATE -- Write the contents of a True."
 ]

--- a/src/Monticello/MCDefinition.class.st
+++ b/src/Monticello/MCDefinition.class.st
@@ -2,22 +2,24 @@
 A MCDefinition is the root of inheritance of entities representing code. 
 "
 Class {
-	#name : #MCDefinition,
-	#superclass : #Object,
-	#category : #'Monticello-Base'
+	#name : 'MCDefinition',
+	#superclass : 'Object',
+	#category : 'Monticello-Base',
+	#package : 'Monticello',
+	#tag : 'Base'
 }
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCDefinition >> <= other [
 	^ self sortKey <= other sortKey
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCDefinition >> = aDefinition [
 	^(aDefinition isKindOf: MCDefinition) and: [self isRevisionOf: aDefinition]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDefinition >> actualClass [
 	"Since the targetClass call on a patch operation will fail
 	otherwise."
@@ -25,152 +27,152 @@ MCDefinition >> actualClass [
 	^nil
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCDefinition >> addMethodAdditionTo: aCollection [
 	self load
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDefinition >> className [
 	"Answer the class name here or nil if not applicable."
 	
 	^nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDefinition >> definition [
 
 	^ self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDefinition >> description [
 	self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDefinition >> diffSource [
 	^ self source
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDefinition >> fullClassName [
 	"Answer the className by default."
 	
 	^self className
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCDefinition >> fullTimeStamp [
 	^ DateAndTime current
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCDefinition >> hash [
 	^ self description hash
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCDefinition >> isClassDefinition [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCDefinition >> isClassDefinitionExtension [
 	"Answer true if this definition extends the regular class definition"
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCDefinition >> isMethodDefinition [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCDefinition >> isOrganizationDefinition [
 	^false
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCDefinition >> isRevisionOf: aDefinition [
 	^ (aDefinition isKindOf: MCDefinition) and: [aDefinition description = self description]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCDefinition >> isSameRevisionAs: aDefinition [
 	^ self = aDefinition
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCDefinition >> isScriptDefinition [
 	^false
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCDefinition >> load [
 	
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCDefinition >> loadOver: aDefinition [
 	self load
 	
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCDefinition >> postload [
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCDefinition >> postloadOver: aDefinition [
 	self postload
 ]
 
-{ #category : #annotations }
+{ #category : 'annotations' }
 MCDefinition >> printAnnotations: requests on: aStream [
 	"Add a string for an annotation pane, trying to fulfill the browser annotationRequests."
 
 	aStream nextPutAll: 'not yet implemented'
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCDefinition >> printOn: aStream [
 	super printOn: aStream.
 	aStream nextPutAll: '(', self summary, ')'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDefinition >> provisions [
 	^ #()
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDefinition >> requirements [
 	^ #()
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCDefinition >> sortKey [
 	self subclassResponsibility 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDefinition >> source [
 	^ self subclassResponsibility.
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCDefinition >> summary [
 	self subclassResponsibility 
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCDefinition >> summarySuffixOver: previousDefinition [
 	^self source = previousDefinition source
 		ifTrue: [ ' (source same but rev changed)' ]
 		ifFalse: [ ' (changed)' ]
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCDefinition >> unload [
 ]

--- a/src/Monticello/MCDefinitionIndex.class.st
+++ b/src/Monticello/MCDefinitionIndex.class.st
@@ -2,30 +2,32 @@
 I'm a simple container of MCDefinitions which can be added or removed.
 "
 Class {
-	#name : #MCDefinitionIndex,
-	#superclass : #Object,
+	#name : 'MCDefinitionIndex',
+	#superclass : 'Object',
 	#instVars : [
 		'definitions'
 	],
-	#category : #'Monticello-Patching'
+	#category : 'Monticello-Patching',
+	#package : 'Monticello',
+	#tag : 'Patching'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCDefinitionIndex class >> definitions: aCollection [
 	^ self new addAll: aCollection
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 MCDefinitionIndex >> add: aDefinition [
 	^ definitions at: aDefinition description put: aDefinition
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 MCDefinitionIndex >> addAll: aCollection [
 	aCollection do: [:ea | self add: ea]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDefinitionIndex >> definitionLike: aDefinition ifPresent: foundBlock ifAbsent: errorBlock [
 	| definition |
 	definition := definitions at: aDefinition description ifAbsent: [].
@@ -34,18 +36,18 @@ MCDefinitionIndex >> definitionLike: aDefinition ifPresent: foundBlock ifAbsent:
 		ifNotNil: [foundBlock value: definition]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDefinitionIndex >> definitions [
 	^ definitions values
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCDefinitionIndex >> initialize [
 	super initialize.
 	definitions := Dictionary new
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 MCDefinitionIndex >> remove: aDefinition [
 	definitions removeKey: aDefinition description ifAbsent: []
 ]

--- a/src/Monticello/MCDependencySorter.class.st
+++ b/src/Monticello/MCDependencySorter.class.st
@@ -2,22 +2,24 @@
 A MCDependencySorter computes the dependencies to a set of entities.
 "
 Class {
-	#name : #MCDependencySorter,
-	#superclass : #Object,
+	#name : 'MCDependencySorter',
+	#superclass : 'Object',
 	#instVars : [
 		'required',
 		'provided',
 		'orderedItems'
 	],
-	#category : #'Monticello-Loading'
+	#category : 'Monticello-Loading',
+	#package : 'Monticello',
+	#tag : 'Loading'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCDependencySorter class >> items: aCollection [
 	^ self new addAll: aCollection
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MCDependencySorter class >> sortItems: aCollection [
 	| sorter |
 	sorter := self items: aCollection.
@@ -25,7 +27,7 @@ MCDependencySorter class >> sortItems: aCollection [
 	^ sorter orderedItems.
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 MCDependencySorter >> add: anItem [
 	| requirements |
 	requirements := self unresolvedRequirementsFor: anItem.
@@ -35,18 +37,18 @@ MCDependencySorter >> add: anItem [
 	^ anItem
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 MCDependencySorter >> addAll: aCollection [
 	aCollection asArray sort do: [:ea | self add: ea]
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 MCDependencySorter >> addExternalProvisions: aCollection [
 	(aCollection intersection: self externalRequirements)
 		do: [:ea | self addProvision: ea]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCDependencySorter >> addProvision: anObject [
 	| newlySatisfied |
 	provided add: anObject.
@@ -54,23 +56,23 @@ MCDependencySorter >> addProvision: anObject [
 	self addAll: newlySatisfied.
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCDependencySorter >> addRequirement: reqObject for: itemObject [
 	(self itemsRequiring: reqObject) add: itemObject
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCDependencySorter >> addRequirements: aCollection for: anObject [
 	aCollection do: [:ea | self addRequirement: ea for: anObject]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCDependencySorter >> addToOrder: anItem [
 	orderedItems add: anItem.
 	anItem provisions do: [:ea | self addProvision: ea].
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDependencySorter >> externalRequirements [
 	| unloaded providedByUnloaded |
 	unloaded := self itemsWithMissingRequirements.
@@ -78,7 +80,7 @@ MCDependencySorter >> externalRequirements [
 	^ required keys reject: [:ea | providedByUnloaded includes: ea ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCDependencySorter >> initialize [
 	super initialize.
 	provided := Set new.
@@ -86,12 +88,12 @@ MCDependencySorter >> initialize [
 	orderedItems := OrderedCollection new.
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCDependencySorter >> itemsRequiring: anObject [
 	^ required at: anObject ifAbsentPut: [Set new]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDependencySorter >> itemsWithMissingRequirements [
 	| items |
 	items := Set new.
@@ -100,12 +102,12 @@ MCDependencySorter >> itemsWithMissingRequirements [
 
 ]
 
-{ #category : #sorting }
+{ #category : 'sorting' }
 MCDependencySorter >> orderedItems [
 	^ orderedItems
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCDependencySorter >> unresolvedRequirementsFor: anItem [
 	^ anItem requirements difference: provided
 ]

--- a/src/Monticello/MCDictionaryRepository.class.st
+++ b/src/Monticello/MCDictionaryRepository.class.st
@@ -2,31 +2,33 @@
 A dictionary repository (in nemory)
 "
 Class {
-	#name : #MCDictionaryRepository,
-	#superclass : #MCRepository,
+	#name : 'MCDictionaryRepository',
+	#superclass : 'MCRepository',
 	#instVars : [
 		'description',
 		'dict'
 	],
-	#category : #'Monticello-Repositories'
+	#category : 'Monticello-Repositories',
+	#package : 'Monticello',
+	#tag : 'Repositories'
 }
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCDictionaryRepository >> = other [
 	^ self == other
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDictionaryRepository >> allVersionInfos [
 	^ dict values collect: [:ea | ea info]
 ]
 
-{ #category : #storing }
+{ #category : 'storing' }
 MCDictionaryRepository >> basicStoreVersion: aVersion [
 	dict at: aVersion info put: aVersion
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDictionaryRepository >> closestAncestorVersionFor: anAncestry ifNone: errorBlock [
 	^ anAncestry breadthFirstAncestors
 		detect: [ :ea | self includesVersionWithInfo: ea ]
@@ -34,47 +36,47 @@ MCDictionaryRepository >> closestAncestorVersionFor: anAncestry ifNone: errorBlo
 		ifNone: errorBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDictionaryRepository >> description [
 
 	^ description ifNil: ['cache']
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDictionaryRepository >> description: aString [
 
 	description := aString 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDictionaryRepository >> dictionary [
 
 	^ dict
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDictionaryRepository >> dictionary: aDictionary [
 
 	dict := aDictionary
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCDictionaryRepository >> hash [
 
 	^ self identityHash
 ]
 
-{ #category : #interface }
+{ #category : 'interface' }
 MCDictionaryRepository >> includesVersionNamed: aString [
 	^ dict anySatisfy: [:ea | ea info name = aString]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCDictionaryRepository >> includesVersionWithInfo: aVersionInfo [
 	^ dict includesKey: aVersionInfo
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCDictionaryRepository >> initialize [
 
 	super initialize.
@@ -82,13 +84,13 @@ MCDictionaryRepository >> initialize [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDictionaryRepository >> possiblyNewerVersionsOfAnyOf: versionNames [ 
 
 	^#()
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDictionaryRepository >> sortedVersionInfos [
 	| sorter |
 	sorter := MCVersionSorter new.
@@ -97,12 +99,12 @@ MCDictionaryRepository >> sortedVersionInfos [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDictionaryRepository >> versionFrom: aVersionReferenceString [
 	^ self dictionary detect: [ :version | version info name = aVersionReferenceString ]
 ]
 
-{ #category : #interface }
+{ #category : 'interface' }
 MCDictionaryRepository >> versionWithInfo: aVersionInfo ifAbsent: errorBlock [
 	^ dict at: aVersionInfo ifAbsent: errorBlock
 ]

--- a/src/Monticello/MCDiffyVersion.class.st
+++ b/src/Monticello/MCDiffyVersion.class.st
@@ -2,16 +2,18 @@
 A diffy version
 "
 Class {
-	#name : #MCDiffyVersion,
-	#superclass : #MCVersion,
+	#name : 'MCDiffyVersion',
+	#superclass : 'MCVersion',
 	#instVars : [
 		'base',
 		'patch'
 	],
-	#category : #'Monticello-Versioning'
+	#category : 'Monticello-Versioning',
+	#package : 'Monticello',
+	#tag : 'Versioning'
 }
 
-{ #category : #'name utilities' }
+{ #category : 'name utilities' }
 MCDiffyVersion class >> baseNameFrom: diffName [
 	| baseId verName |
 	baseId := (diffName copyAfter: $() copyUpTo: $).
@@ -25,7 +27,7 @@ MCDiffyVersion class >> baseNameFrom: diffName [
 
 ]
 
-{ #category : #'name utilities' }
+{ #category : 'name utilities' }
 MCDiffyVersion class >> canonicalNameFor: aFileName [
 	^(self nameForVer: (self verNameFrom: aFileName)
 		base: (self baseNameFrom: aFileName))
@@ -33,7 +35,7 @@ MCDiffyVersion class >> canonicalNameFor: aFileName [
 
 ]
 
-{ #category : #'name utilities' }
+{ #category : 'name utilities' }
 MCDiffyVersion class >> nameForVer: versionName base: baseName [
 	| baseId |
 	baseId := (versionName copyUpToLast: $.) = (baseName copyUpToLast: $.)
@@ -44,14 +46,14 @@ MCDiffyVersion class >> nameForVer: versionName base: baseName [
 	^ versionName, '(', baseId, ')'
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCDiffyVersion class >> package: aPackage info: aVersionInfo dependencies: aCollection baseInfo: baseVersionInfo patch:
 aPatch [
 	^ self basicNew initializeWithPackage: aPackage info: aVersionInfo dependencies: aCollection baseInfo: baseVersionInfo patch:
 aPatch
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCDiffyVersion class >> package: aPackage info: aVersionInfo snapshot: aSnapshot dependencies: aCollection baseVersion: aVersion [
 	^ self 
 		package: aPackage
@@ -61,17 +63,17 @@ MCDiffyVersion class >> package: aPackage info: aVersionInfo snapshot: aSnapshot
 		patch: (aSnapshot patchRelativeToBase: aVersion snapshot)
 ]
 
-{ #category : #'name utilities' }
+{ #category : 'name utilities' }
 MCDiffyVersion class >> verNameFrom: diffName [
 	^diffName copyUpTo: $(
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDiffyVersion >> baseInfo [
 	^ base
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCDiffyVersion >> baseSnapshot [
        | baseVersion |
        baseVersion := self workingCopy repositoryGroup versionWithInfo: base.
@@ -79,7 +81,7 @@ MCDiffyVersion >> baseSnapshot [
        ^ baseVersion snapshot
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCDiffyVersion >> canOptimizeLoading [
 	"Answer wether I can provide a patch for the working copy without the usual diff pass"
 	^ package hasWorkingCopy
@@ -87,12 +89,12 @@ MCDiffyVersion >> canOptimizeLoading [
 			and: [package workingCopy ancestors includes: self baseInfo]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDiffyVersion >> fileName [
 	^ (self class nameForVer: info name base: base name), '.', self writerClass extension
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCDiffyVersion >> initializeWithPackage: aPackage info: aVersionInfo dependencies: aCollection baseInfo: baseVersionInfo patch: aPatch [
 	patch := aPatch.
 	base := baseVersionInfo.
@@ -100,27 +102,27 @@ MCDiffyVersion >> initializeWithPackage: aPackage info: aVersionInfo dependencie
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCDiffyVersion >> isDiffy [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDiffyVersion >> patch [
 	^ patch
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDiffyVersion >> snapshot [
 	^ snapshot ifNil: [snapshot := MCPatcher apply: patch to: self baseSnapshot]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDiffyVersion >> summary [
 	^ '(Diff against ', self baseInfo name, ')', String cr, super summary
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDiffyVersion >> writerClass [
 	^ MCMcdWriter 
 ]

--- a/src/Monticello/MCDirectoryRepository.class.st
+++ b/src/Monticello/MCDirectoryRepository.class.st
@@ -2,33 +2,35 @@
 A metacello repository in a directory 
 "
 Class {
-	#name : #MCDirectoryRepository,
-	#superclass : #MCFileBasedRepository,
+	#name : 'MCDirectoryRepository',
+	#superclass : 'MCFileBasedRepository',
 	#instVars : [
 		'directory'
 	],
 	#classVars : [
 		'DefaultDirectoryName'
 	],
-	#category : #'Monticello-Repositories'
+	#category : 'Monticello-Repositories',
+	#package : 'Monticello',
+	#tag : 'Repositories'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDirectoryRepository class >> defaultDirectoryName [
 	^ DefaultDirectoryName ifNil: [ FileSystem workingDirectory fullName].
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDirectoryRepository class >> defaultDirectoryName: aDirectoryName [
 	DefaultDirectoryName := aDirectoryName.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDirectoryRepository class >> description [
 	^ 'directory'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDirectoryRepository >> allFileNamesForVersionNamed: aString [
 	"avoid slow default implementation and directly check for existing files"
 	|extensions|
@@ -38,60 +40,60 @@ MCDirectoryRepository >> allFileNamesForVersionNamed: aString [
 		thenSelect: [ :fileName| self includesFileNamed: fileName ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDirectoryRepository >> description [
 	^ directory fullName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDirectoryRepository >> directory [
 	^ directory
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDirectoryRepository >> directory: aDirectory [
 	directory := aDirectory
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCDirectoryRepository >> hash [
 	^ directory hash
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCDirectoryRepository >> includesFileNamed: aString [
 	"HACK: speed up the cache hits"
 	^ (directory / aString) exists.
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCDirectoryRepository >> includesVersionNamed: aString [
 	"avoid slow default implementation and directly check for existing files"
 	^ (self allFileNamesForVersionNamed: aString) isEmpty not
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCDirectoryRepository >> initialize [
 	super initialize.
 	directory := FileSystem workingDirectory
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCDirectoryRepository >> isValid [
 	^directory exists
 ]
 
-{ #category : #interface }
+{ #category : 'interface' }
 MCDirectoryRepository >> loadAllFileNames [
 	^ (directory entries sort: [:a :b | a modificationTime >= b modificationTime]) collect: [:ea | ea basename]
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MCDirectoryRepository >> pathForFileNamed: aFileName [
   ^ (directory / aFileName) fullName
 ]
 
-{ #category : #'i/o' }
+{ #category : 'i/o' }
 MCDirectoryRepository >> readStreamForFileNamed: aString do: aBlock [
 	| val |
 	directory / aString binaryReadStreamDo: [ :stream|
@@ -99,7 +101,7 @@ MCDirectoryRepository >> readStreamForFileNamed: aString do: aBlock [
 	^ val
 ]
 
-{ #category : #'i/o' }
+{ #category : 'i/o' }
 MCDirectoryRepository >> writeStreamForFileNamed: aString replace: shouldReplace do: aBlock [
 
 	| file |

--- a/src/Monticello/MCDoItParser.class.st
+++ b/src/Monticello/MCDoItParser.class.st
@@ -7,30 +7,32 @@ MCDoitParser invokes automatically its subclasses to parse the correct source.
 Each Doit entities (entities which are defined as doits) extend this entry point to add specific behavior.
 "
 Class {
-	#name : #MCDoItParser,
-	#superclass : #Object,
+	#name : 'MCDoItParser',
+	#superclass : 'Object',
 	#instVars : [
 		'source'
 	],
-	#category : #'Monticello-Chunk Format'
+	#category : 'Monticello-Chunk Format',
+	#package : 'Monticello',
+	#tag : 'Chunk Format'
 }
 
-{ #category : #private }
+{ #category : 'private' }
 MCDoItParser class >> concreteSubclasses [
 	^ self allSubclasses reject: [:c | c isAbstract]
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCDoItParser class >> forDoit: aString [
 	^ (self subclassForDoit: aString) ifNotNil: [:c | c new source: aString]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCDoItParser class >> isAbstract [
 	^ self pattern isNil
 ]
 
-{ #category : #'factory identification hook' }
+{ #category : 'factory identification hook' }
 MCDoItParser class >> pattern [
 	"return a pattern matching expression to identify the parser corresponding to the expression.
 	Subclasses should specialize it."
@@ -38,22 +40,22 @@ MCDoItParser class >> pattern [
 	^ nil
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCDoItParser class >> subclassForDoit: aString [
 	^ self concreteSubclasses detect: [:ea | ea pattern match: aString] ifNone: []
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCDoItParser >> addDefinitionsTo: aCollection [
 	self subclassResponsibility 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDoItParser >> source [
 	^ source
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCDoItParser >> source: aString [
 	source := aString
 ]

--- a/src/Monticello/MCFileBasedRepository.class.st
+++ b/src/Monticello/MCFileBasedRepository.class.st
@@ -2,34 +2,36 @@
 A file based metacello repository
 "
 Class {
-	#name : #MCFileBasedRepository,
-	#superclass : #MCRepository,
+	#name : 'MCFileBasedRepository',
+	#superclass : 'MCRepository',
 	#instVars : [
 		'cache',
 		'allFileNames',
 		'cacheFileNames'
 	],
-	#category : #'Monticello-Repositories'
+	#category : 'Monticello-Repositories',
+	#package : 'Monticello',
+	#tag : 'Repositories'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCFileBasedRepository class >> basicFromUrl: aZnUrl [ 
 	^ MCDirectoryRepository new directory: aZnUrl asFileReference
 ]
 
-{ #category : #cleanup }
+{ #category : 'cleanup' }
 MCFileBasedRepository class >> cleanUp [
 	"Flush caches"
 
 	self flushAllCaches.
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCFileBasedRepository class >> flushAllCaches [
 	self allSubInstancesDo: [:ea | ea flushCache]
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 MCFileBasedRepository class >> monticelloSettingsOn: aBuilder [  
 	<systemsettings>  
 	(aBuilder group: #monticello)
@@ -53,12 +55,12 @@ MCFileBasedRepository class >> monticelloSettingsOn: aBuilder [
 				].
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileBasedRepository class >> urlSchemes [
 	^ #(file)
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 MCFileBasedRepository >> addVersionInformationExtractedFrom: readableFileName to: versions [
 	| name |
 	name := (readableFileName copyUpToLast: $.) copyUpTo: $(.
@@ -72,31 +74,31 @@ MCFileBasedRepository >> addVersionInformationExtractedFrom: readableFileName to
 					readableFileName }]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileBasedRepository >> allFileNames [
 	cacheFileNames == true ifFalse: [ ^ self loadAllFileNames ].
 	^ allFileNames ifNil: [
 			allFileNames := self loadAllFileNames]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileBasedRepository >> allFileNamesForVersionNamed: aString [
 	^ self filterFileNames: self readableFileNames forVersionNamed: aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileBasedRepository >> allFileNamesOrCache [
 	cacheFileNames == true ifFalse: [ ^ self allFileNames ].
 	^ allFileNames ifNil: [
 			allFileNames := self allFileNames]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileBasedRepository >> allVersionNames [
 	^ self readableFileNames collect: [:ea | self versionNameFromFileName: ea]
 ]
 
-{ #category : #storing }
+{ #category : 'storing' }
 MCFileBasedRepository >> basicStoreVersion: aVersion [
 	self
 		writeStreamForFileNamed: aVersion fileName
@@ -107,12 +109,12 @@ MCFileBasedRepository >> basicStoreVersion: aVersion [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileBasedRepository >> cache [
 	^ cache ifNil: [cache := Dictionary new]
 ]
 
-{ #category : #caching }
+{ #category : 'caching' }
 MCFileBasedRepository >> cacheAllFileNamesDuring: aBlock [
 	cacheFileNames == true ifTrue: [ ^ aBlock value ].
 	allFileNames := nil.
@@ -122,21 +124,21 @@ MCFileBasedRepository >> cacheAllFileNamesDuring: aBlock [
 		cacheFileNames := false]
 ]
 
-{ #category : #caching }
+{ #category : 'caching' }
 MCFileBasedRepository >> cachedFileNames [
 	^cache == nil
 		ifTrue: [#()]
 		ifFalse: [cache keys]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCFileBasedRepository >> canReadFileNamed: aString [
 	| reader |
 	reader := MCVersionReader readerClassForFileNamed: aString.
 	^ reader notNil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileBasedRepository >> closestAncestorVersionFor: anAncestry ifNone: errorBlock [
 	^ self
 		cacheAllFileNamesDuring: [ 
@@ -144,39 +146,39 @@ MCFileBasedRepository >> closestAncestorVersionFor: anAncestry ifNone: errorBloc
 			^ errorBlock value ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileBasedRepository >> filterFileNames: aCollection forVersionNamed: aString [
 	^ aCollection select: [:ea | (self versionNameFromFileName: ea) = aString] 
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCFileBasedRepository >> flushCache [
 	cache := nil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCFileBasedRepository >> includesFileNamed: aString [
 	"slow default implementation"
 	^ self allFileNames includes: aString
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCFileBasedRepository >> includesVersionNamed: aString [
 	^ self allVersionNames includes: aString
 ]
 
-{ #category : #interface }
+{ #category : 'interface' }
 MCFileBasedRepository >> loadAllFileNames [
 	self subclassResponsibility
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCFileBasedRepository >> loadNotCachedVersionFromFileNamed: aString [
 	
 	^ self versionReaderForFileNamed: aString do: [:r | r version]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCFileBasedRepository >> loadVersionFromFileNamed: aString [
 
 	(MCCacheRepository uniqueInstance includesFileNamed: aString)
@@ -185,18 +187,18 @@ MCFileBasedRepository >> loadVersionFromFileNamed: aString [
 	^ self versionReaderForFileNamed: aString do: [:r | r version]
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MCFileBasedRepository >> loadVersionInfoFromFileNamed: aString [
 	^ self versionReaderForFileNamed: aString do: [:r | r info]
 	
 ]
 
-{ #category : #caching }
+{ #category : 'caching' }
 MCFileBasedRepository >> maxCacheSize [
 	^ 512
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MCFileBasedRepository >> notCachedVersionWithInfo: aVersionInfo [ 
 	(self allFileNamesForVersionNamed: aVersionInfo name)
 		do: [ :fileName | 
@@ -207,12 +209,12 @@ MCFileBasedRepository >> notCachedVersionWithInfo: aVersionInfo [
 	^ nil
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MCFileBasedRepository >> pathForFileNamed: aFileName [
   ^ aFileName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileBasedRepository >> possiblyNewerVersionsOfAnyOf: someVersions [
 	| pkgs |
 	pkgs := Dictionary new.
@@ -229,7 +231,7 @@ MCFileBasedRepository >> possiblyNewerVersionsOfAnyOf: someVersions [
 	] on: Error do: [:ex | ex return: #()]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileBasedRepository >> readableFileNames [
 	| all cached new emptyFilenamelength |
 	"<hyphenated-package-name>.<dotted.branch.tag>-<initials>.<count>.mcz"
@@ -249,32 +251,32 @@ MCFileBasedRepository >> readableFileNames [
 		select: [:ea | self canReadFileNamed: ea]
 ]
 
-{ #category : #caching }
+{ #category : 'caching' }
 MCFileBasedRepository >> resizeCache: aDictionary [
 	[aDictionary size <= self maxCacheSize] whileFalse:
 		[aDictionary removeKey: aDictionary keys atRandom]
 ]
 
-{ #category : #storing }
+{ #category : 'storing' }
 MCFileBasedRepository >> storeVersion: aVersion [
 
 	(self includesFileNamed: aVersion fileName) ifTrue: [ ^ self ].
 	^ super storeVersion: aVersion.
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCFileBasedRepository >> updateCachedVersionFromFileName: aString with: aVersion [
 	self resizeCache: cache.
 	(aVersion notNil and: [aVersion isCacheable]) ifTrue: [cache at: aString put: aVersion].
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileBasedRepository >> versionFrom: aVersionReferenceString [
 	^ self loadVersionFromFileNamed: aVersionReferenceString , '.mcz'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileBasedRepository >> versionFromFileNamed: aFileName [
 	| version |
 	version := self cache
@@ -284,7 +286,7 @@ MCFileBasedRepository >> versionFromFileNamed: aFileName [
 	^ version
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileBasedRepository >> versionFromRepositoryFromFileNamed: aFileName [
 	| version |
 	version := self cache
@@ -294,7 +296,7 @@ MCFileBasedRepository >> versionFromRepositoryFromFileNamed: aFileName [
 	^ version
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileBasedRepository >> versionInfoFromFileNamed: aFileName [
 	self cache 
 		at: aFileName
@@ -302,12 +304,12 @@ MCFileBasedRepository >> versionInfoFromFileNamed: aFileName [
 	^ self loadVersionInfoFromFileNamed: aFileName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileBasedRepository >> versionNameFromFileName: aFileName [
 	^ (aFileName copyUpToLast: $.) copyUpTo: $(
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCFileBasedRepository >> versionReaderForFileNamed: aString do: aBlock [
 ^ self
 		readStreamForFileNamed: aString
@@ -316,7 +318,7 @@ MCFileBasedRepository >> versionReaderForFileNamed: aString do: aBlock [
 				[:class | aBlock value: (class on: s fileName: (self pathForFileNamed: aString))]]
 ]
 
-{ #category : #interface }
+{ #category : 'interface' }
 MCFileBasedRepository >> versionWithInfo: aVersionInfo ifAbsent: errorBlock [
 	"get a version for the given versionInfo. always query first the packageCache and only then try to load the version from the remote location"
 	^ MCCacheRepository uniqueInstance
@@ -329,7 +331,7 @@ MCFileBasedRepository >> versionWithInfo: aVersionInfo ifAbsent: errorBlock [
 			^ errorBlock value].
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileBasedRepository >> versionsWithPackageNames [
 	| versions |
 	versions := OrderedCollection new.
@@ -339,7 +341,7 @@ MCFileBasedRepository >> versionsWithPackageNames [
 	^ versions
 ]
 
-{ #category : #storing }
+{ #category : 'storing' }
 MCFileBasedRepository >> writeStreamForFileNamed: aString do: aBlock [
 	^ self writeStreamForFileNamed: aString replace: false do: aBlock
 ]

--- a/src/Monticello/MCFilteredVersionSorter.class.st
+++ b/src/Monticello/MCFilteredVersionSorter.class.st
@@ -2,22 +2,24 @@
 Sort filtered versions 
 "
 Class {
-	#name : #MCFilteredVersionSorter,
-	#superclass : #MCVersionSorter,
+	#name : 'MCFilteredVersionSorter',
+	#superclass : 'MCVersionSorter',
 	#instVars : [
 		'target'
 	],
-	#category : #'Monticello-Versioning'
+	#category : 'Monticello-Versioning',
+	#package : 'Monticello',
+	#tag : 'Versioning'
 }
 
-{ #category : #adding }
+{ #category : 'adding' }
 MCFilteredVersionSorter >> addVersionInfo: aVersionInfo [
 	(aVersionInfo hasAncestor: target)
 		ifTrue: [super addVersionInfo: aVersionInfo]
 
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCFilteredVersionSorter >> processVersionInfo: aVersionInfo [
 	| success |
 	aVersionInfo = target ifTrue: [^ true].
@@ -30,7 +32,7 @@ MCFilteredVersionSorter >> processVersionInfo: aVersionInfo [
 	^ success	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFilteredVersionSorter >> target: aVersionInfo [
 	target := aVersionInfo
 ]

--- a/src/Monticello/MCFrontier.class.st
+++ b/src/Monticello/MCFrontier.class.st
@@ -2,26 +2,28 @@
 Utility class
 "
 Class {
-	#name : #MCFrontier,
-	#superclass : #Object,
+	#name : 'MCFrontier',
+	#superclass : 'Object',
 	#instVars : [
 		'frontier',
 		'bag'
 	],
-	#category : #'Monticello-Versioning'
+	#category : 'Monticello-Versioning',
+	#package : 'Monticello',
+	#tag : 'Versioning'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCFrontier class >> frontierOn: aVersionInfo [
 	^ self frontierOnAll: (Array with: aVersionInfo)
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCFrontier class >> frontierOn: aVersionInfo and: otherVersionInfo [
 	^ self frontierOnAll: (Array with: aVersionInfo with: otherVersionInfo)
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCFrontier class >> frontierOnAll: aCollection [
 	| remaining  allVersions |
 	remaining := Bag new.
@@ -30,18 +32,18 @@ MCFrontier class >> frontierOnAll: aCollection [
 	^self new frontier: aCollection bag: remaining
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFrontier >> frontier [
 	^frontier
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCFrontier >> frontier: f bag: remaining [
 	frontier := f asOrderedCollection.
 	bag := remaining
 ]
 
-{ #category : #advancing }
+{ #category : 'advancing' }
 MCFrontier >> remove: aVersionInfo [
 	frontier remove: aVersionInfo.
 	aVersionInfo ancestors  do:
@@ -52,7 +54,7 @@ MCFrontier >> remove: aVersionInfo [
 	^aVersionInfo
 ]
 
-{ #category : #advancing }
+{ #category : 'advancing' }
 MCFrontier >> removeAll: collection [
 	collection do: [ :n | self remove: n]
 ]

--- a/src/Monticello/MCInstanceVariableDefinition.class.st
+++ b/src/Monticello/MCInstanceVariableDefinition.class.st
@@ -2,17 +2,19 @@
 A MCInstanceVariableDefinition represents an instance variable definition.
 "
 Class {
-	#name : #MCInstanceVariableDefinition,
-	#superclass : #MCVariableDefinition,
-	#category : #'Monticello-Modeling'
+	#name : 'MCInstanceVariableDefinition',
+	#superclass : 'MCVariableDefinition',
+	#category : 'Monticello-Modeling',
+	#package : 'Monticello',
+	#tag : 'Modeling'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCInstanceVariableDefinition class >> type [
 	^ #instance
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCInstanceVariableDefinition >> isInstanceVariable [
 	^ true
 ]

--- a/src/Monticello/MCLazyVersionInfo.class.st
+++ b/src/Monticello/MCLazyVersionInfo.class.st
@@ -19,12 +19,14 @@ Warnings:
 
 "
 Class {
-	#name : #MCLazyVersionInfo,
-	#superclass : #MCVersionInfo,
-	#category : #'Monticello-Versioning'
+	#name : 'MCLazyVersionInfo',
+	#superclass : 'MCVersionInfo',
+	#category : 'Monticello-Versioning',
+	#package : 'Monticello',
+	#tag : 'Versioning'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCLazyVersionInfo class >> from: aVersionInfo [
 	^ self new
 		initializeWithName: aVersionInfo name
@@ -37,12 +39,12 @@ MCLazyVersionInfo class >> from: aVersionInfo [
 		stepChildren: aVersionInfo stepChildren
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 MCLazyVersionInfo class >> initialize [
 	self install
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 MCLazyVersionInfo class >> install [
 	"Install the lazy mc versions on..."
 
@@ -54,7 +56,7 @@ MCLazyVersionInfo class >> install [
 	Smalltalk garbageCollect
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCLazyVersionInfo >> ancestors [
 	"Ensure we load ancestors as appropriate if necessary. Failure to load force us to return an empty set to avoid errors, but we'll keep track of the fact that this failure may be transient and that we can continue."
 
@@ -65,14 +67,14 @@ MCLazyVersionInfo >> ancestors [
 	^ ancestors
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCLazyVersionInfo >> initialize [
 	super initialize.
 	ancestors := WeakArray new.
 	stepChildren := WeakArray new
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCLazyVersionInfo >> initializeWithName: vName id: aUUID message: aString date: aDate time: aTime author: initials ancestors: aCollection stepChildren: stepCollection [
 	name := vName.
 	id := aUUID.
@@ -84,12 +86,12 @@ MCLazyVersionInfo >> initializeWithName: vName id: aUUID message: aString date: 
 	stepChildren := WeakArray withAll: stepCollection
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCLazyVersionInfo >> lazy [
 	^ self
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCLazyVersionInfo >> setAncestors: someAncestors [
 	"Unused in MCVersionInfo"
 
@@ -98,7 +100,7 @@ MCLazyVersionInfo >> setAncestors: someAncestors [
 	ancestors := WeakArray withAll: someAncestors
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCLazyVersionInfo >> setStepChildren: someStepChildren [
 	"Unused in MCVersionInfo"
 
@@ -107,14 +109,14 @@ MCLazyVersionInfo >> setStepChildren: someStepChildren [
 	stepChildren := WeakArray withAll: someStepChildren
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCLazyVersionInfo >> species [
 	"Make this class equivalent to a MCVersionInfo in all regards."
 
 	^ self class superclass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCLazyVersionInfo >> stepChildren [
 	"Ensure we load step children as appropriate if necessary."
 

--- a/src/Monticello/MCMcdReader.class.st
+++ b/src/Monticello/MCMcdReader.class.st
@@ -2,26 +2,28 @@
 Reader for an MCD format
 "
 Class {
-	#name : #MCMcdReader,
-	#superclass : #MCMczReader,
+	#name : 'MCMcdReader',
+	#superclass : 'MCMczReader',
 	#instVars : [
 		'baseInfo',
 		'patch'
 	],
-	#category : #'Monticello-Storing'
+	#category : 'Monticello-Storing',
+	#package : 'Monticello',
+	#tag : 'Storing'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMcdReader class >> extension [
 	^ 'mcd'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMcdReader >> baseInfo [
 	^ baseInfo ifNil: [self loadBaseInfo]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMcdReader >> basicVersion [
 	^ MCDiffyVersion
 		package: self package
@@ -31,19 +33,19 @@ MCMcdReader >> basicVersion [
 		patch: self patch
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MCMcdReader >> buildPatchFrom: oldDefinitions to: newDefinitions [
 	^ MCPatch
 		fromBase: (MCSnapshot fromDefinitions: oldDefinitions)
 		target: (MCSnapshot fromDefinitions: newDefinitions)
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MCMcdReader >> loadBaseInfo [
 	^ baseInfo := self extractInfoFrom: (self parseMember: 'base')
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MCMcdReader >> loadPatch [
 	| old new |
 	(self zip memberNamed: 'patch.bin') ifNotNil:
@@ -61,7 +63,7 @@ MCMcdReader >> loadPatch [
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMcdReader >> patch [
 	^ patch ifNil: [self loadPatch]
 ]

--- a/src/Monticello/MCMcdWriter.class.st
+++ b/src/Monticello/MCMcdWriter.class.st
@@ -2,17 +2,19 @@
 Writing MCD format
 "
 Class {
-	#name : #MCMcdWriter,
-	#superclass : #MCMczWriter,
-	#category : #'Monticello-Storing'
+	#name : 'MCMcdWriter',
+	#superclass : 'MCMczWriter',
+	#category : 'Monticello-Storing',
+	#package : 'Monticello',
+	#tag : 'Storing'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMcdWriter class >> readerClass [
 	^ MCMcdReader
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCMcdWriter >> writeBaseInfo: aVersionInfo [
 	| string |
 	string := self serializeVersionInfo: aVersionInfo.
@@ -20,23 +22,23 @@ MCMcdWriter >> writeBaseInfo: aVersionInfo [
 
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCMcdWriter >> writeDefinitions: aVersion [
 	self writeBaseInfo: aVersion baseInfo.
 	self writePatch: aVersion patch.
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCMcdWriter >> writeNewDefinitions: aCollection [
 	self addString: (self serializeDefinitions: aCollection) at: 'new/source.', self snapshotWriterClass extension encodedTo: 'utf8'.
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCMcdWriter >> writeOldDefinitions: aCollection [
 	self addString: (self serializeDefinitions: aCollection) at: 'old/source.', self snapshotWriterClass extension encodedTo: 'utf8'.
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCMcdWriter >> writePatch: aPatch [
 	| old new |
 	old := OrderedCollection new.

--- a/src/Monticello/MCMczReader.class.st
+++ b/src/Monticello/MCMczReader.class.st
@@ -2,39 +2,41 @@
 Reader for an MCZ format
 "
 Class {
-	#name : #MCMczReader,
-	#superclass : #MCVersionReader,
+	#name : 'MCMczReader',
+	#superclass : 'MCVersionReader',
 	#instVars : [
 		'zip',
 		'infoCache',
 		'filename'
 	],
-	#category : #'Monticello-Storing'
+	#category : 'Monticello-Storing',
+	#package : 'Monticello',
+	#tag : 'Storing'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMczReader class >> extension [
 	^ 'mcz'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMczReader class >> on: s fileName: f [
 	^ (self on: s)
 		filename: f;
 		yourself
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCMczReader class >> supportsDependencies [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCMczReader class >> supportsVersions [
 	^ true
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 MCMczReader >> associate: tokens [
 	| result |
 	result := Dictionary new.
@@ -47,7 +49,7 @@ MCMczReader >> associate: tokens [
 	^ result
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCMczReader >> contentStreamForMember: member [
 	^[(member contentStreamFromEncoding: 'utf8') text] on: ZnInvalidUTF8
 		do: [:exc | 
@@ -60,7 +62,7 @@ MCMczReader >> contentStreamForMember: member [
 			exc return: str]
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 MCMczReader >> contentsForMember: member [
 	^[(member contentStreamFromEncoding: 'utf8') contents] on: ZnInvalidUTF8
 		do: [:exc | 
@@ -73,7 +75,7 @@ MCMczReader >> contentsForMember: member [
 				ifFalse: [str contents])]
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 MCMczReader >> extractDefinitionsFrom: member [
 	| reader |
 	(MCSnapshotReader readerClassForFileNamed: member fileName)
@@ -83,34 +85,34 @@ MCMczReader >> extractDefinitionsFrom: member [
 
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 MCMczReader >> extractDependencyFrom: zipMember [
 	^ MCVersionDependency
 		package: (MCPackage named: (zipMember fileName copyAfterLast: $/))
 		info: (self extractInfoFrom: (self parseMember: zipMember))
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCMczReader >> extractInfoFrom: dict [
 	^MCWorkingCopy infoFromDictionary: dict cache: self infoCache
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMczReader >> filename [
 	^ filename
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMczReader >> filename: aString [
 	filename := aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMczReader >> infoCache [
 	^ infoCache ifNil: [infoCache := Dictionary new]
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MCMczReader >> loadDefinitions [
 	definitions := OrderedCollection new.
 	(self zip memberNamed: 'snapshot.bin') ifNotNil:
@@ -122,27 +124,27 @@ MCMczReader >> loadDefinitions [
 
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MCMczReader >> loadDependencies [
 	dependencies := (self zip membersMatching: 'dependencies/*') collect: [:m | self extractDependencyFrom: m].
 	dependencies := dependencies asArray.
 
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MCMczReader >> loadPackage [
 	| dict |
 	dict := self parseMember: 'package'.
 	package := MCPackage named: (dict at: #name)
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MCMczReader >> loadVersionInfo [
 
 	info := self extractInfoFrom: (self parseMember: 'version')
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 MCMczReader >> parseMember: memberOrName [
 	| member tokens |
 	member := self zip member: memberOrName.
@@ -150,12 +152,12 @@ MCMczReader >> parseMember: memberOrName [
 	^ self associate: tokens
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMczReader >> scanner [
 	^ MCScanner
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMczReader >> zip [
 	stream closed ifTrue: [
 		zip := nil].

--- a/src/Monticello/MCMczWriter.class.st
+++ b/src/Monticello/MCMczWriter.class.st
@@ -2,16 +2,18 @@
 Writing MCZ format
 "
 Class {
-	#name : #MCMczWriter,
-	#superclass : #MCWriter,
+	#name : 'MCMczWriter',
+	#superclass : 'MCWriter',
 	#instVars : [
 		'zip',
 		'infoWriter'
 	],
-	#category : #'Monticello-Storing'
+	#category : 'Monticello-Storing',
+	#package : 'Monticello',
+	#tag : 'Storing'
 }
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCMczWriter class >> fileOut: aVersion on: aStream [
 	| inst |
 	inst := self on: aStream.
@@ -21,12 +23,12 @@ MCMczWriter class >> fileOut: aVersion on: aStream [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMczWriter class >> readerClass [
 	^ MCMczReader
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCMczWriter >> addString: string at: path [
 	| member |
 	member := zip addString: string as: path.
@@ -34,7 +36,7 @@ MCMczWriter >> addString: string at: path [
 	
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCMczWriter >> addString: string at: path encodedTo: encodingName [
 	| member |
 	member := zip addString: (string encodeWith: encodingName) as: path.
@@ -42,24 +44,24 @@ MCMczWriter >> addString: string at: path encodedTo: encodingName [
 	
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCMczWriter >> flush [
 	zip writeTo: stream.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMczWriter >> format [
 	^ '1'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCMczWriter >> initialize [
 	super initialize.
 	zip := ZipArchive new.
 
 ]
 
-{ #category : #serializing }
+{ #category : 'serializing' }
 MCMczWriter >> serializeDefinitions: aCollection [
 	^String streamContents: [:aStream |
 		| writer |
@@ -67,7 +69,7 @@ MCMczWriter >> serializeDefinitions: aCollection [
 		writer writeDefinitions: aCollection]
 ]
 
-{ #category : #serializing }
+{ #category : 'serializing' }
 MCMczWriter >> serializeInBinary: aSnapshot [
 	
 	^ ByteArray streamContents: [ :str | | writer |
@@ -75,12 +77,12 @@ MCMczWriter >> serializeInBinary: aSnapshot [
 		writer nextPut: aSnapshot ]
 ]
 
-{ #category : #serializing }
+{ #category : 'serializing' }
 MCMczWriter >> serializePackage: aPackage [
 	^ '(name ''', aPackage name, ''')'
 ]
 
-{ #category : #serializing }
+{ #category : 'serializing' }
 MCMczWriter >> serializeVersionInfo: aVersionInfo [
 	infoWriter ifNil: [infoWriter := MCVersionInfoWriter new].
 	^ String streamContents: [:s |
@@ -88,34 +90,34 @@ MCMczWriter >> serializeVersionInfo: aVersionInfo [
 		infoWriter writeVersionInfo: aVersionInfo]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMczWriter >> snapshotWriterClass [
 	^ MCStWriter
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCMczWriter >> writeDefinitions: aVersion [
 	self writeSnapshot: aVersion snapshot
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCMczWriter >> writeFormat [
 "	self addString: self format at: 'format'."
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCMczWriter >> writePackage: aPackage [
 	self addString: (self serializePackage: aPackage) at: 'package' encodedTo: 'utf8'
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCMczWriter >> writeSnapshot: aSnapshot [
 
 	self addString: (self serializeDefinitions: aSnapshot definitions) at: 'snapshot/source.' , self snapshotWriterClass extension encodedTo: 'utf8'.
 	self addString: (self serializeInBinary: aSnapshot) at: 'snapshot.bin'
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCMczWriter >> writeVersion: aVersion [
 	self writeFormat.
 	self writePackage: aVersion package.
@@ -124,14 +126,14 @@ MCMczWriter >> writeVersion: aVersion [
 	aVersion dependencies do: [:ea | self writeVersionDependency: ea]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCMczWriter >> writeVersionDependency: aVersionDependency [
 	| string |
 	string := (self serializeVersionInfo: aVersionDependency versionInfo).
 	self addString: string at: 'dependencies/', aVersionDependency package name encodedTo: 'utf8'
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCMczWriter >> writeVersionInfo: aVersionInfo [
 	| string |
 	string := self serializeVersionInfo: aVersionInfo.
@@ -139,7 +141,7 @@ MCMczWriter >> writeVersionInfo: aVersionInfo [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMczWriter >> zip [
 	^ zip
 ]

--- a/src/Monticello/MCMergeOrLoadWarning.class.st
+++ b/src/Monticello/MCMergeOrLoadWarning.class.st
@@ -2,27 +2,29 @@
 A MCMergeOrLoadWarning is a simple warning used when amerge or a load action may override existing entities.
 "
 Class {
-	#name : #MCMergeOrLoadWarning,
-	#superclass : #Warning,
+	#name : 'MCMergeOrLoadWarning',
+	#superclass : 'Warning',
 	#instVars : [
 		'versions'
 	],
-	#category : #'Monticello-Loading'
+	#category : 'Monticello-Loading',
+	#package : 'Monticello',
+	#tag : 'Loading'
 }
 
-{ #category : #signalling }
+{ #category : 'signalling' }
 MCMergeOrLoadWarning class >> signalFor: aVersionCollection [
 	^ self new
 		versions: aVersionCollection;
 		signal
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCMergeOrLoadWarning >> cancel [
 	^ self resume: nil
 ]
 
-{ #category : #exceptionDescription }
+{ #category : 'exceptionDescription' }
 MCMergeOrLoadWarning >> defaultAction [
 	^ ( UIManager default
 		confirm: self messageText
@@ -32,17 +34,17 @@ MCMergeOrLoadWarning >> defaultAction [
 		default: nil ).
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCMergeOrLoadWarning >> load [
 	^ self resume: true
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCMergeOrLoadWarning >> merge [
 	^ self resume: false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMergeOrLoadWarning >> messageText [
 	| packageNames |
 	
@@ -59,12 +61,12 @@ MCMergeOrLoadWarning >> messageText [
 			nextPutAll: 'If you continue, you will lose these changes:']
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMergeOrLoadWarning >> versions [
 	^ versions
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMergeOrLoadWarning >> versions: aCollection [
 	versions := aCollection
 ]

--- a/src/Monticello/MCMergeRecord.class.st
+++ b/src/Monticello/MCMergeRecord.class.st
@@ -2,8 +2,8 @@
 A record for merging
 "
 Class {
-	#name : #MCMergeRecord,
-	#superclass : #Object,
+	#name : 'MCMergeRecord',
+	#superclass : 'Object',
 	#instVars : [
 		'version',
 		'packageSnapshot',
@@ -12,25 +12,27 @@ Class {
 		'imagePatch',
 		'mergePatch'
 	],
-	#category : #'Monticello-Versioning'
+	#category : 'Monticello-Versioning',
+	#package : 'Monticello',
+	#tag : 'Versioning'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCMergeRecord class >> version: aVersion [
 	^ self basicNew initializeWithVersion: aVersion
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMergeRecord >> ancestorInfo [
 	^ ancestorInfo ifNil: [ancestorInfo := version info commonAncestorWith: version workingCopy ancestry]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMergeRecord >> ancestorSnapshot [
 	^ ancestorSnapshot ifNil: [ancestorSnapshot := version workingCopy findSnapshotWithVersionInfo: self ancestorInfo]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCMergeRecord >> imageIsClean [
 	| ancestors |
 	ancestors := version workingCopy ancestors.
@@ -39,32 +41,32 @@ MCMergeRecord >> imageIsClean [
 				and: [self imagePatch isEmpty]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMergeRecord >> imagePatch [
 	^ imagePatch ifNil: [imagePatch := self packageSnapshot patchRelativeToBase: self ancestorSnapshot]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCMergeRecord >> initializeWithVersion: aVersion [
 	version := aVersion
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCMergeRecord >> isAncestorMerge [
 	^ version workingCopy ancestry hasAncestor: version info
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMergeRecord >> mergePatch [
 	^ mergePatch ifNil: [mergePatch := version snapshot patchRelativeToBase: self ancestorSnapshot]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMergeRecord >> packageSnapshot [
 	^ packageSnapshot ifNil: [packageSnapshot := version package snapshot]
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCMergeRecord >> updateWorkingCopy [
 	self isAncestorMerge ifFalse:
 		[self imageIsClean
@@ -72,7 +74,7 @@ MCMergeRecord >> updateWorkingCopy [
 			ifFalse: [version workingCopy merged: version]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMergeRecord >> version [
 	^ version
 ]

--- a/src/Monticello/MCMergeResolutionRequest.class.st
+++ b/src/Monticello/MCMergeResolutionRequest.class.st
@@ -2,15 +2,17 @@
 Notify to resolve conflicts by merging
 "
 Class {
-	#name : #MCMergeResolutionRequest,
-	#superclass : #Notification,
+	#name : 'MCMergeResolutionRequest',
+	#superclass : 'Notification',
 	#instVars : [
 		'merger'
 	],
-	#category : #'Monticello-Versioning'
+	#category : 'Monticello-Versioning',
+	#package : 'Monticello',
+	#tag : 'Versioning'
 }
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCMergeResolutionRequest >> autoMerge [
 	"If there are not conflicts, merge, otherwise delegate to the UI"
 	self hasConflicts
@@ -18,27 +20,27 @@ MCMergeResolutionRequest >> autoMerge [
 		ifFalse: [ self merge ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCMergeResolutionRequest >> hasConflicts [
 	^ self merger hasConflicts
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCMergeResolutionRequest >> merge [
 	self resume: true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMergeResolutionRequest >> merger [
 	^ merger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMergeResolutionRequest >> merger: aMerger [
 	merger := aMerger
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCMergeResolutionRequest >> resolve [
 	self pass
 ]

--- a/src/Monticello/MCMerger.class.st
+++ b/src/Monticello/MCMerger.class.st
@@ -2,39 +2,41 @@
 A MCMerger is an abstract responsible for performing merge operations and detecting conflicts.
 "
 Class {
-	#name : #MCMerger,
-	#superclass : #Object,
-	#category : #'Monticello-Merging'
+	#name : 'MCMerger',
+	#superclass : 'Object',
+	#category : 'Monticello-Merging',
+	#package : 'Monticello',
+	#tag : 'Merging'
 }
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCMerger >> addConflictWithOperation: anOperation [
 	self operations add: anOperation beConflict
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCMerger >> applyTo: anObject [
 	self isMerged ifFalse: [self error: 'You must resolve all the conflicts first'].
 	self operations do: [:ea | ea applyTo: anObject]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMerger >> conflicts [	
 	^ self operations select: #isConflict
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCMerger >> hasConflicts [
 	^ self conflicts notEmpty
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCMerger >> isMerged [
 	^ self conflicts allSatisfy: [:ea | ea isResolved]
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCMerger >> load [
 	| loader |
 	loader := MCPackageLoader new.
@@ -43,7 +45,7 @@ MCMerger >> load [
 	loader load
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCMerger >> loadWithNameLike: baseName [
 	| loader |
 	loader := MCPackageLoader new.
@@ -52,17 +54,17 @@ MCMerger >> loadWithNameLike: baseName [
 	loader loadWithNameLike: baseName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMerger >> mergedSnapshot [
 	^ MCPatcher apply: self to: self baseSnapshot
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMerger >> operations [
 	^ #()
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMerger >> provisions [
 	^ #()
 ]

--- a/src/Monticello/MCMethodDefinition.class.st
+++ b/src/Monticello/MCMethodDefinition.class.st
@@ -13,8 +13,8 @@ Instance Variables
 
 "
 Class {
-	#name : #MCMethodDefinition,
-	#superclass : #MCDefinition,
+	#name : 'MCMethodDefinition',
+	#superclass : 'MCDefinition',
 	#instVars : [
 		'classIsMeta',
 		'source',
@@ -28,16 +28,18 @@ Class {
 		'Definitions',
 		'InitializersEnabled'
 	],
-	#category : #'Monticello-Modeling'
+	#category : 'Monticello-Modeling',
+	#package : 'Monticello',
+	#tag : 'Modeling'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCMethodDefinition class >> cachedDefinitions [
 	^ Definitions 
 		ifNil: [ Definitions := WeakIdentityKeyDictionary new ]
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCMethodDefinition class >> className: classString classIsMeta: metaBoolean selector: selectorString category: catString timeStamp: timeString source: sourceString [
 	^ self new
 		initializeWithClassName: classString
@@ -48,7 +50,7 @@ MCMethodDefinition class >> className: classString classIsMeta: metaBoolean sele
 		source: sourceString
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCMethodDefinition class >> className: classString
 selector: selectorString
 category: catString
@@ -62,56 +64,56 @@ source: sourceString [
 			source: sourceString
 ]
 
-{ #category : #cleanup }
+{ #category : 'cleanup' }
 MCMethodDefinition class >> cleanUp [
 	"Flush caches"
 
 	self shutDown.
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCMethodDefinition class >> flushMethodCache [
 	"We do not named this method flushCache because it would override an important class methods."
 	Definitions := nil.
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 MCMethodDefinition class >> initialize [
 
 	SessionManager default registerSystemClassNamed: self name
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 MCMethodDefinition class >> initializersEnabled [
 
 	^ InitializersEnabled ifNil: [true]
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 MCMethodDefinition class >> initializersEnabled: aBoolean [
 
 	InitializersEnabled := aBoolean
 ]
 
-{ #category : #'system startup' }
+{ #category : 'system startup' }
 MCMethodDefinition class >> shutDown [
 	"Free up all cached monticello method definitions"
 	self flushMethodCache 
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCMethodDefinition >> = aDefinition [
 	^ super = aDefinition
 		and: [ aDefinition category = self category
 		and: [ aDefinition source withInternalLineEndings = self source withInternalLineEndings ] ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCMethodDefinition >> accept: aVisitor [
 	^ aVisitor visitMethodDefinition: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMethodDefinition >> actualClass [
 	^ Smalltalk globals
 		at: className
@@ -121,7 +123,7 @@ MCMethodDefinition >> actualClass [
 				ifFalse: [ class ] ]
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCMethodDefinition >> addMethodAdditionTo: aCollection [
 	| methodAddition |
 	methodAddition := MethodAddition new
@@ -136,23 +138,23 @@ MCMethodDefinition >> addMethodAdditionTo: aCollection [
 
 ]
 
-{ #category : #'accessing - backward' }
+{ #category : 'accessing - backward' }
 MCMethodDefinition >> category [
 	"Please favor protocol instead of category. We want to have method protocol and class package and tag = a category"
 	^ category
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMethodDefinition >> classIsMeta [
 	^ classIsMeta
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMethodDefinition >> className [
 	^className
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCMethodDefinition >> description [
 	^ Array	
 		with: className
@@ -160,13 +162,13 @@ MCMethodDefinition >> description [
 		with: classIsMeta
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMethodDefinition >> diffSource [
 	^'"protocol: ', self protocol,'"
 ', self source.
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCMethodDefinition >> fullClassName [
 	"Using #class selector for classes for backwards compatibility"
 
@@ -178,12 +180,12 @@ MCMethodDefinition >> fullClassName [
 				ifTrue: [self className, ' classSide']]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMethodDefinition >> fullTimeStamp [
 	^ DateAndTime fromMethodTimeStamp: timeStamp
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCMethodDefinition >> hash [
 	| hash |
 	hash := String stringHash: classIsMeta asString initialHash: 0.
@@ -193,7 +195,7 @@ MCMethodDefinition >> hash [
 	^ hash
 ]
 
-{ #category : #serializing }
+{ #category : 'serializing' }
 MCMethodDefinition >> initializeWithClassName: classString classIsMeta: metaBoolean selector: selectorString category: protocolName timeStamp: timeString source: sourceString [
 
 	className := classString asSymbol.
@@ -204,17 +206,17 @@ MCMethodDefinition >> initializeWithClassName: classString classIsMeta: metaBool
 	source := sourceString withInternalLineEndings
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCMethodDefinition >> isCodeDefinition [
 	^ true
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCMethodDefinition >> isExtensionMethod [
 	^ category beginsWith: '*'
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCMethodDefinition >> isExternalStructureFieldDefinition [
 	"Really belongs in the FFI package, for now, include in base even if FFI is not loaded due to the dire consequences if its not here and an FFI package is loaded (incorrect field compilation can cause VM crashes).
 	
@@ -227,29 +229,29 @@ MCMethodDefinition >> isExternalStructureFieldDefinition [
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCMethodDefinition >> isInitializer [
 	^ selector = #initialize and: [classIsMeta]
 	
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCMethodDefinition >> isLoadable [
 	^self actualClass notNil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCMethodDefinition >> isMethodDefinition [
 	^true
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCMethodDefinition >> isOverrideMethod [
 	"this oughta check the package"
 	^ self isExtensionMethod and: [category endsWith: '-override']
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCMethodDefinition >> load [
 	| sel |
 	sel := (self actualClass compiler
@@ -264,7 +266,7 @@ MCMethodDefinition >> load [
 	selector := sel
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCMethodDefinition >> overridenMethodOrNil [
 	"Answer the method that I've overriden on load. 
 
@@ -282,7 +284,7 @@ MCMethodDefinition >> overridenMethodOrNil [
 		detect: [ :protocol | protocol ~= category ]
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCMethodDefinition >> postloadOver: aDefinition [
 	super postloadOver: aDefinition.
 	self class initializersEnabled ifTrue: [
@@ -295,7 +297,7 @@ MCMethodDefinition >> postloadOver: aDefinition [
 		ifTrue: [self actualClass instanceSide compileFields].
 ]
 
-{ #category : #annotations }
+{ #category : 'annotations' }
 MCMethodDefinition >> printAnnotations: requests on: aStream [
 	"Add a string for an annotation pane, trying to fulfill the browser annotationRequests."
 	
@@ -308,13 +310,13 @@ MCMethodDefinition >> printAnnotations: requests on: aStream [
 	] separatedBy: [ aStream space ].
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMethodDefinition >> protocol [
 	"Return in which protocol (conceptual groups of methods) the receiver is grouped into."
 	^ category
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCMethodDefinition >> removeSelector: aSelector fromClass: aClass [
 	"Safely remove the given selector from the target class.
 	Be careful not to remove the selector when it has wandered
@@ -331,23 +333,23 @@ MCMethodDefinition >> removeSelector: aSelector fromClass: aClass [
 		removeProtocolIfEmpty: category
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCMethodDefinition >> requirements [
 	^ { className }
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMethodDefinition >> selector [
 	^selector
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCMethodDefinition >> shortSummaryPrefix [
 
 	^ self definition selector asString
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCMethodDefinition >> sortKey [
 	^ sortKey
 		ifNil: [ sortKey := self className , '.'
@@ -357,23 +359,23 @@ MCMethodDefinition >> sortKey [
 						ifFalse: [ 'nonmeta' ]) , '.' , self selector ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMethodDefinition >> source [
 	^ source
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCMethodDefinition >> summary [
 
 	^ className asString , '>>' , selector printString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMethodDefinition >> timeStamp [
 	^ timeStamp
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCMethodDefinition >> unload [
 	"Unload me. If I represent an override method, then restore the overriden version. If not, just remove the selector from the class."
 

--- a/src/Monticello/MCMock.class.st
+++ b/src/Monticello/MCMock.class.st
@@ -2,12 +2,14 @@
 Common superclass for mocks
 "
 Class {
-	#name : #MCMock,
-	#superclass : #Object,
-	#category : #'Monticello-Mocks'
+	#name : 'MCMock',
+	#superclass : 'Object',
+	#category : 'Monticello-Mocks',
+	#package : 'Monticello',
+	#tag : 'Mocks'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 MCMock class >> wantsChangeSetLogging [
 	^ false
 ]

--- a/src/Monticello/MCMockAPoolDictionary.class.st
+++ b/src/Monticello/MCMockAPoolDictionary.class.st
@@ -2,7 +2,9 @@
 Mocking a pool
 "
 Class {
-	#name : #MCMockAPoolDictionary,
-	#superclass : #SharedPool,
-	#category : #'Monticello-Mocks'
+	#name : 'MCMockAPoolDictionary',
+	#superclass : 'SharedPool',
+	#category : 'Monticello-Mocks',
+	#package : 'Monticello',
+	#tag : 'Mocks'
 }

--- a/src/Monticello/MCMockDefinition.class.st
+++ b/src/Monticello/MCMockDefinition.class.st
@@ -2,26 +2,28 @@
 A mock definition used for testing purposes
 "
 Class {
-	#name : #MCMockDefinition,
-	#superclass : #MCDefinition,
+	#name : 'MCMockDefinition',
+	#superclass : 'MCDefinition',
 	#instVars : [
 		'token'
 	],
-	#category : #'Monticello-Mocks'
+	#category : 'Monticello-Mocks',
+	#package : 'Monticello',
+	#tag : 'Mocks'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMockDefinition class >> token: aString [
 
 	^ self new token: aString
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 MCMockDefinition class >> wantsChangeSetLogging [
 	^ false
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCMockDefinition >> = definition [
 	self == definition
 		ifTrue: [ ^ true ].
@@ -30,43 +32,43 @@ MCMockDefinition >> = definition [
 	^definition token = token
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 MCMockDefinition >> asString [
 
 	^ token
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCMockDefinition >> description [
 
 	^ token first
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCMockDefinition >> hash [
 
 	^ token hash
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCMockDefinition >> printString [
 
 	^ token
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCMockDefinition >> summary [
 
 	^ token
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMockDefinition >> token [
 
 	^ token
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMockDefinition >> token: aString [
 
 	token := aString

--- a/src/Monticello/MCMockDependentItem.class.st
+++ b/src/Monticello/MCMockDependentItem.class.st
@@ -2,52 +2,54 @@
 Mock for dependency testing
 "
 Class {
-	#name : #MCMockDependentItem,
-	#superclass : #MCMock,
+	#name : 'MCMockDependentItem',
+	#superclass : 'MCMock',
 	#instVars : [
 		'name',
 		'provides',
 		'requires'
 	],
-	#category : #'Monticello-Mocks'
+	#category : 'Monticello-Mocks',
+	#package : 'Monticello',
+	#tag : 'Mocks'
 }
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCMockDependentItem >> <= other [
 	^ self name <= other name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMockDependentItem >> name [
 
 	^ name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMockDependentItem >> name: aString [
 
 	name := aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMockDependentItem >> provides: anArray [
 
 	provides := anArray
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMockDependentItem >> provisions [
 
 	^ provides ifNil: [#()]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCMockDependentItem >> requirements [
 
 	^ requires ifNil: [#()]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCMockDependentItem >> requires: anArray [
 
 	requires := anArray

--- a/src/Monticello/MCModification.class.st
+++ b/src/Monticello/MCModification.class.st
@@ -2,72 +2,74 @@
 A MCModification represents the operation to modify an entity to a snapshot. 
 "
 Class {
-	#name : #MCModification,
-	#superclass : #MCPatchOperation,
+	#name : 'MCModification',
+	#superclass : 'MCPatchOperation',
 	#instVars : [
 		'obsoletion',
 		'modification'
 	],
-	#category : #'Monticello-Patching'
+	#category : 'Monticello-Patching',
+	#package : 'Monticello',
+	#tag : 'Patching'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCModification class >> of: base to: target [
 	^ self new initializeWithBase: base target: target
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCModification >> baseDefinition [
 	^ obsoletion
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCModification >> basicApplyTo: anObject [
 	anObject modifyDefinition: obsoletion to: modification
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCModification >> definition [
 	^ modification
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCModification >> fromSource [
 	^ obsoletion source
 ]
 
-{ #category : #initializing }
+{ #category : 'initializing' }
 MCModification >> initializeWithBase: base target: target [
 	obsoletion := base.
 	modification := target.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCModification >> inverse [
 	^ MCModification of: modification to: obsoletion
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCModification >> isClassPatch [
 	^obsoletion isClassDefinition
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCModification >> isModification [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCModification >> modification [
 	^ modification
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCModification >> obsoletion [
 	^ obsoletion
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCModification >> printAnnotations: request on: aStream [
 	aStream nextPutAll: 'old: '.
 	obsoletion printAnnotations: request on: aStream.
@@ -76,13 +78,13 @@ MCModification >> printAnnotations: request on: aStream [
 	modification printAnnotations: request on: aStream.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCModification >> summarySuffix [
 	^ modification summarySuffixOver: obsoletion
 
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCModification >> summarySuffixOver: previousDefinition [
 	| sourceChanged categoryChanged timeStampChanged |
 	sourceChanged := self source ~= previousDefinition source.
@@ -102,17 +104,17 @@ MCModification >> summarySuffixOver: previousDefinition [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCModification >> targetClass [
 	^ obsoletion actualClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCModification >> targetDefinition [
 	^ modification
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCModification >> toSource [
 	^ modification diffSource
 ]

--- a/src/Monticello/MCMultiPackageLoader.class.st
+++ b/src/Monticello/MCMultiPackageLoader.class.st
@@ -2,12 +2,14 @@
 A PackageLoader doing some additional cross-package checks
 "
 Class {
-	#name : #MCMultiPackageLoader,
-	#superclass : #MCPackageLoader,
-	#category : #'Monticello-Loading'
+	#name : 'MCMultiPackageLoader',
+	#superclass : 'MCPackageLoader',
+	#category : 'Monticello-Loading',
+	#package : 'Monticello',
+	#tag : 'Loading'
 }
 
-{ #category : #private }
+{ #category : 'private' }
 MCMultiPackageLoader >> analyze [
 	| index |
 	index := MCDefinitionIndex definitions: additions.

--- a/src/Monticello/MCNoChangesException.class.st
+++ b/src/Monticello/MCNoChangesException.class.st
@@ -2,12 +2,14 @@
 Notify that no changes have to be merged
 "
 Class {
-	#name : #MCNoChangesException,
-	#superclass : #Exception,
-	#category : #'Monticello-Versioning'
+	#name : 'MCNoChangesException',
+	#superclass : 'Exception',
+	#category : 'Monticello-Versioning',
+	#package : 'Monticello',
+	#tag : 'Versioning'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCNoChangesException >> defaultAction [
 	self inform: 'No changes'
 ]

--- a/src/Monticello/MCOrganizationDefinition.class.st
+++ b/src/Monticello/MCOrganizationDefinition.class.st
@@ -5,7 +5,6 @@ Class {
 	#name : 'MCOrganizationDefinition',
 	#superclass : 'MCDefinition',
 	#instVars : [
-		'categories',
 		'packageName',
 		'tagNames'
 	],

--- a/src/Monticello/MCOrganizationDefinition.class.st
+++ b/src/Monticello/MCOrganizationDefinition.class.st
@@ -2,22 +2,19 @@
 A MCOrganizationDefinition represents a category change. 
 "
 Class {
-	#name : #MCOrganizationDefinition,
-	#superclass : #MCDefinition,
+	#name : 'MCOrganizationDefinition',
+	#superclass : 'MCDefinition',
 	#instVars : [
 		'categories',
 		'packageName',
 		'tagNames'
 	],
-	#category : #'Monticello-Modeling'
+	#category : 'Monticello-Modeling',
+	#package : 'Monticello',
+	#tag : 'Modeling'
 }
 
-{ #category : #'instance creation' }
-MCOrganizationDefinition class >> categories: aCollection [
-	^ self new categories: aCollection
-]
-
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCOrganizationDefinition class >> packageName: aPackageName [
 
 	^ self new
@@ -25,7 +22,7 @@ MCOrganizationDefinition class >> packageName: aPackageName [
 		  yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCOrganizationDefinition class >> packageName: aPackageName tagNames: aCollection [
 
 	^ (self packageName: aPackageName)
@@ -33,162 +30,123 @@ MCOrganizationDefinition class >> packageName: aPackageName tagNames: aCollectio
 		  yourself
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCOrganizationDefinition >> = aDefinition [
 
-	^ (super = aDefinition)
-		and: [ self categories size = aDefinition categories size and: [ self categories includesAll: aDefinition categories ] ].
+	^ super = aDefinition and: [ packageName = aDefinition packageName and: [ tagNames = aDefinition tagNames ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCOrganizationDefinition >> accept: aVisitor [
 	^ aVisitor visitOrganizationDefinition: self
 ]
 
-{ #category : #private }
-MCOrganizationDefinition >> basicCommonPrefix [
-	"Answers the minimum common denominator on package names contained in the monticello package. 
-	 It can answer a package in the form X-Y-, with a minus at end..."
-	| stream  |
-	self categories ifEmpty: [ ^ '' ].
-	
-	stream := String new writeStream.
-	self categories first withIndexDo: [:c :index |
-		self categories do: [:each |
-			(each at: index ifAbsent: []) = c 
-				ifFalse: [ ^ stream contents ] ].
-		stream nextPut: c ].
-	
-	^stream contents
-]
-
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCOrganizationDefinition >> categories [
 
-	^ categories ifNil: [
-		  self packageName
-			  ifNil: [ {  } ]
-			  ifNotNil: [ :package |
-				  { package } , (self tagNames
-					   reject: [ :tagName | tagName = package ]
-					   thenCollect: [ :tagName | package , '-' , tagName ]) ] ]
+	^ self packageName
+		  ifNil: [ {  } ]
+		  ifNotNil: [ :package |
+			  { package } , (self tagNames
+				   reject: [ :tagName | tagName = package ]
+				   thenCollect: [ :tagName | package , '-' , tagName ]) ]
 ]
 
-{ #category : #deprecated }
-MCOrganizationDefinition >> categories: aCollection [
-	"Do not use. This methods should be replaced by #packageName and #tagNames"
-
-	categories := aCollection sorted asArray
-]
-
-{ #category : #accessing }
-MCOrganizationDefinition >> commonPrefix [
-	"Answer the package common name. 
-	 In ancient times, this was answering X-Y-, with a minus at the end... this was useful for the 
-	 old PackageInfo framework. RPackage does not do pattern matching, thus this is not needed anymore 
-	 (and provoques an error)"
-	| prefix |
-	prefix := self basicCommonPrefix.
-	^(prefix notEmpty and: [ prefix endsWith: '-' ])
-		ifTrue: [ prefix allButLast ]
-		ifFalse: [ prefix ].
-	
-
-]
-
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCOrganizationDefinition >> description [
 	^ Array with: #organization with: self fullDescription
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCOrganizationDefinition >> fullDescription [
-	self categories ifEmpty: [ ^ self commonPrefix ].
-	^ String
-		streamContents: [ :stream | 
-			| first |
-			first := self categories first.
-			stream << first.
-			self categories allButFirst
-				do: [ :c | 
-					| part |
-					part := c withoutPrefix: first.
-					stream << $| << part ] ]
+
+	self tagNames ifEmpty: [ ^ self packageName ].
+
+	^ String streamContents: [ :stream |
+		  | first |
+		  first := self categories first.
+		  stream << first.
+		  self categories allButFirst do: [ :c |
+			  | part |
+			  part := c withoutPrefix: first.
+			  stream << $| << part ] ]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCOrganizationDefinition >> hash [
-	^ (self species hash 
-		bitXor: super hash)
-		bitXor: self categories hash
+
+	^ ((self species hash bitXor: super hash) bitXor: self packageName hash) bitXor: self tagNames hash
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCOrganizationDefinition >> initialize [
 	super initialize.
 	tagNames := #()
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCOrganizationDefinition >> isOrganizationDefinition [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCOrganizationDefinition >> packageName [
 
 	^ packageName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCOrganizationDefinition >> packageName: anObject [
 
 	packageName := anObject
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCOrganizationDefinition >> postloadOver: oldDefinition [
 	"Nothing to do"
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCOrganizationDefinition >> shortSummaryPrefix [
 
 	^ self definition description last
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCOrganizationDefinition >> sortKey [
 	^ '<organization>'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCOrganizationDefinition >> source [
 
 	^ String streamContents: [ :s | self categories do: [ :ea | s nextPutAll: ea ] separatedBy: [ s cr ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCOrganizationDefinition >> summary [
 
 	^ self categories asArray printString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCOrganizationDefinition >> tagNames [
 
 	^ tagNames
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCOrganizationDefinition >> tagNames: aCollection [
 	"ensure the tags are sorted alphabetically, so the merge don't take it as a conflict"
 
 	tagNames := aCollection sorted asArray
 ]
 
-{ #category : #unloading }
+{ #category : 'unloading' }
 MCOrganizationDefinition >> unload [
 
-	self categories do: [ :category | (self packageOrganizer isEmptyCategoryNamed: category) ifTrue: [ self packageOrganizer removeCategory: category ] ]
+	| package |
+	package := self packageOrganizer packageNamed: self packageName ifAbsent: [ ^ self ].
+	package removeEmptyTags.
+	package isEmpty ifTrue: [ package removeFromSystem ]
 ]

--- a/src/Monticello/MCOrganizationDefinition.class.st
+++ b/src/Monticello/MCOrganizationDefinition.class.st
@@ -45,10 +45,7 @@ MCOrganizationDefinition >> categories [
 
 	^ self packageName
 		  ifNil: [ {  } ]
-		  ifNotNil: [ :package |
-			  { package } , (self tagNames
-				   reject: [ :tagName | tagName = package ]
-				   thenCollect: [ :tagName | package , '-' , tagName ]) ]
+		  ifNotNil: [ :package | { package } , (self tagNames collect: [ :tagName | package , '-' , tagName ]) ]
 ]
 
 { #category : 'accessing' }
@@ -138,7 +135,10 @@ MCOrganizationDefinition >> tagNames [
 MCOrganizationDefinition >> tagNames: aCollection [
 	"ensure the tags are sorted alphabetically, so the merge don't take it as a conflict"
 
-	tagNames := aCollection sorted asArray
+	| tags |
+	tags := aCollection.
+	tags remove: self packageName ifAbsent: [ "do nothing here" ].
+	tagNames := tags sorted asArray
 ]
 
 { #category : 'unloading' }

--- a/src/Monticello/MCOrganizationDefinition.class.st
+++ b/src/Monticello/MCOrganizationDefinition.class.st
@@ -60,7 +60,7 @@ MCOrganizationDefinition >> description [
 { #category : 'private' }
 MCOrganizationDefinition >> fullDescription [
 
-	self tagNames ifEmpty: [ ^ self packageName ].
+	self tagNames ifNil: [ ^ self packageName ].
 
 	^ String streamContents: [ :stream |
 		  | first |

--- a/src/Monticello/MCOrganizationDefinition.class.st
+++ b/src/Monticello/MCOrganizationDefinition.class.st
@@ -137,7 +137,7 @@ MCOrganizationDefinition >> tagNames: aCollection [
 
 	| tags |
 	tags := aCollection.
-	tags remove: self packageName ifAbsent: [ "do nothing here" ].
+	tags := tags \ { self packageName }.
 	tagNames := tags sorted asArray
 ]
 

--- a/src/Monticello/MCOrganizationParser.class.st
+++ b/src/Monticello/MCOrganizationParser.class.st
@@ -1,0 +1,33 @@
+"
+A MCSystemCategoryParser extracts or set a category/protocol to the corresponding MCOrganizationDefinition with the new definition
+"
+Class {
+	#name : 'MCOrganizationParser',
+	#superclass : 'MCSystemCategoryParser',
+	#category : 'Monticello-Chunk Format',
+	#package : 'Monticello',
+	#tag : 'Chunk Format'
+}
+
+{ #category : 'factory identification hook' }
+MCOrganizationParser class >> pattern [
+	^ '*ensurePackage:*'
+]
+
+{ #category : 'actions' }
+MCOrganizationParser >> addDefinitionsTo: aCollection [
+
+	| definition tokens packageName tags |
+	definition := aCollection
+		              detect: [ :ea | ea isOrganizationDefinition ]
+		              ifNone: [ aCollection add: MCOrganizationDefinition new ].
+
+	tokens := source parseLiterals.
+
+	packageName := (tokens at: 7) at: 4.
+	tags := tokens at: 1.
+
+	definition
+		packageName: packageName;
+		tagNames: tags
+]

--- a/src/Monticello/MCOrganizationParser.class.st
+++ b/src/Monticello/MCOrganizationParser.class.st
@@ -24,8 +24,8 @@ MCOrganizationParser >> addDefinitionsTo: aCollection [
 
 	tokens := source parseLiterals.
 
-	packageName := (tokens at: 7) at: 4.
-	tags := tokens at: 1.
+	packageName := tokens at: 4.
+	tags := tokens at: 6.
 
 	definition
 		packageName: packageName;

--- a/src/Monticello/MCPackage.class.st
+++ b/src/Monticello/MCPackage.class.st
@@ -6,61 +6,63 @@ Strangely enough it does not inherit from MCDefinition.
 Its most important method is snapshot which returns a snapshot with all the entities that should be saved. 
 "
 Class {
-	#name : #MCPackage,
-	#superclass : #Object,
+	#name : 'MCPackage',
+	#superclass : 'Object',
 	#instVars : [
 		'name',
 		'environment'
 	],
-	#category : #'Monticello-Base'
+	#category : 'Monticello-Base',
+	#package : 'Monticello',
+	#tag : 'Base'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCPackage class >> named: aString [
 	^ self new name: aString
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCPackage >> = other [
 	^ other species = self species and: [other name = name]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPackage >> correspondingRPackage [
 	"Use #systemPackage instead"
 
 	^ self systemPackage
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCPackage >> displayStringOn: aStream [
 	aStream nextPutAll: self name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPackage >> environment [
 	"Allows to have MCPackage that are link to system packages from a non default package organizer."
 
 	^ environment ifNil: [ self class environment ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPackage >> environment: anObject [
 
 	environment := anObject
 ]
 
-{ #category : #'working copies' }
+{ #category : 'working copies' }
 MCPackage >> hasWorkingCopy [
 	^ MCWorkingCopy registry includesKey: self
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCPackage >> hash [
 	^ name asLowercase hash
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCPackage >> isDirty [
 	
 	^ self workingCopy
@@ -68,22 +70,22 @@ MCPackage >> isDirty [
 		ifNotNil: [ :wc | wc modified ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPackage >> name [
 	^ name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPackage >> name: aString [
 	name := aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPackage >> packageSet [
 	^ RPackageSet named: name
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCPackage >> printOn: aStream [
 	super printOn: aStream.
 	aStream
@@ -92,7 +94,7 @@ MCPackage >> printOn: aStream [
 		nextPut: $)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPackage >> snapshot [
 
 	^ MCSnapshot fromDefinitions: (self systemPackage
@@ -105,26 +107,26 @@ MCPackage >> snapshot [
 					   yourself ])
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCPackage >> storeOn: aStream [
 	aStream
 		nextPutAll: 'MCPackage';
 		space; nextPutAll: 'named: '; store: name.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPackage >> systemPackage [
 	"Return the corresponding system package. Return nil if no package in the system has this name."
 
 	^ self environment organization packageNamed: self name ifAbsent: [ nil ]
 ]
 
-{ #category : #'working copies' }
+{ #category : 'working copies' }
 MCPackage >> unload [
 	^ self workingCopy unload
 ]
 
-{ #category : #'working copies' }
+{ #category : 'working copies' }
 MCPackage >> workingCopy [
 
 	^ MCWorkingCopy ensureForPackage: self

--- a/src/Monticello/MCPackageCache.class.st
+++ b/src/Monticello/MCPackageCache.class.st
@@ -2,29 +2,31 @@
 I'm a kind of cache for versions and filenames of packages.
 "
 Class {
-	#name : #MCPackageCache,
-	#superclass : #Object,
+	#name : 'MCPackageCache',
+	#superclass : 'Object',
 	#instVars : [
 		'sorter',
 		'fileNames'
 	],
-	#category : #'Monticello-Repositories'
+	#category : 'Monticello-Repositories',
+	#package : 'Monticello',
+	#tag : 'Repositories'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCPackageCache >> initialize [
 	super initialize.
 	sorter := MCVersionSorter new.
 	fileNames := Dictionary new.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPackageCache >> recordVersionInfo: aVersionInfo forFileNamed: aString [
 	fileNames at: aVersionInfo put: aString.
 	sorter addVersionInfo: aVersionInfo
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPackageCache >> versionInfos [
 	^ sorter sortedVersionInfos 
 ]

--- a/src/Monticello/MCPackageLoader.class.st
+++ b/src/Monticello/MCPackageLoader.class.st
@@ -13,8 +13,8 @@ Instance Variables
 
 "
 Class {
-	#name : #MCPackageLoader,
-	#superclass : #Object,
+	#name : 'MCPackageLoader',
+	#superclass : 'Object',
 	#instVars : [
 		'requirements',
 		'unloadableDefinitions',
@@ -25,36 +25,38 @@ Class {
 		'provisions',
 		'methodAdditions'
 	],
-	#category : #'Monticello-Loading'
+	#category : 'Monticello-Loading',
+	#package : 'Monticello',
+	#tag : 'Loading'
 }
 
-{ #category : #public }
+{ #category : 'public' }
 MCPackageLoader class >> installSnapshot: aSnapshot [
 	self new
 		installSnapshot: aSnapshot;
 		load
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MCPackageLoader class >> unloadPackage: aPackage [
 	self new
 		unloadPackage: aPackage;
 		loadWithNameLike: aPackage name, '-unload'
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MCPackageLoader class >> updatePackage: aPackage withSnapshot: aSnapshot [
 	self new
 		updatePackage: aPackage withSnapshot: aSnapshot;
 		load
 ]
 
-{ #category : #'patch ops' }
+{ #category : 'patch ops' }
 MCPackageLoader >> addDefinition: aDefinition [
 	additions add: aDefinition
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCPackageLoader >> analyze [
 	| sorter |
 	sorter := self sorterForItems: additions.
@@ -66,13 +68,13 @@ MCPackageLoader >> analyze [
 	removals := sorter orderedItems reversed.
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCPackageLoader >> basicLoad [
     errorDefinitions := OrderedCollection new.
     SourceFiles deferFlushDuring: [self basicLoadDefinitions].
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCPackageLoader >> basicLoadDefinitions [
 
 	"FIXME. Do a separate pass on loading class definitions as the very first thing.
@@ -98,7 +100,7 @@ MCPackageLoader >> basicLoadDefinitions [
 	
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCPackageLoader >> dependencyWarning [
 	| packageName |
 	
@@ -117,7 +119,7 @@ MCPackageLoader >> dependencyWarning [
 		unloadableDefinitions do: [:ea | stream space; space; nextPutAll: ea summary; cr]] 
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCPackageLoader >> errorDefinitionWarning [
 	^ String streamContents:
 		[:s |
@@ -125,7 +127,7 @@ MCPackageLoader >> errorDefinitionWarning [
 		errorDefinitions do: [:ea | s space; space; nextPutAll: ea summary; cr]] 
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCPackageLoader >> initialize [
 	super initialize.
 	additions := OrderedCollection new.
@@ -135,7 +137,7 @@ MCPackageLoader >> initialize [
 
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MCPackageLoader >> installSnapshot: aSnapshot [
 	| patch |
 	patch := aSnapshot patchRelativeToBase: MCSnapshot empty.
@@ -143,14 +145,14 @@ MCPackageLoader >> installSnapshot: aSnapshot [
 
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MCPackageLoader >> load [
 
 	self validate.
 	self useNewChangeSetDuring: [ self basicLoad ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCPackageLoader >> loadClassDefinition: aDefinition [
 
 	[ aDefinition isClassDefinition 
@@ -159,55 +161,55 @@ MCPackageLoader >> loadClassDefinition: aDefinition [
 		errorDefinitions add: aDefinition ].
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MCPackageLoader >> loadWithName: baseName [
 	self validate.
 	self useChangeSetNamed: baseName during: [self basicLoad]
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MCPackageLoader >> loadWithNameLike: baseName [
 	self validate.
 	self useNewChangeSetNamedLike: baseName during: [self basicLoad]
 ]
 
-{ #category : #'patch ops' }
+{ #category : 'patch ops' }
 MCPackageLoader >> modifyDefinition: old to: new [
 	self addDefinition: new.
 	obsoletions at: new put: old.
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCPackageLoader >> obsoletionFor: aDefinition [
 	^ obsoletions at: aDefinition ifAbsent: [nil]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCPackageLoader >> orderDefinitionsForLoading: aCollection [
 	^ (self sorterForItems: aCollection) orderedItems
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCPackageLoader >> orderedAdditions [
 	^ additions
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCPackageLoader >> provisions [
 	^ provisions ifNil: [provisions := Set withAll: Smalltalk globals keys]
 ]
 
-{ #category : #'patch ops' }
+{ #category : 'patch ops' }
 MCPackageLoader >> removeDefinition: aDefinition [
 	removals add: aDefinition
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCPackageLoader >> shouldWarnAboutErrors [
 	^ errorDefinitions isEmpty not and: [false "should make this a setting ?"]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCPackageLoader >> sorterForItems: aCollection [
 	| sorter |
 	sorter := MCDependencySorter items: aCollection.
@@ -215,7 +217,7 @@ MCPackageLoader >> sorterForItems: aCollection [
 	^ sorter
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCPackageLoader >> tryToLoad: aDefinition [
 	"Here we are only interested by method definition. We want to avoid recompilating classes or traits for example."
 
@@ -226,13 +228,13 @@ MCPackageLoader >> tryToLoad: aDefinition [
 		do: [ errorDefinitions add: aDefinition ]
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MCPackageLoader >> unloadPackage: aPackage [
 
 	self updatePackage: aPackage withSnapshot: MCSnapshot empty
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 MCPackageLoader >> updatePackage: aPackage withSnapshot: aSnapshot [
 	|  patch packageSnap |
 	packageSnap := aPackage snapshot.
@@ -242,7 +244,7 @@ MCPackageLoader >> updatePackage: aPackage withSnapshot: aSnapshot [
 
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCPackageLoader >> useChangeSetNamed: baseName during: aBlock [
 	"Use the named change set, or create one with the given name."
 	| oldChanges newChanges |
@@ -253,28 +255,28 @@ MCPackageLoader >> useChangeSetNamed: baseName during: aBlock [
 
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCPackageLoader >> useNewChangeSetDuring: aBlock [
 	^self useNewChangeSetNamedLike: 'MC' during: aBlock
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCPackageLoader >> useNewChangeSetNamedLike: baseName during: aBlock [
 	^self useChangeSetNamed: (ChangeSet uniqueNameLike: baseName) during: aBlock
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCPackageLoader >> validate [
 	self analyze.
 	unloadableDefinitions isEmpty ifFalse: [self warnAboutDependencies].
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCPackageLoader >> warnAboutDependencies [ 
 	self notify: self dependencyWarning
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCPackageLoader >> warnAboutErrors [
 	self notify: self errorDefinitionWarning.
 

--- a/src/Monticello/MCPackageModified.class.st
+++ b/src/Monticello/MCPackageModified.class.st
@@ -2,27 +2,29 @@
 An MCPackageModified is raised when a MCPackage is modified
 "
 Class {
-	#name : #MCPackageModified,
-	#superclass : #Announcement,
+	#name : 'MCPackageModified',
+	#superclass : 'Announcement',
 	#instVars : [
 		'package'
 	],
-	#category : #'Monticello-Announcements'
+	#category : 'Monticello-Announcements',
+	#package : 'Monticello',
+	#tag : 'Announcements'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCPackageModified class >> package: aMCPackage [
 
 	^ self new package: aMCPackage
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPackageModified >> package [
 
 		^ package
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPackageModified >> package: anObject [
 	
 		package := anObject

--- a/src/Monticello/MCPatch.class.st
+++ b/src/Monticello/MCPatch.class.st
@@ -2,36 +2,38 @@
 I represent a set of patch operations which can be applied by sending message applyTo: to my instances. 
 "
 Class {
-	#name : #MCPatch,
-	#superclass : #Object,
+	#name : 'MCPatch',
+	#superclass : 'Object',
 	#instVars : [
 		'operations'
 	],
-	#category : #'Monticello-Patching'
+	#category : 'Monticello-Patching',
+	#package : 'Monticello',
+	#tag : 'Patching'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCPatch class >> fromBase: baseSnapshot target: targetSnapshot [
 	^ self new initializeWithBase: baseSnapshot target: targetSnapshot
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCPatch class >> operations: aCollection [
 	^ self basicNew initializeWithOperations: aCollection
 ]
 
-{ #category : #applying }
+{ #category : 'applying' }
 MCPatch >> applyTo: anObject [
 	operations do: [:ea | ea applyTo: anObject].
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPatch >> hasConflict [
 	^ self operations anySatisfy: [ :change| change isConflict ]
 ]
 
-{ #category : #intializing }
+{ #category : 'intializing' }
 MCPatch >> initializeWithBase: baseSnapshot target: targetSnapshot [
 	| base target |	
 	operations := OrderedCollection new.
@@ -53,17 +55,17 @@ MCPatch >> initializeWithBase: baseSnapshot target: targetSnapshot [
 			ifAbsent: [operations add: (MCRemoval of: b)]]		
 ]
 
-{ #category : #intializing }
+{ #category : 'intializing' }
 MCPatch >> initializeWithOperations: aCollection [
 	operations := aCollection
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 MCPatch >> isEmpty [
 	^ operations isEmpty
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPatch >> operations [
 	^ operations
 ]

--- a/src/Monticello/MCPatchOperation.class.st
+++ b/src/Monticello/MCPatchOperation.class.st
@@ -2,21 +2,23 @@
 I'm an abstract class that represent an single delta element between two packages: removal, addition or modification.
 "
 Class {
-	#name : #MCPatchOperation,
-	#superclass : #Object,
+	#name : 'MCPatchOperation',
+	#superclass : 'Object',
 	#instVars : [
 		'isApplicable',
 		'isConflict'
 	],
-	#category : #'Monticello-Patching'
+	#category : 'Monticello-Patching',
+	#package : 'Monticello',
+	#tag : 'Patching'
 }
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCPatchOperation >> <= other [
 	^ self definition <= other definition
 ]
 
-{ #category : #'applying operation' }
+{ #category : 'applying operation' }
 MCPatchOperation >> applyTo: anObject [
 
 	(self isConflict and: [self isResolved not] ) ifTrue: [
@@ -25,145 +27,145 @@ MCPatchOperation >> applyTo: anObject [
 	self remoteChosen ifTrue: [ self basicApplyTo: anObject ].
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPatchOperation >> beConflict [
 	isConflict := true.
 	isApplicable := nil. "not resolved"
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPatchOperation >> beNonConflict [
 	isConflict := false.
 	isApplicable := true.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPatchOperation >> chooseLocal [
 	isApplicable := false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPatchOperation >> chooseNewer [
 	self isLocalNewer 
 		ifTrue: [ self chooseLocal ]
 		ifFalse: [ self isRemoteNewer ifTrue: [ self chooseRemote ]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPatchOperation >> chooseOlder [
 	self isRemoteNewer 
 		ifTrue: [ self chooseLocal ]
 		ifFalse: [ self isLocalNewer ifTrue: [ self chooseRemote ]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPatchOperation >> chooseRemote [
 	isApplicable := true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPatchOperation >> clearChoice [
 	isApplicable := nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPatchOperation >> definition [
 	^ self subclassResponsibility 
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCPatchOperation >> initialize [
 	super initialize.
 	self beNonConflict
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPatchOperation >> inverse [
 	self subclassResponsibility
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCPatchOperation >> isAddition [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCPatchOperation >> isClassPatch [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCPatchOperation >> isConflict [
 	^ isConflict == true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCPatchOperation >> isLocalNewer [
 	^ self localDefinition fullTimeStamp > self remoteDefinition fullTimeStamp
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCPatchOperation >> isModification [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCPatchOperation >> isRemoteNewer [
 	^ self localDefinition fullTimeStamp < self remoteDefinition fullTimeStamp
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCPatchOperation >> isRemoval [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCPatchOperation >> isResolved [
 	^ isConflict and: [ isApplicable notNil ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCPatchOperation >> localChosen [
 	^ isApplicable == false
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCPatchOperation >> localDefinition [
 	^ self baseDefinition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPatchOperation >> operation [
 	"for compatibility with MCConflict interface"
 	^ self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPatchOperation >> prefixForOperation: aSymbol [
 	aSymbol == #insert ifTrue: [^ '+'].
 	aSymbol == #remove ifTrue: [^ '-'].
 	^ ' '
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPatchOperation >> printAnnotations: requests on: aStream [
 	"Add a string for an annotation pane, trying to fulfill the CodeHolder annotationRequests"
 
 	self definition printAnnotations: requests on: aStream.
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCPatchOperation >> remoteChosen [
 	^ isApplicable ~~ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPatchOperation >> remoteDefinition [
 	^ self targetDefinition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPatchOperation >> status [
 	^ self isResolved
 		ifFalse: ['']
@@ -172,12 +174,12 @@ MCPatchOperation >> status [
 					ifTrue: ['R']]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPatchOperation >> summarySuffix [
 	^ ''
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPatchOperation >> targetClass [
 	self subclassResponsibility.
 ]

--- a/src/Monticello/MCPatcher.class.st
+++ b/src/Monticello/MCPatcher.class.st
@@ -2,15 +2,17 @@
 I can add or remove or modify definitions. My main purpose is to generate monticello snapshot out of multiple snapshots or definitions by using my most used method #apply:to:.
 "
 Class {
-	#name : #MCPatcher,
-	#superclass : #Object,
+	#name : 'MCPatcher',
+	#superclass : 'Object',
 	#instVars : [
 		'definitions'
 	],
-	#category : #'Monticello-Patching'
+	#category : 'Monticello-Patching',
+	#package : 'Monticello',
+	#tag : 'Patching'
 }
 
-{ #category : #public }
+{ #category : 'public' }
 MCPatcher class >> apply: aPatch to: aSnapshot [
 	| loader |
 	loader := self snapshot: aSnapshot.
@@ -18,22 +20,22 @@ MCPatcher class >> apply: aPatch to: aSnapshot [
 	^ loader patchedSnapshot
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCPatcher class >> snapshot: aSnapshot [
 	^ self new initializeWithSnapshot: aSnapshot
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 MCPatcher >> addDefinition: aDefinition [
 	definitions add: aDefinition
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCPatcher >> initializeWithSnapshot: aSnapshot [
 	definitions := MCDefinitionIndex definitions: aSnapshot definitions
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCPatcher >> modifyDefinition: baseDefinition to: targetDefinition [
 	
 	"Only modify the definition if present"
@@ -45,12 +47,12 @@ MCPatcher >> modifyDefinition: baseDefinition to: targetDefinition [
 		ifAbsent: [ "nothing" ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPatcher >> patchedSnapshot [
 	^ MCSnapshot fromDefinitions: definitions definitions
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCPatcher >> removeDefinition: aDefinition [
 	definitions remove: aDefinition
 ]

--- a/src/Monticello/MCPoolImportDefinition.class.st
+++ b/src/Monticello/MCPoolImportDefinition.class.st
@@ -2,22 +2,24 @@
 A MCPoolImportDefinition represents a pool definition.
 "
 Class {
-	#name : #MCPoolImportDefinition,
-	#superclass : #MCVariableDefinition,
-	#category : #'Monticello-Modeling'
+	#name : 'MCPoolImportDefinition',
+	#superclass : 'MCVariableDefinition',
+	#category : 'Monticello-Modeling',
+	#package : 'Monticello',
+	#tag : 'Modeling'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPoolImportDefinition class >> type [
 	^ #pool
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCPoolImportDefinition >> isOrderDependend [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCPoolImportDefinition >> isPoolImport [
 	^ true
 ]

--- a/src/Monticello/MCPostscriptDefinition.class.st
+++ b/src/Monticello/MCPostscriptDefinition.class.st
@@ -2,22 +2,24 @@
 A postscript evaluated after load
 "
 Class {
-	#name : #MCPostscriptDefinition,
-	#superclass : #MCScriptDefinition,
-	#category : #'Monticello-Modeling'
+	#name : 'MCPostscriptDefinition',
+	#superclass : 'MCScriptDefinition',
+	#category : 'Monticello-Modeling',
+	#package : 'Monticello',
+	#tag : 'Modeling'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPostscriptDefinition class >> scriptSelector [
 	^ #postscript
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCPostscriptDefinition >> postload [
 	self evaluate
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPostscriptDefinition >> sortKey [
 	^ 'zzz' "force to the end so it gets loaded late"
 ]

--- a/src/Monticello/MCPreambleDefinition.class.st
+++ b/src/Monticello/MCPreambleDefinition.class.st
@@ -2,17 +2,19 @@
 A preamble evaluated before load
 "
 Class {
-	#name : #MCPreambleDefinition,
-	#superclass : #MCScriptDefinition,
-	#category : #'Monticello-Modeling'
+	#name : 'MCPreambleDefinition',
+	#superclass : 'MCScriptDefinition',
+	#category : 'Monticello-Modeling',
+	#package : 'Monticello',
+	#tag : 'Modeling'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCPreambleDefinition class >> scriptSelector [
 	^ #preamble
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCPreambleDefinition >> load [
 	super load.
 	self evaluate

--- a/src/Monticello/MCReader.class.st
+++ b/src/Monticello/MCReader.class.st
@@ -2,15 +2,17 @@
 Common superclass for Monticello readers
 "
 Class {
-	#name : #MCReader,
-	#superclass : #Object,
+	#name : 'MCReader',
+	#superclass : 'Object',
 	#instVars : [
 		'stream'
 	],
-	#category : #'Monticello-Storing'
+	#category : 'Monticello-Storing',
+	#package : 'Monticello',
+	#tag : 'Storing'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCReader class >> canReadFileNamed: fileName [
 	| ext |
 	ext := (self extension beginsWith: '.')
@@ -19,22 +21,22 @@ MCReader class >> canReadFileNamed: fileName [
 	^ (fileName endsWith: ext)	
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCReader class >> concreteSubclasses [
 	^ self allSubclasses reject: [:c | c isAbstract]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCReader class >> isAbstract [
 	^ (self respondsTo: #extension) not
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCReader class >> on: aStream [
 	^ self new stream: aStream
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCReader class >> on: aStream name: aFileName [
 	| class |
 	class := self readerClassForFileNamed: aFileName.
@@ -43,21 +45,21 @@ MCReader class >> on: aStream name: aFileName [
 		ifNotNil: [class on: aStream]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCReader class >> readerClassForFileNamed: fileName [
 	^ self concreteSubclasses
 		detect: [:c | c canReadFileNamed: fileName]
 		ifNone: [nil]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCReader >> stream [
 	stream closed ifTrue: [ stream open ].
 	^ stream
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCReader >> stream: aStream [
 	stream := aStream
 ]

--- a/src/Monticello/MCRemoval.class.st
+++ b/src/Monticello/MCRemoval.class.st
@@ -2,75 +2,77 @@
 A MCRemoval represents the removal of an entity of a given snapshot.
 "
 Class {
-	#name : #MCRemoval,
-	#superclass : #MCPatchOperation,
+	#name : 'MCRemoval',
+	#superclass : 'MCPatchOperation',
 	#instVars : [
 		'definition'
 	],
-	#category : #'Monticello-Patching'
+	#category : 'Monticello-Patching',
+	#package : 'Monticello',
+	#tag : 'Patching'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCRemoval class >> of: aDefinition [
 	^ self new intializeWithDefinition: aDefinition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRemoval >> baseDefinition [
 	^ definition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRemoval >> basicApplyTo: anObject [
 	anObject removeDefinition: definition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRemoval >> definition [
 	^ definition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRemoval >> fromSource [
 	^ definition diffSource
 ]
 
-{ #category : #initializing }
+{ #category : 'initializing' }
 MCRemoval >> intializeWithDefinition: aDefinition [
 	definition := aDefinition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRemoval >> inverse [
 	^ MCAddition of: definition
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCRemoval >> isClassPatch [
 	^definition isClassDefinition
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCRemoval >> isRemoval [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRemoval >> summarySuffix [
 	^ ' (removed)'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRemoval >> targetClass [
 	^ definition actualClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRemoval >> targetDefinition [
 	^ nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRemoval >> toSource [
 	^ ''
 ]

--- a/src/Monticello/MCRemovalPostscriptDefinition.class.st
+++ b/src/Monticello/MCRemovalPostscriptDefinition.class.st
@@ -2,17 +2,19 @@
 A postscript evaluated after unloading/removing
 "
 Class {
-	#name : #MCRemovalPostscriptDefinition,
-	#superclass : #MCScriptDefinition,
-	#category : #'Monticello-Modeling'
+	#name : 'MCRemovalPostscriptDefinition',
+	#superclass : 'MCScriptDefinition',
+	#category : 'Monticello-Modeling',
+	#package : 'Monticello',
+	#tag : 'Modeling'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRemovalPostscriptDefinition class >> scriptSelector [
 	^ #postscriptOfRemoval 
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCRemovalPostscriptDefinition >> unload [
 	super unload.
 	self evaluate

--- a/src/Monticello/MCRemovalPreambleDefinition.class.st
+++ b/src/Monticello/MCRemovalPreambleDefinition.class.st
@@ -2,22 +2,24 @@
 A preamble evaluated before unloading/removing
 "
 Class {
-	#name : #MCRemovalPreambleDefinition,
-	#superclass : #MCScriptDefinition,
-	#category : #'Monticello-Modeling'
+	#name : 'MCRemovalPreambleDefinition',
+	#superclass : 'MCScriptDefinition',
+	#category : 'Monticello-Modeling',
+	#package : 'Monticello',
+	#tag : 'Modeling'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRemovalPreambleDefinition class >> scriptSelector [
 	^ #preambleOfRemoval
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRemovalPreambleDefinition >> sortKey [
 	^ 'zzz' "force to the end so it gets unloaded early"
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCRemovalPreambleDefinition >> unload [
 	super unload.
 	self evaluate

--- a/src/Monticello/MCRepository.class.st
+++ b/src/Monticello/MCRepository.class.st
@@ -2,33 +2,35 @@
 A Metacello repository
 "
 Class {
-	#name : #MCRepository,
-	#superclass : #Object,
+	#name : 'MCRepository',
+	#superclass : 'Object',
 	#instVars : [
 		'creationTemplate'
 	],
 	#classVars : [
 		'Settings'
 	],
-	#category : #'Monticello-Repositories'
+	#category : 'Monticello-Repositories',
+	#package : 'Monticello',
+	#tag : 'Repositories'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRepository class >> allConcreteSubclasses [
 	^ self withAllSubclasses reject: [:ea | ea isAbstract]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRepository class >> creationTemplate [
 	self subclassResponsibility.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRepository class >> description [
 	^ nil
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCRepository class >> fromUrl: aUrlOrString [ 
 	| url |
 	url := aUrlOrString asUrl.
@@ -41,38 +43,38 @@ MCRepository class >> fromUrl: aUrlOrString [
 		ifNone: [ MCRepositoryError signal: 'Cannot instantiate a repository from the url: ', url asString ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCRepository class >> isAbstract [
 	^ self description isNil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRepository class >> urlSchemes [
 	"Returns the URL schemes used to describe this repository"
 	^ #()
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCRepository >> = other [
 	^ other species = self species and: [other description = self description]
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 MCRepository >> addTo: aRepository [
 	^ aRepository addBasicRepository: self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 MCRepository >> asCreationTemplate [
 	^ self creationTemplate
 ]
 
-{ #category : #storing }
+{ #category : 'storing' }
 MCRepository >> basicStoreVersion: aVersion [
 	self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRepository >> closestAncestorVersionFor: anAncestry ifNone: errorBlock [
 	anAncestry breadthFirstAncestorsDo:
 		[:ancestorInfo |
@@ -80,54 +82,54 @@ MCRepository >> closestAncestorVersionFor: anAncestry ifNone: errorBlock [
 	^ errorBlock value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRepository >> creationTemplate [
 	^ creationTemplate
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRepository >> creationTemplate: aString [
 	self creationTemplate ifNotNil: [ self error: 'Creation template already set for this MCRepository instance.' ].
 	
 	creationTemplate := aString.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRepository >> description [
 	^ self class name
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCRepository >> displayStringOn: aStream [
 	aStream nextPutAll: self description
 ]
 
-{ #category : #'error handling' }
+{ #category : 'error handling' }
 MCRepository >> error: aString [ 
 	^ MCRepositoryError new signal: aString
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCRepository >> hash [
 	^ self description hash
 ]
 
-{ #category : #interface }
+{ #category : 'interface' }
 MCRepository >> includesVersionNamed: aString [
 	self subclassResponsibility
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCRepository >> isValid [
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRepository >> possiblyNewerVersionsOfAnyOf: someVersions [
 	^#()
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCRepository >> printOn: aStream [
 	super printOn: aStream.
 	aStream
@@ -136,7 +138,7 @@ MCRepository >> printOn: aStream [
 		nextPut: $).
 ]
 
-{ #category : #storing }
+{ #category : 'storing' }
 MCRepository >> storeDependencies: aVersion [
 	MCCacheRepository uniqueInstance cacheAllFileNamesDuring: 
 		[self cacheAllFileNamesDuring: 
@@ -146,24 +148,24 @@ MCRepository >> storeDependencies: aVersion [
 						ifFalse: [self storeVersion: dep]]]]
 ]
 
-{ #category : #storing }
+{ #category : 'storing' }
 MCRepository >> storeVersion: aVersion [
 	self basicStoreVersion: aVersion.
 	SystemAnnouncer uniqueInstance
 		announce: (MCVersionSaved version: aVersion repository: self)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRepository >> versionFrom: aVersionReferenceString [
 	self error: 'Unable to load from ' , self printString
 ]
 
-{ #category : #interface }
+{ #category : 'interface' }
 MCRepository >> versionWithInfo: aVersionInfo [
 	^ self versionWithInfo: aVersionInfo ifAbsent: [nil]
 ]
 
-{ #category : #interface }
+{ #category : 'interface' }
 MCRepository >> versionWithInfo: aVersionInfo ifAbsent: aBlock [
 	self subclassResponsibility 
 ]

--- a/src/Monticello/MCRepositoryAdded.class.st
+++ b/src/Monticello/MCRepositoryAdded.class.st
@@ -2,20 +2,22 @@
 Announcement sent when a Repository is added to a Repository group.
 "
 Class {
-	#name : #MCRepositoryAdded,
-	#superclass : #Announcement,
+	#name : 'MCRepositoryAdded',
+	#superclass : 'Announcement',
 	#instVars : [
 		'repository'
 	],
-	#category : #'Monticello-Announcements'
+	#category : 'Monticello-Announcements',
+	#package : 'Monticello',
+	#tag : 'Announcements'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRepositoryAdded >> repository [
 	^ repository
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRepositoryAdded >> repository: anObject [
 	repository := anObject
 ]

--- a/src/Monticello/MCRepositoryError.class.st
+++ b/src/Monticello/MCRepositoryError.class.st
@@ -2,7 +2,9 @@
 I am an MC-specific errror
 "
 Class {
-	#name : #MCRepositoryError,
-	#superclass : #Error,
-	#category : #'Monticello-Repositories'
+	#name : 'MCRepositoryError',
+	#superclass : 'Error',
+	#category : 'Monticello-Repositories',
+	#package : 'Monticello',
+	#tag : 'Repositories'
 }

--- a/src/Monticello/MCRepositoryGroup.class.st
+++ b/src/Monticello/MCRepositoryGroup.class.st
@@ -2,8 +2,8 @@
 A singleton class, holds the list of repositories. Can look for a requested VersionInfo among its repositories.
 "
 Class {
-	#name : #MCRepositoryGroup,
-	#superclass : #Object,
+	#name : 'MCRepositoryGroup',
+	#superclass : 'Object',
 	#instVars : [
 		'repositories',
 		'useCache'
@@ -11,15 +11,17 @@ Class {
 	#classInstVars : [
 		'default'
 	],
-	#category : #'Monticello-Versioning'
+	#category : 'Monticello-Versioning',
+	#package : 'Monticello',
+	#tag : 'Versioning'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRepositoryGroup class >> default [
 	^ default ifNil: [default := self new]
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCRepositoryGroup class >> withRepositories: aCollection [ 
 	| group |
 	group  := self new.
@@ -28,7 +30,7 @@ MCRepositoryGroup class >> withRepositories: aCollection [
 		
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 MCRepositoryGroup >> addBasicRepository: aRepository [
 	((repositories includes: aRepository) 
 	or: [ aRepository == MCCacheRepository uniqueInstance ])
@@ -39,24 +41,24 @@ MCRepositoryGroup >> addBasicRepository: aRepository [
 	^ aRepository
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 MCRepositoryGroup >> addRepository: aRepository [
 	aRepository addTo: self.
 	^ aRepository
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 MCRepositoryGroup >> addRepositoryGroup: aRepositoryGroup [
 	aRepositoryGroup repositoriesDo: [ :each | 
 		each addTo: self ]
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 MCRepositoryGroup >> addTo: aRepository [
 	^ aRepository addRepositoryGroup: self
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCRepositoryGroup >> announceRepositoryAdded: aRepository [
 	SystemAnnouncer uniqueInstance
 		announce:
@@ -65,7 +67,7 @@ MCRepositoryGroup >> announceRepositoryAdded: aRepository [
 				yourself)
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCRepositoryGroup >> announceRepositoryRemoved: aRepository [
 	SystemAnnouncer uniqueInstance
 		announce:
@@ -74,17 +76,17 @@ MCRepositoryGroup >> announceRepositoryRemoved: aRepository [
 				yourself)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRepositoryGroup >> disableCache [
 	useCache := false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCRepositoryGroup >> includes: aRepository [
 	^ self repositories includes: aRepository
 ]
 
-{ #category : #interface }
+{ #category : 'interface' }
 MCRepositoryGroup >> includesVersionNamed: aString [
 	" check for existing version name in parallel over all repositories "
 	| results |
@@ -101,43 +103,43 @@ MCRepositoryGroup >> includesVersionNamed: aString [
 	^ results anySatisfy: [:result| result = true ]	
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCRepositoryGroup >> initialize [
 	super initialize.
 	repositories := OrderedCollection new
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRepositoryGroup >> removeRepository: aRepository [
 	repositories remove: aRepository ifAbsent: [ ^ self ].
 	self announceRepositoryRemoved: aRepository
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRepositoryGroup >> repositories [
 	^ (self useCache 
 		ifTrue: [Array with: MCCacheRepository uniqueInstance] 
 		ifFalse: [Array new]) , repositories select: #isValid
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 MCRepositoryGroup >> repositoriesDo: aBlock [
 	self repositories do: [:ea | [aBlock value: ea] on: Error do: []]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRepositoryGroup >> useCache [
 	^ useCache ifNil: [
 		useCache := true
 	]
 ]
 
-{ #category : #interface }
+{ #category : 'interface' }
 MCRepositoryGroup >> versionWithInfo: aVersionInfo [
 	^self versionWithInfo: aVersionInfo ifNone: [ self error: 'Could not find version ', aVersionInfo name printString,'. Maybe you need to add a repository?' ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRepositoryGroup >> versionWithInfo: aVersionInfo ifNone: aBlock [
 	self repositoriesDo: [:ea | (ea versionWithInfo: aVersionInfo) ifNotNil: [:v | ^ v]].
 	^aBlock value

--- a/src/Monticello/MCRepositoryRemoved.class.st
+++ b/src/Monticello/MCRepositoryRemoved.class.st
@@ -2,20 +2,22 @@
 Announcement sent when a Repository is removed from  a Repository group.
 "
 Class {
-	#name : #MCRepositoryRemoved,
-	#superclass : #Announcement,
+	#name : 'MCRepositoryRemoved',
+	#superclass : 'Announcement',
 	#instVars : [
 		'repository'
 	],
-	#category : #'Monticello-Announcements'
+	#category : 'Monticello-Announcements',
+	#package : 'Monticello',
+	#tag : 'Announcements'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRepositoryRemoved >> repository [
 	^ repository
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCRepositoryRemoved >> repository: anObject [
 	repository := anObject
 ]

--- a/src/Monticello/MCScanner.class.st
+++ b/src/Monticello/MCScanner.class.st
@@ -6,20 +6,22 @@ For example, try:
 MCScanner scan:  '(name ''MyPackage-ll.6'' message ''Fix bug xxx'' id ''b21dbd73-f1c3-2746-a3cc-92f1d4edea28'')' readStream
 "
 Class {
-	#name : #MCScanner,
-	#superclass : #Object,
+	#name : 'MCScanner',
+	#superclass : 'Object',
 	#instVars : [
 		'stream'
 	],
-	#category : #'Monticello-Chunk Format'
+	#category : 'Monticello-Chunk Format',
+	#package : 'Monticello',
+	#tag : 'Chunk Format'
 }
 
-{ #category : #'public api' }
+{ #category : 'public api' }
 MCScanner class >> scan: aStream [
 	^ (self new stream: aStream) next
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCScanner >> next [
 	"This would be slightly simpler using recursion but it risks a stack overflow 
 	 for some packages on some platforms, so we implement it using a local stack."
@@ -48,7 +50,7 @@ MCScanner >> next [
 	^stack top top
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCScanner >> nextArray [
 	stream next. "("
 	^ Array streamContents: [:s |
@@ -59,12 +61,12 @@ MCScanner >> nextArray [
 			ifFalse: [ self error: 'Unclosed array' ]]
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCScanner >> nextString [
 	^ stream nextDelimited: $'
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCScanner >> nextSymbol [
 	^ (String streamContents:
 		[:s |
@@ -72,7 +74,7 @@ MCScanner >> nextSymbol [
 			
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCScanner >> stream: aStream [
 	stream := aStream
 ]

--- a/src/Monticello/MCScriptDefinition.class.st
+++ b/src/Monticello/MCScriptDefinition.class.st
@@ -2,74 +2,76 @@
 Common superclass for script definitions
 "
 Class {
-	#name : #MCScriptDefinition,
-	#superclass : #MCDefinition,
+	#name : 'MCScriptDefinition',
+	#superclass : 'MCDefinition',
 	#instVars : [
 		'script',
 		'packageName'
 	],
-	#category : #'Monticello-Modeling'
+	#category : 'Monticello-Modeling',
+	#package : 'Monticello',
+	#tag : 'Modeling'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCScriptDefinition class >> from: aPackageInfo [
 	^ self script: (aPackageInfo perform: self scriptSelector) contents asString packageName: aPackageInfo name
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCScriptDefinition class >> script: aString packageName: packageString [
 	^ self new initializeWithScript: aString packageName: packageString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCScriptDefinition class >> scriptSelector [
 	self subclassResponsibility
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCScriptDefinition class >> scriptSelector: selectorString script: aString packageName: packageString [
 	^ (self subclassForScriptSelector: selectorString)
 		script: aString packageName: packageString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCScriptDefinition class >> subclassForScriptSelector: selectorString [
 	^self allSubclasses detect: [:ea | ea scriptSelector = selectorString]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCScriptDefinition >> = aDefinition [
 	^ (super = aDefinition)
 		and: [script = aDefinition script]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCScriptDefinition >> accept: aVisitor [
 	aVisitor visitScriptDefinition: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCScriptDefinition >> description [
 	^ Array with: packageName with: self scriptSelector
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCScriptDefinition >> evaluate [
 	self class compiler evaluate: script
 ]
 
-{ #category : #initializing }
+{ #category : 'initializing' }
 MCScriptDefinition >> initializeWithScript: aString packageName: packageString [
 	script := aString.
 	packageName := packageString
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCScriptDefinition >> installScript [
 	self installScript: script
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCScriptDefinition >> installScript: aString [
 	| sel pi |
 	sel := (self scriptSelector, ':') asSymbol.
@@ -78,52 +80,52 @@ MCScriptDefinition >> installScript: aString [
 		ifTrue: [pi perform: sel with: aString]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCScriptDefinition >> isScriptDefinition [
 	^true
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCScriptDefinition >> load [
 	self installScript
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCScriptDefinition >> packageName [
 	^ packageName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCScriptDefinition >> packageSet [
 	^ RPackageSet named: packageName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCScriptDefinition >> script [
 	^ script
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCScriptDefinition >> scriptSelector [
 	^ self class scriptSelector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCScriptDefinition >> sortKey [
 	^ '!', self scriptSelector "force to the front so it gets loaded first"
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCScriptDefinition >> source [
 	^ script
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCScriptDefinition >> summary [
 	^ packageName, ' ', self scriptSelector
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCScriptDefinition >> unload [
 	self installScript: nil
 ]

--- a/src/Monticello/MCScriptParser.class.st
+++ b/src/Monticello/MCScriptParser.class.st
@@ -2,17 +2,19 @@
 A MCScriptParser identifies script and add MCScriptDefinition. 
 "
 Class {
-	#name : #MCScriptParser,
-	#superclass : #MCDoItParser,
-	#category : #'Monticello-Chunk Format'
+	#name : 'MCScriptParser',
+	#superclass : 'MCDoItParser',
+	#category : 'Monticello-Chunk Format',
+	#package : 'Monticello',
+	#tag : 'Chunk Format'
 }
 
-{ #category : #'factory identification hook' }
+{ #category : 'factory identification hook' }
 MCScriptParser class >> pattern [
 	^'(PackageInfo named: *'
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCScriptParser >> addDefinitionsTo: aCollection [
 	| tokens definition |
 	tokens := source parseLiterals.

--- a/src/Monticello/MCSnapshot.class.st
+++ b/src/Monticello/MCSnapshot.class.st
@@ -4,26 +4,28 @@ MCSnapshot represents a list of entities compared to a given base entities.
 It holds a list of definitions (instances of MCDefinition subclasses). It can install these entities or update a package.
 "
 Class {
-	#name : #MCSnapshot,
-	#superclass : #Object,
+	#name : 'MCSnapshot',
+	#superclass : 'Object',
 	#instVars : [
 		'definitions',
 		'classDefinitionCache'
 	],
-	#category : #'Monticello-Base'
+	#category : 'Monticello-Base',
+	#package : 'Monticello',
+	#tag : 'Base'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCSnapshot class >> empty [
 	^ self fromDefinitions: #()
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCSnapshot class >> fromDefinitions: aCollection [
 	^ self new initializeWithDefinitions: aCollection
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCSnapshot >> = other [
 	self == other
 		ifTrue: [ ^ true ].
@@ -32,23 +34,23 @@ MCSnapshot >> = other [
 	^ definitions asArray = other definitions asArray
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCSnapshot >> classDefinitionNamed: aName ifAbsent: aBlock [
 
 	^ classDefinitionCache at: aName ifAbsent: aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCSnapshot >> definitions [
 	^ definitions
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCSnapshot >> hash [
 	^ definitions asArray hash
 ]
 
-{ #category : #initializing }
+{ #category : 'initializing' }
 MCSnapshot >> initializeWithDefinitions: aCollection [
 	
 	definitions := aCollection.
@@ -60,17 +62,17 @@ MCSnapshot >> initializeWithDefinitions: aCollection [
 				put: e ] ]
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MCSnapshot >> install [
 	MCPackageLoader installSnapshot: self
 ]
 
-{ #category : #patching }
+{ #category : 'patching' }
 MCSnapshot >> patchRelativeToBase: aSnapshot [
 	^ MCPatch fromBase: aSnapshot target: self
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MCSnapshot >> updatePackage: aPackage [
 	MCPackageLoader updatePackage: aPackage withSnapshot: self
 ]

--- a/src/Monticello/MCSnapshotReader.class.st
+++ b/src/Monticello/MCSnapshotReader.class.st
@@ -6,26 +6,28 @@ MCVersionReader could be a subclass of me for reading sources containing additio
 I'm useless and can be safely removed. I'm only referenced in MCMczReader>>extractDefinitionsFrom: and it can be replaced by MCReader.
 "
 Class {
-	#name : #MCSnapshotReader,
-	#superclass : #MCReader,
+	#name : 'MCSnapshotReader',
+	#superclass : 'MCReader',
 	#instVars : [
 		'definitions'
 	],
-	#category : #'Monticello-Storing'
+	#category : 'Monticello-Storing',
+	#package : 'Monticello',
+	#tag : 'Storing'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCSnapshotReader class >> snapshotFromStream: aStream [
 	^ (self on: aStream) snapshot
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCSnapshotReader >> definitions [
 	definitions ifNil: [self loadDefinitions].
 	^ definitions
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCSnapshotReader >> snapshot [
 	^ MCSnapshot fromDefinitions: self definitions
 ]

--- a/src/Monticello/MCStReader.class.st
+++ b/src/Monticello/MCStReader.class.st
@@ -14,24 +14,26 @@ source := String streamContents: [:aStream| |writer|
 (MCStReader on: source readStream) definitions explore.
 "
 Class {
-	#name : #MCStReader,
-	#superclass : #MCSnapshotReader,
-	#category : #'Monticello-Storing'
+	#name : 'MCStReader',
+	#superclass : 'MCSnapshotReader',
+	#category : 'Monticello-Storing',
+	#package : 'Monticello',
+	#tag : 'Storing'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCStReader class >> extension [
 	^ 'st'
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 MCStReader >> addDefinitionsFromDoit: aString [
 	(MCDoItParser forDoit: aString) ifNotNil:
 		[:parser |
 		parser addDefinitionsTo: definitions]
 ]
 
-{ #category : #reading }
+{ #category : 'reading' }
 MCStReader >> categoryFromDoIt: aString [
 	| tokens  |
 	tokens := aString parseLiterals.
@@ -39,7 +41,7 @@ MCStReader >> categoryFromDoIt: aString [
 	^ tokens at: 3
 ]
 
-{ #category : #reading }
+{ #category : 'reading' }
 MCStReader >> classDefinitionFrom: aRingClass [
 
 	| tokens traitCompositionString lastIndex classTraitCompositionString |
@@ -68,7 +70,7 @@ MCStReader >> classDefinitionFrom: aRingClass [
 		  yourself
 ]
 
-{ #category : #reading }
+{ #category : 'reading' }
 MCStReader >> classInstVarNamesFor: aRingClass [
 	| tokens |
 	
@@ -79,7 +81,7 @@ MCStReader >> classInstVarNamesFor: aRingClass [
 	^ tokens last findTokens: ' '
 ]
 
-{ #category : #reading }
+{ #category : 'reading' }
 MCStReader >> commentFor: aRingClass [
 
 	^ aRingClass hasComment
@@ -87,14 +89,14 @@ MCStReader >> commentFor: aRingClass [
 		ifFalse: [ '' ]
 ]
 
-{ #category : #reading }
+{ #category : 'reading' }
 MCStReader >> commentStampFor: aRingClass [
 	^ aRingClass hasComment
 		ifTrue: [ aRingClass comment stamp ]
 		ifFalse: [ nil ]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 MCStReader >> loadDefinitions [
 	| filePackage |
 	filePackage := RingChunkImporter fromStream: self readStream.
@@ -111,21 +113,21 @@ MCStReader >> loadDefinitions [
 	
 ]
 
-{ #category : #reading }
+{ #category : 'reading' }
 MCStReader >> methodDefinitionsFor: aRingClass [
 
 	^ aRingClass methods collect: 
 		[ :each | each asMCMethodDefinition ]
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 MCStReader >> readStream [
 	^ ('!!
 
 ', stream contents) readStream
 ]
 
-{ #category : #reading }
+{ #category : 'reading' }
 MCStReader >> typeOfSubclass: aSymbol [
 	| layoutClass |
 	layoutClass := ObjectLayout layoutForSubclassDefiningSymbol: aSymbol.

--- a/src/Monticello/MCStWriter.class.st
+++ b/src/Monticello/MCStWriter.class.st
@@ -11,26 +11,28 @@ String streamContents: [:aStream| |writer|
 ]
 "
 Class {
-	#name : #MCStWriter,
-	#superclass : #MCWriter,
+	#name : 'MCStWriter',
+	#superclass : 'MCWriter',
 	#instVars : [
 		'initializers',
 		'writeInitializers'
 	],
-	#category : #'Monticello-Storing'
+	#category : 'Monticello-Storing',
+	#package : 'Monticello',
+	#tag : 'Storing'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCStWriter class >> readerClass [
 	^ MCStReader
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCStWriter >> basicChunkContents: aBlock [
 	stream nextPut: (String streamContents: aBlock)
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCStWriter >> chunkContents: aBlock [
 	stream
 		cr;
@@ -38,20 +40,20 @@ MCStWriter >> chunkContents: aBlock [
 		cr
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCStWriter >> stream: aStream [
 
 	stream := ChunkWriteStream on: aStream
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCStWriter >> visitClassDefinition: definition [
 	self writeClassDefinition: definition.
 	definition hasClassInstanceVariables ifTrue: [self writeMetaclassDefinition: definition].
 	definition hasComment ifTrue: [self writeClassComment: definition].
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCStWriter >> visitClassTraitDefinition: definition [
 	self chunkContents: [:s | s
 		nextPutAll: definition baseTrait;
@@ -62,12 +64,12 @@ MCStWriter >> visitClassTraitDefinition: definition [
 
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCStWriter >> visitMetaclassDefinition: definition [
 	self writeMetaclassDefinition: definition
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCStWriter >> visitMethodDefinition: definition [
 	self writeMethodPreamble: definition.
 	self writeMethodSource: definition.
@@ -76,32 +78,32 @@ MCStWriter >> visitMethodDefinition: definition [
 		self writeMethodInitializer: definition ].
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCStWriter >> visitOrganizationDefinition: defintion [
 	defintion categories do: [:cat | self writeCategory: cat].
 
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCStWriter >> visitScriptDefinition: definition [
 	self writeScriptDefinition: definition
 
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCStWriter >> visitTraitDefinition: definition [
 	self writeClassDefinition: definition.
 	definition hasComment ifTrue: [self writeClassComment: definition].
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCStWriter >> writeCategory: categoryName [
 	stream
 		nextChunkPut: 'SystemOrganization addCategory: ', categoryName printString;
 		cr
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCStWriter >> writeClassComment: definition [
 
 	self chunkContents: [ :str |
@@ -114,12 +116,12 @@ MCStWriter >> writeClassComment: definition [
 	stream cr.
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCStWriter >> writeClassDefinition: definition [
 	self chunkContents: [:s | definition printDefinitionOn: s].
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCStWriter >> writeDefinitions: aCollection [
 	
 	"the correct initialization order is unknown if some classes are missing in the image"
@@ -145,7 +147,7 @@ MCStWriter >> writeDefinitions: aCollection [
 		self chunkContents: [ :str | str  nextPutAll: association value contents ] ].
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCStWriter >> writeInitializers [
 
 	"answer if class initializers should be written"
@@ -153,13 +155,13 @@ MCStWriter >> writeInitializers [
 	^ writeInitializers ifNil: [ writeInitializers := true ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCStWriter >> writeInitializers: aBoolean [
 
 	writeInitializers := aBoolean
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCStWriter >> writeMetaclassDefinition: definition [
 	self chunkContents: [:str |
 		str	 nextPutAll: definition className;
@@ -174,7 +176,7 @@ MCStWriter >> writeMetaclassDefinition: definition [
 				nextPut: $']
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCStWriter >> writeMethodInitializer: aMethodDefinition [
 	
 	aMethodDefinition isInitializer ifTrue: [ 
@@ -184,13 +186,13 @@ MCStWriter >> writeMethodInitializer: aMethodDefinition [
 		].
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCStWriter >> writeMethodPostscript [
 	self basicChunkContents: [:str | str space ].
 	stream cr.
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCStWriter >> writeMethodPreamble: definition [
 	self chunkContents: [:str |
 		stream bang.
@@ -205,12 +207,22 @@ MCStWriter >> writeMethodPreamble: definition [
 		]
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCStWriter >> writeMethodSource: definition [
 	self basicChunkContents: [:str | str nextPutAll: definition source ].
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
+MCStWriter >> writePackage: packageName tags: aCollection [
+
+	stream
+		nextChunkPut: ('{1} do: [ :tag | (self packageOrganizer ensurePackage: {2}) ensureTag: tag ]' format: {
+						 aCollection printString.
+						 packageName });
+		cr
+]
+
+{ #category : 'writing' }
 MCStWriter >> writeScriptDefinition: definition [
 	self chunkContents: [:str | 
 		str nextPutAll: (
@@ -222,7 +234,7 @@ MCStWriter >> writeScriptDefinition: definition [
 			}) ]
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCStWriter >> writeSnapshot: aSnapshot [
 	self writeDefinitions: aSnapshot definitions
 ]

--- a/src/Monticello/MCStWriter.class.st
+++ b/src/Monticello/MCStWriter.class.st
@@ -209,7 +209,7 @@ MCStWriter >> writeMethodSource: definition [
 MCStWriter >> writePackage: packageName tags: aCollection [
 
 	stream
-		nextChunkPut: ('{1} do: [ :tag | (self packageOrganizer ensurePackage: {2}) ensureTag: tag ]' format: {
+		nextChunkPut: ('{1} do: [ :tag | (self packageOrganizer ensurePackage: #{2}) ensureTag: tag ]' format: {
 						 aCollection printString.
 						 packageName });
 		cr

--- a/src/Monticello/MCStWriter.class.st
+++ b/src/Monticello/MCStWriter.class.st
@@ -79,9 +79,9 @@ MCStWriter >> visitMethodDefinition: definition [
 ]
 
 { #category : 'visiting' }
-MCStWriter >> visitOrganizationDefinition: defintion [
-	defintion categories do: [:cat | self writeCategory: cat].
+MCStWriter >> visitOrganizationDefinition: definition [
 
+	self writePackage: definition packageName tags: (definition tagNames ifNil: [ #(  ) ])
 ]
 
 { #category : 'visiting' }
@@ -94,13 +94,6 @@ MCStWriter >> visitScriptDefinition: definition [
 MCStWriter >> visitTraitDefinition: definition [
 	self writeClassDefinition: definition.
 	definition hasComment ifTrue: [self writeClassComment: definition].
-]
-
-{ #category : 'writing' }
-MCStWriter >> writeCategory: categoryName [
-	stream
-		nextChunkPut: 'SystemOrganization addCategory: ', categoryName printString;
-		cr
 ]
 
 { #category : 'writing' }

--- a/src/Monticello/MCStWriter.class.st
+++ b/src/Monticello/MCStWriter.class.st
@@ -209,9 +209,9 @@ MCStWriter >> writeMethodSource: definition [
 MCStWriter >> writePackage: packageName tags: aCollection [
 
 	stream
-		nextChunkPut: ('{1} do: [ :tag | (self packageOrganizer ensurePackage: #{2}) ensureTag: tag ]' format: {
-						 aCollection printString.
-						 packageName });
+		nextChunkPut: ('self packageOrganizer ensurePackage: #{1} withTags: {2}' format: {
+						 packageName.
+						 aCollection printString });
 		cr
 ]
 

--- a/src/Monticello/MCSubDirectoryRepository.class.st
+++ b/src/Monticello/MCSubDirectoryRepository.class.st
@@ -2,28 +2,30 @@
 A MCDirectoryRepository that looks in subdirectories too.
 "
 Class {
-	#name : #MCSubDirectoryRepository,
-	#superclass : #MCDirectoryRepository,
-	#category : #'Monticello-Repositories'
+	#name : 'MCSubDirectoryRepository',
+	#superclass : 'MCDirectoryRepository',
+	#category : 'Monticello-Repositories',
+	#package : 'Monticello',
+	#tag : 'Repositories'
 }
 
-{ #category : #'user interface' }
+{ #category : 'user interface' }
 MCSubDirectoryRepository class >> description [
 	^ 'directory with subdirectories'
 ]
 
-{ #category : #enumeration }
+{ #category : 'enumeration' }
 MCSubDirectoryRepository >> allDirectories [
 	^directory allDirectories 
 ]
 
-{ #category : #'user interface' }
+{ #category : 'user interface' }
 MCSubDirectoryRepository >> description [
 	^ (directory / '*') fullName
 
 ]
 
-{ #category : #'i/o' }
+{ #category : 'i/o' }
 MCSubDirectoryRepository >> findFullNameForReading: aBaseName [
 	"Answer the latest version of aBaseName"
 	^((directory glob: [ :each | each basename = aBaseName])
@@ -31,7 +33,7 @@ MCSubDirectoryRepository >> findFullNameForReading: aBaseName [
 		first.
 ]
 
-{ #category : #'i/o' }
+{ #category : 'i/o' }
 MCSubDirectoryRepository >> findFullNameForWriting: aBaseName [
 	| possible split prefix fpattern now |
 	split := self splitNameVersionExtensionFor: aBaseName.
@@ -58,7 +60,7 @@ MCSubDirectoryRepository >> findFullNameForWriting: aBaseName [
 	^ (possible first third) / aBaseName
 ]
 
-{ #category : #interface }
+{ #category : 'interface' }
 MCSubDirectoryRepository >> loadAllFileNames [
 	"sorting {entry. dirName. name}"
 
@@ -73,7 +75,7 @@ MCSubDirectoryRepository >> loadAllFileNames [
 		collect: [:ea | ea third ]
 ]
 
-{ #category : #'i/o' }
+{ #category : 'i/o' }
 MCSubDirectoryRepository >> readStreamForFileNamed: aString do: aBlock [
 
 	| fileReference |
@@ -81,7 +83,7 @@ MCSubDirectoryRepository >> readStreamForFileNamed: aString do: aBlock [
 	fileReference binaryReadStreamDo: [ :stream | ^ aBlock value: stream ].
 ]
 
-{ #category : #'i/o' }
+{ #category : 'i/o' }
 MCSubDirectoryRepository >> splitNameVersionExtensionFor: aBaseName [
 
 	| file version |
@@ -94,7 +96,7 @@ MCSubDirectoryRepository >> splitNameVersionExtensionFor: aBaseName [
 
 ]
 
-{ #category : #'i/o' }
+{ #category : 'i/o' }
 MCSubDirectoryRepository >> writeStreamForFileNamed: aString replace: shouldReplace do: aBlock [ 
 
 	| fileReference |

--- a/src/Monticello/MCSystemCategoryParser.class.st
+++ b/src/Monticello/MCSystemCategoryParser.class.st
@@ -1,5 +1,5 @@
 "
-A MCSystemCategoryParser extracts or set a category/protocol to the corresponding MCOrganizationDefinition.
+A MCSystemCategoryParser extracts or set a category/protocol to the corresponding MCOrganizationDefinition with the old definition
 "
 Class {
 	#name : 'MCSystemCategoryParser',

--- a/src/Monticello/MCSystemCategoryParser.class.st
+++ b/src/Monticello/MCSystemCategoryParser.class.st
@@ -2,17 +2,19 @@
 A MCSystemCategoryParser extracts or set a category/protocol to the corresponding MCOrganizationDefinition.
 "
 Class {
-	#name : #MCSystemCategoryParser,
-	#superclass : #MCDoItParser,
-	#category : #'Monticello-Chunk Format'
+	#name : 'MCSystemCategoryParser',
+	#superclass : 'MCDoItParser',
+	#category : 'Monticello-Chunk Format',
+	#package : 'Monticello',
+	#tag : 'Chunk Format'
 }
 
-{ #category : #'factory identification hook' }
+{ #category : 'factory identification hook' }
 MCSystemCategoryParser class >> pattern [
 	^ 'SystemOrganization*'
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCSystemCategoryParser >> addDefinitionsTo: aCollection [
 
 	| definition |
@@ -30,7 +32,7 @@ MCSystemCategoryParser >> addDefinitionsTo: aCollection [
 						  ifFalse: [ category ])) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCSystemCategoryParser >> category [
 
 	| tokens |

--- a/src/Monticello/MCThreeWayMerger.class.st
+++ b/src/Monticello/MCThreeWayMerger.class.st
@@ -4,18 +4,20 @@ Operations are subclasses of MCPatchOperation:  addition (MCAddition), modificat
 
 "
 Class {
-	#name : #MCThreeWayMerger,
-	#superclass : #MCMerger,
+	#name : 'MCThreeWayMerger',
+	#superclass : 'MCMerger',
 	#instVars : [
 		'index',
 		'operations',
 		'provisions',
 		'redundantAdds'
 	],
-	#category : #'Monticello-Merging'
+	#category : 'Monticello-Merging',
+	#package : 'Monticello',
+	#tag : 'Merging'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCThreeWayMerger class >> base: aSnapshot patch: aPatch [
 	aPatch isEmpty ifTrue: [MCNoChangesException signal].
 	^ self new
@@ -25,12 +27,12 @@ MCThreeWayMerger class >> base: aSnapshot patch: aPatch [
 		
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCThreeWayMerger class >> base: aSnapshot target: targetSnapshot ancestor: ancestorSnapshot [
 	^ self base: aSnapshot patch: (targetSnapshot patchRelativeToBase: ancestorSnapshot)
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCThreeWayMerger >> addBaseSnapshot: aSnapshot [
 	aSnapshot definitions do:
 		[:ea |
@@ -38,7 +40,7 @@ MCThreeWayMerger >> addBaseSnapshot: aSnapshot [
 		provisions addAll: ea provisions]
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCThreeWayMerger >> addDefinition: aDefinition [
 	index
 		definitionLike: aDefinition
@@ -55,29 +57,29 @@ MCThreeWayMerger >> addDefinition: aDefinition [
 		ifAbsent: [self addOperation: (MCAddition of: aDefinition)]
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCThreeWayMerger >> addOperation: anOperation [
 	self operations add: anOperation
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCThreeWayMerger >> applyPatch: aPatch [
 	aPatch applyTo: self
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCThreeWayMerger >> baseSnapshot [
 	^ (MCSnapshot fromDefinitions: index definitions)
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCThreeWayMerger >> initialize [
 	super initialize.
 	index := MCDefinitionIndex new.
 	provisions := Set new
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCThreeWayMerger >> modificationConflictForDefinition: aDefinition [
 	^ self conflicts 
 		detect: [:ea |
@@ -86,7 +88,7 @@ MCThreeWayMerger >> modificationConflictForDefinition: aDefinition [
 		ifNone: []
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCThreeWayMerger >> modifyDefinition: baseDefinition to: targetDefinition [
 	index
 		definitionLike: baseDefinition
@@ -99,22 +101,22 @@ MCThreeWayMerger >> modifyDefinition: baseDefinition to: targetDefinition [
 		ifAbsent: [self addConflictWithOperation: (MCAddition of: targetDefinition)]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCThreeWayMerger >> operations [
 	^ operations ifNil: [operations := OrderedCollection new]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCThreeWayMerger >> provisions [
 	^ provisions
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCThreeWayMerger >> redundantAdds [
 	^ redundantAdds ifNil: [redundantAdds := Set new]
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCThreeWayMerger >> removalForDefinition: aDefinition [
 	^ operations ifNotNil:
 		[operations
@@ -122,7 +124,7 @@ MCThreeWayMerger >> removalForDefinition: aDefinition [
 			ifNone: []]
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCThreeWayMerger >> removeDefinition: aDefinition [
 	index
 		definitionLike: aDefinition
@@ -138,7 +140,7 @@ MCThreeWayMerger >> removeDefinition: aDefinition [
 		ifAbsent: []
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCThreeWayMerger >> removeOperation: anOperation [
 	operations remove: anOperation
 ]

--- a/src/Monticello/MCTraitDefinition.class.st
+++ b/src/Monticello/MCTraitDefinition.class.st
@@ -2,12 +2,14 @@
 A MCTraitDefinition represents a trait.
 "
 Class {
-	#name : #MCTraitDefinition,
-	#superclass : #MCClassDefinition,
-	#category : #'Monticello-Modeling'
+	#name : 'MCTraitDefinition',
+	#superclass : 'MCClassDefinition',
+	#category : 'Monticello-Modeling',
+	#package : 'Monticello',
+	#tag : 'Modeling'
 }
 
-{ #category : #deprecated }
+{ #category : 'deprecated' }
 MCTraitDefinition class >> name: classNameString traitComposition: traitCompositionString category: categoryString instVarNames: ivarArray classInstVarNames: civarArray classTraitComposition: classTraitCompositionString comment: commentString commentStamp: commentStamp [
 	"Do not use this method! This method will be deprecated once Tonel will not use it anymore."
 
@@ -22,7 +24,7 @@ MCTraitDefinition class >> name: classNameString traitComposition: traitComposit
 		  yourself
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCTraitDefinition >> = aDefinition [
 
 	self flag: #traits. "Ugly we harcoded the super superclass method.  We will have to refactor the definition hierarchy"
@@ -36,13 +38,13 @@ MCTraitDefinition >> = aDefinition [
 							  self classInstVarNames = aDefinition classInstVarNames and: [ comment = aDefinition comment ] ] ] ] ] ] ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCTraitDefinition >> accept: aVisitor [
 	^ aVisitor visitTraitDefinition: self
 
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCTraitDefinition >> classSlotDefinitionString [
 
 	^ self needsSlotClassDefinition 
@@ -56,7 +58,7 @@ MCTraitDefinition >> classSlotDefinitionString [
 				stream nextPutAll: ' }']]
 ]
 
-{ #category : #installing }
+{ #category : 'installing' }
 MCTraitDefinition >> createClass [
 
 	| trait |
@@ -75,26 +77,26 @@ MCTraitDefinition >> createClass [
 	^ trait
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCTraitDefinition >> hasClassInstanceVariables [
 	^ false
 
 
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCTraitDefinition >> hash [
 
 	^ (name hash bitXor: traitComposition hash) bitXor: self category hash
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCTraitDefinition >> printClassDefinitionOn: stream [
 
 	^ self printMetaDefinitionOn: stream
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCTraitDefinition >> printDefinitionOn: stream [
 	stream nextPutAll: 'Trait named: #', self className;
 		 cr;
@@ -119,7 +121,7 @@ MCTraitDefinition >> printDefinitionOn: stream [
 
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCTraitDefinition >> requirements [
 	"Assuming that traits in a composition can be identified by
 	testing for the first character beeing an uppercase character
@@ -134,7 +136,7 @@ MCTraitDefinition >> requirements [
 		as: Set) asArray
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCTraitDefinition >> slotDefinitionString [
 
 	variables ifNil: [ ^ '{ }' ].

--- a/src/Monticello/MCTraitParser.class.st
+++ b/src/Monticello/MCTraitParser.class.st
@@ -2,17 +2,19 @@
 A MCTraitParser extracts an MCTraitDefinition from the source.
 "
 Class {
-	#name : #MCTraitParser,
-	#superclass : #MCDoItParser,
-	#category : #'Monticello-Chunk Format'
+	#name : 'MCTraitParser',
+	#superclass : 'MCDoItParser',
+	#category : 'Monticello-Chunk Format',
+	#package : 'Monticello',
+	#tag : 'Chunk Format'
 }
 
-{ #category : #'factory identification hook' }
+{ #category : 'factory identification hook' }
 MCTraitParser class >> pattern [
 	^ 'Trait named:*'
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCTraitParser >> addDefinitionsTo: aCollection [
 
 	| node compositionIndex categoryIndex slotsIndex traitName traitCompositionString slotsArray argumentNode categoryString definition |

--- a/src/Monticello/MCVariableDefinition.class.st
+++ b/src/Monticello/MCVariableDefinition.class.st
@@ -2,77 +2,79 @@
 A MCVariableDefinition represents a variable.
 "
 Class {
-	#name : #MCVariableDefinition,
-	#superclass : #Object,
+	#name : 'MCVariableDefinition',
+	#superclass : 'Object',
 	#instVars : [
 		'name'
 	],
-	#category : #'Monticello-Modeling'
+	#category : 'Monticello-Modeling',
+	#package : 'Monticello',
+	#tag : 'Modeling'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCVariableDefinition class >> name: aString [
 	^ self new name: aString
 	
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCVariableDefinition >> = other [
 	^ (self species = other species)
 		and: [self name = other name]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCVariableDefinition >> hash [
 	^ name hash
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCVariableDefinition >> isClassInstanceVariable [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCVariableDefinition >> isClassInstanceVariableDefinition [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCVariableDefinition >> isClassVariable [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCVariableDefinition >> isInstanceVariable [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCVariableDefinition >> isInstanceVariableDefinition [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCVariableDefinition >> isOrderDependend [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCVariableDefinition >> isPoolImport [
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVariableDefinition >> name [
 	^ name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVariableDefinition >> name: aString [
 	name := aString
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCVariableDefinition >> printOn: aStream [
 	super printOn: aStream.
 	aStream nextPut: $(; nextPutAll: self name; nextPut: $)

--- a/src/Monticello/MCVersion.class.st
+++ b/src/Monticello/MCVersion.class.st
@@ -2,8 +2,8 @@
 A Metacello version
 "
 Class {
-	#name : #MCVersion,
-	#superclass : #Object,
+	#name : 'MCVersion',
+	#superclass : 'Object',
 	#instVars : [
 		'package',
 		'info',
@@ -11,40 +11,42 @@ Class {
 		'dependencies',
 		'completeSnapshot'
 	],
-	#category : #'Monticello-Versioning'
+	#category : 'Monticello-Versioning',
+	#package : 'Monticello',
+	#tag : 'Versioning'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCVersion class >> package: aPackage [
 	^ self package: aPackage info: MCVersionInfo new
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCVersion class >> package: aPackage info: aVersionInfo [
 	^ self package: aPackage info: aVersionInfo snapshot: aPackage snapshot
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCVersion class >> package: aPackage info: aVersionInfo snapshot: aSnapshot [
 	^ self package: aPackage info: aVersionInfo snapshot: aSnapshot dependencies: #()
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCVersion class >> package: aPackage info: aVersionInfo snapshot: aSnapshot dependencies: aCollection [
 	^ self new initializeWithPackage: aPackage info: aVersionInfo snapshot: aSnapshot dependencies: aCollection
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCVersion >> addToCache [
 	MCCacheRepository uniqueInstance storeVersion: self
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCVersion >> adopt [
 	self workingCopy adopt: self
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 MCVersion >> allAvailableDependenciesDo: aBlock [
 	
 	self dependencies do:
@@ -55,19 +57,19 @@ MCVersion >> allAvailableDependenciesDo: aBlock [
 			on: Error do: []]
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 MCVersion >> allDependenciesDo: aBlock [
 	self allDependenciesDo: aBlock ifUnresolved: [:ignored | true]
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 MCVersion >> allDependenciesDo: aBlock ifUnresolved: failBlock [
 	| dict |
 	dict := Dictionary new.
 	self allDependenciesNotIn: dict do: aBlock ifUnresolved: failBlock
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 MCVersion >> allDependenciesNotIn: aDictionary do: aBlock ifUnresolved: failBlock [
 	
 	self dependencies do: 
@@ -84,7 +86,7 @@ MCVersion >> allDependenciesNotIn: aDictionary do: aBlock ifUnresolved: failBloc
 						aBlock value: version]]]
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 MCVersion >> asDiffAgainst: aVersion [
 	aVersion info = self info ifTrue: [self error: 'Cannot diff against self!'].
 	^ MCDiffyVersion
@@ -95,49 +97,49 @@ MCVersion >> asDiffAgainst: aVersion [
 		baseVersion: aVersion
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCVersion >> canOptimizeLoading [
 	"Answer wether I can provide a patch for the working copy without the usual diff pass"
 	^false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersion >> changes [
 	^ self completeSnapshot patchRelativeToBase: self completePackageSnapshot
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersion >> completePackageSnapshot [
 	"Answer with a snapshot of current working copy of this package and all its dependencies."
 	^self loadCompletePackageSnapshot
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersion >> completeSnapshot [
 	^ completeSnapshot ifNil: [ completeSnapshot := self loadCompleteSnapshot ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersion >> dependencies [
 	^ dependencies ifNil: [#()]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersion >> fileName [
 	^ info name, '.', self writerClass extension
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCVersion >> fileOutOn: aStream [
 	self writerClass fileOut: self on: aStream
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersion >> info [
 	^ info
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCVersion >> initializeWithPackage: aPackage info: aVersionInfo snapshot: aSnapshot dependencies: aCollection [
 	package := aPackage.
 	info := aVersionInfo.
@@ -146,22 +148,22 @@ MCVersion >> initializeWithPackage: aPackage info: aVersionInfo snapshot: aSnaps
 	self addToCache.
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCVersion >> isCacheable [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCVersion >> isDiffy [
 	^ false
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCVersion >> load [
 	MCVersionLoader loadVersion: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersion >> loadCompletePackageSnapshot [
 	| definitions |
 	definitions := OrderedCollection withAll: package snapshot definitions.
@@ -175,7 +177,7 @@ MCVersion >> loadCompletePackageSnapshot [
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersion >> loadCompleteSnapshot [
 	|definitions|
 	
@@ -188,23 +190,23 @@ MCVersion >> loadCompleteSnapshot [
 	^ MCSnapshot fromDefinitions: definitions
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCVersion >> merge [
 	MCVersionMerger mergeVersion: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersion >> package [
 	^ package
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCVersion >> printOn: aStream [
 	super printOn: aStream.
 	aStream nextPut: $(; print: self info; nextPut: $).
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCVersion >> setPackage: aPackage info: aVersionInfo snapshot: aSnapshot dependencies: aCollection [
 	package := aPackage.
 	info := aVersionInfo.
@@ -212,7 +214,7 @@ MCVersion >> setPackage: aPackage info: aVersionInfo snapshot: aSnapshot depende
 	dependencies := aCollection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersion >> snapshot [
 	"lazily load snapshot..."
 	snapshot isBlock ifTrue: [ 
@@ -220,7 +222,7 @@ MCVersion >> snapshot [
 	^ snapshot
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersion >> summary [
 	^ String streamContents:
 		[:s |
@@ -233,13 +235,13 @@ MCVersion >> summary [
 		s cr; cr; nextPutAll: info message]
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 MCVersion >> withAllDependenciesDo: aBlock [
 	self allDependenciesDo: aBlock ifUnresolved: [:ignored |].
 	aBlock value: self
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 MCVersion >> withAllDependenciesDo: aBlock ifUnresolved: failBlock [
 	| dict |
 	dict := Dictionary new.
@@ -247,12 +249,12 @@ MCVersion >> withAllDependenciesDo: aBlock ifUnresolved: failBlock [
 	aBlock value: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersion >> workingCopy [
 	^ package workingCopy
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersion >> writerClass [
 	^ MCMczWriter 
 ]

--- a/src/Monticello/MCVersionDependency.class.st
+++ b/src/Monticello/MCVersionDependency.class.st
@@ -2,68 +2,70 @@
 Dependencies
 "
 Class {
-	#name : #MCVersionDependency,
-	#superclass : #Object,
+	#name : 'MCVersionDependency',
+	#superclass : 'Object',
 	#instVars : [
 		'package',
 		'versionInfo'
 	],
-	#category : #'Monticello-Versioning'
+	#category : 'Monticello-Versioning',
+	#package : 'Monticello',
+	#tag : 'Versioning'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCVersionDependency class >> package: aPackage info: aVersionInfo [
 	^ self basicNew initializeWithPackage: aPackage info: aVersionInfo
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCVersionDependency >> = other [
 	^ other species = self species
 		and: [other versionInfo = versionInfo
 				and: [other package = package]]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCVersionDependency >> hash [
 	^ versionInfo hash
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCVersionDependency >> initializeWithPackage: aPackage info: aVersionInfo [
 	package := aPackage.
 	versionInfo := aVersionInfo
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCVersionDependency >> isCurrent [
 	^ package hasWorkingCopy
 		and: [self isFulfilled
 			and: [package workingCopy modified not]]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCVersionDependency >> isFulfilled [
 	^package hasWorkingCopy
 		and: [self isFulfilledBy: package workingCopy ancestry]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCVersionDependency >> isFulfilledBy: anAncestry [
 	^ anAncestry ancestors includes: versionInfo
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCVersionDependency >> isFulfilledByAncestors [
 	^ package hasWorkingCopy
 		and: [self isFulfilledByAncestorsOf: package workingCopy ancestry]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCVersionDependency >> isFulfilledByAncestorsOf: anAncestry [
 	^ anAncestry hasAncestor: versionInfo
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCVersionDependency >> isOlder [
 	"Answer true if I represent an older version of a package that is loaded."
 	^ package hasWorkingCopy
@@ -72,24 +74,24 @@ MCVersionDependency >> isOlder [
 				and: [package workingCopy modified not]]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionDependency >> package [
 	^ package
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionDependency >> repositoryGroup [
 	^ self package workingCopy repositoryGroup
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 MCVersionDependency >> resolve [
 	^ self repositoryGroup
 		versionWithInfo: versionInfo
 		ifNone: [ MCRepositoryGroup default versionWithInfo: versionInfo ifNone: []]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionDependency >> versionInfo [
 	^ versionInfo
 ]

--- a/src/Monticello/MCVersionInfo.class.st
+++ b/src/Monticello/MCVersionInfo.class.st
@@ -2,8 +2,8 @@
 Adds to the record of ancestry, other identifying details.
 "
 Class {
-	#name : #MCVersionInfo,
-	#superclass : #MCAncestry,
+	#name : 'MCVersionInfo',
+	#superclass : 'MCAncestry',
 	#instVars : [
 		'id',
 		'name',
@@ -12,10 +12,12 @@ Class {
 		'time',
 		'author'
 	],
-	#category : #'Monticello-Versioning'
+	#category : 'Monticello-Versioning',
+	#package : 'Monticello',
+	#tag : 'Versioning'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCVersionInfo class >> name: vName id: id message: message date: date time: time author: author ancestors: ancestors [
 	^ self 
 		name: vName
@@ -28,7 +30,7 @@ MCVersionInfo class >> name: vName id: id message: message date: date time: time
 		stepChildren: #()
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCVersionInfo class >> name: vName id: id message: message date: date time: time author: author ancestors: ancestors stepChildren: stepChildren [
 	^ self new
 		initializeWithName: vName
@@ -41,13 +43,13 @@ MCVersionInfo class >> name: vName id: id message: message date: date time: time
 		stepChildren: stepChildren
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCVersionInfo >> = other [
 	^ other species = self species
 		and: [other hasID: id]
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 MCVersionInfo >> asDictionary [
 	^ Dictionary new
 		at: #name put: name;
@@ -60,37 +62,37 @@ MCVersionInfo >> asDictionary [
 		yourself
 ]
 
-{ #category : #pillaging }
+{ #category : 'pillaging' }
 MCVersionInfo >> author [
 	^ author
 ]
 
-{ #category : #pillaging }
+{ #category : 'pillaging' }
 MCVersionInfo >> date [
 	^ date
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCVersionInfo >> displayStringOn: stream [
 	stream nextPutAll: self name
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCVersionInfo >> hasID: aUUID [
 	^ id = aUUID
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCVersionInfo >> hash [
 	^ id hash
 ]
 
-{ #category : #pillaging }
+{ #category : 'pillaging' }
 MCVersionInfo >> id [
 	^ id 
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCVersionInfo >> initializeWithName: vName id: aUUID message: aString date: aDate time: aTime author: initials ancestors: aCollection stepChildren: stepCollection [
 	name := vName.
 	id := aUUID.
@@ -102,12 +104,12 @@ MCVersionInfo >> initializeWithName: vName id: aUUID message: aString date: aDat
 	stepChildren := stepCollection
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCVersionInfo >> lazy [
 	^ MCLazyVersionInfo from: self
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCVersionInfo >> loadAncestorsAndStepChildren [
 	"This code scans all the repositories to find the exact package version and reload the relevant info."
 
@@ -126,17 +128,17 @@ MCVersionInfo >> loadAncestorsAndStepChildren [
 			self setStepChildren: aVersion info stepChildren ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionInfo >> message [
 	^ message ifNil: ['']
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionInfo >> name [
 	^ name ifNil: ['<working copy>']
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionInfo >> nameWithout: packageName [
 	| result |
 	result := self name.
@@ -145,14 +147,14 @@ MCVersionInfo >> nameWithout: packageName [
 	^result
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCVersionInfo >> printOn: aStream [
 	super printOn: aStream.
 	aStream nextPut: $(; nextPutAll: self name; nextPut: $)
 	
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCVersionInfo >> setAncestors: someAncestors [
 	"Unused in MCVersionInfo"
 
@@ -161,7 +163,7 @@ MCVersionInfo >> setAncestors: someAncestors [
 	ancestors := someAncestors
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCVersionInfo >> setStepChildren: someStepChildren [
 	"Unused in MCVersionInfo"
 
@@ -170,7 +172,7 @@ MCVersionInfo >> setStepChildren: someStepChildren [
 	stepChildren := someStepChildren
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionInfo >> summary [
 	^ String streamContents:
 		[:s |
@@ -180,7 +182,7 @@ MCVersionInfo >> summary [
 		]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionInfo >> summaryHeader [
 	^ String streamContents:
 		[:s |
@@ -199,22 +201,22 @@ MCVersionInfo >> summaryHeader [
 		]
 ]
 
-{ #category : #pillaging }
+{ #category : 'pillaging' }
 MCVersionInfo >> time [
 	^ time
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionInfo >> timeStamp [
 	^ DateAndTime date: date time: time
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionInfo >> timeString [
 	^ date asString, ', ', time asString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionInfo >> versionNumber [
 	^ ((self name copyAfterLast: $-) copyAfter: $.) asInteger
 ]

--- a/src/Monticello/MCVersionInfoWriter.class.st
+++ b/src/Monticello/MCVersionInfoWriter.class.st
@@ -4,20 +4,22 @@ If the version info has been serialized before I output a compacted version cons
 
 "
 Class {
-	#name : #MCVersionInfoWriter,
-	#superclass : #MCWriter,
+	#name : 'MCVersionInfoWriter',
+	#superclass : 'MCWriter',
 	#instVars : [
 		'written'
 	],
-	#category : #'Monticello-Storing'
+	#category : 'Monticello-Storing',
+	#package : 'Monticello',
+	#tag : 'Storing'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCVersionInfoWriter >> isWritten: aVersionInfo [
 	^ self written includes: aVersionInfo
 ]
 
-{ #category : #serialization }
+{ #category : 'serialization' }
 MCVersionInfoWriter >> writeVersionInfo: aVersionInfo [
 	(self isWritten: aVersionInfo)
 		ifTrue: [^ stream nextPutAll: '(id '; print: aVersionInfo id asString; nextPut: $) ].
@@ -35,12 +37,12 @@ MCVersionInfoWriter >> writeVersionInfo: aVersionInfo [
 	self wrote: aVersionInfo
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionInfoWriter >> written [
 	^ written ifNil: [written := Set new]
 ]
 
-{ #category : #serialization }
+{ #category : 'serialization' }
 MCVersionInfoWriter >> wrote: aVersionInfo [
 	self written add: aVersionInfo
 ]

--- a/src/Monticello/MCVersionLoader.class.st
+++ b/src/Monticello/MCVersionLoader.class.st
@@ -2,22 +2,24 @@
 A MCVersionLoader is responsible for loading a given version. 
 "
 Class {
-	#name : #MCVersionLoader,
-	#superclass : #Object,
+	#name : 'MCVersionLoader',
+	#superclass : 'Object',
 	#instVars : [
 		'versions'
 	],
-	#category : #'Monticello-Loading'
+	#category : 'Monticello-Loading',
+	#package : 'Monticello',
+	#tag : 'Loading'
 }
 
-{ #category : #'public api' }
+{ #category : 'public api' }
 MCVersionLoader class >> loadVersion: aVersion [
 	self new
 		addVersion: aVersion;
 		load
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MCVersionLoader >> addDependency: aDependency [
 	| dep |
 	aDependency isCurrent ifTrue: [^ self].
@@ -28,14 +30,14 @@ MCVersionLoader >> addDependency: aDependency [
 		ifNotNil: [(versions includes: dep) ifFalse: [self addVersion: dep]]
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MCVersionLoader >> addVersion: aVersion [
 	aVersion dependencies do: [ :ea | self addDependency: ea].
 	versions add: aVersion.
 
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCVersionLoader >> announceLoad: aString do: aBlock [
 	| returnValue |
 	returnValue := nil.
@@ -45,7 +47,7 @@ MCVersionLoader >> announceLoad: aString do: aBlock [
 	^ returnValue
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCVersionLoader >> announceLoadStart: aString [
 	SystemAnnouncer announce: (MCVersionLoaderStarted new
 		versionLoader: self;
@@ -53,7 +55,7 @@ MCVersionLoader >> announceLoadStart: aString [
 		yourself)
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCVersionLoader >> announceLoadStop: aString [
 	SystemAnnouncer announce: (MCVersionLoaderStopped new
 		versionLoader: self;
@@ -61,7 +63,7 @@ MCVersionLoader >> announceLoadStop: aString [
 		yourself)
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCVersionLoader >> basicLoadWithNameLike: aString [
 	| loader |
 	
@@ -80,7 +82,7 @@ MCVersionLoader >> basicLoadWithNameLike: aString [
 	versions do: [:ea | ea workingCopy loaded: ea]
 ]
 
-{ #category : #checking }
+{ #category : 'checking' }
 MCVersionLoader >> checkForModificationsIfCancel: cancelBlock ifMerge: mergeBlock [
 	| modifications |
 	
@@ -92,13 +94,13 @@ MCVersionLoader >> checkForModificationsIfCancel: cancelBlock ifMerge: mergeBloc
 	^ self warnAboutLosingChangesTo: modifications ifCancel: cancelBlock ifMerge: mergeBlock
 ]
 
-{ #category : #checking }
+{ #category : 'checking' }
 MCVersionLoader >> checkIfDepIsOlder: aDependency [
 	^ aDependency isOlder not 
 		or: [self confirm: 'load older dependency ', aDependency versionInfo name , '?']
 ]
 
-{ #category : #checking }
+{ #category : 'checking' }
 MCVersionLoader >> confirmMissingDependency: aDependency [
 	| name |
 	name := aDependency versionInfo name.
@@ -106,37 +108,37 @@ MCVersionLoader >> confirmMissingDependency: aDependency [
 		ifFalse: [self error: 'Can''t find dependency ', name]
 ]
 
-{ #category : #checking }
+{ #category : 'checking' }
 MCVersionLoader >> depAgeIsOk: aDependency [
 	^ aDependency isOlder not 
 		or: [self confirm: 'load older dependency ', aDependency versionInfo name , '?']
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCVersionLoader >> ensurePackage: mcPackage [ 
 	self packageOrganizer ensurePackage: mcPackage name 
 		
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCVersionLoader >> hasLocalModifications [
 	^ self localModifications isEmpty not
 	
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCVersionLoader >> hasVersions [
 
 	^ versions isEmpty not
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCVersionLoader >> initialize [
 	super initialize.
 	versions := OrderedCollection new
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MCVersionLoader >> load [
 	RPackageSet withCacheDo: [   
 		| version |
@@ -147,19 +149,19 @@ MCVersionLoader >> load [
 				run ]
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MCVersionLoader >> loadWithNameLike: aString [
 	" this is THE central entrypoint for all loading (gopher, metacello, monticello, ...) "
 	^ self announceLoad: aString do: [ self basicLoadWithNameLike: aString ]
 ]
 
-{ #category : #checking }
+{ #category : 'checking' }
 MCVersionLoader >> localModifications [
 	^ versions select: [:ea | ea package workingCopy modified].
 	
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MCVersionLoader >> mergeVersions [
 	|merger|
 	merger :=  MCVersionMerger new.
@@ -167,7 +169,7 @@ MCVersionLoader >> mergeVersions [
 	merger merge.
 ]
 
-{ #category : #checking }
+{ #category : 'checking' }
 MCVersionLoader >> warnAboutLosingChangesTo: versionCollection ifCancel: cancelBlock ifMerge: mergeBlock [
 	
 	| result |

--- a/src/Monticello/MCVersionLoaderStarted.class.st
+++ b/src/Monticello/MCVersionLoaderStarted.class.st
@@ -2,31 +2,33 @@
 Announcement sent when a Version is starting to load
 "
 Class {
-	#name : #MCVersionLoaderStarted,
-	#superclass : #Announcement,
+	#name : 'MCVersionLoaderStarted',
+	#superclass : 'Announcement',
 	#instVars : [
 		'versionLoader',
 		'label'
 	],
-	#category : #'Monticello-Announcements'
+	#category : 'Monticello-Announcements',
+	#package : 'Monticello',
+	#tag : 'Announcements'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionLoaderStarted >> label [
 	^ label
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionLoaderStarted >> label: anObject [
 	label := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionLoaderStarted >> versionLoader [
 	^ versionLoader
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionLoaderStarted >> versionLoader: anObject [
 	versionLoader := anObject
 ]

--- a/src/Monticello/MCVersionLoaderStopped.class.st
+++ b/src/Monticello/MCVersionLoaderStopped.class.st
@@ -2,31 +2,33 @@
 Announcement sent when a Version has finished loading
 "
 Class {
-	#name : #MCVersionLoaderStopped,
-	#superclass : #Announcement,
+	#name : 'MCVersionLoaderStopped',
+	#superclass : 'Announcement',
 	#instVars : [
 		'versionLoader',
 		'label'
 	],
-	#category : #'Monticello-Announcements'
+	#category : 'Monticello-Announcements',
+	#package : 'Monticello',
+	#tag : 'Announcements'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionLoaderStopped >> label [
 	^ label
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionLoaderStopped >> label: anObject [
 	label := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionLoaderStopped >> versionLoader [
 	^ versionLoader
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionLoaderStopped >> versionLoader: anObject [
 	versionLoader := anObject
 ]

--- a/src/Monticello/MCVersionMerger.class.st
+++ b/src/Monticello/MCVersionMerger.class.st
@@ -2,23 +2,25 @@
 Merge versions
 "
 Class {
-	#name : #MCVersionMerger,
-	#superclass : #Object,
+	#name : 'MCVersionMerger',
+	#superclass : 'Object',
 	#instVars : [
 		'records',
 		'merger'
 	],
-	#category : #'Monticello-Versioning'
+	#category : 'Monticello-Versioning',
+	#package : 'Monticello',
+	#tag : 'Versioning'
 }
 
-{ #category : #action }
+{ #category : 'action' }
 MCVersionMerger class >> mergeVersion: aVersion [
 	self new
 		addVersion: aVersion;
 		mergeWithNameLike: aVersion info name
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 MCVersionMerger >> addVersion: aVersion [
 	
 	records add: (MCMergeRecord version: aVersion).
@@ -30,26 +32,26 @@ MCVersionMerger >> addVersion: aVersion [
 		displayingProgress: [ :ea| 'Searching dependency: ', ea package name]
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 MCVersionMerger >> addVersions: aCollection [
 	aCollection do: [ :version|
 		self addVersion: version].
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCVersionMerger >> gatherChanges [
 	records do: [:ea | merger addBaseSnapshot: ea packageSnapshot].
 	records do: [:ea | merger applyPatch: ea mergePatch].
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCVersionMerger >> initialize [
 	super initialize.
 	records := OrderedCollection new.
 	merger := MCThreeWayMerger new.
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCVersionMerger >> merge [
 
 	self gatherChanges.
@@ -62,7 +64,7 @@ MCVersionMerger >> merge [
 	^ false
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCVersionMerger >> mergeWithNameLike: baseName [
 
 	self gatherChanges.
@@ -72,7 +74,7 @@ MCVersionMerger >> mergeWithNameLike: baseName [
 		records do: [:ea | ea updateWorkingCopy]].
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCVersionMerger >> resolveConflicts [
 	(records allSatisfy: [:ea | ea isAncestorMerge]) 
 		ifTrue: [

--- a/src/Monticello/MCVersionNameAndMessageRequest.class.st
+++ b/src/Monticello/MCVersionNameAndMessageRequest.class.st
@@ -2,33 +2,35 @@
 Notify to requests for version name and message
 "
 Class {
-	#name : #MCVersionNameAndMessageRequest,
-	#superclass : #Notification,
+	#name : 'MCVersionNameAndMessageRequest',
+	#superclass : 'Notification',
 	#instVars : [
 		'suggestion',
 		'suggestedLogComment'
 	],
-	#category : #'Monticello-Versioning'
+	#category : 'Monticello-Versioning',
+	#package : 'Monticello',
+	#tag : 'Versioning'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionNameAndMessageRequest >> suggestedLogComment [
 
 	^ suggestedLogComment
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionNameAndMessageRequest >> suggestedLogComment: aLogMessage [
 
 	suggestedLogComment := aLogMessage
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionNameAndMessageRequest >> suggestedName [
 	^ suggestion
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionNameAndMessageRequest >> suggestedName: aString [
 	suggestion := aString
 ]

--- a/src/Monticello/MCVersionReader.class.st
+++ b/src/Monticello/MCVersionReader.class.st
@@ -2,25 +2,27 @@
 A version reader
 "
 Class {
-	#name : #MCVersionReader,
-	#superclass : #MCReader,
+	#name : 'MCVersionReader',
+	#superclass : 'MCReader',
 	#instVars : [
 		'package',
 		'info',
 		'definitions',
 		'dependencies'
 	],
-	#category : #'Monticello-Storing'
+	#category : 'Monticello-Storing',
+	#package : 'Monticello',
+	#tag : 'Storing'
 }
 
-{ #category : #reading }
+{ #category : 'reading' }
 MCVersionReader class >> file: fileName streamDo: aBlock [
 	
 	^ fileName asFileReference
 		readStreamDo: [ :file | aBlock value: file]
 ]
 
-{ #category : #'actions - file' }
+{ #category : 'actions - file' }
 MCVersionReader class >> loadVersionFile: fileName [
 	| version |
 	version := self versionFromFile: fileName.
@@ -30,37 +32,37 @@ MCVersionReader class >> loadVersionFile: fileName [
 
 ]
 
-{ #category : #'actions - file' }
+{ #category : 'actions - file' }
 MCVersionReader class >> mergeVersionFile: fileName [
 	(self versionFromFile: fileName) merge
 ]
 
-{ #category : #reading }
+{ #category : 'reading' }
 MCVersionReader class >> on: s fileName: f [
 	^ self on: s
 ]
 
-{ #category : #'actions - file' }
+{ #category : 'actions - file' }
 MCVersionReader class >> openVersionFile: fileName [
 	(self versionFromFile: fileName) open
 ]
 
-{ #category : #reading }
+{ #category : 'reading' }
 MCVersionReader class >> versionFromFile: fileName [
 	^ self file: fileName streamDo: [:stream | self versionFromStream: stream]
 ]
 
-{ #category : #reading }
+{ #category : 'reading' }
 MCVersionReader class >> versionFromStream: aStream [
 	^ (self on: aStream) version
 ]
 
-{ #category : #reading }
+{ #category : 'reading' }
 MCVersionReader class >> versionInfoFromStream: aStream [
 	^ (self on: aStream) info
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionReader >> basicVersion [
 
 	^ MCVersion
@@ -70,56 +72,56 @@ MCVersionReader >> basicVersion [
 		  dependencies: self dependencies
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionReader >> definitions [
 	definitions ifNil: [self loadDefinitions].
 	^ definitions
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionReader >> dependencies [
 	dependencies ifNil: [self loadDependencies].
 	^ dependencies
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionReader >> info [
 	info ifNil: [self loadVersionInfo].
 	^ info
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MCVersionReader >> loadDefinitions [
 	self subclassResponsibility 
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MCVersionReader >> loadDependencies [
 	self subclassResponsibility 
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MCVersionReader >> loadPackage [
 	self subclassResponsibility 
 ]
 
-{ #category : #loading }
+{ #category : 'loading' }
 MCVersionReader >> loadVersionInfo [
 	self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionReader >> package [
 	package ifNil: [self loadPackage].
 	^ package
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionReader >> snapshot [
 	^ MCSnapshot fromDefinitions: self definitions
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionReader >> version [
 	^ self basicVersion
 ]

--- a/src/Monticello/MCVersionSaved.class.st
+++ b/src/Monticello/MCVersionSaved.class.st
@@ -2,16 +2,18 @@
 I announce that a MCVersion was saved into a MCRepository.
 "
 Class {
-	#name : #MCVersionSaved,
-	#superclass : #Announcement,
+	#name : 'MCVersionSaved',
+	#superclass : 'Announcement',
 	#instVars : [
 		'version',
 		'repository'
 	],
-	#category : #'Monticello-Announcements'
+	#category : 'Monticello-Announcements',
+	#package : 'Monticello',
+	#tag : 'Announcements'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCVersionSaved class >> version: aMCVersion repository: aMCRepository [
 
 	^ self basicNew
@@ -20,7 +22,7 @@ MCVersionSaved class >> version: aMCVersion repository: aMCRepository [
 		yourself
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCVersionSaved >> = another [
 
 	^ (self class = another class
@@ -28,7 +30,7 @@ MCVersionSaved >> = another [
 		and: [ self repository = another repository ]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 MCVersionSaved >> hash [
 
 	^ (self class hash
@@ -36,7 +38,7 @@ MCVersionSaved >> hash [
 		bitXor: self repository hash
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCVersionSaved >> initializeWithVersion: aMCVersion repository: aMCRepository [
 
 	self initialize.
@@ -45,7 +47,7 @@ MCVersionSaved >> initializeWithVersion: aMCVersion repository: aMCRepository [
 	repository := aMCRepository.
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCVersionSaved >> printOn: aStream [
 
 	super printOn: aStream.
@@ -58,13 +60,13 @@ MCVersionSaved >> printOn: aStream [
 		nextPut: $).
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionSaved >> repository [
 
 	^ repository
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionSaved >> version [
 
 	^ version

--- a/src/Monticello/MCVersionSorter.class.st
+++ b/src/Monticello/MCVersionSorter.class.st
@@ -2,8 +2,8 @@
 Sort versions
 "
 Class {
-	#name : #MCVersionSorter,
-	#superclass : #Object,
+	#name : 'MCVersionSorter',
+	#superclass : 'Object',
 	#instVars : [
 		'layers',
 		'depthIndex',
@@ -11,10 +11,12 @@ Class {
 		'stepparents',
 		'roots'
 	],
-	#category : #'Monticello-Versioning'
+	#category : 'Monticello-Versioning',
+	#package : 'Monticello',
+	#tag : 'Versioning'
 }
 
-{ #category : #adding }
+{ #category : 'adding' }
 MCVersionSorter >> addAllAncestorsOf: aVersionInfo to: aSet [
 	(aSet includes: aVersionInfo) ifTrue: [^ self].
 	aSet add: aVersionInfo.
@@ -23,12 +25,12 @@ MCVersionSorter >> addAllAncestorsOf: aVersionInfo to: aSet [
 		self addAllAncestorsOf: ea to: aSet]
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 MCVersionSorter >> addAllVersionInfos: aCollection [
 	aCollection do: [:ea | self addVersionInfo: ea]
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 MCVersionSorter >> addToCurrentLayer: aVersionInfo [
 	| layer |
 	layer := layers at: depthIndex.
@@ -44,13 +46,13 @@ MCVersionSorter >> addToCurrentLayer: aVersionInfo [
 	^ false 
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 MCVersionSorter >> addVersionInfo: aVersionInfo [
 	roots add: aVersionInfo.
 	self registerStepChildrenOf: aVersionInfo seen: Set new
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionSorter >> allAncestorsOf: aVersionInfo [
 	| all |
 	all := Set new.
@@ -58,29 +60,29 @@ MCVersionSorter >> allAncestorsOf: aVersionInfo [
 	^ all
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCVersionSorter >> initialize [
 	super initialize.
 	stepparents := Dictionary new.
 	roots := OrderedCollection new.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionSorter >> knownAncestorsOf: aVersionInfo [
 	^ aVersionInfo ancestors, (self stepParentsOf: aVersionInfo) asArray
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionSorter >> layers [
 	^ layers
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCVersionSorter >> popLayer [
 	depthIndex := depthIndex - 1
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCVersionSorter >> processVersionInfo: aVersionInfo [
 	(self addToCurrentLayer: aVersionInfo) ifTrue:
 		[self pushLayer.
@@ -89,14 +91,14 @@ MCVersionSorter >> processVersionInfo: aVersionInfo [
 
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCVersionSorter >> pushLayer [
 	depthIndex := depthIndex + 1.
 	depthIndex > layers size ifTrue: [layers add: OrderedCollection new].
 	
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCVersionSorter >> registerStepChildrenOf: aVersionInfo seen: aSet [
 	(aSet includes: aVersionInfo) ifTrue: [^ self].
 	aSet add: aVersionInfo.
@@ -104,7 +106,7 @@ MCVersionSorter >> registerStepChildrenOf: aVersionInfo seen: aSet [
 	aVersionInfo ancestors do: [:ea | self registerStepChildrenOf: ea seen: aSet].
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionSorter >> sortedVersionInfos [
 	layers := OrderedCollection with: OrderedCollection new.
 	depthIndex := 1.
@@ -113,7 +115,7 @@ MCVersionSorter >> sortedVersionInfos [
 	^ layers flatCollect: [:ea | ea]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCVersionSorter >> stepParentsOf: aVersionInfo [
 	^ (stepparents at: aVersionInfo ifAbsentPut: [Set new])
 ]

--- a/src/Monticello/MCWorkingAncestry.class.st
+++ b/src/Monticello/MCWorkingAncestry.class.st
@@ -2,27 +2,29 @@
 The interim record of ancestry for a working copy, gets merged version added to the ancestry, and is used to create the VersionInfo when the working copy becomes a version. 
 "
 Class {
-	#name : #MCWorkingAncestry,
-	#superclass : #MCAncestry,
-	#category : #'Monticello-Versioning'
+	#name : 'MCWorkingAncestry',
+	#superclass : 'MCAncestry',
+	#category : 'Monticello-Versioning',
+	#package : 'Monticello',
+	#tag : 'Versioning'
 }
 
-{ #category : #adding }
+{ #category : 'adding' }
 MCWorkingAncestry >> addAncestor: aNode [
 	ancestors := (self ancestors reject: [ :each | aNode hasAncestor: each ]) copyWith: aNode lazy
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 MCWorkingAncestry >> addStepChild: aVersionInfo [
 	stepChildren := stepChildren copyWith: aVersionInfo lazy
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingAncestry >> ancestors: anObject [
 	ancestors := anObject collect: [ :a | a lazy ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingAncestry >> infoWithName: nameString message: messageString [
 	^ MCVersionInfo
 		name: nameString
@@ -35,17 +37,17 @@ MCWorkingAncestry >> infoWithName: nameString message: messageString [
 		stepChildren: self stepChildren asArray
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCWorkingAncestry >> lazy [
 	^ self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingAncestry >> name [
 	^ '<working copy>'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingAncestry >> summary [
 	^ 'Ancestors: ', self ancestorString
 ]

--- a/src/Monticello/MCWorkingCopy.class.st
+++ b/src/Monticello/MCWorkingCopy.class.st
@@ -17,8 +17,8 @@ Class Instance Variables:
 	registry	<Dictionary>
 "
 Class {
-	#name : #MCWorkingCopy,
-	#superclass : #Model,
+	#name : 'MCWorkingCopy',
+	#superclass : 'Model',
 	#instVars : [
 		'ancestry',
 		'counter',
@@ -33,15 +33,17 @@ Class {
 	#classInstVars : [
 		'registry'
 	],
-	#category : #'Monticello-Versioning'
+	#category : 'Monticello-Versioning',
+	#package : 'Monticello',
+	#tag : 'Versioning'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy class >> allWorkingCopies [
 	^ self registry values
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCWorkingCopy class >> ancestorsFromArray: anArray cache: cacheDictionary [
 	"While using recursion is simpler, it runs a risk of stack overflow for packages with many ancestors,
 	 so we use a local stack to pre-load the cache in reverse order. 
@@ -67,29 +69,29 @@ MCWorkingCopy class >> ancestorsFromArray: anArray cache: cacheDictionary [
 	^ anArray collect: [:dict | self infoFromDictionary: dict cache: cacheDictionary]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCWorkingCopy class >> announcer [
 	^PrivateAnnouncer ifNil: [ SystemAnnouncer uniqueInstance  ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCWorkingCopy class >> announcer: anAnnouncer [
 	PrivateAnnouncer := anAnnouncer
 ]
 
-{ #category : #'system changes' }
+{ #category : 'system changes' }
 MCWorkingCopy class >> classModified: anEvent [
 
 	self workingCopiesForClass: anEvent classAffected do: [ :wc | wc modified: true ]
 ]
 
-{ #category : #'system changes' }
+{ #category : 'system changes' }
 MCWorkingCopy class >> classMoved: anEvent [
 	self workingCopiesForPackage: anEvent oldPackage do: [ :mgr | mgr modified: true ].
 	self workingCopiesForPackage: anEvent newPackage do: [ :mgr | mgr modified: true ].
 ]
 
-{ #category : #'system changes' }
+{ #category : 'system changes' }
 MCWorkingCopy class >> classRemoved: anEvent [
 	"Informs the registry who use to keep this class that its changed. Unlike #classModified:, class is not anymore in RPackages so it will not be found, that's why we look for system category instead if class is included or not"
 
@@ -102,26 +104,26 @@ MCWorkingCopy class >> classRemoved: anEvent [
 				package mcWorkingCopy ifNotNil: [ :workingCopy | workingCopy modified: true ] ] ] ]
 ]
 
-{ #category : #'system changes' }
+{ #category : 'system changes' }
 MCWorkingCopy class >> classRenamed: anEvent [
 
 	self classModified: anEvent.
 	anEvent classAffected extendingPackages do: [ :pkg | self workingCopiesForPackage: pkg do: [ :workingCopy | workingCopy modified: true ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy class >> ensureForPackage: aPackage [
 
 	^ self registry at: aPackage ifAbsent: [ self registerPackage: aPackage packageOrganizer: self packageOrganizer ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy class >> ensureForPackageNamed: aPackageName [
 
 	^ self ensureForPackageNamed: aPackageName packageOrganizer: self packageOrganizer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy class >> ensureForPackageNamed: aPackageName packageOrganizer: aPackageOrganizer [
 
 	^ (self hasPackageNamed: aPackageName)
@@ -129,13 +131,13 @@ MCWorkingCopy class >> ensureForPackageNamed: aPackageName packageOrganizer: aPa
 		  ifFalse: [ self registerPackage: (MCPackage named: aPackageName) packageOrganizer: aPackageOrganizer ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy class >> forPackage: aPackage [
 
 	^ self registry at: aPackage ifAbsent: [ NotFound signalFor: aPackage in: self ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy class >> forPackageNamed: aPackageName [
 
 	^ self registry values
@@ -143,13 +145,13 @@ MCWorkingCopy class >> forPackageNamed: aPackageName [
 		  ifNone: [ NotFound signalFor: aPackageName in: self ]
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 MCWorkingCopy class >> hasPackageNamed: aName [
 
 	^ self allWorkingCopies anySatisfy: [ :each | each packageName = aName ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCWorkingCopy class >> infoFromDictionary: aDictionary cache: cache [
 	| id |
 	id := (aDictionary at: #id) asString.
@@ -165,14 +167,14 @@ MCWorkingCopy class >> infoFromDictionary: aDictionary cache: cache [
 			stepChildren: (self ancestorsFromArray: (aDictionary at: #stepChildren ifAbsent: []) cache: cache)]
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 MCWorkingCopy class >> initialize [
 
 	registry ifNotNil: [ registry rehash ].
 	self registerForNotifications
 ]
 
-{ #category : #'system changes' }
+{ #category : 'system changes' }
 MCWorkingCopy class >> methodModified: anEvent [
 
 	"If the method has just been loaded by monticello itself, do not mark it as dirty"
@@ -184,32 +186,32 @@ MCWorkingCopy class >> methodModified: anEvent [
 	^ self workingCopiesForClass: anEvent methodClass protocol: anEvent protocol do: [ :wc | wc modified: true ]
 ]
 
-{ #category : #'system changes' }
+{ #category : 'system changes' }
 MCWorkingCopy class >> methodMoved: anEvent [
 
 	self workingCopiesForPackage: anEvent oldPackage do: [ :workingCopy | workingCopy modified: true ].
 	self workingCopiesForPackage: anEvent newPackage do: [ :workingCopy | workingCopy modified: true ]
 ]
 
-{ #category : #'system changes' }
+{ #category : 'system changes' }
 MCWorkingCopy class >> methodRemoved: anEvent [
 
 	self workingCopiesForClass: anEvent methodClass protocol: anEvent protocol do: [ :wc | wc modified: true ]
 ]
 
-{ #category : #'system changes' }
+{ #category : 'system changes' }
 MCWorkingCopy class >> packageAdded: anAnnouncement [
 
 	^ self ensureForPackageNamed: anAnnouncement package name packageOrganizer: anAnnouncement package organizer
 ]
 
-{ #category : #'system changes' }
+{ #category : 'system changes' }
 MCWorkingCopy class >> packageRemoved: anAnnouncement [
 
 	anAnnouncement package mcWorkingCopy ifNotNil: [ :wc | wc unregister ]
 ]
 
-{ #category : #'system changes' }
+{ #category : 'system changes' }
 MCWorkingCopy class >> packageRenamed: anAnnouncement [
 
 	| oldWorkingCopy |
@@ -223,7 +225,7 @@ MCWorkingCopy class >> packageRenamed: anAnnouncement [
 	oldWorkingCopy unload
 ]
 
-{ #category : #'event registration' }
+{ #category : 'event registration' }
 MCWorkingCopy class >> registerForNotifications [
 
 	<systemEventRegistration>
@@ -233,7 +235,7 @@ MCWorkingCopy class >> registerForNotifications [
 		registerInterestOnSystemChanges
 ]
 
-{ #category : #'event registration' }
+{ #category : 'event registration' }
 MCWorkingCopy class >> registerInterestOnSystemChanges [
 
 	SystemAnnouncer uniqueInstance weak
@@ -249,7 +251,7 @@ MCWorkingCopy class >> registerInterestOnSystemChanges [
 		when: MethodRemoved send: #methodRemoved: to: self
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCWorkingCopy class >> registerPackage: aPackage packageOrganizer: aPackageOrganizer [
 
 	| workingCopy |
@@ -263,24 +265,24 @@ MCWorkingCopy class >> registerPackage: aPackage packageOrganizer: aPackageOrgan
 	^ workingCopy
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy class >> registry [
 	^ registry ifNil: [registry := Dictionary new]
 ]
 
-{ #category : #'event registration' }
+{ #category : 'event registration' }
 MCWorkingCopy class >> unregisterForNotifications [
 
 	SystemAnnouncer uniqueInstance unsubscribe: self
 ]
 
-{ #category : #'system changes' }
+{ #category : 'system changes' }
 MCWorkingCopy class >> workingCopiesForClass: aClass do: aBlock [
 
 	^ self workingCopiesForPackage: aClass package do: aBlock
 ]
 
-{ #category : #'system changes' }
+{ #category : 'system changes' }
 MCWorkingCopy class >> workingCopiesForClass: aClass protocol: protocol do: aBlock [
 
 	protocol ifNil: [ ^ self ]. "This can happen, for example when a method recategorised is raised at a method removal."
@@ -290,7 +292,7 @@ MCWorkingCopy class >> workingCopiesForClass: aClass protocol: protocol do: aBlo
 	self workingCopiesForExtensionProtocol: protocol name allButFirst do: aBlock
 ]
 
-{ #category : #'system changes' }
+{ #category : 'system changes' }
 MCWorkingCopy class >> workingCopiesForExtensionProtocol: extensionName do: aBlock [
 
 	| packageName |
@@ -306,7 +308,7 @@ MCWorkingCopy class >> workingCopiesForExtensionProtocol: extensionName do: aBlo
 	aBlock value: (self ensureForPackageNamed: extensionName capitalized)
 ]
 
-{ #category : #'system changes' }
+{ #category : 'system changes' }
 MCWorkingCopy class >> workingCopiesForPackage: aPackage do: aBlock [
 
 	| packageName |
@@ -315,35 +317,35 @@ MCWorkingCopy class >> workingCopiesForPackage: aPackage do: aBlock [
 	self registry select: [ :workingCopy | workingCopy packageName = packageName ] thenDo: aBlock
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCWorkingCopy >> adopt: aVersion [
 	ancestry addAncestor: aVersion info.
 	self changed.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> allAncestors [
 	^ self versionInfo 
 		ifNotNil: [ :versionInfo | versionInfo allAncestors ]
 		ifNil: [ #() ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> ancestors [
 	^ ancestry ancestors
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> ancestry [
 	^ ancestry
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCWorkingCopy >> announcer [
 	^self class announcer
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCWorkingCopy >> backportChangesTo: aVersionInfo [
 	| baseVersion fullPatch currentVersionInfo currentVersion newSnapshot newAncestry |
 	currentVersionInfo := self currentVersionInfo.
@@ -365,17 +367,17 @@ MCWorkingCopy >> backportChangesTo: aVersionInfo [
 		self modified: false; modified: true]
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCWorkingCopy >> changesRelativeToRepository: aRepository [
 	^ self completeSnapshot patchRelativeToBase: (self closestAncestorSnapshotIn: aRepository).
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCWorkingCopy >> clearRequiredPackages [
 	requiredPackages := nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> closestAncestorSnapshotIn: aRepository [
 	
 	"Returns a complete Snapshot including all required packages by recurisveliy walking all required package and trying to find the closes ancestor in the given repository"
@@ -393,7 +395,7 @@ MCWorkingCopy >> closestAncestorSnapshotIn: aRepository [
 	^ MCSnapshot fromDefinitions: definitions
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCWorkingCopy >> collectDependenciesWithMessage: messageString in: aRepository [
 	
 	^ self requiredPackages collect: [:aPackage | 
@@ -405,7 +407,7 @@ MCWorkingCopy >> collectDependenciesWithMessage: messageString in: aRepository [
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> completeSnapshot [
 	"return a complete snapshot of the loaded sources in this working copy. 
 	unlike snapshot this includes also the snapshots of all packages"
@@ -421,7 +423,7 @@ MCWorkingCopy >> completeSnapshot [
 	^ MCSnapshot fromDefinitions: definitions
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> currentVersionInfo [
 	^ (self needsSaving or: [ancestry ancestors isEmpty])
 		ifTrue: [ (self newVersionIn: self repositoryGroup) 
@@ -429,19 +431,19 @@ MCWorkingCopy >> currentVersionInfo [
 		ifFalse: [ancestry ancestors first]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> currentVersionInfoWithMessage: aMessageString in: aRepository [
 	^ (self needsSaving or: [ancestry ancestors isEmpty])
 		ifTrue: [ (self newVersionWithMessage: aMessageString in: aRepository) info ]
 		ifFalse: [ancestry ancestors first]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> description [
 	^ self packageNameWithStar, ' (', (ancestry ancestorStringWithout: self packageName), ')'
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCWorkingCopy >> displayStringOn: stream [
 
 	ancestry ancestors
@@ -454,7 +456,7 @@ MCWorkingCopy >> displayStringOn: stream [
 			self needsSaving ifTrue: [ stream nextPutAll: ' (modified)' ] ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCWorkingCopy >> findSnapshotWithVersionInfo: aVersionInfo [
     "when an ancestor inside the ancestor chain is not found, does not pass nil instead.
     With this change we can now browse history and delta between them without having to 
@@ -469,20 +471,20 @@ MCWorkingCopy >> findSnapshotWithVersionInfo: aVersionInfo [
             ifNotNil: [:aVersion | aVersion snapshot]]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCWorkingCopy >> initialize [
 	super initialize.
 	modified := false.
 	ancestry := MCWorkingAncestry new
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCWorkingCopy >> initializeWithPackage: aPackage [
 	package := aPackage.
 	self initialize.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> loadRemoteDependenciesIn: aRepository [
 	"load the remote dependencies of all packages in parallel"
 	| dependencies |
@@ -494,7 +496,7 @@ MCWorkingCopy >> loadRemoteDependenciesIn: aRepository [
 
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCWorkingCopy >> loaded: aVersion [
 	ancestry := MCWorkingAncestry new addAncestor: aVersion info.
 	requiredPackages := OrderedCollection withAll: (aVersion dependencies collect: [:ea | ea package]).
@@ -502,7 +504,7 @@ MCWorkingCopy >> loaded: aVersion [
 	self changed
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCWorkingCopy >> merge: targetVersion [
 	| ancestorInfo merger ancestorSnapshot packageSnapshot |
 	targetVersion dependencies do: [:ea | ea resolve merge].
@@ -532,19 +534,19 @@ MCWorkingCopy >> merge: targetVersion [
 	self changed
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCWorkingCopy >> merged: aVersion [
 	ancestry addAncestor: aVersion info.
 	aVersion dependencies do: [:ea | self requirePackage: ea package].
 	self changed
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> modified [
 	^ modified
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> modified: aBoolean [
 	modified = aBoolean
 		ifTrue: [ ^ self ].
@@ -557,12 +559,12 @@ MCWorkingCopy >> modified: aBoolean [
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> needsSaving [
 	^ self modified or: [self requiredPackages anySatisfy: [:ea | ea workingCopy needsSaving]]
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCWorkingCopy >> newVersionIn: aRepository [
 	^ (self requestVersionNameAndMessageWithSuggestion: (self uniqueVersionNameIn: aRepository)) 
 		ifNotNil: [:pair |
@@ -573,7 +575,7 @@ MCWorkingCopy >> newVersionIn: aRepository [
 
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCWorkingCopy >> newVersionWithMessage: aMessageString in: aRepository [
 	^ self 
 		newVersionWithName: (self uniqueVersionNameIn: aRepository)  
@@ -586,7 +588,7 @@ MCWorkingCopy >> newVersionWithMessage: aMessageString in: aRepository [
 	"
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCWorkingCopy >> newVersionWithName: nameString message: messageString in: aRepository [
 	
 	| info deps |
@@ -606,14 +608,14 @@ MCWorkingCopy >> newVersionWithName: nameString message: messageString in: aRepo
 		dependencies: deps
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> nextAncestors [
 	^ self versionInfo 
 		ifNotNil: [ :versionInfo | versionInfo ancestors ]
 		ifNil: [ #() ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCWorkingCopy >> nextVersionName [
 	| branch oldName base author |
 	branch := ''.
@@ -638,7 +640,7 @@ MCWorkingCopy >> nextVersionName [
 	^ base , '-' , author , branch , '.' , counter asString
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCWorkingCopy >> notifyNoCommonAncestorWith: aVersion [
 	self notify:
 'Could not find a common ancestor between (',
@@ -648,29 +650,29 @@ ancestry ancestorString, ').
 Proceeding with this merge may cause spurious conflicts.'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> package [
 	^ package
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> packageName [
 	^ package name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> packageNameWithStar [
 	^ modified
 		ifTrue: ['* ', self packageName]
 		ifFalse: [self packageName]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> packageSet [
 	^ package packageSet
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCWorkingCopy >> possiblyNewerVersions [
 
 	^Array streamContents: [:strm |
@@ -678,13 +680,13 @@ MCWorkingCopy >> possiblyNewerVersions [
 			strm nextPutAll: (self possiblyNewerVersionsIn: repo)]]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCWorkingCopy >> possiblyNewerVersionsIn: aRepository [
 
 	^aRepository possiblyNewerVersionsOfAnyOf: self ancestors
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MCWorkingCopy >> printOn: aStream [
 
 	super printOn: aStream.
@@ -694,39 +696,39 @@ MCWorkingCopy >> printOn: aStream [
  										nextPut: $)]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> removeRequiredPackage: aPackage [
 
 	requiredPackages remove: aPackage ifAbsent: []
 
 ]
 
-{ #category : #repositories }
+{ #category : 'repositories' }
 MCWorkingCopy >> repositoryGroup [
 	^ repositoryGroup ifNil: [repositoryGroup := MCRepositoryGroup new]
 ]
 
-{ #category : #repositories }
+{ #category : 'repositories' }
 MCWorkingCopy >> repositoryGroup: aRepositoryGroup [
 	repositoryGroup := aRepositoryGroup
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCWorkingCopy >> requestVersionNameAndMessageWithSuggestion: aString [
 	^ (MCVersionNameAndMessageRequest new suggestedName: aString) signal
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> requirePackage: aPackage [
 	(self requiredPackages includes: aPackage) ifFalse: [requiredPackages add: aPackage]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> requiredPackages [
 	^ requiredPackages ifNil: [requiredPackages := OrderedCollection new]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> requiredPackagesParallelCollect: aBlock withMessage: aMessage [
 	"load the remote dependencies of all packages in parallel"
 
@@ -757,24 +759,24 @@ MCWorkingCopy >> requiredPackagesParallelCollect: aBlock withMessage: aMessage [
 	^ results
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> snapshot [
 	^ self package snapshot
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> systemPackage [
 
 	^ self package systemPackage
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> theCachedRepository [
 
 	^ MCCacheRepository uniqueInstance.
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCWorkingCopy >> uniqueVersionName [
 	|versionName|
 	counter := nil.
@@ -787,7 +789,7 @@ MCWorkingCopy >> uniqueVersionName [
 	^ versionName
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCWorkingCopy >> uniqueVersionNameIn: aRepository [
 	|versionName|
 	counter := nil.
@@ -800,7 +802,7 @@ MCWorkingCopy >> uniqueVersionNameIn: aRepository [
 	^ versionName
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCWorkingCopy >> unload [
 	"Unloads mcpackage, rpackage, classes and method extensions from this working copy"
 
@@ -816,7 +818,7 @@ MCWorkingCopy >> unload [
 	postUnloadAction value
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MCWorkingCopy >> unregister [
 	self class registry 
 		removeKey: package
@@ -825,19 +827,19 @@ MCWorkingCopy >> unregister [
 	self announcer announce: (MCWorkingCopyDeleted workingCopy: self package: package)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> versionInfo [
 	^ self ancestors 
 		ifNotEmpty: [ :list | list first ] 
 		ifEmpty: [ nil ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopy >> versionInfo: aVersionInfo [
 	ancestry := MCWorkingAncestry new addAncestor: aVersionInfo
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCWorkingCopy >> versionSeparator [
 	^ $_
 ]

--- a/src/Monticello/MCWorkingCopyCreated.class.st
+++ b/src/Monticello/MCWorkingCopyCreated.class.st
@@ -2,16 +2,18 @@
 A MCWorkingCopyCreated is a announcement raised when a new MCWorkingCopy is created
 "
 Class {
-	#name : #MCWorkingCopyCreated,
-	#superclass : #Announcement,
+	#name : 'MCWorkingCopyCreated',
+	#superclass : 'Announcement',
 	#instVars : [
 		'package',
 		'workingCopy'
 	],
-	#category : #'Monticello-Announcements'
+	#category : 'Monticello-Announcements',
+	#package : 'Monticello',
+	#tag : 'Announcements'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCWorkingCopyCreated class >> workingCopy: workingCopy [
 
 	^ self new
@@ -19,7 +21,7 @@ MCWorkingCopyCreated class >> workingCopy: workingCopy [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCWorkingCopyCreated class >> workingCopy: aWC package: package [
 
 	^ self new
@@ -28,22 +30,22 @@ MCWorkingCopyCreated class >> workingCopy: aWC package: package [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopyCreated >> package [
 	^ package
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopyCreated >> package: anObject [
 	package := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopyCreated >> workingCopy [
 	^ workingCopy
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopyCreated >> workingCopy: anObject [
 	workingCopy := anObject
 ]

--- a/src/Monticello/MCWorkingCopyDeleted.class.st
+++ b/src/Monticello/MCWorkingCopyDeleted.class.st
@@ -2,16 +2,18 @@
 A MCWorkingCopyDeleted class is an announcement raised when a MCWorkingCopy is removed
 "
 Class {
-	#name : #MCWorkingCopyDeleted,
-	#superclass : #Announcement,
+	#name : 'MCWorkingCopyDeleted',
+	#superclass : 'Announcement',
 	#instVars : [
 		'package',
 		'workingCopy'
 	],
-	#category : #'Monticello-Announcements'
+	#category : 'Monticello-Announcements',
+	#package : 'Monticello',
+	#tag : 'Announcements'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCWorkingCopyDeleted class >> workingCopy: workingCopy [
 
 	^ self new
@@ -19,7 +21,7 @@ MCWorkingCopyDeleted class >> workingCopy: workingCopy [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCWorkingCopyDeleted class >> workingCopy: aWC package: package [
 
 	^ self new
@@ -28,22 +30,22 @@ MCWorkingCopyDeleted class >> workingCopy: aWC package: package [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopyDeleted >> package [
 	^ package
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopyDeleted >> package: anObject [
 	package := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopyDeleted >> workingCopy [
 	^ workingCopy
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWorkingCopyDeleted >> workingCopy: anObject [
 	workingCopy := anObject
 ]

--- a/src/Monticello/MCWriter.class.st
+++ b/src/Monticello/MCWriter.class.st
@@ -2,35 +2,37 @@
 Common superclass for metacello writers
 "
 Class {
-	#name : #MCWriter,
-	#superclass : #Object,
+	#name : 'MCWriter',
+	#superclass : 'Object',
 	#instVars : [
 		'stream'
 	],
-	#category : #'Monticello-Storing'
+	#category : 'Monticello-Storing',
+	#package : 'Monticello',
+	#tag : 'Storing'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWriter class >> extension [
 	^ self readerClass extension
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCWriter class >> on: aStream [
 	^ self new stream: aStream
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWriter class >> readerClass [
 	^ self subclassResponsibility 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWriter >> stream [
 	^ stream
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCWriter >> stream: aStream [
 	stream := aStream
 ]

--- a/src/Monticello/ManifestMonticello.class.st
+++ b/src/Monticello/ManifestMonticello.class.st
@@ -2,17 +2,19 @@
 Includes the Monticello source code control system.
 "
 Class {
-	#name : #ManifestMonticello,
-	#superclass : #PackageManifest,
-	#category : #'Monticello-Manifest'
+	#name : 'ManifestMonticello',
+	#superclass : 'PackageManifest',
+	#category : 'Monticello-Manifest',
+	#package : 'Monticello',
+	#tag : 'Manifest'
 }
 
-{ #category : #'meta-data - dependency analyser' }
+{ #category : 'meta-data - dependency analyser' }
 ManifestMonticello class >> ignoredDependencies [
 	^ #(#'Graphics-Primitives' #'FFI-Kernel' #'System-Settings-Core')
 ]
 
-{ #category : #'meta-data - dependency analyser' }
+{ #category : 'meta-data - dependency analyser' }
 ManifestMonticello class >> manuallyResolvedDependencies [
 	^ #(#'Graphics-Primitives' #'OpalCompiler-Core' #Jobs #'Random-Core' #'FFI-Kernel' #'Ring-Definitions-Monticello' #'System-Settings-Core' #'FileSystem-Disk')
 ]

--- a/src/Monticello/MetaclassForTraits.extension.st
+++ b/src/Monticello/MetaclassForTraits.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #MetaclassForTraits }
+Extension { #name : 'MetaclassForTraits' }
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 MetaclassForTraits >> asMCDefinition [
 
 	^ (MCClassTraitDefinition baseTraitName: self instanceSide name)

--- a/src/Monticello/MethodAddition.class.st
+++ b/src/Monticello/MethodAddition.class.st
@@ -2,8 +2,8 @@
 I represent the addition of a method to a class.  I can produce the CompiledMethod, install it, and then notify the system that the method has been added.  This allows Monticello to implement atomic addition.  A loader can compile all classes and methods first and then install all methods only after they have been all compiled, and in a way that executes little code.
 "
 Class {
-	#name : #MethodAddition,
-	#superclass : #Object,
+	#name : 'MethodAddition',
+	#superclass : 'Object',
 	#instVars : [
 		'text',
 		'changeStamp',
@@ -16,10 +16,12 @@ Class {
 		'priorProtocol',
 		'priorOrigin'
 	],
-	#category : #'Monticello-Loading'
+	#category : 'Monticello-Loading',
+	#package : 'Monticello',
+	#tag : 'Loading'
 }
 
-{ #category : #compilation }
+{ #category : 'compilation' }
 MethodAddition >> compile [
 	"This method is the how compiling a method used to work.  All these steps were done at once.
      This method should not normally be used, because the whole point of MethodAddition is to let
@@ -32,7 +34,7 @@ MethodAddition >> compile [
 	^ selector
 ]
 
-{ #category : #compilation }
+{ #category : 'compilation' }
 MethodAddition >> compile: aString classified: aProtocolName withStamp: aString2 logSource: aBoolean inClass: aClass [
 
 	text := aString.
@@ -42,7 +44,7 @@ MethodAddition >> compile: aString classified: aProtocolName withStamp: aString2
 	myClass := aClass
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MethodAddition >> createCompiledMethod [
 	"CyrilFerlicot: Why do we need to explicitly write to the source? Why do we call the compiler?
 	
@@ -55,13 +57,13 @@ MethodAddition >> createCompiledMethod [
 	priorProtocol := myClass protocolOfSelector: selector
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MethodAddition >> installMethod [
 	SystemAnnouncer uniqueInstance
 		suspendAllWhile: [ myClass addSelector: selector withMethod: compiledMethod ]
 ]
 
-{ #category : #notifying }
+{ #category : 'notifying' }
 MethodAddition >> notifyObservers [
 
 	SystemAnnouncer uniqueInstance suspendAllWhile: [ myClass classify: selector under: protocolName ].
@@ -74,12 +76,12 @@ MethodAddition >> notifyObservers [
 	myClass instanceSide noteCompilationOf: compiledMethod meta: myClass isClassSide
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MethodAddition >> priorProtocol [
 	^ priorProtocol
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MethodAddition >> writeSourceToLog [
 
 	logSource ifTrue: [

--- a/src/Monticello/MonticelloBootstrap.class.st
+++ b/src/Monticello/MonticelloBootstrap.class.st
@@ -15,29 +15,31 @@ The convenience method #bootstrapDefault will create an instance with the defaul
   MonticelloBootstrap bootstrapDefault
 "
 Class {
-	#name : #MonticelloBootstrap,
-	#superclass : #Object,
+	#name : 'MonticelloBootstrap',
+	#superclass : 'Object',
 	#instVars : [
 		'directory',
 		'localRepository'
 	],
-	#category : #'Monticello-Base'
+	#category : 'Monticello-Base',
+	#package : 'Monticello',
+	#tag : 'Base'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MonticelloBootstrap class >> bootstrapDefault [
 
 	(self inDirectory: self defaultDirectory)
 		bootstrap
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 MonticelloBootstrap class >> defaultDirectory [
 
 	^ FileLocator localDirectory / 'package-cache'
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MonticelloBootstrap class >> inDirectory: aDirectory [
 
 	^ self new
@@ -45,7 +47,7 @@ MonticelloBootstrap class >> inDirectory: aDirectory [
 		yourself
 ]
 
-{ #category : #bootstrapping }
+{ #category : 'bootstrapping' }
 MonticelloBootstrap >> bootstrap [
 
 	self createWorkingCopies.
@@ -55,13 +57,13 @@ MonticelloBootstrap >> bootstrap [
 
 ]
 
-{ #category : #versions }
+{ #category : 'versions' }
 MonticelloBootstrap >> bootstrapVersionsExcept: aBlock [
 
 	^ self bootstrapVersionsSatisfying: [ :arg | (aBlock value: arg) not ]
 ]
 
-{ #category : #versions }
+{ #category : 'versions' }
 MonticelloBootstrap >> bootstrapVersionsSatisfying: aBlock [
 
 	^ RPackageOrganizer default packages
@@ -69,7 +71,7 @@ MonticelloBootstrap >> bootstrapVersionsSatisfying: aBlock [
 		thenCollect: [ :rpackage | self fileNameForPackageNamed: rpackage name ]
 ]
 
-{ #category : #bootstrapping }
+{ #category : 'bootstrapping' }
 MonticelloBootstrap >> createWorkingCopies [
 	"For each of the packages inside the image, excepted by the Unpackaged package, create a monticello working copy.
 	This is achieved by creating an instance of a working copy and snapshotting it. This generates and registers the working copy automatically."
@@ -79,13 +81,13 @@ MonticelloBootstrap >> createWorkingCopies [
 		(MCWorkingCopy ensureForPackageNamed: packageName) snapshot ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MonticelloBootstrap >> directory: aDirectory [
 
 	directory := aDirectory
 ]
 
-{ #category : #versions }
+{ #category : 'versions' }
 MonticelloBootstrap >> fileNameForPackageNamed: name [
 
 	| versionInfos |
@@ -100,13 +102,13 @@ MonticelloBootstrap >> fileNameForPackageNamed: name [
 	^ versionInfos anyOne basename
 ]
 
-{ #category : #bootstrapping }
+{ #category : 'bootstrapping' }
 MonticelloBootstrap >> loadBootstrapPackageNamed: aName [
 
 	self loadBootstrapPackagesNamed: { aName }
 ]
 
-{ #category : #bootstrapping }
+{ #category : 'bootstrapping' }
 MonticelloBootstrap >> loadBootstrapPackages [
 
 	MCCacheRepository cacheDirectory: directory.
@@ -125,20 +127,20 @@ MonticelloBootstrap >> loadBootstrapPackages [
 	self loadBootstrapPackageNamed: 'Monticello'
 ]
 
-{ #category : #bootstrapping }
+{ #category : 'bootstrapping' }
 MonticelloBootstrap >> loadBootstrapPackagesNamed: aCollectionOfNames [
 
 	(self bootstrapVersionsSatisfying: [ :package | aCollectionOfNames includes: package name ])
 		do: [ :version | self loadPackageVersion: version ].
 ]
 
-{ #category : #bootstrapping }
+{ #category : 'bootstrapping' }
 MonticelloBootstrap >> loadPackageNamed: aName [
 
 	self loadPackagesNamed: { aName }
 ]
 
-{ #category : #bootstrapping }
+{ #category : 'bootstrapping' }
 MonticelloBootstrap >> loadPackageVersion: aFileName [
 	
 	[ 	SystemNotification signal: ('Loading ', aFileName asString).
@@ -150,7 +152,7 @@ MonticelloBootstrap >> loadPackageVersion: aFileName [
 		warning resume: true ]
 ]
 
-{ #category : #bootstrapping }
+{ #category : 'bootstrapping' }
 MonticelloBootstrap >> loadPackagesNamed: aCollectionOfNames [
 
 	aCollectionOfNames do: [ :name | | filename |
@@ -158,7 +160,7 @@ MonticelloBootstrap >> loadPackagesNamed: aCollectionOfNames [
 		self loadPackageVersion: filename ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MonticelloBootstrap >> localRepository [
 
 	^ localRepository ifNil: [

--- a/src/Monticello/Object.extension.st
+++ b/src/Monticello/Object.extension.st
@@ -1,13 +1,13 @@
-Extension { #name : #Object }
+Extension { #name : 'Object' }
 
-{ #category : #'*Monticello-Storing' }
+{ #category : '*Monticello-Storing' }
 Object >> comeFullyUpOnReload: smartRefStream [
 	"Normally this read-in object is exactly what we want to store."
 
 	^ self
 ]
 
-{ #category : #'*Monticello-Storing' }
+{ #category : '*Monticello-Storing' }
 Object >> readDataFrom: aDataStream size: varsOnDisk [
 	"Fill in the fields of self based on the contents of aDataStream.  Return self.
 	 Read in the instance-variables written by Object>>storeDataOn:.
@@ -33,7 +33,7 @@ Object >> readDataFrom: aDataStream size: varsOnDisk [
 			on (super readDataFrom: aDataStream size: anInteger)"
 ]
 
-{ #category : #'*Monticello-Storing' }
+{ #category : '*Monticello-Storing' }
 Object >> storeDataOn: aDataStream [
 	"Store myself on a DataStream.  Answer self.  This is a low-level DataStream/ReferenceStream method. See also objectToStoreOnDataStream.  NOTE: This method must send 'aDataStream beginInstance:size:' and then (nextPut:/nextPutWeak:) its subobjects.  readDataFrom:size: reads back what we write here."
 	| cntInstVars cntIndexedVars |

--- a/src/Monticello/ObjectLayout.extension.st
+++ b/src/Monticello/ObjectLayout.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #ObjectLayout }
+Extension { #name : 'ObjectLayout' }
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 ObjectLayout class >> layoutForType: typeSymbol [
 	"used to get the layout for a Monticello internal layout symbol"
 	^self allSubclasses 
@@ -8,7 +8,7 @@ ObjectLayout class >> layoutForType: typeSymbol [
 		ifNone: [ Error signal: 'Invalid layout type: ', typeSymbol asString ]
 ]
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 ObjectLayout class >> mcTypeSymbol [
 	"return the symbol that Monticello uses to encode the layout"
 	^self name asSymbol

--- a/src/Monticello/RGMethodDefinition.extension.st
+++ b/src/Monticello/RGMethodDefinition.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #RGMethodDefinition }
+Extension { #name : 'RGMethodDefinition' }
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 RGMethodDefinition >> asMCMethodDefinition [
    "Creates a MCMethodDefinition from the receiver"
 	| cached |
@@ -19,7 +19,7 @@ RGMethodDefinition >> asMCMethodDefinition [
 	^ cached
 ]
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 RGMethodDefinition >> asMCMethodDefinitionFromActiveDefinition [
 	"Creates a MCMethodDefinition from a source file assuming the current method isActive."
 
@@ -36,7 +36,7 @@ RGMethodDefinition >> asMCMethodDefinitionFromActiveDefinition [
 		  source: compiledMethod sourceCode
 ]
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 RGMethodDefinition >> basicAsMCMethodDefinition [
    "Creates a MCMethodDefinition from the receiver"
    

--- a/src/Monticello/RPackage.extension.st
+++ b/src/Monticello/RPackage.extension.st
@@ -1,12 +1,12 @@
-Extension { #name : #RPackage }
+Extension { #name : 'RPackage' }
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 RPackage >> asMCOrganizationDefinition [
 
 	^ MCOrganizationDefinition packageName: self name tagNames: self tagNames
 ]
 
-{ #category : #'*Monticello-RPackage' }
+{ #category : '*Monticello-RPackage' }
 RPackage >> isDirty [
 	
 	| mcp |
@@ -19,7 +19,7 @@ RPackage >> isDirty [
 		ifAbsent: [ false ])
 ]
 
-{ #category : #'*Monticello-RPackage' }
+{ #category : '*Monticello-RPackage' }
 RPackage >> mcPackage [
 	"Normally the corresponding MCPackage should exist, but in certain cases it could happen that it does not"
 	
@@ -27,7 +27,7 @@ RPackage >> mcPackage [
 	
 ]
 
-{ #category : #'*Monticello-RPackage' }
+{ #category : '*Monticello-RPackage' }
 RPackage >> mcWorkingCopy [
 
 	^ (MCWorkingCopy hasPackageNamed: name)

--- a/src/Monticello/RPackageOrganizer.extension.st
+++ b/src/Monticello/RPackageOrganizer.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #RPackageOrganizer }
+Extension { #name : 'RPackageOrganizer' }
 
-{ #category : #'*Monticello-RPackage' }
+{ #category : '*Monticello-RPackage' }
 RPackageOrganizer >> isDefinedAsPackageOrSubPackageInMC: aSymbol [
 	"a category has been added. "
 

--- a/src/Monticello/Set.extension.st
+++ b/src/Monticello/Set.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Set }
+Extension { #name : 'Set' }
 
-{ #category : #'*Monticello-Storing' }
+{ #category : '*Monticello-Storing' }
 Set >> comeFullyUpOnReload: smartRefStream [
 	"Symbols have new hashes in this image."
 

--- a/src/Monticello/String.extension.st
+++ b/src/Monticello/String.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #String }
+Extension { #name : 'String' }
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 String >> extractNumber [
 	^ ('0', self select: [:ea | ea isDigit]) asNumber
 ]

--- a/src/Monticello/Trait.extension.st
+++ b/src/Monticello/Trait.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Trait }
+Extension { #name : 'Trait' }
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 Trait >> asClassDefinition [
 	"We do not dispatch on the printer because in fact MC only support the oldPharo syntax. 
 	This syntax is hijacked to store the full definition of a slot in case of complex slots: 
@@ -33,7 +33,7 @@ Trait >> asClassDefinition [
 	^ definition
 ]
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 Trait >> classDefinitions [
 	| definitions |
 	definitions := OrderedCollection with: self asClassDefinition.

--- a/src/Monticello/UndefinedObject.extension.st
+++ b/src/Monticello/UndefinedObject.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #UndefinedObject }
+Extension { #name : 'UndefinedObject' }
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 UndefinedObject >> mcType [
 	"Answer the symbol that Monticello uses internally to encode layouts"
 	"Implemented here  to support disjoint class hierarchies"

--- a/src/Monticello/VariableLayout.extension.st
+++ b/src/Monticello/VariableLayout.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #VariableLayout }
+Extension { #name : 'VariableLayout' }
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 VariableLayout class >> mcTypeSymbol [ 
 	^ #variable
 ]

--- a/src/Monticello/WeakLayout.extension.st
+++ b/src/Monticello/WeakLayout.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #WeakLayout }
+Extension { #name : 'WeakLayout' }
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 WeakLayout class >> mcTypeSymbol [ 
 	^ #weak
 ]

--- a/src/Monticello/WideString.extension.st
+++ b/src/Monticello/WideString.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #WideString }
+Extension { #name : 'WideString' }
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 WideString class >> newFromStream: s [
 	"Only meant for my subclasses that are raw bits and word-like.  For quick unpack form the disk."
 	| len |

--- a/src/Monticello/WordLayout.extension.st
+++ b/src/Monticello/WordLayout.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #WordLayout }
+Extension { #name : 'WordLayout' }
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 WordLayout class >> mcTypeSymbol [ 
 	^ #words
 ]

--- a/src/Monticello/ZnUrl.extension.st
+++ b/src/Monticello/ZnUrl.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #ZnUrl }
+Extension { #name : 'ZnUrl' }
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 ZnUrl >> asFileReferenceWithRelativePath [
 	"Convert the receiver into a new FileReference object accepting relative paths.
 	This works for filetree (a special pharo format).
@@ -24,7 +24,7 @@ ZnUrl >> asFileReferenceWithRelativePath [
 		asFileReference
 ]
 
-{ #category : #'*Monticello' }
+{ #category : '*Monticello' }
 ZnUrl >> location [
 	"Returns the URL location string without username and password"
 	^ String streamContents: [ :stream |

--- a/src/Monticello/package.st
+++ b/src/Monticello/package.st
@@ -1,1 +1,1 @@
-Package { #name : #Monticello }
+Package { #name : 'Monticello' }

--- a/src/MonticelloFileTree-Core/MCFileBasedRepository.extension.st
+++ b/src/MonticelloFileTree-Core/MCFileBasedRepository.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #MCFileBasedRepository }
+Extension { #name : 'MCFileBasedRepository' }
 
-{ #category : #'*MonticelloFileTree-Core' }
+{ #category : '*MonticelloFileTree-Core' }
 MCFileBasedRepository >> packageDescriptionsFromReadableFileNames [
 	^ self readableFileNames
 		collect: [ :each | 
@@ -23,7 +23,7 @@ MCFileBasedRepository >> packageDescriptionsFromReadableFileNames [
 					each} ] ]
 ]
 
-{ #category : #'*MonticelloFileTree-Core' }
+{ #category : '*MonticelloFileTree-Core' }
 MCFileBasedRepository >> retrieveVersionsWithPackageNames: packageNames [
 	| packageDescriptions |
 	packageDescriptions := self packageDescriptionsFromReadableFileNames.

--- a/src/MonticelloFileTree-Core/MCFileTreeAbstractReader.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeAbstractReader.class.st
@@ -2,33 +2,34 @@
 Abstract reader superclass for FileTree
 "
 Class {
-	#name : #MCFileTreeAbstractReader,
-	#superclass : #MCMczReader,
+	#name : 'MCFileTreeAbstractReader',
+	#superclass : 'MCMczReader',
 	#instVars : [
 		'packageDirectory',
 		'packageProperties'
 	],
-	#category : #'MonticelloFileTree-Core'
+	#category : 'MonticelloFileTree-Core',
+	#package : 'MonticelloFileTree-Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeAbstractReader class >> monticelloMetaDirName [
     ^ '.'
 ]
 
-{ #category : #reading }
+{ #category : 'reading' }
 MCFileTreeAbstractReader class >> on: s fileName: f [
 	^ (self on: s)
 		packageDirectory: f;
 		yourself
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeAbstractReader >> addClassAndMethodDefinitionsFromDirectory: aDirectory [
     self subclassResponsibility
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeAbstractReader >> addClassAndMethodDefinitionsFromDirectoryEntries: entries [
 	| timestamp |
 	self noMethodMetaData
@@ -58,12 +59,12 @@ MCFileTreeAbstractReader >> addClassAndMethodDefinitionsFromDirectoryEntries: en
 									definitions add: definition ] ] ] ]
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeAbstractReader >> addDefinitionFromFile: directoryEntry inDirectory: aDirectory [
     (self definitionFromFile: directoryEntry inDirectory: aDirectory) ifNotNil: [ :def | definitions add: def ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeAbstractReader >> basicVersion [
 	^ (MCVersion new)
 		setPackage: self package
@@ -73,7 +74,7 @@ MCFileTreeAbstractReader >> basicVersion [
 		yourself
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeAbstractReader >> definitionFromFile: directoryEntry inDirectory: aDirectory [
     | defs reader |
     directoryEntry ifNil: [ ^ nil ].
@@ -90,12 +91,12 @@ MCFileTreeAbstractReader >> definitionFromFile: directoryEntry inDirectory: aDir
     ^ defs first
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeAbstractReader >> fileUtils [
     ^ MCFileTreeFileUtils current
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCFileTreeAbstractReader >> hasMonticelloMetadata [
     ^ (self fileUtils
 		filePathExists: 'version'
@@ -114,7 +115,7 @@ MCFileTreeAbstractReader >> hasMonticelloMetadata [
 
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeAbstractReader >> isLoadableDefinitionFile: entry [
 
 	"Reject hidden files"
@@ -123,7 +124,7 @@ MCFileTreeAbstractReader >> isLoadableDefinitionFile: entry [
 	^ entry name endsWith: '.st'
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeAbstractReader >> loadDefinitions [
     | entries |
     definitions := OrderedCollection new.
@@ -136,7 +137,7 @@ MCFileTreeAbstractReader >> loadDefinitions [
             inDirectory: packageDirectory
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeAbstractReader >> loadDependencies [
     | dependencyDir directoryPath |
     directoryPath := self monticelloMetaDirName , self fileUtils pathNameDelimiter asString , 'dependencies'.
@@ -155,27 +156,27 @@ MCFileTreeAbstractReader >> loadDependencies [
     dependencies := dependencies asArray
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeAbstractReader >> loadableDefinitionsFrom: directory [
 	^ directory entries select: [ :entry | self isLoadableDefinitionFile: entry ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeAbstractReader >> monticelloMetaDirName [
     ^ self class monticelloMetaDirName
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCFileTreeAbstractReader >> noMethodMetaData [
     ^ self packageProperties at: 'noMethodMetaData' ifAbsent: [ false ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeAbstractReader >> packageDirectory: aDirectoryName [
     packageDirectory := self fileUtils directoryFromPath: aDirectoryName relativeTo: stream
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeAbstractReader >> packageProperties [
     packageProperties
         ifNil: [ 
@@ -208,7 +209,7 @@ MCFileTreeAbstractReader >> packageProperties [
     ^ packageProperties
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeAbstractReader >> parseMember: fileName [
     | directory tokens |
     directory := self fileUtils directoryFromPath: self monticelloMetaDirName relativeTo: packageDirectory.
@@ -216,7 +217,7 @@ MCFileTreeAbstractReader >> parseMember: fileName [
     ^ self associate: tokens
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCFileTreeAbstractReader >> separateMethodMetaAndSource [
     ^ self packageProperties at: 'separateMethodMetaAndSource' ifAbsent: [ false ]
 ]

--- a/src/MonticelloFileTree-Core/MCFileTreeAbstractStWriter.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeAbstractStWriter.class.st
@@ -2,23 +2,24 @@
 Abstract superclass for FileTree writers
 "
 Class {
-	#name : #MCFileTreeAbstractStWriter,
-	#superclass : #MCWriter,
+	#name : 'MCFileTreeAbstractStWriter',
+	#superclass : 'MCWriter',
 	#instVars : [
 		'stWriter',
 		'initializers',
 		'orderedClassNames',
 		'orderedTraitNames'
 	],
-	#category : #'MonticelloFileTree-Core'
+	#category : 'MonticelloFileTree-Core',
+	#package : 'MonticelloFileTree-Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeAbstractStWriter class >> monticelloMetaDirName [
     ^ '.'
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeAbstractStWriter class >> on: aStream [
     MCFileTreePackageStructureStWriter useCypressWriter
         ifTrue: [ ^ MCFileTreeStCypressWriter new stream: aStream ].
@@ -27,19 +28,19 @@ MCFileTreeAbstractStWriter class >> on: aStream [
         ifFalse: [ MCFileTreeStWriter ]) new stream: aStream
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeAbstractStWriter class >> readerClass [
 	^ MCStReader
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCFileTreeAbstractStWriter >> directoryForDirectoryNamed: directoryNameOrPath [
     ^ directoryNameOrPath = '.'
         ifTrue: [ stream packageFileDirectory ]
         ifFalse: [ stream subPackageFileDirectoryFor: directoryNameOrPath ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCFileTreeAbstractStWriter >> fileNameForSelector: selector [
     ^ (selector == #'/'
         ifTrue: [ 'encoded slash' ]
@@ -49,12 +50,12 @@ MCFileTreeAbstractStWriter >> fileNameForSelector: selector [
                 ifFalse: [ selector ] ]) asString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeAbstractStWriter >> fileUtils [
     ^ MCFileTreeFileUtils current
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCFileTreeAbstractStWriter >> initialize [
     stWriter := MCFileTreePackageStructureStWriter new
         initializers: (initializers := Set new);
@@ -63,63 +64,64 @@ MCFileTreeAbstractStWriter >> initialize [
     orderedTraitNames := OrderedCollection new.
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCFileTreeAbstractStWriter >> monticelloMetaDirName [
     ^ self class monticelloMetaDirName
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCFileTreeAbstractStWriter >> repository [
   ^ stream repository
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCFileTreeAbstractStWriter >> setFileStream: file [
     stWriter stream: file
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCFileTreeAbstractStWriter >> visitClassDefinition: definition [
     self subclassResponsibility
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCFileTreeAbstractStWriter >> visitClassTraitDefinition: definition [
     self subclassResponsibility
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCFileTreeAbstractStWriter >> visitMetaclassDefinition: definition [
     "handled by class definition"
 
 
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCFileTreeAbstractStWriter >> visitMethodDefinition: definition [
     self subclassResponsibility
 ]
 
-{ #category : #visiting }
-MCFileTreeAbstractStWriter >> visitOrganizationDefinition: defintion [
-    self
-        writeInDirectoryName: self monticelloMetaDirName
-        fileName: 'categories'
-        extension: '.st'
-        visit: [ defintion categories do: [ :cat | stWriter writeCategory: cat ] ]
+{ #category : 'visiting' }
+MCFileTreeAbstractStWriter >> visitOrganizationDefinition: definition [
+
+	self
+		writeInDirectoryName: self monticelloMetaDirName
+		fileName: 'categories'
+		extension: '.st'
+		visit: [ stWriter writePackage: definition packageName tags: (definition tagNames ifNil: [ #(  ) ]) ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCFileTreeAbstractStWriter >> visitScriptDefinition: definition [
     self flag: #'skippedForNow'
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCFileTreeAbstractStWriter >> visitTraitDefinition: definition [
     self subclassResponsibility
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 MCFileTreeAbstractStWriter >> writeBasicDefinitions: aCollection [
     "the correct initialization order is unknown if some classes are missing in the image"
 
@@ -128,7 +130,7 @@ MCFileTreeAbstractStWriter >> writeBasicDefinitions: aCollection [
     self writeInitializers
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeAbstractStWriter >> writeClassDefinition: definition [
     stWriter writeClassDefinition: definition.
     (definition hasClassInstanceVariables or: [definition hasClassTraitComposition])
@@ -137,20 +139,20 @@ MCFileTreeAbstractStWriter >> writeClassDefinition: definition [
         ifTrue: [ stWriter writeClassComment: definition ]
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeAbstractStWriter >> writeClassTraitDefinition: definition [
     stWriter visitClassTraitDefinition: definition.
 
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCFileTreeAbstractStWriter >> writeDefinitions: aCollection [
     "the correct initialization order is unknown if some classes are missing in the image"
 
     self writeBasicDefinitions: aCollection
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCFileTreeAbstractStWriter >> writeInDirectoryName: directoryNameOrPath fileName: fileName extension: ext visit: visitBlock [
     | directory |
     directory := self directoryForDirectoryNamed: directoryNameOrPath.
@@ -162,7 +164,7 @@ MCFileTreeAbstractStWriter >> writeInDirectoryName: directoryNameOrPath fileName
             visitBlock value ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCFileTreeAbstractStWriter >> writeInitializers [
     self
         writeInDirectoryName: self monticelloMetaDirName
@@ -174,12 +176,12 @@ MCFileTreeAbstractStWriter >> writeInitializers [
                 writeAbsentInitializers ]
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeAbstractStWriter >> writeMethodDefinition: definition [
     stWriter visitMethodDefinition: definition
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCFileTreeAbstractStWriter >> writePropertiesFile [
     self
         writeInDirectoryName: '.'
@@ -188,7 +190,7 @@ MCFileTreeAbstractStWriter >> writePropertiesFile [
         visit: [ stWriter writeProperties ]
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeAbstractStWriter >> writeTraitDefinition: definition [
     stWriter writeClassDefinition: definition.
     definition hasComment 

--- a/src/MonticelloFileTree-Core/MCFileTreeAbstractStWriter.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeAbstractStWriter.class.st
@@ -108,7 +108,7 @@ MCFileTreeAbstractStWriter >> visitOrganizationDefinition: definition [
 		writeInDirectoryName: self monticelloMetaDirName
 		fileName: 'categories'
 		extension: '.st'
-		visit: [ stWriter writePackage: definition packageName tags: (definition tagNames ifNil: [ #(  ) ]) ]
+		visit: [ stWriter visitOrganizationDefinition: definition ]
 ]
 
 { #category : 'visiting' }

--- a/src/MonticelloFileTree-Core/MCFileTreeFileUtils.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeFileUtils.class.st
@@ -2,101 +2,102 @@
 Utility class for file access
 "
 Class {
-	#name : #MCFileTreeFileUtils,
-	#superclass : #Object,
+	#name : 'MCFileTreeFileUtils',
+	#superclass : 'Object',
 	#classVars : [
 		'Current'
 	],
-	#category : #'MonticelloFileTree-Core'
+	#category : 'MonticelloFileTree-Core',
+	#package : 'MonticelloFileTree-Core'
 }
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeFileUtils class >> buildPathFrom: pathCollection [
     ^ String
         streamContents: [ :stream | pathCollection do: [ :element | stream nextPutAll: element ] separatedBy: [ stream nextPut: self pathNameDelimiter ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeFileUtils class >> current [
     ^ Current
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeFileUtils class >> default [
     self subclassResponsibility
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeFileUtils class >> deleteAll: aDirectory [
     self subclassResponsibility
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeFileUtils class >> directoryExists: aDirectory [
     self subclassResponsibility
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeFileUtils class >> directoryFromPath: directoryPath [
     self subclassResponsibility
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeFileUtils class >> directoryFromPath: directoryPath relativeTo: aDirectory [
     self subclassResponsibility
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeFileUtils class >> directoryName: aDirectory [
     self subclassResponsibility
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeFileUtils class >> directoryPathString: aDirectory [
     self subclassResponsibility
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeFileUtils class >> ensureDirectoryExists: aDirectory [
     self subclassResponsibility
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeFileUtils class >> ensureFilePathExists: fileNameOrPath relativeTo: aDirectory [
     self subclassResponsibility
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeFileUtils class >> filePathExists: filePath relativeTo: aDirectory [
     self subclassResponsibility
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCFileTreeFileUtils class >> install [
     Current := self
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeFileUtils class >> parentDirectoryOf: aDirectory [
     self subclassResponsibility
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeFileUtils class >> pathNameDelimiter [
     self subclassResponsibility
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeFileUtils class >> readStreamFor: filePath in: aDirectory do: aBlock [
     self subclassResponsibility
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeFileUtils class >> resolvePath: path in: aDirectory [
     self subclassResponsibility
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeFileUtils class >> writeStreamFor: filePath in: aDirectory do: aBlock [
     self subclassResponsibility
 ]

--- a/src/MonticelloFileTree-Core/MCFileTreePackageStructureStWriter.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreePackageStructureStWriter.class.st
@@ -2,12 +2,13 @@
 Writer for a package structure
 "
 Class {
-	#name : #MCFileTreePackageStructureStWriter,
-	#superclass : #MCStWriter,
-	#category : #'MonticelloFileTree-Core'
+	#name : 'MCFileTreePackageStructureStWriter',
+	#superclass : 'MCStWriter',
+	#category : 'MonticelloFileTree-Core',
+	#package : 'MonticelloFileTree-Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreePackageStructureStWriter class >> useCypressWriter [
     "MCFileTreeRepository defaultPackageExtension:'.package'"
 
@@ -16,40 +17,40 @@ MCFileTreePackageStructureStWriter class >> useCypressWriter [
     ^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreePackageStructureStWriter class >> useSnapShotWriter [
     ^ MCFileTreeRepository defaultPackageExtension = '.pkg'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreePackageStructureStWriter >> absentInitializers [
 	^ initializers reject: [ :each | Smalltalk hasClassNamed: each key ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCFileTreePackageStructureStWriter >> acceptVisitor: aVisitor forDefinitions: aCollection [
 	(MCDependencySorter sortItems: aCollection)
 		do: [ :ea | ea accept: aVisitor ]
 		displayingProgress: 'Writing definitions...'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreePackageStructureStWriter >> initializers: aCollection [
 	initializers := aCollection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreePackageStructureStWriter >> presentInitializers [
 	^ initializers select: [ :each | Smalltalk hasClassNamed: each key ]
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreePackageStructureStWriter >> writeAbsentInitializers [
 	(self absentInitializers asSortedCollection: [ :a :b | a key <= b key ])
 		do: [ :association | stream nextPutAll: association value contents ]
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreePackageStructureStWriter >> writeDefinitions: aCollection [
 	"the correct initialization order is unknown if some classes are missing in the image"
 
@@ -60,7 +61,7 @@ MCFileTreePackageStructureStWriter >> writeDefinitions: aCollection [
 		writeAbsentInitializers
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreePackageStructureStWriter >> writeMethodPreamble: definition [
     stream
         cr;
@@ -72,7 +73,7 @@ MCFileTreePackageStructureStWriter >> writeMethodPreamble: definition [
         cr
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreePackageStructureStWriter >> writePresentInitializers [
 	| orderedClasses presentInitializers |
 	presentInitializers := self presentInitializers.
@@ -83,7 +84,7 @@ MCFileTreePackageStructureStWriter >> writePresentInitializers [
 		do: [ :className | stream nextPutAll: (presentInitializers detect: [ :each | each key = className ]) value contents ]
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreePackageStructureStWriter >> writeProperties [
     stream
         nextPut: ${;

--- a/src/MonticelloFileTree-Core/MCFileTreeRepository.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeRepository.class.st
@@ -2,8 +2,8 @@
 A file tree repository
 "
 Class {
-	#name : #MCFileTreeRepository,
-	#superclass : #MCDirectoryRepository,
+	#name : 'MCFileTreeRepository',
+	#superclass : 'MCDirectoryRepository',
 	#instVars : [
 		'readonly',
 		'repositoryProperties'
@@ -12,15 +12,16 @@ Class {
 		'defaultPackageExtension',
 		'defaultPropertyFileExtension'
 	],
-	#category : #'MonticelloFileTree-Core'
+	#category : 'MonticelloFileTree-Core',
+	#package : 'MonticelloFileTree-Core'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCFileTreeRepository class >> basicFromUrl: aZnUrl [
 	^ self new directory: (self urlAsFileReference: aZnUrl)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeRepository class >> defaultPackageExtension [
     ".tree, .pkg, .package are the only formats supported at the moment:
 	.tree         - original structure
@@ -35,7 +36,7 @@ MCFileTreeRepository class >> defaultPackageExtension [
     ^ defaultPackageExtension
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeRepository class >> defaultPackageExtension: aString [
     ".tree and .pkg are the only two formats supported at the moment"
 
@@ -46,14 +47,14 @@ MCFileTreeRepository class >> defaultPackageExtension: aString [
     defaultPackageExtension := aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeRepository class >> defaultPropertyFileExtension [
   defaultPropertyFileExtension
     ifNil: [ defaultPropertyFileExtension := '.json' ].
   ^ defaultPropertyFileExtension
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeRepository class >> defaultPropertyFileExtension: aString [
   "self defaultPropertyFileExtension:'.ston'"
 
@@ -61,17 +62,17 @@ MCFileTreeRepository class >> defaultPropertyFileExtension: aString [
   defaultPropertyFileExtension := aString
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 MCFileTreeRepository class >> description [
     ^ 'filetree://'
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeRepository class >> parseName: aString [
     ^ self parseName: aString extension: self defaultPackageExtension
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeRepository class >> parseName: aString extension: extension [
     "picked up from GoferVersionReference>>parseName:"
 
@@ -97,7 +98,7 @@ MCFileTreeRepository class >> parseName: aString extension: extension [
     (packageName , extension)}
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeRepository class >> urlAsFileReference: aZnUrl [
 	"Extracted from ZnUrl since the scheme is restricted.
 	We need to keep host as a segment part."
@@ -116,12 +117,12 @@ MCFileTreeRepository class >> urlAsFileReference: aZnUrl [
 	^ (AbsolutePath withAll: path) asFileReference 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeRepository class >> urlSchemes [
 	^ #(#filetree)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeRepository class >> validatePropertyFileExtension: aString [
   "see Issue #90: https://github.com/dalehenrich/filetree/issues/90"
 
@@ -129,18 +130,18 @@ MCFileTreeRepository class >> validatePropertyFileExtension: aString [
     ifFalse: [ self error: 'Unsupported property file extension: ' , aString printString ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeRepository >> allFileNames [
     ^ (self directory entries select: [ :entry | entry isDirectory and: [ self canReadFileNamed: entry name ] ])
         collect: [ :entry | entry name ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeRepository >> allFileNamesForVersionNamed: aString [
 	^ self filterFileNames: self readableFileNames forVersionNamed: aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeRepository >> asRepositorySpecFor: aMetacelloMCProject [
     ^ aMetacelloMCProject repositorySpec
         description: self description;
@@ -148,7 +149,7 @@ MCFileTreeRepository >> asRepositorySpecFor: aMetacelloMCProject [
         yourself
 ]
 
-{ #category : #storing }
+{ #category : 'storing' }
 MCFileTreeRepository >> basicStoreVersion: aVersion [
   self readonly
     ifTrue: [ 
@@ -157,12 +158,12 @@ MCFileTreeRepository >> basicStoreVersion: aVersion [
   MCFileTreeWriter fileOut: aVersion on: self
 ]
 
-{ #category : #caching }
+{ #category : 'caching' }
 MCFileTreeRepository >> cachedFileNames [
 	^ #()
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCFileTreeRepository >> canReadFileNamed: aString [
     ^ (aString endsWith: self packageExtension)
         or: [ 
@@ -172,7 +173,7 @@ MCFileTreeRepository >> canReadFileNamed: aString [
                     aString endsWith: '.package' ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeRepository >> defaultRepositoryProperties [
   ^ Dictionary new
     at: 'packageExtension' put: self class defaultPackageExtension;
@@ -180,29 +181,29 @@ MCFileTreeRepository >> defaultRepositoryProperties [
     yourself
 ]
 
-{ #category : #descriptions }
+{ #category : 'descriptions' }
 MCFileTreeRepository >> description [
     ^ self class description , super description
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeRepository >> directory: aDirectory [
   super directory: aDirectory.
   repositoryProperties := nil.	"force properties to be reloaded from new location"
   self repositoryProperties	"NOW"
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCFileTreeRepository >> fileDirectoryOn: directoryPath [
     ^ self fileUtils directoryFromPath: directoryPath relativeTo: self directory
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeRepository >> fileUtils [
     ^ MCFileTreeFileUtils current
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCFileTreeRepository >> flushCache [
   "force properties to be reread ... if the directory exists, otherwise let nature
    take it's course"
@@ -216,7 +217,7 @@ MCFileTreeRepository >> flushCache [
           self repositoryProperties ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeRepository >> goferVersionFrom: aVersionReference [
     "until we no longer find .tree directories in the wild"
 
@@ -228,7 +229,7 @@ MCFileTreeRepository >> goferVersionFrom: aVersionReference [
     ^ nil
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCFileTreeRepository >> packageDescriptionFromPackageDirectory: packageDirectory [
     | filename info extension |
     filename := self fileUtils current directoryName: packageDirectory.
@@ -253,33 +254,33 @@ MCFileTreeRepository >> packageDescriptionFromPackageDirectory: packageDirectory
             filename} ]
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCFileTreeRepository >> packageDescriptionsFromReadableFileNames [
     ^ ((self readableFileNames collect: [ :fileName | self fileDirectoryOn: fileName ])
         select: [ :packageDirectory | self fileUtils directoryExists: packageDirectory ])
         collect: [ :packageDirectory | self packageDescriptionFromPackageDirectory: packageDirectory ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCFileTreeRepository >> packageExtension [
   ^ self repositoryProperties
     at: 'packageExtension'
     ifAbsent: [ self class defaultPackageExtension ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCFileTreeRepository >> parseName: aString extension: extension [
     ^ self class parseName: aString extension: extension
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCFileTreeRepository >> propertyFileExtension [
   ^ self repositoryProperties
     at: 'propertyFileExtension'
     ifAbsent: [ self class defaultPropertyFileExtension ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCFileTreeRepository >> propertyFileExtension: propertyFileExtension [
   self class validatePropertyFileExtension: propertyFileExtension.
   self repositoryProperties
@@ -288,23 +289,23 @@ MCFileTreeRepository >> propertyFileExtension: propertyFileExtension [
   self writeRepositoryProperties
 ]
 
-{ #category : #'i/o' }
+{ #category : 'i/o' }
 MCFileTreeRepository >> readStreamForFileNamed: aString do: aBlock [
     ^ aBlock value: self directory
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeRepository >> readonly [
     readonly ifNil: [ readonly := false ].
     ^ readonly
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeRepository >> readonly: anObject [
 	readonly := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeRepository >> repositoryProperties [
 
 	repositoryProperties
@@ -325,7 +326,7 @@ MCFileTreeRepository >> repositoryProperties [
 	^ repositoryProperties
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeRepository >> versionFrom: aVersionReferenceString [
     "until we no longer find .tree directories in the wild"
 
@@ -337,12 +338,12 @@ MCFileTreeRepository >> versionFrom: aVersionReferenceString [
     ^ nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeRepository >> versionFromFileNamed: aString [
 	^ self loadVersionFromFileNamed: aString
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 MCFileTreeRepository >> versionInfoForPackageDirectory: packageDirectory [
     ^ ((MCReader readerClassForFileNamed: (self fileUtils directoryName: packageDirectory))
         on: (self fileUtils parentDirectoryOf: packageDirectory)
@@ -351,26 +352,26 @@ MCFileTreeRepository >> versionInfoForPackageDirectory: packageDirectory [
         info
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeRepository >> versionInfoFromFileNamed: aString [
 	^ self loadVersionInfoFromFileNamed: aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeRepository >> versionNameFromFileName: aString [
 	| description |
 	description := self packageDescriptionFromPackageDirectory: (self fileDirectoryOn: aString).
 	^ description first , '-' , description second , '.' , description third printString
 ]
 
-{ #category : #interface }
+{ #category : 'interface' }
 MCFileTreeRepository >> versionWithInfo: aVersionInfo ifAbsent: errorBlock [
 	(self allFileNamesForVersionNamed: aVersionInfo name)
 		ifNotEmpty: [ :aCollection | ^ self versionFromFileNamed: aCollection first ].
 	^ errorBlock value
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MCFileTreeRepository >> writeRepositoryProperties [
   self fileUtils
     writeStreamFor: '.filetree'
@@ -401,7 +402,7 @@ MCFileTreeRepository >> writeRepositoryProperties [
 
 ]
 
-{ #category : #'i/o' }
+{ #category : 'i/o' }
 MCFileTreeRepository >> writeStreamForFileNamed: aString replace: aBoolean do: aBlock [
 	self error: 'we do not open a single stream, but write multiple files'
 ]

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressReader.class.st
@@ -4,22 +4,23 @@ Reader for Cypress format
 see https://github.com/CampSmalltalk/Cypress
 "
 Class {
-	#name : #MCFileTreeStCypressReader,
-	#superclass : #MCFileTreeStSnapshotReader,
-	#category : #'MonticelloFileTree-Core'
+	#name : 'MCFileTreeStCypressReader',
+	#superclass : 'MCFileTreeStSnapshotReader',
+	#category : 'MonticelloFileTree-Core',
+	#package : 'MonticelloFileTree-Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeStCypressReader class >> extension [
     ^ 'package'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeStCypressReader class >> monticelloMetaDirName [
     ^ MCFileTreeStCypressWriter monticelloMetaDirName
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeStCypressReader >> addClassAndMethodDefinitionsFromDirectory: aDirectory [
     aDirectory entries
         do: [ :entry | 
@@ -31,7 +32,7 @@ MCFileTreeStCypressReader >> addClassAndMethodDefinitionsFromDirectory: aDirecto
                 ifTrue: [ self addExtensionClassAndMethodDefinitionsFromEntry: entry ] ]
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeStCypressReader >> addClassAndMethodDefinitionsFromEntry: classEntry [
 	| classDirectory classPropertiesDict classComment entries methodPropertiesDict |
 	classDirectory := self fileUtils directoryFromEntry: classEntry.
@@ -62,7 +63,7 @@ MCFileTreeStCypressReader >> addClassAndMethodDefinitionsFromEntry: classEntry [
 		in: entries
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeStCypressReader >> addClassDefinitionFrom: classPropertiesDict comment: classComment [
 
 	| definition |
@@ -86,7 +87,7 @@ MCFileTreeStCypressReader >> addClassDefinitionFrom: classPropertiesDict comment
 	definitions add: definition
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeStCypressReader >> addExtensionClassAndMethodDefinitionsFromEntry: classEntry [
 	| classDirectory classPropertiesDict methodPropertiesDict entries |
 	classDirectory := self fileUtils directoryFromEntry: classEntry.
@@ -110,7 +111,7 @@ MCFileTreeStCypressReader >> addExtensionClassAndMethodDefinitionsFromEntry: cla
 		extensionMethod: true
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeStCypressReader >> addMethodDefinitionsForClass: className methodProperties: methodProperties in: entries [
   ^ self
     addMethodDefinitionsForClass: className
@@ -119,7 +120,7 @@ MCFileTreeStCypressReader >> addMethodDefinitionsForClass: className methodPrope
     extensionMethod: false
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeStCypressReader >> addMethodDefinitionsForClass: className methodProperties: methodProperties in: entries extensionMethod: extensionMethod [
 	entries
 		do: [ :entry | 
@@ -149,7 +150,7 @@ MCFileTreeStCypressReader >> addMethodDefinitionsForClass: className methodPrope
 												source: source) ] ] ] ]
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeStCypressReader >> addTraitAndMethodDefinitionsFromEntry: classEntry [
 	| classDirectory classPropertiesDict classComment entries methodPropertiesDict |
 	classDirectory := self fileUtils directoryFromEntry: classEntry.
@@ -181,7 +182,7 @@ MCFileTreeStCypressReader >> addTraitAndMethodDefinitionsFromEntry: classEntry [
 		in: entries
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeStCypressReader >> addTraitDefinitionFrom: traitPropertiesDict comment: traitComment [
 
 	| definition |
@@ -204,7 +205,7 @@ MCFileTreeStCypressReader >> addTraitDefinitionFrom: traitPropertiesDict comment
 				 yourself) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeStCypressReader >> basicVersion [
     self hasMonticelloMetadata
         ifTrue: [ ^ super basicVersion ].
@@ -216,17 +217,17 @@ MCFileTreeStCypressReader >> basicVersion [
         yourself
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCFileTreeStCypressReader >> isMethodPropertyFile: entry [
 	^ entry name = 'methodProperties.ston' or: [ entry name = 'methodProperties.json']
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCFileTreeStCypressReader >> isPropertyFile: entry [
 	^ entry name = 'properties.ston' or: [ entry name = 'properties.json']
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeStCypressReader >> loadDefinitions [
 
 	| entries directory |
@@ -250,14 +251,14 @@ MCFileTreeStCypressReader >> loadDefinitions [
 			inDirectory: directory ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeStCypressReader >> loadPackage [
     self hasMonticelloMetadata
         ifTrue: [ ^ super loadPackage ].
     package := MCPackage named: self packageNameFromPackageDirectory
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeStCypressReader >> loadVersionInfo [
   self hasMonticelloMetadata
     ifTrue: [ ^ info := self extractInfoFrom: (self parseMember: 'version') ].
@@ -273,20 +274,20 @@ MCFileTreeStCypressReader >> loadVersionInfo [
 
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeStCypressReader >> methodSelectorFor: source [
     ^ Object compilerClass new parseSelector: source
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeStCypressReader >> packageNameFromPackageDirectory [
     | filename2 |
     filename2 := self fileUtils directoryName: packageDirectory.
     ^ filename2 copyFrom: 1 to: (filename2 lastIndexOf: $.) - 1
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeStCypressReader >> setPackageTagIn: definition fromCategory: category [
 
 	| packageName |
@@ -298,7 +299,7 @@ MCFileTreeStCypressReader >> setPackageTagIn: definition fromCategory: category 
 	category = packageName ifFalse: [ definition tagName: (category withoutPrefix: packageName , '-') ]
 ]
 
-{ #category : #validation }
+{ #category : 'validation' }
 MCFileTreeStCypressReader >> validateExtensionMethodCategory: categoryName for: className selector: selector [
   "https://github.com/dalehenrich/filetree/issues/136"
 
@@ -325,7 +326,7 @@ MCFileTreeStCypressReader >> validateExtensionMethodCategory: categoryName for: 
 
 ]
 
-{ #category : #validation }
+{ #category : 'validation' }
 MCFileTreeStCypressReader >> verifyCategory: categoryName matches: basicPackageName [
   "https://github.com/dalehenrich/filetree/issues/136"
 

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressWriter.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressWriter.class.st
@@ -4,18 +4,19 @@ Writer for Cypress format
 see https://github.com/CampSmalltalk/Cypress
 "
 Class {
-	#name : #MCFileTreeStCypressWriter,
-	#superclass : #MCFileTreeStSnapshotWriter,
+	#name : 'MCFileTreeStCypressWriter',
+	#superclass : 'MCFileTreeStSnapshotWriter',
 	#instVars : [
 		'fileStream'
 	],
 	#classInstVars : [
 		'specials'
 	],
-	#category : #'MonticelloFileTree-Core'
+	#category : 'MonticelloFileTree-Core',
+	#package : 'MonticelloFileTree-Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeStCypressWriter class >> fileNameForSelector: selector [
   ^ (selector includes: $:)
     ifTrue: [ 
@@ -43,14 +44,14 @@ MCFileTreeStCypressWriter class >> fileNameForSelector: selector [
 
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 MCFileTreeStCypressWriter class >> initialize [
     "Force initialization of specials ..."
 
     specials := nil
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCFileTreeStCypressWriter class >> initializeSpecials [
     | map |
     map := Dictionary new.
@@ -75,23 +76,23 @@ MCFileTreeStCypressWriter class >> initializeSpecials [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeStCypressWriter class >> monticelloMetaDirName [
     ^ 'monticello.meta'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeStCypressWriter class >> specials [
     ^ specials ifNil: [ specials := self initializeSpecials ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCFileTreeStCypressWriter >> fileNameForSelector: selector [
   ^ self class fileNameForSelector: selector
 
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCFileTreeStCypressWriter >> fileNameMapFor: aMethodDefinitionCollection [
   "https://github.com/dalehenrich/filetree/issues/92"
 
@@ -143,23 +144,23 @@ MCFileTreeStCypressWriter >> fileNameMapFor: aMethodDefinitionCollection [
   ^ filenameMetaMap
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCFileTreeStCypressWriter >> propertyFileExtension [
   ^ self repository propertyFileExtension
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MCFileTreeStCypressWriter >> setFileStream: aStream [
     super setFileStream: aStream.
     fileStream := aStream
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeStCypressWriter >> writeClassComment: definition [
     fileStream nextPutAll: definition comment withUnixLineEndings
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeStCypressWriter >> writeClassDefinition: definition [
     | properties |
     properties := Dictionary new.
@@ -185,7 +186,7 @@ MCFileTreeStCypressWriter >> writeClassDefinition: definition [
     STON put: properties asJsonOnStreamPretty: fileStream
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeStCypressWriter >> writeClassDefinition: definition to: classPath [
   self
     writeInDirectoryName: classPath
@@ -207,7 +208,7 @@ MCFileTreeStCypressWriter >> writeClassDefinition: definition to: classPath [
           (self methodDefinitions at: definition className ifAbsent: [ #() ]) ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCFileTreeStCypressWriter >> writeDefinitions: aCollection [
   | classDirExtension extensionClasses extensionMethodDefinitions extensionMethodMap methodHolders |
   self writeBasicDefinitions: aCollection.
@@ -273,7 +274,7 @@ MCFileTreeStCypressWriter >> writeDefinitions: aCollection [
 
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeStCypressWriter >> writeExtensionClassDefinition: definition [
     | properties |
     properties := Dictionary new.
@@ -281,7 +282,7 @@ MCFileTreeStCypressWriter >> writeExtensionClassDefinition: definition [
     STON put: properties asJsonOnStreamPretty: fileStream
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeStCypressWriter >> writeExtensionClassDefinition: definition to: classPath [
   self
     writeInDirectoryName: classPath
@@ -290,7 +291,7 @@ MCFileTreeStCypressWriter >> writeExtensionClassDefinition: definition to: class
     visit: [ self writeExtensionClassDefinition: definition ]
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeStCypressWriter >> writeMethodDefinition: definition [
     fileStream
         nextPutAll: definition category;
@@ -298,12 +299,12 @@ MCFileTreeStCypressWriter >> writeMethodDefinition: definition [
         nextPutAll: definition source withUnixLineEndings
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeStCypressWriter >> writeMethodDefinition: methodDefinition to: methodPath [
   self shouldNotImplement
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeStCypressWriter >> writeMethodDefinition: methodDefinition to: methodPath filename: filename [
   self
     writeInDirectoryName: methodPath
@@ -312,7 +313,7 @@ MCFileTreeStCypressWriter >> writeMethodDefinition: methodDefinition to: methodP
     visit: [ self writeMethodDefinition: methodDefinition ]
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 MCFileTreeStCypressWriter >> writeMethodProperties: classMethodDefinitions [
     "Issue 33: https://github.com/dalehenrich/filetree/issues/33"
 
@@ -328,7 +329,7 @@ MCFileTreeStCypressWriter >> writeMethodProperties: classMethodDefinitions [
     STON put: properties asJsonOnStreamPretty: fileStream
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCFileTreeStCypressWriter >> writePropertiesFile [
   | properties |
   properties := Dictionary new.
@@ -347,7 +348,7 @@ MCFileTreeStCypressWriter >> writePropertiesFile [
     visit: [ STON put: (Dictionary new) asJsonOnStreamPretty: fileStream ]
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeStCypressWriter >> writeTraitDefinition: definition [
     | properties compositionString |
     properties := Dictionary new.
@@ -369,7 +370,7 @@ MCFileTreeStCypressWriter >> writeTraitDefinition: definition [
     STON put: properties asJsonOnStreamPretty: fileStream
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeStCypressWriter >> writeTraitDefinition: definition to: classPath [
   self
     writeInDirectoryName: classPath

--- a/src/MonticelloFileTree-Core/MCFileTreeStReader.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStReader.class.st
@@ -2,17 +2,18 @@
 A reader for Smalltalk code
 "
 Class {
-	#name : #MCFileTreeStReader,
-	#superclass : #MCFileTreeAbstractReader,
-	#category : #'MonticelloFileTree-Core'
+	#name : 'MCFileTreeStReader',
+	#superclass : 'MCFileTreeAbstractReader',
+	#category : 'MonticelloFileTree-Core',
+	#package : 'MonticelloFileTree-Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeStReader class >> extension [
 	^ 'tree'
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeStReader >> addClassAndMethodDefinitionsFromDirectory: aDirectory [
     self addClassAndMethodDefinitionsFromDirectoryEntries: aDirectory entries
 ]

--- a/src/MonticelloFileTree-Core/MCFileTreeStSnapshotReader.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStSnapshotReader.class.st
@@ -2,17 +2,18 @@
 Snapshot reader
 "
 Class {
-	#name : #MCFileTreeStSnapshotReader,
-	#superclass : #MCFileTreeAbstractReader,
-	#category : #'MonticelloFileTree-Core'
+	#name : 'MCFileTreeStSnapshotReader',
+	#superclass : 'MCFileTreeAbstractReader',
+	#category : 'MonticelloFileTree-Core',
+	#package : 'MonticelloFileTree-Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeStSnapshotReader class >> extension [
     ^ 'pkg'
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 MCFileTreeStSnapshotReader >> addClassAndMethodDefinitionsFromDirectory: aDirectory [
     | snapshot classes entries extensions |
     snapshot := self fileUtils directoryFromPath: 'snapshot' relativeTo: aDirectory.

--- a/src/MonticelloFileTree-Core/MCFileTreeStSnapshotWriter.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStSnapshotWriter.class.st
@@ -2,67 +2,68 @@
 Snapshot writer
 "
 Class {
-	#name : #MCFileTreeStSnapshotWriter,
-	#superclass : #MCFileTreeAbstractStWriter,
+	#name : 'MCFileTreeStSnapshotWriter',
+	#superclass : 'MCFileTreeAbstractStWriter',
 	#instVars : [
 		'classDefinitions',
 		'traitDefinitions',
 		'classTraitDefinitions',
 		'methodDefinitions'
 	],
-	#category : #'MonticelloFileTree-Core'
+	#category : 'MonticelloFileTree-Core',
+	#package : 'MonticelloFileTree-Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeStSnapshotWriter >> classDefinitions [
     ^ classDefinitions ifNil: [ classDefinitions := Dictionary new ]
    
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeStSnapshotWriter >> classTraitDefinitions [
     classTraitDefinitions ifNil: [ classTraitDefinitions := Dictionary new ].
     ^ classTraitDefinitions
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeStSnapshotWriter >> methodDefinitions [
     methodDefinitions ifNil: [ methodDefinitions := Dictionary new ].
     ^ methodDefinitions
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeStSnapshotWriter >> traitDefinitions [
     traitDefinitions ifNil: [ traitDefinitions := Dictionary new ].
     ^ traitDefinitions
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCFileTreeStSnapshotWriter >> visitClassDefinition: definition [
     orderedClassNames add: definition className.
     self classDefinitions at: definition className put: definition
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCFileTreeStSnapshotWriter >> visitClassTraitDefinition: definition [
     orderedTraitNames add: definition className, ' classTrait'.
     self classTraitDefinitions at: definition className put: definition
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCFileTreeStSnapshotWriter >> visitMethodDefinition: definition [
     (self methodDefinitions
         at: definition className
         ifAbsent: [ self methodDefinitions at: definition className put: OrderedCollection new ]) add: definition
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCFileTreeStSnapshotWriter >> visitTraitDefinition: definition [
     orderedTraitNames add: definition className.
     self traitDefinitions at: definition className put: definition
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeStSnapshotWriter >> writeClassDefinition: definition to: classPath [
     self
         writeInDirectoryName: classPath
@@ -71,7 +72,7 @@ MCFileTreeStSnapshotWriter >> writeClassDefinition: definition to: classPath [
         visit: [ self writeClassDefinition: definition ]
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeStSnapshotWriter >> writeClassTraitDefinition: definition to: traitPath [
     self
         writeInDirectoryName: traitPath
@@ -80,7 +81,7 @@ MCFileTreeStSnapshotWriter >> writeClassTraitDefinition: definition to: traitPat
         visit: [ self writeClassTraitDefinition: definition ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MCFileTreeStSnapshotWriter >> writeDefinitions: aCollection [
   | basePath extensionClasses extensionMethodDefinitions methodHolders |
   self writeBasicDefinitions: aCollection.
@@ -123,7 +124,7 @@ MCFileTreeStSnapshotWriter >> writeDefinitions: aCollection [
 
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeStSnapshotWriter >> writeMethodDefinition: methodDefinition to: methodPath [
     | filename |
     filename := self fileNameForSelector: methodDefinition selector.
@@ -134,7 +135,7 @@ MCFileTreeStSnapshotWriter >> writeMethodDefinition: methodDefinition to: method
         visit: [ self writeMethodDefinition: methodDefinition ]
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeStSnapshotWriter >> writeMethodHolderDefinitions: aCollection extension: extension to: basePath do: aBlock [
   aCollection
     keysAndValuesDo: [ :className :definition | 
@@ -169,7 +170,7 @@ MCFileTreeStSnapshotWriter >> writeMethodHolderDefinitions: aCollection extensio
 
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeStSnapshotWriter >> writeTraitDefinition: definition to: traitPath [
     self
         writeInDirectoryName: traitPath

--- a/src/MonticelloFileTree-Core/MCFileTreeStWriter.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStWriter.class.st
@@ -2,12 +2,13 @@
 A writer for Smalltalk code
 "
 Class {
-	#name : #MCFileTreeStWriter,
-	#superclass : #MCFileTreeAbstractStWriter,
-	#category : #'MonticelloFileTree-Core'
+	#name : 'MCFileTreeStWriter',
+	#superclass : 'MCFileTreeAbstractStWriter',
+	#category : 'MonticelloFileTree-Core',
+	#package : 'MonticelloFileTree-Core'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCFileTreeStWriter >> visitClassDefinition: definition [
     orderedClassNames add: definition className.
     self
@@ -17,7 +18,7 @@ MCFileTreeStWriter >> visitClassDefinition: definition [
         visit: [ self writeClassDefinition: definition ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCFileTreeStWriter >> visitClassTraitDefinition: definition [
     orderedTraitNames add: definition className, ' classTrait'.
     self
@@ -27,7 +28,7 @@ MCFileTreeStWriter >> visitClassTraitDefinition: definition [
         visit: [ self writeClassTraitDefinition: definition ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCFileTreeStWriter >> visitMethodDefinition: definition [
     | filename directoryname |
     directoryname := definition classIsMeta
@@ -41,7 +42,7 @@ MCFileTreeStWriter >> visitMethodDefinition: definition [
         visit: [ self writeMethodDefinition: definition ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCFileTreeStWriter >> visitTraitDefinition: definition [
     orderedTraitNames add: definition className.
     self

--- a/src/MonticelloFileTree-Core/MCFileTreeVersionInfoWriter.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeVersionInfoWriter.class.st
@@ -2,12 +2,13 @@
 Write for the version info
 "
 Class {
-	#name : #MCFileTreeVersionInfoWriter,
-	#superclass : #MCVersionInfoWriter,
-	#category : #'MonticelloFileTree-Core'
+	#name : 'MCFileTreeVersionInfoWriter',
+	#superclass : 'MCVersionInfoWriter',
+	#category : 'MonticelloFileTree-Core',
+	#package : 'MonticelloFileTree-Core'
 }
 
-{ #category : #serialization }
+{ #category : 'serialization' }
 MCFileTreeVersionInfoWriter >> writeVersionInfo: aVersionInfo [
 	(self isWritten: aVersionInfo)
 		ifTrue: [^ stream nextPutAll: '(id '; print: aVersionInfo id asString; nextPut: $) ].

--- a/src/MonticelloFileTree-Core/MCFileTreeWriter.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeWriter.class.st
@@ -2,24 +2,25 @@
 Writer for the file tree
 "
 Class {
-	#name : #MCFileTreeWriter,
-	#superclass : #MCMczWriter,
+	#name : 'MCFileTreeWriter',
+	#superclass : 'MCMczWriter',
 	#instVars : [
 		'directory',
 		'packageFileDirectory',
 		'cachedPackageFileDirectoryEntries'
 	],
-	#category : #'MonticelloFileTree-Core'
+	#category : 'MonticelloFileTree-Core',
+	#package : 'MonticelloFileTree-Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeWriter class >> readerClass [
     "don't expect this message to be sent"
 
     self shouldNotImplement
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeWriter >> addString: string at: fileNameOrPath [
     "fileNameOrPath may have one or two elements"
 
@@ -38,7 +39,7 @@ MCFileTreeWriter >> addString: string at: fileNameOrPath [
         ifFalse: [ utils writeStreamFor: path in: self packageFileDirectory do: [ :file | file nextPutAll: string ] ]
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeWriter >> addString: string at: fileNameOrPath encodedTo: ignored [
     "fileNameOrPath may have one or two elements"
     "encodeTo: arg, because FileTree uses UTF8 by default"
@@ -58,7 +59,7 @@ MCFileTreeWriter >> addString: string at: fileNameOrPath encodedTo: ignored [
         ifFalse: [ utils writeStreamFor: path in: self packageFileDirectory do: [ :file | file nextPutAll: string ] ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCFileTreeWriter >> deleteExistingPackageStructureFor: members [
     "destroy .tree and .pkg directory structure .. otherwise it won't be pretty"
 
@@ -81,17 +82,17 @@ MCFileTreeWriter >> deleteExistingPackageStructureFor: members [
                 ifTrue: [ self fileUtils deleteAll: alternateDir ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeWriter >> fileUtils [
     ^ MCFileTreeFileUtils current
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeWriter >> flush [
 	
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCFileTreeWriter >> initializePackageFileDirectoryCache [
     cachedPackageFileDirectoryEntries := Dictionary new.
     self packageFileDirectory entries
@@ -100,19 +101,19 @@ MCFileTreeWriter >> initializePackageFileDirectoryCache [
                 ifTrue: [ cachedPackageFileDirectoryEntries at: entry name put: (self fileUtils directoryFromEntry: entry) ] ]
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeWriter >> packageFileDirectory [
     packageFileDirectory
         ifNil: [ packageFileDirectory := self fileUtils directoryFromPath: directory relativeTo: stream directory ].
     ^ packageFileDirectory
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 MCFileTreeWriter >> repository [
   ^ stream
 ]
 
-{ #category : #serializing }
+{ #category : 'serializing' }
 MCFileTreeWriter >> serializeVersionInfo: aVersionInfo [
 	infoWriter ifNil: [infoWriter := MCFileTreeVersionInfoWriter new].
 	^ String streamContents: [:s |
@@ -120,12 +121,12 @@ MCFileTreeWriter >> serializeVersionInfo: aVersionInfo [
 		infoWriter writeVersionInfo: aVersionInfo]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MCFileTreeWriter >> snapshotWriterClass [
 	^ MCFileTreeAbstractStWriter
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCFileTreeWriter >> subPackageFileDirectoryFor: directoryNameOrPath [
     ^ cachedPackageFileDirectoryEntries
         at: directoryNameOrPath
@@ -136,12 +137,12 @@ MCFileTreeWriter >> subPackageFileDirectoryFor: directoryNameOrPath [
             dir ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCFileTreeWriter >> writeSnapshot: aSnapshot [
 	(self snapshotWriterClass on: self) writeDefinitions: aSnapshot definitions
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 MCFileTreeWriter >> writeVersion: aVersion [
     | members |
     directory := (members := MCFileTreeRepository parseName: aVersion info name) last.

--- a/src/MonticelloFileTree-Core/MCMethodDefinition.extension.st
+++ b/src/MonticelloFileTree-Core/MCMethodDefinition.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #MCMethodDefinition }
+Extension { #name : 'MCMethodDefinition' }
 
-{ #category : #'*MonticelloFileTree-Core' }
+{ #category : '*MonticelloFileTree-Core' }
 MCMethodDefinition >> setTimeStamp: aString [
     ^ timeStamp := aString
 ]

--- a/src/MonticelloFileTree-Core/MCRepository.extension.st
+++ b/src/MonticelloFileTree-Core/MCRepository.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #MCRepository }
+Extension { #name : 'MCRepository' }
 
-{ #category : #'*MonticelloFileTree-Core' }
+{ #category : '*MonticelloFileTree-Core' }
 MCRepository >> retrieveVersionsWithPackageNames: packageNames [
     ^ self readableFileNames
         collect: [ :each | 

--- a/src/MonticelloFileTree-Core/package.st
+++ b/src/MonticelloFileTree-Core/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'MonticelloFileTree-Core' }
+Package { #name : 'MonticelloFileTree-Core' }

--- a/src/RPackage-Core/ClassDescription.extension.st
+++ b/src/RPackage-Core/ClassDescription.extension.st
@@ -1,88 +1,88 @@
-Extension { #name : #ClassDescription }
+Extension { #name : 'ClassDescription' }
 
-{ #category : #'*RPackage-Core' }
+{ #category : '*RPackage-Core' }
 ClassDescription >> definedSelectors [
 	^ self package definedSelectorsForClass: self
 ]
 
-{ #category : #'*RPackage-Core' }
+{ #category : '*RPackage-Core' }
 ClassDescription >> extendingPackages [
 	"the extending packages of a class are the packages that extend it."
 
 	^ self packageOrganizer extendingPackagesOf: self
 ]
 
-{ #category : #'*RPackage-Core' }
+{ #category : '*RPackage-Core' }
 ClassDescription >> extensionSelectors [
 	^ self extendingPackages flatCollect: [ :each | each extensionSelectorsForClass: self ]
 ]
 
-{ #category : #'*RPackage-Core' }
+{ #category : '*RPackage-Core' }
 ClassDescription >> isDefinedInPackage: aPackage [
 	"returns true if aPackage contains the definitino of this class"
 
 	^ aPackage includesClass: self
 ]
 
-{ #category : #'*RPackage-Core' }
+{ #category : '*RPackage-Core' }
 ClassDescription >> isExtended [
 
 	^ self extendingPackages isEmpty
 ]
 
-{ #category : #'*RPackage-Core' }
+{ #category : '*RPackage-Core' }
 ClassDescription >> isExtendedInPackage: aPackage [
 	"returns true if aPackage defines an extension to this class"
 	^ aPackage extendsClass: self
 ]
 
-{ #category : #'*RPackage-Core' }
+{ #category : '*RPackage-Core' }
 ClassDescription >> package [
 
 	^ self packageOrganizer packageOf: self
 ]
 
-{ #category : #'*RPackage-Core' }
+{ #category : '*RPackage-Core' }
 ClassDescription >> packageFromOrganizer: anOrganizer [
 	"returns the package that defines this class"
 	^ anOrganizer packageOf: self
 ]
 
-{ #category : #'*RPackage-Core' }
+{ #category : '*RPackage-Core' }
 ClassDescription >> packageName [
 
 	^ self package ifNotNil: [ :package | package name ]
 ]
 
-{ #category : #'*RPackage-Core' }
+{ #category : '*RPackage-Core' }
 ClassDescription >> packageTag [
 	"Package tags are sub categories of packages to have a better organization of the packages."
 
 	^ self package tagOf: self
 ]
 
-{ #category : #'*RPackage-Core' }
+{ #category : '*RPackage-Core' }
 ClassDescription >> packageTag: aSymbol [
 
 	self flag: #package. "In the future this method should work with a real package tag also."
 	(self package ensureTag: aSymbol) addClass: self
 ]
 
-{ #category : #'*RPackage-Core' }
+{ #category : '*RPackage-Core' }
 ClassDescription >> packageTagName [
 	"Package tags are sub categories of packages to have a better organization of the packages. I return the name of my package tag or nil if the class is uncategorized."
 
 	^ self packageTag ifNotNil: [ :tag | tag name ]
 ]
 
-{ #category : #'*RPackage-Core' }
+{ #category : '*RPackage-Core' }
 ClassDescription >> packages [
 	"the extending packages of a class are the packages that extend it."
 
 	^  self extendingPackages asSet copy add: self package; yourself
 ]
 
-{ #category : #'*RPackage-Core' }
+{ #category : '*RPackage-Core' }
 ClassDescription >> removePackageTag [
 
 	self packageTag isRoot ifTrue: [ "Cannot remove root tag" ^ self ].

--- a/src/RPackage-Core/CompiledCode.extension.st
+++ b/src/RPackage-Core/CompiledCode.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #CompiledCode }
+Extension { #name : 'CompiledCode' }
 
-{ #category : #'*RPackage-Core' }
+{ #category : '*RPackage-Core' }
 CompiledCode >> extensionPackage [
 	"Private method - Do not use it if you don't know what to do.
 	In case I am in an extension, I return the package containing me. Else return nil."
@@ -14,7 +14,7 @@ CompiledCode >> extensionPackage [
 		  ifNone: [ nil ]
 ]
 
-{ #category : #'*RPackage-Core' }
+{ #category : '*RPackage-Core' }
 CompiledCode >> package [
 	"This method returns the package this method belongs to. It takes into account classes and traits.
 	If the method is in no package, returns nil"

--- a/src/RPackage-Core/CompiledMethod.extension.st
+++ b/src/RPackage-Core/CompiledMethod.extension.st
@@ -1,11 +1,11 @@
-Extension { #name : #CompiledMethod }
+Extension { #name : 'CompiledMethod' }
 
-{ #category : #'*RPackage-Core' }
+{ #category : '*RPackage-Core' }
 CompiledMethod >> isDefinedInPackage: anRPackage [
 	^ anRPackage includesDefinedSelector: self selector ofClass: self methodClass
 ]
 
-{ #category : #'*RPackage-Core' }
+{ #category : '*RPackage-Core' }
 CompiledMethod >> isExtension [
 	"I return true if a method is an extension method. Which means that the methods is not packaged in the package of the class containing the method, but in another package."
 
@@ -16,12 +16,12 @@ CompiledMethod >> isExtension [
 	^ self extensionPackage isNotNil
 ]
 
-{ #category : #'*RPackage-Core' }
+{ #category : '*RPackage-Core' }
 CompiledMethod >> isExtensionInPackage: anRPackage [
 	^ anRPackage includesExtensionSelector: self selector ofClass: self methodClass
 ]
 
-{ #category : #'*RPackage-Core' }
+{ #category : '*RPackage-Core' }
 CompiledMethod >> removeFromPackage [
 
 	self isFromTrait ifFalse: [ self package ifNotNil: [ :package | package removeMethod: self ] ]

--- a/src/RPackage-Core/ManifestRPackageCore.class.st
+++ b/src/RPackage-Core/ManifestRPackageCore.class.st
@@ -2,12 +2,14 @@
 Manifest for RPackage-Core
 "
 Class {
-	#name : #ManifestRPackageCore,
-	#superclass : #PackageManifest,
-	#category : #'RPackage-Core-Manifest'
+	#name : 'ManifestRPackageCore',
+	#superclass : 'PackageManifest',
+	#category : 'RPackage-Core-Manifest',
+	#package : 'RPackage-Core',
+	#tag : 'Manifest'
 }
 
-{ #category : #'meta-data - dependency analyser' }
+{ #category : 'meta-data - dependency analyser' }
 ManifestRPackageCore class >> manuallyResolvedDependencies [
 
 	<ignoreForCoverage>

--- a/src/RPackage-Core/PackageAdded.class.st
+++ b/src/RPackage-Core/PackageAdded.class.st
@@ -2,12 +2,14 @@
 I am a public announcement sent when a new RPackage is created
 "
 Class {
-	#name : #PackageAdded,
-	#superclass : #PackageAnnouncement,
-	#category : #'RPackage-Core-Announcements'
+	#name : 'PackageAdded',
+	#superclass : 'PackageAnnouncement',
+	#category : 'RPackage-Core-Announcements',
+	#package : 'RPackage-Core',
+	#tag : 'Announcements'
 }
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 PackageAdded class >> initialize [
 	self deprecatedAliases: { #RPackageRegistered }
 ]

--- a/src/RPackage-Core/PackageAnnouncement.class.st
+++ b/src/RPackage-Core/PackageAnnouncement.class.st
@@ -2,38 +2,40 @@
 Common superclass for package related announcements
 "
 Class {
-	#name : #PackageAnnouncement,
-	#superclass : #SystemAnnouncement,
+	#name : 'PackageAnnouncement',
+	#superclass : 'SystemAnnouncement',
 	#instVars : [
 		'package'
 	],
-	#category : #'RPackage-Core-Announcements'
+	#category : 'RPackage-Core-Announcements',
+	#package : 'RPackage-Core',
+	#tag : 'Announcements'
 }
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 PackageAnnouncement class >> initialize [
 	self deprecatedAliases: { #RPackageAnnouncement }
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 PackageAnnouncement class >> to: aPackage [
 
 	^ self new package: aPackage
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 PackageAnnouncement >> affectsPackages [
 
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 PackageAnnouncement >> package [
 
 	^ package
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 PackageAnnouncement >> package: anObject [
 
 	package := anObject

--- a/src/RPackage-Core/PackageRemoved.class.st
+++ b/src/RPackage-Core/PackageRemoved.class.st
@@ -2,12 +2,14 @@
 I am a public announcement sent when a new RPackage is unregistred ( kind  of removed from the system )
 "
 Class {
-	#name : #PackageRemoved,
-	#superclass : #PackageAnnouncement,
-	#category : #'RPackage-Core-Announcements'
+	#name : 'PackageRemoved',
+	#superclass : 'PackageAnnouncement',
+	#category : 'RPackage-Core-Announcements',
+	#package : 'RPackage-Core',
+	#tag : 'Announcements'
 }
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 PackageRemoved class >> initialize [
 	self deprecatedAliases: { #RPackageUnregistered }
 ]

--- a/src/RPackage-Core/PackageRenamed.class.st
+++ b/src/RPackage-Core/PackageRenamed.class.st
@@ -2,22 +2,24 @@
 I am a public announcement sent when a new RPackage is renamed
 "
 Class {
-	#name : #PackageRenamed,
-	#superclass : #PackageAnnouncement,
+	#name : 'PackageRenamed',
+	#superclass : 'PackageAnnouncement',
 	#instVars : [
 		'oldName',
 		'newName'
 	],
-	#category : #'RPackage-Core-Announcements'
+	#category : 'RPackage-Core-Announcements',
+	#package : 'RPackage-Core',
+	#tag : 'Announcements'
 }
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 PackageRenamed class >> initialize [
 
 	self deprecatedAliases: { #RPackageRenamed }
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 PackageRenamed class >> to: aPackage oldName: aSymbol newName: anotherSymbol [
 
 	^ (self to: aPackage)
@@ -26,54 +28,54 @@ PackageRenamed class >> to: aPackage oldName: aSymbol newName: anotherSymbol [
 		  yourself
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 PackageRenamed >> affectsClass: aClass [
 	^package == aClass package
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 PackageRenamed >> affectsMethod: aMethod [
 	^package == aMethod package
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 PackageRenamed >> affectsMethods [
 	"methods belong to package which could be represented by tools as part of method"
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 PackageRenamed >> affectsMethodsDefinedInClass: aClass [
 
 	^(package definesClass: aClass)
 		or: [ package extendsClass: aClass ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 PackageRenamed >> affectsMethodsDefinedInPackage: aPackage [
 
 	^package == aPackage
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 PackageRenamed >> newName [
 
 	^ newName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 PackageRenamed >> newName: anObject [
 
 	newName := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 PackageRenamed >> oldName [
 
 	^ oldName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 PackageRenamed >> oldName: anObject [
 
 	oldName := anObject

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -54,8 +54,8 @@ Todo
 	- finish 
 "
 Class {
-	#name : #RPackage,
-	#superclass : #Object,
+	#name : 'RPackage',
+	#superclass : 'Object',
 	#instVars : [
 		'extensionSelectors',
 		'definedSelectors',
@@ -67,15 +67,17 @@ Class {
 		'PackageGlobalOrganizer',
 		'Properties'
 	],
-	#category : #'RPackage-Core-Base'
+	#category : 'RPackage-Core-Base',
+	#package : 'RPackage-Core',
+	#tag : 'Base'
 }
 
-{ #category : #constants }
+{ #category : 'constants' }
 RPackage class >> defaultPackageName [
 	^ #'_UnpackagedPackage'
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 RPackage class >> initialize [
 	"Ensure the organizer will be the RPackageOrganizer default"
 	self organizer: nil.
@@ -87,12 +89,12 @@ RPackage class >> initialize [
 			Properties := newDict ]
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 RPackage class >> initializeProperties [
 	Properties := WeakIdentityKeyDictionary new
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RPackage class >> named: aString [
 
 	^ self new
@@ -100,7 +102,7 @@ RPackage class >> named: aString [
 		  yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RPackage class >> named: aString organizer: aPackageOrganizer [
 
 	^ (self named: aString)
@@ -108,19 +110,19 @@ RPackage class >> named: aString organizer: aPackageOrganizer [
 		  yourself
 ]
 
-{ #category : #'protected only for tests' }
+{ #category : 'protected only for tests' }
 RPackage class >> organizer [
 
 	^ PackageGlobalOrganizer ifNil: [ self packageOrganizer ]
 ]
 
-{ #category : #'protected only for tests' }
+{ #category : 'protected only for tests' }
 RPackage class >> organizer: aPackageOrganizer [
 
 	PackageGlobalOrganizer := aPackageOrganizer
 ]
 
-{ #category : #'protected only for tests' }
+{ #category : 'protected only for tests' }
 RPackage class >> withOrganizer: aNewOrganizer do: aBlock [
 	"Perform an action locally to aNewOrganizer. Does not impact any other organizers."
 
@@ -135,13 +137,13 @@ RPackage class >> withOrganizer: aNewOrganizer do: aBlock [
 		aNewOrganizer unregister]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 RPackage >> <= aRPackage [
 
 	^ self name <= aRPackage name
 ]
 
-{ #category : #'class tags' }
+{ #category : 'class tags' }
 RPackage >> actualClassTags [
 
 	(classTags size = 1 and: [classTags anyOne isRoot]) ifTrue: [ ^#() ].
@@ -149,7 +151,7 @@ RPackage >> actualClassTags [
 	^classTags
 ]
 
-{ #category : #'add class' }
+{ #category : 'add class' }
 RPackage >> addClass: aClass [
 	"TODO: deprecate system category / replace this with a direct call to moveClass:fromPackage:toTag:"
 
@@ -161,7 +163,7 @@ RPackage >> addClass: aClass [
 	aClass category: self rootTag categoryName
 ]
 
-{ #category : #'add method - compiled method' }
+{ #category : 'add method - compiled method' }
 RPackage >> addMethod: aCompiledMethod [
 	"Add the method to the receiver as a defined method if the class is  defined in it, else as an extension."
 
@@ -177,25 +179,25 @@ RPackage >> addMethod: aCompiledMethod [
 	^ aCompiledMethod
 ]
 
-{ #category : #'class tags' }
+{ #category : 'class tags' }
 RPackage >> classTagCategoryNames [
 	^ (Set with: self packageName), (self classTags collect: [:each | each categoryName])
 ]
 
-{ #category : #'class tags' }
+{ #category : 'class tags' }
 RPackage >> classTagNamed: aSymbol [
 
 	^ classTags detect: [ :each | each name = aSymbol ]
 ]
 
-{ #category : #'class tags' }
+{ #category : 'class tags' }
 RPackage >> classTagNamed: aSymbol ifAbsent: aBlock [
 	^ classTags
 		detect: [ :each | each name = aSymbol ]
 		ifNone: aBlock
 ]
 
-{ #category : #'class tags' }
+{ #category : 'class tags' }
 RPackage >> classTagNamed: aSymbol ifPresent: aBlock [
 	^ classTags
 		detect: [ :each | each name = aSymbol ]
@@ -203,64 +205,64 @@ RPackage >> classTagNamed: aSymbol ifPresent: aBlock [
 		ifNone: [ nil ]
 ]
 
-{ #category : #'class tags' }
+{ #category : 'class tags' }
 RPackage >> classTags [
 	"Returns the tags of the receiver"
 
 	^ classTags
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> classes [
 	"Return all the classes"
 	^ self definedClasses, self extendedClasses
 ]
 
-{ #category : #'class tags' }
+{ #category : 'class tags' }
 RPackage >> classesTaggedWith: aSymbol [
 	"Returns the classes tagged using aSymbol"
 
 	^ (self classTagNamed: aSymbol ifAbsent: [ ^ #(  ) ]) classes
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> definedClassNames [
 	"Return the class names having methods defined in the receiver."
 
 	^ self definedClasses collect: [ :class | class name ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> definedClasses [
 
 	^ self classTags flatCollect: [ :tag | tag classes ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> definedMethodsForClass: aClass [
 
 	^ (self definedSelectorsForClass: aClass) asOrderedCollection collect: [ :each | aClass >> each ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> definedOrExtendedClasses [
 	^ self definedClasses | self extendedClasses
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> definedSelectorsForClass: aClass [
 
 	^ definedSelectors at: aClass ifAbsent: [ #(  ) ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackage >> definesClass: aClass [
 	"Returns true if the class, aClass, is one of the locally defined classes"
 	"should be probably removed since this is the same as includesClass: or the inverse"
 	^ self includesClass: aClass
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackage >> definesOrExtendsClass: aClass [
 	"Returns true whether the class, aClass, is one of the locally defined classes of the receiver or
 	if the receiver extends such class (that is defined in another package)"
@@ -270,7 +272,7 @@ RPackage >> definesOrExtendsClass: aClass [
 	^ (self includesClassNamed: canonizedName) or: [ self extendedClassNames includes: canonizedName ]
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 RPackage >> demoteToTagInPackage [
 
 	| newPackage tag |
@@ -290,12 +292,12 @@ RPackage >> demoteToTagInPackage [
 	^ newPackage
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 RPackage >> ensureProperties [
 	^ Properties at: self ifAbsentPut: WeakKeyDictionary new
 ]
 
-{ #category : #'class tags' }
+{ #category : 'class tags' }
 RPackage >> ensureTag: aTag [
 
 	| tagName newTag |
@@ -319,27 +321,27 @@ RPackage >> ensureTag: aTag [
 	^ newTag
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> environment [
 
 	^ self organizer environment
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> extendedClassNames [
 	"Return the name of the classes which are extended by the receiver package. if a metaclass is extended, just get its sole instance class name."
 
 	^ extensionSelectors keys collect: [ :class | class instanceSide name ] as: Set
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> extendedClasses [
 	"Return classes and metaclasses that are extended in the receiver. They represent the classes of method extensions"
 
 	^ extensionSelectors keys
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackage >> extendsClass: aClass [
 	"Returns true if the receiver extends aClass (that is defined in another package)"
 
@@ -348,7 +350,7 @@ RPackage >> extendsClass: aClass [
 	^ self extendedClassNames includes: canonizedName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> extensionMethods [
 	"Extension methods are methods defined on classes that are not defined in the receiver"
 
@@ -358,20 +360,20 @@ RPackage >> extensionMethods [
 	^ methods
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> extensionMethodsForClass: aClass [
 	"Change the set of extensions selectors to an Array to avoid compiled methods collisions in the resulting set."
 
 	^ (self extensionSelectorsForClass: aClass) asArray collect: [ :each | aClass >> each ]
 ]
 
-{ #category : #'system compatibility' }
+{ #category : 'system compatibility' }
 RPackage >> extensionProtocolsForClass: aClass [
 
 	^ aClass protocols select: [ :protocol | protocol isExtensionProtocolMatching: self ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> extensionSelectors [
 	"Extension methods are methods defined on classes that are not defined in the receiver"
 
@@ -381,19 +383,19 @@ RPackage >> extensionSelectors [
 	^ allSelectors
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> extensionSelectorsForClass: aClass [
 
 	^ extensionSelectors at: aClass ifAbsent: [ #(  ) ]
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 RPackage >> hasProperty: aKey [
 	self propertyAt: aKey ifAbsent: [ ^ false ].
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackage >> hasTag: aTag [
 	"Takes a package tag or a package tag name as parameter and return true if I include this package tag."
 
@@ -402,7 +404,7 @@ RPackage >> hasTag: aTag [
 			   ifFalse: [ aTag name ])
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> hierarchyRoots [
 	"Returns all the hiearchy roots (by opposition to single classes inheriting from class outside the package) of a package"
 
@@ -410,7 +412,7 @@ RPackage >> hierarchyRoots [
 		select: [ :each | (each superclass isNil or: [ each superclass package ~~ self ]) and: [ each hasSubclasses ] ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RPackage >> importClass: aClass [
 	"import a class already created but not attached to a package to the receiver.
 	Handle also *- convention. Methods defined in *category are not added to the package.
@@ -420,7 +422,7 @@ RPackage >> importClass: aClass [
 	self importClass: aClass inTag: (self toTagName: aClass category)
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RPackage >> importClass: aClass inTag: aTag [
 	"Import a class already created but not attached to a package to the receiver. It will import the class and its methods.
 
@@ -443,7 +445,7 @@ RPackage >> importClass: aClass inTag: aTag [
 		class protocols reject: [ :protocol | protocol isExtensionProtocol ] thenDo: [ :protocol | self importProtocol: protocol forClass: class ] ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RPackage >> importProtocol: aProtocol forClass: aClass [
 	"import all the local methods of a protocol as defined in the receiver."
 
@@ -452,53 +454,53 @@ RPackage >> importProtocol: aProtocol forClass: aClass [
 		thenDo: [ :method | self addMethod: method ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackage >> includesClass: aClass [
 	"Returns true if the receiver includes aClass in the classes that are defined within it: only class definition are considered - not class extensions"
 
 	^ self classTags anySatisfy: [ :tag | tag includesClass: aClass ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackage >> includesClassNamed: aSymbol [
 	"Returns true if the receiver includes class named aSymbol in the classes that are defined within it: only class definition are considered - not class extensions"
 
 	^ self definedClasses anySatisfy: [ :class | class name = aSymbol ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackage >> includesClassTagNamed: aString [
 	^ self classTags anySatisfy: [ :each | each name = aString ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackage >> includesClassesAffectedBy: aSystemAnnouncement [
 
 	^(aSystemAnnouncement affectsClassesDefinedInPackage: self)
 		or: [ aSystemAnnouncement affectsClassesExtendedInPackage: self ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackage >> includesDefinedSelector: aSelector ofClass: aClass [
 	"Return true if the receiver includes the method of selector aSelector. Only checks methods defined in this package"
 
 	^ (self definedSelectorsForClass: aClass) includes: aSelector asSymbol
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackage >> includesExtensionSelector: aSelector ofClass: aClass [
 	"Return true if the receiver includes the method of selector aSelector. Only checks methods extending other packages"
 
 	^ (self extensionSelectorsForClass: aClass) includes: aSelector asSymbol
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackage >> includesMethodsAffectedBy: aSystemAnnouncement [
 
 	^aSystemAnnouncement affectsMethodsDefinedInPackage: self
 ]
 
-{ #category : #'system compatibility' }
+{ #category : 'system compatibility' }
 RPackage >> includesProtocol: protocol ofClass: aClass [
 
 	(protocol isExtensionProtocolMatching: self) ifTrue: [ ^ true ].
@@ -507,14 +509,14 @@ RPackage >> includesProtocol: protocol ofClass: aClass [
 	^ (self includesClass: aClass) and: [ protocol isExtensionProtocol not ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackage >> includesSelector: aSelector ofClass: aClass [
 	"Return true if the receiver includes the method of selector aSelector. Checks methods defined locally as well as extending other packages"
 
 	^ (self includesDefinedSelector: aSelector ofClass: aClass) or: [ self includesExtensionSelector: aSelector ofClass: aClass ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RPackage >> initialize [
 
 	super initialize.
@@ -523,27 +525,27 @@ RPackage >> initialize [
 	classTags := Set new
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackage >> isDefault [
 	"Return whether the receiver is the default package, i.e. the one used when nothing else is specified."
 	^ self name = self class defaultPackageName
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackage >> isDeprecated [
 	^ self packageManifestOrNil
 		ifNil: [ ^ false ]
 		ifNotNil: [ :manifest | manifest isDeprecated ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackage >> isEmpty [
 
 	self name = self class defaultPackageName ifTrue: [ ^ false ].
 	^ self classes isEmpty and: [ self extensionSelectors isEmpty ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackage >> isTestPackage [
 	"1. Test package ends with suffix -Tests. Suffix is case sensitive.
 	 2. Or test package contains '-Tests-' in middle.
@@ -556,14 +558,14 @@ RPackage >> isTestPackage [
 	^ (self name endsWith: '-Tests') or: [self name includesSubstring: '-Tests-']
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> linesOfCode [
 	"An approximate measure of lines of code.
 	Includes comments, but excludes blank lines."
 	^self methods inject: 0 into: [:sum :each | sum + each linesOfCode]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> methods [
 	"Return all the methods defined in this package. Including extension methods (i.e., methods defined on a class that is not defined by me)"
 
@@ -576,7 +578,7 @@ RPackage >> methods [
 	^ methods
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> methodsForClass: aClass [
 	"Returns all compiled methods for a class in the receiver without distinction of extensions or not"
 
@@ -585,7 +587,7 @@ RPackage >> methodsForClass: aClass [
 		ifTrue: [self definedMethodsForClass: aClass]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RPackage >> moveClass: aClass toTag: aTag [
 
 	| oldPackage |
@@ -597,52 +599,52 @@ RPackage >> moveClass: aClass toTag: aTag [
 	SystemAnnouncer uniqueInstance classRepackaged: aClass from: oldPackage to: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> name [
 
 	^ name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> name: aSymbol [
 	"Set the name of a package. This method is private and should not be used.
 	If you wish to rename a package, use #renameTo: instead"
 	name := aSymbol asSymbol
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RPackage >> organizer [
 
 	self flag: #package.
 	^ organizer ifNil: [ self class organizer ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> organizer: anObject [
 
 	organizer := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> packageManifestOrNil [
 	^ self definedClasses
 		detect: [ :each | each isManifest ]
 		ifNone: [ nil ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> packageName [
 
 	^ name
 ]
 
-{ #category : #'system compatibility' }
+{ #category : 'system compatibility' }
 RPackage >> packages [
 	"Compatibility with monticello and old PackageInfo"
 	^ self classTags
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 RPackage >> printOn: aStream [
 	super printOn: aStream.
 	aStream nextPut: $(.
@@ -650,19 +652,19 @@ RPackage >> printOn: aStream [
 	aStream nextPut: $)
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 RPackage >> properties [
 	^ Properties at: self ifAbsent: nil
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 RPackage >> propertyAt: propName [
 	^ self
 		propertyAt: propName
 		ifAbsent: [ nil ]
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 RPackage >> propertyAt: propName ifAbsent: aBlock [
 	self properties ifNil: [^aBlock value].
 	^ self properties
@@ -670,33 +672,33 @@ RPackage >> propertyAt: propName ifAbsent: aBlock [
 		ifAbsent: aBlock
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 RPackage >> propertyAt: aKey ifAbsentPut: aBlock [
 	"Answer the property associated with aKey or, if aKey isn't found store the result of evaluating aBlock as new value."
 
 	^ self propertyAt: aKey ifAbsent: [ self propertyAt: aKey put: aBlock value ]
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 RPackage >> propertyAt: propName put: propValue [
 	^ self ensureProperties
 		at: propName
 		put: propValue
 ]
 
-{ #category : #register }
+{ #category : 'register' }
 RPackage >> register [
 	self organizer registerPackage: self
 ]
 
-{ #category : #'private - register' }
+{ #category : 'private - register' }
 RPackage >> registerClass: aClass [
 	"Private method that declares the mapping between a class and its package."
 
 	self organizer registerPackage: self forClass: aClass
 ]
 
-{ #category : #'private - register' }
+{ #category : 'private - register' }
 RPackage >> removeAllMethodsFromClass: aClass [
 	"Remove all the methods (defined and extensions) that are related to the class as parameter. The class should always be instance side."
 
@@ -708,7 +710,7 @@ RPackage >> removeAllMethodsFromClass: aClass [
 	self organizer unregisterExtendingPackage: self forClass: aClass
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 RPackage >> removeClass: aClass [
 	"I remove the class, methods and potential empty tags from myself."
 
@@ -724,13 +726,13 @@ RPackage >> removeClass: aClass [
 	self unregisterClass: aClass
 ]
 
-{ #category : #'class tags' }
+{ #category : 'class tags' }
 RPackage >> removeEmptyTags [
 
 	(self classTags select: [ :tag | tag isEmpty ]) do: [ :emptyTag | self removeTag: emptyTag ]
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 RPackage >> removeFromSystem [
 
 	| categories |
@@ -747,7 +749,7 @@ RPackage >> removeFromSystem [
 	self unregister
 ]
 
-{ #category : #'add method - compiled method' }
+{ #category : 'add method - compiled method' }
 RPackage >> removeMethod: aCompiledMethod [
 	"Remove the method to the receiver as a defined method."
 
@@ -770,25 +772,25 @@ RPackage >> removeMethod: aCompiledMethod [
 	^ aCompiledMethod
 ]
 
-{ #category : #'add method - compiled method' }
+{ #category : 'add method - compiled method' }
 RPackage >> removeMethods: aCollection [
 	aCollection do: [ :each | self removeMethod: each ]
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 RPackage >> removePropertiesIfEmpty [
 	^ Properties at: self ifPresent: [ :dict |
 		dict ifEmpty: [ Properties removeKey: self ] ]
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 RPackage >> removeProperty: propName [
 	^ self
 		removeProperty: propName
 		ifAbsent: [ nil ]
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 RPackage >> removeProperty: propName ifAbsent: aBlock [
 	| property |
 	self properties ifNil: [^aBlock value].
@@ -799,7 +801,7 @@ RPackage >> removeProperty: propName ifAbsent: aBlock [
 	^ property
 ]
 
-{ #category : #'class tags' }
+{ #category : 'class tags' }
 RPackage >> removeTag: aTag [
 
 	| tag |
@@ -812,7 +814,7 @@ RPackage >> removeTag: aTag [
 	SystemAnnouncer announce: (PackageTagRemoved to: tag)
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RPackage >> renameExtensionsPrefixedWith: oldName to: newName [
 
 	| protocols |
@@ -821,7 +823,7 @@ RPackage >> renameExtensionsPrefixedWith: oldName to: newName [
 	protocols do: [ :protocol | protocol rename: '*' , newName , (protocol name allButFirst: oldName size + 1) ]
 ]
 
-{ #category : #'class tags' }
+{ #category : 'class tags' }
 RPackage >> renameTag: aTag to: newName [
 
 	(self hasTag: aTag) ifFalse: [ ^ self ].
@@ -831,7 +833,7 @@ RPackage >> renameTag: aTag to: newName [
 		 ifFalse: [ aTag ]) renameTo: newName
 ]
 
-{ #category : #register }
+{ #category : 'register' }
 RPackage >> renameTo: aSymbol [
 	"Rename a package with a different name, provided as a symbol"
 
@@ -854,20 +856,20 @@ RPackage >> renameTo: aSymbol [
 	SystemAnnouncer uniqueInstance announce: (PackageRenamed to: self oldName: oldName newName: newName)
 ]
 
-{ #category : #'class tags' }
+{ #category : 'class tags' }
 RPackage >> rootTag [
 
 	^ self ensureTag: self rootTagName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> rootTagName [
 
 	self flag: #package. "In the future we should not use the name of the package because it causes bugs."
 	^ self name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> roots [
 	"Returns all the root classes of a package. A root class is a class whose superclass is not defined in the package.
 	Root classes are potentially root of inheritance trees defined in a package."
@@ -876,7 +878,7 @@ RPackage >> roots [
 		select: [ :each | each superclass isNil or: [ each superclass package ~~ self ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> selectors [
 
 	| allSelectors |
@@ -886,7 +888,7 @@ RPackage >> selectors [
 	^ allSelectors
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackage >> selectorsForClass: aClass [
 	"Returns all selectors for a class in the receiver without distinction of extensions or not"
 
@@ -895,13 +897,13 @@ RPackage >> selectorsForClass: aClass [
 		ifTrue: [self definedSelectorsForClass: aClass]
 ]
 
-{ #category : #'class tags' }
+{ #category : 'class tags' }
 RPackage >> tagNames [
 
 	^ self classTags collect: [ :tag | tag name ]
 ]
 
-{ #category : #'class tags' }
+{ #category : 'class tags' }
 RPackage >> tagOf: aClass [
 
 	^ self classTags
@@ -909,7 +911,7 @@ RPackage >> tagOf: aClass [
 		  ifNone: [ nil ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RPackage >> toTagName: aSymbol [
 
 	^ (aSymbol beginsWith: self name asString , '-')
@@ -920,13 +922,13 @@ RPackage >> toTagName: aSymbol [
 				  ifFalse: [ aSymbol ] ]
 ]
 
-{ #category : #register }
+{ #category : 'register' }
 RPackage >> unregister [
 
 	self organizer removePackage: self
 ]
 
-{ #category : #'private - register' }
+{ #category : 'private - register' }
 RPackage >> unregisterClass: aClass [
 	"Private method that declares the mapping between a class and its package."
 

--- a/src/RPackage-Core/RPackageConflictError.class.st
+++ b/src/RPackage-Core/RPackageConflictError.class.st
@@ -6,7 +6,9 @@ PackageA(tagB) conflicts with PackageA-B
 PackageA-B conflicts with PackageA(tagB)
 "
 Class {
-	#name : #RPackageConflictError,
-	#superclass : #Error,
-	#category : #'RPackage-Core-Exceptions'
+	#name : 'RPackageConflictError',
+	#superclass : 'Error',
+	#category : 'RPackage-Core-Exceptions',
+	#package : 'RPackage-Core',
+	#tag : 'Exceptions'
 }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -101,8 +101,8 @@ SystemMethodRemovedAnnouncement
        => I would simply remove the method from the RPackage in which it is register
 "
 Class {
-	#name : #RPackageOrganizer,
-	#superclass : #Object,
+	#name : 'RPackageOrganizer',
+	#superclass : 'Object',
 	#instVars : [
 		'classPackageMapping',
 		'packages',
@@ -111,17 +111,19 @@ Class {
 		'environment',
 		'categoryMap'
 	],
-	#category : #'RPackage-Core-Base'
+	#category : 'RPackage-Core-Base',
+	#package : 'RPackage-Core',
+	#tag : 'Base'
 }
 
-{ #category : #singleton }
+{ #category : 'singleton' }
 RPackageOrganizer class >> default [
 	"Warning: Use 'self packageOrganizer' since I will be removed in the future."
 
 	^ self packageOrganizer
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 RPackageOrganizer class >> initialize [
 	"You need manually filll the data:
 
@@ -130,13 +132,13 @@ RPackageOrganizer class >> initialize [
 	is the usual way (but is not in this package by default, it depends on MC)"
 ]
 
-{ #category : #quieries }
+{ #category : 'quieries' }
 RPackageOrganizer class >> isPackageDefinedForClass: aClass [
 
 	^ (self default packageOf: aClass) notNil
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RPackageOrganizer class >> methodAdded: anEvent [
 	"precondition: package exist, class exist"
 
@@ -147,7 +149,7 @@ RPackageOrganizer class >> methodAdded: anEvent [
 			RPackage new named: (self packageOrganizer categoryOfBehavior: anEvent methodClass instanceSide) ] ]
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 RPackageOrganizer class >> registerInterestToSystemAnnouncement [
 
 	<script>
@@ -156,13 +158,13 @@ RPackageOrganizer class >> registerInterestToSystemAnnouncement [
 	self packageOrganizer registerInterestToSystemAnnouncement
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 RPackageOrganizer class >> unregisterInterestToSystemAnnouncement [
 
 	self default unregisterInterestToSystemAnnouncement
 ]
 
-{ #category : #'deprecated - SystemOrganizer leftovers' }
+{ #category : 'deprecated - SystemOrganizer leftovers' }
 RPackageOrganizer >> addCategory: catString [
 	"Add a new category named catString"
 
@@ -171,7 +173,7 @@ RPackageOrganizer >> addCategory: catString [
 	SystemAnnouncer uniqueInstance classCategoryAdded: catString
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RPackageOrganizer >> addMethod: method [
 	"we have to register the method in the parent RPackage of the class.
 	to do that, we first have to look if the method is an extension from an external package:"
@@ -188,12 +190,12 @@ RPackageOrganizer >> addMethod: method [
 	package addMethod: method
 ]
 
-{ #category : #'system integration' }
+{ #category : 'system integration' }
 RPackageOrganizer >> announcer [
 	^SystemAnnouncer uniqueInstance private
 ]
 
-{ #category : #'initialization - data' }
+{ #category : 'initialization - data' }
 RPackageOrganizer >> basicInitializeFromPackagesList: aPackagesList [
 
 	aPackagesList
@@ -214,27 +216,27 @@ RPackageOrganizer >> basicInitializeFromPackagesList: aPackagesList [
 		displayingProgress: 'Importing extensions'
 ]
 
-{ #category : #'private - registration' }
+{ #category : 'private - registration' }
 RPackageOrganizer >> basicRegisterPackage: aPackage [
 	"A new package is now available and declared in the receiver. Note that it is a low level implementation method since it does not deal with package contained information and does not update the related mapping tables."
 
 	^ packages at: aPackage name asSymbol put: aPackage
 ]
 
-{ #category : #'private - registration' }
+{ #category : 'private - registration' }
 RPackageOrganizer >> basicUnregisterPackage: aPackage [
 	"Unregister the specified package from the list of registered packages. Raise the PackageRemoved announcement. This is a low level action. It does not unregister the back pointer from classes to packages or any other information managed by the organizer"
 
 	^ packages removeKey: aPackage name ifAbsent: [  ]
 ]
 
-{ #category : #'deprecated - SystemOrganizer leftovers' }
+{ #category : 'deprecated - SystemOrganizer leftovers' }
 RPackageOrganizer >> categories [
 
 	^ categoryMap keys
 ]
 
-{ #category : #'deprecated - SystemOrganizer leftovers' }
+{ #category : 'deprecated - SystemOrganizer leftovers' }
 RPackageOrganizer >> categoriesMatching: matchString [
 	"Return all matching categories"
 
@@ -242,7 +244,7 @@ RPackageOrganizer >> categoriesMatching: matchString [
 	^ self categories select: [ :c | matchString match: c ]
 ]
 
-{ #category : #'deprecated - SystemOrganizer leftovers' }
+{ #category : 'deprecated - SystemOrganizer leftovers' }
 RPackageOrganizer >> categoryOfBehavior: behavior [
 	"Answer the category associated with the argument. This method can take a Behavior or a Behavior name as parameter."
 
@@ -256,13 +258,13 @@ RPackageOrganizer >> categoryOfBehavior: behavior [
 	^ nil
 ]
 
-{ #category : #'deprecated - SystemOrganizer leftovers' }
+{ #category : 'deprecated - SystemOrganizer leftovers' }
 RPackageOrganizer >> classesInCategory: category [
 
 	^ (self listAtCategoryNamed: category) collect: [ :className | self environment at: className ]
 ]
 
-{ #category : #'deprecated - SystemOrganizer leftovers' }
+{ #category : 'deprecated - SystemOrganizer leftovers' }
 RPackageOrganizer >> classify: behaviorName under: categoryName [
 	"Store the argument, element, in the category named heading."
 
@@ -281,13 +283,13 @@ RPackageOrganizer >> classify: behaviorName under: categoryName [
 	(categoryMap at: categoryName) add: behaviorName
 ]
 
-{ #category : #'deprecated - SystemOrganizer leftovers' }
+{ #category : 'deprecated - SystemOrganizer leftovers' }
 RPackageOrganizer >> classifyAll: aCollection under: categoryName [
 
 	aCollection do: [ :element | self classify: element under: categoryName ]
 ]
 
-{ #category : #registration }
+{ #category : 'registration' }
 RPackageOrganizer >> createPackageNamed: aString [
 
 	self validatePackageDoesNotExist: aString.
@@ -295,25 +297,25 @@ RPackageOrganizer >> createPackageNamed: aString [
 	^ self ensurePackage: aString
 ]
 
-{ #category : #'private - testing' }
+{ #category : 'private - testing' }
 RPackageOrganizer >> debuggingName [
 
 	^ debuggingName
 ]
 
-{ #category : #'private - testing' }
+{ #category : 'private - testing' }
 RPackageOrganizer >> debuggingName: aString [
 
 	debuggingName := aString
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RPackageOrganizer >> defineUnpackagedClassesPackage [
 
 	^ self ensurePackage: RPackage defaultPackageName
 ]
 
-{ #category : #registration }
+{ #category : 'registration' }
 RPackageOrganizer >> ensurePackage: aPackage [
 
 	^ aPackage isString
@@ -323,7 +325,15 @@ RPackageOrganizer >> ensurePackage: aPackage [
 			  aPackage ]
 ]
 
-{ #category : #'system integration' }
+{ #category : 'registration' }
+RPackageOrganizer >> ensurePackage: aPackage withTags: aCollection [
+
+	| package |
+	package := self ensurePackage: aPackage.
+	aCollection do: [ :tag | package ensureTag: tag ]
+]
+
+{ #category : 'system integration' }
 RPackageOrganizer >> ensurePackageMatching: aString [
 	"I try to find a package matching the string. The priority is given to a package having the same name case insensitive. If I don't find it, I'm stripping everything following the last dash and I retry to find the package. If non is found after all dashes are stripped, I create a package of the given name.
 	
@@ -332,36 +342,36 @@ RPackageOrganizer >> ensurePackageMatching: aString [
 	^ (self packageMatchingExtensionName: aString) ifNil: [ self ensurePackage: aString ]
 ]
 
-{ #category : #'system integration' }
+{ #category : 'system integration' }
 RPackageOrganizer >> ensurePackageOfExtensionProtocol: aProtocol [
 
 	^ (self packageForProtocol: aProtocol) ifNil: [ self ensurePackage: aProtocol name allButFirst capitalized ]
 ]
 
-{ #category : #registration }
+{ #category : 'registration' }
 RPackageOrganizer >> ensureTagNamed: aTagName inPackageNamed: aPackageName [
 
 	^ (self ensurePackage: aPackageName) ensureTag: aTagName
 ]
 
-{ #category : #'deprecated - SystemOrganizer leftovers' }
+{ #category : 'accessing' }
 RPackageOrganizer >> environment [
 	 ^ environment ifNil: [ environment := Smalltalk globals]
 ]
 
-{ #category : #'deprecated - SystemOrganizer leftovers' }
+{ #category : 'accessing' }
 RPackageOrganizer >> environment: aSystemDictionary [
 	 environment := aSystemDictionary
 ]
 
-{ #category : #'package - access from class' }
+{ #category : 'package - access from class' }
 RPackageOrganizer >> extendingPackagesOf: aClass [
 	"Returns the packages extending the class aClass"
 
 	^ classExtendingPackagesMapping at: aClass instanceSide ifAbsent: [ #(  ) ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackageOrganizer >> hasPackage: aPackage [
 	"Takes a package or a package name as parameter and return true if I include this package."
 
@@ -370,7 +380,7 @@ RPackageOrganizer >> hasPackage: aPackage [
 		  ifFalse: [ self packages includes: aPackage ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackageOrganizer >> hasTag: aTag inPackage: aPackage [
 
 	(self hasPackage: aPackage) ifFalse: [ ^ false ].
@@ -378,7 +388,7 @@ RPackageOrganizer >> hasTag: aTag inPackage: aPackage [
 	^ (self ensurePackage: aPackage) hasTag: aTag
 ]
 
-{ #category : #'deprecated - SystemOrganizer leftovers' }
+{ #category : 'deprecated - SystemOrganizer leftovers' }
 RPackageOrganizer >> includesCategory: aString [
 	"Tests if a category is already included."
 
@@ -387,7 +397,7 @@ RPackageOrganizer >> includesCategory: aString [
 		  ifNotNil: [ :categories | categories includes: aString ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RPackageOrganizer >> initialize [
 
 	super initialize.
@@ -401,7 +411,7 @@ RPackageOrganizer >> initialize [
 	self defineUnpackagedClassesPackage
 ]
 
-{ #category : #'deprecated - SystemOrganizer leftovers' }
+{ #category : 'deprecated - SystemOrganizer leftovers' }
 RPackageOrganizer >> isEmptyCategoryNamed: categoryName [
 
 	^ categoryMap
@@ -410,14 +420,14 @@ RPackageOrganizer >> isEmptyCategoryNamed: categoryName [
 		  ifAbsent: [ false ]
 ]
 
-{ #category : #'deprecated - SystemOrganizer leftovers' }
+{ #category : 'deprecated - SystemOrganizer leftovers' }
 RPackageOrganizer >> listAtCategoryNamed: categoryName [
 	"Answer the array of elements associated with the name, categoryName."
 
 	^ (categoryMap at: categoryName ifAbsent: [ Array new ]) asArray
 ]
 
-{ #category : #'deprecated - SystemOrganizer leftovers' }
+{ #category : 'deprecated - SystemOrganizer leftovers' }
 RPackageOrganizer >> orderedTraitsIn: category [
 	"Answer an OrderedCollection containing references to the traits in the
 	category whose name is the argument, category (a string). The traits
@@ -430,7 +440,7 @@ RPackageOrganizer >> orderedTraitsIn: category [
 	^ traits asArray
 ]
 
-{ #category : #'system integration' }
+{ #category : 'system integration' }
 RPackageOrganizer >> packageForProtocol: aProtocol [
 	"Return nil if the protocol is not an extension of if there is no package matching the name.
 	
@@ -443,7 +453,7 @@ RPackageOrganizer >> packageForProtocol: aProtocol [
 	^ self packageMatchingExtensionName: (aProtocol name copyWithout: $*)
 ]
 
-{ #category : #'system integration' }
+{ #category : 'system integration' }
 RPackageOrganizer >> packageMatchingExtensionName: anExtensionName [
 	"I try to find a package matching the string. The priority is given to a package having the same name case insensitive. If I don't find it, I'm stripping everything following the last dash and I retry to find the package. If non is found after all dashes are stripped, I return nil.
 	
@@ -464,20 +474,20 @@ RPackageOrganizer >> packageMatchingExtensionName: anExtensionName [
 		  ifFalse: [ self packageNamed: tmpPackageName ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageOrganizer >> packageNamed: aSymbol [
 	^ self
 		packageNamed: aSymbol
 		ifAbsent: [ KeyNotFound signalFor: aSymbol ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageOrganizer >> packageNamed: aSymbol ifAbsent: errorBlock [
 
 	^ packages at: aSymbol asSymbol ifAbsent: errorBlock
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RPackageOrganizer >> packageNamedIgnoreCase: aSymbol ifAbsent: aBlock [
 	"In case of extensions, I can need to take a package ignoring name"
 	self packagesDo: [  :each |
@@ -487,25 +497,25 @@ RPackageOrganizer >> packageNamedIgnoreCase: aSymbol ifAbsent: aBlock [
 	^ aBlock value
 ]
 
-{ #category : #'package - names-cache' }
+{ #category : 'package - names-cache' }
 RPackageOrganizer >> packageNames [
 
 	^ packages keys
 ]
 
-{ #category : #'package - names-cache' }
+{ #category : 'package - names-cache' }
 RPackageOrganizer >> packageNamesDo: aBlock [
 
 	^ self packageNames do: aBlock
 ]
 
-{ #category : #'package - access from class' }
+{ #category : 'package - access from class' }
 RPackageOrganizer >> packageOf: aClass [
 
 	^ classPackageMapping at: aClass instanceSide ifAbsent: [ self packageNamed: RPackage defaultPackageName ]
 ]
 
-{ #category : #'package - access from class' }
+{ #category : 'package - access from class' }
 RPackageOrganizer >> packageOfClassNamed: aName [
 
 	self flag: #pharoFixMe. "Should probably return _UnunpackagedPackage instead of nil"
@@ -514,39 +524,39 @@ RPackageOrganizer >> packageOfClassNamed: aName [
 	^ nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageOrganizer >> packages [
 
 	^ packages values
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageOrganizer >> packagesDo: aBlock [
 
 	self packages do: aBlock
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 RPackageOrganizer >> printOn: aStream [
 
 	super printOn: aStream.
 	debuggingName ifNotNil: [aStream nextPutAll: debuggingName ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RPackageOrganizer >> register [
 
 	"self registerInterestToMC."
 	self registerInterestToSystemAnnouncement
 ]
 
-{ #category : #'private - registration' }
+{ #category : 'private - registration' }
 RPackageOrganizer >> registerExtendingPackage: aPackage forClass: aClass [
 
 	(classExtendingPackagesMapping at: aClass instanceSide ifAbsentPut: [ IdentitySet new ]) add: aPackage
 ]
 
-{ #category : #'system integration' }
+{ #category : 'system integration' }
 RPackageOrganizer >> registerInterestToAnnouncer: anAnnouncer [
 	"There should be only one"
 
@@ -561,7 +571,7 @@ RPackageOrganizer >> registerInterestToAnnouncer: anAnnouncer [
 		when: MethodRecategorized send: #systemMethodRecategorizedActionFrom: to: self
 ]
 
-{ #category : #'system integration' }
+{ #category : 'system integration' }
 RPackageOrganizer >> registerInterestToSystemAnnouncement [
 	"self registerInterestToSystemAnnouncement"
 	<systemEventRegistration>
@@ -569,7 +579,7 @@ RPackageOrganizer >> registerInterestToSystemAnnouncement [
 	self registerInterestToAnnouncer: self announcer
 ]
 
-{ #category : #registration }
+{ #category : 'registration' }
 RPackageOrganizer >> registerPackage: aPackage [
 	"A new package is now available and declared in the receiver. "
 
@@ -584,14 +594,14 @@ RPackageOrganizer >> registerPackage: aPackage [
 	^ aPackage
 ]
 
-{ #category : #'private - registration' }
+{ #category : 'private - registration' }
 RPackageOrganizer >> registerPackage: aPackage forClass: aClass [
 
 	(aPackage includesClass: aClass) ifFalse: [ self error: aPackage name , ' does not includes the class ' , aClass name ].
 	^ classPackageMapping at: aClass instanceSide put: aPackage
 ]
 
-{ #category : #'deprecated - SystemOrganizer leftovers' }
+{ #category : 'deprecated - SystemOrganizer leftovers' }
 RPackageOrganizer >> removeBehavior: behavior [
 	"Remove the behavior from all categories. I can take a Behavior or a Behavior name as argument."
 
@@ -603,14 +613,14 @@ RPackageOrganizer >> removeBehavior: behavior [
 	categoryMap keysAndValuesDo: [ :category :classes | (classes includes: behaviorName) ifTrue: [ classes remove: behaviorName ] ]
 ]
 
-{ #category : #'deprecated - SystemOrganizer leftovers' }
+{ #category : 'deprecated - SystemOrganizer leftovers' }
 RPackageOrganizer >> removeCategoriesMatching: matchString [
 	"Remove all matching categories with their classes"
 
 	(self categoriesMatching: matchString) do: [ :c | self removeSystemCategory: c ]
 ]
 
-{ #category : #'deprecated - SystemOrganizer leftovers' }
+{ #category : 'deprecated - SystemOrganizer leftovers' }
 RPackageOrganizer >> removeCategory: aCategory [
 	"Remove the category named, cat. Create an error notificiation if the
 	category has any elements in it."
@@ -632,7 +642,7 @@ RPackageOrganizer >> removeCategory: aCategory [
 			ifFalse: [ package classTagNamed: (category withoutPrefix: package name , '-') ifPresent: [ :tag | package removeTag: tag ] ] ]
 ]
 
-{ #category : #'system integration' }
+{ #category : 'system integration' }
 RPackageOrganizer >> removeClass: class [
 	"Remove the class, the class backpointer, the extensions and the extension backPointer from the receiver and the class involved with the class named: className. className is a class name and should not be a metaclass one. "
 
@@ -641,7 +651,7 @@ RPackageOrganizer >> removeClass: class [
 	(self extendingPackagesOf: class) do: [ :extendedPackage | extendedPackage removeAllMethodsFromClass: class ]
 ]
 
-{ #category : #cleanup }
+{ #category : 'cleanup' }
 RPackageOrganizer >> removeEmptyPackagesAndTags [
 	"Remove empty packages and tags."
 
@@ -649,7 +659,7 @@ RPackageOrganizer >> removeEmptyPackagesAndTags [
 	(self packages select: [ :package | package isEmpty ]) do: [ :emptyPackage | self removePackage: emptyPackage ]
 ]
 
-{ #category : #registration }
+{ #category : 'registration' }
 RPackageOrganizer >> removePackage: aPackage [
 
 	| package |
@@ -667,7 +677,7 @@ RPackageOrganizer >> removePackage: aPackage [
 	^ package
 ]
 
-{ #category : #'deprecated - SystemOrganizer leftovers' }
+{ #category : 'deprecated - SystemOrganizer leftovers' }
 RPackageOrganizer >> removeSystemCategory: category [
 	"remove all the classes and traits associated with the category"
 
@@ -676,7 +686,7 @@ RPackageOrganizer >> removeSystemCategory: category [
 	self removeCategory: category
 ]
 
-{ #category : #'deprecated - SystemOrganizer leftovers' }
+{ #category : 'system integration' }
 RPackageOrganizer >> removeTag: aTag fromPackage: aPackage [
 
 	(self hasPackage: aPackage) ifFalse: [ ^ self "no need to remove the tag if the package is not there." ].
@@ -684,7 +694,7 @@ RPackageOrganizer >> removeTag: aTag fromPackage: aPackage [
 	(self ensurePackage: aPackage) removeTag: aTag
 ]
 
-{ #category : #'deprecated - SystemOrganizer leftovers' }
+{ #category : 'deprecated - SystemOrganizer leftovers' }
 RPackageOrganizer >> renameCategory: oldCatString toBe: newCatString [
 	"Rename a category. No action if new name already exists, or if old name does not exist."
 
@@ -706,7 +716,7 @@ RPackageOrganizer >> renameCategory: oldCatString toBe: newCatString [
 	package classTagNamed: oldName ifPresent: [ :tag | tag basicRenameTo: newName ]
 ]
 
-{ #category : #'system integration' }
+{ #category : 'system integration' }
 RPackageOrganizer >> renamePackage: aPackage to: newName [
 
 	(self hasPackage: aPackage) ifFalse: [ ^ self ].
@@ -714,7 +724,7 @@ RPackageOrganizer >> renamePackage: aPackage to: newName [
 	(self ensurePackage: aPackage) renameTo: newName
 ]
 
-{ #category : #'system integration' }
+{ #category : 'system integration' }
 RPackageOrganizer >> renameTag: aTag to: newName inPackage: aPackage [
 
 	(self hasPackage: aPackage) ifFalse: [ ^ self ].
@@ -722,13 +732,13 @@ RPackageOrganizer >> renameTag: aTag to: newName inPackage: aPackage [
 	(self ensurePackage: aPackage) renameTag: aTag to: newName
 ]
 
-{ #category : #registration }
+{ #category : 'registration' }
 RPackageOrganizer >> signalPackageExists: aPackageName [
 
 	RPackageConflictError signal: ('A package named {1} already exists' format: {aPackageName})
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RPackageOrganizer >> stopNotification [
 	"(self instVarNamed: #default) stopNotification"
 
@@ -740,7 +750,7 @@ RPackageOrganizer >> stopNotification [
 		wc removeDependent: self]
 ]
 
-{ #category : #'deprecated - SystemOrganizer leftovers' }
+{ #category : 'deprecated - SystemOrganizer leftovers' }
 RPackageOrganizer >> superclassOrder: category [
 	"Answer an OrderedCollection containing references to the classes in the
 	category whose name is the argument, category (a string). The classes
@@ -752,7 +762,7 @@ RPackageOrganizer >> superclassOrder: category [
 	^ Class superclassOrder: classes
 ]
 
-{ #category : #'system integration' }
+{ #category : 'system integration' }
 RPackageOrganizer >> systemCategoryAddedActionFrom: ann [
 
 	| package |
@@ -762,13 +772,13 @@ RPackageOrganizer >> systemCategoryAddedActionFrom: ann [
 	package ensureTag: (package toTagName: ann categoryName)
 ]
 
-{ #category : #'system integration' }
+{ #category : 'system integration' }
 RPackageOrganizer >> systemClassAddedActionFrom: ann [
 
 	(self ensurePackageMatching: ann classAffected category) importClass: ann classAffected
 ]
 
-{ #category : #'system integration' }
+{ #category : 'system integration' }
 RPackageOrganizer >> systemClassRecategorizedActionFrom: announcement [
 
 	| class newPackage newCategoryName |
@@ -782,14 +792,14 @@ RPackageOrganizer >> systemClassRecategorizedActionFrom: announcement [
 	newPackage moveClass: class toTag: (newPackage ensureTag: (newPackage toTagName: newCategoryName))
 ]
 
-{ #category : #'system integration' }
+{ #category : 'system integration' }
 RPackageOrganizer >> systemClassReorganizedActionFrom: ann [
 	"when a class is reorganized, we have to check if an extension has not been added"
 
 	ann classReorganized extensionProtocols do: [ :protocol | self ensurePackageOfExtensionProtocol: protocol ]
 ]
 
-{ #category : #'system integration' }
+{ #category : 'system integration' }
 RPackageOrganizer >> systemMethodAddedActionFrom: ann [
 
 	| method |
@@ -800,7 +810,7 @@ RPackageOrganizer >> systemMethodAddedActionFrom: ann [
 	self addMethod: method
 ]
 
-{ #category : #'system integration' }
+{ #category : 'system integration' }
 RPackageOrganizer >> systemMethodRecategorizedActionFrom: ann [
 
 	| method |
@@ -827,37 +837,37 @@ RPackageOrganizer >> systemMethodRecategorizedActionFrom: ann [
 		SystemAnnouncer uniqueInstance methodRepackaged: method from: oldPackage to: newPackage ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageOrganizer >> testPackageNames [
 
 	^ self testPackages collect: [ :package | package name ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageOrganizer >> testPackages [
 
 	^ self packages select: [ :package | package isTestPackage ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RPackageOrganizer >> unregister [
 	SystemAnnouncer uniqueInstance unsubscribe: self
 ]
 
-{ #category : #'private - registration' }
+{ #category : 'private - registration' }
 RPackageOrganizer >> unregisterExtendingPackage: aPackage forClass: aClass [
 
 	classExtendingPackagesMapping at: aClass instanceSide ifPresent: [ :extendingPackages | extendingPackages remove: aPackage ifAbsent: [  ] ]
 ]
 
-{ #category : #'system integration' }
+{ #category : 'system integration' }
 RPackageOrganizer >> unregisterInterestToSystemAnnouncement [
 	"self unregisterInterestToSystemAnnouncement"
 
 	SystemAnnouncer uniqueInstance unsubscribe: self
 ]
 
-{ #category : #'private - registration' }
+{ #category : 'private - registration' }
 RPackageOrganizer >> unregisterPackage: aPackage forClass: aClass [
 	"unregister the back pointer mapping from classes to packages."
 
@@ -865,7 +875,7 @@ RPackageOrganizer >> unregisterPackage: aPackage forClass: aClass [
 	^ (classPackageMapping at: aClass instanceSide ifAbsent: [ ^ self ]) = aPackage ifTrue: [ classPackageMapping removeKey: aClass instanceSide ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RPackageOrganizer >> validateCanBeAddedPackageName: packageName tagName: tagName [
 
 	| package |
@@ -882,7 +892,7 @@ RPackageOrganizer >> validateCanBeAddedPackageName: packageName tagName: tagName
 					 tagName }) ]
 ]
 
-{ #category : #registration }
+{ #category : 'registration' }
 RPackageOrganizer >> validatePackageDoesNotExist: aPackageName [
 
 	(self hasPackage: aPackageName) ifTrue: [ self signalPackageExists: aPackageName ]

--- a/src/RPackage-Core/RPackageSet.class.st
+++ b/src/RPackage-Core/RPackageSet.class.st
@@ -4,8 +4,8 @@ My purpose is to provide a bridge between monticello and system packages, to all
 
 "
 Class {
-	#name : #RPackageSet,
-	#superclass : #Object,
+	#name : 'RPackageSet',
+	#superclass : 'Object',
 	#instVars : [
 		'packageName',
 		'packages',
@@ -18,22 +18,24 @@ Class {
 		'cacheActive',
 		'cachePackages'
 	],
-	#category : #'RPackage-Core-Base'
+	#category : 'RPackage-Core-Base',
+	#package : 'RPackage-Core',
+	#tag : 'Base'
 }
 
-{ #category : #private }
+{ #category : 'private' }
 RPackageSet class >> basicNamed: aString [
 	^ self basicNew
 		initialize: aString;
 		yourself
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RPackageSet class >> cacheActive: aBoolean [
 	cacheActive := aBoolean
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RPackageSet class >> cachePackageAt: aString ifAbsentPut: aBlock [
 	"self addCount: aString."
 	^ self cachePackages
@@ -41,17 +43,17 @@ RPackageSet class >> cachePackageAt: aString ifAbsentPut: aBlock [
 		ifAbsentPut: aBlock
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RPackageSet class >> cachePackages [
 	^ cachePackages ifNil: [ cachePackages := IdentityDictionary new ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackageSet class >> isCacheActive [
 	^ cacheActive ifNil: [ cacheActive := false ]
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RPackageSet class >> named: aString [
 
 	^ self isCacheActive
@@ -62,12 +64,12 @@ RPackageSet class >> named: aString [
 		ifFalse: [ self basicNamed: aString ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RPackageSet class >> resetCache [
 	cachePackages := nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageSet class >> withCacheDo: aBlock [
 	| oldActive |
 
@@ -78,34 +80,34 @@ RPackageSet class >> withCacheDo: aBlock [
 		self isCacheActive ifFalse: [ self resetCache ] ]
 ]
 
-{ #category : #'system compatibility' }
+{ #category : 'system compatibility' }
 RPackageSet >> asRPackageSet [
 	^self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageSet >> categoryNames [
 	^  self packages
 		inject:  #()
 		into: [ :all :each | all, (each classTagCategoryNames asArray) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageSet >> classes [
 	^classes ifNil: [ classes := self packages flatCollect: #definedClasses ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageSet >> definedClasses [
 	^definedClasses ifNil: [ definedClasses := self packages flatCollect: #definedClasses ]
 ]
 
-{ #category : #'system compatibility' }
+{ #category : 'system compatibility' }
 RPackageSet >> extendedClasses [
 	^ self packages flatCollect: #extendedClasses
 ]
 
-{ #category : #'system compatibility' }
+{ #category : 'system compatibility' }
 RPackageSet >> extensionCategoriesForClass: aClass [
 
 	self
@@ -114,19 +116,19 @@ RPackageSet >> extensionCategoriesForClass: aClass [
 	^ self extensionProtocolsForClass: aClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageSet >> extensionMethods [
 	^ extensionMethods ifNil: [
 		extensionMethods :=
 		(self packages flatCollect: [ :p | p extensionMethods ] as: Set) asArray ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackageSet >> includesClass: aClass [
 	^self packages anySatisfy: [ :each | each includesClass: aClass ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RPackageSet >> initialize: aString [
 
 	self initialize.
@@ -136,12 +138,12 @@ RPackageSet >> initialize: aString [
 		            ifNil: [ {  } ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageSet >> methods [
 	^ methods ifNil: [ methods := (self packages flatCollect: [ :p | p methods ]) ]
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 RPackageSet >> organizer [
 
 	(self packages isNil or: [ self package isEmpty ]) ifTrue: [ ^ self packageOrganizer ].
@@ -149,17 +151,17 @@ RPackageSet >> organizer [
 	^ self packages anyOne organizer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageSet >> packageName [
 	^packageName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageSet >> packages [
 	^packages
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageSet >> unregister [
 	self packages do: #unregister
 ]

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -3,17 +3,19 @@ I'm a class tag for an RPackage.
 Class tags can be any kind of metadata the user needs, but they are for now equivalent to class categories. 
 "
 Class {
-	#name : #RPackageTag,
-	#superclass : #Object,
+	#name : 'RPackageTag',
+	#superclass : 'Object',
 	#instVars : [
 		'package',
 		'name',
 		'classes'
 	],
-	#category : #'RPackage-Core-Base'
+	#category : 'RPackage-Core-Base',
+	#package : 'RPackage-Core',
+	#tag : 'Base'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RPackageTag class >> package: aPackage name: aString [
 
 	^ self new
@@ -22,111 +24,111 @@ RPackageTag class >> package: aPackage name: aString [
 		  yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageTag >> addClass: aClass [
 
 	aClass category = self categoryName ifFalse: [ aClass category: self categoryName ].
 	classes add: aClass
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RPackageTag >> basicRenameTo: aString [
 	name := aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageTag >> categoryName [
 	"Answer this tag as a SystemCategory.
     That would be RPackage, '-', RPackageTag, unless tag is root (same name as RPackage)"
 	^ self toCategoryName: self name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageTag >> classNames [
 
 	^ self classes collect: [ :class | class name ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageTag >> classes [
 
 	^ classes
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageTag >> environment [
 
 	^ self package environment
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackageTag >> hasClass: aClass [
 
 	^ self classes includes: aClass instanceSide
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackageTag >> hasClassNamed: aSymbol [
 	^ self classNames includes: aSymbol
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackageTag >> includesClass: aClass [
 	"To deprecate in favor of #hasClass:"
 
 	^ self hasClass: aClass
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RPackageTag >> initialize [
 
 	super initialize.
 	classes := IdentitySet new
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackageTag >> isEmpty [
 	^ self classNames isEmpty
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RPackageTag >> isRoot [
 	^ self name = self packageName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageTag >> name [
 	^ name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageTag >> name: aSymbol [
 
 	name := aSymbol asSymbol
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageTag >> organizer [
 	^ self package organizer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageTag >> package [
 	^ package
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageTag >> package: anObject [
 
 	package := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageTag >> packageName [
 	^ self package name
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 RPackageTag >> printOn: aStream [
 	super printOn: aStream.
 	aStream nextPut: $(.
@@ -134,7 +136,7 @@ RPackageTag >> printOn: aStream [
 	aStream nextPut: $)
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 RPackageTag >> promoteAsPackage [
 	"This method converts this package tag into a package"
 
@@ -147,7 +149,7 @@ RPackageTag >> promoteAsPackage [
 	self organizer registerPackage: newPackage
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageTag >> removeClass: aClass [
 
 	| oldObject |
@@ -156,7 +158,7 @@ RPackageTag >> removeClass: aClass [
 	^ oldObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageTag >> removeFromPackage [
 
 	self assert: self isEmpty description: 'Package tag is not empty'.
@@ -164,7 +166,7 @@ RPackageTag >> removeFromPackage [
 	self package removeTag: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageTag >> renameTo: newTagName [
 
 	| oldCategoryName newCategoryName oldTagName |
@@ -182,13 +184,13 @@ RPackageTag >> renameTo: newTagName [
 	SystemAnnouncer announce: (PackageTagRenamed to: self oldName: oldTagName newName: newTagName)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RPackageTag >> rootTagName [
 
 	^ self package rootTagName
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RPackageTag >> toCategoryName: aString [
 	^ aString = self packageName
 		ifTrue: [ aString ]

--- a/src/RPackage-Core/SmalltalkImage.extension.st
+++ b/src/RPackage-Core/SmalltalkImage.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #SmalltalkImage }
+Extension { #name : 'SmalltalkImage' }
 
-{ #category : #'*RPackage-Core' }
+{ #category : '*RPackage-Core' }
 SmalltalkImage >> packages [
 
 	^ RPackageOrganizer default packages

--- a/src/RPackage-Core/String.extension.st
+++ b/src/RPackage-Core/String.extension.st
@@ -1,11 +1,11 @@
-Extension { #name : #String }
+Extension { #name : 'String' }
 
-{ #category : #'*RPackage-Core' }
+{ #category : '*RPackage-Core' }
 String >> asPackage [
 	^ self asPackageIfAbsent: [ NotFound new messageText: 'There is no package named ', self; object: self; signal ]
 ]
 
-{ #category : #'*RPackage-Core' }
+{ #category : '*RPackage-Core' }
 String >> asPackageIfAbsent: aBlock [
 
 	^ self packageOrganizer packageNamed: self ifAbsent: aBlock

--- a/src/RPackage-Core/package.st
+++ b/src/RPackage-Core/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'RPackage-Core' }
+Package { #name : 'RPackage-Core' }


### PR DESCRIPTION
Now that we have TonelV3 and Iceberg is been updated to never set categories in MCOrganizationDefinition, we can rely less on categories.

This change needs this PR of ICeberg to be integrated in order to work well: https://github.com/pharo-vcs/iceberg/pull/1732