### PR TITLE
RPackage: cleanings now that SystemOrganizer is removed

### DIFF
--- a/src/Deprecated12/RPackageOrganizer.extension.st
+++ b/src/Deprecated12/RPackageOrganizer.extension.st
@@ -95,9 +95,9 @@ RPackageOrganizer >> packageExactlyMatchingExtensionName: anExtensionName [
 	"only look for a package for which the name match 'anExtensionName', making no difference about case. Return nil if no package is found"
 
 	self
-		deprecated: 'Use #packageNamedIgnoreCase:ifAbsent: instead.'
-		transformWith: '`@rcv packageExactlyMatchingExtensionName: `@arg' -> '`@rcv packageNamedIgnoreCase: `@arg ifAbsent: [ nil ]'.
-	^ self packageNamedIgnoreCase: anExtensionName ifAbsent: [ nil ]
+		deprecated: 'Use #packageNamed:ifAbsent: instead.'
+		transformWith: '`@rcv packageExactlyMatchingExtensionName: `@arg' -> '`@rcv packageNamed:ifAbsent: `@arg ifAbsent: [ nil ]'.
+	^ self packageNamed: anExtensionName ifAbsent: [ nil ]
 ]
 
 { #category : '*Deprecated12' }

--- a/src/FluidClassBuilder-Tests/FluidClassBuilderAbstractTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidClassBuilderAbstractTest.class.st
@@ -1,19 +1,21 @@
 Class {
-	#name : #FluidClassBuilderAbstractTest,
-	#superclass : #TestCase,
+	#name : 'FluidClassBuilderAbstractTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'builder'
 	],
-	#category : #'FluidClassBuilder-Tests-Base'
+	#category : 'FluidClassBuilder-Tests-Base',
+	#package : 'FluidClassBuilder-Tests',
+	#tag : 'Base'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FluidClassBuilderAbstractTest >> builder [
 
 	^ builder
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 FluidClassBuilderAbstractTest >> categoryHack [
 	"Currently there is a bug in Fluid class builder that is that when we define a tag X with a package Y it can generate a package Y-X instead. 
 	This is due to the category mess in RPackage and it will not be fixed until the category mess is cleaned. Until then, to make sure the tests are in a right state, we register the package without the tag before creating the class to ensure the tag is not added as part of the package name.
@@ -22,16 +24,16 @@ FluidClassBuilderAbstractTest >> categoryHack [
 	self packageOrganizer ensurePackage: self packageNameForTest
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FluidClassBuilderAbstractTest >> packageNameForTest [
 
 	^ #FakedCore
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 FluidClassBuilderAbstractTest >> tearDown [
 
-	(self packageOrganizer packageNamed: self packageNameForTest ifAbsent: [ nil ]) ifNotNil: [ :x | x removeFromSystem ].
+	self packageOrganizer packageNamed: self packageNameForTest ifPresent: [ :x | x removeFromSystem ].
 
 	super tearDown
 ]

--- a/src/FluidClassBuilder-Tests/FluidClassBuilderTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidClassBuilderTest.class.st
@@ -2,12 +2,14 @@
 This class contains tests for `FluidClassBuilder`
 "
 Class {
-	#name : #FluidClassBuilderTest,
-	#superclass : #FluidClassBuilderAbstractTest,
-	#category : #'FluidClassBuilder-Tests-Base'
+	#name : 'FluidClassBuilderTest',
+	#superclass : 'FluidClassBuilderAbstractTest',
+	#category : 'FluidClassBuilder-Tests-Base',
+	#package : 'FluidClassBuilder-Tests',
+	#tag : 'Base'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 FluidClassBuilderTest >> setUp [
 
 	super setUp.
@@ -17,7 +19,7 @@ FluidClassBuilderTest >> setUp [
 		           package: 'FakedPackage'
 ]
 
-{ #category : #'tests - hidden protocols' }
+{ #category : 'tests - hidden protocols' }
 FluidClassBuilderTest >> testBuildClassSlotsAPI [
 
 	| clas |
@@ -35,7 +37,7 @@ FluidClassBuilderTest >> testBuildClassSlotsAPI [
 	self assert: clas class slots size equals: 2
 ]
 
-{ #category : #'tests - hidden protocols' }
+{ #category : 'tests - hidden protocols' }
 FluidClassBuilderTest >> testBuildClassTraitsAPI [
 
 	| clas |
@@ -51,7 +53,7 @@ FluidClassBuilderTest >> testBuildClassTraitsAPI [
 	self assert: clas class traitComposition equals: { TViewModelMock2 classTrait } asTraitComposition
 ]
 
-{ #category : #'tests - gathering' }
+{ #category : 'tests - gathering' }
 FluidClassBuilderTest >> testBuildLayout [
 
 	builder
@@ -61,7 +63,7 @@ FluidClassBuilderTest >> testBuildLayout [
 	self assert: builder layoutToBuild equals: VariableLayout
 ]
 
-{ #category : #'tests - classBuilder generation' }
+{ #category : 'tests - classBuilder generation' }
 FluidClassBuilderTest >> testBuildSimplePoint2 [
 
 	| clas |
@@ -77,7 +79,7 @@ FluidClassBuilderTest >> testBuildSimplePoint2 [
 	"self assert: clas package packageName equals: self packageNameForTest"
 ]
 
-{ #category : #'tests - gathering' }
+{ #category : 'tests - gathering' }
 FluidClassBuilderTest >> testBuilderSharedPools [
 
 	builder slots: {#string . #runs};
@@ -88,7 +90,7 @@ FluidClassBuilderTest >> testBuilderSharedPools [
 	self assert: builder sharedPoolsToBuild equals: 'TextConstants'
 ]
 
-{ #category : #'tests - gathering' }
+{ #category : 'tests - gathering' }
 FluidClassBuilderTest >> testBuilderSharedVariables [
 
 	builder
@@ -100,7 +102,7 @@ FluidClassBuilderTest >> testBuilderSharedVariables [
 	self assert: builder layoutToBuild equals: ByteLayout
 ]
 
-{ #category : #'tests - gathering' }
+{ #category : 'tests - gathering' }
 FluidClassBuilderTest >> testBuilderTraits [
 
 	builder traits: TViewModelMock.
@@ -108,7 +110,7 @@ FluidClassBuilderTest >> testBuilderTraits [
 	builder fillShiftClassBuilder
 ]
 
-{ #category : #'tests - gathering' }
+{ #category : 'tests - gathering' }
 FluidClassBuilderTest >> testBuilderTraitsClass [
 
 	builder traits: TViewModelMock class.
@@ -116,7 +118,7 @@ FluidClassBuilderTest >> testBuilderTraitsClass [
 	builder fillShiftClassBuilder
 ]
 
-{ #category : #'tests - gathering' }
+{ #category : 'tests - gathering' }
 FluidClassBuilderTest >> testBuilderTraitsWithComposition [
 
 	builder traits: TViewModelMock + TViewModelMock2.
@@ -126,7 +128,7 @@ FluidClassBuilderTest >> testBuilderTraitsWithComposition [
 	builder fillShiftClassBuilder
 ]
 
-{ #category : #'tests - mandatory' }
+{ #category : 'tests - mandatory' }
 FluidClassBuilderTest >> testBuilderWithPackage [
 
 	builder package: 'Kernel-BasicObjects'.
@@ -135,14 +137,14 @@ FluidClassBuilderTest >> testBuilderWithPackage [
 		equals: 'Kernel-BasicObjects'
 ]
 
-{ #category : #'tests - gathering' }
+{ #category : 'tests - gathering' }
 FluidClassBuilderTest >> testBuilderWithSlots [
 
 	builder slots: { #x . #y }.
 	self assert: builder slotsToBuild equals: { #x => InstanceVariableSlot. #y => InstanceVariableSlot }
 ]
 
-{ #category : #'tests - gathering' }
+{ #category : 'tests - gathering' }
 FluidClassBuilderTest >> testBuilderWithTag [
 
 	builder tag: 'Foo'.
@@ -150,7 +152,7 @@ FluidClassBuilderTest >> testBuilderWithTag [
 	self assert: builder tagToBuild equals: 'Foo'
 ]
 
-{ #category : #'tests - class creation' }
+{ #category : 'tests - class creation' }
 FluidClassBuilderTest >> testChevronIsWorkingOnClassSide [
 
 	| instBuilder newClass clasBuilder |
@@ -187,7 +189,7 @@ FluidClassBuilderTest >> testChevronIsWorkingOnClassSide [
 	self assert: clasBuilder classTraitsToBuild equals: instBuilder classTraitsToBuild
 ]
 
-{ #category : #'tests - class creation' }
+{ #category : 'tests - class creation' }
 FluidClassBuilderTest >> testChevronIsWorkingOnClassSideOnEmpty [
 
 	| instBuilder newClass clasBuilder |
@@ -215,21 +217,21 @@ FluidClassBuilderTest >> testChevronIsWorkingOnClassSideOnEmpty [
 	self assert: clasBuilder classTraitsToBuild equals: instBuilder classTraitsToBuild
 ]
 
-{ #category : #'tests - class creation' }
+{ #category : 'tests - class creation' }
 FluidClassBuilderTest >> testClassSlots [
 
 	builder classSlots: {#string . #runs}.
 	self assert: builder classSlotsToBuild equals: {#string => InstanceVariableSlot. #runs => InstanceVariableSlot}
 ]
 
-{ #category : #'tests - class creation' }
+{ #category : 'tests - class creation' }
 FluidClassBuilderTest >> testClassTraits [
 
 	builder classTraits: {TViewModel classSide}.
 	self assert: builder classTraitsToBuild equals: {TViewModel classSide} asTraitComposition
 ]
 
-{ #category : #'tests - mandatory' }
+{ #category : 'tests - mandatory' }
 FluidClassBuilderTest >> testCreateBuilder [
 
 	builder := Object << #Point.
@@ -238,7 +240,7 @@ FluidClassBuilderTest >> testCreateBuilder [
 	self assert: builder nameToBuild equals: #Point
 ]
 
-{ #category : #'tests - mandatory' }
+{ #category : 'tests - mandatory' }
 FluidClassBuilderTest >> testCreateBuilderWithNil [
 
 	builder := nil << #NewProtoObject.
@@ -247,7 +249,7 @@ FluidClassBuilderTest >> testCreateBuilderWithNil [
 	self assert: builder nameToBuild equals: #NewProtoObject
 ]
 
-{ #category : #'tests - mandatory' }
+{ #category : 'tests - mandatory' }
 FluidClassBuilderTest >> testCreateClassWithFullExpandedDefinitionKeepsTheMinimum [
 	"check ClassDescription>>#definitionFullExpanded"
 
@@ -273,7 +275,7 @@ FluidClassBuilderTest >> testCreateClassWithFullExpandedDefinitionKeepsTheMinimu
 	self assert: shiftClassBuilder layoutDefinition sharedPools isEmpty
 ]
 
-{ #category : #'tests - class creation' }
+{ #category : 'tests - class creation' }
 FluidClassBuilderTest >> testCreatedClassHasAllElements [
 
 	| instBuilder newClass |
@@ -304,7 +306,7 @@ FluidClassBuilderTest >> testCreatedClassHasAllElements [
 	self assert: newClass category equals: self packageNameForTest , '-boring'
 ]
 
-{ #category : #'tests - class creation' }
+{ #category : 'tests - class creation' }
 FluidClassBuilderTest >> testCreatedEmptyClassHasDefaultElements [
 
 	| instBuilder newClass |
@@ -325,7 +327,7 @@ FluidClassBuilderTest >> testCreatedEmptyClassHasDefaultElements [
 	self assert: newClass category equals: self packageNameForTest
 ]
 
-{ #category : #'tests - class creation' }
+{ #category : 'tests - class creation' }
 FluidClassBuilderTest >> testExistingClassWithClassSlot [
 
 	| instBuilder newClass |
@@ -364,7 +366,7 @@ FluidClassBuilderTest >> testExistingClassWithClassSlot [
 	self assert: newClass class slots first name equals: #AAA
 ]
 
-{ #category : #'tests - class creation' }
+{ #category : 'tests - class creation' }
 FluidClassBuilderTest >> testExistingClassWithClassSlotThenWeRemoveIt [
 
 	| instBuilder newClass classBuilder |
@@ -397,7 +399,7 @@ FluidClassBuilderTest >> testExistingClassWithClassSlotThenWeRemoveIt [
 	self assert: newClass class slots equals: #(  )
 ]
 
-{ #category : #'tests - classBuilder generation' }
+{ #category : 'tests - classBuilder generation' }
 FluidClassBuilderTest >> testFillShiftClassBuilder [
 
 	| shift |
@@ -418,7 +420,7 @@ FluidClassBuilderTest >> testFillShiftClassBuilder [
 	"self assert: clas package packageName equals: self packageNameForTest"
 ]
 
-{ #category : #'tests - mandatory' }
+{ #category : 'tests - mandatory' }
 FluidClassBuilderTest >> testInstallMinimalMockClass [
 
 	| shiftClassBuilder installedClass |
@@ -445,7 +447,7 @@ FluidClassBuilderTest >> testInstallMinimalMockClass [
 	self assert: installedClass sharedPools isEmpty
 ]
 
-{ #category : #'tests - classBuilder generation' }
+{ #category : 'tests - classBuilder generation' }
 FluidClassBuilderTest >> testInstallSimplePoint2 [
 
 	[

--- a/src/FluidClassBuilder-Tests/FluidClassSideClassBuilderTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidClassSideClassBuilderTest.class.st
@@ -2,12 +2,14 @@
 This class contains tests for `FluidClassSideClassBuilder`
 "
 Class {
-	#name : #FluidClassSideClassBuilderTest,
-	#superclass : #FluidClassBuilderAbstractTest,
-	#category : #'FluidClassBuilder-Tests-Base'
+	#name : 'FluidClassSideClassBuilderTest',
+	#superclass : 'FluidClassBuilderAbstractTest',
+	#category : 'FluidClassBuilder-Tests-Base',
+	#package : 'FluidClassBuilder-Tests',
+	#tag : 'Base'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 FluidClassSideClassBuilderTest >> setUp [
 
 	super setUp.
@@ -18,20 +20,20 @@ FluidClassSideClassBuilderTest >> setUp [
 		           package: 'FakedPackage'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 FluidClassSideClassBuilderTest >> testBuilderClassName [
 	"Yes a class side builder expects the instance name."
 
 	self assert: builder nameToBuild equals: #'Point33'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 FluidClassSideClassBuilderTest >> testBuilderSuperclass [
 
 	self assert: builder superclassToBuild equals: Object
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 FluidClassSideClassBuilderTest >> testBuilderWithSlots [
 
 	builder slots: { #metaX . #metaY }.
@@ -41,7 +43,7 @@ FluidClassSideClassBuilderTest >> testBuilderWithSlots [
 	self assert: builder slotsToBuild equals: #()
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 FluidClassSideClassBuilderTest >> testBuilderWithTraits [
 
 	builder traits: { TViewModelMock classTrait }.

--- a/src/FluidClassBuilder-Tests/FluidClassSideTraitBuilderTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidClassSideTraitBuilderTest.class.st
@@ -2,12 +2,14 @@
 This class contains tests for `FluidClassSideTraitBuilder`
 "
 Class {
-	#name : #FluidClassSideTraitBuilderTest,
-	#superclass : #FluidClassBuilderAbstractTest,
-	#category : #'FluidClassBuilder-Tests-Base'
+	#name : 'FluidClassSideTraitBuilderTest',
+	#superclass : 'FluidClassBuilderAbstractTest',
+	#category : 'FluidClassBuilder-Tests-Base',
+	#package : 'FluidClassBuilder-Tests',
+	#tag : 'Base'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 FluidClassSideTraitBuilderTest >> setUp [
 
 	super setUp.
@@ -16,7 +18,7 @@ FluidClassSideTraitBuilderTest >> setUp [
 		           nameToBuild: TViewModelMock
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 FluidClassSideTraitBuilderTest >> testSlots [
 
 	| trait |

--- a/src/FluidClassBuilder-Tests/FluidTraitBuilderTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidTraitBuilderTest.class.st
@@ -2,19 +2,21 @@
 This class contains tests for `FluidTraitBuilder`
 "
 Class {
-	#name : #FluidTraitBuilderTest,
-	#superclass : #FluidClassBuilderAbstractTest,
-	#category : #'FluidClassBuilder-Tests-Base'
+	#name : 'FluidTraitBuilderTest',
+	#superclass : 'FluidClassBuilderAbstractTest',
+	#category : 'FluidClassBuilder-Tests-Base',
+	#package : 'FluidClassBuilder-Tests',
+	#tag : 'Base'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 FluidTraitBuilderTest >> setUp [
 
 	super setUp.
 	builder := FluidTraitBuilder new
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 FluidTraitBuilderTest >> tearDown [
 
 	"self class environment
@@ -23,7 +25,7 @@ FluidTraitBuilderTest >> tearDown [
 	super tearDown
 ]
 
-{ #category : #'tests - classBuilder generation' }
+{ #category : 'tests - classBuilder generation' }
 FluidTraitBuilderTest >> testBuildSimplePoint2 [
 
 	| trait |
@@ -36,14 +38,14 @@ FluidTraitBuilderTest >> testBuildSimplePoint2 [
 	self assert: trait slots size equals: 2
 ]
 
-{ #category : #'class side' }
+{ #category : 'class side' }
 FluidTraitBuilderTest >> testClassSlots [
 
 	builder classSlots: {#string . #runs}.
 	self assert: builder classSlotsToBuild equals: {#string => InstanceVariableSlot. #runs => InstanceVariableSlot}
 ]
 
-{ #category : #'tests - class creation' }
+{ #category : 'tests - class creation' }
 FluidTraitBuilderTest >> testCreatingEmptyTraitHasDefaultElements [
 
 	| instBuilder newTrait |
@@ -62,7 +64,7 @@ FluidTraitBuilderTest >> testCreatingEmptyTraitHasDefaultElements [
 	self assert: newTrait category equals: self packageNameForTest
 ]
 
-{ #category : #'tests - class creation' }
+{ #category : 'tests - class creation' }
 FluidTraitBuilderTest >> testCreatingFullTraitHasAllElements [
 
 	| instBuilder newTrait |
@@ -86,7 +88,7 @@ FluidTraitBuilderTest >> testCreatingFullTraitHasAllElements [
 	self assert: newTrait category equals: self packageNameForTest , '-lala'
 ]
 
-{ #category : #'tests - class creation' }
+{ #category : 'tests - class creation' }
 FluidTraitBuilderTest >> testExistingTraitWithClassSlotsArePreservedIfChangingInstanceSide [
 
 	| instBuilder newTrait |
@@ -108,7 +110,7 @@ FluidTraitBuilderTest >> testExistingTraitWithClassSlotsArePreservedIfChangingIn
 	self assert: newTrait class slotNames equals: #( AAA )
 ]
 
-{ #category : #'tests - class creation' }
+{ #category : 'tests - class creation' }
 FluidTraitBuilderTest >> testExistingTraitWithSlotsArePreservedIfChangingClassSide [
 
 	| instBuilder newTrait classBuilder |
@@ -131,7 +133,7 @@ FluidTraitBuilderTest >> testExistingTraitWithSlotsArePreservedIfChangingClassSi
 	self assert: newTrait slotNames equals: #( aaa )
 ]
 
-{ #category : #'tests - classBuilder generation' }
+{ #category : 'tests - classBuilder generation' }
 FluidTraitBuilderTest >> testFillShiftClassBuilder [
 
 	| shift |
@@ -151,7 +153,7 @@ FluidTraitBuilderTest >> testFillShiftClassBuilder [
 	"self assert: clas package packageName equals: self packageNameForTest"
 ]
 
-{ #category : #'tests - install' }
+{ #category : 'tests - install' }
 FluidTraitBuilderTest >> testInstallMinimalMockClass [
 
 	| shiftClassBuilder installedClass |
@@ -171,7 +173,7 @@ FluidTraitBuilderTest >> testInstallMinimalMockClass [
 	self assert: installedClass traitComposition isEmpty
 ]
 
-{ #category : #'tests - install' }
+{ #category : 'tests - install' }
 FluidTraitBuilderTest >> testInstallSimplePoint2 [
 
 	| trait |
@@ -186,7 +188,7 @@ FluidTraitBuilderTest >> testInstallSimplePoint2 [
 	self assert: trait slots size equals: 2
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 FluidTraitBuilderTest >> testTraitNoSlotsNoUse [
 
 	| trait |
@@ -199,7 +201,7 @@ FluidTraitBuilderTest >> testTraitNoSlotsNoUse [
 	self assert: trait package packageName equals: '_UnpackagedPackage'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 FluidTraitBuilderTest >> testTraitUse [
 
 	| trait |

--- a/src/FluidClassBuilder-Tests/TViewModelMock.trait.st
+++ b/src/FluidClassBuilder-Tests/TViewModelMock.trait.st
@@ -2,20 +2,22 @@
 A trait to use as a mock in test classes like `FluidClassBuilderTest` and class `FluidTraitBuilderTest`
 "
 Trait {
-	#name : #TViewModelMock,
+	#name : 'TViewModelMock',
 	#classInstVars : [
 		'a'
 	],
-	#category : #'FluidClassBuilder-Tests-Mocks'
+	#category : 'FluidClassBuilder-Tests-Mocks',
+	#package : 'FluidClassBuilder-Tests',
+	#tag : 'Mocks'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TViewModelMock classSide >> a [
 
 	^ a
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TViewModelMock classSide >> a: anObject [
 
 	a := anObject

--- a/src/FluidClassBuilder-Tests/TViewModelMock2.trait.st
+++ b/src/FluidClassBuilder-Tests/TViewModelMock2.trait.st
@@ -2,6 +2,8 @@
 A trait to use as a mock in test classes like `FluidClassBuilderTest`
 "
 Trait {
-	#name : #TViewModelMock2,
-	#category : #'FluidClassBuilder-Tests-Mocks'
+	#name : 'TViewModelMock2',
+	#category : 'FluidClassBuilder-Tests-Mocks',
+	#package : 'FluidClassBuilder-Tests',
+	#tag : 'Mocks'
 }

--- a/src/FluidClassBuilder-Tests/package.st
+++ b/src/FluidClassBuilder-Tests/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'FluidClassBuilder-Tests' }
+Package { #name : 'FluidClassBuilder-Tests' }

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -473,7 +473,7 @@ CompiledMethodTest >> testIsExtension [
 
 	self class removeSelector: #isExtensionTestMethod.
 	self deny: method isExtension ] ensure: [
-		(self packageOrganizer packageNamed: 'Kernel-Tests-Generated-Package' ifAbsent: [ nil ]) ifNotNil: [ :package | package removeFromSystem ].
+		self packageOrganizer packageNamed: 'Kernel-Tests-Generated-Package' ifPresent: [ :package | package removeFromSystem ].
 		self class compiledMethodAt: #isExtensionTestMethod ifPresent: [ :method | method removeFromSystem ] ]
 ]
 

--- a/src/Kernel-Tests/ClassDescriptionTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionTest.class.st
@@ -34,8 +34,7 @@ ClassDescriptionTest >> createTestClass [
 { #category : 'running' }
 ClassDescriptionTest >> tearDown [
 
-	(RPackageOrganizer default packageNamed: self compilationTestPackageName ifAbsent: [ nil ])
-		ifNotNil: [ :package | package removeFromSystem ].
+	RPackageOrganizer default packageNamed: self compilationTestPackageName ifPresent: [ :package | package removeFromSystem ].
 
 	super tearDown
 ]

--- a/src/Monticello/MCWorkingCopy.class.st
+++ b/src/Monticello/MCWorkingCopy.class.st
@@ -260,7 +260,7 @@ MCWorkingCopy class >> registerPackage: aPackage packageOrganizer: aPackageOrgan
 	self registry at: aPackage put: workingCopy.
 	"When creating a MC package and a working copy, we need to ensure we create a system package also in case someone creates a package without an associated system package.
 	But we still check that the package does not exist because the working copy creation might be caused by the creation of the system package and we do not want to end up in a loop."
-	aPackageOrganizer packageNamedIgnoreCase: aPackage name ifAbsent: [ aPackageOrganizer ensurePackage: aPackage name ].
+	aPackageOrganizer packageNamed: aPackage name ifAbsent: [ aPackageOrganizer ensurePackage: aPackage name ].
 	self announcer announce: (MCWorkingCopyCreated workingCopy: workingCopy package: aPackage).
 	^ workingCopy
 ]

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -307,10 +307,6 @@ RPackage >> ensureTag: aTag [
 
 	(self hasTag: aTag) ifTrue: [ ^ self classTagNamed: tagName ].
 
-
-	self flag: #package. "We are checking because currently there is a bug that we cannot have a package that has the same name as a package and tag. So we first want to ensure we do not have a package of the same name. When this limitation will be removed in the future we should remove the next check."
-	self name = tagName ifFalse: [ self organizer validateCanBeAddedPackageName: self name , '-' , tagName tagName: nil ].
-
 	newTag := RPackageTag package: self name: tagName.
 	classTags add: newTag.
 

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -732,11 +732,6 @@ RPackage >> removeEmptyTags [
 { #category : 'removing' }
 RPackage >> removeFromSystem [
 
-	| categories |
-	categories := (self classTags collect: [ :each | each categoryName ] as: Set)
-		              add: self name;
-		              yourself.
-
 	self definedClasses do: #removeFromSystem.
 	self extensionMethods do: #removeFromSystem.
 

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -447,7 +447,9 @@ RPackageOrganizer >> registerInterestToSystemAnnouncement [
 RPackageOrganizer >> registerPackage: aPackage [
 	"A new package is now available and declared in the receiver. "
 
-	self validateCanBeAddedPackageName: aPackage name tagName: nil.
+	(self packageNamed: aPackage name ifAbsent: [ nil ]) ifNotNil: [
+		RPackageConflictError signal: ('Package can not be added because it conflicts with package a package of the same name.' format: { aPackage name }) ].
+
 
 	self basicRegisterPackage: aPackage.
 	aPackage extendedClasses do: [ :extendedClass | self registerExtendingPackage: aPackage forClass: extendedClass ].
@@ -643,23 +645,6 @@ RPackageOrganizer >> unregisterPackage: aPackage forClass: aClass [
 
 	self flag: #package. "When RPackage will be simplified we should not have to check the package but it is required for now"
 	^ (classPackageMapping at: aClass instanceSide ifAbsent: [ ^ self ]) = aPackage ifTrue: [ classPackageMapping removeKey: aClass instanceSide ]
-]
-
-{ #category : 'private' }
-RPackageOrganizer >> validateCanBeAddedPackageName: packageName tagName: tagName [
-
-	| package |
-	package := self packageNamed: packageName ifAbsent: [
-		           (packageName includes: $-) ifFalse: [ ^ self ].
-
-		           ^ self validateCanBeAddedPackageName: (packageName copyUpToLast: $-) tagName: (packageName copyAfterLast: $-) , (tagName
-				              ifNotNil: [ '-' , tagName ]
-				              ifNil: [ '' ]) ].
-
-	(tagName isEmptyOrNil or: [ package includesClassTagNamed: tagName ]) ifTrue: [
-		RPackageConflictError signal: ('Package/Tag can not be added because it conflicts with package {1} tag {2}' format: {
-					 packageName.
-					 tagName }) ]
 ]
 
 { #category : 'registration' }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -342,7 +342,7 @@ RPackageOrganizer >> packageMatchingExtensionName: anExtensionName [
 
 	| tmpPackageName |
 	"we first look if their is a package matching exactly the name specified"
-	(self packageNamed: anExtensionName ifAbsent: [ nil ]) ifNotNil: [ :package | ^ package ].
+	self packageNamed: anExtensionName ifPresent: [ :package | ^ package ].
 
 	"if no package was found, we try to find one matching the begining of the name specified"
 	tmpPackageName := ''.
@@ -461,8 +461,9 @@ RPackageOrganizer >> registerInterestToSystemAnnouncement [
 RPackageOrganizer >> registerPackage: aPackage [
 	"A new package is now available and declared in the receiver. "
 
-	(self packageNamed: aPackage name ifAbsent: [ nil ]) ifNotNil: [
-		RPackageConflictError signal: ('Package can not be added because it conflicts with package a package of the same name.' format: { aPackage name }) ].
+	self
+		packageNamed: aPackage name
+		ifPresent: [ RPackageConflictError signal: ('Package can not be added because it conflicts with package a package of the same name.' format: { aPackage name }) ].
 
 	self basicRegisterPackage: aPackage.
 	aPackage extendedClasses do: [ :extendedClass | self registerExtendingPackage: aPackage forClass: extendedClass ].

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -183,9 +183,7 @@ RPackageOrganizer >> announcer [
 { #category : 'initialization - data' }
 RPackageOrganizer >> basicInitializeFromPackagesList: aPackagesList [
 
-	aPackagesList
-		do: [ :packageName | self basicRegisterPackage: (RPackage named: packageName organizer: self) ]
-		displayingProgress: 'Importing monticello packages'.
+	aPackagesList do: [ :packageName | self ensurePackage: packageName ] displayingProgress: 'Importing monticello packages'.
 
 	Smalltalk allClassesAndTraits
 		do: [ :behavior | (self ensurePackageMatching: behavior category) importClass: behavior ]

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -230,6 +230,13 @@ RPackageOrganizer >> defineUnpackagedClassesPackage [
 { #category : 'registration' }
 RPackageOrganizer >> ensurePackage: aPackage [
 
+	| packageName |
+	packageName := aPackage isString
+		               ifTrue: [ aPackage ]
+		               ifFalse: [ aPackage name ].
+
+	(self hasPackage: aPackage) ifTrue: [ ^ self packageNamed: packageName ].
+
 	^ aPackage isString
 		  ifTrue: [ self packageNamed: aPackage ifAbsent: [ self registerPackage: (RPackage named: aPackage organizer: self) ] ]
 		  ifFalse: [
@@ -288,7 +295,9 @@ RPackageOrganizer >> hasPackage: aPackage [
 	"Takes a package or a package name as parameter and return true if I include this package."
 
 	^ aPackage isString
-		  ifTrue: [ packages includesKey: aPackage asSymbol ]
+		  ifTrue: [
+			  self packageNamed: aPackage asSymbol ifAbsent: [ ^ false ].
+			  ^ true ]
 		  ifFalse: [ self packages includes: aPackage ]
 ]
 
@@ -333,7 +342,7 @@ RPackageOrganizer >> packageMatchingExtensionName: anExtensionName [
 
 	| tmpPackageName |
 	"we first look if their is a package matching exactly the name specified"
-	(self packageNamedIgnoreCase: anExtensionName ifAbsent: [ nil ]) ifNotNil: [ :package | ^ package ].
+	(self packageNamed: anExtensionName ifAbsent: [ nil ]) ifNotNil: [ :package | ^ package ].
 
 	"if no package was found, we try to find one matching the begining of the name specified"
 	tmpPackageName := ''.
@@ -355,18 +364,23 @@ RPackageOrganizer >> packageNamed: aSymbol [
 
 { #category : 'accessing' }
 RPackageOrganizer >> packageNamed: aSymbol ifAbsent: errorBlock [
+	"We first look at the fast solution then we try the case insensitive way because we do not care about the case in this package manager."
 
-	^ packages at: aSymbol asSymbol ifAbsent: errorBlock
+	^ packages at: aSymbol asSymbol ifAbsent: [
+		  self packagesDo: [ :each | (each name sameAs: aSymbol) ifTrue: [ ^ each ] ].
+		  errorBlock value ]
 ]
 
-{ #category : 'private' }
-RPackageOrganizer >> packageNamedIgnoreCase: aSymbol ifAbsent: aBlock [
-	"In case of extensions, I can need to take a package ignoring name"
-	self packagesDo: [  :each |
-		(each name sameAs: aSymbol)
-			ifTrue: [  ^ each  ]  ].
+{ #category : 'accessing' }
+RPackageOrganizer >> packageNamed: aSymbol ifPresent: aBlock [
+	"We first look at the fast solution then we try the case insensitive way because we do not care about the case in this package manager."
 
-	^ aBlock value
+	^ packages
+		  at: aSymbol asSymbol
+		  ifPresent: aBlock
+		  ifAbsent: [
+			  self packagesDo: [ :each | (each name sameAs: aSymbol) ifTrue: [ ^ aBlock cull: each ] ].
+			  nil ]
 ]
 
 { #category : 'package - names-cache' }
@@ -449,7 +463,6 @@ RPackageOrganizer >> registerPackage: aPackage [
 
 	(self packageNamed: aPackage name ifAbsent: [ nil ]) ifNotNil: [
 		RPackageConflictError signal: ('Package can not be added because it conflicts with package a package of the same name.' format: { aPackage name }) ].
-
 
 	self basicRegisterPackage: aPackage.
 	aPackage extendedClasses do: [ :extendedClass | self registerExtendingPackage: aPackage forClass: extendedClass ].

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -156,24 +156,30 @@ RPackageOrganizerTest >> testRegisterPackageConflictWithPackage [
 
 { #category : 'tests' }
 RPackageOrganizerTest >> testRegisterPackageConflictWithPackageTag [
+	"In the past we could not have package-tag with the same name than a package but now it is possible"
 
-	| package1 |
-	self flag: #package. "This is a limitiation of the system organizer. I hope to kill this limitiation before p12 release."
+	| package1 package2 tag |
 	package1 := self createNewPackageNamed: 'P1'.
-	package1 ensureTag: #T1.
+	tag := package1 ensureTag: #T1.
 
-	self should: [ self createNewPackageNamed: 'P1-T1' ] raise: Error
+	package2 := self createNewPackageNamed: #'P1-T1'.
+
+	self assert: package2 name equals: #'P1-T1'.
+	self assert: package1 name equals: #P1.
+	self assert: tag name equals: #T1
 ]
 
 { #category : 'tests' }
 RPackageOrganizerTest >> testRegisterPackageTagConflictWithPackage [
 
-	| package1 package2 |
-	self flag: #package. "This is a limitiation of the system organizer. I hope to kill this limitiation before p12 release."
-	package1 := self createNewPackageNamed: 'P1-T1'.
+	| package1 package2 tag |
+	package1 := self createNewPackageNamed: #P1.
+	package2 := self createNewPackageNamed: #'P1-T1'.
+	tag := package1 ensureTag: #T1.
 
-	package2 := self createNewPackageNamed: 'P1'.
-	self should: [ package2 ensureTag: #T1 ] raise: Error
+	self assert: package2 name equals: #'P1-T1'.
+	self assert: package1 name equals: #P1.
+	self assert: tag name equals: #T1
 ]
 
 { #category : 'tests' }

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -80,6 +80,21 @@ RPackageOrganizerTest >> testEmpty [
 ]
 
 { #category : 'tests' }
+RPackageOrganizerTest >> testEnsurePackageManagesDifferentCase [
+
+	| package1 package2 |
+	package1 := self organizer ensurePackage: #Package1.
+	package2 := self organizer ensurePackage: #PaCkaGe1.
+
+	self assert: self organizer packages size equals: 2. "Unpackaged + Package1"
+	self assert: package1 identicalTo: package2.
+	self assert: package2 name equals: #Package1.
+	self assert: (self organizer packageNamed: #Package1) identicalTo: package1.
+	self assert: (self organizer packageNamed: #PaCKaGe1) identicalTo: package1.
+	self assert: (self organizer packageNamed: #PackagE1) identicalTo: package1
+]
+
+{ #category : 'tests' }
 RPackageOrganizerTest >> testExtensionMethodNotExactlyTheName [
 
 	| p1 p2 c1 |
@@ -145,6 +160,68 @@ RPackageOrganizerTest >> testHasPackage [
 	self assert: (organizer hasPackage: package).
 
 	self deny: (organizer hasPackage: packageFromOtherOrganizer)
+]
+
+{ #category : 'tests' }
+RPackageOrganizerTest >> testHasPackageCaseInsensitive [
+
+	self organizer ensurePackage: #Package1.
+
+	self assert: (self organizer hasPackage: #Package1).
+	self assert: (self organizer hasPackage: #PackaGe1).
+	self deny: (self organizer hasPackage: #Packae1)
+]
+
+{ #category : 'tests' }
+RPackageOrganizerTest >> testPackageNamed [
+
+	| package |
+	package := self organizer ensurePackage: #Package1.
+
+	self assert: self organizer packages size equals: 2. "Unpackaged + Package"
+	self assert: package name equals: #Package1.
+	self assert: (self organizer packageNamed: #Package1) identicalTo: package
+]
+
+{ #category : 'tests' }
+RPackageOrganizerTest >> testPackageNamedIfAbsent [
+
+	| package |
+	package := self organizer ensurePackage: #Package1.
+
+	self assert: self organizer packages size equals: 2. "Unpackaged + Package"
+	self assert: package name equals: #Package1.
+	self assert: (self organizer packageNamed: #Package1 ifAbsent: [ self fail ]) identicalTo: package.
+	self assert: (self organizer packageNamed: #Package ifAbsent: [ true ])
+]
+
+{ #category : 'tests' }
+RPackageOrganizerTest >> testPackageNamedIfPresent [
+
+	| package |
+	package := self organizer ensurePackage: #Package1.
+
+	self assert: self organizer packages size equals: 2. "Unpackaged + Package"
+	self assert: package name equals: #Package1.
+	self assert: (self organizer packageNamed: #Package1 ifPresent: [ :package | package name ]) equals: package name.
+	self assert: (self organizer packageNamed: #Package ifPresent: [ :package | self fail ]) isNil
+]
+
+{ #category : 'tests' }
+RPackageOrganizerTest >> testPackageNamedWithDifferentCase [
+
+	| package |
+	package := self organizer ensurePackage: #Package1.
+
+	self assert: self organizer packages size equals: 2. "Unpackaged + Package"
+	self assert: package name equals: #Package1.
+	self assert: (self organizer packageNamed: #PacKAge1) identicalTo: package
+]
+
+{ #category : 'tests' }
+RPackageOrganizerTest >> testPackageNamedWithoutMatchingPackage [
+
+	self should: [ self organizer packageNamed: #PacKAge1 ] raise: NotFound
 ]
 
 { #category : 'tests' }

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -203,8 +203,8 @@ RPackageOrganizerTest >> testPackageNamedIfPresent [
 
 	self assert: self organizer packages size equals: 2. "Unpackaged + Package"
 	self assert: package name equals: #Package1.
-	self assert: (self organizer packageNamed: #Package1 ifPresent: [ :package | package name ]) equals: package name.
-	self assert: (self organizer packageNamed: #Package ifPresent: [ :package | self fail ]) isNil
+	self assert: (self organizer packageNamed: #Package1 ifPresent: [ :package2 | package2 name ]) equals: package name.
+	self assert: (self organizer packageNamed: #Package ifPresent: [ self fail ]) isNil
 ]
 
 { #category : 'tests' }

--- a/src/RPackage-Tests/RPackageRenameTest.class.st
+++ b/src/RPackage-Tests/RPackageRenameTest.class.st
@@ -125,35 +125,6 @@ RPackageRenameTest >> testRenamePackageToOwnTagNameWithClassesInRoot [
 ]
 
 { #category : 'tests' }
-RPackageRenameTest >> testRenamePackageUppercase [
-	"Test that we do rename the package as expected."
-
-	| package pkg oldWorkingCopy |
-	"preparation: creation of a pkg and its associated mcworkingcopy"
-	[
-	package := self packageOrganizer ensurePackage: 'Test1'.
-	oldWorkingCopy := MCWorkingCopy forPackageNamed: 'Test1'.
-	self assert: (self packageOrganizer hasPackage: #Test1).
-	self assert: (MCWorkingCopy hasPackageNamed: #Test1) isNotNil.
-
-	"renaming"
-	package renameTo: 'TEST1'.
-
-	pkg := self packageOrganizer packageNamed: 'Test1' ifAbsent: [ nil ].
-	self assert: pkg isNil.
-	self assert: 'TEST1' asPackage isNotNil.
-	self deny: 'TEST1' asPackage mcWorkingCopy equals: oldWorkingCopy.
-	self assert: 'TEST1' asPackage mcWorkingCopy isNotNil.
-	self assert: (self packageOrganizer hasPackage: #TEST1).
-	self assert: (MCWorkingCopy hasPackageNamed: #TEST1) isNotNil ] ensure: [ "cleaning"
-		'TEST1' asPackage removeFromSystem.
-		self deny: (self packageOrganizer hasPackage: #TEST1).
-		self deny: (MCWorkingCopy hasPackageNamed: #TEST1).
-		self deny: (self packageOrganizer hasPackage: #Test1).
-		self deny: (MCWorkingCopy hasPackageNamed: #Test1) ]
-]
-
-{ #category : 'tests' }
 RPackageRenameTest >> testRenamePackageWithExtensions [
 
 	| package class extendedPackage extension |

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -236,7 +236,7 @@ RPackageTest >> testIsTestPackage [
 	"Happy case: test package 'MockPackage-Tests' must contain -Tests suffix."
 	self assert: packages first isTestPackage equals: true.
 
-	"Package 'MockPackage-tests' is not test package, since it has lowercase suffix."
+	"Package 'MockPackage2-tests' is not test package, since it has lowercase suffix."
 	self assert: packages second isTestPackage  equals: false.
 
 	"Happy case: regular package 'MockPackage' without -Tests suffix is not a test package."

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -96,7 +96,7 @@ RPackageTestCase >> createNewTraitNamed: aName inPackage: p [
 { #category : 'utilities' }
 RPackageTestCase >> namesOfMockTestPackages [
 
-	^ #( 'MockPackage-Tests' 'MockPackage-tests' 'MockPackage' 'MockPackage-Tests-Package')
+	^ #( 'MockPackage-Tests' 'MockPackage2-tests' 'MockPackage' 'MockPackage-Tests-Package')
 ]
 
 { #category : 'accessing' }

--- a/src/TraitsV2-Tests/TraitFileOutTest.class.st
+++ b/src/TraitsV2-Tests/TraitFileOutTest.class.st
@@ -55,7 +55,7 @@ TraitFileOutTest >> tearDown [
 	dir := FileSystem workingDirectory.
 	self createdClassesAndTraits , self resourceClassesAndTraits do: [ :each | (dir / each asString , 'st') ensureDelete ].
 	(dir / self packageName , 'st') ensureDelete.
-	(self packageOrganizer packageNamed: self packageName ifAbsent: [ nil ]) ifNotNil: [ :package | package removeFromSystem ].
+	self packageOrganizer packageNamed: self packageName ifPresent: [ :package | package removeFromSystem ].
 	"Ensure cleaning of obsoletes refs"
 	ca := cb := ta := tb := tc := td := nil.
 	super tearDown


### PR DESCRIPTION
This PR brings a few changes now that the SystemOrganizer is removed.

# Feature

- It is now possible to have a Package + tag that have the same category than a Package name (for example Package #P1 with a tag #T1 in a system with a Package #'P1-T1')
- Implementation of #packageNamed:ifPresent:

# Bug fix

- #packageNamed:(ifAbsent:) now matches name in case insensitive because RPackage does not care about the case. This lead to the removal of #packageNamedIgnoreCase:ifAbsent:
- A bug was fixed when using #ensurePackage: to add a package with the same name than an existing package but a different case
- RPackageOrganizer >> hasPackage:  now knows how to deal with case in package names 

# Cleaning

- RPackage >> removeFromSystem got simplified
- RPackageOrganizer >> basicInitializeFromPackagesList: now uses #ensurePackage: that is a public API instead of the low level #basicRegisterPackage: that is too low level and might be removed later

And missing tests got added