### PR TITLE
RPackage: simplify classes cleanup of packages tests

### DIFF
--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -22,16 +22,6 @@ Class {
 { #category : 'setup' }
 RPackageMCSynchronisationTest >> cleanClassesPackagesAndCategories [
 
-	self organizer environment
-		removeClassNamed: 'NewClass';
-		removeClassNamed: 'RPackageNewStubClass';
-		removeClassNamed: 'RPackageOldStubClass';
-		removeClassNamed: 'Foo';
-		removeClassNamed: 'FooOther';
-		removeClassNamed: 'NewTrait';
-		removeClassNamed: 'ClassInYPackage';
-		removeClassNamed: 'ClassInZPackage'.
-
 	#( 'OriginalCategory' 'XXXXX' 'XXXX' 'YYYYY' 'YYYY' 'Yyyyy' 'YyYyY' 'Y' 'ZZZZZ' 'Zzzzz' 'FooPackage-Core' 'FooPackage-Other' 'FooPackage' 'Zork' ) do: [
 		:packageName |
 		self allWorkingCopies

--- a/src/RPackage-Tests/RPackageTagTest.class.st
+++ b/src/RPackage-Tests/RPackageTagTest.class.st
@@ -8,13 +8,6 @@ Class {
 	#package : 'RPackage-Tests'
 }
 
-{ #category : 'running' }
-RPackageTagTest >> tearDown [
-
-	#( TestClass TestClassOther ) do: [ :each | testEnvironment at: each ifPresent: #removeFromSystem ].
-	super tearDown
-]
-
 { #category : 'tests' }
 RPackageTagTest >> testAddClass [
 

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -8,15 +8,6 @@ Class {
 	#package : 'RPackage-Tests'
 }
 
-{ #category : 'running' }
-RPackageTest >> tearDown [
-
-	#(TestClass TestClassOther)
-		do: [ :each |
-			self class environment at: each ifPresent: #removeFromSystem ].
-	super tearDown
-]
-
 { #category : 'tests' }
 RPackageTest >> testAddClass [
 

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -5,7 +5,6 @@ Class {
 	#name : 'RPackageTestCase',
 	#superclass : 'AbstractEnvironmentTestCase',
 	#instVars : [
-		'createdClasses',
 		'createdPackages',
 		'testEnvironment'
 	],
@@ -40,7 +39,6 @@ RPackageTestCase >> createNewClassNamed: aName inCategory: cat [
 			       installingEnvironment: testEnvironment;
 			       package: cat ].
 
-	createdClasses add: cls.
 	createdPackages add: cls package.
 	^ cls
 ]
@@ -79,7 +77,6 @@ RPackageTestCase >> createNewTraitNamed: aName inCategory: cat [
 			       installingEnvironment: testEnvironment;
 			       beTrait ].
 
-	createdClasses add: cls.
 	createdPackages add: cls package.
 	^ cls
 ]
@@ -128,14 +125,13 @@ RPackageTestCase >> runCase [
 RPackageTestCase >> setUp [
 
 	super setUp.
-	createdClasses := Set new.
 	createdPackages := Set new
 ]
 
 { #category : 'running' }
 RPackageTestCase >> tearDown [
 
-	createdClasses do: [ :cls | cls removeFromSystem ].
+	self organizer environment allClasses do: [ :cls | cls removeFromSystem ].
 
 	super tearDown
 ]


### PR DESCRIPTION
This change makes the tests a little cleaner about classes removal with a more generic way to do it that do not requires to save the created classes and traits