### PR TITLE
Unify class added and recategorized actions

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -281,7 +281,10 @@ Class >> category: aString [
 	oldCategory := self category.
 	oldCategory = aString ifTrue: [ ^ self ].
 	self basicCategory: aString asSymbol.
-	SystemAnnouncer uniqueInstance class: self recategorizedFrom: oldCategory to: self category
+
+	oldCategory = Class unclassifiedCategory
+		ifTrue: [ SystemAnnouncer uniqueInstance classAdded: self inCategory: self category ]
+		ifFalse: [ SystemAnnouncer uniqueInstance class: self recategorizedFrom: oldCategory to: self category ]
 ]
 
 { #category : 'subclass creation - variableByte' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -583,11 +583,14 @@ RPackage >> methodsForClass: aClass [
 { #category : 'private' }
 RPackage >> moveClass: aClass toTag: aTag [
 
-	| oldPackage |
+	| oldPackage tag |
+	tag := self ensureTag: aTag.
+	aClass packageTag = tag ifTrue: [ ^ self ].
+
 	oldPackage := aClass package.
 
 	oldPackage removeClass: aClass.
-	self importClass: aClass inTag: aTag.
+	self importClass: aClass inTag: tag.
 
 	SystemAnnouncer uniqueInstance classRepackaged: aClass from: oldPackage to: self
 ]

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -559,23 +559,17 @@ RPackageOrganizer >> stopNotification [
 ]
 
 { #category : 'system integration' }
-RPackageOrganizer >> systemClassAddedActionFrom: ann [
+RPackageOrganizer >> systemClassAddedActionFrom: announcement [
 
-	(self ensurePackageMatching: ann classAffected category) importClass: ann classAffected
+	self systemClassRecategorizedActionFrom: announcement
 ]
 
 { #category : 'system integration' }
 RPackageOrganizer >> systemClassRecategorizedActionFrom: announcement [
 
-	| class newPackage newCategoryName |
-	class := announcement classAffected.
-
-	newCategoryName := announcement newCategory.
-
-	newCategoryName = announcement oldCategory ifTrue: [ ^ self ].
-	newPackage := self ensurePackageMatching: newCategoryName.
-
-	newPackage moveClass: class toTag: (newPackage ensureTag: (newPackage toTagName: newCategoryName))
+	| newPackage |
+	newPackage := self ensurePackageMatching: announcement classAffected category.
+	newPackage moveClass: announcement classAffected toTag: (newPackage toTagName: announcement classAffected category)
 ]
 
 { #category : 'system integration' }

--- a/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassInstaller/ShiftClassInstaller.class.st
@@ -296,15 +296,7 @@ ShiftClassInstaller >> oldClass: anObject [
 { #category : 'notifications' }
 ShiftClassInstaller >> recategorize: aClass to: newCategory [
 
-	| oldCategory |
-	oldCategory := oldClass ifNotNil: [ oldClass category ].
-	oldCategory == newCategory ifTrue: [ ^ self ].
-
-	self installingEnvironment organization ifNotNil: [ :systemOrganizer | aClass basicCategory: newCategory ].
-
-	(oldCategory isNil or: [ oldCategory = Class unclassifiedCategory ])
-		ifTrue: [ SystemAnnouncer uniqueInstance classAdded: aClass inCategory: newCategory ]
-		ifFalse: [ SystemAnnouncer uniqueInstance class: aClass recategorizedFrom: oldCategory to: newCategory ]
+	aClass category: newCategory
 ]
 
 { #category : 'building' }


### PR DESCRIPTION
This change has two main goals.

The first is to factorize the code managing announcements of class addition and recategorization. Currently it was dealt with in two places: Class>>category: and ShiftClassInstaller>>recategorize:to:. Now this is only in #category: and the second call the first one simplifying the code.

The second goal is to unify what is happening in RPackage when a class gets added or recategorized because the code was different until now but there is no reason to act differently.

A future goal is to not do the package update through announcements but this currently breaks the bootstrap