### PR TITLE
WindowsStore>>printPath:on: handle the first segment size = 1

### DIFF
--- a/src/FileSystem-Disk/WindowsStore.class.st
+++ b/src/FileSystem-Disk/WindowsStore.class.st
@@ -260,7 +260,7 @@ WindowsStore >> permissions: aPath [
 
 { #category : 'converting' }
 WindowsStore >> printPath: aPath on: aStream [
-	| hasDrive |
+	| hasDrive firstSegment |
 
 	aPath isNetworkPath
 		ifTrue: [ ^ aPath printOn: aStream delimiter: self delimiter ].
@@ -274,9 +274,9 @@ WindowsStore >> printPath: aPath on: aStream [
 		ifTrue: [ ^ aPath printOn: aStream delimiter: self delimiter ].
 	aPath segments first first = $:
 		ifTrue: [ ^ aStream nextPut: self delimiter ].	"as tagged in #pathFromString:  "
-	hasDrive := aPath segments first second = $:.
-	(hasDrive not )
-		ifTrue: [ aStream nextPut: self delimiter ].
+	firstSegment := aPath segments first.
+	hasDrive := firstSegment size >= 2 and: [ firstSegment second = $: ].
+	hasDrive ifFalse: [ aStream nextPut: self delimiter ].
 	aPath printOn: aStream delimiter: self delimiter.
 	(hasDrive and: [ aPath segments size = 1 ])
 		ifTrue: [ aStream nextPut: self delimiter ]

--- a/src/FileSystem-Tests-Disk/WindowsStoreTest.class.st
+++ b/src/FileSystem-Tests-Disk/WindowsStoreTest.class.st
@@ -56,6 +56,7 @@ WindowsStoreTest >> testPrintString [
 
 	"path"
 	self assert: (filesystem referenceTo: 'a/b') printString equals: 'File @ a\b'.
+	self assert: (filesystem referenceTo: '/a/b') printString equals: 'File @ \a\b'.
 	self assert: (filesystem referenceTo: '\test.txt') printString equals: 'File @ \test.txt'.
 
 	"root"


### PR DESCRIPTION
Currently

```
'/a/path' asFileReference printString
```

triggers an error

Updated `WindowsStoreTest>>testPrintString` to cover this scenario.

Fixes: https://github.com/pharo-project/pharo/issues/14760