### PR TITLE
RPackage: Iteration on package cleanings

### DIFF
--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -19,6 +19,12 @@ Class {
 	#tag : 'RPackage'
 }
 
+{ #category : 'accessing' }
+RPackageMCSynchronisationTest >> allWorkingCopies [
+
+	^ MCWorkingCopy allWorkingCopies
+]
+
 { #category : 'setup' }
 RPackageMCSynchronisationTest >> cleanClassesPackagesAndCategories [
 
@@ -109,6 +115,10 @@ RPackageMCSynchronisationTest >> tearDown [
 	MCWorkingCopy removeDependent: self emptyOrganizer.
 	self cleanClassesPackagesAndCategories.
 	SystemAnnouncer uniqueInstance unsubscribe: self.
+	createdPackages do: [ :each |
+		self allWorkingCopies
+			detect: [ :mcPackage | mcPackage packageName = each packageName asString ]
+			ifFound: [ :mcPackage | mcPackage unregister ] ].
 	super tearDown
 ]
 

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -52,15 +52,8 @@ RPackageIncrementalTest >> setUp [
 { #category : 'running' }
 RPackageIncrementalTest >> tearDown [
 
-	createdPackages do: [ :package | self removePackage: package ].
-	"just remove package from package organizer dictionary"
+	createdPackages do: [ :package | package removeFromSystem ].
 
-	createdPackages do: [ :each |
-		self allWorkingCopies
-			detect: [ :mcPackage | mcPackage packageName = each packageName asString ]
-			ifFound: [ :mcPackage | mcPackage unregister ].
-		each extendedClasses do: [ :extendedClass | self organizer unregisterExtendingPackage: each forClass: extendedClass ] ].
-	"all ***extending*** classes the packages are also unregistered from PackageOrganizer"
 	super tearDown
 ]
 

--- a/src/RPackage-Tests/RPackageRenameTest.class.st
+++ b/src/RPackage-Tests/RPackageRenameTest.class.st
@@ -3,55 +3,19 @@ SUnit tests on renaming packages
 "
 Class {
 	#name : 'RPackageRenameTest',
-	#superclass : 'TestCase',
-	#instVars : [
-		'oldSystemAnnouncer',
-		'packageNamesToClean'
-	],
+	#superclass : 'RPackageTestCase',
 	#category : 'RPackage-Tests',
 	#package : 'RPackage-Tests'
 }
-
-{ #category : 'utilities' }
-RPackageRenameTest >> cleanWorkingCopiesInTearDown: aCollection [
-
-	packageNamesToClean addAll: aCollection
-]
-
-{ #category : 'running' }
-RPackageRenameTest >> setUp [
-	super setUp.
-	oldSystemAnnouncer := SystemAnnouncer uniqueInstance.
-	SystemAnnouncer restoreAllNotifications.
-	packageNamesToClean := OrderedCollection new
-]
-
-{ #category : 'running' }
-RPackageRenameTest >> tearDown [
-
-	SystemAnnouncer announcer: oldSystemAnnouncer.
-	self class environment at: #TestClass ifPresent: [ :class | class removeFromSystem ].
-	self class environment at: #TestClass1 ifPresent: [ :class | class removeFromSystem ].
-	self class environment at: #TestClass2 ifPresent: [ :class | class removeFromSystem ].
-	self class environment at: #TestClass3 ifPresent: [ :class | class removeFromSystem ].
-
-	packageNamesToClean do: [ :aPackageName |
-		(MCWorkingCopy hasPackageNamed: aPackageName) ifTrue: [ (MCWorkingCopy forPackageNamed: aPackageName) unload ].
-		(aPackageName asPackageIfAbsent: [ nil ]) ifNotNil: [ :package | package removeFromSystem ] ].
-
-	super tearDown
-]
 
 { #category : 'tests' }
 RPackageRenameTest >> testRenamePackage [
 	"Test that we do rename the package as expected."
 
 	| package workingCopy class |
-	self cleanWorkingCopiesInTearDown: #( 'TestRename' ).
-
-	package := self packageOrganizer ensurePackage: 'Test1'.
+	package := self createNewPackageNamed: 'Test1'.
 	workingCopy := MCWorkingCopy forPackageNamed: 'Test1'.
-	class := (Object << #TestClass package: 'Test1-TAG') install.
+	class := self createNewClassNamed: #TestClass inCategory: 'Test1-TAG'.
 
 	self assert: (package includesClass: class).
 	self assert: (package classTagNamed: #TAG ifAbsent: [ nil ]) notNil.
@@ -76,12 +40,10 @@ RPackageRenameTest >> testRenamePackageToOwnTagName [
 	"If we rename a package to the (full)category name of one of its tags"
 
 	| package workingCopy class1 class2 |
-	self cleanWorkingCopiesInTearDown: #( 'Test1-Core' ).
-
-	package := self packageOrganizer ensurePackage: 'Test1'.
+	package := self createNewPackageNamed: 'Test1'.
 	workingCopy := MCWorkingCopy forPackageNamed: 'Test1'.
-	class1 := (Object << #TestClass1 package: 'Test1-Core') install.
-	class2 := (Object << #TestClass2 package: 'Test1-Util') install.
+	class1 := self createNewClassNamed: #TestClass1 inCategory: 'Test1-Core'.
+	class2 := self createNewClassNamed: #TestClass2 inCategory: 'Test1-Util'.
 
 	self assert: (package classTagNamed: #Core ifAbsent: [ nil ]) notNil.
 	self assert: (package classTagNamed: #Util ifAbsent: [ nil ]) notNil.
@@ -102,13 +64,11 @@ RPackageRenameTest >> testRenamePackageToOwnTagNameWithClassesInRoot [
 	"If we rename a package to the (full)category name of one of its tags and the (non-tag)package is not empty"
 
 	| package workingCopy class1 class2 class3 |
-	self cleanWorkingCopiesInTearDown: #( 'Test1-Core' ).
-
-	package := self packageOrganizer ensurePackage: 'Test1'.
+	package := self createNewPackageNamed: 'Test1'.
 	workingCopy := MCWorkingCopy forPackageNamed: 'Test1'.
-	class1 := (Object << #TestClass1 package: 'Test1-Core') install.
-	class2 := (Object << #TestClass2 package: 'Test1-Util') install.
-	class3 := (Object << #TestClass3 package: 'Test1') install.
+	class1 := self createNewClassNamed: #TestClass1 inCategory: 'Test1-Core'.
+	class2 := self createNewClassNamed: #TestClass2 inCategory: 'Test1-Util'.
+	class3 := self createNewClassNamed: #TestClass3 inCategory: 'Test1'.
 
 	self assert: (package classTagNamed: #Core ifAbsent: [ nil ]) notNil.
 	self assert: (package classTagNamed: #Util ifAbsent: [ nil ]) notNil.
@@ -128,15 +88,14 @@ RPackageRenameTest >> testRenamePackageToOwnTagNameWithClassesInRoot [
 RPackageRenameTest >> testRenamePackageWithExtensions [
 
 	| package class extendedPackage extension |
-	package := self packageOrganizer ensurePackage: 'OriginalPackage'.
+	package := self createNewPackageNamed: 'OriginalPackage'.
 
-	class := (Object << #TestClass package: 'OriginalPackage-TAG') install.
+	class := self createNewClassNamed: #TestClass inCategory: 'OriginalPackage-TAG'.
 
-	extendedPackage := self packageOrganizer ensurePackage: 'ExtendedPackage'.
+	extendedPackage := self createNewPackageNamed: 'ExtendedPackage'.
 
-	self cleanWorkingCopiesInTearDown: #( ExtendedPackage RenamedPackage OriginalPackage ).
 
-	class := (Object << #TestExtendedClass package: 'ExtendedPackage') install.
+	class := self createNewClassNamed: #TestExtendedClass inCategory: 'ExtendedPackage'.
 
 	class compile: 'm ^ 42' classified: '*OriginalPackage'.
 	extension := class >> #m.
@@ -160,15 +119,14 @@ RPackageRenameTest >> testRenamePackageWithExtensions [
 RPackageRenameTest >> testRenamePackageWithExtensionsInClassSide [
 
 	| package class extendedPackage extension |
-	package := self packageOrganizer ensurePackage: 'OriginalPackage'.
+	package := self createNewPackageNamed: 'OriginalPackage'.
 
-	class := (Object << #TestClass package: 'OriginalPackage-TAG') install.
+	class := self createNewClassNamed: #TestClass inCategory: 'OriginalPackage-TAG'.
 
-	extendedPackage := self packageOrganizer ensurePackage: 'ExtendedPackage'.
+	extendedPackage := self createNewPackageNamed: 'ExtendedPackage'.
 
-	self cleanWorkingCopiesInTearDown: #( ExtendedPackage RenamedPackage OriginalPackage ).
 
-	class := (Object << #TestExtendedClass package: 'ExtendedPackage') install.
+	class := self createNewClassNamed: #TestExtendedClass inCategory: 'ExtendedPackage'.
 
 	class := class class.
 
@@ -195,9 +153,9 @@ RPackageRenameTest >> testUnregisterPackage [
 	"Test that we do unregister the package as expected."
 
 	| package workingCopy class |
-	package := self packageOrganizer ensurePackage: 'Test1'.
+	package := self createNewPackageNamed: 'Test1'.
 	workingCopy := MCWorkingCopy forPackageNamed: 'Test1'.
-	class := (Object << #TestClass package: 'Test1-TAG') install.
+	class := self createNewClassNamed: #TestClass inCategory: 'Test1-TAG'.
 	self assert: (package includesClass: class).
 	self assert: (package classTagNamed: #TAG ifAbsent: [ nil ]) notNil.
 	self assert: ((package classTagNamed: #TAG ifAbsent: [ nil ]) includesClass: class).
@@ -205,6 +163,6 @@ RPackageRenameTest >> testUnregisterPackage [
 
 	package unregister.
 
-	self deny: (self packageOrganizer hasPackage: #Test1).
+	self deny: (self organizer hasPackage: #Test1).
 	self deny: (MCWorkingCopy hasPackageNamed: #Test1)
 ]

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -12,12 +12,6 @@ Class {
 	#package : 'RPackage-Tests'
 }
 
-{ #category : 'accessing' }
-RPackageTestCase >> allWorkingCopies [
-
-	^ MCWorkingCopy allWorkingCopies
-]
-
 { #category : 'utilities' }
 RPackageTestCase >> createMockTestPackages [
 
@@ -100,12 +94,6 @@ RPackageTestCase >> namesOfMockTestPackages [
 RPackageTestCase >> organizer [
 
 	^ testEnvironment organization
-]
-
-{ #category : 'utilities' }
-RPackageTestCase >> removePackage: aPackage [
-
-	self organizer basicUnregisterPackage: aPackage
 ]
 
 { #category : 'running' }


### PR DESCRIPTION
RPackage tests are messy and I've been cleaning them since a while now. My last bug change broke too many tests so here is a new small iteration on tests cleanings.

- Code specific to Monticello got pushed down in Monticello tests.
- Rename tests now are subclass of RPackageTestCase and use the same cleanup mecanism 
- RPackageIncrementalTest>>#tearDown has been made more general