### PR TITLE
Kernel: Always recompile silently methods

### DIFF
--- a/src/Deprecated12/Behavior.extension.st
+++ b/src/Deprecated12/Behavior.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : 'Behavior' }
+
+{ #category : '*Deprecated12' }
+Behavior >> addSelector: selector withRecompiledMethod: compiledMethod [
+
+	self
+		deprecated: 'Use #addSelectorSilently:withMethod: instead'
+		transformWith: '`@rcv addSelector: `@arg1 withRecompiledMethod: `@arg2' -> '`@rcv addSelectorSilently: `@arg1 withMethod: `@arg2'.
+	^ self addSelectorSilently: selector withMethod: compiledMethod
+]

--- a/src/Flashback-Decompiler/CannotDecompileNativeBoostCalls.class.st
+++ b/src/Flashback-Decompiler/CannotDecompileNativeBoostCalls.class.st
@@ -2,7 +2,9 @@
 Notify that a method can not be decompiled because of a native boost call
 "
 Class {
-	#name : #CannotDecompileNativeBoostCalls,
-	#superclass : #Exception,
-	#category : #'Flashback-Decompiler-Exceptions'
+	#name : 'CannotDecompileNativeBoostCalls',
+	#superclass : 'Exception',
+	#category : 'Flashback-Decompiler-Exceptions',
+	#package : 'Flashback-Decompiler',
+	#tag : 'Exceptions'
 }

--- a/src/Flashback-Decompiler/FBDASTBuilder.class.st
+++ b/src/Flashback-Decompiler/FBDASTBuilder.class.st
@@ -4,22 +4,24 @@ I am used to create AST nodes. This class is reserved for the RBAST.
 methodClass <Behavior> behavior where the compiled method is installed.
 "
 Class {
-	#name : #FBDASTBuilder,
-	#superclass : #Object,
+	#name : 'FBDASTBuilder',
+	#superclass : 'Object',
 	#instVars : [
 		'methodClass'
 	],
-	#category : #'Flashback-Decompiler-Utilities'
+	#category : 'Flashback-Decompiler-Utilities',
+	#package : 'Flashback-Decompiler',
+	#tag : 'Utilities'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 FBDASTBuilder class >> newFor: class [
 	^ self new
 		methodClass: class;
 		yourself
 ]
 
-{ #category : #constructor }
+{ #category : 'constructor' }
 FBDASTBuilder >> codeAnyLitInd: anAssociation [
 	| varName |
 	"class binding on the class side has nil as key"
@@ -29,42 +31,42 @@ FBDASTBuilder >> codeAnyLitInd: anAssociation [
 		yourself
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeArgument: tempName [
 	^ RBVariableNode named: tempName
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeArray: array [
 	^ RBArrayNode statements: array
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeAssignment: value to: variable [
 	^ RBAssignmentNode variable: variable value: value
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeBlock: body [
 	^ self codeBlock: body arguments: #()
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeBlock: body arguments: args [
 	^ RBBlockNode arguments: args body: body
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeBlockFromStatements: statements [
 	^ self codeBlock: ((self codeSequence: #()) statements: statements; yourself)
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeCascade: messages [
 	^ RBCascadeNode messages: messages
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeConditionalNode: expr trueSequence: seq1 falseSequence: seq2 [
 	^ (self
 		codeMessage: #ifTrue:ifFalse:
@@ -76,32 +78,32 @@ FBDASTBuilder >> codeConditionalNode: expr trueSequence: seq1 falseSequence: seq
 		yourself
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeEmptyBlock [
 	^ RBBlockNode body: (self codeSequence: #())
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeEmptySequence [
 	^ self codeSequence: #()
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeInstanceVariable: offset [
 	^ RBVariableNode named: (methodClass allSlots at: offset) name
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeLiteral: lit [
 	^ RBLiteralNode value: lit
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeLiteralValue: lit [
 	^ RBLiteralValueNode value: lit
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeLoopNode: bool condition: seq1 body: seq2 [
 	^ (self
 		codeMessage: (#while , bool class name , ':') asSymbol
@@ -111,12 +113,12 @@ FBDASTBuilder >> codeLoopNode: bool condition: seq1 body: seq2 [
 		yourself
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeMessage: selector receiver: rcvr arguments:args [
 	^ RBMessageNode receiver: rcvr selector: selector arguments: args
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeMethod: selector arguments: args body: body pragmas: pragmas class: class [
 
 	^ (RBMethodNode selector: selector arguments: args body: body)
@@ -124,12 +126,12 @@ FBDASTBuilder >> codeMethod: selector arguments: args body: body pragmas: pragma
 		doSemanticAnalysisIn: class
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeReceiver [
 	^ RBVariableNode selfNode
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeRepeatNode: body [
 	^ (self
 		codeMessage: #repeat
@@ -139,47 +141,47 @@ FBDASTBuilder >> codeRepeatNode: body [
 			yourself
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeReturn: value [
 	^ RBReturnNode value: value
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeSelf [
 	^ RBVariableNode selfNode
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeSequence: temps [
 	^ RBSequenceNode temporaries: temps statements: OrderedCollection new
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeSuper [
 	^ RBVariableNode superNode
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeTemp: tempName [
 	^ RBVariableNode named: tempName
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeThisContext [
 	^ RBVariableNode thisContextNode
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 FBDASTBuilder >> codeVariable: variable [
 	^ RBVariableNode named: variable
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FBDASTBuilder >> methodClass [
 	^ methodClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FBDASTBuilder >> methodClass: anObject [
 	methodClass := anObject
 ]

--- a/src/Flashback-Decompiler/FBDConditionalLoop.class.st
+++ b/src/Flashback-Decompiler/FBDConditionalLoop.class.st
@@ -4,25 +4,27 @@ I represent a conditional loop (typically, a for or while loop). In addition to 
 exitCondition <Smi> pc of the conditional jump where the execution flows exits the loop body.
 "
 Class {
-	#name : #FBDConditionalLoop,
-	#superclass : #FBDLoop,
+	#name : 'FBDConditionalLoop',
+	#superclass : 'FBDLoop',
 	#instVars : [
 		'exitCondition'
 	],
-	#category : #'Flashback-Decompiler-Utilities'
+	#category : 'Flashback-Decompiler-Utilities',
+	#package : 'Flashback-Decompiler',
+	#tag : 'Utilities'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FBDConditionalLoop >> exitCondition [
 	^ exitCondition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FBDConditionalLoop >> exitCondition: anObject [
 	exitCondition := anObject
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 FBDConditionalLoop >> isConditionalLoop [
 	^ true
 ]

--- a/src/Flashback-Decompiler/FBDDecompiler.class.st
+++ b/src/Flashback-Decompiler/FBDDecompiler.class.st
@@ -22,8 +22,8 @@ Instance Variables
 
 "
 Class {
-	#name : #FBDDecompiler,
-	#superclass : #InstructionClient,
+	#name : 'FBDDecompiler',
+	#superclass : 'InstructionClient',
 	#instVars : [
 		'simulatedStack',
 		'builder',
@@ -35,27 +35,29 @@ Class {
 		'loopsArray',
 		'method'
 	],
-	#category : #'Flashback-Decompiler-Base'
+	#category : 'Flashback-Decompiler-Base',
+	#package : 'Flashback-Decompiler',
+	#tag : 'Base'
 }
 
-{ #category : #'instruction decoding forward' }
+{ #category : 'instruction decoding forward' }
 FBDDecompiler >> blockReturnConstant: value [
 	self pushConstant: value.
 	self blockReturnTop
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> blockReturnTop [
 	self doPop
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 FBDDecompiler >> canDecompile: aCompiledMethod [
 	"Answers false if aCompiledMethod can't be decompiled due to framework specific constraints."
 	^ (self isPrimitiveNativeCall: aCompiledMethod) not
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 FBDDecompiler >> createNArgs: numArgs [
 
 	| argName |
@@ -68,12 +70,12 @@ FBDDecompiler >> createNArgs: numArgs [
 			builder codeArgument: argName ]
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 FBDDecompiler >> createNTemps: numTemps [
 	^ (1 to: numTemps) collect: [ :i | self newTemp ]
 ]
 
-{ #category : #'control flow instructions' }
+{ #category : 'control flow instructions' }
 FBDDecompiler >> decodeConditionalLoop: loop nextLoops: loops [
 	| condSeq pastSequence boolean |
 
@@ -98,21 +100,21 @@ FBDDecompiler >> decodeConditionalLoop: loop nextLoops: loops [
 	self doPop
 ]
 
-{ #category : #'control flow instructions' }
+{ #category : 'control flow instructions' }
 FBDDecompiler >> decodeLoop: loop nextLoops: loops [
 	loop isConditionalLoop
 		ifTrue: [ self decodeConditionalLoop: loop nextLoops: loops ]
 		ifFalse: [ self decodeRepeatLoop: loop nextLoops: loops ]
 ]
 
-{ #category : #'control flow instructions' }
+{ #category : 'control flow instructions' }
 FBDDecompiler >> decodeLoops: loops [
 	"There are multiple loops if all their backjumps target the same pc.
 	In this case the loops are ordereed from innerMost to outerMost, and we decompile them in the correct order so the inner loop is decompiled inside the outerloop"
 	self decodeLoop: loops removeLast nextLoops: loops
 ]
 
-{ #category : #'control flow instructions' }
+{ #category : 'control flow instructions' }
 FBDDecompiler >> decodeRepeatLoop: loop nextLoops: loops [
 	| pastSequence  |
 
@@ -127,7 +129,7 @@ FBDDecompiler >> decodeRepeatLoop: loop nextLoops: loops [
 	self doPop
 ]
 
-{ #category : #'public api' }
+{ #category : 'public api' }
 FBDDecompiler >> decompile: aCompiledMethod [
 	"Main API. Works only if the method holds a reference to the class it is installed in and its selector. Answers an AST"
 	^ self
@@ -136,7 +138,7 @@ FBDDecompiler >> decompile: aCompiledMethod [
 		method: aCompiledMethod
 ]
 
-{ #category : #'public api' }
+{ #category : 'public api' }
 FBDDecompiler >> decompile: aSelector in: aClass method: anInitialCompiledMethod [
 	| aCompiledMethod |
 	builder := FBDASTBuilder newFor: aClass.
@@ -157,14 +159,14 @@ FBDDecompiler >> decompile: aSelector in: aClass method: anInitialCompiledMethod
 				class: aClass)
 ]
 
-{ #category : #'public api' }
+{ #category : 'public api' }
 FBDDecompiler >> decompileAll [
 	Smalltalk globals allClassesAndTraits
 		do: [ :classOrTrait | self decompileThenRecompileClass: classOrTrait ]
 		displayingProgress: 'Decompiling all classes and traits'
 ]
 
-{ #category : #recompilation }
+{ #category : 'recompilation' }
 FBDDecompiler >> decompileThenRecompileClass: aClass [
 	{aClass.
 	aClass class}
@@ -174,7 +176,7 @@ FBDDecompiler >> decompileThenRecompileClass: aClass [
 				displayingProgress: [ :aMethod | 'Decompiling ' , class name , '>>#' , aMethod asString ] ]
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> directedSuperSend: selector numArgs: numberArguments [
 
 	| args currentClass |
@@ -185,7 +187,7 @@ FBDDecompiler >> directedSuperSend: selector numArgs: numberArguments [
 	simulatedStack addLast: (builder codeMessage: selector receiver: builder codeSuper arguments: args )
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> doDup [
 	| dupTemp |
 	simulatedStack last class == RBVariableNode
@@ -199,12 +201,12 @@ FBDDecompiler >> doDup [
 		addLast: dupTemp
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> doPop [
 	currentSequence addNode: simulatedStack removeLast
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 FBDDecompiler >> errorCodeNameFor: cm [
 	"Assumes the method holds a primitive with error code"
 	| primitivePragma selectorParts |
@@ -214,7 +216,7 @@ FBDDecompiler >> errorCodeNameFor: cm [
 	^ primitivePragma argumentAt: (selectorParts indexOf: 'error:')
 ]
 
-{ #category : #'closure support' }
+{ #category : 'closure support' }
 FBDDecompiler >> extractFullBlock: aCompiledBlock numCopied: numCopied [
 
 	| oldInstructionStream oldLoops|
@@ -240,7 +242,7 @@ FBDDecompiler >> extractFullBlock: aCompiledBlock numCopied: numCopied [
 		arguments: (simulatedStack first: aCompiledBlock numArgs)
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 FBDDecompiler >> generateNativeBoostCallErrorMethodFrom: aCompiledMethod [
 	| seq args |
 	seq := RBSequenceNode
@@ -256,22 +258,22 @@ FBDDecompiler >> generateNativeBoostCallErrorMethodFrom: aCompiledMethod [
 		class: aCompiledMethod methodClass
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> goToNextInstruction [
 	instructionStream advanceToFollowingPc
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 FBDDecompiler >> incrArgCount [
 	argCount := argCount + 1
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 FBDDecompiler >> incrTempCount [
 	tempCount := tempCount + 1
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 FBDDecompiler >> initializeErrorCode: cm [
 	| index |
 	cm isPrimitive
@@ -283,7 +285,7 @@ FBDDecompiler >> initializeErrorCode: cm [
 	simulatedStack at: index + 1 put: (builder codeTemp: (self errorCodeNameFor: cm))
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 FBDDecompiler >> initializeForMethod: aCompiledMethod [
 	method := aCompiledMethod.
 	loopsArray := FBDLoopScanner scan: method.
@@ -292,7 +294,7 @@ FBDDecompiler >> initializeForMethod: aCompiledMethod [
 	jumpSize := 0
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 FBDDecompiler >> initializeStack [
 	argCount := 0.
 	tempCount := 0.
@@ -302,7 +304,7 @@ FBDDecompiler >> initializeStack [
 		numTemps: method numTemps - method numArgs
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 FBDDecompiler >> initializeStackNumArgs: numArgs copied: copiedVars numTemps: numTemps [
 	| args temps |
 	simulatedStack := OrderedCollection new.
@@ -312,7 +314,7 @@ FBDDecompiler >> initializeStackNumArgs: numArgs copied: copiedVars numTemps: nu
 	currentSequence := builder codeSequence: temps
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 FBDDecompiler >> interpret: endPC [
 	[ self pc > endPC ]
 		whileFalse: [
@@ -321,7 +323,7 @@ FBDDecompiler >> interpret: endPC [
 				ifNil: [ instructionStream interpretNextInstructionFor: self ] ]
 ]
 
-{ #category : #'control flow instructions' }
+{ #category : 'control flow instructions' }
 FBDDecompiler >> interpret: endPC nextLoops: loops [
 	loops
 		ifNotEmpty: [ self decodeLoops: loops ]
@@ -329,7 +331,7 @@ FBDDecompiler >> interpret: endPC nextLoops: loops [
 	self interpret: endPC
 ]
 
-{ #category : #'control flow instructions' }
+{ #category : 'control flow instructions' }
 FBDDecompiler >> interpret: seq1 then: seq2 distance: distance [
 	| hasPopped hasPopped2 jmpSz topValue stackSize |
 	"If next instruction will pop, skip it and pop the element from the stack"
@@ -346,7 +348,7 @@ FBDDecompiler >> interpret: seq1 then: seq2 distance: distance [
 	^ hasPopped2 or: [hasPopped]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 FBDDecompiler >> interpretMethod: aCompiledMethod [
 	self maybeSkipCallPrimitiveBytecode: aCompiledMethod.
 	aCompiledMethod isQuick
@@ -356,7 +358,7 @@ FBDDecompiler >> interpretMethod: aCompiledMethod [
 			self interpret: aCompiledMethod endPC ]
 ]
 
-{ #category : #'control flow instructions' }
+{ #category : 'control flow instructions' }
 FBDDecompiler >> interpretSeq: seq baseStackSize: stackSize distance: distance [
 	currentSequence := seq.
 	self interpret: self pc + distance - 1.
@@ -365,20 +367,20 @@ FBDDecompiler >> interpretSeq: seq baseStackSize: stackSize distance: distance [
 		ifTrue: [ false ]
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 FBDDecompiler >> isPrimitiveNativeCall: aCompiledMethod [
 	aCompiledMethod isPrimitive
 		ifFalse: [ ^ false ].
 	^ (aCompiledMethod pragmas anySatisfy: [ :aPragma | aPragma arguments isNotEmpty and: [ (aPragma argumentAt: 1) = 'primitiveNativeCall' ] ])
 ]
 
-{ #category : #'control flow instructions' }
+{ #category : 'control flow instructions' }
 FBDDecompiler >> jump: distance [
 	distance < 0 ifTrue: [ ^ self error: 'should have been detected by the scanner and skipped' ].
 	jumpSize := distance
 ]
 
-{ #category : #'control flow instructions' }
+{ #category : 'control flow instructions' }
 FBDDecompiler >> jump: distance if: boolean [
 	"If we reach this code, this means this is a condition (if) and not a loop."
 
@@ -396,7 +398,7 @@ FBDDecompiler >> jump: distance if: boolean [
 		ifFalse: [ self doPop ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 FBDDecompiler >> maybeSkipCallPrimitiveBytecode: aCompiledMethod [
 	"If the method's bytecode set uses the callPrimitive bytecode, ignore it.
 	The primitive is handled specifically before bytecode interpretation."
@@ -404,58 +406,58 @@ FBDDecompiler >> maybeSkipCallPrimitiveBytecode: aCompiledMethod [
 		ifTrue: [ instructionStream advanceToFollowingPc ]
 ]
 
-{ #category : #'instruction decoding forward' }
+{ #category : 'instruction decoding forward' }
 FBDDecompiler >> methodReturnConstant: value [
 	self pushConstant: value.
 	self methodReturnTop
 ]
 
-{ #category : #'instruction decoding forward' }
+{ #category : 'instruction decoding forward' }
 FBDDecompiler >> methodReturnReceiver [
 	self pushReceiver.
 	self methodReturnTop
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> methodReturnTop [
 	^ currentSequence addNode: (builder codeReturn: simulatedStack removeLast)
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 FBDDecompiler >> newTemp [
 	self incrTempCount.
 	^ builder codeTemp: 'tmp' , tempCount printString
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 FBDDecompiler >> pc [
 	^ instructionStream pc
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 FBDDecompiler >> popFromStack: numElements [
 	^ ((1 to: numElements) collect: [ :i | simulatedStack removeLast ]) reverse
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> popIntoLiteralVariable: association [
 	self storeIntoLiteralVariable: association.
 	self doPop
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> popIntoReceiverVariable: offset [
 	self storeIntoReceiverVariable: offset.
 	self doPop
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> popIntoRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex [
 	self storeIntoRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex.
 	self doPop
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> popIntoTemporaryVariable: offset [
 	simulatedStack last class = Array
 		ifTrue: [
@@ -467,7 +469,7 @@ FBDDecompiler >> popIntoTemporaryVariable: offset [
 				addLast: (builder codeAssignment: simulatedStack removeLast to: (simulatedStack at: offset + 1)). self doPop ]
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 FBDDecompiler >> pragmasForMethod: aCompiledMethod [
 	^ aCompiledMethod pragmas collect: [ :each |
 		RBPragmaNode
@@ -475,12 +477,12 @@ FBDDecompiler >> pragmasForMethod: aCompiledMethod [
 			arguments: (each arguments collect: [ :arg | RBLiteralNode value: arg ]) ]
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> pushActiveContext [
 	simulatedStack addLast: builder codeThisContext
 ]
 
-{ #category : #'closure support' }
+{ #category : 'closure support' }
 FBDDecompiler >> pushCleanClosure: aCompiledBlock [
 
 	| savedSimStack savedSequence |
@@ -495,7 +497,7 @@ FBDDecompiler >> pushCleanClosure: aCompiledBlock [
 	currentSequence := savedSequence
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> pushConsArrayWithElements: numElements [
 	| array |
 	array := Array new: numElements.
@@ -503,13 +505,13 @@ FBDDecompiler >> pushConsArrayWithElements: numElements [
 	simulatedStack addLast: (builder codeArray: array)
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> pushConstant: value [
 	value isEmbeddedBlock ifTrue: [ ^self pushCleanClosure: value compiledBlock  ].
 	simulatedStack addLast: (builder codeLiteral: value)
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> pushFullClosure: aCompiledBlock numCopied: numCopied receiverOnStack: receiverOnStack ignoreOuterContext: ignoreOuterContext [
 
 	| savedSimStack savedSequence |
@@ -526,12 +528,12 @@ FBDDecompiler >> pushFullClosure: aCompiledBlock numCopied: numCopied receiverOn
 	currentSequence := savedSequence
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> pushLiteralVariable: anAssociation [
 	simulatedStack addLast: (builder codeAnyLitInd: anAssociation)
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> pushNewArrayOfSize: numElements [
 	"tempVector"
 
@@ -541,27 +543,27 @@ FBDDecompiler >> pushNewArrayOfSize: numElements [
 	simulatedStack addLast: tempVect
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> pushReceiver [
 	simulatedStack addLast: builder codeReceiver
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> pushReceiverVariable: offset [
 	simulatedStack addLast: (builder codeInstanceVariable: offset + 1)
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> pushRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex [
 	simulatedStack addLast: ((simulatedStack at: tempVectorIndex + 1) at: remoteTempIndex + 1)
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> pushTemporaryVariable: offset [
 	simulatedStack addLast: (simulatedStack at: offset + 1)
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 FBDDecompiler >> quickMethod [
 	instructionStream method isReturnSelf
 		ifTrue: [ ^ self methodReturnReceiver ].
@@ -577,61 +579,61 @@ FBDDecompiler >> quickMethod [
 	self error: 'quick method inconsistency'
 ]
 
-{ #category : #recompilation }
+{ #category : 'recompilation' }
 FBDDecompiler >> recompile: selector from: oldClass [
+
 	| newMethod |
 	newMethod := oldClass compiler
-		source: (self decompile: oldClass >> selector) formattedCode;
-		class: oldClass;
-		failBlock: [ ^ self ];
-		compile.	"Assume OK after proceed from SyntaxError"
-	selector == newMethod selector
-		ifFalse: [ self error: 'selector changed!' ].
-	oldClass 	addSelector: selector withRecompiledMethod: newMethod
+		             source: (self decompile: oldClass >> selector) formattedCode;
+		             class: oldClass;
+		             failBlock: [ ^ self ];
+		             compile. "Assume OK after proceed from SyntaxError"
+	selector == newMethod selector ifFalse: [ self error: 'selector changed!' ].
+	oldClass addSelectorSilently: selector withMethod: newMethod
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> send: selector numArgs: numberArguments [
 	| args |
 	args := self popFromStack: numberArguments.
 	simulatedStack addLast: (builder codeMessage: selector receiver: simulatedStack removeLast arguments: args)
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> send: selector super: supered numArgs: numberArguments [
 	supered
 		ifTrue:[ self superSend: selector numArgs: numberArguments ]
 		ifFalse: [ self send: selector numArgs: numberArguments ]
 ]
 
-{ #category : #asserting }
+{ #category : 'asserting' }
 FBDDecompiler >> shouldUseOriginalMethod: aCompiledMethod [
 	^ aCompiledMethod hasProperty: #ffiNonCompiledMethod
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> storeIntoLiteralVariable: association [
 	simulatedStack addLast: (builder codeAssignment: simulatedStack removeLast to: (builder codeVariable: association key))
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> storeIntoReceiverVariable: offset [
 	simulatedStack addLast: (builder codeAssignment: simulatedStack removeLast to: (builder codeInstanceVariable: offset + 1))
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> storeIntoRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex [
 	simulatedStack addLast: (builder codeAssignment: simulatedStack removeLast to: ((simulatedStack at: tempVectorIndex + 1) at: remoteTempIndex + 1))
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> storeIntoTemporaryVariable: offset [
 	| val |
 	simulatedStack addLast: (builder codeAssignment: (val := simulatedStack removeLast) to: (simulatedStack at: offset +1)).
 	(loopsArray at: self pc) ifNotNil: [ self doPop. simulatedStack addLast: val ]
 ]
 
-{ #category : #'data flow instructions' }
+{ #category : 'data flow instructions' }
 FBDDecompiler >> superSend: selector numArgs: numberArguments [
 	| args |
 	args := self popFromStack: numberArguments.

--- a/src/Flashback-Decompiler/FBDLoop.class.st
+++ b/src/Flashback-Decompiler/FBDLoop.class.st
@@ -8,25 +8,27 @@ Conditional loops are instances of my subclass.
 backjump <Smi> pc of the backjump instruction
 "
 Class {
-	#name : #FBDLoop,
-	#superclass : #Object,
+	#name : 'FBDLoop',
+	#superclass : 'Object',
 	#instVars : [
 		'backjump'
 	],
-	#category : #'Flashback-Decompiler-Utilities'
+	#category : 'Flashback-Decompiler-Utilities',
+	#package : 'Flashback-Decompiler',
+	#tag : 'Utilities'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FBDLoop >> backjump [
 	^ backjump
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FBDLoop >> backjump: anObject [
 	backjump := anObject
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 FBDLoop >> isConditionalLoop [
 	^ false
 ]

--- a/src/Flashback-Decompiler/FBDLoopScanner.class.st
+++ b/src/Flashback-Decompiler/FBDLoopScanner.class.st
@@ -8,23 +8,25 @@ currentPC <Smi> by opposition to self pc which holds the pc just *after* the ins
 
 "
 Class {
-	#name : #FBDLoopScanner,
-	#superclass : #InstructionClient,
+	#name : 'FBDLoopScanner',
+	#superclass : 'InstructionClient',
 	#instVars : [
 		'instructionStream',
 		'branchTargets',
 		'loops',
 		'currentPC'
 	],
-	#category : #'Flashback-Decompiler-Utilities'
+	#category : 'Flashback-Decompiler-Utilities',
+	#package : 'Flashback-Decompiler',
+	#tag : 'Utilities'
 }
 
-{ #category : #'public api' }
+{ #category : 'public api' }
 FBDLoopScanner class >> scan: method [
 	^ self new scan: method
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 FBDLoopScanner >> interpretMethod: method [
 	[ instructionStream pc > method endPC ]
 		whileFalse: [
@@ -32,7 +34,7 @@ FBDLoopScanner >> interpretMethod: method [
 			instructionStream interpretNextInstructionFor: self ]
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 FBDLoopScanner >> jump: offset [
 	| loop backjumpTarget |
 	offset < 0 ifFalse: [ ^ self ].
@@ -46,17 +48,17 @@ FBDLoopScanner >> jump: offset [
 		ifNotNil: [ :col | col add: loop ]
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 FBDLoopScanner >> jump: offset if: bool [
 	branchTargets at: self pc + offset put: currentPC
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FBDLoopScanner >> pc [
 	^ instructionStream pc
 ]
 
-{ #category : #'public api' }
+{ #category : 'public api' }
 FBDLoopScanner >> scan: method [
 	loops := Array new: method endPC.
 	branchTargets := Array new: method endPC.

--- a/src/Flashback-Decompiler/FBDOptimizedMessagesRewriter.class.st
+++ b/src/Flashback-Decompiler/FBDOptimizedMessagesRewriter.class.st
@@ -10,17 +10,19 @@ example: FBDOptimizedMessagesRewriter rewriteAST: (Object >> #asString ) ast.
 I only rewrite nodes with ""reconstructed"" property to ensure that I reoptimize only the messages that were optimized in the non-decompiled method.
 "
 Class {
-	#name : #FBDOptimizedMessagesRewriter,
-	#superclass : #RBProgramNodeVisitor,
-	#category : #'Flashback-Decompiler-Utilities'
+	#name : 'FBDOptimizedMessagesRewriter',
+	#superclass : 'RBProgramNodeVisitor',
+	#category : 'Flashback-Decompiler-Utilities',
+	#package : 'Flashback-Decompiler',
+	#tag : 'Utilities'
 }
 
-{ #category : #'public api' }
+{ #category : 'public api' }
 FBDOptimizedMessagesRewriter class >> rewriteAST: ast [
 	self new rewriteAST: ast
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 FBDOptimizedMessagesRewriter >> analyseSeq: seq [
 	"Checks if consecutive messages have the same receiver. If not, creates a cascade"
 
@@ -39,54 +41,54 @@ FBDOptimizedMessagesRewriter >> analyseSeq: seq [
 	self rewriteSeq: seq with: currentCascade
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 FBDOptimizedMessagesRewriter >> areArgumentsBlocks: msgNode [
 	^ msgNode arguments allSatisfy: [ :arg | arg isBlock ]
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 FBDOptimizedMessagesRewriter >> convertToAnd: msgNode [
 	msgNode selector: #and:.
 	msgNode arguments: {msgNode arguments first}
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 FBDOptimizedMessagesRewriter >> convertToIfFalse: msgNode [
 	msgNode selector: #ifFalse:.
 	msgNode arguments: {msgNode arguments second}
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 FBDOptimizedMessagesRewriter >> convertToIfNil: msgNode [
 	msgNode selector: #ifNil:.
 	msgNode arguments: {msgNode arguments first}
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 FBDOptimizedMessagesRewriter >> convertToIfNilIfNotNil: msgNode [
 	msgNode receiver: msgNode receiver receiver.
 	msgNode selector: #ifNil:ifNotNil:
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 FBDOptimizedMessagesRewriter >> convertToIfNotNil: msgNode [
 	msgNode selector: #ifNotNil:.
 	msgNode arguments: {msgNode arguments last}
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 FBDOptimizedMessagesRewriter >> convertToIfTrue: msgNode [
 	msgNode selector: #ifTrue:.
 	msgNode arguments: {msgNode arguments first}
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 FBDOptimizedMessagesRewriter >> convertToOr: msgNode [
 	msgNode selector: #or:.
 	msgNode arguments: {msgNode arguments second}
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 FBDOptimizedMessagesRewriter >> convertWhileTrueToToByDo: msgNode start: start end: end by: incrValue incrVariable: incrVar assignement: assignement [
 	| selector arguments loopBlock |
 	loopBlock := msgNode arguments last.
@@ -107,7 +109,7 @@ FBDOptimizedMessagesRewriter >> convertWhileTrueToToByDo: msgNode start: start e
 	msgNode parent removeNode: assignement
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 FBDOptimizedMessagesRewriter >> extractStartValue: msgNode startTemp: startTemp [
 	| assignement indexOfMsg |
 	indexOfMsg := msgNode parent statements indexOf: msgNode.
@@ -119,7 +121,7 @@ FBDOptimizedMessagesRewriter >> extractStartValue: msgNode startTemp: startTemp 
 	^ assignement value
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 FBDOptimizedMessagesRewriter >> handleBigArray: msgNode [
 	| seq cascade |
 	seq := msgNode parent parent.
@@ -128,7 +130,7 @@ FBDOptimizedMessagesRewriter >> handleBigArray: msgNode [
 	seq replaceNode: cascade withNode: (RBArrayNode statements: (cascade  messages removeLast; collect: [ :msg | msg arguments first ]))
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 FBDOptimizedMessagesRewriter >> handleIfFalse: msgNode [
 	(self isIfNilIfNotNil: msgNode)
 		ifTrue: [
@@ -136,7 +138,7 @@ FBDOptimizedMessagesRewriter >> handleIfFalse: msgNode [
 			msgNode selector: #ifNotNil: ]
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 FBDOptimizedMessagesRewriter >> handleIfNilIfNotNil: msgNode [
 	(self isIfNil: msgNode)
 		ifTrue: [ ^ self convertToIfNil: msgNode ].
@@ -144,7 +146,7 @@ FBDOptimizedMessagesRewriter >> handleIfNilIfNotNil: msgNode [
 		ifTrue: [ ^ self convertToIfNotNil: msgNode ]
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 FBDOptimizedMessagesRewriter >> handleIfTrue: msgNode [
 	(self isIfNilIfNotNil: msgNode)
 		ifTrue: [
@@ -152,7 +154,7 @@ FBDOptimizedMessagesRewriter >> handleIfTrue: msgNode [
 			msgNode selector: #ifNil: ]
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 FBDOptimizedMessagesRewriter >> handleIfTrueIfFalse: msgNode [
 	(self areArgumentsBlocks: msgNode) ifFalse: [ ^ self ].
 	(self isIfFalse: msgNode) ifTrue: [ ^ self convertToIfFalse: msgNode ].
@@ -162,7 +164,7 @@ FBDOptimizedMessagesRewriter >> handleIfTrueIfFalse: msgNode [
 	(self isIfNilIfNotNil: msgNode) ifTrue: [ ^ self convertToIfNilIfNotNil: msgNode ]
 ]
 
-{ #category : #handling }
+{ #category : 'handling' }
 FBDOptimizedMessagesRewriter >> handleWhileTrue: msgNode [
 	| startTemp start end incrValue rcvr |
 	(self isReceiverCorrectCondition: msgNode)
@@ -186,7 +188,7 @@ FBDOptimizedMessagesRewriter >> handleWhileTrue: msgNode [
 		assignement: (msgNode parent statements at: (msgNode parent statements indexOf: msgNode) - 1)
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 FBDOptimizedMessagesRewriter >> hasCorrectIncrInstruction: msgNode startTemp: startTemp isPositiveLoop: isPositiveLoop [
 	| incrInstruction |
 	incrInstruction := msgNode arguments first body statements last.
@@ -205,29 +207,29 @@ FBDOptimizedMessagesRewriter >> hasCorrectIncrInstruction: msgNode startTemp: st
 	^ incrInstruction value arguments first value positive = isPositiveLoop
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 FBDOptimizedMessagesRewriter >> isAnd: msgNode [
 	| stmts |
 	stmts := msgNode arguments second body statements.
 	^ stmts size = 1 and: [ stmts first value = false ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 FBDOptimizedMessagesRewriter >> isBigArray: msgNode [
 	^ (msgNode selector = #braceStream:) and: [ msgNode receiver isVariable and: [ msgNode receiver name = #Array ] ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 FBDOptimizedMessagesRewriter >> isIfFalse: msgNode [
 	^ msgNode arguments first body statements isEmpty
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 FBDOptimizedMessagesRewriter >> isIfNil: msgNode [
 	^ msgNode arguments second = msgNode receiver
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 FBDOptimizedMessagesRewriter >> isIfNilIfNotNil: msgNode [
 	msgNode receiver isMessage
 		ifFalse: [ ^ false ].
@@ -236,31 +238,31 @@ FBDOptimizedMessagesRewriter >> isIfNilIfNotNil: msgNode [
 	^ msgNode receiver arguments first value isNil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 FBDOptimizedMessagesRewriter >> isIfNotNil: msgNode [
 	| stmts |
 	stmts := msgNode arguments first body statements.
 	^ stmts size = 1 and: [ stmts first = msgNode receiver ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 FBDOptimizedMessagesRewriter >> isIfTrue: msgNode [
 	^ msgNode arguments second body statements isEmpty
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 FBDOptimizedMessagesRewriter >> isLastStatementReturnSelf: seq [
 	^ seq parent isMethod and: [ seq statements last isReturn and: [ seq statements last value isSelfVariable ] ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 FBDOptimizedMessagesRewriter >> isOr: msgNode [
 	| stmts |
 	stmts := msgNode arguments first body statements.
 	^ stmts size = 1 and: [ stmts first value = true ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 FBDOptimizedMessagesRewriter >> isPositiveLoopOrNil: rcvr [
 	rcvr selector = #<=
 		ifTrue: [ ^ true ].
@@ -269,14 +271,14 @@ FBDOptimizedMessagesRewriter >> isPositiveLoopOrNil: rcvr [
 	^ nil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 FBDOptimizedMessagesRewriter >> isReceiver1StatementBlock: msgNode [
 	msgNode receiver isBlock
 		ifFalse: [ ^ false ].
 	^ msgNode receiver body statements size = 1
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 FBDOptimizedMessagesRewriter >> isReceiverCorrectCondition: msgNode [
 	| condition |
 	(self isReceiver1StatementBlock: msgNode ) ifFalse: [ ^ false ].
@@ -284,12 +286,12 @@ FBDOptimizedMessagesRewriter >> isReceiverCorrectCondition: msgNode [
 	^ condition isMessage and: [ condition isBinary ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 FBDOptimizedMessagesRewriter >> isReconstructed: msg [
 	^ msg hasProperty: #reconstructed
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 FBDOptimizedMessagesRewriter >> removeTempFromSequence: seq temp: temp [
 	| temps |
 	seq ifNil: [ ^self "2 to:do: in the same method, temp has already  been removed" ].
@@ -300,20 +302,20 @@ FBDOptimizedMessagesRewriter >> removeTempFromSequence: seq temp: temp [
 		ifFalse: [ seq temporaries: temps ]
 ]
 
-{ #category : #'public api' }
+{ #category : 'public api' }
 FBDOptimizedMessagesRewriter >> rewriteAST: aMethodNode [
 	self visitNode: aMethodNode.
 	^ aMethodNode
 ]
 
-{ #category : #rewriting }
+{ #category : 'rewriting' }
 FBDOptimizedMessagesRewriter >> rewriteSeq: seq with: currentCascade [
 	currentCascade size > 1
 		ifTrue: [ self rewriteStatements: currentCascade in: seq ].
 		currentCascade removeAll
 ]
 
-{ #category : #rewriting }
+{ #category : 'rewriting' }
 FBDOptimizedMessagesRewriter >> rewriteStatements: statements in: seq [
 "You have to remove the first statement from the collection before removing all nodes in the sequence.
 RemoveNode first uses == to detect the node , then =
@@ -325,7 +327,7 @@ So if you have the same node twice in the sequence, and this node is the first m
 		yourself) do: [ :each | seq removeNode: each ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 FBDOptimizedMessagesRewriter >> visitBlockNode: block [
 	super visitBlockNode: block.
 	block body statements ifEmpty: [  ^ self ].
@@ -334,7 +336,7 @@ FBDOptimizedMessagesRewriter >> visitBlockNode: block [
 	block body statements removeLast
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 FBDOptimizedMessagesRewriter >> visitMessageNode: msgNode [
 	"Do not add return statements.
 	ifTrue:ifFalse: handling may change the current message node into an ifTrue: , an ifFalse: or an ifNil:ifNotNil: message.
@@ -357,7 +359,7 @@ FBDOptimizedMessagesRewriter >> visitMessageNode: msgNode [
 		ifTrue: [ self handleBigArray: msgNode ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 FBDOptimizedMessagesRewriter >> visitSequenceNode: seq [
 	self analyseSeq: seq .
 	super visitSequenceNode: seq.

--- a/src/Flashback-Decompiler/ManifestFlashbackDecompiler.class.st
+++ b/src/Flashback-Decompiler/ManifestFlashbackDecompiler.class.st
@@ -4,7 +4,9 @@ Flashback is a Decompiler for Pharo code.
 My job is to decompile a compiledMethod to get valid Abstract Syntax Tree (AST).
 "
 Class {
-	#name : #ManifestFlashbackDecompiler,
-	#superclass : #PackageManifest,
-	#category : #'Flashback-Decompiler-Manifest'
+	#name : 'ManifestFlashbackDecompiler',
+	#superclass : 'PackageManifest',
+	#category : 'Flashback-Decompiler-Manifest',
+	#package : 'Flashback-Decompiler',
+	#tag : 'Manifest'
 }

--- a/src/Flashback-Decompiler/package.st
+++ b/src/Flashback-Decompiler/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Flashback-Decompiler' }
+Package { #name : 'Flashback-Decompiler' }

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -72,11 +72,6 @@ Behavior >> addSelector: selector withMethod: compiledMethod [
 ]
 
 { #category : 'adding-removing methods' }
-Behavior >> addSelector: selector withRecompiledMethod: compiledMethod [
-	^ self addSelectorSilently: selector withMethod: compiledMethod
-]
-
-{ #category : 'adding-removing methods' }
 Behavior >> addSelectorSilently: selector withMethod: compiledMethod [
 	"Add the message selector with the corresponding compiled method to the
 	receiver's method dictionary.

--- a/src/OpalCompiler-Core/ArgumentVariable.class.st
+++ b/src/OpalCompiler-Core/ArgumentVariable.class.st
@@ -2,39 +2,41 @@
 I model argument variables. By definition, an argument variable is always initialized, and can't be written to.
 "
 Class {
-	#name : #ArgumentVariable,
-	#superclass : #LocalVariable,
-	#category : #'OpalCompiler-Core-Semantics'
+	#name : 'ArgumentVariable',
+	#superclass : 'LocalVariable',
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 ArgumentVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 	^ aProgramNodeVisitor visitArgumentVariableNode: aNode
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 ArgumentVariable >> definingNode [
 	^ scope node arguments detect: [ :each | each variable == self ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ArgumentVariable >> isArgumentVariable [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ArgumentVariable >> isUninitialized [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ArgumentVariable >> isWritable [
 
 	^ false
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 ArgumentVariable >> writeFromContext: aContext scope: contextScope value: aValue [
 	self error: 'Arguments are read only'
 ]

--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -1,11 +1,11 @@
-Extension { #name : #Behavior }
+Extension { #name : 'Behavior' }
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Behavior >> allTemps [
 	^#()
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Behavior >> compile: code [
 	"Compile the argument, code, as source code in the context of the
 	receiver. Create an error notification if the code can not be compiled.
@@ -15,7 +15,7 @@ Behavior >> compile: code [
 	^self compile: code notifying: nil
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Behavior >> compile: code notifying: requestor [
 	"Compile the argument, code, as source code in the context of the
 	receiver and insEtall the result in the receiver's method dictionary. The
@@ -36,12 +36,12 @@ Behavior >> compile: code notifying: requestor [
 	^ method selector
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Behavior >> compileAll [
 	^ self compileAllFrom: self
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Behavior >> compileAllFrom: oldClass [
 	"Compile all the methods in the receiver's method dictionary.
 	This validates sourceCode and variable references and forces
@@ -49,7 +49,7 @@ Behavior >> compileAllFrom: oldClass [
 	oldClass localSelectors do: [:sel | self recompile: sel from: oldClass]
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Behavior >> compiler [
 	"Answer a compiler appropriate for source methods of this class."
 
@@ -58,45 +58,45 @@ Behavior >> compiler [
 		class: self
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Behavior >> compilerClass [
 	"Answer a compiler class appropriate for source methods of this class."
 
 	^Smalltalk compilerClass
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Behavior >> evaluate: aString [
 	self deprecated: 'You should not even use it as `self` does not impact the result' transformWith: '`@rcv evaluate: `@arg' -> '`@rcv compiler evaluate: `@arg'.
 	^self compiler evaluate: aString
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Behavior >> outerScope [
 	^self environment
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Behavior >> recompile [
 	self compileAll
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Behavior >> recompile: selector [
 	"Compile the method associated with selector in the receiver's method dictionary."
 	^self recompile: selector from: self
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Behavior >> recompile: selector from: oldClass [
 	"Compile the method associated with selector in the receiver's method dictionary."
 
 	| newMethod |
 	newMethod := self recompileBasic: selector from: oldClass.
-	self addSelector: selector withRecompiledMethod: newMethod
+	self addSelectorSilently: selector withMethod: newMethod
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Behavior >> recompileBasic: selector from: oldClass [
 	"Compile the method associated with selector in the receiver's context.
 	The resulting compiled method is not installed.

--- a/src/OpalCompiler-Core/BlockClosure.extension.st
+++ b/src/OpalCompiler-Core/BlockClosure.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #BlockClosure }
+Extension { #name : 'BlockClosure' }
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 BlockClosure >> sourceNode [
 	^ self compiledBlock sourceNodeInOuter
 ]

--- a/src/OpalCompiler-Core/Class.extension.st
+++ b/src/OpalCompiler-Core/Class.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Class }
+Extension { #name : 'Class' }
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Class >> classSideCompiler [
 	"Redefine this method if you want to customize the compiler for class-side methods"
 	^self classSideCompilerClass new
@@ -8,7 +8,7 @@ Class >> classSideCompiler [
 		class: self classSide
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Class >> classSideCompilerClass [
 	"Redefine this method if you want to customize the compiler class for class-side methods"
 	^ Smalltalk compilerClass

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -13,8 +13,8 @@ environment <SystemDictionary> place to look for literal variables (Globals for 
 
 "
 Class {
-	#name : #CompilationContext,
-	#superclass : #Object,
+	#name : 'CompilationContext',
+	#superclass : 'Object',
 	#instVars : [
 		'options',
 		'environment',
@@ -36,21 +36,23 @@ Class {
 		'DefaultParseTransformationPlugins',
 		'DefaultTransformationPlugins'
 	],
-	#category : #'OpalCompiler-Core-FrontEnd'
+	#category : 'OpalCompiler-Core-FrontEnd',
+	#package : 'OpalCompiler-Core',
+	#tag : 'FrontEnd'
 }
 
-{ #category : #adding }
+{ #category : 'adding' }
 CompilationContext class >> addDefaultParseTransformationPlugin: aPlugin [
 
 	self defaultParseTransformationPlugins add: aPlugin
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 CompilationContext class >> addDefaultTransformationPlugin: aPlugin [
 	self defaultTransformationPlugins add: aPlugin
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext class >> cleanOptionString: string [
 	"Would be nice to put it on String but I don't fancy class extensions..."
 	"Takes the option symbol and tries to beautify it  bit for the option menu (Add space, etc.)"
@@ -65,7 +67,7 @@ CompilationContext class >> cleanOptionString: string [
 	^ ws contents
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext class >> compilerSettingsOn: aBuilder [
 	self optionsDescription withIndexDo: [ :description :index |
 		| optionStringCleaned option |
@@ -80,186 +82,186 @@ CompilationContext class >> compilerSettingsOn: aBuilder [
 		 ]
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CompilationContext class >> default [
 	^ self new
 		setOptions: self defaultOptions copy;
 		yourself
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext class >> defaultOptions [
 	^ DefaultOptions ifNil: [ DefaultOptions := Set new parseOptions: self initialDefaultOptions ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext class >> defaultParseTransformationPlugins [
 
 	^ DefaultParseTransformationPlugins
 		ifNil: [ DefaultParseTransformationPlugins := OrderedCollection new ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext class >> defaultTransformationPlugins [
 
 	^ DefaultTransformationPlugins ifNil: [
 		DefaultTransformationPlugins := OrderedCollection new ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext class >> defaultTransformationPlugins: anObject [
 	DefaultTransformationPlugins := anObject
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext class >> initialDefaultOptions [
 	"Skip the comment of each option"
 	^ (self optionsDescription collect: [ :each | each allButLast ]) flattened
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 CompilationContext class >> initialize [
 	"Note: we don't set-up here DefaultOptions since it requires other class-side methods, and that's messed up."
 	DefaultTransformationPlugins := OrderedCollection new
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionBlockClosureOptionalOuter [
 	^ self readDefaultOption: #optionBlockClosureOptionalOuter
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionBlockClosureOptionalOuter: aBoolean [
 	^ self writeDefaultOption: #optionBlockClosureOptionalOuter value: aBoolean
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionCleanBlockClosure [
 	^ self readDefaultOption: #optionCleanBlockClosure
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionCleanBlockClosure: aBoolean [
 	^ self writeDefaultOption: #optionCleanBlockClosure value: aBoolean
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionConstantBlockClosure [
 	^ self readDefaultOption: #optionConstantBlockClosure
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionConstantBlockClosure: aBoolean [
 	^ self writeDefaultOption: #optionConstantBlockClosure value: aBoolean
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionInlineAndOr [
 	^ self readDefaultOption: #optionInlineAndOr
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionInlineAndOr: aBoolean [
 	^ self writeDefaultOption: #optionInlineAndOr value: aBoolean
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionInlineCase [
 	^ self readDefaultOption: #optionInlineCase
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionInlineCase: aBoolean [
 	^ self writeDefaultOption: #optionInlineCase value: aBoolean
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionInlineIf [
 	^ self readDefaultOption: #optionInlineIf
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionInlineIf: aBoolean [
 	^ self writeDefaultOption: #optionInlineIf value: aBoolean
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionInlineIfNil [
 	^ self readDefaultOption: #optionInlineIfNil
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionInlineIfNil: aBoolean [
 	^ self writeDefaultOption: #optionInlineIfNil value: aBoolean
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionInlineNone [
 	^ self readDefaultOption: #optionInlineNone
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionInlineNone: aBoolean [
 	^ self writeDefaultOption: #optionInlineNone value: aBoolean
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionInlineRepeat [
 	^ self readDefaultOption: #optionInlineRepeat
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionInlineRepeat: aBoolean [
 	^ self writeDefaultOption: #optionInlineRepeat value: aBoolean
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionInlineTimesRepeat [
 	^ self readDefaultOption: #optionInlineTimesRepeat
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionInlineTimesRepeat: aBoolean [
 	^ self writeDefaultOption: #optionInlineTimesRepeat value: aBoolean
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionInlineToDo [
 	^ self readDefaultOption: #optionInlineToDo
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionInlineToDo: aBoolean [
 	^ self writeDefaultOption: #optionInlineToDo value: aBoolean
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionInlineWhile [
 	^ self readDefaultOption: #optionInlineWhile
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionInlineWhile: aBoolean [
 	^ self writeDefaultOption: #optionInlineWhile value: aBoolean
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionLongIvarAccessBytecodes [
 	^ self readDefaultOption: #optionLongIvarAccessBytecodes
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionLongIvarAccessBytecodes: aBoolean [
 	^ self writeDefaultOption: #optionLongIvarAccessBytecodes value: aBoolean
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext class >> optionOptimiseSpecialSends [
 
 	^ self readDefaultOption: #optionOptimiseSpecialSends
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext class >> optionOptimiseSpecialSends: aBoolean [
 
 	^ self
@@ -267,47 +269,47 @@ CompilationContext class >> optionOptimiseSpecialSends: aBoolean [
 		  value: aBoolean
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionOptimizeIR [
 	^ self readDefaultOption: #optionOptimizeIR
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionOptimizeIR: aBoolean [
 	^ self writeDefaultOption: #optionOptimizeIR value: aBoolean
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionParseErrors [
 	^ self readDefaultOption: #optionParseErrors
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionParseErrors: aBoolean [
 	^ self writeDefaultOption: #optionParseErrors value: aBoolean
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionParseErrorsNonInteractiveOnly [
 	^ self readDefaultOption: #optionParseErrorsNonInteractiveOnly
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionParseErrorsNonInteractiveOnly: aBoolean [
 	^ self writeDefaultOption: #optionParseErrorsNonInteractiveOnly value: aBoolean
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionSkipSemanticWarnings [
 	^ self readDefaultOption: #optionSkipSemanticWarnings
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> optionSkipSemanticWarnings: aBoolean [
 	^ self writeDefaultOption: #optionSkipSemanticWarnings value: aBoolean
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext class >> optionsDescription [
 	"Default options are held by DefaultOptions class variable.
 	 The description of default options here is only used as a
@@ -338,63 +340,63 @@ CompilationContext class >> optionsDescription [
 	)
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> readDefaultOption: option [
 	^ self defaultOptions includes: option
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 CompilationContext class >> removeDefaultTransformationPlugin: aPlugin [
 	self defaultTransformationPlugins remove: aPlugin
 ]
 
-{ #category : #'options - settings API' }
+{ #category : 'options - settings API' }
 CompilationContext class >> writeDefaultOption: option value: boolean [
 	boolean
 		ifTrue: [ self defaultOptions add: option ]
 		ifFalse: [ self defaultOptions remove: option ifAbsent: []]
 ]
 
-{ #category : #plugins }
+{ #category : 'plugins' }
 CompilationContext >> addASTTransformationPlugin: aPlugin [
 
 	astTransformPlugins add: aPlugin
 ]
 
-{ #category : #plugins }
+{ #category : 'plugins' }
 CompilationContext >> addParseASTTransformationPlugin: aPlugin [
 
 	astParseTransformPlugins add: aPlugin
 ]
 
-{ #category : #plugins }
+{ #category : 'plugins' }
 CompilationContext >> astParseTransformPlugins [
 
 	^ astParseTransformPlugins
 ]
 
-{ #category : #plugins }
+{ #category : 'plugins' }
 CompilationContext >> astTransformPlugins [
 
 	^ astTransformPlugins
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> astTranslatorClass [
 	^ astTranslatorClass ifNil: [ astTranslatorClass := OCASTTranslator ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> astTranslatorClass: anObject [
 	astTranslatorClass := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> bindings [
 	^ bindings
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> bindings: aCollectionOfAssociations [
 	"bindings are LiteralVariables, not simple Associations.
 	This method receives any collection with Associations or Variables inside and converts those to AdditionalBindings"
@@ -402,22 +404,22 @@ CompilationContext >> bindings: aCollectionOfAssociations [
 		collect: [ :each | (each isAssociation ifTrue: [ AdditionalBinding key: each key value: each value ] ifFalse: [each])]) asDictionary
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> bytecodeGeneratorClass [
 	^ bytecodeGeneratorClass ifNil: [ bytecodeGeneratorClass := IRBytecodeGenerator ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> bytecodeGeneratorClass: anObject [
 	bytecodeGeneratorClass := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> class: aClass [
 	self semanticScope: (OCMethodSemanticScope targetingClass: aClass)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> compiledMethodClass [
 	"Return the class used to instantiate the compiled method created by the compiler"
 	^ compiledMethodClass ifNil: [
@@ -426,39 +428,39 @@ CompilationContext >> compiledMethodClass [
 			ifAbsent: [ CompiledMethod ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> compiledMethodClass: aCompiledMethodClass [
 	"Return the class used to instantiate the compiled method created by the compiler"
 
 	compiledMethodClass := aCompiledMethodClass
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext >> compilerOptions: anArray [
 	self parseOptions: anArray
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> encoderClass [
 	^ encoderClass ifNil: [ encoderClass := EncoderForSistaV1 ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> encoderClass: anObject [
 	encoderClass := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> environment [
 	^ environment ifNil: [ environment := semanticScope environment ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> environment: anObject [
 	environment := anObject
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 CompilationContext >> initialize [
 
 	options := Set new.
@@ -467,183 +469,183 @@ CompilationContext >> initialize [
 	semanticScope := OCMethodSemanticScope targetingClass: nil class
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> noPattern [
 	^semanticScope isDoItScope
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> noPattern: anObject [
 
 	(anObject and: [ self noPattern not ]) ifTrue: [
 		semanticScope := OCReceiverDoItSemanticScope targetingNilReceiver ]
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext >> optionBlockClosureOptionalOuter [
 	^ options includes: #optionBlockClosureOptionalOuter
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext >> optionCleanBlockClosure [
 	^ options includes: #optionCleanBlockClosure
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext >> optionConstantBlockClosure [
 	^ options includes: #optionConstantBlockClosure
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext >> optionInlineAndOr [
 
 	^ self optionInlineNone not and: [
 		  options includes: #optionInlineAndOr ]
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext >> optionInlineCase [
 
 	^ self optionInlineNone not and: [
 		  options includes: #optionInlineCase ]
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext >> optionInlineIf [
 
 	^ self optionInlineNone not and: [ options includes: #optionInlineIf ]
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext >> optionInlineIfNil [
 
 	^ self optionInlineNone not and: [
 		  options includes: #optionInlineIfNil ]
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext >> optionInlineNone [
 	^ options includes: #optionInlineNone
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext >> optionInlineRepeat [
 
 	^ self optionInlineNone not and: [
 		  options includes: #optionInlineRepeat ]
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext >> optionInlineTimesRepeat [
 
 	^ self optionInlineNone not and: [
 		  options includes: #optionInlineTimesRepeat ]
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext >> optionInlineToDo [
 
 	^ self optionInlineNone not and: [
 		  options includes: #optionInlineToDo ]
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext >> optionInlineWhile [
 
 	^ self optionInlineNone not and: [
 		  options includes: #optionInlineWhile ]
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext >> optionLongIvarAccessBytecodes [
 	^ options includes: #optionLongIvarAccessBytecodes
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext >> optionOptimiseSpecialSends [
 	^ options includes: #optionOptimiseSpecialSends
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext >> optionOptimizeIR [
 	^ options includes: #optionOptimizeIR
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext >> optionParseErrors [
 	^ options includes: #optionParseErrors
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext >> optionParseErrorsNonInteractiveOnly [
 	^ options includes: #optionParseErrorsNonInteractiveOnly
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext >> optionSkipSemanticWarnings [
 	^ options includes: #optionSkipSemanticWarnings
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext >> parseOptions: optionsArray [
 
 	options parseOptions: optionsArray
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> parserClass [
 	^ parserClass ifNil: [ parserClass := RBParser ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> parserClass: anObject [
 	parserClass := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> productionEnvironment [
 	^productionEnvironment ifNil: [ ^self environment ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> productionEnvironment: aDictionary [
 	productionEnvironment := aDictionary
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> requestorScopeClass [
 	^ requestorScopeClass ifNil: [ requestorScopeClass := OCRequestorScope ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> requestorScopeClass: anObject [
 	"clients can set their own subclass of OCRequestorScope if needed"
 	requestorScopeClass := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> semanticAnalyzerClass [
 	^ semanticAnalyzerClass ifNil: [ semanticAnalyzerClass := OCASTSemanticAnalyzer  ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> semanticAnalyzerClass: anObject [
 	semanticAnalyzerClass := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> semanticScope [
 
 	^ semanticScope
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CompilationContext >> semanticScope: anObject [
 
 	semanticScope := anObject
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 CompilationContext >> setOptions: opts [
 	options := opts
 ]

--- a/src/OpalCompiler-Core/CompiledBlock.extension.st
+++ b/src/OpalCompiler-Core/CompiledBlock.extension.st
@@ -1,23 +1,23 @@
-Extension { #name : #CompiledBlock }
+Extension { #name : 'CompiledBlock' }
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 CompiledBlock >> ast [
 	^ self sourceNodeInOuter
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 CompiledBlock >> sourceNode [
 	^ self sourceNodeInOuter
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 CompiledBlock >> sourceNodeForPC: aPC [
 	| blockNode |
 	blockNode := self outerCode sourceNodeForPC: self pcInOuter.
 	^blockNode sourceNodeForPC: aPC
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 CompiledBlock >> sourceNodeInOuter [
 	^ self outerCode sourceNodeForPC: self pcInOuter
 ]

--- a/src/OpalCompiler-Core/CompiledCode.extension.st
+++ b/src/OpalCompiler-Core/CompiledCode.extension.st
@@ -1,29 +1,29 @@
-Extension { #name : #CompiledCode }
+Extension { #name : 'CompiledCode' }
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 CompiledCode >> ast [
 	^ self subclassResponsibility
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 CompiledCode >> compiler [
 	^self methodClass compiler
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 CompiledCode >> compilerClass [
 	^self methodClass
 		ifNil: [Smalltalk compilerClass]
 		ifNotNil: [:class | class compilerClass]
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 CompiledCode >> ir [
 	"We as the AST for the IR... for decompiling ir from bytecode, look at IRBytecodeDecompiler"
 	^ self ast ir
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 CompiledCode >> irPrimitive [
 
 	| primNode n |

--- a/src/OpalCompiler-Core/CompiledMethod.extension.st
+++ b/src/OpalCompiler-Core/CompiledMethod.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #CompiledMethod }
+Extension { #name : 'CompiledMethod' }
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 CompiledMethod >> decompile [
 	^Smalltalk globals
 		at: #FBDDecompiler
@@ -9,40 +9,40 @@ CompiledMethod >> decompile [
 	self noSourceAvailable' ]
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 CompiledMethod >> decompileIR [
 
 	^ IRBytecodeDecompiler new decompile: self
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 CompiledMethod >> lookupVar: aString [
 	^self ast scope lookupVar: aString
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 CompiledMethod >> methodNode [
 	"returns an AST for this method, do not cache it. (see #ast for the cached alternative)"
 	^self parseTree
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 CompiledMethod >> recompile [
 	^ self methodClass recompile: self selector
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 CompiledMethod >> reformat [
 
 	self methodClass compile: self ast formattedCode classified: self protocol
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 CompiledMethod >> sourceNode [
 	^self ast
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 CompiledMethod >> sourceNodeForPC: aPC [
 	^self sourceNode sourceNodeForPC: aPC
 ]

--- a/src/OpalCompiler-Core/Context.extension.st
+++ b/src/OpalCompiler-Core/Context.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Context }
+Extension { #name : 'Context' }
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Context >> astScope [
 	"Return the scope of the method or the block of this context.
 	Note: if the compiler would not model scopes for optimized blocks, this would just just be the
@@ -18,7 +18,7 @@ Context >> astScope [
 		ifFalse: [node methodOrBlockNode scope ]
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Context >> compiler [
 	"Return a compiler set up to parse/compile/evaluate scripts on the current context.
 	The compiler is also setup according to the class of the receiver"
@@ -26,7 +26,7 @@ Context >> compiler [
 	^ self receiver class compiler context: self
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Context >> executedPC [
 	"Deeper in the stack the pc was already advanced one bytecode, so we need to go back
 	this one bytecode, which can consist of multiple bytes. But on IR, we record the *last*
@@ -39,32 +39,32 @@ Context >> executedPC [
 	^self isDead ifTrue: [ self endPC - 1] ifFalse: [ pc - 1]
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Context >> isBlockReturn: aPC [
 	^method encoderClass isBlockReturnAt: aPC in: method
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Context >> isPushLiteralNil: aPC [
 	^ (self compiledCode at: aPC) = method encoderClass pushNilByte
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Context >> isPushTemp: aPC [
 	^ self compiledCode encoderClass isPushTempAt: aPC in: method
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Context >> isReturnAt: aPC [
 	^method encoderClass isReturnAt: aPC in: method
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Context >> lookupVar: aSymbol [
 	^ self astScope lookupVar: aSymbol
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Context >> sourceNode [
 	"Return the source node that created the method or the block of this context"
 
@@ -73,7 +73,7 @@ Context >> sourceNode [
 		ifNotNil: [ closureOrNil sourceNode ]
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Context >> sourceNodeExecuted [
 	"When down in the stack, I return the node that executed"
 	^ method sourceNodeForPC: self executedPC

--- a/src/OpalCompiler-Core/CopiedLocalVariable.class.st
+++ b/src/OpalCompiler-Core/CopiedLocalVariable.class.st
@@ -2,68 +2,70 @@
 A copied variable is an arg or temp var that is copied into a block that later reads this variable
 "
 Class {
-	#name : #CopiedLocalVariable,
-	#superclass : #LocalVariable,
+	#name : 'CopiedLocalVariable',
+	#superclass : 'LocalVariable',
 	#instVars : [
 		'originalVar'
 	],
-	#category : #'OpalCompiler-Core-Semantics'
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 CopiedLocalVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 	^ originalVar acceptVisitor: aProgramNodeVisitor node: aNode
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 CopiedLocalVariable >> definingNode [
 	^ scope node temporaries
 		detect: [ :each | each variable == self ]
 		ifNone: [ nil ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CopiedLocalVariable >> index: anIndex [
 	self scope == originalVar scope ifTrue: [ originalVar index: anIndex ].
 	super index: anIndex
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CopiedLocalVariable >> isArgumentVariable [
 	^originalVar isArgumentVariable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CopiedLocalVariable >> isCopying [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CopiedLocalVariable >> isTempVariable [
 	^ originalVar isTempVariable
 ]
 
-{ #category : #'read/write usage' }
+{ #category : 'read/write usage' }
 CopiedLocalVariable >> isUninitialized [
 	^originalVar isUninitialized
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CopiedLocalVariable >> isWritable [
 	^originalVar isWritable
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CopiedLocalVariable >> originalVar [
 	^ originalVar
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CopiedLocalVariable >> originalVar: anObject [
 	originalVar := anObject
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 CopiedLocalVariable >> writeFromContext: aContext scope: contextScope value: aValue [
 	self isWritable ifFalse: [ 	^self error: 'Arguments are read only' ].
 	"we need to change this var, all the other copies, and the orginal"

--- a/src/OpalCompiler-Core/IRAccess.class.st
+++ b/src/OpalCompiler-Core/IRAccess.class.st
@@ -2,7 +2,9 @@
 IRAccess models all bytecodes that read or write variables or self/super/thisContext
 "
 Class {
-	#name : #IRAccess,
-	#superclass : #IRInstruction,
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#name : 'IRAccess',
+	#superclass : 'IRInstruction',
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }

--- a/src/OpalCompiler-Core/IRBlockReturnTop.class.st
+++ b/src/OpalCompiler-Core/IRBlockReturnTop.class.st
@@ -2,37 +2,39 @@
 I model the bytecode for block returns.
 "
 Class {
-	#name : #IRBlockReturnTop,
-	#superclass : #IRReturn,
+	#name : 'IRBlockReturnTop',
+	#superclass : 'IRReturn',
 	#instVars : [
 		'successor'
 	],
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRBlockReturnTop >> accept: aVisitor [
 	^ aVisitor visitBlockReturnTop: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRBlockReturnTop >> isBlockReturnTop [
 
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBlockReturnTop >> successor [
 	^ successor
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBlockReturnTop >> successor: anObject [
 
 	successor := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBlockReturnTop >> successorSequences [
 	"sent to last instruction in sequence which is expected to be a jump and return instruction"
 

--- a/src/OpalCompiler-Core/IRBuilder.class.st
+++ b/src/OpalCompiler-Core/IRBuilder.class.st
@@ -20,8 +20,8 @@ Sending #compiledMethod to an ir method will generate its compiledMethod.  Sendi
 
 "
 Class {
-	#name : #IRBuilder,
-	#superclass : #Object,
+	#name : 'IRBuilder',
+	#superclass : 'Object',
 	#instVars : [
 		'ir',
 		'currentScope',
@@ -31,20 +31,22 @@ Class {
 		'sourceMapNodes',
 		'sourceMapByteIndex'
 	],
-	#category : #'OpalCompiler-Core-IR-Manipulation'
+	#category : 'OpalCompiler-Core-IR-Manipulation',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Manipulation'
 }
 
-{ #category : #'builder api' }
+{ #category : 'builder api' }
 IRBuilder class >> buildIR: aBlock [
 	^(aBlock value: self new) ir
 ]
 
-{ #category : #'builder api' }
+{ #category : 'builder api' }
 IRBuilder class >> buildMethod: aBlock [
 	^(self buildIR: aBlock) compiledMethod
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 IRBuilder >> add: instr [
 
 	"Associate instr with current parse node or byte range"
@@ -53,7 +55,7 @@ IRBuilder >> add: instr [
 	^ currentSequence add: instr
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> addBlockReturnTopIfRequired [
 	"If the current sequence is empty this means that there was a returntop before
 	then since there is no more stmts we do not need a blockreturntop"
@@ -71,26 +73,26 @@ IRBuilder >> addBlockReturnTopIfRequired [
 							ifFalse: [self blockReturnTop ]
 ]
 
-{ #category : #decompiling }
+{ #category : 'decompiling' }
 IRBuilder >> addJumpBackTarget: label to: sequence [
 
 	(jumpBackTargetStacks at: label ifAbsentPut: [OrderedCollection new])
 		addLast: sequence
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 IRBuilder >> addLiteral: aLiteral [
 	"Add this literal at the end of the literal array if there is space left"
 	aLiteral ifNil: [ ^ self ].
 	ir addAdditionalLiteral: aLiteral
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 IRBuilder >> addPragma: aPragma [
 	^ir addPragma: aPragma
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 IRBuilder >> addTemp: tempKey [
 
 	| tempMap |
@@ -103,18 +105,18 @@ IRBuilder >> addTemp: tempKey [
 	self cacheIndex: tempKey
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 IRBuilder >> addTemps: newKeys [
 	newKeys do: [ :key | self addTemp: key ]
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 IRBuilder >> additionalLiterals:  literals [
 	"Add this literal at the end of the literal array if there is space left"
 	ir addAdditionalLiterals: literals
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> blockReturnTop [
 	| retInst |
 
@@ -125,7 +127,7 @@ IRBuilder >> blockReturnTop [
 	self popScope
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 IRBuilder >> cacheIndex: tempKey [
 	"if we have the ast, we can store the temp offset"
 	self sourceNode ifNotNil: [ :sourceNode |
@@ -135,17 +137,17 @@ IRBuilder >> cacheIndex: tempKey [
 		var ifNotNil: [ var index: (self currentScope tempMap at: tempKey) ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBuilder >> compilationContext [
 	^ir compilationContext
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 IRBuilder >> compilationContext: aCompilationContext [
 	ir compilationContext: aCompilationContext
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 IRBuilder >> createTempVectorNamed: name withVars: anArray [
 
 	self addTemp: name.
@@ -157,12 +159,12 @@ IRBuilder >> createTempVectorNamed: name withVars: anArray [
 			(sourceNode scope lookupVar: varName) index: i]]
 ]
 
-{ #category : #scopes }
+{ #category : 'scopes' }
 IRBuilder >> currentScope [
 	^currentScope top
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 IRBuilder >> initialize [
 	ir := IRMethod new.
 	jumpAheadStacks := IdentityDictionary new.
@@ -181,20 +183,20 @@ IRBuilder >> initialize [
 			yourself)
 ]
 
-{ #category : #results }
+{ #category : 'results' }
 IRBuilder >> ir [
 
 	self optimize.
 	^ ir
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBuilder >> irPrimitive: primNode [
 
 	ir irPrimitive: primNode
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> jumpAheadTarget: labelSymbol [
 	"Pop latest jumpAheadTo: with this labelSymbol and have it point to this new instruction sequence"
 
@@ -205,7 +207,7 @@ IRBuilder >> jumpAheadTarget: labelSymbol [
 	jumpInstr destination: currentSequence
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> jumpAheadTo: labelSymbol [
 	"Jump to the sequence that will be created when jumpAheadTarget: labelSymbol is sent to self.  This is and its corresponding target is only good for one use.  Other jumpAheadTo: with the same label will be put on a stack and superceed existing ones until its jumpAheadTarget: is called."
 
@@ -216,7 +218,7 @@ IRBuilder >> jumpAheadTo: labelSymbol [
 	self startNewSequence
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> jumpAheadTo: labelSymbol if: boolean [
 	"Conditional jump to the sequence that will be created when jumpAheadTarget: labelSymbol is sent to self.  This and its corresponding target is only good for one use.  Other jumpAheadTo:... with the same label will be put on a stack and superceed existing ones until its jumpAheadTarget: is called."
 
@@ -228,7 +230,7 @@ IRBuilder >> jumpAheadTo: labelSymbol if: boolean [
 	instr otherwise: currentSequence
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> jumpBackTarget: labelSymbol [
 	"Remember this basic block for a future jumpBackTo: labelSymbol.  Stack up remembered targets with same name and remove them from stack for each jumpBackTo: called with same name."
 
@@ -237,7 +239,7 @@ IRBuilder >> jumpBackTarget: labelSymbol [
 		addLast: currentSequence
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> jumpBackTo: labelSymbol [
 	"Pop last remembered position with this label and write an unconditional jump to it"
 
@@ -249,27 +251,27 @@ IRBuilder >> jumpBackTo: labelSymbol [
 	jump successor: currentSequence
 ]
 
-{ #category : #mapping }
+{ #category : 'mapping' }
 IRBuilder >> mapToByteIndex: index [
 	"decompiling"
 
 	sourceMapByteIndex := index
 ]
 
-{ #category : #mapping }
+{ #category : 'mapping' }
 IRBuilder >> mapToNode: object [
 	"new instructions will be associated with object"
 
 	sourceMapNodes addLast: object
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 IRBuilder >> numArgs: anInteger [
 	ir numArgs: anInteger.
 	ir sourceNode: self sourceNode
 ]
 
-{ #category : #optimizing }
+{ #category : 'optimizing' }
 IRBuilder >> optimize [
 	"Perform configured optimizations"
 
@@ -278,18 +280,18 @@ IRBuilder >> optimize [
 	ir absorbJumpsToSingleInstrs
 ]
 
-{ #category : #mapping }
+{ #category : 'mapping' }
 IRBuilder >> popMap [
 
 	sourceMapNodes removeLast
 ]
 
-{ #category : #scopes }
+{ #category : 'scopes' }
 IRBuilder >> popScope [
 	currentScope pop
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> popTop [
 
 	currentSequence ifNotEmpty: [
@@ -298,128 +300,128 @@ IRBuilder >> popTop [
 	self add: IRInstruction popTop
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBuilder >> properties: aDict [
 	ir properties: aDict
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> pushConsArray: size [
 
 	self add: (IRInstruction pushConsArray: size)
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> pushDup [
 
 	self add: IRInstruction pushDup
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> pushFullClosureCompiledBlock: compiledBlock copiedValues: copiedValues [
 
 	^ self add: (IRInstruction pushFullClosureCompiledBlock: compiledBlock copiedValues: copiedValues)
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> pushFullClosureCompiledBlock: compiledBlock copiedValues: copiedValues outerContextNeeded: aBoolean [
 
 	^ self add: (IRInstruction pushFullClosureCompiledBlock: compiledBlock copiedValues: copiedValues outerContextNeeded: aBoolean)
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> pushInstVar: index [
 
 	self add: (IRInstruction pushInstVar: index)
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> pushLiteral: object [
 
 	self add: (IRInstruction pushLiteral: object)
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> pushLiteralVariable: object [
 
 	self add: (IRInstruction pushLiteralVariable: object)
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> pushNewArray: size [
 
 	self add: (IRInstruction pushNewArray: size)
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> pushReceiver [
 
 	self add: (IRInstruction pushReceiver)
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> pushRemoteTemp: name inVector: nameOfVector [
 
 	^self add: (IRInstruction pushRemoteTemp: name inVectorAt: nameOfVector)
 ]
 
-{ #category : #scopes }
+{ #category : 'scopes' }
 IRBuilder >> pushScope: anIRBlockOrMethod [
 
 	currentScope push: anIRBlockOrMethod
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> pushTemp: aSelector [
 
 	^ self add: (IRInstruction pushTemp: aSelector)
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> pushThisContext [
 
 	self add: (IRInstruction pushThisContext)
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> pushThisProcess [
 	"This is only supported with EncoderForSistaV1"
 	self add: (IRInstruction pushThisProcess)
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> returnTop [
 
 	self add: IRInstruction returnTop.
 	self startNewSequence
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> send: selector [
 
 	^self add: (IRInstruction send: selector)
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> send: selector toSuperOf: behavior [
 
 	^self add: (IRInstruction send: selector toSuperOf: behavior)
 ]
 
-{ #category : #mapping }
+{ #category : 'mapping' }
 IRBuilder >> sourceByteIndex [
 
 	^ sourceMapByteIndex
 ]
 
-{ #category : #mapping }
+{ #category : 'mapping' }
 IRBuilder >> sourceNode [
 	^ sourceMapNodes
 		ifEmpty: [nil]
 		ifNotEmpty: [sourceMapNodes last]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 IRBuilder >> startNewSequence [
 	"End current instruction sequence and start a new sequence to add instructions to.  If ending block just falls through to new block then add an explicit jump to it so they stay linked"
 
@@ -433,31 +435,31 @@ IRBuilder >> startNewSequence [
 	currentSequence := newSequence
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> storeInstVar: name [
 
 	^self add: (IRInstruction storeInstVar: name)
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> storeIntoLiteralVariable: name [
 
 	^self add: (IRInstruction storeIntoLiteralVariable: name)
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> storeRemoteTemp: name inVector: nameOfVector [
 
 	^self add: (IRInstruction storeRemoteTemp: name inVectorAt: nameOfVector)
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBuilder >> storeTemp: aSymbol [
 
 	^self add: (IRInstruction storeTemp: aSymbol)
 ]
 
-{ #category : #decompiling }
+{ #category : 'decompiling' }
 IRBuilder >> testJumpAheadTarget: label [
 
 	jumpAheadStacks at: label ifPresent: [:stack |

--- a/src/OpalCompiler-Core/IRBytecodeDecompiler.class.st
+++ b/src/OpalCompiler-Core/IRBytecodeDecompiler.class.st
@@ -2,29 +2,31 @@
 I interpret bytecode instructions, sending the appropriate instruction messages to my IRBuilder, resulting in an IRMethod.
 "
 Class {
-	#name : #IRBytecodeDecompiler,
-	#superclass : #InstructionClient,
+	#name : 'IRBytecodeDecompiler',
+	#superclass : 'InstructionClient',
 	#instVars : [
 		'instructionStream',
 		'irBuilder',
 		'newTempVector',
 		'scopeStack'
 	],
-	#category : #'OpalCompiler-Core-Bytecode'
+	#category : 'OpalCompiler-Core-Bytecode',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Bytecode'
 }
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> blockReturnTop [
 	self popScope.
 	irBuilder blockReturnTop
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 IRBytecodeDecompiler >> checkIfJumpTarget [
 	irBuilder testJumpAheadTarget: instructionStream pc
 ]
 
-{ #category : #'public access' }
+{ #category : 'public access' }
 IRBytecodeDecompiler >> decompile: aCompiledMethod [
 	instructionStream := InstructionStream on: aCompiledMethod.
 	irBuilder := IRReconstructor new.
@@ -47,17 +49,17 @@ IRBytecodeDecompiler >> decompile: aCompiledMethod [
 	^ irBuilder ir
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> doDup [
 	irBuilder pushDup
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> doPop [
 	irBuilder popTop
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> interpret [
 	| endPC |
 	endPC := instructionStream method endPC.
@@ -68,7 +70,7 @@ IRBytecodeDecompiler >> interpret [
 			instructionStream interpretNextInstructionFor: self.]
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> jump: dist [
 	| index seq instr newSeq seqs |
 	index := instructionStream pc + dist.
@@ -97,7 +99,7 @@ IRBytecodeDecompiler >> jump: dist [
 	irBuilder jumpBackTo: index
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> jump: dist if: bool [
 	| index |
 	index := instructionStream pc + dist .
@@ -109,24 +111,24 @@ IRBytecodeDecompiler >> jump: dist if: bool [
 	self error: 'Should not do this'
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 IRBytecodeDecompiler >> methodClass [
 	^ instructionStream  method methodClass
 ]
 
-{ #category : #'quick methods' }
+{ #category : 'quick methods' }
 IRBytecodeDecompiler >> methodReturnConstant: value [
 	self pushConstant: value.
 	self methodReturnTop
 ]
 
-{ #category : #'quick methods' }
+{ #category : 'quick methods' }
 IRBytecodeDecompiler >> methodReturnReceiver [
 	self pushReceiver.
 	self methodReturnTop
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> methodReturnTop [
 	irBuilder isLastClosureInstruction
 		ifTrue: [
@@ -137,25 +139,25 @@ IRBytecodeDecompiler >> methodReturnTop [
 		ifFalse: [ irBuilder returnTop ]
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> popIntoLiteralVariable: offset [
 	self storeIntoLiteralVariable: offset.
 	self doPop
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> popIntoReceiverVariable: offset [
 	self storeIntoReceiverVariable: offset.
 	self doPop
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> popIntoRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex [
 	self storeIntoRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex.
 	self doPop
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> popIntoTemporaryVariable: offset [
 	newTempVector
 		ifNil: [
@@ -169,7 +171,7 @@ IRBytecodeDecompiler >> popIntoTemporaryVariable: offset [
 			newTempVector := nil ]
 ]
 
-{ #category : #scope }
+{ #category : 'scope' }
 IRBytecodeDecompiler >> popScope [
 	| scope tempIndex |
 	scope := self scope.
@@ -193,22 +195,22 @@ IRBytecodeDecompiler >> popScope [
 	^ scopeStack pop
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> pushActiveContext [
 	irBuilder pushThisContext
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> pushConsArrayWithElements: numElements [
 	irBuilder pushConsArray: numElements
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> pushConstant: value [
 	irBuilder pushLiteral: value
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> pushFullClosure: compiledBlock numCopied: numCopied receiverOnStack: receiverOnStack ignoreOuterContext: ignoreOuterContext [
 
 	| copiedValues |
@@ -219,27 +221,27 @@ IRBytecodeDecompiler >> pushFullClosure: compiledBlock numCopied: numCopied rece
 		pushFullClosureCompiledBlock: compiledBlock copiedValues: copiedValues
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> pushLiteralVariable: assoc [
 	irBuilder pushLiteralVariable: assoc
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> pushNewArrayOfSize: size [
 	newTempVector := IRRemoteArray new size: size
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> pushReceiver [
 	irBuilder pushReceiver
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> pushReceiverVariable: offset [
 	irBuilder pushInstVar: offset + 1
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> pushRemoteTemp: remoteIndex inVectorAt: tempIndex [
 	|  remoteArray remoteTempName |
 	remoteArray := self scope tempAt: tempIndex.
@@ -247,7 +249,7 @@ IRBytecodeDecompiler >> pushRemoteTemp: remoteIndex inVectorAt: tempIndex [
 	irBuilder pushRemoteTemp: remoteTempName inVector: remoteArray
 ]
 
-{ #category : #scope }
+{ #category : 'scope' }
 IRBytecodeDecompiler >> pushScope: copiedValues numArgs: numArgs [
 	|scope |
 	scope := IRBytecodeScope new numArgs: numArgs.
@@ -255,12 +257,12 @@ IRBytecodeDecompiler >> pushScope: copiedValues numArgs: numArgs [
 	scope copiedValues: copiedValues
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> pushTemporaryVariable: offset [
 	irBuilder pushTemp: (self scope tempAt: offset)
 ]
 
-{ #category : #'quick methods' }
+{ #category : 'quick methods' }
 IRBytecodeDecompiler >> quickMethod [
 
 	instructionStream method primitive = 256 ifTrue: [
@@ -276,29 +278,29 @@ IRBytecodeDecompiler >> quickMethod [
 	self error: 'quick method inconsistency'
 ]
 
-{ #category : #scope }
+{ #category : 'scope' }
 IRBytecodeDecompiler >> scope [
 	^ scopeStack top
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> send: selector super: superFlag numArgs: numArgs [
 	superFlag
 		ifTrue: [irBuilder send: selector toSuperOf: self methodClass]
 		ifFalse: [irBuilder send: selector]
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> storeIntoLiteralVariable: value [
 	irBuilder storeIntoLiteralVariable: value
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> storeIntoReceiverVariable: offset [
 	irBuilder storeInstVar: offset + 1
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> storeIntoRemoteTemp: remoteIndex inVectorAt: tempIndex [
 	|  remoteArray remoteTempName |
 	remoteArray := self scope tempAt: tempIndex.
@@ -306,7 +308,7 @@ IRBytecodeDecompiler >> storeIntoRemoteTemp: remoteIndex inVectorAt: tempIndex [
 	irBuilder storeRemoteTemp: remoteTempName inVector: remoteArray
 ]
 
-{ #category : #'instruction decoding' }
+{ #category : 'instruction decoding' }
 IRBytecodeDecompiler >> storeIntoTemporaryVariable: offset [
 	irBuilder storeTemp: (self scope tempAt: offset)
 ]

--- a/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
+++ b/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
@@ -49,8 +49,8 @@ Instance Variables
 	stacks:		<IdentityDictionary (seqId -> stackCount)> used to find out the maximum depth of the method and therefore set the largeFrameBit
 "
 Class {
-	#name : #IRBytecodeGenerator,
-	#superclass : #Object,
+	#name : 'IRBytecodeGenerator',
+	#superclass : 'Object',
 	#instVars : [
 		'encoder',
 		'seqOrder',
@@ -77,10 +77,12 @@ Class {
 		'inBlock',
 		'compilationContext'
 	],
-	#category : #'OpalCompiler-Core-Bytecode'
+	#category : 'OpalCompiler-Core-Bytecode',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Bytecode'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRBytecodeGenerator class >> newWithEncoderClass: class [
 	^ self basicNew
 		encoderClass: class;
@@ -88,7 +90,7 @@ IRBytecodeGenerator class >> newWithEncoderClass: class [
 		yourself
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 IRBytecodeGenerator >> addLastLiteral: object [
 	lastLiteral ifNil: [ ^ lastLiteral := object ].
 	((lastLiteral literalEqual: object)
@@ -98,18 +100,18 @@ IRBytecodeGenerator >> addLastLiteral: object [
 		ifFalse: [ self error: 'there can only be one last literal' ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 IRBytecodeGenerator >> addLiteral: object [
 	^ literals addLiteral: object
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 IRBytecodeGenerator >> addPragma: aPragma [
 	properties ifNil: [ properties := AdditionalMethodState new ].
 	properties := properties copyWith: aPragma
 ]
 
-{ #category : #results }
+{ #category : 'results' }
 IRBytecodeGenerator >> addProperties: cm [
 	"set the properties of cm according to properties saved"
 
@@ -119,12 +121,12 @@ IRBytecodeGenerator >> addProperties: cm [
 			properties pragmas do: [ :each | each method: cm ] ]
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> blockReturnTop [
 	encoder genReturnTopToCaller
 ]
 
-{ #category : #results }
+{ #category : 'results' }
 IRBytecodeGenerator >> bytecodes [
 	| stream |
 	self updateJumpOffsets.
@@ -144,17 +146,17 @@ IRBytecodeGenerator >> bytecodes [
 	^ stream contents
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBytecodeGenerator >> compilationContext [
 	^ compilationContext ifNil: [compilationContext := CompilationContext default]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBytecodeGenerator >> compilationContext: aCompilationContext [
 	compilationContext := aCompilationContext
 ]
 
-{ #category : #results }
+{ #category : 'results' }
 IRBytecodeGenerator >> compiledBlock [
 	| lits quickPrimitive header cb |
 	lits := self literals allButLast "1 free only for compiledBlock".
@@ -178,7 +180,7 @@ IRBytecodeGenerator >> compiledBlock [
 	^ cb
 ]
 
-{ #category : #results }
+{ #category : 'results' }
 IRBytecodeGenerator >> compiledMethod [
 	| lits quickPrimitive |
 	lits := self literals.
@@ -193,7 +195,7 @@ IRBytecodeGenerator >> compiledMethod [
 	^ self compiledMethodHeader: (self spurVMHeader: lits size) literals: lits
 ]
 
-{ #category : #results }
+{ #category : 'results' }
 IRBytecodeGenerator >> compiledMethodHeader: header literals: lits [
 	| cm cmClass|
 	"we look up the class in the productionEnvironment"
@@ -209,17 +211,17 @@ IRBytecodeGenerator >> compiledMethodHeader: header literals: lits [
 	^ cm
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBytecodeGenerator >> encoderClass [
 	^ encoderClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBytecodeGenerator >> encoderClass: class [
 	encoderClass := class
 ]
 
-{ #category : #results }
+{ #category : 'results' }
 IRBytecodeGenerator >> endPrimNumber [
 	"primitive number including quick return. Only valid at the end of generation"
 	^ primNumber > 0
@@ -227,12 +229,12 @@ IRBytecodeGenerator >> endPrimNumber [
 			ifFalse: [ self quickMethodPrim ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBytecodeGenerator >> forceLongForm: aBoolean [
 	forceLongForm := aBoolean
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 IRBytecodeGenerator >> from: fromSeqId goto: toSeqId [
 
 	| distance from to |
@@ -252,7 +254,7 @@ IRBytecodeGenerator >> from: fromSeqId goto: toSeqId [
 	]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 IRBytecodeGenerator >> from: fromSeqId if: bool goto: toSeqId otherwise: otherwiseSeqId [
 
 	| distance from to otherwise |
@@ -267,7 +269,7 @@ IRBytecodeGenerator >> from: fromSeqId if: bool goto: toSeqId otherwise: otherwi
 	self jump: distance if: bool
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> goto: seqId [
 	stacks at: seqId put: (stack linkTo: (stacks at: seqId ifAbsentPut: [ nil ])).
 	self
@@ -280,14 +282,14 @@ IRBytecodeGenerator >> goto: seqId [
 	self from: currentSeqId goto: seqId
 ]
 
-{ #category : #results }
+{ #category : 'results' }
 IRBytecodeGenerator >> hasPrimitive [
 	"do I have a primitive? Both normal primitive and quick return"
 	primNumber > 0 ifTrue: [ ^true ].
 	^ self endPrimNumber > 0
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> if: bool goto: seqId [
 	| otherwiseSeqId |
 	otherwiseSeqId := self newDummySeqId.
@@ -295,7 +297,7 @@ IRBytecodeGenerator >> if: bool goto: seqId [
 	self label: otherwiseSeqId
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> if: bool goto: seqId1 otherwise: seqId2 [
 	stack pop.
 	stacks at: seqId1 put: (stack linkTo: (stacks at: seqId1 ifAbsentPut: [ nil ])).
@@ -316,12 +318,12 @@ IRBytecodeGenerator >> if: bool goto: seqId1 otherwise: seqId2 [
 		otherwise: seqId2
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBytecodeGenerator >> inBlock: bool [
 	inBlock := bool
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 IRBytecodeGenerator >> initialize [
 
 	super initialize.
@@ -347,7 +349,7 @@ IRBytecodeGenerator >> initialize [
 	self label: self newDummySeqId
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 IRBytecodeGenerator >> irPrimitive: anIrPrimitive [
 	literals isEmpty ifFalse: [self error: 'init prim before adding instructions'].
 	anIrPrimitive spec ifNotNil: [literals addLiteral: anIrPrimitive spec].
@@ -357,7 +359,7 @@ IRBytecodeGenerator >> irPrimitive: anIrPrimitive [
 	encoder genCallPrimitive: primNumber
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> jump: distance if: condition [
 	distance = 0
 		ifTrue: [ ^ encoder genPop ].
@@ -366,26 +368,26 @@ IRBytecodeGenerator >> jump: distance if: condition [
 		ifFalse: [ encoder genBranchPopFalse: distance ]
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> jump: distance if: condition withInterpreter: anInterpreter [
 
 	^ self jump: distance if: condition
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> jumpBackward: distance [
 
 	encoder genJumpLong: distance negated - self encoderClass backJumpBytecodeSize
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> jumpForward: distance [
 
 	distance = 0 ifTrue: [^ self].
 	encoder genJump: distance
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> label: seqId [
 	lastSpecialReturn := nil.
 	currentSeqId := seqId.
@@ -400,7 +402,7 @@ IRBytecodeGenerator >> label: seqId [
 		ifNotNil: [stack := stacks at: currentSeqId ifAbsentPut: [ stack class newOn:stack ] ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 IRBytecodeGenerator >> literalIndexOf: object [
 
 	| index |
@@ -411,7 +413,7 @@ IRBytecodeGenerator >> literalIndexOf: object [
 	^ index - 1
 ]
 
-{ #category : #results }
+{ #category : 'results' }
 IRBytecodeGenerator >> literals [
 	literals := literals asArray.
 	(literals anySatisfy: [ :each | each isMethodProperties ])
@@ -419,7 +421,7 @@ IRBytecodeGenerator >> literals [
 	^ lastLiteral ifNil: [ literals copyWith: nil ] ifNotNil: [ literals copyWith: lastLiteral ]
 ]
 
-{ #category : #mapping }
+{ #category : 'mapping' }
 IRBytecodeGenerator >> mapBytesTo: instr [
 	"Record the current byte offset in instruction sequence as start of instr.
 	This is later used to calculate the total byte offset of instruction in generated code,
@@ -427,81 +429,81 @@ IRBytecodeGenerator >> mapBytesTo: instr [
 	instrMap add: instr -> (bytes size + 1)
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 IRBytecodeGenerator >> newDummySeqId [
 
 	^ Object new
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 IRBytecodeGenerator >> nextPut: byte [
 	bytes add: byte
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBytecodeGenerator >> numArgs [
 
 	^ numArgs
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBytecodeGenerator >> numArgs: n [
 
 	numArgs := n
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBytecodeGenerator >> numTemps [
 
 	^ numberOfTemps
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBytecodeGenerator >> numTemps: anInteger [
 
 	numberOfTemps := anInteger
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> popTop [
 	stack pop.
 	encoder genPop
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 IRBytecodeGenerator >> pragmas: aCollection [
 	aCollection do: [:each | self addPragma: each]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBytecodeGenerator >> primNum [
 	^ primNumber
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBytecodeGenerator >> properties [
 	^ properties
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBytecodeGenerator >> properties: propDict [
 	properties := propDict
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> pushConsArray: size [
 	stack push.
 	stack pop: size.
 	encoder genPushConsArray: size
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> pushDup [
 	stack push.
 	encoder genDup
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> pushFullBlockClosure: fullBlock [
 	| numCopied |
 	numCopied := fullBlock copiedValues size.
@@ -514,7 +516,7 @@ IRBytecodeGenerator >> pushFullBlockClosure: fullBlock [
 		outerContextNeeded: fullBlock outerContextNeeded
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> pushInstVar: instVarIndex [
 	stack push.
 	forceLongForm
@@ -522,7 +524,7 @@ IRBytecodeGenerator >> pushInstVar: instVarIndex [
 		ifFalse: [ encoder genPushInstVar: instVarIndex - 1 ]
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> pushLiteral: object [
 	stack push.
 	"identity includes else 0.0 = 0 whereas it's a Float"
@@ -531,51 +533,51 @@ IRBytecodeGenerator >> pushLiteral: object [
 	encoder genPushLiteral: (self literalIndexOf: object)
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> pushLiteralVariable: object [
 	stack push.
 	encoder genPushLiteralVar: (self literalIndexOf: object)
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> pushNewArray: size [
 	stack push.
 	encoder genPushNewArray: size
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> pushReceiver [
 	stack push.
 	encoder genPushReceiver
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> pushRemoteTemp: tempIndex inVectorAt: tempVectorIndex [
 	stack push.
 	encoder genPushRemoteTemp: tempIndex - 1 inVectorAt: tempVectorIndex - 1
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> pushTemp: index [
 	stack push.
 	encoder genPushTemp: index - 1
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> pushThisContext [
 
 	stack push.
 	encoder genPushThisContext
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> pushThisProcess [
 
 	stack push.
 	encoder genPushThisProcess
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 IRBytecodeGenerator >> quickMethodPrim [
 
 	| index |
@@ -597,7 +599,7 @@ IRBytecodeGenerator >> quickMethodPrim [
 					ifFalse: [263 + lastSpecialReturn argument]]
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> returnConstant: constant [
 	bytes ifEmpty: [ lastSpecialReturn := Message selector: #returnConstant: argument: constant ].
 	(#(nil true false) includes: constant) ifTrue:
@@ -606,7 +608,7 @@ IRBytecodeGenerator >> returnConstant: constant [
 	self returnTop
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> returnInstVar: index [
 	bytes ifEmpty: [
 		lastSpecialReturn := Message selector: #returnInstVar: argument: index].
@@ -614,24 +616,24 @@ IRBytecodeGenerator >> returnInstVar: index [
 	self returnTop
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> returnReceiver [
 	bytes ifEmpty: [ lastSpecialReturn := Message selector: #returnReceiver].
 	encoder genReturnReceiver
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> returnTop [
 	stack pop.
 	encoder genReturnTop
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 IRBytecodeGenerator >> saveLastJump: message [
 	jumps at: currentSeqId put: {bytes size. message}
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> send: selector [
 
 	| nArgs |
@@ -646,7 +648,7 @@ IRBytecodeGenerator >> send: selector [
 	encoder genSend: (self literalIndexOf: selector) numArgs: nArgs
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> send: selector toSuperOf: behavior [
 	| index nArgs |
 	nArgs := selector numArgs.
@@ -663,7 +665,7 @@ IRBytecodeGenerator >> send: selector toSuperOf: behavior [
 			encoder genSendSuper: index numArgs: nArgs ]
 ]
 
-{ #category : #results }
+{ #category : 'results' }
 IRBytecodeGenerator >> spurVMHeader: literalsSize [
 	^ (CompiledMethod headerFlagForEncoder: self encoderClass) +
 		(self numArgs bitShift: 24) +
@@ -672,24 +674,24 @@ IRBytecodeGenerator >> spurVMHeader: literalsSize [
 		(self hasPrimitive asBit bitShift: 16)
 ]
 
-{ #category : #results }
+{ #category : 'results' }
 IRBytecodeGenerator >> stackFrameSize [
 	^ (stacks collect: [:s | s length]) max
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> storeInstVar: index [
 	forceLongForm
 		ifTrue: [ encoder genStoreInstVarLong: index - 1 ]
 		ifFalse: [ encoder genStoreInstVar: index - 1 ]
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> storeIntoLiteralVariable: object [
 	encoder genStoreLiteralVar: (self literalIndexOf: object)
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> storePopInstVar: index [
 	stack pop.
 	forceLongForm
@@ -697,36 +699,36 @@ IRBytecodeGenerator >> storePopInstVar: index [
 		ifFalse: [ encoder genStorePopInstVar: index - 1 ]
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> storePopIntoLiteralVariable: assoc [
 
 	encoder genStorePopLiteralVar: (self literalIndexOf: assoc).
 	stack pop
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> storePopRemoteTemp: tempIndex inVectorAt: tempVectorIndex [
 	stack pop.
 	encoder genStorePopRemoteTemp: tempIndex - 1 inVectorAt: tempVectorIndex - 1
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> storePopTemp: index [
 	stack pop.
 	encoder genStorePopTemp: index - 1
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> storeRemoteTemp: tempIndex inVectorAt: tempVectorIndex [
 	encoder genStoreRemoteTemp: tempIndex - 1 inVectorAt: tempVectorIndex - 1
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRBytecodeGenerator >> storeTemp: index [
 	encoder genStoreTemp: index - 1
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 IRBytecodeGenerator >> updateJump: seqId [
 	"Recalculate final jump bytecodes.  Return true if jump bytecodes SIZE has changed, otherwise return false"
 	| pair s1 |
@@ -739,7 +741,7 @@ IRBytecodeGenerator >> updateJump: seqId [
 	^ s1 ~= bytes size
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 IRBytecodeGenerator >> updateJumpOffsets [
 	[ orderSeq
 		inject: false
@@ -747,7 +749,7 @@ IRBytecodeGenerator >> updateJumpOffsets [
 	] whileTrue
 ]
 
-{ #category : #results }
+{ #category : 'results' }
 IRBytecodeGenerator >> updateOuterCodeBlocks: code [
 	"Add back pointer from compiled block to outer code for all blocks referenced from the literals"
 

--- a/src/OpalCompiler-Core/IRBytecodeScope.class.st
+++ b/src/OpalCompiler-Core/IRBytecodeScope.class.st
@@ -2,18 +2,20 @@
 I am an internal class used by the  decompiler to recreat variable information
 "
 Class {
-	#name : #IRBytecodeScope,
-	#superclass : #Object,
+	#name : 'IRBytecodeScope',
+	#superclass : 'Object',
 	#instVars : [
 		'temps',
 		'numArgs',
 		'ownTempVectors',
 		'copiedValues'
 	],
-	#category : #'OpalCompiler-Core-Bytecode'
+	#category : 'OpalCompiler-Core-Bytecode',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Bytecode'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBytecodeScope >> args [
 	| args |
 	args := Array new: numArgs.
@@ -21,56 +23,56 @@ IRBytecodeScope >> args [
 	^ args
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBytecodeScope >> copiedValues [
 	^ copiedValues
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBytecodeScope >> copiedValues: someCopiedValues [
 	copiedValues := someCopiedValues
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 IRBytecodeScope >> initialize [
 	temps := 0.
 	ownTempVectors := OrderedCollection new
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBytecodeScope >> newTempVector: aTempVector at: offset [
 	ownTempVectors add: aTempVector.
 	self tempAt: offset
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBytecodeScope >> numArgs [
 	^ numArgs
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBytecodeScope >> numArgs: anInteger [
 	numArgs := anInteger.
 	temps := temps max: numArgs
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBytecodeScope >> ownTempVectors [
 	^ ownTempVectors
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBytecodeScope >> tempAt: zeroBasedIndex [
 	temps := temps max: zeroBasedIndex + 1.
 	^ self -> zeroBasedIndex
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBytecodeScope >> tempAt: remoteIndex inRemote: remoteArray [
 	^ remoteIndex
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRBytecodeScope >> temps [
 	| result tempOffset numTemps |
 	tempOffset := copiedValues size + numArgs.

--- a/src/OpalCompiler-Core/IRFix.class.st
+++ b/src/OpalCompiler-Core/IRFix.class.st
@@ -7,17 +7,19 @@ store, pop => popInto
 some returns => quick returns
 "
 Class {
-	#name : #IRFix,
-	#superclass : #IRVisitor,
+	#name : 'IRFix',
+	#superclass : 'IRVisitor',
 	#instVars : [
 		'prevInstr',
 		'storePopToFix',
 		'retToFix'
 	],
-	#category : #'OpalCompiler-Core-IR-Manipulation'
+	#category : 'OpalCompiler-Core-IR-Manipulation',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Manipulation'
 }
 
-{ #category : #private }
+{ #category : 'private' }
 IRFix >> convertRet: assoc forSeq: seq [
 	| push ret |
 	push := assoc key.
@@ -26,7 +28,7 @@ IRFix >> convertRet: assoc forSeq: seq [
 	seq remove: ret
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 IRFix >> convertStorePop: assoc forSeq: seq [
 	| store pop |
 	store := assoc key.
@@ -35,7 +37,7 @@ IRFix >> convertStorePop: assoc forSeq: seq [
 	seq remove: pop
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 IRFix >> initialize [
 
 	super initialize.
@@ -44,13 +46,13 @@ IRFix >> initialize [
 	retToFix := OrderedCollection new
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRFix >> visitInstruction: instr [
 	self visitNode: instr.
 	prevInstr := instr
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRFix >> visitPop: pop [
 	prevInstr ifNil: [ ^ self ].
 	prevInstr isStore ifFalse: [ ^ self ].
@@ -58,14 +60,14 @@ IRFix >> visitPop: pop [
 	storePopToFix add: prevInstr -> pop
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRFix >> visitReturn: ret [
 	prevInstr ifNil: [ ^ self ].
 	prevInstr canBeQuickReturn ifFalse: [ ^ self ].
 	retToFix add: prevInstr -> ret
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRFix >> visitSequence: instructionSequence [
 	prevInstr := nil.
 	storePopToFix reset.

--- a/src/OpalCompiler-Core/IRInstVarAccess.class.st
+++ b/src/OpalCompiler-Core/IRInstVarAccess.class.st
@@ -2,25 +2,27 @@
 I am a bytecode accessing an instance variable. As such, I have an index.
 "
 Class {
-	#name : #IRInstVarAccess,
-	#superclass : #IRAccess,
+	#name : 'IRInstVarAccess',
+	#superclass : 'IRAccess',
 	#instVars : [
 		'index'
 	],
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRInstVarAccess >> index [
 	^ index
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRInstVarAccess >> index: anInteger [
 	index := anInteger
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRInstVarAccess >> isInstVarAccess [
 	^ true
 ]

--- a/src/OpalCompiler-Core/IRInstruction.class.st
+++ b/src/OpalCompiler-Core/IRInstruction.class.st
@@ -18,22 +18,24 @@ Each instruction is reified as an instance of one of my subclasses and grouped b
 
 "
 Class {
-	#name : #IRInstruction,
-	#superclass : #Object,
+	#name : 'IRInstruction',
+	#superclass : 'Object',
 	#instVars : [
 		'sourceNode',
 		'bytecodeIndex',
 		'sequence'
 	],
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRInstruction class >> blockReturnTop [
 	^ IRBlockReturnTop new
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRInstruction class >> createTempVectorNamed: aTempVectorName withVars: anArray [
 
 	^ IRTempVector new
@@ -42,12 +44,12 @@ IRInstruction class >> createTempVectorNamed: aTempVectorName withVars: anArray 
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRInstruction class >> popTop [
 	^ IRPop new
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRInstruction class >> pushConsArray: aSize [
 	^IRPushArray new
 		size: aSize;
@@ -55,13 +57,13 @@ IRInstruction class >> pushConsArray: aSize [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRInstruction class >> pushDup [
 
 	^ IRPushDup new
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRInstruction class >> pushFullClosureCompiledBlock: compiledBlock copiedValues: copiedValues [
 	^IRPushFullClosure new
 			copiedValues: copiedValues;
@@ -69,7 +71,7 @@ IRInstruction class >> pushFullClosureCompiledBlock: compiledBlock copiedValues:
 			yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRInstruction class >> pushFullClosureCompiledBlock: compiledBlock copiedValues: copiedValues outerContextNeeded: aBoolean [
 	^IRPushFullClosure new
 			copiedValues: copiedValues;
@@ -78,7 +80,7 @@ IRInstruction class >> pushFullClosureCompiledBlock: compiledBlock copiedValues:
 			yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRInstruction class >> pushInstVar: index [
 
 	^ IRPushInstVar new
@@ -86,14 +88,14 @@ IRInstruction class >> pushInstVar: index [
 			yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRInstruction class >> pushLiteral: object [
 
 	^ IRPushLiteral new
 		literal: object
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRInstruction class >> pushLiteralVariable: object [
 
 	^ IRPushLiteralVariable new
@@ -101,7 +103,7 @@ IRInstruction class >> pushLiteralVariable: object [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRInstruction class >> pushNewArray: aSize [
 
 	^IRPushArray new
@@ -110,12 +112,12 @@ IRInstruction class >> pushNewArray: aSize [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRInstruction class >> pushReceiver [
 	^ IRPushReceiver new
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRInstruction class >> pushRemoteTemp: aName inVectorAt: nameOfVector [
 	^ IRPushRemoteTemp new
 		name: aName;
@@ -123,7 +125,7 @@ IRInstruction class >> pushRemoteTemp: aName inVectorAt: nameOfVector [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRInstruction class >> pushTemp: aName [
 
 	^ IRPushTemp new
@@ -131,30 +133,30 @@ IRInstruction class >> pushTemp: aName [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRInstruction class >> pushThisContext [
 	^ IRPushThisContext new
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRInstruction class >> pushThisProcess [
 	^ IRPushThisProcess new
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRInstruction class >> returnTop [
 
 	^ IRReturn new
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRInstruction class >> send: selector [
 
 	^ IRSend new
 		selector: selector
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRInstruction class >> send: selector toSuperOf: behavior [
 
 	behavior ifNil: [self error: 'super of nil does not exist'].
@@ -164,14 +166,14 @@ IRInstruction class >> send: selector toSuperOf: behavior [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRInstruction class >> storeInstVar: index [
 	^ IRStoreInstVar new
 		index: index;
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRInstruction class >> storeIntoLiteralVariable: object [
 
 	^ IRStoreLiteralVariable new
@@ -179,7 +181,7 @@ IRInstruction class >> storeIntoLiteralVariable: object [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRInstruction class >> storeRemoteTemp: aName inVectorAt: nameOfVector [
 	^ IRStoreRemoteTemp new
 		name: aName;
@@ -187,41 +189,41 @@ IRInstruction class >> storeRemoteTemp: aName inVectorAt: nameOfVector [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRInstruction class >> storeTemp: aName [
 	^ IRStoreTemp new
 		name: aName;
 		yourself
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRInstruction >> accept: aVisitor [
 	self subclassResponsibility
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 IRInstruction >> addInstructionsAfter: aCollection [
 	sequence addInstructions: aCollection after: self
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 IRInstruction >> addInstructionsBefore: aCollection [
 	sequence addInstructions: aCollection before: self
 ]
 
-{ #category : #mapping }
+{ #category : 'mapping' }
 IRInstruction >> bytecodeIndex [
 
 	^ bytecodeIndex
 ]
 
-{ #category : #mapping }
+{ #category : 'mapping' }
 IRInstruction >> bytecodeIndex: index [
 
 	bytecodeIndex := index
 ]
 
-{ #category : #mapping }
+{ #category : 'mapping' }
 IRInstruction >> bytecodeOffset [
 	| startpc |
 	startpc := self method compiledMethod initialPC.
@@ -229,188 +231,188 @@ IRInstruction >> bytecodeOffset [
 	^self bytecodeIndex + startpc - 1
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRInstruction >> canBeQuickReturn [
 	^ false
 ]
 
-{ #category : #inspector }
+{ #category : 'inspector' }
 IRInstruction >> children [
 	^#()
 ]
 
-{ #category : #replacing }
+{ #category : 'replacing' }
 IRInstruction >> delete [
 	sequence ifNil: [self error: 'This node doesn''t have a sequence'].
 	sequence remove: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRInstruction >> isBlockReturnTop [
 
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRInstruction >> isGoto [
 	"is unconditional jump"
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRInstruction >> isIf [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRInstruction >> isInstVarAccess [
 
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRInstruction >> isJump [
 	"goto or if"
 
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRInstruction >> isLiteralVariable [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRInstruction >> isPop [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRInstruction >> isPushLiteral [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRInstruction >> isPushLiteral: valueTest [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRInstruction >> isRead [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRInstruction >> isRemovableByPop [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRInstruction >> isReturn [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRInstruction >> isSelf [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRInstruction >> isSend [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRInstruction >> isStore [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRInstruction >> isTemp [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRInstruction >> isTempVector [
 	^false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRInstruction >> method [
 	^sequence method
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRInstruction >> nonBodySuccessorSequences [
 	^self successorSequences
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 IRInstruction >> printOn: aStream [
 	IRPrinter new
 			stream: aStream;
 			visitNode: self
 ]
 
-{ #category : #replacing }
+{ #category : 'replacing' }
 IRInstruction >> replaceNode: aNode withNode: anotherNode [
 	self error: 'I don''t store other nodes'
 ]
 
-{ #category : #replacing }
+{ #category : 'replacing' }
 IRInstruction >> replaceWith: aNode [
 	sequence ifNil: [self error: 'This node doesn''t have a sequence'].
 	sequence replaceNode: self withNode: aNode
 ]
 
-{ #category : #replacing }
+{ #category : 'replacing' }
 IRInstruction >> replaceWithInstructions: aCollection [
 
 	sequence ifNil: [self error: 'This node doesn''t have a sequence'].
 	sequence replaceNode: self withNodes: aCollection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRInstruction >> sequence [
 	^sequence
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRInstruction >> sequence: aSeq [
 	sequence := aSeq
 ]
 
-{ #category : #inspector }
+{ #category : 'inspector' }
 IRInstruction >> sourceInterval [
 	^self sourceNode sourceInterval
 ]
 
-{ #category : #mapping }
+{ #category : 'mapping' }
 IRInstruction >> sourceNode [
 
 	^ sourceNode
 ]
 
-{ #category : #mapping }
+{ #category : 'mapping' }
 IRInstruction >> sourceNode: parseNode [
 
 	sourceNode := parseNode
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRInstruction >> successorSequences [
 	"sent to last instruction in sequence which is expected to be a jump and return instruction"
 
 	^ #()
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRInstruction >> transitionsToNextSequence [
 	"Does the current instruction intrinsically know how to transition to the next sequence?"
 	^ self isJump or: [self isReturn]

--- a/src/OpalCompiler-Core/IRJump.class.st
+++ b/src/OpalCompiler-Core/IRJump.class.st
@@ -2,61 +2,63 @@
 Instruction ""goto: labelNum""
 "
 Class {
-	#name : #IRJump,
-	#superclass : #IRInstruction,
+	#name : 'IRJump',
+	#superclass : 'IRInstruction',
 	#instVars : [
 		'destination',
 		'successor'
 	],
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRJump >> accept: aVisitor [
 	^ aVisitor visitJump: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRJump >> destination [
 
 	^ destination
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRJump >> destination: aSequence [
 	destination := aSequence
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRJump >> isGoto [
 	"is unconditional jump"
 
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRJump >> isJump [
 	"goto or if"
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRJump >> nextBytecodeOffsetAfterJump [
 	^ destination last destination first bytecodeOffset
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRJump >> successor [
 	^successor
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRJump >> successor: succ [
 	successor := succ
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRJump >> successorSequences [
 
 	^ {destination. successor}

--- a/src/OpalCompiler-Core/IRJumpIf.class.st
+++ b/src/OpalCompiler-Core/IRJumpIf.class.st
@@ -2,46 +2,48 @@
 Instruction ""if: boolean goto: labelNum1 otherwise: labelNum2""
 "
 Class {
-	#name : #IRJumpIf,
-	#superclass : #IRJump,
+	#name : 'IRJumpIf',
+	#superclass : 'IRJump',
 	#instVars : [
 		'boolean',
 		'otherwise'
 	],
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRJumpIf >> accept: aVisitor [
 	^ aVisitor visitJumpIf: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRJumpIf >> boolean [
 
 	^ boolean
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRJumpIf >> boolean: bool [
 
 	boolean := bool
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRJumpIf >> isGoto [
 	"is unconditional jump"
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRJumpIf >> isIf [
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRJumpIf >> nextBytecodeOffsetAfterJump [
 	"check if we are in ifTrue:ifFalse: / ifFalse:ifTrue: or in ifTrue: / ifFalse: and answers the next byte code offset"
 	^destination last isJump
@@ -50,25 +52,25 @@ IRJumpIf >> nextBytecodeOffsetAfterJump [
 			(destination sequence at: ((destination size - 1) max: 1)) bytecodeOffset ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRJumpIf >> nonBodySuccessorSequences [
 
 	^ {destination}
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRJumpIf >> otherwise [
 
 	^ otherwise
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRJumpIf >> otherwise: aSequence [
 
 	otherwise := aSequence
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRJumpIf >> successorSequences [
 
 	^ {destination. otherwise}

--- a/src/OpalCompiler-Core/IRLiteralVariableAccess.class.st
+++ b/src/OpalCompiler-Core/IRLiteralVariableAccess.class.st
@@ -6,30 +6,32 @@ LiteralVariables are
 -> Class Var access
 "
 Class {
-	#name : #IRLiteralVariableAccess,
-	#superclass : #IRAccess,
+	#name : 'IRLiteralVariableAccess',
+	#superclass : 'IRAccess',
 	#instVars : [
 		'association'
 	],
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRLiteralVariableAccess >> association [
 	^association
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRLiteralVariableAccess >> association: anAssociation [
 	association := anAssociation
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRLiteralVariableAccess >> isLiteralVariable [
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRLiteralVariableAccess >> name [
 	^association key
 ]

--- a/src/OpalCompiler-Core/IRMethod.class.st
+++ b/src/OpalCompiler-Core/IRMethod.class.st
@@ -3,8 +3,8 @@ I am a method in the IR (intermediate representation) language consisting of IRI
 
 "
 Class {
-	#name : #IRMethod,
-	#superclass : #Object,
+	#name : 'IRMethod',
+	#superclass : 'Object',
 	#instVars : [
 		'sourceNode',
 		'startSequence',
@@ -17,31 +17,33 @@ Class {
 		'compilationContext',
 		'irPrimitive'
 	],
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #optimizing }
+{ #category : 'optimizing' }
 IRMethod >> absorbJumpsToSingleInstrs [
 
 	startSequence absorbJumpToSingleInstr: IdentitySet new
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRMethod >> accept: aVisitor [
 	^ aVisitor visitMethod: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRMethod >> addAdditionalLiteral: aLiteral [
 	additionalLiterals add: aLiteral
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRMethod >> addAdditionalLiterals: literals [
 	additionalLiterals :=  literals
 ]
 
-{ #category : #inlining }
+{ #category : 'inlining' }
 IRMethod >> addInstructionsAfter: aCollection [
 	| returningSeqs  lastInstr |
 	aCollection ifEmpty: [^self].
@@ -50,24 +52,24 @@ IRMethod >> addInstructionsAfter: aCollection [
 	lastInstr addInstructionsBefore: aCollection
 ]
 
-{ #category : #inlining }
+{ #category : 'inlining' }
 IRMethod >> addInstructionsBefore: aCollection [
 
 	(self startSequence nextSequence first) addInstructionsBefore: aCollection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRMethod >> addPragma: aPragma [
 
 	pragmas add: aPragma
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRMethod >> additionalLiterals [
 	^additionalLiterals
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 IRMethod >> allInstructions [
 	" return irNodes as a flat collection "
 
@@ -77,7 +79,7 @@ IRMethod >> allInstructions [
 	^irInstructions
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 IRMethod >> allInstructionsMatching: aBlock [
 	" return irNodes as a flat collection "
 
@@ -87,34 +89,34 @@ IRMethod >> allInstructionsMatching: aBlock [
 	^irInstructions
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 IRMethod >> allSequences [
 	^ startSequence withAllSuccessors
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 IRMethod >> allTempAccessInstructions [
 	^self allInstructionsMatching: [:bc | bc isTemp]
 ]
 
-{ #category : #inspector }
+{ #category : 'inspector' }
 IRMethod >> children [
 	^self startSequence withAllSuccessors
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRMethod >> compilationContext [
 	^ compilationContext ifNil: [
 		"only happens when decompiling or using stand-alone"
 		compilationContext := CompilationContext default]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRMethod >> compilationContext: aCompilationContext [
 	compilationContext := aCompilationContext
 ]
 
-{ #category : #translating }
+{ #category : 'translating' }
 IRMethod >> compiledBlock: scope [
 
 	^compiledMethod
@@ -122,7 +124,7 @@ IRMethod >> compiledBlock: scope [
 		ifNotNil: [compiledMethod]
 ]
 
-{ #category : #translating }
+{ #category : 'translating' }
 IRMethod >> compiledMethod [
 
 	^ compiledMethod 
@@ -130,7 +132,7 @@ IRMethod >> compiledMethod [
 
 ]
 
-{ #category : #translating }
+{ #category : 'translating' }
 IRMethod >> compiledMethodWith: trailer [
 	self
 		deprecated: 'Use compiledMethod'
@@ -139,7 +141,7 @@ IRMethod >> compiledMethodWith: trailer [
 	^ self compiledMethod
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 IRMethod >> firstInstructionMatching: aBlock [
 	" return irNodes as a flat collection "
 
@@ -147,7 +149,7 @@ IRMethod >> firstInstructionMatching: aBlock [
 	^nil
 ]
 
-{ #category : #translating }
+{ #category : 'translating' }
 IRMethod >> generate [
 
 	| irTranslator |
@@ -166,7 +168,7 @@ IRMethod >> generate [
 	^ compiledMethod
 ]
 
-{ #category : #translating }
+{ #category : 'translating' }
 IRMethod >> generate: trailer [
 	self
 		deprecated: 'Use generate'
@@ -175,7 +177,7 @@ IRMethod >> generate: trailer [
 	^ self generate 
 ]
 
-{ #category : #translating }
+{ #category : 'translating' }
 IRMethod >> generateBlockWithScope: scope [
 	| irTranslator |
       irTranslator := IRTranslator context: self compilationContext.
@@ -187,13 +189,13 @@ IRMethod >> generateBlockWithScope: scope [
 	^ compiledMethod
 ]
 
-{ #category : #scoping }
+{ #category : 'scoping' }
 IRMethod >> indexForVarNamed: aName [
 
 	^tempMap at: aName
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 IRMethod >> initialize [
 
 	irPrimitive := IRPrimitive null.
@@ -203,7 +205,7 @@ IRMethod >> initialize [
 	numArgs := 0
 ]
 
-{ #category : #decompiling }
+{ #category : 'decompiling' }
 IRMethod >> instructionsForDecompiling [
 	"return all instructions, but skip the block bodies, as the decompiler
 	recurses over blocks"
@@ -211,29 +213,29 @@ IRMethod >> instructionsForDecompiling [
 	^startSequence instructionsForDecompiling allButFirst
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRMethod >> ir [
 	^self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRMethod >> irPrimitive [
 
 	^ irPrimitive
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRMethod >> irPrimitive: aPrimitiveNode [
 
 	irPrimitive := aPrimitiveNode
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRMethod >> isSend [
 	^false
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 IRMethod >> longPrintOn: stream [
 
 	IRPrinter new
@@ -241,24 +243,24 @@ IRMethod >> longPrintOn: stream [
 		visitNode: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRMethod >> method [
 	^self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRMethod >> numArgs [
 
 	^ numArgs
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRMethod >> numArgs: anInteger [
 
 	numArgs := anInteger
 ]
 
-{ #category : #optimizing }
+{ #category : 'optimizing' }
 IRMethod >> optimize [
 	"Perform all optimizations"
 
@@ -266,7 +268,7 @@ IRMethod >> optimize [
 	self absorbJumpsToSingleInstrs
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRMethod >> predecessorsOf: aSequence [
 	| predecessors |
 	predecessors := OrderedCollection new.
@@ -274,17 +276,17 @@ IRMethod >> predecessorsOf: aSequence [
 	^predecessors
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRMethod >> properties [
 	^properties
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRMethod >> properties: propDict [
 	properties := propDict
 ]
 
-{ #category : #optimizing }
+{ #category : 'optimizing' }
 IRMethod >> removeEmptyStart [
 
 	 (startSequence size = 1) ifTrue: [
@@ -292,41 +294,41 @@ IRMethod >> removeEmptyStart [
         startSequence := startSequence last destination]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRMethod >> sourceInterval [
 	^self sourceNode sourceInterval
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRMethod >> sourceNode [
 	^sourceNode
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRMethod >> sourceNode: aNode [
 	sourceNode := aNode
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRMethod >> startSequence [
 
 	^ startSequence
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 IRMethod >> startSequence: irSequence [
 
 	startSequence := irSequence.
 	irSequence method: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRMethod >> tempKeys [
 
 	^ tempMap keys
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRMethod >> tempMap [
 	^ tempMap
 ]

--- a/src/OpalCompiler-Core/IRPop.class.st
+++ b/src/OpalCompiler-Core/IRPop.class.st
@@ -2,17 +2,19 @@
 Instruction ""popTop""
 "
 Class {
-	#name : #IRPop,
-	#superclass : #IRInstruction,
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#name : 'IRPop',
+	#superclass : 'IRInstruction',
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPop >> accept: aVisitor [
 	^ aVisitor visitPop: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRPop >> isPop [
 	^true
 ]

--- a/src/OpalCompiler-Core/IRPopIntoInstVar.class.st
+++ b/src/OpalCompiler-Core/IRPopIntoInstVar.class.st
@@ -2,12 +2,14 @@
 Pop into instance variable.
 "
 Class {
-	#name : #IRPopIntoInstVar,
-	#superclass : #IRInstVarAccess,
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#name : 'IRPopIntoInstVar',
+	#superclass : 'IRInstVarAccess',
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPopIntoInstVar >> accept: aVisitor [
 	^ aVisitor visitPopIntoInstVar: self
 ]

--- a/src/OpalCompiler-Core/IRPopIntoLiteralVariable.class.st
+++ b/src/OpalCompiler-Core/IRPopIntoLiteralVariable.class.st
@@ -2,12 +2,14 @@
 pop into literal variable
 "
 Class {
-	#name : #IRPopIntoLiteralVariable,
-	#superclass : #IRLiteralVariableAccess,
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#name : 'IRPopIntoLiteralVariable',
+	#superclass : 'IRLiteralVariableAccess',
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPopIntoLiteralVariable >> accept: aVisitor [
 	^ aVisitor visitPopIntoLiteralVariable: self
 ]

--- a/src/OpalCompiler-Core/IRPopIntoRemoteTemp.class.st
+++ b/src/OpalCompiler-Core/IRPopIntoRemoteTemp.class.st
@@ -2,12 +2,14 @@
 pop into remote temp
 "
 Class {
-	#name : #IRPopIntoRemoteTemp,
-	#superclass : #IRRemoteTempAccess,
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#name : 'IRPopIntoRemoteTemp',
+	#superclass : 'IRRemoteTempAccess',
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPopIntoRemoteTemp >> accept: aVisitor [
 	^ aVisitor visitPopIntoRemoteTemp: self
 ]

--- a/src/OpalCompiler-Core/IRPopIntoTemp.class.st
+++ b/src/OpalCompiler-Core/IRPopIntoTemp.class.st
@@ -2,17 +2,19 @@
 pop into temp
 "
 Class {
-	#name : #IRPopIntoTemp,
-	#superclass : #IRTempAccess,
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#name : 'IRPopIntoTemp',
+	#superclass : 'IRTempAccess',
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPopIntoTemp >> accept: aVisitor [
 	^ aVisitor visitPopIntoTemp: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRPopIntoTemp >> nextBytecodeOffsetAfterJump [
 	"if we are in to:do: answers the next byte code offset"
 	^ self sequence last destination last destination first bytecodeOffset

--- a/src/OpalCompiler-Core/IRPrimitive.class.st
+++ b/src/OpalCompiler-Core/IRPrimitive.class.st
@@ -8,28 +8,30 @@ Structure:
 
 "
 Class {
-	#name : #IRPrimitive,
-	#superclass : #Object,
+	#name : 'IRPrimitive',
+	#superclass : 'Object',
 	#instVars : [
 		'primitiveNum',
 		'spec'
 	],
-	#category : #'OpalCompiler-Core-Bytecode'
+	#category : 'OpalCompiler-Core-Bytecode',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Bytecode'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 IRPrimitive class >> from: aPragmaNode [
 
 	^ self new initializeFrom: aPragmaNode
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRPrimitive class >> null [
 
 	^ self new num: 0
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRPrimitive >> initializeFrom: aPragmaNode [
 
 	primitiveNum := 0.
@@ -39,25 +41,25 @@ IRPrimitive >> initializeFrom: aPragmaNode [
 		with: 0 with: 0
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRPrimitive >> num [
 
 	^ primitiveNum
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRPrimitive >> num: n [
 
 	primitiveNum := n
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 IRPrimitive >> printOn: aStream [
 
 	aStream nextPutAll: 'primitive '; print: primitiveNum
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 IRPrimitive >> printPrimitiveOn: aStream [
 	"Print the primitive on aStream"
 
@@ -88,20 +90,20 @@ IRPrimitive >> printPrimitiveOn: aStream [
 	aStream nextPut: $>
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 IRPrimitive >> sourceText [
 
 	^ String streamContents: [:stream |
 		self printPrimitiveOn: stream]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRPrimitive >> spec [
 
 	^ spec
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRPrimitive >> spec: literal [
 
 	spec := literal

--- a/src/OpalCompiler-Core/IRPrinter.class.st
+++ b/src/OpalCompiler-Core/IRPrinter.class.st
@@ -2,15 +2,17 @@
 I interpret IRMethod instructions and write them out to a print stream.
 "
 Class {
-	#name : #IRPrinter,
-	#superclass : #IRVisitor,
+	#name : 'IRPrinter',
+	#superclass : 'IRVisitor',
 	#instVars : [
 		'stream'
 	],
-	#category : #'OpalCompiler-Core-IR-Manipulation'
+	#category : 'OpalCompiler-Core-IR-Manipulation',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Manipulation'
 }
 
-{ #category : #private }
+{ #category : 'private' }
 IRPrinter >> label: seqNum [
 
 	"add tab and cr since this does not get called within interpretInstruction:"
@@ -20,32 +22,32 @@ IRPrinter >> label: seqNum [
 	stream cr
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 IRPrinter >> stream: stringWriteStream [
 
 	stream := stringWriteStream
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitBlockReturnTop: blockReturnTop [
 
 	stream nextPutAll: 'blockReturnTop'
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitInstruction: aNode [
 	self visitNode: aNode.
 	stream cr
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitJump: jump [
 
 	stream nextPutAll: 'goto: '.
 	jump destination orderNumber printOn: stream
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitJumpIf: jumpIf [
 
 	stream nextPutAll: 'if: '.
@@ -56,20 +58,20 @@ IRPrinter >> visitJumpIf: jumpIf [
 	jumpIf otherwise orderNumber printOn: stream
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitPop: pop [
 
 	stream nextPutAll: 'popTop'
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitPopIntoInstVar: instVar [
 
 	stream nextPutAll: 'popIntoInstVar: '.
 	instVar index printOn: stream
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitPopIntoLiteralVariable: litVar [
 
 	| object |
@@ -79,7 +81,7 @@ IRPrinter >> visitPopIntoLiteralVariable: litVar [
 	object printOn: stream
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitPopIntoRemoteTemp: remoteTemp [
 
 	stream nextPutAll: 'popIntoRemoteTemp: '.
@@ -88,14 +90,14 @@ IRPrinter >> visitPopIntoRemoteTemp: remoteTemp [
 	remoteTemp tempVectorName printOn: stream
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitPopIntoTemp: tmp [
 
 	stream nextPutAll: 'popIntoTemp: '.
 	tmp name printOn: stream
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitPushArray: array [
 
 	array cons
@@ -106,13 +108,13 @@ IRPrinter >> visitPushArray: array [
 	array size printOn: stream
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitPushDup: dup [
 
 	stream nextPutAll: 'pushDup'
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitPushFullClosure: fullBlock [
 
 	stream nextPutAll: 'pushFullBlock: '.
@@ -121,14 +123,14 @@ IRPrinter >> visitPushFullClosure: fullBlock [
 	stream nextPutAll: fullBlock copiedValues size printString
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitPushInstVar: instVar [
 
 	stream nextPutAll: 'pushInstVar: '.
 	instVar index printOn: stream
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitPushLiteral: lit [
 
 	| object |
@@ -138,7 +140,7 @@ IRPrinter >> visitPushLiteral: lit [
 	object printOn: stream
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitPushLiteralVariable: var [
 
 	| object |
@@ -148,13 +150,13 @@ IRPrinter >> visitPushLiteralVariable: var [
 	object printOn: stream
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitPushReceiver: receiver [
 
 	stream nextPutAll: 'pushReceiver'
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitPushRemoteTemp: remoteTemp [
 
 	stream nextPutAll: 'pushRemoteTemp: '.
@@ -163,38 +165,38 @@ IRPrinter >> visitPushRemoteTemp: remoteTemp [
 	remoteTemp tempVectorName printOn: stream
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitPushTemp: tmp [
 
 	stream nextPutAll: 'pushTemp: '.
 	tmp name printOn: stream
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitPushThisContext: ctxt [
 
 	stream nextPutAll: 'pushThisContext'
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitPushThisProcess: pushThisProcess [
 
 	stream nextPutAll: 'pushThisProcess'
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitReturn: ret [
 
 	stream nextPutAll: 'returnTop'
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitReturnInstVar: instVar [
 	stream nextPutAll: 'returnInstVar: '.
    instVar index printOn: stream
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitReturnLiteral: lit [
 
 	| object |
@@ -204,13 +206,13 @@ IRPrinter >> visitReturnLiteral: lit [
 	object printOn: stream
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitReturnReceiver: receiver [
 
 	stream nextPutAll: 'returnReceiver'
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitSend: send [
 
 	send superOf
@@ -222,19 +224,19 @@ IRPrinter >> visitSend: send [
 			behavior printOn: stream ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitSequence: instructionSequence [
 	self label: instructionSequence orderNumber.
 	super visitSequence: instructionSequence
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitStoreInstVar: instVar [
 	stream nextPutAll: 'storeInstVar: '.
    instVar index printOn: stream
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitStoreLiteralVariable: var [
 
 	| object |
@@ -244,7 +246,7 @@ IRPrinter >> visitStoreLiteralVariable: var [
 	object printOn: stream
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitStoreRemoteTemp: remoteTemp [
 	stream nextPutAll: 'storeRemoteTemp: '.
 	remoteTemp name printOn: stream.
@@ -252,14 +254,14 @@ IRPrinter >> visitStoreRemoteTemp: remoteTemp [
 	remoteTemp tempVectorName printOn: stream
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitStoreTemp: tmp [
 
    	stream nextPutAll: 'storeTemp: '.
 	tmp name printOn: stream
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPrinter >> visitTempVector: tempVector [
 
 	stream nextPutAll: 'createTempVectorNamed: '.

--- a/src/OpalCompiler-Core/IRPushArray.class.st
+++ b/src/OpalCompiler-Core/IRPushArray.class.st
@@ -4,42 +4,44 @@ I model the pushArray bytecode.
 Used for setting up the temp vectors and for the brace array construct: { }.
 "
 Class {
-	#name : #IRPushArray,
-	#superclass : #IRInstruction,
+	#name : 'IRPushArray',
+	#superclass : 'IRInstruction',
 	#instVars : [
 		'size',
 		'cons'
 	],
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPushArray >> accept: aVisitor [
 	^ aVisitor visitPushArray: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRPushArray >> cons [
 	^ cons
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRPushArray >> cons: aBool [
 	cons := aBool
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 IRPushArray >> initialize [
 	size := 0.
 	cons := false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRPushArray >> size [
 	^ size
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRPushArray >> size: aSmallInteger [
 	size := aSmallInteger
 ]

--- a/src/OpalCompiler-Core/IRPushDup.class.st
+++ b/src/OpalCompiler-Core/IRPushDup.class.st
@@ -2,17 +2,19 @@
 Instruction ""pushDup""
 "
 Class {
-	#name : #IRPushDup,
-	#superclass : #IRInstruction,
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#name : 'IRPushDup',
+	#superclass : 'IRInstruction',
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPushDup >> accept: aVisitor [
 	^ aVisitor visitPushDup: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRPushDup >> isRemovableByPop [
 
 	^ true

--- a/src/OpalCompiler-Core/IRPushFullClosure.class.st
+++ b/src/OpalCompiler-Core/IRPushFullClosure.class.st
@@ -4,59 +4,61 @@ I represent the creation and the push on stack of a FullBlockClosure.
 
 "
 Class {
-	#name : #IRPushFullClosure,
-	#superclass : #IRInstruction,
+	#name : 'IRPushFullClosure',
+	#superclass : 'IRInstruction',
 	#instVars : [
 		'compiledBlock',
 		'copiedValues',
 		'outerContextNeeded'
 	],
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPushFullClosure >> accept: aVisitor [
 	^ aVisitor visitPushFullClosure: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRPushFullClosure >> compiledBlock [
 	^ compiledBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRPushFullClosure >> compiledBlock: anObject [
 	compiledBlock := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRPushFullClosure >> copiedValues [
 	^ copiedValues
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRPushFullClosure >> copiedValues: anObject [
 	copiedValues := anObject
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 IRPushFullClosure >> indexForVarNamed: aName [
 	^ sourceNode ir indexForVarNamed: aName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRPushFullClosure >> outerContextNeeded [
 
 	^ outerContextNeeded ifNil: [ true ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRPushFullClosure >> outerContextNeeded: anObject [
 
 	outerContextNeeded := anObject
 ]
 
-{ #category : #scoping }
+{ #category : 'scoping' }
 IRPushFullClosure >> remapCopiedValueAt: index oldOne: aTemp newOne: aRemote [
 
 	self copiedValues at: index put: aRemote

--- a/src/OpalCompiler-Core/IRPushInstVar.class.st
+++ b/src/OpalCompiler-Core/IRPushInstVar.class.st
@@ -2,28 +2,30 @@
 push inst var
 "
 Class {
-	#name : #IRPushInstVar,
-	#superclass : #IRInstVarAccess,
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#name : 'IRPushInstVar',
+	#superclass : 'IRInstVarAccess',
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPushInstVar >> accept: aVisitor [
 	^ aVisitor visitPushInstVar: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRPushInstVar >> canBeQuickReturn [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRPushInstVar >> isRemovableByPop [
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRPushInstVar >> quickRetNode [
 	^ IRReturnInstVar new
 		index: index;

--- a/src/OpalCompiler-Core/IRPushLiteral.class.st
+++ b/src/OpalCompiler-Core/IRPushLiteral.class.st
@@ -2,55 +2,57 @@
 Instruction ""pushLiteral: object""
 "
 Class {
-	#name : #IRPushLiteral,
-	#superclass : #IRInstruction,
+	#name : 'IRPushLiteral',
+	#superclass : 'IRInstruction',
 	#instVars : [
 		'literal'
 	],
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPushLiteral >> accept: aVisitor [
 	^ aVisitor visitPushLiteral: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRPushLiteral >> canBeQuickReturn [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRPushLiteral >> isPushLiteral [
 
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRPushLiteral >> isPushLiteral: valueTest [
 	^ valueTest value: literal
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRPushLiteral >> isRemovableByPop [
 	"Be conservative to keep symbols and other things"
 
 	^ (#( nil true false ) includes: literal) or: [ literal isNumber ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRPushLiteral >> literal [
 
 	^ literal
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRPushLiteral >> literal: object [
 
 	literal := object
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRPushLiteral >> quickRetNode [
 	^ IRReturnLiteral new
 		literal: literal;

--- a/src/OpalCompiler-Core/IRPushLiteralVariable.class.st
+++ b/src/OpalCompiler-Core/IRPushLiteralVariable.class.st
@@ -2,12 +2,14 @@
 push literal variable
 "
 Class {
-	#name : #IRPushLiteralVariable,
-	#superclass : #IRLiteralVariableAccess,
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#name : 'IRPushLiteralVariable',
+	#superclass : 'IRLiteralVariableAccess',
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPushLiteralVariable >> accept: aVisitor [
 	^ aVisitor visitPushLiteralVariable: self
 ]

--- a/src/OpalCompiler-Core/IRPushReceiver.class.st
+++ b/src/OpalCompiler-Core/IRPushReceiver.class.st
@@ -2,33 +2,35 @@
 I am modelling the push self bytecode
 "
 Class {
-	#name : #IRPushReceiver,
-	#superclass : #IRAccess,
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#name : 'IRPushReceiver',
+	#superclass : 'IRAccess',
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPushReceiver >> accept: aVisitor [
 	^ aVisitor visitPushReceiver: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRPushReceiver >> canBeQuickReturn [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRPushReceiver >> isRemovableByPop [
 
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRPushReceiver >> isSelf [
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRPushReceiver >> quickRetNode [
 	^ IRReturnReceiver new
 ]

--- a/src/OpalCompiler-Core/IRPushRemoteTemp.class.st
+++ b/src/OpalCompiler-Core/IRPushRemoteTemp.class.st
@@ -2,17 +2,19 @@
 push remote temp
 "
 Class {
-	#name : #IRPushRemoteTemp,
-	#superclass : #IRRemoteTempAccess,
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#name : 'IRPushRemoteTemp',
+	#superclass : 'IRRemoteTempAccess',
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPushRemoteTemp >> accept: aVisitor [
 	^ aVisitor visitPushRemoteTemp: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRPushRemoteTemp >> isRemovableByPop [
 
 	^ true

--- a/src/OpalCompiler-Core/IRPushTemp.class.st
+++ b/src/OpalCompiler-Core/IRPushTemp.class.st
@@ -2,17 +2,19 @@
 push temp
 "
 Class {
-	#name : #IRPushTemp,
-	#superclass : #IRTempAccess,
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#name : 'IRPushTemp',
+	#superclass : 'IRTempAccess',
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPushTemp >> accept: aVisitor [
 	^ aVisitor visitPushTemp: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRPushTemp >> isRemovableByPop [
 
 	^ true

--- a/src/OpalCompiler-Core/IRPushThisContext.class.st
+++ b/src/OpalCompiler-Core/IRPushThisContext.class.st
@@ -2,17 +2,19 @@
 I model push thisContext bytecode
 "
 Class {
-	#name : #IRPushThisContext,
-	#superclass : #IRAccess,
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#name : 'IRPushThisContext',
+	#superclass : 'IRAccess',
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPushThisContext >> accept: aVisitor [
 	^ aVisitor visitPushThisContext: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRPushThisContext >> isRemovableByPop [
 
 	^ true

--- a/src/OpalCompiler-Core/IRPushThisProcess.class.st
+++ b/src/OpalCompiler-Core/IRPushThisProcess.class.st
@@ -2,17 +2,19 @@
 I model push thisThisProcess bytecode
 "
 Class {
-	#name : #IRPushThisProcess,
-	#superclass : #IRAccess,
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#name : 'IRPushThisProcess',
+	#superclass : 'IRAccess',
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRPushThisProcess >> accept: aVisitor [
 	^ aVisitor visitPushThisProcess: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRPushThisProcess >> isRemovableByPop [
 
 	^ true

--- a/src/OpalCompiler-Core/IRReconstructor.class.st
+++ b/src/OpalCompiler-Core/IRReconstructor.class.st
@@ -2,23 +2,25 @@
 I am a specialized IRBuilder for the decompiler
 "
 Class {
-	#name : #IRReconstructor,
-	#superclass : #IRBuilder,
+	#name : 'IRReconstructor',
+	#superclass : 'IRBuilder',
 	#instVars : [
 		'temps',
 		'remoteTemps',
 		'closureCopiedValues'
 	],
-	#category : #'OpalCompiler-Core-Bytecode'
+	#category : 'OpalCompiler-Core-Bytecode',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Bytecode'
 }
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRReconstructor >> blockReturnTop [
 	self fixPushNilsForTemps.
 	^ super blockReturnTop
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 IRReconstructor >> createTempVectorNamed: name withVars: anArray [
 	" Don't add the temp yet, we only know it's index at the end of the block or method "
 	"self addVectorTemps: anArray"
@@ -27,17 +29,17 @@ IRReconstructor >> createTempVectorNamed: name withVars: anArray [
 	self add: (IRInstruction createTempVectorNamed: name withVars: anArray)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRReconstructor >> currentSequence [
 	^currentSequence
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRReconstructor >> currentSequence: aSeq [
 	currentSequence := aSeq
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 IRReconstructor >> fixPushNilsForTemps [
 	" There are pushConstant: nil in the beginning of the blocksequence for all of the defined temps.
 	  We got these pushConstant: nil in. Now our closure will generate them again, meaning we will double
@@ -48,7 +50,7 @@ IRReconstructor >> fixPushNilsForTemps [
 	self currentScope definedTemps do: [ :temp | blocksequence removeFirst ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 IRReconstructor >> initialize [
 	temps := Dictionary new.
 	remoteTemps := Dictionary new.
@@ -57,14 +59,14 @@ IRReconstructor >> initialize [
 	super initialize
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRReconstructor >> isLastClosureInstruction [
 	| nextJumps |
 	nextJumps := jumpAheadStacks at: sourceMapByteIndex + 1 ifAbsent: [ ^ false ].
 	^ nextJumps anySatisfy: [ :anOrigin | anOrigin = self currentScope ]
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRReconstructor >> pushFullClosureCompiledBlock: compiledBlock copiedValues: copiedValues [
 	| anInstruction |
 	anInstruction := super pushFullClosureCompiledBlock: compiledBlock copiedValues: copiedValues.
@@ -73,21 +75,21 @@ IRReconstructor >> pushFullClosureCompiledBlock: compiledBlock copiedValues: cop
 		self rememberReference: anInstruction -> index to: aValue in: closureCopiedValues ]
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRReconstructor >> pushRemoteTemp: name inVector: nameOfVector [
 	| anInstruction |
 	anInstruction := super pushRemoteTemp: name inVector: nameOfVector.
 	self rememberReference: anInstruction to: nameOfVector in: remoteTemps
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRReconstructor >> pushTemp: aSelector [
 	| anInstruction |
 	anInstruction := super pushTemp: aSelector.
 	self rememberReference: anInstruction to: aSelector in: temps
 ]
 
-{ #category : #remapping }
+{ #category : 'remapping' }
 IRReconstructor >> remapTemp: aTemp toRemote: aRemote [
 	(temps removeKey: aTemp ifAbsent: [ #() ])
 		do: [ :tempAccess |
@@ -107,13 +109,13 @@ IRReconstructor >> remapTemp: aTemp toRemote: aRemote [
 			self rememberReference: aClosureAndIndex to: aRemote in: closureCopiedValues. ]
 ]
 
-{ #category : #remapping }
+{ #category : 'remapping' }
 IRReconstructor >> rememberReference: anInstruction to: name in: dictionary [
 	(dictionary at: name ifAbsentPut: [ OrderedCollection new ])
 		add: anInstruction
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 IRReconstructor >> removeLast: n [
 	" Make the address of the instruction be the address of the first removed instruction. "
 	sourceMapByteIndex := sourceMapByteIndex - n.
@@ -122,14 +124,14 @@ IRReconstructor >> removeLast: n [
 		node name ]
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRReconstructor >> storeRemoteTemp: name inVector: nameOfVector [
 	| anInstruction |
 	anInstruction := super storeRemoteTemp: name inVector: nameOfVector.
 	self rememberReference: anInstruction to: nameOfVector in: remoteTemps
 ]
 
-{ #category : #instructions }
+{ #category : 'instructions' }
 IRReconstructor >> storeTemp: aSelector [
 	| anInstruction |
 	anInstruction := super storeTemp: aSelector.

--- a/src/OpalCompiler-Core/IRRemoteArray.class.st
+++ b/src/OpalCompiler-Core/IRRemoteArray.class.st
@@ -2,41 +2,43 @@
 I model the TempVector for the decompiler
 "
 Class {
-	#name : #IRRemoteArray,
-	#superclass : #Object,
+	#name : 'IRRemoteArray',
+	#superclass : 'Object',
 	#instVars : [
 		'size',
 		'index'
 	],
-	#category : #'OpalCompiler-Core-Bytecode'
+	#category : 'OpalCompiler-Core-Bytecode',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Bytecode'
 }
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 IRRemoteArray >> do: aBlock [
 	1 to: size do: [ :idx | aBlock value: (idx - 1) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRRemoteArray >> index [
 	^ index
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRRemoteArray >> index: anIndex [
 	index := anIndex
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 IRRemoteArray >> indexOf: anInteger [
 	^anInteger + 1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRRemoteArray >> size [
 	^ size
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRRemoteArray >> size: aSize [
 	size := aSize
 ]

--- a/src/OpalCompiler-Core/IRRemoteTempAccess.class.st
+++ b/src/OpalCompiler-Core/IRRemoteTempAccess.class.st
@@ -2,25 +2,27 @@
 I model the pushRemoteTemporary Bytecode
 "
 Class {
-	#name : #IRRemoteTempAccess,
-	#superclass : #IRTempAccess,
+	#name : 'IRRemoteTempAccess',
+	#superclass : 'IRTempAccess',
 	#instVars : [
 		'tempVectorName'
 	],
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRRemoteTempAccess >> isRemoteTemp [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRRemoteTempAccess >> tempVectorName [
 	^ tempVectorName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRRemoteTempAccess >> tempVectorName: anObject [
 	tempVectorName := anObject
 ]

--- a/src/OpalCompiler-Core/IRReturn.class.st
+++ b/src/OpalCompiler-Core/IRReturn.class.st
@@ -2,23 +2,25 @@
 Instruction ""returnTop""
 "
 Class {
-	#name : #IRReturn,
-	#superclass : #IRInstruction,
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#name : 'IRReturn',
+	#superclass : 'IRInstruction',
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRReturn >> accept: aVisitor [
 	^ aVisitor visitReturn: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRReturn >> isReturn [
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRReturn >> nonBodySuccessorSequences [
 	^#()
 ]

--- a/src/OpalCompiler-Core/IRReturnInstVar.class.st
+++ b/src/OpalCompiler-Core/IRReturnInstVar.class.st
@@ -2,25 +2,27 @@
 specific node when returning an inst var
 "
 Class {
-	#name : #IRReturnInstVar,
-	#superclass : #IRReturn,
+	#name : 'IRReturnInstVar',
+	#superclass : 'IRReturn',
 	#instVars : [
 		'index'
 	],
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRReturnInstVar >> accept: aVisitor [
 	^ aVisitor visitReturnInstVar: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRReturnInstVar >> index [
 	^ index
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRReturnInstVar >> index: anObject [
 	index := anObject
 ]

--- a/src/OpalCompiler-Core/IRReturnLiteral.class.st
+++ b/src/OpalCompiler-Core/IRReturnLiteral.class.st
@@ -2,25 +2,27 @@
 specific node when returning a constant
 "
 Class {
-	#name : #IRReturnLiteral,
-	#superclass : #IRReturn,
+	#name : 'IRReturnLiteral',
+	#superclass : 'IRReturn',
 	#instVars : [
 		'literal'
 	],
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRReturnLiteral >> accept: aVisitor [
 	^ aVisitor visitReturnLiteral: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRReturnLiteral >> literal [
 	^ literal
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRReturnLiteral >> literal: anObject [
 	literal := anObject
 ]

--- a/src/OpalCompiler-Core/IRReturnReceiver.class.st
+++ b/src/OpalCompiler-Core/IRReturnReceiver.class.st
@@ -2,12 +2,14 @@
 specific node when returning self
 "
 Class {
-	#name : #IRReturnReceiver,
-	#superclass : #IRReturn,
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#name : 'IRReturnReceiver',
+	#superclass : 'IRReturn',
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRReturnReceiver >> accept: aVisitor [
 	^ aVisitor visitReturnReceiver: self
 ]

--- a/src/OpalCompiler-Core/IRSend.class.st
+++ b/src/OpalCompiler-Core/IRSend.class.st
@@ -2,48 +2,50 @@
 Instruction ""send: selector"" or ""send: selector toSuperOf: behavior""
 "
 Class {
-	#name : #IRSend,
-	#superclass : #IRInstruction,
+	#name : 'IRSend',
+	#superclass : 'IRInstruction',
 	#instVars : [
 		'selector',
 		'superOf'
 	],
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRSend >> accept: aVisitor [
 	^ aVisitor visitSend: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRSend >> isSend [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRSend >> isSuperSend [
     ^superOf notNil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRSend >> selector [
 	^selector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRSend >> selector: symbol [
 
 	selector := symbol
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRSend >> superOf [
 
 	^ superOf
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRSend >> superOf: behavior [
 
 	superOf := behavior

--- a/src/OpalCompiler-Core/IRSequence.class.st
+++ b/src/OpalCompiler-Core/IRSequence.class.st
@@ -2,27 +2,29 @@
 A sequence is corresponds to a block in the control flow graph.
 "
 Class {
-	#name : #IRSequence,
-	#superclass : #Object,
+	#name : 'IRSequence',
+	#superclass : 'Object',
 	#instVars : [
 		'sequence',
 		'orderNumber',
 		'method'
 	],
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRSequence class >> orderNumber: aNumber [
 	^self new orderNumber: aNumber
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 IRSequence >> , otherCollection [
 	^sequence, otherCollection
 ]
 
-{ #category : #optimizing }
+{ #category : 'optimizing' }
 IRSequence >> absorbJumpToSingleInstr: alreadySeen [
 	"Collapse jumps to single return instructions into caller"
 
@@ -42,12 +44,12 @@ IRSequence >> absorbJumpToSingleInstr: alreadySeen [
 	seqs do: [:instrs | instrs ifNotNil: [:i | i absorbJumpToSingleInstr: alreadySeen]]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRSequence >> accept: aVisitor [
 	^ aVisitor visitSequence: self
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 IRSequence >> add: anInstruction [
 
 	sequence add: anInstruction.
@@ -55,7 +57,7 @@ IRSequence >> add: anInstruction [
 	^anInstruction
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 IRSequence >> add: instr after: another [
 
 	sequence add: instr after: another.
@@ -63,103 +65,103 @@ IRSequence >> add: instr after: another [
 	^instr
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 IRSequence >> add: instr before: another [
 	sequence add: instr before: another.
 	instr sequence: self.
 	^instr
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 IRSequence >> addAll: aCollection [
 	^sequence addAll: aCollection
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 IRSequence >> addAllFirst: aCollection [
 	^sequence addAllFirst: aCollection
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 IRSequence >> addInstructions: aCollection [
 
 	^aCollection do: [:instr | self add: instr]
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 IRSequence >> addInstructions: aCollection after: anInstruction [
 
 	^aCollection reverseDo: [:instr | self add: instr after: anInstruction]
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 IRSequence >> addInstructions: aCollection before: anInstruction [
 
 	aCollection do: [:instr | self add: instr before: anInstruction]
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 IRSequence >> addLast: anInstruction [
 	^self add: anInstruction
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRSequence >> after: o [
 	^sequence after: o
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRSequence >> at: index [
 	^sequence at: index
 ]
 
-{ #category : #inspector }
+{ #category : 'inspector' }
 IRSequence >> children [
 	^sequence
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 IRSequence >> contains: aBlock [
 	^sequence contains: aBlock
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 IRSequence >> detect: aBlock [
 	^sequence detect: aBlock
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 IRSequence >> do: aBlock [
 	^sequence do: aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRSequence >> first [
 	^sequence first
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRSequence >> ifEmpty: aBlock [
 	^sequence ifEmpty: aBlock
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRSequence >> ifNotEmpty: aBlock [
 	^sequence ifNotEmpty: aBlock
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 IRSequence >> initialize [
 	sequence := OrderedCollection new
 ]
 
-{ #category : #'successor sequences' }
+{ #category : 'successor sequences' }
 IRSequence >> instructionsDo: aBlock [
 
 	^self withAllSuccessorsDo: [:seq | seq do: aBlock]
 ]
 
-{ #category : #'successor sequences' }
+{ #category : 'successor sequences' }
 IRSequence >> instructionsForDecompiling [
 
 	| irInstructions |
@@ -168,17 +170,17 @@ IRSequence >> instructionsForDecompiling [
 	^irInstructions
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRSequence >> isEmpty [
 	^sequence isEmpty
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRSequence >> last [
 	^sequence last
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 IRSequence >> longPrintOn: stream [
 
 	[IRPrinter new
@@ -187,19 +189,19 @@ IRSequence >> longPrintOn: stream [
 	] onDNU: #orderNumber do: [:ex | ex resume: ex receiver]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRSequence >> method [
 
 	^method
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRSequence >> method: aIRMethod [
 
 	method := aIRMethod
 ]
 
-{ #category : #'successor sequences' }
+{ #category : 'successor sequences' }
 IRSequence >> nextSequence [
 
 	| sequences i |
@@ -209,32 +211,32 @@ IRSequence >> nextSequence [
 	^ sequences at: i + 1
 ]
 
-{ #category : #'successor sequences' }
+{ #category : 'successor sequences' }
 IRSequence >> nonBodySuccessorSequences [
 
 	sequence isEmpty ifTrue: [^ #()].
 	^ sequence last nonBodySuccessorSequences
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRSequence >> notEmpty [
 	^sequence notEmpty
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRSequence >> orderNumber [
 	"Sequences are sorted by this number"
 
 	^ orderNumber
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRSequence >> orderNumber: num [
 	"Sequences are sorted by this number"
 	orderNumber := num
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 IRSequence >> printOn: stream [
 
 	stream nextPutAll: 'an '.
@@ -245,28 +247,28 @@ IRSequence >> printOn: stream [
 	stream nextPut: $)
 ]
 
-{ #category : #replacing }
+{ #category : 'replacing' }
 IRSequence >> remove: aNode [
 	aNode sequence: nil.
 	sequence remove: aNode ifAbsent: [self error]
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 IRSequence >> removeFirst [
 	^sequence removeFirst
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 IRSequence >> removeLast [
 	^sequence removeLast
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 IRSequence >> removeLast: n [
 	^sequence removeLast: n
 ]
 
-{ #category : #replacing }
+{ #category : 'replacing' }
 IRSequence >> replaceNode: aNode withNode: anotherNode [
 
 	| index |
@@ -274,45 +276,45 @@ IRSequence >> replaceNode: aNode withNode: anotherNode [
 	sequence at: index put: (anotherNode sequence: self)
 ]
 
-{ #category : #replacing }
+{ #category : 'replacing' }
 IRSequence >> replaceNode: aNode withNodes: aCollection [
 
 	self addInstructions: aCollection before: aNode.
 	sequence remove: aNode ifAbsent: [self error]
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 IRSequence >> reverseDo: aBlock [
 	^sequence reverseDo: aBlock
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 IRSequence >> select: aBlock [
 	^sequence select: aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRSequence >> sequence [
 	^sequence
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRSequence >> size [
 	^sequence size
 ]
 
-{ #category : #inspector }
+{ #category : 'inspector' }
 IRSequence >> sourceInterval [
 	^self sequence first sourceInterval first to: self sequence last sourceInterval last
 ]
 
-{ #category : #inspector }
+{ #category : 'inspector' }
 IRSequence >> sourceNode [
 	"we should do better here"
 	^RBSequenceNode new
 ]
 
-{ #category : #manipulating }
+{ #category : 'manipulating' }
 IRSequence >> splitAfter: instruction [
 
 	| newSeq index next |
@@ -331,14 +333,14 @@ IRSequence >> splitAfter: instruction [
 	^ newSeq
 ]
 
-{ #category : #'successor sequences' }
+{ #category : 'successor sequences' }
 IRSequence >> successorSequences [
 
 	sequence isEmpty ifTrue: [^ #()].
 	^ sequence last successorSequences
 ]
 
-{ #category : #'successor sequences' }
+{ #category : 'successor sequences' }
 IRSequence >> withAllSuccessors [
 	"Return me and all my successors sorted by sequence orderNumber"
 
@@ -348,14 +350,14 @@ IRSequence >> withAllSuccessors [
 	^ list asSortedCollection: [:x :y | x orderNumber <= y orderNumber]
 ]
 
-{ #category : #'successor sequences' }
+{ #category : 'successor sequences' }
 IRSequence >> withAllSuccessorsDo: block [
 	"Iterate over me and all my successors only once"
 
 	self withAllSuccessorsDo: block alreadySeen: IdentitySet new
 ]
 
-{ #category : #'successor sequences' }
+{ #category : 'successor sequences' }
 IRSequence >> withAllSuccessorsDo: block alreadySeen: set [
 	"Iterate over me and all my successors only once"
 
@@ -366,14 +368,14 @@ IRSequence >> withAllSuccessorsDo: block alreadySeen: set [
 		seq ifNotNil: [seq withAllSuccessorsDo: block alreadySeen: set]]
 ]
 
-{ #category : #'successor sequences' }
+{ #category : 'successor sequences' }
 IRSequence >> withNonBodySuccessorsDo: block [
 	"Iterate over me and all my successors only once"
 
 	self withNonBodySuccessorsDo: block alreadySeen: IdentitySet new
 ]
 
-{ #category : #'successor sequences' }
+{ #category : 'successor sequences' }
 IRSequence >> withNonBodySuccessorsDo: block alreadySeen: set [
 	"Iterate over me and all my successors only once"
 

--- a/src/OpalCompiler-Core/IRStackCount.class.st
+++ b/src/OpalCompiler-Core/IRStackCount.class.st
@@ -2,35 +2,37 @@
 This keeps track of the stack count for the BytecodeGenerator.
 "
 Class {
-	#name : #IRStackCount,
-	#superclass : #Object,
+	#name : 'IRStackCount',
+	#superclass : 'Object',
 	#instVars : [
 		'start',
 		'position',
 		'length'
 	],
-	#category : #'OpalCompiler-Core-Bytecode'
+	#category : 'OpalCompiler-Core-Bytecode',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Bytecode'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRStackCount class >> new [
 
 	^ super new startAt: 0
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRStackCount class >> newOn: stack [
 
 	^ self startAt: stack position
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRStackCount class >> startAt: pos [
 
 	^ self new startAt: pos
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 IRStackCount >> = other [
 
 	^ self class == other class
@@ -39,19 +41,19 @@ IRStackCount >> = other [
 	  and: [length = other size]]]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 IRStackCount >> hash [
 
 	^ position hash bitXor: (length hash bitXor: start hash)
 ]
 
-{ #category : #results }
+{ #category : 'results' }
 IRStackCount >> length [
 
 	^length
 ]
 
-{ #category : #results }
+{ #category : 'results' }
 IRStackCount >> linkTo: stackOrNil [
 
 	stackOrNil ifNil: [^  self class newOn: self].
@@ -60,26 +62,26 @@ IRStackCount >> linkTo: stackOrNil [
 		ifFalse: [self error: 'stack out of sync in bytecode generator']
 ]
 
-{ #category : #affecting }
+{ #category : 'affecting' }
 IRStackCount >> pop [
 
 	^ self pop: 1
 ]
 
-{ #category : #affecting }
+{ #category : 'affecting' }
 IRStackCount >> pop: n [
 
 	(position := position - n) < 0
 		ifTrue: [self error: 'stack underflow in bytecode generator']
 ]
 
-{ #category : #results }
+{ #category : 'results' }
 IRStackCount >> position [
 
 	^position
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 IRStackCount >> printOn: aStream [
 
 	super printOn: aStream.
@@ -89,30 +91,30 @@ IRStackCount >> printOn: aStream [
 		nextPutAll: ' max '; print: length
 ]
 
-{ #category : #affecting }
+{ #category : 'affecting' }
 IRStackCount >> push [
 	^ self push: 1
 ]
 
-{ #category : #affecting }
+{ #category : 'affecting' }
 IRStackCount >> push: n [
 	(position := position + n) > length
 		ifTrue: [length := position]
 ]
 
-{ #category : #results }
+{ #category : 'results' }
 IRStackCount >> size [
 
 	^length
 ]
 
-{ #category : #results }
+{ #category : 'results' }
 IRStackCount >> start [
 
 	^ start
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 IRStackCount >> startAt: pos [
 
 	start := position := length := pos

--- a/src/OpalCompiler-Core/IRStoreInstVar.class.st
+++ b/src/OpalCompiler-Core/IRStoreInstVar.class.st
@@ -2,22 +2,24 @@
 store inst var
 "
 Class {
-	#name : #IRStoreInstVar,
-	#superclass : #IRInstVarAccess,
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#name : 'IRStoreInstVar',
+	#superclass : 'IRInstVarAccess',
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRStoreInstVar >> accept: aVisitor [
 	^ aVisitor visitStoreInstVar: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRStoreInstVar >> isStore [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRStoreInstVar >> popIntoNode [
 	^ IRPopIntoInstVar new
 		index: index;

--- a/src/OpalCompiler-Core/IRStoreLiteralVariable.class.st
+++ b/src/OpalCompiler-Core/IRStoreLiteralVariable.class.st
@@ -2,22 +2,24 @@
 store literal variable
 "
 Class {
-	#name : #IRStoreLiteralVariable,
-	#superclass : #IRLiteralVariableAccess,
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#name : 'IRStoreLiteralVariable',
+	#superclass : 'IRLiteralVariableAccess',
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRStoreLiteralVariable >> accept: aVisitor [
 	^ aVisitor visitStoreLiteralVariable: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRStoreLiteralVariable >> isStore [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRStoreLiteralVariable >> popIntoNode [
 	^ IRPopIntoLiteralVariable new
 		association: association;

--- a/src/OpalCompiler-Core/IRStoreRemoteTemp.class.st
+++ b/src/OpalCompiler-Core/IRStoreRemoteTemp.class.st
@@ -2,22 +2,24 @@
 store remote temp
 "
 Class {
-	#name : #IRStoreRemoteTemp,
-	#superclass : #IRRemoteTempAccess,
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#name : 'IRStoreRemoteTemp',
+	#superclass : 'IRRemoteTempAccess',
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRStoreRemoteTemp >> accept: aVisitor [
 	^ aVisitor visitStoreRemoteTemp: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRStoreRemoteTemp >> isStore [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRStoreRemoteTemp >> popIntoNode [
 	^ IRPopIntoRemoteTemp new
 		name: name;

--- a/src/OpalCompiler-Core/IRStoreTemp.class.st
+++ b/src/OpalCompiler-Core/IRStoreTemp.class.st
@@ -2,22 +2,24 @@
 store temp
 "
 Class {
-	#name : #IRStoreTemp,
-	#superclass : #IRTempAccess,
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#name : 'IRStoreTemp',
+	#superclass : 'IRTempAccess',
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRStoreTemp >> accept: aVisitor [
 	^ aVisitor visitStoreTemp: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRStoreTemp >> isStore [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRStoreTemp >> popIntoNode [
 	^ IRPopIntoTemp new
 		name: name;

--- a/src/OpalCompiler-Core/IRTempAccess.class.st
+++ b/src/OpalCompiler-Core/IRTempAccess.class.st
@@ -2,31 +2,33 @@
 I model the pushTemporary Bytecode
 "
 Class {
-	#name : #IRTempAccess,
-	#superclass : #IRAccess,
+	#name : 'IRTempAccess',
+	#superclass : 'IRAccess',
 	#instVars : [
 		'name'
 	],
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRTempAccess >> isRemoteTemp [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRTempAccess >> isTemp [
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRTempAccess >> name [
 
 	^name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRTempAccess >> name: aString [
 	name := aString
 ]

--- a/src/OpalCompiler-Core/IRTempVector.class.st
+++ b/src/OpalCompiler-Core/IRTempVector.class.st
@@ -4,46 +4,48 @@ I model the tempVector.
 The tempvector is an array that stores all escaping variables of a block that are written to from outside.
 "
 Class {
-	#name : #IRTempVector,
-	#superclass : #IRInstruction,
+	#name : 'IRTempVector',
+	#superclass : 'IRInstruction',
 	#instVars : [
 		'name',
 		'vars'
 	],
-	#category : #'OpalCompiler-Core-IR-Nodes'
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTempVector >> accept: aVisitor [
 	^ aVisitor visitTempVector: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRTempVector >> indexForVarNamed: aName [
 	^vars indexOf: aName
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 IRTempVector >> isTempVector [
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRTempVector >> name [
 	^ name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRTempVector >> name: anObject [
 	name := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRTempVector >> vars [
 	^ vars
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRTempVector >> vars: anObject [
 	vars := anObject
 ]

--- a/src/OpalCompiler-Core/IRTranslator.class.st
+++ b/src/OpalCompiler-Core/IRTranslator.class.st
@@ -2,80 +2,82 @@
 I visit IRMethod instructions, sending the appropriate bytecode messages to my BytecodeGenerator (gen). 
 "
 Class {
-	#name : #IRTranslator,
-	#superclass : #IRVisitor,
+	#name : 'IRTranslator',
+	#superclass : 'IRVisitor',
 	#instVars : [
 		'gen',
 		'currentScope',
 		'tempVectorStack',
 		'compilationContext'
 	],
-	#category : #'OpalCompiler-Core-IR-Manipulation'
+	#category : 'OpalCompiler-Core-IR-Manipulation',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Manipulation'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRTranslator class >> context: aCompilationContext [
 	^self basicNew
 		initialize;
 		compilationContext: aCompilationContext
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 IRTranslator class >> new [
 	^self context: CompilationContext default
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRTranslator >> compilationContext [
 	^ compilationContext
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 IRTranslator >> compilationContext: aContext [
 	compilationContext := aContext.
 	gen := compilationContext bytecodeGeneratorClass newWithEncoderClass: compilationContext encoderClass.
 	gen compilationContext: aContext
 ]
 
-{ #category : #results }
+{ #category : 'results' }
 IRTranslator >> compiledBlock [
 	^ gen compiledBlock
 ]
 
-{ #category : #results }
+{ #category : 'results' }
 IRTranslator >> compiledMethod [
 	^ gen compiledMethod
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 IRTranslator >> currentScope [
 	^currentScope top
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 IRTranslator >> initialize [
 	currentScope := Stack new.
 	tempVectorStack := Stack new
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 IRTranslator >> label: seqNum [
 
 	gen label: seqNum
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 IRTranslator >> popScope [
 
 	currentScope size = 1 ifFalse: [currentScope pop]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 IRTranslator >> pragmas: aCollection [
 	gen pragmas: aCollection
 ]
 
-{ #category : #results }
+{ #category : 'results' }
 IRTranslator >> pushOuterVectors: scope [
 	| scopesWithVector sc |
 	scopesWithVector := OrderedCollection new.
@@ -90,31 +92,31 @@ IRTranslator >> pushOuterVectors: scope [
 	gen inBlock: true
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 IRTranslator >> pushScope: anIRBlockOrMethod [
 
 	currentScope push: anIRBlockOrMethod
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitBlockReturnTop: blockReturnTop [
 
 	gen blockReturnTop
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitInstruction: instr [
 	gen mapBytesTo: instr.
 	self visitNode: instr
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitJump: jump [
 
 	gen goto: jump destination orderNumber
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitJumpIf: jumpIf [
 
 	gen
@@ -123,7 +125,7 @@ IRTranslator >> visitJumpIf: jumpIf [
 		otherwise: jumpIf otherwise orderNumber
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitMethod: anIr [
 	IRFix new visitNode: anIr.
 	self pushScope: anIr.
@@ -140,24 +142,24 @@ IRTranslator >> visitMethod: anIr [
 	anIr additionalLiterals do: [ :each | gen addLiteral: each ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitPop: pop [
 
 	gen popTop
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitPopIntoInstVar: instVar [
 	gen storePopInstVar: instVar index
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitPopIntoLiteralVariable: var [
 
 	gen storePopIntoLiteralVariable: var association
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitPopIntoRemoteTemp: remoteTemp [
 	| tempIndex tempVectorIndex tempVector |
 
@@ -168,13 +170,13 @@ IRTranslator >> visitPopIntoRemoteTemp: remoteTemp [
 	gen storePopRemoteTemp: tempVectorIndex inVectorAt: tempIndex
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitPopIntoTemp: tmp [
 
    	gen storePopTemp: (self currentScope indexForVarNamed: tmp name)
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitPushArray: array [
 
 	array cons
@@ -184,13 +186,13 @@ IRTranslator >> visitPushArray: array [
 			gen pushNewArray: array size ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitPushDup: dup [
 
 	gen pushDup
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitPushFullClosure: fullBlock [
 
 	fullBlock copiedValues do: [:name |
@@ -199,30 +201,30 @@ IRTranslator >> visitPushFullClosure: fullBlock [
 	gen pushFullBlockClosure: fullBlock
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitPushInstVar: instVar [
 
 	gen pushInstVar: instVar index
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitPushLiteral: lit [
 	^ gen pushLiteral: lit literal beReadOnlyLiteral
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitPushLiteralVariable: var [
 
 	gen pushLiteralVariable: var association
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitPushReceiver: receiver [
 
 	gen pushReceiver
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitPushRemoteTemp: remoteTemp [
 	| tempIndex tempVectorIndex tempVector |
 
@@ -233,48 +235,48 @@ IRTranslator >> visitPushRemoteTemp: remoteTemp [
 	gen pushRemoteTemp: tempVectorIndex inVectorAt: tempIndex
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitPushTemp: tmp [
 
 	gen pushTemp: (self currentScope indexForVarNamed: tmp name)
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitPushThisContext: ctxt [
 
 	gen pushThisContext
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitPushThisProcess: pushThisProcess [
 	gen pushThisProcess
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitReturn: ret [
 
 	gen returnTop
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitReturnInstVar: instVar [
 
 	gen returnInstVar: instVar index
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitReturnLiteral: lit [
 
 	gen returnConstant: lit literal
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitReturnReceiver: rec [
 
 	gen returnReceiver
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitSend: send [
 
 	send superOf
@@ -282,30 +284,30 @@ IRTranslator >> visitSend: send [
 		ifNotNil: [ :behavior |  gen send: send selector toSuperOf: behavior ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitSequence: instructionSequence [
 	self label: instructionSequence orderNumber.
 	super visitSequence: instructionSequence
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitSequences:  irSequences [
 	irSequences withIndexDo: [ :seq :i | seq orderNumber: i].
 	self visitNodes: irSequences
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitStoreInstVar: instVar [
 	gen storeInstVar: instVar index
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitStoreLiteralVariable: var [
 
 	gen storeIntoLiteralVariable: var association
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitStoreRemoteTemp: remoteTemp [
 	| tempIndex tempVectorIndex tempVector |
 
@@ -316,13 +318,13 @@ IRTranslator >> visitStoreRemoteTemp: remoteTemp [
 	gen storeRemoteTemp: tempVectorIndex inVectorAt: tempIndex
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitStoreTemp: tmp [
 
    	gen storeTemp: (self currentScope indexForVarNamed: tmp name)
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRTranslator >> visitTempVector: tempVector [
 
 	tempVectorStack push: tempVector.

--- a/src/OpalCompiler-Core/IRVisitor.class.st
+++ b/src/OpalCompiler-Core/IRVisitor.class.st
@@ -2,147 +2,149 @@
 I visit an IRMethod instructions and write them out to a print stream.
 "
 Class {
-	#name : #IRVisitor,
-	#superclass : #Object,
-	#category : #'OpalCompiler-Core-IR-Manipulation'
+	#name : 'IRVisitor',
+	#superclass : 'Object',
+	#category : 'OpalCompiler-Core-IR-Manipulation',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Manipulation'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitBlockReturnTop: blockReturnTop [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitInstruction: instr [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitJump: jump [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitJumpIf: jumpIf [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitMethod: method [
 	self visitNodes: method allSequences
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitNode: elem [
 	^ elem accept: self
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitNodes: col [
 	col do: [ :each | self visitNode: each ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitPop: pop [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitPopIntoInstVar: instVar [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitPopIntoLiteralVariable: litVar [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitPopIntoRemoteTemp: remoteTemp [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitPopIntoTemp: tmp [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitPushArray: pushArray [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitPushDup: pushDup [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitPushFullClosure: fullBlock [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitPushInstVar: pushInstVar [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitPushLiteral: pushLiteral [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitPushLiteralVariable: pushLiteralVariable [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitPushReceiver: receiver [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitPushRemoteTemp: pushRemoteTemp [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitPushTemp: pushTemp [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitPushThisContext: pushThisContext [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitPushThisProcess: pushThisProcess [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitReturn: return [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitReturnInstVar: instVar [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitReturnLiteral: lit [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitReturnReceiver: rec [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitSend: send [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitSequence: sequence [
 	sequence do: [ :instr | self visitInstruction: instr]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitStoreInstVar: storeInstVar [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitStoreLiteralVariable: storeLiteralVariable [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitStoreRemoteTemp: storeRemoteTemp [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitStoreTemp: storeTemp [
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 IRVisitor >> visitTempVector: tempVector [
 ]

--- a/src/OpalCompiler-Core/InstructionStream.extension.st
+++ b/src/OpalCompiler-Core/InstructionStream.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #InstructionStream }
+Extension { #name : 'InstructionStream' }
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 InstructionStream class >> compiler [
 	"The JIT compiler needs to trap all reads to instance variables of contexts. As this check is costly, it is only done in the long form of the bytecodes, which are not used often. In this hierarchy we force the compiler to alwasy generate long bytecodes"
 	^super compiler options: #(+ optionLongIvarAccessBytecodes)

--- a/src/OpalCompiler-Core/InvalidVariable.class.st
+++ b/src/OpalCompiler-Core/InvalidVariable.class.st
@@ -5,22 +5,24 @@ I exists only to track information on bad variables in a degraded mode, and avoi
 Once the AST is fixed I will be no more be present, so ignore me.
 "
 Class {
-	#name : #InvalidVariable,
-	#superclass : #Variable,
-	#category : #'OpalCompiler-Core-Semantics'
+	#name : 'InvalidVariable',
+	#superclass : 'Variable',
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 InvalidVariable >> allowsShadowing [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 InvalidVariable >> isInvalidVariable [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 InvalidVariable >> isUsed [
 	"Not really used, but need to silence warnings"
 

--- a/src/OpalCompiler-Core/LocalVariable.class.st
+++ b/src/OpalCompiler-Core/LocalVariable.class.st
@@ -2,23 +2,25 @@
 I model local Variables
 "
 Class {
-	#name : #LocalVariable,
-	#superclass : #Variable,
+	#name : 'LocalVariable',
+	#superclass : 'Variable',
 	#instVars : [
 		'escaping',
 		'index',
 		'scope',
 		'usage'
 	],
-	#category : #'OpalCompiler-Core-Semantics'
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 LocalVariable class >> isAbstract [
 	^ self = LocalVariable
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 LocalVariable >> = aTempVar [
 
 	^aTempVar class = self class
@@ -27,42 +29,42 @@ LocalVariable >> = aTempVar [
 		and: [aTempVar usage = self usage]]]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 LocalVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 	^ aProgramNodeVisitor visitLocalVariableNode: aNode
 ]
 
-{ #category : #'read/write usage' }
+{ #category : 'read/write usage' }
 LocalVariable >> analyzeRead: aVariableNode by: aSemanticAnalyzer [
 	super analyzeRead: aVariableNode by: aSemanticAnalyzer.
 
 	aSemanticAnalyzer analyzeLocalVariableRead: self
 ]
 
-{ #category : #'read/write usage' }
+{ #category : 'read/write usage' }
 LocalVariable >> analyzeWrite: aVariableNode by: aSemanticAnalyzer [
 	super analyzeWrite: aVariableNode by: aSemanticAnalyzer.
 
 	aSemanticAnalyzer analyzeLocalVariableWrite: self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 LocalVariable >> asDoItVariableFrom: aContext [
 	^ DoItVariable fromContext: aContext variable: self
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 LocalVariable >> asString [
 
 	^ self name
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 LocalVariable >> astNodes [
 	^scope node methodNode variableNodes select: [ :each | each variable == self]
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 LocalVariable >> createCopiedVariableFor: aScope [
 	^ CopiedLocalVariable new
 			originalVar: self originalVar;
@@ -72,35 +74,35 @@ LocalVariable >> createCopiedVariableFor: aScope [
 			scope: aScope
 ]
 
-{ #category : #emitting }
+{ #category : 'emitting' }
 LocalVariable >> emitStore: methodBuilder [
 
 	methodBuilder storeTemp: name
 ]
 
-{ #category : #emitting }
+{ #category : 'emitting' }
 LocalVariable >> emitValue: methodBuilder [
 
 	methodBuilder pushTemp: name
 ]
 
-{ #category : #escaping }
+{ #category : 'escaping' }
 LocalVariable >> escaping [
 	^escaping
 ]
 
-{ #category : #escaping }
+{ #category : 'escaping' }
 LocalVariable >> escaping: anObject [
 	escaping := anObject
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 LocalVariable >> hash [
 
 	^ name hash bitXor: (usage hash bitXor: scope hash)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LocalVariable >> index [
 	^ index ifNil: [
 		"if the index is nil, we are in an AST after name analysis but before
@@ -109,128 +111,128 @@ LocalVariable >> index [
 		index ifNil: [ self error: 'no temp index, should never happen' ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LocalVariable >> index: anObject [
 	index := anObject
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 LocalVariable >> initialize [
 	super initialize.
 	escaping := false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LocalVariable >> isAccessedIn: aMethod [
 
 	^ self isUsed and: [ aMethod == self method ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LocalVariable >> isCopying [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LocalVariable >> isDefinedByBlock [
 	"true if a variable node is defined by a block"
 	^scope isBlockScope
 ]
 
-{ #category : #escaping }
+{ #category : 'escaping' }
 LocalVariable >> isEscaping [
 	^escaping = #escapingRead or: [escaping = #escapingWrite]
 ]
 
-{ #category : #escaping }
+{ #category : 'escaping' }
 LocalVariable >> isEscapingRead [
 	^escaping = #escapingRead
 ]
 
-{ #category : #escaping }
+{ #category : 'escaping' }
 LocalVariable >> isEscapingWrite [
 	^escaping = #escapingWrite
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LocalVariable >> isLocalVariable [
 
 	^true
 ]
 
-{ #category : #'read/write usage' }
+{ #category : 'read/write usage' }
 LocalVariable >> isRead [
 	^usage = #read
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LocalVariable >> isReferenced [
 	^ self isUsed
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LocalVariable >> isRemote [
 	^false
 ]
 
-{ #category : #'read/write usage' }
+{ #category : 'read/write usage' }
 LocalVariable >> isRepeatedWrite [
 	^usage = #repeatedWrite
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LocalVariable >> isStoringTempVector [
 	"I am a temp that stores a temp vector. Those generated temps have a invalid name starting with 0"
 	^name first = $0
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LocalVariable >> isTempVectorTemp [
 	^false
 ]
 
-{ #category : #'read/write usage' }
+{ #category : 'read/write usage' }
 LocalVariable >> isUninitialized [
 
 	^ self isWrite not
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 LocalVariable >> isUsed [
 	"when the var is never read or written, it is not used"
 	^ usage isNotNil
 ]
 
-{ #category : #'read/write usage' }
+{ #category : 'read/write usage' }
 LocalVariable >> isWrite [
 	^ usage = #write or: [ self isRepeatedWrite ]
 ]
 
-{ #category : #escaping }
+{ #category : 'escaping' }
 LocalVariable >> markEscapingRead [
 	escaping = #escapingWrite ifFalse: [escaping := #escapingRead]
 ]
 
-{ #category : #escaping }
+{ #category : 'escaping' }
 LocalVariable >> markEscapingWrite [
 	escaping := #escapingWrite.
 	self isRepeatedWrite ifFalse: [usage := #write]
 ]
 
-{ #category : #'read/write usage' }
+{ #category : 'read/write usage' }
 LocalVariable >> markRead [
 	"reading does not change a #write, nor an #arg"
 	usage ifNil: [usage := #read]
 ]
 
-{ #category : #escaping }
+{ #category : 'escaping' }
 LocalVariable >> markRepeatedWrite [
 	"same as write"
 	self markWrite.
 	usage := #repeatedWrite
 ]
 
-{ #category : #escaping }
+{ #category : 'escaping' }
 LocalVariable >> markWrite [
 
 	"if an escaping var is wrote to later, it needs to be remote"
@@ -240,31 +242,31 @@ LocalVariable >> markWrite [
 	usage := #write
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 LocalVariable >> method [
 	^scope node methodNode compiledMethod
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 LocalVariable >> printOn: stream [
 
 	stream nextPutAll: self name
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 LocalVariable >> readFromContext: aContext scope: contextScope [
 	| definitionContext |
 	definitionContext := contextScope lookupDefiningContextForVariable: self startingFrom: aContext.
 	^ self readFromLocalContext: definitionContext
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 LocalVariable >> readFromLocalContext: aContext [
 
 	^ aContext tempAt: self index
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 LocalVariable >> readInContext: aContext [
 
 	| contextScope |
@@ -272,43 +274,43 @@ LocalVariable >> readInContext: aContext [
 	^self readFromContext: aContext scope: contextScope
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LocalVariable >> scope [
 	"this is the scope that the variable is declared in"
 	^ scope
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 LocalVariable >> scope: aLexicalScope [
 
 	scope := aLexicalScope
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LocalVariable >> usage [
 
 	^ usage
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 LocalVariable >> usage: anObject [
 
 	usage := anObject
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 LocalVariable >> usingMethods [
 
 	^ self isUsed ifTrue: [ { self method } ] ifFalse: [ #(  ) ]
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 LocalVariable >> write: aValue inContext: aContext [
 
 	^self writeFromContext: aContext scope: aContext astScope value: aValue
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 LocalVariable >> writeFromContext: aContext scope: contextScope value: aValue [
 
 	| definitionContext |
@@ -316,7 +318,7 @@ LocalVariable >> writeFromContext: aContext scope: contextScope value: aValue [
 	^self writeFromLocalContext: definitionContext put: aValue
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 LocalVariable >> writeFromLocalContext: aContext put: aValue [
 
 	^ aContext tempAt: self index put: aValue

--- a/src/OpalCompiler-Core/ManifestOpalCompilerCore.class.st
+++ b/src/OpalCompiler-Core/ManifestOpalCompilerCore.class.st
@@ -1,55 +1,57 @@
 Class {
-	#name : #ManifestOpalCompilerCore,
-	#superclass : #PackageManifest,
-	#category : #'OpalCompiler-Core-Manifest'
+	#name : 'ManifestOpalCompilerCore',
+	#superclass : 'PackageManifest',
+	#category : 'OpalCompiler-Core-Manifest',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Manifest'
 }
 
-{ #category : #'meta-data - dependency analyser' }
+{ #category : 'meta-data - dependency analyser' }
 ManifestOpalCompilerCore class >> ignoredDependencies [
 	^ #(#'Morphic-Base' #'System-Settings-Core')
 ]
 
-{ #category : #'meta-data - dependency analyser' }
+{ #category : 'meta-data - dependency analyser' }
 ManifestOpalCompilerCore class >> manuallyResolvedDependencies [
 	^ #(#'Morphic-Base' #'System-Settings-Core' #CodeExport #'System-Announcements' #'System-Sources')
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestOpalCompilerCore class >> rejectRules [
 ^ #('SearchingLiteralRule' 'ExcessiveArgumentsRule' 'LongMethodsRule' 'ClassInstVarNotInitializedRule' 'UsesAddRule' 'ExcessiveMethodsRule' 'MissingYourselfRule' 'ExcessiveVariablesRule' 'TempsReadBeforeWrittenRule' 'AbstractClassRule' 'IfTrueReturnsRule')
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestOpalCompilerCore class >> ruleAssignmentInIfTrueRuleV1TruePositive [
 ^ #(#(#(#RGMethodDefinition #(#OpalCompiler #from:class:context:notifying: #false)) #'2012-12-18T17:43:24.703000001+01:00') )
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestOpalCompilerCore class >> ruleBadMessageRuleV1FalsePositive [
 ^ #(#(#(#RGMethodDefinition #(#OCASTTranslator #initialize #false)) #'2013-05-23T08:43:44.793471+02:00') #(#(#RGMethodDefinition #(#OCASTTranslator #emitCaseOf: #false)) #'2013-05-23T08:43:44.793471+02:00') #(#(#RGMethodDefinition #(#OpalCompiler #evaluate #false)) #'2013-05-23T08:43:44.793471+02:00') )
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestOpalCompilerCore class >> ruleClassNotReferencedRuleV1FalsePositive [
 	^ #(#(#(#RGClassDefinition #(#OpalEncoderForLongFormV3PlusClosures)) #'2015-08-17T13:55:18.528985+02:00') )
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestOpalCompilerCore class >> ruleImplementedNotSentRuleV1FalsePositive [
 	^ #(#(#(#RGMethodDefinition #(#OCASTTranslatorForEffect #emitIfFalse: #false)) #'2012-12-18T17:41:36.969+01:00') #(#(#RGMethodDefinition #(#OCASTTranslatorForEffect #emitIfTrue: #false)) #'2012-12-18T17:41:39.446+01:00') #(#(#RGMethodDefinition #(#OCASTTranslator #emitCaseOf: #false)) #'2012-12-18T17:42:01.724+01:00') #(#(#RGMethodDefinition #(#OCASTTranslator #emitToByDo: #false)) #'2012-12-18T17:42:03.557+01:00') #(#(#RGMethodDefinition #(#OCASTTranslator #emitToDo: #false)) #'2012-12-18T17:42:05.34+01:00') #(#(#RGMethodDefinition #(#OCASTTranslator #emitIfNotNil: #false)) #'2012-12-18T17:42:07.349+01:00') #(#(#RGMethodDefinition #(#OCASTTranslator #emitIfNil: #false)) #'2012-12-18T17:42:09.472+01:00') #(#(#RGMethodDefinition #(#OCASTTranslator #emitCaseOfOtherwise: #false)) #'2012-12-18T17:42:11.795+01:00') #(#(#RGMethodDefinition #(#BytecodeEncoder #sizeCallPrimitive: #false)) #'2015-08-17T13:56:21.549128+02:00') )
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestOpalCompilerCore class >> ruleTempsReadBeforeWrittenRuleV1FalsePositive [
 ^ #(#(#(#RGMethodDefinition #(#IRSequence #absorbJumpToSingleInstr: #false)) #'2012-12-19T08:10:39.177+01:00') )
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestOpalCompilerCore class >> ruleToDoCollectRuleV1FalsePositive [
 ^ #(#(#(#RGMethodDefinition #(#IRBytecodeScope #args #false)) #'2012-12-19T08:16:58.474000001+01:00') #(#(#RGMethodDefinition #(#IRBytecodeScope #temps #false)) #'2012-12-19T08:17:19.677+01:00') )
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestOpalCompilerCore class >> ruleVariableAssignedLiteralRuleV1FalsePositive [
 ^ #(#(#(#RGClassDefinition #(#IRMethod)) #'2012-12-19T08:13:54.508+01:00') )
 ]

--- a/src/OpalCompiler-Core/Metaclass.extension.st
+++ b/src/OpalCompiler-Core/Metaclass.extension.st
@@ -1,12 +1,12 @@
-Extension { #name : #Metaclass }
+Extension { #name : 'Metaclass' }
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Metaclass >> compiler [
 	"The compiler is defined on instance-side to be able to customize it for *one* metaclass"
 	^ self instanceSide classSideCompiler
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Metaclass >> compilerClass [
 	"The compiler class is defined on instance-side to be able to customize it for *one* metaclass"
 	^ self instanceSide classSideCompilerClass

--- a/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
@@ -2,15 +2,17 @@
 I visit the AST of method a second time (after OCASTSemanticAnalyzer) to analyze temps related to closures.
 "
 Class {
-	#name : #OCASTClosureAnalyzer,
-	#superclass : #RBProgramNodeVisitor,
+	#name : 'OCASTClosureAnalyzer',
+	#superclass : 'RBProgramNodeVisitor',
 	#instVars : [
 		'scope'
 	],
-	#category : #'OpalCompiler-Core-Semantics'
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
 }
 
-{ #category : #variables }
+{ #category : 'variables' }
 OCASTClosureAnalyzer >> lookupAndFixBinding: aVariableNode [
 	| var |
 	var := scope lookupVar: aVariableNode name.
@@ -18,12 +20,12 @@ OCASTClosureAnalyzer >> lookupAndFixBinding: aVariableNode [
 	^var
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 OCASTClosureAnalyzer >> visitArgumentNode: aVariableNode [
 	"nothing to do for arguments"
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 OCASTClosureAnalyzer >> visitBlockNode: aBlockNode [
 	"here look at the temps and make copying vars / tempVector out of them"
 	self visitArgumentNodes: aBlockNode arguments.
@@ -35,7 +37,7 @@ OCASTClosureAnalyzer >> visitBlockNode: aBlockNode [
 	scope := scope popScope
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 OCASTClosureAnalyzer >> visitLocalVariableNode: aVariableNode [
 	"re-lookup local variables..."
 	| var |
@@ -46,7 +48,7 @@ OCASTClosureAnalyzer >> visitLocalVariableNode: aVariableNode [
 	var isCopying ifTrue: [scope addCopyingTempToAllScopesUpToDefTemp: var]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 OCASTClosureAnalyzer >> visitMethodNode: aMethodNode [
 	"here look at the temps and make copying vars / tempVector out of them"
 	self visitArgumentNodes: aMethodNode arguments.

--- a/src/OpalCompiler-Core/OCASTCompilerPlugin.class.st
+++ b/src/OpalCompiler-Core/OCASTCompilerPlugin.class.st
@@ -20,31 +20,33 @@ They are sorted by #priority and handed the AST without making a copy (as plugin
 
 "
 Class {
-	#name : #OCASTCompilerPlugin,
-	#superclass : #Object,
-	#category : #'OpalCompiler-Core-Plugins'
+	#name : 'OCASTCompilerPlugin',
+	#superclass : 'Object',
+	#category : 'OpalCompiler-Core-Plugins',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Plugins'
 }
 
-{ #category : #'accessing - defaults' }
+{ #category : 'accessing - defaults' }
 OCASTCompilerPlugin class >> defaultPriority [
 	"Use a high priority by default (a priority of 0 would be used by Reflectivity to be the last)"
 
 	^ 100
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCASTCompilerPlugin class >> isAbstract [
 
 	^ self == OCASTCompilerPlugin
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCASTCompilerPlugin >> priority [
 
 	^ self class defaultPriority
 ]
 
-{ #category : #transforming }
+{ #category : 'transforming' }
 OCASTCompilerPlugin >> transform: ast [
 
 	self subclassResponsibility

--- a/src/OpalCompiler-Core/OCASTMethodMetadataAnalyser.class.st
+++ b/src/OpalCompiler-Core/OCASTMethodMetadataAnalyser.class.st
@@ -5,12 +5,14 @@ compild method.
 One example are methods that contains message send that is a #halt (and any of it's variations)
 "
 Class {
-	#name : #OCASTMethodMetadataAnalyser,
-	#superclass : #RBProgramNodeVisitor,
-	#category : #'OpalCompiler-Core-Semantics'
+	#name : 'OCASTMethodMetadataAnalyser',
+	#superclass : 'RBProgramNodeVisitor',
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 OCASTMethodMetadataAnalyser >> visitMessageNode: aNode [
 
 	super visitMessageNode: aNode.

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -3,8 +3,8 @@ I visit each node in the abstract syntax tree while growing and shrinking a scop
 
 "
 Class {
-	#name : #OCASTSemanticAnalyzer,
-	#superclass : #RBProgramNodeVisitor,
+	#name : 'OCASTSemanticAnalyzer',
+	#superclass : 'RBProgramNodeVisitor',
 	#instVars : [
 		'scope',
 		'outerScope',
@@ -13,10 +13,12 @@ Class {
 		'undeclared',
 		'invalidVariables'
 	],
-	#category : #'OpalCompiler-Core-Semantics'
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
 }
 
-{ #category : #api }
+{ #category : 'api' }
 OCASTSemanticAnalyzer >> analyze: aNode [
 
 	self visitNode: aNode.
@@ -24,7 +26,7 @@ OCASTSemanticAnalyzer >> analyze: aNode [
 	OCASTMethodMetadataAnalyser new visitNode: aNode
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 OCASTSemanticAnalyzer >> analyzeLocalVariableRead: aLocalVariable [
 	aLocalVariable markRead.
 	(aLocalVariable scope outerNotOptimizedScope ~= scope outerNotOptimizedScope ) ifFalse: [ ^self ].
@@ -35,7 +37,7 @@ OCASTSemanticAnalyzer >> analyzeLocalVariableRead: aLocalVariable [
 				ifTrue: [aLocalVariable markEscapingWrite]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 OCASTSemanticAnalyzer >> analyzeLocalVariableWrite: aLocalVariable [
 	(aLocalVariable scope outerNotOptimizedScope ~= scope outerNotOptimizedScope)
 	"only escaping when they will end up in different closures"
@@ -46,27 +48,27 @@ OCASTSemanticAnalyzer >> analyzeLocalVariableWrite: aLocalVariable [
 					ifFalse: [ aLocalVariable markWrite ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCASTSemanticAnalyzer >> blockCounter [
 	^blockCounter ifNil: [0]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCASTSemanticAnalyzer >> compilationContext [
 	^ compilationContext
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCASTSemanticAnalyzer >> compilationContext: aCompilationContext [
 	compilationContext := aCompilationContext
 ]
 
-{ #category : #variables }
+{ #category : 'variables' }
 OCASTSemanticAnalyzer >> declareArgumentNode: aVariableNode [
 	^self declareVariableNode: aVariableNode as: (ArgumentVariable named: aVariableNode name)
 ]
 
-{ #category : #variables }
+{ #category : 'variables' }
 OCASTSemanticAnalyzer >> declareInvalidVariableNode: aVariableNode [
 
 	| var |
@@ -78,12 +80,12 @@ OCASTSemanticAnalyzer >> declareInvalidVariableNode: aVariableNode [
 	aVariableNode binding: var
 ]
 
-{ #category : #variables }
+{ #category : 'variables' }
 OCASTSemanticAnalyzer >> declareTemporaryNode: aVariableNode [
 	^self declareVariableNode: aVariableNode as: (TemporaryVariable named: aVariableNode name)
 ]
 
-{ #category : #variables }
+{ #category : 'variables' }
 OCASTSemanticAnalyzer >> declareVariableNode: aVariableNode as: anOCTempVariable [
 	| name var shadowing |
 	name := aVariableNode name.
@@ -95,24 +97,24 @@ OCASTSemanticAnalyzer >> declareVariableNode: aVariableNode as: anOCTempVariable
 	^ var
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCASTSemanticAnalyzer >> invalidVariables [
 	^ invalidVariables ifNil: [ invalidVariables := Dictionary new ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCASTSemanticAnalyzer >> outerScope [
 
 	^ outerScope
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCASTSemanticAnalyzer >> outerScope: anObject [
 
 	outerScope := anObject
 ]
 
-{ #category : #variables }
+{ #category : 'variables' }
 OCASTSemanticAnalyzer >> resolveVariableNode: aVariableNode [
 	| var |
 	var := (scope lookupVar: aVariableNode name)
@@ -121,30 +123,30 @@ OCASTSemanticAnalyzer >> resolveVariableNode: aVariableNode [
 	^var
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 OCASTSemanticAnalyzer >> scope: aSemScope [
 	scope := aSemScope
 ]
 
-{ #category : #'error handling' }
+{ #category : 'error handling' }
 OCASTSemanticAnalyzer >> shadowing: var withVariable: aNode [
 
 	aNode addWarning: 'Name already defined'
 ]
 
-{ #category : #'error handling' }
+{ #category : 'error handling' }
 OCASTSemanticAnalyzer >> storeIntoReadOnlyVariable: variableNode [
 
 	variableNode addError: 'Assignment to read-only variable'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCASTSemanticAnalyzer >> undeclared [
 
 	^ undeclared ifNil: [ undeclared := Dictionary new ]
 ]
 
-{ #category : #'error handling' }
+{ #category : 'error handling' }
 OCASTSemanticAnalyzer >> undeclaredVariable: variableNode [
 
 	| varName var notice |
@@ -165,18 +167,18 @@ OCASTSemanticAnalyzer >> undeclaredVariable: variableNode [
 	^ var
 ]
 
-{ #category : #'error handling' }
+{ #category : 'error handling' }
 OCASTSemanticAnalyzer >> uninitializedVariable: variableNode [
 	variableNode addWarning: 'Unitialized variable'
 ]
 
-{ #category : #'error handling' }
+{ #category : 'error handling' }
 OCASTSemanticAnalyzer >> unusedVariable: variableNode [
 
 	variableNode addWarning: 'Unused variable'
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 OCASTSemanticAnalyzer >> visitAnnotationMarkNode: aRBAnnotationValueNode [
 
 	(aRBAnnotationValueNode parent isNotNil and: [
@@ -187,7 +189,7 @@ OCASTSemanticAnalyzer >> visitAnnotationMarkNode: aRBAnnotationValueNode [
 	aRBAnnotationValueNode addError: 'Unexpected token'
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 OCASTSemanticAnalyzer >> visitAssignmentNode: anAssignmentNode [
 	| var |
 	self visitNode: anAssignmentNode value.
@@ -196,7 +198,7 @@ OCASTSemanticAnalyzer >> visitAssignmentNode: anAssignmentNode [
 	var analyzeWrite: anAssignmentNode variable by: self
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 OCASTSemanticAnalyzer >> visitBlockNode: aBlockNode [
 	aBlockNode arguments size >15 ifTrue: [ aBlockNode addError: 'Too many arguments' ].
 
@@ -211,7 +213,7 @@ OCASTSemanticAnalyzer >> visitBlockNode: aBlockNode [
 	scope := scope popScope
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 OCASTSemanticAnalyzer >> visitEnglobingErrorNode: aNode [
 	"There is bad arguments or variable, just invalidate them to avoid noisy useless errors/warnings.
 	Because, AST is very wrong with possible missing or superfluous [ or ], we should not believe in scope.
@@ -223,7 +225,7 @@ OCASTSemanticAnalyzer >> visitEnglobingErrorNode: aNode [
 	^ super visitEnglobingErrorNode: aNode
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 OCASTSemanticAnalyzer >> visitInlinedBlockNode: aBlockNode [
 
 	scope := scope newOptimizedBlockScope: blockCounter.
@@ -234,14 +236,14 @@ OCASTSemanticAnalyzer >> visitInlinedBlockNode: aBlockNode [
 	scope := scope popScope
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 OCASTSemanticAnalyzer >> visitMessageNode: aMessageNode [
 	
 	super visitMessageNode: aMessageNode.
 	aMessageNode isSuperSend ifTrue: [ aMessageNode superOf: scope targetClass ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 OCASTSemanticAnalyzer >> visitMethodNode: aMethodNode [
 
 	aMethodNode arguments size > 15 ifTrue: [ aMethodNode addError:  'Too many arguments' ].
@@ -253,7 +255,7 @@ OCASTSemanticAnalyzer >> visitMethodNode: aMethodNode [
 	self visitNode: aMethodNode body
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 OCASTSemanticAnalyzer >> visitPragmaNode: aPragmaNode [
 
 	| varNode |
@@ -269,7 +271,7 @@ OCASTSemanticAnalyzer >> visitPragmaNode: aPragmaNode [
 	self declareVariableNode: varNode as: (PrimitiveErrorVariable node: varNode)
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 OCASTSemanticAnalyzer >> visitSequenceNode: aSequenceNode [
 
 	aSequenceNode temporaries do: [ :node | self declareTemporaryNode: node ].
@@ -279,7 +281,7 @@ OCASTSemanticAnalyzer >> visitSequenceNode: aSequenceNode [
 				ifFalse: [ self unusedVariable: node ] ]
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 OCASTSemanticAnalyzer >> visitVariableNode: aVariableNode [
 	| var |
 	var := self resolveVariableNode: aVariableNode.

--- a/src/OpalCompiler-Core/OCASTSemanticCleaner.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticCleaner.class.st
@@ -5,30 +5,32 @@ I am cleaning the semantic analysis of the AST.
 -> binding from Variables
 "
 Class {
-	#name : #OCASTSemanticCleaner,
-	#superclass : #RBProgramNodeVisitor,
-	#category : #'OpalCompiler-Core-Semantics'
+	#name : 'OCASTSemanticCleaner',
+	#superclass : 'RBProgramNodeVisitor',
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
 }
 
-{ #category : #api }
+{ #category : 'api' }
 OCASTSemanticCleaner class >> clean: aMethodNode [
 	self new visitNode: aMethodNode.
 	^aMethodNode
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 OCASTSemanticCleaner >> visitBlockNode: aBlockNode [
 	aBlockNode removeProperty: #scope ifAbsent: [ ].
 	super visitBlockNode: aBlockNode
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 OCASTSemanticCleaner >> visitMethodNode: aMethodNode [
 	aMethodNode removeProperty: #scope ifAbsent: [ ].
 	super visitMethodNode: aMethodNode
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 OCASTSemanticCleaner >> visitVariableNode: aVariableNode [
 	aVariableNode variable: UnresolvedVariable instance
 ]

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -15,8 +15,8 @@ Whereas, in #visitMethodNode:,  the effectTranslator is used, because no value i
 
 "
 Class {
-	#name : #OCASTTranslator,
-	#superclass : #RBProgramNodeVisitor,
+	#name : 'OCASTTranslator',
+	#superclass : 'RBProgramNodeVisitor',
 	#instVars : [
 		'methodBuilder',
 		'nextUniqueInlineID'
@@ -24,10 +24,12 @@ Class {
 	#classVars : [
 		'OptimizedMessages'
 	],
-	#category : #'OpalCompiler-Core-Translator'
+	#category : 'OpalCompiler-Core-Translator',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Translator'
 }
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 OCASTTranslator class >> initialize [
 
 	OptimizedMessages := {
@@ -53,17 +55,17 @@ OCASTTranslator class >> initialize [
 		                     (#whileTrue -> #emitWhileTrue:) } asDictionary
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCASTTranslator >> compilationContext [
 	^methodBuilder compilationContext
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCASTTranslator >> compilationContext: anObject [
 	methodBuilder compilationContext: anObject
 ]
 
-{ #category : #'inline messages factored' }
+{ #category : 'inline messages factored' }
 OCASTTranslator >> emitAllButLastCases: cases [
 
 	|  assocMessageNode  |
@@ -81,7 +83,7 @@ OCASTTranslator >> emitAllButLastCases: cases [
 	]
 ]
 
-{ #category : #'inline messages' }
+{ #category : 'inline messages' }
 OCASTTranslator >> emitAnd: aMessageNode [
 
 	self visitNode: aMessageNode receiver.
@@ -93,7 +95,7 @@ OCASTTranslator >> emitAnd: aMessageNode [
 	methodBuilder jumpAheadTarget: #end
 ]
 
-{ #category : #'inline messages' }
+{ #category : 'inline messages' }
 OCASTTranslator >> emitCaseOf: aMessageNode [
 
 	self
@@ -103,7 +105,7 @@ OCASTTranslator >> emitCaseOf: aMessageNode [
 			methodBuilder send: #caseError ]
 ]
 
-{ #category : #'inline messages factored' }
+{ #category : 'inline messages factored' }
 OCASTTranslator >> emitCaseOf: aMessageNode otherwiseBlock: aBlock [
 
 	| cases assocMessageNode  |
@@ -131,7 +133,7 @@ OCASTTranslator >> emitCaseOf: aMessageNode otherwiseBlock: aBlock [
 				ifFalse: [methodBuilder returnTop]]
 ]
 
-{ #category : #'inline messages' }
+{ #category : 'inline messages' }
 OCASTTranslator >> emitCaseOfOtherwise: aMessageNode [
 
 	self
@@ -139,7 +141,7 @@ OCASTTranslator >> emitCaseOfOtherwise: aMessageNode [
 		otherwiseBlock: [ self visitInlinedBlockNode: aMessageNode arguments last ]
 ]
 
-{ #category : #'inline messages factored' }
+{ #category : 'inline messages factored' }
 OCASTTranslator >> emitCondition: args boolean: aBoolean [
 	"emits the jumps so that one of the 2 blocks in args is evaluated depending on boolean"
 
@@ -151,7 +153,7 @@ OCASTTranslator >> emitCondition: args boolean: aBoolean [
 	methodBuilder jumpAheadTarget: #end
 ]
 
-{ #category : #'inline messages factored' }
+{ #category : 'inline messages factored' }
 OCASTTranslator >> emitIf: aMessageNode boolean: aBoolean [
 
 	self visitNode: aMessageNode receiver.
@@ -159,7 +161,7 @@ OCASTTranslator >> emitIf: aMessageNode boolean: aBoolean [
 	self emitCondition: aMessageNode arguments boolean: aBoolean
 ]
 
-{ #category : #'inline messages' }
+{ #category : 'inline messages' }
 OCASTTranslator >> emitIfFalse: aMessageNode [
 
 	self visitNode: aMessageNode receiver.
@@ -171,13 +173,13 @@ OCASTTranslator >> emitIfFalse: aMessageNode [
 	methodBuilder jumpAheadTarget: #end
 ]
 
-{ #category : #'inline messages' }
+{ #category : 'inline messages' }
 OCASTTranslator >> emitIfFalseIfTrue: aMessageNode [
 
 	self emitIf: aMessageNode boolean: true
 ]
 
-{ #category : #'inline messages' }
+{ #category : 'inline messages' }
 OCASTTranslator >> emitIfNil: aMessageNode [
 
 	self visitNode: aMessageNode receiver.
@@ -190,7 +192,7 @@ OCASTTranslator >> emitIfNil: aMessageNode [
 	methodBuilder jumpAheadTarget: #else
 ]
 
-{ #category : #'inline messages factored' }
+{ #category : 'inline messages factored' }
 OCASTTranslator >> emitIfNil: aMessageNode boolean: aBoolean [
 	| args notNilBlock |
 
@@ -206,12 +208,12 @@ OCASTTranslator >> emitIfNil: aMessageNode boolean: aBoolean [
 	self emitCondition: args boolean: aBoolean
 ]
 
-{ #category : #'inline messages' }
+{ #category : 'inline messages' }
 OCASTTranslator >> emitIfNilIfNotNil: aMessageNode [
 	self emitIfNil: aMessageNode boolean: false
 ]
 
-{ #category : #'inline messages' }
+{ #category : 'inline messages' }
 OCASTTranslator >> emitIfNotNil: aMessageNode [
 	| args |
 	self visitNode: aMessageNode receiver.
@@ -226,12 +228,12 @@ OCASTTranslator >> emitIfNotNil: aMessageNode [
 	methodBuilder jumpAheadTarget: #end
 ]
 
-{ #category : #'inline messages' }
+{ #category : 'inline messages' }
 OCASTTranslator >> emitIfNotNilIfNil: aMessageNode [
 	self emitIfNil: aMessageNode boolean: true
 ]
 
-{ #category : #'inline messages' }
+{ #category : 'inline messages' }
 OCASTTranslator >> emitIfTrue: aMessageNode [
 
 	self visitNode: aMessageNode receiver.
@@ -243,13 +245,13 @@ OCASTTranslator >> emitIfTrue: aMessageNode [
 	methodBuilder jumpAheadTarget: #end
 ]
 
-{ #category : #'inline messages' }
+{ #category : 'inline messages' }
 OCASTTranslator >> emitIfTrueIfFalse: aMessageNode [
 
 	self emitIf: aMessageNode boolean: false
 ]
 
-{ #category : #'visitor - double dispatching' }
+{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> emitMessageNode: aMessageNode [
 
 	aMessageNode isCascaded ifFalse: [
@@ -261,7 +263,7 @@ OCASTTranslator >> emitMessageNode: aMessageNode [
 		ifFalse: [methodBuilder send: aMessageNode selector]
 ]
 
-{ #category : #'inline messages' }
+{ #category : 'inline messages' }
 OCASTTranslator >> emitOr: aMessageNode [
 
 	self visitNode: aMessageNode receiver.
@@ -273,7 +275,7 @@ OCASTTranslator >> emitOr: aMessageNode [
 	methodBuilder jumpAheadTarget: #end
 ]
 
-{ #category : #'inline messages' }
+{ #category : 'inline messages' }
 OCASTTranslator >> emitRepeat: aMessageNode [
 	| block |
 	block := aMessageNode receiver.
@@ -283,7 +285,7 @@ OCASTTranslator >> emitRepeat: aMessageNode [
 	methodBuilder pushLiteral: nil
 ]
 
-{ #category : #errors }
+{ #category : 'errors' }
 OCASTTranslator >> emitRuntimeError: aNode [
 	"Runtime errors should only be emited on faulty code"
 
@@ -298,7 +300,7 @@ OCASTTranslator >> emitRuntimeError: aNode [
 		send: #signalSyntaxError:
 ]
 
-{ #category : #'inline messages' }
+{ #category : 'inline messages' }
 OCASTTranslator >> emitTimesRepeat: aMessageNode [
 
 	| limit block limitEmit limitVariableName iteratorVariableName uniqueInlineID startLabelName doneLabelName |
@@ -343,7 +345,7 @@ OCASTTranslator >> emitTimesRepeat: aMessageNode [
 	methodBuilder jumpAheadTarget: doneLabelName
 ]
 
-{ #category : #'inline messages' }
+{ #category : 'inline messages' }
 OCASTTranslator >> emitToByDo: aMessageNode [
 
 	| step |
@@ -355,13 +357,13 @@ OCASTTranslator >> emitToByDo: aMessageNode [
 	self emitToDo: aMessageNode step: step
 ]
 
-{ #category : #'inline messages' }
+{ #category : 'inline messages' }
 OCASTTranslator >> emitToDo: aMessageNode [
 
 	self emitToDo: aMessageNode step: 1
 ]
 
-{ #category : #'inline messages factored' }
+{ #category : 'inline messages factored' }
 OCASTTranslator >> emitToDo: aMessageNode step: step [
 	| limit block iterator limitEmit |
 
@@ -397,7 +399,7 @@ OCASTTranslator >> emitToDo: aMessageNode step: step [
 	methodBuilder jumpAheadTarget: #done
 ]
 
-{ #category : #'inline messages factored' }
+{ #category : 'inline messages factored' }
 OCASTTranslator >> emitWhile: aMessageNode boolean: aBoolean [
 
 	methodBuilder jumpBackTarget: #begin.
@@ -410,19 +412,19 @@ OCASTTranslator >> emitWhile: aMessageNode boolean: aBoolean [
 	methodBuilder pushLiteral: nil
 ]
 
-{ #category : #'inline messages' }
+{ #category : 'inline messages' }
 OCASTTranslator >> emitWhileFalse: aMessageNode [
 
 	self emitWhile: aMessageNode boolean: true
 ]
 
-{ #category : #'inline messages' }
+{ #category : 'inline messages' }
 OCASTTranslator >> emitWhileTrue: aMessageNode [
 
 	self emitWhile: aMessageNode boolean: false
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 OCASTTranslator >> initialize [
 
 	super initialize.
@@ -431,32 +433,32 @@ OCASTTranslator >> initialize [
 	nextUniqueInlineID := 0
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCASTTranslator >> ir [
 
 	^ methodBuilder ir
 ]
 
-{ #category : #'inline messages' }
+{ #category : 'inline messages' }
 OCASTTranslator >> nextUniqueInlineID [
 
 	nextUniqueInlineID := nextUniqueInlineID + 1.
 	^ '0', nextUniqueInlineID asString asSymbol
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 OCASTTranslator >> privateMethodBuilder [
 	^ methodBuilder
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 OCASTTranslator >> subTranslator [
 	"Return a new translator that can be used on blocks"
 
 	^ self compilationContext astTranslatorClass new compilationContext: self compilationContext
 ]
 
-{ #category : #'visitor - double dispatching' }
+{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> translateConstantBlock: aBlockNode [
 	| ir |
 	"even though we never execute the compiledBlock, we create it so that the BlockClosure can use e.g. to query on the bytecode level"
@@ -471,7 +473,7 @@ OCASTTranslator >> translateConstantBlock: aBlockNode [
 	^ ir compiledBlock: aBlockNode scope
 ]
 
-{ #category : #'visitor - double dispatching' }
+{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> translateFullBlock: aBlockNode [
 
 	methodBuilder mapToNode: aBlockNode.
@@ -495,13 +497,13 @@ OCASTTranslator >> translateFullBlock: aBlockNode [
 	^ aBlockNode ir compiledBlock: aBlockNode scope
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 OCASTTranslator >> visitAnnotationMarkNode: aRBAnnotationValueNode [
 
 	self emitRuntimeError: aRBAnnotationValueNode
 ]
 
-{ #category : #'visitor - double dispatching' }
+{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> visitArrayNode: anArrayNode [
 
 	| elementNodes |
@@ -513,7 +515,7 @@ OCASTTranslator >> visitArrayNode: anArrayNode [
 	methodBuilder pushConsArray: elementNodes size
 ]
 
-{ #category : #'visitor - double dispatching' }
+{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> visitAssignmentNode: anAssignmentNode [
 
 	| var |
@@ -531,7 +533,7 @@ OCASTTranslator >> visitAssignmentNode: anAssignmentNode [
 	var emitStore: methodBuilder
 ]
 
-{ #category : #'visitor - double dispatching' }
+{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> visitBlockNode: aBlockNode [
 	| compiledBlock |
 	aBlockNode isError ifTrue: [ ^ self emitRuntimeError: aBlockNode ].
@@ -547,7 +549,7 @@ OCASTTranslator >> visitBlockNode: aBlockNode [
 		ifFalse: [ methodBuilder pushFullClosureCompiledBlock: compiledBlock copiedValues: aBlockNode scope inComingCopiedVarNames ]
 ]
 
-{ #category : #'visitor - double dispatching' }
+{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> visitCascadeNode: aCascadeNode [
 
 	self visitNode: aCascadeNode receiver.
@@ -558,7 +560,7 @@ OCASTTranslator >> visitCascadeNode: aCascadeNode [
 	self visitNode: aCascadeNode messages last
 ]
 
-{ #category : #'visitor - double dispatching' }
+{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> visitCleanBlockNode: aBlockNode [
 	"create and push a clean blockclosure. As we create the clean block at compile time,
 	block creation at runtime is much faster than that of a full block"
@@ -571,7 +573,7 @@ OCASTTranslator >> visitCleanBlockNode: aBlockNode [
 	methodBuilder pushLiteral: cleanBlock
 ]
 
-{ #category : #'visitor - double dispatching' }
+{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> visitConstantBlockNode: anBlockNode [
 	"create statically a constant blockclosure (we support 0-3 arguments).
 	Constant blockclosures are specialized clean blocks: same creation speed, but faster execution"
@@ -584,7 +586,7 @@ OCASTTranslator >> visitConstantBlockNode: anBlockNode [
 	methodBuilder pushLiteral: constantBlock
 ]
 
-{ #category : #'visitor - double dispatching' }
+{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> visitEffectInlinedBlockNode: anOptimizedBlockNode [
 
 	self visitInlinedBlockNode: anOptimizedBlockNode.
@@ -594,7 +596,7 @@ OCASTTranslator >> visitEffectInlinedBlockNode: anOptimizedBlockNode [
 	methodBuilder popMap
 ]
 
-{ #category : #'visitor - double dispatching' }
+{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> visitEffectNode: aNode [
 
 	self visitNode: aNode.
@@ -604,13 +606,13 @@ OCASTTranslator >> visitEffectNode: aNode [
 	methodBuilder popMap
 ]
 
-{ #category : #'visitor - double dispatching' }
+{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> visitEnglobingErrorNode: anErrorNode [
 	"raise error at runtime"
 	self visitParseErrorNode: anErrorNode
 ]
 
-{ #category : #'visitor - double dispatching' }
+{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> visitInlinedBlockNode: anOptimizedBlockNode [
 
 	"We are visiting a scope that is not a block, but inlined in the outer context.
@@ -639,7 +641,7 @@ OCASTTranslator >> visitInlinedBlockNode: anOptimizedBlockNode [
 	methodBuilder popMap
 ]
 
-{ #category : #'visitor - double dispatching' }
+{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> visitLargeArrayNode: aRBArrayNode [
 	"Long form: generates (Array braceStream: N) nextPut: a; nextPut: b; ...; braceArray"
 	methodBuilder pushLiteralVariable: Array binding.
@@ -654,19 +656,19 @@ OCASTTranslator >> visitLargeArrayNode: aRBArrayNode [
 	methodBuilder send: #braceArray
 ]
 
-{ #category : #'visitor - double dispatching' }
+{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> visitLiteralArrayNode: aRBLiteralArrayNode [
 
 	methodBuilder pushLiteral: aRBLiteralArrayNode value
 ]
 
-{ #category : #'visitor - double dispatching' }
+{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> visitLiteralNode: aLiteralNode [
 
 	methodBuilder pushLiteral: aLiteralNode value
 ]
 
-{ #category : #'visitor - double dispatching' }
+{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> visitMessageNode: aMessageNode [
 
 	aMessageNode isAnnotation ifTrue: [
@@ -680,7 +682,7 @@ OCASTTranslator >> visitMessageNode: aMessageNode [
 	^ self emitMessageNode: aMessageNode
 ]
 
-{ #category : #'visitor - double dispatching' }
+{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> visitMethodNode: aMethodNode [
 
 	aMethodNode isError ifTrue: [self emitRuntimeError: aMethodNode ].
@@ -710,20 +712,20 @@ OCASTTranslator >> visitMethodNode: aMethodNode [
 				methodBuilder pushReceiver; returnTop ] ]
 ]
 
-{ #category : #'visitor - double dispatching' }
+{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> visitNode: aNode [
 	methodBuilder mapToNode: aNode.
 	super visitNode: aNode.
 	methodBuilder popMap
 ]
 
-{ #category : #'visitor - double dispatching' }
+{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> visitParseErrorNode: anErrorNode [
 
 	self emitRuntimeError: anErrorNode
 ]
 
-{ #category : #'visitor - double dispatching' }
+{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> visitPragmaNode: aPragmaNode [
 
 	| var |
@@ -737,14 +739,14 @@ OCASTTranslator >> visitPragmaNode: aPragmaNode [
 	var emitStore: methodBuilder
 ]
 
-{ #category : #'visitor - double dispatching' }
+{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> visitReturnNode: aReturnNode [
 
 	self visitNode: aReturnNode value.
 	methodBuilder returnTop
 ]
 
-{ #category : #'visitor - double dispatching' }
+{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> visitSequenceNode: aSequenceNode [
 	| statements |
 	statements := aSequenceNode statements.
@@ -755,7 +757,7 @@ OCASTTranslator >> visitSequenceNode: aSequenceNode [
 	self visitNode: statements last
 ]
 
-{ #category : #'visitor - double dispatching' }
+{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> visitVariableNode: aVariableNode [
 
 	"Invalid variable should fail"

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -2,8 +2,8 @@
 I am an abstract superclass for Block and Method scopes
 "
 Class {
-	#name : #OCAbstractMethodScope,
-	#superclass : #OCAbstractScope,
+	#name : 'OCAbstractMethodScope',
+	#superclass : 'OCAbstractScope',
 	#instVars : [
 		'tempVars',
 		'copiedVars',
@@ -12,20 +12,22 @@ Class {
 		'tempVectorVar',
 		'node'
 	],
-	#category : #'OpalCompiler-Core-Semantics'
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCAbstractMethodScope class >> isAbstract [
 	^self = OCAbstractMethodScope
 ]
 
-{ #category : #'temp vars - copying' }
+{ #category : 'temp vars - copying' }
 OCAbstractMethodScope >> addCopyingTemp: aTempVar [
 	^copiedVars at: aTempVar name put: (aTempVar createCopiedVariableFor: self)
 ]
 
-{ #category : #'temp vars - copying' }
+{ #category : 'temp vars - copying' }
 OCAbstractMethodScope >> addCopyingTempToAllScopesUpToDefTemp: aVar [
 
 	(self copiedVarNames includes: aVar name) ifFalse: [self addCopyingTemp: aVar].
@@ -33,7 +35,7 @@ OCAbstractMethodScope >> addCopyingTempToAllScopesUpToDefTemp: aVar [
 	^ self outerScope addCopyingTempToAllScopesUpToDefTemp: aVar
 ]
 
-{ #category : #'temp vars' }
+{ #category : 'temp vars' }
 OCAbstractMethodScope >> addTemp: aTempVar [
 	aTempVar scope: self.
 	^ tempVars
@@ -41,7 +43,7 @@ OCAbstractMethodScope >> addTemp: aTempVar [
 		put: aTempVar
 ]
 
-{ #category : #'temp vars - vector' }
+{ #category : 'temp vars - vector' }
 OCAbstractMethodScope >> addVectorTemp: aTemp [
 	^ tempVector
 		at:  aTemp name
@@ -54,12 +56,12 @@ OCAbstractMethodScope >> addVectorTemp: aTemp [
 			yourself)
 ]
 
-{ #category : #'temp vars' }
+{ #category : 'temp vars' }
 OCAbstractMethodScope >> allTempNames [
 	^self allTemps collect: [: each | each name]
 ]
 
-{ #category : #'temp vars' }
+{ #category : 'temp vars' }
 OCAbstractMethodScope >> allTemps [
 	"return all temps defined, even the ones in the outer scope that are not used in the current.
 	 This includes the arguments. We do not need to care about shadowed temps as temp shadowing is not allowed."
@@ -72,17 +74,17 @@ OCAbstractMethodScope >> allTemps [
 			str nextPutAll: self localTemps ]
 ]
 
-{ #category : #'temp vars - copying' }
+{ #category : 'temp vars - copying' }
 OCAbstractMethodScope >> copiedVarNames [
 	^ copiedVars keys
 ]
 
-{ #category : #'temp vars - copying' }
+{ #category : 'temp vars - copying' }
 OCAbstractMethodScope >> copiedVars [
 	^ copiedVars
 ]
 
-{ #category : #'temp vars - copying' }
+{ #category : 'temp vars - copying' }
 OCAbstractMethodScope >> copyEscapingReads [
 
 	self tempVars values
@@ -90,7 +92,7 @@ OCAbstractMethodScope >> copyEscapingReads [
 		thenDo: [ :each | self addCopyingTemp: each ]
 ]
 
-{ #category : #lookup }
+{ #category : 'lookup' }
 OCAbstractMethodScope >> hasBindingThatBeginsWith: aString [
 	"check weather there are any temporaries defined that start with aString"
 	(copiedVars hasBindingThatBeginsWith: aString) ifTrue: [ ^true ].
@@ -100,17 +102,17 @@ OCAbstractMethodScope >> hasBindingThatBeginsWith: aString [
 	^ self outerScope hasBindingThatBeginsWith: aString
 ]
 
-{ #category : #'temp vars - vector' }
+{ #category : 'temp vars - vector' }
 OCAbstractMethodScope >> hasTempVector [
 	^ tempVector isNotEmpty
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCAbstractMethodScope >> id: int [
 	id := int
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 OCAbstractMethodScope >> initialize [
 
 	tempVars :=  OrderedDictionary new.
@@ -119,12 +121,12 @@ OCAbstractMethodScope >> initialize [
 	id := 0
 ]
 
-{ #category : #'temp vars' }
+{ #category : 'temp vars' }
 OCAbstractMethodScope >> localTempNames [
 	^self localTemps collect: [:each | each name]
 ]
 
-{ #category : #'temp vars' }
+{ #category : 'temp vars' }
 OCAbstractMethodScope >> localTemps [
 	"all temps accessed in the context... for tempVectors, it takes all the vars even those not used here"
 
@@ -136,7 +138,7 @@ OCAbstractMethodScope >> localTemps [
 			str nextPutAll: tempVars values]
 ]
 
-{ #category : #lookup }
+{ #category : 'lookup' }
 OCAbstractMethodScope >> lookupDefiningContextForVariable: var startingFrom: aContext [
 	"Is this the definition context for var? If it not, we look in the outer context using the corresponding outer scope. If found, we return the context"
 
@@ -145,7 +147,7 @@ OCAbstractMethodScope >> lookupDefiningContextForVariable: var startingFrom: aCo
 		ifTrue: [ aContext ]
 ]
 
-{ #category : #lookup }
+{ #category : 'lookup' }
 OCAbstractMethodScope >> lookupVar: name [
 
 	copiedVars at: name ifPresent: [:v | ^ v].
@@ -155,13 +157,13 @@ OCAbstractMethodScope >> lookupVar: name [
 	^ super lookupVar: name
 ]
 
-{ #category : #scope }
+{ #category : 'scope' }
 OCAbstractMethodScope >> methodScope [
 
 	^ self outerScope methodScope
 ]
 
-{ #category : #'temp vars - vector' }
+{ #category : 'temp vars - vector' }
 OCAbstractMethodScope >> moveEscapingWritesToTempVector [
 
 	self tempVars values
@@ -169,19 +171,19 @@ OCAbstractMethodScope >> moveEscapingWritesToTempVector [
 		thenDo: [ :each | self moveToVectorTemp: each ]
 ]
 
-{ #category : #'temp vars - vector' }
+{ #category : 'temp vars - vector' }
 OCAbstractMethodScope >> moveToVectorTemp: aTempVar [
 
 	self addVectorTemp: aTempVar.
 	self removeTemp: aTempVar
 ]
 
-{ #category : #scope }
+{ #category : 'scope' }
 OCAbstractMethodScope >> newBlockScope: int [
 	^ OCBlockScope new outerScope: self; id: int; yourself
 ]
 
-{ #category : #scope }
+{ #category : 'scope' }
 OCAbstractMethodScope >> newOptimizedBlockScope: int [
 	^ OCOptimizedBlockScope new
 			outerScope: self;
@@ -189,40 +191,40 @@ OCAbstractMethodScope >> newOptimizedBlockScope: int [
 			yourself
 ]
 
-{ #category : #lookup }
+{ #category : 'lookup' }
 OCAbstractMethodScope >> nextOuterScopeContextOf: aContext [
 	^aContext
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCAbstractMethodScope >> node [
 	^node
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCAbstractMethodScope >> node: aNode [
 	node := aNode
 ]
 
-{ #category : #scope }
+{ #category : 'scope' }
 OCAbstractMethodScope >> outerNotOptimizedScope [
 	^self
 ]
 
-{ #category : #scope }
+{ #category : 'scope' }
 OCAbstractMethodScope >> popScope [
 	"Propogate free var usages to their outer vars, then return outer scope"
 
 	^ self outerScope
 ]
 
-{ #category : #'temp vars' }
+{ #category : 'temp vars' }
 OCAbstractMethodScope >> removeTemp: tempVar [
 
 	tempVars removeKey: tempVar name
 ]
 
-{ #category : #'temp vars - copying' }
+{ #category : 'temp vars - copying' }
 OCAbstractMethodScope >> setCopyingTempToAllScopesUpToDefTemp: aVar to: aValue from: aContext [
 	"we need to update all the copies if we change the value of a copied temp"
 
@@ -235,37 +237,37 @@ OCAbstractMethodScope >> setCopyingTempToAllScopesUpToDefTemp: aVar to: aValue f
 		from: (self nextOuterScopeContextOf: aContext)
 ]
 
-{ #category : #'temp vars' }
+{ #category : 'temp vars' }
 OCAbstractMethodScope >> tempVarNames [
 
 	^ tempVars keys
 ]
 
-{ #category : #'temp vars' }
+{ #category : 'temp vars' }
 OCAbstractMethodScope >> tempVarNamesWithoutArguments [
 
 	^ tempVars values reject: [ :each | each isArgumentVariable ] thenCollect: [ :each | each name ]
 ]
 
-{ #category : #'temp vars' }
+{ #category : 'temp vars' }
 OCAbstractMethodScope >> tempVars [
 
 	^ tempVars
 ]
 
-{ #category : #'temp vars - vector' }
+{ #category : 'temp vars - vector' }
 OCAbstractMethodScope >> tempVector [
 	^ tempVector
 ]
 
-{ #category : #'temp vars - vector' }
+{ #category : 'temp vars - vector' }
 OCAbstractMethodScope >> tempVectorName [
 	"the name of the tempVector is not a valid name of a temp variable
 	 This way we avoid name clashes "
 	^'0vector', id asString
 ]
 
-{ #category : #'temp vars - vector' }
+{ #category : 'temp vars - vector' }
 OCAbstractMethodScope >> tempVectorVar [
 	^ tempVectorVar ifNil: [ tempVectorVar := TemporaryVariable new
 			name: self tempVectorName;
@@ -273,7 +275,7 @@ OCAbstractMethodScope >> tempVectorVar [
 			yourself]
 ]
 
-{ #category : #'temp vars - vector' }
+{ #category : 'temp vars - vector' }
 OCAbstractMethodScope >> tempVectorVarNames [
 	"As other users are taking the values directly from the tempVector Dictionary,
 	it is important that the collect is performed like this. As in this way it has always the order dependending on the hash of the String (that is constant).

--- a/src/OpalCompiler-Core/OCAbstractScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractScope.class.st
@@ -2,25 +2,27 @@
 I am a symbol table where variable names are associated with SemVars.  Each context (method/closure) get a fresh scope that inherits from its outer scope.
 "
 Class {
-	#name : #OCAbstractScope,
-	#superclass : #Object,
+	#name : 'OCAbstractScope',
+	#superclass : 'Object',
 	#instVars : [
 		'outerScope'
 	],
-	#category : #'OpalCompiler-Core-Semantics'
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCAbstractScope class >> isAbstract [
 	^self = OCAbstractScope
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCAbstractScope >> environment [
 	^self targetClass environment
 ]
 
-{ #category : #lookup }
+{ #category : 'lookup' }
 OCAbstractScope >> hasBindingThatBeginsWith: aString [
 	"check weather there are any variables defined that start with aString"
 	^ outerScope
@@ -28,54 +30,54 @@ OCAbstractScope >> hasBindingThatBeginsWith: aString [
 		ifNotNil: [ outerScope hasBindingThatBeginsWith: aString ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCAbstractScope >> hasTempVector [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCAbstractScope >> isBlockScope [
 
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCAbstractScope >> isInsideOptimizedLoop [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCAbstractScope >> isMethodScope [
 
 	^false
 ]
 
-{ #category : #lookup }
+{ #category : 'lookup' }
 OCAbstractScope >> lookupVar: name [
 	"search the scope (and the outer scopes) for a variable 'name' and return it"
 
 	^ outerScope ifNotNil: [ :it | it lookupVar: name ]
 ]
 
-{ #category : #lookup }
+{ #category : 'lookup' }
 OCAbstractScope >> outerScope [
 
 	^ outerScope
 ]
 
-{ #category : #initializing }
+{ #category : 'initializing' }
 OCAbstractScope >> outerScope: aSemScope [
 
 	outerScope := aSemScope
 ]
 
-{ #category : #lookup }
+{ #category : 'lookup' }
 OCAbstractScope >> registerVariables [
 
 	outerScope ifNotNil: [ :it | it registerVariables ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCAbstractScope >> targetClass [
 	^outerScope ifNotNil: [ :it | it targetClass ]
 ]

--- a/src/OpalCompiler-Core/OCBlockScope.class.st
+++ b/src/OpalCompiler-Core/OCBlockScope.class.st
@@ -2,38 +2,40 @@
 I modelt the scope of a block
 "
 Class {
-	#name : #OCBlockScope,
-	#superclass : #OCAbstractMethodScope,
-	#category : #'OpalCompiler-Core-Semantics'
+	#name : 'OCBlockScope',
+	#superclass : 'OCAbstractMethodScope',
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCBlockScope >> hasEscapingVars [
 	^ self inComingCopiedVarNames isNotEmpty
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCBlockScope >> inComingCopiedVarNames [
 	^ self copiedVarNames intersection: outerScope copiedVarNames
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCBlockScope >> isBlockScope [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCBlockScope >> isInsideOptimizedLoop [
 	^ self outerScope isInsideOptimizedLoop
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCBlockScope >> isOptimized [
 
 	^ false
 ]
 
-{ #category : #lookup }
+{ #category : 'lookup' }
 OCBlockScope >> nextOuterScopeContextOf: aContext [
 
 	"Returns the next context to lookup a variable name from within outer scope.

--- a/src/OpalCompiler-Core/OCBytecodeToASTCache.class.st
+++ b/src/OpalCompiler-Core/OCBytecodeToASTCache.class.st
@@ -12,28 +12,30 @@ I store:
 - the methode node.
 "
 Class {
-	#name : #OCBytecodeToASTCache,
-	#superclass : #Object,
+	#name : 'OCBytecodeToASTCache',
+	#superclass : 'Object',
 	#instVars : [
 		'firstBcOffset',
 		'lastBcOffset',
 		'bcToASTMap',
 		'methodOrBlockNode'
 	],
-	#category : #'OpalCompiler-Core-Bytecode'
+	#category : 'OpalCompiler-Core-Bytecode',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Bytecode'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 OCBytecodeToASTCache class >> generateForNode: aNode [
 	^self new generateForNode: aNode
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCBytecodeToASTCache >> bcToASTMap [
 	^ bcToASTMap
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 OCBytecodeToASTCache >> fillMissingBCOffsetsWithLastBCOffsetNodes [
 	 "It happens that different bytecode offsets map to the same AST node.
 	These cases are detected when there is no node mapped between, for example, bcOffset 46 and bcOffset 50.
@@ -57,18 +59,18 @@ OCBytecodeToASTCache >> fillMissingBCOffsetsWithLastBCOffsetNodes [
 			 bcToASTMap at: i put: (bcToASTMap at: bcAtIndex) ] ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCBytecodeToASTCache >> firstBcOffset [
 	^ firstBcOffset
 ]
 
-{ #category : #astAndAstMapping }
+{ #category : 'astAndAstMapping' }
 OCBytecodeToASTCache >> firstBcOffsetForNode: aNode [
 
 	^ (self pcsForNode: aNode) at: 1 ifAbsent: nil
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 OCBytecodeToASTCache >> generateForNode: aNode [
 	| methodOrBlockIr currentBcOffset |
 	methodOrBlockNode := aNode.
@@ -93,12 +95,12 @@ OCBytecodeToASTCache >> generateForNode: aNode [
 	self fillMissingBCOffsetsWithLastBCOffsetNodes
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCBytecodeToASTCache >> lastBcOffset [
 	^ lastBcOffset
 ]
 
-{ #category : #astAndAstMapping }
+{ #category : 'astAndAstMapping' }
 OCBytecodeToASTCache >> lastBcOffsetForNode: aNode [
 
 	| pcsForNode |
@@ -106,24 +108,24 @@ OCBytecodeToASTCache >> lastBcOffsetForNode: aNode [
 	^ pcsForNode at: pcsForNode size ifAbsent: nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCBytecodeToASTCache >> methodNode [
 	^ methodOrBlockNode
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCBytecodeToASTCache >> methodOrBlockNode [
 	^ methodOrBlockNode
 ]
 
-{ #category : #'node access' }
+{ #category : 'node access' }
 OCBytecodeToASTCache >> nodeForPC: pc [
 	pc < firstBcOffset ifTrue: [ ^ methodOrBlockNode ].
 	pc > lastBcOffset ifTrue: [ ^ bcToASTMap at: lastBcOffset ].
 	^ bcToASTMap at: pc
 ]
 
-{ #category : #astAndAstMapping }
+{ #category : 'astAndAstMapping' }
 OCBytecodeToASTCache >> pcsForNode: aNode [
 
 	^ (bcToASTMap keys select: [ :key | (bcToASTMap at: key) == aNode ]) asOrderedCollection sorted

--- a/src/OpalCompiler-Core/OCCodeReparator.class.st
+++ b/src/OpalCompiler-Core/OCCodeReparator.class.st
@@ -10,34 +10,36 @@ I'm quite limited and I need love to improve and be usable in other context (rig
 * requestor <???> the original requestor (to do reparation on)
 "
 Class {
-	#name : #OCCodeReparator,
-	#superclass : #Object,
+	#name : 'OCCodeReparator',
+	#superclass : 'Object',
 	#instVars : [
 		'node',
 		'requestor'
 	],
-	#category : #'OpalCompiler-Core-FrontEnd'
+	#category : 'OpalCompiler-Core-FrontEnd',
+	#package : 'OpalCompiler-Core',
+	#tag : 'FrontEnd'
 }
 
-{ #category : #correcting }
+{ #category : 'correcting' }
 OCCodeReparator >> declareClassVar [
 
 	node methodNode methodClass instanceSide
 		addClassVarNamed: node name asSymbol
 ]
 
-{ #category : #correcting }
+{ #category : 'correcting' }
 OCCodeReparator >> declareGlobal [
 	Smalltalk globals at: node name asSymbol put: nil
 ]
 
-{ #category : #correcting }
+{ #category : 'correcting' }
 OCCodeReparator >> declareInstVar: name [
 	"Declare an instance variable."
 	node methodNode methodClass addInstVarNamed: name
 ]
 
-{ #category : #correcting }
+{ #category : 'correcting' }
 OCCodeReparator >> declareTempAndPaste: name [
 	| insertion theTextString characterBeforeMark tempsMark newMethodNode |
 
@@ -65,7 +67,7 @@ OCCodeReparator >> declareTempAndPaste: name [
 	self substituteWord: insertion wordInterval: (tempsMark to: tempsMark-1)
 ]
 
-{ #category : #correcting }
+{ #category : 'correcting' }
 OCCodeReparator >> defineClass: classSymbol [
 	"Prompts the user to define a new class."
 
@@ -79,7 +81,7 @@ OCCodeReparator >> defineClass: classSymbol [
 		  definitionString: classDefinition
 ]
 
-{ #category : #correcting }
+{ #category : 'correcting' }
 OCCodeReparator >> defineClassOrTrait: aSymbol definitionString: aString [
 	"Prompts the user to define a new class oe trait."
 
@@ -104,7 +106,7 @@ OCCodeReparator >> defineClassOrTrait: aSymbol definitionString: aString [
 	^classBinding
 ]
 
-{ #category : #correcting }
+{ #category : 'correcting' }
 OCCodeReparator >> defineTrait: traitName [
 	"Prompts the user to define a new trait."
 
@@ -120,19 +122,19 @@ OCCodeReparator >> defineTrait: traitName [
 		  definitionString: traitDefinition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCCodeReparator >> node [
 
 	^ node
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCCodeReparator >> node: anObject [
 
 	node := anObject
 ]
 
-{ #category : #'menu morph' }
+{ #category : 'menu morph' }
 OCCodeReparator >> openMenu [
 	"Display a menu to perform various possible reparations on undefined variables.
 	* Return true if a reparation was done and a recompilation is needed.
@@ -189,7 +191,7 @@ OCCodeReparator >> openMenu [
 	^ true
 ]
 
-{ #category : #correcting }
+{ #category : 'correcting' }
 OCCodeReparator >> possibleVariablesFor: proposedVariable [
 	| results class |
 	class := node methodNode methodClass.
@@ -202,19 +204,19 @@ OCCodeReparator >> possibleVariablesFor: proposedVariable [
 	^ proposedVariable correctAgainst: nil continuedFrom: results
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCCodeReparator >> requestor [
 
 	^ requestor
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCCodeReparator >> requestor: anObject [
 
 	requestor := anObject
 ]
 
-{ #category : #correcting }
+{ #category : 'correcting' }
 OCCodeReparator >> substituteVariable: varName atInterval: anInterval [
 	self
 		substituteWord: varName
@@ -223,7 +225,7 @@ OCCodeReparator >> substituteVariable: varName atInterval: anInterval [
 	node replaceWith:((RBVariableNode named: varName) binding: (node owningScope lookupVar: varName))
 ]
 
-{ #category : #correcting }
+{ #category : 'correcting' }
 OCCodeReparator >> substituteWord: correctWord wordInterval: spot [
 	"Substitute the correctSelector into the (presuamed interactive) receiver."
 

--- a/src/OpalCompiler-Core/OCContextualDoItSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCContextualDoItSemanticScope.class.st
@@ -16,28 +16,30 @@ My instances can be created using following expression:
 
 "
 Class {
-	#name : #OCContextualDoItSemanticScope,
-	#superclass : #OCDoItSemanticScope,
+	#name : 'OCContextualDoItSemanticScope',
+	#superclass : 'OCDoItSemanticScope',
 	#instVars : [
 		'targetContext',
 		'importedVariables'
 	],
-	#category : #'OpalCompiler-Core-Semantics'
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 OCContextualDoItSemanticScope class >> targetingContext: aContext [
 	^self new
 		targetContext: aContext
 ]
 
-{ #category : #'code evaluation' }
+{ #category : 'code evaluation' }
 OCContextualDoItSemanticScope >> announceDoItEvaluation: aSourceString by: aSystemAnnouncer [
 
 	aSystemAnnouncer evaluated: aSourceString context: targetContext
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCContextualDoItSemanticScope >> hasBindingThatBeginsWith: aString [
 
 	(targetContext astScope hasBindingThatBeginsWith: aString) ifTrue: [ ^true ].
@@ -45,7 +47,7 @@ OCContextualDoItSemanticScope >> hasBindingThatBeginsWith: aString [
 	^super hasBindingThatBeginsWith: aString
 ]
 
-{ #category : #lookup }
+{ #category : 'lookup' }
 OCContextualDoItSemanticScope >> importVariable: aVariable [
 
 	^importedVariables
@@ -53,26 +55,26 @@ OCContextualDoItSemanticScope >> importVariable: aVariable [
 		ifAbsentPut: [ aVariable asDoItVariableFrom: targetContext ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCContextualDoItSemanticScope >> importedVariables [
 
 	^ importedVariables
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCContextualDoItSemanticScope >> importedVariables: anObject [
 
 	importedVariables := anObject
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 OCContextualDoItSemanticScope >> initialize [
 	super initialize.
 
 	importedVariables := Dictionary new
 ]
 
-{ #category : #lookup }
+{ #category : 'lookup' }
 OCContextualDoItSemanticScope >> lookupVar: name [
 
 	(targetContext lookupVar: name) ifNotNil: [ :v | ^self importVariable: v].
@@ -80,18 +82,18 @@ OCContextualDoItSemanticScope >> lookupVar: name [
 	^super lookupVar: name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCContextualDoItSemanticScope >> receiver [
 	^targetContext receiver
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCContextualDoItSemanticScope >> targetContext [
 
 	^ targetContext
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCContextualDoItSemanticScope >> targetContext: aContext [
 
 	targetContext := aContext

--- a/src/OpalCompiler-Core/OCDoItSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCDoItSemanticScope.class.st
@@ -10,33 +10,35 @@ My subclasses must implement several methods for doIt method compilation and eva
 See subclasses for examples
 "
 Class {
-	#name : #OCDoItSemanticScope,
-	#superclass : #OCSemanticScope,
-	#category : #'OpalCompiler-Core-Semantics'
+	#name : 'OCDoItSemanticScope',
+	#superclass : 'OCSemanticScope',
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCDoItSemanticScope class >> isAbstract [
 	^self = OCDoItSemanticScope
 ]
 
-{ #category : #'code evaluation' }
+{ #category : 'code evaluation' }
 OCDoItSemanticScope >> evaluateDoIt: doItMethod [
 
 	^self receiver withArgs: #() executeMethod: doItMethod
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCDoItSemanticScope >> isDoItScope [
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCDoItSemanticScope >> receiver [
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCDoItSemanticScope >> targetClass [
 	^ self receiver class
 ]

--- a/src/OpalCompiler-Core/OCDynamicASTCompilerPlugin.class.st
+++ b/src/OpalCompiler-Core/OCDynamicASTCompilerPlugin.class.st
@@ -10,16 +10,18 @@ Instanciate me using """"newFromTransformBlock: aBlock andPriority: aPriority"""
 Check out my test class (`OCDynamicASTCompilerPluginTest`) for a usage example.
 "
 Class {
-	#name : #OCDynamicASTCompilerPlugin,
-	#superclass : #OCASTCompilerPlugin,
+	#name : 'OCDynamicASTCompilerPlugin',
+	#superclass : 'OCASTCompilerPlugin',
 	#instVars : [
 		'priority',
 		'transformBlock'
 	],
-	#category : #'OpalCompiler-Core-Plugins'
+	#category : 'OpalCompiler-Core-Plugins',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Plugins'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 OCDynamicASTCompilerPlugin class >> newFromTransformBlock: aBlock [
 	"Return a new instance of the receiver using the given AST transformation block and default priority."
 
@@ -28,7 +30,7 @@ OCDynamicASTCompilerPlugin class >> newFromTransformBlock: aBlock [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 OCDynamicASTCompilerPlugin class >> newFromTransformBlock: aBlock andPriority: aPriority [
 	"Return a new instance of the receiver using the given AST transformation block and the given priority."
 
@@ -37,38 +39,38 @@ OCDynamicASTCompilerPlugin class >> newFromTransformBlock: aBlock andPriority: a
 			yourself
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 OCDynamicASTCompilerPlugin >> initialize [
 
 	super initialize.
 	self priority: self class defaultPriority
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCDynamicASTCompilerPlugin >> priority [
 
 	^ priority
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCDynamicASTCompilerPlugin >> priority: anObject [
 
 	priority := anObject
 ]
 
-{ #category : #transforming }
+{ #category : 'transforming' }
 OCDynamicASTCompilerPlugin >> transform: ast [
 
 	^ transformBlock value: ast copy
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCDynamicASTCompilerPlugin >> transformBlock [
 
 	^ transformBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCDynamicASTCompilerPlugin >> transformBlock: anObject [
 
 	transformBlock := anObject

--- a/src/OpalCompiler-Core/OCExtraBindingScope.class.st
+++ b/src/OpalCompiler-Core/OCExtraBindingScope.class.st
@@ -16,30 +16,32 @@ result := Smalltalk compiler
 Shadowed global variables can be assigned to even if they referene a class.
 "
 Class {
-	#name : #OCExtraBindingScope,
-	#superclass : #OCAbstractScope,
+	#name : 'OCExtraBindingScope',
+	#superclass : 'OCAbstractScope',
 	#instVars : [
 		'bindings'
 	],
-	#category : #'OpalCompiler-Core-Semantics'
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
 }
 
-{ #category : #'temp vars' }
+{ #category : 'temp vars' }
 OCExtraBindingScope >> allTemps [
 	^#()
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCExtraBindingScope >> bindings [
 	^ bindings
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCExtraBindingScope >> bindings: anObject [
 	bindings := anObject
 ]
 
-{ #category : #lookup }
+{ #category : 'lookup' }
 OCExtraBindingScope >> lookupVar: name [
 	^(bindings bindingOf: name asSymbol)
 		ifNotNil: [ :var | var ]

--- a/src/OpalCompiler-Core/OCLiteralDictionary.class.st
+++ b/src/OpalCompiler-Core/OCLiteralDictionary.class.st
@@ -2,12 +2,14 @@
 I am special version of a dictionary that compares the keys using the #literalEquals: message.
 "
 Class {
-	#name : #OCLiteralDictionary,
-	#superclass : #Dictionary,
-	#category : #'OpalCompiler-Core-Extras'
+	#name : 'OCLiteralDictionary',
+	#superclass : 'Dictionary',
+	#category : 'OpalCompiler-Core-Extras',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Extras'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCLiteralDictionary >> keyAtValue: value ifAbsent: exceptionBlock [
 	"Answer the key that is the external name for the argument, value. If
 	there is none, answer the result of evaluating exceptionBlock."
@@ -17,7 +19,7 @@ OCLiteralDictionary >> keyAtValue: value ifAbsent: exceptionBlock [
 	^ exceptionBlock value
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 OCLiteralDictionary >> scanFor: anObject [
 	"Scan the key array for the first slot containing either a nil (indicating an empty slot) or an element that matches anObject. Answer the index of that slot or zero if no slot is found. This method will be overridden in various subclasses that have different interpretations for matching elements."
 	| finish start element |

--- a/src/OpalCompiler-Core/OCLiteralList.class.st
+++ b/src/OpalCompiler-Core/OCLiteralList.class.st
@@ -4,16 +4,18 @@ I uses an special dictionary inside that compares literals using #literalEquals 
 I am optimised to guarantee that literals all unique and have an unique index.
 "
 Class {
-	#name : #OCLiteralList,
-	#superclass : #Object,
+	#name : 'OCLiteralList',
+	#superclass : 'Object',
 	#instVars : [
 		'literalsDict',
 		'first'
 	],
-	#category : #'OpalCompiler-Core-Extras'
+	#category : 'OpalCompiler-Core-Extras',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Extras'
 }
 
-{ #category : #adding }
+{ #category : 'adding' }
 OCLiteralList >> addLiteral: anObject [
 
 	"I keep the first element, so it can be easily returned"
@@ -24,7 +26,7 @@ OCLiteralList >> addLiteral: anObject [
 	^ literalsDict at: anObject ifAbsentPut: [ literalsDict size + 1 ]
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 OCLiteralList >> asArray [
 
 	| result |
@@ -36,26 +38,26 @@ OCLiteralList >> asArray [
 	^ result
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 OCLiteralList >> first [
 
 	^ first
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 OCLiteralList >> initialize [
 
 	super initialize.
 	literalsDict := OCLiteralDictionary new
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCLiteralList >> isEmpty [
 
 	^ literalsDict isEmpty
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCLiteralList >> literalIndexOf: anElement ifAbsent: exceptionBlock [
 
 	^ literalsDict at: anElement ifAbsent: exceptionBlock

--- a/src/OpalCompiler-Core/OCLiteralSet.class.st
+++ b/src/OpalCompiler-Core/OCLiteralSet.class.st
@@ -7,12 +7,14 @@ Example:
 
 "
 Class {
-	#name : #OCLiteralSet,
-	#superclass : #Set,
-	#category : #'OpalCompiler-Core-Extras'
+	#name : 'OCLiteralSet',
+	#superclass : 'Set',
+	#category : 'OpalCompiler-Core-Extras',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Extras'
 }
 
-{ #category : #adding }
+{ #category : 'adding' }
 OCLiteralSet >> add: newObject [
 	"Include newObject as one of the receiver's elements.  If equivalent is already present don't add and return equivalent object"
 
@@ -24,7 +26,7 @@ OCLiteralSet >> add: newObject [
 		ifNotNil: [array at: index]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 OCLiteralSet >> scanFor: anObject [
 	"Scan the key array for the first slot containing either a nil (indicating an empty slot) or an element that matches anObject. Answer the index of that slot or zero if no slot is found. This method will be overridden in various subclasses that have different interpretations for matching elements."
 	| element start finish |

--- a/src/OpalCompiler-Core/OCMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCMethodScope.class.st
@@ -2,17 +2,19 @@
 I am the scope for a Method
 "
 Class {
-	#name : #OCMethodScope,
-	#superclass : #OCAbstractMethodScope,
-	#category : #'OpalCompiler-Core-Semantics'
+	#name : 'OCMethodScope',
+	#superclass : 'OCAbstractMethodScope',
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCMethodScope >> isMethodScope [
 	^true
 ]
 
-{ #category : #scope }
+{ #category : 'scope' }
 OCMethodScope >> methodScope [
 
 	^ self

--- a/src/OpalCompiler-Core/OCMethodSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCMethodSemanticScope.class.st
@@ -8,27 +8,29 @@ My instances can be created using following expression:
 	OCMethodSemanticScope targetingClass: aClass
 "
 Class {
-	#name : #OCMethodSemanticScope,
-	#superclass : #OCSemanticScope,
+	#name : 'OCMethodSemanticScope',
+	#superclass : 'OCSemanticScope',
 	#instVars : [
 		'targetClass'
 	],
-	#category : #'OpalCompiler-Core-Semantics'
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 OCMethodSemanticScope class >> targetingClass: aClass [
 	^self new
 		targetClass: aClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCMethodSemanticScope >> targetClass [
 
 	^ targetClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCMethodSemanticScope >> targetClass: anObject [
 
 	targetClass := anObject

--- a/src/OpalCompiler-Core/OCOptimizedBlockScope.class.st
+++ b/src/OpalCompiler-Core/OCOptimizedBlockScope.class.st
@@ -5,39 +5,41 @@ To be consistent, these blocks need nevertheless a scope.
 
 "
 Class {
-	#name : #OCOptimizedBlockScope,
-	#superclass : #OCBlockScope,
+	#name : 'OCOptimizedBlockScope',
+	#superclass : 'OCBlockScope',
 	#instVars : [
 		'isInlinedLoop'
 	],
-	#category : #'OpalCompiler-Core-Semantics'
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 OCOptimizedBlockScope >> initialize [
 	super initialize.
 	isInlinedLoop := false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCOptimizedBlockScope >> isInsideOptimizedLoop [
 	^ isInlinedLoop
 		ifTrue: [true]
 		ifFalse: [self outerScope isInsideOptimizedLoop]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCOptimizedBlockScope >> isOptimized [
 
 	^ true
 ]
 
-{ #category : #mark }
+{ #category : 'mark' }
 OCOptimizedBlockScope >> markInlinedLoop [
 	isInlinedLoop := true
 ]
 
-{ #category : #lookup }
+{ #category : 'lookup' }
 OCOptimizedBlockScope >> nextOuterScopeContextOf: aContext [
 
 	"Returns the next context to lookup a variable name from within outer scope.
@@ -46,7 +48,7 @@ OCOptimizedBlockScope >> nextOuterScopeContextOf: aContext [
 	^ aContext
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCOptimizedBlockScope >> outerNotOptimizedScope [
 	^self outerScope outerNotOptimizedScope
 ]

--- a/src/OpalCompiler-Core/OCReceiverDoItSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCReceiverDoItSemanticScope.class.st
@@ -13,44 +13,46 @@ My instances can be created using following expression:
 	OCReceiverDoItSemanticScope targetingReceiver: anObject
 "
 Class {
-	#name : #OCReceiverDoItSemanticScope,
-	#superclass : #OCDoItSemanticScope,
+	#name : 'OCReceiverDoItSemanticScope',
+	#superclass : 'OCDoItSemanticScope',
 	#instVars : [
 		'targetReceiver'
 	],
-	#category : #'OpalCompiler-Core-Semantics'
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 OCReceiverDoItSemanticScope class >> targetingNilReceiver [
 	^self targetingReceiver: nil
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 OCReceiverDoItSemanticScope class >> targetingReceiver: anObject [
 	^self new
 		targetReceiver: anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCReceiverDoItSemanticScope >> receiver [
 
 	^ targetReceiver
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCReceiverDoItSemanticScope >> receiver: anObject [
 
 	targetReceiver := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCReceiverDoItSemanticScope >> targetReceiver [
 
 	^ targetReceiver
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCReceiverDoItSemanticScope >> targetReceiver: anObject [
 
 	targetReceiver := anObject

--- a/src/OpalCompiler-Core/OCRequestorScope.class.st
+++ b/src/OpalCompiler-Core/OCRequestorScope.class.st
@@ -6,21 +6,23 @@ The default scope of the compiler is initialized with a Requestor scope, if the 
 The OCRequestorScope will ask the tool (the requestor) for bindings. This will be an association, and as such it will create a OCLiteralVariable.  It will compile the same bytecode as for a global, but it will use the associations hold on by the tool to do so.
 "
 Class {
-	#name : #OCRequestorScope,
-	#superclass : #OCAbstractScope,
+	#name : 'OCRequestorScope',
+	#superclass : 'OCAbstractScope',
 	#instVars : [
 		'requestor',
 		'variables'
 	],
-	#category : #'OpalCompiler-Core-Semantics'
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
 }
 
-{ #category : #'temp vars' }
+{ #category : 'temp vars' }
 OCRequestorScope >> allTemps [
 	^#()
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCRequestorScope >> canAddBindingOf: name [
 	"Test for free workspace declaration"
 	
@@ -36,7 +38,7 @@ OCRequestorScope >> canAddBindingOf: name [
 	^ requestor canAddBindingOf: name
 ]
 
-{ #category : #lookup }
+{ #category : 'lookup' }
 OCRequestorScope >> lookupVar: name [
 
 	(requestor hasBindingOf: name) ifTrue: [ ^ requestor bindingOf: name ].
@@ -50,7 +52,7 @@ OCRequestorScope >> lookupVar: name [
 	^ self variables at: name ifAbsentPut: [ WorkspaceVariable key: name ]
 ]
 
-{ #category : #lookup }
+{ #category : 'lookup' }
 OCRequestorScope >> registerVariables [
 
 	self variables do: [ :each |
@@ -62,17 +64,17 @@ OCRequestorScope >> registerVariables [
 	super registerVariables
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCRequestorScope >> requestor [
 	^ requestor
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCRequestorScope >> requestor: anObject [
 	requestor := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCRequestorScope >> variables [
 
 	^ variables ifNil: [ variables := Dictionary new ].

--- a/src/OpalCompiler-Core/OCSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCSemanticScope.class.st
@@ -26,28 +26,30 @@ Configuration methods like #class:, #context:, #receiver:, #noPattern: perform t
 
 "
 Class {
-	#name : #OCSemanticScope,
-	#superclass : #OCAbstractScope,
-	#category : #'OpalCompiler-Core-Semantics'
+	#name : 'OCSemanticScope',
+	#superclass : 'OCAbstractScope',
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCSemanticScope class >> isAbstract [
 	^self = OCSemanticScope
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCSemanticScope >> allTemps [
 	^#()
 ]
 
-{ #category : #'code evaluation' }
+{ #category : 'code evaluation' }
 OCSemanticScope >> announceDoItEvaluation: aSourceString by: aSystemAnnouncer [
 
 	aSystemAnnouncer evaluated: aSourceString context: nil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCSemanticScope >> hasBindingThatBeginsWith: aString [
 
 	(self targetClass hasBindingThatBeginsWith: aString) ifTrue: [ ^true ].
@@ -55,12 +57,12 @@ OCSemanticScope >> hasBindingThatBeginsWith: aString [
 	^super hasBindingThatBeginsWith: aString
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCSemanticScope >> isDoItScope [
 	^false
 ]
 
-{ #category : #lookup }
+{ #category : 'lookup' }
 OCSemanticScope >> lookupVar: name [
 
 	(self targetClass lookupVar: name) ifNotNil: [ :v | ^v ].

--- a/src/OpalCompiler-Core/OCStaticASTCompilerPlugin.class.st
+++ b/src/OpalCompiler-Core/OCStaticASTCompilerPlugin.class.st
@@ -2,51 +2,53 @@
 I am an abtract superclass for AST based compiler plugins providing a static transformation of an AST
 "
 Class {
-	#name : #OCStaticASTCompilerPlugin,
-	#superclass : #OCASTCompilerPlugin,
+	#name : 'OCStaticASTCompilerPlugin',
+	#superclass : 'OCASTCompilerPlugin',
 	#instVars : [
 		'ast'
 	],
-	#category : #'OpalCompiler-Core-Plugins'
+	#category : 'OpalCompiler-Core-Plugins',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Plugins'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCStaticASTCompilerPlugin class >> isAbstract [
 
 	^ self == OCStaticASTCompilerPlugin
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 OCStaticASTCompilerPlugin class >> priority [
 	self subclassResponsibility
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 OCStaticASTCompilerPlugin class >> transform: anAST [
 	"Return a new instance of the receiver transforming the given AST"
 
 	^self new transform: anAST
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCStaticASTCompilerPlugin >> ast: anAST [
 
 	ast := anAST
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 OCStaticASTCompilerPlugin >> copyAST [
 	"Utility method to make a copy of the AST before manipulating it"
 
 	ast := ast copy
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCStaticASTCompilerPlugin >> priority [
 	^100 "default. Priority 0 is used by Reflectivity to be the last"
 ]
 
-{ #category : #'private - transforming' }
+{ #category : 'private - transforming' }
 OCStaticASTCompilerPlugin >> transform [
 	"Subclasses override this method to actually provide the AST transformation.
 	 IMPORTANT: If you modify the AST, make sure to copy it before using #copyAST!"
@@ -54,7 +56,7 @@ OCStaticASTCompilerPlugin >> transform [
 	self subclassResponsibility
 ]
 
-{ #category : #transforming }
+{ #category : 'transforming' }
 OCStaticASTCompilerPlugin >> transform: anAST [
 
 	ast := anAST.

--- a/src/OpalCompiler-Core/OCUndeclaredVariableNotice.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariableNotice.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #OCUndeclaredVariableNotice,
-	#superclass : #RBErrorNotice,
-	#category : #'OpalCompiler-Core-FrontEnd'
+	#name : 'OCUndeclaredVariableNotice',
+	#superclass : 'RBErrorNotice',
+	#category : 'OpalCompiler-Core-FrontEnd',
+	#package : 'OpalCompiler-Core',
+	#tag : 'FrontEnd'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCUndeclaredVariableNotice >> isUndeclaredNotice [
 
 	^ true
 ]
 
-{ #category : #correcting }
+{ #category : 'correcting' }
 OCUndeclaredVariableNotice >> reparator [
 
 	^ OCCodeReparator new node: self node

--- a/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariableWarning.class.st
@@ -2,15 +2,17 @@
 I get signalled when a temporary variable is used that is not defined.  My default action is to create an Undeclared binding and add it to the Undeclared dictionary.
 "
 Class {
-	#name : #OCUndeclaredVariableWarning,
-	#superclass : #Notification,
+	#name : 'OCUndeclaredVariableWarning',
+	#superclass : 'Notification',
 	#instVars : [
 		'notice'
 	],
-	#category : #'OpalCompiler-Core-Exception'
+	#category : 'OpalCompiler-Core-Exception',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Exception'
 }
 
-{ #category : #handling }
+{ #category : 'handling' }
 OCUndeclaredVariableWarning >> defaultAction [
 	| className selector |
  	className := self methodClass name.
@@ -23,46 +25,46 @@ OCUndeclaredVariableWarning >> defaultAction [
 	^ super defaultAction
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCUndeclaredVariableWarning >> description [
 
 	^ self class name , ':' , self notice description
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCUndeclaredVariableWarning >> methodClass [
 	^ self methodNode methodClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCUndeclaredVariableWarning >> methodNode [
 	^ self node methodNode
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCUndeclaredVariableWarning >> node [
 	^ self notice node
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCUndeclaredVariableWarning >> notice [
 
 	^ notice
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCUndeclaredVariableWarning >> notice: anObject [
 
 	notice := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCUndeclaredVariableWarning >> position [
 
 	^ self notice position
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCUndeclaredVariableWarning >> sourceCode [
 
 	^ self methodNode sourceCode

--- a/src/OpalCompiler-Core/OCVectorTempVariable.class.st
+++ b/src/OpalCompiler-Core/OCVectorTempVariable.class.st
@@ -13,37 +13,39 @@ reading and writing thus is a multi step process:
 4) use the index to access this array
 "
 Class {
-	#name : #OCVectorTempVariable,
-	#superclass : #TemporaryVariable,
+	#name : 'OCVectorTempVariable',
+	#superclass : 'TemporaryVariable',
 	#instVars : [
 		'vectorName'
 	],
-	#category : #'OpalCompiler-Core-Semantics'
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
 }
 
-{ #category : #emitting }
+{ #category : 'emitting' }
 OCVectorTempVariable >> emitStore: methodBuilder [
 
 	methodBuilder storeRemoteTemp: name inVector: vectorName
 ]
 
-{ #category : #emitting }
+{ #category : 'emitting' }
 OCVectorTempVariable >> emitValue: methodBuilder [
 
 	methodBuilder pushRemoteTemp: name inVector: vectorName
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCVectorTempVariable >> isRemote [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OCVectorTempVariable >> isTempVectorTemp [
 	^true
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 OCVectorTempVariable >> readFromContext: aContext scope: contextScope [
 
 	| theVector |
@@ -51,7 +53,7 @@ OCVectorTempVariable >> readFromContext: aContext scope: contextScope [
 	^theVector at: self index
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 OCVectorTempVariable >> readVectorFromContext: aContext scope: contextScope [
 	| tempVectorVar theVector |
 	"We need to first read the temp vector. We use the closest copied var up the stack possible as
@@ -68,17 +70,17 @@ OCVectorTempVariable >> readVectorFromContext: aContext scope: contextScope [
 			ifNotNil: [: ctxt | self readVectorFromContext: ctxt scope: contextScope outerScope ]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCVectorTempVariable >> vectorName [
 	^ vectorName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OCVectorTempVariable >> vectorName: anObject [
 	vectorName := anObject
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 OCVectorTempVariable >> writeFromContext: aContext scope: contextScope value: aValue [
 
 	| theVector |

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -26,8 +26,8 @@ Smalltalk compiler
 This returns a CompiledMethod.
 "
 Class {
-	#name : #OpalCompiler,
-	#superclass : #Object,
+	#name : 'OpalCompiler',
+	#superclass : 'Object',
 	#instVars : [
 		'ast',
 		'source',
@@ -44,10 +44,12 @@ Class {
 	#classInstVars : [
 		'overlayEnvironment'
 	],
-	#category : #'OpalCompiler-Core-FrontEnd'
+	#category : 'OpalCompiler-Core-FrontEnd',
+	#package : 'OpalCompiler-Core',
+	#tag : 'FrontEnd'
 }
 
-{ #category : #overlay }
+{ #category : 'overlay' }
 OpalCompiler class >> compilerClasses [
 	"here the classes for the overlay can changed. the default is just the compiler"
 	^self package definedClasses
@@ -57,7 +59,7 @@ OpalCompiler class >> compilerClasses [
 	"
 ]
 
-{ #category : #options }
+{ #category : 'options' }
 OpalCompiler class >> compilerSettingsOn: aBuilder [
 	<systemsettings>
 	(aBuilder group: #compiler)
@@ -72,12 +74,12 @@ OpalCompiler class >> compilerSettingsOn: aBuilder [
 				CompilationContext compilerSettingsOn: aBuilder]
 ]
 
-{ #category : #overlay }
+{ #category : 'overlay' }
 OpalCompiler class >> createAndEnableOverlay [
 	^self overlayIsActive
 ]
 
-{ #category : #overlay }
+{ #category : 'overlay' }
 OpalCompiler class >> createAndEnableOverlay: aBoolean [
 
 	aBoolean = self overlayIsActive ifTrue: [ ^self ].
@@ -86,7 +88,7 @@ OpalCompiler class >> createAndEnableOverlay: aBoolean [
 		ifFalse: [ self stopUsingOverlayForDevelopment   ]
 ]
 
-{ #category : #'old - deprecated' }
+{ #category : 'old - deprecated' }
 OpalCompiler class >> evaluate: textOrString [
 	self
 		deprecated: 'Please use new compiler API instead'
@@ -96,28 +98,28 @@ OpalCompiler class >> evaluate: textOrString [
 		evaluate
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 OpalCompiler class >> isActive [
 	^Smalltalk compilerClass == self
 ]
 
-{ #category : #overlay }
+{ #category : 'overlay' }
 OpalCompiler class >> overlayEnvironment [
 	^overlayEnvironment ifNil: [ overlayEnvironment := Dictionary new ]
 ]
 
-{ #category : #overlay }
+{ #category : 'overlay' }
 OpalCompiler class >> overlayIsActive [
 	^overlayEnvironment notNil
 ]
 
-{ #category : #overlay }
+{ #category : 'overlay' }
 OpalCompiler class >> overlayStep1CopyClasses [
 	"now we put a copy of all the classes into the environment"
 	self compilerClasses do: [ :class | self overlayEnvironment at: class name put: class copy ]
 ]
 
-{ #category : #overlay }
+{ #category : 'overlay' }
 OpalCompiler class >> overlayStep2Recompile [
 	"now we recompile the classes in the environment with itself as an overlay"
 	self overlayEnvironment valuesDo: [ :class |
@@ -129,7 +131,7 @@ OpalCompiler class >> overlayStep2Recompile [
 					class addSelectorSilently: method selector withMethod: newMethod ] ]
 ]
 
-{ #category : #overlay }
+{ #category : 'overlay' }
 OpalCompiler class >> overlayStep3FixSuperclassPointers [
 	"make sure superclass pointers are correct"
     self overlayEnvironment valuesDo: [ :class |
@@ -137,14 +139,14 @@ OpalCompiler class >> overlayStep3FixSuperclassPointers [
 				ifTrue: [ class superclass: (self overlayEnvironment at: class superclass name)]]
 ]
 
-{ #category : #overlay }
+{ #category : 'overlay' }
 OpalCompiler class >> overlayStep4SetImageCompiler [
 	"make the copy the default compiler for the image"
 	SmalltalkImage compilerClass: (self overlayEnvironment at: #OpalCompiler).
 	ASTCache reset
 ]
 
-{ #category : #overlay }
+{ #category : 'overlay' }
 OpalCompiler class >> overlayStep5UpdateInstances [
 	"transform existing instances to be instances of the overlay"
 	self compilerClasses do: [ :class |
@@ -152,20 +154,20 @@ OpalCompiler class >> overlayStep5UpdateInstances [
 			(self overlayEnvironment at: class name) adoptInstance: object ]]
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 OpalCompiler class >> recompileAll [
 	"Recompile all classes and traits in the system."
 
 	Smalltalk image recompile
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 OpalCompiler class >> register [
 
 	SmalltalkImage current compilerClass: self
 ]
 
-{ #category : #overlay }
+{ #category : 'overlay' }
 OpalCompiler class >> startUsingOverlayForDevelopment [
 	"this method sets up an overlay so we can change the compiler package without breaking the compiler"
 
@@ -180,7 +182,7 @@ OpalCompiler class >> startUsingOverlayForDevelopment [
 		overlayStep5UpdateInstances
 ]
 
-{ #category : #overlay }
+{ #category : 'overlay' }
 OpalCompiler class >> stopUsingOverlayForDevelopment [
 	"set compiler back to normal and throw away overlay environment"
 
@@ -190,23 +192,23 @@ OpalCompiler class >> stopUsingOverlayForDevelopment [
 	ASTCache reset
 ]
 
-{ #category : #plugins }
+{ #category : 'plugins' }
 OpalCompiler >> addParsePlugin: aClass [
 	self compilationContext addParseASTTransformationPlugin: aClass
 ]
 
-{ #category : #plugins }
+{ #category : 'plugins' }
 OpalCompiler >> addPlugin: aClass [
 	self compilationContext addASTTransformationPlugin: aClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> ast [
 
 	^ ast
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> ast: anObject [
 
 	ast := anObject.
@@ -219,18 +221,18 @@ OpalCompiler >> ast: anObject [
 		ifNotNil: [ self compilationContext: ast compilationContext ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> bindings [
 	^ self compilationContext bindings
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> bindings: aDictionary [
 	"allows to define additional binding, note: Globals are not shadowed"
 	self compilationContext bindings: aDictionary
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 OpalCompiler >> buildOuterScope [
 	| newScope |
 
@@ -248,7 +250,7 @@ OpalCompiler >> buildOuterScope [
 	^newScope
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 OpalCompiler >> callParsePlugins [
 	| plugins |
 
@@ -257,7 +259,7 @@ OpalCompiler >> callParsePlugins [
 	plugins do: [ :each | ast := each transform: ast ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 OpalCompiler >> callPlugins [
 	| plugins |
 
@@ -266,12 +268,12 @@ OpalCompiler >> callPlugins [
 	plugins do: [ :each | ast := each transform: ast ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> changeStamp: aString [ 
 	changeStamp := aString
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 OpalCompiler >> checkNotice: aNotice [
 	"This method handles all the logic of error handling.
 	
@@ -334,32 +336,32 @@ OpalCompiler >> checkNotice: aNotice [
 	^ true "Error was resumed, so we consider it's OK to continue"
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> class: aClass [
 	self compilationContext class: aClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> compilationContext [
 	^ compilationContext ifNil: [ compilationContext := self compilationContextClass default ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> compilationContext: anObject [
 	compilationContext := anObject
 ]
 
-{ #category : #plugins }
+{ #category : 'plugins' }
 OpalCompiler >> compilationContextClass [
 	^compilationContextClass ifNil: [ CompilationContext  ]
 ]
 
-{ #category : #plugins }
+{ #category : 'plugins' }
 OpalCompiler >> compilationContextClass: aClass [
 	compilationContextClass := aClass
 ]
 
-{ #category : #'public access' }
+{ #category : 'public access' }
 OpalCompiler >> compile [
 
 	| result |
@@ -375,7 +377,7 @@ OpalCompiler >> compile [
 	^ self generateMethod
 ]
 
-{ #category : #'public access' }
+{ #category : 'public access' }
 OpalCompiler >> compile: textOrString [
 
 	^self
@@ -383,18 +385,18 @@ OpalCompiler >> compile: textOrString [
 		compile
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> compiledMethodClass: aClass [
 
 	self compilationContext compiledMethodClass: aClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> compiledMethodTrailer: bytes [
 	self deprecated: 'CompiledMethodTrailer has been removed in Pharo12. Just set the sourcePointer after compiling, see class comment of the deprecated class CompiledMethodTrailer'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> context: aContext [
 	"Prepare self to parse/compile/evaluate according to a context.
 	This impacts the scope (for name resolutions) and toggles `isScripting` to true.
@@ -410,7 +412,7 @@ OpalCompiler >> context: aContext [
 	self semanticScope: (OCContextualDoItSemanticScope targetingContext: aContext)
 ]
 
-{ #category : #'public access' }
+{ #category : 'public access' }
 OpalCompiler >> decompileMethod: aCompiledMethod [
 	^ Smalltalk globals
 		at: #FBDDecompiler
@@ -420,7 +422,7 @@ OpalCompiler >> decompileMethod: aCompiledMethod [
 		ifAbsent: [ RBMethodNode errorMethodNode: aCompiledMethod selector errorMessage: 'No decompiler available'. ]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 OpalCompiler >> doSemanticAnalysis [
 
 	|scope|
@@ -437,18 +439,18 @@ OpalCompiler >> doSemanticAnalysis [
 	^ ast
 ]
 
-{ #category : #plugins }
+{ #category : 'plugins' }
 OpalCompiler >> encoderClass: aClass [
 	self compilationContext encoderClass: aClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> environment: anEnvironment [
 	"Set the environment (dictionary of class, traits and globals) used during the compilation"
 	self compilationContext environment: anEnvironment
 ]
 
-{ #category : #'public access' }
+{ #category : 'public access' }
 OpalCompiler >> evaluate [
 	"Compiles the sourceStream into a parse tree, then generates code into
 	 a method. If aContext is not nil, the text can refer to temporaries in that
@@ -471,7 +473,7 @@ OpalCompiler >> evaluate [
 	^ value
 ]
 
-{ #category : #'public access' }
+{ #category : 'public access' }
 OpalCompiler >> evaluate: textOrString [
 
 	^self
@@ -479,24 +481,24 @@ OpalCompiler >> evaluate: textOrString [
 		evaluate
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> failBlock [
 
 	^ failBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> failBlock: aBlock [
 
 	failBlock := aBlock
 ]
 
-{ #category : #'public access' }
+{ #category : 'public access' }
 OpalCompiler >> format [
 	^self parse formattedCode
 ]
 
-{ #category : #'public access' }
+{ #category : 'public access' }
 OpalCompiler >> format: textOrString [
 
 	^self
@@ -504,7 +506,7 @@ OpalCompiler >> format: textOrString [
 		format
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 OpalCompiler >> generateIR [
 	| ir |
 
@@ -525,7 +527,7 @@ OpalCompiler >> generateIR [
 	^ ir
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 OpalCompiler >> generateMethod [
 
 	| method ir |
@@ -543,7 +545,7 @@ OpalCompiler >> generateMethod [
 	^ method
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 OpalCompiler >> install [
 	"Compile and install a method in a class"
 
@@ -573,14 +575,14 @@ OpalCompiler >> install [
 	^ method
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 OpalCompiler >> install: aSource [
 
 	self source: aSource.
 	^ self install
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OpalCompiler >> isInteractive [
 
 	self requestor ifNil: [ ^ false ].
@@ -591,29 +593,29 @@ OpalCompiler >> isInteractive [
 		  ifFalse: [ true ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> isScripting [
 	^ self semanticScope isDoItScope
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> isScripting: aBoolean [
 
 	(aBoolean and: [ self isScripting not ]) ifTrue: [
 		self semanticScope: OCReceiverDoItSemanticScope targetingNilReceiver ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> logged [
 	^ logged
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> logged: aBoolean [
 	logged := aBoolean
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 OpalCompiler >> needRequestorScope [
 	"The requestor scope allows the requestor to bind exsiting and new variables, like worspaces variables.
 	Modern requestors should not register temselves but use `bindings:`."
@@ -624,7 +626,7 @@ OpalCompiler >> needRequestorScope [
 	^ self requestor needRequestorScope
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> noPattern: aBoolean [
 
 	self
@@ -634,7 +636,7 @@ OpalCompiler >> noPattern: aBoolean [
 	self isScripting: aBoolean
 ]
 
-{ #category : #'public access' }
+{ #category : 'public access' }
 OpalCompiler >> options: anOptionsArray [
 
 	"Compatibility for those options"
@@ -643,7 +645,7 @@ OpalCompiler >> options: anOptionsArray [
 	self compilationContext parseOptions: anOptionsArray
 ]
 
-{ #category : #'public access' }
+{ #category : 'public access' }
 OpalCompiler >> parse [
 
 	| parser |
@@ -672,7 +674,7 @@ OpalCompiler >> parse [
 	^ ast
 ]
 
-{ #category : #'public access' }
+{ #category : 'public access' }
 OpalCompiler >> parse: textOrString [
 
 	^self
@@ -680,65 +682,65 @@ OpalCompiler >> parse: textOrString [
 		parse
 ]
 
-{ #category : #'public access' }
+{ #category : 'public access' }
 OpalCompiler >> parseLiterals: aString [
 	^self parserClass parseLiterals: aString
 ]
 
-{ #category : #'public access' }
+{ #category : 'public access' }
 OpalCompiler >> parseScript: aString [
 
 	self isScripting: true.
 	^ self parse: aString
 ]
 
-{ #category : #'public access' }
+{ #category : 'public access' }
 OpalCompiler >> parseSelector: aString [
 	"Answer the message selector for the argument, aString, which should parse successfully up to the temporary declaration or the end of the method header."
 
 	^[self parserClass parseMethodPattern: aString] on: Error do: [nil]
 ]
 
-{ #category : #plugins }
+{ #category : 'plugins' }
 OpalCompiler >> parserClass [
 	^self compilationContext parserClass
 ]
 
-{ #category : #'public access' }
+{ #category : 'public access' }
 OpalCompiler >> permitFaulty [
 
 	^ permitFaulty
 ]
 
-{ #category : #'public access' }
+{ #category : 'public access' }
 OpalCompiler >> permitFaulty: aBoolean [
 
 	permitFaulty := aBoolean
 ]
 
-{ #category : #'public access' }
+{ #category : 'public access' }
 OpalCompiler >> permitUndeclared [
 
 	^ permitUndeclared
 ]
 
-{ #category : #'public access' }
+{ #category : 'public access' }
 OpalCompiler >> permitUndeclared: aBoolean [
 
 	permitUndeclared := aBoolean
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> productionEnvironment: anObject [
 	self compilationContext productionEnvironment: anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> protocol: aProtocol [ 
 	protocol := aProtocol
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> receiver [
 
 	^ self semanticScope ifNotNil: [ :scope |
@@ -747,7 +749,7 @@ OpalCompiler >> receiver [
 			  ifFalse: [ nil ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> receiver: anObject [
 
 	"Note: some clients set up a `receiver:` AFTER setting up a `context:`
@@ -757,33 +759,33 @@ OpalCompiler >> receiver: anObject [
 	self semanticScope: (OCReceiverDoItSemanticScope targetingReceiver: anObject)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> requestor [
 	^ requestor
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> requestor: aRequestor [
 	requestor := aRequestor
 ]
 
-{ #category : #plugins }
+{ #category : 'plugins' }
 OpalCompiler >> requestorScopeClass: aClass [
 	"clients can set their own subclass of OCRequestorScope if needed"
 	self compilationContext requestorScopeClass: aClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> semanticScope [
 	^self compilationContext semanticScope
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> semanticScope: anObject [
 	self compilationContext semanticScope: anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 OpalCompiler >> source: aString [
 	"source should be a string, but call contents for old clients that send streams. Some users can also send text and so we transform it into a string. If we don't do this transformation, the compiled method #sourceCode method will return a Text instead of a String which can break its users."
 

--- a/src/OpalCompiler-Core/PrimitiveErrorVariable.class.st
+++ b/src/OpalCompiler-Core/PrimitiveErrorVariable.class.st
@@ -2,15 +2,17 @@
 Primitives can declare a local variable that will hold the error code.
 "
 Class {
-	#name : #PrimitiveErrorVariable,
-	#superclass : #LocalVariable,
+	#name : 'PrimitiveErrorVariable',
+	#superclass : 'LocalVariable',
 	#instVars : [
 		'node'
 	],
-	#category : #'OpalCompiler-Core-Semantics'
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 PrimitiveErrorVariable class >> node: aVariableNode [
 	^self new
 		name: aVariableNode name;
@@ -19,17 +21,17 @@ PrimitiveErrorVariable class >> node: aVariableNode [
 		yourself
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 PrimitiveErrorVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 	^ aProgramNodeVisitor visitTemporaryVariableNode: aNode
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 PrimitiveErrorVariable >> definingNode [
 	^node
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 PrimitiveErrorVariable >> node: anObject [
 	node := anObject
 ]

--- a/src/OpalCompiler-Core/RBAnnotationMarkNode.extension.st
+++ b/src/OpalCompiler-Core/RBAnnotationMarkNode.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #RBAnnotationMarkNode }
+Extension { #name : 'RBAnnotationMarkNode' }
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBAnnotationMarkNode >> emitValue: methodBuilder [
 
 	emitValueBlock ifNotNil: [ ^ emitValueBlock value: methodBuilder ].
@@ -10,13 +10,13 @@ RBAnnotationMarkNode >> emitValue: methodBuilder [
 		send: #signalSyntaxError:
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBAnnotationMarkNode >> emitValueBlock [
 
 	^ emitValueBlock
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBAnnotationMarkNode >> emitValueBlock: anObject [
 
 	emitValueBlock := anObject

--- a/src/OpalCompiler-Core/RBBlockNode.extension.st
+++ b/src/OpalCompiler-Core/RBBlockNode.extension.st
@@ -1,35 +1,35 @@
-Extension { #name : #RBBlockNode }
+Extension { #name : 'RBBlockNode' }
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBBlockNode >> bcToASTCache [
 	^ bcToASTCache ifNil: [ bcToASTCache := OCBytecodeToASTCache generateForNode: self ]
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBBlockNode >> firstPcForNode: aNode [
 
 	^ self bcToASTCache firstBcOffsetForNode: aNode
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBBlockNode >> ir [
 	"if the ir is not yet set, generate the IR for the whole method, it fills the property here"
 	self propertyAt: #ir ifAbsent: [ self methodNode generateIR  ].
 	^self propertyAt: #ir
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBBlockNode >> ir: aIRMethodNode [
 
 	^ self propertyAt: #ir put: aIRMethodNode
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBBlockNode >> irInstruction [
 	^ self parent methodOrBlockNode ir firstInstructionMatching: [:instr | instr sourceNode == self ]
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBBlockNode >> isClean [
 	"a block is clean if..."
 	"it or any embedded blocks do not need self"
@@ -42,7 +42,7 @@ RBBlockNode >> isClean [
 
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBBlockNode >> isInlined [
 	parent isMessage ifFalse: [ ^ false ].
 	parent methodCompilationContextOrNil ifNotNil:[:c | c optionInlineNone ifTrue: [ ^false ]].
@@ -52,7 +52,7 @@ RBBlockNode >> isInlined [
 	^ self isInlinedLoop
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBBlockNode >> isInlinedLoop [
 
 	parent isMessage ifFalse: [ ^ false ].
@@ -65,31 +65,31 @@ RBBlockNode >> isInlinedLoop [
 	^ false
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBBlockNode >> lastPcForNode: aNode [
 
 	^ self bcToASTCache lastBcOffsetForNode: aNode
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBBlockNode >> owningScope [
 
 	^ self scope ifNil: ["inlined" ^ parent owningScope]
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBBlockNode >> pcsForNode: aNode [
 
 	^ self bcToASTCache pcsForNode: aNode
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBBlockNode >> resetBcToASTCache [
 
 	bcToASTCache := nil
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBBlockNode >> sourceNodeForPC: anInteger [
 	^ self bcToASTCache nodeForPC: anInteger
 ]

--- a/src/OpalCompiler-Core/RBMessageNode.extension.st
+++ b/src/OpalCompiler-Core/RBMessageNode.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #RBMessageNode }
+Extension { #name : 'RBMessageNode' }
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMessageNode >> isInlineAndOr [
 
 	self methodCompilationContextOrNil ifNotNil:[:c | c optionInlineAndOr ifFalse: [ ^false ]].
@@ -10,7 +10,7 @@ RBMessageNode >> isInlineAndOr [
 	^self arguments allSatisfy: [ :each |  each isBlock and: [each arguments isEmpty ]]
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMessageNode >> isInlineCase [
 	self methodCompilationContextOrNil ifNotNil:[:c | c optionInlineCase ifFalse: [ ^false ]].
 	self isCascaded ifTrue: [^ false].
@@ -28,7 +28,7 @@ RBMessageNode >> isInlineCase [
 	^ true
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMessageNode >> isInlineIf [
 
 	self methodCompilationContextOrNil ifNotNil: [ :c |
@@ -39,7 +39,7 @@ RBMessageNode >> isInlineIf [
 	^ self arguments allSatisfy: [ :node | node isBlock and: [ node arguments isEmpty ]]
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMessageNode >> isInlineIfNil [
 
 	| assertNone assertOneOrNone |
@@ -66,7 +66,7 @@ RBMessageNode >> isInlineIfNil [
 	^ true
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMessageNode >> isInlineRepeat [
 	self methodCompilationContextOrNil ifNotNil:[:c | c optionInlineRepeat
 		ifFalse: [ ^ false ]].
@@ -80,7 +80,7 @@ RBMessageNode >> isInlineRepeat [
 	^ true
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMessageNode >> isInlineTimesRepeat [
 
 	| block |
@@ -95,7 +95,7 @@ RBMessageNode >> isInlineTimesRepeat [
 	^ true
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMessageNode >> isInlineToDo [
 
 	| block step |
@@ -120,7 +120,7 @@ RBMessageNode >> isInlineToDo [
 	^ true
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMessageNode >> isInlineWhile [
 
 	self methodCompilationContextOrNil ifNotNil:[:c | c optionInlineWhile ifFalse: [ ^false ]].
@@ -135,7 +135,7 @@ RBMessageNode >> isInlineWhile [
 	^ true
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMessageNode >> isInlined [
 	self methodCompilationContextOrNil ifNotNil:[:c | c optionInlineNone ifTrue: [ ^false ]].
 	self isInlineIf ifTrue: [^true].
@@ -149,7 +149,7 @@ RBMessageNode >> isInlined [
 	^false
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMessageNode >> methodCompilationContextOrNil [
 	^ self methodNode ifNotNil: [ :node | node compilationContext ]
 ]

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -1,17 +1,17 @@
-Extension { #name : #RBMethodNode }
+Extension { #name : 'RBMethodNode' }
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> bcToASTCache [
 	^ bcToASTCache ifNil: [ bcToASTCache := OCBytecodeToASTCache generateForNode: self ]
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> bcToASTCache: anObject [
 
 	bcToASTCache := anObject
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> compiledMethod [
 	"Retrieve the associated CompiledMethod (cached version).
 	If no CompiledMethod was generated, nil is returned.
@@ -22,13 +22,13 @@ RBMethodNode >> compiledMethod [
 	^ self propertyAt: #compiledMethod ifAbsent: [ nil ]
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> compiledMethod: aCompiledMethod [
 
 	self propertyAt: #compiledMethod put: aCompiledMethod
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> compiler [
 	"Return a compiler configured with self as the AST"
 
@@ -37,13 +37,13 @@ RBMethodNode >> compiler [
 	^ class compiler ast: self
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> doSemanticAnalysis [
 
 	self compiler doSemanticAnalysis
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> doSemanticAnalysisIn: behavior [
 
 	behavior compiler
@@ -51,12 +51,12 @@ RBMethodNode >> doSemanticAnalysisIn: behavior [
 		doSemanticAnalysis
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> ensureCachedArgumentNames [
 	^self methodPropertyAt: #argumentNames put: self argumentNames
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode class >> errorMethodNode: selector errorMessage: messageText [
 	| message |
 	message := RBMessageNode
@@ -69,13 +69,13 @@ RBMethodNode class >> errorMethodNode: selector errorMessage: messageText [
 		body: (RBSequenceNode statements: {message})
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> firstPcForNode: aNode [
 
 	^ self bcToASTCache firstBcOffsetForNode: aNode
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> generate [
 
 	self deprecated: 'Use generateMethod. Beware that there are limitations so read the comments.' transformWith: '`@receiver generate' -> '`@receiver generateMethod'.
@@ -83,7 +83,7 @@ RBMethodNode >> generate [
 	^ self generateMethod
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> generate: trailer [
 	self
 		deprecated: 'Use generateMethod'
@@ -92,14 +92,14 @@ RBMethodNode >> generate: trailer [
 	^ self generateMethod
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> generateIR [
 	"Generate an IRMethod. See `ir` for the cached version."
 
 	^ self compiler generateIR
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> generateMethod [
 	"Generate a CompiledMethod (uncached, see `compiledMethod` for the cached version).
 	Important: the current state of the AST is not cheched, and specific controls or steps done
@@ -109,42 +109,42 @@ RBMethodNode >> generateMethod [
 	^ self compiler compile
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> ir [
 	"Retrieve or generate an IRMethod (cached version)"
 
 	^ self propertyAt: #ir ifAbsentPut: [ self generateIR ]
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> ir: aIRMethodNode [
 
 	^ self propertyAt: #ir put: aIRMethodNode
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> irInstruction [
 	^ self ir
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> lastPcForNode: aNode [
 
 	^ self bcToASTCache lastBcOffsetForNode: aNode
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> methodProperties [
 	^self propertyAt: #methodProperties ifAbsent: nil
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> methodPropertyAt: aKey [
 
 	^self methodPropertyAt: aKey ifAbsent: [ self error: 'Property not found' ]
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> methodPropertyAt: aKey ifAbsent: absentBlock [
 	| existingProperties |
 	existingProperties := self propertyAt: #methodProperties ifAbsent: absentBlock.
@@ -152,7 +152,7 @@ RBMethodNode >> methodPropertyAt: aKey ifAbsent: absentBlock [
 	^existingProperties propertyAt: aKey ifAbsent: absentBlock
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> methodPropertyAt: aKey put: anObject [
 	| existingProperties newProperties |
 	existingProperties := self propertyAt: #methodProperties ifAbsentPut: [
@@ -166,18 +166,18 @@ RBMethodNode >> methodPropertyAt: aKey put: anObject [
 	self propertyAt: #methodProperties put: newProperties
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> owningScope [
 	^ self scope
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> pcsForNode: aNode [
 
 	^ self bcToASTCache pcsForNode: aNode
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> primitiveFromPragma [
 	^ pragmas
 		detect: [ :each | each isPrimitive ]
@@ -185,7 +185,7 @@ RBMethodNode >> primitiveFromPragma [
 		ifNone: [ IRPrimitive null ]
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> sourceNodeForPC: anInteger [
 	^ self bcToASTCache nodeForPC: anInteger
 ]

--- a/src/OpalCompiler-Core/RBNotice.extension.st
+++ b/src/OpalCompiler-Core/RBNotice.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #RBNotice }
+Extension { #name : 'RBNotice' }
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBNotice >> reparator [
 
 	^ nil

--- a/src/OpalCompiler-Core/RBPragmaNode.extension.st
+++ b/src/OpalCompiler-Core/RBPragmaNode.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #RBPragmaNode }
+Extension { #name : 'RBPragmaNode' }
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBPragmaNode >> asIRPrimitive [
 	"return a IRPrimitive for this method to be used in the compiler intermediate representation"
 	| args module name spec |
@@ -23,19 +23,19 @@ RBPragmaNode >> asIRPrimitive [
 				yourself ]
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBPragmaNode >> asPragma [
 	^ Pragma
 		selector: selector
 		arguments: (arguments collect: [ :each | each value ]) asArray
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBPragmaNode >> isPrimitiveError [
 	^ #( primitive:error: primitive:module:error: primitive:error:module:) includes: self selector
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBPragmaNode >> primitiveErrorVariableName [
 	^(self argumentAt: #error:) value
 ]

--- a/src/OpalCompiler-Core/RBProgramNode.extension.st
+++ b/src/OpalCompiler-Core/RBProgramNode.extension.st
@@ -1,35 +1,35 @@
-Extension { #name : #RBProgramNode }
+Extension { #name : 'RBProgramNode' }
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBProgramNode >> doSemanticAnalysis [
 	self methodNode ifNil: [ ^self ].
 	^ self methodNode doSemanticAnalysis
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBProgramNode >> doSemanticAnalysisIn: aClass [
 	self methodNode ifNil: [ ^self ].
 	^ self methodNode doSemanticAnalysisIn: aClass
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBProgramNode >> irInstruction [
 	^ self methodOrBlockNode ir firstInstructionMatching: [:instr | instr sourceNode == self ]
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBProgramNode >> isAccessingSelf [
 	"return true if accessing an ivar, self or super"
 	^ self children anySatisfy: [ :child | child isAccessingSelf ]
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBProgramNode >> owningScope [
 
 	^ parent owningScope
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBProgramNode >> scope [
 	^ self methodOrBlockNode scope
 ]

--- a/src/OpalCompiler-Core/RBVariableNode.extension.st
+++ b/src/OpalCompiler-Core/RBVariableNode.extension.st
@@ -1,26 +1,26 @@
-Extension { #name : #RBVariableNode }
+Extension { #name : 'RBVariableNode' }
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBVariableNode >> binding [
 	^self variable
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBVariableNode >> binding: aSemVar [
 	self variable: aSemVar
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBVariableNode >> isAccessingSelf [
 	^ self isInstanceVariable or: [ self isSelfVariable or: [self isSuperVariable]]
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBVariableNode >> variable [
 	^variable
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 RBVariableNode >> variable: aSemVar [
 	variable := aSemVar
 ]

--- a/src/OpalCompiler-Core/Set.extension.st
+++ b/src/OpalCompiler-Core/Set.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Set }
+Extension { #name : 'Set' }
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Set >> parseOptions: anArray [
 
 	"

--- a/src/OpalCompiler-Core/String.extension.st
+++ b/src/OpalCompiler-Core/String.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #String }
+Extension { #name : 'String' }
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 String >> parseLiterals [
 	^ self class compiler parseLiterals: self
 ]

--- a/src/OpalCompiler-Core/Symbol.extension.st
+++ b/src/OpalCompiler-Core/Symbol.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Symbol }
+Extension { #name : 'Symbol' }
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Symbol >> asMethodPreamble [
 	self numArgs = 0
 		ifTrue: [ ^ self asString ].

--- a/src/OpalCompiler-Core/TemporaryVariable.class.st
+++ b/src/OpalCompiler-Core/TemporaryVariable.class.st
@@ -2,24 +2,26 @@
 I model temp variables. With Closures, there are two kinds: Copying and those that are stored in a so called temp vector, a heap allocated array that itself is stored in a copying temp variable.
 "
 Class {
-	#name : #TemporaryVariable,
-	#superclass : #LocalVariable,
-	#category : #'OpalCompiler-Core-Semantics'
+	#name : 'TemporaryVariable',
+	#superclass : 'LocalVariable',
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
 }
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 TemporaryVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
 	^ aProgramNodeVisitor visitTemporaryVariableNode: aNode
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 TemporaryVariable >> definingNode [
 	^ scope node temporaries
 		detect: [ :each | each variable == self ]
 		ifNone: [ nil ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TemporaryVariable >> isTempVariable [
 
 	^ true

--- a/src/OpalCompiler-Core/UndefinedObject.extension.st
+++ b/src/OpalCompiler-Core/UndefinedObject.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #UndefinedObject }
+Extension { #name : 'UndefinedObject' }
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 UndefinedObject >> compiler [
 	"Expressions (for example DoIts) are compiled with nil as the class. If we have this method, we can easily use the compiler that the class defines for syntax highlighting and code completion (without needing to add a check for nil)"
 	^self class compilerClass new semanticScope: OCReceiverDoItSemanticScope targetingNilReceiver

--- a/src/OpalCompiler-Core/Variable.extension.st
+++ b/src/OpalCompiler-Core/Variable.extension.st
@@ -1,12 +1,12 @@
-Extension { #name : #Variable }
+Extension { #name : 'Variable' }
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Variable >> analyzeRead: aVariableNode by: aSemanticAnalyzer [
 
 	self isUninitialized ifTrue: [ aSemanticAnalyzer uninitializedVariable: aVariableNode ]
 ]
 
-{ #category : #'*OpalCompiler-Core' }
+{ #category : '*OpalCompiler-Core' }
 Variable >> analyzeWrite: aVariableNode by: aSemanticAnalyzer [
 
 	self isWritable ifFalse: [ aSemanticAnalyzer storeIntoReadOnlyVariable: aVariableNode ]

--- a/src/OpalCompiler-Core/package.st
+++ b/src/OpalCompiler-Core/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'OpalCompiler-Core' }
+Package { #name : 'OpalCompiler-Core' }

--- a/src/TraitsV2/Array.extension.st
+++ b/src/TraitsV2/Array.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Array }
+Extension { #name : 'Array' }
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Array >> asTraitComposition [
 
 	^ self

--- a/src/TraitsV2/Behavior.extension.st
+++ b/src/TraitsV2/Behavior.extension.st
@@ -1,17 +1,17 @@
-Extension { #name : #Behavior }
+Extension { #name : 'Behavior' }
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Behavior >> allTraits [
 	^ #()
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Behavior >> hasTraitComposition [
 
 	^ false
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Behavior >> isAliasSelector: aSymbol [
 	"Return true if the selector aSymbol is an alias defined
 	in my or in another composition somewhere deeper in
@@ -20,7 +20,7 @@ Behavior >> isAliasSelector: aSymbol [
 	^ false
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Behavior >> isComposedBy: aTrait [
 	"Answers if this object includes trait aTrait into its composition"
 	aTrait isTrait ifFalse: [ ^false].
@@ -28,7 +28,7 @@ Behavior >> isComposedBy: aTrait [
 		and: [ self traitComposition includesTrait: aTrait ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Behavior >> isLocalAliasSelector: aSymbol [
 	"Return true if the selector aSymbol is an alias defined
 	in my trait composition."
@@ -36,43 +36,43 @@ Behavior >> isLocalAliasSelector: aSymbol [
 	^ false
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Behavior >> localMethodNamed: selector ifAbsent: aBlock [
 	"Answer the locally defined method associated with the argument, selector (a Symbol), a message selector in the receiver's method dictionary. If the selector is not in the dictionary or it is not a local one, return the value of aBlock"
 
 	^ self compiledMethodAt: selector ifAbsent: aBlock
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Behavior >> localMethods [
 	"returns the methods of classes excluding the ones of the traits that the class uses"
 
 	^ self methods
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Behavior >> localSelectors [
 
 	^ self methodDict keys
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Behavior >> setTraitComposition: aComposition [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Behavior >> traitCompositionString [
 	^ '{}'
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Behavior >> traits [
 	^ #()
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Behavior >> users [
 	^ #()
 ]

--- a/src/TraitsV2/Class.extension.st
+++ b/src/TraitsV2/Class.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Class }
+Extension { #name : 'Class' }
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> immediateSubclass: aClassName uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames package: aCategory [
 
 	^ self classInstaller make: [ :builder |
@@ -14,7 +14,7 @@ Class >> immediateSubclass: aClassName uses: aTraitCompositionOrArray instanceVa
 			  category: aCategory ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> immediateSubclass: aName uses: aTraitComposition instanceVariableNames: someInstanceVariableNames classVariableNames: someClassVariableNames poolDictionaries: someSharedPoolNames package: aCategory [
 
 	^ self classInstaller make: [ :builder |
@@ -29,7 +29,7 @@ Class >> immediateSubclass: aName uses: aTraitComposition instanceVariableNames:
 			  category: aCategory ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> setTraitComposition: aTraitComposition [
 
 	^ self classInstaller
@@ -37,7 +37,7 @@ Class >> setTraitComposition: aTraitComposition [
 		  to: [ :builder | builder traitComposition: aTraitComposition ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> subclass: aName uses: aTraitComposition [
 
 	^ self classInstaller make: [ :builder |
@@ -47,7 +47,7 @@ Class >> subclass: aName uses: aTraitComposition [
 			  traitComposition: aTraitComposition ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> subclass: aName uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames category: aCategory [
 
 	^ self classInstaller make: [ :builder |
@@ -60,7 +60,7 @@ Class >> subclass: aName uses: aTraitCompositionOrArray instanceVariableNames: i
 			  category: aCategory ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> subclass: aName uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames package: aCategory [
 
 	^ self classInstaller make: [ :builder |
@@ -73,7 +73,7 @@ Class >> subclass: aName uses: aTraitCompositionOrArray instanceVariableNames: i
 			  category: aCategory ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> subclass: aName uses: aTraitCompositionOrArray instanceVariableNames: someInstanceVariableNames classVariableNames: someClassVariableNames poolDictionaries: someSharedPoolNames category: aCategory [
 
 	^ self classInstaller make: [ :builder |
@@ -87,7 +87,7 @@ Class >> subclass: aName uses: aTraitCompositionOrArray instanceVariableNames: s
 			  category: aCategory ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> subclass: aName uses: aTraitCompositionOrArray instanceVariableNames: someInstanceVariableNames classVariableNames: someClassVariableNames poolDictionaries: someSharedPoolNames package: aCategory [
 
 	^ self classInstaller make: [ :builder |
@@ -101,7 +101,7 @@ Class >> subclass: aName uses: aTraitCompositionOrArray instanceVariableNames: s
 			  category: aCategory ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> subclass: aSubclassSymbol uses: aTraitCompositionOrArray layout: layoutClass slots: slotDefinition classVariables: classVarDefinition category: aCategorySymbol [
 
 	^ self classInstaller make: [ :builder |
@@ -115,7 +115,7 @@ Class >> subclass: aSubclassSymbol uses: aTraitCompositionOrArray layout: layout
 			  category: aCategorySymbol ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> subclass: aSubclassSymbol uses: aTraitCompositionOrArray layout: layoutClass slots: slotDefinition classVariables: classVarDefinition package: aCategorySymbol [
 
 	^ self classInstaller make: [ :builder |
@@ -129,7 +129,7 @@ Class >> subclass: aSubclassSymbol uses: aTraitCompositionOrArray layout: layout
 			  category: aCategorySymbol ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> subclass: subclassName uses: aTraitComposition layout: aLayout slots: someSlots classVariables: someClassVariables poolDictionaries: somePoolDictionaries category: aCategory [
 
 	^ self classInstaller make: [ :builder |
@@ -144,7 +144,7 @@ Class >> subclass: subclassName uses: aTraitComposition layout: aLayout slots: s
 			  category: aCategory ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> subclass: subclassName uses: aTraitComposition layout: aLayout slots: someSlots classVariables: someClassVariables poolDictionaries: somePoolDictionaries package: aCategory [
 
 	^ self classInstaller make: [ :builder |
@@ -159,7 +159,7 @@ Class >> subclass: subclassName uses: aTraitComposition layout: aLayout slots: s
 			  category: aCategory ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> subclass: subclassName uses: aTraitComposition layout: aLayout slots: someSlots classVariablesNames: someClassVariablesNames poolDictionaries: somePoolDictionaries category: aCategory [
 
 	^ self classInstaller make: [ :builder |
@@ -174,7 +174,7 @@ Class >> subclass: subclassName uses: aTraitComposition layout: aLayout slots: s
 			  category: aCategory ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> subclass: subclassName uses: aTraitComposition layout: aLayout slots: someSlots classVariablesNames: someClassVariablesNames poolDictionaries: somePoolDictionaries package: aCategory [
 
 	^ self classInstaller make: [ :builder |
@@ -189,7 +189,7 @@ Class >> subclass: subclassName uses: aTraitComposition layout: aLayout slots: s
 			  category: aCategory ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> subclass: aSubclassSymbol uses: aTraitCompositionOrArray slots: slotDefinition classVariables: classVarDefinition category: aCategorySymbol [
 
 	^ self classInstaller make: [ :builder |
@@ -202,7 +202,7 @@ Class >> subclass: aSubclassSymbol uses: aTraitCompositionOrArray slots: slotDef
 			  category: aCategorySymbol ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> subclass: aSubclassSymbol uses: aTraitCompositionOrArray slots: slotDefinition classVariables: classVarDefinition package: aCategorySymbol [
 
 	^ self classInstaller make: [ :builder |
@@ -215,7 +215,7 @@ Class >> subclass: aSubclassSymbol uses: aTraitCompositionOrArray slots: slotDef
 			  category: aCategorySymbol ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> subclass: aSubclassSymbol uses: aTraitCompositionOrArray slots: slotDefinition classVariables: classVarDefinition poolDictionaries: someSharedPoolNames category: aCategorySymbol [
 
 	^ self classInstaller make: [ :builder |
@@ -229,7 +229,7 @@ Class >> subclass: aSubclassSymbol uses: aTraitCompositionOrArray slots: slotDef
 			  category: aCategorySymbol ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> subclass: aSubclassSymbol uses: aTraitCompositionOrArray slots: slotDefinition classVariables: classVarDefinition poolDictionaries: someSharedPoolNames package: aCategorySymbol [
 
 	^ self classInstaller make: [ :builder |
@@ -243,19 +243,19 @@ Class >> subclass: aSubclassSymbol uses: aTraitCompositionOrArray slots: slotDef
 			  category: aCategorySymbol ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> usesTrait: aTrait [
 	"Returns whether self or one of its superclasses are among the users of aTrait"
 	^ aTrait users includesAny: self withAllSuperclasses
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> usesTraitLocally: aTrait [
 	"Returns whether self is among the users of aTrait. Note that this will return false if aTrait is used by a superclass of self and not self itself. If you want to get true in this case, use #usesTrait:"
 	^ aTrait users includes: self
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> variableByteSubclass: className uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames category: aCategory [
 
 	^ self classInstaller
@@ -270,7 +270,7 @@ Class >> variableByteSubclass: className uses: aTraitCompositionOrArray instance
 				category: aCategory ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> variableByteSubclass: aName uses: aTraitComposition instanceVariableNames: someInstanceVariableNames classVariableNames: someClassVariableNames poolDictionaries: someSharedPoolNames category: aCategory [
 
 	^ self classInstaller
@@ -286,7 +286,7 @@ Class >> variableByteSubclass: aName uses: aTraitComposition instanceVariableNam
 				category: aCategory ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> variableSubclass: aClassName uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames category: aCategory [
 
 	^ self classInstaller make: [ :builder |
@@ -300,7 +300,7 @@ Class >> variableSubclass: aClassName uses: aTraitCompositionOrArray instanceVar
 			  category: aCategory ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> variableSubclass: aClassName uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames package: aCategory [
 
 	^ self classInstaller make: [ :builder |
@@ -314,7 +314,7 @@ Class >> variableSubclass: aClassName uses: aTraitCompositionOrArray instanceVar
 			  category: aCategory ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> variableSubclass: aName uses: aTraitComposition instanceVariableNames: someInstanceVariableNames classVariableNames: someClassVariableNames poolDictionaries: someSharedPoolNames category: aCategory [
 
 	^ self classInstaller make: [ :builder |
@@ -329,7 +329,7 @@ Class >> variableSubclass: aName uses: aTraitComposition instanceVariableNames: 
 			  category: aCategory ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> variableSubclass: aName uses: aTraitComposition instanceVariableNames: someInstanceVariableNames classVariableNames: someClassVariableNames poolDictionaries: someSharedPoolNames package: aCategory [
 
 	^ self classInstaller make: [ :builder |
@@ -344,7 +344,7 @@ Class >> variableSubclass: aName uses: aTraitComposition instanceVariableNames: 
 			  category: aCategory ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> variableWordSubclass: className uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames category: aCategory [
 
 	^ self classInstaller make: [ :builder |
@@ -358,7 +358,7 @@ Class >> variableWordSubclass: className uses: aTraitCompositionOrArray instance
 			  category: aCategory ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> variableWordSubclass: className uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames package: aCategory [
 
 	^ self classInstaller make: [ :builder |
@@ -372,7 +372,7 @@ Class >> variableWordSubclass: className uses: aTraitCompositionOrArray instance
 			  category: aCategory ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> variableWordSubclass: aName uses: aTraitComposition instanceVariableNames: someInstanceVariableNames classVariableNames: someClassVariableNames poolDictionaries: someSharedPoolNames category: aCategory [
 
 	^ self classInstaller make: [ :builder |
@@ -387,7 +387,7 @@ Class >> variableWordSubclass: aName uses: aTraitComposition instanceVariableNam
 			  category: aCategory ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> variableWordSubclass: aName uses: aTraitComposition instanceVariableNames: someInstanceVariableNames classVariableNames: someClassVariableNames poolDictionaries: someSharedPoolNames package: aCategory [
 
 	^ self classInstaller make: [ :builder |
@@ -402,7 +402,7 @@ Class >> variableWordSubclass: aName uses: aTraitComposition instanceVariableNam
 			  category: aCategory ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> weakSubclass: className uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames category: aCategory [
 
 	^ self classInstaller make: [ :builder |
@@ -416,7 +416,7 @@ Class >> weakSubclass: className uses: aTraitCompositionOrArray instanceVariable
 			  category: aCategory ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> weakSubclass: className uses: aTraitCompositionOrArray instanceVariableNames: instVarNameList classVariableNames: classVarNames package: aCategory [
 
 	^ self classInstaller make: [ :builder |
@@ -430,7 +430,7 @@ Class >> weakSubclass: className uses: aTraitCompositionOrArray instanceVariable
 			  category: aCategory ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> weakSubclass: aName uses: aTraitComposition instanceVariableNames: someInstanceVariableNames classVariableNames: someClassVariableNames poolDictionaries: someSharedPoolNames category: aCategory [
 
 	^ self classInstaller make: [ :builder |
@@ -445,7 +445,7 @@ Class >> weakSubclass: aName uses: aTraitComposition instanceVariableNames: some
 			  category: aCategory ]
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Class >> weakSubclass: aName uses: aTraitComposition instanceVariableNames: someInstanceVariableNames classVariableNames: someClassVariableNames poolDictionaries: someSharedPoolNames package: aCategory [
 
 	^ self classInstaller make: [ :builder |

--- a/src/TraitsV2/ClassDescription.extension.st
+++ b/src/TraitsV2/ClassDescription.extension.st
@@ -1,27 +1,27 @@
-Extension { #name : #ClassDescription }
+Extension { #name : 'ClassDescription' }
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 ClassDescription >> addToComposition: aTrait [
 	self setTraitComposition: self traitComposition + aTrait
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 ClassDescription >> asTraitComposition [
 
 	^ TaCompositionElement for: self
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 ClassDescription >> baseComposition [
 	^ TaEmptyComposition new
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 ClassDescription >> selectorsWithExplicitOrigin [
 	^self traitComposition selectors , self localSelectors
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 ClassDescription >> traitComposition [
 	^ TaEmptyComposition new
 ]

--- a/src/TraitsV2/CompiledMethod.extension.st
+++ b/src/TraitsV2/CompiledMethod.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #CompiledMethod }
+Extension { #name : 'CompiledMethod' }
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 CompiledMethod >> traitSource [
 	^ self propertyAt: #traitSource
 ]

--- a/src/TraitsV2/HEInstaller.extension.st
+++ b/src/TraitsV2/HEInstaller.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #HEInstaller }
+Extension { #name : 'HEInstaller' }
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 HEInstaller >> buildTrait: aTraitDefinition [
 	| newTrait traitComposition traitClass|
 
@@ -21,7 +21,7 @@ HEInstaller >> buildTrait: aTraitDefinition [
 	^ newTrait
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 HEInstaller >> buildTraitCompositionFor: traitComposition [
 
 	| aLiteral |

--- a/src/TraitsV2/Metaclass.extension.st
+++ b/src/TraitsV2/Metaclass.extension.st
@@ -1,35 +1,35 @@
-Extension { #name : #Metaclass }
+Extension { #name : 'Metaclass' }
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Metaclass >> baseLocalMethods [
 	^ self instanceSide methodDict
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Metaclass >> initializeBasicMethods [
 
 	"Nothing to do in the metaclass"
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Metaclass >> setTraitComposition: aTraitCompositionOrArray [
 
 	^ self trait: aTraitCompositionOrArray slots: self slots
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Metaclass >> trait: aTraitCompositionOrArray [
 
 	^ self trait: aTraitCompositionOrArray slots: #()
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Metaclass >> trait: aTraitCompositionOrArray instanceVariableNames: instVarString [
 
 	^ self trait: aTraitCompositionOrArray slots: instVarString asSlotCollection
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Metaclass >> trait: aTraitCompositionOrArray slots: slotArray [
 	| theClass |
 	theClass := self instanceSide.
@@ -43,20 +43,20 @@ Metaclass >> trait: aTraitCompositionOrArray slots: slotArray [
 	^ theClass classSide
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Metaclass >> uses: aTraitCompositionOrArray [
 	"This method will be deprecated better use trait."
 
 	self trait: aTraitCompositionOrArray slots: #()
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Metaclass >> uses: aTraitCompositionOrArray instanceVariableNames: instVarString [
 	"This method will be deprecated better use trait:slots: or trait:instanceVariableNames:"
 	^ self uses: aTraitCompositionOrArray slots: instVarString asSlotCollection
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Metaclass >> uses: aTraitCompositionOrArray slots: slotArray [
 	| theClass |
 	theClass := self instanceSide.

--- a/src/TraitsV2/MetaclassForTraits.class.st
+++ b/src/TraitsV2/MetaclassForTraits.class.st
@@ -3,63 +3,65 @@ I am the metaclass used for traits.
 I implement all the behavior for the classSide traits.
 "
 Class {
-	#name : #MetaclassForTraits,
-	#superclass : #TraitedMetaclass,
+	#name : 'MetaclassForTraits',
+	#superclass : 'TraitedMetaclass',
 	#instVars : [
 		'users'
 	],
-	#category : #'TraitsV2-Base'
+	#category : 'TraitsV2-Base',
+	#package : 'TraitsV2',
+	#tag : 'Base'
 }
 
-{ #category : #operations }
+{ #category : 'operations' }
 MetaclassForTraits >> + anotherTrait [
 	"I return my self in a sequence with anotherTrait"
 	^ self asTraitComposition + anotherTrait asTraitComposition
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 MetaclassForTraits >> - anArray [
 	"I return myself with a removed method. Check TaAbstractComposition >> #- for more details"
 
 	^ self asTraitComposition - anArray
 ]
 
-{ #category : #composition }
+{ #category : 'composition' }
 MetaclassForTraits >> @ anArray [
 	"I return myself with an aliased method. Check TaAbstractComposition >> #@ for more details"
 	^ self asTraitComposition @ anArray
 ]
 
-{ #category : #users }
+{ #category : 'users' }
 MetaclassForTraits >> addUser: aClass [
 
 	self users add: aClass
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 MetaclassForTraits >> asTraitComposition [
 	^ TaClassCompositionElement for: self
 ]
 
-{ #category : #fileout }
+{ #category : 'fileout' }
 MetaclassForTraits >> expandedDefinitionStringFor: aPrinter [
 
 	^ aPrinter expandedTraitClassDefinitionString
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MetaclassForTraits >> isBaseTrait [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MetaclassForTraits >> isClassTrait [
 
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MetaclassForTraits >> isEmpty [
 	"Since we can have potential an empty array in the fluid definition (to be revisited)
 	when the trait composition is aTrait it received the message isEmpty and would break
@@ -68,34 +70,34 @@ MetaclassForTraits >> isEmpty [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MetaclassForTraits >> isRejectedMethod: aSelector [
 	^ (super isRejectedMethod: aSelector)
 		or: [ Trait methodDict includesKey: aSelector ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MetaclassForTraits >> isTrait [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MetaclassForTraits >> isTraitAlias [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 MetaclassForTraits >> isTraitExclusion [
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MetaclassForTraits >> name [
 
 	^ thisClass ifNil: [ 'a MetaclassForTraits' ] ifNotNil: [ thisClass name asString , ' classTrait' ]
 ]
 
-{ #category : #'organization updating' }
+{ #category : 'organization updating' }
 MetaclassForTraits >> notifyOfRecategorizedSelector: selector from: oldProtocol to: newProtocol [
 	"When there is a recategorization of a selector, I propagate the changes to my users"
 
@@ -103,14 +105,14 @@ MetaclassForTraits >> notifyOfRecategorizedSelector: selector from: oldProtocol 
 	self traitUsers do: [ :e | e recategorizeSelector: selector from: oldProtocol to: newProtocol ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 MetaclassForTraits >> printOn: aStream [
 	aStream
 		nextPutAll: self instanceSide name;
 		nextPutAll: ' classTrait'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MetaclassForTraits >> rebuildMethodDictionary [
 	"I extend the behavior in TraitedMetaclass propagating the changes to my users"
 	super rebuildMethodDictionary ifFalse: [ ^ false].
@@ -118,24 +120,24 @@ MetaclassForTraits >> rebuildMethodDictionary [
 	^ true
 ]
 
-{ #category : #users }
+{ #category : 'users' }
 MetaclassForTraits >> removeUser: aClass [
 
 	self users remove: aClass ifAbsent: [  ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MetaclassForTraits >> traitUsers [
 	^ self users
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MetaclassForTraits >> users [
 
 	^ users ifNil: [ users := IdentitySet new ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MetaclassForTraits >> users: anObject [
 	users := anObject
 ]

--- a/src/TraitsV2/Protocol.extension.st
+++ b/src/TraitsV2/Protocol.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Protocol }
+Extension { #name : 'Protocol' }
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 Protocol class >> traitConflictName [
 	"I am protocol used when traits are bringing a method and a protocol conflict happens."
 

--- a/src/TraitsV2/ShiftClassBuilder.extension.st
+++ b/src/TraitsV2/ShiftClassBuilder.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #ShiftClassBuilder }
+Extension { #name : 'ShiftClassBuilder' }
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 ShiftClassBuilder >> beTrait [
 
 	self
@@ -9,17 +9,17 @@ ShiftClassBuilder >> beTrait [
 		metaclassClass: MetaclassForTraits
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 ShiftClassBuilder >> isTrait [
 	^ self metaSuperclass isKindOf: Trait class
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 ShiftClassBuilder >> traitComposition [
 	^ extensibleProperties at: #traitComposition ifAbsent: {}
 ]
 
-{ #category : #'*TraitsV2' }
+{ #category : '*TraitsV2' }
 ShiftClassBuilder >> traitComposition: aValue [
 
 	| aTraitComposition |

--- a/src/TraitsV2/TaAbstractComposition.class.st
+++ b/src/TraitsV2/TaAbstractComposition.class.st
@@ -8,32 +8,34 @@ I know how to resolve the methods and slots included in a trait or traited class
 Also I and my subclasses control how the new methods are compiled.
 "
 Class {
-	#name : #TaAbstractComposition,
-	#superclass : #Object,
-	#category : #'TraitsV2-Compositions'
+	#name : 'TaAbstractComposition',
+	#superclass : 'Object',
+	#category : 'TraitsV2-Compositions',
+	#package : 'TraitsV2',
+	#tag : 'Compositions'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaAbstractComposition class >> isAbstract [
 
 	^self == TaAbstractComposition
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaAbstractComposition >> + anotherTrait [
 	"I create another TaSequence with me and then I concatenate anotherTrait to it. The new sequence includes both elements, me and the anotherTrait.
 	This operation creates a new sequence with copies. Does not affect the existing one."
 	^ (TaSequence with: self) + anotherTrait asTraitComposition
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaAbstractComposition >> , anotherTrait [
 	"I create another TaSequence with me and then I concatenate anotherTrait to it. The new sequence includes both elements, me and the anotherTrait.
 	This operation creates a new sequence with copies. Does not affect the existing one."
 	^ (TaSequence with: self) , anotherTrait asTraitComposition
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaAbstractComposition >> - anArrayOrASymbol [
 	| anArray |
 
@@ -46,7 +48,7 @@ TaAbstractComposition >> - anArrayOrASymbol [
 	^ TaRemoveMethod remove: anArray to: self
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaAbstractComposition >> -- anArrayOfSlotNames [
 
 	"I create a new trait composition element, from me but without the slot named as the parameter"
@@ -54,24 +56,24 @@ TaAbstractComposition >> -- anArrayOfSlotNames [
 	^ TaRemoveSlot remove: anArrayOfSlotNames from: self
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 TaAbstractComposition >> = anotherTrait [
 	^ self shouldBeImplemented
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaAbstractComposition >> @ anArrayOfAssociations [
 	"I return a new trait composition with the aliases passed as parameters. It is an array of associations, the keys are the new selectors and the values are the original selectors"
 	^ TaAliasMethod alias: anArrayOfAssociations to: self
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaAbstractComposition >> @= anAssociation [
 	"This performs a deep alias, rewriting all the sendings of this message. The association has its key as the new alias selector and the value as the original selector."
 	^ TaDeepAliasMethod alias:anAssociation to: self
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaAbstractComposition >> @@ anArrayOfAssociations [
 
 	"This operation creates a new trait composition element with a slot renamed.
@@ -80,7 +82,7 @@ TaAbstractComposition >> @@ anArrayOfAssociations [
 	^ TaRenameSlot rename: anArrayOfAssociations on: self
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaAbstractComposition >> addToSequence: sequence [
 
 	"I basically add myself to the sequence passed as parameter. For sure you want to use #+ or #,"
@@ -88,43 +90,43 @@ TaAbstractComposition >> addToSequence: sequence [
 	^ sequence
 ]
 
-{ #category : #'transforming selectors' }
+{ #category : 'transforming selectors' }
 TaAbstractComposition >> aliasSelector: anOldSelector [
 	"I return the new selector for the old selector passed as parameter"
 	^ self shouldBeImplemented
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaAbstractComposition >> allSelectors [
 	"I return all the selectors exported by the trait composition"
 	^ self selectors
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaAbstractComposition >> allTraits [
 	"I should return all the traits in the trait composition and the traits refered by the traits in the trait composition. It is recursive! #traits is the non recursive version"
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 TaAbstractComposition >> asTraitComposition [
 	^ self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaAbstractComposition >> changesSourceCode: aSelector [
 	"Checks if a selector should be compiled because its code has been rewritten."
 	self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaAbstractComposition >> classComposition [
 	"This is used to access to the classSide of the traitComposition. Used when creating a traited class without class side traitComposition"
 	^ self subclassResponsibility
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 TaAbstractComposition >> compile: selector into: aClass [
 	"Compile the method associated with selector in aClass's method dictionary.
 	This version classify the method in the class passed as parameter"
@@ -154,14 +156,14 @@ TaAbstractComposition >> compile: selector into: aClass [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaAbstractComposition >> compiledMethodAt: aSelector [
 	"Access the compiledMethod to use for a given selector. It should handle aliases, sequences and removals.
 	It signals NotFound"
 	self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaAbstractComposition >> compiledMethodAt: aSelector ifAbsent: aValuable [
 
 	"It handles the NotFound in a graceful way"
@@ -171,7 +173,7 @@ TaAbstractComposition >> compiledMethodAt: aSelector ifAbsent: aValuable [
 		do: [ ^ aValuable value ]
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaAbstractComposition >> copyMethod: aSelector into: aClass replacing: replacing [
 	"When the included method does not need to be source rewritten or recompiled,
 	it is query by using #changesSourceCode:, the method is inserted in aClass' method dictionary.
@@ -213,7 +215,7 @@ TaAbstractComposition >> copyMethod: aSelector into: aClass replacing: replacing
 	^ true
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 TaAbstractComposition >> copySlot: aSlot [
 	"This is a utitlity method to handle the copy of a slot. It is used for instance side and class side slots."
 	| newOne |
@@ -223,25 +225,25 @@ TaAbstractComposition >> copySlot: aSlot [
 	^ newOne
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 TaAbstractComposition >> copyTraitExpression [
 	"I should copy all the elements in the traitComposition"
 	^ self subclassResponsibility
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 TaAbstractComposition >> copyWithoutTrait: aTrait [
 	"Returns a copy without the aTrait"
 	self subclassResponsibility
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaAbstractComposition >> getSourceCodeOf: aCompiledMethod usingSelector: aSelector [
 
 	^ aCompiledMethod getSourceReplacingSelectorWith: aSelector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaAbstractComposition >> hasMethod: aSelector [
 	^ [ self compiledMethodAt: aSelector.
 	true ]
@@ -249,18 +251,18 @@ TaAbstractComposition >> hasMethod: aSelector [
 		do: [ ^ false ]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 TaAbstractComposition >> hash [
 	^ self subclassResponsibility
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaAbstractComposition >> includesTrait: aTrait [
 	"Checks if the trait is used in the trait composition"
 	^ self allTraits includes: aTrait
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaAbstractComposition >> initializeObject: anObject [
 
 	"Handles the custom initialization of a class using stateful talents.
@@ -274,14 +276,14 @@ TaAbstractComposition >> initializeObject: anObject [
 		ifTrue: [ selector value: anObject ]
 ]
 
-{ #category : #'transforming selectors' }
+{ #category : 'transforming selectors' }
 TaAbstractComposition >> initializeSelectorForMe [
 	"Calculates the name of the artificial selector added when a stateful trait includes a initialize method"
 
 	^ self shouldBeImplemented
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaAbstractComposition >> installSelector: aSelector into: aClass [
 	"
 	This method tryies to install a selector in a given class.
@@ -292,7 +294,7 @@ TaAbstractComposition >> installSelector: aSelector into: aClass [
 	^ self installSelector: aSelector into: aClass replacing: true
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaAbstractComposition >> installSelector: aSelector into: aClass replacing: replacing [
 	"
 	This method tryies to install a selector in a given class.
@@ -307,60 +309,60 @@ TaAbstractComposition >> installSelector: aSelector into: aClass replacing: repl
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaAbstractComposition >> isAliasSelector: aSelector [
 
 	"Tests if aSelector is alias to another selector"
 	self subclassResponsibility
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaAbstractComposition >> isEmpty [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaAbstractComposition >> isLocalAliasSelector: aSymbol [
 	"Return true if the selector aSymbol is an alias I define."
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaAbstractComposition >> isNotEmpty [
 	^ self isEmpty not
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaAbstractComposition >> isSourcesPresentInSystem [
 
 	^ ((Smalltalk globals includesKey: #SourceFiles) and: [ (Smalltalk globals at: #SourceFiles) notNil])
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaAbstractComposition >> name [
 	self subclassResponsibility
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaAbstractComposition >> needsRecompilation: aSelector [
 	"Checks if a selector should be compiled because it uses new slots or if its code has been rewritten."
 
 	^ self slots isNotEmpty or: [ self changesSourceCode: aSelector ]
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaAbstractComposition >> originSelectorOf: aSelector [
 	"The original selector for a given selector. It is overriden by the alias."
 	^ aSelector
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 TaAbstractComposition >> printOn: aStream [
 
 	aStream nextPutAll: self traitCompositionExpression
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaAbstractComposition >> protocolForMethod: method [
 	"I return the protocol of the method given as parameter.
 	This is useful when the method is aliased or the method came from different traits or it is a conflicting protocol.
@@ -369,13 +371,13 @@ TaAbstractComposition >> protocolForMethod: method [
 	^ method protocolName
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaAbstractComposition >> reverseAlias: aSelector [
 	"Returns all the aliases that point to this old selector"
 	self subclassResponsibility
 ]
 
-{ #category : #compiling }
+{ #category : 'compiling' }
 TaAbstractComposition >> saveSourceCode: sourceCode ofMethod: newMethod [
 
 	"I have to check because during bootstrap there is no SouceFiles"
@@ -385,12 +387,12 @@ TaAbstractComposition >> saveSourceCode: sourceCode ofMethod: newMethod [
 					withPreamble: [:f | f cr; nextPut: $!; nextChunkPut: 'Trait method'; cr]].
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaAbstractComposition >> selectors [
 	self subclassResponsibility
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 TaAbstractComposition >> semanticallyEquals: another [
 	"Checks if I have the same effect that another traitComposition.
 	I have the same effect if I expose the same selectors and the methods have the same source code.
@@ -401,18 +403,18 @@ TaAbstractComposition >> semanticallyEquals: another [
 						allSatisfy: [ :e | (self sourceCodeAt: e) = (another sourceCodeAt: e) ] ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaAbstractComposition >> slots [
 	self subclassResponsibility
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 TaAbstractComposition >> slotsCopy [
 
 	^ self slots collect: [ :each | self copySlot: each ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaAbstractComposition >> sourceCodeAt: selector [
 	| method |
 	"Returns the source code for a given selector. Handling the rewriting if it is an alias"
@@ -422,48 +424,48 @@ TaAbstractComposition >> sourceCodeAt: selector [
 		ifFalse: [ method getSourceReplacingSelectorWith: selector ]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 TaAbstractComposition >> syntacticallyEquals: another [
 	"This is not 100% true, but it is kept for compatibility with the old implementation.
 	If two trait composition are syntaticallyEquals they should be semanticallyEquals, however the inverse may not be true."
 	^ self semanticallyEquals: another
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 TaAbstractComposition >> traitCompositionExpression [
 	"I give my expression, having parens if they are needed"
 	^ self subclassResponsibility
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 TaAbstractComposition >> traitCompositionExpressionWithParens [
 	"I give my expression, having always parens "
 
 	^ '(' , self traitCompositionExpression , ')'
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaAbstractComposition >> traitDefining: selector [
 	"I return the trait that is used to find the definition of this selector
 	It signals NotFound if it is not found"
 	^ self shouldBeImplemented
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaAbstractComposition >> traitDefining: aSelector ifNone: aBlockClosure [
 	"I return the trait that is used to find the definition of this selector. If none the block is evaluated"
 
 	[ ^ self traitDefining: aSelector ] on: NotFound do: [ ^ aBlockClosure value ]
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaAbstractComposition >> traits [
 	"Returns the traits directly used in the trait composition. #allTraits returns all the traits used and the ones referenced recursively."
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaAbstractComposition >> without: anotherTrait [
 	"Creates a copy of it self without the given trait"
 

--- a/src/TraitsV2/TaAliasMethod.class.st
+++ b/src/TraitsV2/TaAliasMethod.class.st
@@ -4,15 +4,17 @@ As a result, the new trait includes both methods, the original and the newone wi
 I implement the #@ operator.
 "
 Class {
-	#name : #TaAliasMethod,
-	#superclass : #TaSingleComposition,
+	#name : 'TaAliasMethod',
+	#superclass : 'TaSingleComposition',
 	#instVars : [
 		'aliases'
 	],
-	#category : #'TraitsV2-Compositions'
+	#category : 'TraitsV2-Compositions',
+	#package : 'TraitsV2',
+	#tag : 'Compositions'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 TaAliasMethod class >> alias:anArrayOfAssociations to: aTrait [
 	^ self new
 		aliases: anArrayOfAssociations asDictionary;
@@ -21,30 +23,30 @@ TaAliasMethod class >> alias:anArrayOfAssociations to: aTrait [
 		yourself
 ]
 
-{ #category : #'transforming selectors' }
+{ #category : 'transforming selectors' }
 TaAliasMethod >> aliasSelector: aSelector [
 	^ (self hasAliasForOld: aSelector)
 		ifTrue: [ self newSelectorFor: aSelector ]
 		ifFalse: [ inner aliasSelector: aSelector ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaAliasMethod >> aliases [
 	^ aliases
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaAliasMethod >> aliases: anObject [
 	aliases := anObject
 ]
 
-{ #category : #'transforming selectors' }
+{ #category : 'transforming selectors' }
 TaAliasMethod >> changesSourceCode: aSelector [
 
 	^ self hasAliasForNew: aSelector
 ]
 
-{ #category : #validation }
+{ #category : 'validation' }
 TaAliasMethod >> checkAssociations [
 	"I check the validity of the associations used for aliasing"
 	self aliases
@@ -60,7 +62,7 @@ TaAliasMethod >> checkAssociations [
 			(inner compiledMethodAt: old) ifNil: [ NotFound signalFor: old ]" ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaAliasMethod >> compiledMethodAt: aSelector [
 
 	^ (self hasAliasForNew: aSelector)
@@ -68,18 +70,18 @@ TaAliasMethod >> compiledMethodAt: aSelector [
 		ifFalse: [ inner compiledMethodAt: aSelector ]
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 TaAliasMethod >> copyTraitExpression [
 	^ self class alias: aliases to: inner
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 TaAliasMethod >> copyWithoutTrait: aTrait [
 
 	^ self inner = aTrait ifTrue: [ TaEmptyComposition new ] ifFalse: [ self copy ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaAliasMethod >> existingAliasedSelectors [
 	| innerSelectors |
 	"I calculate the new aliases selectors"
@@ -90,56 +92,56 @@ TaAliasMethod >> existingAliasedSelectors [
 		thenCollect: [ :a | a key ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaAliasMethod >> hasAliasForNew: aSelector [
 	"Check if there is a alias for a new selector"
 	^ aliases includesKey: aSelector
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaAliasMethod >> hasAliasForOld: aSelector [
 	"Check if there is a alias for a old selector"
 	^ aliases values includes: aSelector
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaAliasMethod >> isAliasSelector: aSelector [
 
 	^ (self aliases includesKey: aSelector) or: [ inner isAliasSelector: aSelector ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaAliasMethod >> isLocalAliasSelector: aSymbol [
 	^ (self hasAliasForNew: aSymbol) or: [ inner isLocalAliasSelector: aSymbol ]
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 TaAliasMethod >> newSelectorFor: aSelector [
 	^ aliases keyAtValue: aSelector
 ]
 
-{ #category : #aliasing }
+{ #category : 'aliasing' }
 TaAliasMethod >> oldSelectorFor: aSelector [
 	^ aliases at: aSelector
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaAliasMethod >> originSelectorOf: aSelector [
 
 	^ aliases at: aSelector ifAbsent: [ aSelector ]
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaAliasMethod >> reverseAlias: aSelector [
 	^ (inner reverseAlias: aSelector) , (aliases associations select: [ :a | a value = aSelector ] thenCollect: #key)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaAliasMethod >> selectors [
 	^ inner selectors , self existingAliasedSelectors.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaAliasMethod >> sourceCodeAt: aSelector [
 	^ (self hasAliasForNew: aSelector)
 		ifTrue: [ (inner compiledMethodAt: (self oldSelectorFor: aSelector))
@@ -147,13 +149,13 @@ TaAliasMethod >> sourceCodeAt: aSelector [
 		ifFalse: [ super sourceCodeAt: aSelector ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 TaAliasMethod >> traitCompositionExpression [
 
 	^ self inner traitCompositionExpressionWithParens , ' @ ' , aliases associations printString
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaAliasMethod >> traitDefining: aSelector [
 	^ (self hasAliasForNew: aSelector)
 		ifTrue: [ inner traitDefining: (self oldSelectorFor: aSelector) ]

--- a/src/TraitsV2/TaClassCompositionElement.class.st
+++ b/src/TraitsV2/TaClassCompositionElement.class.st
@@ -3,12 +3,14 @@ I represent the root element in a TraitComposition.
 I wrap a metaclass or classTrait to be used as a trait in a trait composition.
 "
 Class {
-	#name : #TaClassCompositionElement,
-	#superclass : #TaCompositionElement,
-	#category : #'TraitsV2-Compositions'
+	#name : 'TaClassCompositionElement',
+	#superclass : 'TaCompositionElement',
+	#category : 'TraitsV2-Compositions',
+	#package : 'TraitsV2',
+	#tag : 'Compositions'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaClassCompositionElement >> methods [
 	"As I am representing a ClassTrait I have to filter the methods that are in all the class traits"
 
@@ -21,7 +23,7 @@ TaClassCompositionElement >> methods [
 		  (innerClassLocalMethods includes: methodSelector) not and: [ traitedClassSelectors anySatisfy: [ :x | x = methodSelector ] ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaClassCompositionElement >> selectors [
 	"As I am representing a ClassTrait I have to filter the methods that are in all the class traits"
 
@@ -34,7 +36,7 @@ TaClassCompositionElement >> selectors [
 		  (innerClassLocalMethods includes: methodSelector) not and: [ traitedClassSelectors anySatisfy: [ :x | x = methodSelector ] ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaClassCompositionElement >> slots [
 	^ innerClass allSlots
 		reject: [ :e |
@@ -42,7 +44,7 @@ TaClassCompositionElement >> slots [
 			TraitedClass allSlots) anySatisfy: [ :x | x name = e name ] ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 TaClassCompositionElement >> traitCompositionExpression [
 
 	^ innerClass instanceSide name , ' classTrait'

--- a/src/TraitsV2/TaCompositionElement.class.st
+++ b/src/TraitsV2/TaCompositionElement.class.st
@@ -3,72 +3,74 @@ I represent the root element in a TraitComposition.
 I wrap a class or Trait to be used as a trait in a trait composition.
 "
 Class {
-	#name : #TaCompositionElement,
-	#superclass : #TaAbstractComposition,
+	#name : 'TaCompositionElement',
+	#superclass : 'TaAbstractComposition',
 	#instVars : [
 		'innerClass'
 	],
-	#category : #'TraitsV2-Compositions'
+	#category : 'TraitsV2-Compositions',
+	#package : 'TraitsV2',
+	#tag : 'Compositions'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 TaCompositionElement class >> for: aClass [
 	^ self new
 		innerClass: aClass;
 		yourself
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 TaCompositionElement >> = aTrait [
 	^ (aTrait species = self species)
 		ifTrue: [ aTrait innerClass = self innerClass ]
 		ifFalse: [ ^ false ]
 ]
 
-{ #category : #users }
+{ #category : 'users' }
 TaCompositionElement >> addUser: aClass [
 	"When a user is added to me I propagate to the real Trait, as I am the root of the TraitComposition"
 	innerClass addUser: aClass
 ]
 
-{ #category : #'transforming selectors' }
+{ #category : 'transforming selectors' }
 TaCompositionElement >> aliasSelector: selector [
 	^ selector = #initializeTalent
 		ifTrue: [ self initializeSelectorForMe ]
 		ifFalse: [ selector ]
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaCompositionElement >> allTraits [
 	^ { innerClass } , innerClass traitComposition allTraits
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaCompositionElement >> changesSourceCode: aSelector [
 
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaCompositionElement >> classComposition [
 
 	^ TaClassCompositionElement for: innerClass class
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaCompositionElement >> compiledMethodAt: selector [
 	| newSelector |
 	newSelector := self dealiasSelector: selector.
 	^ innerClass methods detect: [ :e | e selector = newSelector ] ifNone: [ innerClass traitComposition compiledMethodAt: newSelector ]
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 TaCompositionElement >> copyTraitExpression [
 	"I can be just shallowCopy, because I have only a reference to the real Trait"
 	^ self shallowCopy
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 TaCompositionElement >> copyWithoutTrait: aTrait [
 
 	"If you want to remove a trait that is equivalent to me, I return an empty composition.
@@ -76,7 +78,7 @@ TaCompositionElement >> copyWithoutTrait: aTrait [
 	^ self = aTrait ifTrue: [ TaEmptyComposition new ] ifFalse: [ self copy ]
 ]
 
-{ #category : #'transforming selectors' }
+{ #category : 'transforming selectors' }
 TaCompositionElement >> dealiasSelector: oldSelector [
 	"Usefule to dealias the initialize selector. Used mostly with stateful Talents"
 
@@ -87,43 +89,43 @@ TaCompositionElement >> dealiasSelector: oldSelector [
 		  ifFalse: [ oldSelector ]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 TaCompositionElement >> hash [
 	^ self innerClass hash
 ]
 
-{ #category : #'transforming selectors' }
+{ #category : 'transforming selectors' }
 TaCompositionElement >> initializeSelectorForMe [
 	^ ('initializeTalent_' , self name) asSymbol
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaCompositionElement >> innerClass [
 	^ innerClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaCompositionElement >> innerClass: anObject [
 	innerClass := anObject
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaCompositionElement >> isAliasSelector: aString [
 
 	^ innerClass traitComposition isAliasSelector: aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaCompositionElement >> methods [
 	^innerClass methods
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaCompositionElement >> name [
 	^ innerClass name
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaCompositionElement >> needsRecompilation: aSelector [
 	"We need to recompile if there is a supersend"
 
@@ -133,19 +135,19 @@ TaCompositionElement >> needsRecompilation: aSelector [
 		  ifAbsent: [ true ]
 ]
 
-{ #category : #users }
+{ #category : 'users' }
 TaCompositionElement >> removeUser: aClass [
 	"When a user is removed from me I propagate to the real Trait, as I am the root of the TraitComposition"
 	innerClass removeUser: aClass
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaCompositionElement >> reverseAlias: aSelector [
 
 	^ #()
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaCompositionElement >> selectors [
 	" I get all the selectors of the methods in this talent, if there is a #initializeTalent selector I rename it to #initializeTalent_NameOfTalent"
 
@@ -156,24 +158,24 @@ TaCompositionElement >> selectors [
 		  ifFalse: [ originals ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaCompositionElement >> slots [
 	^ innerClass allSlots
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 TaCompositionElement >> traitCompositionExpression [
 
 	^ innerClass name
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 TaCompositionElement >> traitCompositionExpressionWithParens [
 
 	^ self traitCompositionExpression
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaCompositionElement >> traitDefining: selector [
 	| newSelector |
 	newSelector := self dealiasSelector: selector.
@@ -184,12 +186,12 @@ TaCompositionElement >> traitDefining: selector [
 		ifNone: [ innerClass traitComposition traitDefining: newSelector ]
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaCompositionElement >> traits [
 	^ { innerClass }
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaCompositionElement >> without: anotherTrait [
 	^ self = anotherTrait ifTrue:[nil] ifFalse:[self]
 ]

--- a/src/TraitsV2/TaDeepAliasMethod.class.st
+++ b/src/TraitsV2/TaDeepAliasMethod.class.st
@@ -5,18 +5,20 @@ I am useful when you want to rename a method. You alias deeply with me and then 
 I implement the #@=  operator.
 "
 Class {
-	#name : #TaDeepAliasMethod,
-	#superclass : #TaAliasMethod,
-	#category : #'TraitsV2-Compositions'
+	#name : 'TaDeepAliasMethod',
+	#superclass : 'TaAliasMethod',
+	#category : 'TraitsV2-Compositions',
+	#package : 'TraitsV2',
+	#tag : 'Compositions'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaDeepAliasMethod >> changesSourceCode: aSelector [
 
 	^ true
 ]
 
-{ #category : #rewriting }
+{ #category : 'rewriting' }
 TaDeepAliasMethod >> rewriteText: aSelector [
 	| stream |
 	stream := WriteStream on: String new.
@@ -37,7 +39,7 @@ TaDeepAliasMethod >> rewriteText: aSelector [
 	^ stream contents
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaDeepAliasMethod >> sourceCodeAt: aSelector [
 	| originalSourceCode parseTree rewriter |
 	originalSourceCode := super sourceCodeAt: aSelector.

--- a/src/TraitsV2/TaEmptyComposition.class.st
+++ b/src/TraitsV2/TaEmptyComposition.class.st
@@ -3,144 +3,146 @@ I am an empty composition
 I have no methods or slots :(
 "
 Class {
-	#name : #TaEmptyComposition,
-	#superclass : #TaAbstractComposition,
-	#category : #'TraitsV2-Compositions'
+	#name : 'TaEmptyComposition',
+	#superclass : 'TaAbstractComposition',
+	#category : 'TraitsV2-Compositions',
+	#package : 'TraitsV2',
+	#tag : 'Compositions'
 }
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaEmptyComposition >> , anotherTrait [
 	^ anotherTrait
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaEmptyComposition >> - anArrayOfSelectors [
 	self error:'Could not remove a selector from an empty composition'
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 TaEmptyComposition >> = anotherTrait [
 	^ self class = anotherTrait class
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaEmptyComposition >> @ anAssociation [
 	self error:'Could not perform on empty composition'
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaEmptyComposition >> @= anAssociation [
 	self error:'Could not perform on empty composition'
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaEmptyComposition >> @@ anAssociation [
 	self error:'Could not perform on empty composition'
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaEmptyComposition >> addToSequence: sequence [
 	"I am empty I will not add my self to anybody"
 	^ sequence
 ]
 
-{ #category : #users }
+{ #category : 'users' }
 TaEmptyComposition >> addUser: aClass [
 
 	"Nothing to do.... I am empty"
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaEmptyComposition >> allTraits [
 	^ #()
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaEmptyComposition >> changesSourceCode: aString [
 
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaEmptyComposition >> classComposition [
 	^ self class new
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaEmptyComposition >> compiledMethodAt: aSelector [
 	NotFound signalFor: aSelector
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 TaEmptyComposition >> copyTraitExpression [
 	^ self
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 TaEmptyComposition >> copyWithoutTrait: aTrait [
 	^ self
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 TaEmptyComposition >> hash [
 	^ 1
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaEmptyComposition >> isAliasSelector: aString [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaEmptyComposition >> isEmpty [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaEmptyComposition >> methods [
 	^ #()
 ]
 
-{ #category : #users }
+{ #category : 'users' }
 TaEmptyComposition >> removeUser: aClass [
 
 	"Nothing to do.... I am empty"
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaEmptyComposition >> reverseAlias: aSelector [
 
 	^ #()
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaEmptyComposition >> selectors [
 	^#()
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaEmptyComposition >> slots [
 	^ #()
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 TaEmptyComposition >> traitCompositionExpression [
 
 	^ '{}'
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 TaEmptyComposition >> traitCompositionExpressionWithParens [
 	^ self traitCompositionExpression
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaEmptyComposition >> traitDefining: aSelector [
 	NotFound signalFor: aSelector
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaEmptyComposition >> traits [
 	^ #()
 ]

--- a/src/TraitsV2/TaPrecedenceComposition.class.st
+++ b/src/TraitsV2/TaPrecedenceComposition.class.st
@@ -1,20 +1,22 @@
 Class {
-	#name : #TaPrecedenceComposition,
-	#superclass : #TaSequence,
+	#name : 'TaPrecedenceComposition',
+	#superclass : 'TaSequence',
 	#instVars : [
 		'preferedTrait'
 	],
-	#category : #'TraitsV2-Compositions'
+	#category : 'TraitsV2-Compositions',
+	#package : 'TraitsV2',
+	#tag : 'Compositions'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaPrecedenceComposition >> classComposition [
 	^ (self class withAll: (members collect: [:each | each classComposition]))
 		preferedTrait: preferedTrait classComposition;
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaPrecedenceComposition >> copyTraitExpression [
 
 	^ (self class withAll: (members collect: [:each | each copyTraitExpression]))
@@ -22,7 +24,7 @@ TaPrecedenceComposition >> copyTraitExpression [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaPrecedenceComposition >> copyWithoutTrait: aTrait [
 	| newMembers |
 
@@ -35,7 +37,7 @@ TaPrecedenceComposition >> copyWithoutTrait: aTrait [
 		yourself
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaPrecedenceComposition >> isConflictingSelector: aSelector [
 
 	"If the method is in the preferedTrait it is not a conflict"
@@ -46,7 +48,7 @@ TaPrecedenceComposition >> isConflictingSelector: aSelector [
 	^ super isConflictingSelector: aSelector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaPrecedenceComposition >> memberForSelector: aSelector [
 
 	"I look first in the prefered trait if not in the other member"
@@ -55,17 +57,17 @@ TaPrecedenceComposition >> memberForSelector: aSelector [
 	^ super memberForSelector: aSelector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaPrecedenceComposition >> preferedTrait [
 	^ preferedTrait
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaPrecedenceComposition >> preferedTrait: anObject [
 	preferedTrait := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaPrecedenceComposition >> traitCompositionExpression [
 
 	^  '(' , (super traitCompositionExpression) , ' withPrecedenceOf: ' , preferedTrait traitCompositionExpression , ')'

--- a/src/TraitsV2/TaRemoveMethod.class.st
+++ b/src/TraitsV2/TaRemoveMethod.class.st
@@ -3,15 +3,17 @@ I can remove a method from a trait.
 I implement the #- operator.
 "
 Class {
-	#name : #TaRemoveMethod,
-	#superclass : #TaSingleComposition,
+	#name : 'TaRemoveMethod',
+	#superclass : 'TaSingleComposition',
 	#instVars : [
 		'removedSelectors'
 	],
-	#category : #'TraitsV2-Compositions'
+	#category : 'TraitsV2-Compositions',
+	#package : 'TraitsV2',
+	#tag : 'Compositions'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 TaRemoveMethod class >> remove: anArrayOfSelectors to: aTrait [
 	^ self new
 		removedSelectors: anArrayOfSelectors;
@@ -19,38 +21,38 @@ TaRemoveMethod class >> remove: anArrayOfSelectors to: aTrait [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaRemoveMethod >> compiledMethodAt: aSelector [
 	(removedSelectors includes: aSelector ) ifTrue:[NotFound signalFor: aSelector].
 	^ inner compiledMethodAt: aSelector
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 TaRemoveMethod >> copyTraitExpression [
 	^ self class remove: removedSelectors to: inner
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaRemoveMethod >> methods [
 	^ inner methods reject: [ :e | removedSelectors includes: e selector ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaRemoveMethod >> removedSelectors [
 	^ removedSelectors
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaRemoveMethod >> removedSelectors: anObject [
 	removedSelectors := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaRemoveMethod >> selectors [
 	^ inner selectors reject: [ :selector | removedSelectors includes: selector ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 TaRemoveMethod >> traitCompositionExpression [
 	^ String
 		streamContents: [ :s |
@@ -60,7 +62,7 @@ TaRemoveMethod >> traitCompositionExpression [
 			removedSelectors printAsSelfEvaluatingFormOn: s ]
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaRemoveMethod >> traitDefining: aSelector [
 	(removedSelectors includes: aSelector ) ifTrue:[NotFound signalFor: aSelector].
 	^ inner traitDefining: aSelector

--- a/src/TraitsV2/TaRemoveSlot.class.st
+++ b/src/TraitsV2/TaRemoveSlot.class.st
@@ -4,15 +4,17 @@ I implement the #--  operator.
 
 "
 Class {
-	#name : #TaRemoveSlot,
-	#superclass : #TaSingleComposition,
+	#name : 'TaRemoveSlot',
+	#superclass : 'TaSingleComposition',
 	#instVars : [
 		'removedSlots'
 	],
-	#category : #'TraitsV2-Compositions'
+	#category : 'TraitsV2-Compositions',
+	#package : 'TraitsV2',
+	#tag : 'Compositions'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 TaRemoveSlot class >> remove: anArrayOfSlotNames from: aTrait [
 	^ self new
 		removedSlots: anArrayOfSlotNames;
@@ -20,18 +22,18 @@ TaRemoveSlot class >> remove: anArrayOfSlotNames from: aTrait [
 		yourself
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 TaRemoveSlot >> copyTraitExpression [
 	^ self class remove: removedSlots from: inner
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaRemoveSlot >> removedSlots [
 
 	^ removedSlots
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaRemoveSlot >> removedSlots: anObject [
 	"we support both a symbol and an array of symbols"
 	removedSlots := anObject isSymbol
@@ -39,12 +41,12 @@ TaRemoveSlot >> removedSlots: anObject [
 		                ifFalse: [ anObject ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaRemoveSlot >> slots [
 	^ inner slots reject: [ :e | removedSlots includes: e name ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 TaRemoveSlot >> traitCompositionExpression [
 
 	removedSlots size = 1

--- a/src/TraitsV2/TaRenameSlot.class.st
+++ b/src/TraitsV2/TaRenameSlot.class.st
@@ -4,15 +4,17 @@ Also I rename all the uses of this slot in my methods.
 I implement the #>> operator in traits.
 "
 Class {
-	#name : #TaRenameSlot,
-	#superclass : #TaSingleComposition,
+	#name : 'TaRenameSlot',
+	#superclass : 'TaSingleComposition',
 	#instVars : [
 		'renames'
 	],
-	#category : #'TraitsV2-Compositions'
+	#category : 'TraitsV2-Compositions',
+	#package : 'TraitsV2',
+	#tag : 'Compositions'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 TaRenameSlot class >> from:oldName to: newName on: aTrait [
 	^ self new
 		oldName: oldName;
@@ -21,7 +23,7 @@ TaRenameSlot class >> from:oldName to: newName on: aTrait [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 TaRenameSlot class >> rename: anArrayOfAssociations on: aTrait [
 	^ self new
 		renames: anArrayOfAssociations;
@@ -29,24 +31,24 @@ TaRenameSlot class >> rename: anArrayOfAssociations on: aTrait [
 		yourself
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 TaRenameSlot >> copyTraitExpression [
 	^ self class rename: renames on: inner
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaRenameSlot >> renames [
 
 	^ renames
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaRenameSlot >> renames: anObject [
 
 	renames := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaRenameSlot >> slots [
 
 	^ inner slots collect: [ :slot |
@@ -56,7 +58,7 @@ TaRenameSlot >> slots [
 			  ifFalse: [ slot ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaRenameSlot >> sourceCodeAt: aSelector [
 	| originalSourceCode parseTree rewriter |
 	originalSourceCode := super sourceCodeAt: aSelector.
@@ -72,7 +74,7 @@ TaRenameSlot >> sourceCodeAt: aSelector [
 		tree) formattedCode
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 TaRenameSlot >> traitCompositionExpression [
 
 	^ self inner traitCompositionExpressionWithParens , ' @@ ' , renames printString

--- a/src/TraitsV2/TaRenamedSlotWrapper.class.st
+++ b/src/TraitsV2/TaRenamedSlotWrapper.class.st
@@ -5,77 +5,79 @@ This wrapper does exactly that: as a Slot subclass, it has a name. It forwards a
 in the trait.
 "
 Class {
-	#name : #TaRenamedSlotWrapper,
-	#superclass : #Slot,
+	#name : 'TaRenamedSlotWrapper',
+	#superclass : 'Slot',
 	#instVars : [
 		'originalSlot'
 	],
-	#category : #'TraitsV2-Compositions'
+	#category : 'TraitsV2-Compositions',
+	#package : 'TraitsV2',
+	#tag : 'Compositions'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 TaRenamedSlotWrapper class >> for: aSlot [
 	^self new originalSlot: aSlot
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 TaRenamedSlotWrapper >> emitStore: aMethodBuilder [
 	originalSlot emitStore: aMethodBuilder
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 TaRenamedSlotWrapper >> emitValue: aMethodBuilder [
 	originalSlot emitValue: aMethodBuilder
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaRenamedSlotWrapper >> index [
 	^ originalSlot index
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaRenamedSlotWrapper >> index: anInteger [
 	originalSlot index: anInteger
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaRenamedSlotWrapper >> isVirtual [
 	^originalSlot isVirtual
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaRenamedSlotWrapper >> isVisible [
 	^originalSlot isVisible
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaRenamedSlotWrapper >> originalSlot [
 
 	^ originalSlot
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaRenamedSlotWrapper >> originalSlot: anObject [
 
 	originalSlot := anObject
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 TaRenamedSlotWrapper >> printOn: aStream [
 	originalSlot printOn: aStream
 ]
 
-{ #category : #'meta-object-protocol' }
+{ #category : 'meta-object-protocol' }
 TaRenamedSlotWrapper >> read: anObject [
 	^ originalSlot read: anObject
 ]
 
-{ #category : #'meta-object-protocol' }
+{ #category : 'meta-object-protocol' }
 TaRenamedSlotWrapper >> wantsInitialization [
 	^ originalSlot wantsInitialization
 ]
 
-{ #category : #'meta-object-protocol' }
+{ #category : 'meta-object-protocol' }
 TaRenamedSlotWrapper >> write: aValue to: anObject [
 	^ originalSlot write: aValue to: anObject
 ]

--- a/src/TraitsV2/TaSequence.class.st
+++ b/src/TraitsV2/TaSequence.class.st
@@ -5,22 +5,24 @@ The methods and slots are the union of my inner members.
 I solve when there are conflicts.
 "
 Class {
-	#name : #TaSequence,
-	#superclass : #TaAbstractComposition,
+	#name : 'TaSequence',
+	#superclass : 'TaAbstractComposition',
 	#instVars : [
 		'members'
 	],
-	#category : #'TraitsV2-Compositions'
+	#category : 'TraitsV2-Compositions',
+	#package : 'TraitsV2',
+	#tag : 'Compositions'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 TaSequence class >> with: initialValue [
 	^ self new
 		addMember: initialValue;
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 TaSequence class >> withAll: initialMembers [
 
 	initialMembers ifEmpty: [ ^ TaEmptyComposition new ].
@@ -30,28 +32,28 @@ TaSequence class >> withAll: initialMembers [
 		yourself
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaSequence >> + anotherTrait [
 	^ anotherTrait asTraitComposition addToSequence: self copyTraitExpression
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaSequence >> , anotherTrait [
 	^ anotherTrait addToSequence: self copy
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 TaSequence >> = anotherTrait [
 	^ anotherTrait species = self species and: [ self members = anotherTrait members ]
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 TaSequence >> addAll: aCollection [
 	"Adds all the members in the othe sequence"
 	aCollection do:[:e | self addMember: e]
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 TaSequence >> addMember: aTrait [
 	"Adds a single trait to me"
 	self validateDuplications: aTrait.
@@ -60,53 +62,53 @@ TaSequence >> addMember: aTrait [
 	members add: aTrait
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaSequence >> addToSequence: sequence [
 	"I add my self to another sequence. When adding I add all my members, not myself"
 	members do:[:e |sequence addMember: e].
 	^ sequence
 ]
 
-{ #category : #users }
+{ #category : 'users' }
 TaSequence >> addUser: aClass [
 	"I propagate the users to all my members"
 	members do: [ :m | m addUser: aClass ]
 ]
 
-{ #category : #'transforming selectors' }
+{ #category : 'transforming selectors' }
 TaSequence >> aliasSelector: aSelector [
 	^ members inject: aSelector into:[:acc :each | each aliasSelector: acc].
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaSequence >> allTraits [
 	^ members flatCollect: #allTraits
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaSequence >> changesSourceCode: aSelector [
 	"If the selector has conflicts it should be recompiled"
 	^ (self isConflictingSelector: aSelector)
 		or: [ self members anySatisfy: [ :e | e changesSourceCode: aSelector ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaSequence >> classComposition [
 	^ self class withAll: (members collect: [:each | each classComposition])
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaSequence >> compiledMethodAt: aSelector [
 
 	^ (self memberForSelector: aSelector) compiledMethodAt: aSelector
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 TaSequence >> copyTraitExpression [
 	^ self class withAll: (members collect: [:each | each copyTraitExpression])
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 TaSequence >> copyWithoutTrait: aTrait [
 	| newMembers |
 
@@ -115,29 +117,29 @@ TaSequence >> copyWithoutTrait: aTrait [
 	^ self class withAll: newMembers
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 TaSequence >> hash [
 	^ self class hash
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 TaSequence >> initialize [
 	super initialize.
 	members := OrderedCollection new
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaSequence >> initializeObject: anObject [
 	members do: [ :e | e initializeObject: anObject ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaSequence >> isAliasSelector: aSelector [
 
 	^ self members anySatisfy: [ :e | e isAliasSelector: aSelector ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaSequence >> isConflictingSelector: aSelector [
 	"I test if a given selector is defined in more than one of my members.
 	Two or more members can have the same method.
@@ -151,12 +153,12 @@ TaSequence >> isConflictingSelector: aSelector [
 	^ (possibleConflicts collect: [:each | each originMethod ] as: Set) size > 1
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaSequence >> isLocalAliasSelector: aSymbol [
 	^ members anySatisfy: [ :e | e isLocalAliasSelector: aSymbol ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaSequence >> memberForSelector: aSelector [
 	"I return the member that defines a given selector.
 	I first look for a valid member, if not, I will return the first"
@@ -166,28 +168,28 @@ TaSequence >> memberForSelector: aSelector [
 		  ifNone: [ members detect: [ :member | member selectors includes: aSelector ] ]
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaSequence >> members [
 	^ members
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaSequence >> methods [
 	^ members flatCollect: #methods
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaSequence >> name [
 	^ '_' join: (members collect: [:each | each name])
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaSequence >> originSelectorOf: aSelector [
 
 	^ (self traitDefining: aSelector ifNone: [ ^ aSelector ]) originSelectorOf: aSelector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaSequence >> protocolForMethod: aMethod [
 
 	| protocols originalSelector |
@@ -202,19 +204,19 @@ TaSequence >> protocolForMethod: aMethod [
 		  ifFalse: [ Protocol traitConflictName ]
 ]
 
-{ #category : #users }
+{ #category : 'users' }
 TaSequence >> removeUser: aClass [
 	"I propagate to my members the removal of an user"
 	self members do: [ :m | m removeUser: aClass]
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaSequence >> reverseAlias: aSelector [
 
 	^ self members flatCollect: [ :e | e reverseAlias: aSelector ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaSequence >> selectorForConflict: selector [
 	| args keywords |
 
@@ -241,19 +243,19 @@ TaSequence >> selectorForConflict: selector [
 							space ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaSequence >> selectors [
 	^ members flatCollect: #selectors
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaSequence >> slots [
 	^ (members flatCollect: #slots)
 		removeDuplicates;
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaSequence >> sourceCodeAt: selector [
 	(self isConflictingSelector: selector)
 		ifTrue: [ ^ self sourceCodeForConflictFor: selector ].
@@ -261,7 +263,7 @@ TaSequence >> sourceCodeAt: selector [
 	^ (self memberForSelector: selector) sourceCodeAt: selector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaSequence >> sourceCodeForConflictFor: selector [
 
 	"I return the method body for a conflicting selector"
@@ -275,7 +277,7 @@ TaSequence >> sourceCodeForConflictFor: selector [
 				nextPutAll: 'self traitConflict' ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 TaSequence >> traitCompositionExpression [
 	self isEmpty
 		ifTrue: [ ^ '{}' ].
@@ -284,23 +286,23 @@ TaSequence >> traitCompositionExpression [
 		, (members allButFirst collect: [:each | each traitCompositionExpressionWithParens]) joinUsing: ' + '
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaSequence >> traitDefining: aSelector [
 	^ (self memberForSelector: aSelector) traitDefining: aSelector
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaSequence >> traits [
 	^ members flatCollect: #traits
 ]
 
-{ #category : #validations }
+{ #category : 'validations' }
 TaSequence >> validateDuplications: anElement [
 	(members noneSatisfy: [ :e | e = anElement ])
 		ifFalse:[self error:'Could not include the same traits twice']
 ]
 
-{ #category : #validations }
+{ #category : 'validations' }
 TaSequence >> validateMethods: aTrait [
 	| newMethods myMethods|
 	myMethods := self methods.
@@ -311,7 +313,7 @@ TaSequence >> validateMethods: aTrait [
 		ifFalse: [ self error: 'The added trait duplicates an existing selector' ]
 ]
 
-{ #category : #validations }
+{ #category : 'validations' }
 TaSequence >> validateSlots: anElement [
 	self slots
 		do: [ :e |
@@ -321,7 +323,7 @@ TaSequence >> validateSlots: anElement [
 						ifTrue: [ self error: 'The added trait duplicates an existing slot ' , e name printString , '. Duplication between ' , e definingClass asString , ' and ' , other definingClass asString ] ] ]
 ]
 
-{ #category : #precedence }
+{ #category : 'precedence' }
 TaSequence >> withPrecedenceOf: aTrait [
 
 	| aTraitComposition |
@@ -335,7 +337,7 @@ TaSequence >> withPrecedenceOf: aTrait [
 			yourself
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaSequence >> without: aTrait [
 	| newMembers |
 	newMembers := members collect:[:e | e without: aTrait] thenSelect:#isNotNil.

--- a/src/TraitsV2/TaSingleComposition.class.st
+++ b/src/TraitsV2/TaSingleComposition.class.st
@@ -2,52 +2,54 @@
 I am the superclass of all the operations that modifies a single trait.
 "
 Class {
-	#name : #TaSingleComposition,
-	#superclass : #TaAbstractComposition,
+	#name : 'TaSingleComposition',
+	#superclass : 'TaAbstractComposition',
 	#instVars : [
 		'inner'
 	],
-	#category : #'TraitsV2-Compositions'
+	#category : 'TraitsV2-Compositions',
+	#package : 'TraitsV2',
+	#tag : 'Compositions'
 }
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 TaSingleComposition >> = another [
 	^ (another class = self class) and: [ another inner = inner ]
 ]
 
-{ #category : #users }
+{ #category : 'users' }
 TaSingleComposition >> addUser: aClass [
 	"I propagate to the inner trait"
 	inner addUser: aClass
 ]
 
-{ #category : #'transforming selectors' }
+{ #category : 'transforming selectors' }
 TaSingleComposition >> aliasSelector: aSelector [
 	^ inner aliasSelector: aSelector
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaSingleComposition >> allTraits [
 	^ inner allTraits
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaSingleComposition >> changesSourceCode: aSelector [
 
 	^ inner changesSourceCode: aSelector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaSingleComposition >> classComposition [
 	^ inner classComposition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaSingleComposition >> compiledMethodAt: aSelector [
 	^ inner compiledMethodAt: aSelector
 ]
 
-{ #category : #copying }
+{ #category : 'copying' }
 TaSingleComposition >> copyWithoutTrait: aTrait [
 	(self = aTrait or: [ inner = aTrait ])
 		ifTrue: [ ^ inner copyWithoutTrait: aTrait ].
@@ -55,85 +57,85 @@ TaSingleComposition >> copyWithoutTrait: aTrait [
 	^ self copy
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 TaSingleComposition >> hash [
 	^ inner hash
 ]
 
-{ #category : #'transforming selectors' }
+{ #category : 'transforming selectors' }
 TaSingleComposition >> initializeSelectorForMe [
 	^ inner initializeSelectorForMe
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaSingleComposition >> inner [
 	^ inner
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaSingleComposition >> inner: anObject [
 	inner := anObject
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaSingleComposition >> isAliasSelector: aSymbol [
 	^ inner isAliasSelector: aSymbol
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TaSingleComposition >> isLocalAliasSelector: aSymbol [
 	^ inner isLocalAliasSelector: aSymbol
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaSingleComposition >> methods [
 	^ inner methods
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaSingleComposition >> name [
 	^ inner name
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaSingleComposition >> originSelectorOf: aSelector [
 
 	^ inner originSelectorOf: aSelector
 ]
 
-{ #category : #users }
+{ #category : 'users' }
 TaSingleComposition >> removeUser: aClass [
 	"I propagate to the inner trait"
 	inner removeUser: aClass
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaSingleComposition >> reverseAlias: aSelector [
 
 	^ inner reverseAlias: aSelector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaSingleComposition >> selectors [
 	^ inner selectors
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TaSingleComposition >> slots [
 	^ inner slots.
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaSingleComposition >> traitDefining: selector [
 	^ inner traitDefining: selector
 ]
 
-{ #category : #querying }
+{ #category : 'querying' }
 TaSingleComposition >> traits [
 	^ inner traits
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TaSingleComposition >> without: anotherTrait [
 	"Returns a single composition without the trait passed as parameter"
 	^ (anotherTrait = self or: [ inner = anotherTrait ])

--- a/src/TraitsV2/Trait.class.st
+++ b/src/TraitsV2/Trait.class.st
@@ -16,15 +16,17 @@ Also a nice diagram can be seen evaluating:
 
 "
 Class {
-	#name : #Trait,
-	#superclass : #Class,
+	#name : 'Trait',
+	#superclass : 'Class',
 	#instVars : [
 		'users'
 	],
-	#category : #'TraitsV2-Base'
+	#category : 'TraitsV2-Base',
+	#package : 'TraitsV2',
+	#tag : 'Base'
 }
 
-{ #category : #'old pharo 8 syntax' }
+{ #category : 'old pharo 8 syntax' }
 Trait class >> named: aName [
 
 	^ self classInstaller make: [ :builder |
@@ -33,7 +35,7 @@ Trait class >> named: aName [
 			  beTrait ]
 ]
 
-{ #category : #'old pharo 8 syntax' }
+{ #category : 'old pharo 8 syntax' }
 Trait class >> named: aName instanceVariableNames: aString package: aPackageName [
 
 	^ self classInstaller make: [ :builder |
@@ -44,7 +46,7 @@ Trait class >> named: aName instanceVariableNames: aString package: aPackageName
 			  beTrait ]
 ]
 
-{ #category : #'old pharo 8 syntax' }
+{ #category : 'old pharo 8 syntax' }
 Trait class >> named: aName package: aString [
 
 	^ self classInstaller make: [ :builder |
@@ -54,7 +56,7 @@ Trait class >> named: aName package: aString [
 			  beTrait ]
 ]
 
-{ #category : #'old pharo 8 syntax' }
+{ #category : 'old pharo 8 syntax' }
 Trait class >> named: aName uses: aCompositionOrArray [
 
 	^ self classInstaller make: [ :builder |
@@ -64,7 +66,7 @@ Trait class >> named: aName uses: aCompositionOrArray [
 			  beTrait ]
 ]
 
-{ #category : #deprecated }
+{ #category : 'deprecated' }
 Trait class >> named: aName uses: aTraitCompositionOrCollection category: aPackageName [
 
 	^ self classInstaller make: [ :builder |
@@ -75,7 +77,7 @@ Trait class >> named: aName uses: aTraitCompositionOrCollection category: aPacka
 			  beTrait ]
 ]
 
-{ #category : #deprecated }
+{ #category : 'deprecated' }
 Trait class >> named: aName uses: aTraitCompositionOrCollection category: aPackageName env: anEnvironment [
 
 	^ self classInstaller make: [ :builder |
@@ -86,7 +88,7 @@ Trait class >> named: aName uses: aTraitCompositionOrCollection category: aPacka
 			  beTrait ]
 ]
 
-{ #category : #'old pharo 8 syntax' }
+{ #category : 'old pharo 8 syntax' }
 Trait class >> named: aName uses: aTraitCompositionOrCollection instanceVariableNames: aString package: aPackageName [
 
 	^ self classInstaller make: [ :builder |
@@ -98,7 +100,7 @@ Trait class >> named: aName uses: aTraitCompositionOrCollection instanceVariable
 			  beTrait ]
 ]
 
-{ #category : #'old pharo 8 syntax' }
+{ #category : 'old pharo 8 syntax' }
 Trait class >> named: aName uses: aTraitCompositionOrCollection instanceVariableNames: aString package: aPackageName env: anEnvironment [
 
 	^ self classInstaller make: [ :builder |
@@ -110,7 +112,7 @@ Trait class >> named: aName uses: aTraitCompositionOrCollection instanceVariable
 			  beTrait ]
 ]
 
-{ #category : #'old pharo 8 syntax' }
+{ #category : 'old pharo 8 syntax' }
 Trait class >> named: aName uses: aTraitCompositionOrCollection package: aString [
 
 	^ self classInstaller make: [ :builder |
@@ -121,7 +123,7 @@ Trait class >> named: aName uses: aTraitCompositionOrCollection package: aString
 			  beTrait ]
 ]
 
-{ #category : #'old pharo 8 syntax' }
+{ #category : 'old pharo 8 syntax' }
 Trait class >> named: aName uses: aTraitCompositionOrCollection package: aString env: anEnvironment [
 
 	^ self classInstaller make: [ :builder |
@@ -132,7 +134,7 @@ Trait class >> named: aName uses: aTraitCompositionOrCollection package: aString
 			  beTrait ]
 ]
 
-{ #category : #deprecated }
+{ #category : 'deprecated' }
 Trait class >> named: aName uses: aTraitCompositionOrCollection slots: someSlots category: aCategory [
 
 	^ self classInstaller make: [ :builder |
@@ -144,7 +146,7 @@ Trait class >> named: aName uses: aTraitCompositionOrCollection slots: someSlots
 			  beTrait ]
 ]
 
-{ #category : #deprecated }
+{ #category : 'deprecated' }
 Trait class >> named: aName uses: aTraitCompositionOrCollection slots: someSlots category: aCategory env: anEnvironment [
 
 	^ self classInstaller make: [ :builder |
@@ -156,7 +158,7 @@ Trait class >> named: aName uses: aTraitCompositionOrCollection slots: someSlots
 			  beTrait ]
 ]
 
-{ #category : #'old pharo 8 syntax' }
+{ #category : 'old pharo 8 syntax' }
 Trait class >> named: aName uses: aTraitCompositionOrCollection slots: someSlots package: aPackageName [
 
 	^ self classInstaller make: [ :builder |
@@ -168,7 +170,7 @@ Trait class >> named: aName uses: aTraitCompositionOrCollection slots: someSlots
 			  beTrait ]
 ]
 
-{ #category : #'old pharo 8 syntax' }
+{ #category : 'old pharo 8 syntax' }
 Trait class >> named: aName uses: aTraitCompositionOrCollection slots: someSlots package: aPackageName env: anEnvironment [
 
 	^ self classInstaller make: [ :builder |
@@ -180,44 +182,44 @@ Trait class >> named: aName uses: aTraitCompositionOrCollection slots: someSlots
 			  beTrait ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Trait >> + anotherTrait [
 	"I return my self in a sequence with anotherTrait"
 	^ self asTraitComposition + anotherTrait asTraitComposition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Trait >> - anArray [
 	"I return myself with a removed method. Check TaAbstractComposition >> #- for more details"
 
 	^ self asTraitComposition - anArray
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Trait >> -- aSlotNameCollection [
 
 	^ self asTraitComposition -- aSlotNameCollection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Trait >> @ anArray [
 	"I return myself with an aliased method. Check TaAbstractComposition >> #@ for more details"
 	^ self asTraitComposition @ anArray
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Trait >> @@ anArray [
 	"I return myself with an aliased method. Check TaAbstractComposition >> #@ for more details"
 	^ self asTraitComposition @@ anArray
 ]
 
-{ #category : #users }
+{ #category : 'users' }
 Trait >> addUser: aClass [
 
 	self users add: aClass
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 Trait >> basicNew [
 	"Traits should never be instantiated.
 	They are naked object: superclass = nil.
@@ -227,43 +229,43 @@ Trait >> basicNew [
 	self error: 'Traits should not be instantiated!'
 ]
 
-{ #category : #'accessing - parallel hierarchy' }
+{ #category : 'accessing - parallel hierarchy' }
 Trait >> classTrait [
 
 	^ self class
 ]
 
-{ #category : #fileout }
+{ #category : 'fileout' }
 Trait >> definitionStringFor: aConfiguredPrinter [
 
 	^ aConfiguredPrinter traitDefinitionString
 ]
 
-{ #category : #fileout }
+{ #category : 'fileout' }
 Trait >> expandedDefinitionStringFor: aPrinter [
 
 	^ aPrinter expandedTraitDefinitionString
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Trait >> isBaseTrait [
 
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Trait >> isClass [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Trait >> isClassTrait [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Trait >> isEmpty [
 	"Since we can have potential an empty array in the fluid definition (to be revisited)
 	when the trait composition is aTrait it received the message isEmpty and would break
@@ -273,28 +275,28 @@ Trait >> isEmpty [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Trait >> isTrait [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Trait >> isTraitAlias [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Trait >> isTraitExclusion [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 Trait >> isUsed [
 
 	^ super isUsed or: [ self traitUsers notEmpty ]
 ]
 
-{ #category : #'organization updating' }
+{ #category : 'organization updating' }
 Trait >> notifyOfRecategorizedSelector: selector from: oldProtocol to: newProtocol [
 	"When there is a recategorization of a selector, I propagate the changes to my users"
 
@@ -302,7 +304,7 @@ Trait >> notifyOfRecategorizedSelector: selector from: oldProtocol to: newProtoc
 	self traitUsers do: [ :e | e recategorizeSelector: selector from: oldProtocol to: newProtocol ]
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 Trait >> rebuildMethodDictionary [
 	"I extend the behavior in TraitedMetaclass propagating the changes to my users"
 	self doRebuildMethodDictionary ifFalse: [ ^ false ].
@@ -310,7 +312,7 @@ Trait >> rebuildMethodDictionary [
 	^ true
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 Trait >> removeFromSystem: logged [
 
 	"When a trait is removed from the system it should:
@@ -327,23 +329,23 @@ Trait >> removeFromSystem: logged [
 	^ super removeFromSystem: logged
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 Trait >> removeUser: aClass [
 
 	self users remove: aClass ifAbsent: [ ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Trait >> traitUsers [
 	^ self users
 ]
 
-{ #category : #users }
+{ #category : 'users' }
 Trait >> users [
 	^ users ifNil: [ users := IdentitySet new ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 Trait >> users: anObject [
 	users := anObject
 ]

--- a/src/TraitsV2/TraitBuilderEnhancer.class.st
+++ b/src/TraitsV2/TraitBuilderEnhancer.class.st
@@ -8,15 +8,17 @@ I inject the methods from TraitedClass to the generated metaclass.
 Also I add all the slots and methods in the trait composition.
 "
 Class {
-	#name : #TraitBuilderEnhancer,
-	#superclass : #ShDefaultBuilderEnhancer,
+	#name : 'TraitBuilderEnhancer',
+	#superclass : 'ShDefaultBuilderEnhancer',
 	#instVars : [
 		'builder'
 	],
-	#category : #'TraitsV2-Class-Builder'
+	#category : 'TraitsV2-Class-Builder',
+	#package : 'TraitsV2',
+	#tag : 'Class-Builder'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 TraitBuilderEnhancer class >> isApplicableFor: aBuilder [
 
 	aBuilder metaSuperclass = Trait ifTrue: [ ^ true ].
@@ -31,7 +33,7 @@ TraitBuilderEnhancer class >> isApplicableFor: aBuilder [
 	^ false
 ]
 
-{ #category : #'class modifications' }
+{ #category : 'class modifications' }
 TraitBuilderEnhancer >> afterMethodsCompiled: aBuilder [
 	"we need to remove the categories leftover after removing Traits"
 
@@ -44,7 +46,7 @@ TraitBuilderEnhancer >> afterMethodsCompiled: aBuilder [
 	aBuilder newClass rebuildMethodDictionary
 ]
 
-{ #category : #migrating }
+{ #category : 'migrating' }
 TraitBuilderEnhancer >> afterMigratingClass: aBuilder installer: anInstaller [
 
 	(self isTraitedMetaclass: aBuilder)
@@ -62,7 +64,7 @@ TraitBuilderEnhancer >> afterMigratingClass: aBuilder installer: anInstaller [
 	aBuilder newClass traitUsers do: [:e | e rebuildMethodDictionary]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitBuilderEnhancer >> allSlotsForBuilder: aBuilder [
 
 	| resultingSlots |
@@ -74,7 +76,7 @@ TraitBuilderEnhancer >> allSlotsForBuilder: aBuilder [
 	^ resultingSlots
 ]
 
-{ #category : #migrating }
+{ #category : 'migrating' }
 TraitBuilderEnhancer >> beforeMigratingClass: aBuilder installer: anInstaller [
 	aBuilder oldClass ifNil: [ ^ self ].
 
@@ -89,7 +91,7 @@ TraitBuilderEnhancer >> beforeMigratingClass: aBuilder installer: anInstaller [
 	aBuilder newMetaclass users: aBuilder oldMetaclass users.
 ]
 
-{ #category : #events }
+{ #category : 'events' }
 TraitBuilderEnhancer >> classCreated: aBuilder [
 
 	(self isTraitedMetaclass: aBuilder)
@@ -101,24 +103,24 @@ TraitBuilderEnhancer >> classCreated: aBuilder [
 	builder newMetaclass traitComposition: self classTraitComposition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitBuilderEnhancer >> classTraitComposition [
 	^ builder classTraitComposition asTraitComposition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitBuilderEnhancer >> classTraitCompositionOf: aBuilder [
 
 	^ aBuilder classTraitComposition asTraitComposition
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 TraitBuilderEnhancer >> classTraitCompositionOfClass: aClass [
 
 	^ aClass class traitComposition asTraitComposition
 ]
 
-{ #category : #'class modifications' }
+{ #category : 'class modifications' }
 TraitBuilderEnhancer >> configureClass: newClass superclass: superclass withLayoutType: layoutType slots: slots [
 	| resultingSlots |
 	self validateTraitComposition: self traitComposition ofClass: builder oldClass.
@@ -128,7 +130,7 @@ TraitBuilderEnhancer >> configureClass: newClass superclass: superclass withLayo
 	newClass superclass: superclass withLayoutType: layoutType slots: resultingSlots
 ]
 
-{ #category : #'class modifications' }
+{ #category : 'class modifications' }
 TraitBuilderEnhancer >> configureMetaclass: newMetaclass superclass: superclass withLayoutType: aLayoutType slots: classSlots [
 	| resultingSlots |
 	self validateTraitComposition: self classTraitComposition ofClass: builder oldMetaclass.
@@ -140,7 +142,7 @@ TraitBuilderEnhancer >> configureMetaclass: newMetaclass superclass: superclass 
 	newMetaclass superclass: superclass withLayoutType: aLayoutType slots: resultingSlots
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 TraitBuilderEnhancer >> eliminateDuplicates: aSlotCollection withSuperclassSlots: superclassSlots [
 	| resultingSlots |
 	resultingSlots := OrderedCollection new.
@@ -154,7 +156,7 @@ TraitBuilderEnhancer >> eliminateDuplicates: aSlotCollection withSuperclassSlots
 	^ resultingSlots asArray
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 TraitBuilderEnhancer >> fillBuilder: aBuilder from: aClass [
 
 	(aBuilder superclass isNil and: [ aClass superclass isNil ])
@@ -166,7 +168,7 @@ TraitBuilderEnhancer >> fillBuilder: aBuilder from: aClass [
 	aBuilder metaclassClass: aClass class class
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 TraitBuilderEnhancer >> initializeBuilder: aBuilder [
 	super initializeBuilder: aBuilder.
 
@@ -175,13 +177,13 @@ TraitBuilderEnhancer >> initializeBuilder: aBuilder [
 	aBuilder addChangeComparer: TraitCompositionChangedDetector
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TraitBuilderEnhancer >> isTraitedMetaclass: aBuilder [
 
 	^ aBuilder metaclassClass includesBehavior: TraitedMetaclass
 ]
 
-{ #category : #events }
+{ #category : 'events' }
 TraitBuilderEnhancer >> migrateInstancesTo: aClass installer: aShiftClassInstaller [
 
 	"Traits does not have instances"
@@ -191,7 +193,7 @@ TraitBuilderEnhancer >> migrateInstancesTo: aClass installer: aShiftClassInstall
 	super migrateInstancesTo: aClass installer: aShiftClassInstaller
 ]
 
-{ #category : #'class modifications' }
+{ #category : 'class modifications' }
 TraitBuilderEnhancer >> newMetaclass: aBuilder [
 
 	(aBuilder traitComposition asTraitComposition isNotEmpty or: [ aBuilder classTraitComposition asTraitComposition isNotEmpty or: [ aBuilder superclass class class = TraitedMetaclass]])
@@ -203,7 +205,7 @@ TraitBuilderEnhancer >> newMetaclass: aBuilder [
 	^ super newMetaclass: aBuilder
 ]
 
-{ #category : #'class modifications' }
+{ #category : 'class modifications' }
 TraitBuilderEnhancer >> propagateChangesToRelatedClasses: newClass installer: installer [
 
 	super propagateChangesToRelatedClasses: newClass installer: installer.
@@ -217,30 +219,30 @@ TraitBuilderEnhancer >> propagateChangesToRelatedClasses: newClass installer: in
 	newClass users do: [ :each | installer remake: each instanceSide ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitBuilderEnhancer >> traitComposition [
 	^ builder traitComposition asTraitComposition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitBuilderEnhancer >> traitCompositionOf: aBuilder [
 
 	^ aBuilder traitComposition asTraitComposition
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 TraitBuilderEnhancer >> traitCompositionOfClass: aClass [
 
 	^ aClass traitComposition asTraitComposition
 ]
 
-{ #category : #migrating }
+{ #category : 'migrating' }
 TraitBuilderEnhancer >> validateRedefinition: anOldClass [
 	(anOldClass isNotNil and: [ anOldClass isTrait ~= builder isTrait ])
 		ifTrue: [ self error: 'A class should not be redefined as a trait. First remove it from the system.' ]
 ]
 
-{ #category : #validating }
+{ #category : 'validating' }
 TraitBuilderEnhancer >> validateTraitComposition: aTraitComposition ofClass: aClass [
 
 	^ (aTraitComposition allTraits includes: aClass) ifTrue: [ self error: 'Cyclic Trait composition' ]

--- a/src/TraitsV2/TraitChange.class.st
+++ b/src/TraitsV2/TraitChange.class.st
@@ -16,17 +16,19 @@ I propagate to the users of the trait.
 If the removal was shadowing a method from the trait composition, the method from the trait composition is installed and the change propagated accordly. 
 "
 Class {
-	#name : #TraitChange,
-	#superclass : #Object,
+	#name : 'TraitChange',
+	#superclass : 'Object',
 	#instVars : [
 		'addedSelectors',
 		'removedSelectors',
 		'updatedSelectors'
 	],
-	#category : #'TraitsV2-Changes'
+	#category : 'TraitsV2-Changes',
+	#package : 'TraitsV2',
+	#tag : 'Changes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 TraitChange class >> addSelector: aSelector on: aClass [
 
 	"I propagate the addition or change of a selector in aClass that is a trait or a trait user.
@@ -37,7 +39,7 @@ TraitChange class >> addSelector: aSelector on: aClass [
 		applyOn: aClass
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 TraitChange class >> removeSelector: aSelector on: aClass [
 
 	"I propagate the removal of a selector in aClass that is a trait or a trait user.
@@ -49,7 +51,7 @@ TraitChange class >> removeSelector: aSelector on: aClass [
 		applyOn: aClass
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TraitChange >> add: aSelector into: aClass changes: changes [
 
 	" After adding or updating a method, it should be added to the local MethodDictionary.
@@ -58,17 +60,17 @@ TraitChange >> add: aSelector into: aClass changes: changes [
 	changes updatedSelectors add: aSelector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitChange >> addedSelectors [
 	^ addedSelectors
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitChange >> addedSelectors: anObject [
 	addedSelectors := anObject
 ]
 
-{ #category : #applying }
+{ #category : 'applying' }
 TraitChange >> applyOn: aClass [
 	| result |
 
@@ -86,7 +88,7 @@ TraitChange >> applyOn: aClass [
 	aClass traitUsers do: [ :aUser | result applyOn: aUser ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 TraitChange >> initialize [
 	super initialize.
 
@@ -95,7 +97,7 @@ TraitChange >> initialize [
 	removedSelectors := Set new
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TraitChange >> remove: aSelector into: aClass changes: results [
 	| isLocal inTrait priorMethod priorProtocol |
 
@@ -142,17 +144,17 @@ TraitChange >> remove: aSelector into: aClass changes: results [
 			results removedSelectors add: aliased ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitChange >> removedSelectors [
 	^ removedSelectors
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitChange >> removedSelectors: anObject [
 	removedSelectors := anObject
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 TraitChange >> update: aSelector into: aClass changes: changes [
 
 	"I am the responsible of propagating a change from an used trait"
@@ -172,12 +174,12 @@ TraitChange >> update: aSelector into: aClass changes: changes [
 			changes updatedSelectors add: aliased ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitChange >> updatedSelectors [
 	^ updatedSelectors
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitChange >> updatedSelectors: anObject [
 	updatedSelectors := anObject
 ]

--- a/src/TraitsV2/TraitCompositionChangedDetector.class.st
+++ b/src/TraitsV2/TraitCompositionChangedDetector.class.st
@@ -3,12 +3,14 @@ I can detect if there is a change in the Trait composition.
 
 "
 Class {
-	#name : #TraitCompositionChangedDetector,
-	#superclass : #ShAbstractChangeDetector,
-	#category : #'TraitsV2-Class-Builder'
+	#name : 'TraitCompositionChangedDetector',
+	#superclass : 'ShAbstractChangeDetector',
+	#category : 'TraitsV2-Class-Builder',
+	#package : 'TraitsV2',
+	#tag : 'Class-Builder'
 }
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 TraitCompositionChangedDetector >> compareClass [
 
 	(self enhancer traitCompositionOf: builder)
@@ -26,7 +28,7 @@ TraitCompositionChangedDetector >> compareClass [
 	^ #()
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitCompositionChangedDetector >> enhancer [
 	^ builder builderEnhancer
 ]

--- a/src/TraitsV2/TraitedClass.class.st
+++ b/src/TraitsV2/TraitedClass.class.st
@@ -11,15 +11,17 @@ TraitedMetaclass >> #initializeBasicMethods
 This method is invoked during the construction of the class, and flattens my methods in the new traited class.
 "
 Class {
-	#name : #TraitedClass,
-	#superclass : #Object,
+	#name : 'TraitedClass',
+	#superclass : 'Object',
 	#classInstVars : [
 		'users'
 	],
-	#category : #'TraitsV2-Base'
+	#category : 'TraitsV2-Base',
+	#package : 'TraitsV2',
+	#tag : 'Base'
 }
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 TraitedClass class >> addAndClassifySelector: selector withMethod: compiledMethod inProtocol: aProtocol [
 
 	super
@@ -30,28 +32,28 @@ TraitedClass class >> addAndClassifySelector: selector withMethod: compiledMetho
 	self propagateChangeOf: selector
 ]
 
-{ #category : #users }
+{ #category : 'users' }
 TraitedClass class >> addUser: aClass [
 
 	self basicUsers add: aClass
 ]
 
-{ #category : #users }
+{ #category : 'users' }
 TraitedClass class >> basicUsers [
 	^ users ifNil: [ users := WeakSet new ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitedClass class >> classTrait [
 	^ self class
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TraitedClass class >> isTrait [
 	^ true
 ]
 
-{ #category : #changes }
+{ #category : 'changes' }
 TraitedClass class >> propagateChangeOf: aSelector [
 	| change |
 
@@ -62,18 +64,18 @@ TraitedClass class >> propagateChangeOf: aSelector [
 	self basicUsers do: [ :e | change applyOn: e ]
 ]
 
-{ #category : #users }
+{ #category : 'users' }
 TraitedClass class >> removeUser: aClass [
 
 	self basicUsers remove: aClass ifAbsent: [ ]
 ]
 
-{ #category : #users }
+{ #category : 'users' }
 TraitedClass class >> traitUsers [
 	^ #()
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 TraitedClass >> addAndClassifySelector: selector withMethod: compiledMethod inProtocol: aProtocol [
 	"When a new methods is added, I add it to the localMethodDict and also propagate the changes to my users"
 
@@ -84,21 +86,12 @@ TraitedClass >> addAndClassifySelector: selector withMethod: compiledMethod inPr
 	TraitChange addSelector: selector on: self
 ]
 
-{ #category : #'accessing - method dictionary' }
-TraitedClass >> addSelector: selector withRecompiledMethod: compiledMethod [
-	"When a new selector is installed in a class I insert the selector in the local methodDict and propagate the changes to my users"
-
-	compiledMethod isFromTrait ifTrue: [ ^ super addSelector: selector withRecompiledMethod: compiledMethod ].
-
-	self addSelector: selector withMethod: compiledMethod
-]
-
-{ #category : #querying }
+{ #category : 'querying' }
 TraitedClass >> allTraits [
 	^ self traitComposition allTraits
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 TraitedClass >> doRebuildMethodDictionary [
 
 	| selectors removedSelectors modified |
@@ -122,7 +115,7 @@ TraitedClass >> doRebuildMethodDictionary [
 	^ modified
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TraitedClass >> findOriginClassOf: aMethod [
 
 	"I return the myself or the trait that has the original implementation of a method.
@@ -137,7 +130,7 @@ TraitedClass >> findOriginClassOf: aMethod [
 	^ (self traitComposition traitDefining: aMethod selector ifNone: [ ^ self ]) innerClass
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TraitedClass >> findOriginMethodOf: aMethod [
 
 	"I return the original method for a aMethod.
@@ -158,18 +151,18 @@ TraitedClass >> findOriginMethodOf: aMethod [
 		compiledMethodAt: aMethod selector ifAbsent: [ ^ aMethod ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TraitedClass >> hasTraitComposition [
 
 	^ self traitComposition isEmpty not
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TraitedClass >> includesLocalSelector: aSymbol [
 	^ self isLocalSelector: aSymbol
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TraitedClass >> isAliasSelector: aSymbol [
 	"Return true if the selector aSymbol is an alias defined
 	in my or in another composition somewhere deeper in
@@ -178,7 +171,7 @@ TraitedClass >> isAliasSelector: aSymbol [
 	^ self traitComposition isAliasSelector: aSymbol
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TraitedClass >> isLocalAliasSelector: aSymbol [
 	"Return true if the selector aSymbol is an alias defined
 	in my trait composition."
@@ -186,44 +179,44 @@ TraitedClass >> isLocalAliasSelector: aSymbol [
 	^ self traitComposition isLocalAliasSelector: aSymbol
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TraitedClass >> isLocalSelector: aSelector [
 
 	^ self localMethodDict includesKey: aSelector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitedClass >> localMethodDict [
 	"The local methodDict is in the metaclass. In this way I do not have to recompile the methods during the bootstrap when we don't have a compiler."
 	^ self class baseLocalMethods
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitedClass >> localMethodDict: aMethodDictionary [
 	^ self class baseLocalMethods: aMethodDictionary
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitedClass >> localMethods [
 	"returns the methods of classes excluding the ones of the traits that the class uses"
 
 	^ self localMethodDict values
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 TraitedClass >> localSelectors [
 
 	^ self localMethodDict keys
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 TraitedClass >> rebuildMethodDictionary [
 
 	"Useful to be rewritten in Traits"
 	^ self doRebuildMethodDictionary
 ]
 
-{ #category : #categories }
+{ #category : 'categories' }
 TraitedClass >> recategorizeSelector: selector from: oldProtocol to: newProtocol [
 	"When a method is recategorized I have to classify the method, but also recategorize the aliases pointing to it"
 
@@ -239,7 +232,7 @@ TraitedClass >> recategorizeSelector: selector from: oldProtocol to: newProtocol
 		self notifyOfRecategorizedSelector: selectorAlias from: oldProtocol to: newProtocol ]
 ]
 
-{ #category : #recompilation }
+{ #category : 'recompilation' }
 TraitedClass >> recompile: selector from: oldClass [
 	"Compile the method associated with selector in the receiver's method dictionary."
 
@@ -247,20 +240,18 @@ TraitedClass >> recompile: selector from: oldClass [
 	method := oldClass compiledMethodAt: selector.
 	newMethod := self recompileBasic: selector from: oldClass.
 
-	method properties
-		at: #traitSource
-		ifPresent: [ :aSource | newMethod propertyAt: #traitSource put: aSource].
+	method properties at: #traitSource ifPresent: [ :aSource | newMethod propertyAt: #traitSource put: aSource ].
 
-	self addSelector: selector withRecompiledMethod: newMethod
+	self addSelectorSilently: selector withMethod: newMethod
 ]
 
-{ #category : #'trait-composition' }
+{ #category : 'trait-composition' }
 TraitedClass >> removeFromComposition: aTrait [
 
 	self setTraitComposition: (self traitComposition copyWithoutTrait: aTrait asTraitComposition)
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 TraitedClass >> removeFromSystem: logged [
 
 	"When a traited class is removed the traits it is using should be updated"
@@ -279,7 +270,7 @@ TraitedClass >> removeFromSystem: logged [
 	mySubclasses do: [ :each | each class initializeBasicMethods ]
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 TraitedClass >> removeSelector: aSelector [
 
 	"When a selector is removed it should be notified to my users.
@@ -290,13 +281,13 @@ TraitedClass >> removeSelector: aSelector [
 	TraitChange removeSelector: aSelector on: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitedClass >> traitComposition [
 	"My trait composition is in my class. So I do not need to recompile the methods when installing them during bootstrap"
 	^ self class baseComposition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitedClass >> traitComposition: aComposition [
 
 	aComposition asTraitComposition allTraits do: [ :aMaybeTrait |
@@ -306,18 +297,18 @@ TraitedClass >> traitComposition: aComposition [
 	self class baseComposition: aComposition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitedClass >> traitCompositionString [
 	^ self traitComposition asString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitedClass >> traitUsers [
 	"I am a traited class, I have no users, this is for compatibility with traits"
 	^ #()
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitedClass >> traits [
 	^ self traitComposition traits
 ]

--- a/src/TraitsV2/TraitedMetaclass.class.st
+++ b/src/TraitsV2/TraitedMetaclass.class.st
@@ -8,23 +8,25 @@ Also I have the localMethodDict and the traitComposition of the base class.
 So it is not needed to recompile the methods from TraitedClass. Check #initializeBasicMethods for more details
 "
 Class {
-	#name : #TraitedMetaclass,
-	#superclass : #Metaclass,
+	#name : 'TraitedMetaclass',
+	#superclass : 'Metaclass',
 	#instVars : [
 		'localMethods',
 		'composition',
 		'baseLocalMethods',
 		'baseComposition'
 	],
-	#category : #'TraitsV2-Base'
+	#category : 'TraitsV2-Base',
+	#package : 'TraitsV2',
+	#tag : 'Base'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitedMetaclass class >> traitedClassTrait [
 	^ (TaCompositionElement for: TraitedClass)
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 TraitedMetaclass >> addAndClassifySelector: selector withMethod: compiledMethod inProtocol: aProtocol [
 
 	self localMethodDict at: selector put: compiledMethod.
@@ -34,58 +36,50 @@ TraitedMetaclass >> addAndClassifySelector: selector withMethod: compiledMethod 
 	TraitChange addSelector: selector on: self
 ]
 
-{ #category : #'accessing - method dictionary' }
-TraitedMetaclass >> addSelector: selector withRecompiledMethod: compiledMethod [
-
-	compiledMethod isFromTrait ifTrue: [ ^ super addSelector: selector withRecompiledMethod: compiledMethod ].
-
-	self addSelector: selector withMethod: compiledMethod
-]
-
-{ #category : #querying }
+{ #category : 'querying' }
 TraitedMetaclass >> allTraits [
 
 	^ self traitComposition allTraits
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitedMetaclass >> baseComposition [
 	^ baseComposition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitedMetaclass >> baseComposition: anObject [
 	baseComposition := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitedMetaclass >> baseLocalMethods [
 	^ baseLocalMethods
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitedMetaclass >> baseLocalMethods: anObject [
 	baseLocalMethods := anObject
 ]
 
-{ #category : #fileout }
+{ #category : 'fileout' }
 TraitedMetaclass >> definitionStringFor: aConfiguredPrinter [
 
 	^ aConfiguredPrinter traitedMetaclassDefinitionString
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 TraitedMetaclass >> emptyMethodDictionary [
 	^ MethodDictionary new: 64
 ]
 
-{ #category : #fileout }
+{ #category : 'fileout' }
 TraitedMetaclass >> expandedDefinitionStringFor: aPrinter [
 
 	^ aPrinter expandedTraitedMetaclassDefinitionString
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TraitedMetaclass >> findOriginClassOf: aMethod [
 
 	"I return the myself or the trait that has the original implementation of a method.
@@ -102,7 +96,7 @@ TraitedMetaclass >> findOriginClassOf: aMethod [
 		ifNone: [ self class traitedClassTrait traitDefining: aMethod selector ifNone: [ ^ self ] ]) innerClass
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TraitedMetaclass >> findOriginMethodOf: aMethod [
 
 	"I return the original method for a aMethod.
@@ -125,18 +119,18 @@ TraitedMetaclass >> findOriginMethodOf: aMethod [
 		compiledMethodAt: aMethod selector ifAbsent: [ ^ aMethod ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TraitedMetaclass >> hasTraitComposition [
 
 	^ self traitComposition isEmpty not
 ]
 
-{ #category : #'testing - method dictionary' }
+{ #category : 'testing - method dictionary' }
 TraitedMetaclass >> includesLocalSelector: aSymbol [
 	^ self isLocalSelector: aSymbol
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 TraitedMetaclass >> initialize [
 	super initialize.
 	localMethods := self emptyMethodDictionary.
@@ -146,7 +140,7 @@ TraitedMetaclass >> initialize [
 	baseLocalMethods := self emptyMethodDictionary
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 TraitedMetaclass >> initializeBasicMethods [
 	| selectors |
 
@@ -157,7 +151,7 @@ TraitedMetaclass >> initializeBasicMethods [
 	selectors do: [ :e | self class traitedClassTrait copyMethod: e into: self replacing: true ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TraitedMetaclass >> isAliasSelector: aSymbol [
 	"Return true if the selector aSymbol is an alias defined
 	in my or in another composition somewhere deeper in
@@ -166,7 +160,7 @@ TraitedMetaclass >> isAliasSelector: aSymbol [
 	^ self traitComposition isAliasSelector: aSymbol
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TraitedMetaclass >> isLocalAliasSelector: aSymbol [
 	"Return true if the selector aSymbol is an alias defined
 	in my trait composition."
@@ -174,13 +168,13 @@ TraitedMetaclass >> isLocalAliasSelector: aSymbol [
 	^ self traitComposition isLocalAliasSelector: aSymbol
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TraitedMetaclass >> isLocalSelector: aSelector [
 
 	^ localMethods includesKey: aSelector
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TraitedMetaclass >> isRejectedMethod: aSelector [
 	"Determine if the method is not to be installed in method dictionary"
 
@@ -210,7 +204,7 @@ TraitedMetaclass >> isRejectedMethod: aSelector [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TraitedMetaclass >> isSelectorToKeep: aSelector [
 	"I have to keep the local methods and the methods from TraitedClass
 	The methods from TraitedClass makes me a class suporting traits, without them I am a normal class"
@@ -219,25 +213,25 @@ TraitedMetaclass >> isSelectorToKeep: aSelector [
 		or: [ TraitedClass methodDict includesKey: aSelector ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitedMetaclass >> localMethodDict [
 	^ localMethods
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitedMetaclass >> localMethods [
 	"returns the methods of classes excluding the ones of the traits that the class uses"
 
 	^ localMethods values
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitedMetaclass >> localSelectors [
 
 	^ localMethods keys
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 TraitedMetaclass >> rebuildMethodDictionary [
 	| selectors removedSelectors modified |
 
@@ -261,7 +255,7 @@ TraitedMetaclass >> rebuildMethodDictionary [
 	^ modified
 ]
 
-{ #category : #categories }
+{ #category : 'categories' }
 TraitedMetaclass >> recategorizeSelector: selector from: oldProtocol to: newProtocol [
 	"When a method is recategorized I have to classify the method, but also recategorize the aliases pointing to it"
 
@@ -277,7 +271,7 @@ TraitedMetaclass >> recategorizeSelector: selector from: oldProtocol to: newProt
 		self notifyOfRecategorizedSelector: selectorAlias from: oldProtocol to: newProtocol ]
 ]
 
-{ #category : #recompilation }
+{ #category : 'recompilation' }
 TraitedMetaclass >> recompile: selector from: oldClass [
 	"Compile the method associated with selector in the receiver's method dictionary."
 
@@ -285,19 +279,17 @@ TraitedMetaclass >> recompile: selector from: oldClass [
 	method := oldClass compiledMethodAt: selector.
 	newMethod := self recompileBasic: selector from: oldClass.
 
-	method properties
-		at: #traitSource
-		ifPresent: [ :aSource | newMethod propertyAt: #traitSource put: aSource].
+	method properties at: #traitSource ifPresent: [ :aSource | newMethod propertyAt: #traitSource put: aSource ].
 
-	self addSelector: selector withRecompiledMethod: newMethod
+	self addSelectorSilently: selector withMethod: newMethod
 ]
 
-{ #category : #traits }
+{ #category : 'traits' }
 TraitedMetaclass >> removeFromComposition: aTrait [
 	self setTraitComposition: (self traitComposition copyWithoutTrait: aTrait asTraitComposition)
 ]
 
-{ #category : #'accessing - method dictionary' }
+{ #category : 'accessing - method dictionary' }
 TraitedMetaclass >> removeSelector: aSelector [
 
 	"When a selector is removed it should be notified to my users.
@@ -308,18 +300,18 @@ TraitedMetaclass >> removeSelector: aSelector [
 	TraitChange removeSelector: aSelector on: self
 ]
 
-{ #category : #slots }
+{ #category : 'slots' }
 TraitedMetaclass >> slots [
 
 	^ super slots reject: [ :e | composition slots includes: e ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitedMetaclass >> traitComposition [
 	^ composition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitedMetaclass >> traitComposition: aComposition [
 
 	aComposition asTraitComposition allTraits do: [ :aMaybeTrait |
@@ -329,18 +321,18 @@ TraitedMetaclass >> traitComposition: aComposition [
 	composition := aComposition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitedMetaclass >> traitCompositionString [
 	^ self traitComposition asString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TraitedMetaclass >> traitUsers [
 
 	^ #()
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 TraitedMetaclass >> traits [
 	^ composition traits
 ]

--- a/src/TraitsV2/package.st
+++ b/src/TraitsV2/package.st
@@ -1,1 +1,1 @@
-Package { #name : #TraitsV2 }
+Package { #name : 'TraitsV2' }


### PR DESCRIPTION
While updating a class, it migrates all the methods from the old class to the new one. In that case, the methods are added silently. Well... Usually. 

In the case of a class that has a trait, the methods on the class side are not added silently but with MethodAdded announcements. 

This change removes the annoucement to always do things silently while recompiling