### PR TITLE
Monticello: Fix st export of organizations

### DIFF
--- a/src/Monticello-Tests/MCStWriterTest.class.st
+++ b/src/Monticello-Tests/MCStWriterTest.class.st
@@ -122,12 +122,6 @@ MCMethodDeclaration className: #MCMockClassD selector: #one category: #''''as ye
 '
 ]
 
-{ #category : 'data' }
-MCStWriterTest >> expectedOrganizationDefinition [
-	^ 'self packageOrganizer ensurePackage: #MonticelloMocks withTags: #()!
-'
-]
-
 { #category : 'testing' }
 MCStWriterTest >> methodWithBangs [
 	^ '
@@ -271,6 +265,18 @@ MCStWriterTest >> testOrganizationDefinition [
 	| definition |
 	definition := self mockPackage systemPackage asMCOrganizationDefinition.
 	writer visitOrganizationDefinition: definition.
-	self assertContentsOf: stream match: self expectedOrganizationDefinition.
+	self assertContentsOf: stream match: 'self packageOrganizer ensurePackage: #MonticelloMocks withTags: #()!
+'.
+	self assertAllChunksAreWellFormed
+]
+
+{ #category : 'testing' }
+MCStWriterTest >> testOrganizationDefinition2 [
+
+	| definition |
+	definition := MCOrganizationDefinition packageName: #'Package-With-Dashes' tagNames: #( #Tag #'Tag-With-Dashes' ).
+	writer visitOrganizationDefinition: definition.
+	self assertContentsOf: stream match: 'self packageOrganizer ensurePackage: #''Package-With-Dashes'' withTags: #(#Tag #''Tag-With-Dashes'')!
+'.
 	self assertAllChunksAreWellFormed
 ]

--- a/src/Monticello/MCOrganizationParser.class.st
+++ b/src/Monticello/MCOrganizationParser.class.st
@@ -24,8 +24,8 @@ MCOrganizationParser >> addDefinitionsTo: aCollection [
 
 	tokens := source parseLiterals.
 
-	packageName := '' join: (tokens copyFrom: 4 to: tokens size - 2).
-	tags := tokens last.
+	packageName := tokens at: 4.
+	tags := tokens at: 6.
 
 	definition
 		packageName: packageName;

--- a/src/Monticello/MCStWriter.class.st
+++ b/src/Monticello/MCStWriter.class.st
@@ -209,9 +209,9 @@ MCStWriter >> writeMethodSource: definition [
 MCStWriter >> writePackage: packageName tags: aCollection [
 
 	stream
-		nextChunkPut: ('self packageOrganizer ensurePackage: #{1} withTags: {2}' format: {
-						 packageName.
-						 aCollection printString });
+		nextChunkPut: ('self packageOrganizer ensurePackage: {1} withTags: {2}' format: {
+						 packageName storeString.
+						 aCollection storeString });
 		cr
 ]
 


### PR DESCRIPTION
In case a package name contained dashes the organization export of MCOrganizationDefinition was wrong.

This change fixes it and adds a test

Thank you @theseion for finding this bug