### PR TITLE
Backport: Clean installation of MCClassTraitDefinition

### DIFF
--- a/src/Monticello/MCClassTraitDefinition.class.st
+++ b/src/Monticello/MCClassTraitDefinition.class.st
@@ -65,6 +65,12 @@ MCClassTraitDefinition >> classTraitComposition [
 ]
 
 { #category : #accessing }
+MCClassTraitDefinition >> classTraitCompositionCompiled [
+
+	^ (Smalltalk compiler evaluate: self classTraitCompositionString) asTraitComposition
+]
+
+{ #category : #accessing }
 MCClassTraitDefinition >> classTraitCompositionString [
 	^ self classTraitComposition ifNil: [ '{}' ]
 ]
@@ -111,8 +117,12 @@ MCClassTraitDefinition >> isClassDefinition [
 ]
 
 { #category : #installing }
-MCClassTraitDefinition >> load [	
-	self class compiler evaluate: self definitionString
+MCClassTraitDefinition >> load [
+
+	self class environment
+		at: self baseTrait
+		ifPresent: [ :trait | trait class setTraitComposition: self classTraitCompositionCompiled ]
+		ifAbsent: [ self class compiler evaluate: self definitionString ]
 ]
 
 { #category : #printing }


### PR DESCRIPTION
This is a fix for issue #14749 in Pharo 11. 

The fix is different than in Pharo 12 because in Pharo 12 I did cleaner version of the clean by removing the usage of MCClassTraitDefinition alltogether since all infos are already on MCTraitDefinition.

The workaround here is to not recompile entirelly the class trait if the base trait is already present in the image. Instead it will just update the trait composition, thus it will not remove the instance variables.