### PR TITLE
Kernel: simplify renaming

### DIFF
--- a/src/Ring-Core/AbstractLayout.extension.st
+++ b/src/Ring-Core/AbstractLayout.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #AbstractLayout }
+Extension { #name : 'AbstractLayout' }
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 AbstractLayout >> asRingMinimalDefinitionIn: anRGEnvironment [
 
 	self subclassResponsibility

--- a/src/Ring-Core/ByteLayout.extension.st
+++ b/src/Ring-Core/ByteLayout.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #ByteLayout }
+Extension { #name : 'ByteLayout' }
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 ByteLayout >> asRingMinimalDefinitionIn: anRGEnvironment [
 
 	^ anRGEnvironment backend definitionFor: self ifAbsentRegister: [

--- a/src/Ring-Core/Class.extension.st
+++ b/src/Ring-Core/Class.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Class }
+Extension { #name : 'Class' }
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 Class >> asRingMinimalCommentDefinitionIn: anRGEnvironment [
 
 	^ anRGEnvironment backend definitionFor: ('classComment:', self name) asSymbol ifAbsentRegister: [
@@ -8,14 +8,14 @@ Class >> asRingMinimalCommentDefinitionIn: anRGEnvironment [
 	]
 ]
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 Class >> asRingMinimalDefinitionIn: anRGEnvironment [
 
 	^ anRGEnvironment backend definitionFor: self ifAbsentRegister: [
 		RGClass named: self name asSymbol parent: anRGEnvironment]
 ]
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 Class >> ensureRingDefinitionIn: anRGEnvironment [
 
 	^ anRGEnvironment ask behaviors

--- a/src/Ring-Core/ClassVariable.extension.st
+++ b/src/Ring-Core/ClassVariable.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #ClassVariable }
+Extension { #name : 'ClassVariable' }
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 ClassVariable >> asRingMinimalDefinitionIn: anRGEnvironment [
 
 	^ anRGEnvironment backend definitionFor: self ifAbsentRegister: [

--- a/src/Ring-Core/CompiledMethod.extension.st
+++ b/src/Ring-Core/CompiledMethod.extension.st
@@ -1,13 +1,13 @@
-Extension { #name : #CompiledMethod }
+Extension { #name : 'CompiledMethod' }
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 CompiledMethod >> asRingMinimalDefinitionIn: anRGEnvironment [
 
 	^ anRGEnvironment backend definitionFor: self ifAbsentRegister: [
 		RGMethod named: self selector asSymbol parent: (self methodClass asRingMinimalDefinitionIn: anRGEnvironment)]
 ]
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 CompiledMethod >> ensureRingDefinitionIn: anRGEnvironment [
 
 	| parentModel |

--- a/src/Ring-Core/CompiledMethodLayout.extension.st
+++ b/src/Ring-Core/CompiledMethodLayout.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #CompiledMethodLayout }
+Extension { #name : 'CompiledMethodLayout' }
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 CompiledMethodLayout >> asRingMinimalDefinitionIn: anRGEnvironment [
 
 	^ anRGEnvironment backend definitionFor: self ifAbsentRegister: [

--- a/src/Ring-Core/DoubleByteLayout.extension.st
+++ b/src/Ring-Core/DoubleByteLayout.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #DoubleByteLayout }
+Extension { #name : 'DoubleByteLayout' }
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 DoubleByteLayout >> asRingMinimalDefinitionIn: anRGEnvironment [
 
 	^ anRGEnvironment backend definitionFor: self ifAbsentRegister: [

--- a/src/Ring-Core/DoubleWordLayout.extension.st
+++ b/src/Ring-Core/DoubleWordLayout.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #DoubleWordLayout }
+Extension { #name : 'DoubleWordLayout' }
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 DoubleWordLayout >> asRingMinimalDefinitionIn: anRGEnvironment [
 
 	^ anRGEnvironment backend definitionFor: self ifAbsentRegister: [

--- a/src/Ring-Core/EmptyLayout.extension.st
+++ b/src/Ring-Core/EmptyLayout.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #EmptyLayout }
+Extension { #name : 'EmptyLayout' }
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 EmptyLayout >> asRingMinimalDefinitionIn: anRGEnvironment [
 
 	| aHost |

--- a/src/Ring-Core/EphemeronLayout.extension.st
+++ b/src/Ring-Core/EphemeronLayout.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #EphemeronLayout }
+Extension { #name : 'EphemeronLayout' }
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 EphemeronLayout >> asRingMinimalDefinitionIn: anRGEnvironment [
 
 	^ anRGEnvironment backend definitionFor: self ifAbsentRegister: [

--- a/src/Ring-Core/FixedLayout.extension.st
+++ b/src/Ring-Core/FixedLayout.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FixedLayout }
+Extension { #name : 'FixedLayout' }
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 FixedLayout >> asRingMinimalDefinitionIn: anRGEnvironment [
 
 	^ anRGEnvironment backend definitionFor: self ifAbsentRegister: [

--- a/src/Ring-Core/GlobalVariable.extension.st
+++ b/src/Ring-Core/GlobalVariable.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #GlobalVariable }
+Extension { #name : 'GlobalVariable' }
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 GlobalVariable >> asRingMinimalDefinitionIn: anRGEnvironment [
 
 	^ anRGEnvironment backend definitionFor: self ifAbsentRegister: [

--- a/src/Ring-Core/ImmediateLayout.extension.st
+++ b/src/Ring-Core/ImmediateLayout.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #ImmediateLayout }
+Extension { #name : 'ImmediateLayout' }
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 ImmediateLayout >> asRingMinimalDefinitionIn: anRGEnvironment [
 
 	^ anRGEnvironment backend definitionFor: self ifAbsentRegister: [

--- a/src/Ring-Core/IndexedSlot.extension.st
+++ b/src/Ring-Core/IndexedSlot.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #IndexedSlot }
+Extension { #name : 'IndexedSlot' }
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 IndexedSlot >> asRingMinimalDefinitionIn: anRGEnvironment [
 
 	^ self class == IndexedSlot

--- a/src/Ring-Core/InstanceVariableSlot.extension.st
+++ b/src/Ring-Core/InstanceVariableSlot.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #InstanceVariableSlot }
+Extension { #name : 'InstanceVariableSlot' }
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 InstanceVariableSlot >> asRingMinimalDefinitionIn: anRGEnvironment [
 
 	^ self class == InstanceVariableSlot

--- a/src/Ring-Core/Metaclass.extension.st
+++ b/src/Ring-Core/Metaclass.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Metaclass }
+Extension { #name : 'Metaclass' }
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 Metaclass >> asRingMinimalDefinitionIn: anRGEnvironment [
 
 	^ RGMetaclass named: self name parent: anRGEnvironment

--- a/src/Ring-Core/Object.extension.st
+++ b/src/Ring-Core/Object.extension.st
@@ -1,42 +1,42 @@
-Extension { #name : #Object }
+Extension { #name : 'Object' }
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 Object >> isRGObject [
 
 	^ false
 ]
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 Object >> isRGUnresolvedValue [
 
 	^ false
 ]
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 Object >> isRingFullyResolved [
 
 	^ true
 ]
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 Object >> isRingFullyUnresolved [
 
 	^ false
 ]
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 Object >> isRingResolved [
 
 	^ true
 ]
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 Object >> markAsRingResolved [
 
 	"do nothing"
 ]
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 Object >> orDefaultForUnresolved [
 
 	^ self

--- a/src/Ring-Core/RGBadInstantiationError.class.st
+++ b/src/Ring-Core/RGBadInstantiationError.class.st
@@ -2,7 +2,9 @@
 I'm a specialized error exception used for cases where you want to work directly with instances of RGBehavior without assigned behavior strategy
 "
 Class {
-	#name : #RGBadInstantiationError,
-	#superclass : #Error,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGBadInstantiationError',
+	#superclass : 'Error',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }

--- a/src/Ring-Core/RGBehavior.class.st
+++ b/src/Ring-Core/RGBehavior.class.st
@@ -7,8 +7,8 @@ Instance Variables
 	superclass:		<Object>
 "
 Class {
-	#name : #RGBehavior,
-	#superclass : #RGBehaviorStrategyUser,
+	#name : 'RGBehavior',
+	#superclass : 'RGBehaviorStrategyUser',
 	#instVars : [
 		'superclass',
 		'localMethods',
@@ -17,22 +17,24 @@ Class {
 		'tagsForMethods',
 		'tags'
 	],
-	#category : #'Ring-Core-Kernel'
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'private - accessing' }
+{ #category : 'private - accessing' }
 RGBehavior class >> badInstantiationError [
 
 	RGBadInstantiationError signal: 'I cannot be instantiated this way because every RGBehavior must know its proper behavior strategy. Please use a subclass of RGBehaviorFactory or my methods like #newClass'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehavior class >> named: aString [
 
 	^ self badInstantiationError
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehavior class >> named: aName behaviorStrategy: anRGBehaviorStrategy [
 
 	| aBehavior |
@@ -46,13 +48,13 @@ RGBehavior class >> named: aName behaviorStrategy: anRGBehaviorStrategy [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehavior class >> named: aString parent: anRGObject [
 
 	^ self badInstantiationError
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehavior class >> named: aName parent: anRGObject behaviorStrategy: anRGBehaviorStrategy [
 
 	| aBehavior |
@@ -67,31 +69,31 @@ RGBehavior class >> named: aName parent: anRGObject behaviorStrategy: anRGBehavi
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGBehavior class >> newClass [
 
 	^ self unnamedWithBehaviorStrategy: RGClassStrategy basicNew
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGBehavior class >> newMetaclass [
 
 	^ self unnamedWithBehaviorStrategy: RGMetaclassStrategy basicNew
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGBehavior class >> newMetaclassTrait [
 
 	^ self unnamedWithBehaviorStrategy: RGMetaclassTrait newStrategy
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGBehavior class >> newTrait [
 
 	^ self unnamedWithBehaviorStrategy: RGTrait newStrategy
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehavior class >> parent: anRGObject behaviorStrategy: anRGBehaviorStrategy [
 
 	| aBehavior |
@@ -104,7 +106,7 @@ RGBehavior class >> parent: anRGObject behaviorStrategy: anRGBehaviorStrategy [
 	^ aBehavior
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehavior class >> unnamedWithBehaviorStrategy: anRGBehaviorStrategy [
 
 	| aBehavior |
@@ -116,7 +118,7 @@ RGBehavior class >> unnamedWithBehaviorStrategy: anRGBehaviorStrategy [
 	^ aBehavior
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehavior class >> unresolvedNamed: aName withParent: anRGObject behaviorStrategy: anRGBehaviorStrategy [
 
 	| aBehavior |
@@ -131,7 +133,7 @@ RGBehavior class >> unresolvedNamed: aName withParent: anRGObject behaviorStrate
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehavior class >> unresolvedWithBehaviorStrategy: anRGBehaviorStrategy [
 
 	| aBehavior |
@@ -143,7 +145,7 @@ RGBehavior class >> unresolvedWithBehaviorStrategy: anRGBehaviorStrategy [
 	^ aBehavior
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehavior class >> unresolvedWithParent: anRGObject behaviorStrategy: anRGBehaviorStrategy [
 
 	| aBehavior |
@@ -156,7 +158,7 @@ RGBehavior class >> unresolvedWithParent: anRGObject behaviorStrategy: anRGBehav
 	^ aBehavior
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGBehavior >> addLocalMethod: anRGMethod [
 
 	self backend forBehavior addLocalMethod: anRGMethod to: self.
@@ -164,13 +166,13 @@ RGBehavior >> addLocalMethod: anRGMethod [
 	self announcer methodAdded: anRGMethod
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGBehavior >> addProtocol: aSymbol [
 
 	self announceDefinitionChangeDuring: [ self backend forBehavior addMethodTag: aSymbol to: self ]
 ]
 
-{ #category : #'managing container' }
+{ #category : 'managing container' }
 RGBehavior >> addoptToParentStub [
 
 	self isRingResolved ifFalse: [ ^ self ].
@@ -180,7 +182,7 @@ RGBehavior >> addoptToParentStub [
 	self parent pvtAddBehavior: self
 ]
 
-{ #category : #'queries - other' }
+{ #category : 'queries - other' }
 RGBehavior >> allInstVarNames [
 	"Answer an Array of the names of the receiver's instance variables. The
 	Array ordering is the order in which the variables are stored and
@@ -193,7 +195,7 @@ RGBehavior >> allInstVarNames [
 	^vars
 ]
 
-{ #category : #announcements }
+{ #category : 'announcements' }
 RGBehavior >> announceDefinitionChangeDuring: aBlock [
 
 	| oldVersion |
@@ -209,13 +211,13 @@ RGBehavior >> announceDefinitionChangeDuring: aBlock [
 	self announcer behaviorModificationAppliedTo: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehavior >> asYetUnclassifiedProtocolName [
 
 	^ Protocol unclassified
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGBehavior >> canMergeWith: anRGObject visited: visitedDefinitions [
 
 	| newVisited |
@@ -237,20 +239,20 @@ RGBehavior >> canMergeWith: anRGObject visited: visitedDefinitions [
 	^ true
 ]
 
-{ #category : #'accessing - definition' }
+{ #category : 'accessing - definition' }
 RGBehavior >> classVariablesBindings [
 
 	^ self propertyNamed: #classVariablesBindings ifAbsentPut: [ IdentityDictionary new.]
 ]
 
-{ #category : #'accessing - definition' }
+{ #category : 'accessing - definition' }
 RGBehavior >> classVariablesString [
 	"Answer a string of my class variable names separated by spaces."
 
 	^ self behaviorStrategy classVariablesString
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGBehavior >> cleanLocalMethods [
 
 	| oldMethods |
@@ -265,38 +267,38 @@ RGBehavior >> cleanLocalMethods [
 		self announcer methodRemoved: each ]
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGBehavior >> cleanProtocols [
 
 	self cleanTagsForMethods
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGBehavior >> cleanTags [
 
 	self announceDefinitionChangeDuring: [
 		self cleanTagsWithoutAnnouncemnt ]
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGBehavior >> cleanTagsForMethods [
 
 	self backend forPackage cleanTagsForMethodsFor: self
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGBehavior >> cleanTagsWithoutAnnouncemnt [
 
 	self backend forBehavior cleanClassTagsFor: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehavior >> compiler [
 
 	^ self class compiler
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 RGBehavior >> convertToMetaclassTrait [
 
 	| metaclassTraitStrategy originalName |
@@ -322,7 +324,7 @@ RGBehavior >> convertToMetaclassTrait [
 	self environment ask replaceName: originalName with: self name
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 RGBehavior >> convertToTrait [
 
 	| traitStrategy originalName |
@@ -353,7 +355,7 @@ RGBehavior >> convertToTrait [
 	self environment ask replaceName: originalName with: self name
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 RGBehavior >> copyForBehaviorDefinitionPostCopy [
 
 	super copyForBehaviorDefinitionPostCopy.
@@ -366,56 +368,56 @@ RGBehavior >> copyForBehaviorDefinitionPostCopy [
 	behaviorStrategy := behaviorStrategy copyForBehaviorDefinitionWithOwner: self
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGBehavior >> defaultLayout [
 
 	^ self defaultFixedLayoutStubIn: self
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGBehavior >> defaultLocalMethods [
 
 	^ Set new
 ]
 
-{ #category : #'managing container' }
+{ #category : 'managing container' }
 RGBehavior >> defaultParentStub [
 
 	^ self defaultEnvironmentStub
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGBehavior >> defaultTags [
 
 	^ Set new
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGBehavior >> defaultTagsForMethods [
 
 	^ Set new
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGBehavior >> defaultTraitComposition [
 
 	^ self defaultTraitCompositionStubIn: self
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 RGBehavior >> definitionString [
 	"Answer a <String> with the receiver's definition accordingly to its strategy"
 
 	^ self behaviorStrategy definitionString
 ]
 
-{ #category : #fileout }
+{ #category : 'fileout' }
 RGBehavior >> definitionStringFor: aConfiguredPrinter [
 
 	^ aConfiguredPrinter classDefinitionString
 ]
 
-{ #category : #'queries - methods' }
+{ #category : 'queries - methods' }
 RGBehavior >> ensureLocalMethodNamed: aSymbol [
 
 	^ self localMethodNamed: aSymbol ifAbsent: [
@@ -425,7 +427,7 @@ RGBehavior >> ensureLocalMethodNamed: aSymbol [
 		newMethod]
 ]
 
-{ #category : #'queries - tags' }
+{ #category : 'queries - tags' }
 RGBehavior >> ensureMethodTagNamed: aSymbol [
 
 	^ self tagsForMethods
@@ -435,13 +437,13 @@ RGBehavior >> ensureMethodTagNamed: aSymbol [
 			  aSymbol ]
 ]
 
-{ #category : #'queries - protocols' }
+{ #category : 'queries - protocols' }
 RGBehavior >> ensureProtocolNamed: aSymbol [
 
 	^ self ensureMethodTagNamed: aSymbol
 ]
 
-{ #category : #'queries - methods' }
+{ #category : 'queries - methods' }
 RGBehavior >> ensureUnresolvedLocalMethod [
 
 	| newMethod |
@@ -450,44 +452,44 @@ RGBehavior >> ensureUnresolvedLocalMethod [
 	^ newMethod
 ]
 
-{ #category : #documentation }
+{ #category : 'documentation' }
 RGBehavior >> extensions [
 
 	^ self localMethods select: [ :each | each package ~= self package ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGBehavior >> hasComment [
 
 	^ self comment isEmptyOrNil not
 ]
 
-{ #category : #'queries - testing' }
+{ #category : 'queries - testing' }
 RGBehavior >> hasMethods [
 	"validates the existance of methods"
 
 	^ self methods notEmpty
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGBehavior >> hasResolvedSuperclass [
 
 	^ self hasResolved: #superclass
 ]
 
-{ #category : #'queries - testing' }
+{ #category : 'queries - testing' }
 RGBehavior >> hasTraitComposition [
 
 	^	self traitComposition transformations isEmpty not
 ]
 
-{ #category : #'queries - methods' }
+{ #category : 'queries - methods' }
 RGBehavior >> includesSelector: aString [
 
 	^ self selectors includes: aString
 ]
 
-{ #category : #'testing - class hierarchy' }
+{ #category : 'testing - class hierarchy' }
 RGBehavior >> inheritsFrom: aClass [
 	"Answer whether the argument, aClass, is on the receiver's superclass
 	chain."
@@ -501,7 +503,7 @@ RGBehavior >> inheritsFrom: aClass [
 	^ false
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGBehavior >> initialize [
 
 	super initialize.
@@ -515,7 +517,7 @@ RGBehavior >> initialize [
 	tags := self unresolvedValue: self defaultTags
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGBehavior >> initializeUnresolved [
 
 	super initializeUnresolved.
@@ -528,74 +530,74 @@ RGBehavior >> initializeUnresolved [
 	tags := self unresolvedValue: self defaultTags
 ]
 
-{ #category : #'queries - testing' }
+{ #category : 'queries - testing' }
 RGBehavior >> isAccessedIn: anRGMethod [
 	^ (anRGMethod ast variableNodes select: [ :each |
 		   each isGlobalVariable ]) anySatisfy: [ :each |
 		  each name = self name ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGBehavior >> isBehavior [
 
 	^ true
 ]
 
-{ #category : #'testing - layouts' }
+{ #category : 'testing - layouts' }
 RGBehavior >> isBits [
 
 	^ self layout isBitsLayout
 ]
 
-{ #category : #'testing - layouts' }
+{ #category : 'testing - layouts' }
 RGBehavior >> isBytes [
 
 	^ self layout isByteLayout
 ]
 
-{ #category : #'testing - layouts' }
+{ #category : 'testing - layouts' }
 RGBehavior >> isCompiledMethod [
 
 	^ self layout isCompiledMethodLayout
 ]
 
-{ #category : #'testing - layouts' }
+{ #category : 'testing - layouts' }
 RGBehavior >> isEphemeron [
 
 	^ self layout isEphemeronLayout
 ]
 
-{ #category : #'testing - layouts' }
+{ #category : 'testing - layouts' }
 RGBehavior >> isEphemeronClass [
 
 	^ self layout isEphemeronLayout
 ]
 
-{ #category : #'testing - layouts' }
+{ #category : 'testing - layouts' }
 RGBehavior >> isImmediateClass [
 
 	^ self layout isImmediateLayout
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGBehavior >> isPointers [
 
 	^ self isBits not
 ]
 
-{ #category : #'queries - testing' }
+{ #category : 'queries - testing' }
 RGBehavior >> isRootInEnvironment [
 
 	^ self superclass == self or: [ self superclass isNil ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGBehavior >> isTaggedWith: aSymbol [
 
 	^self tags includes: aSymbol
 ]
 
-{ #category : #'testing - layouts' }
+{ #category : 'testing - layouts' }
 RGBehavior >> isVariable [
 
 	"is the definition a variable class?"
@@ -603,19 +605,19 @@ RGBehavior >> isVariable [
 	^ self layout isVariableLayout
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGBehavior >> isWeak [
 
 	^ self layout isWeakLayout
 ]
 
-{ #category : #'testing - layouts' }
+{ #category : 'testing - layouts' }
 RGBehavior >> isWords [
 
 	^ self layout isWordLayout
 ]
 
-{ #category : #'queries - methods' }
+{ #category : 'queries - methods' }
 RGBehavior >> localMethodNamed: aSymbol ifAbsent: aBlock [
 
 	self localMethodsDo: [ :each | (each name = aSymbol) ifTrue: [^ each]].
@@ -623,19 +625,19 @@ RGBehavior >> localMethodNamed: aSymbol ifAbsent: aBlock [
 	^ aBlock value
 ]
 
-{ #category : #'queries - methods' }
+{ #category : 'queries - methods' }
 RGBehavior >> localMethods [
 
 	^ self localMethodsSet asArray
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGBehavior >> localMethodsDo: aBlock [
 
 	self backend forBehavior localMethodsFor: self do: aBlock
 ]
 
-{ #category : #'queries - methods' }
+{ #category : 'queries - methods' }
 RGBehavior >> localMethodsSet [
 
 	| methods |
@@ -645,13 +647,13 @@ RGBehavior >> localMethodsSet [
 	^ methods
 ]
 
-{ #category : #'queries - methods' }
+{ #category : 'queries - methods' }
 RGBehavior >> localSelectors [
 
 	^ self localMethods collect: [ :each | each name ]
 ]
 
-{ #category : #lookup }
+{ #category : 'lookup' }
 RGBehavior >> lookupVar: aName [
 
 	^ self allSlots
@@ -659,7 +661,7 @@ RGBehavior >> lookupVar: aName [
 		  ifNone: [ self bindingOf: aName ]
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGBehavior >> makeResolved [
 
 	superclass := self superclass markAsRingResolved.
@@ -672,19 +674,19 @@ RGBehavior >> makeResolved [
 	super makeResolved
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGBehavior >> metaclass [
 
 	^ self backend forBehavior metaclassFor: self
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGBehavior >> metaclass: anRGMetaclass [
 
 	self backend forBehavior setMetaclassFor: self to: anRGMetaclass
 ]
 
-{ #category : #'queries - methods' }
+{ #category : 'queries - methods' }
 RGBehavior >> methodNamed: aSymbol [
 
 	| allMethods |
@@ -693,7 +695,7 @@ RGBehavior >> methodNamed: aSymbol [
 	^ nil
 ]
 
-{ #category : #'queries - methods' }
+{ #category : 'queries - methods' }
 RGBehavior >> methods [
 
 	| methodsFromTraits methodsDict |
@@ -708,13 +710,13 @@ RGBehavior >> methods [
 	^ methodsDict values asArray"]"
 ]
 
-{ #category : #'queries - tags' }
+{ #category : 'queries - tags' }
 RGBehavior >> methodsTaggedWith: aSymbol [
 
 	^ self localMethods select: [ :each | each isTaggedWith: aSymbol ]
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGBehavior >> name: aString [
 
 	| oldName subclassesWithOldDefinitions |
@@ -735,13 +737,13 @@ RGBehavior >> name: aString [
 		self announcer behaviorParentRenamed: assoc key from: oldName ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGBehavior >> needsSlotClassDefinition [
 
 	^ false
 ]
 
-{ #category : #fileout }
+{ #category : 'fileout' }
 RGBehavior >> oldDefinition [
 
 	^ ClassDefinitionPrinter legacy
@@ -749,12 +751,12 @@ RGBehavior >> oldDefinition [
 		definitionString
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 RGBehavior >> printOn: aStream [
 	aStream nextPutAll: self name
 ]
 
-{ #category : #'queries - protocols' }
+{ #category : 'queries - protocols' }
 RGBehavior >> protocols [
 
 	| methodTags |
@@ -769,14 +771,14 @@ RGBehavior >> protocols [
 		ifNotEmpty: [ methodTags  ]
 ]
 
-{ #category : #'accessing - model' }
+{ #category : 'accessing - model' }
 RGBehavior >> protocolsForAllMethods [
 	"I act as #tagsForMethods but I also takes into account methods comming from traits"
 
 	^ self methods flatCollect: [ :each  | each tags ] as: Set
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGBehavior >> pvtAddLocalMethod: anRGMethod [
 
 	self environment verifyOwnership: anRGMethod.
@@ -793,7 +795,7 @@ RGBehavior >> pvtAddLocalMethod: anRGMethod [
 	localMethods add: anRGMethod
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehavior >> pvtAddMethodTag: aSymbol [
 
 	tagsForMethods isRingResolved ifFalse: [
@@ -802,7 +804,7 @@ RGBehavior >> pvtAddMethodTag: aSymbol [
 	tagsForMethods add: aSymbol
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehavior >> pvtAsTrait [
 
 	| traitStrategy |
@@ -830,13 +832,13 @@ RGBehavior >> pvtAsTrait [
 	^ self
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGBehavior >> pvtCleanLocalMethods [
 
 	localMethods := self defaultLocalMethods
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehavior >> pvtCleanTags [
 
 	tags := self defaultTags.
@@ -844,7 +846,7 @@ RGBehavior >> pvtCleanTags [
 	"TODO:Announce if not empty"
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehavior >> pvtCleanTagsForMethods [
 
 	tagsForMethods := self defaultTagsForMethods.
@@ -852,26 +854,26 @@ RGBehavior >> pvtCleanTagsForMethods [
 	"TODO:Announce if not empty"
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RGBehavior >> pvtLocalMethods: aCollection [
 
 	"use only for low-level copying"
 	localMethods := aCollection
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGBehavior >> pvtLocalMethodsDo: aBlock [
 
 	^ localMethods value do: aBlock
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehavior >> pvtMetaclass [
 
 	^ metaclass value
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehavior >> pvtMetaclass: anRGMetaclass [
 
 	self environment verifyOwnership: anRGMetaclass.
@@ -879,7 +881,7 @@ RGBehavior >> pvtMetaclass: anRGMetaclass [
 	^ metaclass := anRGMetaclass
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGBehavior >> pvtRemoveLocalMethod: anRGMethod [
 
 	self environment verifyOwnership: anRGMethod.
@@ -887,7 +889,7 @@ RGBehavior >> pvtRemoveLocalMethod: anRGMethod [
 	localMethods remove: anRGMethod
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehavior >> pvtRemoveMethodTag: aSymbol [
 
 	tagsForMethods remove: aSymbol.
@@ -895,7 +897,7 @@ RGBehavior >> pvtRemoveMethodTag: aSymbol [
 	"TODO:Announce"
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGBehavior >> pvtResolvableProperties [
 
 	^ super pvtResolvableProperties, {
@@ -908,13 +910,13 @@ RGBehavior >> pvtResolvableProperties [
     	}, self behaviorStrategy pvtResolvableProperties
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGBehavior >> pvtSuperclass [
 
 	^ superclass value
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGBehavior >> pvtSuperclass: anRGBehavior [
 
 	anRGBehavior ifNotNil: [
@@ -923,7 +925,7 @@ RGBehavior >> pvtSuperclass: anRGBehavior [
 	^ superclass := anRGBehavior
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehavior >> pvtTagWith: aSymbol [
 
 	tags isRingResolved ifFalse: [
@@ -932,31 +934,31 @@ RGBehavior >> pvtTagWith: aSymbol [
 	tags add: aSymbol
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehavior >> pvtTags: aCollection [
 
 	^ tags := aCollection
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehavior >> pvtTagsDo: aBlock [
 
 	^ tags value do: aBlock
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehavior >> pvtTagsForMethodsDo: aBlock [
 
 	^ tagsForMethods value do: aBlock
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGBehavior >> pvtTraitComposition [
 
 	^ traitComposition value
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGBehavior >> pvtTraitComposition: anRGTraitComposition [
 
 	self environment verifyOwnership: anRGTraitComposition.
@@ -964,7 +966,7 @@ RGBehavior >> pvtTraitComposition: anRGTraitComposition [
 	^ traitComposition := anRGTraitComposition
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehavior >> pvtUntagFrom: aSymbol [
 
 	(tags value includes: aSymbol)
@@ -973,7 +975,7 @@ RGBehavior >> pvtUntagFrom: aSymbol [
 	"TODO:Announce"
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGBehavior >> removeLocalMethod: anRGMethod [
 
 	(anRGMethod package = self package)
@@ -984,7 +986,7 @@ RGBehavior >> removeLocalMethod: anRGMethod [
 	self announcer methodRemoved: anRGMethod
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGBehavior >> removeMethodTag: aSymbol [
 
 	self backend forPackage removeMethodTag: aSymbol from: self.
@@ -993,19 +995,19 @@ RGBehavior >> removeMethodTag: aSymbol [
 		method untagFrom: aSymbol ]
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGBehavior >> removeProtocol: aSymbol [
 
 	self removeMethodTag: aSymbol
 ]
 
-{ #category : #'queries - methods' }
+{ #category : 'queries - methods' }
 RGBehavior >> selectors [
 
 	^ self methods collect: [ :each | each name ]
 ]
 
-{ #category : #'accessing - definition' }
+{ #category : 'accessing - definition' }
 RGBehavior >> sharedPoolsString [
 	"Answer a string of my class variable names separated by spaces."
 
@@ -1016,7 +1018,7 @@ RGBehavior >> sharedPoolsString [
 			separatedBy: [ stream space ] ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 RGBehavior >> slotDefinitionString [
 	"Answer a string that contains an executable description of my Slots"
 
@@ -1033,19 +1035,19 @@ RGBehavior >> slotDefinitionString [
 		str nextPutAll: ' }'. ]
 ]
 
-{ #category : #slots }
+{ #category : 'slots' }
 RGBehavior >> slots [
 
 	^ self layout slots
 ]
 
-{ #category : #slots }
+{ #category : 'slots' }
 RGBehavior >> slotsNeedFullDefinition [
 	"return true if we define something else than InstanceVariableSlots"
 	^self slots anySatisfy: [ :each | each needsFullDefinition ]
 ]
 
-{ #category : #'accessing - class hierarchy' }
+{ #category : 'accessing - class hierarchy' }
 RGBehavior >> subclasses [
 
 	| result |
@@ -1055,20 +1057,20 @@ RGBehavior >> subclasses [
 	^ result asArray
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGBehavior >> superclass [
 
 	^ self backend forBehavior superclassFor: self
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGBehavior >> superclass: anRGBehavior [
 
 	self announceDefinitionChangeDuring: [
 		self backend forBehavior setSuperclassFor: self to: anRGBehavior ]
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGBehavior >> tagWith: aSymbol [
 
 	self announceDefinitionChangeDuring: [
@@ -1077,19 +1079,19 @@ RGBehavior >> tagWith: aSymbol [
 	]
 ]
 
-{ #category : #'accessing - model' }
+{ #category : 'accessing - model' }
 RGBehavior >> tags [
 
 	^ self tagsSet asArray
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGBehavior >> tagsDo: aBlock [
 
 	self backend forBehavior tagsForClass: self do: aBlock
 ]
 
-{ #category : #'accessing - model' }
+{ #category : 'accessing - model' }
 RGBehavior >> tagsForMethods [
 	"Retrieves the traits defined in the receiver"
 
@@ -1099,13 +1101,13 @@ RGBehavior >> tagsForMethods [
 	^ allTags asArray
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGBehavior >> tagsForMethodsDo: aBlock [
 
 	self backend forBehavior tagsForMethodsFor: self do: aBlock
 ]
 
-{ #category : #'accessing - model' }
+{ #category : 'accessing - model' }
 RGBehavior >> tagsForMethodsSet [
 	"Retrieves the traits defined in the receiver"
 
@@ -1115,7 +1117,7 @@ RGBehavior >> tagsForMethodsSet [
 	^ allTags
 ]
 
-{ #category : #'accessing - model' }
+{ #category : 'accessing - model' }
 RGBehavior >> tagsSet [
 
 	| allTags |
@@ -1124,25 +1126,25 @@ RGBehavior >> tagsSet [
 	^ allTags
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGBehavior >> traitComposition [
 
 	^ self backend forBehavior traitCompositionFor: self
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGBehavior >> traitComposition: anRGTraitComposition [
 
 	self announceDefinitionChangeDuring: [
 		self backend forBehavior setTraitCompositionFor: self to: anRGTraitComposition.]
 ]
 
-{ #category : #'accessing - definition' }
+{ #category : 'accessing - definition' }
 RGBehavior >> traitCompositionString [
 	^ self traitComposition traitCompositionString
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGBehavior >> unresolveName [
 
 	| oldName subclassesWithOldDefinitions |
@@ -1163,26 +1165,26 @@ RGBehavior >> unresolveName [
 		self announcer behaviorParentRenamed: assoc key from: oldName ]
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGBehavior >> unresolveSuperclass [
 
 	self announceDefinitionChangeDuring: [
 		self pvtSuperclass: (RGUnresolvedValue recursive) ]
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGBehavior >> untagFrom: aSymbol [
 
 	self backend forPackage untagClass: self from: aSymbol
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehavior >> usedTraits [
 
 	^ self traitComposition usedTraits
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehavior >> users [
 	^ #()
 ]

--- a/src/Ring-Core/RGBehaviorFactory.class.st
+++ b/src/Ring-Core/RGBehaviorFactory.class.st
@@ -4,63 +4,65 @@ My subclasses are very simple factories that serve as entry point to create diff
 The behaviors are composition of a RGBehavior instances and a strategy that describes a kind of the behavior. The behavior factory only create sach pairs so for example my subclass RGClass creates a composition of RGBehavior instance with a RGClassStrategy. 
 "
 Class {
-	#name : #RGBehaviorFactory,
-	#superclass : #Object,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGBehaviorFactory',
+	#superclass : 'Object',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGBehaviorFactory class >> named: aString [
 
 	^ (RGBehavior named: aString behaviorStrategy: self newStrategy)
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGBehaviorFactory class >> named: aString parent: anRGObject [
 
 	^ (RGBehavior named: aString parent: anRGObject  behaviorStrategy: (self newStrategyFor: anRGObject environment))
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGBehaviorFactory class >> newStrategy [
 
 	self subclassResponsibility
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGBehaviorFactory class >> newStrategyFor: anRGEnvironment [
 
 	^ self newStrategy
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGBehaviorFactory class >> parent: anRGObject [
 
 	^ (RGBehavior parent: anRGObject behaviorStrategy: (self newStrategyFor: anRGObject environment))
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGBehaviorFactory class >> unnamed [
 
 	^ RGBehavior unnamedWithBehaviorStrategy: self newStrategy
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGBehaviorFactory class >> unresolved [
 
 	^ RGBehavior unresolvedWithBehaviorStrategy: self newStrategy
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGBehaviorFactory class >> unresolvedNamed: aString withParent: anRGDefintion [
 
 	^ RGBehavior unresolvedNamed: aString withParent: anRGDefintion behaviorStrategy: (self newStrategyFor: anRGDefintion environment)
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGBehaviorFactory class >> unresolvedWithParent: anRGDefintion [
 
 	^ RGBehavior unresolvedWithParent: anRGDefintion behaviorStrategy: (self newStrategyFor: anRGDefintion environment)

--- a/src/Ring-Core/RGBehaviorStrategy.class.st
+++ b/src/Ring-Core/RGBehaviorStrategy.class.st
@@ -1,97 +1,99 @@
 Class {
-	#name : #RGBehaviorStrategy,
-	#superclass : #Object,
+	#name : 'RGBehaviorStrategy',
+	#superclass : 'Object',
 	#instVars : [
 		'owner'
 	],
-	#category : #'Ring-Core-Kernel'
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGBehaviorStrategy class >> unresolved [
 
 	^ self basicNew
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 RGBehaviorStrategy >> acceptVisitor: aVisitor [
 
 	self subclassResponsibility
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> addClassVariable: anRGInstanceVariableDefinition [
 
 	self incompatibleBehaviorType
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> addSharedPool: anRGPoolVariable [
 
 	self incompatibleBehaviorType
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> allClassVarNames [
 
 	self subclassResponsibility
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> allClassVariables [
 
 	self incompatibleBehaviorType
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RGBehaviorStrategy >> allSlots [
 
 	^ OrderedCollection new
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RGBehaviorStrategy >> announceDefinitionChangeDuring: aBlock [
 
 	self owner announceDefinitionChangeDuring: aBlock
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RGBehaviorStrategy >> backend [
 
 	^ self owner backend forBehavior
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> baseBehavior [
 
 	^ self owner
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> baseClass [
 
 	^ self owner
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> baseClass: anRGClass [
 
 	self incompatibleBehaviorType
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> baseTrait [
 
 	self incompatibleBehaviorType
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> baseTrait: anRGClass [
 
 	self incompatibleBehaviorType
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> bindingOf: varName [
 
 	^ self owner isRootInEnvironment
@@ -99,103 +101,103 @@ RGBehaviorStrategy >> bindingOf: varName [
 		ifTrue: [ nil ]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> category [
 
 	self subclassResponsibility
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> category: aString [
 
 	self incompatibleBehaviorType
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehaviorStrategy >> classSide [
 
 	^ self owner
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> classTrait [
 
 	self incompatibleBehaviorType
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> classTrait: anRGMetaclassTrait [
 
 	self incompatibleBehaviorType
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> classVarNames [
 
 	^#()
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 RGBehaviorStrategy >> classVariableDefinitionString [
 
 	self incompatibleBehaviorType
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> classVariables [
 
 	self incompatibleBehaviorType
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> classVariables: aCollectionOfSymbols [
 
 	self incompatibleBehaviorType
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> classVariablesDo: aBlock [
 
 	self incompatibleBehaviorType
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> classVariablesString [
 
 	^ String new
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> cleanClassVariables [
 
 	self incompatibleBehaviorType
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> cleanSharedPools [
 
 	self incompatibleBehaviorType
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> comment [
 
 	self subclassResponsibility
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> comment: anRGComment [
 
 	self incompatibleBehaviorType
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 RGBehaviorStrategy >> copyForBehaviorDefinitionPostCopy [
 
 	super postCopy
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 RGBehaviorStrategy >> copyForBehaviorDefinitionWithOwner: aNewOwner [
 
 	^ self shallowCopy
@@ -203,108 +205,108 @@ RGBehaviorStrategy >> copyForBehaviorDefinitionWithOwner: aNewOwner [
 		copyForBehaviorDefinitionPostCopy
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGBehaviorStrategy >> defaultMetaClass [
 
 	^ self incompatibleBehaviorType
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RGBehaviorStrategy >> environment [
 
 	^ self owner environment
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> incompatibleBehaviorType [
 
 	RGIncompatibleBehaviorTypeError signal
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGBehaviorStrategy >> initializeUnresolved [
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> innerBindingOf: aSymbol [
 
 	^ nil
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RGBehaviorStrategy >> instSize [
 
 	^ 0
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RGBehaviorStrategy >> instVarNames [
 
 	^ OrderedCollection new
 ]
 
-{ #category : #'accessing - parallel hierarchy' }
+{ #category : 'accessing - parallel hierarchy' }
 RGBehaviorStrategy >> instanceSide [
 
 	^ self owner
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> instanceVariables: aCollectionOfSymbols [
 
 	self incompatibleBehaviorType
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> instanceVariablesString [
 
 	^ String new
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGBehaviorStrategy >> isClassStrategy [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGBehaviorStrategy >> isMeta [
 	"By default a non-meta class is considered"
 
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGBehaviorStrategy >> isMetaclass [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGBehaviorStrategy >> isMetaclassStrategy [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGBehaviorStrategy >> isMetaclassTrait [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGBehaviorStrategy >> isMetaclassTraitStrategy [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGBehaviorStrategy >> isTraitStrategy [
 
 	^ false
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> kindOfSubclass [
 	"Answer a String that is the keyword that describes the receiver's kind of subclass
 	Note: this is for printing the ST80 style class definiton, see #subclassDefiningSymbol"
@@ -312,102 +314,102 @@ RGBehaviorStrategy >> kindOfSubclass [
 	^ ' ', self layout class subclassDefiningSymbol, ' '
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehaviorStrategy >> layout [
 
 	^ self backend forBehavior layoutFor: self owner
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehaviorStrategy >> layout: anRGLayout [
 
 	self owner announceDefinitionChangeDuring: [
 		self backend forBehavior setLayoutFor: self owner to: anRGLayout ]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> makeResolved [
 
 	"do nothing"
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehaviorStrategy >> owner [
 	^ owner
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehaviorStrategy >> owner: anObject [
 	owner := anObject
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RGBehaviorStrategy >> pvtResolvableProperties [
 
 	^ OrderedCollection new
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> referencedBehaviors [
 
 	^ { self owner superclass. self owner metaclass}, self owner traitComposition referencedBehaviors
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> referencedPackages [
 
 	^ Array new
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> removeClassVariable: anRGInstanceVariableDefinition [
 
 	self incompatibleBehaviorType
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> removeSharedPool: anRGPoolVariable [
 
 	self incompatibleBehaviorType
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> sharedPoolNames [
 
 	^ OrderedCollection new
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> sharedPools [
 
 	^ OrderedCollection new
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> sharedPools: aCollectionOfSymbols [
 
 	self incompatibleBehaviorType
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGBehaviorStrategy >> sharedPoolsDo: aBlock [
 
 	self incompatibleBehaviorType
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RGBehaviorStrategy >> sibling [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RGBehaviorStrategy >> storeName [
 
 	self subclassResponsibility
 ]
 
-{ #category : #'accessing - deprecated parallel hierarchy' }
+{ #category : 'accessing - deprecated parallel hierarchy' }
 RGBehaviorStrategy >> theMetaClass [
 	"This method is deprecated so consider to migrate."
 
@@ -418,7 +420,7 @@ RGBehaviorStrategy >> theMetaClass [
 	^ self classSide
 ]
 
-{ #category : #'accessing - deprecated parallel hierarchy' }
+{ #category : 'accessing - deprecated parallel hierarchy' }
 RGBehaviorStrategy >> theNonMetaClass [
 	"This method is deprecated so consider to migrate."
 
@@ -429,13 +431,13 @@ RGBehaviorStrategy >> theNonMetaClass [
 	^ self instanceSide
 ]
 
-{ #category : #variables }
+{ #category : 'variables' }
 RGBehaviorStrategy >> trait [
 
 	^ self incompatibleBehaviorType
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RGBehaviorStrategy >> unresolvedValue: aDefaultValue [
 
 	^ self owner unresolvedValue: aDefaultValue

--- a/src/Ring-Core/RGBehaviorStrategyUser.class.st
+++ b/src/Ring-Core/RGBehaviorStrategyUser.class.st
@@ -2,86 +2,88 @@
 I am an abstract behavior that has a behavior strategy and and delegates all messages to it
 "
 Class {
-	#name : #RGBehaviorStrategyUser,
-	#superclass : #RGObject,
+	#name : 'RGBehaviorStrategyUser',
+	#superclass : 'RGObject',
 	#instVars : [
 		'behaviorStrategy'
 	],
-	#category : #'Ring-Core-Kernel'
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 RGBehaviorStrategyUser >> acceptVisitor: aVisitor [
 
 	^ self behaviorStrategy acceptVisitor: aVisitor
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> addClassVariable: anRGInstanceVariableDefinition [
 
 	^ self behaviorStrategy addClassVariable: anRGInstanceVariableDefinition
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> addSharedPool: anRGPoolVariable [
 
 	^ self behaviorStrategy addSharedPool: anRGPoolVariable
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> allClassVarNames [
 
 	^ self behaviorStrategy allClassVarNames
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> allClassVariables [
 
 	^ self behaviorStrategy allClassVariables
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehaviorStrategyUser >> allSlots [
 
 	^ self behaviorStrategy allSlots
 ]
 
-{ #category : #'queries - other' }
+{ #category : 'queries - other' }
 RGBehaviorStrategyUser >> baseBehavior [
 
 	^ self behaviorStrategy baseBehavior
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehaviorStrategyUser >> baseClass [
 
 	^ self behaviorStrategy baseClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehaviorStrategyUser >> baseClass: anRGClass [
 
 	^ self behaviorStrategy baseClass: anRGClass
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> baseTrait [
 
 	^ self behaviorStrategy baseTrait
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> baseTrait: anRGClass [
 
 	^ self behaviorStrategy baseTrait: anRGClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehaviorStrategyUser >> behaviorStrategy [
 	^ behaviorStrategy
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehaviorStrategyUser >> behaviorStrategy: anObject [
 
 	| needsInitialization |
@@ -93,273 +95,273 @@ RGBehaviorStrategyUser >> behaviorStrategy: anObject [
 		behaviorStrategy initializeUnresolved ]
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> bindingOf: varName [
 
 	^ self behaviorStrategy bindingOf: varName
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> category [
 
 	^ self behaviorStrategy category
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> category: aString [
 
 	^ self behaviorStrategy category: aString
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> classSide [
 
 	^ self behaviorStrategy classSide
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> classTrait [
 
 	^ self behaviorStrategy classTrait
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> classTrait: anRGMetaclassTrait [
 
 	^ self behaviorStrategy classTrait: anRGMetaclassTrait
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> classVarNames [
 
 	^ self behaviorStrategy classVarNames
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> classVariableDefinitionString [
 
 	^ self behaviorStrategy classVariableDefinitionString
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> classVariables [
 
 	^ self behaviorStrategy classVariables
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> classVariables: aCollectionOfSymbols [
 
 	^ self behaviorStrategy classVariables: aCollectionOfSymbols
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> classVariablesDo: aBlock [
 
 	^ self behaviorStrategy classVariablesDo: aBlock
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> cleanClassVariables [
 
 	^ self behaviorStrategy cleanClassVariables
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> cleanSharedPools [
 
 	^ self behaviorStrategy cleanSharedPools
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> comment [
 
 	^ self behaviorStrategy comment
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> comment: anRGComment [
 
 	^ self behaviorStrategy comment: anRGComment
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> defaultMetaClass [
 
 	^ self behaviorStrategy defaultMetaClass
 ]
 
-{ #category : #'accessing - definition' }
+{ #category : 'accessing - definition' }
 RGBehaviorStrategyUser >> definition [
 
 	^ self behaviorStrategy definition
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> innerBindingOf: aSymbol [
 
 	^ self behaviorStrategy innerBindingOf: aSymbol
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehaviorStrategyUser >> instSize [
 
 	^ self behaviorStrategy instSize
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehaviorStrategyUser >> instVarNames [
 	^ self behaviorStrategy instVarNames
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehaviorStrategyUser >> instanceSide [
 
 	^ self behaviorStrategy instanceSide
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehaviorStrategyUser >> instanceVariables: aCollectionOfSymbols [
 
 	^ self behaviorStrategy instanceVariables: aCollectionOfSymbols
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 RGBehaviorStrategyUser >> instanceVariablesString [
 
 	^ self behaviorStrategy instanceVariablesString
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGBehaviorStrategyUser >> isClass [
 
 	^ self behaviorStrategy isClass
 ]
 
-{ #category : #'queries - testing' }
+{ #category : 'queries - testing' }
 RGBehaviorStrategyUser >> isMeta [
 	"By default a non-meta class is considered"
 
 	^ self behaviorStrategy isMeta
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGBehaviorStrategyUser >> isMetaclass [
 
 	^ self behaviorStrategy isMetaclass
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGBehaviorStrategyUser >> isMetaclassTrait [
 
 	^ self behaviorStrategy isMetaclassTrait
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> isTrait [
 
 	^ self behaviorStrategy isTrait
 ]
 
-{ #category : #'testing - class hierarchy' }
+{ #category : 'testing - class hierarchy' }
 RGBehaviorStrategyUser >> kindOfSubclass [
 	"Answer a String that is the keyword that describes the receiver's kind of subclass
 	Note: this is for printing the ST80 style class definiton, see #subclassDefiningSymbol"
 	^ self behaviorStrategy kindOfSubclass
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> layout [
 
 	^ self behaviorStrategy layout
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> layout: anRGLayout [
 
 	^ self behaviorStrategy layout: anRGLayout
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGBehaviorStrategyUser >> makeResolved [
 
 	self behaviorStrategy makeResolved.
 	super makeResolved
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> package [
 
 	^ self behaviorStrategy package
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> package: anRGPackage [
 
 	^ self behaviorStrategy package: anRGPackage
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> referencedBehaviors [
 
 	^ self behaviorStrategy referencedBehaviors
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> referencedPackages [
 
 	^ self behaviorStrategy referencedPackages
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> removeClassVariable: anRGInstanceVariableDefinition [
 
 	^ self behaviorStrategy removeClassVariable: anRGInstanceVariableDefinition
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> removeSharedPool: anRGPoolVariable [
 
 	^ self behaviorStrategy removeSharedPool: anRGPoolVariable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGBehaviorStrategyUser >> sharedPoolNames [
 
 	^ self behaviorStrategy sharedPoolNames
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> sharedPools [
 
 	^ self behaviorStrategy sharedPools
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> sharedPools: aCollectionOfSymbols [
 
 	^ self behaviorStrategy sharedPools: aCollectionOfSymbols
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> sharedPoolsDo: aBlock [
 
 	^ self behaviorStrategy sharedPoolsDo: aBlock
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> sibling [
 
 	^ self behaviorStrategy sibling
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 RGBehaviorStrategyUser >> storeOn: aStream [
 
 	^ self behaviorStrategy storeOn: aStream
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehaviorStrategyUser >> theMetaClass [
 	self
 		deprecated: 'Please use #classSide instead'
@@ -368,7 +370,7 @@ RGBehaviorStrategyUser >> theMetaClass [
 	^ self classSide
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGBehaviorStrategyUser >> theNonMetaClass [
 
 	self
@@ -377,7 +379,7 @@ RGBehaviorStrategyUser >> theNonMetaClass [
 	^self instanceSide
 ]
 
-{ #category : #variables }
+{ #category : 'variables' }
 RGBehaviorStrategyUser >> trait [
 
 	"Because of API compatibility between traits and trait transformations"
@@ -385,7 +387,7 @@ RGBehaviorStrategyUser >> trait [
 	^ self behaviorStrategy trait
 ]
 
-{ #category : #strategy }
+{ #category : 'strategy' }
 RGBehaviorStrategyUser >> traitTransformationString [
 
 	^ self behaviorStrategy traitTransformationString

--- a/src/Ring-Core/RGBitsLayout.class.st
+++ b/src/Ring-Core/RGBitsLayout.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RGBitsLayout,
-	#superclass : #RGObjectLayout,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGBitsLayout',
+	#superclass : 'RGObjectLayout',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #description }
+{ #category : 'description' }
 RGBitsLayout class >> subclassDefiningSymbol [
 	"Answer a keyword that describes the receiver's kind of subclass
 	Note: this is for printing the ST80 style class definiton."
@@ -12,13 +14,13 @@ RGBitsLayout class >> subclassDefiningSymbol [
 	^ #variableWordSubclass:
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGBitsLayout >> isBitsLayout [
 
 	^ true
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGBitsLayout >> isVariableLayout [
 
 	^ true

--- a/src/Ring-Core/RGByteLayout.class.st
+++ b/src/Ring-Core/RGByteLayout.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RGByteLayout,
-	#superclass : #RGBitsLayout,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGByteLayout',
+	#superclass : 'RGBitsLayout',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #description }
+{ #category : 'description' }
 RGByteLayout class >> subclassDefiningSymbol [
 	"Answer a keyword that describes the receiver's kind of subclass
 	Note: this is for printing the ST80 style class definiton."
@@ -12,7 +14,7 @@ RGByteLayout class >> subclassDefiningSymbol [
 	^ #variableByteSubclass:
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGByteLayout >> isByteLayout [
 
 	^ true

--- a/src/Ring-Core/RGClass.class.st
+++ b/src/Ring-Core/RGClass.class.st
@@ -2,12 +2,14 @@
 A factory that produces instances of RG2Behavior composed with RG2ClassStrategy
 "
 Class {
-	#name : #RGClass,
-	#superclass : #RGBehaviorFactory,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGClass',
+	#superclass : 'RGBehaviorFactory',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGClass class >> newStrategy [
 
 	^ RGClassStrategy unresolved

--- a/src/Ring-Core/RGClassDescriptionStrategy.class.st
+++ b/src/Ring-Core/RGClassDescriptionStrategy.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #RGClassDescriptionStrategy,
-	#superclass : #RGBehaviorStrategy,
+	#name : 'RGClassDescriptionStrategy',
+	#superclass : 'RGBehaviorStrategy',
 	#instVars : [
 		'layout'
 	],
-	#category : #'Ring-Core-Kernel'
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RGClassDescriptionStrategy >> allSlots [
 
 	| superclassSlots aSuperclass |
@@ -18,7 +20,7 @@ RGClassDescriptionStrategy >> allSlots [
 	^ (superclassSlots, self layout allSlots) asArray
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGClassDescriptionStrategy >> classVariablesString [
 	"Answer a string of my class variable names separated by spaces."
 
@@ -28,7 +30,7 @@ RGClassDescriptionStrategy >> classVariablesString [
 			separatedBy: [ stream space ] ]
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 RGClassDescriptionStrategy >> copyForBehaviorDefinitionPostCopy [
 
 	super copyForBehaviorDefinitionPostCopy.
@@ -36,13 +38,13 @@ RGClassDescriptionStrategy >> copyForBehaviorDefinitionPostCopy [
 	layout parent: self owner
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGClassDescriptionStrategy >> defaultLayout [
 
 	^ self owner defaultFixedLayoutStubIn: self
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGClassDescriptionStrategy >> initialize [
 
 	super initialize.
@@ -51,7 +53,7 @@ RGClassDescriptionStrategy >> initialize [
 	self owner environment backend createUnresolvedClassGroupFor: self owner
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGClassDescriptionStrategy >> initializeUnresolved [
 
 	super initializeUnresolved.
@@ -59,18 +61,18 @@ RGClassDescriptionStrategy >> initializeUnresolved [
 	layout := self unresolvedValue: self defaultLayout
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGClassDescriptionStrategy >> instSize [
 
 	^ self owner allInstVarNames size
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGClassDescriptionStrategy >> instVarNames [
 	^ self layout instVarNames
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGClassDescriptionStrategy >> instanceVariables: aCollectionOfSymbols [
 
 	"specify instance variable names"
@@ -87,7 +89,7 @@ RGClassDescriptionStrategy >> instanceVariables: aCollectionOfSymbols [
 		layout addSlot: (RGInstanceVariableSlot named: instVarName asSymbol parent: self)]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGClassDescriptionStrategy >> instanceVariablesString [
 	"Answer a string of my instance variable names separated by spaces."
 
@@ -97,7 +99,7 @@ RGClassDescriptionStrategy >> instanceVariablesString [
 			separatedBy: [ stream space ] ]
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGClassDescriptionStrategy >> makeResolved [
 
 	super makeResolved.
@@ -105,13 +107,13 @@ RGClassDescriptionStrategy >> makeResolved [
 	layout := self layout makeResolved markAsRingResolved
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGClassDescriptionStrategy >> pvtLayout [
 
 	^ layout value
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGClassDescriptionStrategy >> pvtLayout: anRGLayout [
 
 	self environment verifyOwnership: anRGLayout.
@@ -119,7 +121,7 @@ RGClassDescriptionStrategy >> pvtLayout: anRGLayout [
 	^ layout := anRGLayout
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGClassDescriptionStrategy >> pvtResolvableProperties [
 
 	^ super pvtResolvableProperties, {
@@ -127,7 +129,7 @@ RGClassDescriptionStrategy >> pvtResolvableProperties [
      	}
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 RGClassDescriptionStrategy >> storeOn: aStream [
 	aStream
 		nextPutAll: '(';

--- a/src/Ring-Core/RGClassStrategy.class.st
+++ b/src/Ring-Core/RGClassStrategy.class.st
@@ -1,42 +1,44 @@
 Class {
-	#name : #RGClassStrategy,
-	#superclass : #RGClassDescriptionStrategy,
+	#name : 'RGClassStrategy',
+	#superclass : 'RGClassDescriptionStrategy',
 	#instVars : [
 		'comment',
 		'classVariables',
 		'package',
 		'sharedPools'
 	],
-	#category : #'Ring-Core-Kernel'
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> acceptVisitor: aVisitor [
 
 	^ aVisitor visitClass: self owner
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> addClassVariable: anRGInstanceVariableDefinition [
 
 	self owner announceDefinitionChangeDuring: [
 		self privAddClassVariable: anRGInstanceVariableDefinition ]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> addSharedPool: anRGPoolVariable [
 
 	self owner announceDefinitionChangeDuring: [
 		self privAddSharedPool: anRGPoolVariable ]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> allClassVarNames [
 
 	^self allClassVariables collect:[ :cvar| cvar name ]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> allClassVariables [
 	"Answer a collection of the receiver's classVariables, including those defined its superclasses"
 
@@ -45,7 +47,7 @@ RGClassStrategy >> allClassVariables [
 		ifFalse: [ self owner superclass allClassVariables, self classVariables ]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> bindingOf: varName [
 
 	| aSymbol |
@@ -55,7 +57,7 @@ RGClassStrategy >> bindingOf: varName [
 		 self environment bindingOf: aSymbol ]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> category [
 
 	^ self owner tags
@@ -68,7 +70,7 @@ RGClassStrategy >> category [
 	"todo"
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> category: aString [
 
 	| aTag |
@@ -88,19 +90,19 @@ RGClassStrategy >> category: aString [
 	self announcer behaviorRecategorized: self."
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> classSide [
 
 	^ self owner metaclass
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> classVarNames [
 
 	^ self classVariables collect: [:each | each name]
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 RGClassStrategy >> classVariableDefinitionString [
 	"Answer a string that evaluates to the definition of the class Variables"
 
@@ -115,13 +117,13 @@ RGClassStrategy >> classVariableDefinitionString [
 		str nextPutAll: ' }'. ]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> classVariables [
 
 	^ Array streamContents: [ :str | self classVariablesDo: [ :each | str nextPut: each ] ]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> classVariables: aCollectionOfSymbols [
 
 	self cleanClassVariables.
@@ -129,32 +131,32 @@ RGClassStrategy >> classVariables: aCollectionOfSymbols [
 		self addClassVariable: (RGClassVariable named: classVarName asSymbol parent: self).]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> classVariablesDo: aBlock [
 
 	self backend forBehavior classVariablesFor: self owner do: aBlock
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> cleanClassVariables [
 
 	self owner announceDefinitionChangeDuring: [
 		self backend forBehavior cleanClassVariablesFor: self owner ]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> cleanSharedPools [
 
 	self backend forBehavior cleanSharedPoolsFor: self owner
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> comment [
 
 	^ self backend forBehavior commentFor: self owner
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> comment: anRGComment [
 
 	self backend forBehavior setCommentFor: self owner to: anRGComment.
@@ -162,7 +164,7 @@ RGClassStrategy >> comment: anRGComment [
 	self owner announcer behaviorCommentModified: self
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> copyForBehaviorDefinitionPostCopy [
 
 	| newVariables newSharedPools |
@@ -176,37 +178,37 @@ RGClassStrategy >> copyForBehaviorDefinitionPostCopy [
 	newSharedPools do: [ :each | self privAddSharedPool: each ]
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGClassStrategy >> defaultClassVariables [
 
 	^ OrderedCollection new
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGClassStrategy >> defaultComment [
 
 	^ self owner defaultCommentStubIn: self owner
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGClassStrategy >> defaultMetaClass [
 
 	^ self owner environment backend createNewUnresolvedMetaclassFor: self owner
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGClassStrategy >> defaultPackage [
 
 	^ self owner defaultPackageStubIn: self environment
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGClassStrategy >> defaultSharedPools [
 
 	^ OrderedCollection new
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGClassStrategy >> definition [
 
 	| aStream poolString |
@@ -263,14 +265,14 @@ RGClassStrategy >> definition [
 	^ aStream contents
 ]
 
-{ #category : #fileout }
+{ #category : 'fileout' }
 RGClassStrategy >> definitionString [
 	"Answer the receiver's <String> class definition resolving it from the receiver's package information"
 
 	^ self package definitionFor: self
 ]
 
-{ #category : #fileout }
+{ #category : 'fileout' }
 RGClassStrategy >> definitionStringFor: aRGPackage [
 	"Answer the receiver's definition <String> contained in aRGPackage Monticello snapshot information"
 
@@ -280,7 +282,7 @@ RGClassStrategy >> definitionStringFor: aRGPackage [
 			definitionString
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGClassStrategy >> definitionWithSlots [
 
 	| aStream poolString|
@@ -318,7 +320,7 @@ RGClassStrategy >> definitionWithSlots [
 	^ aStream contents
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGClassStrategy >> initialize [
 
 	super initialize.
@@ -329,7 +331,7 @@ RGClassStrategy >> initialize [
 	sharedPools := self unresolvedValue: self defaultSharedPools
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGClassStrategy >> initializeUnresolved [
 
 	super initializeUnresolved.
@@ -340,7 +342,7 @@ RGClassStrategy >> initializeUnresolved [
 	sharedPools := self unresolvedValue: self defaultSharedPools
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> innerBindingOf: aSymbol [
 
 	self classVariables detect: [ :each | each name = aSymbol  ] ifFound: [ :found | ^ found ].
@@ -353,19 +355,19 @@ RGClassStrategy >> innerBindingOf: aSymbol [
 	^ nil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGClassStrategy >> isClass [
 
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGClassStrategy >> isClassStrategy [
 
 	^ true
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGClassStrategy >> makeResolved [
 
 
@@ -382,13 +384,13 @@ RGClassStrategy >> makeResolved [
 	sharedPools := self sharedPools markAsRingResolved
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGClassStrategy >> package [
 
 	^ self backend forBehavior packageFor: self owner
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGClassStrategy >> package: anRGPackage [
 
 	| oldPackage |
@@ -407,25 +409,25 @@ RGClassStrategy >> package: anRGPackage [
 		newPackage: anRGPackage)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGClassStrategy >> parent [
 
 	^ owner
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> privAddClassVariable: anRGInstanceVariableDefinition [
 
 	self backend forBehavior addClassVariable: anRGInstanceVariableDefinition to: self owner
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> privAddSharedPool: anRGPoolVariable [
 
 	self backend forBehavior addSharedPool: anRGPoolVariable to: self owner
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> pvtAddClassVariable: anRGInstanceVariableDefinition [
 
 	self owner environment verifyOwnership: anRGInstanceVariableDefinition.
@@ -436,7 +438,7 @@ RGClassStrategy >> pvtAddClassVariable: anRGInstanceVariableDefinition [
 	classVariables add: anRGInstanceVariableDefinition
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> pvtAddSharedPool: anRGPoolVariable [
 
 	self owner environment verifyOwnership: anRGPoolVariable.
@@ -447,31 +449,31 @@ RGClassStrategy >> pvtAddSharedPool: anRGPoolVariable [
 	sharedPools add: anRGPoolVariable
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> pvtClassVariablesDo: aBlock [
 
 	classVariables value do: aBlock
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> pvtCleanClassVariables [
 
 	classVariables := self defaultClassVariables
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> pvtCleanSharedPools [
 
 	sharedPools := self defaultSharedPools
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> pvtComment [
 
 	^ comment value
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> pvtComment: anRGComment [
 
 	self owner environment verifyOwnership: anRGComment.
@@ -479,13 +481,13 @@ RGClassStrategy >> pvtComment: anRGComment [
 	^ comment := anRGComment
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGClassStrategy >> pvtPackage [
 
 	^ package value
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGClassStrategy >> pvtPackage: anRGPackage [
 
 	self owner environment verifyOwnership: anRGPackage.
@@ -493,7 +495,7 @@ RGClassStrategy >> pvtPackage: anRGPackage [
 	^ package := anRGPackage
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> pvtRemoveClassVariable: anRGInstanceVariableDefinition [
 
 	self owner environment verifyOwnership: anRGInstanceVariableDefinition.
@@ -501,7 +503,7 @@ RGClassStrategy >> pvtRemoveClassVariable: anRGInstanceVariableDefinition [
 	classVariables remove: anRGInstanceVariableDefinition
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> pvtRemoveSharedPool: anRGPoolVariableDefinition [
 
 	self owner environment verifyOwnership: anRGPoolVariableDefinition.
@@ -509,7 +511,7 @@ RGClassStrategy >> pvtRemoveSharedPool: anRGPoolVariableDefinition [
 	sharedPools remove: anRGPoolVariableDefinition
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGClassStrategy >> pvtResolvableProperties [
 
 	^ super pvtResolvableProperties, {
@@ -520,27 +522,27 @@ RGClassStrategy >> pvtResolvableProperties [
 	}
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 RGClassStrategy >> pvtSharedPoolsDo: aBlock [
 
 	sharedPools value do: aBlock
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> removeClassVariable: anRGInstanceVariableDefinition [
 
 	self owner announceDefinitionChangeDuring: [
 		self backend forBehavior removeClassVariable: anRGInstanceVariableDefinition from: self owner ]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> removeSharedPool: anRGPoolVariable [
 
 	self owner announceDefinitionChangeDuring: [
 		self backend forBehavior removeSharedPool: anRGPoolVariable from: self owner]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> sharedPoolNames [
 
 	| allSharedPools |
@@ -549,7 +551,7 @@ RGClassStrategy >> sharedPoolNames [
 	^ allSharedPools asArray
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> sharedPools [
 
 	| allSharedPools |
@@ -568,7 +570,7 @@ RGClassStrategy >> sharedPools [
 	^ allSharedPools
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> sharedPools: aCollectionOfSymbols [
 
 	self cleanSharedPools.
@@ -576,19 +578,19 @@ RGClassStrategy >> sharedPools: aCollectionOfSymbols [
 		self addSharedPool: (RGPoolVariable named: poolName asSymbol parent: self).]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> sharedPoolsDo: aBlock [
 
 	self owner backend forBehavior sharedPoolsFor: self owner do: aBlock
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGClassStrategy >> sibling [
 
 	^ self owner metaclass
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGClassStrategy >> storeName [
 
 	^ 'RGClass'

--- a/src/Ring-Core/RGClassVariable.class.st
+++ b/src/Ring-Core/RGClassVariable.class.st
@@ -2,12 +2,14 @@
 A class variable definition
 "
 Class {
-	#name : #RGClassVariable,
-	#superclass : #RGVariable,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGClassVariable',
+	#superclass : 'RGVariable',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'managing container' }
+{ #category : 'managing container' }
 RGClassVariable >> addoptToParentStub [
 
 	super addoptToParentStub.
@@ -15,13 +17,13 @@ RGClassVariable >> addoptToParentStub [
 	self parent addClassVariable: self
 ]
 
-{ #category : #'managing container' }
+{ #category : 'managing container' }
 RGClassVariable >> defaultParentStub [
 
 	^ self defaultClassStub
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 RGClassVariable >> definitionString [
 
 	"TODO: special class variables?"
@@ -29,7 +31,7 @@ RGClassVariable >> definitionString [
 	^ self name printString
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGClassVariable >> isClassVariable [
 
 	^true

--- a/src/Ring-Core/RGComment.class.st
+++ b/src/Ring-Core/RGComment.class.st
@@ -2,17 +2,19 @@
 RGComment is a first-class representation of class's comments
 "
 Class {
-	#name : #RGComment,
-	#superclass : #RGElement,
+	#name : 'RGComment',
+	#superclass : 'RGElement',
 	#instVars : [
 		'content',
 		'author',
 		'time'
 	],
-	#category : #'Ring-Core-Kernel'
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'managing container' }
+{ #category : 'managing container' }
 RGComment >> addoptToParentStub [
 
 	super addoptToParentStub.
@@ -20,13 +22,13 @@ RGComment >> addoptToParentStub [
 	self environment backend createUnresolvedClassGroupFor: self parent
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGComment >> author [
 
 	^ self backend forBehavior classCommentAuthorFor: self
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGComment >> author: aString [
 
 	self backend forBehavior setClassCommentAuthorFor: self to: aString.
@@ -34,13 +36,13 @@ RGComment >> author: aString [
 	self announcer behaviorCommentModified: self parent
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGComment >> content [
 
 	^ self backend forBehavior classCommentContentFor: self
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGComment >> content: aString [
 
 	self backend forBehavior setClassCommentContentFor: self to: aString.
@@ -48,37 +50,37 @@ RGComment >> content: aString [
 	self announcer behaviorCommentModified: self parent
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGComment >> defaultAuthor [
 
 	^ ''
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGComment >> defaultContent [
 
 	^ ''
 ]
 
-{ #category : #'managing container' }
+{ #category : 'managing container' }
 RGComment >> defaultParentStub [
 
 	^ self defaultClassStub
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGComment >> defaultTime [
 
 	^ DateAndTime new
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGComment >> fullName [
 
 	^ (self parent name, ' comment') asSymbol
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGComment >> initialize [
 
 	super initialize.
@@ -88,7 +90,7 @@ RGComment >> initialize [
 	time := self unresolvedValue: self defaultTime
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGComment >> initializeUnresolved [
 
 	super initializeUnresolved.
@@ -98,19 +100,19 @@ RGComment >> initializeUnresolved [
 	time := self unresolvedValue: self defaultTime
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGComment >> isComment [
 
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGComment >> isEmptyOrNil [
 
 	^ self content isEmptyOrNil
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGComment >> makeResolved [
 
 	super makeResolved.
@@ -120,7 +122,7 @@ RGComment >> makeResolved [
 	time := self time markAsRingResolved
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 RGComment >> printOn: aStream [
 
 	self parent name ifNotNil: [
@@ -129,31 +131,31 @@ RGComment >> printOn: aStream [
 	aStream nextPutAll: self name asString
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGComment >> pvtAuthor [
 
 	^ author value
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGComment >> pvtAuthor: aString [
 
 	^ author := aString
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGComment >> pvtContent [
 
 	^ content value
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGComment >> pvtContent: aString [
 
 	^ content := aString
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGComment >> pvtResolvableProperties [
 
 	^ super pvtResolvableProperties, {
@@ -163,31 +165,31 @@ RGComment >> pvtResolvableProperties [
 	}
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGComment >> pvtTime [
 
 	^ time value
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGComment >> pvtTime: aDateAndTime [
 
 	^ time := aDateAndTime
 ]
 
-{ #category : #'backward compatibility' }
+{ #category : 'backward compatibility' }
 RGComment >> sourceCode [
 
 	^ self content
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGComment >> time [
 
 	^ self backend forBehavior classCommentTimeFor: self
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGComment >> time: aDateAndTime [
 
 	self backend forBehavior setClassCommentTimeFor: self to: aDateAndTime.

--- a/src/Ring-Core/RGCompiledMethodLayout.class.st
+++ b/src/Ring-Core/RGCompiledMethodLayout.class.st
@@ -1,28 +1,30 @@
 Class {
-	#name : #RGCompiledMethodLayout,
-	#superclass : #RGObjectLayout,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGCompiledMethodLayout',
+	#superclass : 'RGObjectLayout',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGCompiledMethodLayout >> isBitsLayout [
 
 	^ true
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGCompiledMethodLayout >> isByteLayout [
 
 	^ true
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGCompiledMethodLayout >> isCompiledMethodLayout [
 
 	^ true
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGCompiledMethodLayout >> isVariableLayout [
 
 	^ true

--- a/src/Ring-Core/RGDoubleByteLayout.class.st
+++ b/src/Ring-Core/RGDoubleByteLayout.class.st
@@ -2,12 +2,14 @@
 Ring2 model of DoubleByteLayout
 "
 Class {
-	#name : #RGDoubleByteLayout,
-	#superclass : #RGBitsLayout,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGDoubleByteLayout',
+	#superclass : 'RGBitsLayout',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGDoubleByteLayout >> isByteLayout [
 
 	^ true

--- a/src/Ring-Core/RGDoubleWordLayout.class.st
+++ b/src/Ring-Core/RGDoubleWordLayout.class.st
@@ -2,12 +2,14 @@
 Ring2 model of DoubleWordLayout
 "
 Class {
-	#name : #RGDoubleWordLayout,
-	#superclass : #RGBitsLayout,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGDoubleWordLayout',
+	#superclass : 'RGBitsLayout',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGDoubleWordLayout >> isWordLayout [
 	^ true
 ]

--- a/src/Ring-Core/RGElement.class.st
+++ b/src/Ring-Core/RGElement.class.st
@@ -76,7 +76,9 @@ Example:
 
 "
 Class {
-	#name : #RGElement,
-	#superclass : #RGObject,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGElement',
+	#superclass : 'RGObject',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }

--- a/src/Ring-Core/RGEmptyLayout.class.st
+++ b/src/Ring-Core/RGEmptyLayout.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RGEmptyLayout,
-	#superclass : #RGLayout,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGEmptyLayout',
+	#superclass : 'RGLayout',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGEmptyLayout >> isEmptyLayout [
 
 	^ true

--- a/src/Ring-Core/RGEnvironment.class.st
+++ b/src/Ring-Core/RGEnvironment.class.st
@@ -7,8 +7,8 @@ In most cases, you should communicate with me using my query interface. You will
 
 "
 Class {
-	#name : #RGEnvironment,
-	#superclass : #RGObject,
+	#name : 'RGEnvironment',
+	#superclass : 'RGObject',
 	#instVars : [
 		'announcer',
 		'behaviors',
@@ -18,10 +18,12 @@ Class {
 		'queryInterface',
 		'version'
 	],
-	#category : #'Ring-Core-Environment'
+	#category : 'Ring-Core-Environment',
+	#package : 'Ring-Core',
+	#tag : 'Environment'
 }
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGEnvironment >> addBehavior: anRGBehavior [
 
 	self backend forEnvironment
@@ -40,13 +42,13 @@ RGEnvironment >> addBehavior: anRGBehavior [
 		ifTrue: [ self queryInterface behaviorsDictionary at: anRGBehavior name asSymbol put: anRGBehavior ]
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGEnvironment >> addGlobalVariable: anRGGlobalVariable [
 
 	self backend forBehavior addGlobalVariable: anRGGlobalVariable to: self
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGEnvironment >> addPackage: anRGPackage [
 
 	self backend forPackage addPackage: anRGPackage to: self.
@@ -54,37 +56,37 @@ RGEnvironment >> addPackage: anRGPackage [
 	self announce: (PackageAdded to: anRGPackage)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGEnvironment >> announcer [
 
 	^ announcer ifNil: [ announcer := RGEnvironmentAnnouncer new ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGEnvironment >> ask [
 
 	^ queryInterface ifNil: [ queryInterface := RGEnvironmentQueryInterface for: self ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGEnvironment >> backend [
 
 	^ backend ifNil: [ backend := RGEnvironmentBackend for: self ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGEnvironment >> backend: anRGEnvironmentBackend [
 
 	^ backend := anRGEnvironmentBackend
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGEnvironment >> behaviorsDo: aBlock [
 
 	self backend forEnvironment behaviorsFor: self do: aBlock
 ]
 
-{ #category : #binding }
+{ #category : 'binding' }
 RGEnvironment >> bindingOf: aSymbol [
 
 	| behavior result |
@@ -102,20 +104,20 @@ RGEnvironment >> bindingOf: aSymbol [
 	^ result
 ]
 
-{ #category : #events }
+{ #category : 'events' }
 RGEnvironment >> child: aChildDefinition renamedFrom: oldName to: newName [
 
 	self queryInterface behaviorsDictionary removeKey: oldName ifAbsent: [].
 	self queryInterface behaviorsDictionary at: newName asSymbol put: aChildDefinition
 ]
 
-{ #category : #cleaning }
+{ #category : 'cleaning' }
 RGEnvironment >> clean [
 
 	self cleanWithMetaclassNamed: #Metaclass
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGEnvironment >> cleanBehaviors [
 
 	| oldBehaviors |
@@ -130,19 +132,19 @@ RGEnvironment >> cleanBehaviors [
 	self queryInterface resetBehaviorsDictionary
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGEnvironment >> cleanGlobalVariables [
 
 	self backend forBehavior cleanGlobalVariablesFor: self
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGEnvironment >> cleanPackages [
 
 	self backend forEnvironment cleanPackagesFor: self
 ]
 
-{ #category : #cleaning }
+{ #category : 'cleaning' }
 RGEnvironment >> cleanSuperclassesOfMetaclasses [
 
 	"fix suprclasses of metaclasses do not pointing to metaclasses of superclasses"
@@ -154,7 +156,7 @@ RGEnvironment >> cleanSuperclassesOfMetaclasses [
 					each superclass: each baseClass superclass metaclass] ] ]
 ]
 
-{ #category : #cleaning }
+{ #category : 'cleaning' }
 RGEnvironment >> cleanUnusedUnreferencedBehaviors [
 
 	"remove behaviors that are not linked in the graph of the named behaviors"
@@ -181,7 +183,7 @@ RGEnvironment >> cleanUnusedUnreferencedBehaviors [
 	^ unreferenced
 ]
 
-{ #category : #cleaning }
+{ #category : 'cleaning' }
 RGEnvironment >> cleanUnusedUnreferencedPackages [
 
 	"remove packages that are not not used"
@@ -199,7 +201,7 @@ RGEnvironment >> cleanUnusedUnreferencedPackages [
 	^ unreferenced
 ]
 
-{ #category : #cleaning }
+{ #category : 'cleaning' }
 RGEnvironment >> cleanWithMetaclassNamed: aProposedName [
 
 	self unifyMetaclass: aProposedName.
@@ -211,7 +213,7 @@ RGEnvironment >> cleanWithMetaclassNamed: aProposedName [
 	self cleanUnusedUnreferencedPackages
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGEnvironment >> compileANewClassFrom: aString notifying: aMorph startingFrom: aClass [
 	| importer |
 
@@ -222,7 +224,7 @@ RGEnvironment >> compileANewClassFrom: aString notifying: aMorph startingFrom: a
 	^ aClass
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RGEnvironment >> createDefaultEnvironment [
 
 	| protoobject protoobjectClass object objectClass class classClass classDescription classDescriptionClass behavior behaviorClass metaclass metaclassClass kernelPackage |
@@ -289,37 +291,37 @@ RGEnvironment >> createDefaultEnvironment [
 	metaclassClass pvtMetaclass: metaclass
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGEnvironment >> defaultBehaviors [
 
 	^ IdentitySet new
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGEnvironment >> defaultGlobalVariables [
 
 	^ IdentitySet new
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGEnvironment >> defaultPackages [
 
 	^ IdentitySet new
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGEnvironment >> defaultVersion [
 
 	^ 6
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGEnvironment >> definitionFor: anObject [
 
 	^ self backend definitionFor: anObject
 ]
 
-{ #category : #cleaning }
+{ #category : 'cleaning' }
 RGEnvironment >> ensureClassNamed: aSymbol [
 
 	self assert: (aSymbol endsWith: ' classTrait') not.
@@ -348,7 +350,7 @@ RGEnvironment >> ensureClassNamed: aSymbol [
 			newBehavior ]
 ]
 
-{ #category : #cleaning }
+{ #category : 'cleaning' }
 RGEnvironment >> ensureClassTrait [
 
 	| aClassTrait |
@@ -367,7 +369,7 @@ RGEnvironment >> ensureClassTrait [
 	^ aClassTrait
 ]
 
-{ #category : #cleaning }
+{ #category : 'cleaning' }
 RGEnvironment >> ensureMetaclass [
 
 	| aMetaclass |
@@ -386,7 +388,7 @@ RGEnvironment >> ensureMetaclass [
 	^ aMetaclass
 ]
 
-{ #category : #cleaning }
+{ #category : 'cleaning' }
 RGEnvironment >> ensureMetaclass: aProposedName [
 
 	| aMetaclass |
@@ -405,7 +407,7 @@ RGEnvironment >> ensureMetaclass: aProposedName [
 	^ aMetaclass
 ]
 
-{ #category : #cleaning }
+{ #category : 'cleaning' }
 RGEnvironment >> ensureMetaclassTraitNamed: aSymbol [
 
 	| found newTrait newMetaclassTrait similarMetaclass similarMetaclassName siblingName sibling originalMetaclass  |
@@ -479,7 +481,7 @@ RGEnvironment >> ensureMetaclassTraitNamed: aSymbol [
 			found ]
 ]
 
-{ #category : #cleaning }
+{ #category : 'cleaning' }
 RGEnvironment >> ensurePackageNamed: aSymbol [
 
 	^ self ask packages
@@ -490,7 +492,7 @@ RGEnvironment >> ensurePackageNamed: aSymbol [
 				newPackage ]
 ]
 
-{ #category : #cleaning }
+{ #category : 'cleaning' }
 RGEnvironment >> ensureTrait [
 
 	| aTrait |
@@ -509,7 +511,7 @@ RGEnvironment >> ensureTrait [
 	^ aTrait
 ]
 
-{ #category : #cleaning }
+{ #category : 'cleaning' }
 RGEnvironment >> ensureTraitNamed: aSymbol [
 
 	| found siblingName sibling |
@@ -550,7 +552,7 @@ RGEnvironment >> ensureTraitNamed: aSymbol [
 			found ]
 ]
 
-{ #category : #unpackaged }
+{ #category : 'unpackaged' }
 RGEnvironment >> ensureUnpackagedPackage [
 
 	^ self unpackagedPackageOrNil
@@ -562,31 +564,31 @@ RGEnvironment >> ensureUnpackagedPackage [
 			^ newPackage ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGEnvironment >> environment [
 
 	^ self
 ]
 
-{ #category : #cleaning }
+{ #category : 'cleaning' }
 RGEnvironment >> fixProtoObjectClassSuperclass [
 
 	(self ask classNamed: #'ProtoObject class') superclass: (self ask classNamed: #Class)
 ]
 
-{ #category : #binding }
+{ #category : 'binding' }
 RGEnvironment >> globalVariablesBindings [
 
 	^ self propertyNamed: #globalVariablesBindings ifAbsentPut: [ IdentityDictionary new.]
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGEnvironment >> globalVariablesDo: aBlock [
 
 	self backend forBehavior globalVariablesFor: self do: aBlock
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGEnvironment >> hasTraits [
 
 	self behaviorsDo: [ :each |
@@ -595,7 +597,7 @@ RGEnvironment >> hasTraits [
 	^ false
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGEnvironment >> initialize [
 
 	super initialize.
@@ -607,7 +609,7 @@ RGEnvironment >> initialize [
 	version := self defaultVersion
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGEnvironment >> initializeUnresolved [
 
 	super initializeUnresolved.
@@ -619,13 +621,13 @@ RGEnvironment >> initializeUnresolved [
 	version := self defaultVersion
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGEnvironment >> isEnvironment [
 
 	^ true
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGEnvironment >> makeResolved [
 
 	super makeResolved.
@@ -635,19 +637,19 @@ RGEnvironment >> makeResolved [
 	globalVariables := self ask globalVariables markAsRingResolved
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGEnvironment >> package [
 
 	^ nil
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGEnvironment >> packagesDo: aBlock [
 
 	self backend  packagesFor: self do: aBlock
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGEnvironment >> pvtAddBehavior: anRGBehavior [
 
 	self environment verifyOwnership: anRGBehavior.
@@ -661,7 +663,7 @@ RGEnvironment >> pvtAddBehavior: anRGBehavior [
 			self announcer behaviorAdded: anRGBehavior]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGEnvironment >> pvtAddGlobalVariable: anRGGlobalVariable [
 
 	self environment verifyOwnership: anRGGlobalVariable.
@@ -672,7 +674,7 @@ RGEnvironment >> pvtAddGlobalVariable: anRGGlobalVariable [
 	globalVariables add: anRGGlobalVariable
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGEnvironment >> pvtAddPackage: anRGPackage [
 
 	self environment verifyOwnership: anRGPackage.
@@ -683,13 +685,13 @@ RGEnvironment >> pvtAddPackage: anRGPackage [
 	packages add: anRGPackage
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGEnvironment >> pvtBehaviorsDo: aBlock [
 
 	^ behaviors value do: aBlock
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGEnvironment >> pvtCleanBehaviors [
 
 	behaviors := self defaultBehaviors.
@@ -697,13 +699,13 @@ RGEnvironment >> pvtCleanBehaviors [
 	"TODO:Announce if not empty"
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGEnvironment >> pvtCleanGlobalVariables [
 
 	globalVariables := self defaultGlobalVariables
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGEnvironment >> pvtCleanPackages [
 
 	packages := self defaultPackages.
@@ -711,19 +713,19 @@ RGEnvironment >> pvtCleanPackages [
 	"TODO:Announce if not empty"
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGEnvironment >> pvtGlobalVariablesDo: aBlock [
 
 	globalVariables value do: aBlock
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGEnvironment >> pvtPackagesDo: aBlock [
 
 	^ packages value do: aBlock
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGEnvironment >> pvtRemoveBehavior: anRGBehavior [
 
 	self verifyOwnership: anRGBehavior.
@@ -733,7 +735,7 @@ RGEnvironment >> pvtRemoveBehavior: anRGBehavior [
 	"TODO:Announce"
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGEnvironment >> pvtRemoveGlobalVariable: anRGGlobalVariable [
 
 	self environment verifyOwnership: anRGGlobalVariable.
@@ -741,7 +743,7 @@ RGEnvironment >> pvtRemoveGlobalVariable: anRGGlobalVariable [
 	globalVariables remove: anRGGlobalVariable
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGEnvironment >> pvtRemovePackage: anRGPackage [
 
 	self verifyOwnership: anRGPackage.
@@ -751,7 +753,7 @@ RGEnvironment >> pvtRemovePackage: anRGPackage [
 	"TODO:Announce"
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGEnvironment >> pvtResolvableProperties [
 
 	^ super pvtResolvableProperties, {
@@ -761,13 +763,13 @@ RGEnvironment >> pvtResolvableProperties [
 	}
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGEnvironment >> queryInterface [
 
 	^ self ask
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGEnvironment >> removeBehavior: anRGBehavior [
 
 	self backend forEnvironment removeBehavior: anRGBehavior from: self.
@@ -786,13 +788,13 @@ RGEnvironment >> removeBehavior: anRGBehavior [
 		self queryInterface behaviorsDictionary removeKey: anRGBehavior name ifAbsent: []]
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGEnvironment >> removeGlobalVariable: anRGGlobalVariable [
 
 	self backend forBehavior removeGlobalVariable: anRGGlobalVariable from: self
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGEnvironment >> removePackage: anRGPackage [
 
 	self backend forPackage removePackage: anRGPackage from: self.
@@ -800,7 +802,7 @@ RGEnvironment >> removePackage: anRGPackage [
 	self announce: (PackageRemoved to: anRGPackage)
 ]
 
-{ #category : #unpackaged }
+{ #category : 'unpackaged' }
 RGEnvironment >> removeUnusedPackages [
 
 	"remove all packages that are not used in the system. It cannot be done automatically
@@ -821,7 +823,7 @@ RGEnvironment >> removeUnusedPackages [
 			ifFalse: [ self removePackage: each ] ]
 ]
 
-{ #category : #cleaning }
+{ #category : 'cleaning' }
 RGEnvironment >> unifyClassTrait [
 
 	"set all metaclasses of classTraits to the same object (ClassTrait) "
@@ -835,7 +837,7 @@ RGEnvironment >> unifyClassTrait [
 			ifTrue: [ each metaclass: aTrait]]
 ]
 
-{ #category : #cleaning }
+{ #category : 'cleaning' }
 RGEnvironment >> unifyMetaclass [
 
 	"set all metaclasses of metaclasses to the same object (Metaclass) "
@@ -849,7 +851,7 @@ RGEnvironment >> unifyMetaclass [
 			ifTrue: [ each metaclass: aMetaclass] ]
 ]
 
-{ #category : #cleaning }
+{ #category : 'cleaning' }
 RGEnvironment >> unifyMetaclass: aProposedName [
 
 	"set all metaclasses of metaclasses to the same object (Metaclass) "
@@ -863,7 +865,7 @@ RGEnvironment >> unifyMetaclass: aProposedName [
 			ifTrue: [ each metaclass: aMetaclass] ]
 ]
 
-{ #category : #cleaning }
+{ #category : 'cleaning' }
 RGEnvironment >> unifyTrait [
 
 	"set all metaclasses of metaclasses to the same object (Metaclass) "
@@ -879,7 +881,7 @@ RGEnvironment >> unifyTrait [
 	(self ask behaviors select: [ :each | each isRingResolved not and: [(each propertyNamed: #role) = #trait] ]) do: [:each | self removeBehavior: each  ]
 ]
 
-{ #category : #unpackaged }
+{ #category : 'unpackaged' }
 RGEnvironment >> unpackagedPackage [
 
 	| aProtocol |
@@ -889,13 +891,13 @@ RGEnvironment >> unpackagedPackage [
 	^ aProtocol
 ]
 
-{ #category : #unpackaged }
+{ #category : 'unpackaged' }
 RGEnvironment >> unpackagedPackageName [
 
 	^ '_UnpackagedPackage' asSymbol
 ]
 
-{ #category : #unpackaged }
+{ #category : 'unpackaged' }
 RGEnvironment >> unpackagedPackageOrNil [
 
 	self packagesDo: [ :each |
@@ -904,7 +906,7 @@ RGEnvironment >> unpackagedPackageOrNil [
 	^ nil
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RGEnvironment >> verifyOwnership: anRGObject [
 
 	"ignore unresolved values. TODO: check default values ownership?"
@@ -914,12 +916,12 @@ RGEnvironment >> verifyOwnership: anRGObject [
 		ifFalse: [ RGWrongEnvironment signal ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGEnvironment >> version [
 	^ version
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGEnvironment >> version: anObject [
 	version := anObject
 ]

--- a/src/Ring-Core/RGEnvironmentAnnouncer.class.st
+++ b/src/Ring-Core/RGEnvironmentAnnouncer.class.st
@@ -4,17 +4,19 @@ This class plays the role of the announcer for events raised by the Pharo system
 BEWARE: You should not need to subclass me. Think about just using me to send your announces (if you need system behavior) or using your own announcers as instance or class  variables.
 "
 Class {
-	#name : #RGEnvironmentAnnouncer,
-	#superclass : #Announcer,
+	#name : 'RGEnvironmentAnnouncer',
+	#superclass : 'Announcer',
 	#instVars : [
 		'suspended',
 		'private',
 		'storedAnnouncements'
 	],
-	#category : #'Ring-Core-Announcements'
+	#category : 'Ring-Core-Announcements',
+	#package : 'Ring-Core',
+	#tag : 'Announcements'
 }
 
-{ #category : #announce }
+{ #category : 'announce' }
 RGEnvironmentAnnouncer >> announce: anAnnouncement [
 	self isSuspended
 		ifFalse: [
@@ -25,19 +27,19 @@ RGEnvironmentAnnouncer >> announce: anAnnouncement [
 		]
 ]
 
-{ #category : #triggering }
+{ #category : 'triggering' }
 RGEnvironmentAnnouncer >> behaviorAdded: anRGBehavior [
 
 	self announce: (ClassAdded class: anRGBehavior category: nil)
 ]
 
-{ #category : #triggering }
+{ #category : 'triggering' }
 RGEnvironmentAnnouncer >> behaviorCommentModified: anRGBehavior [
 
 	self announce: (ClassCommented classCommented: anRGBehavior)
 ]
 
-{ #category : #triggering }
+{ #category : 'triggering' }
 RGEnvironmentAnnouncer >> behaviorDefinitionChangedFrom: oldRGBehavior to: newRGBehavior [
 
 	self announce: (ClassModifiedClassDefinition
@@ -45,19 +47,19 @@ RGEnvironmentAnnouncer >> behaviorDefinitionChangedFrom: oldRGBehavior to: newRG
 		to: newRGBehavior)
 ]
 
-{ #category : #triggering }
+{ #category : 'triggering' }
 RGEnvironmentAnnouncer >> behaviorDefinitionModified: anRGBehavior [
 
 	self announce: (ClassModificationApplied toClass: anRGBehavior)
 ]
 
-{ #category : #triggering }
+{ #category : 'triggering' }
 RGEnvironmentAnnouncer >> behaviorModificationAppliedTo: anRGBehavior [
 
 	self announce: (ClassModificationApplied toClass: anRGBehavior)
 ]
 
-{ #category : #triggering }
+{ #category : 'triggering' }
 RGEnvironmentAnnouncer >> behaviorParentRenamed: anRGBehavior from: oldName [
 
 	self announce: (ClassParentRenamed
@@ -66,7 +68,7 @@ RGEnvironmentAnnouncer >> behaviorParentRenamed: anRGBehavior from: oldName [
 		to: anRGBehavior name)
 ]
 
-{ #category : #triggering }
+{ #category : 'triggering' }
 RGEnvironmentAnnouncer >> behaviorRecategorized: anRGBehavior [
 
 	self announce: (ClassRecategorized
@@ -75,35 +77,31 @@ RGEnvironmentAnnouncer >> behaviorRecategorized: anRGBehavior [
 		to: anRGBehavior category)
 ]
 
-{ #category : #triggering }
+{ #category : 'triggering' }
 RGEnvironmentAnnouncer >> behaviorRemoved: anRGBehavior [
 
 	self announce: (ClassRemoved
 		class: anRGBehavior category: anRGBehavior category)
 ]
 
-{ #category : #triggering }
+{ #category : 'triggering' }
 RGEnvironmentAnnouncer >> behaviorRenamed: anRGBehavior from: oldName [
 
-	self announce: (ClassRenamed
-		class: anRGBehavior
-		category: anRGBehavior category
-		oldName: oldName
-		newName: anRGBehavior name)
+	self announce: (ClassRenamed class: anRGBehavior oldName: oldName newName: anRGBehavior name)
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGEnvironmentAnnouncer >> isSuspended [
 	^suspended ifNil: [ suspended := false ]
 ]
 
-{ #category : #triggering }
+{ #category : 'triggering' }
 RGEnvironmentAnnouncer >> methodAdded: aMethod [
 
 	self announce: (MethodAdded method: aMethod)
 ]
 
-{ #category : #triggering }
+{ #category : 'triggering' }
 RGEnvironmentAnnouncer >> methodRemoved: aMethod [
 	"For the protocol we should just send #protocol to the method when #protocol will return a protocol and not a symbol."
 
@@ -116,12 +114,12 @@ RGEnvironmentAnnouncer >> methodRemoved: aMethod [
 			 origin: aMethod parent)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGEnvironmentAnnouncer >> private [
 	^private ifNil: [ private := Announcer new ]
 ]
 
-{ #category : #announce }
+{ #category : 'announce' }
 RGEnvironmentAnnouncer >> suspendAllWhile: aBlock [
 	| oldSuspended |
 	oldSuspended := self isSuspended.
@@ -129,7 +127,7 @@ RGEnvironmentAnnouncer >> suspendAllWhile: aBlock [
 	^aBlock ensure: [ suspended := oldSuspended ]
 ]
 
-{ #category : #announce }
+{ #category : 'announce' }
 RGEnvironmentAnnouncer >> suspendAllWhileStoring: aBlock [
 	| reentring |
 	" Suspend all the announcements, storing them in an OrderedCollection, then returns this collection"
@@ -150,7 +148,7 @@ RGEnvironmentAnnouncer >> suspendAllWhileStoring: aBlock [
 	]
 ]
 
-{ #category : #subscription }
+{ #category : 'subscription' }
 RGEnvironmentAnnouncer >> unsubscribe: anObject [
 	self private unsubscribe: anObject.
 	super unsubscribe: anObject

--- a/src/Ring-Core/RGEnvironmentBackend.class.st
+++ b/src/Ring-Core/RGEnvironmentBackend.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #RGEnvironmentBackend,
-	#superclass : #Object,
+	#name : 'RGEnvironmentBackend',
+	#superclass : 'Object',
 	#instVars : [
 		'environment',
 		'providedDefinitions'
 	],
-	#category : #'Ring-Core-Environment'
+	#category : 'Ring-Core-Environment',
+	#package : 'Ring-Core',
+	#tag : 'Environment'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGEnvironmentBackend class >> for: anRGEnvironment [
 
 	^ self new
@@ -16,253 +18,253 @@ RGEnvironmentBackend class >> for: anRGEnvironment [
 		yourself
 ]
 
-{ #category : #'trait alias' }
+{ #category : 'trait alias' }
 RGEnvironmentBackend >> addAlias: aSymbol to: anRGTraitAlias [
 
 	^ anRGTraitAlias pvtAddAlias: aSymbol
 ]
 
-{ #category : #environment }
+{ #category : 'environment' }
 RGEnvironmentBackend >> addBehavior: anRGBehavior to: anRGEnvironment [
 
 	^ anRGEnvironment pvtAddBehavior: anRGBehavior
 ]
 
-{ #category : #package }
+{ #category : 'package' }
 RGEnvironmentBackend >> addClassTag: aSymbol to: anRGPackage [
 
 	^ anRGPackage pvtAddClassTag: aSymbol
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGEnvironmentBackend >> addClassVariable: anRGInstanceVariableDefinition to: anRGBehavior [
 
 	^ anRGBehavior behaviorStrategy pvtAddClassVariable: anRGInstanceVariableDefinition
 ]
 
-{ #category : #package }
+{ #category : 'package' }
 RGEnvironmentBackend >> addDefinedBehavior: anRGBehavior to: anRGPackage [
 
 	^ anRGPackage pvtAddDefinedBehavior: anRGBehavior
 ]
 
-{ #category : #'trait exclusion' }
+{ #category : 'trait exclusion' }
 RGEnvironmentBackend >> addExclusion: aSymbol to: anRGTraitExclusion [
 
 	^ anRGTraitExclusion pvtAddExclusion: aSymbol
 ]
 
-{ #category : #package }
+{ #category : 'package' }
 RGEnvironmentBackend >> addExtensionMethod: anRGMethod to: anRGPackage [
 
 	^ anRGPackage pvtAddExtensionMethod: anRGMethod
 ]
 
-{ #category : #environment }
+{ #category : 'environment' }
 RGEnvironmentBackend >> addGlobalVariable: anRGGlobalVariable to: anRGEnvironment [
 
 	^ anRGEnvironment pvtAddGlobalVariable: anRGGlobalVariable
 ]
 
-{ #category : #behavior }
+{ #category : 'behavior' }
 RGEnvironmentBackend >> addLocalMethod: anRGMethod to: anRGBehavior [
 
 	^ anRGBehavior pvtAddLocalMethod: anRGMethod
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGEnvironmentBackend >> addMethodTag: aSymbol to: anRGBehavior [
 
 	^ anRGBehavior pvtAddMethodTag: aSymbol
 ]
 
-{ #category : #environment }
+{ #category : 'environment' }
 RGEnvironmentBackend >> addPackage: anRGPackage to: anRGEnvironment [
 
 	^ anRGEnvironment pvtAddPackage: anRGPackage
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGEnvironmentBackend >> addSharedPool: anRGPoolVariable to: anRGBehavior [
 
 	^ anRGBehavior behaviorStrategy pvtAddSharedPool: anRGPoolVariable
 ]
 
-{ #category : #'pointer layout' }
+{ #category : 'pointer layout' }
 RGEnvironmentBackend >> addSlot: anRGSlot to: anRGLayout [
 
 	^ anRGLayout pvtAddSlot: anRGSlot
 ]
 
-{ #category : #'trait composition' }
+{ #category : 'trait composition' }
 RGEnvironmentBackend >> addTransformation: anRGTraitTransformation to: anRGTraitComposition [
 
 	^ anRGTraitComposition pvtAddTransformation: anRGTraitTransformation
 ]
 
-{ #category : #'trait alias' }
+{ #category : 'trait alias' }
 RGEnvironmentBackend >> aliasesFor: anRGTraitAlias do: aBlock [
 
 	^ anRGTraitAlias pvtAliasesDo: aBlock
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGEnvironmentBackend >> astFor: anRGMethod [
 
 	^  anRGMethod astFromSource
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGEnvironmentBackend >> authorFor: anRGMethod [
 
 	^  anRGMethod pvtAuthor
 ]
 
-{ #category : #metaclass }
+{ #category : 'metaclass' }
 RGEnvironmentBackend >> baseClassFor: anRGBehavior [
 
 	^  anRGBehavior behaviorStrategy pvtBaseClass
 ]
 
-{ #category : #environment }
+{ #category : 'environment' }
 RGEnvironmentBackend >> behaviorsFor: anRGEnvironment do: aBlock [
 
 	^  anRGEnvironment pvtBehaviorsDo: aBlock
 ]
 
-{ #category : #'class comment' }
+{ #category : 'class comment' }
 RGEnvironmentBackend >> classCommentAuthorFor: anRGComment [
 
 	^  anRGComment pvtAuthor
 ]
 
-{ #category : #'class comment' }
+{ #category : 'class comment' }
 RGEnvironmentBackend >> classCommentContentFor: anRGComment [
 
 	^ anRGComment pvtContent
 ]
 
-{ #category : #'class comment' }
+{ #category : 'class comment' }
 RGEnvironmentBackend >> classCommentTimeFor: anRGComment [
 
 	^  anRGComment pvtTime
 ]
 
-{ #category : #trait }
+{ #category : 'trait' }
 RGEnvironmentBackend >> classTraitFor: anRGTrait [
 
 	^  anRGTrait behaviorStrategy pvtClassTrait
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGEnvironmentBackend >> classVariablesFor: anRGBehavior do: aBlock [
 
 	^ anRGBehavior behaviorStrategy pvtClassVariablesDo: aBlock
 ]
 
-{ #category : #'trait alias' }
+{ #category : 'trait alias' }
 RGEnvironmentBackend >> cleanAliasesFor: anRGTraitAlias [
 
 	^ anRGTraitAlias pvtCleanAliases
 ]
 
-{ #category : #environment }
+{ #category : 'environment' }
 RGEnvironmentBackend >> cleanBehaviorsFor: anRGEnvironment [
 
 	anRGEnvironment pvtCleanBehaviors
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGEnvironmentBackend >> cleanClassTagsFor: anRGBehavior [
 
 	anRGBehavior pvtCleanTags
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGEnvironmentBackend >> cleanClassVariablesFor: anRGBehavior [
 
 	^ anRGBehavior behaviorStrategy pvtCleanClassVariables
 ]
 
-{ #category : #package }
+{ #category : 'package' }
 RGEnvironmentBackend >> cleanDefinedBehaviorsFor: anRGPackage [
 
 	anRGPackage pvtCleanDefinedBehaviors
 ]
 
-{ #category : #'trait exclusion' }
+{ #category : 'trait exclusion' }
 RGEnvironmentBackend >> cleanExclusionsFor: anRGTraitExclusion [
 
 	^ anRGTraitExclusion pvtCleanExclusions
 ]
 
-{ #category : #package }
+{ #category : 'package' }
 RGEnvironmentBackend >> cleanExtensionMethodsFor: anRGPackage [
 
 	anRGPackage pvtCleanExtensionMethods
 ]
 
-{ #category : #environment }
+{ #category : 'environment' }
 RGEnvironmentBackend >> cleanGlobalVariablesFor: anRGEnvironment [
 
 	^ anRGEnvironment pvtCleanGlobalVariables
 ]
 
-{ #category : #behavior }
+{ #category : 'behavior' }
 RGEnvironmentBackend >> cleanLocalMethodsFor: anRGBehavior [
 
 	^ anRGBehavior pvtCleanLocalMethods
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGEnvironmentBackend >> cleanMethodTagsFor: anRGMethod [
 
 	anRGMethod pvtCleanTags
 ]
 
-{ #category : #environment }
+{ #category : 'environment' }
 RGEnvironmentBackend >> cleanPackagesFor: anRGEnvironment [
 
 	anRGEnvironment pvtCleanPackages
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGEnvironmentBackend >> cleanSharedPoolsFor: anRGBehavior [
 
 	^ anRGBehavior behaviorStrategy pvtCleanSharedPools
 ]
 
-{ #category : #'pointer layout' }
+{ #category : 'pointer layout' }
 RGEnvironmentBackend >> cleanSlotsFor: anRGLayout [
 
 	^ anRGLayout pvtCleanSlots
 ]
 
-{ #category : #package }
+{ #category : 'package' }
 RGEnvironmentBackend >> cleanTagsForClassesFor: anRGPackage [
 
 	anRGPackage pvtCleanTagsForClasses
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGEnvironmentBackend >> cleanTagsForMethodsFor: anRGBehavior [
 
 	anRGBehavior pvtCleanTagsForMethods
 ]
 
-{ #category : #'trait composition' }
+{ #category : 'trait composition' }
 RGEnvironmentBackend >> cleanTransformationsFor: anRGTraitComposition [
 
 	^ anRGTraitComposition pvtCleanTransformations
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGEnvironmentBackend >> commentFor: anRGBehavior [
 
 	^  anRGBehavior behaviorStrategy pvtComment
 ]
 
-{ #category : #'unresolved objects' }
+{ #category : 'unresolved objects' }
 RGEnvironmentBackend >> createNewUnresolvedClass [
 
 	| classStub metaclassStub packageStub |
@@ -283,7 +285,7 @@ RGEnvironmentBackend >> createNewUnresolvedClass [
 	^ classStub
 ]
 
-{ #category : #'unresolved objects' }
+{ #category : 'unresolved objects' }
 RGEnvironmentBackend >> createNewUnresolvedMetaclassFor: anRGBehavior [
 
 	| metaclassStub superclassMetaclass |
@@ -303,7 +305,7 @@ RGEnvironmentBackend >> createNewUnresolvedMetaclassFor: anRGBehavior [
 	^ metaclassStub
 ]
 
-{ #category : #'unresolved objects' }
+{ #category : 'unresolved objects' }
 RGEnvironmentBackend >> createUnresolvedClassGroupFor: anRGBehavior [
 
 	| classStub metaclassStub superclassStub superclassMetaclassStub packageStub1 packageStub2 |
@@ -367,7 +369,7 @@ RGEnvironmentBackend >> createUnresolvedClassGroupFor: anRGBehavior [
 		ifTrue: [ classStub ]
 ]
 
-{ #category : #'unresolved objects' }
+{ #category : 'unresolved objects' }
 RGEnvironmentBackend >> createUnresolvedTraitGroupFor: anRGBehavior [
 
 	| traitStub classTraitStub traitMetaclassStub classTraitMetaclassStub packageStub1  |
@@ -421,19 +423,19 @@ RGEnvironmentBackend >> createUnresolvedTraitGroupFor: anRGBehavior [
 		ifTrue: [ classTraitStub ]
 ]
 
-{ #category : #package }
+{ #category : 'package' }
 RGEnvironmentBackend >> definedBehaviorsFor: anRGPackage do: aBlock [
 
 	^  anRGPackage pvtDefinedBehaviorsDo: aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGEnvironmentBackend >> definitionFor: anObject [
 
 	^ self definitionFor: anObject ifAbsentRegister: [ anObject ensureRingDefinitionIn: self environment ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGEnvironmentBackend >> definitionFor: anObject ifAbsentRegister: aDefinitionOrBlock [
 
 	^ providedDefinitions at: anObject
@@ -441,85 +443,85 @@ RGEnvironmentBackend >> definitionFor: anObject ifAbsentRegister: aDefinitionOrB
 		ifAbsentPut: [ aDefinitionOrBlock value ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGEnvironmentBackend >> environment [
 
 	^ environment
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGEnvironmentBackend >> environment: anRGEnironment [
 
 	environment := anRGEnironment
 ]
 
-{ #category : #'trait exclusion' }
+{ #category : 'trait exclusion' }
 RGEnvironmentBackend >> exclusionsFor: anRGTraitExclusion do: aBlock [
 
 	^ anRGTraitExclusion pvtExclusionsDo: aBlock
 ]
 
-{ #category : #slot }
+{ #category : 'slot' }
 RGEnvironmentBackend >> expressionFor: anRGUnknownSlot [
 
 	^  anRGUnknownSlot pvtExpression
 ]
 
-{ #category : #package }
+{ #category : 'package' }
 RGEnvironmentBackend >> extensionMethodsFor: anRGPackage do: aBlock [
 
 	^ anRGPackage pvtExtensionMethodsDo: aBlock
 ]
 
-{ #category : #subbackends }
+{ #category : 'subbackends' }
 RGEnvironmentBackend >> forBehavior [
 
 	^ self
 ]
 
-{ #category : #subbackends }
+{ #category : 'subbackends' }
 RGEnvironmentBackend >> forEnvironment [
 
 	^ self
 ]
 
-{ #category : #subbackends }
+{ #category : 'subbackends' }
 RGEnvironmentBackend >> forMethod [
 
 	^ self
 ]
 
-{ #category : #subbackends }
+{ #category : 'subbackends' }
 RGEnvironmentBackend >> forPackage [
 
 	^ self
 ]
 
-{ #category : #environment }
+{ #category : 'environment' }
 RGEnvironmentBackend >> globalVariablesFor: anRGEnvironment do: aBlock [
 
 	^ anRGEnvironment pvtGlobalVariablesDo: aBlock
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGEnvironmentBackend >> hasFullyResolved: anRGObject [
 
 	^ anRGObject pvtFullyResolved
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGEnvironmentBackend >> hasFullyUnresolved: anRGObject [
 
 	^ anRGObject pvtFullyUnresolved
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGEnvironmentBackend >> hasSourceCodeFor: anRGMethod [
 
 	^ anRGMethod pvtSourceCode notNil
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGEnvironmentBackend >> initialize [
 
 	super initialize.
@@ -527,379 +529,379 @@ RGEnvironmentBackend >> initialize [
 	providedDefinitions := IdentityDictionary new
 ]
 
-{ #category : #behavior }
+{ #category : 'behavior' }
 RGEnvironmentBackend >> layoutFor: anRGBehavior [
 
 	^  anRGBehavior behaviorStrategy pvtLayout
 ]
 
-{ #category : #behavior }
+{ #category : 'behavior' }
 RGEnvironmentBackend >> localMethodsFor: anRGBehavior do: aBlock [
 
 	^ anRGBehavior pvtLocalMethodsDo: aBlock
 ]
 
-{ #category : #metaclass }
+{ #category : 'metaclass' }
 RGEnvironmentBackend >> metaclassFor: anRGBehavior [
 
 	^  anRGBehavior pvtMetaclass
 ]
 
-{ #category : #'metaclass trait' }
+{ #category : 'metaclass trait' }
 RGEnvironmentBackend >> metaclassTraitBaseTraitFor: anRGMetaclassTrait [
 
 	^  anRGMetaclassTrait behaviorStrategy pvtBaseTrait
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGEnvironmentBackend >> methodPackageFor: anRGMethod [
 
 	^  anRGMethod pvtPackage
 ]
 
-{ #category : #general }
+{ #category : 'general' }
 RGEnvironmentBackend >> nameFor: anRGObject [
 
 	^ anRGObject pvtName
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGEnvironmentBackend >> packageFor: anRGBehavior [
 
 	^  anRGBehavior behaviorStrategy pvtPackage
 ]
 
-{ #category : #environment }
+{ #category : 'environment' }
 RGEnvironmentBackend >> packagesFor: anRGEnvironment do: aBlock [
 
 	^  anRGEnvironment pvtPackagesDo: aBlock
 ]
 
-{ #category : #'trait alias' }
+{ #category : 'trait alias' }
 RGEnvironmentBackend >> removeAlias: aSymbol from: anRGTraitAlias [
 
 	^ anRGTraitAlias pvtRemoveAlias: aSymbol
 ]
 
-{ #category : #environment }
+{ #category : 'environment' }
 RGEnvironmentBackend >> removeBehavior: anRGBehavior from: anRGEnvironment [
 
 	anRGEnvironment pvtRemoveBehavior: anRGBehavior
 ]
 
-{ #category : #package }
+{ #category : 'package' }
 RGEnvironmentBackend >> removeClassTag: aSymbol from: anRGPackage [
 
 	^ anRGPackage pvtRemoveClassTag: aSymbol
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGEnvironmentBackend >> removeClassVariable: anRGInstanceVariableDefinition from: anRGBehavior [
 
 	^ anRGBehavior behaviorStrategy pvtRemoveClassVariable: anRGInstanceVariableDefinition
 ]
 
-{ #category : #package }
+{ #category : 'package' }
 RGEnvironmentBackend >> removeDefinedBehavior: anRGBehavior from: anRGPackage [
 
 	^ anRGPackage pvtRemoveDefinedBehavior: anRGBehavior
 ]
 
-{ #category : #'trait exclusion' }
+{ #category : 'trait exclusion' }
 RGEnvironmentBackend >> removeExclusion: aSymbol from: anRGTraitExclusion [
 
 	^ anRGTraitExclusion pvtRemoveExclusion: aSymbol
 ]
 
-{ #category : #package }
+{ #category : 'package' }
 RGEnvironmentBackend >> removeExtensionMethod: anRGMethod from: anRGPackage [
 
 	^ anRGPackage pvtRemoveExtensionMethod: anRGMethod
 ]
 
-{ #category : #environment }
+{ #category : 'environment' }
 RGEnvironmentBackend >> removeGlobalVariable: anRGGlobalVariable from: anRGEnvironment [
 
 	^ anRGEnvironment pvtRemoveGlobalVariable: anRGGlobalVariable
 ]
 
-{ #category : #behavior }
+{ #category : 'behavior' }
 RGEnvironmentBackend >> removeLocalMethod: anRGMethod from: anRGBehavior [
 
 	^ anRGBehavior pvtRemoveLocalMethod: anRGMethod
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGEnvironmentBackend >> removeMethodTag: aSymbol from: anRGBehavior [
 
 	^ anRGBehavior pvtRemoveMethodTag: aSymbol
 ]
 
-{ #category : #environment }
+{ #category : 'environment' }
 RGEnvironmentBackend >> removePackage: anRGPackage from: anRGEnvironment [
 
 	^ anRGEnvironment pvtRemovePackage: anRGPackage
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGEnvironmentBackend >> removeSharedPool: anRGPoolVariable from: anRGBehavior [
 
 	^ anRGBehavior behaviorStrategy pvtRemoveSharedPool: anRGPoolVariable
 ]
 
-{ #category : #'pointer layout' }
+{ #category : 'pointer layout' }
 RGEnvironmentBackend >> removeSlot: anRGSlot from: anRGLayout [
 
 	^ anRGLayout pvtRemoveSlot: anRGSlot
 ]
 
-{ #category : #'trait composition' }
+{ #category : 'trait composition' }
 RGEnvironmentBackend >> removeTransformation: anRGTraitTransformation from: anRGTraitComposition [
 
 	^ anRGTraitComposition pvtRemoveTransformation: anRGTraitTransformation
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGEnvironmentBackend >> resolvedPropertiesFor: anRGObject [
 
 	^ anRGObject pvtResolvedProperties
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGEnvironmentBackend >> setAuthorFor: anRGMethod to: aDateAndTime [
 
 	^  anRGMethod pvtAuthor: aDateAndTime
 ]
 
-{ #category : #metaclass }
+{ #category : 'metaclass' }
 RGEnvironmentBackend >> setBaseClassFor: anRGBehavior to: anRGClass [
 
 	^  anRGBehavior behaviorStrategy pvtBaseClass: anRGClass
 ]
 
-{ #category : #'class comment' }
+{ #category : 'class comment' }
 RGEnvironmentBackend >> setClassCommentAuthorFor: anRGComment to: aString [
 
 	^  anRGComment pvtAuthor: aString
 ]
 
-{ #category : #'class comment' }
+{ #category : 'class comment' }
 RGEnvironmentBackend >> setClassCommentContentFor: anRGComment to: anObject [
 
 	anRGComment pvtContent: anObject
 ]
 
-{ #category : #'class comment' }
+{ #category : 'class comment' }
 RGEnvironmentBackend >> setClassCommentTimeFor: anRGComment to: aDateAndTime [
 
 	^  anRGComment pvtTime: aDateAndTime
 ]
 
-{ #category : #trait }
+{ #category : 'trait' }
 RGEnvironmentBackend >> setClassTraitFor: anRGTrait to: anRGMetatraitDefinition [
 
 	^  anRGTrait behaviorStrategy pvtClassTrait: anRGMetatraitDefinition
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGEnvironmentBackend >> setCommentFor: anRGBehavior to: anRGComment [
 
 	^  anRGBehavior behaviorStrategy pvtComment: anRGComment
 ]
 
-{ #category : #slot }
+{ #category : 'slot' }
 RGEnvironmentBackend >> setExpressionFor: anRGUnknownSlot to: aString [
 
 	^  anRGUnknownSlot pvtExpression: aString
 ]
 
-{ #category : #behavior }
+{ #category : 'behavior' }
 RGEnvironmentBackend >> setLayoutFor: anRGBehavior to: anRGLayout [
 
 	^  anRGBehavior behaviorStrategy pvtLayout: anRGLayout
 ]
 
-{ #category : #metaclass }
+{ #category : 'metaclass' }
 RGEnvironmentBackend >> setMetaclassFor: anRGBehavior to: anRGMetaclass [
 
 	^  anRGBehavior pvtMetaclass: anRGMetaclass
 ]
 
-{ #category : #'metaclass trait' }
+{ #category : 'metaclass trait' }
 RGEnvironmentBackend >> setMetaclassTraitBaseTraitFor: anRGMetaclassTrait to: anRGTrait [
 
 	^  anRGMetaclassTrait pvtBaseTrait: anRGTrait
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGEnvironmentBackend >> setMethodPackageFor: anRGMethod to: anRGPackage [
 
 	^  anRGMethod pvtPackage: anRGPackage
 ]
 
-{ #category : #general }
+{ #category : 'general' }
 RGEnvironmentBackend >> setNameFor: anRGObject to: aString [
 
 	^ anRGObject pvtName: aString
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGEnvironmentBackend >> setPackageFor: anRGBehavior to: anRGPackage [
 
 	^  anRGBehavior behaviorStrategy pvtPackage: anRGPackage
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGEnvironmentBackend >> setSourceCodeFor: anRGMethod to: anObject [
 
 	anRGMethod pvtSourceCode: anObject
 ]
 
-{ #category : #'trait transormation' }
+{ #category : 'trait transormation' }
 RGEnvironmentBackend >> setSubjectFor: anRGTraitComposition to: anRGTrait [
 
 	^  anRGTraitComposition pvtSubject: anRGTrait
 ]
 
-{ #category : #behavior }
+{ #category : 'behavior' }
 RGEnvironmentBackend >> setSuperclassFor: anRGBehavior to: anObject [
 
 	^  anRGBehavior pvtSuperclass: anObject
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGEnvironmentBackend >> setTimeFor: anRGMethod to: aDateAndTime [
 
 	^  anRGMethod pvtTime: aDateAndTime
 ]
 
-{ #category : #trait }
+{ #category : 'trait' }
 RGEnvironmentBackend >> setTraitCommentFor: anRGBehavior to: anRGComment [
 
 	^  anRGBehavior behaviorStrategy pvtComment: anRGComment
 ]
 
-{ #category : #behavior }
+{ #category : 'behavior' }
 RGEnvironmentBackend >> setTraitCompositionFor: anRGBehavior to: anRGTraitComposition [
 
 	^  anRGBehavior pvtTraitComposition: anRGTraitComposition
 ]
 
-{ #category : #trait }
+{ #category : 'trait' }
 RGEnvironmentBackend >> setTraitPackageFor: anRGBehavior to: anRGPackage [
 
 	^  anRGBehavior pvtPackage: anRGPackage
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGEnvironmentBackend >> sharedPoolsFor: anRGBehavior do: aBlock [
 
 	^ anRGBehavior behaviorStrategy pvtSharedPoolsDo: aBlock
 ]
 
-{ #category : #'pointer layout' }
+{ #category : 'pointer layout' }
 RGEnvironmentBackend >> slotsFor: anRGLayout do: aBlock [
 
 	^ anRGLayout pvtSlotsDo: aBlock
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGEnvironmentBackend >> sourceCodeFor: anRGMethod [
 
 	^ anRGMethod pvtSafeSourceCode
 ]
 
-{ #category : #'trait transormation' }
+{ #category : 'trait transormation' }
 RGEnvironmentBackend >> subjectFor: anRGTraitComposition [
 
 	^  anRGTraitComposition pvtSubject
 ]
 
-{ #category : #behavior }
+{ #category : 'behavior' }
 RGEnvironmentBackend >> superclassFor: anRGBehavior [
 
 	^  anRGBehavior pvtSuperclass
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGEnvironmentBackend >> tagClass: anRGBehavior with: aSymbol [
 
 	^ anRGBehavior pvtTagWith: aSymbol
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGEnvironmentBackend >> tagMethod: anRGMethod with: aSymbol [
 
 	^ anRGMethod pvtTagWith: aSymbol
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGEnvironmentBackend >> tagsForClass: anRGBehavior do: aBlock [
 
 	^  anRGBehavior pvtTagsDo: aBlock
 ]
 
-{ #category : #package }
+{ #category : 'package' }
 RGEnvironmentBackend >> tagsForClassesFor: anRGPackage do: aBlock [
 
 	^  anRGPackage pvtTagsForClassesDo: aBlock
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGEnvironmentBackend >> tagsForMethod: anRGMethod do: aBlock [
 
 	^  anRGMethod pvtTagsDo: aBlock
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGEnvironmentBackend >> tagsForMethodsFor: anRGBehavior do: aBlock [
 
 	^  anRGBehavior pvtTagsForMethodsDo: aBlock
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGEnvironmentBackend >> timeFor: anRGMethod [
 
 	^  anRGMethod pvtTime
 ]
 
-{ #category : #trait }
+{ #category : 'trait' }
 RGEnvironmentBackend >> traitCommentFor: anRGBehavior [
 
 	^  anRGBehavior behaviorStrategy pvtComment
 ]
 
-{ #category : #behavior }
+{ #category : 'behavior' }
 RGEnvironmentBackend >> traitCompositionFor: anRGBehavior [
 
 	^  anRGBehavior pvtTraitComposition
 ]
 
-{ #category : #trait }
+{ #category : 'trait' }
 RGEnvironmentBackend >> traitPackageFor: anRGBehavior [
 
 	^  anRGBehavior behaviorStrategy pvtPackage
 ]
 
-{ #category : #'trait composition' }
+{ #category : 'trait composition' }
 RGEnvironmentBackend >> transformationsFor: anRGTraitComposition do: aBlock [
 
 	^ anRGTraitComposition pvtTransformationsDo: aBlock
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGEnvironmentBackend >> unresolvedPropertiesFor: anRGObject [
 
 	^ anRGObject pvtUnresolvedProperties
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGEnvironmentBackend >> untagClass: anRGBehavior from: aSymbol [
 
 	^ anRGBehavior pvtUntagFrom: aSymbol
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGEnvironmentBackend >> untagMethod: anRGMethod from: aSymbol [
 
 	^ anRGMethod pvtUntagFrom: aSymbol

--- a/src/Ring-Core/RGEnvironmentQueryInterface.class.st
+++ b/src/Ring-Core/RGEnvironmentQueryInterface.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #RGEnvironmentQueryInterface,
-	#superclass : #Object,
+	#name : 'RGEnvironmentQueryInterface',
+	#superclass : 'Object',
 	#instVars : [
 		'environment',
 		'behaviorsDictionary'
 	],
-	#category : #'Ring-Core-Environment'
+	#category : 'Ring-Core-Environment',
+	#package : 'Ring-Core',
+	#tag : 'Environment'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGEnvironmentQueryInterface class >> for: anRGEnvironment [
 
 	^ self new
@@ -16,25 +18,25 @@ RGEnvironmentQueryInterface class >> for: anRGEnvironment [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGEnvironmentQueryInterface >> allClasses [
 
 	^ self behaviors select: [ :each | each isClass ]
 ]
 
-{ #category : #classes }
+{ #category : 'classes' }
 RGEnvironmentQueryInterface >> allClassesAndTraits [
 
 	^ self behaviors select: [ :each | each isClass or: [ each isTrait and: [ each isMetaclassTrait not ] ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGEnvironmentQueryInterface >> behaviorNamed: aSymbol [
 
 	^ self behaviorNamed: aSymbol ifAbsent: [ nil]
 ]
 
-{ #category : #classes }
+{ #category : 'classes' }
 RGEnvironmentQueryInterface >> behaviorNamed: aSymbol ifAbsent: aBlock [
 
 	| found siblingName |
@@ -67,13 +69,13 @@ RGEnvironmentQueryInterface >> behaviorNamed: aSymbol ifAbsent: aBlock [
 	^ aBlock value
 ]
 
-{ #category : #classes }
+{ #category : 'classes' }
 RGEnvironmentQueryInterface >> behaviorNamedExactlyAs: aSymbol [
 
 	^ self behaviorNamedExactlyAs: aSymbol ifAbsent: [nil]
 ]
 
-{ #category : #classes }
+{ #category : 'classes' }
 RGEnvironmentQueryInterface >> behaviorNamedExactlyAs: aSymbol ifAbsent: aBlock [
 
 	^ self behaviorsDictionary at: aSymbol asSymbol ifAbsent: aBlock
@@ -85,7 +87,7 @@ RGEnvironmentQueryInterface >> behaviorNamedExactlyAs: aSymbol ifAbsent: aBlock 
 	"
 ]
 
-{ #category : #classes }
+{ #category : 'classes' }
 RGEnvironmentQueryInterface >> behaviors [
 	"Retrieves the traits defined in the receiver"
 
@@ -95,7 +97,7 @@ RGEnvironmentQueryInterface >> behaviors [
 	^ allBehaviors asArray
 ]
 
-{ #category : #caching }
+{ #category : 'caching' }
 RGEnvironmentQueryInterface >> behaviorsDictionary [
 
 	^ behaviorsDictionary ifNil: [
@@ -106,35 +108,35 @@ RGEnvironmentQueryInterface >> behaviorsDictionary [
 		]
 ]
 
-{ #category : #classes }
+{ #category : 'classes' }
 RGEnvironmentQueryInterface >> behaviorsDo: aBlock [
 
 	self environment behaviorsDo: aBlock
 ]
 
-{ #category : #classes }
+{ #category : 'classes' }
 RGEnvironmentQueryInterface >> classNamed: aSymbol [
 
 	^ self behaviorNamed: aSymbol
 ]
 
-{ #category : #classes }
+{ #category : 'classes' }
 RGEnvironmentQueryInterface >> classOrTraitNamed: aSymbol [
 
 	^ self behaviorNamed: aSymbol
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGEnvironmentQueryInterface >> environment [
 	^ environment
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGEnvironmentQueryInterface >> environment: anObject [
 	environment := anObject
 ]
 
-{ #category : #globals }
+{ #category : 'globals' }
 RGEnvironmentQueryInterface >> globalVariables [
 	"Retrieves the traits defined in the receiver"
 
@@ -144,13 +146,13 @@ RGEnvironmentQueryInterface >> globalVariables [
 	^ allGlobalVariables asArray
 ]
 
-{ #category : #globals }
+{ #category : 'globals' }
 RGEnvironmentQueryInterface >> globalVariablesDo: aBlock [
 
 	self environment globalVariablesDo: aBlock
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGEnvironmentQueryInterface >> includesClassNamed: aSymbol [
 
 	self globalVariablesDo: [ :var |
@@ -168,13 +170,13 @@ RGEnvironmentQueryInterface >> includesClassNamed: aSymbol [
 	"
 ]
 
-{ #category : #caching }
+{ #category : 'caching' }
 RGEnvironmentQueryInterface >> invalidateName: aSymbol [
 
 	behaviorsDictionary removeKey: aSymbol
 ]
 
-{ #category : #packages }
+{ #category : 'packages' }
 RGEnvironmentQueryInterface >> packageNamed: aString [
 
 	self packagesDo: [:each |
@@ -183,7 +185,7 @@ RGEnvironmentQueryInterface >> packageNamed: aString [
 	^ nil
 ]
 
-{ #category : #packages }
+{ #category : 'packages' }
 RGEnvironmentQueryInterface >> packages [
 	"Retrieves the traits defined in the receiver"
 
@@ -193,13 +195,13 @@ RGEnvironmentQueryInterface >> packages [
 	^ allPackages asArray
 ]
 
-{ #category : #packages }
+{ #category : 'packages' }
 RGEnvironmentQueryInterface >> packagesDo: aBlock [
 
 	self environment packagesDo: aBlock
 ]
 
-{ #category : #caching }
+{ #category : 'caching' }
 RGEnvironmentQueryInterface >> replaceName: aSymbol with: aNewSymbol [
 
 	| anRGBehavior |
@@ -210,13 +212,13 @@ RGEnvironmentQueryInterface >> replaceName: aSymbol with: aNewSymbol [
 		 ]
 ]
 
-{ #category : #caching }
+{ #category : 'caching' }
 RGEnvironmentQueryInterface >> resetBehaviorsDictionary [
 
 	behaviorsDictionary := IdentityDictionary new
 ]
 
-{ #category : #classes }
+{ #category : 'classes' }
 RGEnvironmentQueryInterface >> traitNamed: traitName [
 	"Retrieves an RGTrait object. The traitName could be classSide name"
 	| trait |

--- a/src/Ring-Core/RGEphemeronLayout.class.st
+++ b/src/Ring-Core/RGEphemeronLayout.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RGEphemeronLayout,
-	#superclass : #RGPointerLayout,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGEphemeronLayout',
+	#superclass : 'RGPointerLayout',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #description }
+{ #category : 'description' }
 RGEphemeronLayout class >> subclassDefiningSymbol [
 	"Answer a keyword that describes the receiver's kind of subclass
 	Note: this is for printing the ST80 style class definiton."
@@ -12,7 +14,7 @@ RGEphemeronLayout class >> subclassDefiningSymbol [
 	^ #ephemeronSubclass:
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGEphemeronLayout >> isEphemeronLayout [
 
 	^ true

--- a/src/Ring-Core/RGFixedLayout.class.st
+++ b/src/Ring-Core/RGFixedLayout.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RGFixedLayout,
-	#superclass : #RGPointerLayout,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGFixedLayout',
+	#superclass : 'RGPointerLayout',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGFixedLayout >> isFixedLayout [
 
 	^ true

--- a/src/Ring-Core/RGGlobalVariable.class.st
+++ b/src/Ring-Core/RGGlobalVariable.class.st
@@ -2,41 +2,43 @@
 A global variable definition
 "
 Class {
-	#name : #RGGlobalVariable,
-	#superclass : #RGObject,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGGlobalVariable',
+	#superclass : 'RGObject',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 RGGlobalVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 
 	^ aProgramNodeVisitor visitGlobalVariableNode: aNode
 ]
 
-{ #category : #'managing container' }
+{ #category : 'managing container' }
 RGGlobalVariable >> addoptToParentStub [
 
 	super addoptToParentStub.
 	self parent addGlobalVariable: self
 ]
 
-{ #category : #analyzing }
+{ #category : 'analyzing' }
 RGGlobalVariable >> analyzeRead: aRBVariableNode by: anOCASTSemanticAnalyzer [
 ]
 
-{ #category : #'managing container' }
+{ #category : 'managing container' }
 RGGlobalVariable >> defaultParentStub [
 
 	^ self defaultEnvironmentStub
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGGlobalVariable >> isGlobalVariable [
 
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGGlobalVariable >> isSuperVariable [
 
 	^ false

--- a/src/Ring-Core/RGImmediateLayout.class.st
+++ b/src/Ring-Core/RGImmediateLayout.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RGImmediateLayout,
-	#superclass : #RGObjectLayout,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGImmediateLayout',
+	#superclass : 'RGObjectLayout',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #description }
+{ #category : 'description' }
 RGImmediateLayout class >> subclassDefiningSymbol [
 	"Answer a keyword that describes the receiver's kind of subclass
 	Note: this is for printing the ST80 style class definiton."
@@ -12,7 +14,7 @@ RGImmediateLayout class >> subclassDefiningSymbol [
 	^ #immediateSubclass:
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGImmediateLayout >> isImmediateLayout [
 
 	^ true

--- a/src/Ring-Core/RGIncompatibleBehaviorTypeError.class.st
+++ b/src/Ring-Core/RGIncompatibleBehaviorTypeError.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RGIncompatibleBehaviorTypeError,
-	#superclass : #Error,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGIncompatibleBehaviorTypeError',
+	#superclass : 'Error',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGIncompatibleBehaviorTypeError >> messageText [
 
 	^ 'This message cannot be sent. Incompatible behavior type.'

--- a/src/Ring-Core/RGIndexedSlot.class.st
+++ b/src/Ring-Core/RGIndexedSlot.class.st
@@ -1,5 +1,7 @@
 Class {
-	#name : #RGIndexedSlot,
-	#superclass : #RGSlot,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGIndexedSlot',
+	#superclass : 'RGSlot',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }

--- a/src/Ring-Core/RGInstanceVariableSlot.class.st
+++ b/src/Ring-Core/RGInstanceVariableSlot.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #RGInstanceVariableSlot,
-	#superclass : #RGIndexedSlot,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGInstanceVariableSlot',
+	#superclass : 'RGIndexedSlot',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGInstanceVariableSlot >> allowsShadowing [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGInstanceVariableSlot >> needsFullDefinition [
 	"I am just a backward compatible ivar slot and can use simple definitions.
 	 Note: my subclasses need full definitions"

--- a/src/Ring-Core/RGJoiningError.class.st
+++ b/src/Ring-Core/RGJoiningError.class.st
@@ -1,5 +1,7 @@
 Class {
-	#name : #RGJoiningError,
-	#superclass : #Error,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGJoiningError',
+	#superclass : 'Error',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }

--- a/src/Ring-Core/RGLayout.class.st
+++ b/src/Ring-Core/RGLayout.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RGLayout,
-	#superclass : #RGObject,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGLayout',
+	#superclass : 'RGObject',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #description }
+{ #category : 'description' }
 RGLayout class >> subclassDefiningSymbol [
 	"Answer a keyword that describes the receiver's kind of subclass
 	Note: this is for printing the ST80 style class definiton."
@@ -12,7 +14,7 @@ RGLayout class >> subclassDefiningSymbol [
 	^ #subclass:
 ]
 
-{ #category : #'managing container' }
+{ #category : 'managing container' }
 RGLayout >> addoptToParentStub [
 
 	super addoptToParentStub.
@@ -20,107 +22,107 @@ RGLayout >> addoptToParentStub [
 	self parent behaviorStrategy pvtLayout: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGLayout >> allSlots [
 
 	^ {  }
 ]
 
-{ #category : #'managing container' }
+{ #category : 'managing container' }
 RGLayout >> defaultParentStub [
 
 	^ self defaultClassStub
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGLayout >> instVarNames [
 	^ {}
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGLayout >> isBitsLayout [
 
 	^ false
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGLayout >> isByteLayout [
 
 	^ false
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGLayout >> isCompiledMethodLayout [
 
 	^ false
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGLayout >> isEmptyLayout [
 
 	^ false
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGLayout >> isEphemeronLayout [
 
 	^ false
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGLayout >> isFixedLayout [
 
 	^ false
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGLayout >> isImmediateLayout [
 
 	^ false
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGLayout >> isLayout [
 
 	^true
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGLayout >> isObjectLayout [
 
 	^ false
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGLayout >> isPointerLayout [
 
 	^ false
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGLayout >> isVariableLayout [
 
 	^ false
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGLayout >> isWeakLayout [
 
 	^ false
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGLayout >> isWordLayout [
 
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGLayout >> layoutName [
 	^ (self class name allButFirst: 2) asSymbol
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGLayout >> resolveSlot: aName ifFound: foundBlock ifNone: exceptionBlock [
 	^exceptionBlock value
 ]

--- a/src/Ring-Core/RGMergeError.class.st
+++ b/src/Ring-Core/RGMergeError.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #RGMergeError,
-	#superclass : #Error,
+	#name : 'RGMergeError',
+	#superclass : 'Error',
 	#instVars : [
 		'property',
 		'target',
 		'source'
 	],
-	#category : #'Ring-Core-Kernel'
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGMergeError class >> property: propertySymbol target: targetDefinition source: sourceDefinition [
 
 	^ self new
@@ -19,32 +21,32 @@ RGMergeError class >> property: propertySymbol target: targetDefinition source: 
 		signal
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGMergeError >> property [
 	^ property
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGMergeError >> property: anObject [
 	property := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGMergeError >> source [
 	^ source
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGMergeError >> source: anObject [
 	source := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGMergeError >> target [
 	^ target
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGMergeError >> target: anObject [
 	target := anObject
 ]

--- a/src/Ring-Core/RGMetaclass.class.st
+++ b/src/Ring-Core/RGMetaclass.class.st
@@ -2,12 +2,14 @@
 A factory that produces instances of RG2Behavior composed with RGMetaclassStrategy
 "
 Class {
-	#name : #RGMetaclass,
-	#superclass : #RGBehaviorFactory,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGMetaclass',
+	#superclass : 'RGBehaviorFactory',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGMetaclass class >> newStrategy [
 
 	^ RGMetaclassStrategy unresolved

--- a/src/Ring-Core/RGMetaclassStrategy.class.st
+++ b/src/Ring-Core/RGMetaclassStrategy.class.st
@@ -1,74 +1,76 @@
 Class {
-	#name : #RGMetaclassStrategy,
-	#superclass : #RGClassDescriptionStrategy,
+	#name : 'RGMetaclassStrategy',
+	#superclass : 'RGClassDescriptionStrategy',
 	#instVars : [
 		'baseClass'
 	],
-	#category : #'Ring-Core-Kernel'
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 RGMetaclassStrategy >> acceptVisitor: aVisitor [
 
 	^ aVisitor visitMetaclass: self owner
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassStrategy >> allClassVarNames [
 
 	self owner instanceSide allClassVarNames
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassStrategy >> baseBehavior [
 
 	^ self baseClass
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassStrategy >> baseClass [
 
 	^ self backend forBehavior baseClassFor: self owner
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassStrategy >> baseClass: anRGClass [
 
 	self backend forBehavior setBaseClassFor: self owner to: anRGClass
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassStrategy >> bindingOf: varName [
 
 	^ self baseClass bindingOf: varName
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassStrategy >> category [
 
 	^ self baseClass category
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassStrategy >> classVarNames [
 
 	^ self instanceSide classVarNames
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassStrategy >> comment [
 
 	^ self baseClass comment
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassStrategy >> defaultMetaClass [
 
 	"will be set correctly together with baseClass"
 	^ RGUnresolvedValue new default: nil
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassStrategy >> definition [
 	"Refer to the comment in ClassDescription|definition."
 
@@ -94,7 +96,7 @@ RGMetaclassStrategy >> definition [
 							nextPutAll: self owner slotDefinitionString]]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGMetaclassStrategy >> initialize [
 
 	baseClass := RGUnresolvedValue recursive.
@@ -102,36 +104,36 @@ RGMetaclassStrategy >> initialize [
 	super initialize
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassStrategy >> innerBindingOf: varName [
 
 	^self instanceSide innerBindingOf: varName
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassStrategy >> instanceSide [
 	^ self baseClass
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassStrategy >> isMeta [
 
 	^true
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassStrategy >> isMetaclass [
 
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGMetaclassStrategy >> isMetaclassStrategy [
 
 	^ true
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassStrategy >> makeResolved [
 
 	"try to set the correct name before resolving of it"
@@ -144,20 +146,20 @@ RGMetaclassStrategy >> makeResolved [
 	baseClass := self baseClass
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassStrategy >> metaclass [
 
 	"temporary"
 	^ self
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassStrategy >> package [
 
 	^ self baseClass package
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassStrategy >> pvtAsMetaclassTrait [
 
 	| newMetaclassTrait |
@@ -176,13 +178,13 @@ RGMetaclassStrategy >> pvtAsMetaclassTrait [
 	^ newMetaclassTrait
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassStrategy >> pvtBaseClass [
 
 	^ baseClass value
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassStrategy >> pvtBaseClass: anRGClass [
 
 	self owner environment verifyOwnership: anRGClass.
@@ -190,7 +192,7 @@ RGMetaclassStrategy >> pvtBaseClass: anRGClass [
 	^ baseClass := anRGClass
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassStrategy >> pvtResolvableProperties [
 
 	^ super pvtResolvableProperties, {
@@ -198,19 +200,19 @@ RGMetaclassStrategy >> pvtResolvableProperties [
    	}
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassStrategy >> referencedBehaviors [
 
 	^ super referencedBehaviors, {self baseClass}
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassStrategy >> sibling [
 
 	^ self baseClass
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGMetaclassStrategy >> storeName [
 
 	^ 'RGMetaclass'

--- a/src/Ring-Core/RGMetaclassTrait.class.st
+++ b/src/Ring-Core/RGMetaclassTrait.class.st
@@ -2,24 +2,26 @@
 A factory that produces instances of RG2Behavior composed with RGMetaclassTraitStrategy
 "
 Class {
-	#name : #RGMetaclassTrait,
-	#superclass : #RGBehaviorFactory,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGMetaclassTrait',
+	#superclass : 'RGBehaviorFactory',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGMetaclassTrait class >> newStrategy [
 
 	^ RGMetaclassTraitStrategy unresolved
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGMetaclassTrait class >> newStrategyFor: anRGEnvironment [
 
 	^ (self strategyClassForVersion: anRGEnvironment version) unresolved
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGMetaclassTrait class >> strategyClassForVersion: aVersionNumber [
 
 	^ (aVersionNumber <= 6)

--- a/src/Ring-Core/RGMetaclassTraitStrategy.class.st
+++ b/src/Ring-Core/RGMetaclassTraitStrategy.class.st
@@ -1,49 +1,51 @@
 Class {
-	#name : #RGMetaclassTraitStrategy,
-	#superclass : #RGTraitDescriptionStrategy,
+	#name : 'RGMetaclassTraitStrategy',
+	#superclass : 'RGTraitDescriptionStrategy',
 	#instVars : [
 		'baseTrait'
 	],
-	#category : #'Ring-Core-Kernel'
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 RGMetaclassTraitStrategy >> acceptVisitor: aVisitor [
 
 	^ aVisitor visitClassTrait: self owner
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitStrategy >> baseBehavior [
 
 	^ self baseTrait
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitStrategy >> baseTrait [
 
 	^ self backend forBehavior metaclassTraitBaseTraitFor: self owner
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitStrategy >> baseTrait: anRGClass [
 
 	self backend forBehavior setMetaclassTraitBaseTraitFor: self to: anRGClass
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitStrategy >> category [
 
 	^ self baseTrait category
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitStrategy >> comment [
 
 	^ self baseTrait comment
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitStrategy >> definition [
 	^String streamContents: [:stream |
 		stream
@@ -54,31 +56,31 @@ RGMetaclassTraitStrategy >> definition [
 			nextPutAll: self owner traitCompositionString]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitStrategy >> instanceSide [
 
 	^ self baseTrait
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitStrategy >> isMeta [
 
 	^true
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitStrategy >> isMetaclassTrait [
 
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGMetaclassTraitStrategy >> isMetaclassTraitStrategy [
 
 	^ true
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitStrategy >> makeResolved [
 
 
@@ -92,19 +94,19 @@ RGMetaclassTraitStrategy >> makeResolved [
 	baseTrait := self baseTrait markAsRingResolved
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitStrategy >> package [
 
 	^ self baseTrait package
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitStrategy >> pvtBaseTrait [
 
 	^ baseTrait value
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitStrategy >> pvtBaseTrait: anRGTrait [
 
 	self owner environment verifyOwnership: anRGTrait.
@@ -112,7 +114,7 @@ RGMetaclassTraitStrategy >> pvtBaseTrait: anRGTrait [
 	^ baseTrait := anRGTrait
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitStrategy >> pvtResolvableProperties [
 
 	^ super pvtResolvableProperties, {
@@ -120,25 +122,25 @@ RGMetaclassTraitStrategy >> pvtResolvableProperties [
    	}
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitStrategy >> referencedBehaviors [
 
 	^ super referencedBehaviors, {self baseTrait}
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitStrategy >> sibling [
 
 	^ self baseTrait
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGMetaclassTraitStrategy >> storeName [
 
 	^ 'RGMetaclassTrait'
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitStrategy >> traitTransformationString [
 
 	^ self owner name

--- a/src/Ring-Core/RGMetaclassTraitV2Strategy.class.st
+++ b/src/Ring-Core/RGMetaclassTraitV2Strategy.class.st
@@ -1,62 +1,64 @@
 Class {
-	#name : #RGMetaclassTraitV2Strategy,
-	#superclass : #RGTraitV2DescriptionStrategy,
+	#name : 'RGMetaclassTraitV2Strategy',
+	#superclass : 'RGTraitV2DescriptionStrategy',
 	#instVars : [
 		'baseClass'
 	],
-	#category : #'Ring-Core-Kernel'
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitV2Strategy >> baseBehavior [
 
 	^ self baseClass
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitV2Strategy >> baseClass [
 
 	^ self backend forBehavior baseClassFor: self owner
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitV2Strategy >> baseClass: anRGClass [
 
 	self backend forBehavior setBaseClassFor: self owner to: anRGClass
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitV2Strategy >> bindingOf: varName [
 
 	^ self baseClass bindingOf: varName
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitV2Strategy >> category [
 
 	^ self baseClass category
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitV2Strategy >> classVarNames [
 
 	^ self instanceSide classVarNames
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitV2Strategy >> comment [
 
 	^ self baseClass comment
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitV2Strategy >> defaultMetaClass [
 
 	"will be set correctly together with baseClass"
 	^ RGUnresolvedValue new default: nil
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitV2Strategy >> definition [
 	^String streamContents: [:stream |
 		stream
@@ -79,7 +81,7 @@ RGMetaclassTraitV2Strategy >> definition [
 								nextPutAll: self owner slotDefinitionString]]]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGMetaclassTraitV2Strategy >> initialize [
 
 	baseClass := RGUnresolvedValue recursive.
@@ -87,30 +89,30 @@ RGMetaclassTraitV2Strategy >> initialize [
 	super initialize
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitV2Strategy >> instanceSide [
 	^ self baseClass
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitV2Strategy >> isMeta [
 
 	^true
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitV2Strategy >> isMetaclass [
 
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGMetaclassTraitV2Strategy >> isMetaclassStrategy [
 
 	^ true
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitV2Strategy >> makeResolved [
 
 	"try to set the correct name before resolving of it"
@@ -123,20 +125,20 @@ RGMetaclassTraitV2Strategy >> makeResolved [
 	baseClass := self baseClass markAsRingResolved
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitV2Strategy >> metaclass [
 
 	"temporary"
 	^ self
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitV2Strategy >> package [
 
 	^ self baseClass package
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitV2Strategy >> pvtAsMetaclassTrait [
 
 	| newMetaclassTrait |
@@ -155,13 +157,13 @@ RGMetaclassTraitV2Strategy >> pvtAsMetaclassTrait [
 	^ newMetaclassTrait
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitV2Strategy >> pvtBaseClass [
 
 	^ baseClass value
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitV2Strategy >> pvtBaseClass: anRGClass [
 
 	self owner environment verifyOwnership: anRGClass.
@@ -169,7 +171,7 @@ RGMetaclassTraitV2Strategy >> pvtBaseClass: anRGClass [
 	^ baseClass := anRGClass
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitV2Strategy >> pvtResolvableProperties [
 
 	^ super pvtResolvableProperties, {
@@ -177,19 +179,19 @@ RGMetaclassTraitV2Strategy >> pvtResolvableProperties [
    	}
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitV2Strategy >> referencedBehaviors [
 
 	^ super referencedBehaviors, {self baseClass}
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGMetaclassTraitV2Strategy >> sibling [
 
 	^ self baseClass
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGMetaclassTraitV2Strategy >> storeName [
 
 	^ 'RGMetaclass'

--- a/src/Ring-Core/RGMethod.class.st
+++ b/src/Ring-Core/RGMethod.class.st
@@ -74,8 +74,8 @@ Example:
 
 "
 Class {
-	#name : #RGMethod,
-	#superclass : #RGElement,
+	#name : 'RGMethod',
+	#superclass : 'RGElement',
 	#instVars : [
 		'sourceCode',
 		'package',
@@ -83,10 +83,12 @@ Class {
 		'time',
 		'tags'
 	],
-	#category : #'Ring-Core-Kernel'
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'managing container' }
+{ #category : 'managing container' }
 RGMethod >> addoptToParentStub [
 
 	super addoptToParentStub.
@@ -94,44 +96,44 @@ RGMethod >> addoptToParentStub [
 	self parent pvtAddLocalMethod: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGMethod >> argumentNames [
 
 	^ self ast argumentNames
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGMethod >> ast [
 	"Answer my AST with semantic analysis. See #parseTree."
 
 	^ self propertyNamed: #ast ifAbsentPut: [ self parseTree doSemanticAnalysisIn: self methodClass ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RGMethod >> astFromSource [
 
 	^ RBParser parseMethod: self sourceCode
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGMethod >> author [
 
 	^ self backend forBehavior authorFor: self
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGMethod >> author: aString [
 
 	self backend forBehavior setAuthorFor: self to: aString
 ]
 
-{ #category : #'backward compatibility' }
+{ #category : 'backward compatibility' }
 RGMethod >> category [
 
 	^ self protocol
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RGMethod >> changeProtocolDuring: aBlock [
 
 	| oldProtocol |
@@ -141,68 +143,68 @@ RGMethod >> changeProtocolDuring: aBlock [
 	self announce: (MethodRecategorized method: self oldProtocol: oldProtocol)
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGMethod >> cleanTags [
 
 	self changeProtocolDuring: [
 		self cleanTagsWithoutAnnouncemnt ]
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGMethod >> cleanTagsWithoutAnnouncemnt [
 
 	self backend forMethod cleanMethodTagsFor: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGMethod >> compiledMethod [
 	^ self
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGMethod >> defaultAuthor [
 
 	^ ''
 ]
 
-{ #category : #'managing container' }
+{ #category : 'managing container' }
 RGMethod >> defaultParentStub [
 
 	^ self defaultClassStub
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGMethod >> defaultSourceCode [
 
 	^ self sourceCodeForNoSelector
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGMethod >> defaultTags [
 
 	^ Set new
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGMethod >> defaultTime [
 
 	^ DateAndTime new
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGMethod >> fullName [
 	"Keeps a unique description for the receiver. As annotation to avoid converting each time is invoked"
 
 	^ (self parent name, '>>#', self selector) asSymbol
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGMethod >> hasSourceCode [
 
 	^ self backend forMethod hasSourceCodeFor: self
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGMethod >> initialize [
 
 	super initialize.
@@ -214,7 +216,7 @@ RGMethod >> initialize [
 	time := self unresolvedValue: self defaultTime
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGMethod >> initializeUnresolved [
 
 	super initializeUnresolved.
@@ -226,43 +228,43 @@ RGMethod >> initializeUnresolved [
 	time := self unresolvedValue: self defaultTime
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGMethod >> isExtension [
 	"The receiver is an extension when is defined in a different package to the one of its parent"
 
 	^ self parent package ~= self package
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGMethod >> isFromTrait [
 	^ self parent isTrait
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGMethod >> isLiteralMethod [
 	"Ring methods does not know how to detect if they are literal"
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGMethod >> isMetaSide [
 
 	^ self parent isMeta
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGMethod >> isMethod [
 
 	^true
 ]
 
-{ #category : #'queries - tags' }
+{ #category : 'queries - tags' }
 RGMethod >> isTaggedWith: aSymbol [
 
 	^self tags includes: aSymbol
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGMethod >> makeResolved [
 
 	super makeResolved.
@@ -274,24 +276,24 @@ RGMethod >> makeResolved [
 	tags := self tags markAsRingResolved
 ]
 
-{ #category : #'queries - class' }
+{ #category : 'queries - class' }
 RGMethod >> methodClass [
 
 	^ self parent
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGMethod >> numArgs [
 	^ self selector asString numArgs
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGMethod >> package [
 
 	^ self backend forMethod methodPackageFor: self
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGMethod >> package: anRGPackage [
 
 	self backend forMethod setMethodPackageFor: self to: anRGPackage.
@@ -300,7 +302,7 @@ RGMethod >> package: anRGPackage [
 		ifFalse: [ self package addExtensionMethod: self ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGMethod >> parseTree [
 	| tree |
 	tree := RBParser
@@ -310,7 +312,7 @@ RGMethod >> parseTree [
 	^ tree
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 RGMethod >> printOn: aStream [
 
 	self parent name ifNotNil: [
@@ -319,7 +321,7 @@ RGMethod >> printOn: aStream [
 	aStream print: self selector
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGMethod >> protocol [
 
 	| methodTags |
@@ -330,26 +332,26 @@ RGMethod >> protocol [
 		ifNotEmpty: [ methodTags sorted first ]
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGMethod >> protocol: aSymbol [
 
 	self cleanTagsWithoutAnnouncemnt.
 	self tagWith: aSymbol
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGMethod >> pvtAuthor [
 
 	^ author value
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGMethod >> pvtAuthor: aString [
 
 	^ author := aString
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGMethod >> pvtCleanTags [
 
 	tags := self defaultTags.
@@ -357,13 +359,13 @@ RGMethod >> pvtCleanTags [
 	"TODO:Announce if not empty"
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGMethod >> pvtPackage [
 
 	^ package value
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGMethod >> pvtPackage: anRGPackageDefinition [
 
 	self environment verifyOwnership: anRGPackageDefinition.
@@ -371,7 +373,7 @@ RGMethod >> pvtPackage: anRGPackageDefinition [
 	^ package := anRGPackageDefinition
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGMethod >> pvtResolvableProperties [
 
 	^ super pvtResolvableProperties, {
@@ -383,7 +385,7 @@ RGMethod >> pvtResolvableProperties [
 	}
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RGMethod >> pvtSafeSourceCode [
 
 	| aStringOrUnresolved |
@@ -396,19 +398,19 @@ RGMethod >> pvtSafeSourceCode [
 		ifTrue: [ aStringOrUnresolved value ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RGMethod >> pvtSourceCode [
 
 	^ sourceCode
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RGMethod >> pvtSourceCode: anObject [
 
 	sourceCode := anObject
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGMethod >> pvtTagWith: aSymbol [
 
 	tags isRingResolved ifFalse: [
@@ -417,25 +419,25 @@ RGMethod >> pvtTagWith: aSymbol [
 	tags add: aSymbol
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RGMethod >> pvtTagsDo: aBlock [
 
 	^ tags value do: aBlock
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGMethod >> pvtTime [
 
 	^ time value
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGMethod >> pvtTime: aDateAndTime [
 
 	^ time := aDateAndTime
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGMethod >> pvtUntagFrom: aSymbol [
 
 	(tags value includes: aSymbol)
@@ -444,26 +446,26 @@ RGMethod >> pvtUntagFrom: aSymbol [
 	"TODO:Announce"
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 RGMethod >> removeFromSystem [
 
 	^ self parent removeLocalMethod: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGMethod >> selector [
 	"Retrieves the name of the method"
 
 	^ self name asSymbol
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGMethod >> sourceCode [
 
 	^ self backend forMethod sourceCodeFor: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGMethod >> sourceCode: anObject [
 
 	"ATTENTION: There is no check here if the selector is changed!"
@@ -472,19 +474,19 @@ RGMethod >> sourceCode: anObject [
 	"TODO: announcements"
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGMethod >> sourceCodeForNoSelector [
 
 	^ 'unresolvedMessage', String cr, String tab, '"source code for the method model not set"'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGMethod >> sourceCodeForNoSource [
 
 	^ self selector asMethodPreamble, String cr, String tab, '"source code for the method model not set"'
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGMethod >> tagWith: aSymbol [
 
 	self changeProtocolDuring: [
@@ -492,7 +494,7 @@ RGMethod >> tagWith: aSymbol [
 		self parent addProtocol: aSymbol ]
 ]
 
-{ #category : #'accessing - model' }
+{ #category : 'accessing - model' }
 RGMethod >> tags [
 
 	| allTags |
@@ -501,25 +503,25 @@ RGMethod >> tags [
 	^ allTags asArray
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGMethod >> tagsDo: aBlock [
 
 	self backend forMethod tagsForMethod: self do: aBlock
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGMethod >> time [
 
 	^ self backend forBehavior timeFor: self
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGMethod >> time: aDateAndTime [
 
 	self backend forBehavior setTimeFor: self to: aDateAndTime
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGMethod >> untagFrom: aSymbol [
 
 	self backend forMethod untagMethod: self from: aSymbol

--- a/src/Ring-Core/RGNotFoundError.class.st
+++ b/src/Ring-Core/RGNotFoundError.class.st
@@ -1,5 +1,7 @@
 Class {
-	#name : #RGNotFoundError,
-	#superclass : #Error,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGNotFoundError',
+	#superclass : 'Error',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }

--- a/src/Ring-Core/RGObject.class.st
+++ b/src/Ring-Core/RGObject.class.st
@@ -3,23 +3,25 @@ I am the root class of the Ring meta-model definitions.
 A Ring definition has a name, properties and knows its environment
 "
 Class {
-	#name : #RGObject,
-	#superclass : #Object,
+	#name : 'RGObject',
+	#superclass : 'Object',
 	#instVars : [
 		'properties',
 		'name',
 		'parent'
 	],
-	#category : #'Ring-Core-Kernel'
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGObject class >> asYetUnclassifiedProtocolName [
 
 	^ Protocol unclassified
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGObject class >> named: aString [
 
 	"create model in its own environment"
@@ -29,7 +31,7 @@ RGObject class >> named: aString [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGObject class >> named: aName parent: anRGObject [
 
 	^self basicNew
@@ -39,7 +41,7 @@ RGObject class >> named: aName parent: anRGObject [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGObject class >> parent: anRGObject [
 
 	^self basicNew
@@ -48,13 +50,13 @@ RGObject class >> parent: anRGObject [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGObject class >> unnamed [
 
 	^self new
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGObject class >> unresolved [
 
 	^ self basicNew
@@ -62,7 +64,7 @@ RGObject class >> unresolved [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGObject class >> unresolvedNamed: aString withParent: anRGDefintion [
 
 	^self basicNew
@@ -72,7 +74,7 @@ RGObject class >> unresolvedNamed: aString withParent: anRGDefintion [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGObject class >> unresolvedWithParent: anRGDefintion [
 
 	^self basicNew
@@ -81,47 +83,47 @@ RGObject class >> unresolvedWithParent: anRGDefintion [
 		yourself
 ]
 
-{ #category : #'managing container' }
+{ #category : 'managing container' }
 RGObject >> addoptToParentStub [
 ]
 
-{ #category : #announcements }
+{ #category : 'announcements' }
 RGObject >> announce: anAnnouncement [
 
 	self environment announcer announce: anAnnouncement
 ]
 
-{ #category : #announcements }
+{ #category : 'announcements' }
 RGObject >> announcer [
 
 	^ self environment announcer
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 RGObject >> asRGDefinition [
 
 	^ self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGObject >> ask [
 
 	^ self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGObject >> backend [
 
 	^ self environment backend
 ]
 
-{ #category : #events }
+{ #category : 'events' }
 RGObject >> child: aChildDefinition renamedFrom: oldName to: newName [
 
 	"react on renaming of a child definition. By default do nothing"
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 RGObject >> copyForBehaviorDefinition [
 
 	"returns copy of the behavior model that contains only information related to the behavior
@@ -129,18 +131,18 @@ RGObject >> copyForBehaviorDefinition [
 	^ self shallowCopy copyForBehaviorDefinitionPostCopy
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 RGObject >> copyForBehaviorDefinitionPostCopy [
 	super postCopy
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 RGObject >> copyPropertiesFrom: anRGObject [
 
 	properties := anRGObject properties copy
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 RGObject >> copyWithParent: newParent [
 
 	"create copy of the definition and then assign the new parent"
@@ -150,13 +152,13 @@ RGObject >> copyWithParent: newParent [
 		yourself
 ]
 
-{ #category : #'hierarchy - defaults' }
+{ #category : 'hierarchy - defaults' }
 RGObject >> defaultClassStub [
 
 	^ RGClass unresolved
 ]
 
-{ #category : #'hierarchy - defaults' }
+{ #category : 'hierarchy - defaults' }
 RGObject >> defaultCommentStubIn: anRGBehavior [
 
 	^ RGComment unresolved
@@ -164,19 +166,19 @@ RGObject >> defaultCommentStubIn: anRGBehavior [
 		yourself
 ]
 
-{ #category : #'hierarchy - defaults' }
+{ #category : 'hierarchy - defaults' }
 RGObject >> defaultEnvironmentStub [
 
 	^ RGEnvironment unresolved
 ]
 
-{ #category : #'hierarchy - defaults' }
+{ #category : 'hierarchy - defaults' }
 RGObject >> defaultFixedLayoutStub [
 
 	^ RGFixedLayout unresolved
 ]
 
-{ #category : #'hierarchy - defaults' }
+{ #category : 'hierarchy - defaults' }
 RGObject >> defaultFixedLayoutStubIn: anRGBehavior [
 
 	^ RGFixedLayout unresolved
@@ -184,7 +186,7 @@ RGObject >> defaultFixedLayoutStubIn: anRGBehavior [
 		yourself
 ]
 
-{ #category : #'hierarchy - defaults' }
+{ #category : 'hierarchy - defaults' }
 RGObject >> defaultPackageStubIn: anRGEnvironment [
 
 	^ RGPackage unresolved
@@ -192,19 +194,19 @@ RGObject >> defaultPackageStubIn: anRGEnvironment [
 		yourself
 ]
 
-{ #category : #'managing container' }
+{ #category : 'managing container' }
 RGObject >> defaultParentStub [
 
 	self subclassResponsibility
 ]
 
-{ #category : #'hierarchy - defaults' }
+{ #category : 'hierarchy - defaults' }
 RGObject >> defaultTraitCompositionStub [
 
 	^ RGTraitComposition unresolved
 ]
 
-{ #category : #'hierarchy - defaults' }
+{ #category : 'hierarchy - defaults' }
 RGObject >> defaultTraitCompositionStubIn: anRGBehavior [
 
 	^ RGTraitComposition unresolved
@@ -212,31 +214,31 @@ RGObject >> defaultTraitCompositionStubIn: anRGBehavior [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGObject >> environment [
 
 	^ self propertyNamed: #environment ifAbsent: [ self parent environment ]
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 RGObject >> fullCopy [
 
 	^ self copy
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGObject >> fullName [
 
 	^self name
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 RGObject >> hasProperties [
 
 	^ properties isEmptyOrNil not
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 RGObject >> hasProperty: propertyName [
 
 	^ self hasProperties
@@ -244,37 +246,37 @@ RGObject >> hasProperty: propertyName [
 		ifFalse:[ false ]
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGObject >> hasResolved: propertySymbol [
 
 	^ self resolvedProperties includes: propertySymbol
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGObject >> hasResolvedAll: aCollectionOfSymbols [
 
 	^ self resolvedProperties includesAll: aCollectionOfSymbols
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGObject >> hasResolvedName [
 
 	^ self hasResolved: #name
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGObject >> hasUnresolved: propertySymbol [
 
 	^ (self resolvedProperties includes: propertySymbol) not
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGObject >> hasUnresolvedAll: aCollectionOfSymbols [
 
 	^ (self resolvedProperties includesAll: aCollectionOfSymbols) not
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGObject >> initialize [
 
 	super initialize.
@@ -282,128 +284,128 @@ RGObject >> initialize [
 	name := self unresolvedValue: self unresolvedName
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGObject >> initializeUnresolved [
 
 	self propertyNamed: #resolved put: false.
 	name := self unresolvedValue: self unresolvedName
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGObject >> isComment [
 
 	^false
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGObject >> isEnvironment [
 
 	^false
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGObject >> isGlobalVariable [
 
 	^false
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGObject >> isLayout [
 
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGObject >> isMeta [
 
 	^ false
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGObject >> isMetaclass [
 
 	^ false
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGObject >> isMetaclassTrait [
 
 	^ false
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGObject >> isMethod [
 
 	^false
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGObject >> isPackage [
 
 	^false
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGObject >> isProtocol [
 
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGObject >> isRGObject [
 
 	^true
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGObject >> isRingFullyResolved [
 
 	^ self backend hasFullyResolved: self
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGObject >> isRingFullyUnresolved [
 
 	^ self backend hasFullyUnresolved: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGObject >> isRingResolved [
 
 	^ self propertyNamed: #resolved ifAbsent: [ true ]
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGObject >> isSlot [
 
 	^ false
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGObject >> isTraitAlias [
 
 	^ false
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGObject >> isTraitComposition [
 
 	^ false
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGObject >> isTraitExclusion [
 
 	^ false
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGObject >> isTraitTransformation [
 
 	^ false
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGObject >> isVariable [
 
 	"is the definition a variable class?"
@@ -411,7 +413,7 @@ RGObject >> isVariable [
 	^ false
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGObject >> makeResolved [
 
 	self markAsRingResolved.
@@ -419,19 +421,19 @@ RGObject >> makeResolved [
 	name := self name markAsRingResolved
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGObject >> markAsRingResolved [
 
 	self propertyNamed: #resolved put: true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGObject >> name [
 
 	^ (self backend nameFor: self) orDefaultForUnresolved
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGObject >> name: aString [
 
 	| oldName |
@@ -441,13 +443,13 @@ RGObject >> name: aString [
 	self parent child: self renamedFrom: oldName to: aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGObject >> package [
 
 	^ self parent package
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGObject >> parent [
 	"The parent of a class definition element: method, comment and variable is the class definition. This method retrieves the class that defines such element"
 
@@ -458,7 +460,7 @@ RGObject >> parent [
 	^ parent
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGObject >> parent: anRGBehavior [
 
 	"If possible, do not use this method directly."
@@ -467,7 +469,7 @@ RGObject >> parent: anRGBehavior [
 	"self addoptToParentStub."
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 RGObject >> postCopy [
 
 	super postCopy.
@@ -475,13 +477,13 @@ RGObject >> postCopy [
 	properties := properties copy
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 RGObject >> properties [
 
 	^ properties ifNil: [ properties := IdentityDictionary new ]
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 RGObject >> propertyNamed: propertyName [
 
 	^ self
@@ -489,7 +491,7 @@ RGObject >> propertyNamed: propertyName [
 		ifAbsent: [ nil ]
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 RGObject >> propertyNamed: annotationName ifAbsent: exceptionBlock [
 
 	^ self properties
@@ -497,7 +499,7 @@ RGObject >> propertyNamed: annotationName ifAbsent: exceptionBlock [
 			ifAbsent: [ exceptionBlock value ]
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 RGObject >> propertyNamed: annotationName ifAbsentPut: blockValue [
 
 	^ self properties
@@ -505,7 +507,7 @@ RGObject >> propertyNamed: annotationName ifAbsentPut: blockValue [
 		ifAbsentPut: blockValue
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 RGObject >> propertyNamed: annotationName put: value [
 
 	self properties
@@ -513,7 +515,7 @@ RGObject >> propertyNamed: annotationName put: value [
 		put: value
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 RGObject >> propertyNames [
 
 	self hasProperties
@@ -521,62 +523,62 @@ RGObject >> propertyNames [
 	^ properties keys
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGObject >> pvtFullyResolved [
 
 	^ (self pvtResolvableProperties collect: [:each | each value]) allSatisfy: [:each | each isRingFullyResolved]
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGObject >> pvtFullyUnresolved [
 
 	^ (self pvtResolvableProperties collect: [:each | each value]) noneSatisfy: [:each | each isRingFullyResolved ]
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGObject >> pvtName [
 
 	^ name
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGObject >> pvtName: aString [
 
 	 name := aString
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RGObject >> pvtParent: anRGObject [
 
 	parent := anRGObject
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGObject >> pvtResolvableProperties [
 
 	^ { #name -> name }
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGObject >> pvtResolvedProperties [
 
 	^ self pvtResolvableProperties select: [:each | each value isRingResolved ] thenCollect: #key
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGObject >> pvtUnresolvedProperties [
 
 	^ self pvtResolvableProperties select: [:each | each value isRingResolved not ] thenCollect: #key
 ]
 
-{ #category : #properties }
+{ #category : 'properties' }
 RGObject >> removePropertyNamed: propertyName [
 
 	(self hasProperty: propertyName) ifTrue: [
 		properties removeKey: propertyName ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGObject >> resolvedNameOrNil [
 
 	^ self hasResolvedName
@@ -584,13 +586,13 @@ RGObject >> resolvedNameOrNil [
 		ifFalse: [ nil ]
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGObject >> resolvedProperties [
 
 	^ (self backend resolvedPropertiesFor: self)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGObject >> unresolveName [
 
 	| oldName result |
@@ -602,25 +604,25 @@ RGObject >> unresolveName [
 	^ result
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 RGObject >> unresolvedName [
 
 	^ #unresolved
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGObject >> unresolvedProperties [
 
 	^ (self backend unresolvedPropertiesFor: self)
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 RGObject >> unresolvedValue [
 
 	^ RGUnresolvedValue new
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 RGObject >> unresolvedValue: aDefaultValue [
 
 	^ RGUnresolvedValue new

--- a/src/Ring-Core/RGObjectLayout.class.st
+++ b/src/Ring-Core/RGObjectLayout.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #RGObjectLayout,
-	#superclass : #RGLayout,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGObjectLayout',
+	#superclass : 'RGLayout',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGObjectLayout >> isObjectLayout [
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGObjectLayout >> slots [
 
 	"only for API compatibility purposes"

--- a/src/Ring-Core/RGPackage.class.st
+++ b/src/Ring-Core/RGPackage.class.st
@@ -5,35 +5,37 @@ A package can also know in which package is defined
 
 "
 Class {
-	#name : #RGPackage,
-	#superclass : #RGObject,
+	#name : 'RGPackage',
+	#superclass : 'RGObject',
 	#instVars : [
 		'definedBehaviors',
 		'extensionMethods',
 		'tagsForClasses'
 	],
-	#category : #'Ring-Core-Kernel'
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGPackage >> addClassTag: sSymbol [
 
 	self backend forPackage addClassTag: sSymbol to: self
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGPackage >> addDefinedBehavior: anRGBehavior [
 
 	self backend forPackage addDefinedBehavior: anRGBehavior to: self
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGPackage >> addExtensionMethod: anRGMethod [
 
 	self backend forPackage addExtensionMethod: anRGMethod to: self
 ]
 
-{ #category : #'managing container' }
+{ #category : 'managing container' }
 RGPackage >> addoptToParentStub [
 
 	self isRingResolved ifFalse: [ ^ self ].
@@ -43,81 +45,81 @@ RGPackage >> addoptToParentStub [
 	^ self parent addPackage: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGPackage >> categories [
 
 	^ self definedBehaviors collect: #category as: Set
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGPackage >> categoryName [
 
 	^ self name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGPackage >> classNames [
 
 	^ self classes collect: [ :each | each name ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGPackage >> classes [
 	"Retrieves a collection of classes defined in the receiver and classes holding extension methods"
 
 	^self definedClassesOnly, self extendedClasses
 ]
 
-{ #category : #'accessing - model' }
+{ #category : 'accessing - model' }
 RGPackage >> classesTaggedWith: aSymbol [
 
 	^ self definedBehaviors select: [ :each | each isTaggedWith: aSymbol ]
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGPackage >> cleanDefinedBehaviors [
 
 	self backend forPackage cleanDefinedBehaviorsFor: self
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGPackage >> cleanExtensionMethods [
 
 	self backend forPackage cleanExtensionMethodsFor: self
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGPackage >> cleanTagsForClasses [
 
 	self backend forPackage cleanTagsForClassesFor: self
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGPackage >> defaultDefinedBehaviors [
 
 	^ Set new
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGPackage >> defaultExtensionMethods [
 
 	^ Set new
 ]
 
-{ #category : #'managing container' }
+{ #category : 'managing container' }
 RGPackage >> defaultParentStub [
 
 	^ RGEnvironment new
 		yourself
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGPackage >> defaultTagsForClasses [
 
 	^ Set new
 ]
 
-{ #category : #'queries - behaviors' }
+{ #category : 'queries - behaviors' }
 RGPackage >> definedBehaviors [
 
 	| allDefinedBehaviors |
@@ -126,45 +128,45 @@ RGPackage >> definedBehaviors [
 	^ allDefinedBehaviors asArray
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGPackage >> definedBehaviorsDo: aBlock [
 
 	self backend forPackage definedBehaviorsFor: self do: aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGPackage >> definedClassNames [
 
 	^ self definedClassesOnly collect: [ :each | each name ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGPackage >> definedClasses [
 
 	^ self definedBehaviors
 ]
 
-{ #category : #'queries - behaviors' }
+{ #category : 'queries - behaviors' }
 RGPackage >> definedClassesOnly [
 
 	^ self definedBehaviors select: #isClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGPackage >> definedTraits [
 	"Retrieves the traits defined in the receiver"
 
 	^self definedBehaviors select: #isTrait
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGPackage >> definitionFor: aRGClassStrategy [
 	"Answer a <String>. Use aRGBehaviourStrategy to access the definition <String> for the receiver"
 
 	^ aRGClassStrategy definitionStringFor: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGPackage >> extendedBehaviors [
 
 	^ ((self extensionMethods collect: [:each | each parent]) collect: [:behavior |
@@ -173,32 +175,32 @@ RGPackage >> extendedBehaviors [
 			ifFalse: [ behavior baseClass]] as: IdentitySet) asArray
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGPackage >> extendedClasses [
 
 	^ self extendedBehaviors
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGPackage >> extendedClassesAndTraits [
 
 	^ self extendedBehaviors
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGPackage >> extendedSelectors [
 	"Retrieves the names of the methods"
 
 	^ self extensionMethods collect: [ :each | each selector ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGPackage >> extendedTraits [
 
 	^ (self extensionMethods collect: [:each | each parent]) select: [:each | each isTrait]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGPackage >> extensionMethods [
 
 	| allMethods |
@@ -207,13 +209,13 @@ RGPackage >> extensionMethods [
 	^ allMethods asArray
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGPackage >> extensionMethodsDo: aBlock [
 
 	self backend forPackage extensionMethodsFor: self do: aBlock
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGPackage >> initialize [
 
 	super initialize.
@@ -223,7 +225,7 @@ RGPackage >> initialize [
 	tagsForClasses := self unresolvedValue: self defaultTagsForClasses
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGPackage >> initializeUnresolved [
 
 	super initializeUnresolved.
@@ -233,13 +235,13 @@ RGPackage >> initializeUnresolved [
 	tagsForClasses := self unresolvedValue: self defaultTagsForClasses
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGPackage >> isPackage [
 
 	^true
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGPackage >> makeResolved [
 
 	super makeResolved.
@@ -249,7 +251,7 @@ RGPackage >> makeResolved [
 	tagsForClasses := self tagsForClasses markAsRingResolved
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGPackage >> methods [
 	"Retrieves all the methods defined in the receiver.
 	#methods holds the methods of defined classes"
@@ -257,7 +259,7 @@ RGPackage >> methods [
 	^ (self definedBehaviors flatCollect: #methods), self extensionMethods
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGPackage >> name: aString [
 
 	| oldName |
@@ -271,13 +273,13 @@ RGPackage >> name: aString [
 			newName: aString)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGPackage >> package [
 
 	^ self
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 RGPackage >> printOn: aStream [
 	aStream
 		nextPutAll: self class name;
@@ -286,7 +288,7 @@ RGPackage >> printOn: aStream [
 		nextPutAll: ')'
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGPackage >> pvtAddClassTag: aSymbol [
 
 	tagsForClasses isRingResolved ifFalse: [
@@ -295,7 +297,7 @@ RGPackage >> pvtAddClassTag: aSymbol [
 	tagsForClasses add: aSymbol
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGPackage >> pvtAddDefinedBehavior: anRGBehavior [
 
 	self environment verifyOwnership: anRGBehavior.
@@ -306,7 +308,7 @@ RGPackage >> pvtAddDefinedBehavior: anRGBehavior [
 	definedBehaviors add: anRGBehavior
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGPackage >> pvtAddExtensionMethod: aMethodDefinition [
 
 	self environment verifyOwnership: aMethodDefinition.
@@ -319,7 +321,7 @@ RGPackage >> pvtAddExtensionMethod: aMethodDefinition [
 	"TODO:Announce"
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGPackage >> pvtCleanDefinedBehaviors [
 
 	definedBehaviors := self defaultDefinedBehaviors.
@@ -327,7 +329,7 @@ RGPackage >> pvtCleanDefinedBehaviors [
 	"TODO:Announce if not empty"
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGPackage >> pvtCleanExtensionMethods [
 
 	extensionMethods := self defaultExtensionMethods.
@@ -335,7 +337,7 @@ RGPackage >> pvtCleanExtensionMethods [
 	"TODO:Announce if not empty"
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGPackage >> pvtCleanTagsForClasses [
 
 	tagsForClasses := self defaultTagsForClasses.
@@ -343,19 +345,19 @@ RGPackage >> pvtCleanTagsForClasses [
 	"TODO:Announce if not empty"
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGPackage >> pvtDefinedBehaviorsDo: aBlock [
 
 	^ definedBehaviors value do: aBlock
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGPackage >> pvtExtensionMethodsDo: aBlock [
 
 	^ extensionMethods value do: aBlock
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGPackage >> pvtRemoveClassTag: aSymbol [
 
 	tagsForClasses remove: aSymbol.
@@ -363,7 +365,7 @@ RGPackage >> pvtRemoveClassTag: aSymbol [
 	"TODO:Announce"
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGPackage >> pvtRemoveDefinedBehavior: anRGBehavior [
 
 	self environment verifyOwnership: anRGBehavior.
@@ -373,7 +375,7 @@ RGPackage >> pvtRemoveDefinedBehavior: anRGBehavior [
 	"TODO:Announce"
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGPackage >> pvtRemoveExtensionMethod: anRGMethod [
 
 	self environment verifyOwnership: anRGMethod.
@@ -383,7 +385,7 @@ RGPackage >> pvtRemoveExtensionMethod: anRGMethod [
 	"TODO:Announce"
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGPackage >> pvtResolvableProperties [
 
 	^ super pvtResolvableProperties, {
@@ -393,31 +395,31 @@ RGPackage >> pvtResolvableProperties [
 	}
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGPackage >> pvtTagsForClassesDo: aBlock [
 
 	^ tagsForClasses value do: aBlock
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGPackage >> removeClassTag: aSymbol [
 
 	self backend forPackage removeClassTag: aSymbol from: self
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGPackage >> removeDefinedBehavior: anRGBehavior [
 
 	self backend forPackage removeDefinedBehavior: anRGBehavior from: self
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGPackage >> removeExtensionMethod: anRGMethod [
 
 	self backend forPackage removeExtensionMethod: anRGMethod from: self
 ]
 
-{ #category : #'accessing - model' }
+{ #category : 'accessing - model' }
 RGPackage >> tagsForClasses [
 	"Retrieves the traits defined in the receiver"
 
@@ -427,13 +429,13 @@ RGPackage >> tagsForClasses [
 	^ allTags asArray
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGPackage >> tagsForClassesDo: aBlock [
 
 	self backend forPackage tagsForClassesFor: self do: aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGPackage >> traits [
 	"Retrieves a collection of classes defined in the receiver and classes holding extension methods"
 

--- a/src/Ring-Core/RGPointerLayout.class.st
+++ b/src/Ring-Core/RGPointerLayout.class.st
@@ -1,64 +1,66 @@
 Class {
-	#name : #RGPointerLayout,
-	#superclass : #RGLayout,
+	#name : 'RGPointerLayout',
+	#superclass : 'RGLayout',
 	#instVars : [
 		'slots'
 	],
-	#category : #'Ring-Core-Kernel'
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGPointerLayout >> addSlot: anRGSlot [
 
 	self parent announceDefinitionChangeDuring: [
 		self backend forBehavior addSlot: anRGSlot to: self ]
 ]
 
-{ #category : #'queries - slots' }
+{ #category : 'queries - slots' }
 RGPointerLayout >> allSlots [
 
 	^ self slots
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGPointerLayout >> cleanSlots [
 
 	self parent announceDefinitionChangeDuring: [
 		self backend forBehavior cleanSlotsFor: self ]
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGPointerLayout >> defaultSlots [
 
 	^ OrderedCollection new
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGPointerLayout >> initialize [
 
 	super initialize.
 	slots := self unresolvedValue: self defaultSlots
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGPointerLayout >> initializeUnresolved [
 
 	super initializeUnresolved.
 	slots := self unresolvedValue: self defaultSlots
 ]
 
-{ #category : #'queries - slots' }
+{ #category : 'queries - slots' }
 RGPointerLayout >> instVarNames [
 	^ self slots collect: [:each | each name]
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGPointerLayout >> isPointerLayout [
 
 	^ true
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGPointerLayout >> makeResolved [
 
 	super makeResolved.
@@ -66,7 +68,7 @@ RGPointerLayout >> makeResolved [
 	slots := self slots asOrderedCollection markAsRingResolved
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGPointerLayout >> pvtAddSlot: anRGSlot [
 
 	self environment verifyOwnership: anRGSlot.
@@ -77,13 +79,13 @@ RGPointerLayout >> pvtAddSlot: anRGSlot [
 	slots add: anRGSlot
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGPointerLayout >> pvtCleanSlots [
 
 	slots := self defaultSlots
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGPointerLayout >> pvtRemoveSlot: anRGSlot [
 
 	self environment verifyOwnership: anRGSlot.
@@ -91,7 +93,7 @@ RGPointerLayout >> pvtRemoveSlot: anRGSlot [
 	slots remove: anRGSlot
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGPointerLayout >> pvtResolvableProperties [
 
 	^ super pvtResolvableProperties, {
@@ -99,20 +101,20 @@ RGPointerLayout >> pvtResolvableProperties [
 	}
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGPointerLayout >> pvtSlotsDo: aBlock [
 
 	slots value do: aBlock
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGPointerLayout >> removeSlot: anRGSlot [
 
 	self parent announceDefinitionChangeDuring: [
 		self backend forBehavior removeSlot: anRGSlot from: self ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGPointerLayout >> resolveSlot: aName ifFound: foundBlock ifNone: noneBlock [
 
 	self allSlots do: [ :slot |
@@ -120,7 +122,7 @@ RGPointerLayout >> resolveSlot: aName ifFound: foundBlock ifNone: noneBlock [
 	^ noneBlock value
 ]
 
-{ #category : #'queries - slots' }
+{ #category : 'queries - slots' }
 RGPointerLayout >> slots [
 
 	| allSlots |
@@ -129,7 +131,7 @@ RGPointerLayout >> slots [
 	^ allSlots asArray
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGPointerLayout >> slotsDo: aBlock [
 
 	self backend forBehavior slotsFor: self do: aBlock

--- a/src/Ring-Core/RGPoolVariable.class.st
+++ b/src/Ring-Core/RGPoolVariable.class.st
@@ -2,12 +2,14 @@
 A pool variable definition
 "
 Class {
-	#name : #RGPoolVariable,
-	#superclass : #RGVariable,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGPoolVariable',
+	#superclass : 'RGVariable',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'managing container' }
+{ #category : 'managing container' }
 RGPoolVariable >> addoptToParentStub [
 
 	super addoptToParentStub.
@@ -15,13 +17,13 @@ RGPoolVariable >> addoptToParentStub [
 	self environment backend createUnresolvedClassGroupFor: self parent
 ]
 
-{ #category : #'managing container' }
+{ #category : 'managing container' }
 RGPoolVariable >> defaultParentStub [
 
 	^ self defaultClassStub
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGPoolVariable >> isPoolVariable [
 
 	^true

--- a/src/Ring-Core/RGReadOnlyBackend.class.st
+++ b/src/Ring-Core/RGReadOnlyBackend.class.st
@@ -1,214 +1,216 @@
 Class {
-	#name : #RGReadOnlyBackend,
-	#superclass : #RGEnvironmentBackend,
-	#category : #'Ring-Core-Environment'
+	#name : 'RGReadOnlyBackend',
+	#superclass : 'RGEnvironmentBackend',
+	#category : 'Ring-Core-Environment',
+	#package : 'Ring-Core',
+	#tag : 'Environment'
 }
 
-{ #category : #'trait alias' }
+{ #category : 'trait alias' }
 RGReadOnlyBackend >> addAlias: aSymbol to: anRGTraitAlias [
 
 	self readOnlyError
 ]
 
-{ #category : #environment }
+{ #category : 'environment' }
 RGReadOnlyBackend >> addBehavior: anRGBehavior to: anRGEnvironment [
 
 	self readOnlyError
 ]
 
-{ #category : #package }
+{ #category : 'package' }
 RGReadOnlyBackend >> addClassTag: aSymbol to: anRGPackageDefinition [
 
 	self readOnlyError
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGReadOnlyBackend >> addClassVariable: anRGInstanceVariableDefinition to: anRGBehavior [
 
 	self readOnlyError
 ]
 
-{ #category : #package }
+{ #category : 'package' }
 RGReadOnlyBackend >> addDefinedBehavior: anRGBehavior to: anRGPackage [
 
 	self readOnlyError
 ]
 
-{ #category : #'trait exclusion' }
+{ #category : 'trait exclusion' }
 RGReadOnlyBackend >> addExclusion: aSymbol to: anRGTraitExclusion [
 
 	self readOnlyError
 ]
 
-{ #category : #package }
+{ #category : 'package' }
 RGReadOnlyBackend >> addExtensionMethod: anRGMethod to: anRGPackageDefinition [
 
 	self readOnlyError
 ]
 
-{ #category : #environment }
+{ #category : 'environment' }
 RGReadOnlyBackend >> addGlobalVariable: anRGGlobalVariable to: anRGEnvironment [
 
 	self readOnlyError
 ]
 
-{ #category : #'class description' }
+{ #category : 'class description' }
 RGReadOnlyBackend >> addInstanceVariable: anRGInstanceVariableDefinition to: anRGBehavior [
 
 	self readOnlyError
 ]
 
-{ #category : #behavior }
+{ #category : 'behavior' }
 RGReadOnlyBackend >> addLocalMethod: anRGMethod to: anRGBehavior [
 
 	self readOnlyError
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGReadOnlyBackend >> addMethodTag: aSymbol to: anRGBehavior [
 
 	self readOnlyError
 ]
 
-{ #category : #environment }
+{ #category : 'environment' }
 RGReadOnlyBackend >> addPackage: anRGPackageDefinition to: anRGEnvironment [
 
 	self readOnlyError
 ]
 
-{ #category : #behavior }
+{ #category : 'behavior' }
 RGReadOnlyBackend >> addProtocol: anRGProtocolDefinition to: anRGBehavior [
 
 	self readOnlyError
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGReadOnlyBackend >> addSharedPool: anRGPoolVariable to: anRGBehavior [
 
 	self readOnlyError
 ]
 
-{ #category : #'pointer layout' }
+{ #category : 'pointer layout' }
 RGReadOnlyBackend >> addSlot: anRGSlot to: anRGLayout [
 
 	self readOnlyError
 ]
 
-{ #category : #'trait composition' }
+{ #category : 'trait composition' }
 RGReadOnlyBackend >> addTransformation: anRGTraitTransformation to: anRGTraitComposition [
 
 	self readOnlyError
 ]
 
-{ #category : #'trait alias' }
+{ #category : 'trait alias' }
 RGReadOnlyBackend >> cleanAliasesFor: anRGTraitAlias [
 
 	self readOnlyError
 ]
 
-{ #category : #environment }
+{ #category : 'environment' }
 RGReadOnlyBackend >> cleanBehaviorsFor: anRGEnvironment [
 
 	self readOnlyError
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGReadOnlyBackend >> cleanClassTagsFor: anRGBehavior [
 
 	self readOnlyError
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGReadOnlyBackend >> cleanClassVariablesFor: anRGBehavior [
 
 	self readOnlyError
 ]
 
-{ #category : #package }
+{ #category : 'package' }
 RGReadOnlyBackend >> cleanDefinedBehaviorsFor: anRGPackage [
 
 	self readOnlyError
 ]
 
-{ #category : #'trait exclusion' }
+{ #category : 'trait exclusion' }
 RGReadOnlyBackend >> cleanExclusionsFor: anRGTraitExclusion [
 
 	self readOnlyError
 ]
 
-{ #category : #package }
+{ #category : 'package' }
 RGReadOnlyBackend >> cleanExtensionMethodsFor: anRGPackage [
 
 	self readOnlyError
 ]
 
-{ #category : #environment }
+{ #category : 'environment' }
 RGReadOnlyBackend >> cleanGlobalVariablesFor: anRGEnvironment [
 
 	self readOnlyError
 ]
 
-{ #category : #'class description' }
+{ #category : 'class description' }
 RGReadOnlyBackend >> cleanInstanceVariablesFor: anRGBehavior [
 
 	self readOnlyError
 ]
 
-{ #category : #behavior }
+{ #category : 'behavior' }
 RGReadOnlyBackend >> cleanLocalMethodsFor: anRGBehavior [
 
 	self readOnlyError
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGReadOnlyBackend >> cleanMethodTagsFor: anRGMethod [
 
 	self readOnlyError
 ]
 
-{ #category : #environment }
+{ #category : 'environment' }
 RGReadOnlyBackend >> cleanPackagesFor: anRGEnvironment [
 
 	self readOnlyError
 ]
 
-{ #category : #behavior }
+{ #category : 'behavior' }
 RGReadOnlyBackend >> cleanProtocolsFor: anRGBehavior [
 
 	self readOnlyError
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGReadOnlyBackend >> cleanSharedPoolsFor: anRGBehavior [
 
 	self readOnlyError
 ]
 
-{ #category : #'pointer layout' }
+{ #category : 'pointer layout' }
 RGReadOnlyBackend >> cleanSlotsFor: anRGLayout [
 
 	self readOnlyError
 ]
 
-{ #category : #package }
+{ #category : 'package' }
 RGReadOnlyBackend >> cleanTagsForClassesFor: anRGPackage [
 
 	self readOnlyError
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGReadOnlyBackend >> cleanTagsForMethodsFor: anRGBehavior [
 
 	self readOnlyError
 ]
 
-{ #category : #'trait composition' }
+{ #category : 'trait composition' }
 RGReadOnlyBackend >> cleanTransformationsFor: anRGTraitComposition [
 
 	self readOnlyError
 ]
 
-{ #category : #'unresolved objects' }
+{ #category : 'unresolved objects' }
 RGReadOnlyBackend >> createNewUnresolvedClass [
 
 	self readOnlyError
@@ -219,14 +221,14 @@ RGReadOnlyBackend >> createNewUnresolvedClass [
 	^ unresolvedValue."
 ]
 
-{ #category : #'unresolved objects' }
+{ #category : 'unresolved objects' }
 RGReadOnlyBackend >> createNewUnresolvedMetaclassFor: anRGBehavior [
 
 	self readOnlyError
 	"^ RGUnresolvedValue recursive"
 ]
 
-{ #category : #'unresolved objects' }
+{ #category : 'unresolved objects' }
 RGReadOnlyBackend >> createNewUnresolvedMetaclassMetaclassFor: anRGBehavior [
 
 	self readOnlyError
@@ -237,241 +239,241 @@ RGReadOnlyBackend >> createNewUnresolvedMetaclassMetaclassFor: anRGBehavior [
 	^ unresolvedValue."
 ]
 
-{ #category : #errors }
+{ #category : 'errors' }
 RGReadOnlyBackend >> readOnlyError [
 
 	self error: 'read-only environment'
 ]
 
-{ #category : #'trait alias' }
+{ #category : 'trait alias' }
 RGReadOnlyBackend >> removeAlias: aSymbol from: anRGTraitAlias [
 
 	self readOnlyError
 ]
 
-{ #category : #environment }
+{ #category : 'environment' }
 RGReadOnlyBackend >> removeBehavior: anRGBehavior from: anRGEnvironment [
 
 	self readOnlyError
 ]
 
-{ #category : #package }
+{ #category : 'package' }
 RGReadOnlyBackend >> removeClassTag: aSymbol from: anRGPackageDefinition [
 
 	self readOnlyError
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGReadOnlyBackend >> removeClassVariable: anRGInstanceVariableDefinition from: anRGBehavior [
 
 	self readOnlyError
 ]
 
-{ #category : #package }
+{ #category : 'package' }
 RGReadOnlyBackend >> removeDefinedBehavior: anRGBehavior from: anRGPackage [
 
 	self readOnlyError
 ]
 
-{ #category : #'trait exclusion' }
+{ #category : 'trait exclusion' }
 RGReadOnlyBackend >> removeExclusion: aSymbol from: anRGTraitExclusion [
 
 	self readOnlyError
 ]
 
-{ #category : #package }
+{ #category : 'package' }
 RGReadOnlyBackend >> removeExtensionMethod: anRGMethod from: anRGPackage [
 
 	self readOnlyError
 ]
 
-{ #category : #environment }
+{ #category : 'environment' }
 RGReadOnlyBackend >> removeGlobalVariable: anRGGlobalVariable from: anRGEnvironment [
 
 	self readOnlyError
 ]
 
-{ #category : #'class description' }
+{ #category : 'class description' }
 RGReadOnlyBackend >> removeInstanceVariable: anRGInstanceVariableDefinition from: anRGBehavior [
 
 	self readOnlyError
 ]
 
-{ #category : #behavior }
+{ #category : 'behavior' }
 RGReadOnlyBackend >> removeLocalMethod: anRGMethod from: anRGBehavior [
 
 	self readOnlyError
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGReadOnlyBackend >> removeMethodTag: aSymbol from: anRGBehavior [
 
 	self readOnlyError
 ]
 
-{ #category : #environment }
+{ #category : 'environment' }
 RGReadOnlyBackend >> removePackage: anRGPackageDefinition from: anRGEnvironment [
 
 	self readOnlyError
 ]
 
-{ #category : #behavior }
+{ #category : 'behavior' }
 RGReadOnlyBackend >> removeProtocol: anRGProtocolDefinition from: anRGBehavior [
 
 	self readOnlyError
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGReadOnlyBackend >> removeSharedPool: anRGPoolVariable from: anRGBehavior [
 
 	self readOnlyError
 ]
 
-{ #category : #'pointer layout' }
+{ #category : 'pointer layout' }
 RGReadOnlyBackend >> removeSlot: anRGSlot from: anRGLayout [
 
 	self readOnlyError
 ]
 
-{ #category : #'trait composition' }
+{ #category : 'trait composition' }
 RGReadOnlyBackend >> removeTransformation: anRGTraitTransformation from: anRGTraitComposition [
 
 	self readOnlyError
 ]
 
-{ #category : #metaclass }
+{ #category : 'metaclass' }
 RGReadOnlyBackend >> setBaseClassFor: anRGBehavior to: anRGClass [
 
 	self readOnlyError
 ]
 
-{ #category : #'class comment' }
+{ #category : 'class comment' }
 RGReadOnlyBackend >> setClassCommentAuthorFor: anRGComment to: aString [
 
 	self readOnlyError
 ]
 
-{ #category : #'class comment' }
+{ #category : 'class comment' }
 RGReadOnlyBackend >> setClassCommentContentFor: anRGComment to: anObject [
 
 	self readOnlyError
 ]
 
-{ #category : #'class comment' }
+{ #category : 'class comment' }
 RGReadOnlyBackend >> setClassCommentTimeFor: anRGComment to: aDateAndTime [
 
 	self readOnlyError
 ]
 
-{ #category : #trait }
+{ #category : 'trait' }
 RGReadOnlyBackend >> setClassTraitFor: anRGTrait to: anRGMetatraitDefinition [
 
 	self readOnlyError
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGReadOnlyBackend >> setCommentFor: anRGBehavior to: anRGComment [
 
 	self readOnlyError
 ]
 
-{ #category : #slot }
+{ #category : 'slot' }
 RGReadOnlyBackend >> setExpressionFor: anRGUnknownSlot to: aString [
 
 	self readOnlyError
 ]
 
-{ #category : #behavior }
+{ #category : 'behavior' }
 RGReadOnlyBackend >> setLayoutFor: anRGBehavior to: anRGLayout [
 
 	self readOnlyError
 ]
 
-{ #category : #'class description' }
+{ #category : 'class description' }
 RGReadOnlyBackend >> setMetaClassFor: anRGBehavior to: anRGMetaclass [
 
 	self readOnlyError
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGReadOnlyBackend >> setMethodPackageFor: anRGMethod to: anRGPackageDefinition [
 
 	self readOnlyError
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGReadOnlyBackend >> setMethodStampFor: anRGMethod to: anObject [
 
 	self readOnlyError
 ]
 
-{ #category : #general }
+{ #category : 'general' }
 RGReadOnlyBackend >> setNameFor: anRGObject to: aString [
 
 	self readOnlyError
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGReadOnlyBackend >> setPackageFor: anRGBehavior to: anRGPackageDefinition [
 
 	self readOnlyError
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGReadOnlyBackend >> setProtocolFor: anRGMethod to: anObject [
 
 	self readOnlyError
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGReadOnlyBackend >> setSourceCodeFor: anRGMethod to: anObject [
 
 	self readOnlyError
 ]
 
-{ #category : #'trait transormation' }
+{ #category : 'trait transormation' }
 RGReadOnlyBackend >> setSubjectFor: anRGTraitComposition to: anRGTrait [
 
 	self readOnlyError
 ]
 
-{ #category : #behavior }
+{ #category : 'behavior' }
 RGReadOnlyBackend >> setSuperclassFor: anRGBehavior to: anObject [
 
 	self readOnlyError
 ]
 
-{ #category : #trait }
+{ #category : 'trait' }
 RGReadOnlyBackend >> setTraitCommentFor: anRGBehavior to: anRGComment [
 
 	self readOnlyError
 ]
 
-{ #category : #trait }
+{ #category : 'trait' }
 RGReadOnlyBackend >> setTraitPackageFor: anRGBehavior to: anRGPackageDefinition [
 
 	self readOnlyError
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGReadOnlyBackend >> tagClass: anRGBehavior with: aSymbol [
 
 	self readOnlyError
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGReadOnlyBackend >> tagMethod: anRGMethod with: aSymbol [
 
 	self readOnlyError
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGReadOnlyBackend >> untagClass: anRGBehavior from: aSymbol [
 
 	self readOnlyError
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGReadOnlyBackend >> untagMethod: anRGMethod from: aSymbol [
 
 	self readOnlyError

--- a/src/Ring-Core/RGReadOnlyImageBackend.class.st
+++ b/src/Ring-Core/RGReadOnlyImageBackend.class.st
@@ -1,28 +1,30 @@
 Class {
-	#name : #RGReadOnlyImageBackend,
-	#superclass : #RGReadOnlyBackend,
-	#category : #'Ring-Core-Environment'
+	#name : 'RGReadOnlyImageBackend',
+	#superclass : 'RGReadOnlyBackend',
+	#category : 'Ring-Core-Environment',
+	#package : 'Ring-Core',
+	#tag : 'Environment'
 }
 
-{ #category : #'trait alias' }
+{ #category : 'trait alias' }
 RGReadOnlyImageBackend >> aliasesFor: anRGTraitAlias do: aBlock [
 
 	^ (anRGTraitAlias propertyNamed: #realObject ifAbsent: [ self error: 'You can use only trait transformations generated directly by this backend' ]) aliases associations do: [:each | aBlock value: each ]
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGReadOnlyImageBackend >> authorFor: anRGMethod [
 
 	^ RGStampParser authorForStamp: (self realMethodFor: anRGMethod) stamp
 ]
 
-{ #category : #metaclass }
+{ #category : 'metaclass' }
 RGReadOnlyImageBackend >> baseClassFor: anRGMetaclassTrait [
 
 	^ (self realBehaviorFor: anRGMetaclassTrait) baseClass asRingMinimalDefinitionIn: anRGMetaclassTrait environment
 ]
 
-{ #category : #environment }
+{ #category : 'environment' }
 RGReadOnlyImageBackend >> behaviorsFor: anRGEnvironment do: aBlock [
 
 	SystemNavigation default allBehaviors do: [:each |
@@ -31,37 +33,37 @@ RGReadOnlyImageBackend >> behaviorsFor: anRGEnvironment do: aBlock [
 		aBlock value: def.]
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGReadOnlyImageBackend >> categoryFor: anRGBehavior [
 
 	^ (self realBehaviorFor: anRGBehavior) category
 ]
 
-{ #category : #'class comment' }
+{ #category : 'class comment' }
 RGReadOnlyImageBackend >> classCommentAuthorFor: anRGComment [
 
 	^ RGStampParser authorForStamp: (self realBehaviorFor: anRGComment parent) commentStamp
 ]
 
-{ #category : #'class comment' }
+{ #category : 'class comment' }
 RGReadOnlyImageBackend >> classCommentContentFor: anRGComment [
 
 	^ (self realBehaviorFor: anRGComment parent) comment
 ]
 
-{ #category : #'class comment' }
+{ #category : 'class comment' }
 RGReadOnlyImageBackend >> classCommentTimeFor: anRGComment [
 
 	^ RGStampParser timeForStamp: (self realBehaviorFor: anRGComment parent) commentStamp
 ]
 
-{ #category : #trait }
+{ #category : 'trait' }
 RGReadOnlyImageBackend >> classTraitFor: anRGTrait [
 
 	^ (self realBehaviorFor: anRGTrait) classTrait asRingMinimalDefinitionIn: anRGTrait environment
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGReadOnlyImageBackend >> classVariablesFor: anRGBehavior do: aBlock [
 
 	| realClass |
@@ -72,13 +74,13 @@ RGReadOnlyImageBackend >> classVariablesFor: anRGBehavior do: aBlock [
 		aBlock value: def. ]
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGReadOnlyImageBackend >> commentFor: anRGBehavior [
 
 	^  (self realBehaviorFor: anRGBehavior) asRingMinimalCommentDefinitionIn: self environment
 ]
 
-{ #category : #'unresolved objects' }
+{ #category : 'unresolved objects' }
 RGReadOnlyImageBackend >> createUnresolvedClassGroupFor: anRGBehavior [
 
 	^ 	anRGBehavior isMeta
@@ -86,7 +88,7 @@ RGReadOnlyImageBackend >> createUnresolvedClassGroupFor: anRGBehavior [
 		ifTrue: [ anRGBehavior metaclass]
 ]
 
-{ #category : #package }
+{ #category : 'package' }
 RGReadOnlyImageBackend >> definedBehaviorsFor: anRGPackage do: aBlock [
 
 	(self realPackageFor: anRGPackage) ifNotNil: [ :realPackage |
@@ -96,13 +98,13 @@ RGReadOnlyImageBackend >> definedBehaviorsFor: anRGPackage do: aBlock [
 			aBlock value: def ] ]
 ]
 
-{ #category : #'trait exclusion' }
+{ #category : 'trait exclusion' }
 RGReadOnlyImageBackend >> exclusionsFor: anRGTraitExclusion do: aBlock [
 
 	^ (anRGTraitExclusion propertyNamed: #realObject ifAbsent: [ self error: 'You can use only trait transformations generated directly by this backend' ]) exclusions do: [:each | aBlock value: each ]
 ]
 
-{ #category : #slot }
+{ #category : 'slot' }
 RGReadOnlyImageBackend >> expressionFor: anRGUnknownSlot [
 
 	| realClass realSlot |
@@ -112,7 +114,7 @@ RGReadOnlyImageBackend >> expressionFor: anRGUnknownSlot [
 	^ (realSlot printString copyAfter: $>) trimBoth
 ]
 
-{ #category : #package }
+{ #category : 'package' }
 RGReadOnlyImageBackend >> extensionMethodsFor: anRGPackage do: aBlock [
 
 	| realPackage |
@@ -125,7 +127,7 @@ RGReadOnlyImageBackend >> extensionMethodsFor: anRGPackage do: aBlock [
 			aBlock value: def.]]
 ]
 
-{ #category : #environment }
+{ #category : 'environment' }
 RGReadOnlyImageBackend >> globalVariablesFor: anRGEnvironment do: aBlock [
 
 	Smalltalk globals associations do: [:each |
@@ -134,31 +136,31 @@ RGReadOnlyImageBackend >> globalVariablesFor: anRGEnvironment do: aBlock [
 		aBlock value: def.]
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGReadOnlyImageBackend >> hasFullyResolved: anRGObject [
 
 	^ true
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGReadOnlyImageBackend >> hasFullyUnresolved: anRGObject [
 
 	^ false
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGReadOnlyImageBackend >> hasResolved: anRGObject [
 
 	^ true
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGReadOnlyImageBackend >> hasSourceCodeFor: anRGMethod [
 
 	^ (self realMethodFor: anRGMethod) sourceCode
 ]
 
-{ #category : #behavior }
+{ #category : 'behavior' }
 RGReadOnlyImageBackend >> layoutFor: anRGBehavior [
 
 	| realClass realLayout def |
@@ -170,7 +172,7 @@ RGReadOnlyImageBackend >> layoutFor: anRGBehavior [
 	^ def
 ]
 
-{ #category : #behavior }
+{ #category : 'behavior' }
 RGReadOnlyImageBackend >> localMethodsFor: anRGBehavior do: aBlock [
 
 	(self realBehaviorFor: anRGBehavior) localMethods do: [:method |
@@ -180,7 +182,7 @@ RGReadOnlyImageBackend >> localMethodsFor: anRGBehavior do: aBlock [
 		aBlock value: def]
 ]
 
-{ #category : #'class description' }
+{ #category : 'class description' }
 RGReadOnlyImageBackend >> metaClassFor: anRGBehavior [
 
 	| realClass realMetaclass def |
@@ -192,7 +194,7 @@ RGReadOnlyImageBackend >> metaClassFor: anRGBehavior [
 	^ def
 ]
 
-{ #category : #behavior }
+{ #category : 'behavior' }
 RGReadOnlyImageBackend >> metaclassFor: anRGBehavior [
 
 	| realBehavior realMetaclass def |
@@ -204,25 +206,25 @@ RGReadOnlyImageBackend >> metaclassFor: anRGBehavior [
 	^ def
 ]
 
-{ #category : #'metaclass trait' }
+{ #category : 'metaclass trait' }
 RGReadOnlyImageBackend >> metaclassTraitBaseTraitFor: anRGMetaclassTrait [
 	^ (self realBehaviorFor: anRGMetaclassTrait) instanceSide
 		asRingMinimalDefinitionIn: anRGMetaclassTrait environment
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGReadOnlyImageBackend >> methodPackageFor: anRGMethod [
 
 	^ (self realMethodFor: anRGMethod) package asRingMinimalDefinitionIn: anRGMethod environment
 ]
 
-{ #category : #class }
+{ #category : 'class' }
 RGReadOnlyImageBackend >> packageFor: anRGBehavior [
 
 	^ (self realBehaviorFor: anRGBehavior) package asRingMinimalDefinitionIn: anRGBehavior environment
 ]
 
-{ #category : #environment }
+{ #category : 'environment' }
 RGReadOnlyImageBackend >> packagesFor: anRGEnvironment do: aBlock [
 
 	RPackageOrganizer default packagesDo: [:each |
@@ -231,33 +233,33 @@ RGReadOnlyImageBackend >> packagesFor: anRGEnvironment do: aBlock [
 		aBlock value: def.]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGReadOnlyImageBackend >> realBehaviorFor: anRGBehavior [
 
 	"TODO: should we cache the definition?"
 	^ Smalltalk classOrTraitNamed: anRGBehavior name asSymbol
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGReadOnlyImageBackend >> realMethodFor: anRGMethod [
 
 	"TODO: should we cache the definition?"
 	^ ((self realBehaviorFor: anRGMethod parent) >> anRGMethod selector)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGReadOnlyImageBackend >> realPackageFor: anRGPackage [
 
 	^ RPackageOrganizer default packageNamed: anRGPackage name ifAbsent: [nil]
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGReadOnlyImageBackend >> resolvedPropertiesFor: anRGObject [
 
 	^ anRGObject pvtResolvableProperties collect: [:each | each key]
 ]
 
-{ #category : #'pointer layout' }
+{ #category : 'pointer layout' }
 RGReadOnlyImageBackend >> slotsFor: anRGLayout do: aBlock [
 	| realClass |
 	realClass := self realBehaviorFor: anRGLayout parent.
@@ -270,19 +272,19 @@ RGReadOnlyImageBackend >> slotsFor: anRGLayout do: aBlock [
 			aBlock value: def ]
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGReadOnlyImageBackend >> sourceCodeFor: anRGMethod [
 
 	^ (self realMethodFor: anRGMethod) sourceCode
 ]
 
-{ #category : #'trait transormation' }
+{ #category : 'trait transormation' }
 RGReadOnlyImageBackend >> subjectFor: anRGTraitTransformation [
 
 	^ (anRGTraitTransformation propertyNamed: #realObject ifAbsent: [ self error: 'You can use only trait transformations generated directly by this backend' ]) subject asRingMinimalDefinitionIn: anRGTraitTransformation environment
 ]
 
-{ #category : #behavior }
+{ #category : 'behavior' }
 RGReadOnlyImageBackend >> superclassFor: anRGBehavior [
 
 	| realClass realSuperclass def |
@@ -295,13 +297,13 @@ RGReadOnlyImageBackend >> superclassFor: anRGBehavior [
 	^ def
 ]
 
-{ #category : #behavior }
+{ #category : 'behavior' }
 RGReadOnlyImageBackend >> tagsForClass: anRGBehavior do: aBlock [
 
 	(self realBehaviorFor: anRGBehavior) packageTag isRoot ifFalse: [ aBlock value: (self realBehaviorFor: anRGBehavior) packageTagName ]
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGReadOnlyImageBackend >> tagsForMethod: anRGMethod do: aBlock [
 
 	| realMethod |
@@ -310,25 +312,25 @@ RGReadOnlyImageBackend >> tagsForMethod: anRGMethod do: aBlock [
 	{ realMethod protocolName } do: aBlock
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGReadOnlyImageBackend >> tagsForMethodsFor: anRGBehavior do: aBlock [
 
 	(self realBehaviorFor: anRGBehavior) protocolNames do: aBlock
 ]
 
-{ #category : #method }
+{ #category : 'method' }
 RGReadOnlyImageBackend >> timeFor: anRGMethod [
 
 	^ RGStampParser timeForStamp: (self realMethodFor: anRGMethod) stamp
 ]
 
-{ #category : #trait }
+{ #category : 'trait' }
 RGReadOnlyImageBackend >> traitCommentFor: anRGBehavior [
 
 	^  (self realBehaviorFor: anRGBehavior) asRingMinimalCommentDefinitionIn: self environment
 ]
 
-{ #category : #behavior }
+{ #category : 'behavior' }
 RGReadOnlyImageBackend >> traitCompositionFor: anRGBehavior [
 
 	| realClass realTraitComposition def |
@@ -340,13 +342,13 @@ RGReadOnlyImageBackend >> traitCompositionFor: anRGBehavior [
 	^ def
 ]
 
-{ #category : #trait }
+{ #category : 'trait' }
 RGReadOnlyImageBackend >> traitPackageFor: anRGBehavior [
 
 	^ (self realBehaviorFor: anRGBehavior) package asRingMinimalDefinitionIn: anRGBehavior environment
 ]
 
-{ #category : #'trait composition' }
+{ #category : 'trait composition' }
 RGReadOnlyImageBackend >> transformationsFor: anRGTraitComposition do: aBlock [
 
 	| realBehavior realTraitComposition |
@@ -362,7 +364,7 @@ RGReadOnlyImageBackend >> transformationsFor: anRGTraitComposition do: aBlock [
 		aBlock value: def]
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGReadOnlyImageBackend >> unresolvedPropertiesFor: anRGObject [
 
 	^ Dictionary new

--- a/src/Ring-Core/RGResolvingError.class.st
+++ b/src/Ring-Core/RGResolvingError.class.st
@@ -4,7 +4,9 @@ I'm a specialized error exception used mainly during failures in applying of cha
 
 "
 Class {
-	#name : #RGResolvingError,
-	#superclass : #Error,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGResolvingError',
+	#superclass : 'Error',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }

--- a/src/Ring-Core/RGSlot.class.st
+++ b/src/Ring-Core/RGSlot.class.st
@@ -1,51 +1,53 @@
 Class {
-	#name : #RGSlot,
-	#superclass : #RGVariable,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGSlot',
+	#superclass : 'RGVariable',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #bootstrap }
+{ #category : 'bootstrap' }
 RGSlot >> accept: anInterpreter assign: aValue inNode: aVariableNode [
 	self error: #TBD
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 RGSlot >> acceptVisitor: aProgramNodeVisitor node: aNode [
 	^ aProgramNodeVisitor visitInstanceVariableNode: aNode
 ]
 
-{ #category : #'managing container' }
+{ #category : 'managing container' }
 RGSlot >> addoptToParentStub [
 
 	super addoptToParentStub.
 	self parent addSlot: self
 ]
 
-{ #category : #'managing container' }
+{ #category : 'managing container' }
 RGSlot >> defaultParentStub [
 
 	^ self defaultFixedLayoutStub
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGSlot >> definitionString [
 
 	^ String streamContents: [ :aStream |
 		aStream nextPutAll: '#'; nextPutAll: self name]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGSlot >> isInstanceVariable [
 	^ true
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGSlot >> isSlot [
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGSlot >> name: aString [
 
 	self parent parent announceDefinitionChangeDuring: [

--- a/src/Ring-Core/RGStampParser.class.st
+++ b/src/Ring-Core/RGStampParser.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RGStampParser,
-	#superclass : #Object,
-	#category : #'Ring-Core-Parsing'
+	#name : 'RGStampParser',
+	#superclass : 'Object',
+	#category : 'Ring-Core-Parsing',
+	#package : 'Ring-Core',
+	#tag : 'Parsing'
 }
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 RGStampParser class >> authorForStamp: aString [
 
 	^ aString isEmptyOrNil
@@ -12,31 +14,31 @@ RGStampParser class >> authorForStamp: aString [
 		ifFalse: [ self parseAuthorAliasFrom: aString ]
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 RGStampParser class >> historicalStamp [
 
 	^ '<historical>'
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 RGStampParser class >> parseAuthorAliasFrom: aString [
 
 	^ self new basicParseAuthorAliasFrom: aString
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 RGStampParser class >> parseTimestampFrom: aString [
 
 	^ self new parseTimestampFrom: aString
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 RGStampParser class >> timeForStamp: stamp [
 
 	^ self new timeForStamp: stamp
 ]
 
-{ #category : #'parsing stamp' }
+{ #category : 'parsing stamp' }
 RGStampParser >> basicParseAuthorAliasFrom: aString [
 	"Parse an alias/name of the author from a string that is extracted from a source file. If there is no alias/name we return emtpy string."
 
@@ -76,20 +78,20 @@ RGStampParser >> basicParseAuthorAliasFrom: aString [
 		do: [ :e | unknown ]
 ]
 
-{ #category : #'parsing stamp' }
+{ #category : 'parsing stamp' }
 RGStampParser >> parseAuthorAliasFrom: aString [
 	"Allows other applications  to treat a different empty alias by overriding this method"
 
 	^self basicParseAuthorAliasFrom: aString
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 RGStampParser >> parseTimestampFrom: aString [
 
 	^self parseTimestampFrom: aString default: nil
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 RGStampParser >> parseTimestampFrom: aString default: anObject [
 	"Parse a date-time from a timestamp-string that is extracted from a source file. If there is no timestamp, or we cannot make sense of it, we return the default value."
 
@@ -121,7 +123,7 @@ RGStampParser >> parseTimestampFrom: aString default: anObject [
 		do: [ :e | unknown ]
 ]
 
-{ #category : #'parsing stamp' }
+{ #category : 'parsing stamp' }
 RGStampParser >> timeForStamp: stamp [
 
 	^ stamp

--- a/src/Ring-Core/RGTrait.class.st
+++ b/src/Ring-Core/RGTrait.class.st
@@ -2,24 +2,26 @@
 A factory that produces instances of RGBehavior composed with RGTraitStrategy
 "
 Class {
-	#name : #RGTrait,
-	#superclass : #RGBehaviorFactory,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGTrait',
+	#superclass : 'RGBehaviorFactory',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGTrait class >> newStrategy [
 
 	^ RGTraitStrategy basicNew
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGTrait class >> newStrategyFor: anRGEnvironment [
 
 	^ (self strategyClassForVersion: anRGEnvironment version) basicNew
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGTrait class >> strategyClassForVersion: aVersionNumber [
 
 	^ (aVersionNumber <= 6)

--- a/src/Ring-Core/RGTraitAlias.class.st
+++ b/src/Ring-Core/RGTraitAlias.class.st
@@ -1,20 +1,22 @@
 Class {
-	#name : #RGTraitAlias,
-	#superclass : #RGTraitTransformation,
+	#name : 'RGTraitAlias',
+	#superclass : 'RGTraitTransformation',
 	#instVars : [
 		'aliases'
 	],
-	#category : #'Ring-Core-Kernel'
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGTraitAlias >> addAlias: aSymbol [
 
 	self parent parent announceDefinitionChangeDuring: [
 		self backend forBehavior addAlias: aSymbol to: self ]
 ]
 
-{ #category : #'queries - aliases' }
+{ #category : 'queries - aliases' }
 RGTraitAlias >> aliases [
 
 	| allAliases |
@@ -23,26 +25,26 @@ RGTraitAlias >> aliases [
 	^ allAliases
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGTraitAlias >> aliasesDo: aBlock [
 
 	self backend forBehavior aliasesFor: self do: aBlock
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGTraitAlias >> cleanAliases [
 
 	self parent parent announceDefinitionChangeDuring: [
 		self backend forBehavior cleanAliasesFor: self ]
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGTraitAlias >> defaultAliases [
 
 	^ OrderedCollection new
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGTraitAlias >> initialize [
 
 	super initialize.
@@ -50,7 +52,7 @@ RGTraitAlias >> initialize [
 	aliases := self unresolvedValue: self defaultAliases
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 RGTraitAlias >> initializeUnresolved [
 
 	super initializeUnresolved.
@@ -58,13 +60,13 @@ RGTraitAlias >> initializeUnresolved [
 	aliases := self unresolvedValue: self defaultAliases
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGTraitAlias >> isTraitAlias [
 
 	^ true
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGTraitAlias >> makeResolved [
 
 	super makeResolved.
@@ -72,14 +74,14 @@ RGTraitAlias >> makeResolved [
 	aliases := self aliases markAsRingResolved
 ]
 
-{ #category : #'queries - methods' }
+{ #category : 'queries - methods' }
 RGTraitAlias >> methods [
 
 	"TODO"
 	^ self subject methods reject: [ :each | self aliases includes: each name  ]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitAlias >> pvtAddAlias: aSymbol [
 
 	aliases isRingResolved ifFalse: [
@@ -88,25 +90,25 @@ RGTraitAlias >> pvtAddAlias: aSymbol [
 	aliases add: aSymbol
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitAlias >> pvtAliasesDo: aBlock [
 
 	aliases value do: aBlock
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitAlias >> pvtCleanAliases [
 
 	aliases := self defaultAliases
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitAlias >> pvtRemoveAlias: aSymbol [
 
 	aliases remove: aSymbol
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitAlias >> pvtResolvableProperties [
 
 	^ super pvtResolvableProperties, {
@@ -114,14 +116,14 @@ RGTraitAlias >> pvtResolvableProperties [
 	}
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGTraitAlias >> removeAlias: aSymbol [
 
 	self parent parent announceDefinitionChangeDuring: [
 		self backend forBehavior removeAlias: aSymbol from: self ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitAlias >> traitCompositionString [
 
 	^ String streamContents: [:aStream |
@@ -136,7 +138,7 @@ RGTraitAlias >> traitCompositionString [
 	aStream nextPut: $}]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitAlias >> traitTransformationString [
 
 	^ String streamContents: [:aStream |

--- a/src/Ring-Core/RGTraitComposition.class.st
+++ b/src/Ring-Core/RGTraitComposition.class.st
@@ -1,20 +1,22 @@
 Class {
-	#name : #RGTraitComposition,
-	#superclass : #RGObject,
+	#name : 'RGTraitComposition',
+	#superclass : 'RGObject',
 	#instVars : [
 		'transformations'
 	],
-	#category : #'Ring-Core-Kernel'
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGTraitComposition >> addTransformation: anRGTraitTransformation [
 
 	self parent announceDefinitionChangeDuring: [
 		self backend forBehavior addTransformation: anRGTraitTransformation to: self ]
 ]
 
-{ #category : #'managing container' }
+{ #category : 'managing container' }
 RGTraitComposition >> addoptToParentStub [
 
 	super addoptToParentStub.
@@ -22,26 +24,26 @@ RGTraitComposition >> addoptToParentStub [
 	self environment backend createUnresolvedClassGroupFor: self parent
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGTraitComposition >> cleanTransformations [
 
 	self parent announceDefinitionChangeDuring: [
 		self backend forBehavior cleanTransformationsFor: self ]
 ]
 
-{ #category : #'managing container' }
+{ #category : 'managing container' }
 RGTraitComposition >> defaultParentStub [
 
 	^ self defaultClassStub
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitComposition >> defaultTransformations [
 
 	^ OrderedCollection new
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGTraitComposition >> initialize [
 
 	super initialize.
@@ -49,7 +51,7 @@ RGTraitComposition >> initialize [
 	transformations := self unresolvedValue: self defaultTransformations
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGTraitComposition >> initializeUnresolved [
 
 	super initializeUnresolved.
@@ -57,13 +59,13 @@ RGTraitComposition >> initializeUnresolved [
 	transformations := self unresolvedValue: self defaultTransformations
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGTraitComposition >> isTraitComposition [
 
 	^ true
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGTraitComposition >> makeResolved [
 
 	super makeResolved.
@@ -71,14 +73,14 @@ RGTraitComposition >> makeResolved [
 	transformations := self transformations markAsRingResolved
 ]
 
-{ #category : #'queries - methods' }
+{ #category : 'queries - methods' }
 RGTraitComposition >> methods [
 
 	^ Array streamContents: [ :stream |
 		self transformationsDo: [ :transformation | stream nextPutAll: transformation methods ]]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitComposition >> pvtAddTransformation: anRGTraitTransformation [
 
 	self environment verifyOwnership: anRGTraitTransformation.
@@ -89,13 +91,13 @@ RGTraitComposition >> pvtAddTransformation: anRGTraitTransformation [
 	transformations add: anRGTraitTransformation
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitComposition >> pvtCleanTransformations [
 
 	transformations := self defaultTransformations
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitComposition >> pvtRemoveTransformation: anRGTraitTransformation [
 
 	self environment verifyOwnership: anRGTraitTransformation.
@@ -103,7 +105,7 @@ RGTraitComposition >> pvtRemoveTransformation: anRGTraitTransformation [
 	transformations remove: anRGTraitTransformation
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitComposition >> pvtResolvableProperties [
 
 	^ super pvtResolvableProperties, {
@@ -111,13 +113,13 @@ RGTraitComposition >> pvtResolvableProperties [
 	}
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitComposition >> pvtTransformationsDo: aBlock [
 
 	transformations value do: aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitComposition >> referencedBehaviors [
 
 	^ self transformations collect: [ :each |
@@ -126,14 +128,14 @@ RGTraitComposition >> referencedBehaviors [
 			ifFalse: [ each subject ] ]
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGTraitComposition >> removeTransformation: anRGTraitTransformation [
 
 	self parent announceDefinitionChangeDuring: [
 		self backend forBehavior removeTransformation: anRGTraitTransformation from: self ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitComposition >> traitCompositionString [
 
 	self transformations isEmpty ifTrue: [ ^ '{}' ].
@@ -144,13 +146,13 @@ RGTraitComposition >> traitCompositionString [
 			separatedBy: [ stream nextPutAll: ' + ' ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitComposition >> traits [
 
 	^ self transformations collect: [:each | each trait ]
 ]
 
-{ #category : #'queries - transformations' }
+{ #category : 'queries - transformations' }
 RGTraitComposition >> transformations [
 
 	| allTransformations |
@@ -159,13 +161,13 @@ RGTraitComposition >> transformations [
 	^ allTransformations
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGTraitComposition >> transformationsDo: aBlock [
 
 	self backend forBehavior transformationsFor: self do: aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitComposition >> usedTraits [
 
 	^ self transformations flatCollect: [ :each |

--- a/src/Ring-Core/RGTraitCompositionVisitor.class.st
+++ b/src/Ring-Core/RGTraitCompositionVisitor.class.st
@@ -17,15 +17,17 @@ ast acceptVisitor: visitor.
 
 "
 Class {
-	#name : #RGTraitCompositionVisitor,
-	#superclass : #RBProgramNodeVisitor,
+	#name : 'RGTraitCompositionVisitor',
+	#superclass : 'RBProgramNodeVisitor',
 	#instVars : [
 		'traitComposition'
 	],
-	#category : #'Ring-Core-Parsing'
+	#category : 'Ring-Core-Parsing',
+	#package : 'Ring-Core',
+	#tag : 'Parsing'
 }
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 RGTraitCompositionVisitor >> parse: anExpressionString for: anRGTraitCompositionDefinition [
 
 	| ast result |
@@ -39,36 +41,36 @@ RGTraitCompositionVisitor >> parse: anExpressionString for: anRGTraitComposition
 	^ result
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitCompositionVisitor >> traitComposition [
 	^ traitComposition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitCompositionVisitor >> traitComposition: anObject [
 	traitComposition := anObject.
 	traitComposition pvtCleanTransformations
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 RGTraitCompositionVisitor >> visitArrayNode: anArrayNode [
 
 	^ anArrayNode children collect: [:each | self visitNode: each]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 RGTraitCompositionVisitor >> visitLiteralArrayNode: aRBLiteralArrayNode [
 
 	^ aRBLiteralArrayNode contents collect: [:each | self visitNode: each]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 RGTraitCompositionVisitor >> visitLiteralNode: aLiteralNode [
 
 	^ aLiteralNode value
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 RGTraitCompositionVisitor >> visitMessageNode: aMessageNode [
 
 	| rec args |
@@ -113,13 +115,13 @@ RGTraitCompositionVisitor >> visitMessageNode: aMessageNode [
 	self error: 'Unknown trait composition message'
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 RGTraitCompositionVisitor >> visitSequenceNode: aSequenceNode [
 
 	^ aSequenceNode statements collect: [:each | self visitNode: each]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 RGTraitCompositionVisitor >> visitVariableNode: aVariableNode [
 
 	^ self traitComposition environment ensureTraitNamed: aVariableNode name

--- a/src/Ring-Core/RGTraitDescriptionStrategy.class.st
+++ b/src/Ring-Core/RGTraitDescriptionStrategy.class.st
@@ -1,22 +1,24 @@
 Class {
-	#name : #RGTraitDescriptionStrategy,
-	#superclass : #RGBehaviorStrategy,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGTraitDescriptionStrategy',
+	#superclass : 'RGBehaviorStrategy',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #variables }
+{ #category : 'variables' }
 RGTraitDescriptionStrategy >> allSharedPoolNames [
 
 	^#()
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitDescriptionStrategy >> bindingOf: varName [
 
 	^ self environment bindingOf: varName
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGTraitDescriptionStrategy >> initialize [
 
 	super initialize.
@@ -24,25 +26,25 @@ RGTraitDescriptionStrategy >> initialize [
 	self owner environment backend createUnresolvedTraitGroupFor: self owner
 ]
 
-{ #category : #variables }
+{ #category : 'variables' }
 RGTraitDescriptionStrategy >> isTrait [
 
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitDescriptionStrategy >> layout [
 
 	self incompatibleBehaviorType
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitDescriptionStrategy >> layout: anRGLayout [
 
 	self incompatibleBehaviorType
 ]
 
-{ #category : #variables }
+{ #category : 'variables' }
 RGTraitDescriptionStrategy >> methods [
 
 	| allMethods |
@@ -51,7 +53,7 @@ RGTraitDescriptionStrategy >> methods [
 	^ allMethods asArray
 ]
 
-{ #category : #variables }
+{ #category : 'variables' }
 RGTraitDescriptionStrategy >> name: aString [
 
 	| usersWithOldDefinition |
@@ -66,13 +68,13 @@ RGTraitDescriptionStrategy >> name: aString [
 		self trait announcer behaviorModificationAppliedTo: assoc key. ]
 ]
 
-{ #category : #variables }
+{ #category : 'variables' }
 RGTraitDescriptionStrategy >> trait [
 
 	^ self owner
 ]
 
-{ #category : #variables }
+{ #category : 'variables' }
 RGTraitDescriptionStrategy >> users [
 
 	"return collection of user of the trait"

--- a/src/Ring-Core/RGTraitExclusion.class.st
+++ b/src/Ring-Core/RGTraitExclusion.class.st
@@ -1,33 +1,35 @@
 Class {
-	#name : #RGTraitExclusion,
-	#superclass : #RGTraitTransformation,
+	#name : 'RGTraitExclusion',
+	#superclass : 'RGTraitTransformation',
 	#instVars : [
 		'exclusions'
 	],
-	#category : #'Ring-Core-Kernel'
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGTraitExclusion >> addExclusion: aSymbol [
 
 	self parent parent announceDefinitionChangeDuring: [
 		self backend forBehavior addExclusion: aSymbol to: self. ]
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGTraitExclusion >> cleanExclusions [
 
 	self parent parent announceDefinitionChangeDuring: [
 		self backend forBehavior cleanExclusionsFor: self. ]
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGTraitExclusion >> defaultExclusions [
 
 	^ OrderedCollection new
 ]
 
-{ #category : #'queries - exclusions' }
+{ #category : 'queries - exclusions' }
 RGTraitExclusion >> exclusions [
 
 	| allExclusions |
@@ -36,13 +38,13 @@ RGTraitExclusion >> exclusions [
 	^ allExclusions
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGTraitExclusion >> exclusionsDo: aBlock [
 
 	self backend forBehavior exclusionsFor: self do: aBlock
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGTraitExclusion >> initialize [
 
 	super initialize.
@@ -50,7 +52,7 @@ RGTraitExclusion >> initialize [
 	exclusions := self unresolvedValue: self defaultExclusions
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGTraitExclusion >> initializeUnresolved [
 
 	super initializeUnresolved.
@@ -58,13 +60,13 @@ RGTraitExclusion >> initializeUnresolved [
 	exclusions := self unresolvedValue: self defaultExclusions
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGTraitExclusion >> isTraitExclusion [
 
 	^ true
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGTraitExclusion >> makeResolved [
 
 	super makeResolved.
@@ -72,13 +74,13 @@ RGTraitExclusion >> makeResolved [
 	exclusions := self exclusions markAsRingResolved
 ]
 
-{ #category : #'queries - methods' }
+{ #category : 'queries - methods' }
 RGTraitExclusion >> methods [
 
 	^ self subject methods reject: [ :each | self exclusions includes: each name  ]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitExclusion >> pvtAddExclusion: aSymbol [
 
 
@@ -88,25 +90,25 @@ RGTraitExclusion >> pvtAddExclusion: aSymbol [
 	exclusions add: aSymbol
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitExclusion >> pvtCleanExclusions [
 
 	exclusions := self defaultExclusions
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitExclusion >> pvtExclusionsDo: aBlock [
 
 	exclusions value do: aBlock
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitExclusion >> pvtRemoveExclusion: aSymbol [
 
 	exclusions remove: aSymbol
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitExclusion >> pvtResolvableProperties [
 
 	^ super pvtResolvableProperties, {
@@ -114,14 +116,14 @@ RGTraitExclusion >> pvtResolvableProperties [
 	}
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGTraitExclusion >> removeExclusion: aSymbol [
 
 	self parent parent announceDefinitionChangeDuring: [
 		self backend forBehavior removeExclusion: aSymbol from: self. ]
 ]
 
-{ #category : #traits }
+{ #category : 'traits' }
 RGTraitExclusion >> traitCompositionString [
 
 	^ String streamContents: [:aStream |
@@ -136,7 +138,7 @@ RGTraitExclusion >> traitCompositionString [
 	aStream nextPut: $}]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitExclusion >> traitTransformationString [
 
 	^ String streamContents: [:aStream |

--- a/src/Ring-Core/RGTraitStrategy.class.st
+++ b/src/Ring-Core/RGTraitStrategy.class.st
@@ -1,27 +1,29 @@
 Class {
-	#name : #RGTraitStrategy,
-	#superclass : #RGTraitDescriptionStrategy,
+	#name : 'RGTraitStrategy',
+	#superclass : 'RGTraitDescriptionStrategy',
 	#instVars : [
 		'classTrait',
 		'comment',
 		'package'
 	],
-	#category : #'Ring-Core-Kernel'
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitStrategy >> acceptVisitor: aVisitor [
 
 	^ aVisitor visitTrait: self owner
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitStrategy >> baseTrait [
 
 	^ self owner
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitStrategy >> category [
 
 	^ self owner tags
@@ -34,7 +36,7 @@ RGTraitStrategy >> category [
 	"todo"
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitStrategy >> category: aString [
 
 	| aTag |
@@ -54,31 +56,31 @@ RGTraitStrategy >> category: aString [
 	self announcer behaviorRecategorized: self."
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGTraitStrategy >> classSide [
 
 	^ self classTrait
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitStrategy >> classTrait [
 
 	^ self backend forBehavior classTraitFor: self owner
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitStrategy >> classTrait: anRGMetatraitDefinition [
 
 	self backend forBehavior setClassTraitFor: self owner to: anRGMetatraitDefinition
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGTraitStrategy >> comment [
 
 	^ self backend forBehavior traitCommentFor: self owner
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGTraitStrategy >> comment: anRGComment [
 
 	self backend forBehavior setTraitCommentFor: self owner to: anRGComment.
@@ -86,25 +88,25 @@ RGTraitStrategy >> comment: anRGComment [
 	self owner announcer behaviorCommentModified: self owner
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGTraitStrategy >> defaultCategory [
 
 	^ nil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGTraitStrategy >> defaultComment [
 
 	^ self owner defaultCommentStubIn: self owner
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGTraitStrategy >> defaultPackage [
 
 	^ self owner defaultPackageStubIn: self environment
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGTraitStrategy >> definition [
 	"Answer a String that defines the receiver"
 
@@ -118,13 +120,13 @@ RGTraitStrategy >> definition [
 				store: self owner category asString]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGTraitStrategy >> hasComment [
 
 	^ self comment isEmptyOrNil not
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGTraitStrategy >> initialize [
 
 	super initialize.
@@ -134,7 +136,7 @@ RGTraitStrategy >> initialize [
 	package := self unresolvedValue: self defaultPackage
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGTraitStrategy >> initializeUnresolved [
 
 	super initializeUnresolved.
@@ -144,18 +146,18 @@ RGTraitStrategy >> initializeUnresolved [
 	package := self unresolvedValue: self defaultPackage
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGTraitStrategy >> instanceSide [
 	^ self baseTrait
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGTraitStrategy >> isTraitStrategy [
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitStrategy >> makeResolved [
 
 
@@ -170,13 +172,13 @@ RGTraitStrategy >> makeResolved [
 	package := self package markAsRingResolved
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitStrategy >> package [
 
 	^ self backend forBehavior traitPackageFor: self owner
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitStrategy >> package: anRGPackage [
 
 	self announceDefinitionChangeDuring: [
@@ -185,13 +187,13 @@ RGTraitStrategy >> package: anRGPackage [
 		anRGPackage addDefinedBehavior: self owner. ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitStrategy >> pvtClassTrait [
 
 	^ classTrait value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitStrategy >> pvtClassTrait: anRGMetatraitDefinition [
 
 	self owner environment verifyOwnership: anRGMetatraitDefinition.
@@ -199,13 +201,13 @@ RGTraitStrategy >> pvtClassTrait: anRGMetatraitDefinition [
 	^ classTrait := anRGMetatraitDefinition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitStrategy >> pvtComment [
 
 	^ comment value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitStrategy >> pvtComment: anRGComment [
 
 	self owner environment verifyOwnership: anRGComment.
@@ -213,13 +215,13 @@ RGTraitStrategy >> pvtComment: anRGComment [
 	^ comment := anRGComment
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitStrategy >> pvtPackage [
 
 	^ package value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitStrategy >> pvtPackage: anRGPackage [
 
 	self owner environment verifyOwnership: anRGPackage.
@@ -227,7 +229,7 @@ RGTraitStrategy >> pvtPackage: anRGPackage [
 	^ package := anRGPackage
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitStrategy >> pvtResolvableProperties [
 
 	^ super pvtResolvableProperties, {
@@ -237,31 +239,31 @@ RGTraitStrategy >> pvtResolvableProperties [
    	}
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitStrategy >> referencedBehaviors [
 
 	^ super referencedBehaviors, {self classTrait}
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitStrategy >> referencedPackages [
 
 	^ Array with: package
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitStrategy >> sibling [
 
 	^ self classTrait
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGTraitStrategy >> storeName [
 
 	^ 'RGTrait'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitStrategy >> traitTransformationString [
 
 	^ self owner name

--- a/src/Ring-Core/RGTraitTransformation.class.st
+++ b/src/Ring-Core/RGTraitTransformation.class.st
@@ -1,32 +1,34 @@
 Class {
-	#name : #RGTraitTransformation,
-	#superclass : #RGObject,
+	#name : 'RGTraitTransformation',
+	#superclass : 'RGObject',
 	#instVars : [
 		'subject'
 	],
-	#category : #'Ring-Core-Kernel'
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'managing container' }
+{ #category : 'managing container' }
 RGTraitTransformation >> addoptToParentStub [
 
 	super addoptToParentStub.
 	self parent addTransformation: self
 ]
 
-{ #category : #'managing container' }
+{ #category : 'managing container' }
 RGTraitTransformation >> defaultParentStub [
 
 	^ self defaultTraitCompositionStub
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGTraitTransformation >> defaultSubject [
 
 	^ RGUnresolvedValue recursive
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGTraitTransformation >> initialize [
 
 	super initialize.
@@ -34,7 +36,7 @@ RGTraitTransformation >> initialize [
 	subject := self unresolvedValue: self defaultSubject
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 RGTraitTransformation >> initializeUnresolved [
 
 	super initializeUnresolved.
@@ -42,13 +44,13 @@ RGTraitTransformation >> initializeUnresolved [
 	subject := self unresolvedValue: self defaultSubject
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGTraitTransformation >> isTraitTransformation [
 
 	^ true
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGTraitTransformation >> makeResolved [
 
 	super makeResolved.
@@ -56,20 +58,20 @@ RGTraitTransformation >> makeResolved [
 	subject := self subject markAsRingResolved
 ]
 
-{ #category : #'queries - methods' }
+{ #category : 'queries - methods' }
 RGTraitTransformation >> methods [
 
 	self subclassResponsibility
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGTraitTransformation >> name: aString [
 
 	self parent parent announceDefinitionChangeDuring: [
 		super name: aString ]
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGTraitTransformation >> pvtResolvableProperties [
 
 	^ super pvtResolvableProperties, {
@@ -77,13 +79,13 @@ RGTraitTransformation >> pvtResolvableProperties [
 	}
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGTraitTransformation >> pvtSubject [
 
 	^ subject value
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGTraitTransformation >> pvtSubject: anRGTrait [
 
 	self environment verifyOwnership: anRGTrait.
@@ -91,26 +93,26 @@ RGTraitTransformation >> pvtSubject: anRGTrait [
 	^ subject := anRGTrait
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGTraitTransformation >> subject [
 
 	^ self backend forBehavior subjectFor: self
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGTraitTransformation >> subject: anRGTrait [
 
 	self parent parent announceDefinitionChangeDuring: [
 		self backend forBehavior setSubjectFor: self to: anRGTrait. ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitTransformation >> trait [
 
 	^ self subject trait
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGTraitTransformation >> usedTraits [
 
 	^ IdentitySet with: subject

--- a/src/Ring-Core/RGTraitV2DescriptionStrategy.class.st
+++ b/src/Ring-Core/RGTraitV2DescriptionStrategy.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #RGTraitV2DescriptionStrategy,
-	#superclass : #RGBehaviorStrategy,
+	#name : 'RGTraitV2DescriptionStrategy',
+	#superclass : 'RGBehaviorStrategy',
 	#instVars : [
 		'layout'
 	],
-	#category : #'Ring-Core-Kernel'
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RGTraitV2DescriptionStrategy >> allSlots [
 
 	| superclassSlots aSuperclass |
@@ -18,7 +20,7 @@ RGTraitV2DescriptionStrategy >> allSlots [
 	^ (superclassSlots, self layout allSlots) asArray
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGTraitV2DescriptionStrategy >> classVariablesString [
 	"Answer a string of my class variable names separated by spaces."
 
@@ -28,7 +30,7 @@ RGTraitV2DescriptionStrategy >> classVariablesString [
 			separatedBy: [ stream space ] ]
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 RGTraitV2DescriptionStrategy >> copyForBehaviorDefinitionPostCopy [
 
 	super copyForBehaviorDefinitionPostCopy.
@@ -36,13 +38,13 @@ RGTraitV2DescriptionStrategy >> copyForBehaviorDefinitionPostCopy [
 	layout parent: self owner
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGTraitV2DescriptionStrategy >> defaultLayout [
 
 	^ self owner defaultFixedLayoutStubIn: self
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGTraitV2DescriptionStrategy >> initialize [
 
 	super initialize.
@@ -51,7 +53,7 @@ RGTraitV2DescriptionStrategy >> initialize [
 	self owner environment backend createUnresolvedClassGroupFor: self owner
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGTraitV2DescriptionStrategy >> initializeUnresolved [
 
 	super initializeUnresolved.
@@ -59,18 +61,18 @@ RGTraitV2DescriptionStrategy >> initializeUnresolved [
 	layout := self unresolvedValue: self defaultLayout
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGTraitV2DescriptionStrategy >> instSize [
 
 	^ self owner allInstVarNames size
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGTraitV2DescriptionStrategy >> instVarNames [
 	^ self layout instVarNames
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitV2DescriptionStrategy >> instanceVariables: aCollectionOfSymbols [
 
 	"specify instance variable names"
@@ -87,7 +89,7 @@ RGTraitV2DescriptionStrategy >> instanceVariables: aCollectionOfSymbols [
 		layout addSlot: (RGInstanceVariableSlot named: instVarName asSymbol parent: self)]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitV2DescriptionStrategy >> instanceVariablesString [
 	"Answer a string of my instance variable names separated by spaces."
 
@@ -97,13 +99,13 @@ RGTraitV2DescriptionStrategy >> instanceVariablesString [
 			separatedBy: [ stream space ] ]
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGTraitV2DescriptionStrategy >> isTrait [
 
 	^true
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGTraitV2DescriptionStrategy >> makeResolved [
 
 	super makeResolved.
@@ -111,13 +113,13 @@ RGTraitV2DescriptionStrategy >> makeResolved [
 	layout := self layout makeResolved markAsRingResolved
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGTraitV2DescriptionStrategy >> pvtLayout [
 
 	^ layout value
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGTraitV2DescriptionStrategy >> pvtLayout: anRGLayout [
 
 	self owner environment verifyOwnership: anRGLayout.
@@ -125,7 +127,7 @@ RGTraitV2DescriptionStrategy >> pvtLayout: anRGLayout [
 	^ layout := anRGLayout
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGTraitV2DescriptionStrategy >> pvtResolvableProperties [
 
 	^ super pvtResolvableProperties, {
@@ -133,7 +135,7 @@ RGTraitV2DescriptionStrategy >> pvtResolvableProperties [
      	}
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 RGTraitV2DescriptionStrategy >> storeOn: aStream [
 	aStream
 		nextPutAll: '(';
@@ -143,13 +145,13 @@ RGTraitV2DescriptionStrategy >> storeOn: aStream [
 	aStream nextPut: $)
 ]
 
-{ #category : #variables }
+{ #category : 'variables' }
 RGTraitV2DescriptionStrategy >> trait [
 
 	^ self owner
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2DescriptionStrategy >> traitTransformationString [
 
 	^ self owner name

--- a/src/Ring-Core/RGTraitV2Strategy.class.st
+++ b/src/Ring-Core/RGTraitV2Strategy.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #RGTraitV2Strategy,
-	#superclass : #RGTraitV2DescriptionStrategy,
+	#name : 'RGTraitV2Strategy',
+	#superclass : 'RGTraitV2DescriptionStrategy',
 	#instVars : [
 		'comment',
 		'classVariables',
@@ -8,36 +8,38 @@ Class {
 		'sharedPools',
 		'classTrait'
 	],
-	#category : #'Ring-Core-Kernel'
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> acceptVisitor: aVisitor [
 
 	^ aVisitor visitClass: self owner
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> addClassVariable: anRGInstanceVariableDefinition [
 
 	self owner announceDefinitionChangeDuring: [
 		self privAddClassVariable: anRGInstanceVariableDefinition ]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> addSharedPool: anRGPoolVariable [
 
 	self owner announceDefinitionChangeDuring: [
 		self privAddSharedPool: anRGPoolVariable ]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> allClassVarNames [
 
 	^self allClassVariables collect:[ :cvar| cvar name ]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> allClassVariables [
 	"Answer a collection of the receiver's classVariables, including those defined its superclasses"
 
@@ -46,7 +48,7 @@ RGTraitV2Strategy >> allClassVariables [
 		ifFalse: [ self owner superclass allClassVariables, classVariables ]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> bindingOf: varName [
 
 	| aSymbol |
@@ -56,7 +58,7 @@ RGTraitV2Strategy >> bindingOf: varName [
 		 self environment bindingOf: aSymbol ]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> category [
 
 	^ self owner tags
@@ -69,7 +71,7 @@ RGTraitV2Strategy >> category [
 	"todo"
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> category: aString [
 
 	| aTag |
@@ -89,31 +91,31 @@ RGTraitV2Strategy >> category: aString [
 	self announcer behaviorRecategorized: self."
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> classSide [
 
 	^ self owner metaclass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitV2Strategy >> classTrait [
 
 	^ self backend forBehavior classTraitFor: self owner
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGTraitV2Strategy >> classTrait: anRGMetatraitDefinition [
 
 	self backend forBehavior setClassTraitFor: self owner to: anRGMetatraitDefinition
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> classVarNames [
 
 	^ self classVariables collect: [ :each | each name ]
 ]
 
-{ #category : #'class variables' }
+{ #category : 'class variables' }
 RGTraitV2Strategy >> classVariableDefinitionString [
 	"Answer a string that evaluates to the definition of the class Variables"
 
@@ -128,13 +130,13 @@ RGTraitV2Strategy >> classVariableDefinitionString [
 		str nextPutAll: ' }'. ]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> classVariables [
 
 	^ Array streamContents: [ :str | self classVariablesDo: [ :each | str nextPut: each ] ]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> classVariables: aCollectionOfSymbols [
 
 	self cleanClassVariables.
@@ -142,32 +144,32 @@ RGTraitV2Strategy >> classVariables: aCollectionOfSymbols [
 		self addClassVariable: (RGClassVariable named: classVarName asSymbol parent: self).]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> classVariablesDo: aBlock [
 
 	self backend forBehavior classVariablesFor: self owner do: aBlock
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> cleanClassVariables [
 
 	self owner announceDefinitionChangeDuring: [
 		self backend forBehavior cleanClassVariablesFor: self owner ]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> cleanSharedPools [
 
 	self backend forBehavior cleanSharedPoolsFor: self owner
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> comment [
 
 	^ self backend forBehavior commentFor: self owner
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> comment: anRGComment [
 
 	self backend forBehavior setCommentFor: self owner to: anRGComment.
@@ -175,7 +177,7 @@ RGTraitV2Strategy >> comment: anRGComment [
 	self owner announcer behaviorCommentModified: self
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> copyForBehaviorDefinitionPostCopy [
 
 	| newVariables newSharedPools |
@@ -194,37 +196,37 @@ RGTraitV2Strategy >> copyForBehaviorDefinitionPostCopy [
 	newSharedPools do: [ :each | self privAddSharedPool: each ]
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGTraitV2Strategy >> defaultClassVariables [
 
 	^ OrderedCollection new
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGTraitV2Strategy >> defaultComment [
 
 	^ self owner defaultCommentStubIn: self owner
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGTraitV2Strategy >> defaultMetaClass [
 
 	^ self owner environment backend createNewUnresolvedMetaclassFor: self owner
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGTraitV2Strategy >> defaultPackage [
 
 	^ self owner defaultPackageStubIn: self environment
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGTraitV2Strategy >> defaultSharedPools [
 
 	^ OrderedCollection new
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGTraitV2Strategy >> definition [
 	"Answer a String that defines the receiver"
 
@@ -243,7 +245,7 @@ RGTraitV2Strategy >> definition [
 				store: self category asString]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGTraitV2Strategy >> definitionWithSlots [
 
 	| aStream poolString|
@@ -281,7 +283,7 @@ RGTraitV2Strategy >> definitionWithSlots [
 	^ aStream contents
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGTraitV2Strategy >> initialize [
 
 	super initialize.
@@ -292,7 +294,7 @@ RGTraitV2Strategy >> initialize [
 	sharedPools := self unresolvedValue: self defaultSharedPools
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGTraitV2Strategy >> initializeUnresolved [
 
 	super initializeUnresolved.
@@ -303,7 +305,7 @@ RGTraitV2Strategy >> initializeUnresolved [
 	sharedPools := self unresolvedValue: self defaultSharedPools
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> innerBindingOf: aSymbol [
 
 	self classVariables detect: [ :each | each name = aSymbol  ] ifFound: [ :found | ^ found ].
@@ -316,13 +318,13 @@ RGTraitV2Strategy >> innerBindingOf: aSymbol [
 	^ nil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGTraitV2Strategy >> isClass [
 
 	^ true
 ]
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGTraitV2Strategy >> makeResolved [
 
 
@@ -340,13 +342,13 @@ RGTraitV2Strategy >> makeResolved [
 	sharedPools := self sharedPools markAsRingResolved
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGTraitV2Strategy >> package [
 
 	^ self backend forBehavior packageFor: self owner
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGTraitV2Strategy >> package: anRGPackage [
 
 	| oldPackage |
@@ -365,19 +367,19 @@ RGTraitV2Strategy >> package: anRGPackage [
 		newPackage: anRGPackage)
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> privAddClassVariable: anRGInstanceVariableDefinition [
 
 	self backend forBehavior addClassVariable: anRGInstanceVariableDefinition to: self owner
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> privAddSharedPool: anRGPoolVariable [
 
 	self backend forBehavior addSharedPool: anRGPoolVariable to: self owner
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> pvtAddClassVariable: anRGInstanceVariableDefinition [
 
 	self owner environment verifyOwnership: anRGInstanceVariableDefinition.
@@ -388,7 +390,7 @@ RGTraitV2Strategy >> pvtAddClassVariable: anRGInstanceVariableDefinition [
 	classVariables add: anRGInstanceVariableDefinition
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> pvtAddSharedPool: anRGPoolVariable [
 
 	self owner environment verifyOwnership: anRGPoolVariable.
@@ -399,13 +401,13 @@ RGTraitV2Strategy >> pvtAddSharedPool: anRGPoolVariable [
 	sharedPools add: anRGPoolVariable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGTraitV2Strategy >> pvtClassTrait [
 
 	^ classTrait value
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> pvtClassTrait: anRGMetatraitDefinition [
 
 	self owner environment verifyOwnership: anRGMetatraitDefinition.
@@ -413,31 +415,31 @@ RGTraitV2Strategy >> pvtClassTrait: anRGMetatraitDefinition [
 	^ classTrait := anRGMetatraitDefinition
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> pvtClassVariablesDo: aBlock [
 
 	classVariables value do: aBlock
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> pvtCleanClassVariables [
 
 	classVariables := self defaultClassVariables
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> pvtCleanSharedPools [
 
 	sharedPools := self defaultSharedPools
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> pvtComment [
 
 	^ comment value
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> pvtComment: anRGComment [
 
 	self owner environment verifyOwnership: anRGComment.
@@ -445,13 +447,13 @@ RGTraitV2Strategy >> pvtComment: anRGComment [
 	^ comment := anRGComment
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGTraitV2Strategy >> pvtPackage [
 
 	^ package value
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGTraitV2Strategy >> pvtPackage: anRGPackage [
 
 	self owner environment verifyOwnership: anRGPackage.
@@ -459,7 +461,7 @@ RGTraitV2Strategy >> pvtPackage: anRGPackage [
 	^ package := anRGPackage
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> pvtRemoveClassVariable: anRGInstanceVariableDefinition [
 
 	self owner environment verifyOwnership: anRGInstanceVariableDefinition.
@@ -467,7 +469,7 @@ RGTraitV2Strategy >> pvtRemoveClassVariable: anRGInstanceVariableDefinition [
 	classVariables remove: anRGInstanceVariableDefinition
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> pvtRemoveSharedPool: anRGPoolVariableDefinition [
 
 	self owner environment verifyOwnership: anRGPoolVariableDefinition.
@@ -475,7 +477,7 @@ RGTraitV2Strategy >> pvtRemoveSharedPool: anRGPoolVariableDefinition [
 	sharedPools remove: anRGPoolVariableDefinition
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGTraitV2Strategy >> pvtResolvableProperties [
 
 	^ super pvtResolvableProperties, {
@@ -486,27 +488,27 @@ RGTraitV2Strategy >> pvtResolvableProperties [
 	}
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 RGTraitV2Strategy >> pvtSharedPoolsDo: aBlock [
 
 	sharedPools value do: aBlock
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> removeClassVariable: anRGInstanceVariableDefinition [
 
 	self owner announceDefinitionChangeDuring: [
 		self backend forBehavior removeClassVariable: anRGInstanceVariableDefinition from: self owner ]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> removeSharedPool: anRGPoolVariable [
 
 	self owner announceDefinitionChangeDuring: [
 		self backend forBehavior removeSharedPool: anRGPoolVariable from: self owner]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> sharedPoolNames [
 
 	| allSharedPools |
@@ -515,7 +517,7 @@ RGTraitV2Strategy >> sharedPoolNames [
 	^ allSharedPools asArray
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> sharedPools [
 
 	| allSharedPools |
@@ -534,7 +536,7 @@ RGTraitV2Strategy >> sharedPools [
 	^ allSharedPools
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> sharedPools: aCollectionOfSymbols [
 
 	self cleanSharedPools.
@@ -542,19 +544,19 @@ RGTraitV2Strategy >> sharedPools: aCollectionOfSymbols [
 		self addSharedPool: (RGPoolVariable named: poolName asSymbol parent: self).]
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> sharedPoolsDo: aBlock [
 
 	self owner backend forBehavior sharedPoolsFor: self owner do: aBlock
 ]
 
-{ #category : #'private - backend access' }
+{ #category : 'private - backend access' }
 RGTraitV2Strategy >> sibling [
 
 	^ self owner metaclass
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGTraitV2Strategy >> storeName [
 
 	^ 'RGClass'

--- a/src/Ring-Core/RGUnknownSlot.class.st
+++ b/src/Ring-Core/RGUnknownSlot.class.st
@@ -1,39 +1,41 @@
 Class {
-	#name : #RGUnknownSlot,
-	#superclass : #RGSlot,
+	#name : 'RGUnknownSlot',
+	#superclass : 'RGSlot',
 	#instVars : [
 		'expression'
 	],
-	#category : #'Ring-Core-Kernel'
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'default model values' }
+{ #category : 'default model values' }
 RGUnknownSlot >> defaultExpression [
 
 	'InstanceVariableSlot named: #slotOfUnknownType'
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGUnknownSlot >> definitionString [
 
 	^ String streamContents: [ :aStream |
 		aStream nextPutAll: '#'; nextPutAll: self name; nextPutAll: ' => '; nextPutAll: self expression ]
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGUnknownSlot >> expression [
 
 	^ self backend forBehavior expressionFor: self
 ]
 
-{ #category : #'accessing - backend' }
+{ #category : 'accessing - backend' }
 RGUnknownSlot >> expression: aString [
 
 	self parent parent announceDefinitionChangeDuring: [
 		self backend forBehavior setExpressionFor: self to: aString ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGUnknownSlot >> initialize [
 
 	super initialize.
@@ -41,7 +43,7 @@ RGUnknownSlot >> initialize [
 	expression := self unresolvedValue: self defaultExpression
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RGUnknownSlot >> initializeUnresolved [
 
 	super initializeUnresolved.
@@ -49,7 +51,7 @@ RGUnknownSlot >> initializeUnresolved [
 	expression := self unresolvedValue: self defaultExpression
 ]
 
-{ #category : #resolving }
+{ #category : 'resolving' }
 RGUnknownSlot >> makeResolved [
 
 	super makeResolved.
@@ -57,19 +59,19 @@ RGUnknownSlot >> makeResolved [
 	expression := self expression markAsRingResolved
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGUnknownSlot >> pvtExpression [
 
 	^ expression value
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGUnknownSlot >> pvtExpression: aString [
 
 	^ expression := aString
 ]
 
-{ #category : #'private - backend interface' }
+{ #category : 'private - backend interface' }
 RGUnknownSlot >> pvtResolvableProperties [
 
 	^ super pvtResolvableProperties, {

--- a/src/Ring-Core/RGUnresolvedValue.class.st
+++ b/src/Ring-Core/RGUnresolvedValue.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #RGUnresolvedValue,
-	#superclass : #Object,
+	#name : 'RGUnresolvedValue',
+	#superclass : 'Object',
 	#instVars : [
 		'default'
 	],
-	#category : #'Ring-Core-Kernel'
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RGUnresolvedValue class >> recursive [
 
 	| unresolvedValue |
@@ -17,59 +19,59 @@ RGUnresolvedValue class >> recursive [
 	^ unresolvedValue
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGUnresolvedValue >> default [
 	^ default
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGUnresolvedValue >> default: anObject [
 	default := anObject
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGUnresolvedValue >> hasResolvedName [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGUnresolvedValue >> isRGUnresolvedValue [
 
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGUnresolvedValue >> isRingFullyResolved [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGUnresolvedValue >> isRingFullyUnresolved [
 
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGUnresolvedValue >> isRingResolved [
 
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGUnresolvedValue >> orDefaultForUnresolved [
 
 	^ self default
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGUnresolvedValue >> referencedBehaviors [
 
 	^ #()
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGUnresolvedValue >> value [
 
 	^ self default

--- a/src/Ring-Core/RGVariable.class.st
+++ b/src/Ring-Core/RGVariable.class.st
@@ -2,25 +2,27 @@
 A variable definition
 "
 Class {
-	#name : #RGVariable,
-	#superclass : #RGElement,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGVariable',
+	#superclass : 'RGElement',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 RGVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 	^ aProgramNodeVisitor visitVariableNode: aNode
 ]
 
-{ #category : #'read/write usage' }
+{ #category : 'read/write usage' }
 RGVariable >> analyzeRead: aVariableNode by: aSemanticAnalyzer [
 ]
 
-{ #category : #'read/write usage' }
+{ #category : 'read/write usage' }
 RGVariable >> analyzeWrite: aVariableNode by: aSemanticAnalyzer [
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGVariable >> definitionString [
 	"non special globals are defined by the symbol"
 	^self needsFullDefinition
@@ -29,86 +31,86 @@ RGVariable >> definitionString [
 		ifFalse: [self name printString]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGVariable >> isArgumentVariable [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGVariable >> isClassInstanceVariable [
 
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGVariable >> isClassVariable [
 
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGVariable >> isInstanceVariable [
 	"check if the var is an instance variable (a Slot)"
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGVariable >> isLocalVariable [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGVariable >> isPoolVariable [
 
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGVariable >> isPseudoVariable [
 	"Ring2 does not model self, super, thisContext, thisProcess"
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGVariable >> isSuperVariable [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGVariable >> isTempVariable [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGVariable >> isUninitialized [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGVariable >> isVariable [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGVariable >> isWorkspaceVariable [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGVariable >> isWritable [
 	"Ring2 variables are all writable, e.g. it does not model Arguments"
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RGVariable >> name: aString [
 
 	self parent announceDefinitionChangeDuring: [
 		super name: aString ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RGVariable >> needsFullDefinition [
 	"all but InstanceVariableSlot and ClassVariable need to print the full definition"
 	^true

--- a/src/Ring-Core/RGVariableLayout.class.st
+++ b/src/Ring-Core/RGVariableLayout.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RGVariableLayout,
-	#superclass : #RGPointerLayout,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGVariableLayout',
+	#superclass : 'RGPointerLayout',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #description }
+{ #category : 'description' }
 RGVariableLayout class >> subclassDefiningSymbol [
 	"Answer a keyword that describes the receiver's kind of subclass
 	Note: this is for printing the ST80 style class definiton."
@@ -12,7 +14,7 @@ RGVariableLayout class >> subclassDefiningSymbol [
 	^ #variableSubclass:
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGVariableLayout >> isVariableLayout [
 
 	^ true

--- a/src/Ring-Core/RGWeakLayout.class.st
+++ b/src/Ring-Core/RGWeakLayout.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RGWeakLayout,
-	#superclass : #RGPointerLayout,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGWeakLayout',
+	#superclass : 'RGPointerLayout',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #description }
+{ #category : 'description' }
 RGWeakLayout class >> subclassDefiningSymbol [
 	"Answer a keyword that describes the receiver's kind of subclass
 	Note: this is for printing the ST80 style class definiton."
@@ -12,13 +14,13 @@ RGWeakLayout class >> subclassDefiningSymbol [
 	^ #weakSubclass:
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGWeakLayout >> isVariableLayout [
 
 	^ true
 ]
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGWeakLayout >> isWeakLayout [
 
 	^ true

--- a/src/Ring-Core/RGWordLayout.class.st
+++ b/src/Ring-Core/RGWordLayout.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RGWordLayout,
-	#superclass : #RGBitsLayout,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGWordLayout',
+	#superclass : 'RGBitsLayout',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }
 
-{ #category : #'testing - types' }
+{ #category : 'testing - types' }
 RGWordLayout >> isWordLayout [
 
 	^ true

--- a/src/Ring-Core/RGWrongEnvironment.class.st
+++ b/src/Ring-Core/RGWrongEnvironment.class.st
@@ -2,7 +2,9 @@
 Trying to add to a model an element from a different environment.
 "
 Class {
-	#name : #RGWrongEnvironment,
-	#superclass : #Error,
-	#category : #'Ring-Core-Kernel'
+	#name : 'RGWrongEnvironment',
+	#superclass : 'Error',
+	#category : 'Ring-Core-Kernel',
+	#package : 'Ring-Core',
+	#tag : 'Kernel'
 }

--- a/src/Ring-Core/RPackage.extension.st
+++ b/src/Ring-Core/RPackage.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #RPackage }
+Extension { #name : 'RPackage' }
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 RPackage >> asRingMinimalDefinitionIn: anRGEnvironment [
 
 	^ anRGEnvironment backend definitionFor: self ifAbsentRegister: [

--- a/src/Ring-Core/Slot.extension.st
+++ b/src/Ring-Core/Slot.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Slot }
+Extension { #name : 'Slot' }
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 Slot >> asRingMinimalDefinitionIn: anRGEnvironment [
 	^ anRGEnvironment backend definitionFor: self ifAbsentRegister: [
 		RGUnknownSlot named: self name asSymbol parent: (self definingClass classLayout asRingMinimalDefinitionIn: anRGEnvironment)]

--- a/src/Ring-Core/VariableLayout.extension.st
+++ b/src/Ring-Core/VariableLayout.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #VariableLayout }
+Extension { #name : 'VariableLayout' }
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 VariableLayout >> asRingMinimalDefinitionIn: anRGEnvironment [
 
 	^ anRGEnvironment backend definitionFor: self ifAbsentRegister: [

--- a/src/Ring-Core/WeakLayout.extension.st
+++ b/src/Ring-Core/WeakLayout.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #WeakLayout }
+Extension { #name : 'WeakLayout' }
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 WeakLayout >> asRingMinimalDefinitionIn: anRGEnvironment [
 
 	^ anRGEnvironment backend definitionFor: self ifAbsentRegister: [

--- a/src/Ring-Core/WordLayout.extension.st
+++ b/src/Ring-Core/WordLayout.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #WordLayout }
+Extension { #name : 'WordLayout' }
 
-{ #category : #'*Ring-Core' }
+{ #category : '*Ring-Core' }
 WordLayout >> asRingMinimalDefinitionIn: anRGEnvironment [
 
 	^ anRGEnvironment backend definitionFor: self ifAbsentRegister: [

--- a/src/Ring-Core/package.st
+++ b/src/Ring-Core/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Ring-Core' }
+Package { #name : 'Ring-Core' }

--- a/src/System-Announcements/ClassRenamed.class.st
+++ b/src/System-Announcements/ClassRenamed.class.st
@@ -8,7 +8,6 @@ Class {
 	#name : 'ClassRenamed',
 	#superclass : 'ClassAnnouncement',
 	#instVars : [
-		'category',
 		'classRenamed',
 		'newName',
 		'oldName'
@@ -19,13 +18,13 @@ Class {
 }
 
 { #category : 'instance creation' }
-ClassRenamed class >> class: aClass category: aCategoryName oldName: anOldClassName newName: aNewClassName [
-	^self new
-			classRenamed: aClass;
-			category: aCategoryName;
-			oldName: anOldClassName;
-			newName: aNewClassName;
-			yourself
+ClassRenamed class >> class: aClass oldName: anOldClassName newName: aNewClassName [
+
+	^ self new
+		  classRenamed: aClass;
+		  oldName: anOldClassName;
+		  newName: aNewClassName;
+		  yourself
 ]
 
 { #category : 'testing' }
@@ -71,13 +70,7 @@ ClassRenamed >> affectsVariablesOf: aClass [
 { #category : 'accessing' }
 ClassRenamed >> category [
 
-	^ category
-]
-
-{ #category : 'accessing' }
-ClassRenamed >> category: anObject [
-
-	category := anObject
+	^ self classRenamed category
 ]
 
 { #category : 'accessing' }

--- a/src/System-Announcements/SystemAnnouncer.class.st
+++ b/src/System-Announcements/SystemAnnouncer.class.st
@@ -109,12 +109,9 @@ SystemAnnouncer >> classParentOf: aClass renamedFrom: oldName to: newName [
 ]
 
 { #category : 'triggering' }
-SystemAnnouncer >> classRenamed: aClass from: oldClassName to: newClassName inCategory: aCategoryName [
-	self announce: (ClassRenamed
-				class: aClass
-				category: aCategoryName
-				oldName: oldClassName
-				newName: newClassName)
+SystemAnnouncer >> classRenamed: aClass from: oldClassName to: newClassName [
+
+	self announce: (ClassRenamed class: aClass oldName: oldClassName newName: newClassName)
 ]
 
 { #category : 'triggering' }

--- a/src/System-Changes/ChangeRecord.class.st
+++ b/src/System-Changes/ChangeRecord.class.st
@@ -4,8 +4,8 @@ A ChangeRecord represents a change recorded on a file in fileOut format.
 It includes a type (more needs to be done here), and additional information for certain types such as method defs which need class and protocol name.
 "
 Class {
-	#name : #ChangeRecord,
-	#superclass : #Object,
+	#name : 'ChangeRecord',
+	#superclass : 'Object',
 	#instVars : [
 		'file',
 		'position',
@@ -15,10 +15,12 @@ Class {
 		'meta',
 		'stamp'
 	],
-	#category : #'System-Changes-Records'
+	#category : 'System-Changes-Records',
+	#package : 'System-Changes',
+	#tag : 'Records'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ChangeRecord >> <= anotherOne [
 
 	self stamp ifNil: [ ^ false ].
@@ -26,7 +28,7 @@ ChangeRecord >> <= anotherOne [
 	^ self timeStamp <= anotherOne timeStamp
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ChangeRecord >> classIncludesSelector [
 
 	| aClass |
@@ -34,7 +36,7 @@ ChangeRecord >> classIncludesSelector [
 			and: [aClass includesSelector: self methodSelector]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ChangeRecord >> commentClass [
 	| commentClass |
 	type == #classComment ifFalse: [^ nil].
@@ -44,14 +46,14 @@ ChangeRecord >> commentClass [
 		ifFalse: [commentClass]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ChangeRecord >> file: f position: p type: t [
 	file := f.
 	position := p.
 	type := t
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ChangeRecord >> file: f position: p type: t class: c protocol: aProtocol meta: m stamp: s [
 	self file: f position: p type: t.
 	class := c.
@@ -60,7 +62,7 @@ ChangeRecord >> file: f position: p type: t class: c protocol: aProtocol meta: m
 	stamp := s
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ChangeRecord >> fileIn [
 	"File the receiver in.  If I represent a method or a class-comment, file the method in and make a note of it in the recent-submissions list; if I represent a do-it, then, well, do it."
 
@@ -78,12 +80,12 @@ ChangeRecord >> fileIn [
 		type == #classComment ifTrue: [ (Smalltalk globals at: class asSymbol) comment: self string stamp: stamp ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ChangeRecord >> fileName [
 	^file ifNotNil: [ file name ] ifNil: [ '<no file>' ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ChangeRecord >> fileOutOn: aFileStream [
 	"File the receiver out on the given file stream"
 
@@ -113,12 +115,12 @@ ChangeRecord >> fileOutOn: aFileStream [
 	aFileStream cr
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ChangeRecord >> isMetaClassChange [
 	^meta
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ChangeRecord >> isMethodDefinedInImage [
 	"answer whether the method represented by the receiver is present in the image"
 
@@ -126,7 +128,7 @@ ChangeRecord >> isMethodDefinedInImage [
 		and: [self classIncludesSelector]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ChangeRecord >> isMethodNotDefinedInImage [
 	"answer whether the method represented by the receiver is not present in the image.
 	pay attention is it not just isMethodDefinedInImage not"
@@ -137,7 +139,7 @@ ChangeRecord >> isMethodNotDefinedInImage [
 				[(aClass includesSelector: self methodSelector) not]]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ChangeRecord >> isUnchangedMethod [
 
 	^ self isMethodDefinedInImage
@@ -145,7 +147,7 @@ ChangeRecord >> isUnchangedMethod [
 				= (self methodClass sourceCodeAt: self methodSelector) asString withBlanksCondensed ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ChangeRecord >> methodClass [
 	| methodClass |
 	type == #method
@@ -158,38 +160,38 @@ ChangeRecord >> methodClass [
 		ifFalse: [ methodClass ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ChangeRecord >> methodClassName [
 	^ meta
 		ifTrue: [ class , ' class' ]
 		ifFalse: [ class ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ChangeRecord >> methodSelector [
 	^ type == #method
 		ifTrue: [ (Smalltalk globals at: class ifAbsent: [ Object ]) compiler parseSelector: self string ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ChangeRecord >> position [
 	^ position
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ChangeRecord >> printOn: aStream [
 
 	self type printOn: aStream.
 	self stamp ifNotNil: [ :s | s printOn: aStream ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ChangeRecord >> protocol [
 
 	^ protocol
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ChangeRecord >> sourceCode [
 
 	self type= #preamble ifTrue: [ ^ #preamble printString ].
@@ -199,18 +201,18 @@ ChangeRecord >> sourceCode [
 	^ self string
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ChangeRecord >> stamp [
 	^ stamp
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ChangeRecord >> stamp: threePartString [
 
 	stamp := threePartString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ChangeRecord >> string [
 	| copy |
 	copy := file readOnlyCopy.
@@ -219,7 +221,7 @@ ChangeRecord >> string [
 		ensure: [ copy close ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ChangeRecord >> timeStamp [
 	"Answer a TimeStamp that corresponds to my (text) stamp"
 
@@ -237,7 +239,7 @@ ChangeRecord >> timeStamp [
 		ifFalse: [ DateAndTime new ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ChangeRecord >> type [
 	^ type
 ]

--- a/src/System-Changes/ChangeSet.class.st
+++ b/src/System-Changes/ChangeSet.class.st
@@ -9,8 +9,8 @@ changeRecords -  Dictionary {class name -> a ClassChangeRecord}.
 These classChangeRecords (qv) remember all of the system changes.
 "
 Class {
-	#name : #ChangeSet,
-	#superclass : #Object,
+	#name : 'ChangeSet',
+	#superclass : 'Object',
 	#instVars : [
 		'name',
 		'preamble',
@@ -25,30 +25,32 @@ Class {
 	#classInstVars : [
 		'current'
 	],
-	#category : #'System-Changes-Base'
+	#category : 'System-Changes-Base',
+	#package : 'System-Changes',
+	#tag : 'Base'
 }
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ChangeSet class >> allChangeSetNames [
 
 	^ self allChangeSets collect: [:c | c name]
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ChangeSet class >> allChangeSets [
 	"Return the list of all current ChangeSets"
 
 	^ AllChangeSets
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ChangeSet class >> allChangeSets: aCollection [
 	"Return the list of all current ChangeSets"
 
 	AllChangeSets := aCollection
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ChangeSet class >> allChangeSetsWithClass: class selector: selector [
 
 	class ifNil: [^ #()].
@@ -56,7 +58,7 @@ ChangeSet class >> allChangeSetsWithClass: class selector: selector [
 		[:cs | (cs atSelector: selector class: class) ~~ #none]
 ]
 
-{ #category : #services }
+{ #category : 'services' }
 ChangeSet class >> assuredChangeSetNamed: aName [
 	"Answer a change set of the given name.  If one already exists, answer that, else create a new one and answer it."
 
@@ -65,7 +67,7 @@ ChangeSet class >> assuredChangeSetNamed: aName [
 		  ifNil: [ self newChangeSet: aName ]
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ChangeSet class >> changeSetsNamedSuchThat: nameBlock [
 
 	"(ChangeSet changeSetsNamedSuchThat:
@@ -75,7 +77,7 @@ ChangeSet class >> changeSetsNamedSuchThat: nameBlock [
 	^ AllChangeSets select: [:aChangeSet | nameBlock value: aChangeSet name]
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet class >> classesOrder: classes [
 	"Answer a collection with the classes ordered so they can be filed in."
 
@@ -86,7 +88,7 @@ ChangeSet class >> classesOrder: classes [
 	^ listInOrder
 ]
 
-{ #category : #cleanup }
+{ #category : 'cleanup' }
 ChangeSet class >> cleanUp: aggressive [
 	"Only delete change sets when being aggressive"
 
@@ -96,14 +98,14 @@ ChangeSet class >> cleanUp: aggressive [
 	self resetCurrentToNewUnnamedChangeSet
 ]
 
-{ #category : #services }
+{ #category : 'services' }
 ChangeSet class >> countOfChangeSetsWithClass: aClass andSelector: aSelector [
 	"Answer how many change sets record a change for the given class and selector"
 
 	^ (self allChangeSetsWithClass: aClass selector: aSelector) size
 ]
 
-{ #category : #'current changeset' }
+{ #category : 'current changeset' }
 ChangeSet class >> current [
 	"Return the current changeset assure first that we have a named changeset."
 
@@ -114,7 +116,7 @@ ChangeSet class >> current [
 	^ current
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 ChangeSet class >> defaultChangeSetDirectory [
 	"Answer the directory in which to store ChangeSets.
 	Answer the default directory if the preferred directory doesn't exist."
@@ -128,7 +130,7 @@ ChangeSet class >> defaultChangeSetDirectory [
 	^ FileSystem workingDirectory
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 ChangeSet class >> defaultChangeSetDirectory: dirOrName [
 	"Set the Preference for storing change sets to the given directory or name (possibly relative).
 	Rewrite directory names below the default directory as relative names.
@@ -151,33 +153,33 @@ ChangeSet class >> defaultChangeSetDirectory: dirOrName [
 	self defaultChangeSetDirectoryName: dirName
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 ChangeSet class >> defaultChangeSetDirectoryName [
 
 	^ DefaultChangeSetDirectoryName ifNil: [
 		  DefaultChangeSetDirectoryName := FileSystem workingDirectory ]
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 ChangeSet class >> defaultChangeSetDirectoryName: aName [
 
 	DefaultChangeSetDirectoryName := aName
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 ChangeSet class >> defaultName [
 
 	^ self uniqueNameLike: 'Unnamed'
 ]
 
-{ #category : #services }
+{ #category : 'services' }
 ChangeSet class >> doesAnyChangeSetHaveClass: aClass andSelector: aSelector [
 	"Answer whether any known change set bears a change for the given class and selector"
 
 	^ (self countOfChangeSetsWithClass: aClass andSelector: aSelector) > 0
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet class >> fileOutChangeSetsNamed: nameList [
 	"File out the list of change sets whose names are provided"
      "ChangesOrganizer fileOutChangeSetsNamed: #('New Changes' 'miscTidies-sw')"
@@ -211,7 +213,7 @@ ChangeSet class >> fileOutChangeSetsNamed: nameList [
 	self inform: infoString
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ChangeSet class >> gatherChangeSets [
 	"Collect any change sets created in other projects"
 	<script>
@@ -228,7 +230,7 @@ ChangeSet class >> gatherChangeSets [
 	^ AllChangeSets
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet class >> hasNoDependenciesFor: aTrait in: traits [
 	"Answer if the trait does not depend on a trait in the collection."
 
@@ -238,7 +240,7 @@ ChangeSet class >> hasNoDependenciesFor: aTrait in: traits [
 				(aTrait traitComposition allTraits includes: another) not ] ] ]
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 ChangeSet class >> initialize [
 
 	AllChangeSets ifNil: [ AllChangeSets := OrderedCollection new ].
@@ -246,7 +248,7 @@ ChangeSet class >> initialize [
 	self gatherChangeSets
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ChangeSet class >> mostRecentChangeSetWithChangeForClass: class selector: selector [
 
 	| hits |
@@ -256,19 +258,19 @@ ChangeSet class >> mostRecentChangeSetWithChangeForClass: class selector: select
 	^ 'recent cs: ', hits last name
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 ChangeSet class >> mustCheckForSlips [
 
 	^ MustCheckForSlips ifNil: [ MustCheckForSlips := true ]
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 ChangeSet class >> mustCheckForSlips: aBoolean [
 
 	MustCheckForSlips := aBoolean
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ChangeSet class >> named: aName [
 	"Return the change set of the given name, or nil if none found."
 
@@ -277,7 +279,7 @@ ChangeSet class >> named: aName [
 		  ifNone: [ nil ]
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ChangeSet class >> new [
 	"All current changeSets must be registered in the AllChangeSets collection.
 	Due to a quirk of history, this is maintained as class variable of ChangeSorter."
@@ -285,7 +287,7 @@ ChangeSet class >> new [
 	^ self newChangeSet: self defaultName
 ]
 
-{ #category : #services }
+{ #category : 'services' }
 ChangeSet class >> newChangeSet [
 	"Prompt the user for a name, and establish a new change set of
 	that name (if ok), making it the current changeset.  Return nil
@@ -299,7 +301,7 @@ ChangeSet class >> newChangeSet [
 	^ newSet
 ]
 
-{ #category : #services }
+{ #category : 'services' }
 ChangeSet class >> newChangeSet: newName [
 
 	| newSet |
@@ -312,7 +314,7 @@ ChangeSet class >> newChangeSet: newName [
 	^ newSet
 ]
 
-{ #category : #'current changeset' }
+{ #category : 'current changeset' }
 ChangeSet class >> newChanges: aChangeSet [
 	"Set the system ChangeSet to be the argument, aChangeSet."
 
@@ -321,7 +323,7 @@ ChangeSet class >> newChanges: aChangeSet [
 	self newChanges: aChangeSet withOld: self current
 ]
 
-{ #category : #'current changeset' }
+{ #category : 'current changeset' }
 ChangeSet class >> newChanges: aChangeSet withOld: old [
 	"Set the system ChangeSet to be the argument, aChangeSet."
 
@@ -347,7 +349,7 @@ ChangeSet class >> newChanges: aChangeSet withOld: old [
 	SystemAnnouncer announce: (CurrentChangeSetChanged new old: old; new: aChangeSet ; yourself)
 ]
 
-{ #category : #services }
+{ #category : 'services' }
 ChangeSet class >> newChangesFromStream: aStream named: aName [
 	"File in the code from the stream into a new change set whose
 	name is derived from aName. Leave the 'current change set'
@@ -364,13 +366,13 @@ ChangeSet class >> newChangesFromStream: aStream named: aName [
 	^ newSet
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ChangeSet class >> newNamed: aName [
 
 	^ (self basicNew name: aName) initialize
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ChangeSet class >> promoteToTop: aChangeSet [
 	"Make aChangeSet the first in the list from now on"
 
@@ -378,7 +380,7 @@ ChangeSet class >> promoteToTop: aChangeSet [
 	AllChangeSets add: aChangeSet
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 ChangeSet class >> promptForDefaultChangeSetDirectoryIfNecessary [
 	<script>
 
@@ -390,14 +392,14 @@ ChangeSet class >> promptForDefaultChangeSetDirectoryIfNecessary [
 	^ path asFileReference
 ]
 
-{ #category : #'system-events' }
+{ #category : 'system-events' }
 ChangeSet class >> registerInterestToSystemAnnouncer [
 	<systemEventRegistration>
 
 	self newChanges: self current
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ChangeSet class >> removeChangeSet: aChangeSet [
 	"Remove the given changeSet.  Caller must assure that it's cool to do this"
 
@@ -405,14 +407,14 @@ ChangeSet class >> removeChangeSet: aChangeSet [
 	aChangeSet wither
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 ChangeSet class >> removeChangeSetsNamedSuchThat: nameBlock [
 
 	(self changeSetsNamedSuchThat: nameBlock) do: [ :cs |
 		self removeChangeSet: cs ]
 ]
 
-{ #category : #services }
+{ #category : 'services' }
 ChangeSet class >> reorderChangeSets [
 	"Change the order of the change sets to something more convenient:
 		First come all numbered updates.
@@ -430,14 +432,14 @@ ChangeSet class >> reorderChangeSets [
 	self allChangeSets: newMid, newTail
 ]
 
-{ #category : #'current changeset' }
+{ #category : 'current changeset' }
 ChangeSet class >> resetCurrentToNewUnnamedChangeSet [
 
 	current := self new.
 	self newChanges: current
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet class >> traitsOrder: aCollection [
 	"Arrange the traits in the collection, first who don't depend on others."
 
@@ -451,7 +453,7 @@ ChangeSet class >> traitsOrder: aCollection [
 			unprocessed remove: aTrait] ]
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 ChangeSet class >> uniqueNameLike: aString [
 
 	| try index |
@@ -464,7 +466,7 @@ ChangeSet class >> uniqueNameLike: aString [
 	  index := index + 1 ] repeat
 ]
 
-{ #category : #'moving changes' }
+{ #category : 'moving changes' }
 ChangeSet >> absorbClass: className from: otherChangeSet [
 	"Absorb into the receiver all the changes found in the class in the other change set.
 	*** Classes renamed in otherChangeSet may have problems"
@@ -473,7 +475,7 @@ ChangeSet >> absorbClass: className from: otherChangeSet [
 		(otherChangeSet changeRecorderFor: className)
 ]
 
-{ #category : #'moving changes' }
+{ #category : 'moving changes' }
 ChangeSet >> absorbMethod: selector class: aClass from: aChangeSet [
 	"Absorb into the receiver all the changes for the method in the class in the other change set."
 
@@ -484,7 +486,7 @@ ChangeSet >> absorbMethod: selector class: aClass from: aChangeSet [
 	self atSelector: selector class: aClass put: (info at: selector)
 ]
 
-{ #category : #'change logging' }
+{ #category : 'change logging' }
 ChangeSet >> addClass: class [
 	"Include indication that a new class was created."
 
@@ -494,7 +496,7 @@ ChangeSet >> addClass: class [
 	self addCoherency: class name
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ChangeSet >> addCoherency: className [
 	"SqR! 19980923: If I recreate the class then don't remove it"
 
@@ -507,7 +509,7 @@ ChangeSet >> addCoherency: className [
 "
 ]
 
-{ #category : #'method changes' }
+{ #category : 'method changes' }
 ChangeSet >> adoptSelector: aSelector forClass: aClass [
 	"Adopt the given selector/class combination as a change in the receiver"
 
@@ -518,7 +520,7 @@ ChangeSet >> adoptSelector: aSelector forClass: aClass [
 		priorMethod: nil
 ]
 
-{ #category : #'moving changes' }
+{ #category : 'moving changes' }
 ChangeSet >> assimilateAllChangesFoundIn: otherChangeSet [
 	"Make all changes in otherChangeSet take effect on self as if they happened just now."
 
@@ -526,7 +528,7 @@ ChangeSet >> assimilateAllChangesFoundIn: otherChangeSet [
 		[:className | self absorbClass: className from: otherChangeSet]
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet >> assurePostscriptExists [
 	"Make sure there is a StringHolder holding the postscript.  "
 
@@ -541,28 +543,28 @@ Be sure to put any further comments in double-quotes, like this one."
 ' ]
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet >> assurePreambleExists [
 	"Make sure there is a StringHolder holding the preamble; if it's found to have reverted to empty contents, put up the template"
 
 	preamble isEmptyOrNil ifTrue: [ preamble := self preambleTemplate ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ChangeSet >> atClass: class add: changeType [
 
 	(self changeRecorderFor: class)
 		noteChangeType: changeType fromClass: class
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ChangeSet >> atClass: class includes: changeType [
 
 	^ (changeRecords at: class name ifAbsent: [ ^ false ])
 		  includesChangeType: changeType
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ChangeSet >> atSelector: selector class: class [
 
 	^ (changeRecords at: class name ifAbsent: [ ^ #none ])
@@ -570,13 +572,13 @@ ChangeSet >> atSelector: selector class: class [
 		  ifAbsent: [ ^ #none ]
 ]
 
-{ #category : #'method changes' }
+{ #category : 'method changes' }
 ChangeSet >> atSelector: selector class: class put: changeType [
 
 	(self changeRecorderFor: class) atSelector: selector put: changeType
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ChangeSet >> author [
 
 	| author |
@@ -586,7 +588,7 @@ ChangeSet >> author [
 	^ author trimBoth
 ]
 
-{ #category : #'change logging' }
+{ #category : 'change logging' }
 ChangeSet >> changeClass: class from: oldClass [
 	"Remember that a class definition has been changed.  Record the original structure, so that a conversion method can be built."
 
@@ -602,7 +604,7 @@ ChangeSet >> changeClass: class from: oldClass [
 	(self changeRecorderFor: class) notePriorDefinition: oldClass
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ChangeSet >> changeRecorderFor: class [
 
 	| cname |
@@ -612,7 +614,7 @@ ChangeSet >> changeRecorderFor: class [
 	^ changeRecords at: cname ifAbsentPut: [ ClassChangeRecord new initFor: cname ]
 ]
 
-{ #category : #'class changes' }
+{ #category : 'class changes' }
 ChangeSet >> changedClassNames [
 	"Answer a OrderedCollection of the names of changed or edited classes.
 	Does include removed classes.  Sort alphabetically."
@@ -620,7 +622,7 @@ ChangeSet >> changedClassNames [
 	^ changeRecords keysSortedSafely
 ]
 
-{ #category : #'class changes' }
+{ #category : 'class changes' }
 ChangeSet >> changedClasses [
 	"Answer an OrderedCollection of changed or edited classes.
 	Does not include removed classes.  Sort alphabetically by name."
@@ -633,7 +635,7 @@ ChangeSet >> changedClasses [
 		thenSelect: [ :aClass | aClass notNil ]
 ]
 
-{ #category : #'method changes' }
+{ #category : 'method changes' }
 ChangeSet >> changedMessageList [
 	"Used by a message set browser to access the list view information."
 
@@ -657,7 +659,7 @@ ChangeSet >> changedMessageList [
 	^ messageList asArray sort
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet >> checkForSlips [
 	"Return a collection of method refs with possible debugging code in them."
 
@@ -670,13 +672,13 @@ ChangeSet >> checkForSlips [
 	^ slips
 ]
 
-{ #category : #'change logging' }
+{ #category : 'change logging' }
 ChangeSet >> classAdded: anEvent [
 
 	self addClass: anEvent classAdded
 ]
 
-{ #category : #'class changes' }
+{ #category : 'class changes' }
 ChangeSet >> classChangeAt: className [
 	"Return what we know about class changes to this class."
 
@@ -684,13 +686,13 @@ ChangeSet >> classChangeAt: className [
 		  allChangeTypes
 ]
 
-{ #category : #'change logging' }
+{ #category : 'change logging' }
 ChangeSet >> classCommented: anEvent [
 
 	self commentClass: anEvent classCommented
 ]
 
-{ #category : #'change logging' }
+{ #category : 'change logging' }
 ChangeSet >> classModified: anEvent [
 
 	self
@@ -698,7 +700,7 @@ ChangeSet >> classModified: anEvent [
 		from: anEvent oldClassDefinition
 ]
 
-{ #category : #'change logging' }
+{ #category : 'change logging' }
 ChangeSet >> classRecategorized: anEvent [
 
 	self
@@ -706,35 +708,49 @@ ChangeSet >> classRecategorized: anEvent [
 		from: anEvent classRecategorized
 ]
 
-{ #category : #'change logging' }
+{ #category : 'change logging' }
 ChangeSet >> classRemoved: anEvent [
 
 	self noteRemovalOf: anEvent classRemoved
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ChangeSet >> classRemoves [
 
 	^ changeRecords keys select: [ :className |
 		  (changeRecords at: className) isClassRemoval ]
 ]
 
-{ #category : #'change logging' }
+{ #category : 'change logging' }
 ChangeSet >> classRenamed: anEvent [
 
-	self
-		renameClass: anEvent classRenamed
-		from: anEvent oldName
-		to: anEvent newName
+	| recorder oldMetaClassName newMetaClassName oldName newName |
+	oldName := anEvent oldName.
+	newName := anEvent newName.
+
+	(recorder := self changeRecorderFor: oldName)
+		noteChangeType: #rename;
+		noteNewName: newName asSymbol.
+
+	"store under new name (metaclass too)"
+	changeRecords at: newName put: recorder.
+	changeRecords removeKey: oldName.
+
+	newMetaClassName := newName , ' class'.
+	oldMetaClassName := oldName , ' class'.
+	recorder := changeRecords at: oldMetaClassName ifAbsent: [ ^ nil ].
+	changeRecords at: newMetaClassName put: recorder.
+	changeRecords removeKey: oldMetaClassName.
+	recorder noteNewName: newMetaClassName
 ]
 
-{ #category : #'change logging' }
+{ #category : 'change logging' }
 ChangeSet >> classReorganized: anEvent [
 
 	self reorganizeClass: anEvent classReorganized
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ChangeSet >> clear [
 
 	"Reset the receiver to be empty."
@@ -744,7 +760,7 @@ ChangeSet >> clear [
 	postscript := nil
 ]
 
-{ #category : #'class changes' }
+{ #category : 'class changes' }
 ChangeSet >> commentClass: class [
 	"Include indication that a class comment has been changed."
 
@@ -752,19 +768,19 @@ ChangeSet >> commentClass: class [
 	self atClass: class add: #comment
 ]
 
-{ #category : #'class changes' }
+{ #category : 'class changes' }
 ChangeSet >> containsClass: aClass [
 
 	^ self changedClasses includes: aClass
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet >> defaultChangeSetDirectory [
 
 	^ self class defaultChangeSetDirectory
 ]
 
-{ #category : #'change logging' }
+{ #category : 'change logging' }
 ChangeSet >> doItChunkImported: anAnnouncemnet [
 
 	self class current = self ifFalse: [ ^ self ].
@@ -777,7 +793,7 @@ ChangeSet >> doItChunkImported: anAnnouncemnet [
 		ifTrue: [ self postscriptString: anAnnouncemnet contents ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ChangeSet >> editPostscript [
 	"Edit the receiver's postscript, in a separate window."
 
@@ -788,7 +804,7 @@ ChangeSet >> editPostscript [
 		accept:[:aString| self postscript: aString]
 ]
 
-{ #category : #'moving changes' }
+{ #category : 'moving changes' }
 ChangeSet >> editPreamble [
 	"Edit the receiver's preamble, in a separate window."
 
@@ -799,14 +815,14 @@ ChangeSet >> editPreamble [
 		accept:[:aString| self preamble: aString]
 ]
 
-{ #category : #'moving changes' }
+{ #category : 'moving changes' }
 ChangeSet >> expungeEmptyClassChangeEntries [
 
 	changeRecords keysAndValuesRemove: [ :className :classRecord |
 		classRecord hasNoChanges ]
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet >> fileOut [
 	"File out the receiver, to a file whose name is a function of the
 	change-set name and a unique numeric tag."
@@ -817,7 +833,7 @@ ChangeSet >> fileOut [
 	self fileOutBody: fileReference
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet >> fileOutBody: fileReference [
 
 	UIManager default
@@ -837,7 +853,7 @@ ChangeSet >> fileOutBody: fileReference [
 				toFileReference: fileReference ]
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet >> fileOutChangesFor: class on: stream [
 	"Write out all the method changes for this class."
 
@@ -853,7 +869,7 @@ ChangeSet >> fileOutChangesFor: class on: stream [
 	stream cr
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ChangeSet >> fileOutClassDefinition: class on: stream [
 	"Write out class definition for the given class on the given stream, if the class definition was added or changed."
 
@@ -885,7 +901,7 @@ ChangeSet >> fileOutClassDefinition: class on: stream [
 	stream cr
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet >> fileOutOn: stream [
 	"Write out all the changes the receiver knows about"
 
@@ -914,7 +930,7 @@ ChangeSet >> fileOutOn: stream [
 		[:aClassName | stream nextChunkPut: 'Smalltalk removeClassNamed: #', aClassName; cr]
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet >> fileOutPSFor: class on: stream [
 	"Write out removals and initialization for this class."
 
@@ -947,7 +963,7 @@ ChangeSet >> fileOutPSFor: class on: stream [
 	stream cr
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet >> fileOutPostscriptOn: stream [
 	"If the receiver has a postscript, put it out onto the stream.  "
 
@@ -961,7 +977,7 @@ ChangeSet >> fileOutPostscriptOn: stream [
 		cr
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet >> fileOutPreambleOn: stream [
 	"If the receiver has a preamble, put it out onto the stream.  "
 
@@ -975,7 +991,7 @@ ChangeSet >> fileOutPreambleOn: stream [
 		cr
 ]
 
-{ #category : #'moving changes' }
+{ #category : 'moving changes' }
 ChangeSet >> forgetAllChangesFoundIn: otherChangeSet [
 	"Remove from the receiver all method changes found in aChangeSet. The intention is facilitate the process of factoring a large set of changes into disjoint change sets.  To use:  in a change sorter, copy over all the changes you want into some new change set, then use the subtract-other-side feature to subtract those changes from the larger change set, and continue in this manner."
 
@@ -985,7 +1001,7 @@ ChangeSet >> forgetAllChangesFoundIn: otherChangeSet [
 	self expungeEmptyClassChangeEntries
 ]
 
-{ #category : #'moving changes' }
+{ #category : 'moving changes' }
 ChangeSet >> forgetChangesForClass: className in: otherChangeSet [
 	"See forgetAllChangesFoundIn:.  Used in culling changeSets."
 
@@ -993,26 +1009,26 @@ ChangeSet >> forgetChangesForClass: className in: otherChangeSet [
 		(otherChangeSet changeRecorderFor: className)
 ]
 
-{ #category : #'method changes' }
+{ #category : 'method changes' }
 ChangeSet >> hasAnyChangeForSelector: aSelector [
 	"Answer whether the receiver has any change under the given selector, whether it be add, change, or remove, for any class"
 
 	^ changeRecords anySatisfy: [ :aRecord | aRecord changedSelectors includes: aSelector ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ChangeSet >> hasPostscript [
 
 	^ postscript notNil
 ]
 
-{ #category : #'moving changes' }
+{ #category : 'moving changes' }
 ChangeSet >> hasPreamble [
 
 	^ preamble notNil
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet >> hasReportableSlip: aMethod [
 	"Answer whether the receiver contains anything that should be brought
 	to the attention of the author when filing out. Customize the lists here
@@ -1023,7 +1039,7 @@ ChangeSet >> hasReportableSlip: aMethod [
 	^ aMethod readsRef: (Smalltalk globals associationAt: #Transcript)
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ChangeSet >> initialize [
 
 	"Initialize the receiver to be empty."
@@ -1033,28 +1049,28 @@ ChangeSet >> initialize [
 	self clear
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ChangeSet >> isEmpty [
 	"Answer whether the receiver contains any elements."
 
 	^ changeRecords isEmptyOrNil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ChangeSet >> isMoribund [
 	"Answer whether the receiver is obsolete and about to die; part of an effort to get such guys cleared out from the change sorter."
 
 	^ name isNil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ChangeSet >> isNumbered [
 	"Answer whether a change set is numbered"
 
 	^  self name startsWithDigit
 ]
 
-{ #category : #'change logging' }
+{ #category : 'change logging' }
 ChangeSet >> methodAdded: anEvent [
 
 	self
@@ -1064,7 +1080,7 @@ ChangeSet >> methodAdded: anEvent [
 		priorMethod: nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ChangeSet >> methodChanges [
 
 	| methodChangeDict |
@@ -1076,7 +1092,7 @@ ChangeSet >> methodChanges [
 	^ methodChangeDict
 ]
 
-{ #category : #'method changes' }
+{ #category : 'method changes' }
 ChangeSet >> methodChangesAtClass: className [
 	"Return an old-style dictionary of method change types."
 
@@ -1084,7 +1100,7 @@ ChangeSet >> methodChangesAtClass: className [
 		  methodChangeTypes
 ]
 
-{ #category : #'change logging' }
+{ #category : 'change logging' }
 ChangeSet >> methodModified: anEvent [
 
 	self
@@ -1094,13 +1110,13 @@ ChangeSet >> methodModified: anEvent [
 		priorMethod: anEvent oldMethod
 ]
 
-{ #category : #'change logging' }
+{ #category : 'change logging' }
 ChangeSet >> methodRecategorized: anEvent [
 
 	self reorganizeClass: anEvent methodClass
 ]
 
-{ #category : #'change logging' }
+{ #category : 'change logging' }
 ChangeSet >> methodRemoved: anEvent [
 
 	self
@@ -1110,7 +1126,7 @@ ChangeSet >> methodRemoved: anEvent [
 		lastSourcePointer: anEvent method sourcePointer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ChangeSet >> name [
 	"The name of this changeSet. If name is nil, we've got garbage.  Help to identify."
 
@@ -1119,13 +1135,13 @@ ChangeSet >> name [
 		ifNotNil: [ name ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ChangeSet >> name: anObject [
 
 	name := anObject
 ]
 
-{ #category : #'change logging' }
+{ #category : 'change logging' }
 ChangeSet >> noteNewMethod: newMethod forClass: class selector: selector priorMethod: methodOrNil [
 
 	class wantsChangeSetLogging ifFalse: [^ self].
@@ -1133,7 +1149,7 @@ ChangeSet >> noteNewMethod: newMethod forClass: class selector: selector priorMe
 		noteNewMethod: newMethod selector: selector priorMethod: methodOrNil
 ]
 
-{ #category : #'class changes' }
+{ #category : 'class changes' }
 ChangeSet >> noteRemovalOf: class [
 	"The class is about to be removed from the system.
 	Adjust the receiver to reflect that fact."
@@ -1145,13 +1161,13 @@ ChangeSet >> noteRemovalOf: class [
 	changeRecords removeKey: class class name ifAbsent: [  ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ChangeSet >> okayToRemove [
 
 	^ self okayToRemoveInforming: true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ChangeSet >> okayToRemoveInforming: aBoolean [
 	"Answer whether it is okay to remove the receiver.  If aBoolean is true, inform the receiver if it is not okay"
 
@@ -1166,13 +1182,13 @@ current change set.' ].
 	^ true
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 ChangeSet >> oldNameFor: class [
 
 	^ (changeRecords at: class name) priorName
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet >> postscript [
 	"Answer the string representing the postscript.  "
 
@@ -1182,34 +1198,34 @@ ChangeSet >> postscript [
 			  ifFalse: [ postscript contents asString ] ]
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet >> postscript: aString [
 	"Answer the string representing the postscript."
 
 	postscript := aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ChangeSet >> postscriptHasDependents [
 
 	^ false
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet >> postscriptString [
 	"Answer the string representing the postscript."
 
 	^ self postscript
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet >> postscriptString: aString [
 	"Establish aString as the new contents of the postscript."
 
 	self postscript: aString
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet >> preamble [
 	"Answer the string representing the preamble"
 
@@ -1219,28 +1235,28 @@ ChangeSet >> preamble [
 			  ifFalse: [ preamble contents asString ] ]
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet >> preamble: aString [
 	"Establish aString as the new contents of the preamble.  "
 
 	preamble := aString
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet >> preambleString [
 	"Answer the string representing the preamble"
 
 	^self preamble
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet >> preambleString: aString [
 	"Establish aString as the new contents of the preamble."
 
 	self preamble: aString
 ]
 
-{ #category : #'file in/out' }
+{ #category : 'file in/out' }
 ChangeSet >> preambleTemplate [
 	"Answer a string that will form the default contents for a change set's preamble.
 	Just a first stab at what the content should be."
@@ -1265,7 +1281,7 @@ ChangeSet >> preambleTemplate [
 			  nextPutAll: '<your descriptive text goes here>"' ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ChangeSet >> printOn: aStream [
 
 	super printOn: aStream.
@@ -1274,7 +1290,7 @@ ChangeSet >> printOn: aStream [
 		nextPutAll: self name
 ]
 
-{ #category : #'moving changes' }
+{ #category : 'moving changes' }
 ChangeSet >> removeClassAndMetaClassChanges: class [
 	"Remove all memory of changes associated with this class and its metaclass."
 
@@ -1283,7 +1299,7 @@ ChangeSet >> removeClassAndMetaClassChanges: class [
 		removeKey: class class name ifAbsent: []
 ]
 
-{ #category : #'moving changes' }
+{ #category : 'moving changes' }
 ChangeSet >> removeClassChanges: class [
 	"Remove all memory of changes associated with this class"
 
@@ -1294,19 +1310,19 @@ ChangeSet >> removeClassChanges: class [
 	changeRecords removeKey: cname ifAbsent: [  ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ChangeSet >> removePostscript [
 
 	postscript := nil
 ]
 
-{ #category : #'moving changes' }
+{ #category : 'moving changes' }
 ChangeSet >> removePreamble [
 
 	preamble := nil
 ]
 
-{ #category : #'change logging' }
+{ #category : 'change logging' }
 ChangeSet >> removeSelector: selector class: class priorMethod: priorMethod lastSourcePointer: lastSourcePointer [
 	"Include indication that a method has been forgotten."
 
@@ -1314,7 +1330,7 @@ ChangeSet >> removeSelector: selector class: class priorMethod: priorMethod last
 	(self changeRecorderFor: class) noteRemoveSelector: selector priorMethod: priorMethod lastSourcePointer: lastSourcePointer
 ]
 
-{ #category : #'method changes' }
+{ #category : 'method changes' }
 ChangeSet >> removeSelectorChanges: selector class: class [
 	"Remove all memory of changes associated with the argument, selector, in
 	this class."
@@ -1325,35 +1341,14 @@ ChangeSet >> removeSelectorChanges: selector class: class [
 	chgRecord hasNoChanges ifTrue: [changeRecords removeKey: class name]
 ]
 
-{ #category : #'change logging' }
-ChangeSet >> renameClass: class from: oldName to: newName [
-	"Include indication that a class has been renamed."
-
-	| recorder oldMetaClassName newMetaClassName |
-	(recorder := self changeRecorderFor: oldName)
-		noteChangeType: #rename;
-		noteNewName: newName asSymbol.
-
-	"store under new name (metaclass too)"
-	changeRecords at: newName put: recorder.
-	changeRecords removeKey: oldName.
-
-	newMetaClassName := newName, ' class'.
-	oldMetaClassName := oldName, ' class'.
-	recorder := changeRecords at: oldMetaClassName ifAbsent: [^ nil].
-	changeRecords at: newMetaClassName put: recorder.
-	changeRecords removeKey: oldMetaClassName.
-	recorder noteNewName: newMetaClassName
-]
-
-{ #category : #'class changes' }
+{ #category : 'class changes' }
 ChangeSet >> reorganizeClass: class [
 	"Include indication that a class was reorganized."
 
 	self atClass: class add: #reorganize
 ]
 
-{ #category : #'method changes' }
+{ #category : 'method changes' }
 ChangeSet >> selectorsInClass: aClassName [
 	"Used by a ChangeSorter to access the list methods."
 
@@ -1361,19 +1356,19 @@ ChangeSet >> selectorsInClass: aClassName [
 		  changedSelectors
 ]
 
-{ #category : #'class changes' }
+{ #category : 'class changes' }
 ChangeSet >> trimHistory [
 	"Drop non-essential history:  methods added and then removed, as well as rename and reorganization of newly-added classes."
 
 	changeRecords do: [:chgRecord | chgRecord trimHistory]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ChangeSet >> veryDeepCopyWith: deepCopier [
 	"Return self; this is NOT the way to launch new change sets! Having this method here allows Change Sorters to be in parts bins"
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ChangeSet >> wither [
 	"The receiver is to be clobbered. Clear it out."
 

--- a/src/System-Changes/Class.extension.st
+++ b/src/System-Changes/Class.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Class }
+Extension { #name : 'Class' }
 
-{ #category : #'*System-Changes' }
+{ #category : '*System-Changes' }
 Class >> removeFromChanges [
 	"References to the receiver, a class, and its metaclass should no longer be included in the system ChangeSet."
 

--- a/src/System-Changes/ClassChangeRecord.class.st
+++ b/src/System-Changes/ClassChangeRecord.class.st
@@ -47,8 +47,8 @@ A classChangeRecorder is notified of changes by the method
 ClassChangeRecorders are designed to invoke a set of changes relative to the definition of a class in an prior layer.  It is important that both invocation and revocation of these changes take place in a nearly atomic fashion so that interdependent changes will be adopted as a whole, and so that only one flush of the method cache should be necessary.  A further reason for revocation to be simple is that it may be requested as an attempt to recover from an error in a project that is failing.
 "
 Class {
-	#name : #ClassChangeRecord,
-	#superclass : #Object,
+	#name : 'ClassChangeRecord',
+	#superclass : 'Object',
 	#instVars : [
 		'changeTypes',
 		'priorDefinition',
@@ -56,10 +56,12 @@ Class {
 		'priorName',
 		'methodChanges'
 	],
-	#category : #'System-Changes-Records'
+	#category : 'System-Changes-Records',
+	#package : 'System-Changes',
+	#tag : 'Records'
 }
 
-{ #category : #'all changes' }
+{ #category : 'all changes' }
 ClassChangeRecord >> allChangeTypes [
 	| chgs |
 	(priorName notNil and: [ changeTypes includes: #rename ])
@@ -69,7 +71,7 @@ ClassChangeRecord >> allChangeTypes [
 	^ changeTypes
 ]
 
-{ #category : #'all changes' }
+{ #category : 'all changes' }
 ClassChangeRecord >> assimilateAllChangesIn: otherRecord [
 
 
@@ -90,28 +92,28 @@ ClassChangeRecord >> assimilateAllChangesIn: otherRecord [
 				[self atSelector: selector put: changeType]]
 ]
 
-{ #category : #'method changes' }
+{ #category : 'method changes' }
 ClassChangeRecord >> atSelector: selector ifAbsent: absentBlock [
 
 	^ (methodChanges at: selector ifAbsent: absentBlock)
 		changeType
 ]
 
-{ #category : #'method changes' }
+{ #category : 'method changes' }
 ClassChangeRecord >> atSelector: selector put: changeType [
 
 	(self findOrMakeMethodChangeAt: selector priorMethod: nil)
 		noteChangeType: changeType
 ]
 
-{ #category : #'method changes' }
+{ #category : 'method changes' }
 ClassChangeRecord >> changedSelectors [
 	"Return a set of the changed or removed selectors."
 
 	^ methodChanges keys
 ]
 
-{ #category : #definition }
+{ #category : 'definition' }
 ClassChangeRecord >> checkCoherence [
 	"If I recreate the class then don't remove it"
 
@@ -125,13 +127,13 @@ ClassChangeRecord >> checkCoherence [
 	changeTypes add: #add
 ]
 
-{ #category : #'method changes' }
+{ #category : 'method changes' }
 ClassChangeRecord >> findOrMakeMethodChangeAt: selector priorMethod: priorMethod [
 	^methodChanges at: selector
 		ifAbsentPut: [MethodChangeRecord new]
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 ClassChangeRecord >> forgetChangesIn: otherRecord [
 	"See forgetAllChangesFoundIn:.  Used in culling changeSets."
 
@@ -157,20 +159,20 @@ ClassChangeRecord >> forgetChangesIn: otherRecord [
 		ifFalse: [ changeTypes removeAllSuchThat: [ :x | x beginsWith: 'oldName: ' ] ]
 ]
 
-{ #category : #'all changes' }
+{ #category : 'all changes' }
 ClassChangeRecord >> hasNoChanges [
 
 	^ changeTypes isEmpty and: [methodChanges isEmpty]
 ]
 
-{ #category : #'all changes' }
+{ #category : 'all changes' }
 ClassChangeRecord >> includesChangeType: changeType [
 
 	changeType == #new ifTrue: [^ changeTypes includes: #add].  "Backwd compat"
 	^ changeTypes includes: changeType
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ClassChangeRecord >> initFor: className [
 
 	changeTypes := IdentitySet new.
@@ -178,7 +180,7 @@ ClassChangeRecord >> initFor: className [
 	priorName := thisName := className
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 ClassChangeRecord >> isClassRemoval [
 	"NOTE: there are other removals with changeType #addedThenRemoved,
 	but this message is used to write out removals in fileOut, and those
@@ -187,7 +189,7 @@ ClassChangeRecord >> isClassRemoval [
 	^ (changeTypes includes: #remove) or: [changeTypes includes: #removeClass]
 ]
 
-{ #category : #'method changes' }
+{ #category : 'method changes' }
 ClassChangeRecord >> methodChangeTypes [
 	"Return an old-style dictionary of method change types."
 
@@ -201,19 +203,19 @@ ClassChangeRecord >> methodChangeTypes [
 	^ dict
 ]
 
-{ #category : #'method changes' }
+{ #category : 'method changes' }
 ClassChangeRecord >> methodChanges [
 
 	^ methodChanges
 ]
 
-{ #category : #'all changes' }
+{ #category : 'all changes' }
 ClassChangeRecord >> noteChangeType: changeSymbol [
 
 	^ self noteChangeType: changeSymbol fromClass: nil
 ]
 
-{ #category : #'all changes' }
+{ #category : 'all changes' }
 ClassChangeRecord >> noteChangeType: changeSymbol fromClass: class [
 
 	(changeSymbol = #new or: [changeSymbol = #add]) ifTrue:
@@ -245,7 +247,7 @@ ClassChangeRecord >> noteChangeType: changeSymbol fromClass: class [
 	self error: 'Unrecognized changeType'
 ]
 
-{ #category : #'method changes' }
+{ #category : 'method changes' }
 ClassChangeRecord >> noteNewMethod: newMethod selector: selector priorMethod: methodOrNil [
 	| methodChange |
 	methodChange := self findOrMakeMethodChangeAt: selector priorMethod: methodOrNil.
@@ -254,20 +256,20 @@ ClassChangeRecord >> noteNewMethod: newMethod selector: selector priorMethod: me
 		ifNotNil: [ methodChange noteChangeType: #change ]
 ]
 
-{ #category : #rename }
+{ #category : 'rename' }
 ClassChangeRecord >> noteNewName: newName [
 
 	thisName := newName
 ]
 
-{ #category : #definition }
+{ #category : 'definition' }
 ClassChangeRecord >> notePriorDefinition: oldClass [
 
 	oldClass ifNil: [ ^ self ].
 	priorDefinition ifNil: [ priorDefinition := oldClass definitionString ]
 ]
 
-{ #category : #'method changes' }
+{ #category : 'method changes' }
 ClassChangeRecord >> noteRemoveSelector: selector priorMethod: priorMethod lastSourcePointer: lastSourcePointer [
 
 	| methodChange |
@@ -280,19 +282,19 @@ ClassChangeRecord >> noteRemoveSelector: selector priorMethod: priorMethod lastS
 	methodChange lastSourcePointer: lastSourcePointer
 ]
 
-{ #category : #definition }
+{ #category : 'definition' }
 ClassChangeRecord >> priorDefinition [
 
 	^ priorDefinition
 ]
 
-{ #category : #rename }
+{ #category : 'rename' }
 ClassChangeRecord >> priorName [
 
 	^ priorName
 ]
 
-{ #category : #'isolation layers' }
+{ #category : 'isolation layers' }
 ClassChangeRecord >> realClass [
 	"Return the actual class (or meta), as determined from my name."
 
@@ -302,7 +304,7 @@ ClassChangeRecord >> realClass [
 		ifFalse: [ Smalltalk globals at: thisName ifAbsent: [ ^ nil ] ]
 ]
 
-{ #category : #'method changes' }
+{ #category : 'method changes' }
 ClassChangeRecord >> removeSelector: selector [
 	"Remove all memory of changes associated with the argument, selector, in this class."
 
@@ -313,13 +315,13 @@ ClassChangeRecord >> removeSelector: selector [
 			[methodChanges removeKey: selector ifAbsent: []]
 ]
 
-{ #category : #rename }
+{ #category : 'rename' }
 ClassChangeRecord >> thisName [
 
 	^ thisName
 ]
 
-{ #category : #'all changes' }
+{ #category : 'all changes' }
 ClassChangeRecord >> trimHistory [
 	"Drop non-essential history."
 

--- a/src/System-Changes/CurrentChangeSetChanged.class.st
+++ b/src/System-Changes/CurrentChangeSetChanged.class.st
@@ -2,31 +2,33 @@
 Announce that the current change set has changed
 "
 Class {
-	#name : #CurrentChangeSetChanged,
-	#superclass : #Announcement,
+	#name : 'CurrentChangeSetChanged',
+	#superclass : 'Announcement',
 	#instVars : [
 		'new',
 		'old'
 	],
-	#category : #'System-Changes-Announcements'
+	#category : 'System-Changes-Announcements',
+	#package : 'System-Changes',
+	#tag : 'Announcements'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CurrentChangeSetChanged >> new [
 	^ new
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CurrentChangeSetChanged >> new: anObject [
 	new := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CurrentChangeSetChanged >> old [
 	^ old
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CurrentChangeSetChanged >> old: anObject [
 	old := anObject
 ]

--- a/src/System-Changes/ManifestSystemChanges.class.st
+++ b/src/System-Changes/ManifestSystemChanges.class.st
@@ -2,18 +2,20 @@
 Packacke with support for system changes recorded in changesets
 "
 Class {
-	#name : #ManifestSystemChanges,
-	#superclass : #PackageManifest,
-	#category : #'System-Changes-Manifest'
+	#name : 'ManifestSystemChanges',
+	#superclass : 'PackageManifest',
+	#category : 'System-Changes-Manifest',
+	#package : 'System-Changes',
+	#tag : 'Manifest'
 }
 
-{ #category : #'meta-data - dependency analyser' }
+{ #category : 'meta-data - dependency analyser' }
 ManifestSystemChanges class >> manuallyResolvedDependencies [
 
 	^ #( #'OpalCompiler-Core' #'FileSystem-Disk' #'Collections-Abstract' )
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestSystemChanges class >> ruleClassNameInSelectorRuleV1FalsePositive [
 	^ #(#(#(#RGMetaclassDefinition #(#'ChangeSet class' #ChangeSet)) #'2021-10-04T20:06:46.530781+02:00') )
 ]

--- a/src/System-Changes/MethodChangeRecord.class.st
+++ b/src/System-Changes/MethodChangeRecord.class.st
@@ -22,42 +22,44 @@ Note that the above states each have an associated revoke action:
 However all of these are accomplished trivially by restoring the original method dictionary.
 "
 Class {
-	#name : #MethodChangeRecord,
-	#superclass : #Object,
+	#name : 'MethodChangeRecord',
+	#superclass : 'Object',
 	#instVars : [
 		'changeType',
 		'lastSourcePointer'
 	],
-	#category : #'System-Changes-Records'
+	#category : 'System-Changes-Records',
+	#package : 'System-Changes',
+	#tag : 'Records'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MethodChangeRecord >> changeType [
 
 	^ changeType
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MethodChangeRecord >> lastSourcePointer [
 
 	^ lastSourcePointer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MethodChangeRecord >> lastSourcePointer: sourcePointer [
 	"Store the source index of the last version of the method so it can be put back there if re-accepted from a version browser."
 
 	lastSourcePointer := sourcePointer
 ]
 
-{ #category : #'all changes' }
+{ #category : 'all changes' }
 MethodChangeRecord >> noteChangeType: newChangeType [
 	changeType := (changeType == #addedThenRemoved and: [ newChangeType == #change ])
 		ifTrue: [ #add ]
 		ifFalse: [ newChangeType ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MethodChangeRecord >> printOn: strm [
 
 	super printOn: strm.

--- a/src/System-Changes/PositionableStream.extension.st
+++ b/src/System-Changes/PositionableStream.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #PositionableStream }
+Extension { #name : 'PositionableStream' }
 
-{ #category : #'*System-Changes' }
+{ #category : '*System-Changes' }
 PositionableStream >> basicNextChunk [
 	"Answer the contents of the receiver, up to the next terminator character. Doubled terminators indicate an embedded terminator character."
 
@@ -19,7 +19,7 @@ PositionableStream >> basicNextChunk [
 	^ out contents
 ]
 
-{ #category : #'*System-Changes' }
+{ #category : '*System-Changes' }
 PositionableStream >> decodeString: string andRuns: runsRaw [
 	| strm runLength runValues newString index |
 	strm := ReadStream on: runsRaw from: 1 to: runsRaw size.
@@ -44,12 +44,12 @@ PositionableStream >> decodeString: string andRuns: runsRaw [
 	^ newString
 ]
 
-{ #category : #'*System-Changes' }
+{ #category : '*System-Changes' }
 PositionableStream >> header [
 	"If the stream requires a standard header, override this message.  See HtmlFileStream"
 ]
 
-{ #category : #'*System-Changes' }
+{ #category : '*System-Changes' }
 PositionableStream >> nextChunk [
 	"Answer the contents of the receiver, up to the next terminator character. Doubled terminators indicate an embedded terminator character."
 
@@ -68,7 +68,7 @@ PositionableStream >> nextChunk [
 	^ self parseLangTagFor: out contents
 ]
 
-{ #category : #'*System-Changes' }
+{ #category : '*System-Changes' }
 PositionableStream >> nextPreamble [
 	"Assuming that preamble part does not contain ]lang[ tag"
 	| terminator out ch |
@@ -86,7 +86,7 @@ PositionableStream >> nextPreamble [
 	^ out contents
 ]
 
-{ #category : #'*System-Changes' }
+{ #category : '*System-Changes' }
 PositionableStream >> parseLangTagFor: aString [
 
 	| string peek runsRaw pos |
@@ -104,7 +104,7 @@ PositionableStream >> parseLangTagFor: aString [
 	^ string
 ]
 
-{ #category : #'*System-Changes' }
+{ #category : '*System-Changes' }
 PositionableStream >> skipStyleChunk [
 	"Get to the start of the next chunk that is not a style for the previous chunk"
 
@@ -119,7 +119,7 @@ PositionableStream >> skipStyleChunk [
 		ifFalse: [self position: pos]	"leave untouched"
 ]
 
-{ #category : #'*System-Changes' }
+{ #category : '*System-Changes' }
 PositionableStream >> verbatim: aString [
 	"Do not attempt to translate the characters.  Use to override nextPutAll:"
 	^ self nextPutAll: aString

--- a/src/System-Changes/SourceFileArray.extension.st
+++ b/src/System-Changes/SourceFileArray.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #SourceFileArray }
+Extension { #name : 'SourceFileArray' }
 
-{ #category : #'*System-Changes' }
+{ #category : '*System-Changes' }
 SourceFileArray >> changeRecordsFor: aMethodDefinition [
 
 	^ self
@@ -9,7 +9,7 @@ SourceFileArray >> changeRecordsFor: aMethodDefinition [
 		isMeta: aMethodDefinition methodClass isMeta
 ]
 
-{ #category : #'*System-Changes' }
+{ #category : '*System-Changes' }
 SourceFileArray >> changeRecordsFor: aMethodDefinition detect: aUnaryBlock [
 	"Try to detect the most recent ChangeRecord that satisfies aUnaryBlock. Answer nil if none satisfies."
 
@@ -18,7 +18,7 @@ SourceFileArray >> changeRecordsFor: aMethodDefinition detect: aUnaryBlock [
 	^ nil
 ]
 
-{ #category : #'*System-Changes' }
+{ #category : '*System-Changes' }
 SourceFileArray >> changeRecordsFor: aMethodDefinition do: aUnaryBlock [
 	"Evaluate aUnaryBlock with each of the ChangeRecords of aMethodDefinition. Most recent changes are evaluated first."
 
@@ -29,7 +29,7 @@ SourceFileArray >> changeRecordsFor: aMethodDefinition do: aUnaryBlock [
 		do: aUnaryBlock
 ]
 
-{ #category : #'*System-Changes' }
+{ #category : '*System-Changes' }
 SourceFileArray >> changeRecordsFrom: initialSourcePointer className: theNonMetaClassName isMeta: classIsMeta [
 	"Answer the ChangeRecords of a method or class comment, starting from the initialSourcePointer.
 	Most recent changes go first."
@@ -46,7 +46,7 @@ SourceFileArray >> changeRecordsFrom: initialSourcePointer className: theNonMeta
 	^ changeRecords
 ]
 
-{ #category : #'*System-Changes' }
+{ #category : '*System-Changes' }
 SourceFileArray >> changeRecordsFrom: initialSourcePointer className: theNonMetaClassName isMeta: classIsMeta do: aUnaryBlock [
 	"Evaluate aUnaryBlock with each of the ChangeRecords of a method or class comment, starting from the initialSourcePointer.
 	Most recent changes are evaluated first."

--- a/src/System-Changes/package.st
+++ b/src/System-Changes/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'System-Changes' }
+Package { #name : 'System-Changes' }

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1552,13 +1552,6 @@ SmalltalkImage >> removeSelector: descriptor [
 ]
 
 { #category : 'class and trait names' }
-SmalltalkImage >> renameClass: aClass as: newName [
-	"Rename the class, aClass, to have the title newName."
-
-	^globals renameClass: aClass as: newName
-]
-
-{ #category : 'class and trait names' }
 SmalltalkImage >> renameClass: aClass from: oldName [
 	"Rename the class, aClass, to have the title newName."
 

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -371,37 +371,17 @@ SystemDictionary >> removeKey: key ifAbsent: aBlock [
 ]
 
 { #category : 'renaming' }
-SystemDictionary >> renameClass: aClass as: newName [
-	"Rename the class, aClass, to have the title newName."
-
-	^ self renameClass: aClass from: aClass name to: newName
-]
-
-{ #category : 'renaming' }
 SystemDictionary >> renameClass: aClass from: oldName [
-	"Rename the class, aClass, to have the title newName."
-
-	^ self renameClass: aClass from: oldName to: aClass name
-]
-
-{ #category : 'renaming' }
-SystemDictionary >> renameClass: aClass from: oldName to: newName [
-	"Rename the class, aClass, to have the title newName."
 
 	| oldref |
 	oldref := self associationAt: oldName.
 	self removeKey: oldName.
-	oldref key: newName.
+	oldref key: aClass name.
 	self add: oldref. "Old association preserves old refs"
-	SessionManager default renamedClass: aClass from: oldName to: newName.
+	SessionManager default renamedClass: aClass from: oldName to: aClass name.
 	self flushClassNameCache.
-	self flag: #package. "There is no need to give the category"
-	SystemAnnouncer uniqueInstance
-		classRenamed: aClass
-		from: oldName
-		to: newName
-		inCategory: aClass category.
-	aClass subclassesDo: [ :subclass | SystemAnnouncer uniqueInstance classParentOf: subclass renamedFrom: oldName to: newName ]
+	SystemAnnouncer uniqueInstance classRenamed: aClass from: oldName to: aClass name.
+	aClass subclassesDo: [ :subclass | SystemAnnouncer uniqueInstance classParentOf: subclass renamedFrom: oldName to: aClass name ]
 ]
 
 { #category : 'renaming' }


### PR DESCRIPTION
This change simplifies the code of class renaming in the system

- ClassRenamed does not need to be paramitrized with a category since the class already know it's category
- #renameClass:as: is dead code
- #renameClass:from:to: is only called in one place adding just one parameter than another parameter already know -> I propose to inline the method