### PR TITLE
RPackage: #removeTag: should remove contained classes

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -728,8 +728,8 @@ RPackage >> removeEmptyTags [
 { #category : 'removing' }
 RPackage >> removeFromSystem [
 
-	self definedClasses do: #removeFromSystem.
-	self extensionMethods do: #removeFromSystem.
+	self classTags do: [ :tag | tag removeFromSystem ].
+	self extensionMethods do: [ :method | method removeFromSystem ].
 
 	self unregister
 ]
@@ -793,6 +793,8 @@ RPackage >> removeTag: aTag [
 	tag := aTag isString
 		       ifTrue: [ self classTagNamed: aTag ifAbsent: [ ^ self ] ]
 		       ifFalse: [ aTag ].
+
+	tag classes do: [ :class | class removeFromSystem ].
 
 	classTags remove: tag ifAbsent: [ ^ self ].
 

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -167,6 +167,13 @@ RPackageTag >> removeFromPackage [
 ]
 
 { #category : 'accessing' }
+RPackageTag >> removeFromSystem [
+	"Remove the tag and its content from the system"
+
+	self package removeTag: self
+]
+
+{ #category : 'accessing' }
 RPackageTag >> renameTo: newTagName [
 
 	| oldCategoryName newCategoryName oldTagName |

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -289,28 +289,6 @@ RPackageReadOnlyCompleteSetupTest >> testPackagesOfClass [
 ]
 
 { #category : 'tests - tag class' }
-RPackageReadOnlyCompleteSetupTest >> testRemoveTag [
-
-	self assert: p1 classTags size equals: 1. "We start with the root tag"
-
-	p1 importClass: a1 inTag: #foo.
-	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
-	self assert: (p1 classesTaggedWith: #foo) size equals: 1.
-
-	p1 importClass: b1 inTag: #foo.
-	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
-	self assert: (p1 classesTaggedWith: #foo) size equals: 2.
-
-	p1 removeTag: #bar.
-	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
-	self assert: (p1 classesTaggedWith: #foo) size equals: 2.
-
-	p1 removeTag: #foo.
-	self deny: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
-	self assert: (p1 classesTaggedWith: #foo) size equals: 0
-]
-
-{ #category : 'tests - tag class' }
 RPackageReadOnlyCompleteSetupTest >> testRemoveTaggedClasses [
 
 	p1 importClass: a1 inTag: #foo.

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -306,6 +306,54 @@ RPackageTest >> testRemoveEmptyTags [
 ]
 
 { #category : 'tests' }
+RPackageTest >> testRemoveTag [
+
+	| p1 a1 b1 |
+	p1 := self createNewPackageNamed: #P1.
+
+	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
+	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.
+	self assert: p1 classTags size equals: 1. "We start with the root tag"
+
+	p1 importClass: a1 inTag: #foo.
+	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
+	self assert: (p1 classesTaggedWith: #foo) size equals: 1.
+
+	p1 importClass: b1 inTag: #foo.
+	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+	self assert: (p1 classesTaggedWith: #foo) size equals: 2.
+
+	p1 removeTag: #bar.
+	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+	self assert: (p1 classesTaggedWith: #foo) size equals: 2.
+
+	p1 removeTag: #foo.
+	self deny: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+	self assertEmpty: (p1 classesTaggedWith: #foo)
+]
+
+{ #category : 'tests' }
+RPackageTest >> testRemoveTagRemoveClasses [
+
+	| p1 a1 |
+	p1 := self createNewPackageNamed: #P1.
+
+	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
+	self assert: p1 classTags size equals: 1. "We start with the root tag"
+
+	p1 importClass: a1 inTag: #foo.
+	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
+	self assert: (p1 classesTaggedWith: #foo) size equals: 1.
+
+	p1 removeTag: #foo.
+	self deny: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
+	self assertEmpty: (p1 classesTaggedWith: #foo).
+	self deny: (p1 includesClass: a1).
+	self assert: (self organizer packageOf: a1) name equals: RPackage defaultPackageName.
+	self assert: a1 isObsolete
+]
+
+{ #category : 'tests' }
 RPackageTest >> testRenamePackageAlsoRenameAllExtensionProtocols [
 	"test that when we rename a category, all corresponding extension protocols in the system are renamed"
 


### PR DESCRIPTION
#removeTag: currently leaves the system in a bastard state because the RPackageOrganizer still contains the class since it was not removed from the system but the package does not.

Checking all senders of this method, they seems to expect the classes contained to be remove from the system so I updated the code to act accordingly.

This should fix some missmatch between package organizer state and unpackaged classes