### PR TITLE
fix: expect package names to be hyphenated

### DIFF
--- a/src/Monticello/MCOrganizationParser.class.st
+++ b/src/Monticello/MCOrganizationParser.class.st
@@ -24,8 +24,8 @@ MCOrganizationParser >> addDefinitionsTo: aCollection [
 
 	tokens := source parseLiterals.
 
-	packageName := tokens at: 4.
-	tags := tokens at: 6.
+	packageName := '' join: (tokens copyFrom: 4 to: tokens size - 2).
+	tags := tokens last.
 
 	definition
 		packageName: packageName;


### PR DESCRIPTION
MCOrganizationParser>>#addDefinitions: did not expect package names to be hyphenated. This commit changes that, resulting in the parser properly detecting package name and tags.

Fixes #14750