### PR TITLE
RPackage: Some cleanings

### DIFF
--- a/src/Deprecated12/RPackage.extension.st
+++ b/src/Deprecated12/RPackage.extension.st
@@ -1,6 +1,15 @@
 Extension { #name : 'RPackage' }
 
 { #category : '*Deprecated12' }
+RPackage >> actualClassTags [
+
+	self deprecated: 'This method is too specific and will be removed in future versions of Pharo.'.
+	(classTags size = 1 and: [ classTags anyOne isRoot ]) ifTrue: [ ^ #(  ) ].
+
+	^ classTags
+]
+
+{ #category : '*Deprecated12' }
 RPackage >> addClassTag: tagName [
 
 	self deprecated: 'Use #ensureTag: instead' transformWith: '`@rcv addClassTag: `@arg' -> '`@rcv ensureTag: `@arg'.

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -143,14 +143,6 @@ RPackage >> <= aRPackage [
 	^ self name <= aRPackage name
 ]
 
-{ #category : 'class tags' }
-RPackage >> actualClassTags [
-
-	(classTags size = 1 and: [classTags anyOne isRoot]) ifTrue: [ ^#() ].
-
-	^classTags
-]
-
 { #category : 'add class' }
 RPackage >> addClass: aClass [
 	"TODO: deprecate system category / replace this with a direct call to moveClass:fromPackage:toTag:"
@@ -429,9 +421,6 @@ RPackage >> importClass: aClass inTag: aTag [
 	
 	(self ensureTag: aTag) addClass: aClass instanceSide.
 
-	"Maybe this should go in the PackageTag during the addition of the class"
-	self registerClass: aClass.
-
 	{ aClass . aClass classSide } do: [ :class |
 		(self extensionProtocolsForClass: class) do: [ :protocol | class renameProtocol: protocol as: Protocol unclassified ].
 
@@ -685,13 +674,6 @@ RPackage >> register [
 ]
 
 { #category : 'private - register' }
-RPackage >> registerClass: aClass [
-	"Private method that declares the mapping between a class and its package."
-
-	self organizer registerPackage: self forClass: aClass
-]
-
-{ #category : 'private - register' }
 RPackage >> removeAllMethodsFromClass: aClass [
 	"Remove all the methods (defined and extensions) that are related to the class as parameter. The class should always be instance side."
 
@@ -713,10 +695,7 @@ RPackage >> removeClass: aClass [
 	"Then I unregister it from the tags"
 	self classTags
 		detect: [ :tag | tag includesClass: aClass ]
-		ifFound: [ :tag | tag removeClass: aClass ].
-
-	"Lastly I remove the class from the organizer. Maybe this should go in the PackageTag during the removal."
-	self unregisterClass: aClass
+		ifFound: [ :tag | tag removeClass: aClass ]
 ]
 
 { #category : 'class tags' }
@@ -909,11 +888,4 @@ RPackage >> toTagName: aSymbol [
 RPackage >> unregister [
 
 	self organizer removePackage: self
-]
-
-{ #category : 'private - register' }
-RPackage >> unregisterClass: aClass [
-	"Private method that declares the mapping between a class and its package."
-
-	self organizer unregisterPackage: self forClass: aClass
 ]

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -540,24 +540,6 @@ RPackageOrganizer >> renameTag: aTag to: newName inPackage: aPackage [
 	(self ensurePackage: aPackage) renameTag: aTag to: newName
 ]
 
-{ #category : 'registration' }
-RPackageOrganizer >> signalPackageExists: aPackageName [
-
-	RPackageConflictError signal: ('A package named {1} already exists' format: {aPackageName})
-]
-
-{ #category : 'private' }
-RPackageOrganizer >> stopNotification [
-	"(self instVarNamed: #default) stopNotification"
-
-	"pay attention that we can break the system using this method"
-
-	SystemAnnouncer uniqueInstance unsubscribe: self.
-
-	self class environment at: #MCWorkingCopy ifPresent: [:wc |
-		wc removeDependent: self]
-]
-
 { #category : 'system integration' }
 RPackageOrganizer >> systemClassAddedActionFrom: ann [
 
@@ -664,5 +646,5 @@ RPackageOrganizer >> unregisterPackage: aPackage forClass: aClass [
 { #category : 'registration' }
 RPackageOrganizer >> validatePackageDoesNotExist: aPackageName [
 
-	(self hasPackage: aPackageName) ifTrue: [ self signalPackageExists: aPackageName ]
+	(self hasPackage: aPackageName) ifTrue: [ RPackageConflictError signal: ('A package named {1} already exists' format: { aPackageName }) ]
 ]

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -28,7 +28,8 @@ RPackageTag class >> package: aPackage name: aString [
 RPackageTag >> addClass: aClass [
 
 	aClass category = self categoryName ifFalse: [ aClass category: self categoryName ].
-	classes add: aClass
+	classes add: aClass.
+	self organizer registerPackage: self package forClass: aClass
 ]
 
 { #category : 'private' }
@@ -154,6 +155,7 @@ RPackageTag >> removeClass: aClass [
 
 	| oldObject |
 	oldObject := classes remove: aClass ifAbsent: [  ].
+	self organizer unregisterPackage: self package forClass: aClass.
 	self isEmpty ifTrue: [ self removeFromPackage ].
 	^ oldObject
 ]

--- a/src/RPackage-Tests/RPackageTagTest.class.st
+++ b/src/RPackage-Tests/RPackageTagTest.class.st
@@ -18,7 +18,7 @@ RPackageTagTest >> tearDown [
 { #category : 'tests' }
 RPackageTagTest >> testAddClass [
 
-	| package1 package2 class |
+	| package1 package2 tag class |
 	package1 := self createNewPackageNamed: #Test1.
 	class := self createNewClassNamed: 'TestClass' inPackage: package1.
 
@@ -26,8 +26,11 @@ RPackageTagTest >> testAddClass [
 
 	package2 := self createNewPackageNamed: #Test2.
 
-	(package2 ensureTag: #TAG) addClass: class.
+	tag := package2 ensureTag: #TAG.
 
+	tag addClass: class.
+
+	self assert: class packageTag equals: tag.
 	self deny: (package1 includesClass: class).
 	self assert: (package2 includesClass: class).
 	self assert: (package2 hasTag: #TAG).
@@ -88,6 +91,23 @@ RPackageTagTest >> testPromoteAsPackage [
 	self assert: package2 isNotNil.
 	self assert: (package2 classes includes: class).
 	self deny: (package1 classes includes: class)
+]
+
+{ #category : 'tests' }
+RPackageTagTest >> testRemoveClass [
+
+	| package tag class |
+	package := self createNewPackageNamed: #Test1.
+	tag := package ensureTag: #TAG.
+	class := self createNewClassNamed: 'TestClass' inCategory: package name , '-TAG'.
+
+	self assert: (tag includesClass: class).
+
+	tag removeClass: class.
+
+	self deny: (tag includesClass: class).
+	self deny: (package includesClass: class).
+	self deny: class packageTag equals: tag
 ]
 
 { #category : 'tests' }

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -18,18 +18,6 @@ RPackageTest >> tearDown [
 ]
 
 { #category : 'tests' }
-RPackageTest >> testActualClassTags [
-
-	| packageWithoutClassTags packageWithClassTags |
-	packageWithoutClassTags := self packageOrganizer packageOf: StartupAction.
-	self denyEmpty: packageWithoutClassTags classTags.
-	self assertEmpty: packageWithoutClassTags actualClassTags.
-
-	packageWithClassTags := self packageOrganizer packageOf: Object.
-	self assert: packageWithClassTags actualClassTags equals: packageWithClassTags classTags
-]
-
-{ #category : 'tests' }
 RPackageTest >> testAddClass [
 
 	| package1 package2 class done |


### PR DESCRIPTION
- #actualClassTags is tto specific and got deprecated
- Registration and unregistration of classes in the organizer are done at the level of class tags and not package anymore to ensure state is coherent
- #dead code is removed