### PR TITLE
Monticello: Clean installation of classes and traits

### DIFF
--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -207,7 +207,7 @@ MCClassDefinition >> createClass [
 
 	superClass := superclassName = #nil ifFalse: [ Smalltalk globals at: superclassName ].
 	^ [
-	  Smalltalk classInstaller make: [ :builder |
+	  self class classInstaller make: [ :builder |
 		  builder
 			  superclass: superClass;
 			  name: name;

--- a/src/Monticello/MCTraitDefinition.class.st
+++ b/src/Monticello/MCTraitDefinition.class.st
@@ -66,6 +66,7 @@ MCTraitDefinition >> createClass [
 		  aBuilder
 			  name: name;
 			  traitComposition: (Smalltalk compiler evaluate: self traitCompositionString);
+			  classTraitComposition: (Smalltalk compiler evaluate: self classTraitCompositionString);
 			  slots: self instanceVariables;
 			  classSlots: self classInstanceVariables;
 			  package: self category;

--- a/src/Monticello/MCTraitDefinition.class.st
+++ b/src/Monticello/MCTraitDefinition.class.st
@@ -61,20 +61,18 @@ MCTraitDefinition >> classSlotDefinitionString [
 { #category : 'installing' }
 MCTraitDefinition >> createClass [
 
-	| trait |
-	trait := self class classInstaller make: [ :aBuilder |
-		         aBuilder
-			         name: name;
-			         traitComposition: (Smalltalk compiler evaluate: self traitCompositionString);
-			         slots: self instanceVariables;
-			         package: self category;
-			         beTrait ].
-
-
-	trait ifNotNil: [
-		trait comment: comment stamp: commentStamp.
-		self classInstanceVariables ifNotEmpty: [ :vars | trait classSide slots: vars ] ].
-	^ trait
+	^ [
+	  self class classInstaller make: [ :aBuilder |
+		  aBuilder
+			  name: name;
+			  traitComposition: (Smalltalk compiler evaluate: self traitCompositionString);
+			  slots: self instanceVariables;
+			  classSlots: self classInstanceVariables;
+			  package: self category;
+			  comment: comment stamp: commentStamp;
+			  beTrait ] ]
+		  on: Warning , DuplicatedVariableError
+		  do: [ :ex | ex resume ]
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
- MCClassDefinition>>createClass  should not hardcode a global access
- MCTraitDefinition>>createClass should not set the class slots and comment outside the class builder
- MCTraitDefinition>>createClass should catch the same warning as the overriden method (I guess? Or it should be removed in both? If someone knows this part of the system better than me let me know what you think :) )

I found this looking at #14749 but this does not fix the problem