### PR TITLE
ShClassInstallerTest>>#testInstallInSpecificEnvironment should clean …

### DIFF
--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -300,6 +300,7 @@ ShClassInstallerTest >> testInstallInSpecificEnvironment [
 
 	| newEnvironment |
 	newEnvironment := self class environment class new.
+	[
 	newClass := ShiftClassInstaller make: [ :builder |
 		            builder
 			            installingEnvironment: newEnvironment;
@@ -315,7 +316,9 @@ ShClassInstallerTest >> testInstallInSpecificEnvironment [
 	self skip.
 	self flag: #package. "ShiftClassInstaller>>#recategorize:to: is using the old SystemOrganizer system to classify classes, but this does not add the classes to the instance of RPackageOrganizer but to the default package organizer of the image instead. Until we can fix this, we cannot have the next assertions working. They are clearly a bug but it'll be hard to fix this bug in short term........ :("
 	self deny: (self packageOrganizer hasPackage: self generatedClassesPackageName).
-	self assert: (newEnvironment organization hasPackage: self generatedClassesPackageName)
+	self assert: (newEnvironment organization hasPackage: self generatedClassesPackageName) ] ensure: [
+		"The tear down will not remove the class in the other environment"
+		newEnvironment organization packageNamed: self generatedClassesPackageName ifPresent: [ :package | package removeFromSystem ] ]
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
…itself

ShClassInstallerTest>>#testInstallInSpecificEnvironment is generating a class in another environment but the tearDown only take care of the global environment.  This change also cleans the other environment. 

Maybe we should add a #finalize method on RPackageOrganizer to remove from the system the packages and classes it contains? What do you think @MarcusDenker ?

I think this might be the root of some failings in the STON tests