### PR TITLE
Add an ensure block in Shift changes test to clean better the system

### DIFF
--- a/src/Shift-Changes-Tests/ShSuperclassChangeDetectorTest.class.st
+++ b/src/Shift-Changes-Tests/ShSuperclassChangeDetectorTest.class.st
@@ -8,13 +8,16 @@ Class {
 { #category : 'tests' }
 ShSuperclassChangeDetectorTest >> testChangeInSuperclassIsDetected [
 
-	newBuilder superclass: (self class classInstaller make: [ :builder |
-			 builder
-				 name: #ShSuperTestForClass2;
-				 package: self packageName ]).
+	| newSuperclass |
+	[
+	newSuperclass := self class classInstaller make: [ :builder |
+		                 builder
+			                 name: #ShSuperTestForClass2;
+			                 package: self packageName ].
+	newBuilder superclass: newSuperclass.
 
 	self denyEmpty: self newComparer compareClass.
-	self assertChangeAreDetected
+	self assertChangeAreDetected ] ensure: [ newSuperclass ifNotNil: [ newSuperclass removeFromSystem ] ]
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
It seems that we still have random test artifact in the image sometimes. Here I'm adding yet another guard to clean everything