### PR TITLE
RPackage: Simplify package creation and deletion in tests

### DIFF
--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -115,9 +115,9 @@ RPackageMCSynchronisationTest >> tearDown [
 	MCWorkingCopy removeDependent: self emptyOrganizer.
 	self cleanClassesPackagesAndCategories.
 	SystemAnnouncer uniqueInstance unsubscribe: self.
-	createdPackages do: [ :each |
+	self organizer package do: [ :package |
 		self allWorkingCopies
-			detect: [ :mcPackage | mcPackage packageName = each packageName asString ]
+			detect: [ :mcPackage | mcPackage packageName = package name ]
 			ifFound: [ :mcPackage | mcPackage unregister ] ].
 	super tearDown
 ]

--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -115,10 +115,6 @@ RPackageMCSynchronisationTest >> tearDown [
 	MCWorkingCopy removeDependent: self emptyOrganizer.
 	self cleanClassesPackagesAndCategories.
 	SystemAnnouncer uniqueInstance unsubscribe: self.
-	self organizer package do: [ :package |
-		self allWorkingCopies
-			detect: [ :mcPackage | mcPackage packageName = package name ]
-			ifFound: [ :mcPackage | mcPackage unregister ] ].
 	super tearDown
 ]
 

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -706,6 +706,7 @@ RPackage >> removeEmptyTags [
 { #category : 'removing' }
 RPackage >> removeFromSystem [
 
+	self isDefault ifTrue: [ ^ self ].
 	self classTags do: [ :tag | tag removeFromSystem ].
 	self extensionMethods do: [ :method | method removeFromSystem ].
 

--- a/src/RPackage-Tests/RPackageCompleteSetupButForModificationTest.class.st
+++ b/src/RPackage-Tests/RPackageCompleteSetupButForModificationTest.class.st
@@ -22,9 +22,9 @@ Class {
 RPackageCompleteSetupButForModificationTest >> setUp [
 
 	super setUp.
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
-	p3 := self createNewPackageNamed: self p3Name.
+	p1 := self ensurePackage: self p1Name.
+	p2 := self ensurePackage: self p2Name.
+	p3 := self ensurePackage: self p3Name.
 
 	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
 	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -52,7 +52,7 @@ RPackageIncrementalTest >> setUp [
 { #category : 'running' }
 RPackageIncrementalTest >> tearDown [
 
-	createdPackages do: [ :package | package removeFromSystem ].
+	self organizer packages do: [ :package | package removeFromSystem ].
 
 	super tearDown
 ]
@@ -61,9 +61,9 @@ RPackageIncrementalTest >> tearDown [
 RPackageIncrementalTest >> testAddRemoveMethod [
 
 	| p1 p2 p3 a2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
-	p3 := self createNewPackageNamed: self p3Name.
+	p1 := self ensurePackage: self p1Name.
+	p2 := self ensurePackage: self p2Name.
+	p3 := self ensurePackage: self p3Name.
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	a2 compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2'.
 
@@ -94,9 +94,9 @@ RPackageIncrementalTest >> testAddRemoveMethod [
 RPackageIncrementalTest >> testAddRemoveSelector [
 
 	| p1 p2 p3 a2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
-	p3 := self createNewPackageNamed: self p3Name.
+	p1 := self ensurePackage: self p1Name.
+	p2 := self ensurePackage: self p2Name.
+	p3 := self ensurePackage: self p3Name.
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 
 	p2 addMethod: a2 >> (a2 compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2').
@@ -123,7 +123,7 @@ RPackageIncrementalTest >> testAddRemoveSelector [
 RPackageIncrementalTest >> testClassAddition [
 
 	| p a1 |
-	p := self createNewPackageNamed: self p1Name.
+	p := self ensurePackage: self p1Name.
 	a1 := self createNewClassNamed: #A1InPAckageP1.
 	self assertEmpty: p definedClasses.
 	p importClass: a1.
@@ -136,7 +136,7 @@ RPackageIncrementalTest >> testClassAddition [
 RPackageIncrementalTest >> testClassDefinitionRemoval [
 
 	| p a1 b1 |
-	p := self createNewPackageNamed: self p1Name.
+	p := self ensurePackage: self p1Name.
 	a1 := self createNewClassNamed: #A1InPAckageP1.
 	b1 := self createNewClassNamed: #B1InPAckageP1.
 	self assertEmpty: p definedClasses.
@@ -161,7 +161,7 @@ RPackageIncrementalTest >> testClassDefinitionRemoval [
 RPackageIncrementalTest >> testClassDefinitionWithTagsRemoval [
 
 	| p a1 b1 |
-	p := self createNewPackageNamed: self p1Name.
+	p := self ensurePackage: self p1Name.
 
 	a1 := self createNewClassNamed: #A1InPAckageP1 inPackage: p.
 	b1 := self createNewClassNamed: #B1InPAckageP1 inPackage: p.
@@ -188,7 +188,7 @@ RPackageIncrementalTest >> testClassDefinitionWithTagsRemoval [
 RPackageIncrementalTest >> testDefinedClassesAndDefinedClassNames [
 
 	| p a1 b1 |
-	p := self createNewPackageNamed: self p1Name.
+	p := self ensurePackage: self p1Name.
 	a1 := self createNewClassNamed: #A1InPackageP1 inPackage: p.
 	self assert: p definedClasses size equals: 1.
 	self assert: (p definedClasses includes: a1).
@@ -204,8 +204,8 @@ RPackageIncrementalTest >> testDefinedClassesAndDefinedClassNames [
 RPackageIncrementalTest >> testExtensionClassNames [
 
 	| p1 p2 a2 b2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
+	p1 := self ensurePackage: self p1Name.
+	p2 := self ensurePackage: self p2Name.
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	b2 := self createNewClassNamed: #B2InPackageP2 inPackage: p2.
 	self deny: (p1 includesClass: a2).
@@ -239,8 +239,8 @@ RPackageIncrementalTest >> testExtensionClassNames [
 RPackageIncrementalTest >> testExtensionClasses [
 
 	| p1 p2 a2 b2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
+	p1 := self ensurePackage: self p1Name.
+	p2 := self ensurePackage: self p2Name.
 
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	b2 := self createNewClassNamed: #B2InPackageP2 inPackage: p2.
@@ -268,8 +268,8 @@ RPackageIncrementalTest >> testExtensionClasses [
 RPackageIncrementalTest >> testExtensionClassesWithCompiledMethod [
 
 	| p1 p2 a2 b2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
+	p1 := self ensurePackage: self p1Name.
+	p2 := self ensurePackage: self p2Name.
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	b2 := self createNewClassNamed: #B2InPackageP2 inPackage: p2.
 	self deny: (p1 includesClass: a2).
@@ -303,8 +303,8 @@ RPackageIncrementalTest >> testExtensionClassesWithCompiledMethod [
 RPackageIncrementalTest >> testExtensionMethods [
 
 	| p1 p2 a2 b2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
+	p1 := self ensurePackage: self p1Name.
+	p2 := self ensurePackage: self p2Name.
 
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	b2 := self createNewClassNamed: #B2InPackageP2 inPackage: p2.
@@ -322,7 +322,7 @@ RPackageIncrementalTest >> testExtensionMethods [
 RPackageIncrementalTest >> testImportClassNoDuplicate [
 
 	| p a1 b1 |
-	p := self createNewPackageNamed: self p1Name.
+	p := self ensurePackage: self p1Name.
 	a1 := self createNewClassNamed: #A1InPackageP1.
 	self assertEmpty: p definedClasses.
 	p importClass: a1.
@@ -339,8 +339,8 @@ RPackageIncrementalTest >> testImportClassNoDuplicate [
 RPackageIncrementalTest >> testIncludeClass [
 
 	| p1 p2 a2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
+	p1 := self ensurePackage: self p1Name.
+	p2 := self ensurePackage: self p2Name.
 
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	a2 compile: 'methodPackagedInP1 ^ #methodPackagedInP1' classified: '*' , p1 name.
@@ -361,9 +361,9 @@ RPackageIncrementalTest >> testIncludeClass [
 RPackageIncrementalTest >> testIncludeClassMore [
 
 	| p1 p2 p3 a2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
-	p3 := self createNewPackageNamed: self p3Name.
+	p1 := self ensurePackage: self p1Name.
+	p2 := self ensurePackage: self p2Name.
+	p3 := self ensurePackage: self p3Name.
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	a2 compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
 	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
@@ -378,9 +378,9 @@ RPackageIncrementalTest >> testIncludeClassMore [
 RPackageIncrementalTest >> testIncludeSelectorOfClass [
 
 	| p1 p2 p3 a2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
-	p3 := self createNewPackageNamed: self p3Name.
+	p1 := self ensurePackage: self p1Name.
+	p2 := self ensurePackage: self p2Name.
+	p3 := self ensurePackage: self p3Name.
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	a2 compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
 	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
@@ -404,9 +404,9 @@ RPackageIncrementalTest >> testIncludeSelectorOfClass [
 RPackageIncrementalTest >> testIncludeSelectorOfMetaClass [
 
 	| p1 p2 p3 a2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
-	p3 := self createNewPackageNamed: self p3Name.
+	p1 := self ensurePackage: self p1Name.
+	p2 := self ensurePackage: self p2Name.
+	p3 := self ensurePackage: self p3Name.
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	a2 class compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
 	a2 class compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
@@ -431,9 +431,9 @@ RPackageIncrementalTest >> testIncludeSelectorOfMetaClass [
 RPackageIncrementalTest >> testIncludesMethodOfClassInPresenceOfOtherPackageExtensions [
 
 	| p1 p2 p3 a2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
-	p3 := self createNewPackageNamed: self p3Name.
+	p1 := self ensurePackage: self p1Name.
+	p2 := self ensurePackage: self p2Name.
+	p3 := self ensurePackage: self p3Name.
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 
 	a2 compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
@@ -456,8 +456,8 @@ RPackageIncrementalTest >> testIncludesMethodOfClassInPresenceOfOtherPackageExte
 RPackageIncrementalTest >> testIncludesOrTouches [
 
 	| p1 p2 a2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
+	p1 := self ensurePackage: self p1Name.
+	p2 := self ensurePackage: self p2Name.
 
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	self deny: (p1 includesClass: a2).
@@ -476,7 +476,7 @@ RPackageIncrementalTest >> testIncludesOrTouches [
 RPackageIncrementalTest >> testMethodAddition [
 
 	| p1 a1 |
-	p1 := self createNewPackageNamed: self p1Name.
+	p1 := self ensurePackage: self p1Name.
 	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
 	a1 compileSilently: 'foo ^ 10'.
 	p1 addMethod: a1 >> #foo.
@@ -487,7 +487,7 @@ RPackageIncrementalTest >> testMethodAddition [
 RPackageIncrementalTest >> testMethodPackageResolution [
 
 	| p1 a1 |
-	p1 := self createNewPackageNamed: self p1Name.
+	p1 := self ensurePackage: self p1Name.
 	a1 := self createNewClassNamed: #A2InPackageP1 inPackage: p1.
 	a1 compile: 'method ^ #methodDefinedInP1'.
 	a1 class compile: 'method ^ #methodDefinedInP1'.
@@ -500,8 +500,8 @@ RPackageIncrementalTest >> testMethodPackageResolution [
 RPackageIncrementalTest >> testPackageOfClassForClassesNotDefinedInPackageButJustExtendingIt [
 
 	| p1 p2 a2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
+	p1 := self ensurePackage: self p1Name.
+	p2 := self ensurePackage: self p2Name.
 
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
@@ -516,7 +516,7 @@ RPackageIncrementalTest >> testPackageOfClassForClassesNotDefinedInPackageButJus
 RPackageIncrementalTest >> testPackageOfClassForDefinedClasses [
 
 	| p a1 b1 |
-	p := self createNewPackageNamed: self p1Name.
+	p := self ensurePackage: self p1Name.
 	a1 := self createNewClassNamed: #A1InPAckageP1 inPackage: p.
 	b1 := self createNewClassNamed: #B1InPAckageP1 inPackage: p.
 
@@ -528,8 +528,8 @@ RPackageIncrementalTest >> testPackageOfClassForDefinedClasses [
 RPackageIncrementalTest >> testRemoveClassRemovesExtensions [
 
 	| p1 p2 a1 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
+	p1 := self ensurePackage: self p1Name.
+	p2 := self ensurePackage: self p2Name.
 	"the class is created but not added to the package for now"
 	a1 := self createNewClassNamed: #A1InPackageP1 inPackage: p1.
 	self assert: p1 definedClasses size equals: 1.
@@ -549,8 +549,8 @@ RPackageIncrementalTest >> testRemoveClassRemovesExtensions [
 RPackageIncrementalTest >> testRemoveExtensionMethodRemovesExtensionsFromPackage [
 
 	| p1 p2 a1 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
+	p1 := self ensurePackage: self p1Name.
+	p2 := self ensurePackage: self p2Name.
 	"the class is created but not added to the package for now"
 	a1 := self createNewClassNamed: #A1InPackageP1 inPackage: p1.
 	self assert: p1 definedClasses size equals: 1.
@@ -570,8 +570,8 @@ RPackageIncrementalTest >> testRemoveExtensionMethodRemovesExtensionsFromPackage
 RPackageIncrementalTest >> testTwoClassesWithExtensions [
 
 	| p1 p2 a2 b2 |
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
+	p1 := self ensurePackage: self p1Name.
+	p2 := self ensurePackage: self p2Name.
 
 	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
 	b2 := self createNewClassNamed: #B2InPackageP2 inPackage: p2.
@@ -586,7 +586,7 @@ RPackageIncrementalTest >> testTwoClassesWithExtensions [
 RPackageIncrementalTest >> testUniqueClassInDefinedClassesUsingAddClassDefinition [
 
 	| p a1 |
-	p := self createNewPackageNamed: self p1Name.
+	p := self ensurePackage: self p1Name.
 	a1 := self createNewClassNamed: #A1InPAckageP1.
 	self assertEmpty: p definedClasses.
 	p importClass: a1.

--- a/src/RPackage-Tests/RPackageObsoleteTest.class.st
+++ b/src/RPackage-Tests/RPackageObsoleteTest.class.st
@@ -33,12 +33,12 @@ RPackageObsoleteTest >> testAnnouncementClassRemovedIsRaisedOnRemoveFromSystem [
 RPackageObsoleteTest >> testMethodPackageFromObsoleteClass [
 
 	| pack method foo |
-	[
-	pack := self createNewPackageNamed: 'P1'.
+	pack := self ensurePackage: 'P1'.
 	foo := self createNewClassNamed: #FooForTest inPackage: pack.
 	foo compile: 'bar ^42'.
 	method := foo >> #bar.
 
+	[
 	foo obsolete.
 	self assert: method package equals: foo package ] ensure: [
 		foo ifNotNil: [
@@ -51,7 +51,7 @@ RPackageObsoleteTest >> testMethodPackageFromObsoleteClass [
 RPackageObsoleteTest >> testMethodPackageOfRemovedClass [
 
 	| pack method foo |
-	pack := self createNewPackageNamed: 'P1'.
+	pack := self ensurePackage: 'P1'.
 	foo := self createNewClassNamed: #FooForTest2 inPackage: pack.
 	foo compile: 'bar ^42'.
 	method := foo >> #bar.

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -42,7 +42,7 @@ RPackageOrganizerTest >> quadrangleClass [
 RPackageOrganizerTest >> testAccessingPackage [
 
 	| p1 |
-	p1 := self createNewPackageNamed: 'P1'.
+	p1 := self ensurePackage: 'P1'.
 	self assert: (self organizer packageNamed: #P1) equals: p1.
 	self should: [ self organizer packageNamed: #P22 ] raise: Error
 ]
@@ -65,7 +65,7 @@ RPackageOrganizerTest >> testCreateNewPackageWithoutConflictCreatesPackage [
 RPackageOrganizerTest >> testDefinedClassesInstanceAndMetaSideAPI [
 
 	| p1 |
-	p1 := self createNewPackageNamed: self p1Name.
+	p1 := self ensurePackage: self p1Name.
 	self createNewClassNamed: #MyPoint inPackage: p1.
 	self assert: self organizer packageNames size equals: 2.
 	self assert: self organizer packages size equals: 2.
@@ -98,8 +98,8 @@ RPackageOrganizerTest >> testEnsurePackageManagesDifferentCase [
 RPackageOrganizerTest >> testExtensionMethodNotExactlyTheName [
 
 	| p1 p2 c1 |
-	p1 := self createNewPackageNamed: 'P1'.
-	p2 := self createNewPackageNamed: 'P2'.
+	p1 := self ensurePackage: 'P1'.
+	p2 := self ensurePackage: 'P2'.
 
 	c1 := self createNewClassNamed: #C1 inPackage: p2.
 
@@ -115,9 +115,9 @@ RPackageOrganizerTest >> testFullRegistration [
 
 	| p1 p2 p3 a1 a2 b1 b2 a3 |
 	"taken from setup of RPackageReadOnlyCompleteSetup"
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
-	p3 := self createNewPackageNamed: self p3Name.
+	p1 := self ensurePackage: self p1Name.
+	p2 := self ensurePackage: self p2Name.
+	p3 := self ensurePackage: self p3Name.
 
 	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
 	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.
@@ -227,7 +227,7 @@ RPackageOrganizerTest >> testPackageNamedWithoutMatchingPackage [
 { #category : 'tests' }
 RPackageOrganizerTest >> testRegisterPackageConflictWithPackage [
 
-	self createNewPackageNamed: 'P1'.
+	self ensurePackage: 'P1'.
 	self should: [ (RPackage named: 'P1') register ] raise: Error
 ]
 
@@ -236,10 +236,10 @@ RPackageOrganizerTest >> testRegisterPackageConflictWithPackageTag [
 	"In the past we could not have package-tag with the same name than a package but now it is possible"
 
 	| package1 package2 tag |
-	package1 := self createNewPackageNamed: 'P1'.
+	package1 := self ensurePackage: 'P1'.
 	tag := package1 ensureTag: #T1.
 
-	package2 := self createNewPackageNamed: #'P1-T1'.
+	package2 := self ensurePackage: #'P1-T1'.
 
 	self assert: package2 name equals: #'P1-T1'.
 	self assert: package1 name equals: #P1.
@@ -250,8 +250,8 @@ RPackageOrganizerTest >> testRegisterPackageConflictWithPackageTag [
 RPackageOrganizerTest >> testRegisterPackageTagConflictWithPackage [
 
 	| package1 package2 tag |
-	package1 := self createNewPackageNamed: #P1.
-	package2 := self createNewPackageNamed: #'P1-T1'.
+	package1 := self ensurePackage: #P1.
+	package2 := self ensurePackage: #'P1-T1'.
 	tag := package1 ensureTag: #T1.
 
 	self assert: package2 name equals: #'P1-T1'.
@@ -262,9 +262,9 @@ RPackageOrganizerTest >> testRegisterPackageTagConflictWithPackage [
 { #category : 'tests' }
 RPackageOrganizerTest >> testRegisteredNumberOfPackageIsOk [
 	| p1 p2 p3 |
-	p1 := self createNewPackageNamed: 'P1'.
-	p2 := self createNewPackageNamed: 'P2'.
-	p3 := self createNewPackageNamed: 'P3'.
+	p1 := self ensurePackage: 'P1'.
+	p2 := self ensurePackage: 'P2'.
+	p3 := self ensurePackage: 'P3'.
 
 	self organizer basicRegisterPackage: p1.
 	self organizer basicRegisterPackage: p2.
@@ -278,9 +278,9 @@ RPackageOrganizerTest >> testRegisteredNumberOfPackageIsOk [
 RPackageOrganizerTest >> testRegisteredPackages [
 
 	| p1 p2 p3 |
-	p1 := self createNewPackageNamed: 'P1'.
-	p2 := self createNewPackageNamed: 'P2'.
-	p3 := self createNewPackageNamed: 'P3'.
+	p1 := self ensurePackage: 'P1'.
+	p2 := self ensurePackage: 'P2'.
+	p3 := self ensurePackage: 'P3'.
 
 	self assert: self organizer packageNames size equals: 4. "We also have the default package."
 	{ p1 . p2 . p3 } do: [ :package |
@@ -294,7 +294,7 @@ RPackageOrganizerTest >> testRegistrationExtendingPackages [
 	| p |
 	self createNewClassNamed: 'QuadrangleForTesting' inCategory: self class category.
 	self assertEmpty: (self organizer extendingPackagesOf: self quadrangleClass).
-	p := self createNewPackageNamed: 'P1'.
+	p := self ensurePackage: 'P1'.
 	self organizer registerExtendingPackage: p forClass: self quadrangleClass.
 	self denyEmpty: (self organizer extendingPackagesOf: self quadrangleClass).
 	self assert: (self organizer extendingPackagesOf: self quadrangleClass) anyOne name equals: #P1
@@ -303,48 +303,45 @@ RPackageOrganizerTest >> testRegistrationExtendingPackages [
 { #category : 'tests' }
 RPackageOrganizerTest >> testRemoveEmptyPackagesAndTags [
 
-	| organizer package1 package2 package3 package4 class tag1 tag2 |
+	| package1 package2 package3 package4 class tag1 tag2 |
 	"This one will contain a class"
-	package1 := (self createNewPackageNamed: #Test1).
+	package1 := self ensurePackage: #Test1.
 	"This one will contain an extension method"
-	package2 := (self createNewPackageNamed: #Test2).
+	package2 := self ensurePackage: #Test2.
 	"This one will contain a tag with a class and an empty tag"
-	package3 := (self createNewPackageNamed: #Test3).
+	package3 := self ensurePackage: #Test3.
 	"This one will be empty"
-	package4 := (self createNewPackageNamed: #Test4).
+	package4 := self ensurePackage: #Test4.
 
 	tag1 := package3 ensureTag: #Tag1.
 	tag2 := package3 ensureTag: #Tag2.
 
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1'.
 	class compile: 'extension ^ 1' classified: '*Test2'.
-	
+
 	class := self createNewClassNamed: 'TestClass2' inCategory: 'Test3-Tag1'.
 
-	self flag: #package. "Use the organizer provided by the tests later."
-	organizer := package1 organizer.
-
-	self assert: (organizer hasPackage: package1).
+	self assert: (self organizer hasPackage: package1).
 	self deny: package1 isEmpty.
-	self assert: (organizer hasPackage: package2).
+	self assert: (self organizer hasPackage: package2).
 	self deny: package2 isEmpty.
-	self assert: (organizer hasPackage: package3).
+	self assert: (self organizer hasPackage: package3).
 	self deny: package3 isEmpty.
 	self deny: tag1 isEmpty.
 	self assert: tag2 isEmpty.
 	self assert: (package3 includesClassTagNamed: #Tag1).
 	self assert: (package3 includesClassTagNamed: #Tag2).
-	self assert: (organizer hasPackage: package4).
+	self assert: (self organizer hasPackage: package4).
 	self assert: package4 isEmpty.
 
-	organizer removeEmptyPackagesAndTags.
+	self organizer removeEmptyPackagesAndTags.
 
-	self assert: (organizer hasPackage: package1).
-	self assert: (organizer hasPackage: package2).
-	self assert: (organizer hasPackage: package3).
+	self assert: (self organizer hasPackage: package1).
+	self assert: (self organizer hasPackage: package2).
+	self assert: (self organizer hasPackage: package3).
 	self assert: (package3 includesClassTagNamed: #Tag1).
 	self deny: (package3 includesClassTagNamed: #Tag2).
-	self deny: (organizer hasPackage: package4)
+	self deny: (self organizer hasPackage: package4)
 ]
 
 { #category : 'tests' }
@@ -352,9 +349,9 @@ RPackageOrganizerTest >> testRemovePackage [
 
 	| p1 p2 p3 a1 a2 b1 b2 a3 |
 	"taken from setup of RPackageReadOnlyCompleteSetup"
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
-	p3 := self createNewPackageNamed: self p3Name.
+	p1 := self ensurePackage: self p1Name.
+	p2 := self ensurePackage: self p2Name.
+	p3 := self ensurePackage: self p3Name.
 
 	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
 	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.
@@ -386,7 +383,7 @@ RPackageOrganizerTest >> testRenameUpdateTheOrganizer [
 	"test that when we rename a category, the organizer dictionary is update with this new name, so that we can access the package with this new name as key"
 
 	| package |
-	package := self createNewPackageNamed: #Test1.
+	package := self ensurePackage: #Test1.
 
 	self organizer renamePackage: package to: #Test2.
 	self assert: package name equals: #Test2.
@@ -424,9 +421,9 @@ RPackageOrganizerTest >> testTestPackages [
 RPackageOrganizerTest >> testUnregister [
 
 	| p1 p2 p3 |
-	p1 := self createNewPackageNamed: 'P1'.
-	p2 := self createNewPackageNamed: 'P2'.
-	p3 := self createNewPackageNamed: 'P3'.
+	p1 := self ensurePackage: 'P1'.
+	p2 := self ensurePackage: 'P2'.
+	p3 := self ensurePackage: 'P3'.
 
 	self assert: self organizer packageNames size equals: 4.
 
@@ -442,7 +439,7 @@ RPackageOrganizerTest >> testUnregistrationExtendingPackages [
 
 	| p |
 	self createNewClassNamed: 'QuadrangleForTesting' inCategory: self class category.
-	p := self createNewPackageNamed: 'P1'.
+	p := self ensurePackage: 'P1'.
 	self organizer registerExtendingPackage: p forClass: self quadrangleClass.
 	self denyEmpty: (self organizer extendingPackagesOf: self quadrangleClass).
 	self assert: (self organizer extendingPackagesOf: self quadrangleClass) anyOne name equals: #P1.

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -38,9 +38,9 @@ Class {
 RPackageReadOnlyCompleteSetupTest >> setUp [
 
 	super setUp.
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
-	p3 := self createNewPackageNamed: self p3Name.
+	p1 := self ensurePackage: self p1Name.
+	p2 := self ensurePackage: self p2Name.
+	p3 := self ensurePackage: self p3Name.
 
 	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
 	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.

--- a/src/RPackage-Tests/RPackageRenameTest.class.st
+++ b/src/RPackage-Tests/RPackageRenameTest.class.st
@@ -13,7 +13,7 @@ RPackageRenameTest >> testRenamePackage [
 	"Test that we do rename the package as expected."
 
 	| package workingCopy class |
-	package := self createNewPackageNamed: 'Test1'.
+	package := self ensurePackage: 'Test1'.
 	workingCopy := MCWorkingCopy forPackageNamed: 'Test1'.
 	class := self createNewClassNamed: #TestClass inCategory: 'Test1-TAG'.
 
@@ -40,7 +40,7 @@ RPackageRenameTest >> testRenamePackageToOwnTagName [
 	"If we rename a package to the (full)category name of one of its tags"
 
 	| package workingCopy class1 class2 |
-	package := self createNewPackageNamed: 'Test1'.
+	package := self ensurePackage: 'Test1'.
 	workingCopy := MCWorkingCopy forPackageNamed: 'Test1'.
 	class1 := self createNewClassNamed: #TestClass1 inCategory: 'Test1-Core'.
 	class2 := self createNewClassNamed: #TestClass2 inCategory: 'Test1-Util'.
@@ -64,7 +64,7 @@ RPackageRenameTest >> testRenamePackageToOwnTagNameWithClassesInRoot [
 	"If we rename a package to the (full)category name of one of its tags and the (non-tag)package is not empty"
 
 	| package workingCopy class1 class2 class3 |
-	package := self createNewPackageNamed: 'Test1'.
+	package := self ensurePackage: 'Test1'.
 	workingCopy := MCWorkingCopy forPackageNamed: 'Test1'.
 	class1 := self createNewClassNamed: #TestClass1 inCategory: 'Test1-Core'.
 	class2 := self createNewClassNamed: #TestClass2 inCategory: 'Test1-Util'.
@@ -88,11 +88,11 @@ RPackageRenameTest >> testRenamePackageToOwnTagNameWithClassesInRoot [
 RPackageRenameTest >> testRenamePackageWithExtensions [
 
 	| package class extendedPackage extension |
-	package := self createNewPackageNamed: 'OriginalPackage'.
+	package := self ensurePackage: 'OriginalPackage'.
 
 	class := self createNewClassNamed: #TestClass inCategory: 'OriginalPackage-TAG'.
 
-	extendedPackage := self createNewPackageNamed: 'ExtendedPackage'.
+	extendedPackage := self ensurePackage: 'ExtendedPackage'.
 
 
 	class := self createNewClassNamed: #TestExtendedClass inCategory: 'ExtendedPackage'.
@@ -119,11 +119,11 @@ RPackageRenameTest >> testRenamePackageWithExtensions [
 RPackageRenameTest >> testRenamePackageWithExtensionsInClassSide [
 
 	| package class extendedPackage extension |
-	package := self createNewPackageNamed: 'OriginalPackage'.
+	package := self ensurePackage: 'OriginalPackage'.
 
 	class := self createNewClassNamed: #TestClass inCategory: 'OriginalPackage-TAG'.
 
-	extendedPackage := self createNewPackageNamed: 'ExtendedPackage'.
+	extendedPackage := self ensurePackage: 'ExtendedPackage'.
 
 
 	class := self createNewClassNamed: #TestExtendedClass inCategory: 'ExtendedPackage'.
@@ -153,7 +153,7 @@ RPackageRenameTest >> testUnregisterPackage [
 	"Test that we do unregister the package as expected."
 
 	| package workingCopy class |
-	package := self createNewPackageNamed: 'Test1'.
+	package := self ensurePackage: 'Test1'.
 	workingCopy := MCWorkingCopy forPackageNamed: 'Test1'.
 	class := self createNewClassNamed: #TestClass inCategory: 'Test1-TAG'.
 	self assert: (package includesClass: class).

--- a/src/RPackage-Tests/RPackageTagTest.class.st
+++ b/src/RPackage-Tests/RPackageTagTest.class.st
@@ -12,12 +12,12 @@ Class {
 RPackageTagTest >> testAddClass [
 
 	| package1 package2 tag class |
-	package1 := self createNewPackageNamed: #Test1.
+	package1 := self ensurePackage: #Test1.
 	class := self createNewClassNamed: 'TestClass' inPackage: package1.
 
 	self assert: (package1 includesClass: class).
 
-	package2 := self createNewPackageNamed: #Test2.
+	package2 := self ensurePackage: #Test2.
 
 	tag := package2 ensureTag: #TAG.
 
@@ -34,14 +34,14 @@ RPackageTagTest >> testAddClass [
 RPackageTagTest >> testAddClassFromTag [
 
 	| package1 package2 class |
-	package1 := self createNewPackageNamed: #Test1.
+	package1 := self ensurePackage: #Test1.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
 
 	self assert: (package1 includesClass: class).
 	self assert: (package1 hasTag: #TAG1).
 	self assert: ((package1 classTagNamed: #TAG1) includesClass: class).
 
-	package2 := self createNewPackageNamed: #Test2.
+	package2 := self ensurePackage: #Test2.
 
 	(package2 ensureTag: #TAG2) addClass: class.
 
@@ -55,7 +55,7 @@ RPackageTagTest >> testAddClassFromTag [
 RPackageTagTest >> testHasClass [
 
 	| package class tag |
-	package := self createNewPackageNamed: #Test1.
+	package := self ensurePackage: #Test1.
 	class := self createNewClassNamed: 'TestClass' inCategory: package name , '-TAG'.
 	tag := class packageTag.
 
@@ -72,7 +72,7 @@ RPackageTagTest >> testHasClass [
 RPackageTagTest >> testPromoteAsPackage [
 
 	| package1 package2 class tag1 |
-	package1 := self createNewPackageNamed: #Test1.
+	package1 := self ensurePackage: #Test1.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
 	class compile: 'foo ^42' classified: 'accessing'.
 
@@ -90,7 +90,7 @@ RPackageTagTest >> testPromoteAsPackage [
 RPackageTagTest >> testRemoveClass [
 
 	| package tag class |
-	package := self createNewPackageNamed: #Test1.
+	package := self ensurePackage: #Test1.
 	tag := package ensureTag: #TAG.
 	class := self createNewClassNamed: 'TestClass' inCategory: package name , '-TAG'.
 
@@ -107,7 +107,7 @@ RPackageTagTest >> testRemoveClass [
 RPackageTagTest >> testRemoveClassRemoveTagIfEmpty [
 
 	| package tag class |
-	package := self createNewPackageNamed: #Test1.
+	package := self ensurePackage: #Test1.
 	tag := package ensureTag: #TAG.
 	class := self createNewClassNamed: 'TestClass' inCategory: package name , '-TAG'.
 

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -12,7 +12,7 @@ Class {
 RPackageTest >> testAddClass [
 
 	| package1 package2 class done |
-	package1 := self createNewPackageNamed: #Test1.
+	package1 := self ensurePackage: #Test1.
 	done := 0.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG'.
 
@@ -21,7 +21,7 @@ RPackageTest >> testAddClass [
 	self assert: (package1 hasTag: #TAG).
 	self assert: ((package1 classTagNamed: #TAG) includesClass: class).
 
-	package2 := self createNewPackageNamed: #Test2.
+	package2 := self ensurePackage: #Test2.
 	[
 	SystemAnnouncer uniqueInstance when: ClassRecategorized do: [ done := done + 1 ] for: self.
 	package2 addClass: class ] ensure: [ SystemAnnouncer uniqueInstance unsubscribe: self ].
@@ -37,12 +37,12 @@ RPackageTest >> testAddClass [
 RPackageTest >> testAddClassFromTag [
 
 	| package1 package2 class |
-	package1 := self createNewPackageNamed: #Test1.
+	package1 := self ensurePackage: #Test1.
 	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG'.
 
 	self assert: (package1 includesClass: class).
 
-	package2 := self createNewPackageNamed: #Test2.
+	package2 := self ensurePackage: #Test2.
 
 	package2 addClass: class.
 
@@ -56,7 +56,7 @@ RPackageTest >> testAddClassFromTag [
 RPackageTest >> testAllUnsentMessages [
 
 	| package class1 class2 |
-	package := self createNewPackageNamed: #Test1.
+	package := self ensurePackage: #Test1.
 
 	class1 := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG'.
 	class2 := self createNewClassNamed: 'TestClassOther' inCategory: 'Test1-TAG'.
@@ -97,7 +97,7 @@ RPackageTest >> testAnonymousClassAndSelector [
 RPackageTest >> testDemoteToRPackageNamed [
 
 	| package1 package2 class |
-	package1 := self createNewPackageNamed: #'Test1-TAG1'.
+	package1 := self ensurePackage: #'Test1-TAG1'.
 	class := self createNewClassNamed: 'TestClass' inPackage: package1.
 	class compile: 'foo ^42' classified: 'accessing'.
 
@@ -114,8 +114,8 @@ RPackageTest >> testDemoteToRPackageNamed [
 RPackageTest >> testDemoteToRPackageNamedExistingPackage [
 
 	| package1 package2 packageExisting class |
-	package1 := self createNewPackageNamed: #'Test1-TAG1'.
-	packageExisting := self createNewPackageNamed: #Test1.
+	package1 := self ensurePackage: #'Test1-TAG1'.
+	packageExisting := self ensurePackage: #Test1.
 	class := self createNewClassNamed: 'TestClass' inPackage: package1.
 	class compile: 'foo ^42' classified: 'accessing'.
 
@@ -146,7 +146,7 @@ RPackageTest >> testDemoteToRPackageNamedKeepOrganizer [
 RPackageTest >> testDemoteToRPackageNamedMultilevelPackage [
 
 	| package1 package2 class |
-	package1 := self createNewPackageNamed: #'Test1-TAG1-X1'.
+	package1 := self ensurePackage: #'Test1-TAG1-X1'.
 	class := self createNewClassNamed: 'TestClass' inPackage: package1.
 	class compile: 'foo ^42' classified: 'accessing'.
 
@@ -163,7 +163,7 @@ RPackageTest >> testDemoteToRPackageNamedMultilevelPackage [
 RPackageTest >> testDemoteToRPackageNamedWithExtension [
 
 	| packageOriginal packageDemoted class classOther |
-	packageOriginal := self createNewPackageNamed: #'Test1-TAG1'.
+	packageOriginal := self ensurePackage: #'Test1-TAG1'.
 	class := self createNewClassNamed: 'TestClass' inPackage: packageOriginal.
 	class compile: 'foo ^42' classified: 'accessing'.
 
@@ -264,7 +264,7 @@ RPackageTest >> testPropertyAtPut [
 RPackageTest >> testRemoveEmptyTags [
 
 	| package class tag1 tag2 |
-	package := self createNewPackageNamed: #Test1.
+	package := self ensurePackage: #Test1.
 
 	tag1 := package ensureTag: #Tag1.
 	tag2 := package ensureTag: #Tag2.
@@ -288,7 +288,7 @@ RPackageTest >> testRemoveEmptyTags [
 RPackageTest >> testRemoveTag [
 
 	| p1 a1 b1 |
-	p1 := self createNewPackageNamed: #P1.
+	p1 := self ensurePackage: #P1.
 
 	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
 	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.
@@ -315,7 +315,7 @@ RPackageTest >> testRemoveTag [
 RPackageTest >> testRemoveTagRemoveClasses [
 
 	| p1 a1 |
-	p1 := self createNewPackageNamed: #P1.
+	p1 := self ensurePackage: #P1.
 
 	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
 	self assert: p1 classTags size equals: 1. "We start with the root tag"
@@ -337,9 +337,9 @@ RPackageTest >> testRenamePackageAlsoRenameAllExtensionProtocols [
 	"test that when we rename a category, all corresponding extension protocols in the system are renamed"
 
 	| p1 p2 p3 classInY classInZ |
-	p1 := self createNewPackageNamed: #Test1.
-	p2 := self createNewPackageNamed: #Test2.
-	p3 := self createNewPackageNamed: #Test3.
+	p1 := self ensurePackage: #Test1.
+	p2 := self ensurePackage: #Test2.
+	p3 := self ensurePackage: #Test3.
 
 	classInY := self createNewClassNamed: 'ClassInYPackage' inPackage: p2.
 	classInZ := self createNewClassNamed: 'ClassInZPackage' inPackage: p3.
@@ -361,7 +361,7 @@ RPackageTest >> testRenameUpdateTheOrganizer [
 	"test that when we rename a category, the organizer dictionary is update with this new name, so that we can access the package with this new name as key"
 
 	| package |
-	package := self createNewPackageNamed: #Test1.
+	package := self ensurePackage: #Test1.
 
 	package renameTo: #Test2.
 	self assert: package name equals: #Test2.

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -5,7 +5,6 @@ Class {
 	#name : 'RPackageTestCase',
 	#superclass : 'AbstractEnvironmentTestCase',
 	#instVars : [
-		'createdPackages',
 		'testEnvironment'
 	],
 	#category : 'RPackage-Tests',
@@ -15,7 +14,7 @@ Class {
 { #category : 'utilities' }
 RPackageTestCase >> createMockTestPackages [
 
-	^ self namesOfMockTestPackages collect: [:pName | self createNewPackageNamed: pName]
+	^ self namesOfMockTestPackages collect: [:pName | self ensurePackage: pName]
 ]
 
 { #category : 'utilities' }
@@ -26,15 +25,11 @@ RPackageTestCase >> createNewClassNamed: aName [
 { #category : 'utilities' }
 RPackageTestCase >> createNewClassNamed: aName inCategory: cat [
 
-	| cls |
-	cls := self class classInstaller make: [ :aClassBuilder |
-		       aClassBuilder
-			       name: aName;
-			       installingEnvironment: testEnvironment;
-			       package: cat ].
-
-	createdPackages add: cls package.
-	^ cls
+	^ self class classInstaller make: [ :aClassBuilder |
+		  aClassBuilder
+			  name: aName;
+			  installingEnvironment: testEnvironment;
+			  package: cat ]
 ]
 
 { #category : 'utilities' }
@@ -47,15 +42,6 @@ RPackageTestCase >> createNewClassNamed: aName inPackage: p [
 ]
 
 { #category : 'utilities' }
-RPackageTestCase >> createNewPackageNamed: aName [
-
-	| pack |
-	pack := self organizer ensurePackage: aName.
-	createdPackages add: pack.
-	^ pack
-]
-
-{ #category : 'utilities' }
 RPackageTestCase >> createNewTraitNamed: aName [
 	^ self createNewTraitNamed: aName inCategory: 'RPackageTest'
 ]
@@ -63,16 +49,12 @@ RPackageTestCase >> createNewTraitNamed: aName [
 { #category : 'utilities' }
 RPackageTestCase >> createNewTraitNamed: aName inCategory: cat [
 
-	| cls |
-	cls := self class classInstaller make: [ :aBuilder |
-		       aBuilder
-			       name: aName;
-			       package: cat;
-			       installingEnvironment: testEnvironment;
-			       beTrait ].
-
-	createdPackages add: cls package.
-	^ cls
+	^ self class classInstaller make: [ :aBuilder |
+		  aBuilder
+			  name: aName;
+			  package: cat;
+			  installingEnvironment: testEnvironment;
+			  beTrait ]
 ]
 
 { #category : 'utilities' }
@@ -82,6 +64,12 @@ RPackageTestCase >> createNewTraitNamed: aName inPackage: p [
 	cls := self createNewTraitNamed: aName.
 	p importClass: cls.
 	^ cls
+]
+
+{ #category : 'utilities' }
+RPackageTestCase >> ensurePackage: aName [
+
+	^ self organizer ensurePackage: aName
 ]
 
 { #category : 'utilities' }
@@ -107,13 +95,6 @@ RPackageTestCase >> runCase [
 		  self performTest ] ] ensure: [
 		self tearDown.
 		self cleanUpInstanceVariables ]
-]
-
-{ #category : 'running' }
-RPackageTestCase >> setUp [
-
-	super setUp.
-	createdPackages := Set new
 ]
 
 { #category : 'running' }

--- a/src/RPackage-Tests/RPackageTraitTest.class.st
+++ b/src/RPackage-Tests/RPackageTraitTest.class.st
@@ -21,9 +21,9 @@ RPackageTraitTest >> setUp [
 
 	super setUp.
 
-	p1 := self createNewPackageNamed: self p1Name.
-	p2 := self createNewPackageNamed: self p2Name.
-	p3 := self createNewPackageNamed: self p3Name.
+	p1 := self ensurePackage: self p1Name.
+	p2 := self ensurePackage: self p2Name.
+	p3 := self ensurePackage: self p3Name.
 
 	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
 


### PR DESCRIPTION
Removes the need for the #createdPackages variable and rename #createNewPackageNamed: into #ensurePackage: since this is what it does