### PR TITLE
Fix: rename methods from different classes

### DIFF
--- a/src/Refactoring-DataForTesting/MyClassA.class.st
+++ b/src/Refactoring-DataForTesting/MyClassA.class.st
@@ -2,8 +2,8 @@
 This is a stupid comment for a stupid class.
 "
 Class {
-	#name : #MyClassA,
-	#superclass : #Object,
+	#name : 'MyClassA',
+	#superclass : 'Object',
 	#instVars : [
 		'instVarName1',
 		'instVarName2'
@@ -12,10 +12,12 @@ Class {
 		'ClassVarName1',
 		'ClassVarName2'
 	],
-	#category : #'Refactoring-DataForTesting-StaticModel'
+	#category : 'Refactoring-DataForTesting-StaticModel',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'StaticModel'
 }
 
-{ #category : #'dummy methods' }
+{ #category : 'dummy methods' }
 MyClassA >> stupidMethodForStupidRule [
 
 	instVarName1 := instVarName2 := ClassVarName1 := ClassVarName2 := 0

--- a/src/Refactoring-DataForTesting/MyClassB.class.st
+++ b/src/Refactoring-DataForTesting/MyClassB.class.st
@@ -2,7 +2,9 @@
 This is a stupid comment for a stupid class.
 "
 Class {
-	#name : #MyClassB,
-	#superclass : #MyClassA,
-	#category : #'Refactoring-DataForTesting-StaticModel'
+	#name : 'MyClassB',
+	#superclass : 'MyClassA',
+	#category : 'Refactoring-DataForTesting-StaticModel',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'StaticModel'
 }

--- a/src/Refactoring-DataForTesting/MyClassC.class.st
+++ b/src/Refactoring-DataForTesting/MyClassC.class.st
@@ -2,7 +2,9 @@
 This is a stupid comment for a stupid class.
 "
 Class {
-	#name : #MyClassC,
-	#superclass : #MyClassA,
-	#category : #'Refactoring-DataForTesting-StaticModel'
+	#name : 'MyClassC',
+	#superclass : 'MyClassA',
+	#category : 'Refactoring-DataForTesting-StaticModel',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'StaticModel'
 }

--- a/src/Refactoring-DataForTesting/MyClassNonEmptyLeafUnused.class.st
+++ b/src/Refactoring-DataForTesting/MyClassNonEmptyLeafUnused.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #MyClassNonEmptyLeafUnused,
-	#superclass : #MyClassA,
+	#name : 'MyClassNonEmptyLeafUnused',
+	#superclass : 'MyClassA',
 	#instVars : [
 		'instVarName1222',
 		'instVarName23333'
@@ -8,17 +8,19 @@ Class {
 	#classVars : [
 		'ClassVarName2456'
 	],
-	#category : #'Refactoring-DataForTesting-StaticModel'
+	#category : 'Refactoring-DataForTesting-StaticModel',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'StaticModel'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 MyClassNonEmptyLeafUnused >> initialize [
 
 	<ignoreUnusedVariables: #( instVarName1222 #instVarName23333 )>
 	super initialize
 ]
 
-{ #category : #'dummy methods' }
+{ #category : 'dummy methods' }
 MyClassNonEmptyLeafUnused >> methodForThePleasureOfIt [
 
 	^ 666

--- a/src/Refactoring-DataForTesting/OnlyReferencedByASymbol.class.st
+++ b/src/Refactoring-DataForTesting/OnlyReferencedByASymbol.class.st
@@ -1,5 +1,7 @@
 Class {
-	#name : #OnlyReferencedByASymbol,
-	#superclass : #Object,
-	#category : #'Refactoring-DataForTesting-SymbolUses'
+	#name : 'OnlyReferencedByASymbol',
+	#superclass : 'Object',
+	#category : 'Refactoring-DataForTesting-SymbolUses',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'SymbolUses'
 }

--- a/src/Refactoring-DataForTesting/OnlyReferencing.class.st
+++ b/src/Refactoring-DataForTesting/OnlyReferencing.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #OnlyReferencing,
-	#superclass : #Object,
-	#category : #'Refactoring-DataForTesting-SymbolUses'
+	#name : 'OnlyReferencing',
+	#superclass : 'Object',
+	#category : 'Refactoring-DataForTesting-SymbolUses',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'SymbolUses'
 }
 
-{ #category : #dull }
+{ #category : 'dull' }
 OnlyReferencing >> referToClassBySymbol [
 
 	^ #OnlyReferencedByASymbol

--- a/src/Refactoring-DataForTesting/RBBasicDummyLintRuleTest.class.st
+++ b/src/Refactoring-DataForTesting/RBBasicDummyLintRuleTest.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #RBBasicDummyLintRuleTest,
-	#superclass : #RBDummyLintRuleTest,
+	#name : 'RBBasicDummyLintRuleTest',
+	#superclass : 'RBDummyLintRuleTest',
 	#instVars : [
 		'methodBlock',
 		'result',
 		'classBlock',
 		'anInstVar'
 	],
-	#category : #'Refactoring-DataForTesting-LittleHierarchy'
+	#category : 'Refactoring-DataForTesting-LittleHierarchy',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'LittleHierarchy'
 }
 
-{ #category : #'possible bugs' }
+{ #category : 'possible bugs' }
 RBBasicDummyLintRuleTest class >> abstractClass [
 	| detector subclassResponsibilitySymbol |
 	detector := self new.
@@ -25,7 +27,7 @@ RBBasicDummyLintRuleTest class >> abstractClass [
 	^detector
 ]
 
-{ #category : #'possible bugs' }
+{ #category : 'possible bugs' }
 RBBasicDummyLintRuleTest class >> addRemoveDependents [
 	| detector |
 	detector := self new.
@@ -48,7 +50,7 @@ RBBasicDummyLintRuleTest class >> addRemoveDependents [
 	^detector
 ]
 
-{ #category : #miscellaneous }
+{ #category : 'miscellaneous' }
 RBBasicDummyLintRuleTest class >> assignmentInBlock [
 	^self createParseTreeRule: #(
 			'`@cursor showWhile: [| `@temps | `@.Statements1. `var := `@object]'
@@ -60,7 +62,7 @@ RBBasicDummyLintRuleTest class >> assignmentInBlock [
 		name: 'Unnecessary assignment or return in block'
 ]
 
-{ #category : #'intention revealing' }
+{ #category : 'intention revealing' }
 RBBasicDummyLintRuleTest class >> assignmentInIfTrue [
 	^self createParseTreeRule:
 			#('`@boolean
@@ -72,7 +74,7 @@ RBBasicDummyLintRuleTest class >> assignmentInIfTrue [
 		name: 'Assignment to same variable and end of ifTrue:ifFalse: blocks'
 ]
 
-{ #category : #'intention revealing' }
+{ #category : 'intention revealing' }
 RBBasicDummyLintRuleTest class >> atIfAbsent [
 	^self createParseTreeRule:
 				#('`@object
@@ -88,7 +90,7 @@ RBBasicDummyLintRuleTest class >> atIfAbsent [
 		name: 'Uses at:ifAbsent: instead of at:ifAbsentPut:'
 ]
 
-{ #category : #bugs }
+{ #category : 'bugs' }
 RBBasicDummyLintRuleTest class >> booleanPrecedence [
 	^self createParseTreeRule:
 			#('`@object1 | `@object2 = `@object3'
@@ -102,7 +104,7 @@ RBBasicDummyLintRuleTest class >> booleanPrecedence [
 		name: 'Uses A | B = C instead of A | (B = C)'
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBBasicDummyLintRuleTest class >> canCall: aSelector in: aClass from: anApplication [
 	"This method contains on purpose not implemented messages, such as rootApplication "
 	| methodApp root |
@@ -113,7 +115,7 @@ RBBasicDummyLintRuleTest class >> canCall: aSelector in: aClass from: anApplicat
 	^methodApp == root or: [root isBasedOn: methodApp]
 ]
 
-{ #category : #miscellaneous }
+{ #category : 'miscellaneous' }
 RBBasicDummyLintRuleTest class >> classNameInSelector [
 	| detector |
 	detector := self new.
@@ -128,7 +130,7 @@ RBBasicDummyLintRuleTest class >> classNameInSelector [
 	^detector
 ]
 
-{ #category : #'unnecessary code' }
+{ #category : 'unnecessary code' }
 RBBasicDummyLintRuleTest class >> classNotReferenced [
 	| detector |
 	detector := self new.
@@ -146,12 +148,12 @@ RBBasicDummyLintRuleTest class >> classNotReferenced [
 	^detector
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBBasicDummyLintRuleTest class >> classShouldNotOverride [
 	^#(#== #class)
 ]
 
-{ #category : #'possible bugs' }
+{ #category : 'possible bugs' }
 RBBasicDummyLintRuleTest class >> collectionCopyEmpty [
 	| detector |
 	detector := self new.
@@ -168,7 +170,7 @@ RBBasicDummyLintRuleTest class >> collectionCopyEmpty [
 	^detector
 ]
 
-{ #category : #'intention revealing' }
+{ #category : 'intention revealing' }
 RBBasicDummyLintRuleTest class >> collectionMessagesToExternalObject [
 	| detector matcher |
 	detector := self new.
@@ -194,7 +196,7 @@ RBBasicDummyLintRuleTest class >> collectionMessagesToExternalObject [
 	^detector
 ]
 
-{ #category : #'intention revealing' }
+{ #category : 'intention revealing' }
 RBBasicDummyLintRuleTest class >> collectionProtocol [
 	^self createParseTreeRule:
 			#('`@collection do: [:`each | | `@temps | `@.Statements1. `@object add: `@arg. `@.Statements2]'
@@ -215,7 +217,7 @@ RBBasicDummyLintRuleTest class >> collectionProtocol [
 		name: 'Uses do: instead of collect: or select:''s'
 ]
 
-{ #category : #'intention revealing' }
+{ #category : 'intention revealing' }
 RBBasicDummyLintRuleTest class >> consistencyCheck [
 	^self createParseTreeRule:
 				#('`@object size == 0'
@@ -227,7 +229,7 @@ RBBasicDummyLintRuleTest class >> consistencyCheck [
 		name: 'Uses "size = 0" or "= nil" instead of "isEmpty" or "isNil"'
 ]
 
-{ #category : #'intention revealing' }
+{ #category : 'intention revealing' }
 RBBasicDummyLintRuleTest class >> contains [
 	^self createParseTreeRule:
 			#('(`@object detect: [:`each | | `@temps| `@.Statements] ifNone: [nil]) isNil'
@@ -240,7 +242,7 @@ RBBasicDummyLintRuleTest class >> contains [
 		name: 'Uses detect:ifNone: instead of contains:'
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBBasicDummyLintRuleTest class >> createMatcherFor: codeStrings method: aBoolean [
 	| matcher |
 	matcher := self parseTreeSearcher.
@@ -250,7 +252,7 @@ RBBasicDummyLintRuleTest class >> createMatcherFor: codeStrings method: aBoolean
 	^matcher
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RBBasicDummyLintRuleTest class >> createParseTreeRule: codeStrings method: aBoolean name: aName [
 	| detector matcher |
 	detector := self new.
@@ -263,14 +265,14 @@ RBBasicDummyLintRuleTest class >> createParseTreeRule: codeStrings method: aBool
 	^detector
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RBBasicDummyLintRuleTest class >> createParseTreeRule: codeStrings name: aName [
 	^self createParseTreeRule: codeStrings
 		method: false
 		name: aName
 ]
 
-{ #category : #'possible bugs' }
+{ #category : 'possible bugs' }
 RBBasicDummyLintRuleTest class >> definesEqualNotHash [
 	| detector |
 	detector := self new.
@@ -284,7 +286,7 @@ RBBasicDummyLintRuleTest class >> definesEqualNotHash [
 	^detector
 ]
 
-{ #category : #'intention revealing' }
+{ #category : 'intention revealing' }
 RBBasicDummyLintRuleTest class >> detectContains [
 	^self createParseTreeRule:
 			#('`@collection do: [:`each | | `@temps |
@@ -314,7 +316,7 @@ RBBasicDummyLintRuleTest class >> detectContains [
 		name: 'Uses do: instead of contains: or detect:''s'
 ]
 
-{ #category : #'unnecessary code' }
+{ #category : 'unnecessary code' }
 RBBasicDummyLintRuleTest class >> endTrueFalse [
 	| detector matcher |
 	detector := self new.
@@ -342,7 +344,7 @@ RBBasicDummyLintRuleTest class >> endTrueFalse [
 	^detector
 ]
 
-{ #category : #'unnecessary code' }
+{ #category : 'unnecessary code' }
 RBBasicDummyLintRuleTest class >> equalsTrue [
 	| detector matcher |
 	detector := self new.
@@ -360,7 +362,7 @@ RBBasicDummyLintRuleTest class >> equalsTrue [
 	^detector
 ]
 
-{ #category : #'unnecessary code' }
+{ #category : 'unnecessary code' }
 RBBasicDummyLintRuleTest class >> equivalentSuperclassMethods [
 	| detector |
 	detector := self new.
@@ -378,7 +380,7 @@ RBBasicDummyLintRuleTest class >> equivalentSuperclassMethods [
 	^detector
 ]
 
-{ #category : #'unnecessary code' }
+{ #category : 'unnecessary code' }
 RBBasicDummyLintRuleTest class >> extraBlock [
 	^self
 		createParseTreeRule: (#('value' 'value: `@value' 'value: `@value1 value: `@value2' 'value: `@value1 value: `value2 value: `@value3' 'valueWithArguments: `@values')
@@ -386,7 +388,7 @@ RBBasicDummyLintRuleTest class >> extraBlock [
 		name: 'Block immediately evaluated'
 ]
 
-{ #category : #'possible bugs' }
+{ #category : 'possible bugs' }
 RBBasicDummyLintRuleTest class >> fileBlocks [
 	^self createParseTreeRule:
 				#('[| `@temps |
@@ -402,7 +404,7 @@ RBBasicDummyLintRuleTest class >> fileBlocks [
 		name: 'Assignment inside unwind blocks should be outside.'
 ]
 
-{ #category : #miscellaneous }
+{ #category : 'miscellaneous' }
 RBBasicDummyLintRuleTest class >> fullBlocks [
 
 "	| detector |
@@ -417,7 +419,7 @@ RBBasicDummyLintRuleTest class >> fullBlocks [
 	^detector"
 ]
 
-{ #category : #'intention revealing' }
+{ #category : 'intention revealing' }
 RBBasicDummyLintRuleTest class >> guardingClause [
 	^self
 		createParseTreeRule:
@@ -433,7 +435,7 @@ RBBasicDummyLintRuleTest class >> guardingClause [
 		name: 'Guarding clauses'
 ]
 
-{ #category : #miscellaneous }
+{ #category : 'miscellaneous' }
 RBBasicDummyLintRuleTest class >> ifTrueBlocks [
 	| detector matcher |
 	detector := self new.
@@ -452,7 +454,7 @@ RBBasicDummyLintRuleTest class >> ifTrueBlocks [
 	^detector
 ]
 
-{ #category : #'intention revealing' }
+{ #category : 'intention revealing' }
 RBBasicDummyLintRuleTest class >> ifTrueReturns [
 	| detector matcher |
 	detector := self new.
@@ -474,7 +476,7 @@ RBBasicDummyLintRuleTest class >> ifTrueReturns [
 	^detector
 ]
 
-{ #category : #'unnecessary code' }
+{ #category : 'unnecessary code' }
 RBBasicDummyLintRuleTest class >> implementedNotSent [
 	| detector |
 	detector := self new.
@@ -486,7 +488,7 @@ RBBasicDummyLintRuleTest class >> implementedNotSent [
 	^detector
 ]
 
-{ #category : #miscellaneous }
+{ #category : 'miscellaneous' }
 RBBasicDummyLintRuleTest class >> instVarInSubclasses [
 	| detector |
 	detector := self new.
@@ -507,7 +509,7 @@ RBBasicDummyLintRuleTest class >> instVarInSubclasses [
 	^detector
 ]
 
-{ #category : #'unnecessary code' }
+{ #category : 'unnecessary code' }
 RBBasicDummyLintRuleTest class >> justSendsSuper [
 	| detector matcher |
 	detector := self new.
@@ -521,12 +523,12 @@ RBBasicDummyLintRuleTest class >> justSendsSuper [
 	^detector
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBBasicDummyLintRuleTest class >> longMethodSize [
 	^10
 ]
 
-{ #category : #miscellaneous }
+{ #category : 'miscellaneous' }
 RBBasicDummyLintRuleTest class >> longMethods [
 	| detector matcher |
 	detector := self new.
@@ -545,12 +547,12 @@ RBBasicDummyLintRuleTest class >> longMethods [
 	^detector
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBBasicDummyLintRuleTest class >> metaclassShouldNotOverride [
 	^#(#name #comment)
 ]
 
-{ #category : #'intention revealing' }
+{ #category : 'intention revealing' }
 RBBasicDummyLintRuleTest class >> minMax [
 	| detector matcher |
 	detector := self new.
@@ -571,7 +573,7 @@ RBBasicDummyLintRuleTest class >> minMax [
 	^detector
 ]
 
-{ #category : #'intention revealing' }
+{ #category : 'intention revealing' }
 RBBasicDummyLintRuleTest class >> missingSubclassResponsibility [
 	| detector |
 	detector := self new.
@@ -599,7 +601,7 @@ RBBasicDummyLintRuleTest class >> missingSubclassResponsibility [
 	^detector
 ]
 
-{ #category : #'possible bugs' }
+{ #category : 'possible bugs' }
 RBBasicDummyLintRuleTest class >> missingYourself [
 	| detector matcher |
 	detector := self new.
@@ -618,7 +620,7 @@ RBBasicDummyLintRuleTest class >> missingYourself [
 	^detector
 ]
 
-{ #category : #'possible bugs' }
+{ #category : 'possible bugs' }
 RBBasicDummyLintRuleTest class >> modifiesCollection [
 	| detector addSearcher |
 	detector := self new.
@@ -632,7 +634,7 @@ RBBasicDummyLintRuleTest class >> modifiesCollection [
 	^detector
 ]
 
-{ #category : #'unnecessary code' }
+{ #category : 'unnecessary code' }
 RBBasicDummyLintRuleTest class >> onlyReadOrWritten [
 	| detector |
 	detector := self new.
@@ -656,7 +658,7 @@ RBBasicDummyLintRuleTest class >> onlyReadOrWritten [
 	^detector
 ]
 
-{ #category : #bugs }
+{ #category : 'bugs' }
 RBBasicDummyLintRuleTest class >> overridesSpecialMessage [
 	| detector |
 	detector := self new.
@@ -675,7 +677,7 @@ RBBasicDummyLintRuleTest class >> overridesSpecialMessage [
 	^detector
 ]
 
-{ #category : #miscellaneous }
+{ #category : 'miscellaneous' }
 RBBasicDummyLintRuleTest class >> precedence [
 	| detector matcher |
 	detector := self new.
@@ -693,12 +695,12 @@ RBBasicDummyLintRuleTest class >> precedence [
 	^ detector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBBasicDummyLintRuleTest class >> protocolsToCheck [
 	^#('bugs' 'possible bugs' 'unnecessary code' 'intention revealing' 'miscellaneous')
 ]
 
-{ #category : #miscellaneous }
+{ #category : 'miscellaneous' }
 RBBasicDummyLintRuleTest class >> refersToClass [
 	| detector |
 	detector := self new.
@@ -715,7 +717,7 @@ RBBasicDummyLintRuleTest class >> refersToClass [
 	^detector
 ]
 
-{ #category : #'possible bugs' }
+{ #category : 'possible bugs' }
 RBBasicDummyLintRuleTest class >> returnsBooleanAndOther [
 	| detector matcher |
 	detector := self new.
@@ -743,7 +745,7 @@ RBBasicDummyLintRuleTest class >> returnsBooleanAndOther [
 	^detector
 ]
 
-{ #category : #'possible bugs' }
+{ #category : 'possible bugs' }
 RBBasicDummyLintRuleTest class >> returnsIfTrue [
 	^self createParseTreeRule:
 				#('^`@condition ifTrue: [| `@temps | `@.statements]'
@@ -751,7 +753,7 @@ RBBasicDummyLintRuleTest class >> returnsIfTrue [
 		name: 'Returns value of ifTrue:/ifFalse: without ifFalse:/ifTrue: block'
 ]
 
-{ #category : #'possible bugs' }
+{ #category : 'possible bugs' }
 RBBasicDummyLintRuleTest class >> sendsDifferentSuper [
 	| detector |
 	detector := self new.
@@ -766,7 +768,7 @@ RBBasicDummyLintRuleTest class >> sendsDifferentSuper [
 	^detector
 ]
 
-{ #category : #bugs }
+{ #category : 'bugs' }
 RBBasicDummyLintRuleTest class >> sentNotImplemented [
 
 	| detector |
@@ -799,7 +801,7 @@ RBBasicDummyLintRuleTest class >> sentNotImplemented [
 	^ detector
 ]
 
-{ #category : #'possible bugs' }
+{ #category : 'possible bugs' }
 RBBasicDummyLintRuleTest class >> sentNotImplementedInApplication [
 
 	| detector |
@@ -837,7 +839,7 @@ RBBasicDummyLintRuleTest class >> sentNotImplementedInApplication [
 	^ detector
 ]
 
-{ #category : #'intention revealing' }
+{ #category : 'intention revealing' }
 RBBasicDummyLintRuleTest class >> sizeCheck [
 	^self createParseTreeRule: (#(#do: #collect: #reject: #select:) collect:
 					[:each |
@@ -850,7 +852,7 @@ RBBasicDummyLintRuleTest class >> sizeCheck [
 		name: 'Unnecessary size check'
 ]
 
-{ #category : #miscellaneous }
+{ #category : 'miscellaneous' }
 RBBasicDummyLintRuleTest class >> stringConcatenation [
 	| detector matcher concatenationMatcher |
 	detector := self new.
@@ -876,7 +878,7 @@ RBBasicDummyLintRuleTest class >> stringConcatenation [
 	^detector
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBBasicDummyLintRuleTest class >> subclassOf: aClass overrides: aSelector [
 	| subs |
 	subs := aClass subclasses.
@@ -890,7 +892,7 @@ RBBasicDummyLintRuleTest class >> subclassOf: aClass overrides: aSelector [
 	^false
 ]
 
-{ #category : #bugs }
+{ #category : 'bugs' }
 RBBasicDummyLintRuleTest class >> subclassResponsibilityNotDefined [
 	| detector subclassResponsibilitySymbol |
 	detector := self new.
@@ -910,12 +912,12 @@ RBBasicDummyLintRuleTest class >> subclassResponsibilityNotDefined [
 	^detector
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBBasicDummyLintRuleTest class >> superMessages [
 	^#(#release #postCopy #postBuildWith: #preBuildWith: #postOpenWith: #noticeOfWindowClose: #initialize)
 ]
 
-{ #category : #'possible bugs' }
+{ #category : 'possible bugs' }
 RBBasicDummyLintRuleTest class >> superSends [
 	| detector |
 	detector := self new.
@@ -932,7 +934,7 @@ RBBasicDummyLintRuleTest class >> superSends [
 	^detector
 ]
 
-{ #category : #'possible bugs' }
+{ #category : 'possible bugs' }
 RBBasicDummyLintRuleTest class >> tempVarOverridesInstVar [
 	| detector matcher vars varName |
 	detector := self new.
@@ -952,7 +954,7 @@ RBBasicDummyLintRuleTest class >> tempVarOverridesInstVar [
 	^detector
 ]
 
-{ #category : #'possible bugs' }
+{ #category : 'possible bugs' }
 RBBasicDummyLintRuleTest class >> tempsReadBeforeWritten [
 	| detector |
 	detector := self new.
@@ -971,7 +973,7 @@ RBBasicDummyLintRuleTest class >> tempsReadBeforeWritten [
 	^detector
 ]
 
-{ #category : #'possible bugs' }
+{ #category : 'possible bugs' }
 RBBasicDummyLintRuleTest class >> threeElementPoint [
 	| detector matcher |
 	detector := self new.
@@ -995,7 +997,7 @@ RBBasicDummyLintRuleTest class >> threeElementPoint [
 	^detector
 ]
 
-{ #category : #'intention revealing' }
+{ #category : 'intention revealing' }
 RBBasicDummyLintRuleTest class >> toDo [
 	| detector matcher |
 	detector := self new.
@@ -1018,7 +1020,7 @@ RBBasicDummyLintRuleTest class >> toDo [
 	^detector
 ]
 
-{ #category : #'unnecessary code' }
+{ #category : 'unnecessary code' }
 RBBasicDummyLintRuleTest class >> unreferencedVariables [
 	| detector |
 	detector := self new.
@@ -1040,7 +1042,7 @@ RBBasicDummyLintRuleTest class >> unreferencedVariables [
 	^detector
 ]
 
-{ #category : #'possible bugs' }
+{ #category : 'possible bugs' }
 RBBasicDummyLintRuleTest class >> usesAdd [
 	| detector addSearcher |
 	detector := self new.
@@ -1053,7 +1055,7 @@ RBBasicDummyLintRuleTest class >> usesAdd [
 	^detector
 ]
 
-{ #category : #bugs }
+{ #category : 'bugs' }
 RBBasicDummyLintRuleTest class >> usesTrue [
 	| detector trueBinding falseBinding |
 	detector := self new.
@@ -1071,7 +1073,7 @@ RBBasicDummyLintRuleTest class >> usesTrue [
 	^detector
 ]
 
-{ #category : #miscellaneous }
+{ #category : 'miscellaneous' }
 RBBasicDummyLintRuleTest class >> utilityMethods [
 	| detector |
 	detector := self new.
@@ -1096,14 +1098,14 @@ RBBasicDummyLintRuleTest class >> utilityMethods [
 	^detector
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBBasicDummyLintRuleTest class >> utilityProtocols [
 	"If a method is defined in one of these protocols, then don't check if its a utility method."
 
 	^#('*utilit*')
 ]
 
-{ #category : #miscellaneous }
+{ #category : 'miscellaneous' }
 RBBasicDummyLintRuleTest class >> variableAssignedLiteral [
 	| detector |
 	detector := self new.
@@ -1137,7 +1139,7 @@ RBBasicDummyLintRuleTest class >> variableAssignedLiteral [
 	^detector
 ]
 
-{ #category : #'unnecessary code' }
+{ #category : 'unnecessary code' }
 RBBasicDummyLintRuleTest class >> variableReferencedOnce [
 	| detector |
 	detector := self new.
@@ -1174,7 +1176,7 @@ RBBasicDummyLintRuleTest class >> variableReferencedOnce [
 	^detector
 ]
 
-{ #category : #'intention revealing' }
+{ #category : 'intention revealing' }
 RBBasicDummyLintRuleTest class >> whileTrue [
 	^self createParseTreeRule:
 			#('| `@temps |
@@ -1212,7 +1214,7 @@ RBBasicDummyLintRuleTest class >> whileTrue [
 		name: 'Uses whileTrue: instead of to:do:'
 ]
 
-{ #category : #miscellaneous }
+{ #category : 'miscellaneous' }
 RBBasicDummyLintRuleTest class >> yourselfNotUsed [
 	| detector addSearcher |
 	detector := self new.
@@ -1227,43 +1229,43 @@ RBBasicDummyLintRuleTest class >> yourselfNotUsed [
 	^detector
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBBasicDummyLintRuleTest >> anInstVar [
 	^ anInstVar
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 RBBasicDummyLintRuleTest >> anInstVar: anObject [
 	anInstVar := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBBasicDummyLintRuleTest >> checkClass: aSmalllintContext [
 	^classBlock value: aSmalllintContext value: result
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBBasicDummyLintRuleTest >> checkMethod: aSmalllintContext [
 	^methodBlock value: aSmalllintContext value: result
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBBasicDummyLintRuleTest >> classBlock [
 	^ self anInstVar + 5
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBBasicDummyLintRuleTest >> classBlock: aBlock [
 	classBlock := aBlock testMethod1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBBasicDummyLintRuleTest >> foobar [
 
 	^#( true false )
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBBasicDummyLintRuleTest >> initialize [
 	super initialize.
 	self anInstVar: 1.
@@ -1272,59 +1274,59 @@ RBBasicDummyLintRuleTest >> initialize [
 	self resultClass: RBSelectorEnvironment
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBBasicDummyLintRuleTest >> isEmpty [
 	^result isEmpty
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBBasicDummyLintRuleTest >> method: anObject1 with: anObject2 lots: anObject3 of: anObject4 arguments: anObject5 [
 	^ anObject5 + anObject1 > (anObject4 - anObject2 + anObject3)
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBBasicDummyLintRuleTest >> methodBlock: aBlock [
 	methodBlock := aBlock
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBBasicDummyLintRuleTest >> newResultClass: aClass [
 "New one:)"
 	result := aClass new
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBBasicDummyLintRuleTest >> problemCount [
 	^result problemCount
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 RBBasicDummyLintRuleTest >> resetResult [
 	result := result copyEmpty.
 	result label: name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBBasicDummyLintRuleTest >> result [
 	^result
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 RBBasicDummyLintRuleTest >> result: aResult [
 	result := aResult copyEmpty
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBBasicDummyLintRuleTest >> resultClass: aClass [
 	result := aClass new
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBBasicDummyLintRuleTest >> someDemoMethod [
 	^ self junk
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBBasicDummyLintRuleTest >> viewResults [
 	result openEditor
 ]

--- a/src/Refactoring-DataForTesting/RBBasicLintRuleTestData.class.st
+++ b/src/Refactoring-DataForTesting/RBBasicLintRuleTestData.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #RBBasicLintRuleTestData,
-	#superclass : #RBLintRuleTestData,
+	#name : 'RBBasicLintRuleTestData',
+	#superclass : 'RBLintRuleTestData',
 	#instVars : [
 		'methodBlock',
 		'result',
 		'classBlock',
 		'anInstVar'
 	],
-	#category : #'Refactoring-DataForTesting-LittleHierarchy'
+	#category : 'Refactoring-DataForTesting-LittleHierarchy',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'LittleHierarchy'
 }
 
-{ #category : #private }
+{ #category : 'private' }
 RBBasicLintRuleTestData class >> canCall: aSelector in: aClass from: anApplication [
 	"This method contains on purpose not implemented messages, such as rootApplication "
 	| methodApp root |
@@ -21,12 +23,12 @@ RBBasicLintRuleTestData class >> canCall: aSelector in: aClass from: anApplicati
 	^methodApp == root or: [root isBasedOn: methodApp]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBBasicLintRuleTestData class >> classShouldNotOverride [
 	^#(#== #class)
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBBasicLintRuleTestData class >> createMatcherFor: codeStrings method: aBoolean [
 	| matcher |
 	matcher := self parseTreeSearcher.
@@ -36,7 +38,7 @@ RBBasicLintRuleTestData class >> createMatcherFor: codeStrings method: aBoolean 
 	^matcher
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RBBasicLintRuleTestData class >> createParseTreeRule: codeStrings method: aBoolean name: aName [
 	| detector matcher |
 	detector := self new.
@@ -49,14 +51,14 @@ RBBasicLintRuleTestData class >> createParseTreeRule: codeStrings method: aBoole
 	^detector
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RBBasicLintRuleTestData class >> createParseTreeRule: codeStrings name: aName [
 	^self createParseTreeRule: codeStrings
 		method: false
 		name: aName
 ]
 
-{ #category : #'unnecessary code' }
+{ #category : 'unnecessary code' }
 RBBasicLintRuleTestData class >> justSendsSuper [
 	| detector matcher |
 	detector := self new.
@@ -70,17 +72,17 @@ RBBasicLintRuleTestData class >> justSendsSuper [
 	^detector
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBBasicLintRuleTestData class >> longMethodSize [
 	^10
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBBasicLintRuleTestData class >> metaclassShouldNotOverride [
 	^#(#name #comment)
 ]
 
-{ #category : #'possible bugs' }
+{ #category : 'possible bugs' }
 RBBasicLintRuleTestData class >> modifiesCollection [
 	| detector addSearcher |
 	detector := self new.
@@ -94,7 +96,7 @@ RBBasicLintRuleTestData class >> modifiesCollection [
 	^detector
 ]
 
-{ #category : #miscellaneous }
+{ #category : 'miscellaneous' }
 RBBasicLintRuleTestData class >> precedence [
 	| detector matcher |
 	detector := self new.
@@ -109,12 +111,12 @@ RBBasicLintRuleTestData class >> precedence [
 	^detector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBBasicLintRuleTestData class >> protocolsToCheck [
 	^#('bugs' 'possible bugs' 'unnecessary code' 'intention revealing' 'miscellaneous')
 ]
 
-{ #category : #'possible bugs' }
+{ #category : 'possible bugs' }
 RBBasicLintRuleTestData class >> sentNotImplementedInApplication [
 	| detector |
 	detector := self new.
@@ -146,7 +148,7 @@ RBBasicLintRuleTestData class >> sentNotImplementedInApplication [
 	^detector
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBBasicLintRuleTestData class >> subclassOf: aClass overrides: aSelector [
 	| subs |
 	subs := aClass subclasses.
@@ -160,7 +162,7 @@ RBBasicLintRuleTestData class >> subclassOf: aClass overrides: aSelector [
 	^false
 ]
 
-{ #category : #bugs }
+{ #category : 'bugs' }
 RBBasicLintRuleTestData class >> subclassResponsibilityNotDefined [
 	| detector subclassResponsibilitySymbol |
 	detector := self new.
@@ -180,12 +182,12 @@ RBBasicLintRuleTestData class >> subclassResponsibilityNotDefined [
 	^detector
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBBasicLintRuleTestData class >> superMessages [
 	^#(#release #postCopy #postBuildWith: #preBuildWith: #postOpenWith: #noticeOfWindowClose: #initialize)
 ]
 
-{ #category : #'possible bugs' }
+{ #category : 'possible bugs' }
 RBBasicLintRuleTestData class >> superSends [
 	| detector |
 	detector := self new.
@@ -202,7 +204,7 @@ RBBasicLintRuleTestData class >> superSends [
 	^detector
 ]
 
-{ #category : #'intention revealing' }
+{ #category : 'intention revealing' }
 RBBasicLintRuleTestData class >> toDo [
 	| detector matcher |
 	detector := self new.
@@ -225,7 +227,7 @@ RBBasicLintRuleTestData class >> toDo [
 	^detector
 ]
 
-{ #category : #miscellaneous }
+{ #category : 'miscellaneous' }
 RBBasicLintRuleTestData class >> utilityMethods [
 	| detector |
 	detector := self new.
@@ -250,50 +252,50 @@ RBBasicLintRuleTestData class >> utilityMethods [
 	^detector
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBBasicLintRuleTestData class >> utilityProtocols [
 	"If a method is defined in one of these protocols, then don't check if its a utility method."
 
 	^#('*utilit*')
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBBasicLintRuleTestData >> anInstVar [
 	^ anInstVar
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 RBBasicLintRuleTestData >> anInstVar: anObject [
 	anInstVar := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBBasicLintRuleTestData >> checkClass: aSmalllintContext [
 	^classBlock value: aSmalllintContext value: result
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBBasicLintRuleTestData >> checkMethod: aSmalllintContext [
 	^methodBlock value: aSmalllintContext value: result
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBBasicLintRuleTestData >> classBlock [
 	^ self anInstVar + 5
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBBasicLintRuleTestData >> classBlock: aBlock [
 	classBlock := aBlock testMethod1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBBasicLintRuleTestData >> foobar [
 
 	^#( true false )
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBBasicLintRuleTestData >> initialize [
 	super initialize.
 	self anInstVar: 1.
@@ -302,65 +304,65 @@ RBBasicLintRuleTestData >> initialize [
 	self resultClass: RBSelectorEnvironment
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBBasicLintRuleTestData >> isEmpty [
 	^result isEmpty
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBBasicLintRuleTestData >> method: anObject1 with: anObject2 lots: anObject3 of: anObject4 arguments: anObject5 [
 	^ anObject5 + anObject1 > (anObject4 - anObject2 + anObject3)
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBBasicLintRuleTestData >> methodBlock: aBlock [
 	methodBlock := aBlock
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBBasicLintRuleTestData >> newResultClass: aClass [
 "New one:)"
 	result := aClass new
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBBasicLintRuleTestData >> onlyReferenceToSomeDemoMethod [
 
 	^ self onlyReferenceToSomeDemoMethod 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBBasicLintRuleTestData >> problemCount [
 	^result problemCount
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 RBBasicLintRuleTestData >> resetResult [
 	result := result copyEmpty.
 	result label: name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBBasicLintRuleTestData >> result [
 	^result
 ]
 
-{ #category : #'initialize-release' }
+{ #category : 'initialize-release' }
 RBBasicLintRuleTestData >> result: aResult [
 	result := aResult copyEmpty
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBBasicLintRuleTestData >> resultClass: aClass [
 	result := aClass new
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBBasicLintRuleTestData >> someDemoMethod [
 	^ self junk
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBBasicLintRuleTestData >> viewResults [
 	result openEditor
 ]

--- a/src/Refactoring-DataForTesting/RBClassDataForRefactoringTest.class.st
+++ b/src/Refactoring-DataForTesting/RBClassDataForRefactoringTest.class.st
@@ -1,23 +1,25 @@
 Class {
-	#name : #RBClassDataForRefactoringTest,
-	#superclass : #Object,
+	#name : 'RBClassDataForRefactoringTest',
+	#superclass : 'Object',
 	#instVars : [
 		'instanceVariable'
 	],
-	#category : #'Refactoring-DataForTesting-FatClasses'
+	#category : 'Refactoring-DataForTesting-FatClasses',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'FatClasses'
 }
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> asOrderedCollectionNotNeeded [
 	self foo addAll: (1 to: 10) asOrderedCollection
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> assignmentInBlock [
 	[^self printString] ensure: [self close]
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> assignmentInIfTrue [
 	| variable |
 	self isVariable
@@ -26,7 +28,7 @@ RBClassDataForRefactoringTest >> assignmentInIfTrue [
 	^variable
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> atIfAbsent [
 	^ Smalltalk at: #MyTest
 		ifAbsent:
@@ -35,27 +37,27 @@ RBClassDataForRefactoringTest >> atIfAbsent [
 			Smalltalk at: #MyTest put: collection]
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> badMessage [
 	self become: String new
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> booleanPrecedence [
 	^true & 4 = 45
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBClassDataForRefactoringTest >> callFoo [
 	^self testFoo: 5
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBClassDataForRefactoringTest >> callMethod [
 	^self renameThisMethod: 5
 ]
 
-{ #category : #inline }
+{ #category : 'inline' }
 RBClassDataForRefactoringTest >> called: anObject on1: aBlock [
 	| each |
 	each := anObject printString.
@@ -63,14 +65,14 @@ RBClassDataForRefactoringTest >> called: anObject on1: aBlock [
 	aBlock value: each
 ]
 
-{ #category : #inline }
+{ #category : 'inline' }
 RBClassDataForRefactoringTest >> called: anObject on: aBlock [
 	
 	anObject printString traceCr; cr.
 	aBlock value
 ]
 
-{ #category : #inline }
+{ #category : 'inline' }
 RBClassDataForRefactoringTest >> caller [
 	| anObject |
 	anObject := 5.
@@ -79,7 +81,7 @@ RBClassDataForRefactoringTest >> caller [
 		on: [^anObject]
 ]
 
-{ #category : #inline }
+{ #category : 'inline' }
 RBClassDataForRefactoringTest >> caller1 [
 	| anObject |
 	anObject := 5.
@@ -90,22 +92,22 @@ RBClassDataForRefactoringTest >> caller1 [
 			^anObject]
 ]
 
-{ #category : #inline }
+{ #category : 'inline' }
 RBClassDataForRefactoringTest >> caller2 [
 	^(1 to: 10) inject: 1 into: [:sum :each | sum * (self foo: each)]
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> collectSelectNotUsed [
 	(1 to: 10) select: [:each | each = 4]
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> collectionMessagesToExternalObject [
 	self someObject collection remove: 10
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> collectionProtocol [
 	| newCollection |
 	newCollection := OrderedCollection new.
@@ -117,28 +119,28 @@ RBClassDataForRefactoringTest >> collectionProtocol [
 	^newCollection
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> consistencyCheck [
 	^(1 to: 10) size > 0
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> contains [
 	^((1 to: 10) detect: [:each | each > 2] ifNone: [nil]) isNil
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> cruft [
 	<haltOrBreakpointForTesting>
 	self halt
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBClassDataForRefactoringTest >> demoExampleCall [
 	^ self demoRenameMethod: 1 PermuteArgs: 2
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBClassDataForRefactoringTest >> demoMethodWithDuplicates [
 	| a b result1 result2 answer |
 	a := 3.
@@ -149,19 +151,19 @@ RBClassDataForRefactoringTest >> demoMethodWithDuplicates [
 	^ answer
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBClassDataForRefactoringTest >> demoRenameMethod: arg1 PermuteArgs: arg2 [
 	self do: arg1.
 	self do: arg2.
 	^ arg1 > arg2
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> detectContains [
 	^(1 to: 10) do: [:each | each > 2 ifTrue: [^each]]
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> endTrueFalse [
 	self isVariable
 		ifTrue:
@@ -172,7 +174,7 @@ RBClassDataForRefactoringTest >> endTrueFalse [
 			^4]
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> equalNotUsed [
 	| string |
 	string = '' yourself.
@@ -180,23 +182,23 @@ RBClassDataForRefactoringTest >> equalNotUsed [
 	^string
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> equalsTrue [
 	^true == self
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBClassDataForRefactoringTest >> exampleCall [
 	<sampleInstance>
 	^self rename: 1 two: 2
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> extraBlock [
 	^[:arg | arg + 43] value: 45
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> fileBlocks [
 	| file |
 	^
@@ -204,17 +206,17 @@ RBClassDataForRefactoringTest >> fileBlocks [
 	file contents] ensure: [file close]
 ]
 
-{ #category : #inline }
+{ #category : 'inline' }
 RBClassDataForRefactoringTest >> foo: aValue [
 	^(1 to: 10) inject: aValue into: [:sum :each | sum + each]
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> fullBlocks [
 	^[thisContext]
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> guardingClause [
 	self isSymbol
 		ifFalse:
@@ -222,18 +224,18 @@ RBClassDataForRefactoringTest >> guardingClause [
 			self isSymbol printString]
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> ifTrueReturns [
 	self isSymbol ifFalse: [^true].
 	^false
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBClassDataForRefactoringTest >> inlineBar: aSymbol [
 	^aSymbol isSymbol
 ]
 
-{ #category : #inline }
+{ #category : 'inline' }
 RBClassDataForRefactoringTest >> inlineComponent [
 	| a |
 	a := 5.
@@ -243,7 +245,7 @@ RBClassDataForRefactoringTest >> inlineComponent [
 		yourself
 ]
 
-{ #category : #inline }
+{ #category : 'inline' }
 RBClassDataForRefactoringTest >> inlineFailed [
 	| x y q |
 	x := 5.
@@ -252,7 +254,7 @@ RBClassDataForRefactoringTest >> inlineFailed [
 	^q
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBClassDataForRefactoringTest >> inlineFoo: aBlock [
 	| bar baz asdf |
 	bar := aBlock value: self.
@@ -261,7 +263,7 @@ RBClassDataForRefactoringTest >> inlineFoo: aBlock [
 	^asdf
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBClassDataForRefactoringTest >> inlineJunk [
 	| asdf |
 	asdf := self inlineFoo:
@@ -276,12 +278,12 @@ RBClassDataForRefactoringTest >> inlineJunk [
 			baz * baz]
 ]
 
-{ #category : #inline }
+{ #category : 'inline' }
 RBClassDataForRefactoringTest >> inlineLast [
 	5 = 3 ifTrue: [^self caller] ifFalse: [^self caller2]
 ]
 
-{ #category : #inline }
+{ #category : 'inline' }
 RBClassDataForRefactoringTest >> inlineMax [
 	| x y q |
 	x := 5.
@@ -290,7 +292,7 @@ RBClassDataForRefactoringTest >> inlineMax [
 	^q
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBClassDataForRefactoringTest >> inlineMethod [
 	| temp |
 	temp := self
@@ -300,29 +302,29 @@ RBClassDataForRefactoringTest >> inlineMethod [
 	^temp
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBClassDataForRefactoringTest >> inlineParameterMethod: aSymbol [
 	^aSymbol isSymbol
 ]
 
-{ #category : #inline }
+{ #category : 'inline' }
 RBClassDataForRefactoringTest >> inlineTemporary [
 	| temp |
 	self isNil ifTrue: [temp := 4].
 	^temp
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> justSendsSuper [
 	super justSendsSuper
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> literalArrayCharacters [
 	^#($a $b $c) includes: $a
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> literalArrayWithTrueFalseOrNil [
 	| a b c |
 	a := #(true false nil).
@@ -331,7 +333,7 @@ RBClassDataForRefactoringTest >> literalArrayWithTrueFalseOrNil [
 	^{a. b. c}
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> literalArrayWithTrueFalseOrNil2 [
 	| b c |
 	b := #(#true #false #nil).
@@ -339,7 +341,7 @@ RBClassDataForRefactoringTest >> literalArrayWithTrueFalseOrNil2 [
 ^b
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> longMethods [
 	self printString.
 	self printString.
@@ -349,7 +351,7 @@ RBClassDataForRefactoringTest >> longMethods [
 	self isVariable ifTrue: [self printString]
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> minMax [
 	"Bug in 3<5 ifTrue: [3]  ifFalse: [5]"
 
@@ -360,7 +362,7 @@ RBClassDataForRefactoringTest >> minMax [
 	^var"
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> missingYourself [
 	^(OrderedCollection new)
 		add: 1;
@@ -368,7 +370,7 @@ RBClassDataForRefactoringTest >> missingYourself [
 		removeFirst
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> modifiesCollection [
 	| collection |
 	collection := (1 to: 10) asOrderedCollection.
@@ -376,7 +378,7 @@ RBClassDataForRefactoringTest >> modifiesCollection [
 	^collection
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBClassDataForRefactoringTest >> moveDefinition [
 	| temp |
 	^(self collect:
@@ -389,13 +391,13 @@ RBClassDataForRefactoringTest >> moveDefinition [
 			temp odd]
 ]
 
-{ #category : #inline }
+{ #category : 'inline' }
 RBClassDataForRefactoringTest >> multipleCalls [
 	self caller2.
 	self caller2
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBClassDataForRefactoringTest >> noMoveDefinition [
 	| temp |
 	^(self collect:
@@ -405,12 +407,12 @@ RBClassDataForRefactoringTest >> noMoveDefinition [
 		select: [:each | temp := each size + temp]
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> precedence [
 	^self isArray ifFalse: [self block + 5 * 34] ifTrue: [self printString = 10]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBClassDataForRefactoringTest >> referencesConditionFor: aClass [
 	| environment association |
 	^(RBCondition withBlock:
@@ -424,27 +426,27 @@ RBClassDataForRefactoringTest >> referencesConditionFor: aClass [
 		yourself
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> refersToClass [
 	^ RBClassDataForRefactoringTest
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> release [
 	self printString
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBClassDataForRefactoringTest >> rename: this two: argumentMethod [
 	^self printString , this , argumentMethod
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBClassDataForRefactoringTest >> renameThisMethod: anArg [
 	^self
 ]
 
-{ #category : #rendering }
+{ #category : 'rendering' }
 RBClassDataForRefactoringTest >> renderContentOn: html [
 	html
 		form: [ html text: 'Name:'.
@@ -465,60 +467,60 @@ RBClassDataForRefactoringTest >> renderContentOn: html [
 					html break
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> returnInEnsure [
 	[self error: 'asdf'] ensure: [^4]
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> returnsBooleanAndOther [
 	self isVariable ifTrue: [^false].
 	self printString
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> returnsIfTrue [
 	^self isNil ifTrue: [4]
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> searchingLiteral [
 	^self printString = #a or: [#() = self printString | ( #() == self printString)]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBClassDataForRefactoringTest >> selectorNotReferenced [
 	^self selectorNotReferenced + 4
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBClassDataForRefactoringTest >> sendInlineBar [
 	^ self inlineBar: #example1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBClassDataForRefactoringTest >> sendInlineBar2 [
 	^ self inlineBar: 'example2'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBClassDataForRefactoringTest >> sendInlineParameterMethod [
 	^self inlineParameterMethod: #(#asdf)
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> sendsDifferentSuper [
 	super printString
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> sizeCheck [
 
 	self isEmpty 
 		ifFalse: [ self do: [ :each | each traceCr ] ]
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> stringConcatenation [
 	| string |
 	string := '' yourself.
@@ -526,59 +528,59 @@ RBClassDataForRefactoringTest >> stringConcatenation [
 	^string
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBClassDataForRefactoringTest >> symbolReference [
 	^#(#renameThisMethod: #(4 #renameThisMethod:))
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> tempVarOverridesInstVar [
 	| temporaryVariable |
 	temporaryVariable := 4.
 	^temporaryVariable
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> tempsReadBeforeWritten [
 	| temp |
 	self isVariable ifTrue: [temp := 4].
 	^temp
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBClassDataForRefactoringTest >> testFoo: anObject [
 	^self class + anObject
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBClassDataForRefactoringTest >> testMethod [
 	^self class
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBClassDataForRefactoringTest >> testMethod1 [
 	^self testMethod1
 		, ([:each | each testMethod1] value: #(#(#testMethod1) 2 #testMethod1))
 ]
 
-{ #category : #rendering }
+{ #category : 'rendering' }
 RBClassDataForRefactoringTest >> textInput: html name: aString symbol: aSymbol [
 	html text: aString.
 	html textInput on: aSymbol of: self contact.
 	html break
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> threeElementPoint [
 	^5 @ 5 + 6 @ 6
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> toDo [
 	1 to: self size do: [:i | (self at: i) printString]
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> toDoCollect [
 	| array |
 	array := Array new: 10.
@@ -586,7 +588,7 @@ RBClassDataForRefactoringTest >> toDoCollect [
 	^array
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> toDoWithIncrement [
 	| counter |
 	counter := 0.
@@ -596,17 +598,17 @@ RBClassDataForRefactoringTest >> toDoWithIncrement [
 	^counter
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> usesAdd [
 	^(1 to: 10) asOrderedCollection addAll: (11 to: 20)
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> variableAssignedLiteral [
 	instanceVariable := #()
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> whileTrue [
 	| i |
 	i := 1.
@@ -615,7 +617,7 @@ RBClassDataForRefactoringTest >> whileTrue [
 			i := i + 1]
 ]
 
-{ #category : #lint }
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> yourselfNotUsed [
 	self
 		printString;

--- a/src/Refactoring-DataForTesting/RBClassToRename.class.st
+++ b/src/Refactoring-DataForTesting/RBClassToRename.class.st
@@ -1,32 +1,34 @@
 Class {
-	#name : #RBClassToRename,
-	#superclass : #Model,
-	#category : #'Refactoring-DataForTesting-MiniHierarchy'
+	#name : 'RBClassToRename',
+	#superclass : 'Model',
+	#category : 'Refactoring-DataForTesting-MiniHierarchy',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'MiniHierarchy'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBClassToRename class >> justForTest [
 	^ 42
 ]
 
-{ #category : #performing }
+{ #category : 'performing' }
 RBClassToRename >> equallyDefinedInSubclass [
 
 	^ self method1 + 33
 ]
 
-{ #category : #performing }
+{ #category : 'performing' }
 RBClassToRename >> justSuperSendInSubclass [
 
 	^ self method1 + 33
 ]
 
-{ #category : #performing }
+{ #category : 'performing' }
 RBClassToRename >> method1 [
 	^self method2
 ]
 
-{ #category : #performing }
+{ #category : 'performing' }
 RBClassToRename >> method2 [
 	^self method1
 ]

--- a/src/Refactoring-DataForTesting/RBClassUsingSharedPoolForTestData.class.st
+++ b/src/Refactoring-DataForTesting/RBClassUsingSharedPoolForTestData.class.st
@@ -1,27 +1,29 @@
 Class {
-	#name : #RBClassUsingSharedPoolForTestData,
-	#superclass : #Object,
+	#name : 'RBClassUsingSharedPoolForTestData',
+	#superclass : 'Object',
 	#traits : 'RBTDummy',
 	#classTraits : 'RBTDummy classTrait',
 	#pools : [
 		'RBSharedPoolForTestData'
 	],
-	#category : #'Refactoring-DataForTesting-ForSharedPool'
+	#category : 'Refactoring-DataForTesting-ForSharedPool',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'ForSharedPool'
 }
 
-{ #category : #'accessing - instances and variables' }
+{ #category : 'accessing - instances and variables' }
 RBClassUsingSharedPoolForTestData >> msg1 [
 
 	var1 asString
 ]
 
-{ #category : #'accessing - instances and variables' }
+{ #category : 'accessing - instances and variables' }
 RBClassUsingSharedPoolForTestData >> msg2 [
 
 	var1
 ]
 
-{ #category : #'accessing - instances and variables' }
+{ #category : 'accessing - instances and variables' }
 RBClassUsingSharedPoolForTestData >> msg3 [
 
 	^ Var1

--- a/src/Refactoring-DataForTesting/RBCompositeLintRuleTestData.class.st
+++ b/src/Refactoring-DataForTesting/RBCompositeLintRuleTestData.class.st
@@ -1,18 +1,20 @@
 Class {
-	#name : #RBCompositeLintRuleTestData,
-	#superclass : #RBLintRuleTestData,
+	#name : 'RBCompositeLintRuleTestData',
+	#superclass : 'RBLintRuleTestData',
 	#instVars : [
 		'rules'
 	],
-	#category : #'Refactoring-DataForTesting-LittleHierarchy'
+	#category : 'Refactoring-DataForTesting-LittleHierarchy',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'LittleHierarchy'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RBCompositeLintRuleTestData class >> allRules [
 	^self ruleFor: self protocol: 'all checks'
 ]
 
-{ #category : #'all checks' }
+{ #category : 'all checks' }
 RBCompositeLintRuleTestData class >> lintChecks [
 	^ self
 		rules: (RBBasicLintRuleTestData protocolsToCheck collect:
@@ -23,7 +25,7 @@ RBCompositeLintRuleTestData class >> lintChecks [
 		name: 'Lint checks'
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RBCompositeLintRuleTestData class >> ruleFor: aClass protocol: aProtocol [
 	^self
 		rules: (((RBBrowserEnvironment new selectorsFor: aProtocol asSymbol in: aClass class)
@@ -33,26 +35,26 @@ RBCompositeLintRuleTestData class >> ruleFor: aClass protocol: aProtocol [
 				yourself)
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RBCompositeLintRuleTestData class >> rules: aCollection [
 	^self new rules: aCollection
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RBCompositeLintRuleTestData class >> rules: aCollection name: aString [
 	^(self new) rules: aCollection;
 		name: aString;
 		yourself
 ]
 
-{ #category : #'all checks' }
+{ #category : 'all checks' }
 RBCompositeLintRuleTestData class >> transformations [
 	^ self
 		ruleFor: RBTransformationRuleTestData
 		protocol: 'transformations'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBCompositeLintRuleTestData >> checkClass: aSmalllintContext [
 	rules do:
 			[:each |
@@ -60,7 +62,7 @@ RBCompositeLintRuleTestData >> checkClass: aSmalllintContext [
 			Processor yield]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBCompositeLintRuleTestData >> checkMethod: aSmalllintContext [
 	rules do:
 			[:each |
@@ -68,47 +70,47 @@ RBCompositeLintRuleTestData >> checkMethod: aSmalllintContext [
 			Processor yield]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBCompositeLintRuleTestData >> failedRules [
 	^rules inject: OrderedCollection new into: [:oc :each | oc addAll: each failedRules; yourself]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBCompositeLintRuleTestData >> hasConflicts [
 	^ rules anySatisfy: [ :each | each hasConflicts ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBCompositeLintRuleTestData >> isComposite [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBCompositeLintRuleTestData >> isEmpty [
 	^ rules allSatisfy: [ :each | each isEmpty ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBCompositeLintRuleTestData >> problemCount [
 	^rules inject: 0 into: [:count :each | count + each problemCount]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBCompositeLintRuleTestData >> resetResult [
 	rules do: [:each | each resetResult]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBCompositeLintRuleTestData >> rules [
 	^rules
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBCompositeLintRuleTestData >> rules: aCollection [
 	rules := aCollection
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBCompositeLintRuleTestData >> viewResults [
 	rules do: [:each | each viewResults]
 ]

--- a/src/Refactoring-DataForTesting/RBDummyCompositeLintRuleTest.class.st
+++ b/src/Refactoring-DataForTesting/RBDummyCompositeLintRuleTest.class.st
@@ -1,18 +1,20 @@
 Class {
-	#name : #RBDummyCompositeLintRuleTest,
-	#superclass : #RBDummyLintRuleTest,
+	#name : 'RBDummyCompositeLintRuleTest',
+	#superclass : 'RBDummyLintRuleTest',
 	#instVars : [
 		'rules'
 	],
-	#category : #'Refactoring-DataForTesting-LittleHierarchy'
+	#category : 'Refactoring-DataForTesting-LittleHierarchy',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'LittleHierarchy'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RBDummyCompositeLintRuleTest class >> allRules [
 	^self ruleFor: self protocol: 'all checks'
 ]
 
-{ #category : #'all checks' }
+{ #category : 'all checks' }
 RBDummyCompositeLintRuleTest class >> lintChecks [
 	^ self
 		rules: (RBBasicLintRuleTestData protocolsToCheck collect:
@@ -23,7 +25,7 @@ RBDummyCompositeLintRuleTest class >> lintChecks [
 		name: 'Lint checks'
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RBDummyCompositeLintRuleTest class >> ruleFor: aClass protocol: aProtocol [
 	^self
 		rules: (((RBBrowserEnvironment new selectorsFor: aProtocol asSymbol in: aClass class)
@@ -33,26 +35,26 @@ RBDummyCompositeLintRuleTest class >> ruleFor: aClass protocol: aProtocol [
 				yourself)
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RBDummyCompositeLintRuleTest class >> rules: aCollection [
 	^self new rules: aCollection
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RBDummyCompositeLintRuleTest class >> rules: aCollection name: aString [
 	^(self new) rules: aCollection;
 		name: aString;
 		yourself
 ]
 
-{ #category : #'all checks' }
+{ #category : 'all checks' }
 RBDummyCompositeLintRuleTest class >> transformations [
 	^ self
 		ruleFor: RBTransformationRuleTestData
 		protocol: 'transformations'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBDummyCompositeLintRuleTest >> checkClass: aSmalllintContext [
 	rules do:
 			[:each |
@@ -60,7 +62,7 @@ RBDummyCompositeLintRuleTest >> checkClass: aSmalllintContext [
 			Processor yield]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBDummyCompositeLintRuleTest >> checkMethod: aSmalllintContext [
 	rules do:
 			[:each |
@@ -68,47 +70,47 @@ RBDummyCompositeLintRuleTest >> checkMethod: aSmalllintContext [
 			Processor yield]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBDummyCompositeLintRuleTest >> failedRules [
 	^rules inject: OrderedCollection new into: [:oc :each | oc addAll: each failedRules; yourself]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBDummyCompositeLintRuleTest >> hasConflicts [
 	^(rules detect: [:each | each hasConflicts] ifNone: [nil]) notNil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBDummyCompositeLintRuleTest >> isComposite [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBDummyCompositeLintRuleTest >> isEmpty [
 	^(rules detect: [:each | each isEmpty not] ifNone: [nil]) isNil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBDummyCompositeLintRuleTest >> problemCount [
 	^rules inject: 0 into: [:count :each | count + each problemCount]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBDummyCompositeLintRuleTest >> resetResult [
 	rules do: [:each | each resetResult]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBDummyCompositeLintRuleTest >> rules [
 	^rules
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBDummyCompositeLintRuleTest >> rules: aCollection [
 	rules := aCollection
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBDummyCompositeLintRuleTest >> viewResults [
 	rules do: [:each | each viewResults]
 ]

--- a/src/Refactoring-DataForTesting/RBDummyEmptyClass.class.st
+++ b/src/Refactoring-DataForTesting/RBDummyEmptyClass.class.st
@@ -2,12 +2,14 @@
 MRDummyEmptyClass is a test class to exercise class transformations
 "
 Class {
-	#name : #RBDummyEmptyClass,
-	#superclass : #Object,
-	#category : #'Refactoring-DataForTesting-MiniHierarchy'
+	#name : 'RBDummyEmptyClass',
+	#superclass : 'Object',
+	#category : 'Refactoring-DataForTesting-MiniHierarchy',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'MiniHierarchy'
 }
 
-{ #category : #'empty protocol 1' }
+{ #category : 'empty protocol 1' }
 RBDummyEmptyClass >> someMethod [
 
 	^ 'a String'

--- a/src/Refactoring-DataForTesting/RBDummyLintRuleTest.class.st
+++ b/src/Refactoring-DataForTesting/RBDummyLintRuleTest.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #RBDummyLintRuleTest,
-	#superclass : #Object,
+	#name : 'RBDummyLintRuleTest',
+	#superclass : 'Object',
 	#instVars : [
 		'name',
 		'foo1'
@@ -11,38 +11,40 @@ Class {
 	#pools : [
 		'TextConstants'
 	],
-	#category : #'Refactoring-DataForTesting-LittleHierarchy'
+	#category : 'Refactoring-DataForTesting-LittleHierarchy',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'LittleHierarchy'
 }
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 RBDummyLintRuleTest class >> parseTreeSearcher [
 	^ self parseTreeSearcherClass new
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 RBDummyLintRuleTest class >> parseTreeSearcherClass [
 	^ RBParseTreeSearcher
 ]
 
-{ #category : #foo }
+{ #category : 'foo' }
 RBDummyLintRuleTest class >> someFooMethod [
 	^ 'does nothing here:)'
 ]
 
-{ #category : #foo }
+{ #category : 'foo' }
 RBDummyLintRuleTest class >> someOtherFooMethod [
 	^ 'does nothing here even better:)'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBDummyLintRuleTest >> checkClass: aSmalllintContext [
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBDummyLintRuleTest >> checkMethod: aSmalllintContext [
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBDummyLintRuleTest >> displayName [
 	| nameStream |
 	nameStream := WriteStream on: (String new: 64).
@@ -53,52 +55,52 @@ RBDummyLintRuleTest >> displayName [
 	^nameStream contents
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBDummyLintRuleTest >> failedRules [
 	^self isEmpty
 		ifTrue: [#()]
 		ifFalse: [Array with: self]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBDummyLintRuleTest >> hasConflicts [
 	^false
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBDummyLintRuleTest >> initialize [
 	<ignoreUnusedVariables: #(#foo1)>
 	name := ''
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBDummyLintRuleTest >> isComposite [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBDummyLintRuleTest >> isEmpty [
 	self subclassResponsibility
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBDummyLintRuleTest >> junk [
 	^ RBClassDataForRefactoringTest printString
 		copyFrom: 1
 		to: CR
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBDummyLintRuleTest >> name [
 	^name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBDummyLintRuleTest >> name: aString [
 	name := aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBDummyLintRuleTest >> openEditor [
 	| rules |
 	rules := self failedRules.
@@ -106,34 +108,34 @@ RBDummyLintRuleTest >> openEditor [
 	rules size == 1 ifTrue: [^rules first viewResults]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 RBDummyLintRuleTest >> printOn: aStream [
 
 	name ifNil: [ super printOn: aStream ] ifNotNil: [ aStream nextPutAll: name ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBDummyLintRuleTest >> problemCount [
 	^self subclassResponsibility
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBDummyLintRuleTest >> resetResult [
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBDummyLintRuleTest >> run [
 	^Object printOn: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBDummyLintRuleTest >> someOtherDemoMethod [
 	| temp |
 	temp := self new.
 	^ temp junk
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBDummyLintRuleTest >> viewResults [
 	self subclassResponsibility
 ]

--- a/src/Refactoring-DataForTesting/RBFooDummyLintRuleTest.class.st
+++ b/src/Refactoring-DataForTesting/RBFooDummyLintRuleTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBFooDummyLintRuleTest,
-	#superclass : #RBDummyLintRuleTest,
-	#category : #'Refactoring-DataForTesting-LittleHierarchy'
+	#name : 'RBFooDummyLintRuleTest',
+	#superclass : 'RBDummyLintRuleTest',
+	#category : 'Refactoring-DataForTesting-LittleHierarchy',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'LittleHierarchy'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBFooDummyLintRuleTest >> foo [
 	^ 6
 ]

--- a/src/Refactoring-DataForTesting/RBFooDummyLintRuleTest1.class.st
+++ b/src/Refactoring-DataForTesting/RBFooDummyLintRuleTest1.class.st
@@ -1,5 +1,7 @@
 Class {
-	#name : #RBFooDummyLintRuleTest1,
-	#superclass : #RBDummyLintRuleTest,
-	#category : #'Refactoring-DataForTesting-LittleHierarchy'
+	#name : 'RBFooDummyLintRuleTest1',
+	#superclass : 'RBDummyLintRuleTest',
+	#category : 'Refactoring-DataForTesting-LittleHierarchy',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'LittleHierarchy'
 }

--- a/src/Refactoring-DataForTesting/RBFooLintRuleTestData.class.st
+++ b/src/Refactoring-DataForTesting/RBFooLintRuleTestData.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBFooLintRuleTestData,
-	#superclass : #RBLintRuleTestData,
-	#category : #'Refactoring-DataForTesting-LittleHierarchy'
+	#name : 'RBFooLintRuleTestData',
+	#superclass : 'RBLintRuleTestData',
+	#category : 'Refactoring-DataForTesting-LittleHierarchy',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'LittleHierarchy'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBFooLintRuleTestData >> foo [
 	^ 6
 ]

--- a/src/Refactoring-DataForTesting/RBFooLintRuleTestData1.class.st
+++ b/src/Refactoring-DataForTesting/RBFooLintRuleTestData1.class.st
@@ -1,5 +1,7 @@
 Class {
-	#name : #RBFooLintRuleTestData1,
-	#superclass : #RBLintRuleTestData,
-	#category : #'Refactoring-DataForTesting-LittleHierarchy'
+	#name : 'RBFooLintRuleTestData1',
+	#superclass : 'RBLintRuleTestData',
+	#category : 'Refactoring-DataForTesting-LittleHierarchy',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'LittleHierarchy'
 }

--- a/src/Refactoring-DataForTesting/RBLintRuleTestData.class.st
+++ b/src/Refactoring-DataForTesting/RBLintRuleTestData.class.st
@@ -3,8 +3,8 @@ This hierarchy is code that is used as test data to test the refactoring engine.
 no sense or have lots of easy possible improvements... but as it is used for testing, they should not be fixed.
 "
 Class {
-	#name : #RBLintRuleTestData,
-	#superclass : #Object,
+	#name : 'RBLintRuleTestData',
+	#superclass : 'Object',
 	#instVars : [
 		'name',
 		'foo1'
@@ -16,50 +16,52 @@ Class {
 	#pools : [
 		'TextConstants'
 	],
-	#category : #'Refactoring-DataForTesting-LittleHierarchy'
+	#category : 'Refactoring-DataForTesting-LittleHierarchy',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'LittleHierarchy'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBLintRuleTestData class >> name1 [
 
 	^ Name1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBLintRuleTestData class >> name1: anObject [
 
 	Name1 := anObject
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 RBLintRuleTestData class >> parseTreeSearcher [
 	^ self parseTreeSearcherClass new
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 RBLintRuleTestData class >> parseTreeSearcherClass [
 	^ RBParseTreeSearcher
 ]
 
-{ #category : #foo }
+{ #category : 'foo' }
 RBLintRuleTestData class >> someFooMethod [
 	^ 'does nothing here:)'
 ]
 
-{ #category : #foo }
+{ #category : 'foo' }
 RBLintRuleTestData class >> someOtherFooMethod [
 	^ 'does nothing here even better:)'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBLintRuleTestData >> checkClass: aSmalllintContext [
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBLintRuleTestData >> checkMethod: aSmalllintContext [
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBLintRuleTestData >> displayName [
 	| nameStream |
 	nameStream := WriteStream on: (String new: 64).
@@ -70,52 +72,52 @@ RBLintRuleTestData >> displayName [
 	^nameStream contents
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBLintRuleTestData >> failedRules [
 	^self isEmpty
 		ifTrue: [#()]
 		ifFalse: [Array with: self]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBLintRuleTestData >> hasConflicts [
 	^false
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBLintRuleTestData >> initialize [
 	<ignoreUnusedVariables: #(#foo1)>
 	name := ''
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBLintRuleTestData >> isComposite [
 	^false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBLintRuleTestData >> isEmpty [
 	self subclassResponsibility
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBLintRuleTestData >> junk [
 	^ RBClassDataForRefactoringTest printString
 		copyFrom: 1
 		to: CR
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBLintRuleTestData >> name [
 	^name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBLintRuleTestData >> name: aString [
 	name := aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBLintRuleTestData >> openEditor [
 	| rules |
 	rules := self failedRules.
@@ -123,39 +125,39 @@ RBLintRuleTestData >> openEditor [
 	rules size == 1 ifTrue: [^rules first viewResults]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 RBLintRuleTestData >> printOn: aStream [
 
 	name ifNil: [ super printOn: aStream ] ifNotNil: [ aStream nextPutAll: name ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBLintRuleTestData >> problemCount [
 	^self subclassResponsibility
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBLintRuleTestData >> resetResult [
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBLintRuleTestData >> run [
 	^Object printOn: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBLintRuleTestData >> runOnEnvironment: anEnvironment [
 	^Object printOn: self onEnvironment: anEnvironment
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBLintRuleTestData >> someOtherDemoMethod [
 	| temp |
 	temp := self new.
 	^ temp junk
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBLintRuleTestData >> viewResults [
 	self subclassResponsibility
 ]

--- a/src/Refactoring-DataForTesting/RBSharedPoolForTestData.class.st
+++ b/src/Refactoring-DataForTesting/RBSharedPoolForTestData.class.st
@@ -1,25 +1,27 @@
 Class {
-	#name : #RBSharedPoolForTestData,
-	#superclass : #SharedPool,
+	#name : 'RBSharedPoolForTestData',
+	#superclass : 'SharedPool',
 	#classVars : [
 		'Var1'
 	],
-	#category : #'Refactoring-DataForTesting-ForSharedPool'
+	#category : 'Refactoring-DataForTesting-ForSharedPool',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'ForSharedPool'
 }
 
-{ #category : #'tests - perform' }
+{ #category : 'tests - perform' }
 RBSharedPoolForTestData >> msg1 [
 
 	^ Var1
 ]
 
-{ #category : #'tests - perform' }
+{ #category : 'tests - perform' }
 RBSharedPoolForTestData >> msg2 [
 
 	^ Var1
 ]
 
-{ #category : #'tests - perform' }
+{ #category : 'tests - perform' }
 RBSharedPoolForTestData >> msg4 [
 
 	^ Var1

--- a/src/Refactoring-DataForTesting/RBSharedPoolForTestData1.class.st
+++ b/src/Refactoring-DataForTesting/RBSharedPoolForTestData1.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBSharedPoolForTestData1,
-	#superclass : #RBSharedPoolForTestData,
-	#category : #'Refactoring-DataForTesting-ForSharedPool'
+	#name : 'RBSharedPoolForTestData1',
+	#superclass : 'RBSharedPoolForTestData',
+	#category : 'Refactoring-DataForTesting-ForSharedPool',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'ForSharedPool'
 }
 
-{ #category : #'tests perform' }
+{ #category : 'tests perform' }
 RBSharedPoolForTestData1 >> msg4 [
 
 	^ Var1

--- a/src/Refactoring-DataForTesting/RBSharedPoolForTestData2.class.st
+++ b/src/Refactoring-DataForTesting/RBSharedPoolForTestData2.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #RBSharedPoolForTestData2,
-	#superclass : #RBSharedPoolForTestData1,
-	#category : #'Refactoring-DataForTesting-ForSharedPool'
+	#name : 'RBSharedPoolForTestData2',
+	#superclass : 'RBSharedPoolForTestData1',
+	#category : 'Refactoring-DataForTesting-ForSharedPool',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'ForSharedPool'
 }
 
-{ #category : #'tests - perform' }
+{ #category : 'tests - perform' }
 RBSharedPoolForTestData2 >> msg4 [
 
 	^ Var1
 ]
 
-{ #category : #'tests - perform' }
+{ #category : 'tests - perform' }
 RBSharedPoolForTestData2 >> reference [
 	^ RBRemoveClassRefactoringTest
 ]

--- a/src/Refactoring-DataForTesting/RBSubclassOfClassToRename.class.st
+++ b/src/Refactoring-DataForTesting/RBSubclassOfClassToRename.class.st
@@ -1,52 +1,54 @@
 Class {
-	#name : #RBSubclassOfClassToRename,
-	#superclass : #RBClassToRename,
+	#name : 'RBSubclassOfClassToRename',
+	#superclass : 'RBClassToRename',
 	#instVars : [
 		'rewriteRule1'
 	],
-	#category : #'Refactoring-DataForTesting-MiniHierarchy'
+	#category : 'Refactoring-DataForTesting-MiniHierarchy',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'MiniHierarchy'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBSubclassOfClassToRename >> calls [
 	^self rewriteRule1: self name , self rewriteRule1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBSubclassOfClassToRename >> calls1 [
 	^self rewriteRule1: (self rewriteRule1: self calls)
 ]
 
-{ #category : #performing }
+{ #category : 'performing' }
 RBSubclassOfClassToRename >> equallyDefinedInSubclass [
 
 	^ self method1 + 33
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBSubclassOfClassToRename >> justSuperSendInSubclass [
 
 	^ super justSuperSendInSubclass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBSubclassOfClassToRename >> justSuperSendInSubclassBroken [
 
 	^ super justSuperSendInSubclass + 2
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBSubclassOfClassToRename >> methodThatIsNotUsedForSure [
 
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBSubclassOfClassToRename >> name [
 	^rewriteRule1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBSubclassOfClassToRename >> printOn: aStream [
 
 	"just for the test"
@@ -54,22 +56,22 @@ RBSubclassOfClassToRename >> printOn: aStream [
 	aStream nextPutAll: 'tintin'
 ]
 
-{ #category : #performing }
+{ #category : 'performing' }
 RBSubclassOfClassToRename >> reference [
 	^ RBClassToRename new
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBSubclassOfClassToRename >> rewriteRule1 [
 	^rewriteRule1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBSubclassOfClassToRename >> rewriteRule1: anObject [
 	^rewriteRule1 := anObject
 ]
 
-{ #category : #performing }
+{ #category : 'performing' }
 RBSubclassOfClassToRename >> symbolReference [
 	^ #RBClassToRename
 ]

--- a/src/Refactoring-DataForTesting/RBTDummy.trait.st
+++ b/src/Refactoring-DataForTesting/RBTDummy.trait.st
@@ -1,17 +1,19 @@
 Trait {
-	#name : #RBTDummy,
+	#name : 'RBTDummy',
 	#instVars : [
 		'var1'
 	],
-	#category : #'Refactoring-DataForTesting-Utils'
+	#category : 'Refactoring-DataForTesting-Utils',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'Utils'
 }
 
-{ #category : #'tests - some' }
+{ #category : 'tests - some' }
 RBTDummy >> methodFromTrait [
 	RBClassToRename justForTest
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBTDummy >> var1 [
 	^ var1
 ]

--- a/src/Refactoring-DataForTesting/RBTestAsDataForExtractSetupTransformationTest.class.st
+++ b/src/Refactoring-DataForTesting/RBTestAsDataForExtractSetupTransformationTest.class.st
@@ -1,30 +1,32 @@
 Class {
-	#name : #RBTestAsDataForExtractSetupTransformationTest,
-	#superclass : #TestCase,
+	#name : 'RBTestAsDataForExtractSetupTransformationTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'aString'
 	],
-	#category : #'Refactoring-DataForTesting-ForTestRelatedOperation'
+	#category : 'Refactoring-DataForTesting-ForTestRelatedOperation',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'ForTestRelatedOperation'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 RBTestAsDataForExtractSetupTransformationTest >> accessToAClass [
 	RBClassDataForRefactoringTest new
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTestAsDataForExtractSetupTransformationTest >> someMethod [
 	#'some.initializations'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBTestAsDataForExtractSetupTransformationTest >> testExtractSetupExample1 [
 	self accessToAClass.
 	aString := 'Example'.
 	self assert: 4 > 5 equals: false
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBTestAsDataForExtractSetupTransformationTest >> testExtractSetupExample2 [
 	"Example"
 	self accessToAClass.
@@ -32,7 +34,7 @@ RBTestAsDataForExtractSetupTransformationTest >> testExtractSetupExample2 [
 	self assert: true
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBTestAsDataForExtractSetupTransformationTest >> testExtractSetupExample3 [
 	"Example"
 	self accessToAClass.
@@ -41,19 +43,19 @@ RBTestAsDataForExtractSetupTransformationTest >> testExtractSetupExample3 [
 	self deny: false
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBTestAsDataForExtractSetupTransformationTest >> testExtractSetupExample4 [
 	self assert: true.
 	self deny: false
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTestAsDataForExtractSetupTransformationTest >> testExtractSetupExample5 [
 	self someMethod.
 	self assert: true
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTestAsDataForExtractSetupTransformationTest >> testExtractSetupExample6 [
 	| aString2 aNumber |
 	aString2 := 'Some string'.
@@ -64,7 +66,7 @@ RBTestAsDataForExtractSetupTransformationTest >> testExtractSetupExample6 [
 	self assert: true
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTestAsDataForExtractSetupTransformationTest >> testExtractSetupExample7 [
 	| aString2 aNumber |
 	aString2 := 'sa'.
@@ -73,7 +75,7 @@ RBTestAsDataForExtractSetupTransformationTest >> testExtractSetupExample7 [
 	self assert: aString2 isNotEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTestAsDataForExtractSetupTransformationTest >> testExtractSetupExample8 [
 	| aString2 aNumber |
 	aString2 := 'Some string'.

--- a/src/Refactoring-DataForTesting/RBTransformationDummyRuleTest.class.st
+++ b/src/Refactoring-DataForTesting/RBTransformationDummyRuleTest.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #RBTransformationDummyRuleTest,
-	#superclass : #RBFooDummyLintRuleTest,
+	#name : 'RBTransformationDummyRuleTest',
+	#superclass : 'RBFooDummyLintRuleTest',
 	#instVars : [
 		'rewriteRule',
 		'builder',
@@ -9,10 +9,12 @@ Class {
 	#classVars : [
 		'RecursiveSelfRule'
 	],
-	#category : #'Refactoring-DataForTesting-LittleHierarchy'
+	#category : 'Refactoring-DataForTesting-LittleHierarchy',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'LittleHierarchy'
 }
 
-{ #category : #transformations }
+{ #category : 'transformations' }
 RBTransformationDummyRuleTest class >> assignmentInIfTrue [
 	^self rewrite: #(
 			#('``@Boolean ifTrue: [`variable := ``@true] ifFalse: [`variable := ``@false]'
@@ -25,7 +27,7 @@ RBTransformationDummyRuleTest class >> assignmentInIfTrue [
 		name: 'Move variable assignment outside of single statement ifTrue:ifFalse: blocks'
 ]
 
-{ #category : #transformations }
+{ #category : 'transformations' }
 RBTransformationDummyRuleTest class >> atIfAbsent [
 	^self rewrite: #(
 			#('``@dictionary at: ``@key
@@ -53,7 +55,7 @@ RBTransformationDummyRuleTest class >> atIfAbsent [
 		name: 'at:ifAbsent: -> at:ifAbsentPut:'
 ]
 
-{ #category : #transformations }
+{ #category : 'transformations' }
 RBTransformationDummyRuleTest class >> betweenAnd [
 	^self rewrite: #(
 			#('``@a >= ``@b and: [``@a <= ``@c]' "->" '``@a between: ``@b and: ``@c')
@@ -76,12 +78,12 @@ RBTransformationDummyRuleTest class >> betweenAnd [
 		name: '"a >= b and: [a <= c]" -> "a between: b and: c"'
 ]
 
-{ #category : #cleanup }
+{ #category : 'cleanup' }
 RBTransformationDummyRuleTest class >> cleanUp [
 	self nuke
 ]
 
-{ #category : #transformations }
+{ #category : 'transformations' }
 RBTransformationDummyRuleTest class >> detectIfNone [
 	^self rewrite: #(
 			#('(``@collection detect: [:`each | | `@temps | ``@.Statements] ifNone: [nil]) isNil'
@@ -100,7 +102,7 @@ RBTransformationDummyRuleTest class >> detectIfNone [
 		name: 'detect:ifNone: -> contains:'
 ]
 
-{ #category : #transformations }
+{ #category : 'transformations' }
 RBTransformationDummyRuleTest class >> equalNil [
 	^self
 		rewrite: #(
@@ -112,7 +114,7 @@ RBTransformationDummyRuleTest class >> equalNil [
 		name: '= nil -> isNil AND ~= nil -> notNil'
 ]
 
-{ #category : #transformations }
+{ #category : 'transformations' }
 RBTransformationDummyRuleTest class >> guardClause [
 	^self
 		rewrite: #(
@@ -144,7 +146,7 @@ RBTransformationDummyRuleTest class >> guardClause [
 		name: 'Eliminate guarding clauses'
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 RBTransformationDummyRuleTest class >> initializeAfterLoad1 [
 	RecursiveSelfRule := self parseTreeSearcher.
 	RecursiveSelfRule
@@ -152,7 +154,7 @@ RBTransformationDummyRuleTest class >> initializeAfterLoad1 [
 				-> [:aNode :answer | true]
 ]
 
-{ #category : #transformations }
+{ #category : 'transformations' }
 RBTransformationDummyRuleTest class >> minMax [
 	^self rewrite: #(
 			#('``@a < ``@b ifTrue: [``@a] ifFalse: [``@b]'	"->"	'``@a min: ``@b')
@@ -183,7 +185,7 @@ RBTransformationDummyRuleTest class >> minMax [
 		name: 'Rewrite ifTrue:ifFalse: using min:/max:'
 ]
 
-{ #category : #transformations }
+{ #category : 'transformations' }
 RBTransformationDummyRuleTest class >> notElimination [
 	^self
 		rewrite: #(
@@ -214,12 +216,12 @@ RBTransformationDummyRuleTest class >> notElimination [
 		name: 'Eliminate unnecessary not''s'
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 RBTransformationDummyRuleTest class >> nuke [
 	RecursiveSelfRule := nil
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RBTransformationDummyRuleTest class >> rewrite: stringArrays methods: aBoolean name: aName [
 	| rewriteRule |
 	rewriteRule := RBParseTreeRewriter new.
@@ -233,7 +235,7 @@ RBTransformationDummyRuleTest class >> rewrite: stringArrays methods: aBoolean n
 		yourself
 ]
 
-{ #category : #transformations }
+{ #category : 'transformations' }
 RBTransformationDummyRuleTest class >> showWhileBlocks [
 	^self
 		rewrite: #(
@@ -245,7 +247,7 @@ RBTransformationDummyRuleTest class >> showWhileBlocks [
 		name: 'Move assignment out of showWhile: blocks'
 ]
 
-{ #category : #transformations }
+{ #category : 'transformations' }
 RBTransformationDummyRuleTest class >> superSends [
 	^(self new)
 		name: 'Rewrite super messages to self messages when both refer to same method';
@@ -253,7 +255,7 @@ RBTransformationDummyRuleTest class >> superSends [
 		yourself
 ]
 
-{ #category : #transformations }
+{ #category : 'transformations' }
 RBTransformationDummyRuleTest class >> unwindBlocks [
 	^self
 		rewrite: #(
@@ -269,7 +271,7 @@ RBTransformationDummyRuleTest class >> unwindBlocks [
 		name: 'Move assignment out of unwind blocks'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBTransformationDummyRuleTest >> checkMethod: aSmalllintContext [
 	class := aSmalllintContext selectedClass.
 	(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue:
@@ -280,38 +282,44 @@ RBTransformationDummyRuleTest >> checkMethod: aSmalllintContext [
 						classified: aSmalllintContext protocols]]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBTransformationDummyRuleTest >> hasConflicts [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBTransformationDummyRuleTest >> isEmpty [
 	^builder changes isEmpty
 ]
 
-{ #category : #rules }
+{ #category : 'accessing' }
+RBTransformationDummyRuleTest >> justAUnreferencedMethodForTesting [
+
+	^ 42
+]
+
+{ #category : 'rules' }
 RBTransformationDummyRuleTest >> parseTreeRewriter [
 	^ RBParseTreeRewriter new
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBTransformationDummyRuleTest >> problemCount [
 	^builder problemCount
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBTransformationDummyRuleTest >> resetResult [
 	builder := RBRefactoryChangeManager changeFactory compositeRefactoryChange
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBTransformationDummyRuleTest >> rewriteUsing: searchReplacer [
 	rewriteRule := searchReplacer.
 	self resetResult
 ]
 
-{ #category : #rules }
+{ #category : 'rules' }
 RBTransformationDummyRuleTest >> superSends [
 	| rule |
 	rule := self parseTreeRewriter.
@@ -326,7 +334,7 @@ RBTransformationDummyRuleTest >> superSends [
 	self rewriteUsing: rule
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBTransformationDummyRuleTest >> viewResults [
 	"I reset the result so that we don't fill up memory with methods to compile in the builder."
 

--- a/src/Refactoring-DataForTesting/RBTransformationDummyRuleTest1.class.st
+++ b/src/Refactoring-DataForTesting/RBTransformationDummyRuleTest1.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBTransformationDummyRuleTest1,
-	#superclass : #RBFooDummyLintRuleTest1,
-	#category : #'Refactoring-DataForTesting-LittleHierarchy'
+	#name : 'RBTransformationDummyRuleTest1',
+	#superclass : 'RBFooDummyLintRuleTest1',
+	#category : 'Refactoring-DataForTesting-LittleHierarchy',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'LittleHierarchy'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBTransformationDummyRuleTest1 >> openEditor [
 	| rules |
 	rules := self failedRules.

--- a/src/Refactoring-DataForTesting/RBTransformationRuleTestData.class.st
+++ b/src/Refactoring-DataForTesting/RBTransformationRuleTestData.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #RBTransformationRuleTestData,
-	#superclass : #RBFooLintRuleTestData,
+	#name : 'RBTransformationRuleTestData',
+	#superclass : 'RBFooLintRuleTestData',
 	#instVars : [
 		'rewriteRule',
 		'builder',
@@ -9,10 +9,12 @@ Class {
 	#classVars : [
 		'RecursiveSelfRule'
 	],
-	#category : #'Refactoring-DataForTesting-LittleHierarchy'
+	#category : 'Refactoring-DataForTesting-LittleHierarchy',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'LittleHierarchy'
 }
 
-{ #category : #transformations }
+{ #category : 'transformations' }
 RBTransformationRuleTestData class >> assignmentInIfTrue [
 	^self rewrite: #(
 			#('``@Boolean ifTrue: [`variable := ``@true] ifFalse: [`variable := ``@false]'
@@ -25,7 +27,7 @@ RBTransformationRuleTestData class >> assignmentInIfTrue [
 		name: 'Move variable assignment outside of single statement ifTrue:ifFalse: blocks'
 ]
 
-{ #category : #transformations }
+{ #category : 'transformations' }
 RBTransformationRuleTestData class >> atIfAbsent [
 	^self rewrite: #(
 			#('``@dictionary at: ``@key
@@ -53,7 +55,7 @@ RBTransformationRuleTestData class >> atIfAbsent [
 		name: 'at:ifAbsent: -> at:ifAbsentPut:'
 ]
 
-{ #category : #transformations }
+{ #category : 'transformations' }
 RBTransformationRuleTestData class >> betweenAnd [
 	^self rewrite: #(
 			#('``@a >= ``@b and: [``@a <= ``@c]' "->" '``@a between: ``@b and: ``@c')
@@ -76,12 +78,12 @@ RBTransformationRuleTestData class >> betweenAnd [
 		name: '"a >= b and: [a <= c]" -> "a between: b and: c"'
 ]
 
-{ #category : #cleanup }
+{ #category : 'cleanup' }
 RBTransformationRuleTestData class >> cleanUp [
 	self nuke
 ]
 
-{ #category : #transformations }
+{ #category : 'transformations' }
 RBTransformationRuleTestData class >> detectIfNone [
 	^self rewrite: #(
 			#('(``@collection detect: [:`each | | `@temps | ``@.Statements] ifNone: [nil]) isNil'
@@ -100,7 +102,7 @@ RBTransformationRuleTestData class >> detectIfNone [
 		name: 'detect:ifNone: -> contains:'
 ]
 
-{ #category : #transformations }
+{ #category : 'transformations' }
 RBTransformationRuleTestData class >> equalNil [
 	^self
 		rewrite: #(
@@ -112,7 +114,7 @@ RBTransformationRuleTestData class >> equalNil [
 		name: '= nil -> isNil AND ~= nil -> notNil'
 ]
 
-{ #category : #transformations }
+{ #category : 'transformations' }
 RBTransformationRuleTestData class >> guardClause [
 	^self
 		rewrite: #(
@@ -144,7 +146,7 @@ RBTransformationRuleTestData class >> guardClause [
 		name: 'Eliminate guarding clauses'
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 RBTransformationRuleTestData class >> initializeAfterLoad1 [
 	RecursiveSelfRule := self parseTreeSearcher.
 	RecursiveSelfRule
@@ -152,7 +154,7 @@ RBTransformationRuleTestData class >> initializeAfterLoad1 [
 				-> [:aNode :answer | true]
 ]
 
-{ #category : #transformations }
+{ #category : 'transformations' }
 RBTransformationRuleTestData class >> minMax [
 	^self rewrite: #(
 			#('``@a < ``@b ifTrue: [``@a] ifFalse: [``@b]'	"->"	'``@a min: ``@b')
@@ -183,7 +185,7 @@ RBTransformationRuleTestData class >> minMax [
 		name: 'Rewrite ifTrue:ifFalse: using min:/max:'
 ]
 
-{ #category : #transformations }
+{ #category : 'transformations' }
 RBTransformationRuleTestData class >> notElimination [
 	^self
 		rewrite: #(
@@ -214,12 +216,12 @@ RBTransformationRuleTestData class >> notElimination [
 		name: 'Eliminate unnecessary not''s'
 ]
 
-{ #category : #'class initialization' }
+{ #category : 'class initialization' }
 RBTransformationRuleTestData class >> nuke [
 	RecursiveSelfRule := nil
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RBTransformationRuleTestData class >> rewrite: stringArrays methods: aBoolean name: aName [
 	| rewriteRule |
 	rewriteRule := RBParseTreeRewriter new.
@@ -233,7 +235,7 @@ RBTransformationRuleTestData class >> rewrite: stringArrays methods: aBoolean na
 		yourself
 ]
 
-{ #category : #transformations }
+{ #category : 'transformations' }
 RBTransformationRuleTestData class >> showWhileBlocks [
 	^self
 		rewrite: #(
@@ -245,7 +247,7 @@ RBTransformationRuleTestData class >> showWhileBlocks [
 		name: 'Move assignment out of showWhile: blocks'
 ]
 
-{ #category : #transformations }
+{ #category : 'transformations' }
 RBTransformationRuleTestData class >> superSends [
 	^(self new)
 		name: 'Rewrite super messages to self messages when both refer to same method';
@@ -253,7 +255,7 @@ RBTransformationRuleTestData class >> superSends [
 		yourself
 ]
 
-{ #category : #transformations }
+{ #category : 'transformations' }
 RBTransformationRuleTestData class >> unwindBlocks [
 	^self
 		rewrite: #(
@@ -269,7 +271,7 @@ RBTransformationRuleTestData class >> unwindBlocks [
 		name: 'Move assignment out of unwind blocks'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBTransformationRuleTestData >> checkMethod: aSmalllintContext [
 	class := aSmalllintContext selectedClass.
 	(rewriteRule executeTree: aSmalllintContext parseTree) ifTrue:
@@ -280,44 +282,44 @@ RBTransformationRuleTestData >> checkMethod: aSmalllintContext [
 						classified: aSmalllintContext protocols]]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBTransformationRuleTestData >> class: anObject [
 
 	class := anObject
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBTransformationRuleTestData >> hasConflicts [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBTransformationRuleTestData >> isEmpty [
 	^builder changes isEmpty
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBTransformationRuleTestData >> problemCount [
 	^builder problemCount
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBTransformationRuleTestData >> resetResult [
 	builder := RBRefactoryChangeManager changeFactory compositeRefactoryChange
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBTransformationRuleTestData >> rewriteRuleAsString [
 	^ rewriteRule tree printString
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBTransformationRuleTestData >> rewriteUsing: searchReplacer [
 	rewriteRule := searchReplacer.
 	self resetResult
 ]
 
-{ #category : #rules }
+{ #category : 'rules' }
 RBTransformationRuleTestData >> superSends [
 	| rule |
 	rule := RBParseTreeRewriter new.
@@ -331,7 +333,7 @@ RBTransformationRuleTestData >> superSends [
 	self rewriteUsing: rule
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 RBTransformationRuleTestData >> viewResults [
 	"I reset the result so that we don't fill up memory with methods to compile in the builder."
 

--- a/src/Refactoring-DataForTesting/RBTransformationRuleTestData1.class.st
+++ b/src/Refactoring-DataForTesting/RBTransformationRuleTestData1.class.st
@@ -1,21 +1,23 @@
 Class {
-	#name : #RBTransformationRuleTestData1,
-	#superclass : #RBFooLintRuleTestData1,
+	#name : 'RBTransformationRuleTestData1',
+	#superclass : 'RBFooLintRuleTestData1',
 	#instVars : [
 		'foo'
 	],
 	#classVars : [
 		'A'
 	],
-	#category : #'Refactoring-DataForTesting-LittleHierarchy'
+	#category : 'Refactoring-DataForTesting-LittleHierarchy',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'LittleHierarchy'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 RBTransformationRuleTestData1 >> classVarA [
 	^A
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBTransformationRuleTestData1 >> foo [
 	^ foo
 ]

--- a/src/Refactoring-DataForTesting/RBTransformationRuleTestData2.class.st
+++ b/src/Refactoring-DataForTesting/RBTransformationRuleTestData2.class.st
@@ -1,5 +1,7 @@
 Class {
-	#name : #RBTransformationRuleTestData2,
-	#superclass : #RBTransformationRuleTestData1,
-	#category : #'Refactoring-DataForTesting-LittleHierarchy'
+	#name : 'RBTransformationRuleTestData2',
+	#superclass : 'RBTransformationRuleTestData1',
+	#category : 'Refactoring-DataForTesting-LittleHierarchy',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'LittleHierarchy'
 }

--- a/src/Refactoring-DataForTesting/RBUnusedRootClass.class.st
+++ b/src/Refactoring-DataForTesting/RBUnusedRootClass.class.st
@@ -1,5 +1,7 @@
 Class {
-	#name : #RBUnusedRootClass,
-	#superclass : #Model,
-	#category : #'Refactoring-DataForTesting-MiniHierarchy'
+	#name : 'RBUnusedRootClass',
+	#superclass : 'Model',
+	#category : 'Refactoring-DataForTesting-MiniHierarchy',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'MiniHierarchy'
 }

--- a/src/Refactoring-DataForTesting/package.st
+++ b/src/Refactoring-DataForTesting/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Refactoring-DataForTesting' }
+Package { #name : 'Refactoring-DataForTesting' }

--- a/src/Refactoring-UI/RBBreakingChangeReport.class.st
+++ b/src/Refactoring-UI/RBBreakingChangeReport.class.st
@@ -1,25 +1,27 @@
 Class {
-	#name : #RBBreakingChangeReport,
-	#superclass : #Object,
+	#name : 'RBBreakingChangeReport',
+	#superclass : 'Object',
 	#instVars : [
 		'environment',
 		'refactoring'
 	],
-	#category : #'Refactoring-UI-Drivers'
+	#category : 'Refactoring-UI-Drivers',
+	#package : 'Refactoring-UI',
+	#tag : 'Drivers'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBBreakingChangeReport >> environment [
 
 	^ environment
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBBreakingChangeReport >> refactoring [
 	^ refactoring
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBBreakingChangeReport >> refactoring: aRefactoring [
 
 	refactoring := aRefactoring.

--- a/src/Refactoring-UI/RBChoice.class.st
+++ b/src/Refactoring-UI/RBChoice.class.st
@@ -1,32 +1,34 @@
 Class {
-	#name : #RBChoice,
-	#superclass : #Object,
+	#name : 'RBChoice',
+	#superclass : 'Object',
 	#instVars : [
 		'refactoring',
 		'driver'
 	],
-	#category : #'Refactoring-UI-Choices'
+	#category : 'Refactoring-UI-Choices',
+	#package : 'Refactoring-UI',
+	#tag : 'Choices'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBChoice >> driver [
 
 	^ driver
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBChoice >> driver: aDriver [
 
 	driver := aDriver
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBChoice >> refactoring [
 
 	^ refactoring
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBChoice >> refactoring: anObject [
 
 	refactoring := anObject

--- a/src/Refactoring-UI/RBDeprecateMethodDriver.class.st
+++ b/src/Refactoring-UI/RBDeprecateMethodDriver.class.st
@@ -11,23 +11,25 @@ You can create my instance and execute the refactoring by running:
 ```
 "
 Class {
-	#name : #RBDeprecateMethodDriver,
-	#superclass : #RBDriver,
+	#name : 'RBDeprecateMethodDriver',
+	#superclass : 'RBDriver',
 	#instVars : [
 		'refactoring',
 		'useInsteadSelector',
 		'selectorToDeprecate'
 	],
-	#category : #'Refactoring-UI-Drivers'
+	#category : 'Refactoring-UI-Drivers',
+	#package : 'Refactoring-UI',
+	#tag : 'Drivers'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RBDeprecateMethodDriver class >> deprecateMethod: aString in: aClass scopes: aCollection [
 
 	^ self new deprecateMethod: aString in: aClass  scopes: aCollection
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBDeprecateMethodDriver >> deprecateMethod: aSelector in: aClass scopes: aCollection [
 
 	scopes := aCollection.
@@ -41,12 +43,12 @@ RBDeprecateMethodDriver >> deprecateMethod: aSelector in: aClass scopes: aCollec
 	self selectorToReplaceDeprecatedSelector.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBDeprecateMethodDriver >> refactoring [
 	^ refactoring
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 RBDeprecateMethodDriver >> runRefactoring [
 
 	| compositeChange |
@@ -73,7 +75,7 @@ RBDeprecateMethodDriver >> runRefactoring [
 	self openPreviewWithChanges: compositeChange
 ]
 
-{ #category : #'ui - requests' }
+{ #category : 'ui - requests' }
 RBDeprecateMethodDriver >> selectorToReplaceDeprecatedSelector [
 
 	useInsteadSelector := SpRequestDialog new

--- a/src/Refactoring-UI/RBDontRemoveButShowSendersChoice.class.st
+++ b/src/Refactoring-UI/RBDontRemoveButShowSendersChoice.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #RBDontRemoveButShowSendersChoice,
-	#superclass : #RBRemoveMethodChoice,
-	#category : #'Refactoring-UI-Choices'
+	#name : 'RBDontRemoveButShowSendersChoice',
+	#superclass : 'RBRemoveMethodChoice',
+	#category : 'Refactoring-UI-Choices',
+	#package : 'Refactoring-UI',
+	#tag : 'Choices'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBDontRemoveButShowSendersChoice >> action [
 
 	driver browseSenders
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBDontRemoveButShowSendersChoice >> description [
 
 	^ 'Don''t remove, but show me those senders'

--- a/src/Refactoring-UI/RBDriver.class.st
+++ b/src/Refactoring-UI/RBDriver.class.st
@@ -10,28 +10,30 @@ I am a driver object responsible for invoking refactorings. I am responsible for
 
 "
 Class {
-	#name : #RBDriver,
-	#superclass : #Object,
+	#name : 'RBDriver',
+	#superclass : 'Object',
 	#instVars : [
 		'model',
 		'scopes'
 	],
-	#category : #'Refactoring-UI-Drivers'
+	#category : 'Refactoring-UI-Drivers',
+	#package : 'Refactoring-UI',
+	#tag : 'Drivers'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBDriver class >> isAbstract [
 
 	^ self == RBDriver
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 RBDriver >> furtherActionFor: aReport [
 	
 	aReport browse
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 RBDriver >> openPreviewWithChanges: changes [
 	
 	^ (StRefactoringPreviewPresenter
@@ -41,13 +43,13 @@ RBDriver >> openPreviewWithChanges: changes [
 		openModal
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RBDriver >> refactoringScopeOn: aScope [
 
 	^ RBClassModelFactory rbNamespace onEnvironment: aScope asRBEnvironment
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 RBDriver >> runRefactoring [
 
 	self subclassResponsibility

--- a/src/Refactoring-UI/RBInstanceVariableStillReferenced.class.st
+++ b/src/Refactoring-UI/RBInstanceVariableStillReferenced.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBInstanceVariableStillReferenced,
-	#superclass : #RBBreakingChangeReport,
-	#category : #'Refactoring-UI-Drivers'
+	#name : 'RBInstanceVariableStillReferenced',
+	#superclass : 'RBBreakingChangeReport',
+	#category : 'Refactoring-UI-Drivers',
+	#package : 'Refactoring-UI',
+	#tag : 'Drivers'
 }
 
-{ #category : #execution }
+{ #category : 'execution' }
 RBInstanceVariableStillReferenced >> browse [
 	"This is not satisfactory because not connected to any UI element."
 	SystemNavigation default 
@@ -12,7 +14,7 @@ RBInstanceVariableStillReferenced >> browse [
 		from: self refactoring refactoredClass realClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBInstanceVariableStillReferenced >> refactoring: aRefactoring [
 
 	refactoring := aRefactoring.

--- a/src/Refactoring-UI/RBMethodStillCalled.class.st
+++ b/src/Refactoring-UI/RBMethodStillCalled.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBMethodStillCalled,
-	#superclass : #RBBreakingChangeReport,
-	#category : #'Refactoring-UI-Drivers'
+	#name : 'RBMethodStillCalled',
+	#superclass : 'RBBreakingChangeReport',
+	#category : 'Refactoring-UI-Drivers',
+	#package : 'Refactoring-UI',
+	#tag : 'Drivers'
 }
 
-{ #category : #private }
+{ #category : 'private' }
 RBMethodStillCalled >> browse [
 	"This is not satisfactory because not connected to any UI element."
 

--- a/src/Refactoring-UI/RBMoveMethodsToClassSideDriver.class.st
+++ b/src/Refactoring-UI/RBMoveMethodsToClassSideDriver.class.st
@@ -13,26 +13,28 @@ You can create my instance and execute the refactoring by running:
 ```
 "
 Class {
-	#name : #RBMoveMethodsToClassSideDriver,
-	#superclass : #RBDriver,
+	#name : 'RBMoveMethodsToClassSideDriver',
+	#superclass : 'RBDriver',
 	#instVars : [
 		'refactoring'
 	],
-	#category : #'Refactoring-UI-Drivers'
+	#category : 'Refactoring-UI-Drivers',
+	#package : 'Refactoring-UI',
+	#tag : 'Drivers'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 RBMoveMethodsToClassSideDriver class >> scopes: scopesList methods: aCollectionOfMethods [
 
 	^ self new scopes: scopesList methods: aCollectionOfMethods
 ]
 
-{ #category : #resources }
+{ #category : 'resources' }
 RBMoveMethodsToClassSideDriver >> refactoring [
 	^ refactoring.
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 RBMoveMethodsToClassSideDriver >> runRefactoring [
 
 	[
@@ -57,7 +59,7 @@ RBMoveMethodsToClassSideDriver >> runRefactoring [
 				err return ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBMoveMethodsToClassSideDriver >> scopes: scopesList methods: methods [
 
 	scopes := scopesList.

--- a/src/Refactoring-UI/RBOverrideMethod.class.st
+++ b/src/Refactoring-UI/RBOverrideMethod.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBOverrideMethod,
-	#superclass : #RBBreakingChangeReport,
-	#category : #'Refactoring-UI-Drivers'
+	#name : 'RBOverrideMethod',
+	#superclass : 'RBBreakingChangeReport',
+	#category : 'Refactoring-UI-Drivers',
+	#package : 'Refactoring-UI',
+	#tag : 'Drivers'
 }
 
-{ #category : #execution }
+{ #category : 'execution' }
 RBOverrideMethod >> browse [
 	"This is not satisfactory because not connected to any UI element."
 	SpConfirmDialog new 
@@ -18,7 +20,7 @@ RBOverrideMethod >> browse [
 		openDialog
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBOverrideMethod >> refactoring: aRefactoring [
 
 	refactoring := aRefactoring

--- a/src/Refactoring-UI/RBPushDownMethodDriver.class.st
+++ b/src/Refactoring-UI/RBPushDownMethodDriver.class.st
@@ -12,23 +12,25 @@ You can create my instance and execute the refactoring by running:
 ```
 "
 Class {
-	#name : #RBPushDownMethodDriver,
-	#superclass : #RBDriver,
+	#name : 'RBPushDownMethodDriver',
+	#superclass : 'RBDriver',
 	#instVars : [
 		'methods',
 		'class',
 		'refactoring'
 	],
-	#category : #'Refactoring-UI-Drivers'
+	#category : 'Refactoring-UI-Drivers',
+	#package : 'Refactoring-UI',
+	#tag : 'Drivers'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBPushDownMethodDriver class >> model: aRBNamespace scopes: refactoringScopes pushDown: methods [
 
 	^ self new model: aRBNamespace scopes: refactoringScopes pushDown: methods
 ]
 
-{ #category : #resources }
+{ #category : 'resources' }
 RBPushDownMethodDriver >> configureRefactoring [
 
 	refactoring :=  RBPushDownMethodRefactoring
@@ -37,7 +39,7 @@ RBPushDownMethodDriver >> configureRefactoring [
 		  from: class
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBPushDownMethodDriver >> model: aRBNamespace scopes: refactoringScopes pushDown: methodsList [
 
 	model := aRBNamespace.
@@ -46,7 +48,7 @@ RBPushDownMethodDriver >> model: aRBNamespace scopes: refactoringScopes pushDown
 	class := methods first origin
 ]
 
-{ #category : #resources }
+{ #category : 'resources' }
 RBPushDownMethodDriver >> refactoring [
 
 	refactoring :=  RBPushDownMethodRefactoring
@@ -55,7 +57,7 @@ RBPushDownMethodDriver >> refactoring [
 		  from: class
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 RBPushDownMethodDriver >> runRefactoring [
 
 	| changes |
@@ -76,7 +78,7 @@ RBPushDownMethodDriver >> runRefactoring [
 	self openPreviewWithChanges: changes
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 RBPushDownMethodDriver >> selectMethods [
 
 	| dialog |

--- a/src/Refactoring-UI/RBPushDownMethodInSomeClassesDriver.class.st
+++ b/src/Refactoring-UI/RBPushDownMethodInSomeClassesDriver.class.st
@@ -12,15 +12,17 @@ You can create my instance and execute the refactoring by running:
 ```
 "
 Class {
-	#name : #RBPushDownMethodInSomeClassesDriver,
-	#superclass : #RBPushDownMethodDriver,
+	#name : 'RBPushDownMethodInSomeClassesDriver',
+	#superclass : 'RBPushDownMethodDriver',
 	#instVars : [
 		'classes'
 	],
-	#category : #'Refactoring-UI-Drivers'
+	#category : 'Refactoring-UI-Drivers',
+	#package : 'Refactoring-UI',
+	#tag : 'Drivers'
 }
 
-{ #category : #resources }
+{ #category : 'resources' }
 RBPushDownMethodInSomeClassesDriver >> configureRefactoring [
 
 	refactoring :=  RBPushDownMethodRefactoring
@@ -30,7 +32,7 @@ RBPushDownMethodInSomeClassesDriver >> configureRefactoring [
 		in: classes.
 ]
 
-{ #category : #resources }
+{ #category : 'resources' }
 RBPushDownMethodInSomeClassesDriver >> refactoring [
 
 	refactoring :=  RBPushDownMethodRefactoring
@@ -40,7 +42,7 @@ RBPushDownMethodInSomeClassesDriver >> refactoring [
 		in: classes.
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 RBPushDownMethodInSomeClassesDriver >> runRefactoring [
 
 	| changes  |
@@ -63,7 +65,7 @@ RBPushDownMethodInSomeClassesDriver >> runRefactoring [
 	self openPreviewWithChanges: changes
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 RBPushDownMethodInSomeClassesDriver >> selectClasses [
 
 	| dialog |

--- a/src/Refactoring-UI/RBPushUpMethodDriver.class.st
+++ b/src/Refactoring-UI/RBPushUpMethodDriver.class.st
@@ -11,18 +11,20 @@ You can create my instance and execute the refactoring by running:
 ```
 "
 Class {
-	#name : #RBPushUpMethodDriver,
-	#superclass : #RBDriver,
+	#name : 'RBPushUpMethodDriver',
+	#superclass : 'RBDriver',
 	#instVars : [
 		'class',
 		'methods',
 		'superclass',
 		'refactoring'
 	],
-	#category : #'Refactoring-UI-Drivers'
+	#category : 'Refactoring-UI-Drivers',
+	#package : 'Refactoring-UI',
+	#tag : 'Drivers'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBPushUpMethodDriver class >> model: aRBNamespace scopes: refactoringScopes pushUp: methodsList [
 
 	^ self new
@@ -31,7 +33,7 @@ RBPushUpMethodDriver class >> model: aRBNamespace scopes: refactoringScopes push
 		  pushUp: methodsList
 ]
 
-{ #category : #resources }
+{ #category : 'resources' }
 RBPushUpMethodDriver >> configureRefactoring [
 	"I'm gathering user input and creating refactoring instance"
 
@@ -43,7 +45,7 @@ RBPushUpMethodDriver >> configureRefactoring [
 		  to: superclass
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBPushUpMethodDriver >> model: aRBNamespace scopes: refactoringScopes pushUp: methodsList [
 
 	model := aRBNamespace.
@@ -52,7 +54,7 @@ RBPushUpMethodDriver >> model: aRBNamespace scopes: refactoringScopes pushUp: me
 	class := methods first origin
 ]
 
-{ #category : #resources }
+{ #category : 'resources' }
 RBPushUpMethodDriver >> refactoring [
 	"I'm gathering user input and creating refactoring instance"
 
@@ -64,7 +66,7 @@ RBPushUpMethodDriver >> refactoring [
 		  to: superclass
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 RBPushUpMethodDriver >> runRefactoring [
 
 	| changes |
@@ -82,7 +84,7 @@ RBPushUpMethodDriver >> runRefactoring [
 	self openPreviewWithChanges: changes
 ]
 
-{ #category : #'initialization - data' }
+{ #category : 'initialization - data' }
 RBPushUpMethodDriver >> selectMethodsAndSuperclass [
 
 	| classes |

--- a/src/Refactoring-UI/RBRemoveAndShowSendersChoice.class.st
+++ b/src/Refactoring-UI/RBRemoveAndShowSendersChoice.class.st
@@ -1,17 +1,19 @@
 Class {
-	#name : #RBRemoveAndShowSendersChoice,
-	#superclass : #RBRemoveMethodChoice,
-	#category : #'Refactoring-UI-Choices'
+	#name : 'RBRemoveAndShowSendersChoice',
+	#superclass : 'RBRemoveMethodChoice',
+	#category : 'Refactoring-UI-Choices',
+	#package : 'Refactoring-UI',
+	#tag : 'Choices'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBRemoveAndShowSendersChoice >> action [ 
 	
 	driver removeMethodChanges.
 	driver browseSenders.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBRemoveAndShowSendersChoice >> description [
 
 	^ 'Remove, then browse senders'

--- a/src/Refactoring-UI/RBRemoveChoice.class.st
+++ b/src/Refactoring-UI/RBRemoveChoice.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #RBRemoveChoice,
-	#superclass : #RBRemoveMethodChoice,
-	#category : #'Refactoring-UI-Choices'
+	#name : 'RBRemoveChoice',
+	#superclass : 'RBRemoveMethodChoice',
+	#category : 'Refactoring-UI-Choices',
+	#package : 'Refactoring-UI',
+	#tag : 'Choices'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBRemoveChoice >> action [
 
 	driver removeMethodChanges
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBRemoveChoice >> description [
 
 	^ 'Remove it'

--- a/src/Refactoring-UI/RBRemoveInstanceVariablesDriver.class.st
+++ b/src/Refactoring-UI/RBRemoveInstanceVariablesDriver.class.st
@@ -2,17 +2,19 @@
 I'm a model for user interaction for the remove instance variable refactoring.
 "
 Class {
-	#name : #RBRemoveInstanceVariablesDriver,
-	#superclass : #RBDriver,
+	#name : 'RBRemoveInstanceVariablesDriver',
+	#superclass : 'RBDriver',
 	#instVars : [
 		'class',
 		'variables',
 		'refactoring'
 	],
-	#category : #'Refactoring-UI-Drivers'
+	#category : 'Refactoring-UI-Drivers',
+	#package : 'Refactoring-UI',
+	#tag : 'Drivers'
 }
 
-{ #category : #resources }
+{ #category : 'resources' }
 RBRemoveInstanceVariablesDriver >> configureRefactoring [
 
 	refactoring := RBCompositeRefactoring new
@@ -22,13 +24,13 @@ RBRemoveInstanceVariablesDriver >> configureRefactoring [
 								yourself 
 ]
 
-{ #category : #resources }
+{ #category : 'resources' }
 RBRemoveInstanceVariablesDriver >> refactoring [
 
 	refactoring := RBRemoveInstanceVariableRefactoring model: model remove: variables first from: class
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 RBRemoveInstanceVariablesDriver >> runRefactoring [
 
 	self configureRefactoring.
@@ -55,7 +57,7 @@ RBRemoveInstanceVariablesDriver >> runRefactoring [
 	
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBRemoveInstanceVariablesDriver >> scopes: refactoringScopes variables: aCollection for: aClass [
 	
 	scopes := refactoringScopes.

--- a/src/Refactoring-UI/RBRemoveMethodChoice.class.st
+++ b/src/Refactoring-UI/RBRemoveMethodChoice.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBRemoveMethodChoice,
-	#superclass : #RBChoice,
-	#category : #'Refactoring-UI-Choices'
+	#name : 'RBRemoveMethodChoice',
+	#superclass : 'RBChoice',
+	#category : 'Refactoring-UI-Choices',
+	#package : 'Refactoring-UI',
+	#tag : 'Choices'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBRemoveMethodChoice >> action [
 
 	self subclassResponsibility 

--- a/src/Refactoring-UI/RBRemoveMethodDriver.class.st
+++ b/src/Refactoring-UI/RBRemoveMethodDriver.class.st
@@ -5,7 +5,6 @@ Class {
 	#name : 'RBRemoveMethodDriver',
 	#superclass : 'RBDriver',
 	#instVars : [
-		'class',
 		'refactoring',
 		'methods',
 		'senders'
@@ -91,19 +90,17 @@ RBRemoveMethodDriver >> runRefactoring [
 ]
 
 { #category : 'initialization' }
-RBRemoveMethodDriver >> scopes: refactoringScopes method: aMethod for: aClass [
+RBRemoveMethodDriver >> scopes: refactoringScopes method: aMethod [
 	
 	scopes := refactoringScopes.
 	model := self refactoringScopeOn: scopes first.
-	methods := {aMethod}.
-	class := aClass
+	methods := { aMethod }
 ]
 
 { #category : 'initialization' }
-RBRemoveMethodDriver >> scopes: refactoringScopes methods: aMethods for: aClass [
+RBRemoveMethodDriver >> scopes: refactoringScopes methods: aMethods [
 	
 	scopes := refactoringScopes.
 	model := self refactoringScopeOn: scopes first.
-	methods := aMethods.
-	class := aClass
+	methods := aMethods
 ]

--- a/src/Refactoring-UI/RBRemoveMethodDriver.class.st
+++ b/src/Refactoring-UI/RBRemoveMethodDriver.class.st
@@ -2,56 +2,69 @@
 I'm a model for user interaction for the remove method refactoring.
 "
 Class {
-	#name : #RBRemoveMethodDriver,
-	#superclass : #RBDriver,
+	#name : 'RBRemoveMethodDriver',
+	#superclass : 'RBDriver',
 	#instVars : [
 		'class',
 		'refactoring',
 		'methods',
 		'senders'
 	],
-	#category : #'Refactoring-UI-Drivers'
+	#category : 'Refactoring-UI-Drivers',
+	#package : 'Refactoring-UI',
+	#tag : 'Drivers'
 }
 
-{ #category : #execution }
+{ #category : 'execution' }
 RBRemoveMethodDriver >> browseSenders [
 
 	StMessageBrowserPresenter  
 		browse: (senders collect: [ :each | each value methodClass realClass >> each value selector ]) 
-		asSendersOf: refactoring selectors
+		asSendersOf: (refactoring refactorings flatCollect: [ :ref | ref selectors ])
 	"this does not work for multiple selectors remove."
 ]
 
-{ #category : #resources }
+{ #category : 'resources' }
 RBRemoveMethodDriver >> configureRefactoring [
 
-	refactoring := RBRemoveMethodsRefactoring
-		               model: model
-		               selectors: (methods collect: [ :each | each selector ])
-		               from: class
+	| refactorings |
+	refactorings := OrderedCollection new.
+	(methods groupedBy: [ :m | m origin ])
+		keysAndValuesDo: [ :k :v |
+			refactorings add: (
+				RBRemoveMethodsRefactoring
+	            model: model
+	            selectors: (v collect: [ :each | each selector ])
+	         		from: k
+				)
+			].
+	refactoring := RBCompositeRefactoring new
+							model: model;
+							refactorings: refactorings 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBRemoveMethodDriver >> refactoring [
 
 	^ refactoring
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 RBRemoveMethodDriver >> removeMethodChanges [ 
 
-	self openPreviewWithChanges: refactoring removeMethodChanges
+	refactoring refactorings do: [ :ref | ref removeMethodChanges ].
+	self openPreviewWithChanges: refactoring changes
 
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 RBRemoveMethodDriver >> runRefactoring [
 
 	| select |
 	self configureRefactoring.
 	[
 	[
-	senders := refactoring senders.
+	senders := refactoring refactorings flatCollect: [ :ref | ref senders ].
 
 	senders
 		ifEmpty: [ self openPreviewWithChanges: refactoring generateChanges ]
@@ -77,7 +90,7 @@ RBRemoveMethodDriver >> runRefactoring [
 
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBRemoveMethodDriver >> scopes: refactoringScopes method: aMethod for: aClass [
 	
 	scopes := refactoringScopes.
@@ -86,7 +99,7 @@ RBRemoveMethodDriver >> scopes: refactoringScopes method: aMethod for: aClass [
 	class := aClass
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBRemoveMethodDriver >> scopes: refactoringScopes methods: aMethods for: aClass [
 	
 	scopes := refactoringScopes.

--- a/src/Refactoring-UI/RBRemoveSharedVariableDriver.class.st
+++ b/src/Refactoring-UI/RBRemoveSharedVariableDriver.class.st
@@ -2,17 +2,19 @@
 I'm a model for user interaction for the remove shared variable refactoring.
 "
 Class {
-	#name : #RBRemoveSharedVariableDriver,
-	#superclass : #RBDriver,
+	#name : 'RBRemoveSharedVariableDriver',
+	#superclass : 'RBDriver',
 	#instVars : [
 		'class',
 		'variables',
 		'refactoring'
 	],
-	#category : #'Refactoring-UI-Drivers'
+	#category : 'Refactoring-UI-Drivers',
+	#package : 'Refactoring-UI',
+	#tag : 'Drivers'
 }
 
-{ #category : #resources }
+{ #category : 'resources' }
 RBRemoveSharedVariableDriver >> refactoring [
 
 	refactoring := RBRemoveSharedVariableRefactoring
@@ -21,7 +23,7 @@ RBRemoveSharedVariableDriver >> refactoring [
 		               from: class
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 RBRemoveSharedVariableDriver >> runRefactoring [
 
 	self refactoring.
@@ -47,7 +49,7 @@ RBRemoveSharedVariableDriver >> runRefactoring [
 			err return ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 RBRemoveSharedVariableDriver >> scopes: refactoringScopes variable: aVariable for: aClass [
 	
 	scopes := refactoringScopes.

--- a/src/Refactoring-UI/RBRenameMethodDriver.class.st
+++ b/src/Refactoring-UI/RBRenameMethodDriver.class.st
@@ -2,8 +2,8 @@
 I'm a model for user interaction for the rename method refactoring.
 "
 Class {
-	#name : #RBRenameMethodDriver,
-	#superclass : #RBDriver,
+	#name : 'RBRenameMethodDriver',
+	#superclass : 'RBDriver',
 	#instVars : [
 		'class',
 		'originalMessage',
@@ -12,36 +12,38 @@ Class {
 		'command',
 		'postAction'
 	],
-	#category : #'Refactoring-UI-Drivers'
+	#category : 'Refactoring-UI-Drivers',
+	#package : 'Refactoring-UI',
+	#tag : 'Drivers'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBRenameMethodDriver >> canAddArgs [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBRenameMethodDriver >> canEditName [
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBRenameMethodDriver >> canRemoveArgs [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 RBRenameMethodDriver >> canRenameArgs [
 	^ true
 ]
 
-{ #category : #'To be removed' }
+{ #category : 'To be removed' }
 RBRenameMethodDriver >> command: aCommand andPostAction: aClosure [ 
 	command := aCommand. "may be not needed"
 	postAction := aClosure
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 RBRenameMethodDriver >> model: aModel renameMethodSignature: aMessage in: aClass [ 
 	model := aModel.
 	originalMessage := aMessage.
@@ -49,13 +51,13 @@ RBRenameMethodDriver >> model: aModel renameMethodSignature: aMessage in: aClass
 	class := aClass
 ]
 
-{ #category : #'To be removed' }
+{ #category : 'To be removed' }
 RBRenameMethodDriver >> newMessage [
 
 	^ newMessage
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 RBRenameMethodDriver >> refactoring [
 	"here we do not fully configure the refactoring because we are missing information such as the signature.
 	Since we want to let the refactoring validate input we need to create it upfront then configure later."
@@ -63,7 +65,7 @@ RBRenameMethodDriver >> refactoring [
 	^ RBRenameMethodRefactoring new renameMethod: originalMessage selector in: class 
 ]
 
-{ #category : #'To be removed' }
+{ #category : 'To be removed' }
 RBRenameMethodDriver >> requestNewMessage [
 
 	| methodName dialog  |
@@ -81,7 +83,7 @@ RBRenameMethodDriver >> requestNewMessage [
 	^ methodName
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 RBRenameMethodDriver >> runRefactoring [
 
 	refactoring := self refactoring.
@@ -102,7 +104,7 @@ RBRenameMethodDriver >> runRefactoring [
 			do: [ :err | self furtherActionFor: (RBOverrideMethod new refactoring: refactoring).  err return ]
 ]
 
-{ #category : #initialize }
+{ #category : 'initialize' }
 RBRenameMethodDriver >> scopes: refactoringScope model: aModel renameMethodSignature: aMessage in: aClass [
 
 	scopes := refactoringScope.

--- a/src/Refactoring-UI/RBSharedVariableStillReferenced.class.st
+++ b/src/Refactoring-UI/RBSharedVariableStillReferenced.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #RBSharedVariableStillReferenced,
-	#superclass : #RBBreakingChangeReport,
-	#category : #'Refactoring-UI-Drivers'
+	#name : 'RBSharedVariableStillReferenced',
+	#superclass : 'RBBreakingChangeReport',
+	#category : 'Refactoring-UI-Drivers',
+	#package : 'Refactoring-UI',
+	#tag : 'Drivers'
 }
 
-{ #category : #execution }
+{ #category : 'execution' }
 RBSharedVariableStillReferenced >> browse [
 
 	MessageBrowserPresenter browse: (SystemNavigation default allReferencesToBinding: (self refactoring refactoredClass realClass bindingOf: self refactoring variableName))
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBSharedVariableStillReferenced >> refactoring: aRefactoring [
 
 	refactoring := aRefactoring.

--- a/src/Refactoring-UI/StAbstractSelectionPresenter.class.st
+++ b/src/Refactoring-UI/StAbstractSelectionPresenter.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #StAbstractSelectionPresenter,
-	#superclass : #StItemsSelectionPresenter,
+	#name : 'StAbstractSelectionPresenter',
+	#superclass : 'StItemsSelectionPresenter',
 	#instVars : [
 		'dropList',
 		'dropLabel',
 		'acceptBlock'
 	],
-	#category : #'Refactoring-UI-UI'
+	#category : 'Refactoring-UI-UI',
+	#package : 'Refactoring-UI',
+	#tag : 'UI'
 }
 
-{ #category : #layout }
+{ #category : 'layout' }
 StAbstractSelectionPresenter class >> defaultLayout [
 	^ SpBoxLayout newTopToBottom
 		add: #dropLabel withConstraints: [ :c | c height: self labelHeight ];
@@ -25,7 +27,7 @@ StAbstractSelectionPresenter class >> defaultLayout [
 		yourself
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 StAbstractSelectionPresenter class >> label: aString dropLabel: aString2 withItems: items selecting: selectedItems dropItems: dropItems acceptBlock: aBlock [
 	^ self new
 		label: aString
@@ -37,17 +39,17 @@ StAbstractSelectionPresenter class >> label: aString dropLabel: aString2 withIte
 		openBlockedDialog
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 StAbstractSelectionPresenter >> accept [
 	acceptBlock value: self selectedItem value: table selectedItems
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StAbstractSelectionPresenter >> components [
 	^ super components , { dropList . dropLabel }
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 StAbstractSelectionPresenter >> initializeDropList [
 
 	dropList := self newDropList.
@@ -56,14 +58,14 @@ StAbstractSelectionPresenter >> initializeDropList [
 		displayIcon: [ :each | (self iconNamed: each systemIconName) ]
 ]
 
-{ #category : #'initialization - deprecated' }
+{ #category : 'initialization - deprecated' }
 StAbstractSelectionPresenter >> initializeWidgets [
 	super initializeWidgets .
 	dropLabel := self newLabel.
 	self initializeDropList
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 StAbstractSelectionPresenter >> label: aString dropLabel: dropString withItems: items selecting: selItems dropItems: dropItems acceptBlock: aBlock [
 	self label: aString withItems: items selecting: selItems.
 	dropLabel label: dropString.
@@ -71,7 +73,7 @@ StAbstractSelectionPresenter >> label: aString dropLabel: dropString withItems: 
 	acceptBlock := aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StAbstractSelectionPresenter >> selectedItem [
 	^ dropList selectedItem
 ]

--- a/src/Refactoring-UI/StItemsSelectionPresenter.class.st
+++ b/src/Refactoring-UI/StItemsSelectionPresenter.class.st
@@ -17,17 +17,19 @@ items:                   <OrderedCollection> A list to select
 selectedItems:           <OrderedCollection> A list with selected items
 "
 Class {
-	#name : #StItemsSelectionPresenter,
-	#superclass : #SpPresenter,
+	#name : 'StItemsSelectionPresenter',
+	#superclass : 'SpPresenter',
 	#instVars : [
 		'table',
 		'label',
 		'selectedItems'
 	],
-	#category : #'Refactoring-UI-UI'
+	#category : 'Refactoring-UI-UI',
+	#package : 'Refactoring-UI',
+	#tag : 'UI'
 }
 
-{ #category : #layout }
+{ #category : 'layout' }
 StItemsSelectionPresenter class >> defaultLayout [
 	^ SpBoxLayout newTopToBottom
 		add: #label withConstraints: [ :c | c height: self buttonHeight ];
@@ -38,20 +40,20 @@ StItemsSelectionPresenter class >> defaultLayout [
 		yourself
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 StItemsSelectionPresenter class >> label: aString withItems: items selecting: selectedItems [
 	^ self new
 		label: aString withItems: items selecting: selectedItems;
 		openBlockedDialog
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 StItemsSelectionPresenter >> accept [
 
 	selectedItems := table selectedItems
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 StItemsSelectionPresenter >> accept: presenter [
 	self accept.
 	presenter
@@ -59,22 +61,22 @@ StItemsSelectionPresenter >> accept: presenter [
 				close
 ]
 
-{ #category : #attributes }
+{ #category : 'attributes' }
 StItemsSelectionPresenter >> columnName [
 	self shouldBeImplemented
 ]
 
-{ #category : #attributes }
+{ #category : 'attributes' }
 StItemsSelectionPresenter >> columnSelector [
 	self shouldBeImplemented
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StItemsSelectionPresenter >> components [
 	^ { table . label }
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 StItemsSelectionPresenter >> connectPresenters [
 
 	table bindKeyCombination: Character backspace asShortcut
@@ -84,7 +86,7 @@ StItemsSelectionPresenter >> connectPresenters [
 		toAction: [ :presenter | self accept: presenter] ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 StItemsSelectionPresenter >> initializeDialogWindow: aModalPresenter [
 	aModalPresenter
 		addButton: 'Refactor' do: [ :presenter | self accept: presenter ];
@@ -94,14 +96,14 @@ StItemsSelectionPresenter >> initializeDialogWindow: aModalPresenter [
 				close ]
 ]
 
-{ #category : #'initialization - deprecated' }
+{ #category : 'initialization - deprecated' }
 StItemsSelectionPresenter >> initializeWidgets [
 	table := self instantiate: SpFilteringSelectableListPresenter.
 	table display: self columnSelector.
 	label := self newLabel
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 StItemsSelectionPresenter >> label: aString withItems: coll1 selecting: coll2 [
 	label label: aString.
 
@@ -109,7 +111,7 @@ StItemsSelectionPresenter >> label: aString withItems: coll1 selecting: coll2 [
 		selectItems: coll2
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StItemsSelectionPresenter >> selectedItems [
 	^ selectedItems
 ]

--- a/src/Refactoring-UI/StMethodNameEditorPresenter.class.st
+++ b/src/Refactoring-UI/StMethodNameEditorPresenter.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #StMethodNameEditorPresenter,
-	#superclass : #SpPresenter,
+	#name : 'StMethodNameEditorPresenter',
+	#superclass : 'SpPresenter',
 	#instVars : [
 		'selectorInput',
 		'argumentsList',
@@ -14,10 +14,12 @@ Class {
 		'canAddArgs',
 		'canEditName'
 	],
-	#category : #'Refactoring-UI-UI'
+	#category : 'Refactoring-UI-UI',
+	#package : 'Refactoring-UI',
+	#tag : 'UI'
 }
 
-{ #category : #examples }
+{ #category : 'examples' }
 StMethodNameEditorPresenter class >> example2 [
 	<script>
 	self
@@ -30,7 +32,7 @@ StMethodNameEditorPresenter class >> example2 [
 		canAddArgs: true
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 StMethodNameEditorPresenter class >> openOn: aMethod [
 	"I take a RBMethodName as parameter and open the refactoring UI in a modal to rename it."
 	|temp|
@@ -38,7 +40,7 @@ StMethodNameEditorPresenter class >> openOn: aMethod [
 	^ temp openBlockedDialog
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 StMethodNameEditorPresenter class >> openOn: aMethod canRenameArgs: aBoolean1 canRemoveArgs: aBoolean2 canAddArgs: aBoolean3 [
 	"I take a RBMethodName as parameter and open the refactoring UI in a modal to rename it."
 	|temp|
@@ -49,7 +51,7 @@ StMethodNameEditorPresenter class >> openOn: aMethod canRenameArgs: aBoolean1 ca
 	^ temp openBlockedDialog
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 StMethodNameEditorPresenter class >> openOn: aMethod withInvalidArgs: aSet canRenameArgs: aBoolean1 canRemoveArgs: aBoolean2 canAddArgs: aBoolean3 [
 	"I take a RBMethodName as parameter and open the refactoring UI in a modal to rename it."
 	|temp|
@@ -61,7 +63,7 @@ StMethodNameEditorPresenter class >> openOn: aMethod withInvalidArgs: aSet canRe
 	^ temp openBlockedDialog
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 StMethodNameEditorPresenter class >> openOn: aMethod withInvalidArgs: aSet canRenameArgs: aBoolean1 canRemoveArgs: aBoolean2 canAddArgs: aBoolean3 canEditName: aBoolean4 [
 	"I take a RBMethodName as parameter and open the refactoring UI in a modal to rename it."
 
@@ -75,7 +77,7 @@ StMethodNameEditorPresenter class >> openOn: aMethod withInvalidArgs: aSet canRe
 	^ temp openModal
 ]
 
-{ #category : #action }
+{ #category : 'action' }
 StMethodNameEditorPresenter >> addArgument [
 
 	| newArg argValue newKeyword |
@@ -92,7 +94,7 @@ StMethodNameEditorPresenter >> addArgument [
 	self updateLabel
 ]
 
-{ #category : #action }
+{ #category : 'action' }
 StMethodNameEditorPresenter >> addArgumentAfter: anItem [
 
 	| newArg argValue selectedIndex newKeyword |
@@ -112,17 +114,17 @@ StMethodNameEditorPresenter >> addArgumentAfter: anItem [
 	self updateLabel
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StMethodNameEditorPresenter >> addButton [
 	^ addButton
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StMethodNameEditorPresenter >> argumentsList [
 	^ argumentsList
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StMethodNameEditorPresenter >> argumentsListMenu [
 	^ self newMenu
 		addGroup: [ :aGroup |
@@ -149,41 +151,41 @@ StMethodNameEditorPresenter >> argumentsListMenu [
 						action: [ self removeArgument: argumentsList selectedItem ] ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StMethodNameEditorPresenter >> canAddArgs [
 	^ canAddArgs ifNil: [ canAddArgs := false ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StMethodNameEditorPresenter >> canAddArgs: aBoolean [
 	canAddArgs := aBoolean.
 	addButton enabled: canAddArgs
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StMethodNameEditorPresenter >> canEditName [
 	^ canEditName ifNil: [ canEditName := true ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StMethodNameEditorPresenter >> canEditName: aBoolean [
 	canEditName := aBoolean.
 	selectorInput enabled: canEditName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StMethodNameEditorPresenter >> canRemoveArgs: anObject [
 
 	argumentsList items do: [ :arg | arg canBeRemoved: anObject ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StMethodNameEditorPresenter >> canRenameArgs: anObject [
 
 	argumentsList items do: [ :arg | arg canBeRenamed: anObject ]
 ]
 
-{ #category : #action }
+{ #category : 'action' }
 StMethodNameEditorPresenter >> computePermutation [
 
 	| index |
@@ -192,7 +194,7 @@ StMethodNameEditorPresenter >> computePermutation [
 		args indexOf: e name ifAbsent: [ index := index -1. index ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StMethodNameEditorPresenter >> connectPresenters [
 
 	selectorInput
@@ -203,7 +205,7 @@ StMethodNameEditorPresenter >> connectPresenters [
 			toAction: [ self owner triggerCancelAction; close ]
 ]
 
-{ #category : #layout }
+{ #category : 'layout' }
 StMethodNameEditorPresenter >> defaultLayout [
 
 	| argumentsEditor |
@@ -229,12 +231,12 @@ StMethodNameEditorPresenter >> defaultLayout [
 		yourself
 ]
 
-{ #category : #'accessing - ui' }
+{ #category : 'accessing - ui' }
 StMethodNameEditorPresenter >> downButton [
 	^ downButton
 ]
 
-{ #category : #action }
+{ #category : 'action' }
 StMethodNameEditorPresenter >> getDefaultValue [
 
 	^ self 
@@ -242,7 +244,7 @@ StMethodNameEditorPresenter >> getDefaultValue [
 		  initialAnswer: 'nil'
 ]
 
-{ #category : #action }
+{ #category : 'action' }
 StMethodNameEditorPresenter >> getNewKeywordName [
 
 	^ self
@@ -250,12 +252,12 @@ StMethodNameEditorPresenter >> getNewKeywordName [
 		  initialAnswer: 'arg'
 ]
 
-{ #category : #services }
+{ #category : 'services' }
 StMethodNameEditorPresenter >> getParametersOrder [
 	^ argumentsList items collect: [ :arg | arg newName ]
 ]
 
-{ #category : #'to be pushed to presenter' }
+{ #category : 'to be pushed to presenter' }
 StMethodNameEditorPresenter >> inform: aString [
 
 	self application newDialog
@@ -264,7 +266,7 @@ StMethodNameEditorPresenter >> inform: aString [
 		openDialog
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 StMethodNameEditorPresenter >> initializeDialogWindow: aModalPresenter [
 	aModalPresenter
 		addButton: 'Rename' do: [ :presenter | self renameMethodAndClose: presenter ];
@@ -275,7 +277,7 @@ StMethodNameEditorPresenter >> initializeDialogWindow: aModalPresenter [
 					ifNotNil: [ :selector | ' : "', selector, '"' ])
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 StMethodNameEditorPresenter >> initializePresenters [
 
 	selectorInput := self newTextInput.
@@ -315,17 +317,17 @@ StMethodNameEditorPresenter >> initializePresenters [
 	argumentsList items ifNotEmpty: [ argumentsList selectIndex: 1 ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StMethodNameEditorPresenter >> invalidArgNames [
 	^ invalidArgNames ifNil: [ invalidArgNames := { } ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StMethodNameEditorPresenter >> invalidArgNames: aSet [
 	invalidArgNames := aSet
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 StMethodNameEditorPresenter >> newArgName [
 	| baseString index newString |
 	newString := baseString := 'anObject'.
@@ -337,17 +339,17 @@ StMethodNameEditorPresenter >> newArgName [
 	^ newString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StMethodNameEditorPresenter >> newArgs [
 	^ argumentsList items select: [ :e | (args includes: e name) not ]
 ]
 
-{ #category : #'accessing - ui' }
+{ #category : 'accessing - ui' }
 StMethodNameEditorPresenter >> previewResult [
 	^ previewResult
 ]
 
-{ #category : #action }
+{ #category : 'action' }
 StMethodNameEditorPresenter >> pushDownSelectedArgument [
 	| selectedIndex |
 	selectedIndex := argumentsList selection selectedIndex.
@@ -360,7 +362,7 @@ StMethodNameEditorPresenter >> pushDownSelectedArgument [
 	self updateLabel
 ]
 
-{ #category : #action }
+{ #category : 'action' }
 StMethodNameEditorPresenter >> pushUpSelectedArgument [
 	| selectedIndex |
 	selectedIndex := argumentsList selection selectedIndex.
@@ -373,7 +375,7 @@ StMethodNameEditorPresenter >> pushUpSelectedArgument [
 	self updateLabel
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StMethodNameEditorPresenter >> removeArgument: anItem [
 	| selectedIndex |
 	selectedIndex := argumentsList selection selectedIndex.
@@ -382,7 +384,7 @@ StMethodNameEditorPresenter >> removeArgument: anItem [
 	self updateLabel
 ]
 
-{ #category : #action }
+{ #category : 'action' }
 StMethodNameEditorPresenter >> renameArgument: anItem [
 
 	| argName selectedIndex |
@@ -398,13 +400,13 @@ StMethodNameEditorPresenter >> renameArgument: anItem [
 	self updateLabel
 ]
 
-{ #category : #services }
+{ #category : 'services' }
 StMethodNameEditorPresenter >> renameMap [
 
 	^ argumentsList items select: [ :arg | arg hasNewName ]
 ]
 
-{ #category : #action }
+{ #category : 'action' }
 StMethodNameEditorPresenter >> renameMethodAndClose: presenter [
 
 	^ self previewResult label = '(invalid)'
@@ -421,7 +423,7 @@ StMethodNameEditorPresenter >> renameMethodAndClose: presenter [
 				close ]
 ]
 
-{ #category : #action }
+{ #category : 'action' }
 StMethodNameEditorPresenter >> request: aString initialAnswer: aSecondString [
 
 	^ self application newRequest
@@ -431,23 +433,23 @@ StMethodNameEditorPresenter >> request: aString initialAnswer: aSecondString [
 			openModal
 ]
 
-{ #category : #'accessing - ui' }
+{ #category : 'accessing - ui' }
 StMethodNameEditorPresenter >> selectorInput [
 	^ selectorInput
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 StMethodNameEditorPresenter >> setModelBeforeInitialization: aRBMethodName [
 	methodName := aRBMethodName.
 	args := methodName arguments copy
 ]
 
-{ #category : #'accessing - ui' }
+{ #category : 'accessing - ui' }
 StMethodNameEditorPresenter >> upButton [
 	^ upButton
 ]
 
-{ #category : #action }
+{ #category : 'action' }
 StMethodNameEditorPresenter >> updateLabel [
 	"Update the new method name to display to the user when the user change its name or order of the arguments."
 
@@ -458,7 +460,7 @@ StMethodNameEditorPresenter >> updateLabel [
 				arguments: (argumentsList items collect: #newName) ) methodName
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 StMethodNameEditorPresenter >> updatePresenter [
 
 	selectorInput text: methodName selector.

--- a/src/Refactoring-UI/StMethodNameEditorPresenterTest.class.st
+++ b/src/Refactoring-UI/StMethodNameEditorPresenterTest.class.st
@@ -1,41 +1,43 @@
 Class {
-	#name : #StMethodNameEditorPresenterTest,
-	#superclass : #TestCase,
+	#name : 'StMethodNameEditorPresenterTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'methodNameEditor'
 	],
-	#category : #'Refactoring-UI-UI'
+	#category : 'Refactoring-UI-UI',
+	#package : 'Refactoring-UI',
+	#tag : 'UI'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StMethodNameEditorPresenterTest >> a [
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StMethodNameEditorPresenterTest >> a: a b: b c: c [
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 StMethodNameEditorPresenterTest >> methodNamedFor: aSymbol [
 	^ RBMethodName
 		selector: (self class >> aSymbol) selector
 		arguments: ((self class >> aSymbol) ast arguments collect: [:each | each name])
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 StMethodNameEditorPresenterTest >> setUp [
 	super setUp.
 	methodNameEditor := SycMethodNameEditorPresenter on: (self methodNamedFor: #a:b:c:)
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 StMethodNameEditorPresenterTest >> tearDown [
 
 	methodNameEditor ifNotNil: [ :x | x application closeAllWindows ].
 	super tearDown
 ]
 
-{ #category : #'tests - argument selection' }
+{ #category : 'tests - argument selection' }
 StMethodNameEditorPresenterTest >> testAddArgument [
 
 	methodNameEditor := SycMethodNameEditorPresenter on: (self methodNamedFor: #a:b:c:).
@@ -49,7 +51,7 @@ StMethodNameEditorPresenterTest >> testAddArgument [
 		(e name = 'Add') ifTrue: [ self assert: e isVisible ] ])
 ]
 
-{ #category : #'tests - up/down buttons' }
+{ #category : 'tests - up/down buttons' }
 StMethodNameEditorPresenterTest >> testButtonDownClickShouldModifiedArgumentsList [
 	| arrayBeforeClick arrayAfterClick |
 	methodNameEditor argumentsList selectIndex: 2.
@@ -60,21 +62,21 @@ StMethodNameEditorPresenterTest >> testButtonDownClickShouldModifiedArgumentsLis
 	self assert: (arrayAfterClick collect: [ :each | each newName ]) asArray equals: #(a c b)
 ]
 
-{ #category : #'tests - up/down buttons' }
+{ #category : 'tests - up/down buttons' }
 StMethodNameEditorPresenterTest >> testButtonDownClickShouldModifiedPreviewFinal [
 	methodNameEditor argumentsList selectIndex: 1.
 	methodNameEditor downButton click.
 	self assert: methodNameEditor previewResult label equals: 'a: b b: a c: c'
 ]
 
-{ #category : #'tests - up/down buttons' }
+{ #category : 'tests - up/down buttons' }
 StMethodNameEditorPresenterTest >> testButtonDownClickShouldSelectionIndexBeDecremented [
 	methodNameEditor argumentsList selectIndex: 1.
 	methodNameEditor downButton click.
 	self assert: methodNameEditor argumentsList selection selectedIndex equals: 2
 ]
 
-{ #category : #'tests - up/down buttons' }
+{ #category : 'tests - up/down buttons' }
 StMethodNameEditorPresenterTest >> testButtonDownClickWithoutSelectOption [
 	| arrayBeforeClick arrayAfterClick |
 	arrayBeforeClick := methodNameEditor argumentsList items.
@@ -84,7 +86,7 @@ StMethodNameEditorPresenterTest >> testButtonDownClickWithoutSelectOption [
 	self assert: (arrayAfterClick collect: [ :each | each newName ]) asArray equals: #(b a c)
 ]
 
-{ #category : #'tests - up/down buttons' }
+{ #category : 'tests - up/down buttons' }
 StMethodNameEditorPresenterTest >> testButtonUpClickShouldModifiedArgumentsList [
 	methodNameEditor argumentsList selectIndex: 2.
 	self assert: (methodNameEditor argumentsList items collect: [ :each | each newName ]) asArray
@@ -94,21 +96,21 @@ StMethodNameEditorPresenterTest >> testButtonUpClickShouldModifiedArgumentsList 
 		equals: #(a c b)
 ]
 
-{ #category : #'tests - up/down buttons' }
+{ #category : 'tests - up/down buttons' }
 StMethodNameEditorPresenterTest >> testButtonUpClickShouldModifiedPreviewFinal [
 	methodNameEditor argumentsList selectIndex: 2.
 	methodNameEditor upButton click.
 	self assert: methodNameEditor previewResult label equals: 'a: b b: a c: c'
 ]
 
-{ #category : #'tests - up/down buttons' }
+{ #category : 'tests - up/down buttons' }
 StMethodNameEditorPresenterTest >> testButtonUpClickShouldSelectionIndexBeDecremented [
 	methodNameEditor argumentsList selectIndex: 2.
 	methodNameEditor upButton click.
 	self assert: methodNameEditor argumentsList selection selectedIndex equals: 1
 ]
 
-{ #category : #'tests - up/down buttons' }
+{ #category : 'tests - up/down buttons' }
 StMethodNameEditorPresenterTest >> testButtonUpClickWithoutSelectOption [
 	self assert: (methodNameEditor argumentsList items collect: [ :each | each newName ]) asArray
 		equals: #(a b c).
@@ -117,49 +119,49 @@ StMethodNameEditorPresenterTest >> testButtonUpClickWithoutSelectOption [
 		equals: #(b a c)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 StMethodNameEditorPresenterTest >> testChangeInInputSelectorShouldChangePreviewLabelFinal [
 	methodNameEditor selectorInput text: 'd:e:f:'.
 	self assert: methodNameEditor previewResult label equals: 'd: a e: b f: c'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 StMethodNameEditorPresenterTest >> testChangeInInputSelectorWithFewAccessorThanArgumentsShouldChangePreviewLabelFinalWithFailedText [
 	methodNameEditor selectorInput text: 'd:'.
 	self assert: methodNameEditor previewResult label equals: '(invalid)'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 StMethodNameEditorPresenterTest >> testChangeInInputSelectorWithNothingShouldChangePreviewLabelFinalWithFailedText [
 	methodNameEditor selectorInput text: ''.
 	self assert: methodNameEditor previewResult label equals: '(invalid)'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 StMethodNameEditorPresenterTest >> testChangeInInputSelectorWithToMuchAccessorThanArgumentsShouldChangePreviewLabelFinalWithFailedText [
 	methodNameEditor selectorInput text: 'd:e:f:g:'.
 	self assert: methodNameEditor previewResult label equals: '(invalid)'
 ]
 
-{ #category : #'tests - initial state' }
+{ #category : 'tests - initial state' }
 StMethodNameEditorPresenterTest >> testInitialArgumentListAutoSelection [
 
 	self assert: methodNameEditor argumentsList selection selectedIndexes equals: #(1)
 ]
 
-{ #category : #'tests - initial state' }
+{ #category : 'tests - initial state' }
 StMethodNameEditorPresenterTest >> testInitialButtonDownIsDisable [
 	methodNameEditor := SycMethodNameEditorPresenter on: (self methodNamedFor: #a).
 	self deny: methodNameEditor downButton isEnabled
 ]
 
-{ #category : #'tests - initial state' }
+{ #category : 'tests - initial state' }
 StMethodNameEditorPresenterTest >> testInitialButtonUpIsDisable [
 	methodNameEditor := SycMethodNameEditorPresenter on: (self methodNamedFor: #a).
 	self deny: methodNameEditor upButton isEnabled
 ]
 
-{ #category : #'tests - argument selection' }
+{ #category : 'tests - argument selection' }
 StMethodNameEditorPresenterTest >> testRemoveArguments [
 
 	methodNameEditor := SycMethodNameEditorPresenter on: (self methodNamedFor: #a:b:c:).
@@ -173,7 +175,7 @@ StMethodNameEditorPresenterTest >> testRemoveArguments [
 		(e name = 'Remove') ifTrue: [ self assert: e isVisible ] ])
 ]
 
-{ #category : #'tests - argument selection' }
+{ #category : 'tests - argument selection' }
 StMethodNameEditorPresenterTest >> testRenameArgument [
 
 	methodNameEditor := SycMethodNameEditorPresenter on: (self methodNamedFor: #a:b:c:).

--- a/src/Refactoring-UI/StMethodsSelectionPresenter.class.st
+++ b/src/Refactoring-UI/StMethodsSelectionPresenter.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #StMethodsSelectionPresenter,
-	#superclass : #StItemsSelectionPresenter,
-	#category : #'Refactoring-UI-UI'
+	#name : 'StMethodsSelectionPresenter',
+	#superclass : 'StItemsSelectionPresenter',
+	#category : 'Refactoring-UI-UI',
+	#package : 'Refactoring-UI',
+	#tag : 'UI'
 }
 
-{ #category : #examples }
+{ #category : 'examples' }
 StMethodsSelectionPresenter class >> example [
 	<script>
 	^ (self label: 'example ...'
@@ -12,17 +14,17 @@ StMethodsSelectionPresenter class >> example [
 		selecting: {} )
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 StMethodsSelectionPresenter class >> title [
 	^ 'Methods'
 ]
 
-{ #category : #attributes }
+{ #category : 'attributes' }
 StMethodsSelectionPresenter >> columnName [
 	^ 'Methods'
 ]
 
-{ #category : #attributes }
+{ #category : 'attributes' }
 StMethodsSelectionPresenter >> columnSelector [
 	^ #selector
 ]

--- a/src/Refactoring-UI/StRefactoringPreviewPresenter.class.st
+++ b/src/Refactoring-UI/StRefactoringPreviewPresenter.class.st
@@ -5,8 +5,8 @@ I am responsible for keeping track of `selectedChanges` (which changes to apply)
 
 "
 Class {
-	#name : #StRefactoringPreviewPresenter,
-	#superclass : #SpPresenter,
+	#name : 'StRefactoringPreviewPresenter',
+	#superclass : 'SpPresenter',
 	#instVars : [
 		'changes',
 		'changesInScope',
@@ -22,10 +22,12 @@ Class {
 		'compositeChange',
 		'refactoring'
 	],
-	#category : #'Refactoring-UI-UI'
+	#category : 'Refactoring-UI-UI',
+	#package : 'Refactoring-UI',
+	#tag : 'UI'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 StRefactoringPreviewPresenter class >> changes: aCompositeRefactoring scopes: scopes [
 
 	^ self new
@@ -33,12 +35,12 @@ StRefactoringPreviewPresenter class >> changes: aCompositeRefactoring scopes: sc
 		  yourself
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 StRefactoringPreviewPresenter class >> title [
 	^ 'Refactoring changes'
 ]
 
-{ #category : #action }
+{ #category : 'action' }
 StRefactoringPreviewPresenter >> accept [
 	
 	(self okToChange not or: [ selectedChanges isEmptyOrNil ]) ifTrue: [
@@ -63,7 +65,7 @@ StRefactoringPreviewPresenter >> accept [
 	self closeWindow
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 StRefactoringPreviewPresenter >> buildDiffFor: aChange [
 
 	^ diffPresenter
@@ -71,7 +73,7 @@ StRefactoringPreviewPresenter >> buildDiffFor: aChange [
 		  rightText: aChange textToDisplay
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 StRefactoringPreviewPresenter >> changesFrom: aCompositeChange scopes: aCollection [
 
 	compositeChange := aCompositeChange.
@@ -84,13 +86,13 @@ StRefactoringPreviewPresenter >> changesFrom: aCompositeChange scopes: aCollecti
 	self updateTablePresenter
 ]
 
-{ #category : #action }
+{ #category : 'action' }
 StRefactoringPreviewPresenter >> closeWindow [
 
 	self window close
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 StRefactoringPreviewPresenter >> columns [
 
 	^ { (SpCompositeTableColumn new
@@ -103,7 +105,7 @@ StRefactoringPreviewPresenter >> columns [
 		   yourself) }
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 StRefactoringPreviewPresenter >> connectPresenters [
 
 	table whenSelectionChangedDo: [ :selection |
@@ -116,7 +118,7 @@ StRefactoringPreviewPresenter >> connectPresenters [
 	buttonOk action: [ self accept ]
 ]
 
-{ #category : #layout }
+{ #category : 'layout' }
 StRefactoringPreviewPresenter >> defaultLayout [
 	| scopesLayout |
 	
@@ -135,7 +137,7 @@ StRefactoringPreviewPresenter >> defaultLayout [
 		yourself
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 StRefactoringPreviewPresenter >> initializeDialogWindow: aDialogWindowPresenter [
 	"Used to initialize the model in the case of the use into a dialog window.
 	 Override this to set buttons other than the default (Ok, Cancel)."
@@ -148,7 +150,7 @@ StRefactoringPreviewPresenter >> initializeDialogWindow: aDialogWindowPresenter 
 			presenter close ]	
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 StRefactoringPreviewPresenter >> initializePresenters [
 
 	diffPresenter := self newDiff.
@@ -175,7 +177,7 @@ StRefactoringPreviewPresenter >> initializePresenters [
 		add: buttonCancel
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 StRefactoringPreviewPresenter >> initializeWindow: aWindowPresenter [
 
 	aWindowPresenter
@@ -183,18 +185,18 @@ StRefactoringPreviewPresenter >> initializeWindow: aWindowPresenter [
 		initialExtent: 700 @ 500
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 StRefactoringPreviewPresenter >> refactoring: aRBRemoveMethodDriver [ 
 	refactoring := aRBRemoveMethodDriver
 ]
 
-{ #category : #update }
+{ #category : 'update' }
 StRefactoringPreviewPresenter >> updateActiveScope [
 
 	activeScope := scopeDropList selectedItem asRBEnvironment
 ]
 
-{ #category : #update }
+{ #category : 'update' }
 StRefactoringPreviewPresenter >> updateChanges [
 
 	changesInScope := changes select: [ :change |
@@ -202,13 +204,13 @@ StRefactoringPreviewPresenter >> updateChanges [
 	selectedChanges := OrderedCollection withAll: changesInScope
 ]
 
-{ #category : #update }
+{ #category : 'update' }
 StRefactoringPreviewPresenter >> updateScopeList [
 
 	scopeDropList items: scopes
 ]
 
-{ #category : #update }
+{ #category : 'update' }
 StRefactoringPreviewPresenter >> updateTablePresenter [
 
 	table items: changesInScope.

--- a/src/Refactoring-UI/StSelectClassAndMethodsPresenter.class.st
+++ b/src/Refactoring-UI/StSelectClassAndMethodsPresenter.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #StSelectClassAndMethodsPresenter,
-	#superclass : #StAbstractSelectionPresenter,
-	#category : #'Refactoring-UI-UI'
+	#name : 'StSelectClassAndMethodsPresenter',
+	#superclass : 'StAbstractSelectionPresenter',
+	#category : 'Refactoring-UI-UI',
+	#package : 'Refactoring-UI',
+	#tag : 'UI'
 }
 
-{ #category : #examples }
+{ #category : 'examples' }
 StSelectClassAndMethodsPresenter class >> example [
 	<script>
 	^ (self label: 'example ...'
@@ -15,17 +17,17 @@ StSelectClassAndMethodsPresenter class >> example [
 		acceptBlock: [ :item :items |  ] )
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 StSelectClassAndMethodsPresenter class >> title [
 	^ 'Methods'
 ]
 
-{ #category : #attributes }
+{ #category : 'attributes' }
 StSelectClassAndMethodsPresenter >> columnName [
 	^ 'Methods'
 ]
 
-{ #category : #attributes }
+{ #category : 'attributes' }
 StSelectClassAndMethodsPresenter >> columnSelector [
 	^ #selector
 ]

--- a/src/Refactoring-UI/StVariablesSelectionPresenter.class.st
+++ b/src/Refactoring-UI/StVariablesSelectionPresenter.class.st
@@ -2,12 +2,14 @@
 I am preview to select variables (Class Variable) 
 "
 Class {
-	#name : #StVariablesSelectionPresenter,
-	#superclass : #StItemsSelectionPresenter,
-	#category : #'Refactoring-UI-UI'
+	#name : 'StVariablesSelectionPresenter',
+	#superclass : 'StItemsSelectionPresenter',
+	#category : 'Refactoring-UI-UI',
+	#package : 'Refactoring-UI',
+	#tag : 'UI'
 }
 
-{ #category : #examples }
+{ #category : 'examples' }
 StVariablesSelectionPresenter class >> example [
 	<script>
 	^ (self label: 'example ...'
@@ -16,17 +18,17 @@ StVariablesSelectionPresenter class >> example [
 		selecting: {(ClassVariable named: #z) . (ClassVariable named: #a) } asOrderedCollection )
 ]
 
-{ #category : #specs }
+{ #category : 'specs' }
 StVariablesSelectionPresenter class >> title [
 	^ 'Class variables'
 ]
 
-{ #category : #attributes }
+{ #category : 'attributes' }
 StVariablesSelectionPresenter >> columnName [
 	^ 'Variables'
 ]
 
-{ #category : #attributes }
+{ #category : 'attributes' }
 StVariablesSelectionPresenter >> columnSelector [
 	^ #name
 ]

--- a/src/Refactoring-UI/package.st
+++ b/src/Refactoring-UI/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Refactoring-UI' }
+Package { #name : 'Refactoring-UI' }

--- a/src/Refactoring2-Transformations-Tests/RBAbstractClassVariableParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAbstractClassVariableParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBAbstractClassVariableParametrizedTest,
-	#superclass : #RBWithDifferentConstructorsParametrizedTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBAbstractClassVariableParametrizedTest',
+	#superclass : 'RBWithDifferentConstructorsParametrizedTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 RBAbstractClassVariableParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBAbstractClassVariableReferencesRefactoring .
@@ -14,13 +16,13 @@ RBAbstractClassVariableParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBAbstractClassVariableParametrizedTest >> setUp [
 	super setUp.
 	model := self rbModelForVariableTest
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAbstractClassVariableParametrizedTest >> testAbstractClassVariable [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments:
@@ -48,14 +50,14 @@ RBAbstractClassVariableParametrizedTest >> testAbstractClassVariable [
 												classified: aSmalllintContext protocols]]')"
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAbstractClassVariableParametrizedTest >> testFailureInheritedName [
 
 	self shouldFail: (self createRefactoringWithArguments:
 			 { #DependentsFields. #RBBasicLintRuleTestData })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAbstractClassVariableParametrizedTest >> testFailureInvalidClass [
 
 	self shouldFail:
@@ -63,21 +65,21 @@ RBAbstractClassVariableParametrizedTest >> testFailureInvalidClass [
 		 #Object })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAbstractClassVariableParametrizedTest >> testFailureMetaClassFailure [
 
 	self shouldFail: (self createRefactoringWithArguments:
 			 { #RecursiveSelfRule. #'RBTransformationRuleTestData class' })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAbstractClassVariableParametrizedTest >> testFailureNonExistantName [
 
 	self shouldFail: (self createRefactoringWithArguments:
 			 { #Foo. #RBBasicLintRuleTestData })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAbstractClassVariableParametrizedTest >> testModelAbstractClassVariable [
 	| refactoring meta class |
 	class := model classNamed: #Foo.
@@ -103,7 +105,7 @@ RBAbstractClassVariableParametrizedTest >> testModelAbstractClassVariable [
 						instVarName1 := instVarName1 + instVarName2 + self class classVarName1')"
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAbstractClassVariableParametrizedTest >> testModelAbstractClassVariableOverridenMethodsInSubclass [
 	| refactoring meta class |
 	class := model classNamed: #Foo.

--- a/src/Refactoring2-Transformations-Tests/RBAbstractEnvTestCase.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAbstractEnvTestCase.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #RBAbstractEnvTestCase,
-	#superclass : #ParametrizedTestCase,
+	#name : 'RBAbstractEnvTestCase',
+	#superclass : 'ParametrizedTestCase',
 	#instVars : [
 		'testingEnvironment',
 		'model'
 	],
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RBAbstractEnvTestCase class >> makeAllFailureShownInTestMethodNames [
 	
 	| methods nSel |
@@ -27,7 +29,7 @@ RBAbstractEnvTestCase class >> makeAllFailureShownInTestMethodNames [
 	classified: 'failure tests']
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RBAbstractEnvTestCase class >> removeDuplicates [
 	
 	| methods  |
@@ -44,7 +46,7 @@ RBAbstractEnvTestCase class >> removeDuplicates [
 	
 ]
 
-{ #category : #'mocking helpers' }
+{ #category : 'mocking helpers' }
 RBAbstractEnvTestCase >> addMethodsToModelClasses: aCollection in: newModel [
 	
 	aCollection do: [:each |
@@ -57,7 +59,7 @@ RBAbstractEnvTestCase >> addMethodsToModelClasses: aCollection in: newModel [
 	^ newModel
 ]
 
-{ #category : #mocking }
+{ #category : 'mocking' }
 RBAbstractEnvTestCase >> childrenToSiblingTestData [
 
 	^ Smalltalk compiler evaluate: '
@@ -125,17 +127,17 @@ m
 '
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBAbstractEnvTestCase >> defaultNamespaceClass [
 	^ RBNamespace
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBAbstractEnvTestCase >> environmentOfTest [
 	^ testingEnvironment
 ]
 
-{ #category : #mocking }
+{ #category : 'mocking' }
 RBAbstractEnvTestCase >> inlineMethodTestData [
 
 	^ Smalltalk compiler evaluate: '
@@ -345,7 +347,7 @@ m
 '
 ]
 
-{ #category : #'mocking helpers' }
+{ #category : 'mocking helpers' }
 RBAbstractEnvTestCase >> modelWithoutRealClasses: aColOfClasses [
 
 	| newModel classEnvironment classes |
@@ -363,12 +365,12 @@ RBAbstractEnvTestCase >> modelWithoutRealClasses: aColOfClasses [
 	
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 RBAbstractEnvTestCase >> proceedThroughWarning: aBlock [
 	aBlock on: RBRefactoringWarning do: [ :ex | ex resume ]
 ]
 
-{ #category : #mocking }
+{ #category : 'mocking' }
 RBAbstractEnvTestCase >> rbModelForExtractMethodTest [
 
 	| newModel |
@@ -455,7 +457,7 @@ RBAbstractEnvTestCase >> rbModelForExtractMethodTest [
 	^ newModel
 ]
 
-{ #category : #mocking }
+{ #category : 'mocking' }
 RBAbstractEnvTestCase >> rbModelForInliningMethodTest [
 
 	| newModel |
@@ -739,7 +741,7 @@ RBAbstractEnvTestCase >> rbModelForInliningMethodTest [
 	^ newModel
 ]
 
-{ #category : #mocking }
+{ #category : 'mocking' }
 RBAbstractEnvTestCase >> rbModelForVariableTest [
 
 	| newModel |
@@ -790,13 +792,13 @@ RBAbstractEnvTestCase >> rbModelForVariableTest [
 	^ newModel
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBAbstractEnvTestCase >> setUp [
 	super setUp.
 	testingEnvironment := Smalltalk globals
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 RBAbstractEnvTestCase >> shouldFail: aRefactoring [
 
 	self proceedThroughWarning: [
@@ -806,14 +808,14 @@ RBAbstractEnvTestCase >> shouldFail: aRefactoring [
 	]
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 RBAbstractEnvTestCase >> shouldWarn: aRefactoring [
 	self
 		should: [ aRefactoring generateChanges ]
 		raise: RBRefactoringWarning
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBAbstractEnvTestCase >> testingEnvironment: anObject [
 	testingEnvironment := anObject
 ]

--- a/src/Refactoring2-Transformations-Tests/RBAbstractInstanceVariableParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAbstractInstanceVariableParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBAbstractInstanceVariableParametrizedTest,
-	#superclass : #RBWithDifferentConstructorsParametrizedTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBAbstractInstanceVariableParametrizedTest',
+	#superclass : 'RBWithDifferentConstructorsParametrizedTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAbstractInstanceVariableParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBAbstractInstanceVariableRefactoring .
@@ -14,13 +16,13 @@ RBAbstractInstanceVariableParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBAbstractInstanceVariableParametrizedTest >> setUp [
 	super setUp.
 	model := self rbModelForVariableTest
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAbstractInstanceVariableParametrizedTest >> testAbstractInstanceVariable [
 	| refactoring class |
 	refactoring := self createRefactoringWithArguments:
@@ -37,7 +39,7 @@ RBAbstractInstanceVariableParametrizedTest >> testAbstractInstanceVariable [
 	self name ifNil: [ super printOn: aStream ] ifNotNil: [ aStream nextPutAll: self name ]')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAbstractInstanceVariableParametrizedTest >> testAbstractWithAssignmentUsed [
 	| refactoring class |
 	class := model classNamed: #Foo.
@@ -65,7 +67,7 @@ RBAbstractInstanceVariableParametrizedTest >> testAbstractWithAssignmentUsed [
 						instVarName1 := instVarName1 + self instVarName2 + ClassVarName1')"
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAbstractInstanceVariableParametrizedTest >> testAbstractWithDefaultNamesUsed [
 	| refactoring class |
 	class := model classNamed: #Foo.
@@ -92,21 +94,21 @@ RBAbstractInstanceVariableParametrizedTest >> testAbstractWithDefaultNamesUsed [
 						self instVarName11: self instVarName11 + instVarName2 + ClassVarName1')"
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAbstractInstanceVariableParametrizedTest >> testFailureInheritedName [
 
 	self shouldFail: (self createRefactoringWithArguments:
 			 { 'name'. #RBBasicLintRuleTestData })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAbstractInstanceVariableParametrizedTest >> testFailureNonExistantName [
 
 	self shouldFail: (self createRefactoringWithArguments:
 			 { 'foo'. #RBBasicLintRuleTestData })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAbstractInstanceVariableParametrizedTest >> testMetaclassInstanceVariables [
 	| refactoring class |
 	class := model metaclassNamed: #Foo.

--- a/src/Refactoring2-Transformations-Tests/RBAbstractRefactoringTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAbstractRefactoringTest.class.st
@@ -1,17 +1,19 @@
 Class {
-	#name : #RBAbstractRefactoringTest,
-	#superclass : #RBAbstractEnvTestCase,
+	#name : 'RBAbstractRefactoringTest',
+	#superclass : 'RBAbstractEnvTestCase',
 	#instVars : [
 		'rbClass'
 	],
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBAbstractRefactoringTest >> constructor [
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 RBAbstractRefactoringTest >> createRefactoringWithArguments: aParameterCollection [
 
 	^ rbClass
@@ -19,7 +21,7 @@ RBAbstractRefactoringTest >> createRefactoringWithArguments: aParameterCollectio
 		  withArguments: aParameterCollection
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 RBAbstractRefactoringTest >> createRefactoringWithModel: aRBNamespace andArguments: aParameterCollection [
 
 	^ rbClass
@@ -27,63 +29,63 @@ RBAbstractRefactoringTest >> createRefactoringWithModel: aRBNamespace andArgumen
 		  withArguments: { aRBNamespace } , aParameterCollection
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 RBAbstractRefactoringTest >> executeRefactoring: aRefactoring [
 	aRefactoring generateChanges
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 RBAbstractRefactoringTest >> executeRefactorings: aRefactoringColl [
 	aRefactoringColl do: [ :ref | ref generateChanges]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAbstractRefactoringTest >> methodSignatureStringForSymbol: aSymbol withArgumentString: aString [
 	"The method is written this way to make sure that we can rename test input (methods) and do not break the tests."
 	
 	^ aSymbol asString, aString, Character cr asString
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAbstractRefactoringTest >> methodSignatureStringForUnarySymbol: aSymbol [
 	"The method is written this way to make sure that we can rename test input (methods) and do not break the tests."
 	
 	^ aSymbol asString, Character cr asString
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 RBAbstractRefactoringTest >> objectClassVariable [
 	^Object classPool keys detect: [:each | true]
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 RBAbstractRefactoringTest >> parseExpression: aString [
 	^ self parserClass parseExpression: aString
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 RBAbstractRefactoringTest >> parseMethod: aString [
 	^ self parserClass parseMethod: aString
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 RBAbstractRefactoringTest >> parserClass [
 	^ RBParser
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBAbstractRefactoringTest >> rbClass: anObject [
 
 	rbClass := anObject
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBAbstractRefactoringTest >> setUp [
 	super setUp.
 	model := self defaultNamespaceClass new
 ]
 
-{ #category : #'set up' }
+{ #category : 'set up' }
 RBAbstractRefactoringTest >> setupExtractionClassFor: aRefactoring toReturn: aClass [
 	| options |
 	options := aRefactoring options copy.
@@ -92,7 +94,7 @@ RBAbstractRefactoringTest >> setupExtractionClassFor: aRefactoring toReturn: aCl
 	aRefactoring options: options
 ]
 
-{ #category : #'set up' }
+{ #category : 'set up' }
 RBAbstractRefactoringTest >> setupImplementorToInlineFor: aRefactoring toReturn: anObject [
 	| options |
 	options := aRefactoring options copy.
@@ -100,7 +102,7 @@ RBAbstractRefactoringTest >> setupImplementorToInlineFor: aRefactoring toReturn:
 	aRefactoring options: options
 ]
 
-{ #category : #'set up' }
+{ #category : 'set up' }
 RBAbstractRefactoringTest >> setupInlineExpressionFor: aRefactoring toReturn: aBoolean [
 	| options |
 	options := aRefactoring options copy.
@@ -108,7 +110,7 @@ RBAbstractRefactoringTest >> setupInlineExpressionFor: aRefactoring toReturn: aB
 	aRefactoring options: options
 ]
 
-{ #category : #'set up' }
+{ #category : 'set up' }
 RBAbstractRefactoringTest >> setupMethodNameFor: aRefactoring toReturn: aSelector [
 
 	| options |
@@ -122,7 +124,7 @@ RBAbstractRefactoringTest >> setupMethodNameFor: aRefactoring toReturn: aSelecto
 	aRefactoring options: options
 ]
 
-{ #category : #'set up' }
+{ #category : 'set up' }
 RBAbstractRefactoringTest >> setupMethodNameFor: aRefactoring toReturn: aSelector withArguments: stringCollection [
 
 	| options |
@@ -137,7 +139,7 @@ RBAbstractRefactoringTest >> setupMethodNameFor: aRefactoring toReturn: aSelecto
 	aRefactoring options: options
 ]
 
-{ #category : #'set up' }
+{ #category : 'set up' }
 RBAbstractRefactoringTest >> setupSearchInAllHierarchyFor: aRefactoring toReturn: aBoolean [
 
 	| options |
@@ -146,7 +148,7 @@ RBAbstractRefactoringTest >> setupSearchInAllHierarchyFor: aRefactoring toReturn
 	aRefactoring options: options
 ]
 
-{ #category : #'set up' }
+{ #category : 'set up' }
 RBAbstractRefactoringTest >> setupSelfArgumentNameFor: aRefactoring toReturn: aString [
 
 	| options |
@@ -155,7 +157,7 @@ RBAbstractRefactoringTest >> setupSelfArgumentNameFor: aRefactoring toReturn: aS
 	aRefactoring options: options
 ]
 
-{ #category : #'set up' }
+{ #category : 'set up' }
 RBAbstractRefactoringTest >> setupShouldUseExistingMethodFor: aRefactoring toReturn: aBoolean [
 
 	| options |
@@ -164,7 +166,7 @@ RBAbstractRefactoringTest >> setupShouldUseExistingMethodFor: aRefactoring toRet
 	aRefactoring options: options
 ]
 
-{ #category : #'set up' }
+{ #category : 'set up' }
 RBAbstractRefactoringTest >> setupVariableToMoveToFor: aRefactoring toReturn: aString [
 
 	| options |
@@ -173,7 +175,7 @@ RBAbstractRefactoringTest >> setupVariableToMoveToFor: aRefactoring toReturn: aS
 	aRefactoring options: options
 ]
 
-{ #category : #'set up' }
+{ #category : 'set up' }
 RBAbstractRefactoringTest >> setupVariableTypesFor: aRefactoring toReturn: anObject [
 
 	| options |
@@ -182,14 +184,14 @@ RBAbstractRefactoringTest >> setupVariableTypesFor: aRefactoring toReturn: anObj
 	aRefactoring options: options
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 RBAbstractRefactoringTest >> shouldntWarn: aRefactoring [
 	self
 		shouldnt: [ self executeRefactoring: aRefactoring ]
 		raise: RBRefactoringWarning
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAbstractRefactoringTest >> testConditions [
 	| condition newCondition |
 	condition := RBCondition new

--- a/src/Refactoring2-Transformations-Tests/RBAbstractTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAbstractTransformationTest.class.st
@@ -1,32 +1,34 @@
 Class {
-	#name : #RBAbstractTransformationTest,
-	#superclass : #RBAbstractEnvTestCase,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBAbstractTransformationTest',
+	#superclass : 'RBAbstractEnvTestCase',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #mocking }
+{ #category : 'mocking' }
 RBAbstractTransformationTest >> changeMockClass [
 
 	^ RBRefactoringChangeMock
 ]
 
-{ #category : #mocking }
+{ #category : 'mocking' }
 RBAbstractTransformationTest >> objectClassVariable [
 
 	^ Object classPool keys detect: [:each | true]
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 RBAbstractTransformationTest >> parseMethod: aString [
 	^ self parserClass parseMethod: aString
 ]
 
-{ #category : #parsing }
+{ #category : 'parsing' }
 RBAbstractTransformationTest >> parserClass [
 	^ RBParser
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBAbstractTransformationTest >> performAndUndoChange: aChange do: aBlock [
 	"Perform a change in the system silently, evaluate aBlock and then undo the change again."
 
@@ -36,14 +38,14 @@ RBAbstractTransformationTest >> performAndUndoChange: aChange do: aBlock [
 		aBlock ensure: [ undo execute ] ]
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBAbstractTransformationTest >> setUp [
 
 	super setUp.
 	model := RBNamespace new
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAbstractTransformationTest >> testAPI [
 	"all classes must implement #storeOn: and #transform"
 
@@ -63,7 +65,7 @@ RBAbstractTransformationTest >> testAPI [
 	self assertEmpty: incompleteTransformations
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAbstractTransformationTest >> testBuildSelectorStringWithPermuteMapAndNewArguments [
 
 	| selector permutations args trans selectorString |
@@ -77,7 +79,7 @@ RBAbstractTransformationTest >> testBuildSelectorStringWithPermuteMapAndNewArgum
 	self assert: selectorString equals: 'a123: ``@arg1 b123: ``@arg2 c123: ``@arg3 '
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAbstractTransformationTest >> testBuildSelectorStringWithPermuteMapAndNewArgumentsWhenAllNewArguments [
 
 	| selector permutations args trans selectorString |
@@ -93,7 +95,7 @@ RBAbstractTransformationTest >> testBuildSelectorStringWithPermuteMapAndNewArgum
 	self assert: selectorString equals: 'a123: ``@arg1 c123: (5) b123: ([ :each | each + 2 ]) '
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAbstractTransformationTest >> testBuildSelectorStringWithPermuteMapAndNewArgumentsWhenArgsPermuted [
 
 	| selector permutations args trans selectorString |
@@ -107,7 +109,7 @@ RBAbstractTransformationTest >> testBuildSelectorStringWithPermuteMapAndNewArgum
 	self assert: selectorString equals: 'b123: ``@arg2 a123: ``@arg3 c123: ``@arg1 '
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAbstractTransformationTest >> testBuildSelectorStringWithPermuteMapAndNewArgumentsWhenNewArgumentAdded [
 
 	| selector permutations args trans selectorString |
@@ -121,7 +123,7 @@ RBAbstractTransformationTest >> testBuildSelectorStringWithPermuteMapAndNewArgum
 	self assert: selectorString equals: 'b123: ``@arg2 a123: (OrderedCollection new) c123: ``@arg1 '
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAbstractTransformationTest >> testBuildSelectorStringWithPermuteMapAndNewArgumentsWhenNoArguments [
 
 	| selector permutations args trans selectorString |

--- a/src/Refactoring2-Transformations-Tests/RBAddAccessorsForClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddAccessorsForClassTransformationTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBAddAccessorsForClassTransformationTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBAddAccessorsForClassTransformationTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddAccessorsForClassTransformationTest >> testRefactoring [
 
 	| refactoring class |
@@ -23,7 +25,7 @@ RBAddAccessorsForClassTransformationTest >> testRefactoring [
 		(self parseMethod: 'variableName: anObject variableName := anObject')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddAccessorsForClassTransformationTest >> testTransform [
 
 	| transformation class |

--- a/src/Refactoring2-Transformations-Tests/RBAddAssignmentTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddAssignmentTransformationTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBAddAssignmentTransformationTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBAddAssignmentTransformationTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RBAddAssignmentTransformationTest >> methodAfter [
 
 	| variable |
@@ -12,14 +14,14 @@ RBAddAssignmentTransformationTest >> methodAfter [
 	variable := 1 asString
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RBAddAssignmentTransformationTest >> methodBefore [
 
 	| variable |
 	variable := 'String'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddAssignmentTransformationTest >> testClassDoesNotExist [
 
 	self shouldFail: (RBAddAssignmentTransformation
@@ -29,7 +31,7 @@ RBAddAssignmentTransformationTest >> testClassDoesNotExist [
 			 inClass: #RBAssignmentTransformationTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddAssignmentTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBAddAssignmentTransformation
@@ -39,7 +41,7 @@ RBAddAssignmentTransformationTest >> testMethodDoesNotExist [
 			 inClass: #RBAddAssignmentTransformationTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddAssignmentTransformationTest >> testRefactoring [
 
 	| refactoring class |
@@ -66,7 +68,7 @@ RBAddAssignmentTransformationTest >> testRefactoring [
 		equals: '1 asString'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddAssignmentTransformationTest >> testTransform [
 
 	| transformation class |
@@ -84,7 +86,7 @@ RBAddAssignmentTransformationTest >> testTransform [
 		equals: (class parseTreeForSelector: #methodAfter) body
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddAssignmentTransformationTest >> testVariableDoesNotExist [
 
 	self shouldFail: (RBAddAssignmentTransformation

--- a/src/Refactoring2-Transformations-Tests/RBAddClassVariableRefactoringTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddClassVariableRefactoringTest.class.st
@@ -1,17 +1,19 @@
 Class {
-	#name : #RBAddClassVariableRefactoringTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBAddClassVariableRefactoringTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 RBAddClassVariableRefactoringTest >> setUp [
 
 	super setUp.
 	model := self rbModelForVariableTest
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddClassVariableRefactoringTest >> testFailureAlreadyExistingName [
 
 	self shouldFail: (RBAddClassVariableRefactoring
@@ -22,7 +24,7 @@ RBAddClassVariableRefactoringTest >> testFailureAlreadyExistingName [
 				 class: #RBTransformationRuleTestData )
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddClassVariableRefactoringTest >> testFailureModelAlreadyExistingName [
 
 	self shouldFail: (RBAddClassVariableRefactoring

--- a/src/Refactoring2-Transformations-Tests/RBAddClassVariableTransformationParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddClassVariableTransformationParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBAddClassVariableTransformationParametrizedTest,
-	#superclass : #RBWithDifferentConstructorsParametrizedTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBAddClassVariableTransformationParametrizedTest',
+	#superclass : 'RBWithDifferentConstructorsParametrizedTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 RBAddClassVariableTransformationParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBAddVariableTransformation .
@@ -14,13 +16,13 @@ RBAddClassVariableTransformationParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBAddClassVariableTransformationParametrizedTest >> setUp [
 	super setUp.
 	model := self rbModelForVariableTest
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddClassVariableTransformationParametrizedTest >> testAddClassVariable [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments:
@@ -33,14 +35,14 @@ RBAddClassVariableTransformationParametrizedTest >> testAddClassVariable [
 		directlyDefinesClassVariable: #Asdf)
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddClassVariableTransformationParametrizedTest >> testFailureMetaClassFailure [
 
 	self shouldFail: (self createRefactoringWithArguments:
 			 { #VariableName. #'RBTransformationRuleTestData class' })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddClassVariableTransformationParametrizedTest >> testFailureMetaclass [
 
 	| refactoring |
@@ -51,7 +53,7 @@ RBAddClassVariableTransformationParametrizedTest >> testFailureMetaclass [
 	self shouldFail: refactoring
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddClassVariableTransformationParametrizedTest >> testFailureModelMetaclass [
 
 	| refactoring |
@@ -62,7 +64,7 @@ RBAddClassVariableTransformationParametrizedTest >> testFailureModelMetaclass [
 	self shouldFail: refactoring
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddClassVariableTransformationParametrizedTest >> testModelAddClassVariable [
 	| refactoring |
 	refactoring := self createRefactoringWithModel: model

--- a/src/Refactoring2-Transformations-Tests/RBAddInstanceVariableParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddInstanceVariableParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBAddInstanceVariableParametrizedTest,
-	#superclass : #RBWithDifferentConstructorsParametrizedTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBAddInstanceVariableParametrizedTest',
+	#superclass : 'RBWithDifferentConstructorsParametrizedTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 RBAddInstanceVariableParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBAddInstanceVariableRefactoring .
@@ -14,13 +16,13 @@ RBAddInstanceVariableParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBAddInstanceVariableParametrizedTest >> setUp [
 	super setUp.
 	model := self rbModelForVariableTest
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddInstanceVariableParametrizedTest >> testAddInstanceVariable [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments:
@@ -33,7 +35,7 @@ RBAddInstanceVariableParametrizedTest >> testAddInstanceVariable [
 		directlyDefinesInstanceVariable: 'asdf')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddInstanceVariableParametrizedTest >> testAddToModel [
 	| refactoring |
 	model := RBNamespace new.
@@ -51,7 +53,7 @@ RBAddInstanceVariableParametrizedTest >> testAddToModel [
 		directlyDefinesInstanceVariable: 'asdf')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddInstanceVariableParametrizedTest >> testInvalidVariableName [
 
 	self shouldFail: (self createRefactoringWithArguments:

--- a/src/Refactoring2-Transformations-Tests/RBAddInstanceVariableRefactoringTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddInstanceVariableRefactoringTest.class.st
@@ -1,17 +1,19 @@
 Class {
-	#name : #RBAddInstanceVariableRefactoringTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBAddInstanceVariableRefactoringTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 RBAddInstanceVariableRefactoringTest >> setUp [
 
 	super setUp.
 	model := self rbModelForVariableTest
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddInstanceVariableRefactoringTest >> testFailureAlreadyExistingName [
 
 	self shouldFail: (RBAddInstanceVariableRefactoring
@@ -22,7 +24,7 @@ RBAddInstanceVariableRefactoringTest >> testFailureAlreadyExistingName [
 			 class: #RBTransformationRuleTestData)
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddInstanceVariableRefactoringTest >> testFailureModelAlreadyExistingName [
 
 	self shouldFail: (RBAddInstanceVariableRefactoring
@@ -31,7 +33,7 @@ RBAddInstanceVariableRefactoringTest >> testFailureModelAlreadyExistingName [
 			 class: #Bar)
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddInstanceVariableRefactoringTest >> testFailureModelMetaclassAlreadyExistingName [
 
 	(model metaclassNamed: #Foo) addInstanceVariable: 'instVarName1'.
@@ -42,7 +44,7 @@ RBAddInstanceVariableRefactoringTest >> testFailureModelMetaclassAlreadyExisting
 			 class: #'Bar class')
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddInstanceVariableRefactoringTest >> testFailureNewExistingName [
 
 	| refactoring |
@@ -60,7 +62,7 @@ RBAddInstanceVariableRefactoringTest >> testFailureNewExistingName [
 	self shouldFail: refactoring
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddInstanceVariableRefactoringTest >> testFailureNewHierarchyExistingName [
 
 	| refactoring |

--- a/src/Refactoring2-Transformations-Tests/RBAddMessageSendTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddMessageSendTransformationTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBAddMessageSendTransformationTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBAddMessageSendTransformationTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RBAddMessageSendTransformationTest >> methodAfter [
 
 	| variable |
@@ -12,14 +14,14 @@ RBAddMessageSendTransformationTest >> methodAfter [
 	variable byteAt: 1
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RBAddMessageSendTransformationTest >> methodBefore [
 
 	| variable |
 	variable := 'String'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddMessageSendTransformationTest >> testClassDoesNotExist [
 
 	self shouldFail: (RBAddMessageSendTransformation
@@ -28,7 +30,7 @@ RBAddMessageSendTransformationTest >> testClassDoesNotExist [
 			 inClass: #RBMessageSendTransformationTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddMessageSendTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBAddMessageSendTransformation
@@ -37,7 +39,7 @@ RBAddMessageSendTransformationTest >> testMethodDoesNotExist [
 			 inClass: #RBAddMessageSendTransformationTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddMessageSendTransformationTest >> testReceiverDoesNotExist [
 
 	self shouldFail: (RBAddMessageSendTransformation
@@ -46,7 +48,7 @@ RBAddMessageSendTransformationTest >> testReceiverDoesNotExist [
 			 inClass: #RBAddMessageSendTransformationTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddMessageSendTransformationTest >> testRefactoring [
 
 	| refactoring class |
@@ -65,7 +67,7 @@ RBAddMessageSendTransformationTest >> testRefactoring [
 		equals: (class parseTreeForSelector: #methodAfter) body
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddMessageSendTransformationTest >> testTransform [
 
 	| transformation class |

--- a/src/Refactoring2-Transformations-Tests/RBAddMethodRefactoringTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddMethodRefactoringTest.class.st
@@ -1,17 +1,19 @@
 Class {
-	#name : #RBAddMethodRefactoringTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBAddMethodRefactoringTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 RBAddMethodRefactoringTest >> setUp [
 
 	super setUp.
 	model := self rbModelForVariableTest
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddMethodRefactoringTest >> testFailureExistingSelector [
 
 	self shouldFail: (RBAddMethodRefactoring
@@ -20,7 +22,7 @@ RBAddMethodRefactoringTest >> testFailureExistingSelector [
 			 withProtocol: #accessing)
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddMethodRefactoringTest >> testFailureModelExistingSelector [
 
 	self
@@ -36,7 +38,7 @@ RBAddMethodRefactoringTest >> testFailureModelExistingSelector [
 				 withProtocol: #accessing)
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddMethodRefactoringTest >> testFailureModelInheritedSelector [
 
 	| refactoring |

--- a/src/Refactoring2-Transformations-Tests/RBAddMethodTransformationParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddMethodTransformationParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBAddMethodTransformationParametrizedTest,
-	#superclass : #RBWithDifferentConstructorsParametrizedTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBAddMethodTransformationParametrizedTest',
+	#superclass : 'RBWithDifferentConstructorsParametrizedTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 RBAddMethodTransformationParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBAddMethodTransformation .
@@ -14,14 +16,14 @@ RBAddMethodTransformationParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBAddMethodTransformationParametrizedTest >> setUp [
 
 	super setUp.
 	model := self rbModelForVariableTest
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddMethodTransformationParametrizedTest >> testAddMethod [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments:
@@ -35,7 +37,7 @@ RBAddMethodTransformationParametrizedTest >> testAddMethod [
 		equals: (self parseMethod: 'printString1 ^super printString')
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddMethodTransformationParametrizedTest >> testFailureBadMethod [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -44,7 +46,7 @@ RBAddMethodTransformationParametrizedTest >> testFailureBadMethod [
 				 #( #accessing ) })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddMethodTransformationParametrizedTest >> testModelAddMethod [
 	| refactoring class |
 	class := model metaclassNamed: #Bar.

--- a/src/Refactoring2-Transformations-Tests/RBAddParameterParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddParameterParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBAddParameterParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBAddParameterParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddParameterParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBAddParameterTransformation };
@@ -13,18 +15,18 @@ RBAddParameterParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBAddParameterParametrizedTest >> constructor [
 	^ #addParameterToMethod:in:newSelector:permutation:newArgs:
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBAddParameterParametrizedTest >> setUp [
 	super setUp.
 	model := self rbModelForVariableTest
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddParameterParametrizedTest >> testAddParameterAndRenameParameters [
 	| oldSelector newSelector refactoring class newArg |
 	oldSelector := ('called:' , 'on:') asSymbol.
@@ -51,7 +53,7 @@ RBAddParameterParametrizedTest >> testAddParameterAndRenameParameters [
 	self deny: (class directlyDefinesMethod: oldSelector)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddParameterParametrizedTest >> testAddParameterForTwoArgumentMessage [
 	| oldSelector newSelector refactoring class newArg |
 	oldSelector := ('called:' , 'on:') asSymbol.
@@ -76,7 +78,7 @@ RBAddParameterParametrizedTest >> testAddParameterForTwoArgumentMessage [
 	self deny: (class directlyDefinesMethod: oldSelector)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddParameterParametrizedTest >> testAddParameterThatReferencesABlockWithInstanceVariableReference [
 
 	| refactoring class oldSelector newSelector newArg |
@@ -99,7 +101,7 @@ RBAddParameterParametrizedTest >> testAddParameterThatReferencesABlockWithInstan
 	self deny: (class directlyDefinesMethod: oldSelector)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddParameterParametrizedTest >> testAddParameterThatReferencesGlobalAndLiteral [
 
 	| refactoring class oldSelector newSelector newArg |
@@ -121,7 +123,7 @@ RBAddParameterParametrizedTest >> testAddParameterThatReferencesGlobalAndLiteral
 	self deny: (class directlyDefinesMethod: oldSelector)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddParameterParametrizedTest >> testAddParameterThatReferencesInstanceVariable [
 
 	| refactoring class oldSelector newSelector newArg |
@@ -144,7 +146,7 @@ RBAddParameterParametrizedTest >> testAddParameterThatReferencesInstanceVariable
 	self deny: (class directlyDefinesMethod: oldSelector)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddParameterParametrizedTest >> testAddParameterThatReferencesModelGlobal [
 
 	| refactoring class oldSelector newSelector newArg |
@@ -166,7 +168,7 @@ RBAddParameterParametrizedTest >> testAddParameterThatReferencesModelGlobal [
 	self deny: (class directlyDefinesMethod: oldSelector)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddParameterParametrizedTest >> testAddParameterThatReferencesSelf [
 
 	| refactoring class oldSelector newSelector newArg |
@@ -189,7 +191,7 @@ RBAddParameterParametrizedTest >> testAddParameterThatReferencesSelf [
 	self deny: (class directlyDefinesMethod: oldSelector)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddParameterParametrizedTest >> testAddTwoParameters [
 
 	| refactoring class oldSelector newSelector newArgs |
@@ -212,7 +214,7 @@ RBAddParameterParametrizedTest >> testAddTwoParameters [
 	self deny: (class directlyDefinesMethod: oldSelector)
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddParameterParametrizedTest >> testFailureBadDefaultValueForNewArgument [
 
 	| newArg |
@@ -233,7 +235,7 @@ RBAddParameterParametrizedTest >> testFailureBadDefaultValueForNewArgument [
 				 { newArg } })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddParameterParametrizedTest >> testFailureInvalidNumArgsOfNewSelector [
 
 	| newArg |
@@ -246,7 +248,7 @@ RBAddParameterParametrizedTest >> testFailureInvalidNumArgsOfNewSelector [
 				 { newArg } })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddParameterParametrizedTest >> testFailureModelBadInitializationCode [
 
 	| refactoring newArg |
@@ -265,7 +267,7 @@ RBAddParameterParametrizedTest >> testFailureModelBadInitializationCode [
 	self shouldFail: refactoring
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddParameterParametrizedTest >> testFailureModelNonExistantName [
 
 	| refactoring newArg |
@@ -282,7 +284,7 @@ RBAddParameterParametrizedTest >> testFailureModelNonExistantName [
 	self shouldFail: refactoring
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddParameterParametrizedTest >> testFailureNonExistantName [
 
 	| newArg |
@@ -295,7 +297,7 @@ RBAddParameterParametrizedTest >> testFailureNonExistantName [
 				 { newArg } })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddParameterParametrizedTest >> testFailurePrimitiveMethods [
 
 	| refactoring newArg |
@@ -321,7 +323,7 @@ RBAddParameterParametrizedTest >> testFailurePrimitiveMethods [
 	self shouldFail: refactoring
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddParameterParametrizedTest >> testFailureUseExistingNewSelector [
 
 	| newArg |

--- a/src/Refactoring2-Transformations-Tests/RBAddPragmaTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddPragmaTransformationTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBAddPragmaTransformationTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBAddPragmaTransformationTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RBAddPragmaTransformationTest >> methodAfter [
 	<pragmaForTesting: 56>
 
@@ -12,14 +14,14 @@ RBAddPragmaTransformationTest >> methodAfter [
 	variable := 'String'
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RBAddPragmaTransformationTest >> methodBefore [
 
 	| variable |
 	variable := 'String'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddPragmaTransformationTest >> testClassDoesNotExist [
 
 	self shouldFail: (RBAddPragmaTransformation
@@ -28,7 +30,7 @@ RBAddPragmaTransformationTest >> testClassDoesNotExist [
 			 inClass: #RBPragmaTransformationTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddPragmaTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBAddPragmaTransformation
@@ -37,7 +39,7 @@ RBAddPragmaTransformationTest >> testMethodDoesNotExist [
 			 inClass: #RBAddPragmaTransformationTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddPragmaTransformationTest >> testPragmaAlreadyExists [
 
 	self shouldFail: (RBAddPragmaTransformation
@@ -46,7 +48,7 @@ RBAddPragmaTransformationTest >> testPragmaAlreadyExists [
 			 inClass: #RBAddPragmaTransformationTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddPragmaTransformationTest >> testRefactoring [
 
 	| refactoring class |
@@ -64,7 +66,7 @@ RBAddPragmaTransformationTest >> testRefactoring [
 		equals: (class parseTreeForSelector: #methodAfter) body
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddPragmaTransformationTest >> testTransform [
 
 	| transformation class |

--- a/src/Refactoring2-Transformations-Tests/RBAddReturnStatementTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddReturnStatementTransformationTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBAddReturnStatementTransformationTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBAddReturnStatementTransformationTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RBAddReturnStatementTransformationTest >> methodAfter [
 
 	| variable |
@@ -12,14 +14,14 @@ RBAddReturnStatementTransformationTest >> methodAfter [
 	^ variable
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RBAddReturnStatementTransformationTest >> methodBefore [
 
 	| variable |
 	variable := 'String'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddReturnStatementTransformationTest >> testAccessIsNotDefined [
 
 	self shouldFail: (RBAddReturnStatementTransformation
@@ -28,7 +30,7 @@ RBAddReturnStatementTransformationTest >> testAccessIsNotDefined [
 			 inClass: #RBAddReturnStatementTransformationTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddReturnStatementTransformationTest >> testAlreadyDefinesReturn [
 
 	self shouldFail: (RBAddReturnStatementTransformation
@@ -37,7 +39,7 @@ RBAddReturnStatementTransformationTest >> testAlreadyDefinesReturn [
 			 inClass: #RBAddReturnStatementTransformationTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddReturnStatementTransformationTest >> testClassDoesNotExist [
 
 	self shouldFail: (RBAddReturnStatementTransformation
@@ -46,7 +48,7 @@ RBAddReturnStatementTransformationTest >> testClassDoesNotExist [
 			 inClass: #RBReturnStatementTransformationTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddReturnStatementTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBAddReturnStatementTransformation
@@ -55,7 +57,7 @@ RBAddReturnStatementTransformationTest >> testMethodDoesNotExist [
 			 inClass: #RBAddReturnStatementTransformationTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddReturnStatementTransformationTest >> testRefactoring [
 
 	| refactoring class |
@@ -74,7 +76,7 @@ RBAddReturnStatementTransformationTest >> testRefactoring [
 		equals: (class parseTreeForSelector: #methodAfter) body
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddReturnStatementTransformationTest >> testTransform [
 
 	| transformation class |

--- a/src/Refactoring2-Transformations-Tests/RBAddSubtreeTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddSubtreeTransformationTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBAddSubtreeTransformationTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBAddSubtreeTransformationTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddSubtreeTransformationTest >> testMethodDoesNotExist [
 	
 	self shouldFail: (RBAddSubtreeTransformation
@@ -14,7 +16,7 @@ RBAddSubtreeTransformationTest >> testMethodDoesNotExist [
 		in: self changeMockClass name)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddSubtreeTransformationTest >> testParseFailure [
 
 	self shouldFail: (RBAddSubtreeTransformation
@@ -24,7 +26,7 @@ RBAddSubtreeTransformationTest >> testParseFailure [
 		in: self changeMockClass name)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddSubtreeTransformationTest >> testRefactoring [
 
 	self
@@ -40,7 +42,7 @@ RBAddSubtreeTransformationTest >> testRefactoring [
 				 in: #RBRemoveMethodTransformation)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddSubtreeTransformationTest >> testTransform [
 
 	| transformation class |

--- a/src/Refactoring2-Transformations-Tests/RBAddTemporaryVariableParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddTemporaryVariableParametrizedTest.class.st
@@ -1,22 +1,24 @@
 Class {
-	#name : #RBAddTemporaryVariableParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#name : 'RBAddTemporaryVariableParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddTemporaryVariableParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBAddTemporaryVariableTransformation };
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBAddTemporaryVariableParametrizedTest >> constructor [
 	^ #variable:inMethod:inClass:
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddTemporaryVariableParametrizedTest >> testAddTemporaryRefactoring [
 
 	| refactoring class |
@@ -31,14 +33,14 @@ RBAddTemporaryVariableParametrizedTest >> testAddTemporaryRefactoring [
 	self assert: (class parseTreeForSelector: #methodBefore) temporaries size equals: 2
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddTemporaryVariableParametrizedTest >> testFailureClassDoesNotExist [
 
 	self shouldFail: (self createRefactoringWithArguments:
 			 { 'variable2'. #methodBefore. #RBReturnStatementTransformationTest })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddTemporaryVariableParametrizedTest >> testFailureMethodDoesNotExist [
 
 	self shouldFail: (self createRefactoringWithArguments:

--- a/src/Refactoring2-Transformations-Tests/RBAddVariableAccessorsParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddVariableAccessorsParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBAddVariableAccessorsParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBAddVariableAccessorsParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddVariableAccessorsParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBCreateAccessorsForVariableTransformation };
@@ -12,13 +14,13 @@ RBAddVariableAccessorsParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBAddVariableAccessorsParametrizedTest >> setUp [
 	super setUp.
 	model := self rbModelForVariableTest
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddVariableAccessorsParametrizedTest >> testExistingClassVariableAccessors [
 
 	| refactoring |
@@ -31,7 +33,7 @@ RBAddVariableAccessorsParametrizedTest >> testExistingClassVariableAccessors [
 	self assertEmpty: refactoring changes changes
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddVariableAccessorsParametrizedTest >> testExistingInstanceVariableAccessors [
 
 	| refactoring |
@@ -44,21 +46,21 @@ RBAddVariableAccessorsParametrizedTest >> testExistingInstanceVariableAccessors 
 	self assertEmpty: refactoring changes changes
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddVariableAccessorsParametrizedTest >> testFailureNonExistantClassVariable [
 
 	self shouldFail:
 		(rbClass classVariable: 'Foo' class: #RBBasicLintRuleTestData)
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddVariableAccessorsParametrizedTest >> testFailureNonExistantInstanceVariable [
 
 	self shouldFail:
 		(rbClass instanceVariable: 'foo' class: #RBBasicLintRuleTestData)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddVariableAccessorsParametrizedTest >> testNewClassVariableAccessors [
 
 	| refactoring class |
@@ -78,7 +80,7 @@ RBAddVariableAccessorsParametrizedTest >> testNewClassVariableAccessors [
 		equals: (self parseMethod: 'foo1: anObject Foo1 := anObject')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddVariableAccessorsParametrizedTest >> testNewInstanceVariableAccessors [
 
 	| refactoring class |

--- a/src/Refactoring2-Transformations-Tests/RBAddVariableAccessorsWithLazyInitializationParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddVariableAccessorsWithLazyInitializationParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBAddVariableAccessorsWithLazyInitializationParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBAddVariableAccessorsWithLazyInitializationParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddVariableAccessorsWithLazyInitializationParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBCreateLazyAccessorsForVariableTransformation };
@@ -12,18 +14,18 @@ RBAddVariableAccessorsWithLazyInitializationParametrizedTest class >> testParame
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBAddVariableAccessorsWithLazyInitializationParametrizedTest >> constructor [
 	^ #variable:class:classVariable:defaultValue:
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBAddVariableAccessorsWithLazyInitializationParametrizedTest >> setUp [
 	super setUp.
 	model := self rbModelForVariableTest
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddVariableAccessorsWithLazyInitializationParametrizedTest >> testExistingClassVariableAccessors [
 	| refactoring class |
 
@@ -37,7 +39,7 @@ RBAddVariableAccessorsWithLazyInitializationParametrizedTest >> testExistingClas
 		equals: (self parseMethod: 'name1 ^Name1 ifNil: [Name1 := nil]')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddVariableAccessorsWithLazyInitializationParametrizedTest >> testExistingInstanceVariableAccessors [
 	| refactoring class |
 	refactoring := self createRefactoringWithArguments:
@@ -50,7 +52,7 @@ RBAddVariableAccessorsWithLazyInitializationParametrizedTest >> testExistingInst
 		equals: (self parseMethod: 'name ^name ifNil: [name := nil]')
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddVariableAccessorsWithLazyInitializationParametrizedTest >> testFailureBadDefaultValueForNewArgument [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -60,7 +62,7 @@ RBAddVariableAccessorsWithLazyInitializationParametrizedTest >> testFailureBadDe
 				 'foo:' })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddVariableAccessorsWithLazyInitializationParametrizedTest >> testFailureBadInitializationCode1 [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -70,7 +72,7 @@ RBAddVariableAccessorsWithLazyInitializationParametrizedTest >> testFailureBadIn
 				 '''string' })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBAddVariableAccessorsWithLazyInitializationParametrizedTest >> testFailureNonExistantName [
 
 	self
@@ -86,7 +88,7 @@ RBAddVariableAccessorsWithLazyInitializationParametrizedTest >> testFailureNonEx
 						 nil })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddVariableAccessorsWithLazyInitializationParametrizedTest >> testNewClassVariableAccessors [
 	| ref class |
 	ref := self createRefactoringWithArguments:
@@ -99,7 +101,7 @@ RBAddVariableAccessorsWithLazyInitializationParametrizedTest >> testNewClassVari
 		or: [ (class parseTreeForSelector: #foo1:) = (self parseMethod: 'foo1: anObject Foo1 := anObject') ])
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBAddVariableAccessorsWithLazyInitializationParametrizedTest >> testNewInstanceVariableAccessors [
 	| ref class |
 	ref := self createRefactoringWithArguments:

--- a/src/Refactoring2-Transformations-Tests/RBChildrenToSiblingsParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBChildrenToSiblingsParametrizedTest.class.st
@@ -1,28 +1,30 @@
 Class {
-	#name : #RBChildrenToSiblingsParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#name : 'RBChildrenToSiblingsParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBChildrenToSiblingsParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBChildrenToSiblingsRefactoring };
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBChildrenToSiblingsParametrizedTest >> constructor [
 	^ #name:class:subclasses:
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBChildrenToSiblingsParametrizedTest >> setUp [
 	super setUp.
 	model := self childrenToSiblingTestData
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBChildrenToSiblingsParametrizedTest >> testFailureBadName [
 
 	self shouldFail: (self createRefactoringWithArguments:
@@ -31,7 +33,7 @@ RBChildrenToSiblingsParametrizedTest >> testFailureBadName [
 					with: RBCompositeLintRuleTestData)})
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBChildrenToSiblingsParametrizedTest >> testFailureExistingName [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -48,7 +50,7 @@ RBChildrenToSiblingsParametrizedTest >> testFailureExistingName [
 					  with: RBCompositeLintRuleTestData) })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBChildrenToSiblingsParametrizedTest >> testFailureInvalidSubclass [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -59,7 +61,7 @@ RBChildrenToSiblingsParametrizedTest >> testFailureInvalidSubclass [
 					  with: RBCompositeLintRuleTestData) })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBChildrenToSiblingsParametrizedTest >> testFailureMetaClassFailure [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -70,7 +72,7 @@ RBChildrenToSiblingsParametrizedTest >> testFailureMetaClassFailure [
 					  with: RBCompositeLintRuleTestData class) })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBChildrenToSiblingsParametrizedTest >> testModelChildrenToSibling [
 	| refactoring class subclass superclass |
 	class := model classNamed: #ConcreteSuperclass.

--- a/src/Refactoring2-Transformations-Tests/RBCopyPackageParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBCopyPackageParametrizedTest.class.st
@@ -1,17 +1,19 @@
 Class {
-	#name : #RBCopyPackageParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#name : 'RBCopyPackageParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 RBCopyPackageParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBCopyPackageRefactoring };
 		yourself
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBCopyPackageParametrizedTest >> addMethodWithRefTo: classRefName inClass: className [
 
 	(RBAddMethodTransformation
@@ -25,12 +27,12 @@ RBCopyPackageParametrizedTest >> addMethodWithRefTo: classRefName inClass: class
 		 withProtocol: #accessing ) execute
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBCopyPackageParametrizedTest >> constructor [
 	^ #copyPackage:in:
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBCopyPackageParametrizedTest >> createPackageNamed: packageName withClasses: aCollection [
 
 	self packageOrganizer ensurePackage: packageName.
@@ -45,13 +47,13 @@ RBCopyPackageParametrizedTest >> createPackageNamed: packageName withClasses: aC
 		refactoring execute ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBCopyPackageParametrizedTest >> removePackageNamed: packageName [
 
 	RPackageOrganizer default removePackageNamed: packageName
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBCopyPackageParametrizedTest >> setUp [
 	super setUp.
 	model := self defaultNamespaceClass new.
@@ -61,7 +63,7 @@ RBCopyPackageParametrizedTest >> setUp [
 	self addMethodWithRefTo: 'RBFTTest2' inClass: 'RBFTTest1'
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBCopyPackageParametrizedTest >> tearDown [
 
 	(RBRefactoryChangeFactory instance removePackageNamed: 'RefactoringSmallPackageForTest')
@@ -69,7 +71,7 @@ RBCopyPackageParametrizedTest >> tearDown [
 	super tearDown
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBCopyPackageParametrizedTest >> testCopyPackageAndChangesCopyReferences [
 	| refactoring aModel |
 
@@ -91,7 +93,7 @@ RBCopyPackageParametrizedTest >> testCopyPackageAndChangesCopyReferences [
 			^ BarFTTest2')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBCopyPackageParametrizedTest >> testCopyPackageWithParameters [
 	| refactoring aModel |
 
@@ -112,13 +114,13 @@ RBCopyPackageParametrizedTest >> testCopyPackageWithParameters [
 		description: 'It test that original class where we copied from is still there'
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBCopyPackageParametrizedTest >> testFailureBadName [
 	self shouldFail: (self createRefactoringWithArguments:
 		{#'Refactoring-Tests-Core' . #'Refactoring-Tests-Core'})
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBCopyPackageParametrizedTest >> testFailureExistingPackage [
 
 	self shouldFail: (self createRefactoringWithArguments:

--- a/src/Refactoring2-Transformations-Tests/RBDeprecateClassParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBDeprecateClassParametrizedTest.class.st
@@ -1,22 +1,24 @@
 Class {
-	#name : #RBDeprecateClassParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#name : 'RBDeprecateClassParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBDeprecateClassParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBDeprecateClassRefactoring };
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBDeprecateClassParametrizedTest >> constructor [
 	^ #deprecate:in:
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBDeprecateClassParametrizedTest >> testFailureBadName [
 	self shouldFail: (self createRefactoringWithArguments:
 		{ RBLintRuleTestData . self objectClassVariable }).
@@ -24,7 +26,7 @@ RBDeprecateClassParametrizedTest >> testFailureBadName [
 		{ RBLintRuleTestData . #'Ob ject' })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBDeprecateClassParametrizedTest >> testFailureMetaClassFailure [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -32,7 +34,7 @@ RBDeprecateClassParametrizedTest >> testFailureMetaClassFailure [
 				 #Foo })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBDeprecateClassParametrizedTest >> testModelRenameClass [
 	| refactoring replacement deprecated user |
 

--- a/src/Refactoring2-Transformations-Tests/RBDeprecateMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBDeprecateMethodParametrizedTest.class.st
@@ -1,22 +1,24 @@
 Class {
-	#name : #RBDeprecateMethodParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBDeprecateMethodParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 RBDeprecateMethodParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBDeprecateMethodTransformation };
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBDeprecateMethodParametrizedTest >> constructor [
 	^ #deprecateMethod:in:using:
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBDeprecateMethodParametrizedTest >> testDeprecateMethodUsingMethodWithSameNumberOfArgs [
 
 	| refactoring class oldSelector newSelector |
@@ -37,7 +39,7 @@ RBDeprecateMethodParametrizedTest >> testDeprecateMethodUsingMethodWithSameNumbe
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBDeprecateMethodParametrizedTest >> testDeprecateMethodUsingMethodWithoutArgs [
 
 	| refactoring class oldSelector newSelector |
@@ -56,7 +58,7 @@ RBDeprecateMethodParametrizedTest >> testDeprecateMethodUsingMethodWithoutArgs [
 			[ :e | e isMessage and: [ e selector = #deprecated:on:in: ] ])
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBDeprecateMethodParametrizedTest >> testValidateBogusNewSelector [
 
 	| refactoring oldSelector newSelector |
@@ -69,7 +71,7 @@ RBDeprecateMethodParametrizedTest >> testValidateBogusNewSelector [
 	self deny: refactoring preconditions check
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBDeprecateMethodParametrizedTest >> testValidateEmptyNewSelector [
 
 	| refactoring oldSelector newSelector |
@@ -82,7 +84,7 @@ RBDeprecateMethodParametrizedTest >> testValidateEmptyNewSelector [
 	self deny: refactoring preconditions check
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBDeprecateMethodParametrizedTest >> testValidateNewSelector [
 
 	| refactoring oldSelector newSelector |
@@ -95,7 +97,7 @@ RBDeprecateMethodParametrizedTest >> testValidateNewSelector [
 	self assert: refactoring preconditions check
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBDeprecateMethodParametrizedTest >> testValidateSameNewSelector [
 
 	| refactoring oldSelector newSelector |

--- a/src/Refactoring2-Transformations-Tests/RBExtractMethodAndOccurrencesParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBExtractMethodAndOccurrencesParametrizedTest.class.st
@@ -1,28 +1,30 @@
 Class {
-	#name : #RBExtractMethodAndOccurrencesParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#name : 'RBExtractMethodAndOccurrencesParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodAndOccurrencesParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBExtractMethodAndOccurrences };
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBExtractMethodAndOccurrencesParametrizedTest >> constructor [
 	^ #extract:from:in:
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBExtractMethodAndOccurrencesParametrizedTest >> setUp [
 	super setUp.
 	model := self rbModelForExtractMethodTest
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodAndOccurrencesParametrizedTest >> testExtractMethodWithTwoArgsAndOcurrences [
 	|class refactoring|
 	class := model classNamed: #MyClassA.
@@ -56,7 +58,7 @@ RBExtractMethodAndOccurrencesParametrizedTest >> testExtractMethodWithTwoArgsAnd
 	self stringArg: ''dfgdf'' streamArg: aStream')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodAndOccurrencesParametrizedTest >> testExtractSimpleMethodAndOcurrences [
 	|class refactoring|
 	class := model classNamed: #MyClassA.
@@ -105,7 +107,7 @@ RBExtractMethodAndOccurrencesParametrizedTest >> testExtractSimpleMethodAndOcurr
 	^ nil')
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBExtractMethodAndOccurrencesParametrizedTest >> testFailureBadInterval [
 	|class|
 	class := model classNamed: #MyClassA.

--- a/src/Refactoring2-Transformations-Tests/RBExtractMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBExtractMethodParametrizedTest.class.st
@@ -1,22 +1,24 @@
 Class {
-	#name : #RBExtractMethodParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#name : 'RBExtractMethodParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBExtractMethodRefactoring };
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBExtractMethodParametrizedTest >> constructor [
 	^ #extract:from:in:
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodParametrizedTest >> testExtractMethodAtEndOfMethodThatNeedsReturn [
 	| refactoring class |
 	refactoring := self createRefactoringWithArguments: {(52 to: 133) . #openEditor . RBLintRuleTestData }.
@@ -33,7 +35,7 @@ RBExtractMethodParametrizedTest >> testExtractMethodAtEndOfMethodThatNeedsReturn
 	rules size == 1 ifTrue: [^rules first viewResults]')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodParametrizedTest >> testExtractMethodThatMovesTemporaryVariable [
 	| refactoring class |
 	refactoring := self createRefactoringWithArguments: { (22 to: 280) . #superSends . RBTransformationRuleTestData }.
@@ -56,7 +58,7 @@ RBExtractMethodParametrizedTest >> testExtractMethodThatMovesTemporaryVariable [
 		^rule')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodParametrizedTest >> testExtractMethodThatNeedsArgument [
 	| refactoring class |
 	refactoring := self createRefactoringWithArguments: { (143 to: 340) . #checkMethod: . RBTransformationRuleTestData }.
@@ -75,7 +77,7 @@ RBExtractMethodParametrizedTest >> testExtractMethodThatNeedsArgument [
 						classified: aSmalllintContext protocols]')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodParametrizedTest >> testExtractMethodThatNeedsTemporaryVariable [
 	| refactoring class |
 	refactoring := self createRefactoringWithArguments: { (78 to: 197) . #displayName . RBLintRuleTestData }.
@@ -95,7 +97,7 @@ RBExtractMethodParametrizedTest >> testExtractMethodThatNeedsTemporaryVariable [
 	nameStream nextPut: $).')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodParametrizedTest >> testExtractMethodToSuperclass [
 	| refactoring class |
 	refactoring := self createRefactoringWithArguments: { (143 to: 340) . #checkMethod: . RBTransformationRuleTestData }.
@@ -117,7 +119,7 @@ RBExtractMethodParametrizedTest >> testExtractMethodToSuperclass [
 						classified: aSmalllintContext protocols]')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodParametrizedTest >> testExtractWithRenamingOfParameters [
 	| refactoring class |
 	refactoring := self createRefactoringWithArguments: { (78 to: 197) . #displayName . RBLintRuleTestData }.
@@ -150,7 +152,7 @@ RBExtractMethodParametrizedTest >> testExtractWithRenamingOfParameters [
 	newParameter nextPut: $).')
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBExtractMethodParametrizedTest >> testFailureBadInterval [
 	self shouldFail: (self createRefactoringWithArguments:
 		{ (24 to: 30) . #testMethod . RBClassDataForRefactoringTest }).
@@ -158,7 +160,7 @@ RBExtractMethodParametrizedTest >> testFailureBadInterval [
 		{ (80 to: 147) . #subclassOf:overrides: . RBBasicLintRuleTestData class })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBExtractMethodParametrizedTest >> testFailureExtract [
 	self shouldFail: (self createRefactoringWithArguments:
 		{ (80 to: 269) . #subclassOf:overrides: . RBBasicLintRuleTestData class }).
@@ -168,13 +170,13 @@ RBExtractMethodParametrizedTest >> testFailureExtract [
 		{ (77 to: 222) . #subclassResponsibilityNotDefined . RBBasicLintRuleTestData class })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBExtractMethodParametrizedTest >> testFailureNonExistantSelector [
 	self shouldFail: (self createRefactoringWithArguments:
 		{ (10 to: 20) . #checkClass1: . RBBasicLintRuleTestData })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodParametrizedTest >> testModelExtractMethodWithTemporariesSelected [
 	| class refactoring |
 	model := RBClassModelFactory rbNamespace new.
@@ -195,7 +197,7 @@ RBExtractMethodParametrizedTest >> testModelExtractMethodWithTemporariesSelected
 		equals: (self parseMethod: 'foobar |temp | temp := 5. ^temp * temp')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodParametrizedTest >> testModelExtractMethodWithTemporaryAssigned [
 	| class refactoring |
 	model := RBClassModelFactory rbNamespace new.
@@ -216,7 +218,7 @@ RBExtractMethodParametrizedTest >> testModelExtractMethodWithTemporaryAssigned [
 						parseMethod: 'foobar | temp bar | bar := 5. temp := bar * bar. Transcript show: temp printString; cr. ^temp.'))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodParametrizedTest >> testValidateRenameParameters [
 	| refactoring |
 	refactoring := self createRefactoringWithModel: model

--- a/src/Refactoring2-Transformations-Tests/RBExtractMethodToComponentParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBExtractMethodToComponentParametrizedTest.class.st
@@ -1,22 +1,24 @@
 Class {
-	#name : #RBExtractMethodToComponentParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#name : 'RBExtractMethodToComponentParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodToComponentParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBExtractMethodToComponentRefactoring };
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBExtractMethodToComponentParametrizedTest >> constructor [
 	^ #extract:from:in:
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodToComponentParametrizedTest >> testExtractMethodAtEndOfMethodThatNeedsReturn [
 	| refactoring class selectorsSize |
 	refactoring := self createRefactoringWithArguments: { (52 to: 133) . #openEditor . RBLintRuleTestData }.
@@ -49,7 +51,7 @@ RBExtractMethodToComponentParametrizedTest >> testExtractMethodAtEndOfMethodThat
 	self assert: class selectors size equals: selectorsSize
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBExtractMethodToComponentParametrizedTest >> testFailureBadInterval [
 	self shouldFail: (self createRefactoringWithArguments:
 		{ (24 to: 30) . #testMethod . RBClassDataForRefactoringTest }).
@@ -57,7 +59,7 @@ RBExtractMethodToComponentParametrizedTest >> testFailureBadInterval [
 		{ (80 to: 147) . #subclassOf:overrides: . RBBasicLintRuleTestData class })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBExtractMethodToComponentParametrizedTest >> testFailureExtract [
 	self shouldFail: (self createRefactoringWithArguments:
 		{(80 to: 269) . #subclassOf:overrides: . RBBasicLintRuleTestData class }).
@@ -67,13 +69,13 @@ RBExtractMethodToComponentParametrizedTest >> testFailureExtract [
 		{ (77 to: 222) . #subclassResponsibilityNotDefined . RBBasicLintRuleTestData class })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBExtractMethodToComponentParametrizedTest >> testFailureNonExistantSelector [
 	self shouldFail: (self createRefactoringWithArguments:
 		{ (10 to: 20) . #checkClass1: . RBBasicLintRuleTestData })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodToComponentParametrizedTest >> testMoveWithoutSelfReference [
 	| refactoring class selectorsSize |
 	refactoring := self createRefactoringWithArguments: { (118 to: 285) . #copyDictionary: . RBReadBeforeWrittenTester }.

--- a/src/Refactoring2-Transformations-Tests/RBExtractMethodTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBExtractMethodTransformationTest.class.st
@@ -1,17 +1,19 @@
 Class {
-	#name : #RBExtractMethodTransformationTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBExtractMethodTransformationTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #private }
+{ #category : 'private' }
 RBExtractMethodTransformationTest >> sourceCodeAt: anInterval forMethod: aSelector in: aClass [
 
 	^ (aClass sourceCodeAt: aSelector)
 		copyFrom: anInterval first to: anInterval last
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodTransformationTest >> testExtractUsingExistingMethodRefactoring [
 
 	| transformation class |
@@ -40,7 +42,7 @@ RBExtractMethodTransformationTest >> testExtractUsingExistingMethodRefactoring [
 	self deny: (class directlyDefinesMethod: #bar)
 ]
 
-{ #category : #'tests - failures' }
+{ #category : 'tests - failures' }
 RBExtractMethodTransformationTest >> testFailureBadInterval [
 
 	self shouldFail: (RBExtractMethodTransformation
@@ -55,7 +57,7 @@ RBExtractMethodTransformationTest >> testFailureBadInterval [
 							in: #'RBBasicLintRuleTestData class')
 ]
 
-{ #category : #'tests - failures' }
+{ #category : 'tests - failures' }
 RBExtractMethodTransformationTest >> testFailureExtract [
 
 	self shouldFail: (RBExtractMethodTransformation
@@ -86,7 +88,7 @@ RBExtractMethodTransformationTest >> testFailureExtract [
 			 in: #'RBBasicLintRuleTestData class')
 ]
 
-{ #category : #'tests - failures' }
+{ #category : 'tests - failures' }
 RBExtractMethodTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBExtractMethodTransformation
@@ -97,7 +99,7 @@ RBExtractMethodTransformationTest >> testMethodDoesNotExist [
 			
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodTransformationTest >> testNeedsReturn [
 
 	| refactoring class |
@@ -124,7 +126,7 @@ RBExtractMethodTransformationTest >> testNeedsReturn [
 				rules size == 1 ifTrue: [^rules first viewResults]')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodTransformationTest >> testRefactoring [
 
 	| transformation class |
@@ -160,7 +162,7 @@ RBExtractMethodTransformationTest >> testRefactoring [
 							classified: aSmalllintContext protocols ]')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodTransformationTest >> testTransform [
 
 	| transformation class |
@@ -202,7 +204,7 @@ RBExtractMethodTransformationTest >> testTransform [
 													^temp.')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodTransformationTest >> testWithArgument [
 
 	| refactoring class |
@@ -234,7 +236,7 @@ RBExtractMethodTransformationTest >> testWithArgument [
 										classified: aSmalllintContext protocols]')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodTransformationTest >> testWithTemporariesSelected [
 
 	| class refactoring |
@@ -260,7 +262,7 @@ RBExtractMethodTransformationTest >> testWithTemporariesSelected [
 		equals: (self parseMethod: 'foobar |temp | temp := 5. ^temp * temp')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodTransformationTest >> testWithTemporaryAssigned [
 
 	| class method refactoring |
@@ -292,7 +294,7 @@ RBExtractMethodTransformationTest >> testWithTemporaryAssigned [
 				 'foobar | temp bar | bar := 5. temp := bar * bar. Transcript show: temp printString; cr. ^temp.')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodTransformationTest >> testWithTemporaryVariable [
 
 	| refactoring class |
@@ -327,7 +329,7 @@ RBExtractMethodTransformationTest >> testWithTemporaryVariable [
 				^rule')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractMethodTransformationTest >> testWithTemporaryVariable2 [
 
 	| refactoring class |

--- a/src/Refactoring2-Transformations-Tests/RBExtractSetUpMethodAndOccurrencesParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBExtractSetUpMethodAndOccurrencesParametrizedTest.class.st
@@ -1,22 +1,24 @@
 Class {
-	#name : #RBExtractSetUpMethodAndOccurrencesParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#name : 'RBExtractSetUpMethodAndOccurrencesParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractSetUpMethodAndOccurrencesParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBExtractSetUpMethodAndOccurrences };
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBExtractSetUpMethodAndOccurrencesParametrizedTest >> constructor [
 	^ #extract:from:in:
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractSetUpMethodAndOccurrencesParametrizedTest >> testExtractSimpleMethodAndOcurrences [
 	|class refactoring|
 	refactoring := self createRefactoringWithArguments: { (15+12 to: 59+12) . #testExtractSetupExample1 . RBTestAsDataForExtractSetupTransformationTest }.
@@ -47,7 +49,7 @@ RBExtractSetUpMethodAndOccurrencesParametrizedTest >> testExtractSimpleMethodAnd
 		self deny: false')
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBExtractSetUpMethodAndOccurrencesParametrizedTest >> testFailureBadInterval [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments: { (36 to: 56) . #testExtractSetupExample1 . RBTestAsDataForExtractSetupTransformationTest }.
@@ -55,7 +57,7 @@ RBExtractSetUpMethodAndOccurrencesParametrizedTest >> testFailureBadInterval [
 	self shouldFail: refactoring
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBExtractSetUpMethodAndOccurrencesParametrizedTest >> testFailureBadMethodName [
 
 	| refactoring |

--- a/src/Refactoring2-Transformations-Tests/RBExtractSetUpMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBExtractSetUpMethodParametrizedTest.class.st
@@ -1,22 +1,24 @@
 Class {
-	#name : #RBExtractSetUpMethodParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#name : 'RBExtractSetUpMethodParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractSetUpMethodParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBExtractSetUpMethodRefactoring };
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBExtractSetUpMethodParametrizedTest >> constructor [
 	^ #extract:from:in:
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractSetUpMethodParametrizedTest >> testExtractSetUp [
 	| class refactoring |
 	refactoring := self createRefactoringWithArguments: { (14+12 to: 29+12) . #testExtractSetupExample5 . RBTestAsDataForExtractSetupTransformationTest}.
@@ -36,7 +38,7 @@ RBExtractSetUpMethodParametrizedTest >> testExtractSetUp [
 	self someMethod')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractSetUpMethodParametrizedTest >> testExtractSetUpAndConvertTempsToInstVars [
 	| class refactoring |
 	refactoring := self createRefactoringWithArguments: { (35+12  to: 81+12) . #testExtractSetupExample6 . RBTestAsDataForExtractSetupTransformationTest }.
@@ -71,7 +73,7 @@ RBExtractSetUpMethodParametrizedTest >> testExtractSetUpAndConvertTempsToInstVar
 	self someMethod.')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractSetUpMethodParametrizedTest >> testExtractSetUpAndConvertTwoTempsToInstVars [
 	| class refactoring |
 	self skip.
@@ -111,7 +113,7 @@ RBExtractSetUpMethodParametrizedTest >> testExtractSetUpAndConvertTwoTempsToInst
 	aNumber := 4')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractSetUpMethodParametrizedTest >> testExtractSetUpWorksWellInOtherMethod [
 	| class refactoring |
 	self skip.
@@ -163,7 +165,7 @@ RBExtractSetUpMethodParametrizedTest >> testExtractSetUpWorksWellInOtherMethod [
 	self someMethod.')
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBExtractSetUpMethodParametrizedTest >> testFailureBadClass [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -172,13 +174,13 @@ RBExtractSetUpMethodParametrizedTest >> testFailureBadClass [
 				 RBLintRuleTestData })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBExtractSetUpMethodParametrizedTest >> testFailureBadInterval [
 	self shouldFail: (self createRefactoringWithArguments:
 		{ (14 to: 35) . #testExtractSetupExample1 . RBTestAsDataForExtractSetupTransformationTest })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBExtractSetUpMethodParametrizedTest >> testFailureExtractSetUpWhenIsNotFirstsSentences [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -187,7 +189,7 @@ RBExtractSetUpMethodParametrizedTest >> testFailureExtractSetUpWhenIsNotFirstsSe
 				 RBTestAsDataForExtractSetupTransformationTest })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBExtractSetUpMethodParametrizedTest >> testFailureModelExistingSetUpMethod [
 
 	| class |

--- a/src/Refactoring2-Transformations-Tests/RBExtractToTemporaryParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBExtractToTemporaryParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBExtractToTemporaryParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBExtractToTemporaryParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractToTemporaryParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBExtractToTemporaryRefactoring };
@@ -12,12 +14,12 @@ RBExtractToTemporaryParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBExtractToTemporaryParametrizedTest >> constructor [
 	^ #extract:to:from:in:
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractToTemporaryParametrizedTest >> testExtractToTemporaryForLastStatementInBlock [
 	| refactoring methodName |
 	methodName := #caller2.
@@ -29,7 +31,7 @@ RBExtractToTemporaryParametrizedTest >> testExtractToTemporaryForLastStatementIn
 	^(1 to: 10) inject: 1 into: [:sum :each | | temp | temp := sum * (self foo: each). temp]')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractToTemporaryParametrizedTest >> testExtractToTemporaryInsideBlock [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments:
@@ -45,7 +47,7 @@ RBExtractToTemporaryParametrizedTest >> testExtractToTemporaryInsideBlock [
 		select: [:each | | asdf | asdf := each size. temp := asdf + temp]')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractToTemporaryParametrizedTest >> testExtractToTemporaryWithDuplicates [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments:
@@ -62,7 +64,7 @@ RBExtractToTemporaryParametrizedTest >> testExtractToTemporaryWithDuplicates [
 	^ answer')
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBExtractToTemporaryParametrizedTest >> testFailureBadInterval [
 	self shouldFail:
 		(self createRefactoringWithArguments:
@@ -75,14 +77,14 @@ RBExtractToTemporaryParametrizedTest >> testFailureBadInterval [
 			{ (61 to: 101) . 'asdf' . #noMoveDefinition . RBClassDataForRefactoringTest })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBExtractToTemporaryParametrizedTest >> testFailureBadName [
 	self shouldFail:
 		(self createRefactoringWithArguments:
 			{ (14 to: 23) . 'a sdf' . #testMethod . RBClassDataForRefactoringTest })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBExtractToTemporaryParametrizedTest >> testFailureNoValidNameOfTemp [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -92,7 +94,7 @@ RBExtractToTemporaryParametrizedTest >> testFailureNoValidNameOfTemp [
 				 RBClassDataForRefactoringTest })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBExtractToTemporaryParametrizedTest >> testFailureNonExistantSelector [
 	self shouldFail:
 		( self createRefactoringWithArguments:

--- a/src/Refactoring2-Transformations-Tests/RBFindAndReplaceParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBFindAndReplaceParametrizedTest.class.st
@@ -1,28 +1,30 @@
 Class {
-	#name : #RBFindAndReplaceParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#name : 'RBFindAndReplaceParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 RBFindAndReplaceParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBFindAndReplaceTransformation };
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBFindAndReplaceParametrizedTest >> constructor [
 	^ #find:of:inWholeHierarchy:
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBFindAndReplaceParametrizedTest >> setUp [
 	super setUp.
 	model := self rbModelForExtractMethodTest
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBFindAndReplaceParametrizedTest >> testFailureBadSelector [
 	|class|
 	class := model classNamed: #MyClassA.
@@ -30,7 +32,7 @@ RBFindAndReplaceParametrizedTest >> testFailureBadSelector [
 		andArguments: { #unexitingMethod . class . true })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBFindAndReplaceParametrizedTest >> testFailureFindOcurrencesInHierarchy [
 	|class refactoring|
 	class := model classNamed: #MyClassA.
@@ -47,7 +49,7 @@ RBFindAndReplaceParametrizedTest >> testFailureFindOcurrencesInHierarchy [
 	self shouldFail: refactoring
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBFindAndReplaceParametrizedTest >> testFindOcurrencesInClass [
 
 	| class refactoring |
@@ -97,7 +99,7 @@ RBFindAndReplaceParametrizedTest >> testFindOcurrencesInClass [
 	^ nil')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBFindAndReplaceParametrizedTest >> testFindOcurrencesInHierarchy [
 	| class refactoring |
 	class := model classNamed: #MyClassA.
@@ -138,7 +140,7 @@ RBFindAndReplaceParametrizedTest >> testFindOcurrencesInHierarchy [
 	^ nil')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBFindAndReplaceParametrizedTest >> testFindOcurrencesWithArgInHierarchy [
 	|class refactoring|
 	class := model classNamed: #MyClassA.

--- a/src/Refactoring2-Transformations-Tests/RBFindAndReplaceSetUpParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBFindAndReplaceSetUpParametrizedTest.class.st
@@ -1,29 +1,31 @@
 Class {
-	#name : #RBFindAndReplaceSetUpParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#name : 'RBFindAndReplaceSetUpParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 RBFindAndReplaceSetUpParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBFindAndReplaceSetUpTransformation };
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBFindAndReplaceSetUpParametrizedTest >> constructor [
 	^ #of:inWholeHierarchy:
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBFindAndReplaceSetUpParametrizedTest >> testClassDoesNotDefineSetUpMethod [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments: { RBTestAsDataForExtractSetupTransformationTest . true }.
 	self shouldFail: refactoring
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBFindAndReplaceSetUpParametrizedTest >> testReplaceSetUp [
 	| class refactoring |
 	refactoring := self createRefactoringWithArguments: { RBTestAsDataForExtractSetupTransformationTest . true }.

--- a/src/Refactoring2-Transformations-Tests/RBInlineAllMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBInlineAllMethodParametrizedTest.class.st
@@ -1,22 +1,24 @@
 Class {
-	#name : #RBInlineAllMethodParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#name : 'RBInlineAllMethodParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineAllMethodParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBInlineAllSendersRefactoring };
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBInlineAllMethodParametrizedTest >> constructor [
 	^ #sendersOf:in:
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBInlineAllMethodParametrizedTest >> testFailureInlineMethodCanNotUnderstandSelectorInClass [
 
 	| refactoring |
@@ -26,7 +28,7 @@ RBInlineAllMethodParametrizedTest >> testFailureInlineMethodCanNotUnderstandSele
 	self shouldFail: refactoring
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineAllMethodParametrizedTest >> testInlineMethodCalledAsSuper [
 	| class superclass |
 	model := RBClassModelFactory rbNamespace new.
@@ -40,7 +42,7 @@ RBInlineAllMethodParametrizedTest >> testInlineMethodCalledAsSuper [
 			equals: (self parseMethod: 'foo: arg1 bar: arg2 ^ (arg1 + arg2) - arg1')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineAllMethodParametrizedTest >> testInlineMethodWithMultipleArgs [
 	| class |
 	model := RBClassModelFactory rbNamespace new.
@@ -58,7 +60,7 @@ RBInlineAllMethodParametrizedTest >> testInlineMethodWithMultipleArgs [
 	^ 5 + 7')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineAllMethodParametrizedTest >> testInlineMethodWithMultipleSendersInMethod [
 	| refactoring methodName |
 	methodName := #caller2.
@@ -72,7 +74,7 @@ RBInlineAllMethodParametrizedTest >> testInlineMethodWithMultipleSendersInMethod
 	(1 to: 10) inject: 1 into: [:sum1 :each1 | sum1 * (self foo: each1)]')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineAllMethodParametrizedTest >> testRecursiveMethod [
 	| class |
 	model := RBClassModelFactory rbNamespace new.

--- a/src/Refactoring2-Transformations-Tests/RBInlineMethodFromComponentParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBInlineMethodFromComponentParametrizedTest.class.st
@@ -1,22 +1,24 @@
 Class {
-	#name : #RBInlineMethodFromComponentParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#name : 'RBInlineMethodFromComponentParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineMethodFromComponentParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBInlineMethodFromComponentRefactoring };
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBInlineMethodFromComponentParametrizedTest >> constructor [
 	^ #inline:inMethod:forClass:
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBInlineMethodFromComponentParametrizedTest >> testFailureInlineMethodFromComponentFailure [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -25,7 +27,7 @@ RBInlineMethodFromComponentParametrizedTest >> testFailureInlineMethodFromCompon
 				 RBClassDataForRefactoringTest })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineMethodFromComponentParametrizedTest >> testInlineComponentIntoCascadedMessage [
 	| refactoring |
 	self proceedThroughWarning:
@@ -49,7 +51,7 @@ RBInlineMethodFromComponentParametrizedTest >> testInlineComponentIntoCascadedMe
 	^aBehavior yourself')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineMethodFromComponentParametrizedTest >> testInlineComponentMethodMax [
 	| refactoring |
 	self proceedThroughWarning: [ | class |
@@ -81,7 +83,7 @@ RBInlineMethodFromComponentParametrizedTest >> testInlineComponentMethodMax [
 								^q')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineMethodFromComponentParametrizedTest >> testInlineEmptyComponentMethod [
 	| refactoring |
 
@@ -107,7 +109,7 @@ RBInlineMethodFromComponentParametrizedTest >> testInlineEmptyComponentMethod [
 	^anObject')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineMethodFromComponentParametrizedTest >> testModelInlineMethodWithSameVariableNames [
 	| class refactoring |
 	model := RBClassModelFactory rbNamespace new.
@@ -126,7 +128,7 @@ RBInlineMethodFromComponentParametrizedTest >> testModelInlineMethodWithSameVari
 						parseMethod: 'foo | a b c | a := InlineMethodFromComponentTest new. b := 1. c := 2. ^a + b + c')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineMethodFromComponentParametrizedTest >> testModelInlineMethodWithSameVariableNames1 [
 	| class refactoring |
 	model := RBClassModelFactory rbNamespace new.
@@ -148,7 +150,7 @@ RBInlineMethodFromComponentParametrizedTest >> testModelInlineMethodWithSameVari
 						parseMethod: 'foo | aRectangle temp | aRectangle := 0@0 corner: 1@1. temp := aRectangle. ^aRectangle origin extent: temp extent')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineMethodFromComponentParametrizedTest >> testModelInlineMethodWithSameVariableNames2 [
 	| class refactoring |
 	model := RBClassModelFactory rbNamespace new.

--- a/src/Refactoring2-Transformations-Tests/RBInlineMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBInlineMethodParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBInlineMethodParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBInlineMethodParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineMethodParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBInlineMethodRefactoring };
@@ -12,12 +14,12 @@ RBInlineMethodParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBInlineMethodParametrizedTest >> constructor [
 	^ #inline:inMethod:forClass:
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBInlineMethodParametrizedTest >> testFailureBadInterval [
 	self shouldFail:
 		(self createRefactoringWithArguments: { (13 to: 23) . #testMethod . RBClassDataForRefactoringTest }).
@@ -29,7 +31,7 @@ RBInlineMethodParametrizedTest >> testFailureBadInterval [
 		(self createRefactoringWithArguments: { (1 to: 30) . #testMethod . RBClassDataForRefactoringTest })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBInlineMethodParametrizedTest >> testFailureInlineMethodForSuperSendThatAlsoSendsSuper [
 
 	| refactoring |
@@ -41,13 +43,13 @@ RBInlineMethodParametrizedTest >> testFailureInlineMethodForSuperSendThatAlsoSen
 	self shouldFail: refactoring
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBInlineMethodParametrizedTest >> testFailureNonExistantSelector [
 	self shouldFail: (self createRefactoringWithArguments:
 		{ (14 to: 17) . #checkClass1: . RBClassDataForRefactoringTest })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBInlineMethodParametrizedTest >> testFailureOverriden [
 
 	self shouldWarn: (self createRefactoringWithArguments: {
@@ -56,7 +58,7 @@ RBInlineMethodParametrizedTest >> testFailureOverriden [
 				 RBLintRuleTestData })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBInlineMethodParametrizedTest >> testFailurePrimitive [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -65,7 +67,7 @@ RBInlineMethodParametrizedTest >> testFailurePrimitive [
 				 RBClassDataForRefactoringTest })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBInlineMethodParametrizedTest >> testFailureReturn [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -74,7 +76,7 @@ RBInlineMethodParametrizedTest >> testFailureReturn [
 				 RBBasicLintRuleTestData class })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineMethodParametrizedTest >> testInlineMethod [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments:
@@ -122,7 +124,7 @@ RBInlineMethodParametrizedTest >> testInlineMethod [
 									^detector')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineMethodParametrizedTest >> testInlineMethod1 [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments:
@@ -142,7 +144,7 @@ RBInlineMethodParametrizedTest >> testInlineMethod1 [
 	^ anObject')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineMethodParametrizedTest >> testInlineMethod2 [
 	| refactoring methodName |
 	methodName := #caller1.
@@ -164,7 +166,7 @@ RBInlineMethodParametrizedTest >> testInlineMethod2 [
 	^ anObject ] value: each1')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineMethodParametrizedTest >> testInlineMethod3 [
 	| refactoring methodName |
 	methodName := #caller2.
@@ -178,7 +180,7 @@ RBInlineMethodParametrizedTest >> testInlineMethod3 [
 								^(1 to: 10) inject: 1 into: [:sum :each | sum * ((1 to: 10) inject: each into: [:sum1 :each1 | sum1 + each1])]	')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineMethodParametrizedTest >> testInlineMethod4 [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments:
@@ -204,7 +206,7 @@ RBInlineMethodParametrizedTest >> testInlineMethod4 [
 												baz * baz]')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineMethodParametrizedTest >> testInlineMethod5 [
 	| refactoring |
 
@@ -216,7 +218,7 @@ RBInlineMethodParametrizedTest >> testInlineMethod5 [
 									5 = 3 ifTrue: [^self caller] ifFalse: [^	(1 to: 10) inject: 1 into: [:sum :each | sum * (self foo: each)]]')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineMethodParametrizedTest >> testInlineMethodForSuperSend [
 	| refactoring |
 	model := self rbModelForInliningMethodTest.
@@ -241,7 +243,7 @@ RBInlineMethodParametrizedTest >> testInlineMethodForSuperSend [
 									^undo')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineMethodParametrizedTest >> testInlineRecursiveCascadedMethod [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments:
@@ -257,7 +259,7 @@ RBInlineMethodParametrizedTest >> testInlineRecursiveCascadedMethod [
 									^temp')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineMethodParametrizedTest >> testModelInlineRecursiveMethod [
 	| refactoring class |
 	class := model classNamed: #Object.

--- a/src/Refactoring2-Transformations-Tests/RBInlineParameterParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBInlineParameterParametrizedTest.class.st
@@ -1,22 +1,24 @@
 Class {
-	#name : #RBInlineParameterParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#name : 'RBInlineParameterParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineParameterParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBInlineParameterRefactoring };
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBInlineParameterParametrizedTest >> constructor [
 	^ #inlineParameter:in:selector:
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBInlineParameterParametrizedTest >> testFailureInlineArgsWhitoutSameLiteral [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -25,7 +27,7 @@ RBInlineParameterParametrizedTest >> testFailureInlineArgsWhitoutSameLiteral [
 				 ('inline' , 'Bar:') asSymbol })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBInlineParameterParametrizedTest >> testFailureInlineBlockFailure [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -34,7 +36,7 @@ RBInlineParameterParametrizedTest >> testFailureInlineBlockFailure [
 				 ('inline' , 'Foo:') asSymbol })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineParameterParametrizedTest >> testInlineLiteralArray [
 	| refactoring class |
 	refactoring := self createRefactoringWithArguments:

--- a/src/Refactoring2-Transformations-Tests/RBInlineTemporaryParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBInlineTemporaryParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBInlineTemporaryParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBInlineTemporaryParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineTemporaryParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBInlineTemporaryRefactoring };
@@ -12,12 +14,12 @@ RBInlineTemporaryParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBInlineTemporaryParametrizedTest >> constructor [
 	^ #inline:from:in:
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBInlineTemporaryParametrizedTest >> testFailureInlineTemporaryBadInterval [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -26,7 +28,7 @@ RBInlineTemporaryParametrizedTest >> testFailureInlineTemporaryBadInterval [
 				 RBClassDataForRefactoringTest })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBInlineTemporaryParametrizedTest >> testFailureInlineTemporaryMutlipleAssignment [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -35,7 +37,7 @@ RBInlineTemporaryParametrizedTest >> testFailureInlineTemporaryMutlipleAssignmen
 				 RBClassDataForRefactoringTest })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBInlineTemporaryParametrizedTest >> testFailureInlineTemporaryReadBeforeWritten [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -44,7 +46,7 @@ RBInlineTemporaryParametrizedTest >> testFailureInlineTemporaryReadBeforeWritten
 				 RBClassDataForRefactoringTest })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInlineTemporaryParametrizedTest >> testInlineTemporary [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments:

--- a/src/Refactoring2-Transformations-Tests/RBInsertClassParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBInsertClassParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBInsertClassParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBInsertClassParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInsertClassParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBInsertNewClassRefactoring };
@@ -12,19 +14,19 @@ RBInsertClassParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBInsertClassParametrizedTest >> constructor [
 	^ #addClass:superclass:subclasses:category:
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBInsertClassParametrizedTest >> setUp [
 
 	super setUp.
 	model := self rbModelForVariableTest
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBInsertClassParametrizedTest >> testFailureEmptyCategory [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -34,7 +36,7 @@ RBInsertClassParametrizedTest >> testFailureEmptyCategory [
 				 #'' })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBInsertClassParametrizedTest >> testFailureExistingClassName [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -44,7 +46,7 @@ RBInsertClassParametrizedTest >> testFailureExistingClassName [
 				 #'Refactory-Testing' })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBInsertClassParametrizedTest >> testFailureModelExistingClassName [
 
 	self shouldFail:
@@ -55,7 +57,7 @@ RBInsertClassParametrizedTest >> testFailureModelExistingClassName [
 				 #'Refactory-Testing' })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBInsertClassParametrizedTest >> testFailureModelInvalidSubclass [
 
 	self shouldFail:
@@ -66,7 +68,7 @@ RBInsertClassParametrizedTest >> testFailureModelInvalidSubclass [
 				 #'Refactory-Tesing' })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBInsertClassParametrizedTest >> testFailureModelNonImmediateSubclassOfSuperclass [
 
 	| refactoring |
@@ -81,7 +83,7 @@ RBInsertClassParametrizedTest >> testFailureModelNonImmediateSubclassOfSuperclas
 	self shouldFail: refactoring
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBInsertClassParametrizedTest >> testFailureNonImmediateSubclassOfSuperclass [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -91,7 +93,7 @@ RBInsertClassParametrizedTest >> testFailureNonImmediateSubclassOfSuperclass [
 				 #'Refactory-Tesing' })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBInsertClassParametrizedTest >> testFailureSubclassIsMetaslass [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -101,7 +103,7 @@ RBInsertClassParametrizedTest >> testFailureSubclassIsMetaslass [
 				 #'Refactory-Tesing' })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBInsertClassParametrizedTest >> testFailureSuperclassIsMetaclass [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -111,7 +113,7 @@ RBInsertClassParametrizedTest >> testFailureSuperclassIsMetaclass [
 				 #'Refactory-Testing' })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInsertClassParametrizedTest >> testInsertClassWithinExistingHiearchy [
 	| refactoring insertedClass parentOfInsertedClass childOfInsertedClass |
 
@@ -141,7 +143,7 @@ RBInsertClassParametrizedTest >> testInsertClassWithinExistingHiearchy [
 	self assert: (insertedClass classSide subclasses includes: childOfInsertedClass classSide)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBInsertClassParametrizedTest >> testModelInsertClass [
 	| refactoring insertedClass superClass subclass |
 	superClass := model classNamed: #Foo.

--- a/src/Refactoring2-Transformations-Tests/RBMakeClassAbstractParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMakeClassAbstractParametrizedTest.class.st
@@ -1,20 +1,22 @@
 Class {
-	#name : #RBMakeClassAbstractParametrizedTest,
-	#superclass : #RBWithDifferentConstructorsParametrizedTest,
+	#name : 'RBMakeClassAbstractParametrizedTest',
+	#superclass : 'RBWithDifferentConstructorsParametrizedTest',
 	#instVars : [
 		'testClass'
 	],
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMakeClassAbstractParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBMakeClassAbstractTransformation };
 		yourself
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBMakeClassAbstractParametrizedTest >> setUp [
 	super setUp.
 	model := self rbModelForVariableTest.
@@ -23,14 +25,14 @@ RBMakeClassAbstractParametrizedTest >> setUp [
 	testClass class removeSelector: #isAbstract
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBMakeClassAbstractParametrizedTest >> tearDown [
 
 	testClass class removeSelector: #isAbstract.
 	super tearDown
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMakeClassAbstractParametrizedTest >> testMakeClassAbstractAddsIsAbstractMethodToClassSide [
 	| refactoring |
 	refactoring := rbClass class: testClass.
@@ -41,7 +43,7 @@ RBMakeClassAbstractParametrizedTest >> testMakeClassAbstractAddsIsAbstractMethod
 		equals: (self parseMethod: 'isAbstract ^self == ', testClass name)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMakeClassAbstractParametrizedTest >> testMakeClassAbstractPerformChanges [
 	"This test checks if actually performing refactoring applies the changes
 	since model needs to be set correctly. There was a regression when model

--- a/src/Refactoring2-Transformations-Tests/RBMergeInstanceVariableIntoAnotherParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMergeInstanceVariableIntoAnotherParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBMergeInstanceVariableIntoAnotherParametrizedTest,
-	#superclass : #RBWithDifferentConstructorsParametrizedTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBMergeInstanceVariableIntoAnotherParametrizedTest',
+	#superclass : 'RBWithDifferentConstructorsParametrizedTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMergeInstanceVariableIntoAnotherParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBMergeInstanceVariableIntoAnother .
@@ -14,7 +16,7 @@ RBMergeInstanceVariableIntoAnotherParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBMergeInstanceVariableIntoAnotherParametrizedTest >> testFailureEqualsVariables [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -23,7 +25,7 @@ RBMergeInstanceVariableIntoAnotherParametrizedTest >> testFailureEqualsVariables
 				 RBBasicLintRuleTestData })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBMergeInstanceVariableIntoAnotherParametrizedTest >> testFailureNonExistingVariable [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -32,7 +34,7 @@ RBMergeInstanceVariableIntoAnotherParametrizedTest >> testFailureNonExistingVari
 				 RBBasicLintRuleTestData })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMergeInstanceVariableIntoAnotherParametrizedTest >> testReplaceVariableIntoAnother [
 	| refactoring class |
 	refactoring := self createRefactoringWithArguments:
@@ -44,7 +46,7 @@ RBMergeInstanceVariableIntoAnotherParametrizedTest >> testReplaceVariableIntoAno
 	self assert: (class whichSelectorsReferToInstanceVariable: 'classBlock') isEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMergeInstanceVariableIntoAnotherParametrizedTest >> testReplaceVariableIntoSupeclassVariable [
 	| refactoring class |
 	refactoring := self createRefactoringWithArguments:

--- a/src/Refactoring2-Transformations-Tests/RBMethodProtocolTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMethodProtocolTransformationTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBMethodProtocolTransformationTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBMethodProtocolTransformationTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMethodProtocolTransformationTest >> testClassDoesNotExist [
 
 	self shouldFail: (RBMethodProtocolTransformation
@@ -13,7 +15,7 @@ RBMethodProtocolTransformationTest >> testClassDoesNotExist [
 			 inClass: #RBDummyEmptyClass123)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMethodProtocolTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBMethodProtocolTransformation
@@ -22,7 +24,7 @@ RBMethodProtocolTransformationTest >> testMethodDoesNotExist [
 			 inClass: #RBDummyEmptyClass)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMethodProtocolTransformationTest >> testRefactoring [
 
 	| refactoring |
@@ -46,7 +48,7 @@ RBMethodProtocolTransformationTest >> testRefactoring [
 	self deny: (RBDummyEmptyClass hasProtocol: 'empty protocol 2')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMethodProtocolTransformationTest >> testTransform [
 
 	| transformation |

--- a/src/Refactoring2-Transformations-Tests/RBMoveClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveClassTransformationTest.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #RBMoveClassTransformationTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBMoveClassTransformationTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMoveClassTransformationTest >> testBadPackageName [
 
 	self shouldFail: (RBMoveClassTransformation move: self class name toPackage: #'Refactoring2-Transformations-Test')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMoveClassTransformationTest >> testRefactoring [
 
 	| transformation class |
@@ -24,7 +26,7 @@ RBMoveClassTransformationTest >> testRefactoring [
 	self assert: class category equals: #'Refactoring2-Transformations-Utilities'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMoveClassTransformationTest >> testTransform [
 
 	| transformation class |

--- a/src/Refactoring2-Transformations-Tests/RBMoveInstanceVariableToClassParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveInstanceVariableToClassParametrizedTest.class.st
@@ -1,22 +1,24 @@
 Class {
-	#name : #RBMoveInstanceVariableToClassParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#name : 'RBMoveInstanceVariableToClassParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 RBMoveInstanceVariableToClassParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBMoveInstanceVariableToClassTransformation };
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBMoveInstanceVariableToClassParametrizedTest >> constructor [
 	^ #variable:fromClass:toClass:
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBMoveInstanceVariableToClassParametrizedTest >> testFailureVariableAlreadyExists [
 
 	self shouldFail: (self
@@ -25,7 +27,7 @@ RBMoveInstanceVariableToClassParametrizedTest >> testFailureVariableAlreadyExist
 			 { 'result'. #RBFooLintRuleTestData. #RBBasicLintRuleTestData })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBMoveInstanceVariableToClassParametrizedTest >> testFailureVariableDoesNotExistInOldClass [
 
 	self shouldFail: (self
@@ -34,7 +36,7 @@ RBMoveInstanceVariableToClassParametrizedTest >> testFailureVariableDoesNotExist
 			 { 'abc'. #RBFooLintRuleTestData. #RBBasicLintRuleTestData })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMoveInstanceVariableToClassParametrizedTest >> testRefactoring [
 
 	| refactoring oldClass newClass |

--- a/src/Refactoring2-Transformations-Tests/RBMoveMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveMethodParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBMoveMethodParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBMoveMethodParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMoveMethodParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBMoveMethodRefactoring };
@@ -12,12 +14,12 @@ RBMoveMethodParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBMoveMethodParametrizedTest >> constructor [
 	^ #selector:class:variable:
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBMoveMethodParametrizedTest >> testFailureMovePrimitiveMethod [
 
 	| refactoring |
@@ -33,7 +35,7 @@ RBMoveMethodParametrizedTest >> testFailureMovePrimitiveMethod [
 	self shouldFail: refactoring
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMoveMethodParametrizedTest >> testMoveMethodIntoArgument [
 	| refactoring class |
 	self proceedThroughWarning:
@@ -69,7 +71,7 @@ RBMoveMethodParametrizedTest >> testMoveMethodIntoArgument [
 	self assert: (class parseTreeForSelector: #rewriteRule:) equals: (self parseMethod: 'rewriteRule: anObject rewriteRule := anObject')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMoveMethodParametrizedTest >> testMoveMethodIntoClass [
 	| refactoring class |
 	(model classFor: Object) compile: 'aTestMethodName ^ OrderedCollection new addAll: (1 to: 100); yourself' classified: #test.
@@ -92,7 +94,7 @@ RBMoveMethodParametrizedTest >> testMoveMethodIntoClass [
 		equals: (self parseMethod: 'oneToOneHundred ^ self new addAll: (1 to: 100); yourself')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMoveMethodParametrizedTest >> testMoveMethodIntoClassVariable [
 	| refactoring class |
 	self proceedThroughWarning:
@@ -127,7 +129,7 @@ RBMoveMethodParametrizedTest >> testMoveMethodIntoClassVariable [
 	self assert: (class parseTreeForSelector: #rewriteRule:) equals: (self parseMethod: 'rewriteRule: anObject rewriteRule := anObject')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMoveMethodParametrizedTest >> testMoveMethodIntoInstanceVariable [
 	| refactoring class |
 	self proceedThroughWarning:
@@ -162,7 +164,7 @@ RBMoveMethodParametrizedTest >> testMoveMethodIntoInstanceVariable [
 	self assert: (class parseTreeForSelector: #builder:) equals: (self parseMethod: 'builder: anObject builder := anObject')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMoveMethodParametrizedTest >> testMoveMethodThatReferencesPoolDictionary [
 	| refactoring class |
 	self proceedThroughWarning:

--- a/src/Refactoring2-Transformations-Tests/RBMoveMethodToClassParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveMethodToClassParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBMoveMethodToClassParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBMoveMethodToClassParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMoveMethodToClassParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBMoveMethodToClassRefactoring };
@@ -12,12 +14,12 @@ RBMoveMethodToClassParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMoveMethodToClassParametrizedTest >> constructor [
 	^ #method:class:
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBMoveMethodToClassParametrizedTest >> testFailureMethodAlreadyDefined [
 
 	| method someClass |

--- a/src/Refactoring2-Transformations-Tests/RBMoveMethodToClassSideParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveMethodToClassSideParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBMoveMethodToClassSideParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBMoveMethodToClassSideParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMoveMethodToClassSideParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBMoveMethodToClassSideRefactoring };
@@ -12,12 +14,12 @@ RBMoveMethodToClassSideParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBMoveMethodToClassSideParametrizedTest >> constructor [
 	^ #method:class:
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBMoveMethodToClassSideParametrizedTest >> testFailureClassIsNotMeta [
 
 	| method someClass className refactoring |
@@ -35,7 +37,7 @@ RBMoveMethodToClassSideParametrizedTest >> testFailureClassIsNotMeta [
 	self shouldFail: refactoring
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMoveMethodToClassSideParametrizedTest >> testMoveMethodToClassSide [
 	| method someClass className refactoring |
 	className := RBClassDataForRefactoringTest.
@@ -49,7 +51,7 @@ RBMoveMethodToClassSideParametrizedTest >> testMoveMethodToClassSide [
 	self assert: (someClass parseTreeForSelector: ('threeElement', 'Point') asSymbol) equals: (self parseMethod: 'threeElementPoint ^5 @ 5 + 6 @ 6')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMoveMethodToClassSideParametrizedTest >> testMoveMethodToClassSideWithInsAndMetReferences [
 	| method someClass className refactoring |
 	className := RBTransformationRuleTestData.

--- a/src/Refactoring2-Transformations-Tests/RBMoveMethodToClassSideRefactoringTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveMethodToClassSideRefactoringTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBMoveMethodToClassSideRefactoringTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBMoveMethodToClassSideRefactoringTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBMoveMethodToClassSideRefactoringTest >> testFailureExistsMethodInClassSide [
 
 	| method someClass className refactoring |

--- a/src/Refactoring2-Transformations-Tests/RBMoveTemporaryVariableDefinitionTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveTemporaryVariableDefinitionTransformationTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBMoveTemporaryVariableDefinitionTransformationTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBMoveTemporaryVariableDefinitionTransformationTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMoveTemporaryVariableDefinitionTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBMoveTemporaryVariableDefinitionTransformation
@@ -13,7 +15,7 @@ RBMoveTemporaryVariableDefinitionTransformationTest >> testMethodDoesNotExist [
 							inClass: #RBDummyLintRuleTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMoveTemporaryVariableDefinitionTransformationTest >> testMoveDefinition [
 
 	| transformation class |
@@ -40,7 +42,7 @@ RBMoveTemporaryVariableDefinitionTransformationTest >> testMoveDefinition [
 										temp odd]')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMoveTemporaryVariableDefinitionTransformationTest >> testMoveDefinitionIntoBlockThatIsAReceiverOfACascadedMessage [
 
 	| transformation class |
@@ -67,7 +69,7 @@ RBMoveTemporaryVariableDefinitionTransformationTest >> testMoveDefinitionIntoBlo
 							yourself')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMoveTemporaryVariableDefinitionTransformationTest >> testNowhereToMove [
 
 	| transformation |
@@ -83,7 +85,7 @@ RBMoveTemporaryVariableDefinitionTransformationTest >> testNowhereToMove [
 			 inClass: #RBClassDataForRefactoringTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMoveTemporaryVariableDefinitionTransformationTest >> testVariableDoesNotExist [
 
 	self shouldFail: (RBMoveTemporaryVariableDefinitionTransformation

--- a/src/Refactoring2-Transformations-Tests/RBMoveVariableDefinitionParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveVariableDefinitionParametrizedTest.class.st
@@ -1,22 +1,24 @@
 Class {
-	#name : #RBMoveVariableDefinitionParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#name : 'RBMoveVariableDefinitionParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 RBMoveVariableDefinitionParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBMoveVariableDefinitionToSmallestValidScopeRefactoring };
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBMoveVariableDefinitionParametrizedTest >> constructor [
 	^ #bindTight:in:selector:
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBMoveVariableDefinitionParametrizedTest >> testFailureInvalidSelector [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -25,7 +27,7 @@ RBMoveVariableDefinitionParametrizedTest >> testFailureInvalidSelector [
 				 #caller3 })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBMoveVariableDefinitionParametrizedTest >> testFailureNoMoveDefinition [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -34,7 +36,7 @@ RBMoveVariableDefinitionParametrizedTest >> testFailureNoMoveDefinition [
 				 #noMoveDefinition })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBMoveVariableDefinitionParametrizedTest >> testFailureNonExistantName [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -51,7 +53,7 @@ RBMoveVariableDefinitionParametrizedTest >> testFailureNonExistantName [
 				 #displayName })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMoveVariableDefinitionParametrizedTest >> testMoveDefinition [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments:
@@ -71,7 +73,7 @@ RBMoveVariableDefinitionParametrizedTest >> testMoveDefinition [
 										temp odd]')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBMoveVariableDefinitionParametrizedTest >> testMoveDefinitionIntoBlockThatIsAReceiverOfACascadedMessage [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments:

--- a/src/Refactoring2-Transformations-Tests/RBProtectInstanceVariableParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBProtectInstanceVariableParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBProtectInstanceVariableParametrizedTest,
-	#superclass : #RBWithDifferentConstructorsParametrizedTest,
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#name : 'RBProtectInstanceVariableParametrizedTest',
+	#superclass : 'RBWithDifferentConstructorsParametrizedTest',
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBProtectInstanceVariableParametrizedTest class >> testParameters [
 self flag: 'need change tranformation to have the same behavior of ref'.
 	^ ParametrizedTestMatrix new
@@ -15,14 +17,14 @@ self flag: 'need change tranformation to have the same behavior of ref'.
 	"	yourself
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBProtectInstanceVariableParametrizedTest >> setUp [
 
 	super setUp.
 	model := self rbModelForVariableTest
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBProtectInstanceVariableParametrizedTest >> testFailureVariableNotDefined [
 
 	self shouldFail: (self createRefactoringWithArguments:
@@ -31,7 +33,7 @@ RBProtectInstanceVariableParametrizedTest >> testFailureVariableNotDefined [
 			 { 'foo'. #RBBasicLintRuleTestData })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBProtectInstanceVariableParametrizedTest >> testProtectInstanceVariable [
 	| refactoring class |
 	refactoring := self createRefactoringWithArguments:

--- a/src/Refactoring2-Transformations-Tests/RBProtectVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBProtectVariableTransformationTest.class.st
@@ -1,17 +1,19 @@
 Class {
-	#name : #RBProtectVariableTransformationTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBProtectVariableTransformationTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 RBProtectVariableTransformationTest >> setUp [
 
 	super setUp.
 	model := self rbModelForVariableTest
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBProtectVariableTransformationTest >> testAccessorsAlreadyExist [
 
 	| class |
@@ -40,7 +42,7 @@ RBProtectVariableTransformationTest >> testAccessorsAlreadyExist [
 			self instVarName11: self instVarName11 + instVarName2 + ClassVarName1')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBProtectVariableTransformationTest >> testClassVariable [
 
 	| refactoring class |
@@ -83,7 +85,7 @@ RBProtectVariableTransformationTest >> testClassVariable [
 								classified: aSmalllintContext protocols]]')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBProtectVariableTransformationTest >> testClassVariableInModel [
 
 	| class |
@@ -127,7 +129,7 @@ RBProtectVariableTransformationTest >> testClassVariableInModel [
 				instVarName1 := instVarName1 + instVarName2 + self class classVarName1')"
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBProtectVariableTransformationTest >> testMetaclass [
 
 	| class |
@@ -153,7 +155,7 @@ RBProtectVariableTransformationTest >> testMetaclass [
 		(self parseMethod: 'zzz ^self foo: self foo1 + self foo1 * 2')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBProtectVariableTransformationTest >> testMetaclassFailure [
 
 	self shouldFail: (RBProtectVariableTransformation
@@ -161,7 +163,7 @@ RBProtectVariableTransformationTest >> testMetaclassFailure [
 			 class: RBTransformationRuleTestData class)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBProtectVariableTransformationTest >> testRefactoring [
 
 	| refactoring class |
@@ -197,7 +199,7 @@ RBProtectVariableTransformationTest >> testRefactoring [
 						classified: aSmalllintContext protocols]]')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBProtectVariableTransformationTest >> testTransform [
 
 	| transformation class |
@@ -237,7 +239,7 @@ RBProtectVariableTransformationTest >> testTransform [
 					classified: aSmalllintContext protocols]]')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBProtectVariableTransformationTest >> testVariableDoesNotExist [
 
 	self
@@ -249,7 +251,7 @@ RBProtectVariableTransformationTest >> testVariableDoesNotExist [
 				 class: #RBBasicLintRuleTestData)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBProtectVariableTransformationTest >> testVariableIsNotAccessed [
 
 	| transformation class |
@@ -269,7 +271,7 @@ RBProtectVariableTransformationTest >> testVariableIsNotAccessed [
 	self assert: (class directlyDefinesLocalMethod: #instVar:)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBProtectVariableTransformationTest >> testVariableNotDirectlyDefined [
 
 	self
@@ -285,7 +287,7 @@ RBProtectVariableTransformationTest >> testVariableNotDirectlyDefined [
 				 class: #Bar)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBProtectVariableTransformationTest >> testWithAssignment [
 
 	| refactoring class |

--- a/src/Refactoring2-Transformations-Tests/RBPullUpClassVariableParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBPullUpClassVariableParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBPullUpClassVariableParametrizedTest,
-	#superclass : #RBWithDifferentConstructorsParametrizedTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBPullUpClassVariableParametrizedTest',
+	#superclass : 'RBWithDifferentConstructorsParametrizedTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPullUpClassVariableParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBPullUpClassVariableRefactoring .
@@ -14,14 +16,14 @@ RBPullUpClassVariableParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBPullUpClassVariableParametrizedTest >> testFailureMetaClassFailure [
 
 	self shouldFail: (self createRefactoringWithArguments:
 			 { #RecursiveSelfRule. #'RBLintRuleTestData class' })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBPullUpClassVariableParametrizedTest >> testFailureNonExistantName [
 
 	self skip.
@@ -29,7 +31,7 @@ RBPullUpClassVariableParametrizedTest >> testFailureNonExistantName [
 		{ #Foo . #RBLintRuleTestData })"
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPullUpClassVariableParametrizedTest >> testPullUpClassVariable [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments:

--- a/src/Refactoring2-Transformations-Tests/RBPullUpInstanceVariableParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBPullUpInstanceVariableParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBPullUpInstanceVariableParametrizedTest,
-	#superclass : #RBWithDifferentConstructorsParametrizedTest,
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#name : 'RBPullUpInstanceVariableParametrizedTest',
+	#superclass : 'RBWithDifferentConstructorsParametrizedTest',
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPullUpInstanceVariableParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBPullUpInstanceVariableRefactoring .
@@ -12,14 +14,14 @@ RBPullUpInstanceVariableParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBPullUpInstanceVariableParametrizedTest >> testFailurePullUpVariableNotDefined [
 
 	self shouldFail: (self createRefactoringWithArguments:
 			 { 'notDefinedVariable'. #RBLintRuleTestData })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPullUpInstanceVariableParametrizedTest >> testPullUpInstVar [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments:

--- a/src/Refactoring2-Transformations-Tests/RBPullUpMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBPullUpMethodParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBPullUpMethodParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBPullUpMethodParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPullUpMethodParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBPullUpMethodRefactoring };
@@ -12,7 +14,7 @@ RBPullUpMethodParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPullUpMethodParametrizedTest >> addClassHierarchy [
 	model defineClass: 'Object << #SomeClass
 		sharedVariables: {Foo};
@@ -25,7 +27,7 @@ RBPullUpMethodParametrizedTest >> addClassHierarchy [
 		package: #''Refactory-Test data'''
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPullUpMethodParametrizedTest >> addClassHierarchyForPools [
 	model defineClass: 'SharedPool << #TotoSharedPool
 		sharedVariables: { #SP };
@@ -39,12 +41,12 @@ RBPullUpMethodParametrizedTest >> addClassHierarchyForPools [
 	(model classNamed: #Toto) compile: 'poolReference ^ SP' classified: #(#accessing)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBPullUpMethodParametrizedTest >> constructor [
 	^ #pullUp:from:
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBPullUpMethodParametrizedTest >> testFailureDoesntPullUpReferencesInstVar [
 
 	| refactoring class |
@@ -58,7 +60,7 @@ RBPullUpMethodParametrizedTest >> testFailureDoesntPullUpReferencesInstVar [
 	[ self shouldFail: refactoring ] valueSupplyingAnswer: false
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBPullUpMethodParametrizedTest >> testFailurePullUpClassMethod [
 
 	| class |
@@ -71,7 +73,7 @@ RBPullUpMethodParametrizedTest >> testFailurePullUpClassMethod [
 				 class classSide })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBPullUpMethodParametrizedTest >> testFailurePullUpWhenSuperClassDoesNotDirectlyImplement [
 
 	| classEnvironment classes |
@@ -103,7 +105,7 @@ RBPullUpMethodParametrizedTest >> testFailurePullUpWhenSuperClassDoesNotDirectly
 				 (model classNamed: #ClassC) })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBPullUpMethodParametrizedTest >> testFailurePullUpWithInvalidSuperSend [
 
 	| class |
@@ -120,7 +122,7 @@ RBPullUpMethodParametrizedTest >> testFailurePullUpWithInvalidSuperSend [
 				 class })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBPullUpMethodParametrizedTest >> testFailurePullUpWithMethodThatCannotBePullUp [
 
 	model defineClass: 'Object << #SomeClass
@@ -136,7 +138,7 @@ RBPullUpMethodParametrizedTest >> testFailurePullUpWithMethodThatCannotBePullUp 
 				 (model classNamed: #SomeClass) })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBPullUpMethodParametrizedTest >> testFailurePullUpWithSuperSendThatCannotBeCopiedDown [
 
 	| class |
@@ -157,7 +159,7 @@ RBPullUpMethodParametrizedTest >> testFailurePullUpWithSuperSendThatCannotBeCopi
 				 class })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPullUpMethodParametrizedTest >> testPullUpAndCopyDown [
 	| class |
 	self addClassHierarchy.
@@ -175,7 +177,7 @@ RBPullUpMethodParametrizedTest >> testPullUpAndCopyDown [
 			equals: ((model classNamed: #Object) parseTreeForSelector: #yourself)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPullUpMethodParametrizedTest >> testPullUpInAHighHierarchyClass [
 	| class superClass |
 
@@ -198,7 +200,7 @@ RBPullUpMethodParametrizedTest >> testPullUpInAHighHierarchyClass [
 				equals: ((model classNamed: #SomeClass) parseTreeForSelector: #example)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPullUpMethodParametrizedTest >> testPullUpMethodWithCopyOverriddenMethodsDown [
 	| refactoring |
 	self proceedThroughWarning:
@@ -218,7 +220,7 @@ RBPullUpMethodParametrizedTest >> testPullUpMethodWithCopyOverriddenMethodsDown 
 		directlyDefinesMethod: #isComposite)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPullUpMethodParametrizedTest >> testPullUpMethodWithSharedPool [
 	| class superClass |
 
@@ -236,7 +238,7 @@ RBPullUpMethodParametrizedTest >> testPullUpMethodWithSharedPool [
 	self deny: (class directlyDefinesMethod: #poolReference)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPullUpMethodParametrizedTest >> testPullUpReferencesInstVar [
 	| refactoring class superClass |
 	class := model classNamed: ('RBTransformation', 'RuleTestData1') asSymbol.

--- a/src/Refactoring2-Transformations-Tests/RBPushDownClassVariableParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBPushDownClassVariableParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBPushDownClassVariableParametrizedTest,
-	#superclass : #RBWithDifferentConstructorsParametrizedTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBPushDownClassVariableParametrizedTest',
+	#superclass : 'RBWithDifferentConstructorsParametrizedTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 RBPushDownClassVariableParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBPushDownClassVariableRefactoring .
@@ -14,7 +16,7 @@ RBPushDownClassVariableParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBPushDownClassVariableParametrizedTest >> testFailureModelNonExistantName [
 
 	model defineClass:
@@ -24,14 +26,14 @@ RBPushDownClassVariableParametrizedTest >> testFailureModelNonExistantName [
 			 andArguments: { #Foo. #SomeClass })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBPushDownClassVariableParametrizedTest >> testFailureNonExistantName [
 
 	self shouldFail: (self createRefactoringWithArguments:
 			 { #Foo. #RBBasicLintRuleTestData })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPushDownClassVariableParametrizedTest >> testModelPushDownVariable [
 	| class |
 	model defineClass: 'Object << #SomeClass
@@ -47,7 +49,7 @@ RBPushDownClassVariableParametrizedTest >> testModelPushDownVariable [
 	self assert: (class directlyDefinesClassVariable: #Foo)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPushDownClassVariableParametrizedTest >> testModelPushDownVariableToClassDownTwoLevels [
 	| class |
 	model defineClass: 'Object << #SomeClass
@@ -69,7 +71,7 @@ RBPushDownClassVariableParametrizedTest >> testModelPushDownVariableToClassDownT
 	self assert: (class directlyDefinesClassVariable: #Foo)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPushDownClassVariableParametrizedTest >> testModelPushDownVariableToMultipleClassesInSameHierarchy [
 	| class |
 	model defineClass: 'Object << #SomeClass
@@ -87,7 +89,7 @@ RBPushDownClassVariableParametrizedTest >> testModelPushDownVariableToMultipleCl
 	self assert: (class directlyDefinesClassVariable: #Foo)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPushDownClassVariableParametrizedTest >> testModelRemoveUnusedVariable [
 	model defineClass: 'Object << #SomeClass
 		sharedVariables: { #Foo };
@@ -101,7 +103,7 @@ RBPushDownClassVariableParametrizedTest >> testModelRemoveUnusedVariable [
 	self deny: ((model classNamed: #Subclass) directlyDefinesVariable: #Foo)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPushDownClassVariableParametrizedTest >> testPushDownClassVariable [
 	| refactoring class |
 	refactoring := self createRefactoringWithArguments:

--- a/src/Refactoring2-Transformations-Tests/RBPushDownClassVariableRefactoringTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBPushDownClassVariableRefactoringTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBPushDownClassVariableRefactoringTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBPushDownClassVariableRefactoringTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBPushDownClassVariableRefactoringTest >> testFailureModelPushDownToMultipleSubclassesFailure [
 
 	model defineClass: 'Object << #SomeClass

--- a/src/Refactoring2-Transformations-Tests/RBPushDownInstanceVariableParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBPushDownInstanceVariableParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBPushDownInstanceVariableParametrizedTest,
-	#superclass : #RBWithDifferentConstructorsParametrizedTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBPushDownInstanceVariableParametrizedTest',
+	#superclass : 'RBWithDifferentConstructorsParametrizedTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPushDownInstanceVariableParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBPushDownInstanceVariableRefactoring .
@@ -14,14 +16,14 @@ RBPushDownInstanceVariableParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBPushDownInstanceVariableParametrizedTest >> testFailureNonExistantName [
 
 	self shouldFail: (self createRefactoringWithArguments:
 			 { 'foo'. #RBBasicLintRuleTestData })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPushDownInstanceVariableParametrizedTest >> testModelPushDownOnMetaclassSide [
 
 	model defineClass: 'Object << #SomeClass package: #''Refactory-Test data'''.
@@ -38,7 +40,7 @@ RBPushDownInstanceVariableParametrizedTest >> testModelPushDownOnMetaclassSide [
 		assert: ((model metaclassNamed: #Subclass) directlyDefinesVariable: 'foo')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPushDownInstanceVariableParametrizedTest >> testModelPushDownToMultipleSubclasses [
 	model defineClass: 'Object << #SomeClass
 		slots: { #foo } ;
@@ -55,7 +57,7 @@ RBPushDownInstanceVariableParametrizedTest >> testModelPushDownToMultipleSubclas
 	self assert: ((model classNamed: #AnotherSubclass) directlyDefinesVariable: 'foo')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPushDownInstanceVariableParametrizedTest >> testModelRemoveUnusedVariable [
 	model defineClass: 'Object << #SomeClass
 		slots: { #foo} ;
@@ -68,7 +70,7 @@ RBPushDownInstanceVariableParametrizedTest >> testModelRemoveUnusedVariable [
 	self assert: ((model classNamed: #Subclass) directlyDefinesVariable: 'foo')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPushDownInstanceVariableParametrizedTest >> testPushDownInstanceVariable [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments:

--- a/src/Refactoring2-Transformations-Tests/RBPushDownMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBPushDownMethodParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBPushDownMethodParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBPushDownMethodParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPushDownMethodParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBPushDownMethodRefactoring };
@@ -12,12 +14,12 @@ RBPushDownMethodParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBPushDownMethodParametrizedTest >> constructor [
 	^ #pushDown:from:
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBPushDownMethodParametrizedTest >> testFailurePushDownNonExistantMenu [
 
 	| refactoring |
@@ -27,7 +29,7 @@ RBPushDownMethodParametrizedTest >> testFailurePushDownNonExistantMenu [
 	self shouldFail: refactoring
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPushDownMethodParametrizedTest >> testPushDownMethod [
 
 	| refactoring class |
@@ -43,7 +45,7 @@ RBPushDownMethodParametrizedTest >> testPushDownMethod [
 			equals: (self parseMethod: 'name: aString name := aString') ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBPushDownMethodParametrizedTest >> testPushDownMethodThatReferencesPoolDictionary [
 
 	| refactoring class parseTree |

--- a/src/Refactoring2-Transformations-Tests/RBPushDownMethodRefactoringTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBPushDownMethodRefactoringTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBPushDownMethodRefactoringTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBPushDownMethodRefactoringTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBPushDownMethodRefactoringTest >> testFailurePushDownMethodOnNonAbstractClass [
 
 	| refactoring |
@@ -17,7 +19,7 @@ RBPushDownMethodRefactoringTest >> testFailurePushDownMethodOnNonAbstractClass [
 		raise: RBRefactoringWarning
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBPushDownMethodRefactoringTest >> testFailurePushDownMethodSubclassesReferToSelector [
 
 	| refactoring |

--- a/src/Refactoring2-Transformations-Tests/RBRealizeClassParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRealizeClassParametrizedTest.class.st
@@ -1,17 +1,19 @@
 Class {
-	#name : #RBRealizeClassParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#name : 'RBRealizeClassParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 RBRealizeClassParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBRealizeClassTransformation };
 		yourself
 ]
 
-{ #category : #builder }
+{ #category : 'builder' }
 RBRealizeClassParametrizedTest >> addSomeAbstractMethods [
 	(model classNamed: #RBFooLintRuleTestData)
 		compile: 'bar ^ self subclassResponsibility'
@@ -21,12 +23,12 @@ RBRealizeClassParametrizedTest >> addSomeAbstractMethods [
 		classified: #(#accessing)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBRealizeClassParametrizedTest >> constructor [
 	^ #model:className:
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRealizeClassParametrizedTest >> testClassWithoutChanges [
 	self proceedThroughWarning: [
 		self executeRefactoring:
@@ -34,7 +36,7 @@ RBRealizeClassParametrizedTest >> testClassWithoutChanges [
 	self assert: model changes changes isEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRealizeClassParametrizedTest >> testRealizeAbstractClass [
 	| class |
 	class := model classNamed: #RBFooLintRuleTestData.
@@ -53,7 +55,7 @@ RBRealizeClassParametrizedTest >> testRealizeAbstractClass [
 		self shouldBeImplemented')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRealizeClassParametrizedTest >> testRealizeClass [
 	| class |
 	class := model classNamed: #RBFooLintRuleTestData.
@@ -70,7 +72,7 @@ RBRealizeClassParametrizedTest >> testRealizeClass [
 		self shouldBeImplemented')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRealizeClassParametrizedTest >> testRealizeWithAbstractSubclass [
 	| class |
 	class := model classNamed: #RBTransformationRuleTestData.

--- a/src/Refactoring2-Transformations-Tests/RBRemoveAllMessageSendsTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveAllMessageSendsTransformationTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBRemoveAllMessageSendsTransformationTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBRemoveAllMessageSendsTransformationTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRemoveAllMessageSendsTransformationTest >> testClassDoesNotExist [
 
 	| trans |
@@ -15,7 +17,7 @@ RBRemoveAllMessageSendsTransformationTest >> testClassDoesNotExist [
 	self should: [ trans generateChanges ] raise: trans refactoringErrorClass.
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRemoveAllMessageSendsTransformationTest >> testFailureNonExistantSelector [
 
 	| trans |
@@ -26,7 +28,7 @@ RBRemoveAllMessageSendsTransformationTest >> testFailureNonExistantSelector [
 	self should: [ trans generateChanges ] raise: trans refactoringErrorClass.
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRemoveAllMessageSendsTransformationTest >> testMethodDoesNotExist [
 		
 	| trans |
@@ -37,7 +39,7 @@ RBRemoveAllMessageSendsTransformationTest >> testMethodDoesNotExist [
 	self should: [ trans generateChanges ] raise: trans refactoringErrorClass.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveAllMessageSendsTransformationTest >> testRemoveMessageInsideBlock [
 
 	| trans |
@@ -56,7 +58,7 @@ RBRemoveAllMessageSendsTransformationTest >> testRemoveMessageInsideBlock [
 			^anObject]')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveAllMessageSendsTransformationTest >> testRemoveSenderIntoCascaded2Message [
 
 	| transformedMethod afterRefactoring1 afterRefactoring2 trans |
@@ -80,7 +82,7 @@ RBRemoveAllMessageSendsTransformationTest >> testRemoveSenderIntoCascaded2Messag
 	self assert: (transformedMethod = afterRefactoring1 or: [ transformedMethod = afterRefactoring2])
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveAllMessageSendsTransformationTest >> testRemoveSenderIntoCascaded3Message [
 
 	| transformedMethod afterRefactoring1 afterRefactoring2 trans |
@@ -122,7 +124,7 @@ RBRemoveAllMessageSendsTransformationTest >> testRemoveSenderIntoCascaded3Messag
 	self assert: (transformedMethod = afterRefactoring1 or: [ transformedMethod = afterRefactoring2])
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveAllMessageSendsTransformationTest >> testRemoveSenderIntoCascadedMessage [
 
 	| trans |
@@ -138,7 +140,7 @@ RBRemoveAllMessageSendsTransformationTest >> testRemoveSenderIntoCascadedMessage
 			aBlock value')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveAllMessageSendsTransformationTest >> testRemoveSimpleSenderOfMessage [
 
 	|  transformedMethod afterRefactoring1 afterRefactoring2 trans |

--- a/src/Refactoring2-Transformations-Tests/RBRemoveAllSendersParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveAllSendersParametrizedTest.class.st
@@ -1,22 +1,24 @@
 Class {
-	#name : #RBRemoveAllSendersParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#name : 'RBRemoveAllSendersParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveAllSendersParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBRemoveAllSendersRefactoring };
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBRemoveAllSendersParametrizedTest >> constructor [
 	^ #removeSendersOf:
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveAllSendersParametrizedTest >> testRemoveMessageInsideBlock [
 	| refactoring methodName |
 	methodName := #caller2.

--- a/src/Refactoring2-Transformations-Tests/RBRemoveAssignmentTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveAssignmentTransformationTest.class.st
@@ -1,17 +1,19 @@
 Class {
-	#name : #RBRemoveAssignmentTransformationTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBRemoveAssignmentTransformationTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RBRemoveAssignmentTransformationTest >> methodAfter [
 
 	| variable |
 	variable := 'String'
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RBRemoveAssignmentTransformationTest >> methodBefore [
 
 	| variable |
@@ -19,7 +21,7 @@ RBRemoveAssignmentTransformationTest >> methodBefore [
 	variable := 1 asString
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveAssignmentTransformationTest >> testAssignmentDoesNotExist [
 
 	| refactoring |
@@ -37,7 +39,7 @@ RBRemoveAssignmentTransformationTest >> testAssignmentDoesNotExist [
 			 inClass: #RBRemoveAssignmentTransformationTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveAssignmentTransformationTest >> testClassDoesNotExist [
 
 	self shouldFail: (RBRemoveAssignmentTransformation
@@ -47,7 +49,7 @@ RBRemoveAssignmentTransformationTest >> testClassDoesNotExist [
 			 inClass: #RBAssignmentTransformationTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveAssignmentTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBRemoveAssignmentTransformation
@@ -57,7 +59,7 @@ RBRemoveAssignmentTransformationTest >> testMethodDoesNotExist [
 			 inClass: #RBRemoveAssignmentTransformationTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveAssignmentTransformationTest >> testRefactoring [
 
 	| refactoring class |
@@ -77,7 +79,7 @@ RBRemoveAssignmentTransformationTest >> testRefactoring [
 		equals: (class parseTreeForSelector: #methodAfter) body
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveAssignmentTransformationTest >> testTransform [
 
 	| transformation class |
@@ -95,7 +97,7 @@ RBRemoveAssignmentTransformationTest >> testTransform [
 		equals: (class parseTreeForSelector: #methodAfter) body
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveAssignmentTransformationTest >> testVariableDoesNotExist [
 
 	self shouldFail: (RBRemoveAssignmentTransformation

--- a/src/Refactoring2-Transformations-Tests/RBRemoveClassPushStateToSubclassesTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveClassPushStateToSubclassesTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBRemoveClassPushStateToSubclassesTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBRemoveClassPushStateToSubclassesTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveClassPushStateToSubclassesTest >> testRemoveNotEmptySuperclassPushDownInstanceVariables [
 
 	| refactoring subclass removedClassName subclassName |
@@ -29,7 +31,7 @@ RBRemoveClassPushStateToSubclassesTest >> testRemoveNotEmptySuperclassPushDownIn
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveClassPushStateToSubclassesTest >> testShouldWarnWhenRemovingClassWithReferences [
 
 	| refactoring |

--- a/src/Refactoring2-Transformations-Tests/RBRemoveClassRefactoringTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveClassRefactoringTest.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #RBRemoveClassRefactoringTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBRemoveClassRefactoringTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBRemoveClassRefactoringTest class >> defaultTimeLimit [
 	^20 seconds
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveClassRefactoringTest >> testCanRemoveAReferencedClassNotHavingReferenceInTheModel [
 
 	| refactoring package |
@@ -33,7 +35,7 @@ RBRemoveClassRefactoringTest >> testCanRemoveAReferencedClassNotHavingReferenceI
 		(refactoring model classNamed: #RBTransformationDummyRuleTest1) isNil
 ]
 
-{ #category : #'tests environment' }
+{ #category : 'tests environment' }
 RBRemoveClassRefactoringTest >> testCanRemoveUnreferencedClassUsingLimitedEnvironmentButReferencedElsewhere [
 
 	| refactoring package |
@@ -53,7 +55,7 @@ RBRemoveClassRefactoringTest >> testCanRemoveUnreferencedClassUsingLimitedEnviro
 		(refactoring model classNamed: #RBTransformationDummyRuleTest1) isNil
 ]
 
-{ #category : #'tests environment' }
+{ #category : 'tests environment' }
 RBRemoveClassRefactoringTest >> testCanRemoveUnreferencedClassWithFullEnvironment [
 
 	| refactoring |
@@ -70,7 +72,7 @@ RBRemoveClassRefactoringTest >> testCanRemoveUnreferencedClassWithFullEnvironmen
 	self assert: (refactoring model classNamed: 'RBUnusedRootClass' asSymbol) isNil
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRemoveClassRefactoringTest >> testFailureRaisesRBRefactoringErrorWhenRemovingNonEmptySuperclass [
 
 	| class |
@@ -79,14 +81,14 @@ RBRemoveClassRefactoringTest >> testFailureRaisesRBRefactoringErrorWhenRemovingN
 		(RBRemoveClassRefactoring model: model classNames: { class })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRemoveClassRefactoringTest >> testFailureRemoveClassWithBadNameRaisesRBRefactoringError [
 
 	self shouldFail:
 		(RBRemoveClassRefactoring model: model classNames: { #NonExistantClassName })
 ]
 
-{ #category : #'tests preconditions' }
+{ #category : 'tests preconditions' }
 RBRemoveClassRefactoringTest >> testPreconditionHasNoReferencesWithClassesWithReferencesBetweenThem [
 
 	| refact classes |
@@ -101,7 +103,7 @@ RBRemoveClassRefactoringTest >> testPreconditionHasNoReferencesWithClassesWithRe
 	self assert: (refact preconditionHasNoReferences: (refact model classNamed: #RBSharedPoolForTestData2)) check.
 ]
 
-{ #category : #'tests preconditions' }
+{ #category : 'tests preconditions' }
 RBRemoveClassRefactoringTest >> testPreconditionHasNoSymbolUseHandlesCorrectlyRemovedClasses [
 
 	| refact classes |
@@ -118,7 +120,7 @@ RBRemoveClassRefactoringTest >> testPreconditionHasNoSymbolUseHandlesCorrectlyRe
 	
 ]
 
-{ #category : #'tests preconditions' }
+{ #category : 'tests preconditions' }
 RBRemoveClassRefactoringTest >> testPreconditionHasNoSymbolUseShouldFail [
 
 	| refact classes |
@@ -135,7 +137,7 @@ RBRemoveClassRefactoringTest >> testPreconditionHasNoSymbolUseShouldFail [
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveClassRefactoringTest >> testPreconditionNotEmptyClass [
 
 	| refactoring  package |
@@ -150,7 +152,7 @@ RBRemoveClassRefactoringTest >> testPreconditionNotEmptyClass [
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveClassRefactoringTest >> testRemoveAClassAndTheirSubclass [
 
 	| aRefactoring package |
@@ -166,7 +168,7 @@ RBRemoveClassRefactoringTest >> testRemoveAClassAndTheirSubclass [
 	self deny: (model includesClassNamed: #RBSharedPoolForTestData1)
 ]
 
-{ #category : #'tests environment' }
+{ #category : 'tests environment' }
 RBRemoveClassRefactoringTest >> testRemoveAClassAndTheirSubclass2UsingAlimitedEnvironment [
 	"This test verifies that the preconditions do not escape the metamodel."
 
@@ -185,7 +187,7 @@ RBRemoveClassRefactoringTest >> testRemoveAClassAndTheirSubclass2UsingAlimitedEn
 	self deny: (model includesClassNamed: RBFooDummyLintRuleTest1 subclasses first name)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveClassRefactoringTest >> testRemoveClassesWithReferencesBetweenThem [
 
 	| aRefactoring package |
@@ -202,7 +204,7 @@ RBRemoveClassRefactoringTest >> testRemoveClassesWithReferencesBetweenThem [
 	self deny: (model includesClassNamed: #RBSharedPoolForTestData2)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveClassRefactoringTest >> testRemovingAnEmptyNonLeafClassIsAllowed [
 
 	| refactoring  package sup |
@@ -226,7 +228,7 @@ RBRemoveClassRefactoringTest >> testRemovingAnEmptyNonLeafClassIsAllowed [
 		(refactoring model includesClassNamed: #MyClassNonEmptyLeafUnused) 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveClassRefactoringTest >> testRemovingAnEmptyNonLeafClassReparent [
 
 	| refactoring  package class subclasses superRoot |
@@ -258,7 +260,7 @@ RBRemoveClassRefactoringTest >> testRemovingAnEmptyNonLeafClassReparent [
 		]
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRemoveClassRefactoringTest >> testShouldWarnWhenRemovingClassWithReferences [
 
 	self shouldWarn: 

--- a/src/Refactoring2-Transformations-Tests/RBRemoveClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveClassTransformationTest.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #RBRemoveClassTransformationTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBRemoveClassTransformationTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBRemoveClassTransformationTest class >> defaultTimeLimit [
 	^20 seconds
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveClassTransformationTest >> testCanRemoveReferencedClass [
 
 	| refactoring package |
@@ -35,7 +37,7 @@ RBRemoveClassTransformationTest >> testCanRemoveReferencedClass [
 	"In Pharo subclasses are removed now in the model this is unclear."
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveClassTransformationTest >> testCanRemoveSuperclass [
 
 	| refactoring package |
@@ -60,7 +62,7 @@ RBRemoveClassTransformationTest >> testCanRemoveSuperclass [
 	"In Pharo subclasses are removed now in the model this is unclear."
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveClassTransformationTest >> testCanRemoveUnreferencedClass [
 
 	| refactoring package |

--- a/src/Refactoring2-Transformations-Tests/RBRemoveClassVariableParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveClassVariableParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBRemoveClassVariableParametrizedTest,
-	#superclass : #RBWithDifferentConstructorsParametrizedTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBRemoveClassVariableParametrizedTest',
+	#superclass : 'RBWithDifferentConstructorsParametrizedTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 RBRemoveClassVariableParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBRemoveClassVariableRefactoring .
@@ -14,14 +16,14 @@ RBRemoveClassVariableParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRemoveClassVariableParametrizedTest >> testFailureNonExistantName [
 
 	self shouldFail: (self createRefactoringWithArguments:
 			 { #RecursiveSelfRule1. #RBTransformationRuleTestData })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveClassVariableParametrizedTest >> testRemoveClassVariable [
 	| refactoring class |
 	refactoring :=  self createRefactoringWithArguments:

--- a/src/Refactoring2-Transformations-Tests/RBRemoveClassVariableRefactoringTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveClassVariableRefactoringTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBRemoveClassVariableRefactoringTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBRemoveClassVariableRefactoringTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRemoveClassVariableRefactoringTest >> testShouldWarnWhenVariableReferenced [
 
 	self shouldWarn: (RBRemoveClassVariableRefactoring

--- a/src/Refactoring2-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
@@ -1,17 +1,19 @@
 Class {
-	#name : #RBRemoveDirectAccessToVariableTransformationTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBRemoveDirectAccessToVariableTransformationTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 RBRemoveDirectAccessToVariableTransformationTest >> setUp [
 
 	super setUp.
 	model := self rbModelForVariableTest
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveDirectAccessToVariableTransformationTest >> testClassVariable [
 
 	| refactoring class |
@@ -36,7 +38,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testClassVariable [
 				redo := OrderedCollection new')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveDirectAccessToVariableTransformationTest >> testDoesNotDefineVariable [
 
 	self
@@ -49,7 +51,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testDoesNotDefineVariable [
 				 class: #RBFooLintRuleTestData)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveDirectAccessToVariableTransformationTest >> testDoesNotUnderstandAccessors [
 
 	self
@@ -62,7 +64,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testDoesNotUnderstandAccesso
 				 class: #RBTransformationRuleTestData)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveDirectAccessToVariableTransformationTest >> testInstanceVariable [
 
 	| class |
@@ -77,7 +79,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testInstanceVariable [
 		equals: (self parseMethod: 'foo ^ self instVarName2: 3')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveDirectAccessToVariableTransformationTest >> testRefactoring [
 
 	| refactoring class |
@@ -110,7 +112,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testRefactoring [
 	sendersCache := IdentityDictionary new')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveDirectAccessToVariableTransformationTest >> testTransform [
 
 	| transformation class |

--- a/src/Refactoring2-Transformations-Tests/RBRemoveInstanceVariable2ParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveInstanceVariable2ParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBRemoveInstanceVariable2ParametrizedTest,
-	#superclass : #RBWithDifferentConstructorsParametrizedTest,
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#name : 'RBRemoveInstanceVariable2ParametrizedTest',
+	#superclass : 'RBWithDifferentConstructorsParametrizedTest',
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveInstanceVariable2ParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBRemoveInstanceVariableRefactoring .
@@ -12,7 +14,7 @@ RBRemoveInstanceVariable2ParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRemoveInstanceVariable2ParametrizedTest >> testFailureNonExistantName [
 
 	self shouldFail:
@@ -20,7 +22,7 @@ RBRemoveInstanceVariable2ParametrizedTest >> testFailureNonExistantName [
 			 { 'name1'. #RBLintRuleTestData })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveInstanceVariable2ParametrizedTest >> testRemoveLocallyDefinedInstanceVariable [
 
 	| refactoring class |
@@ -33,7 +35,7 @@ RBRemoveInstanceVariable2ParametrizedTest >> testRemoveLocallyDefinedInstanceVar
 	self deny: (class definesInstanceVariable: #foo1)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveInstanceVariable2ParametrizedTest >> testRemoveNonLocalInstanceVariableProducesAnError [
 	
 	| subclass subsubclass refactoring |
@@ -65,13 +67,13 @@ RBRemoveInstanceVariable2ParametrizedTest >> testRemoveNonLocalInstanceVariableP
 	self assert: (subclass definesInstanceVariable: #foo1)
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRemoveInstanceVariable2ParametrizedTest >> testShouldWarnWhenVariableReferenced [
 
 	self shouldWarn: (self createRefactoringWithArguments:  { 'name'. #RBLintRuleTestData })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveInstanceVariable2ParametrizedTest >> testVerifyPreconditionWhenRemoveLocallyDefinedInstanceVariable [
 
 	| class refactoring |

--- a/src/Refactoring2-Transformations-Tests/RBRemoveMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveMethodParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBRemoveMethodParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBRemoveMethodParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveMethodParametrizedTest class >> testParameters [
 
 	^ ParametrizedTestMatrix new
@@ -13,7 +15,7 @@ RBRemoveMethodParametrizedTest class >> testParameters [
 		  yourself
 ]
 
-{ #category : #builder }
+{ #category : 'builder' }
 RBRemoveMethodParametrizedTest >> createRefactoringWithModel: rbNamespace andArguments: aParameterCollection [
 
 	^ rbClass
@@ -21,7 +23,7 @@ RBRemoveMethodParametrizedTest >> createRefactoringWithModel: rbNamespace andArg
 		  withArguments: { rbNamespace } , aParameterCollection
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRemoveMethodParametrizedTest >> testFailureRemoveNonExistingMethod [
 
 	self shouldFail: (self
@@ -29,7 +31,7 @@ RBRemoveMethodParametrizedTest >> testFailureRemoveNonExistingMethod [
 			 andArguments: #( #nonExistingMethod #RBBasicLintRuleTestData ))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveMethodParametrizedTest >> testRemoveMethod [
 	| refactoring selector |
 	selector := 'selectorNotReferenced' asSymbol.

--- a/src/Refactoring2-Transformations-Tests/RBRemoveMethodRefactoringTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveMethodRefactoringTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBRemoveMethodRefactoringTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBRemoveMethodRefactoringTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRemoveMethodRefactoringTest >> testFailureRemoveReferenced [
 
 	self shouldWarn: (RBRemoveMethodRefactoring
@@ -13,7 +15,7 @@ RBRemoveMethodRefactoringTest >> testFailureRemoveReferenced [
 			 from: #RBBasicLintRuleTestData)
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRemoveMethodRefactoringTest >> testFailureRemoveSameMethodButSendsSuper [
 
 	<expectedFailure>
@@ -23,7 +25,7 @@ RBRemoveMethodRefactoringTest >> testFailureRemoveSameMethodButSendsSuper [
 			 from: #'RBBasicLintRuleTestData class')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveMethodRefactoringTest >> testJustSendsSuper [
 
 	| refactoring selector |
@@ -39,7 +41,7 @@ RBRemoveMethodRefactoringTest >> testJustSendsSuper [
 	self assert: (refactoring justSendsSuper: selector)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveMethodRefactoringTest >> testJustSendsSuperFailing [
 
 	| refactoring selector |
@@ -54,7 +56,7 @@ RBRemoveMethodRefactoringTest >> testJustSendsSuperFailing [
 	self deny: (refactoring justSendsSuper: selector)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveMethodRefactoringTest >> testModelRecursiveMethodThatIsNotReferencedFromOtherMethods [
 
 	| class otherClass selector |
@@ -80,7 +82,7 @@ RBRemoveMethodRefactoringTest >> testModelRecursiveMethodThatIsNotReferencedFrom
 	self deny: (class definesMethod: selector)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveMethodRefactoringTest >> testSendersIncludesSuperCalls [
 
 	| refactoring |
@@ -91,7 +93,7 @@ RBRemoveMethodRefactoringTest >> testSendersIncludesSuperCalls [
 	self denyEmpty: (refactoring sendersOf: #justSuperSendInSubclass)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveMethodRefactoringTest >> testSendersOfUnsentMessage [
 
 	| refactoring rbclasses rbNamespace2 |

--- a/src/Refactoring2-Transformations-Tests/RBRemoveMethodsInHierarchyRefactoringTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveMethodsInHierarchyRefactoringTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBRemoveMethodsInHierarchyRefactoringTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBRemoveMethodsInHierarchyRefactoringTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRemoveMethodsInHierarchyRefactoringTest >> testFailureRemoveNonExistantMethod [
 
 	self shouldFail: (RBRemoveMethodsInHierarchyRefactoring
@@ -12,7 +14,7 @@ RBRemoveMethodsInHierarchyRefactoringTest >> testFailureRemoveNonExistantMethod 
 			 from: RBBasicLintRuleTestData)
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRemoveMethodsInHierarchyRefactoringTest >> testFailureRemoveReferenced [
 
 	self shouldWarn: (RBRemoveMethodsInHierarchyRefactoring
@@ -20,7 +22,7 @@ RBRemoveMethodsInHierarchyRefactoringTest >> testFailureRemoveReferenced [
 				 from: RBBasicLintRuleTestData)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveMethodsInHierarchyRefactoringTest >> testRemoveMethod [
 	| refactoring selectors |
 	selectors := Array with: 'msg4' asSymbol.

--- a/src/Refactoring2-Transformations-Tests/RBRemoveMethodsRefactoringTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveMethodsRefactoringTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBRemoveMethodsRefactoringTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBRemoveMethodsRefactoringTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveMethodsRefactoringTest >> testFailureMethodHasReferences [
 
 	self shouldWarn: (RBRemoveMethodsRefactoring
@@ -12,7 +14,7 @@ RBRemoveMethodsRefactoringTest >> testFailureMethodHasReferences [
 								from: RBBasicLintRuleTestData )
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveMethodsRefactoringTest >> testFailureNonExistantSelector [
 
 	self shouldFail: (RBRemoveMethodsRefactoring
@@ -20,7 +22,44 @@ RBRemoveMethodsRefactoringTest >> testFailureNonExistantSelector [
 								from: RBLintRuleTestData )
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
+RBRemoveMethodsRefactoringTest >> testRemovingMethodsFromDifferentClasses [
+
+	| package class anotherClass methodWithoutRefs methodReferencing anotherMethodWithoutRefs |
+	package := RBPackageEnvironment packageName:
+		           RBBasicLintRuleTestData packageName.
+	model := RBNamespace onEnvironment: package.
+	class := model classFor: RBBasicLintRuleTestData.
+	methodWithoutRefs := 'someDemoMethod' asSymbol.
+	methodReferencing := 'onlyReferenceToSomeDemoMethod' asSymbol.
+	anotherClass := model classFor: RBTransformationDummyRuleTest.
+	anotherMethodWithoutRefs := 'justAUnreferencedMethodForTesting' asSymbol.
+
+	self assert: (class definesMethod: methodWithoutRefs).
+	self assert: (class definesMethod: methodReferencing).
+	self assert: (anotherClass definesMethod: anotherMethodWithoutRefs).
+
+	(RBCompositeRefactoring new
+		model: model;
+		refactorings: { 
+			RBRemoveMethodsRefactoring
+				model: model
+				selectors: { methodWithoutRefs . methodReferencing }
+				from: class
+			.
+			RBRemoveMethodsRefactoring
+				model: model
+				selectors: { anotherMethodWithoutRefs }
+				from: anotherClass 
+		} 
+	) generateChanges.
+
+	self deny: (class definesMethod: methodWithoutRefs).
+	self deny: (class definesMethod: methodReferencing ).
+	self deny: (anotherClass definesMethod: anotherMethodWithoutRefs)
+]
+
+{ #category : 'tests' }
 RBRemoveMethodsRefactoringTest >> testRemovingMethodsThatOnlyReferenceThemselves [
 
 	| package class methodWithRef methodReferencing |

--- a/src/Refactoring2-Transformations-Tests/RBRemoveParameterParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveParameterParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBRemoveParameterParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBRemoveParameterParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveParameterParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 			addCase: { #rbClass -> RBRemoveParameterTransformation};
@@ -13,12 +15,12 @@ RBRemoveParameterParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBRemoveParameterParametrizedTest >> constructor [
 	^ #removeParameter:in:selector:
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRemoveParameterParametrizedTest >> testFailureNonExistantName [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -31,7 +33,7 @@ RBRemoveParameterParametrizedTest >> testFailureNonExistantName [
 				 #checkClass1: })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRemoveParameterParametrizedTest >> testFailurePrimitiveMethods [
 
 	| refactoring |
@@ -47,7 +49,7 @@ RBRemoveParameterParametrizedTest >> testFailurePrimitiveMethods [
 	self shouldFail: refactoring
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRemoveParameterParametrizedTest >> testFailureReferenceArgument [
 
 	| refactoring |
@@ -63,7 +65,7 @@ RBRemoveParameterParametrizedTest >> testFailureReferenceArgument [
 	self shouldFail: refactoring
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveParameterParametrizedTest >> testRemoveParameter [
 	| refactoring class |
 	refactoring := self createRefactoringWithArguments:

--- a/src/Refactoring2-Transformations-Tests/RBRemovePragmaTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemovePragmaTransformationTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBRemovePragmaTransformationTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBRemovePragmaTransformationTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RBRemovePragmaTransformationTest >> methodAfter [
 
 	| variable |
@@ -12,7 +14,7 @@ RBRemovePragmaTransformationTest >> methodAfter [
 	variable byteAt: 1
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RBRemovePragmaTransformationTest >> methodBefore [
 	<pragmaForTesting: 34>
 
@@ -21,7 +23,7 @@ RBRemovePragmaTransformationTest >> methodBefore [
 	variable byteAt: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemovePragmaTransformationTest >> testClassDoesNotExist [
 
 	self shouldFail: (RBRemovePragmaTransformation
@@ -30,7 +32,7 @@ RBRemovePragmaTransformationTest >> testClassDoesNotExist [
 			 inClass: #RBPragmaTransformationTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemovePragmaTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBRemovePragmaTransformation
@@ -39,7 +41,7 @@ RBRemovePragmaTransformationTest >> testMethodDoesNotExist [
 			 inClass: #RBRemovePragmaTransformationTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemovePragmaTransformationTest >> testPragmaDoesNotExist [
 
 	self shouldFail: (RBRemovePragmaTransformation
@@ -48,7 +50,7 @@ RBRemovePragmaTransformationTest >> testPragmaDoesNotExist [
 			 inClass: #RBRemovePragmaTransformationTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemovePragmaTransformationTest >> testRefactoring [
 
 	| refactoring class |
@@ -67,7 +69,7 @@ RBRemovePragmaTransformationTest >> testRefactoring [
 		equals: (class parseTreeForSelector: #methodAfter) body
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemovePragmaTransformationTest >> testTransform [
 
 	| transformation class |

--- a/src/Refactoring2-Transformations-Tests/RBRemoveProtocolTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveProtocolTransformationTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBRemoveProtocolTransformationTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBRemoveProtocolTransformationTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveProtocolTransformationTest >> testRefactoring [
 
 	| refactoring |
@@ -20,7 +22,7 @@ RBRemoveProtocolTransformationTest >> testRefactoring [
 	self assert: refactoring model changes changes size equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveProtocolTransformationTest >> testTransform [
 
 	| transformation |

--- a/src/Refactoring2-Transformations-Tests/RBRemoveReturnStatementTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveReturnStatementTransformationTest.class.st
@@ -1,17 +1,19 @@
 Class {
-	#name : #RBRemoveReturnStatementTransformationTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBRemoveReturnStatementTransformationTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RBRemoveReturnStatementTransformationTest >> methodAfter [
 
 	| variable |
 	variable := 'String'
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 RBRemoveReturnStatementTransformationTest >> methodBefore [
 
 	| variable |
@@ -19,7 +21,7 @@ RBRemoveReturnStatementTransformationTest >> methodBefore [
 	^ variable
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveReturnStatementTransformationTest >> testClassDoesNotExist [
 
 	self shouldFail: (RBRemoveReturnStatementTransformation
@@ -28,7 +30,7 @@ RBRemoveReturnStatementTransformationTest >> testClassDoesNotExist [
 			 inClass: #RBReturnStatementTransformationTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveReturnStatementTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBRemoveReturnStatementTransformation
@@ -37,7 +39,7 @@ RBRemoveReturnStatementTransformationTest >> testMethodDoesNotExist [
 			 inClass: #RBRemoveReturnStatementTransformationTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveReturnStatementTransformationTest >> testRefactoring [
 
 	| refactoring class |
@@ -56,7 +58,7 @@ RBRemoveReturnStatementTransformationTest >> testRefactoring [
 		equals: (class parseTreeForSelector: #methodAfter) body
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveReturnStatementTransformationTest >> testReturnDoesNotExist [
 
 	self shouldFail: (RBRemoveReturnStatementTransformation
@@ -65,7 +67,7 @@ RBRemoveReturnStatementTransformationTest >> testReturnDoesNotExist [
 			 inClass: #RBRemoveReturnStatementTransformationTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveReturnStatementTransformationTest >> testTransform [
 
 	| transformation class |

--- a/src/Refactoring2-Transformations-Tests/RBRemoveSenderMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveSenderMethodParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBRemoveSenderMethodParametrizedTest,
-	#superclass : #RBWithDifferentsArgumentsParametrizedTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBRemoveSenderMethodParametrizedTest',
+	#superclass : 'RBWithDifferentsArgumentsParametrizedTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveSenderMethodParametrizedTest class >> testParameters [
 
 	^ ParametrizedTestMatrix new
@@ -14,7 +16,7 @@ RBRemoveSenderMethodParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRemoveSenderMethodParametrizedTest >> testFailureClassDoesNotExist [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -25,7 +27,7 @@ RBRemoveSenderMethodParametrizedTest >> testFailureClassDoesNotExist [
 				 #RBMessageSendTransformationTest })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRemoveSenderMethodParametrizedTest >> testFailureIsDirectlyUsed [
 
 	| refactoring |
@@ -39,7 +41,7 @@ RBRemoveSenderMethodParametrizedTest >> testFailureIsDirectlyUsed [
 	self shouldFail: refactoring
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRemoveSenderMethodParametrizedTest >> testFailureIsDirectlyUsed2 [
 
 	| refactoring |
@@ -53,7 +55,7 @@ RBRemoveSenderMethodParametrizedTest >> testFailureIsDirectlyUsed2 [
 	self shouldFail: refactoring
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRemoveSenderMethodParametrizedTest >> testFailureMethodDoesNotExist [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -64,7 +66,7 @@ RBRemoveSenderMethodParametrizedTest >> testFailureMethodDoesNotExist [
 				 #RBClassDataForRefactoringTest })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRemoveSenderMethodParametrizedTest >> testFailureNonExistantSelector [
 
 	self shouldFail: (self createRefactoringWithArguments:
@@ -73,7 +75,7 @@ RBRemoveSenderMethodParametrizedTest >> testFailureNonExistantSelector [
 		#RBClassDataForRefactoringTest})
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveSenderMethodParametrizedTest >> testRemoveMessageInsideBlock [
 
 	| refactoring |
@@ -94,7 +96,7 @@ RBRemoveSenderMethodParametrizedTest >> testRemoveMessageInsideBlock [
 			^anObject]')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveSenderMethodParametrizedTest >> testRemoveSenderIntoCascaded2Message [
 
 	| refactoring transformedMethod afterRefactoring1 afterRefactoring2 |
@@ -121,7 +123,7 @@ RBRemoveSenderMethodParametrizedTest >> testRemoveSenderIntoCascaded2Message [
 	self assert: (transformedMethod = afterRefactoring1 or: [ transformedMethod = afterRefactoring2])
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveSenderMethodParametrizedTest >> testRemoveSenderIntoCascaded3Message [
 
 	| refactoring transformedMethod afterRefactoring1 afterRefactoring2 |
@@ -166,7 +168,7 @@ RBRemoveSenderMethodParametrizedTest >> testRemoveSenderIntoCascaded3Message [
 	self assert: (transformedMethod = afterRefactoring1 or: [transformedMethod = afterRefactoring2])
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveSenderMethodParametrizedTest >> testRemoveSenderIntoCascadedMessage [
 
 	| refactoring |
@@ -188,7 +190,7 @@ RBRemoveSenderMethodParametrizedTest >> testRemoveSenderIntoCascadedMessage [
 	aBlock value')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveSenderMethodParametrizedTest >> testRemoveSimpleSenderOfMessage [
 
 	| refactoring transformedMethod afterRefactoring1 afterRefactoring2 |

--- a/src/Refactoring2-Transformations-Tests/RBRemoveSubtreeTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveSubtreeTransformationTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBRemoveSubtreeTransformationTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBRemoveSubtreeTransformationTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveSubtreeTransformationTest >> testEmptyCode [
 
 	self shouldFail: (RBRemoveSubtreeTransformation
@@ -18,7 +20,7 @@ RBRemoveSubtreeTransformationTest >> testEmptyCode [
 			 in: #RBRemoveMethodTransformation)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveSubtreeTransformationTest >> testFailureExtract [
 
 	self shouldFail: (RBRemoveSubtreeTransformation
@@ -32,7 +34,7 @@ RBRemoveSubtreeTransformationTest >> testFailureExtract [
 			 in: #RBRemoveMethodTransformation)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveSubtreeTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBRemoveSubtreeTransformation
@@ -46,7 +48,7 @@ RBRemoveSubtreeTransformationTest >> testMethodDoesNotExist [
 			 in: #RBRemoveMethodTransformation)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveSubtreeTransformationTest >> testRefactoring [
 
 	| transformation class |
@@ -67,7 +69,7 @@ RBRemoveSubtreeTransformationTest >> testRefactoring [
 		equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveSubtreeTransformationTest >> testTransform [
 
 	| transformation class |
@@ -84,7 +86,7 @@ RBRemoveSubtreeTransformationTest >> testTransform [
 	self assertEmpty: (class parseTreeForSelector: #one) body statements
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveSubtreeTransformationTest >> testTransformNotSequenceNode [
 
 	| transformation class |

--- a/src/Refactoring2-Transformations-Tests/RBRemoveTemporaryVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveTemporaryVariableTransformationTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBRemoveTemporaryVariableTransformationTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBRemoveTemporaryVariableTransformationTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveTemporaryVariableTransformationTest >> testClassDoesNotExist [
 
 	self shouldFail: (RBRemoveTemporaryVariableTransformation
@@ -13,7 +15,7 @@ RBRemoveTemporaryVariableTransformationTest >> testClassDoesNotExist [
 			 inClass: #RBTemporaryVariableTransformationTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveTemporaryVariableTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBRemoveTemporaryVariableTransformation
@@ -22,7 +24,7 @@ RBRemoveTemporaryVariableTransformationTest >> testMethodDoesNotExist [
 			 inClass: #RBRemoveTemporaryVariableTransformationTest)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveTemporaryVariableTransformationTest >> testRefactoring [
 
 	| refactoring class |
@@ -54,7 +56,7 @@ RBRemoveTemporaryVariableTransformationTest >> testRefactoring [
 		equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveTemporaryVariableTransformationTest >> testTransform [
 
 	| transformation class |
@@ -84,7 +86,7 @@ RBRemoveTemporaryVariableTransformationTest >> testTransform [
 		equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRemoveTemporaryVariableTransformationTest >> testVariableDoesNotExist [
 
 	self shouldFail: (RBRemoveTemporaryVariableTransformation

--- a/src/Refactoring2-Transformations-Tests/RBRenameAndDeprecateClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameAndDeprecateClassTransformationTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBRenameAndDeprecateClassTransformationTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBRenameAndDeprecateClassTransformationTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenameAndDeprecateClassTransformationTest >> testTransform [
 
 	| transformation class |

--- a/src/Refactoring2-Transformations-Tests/RBRenameClassRefactoringTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameClassRefactoringTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBRenameClassRefactoringTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBRenameClassRefactoringTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRenameClassRefactoringTest >> testFailureBadName [
 
 	self shouldFail: (RBRenameClassRefactoring
@@ -14,21 +16,21 @@ RBRenameClassRefactoringTest >> testFailureBadName [
 		(RBRenameClassRefactoring rename: #RBLintRuleTestData to: #'Ob ject')
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRenameClassRefactoringTest >> testFailureExistingName [
 
 	self shouldFail:
 		(RBRenameClassRefactoring rename: self class name to: #Object)
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRenameClassRefactoringTest >> testFailureMetaClassFailure [
 
 	self shouldFail:
 		(RBRenameClassRefactoring rename: self class class name to: #Foo)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenameClassRefactoringTest >> testModelRenameSequenceClass [
 
 	model defineClass: 'Object << #Foo1
@@ -52,7 +54,7 @@ RBRenameClassRefactoringTest >> testModelRenameSequenceClass [
 		  equals: (self parseMethod: 'objectName ^ #(Foo3)')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenameClassRefactoringTest >> testRefactoring [
 
 	| refactoring class |
@@ -77,7 +79,7 @@ RBRenameClassRefactoringTest >> testRefactoring [
 	self assert: class superclass name equals: #Thing
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenameClassRefactoringTest >> testRenameClass [
 	| refactoring class classA classB classC aModel |
 
@@ -103,7 +105,7 @@ RBRenameClassRefactoringTest >> testRenameClass [
 								^RBNewClassName new')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenameClassRefactoringTest >> testRenameClassFromTrait [
 	| refactoring class classA classB classC aModel |
 
@@ -122,7 +124,7 @@ RBRenameClassRefactoringTest >> testRenameClassFromTrait [
 	self assert: ((refactoring model classNamed: #RBClassUsingSharedPoolForTestData) methodFor: #methodFromTrait) modelClass name equals: #RBTDummy
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenameClassRefactoringTest >> testUnmarkRemovedClassIfRenameTargetClass [
 	"Unmark a removed class if we rename another class to the removed class name.
 rename class A to C (class A is marked as removed)

--- a/src/Refactoring2-Transformations-Tests/RBRenameClassVariableParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameClassVariableParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBRenameClassVariableParametrizedTest,
-	#superclass : #RBRenameVariableParametrizedTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBRenameClassVariableParametrizedTest',
+	#superclass : 'RBRenameVariableParametrizedTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 RBRenameClassVariableParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBRenameClassVariableRefactoring .
@@ -16,7 +18,7 @@ RBRenameClassVariableParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRenameClassVariableParametrizedTest >> testFailureAlreadyExistingName [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -25,7 +27,7 @@ RBRenameClassVariableParametrizedTest >> testFailureAlreadyExistingName [
 				 #RBTransformationRuleTestData })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRenameClassVariableParametrizedTest >> testFailureMetaClassFailure [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -34,14 +36,14 @@ RBRenameClassVariableParametrizedTest >> testFailureMetaClassFailure [
 				 RBTransformationRuleTestData class name asSymbol })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRenameClassVariableParametrizedTest >> testFailureNonExistantName [
 
 	self shouldFail: (self createRefactoringWithArguments:
 			 { #foo. #newFoo. #RBBasicLintRuleTestData })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenameClassVariableParametrizedTest >> testRenameClassVar [
 	| refactoring class |
 	refactoring := self createRefactoringWithArguments:
@@ -84,7 +86,7 @@ RBRenameClassVariableParametrizedTest >> testRenameClassVar [
 													classified: aSmalllintContext protocols]]')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenameClassVariableParametrizedTest >> testRenameClassVarInSharedPool [
 	| refactoring class userClass |
 

--- a/src/Refactoring2-Transformations-Tests/RBRenameInstanceVariableParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameInstanceVariableParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBRenameInstanceVariableParametrizedTest,
-	#superclass : #RBRenameVariableParametrizedTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBRenameInstanceVariableParametrizedTest',
+	#superclass : 'RBRenameVariableParametrizedTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenameInstanceVariableParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBRenameInstanceVariableRefactoring .
@@ -16,14 +18,14 @@ RBRenameInstanceVariableParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRenameInstanceVariableParametrizedTest >> testFailureAlreadyExistingName [
 
 	self shouldFail: (self createRefactoringWithArguments:
 			 { 'classBlock'. 'name'. #RBBasicLintRuleTestData })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRenameInstanceVariableParametrizedTest >> testFailureMetaclassFailure [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -32,14 +34,14 @@ RBRenameInstanceVariableParametrizedTest >> testFailureMetaclassFailure [
 				 RBTransformationRuleTestData class name })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRenameInstanceVariableParametrizedTest >> testFailureNonExistantName [
 
 	self shouldFail: (self createRefactoringWithArguments:
 			 { 'foo'. 'newFoo'. #RBBasicLintRuleTestData })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenameInstanceVariableParametrizedTest >> testRenameInstVar [
 	| refactoring class |
 	refactoring := self createRefactoringWithArguments:
@@ -74,7 +76,7 @@ RBRenameInstanceVariableParametrizedTest >> testRenameInstVar [
 	self resultClass: RBSelectorEnvironment')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenameInstanceVariableParametrizedTest >> testRenameInstVarFromTrait [
 	| refactoring class |
 
@@ -102,7 +104,7 @@ RBRenameInstanceVariableParametrizedTest >> testRenameInstVarFromTrait [
 		equals: (self parseMethod: 'msg2 var11')"
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenameInstanceVariableParametrizedTest >> testRenameInstVarNotAccessors [
 	| refactoring class |
 	refactoring := self createRefactoringWithArguments:

--- a/src/Refactoring2-Transformations-Tests/RBRenameMethodParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameMethodParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBRenameMethodParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBRenameMethodParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenameMethodParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBRenameMethodRefactoring };
@@ -12,18 +14,18 @@ RBRenameMethodParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBRenameMethodParametrizedTest >> constructor [
 	^ #renameMethod:in:to:permutation:
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRenameMethodParametrizedTest >> testFailureWithNonCorrectNumberOfArgs [
 	self shouldFail: (self createRefactoringWithArguments:
 		{ #checkClass: . RBBasicLintRuleTestData . #checkClass . (1 to: 1) })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenameMethodParametrizedTest >> testRenameMethodFromTrait [
 	| refactoring class |
 	refactoring := self createRefactoringWithArguments:
@@ -47,7 +49,7 @@ RBRenameMethodParametrizedTest >> testRenameMethodFromTrait [
 		equals: #RBTDummy
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenameMethodParametrizedTest >> testRenameMethodOnlyInSomePackages [
 	| refactoring class |
 	model := (RBClassModelFactory rbNamespace onEnvironment: (RBPackageEnvironment packageName: 'Refactoring-DataForTesting')).
@@ -63,7 +65,7 @@ RBRenameMethodParametrizedTest >> testRenameMethodOnlyInSomePackages [
 '	^classBlock value: aSmalllintContext value: result')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenameMethodParametrizedTest >> testRenameMethodPermuteArgs [
 	| refactoring class |
 	refactoring := self createRefactoringWithArguments:
@@ -87,7 +89,7 @@ RBRenameMethodParametrizedTest >> testRenameMethodPermuteArgs [
 		equals: (self parseMethod: (self methodSignatureStringForUnarySymbol: #demoExampleCall), ' ^self demoRenameMethod: 2 PermuteArgs: 1')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenameMethodParametrizedTest >> testRenamePermuteArgs [
 	| refactoring class |
 	refactoring := self createRefactoringWithArguments:
@@ -105,7 +107,7 @@ RBRenameMethodParametrizedTest >> testRenamePermuteArgs [
 		equals: (self parseMethod: (self methodSignatureStringForUnarySymbol: #exampleCall), '<sampleInstance> ^self rename: 2 two: 1')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenameMethodParametrizedTest >> testRenamePrimitive [
 	| refactoring count |
 	count := 0.
@@ -123,7 +125,7 @@ RBRenameMethodParametrizedTest >> testRenamePrimitive [
 	self assert: count equals: 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenameMethodParametrizedTest >> testRenameTestMethod [
 	| refactoring class |
 	refactoring := self createRefactoringWithArguments:
@@ -147,7 +149,7 @@ RBRenameMethodParametrizedTest >> testRenameTestMethod [
 	self deny: (class directlyDefinesMethod: ('rename' , 'ThisMethod:') asSymbol)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenameMethodParametrizedTest >> testRenameTestMethod1 [
 	| refactoring class |
 	refactoring := self createRefactoringWithArguments:

--- a/src/Refactoring2-Transformations-Tests/RBRenameMethodRefactoringTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameMethodRefactoringTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBRenameMethodRefactoringTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBRenameMethodRefactoringTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRenameMethodRefactoringTest >> testFailureExistingSelector [
 		
 	| refactoring |

--- a/src/Refactoring2-Transformations-Tests/RBRenamePackageParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenamePackageParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBRenamePackageParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBRenamePackageParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenamePackageParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBRenamePackageRefactoring };
@@ -12,25 +14,25 @@ RBRenamePackageParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBRenamePackageParametrizedTest >> constructor [
 	^ #rename:to:
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRenamePackageParametrizedTest >> testFailureBadName [
 	self shouldFail: (self createRefactoringWithArguments:
 		{ #'Refactoring-Tests-Core' . #'Refactoring-Tests-Core' })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRenamePackageParametrizedTest >> testFailureExistingPackage [
 
 	self shouldFail: (self createRefactoringWithArguments:
 			 { #'Refactoring-Tests-Core'. #'Refactoring-Tests-Changes' })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenamePackageParametrizedTest >> testRenamePackage [
 	| refactoring aModel |
 

--- a/src/Refactoring2-Transformations-Tests/RBRenameTemporaryParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameTemporaryParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBRenameTemporaryParametrizedTest,
-	#superclass : #RBWithDifferentsArgumentsParametrizedTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBRenameTemporaryParametrizedTest',
+	#superclass : 'RBWithDifferentsArgumentsParametrizedTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenameTemporaryParametrizedTest class >> testParameters [
 
 	^ ParametrizedTestMatrix new
@@ -17,7 +19,7 @@ RBRenameTemporaryParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRenameTemporaryParametrizedTest >> testFailureBadIntervalAndVariableDoesNotExist [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -43,7 +45,7 @@ RBRenameTemporaryParametrizedTest >> testFailureBadIntervalAndVariableDoesNotExi
 				 #testMethod })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRenameTemporaryParametrizedTest >> testFailureBadName [
 	self
 		shouldFail:
@@ -54,7 +56,7 @@ RBRenameTemporaryParametrizedTest >> testFailureBadName [
 				'a b' . #RBLintRuleTestData . #openEditor })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRenameTemporaryParametrizedTest >> testFailureExistingVariable [
 
 	self
@@ -74,7 +76,7 @@ RBRenameTemporaryParametrizedTest >> testFailureExistingVariable [
 						 #openEditor })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRenameTemporaryParametrizedTest >> testFailureModelBadName [
 
 	| class |
@@ -101,7 +103,7 @@ RBRenameTemporaryParametrizedTest >> testFailureModelBadName [
 						 #aMethod: })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBRenameTemporaryParametrizedTest >> testFailureModelExistingVariable [
 
 	| transformation |
@@ -126,7 +128,7 @@ RBRenameTemporaryParametrizedTest >> testFailureModelExistingVariable [
 					 #foo })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenameTemporaryParametrizedTest >> testRenameArg [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments: { { (7 to: 13) . #aString } .
@@ -137,7 +139,7 @@ RBRenameTemporaryParametrizedTest >> testRenameArg [
 	name := asdf')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBRenameTemporaryParametrizedTest >> testRenameTemporary [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments: { {(15 to: 19) . #rules} .

--- a/src/Refactoring2-Transformations-Tests/RBRenameVariableParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameVariableParametrizedTest.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #RBRenameVariableParametrizedTest,
-	#superclass : #RBWithDifferentConstructorsParametrizedTest,
+	#name : 'RBRenameVariableParametrizedTest',
+	#superclass : 'RBWithDifferentConstructorsParametrizedTest',
 	#instVars : [
 		'extraArgument'
 	],
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #builder }
+{ #category : 'builder' }
 RBRenameVariableParametrizedTest >> createRefactoringWithArguments: aParameterCollection [
 
 	^ self renameVariableClass
@@ -15,13 +17,13 @@ RBRenameVariableParametrizedTest >> createRefactoringWithArguments: aParameterCo
 		  withArguments: aParameterCollection , extraArgument
 ]
 
-{ #category : #parameterization }
+{ #category : 'parameterization' }
 RBRenameVariableParametrizedTest >> extraArgument: anObject [
 
 	extraArgument := anObject
 ]
 
-{ #category : #parameterization }
+{ #category : 'parameterization' }
 RBRenameVariableParametrizedTest >> renameVariableClass [
 	^ rbClass
 ]

--- a/src/Refactoring2-Transformations-Tests/RBReplaceMessageSendParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBReplaceMessageSendParametrizedTest.class.st
@@ -1,17 +1,19 @@
 Class {
-	#name : #RBReplaceMessageSendParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#name : 'RBReplaceMessageSendParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBReplaceMessageSendParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBReplaceMessageSendTransformation };
 		yourself
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBReplaceMessageSendParametrizedTest >> testFailureIncompleteInitializers [
 	"please note that this strange way to create symbol is because some tests are counting symbol
 	and rewriting the code in a bad way so for now do not change them."
@@ -26,7 +28,7 @@ RBReplaceMessageSendParametrizedTest >> testFailureIncompleteInitializers [
 				inAllClasses: true)
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBReplaceMessageSendParametrizedTest >> testFailureNotUnderstandNewSelector [
 	self shouldFail: (rbClass
 			replaceCallMethod: #checkClass:
@@ -35,7 +37,7 @@ RBReplaceMessageSendParametrizedTest >> testFailureNotUnderstandNewSelector [
 			permutation: (1 to: 1))
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBReplaceMessageSendParametrizedTest >> testFailureNotUnderstandSelector [
 	self shouldFail: (rbClass
 			replaceCallMethod: #checkClass123:
@@ -44,7 +46,7 @@ RBReplaceMessageSendParametrizedTest >> testFailureNotUnderstandSelector [
 			permutation: (1 to: 1))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBReplaceMessageSendParametrizedTest >> testModelReplaceMethodOnlyInClass [
 	| refactoring sendersNewSelector sendersLastSelector selector newSelector |
 	selector := ('result', 'Class:') asSymbol.
@@ -63,7 +65,7 @@ RBReplaceMessageSendParametrizedTest >> testModelReplaceMethodOnlyInClass [
 		equals: (model allReferencesTo: newSelector) size
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBReplaceMessageSendParametrizedTest >> testModelReplaceMethodWithLessArgs [
 	| refactoring sendersNewSelector sendersLastSelector selector newSelector |
 	selector := ('called:', 'on:') asSymbol.
@@ -84,7 +86,7 @@ RBReplaceMessageSendParametrizedTest >> testModelReplaceMethodWithLessArgs [
 		equals: (model allReferencesTo: newSelector) size
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBReplaceMessageSendParametrizedTest >> testModelReplaceMethodWithMoreArgs [
 	| refactoring sendersNewSelector sendersLastSelector selector newSelector |
 	selector := ('called:', 'on:') asSymbol.
@@ -106,7 +108,7 @@ RBReplaceMessageSendParametrizedTest >> testModelReplaceMethodWithMoreArgs [
 		equals: (model allReferencesTo: newSelector) size
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBReplaceMessageSendParametrizedTest >> testModelReplaceMethodWithSameArgs [
 	| refactoring sendersNewSelector sendersLastSelector selector newSelector |
 	selector := ('called:', 'on:') asSymbol.
@@ -127,7 +129,7 @@ RBReplaceMessageSendParametrizedTest >> testModelReplaceMethodWithSameArgs [
 		equals: (model allReferencesTo: newSelector) size
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBReplaceMessageSendParametrizedTest >> testReplaceMethodInAllClasses [
 	| refactoring sendersNewSelector sendersLastSelector selector newSelector |
 	selector := ('an', 'InstVar:') asSymbol.
@@ -145,7 +147,7 @@ RBReplaceMessageSendParametrizedTest >> testReplaceMethodInAllClasses [
 		equals: (refactoring model allReferencesTo: newSelector) size
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBReplaceMessageSendParametrizedTest >> testReplaceMethodOnlyInClass [
 	| refactoring sendersNewSelector sendersLastSelector selector newSelector |
 	selector := ('result', 'Class:') asSymbol.

--- a/src/Refactoring2-Transformations-Tests/RBReplaceSubtreeTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBReplaceSubtreeTransformationTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBReplaceSubtreeTransformationTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBReplaceSubtreeTransformationTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBReplaceSubtreeTransformationTest >> testEmptyCode [
 
 	self shouldFail: (RBReplaceSubtreeTransformation
@@ -14,7 +16,7 @@ RBReplaceSubtreeTransformationTest >> testEmptyCode [
 			 inClass: #RBRemoveMethodTransformation)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBReplaceSubtreeTransformationTest >> testFailureExtract [
 
 	self shouldFail: (RBReplaceSubtreeTransformation
@@ -24,7 +26,7 @@ RBReplaceSubtreeTransformationTest >> testFailureExtract [
 			 inClass: #RBRemoveMethodTransformation)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBReplaceSubtreeTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBReplaceSubtreeTransformation
@@ -34,7 +36,7 @@ RBReplaceSubtreeTransformationTest >> testMethodDoesNotExist [
 			 inClass: #RBRemoveMethodTransformation)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBReplaceSubtreeTransformationTest >> testParseFailure [
 
 	self shouldFail: (RBReplaceSubtreeTransformation
@@ -44,7 +46,7 @@ RBReplaceSubtreeTransformationTest >> testParseFailure [
 			 inClass: #RBRemoveMethodTransformation)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBReplaceSubtreeTransformationTest >> testRefactoring [
 
 	| transformation class |
@@ -69,7 +71,7 @@ RBReplaceSubtreeTransformationTest >> testRefactoring [
 			isReturn
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBReplaceSubtreeTransformationTest >> testTransform [
 
 	| transformation class |
@@ -96,7 +98,7 @@ RBReplaceSubtreeTransformationTest >> testTransform [
 		equals: 123
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBReplaceSubtreeTransformationTest >> testTransformOneOfManyStatements [
 
 	| transformation class |

--- a/src/Refactoring2-Transformations-Tests/RBSplitCascadeParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBSplitCascadeParametrizedTest.class.st
@@ -1,41 +1,43 @@
 Class {
-	#name : #RBSplitCascadeParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#name : 'RBSplitCascadeParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBSplitCascadeParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBSplitCascadeRefactoring };
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBSplitCascadeParametrizedTest >> constructor [
 	^ #split:from:in:
 ]
 
-{ #category : #data }
+{ #category : 'data' }
 RBSplitCascadeParametrizedTest >> methodWithCascades [
 	| a |
 	a := Object new initialize; asString.
 	^ a
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBSplitCascadeParametrizedTest >> testFailureMethodWithoutCascade [
 	self shouldFail: (self createRefactoringWithArguments:
 		{ (54 to: 55) . ('an', 'InstVar:') asSymbol . RBBasicLintRuleTestData })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBSplitCascadeParametrizedTest >> testFailureNonExistantSelectorName [
 	self shouldFail: (self createRefactoringWithArguments:
 		{ (54 to: 55) . #foo . self class })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBSplitCascadeParametrizedTest >> testSplitCascadeRefactoring [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments:

--- a/src/Refactoring2-Transformations-Tests/RBSplitClassParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBSplitClassParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBSplitClassParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-SingleParametrized'
+	#name : 'RBSplitClassParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-SingleParametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'SingleParametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBSplitClassParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBSplitClassRefactoring };
@@ -12,12 +14,12 @@ RBSplitClassParametrizedTest class >> testParameters [
 		"yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBSplitClassParametrizedTest >> constructor [
 	^ #class:instanceVariables:newClassName:referenceVariableName:
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBSplitClassParametrizedTest >> testFailureInvalidInstanceVariableName [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -27,7 +29,7 @@ RBSplitClassParametrizedTest >> testFailureInvalidInstanceVariableName [
 				 #blocks })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBSplitClassParametrizedTest >> testFailureInvalidNewClassName [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -37,7 +39,7 @@ RBSplitClassParametrizedTest >> testFailureInvalidNewClassName [
 				 #blocks })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBSplitClassParametrizedTest >> testFailureInvalidReferenceVariableName [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -52,7 +54,7 @@ RBSplitClassParametrizedTest >> testFailureInvalidReferenceVariableName [
 				 #temp })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBSplitClassParametrizedTest >> testSplitClass [
 	|ref aModel|
 	ref := self createRefactoringWithArguments:

--- a/src/Refactoring2-Transformations-Tests/RBSplitClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBSplitClassTransformationTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBSplitClassTransformationTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBSplitClassTransformationTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBSplitClassTransformationTest >> testClassVariable [
 
 	self shouldFail: (RBSplitClassTransformation
@@ -14,7 +16,7 @@ RBSplitClassTransformationTest >> testClassVariable [
 			 referenceVariableName: #receiver)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBSplitClassTransformationTest >> testNonExistantName [
 
 	self shouldFail: (RBSplitClassTransformation
@@ -24,7 +26,7 @@ RBSplitClassTransformationTest >> testNonExistantName [
 			 referenceVariableName: #newName)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBSplitClassTransformationTest >> testTransform [
 
 	| transformation class |

--- a/src/Refactoring2-Transformations-Tests/RBTemporaryToInstanceVariableParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBTemporaryToInstanceVariableParametrizedTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RBTemporaryToInstanceVariableParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#name : 'RBTemporaryToInstanceVariableParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTemporaryToInstanceVariableParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBTemporaryToInstanceVariableRefactoring };
@@ -12,7 +14,7 @@ RBTemporaryToInstanceVariableParametrizedTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBTemporaryToInstanceVariableParametrizedTest >> addClassHierarchy [
 	model
 		defineClass: 'Foo << #Foo1
@@ -23,18 +25,18 @@ RBTemporaryToInstanceVariableParametrizedTest >> addClassHierarchy [
 		classified: #(#accessing)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBTemporaryToInstanceVariableParametrizedTest >> constructor [
 	^ #class:selector:variable:
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RBTemporaryToInstanceVariableParametrizedTest >> setUp [
 	super setUp.
 	model := self rbModelForVariableTest
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBTemporaryToInstanceVariableParametrizedTest >> testFailureHierarchyDefinesVarableNamedAsTemporary [
 
 	| class |
@@ -46,7 +48,7 @@ RBTemporaryToInstanceVariableParametrizedTest >> testFailureHierarchyDefinesVara
 				 'foo' })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBTemporaryToInstanceVariableParametrizedTest >> testFailureNonExistantName [
 
 	self shouldFail: (self createRefactoringWithArguments: {
@@ -59,7 +61,7 @@ RBTemporaryToInstanceVariableParametrizedTest >> testFailureNonExistantName [
 				 'aSmalllintContext' })
 ]
 
-{ #category : #'failure tests' }
+{ #category : 'failure tests' }
 RBTemporaryToInstanceVariableParametrizedTest >> testFailureRedefinedTemporary [
 
 	| class |
@@ -74,7 +76,7 @@ RBTemporaryToInstanceVariableParametrizedTest >> testFailureRedefinedTemporary [
 				 'instVarName1' })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTemporaryToInstanceVariableParametrizedTest >> testTemporaryToInstanceVariable [
 	| refactoring class |
 	refactoring := self createRefactoringWithArguments:
@@ -92,7 +94,7 @@ RBTemporaryToInstanceVariableParametrizedTest >> testTemporaryToInstanceVariable
 	self assert: (class directlyDefinesInstanceVariable: 'nameStream')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTemporaryToInstanceVariableParametrizedTest >> testWhenHierarchyDefinesVariableNamedAsTemporary [
 	| class refactoring |
 	self addClassHierarchy.

--- a/src/Refactoring2-Transformations-Tests/RBTransformationsTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBTransformationsTest.class.st
@@ -1,17 +1,19 @@
 Class {
-	#name : #RBTransformationsTest,
-	#superclass : #RBAbstractTransformationTest,
-	#category : #'Refactoring2-Transformations-Tests-Test'
+	#name : 'RBTransformationsTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring2-Transformations-Tests-Test',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Test'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 RBTransformationsTest >> setUp [
 
 	super setUp.
 	model := self rbModelForVariableTest
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTransformationsTest >> testAddClassTransform [
 
 	| transformation class |
@@ -25,7 +27,7 @@ RBTransformationsTest >> testAddClassTransform [
 	self assert: class comment equals: 'New comment for class'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTransformationsTest >> testAddMethodCommentTransform [
 
 	| transformation method |
@@ -44,7 +46,7 @@ RBTransformationsTest >> testAddMethodCommentTransform [
 		equals: 'New comment for method'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTransformationsTest >> testAddMethodTransform [
 
 	| transformation class |
@@ -59,7 +61,7 @@ RBTransformationsTest >> testAddMethodTransform [
 		equals: (self parseMethod: 'printString1 ^super printString')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTransformationsTest >> testAddProtocolTransform [
 
 	| transformation |
@@ -70,7 +72,7 @@ RBTransformationsTest >> testAddProtocolTransform [
 	self assert: transformation model changes changes size equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTransformationsTest >> testAddTemporaryVariableTransform [
 
 	| transformation class |
@@ -90,7 +92,7 @@ RBTransformationsTest >> testAddTemporaryVariableTransform [
 		equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTransformationsTest >> testAddVariableAccessorTransform [
 
 	| transformation class |
@@ -111,7 +113,7 @@ RBTransformationsTest >> testAddVariableAccessorTransform [
 		equals: (self parseMethod: 'instVar: anObject instVar := anObject')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTransformationsTest >> testAddVariableTransform [
 
 	| transformation class |
@@ -127,7 +129,7 @@ RBTransformationsTest >> testAddVariableTransform [
 	self assert: (class directlyDefinesInstanceVariable: 'asdf')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTransformationsTest >> testCompositeTransform [
 
 	| transformation newClassName class |
@@ -159,7 +161,7 @@ RBTransformationsTest >> testCompositeTransform [
 		equals: (self parseMethod: 'printString1 ^super printString')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTransformationsTest >> testCustomTransform [
 
 	| transformation newClassName class |
@@ -186,7 +188,7 @@ RBTransformationsTest >> testCustomTransform [
 	self assert: (class directlyDefinesInstanceVariable: 'asdf')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTransformationsTest >> testDeprecateClassTransform [
 
 	| transformation class |
@@ -216,7 +218,7 @@ RBTransformationsTest >> testDeprecateClassTransform [
 				^ Smalltalk ui icons iconNamed: #packageDelete')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTransformationsTest >> testMoveInstanceVariableToClassTransform [
 
 	| transformation oldClass newClass |
@@ -247,7 +249,7 @@ RBTransformationsTest >> testMoveInstanceVariableToClassTransform [
 	self assert: (newClass directlyDefinesInstanceVariable: 'asdf')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTransformationsTest >> testPullUpVariableTransform [
 
 	| transformation |
@@ -267,7 +269,7 @@ RBTransformationsTest >> testPullUpVariableTransform [
 			 directlyDefinesInstanceVariable: 'result')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTransformationsTest >> testPushDownVariableTransform [
 
 	| transformation |
@@ -280,7 +282,7 @@ RBTransformationsTest >> testPushDownVariableTransform [
 		self assert: (each directlyDefinesInstanceVariable: 'foo1') ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTransformationsTest >> testRemoveClassTransform [
 
 	| transformation newClass superclass |
@@ -300,7 +302,7 @@ RBTransformationsTest >> testRemoveClassTransform [
 			 includes: newClass) not
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTransformationsTest >> testRemoveMessageSendTransform [
 
 	| transformation class |
@@ -319,7 +321,7 @@ RBTransformationsTest >> testRemoveMessageSendTransform [
 	aBlock value')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTransformationsTest >> testRemoveMethodTransform [
 
 	| transformation class |
@@ -334,7 +336,7 @@ RBTransformationsTest >> testRemoveMethodTransform [
 	self deny: (class directlyDefinesMethod: #one)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTransformationsTest >> testRemoveVariableTransform [
 
 	| transformation class |
@@ -350,7 +352,7 @@ RBTransformationsTest >> testRemoveVariableTransform [
 	self deny: (class directlyDefinesInstanceVariable: 'instVar')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTransformationsTest >> testRenameClassTransform [
 
 	| transformation class newClassName oldClassName |
@@ -385,7 +387,7 @@ RBTransformationsTest >> testRenameClassTransform [
 		equals: (self parseMethod: 'reference ^ RBNewDummyClassName new')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTransformationsTest >> testRenameTemporaryTransform [
 
 	| transformation class |
@@ -418,7 +420,7 @@ RBTransformationsTest >> testRenameTemporaryTransform [
 			 e name = #temp2 ])
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBTransformationsTest >> testRenameVariableTransform [
 
 	| transformation class |

--- a/src/Refactoring2-Transformations-Tests/RBWithDifferentConstructorsParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBWithDifferentConstructorsParametrizedTest.class.st
@@ -1,25 +1,27 @@
 Class {
-	#name : #RBWithDifferentConstructorsParametrizedTest,
-	#superclass : #RBAbstractRefactoringTest,
+	#name : 'RBWithDifferentConstructorsParametrizedTest',
+	#superclass : 'RBAbstractRefactoringTest',
 	#instVars : [
 		'constructor'
 	],
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #parameterization }
+{ #category : 'parameterization' }
 RBWithDifferentConstructorsParametrizedTest >> constructor: anObject [
 
 	constructor := anObject
 ]
 
-{ #category : #builder }
+{ #category : 'builder' }
 RBWithDifferentConstructorsParametrizedTest >> createRefactoringWithArguments: aParameterCollection [
 
 	^ rbClass perform: constructor withArguments: aParameterCollection
 ]
 
-{ #category : #builder }
+{ #category : 'builder' }
 RBWithDifferentConstructorsParametrizedTest >> createRefactoringWithModel: rbNamespace andArguments: aParameterCollection [
 
 	^ rbClass

--- a/src/Refactoring2-Transformations-Tests/RBWithDifferentsArgumentsParametrizedTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBWithDifferentsArgumentsParametrizedTest.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #RBWithDifferentsArgumentsParametrizedTest,
-	#superclass : #RBWithDifferentConstructorsParametrizedTest,
+	#name : 'RBWithDifferentsArgumentsParametrizedTest',
+	#superclass : 'RBWithDifferentConstructorsParametrizedTest',
 	#instVars : [
 		'index'
 	],
-	#category : #'Refactoring2-Transformations-Tests-Parametrized'
+	#category : 'Refactoring2-Transformations-Tests-Parametrized',
+	#package : 'Refactoring2-Transformations-Tests',
+	#tag : 'Parametrized'
 }
 
-{ #category : #builder }
+{ #category : 'builder' }
 RBWithDifferentsArgumentsParametrizedTest >> createRefactoringWithArguments: aParameterCollection [
 
 	^ rbClass
@@ -15,7 +17,7 @@ RBWithDifferentsArgumentsParametrizedTest >> createRefactoringWithArguments: aPa
 		  withArguments: (self selectIndex: index of: aParameterCollection)
 ]
 
-{ #category : #builder }
+{ #category : 'builder' }
 RBWithDifferentsArgumentsParametrizedTest >> createRefactoringWithModel: rbNamespace andArguments: aParameterCollection [
 
 	^ rbClass
@@ -25,13 +27,13 @@ RBWithDifferentsArgumentsParametrizedTest >> createRefactoringWithModel: rbNames
 		  , (self selectIndex: index of: aParameterCollection)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBWithDifferentsArgumentsParametrizedTest >> index: aBlock [
 
 	index := aBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RBWithDifferentsArgumentsParametrizedTest >> selectIndex: anInteger of: aCollection [
 	^ aCollection collect: [ :each | each isArray ifTrue: [each at: anInteger ] ifFalse: each ]
 ]

--- a/src/Refactoring2-Transformations-Tests/package.st
+++ b/src/Refactoring2-Transformations-Tests/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Refactoring2-Transformations-Tests' }
+Package { #name : 'Refactoring2-Transformations-Tests' }

--- a/src/SystemCommands-MethodCommands/SycAddProtocolScopeCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycAddProtocolScopeCommand.class.st
@@ -2,15 +2,16 @@
 I am a command to add protocol scope to listScopes
 "
 Class {
-	#name : #SycAddProtocolScopeCommand,
-	#superclass : #SycProtocolCmCommand,
+	#name : 'SycAddProtocolScopeCommand',
+	#superclass : 'SycProtocolCmCommand',
 	#instVars : [
 		'class'
 	],
-	#category : #'SystemCommands-MethodCommands'
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycAddProtocolScopeCommand >> execute [
 
 	| scope protocols |
@@ -22,17 +23,17 @@ SycAddProtocolScopeCommand >> execute [
 	RefactoringSettings addScope: scope
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycAddProtocolScopeCommand >> icon [
 	^ self iconNamed: #add
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycAddProtocolScopeCommand >> name [
 	^ 'Add protocols to scope list'
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycAddProtocolScopeCommand >> prepareFullExecution [
 	super prepareFullExecution.
 	class := context lastSelectedClass

--- a/src/SystemCommands-MethodCommands/SycClassifyMethodCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycClassifyMethodCommand.class.st
@@ -7,51 +7,52 @@ Internal Representation and Key Implementation Points.
 	protocol:		<Symbol>
 "
 Class {
-	#name : #SycClassifyMethodCommand,
-	#superclass : #SycMethodCommand,
+	#name : 'SycClassifyMethodCommand',
+	#superclass : 'SycMethodCommand',
 	#instVars : [
 		'protocol'
 	],
-	#category : #'SystemCommands-MethodCommands'
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycClassifyMethodCommand >> applyResultInContext: aToolContext [
 	super applyResultInContext: aToolContext.
 	aToolContext showProtocol: protocol
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycClassifyMethodCommand >> defaultMenuIconName [
 
 	^ #glamorousBrowse
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycClassifyMethodCommand >> defaultMenuItemName [
 
 	^ 'Classify methods'
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycClassifyMethodCommand >> execute [
 
 	methods do: [ :aMethod | aMethod protocol: protocol ]
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycClassifyMethodCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
 
 	protocol := aToolContext requestProtocol: 'New protocol name'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycClassifyMethodCommand >> protocol [
 	^ protocol
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycClassifyMethodCommand >> protocol: protocolName [
 	protocol := protocolName
 ]

--- a/src/SystemCommands-MethodCommands/SycCopyMethodNameToClypboardCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycCopyMethodNameToClypboardCommand.class.st
@@ -1,25 +1,26 @@
 Class {
-	#name : #SycCopyMethodNameToClypboardCommand,
-	#superclass : #SycMethodCommand,
-	#category : #'SystemCommands-MethodCommands'
+	#name : 'SycCopyMethodNameToClypboardCommand',
+	#superclass : 'SycMethodCommand',
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycCopyMethodNameToClypboardCommand >> defaultMenuIconName [
 	^#smallCopy
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycCopyMethodNameToClypboardCommand >> defaultMenuItemName [
 	^'Copy name(s) to Clipboard'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycCopyMethodNameToClypboardCommand >> description [
 	^'Copy selected methods into Clipboard as class>>selector'
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycCopyMethodNameToClypboardCommand >> execute [
 	| text |
 	text := (methods collect: [ :each | each displayString ]) joinUsing: String cr.

--- a/src/SystemCommands-MethodCommands/SycCopyTestMethodNameToClypboardCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycCopyTestMethodNameToClypboardCommand.class.st
@@ -2,27 +2,28 @@
 Copy selected methods selector into Clipboard as testOriginalSelector
 "
 Class {
-	#name : #SycCopyTestMethodNameToClypboardCommand,
-	#superclass : #SycMethodCommand,
-	#category : #'SystemCommands-MethodCommands'
+	#name : 'SycCopyTestMethodNameToClypboardCommand',
+	#superclass : 'SycMethodCommand',
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycCopyTestMethodNameToClypboardCommand >> defaultMenuIconName [
 	^#smallCopy
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycCopyTestMethodNameToClypboardCommand >> defaultMenuItemName [
 	^'Copy test method selector(s) to Clipboard'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycCopyTestMethodNameToClypboardCommand >> description [
 	^'Copy selected methods selector into Clipboard as testXXX'
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycCopyTestMethodNameToClypboardCommand >> execute [
 	| text |
 	text := (methods collect: [ :each | each selector asTestSelector ]) joinUsing: String cr.

--- a/src/SystemCommands-MethodCommands/SycFindAndReplaceSetUpCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycFindAndReplaceSetUpCommand.class.st
@@ -2,15 +2,16 @@
 I am a command to find and replace setUp method in owner class and its subclasses if apply
 "
 Class {
-	#name : #SycFindAndReplaceSetUpCommand,
-	#superclass : #SycMethodCmCommand,
+	#name : 'SycFindAndReplaceSetUpCommand',
+	#superclass : 'SycMethodCmCommand',
 	#instVars : [
 		'method'
 	],
-	#category : #'SystemCommands-MethodCommands'
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #executing }
+{ #category : 'executing' }
 SycFindAndReplaceSetUpCommand >> executeRefactoring [
 	| refactoring |
 	refactoring := RBFindAndReplaceSetUpTransformation
@@ -20,23 +21,23 @@ SycFindAndReplaceSetUpCommand >> executeRefactoring [
 	refactoring execute
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SycFindAndReplaceSetUpCommand >> isApplicable [
 	^ context lastSelectedMethod selector = #setUp
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycFindAndReplaceSetUpCommand >> name [
 	^ 'Find and replace setUp'
 ]
 
-{ #category : #preparation }
+{ #category : 'preparation' }
 SycFindAndReplaceSetUpCommand >> prepareFullExecution [
 	super prepareFullExecution.
 	method := context lastSelectedMethod
 ]
 
-{ #category : #executing }
+{ #category : 'executing' }
 SycFindAndReplaceSetUpCommand >> searchInTheWholeHierarchy [
 
 	^ method origin subclasses

--- a/src/SystemCommands-MethodCommands/SycMethodCmCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMethodCmCommand.class.st
@@ -2,17 +2,18 @@
 This class is an extension so we can mix command of Commander2 with Commander.
 "
 Class {
-	#name : #SycMethodCmCommand,
-	#superclass : #SycCmCommand,
-	#category : #'SystemCommands-MethodCommands'
+	#name : 'SycMethodCmCommand',
+	#superclass : 'SycCmCommand',
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycMethodCmCommand class >> activationStrategy [
 	^ SycMethodMenuActivation
 ]
 
-{ #category : #preparation }
+{ #category : 'preparation' }
 SycMethodCmCommand >> prepareFullExecution [
 	super prepareFullExecution.
 	self setUpModelFromContext: context

--- a/src/SystemCommands-MethodCommands/SycMethodCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMethodCommand.class.st
@@ -7,50 +7,51 @@ Internal Representation and Key Implementation Points.
 	methods:		<Colletion of<CompiledMethod>>
 "
 Class {
-	#name : #SycMethodCommand,
-	#superclass : #CmdCommand,
+	#name : 'SycMethodCommand',
+	#superclass : 'CmdCommand',
 	#traits : 'TRefactoringCommandSupport',
 	#classTraits : 'TRefactoringCommandSupport classTrait',
 	#instVars : [
 		'methods'
 	],
-	#category : #'SystemCommands-MethodCommands'
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SycMethodCommand class >> canBeExecutedInContext: aToolContext [
 	^aToolContext isMethodSelected
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SycMethodCommand class >> for: methods [
 	^self new
 		methods: methods
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SycMethodCommand class >> isAbstract [
 	^self = SycMethodCommand
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycMethodCommand >> methods [
 	^ methods
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycMethodCommand >> methods: anObject [
 	methods := anObject
 ]
 
-{ #category : #'activation - drag and drop' }
+{ #category : 'activation - drag and drop' }
 SycMethodCommand >> prepareExecutionInDragContext: aToolContext [
 	super prepareExecutionInDragContext: aToolContext.
 
 	methods := aToolContext selectedMethods
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycMethodCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
 	methods := aToolContext selectedMethods

--- a/src/SystemCommands-MethodCommands/SycMethodRepackagingCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMethodRepackagingCommand.class.st
@@ -8,23 +8,24 @@ I provide suitable methods for subclasses to move methods to package:
 Subclasses should just decide what package it should be. 
 "
 Class {
-	#name : #SycMethodRepackagingCommand,
-	#superclass : #SycMethodCommand,
-	#category : #'SystemCommands-MethodCommands'
+	#name : 'SycMethodRepackagingCommand',
+	#superclass : 'SycMethodCommand',
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SycMethodRepackagingCommand class >> isAbstract [
 	^self = SycMethodRepackagingCommand
 ]
 
-{ #category : #categories }
+{ #category : 'categories' }
 SycMethodRepackagingCommand >> classifyMethod: aMethod [
 
 	aMethod protocol: (self newProtocolFor: aMethod)
 ]
 
-{ #category : #categories }
+{ #category : 'categories' }
 SycMethodRepackagingCommand >> newProtocolFor: aMethod [
 
 	^ self asCommandActivator context requestProtocol: 'New protocol name for: ' , aMethod name suggesting: (MethodClassifier suggestProtocolFor: aMethod)

--- a/src/SystemCommands-MethodCommands/SycMoveMethodsToClassCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMoveMethodsToClassCommand.class.st
@@ -7,31 +7,32 @@ Internal Representation and Key Implementation Points.
 	targetClass:		<Class>
 "
 Class {
-	#name : #SycMoveMethodsToClassCommand,
-	#superclass : #SycMethodCommand,
+	#name : 'SycMoveMethodsToClassCommand',
+	#superclass : 'SycMethodCommand',
 	#instVars : [
 		'targetClass'
 	],
-	#category : #'SystemCommands-MethodCommands'
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SycMoveMethodsToClassCommand class >> methods: methods class: targetClass [
 	^(self for: methods)
 		targetClass: targetClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycMoveMethodsToClassCommand >> defaultMenuIconName [
 	^ #smallRedo
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycMoveMethodsToClassCommand >> defaultMenuItemName [
 	^'Move to another class'
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycMoveMethodsToClassCommand >> execute [
 
 	methods
@@ -40,14 +41,14 @@ SycMoveMethodsToClassCommand >> execute [
 	methods do: [ :each | each origin removeEmptyProtocols ]
 ]
 
-{ #category : #'drag and drop support' }
+{ #category : 'drag and drop support' }
 SycMoveMethodsToClassCommand >> prepareExecutionInDropContext: aToolContext [
 	super prepareExecutionInDropContext: aToolContext.
 	targetClass := aToolContext lastSelectedClass.
 	targetClass := aToolContext currentMetaLevelOf: targetClass
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycMoveMethodsToClassCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
 
@@ -55,12 +56,12 @@ SycMoveMethodsToClassCommand >> prepareFullExecutionInContext: aToolContext [
 	targetClass := aToolContext currentMetaLevelOf: targetClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycMoveMethodsToClassCommand >> targetClass [
 	^ targetClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycMoveMethodsToClassCommand >> targetClass: anObject [
 	targetClass := anObject
 ]

--- a/src/SystemCommands-MethodCommands/SycMoveMethodsToClassSideCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMoveMethodsToClassSideCommand.class.st
@@ -2,37 +2,38 @@
 I am a command to move method to the class side of defining class
 "
 Class {
-	#name : #SycMoveMethodsToClassSideCommand,
-	#superclass : #SycMethodCommand,
+	#name : 'SycMoveMethodsToClassSideCommand',
+	#superclass : 'SycMethodCommand',
 	#instVars : [
 		'refactoringScopes'
 	],
-	#category : #'SystemCommands-MethodCommands'
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SycMoveMethodsToClassSideCommand class >> canBeExecutedInContext: aToolContext [
 	^(super canBeExecutedInContext: aToolContext)
 		and: [ aToolContext isInstanceSideMethodSelected ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycMoveMethodsToClassSideCommand >> defaultMenuIconName [
 	^ #smallRedo
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycMoveMethodsToClassSideCommand >> defaultMenuItemName [
 	^'Move to class side'
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycMoveMethodsToClassSideCommand >> execute [
 
 	(RBMoveMethodsToClassSideDriver scopes: refactoringScopes methods: methods) runRefactoring
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycMoveMethodsToClassSideCommand >> prepareFullExecutionInContext: aToolContext [
 
 	super prepareFullExecutionInContext: aToolContext.

--- a/src/SystemCommands-MethodCommands/SycMoveMethodsToInstanceSideCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMoveMethodsToInstanceSideCommand.class.st
@@ -2,28 +2,29 @@
 I am a command to move method to the instance side of defining class
 "
 Class {
-	#name : #SycMoveMethodsToInstanceSideCommand,
-	#superclass : #SycMethodCommand,
-	#category : #'SystemCommands-MethodCommands'
+	#name : 'SycMoveMethodsToInstanceSideCommand',
+	#superclass : 'SycMethodCommand',
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SycMoveMethodsToInstanceSideCommand class >> canBeExecutedInContext: aToolContext [
 	^(super canBeExecutedInContext: aToolContext)
 		and: [ aToolContext isClassSideMethodSelected ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycMoveMethodsToInstanceSideCommand >> defaultMenuIconName [
 	^ #smallRedo
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycMoveMethodsToInstanceSideCommand >> defaultMenuItemName [
 	^'Move to instance side'
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycMoveMethodsToInstanceSideCommand >> execute [
 
 	methods

--- a/src/SystemCommands-MethodCommands/SycMoveMethodsToPackageCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMoveMethodsToPackageCommand.class.st
@@ -9,31 +9,32 @@ Internal Representation and Key Implementation Points.
 	package:		<RPackage>
 "
 Class {
-	#name : #SycMoveMethodsToPackageCommand,
-	#superclass : #SycMethodRepackagingCommand,
+	#name : 'SycMoveMethodsToPackageCommand',
+	#superclass : 'SycMethodRepackagingCommand',
 	#instVars : [
 		'package'
 	],
-	#category : #'SystemCommands-MethodCommands'
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SycMoveMethodsToPackageCommand class >> for: methods to: aPackage [
 	^(self for: methods)
 		package: aPackage
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycMoveMethodsToPackageCommand >> defaultMenuIconName [
 	^ #smallRedo
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycMoveMethodsToPackageCommand >> defaultMenuItemName [
 	^'Move to package'
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycMoveMethodsToPackageCommand >> execute [
 
 	methods do: [ :each |
@@ -41,7 +42,7 @@ SycMoveMethodsToPackageCommand >> execute [
 		each origin removeEmptyProtocols ]
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycMoveMethodsToPackageCommand >> moveMethod: aMethod toPackage: aPackage [
 
 	| existingPackage willBeExtension |
@@ -55,23 +56,23 @@ SycMoveMethodsToPackageCommand >> moveMethod: aMethod toPackage: aPackage [
 		ifFalse: [ self classifyMethod: aMethod ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycMoveMethodsToPackageCommand >> package [
 	^ package
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycMoveMethodsToPackageCommand >> package: anObject [
 	package := anObject
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycMoveMethodsToPackageCommand >> prepareExecutionInDropContext: aToolContext [
 	super prepareExecutionInDropContext: aToolContext.
 	package := aToolContext lastSelectedPackage
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycMoveMethodsToPackageCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
 

--- a/src/SystemCommands-MethodCommands/SycMoveMethodsToTheDefiningClassCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMoveMethodsToTheDefiningClassCommand.class.st
@@ -4,29 +4,30 @@ I am a command to move methods to their defining class.
 I am used to convert extension method to normal one
 "
 Class {
-	#name : #SycMoveMethodsToTheDefiningClassCommand,
-	#superclass : #SycMethodRepackagingCommand,
-	#category : #'SystemCommands-MethodCommands'
+	#name : 'SycMoveMethodsToTheDefiningClassCommand',
+	#superclass : 'SycMethodRepackagingCommand',
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SycMoveMethodsToTheDefiningClassCommand class >> canBeExecutedInContext: aToolContext [
 	^aToolContext isExtensionMethodSelected
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycMoveMethodsToTheDefiningClassCommand >> defaultMenuIconName [
 
 	^ #smallRedo
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycMoveMethodsToTheDefiningClassCommand >> defaultMenuItemName [
 
 	^ 'Move to defining class'
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycMoveMethodsToTheDefiningClassCommand >> execute [
 
 	methods

--- a/src/SystemCommands-MethodCommands/SycNotRemoveMethodStrategy.class.st
+++ b/src/SystemCommands-MethodCommands/SycNotRemoveMethodStrategy.class.st
@@ -2,16 +2,17 @@
 I am simple cancel method remove operation by doing nothing
 "
 Class {
-	#name : #SycNotRemoveMethodStrategy,
-	#superclass : #SycRemoveMethodStrategy,
-	#category : #'SystemCommands-MethodCommands'
+	#name : 'SycNotRemoveMethodStrategy',
+	#superclass : 'SycRemoveMethodStrategy',
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycNotRemoveMethodStrategy >> removeMethods: methods [
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycNotRemoveMethodStrategy >> userRequestString [
 	^'Forget it -- do nothing -- sorry I asked'
 ]

--- a/src/SystemCommands-MethodCommands/SycOpenAdvancedDebuggingInMethodMenuCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycOpenAdvancedDebuggingInMethodMenuCommand.class.st
@@ -3,36 +3,37 @@ I am a command to open special method menu containing debugging commands.
 I show in menu all commands annotated by SycAdvancedDebuggingMenuActivation
 "
 Class {
-	#name : #SycOpenAdvancedDebuggingInMethodMenuCommand,
-	#superclass : #SycOpenDebuggingInMethodMenuCommand,
-	#category : #'SystemCommands-MethodCommands'
+	#name : 'SycOpenAdvancedDebuggingInMethodMenuCommand',
+	#superclass : 'SycOpenDebuggingInMethodMenuCommand',
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #activation }
+{ #category : 'activation' }
 SycOpenAdvancedDebuggingInMethodMenuCommand class >> methodContextMenuActivation [
 	<classAnnotation>
 
 	^CmdContextMenuActivation byRootGroupItemOrder: 1.5 for: ClyMethod asCalypsoItemContext
 ]
 
-{ #category : #activation }
+{ #category : 'activation' }
 SycOpenAdvancedDebuggingInMethodMenuCommand class >> methodEditorShortcutActivation [
 	<classAnnotation>
 
 	^CmdShortcutActivation by: $h meta shift for: ClyMethod asCalypsoItemContext
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycOpenAdvancedDebuggingInMethodMenuCommand >> activationStrategy [
 	^SycAdvancedDebuggingMenuActivation
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycOpenAdvancedDebuggingInMethodMenuCommand >> defaultMenuIconName [
 	^ #smallDebug
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycOpenAdvancedDebuggingInMethodMenuCommand >> defaultMenuItemName [
 	^'Debugging'
 ]

--- a/src/SystemCommands-MethodCommands/SycOpenDebuggingInMethodMenuCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycOpenDebuggingInMethodMenuCommand.class.st
@@ -3,37 +3,38 @@ I am a command to open special method menu containing breakpoint commands.
 I show in menu all commands annotated by SycDebuggingMenuActivation
 "
 Class {
-	#name : #SycOpenDebuggingInMethodMenuCommand,
-	#superclass : #SycOpenMethodMenuCommand,
-	#category : #'SystemCommands-MethodCommands'
+	#name : 'SycOpenDebuggingInMethodMenuCommand',
+	#superclass : 'SycOpenMethodMenuCommand',
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #activation }
+{ #category : 'activation' }
 SycOpenDebuggingInMethodMenuCommand class >> methodContextMenuActivation [
 	<classAnnotation>
 
 	^CmdContextMenuActivation byRootGroupItemOrder: 1.4 for: ClyMethod asCalypsoItemContext
 ]
 
-{ #category : #activation }
+{ #category : 'activation' }
 SycOpenDebuggingInMethodMenuCommand class >> methodEditorShortcutActivation [
 	<classAnnotation>
 
 	^CmdShortcutActivation by: $g meta shift for: ClyMethod asCalypsoItemContext
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycOpenDebuggingInMethodMenuCommand >> activationStrategy [
 
 	^ SycDebuggingMenuActivation
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycOpenDebuggingInMethodMenuCommand >> defaultMenuIconName [
 	^ #halt
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycOpenDebuggingInMethodMenuCommand >> defaultMenuItemName [
 	^'Breakpoints'
 ]

--- a/src/SystemCommands-MethodCommands/SycOpenMethodMenuCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycOpenMethodMenuCommand.class.st
@@ -3,22 +3,23 @@ I am a command to open special method menu.
 I show in menu all commands annotated by SycMethodMenuActivation
 "
 Class {
-	#name : #SycOpenMethodMenuCommand,
-	#superclass : #SycOpenContextMenuCommand,
-	#category : #'SystemCommands-MethodCommands'
+	#name : 'SycOpenMethodMenuCommand',
+	#superclass : 'SycOpenContextMenuCommand',
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycOpenMethodMenuCommand >> activationStrategy [
 	^ SycMethodMenuActivation
 ]
 
-{ #category : #'context menu' }
+{ #category : 'context menu' }
 SycOpenMethodMenuCommand >> cmCommandClass [
 	^ SycMethodCmCommand
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycOpenMethodMenuCommand >> defaultMenuItemName [
 	^'Refactorings'
 ]

--- a/src/SystemCommands-MethodCommands/SycOpenProtocolMenuCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycOpenProtocolMenuCommand.class.st
@@ -1,20 +1,21 @@
 Class {
-	#name : #SycOpenProtocolMenuCommand,
-	#superclass : #SycOpenContextMenuCommand,
-	#category : #'SystemCommands-MethodCommands'
+	#name : 'SycOpenProtocolMenuCommand',
+	#superclass : 'SycOpenContextMenuCommand',
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycOpenProtocolMenuCommand >> activationStrategy [
 	^ SycProtocolMenuActivation
 ]
 
-{ #category : #'context menu' }
+{ #category : 'context menu' }
 SycOpenProtocolMenuCommand >> cmCommandClass [
 	^ SycProtocolCmCommand
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycOpenProtocolMenuCommand >> defaultMenuItemName [
 	^'Scope'
 ]

--- a/src/SystemCommands-MethodCommands/SycOpenReflectivityInMethodMenuCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycOpenReflectivityInMethodMenuCommand.class.st
@@ -3,29 +3,30 @@ I am a command to open special method menu containing metalink related commands.
 I show in menu all commands annotated by SycReflectivityMenuActivation
 "
 Class {
-	#name : #SycOpenReflectivityInMethodMenuCommand,
-	#superclass : #SycOpenDebuggingInMethodMenuCommand,
-	#category : #'SystemCommands-MethodCommands'
+	#name : 'SycOpenReflectivityInMethodMenuCommand',
+	#superclass : 'SycOpenDebuggingInMethodMenuCommand',
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #activation }
+{ #category : 'activation' }
 SycOpenReflectivityInMethodMenuCommand class >> methodContextMenuActivation [
 	<classAnnotation>
 
 	^CmdContextMenuActivation byRootGroupItemOrder: 1.5 for: ClyMethod asCalypsoItemContext
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycOpenReflectivityInMethodMenuCommand >> activationStrategy [
 	^SycReflectivityMenuActivation
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycOpenReflectivityInMethodMenuCommand >> defaultMenuIconName [
 	^ #smallObjects
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycOpenReflectivityInMethodMenuCommand >> defaultMenuItemName [
 
 	^ 'Reflectivity'

--- a/src/SystemCommands-MethodCommands/SycProtocolCmCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycProtocolCmCommand.class.st
@@ -2,20 +2,21 @@
 This class is an extension so we can mix command of Commander2 with Commander.
 "
 Class {
-	#name : #SycProtocolCmCommand,
-	#superclass : #SycCmCommand,
+	#name : 'SycProtocolCmCommand',
+	#superclass : 'SycCmCommand',
 	#instVars : [
 		'methodGroups'
 	],
-	#category : #'SystemCommands-MethodCommands'
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycProtocolCmCommand class >> activationStrategy [
 	^ SycProtocolMenuActivation
 ]
 
-{ #category : #preparation }
+{ #category : 'preparation' }
 SycProtocolCmCommand >> prepareFullExecution [
 	super prepareFullExecution.
 	methodGroups := context selectedMethodGroups

--- a/src/SystemCommands-MethodCommands/SycPushDownMethodCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycPushDownMethodCommand.class.st
@@ -2,31 +2,32 @@
 I am a command to push down given methods
 "
 Class {
-	#name : #SycPushDownMethodCommand,
-	#superclass : #SysRefactoringMethodCommand,
+	#name : 'SycPushDownMethodCommand',
+	#superclass : 'SysRefactoringMethodCommand',
 	#instVars : [
 		'refactoringScopes'
 	],
-	#category : #'SystemCommands-MethodCommands'
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycPushDownMethodCommand >> asRefactorings [
 
 	^ self shouldNotImplement
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycPushDownMethodCommand >> defaultMenuIconName [
 	^ #down
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycPushDownMethodCommand >> defaultMenuItemName [
 	^'Push down'
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycPushDownMethodCommand >> executeRefactorings [
 
 	(RBPushDownMethodDriver
@@ -35,13 +36,13 @@ SycPushDownMethodCommand >> executeRefactorings [
 		pushDown: methods) runRefactoring
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SycPushDownMethodCommand >> isComplexRefactoring [
 
 	^ false
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycPushDownMethodCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
 	refactoringScopes := aToolContext refactoringScopes

--- a/src/SystemCommands-MethodCommands/SycPushDownMethodInSomeClassesCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycPushDownMethodInSomeClassesCommand.class.st
@@ -4,31 +4,32 @@ I am a command that pushes down methods in some classes.
 I am responsible for delegating execution to `RBPushDownMethodInSomeClassesDriver`.
 "
 Class {
-	#name : #SycPushDownMethodInSomeClassesCommand,
-	#superclass : #SysRefactoringMethodCommand,
+	#name : 'SycPushDownMethodInSomeClassesCommand',
+	#superclass : 'SysRefactoringMethodCommand',
 	#instVars : [
 		'refactoringScopes'
 	],
-	#category : #'SystemCommands-MethodCommands'
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #converting }
+{ #category : 'converting' }
 SycPushDownMethodInSomeClassesCommand >> asRefactorings [
 
 	self shouldNotImplement
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycPushDownMethodInSomeClassesCommand >> defaultMenuIconName [
 	^ #down
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycPushDownMethodInSomeClassesCommand >> defaultMenuItemName [
 	^'Push down in some classes'
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycPushDownMethodInSomeClassesCommand >> executeRefactorings [
 
 	(RBPushDownMethodInSomeClassesDriver
@@ -37,13 +38,13 @@ SycPushDownMethodInSomeClassesCommand >> executeRefactorings [
 		pushDown: methods) runRefactoring
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SycPushDownMethodInSomeClassesCommand >> isComplexRefactoring [ 
 
 	^ false
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycPushDownMethodInSomeClassesCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
 	refactoringScopes := aToolContext refactoringScopes

--- a/src/SystemCommands-MethodCommands/SycPushUpMethodCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycPushUpMethodCommand.class.st
@@ -2,31 +2,32 @@
 I am a command to push up given methods
 "
 Class {
-	#name : #SycPushUpMethodCommand,
-	#superclass : #SysRefactoringMethodCommand,
+	#name : 'SycPushUpMethodCommand',
+	#superclass : 'SysRefactoringMethodCommand',
 	#instVars : [
 		'refactoringScopes'
 	],
-	#category : #'SystemCommands-MethodCommands'
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycPushUpMethodCommand >> asRefactorings [
 
 	self shouldNotImplement
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycPushUpMethodCommand >> defaultMenuIconName [
 	^ #up
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycPushUpMethodCommand >> defaultMenuItemName [
 	^'Push up'
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycPushUpMethodCommand >> executeRefactorings [
 
 	(RBPushUpMethodDriver
@@ -35,13 +36,13 @@ SycPushUpMethodCommand >> executeRefactorings [
 		 pushUp: methods) runRefactoring
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SycPushUpMethodCommand >> isComplexRefactoring [
 
 	^ false
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycPushUpMethodCommand >> prepareFullExecutionInContext: aToolContext [
 
 	super prepareFullExecutionInContext: aToolContext.

--- a/src/SystemCommands-MethodCommands/SycRemoveMethod2Command.class.st
+++ b/src/SystemCommands-MethodCommands/SycRemoveMethod2Command.class.st
@@ -1,47 +1,47 @@
 Class {
-	#name : #SycRemoveMethod2Command,
-	#superclass : #SycMethodCommand,
+	#name : 'SycRemoveMethod2Command',
+	#superclass : 'SycMethodCommand',
 	#instVars : [
 		'removeStrategy',
 		'toolContext'
 	],
-	#category : #'SystemCommands-MethodCommands'
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #activation }
+{ #category : 'activation' }
 SycRemoveMethod2Command class >> methodMenuActivation [
 	<classAnnotation>
 
 	^ CmdContextMenuActivation byRootGroupItemOrder: 10000 for: ClyMethod asCalypsoItemContext
 ]
 
-{ #category : #activation }
+{ #category : 'activation' }
 SycRemoveMethod2Command class >> methodShortcutActivation [
 	<classAnnotation>
 
 	^CmdShortcutActivation removalFor: ClyMethod asCalypsoItemContext
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycRemoveMethod2Command >> defaultMenuIconName [
 	^#removeIcon
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycRemoveMethod2Command >> defaultMenuItemName [
 	^'Remove refactoring'
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycRemoveMethod2Command >> execute [
 	
 	(RBRemoveMethodDriver new
 				 scopes: toolContext refactoringScopes
-				 methods: methods
-				 for: methods first methodClass ) runRefactoring
+				 methods: methods) runRefactoring
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SycRemoveMethod2Command >> initialize [
 	
 	super initialize.
@@ -49,13 +49,13 @@ SycRemoveMethod2Command >> initialize [
 	removeStrategy := SycSilentlyRemoveMethodStrategy new
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycRemoveMethod2Command >> isComplexRefactoring [ 
 
 	^ false
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycRemoveMethod2Command >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
 	toolContext := aToolContext.
@@ -63,12 +63,12 @@ SycRemoveMethod2Command >> prepareFullExecutionInContext: aToolContext [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycRemoveMethod2Command >> removeStrategy [
 	^ removeStrategy
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycRemoveMethod2Command >> removeStrategy: anObject [
 	removeStrategy := anObject
 ]

--- a/src/SystemCommands-MethodCommands/SycRemoveMethodCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycRemoveMethodCommand.class.st
@@ -13,50 +13,51 @@ Internal Representation and Key Implementation Points.
 	removeStrategy:		<SycRemoveMethodStrategy>
 "
 Class {
-	#name : #SycRemoveMethodCommand,
-	#superclass : #SycMethodCommand,
+	#name : 'SycRemoveMethodCommand',
+	#superclass : 'SycMethodCommand',
 	#instVars : [
 		'removeStrategy'
 	],
-	#category : #'SystemCommands-MethodCommands'
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycRemoveMethodCommand >> defaultMenuIconName [
 	^#removeIcon
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycRemoveMethodCommand >> defaultMenuItemName [
 	^'Remove'
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycRemoveMethodCommand >> execute [
 
 	removeStrategy removeMethods: methods
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SycRemoveMethodCommand >> initialize [
 	super initialize.
 
 	removeStrategy := SycSilentlyRemoveMethodStrategy new
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycRemoveMethodCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
 
 	removeStrategy := aToolContext requestRemoveMethodStrategyFor: methods
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycRemoveMethodCommand >> removeStrategy [
 	^ removeStrategy
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycRemoveMethodCommand >> removeStrategy: anObject [
 	removeStrategy := anObject
 ]

--- a/src/SystemCommands-MethodCommands/SycRemoveMethodStrategy.class.st
+++ b/src/SystemCommands-MethodCommands/SycRemoveMethodStrategy.class.st
@@ -20,17 +20,18 @@ Strategy selection dialog orders collected strategy using this message.
 It is a string which should be displayed in strategy selection dialog.
 "
 Class {
-	#name : #SycRemoveMethodStrategy,
-	#superclass : #Object,
-	#category : #'SystemCommands-MethodCommands'
+	#name : 'SycRemoveMethodStrategy',
+	#superclass : 'Object',
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycRemoveMethodStrategy >> removeMethods: methods [
 	self subclassResponsibility
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycRemoveMethodStrategy >> userRequestString [
 	self subclassResponsibility
 ]

--- a/src/SystemCommands-MethodCommands/SycRemoveMethodsInHierarchyCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycRemoveMethodsInHierarchyCommand.class.st
@@ -3,12 +3,13 @@ I am a command to remove given methods and the ones in the subclasses.
 
 "
 Class {
-	#name : #SycRemoveMethodsInHierarchyCommand,
-	#superclass : #SysRefactoringMethodCommand,
-	#category : #'SystemCommands-MethodCommands'
+	#name : 'SycRemoveMethodsInHierarchyCommand',
+	#superclass : 'SysRefactoringMethodCommand',
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #converting }
+{ #category : 'converting' }
 SycRemoveMethodsInHierarchyCommand >> asRefactorings [
 
 	| refactoring |
@@ -18,16 +19,16 @@ SycRemoveMethodsInHierarchyCommand >> asRefactorings [
 	^ OrderedCollection with: refactoring
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycRemoveMethodsInHierarchyCommand >> defaultMenuIconName [
 	^ #remove
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycRemoveMethodsInHierarchyCommand >> defaultMenuItemName [
 	^'Remove and the ones in subclasses'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SycRemoveMethodsInHierarchyCommand >> setUpModelFromContext: aToolContext [
 ]

--- a/src/SystemCommands-MethodCommands/SycShowMethodVersionCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycShowMethodVersionCommand.class.st
@@ -9,35 +9,36 @@ Internal Representation and Key Implementation Points.
 	method:		<CompiledMethod>
 "
 Class {
-	#name : #SycShowMethodVersionCommand,
-	#superclass : #CmdCommand,
+	#name : 'SycShowMethodVersionCommand',
+	#superclass : 'CmdCommand',
 	#instVars : [
 		'method'
 	],
-	#category : #'SystemCommands-MethodCommands'
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SycShowMethodVersionCommand class >> canBeExecutedInContext: aToolContext [
 	^aToolContext isMethodSelected
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycShowMethodVersionCommand >> defaultMenuIconName [
 	^#history
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SycShowMethodVersionCommand >> defaultMenuItemName [
 	^'Versions'
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycShowMethodVersionCommand >> execute [
 	Smalltalk tools versionBrowser browseVersionsForMethod: method
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SycShowMethodVersionCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
 

--- a/src/SystemCommands-MethodCommands/SycSilentlyRemoveMethodStrategy.class.st
+++ b/src/SystemCommands-MethodCommands/SycSilentlyRemoveMethodStrategy.class.st
@@ -2,18 +2,19 @@
 I am simple perform method remove operation without any extra logic
 "
 Class {
-	#name : #SycSilentlyRemoveMethodStrategy,
-	#superclass : #SycRemoveMethodStrategy,
-	#category : #'SystemCommands-MethodCommands'
+	#name : 'SycSilentlyRemoveMethodStrategy',
+	#superclass : 'SycRemoveMethodStrategy',
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #removing }
+{ #category : 'removing' }
 SycSilentlyRemoveMethodStrategy >> removeMethods: methods [
 
 	methods do: [ :method | method removeFromSystem ]
 ]
 
-{ #category : #removing }
+{ #category : 'removing' }
 SycSilentlyRemoveMethodStrategy >> userRequestString [
 	^'Remove it'
 ]

--- a/src/SystemCommands-MethodCommands/SysRefactoringMethodCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SysRefactoringMethodCommand.class.st
@@ -1,21 +1,22 @@
 Class {
-	#name : #SysRefactoringMethodCommand,
-	#superclass : #SycMethodCommand,
-	#category : #'SystemCommands-MethodCommands'
+	#name : 'SysRefactoringMethodCommand',
+	#superclass : 'SycMethodCommand',
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : #execution }
+{ #category : 'execution' }
 SysRefactoringMethodCommand >> execute [
 
 	self executeRefactorings
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SysRefactoringMethodCommand >> isComplexRefactoring [
 	^true
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SysRefactoringMethodCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
 	self setUpModelFromContext: aToolContext

--- a/src/SystemCommands-MethodCommands/package.st
+++ b/src/SystemCommands-MethodCommands/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'SystemCommands-MethodCommands' }
+Package { #name : 'SystemCommands-MethodCommands' }


### PR DESCRIPTION
Remove methods driver previously only supported removal of methods from a single class.
This PR extends driver by enabling support for removing methods from multiple classes.