### PR TITLE
Fixes  #14740 : '/..' asFileReference canonicalize returns incorrect result

### DIFF
--- a/src/FileSystem-Path/AbsolutePath.class.st
+++ b/src/FileSystem-Path/AbsolutePath.class.st
@@ -22,6 +22,19 @@ AbsolutePath class >> from: aString delimiter: aDelimiterCharater [
 	^ super from: aString delimiter: aDelimiterCharater
 ]
 
+{ #category : 'private' }
+AbsolutePath class >> removeRedundantSegments: segments [
+	"Remove redundant elements ('.' and '') from the supplied segments.
+	The parent of the root directory is itself."
+	| newSegments |
+
+	newSegments := segments asOrderedCollection copy.
+	[ newSegments isNotEmpty and: [ newSegments first = '..' ] ] whileTrue:
+		[ newSegments removeFirst ].
+	^ newSegments select:
+		[ :segment | segment notEmpty and: [ segment ~= '.' ] ]
+]
+
 { #category : 'testing' }
 AbsolutePath >> isAbsolute [
 	^ true

--- a/src/FileSystem-Tests-Core/FileReferenceTest.class.st
+++ b/src/FileSystem-Tests-Core/FileReferenceTest.class.st
@@ -216,7 +216,7 @@ FileReferenceTest >> testCanonicalization [
 	self assert: ref path segments equals: #('a' 'c').
 
 	ref := '/..' asFileReference canonicalize.
-	self assertEmtpy: ref path segments.
+	self assertEmpty: ref path segments.
 
 	ref := '/../a/b/../c' asFileReference canonicalize.
 	self assert: ref path segments equals: #('a' 'c')

--- a/src/FileSystem-Tests-Core/FileReferenceTest.class.st
+++ b/src/FileSystem-Tests-Core/FileReferenceTest.class.st
@@ -216,7 +216,7 @@ FileReferenceTest >> testCanonicalization [
 	self assert: ref path segments equals: #('a' 'c').
 
 	ref := '/..' asFileReference canonicalize.
-	self assert: ref path segments isEmpty.
+	self assertEmtpy: ref path segments.
 
 	ref := '/../a/b/../c' asFileReference canonicalize.
 	self assert: ref path segments equals: #('a' 'c')

--- a/src/FileSystem-Tests-Core/FileReferenceTest.class.st
+++ b/src/FileSystem-Tests-Core/FileReferenceTest.class.st
@@ -213,6 +213,12 @@ FileReferenceTest >> testCanonicalization [
 	self assert: ref path segments equals: #('a' 'c').
 
 	ref := '/a/b/../c' asFileReference canonicalize.
+	self assert: ref path segments equals: #('a' 'c').
+
+	ref := '/..' asFileReference canonicalize.
+	self assert: ref path segments isEmpty.
+
+	ref := '/../a/b/../c' asFileReference canonicalize.
 	self assert: ref path segments equals: #('a' 'c')
 ]
 

--- a/src/FileSystem-Tests-Core/PathTest.class.st
+++ b/src/FileSystem-Tests-Core/PathTest.class.st
@@ -133,7 +133,14 @@ PathTest >> testCanonicalization [
 	self assert: ref segments equals: #('a' 'c').
 
 	ref := (Path / 'a/b/../c') canonicalize.
+	self assert: ref segments equals: #('a' 'c').
+
+	ref := (Path / '..') canonicalize.
+	self assert: ref segments isEmpty.
+
+	ref := (Path / '../a/b/../c') canonicalize.
 	self assert: ref segments equals: #('a' 'c')
+
 ]
 
 { #category : 'tests' }

--- a/src/FileSystem-Tests-Core/PathTest.class.st
+++ b/src/FileSystem-Tests-Core/PathTest.class.st
@@ -136,7 +136,7 @@ PathTest >> testCanonicalization [
 	self assert: ref segments equals: #('a' 'c').
 
 	ref := (Path / '..') canonicalize.
-	self assert: ref segments isEmpty.
+	self assertEmpty: ref segments.
 
 	ref := (Path / '../a/b/../c') canonicalize.
 	self assert: ref segments equals: #('a' 'c')


### PR DESCRIPTION
Any number of parent references at the start of an absolute path should be removed.

- `PathTest>>testCanonicalization`
- `FileReferenceTest>>testCanonicalization`

have been extended to test leading parent references.